### PR TITLE
fix(parts): stream-extract split jlcparts archives Python zipfile rejects

### DIFF
--- a/src/kicad_tools/parts/jlcparts_catalog.py
+++ b/src/kicad_tools/parts/jlcparts_catalog.py
@@ -40,7 +40,9 @@ import json
 import logging
 import os
 import sqlite3
+import struct
 import zipfile
+import zlib
 from datetime import datetime
 from pathlib import Path
 
@@ -55,6 +57,13 @@ JLCPARTS_DATA_BASE = "https://yaqwsx.github.io/jlcparts/data"
 
 # Filename of the reassembled catalog inside the cache directory.
 CATALOG_FILENAME = "jlcparts.sqlite3"
+
+# Zip signatures (little-endian) relevant to split-archive extraction.
+#   PK\x07\x08 -- "spanning" / split-archive marker prepended to the first
+#                 segment of a ``zip -s`` archive.
+#   PK\x03\x04 -- local file header that begins each archive member.
+_SPANNING_MARKER = b"PK\x07\x08"
+_LOCAL_FILE_HEADER = b"PK\x03\x04"
 
 
 def get_catalog_path() -> Path:
@@ -414,15 +423,63 @@ def sync_catalog(
     return dest
 
 
+def _is_split_archive(archive: Path) -> bool:
+    """Return whether ``archive`` is a ``zip -s`` split (multi-disk) archive.
+
+    A split archive produced by ``zip -s`` begins with the 4-byte spanning
+    marker ``PK\\x07\\x08`` on its first segment. After the segments are
+    concatenated in order the reassembled blob therefore starts with that
+    marker. Python's :mod:`zipfile` refuses these categorically
+    (``BadZipFile: zipfiles that span multiple disks are not supported``)
+    because it consults the multi-disk central directory, so we detect the
+    marker and take a streaming extraction path that never reads the central
+    directory.
+    """
+    with archive.open("rb") as fh:
+        head = fh.read(4)
+    return head[:4] == _SPANNING_MARKER
+
+
 def _extract_catalog(archive: Path, dest: Path) -> None:
     """Extract the SQLite database from a (reassembled) jlcparts zip archive.
 
-    Picks the first ``*.sqlite3``/``*.sqlite``/``*.db`` member, or -- if the
-    archive contains a single member -- that member. Writes it to ``dest``.
+    Two paths are supported:
+
+    * **Single-disk archive** (the CI test fixtures): parsed normally with
+      :mod:`zipfile`; the first ``*.sqlite3``/``*.sqlite``/``*.db`` member (or,
+      failing that, a lone single member) is extracted.
+    * **Split ``zip -s`` archive** (the real yaqwsx/jlcparts dataset): detected
+      by the leading ``PK\\x07\\x08`` spanning marker -- or by ``zipfile``
+      raising the multi-disk ``BadZipFile`` -- and streamed via
+      :func:`_extract_split_archive`, which never consults the multi-disk
+      central directory.
+
+    Both paths write to a sibling temp file and promote it atomically via
+    :func:`os.replace`, so a killed or failed extraction can never leave a
+    truncated catalog that later lookups would silently trust (#4117).
 
     Raises:
-        RuntimeError: If no plausible SQLite member is found.
+        RuntimeError: If no plausible SQLite member is found, or the split
+            archive's first member is not deflate-compressed.
     """
+    if _is_split_archive(archive):
+        _extract_split_archive(archive, dest)
+        return
+
+    try:
+        _extract_single_disk_archive(archive, dest)
+    except zipfile.BadZipFile as e:
+        # Some split archives do not carry the leading spanning marker but
+        # still trip the multi-disk guard once zipfile reads the central
+        # directory. Fall back to the streaming path in that case.
+        if "span multiple disks" in str(e):
+            _extract_split_archive(archive, dest)
+            return
+        raise
+
+
+def _extract_single_disk_archive(archive: Path, dest: Path) -> None:
+    """Extract the SQLite member from a normal single-disk zip archive."""
     with zipfile.ZipFile(archive) as zf:
         names = [n for n in zf.namelist() if not n.endswith("/")]
         sqlite_members = [n for n in names if n.lower().endswith((".sqlite3", ".sqlite", ".db"))]
@@ -435,9 +492,6 @@ def _extract_catalog(archive: Path, dest: Path) -> None:
                 f"Could not locate a SQLite database in the jlcparts archive; members: {names}"
             )
 
-        # Extract to a sibling temp file and promote atomically so a killed
-        # or failed extraction can never leave a truncated catalog that
-        # later lookups would silently trust.
         tmp_dest = dest.with_suffix(".extract.tmp")
         try:
             with zf.open(member) as src, tmp_dest.open("wb") as out:
@@ -449,3 +503,85 @@ def _extract_catalog(archive: Path, dest: Path) -> None:
             os.replace(tmp_dest, dest)
         finally:
             tmp_dest.unlink(missing_ok=True)
+
+
+def _extract_split_archive(archive: Path, dest: Path) -> None:
+    """Stream-extract the first member of a split (``zip -s``) archive.
+
+    The real jlcparts dataset is a true split archive whose multi-disk central
+    directory Python's :mod:`zipfile` refuses to open. This path never consults
+    the central directory: it parses only the leading local file header and
+    streams the single member's deflate payload.
+
+    Steps:
+
+    1. Skip the 4-byte ``PK\\x07\\x08`` spanning marker if present.
+    2. Parse the ``PK\\x03\\x04`` local file header (fixed 30-byte struct):
+       general-purpose flag and compression method live at offset +6/+8, and
+       the file-name / extra-field lengths at offset +26/+28. The method must
+       be 8 (deflate); the name/extra lengths locate the start of the
+       compressed data.
+    3. Feed everything after the header through ``zlib.decompressobj(-15)``
+       (raw deflate, no zlib wrapper) until the decompressor reports EOF. No
+       member sizes are needed, so this works transparently for entries that
+       use a trailing data descriptor and/or zip64 fields.
+
+    The output is written to a sibling temp file and promoted atomically.
+
+    Raises:
+        RuntimeError: If the local file header is missing/truncated or the
+            member is not deflate-compressed.
+    """
+    tmp_dest = dest.with_suffix(".extract.tmp")
+    try:
+        with archive.open("rb") as fh:
+            marker = fh.read(4)
+            if marker[:4] != _SPANNING_MARKER:
+                # No spanning marker: rewind so the local header parse below
+                # sees the full stream from byte 0.
+                fh.seek(0)
+
+            header = fh.read(30)
+            if len(header) < 30 or header[:4] != _LOCAL_FILE_HEADER:
+                raise RuntimeError(
+                    "Split jlcparts archive did not begin with a PK\\x03\\x04 "
+                    "local file header; cannot stream-extract."
+                )
+
+            # Local file header layout (little-endian) after the 4-byte sig:
+            #   +4  version needed (H)   +6  gp flag (H)   +8  method (H)
+            #   +10 mod time (H)  +12 mod date (H)  +14 crc32 (I)
+            #   +18 comp size (I) +22 uncomp size (I)
+            #   +26 name len (H)  +28 extra len (H)
+            method = struct.unpack_from("<H", header, 8)[0]
+            name_len = struct.unpack_from("<H", header, 26)[0]
+            extra_len = struct.unpack_from("<H", header, 28)[0]
+
+            if method != 8:
+                raise RuntimeError(
+                    "Split jlcparts archive member is not deflate-compressed "
+                    f"(compression method {method}, expected 8); cannot "
+                    "stream-extract."
+                )
+
+            # Consume the variable-length file-name and extra fields; the
+            # compressed payload begins immediately after them.
+            fh.read(name_len + extra_len)
+
+            decompressor = zlib.decompressobj(-15)
+            with tmp_dest.open("wb") as out:
+                while not decompressor.eof:
+                    chunk = fh.read(1 << 20)
+                    if not chunk:
+                        # No more input but the stream never reported EOF --
+                        # flush whatever remains and stop.
+                        out.write(decompressor.flush())
+                        break
+                    out.write(decompressor.decompress(chunk))
+                else:
+                    # decompressor.eof reached: flush any buffered tail.
+                    out.write(decompressor.flush())
+
+        os.replace(tmp_dest, dest)
+    finally:
+        tmp_dest.unlink(missing_ok=True)

--- a/tests/parts/fixtures/build_jlcparts_fixture.py
+++ b/tests/parts/fixtures/build_jlcparts_fixture.py
@@ -145,3 +145,53 @@ def build_split_zip_dataset(dir_path: Path, sqlite_path: Path) -> None:
     midpoint = max(1, len(data) // 2)
     (dir_path / "cache.z01").write_bytes(data[:midpoint])
     (dir_path / "cache.zip").write_bytes(data[midpoint:])
+
+
+def build_spanning_split_bytes(sqlite_path: Path, arcname: str = "cache.sqlite3") -> bytes:
+    """Return the concatenated bytes of a *true* ``zip -s`` split archive.
+
+    A genuine split archive produced by ``zip -s`` prepends the 4-byte
+    spanning marker ``PK\\x07\\x08`` to its first segment. After the segments
+    are concatenated in order the reassembled blob therefore begins with that
+    marker, and Python's :mod:`zipfile` refuses to open it
+    (``BadZipFile: zipfiles that span multiple disks are not supported``).
+
+    We synthesize exactly that shape without shelling out to ``zip``: build a
+    single-member *deflate* zip with :mod:`zipfile`, then prepend the spanning
+    marker to its bytes. The streaming extractor under test never reads the
+    central directory, so the multi-disk central-directory difference is
+    irrelevant to it -- the leading marker plus the ``PK\\x03\\x04`` local file
+    header are all that matter.
+
+    Args:
+        sqlite_path: The SQLite database to embed as the single member.
+        arcname: Archive member name (default ``cache.sqlite3``).
+
+    Returns:
+        The reassembled split-archive bytes, beginning with ``PK\\x07\\x08``.
+    """
+    import io
+    import zipfile
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.write(sqlite_path, arcname=arcname)
+    return b"PK\x07\x08" + buf.getvalue()
+
+
+def build_spanning_split_dataset(dir_path: Path, sqlite_path: Path) -> None:
+    """Write a true ``zip -s`` split dataset (leading spanning marker) as segments.
+
+    Mirrors :func:`build_split_zip_dataset` but produces the *real* split shape:
+    the reassembled ``cache.z01`` + ``cache.zip`` concatenation begins with the
+    ``PK\\x07\\x08`` spanning marker, exercising the streaming extraction path.
+
+    Args:
+        dir_path: Directory to write the segment files into.
+        sqlite_path: The SQLite database to embed in the archive.
+    """
+    dir_path.mkdir(parents=True, exist_ok=True)
+    data = build_spanning_split_bytes(sqlite_path)
+    midpoint = max(1, len(data) // 2)
+    (dir_path / "cache.z01").write_bytes(data[:midpoint])
+    (dir_path / "cache.zip").write_bytes(data[midpoint:])

--- a/tests/parts/test_jlcparts_catalog.py
+++ b/tests/parts/test_jlcparts_catalog.py
@@ -21,6 +21,8 @@ from kicad_tools.parts import Part, PartsCache
 from kicad_tools.parts.jlcparts_catalog import (
     CATALOG_FILENAME,
     JlcpartsCatalog,
+    _extract_catalog,
+    _is_split_archive,
     _normalize_lcsc_id,
     _parse_price_json,
     get_catalog_path,
@@ -478,3 +480,202 @@ def test_cli_dispatch_sync_catalog(catalog_db: Path, tmp_path: Path, monkeypatch
     rc = run_parts_command(args)
     assert rc == 0
     assert JlcpartsCatalog(dest).count() == 4
+
+
+# --------------------------------------------------------------------------
+# Split-archive (true ``zip -s``) extraction path
+# --------------------------------------------------------------------------
+
+
+def test_is_split_archive_detects_spanning_marker(catalog_db: Path, tmp_path: Path):
+    """A blob beginning with PK\\x07\\x08 is recognized as a split archive."""
+    split = tmp_path / "split.zip"
+    split.write_bytes(_builder.build_spanning_split_bytes(catalog_db))
+    assert _is_split_archive(split) is True
+
+
+def test_is_split_archive_rejects_plain_zip(catalog_db: Path, tmp_path: Path):
+    """A normal single-disk zip is not flagged as a split archive."""
+    import zipfile
+
+    plain = tmp_path / "plain.zip"
+    with zipfile.ZipFile(plain, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.write(catalog_db, arcname="cache.sqlite3")
+    assert _is_split_archive(plain) is False
+
+
+def test_spanning_marker_routes_to_streaming_not_zipfile(
+    catalog_db: Path, tmp_path: Path, monkeypatch
+):
+    """The leading spanning marker forces the streaming path, bypassing zipfile.
+
+    This guards the premise of the fix: the real dataset carries the
+    ``PK\\x07\\x08`` marker, and we must NOT hand such a blob to stdlib
+    ``zipfile`` (which reads the multi-disk central directory the real dataset
+    trips on). We assert the single-disk zipfile path is never entered when the
+    marker is present.
+    """
+    split = tmp_path / "split.zip"
+    split.write_bytes(_builder.build_spanning_split_bytes(catalog_db))
+
+    def _boom(*_a, **_k):
+        raise AssertionError("single-disk zipfile path must not be used for split archives")
+
+    monkeypatch.setattr("kicad_tools.parts.jlcparts_catalog._extract_single_disk_archive", _boom)
+
+    dest = tmp_path / "out.sqlite3"
+    _extract_catalog(split, dest)
+    assert dest.read_bytes() == catalog_db.read_bytes()
+
+
+def test_extract_falls_back_when_zipfile_reports_multidisk(
+    catalog_db: Path, tmp_path: Path, monkeypatch
+):
+    """A markerless archive that trips zipfile's multi-disk guard falls back.
+
+    Some split archives lack the leading spanning marker but still raise
+    ``BadZipFile: ... span multiple disks ...`` once ``zipfile`` reaches the
+    zip64 end-of-central-directory locator. The extractor must catch that and
+    retry via the streaming path. We simulate the guard by building a plain
+    deflate archive (no marker) and forcing the single-disk path to raise the
+    multi-disk error; the fallback streaming path then succeeds because the
+    local file header is intact at byte 0.
+    """
+    import zipfile
+
+    # Markerless plain-deflate archive so the streaming fallback can parse the
+    # PK\x03\x04 header at byte 0.
+    plain = tmp_path / "plain.zip"
+    with zipfile.ZipFile(plain, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.write(catalog_db, arcname="cache.sqlite3")
+
+    def _raise_multidisk(*_a, **_k):
+        raise zipfile.BadZipFile("zipfiles that span multiple disks are not supported")
+
+    monkeypatch.setattr(
+        "kicad_tools.parts.jlcparts_catalog._extract_single_disk_archive", _raise_multidisk
+    )
+
+    dest = tmp_path / "out.sqlite3"
+    _extract_catalog(plain, dest)
+    assert dest.read_bytes() == catalog_db.read_bytes()
+    assert JlcpartsCatalog(dest).count() == 4
+
+
+def test_extract_split_archive_byte_identical(catalog_db: Path, tmp_path: Path):
+    """Streaming extraction of a split archive yields a byte-identical member."""
+    split = tmp_path / "split.zip"
+    split.write_bytes(_builder.build_spanning_split_bytes(catalog_db))
+
+    dest = tmp_path / "out.sqlite3"
+    _extract_catalog(split, dest)
+
+    assert dest.exists()
+    # Byte-for-byte identical to the embedded SQLite source.
+    assert dest.read_bytes() == catalog_db.read_bytes()
+    # And it is a queryable catalog.
+    assert JlcpartsCatalog(dest).count() == 4
+
+
+def test_extract_plain_zip_still_works(catalog_db: Path, tmp_path: Path):
+    """The single-disk zipfile path is unchanged for plain fixtures."""
+    import zipfile
+
+    plain = tmp_path / "plain.zip"
+    with zipfile.ZipFile(plain, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.write(catalog_db, arcname="cache.sqlite3")
+
+    dest = tmp_path / "out.sqlite3"
+    _extract_catalog(plain, dest)
+    assert dest.read_bytes() == catalog_db.read_bytes()
+    assert JlcpartsCatalog(dest).count() == 4
+
+
+def test_extract_split_archive_non_deflate_errors(catalog_db: Path, tmp_path: Path):
+    """A stored (method 0) split member raises a clear, actionable error."""
+    import io
+    import zipfile
+
+    buf = io.BytesIO()
+    # ZIP_STORED => compression method 0, which the streaming path rejects.
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_STORED) as zf:
+        zf.write(catalog_db, arcname="cache.sqlite3")
+
+    split = tmp_path / "stored-split.zip"
+    split.write_bytes(b"PK\x07\x08" + buf.getvalue())
+
+    dest = tmp_path / "out.sqlite3"
+    with pytest.raises(RuntimeError, match="not deflate-compressed"):
+        _extract_catalog(split, dest)
+    # Atomicity: no partial catalog is left behind on failure.
+    assert not dest.exists()
+
+
+def test_extract_split_archive_missing_local_header_errors(tmp_path: Path):
+    """A spanning marker not followed by a local header raises a clear error."""
+    split = tmp_path / "bogus-split.zip"
+    split.write_bytes(b"PK\x07\x08" + b"not a local file header, definitely not zip")
+
+    dest = tmp_path / "out.sqlite3"
+    with pytest.raises(RuntimeError, match="local file header"):
+        _extract_catalog(split, dest)
+    assert not dest.exists()
+
+
+def test_sync_catalog_extracts_true_split_dataset(catalog_db: Path, tmp_path: Path, monkeypatch):
+    """sync_catalog assembles and extracts a real split-shaped dataset."""
+    data_dir = tmp_path / "dataset"
+    _builder.build_spanning_split_dataset(data_dir, catalog_db)
+
+    fake_requests = _make_fake_requests(data_dir)
+    monkeypatch.setitem(sys.modules, "requests", fake_requests)
+
+    dest = tmp_path / "out" / "jlcparts.sqlite3"
+    result = sync_catalog(
+        dest=dest,
+        base_url="https://fake.local/data",
+        force=False,
+        progress=False,
+    )
+
+    assert result == dest
+    assert dest.read_bytes() == catalog_db.read_bytes()
+    catalog = JlcpartsCatalog(dest)
+    assert catalog.count() == 4
+    assert catalog.lookup("C25804") is not None
+
+
+def test_cli_surfaces_extraction_error(catalog_db: Path, tmp_path: Path, monkeypatch, capsys):
+    """A sync-catalog extraction failure prints an actionable error (exit 1)."""
+    import io
+    import zipfile
+
+    from kicad_tools.cli import parts_cmd
+
+    # Build a split dataset whose single member is STORED (method 0) so the
+    # streaming extractor raises -- exercising the CLI error surface.
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_STORED) as zf:
+        zf.write(catalog_db, arcname="cache.sqlite3")
+    data = b"PK\x07\x08" + buf.getvalue()
+
+    data_dir = tmp_path / "dataset"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    midpoint = max(1, len(data) // 2)
+    (data_dir / "cache.z01").write_bytes(data[:midpoint])
+    (data_dir / "cache.zip").write_bytes(data[midpoint:])
+
+    dest = tmp_path / "cli-out" / "jlcparts.sqlite3"
+    fake_requests = _make_fake_requests(data_dir)
+    monkeypatch.setitem(sys.modules, "requests", fake_requests)
+    monkeypatch.setattr("kicad_tools.parts.jlcparts_catalog.get_catalog_path", lambda: dest)
+
+    rc = parts_cmd.main(["sync-catalog", "--base-url", "https://fake.local/data"])
+    assert rc == 1
+
+    err = capsys.readouterr().err
+    # The actual extraction error text is surfaced -- not a silent exit-1.
+    assert "failed to sync jlcparts catalog" in err
+    assert "not deflate-compressed" in err
+    # No partial catalog left behind.
+    assert not dest.exists()


### PR DESCRIPTION
## Summary

`kct parts sync-catalog` could not extract the real yaqwsx/jlcparts dataset. The dataset is a true `zip -s` split archive: after its segments are concatenated the blob begins with the `PK\x07\x08` spanning marker and carries a multi-disk (zip64) central directory that Python's `zipfile` refuses categorically (`BadZipFile: zipfiles that span multiple disks are not supported`). CI never downloads the real dataset (by design), so the single-disk fixture tests never exercised this shape.

This adds a pure-Python streaming extraction path that never consults the multi-disk central directory, and keeps the existing `zipfile.ZipFile` path for single-disk archives (the test fixtures). The orchestrator validated the same approach live today against the real 618 MiB dataset (5.14 GiB SQLite, 7,157,042 components, `lookup("C25804")` correct).

## Changes

- `src/kicad_tools/parts/jlcparts_catalog.py`:
  - `_is_split_archive()` — detects the leading `PK\x07\x08` spanning marker.
  - `_extract_split_archive()` — skips the 4-byte marker, parses the `PK\x03\x04` local file header (compression method must be 8/deflate; reads name/extra lengths to find the data start), then streams `zlib.decompressobj(-15)` over the remaining bytes until `d.eof`. No member sizes are needed, so data-descriptor and zip64 entries work.
  - `_extract_catalog()` now routes: split → streaming; otherwise the single-disk `zipfile` path, with a fallback to streaming if `zipfile` raises the multi-disk `BadZipFile` on a markerless split. Both paths keep the tmp + `os.replace` atomic promotion from #4117.
- `tests/parts/fixtures/build_jlcparts_fixture.py`: `build_spanning_split_bytes()` / `build_spanning_split_dataset()` synthesize a genuine split-shaped archive in-process (single-member deflate zip with `PK\x07\x08` prepended — exactly segment-1 of a `zip -s` archive after concatenation).
- `tests/parts/test_jlcparts_catalog.py`: new tests for marker detection, byte-identical streaming extraction, the plain-zipfile fallback, non-deflate members raising a clear error, the multi-disk `BadZipFile` fallback, `sync_catalog` end-to-end over a split dataset, and CLI error surfacing.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `sync-catalog` completes against the real dataset shape (split fixture in CI as proxy) | ✅ | `test_sync_catalog_extracts_true_split_dataset` assembles a split dataset and extracts a byte-identical, queryable catalog |
| Split-aware path chosen when blob starts with `PK\x07\x08`; plain-zipfile kept for single-disk | ✅ | `test_is_split_archive_*`, `test_spanning_marker_routes_to_streaming_not_zipfile`, `test_extract_plain_zip_still_works` |
| Extraction failure prints an actionable error (no silent exit-1) | ✅ | `test_cli_surfaces_extraction_error` asserts `rc == 1` and stderr contains the real error text |
| Existing fixture tests pass; atomicity preserved | ✅ | All prior tests green; failure tests assert no partial catalog is left behind |
| No downloads in tests | ✅ | All fixtures built in-process; `requests` is mocked |

## Test Plan

- `uv run pytest tests/parts/test_jlcparts_catalog.py` → 33 passed
- `uv run ruff check` + `ruff format --check` on all three files → clean
- `uv run mypy src/kicad_tools/parts/jlcparts_catalog.py` → no errors in the changed module

## Notes on the streaming-path premise

Prepending `PK\x07\x08` alone does not make stdlib `zipfile` raise (it reads the central directory from the file tail and tolerates a leading prefix); the real dataset's multi-disk rejection comes from its zip64 end-of-central-directory locator, which needs a >4 GiB member to reproduce faithfully. The streaming path never reads the central directory, so it is driven entirely by the marker + local header — which is exactly what the fixture provides. The multi-disk `BadZipFile` fallback is covered by a dedicated test that forces the guard.

Closes #4123