### PR TITLE
feat(router): reserve soft corridor for cross-package diff pairs at escape

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -921,6 +921,31 @@ class Autorouter:
         # ``_apply_byte_lane_inner_priority``.
         self.enable_monotone_certificate_order = False
 
+        # Issue #4086 (Phase 1, epic #4049): cross-package diff-pair
+        # corridor reservation.  OFF by default, following the #4051 /
+        # ``enable_byte_lane_reorder`` precedent (escape-ordering /
+        # corridor-occupancy changes are measured before default-on).
+        #
+        # The intra-package paired-escape + corridor path (Phase 2F,
+        # #2639/#2677) only fires when BOTH halves of a diff pair sit on
+        # the same package.  When they live on different packages (driver
+        # -> connector, or driver -> receiver on opposite sides), each
+        # leg escapes single-ended and the coupled pathfinder free-searches
+        # the joint state space with no reserved geometry.  When this flag
+        # is True, ``EscapeRouter._generate_paired_escapes`` reserves a
+        # SOFT (attractor-only) continuation corridor from each leg's
+        # escape launch point toward the off-package partner (resolved via
+        # the board-wide ``net_pad_positions`` map), so the coupled search
+        # (via the #4080 attractor) has geometry to follow.  Soft -- not a
+        # hard fence -- because a hard keep-out spanning the board between
+        # two packages would starve unrelated nets (#4087 short-induce
+        # evidence for dense hard fences applies doubly to a long span).
+        #
+        # Flag-off is byte-identical to pre-#4086 main: no board 00-07
+        # fixture has a cross-package diff pair, so the new code path is a
+        # no-op ``continue`` there regardless.  Set True to opt in.
+        self.enable_cross_package_pair_corridor = False
+
         # Issue #4084: records the most recent certificate classification
         # per qualifying byte-lane group (group name -> MonotoneCertificate)
         # so callers/tests can inspect the feasibility decision and failure
@@ -13921,9 +13946,17 @@ class Autorouter:
             # the partner connector (off-package endpoints) instead of
             # blindly outward from the package center.
             net_pad_positions: dict[str, list[tuple[float, float]]] = {}
+            # Issue #4086: parallel net-name -> net-id map so the
+            # cross-package corridor can resolve the off-package partner's
+            # net id for the corridor owner set (both legs get the soft
+            # attractor bonus).  First-writer-wins per net name (all pads
+            # on a net share the id).
+            net_name_to_id: dict[str, int] = {}
             for pad in self.pads.values():
                 if pad.net_name:
                     net_pad_positions.setdefault(pad.net_name, []).append((pad.x, pad.y))
+                    if pad.net is not None and pad.net_name not in net_name_to_id:
+                        net_name_to_id[pad.net_name] = int(pad.net)
             self._escape_router = EscapeRouter(
                 self.grid,
                 self.rules,
@@ -13946,6 +13979,12 @@ class Autorouter:
                 # 27% reach once the BGA-49 detection fix landed.
                 diff_pair_map=(self.get_diff_pair_map() if self.paired_escape_coupling else {}),
                 net_pad_positions=net_pad_positions,
+                # Issue #4086 (Phase 1): cross-package diff-pair corridor
+                # gate (default OFF) + the net-name -> id map its owner-set
+                # resolution needs.  When OFF the escape router's
+                # cross-package branch is a no-op ``continue``.
+                enable_cross_package_pair_corridor=self.enable_cross_package_pair_corridor,
+                net_name_to_id=net_name_to_id,
                 # Issue #3428: board-wide net-id -> pad-position map so the
                 # fine-pitch QFP in-pad rescue can aim its inner stub at
                 # the net's actual routing target instead of the parity-

--- a/src/kicad_tools/router/escape.py
+++ b/src/kicad_tools/router/escape.py
@@ -1096,6 +1096,8 @@ class EscapeRouter:
         diff_pair_map: dict[str, str] | None = None,
         net_pad_positions: dict[str, list[tuple[float, float]]] | None = None,
         net_target_positions: dict[int, list[tuple[float, float, str]]] | None = None,
+        enable_cross_package_pair_corridor: bool = False,
+        net_name_to_id: dict[str, int] | None = None,
     ):
         """Initialize the escape router.
 
@@ -1148,6 +1150,28 @@ class EscapeRouter:
                 directions exactly.  Distinct from ``net_pad_positions``
                 (Issue #3419), which is keyed by net NAME and consumed by
                 the diff-pair launch heuristic.
+            enable_cross_package_pair_corridor: Issue #4086 (Phase 1,
+                epic #4049).  Default ``False``.  When ``True`` and a
+                diff pair's two halves live on DIFFERENT packages,
+                ``_generate_paired_escapes`` resolves the off-package
+                partner endpoint via ``net_pad_positions`` and reserves a
+                SOFT (attractor-only) corridor from this leg's escape
+                launch point toward the partner, so the downstream coupled
+                pathfinder (``CoupledPathfinder`` / #4080 attractor) has
+                real geometry to follow even when no single-ended guide
+                route exists yet.  The two legs still escape independently
+                at the per-pad level (this is NOT joint pin-assignment
+                ILP).  With the flag ``False`` cross-package pairs fall
+                through to the single-ended dispatcher exactly as before
+                (byte-identical), so the intra-package Phase 2F behaviour
+                and all board 00-07 fixtures are unchanged.
+            net_name_to_id: Optional board-wide map of net name to net id
+                (Issue #4086).  Consulted ONLY by the cross-package
+                corridor path to resolve the off-package partner's net id
+                for the corridor owner set (so both legs of the pair see
+                the soft attractor bonus).  Defaults to ``None``; when
+                absent the cross-package corridor owner set falls back to
+                this leg's net id alone.
         """
         self.grid = grid
         self.rules = rules
@@ -1191,6 +1215,21 @@ class EscapeRouter:
         # the total number of grid cells reserved across all calls.
         self.pair_corridor_reservations: int = 0
         self.pair_corridor_reserved_cells: int = 0
+        # Issue #4086 (Phase 1): cross-package diff-pair corridor gate +
+        # instrumentation.  When enabled, a diff pair whose two halves are
+        # on different packages gets a SOFT continuation corridor from each
+        # leg's escape launch point toward the off-package partner.  The
+        # counters mirror ``pair_corridor_reservations`` /
+        # ``pair_corridor_reserved_cells`` so tests can assert the
+        # cross-package path fired (or did not, when the flag is off / no
+        # partner is resolvable) without monkey-patching internals.
+        self.enable_cross_package_pair_corridor: bool = bool(enable_cross_package_pair_corridor)
+        self.cross_package_pair_corridor_reservations: int = 0
+        self.cross_package_pair_corridor_reserved_cells: int = 0
+        # Issue #4086: board-wide net-name -> net-id map used ONLY to
+        # resolve the off-package partner's net id for the cross-package
+        # corridor owner set.  Empty map => owner set is this leg alone.
+        self.net_name_to_id: dict[str, int] = net_name_to_id or {}
         # Issue #2983: Instrumentation counters for single-ended byte-lane
         # inner-corner corridor reservations.  Mirrors the diff-pair
         # ``pair_corridor_*`` pattern but tracks calls into
@@ -1772,11 +1811,23 @@ class EscapeRouter:
         package already at the target intra-pair spacing.
 
         Pads whose partner is on a DIFFERENT package (cross-package
-        pair coupling) are skipped here -- those cases fall through to
-        the single-ended dispatcher and are coupled by the main
-        pathfinder later.  This matches the issue scope note: "Coupling
-        escapes across different packages ... is out of scope (Phase 2F
-        handles intra-package only)."
+        pair coupling) fall through to the single-ended dispatcher and
+        are coupled by the main pathfinder later -- their per-pad escape
+        geometry is NOT hijacked here (this is not joint pin-assignment
+        ILP; see Issue #4086's scope).
+
+        Issue #4086 (Phase 1, epic #4049): when
+        ``self.enable_cross_package_pair_corridor`` is True (default
+        False) AND ``self.net_pad_positions`` resolves an off-package
+        endpoint for the partner net, this method additionally reserves a
+        SOFT continuation corridor from this leg's escape launch point
+        toward the partner (via ``_reserve_cross_package_pair_corridor``)
+        so the downstream coupled pathfinder has geometry to follow.  The
+        pad is deliberately NOT added to ``paired_pad_keys`` in that case
+        -- the leg still escapes single-ended; only the corridor
+        reservation is added.  With the flag False the cross-package
+        branch is a byte-identical no-op ``continue`` (all board 00-07
+        fixtures, whose pairs are intra-package, are unaffected).
 
         Args:
             package: Package info, expected to be one of the three
@@ -1831,9 +1882,23 @@ class EscapeRouter:
                 continue
             partner_pad = net_to_pad.get(partner_name)
             if partner_pad is None:
-                # Partner net does not appear on this package -- defer
-                # to the per-package dispatcher (cross-package coupling
-                # is handled by the main pathfinder).
+                # Partner net does not appear on this package.  The leg
+                # defers to the per-package dispatcher (single-ended
+                # escape); cross-package coupling is handled by the main
+                # pathfinder.  Issue #4086 (Phase 1): when the gate is on
+                # and the off-package partner endpoint is resolvable,
+                # additionally reserve a SOFT continuation corridor from
+                # this leg toward the partner so the coupled pathfinder
+                # has geometry to follow.  This does NOT change the leg's
+                # own escape geometry -- the pad is intentionally left out
+                # of ``paired_pad_keys`` so it still escapes single-ended.
+                if self.enable_cross_package_pair_corridor:
+                    self._reserve_cross_package_pair_corridor(
+                        pad=pad,
+                        partner_name=partner_name,
+                        intra_pair_clearance=_resolve_intra_pair_clearance(pad.net_name),
+                        package=package,
+                    )
                 continue
             if partner_pad is pad:
                 # Self-pair shouldn't happen but be defensive.
@@ -2343,6 +2408,200 @@ class EscapeRouter:
                 sorted(owner_nets),
                 len(members),
                 members[0].direction.name,
+            )
+        return count
+
+    def _reserve_cross_package_pair_corridor(
+        self,
+        pad: Pad,
+        partner_name: str,
+        intra_pair_clearance: float,
+        package: PackageInfo,
+    ) -> int:
+        """Reserve a SOFT continuation corridor for a cross-package pair leg.
+
+        Issue #4086 (Phase 1, epic #4049).  When a diff pair's two halves
+        live on DIFFERENT packages, the intra-package paired-escape path
+        (``_escape_diff_pair_segment`` +
+        ``_reserve_pair_continuation_corridor``) does not apply -- each
+        leg escapes single-ended and the only coupling downstream is
+        ``CoupledPathfinder`` free-searching the joint state space.  This
+        helper reserves a corridor connecting THIS leg's escape launch
+        point to the off-package partner endpoint so the coupled search
+        (via the #4080 attractor) has geometry to follow instead of
+        discovering feasibility from scratch.
+
+        Unlike ``_reserve_pair_continuation_corridor`` (a HARD keep-out
+        that fences foreign copper out of a planar intra-package
+        corridor), this reservation is SOFT (``soft=True``): it applies
+        ONLY the A* attractor bonus and does NOT fence foreign vias or
+        lateral traces out.  A hard fence spanning the whole board between
+        two packages would carve a foreign-copper-free channel across the
+        board and starve unrelated nets -- the #4087 evidence that hard
+        fences short-induce in dense areas applies doubly to a long
+        cross-package span.  Soft keeps the corridor attractor-visible
+        (so the coupled pair is pulled onto it) while leaving every other
+        net free to cross it.
+
+        Geometry (single leg -> partner):
+            * Partner endpoint is the nearest off-package position for
+              ``partner_name`` in ``self.net_pad_positions``.  If none is
+              resolvable the method is a no-op (returns 0) -- this is the
+              fallback-safety contract mirrored on
+              ``_select_pair_launch_direction``.
+            * Launch direction is the unit vector from THIS pad toward the
+              partner endpoint (this is where the leg wants to go, so the
+              single-ended escape and the coupled continuation both head
+              this way).
+            * Origin is this pad's escape launch point
+              (``pad + direction * escape_dist``), the same launch
+              distance the single-ended and paired escapes use.
+            * The corridor is a rectangle from the launch point toward the
+              partner, laterally padded by ``intra_pair_clearance +
+              trace_width`` so both legs of the pair fit side by side.
+            * Length is clamped so the corridor never overshoots the
+              partner endpoint.
+
+        Args:
+            pad: This leg's pad (on ``package``).
+            partner_name: Net name of the off-package partner half.
+            intra_pair_clearance: Target intra-pair clearance (resolved by
+                the caller from the net class), used for lateral padding.
+            package: This leg's package (for the on-package exclusion set
+                when picking the partner endpoint).
+
+        Returns:
+            Number of grid cells reserved.  0 when the flag path is a
+            no-op (partner endpoint unresolvable, degenerate direction,
+            no inner layer, or grid cells empty).
+        """
+        if not self.net_pad_positions:
+            return 0
+        if pad.net_name is None:
+            return 0
+
+        # Resolve the partner's nearest OFF-package endpoint.  Positions
+        # that coincide with a pad on THIS package are excluded (the
+        # partner's on-package pads, if any, are not the cross-package
+        # target).  Position-keyed exclusion mirrors
+        # ``_select_pair_launch_direction``.
+        on_package = {(round(p.x, 3), round(p.y, 3)) for p in package.pads}
+        partner_positions = [
+            (x, y)
+            for (x, y) in self.net_pad_positions.get(partner_name, ())
+            if (round(x, 3), round(y, 3)) not in on_package
+        ]
+        if not partner_positions:
+            return 0
+
+        # Nearest off-package partner endpoint to this pad.
+        tx, ty = min(
+            partner_positions,
+            key=lambda pt: math.hypot(pt[0] - pad.x, pt[1] - pad.y),
+        )
+
+        # Launch direction: from this pad toward the partner.
+        vx = tx - pad.x
+        vy = ty - pad.y
+        span = math.hypot(vx, vy)
+        if span == 0:
+            return 0
+        dx = vx / span
+        dy = vy / span
+        # Lateral (right-hand-rule perpendicular) unit vector.
+        lat_dx, lat_dy = -dy, dx
+
+        # Inner routable layer for the corridor (same selection the
+        # intra-package continuation corridor uses).
+        target_inner_layer = self._select_inner_escape_layer(pad.layer)
+        if self.grid.layer_stack is not None:
+            target_def = self.grid.layer_stack.get_layer_by_name(target_inner_layer.kicad_name)
+            if target_def is None or target_def.is_outer:
+                # 2-layer boards / no inner signal layer: no corridor.
+                return 0
+        try:
+            target_idx = self.grid.layer_to_index(target_inner_layer.value)
+        except Exception:
+            return 0
+
+        # Owner set: this leg's net id plus (when resolvable) the partner
+        # net id, so BOTH legs of the pair receive the soft attractor
+        # bonus toward this corridor.
+        owner_nets: set[int] = set()
+        if pad.net is not None:
+            owner_nets.add(int(pad.net))
+        partner_id = self.net_name_to_id.get(partner_name)
+        if partner_id is not None:
+            owner_nets.add(int(partner_id))
+        if not owner_nets:
+            return 0
+
+        # Trace width for the padding term (widest of the two legs when
+        # the partner width is resolvable, else this leg's width).
+        trace_w = self._get_trace_width_for_net(pad.net_name)
+        partner_w = self._get_trace_width_for_net(partner_name)
+        max_trace_w = max(trace_w, partner_w)
+
+        # Escape launch point: step off the pad by the same launch
+        # distance the single-ended / paired escapes use, so the corridor
+        # begins where the leg actually leaves the package.
+        escape_dist = self.escape_clearance + max_trace_w * 2
+        # Do not overshoot the partner endpoint if it is closer than the
+        # launch distance (degenerate very-near packages).
+        launch = min(escape_dist, span * 0.5)
+        cx = pad.x + dx * launch
+        cy = pad.y + dy * launch
+
+        # Corridor length: from the launch point to the partner endpoint,
+        # clamped to the remaining span.  This connects the two escape
+        # exits without overshooting into the partner package.
+        corridor_length = max(0.0, span - launch)
+        if corridor_length <= 0.0:
+            return 0
+
+        # Lateral half-width: room for both legs side by side plus the
+        # intra-pair clearance.  (No via-halo widening -- the soft
+        # reservation does not fence, so over-reserving would only dilute
+        # the attractor field, not fence neighbours out.)
+        lat_half = intra_pair_clearance + max_trace_w
+
+        # Enumerate covered cells with a (t, u) parametric walk, stepping
+        # by half the grid resolution to avoid diagonal aliasing -- same
+        # sampling ``_reserve_pair_continuation_corridor`` uses.
+        step = self.grid.resolution * 0.5
+        if step <= 0:
+            return 0
+        cells: set[tuple[int, int]] = set()
+        t = 0.0
+        while t <= corridor_length:
+            u = -lat_half
+            while u <= lat_half:
+                wx = cx + dx * t + lat_dx * u
+                wy = cy + dy * t + lat_dy * u
+                gx, gy = self.grid.world_to_grid(wx, wy)
+                cells.add((gx, gy))
+                u += step
+            t += step
+        if not cells:
+            return 0
+
+        count = self.grid.reserve_corridor_cells(
+            layer_idx=target_idx,
+            cells=cells,
+            net_ids=owner_nets,
+            soft=True,
+        )
+        if count > 0:
+            self.cross_package_pair_corridor_reservations += 1
+            self.cross_package_pair_corridor_reserved_cells += count
+            logger.debug(
+                "Issue #4086 cross-package corridor reserved (soft): "
+                "layer=%s cells=%d nets=%s %s->%s",
+                target_inner_layer.name,
+                count,
+                sorted(owner_nets),
+                pad.net_name,
+                partner_name,
             )
         return count
 

--- a/tests/router/test_cross_package_pair_corridor.py
+++ b/tests/router/test_cross_package_pair_corridor.py
@@ -1,0 +1,459 @@
+"""Tests for cross-package diff-pair corridor reservation (Issue #4086).
+
+Background
+----------
+
+Epic #2556 Phase 2F (issues #2639, #2677) added paired escape + corridor
+reservation for diff pairs whose BOTH halves land on the same package
+(``EscapeRouter._generate_paired_escapes`` ->
+``_escape_diff_pair_segment`` + ``_reserve_pair_continuation_corridor``).
+Cross-package pairs -- partner pin on a DIFFERENT package (driver ->
+connector, or driver -> receiver on opposite board sides) -- were
+explicitly skipped: both legs escaped single-ended and the only coupling
+downstream was ``CoupledPathfinder`` free-searching the joint state space.
+
+Issue #4086 (Phase 1) closes that gap behind a flag (default OFF):
+``EscapeRouter._reserve_cross_package_pair_corridor`` reserves a SOFT
+(attractor-only) continuation corridor from each leg's escape launch point
+toward the off-package partner, resolved via the board-wide
+``net_pad_positions`` map, so the coupled search (via the #4080 attractor)
+has geometry to follow.
+
+These tests pin the Phase-1 contract:
+
+1. Detection fires ONLY when the flag is on AND ``net_pad_positions``
+   resolves an off-package partner endpoint.
+2. Flag OFF (default) => byte-identical no-op (no reservation, cell count
+   unchanged); the leg still escapes single-ended.
+3. ``net_pad_positions`` absent / partner unresolvable => no-op even with
+   the flag ON (fallback-safety, mirrors ``_select_pair_launch_direction``).
+4. The reservation is SOFT (only the attractor applies -- foreign copper
+   is NOT fenced out) and owned by the pair's net-id set only (never a
+   third net).
+5. Intra-package pairs are unaffected -- they still take the existing
+   paired-escape path, not the cross-package path.
+
+The fixtures are synthetic two-package layouts on an otherwise-empty grid;
+no board file is required (board 00-07 fixtures have no cross-package diff
+pair today).
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from kicad_tools.router.escape import (
+    EscapeRouter,
+    PackageInfo,
+    PackageType,
+)
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import (
+    NET_CLASS_HIGH_SPEED,
+    DesignRules,
+)
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def rules() -> DesignRules:
+    return DesignRules(
+        trace_width=0.2,
+        trace_clearance=0.15,
+        via_drill=0.3,
+        via_diameter=0.6,
+        via_clearance=0.15,
+        grid_resolution=0.1,
+    )
+
+
+@pytest.fixture
+def grid_4layer(rules: DesignRules) -> RoutingGrid:
+    """4-layer all-signal grid so an inner SIGNAL layer exists for the
+    corridor (the intra-package corridor uses the same stack-up)."""
+    stack = LayerStack.four_layer_all_signal()
+    return RoutingGrid(60, 60, rules, origin_x=0, origin_y=0, layer_stack=stack)
+
+
+@pytest.fixture
+def grid_2layer(rules: DesignRules) -> RoutingGrid:
+    """2-layer grid -- no inner signal layer, so the corridor must no-op."""
+    return RoutingGrid(60, 60, rules, origin_x=0, origin_y=0)
+
+
+# =============================================================================
+# Synthetic two-package fixture builders
+# =============================================================================
+
+DRIVER_REF = "U1"
+CONNECTOR_REF = "J1"
+P_NET = "HDMI_D0_P"
+N_NET = "HDMI_D0_N"
+P_ID = 1
+N_ID = 2
+
+
+def make_driver_qfn(
+    *,
+    p_net: str = P_NET,
+    n_net: str = N_NET,
+    p_id: int = P_ID,
+    n_id: int = N_ID,
+) -> list[Pad]:
+    """QFN-8 driver whose SOUTH edge carries ONE half of a diff pair.
+
+    The partner half is intentionally NOT on this package -- it lives on
+    the connector (see ``make_connector_pads``).  The other 7 pins get
+    unique single-ended nets.
+    """
+    pitch = 0.5
+    pins_per_side = 8
+    half = (pins_per_side - 1) * pitch / 2 + 1.0
+    pads: list[Pad] = []
+    nid = 100
+
+    # South edge (y = -half): index 4 carries the P half; index 5 carries
+    # a DIFFERENT single-ended net (the N half is off-package).
+    for i in range(pins_per_side):
+        x = -half + 1.0 + i * pitch
+        if i == 4:
+            net_name, net_id = p_net, p_id
+        else:
+            net_name, net_id = f"U1_NET_{nid}", nid
+            nid += 1
+        pads.append(
+            Pad(
+                x=x,
+                y=-half,
+                width=0.3,
+                height=0.8,
+                net=net_id,
+                net_name=net_name,
+                layer=Layer.F_CU,
+                ref=DRIVER_REF,
+            )
+        )
+    return pads
+
+
+def make_connector_pads(
+    *,
+    n_net: str = N_NET,
+    n_id: int = N_ID,
+    origin_y: float = 20.0,
+) -> list[Pad]:
+    """A connector footprint placed well AWAY from the driver.
+
+    Carries the N half of the diff pair (its partner is on the driver).
+    We only need it to populate the board-wide ``net_pad_positions`` map;
+    it is NOT the package passed to ``generate_escapes`` in these tests.
+    """
+    return [
+        Pad(
+            x=0.0,
+            y=origin_y,
+            width=0.3,
+            height=0.8,
+            net=n_id,
+            net_name=n_net,
+            layer=Layer.F_CU,
+            ref=CONNECTOR_REF,
+        ),
+    ]
+
+
+def make_package_info(pads: list[Pad], pkg_type: PackageType, ref: str) -> PackageInfo:
+    xs = [p.x for p in pads]
+    ys = [p.y for p in pads]
+    cx = (min(xs) + max(xs)) / 2.0
+    cy = (min(ys) + max(ys)) / 2.0
+    bbox = (min(xs), min(ys), max(xs), max(ys))
+    pitches = []
+    for i, a in enumerate(pads):
+        for b in pads[i + 1 :]:
+            d = math.hypot(a.x - b.x, a.y - b.y)
+            if d > 0:
+                pitches.append(d)
+    pitch = min(pitches) if pitches else 0.5
+    return PackageInfo(
+        ref=ref,
+        package_type=pkg_type,
+        center=(cx, cy),
+        pads=pads,
+        pin_count=len(pads),
+        pin_pitch=pitch,
+        bounding_box=bbox,
+        is_dense=True,
+    )
+
+
+def build_board_wide_maps(
+    driver_pads: list[Pad], connector_pads: list[Pad]
+) -> tuple[dict[str, list[tuple[float, float]]], dict[str, int]]:
+    """Build the board-wide net_pad_positions + net_name_to_id maps the
+    real ``Autorouter._escape`` property assembles from ``self.pads``."""
+    net_pad_positions: dict[str, list[tuple[float, float]]] = {}
+    net_name_to_id: dict[str, int] = {}
+    for pad in [*driver_pads, *connector_pads]:
+        if pad.net_name:
+            net_pad_positions.setdefault(pad.net_name, []).append((pad.x, pad.y))
+            if pad.net is not None and pad.net_name not in net_name_to_id:
+                net_name_to_id[pad.net_name] = int(pad.net)
+    return net_pad_positions, net_name_to_id
+
+
+def make_router(
+    grid: RoutingGrid,
+    rules: DesignRules,
+    *,
+    enable_flag: bool,
+    with_board_maps: bool = True,
+) -> tuple[EscapeRouter, PackageInfo]:
+    """Assemble an EscapeRouter + the driver PackageInfo for a
+    cross-package HDMI_D0 pair (P on driver, N on connector)."""
+    driver_pads = make_driver_qfn()
+    connector_pads = make_connector_pads()
+    info = make_package_info(driver_pads, PackageType.QFN, DRIVER_REF)
+    ncm = {P_NET: NET_CLASS_HIGH_SPEED, N_NET: NET_CLASS_HIGH_SPEED}
+
+    if with_board_maps:
+        net_pad_positions, net_name_to_id = build_board_wide_maps(driver_pads, connector_pads)
+    else:
+        net_pad_positions, net_name_to_id = {}, {}
+
+    er = EscapeRouter(
+        grid,
+        rules,
+        net_class_map=ncm,
+        diff_pair_map={P_NET: N_NET, N_NET: P_NET},
+        net_pad_positions=net_pad_positions,
+        net_name_to_id=net_name_to_id,
+        enable_cross_package_pair_corridor=enable_flag,
+    )
+    return er, info
+
+
+# =============================================================================
+# Contract 1: fires only when flag ON and partner resolvable
+# =============================================================================
+
+
+class TestCrossPackageDetection:
+    def test_flag_on_reserves_corridor(self, grid_4layer, rules):
+        """Flag ON + resolvable off-package partner => a soft corridor is
+        reserved for the cross-package leg."""
+        er, info = make_router(grid_4layer, rules, enable_flag=True)
+        assert er.cross_package_pair_corridor_reservations == 0
+        assert grid_4layer.reserved_cell_count() == 0
+
+        er.generate_escapes(info)
+
+        assert er.cross_package_pair_corridor_reservations == 1, (
+            "Expected exactly one cross-package corridor reservation "
+            "(one cross-package leg on the driver package)"
+        )
+        assert er.cross_package_pair_corridor_reserved_cells >= 1
+        assert grid_4layer.reserved_cell_count() >= 1
+
+    def test_flag_off_is_noop(self, grid_4layer, rules):
+        """Flag OFF (default) => byte-identical no-op: no reservation, no
+        reserved cells; the leg still escapes single-ended."""
+        er, info = make_router(grid_4layer, rules, enable_flag=False)
+
+        er.generate_escapes(info)
+
+        # Flag OFF => the cross-package branch is a no-op ``continue``:
+        # no reservation, no reserved cells.  The cross-package leg is NOT
+        # removed from the single-ended dispatcher's input (it was never
+        # added to ``paired_pad_keys``), so escape dispatch is unchanged.
+        assert er.cross_package_pair_corridor_reservations == 0
+        assert er.cross_package_pair_corridor_reserved_cells == 0
+        assert grid_4layer.reserved_cell_count() == 0
+
+    def test_flag_off_vs_on_dispatch_identical(self, grid_4layer, rules):
+        """The cross-package leg escapes single-ended IDENTICALLY whether
+        the flag is on or off -- Phase 1 only adds a corridor reservation,
+        it never changes the leg's own escape geometry."""
+        er_off, info = make_router(grid_4layer, rules, enable_flag=False)
+        esc_off = er_off.generate_escapes(info)
+
+        grid2 = RoutingGrid(
+            60, 60, rules, origin_x=0, origin_y=0, layer_stack=LayerStack.four_layer_all_signal()
+        )
+        er_on, info_on = make_router(grid2, rules, enable_flag=True)
+        esc_on = er_on.generate_escapes(info_on)
+
+        # Same number of escape routes and same escape points (the leg's
+        # own geometry is untouched by the corridor reservation).
+        assert len(esc_off) == len(esc_on)
+        pts_off = sorted(round(c, 4) for e in esc_off for c in e.escape_point)
+        pts_on = sorted(round(c, 4) for e in esc_on for c in e.escape_point)
+        assert pts_off == pts_on, (
+            "Cross-package leg escape geometry must be identical flag on vs off"
+        )
+
+    def test_no_board_maps_is_noop_even_with_flag_on(self, grid_4layer, rules):
+        """Flag ON but ``net_pad_positions`` absent => no-op (partner
+        endpoint unresolvable).  Mirrors the fallback-safety contract on
+        ``_select_pair_launch_direction``."""
+        er, info = make_router(grid_4layer, rules, enable_flag=True, with_board_maps=False)
+
+        er.generate_escapes(info)
+
+        assert er.cross_package_pair_corridor_reservations == 0
+        assert er.cross_package_pair_corridor_reserved_cells == 0
+        assert grid_4layer.reserved_cell_count() == 0
+
+    def test_two_layer_grid_is_noop(self, grid_2layer, rules):
+        """No inner signal layer (2-layer stack) => corridor no-op even
+        with the flag on and the partner resolvable."""
+        er, info = make_router(grid_2layer, rules, enable_flag=True)
+
+        er.generate_escapes(info)
+
+        assert er.cross_package_pair_corridor_reservations == 0
+        assert grid_2layer.reserved_cell_count() == 0
+
+
+# =============================================================================
+# Contract 2: reservation is SOFT and owned by the pair only
+# =============================================================================
+
+
+class TestCrossPackageReservationSemantics:
+    def test_owner_set_is_exactly_the_pair(self, grid_4layer, rules):
+        """The corridor owner set is exactly {P_ID, N_ID} -- never a
+        third (foreign) net."""
+        er, info = make_router(grid_4layer, rules, enable_flag=True)
+        er.generate_escapes(info)
+
+        reserved = list(grid_4layer._reserved_for_nets.items())
+        assert reserved, "Expected a non-empty reservation map"
+        for _key, owners in reserved:
+            assert owners == frozenset({P_ID, N_ID}), (
+                f"Cross-package corridor owner set must be the pair "
+                f"{{{P_ID}, {N_ID}}}, got {owners}"
+            )
+
+    def test_reservation_is_soft(self, grid_4layer, rules):
+        """Every reserved cell is marked SOFT (attractor-only) -- a
+        cross-package span must not hard-fence foreign copper out."""
+        er, info = make_router(grid_4layer, rules, enable_flag=True)
+        er.generate_escapes(info)
+
+        reserved_keys = set(grid_4layer._reserved_for_nets.keys())
+        assert reserved_keys, "Expected reserved cells"
+        # A SOFT reservation records every reserved cell key in
+        # ``_soft_reservations``.  A HARD reservation records none.
+        assert reserved_keys <= grid_4layer._soft_reservations, (
+            "Cross-package corridor cells must all be SOFT reservations"
+        )
+
+    def test_soft_corridor_does_not_fence_foreign_via(self, grid_4layer, rules):
+        """A foreign-net via placed on a soft-reserved cell still claims
+        it (soft = attractor-only, no keep-out fence)."""
+        from kicad_tools.router.primitives import Via
+
+        er, info = make_router(grid_4layer, rules, enable_flag=True)
+        er.generate_escapes(info)
+
+        reserved = list(grid_4layer._reserved_for_nets.items())
+        (layer_idx, gy, gx), _owners = reserved[len(reserved) // 2]
+        wx, wy = grid_4layer.grid_to_world(gx, gy)
+
+        foreign_via = Via(
+            x=wx,
+            y=wy,
+            drill=rules.via_drill,
+            diameter=rules.via_diameter,
+            layers=(Layer.F_CU, Layer.B_CU),
+            net=999,  # not in {P_ID, N_ID}
+            net_name="FOREIGN",
+        )
+        grid_4layer._mark_via(foreign_via)
+
+        # SOFT => the foreign via was NOT fenced out; the cell is blocked
+        # (claimed) by the foreign via.
+        assert grid_4layer.grid[layer_idx][gy][gx].blocked, (
+            "A soft cross-package corridor must NOT fence a foreign via out"
+        )
+
+
+# =============================================================================
+# Contract 3: intra-package pairs are unaffected (still Phase 2F path)
+# =============================================================================
+
+
+class TestIntraPackageUnaffected:
+    def _make_intra_pair(self) -> list[Pad]:
+        """QFN-8 whose south edge carries BOTH halves of a pair
+        (adjacent) -- the classic intra-package Phase 2F case."""
+        pitch = 0.5
+        pins_per_side = 8
+        half = (pins_per_side - 1) * pitch / 2 + 1.0
+        pads: list[Pad] = []
+        nid = 200
+        for i in range(pins_per_side):
+            x = -half + 1.0 + i * pitch
+            if i == 4:
+                net_name, net_id = P_NET, P_ID
+            elif i == 5:
+                net_name, net_id = N_NET, N_ID
+            else:
+                net_name, net_id = f"U1_NET_{nid}", nid
+                nid += 1
+            pads.append(
+                Pad(
+                    x=x,
+                    y=-half,
+                    width=0.3,
+                    height=0.8,
+                    net=net_id,
+                    net_name=net_name,
+                    layer=Layer.F_CU,
+                    ref=DRIVER_REF,
+                )
+            )
+        return pads
+
+    def test_intra_pair_uses_phase2f_not_cross_package(self, grid_4layer, rules):
+        """With BOTH halves on-package, the intra-package paired-escape
+        path fires (``pair_corridor_reservations``) and the cross-package
+        path does NOT -- even with the cross-package flag ON."""
+        pads = self._make_intra_pair()
+        info = make_package_info(pads, PackageType.QFN, DRIVER_REF)
+        net_pad_positions: dict[str, list[tuple[float, float]]] = {}
+        net_name_to_id: dict[str, int] = {}
+        for p in pads:
+            if p.net_name:
+                net_pad_positions.setdefault(p.net_name, []).append((p.x, p.y))
+                if p.net is not None:
+                    net_name_to_id.setdefault(p.net_name, int(p.net))
+
+        er = EscapeRouter(
+            grid_4layer,
+            rules,
+            net_class_map={P_NET: NET_CLASS_HIGH_SPEED, N_NET: NET_CLASS_HIGH_SPEED},
+            diff_pair_map={P_NET: N_NET, N_NET: P_NET},
+            net_pad_positions=net_pad_positions,
+            net_name_to_id=net_name_to_id,
+            enable_cross_package_pair_corridor=True,
+        )
+        er.generate_escapes(info)
+
+        assert er.diff_pair_segment_calls == 1, (
+            "Intra-package pair should take the paired-escape segment path"
+        )
+        assert er.pair_corridor_reservations == 1, (
+            "Intra-package pair should reserve the Phase 2F continuation corridor"
+        )
+        assert er.cross_package_pair_corridor_reservations == 0, (
+            "Intra-package pair must NOT trigger the cross-package corridor path"
+        )


### PR DESCRIPTION
## Summary

Extends the escape-stage diff-pair handling to **cross-package** pairs
(partner pin on a different package), gated behind a new flag defaulting
OFF. Epic #2556 Phase 2F already pairs diff-pair escapes and reserves a
continuation corridor, but only for pairs whose two halves land on the
**same** package; cross-package pairs fell through to the single-ended
dispatcher with no reserved geometry, forcing `CoupledPathfinder` to
free-search the joint state space from scratch (the #3438 budget-exhaustion
failure mode).

Phase 1 scope only: detect the cross-package pair and reserve a corridor
connecting the two escape exits. No ILP pin assignment, no C++ core search
changes, no multi-pair bundle joint escape — those remain out of scope per
the curated issue.

## Changes

- `src/kicad_tools/router/escape.py`
  - New `EscapeRouter._reserve_cross_package_pair_corridor(pad, partner_name, intra_pair_clearance, package)`: resolves the nearest off-package partner endpoint from the board-wide `net_pad_positions` map, then reserves a **SOFT** (`soft=True`) corridor from this leg's escape launch point toward the partner using the existing `RoutingGrid.reserve_corridor_cells` primitive (no new reservation mechanism). Owner set is the pair's two net ids only.
  - `_generate_paired_escapes`: the existing "partner not on this package" branch now calls the new helper when `enable_cross_package_pair_corridor` is on. The leg is deliberately **not** added to `paired_pad_keys`, so it still escapes single-ended — only the corridor reservation is added.
  - Constructor: new `enable_cross_package_pair_corridor: bool = False` gate + `net_name_to_id` map (to resolve the partner's net id for the corridor owner set) + instrumentation counters `cross_package_pair_corridor_reservations` / `cross_package_pair_corridor_reserved_cells`.
- `src/kicad_tools/router/core.py`
  - New `Autorouter.enable_cross_package_pair_corridor = False` flag next to `enable_byte_lane_reorder`.
  - `_escape` property threads the flag and a parallel `net_name_to_id` map (built alongside the existing `net_pad_positions`) into the `EscapeRouter`.
- `tests/router/test_cross_package_pair_corridor.py` — new synthetic two-package fixture + 9 unit tests.

## Soft vs hard reservation choice

Chose **`soft=True`** (attractor-only, non-fencing). Rationale, following the curation guidance and the #4087 evidence: a HARD keep-out spanning the board between two packages would carve a foreign-copper-free channel across the whole board and starve unrelated nets — the #4087 finding that hard fences short-induce in dense areas applies doubly to a long cross-package span. Soft keeps the corridor attractor-visible (so the coupled pair is pulled onto it via the #4080 attractor) while leaving every other net free to cross it. The intra-package `_reserve_pair_continuation_corridor` stays HARD because its corridor is short and planar; only the new cross-package path is soft.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Cross-package pairs get paired escape + corridor reservation when flag ON | ✅ | `test_flag_on_reserves_corridor` — 1 reservation, ≥1 cell reserved |
| Synthetic fixture demonstrates it (two packages, one pair spanning them) | ✅ | `tests/router/test_cross_package_pair_corridor.py` (driver QFN P-half + off-package connector N-half) |
| Paired launches + corridor reserved | ✅ | reservation counters + `reserved_cell_count()` asserted |
| Flag OFF = byte-identical default | ✅ | `test_flag_off_is_noop` (no reservation) + `test_flag_off_vs_on_dispatch_identical` (escape geometry identical) |
| No new reservation primitive | ✅ | reuses `reserve_corridor_cells(..., soft=True)` |
| No C++ core search changes / no BUILD_VERSION bump | ✅ | Python-only diff (`escape.py`, `core.py`, test); `kct build-native --check` reports available 1.0.0, no `cpp/**` edits |
| Owner set is the pair only (never widens to a third net) | ✅ | `test_owner_set_is_exactly_the_pair` |
| Reservation is soft | ✅ | `test_reservation_is_soft` + `test_soft_corridor_does_not_fence_foreign_via` |
| Fallback-safety (no fire when partner unresolvable / no `net_pad_positions`) | ✅ | `test_no_board_maps_is_noop_even_with_flag_on`, `test_two_layer_grid_is_noop` |
| Intra-package pairs unaffected (still Phase 2F path) | ✅ | `test_intra_pair_uses_phase2f_not_cross_package` |
| Boards 00-07 regression-clean | ✅ | board 06 (diffpair) + board 07 (matchgroup) suites pass (93 tests); flag OFF, no cross-package pair in any fixture |
| Board 07 coupled success not regressed (its pairs are intra-package) | ✅ | board 07 matchgroup suite unchanged (flag OFF; intra-package pairs still take the Phase 2F path) |

## Test Plan

- New: `tests/router/test_cross_package_pair_corridor.py` — 9 tests, all pass (`0.29s`).
- Regression: `test_escape_diffpair.py`, `test_byte_lane_corridor_reservation.py`, `test_escape.py`, `test_diffpair_corridor.py`, `test_diffpair_routing_integration.py`, `test_diffpair_partner_wiring.py`, `test_escape_diffpair_composition.py`, `test_diffpair_coupled_cpp_parity.py` — all pass.
- Boards: `test_board_06_diffpair_test.py` + `test_board_07_matchgroup_test.py` — 93 pass.
- `uv run ruff format . --check` and `uv run ruff check .` — clean.
- `uv run kct build-native --check` — C++ backend available (version 1.0.0); no C++ sources touched, so no `ROUTER_CPP_BUILD_VERSION` bump expected or made.

## Notes / honest caveats

- **Board 07 delta**: board 07's 4 diff pairs are all intra-package, so this change does not exercise its coupled path and does not move its 7/31 baseline. The synthetic fixture is the primary acceptance evidence, as the curated Test Plan calls out. This PR does not claim a board-07 improvement.
- **Downstream consumption**: the reservation is soft/attractor-visible per #4080. Whether the coupled pathfinder converges faster on a real cross-package board is a measurement for a fixture-bearing follow-up; this PR delivers the escape-stage reservation, not a full end-to-end coupled improvement claim.

Closes #4086
