### PR TITLE
feat(check): warn on stale zone fills + opt-in --refill-zones flag

### DIFF
--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -381,6 +381,76 @@ def _lvs_subcheck(sch_path: Path | None, pcb_path: Path) -> SubCheckResult:
     )
 
 
+# Issue #4096: the clearance rule_ids whose truthfulness depends entirely on
+# the freshness of the committed `filled_polygon` geometry.  When any of these
+# fire, the on-disk fills may be stale (board routed/refilled after the fills
+# were last saved) and the findings may be phantom.
+_ZONE_FILL_DEPENDENT_RULE_IDS: frozenset[str] = frozenset(
+    {
+        "clearance_segment_zone",
+        "clearance_via_zone",
+        "clearance_pad_zone",
+    }
+)
+
+
+def _warn_stale_zone_fills(violations: list[DRCViolation], pcb_path: Path) -> None:
+    """Warn loudly when zone-clearance findings may reflect stale fills (issue #4096).
+
+    ``kct check`` measures segment/via/pad-to-zone clearance against the
+    committed ``filled_polygon`` geometry in the ``.kicad_pcb`` — whatever
+    KiCad last wrote to disk.  If the board was routed or refilled after those
+    fills were saved, the clearance_*_zone rules produce phantom shorts that
+    disappear once the fills are refreshed.  This advisory points the user at
+    the authoritative fix so an honest-looking wall of clearance errors is not
+    mistaken for an unmanufacturable board.  No-op when no such findings exist.
+    """
+    present = sorted({v.rule_id for v in violations if v.rule_id in _ZONE_FILL_DEPENDENT_RULE_IDS})
+    if not present:
+        return
+    print(
+        "WARNING: zone-clearance findings present "
+        f"({', '.join(present)}) — kct check measures these against the "
+        "committed zone fills in the .kicad_pcb, which may be STALE if the "
+        "board was routed or refilled after the fills were last saved. "
+        "Cross-gate / fix with:\n"
+        f"    kicad-cli pcb drc --refill-zones --save-board {pcb_path}\n"
+        "then re-run kct check, or pass --refill-zones to do this "
+        "automatically (issue #4096).",
+        file=sys.stderr,
+    )
+
+
+def _refill_zones_in_place(pcb_path: Path) -> None:
+    """Refresh the on-disk zone fills before checking, if possible (issue #4096).
+
+    Shells out to ``kicad-cli pcb drc --refill-zones --save-board`` via
+    :func:`kicad_tools.cli.runner.run_refill_zones` so the pure-Python pipeline
+    reads fills that are in sync with the copper.  This **mutates the board
+    file in place** (the ``--refill-zones`` flag documents that side effect).
+
+    Graceful degradation: a missing kicad-cli — or any refill failure — is
+    reported as a warning and the check continues against the stored fills
+    rather than aborting.  Never raises.
+    """
+    from kicad_tools.cli.runner import run_refill_zones
+
+    result = run_refill_zones(pcb_path)
+    if result.success:
+        print(
+            f"[INFO] refilled zones in place via kicad-cli: {pcb_path}",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            "WARNING: --refill-zones requested but the refill did not run "
+            f"({result.stderr.strip() or 'unknown error'}); continuing against "
+            "the stored (possibly stale) zone fills.  Install KiCad 8+ so "
+            "kicad-cli is on PATH to enable the pre-check refill (issue #4096).",
+            file=sys.stderr,
+        )
+
+
 def _manifest_subcheck(pcb_path: Path) -> SubCheckResult:
     """Compare ``output/manufacturing/manifest.json`` mtime against the PCB.
 
@@ -576,6 +646,21 @@ def main(argv: list[str] | None = None) -> int:
         help="Exit with error code 2 on warnings",
     )
     parser.add_argument(
+        "--refill-zones",
+        dest="refill_zones",
+        action="store_true",
+        help=(
+            "Before checking, run `kicad-cli pcb drc --refill-zones "
+            "--save-board` to bring the on-disk zone fills back in sync with "
+            "the copper (issue #4096).  WARNING: this MUTATES the board file "
+            "in place (--save-board rewrites <pcb>).  Fixes phantom "
+            "clearance_*_zone findings caused by stale committed fills.  "
+            "Requires kicad-cli (KiCad 8+); degrades gracefully with a "
+            "warning if kicad-cli is not installed (the check still runs "
+            "against the stored fills)."
+        ),
+    )
+    parser.add_argument(
         "--mfr",
         "-m",
         choices=get_manufacturer_ids(),
@@ -769,6 +854,16 @@ def main(argv: list[str] | None = None) -> int:
             strict=args.strict,
         )
 
+    # Optional pre-check zone refill (issue #4096).  When --refill-zones is
+    # set, shell out to `kicad-cli pcb drc --refill-zones --save-board` so the
+    # on-disk fills are refreshed *before* PCB.load reads them — otherwise the
+    # pure-Python clearance rules measure copper against stale committed fills
+    # and report phantom clearance_*_zone shorts.  Degrades gracefully: a
+    # missing kicad-cli (or a failed refill) warns and continues against the
+    # stored fills rather than aborting the check.
+    if getattr(args, "refill_zones", False):
+        _refill_zones_in_place(pcb_path)
+
     try:
         pcb = PCB.load(pcb_path)
     except Exception as e:
@@ -921,6 +1016,18 @@ def main(argv: list[str] | None = None) -> int:
     violations = list(results.violations)
     if args.errors_only:
         violations = [v for v in violations if v.is_error]
+
+    # Fill-freshness advisory (issue #4096).  The clearance_*_zone rules
+    # measure copper against the committed `filled_polygon` geometry, which is
+    # only trustworthy if the on-disk fills are in sync with the copper.  A
+    # board refilled/routed after its fills were last saved produces phantom
+    # clearance_segment_zone / clearance_via_zone / clearance_pad_zone shorts
+    # that vanish once the fills are refreshed.  Warn loudly whenever any of
+    # those findings are present, pointing at the authoritative refill — unless
+    # the user already asked for it via --refill-zones (in which case the fills
+    # are already fresh and any residual findings are real).
+    if not getattr(args, "refill_zones", False):
+        _warn_stale_zone_fills(results.violations, pcb_path)
 
     # Issue #3750: build the DRC SubCheckResult that will feed both the
     # exit-code computation and the meta-check rollup (when not in

--- a/src/kicad_tools/cli/runner.py
+++ b/src/kicad_tools/cli/runner.py
@@ -238,6 +238,101 @@ def run_drc(
         return KiCadCLIResult(success=False, stderr=f"Failed to run DRC: {e}")
 
 
+def run_refill_zones(
+    pcb_path: Path,
+    kicad_cli: Path | None = None,
+) -> KiCadCLIResult:
+    """Refill all copper zones in-place via ``kicad-cli pcb drc --refill-zones``.
+
+    Shells out to ``kicad-cli pcb drc --refill-zones --save-board <pcb>`` so
+    the on-disk ``filled_polygon`` geometry is brought back in sync with the
+    current copper before the pure-Python ``kct check`` pipeline reads it
+    (issue #4096).  This is the authoritative refill: KiCad's own fill engine
+    knocks the pours out around foreign copper, eliminating the phantom
+    ``clearance_*_zone`` findings that stale committed fills produce.
+
+    This **mutates the board file in place** (``--save-board``) — the caller
+    is responsible for surfacing that side effect to the user.
+
+    Graceful degradation: when ``kicad-cli`` is not found on PATH the call
+    returns ``success=False`` with an explanatory ``stderr`` rather than
+    raising, so the caller can warn and continue without refilling.
+
+    A non-zero exit code caused by DRC *violations* (not a fill failure) is
+    treated as success — the zones were still refilled and saved.  When the
+    installed ``kicad-cli`` predates the explicit ``--refill-zones`` /
+    ``--save-board`` flags (KiCad 8/9), DRC refills zones automatically as a
+    side effect and the board is saved by the plain ``drc`` run.
+
+    Args:
+        pcb_path: Path to the ``.kicad_pcb`` file to refill (rewritten in place).
+        kicad_cli: Path to kicad-cli (auto-detected when not provided).
+
+    Returns:
+        KiCadCLIResult with ``output_path`` set to ``pcb_path`` on success.
+    """
+    if kicad_cli is None:
+        kicad_cli = find_kicad_cli()
+        if kicad_cli is None:
+            return KiCadCLIResult(
+                success=False,
+                stderr="kicad-cli not found. Install KiCad 8 from https://www.kicad.org/download/",
+            )
+
+    # Snapshot net state so a --save-board that strips the net table on a
+    # kicad-tools-serialized board can be repaired, mirroring the protection
+    # in _run_fill_zones_via_drc.
+    input_net_nodes = _snapshot_net_declarations(pcb_path)
+    input_element_nets = _snapshot_element_nets(pcb_path)
+
+    fd, report_name = tempfile.mkstemp(suffix=".json", prefix="refill_drc_")
+    os.close(fd)
+    report_path = Path(report_name)
+
+    cmd = [
+        str(kicad_cli),
+        "pcb",
+        "drc",
+        "--output",
+        str(report_path),
+        "--format",
+        "json",
+    ]
+
+    # KiCad 10+ requires explicit flags to refill zones and persist changes;
+    # KiCad 8/9 refill + save as a side effect of the plain drc run.
+    if _kicad_drc_supports_refill(kicad_cli):
+        cmd.extend(["--refill-zones", "--save-board"])
+
+    cmd.append(str(pcb_path))
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True)
+
+        # A produced report means the command ran to completion (a non-zero
+        # exit code here signals DRC violations, not a fill failure).
+        if report_path.exists() and report_path.stat().st_size > 0:
+            _restore_net_declarations(pcb_path, input_net_nodes, input_element_nets)
+            return KiCadCLIResult(
+                success=True,
+                output_path=pcb_path,
+                stdout=result.stdout,
+                stderr=result.stderr,
+                return_code=result.returncode,
+            )
+        return KiCadCLIResult(
+            success=False,
+            stderr=result.stderr or "Zone refill via DRC failed — no report produced",
+            return_code=result.returncode,
+        )
+    except FileNotFoundError as e:
+        return KiCadCLIResult(success=False, stderr=f"kicad-cli not found: {e}")
+    except subprocess.SubprocessError as e:
+        return KiCadCLIResult(success=False, stderr=f"Failed to refill zones: {e}")
+    finally:
+        report_path.unlink(missing_ok=True)
+
+
 def run_netlist_export(
     schematic_path: Path,
     output_path: Path | None = None,

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -728,3 +728,253 @@ class TestCheckMetaCheck:
         assert data["summary"]["passed"] is True
         # ...and meta_checks omitted (OMIT-when-absent convention).
         assert "meta_checks" not in data
+
+
+# ---------------------------------------------------------------------------
+# Issue #4096: stale-zone-fill advisory + opt-in --refill-zones flag
+# ---------------------------------------------------------------------------
+
+
+def _make_zone_clearance_violation(rule_id: str):
+    """Build a synthetic ERROR DRCViolation carrying a zone-clearance rule_id."""
+    from kicad_tools.core.types import Severity
+    from kicad_tools.validate.models import DRCViolation
+
+    return DRCViolation(
+        severity=Severity.ERROR,
+        message=f"synthetic {rule_id} finding",
+        rule_id=rule_id,
+    )
+
+
+class TestStaleZoneFillWarning:
+    """Unit coverage for the _warn_stale_zone_fills advisory (issue #4096)."""
+
+    def test_warns_on_segment_zone_clearance(self, tmp_path: Path, capsys):
+        from kicad_tools.cli.check_cmd import _warn_stale_zone_fills
+
+        pcb = tmp_path / "board.kicad_pcb"
+        violations = [_make_zone_clearance_violation("clearance_segment_zone")]
+
+        _warn_stale_zone_fills(violations, pcb)
+
+        err = capsys.readouterr().err
+        assert "clearance_segment_zone" in err
+        assert "STALE" in err
+        assert "kicad-cli pcb drc --refill-zones --save-board" in err
+        assert str(pcb) in err
+
+    def test_warns_on_via_and_pad_zone_clearance(self, tmp_path: Path, capsys):
+        from kicad_tools.cli.check_cmd import _warn_stale_zone_fills
+
+        pcb = tmp_path / "board.kicad_pcb"
+        violations = [
+            _make_zone_clearance_violation("clearance_via_zone"),
+            _make_zone_clearance_violation("clearance_pad_zone"),
+        ]
+
+        _warn_stale_zone_fills(violations, pcb)
+
+        err = capsys.readouterr().err
+        assert "clearance_via_zone" in err
+        assert "clearance_pad_zone" in err
+
+    def test_no_warning_without_zone_clearance_findings(self, tmp_path: Path, capsys):
+        """A board with only non-zone findings must not emit the advisory."""
+        from kicad_tools.cli.check_cmd import _warn_stale_zone_fills
+        from kicad_tools.core.types import Severity
+        from kicad_tools.validate.models import DRCViolation
+
+        pcb = tmp_path / "board.kicad_pcb"
+        violations = [
+            DRCViolation(
+                severity=Severity.ERROR,
+                message="unrelated clearance",
+                rule_id="clearance_trace_trace",
+            )
+        ]
+
+        _warn_stale_zone_fills(violations, pcb)
+
+        assert "refill-zones" not in capsys.readouterr().err
+
+    def test_no_warning_on_empty_violations(self, tmp_path: Path, capsys):
+        from kicad_tools.cli.check_cmd import _warn_stale_zone_fills
+
+        _warn_stale_zone_fills([], tmp_path / "board.kicad_pcb")
+
+        assert capsys.readouterr().err == ""
+
+    def test_warning_fires_through_main_on_zone_clearance_finding(
+        self, drc_clean_pcb: Path, monkeypatch, capsys
+    ):
+        """End-to-end: a clearance_*_zone finding triggers the advisory via main().
+
+        Injects a synthetic ``clearance_segment_zone`` error into the DRC
+        results so the assertion pins the *wiring* (main -> advisory) rather
+        than a specific committed board's fill staleness, which drifts as
+        artifacts are refilled.  --drc-only confirms the advisory is
+        independent of the meta-check rollup.
+        """
+        import kicad_tools.cli.check_cmd as check_cmd
+        from kicad_tools.cli.check_cmd import main
+        from kicad_tools.validate.violations import DRCResults
+
+        real_run = check_cmd.run_selected_checks
+
+        def _inject(*args, **kwargs) -> DRCResults:
+            results = real_run(*args, **kwargs)
+            results.add(_make_zone_clearance_violation("clearance_segment_zone"))
+            return results
+
+        monkeypatch.setattr(check_cmd, "run_selected_checks", _inject)
+
+        main([str(drc_clean_pcb), "--drc-only"])
+
+        err = capsys.readouterr().err
+        assert "kicad-cli pcb drc --refill-zones --save-board" in err
+        assert "STALE" in err
+
+    def test_no_warning_through_main_on_clean_board(self, drc_clean_pcb: Path, capsys):
+        """A clean board (no zone-clearance findings) emits no advisory."""
+        from kicad_tools.cli.check_cmd import main
+
+        main([str(drc_clean_pcb), "--drc-only"])
+
+        assert "refill-zones" not in capsys.readouterr().err
+
+
+class TestRefillZonesFlag:
+    """Coverage for the opt-in --refill-zones flag (issue #4096)."""
+
+    def test_flag_invokes_kicad_cli_when_available(self, drc_clean_pcb: Path, monkeypatch, capsys):
+        """--refill-zones shells out to run_refill_zones before loading the PCB."""
+        import kicad_tools.cli.runner as runner
+        from kicad_tools.cli.runner import KiCadCLIResult
+
+        calls: list[Path] = []
+
+        def _spy(pcb_path, kicad_cli=None):
+            calls.append(Path(pcb_path))
+            return KiCadCLIResult(success=True, output_path=Path(pcb_path))
+
+        monkeypatch.setattr(runner, "run_refill_zones", _spy)
+
+        result = main_(drc_clean_pcb)
+
+        assert result == 0
+        assert len(calls) == 1
+        assert calls[0] == drc_clean_pcb.resolve()
+        assert "refilled zones in place" in capsys.readouterr().err
+
+    def test_flag_degrades_gracefully_when_kicad_cli_absent(
+        self, drc_clean_pcb: Path, monkeypatch, capsys
+    ):
+        """A missing kicad-cli warns and continues rather than crashing."""
+        import kicad_tools.cli.runner as runner
+        from kicad_tools.cli.runner import KiCadCLIResult
+
+        def _absent(pcb_path, kicad_cli=None):
+            return KiCadCLIResult(success=False, stderr="kicad-cli not found.")
+
+        monkeypatch.setattr(runner, "run_refill_zones", _absent)
+
+        # Must not raise, and the check itself still runs to a clean exit.
+        result = main_(drc_clean_pcb)
+
+        assert result == 0
+        err = capsys.readouterr().err
+        assert "--refill-zones requested but the refill did not run" in err
+        assert "kicad-cli not found" in err
+
+    def test_no_refill_by_default(self, drc_clean_pcb: Path, monkeypatch):
+        """Without --refill-zones the refill helper is never called."""
+        import kicad_tools.cli.runner as runner
+        from kicad_tools.cli.check_cmd import main
+
+        def _boom(pcb_path, kicad_cli=None):
+            raise AssertionError("run_refill_zones must not run by default")
+
+        monkeypatch.setattr(runner, "run_refill_zones", _boom)
+
+        result = main([str(drc_clean_pcb), "--allow-incomplete"])
+        assert result == 0
+
+    def test_help_text_documents_board_mutation(self, capsys):
+        """The flag help must warn that it mutates the board file."""
+        from kicad_tools.cli.check_cmd import main
+
+        with pytest.raises(SystemExit):
+            main(["--help"])
+
+        out = capsys.readouterr().out
+        assert "--refill-zones" in out
+        # The MUTATES side effect must be surfaced explicitly.
+        assert "MUTATE" in out.upper()
+
+
+class TestRunRefillZonesHelper:
+    """Direct coverage for runner.run_refill_zones (issue #4096)."""
+
+    def test_returns_failure_when_kicad_cli_missing(self, tmp_path: Path, monkeypatch):
+        """No kicad-cli on PATH → success=False with an explanatory message."""
+        import kicad_tools.cli.runner as runner
+
+        monkeypatch.setattr(runner, "find_kicad_cli", lambda: None)
+
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+
+        result = runner.run_refill_zones(pcb)
+
+        assert result.success is False
+        assert "kicad-cli not found" in result.stderr
+
+    def test_builds_refill_save_board_command(self, tmp_path: Path, monkeypatch):
+        """Invokes `kicad-cli pcb drc --refill-zones --save-board <pcb>`."""
+        import kicad_tools.cli.runner as runner
+        from kicad_tools.cli.runner import KiCadCLIResult
+
+        fake_cli = tmp_path / "kicad-cli"
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+
+        captured_cmd: list[list[str]] = []
+
+        class _Completed:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        def _fake_run(cmd, capture_output=True, text=True, **kwargs):
+            captured_cmd.append(cmd)
+            # Write a non-empty report so the helper reports success.
+            out_idx = cmd.index("--output") + 1
+            Path(cmd[out_idx]).write_text("{}")
+            return _Completed()
+
+        monkeypatch.setattr(runner, "find_kicad_cli", lambda: fake_cli)
+        monkeypatch.setattr(runner, "_kicad_drc_supports_refill", lambda _cli: True)
+        # Skip net-table repair (no real board content to restore).
+        monkeypatch.setattr(runner, "_snapshot_net_declarations", lambda _p: [])
+        monkeypatch.setattr(runner, "_snapshot_element_nets", lambda _p: {})
+        monkeypatch.setattr(runner, "_restore_net_declarations", lambda *a, **k: None)
+        monkeypatch.setattr(runner.subprocess, "run", _fake_run)
+
+        result: KiCadCLIResult = runner.run_refill_zones(pcb)
+
+        assert result.success is True
+        assert result.output_path == pcb
+        assert len(captured_cmd) == 1
+        cmd = captured_cmd[0]
+        assert cmd[1:3] == ["pcb", "drc"]
+        assert "--refill-zones" in cmd
+        assert "--save-board" in cmd
+        assert str(pcb) == cmd[-1]
+
+
+def main_(pcb: Path) -> int:
+    """Invoke `kct check --refill-zones` with the fast/complete-friendly flags."""
+    from kicad_tools.cli.check_cmd import main
+
+    return main([str(pcb), "--refill-zones", "--allow-incomplete"])


### PR DESCRIPTION
## Summary

`kct check` measures segment/via/pad-to-zone clearance against the committed `filled_polygon` geometry in the `.kicad_pcb` — whatever KiCad last wrote to disk. When those fills are stale (the board was routed or refilled *after* the fills were last saved), the `clearance_*_zone` rules report phantom shorts (~1257 on the board in the report) that all collapse to 0 once `kicad-cli pcb drc --refill-zones --save-board` brings the on-disk fill back in sync with the copper.

This is a pure-Python Phase 1 per the curator: a **loud advisory** plus an **opt-in `--refill-zones` flag**. A true in-memory refill was ruled out (no zone-fill engine exists in the codebase, and `.kicad_pcb` has no per-zone timestamp for a reliable staleness detector). We make the staleness visible and actionable rather than silently picking a side.

## Changes

- **`src/kicad_tools/cli/check_cmd.py`**
  - `_warn_stale_zone_fills()`: prints a loud stderr advisory whenever any `clearance_segment_zone` / `clearance_via_zone` / `clearance_pad_zone` finding is present, pointing at `kicad-cli pcb drc --refill-zones --save-board <pcb>` (mirrors the existing net-class-map INACTIVE / manifest STALE advisory pattern). No-op otherwise. Fires in both default and `--drc-only` mode.
  - New `--refill-zones` CLI flag: shells out to refresh the fills before `PCB.load()`. Help text states explicitly that it **MUTATES the board file in place** (`--save-board`). Suppresses the advisory (fills are already fresh). Graceful degradation via `_refill_zones_in_place()`.
- **`src/kicad_tools/cli/runner.py`**
  - New `run_refill_zones()` helper (follows the `run_drc` / `_run_fill_zones_via_drc` pattern): invokes `kicad-cli pcb drc --refill-zones --save-board`, returns `success=False` with a clear message (no crash) when `kicad-cli` is absent, snapshots/restores the net table around `--save-board`, and treats a DRC-violation non-zero exit as success.
- **`tests/test_cli_check.py`**: unit coverage for the advisory (fires on each zone rule id, silent on unrelated/empty findings), end-to-end through `main()`, the flag (invokes kicad-cli when present, degrades gracefully when absent, no refill by default, help documents mutation), and direct `run_refill_zones` command-construction + kicad-cli-missing coverage.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Advisory fires when zone-clearance violations present | ✅ | `TestStaleZoneFillWarning` unit + `test_warning_fires_through_main_on_zone_clearance_finding` |
| `--refill-zones` invokes kicad-cli when available | ✅ | `test_flag_invokes_kicad_cli_when_available` (spy), `test_builds_refill_save_board_command` |
| Degrades gracefully when kicad-cli absent | ✅ | `test_flag_degrades_gracefully_when_kicad_cli_absent`, `test_returns_failure_when_kicad_cli_missing` |
| Default path byte-identical (no auto-refill) | ✅ | `test_no_refill_by_default`; advisory is stderr-only, gated on findings |
| Help text says the flag mutates the board | ✅ | `test_help_text_documents_board_mutation` |
| Existing check tests pass | ✅ | `tests/test_cli_check.py` + `tests/test_check_cmd_coverage.py` → 70 passed |

## Test Plan

- `uv run pytest tests/test_cli_check.py tests/test_check_cmd_coverage.py` → 70 passed
- `uv run ruff check` + `ruff format --check` on all three files → clean
- mypy: 7 errors in `runner.py` are pre-existing on `origin/main` (verified via `git stash`); zero new errors introduced

Closes #4096