### PR TITLE
fix(sync-netlist): read gr_poly/gr_curve outlines and warn on off-board placement

### DIFF
--- a/src/kicad_tools/cli/pcb_sync_netlist.py
+++ b/src/kicad_tools/cli/pcb_sync_netlist.py
@@ -331,19 +331,43 @@ def sync_netlist(
 
             # Add missing footprints at board edge
             placement_x, placement_y = _get_board_edge_position(pcb)
+            outline_bbox = _outline_bbox(pcb)
+            if outline_bbox is None:
+                # No Edge.Cuts geometry detected at all: _get_board_edge_position
+                # fell back to the board origin (0, 0), which has no relationship
+                # to the true outline extent.  Surface this loudly so it is not
+                # silently mistaken for a routing-density failure downstream.
+                result.warnings.append(
+                    "No Edge.Cuts outline detected; new footprints placed at "
+                    "board origin (0, 0) — verify placement manually."
+                )
             x_offset = 0.0
             for action in result.added:
+                place_x = placement_x + x_offset
+                place_y = placement_y
                 try:
                     pcb.add_footprint(
                         library_id=action.footprint,
                         reference=action.reference,
-                        x=placement_x + x_offset,
-                        y=placement_y,
+                        x=place_x,
+                        y=place_y,
                         value=action.value,
                     )
                     x_offset += 5.0  # Space footprints horizontally
                 except Exception as e:
                     result.errors.append(f"Failed to add footprint for {action.reference}: {e}")
+                    continue
+                # Warn if the placed position falls outside the board outline's
+                # bounding box (padded to exempt the deliberate ~10mm staging
+                # offset).  This fires regardless of *why* a part ended up
+                # off-board — a mis-read outline, an origin fallback, or a
+                # staging placement never followed by a manual placement pass —
+                # so the off-board condition can't survive silently to routing.
+                if outline_bbox is not None and _is_outside_bbox(place_x, place_y, outline_bbox):
+                    result.warnings.append(
+                        f"{action.reference} placed outside board outline at "
+                        f"({place_x:.3f}, {place_y:.3f}) — nets may be unroutable"
+                    )
 
             # Remove orphaned footprints
             for action in result.removed:
@@ -619,6 +643,49 @@ def _get_board_edge_position(pcb) -> tuple[float, float]:
         # get_board_outline() already returns board-relative coords.
         return (max_x + 10.0, min_y)
     return (0.0, 0.0)
+
+
+# Padding (mm) added around the outline bbox before flagging a placement as
+# "off-board".  Must exceed the deliberate ~10mm staging offset applied by
+# _get_board_edge_position() (plus a little headroom for the 5mm-per-part
+# horizontal spacing) so that legitimate staging placement does NOT warn,
+# while a genuinely mis-placed part (mis-read outline, origin fallback) does.
+_OUTLINE_STAGING_MARGIN_MM = 25.0
+
+
+def _outline_bbox(pcb) -> tuple[float, float, float, float] | None:
+    """Return the board outline bounding box in board-relative coordinates.
+
+    Uses :meth:`PCB.get_board_outline` (which now covers ``gr_poly``/``gr_curve``
+    outlines as well as ``gr_line``/``gr_arc``/``gr_rect``) so the bbox is in
+    the same coordinate space as the board-relative positions passed to
+    :meth:`PCB.add_footprint`.
+
+    Returns:
+        ``(min_x, min_y, max_x, max_y)`` or ``None`` when no outline was found.
+    """
+    outline = pcb.get_board_outline()
+    if not outline:
+        return None
+    xs = [pt[0] for pt in outline]
+    ys = [pt[1] for pt in outline]
+    return (min(xs), min(ys), max(xs), max(ys))
+
+
+def _is_outside_bbox(
+    x: float,
+    y: float,
+    bbox: tuple[float, float, float, float],
+    margin: float = _OUTLINE_STAGING_MARGIN_MM,
+) -> bool:
+    """Return True if ``(x, y)`` lies outside ``bbox`` padded by ``margin``.
+
+    The padding exempts the deliberate staging offset applied to newly-added
+    footprints (see :func:`_get_board_edge_position`) so only genuinely
+    off-board placements are flagged.
+    """
+    min_x, min_y, max_x, max_y = bbox
+    return x < min_x - margin or x > max_x + margin or y < min_y - margin or y > max_y + margin
 
 
 def format_text(result: SyncResult, dry_run: bool, pcb_path: Path) -> str:

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -2291,6 +2291,41 @@ class PCB:
             return None
         return (min(xs), min(ys), max(xs), max(ys))
 
+    def _edge_cuts_poly_chains_sexp(self) -> list[list[tuple[float, float]]]:
+        """Collect ``gr_poly``/``gr_curve`` Edge.Cuts vertex chains.
+
+        ``gr_poly`` and ``gr_curve`` graphics are not parsed into the in-memory
+        ``_graphic_lines``/``_graphic_arcs``/``_graphics`` collections, so this
+        walks ``self._sexp`` directly (like :meth:`_edge_cuts_bbox_sexp`) and
+        returns each polygon/curve's ordered ``(pts (xy ...))`` vertex list in
+        **sheet-absolute** coordinates.
+
+        Returns:
+            A list of vertex chains; each chain is an ordered list of
+            ``(x, y)`` tuples.  Empty if no ``gr_poly``/``gr_curve`` Edge.Cuts
+            geometry is present.
+        """
+
+        def _on_edge_cuts(node: SExp) -> bool:
+            layer_node = node.find_child("layer")
+            return bool(layer_node and layer_node.get_string(0) == "Edge.Cuts")
+
+        chains: list[list[tuple[float, float]]] = []
+        for child in self._sexp.iter_children():
+            if child.tag not in ("gr_poly", "gr_curve"):
+                continue
+            if not _on_edge_cuts(child):
+                continue
+            chain: list[tuple[float, float]] = []
+            for pts in child.find_all("pts"):
+                for xy in pts.find_children("xy"):
+                    x, y = xy.get_float(0), xy.get_float(1)
+                    if x is not None and y is not None:
+                        chain.append((x, y))
+            if chain:
+                chains.append(chain)
+        return chains
+
     @staticmethod
     def _translate_coord_node(node: SExp, dx_nm: int, dy_nm: int) -> None:
         """Translate the first two atoms (X, Y) of a coordinate node in place.
@@ -2854,8 +2889,18 @@ class PCB:
         """Extract board outline polygon from Edge.Cuts layer.
 
         Returns an ordered list of (x, y) points forming the board outline.
-        Handles gr_line, gr_arc, and gr_rect elements on the Edge.Cuts layer.
-        Arc segments are approximated by their start and end points.
+        Handles ``gr_line``, ``gr_arc``, ``gr_rect``, ``gr_poly``, and
+        ``gr_curve`` elements on the Edge.Cuts layer.  Arc segments are
+        approximated by their start and end points; polygon/curve outlines
+        contribute their vertex chain (``(pts (xy ...))``).
+
+        ``gr_poly``/``gr_curve`` Edge.Cuts geometry is common for rounded
+        corners, chamfers, and any outline drawn with KiCad's polygon tool.
+        Those elements are not surfaced through the in-memory
+        ``_graphic_lines``/``_graphic_arcs``/``_graphics`` collections, so they
+        are recovered by walking ``self._sexp`` directly (mirroring
+        :meth:`_edge_cuts_bbox_sexp`).  Without this, a board whose outline is
+        a single ``gr_poly`` would silently return ``[]``.
 
         Returns:
             List of (x, y) coordinate tuples in mm. Empty list if no outline found.
@@ -2866,8 +2911,11 @@ class PCB:
         edge_rects = [
             g for g in self._graphics if g.layer == "Edge.Cuts" and g.graphic_type == "rect"
         ]
+        # gr_poly / gr_curve are not parsed into the in-memory collections, so
+        # recover their vertex chains straight off the S-expression tree.
+        poly_chains = self._edge_cuts_poly_chains_sexp()
 
-        if not edge_lines and not edge_arcs and not edge_rects:
+        if not edge_lines and not edge_arcs and not edge_rects and not poly_chains:
             return []
 
         # Build a list of all line segments (including arc endpoints)
@@ -2883,6 +2931,15 @@ class PCB:
 
         for rect in edge_rects:
             segments.extend(self._rect_to_segments(rect.start, rect.end))
+
+        # Each gr_poly / gr_curve contributes edges between consecutive
+        # vertices (and a closing edge back to the first vertex) so the shared
+        # segment-stitching logic below can walk them like any other outline.
+        for chain in poly_chains:
+            for i in range(len(chain) - 1):
+                segments.append((chain[i], chain[i + 1]))
+            if len(chain) >= 3:
+                segments.append((chain[-1], chain[0]))
 
         if not segments:
             return []

--- a/tests/test_pcb_sync_netlist.py
+++ b/tests/test_pcb_sync_netlist.py
@@ -2751,3 +2751,251 @@ class TestBoard05SyncDriftRegression:
         for pad_num, want_net in expected.items():
             got = pad_nets.get(pad_num)
             assert got == want_net, f"U3.{pad_num}: expected net {want_net!r}, got {got!r}"
+
+
+# ---------------------------------------------------------------------------
+# gr_poly / gr_curve Edge.Cuts outline handling (issue #4098, Bug A)
+# ---------------------------------------------------------------------------
+
+# Board whose Edge.Cuts outline is a single gr_poly (chamfered rectangle),
+# offset far from the sheet origin (x in [116.5, 181.5], y in [100, 175]) —
+# mirrors the reporter's 65x75mm board that landed new parts off-board.
+PCB_GR_POLY_OUTLINE = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (gr_poly
+    (pts
+      (xy 116.5 105) (xy 176.5 100) (xy 181.5 105)
+      (xy 181.5 175) (xy 116.5 175)
+    )
+    (stroke (width 0.1) (type default))
+    (layer "Edge.Cuts")
+    (uuid "poly-outline-1")
+  )
+  (footprint "Capacitor_SMD:C_0402"
+    (layer "F.Cu")
+    (uuid "fp-c1")
+    (at 150 140)
+    (property "Reference" "C1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "100n" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 0 ""))
+  )
+)
+"""
+
+# Board with no Edge.Cuts geometry at all (edge case for the loud fallback).
+PCB_NO_OUTLINE = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (footprint "Capacitor_SMD:C_0402"
+    (layer "F.Cu")
+    (uuid "fp-c1")
+    (at 120 100)
+    (property "Reference" "C1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "100n" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 0 ""))
+  )
+)
+"""
+
+
+class TestGetBoardOutlineGrPoly:
+    """PCB.get_board_outline() must handle gr_poly / gr_curve outlines (#4098)."""
+
+    def test_gr_poly_outline_returns_nonempty_polygon(self, tmp_path):
+        """A gr_poly Edge.Cuts outline yields a non-empty polygon (not [])."""
+        from kicad_tools.schema.pcb import PCB
+
+        pcb_path = tmp_path / "poly.kicad_pcb"
+        pcb_path.write_text(PCB_GR_POLY_OUTLINE)
+        pcb = PCB.load(pcb_path)
+
+        outline = pcb.get_board_outline()
+
+        assert outline, "gr_poly outline should not return an empty list"
+        xs = [pt[0] for pt in outline]
+        ys = [pt[1] for pt in outline]
+        assert min(xs) == pytest.approx(116.5)
+        assert max(xs) == pytest.approx(181.5)
+        assert min(ys) == pytest.approx(100.0)
+        assert max(ys) == pytest.approx(175.0)
+
+    def test_gr_curve_outline_returns_nonempty_polygon(self, tmp_path):
+        """A gr_curve Edge.Cuts outline also contributes its vertex chain."""
+        from kicad_tools.schema.pcb import PCB
+
+        pcb_text = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+  (net 0 "")
+  (gr_curve
+    (pts (xy 10 10) (xy 40 5) (xy 70 10) (xy 70 60) (xy 10 60))
+    (stroke (width 0.1) (type default))
+    (layer "Edge.Cuts")
+    (uuid "curve-1")
+  )
+)
+"""
+        pcb_path = tmp_path / "curve.kicad_pcb"
+        pcb_path.write_text(pcb_text)
+        pcb = PCB.load(pcb_path)
+
+        outline = pcb.get_board_outline()
+
+        assert outline, "gr_curve outline should not return an empty list"
+        xs = [pt[0] for pt in outline]
+        assert min(xs) == pytest.approx(10.0)
+        assert max(xs) == pytest.approx(70.0)
+
+    def test_get_board_edge_position_uses_gr_poly_outline(self, tmp_path):
+        """Staging position is derived from the gr_poly outline, not (0, 0)."""
+        from kicad_tools.cli.pcb_sync_netlist import _get_board_edge_position
+        from kicad_tools.schema.pcb import PCB
+
+        pcb_path = tmp_path / "poly.kicad_pcb"
+        pcb_path.write_text(PCB_GR_POLY_OUTLINE)
+        pcb = PCB.load(pcb_path)
+
+        x, y = _get_board_edge_position(pcb)
+
+        # Staged 10mm to the right of the outline's max_x (181.5), not at origin.
+        assert x == pytest.approx(191.5)
+        assert (x, y) != (0.0, 0.0)
+
+
+class TestOutlineBboxHelpers:
+    """Tests for _outline_bbox / _is_outside_bbox (issue #4098)."""
+
+    def test_outline_bbox_from_gr_poly(self, tmp_path):
+        """_outline_bbox returns the correct board-relative bbox for gr_poly."""
+        from kicad_tools.cli.pcb_sync_netlist import _outline_bbox
+        from kicad_tools.schema.pcb import PCB
+
+        pcb_path = tmp_path / "poly.kicad_pcb"
+        pcb_path.write_text(PCB_GR_POLY_OUTLINE)
+        pcb = PCB.load(pcb_path)
+
+        bbox = _outline_bbox(pcb)
+
+        assert bbox is not None
+        min_x, min_y, max_x, max_y = bbox
+        assert (min_x, min_y, max_x, max_y) == pytest.approx((116.5, 100.0, 181.5, 175.0))
+
+    def test_outline_bbox_none_when_no_outline(self, tmp_path):
+        """_outline_bbox returns None when no Edge.Cuts geometry exists."""
+        from kicad_tools.cli.pcb_sync_netlist import _outline_bbox
+        from kicad_tools.schema.pcb import PCB
+
+        pcb_path = tmp_path / "none.kicad_pcb"
+        pcb_path.write_text(PCB_NO_OUTLINE)
+        pcb = PCB.load(pcb_path)
+
+        assert _outline_bbox(pcb) is None
+
+    def test_is_outside_bbox_flags_far_point(self):
+        """A point well beyond the padded bbox is flagged as outside."""
+        from kicad_tools.cli.pcb_sync_netlist import _is_outside_bbox
+
+        bbox = (116.5, 100.0, 181.5, 175.0)
+        # 100mm past max_x — clearly off-board.
+        assert _is_outside_bbox(281.5, 137.5, bbox) is True
+
+    def test_is_outside_bbox_exempts_staging_offset(self):
+        """The deliberate ~10mm staging offset is within the padded bbox."""
+        from kicad_tools.cli.pcb_sync_netlist import _is_outside_bbox
+
+        bbox = (116.5, 100.0, 181.5, 175.0)
+        # max_x + 10 (staging) plus a couple of 5mm spacings — should NOT warn.
+        assert _is_outside_bbox(191.5, 100.0, bbox) is False
+        assert _is_outside_bbox(201.5, 100.0, bbox) is False
+
+
+class TestSyncOffBoardWarnings:
+    """sync_netlist surfaces off-board / no-outline warnings (issue #4098)."""
+
+    def test_no_outline_fallback_emits_warning(self, tmp_path, monkeypatch):
+        """A board with no Edge.Cuts outline emits an explicit fallback warning."""
+        from kicad_tools.cli import pcb_sync_netlist
+        from kicad_tools.cli.pcb_sync_netlist import sync_netlist
+        from kicad_tools.schema.pcb import PCB
+
+        sch = tmp_path / "test.kicad_sch"
+        pcb_path = tmp_path / "test.kicad_pcb"
+        sch.write_text(MINIMAL_SCHEMATIC)  # R1 + C1
+        pcb_path.write_text(PCB_NO_OUTLINE)  # only C1, no outline
+
+        # Avoid depending on KiCad standard libraries: stub the actual add.
+        monkeypatch.setattr(PCB, "add_footprint", lambda self, **kwargs: None)
+
+        result = sync_netlist(sch, pcb_path, output_path=tmp_path / "out.kicad_pcb")
+
+        assert any("No Edge.Cuts outline detected" in w for w in result.warnings), (
+            f"expected fallback warning, got {result.warnings!r}"
+        )
+        # And it must be rendered by both formatters.
+        text = pcb_sync_netlist.format_text(result, dry_run=False, pcb_path=pcb_path)
+        assert "No Edge.Cuts outline detected" in text
+        payload = json.loads(pcb_sync_netlist.format_json(result, dry_run=False, pcb_path=pcb_path))
+        assert any("No Edge.Cuts outline detected" in w for w in payload["warnings"])
+
+    def test_off_board_placement_emits_per_reference_warning(self, tmp_path, monkeypatch):
+        """A footprint placed outside the outline bbox warns naming the ref."""
+        from kicad_tools.cli import pcb_sync_netlist
+        from kicad_tools.cli.pcb_sync_netlist import sync_netlist
+        from kicad_tools.schema.pcb import PCB
+
+        sch = tmp_path / "test.kicad_sch"
+        pcb_path = tmp_path / "test.kicad_pcb"
+        sch.write_text(MINIMAL_SCHEMATIC)  # R1 + C1
+        pcb_path.write_text(PCB_GR_POLY_OUTLINE)  # gr_poly outline, only C1
+
+        # Force placement far outside the outline bbox (simulating Bug A/B).
+        monkeypatch.setattr(
+            pcb_sync_netlist, "_get_board_edge_position", lambda pcb: (500.0, 500.0)
+        )
+        monkeypatch.setattr(PCB, "add_footprint", lambda self, **kwargs: None)
+
+        result = sync_netlist(sch, pcb_path, output_path=tmp_path / "out.kicad_pcb")
+
+        off_board = [w for w in result.warnings if "placed outside board outline" in w]
+        assert off_board, f"expected off-board warning, got {result.warnings!r}"
+        assert any("R1" in w for w in off_board)
+        assert any("(500.000, 500.000)" in w for w in off_board)
+
+        # Rendered in both formatters.
+        text = pcb_sync_netlist.format_text(result, dry_run=False, pcb_path=pcb_path)
+        assert "placed outside board outline" in text
+        payload = json.loads(pcb_sync_netlist.format_json(result, dry_run=False, pcb_path=pcb_path))
+        assert any("placed outside board outline" in w for w in payload["warnings"])
+
+    def test_in_bounds_staging_does_not_warn(self, tmp_path, monkeypatch):
+        """Legitimate outline-derived staging placement produces no new warning."""
+        from kicad_tools.cli.pcb_sync_netlist import sync_netlist
+        from kicad_tools.schema.pcb import PCB
+
+        sch = tmp_path / "test.kicad_sch"
+        pcb_path = tmp_path / "test.kicad_pcb"
+        sch.write_text(MINIMAL_SCHEMATIC)  # R1 + C1
+        pcb_path.write_text(PCB_GR_POLY_OUTLINE)  # gr_poly outline present, only C1
+
+        monkeypatch.setattr(PCB, "add_footprint", lambda self, **kwargs: None)
+
+        result = sync_netlist(sch, pcb_path, output_path=tmp_path / "out.kicad_pcb")
+
+        assert not any("placed outside board outline" in w for w in result.warnings)
+        assert not any("No Edge.Cuts outline detected" in w for w in result.warnings)


### PR DESCRIPTION
## Summary

`kct pcb sync-netlist` could place newly-added footprints outside the board
outline with no warning, making their nets physically unroutable and
presenting downstream as a phantom routing-density wall (issue #4098). Two
compounding defects caused this:

- **Bug A:** `PCB.get_board_outline()` only parsed `gr_line`/`gr_arc`/`gr_rect`
  Edge.Cuts geometry, so a board whose outline is a `gr_poly`/`gr_curve`
  (rounded corners, chamfers, polygon-tool outlines) silently returned `[]`.
- **Bug B:** `_get_board_edge_position()` then fell back to board origin
  `(0, 0)` — unrelated to the true outline — and neither the fallback nor the
  resulting off-board placement produced any warning.

## Changes

- `src/kicad_tools/schema/pcb.py`
  - Extend `get_board_outline()` to recover `gr_poly`/`gr_curve` Edge.Cuts
    vertex chains, stitched through the existing segment-ordering path and
    board-origin conversion (keeps the board-relative contract intact).
  - Add `_edge_cuts_poly_chains_sexp()` helper that walks `self._sexp`
    directly, mirroring the existing `_edge_cuts_bbox_sexp()`.
- `src/kicad_tools/cli/pcb_sync_netlist.py`
  - `sync_netlist()` now emits an explicit `SyncResult.warnings` message when
    no Edge.Cuts outline is detected (the `(0, 0)` origin fallback).
  - Adds a per-reference "placed outside board outline" warning when a
    newly-added footprint lands outside the outline bbox, padded by
    `_OUTLINE_STAGING_MARGIN_MM` (25mm) to exempt the deliberate ~10mm staging
    offset. New `_outline_bbox()` / `_is_outside_bbox()` helpers.
  - Both warnings flow through the existing `format_text()`/`format_json()`
    rendering paths (no formatter changes needed).
- `tests/test_pcb_sync_netlist.py` — new test classes for gr_poly/gr_curve
  outline parsing, bbox helpers, and the off-board/no-outline warning behavior.

Out of scope (per curation): the reporter's suggestion #3 (a `kct check`
preflight off-board rule) is left as a follow-up.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `get_board_outline()` returns non-empty polygon for `gr_poly`/`gr_curve` outlines | ✅ | `TestGetBoardOutlineGrPoly` (both element types), bbox asserted |
| sync places new footprint relative to the real outline (not origin) on a `gr_poly` board | ✅ | `test_get_board_edge_position_uses_gr_poly_outline` (staged at max_x+10, not `(0,0)`) |
| No-outline case emits explicit fallback warning in text + json | ✅ | `test_no_outline_fallback_emits_warning` |
| Off-board placement emits per-reference warning in text + json | ✅ | `test_off_board_placement_emits_per_reference_warning` |
| Existing rectangular-outline / staging behavior unchanged (no spurious warning) | ✅ | `TestGetBoardEdgePosition*` still pass; `test_in_bounds_staging_does_not_warn` |

## Test Plan

- `uv run pytest tests/test_pcb_sync_netlist.py` — 128 passed (118 pre-existing + 10 new).
- Outline-related tests across suite: 164 passed, 6 skipped.
- `ruff check` + `ruff format --check` clean on changed files.
- `mypy` introduces zero new errors (15 pre-existing errors in `pcb.py` unchanged).

Closes #4098