### PR TITLE
fix(diffpair): skip #3270 net-priority promotion on total coupled collapse

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 4104
-# Branch: feature/issue-4104
+# Issue: 4107
+# Branch: feature/issue-4107
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -6875,6 +6875,54 @@ class DiffPairRouter:
                     )
                 diff_net_ids = diff_net_ids - budget_exit_diff_nets
 
+        # Issue #4107 (tier b of #4095): early-abort the collapsed coupled
+        # pass at the coupled->single-ended boundary.  When EVERY considered
+        # coupled pair budget-exited and NOTHING coupled successfully (the
+        # board-07 "total collapse" signature), the coupled pass left the
+        # grid pristine -- ``route_differential_pair_coupled`` returns
+        # ``[], None`` on budget-exit BEFORE any ``_mark_route`` commit, so
+        # there is no partial coupled copper to unwind.  In that state the
+        # ONLY divergence from a plain single-ended route is the #3270
+        # net-priority promotion below (``_budget_exit_diff_nets`` ->
+        # ``complexity_tier = -1``), which reorders the single-ended pass
+        # away from its natural (better) ordering and is the measured
+        # churn / net-loss driver (board 07: 34/22 vs single-ended 13/26).
+        # Skip the promotion on collapse so the single-ended pass runs with
+        # default ordering == byte-equivalent to a plain single-ended route.
+        #
+        # ``considered`` is every pair for which coupled routing was a
+        # candidate: pairs that reached the coupled A* (``coupled_attempted_
+        # count``) plus pairs deferred before it by the aggregate budget
+        # (``aggregate_deferred_pairs``).  Collapse requires the coupled A*
+        # to have actually run for >=1 pair (``coupled_attempted_count > 0``)
+        # -- an aggregate-timeout-only deferral where no A* ran is NOT the
+        # board-07 pathology.  PARTIAL exit (board 06: some pairs couple, or
+        # only some exit) leaves ``coupled_routed_nets`` non-empty (or not
+        # every considered pair exited) -> ``collapsed`` is False -> the
+        # #3270 promotion runs exactly as today (measured beneficial there).
+        #
+        # Instrumentation is deliberately NOT gated: ``budget_exit_pair_names``
+        # (the CLI warning + ``diffpair_budget_exit_pair_names()``) is a
+        # separate object populated in the loop above and is left intact --
+        # the operator is still told the pairs fell back; only the PROMOTION
+        # is skipped.
+        considered_coupled_pairs = coupled_attempted_count + aggregate_deferred_pairs
+        collapsed = (
+            coupled_attempted_count > 0
+            and not coupled_routed_nets
+            and len(budget_exit_pair_names) == considered_coupled_pairs
+        )
+        if collapsed:
+            budget_exit_diff_nets = set()
+            logger.warning(
+                "DIFFPAIR_COUPLED_COLLAPSE_SKIP_PROMOTION: all %d considered "
+                "coupled pair(s) budget-exited with none coupled; skipping the "
+                "#3270 net-priority promotion so the single-ended pass runs "
+                "with default ordering (pristine single-ended-equivalent "
+                "result; issue #4107)",
+                considered_coupled_pairs,
+            )
+
         # Issue #3270: Surface budget-exit diff-pair nets to the
         # Autorouter so ``_get_net_priority`` can promote them to the
         # head of the non-diff main strategy's net order.  Without this
@@ -6883,7 +6931,9 @@ class DiffPairRouter:
         # bursts the per-net timeout (60s observed vs 30s budget) and
         # exhausts the strategy wall-clock before reaching MIPI_RST.
         # The set is cleared after the strategy returns to keep the
-        # promotion local to this invocation.
+        # promotion local to this invocation.  On the #4107 collapse
+        # signature ``budget_exit_diff_nets`` was emptied above, so this
+        # assigns an empty set (no promotion).
         self.autorouter._budget_exit_diff_nets = set(budget_exit_diff_nets)
 
         non_diff_nets = [n for n in self.autorouter.nets if n not in diff_net_ids and n != 0]

--- a/tests/test_diffpair_budget_exit_warning.py
+++ b/tests/test_diffpair_budget_exit_warning.py
@@ -247,3 +247,329 @@ def test_no_pairs_detected_surfaces_no_budget_exit():
 
     assert router._diffpair._last_budget_exit_pair_names == []
     assert router.diffpair_budget_exit_pair_names() == []
+
+
+# ---------------------------------------------------------------------------
+# Issue #4107: collapse skips the #3270 promotion; partial exit keeps it
+#
+# On budget-exit the coupled pass returns ``[], None`` BEFORE any grid
+# commit, so on the all-pairs collapse the grid is pristine and the ONLY
+# divergence from a plain single-ended route is the #3270 net-priority
+# promotion (``_budget_exit_diff_nets`` -> ``complexity_tier = -1``).  The
+# #4107 gate leaves ``_budget_exit_diff_nets`` EMPTY on the collapse
+# signature so the single-ended pass runs with default ordering.  The
+# promotion set is cleared again after the strategy callback returns
+# (#3270 leak guard), so we observe it AT THE STRATEGY-CALL MOMENT via a
+# ``non_diffpair_strategy`` callable that records it -- exactly the vantage
+# point the real negotiated strategy sees.
+# ---------------------------------------------------------------------------
+
+
+def _hard_single_pair_router() -> Autorouter:
+    """One diff pair whose long diagonal span never couples within a
+    microscopic per-pair budget (forces the coupled A* to budget-exit),
+    plus one plain net.  Drives the ALL-PAIRS collapse signature:
+    ``coupled_attempted_count == 1``, ``coupled_routed_nets`` empty, the
+    single considered pair in ``budget_exit_pair_names``.
+    """
+    rules = DesignRules(trace_width=0.2, trace_clearance=0.15, grid_resolution=0.1)
+    router = Autorouter(
+        width=40.0,
+        height=30.0,
+        rules=rules,
+        net_class_map=_opt_in_diffpair_class_map(["DP+", "DP-"]),
+    )
+    router.add_component(
+        "U1",
+        [
+            {
+                "number": "1",
+                "x": 2.0,
+                "y": 2.0,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 1,
+                "net_name": "DP+",
+            },
+            {
+                "number": "2",
+                "x": 2.0,
+                "y": 2.8,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 2,
+                "net_name": "DP-",
+            },
+            {
+                "number": "3",
+                "x": 2.0,
+                "y": 15.0,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 3,
+                "net_name": "GPIO1",
+            },
+        ],
+    )
+    router.add_component(
+        "J1",
+        [
+            {
+                "number": "1",
+                "x": 38.0,
+                "y": 28.0,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 1,
+                "net_name": "DP+",
+            },
+            {
+                "number": "2",
+                "x": 38.0,
+                "y": 28.8,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 2,
+                "net_name": "DP-",
+            },
+            {
+                "number": "3",
+                "x": 38.0,
+                "y": 15.0,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 3,
+                "net_name": "GPIO1",
+            },
+        ],
+    )
+    return router
+
+
+def _one_easy_one_hard_pair_router() -> Autorouter:
+    """Two diff pairs: an EASY pair with a short straight span that couples
+    fast, and a HARD pair on a long diagonal that budget-exits.  With one
+    pair coupling, ``coupled_routed_nets`` is non-empty -> the collapse
+    signature does NOT hold -> the #3270 promotion still runs for the hard
+    pair's nets.  This is design (4)'s "partial budget-exit does NOT trigger
+    the skip".
+    """
+    rules = DesignRules(trace_width=0.2, trace_clearance=0.15, grid_resolution=0.1)
+    router = Autorouter(
+        width=40.0,
+        height=30.0,
+        rules=rules,
+        net_class_map=_opt_in_diffpair_class_map(["E+", "E-", "H+", "H-"]),
+    )
+    router.add_component(
+        "U1",
+        [
+            {
+                "number": "1",
+                "x": 5.0,
+                "y": 5.0,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 1,
+                "net_name": "E+",
+            },
+            {
+                "number": "2",
+                "x": 5.0,
+                "y": 5.8,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 2,
+                "net_name": "E-",
+            },
+            {
+                "number": "3",
+                "x": 2.0,
+                "y": 2.0,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 3,
+                "net_name": "H+",
+            },
+            {
+                "number": "4",
+                "x": 2.0,
+                "y": 2.8,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 4,
+                "net_name": "H-",
+            },
+        ],
+    )
+    router.add_component(
+        "J1",
+        [
+            {
+                "number": "1",
+                "x": 12.0,
+                "y": 5.0,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 1,
+                "net_name": "E+",
+            },
+            {
+                "number": "2",
+                "x": 12.0,
+                "y": 5.8,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 2,
+                "net_name": "E-",
+            },
+            {
+                "number": "3",
+                "x": 38.0,
+                "y": 28.0,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 3,
+                "net_name": "H+",
+            },
+            {
+                "number": "4",
+                "x": 38.0,
+                "y": 28.8,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 4,
+                "net_name": "H-",
+            },
+        ],
+    )
+    return router
+
+
+def test_collapse_skips_budget_exit_promotion():
+    """When ALL considered coupled pairs budget-exit and none couple, the
+    strategy runs with ``_budget_exit_diff_nets`` empty (no #3270 promotion)
+    so the single-ended pass keeps its default ordering."""
+    router = _hard_single_pair_router()
+    config = DifferentialPairConfig(enabled=True, spacing=0.8)
+
+    promotion_at_strategy: dict[str, set[int]] = {}
+
+    def _record_promotion() -> list:
+        # The #3270 promotion set is live only during the strategy call;
+        # snapshot it here (the vantage point the negotiated strategy sees).
+        promotion_at_strategy["nets"] = set(router._budget_exit_diff_nets)
+        return []
+
+    router._diffpair.route_all_with_diffpairs(
+        config,
+        coupled_only=True,
+        per_pair_timeout=0.001,  # microscopic -> the pair's coupled A* budget-exits
+        non_diffpair_strategy=_record_promotion,
+    )
+
+    # The single pair reached the coupled A* and budget-exited (collapse).
+    assert router._diffpair._last_coupled_attempted_count == 1
+    assert router._diffpair._last_budget_exit_pair_names == ["DP"]
+    # THE GUARANTEE: promotion set empty at the strategy call -> pristine
+    # single-ended-equivalent ordering.
+    assert promotion_at_strategy["nets"] == set(), (
+        "On the all-pairs collapse the #3270 promotion must be skipped; "
+        f"strategy saw _budget_exit_diff_nets={promotion_at_strategy['nets']}"
+    )
+
+
+def test_collapse_still_fires_budget_exit_warning(caplog):
+    """Instrumentation is NOT gated by the collapse skip: the operator is
+    still told the pairs fell back (Phase-1 warning + accessor + the
+    ``DIFFPAIR_BUDGET_EXIT_FALLBACK`` log)."""
+    import logging
+
+    router = _hard_single_pair_router()
+    config = DifferentialPairConfig(enabled=True, spacing=0.8)
+
+    with caplog.at_level(logging.WARNING):
+        router._diffpair.route_all_with_diffpairs(
+            config,
+            coupled_only=True,
+            per_pair_timeout=0.001,
+            non_diffpair_strategy=lambda: [],
+        )
+
+    # Phase-1 instrumentation still populated on collapse.
+    assert router._diffpair._last_budget_exit_pair_names == ["DP"]
+    assert router.diffpair_budget_exit_pair_names() == ["DP"]
+    assert router._diffpair._last_budget_exit_count == 1
+
+    msgs = [r.getMessage() for r in caplog.records]
+    # The Phase-1 fallback warning still fires (operator told).
+    assert any("DIFFPAIR_BUDGET_EXIT_FALLBACK" in m and "DP" in m for m in msgs), (
+        f"expected the Phase-1 fallback warning on collapse; saw {msgs}"
+    )
+    # And the new #4107 line records that the promotion was skipped.
+    assert any("DIFFPAIR_COUPLED_COLLAPSE_SKIP_PROMOTION" in m for m in msgs), (
+        f"expected the #4107 collapse-skip log line; saw {msgs}"
+    )
+
+
+def test_partial_exit_keeps_budget_exit_promotion():
+    """When only SOME considered pairs budget-exit (one pair couples), the
+    collapse signature does NOT hold, so the #3270 promotion still runs for
+    the budget-exited pair's nets -- board-06-style behaviour is unchanged."""
+    router = _one_easy_one_hard_pair_router()
+    config = DifferentialPairConfig(enabled=True, spacing=0.8)
+
+    promotion_at_strategy: dict[str, set[int]] = {}
+
+    def _record_promotion() -> list:
+        promotion_at_strategy["nets"] = set(router._budget_exit_diff_nets)
+        return []
+
+    router._diffpair.route_all_with_diffpairs(
+        config,
+        coupled_only=True,
+        per_pair_timeout=0.5,  # easy pair couples; hard pair budget-exits
+        non_diffpair_strategy=_record_promotion,
+    )
+
+    # Two pairs considered; only the HARD pair budget-exited.
+    assert router._diffpair._last_coupled_attempted_count == 2
+    assert router._diffpair._last_budget_exit_pair_names == ["H"]
+    # Partial exit -> promotion KEPT: the hard pair's nets (3, 4) are
+    # promoted for the strategy call.
+    assert promotion_at_strategy["nets"] == {3, 4}, (
+        "Partial budget-exit must keep the #3270 promotion; strategy saw "
+        f"_budget_exit_diff_nets={promotion_at_strategy['nets']}"
+    )
+
+
+def test_aggregate_only_deferral_is_not_a_collapse():
+    """An aggregate-timeout-only deferral where the coupled A* never ran
+    (``coupled_attempted_count == 0``) is NOT the board-07 collapse: the
+    collapse guard requires the coupled A* to have actually attempted at
+    least one pair.  The promotion therefore still runs for the deferred
+    nets (behaviour unchanged from before #4107)."""
+    router = _two_pad_diffpair_router()
+    config = DifferentialPairConfig(enabled=True, spacing=0.8)
+
+    promotion_at_strategy: dict[str, set[int]] = {}
+
+    def _record_promotion() -> list:
+        promotion_at_strategy["nets"] = set(router._budget_exit_diff_nets)
+        return []
+
+    router._diffpair.route_all_with_diffpairs(
+        config,
+        aggregate_timeout=0.001,  # defer before the coupled A* runs
+        non_diffpair_strategy=_record_promotion,
+    )
+
+    # No coupled A* attempted -> not a collapse.
+    assert router._diffpair._last_coupled_attempted_count == 0
+    assert router._diffpair._last_budget_exit_pair_names == ["USB_D"]
+    # Promotion still applied to the deferred pair's nets (1, 2).
+    assert promotion_at_strategy["nets"] == {1, 2}, (
+        "Aggregate-only deferral (no coupled A* attempted) must NOT trigger "
+        "the collapse skip; the #3270 promotion still runs. Strategy saw "
+        f"_budget_exit_diff_nets={promotion_at_strategy['nets']}"
+    )


### PR DESCRIPTION
## Summary

`--differential-pairs` can ship a result strictly worse than the plain single-ended equivalent (board 07, seed 42, C++ backend: 34 vs 13 DRC errors, 22/31 vs 26/31 nets). All pairs budget-exit at `reason=iteration iters=20000` and fall back to single-ended; the subsequent negotiation churn trades away already-landed nets. Phase 1 (#4106) warned; this delivers the guarantee.

On budget-exit `route_differential_pair_coupled` (with `coupled_only=True`) returns `[], None` **before** any `_mark_route` grid commit, so on the all-pairs collapse the grid is pristine and the ONLY divergence from a plain single-ended route is the #3270 net-priority promotion (`_budget_exit_diff_nets` → `complexity_tier = -1`), which reorders the single-ended pass away from its natural (better) ordering. This gates that one promotion on the collapse signature.

## Changes

- `src/kicad_tools/router/diffpair_routing.py` — in `route_all_with_diffpairs`, at the coupled→single-ended boundary (before the `_budget_exit_diff_nets` assignment), compute the collapse signature (`coupled_attempted_count > 0` AND `coupled_routed_nets` empty AND every considered pair in `budget_exit_pair_names`) and, when it holds, set `budget_exit_diff_nets = set()` so the single-ended pass runs with default ordering == byte-equivalent to a plain single-ended route. Emits a greppable `DIFFPAIR_COUPLED_COLLAPSE_SKIP_PROMOTION` log line.
- Instrumentation (`budget_exit_pair_names`, the Phase-1 `DIFFPAIR_BUDGET_EXIT_FALLBACK` warning, `diffpair_budget_exit_pair_names()`) is a separate object, left intact — the operator is still told the pairs fell back; only the promotion is skipped. (No object split was needed — the promotion set and the instrumentation set were already distinct locals.)
- `tests/test_diffpair_budget_exit_warning.py` — added collapse-skip and partial-exit regression tests.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| All-pairs collapse → strategy runs with `_budget_exit_diff_nets` empty | ✅ | `test_collapse_skips_budget_exit_promotion` captures the set at the strategy-call moment == `set()` |
| Board 06 unaffected | ✅ | `test_board_06_diffpair_test.py` + `test_board06_determinism.py` pass unmodified (45 passed, 1 skipped) |
| Partial exit does NOT trigger the skip (#3270 promotion still runs) | ✅ | `test_partial_exit_keeps_budget_exit_promotion` asserts `{3,4}` promoted; `test_aggregate_only_deferral_is_not_a_collapse` covers no-A*-attempted |
| `test_budget_exit_diff_priority.py` passes unmodified | ✅ | 27 passed (with per-pair/aggregate suites) — `_get_net_priority` contract untouched |
| Phase-1 instrumentation still fires on collapse + new skip log line | ✅ | `test_collapse_still_fires_budget_exit_warning` asserts both `DIFFPAIR_BUDGET_EXIT_FALLBACK` and `DIFFPAIR_COUPLED_COLLAPSE_SKIP_PROMOTION` |
| Bounded cost: no second route, O(1) collapse test | ✅ | Added work is one boolean signature test + emptying a set on collapse |

## Test Plan

- `pytest tests/test_diffpair_budget_exit_warning.py` — 10 passed (6 existing + 4 new).
- `pytest tests/test_budget_exit_diff_priority.py tests/test_diffpair_per_pair_timeout.py tests/test_diffpair_aggregate_cap.py` — 27 passed unmodified.
- `pytest tests/test_board_06_diffpair_test.py tests/router/test_board06_determinism.py` — 45 passed, 1 skipped unmodified.
- `pytest tests/test_router_core_diffpair_timeout.py tests/test_escape_diffpair.py tests/router/test_escape_diffpair_composition.py tests/test_diffpair_routing_integration.py tests/test_diffpair_phase_b.py tests/test_diffpair_shadow.py tests/test_diffpair_npad.py` — 147 passed.
- `ruff check` + `ruff format --check` on changed files — clean.
- mypy baseline gate (`scripts/ci/check_mypy_baseline.py`) — no new errors from this change (the one local "new" `cmaes` import-not-found is a pre-existing environment gap, reproduced identically on the unmodified tree; not in any file this PR touches).

C++ backend built and verified in the worktree (`kct build-native --check` → available 1.0.0) so the routing tests exercise the real coupled A*.

Closes #4107