### PR TITLE
feat(cli): expose monotone-certificate / cross-package / slack routing flags on kct route (Closes #4094)

### DIFF
--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -208,6 +208,16 @@ def run_route_command(args) -> int:
     # it (byte-identical when absent).
     if getattr(args, "bundle_river_planner", False):
         sub_argv.append("--bundle-river-planner")
+    # Issue #4094 (epic #4049): forward the three constructor-only routing
+    # flags (#4089/#4090/#4092).  Both parsers declare each as store_true
+    # defaulting to False, so only forward when the user set it — this is
+    # what makes flag-off byte-identical (sub_argv unchanged when absent).
+    if getattr(args, "monotone_certificate_order", False):
+        sub_argv.append("--monotone-certificate-order")
+    if getattr(args, "cross_package_pair_corridor", False):
+        sub_argv.append("--cross-package-pair-corridor")
+    if getattr(args, "slack_corridor_widening", False):
+        sub_argv.append("--slack-corridor-widening")
     max_ripups_val = getattr(args, "max_ripups_per_net", None)
     if max_ripups_val is not None:
         sub_argv.extend(["--max-ripups-per-net", str(max_ripups_val)])

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2778,6 +2778,44 @@ def _add_route_parser(subparsers) -> None:
             "scoped in v1."
         ),
     )
+    route_parser.add_argument(
+        "--monotone-certificate-order",
+        action="store_true",
+        default=False,
+        help=(
+            "Enable the monotone-certificate escape order for byte-lane "
+            "buses (Issue #4089, epic #4049).  Board 07's DDR byte is proven "
+            "feasible and routes 11/11 in isolation (#4089) but has not been "
+            "validated end-to-end on the assembled board; when the "
+            "certificate finds the bundle infeasible as-pinned, order is left "
+            "at IDENTITY (no regression vs. flag-off).  Default OFF "
+            "(byte-identical when absent)."
+        ),
+    )
+    route_parser.add_argument(
+        "--cross-package-pair-corridor",
+        action="store_true",
+        default=False,
+        help=(
+            "Enable the cross-package pair corridor for diff/matched pairs "
+            "whose members escape from facing packages (Issue #4090, epic "
+            "#4049).  Reserves a shared corridor so the pair's two escapes "
+            "stay coupled across the package gap.  Default OFF "
+            "(byte-identical when absent)."
+        ),
+    )
+    route_parser.add_argument(
+        "--slack-corridor-widening",
+        action="store_true",
+        default=False,
+        help=(
+            "Enable slack-corridor widening (Issue #4092, epic #4049).  "
+            "Prefers slack-reserved corridors and threads the reservation "
+            "into the escape router and diff-pair length tuning so tuned "
+            "nets can widen into reserved slack.  Default OFF "
+            "(byte-identical when absent)."
+        ),
+    )
     # Issue #3054 (Phase 2 of #3045): wire region-based parallelism through to
     # ``route_all_negotiated``.  Opt-in (default off) so existing scripts and
     # CI runs see byte-identical routes; when set, the negotiated loop

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -2800,6 +2800,51 @@ def _apply_bundle_river_planner(router: "Autorouter", args) -> None:
         router.enable_bundle_river_planner = True
 
 
+def _apply_monotone_certificate_order(router: "Autorouter", args) -> None:
+    """Enable the monotone-certificate escape order when requested (Issue #4089).
+
+    Off by default (mirrors ``enable_bundle_river_planner`` / the #4051
+    precedent).  When ``--monotone-certificate-order`` is passed, set the
+    router's ``enable_monotone_certificate_order`` flag so
+    ``_apply_byte_lane_inner_priority`` runs its certificate pre-stage: the
+    board-07 DDR byte is proven feasible and routes 11/11 in isolation
+    (#4089).  When the certificate finds the bundle infeasible as-pinned the
+    order is left at IDENTITY, so there is no regression vs. flag-off.  A
+    no-op when the flag is absent, so production routing is byte-identical to
+    pre-#4089 main.
+    """
+    if getattr(args, "monotone_certificate_order", False):
+        router.enable_monotone_certificate_order = True
+
+
+def _apply_cross_package_pair_corridor(router: "Autorouter", args) -> None:
+    """Enable the cross-package pair corridor when requested (Issue #4090).
+
+    Off by default (mirrors ``enable_bundle_river_planner`` / the #4051
+    precedent).  When ``--cross-package-pair-corridor`` is passed, set the
+    router's ``enable_cross_package_pair_corridor`` flag so the reservation
+    is threaded into ``EscapeRouter`` for pairs whose members escape from
+    facing packages.  A no-op when the flag is absent, so production routing
+    is byte-identical to pre-#4090 main.
+    """
+    if getattr(args, "cross_package_pair_corridor", False):
+        router.enable_cross_package_pair_corridor = True
+
+
+def _apply_slack_corridor_widening(router: "Autorouter", args) -> None:
+    """Enable slack-corridor widening when requested (Issue #4092).
+
+    Off by default (mirrors ``enable_bundle_river_planner`` / the #4051
+    precedent).  When ``--slack-corridor-widening`` is passed, set the
+    router's ``enable_slack_corridor_widening`` flag so slack-reserved
+    corridors are preferred and threaded into ``EscapeRouter`` and
+    ``apply_diffpair_length_tuning``.  A no-op when the flag is absent, so
+    production routing is byte-identical to pre-#4092 main.
+    """
+    if getattr(args, "slack_corridor_widening", False):
+        router.enable_slack_corridor_widening = True
+
+
 def _targeted_ripup_budget(args) -> int:
     """Resolve ``--max-ripups-per-net`` for the negotiated targeted path.
 
@@ -3574,6 +3619,9 @@ def route_with_layer_escalation(
         # rip-up budgets (route_all + two-phase stall recovery).
         _apply_ripup_budget_override(router, args)
         _apply_bundle_river_planner(router, args)
+        _apply_monotone_certificate_order(router, args)
+        _apply_cross_package_pair_corridor(router, args)
+        _apply_slack_corridor_widening(router, args)
 
         # Issue #3171: inject boosted analog routing class for --analog-nets /
         # --auto-analog selected nets (pour/ground nets are left untouched).
@@ -4474,6 +4522,9 @@ def route_with_rule_relaxation(
         # rip-up budgets (route_all + two-phase stall recovery).
         _apply_ripup_budget_override(router, args)
         _apply_bundle_river_planner(router, args)
+        _apply_monotone_certificate_order(router, args)
+        _apply_cross_package_pair_corridor(router, args)
+        _apply_slack_corridor_widening(router, args)
 
         # Issue #3171: inject boosted analog routing class for --analog-nets /
         # --auto-analog selected nets (pour/ground nets are left untouched).
@@ -6575,6 +6626,9 @@ def route_with_combined_escalation(
             # rip-up budgets (route_all + two-phase stall recovery).
             _apply_ripup_budget_override(router, args)
             _apply_bundle_river_planner(router, args)
+            _apply_monotone_certificate_order(router, args)
+            _apply_cross_package_pair_corridor(router, args)
+            _apply_slack_corridor_widening(router, args)
 
             # Issue #3171: inject boosted analog routing class for --analog-nets
             # / --auto-analog selected nets (pour/ground nets left untouched).
@@ -7306,6 +7360,41 @@ def main(argv: list[str] | None = None) -> int:
             "the losing net can dip under its partner.  Default OFF "
             "(byte-identical to prior behaviour when absent); DDR-bundle "
             "scoped in v1."
+        ),
+    )
+    parser.add_argument(
+        "--monotone-certificate-order",
+        action="store_true",
+        help=(
+            "Enable the monotone-certificate escape order for byte-lane "
+            "buses (Issue #4089, epic #4049).  Board 07's DDR byte is proven "
+            "feasible and routes 11/11 in isolation (#4089) but has not been "
+            "validated end-to-end on the assembled board; when the "
+            "certificate finds the bundle infeasible as-pinned, order is left "
+            "at IDENTITY (no regression vs. flag-off).  Default OFF "
+            "(byte-identical to prior behaviour when absent)."
+        ),
+    )
+    parser.add_argument(
+        "--cross-package-pair-corridor",
+        action="store_true",
+        help=(
+            "Enable the cross-package pair corridor for diff/matched pairs "
+            "whose members escape from facing packages (Issue #4090, epic "
+            "#4049).  Reserves a shared corridor so the pair's two escapes "
+            "stay coupled across the package gap.  Default OFF "
+            "(byte-identical to prior behaviour when absent)."
+        ),
+    )
+    parser.add_argument(
+        "--slack-corridor-widening",
+        action="store_true",
+        help=(
+            "Enable slack-corridor widening (Issue #4092, epic #4049).  "
+            "Prefers slack-reserved corridors and threads the reservation "
+            "into the escape router and diff-pair length tuning so tuned "
+            "nets can widen into reserved slack.  Default OFF "
+            "(byte-identical to prior behaviour when absent)."
         ),
     )
     parser.add_argument(
@@ -8988,6 +9077,9 @@ def main(argv: list[str] | None = None) -> int:
     # rip-up budgets (route_all + two-phase stall recovery).
     _apply_ripup_budget_override(router, args)
     _apply_bundle_river_planner(router, args)
+    _apply_monotone_certificate_order(router, args)
+    _apply_cross_package_pair_corridor(router, args)
+    _apply_slack_corridor_widening(router, args)
 
     # Issue #3171: inject boosted analog routing class for --analog-nets /
     # --auto-analog selected nets (pour/ground nets are left untouched).

--- a/tests/test_route_cmd_help_string.py
+++ b/tests/test_route_cmd_help_string.py
@@ -129,6 +129,38 @@ def test_route_cmd_region_parallel_help_escapes_percent_signs() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "flag",
+    [
+        "--monotone-certificate-order",
+        "--cross-package-pair-corridor",
+        "--slack-corridor-widening",
+    ],
+)
+def test_route_cmd_help_exposes_new_routing_flags(flag: str) -> None:
+    """``kct route --help`` must advertise the Issue #4094 routing flags.
+
+    The three constructor-only flags (#4089/#4090/#4092) were unreachable
+    from the CLI until #4094 wired them.  This pins that each flag appears
+    in the inner ``route_cmd`` parser's ``--help`` output with help text.
+    """
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, "-m", "kicad_tools.cli", "route", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"kct route --help exited {result.returncode}; stderr: {result.stderr[-500:]}"
+    )
+    assert flag in result.stdout, (
+        f"Expected {flag} in `kct route --help`; got: {result.stdout[:2000]}"
+    )
+
+
 def _placeholder_to_keep_argparse_imported() -> argparse.ArgumentParser:
     """Keep the argparse import alive for tooling; not a real test."""
     return argparse.ArgumentParser()

--- a/tests/test_route_cmd_params.py
+++ b/tests/test_route_cmd_params.py
@@ -510,6 +510,106 @@ class TestRouteCommandAutoFixFlags:
             passes_idx = call_args.index("--auto-fix-passes")
             assert call_args[passes_idx + 1] == "5"
 
+    # --- Issue #4094: monotone-certificate / cross-package / slack flags ---
+
+    def test_monotone_certificate_order_forwarded(self):
+        """--monotone-certificate-order is forwarded to route_cmd.main."""
+        from kicad_tools.cli.commands.routing import run_route_command
+
+        args = self._make_base_args(monotone_certificate_order=True)
+
+        with patch("kicad_tools.cli.route_cmd.main") as mock_main:
+            mock_main.return_value = 0
+            run_route_command(args)
+
+            call_args = mock_main.call_args[0][0]
+            assert "--monotone-certificate-order" in call_args
+
+    def test_monotone_certificate_order_not_forwarded_when_false(self):
+        """--monotone-certificate-order is not forwarded when not set."""
+        from kicad_tools.cli.commands.routing import run_route_command
+
+        args = self._make_base_args(monotone_certificate_order=False)
+
+        with patch("kicad_tools.cli.route_cmd.main") as mock_main:
+            mock_main.return_value = 0
+            run_route_command(args)
+
+            call_args = mock_main.call_args[0][0]
+            assert "--monotone-certificate-order" not in call_args
+
+    def test_cross_package_pair_corridor_forwarded(self):
+        """--cross-package-pair-corridor is forwarded to route_cmd.main."""
+        from kicad_tools.cli.commands.routing import run_route_command
+
+        args = self._make_base_args(cross_package_pair_corridor=True)
+
+        with patch("kicad_tools.cli.route_cmd.main") as mock_main:
+            mock_main.return_value = 0
+            run_route_command(args)
+
+            call_args = mock_main.call_args[0][0]
+            assert "--cross-package-pair-corridor" in call_args
+
+    def test_cross_package_pair_corridor_not_forwarded_when_false(self):
+        """--cross-package-pair-corridor is not forwarded when not set."""
+        from kicad_tools.cli.commands.routing import run_route_command
+
+        args = self._make_base_args(cross_package_pair_corridor=False)
+
+        with patch("kicad_tools.cli.route_cmd.main") as mock_main:
+            mock_main.return_value = 0
+            run_route_command(args)
+
+            call_args = mock_main.call_args[0][0]
+            assert "--cross-package-pair-corridor" not in call_args
+
+    def test_slack_corridor_widening_forwarded(self):
+        """--slack-corridor-widening is forwarded to route_cmd.main."""
+        from kicad_tools.cli.commands.routing import run_route_command
+
+        args = self._make_base_args(slack_corridor_widening=True)
+
+        with patch("kicad_tools.cli.route_cmd.main") as mock_main:
+            mock_main.return_value = 0
+            run_route_command(args)
+
+            call_args = mock_main.call_args[0][0]
+            assert "--slack-corridor-widening" in call_args
+
+    def test_slack_corridor_widening_not_forwarded_when_false(self):
+        """--slack-corridor-widening is not forwarded when not set."""
+        from kicad_tools.cli.commands.routing import run_route_command
+
+        args = self._make_base_args(slack_corridor_widening=False)
+
+        with patch("kicad_tools.cli.route_cmd.main") as mock_main:
+            mock_main.return_value = 0
+            run_route_command(args)
+
+            call_args = mock_main.call_args[0][0]
+            assert "--slack-corridor-widening" not in call_args
+
+    def test_new_routing_flags_all_absent_by_default(self):
+        """None of the three #4094 flags appear when the base args omit them.
+
+        Guards flag-off byte-identity at the sub_argv boundary: with no flag
+        set (the production default), the forwarded argv must not contain any
+        of the three new flags.
+        """
+        from kicad_tools.cli.commands.routing import run_route_command
+
+        args = self._make_base_args()
+
+        with patch("kicad_tools.cli.route_cmd.main") as mock_main:
+            mock_main.return_value = 0
+            run_route_command(args)
+
+            call_args = mock_main.call_args[0][0]
+            assert "--monotone-certificate-order" not in call_args
+            assert "--cross-package-pair-corridor" not in call_args
+            assert "--slack-corridor-widening" not in call_args
+
     def test_auto_fix_passes_not_forwarded_when_none(self):
         """--auto-fix-passes is not forwarded when None (default)."""
         from kicad_tools.cli.commands.routing import run_route_command


### PR DESCRIPTION
Closes #4094

## What ships

Wires the three constructor-only `Autorouter` flags from the #4049 sweep (#4089/#4090/#4092) through the established three-file `--bundle-river-planner` (#4053) CLI seam, all default OFF:

- `--monotone-certificate-order` → `enable_monotone_certificate_order` (#4089)
- `--cross-package-pair-corridor` → `enable_cross_package_pair_corridor` (#4090)
- `--slack-corridor-widening` → `enable_slack_corridor_widening` (#4092)

Files: `route_cmd.py` (inner argparse + `_apply_*` helpers at all four router call sites), `parser.py` (mirrored outer declarations), `commands/routing.py` (forward into `sub_argv` only when set → flag-off byte-identity). `enable_byte_lane_reorder` (#4051) intentionally NOT wired — already measured regressive.

Tests: 66 pass (forwarded/not-forwarded pairs per flag, all-absent default guard, `--help` exposure). ruff clean.

## Board-07 end-to-end measurement (the issue's second half)

Fresh routes of the committed unrouted board, C++ backend, same seed/timeout per the curated recipe; `kct check --mfr jlcpcb --net-class-map` on each result. Baseline is the committed artifact.

| Run | Routed | Opens (connectivity) | Total DRC errors | Notes |
|---|---|---|---|---|
| Committed baseline | 26/31 | 5 | 13 | 5 conn + 4 skew + 4 continuity |
| Fresh route, flags OFF (control) | 26/31 | 5 | **13** | reproduces baseline exactly |
| `--monotone-certificate-order` ON | 26/31 | 5 | **20** | same 5 opens; skew 4→2, continuity 4→2, **+10 new clearance violations** (5 seg-via, 4 pad-seg, 1 pad-via) + 1 match_group_length_skew |
| All three flags ON | 26/31 | 5 | **20** | identical to certificate-ON |

**Conclusion: plateau proof.** The certificate-driven escape ordering — which routes the DDR byte 11/11 in isolation (#4089) — does **not** clear any of the 5 seed-invariant opens on the assembled board, and the reordering trades pair-quality errors for clearance violations (net +7 errors). The committed artifact remains the shipping truth; **no board artifact was touched.** This is the honest completion outcome anticipated by the issue ("if it doesn't, that is the plateau proof") and closes the final open question from epic #4049: all levers from the 2026-07 routing-literature sweep are now measured on the assembled board, and board 07's remaining gap requires a different class of fix (pad-aware fan-in planning / layer assignment, per the #4079 escalation).

Raw run artifacts (routes, check outputs) preserved in the session scratchpad (`m4094/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)