### PR TITLE
fix(lcsc): reject cross-type LCSC value mismatches (resistor vs capacitor)

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 4127
-# Branch: feature/issue-4127
+# Issue: 4128
+# Branch: feature/issue-4128
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/src/kicad_tools/export/lcsc_value_check.py
+++ b/src/kicad_tools/export/lcsc_value_check.py
@@ -113,9 +113,16 @@ class ValueMismatch:
 
     def describe(self) -> str:
         """Human-readable one-line description."""
-        return (
+        base = (
             f"part value {self.candidate_value!r} does not match requested {self.requested_value!r}"
         )
+        # A NaN candidate SI marks a cross-type disagreement (e.g. a
+        # resistor request against a capacitor description, issue #4128):
+        # the two values are not numerically comparable, so flag the
+        # wrong component type explicitly.
+        if math.isnan(self.candidate_si):
+            return f"{base} (different component type)"
+        return base
 
 
 @dataclass(frozen=True)
@@ -361,16 +368,6 @@ def find_package_mismatch(
     )
 
 
-def _parse_requested(value: str, reference: str) -> tuple[float, ComponentType] | None:
-    """Parse the BOM-side requested value to (SI numeric, component type)."""
-    parsed = parse_component_value(value, reference)
-    if parsed.component_type not in _NUMERIC_TYPES:
-        return None
-    if parsed.numeric_value is None:
-        return None
-    return parsed.numeric_value, parsed.component_type
-
-
 def _extract_from_description(
     description: str, component_type: ComponentType
 ) -> tuple[float, str] | None:
@@ -426,6 +423,56 @@ def _extract_from_capacitor_mpn(text: str) -> tuple[float, str] | None:
     return farads, f"{human} (MPN code {m.group(1)}{m.group(2)})"
 
 
+def _description_dominant_type(
+    description: str, request_type: ComponentType
+) -> ComponentType | None:
+    """Detect a *foreign* component type dominating a free-text description.
+
+    Returns a :class:`ComponentType` other than ``request_type`` when the
+    description clearly parses as that type's primary value AND carries no
+    value token of ``request_type``'s own unit; otherwise ``None``.
+
+    This backstops the cross-type gap behind #3590/#3597 (issue #4128):
+    when a resistor-typed request (``330R``) is checked against a
+    capacitor description (``"100nF ... Capacitor"``), the ohm extractor
+    finds nothing -- previously read as "cannot validate, accept".  A
+    description that unambiguously states *another* component's value is
+    a different part, not an unvalidatable one, so it should reject.
+
+    The rule is deliberately conservative to avoid false rejects on
+    genuinely mixed-unit descriptions (RC networks, ferrite beads spec'd
+    in Ω-at-MHz, etc.):
+
+    - If the description matches ``request_type``'s own unit pattern, we
+      do NOT report a foreign type -- the same-type extractor already
+      handles it and any incidental foreign unit is not "dominant".
+    - Only when exactly one foreign numeric type's unit pattern matches
+      (and the request's own does not) is that type treated as dominant.
+      An ambiguous description matching two foreign types resolves to
+      ``None`` (cannot validate -- stay permissive).
+    """
+    if not description:
+        return None
+
+    request_pattern = _DESC_PATTERNS.get(request_type)
+    if request_pattern is not None and request_pattern.search(description):
+        # The description carries the request's own unit -- same-type
+        # comparison applies; do not treat any co-occurring unit as a
+        # dominating foreign type.
+        return None
+
+    foreign_types = [
+        ctype
+        for ctype, pattern in _DESC_PATTERNS.items()
+        if ctype is not request_type and pattern.search(description)
+    ]
+    if len(foreign_types) != 1:
+        # Zero foreign units -> genuinely cannot validate.
+        # Multiple foreign units -> ambiguous; stay permissive.
+        return None
+    return foreign_types[0]
+
+
 def find_value_mismatch(
     requested_value: str,
     reference: str,
@@ -450,10 +497,16 @@ def find_value_mismatch(
         A :class:`ValueMismatch` when both sides parse numerically and
         clearly disagree, otherwise ``None`` (match OR cannot validate).
     """
-    requested = _parse_requested(requested_value, reference)
-    if requested is None:
+    # Resolve the requested component type up front.  The type can be
+    # known even when the numeric value is not (e.g. "330R" parses as a
+    # RESISTOR with no SI value under the canonical parser) -- and the
+    # cross-type reject in issue #4128 only needs the type, since values
+    # of different types are not numerically comparable anyway.
+    parsed_request = parse_component_value(requested_value, reference)
+    if parsed_request.component_type not in _NUMERIC_TYPES:
         return None
-    requested_si, component_type = requested
+    component_type = parsed_request.component_type
+    requested_si: float | None = parsed_request.numeric_value
 
     candidate_si: float | None = None
     candidate_str = ""
@@ -482,7 +535,29 @@ def find_value_mismatch(
                 break
 
     if candidate_si is None:
+        # No same-type value found.  Before accepting as "cannot
+        # validate", check whether the description clearly states a
+        # *different* component type's value (issue #4128: a 330R
+        # resistor request validated against a "100nF ... Capacitor"
+        # description).  A dominating foreign unit means the candidate is
+        # a different part, so reject rather than accept.
+        foreign_type = _description_dominant_type(part_description, component_type)
+        if foreign_type is not None:
+            foreign = _extract_from_description(part_description, foreign_type)
+            candidate_str = foreign[1] if foreign is not None else foreign_type.value
+            return ValueMismatch(
+                requested_value=requested_value,
+                candidate_value=candidate_str,
+                requested_si=math.nan if requested_si is None else requested_si,
+                candidate_si=math.nan,
+            )
         return None  # cannot validate -- accept
+
+    # We have a same-type candidate value.  A numeric comparison needs a
+    # numeric request; if the request value did not parse numerically we
+    # cannot compare magnitudes -- accept (same type, unvalidatable).
+    if requested_si is None:
+        return None
 
     if math.isclose(requested_si, candidate_si, rel_tol=VALUE_REL_TOLERANCE):
         return None

--- a/tests/test_lcsc_value_guard.py
+++ b/tests/test_lcsc_value_guard.py
@@ -14,6 +14,7 @@ the three defense layers:
 from __future__ import annotations
 
 import logging
+import math
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -131,6 +132,70 @@ class TestFindValueMismatch:
 
     def test_unknown_candidate_accepts(self):
         assert find_value_mismatch("16nF", "C1", part_value="", part_description="") is None
+
+
+class TestCrossTypeMismatch:
+    """Cross-type rejection (issue #4128): a resistor request validated
+    against a capacitor description must reject, not accept as
+    "cannot validate"."""
+
+    def test_resistor_request_capacitor_description_rejected(self):
+        # The literal chorus v23 repro: 330R -> C1525 (a 100nF cap).
+        m = find_value_mismatch("330R", "R1", part_description=C1525.description)
+        assert m is not None
+        assert "100nF" in m.candidate_value
+        assert "different component type" in m.describe()
+
+    def test_resistor_request_synthetic_capacitor_rejected(self):
+        m = find_value_mismatch("330R", "R1", part_description="100nF X7R ±10% 0402 Capacitor")
+        assert m is not None
+        assert math.isnan(m.candidate_si)
+
+    def test_capacitor_request_resistor_description_rejected(self):
+        m = find_value_mismatch("16nF", "C10", part_description="62kΩ ±1% 0402 Resistor")
+        assert m is not None
+        assert "62k" in m.candidate_value or "62" in m.candidate_value
+
+    def test_capacitor_request_inductor_description_rejected(self):
+        m = find_value_mismatch("16nF", "C10", part_description="10uH ±20% 0805 Inductor")
+        assert m is not None
+        assert math.isnan(m.candidate_si)
+
+    def test_no_units_anywhere_stays_permissive(self):
+        # Genuine cannot-validate: description carries no unit tokens at
+        # all -> accept (unchanged behavior).
+        assert (
+            find_value_mismatch("330R", "R1", part_description="SOT-23 general purpose part")
+            is None
+        )
+
+    def test_same_type_description_not_treated_as_foreign(self):
+        # A resistor description validated against a resistor request:
+        # the ohm extractor handles it directly; not a cross-type reject.
+        assert find_value_mismatch("10k", "R1", part_description="10kΩ ±1% 0402") is None
+
+    def test_mixed_unit_description_does_not_false_reject(self):
+        # A plausible mixed-unit (RC-network-style) description that
+        # carries BOTH the request's own unit (Ω) and a foreign unit (F):
+        # the request's own unit is present, so this is a same-type
+        # comparison, NOT a cross-type reject.  330R matches "330Ω".
+        assert (
+            find_value_mismatch(
+                "330R",
+                "R1",
+                part_description="RC filter network 330Ω 100nF integrated 0402",
+            )
+            is None
+        )
+
+    def test_ambiguous_multi_foreign_description_stays_permissive(self):
+        # A resistor request whose description contains TWO foreign types
+        # (F and H) but not the request's own (Ω) is ambiguous -> stay
+        # permissive rather than guess which one dominates.
+        assert (
+            find_value_mismatch("330R", "R1", part_description="LC module 100nF 10uH combined 0805")
+            is None
+        )
 
 
 class TestMpnCodeFallback:


### PR DESCRIPTION
## Summary

`find_value_mismatch` in `export/lcsc_value_check.py` was component-type-aware for *parsing* but not for *cross-type checking*. A resistor-typed request (e.g. `330R`) validated against a capacitor description found zero ohm-pattern matches and treated that as "cannot validate, accept" instead of "different component type, reject". This let `bom_enrich`'s `_try_cache_fallback` replay a stale cache row assigning `330R → C1525` (a 100nF capacitor) — the exact chorus v23 recurrence, surviving the `#3590`/`#3597` validation layer that C1525 previously defeated.

## Changes

- Add `_description_dominant_type(description, request_type)`: returns a *foreign* numeric component type when the description clearly parses as that type's primary value AND carries none of the request's own unit. Deliberately conservative — if the request's own unit pattern is present, or if two-or-more foreign unit patterns match, it returns `None` (stay permissive) to avoid false rejects on RC networks / ferrite beads / mixed-unit specs.
- In `find_value_mismatch`, when no same-type candidate value is found, consult `_description_dominant_type` before accepting; a dominating foreign type yields a `ValueMismatch` (cross-type). `candidate_si=NaN` marks the cross-type case and `describe()` appends `(different component type)`.
- Resolve the requested component *type* independently of the numeric parse, so `330R` (parses as `RESISTOR` with `numeric_value=None` under the canonical parser) reaches the cross-type check instead of bailing at the top. Same-type comparisons with an unparseable request value stay permissive (accept).
- Removed the now-unused `_parse_requested` helper (its logic is inlined for the type-vs-numeric split).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `330R` vs `100nF ... Capacitor` → rejected | ✅ | `test_resistor_request_capacitor_description_rejected` (literal C1525 description) + `test_resistor_request_synthetic_capacitor_rejected` |
| Existing `#3590`/`#3597` tests unchanged & green | ✅ | `tests/test_lcsc_value_guard.py` + `tests/test_lcsc_package_guard.py` — 80 passed, no existing test modified |
| No-units-anywhere stays permissive | ✅ | `test_no_units_anywhere_stays_permissive` |
| Multi-unit description does not false-reject | ✅ | `test_mixed_unit_description_does_not_false_reject` (RC network with both Ω and F) + `test_ambiguous_multi_foreign_description_stays_permissive` |
| bom_enrich path unaffected | ✅ | `tests/test_bom_enrich.py` — 24 passed |

## Test Plan

- `pytest tests/test_lcsc_value_guard.py tests/test_lcsc_package_guard.py` → 80 passed
- `pytest tests/test_bom_enrich.py` → 24 passed
- `ruff check .` + `ruff format --check .` → clean
- `scripts/ci/check_mypy_baseline.py` → no new type errors (1496 within 1514 baseline); changed file has zero mypy errors

Closes #4128