### PR TITLE
test(parts): isolate lookup-path tests from a machine-local jlcparts catalog

### DIFF
--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -448,7 +448,13 @@ class TestLCSCClient:
             assert len(part.prices) == 2
 
     def test_lookup_not_found(self, tmp_path):
-        """Test part not found."""
+        """Test part not found.
+
+        The live API returns no data, so ``lookup`` yields ``None``.
+        ``use_local_catalog=False`` keeps this deterministic even when a real
+        jlcparts catalog is synced on the test machine (#4132) -- otherwise the
+        offline fallback would resolve the part and break the assertion.
+        """
         with patch("kicad_tools.parts.lcsc.LCSCClient._get_session") as mock_session:
             mock_resp = MagicMock()
             mock_resp.json.return_value = {"code": 200, "data": None}
@@ -457,7 +463,7 @@ class TestLCSCClient:
 
             from kicad_tools.parts import LCSCClient
 
-            client = LCSCClient(use_cache=False)
+            client = LCSCClient(use_cache=False, use_local_catalog=False)
             part = client.lookup("C999999")
 
             assert part is None
@@ -687,11 +693,18 @@ class TestLCSCClientExtended:
         assert client.timeout == 60.0
 
     def test_part_number_normalization(self, tmp_path):
-        """Test that part numbers are normalized to uppercase with C prefix."""
+        """Test that part numbers are normalized to uppercase with C prefix.
+
+        ``_fetch_part`` is mocked to return ``None``. ``use_local_catalog=False``
+        keeps this deterministic even when a real jlcparts catalog is synced on
+        the test machine (#4132) -- otherwise the offline fallback would resolve
+        the (real) part before ``_fetch_part`` was reached for the second
+        ``lookup`` call, breaking the ``assert_called_with`` check.
+        """
         from kicad_tools.parts import LCSCClient, PartsCache
 
         cache = PartsCache(db_path=tmp_path / "cache.db")
-        client = LCSCClient(cache=cache)
+        client = LCSCClient(cache=cache, use_local_catalog=False)
 
         with patch("kicad_tools.parts.lcsc.LCSCClient._fetch_part") as mock_fetch:
             mock_fetch.return_value = None
@@ -724,11 +737,18 @@ class TestLCSCClientExtended:
             assert part.mfr_part == "FreshPart"
 
     def test_lookup_api_error(self, tmp_path):
-        """Test handling of API errors."""
+        """Test handling of API errors.
+
+        ``_fetch_part`` raises, so ``lookup`` swallows the error and returns
+        ``None``. ``use_local_catalog=False`` keeps this deterministic even when
+        a real jlcparts catalog is synced on the test machine (#4132) --
+        otherwise the offline fallback would resolve the part and break the
+        assertion.
+        """
         from kicad_tools.parts import LCSCClient, PartsCache
 
         cache = PartsCache(db_path=tmp_path / "cache.db")
-        client = LCSCClient(cache=cache)
+        client = LCSCClient(cache=cache, use_local_catalog=False)
 
         with patch("kicad_tools.parts.lcsc.LCSCClient._fetch_part") as mock_fetch:
             mock_fetch.side_effect = Exception("Network error")


### PR DESCRIPTION
## Summary

Three tests in `tests/test_parts.py` fail on any machine that has a real
`~/.cache/kicad-tools/jlcparts.sqlite3` catalog synced (via `kct sync-catalog`)
and pass in CI only because CI has no catalog. They mock the live JLCPCB API to
fail/miss and assert `None` / a specific `_fetch_part` call, but
`LCSCClient.lookup()`'s offline-catalog fallback (shipped in #4117/#4131)
resolves the real part from disk, flipping the assertions.

Fix: pin the three `lookup()`-path tests to `use_local_catalog=False` — the exact
approach #4131 already applied to the two `search()`-path tests
(`test_search_error_handling`, `test_search_raises_forbidden_on_403`). This makes
the tests hermetic regardless of `~/.cache` contents. No assertions were changed.

Reproduced and verified on a machine with the 5.5 GB catalog present.

## Changes

- `TestLCSCClient::test_lookup_not_found` — add `use_local_catalog=False` (no-catalog "not found" contract).
- `TestLCSCClientExtended::test_lookup_api_error` — add `use_local_catalog=False` (API-error → `None` contract).
- `TestLCSCClientExtended::test_part_number_normalization` — add `use_local_catalog=False` (the catalog fall-through cached the real part, so the 2nd `lookup` hit the cache and skipped `_fetch_part`).
- Added a docstring note to each explaining the isolation, mirroring #4131.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Affected tests pass ON THIS MACHINE (catalog present) | ✅ | Installed `requests` to un-skip, catalog present: the 3 tests went 3 failed → 3 passed |
| Full `tests/parts/` + `tests/test_parts.py` pass with catalog present | ✅ | `183 passed` (requests installed, catalog on disk) |
| No other test breaks in the presence of a real catalog | ✅ | Empirical sweep: ran the full suites with `requests` installed and catalog present — only these 3 ever failed |
| Changes don't weaken assertions (none deleted) | ✅ | `git diff` shows zero `assert` lines added/removed/changed — only constructor kwargs + docstrings |
| No regression on the no-catalog (CI-like) path | ✅ | Without `requests`: `135 passed, 48 skipped` |

## Test Plan

```
# catalog present, requests installed (this machine):
uv run pytest tests/test_parts.py tests/parts/   # 183 passed
# CI-like (requests absent):
uv run pytest tests/test_parts.py tests/parts/   # 135 passed, 48 skipped
uv run ruff check tests/test_parts.py            # All checks passed!
uv run ruff format tests/test_parts.py --check   # already formatted
```

Closes #4132