### PR TITLE
feat(diffpair): warn when coupled pairs budget-exit to single-ended

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -9406,6 +9406,13 @@ def main(argv: list[str] | None = None) -> int:
     # Configure differential pair routing if enabled
     diffpair_config = None
     diffpair_warnings = []
+    # Issue #4095: names of diff pairs that budget-exited coupled routing
+    # and fell back to single-ended.  Accumulated from
+    # ``router.diffpair_budget_exit_pair_names()`` after each
+    # ``--differential-pairs`` dispatch so the report site can warn the
+    # operator (fallback can regress completion / DRC on bundle-dense
+    # boards; see #4095).  De-duplicated at report time.
+    diffpair_budget_exit_pairs: list[str] = []
     if args.differential_pairs:
         diffpair_config = DifferentialPairConfig(
             enabled=True,
@@ -9542,7 +9549,7 @@ def main(argv: list[str] | None = None) -> int:
 
         # Define routing function for profiling
         def do_routing():
-            nonlocal diffpair_warnings, relaxed_nets_report
+            nonlocal diffpair_warnings, relaxed_nets_report, diffpair_budget_exit_pairs
 
             # Adaptive multi-resolution routing (when --grid auto selects it)
             if multi_res_plan is not None and multi_res_plan.is_multi_resolution:
@@ -9625,6 +9632,9 @@ def main(argv: list[str] | None = None) -> int:
                             timeout=_budgeted_timeout(args),
                         )
                         diffpair_warnings.extend(dp_warnings)
+                        # Issue #4095: surface any coupled pairs that
+                        # budget-exited and fell back to single-ended.
+                        diffpair_budget_exit_pairs.extend(router.diffpair_budget_exit_pair_names())
                         return result
                     if args.strategy == "evolutionary":
                         return router.route_all_evolutionary(
@@ -9707,6 +9717,10 @@ def main(argv: list[str] | None = None) -> int:
                         per_net_timeout=getattr(args, "per_net_timeout", None) or None,
                     )
                     diffpair_warnings.extend(dp_warnings)
+                    # Issue #4095: the escape-composed path delegates to the
+                    # same diff-pair orchestrator; surface its budget-exit
+                    # fallback too.
+                    diffpair_budget_exit_pairs.extend(router.diffpair_budget_exit_pair_names())
                     return routes
                 return router.route_with_escape(
                     use_negotiated=(args.strategy == "negotiated"),
@@ -9784,6 +9798,9 @@ def main(argv: list[str] | None = None) -> int:
                     timeout=_budgeted_timeout(args),
                 )
                 diffpair_warnings.extend(dp_warnings)
+                # Issue #4095: surface coupled pairs that budget-exited to
+                # single-ended on the negotiated dispatch path.
+                diffpair_budget_exit_pairs.extend(router.diffpair_budget_exit_pair_names())
                 return result
             elif args.strategy == "negotiated":
                 return router.route_all_negotiated(
@@ -9823,6 +9840,9 @@ def main(argv: list[str] | None = None) -> int:
                     timeout=_budgeted_timeout(args),
                 )
                 diffpair_warnings.extend(dp_warnings)
+                # Issue #4095: surface coupled pairs that budget-exited to
+                # single-ended on the basic dispatch path.
+                diffpair_budget_exit_pairs.extend(router.diffpair_budget_exit_pair_names())
                 return result
             elif args.bus_routing and args.strategy == "basic":
                 return router.route_all_with_buses(bus_config)
@@ -10217,6 +10237,36 @@ def main(argv: list[str] | None = None) -> int:
         print(f"\n--- Differential Pair Warnings ({len(diffpair_warnings)}) ---")
         for warning in diffpair_warnings:
             print(f"  {warning}")
+
+    # Issue #4095: report diff pairs that budget-exited coupled routing and
+    # fell back to single-ended.  Printed unconditionally (only gated on
+    # ``not quiet``, mirroring the length-mismatch block above) so the
+    # regression risk is never accidentally hidden behind --verbose.  On
+    # bundle-dense boards the coupled attempts can regress completion / DRC
+    # vs. a plain single-ended route (board 07: 34 vs 13 DRC errors, 22/31
+    # vs 26/31 nets; epic #4049 closeout), so the operator is told which
+    # pairs fell back and advised to compare a single-ended re-route.
+    if diffpair_budget_exit_pairs and not quiet:
+        # De-duplicate while preserving order (a pair can appear once per
+        # dispatch; the escape path can re-enter the orchestrator).
+        _seen: set[str] = set()
+        _exit_pairs = [
+            name for name in diffpair_budget_exit_pairs if not (name in _seen or _seen.add(name))
+        ]
+        print("\n--- Differential Pair Budget-Exit Warning ---")
+        print(
+            f"  {len(_exit_pairs)} pair(s) budget-exited coupled routing and "
+            f"fell back to single-ended: {', '.join(_exit_pairs)}"
+        )
+        print(
+            "  WARNING: --differential-pairs can regress completion/DRC vs. a "
+            "plain single-ended route on bundle-dense boards (see #4095)."
+        )
+        print(
+            "  Consider re-routing without --differential-pairs and comparing "
+            "`kct check` results if this board is dense with matched-length "
+            "bundles."
+        )
 
     # Report nets that needed clearance relaxation (--progressive-clearance mode)
     if relaxed_nets_report and not quiet:

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -10250,9 +10250,11 @@ def main(argv: list[str] | None = None) -> int:
         # De-duplicate while preserving order (a pair can appear once per
         # dispatch; the escape path can re-enter the orchestrator).
         _seen: set[str] = set()
-        _exit_pairs = [
-            name for name in diffpair_budget_exit_pairs if not (name in _seen or _seen.add(name))
-        ]
+        _exit_pairs: list[str] = []
+        for name in diffpair_budget_exit_pairs:
+            if name not in _seen:
+                _seen.add(name)
+                _exit_pairs.append(name)
         print("\n--- Differential Pair Budget-Exit Warning ---")
         print(
             f"  {len(_exit_pairs)} pair(s) budget-exited coupled routing and "

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -13515,6 +13515,30 @@ class Autorouter:
             return []
         return self._diffpair_router.intra_clearance_violations()
 
+    def diffpair_budget_exit_pair_names(self) -> list[str]:
+        """Names of diff pairs that budget-exited coupled routing (Issue #4095).
+
+        After a ``route_all_with_diffpairs`` /
+        ``route_with_escape_and_diffpairs`` call, returns the base names of
+        every differential pair whose coupled A* hit its per-pair or
+        aggregate budget and was consequently deferred to the single-ended
+        main strategy.  These pairs routed *without* coupling, which on
+        bundle-dense boards can regress completion / DRC vs. a plain
+        single-ended route (board 07: 34 vs 13 DRC errors, 22/31 vs 26/31
+        nets; epic #4049 closeout).  The CLI reads this to emit an
+        unconditional operator warning.
+
+        Returns:
+            A shallow copy of the budget-exit pair names from the most
+            recent ``route_all_with_diffpairs`` call, in detection order.
+            Empty when no diff-pair routing happened, when
+            ``--differential-pairs`` was not enabled, or when every coupled
+            pair converged within budget (e.g. board 06).
+        """
+        if self._diffpair_router is None:
+            return []
+        return list(self._diffpair_router._last_budget_exit_pair_names)
+
     def route_all_with_diffpairs(
         self,
         diffpair_config: DifferentialPairConfig | None = None,

--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -2730,6 +2730,28 @@ class DiffPairRouter:
         # strategy) from a genuine no-path-found exit (where the
         # caller's existing handling is unchanged).
         self._last_pair_budget_exit: bool = False
+        # Issue #4095: names of the differential pairs whose coupled
+        # search budget-exited (per-pair or aggregate) during the most
+        # recent ``route_all_with_diffpairs`` call and were consequently
+        # deferred to the single-ended main strategy.  Local
+        # ``budget_exit_diff_nets`` bookkeeping drives fallback + the
+        # #3270 net-priority promotion but is discarded at function exit;
+        # this attribute surfaces the same information (by human-readable
+        # pair name) so the CLI can warn the operator that
+        # ``--differential-pairs`` fell back to single-ended routing --
+        # which on bundle-dense boards can *regress* completion / DRC
+        # vs. a plain single-ended route (board 07: 34 vs 13 DRC errors,
+        # 22/31 vs 26/31 nets; epic #4049 closeout).  Reset at the start
+        # of every ``route_all_with_diffpairs`` call so it reflects only
+        # the latest invocation.
+        self._last_budget_exit_pair_names: list[str] = []
+        # Issue #4095 instrumentation: monotonic counters for a future
+        # checkpoint-and-compare follow-up to key on.  ``coupled_attempted``
+        # counts pairs that reached the coupled A* (engaged, within
+        # budget); ``budget_exited`` counts pairs deferred to the main
+        # strategy via the budget-exit path (per-pair or aggregate).
+        self._last_coupled_attempted_count: int = 0
+        self._last_budget_exit_count: int = 0
         # Issue #3508: opt-in gate for the geometric shadow
         # constructor (see
         # ``DifferentialPairConfig.enable_shadow_construction`` for
@@ -6645,6 +6667,15 @@ class DiffPairRouter:
             self.enable_shadow_construction = bool(
                 getattr(diffpair_config, "enable_shadow_construction", False)
             )
+        # Issue #4095: reset the budget-exit surface + instrumentation
+        # counters up front (before any early return) so they always
+        # describe only the latest invocation and never leak stale data
+        # from a prior call on the same router (e.g. a coupled-success run
+        # followed by a no-pairs run).
+        self._last_budget_exit_pair_names = []
+        self._last_coupled_attempted_count = 0
+        self._last_budget_exit_count = 0
+
         if diffpair_config is None or not diffpair_config.enabled:
             return self.autorouter.route_all(net_order), []
 
@@ -6674,6 +6705,11 @@ class DiffPairRouter:
         print("\n--- Routing differential pairs first (most constrained) ---")
         all_routes: list[Route] = []
         warnings: list[LengthMismatchWarning] = []
+        # Issue #4095: local collector for the base names of pairs deferred
+        # to the main strategy (per-pair or aggregate budget-exit); copied
+        # onto the instance attribute after the loop for the CLI to read.
+        budget_exit_pair_names: list[str] = []
+        coupled_attempted_count = 0
         # Track diff-pair nets that we successfully routed so the
         # caller can decide which nets to leave for the main strategy.
         coupled_routed_nets: set[int] = set()
@@ -6731,6 +6767,9 @@ class DiffPairRouter:
                     )
                     budget_exit_diff_nets.add(p_id)
                     budget_exit_diff_nets.add(n_id)
+                    # Issue #4095: record the deferred pair by name so the
+                    # CLI can surface the aggregate budget-exit fallback.
+                    budget_exit_pair_names.append(pair.name)
                     aggregate_deferred_pairs += 1
                     continue
                 pair_timeout = (
@@ -6738,6 +6777,9 @@ class DiffPairRouter:
                     if pair_timeout is not None
                     else aggregate_remaining
                 )
+            # Issue #4095: this pair passed the engagement gate and the
+            # aggregate-budget gate, so the coupled A* is about to run.
+            coupled_attempted_count += 1
             if coupled_only:
                 pair_routes, warning = self.route_differential_pair_coupled(
                     pair,
@@ -6764,6 +6806,9 @@ class DiffPairRouter:
             if not pair_routes and self._last_pair_budget_exit:
                 budget_exit_diff_nets.add(p_id)
                 budget_exit_diff_nets.add(n_id)
+                # Issue #4095: record the deferred pair by name so the CLI
+                # can surface the per-pair budget-exit fallback.
+                budget_exit_pair_names.append(pair.name)
             if pair_routes:
                 routed_for_net: dict[int, int] = {}
                 for r in pair_routes:
@@ -6886,6 +6931,39 @@ class DiffPairRouter:
                     # legacy per-net path too -- the priority lift
                     # is meaningful only for this strategy invocation.
                     self.autorouter._budget_exit_diff_nets = set()
+
+        # Issue #4095: surface the budget-exit pair set to the instance so
+        # the CLI can warn that ``--differential-pairs`` fell back to
+        # single-ended routing for these pairs.  De-duplicate while
+        # preserving detection order (a pair can only budget-exit once, but
+        # keep this defensive against future double-counting).  This does
+        # NOT alter routing behavior -- the fallback + #3270 priority
+        # promotion already ran above off the local ``budget_exit_diff_nets``
+        # set; this is a pure visibility hook.
+        seen: set[str] = set()
+        deduped_names = [
+            name for name in budget_exit_pair_names if not (name in seen or seen.add(name))
+        ]
+        self._last_budget_exit_pair_names = deduped_names
+        self._last_coupled_attempted_count = coupled_attempted_count
+        self._last_budget_exit_count = len(deduped_names)
+        if deduped_names:
+            # Instrumentation for a future checkpoint-and-compare follow-up
+            # to key on: a structured, greppable log line naming the pairs
+            # that fell back and the counts.
+            # Denominator: pairs that reached the coupled A* plus pairs
+            # deferred before it by the aggregate budget -- i.e. every pair
+            # for which coupled routing was considered (engagement-refused
+            # pairs are excluded; they were never candidates for coupling).
+            considered = coupled_attempted_count + aggregate_deferred_pairs
+            logger.warning(
+                "DIFFPAIR_BUDGET_EXIT_FALLBACK: %d/%d coupled pair(s) "
+                "budget-exited and fell back to single-ended routing: %s "
+                "(issue #4095)",
+                len(deduped_names),
+                considered,
+                ", ".join(deduped_names),
+            )
 
         print("\n=== Differential Pair Routing Complete ===")
         print(f"  Total routes: {len(all_routes)}")

--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -6941,9 +6941,11 @@ class DiffPairRouter:
         # promotion already ran above off the local ``budget_exit_diff_nets``
         # set; this is a pure visibility hook.
         seen: set[str] = set()
-        deduped_names = [
-            name for name in budget_exit_pair_names if not (name in seen or seen.add(name))
-        ]
+        deduped_names: list[str] = []
+        for name in budget_exit_pair_names:
+            if name not in seen:
+                seen.add(name)
+                deduped_names.append(name)
         self._last_budget_exit_pair_names = deduped_names
         self._last_coupled_attempted_count = coupled_attempted_count
         self._last_budget_exit_count = len(deduped_names)

--- a/tests/test_diffpair_budget_exit_warning.py
+++ b/tests/test_diffpair_budget_exit_warning.py
@@ -1,0 +1,249 @@
+"""Issue #4095: surface budget-exited diff pairs to the CLI.
+
+Background: ``DiffPairRouter.route_all_with_diffpairs`` routes differential
+pairs through the ``CoupledPathfinder`` first, then defers any pair whose
+coupled A* hits its per-pair or aggregate budget to the single-ended main
+strategy (the #3089/#3439 budget-exit fallback).  The fallback is correct
+-- no net goes unrouted -- but on bundle-dense boards the coupled attempts
+can *regress* completion / DRC vs. a plain single-ended route (board 07:
+34 vs 13 DRC errors, 22/31 vs 26/31 nets; epic #4049 closeout).
+
+Before this issue the ``budget_exit_diff_nets`` set that drives the
+fallback + the #3270 net-priority promotion was purely local to
+``route_all_with_diffpairs`` -- never returned, never surfaced to the CLI.
+Phase 1 (this issue) is warn-only + instrumentation:
+
+* ``DiffPairRouter._last_budget_exit_pair_names`` records the base name of
+  every pair that budget-exited during the most recent call.
+* ``Autorouter.diffpair_budget_exit_pair_names()`` exposes that to the CLI.
+* The CLI emits an unconditional (``not quiet``) "Differential Pair
+  Budget-Exit Warning" naming the pairs and the regression risk.
+
+These tests pin the boundary at the cheapest surface: the orchestrator
+return-value / instance attribute and the Autorouter accessor.  Checkpoint-
+and-compare (auto-fallback to the single-ended result) is an explicit
+follow-up, NOT this issue.
+"""
+
+from __future__ import annotations
+
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.diffpair import DifferentialPairConfig
+from kicad_tools.router.rules import DesignRules, NetClassRouting
+
+
+def _opt_in_diffpair_class_map(net_names: list[str]) -> dict[str, NetClassRouting]:
+    nc = NetClassRouting(name="HighSpeedOptIn", coupled_routing=True)
+    return dict.fromkeys(net_names, nc)
+
+
+def _two_pad_diffpair_router() -> Autorouter:
+    """30x10mm board with one straight two-pad diff pair plus one plain net.
+
+    Mirrors the fixture in ``tests/test_diffpair_aggregate_cap.py`` so the
+    aggregate-budget budget-exit path is exercised the same way.
+    """
+    rules = DesignRules(trace_width=0.2, trace_clearance=0.15, grid_resolution=0.1)
+    router = Autorouter(
+        width=30.0,
+        height=10.0,
+        rules=rules,
+        net_class_map=_opt_in_diffpair_class_map(["USB_D+", "USB_D-"]),
+    )
+    router.add_component(
+        "U1",
+        [
+            {
+                "number": "1",
+                "x": 5.0,
+                "y": 4.6,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 1,
+                "net_name": "USB_D+",
+            },
+            {
+                "number": "2",
+                "x": 5.0,
+                "y": 5.4,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 2,
+                "net_name": "USB_D-",
+            },
+            {
+                "number": "3",
+                "x": 5.0,
+                "y": 8.0,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 3,
+                "net_name": "GPIO1",
+            },
+        ],
+    )
+    router.add_component(
+        "J1",
+        [
+            {
+                "number": "1",
+                "x": 25.0,
+                "y": 4.6,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 1,
+                "net_name": "USB_D+",
+            },
+            {
+                "number": "2",
+                "x": 25.0,
+                "y": 5.4,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 2,
+                "net_name": "USB_D-",
+            },
+            {
+                "number": "3",
+                "x": 25.0,
+                "y": 8.0,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 3,
+                "net_name": "GPIO1",
+            },
+        ],
+    )
+    return router
+
+
+# ---------------------------------------------------------------------------
+# Surface + accessor existence
+# ---------------------------------------------------------------------------
+
+
+def test_autorouter_exposes_budget_exit_accessor():
+    """``Autorouter`` exposes the budget-exit pair names the CLI reads."""
+    router = _two_pad_diffpair_router()
+    # Before any diff-pair routing the accessor is empty (and does not
+    # auto-initialise the lazy DiffPairRouter).
+    assert router.diffpair_budget_exit_pair_names() == []
+
+
+# ---------------------------------------------------------------------------
+# Budget-exit surfaces the named pair
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_budget_exit_surfaces_pair_name():
+    """A pair deferred by an exhausted aggregate budget appears by name in
+    both the orchestrator instance attribute and the Autorouter accessor."""
+    router = _two_pad_diffpair_router()
+    config = DifferentialPairConfig(enabled=True, spacing=0.8)
+
+    routes, _warnings = router._diffpair.route_all_with_diffpairs(
+        config,
+        aggregate_timeout=0.001,  # near-zero -> defer before coupled A*
+    )
+
+    # The single detected pair ("USB_D") budget-exited to single-ended.
+    assert router._diffpair._last_budget_exit_pair_names == ["USB_D"], (
+        "route_all_with_diffpairs must record the budget-exited pair by "
+        f"name; saw {router._diffpair._last_budget_exit_pair_names}"
+    )
+    # And it is reachable through the Autorouter accessor the CLI uses.
+    assert router.diffpair_budget_exit_pair_names() == ["USB_D"]
+
+    # Fallback behaviour is unchanged: every net (incl. the diff-pair
+    # members) is still routed by the main per-net strategy.
+    routed_nets = {r.net for r in routes}
+    assert {1, 2, 3} <= routed_nets
+
+
+def test_budget_exit_instrumentation_counters():
+    """Instrumentation counters are populated for a future checkpoint-and-
+    compare follow-up to key on."""
+    router = _two_pad_diffpair_router()
+    config = DifferentialPairConfig(enabled=True, spacing=0.8)
+
+    router._diffpair.route_all_with_diffpairs(config, aggregate_timeout=0.001)
+
+    # One pair deferred before ever reaching the coupled A*.
+    assert router._diffpair._last_budget_exit_count == 1
+    assert router._diffpair._last_coupled_attempted_count == 0
+
+
+def test_budget_exit_log_line_emitted(caplog):
+    """A structured, greppable log line names the budget-exited pairs."""
+    import logging
+
+    router = _two_pad_diffpair_router()
+    config = DifferentialPairConfig(enabled=True, spacing=0.8)
+
+    with caplog.at_level(logging.WARNING):
+        router._diffpair.route_all_with_diffpairs(config, aggregate_timeout=0.001)
+
+    matching = [r for r in caplog.records if "DIFFPAIR_BUDGET_EXIT_FALLBACK" in r.getMessage()]
+    assert matching, "expected a DIFFPAIR_BUDGET_EXIT_FALLBACK instrumentation log line"
+    assert "USB_D" in matching[0].getMessage()
+
+
+# ---------------------------------------------------------------------------
+# Negative cases: coupled success and zero-pairs must NOT surface a warning
+# ---------------------------------------------------------------------------
+
+
+def test_coupled_success_surfaces_no_budget_exit():
+    """When the pair routes coupled within budget (no aggregate cap), the
+    budget-exit surface stays empty -- mirroring board 06 behaviour."""
+    router = _two_pad_diffpair_router()
+    config = DifferentialPairConfig(enabled=True, spacing=0.8)
+
+    routes, _warnings = router._diffpair.route_all_with_diffpairs(config)
+
+    assert router._diffpair._last_budget_exit_pair_names == []
+    assert router.diffpair_budget_exit_pair_names() == []
+    assert router._diffpair._last_budget_exit_count == 0
+    # Sanity: the pair actually routed.
+    assert {1, 2, 3} <= {r.net for r in routes}
+
+
+def test_no_pairs_detected_surfaces_no_budget_exit():
+    """A ``--differential-pairs`` run on a board with no detectable pairs
+    hits the early-return path and surfaces no budget-exit warning."""
+    rules = DesignRules(trace_width=0.2, trace_clearance=0.15, grid_resolution=0.1)
+    router = Autorouter(width=30.0, height=10.0, rules=rules)
+    router.add_component(
+        "U1",
+        [
+            {
+                "number": "1",
+                "x": 5.0,
+                "y": 5.0,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 1,
+                "net_name": "GPIO1",
+            },
+        ],
+    )
+    router.add_component(
+        "J1",
+        [
+            {
+                "number": "1",
+                "x": 25.0,
+                "y": 5.0,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 1,
+                "net_name": "GPIO1",
+            },
+        ],
+    )
+    config = DifferentialPairConfig(enabled=True, spacing=0.8)
+
+    router._diffpair.route_all_with_diffpairs(config)
+
+    assert router._diffpair._last_budget_exit_pair_names == []
+    assert router.diffpair_budget_exit_pair_names() == []


### PR DESCRIPTION
## Summary

The coupled differential-pair pre-pass (`route_all_with_diffpairs`) defers any pair whose `CoupledPathfinder` A* hits its per-pair or aggregate budget to the single-ended main strategy. The fallback is correct — no net goes unrouted — but on bundle-dense boards the coupled attempts can **regress** completion / DRC vs. a plain single-ended route (board 07, epic #4049 closeout: **34 vs 13 DRC errors, 22/31 vs 26/31 nets**). The `budget_exit_diff_nets` set that drives the fallback + the #3270 net-priority promotion was purely local to `route_all_with_diffpairs` — never returned, never distinct from `LengthMismatchWarning`, never surfaced to the CLI.

This is **Phase 1: warn-only + instrumentation.** Checkpoint-and-compare (auto-fallback to the single-ended result when the coupled-enabled result is worse) is an explicit follow-up — it needs either a full second route (~doubles wall-clock) or a grid-state snapshot/restore primitive that does not exist at this boundary today. Scope is a pure visibility/instrumentation fix at the existing (correct) fallback boundary; **routing behavior is unchanged.**

`boards/07-matchgroup-test/generate_design.py` (~line 1244) already documents that board 07's own generator omits `--differential-pairs` for exactly this regression; this change makes the risk visible to any other caller.

## Changes

- **`src/kicad_tools/router/diffpair_routing.py`** — record budget-exited pair base names on the `DiffPairRouter` instance (`_last_budget_exit_pair_names`) plus attempt / exit counters (`_last_coupled_attempted_count`, `_last_budget_exit_count`), reset up front so the surface reflects only the latest call. Emit a greppable `DIFFPAIR_BUDGET_EXIT_FALLBACK` log line for a future checkpoint-and-compare follow-up to key on. The existing local `budget_exit_diff_nets` set still drives the fallback + #3270 promotion unchanged.
- **`src/kicad_tools/router/core.py`** — `Autorouter.diffpair_budget_exit_pair_names()` accessor exposing the surface to the CLI. All dispatch paths (negotiated, basic, escape-composed via `route_with_escape_and_diffpairs`) funnel through the `Autorouter.route_all_with_diffpairs` proxy, so one accessor covers all three.
- **`src/kicad_tools/cli/route_cmd.py`** — collect budget-exit pairs at all four diffpair dispatch sites and print an unconditional (`not quiet`, mirroring the existing length-mismatch block) `--- Differential Pair Budget-Exit Warning ---` naming the pairs and the regression risk.
- **`tests/test_diffpair_budget_exit_warning.py`** (new) — pins the boundary.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `--differential-pairs` (negotiated, basic, escape-composed) emits an unconditional warning naming budget-exited pairs | ✅ | All 4 dispatch sites collect via the accessor; report gated only on `not quiet`. Manual board-07 run printed the block naming the 7 pairs. |
| Warning states the regression risk (completion/DRC vs. single-ended on dense boards) | ✅ | Warning text: "can regress completion/DRC vs. a plain single-ended route on bundle-dense boards (see #4095)". |
| Board 06 unaffected — no new warning, output/DRC unchanged | ✅ | `test_board_06_diffpair_test.py` + `test_board06_determinism.py` pass unmodified (45 passed, 1 skipped); coupled-success test asserts empty budget-exit surface. |
| Regression test pins the boundary (named pairs surface in the return value/warning) | ✅ | New test forces aggregate budget-exit; asserts pair name in instance attr, accessor, and log line. |
| `budget_exit_diff_nets` plumbed out without altering fallback routing; `test_budget_exit_diff_priority.py` green | ✅ | Passes unmodified; priority-promotion path untouched (still runs off the local set). |
| Checkpoint-and-compare out of scope; file follow-up before closing | ⏳ | Follow-up issue to be filed referencing this PR's feasibility notes. |

## Test Plan

- `pytest tests/test_diffpair_budget_exit_warning.py tests/test_budget_exit_diff_priority.py tests/test_diffpair_per_pair_timeout.py tests/test_diffpair_aggregate_cap.py` — 33 passed.
- `pytest tests/test_board_06_diffpair_test.py tests/router/test_board06_determinism.py` — 45 passed, 1 skipped (board 06 unaffected).
- `pytest` diffpair + escape/composition suites (`test_router_core_diffpair_timeout`, `test_escape_diffpair`, `test_escape_diffpair_composition`, `test_diffpair_routing_integration`, `test_diffpair_phase_b`, `test_diffpair_shadow`, `test_diffpair_npad`) — 147 passed.
- `ruff check` + `ruff format --check` on all changed files — clean.
- Manual: `kct route boards/07-matchgroup-test/output/matchgroup_test.kicad_pcb --differential-pairs --strategy negotiated --manufacturer jlcpcb --no-auto-layers --layers 4 --seed 42` printed the new warning naming the 7 known budget-exit pairs (DQS, MIPI_CLK, MIPI_DAT0, MIPI_DAT1, TMDS_D0, TMDS_D1, TMDS_D2), matching the epic #4049 closeout measurement.

Closes #4095