### PR TITLE
feat(check): label hole-to-hole findings same-net/different-net in report

### DIFF
--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -52,6 +52,30 @@ _MEASUREMENT_RULE_IDS: frozenset[str] = frozenset(
     }
 )
 
+# Issue #4102: ``dimension_drill_clearance`` hole-to-hole findings carry both
+# endpoints' resolved net names in ``nets=(net1, net2)``.  A user reading the
+# report needs to separate the fab's real concern (different-net pairs, where a
+# drill-wall break creates a short) from same-net / floating pairs.  The data is
+# already present per-finding and in ``--format json``; the report just needs to
+# surface it (net names shown unconditionally, plus an explicit same-net /
+# different-net qualifier).  This is presentational only -- severity is
+# unchanged (see #2976: same-net drill overlap is still a manufacturing defect).
+_NET_RELATIONSHIP_RULE_IDS: frozenset[str] = frozenset({"dimension_drill_clearance"})
+
+
+def _net_relationship(nets: tuple[str, ...]) -> str | None:
+    """Classify a hole-to-hole finding's net pair as same-net / different-net.
+
+    Returns ``"same-net"`` when both endpoints resolve to the same net name,
+    ``"different-net"`` when they differ, and ``None`` when the finding does
+    not carry exactly two net names (nothing to compare).  Unnamed nets are
+    already resolved to distinct ``net:<n>`` placeholders upstream, so an
+    unconnected pin next to a signal via reads as ``different-net``.
+    """
+    if len(nets) != 2:
+        return None
+    return "same-net" if nets[0] == nets[1] else "different-net"
+
 
 @dataclass
 class SubCheckResult:
@@ -1303,6 +1327,11 @@ def output_table(
         else [v for v in violations if not (v.is_info and v.rule_id in _MEASUREMENT_RULE_IDS)]
     )
     by_rule: dict[str, dict[str, int]] = {}
+    # Issue #4102: for net-relationship rules (dimension_drill_clearance),
+    # additionally tally a same-net / different-net breakdown so the BY RULE
+    # summary line is immediately actionable -- directly answering the
+    # "49-finding wall" complaint without scrolling the detail list.
+    by_rule_relationship: dict[str, dict[str, int]] = {}
     for v in by_rule_source:
         if v.rule_id not in by_rule:
             by_rule[v.rule_id] = {"errors": 0, "warnings": 0, "infos": 0}
@@ -1312,6 +1341,14 @@ def output_table(
             by_rule[v.rule_id]["infos"] += 1
         else:
             by_rule[v.rule_id]["warnings"] += 1
+
+        if v.rule_id in _NET_RELATIONSHIP_RULE_IDS:
+            relationship = _net_relationship(v.nets)
+            if relationship is not None:
+                counts = by_rule_relationship.setdefault(
+                    v.rule_id, {"same-net": 0, "different-net": 0}
+                )
+                counts[relationship] += 1
 
     # ``by_rule`` can be empty when the only findings are measurement info
     # rows suppressed above (already surfaced in MEASUREMENT SUMMARY); skip the
@@ -1330,7 +1367,16 @@ def output_table(
             parts.append(f"{counts['warnings']} warning{'s' if counts['warnings'] != 1 else ''}")
         if counts["infos"]:
             parts.append(f"{counts['infos']} info{'s' if counts['infos'] != 1 else ''}")
-        print(f"  {rule_id}: {', '.join(parts)}")
+        line = f"  {rule_id}: {', '.join(parts)}"
+        # Issue #4102: append the same-net / different-net breakdown for
+        # net-relationship rules, e.g.
+        #   dimension_drill_clearance: 49 errors (32 different-net, 17 same-net)
+        rel = by_rule_relationship.get(rule_id)
+        if rel:
+            diff_n = rel["different-net"]
+            same_n = rel["same-net"]
+            line += f" ({diff_n} different-net, {same_n} same-net)"
+        print(line)
 
     # Detailed output
     errors = [v for v in violations if v.is_error]
@@ -1387,8 +1433,26 @@ def _print_violation(v: DRCViolation, verbose: bool, indent: str = "  ") -> None
         symbol = "i"
     else:
         symbol = "!"
-    print(f"\n{indent}[{symbol}] {v.rule_id}")
+
+    # Issue #4102: for hole-to-hole clearance findings, tag the header line
+    # with the net relationship (same-net / different-net) so a user scanning
+    # a wall of findings can immediately tell the fab's real concern
+    # (different-net drill-wall breakage -> short) from lower-risk same-net /
+    # floating pairs -- without eyeballing two net names.  Presentational only;
+    # severity is unchanged.
+    relationship = _net_relationship(v.nets) if v.rule_id in _NET_RELATIONSHIP_RULE_IDS else None
+    header = v.rule_id if relationship is None else f"{v.rule_id} ({relationship})"
+    print(f"\n{indent}[{symbol}] {header}")
     print(f"{indent}    {v.message}")
+
+    # Issue #4102: show the net endpoints unconditionally for net-relationship
+    # rules (not only under --verbose), rendered as ``net1 / net2`` so the
+    # same-net / different-net qualifier above is self-evident.
+    net_shown = False
+    if relationship is not None and v.nets:
+        net_labels = [n if n else "<no net>" for n in v.nets]
+        print(f"{indent}    Nets: {' / '.join(net_labels)}")
+        net_shown = True
 
     if verbose:
         if v.location:
@@ -1399,7 +1463,7 @@ def _print_violation(v: DRCViolation, verbose: bool, indent: str = "  ") -> None
             print(f"{indent}    Actual: {v.actual_value:.3f}mm, Required: {v.required_value:.3f}mm")
         if v.items:
             print(f"{indent}    Items: {', '.join(v.items)}")
-        if v.nets:
+        if v.nets and not net_shown:
             net_labels = [n if n else "<no net>" for n in v.nets]
             print(f"{indent}    Nets: {', '.join(net_labels)}")
 

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -978,3 +978,109 @@ def main_(pcb: Path) -> int:
     from kicad_tools.cli.check_cmd import main
 
     return main([str(pcb), "--refill-zones", "--allow-incomplete"])
+
+
+class TestDrillClearanceNetRelationship:
+    """Issue #4102: net-relationship enrichment for dimension_drill_clearance.
+
+    The findings already carry both endpoints' nets (``nets=(net1, net2)``,
+    also serialized in ``--format json`` via ``DRCViolation.to_dict``).  These
+    tests exercise the report *formatting* only: net names shown
+    unconditionally with a same-net / different-net qualifier on the finding
+    line, and a same-net / different-net sub-count in the ``BY RULE:`` summary.
+    """
+
+    @staticmethod
+    def _violation(nets, severity="error"):
+        from kicad_tools.validate import DRCViolation
+
+        return DRCViolation(
+            rule_id="dimension_drill_clearance",
+            severity=severity,
+            message="Hole-to-hole clearance 0.113mm < minimum 0.500mm",
+            location=(10.0, 20.0),
+            layer=None,
+            actual_value=0.113,
+            required_value=0.500,
+            items=("V1", "R1-2:GND"),
+            nets=tuple(nets),
+        )
+
+    def test_net_relationship_helper(self):
+        from kicad_tools.cli.check_cmd import _net_relationship
+
+        assert _net_relationship(("HALL_A", "GND")) == "different-net"
+        assert _net_relationship(("HALL_A", "HALL_A")) == "same-net"
+        # Unnamed nets resolve to distinct net:<n> placeholders upstream.
+        assert _net_relationship(("net:3", "net:7")) == "different-net"
+        # Not a pair -> nothing to compare.
+        assert _net_relationship(()) is None
+        assert _net_relationship(("only-one",)) is None
+
+    def test_different_net_finding_shows_label_and_nets_default(self, capsys):
+        """Default (non-verbose) output labels the pair and prints both nets."""
+        from kicad_tools.cli.check_cmd import _print_violation
+
+        _print_violation(self._violation(("HALL_A", "GND")), verbose=False)
+        out = capsys.readouterr().out
+        assert "dimension_drill_clearance (different-net)" in out
+        assert "Nets: HALL_A / GND" in out
+
+    def test_same_net_finding_shows_label_and_nets_default(self, capsys):
+        """Same-net pairs are labeled same-net; still shown without --verbose."""
+        from kicad_tools.cli.check_cmd import _print_violation
+
+        _print_violation(self._violation(("HALL_A", "HALL_A")), verbose=False)
+        out = capsys.readouterr().out
+        assert "dimension_drill_clearance (same-net)" in out
+        assert "Nets: HALL_A / HALL_A" in out
+
+    def test_verbose_keeps_label_and_nets(self, capsys):
+        """--verbose keeps the qualifier and the Nets line (no duplicate)."""
+        from kicad_tools.cli.check_cmd import _print_violation
+
+        _print_violation(self._violation(("HALL_A", "GND")), verbose=True)
+        out = capsys.readouterr().out
+        assert "dimension_drill_clearance (different-net)" in out
+        # Net endpoints rendered exactly once, in the net-relationship form.
+        assert out.count("Nets:") == 1
+        assert "Nets: HALL_A / GND" in out
+
+    def test_other_rules_unaffected(self, capsys):
+        """Non-drill rules keep their plain header and verbose-only Nets line."""
+        from kicad_tools.cli.check_cmd import _print_violation
+        from kicad_tools.validate import DRCViolation
+
+        v = DRCViolation(
+            rule_id="clearance_trace_trace",
+            severity="error",
+            message="clearance too small",
+            nets=("NET_A", "NET_B"),
+        )
+        _print_violation(v, verbose=False)
+        out = capsys.readouterr().out
+        assert "clearance_trace_trace" in out
+        assert "(different-net)" not in out
+        assert "Nets:" not in out  # gated on --verbose for non-drill rules
+
+    def test_by_rule_summary_includes_breakdown(self, capsys):
+        """BY RULE line carries the different-net / same-net sub-count."""
+        from pathlib import Path
+
+        from kicad_tools.cli.check_cmd import output_table
+        from kicad_tools.validate import DRCResults
+
+        results = DRCResults()
+        # 2 different-net + 1 same-net.
+        violations = [
+            self._violation(("HALL_A", "GND")),
+            self._violation(("SIG", "GND")),
+            self._violation(("GND", "GND")),
+        ]
+        for v in violations:
+            results.add(v)
+        results.rules_checked = 1
+
+        output_table(violations, results, Path("board.kicad_pcb"), "jlcpcb", 2, False)
+        out = capsys.readouterr().out
+        assert "dimension_drill_clearance: 3 errors (2 different-net, 1 same-net)" in out

--- a/tests/test_validate_dimensions.py
+++ b/tests/test_validate_dimensions.py
@@ -913,6 +913,38 @@ class TestSameFootprintDrillClearance:
         assert len(clearance_violations) == 1
         assert clearance_violations[0].severity == "error"
 
+    def test_same_net_via_pair_remains_error_and_carries_nets(self):
+        """Two close vias on the SAME net stay error and carry both net names.
+
+        Issue #4102 / #2976: same-net drill-to-drill proximity is still a
+        manufacturing defect (overlapping drills break the drill file), so the
+        severity must NOT be downgraded for same-net pairs.  This guards against
+        a future accidental downgrade and confirms both endpoints' nets are
+        attached so the report can label the pair as ``same-net``.
+        """
+        pcb = MockPCB(
+            vias=[
+                MockVia((0, 0), size=0.6, drill=0.3, layers=["F.Cu", "B.Cu"], net_number=1),
+                MockVia((0.4, 0), size=0.6, drill=0.3, layers=["F.Cu", "B.Cu"], net_number=1),
+            ],
+            nets={1: MockNet(1, "GND")},
+        )
+        # edge distance = 0.4 - 0.15 - 0.15 = 0.1mm < 0.127
+        rules = MockDesignRules(min_clearance_mm=0.127)
+        rule = DimensionRules()
+
+        results = rule.check(pcb, rules)
+
+        clearance_violations = [
+            v for v in results.violations if v.rule_id == "dimension_drill_clearance"
+        ]
+        assert len(clearance_violations) == 1
+        v = clearance_violations[0]
+        # Same-net pairs must remain error (no downgrade).
+        assert v.severity == "error"
+        # Both endpoints carry the same net name -> report labels it same-net.
+        assert v.nets == ("GND", "GND")
+
     def test_single_pad_footprint_no_same_footprint_pair(self):
         """A footprint with only 1 thru-hole pad cannot trigger same-footprint logic."""
         pcb = MockPCB(


### PR DESCRIPTION
## Summary

`kct check`'s `dimension_drill_clearance` (hole-to-hole) findings already carry
both endpoints' nets (`nets=(net1, net2)`, also serialized in `--format json`
via `DRCViolation.to_dict()`), but the text/table report hid the net
relationship: `Nets:` was only printed under `--verbose`, and even then it was a
raw label list with no same-net/different-net framing. This forced manual
classification of drill-clearance walls during manufacturing sign-off.

This PR enriches the report (formatting only) so a user can immediately separate
the fab's real concern (different-net pairs, where a drill-wall break creates a
short) from lower-risk same-net / floating pairs.

## Changes

- `_print_violation()`: for `dimension_drill_clearance`, tag the header line
  with a `(same-net)` / `(different-net)` qualifier and print
  `Nets: net1 / net2` **unconditionally** (not gated on `--verbose`). Non-drill
  rules are unaffected and keep their verbose-only `Nets:` line.
- `output_table()`: append a same-net/different-net sub-count to the `BY RULE:`
  line, e.g. `dimension_drill_clearance: 49 errors (32 different-net, 17 same-net)`.
- Added `_net_relationship()` helper + `_NET_RELATIONSHIP_RULE_IDS` frozenset.
- Tests: new `TestDrillClearanceNetRelationship` in `tests/test_cli_check.py`
  (helper, default + verbose label/nets, non-drill isolation, BY RULE breakdown);
  new same-net via-pair severity guard in `tests/test_validate_dimensions.py`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Default (non-verbose) output shows both nets + same/different-net qualifier | ✅ | `test_different_net_finding_shows_label_and_nets_default`, `test_same_net_finding_shows_label_and_nets_default` |
| `--verbose` keeps/improves the `Nets:` line with qualifier (no dup) | ✅ | `test_verbose_keeps_label_and_nets` asserts `Nets:` printed exactly once |
| Severity unchanged; same-net stays `error`; same-footprint warning not regressed | ✅ | `test_same_net_via_pair_remains_error_and_carries_nets`; existing `test_same_footprint_pads_produce_warning` still passes |
| `BY RULE:` summary breaks count into same-net / different-net | ✅ | `test_by_rule_summary_includes_breakdown` |
| `--format json` shape unchanged (`to_dict` untouched) | ✅ | No edits to `violations.py`; diff limited to `check_cmd.py` + tests |
| No changes to `rule_id`, geometry/rotation, or router guards | ✅ | Diff touches only `check_cmd.py` report formatting + tests |

## Test Plan

- `uv run pytest tests/test_cli_check.py tests/test_validate_dimensions.py` — 85 passed.
- `uv run ruff check` + `ruff format --check` — clean.
- `uv run mypy src/kicad_tools/cli/check_cmd.py` — no issues.

Note: diff kept surgical (`_print_violation` + `output_table` summary only) to
avoid overlap with the still-open PR #4113 (#4096, advisory warning + `--refill-zones`),
which touches unrelated regions of `check_cmd.py`.

Closes #4102