### PR TITLE
test(router): gate slow DDR reach absolute assertions on native backend

### DIFF
--- a/tests/router/test_monotone_reach.py
+++ b/tests/router/test_monotone_reach.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import pytest
 
 from kicad_tools.router.core import Autorouter
+from kicad_tools.router.cpp_backend import is_cpp_available
 from kicad_tools.router.layers import LayerStack
 from kicad_tools.router.rules import NetClassRouting
 
@@ -124,9 +125,17 @@ class TestDDRByteReach:
         with_cert = _reach(router_on.route_all_negotiated(seed=42), ids_on)
 
         # Phase-1 acceptance: certificate ordering is NO WORSE than the
-        # identity baseline on the isolated bundle.
+        # identity baseline on the isolated bundle.  This relative guard holds
+        # on every backend, including the pure-Python A* fallback.
         assert with_cert >= baseline
-        # Both reach full on the empty board (the #3438 2/11 loss is a
-        # full-board congestion effect, not intrinsic to the bundle).
-        assert baseline == len(ids_off)
-        assert with_cert == len(ids_on)
+        # The absolute reach numbers are backend-dependent: full 11/11 with the
+        # C++ router_cpp extension, but only 7/11 on the pure-Python fallback
+        # (a backend artifact, not a router regression — see repo CLAUDE.md,
+        # `uv sync` does not build the native extension).  Gate them on native
+        # availability so a fresh checkout / Loom worktree that hasn't run
+        # `kct build-native` sees a clean pass, not a confusing AssertionError.
+        if is_cpp_available():
+            # Both reach full on the empty board (the #3438 2/11 loss is a
+            # full-board congestion effect, not intrinsic to the bundle).
+            assert baseline == len(ids_off)
+            assert with_cert == len(ids_on)


### PR DESCRIPTION
## Summary

The slow `TestDDRByteReach.test_certificate_reach_no_worse_than_identity_baseline`
in `tests/router/test_monotone_reach.py` asserted absolute `11/11` reach on both
the flag-OFF baseline and the flag-ON certificate run. Those absolute numbers are
**backend-dependent**: they hold with the C++ `router_cpp` extension, but the
pure-Python A* fallback deterministically reaches only 7/11. Any fresh checkout or
Loom worktree (`.loom/worktrees/issue-N/`) that hasn't run `kct build-native`
fails this test with a confusing "routing regression" `AssertionError` that is
actually a backend artifact, not a router defect (`uv sync` does not build the
native extension — see repo `CLAUDE.md`).

## Changes

- Import `is_cpp_available` from `kicad_tools.router.cpp_backend` (the established
  repo idiom, 170+ references; it internally checks `BUILD_VERSION`, so a stale
  `.so` is also correctly reported unavailable).
- Keep the relative `assert with_cert >= baseline` guard **unconditional** so the
  Phase-1 acceptance bar still runs on every backend, including the Python fallback.
- Gate the two absolute assertions (`baseline == len(ids_off)`,
  `with_cert == len(ids_on)`) behind `if is_cpp_available():`.
- Guard is scoped to `TestDDRByteReach` only — no module-level `pytestmark`. The
  fast, non-routing `TestDDRByteCertificateClassification` is unaffected.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Slow test no longer hard-fails when C++ backend unavailable/stale | ✅ | Absolute asserts now gated on `is_cpp_available()`; relative-only path runs otherwise |
| Relative guard (`with_cert >= baseline`) still runs on every backend | ✅ | Assertion left unconditional above the gate |
| With C++ backend built, behavior unchanged (still asserts `== 11`) | ✅ | `kct build-native --check` → available; slow test PASSED with absolute asserts active |
| `TestDDRByteCertificateClassification` unaffected | ✅ | Fast class run: 1 passed; no skip condition added to it |
| Fix confined to `tests/router/test_monotone_reach.py`; no new labels | ✅ | `git diff --stat`: single test file, 14 insertions / 5 deletions |

## Test Plan

Ran in the issue worktree with the native extension built:

- `uv run kct build-native --check` → `C++ backend: available (version 1.0.0)`
- `uv run pytest ...::TestDDRByteCertificateClassification -v` → **1 passed**
- `uv run pytest ...::TestDDRByteReach --collect-only` → **1 test collected** (clean)
- `uv run pytest ...::TestDDRByteReach::test_certificate_reach_no_worse_than_identity_baseline -m slow -v` → **1 passed** (absolute `== 11` assertions active and passing under C++ backend)
- `uv run ruff check` + `ruff format --check` on the changed file → clean

Closes #4091

🤖 Generated with [Claude Code](https://claude.com/claude-code)