### PR TITLE
fix(install): use git+URL direct reference instead of removed 'uv add --git' flags

### DIFF
--- a/scripts/install-kct.sh
+++ b/scripts/install-kct.sh
@@ -325,9 +325,11 @@ run_uv_add() {
     # CI-no-network constraint). The operator runs `uv sync` afterwards.
     ( cd "$TARGET" && uv add "$RESOLVED_PATH" --editable --frozen )
   elif [[ -n "$GIT_TAG" ]]; then
-    ( cd "$TARGET" && uv add kicad-tools --git "$KCT_GIT_URL" --tag "$GIT_TAG" )
+    # uv >= 0.5 dropped `--git`; the supported spelling is a git+ URL with
+    # the ref appended (works across uv versions).
+    ( cd "$TARGET" && uv add "kicad-tools @ git+${KCT_GIT_URL}@${GIT_TAG}" )
   else
-    ( cd "$TARGET" && uv add kicad-tools --git "$KCT_GIT_URL" --rev "$GIT_REV" )
+    ( cd "$TARGET" && uv add "kicad-tools @ git+${KCT_GIT_URL}@${GIT_REV}" )
   fi
 }
 


### PR DESCRIPTION
Closes #4121

Stage 5 of scripts/install-kct.sh used `uv add kicad-tools --git URL --tag/--rev REF`, which current uv rejects ('unexpected argument --git'). Replaced with the PEP 508 direct-reference spelling `uv add "kicad-tools @ git+URL@REF"` for both the tag and rev branches.

Verified end-to-end post-release: two successful `--tag v0.15.0` installs (softstart and chorus), both consumers now at kicad-tools 0.15.0 with the C++ backend built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)