### PR TITLE
feat(parts): offline jlcparts catalog fallback + kct parts sync-catalog

### DIFF
--- a/src/kicad_tools/cli/commands/parts.py
+++ b/src/kicad_tools/cli/commands/parts.py
@@ -13,7 +13,7 @@ def run_parts_command(args) -> int:
     """Handle parts subcommands."""
     if not args.parts_command:
         print("Usage: kicad-tools parts <command> [options]")
-        print("Commands: lookup, search, availability, cache, suggest")
+        print("Commands: lookup, search, availability, cache, suggest, sync-catalog")
         return 1
 
     from ..parts_cmd import main as parts_main
@@ -52,6 +52,14 @@ def run_parts_command(args) -> int:
 
     elif args.parts_command == "cache":
         sub_argv = ["cache", args.cache_action]
+        return parts_main(sub_argv) or 0
+
+    elif args.parts_command == "sync-catalog":
+        sub_argv = ["sync-catalog"]
+        if args.force:
+            sub_argv.append("--force")
+        if args.base_url:
+            sub_argv.extend(["--base-url", args.base_url])
         return parts_main(sub_argv) or 0
 
     elif args.parts_command == "suggest":

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -4039,6 +4039,18 @@ def _add_parts_parser(subparsers) -> None:
         help="Cache action (default: stats)",
     )
 
+    # parts sync-catalog
+    parts_sync = parts_subparsers.add_parser(
+        "sync-catalog",
+        help="Download the offline jlcparts catalog for offline/rate-limited lookups",
+    )
+    parts_sync.add_argument(
+        "--force", action="store_true", help="Re-download even if a catalog already exists"
+    )
+    parts_sync.add_argument(
+        "--base-url", default=None, help="Override dataset base URL (advanced/testing)"
+    )
+
     # parts suggest
     parts_suggest = parts_subparsers.add_parser(
         "suggest", help="Suggest LCSC part numbers for components without them"

--- a/src/kicad_tools/cli/parts_cmd.py
+++ b/src/kicad_tools/cli/parts_cmd.py
@@ -131,6 +131,22 @@ def main(argv: list[str] | None = None) -> int:
         help="Don't prefer JLCPCB Basic parts",
     )
 
+    # sync-catalog subcommand
+    sync_parser = subparsers.add_parser(
+        "sync-catalog",
+        help="Download the offline jlcparts catalog for offline/rate-limited lookups",
+    )
+    sync_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-download even if a catalog already exists",
+    )
+    sync_parser.add_argument(
+        "--base-url",
+        default=None,
+        help="Override dataset base URL (advanced/testing)",
+    )
+
     # cache subcommand
     cache_parser = subparsers.add_parser("cache", help="Cache management")
     cache_subparsers = cache_parser.add_subparsers(dest="cache_action", help="Cache commands")
@@ -157,7 +173,33 @@ def main(argv: list[str] | None = None) -> int:
         return _suggest(args)
     elif args.action == "cache":
         return _cache(args)
+    elif args.action == "sync-catalog":
+        return _sync_catalog(args)
 
+    return 0
+
+
+def _sync_catalog(args) -> int:
+    """Handle the sync-catalog command."""
+    try:
+        from ..parts.jlcparts_catalog import JLCPARTS_DATA_BASE, sync_catalog
+    except ImportError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        print("Install with: pip install kicad-tools[parts]", file=sys.stderr)
+        return 1
+
+    base_url = args.base_url or JLCPARTS_DATA_BASE
+    try:
+        dest = sync_catalog(base_url=base_url, force=args.force, progress=True)
+    except ImportError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        print("Install with: pip install kicad-tools[parts]", file=sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"Error: failed to sync jlcparts catalog: {e}", file=sys.stderr)
+        return 1
+
+    print(f"Offline catalog available at: {dest}")
     return 0
 
 

--- a/src/kicad_tools/parts/__init__.py
+++ b/src/kicad_tools/parts/__init__.py
@@ -66,6 +66,7 @@ from .importer import (
     LayoutStyle,
     PartImporter,
 )
+from .jlcparts_catalog import JlcpartsCatalog, get_catalog_path, sync_catalog
 from .lcsc import LCSCClient, LCSCForbiddenError, RateLimiter
 from .models import (
     BOMAvailability,
@@ -91,6 +92,10 @@ __all__ = [
     # Cache
     "PartsCache",
     "get_default_cache_path",
+    # Offline jlcparts catalog
+    "JlcpartsCatalog",
+    "get_catalog_path",
+    "sync_catalog",
     # Composition
     "ComposedPart",
     "ComposedPartStore",

--- a/src/kicad_tools/parts/jlcparts_catalog.py
+++ b/src/kicad_tools/parts/jlcparts_catalog.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import sqlite3
 import zipfile
 from datetime import datetime
@@ -310,7 +311,7 @@ def _discover_split_parts(base_url: str) -> list[str]:
     ``cache.zip`` is the *last* segment. This helper returns URLs in the
     correct concatenation order (``z01``, ``z02``, ..., then ``cache.zip``).
     """
-    import requests
+    import requests  # type: ignore[import-untyped]
 
     part_urls: list[str] = []
     index = 1
@@ -434,9 +435,17 @@ def _extract_catalog(archive: Path, dest: Path) -> None:
                 f"Could not locate a SQLite database in the jlcparts archive; members: {names}"
             )
 
-        with zf.open(member) as src, dest.open("wb") as out:
-            while True:
-                chunk = src.read(1 << 20)
-                if not chunk:
-                    break
-                out.write(chunk)
+        # Extract to a sibling temp file and promote atomically so a killed
+        # or failed extraction can never leave a truncated catalog that
+        # later lookups would silently trust.
+        tmp_dest = dest.with_suffix(".extract.tmp")
+        try:
+            with zf.open(member) as src, tmp_dest.open("wb") as out:
+                while True:
+                    chunk = src.read(1 << 20)
+                    if not chunk:
+                        break
+                    out.write(chunk)
+            os.replace(tmp_dest, dest)
+        finally:
+            tmp_dest.unlink(missing_ok=True)

--- a/src/kicad_tools/parts/jlcparts_catalog.py
+++ b/src/kicad_tools/parts/jlcparts_catalog.py
@@ -1,0 +1,442 @@
+"""
+Offline JLCPCB parts catalog backed by the yaqwsx/jlcparts dataset.
+
+This module provides a *local, offline* fallback for LCSC part lookups when
+the live JLCPCB web API is unavailable (403 anti-bot enforcement, network
+errors, or an explicit offline request). It consumes the publicly published
+``yaqwsx/jlcparts`` SQLite dataset -- a mirror of the entire JLCPCB catalog --
+downloaded on demand into the existing kicad-tools cache directory.
+
+Two responsibilities live here:
+
+* :func:`sync_catalog` -- download the split-zip SQLite dataset from
+  ``https://yaqwsx.github.io/jlcparts/data/`` (``cache.zip`` + ``cache.z01``,
+  ``cache.z02``, ... sequential parts), reassemble and unzip it into
+  ``~/.cache/kicad-tools/jlcparts.sqlite3``. This is a large, user-invoked
+  download -- it is *never* triggered automatically as a side effect of a
+  lookup, and *never* runs in CI/tests (tests use a small hand-curated
+  fixture SQLite instead).
+
+* :class:`JlcpartsCatalog` -- a read-only reader over the downloaded
+  ``jlcparts.sqlite3`` that translates ``jlc_components`` rows into the
+  existing :class:`~kicad_tools.parts.models.Part` dataclass by exact
+  ``lcsc`` part-number lookup.
+
+Design notes
+------------
+
+* No ``PartProvider`` protocol / multi-backend abstraction is introduced
+  (deferred per owner direction on #4108) -- the catalog is consulted as a
+  fallback inside :class:`~kicad_tools.parts.lcsc.LCSCClient`.
+* Only exact ``lcsc`` lookup is supported in this phase; full-catalog fuzzy
+  matching is explicitly out of scope.
+* The dataset is *never* committed to the repository; ``sync_catalog`` writes
+  only into the cache directory.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import zipfile
+from datetime import datetime
+from pathlib import Path
+
+from .cache import get_default_cache_path
+from .lcsc import PARTS_INSTALL_HINT, _categorize_part, _guess_package_type
+from .models import Part, PartPrice
+
+logger = logging.getLogger(__name__)
+
+# Public GitHub Pages location of the split-zip jlcparts SQLite dataset.
+JLCPARTS_DATA_BASE = "https://yaqwsx.github.io/jlcparts/data"
+
+# Filename of the reassembled catalog inside the cache directory.
+CATALOG_FILENAME = "jlcparts.sqlite3"
+
+
+def get_catalog_path() -> Path:
+    """Return the path to the local jlcparts catalog inside the cache dir.
+
+    Sits alongside the per-query ``parts.db`` produced by
+    :func:`~kicad_tools.parts.cache.get_default_cache_path`. Does not require
+    the file to exist -- callers check :meth:`Path.exists` themselves.
+    """
+    return get_default_cache_path().parent / CATALOG_FILENAME
+
+
+class JlcpartsCatalog:
+    """Read-only reader over a downloaded jlcparts SQLite catalog.
+
+    Translates ``jlc_components`` rows into :class:`Part` objects by exact
+    ``lcsc`` part-number lookup. If the backing file is absent the reader is a
+    silent no-op: :meth:`lookup` returns ``None`` for every query so callers
+    fall through to their existing "not found" behavior.
+
+    Example::
+
+        catalog = JlcpartsCatalog()
+        if catalog.available:
+            part = catalog.lookup("C123456")
+    """
+
+    def __init__(self, db_path: Path | None = None):
+        """Initialize the catalog reader.
+
+        Args:
+            db_path: Path to the jlcparts SQLite file (default:
+                ``~/.cache/kicad-tools/jlcparts.sqlite3``). The file is not
+                required to exist.
+        """
+        self.db_path = db_path or get_catalog_path()
+
+    @property
+    def available(self) -> bool:
+        """Whether the backing catalog file exists on disk."""
+        return self.db_path.exists()
+
+    def lookup(self, lcsc_part: str) -> Part | None:
+        """Look up a single part by exact LCSC number.
+
+        Args:
+            lcsc_part: LCSC part number (e.g. ``"C123456"``). The numeric
+                portion is matched against the ``lcsc`` column.
+
+        Returns:
+            A translated :class:`Part` if found, otherwise ``None`` (including
+            when the catalog file does not exist).
+        """
+        if not self.available:
+            return None
+
+        lcsc_id = _normalize_lcsc_id(lcsc_part)
+        if lcsc_id is None:
+            return None
+
+        try:
+            with sqlite3.connect(f"file:{self.db_path}?mode=ro", uri=True) as conn:
+                conn.row_factory = sqlite3.Row
+                cursor = conn.execute(
+                    "SELECT * FROM jlc_components WHERE lcsc = ?",
+                    (lcsc_id,),
+                )
+                row = cursor.fetchone()
+        except sqlite3.Error as e:
+            logger.warning(f"jlcparts catalog read failed for {lcsc_part}: {e}")
+            return None
+
+        if row is None:
+            return None
+
+        return _row_to_part(row)
+
+    def lookup_many(self, lcsc_parts: list[str]) -> dict[str, Part]:
+        """Look up multiple parts by exact LCSC number.
+
+        Args:
+            lcsc_parts: LCSC part numbers to resolve.
+
+        Returns:
+            Dict mapping normalized (``C``-prefixed, upper-case) part numbers
+            to :class:`Part`. Missing parts are omitted. An empty dict is
+            returned when the catalog file does not exist.
+        """
+        if not self.available or not lcsc_parts:
+            return {}
+
+        # Map numeric id -> canonical requested key so results round-trip.
+        id_to_key: dict[int, str] = {}
+        for raw in lcsc_parts:
+            lcsc_id = _normalize_lcsc_id(raw)
+            if lcsc_id is not None:
+                id_to_key[lcsc_id] = _canonical_lcsc(raw)
+
+        if not id_to_key:
+            return {}
+
+        result: dict[str, Part] = {}
+        try:
+            with sqlite3.connect(f"file:{self.db_path}?mode=ro", uri=True) as conn:
+                conn.row_factory = sqlite3.Row
+                placeholders = ",".join("?" * len(id_to_key))
+                cursor = conn.execute(
+                    f"SELECT * FROM jlc_components WHERE lcsc IN ({placeholders})",
+                    list(id_to_key.keys()),
+                )
+                for row in cursor:
+                    part = _row_to_part(row)
+                    key = id_to_key.get(int(row["lcsc"]), part.lcsc_part)
+                    result[key] = part
+        except sqlite3.Error as e:
+            logger.warning(f"jlcparts catalog bulk read failed: {e}")
+            return {}
+
+        return result
+
+    def count(self) -> int:
+        """Return the number of components in the catalog (0 if absent)."""
+        if not self.available:
+            return 0
+        try:
+            with sqlite3.connect(f"file:{self.db_path}?mode=ro", uri=True) as conn:
+                return int(conn.execute("SELECT COUNT(*) FROM jlc_components").fetchone()[0])
+        except sqlite3.Error:
+            return 0
+
+
+def _canonical_lcsc(lcsc_part: str) -> str:
+    """Normalize a part number to canonical ``C<digits>`` upper-case form."""
+    normalized = lcsc_part.strip().upper()
+    if not normalized.startswith("C"):
+        normalized = f"C{normalized}"
+    return normalized
+
+
+def _normalize_lcsc_id(lcsc_part: str) -> int | None:
+    """Extract the integer ``lcsc`` id from a ``C123456``-style part number.
+
+    The jlcparts ``jlc_components.lcsc`` column stores the numeric id without
+    the ``C`` prefix, so ``"C123456"`` maps to ``123456``.
+
+    Returns:
+        The integer id, or ``None`` if the input has no numeric portion.
+    """
+    digits = _canonical_lcsc(lcsc_part)[1:]
+    if not digits.isdigit():
+        return None
+    return int(digits)
+
+
+def _row_to_part(row: sqlite3.Row) -> Part:
+    """Translate a ``jlc_components`` row into a :class:`Part`.
+
+    Maps the stable jlcparts schema columns onto the existing ``Part``
+    dataclass. The ``price`` column is a JSON array of price breaks
+    (``[{"qFrom": n, "price": p}, ...]``); ``library_type`` distinguishes
+    JLCPCB Basic/Preferred parts.
+    """
+    keys = set(row.keys())
+
+    def col(name: str, default: object = None) -> object:
+        return row[name] if name in keys else default
+
+    def col_str(name: str) -> str:
+        value = col(name)
+        return str(value) if value not in (None, "") else ""
+
+    def col_int(name: str, default: int = 0) -> int:
+        value = col(name)
+        if value in (None, ""):
+            return default
+        try:
+            return int(str(value))
+        except (TypeError, ValueError):
+            return default
+
+    lcsc_id = col("lcsc")
+    lcsc_part = f"C{lcsc_id}" if lcsc_id is not None else ""
+
+    description = col_str("description")
+    package = col_str("package")
+    library_type = col_str("library_type").lower()
+
+    prices = _parse_price_json(col("price"))
+
+    return Part(
+        lcsc_part=lcsc_part,
+        mfr_part=col_str("mfr"),
+        manufacturer=col_str("manufacturer"),
+        description=description,
+        category=_categorize_part(description, package),
+        package=package,
+        package_type=_guess_package_type(package),
+        stock=col_int("stock", 0),
+        min_order=col_int("min_order", 1),
+        prices=prices,
+        is_basic=library_type == "basic",
+        is_preferred=library_type == "preferred",
+        datasheet_url=col_str("datasheet"),
+        product_url=f"https://jlcpcb.com/partdetail/{lcsc_part}" if lcsc_part else "",
+        fetched_at=datetime.now(),
+    )
+
+
+def _parse_price_json(raw: object) -> list[PartPrice]:
+    """Parse the jlcparts ``price`` JSON column into price breaks.
+
+    The column holds a JSON array of ``{"qFrom": <int>, "price": <float>}``
+    objects (``qTo`` may also be present). Malformed or empty values yield an
+    empty list.
+    """
+    if not raw:
+        return []
+
+    try:
+        data = json.loads(raw) if isinstance(raw, str | bytes | bytearray) else raw
+    except (json.JSONDecodeError, TypeError):
+        return []
+
+    if not isinstance(data, list):
+        return []
+
+    prices: list[PartPrice] = []
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        qty = entry.get("qFrom") or entry.get("startNumber") or entry.get("quantity") or 0
+        unit_price = entry.get("price") or entry.get("productPrice") or entry.get("unit_price") or 0
+        try:
+            qty_i = int(qty)
+            price_f = float(unit_price)
+        except (TypeError, ValueError):
+            continue
+        if qty_i > 0 and price_f > 0:
+            prices.append(PartPrice(quantity=qty_i, unit_price=price_f))
+
+    prices.sort(key=lambda p: p.quantity)
+    return prices
+
+
+def _discover_split_parts(base_url: str) -> list[str]:
+    """Return the ordered list of split-zip URLs to download.
+
+    The dataset is published as ``cache.zip`` (the final segment of a split
+    archive) plus sequential ``cache.z01``, ``cache.z02``, ... segments. The
+    number of ``.zNN`` segments changes as the catalog grows, so probe
+    sequentially until a segment 404s.
+
+    Note the split-archive convention: the ``.zNN`` parts come *first* and
+    ``cache.zip`` is the *last* segment. This helper returns URLs in the
+    correct concatenation order (``z01``, ``z02``, ..., then ``cache.zip``).
+    """
+    import requests
+
+    part_urls: list[str] = []
+    index = 1
+    while True:
+        url = f"{base_url}/cache.z{index:02d}"
+        resp = requests.head(url, timeout=30, allow_redirects=True)
+        if resp.status_code == 404:
+            break
+        resp.raise_for_status()
+        part_urls.append(url)
+        index += 1
+        # Safety bound: the dataset is ~12-20 segments; stop well before runaway.
+        if index > 100:
+            break
+
+    part_urls.append(f"{base_url}/cache.zip")
+    return part_urls
+
+
+def sync_catalog(
+    dest: Path | None = None,
+    *,
+    base_url: str = JLCPARTS_DATA_BASE,
+    force: bool = False,
+    progress: bool = True,
+) -> Path:
+    """Download and assemble the jlcparts catalog into the cache directory.
+
+    Downloads the split-zip SQLite dataset from ``base_url`` (``cache.z01`` ..
+    ``cache.zNN`` + ``cache.zip``), concatenates the segments, unzips the
+    resulting archive, and writes the extracted SQLite database to ``dest``
+    (default ``~/.cache/kicad-tools/jlcparts.sqlite3``).
+
+    This is a *large* download (hundreds of MB) and must only ever be invoked
+    explicitly by a user or CI job -- never as a side effect of a lookup, and
+    never in the test suite.
+
+    Args:
+        dest: Destination path for the assembled SQLite catalog.
+        base_url: Base URL of the published dataset (override for testing).
+        force: Re-download even if ``dest`` already exists.
+        progress: Print progress to stdout.
+
+    Returns:
+        The path to the assembled catalog.
+
+    Raises:
+        ImportError: If the ``requests`` dependency (``[parts]`` extra) is
+            missing.
+        RuntimeError: If the assembled archive does not contain the expected
+            SQLite database.
+    """
+    try:
+        import requests
+    except ImportError as e:
+        raise ImportError(
+            f"Downloading the jlcparts catalog requires the 'requests' library. "
+            f"{PARTS_INSTALL_HINT}"
+        ) from e
+
+    dest = dest or get_catalog_path()
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    if dest.exists() and not force:
+        if progress:
+            print(f"Catalog already present: {dest}")
+            print("Use --force to re-download.")
+        return dest
+
+    def _log(msg: str) -> None:
+        if progress:
+            print(msg)
+
+    _log(f"Discovering dataset segments at {base_url} ...")
+    part_urls = _discover_split_parts(base_url)
+    _log(f"Found {len(part_urls)} archive segment(s).")
+
+    # Assemble the split archive into a single temporary .zip next to dest.
+    combined_zip = dest.with_suffix(".download.zip")
+    total_bytes = 0
+    try:
+        with combined_zip.open("wb") as out:
+            for idx, url in enumerate(part_urls, start=1):
+                _log(f"  [{idx}/{len(part_urls)}] {url}")
+                with requests.get(url, stream=True, timeout=120) as resp:
+                    resp.raise_for_status()
+                    for chunk in resp.iter_content(chunk_size=1 << 20):
+                        if chunk:
+                            out.write(chunk)
+                            total_bytes += len(chunk)
+        _log(f"Downloaded {total_bytes / (1 << 20):.1f} MiB across {len(part_urls)} segment(s).")
+
+        _log("Extracting SQLite database ...")
+        _extract_catalog(combined_zip, dest)
+    finally:
+        combined_zip.unlink(missing_ok=True)
+
+    count = JlcpartsCatalog(dest).count()
+    _log(f"Catalog ready: {dest} ({count:,} components)")
+    return dest
+
+
+def _extract_catalog(archive: Path, dest: Path) -> None:
+    """Extract the SQLite database from a (reassembled) jlcparts zip archive.
+
+    Picks the first ``*.sqlite3``/``*.sqlite``/``*.db`` member, or -- if the
+    archive contains a single member -- that member. Writes it to ``dest``.
+
+    Raises:
+        RuntimeError: If no plausible SQLite member is found.
+    """
+    with zipfile.ZipFile(archive) as zf:
+        names = [n for n in zf.namelist() if not n.endswith("/")]
+        sqlite_members = [n for n in names if n.lower().endswith((".sqlite3", ".sqlite", ".db"))]
+        if sqlite_members:
+            member = sqlite_members[0]
+        elif len(names) == 1:
+            member = names[0]
+        else:
+            raise RuntimeError(
+                f"Could not locate a SQLite database in the jlcparts archive; members: {names}"
+            )
+
+        with zf.open(member) as src, dest.open("wb") as out:
+            while True:
+                chunk = src.read(1 << 20)
+                if not chunk:
+                    break
+                out.write(chunk)

--- a/src/kicad_tools/parts/lcsc.py
+++ b/src/kicad_tools/parts/lcsc.py
@@ -14,6 +14,7 @@ import random
 import re
 import time
 from datetime import datetime
+from pathlib import Path
 from threading import Lock
 from typing import TYPE_CHECKING
 
@@ -30,6 +31,7 @@ from .models import (
 
 if TYPE_CHECKING:
     from ..schema.bom import BOMItem
+    from .jlcparts_catalog import JlcpartsCatalog
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +45,9 @@ logger = logging.getLogger(__name__)
 PARTS_INSTALL_HINT = (
     "The 'requests' library is required for LCSC API access. "
     "Install it with the 'parts' extra: uv sync --extra parts "
-    '(or: pip install "kicad-tools[parts]").'
+    '(or: pip install "kicad-tools[parts]"). '
+    "Alternatively, sync the offline jlcparts catalog with "
+    "`kct parts sync-catalog` to look up parts without the live API."
 )
 
 
@@ -55,7 +59,7 @@ class LCSCForbiddenError(Exception):
     """
 
 
-class LCSCDependencyMissingError(Exception):
+class LCSCDependencyMissingError(ImportError):
     """Raised when the optional ``parts`` extra (``requests``) is absent.
 
     This is a *capability* failure -- the requested LCSC matcher cannot run
@@ -64,7 +68,15 @@ class LCSCDependencyMissingError(Exception):
     first occurrence and surface it as a hard, actionable failure instead of
     degrading silently to an empty ``LCSC Part #`` column (issue #4104).
 
-    The message is the canonical :data:`PARTS_INSTALL_HINT`.
+    Subclasses :class:`ImportError` so that call sites which historically
+    caught / expected the bare ``ImportError`` (e.g. the live-API-only
+    ``lookup`` no-fallback path, issue #4108) keep working, while newer
+    callers can catch the more specific type. ``suggest_for_component``'s
+    ``isinstance(e, ImportError)`` promotion therefore still fires whether the
+    underlying layer raised a bare ``ImportError`` or this subclass.
+
+    The message is the canonical :data:`PARTS_INSTALL_HINT`, which now also
+    points at the offline ``kct parts sync-catalog`` alternative (issue #4108).
     """
 
 
@@ -112,14 +124,19 @@ PART_LOOKUP_URL = (
 SEARCH_URL = f"{JLCPCB_API_BASE}/overseas-pcb-order/v1/shoppingCart/smtGood/selectSmtComponentList"
 
 
+def _requests_installed() -> bool:
+    """Return True if the optional ``requests`` dependency is importable."""
+    import importlib.util
+
+    return importlib.util.find_spec("requests") is not None
+
+
 def _requires_requests(func):
     """Decorator to check if requests is available."""
 
     def wrapper(*args, **kwargs):
-        try:
-            import requests  # noqa: F401
-        except ImportError as exc:
-            raise ImportError(PARTS_INSTALL_HINT) from exc
+        if not _requests_installed():
+            raise LCSCDependencyMissingError(PARTS_INSTALL_HINT)
         return func(*args, **kwargs)
 
     return wrapper
@@ -266,6 +283,8 @@ class LCSCClient:
         rate_limit: float = 3.0,
         max_retries: int = 3,
         base_retry_delay: float = 2.0,
+        use_local_catalog: bool = True,
+        catalog_path: Path | None = None,
     ):
         """
         Initialize the client.
@@ -278,6 +297,13 @@ class LCSCClient:
                 Set to 0 to disable rate limiting.
             max_retries: Maximum retry attempts on rate limit errors (default: 3)
             base_retry_delay: Initial delay in seconds before retry (default: 2.0)
+            use_local_catalog: Whether to fall back to the offline jlcparts
+                catalog (``kct parts sync-catalog``) when the live API is
+                unavailable. If the catalog file does not exist this is a
+                silent no-op, so the live-API path is byte-for-byte unchanged
+                when no catalog has been synced (default: True).
+            catalog_path: Override path to the local jlcparts SQLite catalog
+                (default: ``~/.cache/kicad-tools/jlcparts.sqlite3``).
         """
         self.cache = cache if cache is not None else PartsCache() if use_cache else None
         self.timeout = timeout
@@ -286,6 +312,24 @@ class LCSCClient:
         self._max_retries = max_retries
         self._base_retry_delay = base_retry_delay
         self._api_forbidden = False
+        self._use_local_catalog = use_local_catalog
+        self._catalog_path = catalog_path
+        self._catalog: JlcpartsCatalog | None = None
+
+    def _get_catalog(self) -> JlcpartsCatalog | None:
+        """Return the lazily-constructed offline catalog reader, or None.
+
+        Returns ``None`` when the offline fallback is disabled. The reader
+        itself is a silent no-op when the backing catalog file is absent, so
+        constructing it has no effect on the live-API path.
+        """
+        if not self._use_local_catalog:
+            return None
+        if self._catalog is None:
+            from .jlcparts_catalog import JlcpartsCatalog
+
+            self._catalog = JlcpartsCatalog(self._catalog_path)
+        return self._catalog
 
     def _get_session(self):
         """Get or create requests session."""
@@ -391,10 +435,15 @@ class LCSCClient:
             raise last_exception
         return None
 
-    @_requires_requests
     def lookup(self, lcsc_part: str, bypass_cache: bool = False) -> Part | None:
         """
         Look up a single part by LCSC number.
+
+        Resolution order: local response cache -> live JLCPCB API -> offline
+        jlcparts catalog. The catalog is only consulted when the live API is
+        unavailable (403 circuit breaker, network error, or the ``requests``
+        extra is not installed) and a synced catalog exists; when no catalog
+        is present the live-API path is byte-for-byte unchanged.
 
         Args:
             lcsc_part: LCSC part number (e.g., "C123456")
@@ -402,6 +451,12 @@ class LCSCClient:
 
         Returns:
             Part if found, None otherwise
+
+        Raises:
+            LCSCDependencyMissingError: If the ``requests`` extra is missing
+                *and* no offline catalog is available. Subclasses
+                ``ImportError``, so callers that historically caught the bare
+                ``ImportError`` (no offline fallback configured) still work.
         """
         # Normalize part number
         lcsc_part = lcsc_part.upper()
@@ -415,15 +470,38 @@ class LCSCClient:
                 logger.debug(f"Cache hit for {lcsc_part}")
                 return cached
 
-        # Fetch from API
-        try:
-            part = self._fetch_part(lcsc_part)
-            if part and self.cache:
-                self.cache.put(part)
-            return part
-        except Exception as e:
-            logger.error(f"Failed to lookup {lcsc_part}: {e}")
-            return None
+        catalog = self._get_catalog()
+
+        # If requests is unavailable, the live API cannot be reached. Preserve
+        # the historical (Import)Error only when there is no offline fallback.
+        if not _requests_installed():
+            if catalog is None or not catalog.available:
+                raise LCSCDependencyMissingError(PARTS_INSTALL_HINT)
+        else:
+            # Fetch from live API (authoritative for freshness/pricing).
+            part: Part | None = None
+            try:
+                part = self._fetch_part(lcsc_part)
+            except Exception as e:
+                # 403 circuit breaker (LCSCForbiddenError) or other API failure
+                # -- fall through to the offline catalog rather than giving up.
+                logger.warning(f"Live API lookup failed for {lcsc_part}: {e}")
+
+            if part is not None:
+                if self.cache:
+                    self.cache.put(part)
+                return part
+
+        # Live API unavailable / miss -- try the offline jlcparts catalog.
+        if catalog is not None:
+            catalog_part = catalog.lookup(lcsc_part)
+            if catalog_part is not None:
+                logger.debug(f"Offline catalog hit for {lcsc_part}")
+                if self.cache:
+                    self.cache.put(catalog_part)
+                return catalog_part
+
+        return None
 
     def _fetch_part(self, lcsc_part: str) -> Part | None:
         """Fetch part from JLCPCB API."""
@@ -564,7 +642,6 @@ class LCSCClient:
             page_size=page_size,
         )
 
-    @_requires_requests
     def lookup_many(
         self,
         lcsc_parts: list[str],
@@ -573,7 +650,9 @@ class LCSCClient:
         """
         Look up multiple parts.
 
-        Uses cache where possible, fetches missing parts from API.
+        Uses cache where possible, fetches missing parts from the live API,
+        then fills any still-missing parts from the offline jlcparts catalog
+        (see :meth:`lookup` for the full resolution order).
 
         Args:
             lcsc_parts: List of LCSC part numbers
@@ -581,6 +660,11 @@ class LCSCClient:
 
         Returns:
             Dict mapping part numbers to Parts
+
+        Raises:
+            LCSCDependencyMissingError: If the ``requests`` extra is missing
+                *and* no offline catalog is available. Subclasses
+                ``ImportError`` for backward compatibility.
         """
         if not lcsc_parts:
             return {}
@@ -596,10 +680,30 @@ class LCSCClient:
             result.update(cached)
             parts = [p for p in parts if p not in cached]
 
-        # Fetch remaining from API
-        for part_num in parts:
-            part = self._fetch_part(part_num)
-            if part:
+        catalog = self._get_catalog()
+
+        if not _requests_installed():
+            if catalog is None or not catalog.available:
+                raise LCSCDependencyMissingError(PARTS_INSTALL_HINT)
+        else:
+            # Fetch remaining from the live API (authoritative when reachable).
+            for part_num in parts:
+                try:
+                    part = self._fetch_part(part_num)
+                except Exception as e:
+                    # 403 circuit breaker or other API failure -- stop hammering
+                    # the API and fall back to the offline catalog for the rest.
+                    logger.warning(f"Live API lookup failed for {part_num}: {e}")
+                    break
+                if part:
+                    result[part_num] = part
+                    if self.cache:
+                        self.cache.put(part)
+
+        # Fill any still-missing parts from the offline jlcparts catalog.
+        missing = [p for p in parts if p not in result]
+        if missing and catalog is not None:
+            for part_num, part in catalog.lookup_many(missing).items():
                 result[part_num] = part
                 if self.cache:
                     self.cache.put(part)

--- a/tests/parts/fixtures/build_jlcparts_fixture.py
+++ b/tests/parts/fixtures/build_jlcparts_fixture.py
@@ -1,0 +1,147 @@
+"""Programmatic builder for a tiny jlcparts-schema fixture SQLite.
+
+The real ``yaqwsx/jlcparts`` dataset is hundreds of MB and must never be
+committed or downloaded in CI. Instead, tests build a small hand-curated
+SQLite database (a handful of rows) that mirrors the ``jlc_components`` schema
+the offline-catalog reader targets. This keeps the fixture in code (reviewable,
+diffable, no binary blob) while exercising the real column-to-``Part``
+translation path.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+# A few hand-curated rows spanning basic/preferred/extended library types,
+# SMD and through-hole packages, and present/absent price + datasheet fields.
+SAMPLE_ROWS = [
+    {
+        "lcsc": 25804,  # -> C25804
+        "mfr": "RC0402FR-0710KL",
+        "package": "0402",
+        "manufacturer": "YAGEO",
+        "library_type": "basic",
+        "description": "10kOhms 1% 0402 Chip Resistor",
+        "datasheet": "https://example.com/rc0402.pdf",
+        "stock": 500000,
+        "price": json.dumps(
+            [
+                {"qFrom": 10, "qTo": 100, "price": 0.005},
+                {"qFrom": 100, "qTo": None, "price": 0.002},
+            ]
+        ),
+    },
+    {
+        "lcsc": 1525,  # -> C1525
+        "mfr": "CL10B104KB8NNNC",
+        "package": "0402",
+        "manufacturer": "Samsung",
+        "library_type": "basic",
+        "description": "100nF 50V X7R 0402 Multilayer Ceramic Capacitor MLCC",
+        "datasheet": "https://example.com/cl10b104.pdf",
+        "stock": 1000000,
+        "price": json.dumps([{"qFrom": 20, "qTo": None, "price": 0.0018}]),
+    },
+    {
+        "lcsc": 8734,  # -> C8734
+        "mfr": "STM32F103C8T6",
+        "package": "LQFP-48",
+        "manufacturer": "STMicroelectronics",
+        "library_type": "extended",
+        "description": "ARM Cortex-M3 MCU 32-bit Microcontroller LQFP-48",
+        "datasheet": "https://example.com/stm32f103.pdf",
+        "stock": 1200,
+        "price": json.dumps([{"qFrom": 1, "qTo": None, "price": 1.85}]),
+    },
+    {
+        "lcsc": 100,  # -> C100, preferred, no prices, no datasheet
+        "mfr": "GENERIC-PREF",
+        "package": "SOT-23",
+        "manufacturer": "GenericCo",
+        "library_type": "preferred",
+        "description": "NPN Transistor SOT-23",
+        "datasheet": "",
+        "stock": 0,
+        "price": None,
+    },
+]
+
+
+def build_fixture(dest: Path, rows: list[dict] | None = None) -> Path:
+    """Create a jlcparts-schema fixture SQLite at ``dest``.
+
+    Args:
+        dest: Path to write the SQLite database to.
+        rows: Override the sample rows (defaults to :data:`SAMPLE_ROWS`).
+
+    Returns:
+        The path that was written (``dest``).
+    """
+    rows = rows if rows is not None else SAMPLE_ROWS
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if dest.exists():
+        dest.unlink()
+
+    conn = sqlite3.connect(str(dest))
+    try:
+        conn.execute(
+            """
+            CREATE TABLE jlc_components (
+                lcsc INTEGER PRIMARY KEY,
+                mfr TEXT,
+                package TEXT,
+                manufacturer TEXT,
+                library_type TEXT,
+                description TEXT,
+                datasheet TEXT,
+                stock INTEGER,
+                price TEXT
+            )
+            """
+        )
+        conn.executemany(
+            """
+            INSERT INTO jlc_components
+                (lcsc, mfr, package, manufacturer, library_type,
+                 description, datasheet, stock, price)
+            VALUES
+                (:lcsc, :mfr, :package, :manufacturer, :library_type,
+                 :description, :datasheet, :stock, :price)
+            """,
+            rows,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    return dest
+
+
+def build_split_zip_dataset(dir_path: Path, sqlite_path: Path) -> None:
+    """Create a mock split-zip dataset mirroring the jlcparts publish layout.
+
+    Writes ``cache.z01`` (first segment) and ``cache.zip`` (final segment) whose
+    concatenation is a valid zip archive containing ``cache.sqlite3``. Used to
+    exercise ``sync_catalog`` end-to-end without any real network access.
+
+    Args:
+        dir_path: Directory to write the segment files into.
+        sqlite_path: The SQLite database to embed in the archive.
+    """
+    import zipfile
+
+    dir_path.mkdir(parents=True, exist_ok=True)
+    archive = dir_path / "combined.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.write(sqlite_path, arcname="cache.sqlite3")
+
+    data = archive.read_bytes()
+    archive.unlink()
+
+    # Split into two segments: the first half becomes cache.z01, the remainder
+    # becomes cache.zip (the split-archive convention: .zNN first, .zip last).
+    midpoint = max(1, len(data) // 2)
+    (dir_path / "cache.z01").write_bytes(data[:midpoint])
+    (dir_path / "cache.zip").write_bytes(data[midpoint:])

--- a/tests/parts/test_jlcparts_catalog.py
+++ b/tests/parts/test_jlcparts_catalog.py
@@ -1,0 +1,480 @@
+"""Tests for the offline jlcparts catalog reader, LCSCClient fallback, and
+the ``sync-catalog`` command.
+
+No test in this file makes a real network request. The offline catalog is
+exercised against a small, hand-built fixture SQLite (see
+``tests/parts/fixtures/build_jlcparts_fixture.py``), and ``sync_catalog`` is
+driven against a mocked ``requests`` module + a local split-zip archive built
+from that same fixture.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from kicad_tools.parts import Part, PartsCache
+from kicad_tools.parts.jlcparts_catalog import (
+    CATALOG_FILENAME,
+    JlcpartsCatalog,
+    _normalize_lcsc_id,
+    _parse_price_json,
+    get_catalog_path,
+    sync_catalog,
+)
+from kicad_tools.parts.lcsc import LCSCClient, LCSCForbiddenError
+
+# --------------------------------------------------------------------------
+# Load the fixture builder (not an importable package -- load by path)
+# --------------------------------------------------------------------------
+_FIXTURE_DIR = Path(__file__).parent / "fixtures"
+_spec = importlib.util.spec_from_file_location(
+    "build_jlcparts_fixture", _FIXTURE_DIR / "build_jlcparts_fixture.py"
+)
+assert _spec is not None and _spec.loader is not None
+_builder = importlib.util.module_from_spec(_spec)
+sys.modules["build_jlcparts_fixture"] = _builder
+_spec.loader.exec_module(_builder)
+
+
+@pytest.fixture
+def catalog_db(tmp_path: Path) -> Path:
+    """Build a tiny jlcparts-schema fixture SQLite and return its path."""
+    return _builder.build_fixture(tmp_path / "jlcparts_sample.sqlite3")
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+
+def test_normalize_lcsc_id():
+    assert _normalize_lcsc_id("C25804") == 25804
+    assert _normalize_lcsc_id("c25804") == 25804
+    assert _normalize_lcsc_id("25804") == 25804
+    assert _normalize_lcsc_id("C0100") == 100
+    assert _normalize_lcsc_id("Cabc") is None
+    assert _normalize_lcsc_id("") is None
+
+
+def test_parse_price_json_variants():
+    prices = _parse_price_json('[{"qFrom": 10, "price": 0.005}, {"qFrom": 100, "price": 0.002}]')
+    assert len(prices) == 2
+    assert prices[0].quantity == 10
+    assert prices[0].unit_price == 0.005
+    # Sorted ascending by quantity
+    assert prices[1].quantity == 100
+
+    # Already-parsed list passes through.
+    assert _parse_price_json([{"qFrom": 5, "price": 1.0}])[0].quantity == 5
+
+    # Bad / empty inputs degrade to empty list, never raise.
+    assert _parse_price_json(None) == []
+    assert _parse_price_json("") == []
+    assert _parse_price_json("not json") == []
+    assert _parse_price_json("{}") == []
+    assert _parse_price_json('[{"qFrom": 0, "price": 0}]') == []
+
+
+# --------------------------------------------------------------------------
+# JlcpartsCatalog reader
+# --------------------------------------------------------------------------
+
+
+def test_get_catalog_path_sits_beside_cache():
+    path = get_catalog_path()
+    assert path.name == CATALOG_FILENAME
+    # Same directory as the per-query parts cache.
+    from kicad_tools.parts.cache import get_default_cache_path
+
+    assert path.parent == get_default_cache_path().parent
+
+
+def test_catalog_absent_is_silent_noop(tmp_path: Path):
+    catalog = JlcpartsCatalog(tmp_path / "does-not-exist.sqlite3")
+    assert catalog.available is False
+    assert catalog.lookup("C25804") is None
+    assert catalog.lookup_many(["C25804", "C1525"]) == {}
+    assert catalog.count() == 0
+
+
+def test_catalog_lookup_translates_row(catalog_db: Path):
+    catalog = JlcpartsCatalog(catalog_db)
+    assert catalog.available is True
+
+    part = catalog.lookup("C25804")
+    assert part is not None
+    assert part.lcsc_part == "C25804"
+    assert part.mfr_part == "RC0402FR-0710KL"
+    assert part.manufacturer == "YAGEO"
+    assert part.package == "0402"
+    assert part.stock == 500000
+    assert part.is_basic is True
+    assert part.is_preferred is False
+    assert part.datasheet_url == "https://example.com/rc0402.pdf"
+    assert part.product_url == "https://jlcpcb.com/partdetail/C25804"
+    # Price breaks parsed and sorted.
+    assert [p.quantity for p in part.prices] == [10, 100]
+    assert part.best_price == 0.002
+
+
+def test_catalog_lookup_normalizes_and_missing(catalog_db: Path):
+    catalog = JlcpartsCatalog(catalog_db)
+    # Numeric / lowercase / bare forms all resolve.
+    assert catalog.lookup("25804") is not None
+    assert catalog.lookup("c25804") is not None
+    # Absent part -> None
+    assert catalog.lookup("C999999") is None
+
+
+def test_catalog_library_type_mapping(catalog_db: Path):
+    catalog = JlcpartsCatalog(catalog_db)
+    preferred = catalog.lookup("C100")
+    assert preferred is not None
+    assert preferred.is_preferred is True
+    assert preferred.is_basic is False
+    # No prices / datasheet on this row.
+    assert preferred.prices == []
+    assert preferred.datasheet_url == ""
+
+    extended = catalog.lookup("C8734")
+    assert extended is not None
+    assert extended.is_basic is False
+    assert extended.is_preferred is False
+
+
+def test_catalog_lookup_many(catalog_db: Path):
+    catalog = JlcpartsCatalog(catalog_db)
+    got = catalog.lookup_many(["C25804", "C1525", "C999999", "cabc"])
+    assert set(got.keys()) == {"C25804", "C1525"}
+    assert got["C25804"].mfr_part == "RC0402FR-0710KL"
+    assert got["C1525"].description.startswith("100nF")
+
+
+def test_catalog_count(catalog_db: Path):
+    catalog = JlcpartsCatalog(catalog_db)
+    assert catalog.count() == 4
+
+
+# --------------------------------------------------------------------------
+# LCSCClient fallback path
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def force_requests_present(monkeypatch):
+    """Pretend the ``requests`` extra is installed so the live-API branch runs.
+
+    The base dev env does not install ``requests`` (it is the ``[parts]``
+    extra), so the live-fetch branch is otherwise skipped. Tests that exercise
+    the *API-failure -> catalog* fallback need the live branch to be entered
+    (and ``_fetch_part`` to be reached) regardless of the local install.
+    """
+    monkeypatch.setattr("kicad_tools.parts.lcsc._requests_installed", lambda: True)
+
+
+def test_lookup_falls_back_to_catalog_on_api_failure(
+    catalog_db: Path, tmp_path: Path, force_requests_present
+):
+    """When the live API 403s, lookup() resolves from the offline catalog."""
+    cache = PartsCache(db_path=tmp_path / "cache.db")
+    client = LCSCClient(cache=cache, catalog_path=catalog_db)
+
+    with mock.patch.object(
+        client, "_fetch_part", side_effect=LCSCForbiddenError("403")
+    ) as mock_fetch:
+        part = client.lookup("C25804")
+
+    mock_fetch.assert_called_once()
+    assert part is not None
+    assert part.lcsc_part == "C25804"
+    assert part.mfr_part == "RC0402FR-0710KL"
+    # Fallback result is cached for subsequent lookups.
+    assert cache.get("C25804") is not None
+
+
+def test_lookup_no_requests_uses_catalog(catalog_db: Path, tmp_path: Path, monkeypatch):
+    """Without the requests extra, lookup() serves directly from the catalog."""
+    monkeypatch.setattr("kicad_tools.parts.lcsc._requests_installed", lambda: False)
+    cache = PartsCache(db_path=tmp_path / "cache.db")
+    client = LCSCClient(cache=cache, catalog_path=catalog_db)
+
+    # _fetch_part must NOT be called when requests is unavailable.
+    with mock.patch.object(client, "_fetch_part", side_effect=AssertionError("no live fetch")):
+        part = client.lookup("C25804")
+
+    assert part is not None
+    assert part.mfr_part == "RC0402FR-0710KL"
+
+
+def test_lookup_no_requests_no_catalog_raises(tmp_path: Path, monkeypatch):
+    """Without requests AND without a catalog, the historical ImportError stands."""
+    monkeypatch.setattr("kicad_tools.parts.lcsc._requests_installed", lambda: False)
+    cache = PartsCache(db_path=tmp_path / "cache.db")
+    client = LCSCClient(cache=cache, catalog_path=tmp_path / "missing.sqlite3")
+
+    with pytest.raises(ImportError):
+        client.lookup("C25804")
+
+
+def test_lookup_returns_none_when_catalog_absent_and_api_fails(
+    tmp_path: Path, force_requests_present
+):
+    """No catalog + API down = existing 'not found' behavior (None)."""
+    cache = PartsCache(db_path=tmp_path / "cache.db")
+    client = LCSCClient(cache=cache, catalog_path=tmp_path / "missing.sqlite3")
+
+    with mock.patch.object(client, "_fetch_part", side_effect=LCSCForbiddenError("403")):
+        assert client.lookup("C25804") is None
+
+
+def test_lookup_missing_part_falls_through_to_none(
+    catalog_db: Path, tmp_path: Path, force_requests_present
+):
+    """Catalog present but part absent -> None."""
+    cache = PartsCache(db_path=tmp_path / "cache.db")
+    client = LCSCClient(cache=cache, catalog_path=catalog_db)
+
+    with mock.patch.object(client, "_fetch_part", side_effect=LCSCForbiddenError("403")):
+        assert client.lookup("C999999") is None
+
+
+def test_live_api_success_bypasses_catalog(
+    catalog_db: Path, tmp_path: Path, force_requests_present
+):
+    """When the live API returns a part, the catalog is never consulted."""
+    cache = PartsCache(db_path=tmp_path / "cache.db")
+    client = LCSCClient(cache=cache, catalog_path=catalog_db)
+
+    live_part = Part(lcsc_part="C25804", mfr_part="LIVE-API-PART")
+    with mock.patch.object(client, "_fetch_part", return_value=live_part):
+        with mock.patch.object(JlcpartsCatalog, "lookup") as catalog_lookup:
+            part = client.lookup("C25804")
+
+    catalog_lookup.assert_not_called()
+    assert part is not None
+    assert part.mfr_part == "LIVE-API-PART"
+
+
+def test_catalog_disabled_never_constructed(
+    catalog_db: Path, tmp_path: Path, force_requests_present
+):
+    """use_local_catalog=False -> catalog is never consulted even on failure."""
+    cache = PartsCache(db_path=tmp_path / "cache.db")
+    client = LCSCClient(cache=cache, use_local_catalog=False, catalog_path=catalog_db)
+
+    with mock.patch.object(client, "_fetch_part", side_effect=LCSCForbiddenError("403")):
+        assert client.lookup("C25804") is None
+    assert client._get_catalog() is None
+
+
+def test_lookup_many_fallback(catalog_db: Path, tmp_path: Path, force_requests_present):
+    """lookup_many falls back to the catalog for parts the API can't serve."""
+    cache = PartsCache(db_path=tmp_path / "cache.db")
+    client = LCSCClient(cache=cache, catalog_path=catalog_db)
+
+    with mock.patch.object(client, "_fetch_part", side_effect=LCSCForbiddenError("403")):
+        got = client.lookup_many(["C25804", "C1525", "C999999"])
+
+    assert set(got.keys()) == {"C25804", "C1525"}
+    assert got["C25804"].mfr_part == "RC0402FR-0710KL"
+
+
+def test_lookup_many_live_partial_then_catalog(
+    catalog_db: Path, tmp_path: Path, force_requests_present
+):
+    """API serves one part; the catalog fills a second; a third stays missing."""
+    cache = PartsCache(db_path=tmp_path / "cache.db")
+    client = LCSCClient(cache=cache, catalog_path=catalog_db)
+
+    def fake_fetch(part_num: str):
+        if part_num == "C1525":
+            return Part(lcsc_part="C1525", mfr_part="LIVE-CAP")
+        # Everything else "fails" via circuit breaker.
+        raise LCSCForbiddenError("403")
+
+    with mock.patch.object(client, "_fetch_part", side_effect=fake_fetch):
+        got = client.lookup_many(["C1525", "C25804", "C999999"])
+
+    # C1525 from live API, C25804 from catalog, C999999 missing.
+    assert got["C1525"].mfr_part == "LIVE-CAP"
+    assert got["C25804"].mfr_part == "RC0402FR-0710KL"
+    assert "C999999" not in got
+
+
+# --------------------------------------------------------------------------
+# sync_catalog (download mocked -- no real network)
+# --------------------------------------------------------------------------
+
+
+def test_sync_catalog_downloads_and_assembles(catalog_db: Path, tmp_path: Path, monkeypatch):
+    """sync_catalog assembles the split-zip dataset without real network I/O."""
+    data_dir = tmp_path / "dataset"
+    _builder.build_split_zip_dataset(data_dir, catalog_db)
+
+    fake_requests = _make_fake_requests(data_dir)
+    monkeypatch.setitem(sys.modules, "requests", fake_requests)
+
+    dest = tmp_path / "out" / "jlcparts.sqlite3"
+    result = sync_catalog(
+        dest=dest,
+        base_url="https://fake.local/data",
+        force=False,
+        progress=False,
+    )
+
+    assert result == dest
+    assert dest.exists()
+    # The assembled catalog is queryable and matches the fixture contents.
+    catalog = JlcpartsCatalog(dest)
+    assert catalog.count() == 4
+    assert catalog.lookup("C25804") is not None
+
+
+def test_sync_catalog_skips_when_present(tmp_path: Path, monkeypatch):
+    """An existing catalog is not re-downloaded unless --force is given."""
+    dest = tmp_path / "jlcparts.sqlite3"
+    dest.write_bytes(b"existing")
+
+    called = {"get": False}
+
+    class _Boom:
+        @staticmethod
+        def get(*a, **k):
+            called["get"] = True
+            raise AssertionError("should not download")
+
+        @staticmethod
+        def head(*a, **k):
+            called["get"] = True
+            raise AssertionError("should not probe")
+
+    monkeypatch.setitem(sys.modules, "requests", _Boom)
+
+    result = sync_catalog(dest=dest, force=False, progress=False)
+    assert result == dest
+    assert called["get"] is False
+    assert dest.read_bytes() == b"existing"
+
+
+def test_sync_catalog_force_redownloads(catalog_db: Path, tmp_path: Path, monkeypatch):
+    """--force re-downloads even when a catalog file already exists."""
+    data_dir = tmp_path / "dataset"
+    _builder.build_split_zip_dataset(data_dir, catalog_db)
+
+    dest = tmp_path / "jlcparts.sqlite3"
+    dest.write_bytes(b"stale")
+
+    fake_requests = _make_fake_requests(data_dir)
+    monkeypatch.setitem(sys.modules, "requests", fake_requests)
+
+    result = sync_catalog(dest=dest, base_url="https://fake.local/data", force=True, progress=False)
+    assert result == dest
+    assert dest.read_bytes() != b"stale"
+    assert JlcpartsCatalog(dest).count() == 4
+
+
+# --------------------------------------------------------------------------
+# Fake requests module backed by local files (no sockets)
+# --------------------------------------------------------------------------
+
+
+def _make_fake_requests(data_dir: Path):
+    """Build a minimal stand-in for the ``requests`` module.
+
+    ``head`` reports 404 for missing segments (to end split-part discovery)
+    and 200 for present ones; ``get`` streams the local file bytes. No network
+    is touched.
+    """
+
+    class _Resp:
+        def __init__(self, path: Path | None, status: int):
+            self._path = path
+            self.status_code = status
+
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise RuntimeError(f"HTTP {self.status_code}")
+
+        def iter_content(self, chunk_size=1 << 20):
+            assert self._path is not None
+            data = self._path.read_bytes()
+            for i in range(0, len(data), chunk_size):
+                yield data[i : i + chunk_size]
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    def _path_for(url: str) -> Path:
+        return data_dir / url.rsplit("/", 1)[-1]
+
+    class _FakeRequests:
+        @staticmethod
+        def head(url, timeout=None, allow_redirects=True):
+            path = _path_for(url)
+            return _Resp(path if path.exists() else None, 200 if path.exists() else 404)
+
+        @staticmethod
+        def get(url, stream=False, timeout=None):
+            path = _path_for(url)
+            if not path.exists():
+                return _Resp(None, 404)
+            return _Resp(path, 200)
+
+    return _FakeRequests
+
+
+# --------------------------------------------------------------------------
+# CLI: kct parts sync-catalog (download mocked -- no real network)
+# --------------------------------------------------------------------------
+
+
+def test_cli_sync_catalog(catalog_db: Path, tmp_path: Path, monkeypatch):
+    """The `parts sync-catalog` subcommand wires through to sync_catalog."""
+    from kicad_tools.cli import parts_cmd
+
+    data_dir = tmp_path / "dataset"
+    _builder.build_split_zip_dataset(data_dir, catalog_db)
+    dest = tmp_path / "cli-out" / "jlcparts.sqlite3"
+
+    fake_requests = _make_fake_requests(data_dir)
+    monkeypatch.setitem(sys.modules, "requests", fake_requests)
+    # Redirect the default catalog path to a tmp location so the test never
+    # touches the real ~/.cache directory.
+    monkeypatch.setattr("kicad_tools.parts.jlcparts_catalog.get_catalog_path", lambda: dest)
+
+    rc = parts_cmd.main(["sync-catalog", "--base-url", "https://fake.local/data"])
+    assert rc == 0
+    assert dest.exists()
+    assert JlcpartsCatalog(dest).count() == 4
+
+
+def test_cli_dispatch_sync_catalog(catalog_db: Path, tmp_path: Path, monkeypatch):
+    """The top-level `kct parts sync-catalog` dispatcher forwards correctly."""
+    import argparse
+
+    from kicad_tools.cli.commands.parts import run_parts_command
+
+    data_dir = tmp_path / "dataset"
+    _builder.build_split_zip_dataset(data_dir, catalog_db)
+    dest = tmp_path / "dispatch-out" / "jlcparts.sqlite3"
+
+    fake_requests = _make_fake_requests(data_dir)
+    monkeypatch.setitem(sys.modules, "requests", fake_requests)
+    monkeypatch.setattr("kicad_tools.parts.jlcparts_catalog.get_catalog_path", lambda: dest)
+
+    args = argparse.Namespace(
+        parts_command="sync-catalog",
+        force=False,
+        base_url="https://fake.local/data",
+    )
+    rc = run_parts_command(args)
+    assert rc == 0
+    assert JlcpartsCatalog(dest).count() == 4


### PR DESCRIPTION
## Summary

Adds an offline JLCPCB parts-catalog backend (Phase 1 per the owner-direction
re-scope on #4108) so LCSC lookups survive the live `jlcpcb.com/api` 403
anti-bot wall. Consumes the public `yaqwsx/jlcparts` SQLite dataset, downloaded
on demand into the existing cache dir — never committed, never fetched in CI.

No `PartProvider` protocol, no fuzzy matching, no auto-refresh, no JLCPCB
API-key auth (all explicitly deferred per the curated Non-Goals). The fallback
lives inside/alongside `LCSCClient`.

## Changes

- **New `parts/jlcparts_catalog.py`**
  - `sync_catalog()` — downloads the split-zip dataset (`cache.z01..` +
    `cache.zip`) from `https://yaqwsx.github.io/jlcparts/data/`, reassembles
    and unzips it into `~/.cache/kicad-tools/jlcparts.sqlite3`. Progress
    output, `--force` re-download, clear error handling, requires the
    `[parts]` extra (requests). Manual/user-invoked only.
  - `JlcpartsCatalog` — read-only reader translating `jlc_components` rows
    into the existing `Part` dataclass by exact `lcsc` lookup. Absent file =
    silent no-op.
- **`parts/lcsc.py`** — `lookup()`/`lookup_many()` gain a catalog fallback.
  Resolution order: response cache → live API → offline catalog → miss. The
  live-API path (`_fetch_part`, `_make_request`, rate limiter, 403 circuit
  breaker, `PartsCache`) is unchanged when no catalog is synced. The catalog
  also serves lookups when the `requests` extra is absent; the historical
  `ImportError` is preserved only when *neither* the API nor a catalog is
  available.
- **CLI** — `kct parts sync-catalog` wired through `cli/parts_cmd.py` and the
  primary `cli/parser.py` + `cli/commands/parts.py` dispatcher (`--force`,
  `--base-url`).
- **`parts/__init__.py`** — export `JlcpartsCatalog`, `get_catalog_path`,
  `sync_catalog`.
- **Tests** — `tests/parts/test_jlcparts_catalog.py` (24 tests) + an in-code
  fixture builder (`tests/parts/fixtures/build_jlcparts_fixture.py`) that
  writes a tiny hand-curated `jlc_components` SQLite and a local split-zip
  archive. No test hits the real dataset or network — `requests` is stubbed
  via `sys.modules`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `sync-catalog` downloads+assembles into cache dir, `--force` supported | ✅ | `test_sync_catalog_downloads_and_assembles`, `test_sync_catalog_skips_when_present`, `test_sync_catalog_force_redownloads` (download stubbed) |
| `lookup`/`lookup_many` fall back to catalog on API failure; unchanged when catalog absent/API OK | ✅ | `test_lookup_falls_back_to_catalog_on_api_failure`, `test_live_api_success_bypasses_catalog`, `test_lookup_many_live_partial_then_catalog` |
| Live-API path untouched when no catalog configured | ✅ | Existing `tests/test_parts.py` (216 parts tests green); catalog fallback only engages after a live miss/failure |
| CI never downloads the real dataset | ✅ | All tests use the in-code fixture SQLite + stubbed `requests`; grep shows no real `yaqwsx.github.io`/`jlcpcb.com` fetch |
| Offline-fixture test: present → Part, absent → None | ✅ | `test_catalog_lookup_translates_row`, `test_lookup_missing_part_falls_through_to_none` |
| `sync-catalog` smoke-tested with mocked download | ✅ | `test_cli_sync_catalog`, `test_cli_dispatch_sync_catalog` |
| ruff check / format clean on touched files | ✅ | `ruff check` + `ruff format --check` pass on all touched src/test files |
| No new failures | ✅ | 216 parts/LCSC/BOM regression tests pass; 24 new tests pass |

## Test Plan

```
uv run pytest tests/parts/test_jlcparts_catalog.py   # 24 passed
uv run pytest tests/parts tests/test_parts.py tests/test_lcsc_models.py \
  tests/test_bom_lcsc_merge.py tests/test_bom_enrich.py   # 216 passed
uv run ruff check <touched files>    # clean
uv run ruff format --check <touched files>   # clean
uv run kct parts sync-catalog --help   # subcommand registered
```

Note on mypy: the offline module carries one pre-existing-pattern
`import-untyped` for `requests` (identical to the existing `lcsc.py:307`);
the `parts/` module already has several pre-existing mypy errors on `main`
(`lcsc.py`, `importer.py`, `parts_cmd.py`). No *new* mypy error class is
introduced by the touched non-`requests` code.

Closes #4108