### PR TITLE
fix(mfr): write sibling .kicad_pro + Default netclass on apply-rules

### DIFF
--- a/src/kicad_tools/cli/mfr.py
+++ b/src/kicad_tools/cli/mfr.py
@@ -290,6 +290,7 @@ def cmd_export_dru(args):
 def cmd_apply_rules(args):
     """Apply manufacturer design rules to a KiCad project or PCB file."""
     from kicad_tools.core.project_file import (
+        add_netclass_definition,
         apply_manufacturer_rules,
         load_project,
         save_project,
@@ -361,6 +362,19 @@ def cmd_apply_rules(args):
             copper_oz=args.copper,
         )
 
+        # Write/update the Default netclass so KiCad's clearance DRC test
+        # (which reads the applied netclass clearance, not
+        # design_settings.rules.min_clearance) enforces the manufacturer tier
+        # instead of the stock 0.20 mm Default (issue #4097).
+        add_netclass_definition(
+            data,
+            "Default",
+            track_width=rules.min_trace_width_mm,
+            clearance=rules.min_clearance_mm,
+            via_diameter=rules.min_via_diameter_mm,
+            via_drill=rules.min_via_drill_mm,
+        )
+
         # Save
         output_path = Path(args.output) if args.output else file_path
         try:
@@ -395,6 +409,31 @@ def cmd_apply_rules(args):
         except Exception as e:
             print(f"Error saving PCB: {e}", file=sys.stderr)
             sys.exit(1)
+
+        # A bare .kicad_pcb has no sibling .kicad_pro, so kicad-cli pcb drc
+        # silently falls back to KiCad factory defaults (0.20 mm track/clearance,
+        # etc.).  Create-or-merge the sibling .kicad_pro (and a companion
+        # .kicad_dru) from the manufacturer profile so both the GUI and
+        # kicad-cli enforce the intended tier, including the Default netclass
+        # clearance (issue #4097).  Non-fatal: the zone-clearance write above
+        # already succeeded, so a sidecar failure only warns.
+        from kicad_tools.manufacturers import write_drc_constraints
+
+        try:
+            written = write_drc_constraints(
+                output_path,
+                rules,
+                manufacturer_id=profile.id,
+                layers=args.layers,
+                copper_oz=args.copper,
+            )
+            if written:
+                print("DRC-constraint sidecars updated: " + ", ".join(str(p) for p in written))
+        except (ValueError, OSError, KeyError) as e:
+            print(
+                f"Warning: could not write DRC-constraint sidecars: {e}",
+                file=sys.stderr,
+            )
 
     else:
         print(f"Error: Unsupported file type: {file_path.suffix}", file=sys.stderr)

--- a/tests/test_mfr.py
+++ b/tests/test_mfr.py
@@ -449,6 +449,142 @@ class TestMfrCLICommands:
         # Should return 0 (success) on dry-run
         assert result is None  # main() doesn't return anything on success
 
+        # dry-run must not write a sibling .kicad_pro (issue #4097)
+        assert not (tmp_path / "test.kicad_pro").exists()
+
+    # Minimal, self-contained .kicad_pcb so these regression tests do not
+    # depend on generated demo-board artifacts (which are not committed).
+    _MINIMAL_PCB = "(kicad_pcb (version 20240108) (generator test))"
+
+    def test_apply_rules_pcb_creates_kicad_pro(self, tmp_path):
+        """apply-rules on a bare .kicad_pcb creates a sibling .kicad_pro.
+
+        Regression for #4097: without a .kicad_pro, kicad-cli pcb drc falls
+        back to KiCad factory defaults.  The sidecar must carry the profile's
+        design_settings.rules and a Default netclass matching the tier.
+        """
+        import json
+
+        from kicad_tools.cli.mfr import main as mfr_main
+        from kicad_tools.manufacturers import get_profile
+
+        test_pcb = tmp_path / "test.kicad_pcb"
+        test_pcb.write_text(self._MINIMAL_PCB)
+
+        pro_path = tmp_path / "test.kicad_pro"
+        assert not pro_path.exists()  # precondition: no project file yet
+
+        mfr_main(["apply-rules", str(test_pcb), "jlcpcb", "--layers", "4", "--copper", "1"])
+
+        assert pro_path.exists(), "sibling .kicad_pro was not created"
+
+        data = json.loads(pro_path.read_text())
+        rules = get_profile("jlcpcb").get_design_rules(layers=4, copper_oz=1.0)
+
+        proj_rules = data["board"]["design_settings"]["rules"]
+        assert proj_rules["min_clearance"] == pytest.approx(rules.min_clearance_mm)
+        assert proj_rules["min_track_width"] == pytest.approx(rules.min_trace_width_mm)
+        assert proj_rules["min_via_diameter"] == pytest.approx(rules.min_via_diameter_mm)
+
+        # Default netclass must carry the profile clearance, not the stock 0.20
+        classes = data["net_settings"]["classes"]
+        default_cls = next(c for c in classes if c.get("name") == "Default")
+        assert default_cls["clearance"] == pytest.approx(rules.min_clearance_mm)
+        assert default_cls["track_width"] == pytest.approx(rules.min_trace_width_mm)
+        assert default_cls["via_diameter"] == pytest.approx(rules.min_via_diameter_mm)
+        assert default_cls["via_drill"] == pytest.approx(rules.min_via_drill_mm)
+
+    def test_apply_rules_pcb_merges_existing_kicad_pro(self, tmp_path):
+        """apply-rules updates an existing .kicad_pro without clobbering keys."""
+        import json
+
+        from kicad_tools.cli.mfr import main as mfr_main
+        from kicad_tools.manufacturers import get_profile
+
+        test_pcb = tmp_path / "test.kicad_pcb"
+        test_pcb.write_text(self._MINIMAL_PCB)
+
+        # Pre-existing project with an unrelated key that must survive.
+        pro_path = tmp_path / "test.kicad_pro"
+        pro_path.write_text(
+            json.dumps(
+                {
+                    "board": {"design_settings": {"rules": {"min_clearance": 0.05}}},
+                    "text_variables": {"MY_VAR": "keep-me"},
+                    "sheets": [["abc", "Root"]],
+                }
+            )
+        )
+
+        mfr_main(["apply-rules", str(test_pcb), "jlcpcb", "--layers", "4", "--copper", "1"])
+
+        data = json.loads(pro_path.read_text())
+        rules = get_profile("jlcpcb").get_design_rules(layers=4, copper_oz=1.0)
+
+        # Unrelated keys preserved.
+        assert data["text_variables"] == {"MY_VAR": "keep-me"}
+        assert data["sheets"] == [["abc", "Root"]]
+
+        # Rules overwritten to the new profile (not left at 0.05).
+        assert data["board"]["design_settings"]["rules"]["min_clearance"] == pytest.approx(
+            rules.min_clearance_mm
+        )
+        default_cls = next(c for c in data["net_settings"]["classes"] if c.get("name") == "Default")
+        assert default_cls["clearance"] == pytest.approx(rules.min_clearance_mm)
+
+    def test_apply_rules_pcb_output_redirect_places_sidecar(self, tmp_path):
+        """--output places the .kicad_pro next to the redirected board."""
+        from kicad_tools.cli.mfr import main as mfr_main
+
+        test_pcb = tmp_path / "input.kicad_pcb"
+        test_pcb.write_text(self._MINIMAL_PCB)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        out_pcb = out_dir / "redirected.kicad_pcb"
+
+        mfr_main(
+            [
+                "apply-rules",
+                str(test_pcb),
+                "jlcpcb",
+                "--layers",
+                "4",
+                "--output",
+                str(out_pcb),
+            ]
+        )
+
+        # Sidecar lands next to the redirected board, not the input.
+        assert (out_dir / "redirected.kicad_pro").exists()
+        assert not (tmp_path / "input.kicad_pro").exists()
+
+    def test_apply_rules_pro_input_writes_default_netclass(self, tmp_path):
+        """apply-rules on a .kicad_pro input also writes the Default netclass.
+
+        Previously the .kicad_pro branch set design_settings.rules but never
+        touched net_settings.classes, so KiCad's clearance test kept the stock
+        0.20 mm Default (issue #4097).
+        """
+        import json
+
+        from kicad_tools.cli.mfr import main as mfr_main
+        from kicad_tools.manufacturers import get_profile
+
+        pro_path = tmp_path / "test.kicad_pro"
+        pro_path.write_text(json.dumps({"meta": {"version": 1}}))
+
+        mfr_main(["apply-rules", str(pro_path), "jlcpcb", "--layers", "4", "--copper", "1"])
+
+        data = json.loads(pro_path.read_text())
+        rules = get_profile("jlcpcb").get_design_rules(layers=4, copper_oz=1.0)
+
+        default_cls = next(c for c in data["net_settings"]["classes"] if c.get("name") == "Default")
+        assert default_cls["clearance"] == pytest.approx(rules.min_clearance_mm)
+        assert default_cls["track_width"] == pytest.approx(rules.min_trace_width_mm)
+        assert default_cls["via_diameter"] == pytest.approx(rules.min_via_diameter_mm)
+        assert default_cls["via_drill"] == pytest.approx(rules.min_via_drill_mm)
+
     def test_validate_command(self, tmp_path):
         """Test validate command."""
         from pathlib import Path


### PR DESCRIPTION
## Summary

`kct mfr apply-rules <board>.kicad_pcb <mfr>` reported success but only edited
in-board zone clearances — it never produced a sibling `.kicad_pro`. Standalone
`kicad-cli pcb drc` then silently fell back to KiCad factory defaults (0.20 mm
track/clearance, 0.50 mm via, 0.30 mm hole) and reported phantom violations
(the reporter measured ~1175 false errors on a dense 4-layer board). This is
the same failure class as #3919, for which `manufacturers.write_drc_constraints()`
already exists and is wired into `route_cmd.py` and `export/manufacturing.py`.

This PR wires `cmd_apply_rules()` to that existing implementation.

## Changes

- `src/kicad_tools/cli/mfr.py`:
  - `.kicad_pcb` branch: after `save_pcb()`, call `write_drc_constraints(output_path, rules, manufacturer_id=..., layers=..., copper_oz=...)` to create-or-merge the sibling `.kicad_pro` (+ companion `.kicad_dru`). Non-fatal — a sidecar failure degrades to a stderr warning while the zone-clearance write still succeeds (matches the `route_cmd.py` / `export/manufacturing.py` precedent).
  - `.kicad_pro` branch: after `apply_manufacturer_rules()`, also write/update the `Default` netclass via `add_netclass_definition()` so KiCad's `clearance` DRC test (which reads the applied netclass clearance, not `design_settings.rules.min_clearance`) enforces the manufacturer tier instead of the stock 0.20 mm Default.
- `tests/test_mfr.py`: 4 new regression tests (self-contained minimal `.kicad_pcb`, no demo-artifact dependency).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `.kicad_pcb` input creates sibling `.kicad_pro` with profile rules | ✅ | `test_apply_rules_pcb_creates_kicad_pro` asserts `design_settings.rules` matches `jlcpcb.get_design_rules(4, 1.0)` |
| Existing `.kicad_pro` merged in place, unrelated keys preserved | ✅ | `test_apply_rules_pcb_merges_existing_kicad_pro` keeps `text_variables`/`sheets`, overwrites `min_clearance` |
| Default netclass written in BOTH `.kicad_pcb` and `.kicad_pro` paths | ✅ | `test_apply_rules_pcb_creates_kicad_pro` + `test_apply_rules_pro_input_writes_default_netclass` |
| `--output` redirects sidecars next to output board | ✅ | `test_apply_rules_pcb_output_redirect_places_sidecar` |
| `--dry-run` writes nothing | ✅ | `test_apply_rules_dry_run` extended to assert no `.kicad_pro` |
| Round-trip: no factory-default track/via/clearance fallback | ✅ | Sidecar carries profile `min_track_width`/`min_clearance`/`min_via_diameter` + Default netclass clearance; `write_drc_constraints` mapping is exercised by `test_drc_constraints_export.py` |
| Unknown mfr / read-only dir degrades to warning, not crash | ✅ | `write_drc_constraints` call wrapped in `except (ValueError, OSError, KeyError)` → stderr warning; zone write already committed |
| Corrupt existing `.kicad_pro` falls back to clean rebuild | ✅ | Preserved via `write_drc_constraints`'s existing `except (json.JSONDecodeError, OSError)` |

## Test Plan

- `uv run pytest tests/test_mfr.py tests/test_drc_constraints_export.py` → 71 passed, 2 skipped (pre-existing demo-artifact guards).
- `uv run ruff check` / `ruff format --check` clean on both files.
- `uv run mypy src/kicad_tools/cli/mfr.py` → no issues.

Closes #4097