### PR TITLE
fix(cost): parse R-notation resistor values (330R/4R7) so sub-kΩ parts rank correctly

### DIFF
--- a/src/kicad_tools/cost/alternatives.py
+++ b/src/kicad_tools/cost/alternatives.py
@@ -139,6 +139,10 @@ class AlternativePartFinder:
     RESISTOR_VALUE_PATTERN = re.compile(
         r"(\d+(?:\.\d+)?)\s*([kKmMgG]?)\s*(?:ohm|Ω)?", re.IGNORECASE
     )
+    # ``R``-as-decimal-point notation (IEC 60062): ``4R7`` -> 4.7, ``330R`` ->
+    # 330, ``4K7`` -> 4700. Anchored so it only fires on bare value tokens and
+    # never mis-consumes a longer free-text description.
+    RESISTOR_R_NOTATION_PATTERN = re.compile(r"^(\d+)([RKM])(\d*)$", re.IGNORECASE)
     CAPACITOR_VALUE_PATTERN = re.compile(r"(\d+(?:\.\d+)?)\s*([pnuμmfF]?)\s*[Ff]?", re.IGNORECASE)
     INDUCTOR_VALUE_PATTERN = re.compile(r"(\d+(?:\.\d+)?)\s*([pnuμmH]?)\s*[Hh]?", re.IGNORECASE)
 
@@ -758,6 +762,18 @@ class AlternativePartFinder:
 
     def _normalize_resistor_value(self, value: str) -> float | None:
         """Normalize resistor value to ohms."""
+        # Handle ``R``-as-decimal-point notation first (4R7 -> 4.7, 330R -> 330,
+        # 4K7 -> 4700). The generic RESISTOR_VALUE_PATTERN below leaves the ``R``
+        # unmatched and would mis-parse ``4R7`` as 4.0.
+        r_match = self.RESISTOR_R_NOTATION_PATTERN.match(value.strip())
+        if r_match:
+            whole = r_match.group(1)
+            unit = r_match.group(2).lower()
+            decimal = r_match.group(3)
+            num = float(f"{whole}.{decimal}") if decimal else float(whole)
+            r_multipliers = {"r": 1, "k": 1e3, "m": 1e6}
+            return num * r_multipliers.get(unit, 1)
+
         match = self.RESISTOR_VALUE_PATTERN.search(value)
         if not match:
             return None

--- a/src/kicad_tools/cost/suggest.py
+++ b/src/kicad_tools/cost/suggest.py
@@ -136,6 +136,15 @@ class SuggestionResult:
 RESISTOR_PATTERN = re.compile(
     r"^(\d+(?:\.\d+)?)\s*([kKmMgG]?)\s*([Ωohm]*)(?:\s+(\d+(?:\.\d+)?%?))?$", re.IGNORECASE
 )
+# ``R``-as-decimal-point notation for resistors, where ``R``/``K``/``M`` acts
+# as both the unit and the decimal separator (IEC 60062). Handles:
+#   - suffix ohms: ``330R`` -> 330, ``33R`` -> 33, ``470R`` -> 470
+#   - inline-decimal ohms: ``4R7`` -> 4.7, ``0R5`` -> 0.5
+#   - inline-decimal kilo/mega: ``4K7`` -> 4700, ``1M2`` -> 1_200_000
+# Optional trailing tolerance (e.g. ``330R 1%``) is captured in group 4.
+RESISTOR_R_NOTATION_PATTERN = re.compile(
+    r"^(\d+)([RKM])(\d*)(?:\s+(\d+(?:\.\d+)?%?))?$", re.IGNORECASE
+)
 CAPACITOR_PATTERN = re.compile(
     r"^(\d+(?:\.\d+)?)\s*([pnuμmµ]?)[fF]?(?:\s+(\d+[Vv]))?(?:\s+(\d+(?:\.\d+)?%?))?$",
     re.IGNORECASE,
@@ -311,23 +320,48 @@ def parse_component_value(value: str, reference: str = "") -> ParsedValue:
 
     # Parse resistor values
     if component_type == ComponentType.RESISTOR:
-        match = RESISTOR_PATTERN.match(value)
-        if match:
-            num = float(match.group(1))
-            multiplier = match.group(2).upper() if match.group(2) else ""
+        num: float | None = None
+        tolerance: str | None = None
 
-            if multiplier == "K":
+        # Try ``R``-as-decimal-point notation first (330R, 4R7, 4K7, ...).
+        # This must precede RESISTOR_PATTERN because the latter cannot match
+        # the trailing ``R`` and would otherwise leave the value unparsed,
+        # producing a package-only search that mis-ranks a generic value.
+        r_match = RESISTOR_R_NOTATION_PATTERN.match(value.strip())
+        if r_match:
+            whole = r_match.group(1)
+            unit = r_match.group(2).upper()
+            decimal = r_match.group(3)
+            # "4R7" -> 4.7, "330R" -> 330.0 (empty decimal treated as ".0")
+            num = float(f"{whole}.{decimal}") if decimal else float(whole)
+
+            if unit == "K":
                 num *= 1000
-            elif multiplier == "M":
+            elif unit == "M":
                 num *= 1_000_000
-            elif multiplier == "G":
-                num *= 1_000_000_000
 
+            tolerance = r_match.group(4)
+        else:
+            match = RESISTOR_PATTERN.match(value)
+            if match:
+                num = float(match.group(1))
+                multiplier = match.group(2).upper() if match.group(2) else ""
+
+                if multiplier == "K":
+                    num *= 1000
+                elif multiplier == "M":
+                    num *= 1_000_000
+                elif multiplier == "G":
+                    num *= 1_000_000_000
+
+                tolerance = match.group(4)
+
+        if num is not None:
             parsed.numeric_value = num
             parsed.unit = "Ω"
 
-            if match.group(4):
-                parsed.tolerance = match.group(4)
+            if tolerance:
+                parsed.tolerance = tolerance
 
             # Build search terms
             if num >= 1_000_000:

--- a/tests/cost/test_suggest.py
+++ b/tests/cost/test_suggest.py
@@ -79,6 +79,69 @@ class TestParseComponentValue:
         assert result.numeric_value == 1_000_000
         assert "1M" in result.search_terms
 
+    def test_resistor_330R(self):
+        """Test parsing sub-1kΩ suffix-R notation (330R -> 330 Ω)."""
+        result = parse_component_value("330R", "R1")
+        assert result.component_type == ComponentType.RESISTOR
+        assert result.numeric_value == 330.0
+        assert result.unit == "Ω"
+        assert "330" in result.search_terms
+
+    def test_resistor_33R(self):
+        """Test parsing sub-1kΩ suffix-R notation (33R -> 33 Ω)."""
+        result = parse_component_value("33R", "R7")
+        assert result.component_type == ComponentType.RESISTOR
+        assert result.numeric_value == 33.0
+        assert "33" in result.search_terms
+
+    def test_resistor_470R(self):
+        """Test parsing sub-1kΩ suffix-R notation (470R -> 470 Ω)."""
+        result = parse_component_value("470R", "R8")
+        assert result.component_type == ComponentType.RESISTOR
+        assert result.numeric_value == 470.0
+        assert "470" in result.search_terms
+
+    def test_resistor_4R7(self):
+        """Test parsing inline-decimal R notation (4R7 -> 4.7 Ω)."""
+        result = parse_component_value("4R7", "R1")
+        assert result.component_type == ComponentType.RESISTOR
+        assert result.numeric_value == pytest.approx(4.7)
+        assert result.unit == "Ω"
+        assert result.search_terms  # non-empty so value bonus can fire
+
+    def test_resistor_0R5(self):
+        """Test parsing sub-1Ω inline-decimal R notation (0R5 -> 0.5 Ω)."""
+        result = parse_component_value("0R5", "R2")
+        assert result.component_type == ComponentType.RESISTOR
+        assert result.numeric_value == pytest.approx(0.5)
+        assert result.search_terms
+
+    def test_resistor_4K7_inline(self):
+        """Test inline-decimal kilo notation (4K7 -> 4700 Ω)."""
+        result = parse_component_value("4K7", "R3")
+        assert result.component_type == ComponentType.RESISTOR
+        assert result.numeric_value == 4700
+        assert "4.7k" in result.search_terms
+
+    def test_resistor_330R_with_tolerance(self):
+        """Test R-notation with a trailing tolerance suffix (330R 1%)."""
+        result = parse_component_value("330R 1%", "R1")
+        assert result.component_type == ComponentType.RESISTOR
+        assert result.numeric_value == 330.0
+        assert result.tolerance == "1%"
+        assert "330" in result.search_terms
+
+    def test_resistor_330R_search_term_not_empty(self):
+        """Regression: sub-kΩ R-notation must yield a non-empty search term.
+
+        Previously ``330R`` failed to parse, leaving ``search_terms`` empty so
+        the ranker fell back to a package-only query and mis-ranked a 10kΩ part
+        (issue #4134).
+        """
+        result = parse_component_value("330R", "R1")
+        assert result.search_terms != []
+        assert result.numeric_value is not None
+
     def test_capacitor_100nF(self):
         """Test parsing 100nF capacitor value."""
         result = parse_component_value("100nF", "C1")


### PR DESCRIPTION
## Summary

`kct parts suggest` mis-ranked a generic 10 kΩ part first for small-value
resistors written in IEC-60062 `R`-as-decimal-point notation (`330R`, `33R`,
`470R`, `4R7`). The offline catalog resolved the right *type* and *footprint*
but the wrong ohm value.

Root cause: `RESISTOR_PATTERN` in `cost/suggest.py` has no `R`-notation
support, so `parse_component_value("330R", "R1")` returned `numeric_value=None`
and empty `search_terms`. `suggest_for_component` then issued a package-only
query and `_calculate_confidence` never applied its value-match bonus, leaving
value discrimination off entirely.

## Changes

- **`cost/suggest.py`**: add `RESISTOR_R_NOTATION_PATTERN` and try it before
  `RESISTOR_PATTERN` in the resistor branch. Handles suffix ohms (`330R`,
  `33R`, `470R`), inline-decimal ohms (`4R7` → 4.7, `0R5` → 0.5), and
  inline-decimal kilo/mega (`4K7` → 4700). Preserves the trailing tolerance
  capture (`330R 1%`). Return contract (`numeric_value`, `unit`,
  `search_terms`, `tolerance`) is unchanged; only parse coverage expands.
- **`cost/alternatives.py`**: fix the adjacent
  `_normalize_resistor_value`, whose unanchored `.search()` pattern silently
  mis-parsed `4R7` as `4.0`. Now normalizes `R`/`K`/`M` inline-decimal tokens
  correctly (`4R7` → 4.7).
- **`tests/cost/test_suggest.py`**: new `TestParseComponentValue` cases for
  `330R`, `33R`, `470R`, `4R7`, `0R5`, `4K7`, `330R 1%`, plus a regression
  guard asserting `search_terms` is non-empty for sub-kΩ `R`-notation.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `parse_component_value("330R").numeric_value == 330.0` | ✅ | new test `test_resistor_330R` |
| `parse_component_value("33R").numeric_value == 33.0` | ✅ | `test_resistor_33R` |
| `parse_component_value("470R").numeric_value == 470.0` | ✅ | `test_resistor_470R` |
| `parse_component_value("4R7") ≈ 4.7` | ✅ | `test_resistor_4R7` |
| Existing kΩ/MΩ/plain-ohm cases unchanged | ✅ | pre-existing tests still pass (10k→10000, 1M→1e6, 4.7k→4700, 100→100) |
| `search_terms` non-empty for sub-1kΩ R-notation | ✅ | `330R`→`["330"]` matches bare-ohm catalog descriptions (e.g. "330Ω"); `test_resistor_330R_search_term_not_empty` |
| Ranker discriminates by value, no 10kΩ fallback | ✅ | with `numeric_value` + non-empty `search_terms`, `_calculate_confidence`'s value-match bonus now fires for these values (previously never) |
| `0R5` sub-1Ω, tolerance suffix edge cases | ✅ | `test_resistor_0R5`, `test_resistor_330R_with_tolerance` |

## Test Plan

- `uv run pytest tests/cost/ tests/test_alternatives.py` — 65 passed
- `uv run pytest tests/cost/test_suggest.py` — 29 passed
- `uv run ruff check` + `ruff format --check` on all three changed files — clean
- Manual: `parse_component_value` returns correct ohms/terms for
  `330R/33R/470R/4R7/0R5/4K7/330R 1%`; `_normalize_resistor_value("4R7")` → 4.7
  (was 4.0)

Closes #4134