### PR TITLE
fix: classify floating-pin hole pairs as different-net, not same-net

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 4107
-# Branch: feature/issue-4107
+# Issue: 4127
+# Branch: feature/issue-4127
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -55,25 +55,54 @@ _MEASUREMENT_RULE_IDS: frozenset[str] = frozenset(
 # Issue #4102: ``dimension_drill_clearance`` hole-to-hole findings carry both
 # endpoints' resolved net names in ``nets=(net1, net2)``.  A user reading the
 # report needs to separate the fab's real concern (different-net pairs, where a
-# drill-wall break creates a short) from same-net / floating pairs.  The data is
+# drill-wall break creates a short) from same-net pairs.  The data is
 # already present per-finding and in ``--format json``; the report just needs to
 # surface it (net names shown unconditionally, plus an explicit same-net /
 # different-net qualifier).  This is presentational only -- severity is
 # unchanged (see #2976: same-net drill overlap is still a manufacturing defect).
+#
+# Issue #4127: the classifier uses a floating-aware check (``_is_floating_net``),
+# not naive string equality.  Every genuinely unconnected pad/via resolves to
+# the *same* ``net:0`` placeholder (net 0 is a single canonical no-net sentinel
+# in the PCB net table -- see ``PCB`` construction in schema/pcb.py), so a naive
+# ``nets[0] == nets[1]`` would mislabel two *distinct* floating pins as
+# ``same-net``.  Floating pins share no electrical identity, so any pair
+# involving a floating endpoint is ``different-net``.
 _NET_RELATIONSHIP_RULE_IDS: frozenset[str] = frozenset({"dimension_drill_clearance"})
+
+
+def _is_floating_net(net: str) -> bool:
+    """True for KiCad's unconnected/no-net sentinel as resolved by dimensions.py.
+
+    Unconnected pads/vias always carry ``net_number == 0`` (a single canonical
+    sentinel -- see ``PCB`` net-table construction, ``self._nets[0] = Net(0,
+    "")``), which resolves to the empty string or, in dimensions.py's fallback,
+    the literal placeholder ``"net:0"``.  Treat either spelling as floating so
+    this stays correct if the empty-string form ever reaches here directly
+    (e.g. a future caller that skips the ``f"net:{number}"`` fallback).
+    """
+    return net in ("", "net:0")
 
 
 def _net_relationship(nets: tuple[str, ...]) -> str | None:
     """Classify a hole-to-hole finding's net pair as same-net / different-net.
 
-    Returns ``"same-net"`` when both endpoints resolve to the same net name,
-    ``"different-net"`` when they differ, and ``None`` when the finding does
-    not carry exactly two net names (nothing to compare).  Unnamed nets are
-    already resolved to distinct ``net:<n>`` placeholders upstream, so an
-    unconnected pin next to a signal via reads as ``different-net``.
+    Returns ``"same-net"`` when both endpoints resolve to the same *named,
+    non-floating* net, ``"different-net"`` when they differ, and ``None`` when
+    the finding does not carry exactly two net names (nothing to compare).
+
+    Floating/unconnected pins have no net identity to share: every one of them
+    resolves to the *same* ``net:0`` placeholder upstream (net 0 is a single
+    canonical no-net sentinel, not a per-pad unique ID -- see schema/pcb.py).
+    So any pair with a floating endpoint -- including two distinct floating pins
+    that collide on the ``net:0`` string -- is ``different-net``, never
+    ``same-net`` (issue #4127).  A plain string equality would wrongly report
+    ``net:0 == net:0`` as same-net; the floating-aware check below prevents that.
     """
     if len(nets) != 2:
         return None
+    if _is_floating_net(nets[0]) or _is_floating_net(nets[1]):
+        return "different-net"
     return "same-net" if nets[0] == nets[1] else "different-net"
 
 

--- a/src/kicad_tools/validate/rules/dimensions.py
+++ b/src/kicad_tools/validate/rules/dimensions.py
@@ -202,6 +202,12 @@ class DimensionRules(DRCRule):
         # Add vias
         for via in pcb.vias:
             net = pcb.get_net(via.net_number)
+            # Unconnected vias carry net_number == 0, a single canonical no-net
+            # sentinel (schema/pcb.py: self._nets[0] = Net(0, "")), so this
+            # fallback yields the identical "net:0" string for *every* floating
+            # via -- distinct floating endpoints collide on it. The
+            # net-relationship classifier (check_cmd._net_relationship, #4127)
+            # is floating-aware and treats such collisions as different-net.
             net_name = net.name if net else f"net:{via.net_number}"
             drills.append((via.position, via.drill, net_name, "", net_name))
 
@@ -221,6 +227,12 @@ class DimensionRules(DRCRule):
                     )
                     abs_x = fp.position[0] + rotated_x
                     abs_y = fp.position[1] + rotated_y
+                    # As with vias above, every floating pad has net_number == 0
+                    # and net_name == "", so this fallback produces the same
+                    # "net:0" placeholder for all of them (they collide, not
+                    # distinct per-pad IDs). check_cmd._net_relationship is
+                    # floating-aware and classifies any such pair as
+                    # different-net (#4127).
                     net_name = pad.net_name if pad.net_name else f"net:{pad.net_number}"
                     drills.append(
                         (

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -1011,11 +1011,36 @@ class TestDrillClearanceNetRelationship:
 
         assert _net_relationship(("HALL_A", "GND")) == "different-net"
         assert _net_relationship(("HALL_A", "HALL_A")) == "same-net"
-        # Unnamed nets resolve to distinct net:<n> placeholders upstream.
+        # Two *distinct named* nets that happen to look like placeholders --
+        # NOT a floating-pad scenario (floating pads never get distinct
+        # per-pad numbers; they all resolve to the single "net:0" sentinel).
         assert _net_relationship(("net:3", "net:7")) == "different-net"
         # Not a pair -> nothing to compare.
         assert _net_relationship(()) is None
         assert _net_relationship(("only-one",)) is None
+
+    def test_net_relationship_floating_pins(self):
+        """Issue #4127: floating/unconnected pins never read as same-net.
+
+        Every genuinely unconnected pad/via resolves to the *same* ``net:0``
+        placeholder (net 0 is a single canonical no-net sentinel), so a naive
+        string equality would mislabel two distinct floating pins as same-net.
+        Any pair involving a floating endpoint must classify as different-net.
+        """
+        from kicad_tools.cli.check_cmd import _net_relationship
+
+        # Core regression: two distinct floating pins, both resolved to net:0,
+        # must NOT read as same-net.
+        assert _net_relationship(("net:0", "net:0")) == "different-net"
+        # Floating vs named (already correct today; keep it correct).
+        assert _net_relationship(("net:0", "GND")) == "different-net"
+        assert _net_relationship(("GND", "net:0")) == "different-net"
+        # Empty-string spelling of the no-net sentinel is also floating.
+        assert _net_relationship(("", "")) == "different-net"
+        assert _net_relationship(("", "GND")) == "different-net"
+        assert _net_relationship(("GND", "")) == "different-net"
+        # Named/named is unchanged -- the fix does not over-broaden.
+        assert _net_relationship(("GND", "GND")) == "same-net"
 
     def test_different_net_finding_shows_label_and_nets_default(self, capsys):
         """Default (non-verbose) output labels the pair and prints both nets."""
@@ -1076,6 +1101,32 @@ class TestDrillClearanceNetRelationship:
             self._violation(("HALL_A", "GND")),
             self._violation(("SIG", "GND")),
             self._violation(("GND", "GND")),
+        ]
+        for v in violations:
+            results.add(v)
+        results.rules_checked = 1
+
+        output_table(violations, results, Path("board.kicad_pcb"), "jlcpcb", 2, False)
+        out = capsys.readouterr().out
+        assert "dimension_drill_clearance: 3 errors (2 different-net, 1 same-net)" in out
+
+    def test_by_rule_summary_floating_pair_counts_as_different(self, capsys):
+        """Issue #4127: floating/floating pairs count as different-net in BY RULE.
+
+        The ``diff_n + same_n == errors`` invariant must hold after the fix:
+        1 floating/floating + 1 named-different + 1 named-same ->
+        (2 different-net, 1 same-net).
+        """
+        from pathlib import Path
+
+        from kicad_tools.cli.check_cmd import output_table
+        from kicad_tools.validate import DRCResults
+
+        results = DRCResults()
+        violations = [
+            self._violation(("net:0", "net:0")),  # floating/floating
+            self._violation(("HALL_A", "GND")),  # named-different
+            self._violation(("GND", "GND")),  # named-same
         ]
         for v in violations:
             results.add(v)


### PR DESCRIPTION
## Summary

`kct check`'s `dimension_drill_clearance` net-relationship classifier
(`_net_relationship` in `check_cmd.py`, added in #4102/#4114) misclassified
**floating-pin ↔ floating-pin** hole pairs as `same-net`. Every genuinely
unconnected pad/via resolves to the single canonical `net:0` no-net sentinel
(net 0 is one shared placeholder in the PCB net table — `self._nets[0] =
Net(0, "")` in `schema/pcb.py:1945` — not a per-pad unique ID), so two
distinct floating pins collided on the identical `"net:0"` string and the
naive `nets[0] == nets[1]` comparison read them as same-net. This is
electrically backwards: floating pins share no net identity, and a fab
drill-wall break between two floating pins is at least as much of a latent
short risk as a genuinely different-net pair. This was the root cause of the
chorus v23 26/23 vs hand-adjudicated 32/17 split.

## Changes

- **`check_cmd.py`**: new `_is_floating_net(net)` helper (matches `""` and
  `"net:0"`); `_net_relationship` now short-circuits to `different-net`
  whenever *either* endpoint is floating, before the named-net equality
  check. Two-bucket labels are unchanged so `output_table`'s
  `diff + same == errors` arithmetic is untouched. Corrected the stale
  docstring (which wrongly claimed unconnected pads get "distinct `net:<n>`
  placeholders") and the `_NET_RELATIONSHIP_RULE_IDS` comment block to
  document the `net:0` collision and the floating-aware rule.
- **`dimensions.py`**: comments near the via (line ~205) and pad (line ~224)
  `f"net:{...}"` fallbacks now accurately describe that all floating
  endpoints collide on the same `net:0` placeholder (no functional change).
- **`tests/test_cli_check.py`**: re-labeled the unrealistic `("net:3",
  "net:7")` case as *distinct named* nets (not a floating scenario); added
  `test_net_relationship_floating_pins` covering `("net:0","net:0")`,
  `("net:0","GND")`, `("","")`, `("","GND")` → `different-net` and
  `("GND","GND")` → `same-net`; added a BY RULE summary case proving the
  `diff + same == errors` invariant holds with a floating pair.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Floating/floating no longer same-net | ✅ | `_net_relationship(("net:0","net:0")) == "different-net"` asserted |
| Floating/named stays different-net | ✅ | `("net:0","GND")`, `("","GND")` asserted |
| Named/named unchanged (no over-broadening) | ✅ | `("GND","GND") == "same-net"` asserted |
| Empty-string sentinel treated as floating | ✅ | `("","")`, `("","GND")` asserted |
| Two-bucket arithmetic (`diff+same==errors`) intact | ✅ | new BY RULE test: 1 floating + 1 named-diff + 1 named-same → `(2 different-net, 1 same-net)` |
| No severity/verdict change (#4114/#2976 guard) | ✅ | only `_net_relationship`/labels touched; downgrade logic in `dimensions.py:251-253` untouched |
| Docstrings/comments corrected | ✅ | check_cmd.py docstring + comment block and dimensions.py fallback comments updated |

## Test Plan

- `uv run pytest tests/test_cli_check.py tests/test_validate_dimensions.py` → **99 passed** (dimensions.py at 100% coverage).
- `uv run ruff check` + `ruff format --check` on all 3 files → clean.
- `uv run --with mypy mypy --ignore-missing-imports` on both changed source files → `Success: no issues found`.

### Notes for reviewer

- **mypy baseline gate**: `scripts/ci/check_mypy_baseline.py` reports 10
  "new" errors here, but they are pre-existing environment artifacts
  (missing optional-dependency stubs: `mcp`, `cmaes`, `matplotlib`,
  `weasyprint`, plus unused-ignore comments) in files I did not touch. I
  confirmed the identical 10 errors appear on pristine `main` with my changes
  stashed. `mypy` is not installed in the project env, so the baseline was
  generated against a different (fuller) environment; a direct run over my
  two files is clean.
- **Chorus reconciliation (reasoning, not a CI gate)**: the fix moves
  floating-involved pairs from `same-net` → `different-net`, the direction
  consistent with the 26/23 → 32/17 hand count (chorus v23's 4-pin floating
  RPi-header cluster yields up to `C(4,2)=6` floating/floating pairs, and
  32 − 26 = 6). The `chorus-test-revA_v23_mfg.kicad_pcb` fixture is
  local-only and dangles in worktrees, so the live re-run could not be
  executed here; documenting the reasoning as validation, not a gate.

Closes #4127