### PR TITLE
fix(export): hard-fail --auto-lcsc when the 'parts' extra is missing

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 4099
-# Branch: feature/issue-4099
+# Issue: 4104
+# Branch: feature/issue-4104
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/src/kicad_tools/cost/suggest.py
+++ b/src/kicad_tools/cost/suggest.py
@@ -562,10 +562,23 @@ class PartSuggester:
         except Exception as e:
             # Re-raise LCSCForbiddenError so callers can detect API-wide
             # unavailability and short-circuit remaining lookups.
-            from ..parts.lcsc import LCSCForbiddenError
+            from ..parts.lcsc import (
+                PARTS_INSTALL_HINT,
+                LCSCDependencyMissingError,
+                LCSCForbiddenError,
+            )
 
             if isinstance(e, LCSCForbiddenError):
                 raise
+
+            # An ImportError here means the optional ``parts`` extra
+            # (``requests``) is absent: the LCSC matcher literally cannot
+            # run.  This is a capability failure, not a genuine no-match --
+            # promote it to a distinct exception so callers can surface a
+            # hard, actionable error instead of recording an empty match
+            # for every BOM group (issue #4104).
+            if isinstance(e, ImportError):
+                raise LCSCDependencyMissingError(PARTS_INSTALL_HINT) from e
 
             logger.warning(f"Search failed for {reference}: {e}")
             suggestion.error = str(e)

--- a/src/kicad_tools/export/assembly.py
+++ b/src/kicad_tools/export/assembly.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
 
+from ..parts.lcsc import LCSCDependencyMissingError
 from .bom_enrich import EnrichmentReport, enrich_bom_lcsc
 from .bom_formats import (
     BOMExportConfig,
@@ -275,6 +276,13 @@ class AssemblyPackage:
         if self.config.include_bom:
             try:
                 result.bom_path = self._generate_bom(out_dir, result)
+            except LCSCDependencyMissingError:
+                # A missing ``parts`` extra means --auto-lcsc could not run
+                # at all.  Propagate out of ``export`` so the manufacturing
+                # pipeline aborts BEFORE writing the manifest/bundle, rather
+                # than recording an error and shipping a BOM with an empty
+                # ``LCSC Part #`` column (issue #4104).
+                raise
             except Exception as e:
                 result.errors.append(f"BOM generation failed: {e}")
                 logger.error(f"BOM generation failed: {e}")
@@ -452,6 +460,17 @@ class AssemblyPackage:
                     result.lcsc_enrichment = enrichment
                 for line in enrichment.summary_lines():
                     logger.info(line)
+            except LCSCDependencyMissingError:
+                # The optional ``parts`` extra is missing, so --auto-lcsc
+                # (the CLI default for JLCPCB) cannot populate a single LCSC
+                # part number.  Do NOT swallow this into a warning-and-
+                # continue: propagate it so the BOM CSV is never written and
+                # ``kct export`` exits non-zero with the install hint, before
+                # the manifest/bundle is finalized (issue #4104).  This is
+                # distinct from best-effort degradation (cache-unavailable,
+                # a single API hiccup, a genuine no-match), which must keep
+                # exit 0.
+                raise
             except Exception as e:
                 logger.warning(f"LCSC auto-matching failed (continuing without): {e}")
 

--- a/src/kicad_tools/export/bom_enrich.py
+++ b/src/kicad_tools/export/bom_enrich.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING
 
 from ..cost.suggest import PartSuggester
 from ..parts.cache import PartsCache
-from ..parts.lcsc import LCSCForbiddenError
+from ..parts.lcsc import LCSCDependencyMissingError, LCSCForbiddenError
 from .lcsc_value_check import (
     check_lcsc_against_cache,
     find_package_mismatch,
@@ -308,6 +308,17 @@ def enrich_bom_lcsc(
                     footprint=footprint,
                     existing_lcsc=None,
                 )
+            except LCSCDependencyMissingError:
+                # The optional ``parts`` extra (``requests``) is absent, so
+                # the LCSC matcher cannot run for ANY group.  Short-circuit
+                # on the first occurrence and re-raise instead of recording
+                # a full pass of misleadingly-worded "no LCSC match" entries
+                # with an empty ``LCSC Part #`` column.  Callers surface this
+                # as a hard, actionable failure with the install hint
+                # (issue #4104).  Distinct from LCSCForbiddenError, which is
+                # a transient/global API state that legitimately falls back
+                # to the offline cache.
+                raise
             except LCSCForbiddenError:
                 # API is globally unavailable -- emit a single warning and
                 # fall back to cache for this and all remaining groups.

--- a/src/kicad_tools/export/manufacturing.py
+++ b/src/kicad_tools/export/manufacturing.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 import kicad_tools
 from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
+from kicad_tools.parts.lcsc import LCSCDependencyMissingError
 
 from .assembly import AssemblyConfig, AssemblyPackage, AssemblyPackageResult
 from .preflight import PreflightChecker, PreflightConfig, PreflightResult
@@ -699,6 +700,17 @@ class ManufacturingPackage:
             result.assembly_result = assembly.export(out_dir)
             if result.assembly_result.errors:
                 result.errors.extend(result.assembly_result.errors)
+        except LCSCDependencyMissingError as e:
+            # The optional ``parts`` extra is missing, so --auto-lcsc could
+            # not populate any LCSC part numbers.  This is raised out of BOM
+            # generation BEFORE the BOM CSV (the first artefact) is written,
+            # so nothing is on disk yet.  Abort the whole pipeline so we
+            # never finalize a manifest/bundle whose BOM has an empty
+            # ``LCSC Part #`` column; ``kct export`` then exits non-zero with
+            # this actionable install hint (issue #4104).
+            result.errors.append(str(e))
+            logger.error("LCSC auto-matching requires the 'parts' extra: %s", e)
+            return False
         except Exception as e:
             result.errors.append(f"Assembly generation failed: {e}")
             logger.error(f"Assembly generation failed: {e}")

--- a/src/kicad_tools/parts/lcsc.py
+++ b/src/kicad_tools/parts/lcsc.py
@@ -34,11 +34,37 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+# Canonical install hint for the optional ``parts`` extra.  Mirrors the
+# ``CMAES_INSTALL_HINT`` convention established for the ``placement`` extra
+# (issue #4100 / PR #4111): name the declared extra and give both the
+# ``uv sync`` and ``pip install`` incantations so a base-install failure is
+# actionable rather than a silent degrade.  Unlike ``cmaes``, ``parts`` is
+# NOT pulled in transitively by the ``dev`` or ``all`` extras.
+PARTS_INSTALL_HINT = (
+    "The 'requests' library is required for LCSC API access. "
+    "Install it with the 'parts' extra: uv sync --extra parts "
+    '(or: pip install "kicad-tools[parts]").'
+)
+
+
 class LCSCForbiddenError(Exception):
     """Raised when the JLCPCB API returns 403 Forbidden.
 
     This indicates the API is globally unavailable (e.g. authentication
     required, geo-blocking) and further requests should not be attempted.
+    """
+
+
+class LCSCDependencyMissingError(Exception):
+    """Raised when the optional ``parts`` extra (``requests``) is absent.
+
+    This is a *capability* failure -- the requested LCSC matcher cannot run
+    at all -- and is deliberately distinct from a per-part "no match found"
+    result.  Callers (BOM enrichment, ``kct export``) short-circuit on the
+    first occurrence and surface it as a hard, actionable failure instead of
+    degrading silently to an empty ``LCSC Part #`` column (issue #4104).
+
+    The message is the canonical :data:`PARTS_INSTALL_HINT`.
     """
 
 
@@ -92,11 +118,8 @@ def _requires_requests(func):
     def wrapper(*args, **kwargs):
         try:
             import requests  # noqa: F401
-        except ImportError:
-            raise ImportError(
-                "The 'requests' library is required for LCSC API access. "
-                "Install with: pip install kicad-tools[parts]"
-            )
+        except ImportError as exc:
+            raise ImportError(PARTS_INSTALL_HINT) from exc
         return func(*args, **kwargs)
 
     return wrapper

--- a/tests/test_bom_enrich_missing_parts_extra.py
+++ b/tests/test_bom_enrich_missing_parts_extra.py
@@ -1,0 +1,255 @@
+"""Tests for the hard, actionable failure when the ``parts`` extra is missing.
+
+Issue #4104: ``kct export <board> --mfr jlcpcb --auto-lcsc`` on a venv without
+the optional ``parts`` extra (``requests``) used to soft-fail -- every BOM
+group was recorded as "unmatched" with the ImportError text, the BOM CSV was
+written with an empty ``LCSC Part #`` column, the manifest/bundle was finalized,
+and the command exited 0.  A missing capability is a precondition failure, not a
+degraded result, so it must now:
+
+- translate the swallowed ``ImportError`` into a distinct
+  :class:`LCSCDependencyMissingError` at :meth:`PartSuggester.suggest_for_component`,
+- short-circuit :func:`enrich_bom_lcsc` on the first occurrence (mirroring the
+  existing ``LCSCForbiddenError`` circuit breaker) and re-raise,
+- propagate out of ``AssemblyPackage.export`` / ``_generate_bom`` before the BOM
+  CSV is written, and
+- abort the manufacturing pipeline before the manifest is finalized, so
+  ``kct export`` exits non-zero with the install hint.
+
+These tests simulate the missing ``requests`` import by monkeypatching the
+search/import path to raise ``ImportError`` -- they do NOT uninstall ``requests``
+in CI (mirroring PR #4111's ``test_cmaes_missing_extra.py`` approach), so they
+run deterministically regardless of the real environment's installed packages.
+
+Genuine no-match results (dependency present, API reachable, zero candidates)
+must continue to produce the existing warning-only degrade with exit 0 -- this
+issue must not regress that legitimate use case.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kicad_tools.cost.suggest import PartSuggester
+from kicad_tools.export.bom_enrich import enrich_bom_lcsc
+from kicad_tools.parts.lcsc import (
+    PARTS_INSTALL_HINT,
+    LCSCDependencyMissingError,
+    LCSCForbiddenError,
+)
+from kicad_tools.schema.bom import BOMItem
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_item(ref: str, value: str, footprint: str, lcsc: str = "") -> BOMItem:
+    return BOMItem(
+        reference=ref,
+        value=value,
+        footprint=footprint,
+        lib_id="Device:R",
+        lcsc=lcsc,
+    )
+
+
+def _make_suggester_mock(mock_instance: MagicMock) -> None:
+    """Configure a mock PartSuggester context manager with no cache."""
+    mock_instance.__enter__ = MagicMock(return_value=mock_instance)
+    mock_instance.__exit__ = MagicMock(return_value=False)
+    mock_client = MagicMock()
+    mock_client.cache = None
+    mock_instance._get_client.return_value = mock_client
+
+
+# ---------------------------------------------------------------------------
+# Install hint constant
+# ---------------------------------------------------------------------------
+
+
+class TestPartsInstallHint:
+    """The canonical install hint must name the 'parts' extra (PR #4111 shape)."""
+
+    def test_hint_names_parts_extra(self):
+        assert "parts" in PARTS_INSTALL_HINT
+        assert "kicad-tools[parts]" in PARTS_INSTALL_HINT
+
+    def test_hint_gives_both_uv_and_pip(self):
+        assert "uv sync --extra parts" in PARTS_INSTALL_HINT
+        assert "pip install" in PARTS_INSTALL_HINT
+
+
+# ---------------------------------------------------------------------------
+# suggest.py: ImportError -> LCSCDependencyMissingError (not swallowed)
+# ---------------------------------------------------------------------------
+
+
+class TestSuggestForComponentDependencyMissing:
+    """The dependency ImportError must surface distinctly, not as a no-match."""
+
+    def test_import_error_raises_dependency_missing(self):
+        """A search-time ImportError becomes LCSCDependencyMissingError."""
+        suggester = PartSuggester()
+
+        client = MagicMock()
+        client.search.side_effect = ImportError(PARTS_INSTALL_HINT)
+        with patch.object(suggester, "_get_client", return_value=client):
+            with pytest.raises(LCSCDependencyMissingError) as excinfo:
+                suggester.suggest_for_component(
+                    reference="R1",
+                    value="10k",
+                    footprint="Resistor_SMD:R_0402_1005Metric",
+                )
+
+        # Actionable hint is preserved, and the original ImportError chains.
+        assert "kicad-tools[parts]" in str(excinfo.value)
+        assert isinstance(excinfo.value.__cause__, ImportError)
+
+    def test_genuine_no_match_still_degrades(self):
+        """A real 'no candidates' result must NOT raise -- warning-only degrade."""
+        suggester = PartSuggester()
+
+        results = MagicMock()
+        results.parts = []  # API reachable, zero candidates
+        client = MagicMock()
+        client.search.return_value = results
+        with patch.object(suggester, "_get_client", return_value=client):
+            suggestion = suggester.suggest_for_component(
+                reference="U1",
+                value="STM32C011F4P6",
+                footprint="Package_SO:TSSOP-20",
+            )
+
+        # No exception; a normal (empty) suggestion is returned.
+        assert suggestion.has_suggestion is False
+
+
+# ---------------------------------------------------------------------------
+# bom_enrich.py: short-circuit + re-raise on first dependency-missing signal
+# ---------------------------------------------------------------------------
+
+
+class TestEnrichBomLcscDependencyMissing:
+    """enrich_bom_lcsc must raise (not accumulate unmatched) when the extra is gone."""
+
+    @patch("kicad_tools.export.bom_enrich.PartSuggester")
+    def test_first_import_error_short_circuits_and_raises(self, MockSuggester):
+        mock_instance = MagicMock()
+        _make_suggester_mock(mock_instance)
+        mock_instance.suggest_for_component.side_effect = LCSCDependencyMissingError(
+            PARTS_INSTALL_HINT
+        )
+        MockSuggester.return_value = mock_instance
+
+        items = [
+            _make_item("R1", "10k", "Resistor_SMD:R_0402_1005Metric"),
+            _make_item("C1", "100nF", "Capacitor_SMD:C_0402_1005Metric"),
+            _make_item("L1", "4.7uH", "Inductor_SMD:L_0603_1608Metric"),
+        ]
+
+        with pytest.raises(LCSCDependencyMissingError):
+            enrich_bom_lcsc(items)
+
+        # Short-circuited after the FIRST group -- did not loop all three
+        # accumulating misleading "no LCSC match" entries.
+        assert mock_instance.suggest_for_component.call_count == 1
+
+    @patch("kicad_tools.export.bom_enrich.PartSuggester")
+    def test_forbidden_still_falls_back_to_cache(self, MockSuggester):
+        """The LCSCForbiddenError circuit breaker is unaffected (issue #3935)."""
+        mock_instance = MagicMock()
+        _make_suggester_mock(mock_instance)
+        mock_instance.suggest_for_component.side_effect = LCSCForbiddenError("403 Forbidden")
+        MockSuggester.return_value = mock_instance
+
+        items = [
+            _make_item("R1", "10k", "Resistor_SMD:R_0402_1005Metric"),
+            _make_item("C1", "100nF", "Capacitor_SMD:C_0402_1005Metric"),
+        ]
+
+        # Forbidden must NOT raise -- it degrades to cache/unmatched (exit 0).
+        report = enrich_bom_lcsc(items)
+        assert report.unmatched == 2
+        assert mock_instance.suggest_for_component.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# assembly / manufacturing: hard-fail, no BOM CSV, no manifest
+# ---------------------------------------------------------------------------
+
+
+class TestAssemblyPropagatesDependencyMissing:
+    """AssemblyPackage.export must let the dependency error escape, unwritten BOM."""
+
+    def test_generate_bom_raises_before_writing_csv(self, tmp_path):
+        from kicad_tools.export.assembly import AssemblyConfig, AssemblyPackage
+        from kicad_tools.schema.bom import BOM
+
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+
+        config = AssemblyConfig()
+        config.auto_lcsc = True
+        config.no_spec = True  # skip spec-overlay auto-detection
+        config.bom_source = "pcb"  # avoid needing a schematic on disk
+
+        pkg = AssemblyPackage(
+            pcb_path=pcb,
+            schematic_path=None,
+            manufacturer="jlcpcb",
+            config=config,
+        )
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        bom = BOM(items=[_make_item("R1", "10k", "Resistor_SMD:R_0402_1005Metric")])
+
+        with (
+            patch("kicad_tools.schema.bom.extract_bom_from_pcb", return_value=bom),
+            patch(
+                "kicad_tools.export.assembly.enrich_bom_lcsc",
+                side_effect=LCSCDependencyMissingError(PARTS_INSTALL_HINT),
+            ),
+            pytest.raises(LCSCDependencyMissingError),
+        ):
+            pkg._generate_bom(out_dir)
+
+        # No BOM CSV was written -- the failure happens before export_bom().
+        assert list(out_dir.glob("*.csv")) == []
+
+
+class TestManufacturingHardFailsWithoutParts:
+    """The full pipeline must abort before the manifest when the extra is gone."""
+
+    def test_no_manifest_written_and_error_reported(self, tmp_path):
+        from kicad_tools.export.manufacturing import ManufacturingPackage
+
+        pkg = ManufacturingPackage.__new__(ManufacturingPackage)  # skip __init__
+        pkg.pcb_path = tmp_path / "board.kicad_pcb"
+        pkg.schematic_path = None
+        pkg.manufacturer = "jlcpcb"
+        pkg.config = MagicMock()
+
+        result = MagicMock()
+        result.errors = []
+        result.assembly_result = None
+
+        # Simulate AssemblyPackage.export() raising the dependency error.
+        assembly = MagicMock()
+        assembly.export.side_effect = LCSCDependencyMissingError(PARTS_INSTALL_HINT)
+
+        out_dir = tmp_path / "out"
+        with patch(
+            "kicad_tools.export.manufacturing.AssemblyPackage",
+            return_value=assembly,
+        ):
+            assembly_ok = pkg._generate_assembly(out_dir, result)
+
+        # The stage aborts (returns False) so the manufacturing pipeline
+        # skips Report/ProjectZip/Manifest -- no bundle is finalized.
+        assert assembly_ok is False
+        assert any("parts" in e for e in result.errors)


### PR DESCRIPTION
## Summary

`kct export <board> --mfr jlcpcb --auto-lcsc` on a venv without the optional `parts` extra (`requests`) used to **soft-fail**: the `ImportError` was swallowed at three independent layers, every BOM group was recorded as `source="unmatched"`, the BOM CSV shipped with an intact `LCSC Part #` header and every cell empty, the manifest/bundle was finalized, and the command exited 0. A manufacturing bundle landed on main with zero orderable part numbers, caught only by human CSV inspection.

Because `--auto-lcsc` defaults to `True` for JLCPCB, this hit every `kct export --mfr jlcpcb` without `--no-auto-lcsc`. A missing capability is a precondition failure, not a degraded result — this PR promotes it to a hard, actionable failure while leaving genuine no-match degradation (obscure parts) untouched.

## Changes

- **`parts/lcsc.py`** — add `LCSCDependencyMissingError` and a `PARTS_INSTALL_HINT` constant (`uv sync --extra parts` / `pip install "kicad-tools[parts]"`), matching the `placement` extra's `CMAES_INSTALL_HINT` convention from PR #4111. The `_requires_requests` decorator now raises the constant.
- **`cost/suggest.py`** (`suggest_for_component`, ~L562) — translate a search-time `ImportError` into `LCSCDependencyMissingError` and re-raise it (mirroring the existing `LCSCForbiddenError` special case) instead of stashing it in `suggestion.error` where it's indistinguishable from "no match found".
- **`export/bom_enrich.py`** (`enrich_bom_lcsc`) — short-circuit on the **first** `LCSCDependencyMissingError` and re-raise, instead of looping every group accumulating misleading "no LCSC match" entries. The `LCSCForbiddenError` cache-fallback circuit breaker (issue #3935) is unchanged.
- **`export/assembly.py`** — let `LCSCDependencyMissingError` escape `_generate_bom` (which raises *before* the BOM CSV is written) and `export()`, rather than being caught by the blanket `except Exception`.
- **`export/manufacturing.py`** — abort `_generate_assembly` (return `False`) on the dependency error so the pipeline skips Report/ProjectZip/**Manifest**; the error is recorded in `result.errors`, so `kct export` exits non-zero (`result.success` is `False`) with the actionable hint before any bundle is finalized.

Scope guards honored: `requests` stays a standalone `parts`-only extra (not added to core deps or another extra); `PreflightConfig`/`preflight.py` untouched (this is a BOM-generation-time gate); `parts/importer.py`'s datasheet-import `Search failed` warning untouched.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Missing `parts` extra → non-zero exit, no manifest/bundle written | ✅ | `_generate_assembly` returns `False` → pipeline skips manifest; `result.errors` non-empty → CLI exits 1. Test `TestManufacturingHardFailsWithoutParts` + `TestAssemblyPropagatesDependencyMissing` (no CSV written). |
| Failure message names the extra via the install-hint pattern | ✅ | `PARTS_INSTALL_HINT` asserts `uv sync --extra parts` + `pip install "kicad-tools[parts]"` (`TestPartsInstallHint`). |
| Genuine no-match still degrades warning-only, exit 0 | ✅ | `test_genuine_no_match_still_degrades` — zero candidates returns an empty suggestion, no raise. |
| `--no-auto-lcsc` unaffected | ✅ | `auto_lcsc=False` never calls `enrich_bom_lcsc` (`assembly.py:443` guard, unchanged). |
| `LCSCForbiddenError` cache-fallback unaffected | ✅ | `test_forbidden_still_falls_back_to_cache` + existing `TestEnrichBomLcscCircuitBreaker` pass unchanged. |
| `parts` installed + API reachable → unchanged | ✅ | Only the `ImportError` branch is newly promoted; all existing enrich/suggest tests pass. |

## Test Plan

New `tests/test_bom_enrich_missing_parts_extra.py` (8 tests) simulates the missing import by monkeypatching `client.search` / `enrich_bom_lcsc` / `AssemblyPackage.export` to raise — **no uninstall of `requests` in CI** (mirrors PR #4111's `test_cmaes_missing_extra.py`). Covers: suggest-level translation, bom_enrich short-circuit-and-raise, assembly propagation (no CSV), manufacturing abort (no manifest), the no-match regression, the forbidden circuit-breaker regression, and the install-hint constant.

```
uv run pytest tests/test_bom_enrich.py tests/cost/test_suggest.py \
  tests/test_bom_enrich_missing_parts_extra.py tests/test_parts.py -q
# 107 passed, 47 skipped
```

`ruff check` / `ruff format --check` clean on all changed files.

Closes #4104