### PR TITLE
docs: v0.15.0 currency pass (parts-tier reality, new flags, skills list)

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,9 +481,12 @@ Part lookups resolve through a tiered chain (each tier falls back to the next):
 2. **Official JLCPCB open-platform API** — only when you supply your own API key
    (see below). Off by default; inert without keys.
 3. **Anonymous scrape API** — the public JLCPCB web endpoints (requires the
-   `parts` extra: `pip install "kicad-tools[parts]"`).
+   `parts` extra: `pip install "kicad-tools[parts]"`). **Note:** as of
+   July 2026 JLCPCB's public endpoint returns 404 — treat this tier as
+   best-effort/deprecated and rely on tier 2 (BYO key) or tier 4 (offline).
 4. **Offline jlcparts catalog** — a locally synced mirror
-   (`kct parts sync-catalog`), usable fully offline.
+   (`kct parts sync-catalog`, ~620 MB download, ~5 GB on disk, ~7.1 M
+   components), usable fully offline.
 
 #### Using your own JLCPCB API key
 
@@ -542,6 +545,10 @@ Notes and caveats:
 | `kct route-auto <pcb>` | Orchestrator-based multi-strategy autorouting |
 | `kct optimize-traces <pcb>` | Optimize routed traces |
 | `kct datasheet <subcommand>` | Search, download, parse datasheets |
+| `kct parts <subcommand>` | LCSC/JLCPCB part lookup, cache, offline catalog sync |
+| `kct export <pcb>` | Manufacturing bundle export (gerbers, BOM, CPL) |
+| `kct mfr <subcommand>` | Manufacturer rule profiles (apply-rules, validate) |
+| `kct fleet status` | Routing + manufacturing readiness across all boards |
 | `kct mcp serve` | Start MCP server for AI agent integration |
 
 All commands support `--format json` for machine-readable output.
@@ -585,10 +592,24 @@ All commands support `--format json` for machine-readable output.
 | `mcp` | MCP server for AI agent integration |
 | `layout` | Layout preservation for PCB regeneration |
 
-## What's New (May 2026)
+## What's New (v0.15.0, July 2026)
 
 Recent additions an agent reading these docs cold should know about:
 
+- **Router feasibility & coupling flags on `kct route`** — `--monotone-certificate-order`
+  (certify a bundle's escape feasibility and derive a constructive net order),
+  `--cross-package-pair-corridor`, and `--slack-corridor-widening` (all default
+  off). Coupled diff-pair attempts that all budget-exit now early-abort to a
+  plain single-ended route instead of degrading the result.
+- **JLCPCB parts stack** — `kct parts sync-catalog` mirrors the full jlcparts
+  dataset for offline lookups; set `JLCPCB_ACCESS_KEY`/`JLCPCB_SECRET_KEY` to
+  use the official open-platform API (see Parts Lookup below).
+- **`kct check --refill-zones`** — refill zone fills via kicad-cli before the
+  pure-Python checks, killing stale-fill clearance false positives; a loud
+  advisory now fires when copper is measured against possibly-stale fills.
+- **Hierarchical-schematic LVS** — multi-sheet designs are no longer vacuous.
+- **`/kct:tapeout` skill** — one command that produces a complete, fab-ready
+  export bundle or refuses loudly.
 - **`kct fleet status`** — survey routing + manufacturing readiness across every
   board in `boards/`. The "are we ship-ready?" entry point. See
   [Manufacturing Export → ship-ready check](docs/guides/manufacturing-export.md#are-we-ship-ready-kct-fleet-status).
@@ -724,7 +745,7 @@ uv run ruff format . --check && uv run ruff check . && uv run pytest
 
 ## Agent Skills (`kct` namespace)
 
-kicad-tools ships its own Claude agent skills under `.claude/commands/kct/` (invoked as `/kct:<name>`), a harness-agnostic namespace kept separate from any installed orchestration framework. Currently available: **`/kct:ee-review <issue-or-board>`** — produces an advisory EE decision document (escalating intervention ladder + binding electrical constraints, cited and confidence-graded) for analog/placement-blocked boards; it emits decisions for human ratification, never routes copper.
+kicad-tools ships its own Claude agent skills under `.claude/commands/kct/` (invoked as `/kct:<name>`), a harness-agnostic namespace kept separate from any installed orchestration framework. Five skills ship today — `/kct:tapeout` (complete fab-ready export bundle or loud refusal), `/kct:manufacturing-readiness` (sign-off gates), `/kct:board-recipe-scaffold`, `/kct:layout-journal`, and `/kct:ee-review` (advisory EE decision document for analog/placement-blocked boards). See [.claude/commands/kct/README.md](.claude/commands/kct/README.md) for the full contracts.
 
 ## Related Projects
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -225,6 +225,7 @@ kct check <pcb_file> [options]
 | `--format {table,json}` | Output format |
 | `--mfr {jlcpcb,oshpark,pcbway}` | Manufacturer rules |
 | `--rules RULES` | Custom rules file |
+| `--refill-zones` | Refill zone fills in-place via `kicad-cli pcb drc --refill-zones --save-board` before checking (mutates the board file; kills stale-fill clearance false positives, #4113) |
 
 **Examples:**
 ```bash
@@ -523,6 +524,7 @@ kct parts <subcommand> [options]
 | `search` | Search for parts |
 | `lookup` | Get part details by LCSC number |
 | `check` | Check part availability |
+| `sync-catalog` | Download the jlcparts dataset (~620 MB) into the cache dir for fully-offline lookups (#4117) |
 
 **Examples:**
 ```bash
@@ -583,6 +585,14 @@ Common flags (the full surface lives in `kct route --help`):
 | `--seed N` | Seed Python `random` for reproducible routing (#2589) |
 | `--auto-fix` / `--auto-fix-passes N` | Run `kct fix-drc` after routing on DRC failure |
 | `--skip-drc` | Skip post-route DRC validation |
+
+#### Feasibility / coupling flags (v0.15.0, all default off)
+
+| Option | Description |
+|--------|-------------|
+| `--monotone-certificate-order` | Certify bundle escape feasibility (monotone-routability) and route bundle nets in the derived constructive order (#4089/#4103) |
+| `--cross-package-pair-corridor` | Reserve a soft corridor between the two legs of a cross-package differential pair at escape time (#4090) |
+| `--slack-corridor-widening` | Widen pair-continuation corridors by an estimated skew budget so length matching has room by construction (#4092) |
 
 #### Strategy escalation flags
 
@@ -1076,3 +1086,15 @@ Source of truth: module docstring at
 | `KICAD_TOOLS_CONFIG` | Config file path |
 | `KICAD_CLI_PATH` | Path to kicad-cli binary |
 | `LCSC_API_KEY` | LCSC API key for parts lookup |
+| `JLCPCB_ACCESS_KEY` / `JLCPCB_SECRET_KEY` | BYO-key official JLCPCB open-platform API — when both are set, becomes the preferred parts-lookup tier (#4119); see README "Using your own JLCPCB API key" |
+| `JLCPCB_APP_ID` | Optional app id for the official JLCPCB API |
+
+## Export / BOM Notes
+
+`kct export` enriches the BOM with LCSC part numbers by default (`--auto-lcsc`,
+on by default for JLCPCB exports). If the `parts` extra is missing, the export
+**fails loudly** with an install hint instead of silently shipping an empty
+LCSC column (#4116); pass `--no-auto-lcsc` to export without enrichment.
+`kct mfr apply-rules` writes a sibling `.kicad_pro` (rules + Default netclass)
+so `kicad-cli pcb drc` uses the applied constraints instead of factory
+defaults (#4109).


### PR DESCRIPTION
Park-the-repo documentation audit (README + docs/reference/cli.md only, no code).

Fixes the two misleading claims found by the audit — the anonymous JLCPCB parts endpoint 404s upstream as of July 2026 (verified live), and the offline catalog's real footprint — and backfills the v0.15.0 capabilities: route feasibility/coupling flags, check --refill-zones, parts sync-catalog, JLCPCB_* env vars, export --auto-lcsc semantics, mfr apply-rules .kicad_pro, all five kct skills, refreshed What's New.

All flag names verified against src/kicad_tools/cli/*. ruff clean; skill-convention tests 24/24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)