### PR TITLE
feat(sch): add fix-annotation command for hierarchy-aware power/flag repair

### DIFF
--- a/src/kicad_tools/cli/commands/schematic.py
+++ b/src/kicad_tools/cli/commands/schematic.py
@@ -29,7 +29,7 @@ def run_sch_command(args) -> int:
             " add-label, cleanup-wires, remove-wire, insert-inline,"
         )
         print("          disconnect, reconnect-pin, move-component, remove-component, re-annotate,")
-        print("          repair-instances")
+        print("          repair-instances, fix-annotation")
         return 1
 
     schematic_path = Path(args.schematic)
@@ -629,6 +629,17 @@ def run_sch_command(args) -> int:
             per_sheet=getattr(args, "per_sheet", False),
             format=getattr(args, "format", "text"),
             unannotated_only=getattr(args, "unannotated_only", False),
+        )
+
+    elif args.sch_command == "fix-annotation":
+        from ..sch_fix_annotation import run_fix_annotation
+
+        return run_fix_annotation(
+            schematic_path=schematic_path,
+            dry_run=getattr(args, "dry_run", False),
+            backup=getattr(args, "backup", True),
+            format=getattr(args, "format", "text"),
+            skip_net_check=getattr(args, "skip_net_check", False),
         )
 
     return 1

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1450,6 +1450,37 @@ def _add_sch_parser(subparsers) -> None:
         default="text",
     )
 
+    # sch fix-annotation
+    sch_fix_annotation = sch_subparsers.add_parser(
+        "fix-annotation",
+        help=(
+            "Hierarchy-aware power/flag annotation repair "
+            "(net-neutrality gated)"
+        ),
+    )
+    sch_fix_annotation.add_argument("schematic", help="Path to root .kicad_sch file")
+    sch_fix_annotation.add_argument(
+        "--dry-run",
+        "-n",
+        action="store_true",
+        help="Preview changes without modifying files",
+    )
+    sch_fix_annotation.add_argument(
+        "--backup",
+        action="store_true",
+        help="Create backup before modifying",
+    )
+    sch_fix_annotation.add_argument(
+        "--skip-net-check",
+        action="store_true",
+        help="Skip the net-neutrality gate (unsafe; e.g. no kicad-cli)",
+    )
+    sch_fix_annotation.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+    )
+
 
 def _add_pcb_parser(subparsers) -> None:
     """Add PCB subcommand parser with its subcommands."""

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1453,10 +1453,7 @@ def _add_sch_parser(subparsers) -> None:
     # sch fix-annotation
     sch_fix_annotation = sch_subparsers.add_parser(
         "fix-annotation",
-        help=(
-            "Hierarchy-aware power/flag annotation repair "
-            "(net-neutrality gated)"
-        ),
+        help=("Hierarchy-aware power/flag annotation repair (net-neutrality gated)"),
     )
     sch_fix_annotation.add_argument("schematic", help="Path to root .kicad_sch file")
     sch_fix_annotation.add_argument(

--- a/src/kicad_tools/cli/sch_fix_annotation.py
+++ b/src/kicad_tools/cli/sch_fix_annotation.py
@@ -1,0 +1,685 @@
+#!/usr/bin/env python3
+"""
+Hierarchy-aware power/flag-symbol annotation repair with a net-neutrality gate.
+
+This command walks a hierarchical KiCad schematic from its root and repairs
+power/flag-symbol annotation problems that ``kicad-cli`` reports as
+``schematic has annotation errors``:
+
+- Un-numbered, net-name-styled power refs (``#GNDD``, ``#+3.3V``, ``#+5V``,
+  ``#GNDA``) that neither ``re-annotate`` nor ``repair-instances`` recognize.
+- Duplicate power refs across the flattened hierarchy (e.g. ``#GNDD`` placed
+  in several sub-sheets).
+- Inconsistent zero-padding on numbered power refs (``#PWR40`` vs ``#PWR040``).
+- Missing ``(instances)`` blocks for power symbols.
+
+Every ``power:``-lib_id symbol whose reference is not already in the canonical
+``#PWR<dd>`` / ``#FLG<dd>`` shape is assigned a globally-unique designator.
+Real-component references (``R1``, ``C3``, ``U2``) are never touched.
+
+Because renumbering power symbols must be an electrically-neutral operation
+(power symbols connect by *value*, not by designator), the command exports the
+schematic netlist before and after the repair via ``kicad-cli`` and refuses to
+write if net membership changes.  The comparison translates the *before*
+snapshot's references through the rename mapping so a renamed symbol's own
+nodes are compared apples-to-apples.
+
+Usage:
+    # Preview the repair plan (no netlist gate, no writes)
+    kicad-tools sch fix-annotation root.kicad_sch --dry-run
+
+    # Repair in place (runs the net-neutrality gate first)
+    kicad-tools sch fix-annotation root.kicad_sch
+
+    # Repair with backups
+    kicad-tools sch fix-annotation root.kicad_sch --backup
+
+    # Repair without the net-neutrality gate (unsafe; e.g. no kicad-cli)
+    kicad-tools sch fix-annotation root.kicad_sch --skip-net-check
+"""
+
+import re
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+from kicad_tools.cli.export_netlist import Netlist, export_netlist, load_netlist
+from kicad_tools.cli.modify_schematic import create_backup
+from kicad_tools.cli.runner import find_kicad_cli
+from kicad_tools.cli.sch_re_annotate import (
+    _apply_uuid_reference_rename,
+    _detect_project_info,
+    _format_reference,
+    _parse_reference,
+)
+from kicad_tools.cli.sch_repair_instances import (
+    _find_sub_block_span,
+    _find_symbol_block,
+    _insert_project_instance,
+    _scan_symbol_children,
+)
+from kicad_tools.cli.sch_set_footprint import _collect_schematic_files
+
+# Whitespace token for regex: matches one or more tabs or spaces
+_WS = r"[ \t]+"
+
+# Canonical shapes for already-correct power/flag references: ``#PWR`` or
+# ``#FLG`` followed by two-or-more digits (KiCad zero-pads to at least two).
+_CANONICAL_POWER_RE = re.compile(r"^#(PWR|FLG)\d{2,}$")
+
+# Reference prefix chosen for a ``power:`` symbol.  Flag symbols (PWR_FLAG and
+# any lib_id containing ``FLAG``) get ``#FLG``; all other power symbols
+# (grounds and rails alike) get ``#PWR``, matching KiCad convention.
+_FLAG_PREFIX = "#FLG"
+_POWER_PREFIX = "#PWR"
+
+
+def _is_power_symbol(sym: dict) -> bool:
+    """Return True if *sym* is a KiCad power/flag symbol."""
+    return str(sym.get("lib_id", "")).startswith("power:")
+
+
+def _is_flag_symbol(sym: dict) -> bool:
+    """Return True if *sym* is a power *flag* symbol (gets ``#FLG``)."""
+    lib_id = str(sym.get("lib_id", ""))
+    return "FLAG" in lib_id.upper() or "PWR_FLAG" in lib_id.upper()
+
+
+def _power_prefix_for(sym: dict) -> str:
+    """Return the canonical reference prefix for a power/flag *sym*."""
+    return _FLAG_PREFIX if _is_flag_symbol(sym) else _POWER_PREFIX
+
+
+def _canonical_number(sym: dict) -> int | None:
+    """Return the canonical number a power/flag *sym* already holds, else None.
+
+    A reference is canonical only when it *exactly* round-trips through
+    ``_format_reference`` for the prefix appropriate to the symbol kind.  This
+    makes ``#PWR40`` canonical (number 40) but ``#PWR040`` non-canonical (that
+    number formats to ``#PWR40``, not ``#PWR040``), catching the inconsistent
+    zero-padding described in the issue.  Net-name-styled refs (``#GNDD``),
+    unpadded single digits (``#PWR2``), and family mismatches (a flag symbol
+    carrying ``#PWR01``) all return None.
+    """
+    ref = str(sym.get("reference", ""))
+    m = _CANONICAL_POWER_RE.match(ref)
+    if not m:
+        return None
+    number = int(ref[4:])
+    expected = _power_prefix_for(sym)
+    if _format_reference(expected, number) != ref:
+        return None
+    return number
+
+
+def _needs_reassignment(sym: dict) -> bool:
+    """Return True if a power/flag *sym*'s reference is not canonical."""
+    return _canonical_number(sym) is None
+
+
+def _existing_canonical_numbers(power_symbols: list[dict]) -> dict[str, set[int]]:
+    """Collect canonical numbers already in use, keyed by prefix.
+
+    Only references that are *already canonical and correctly-familied*
+    (i.e. would not be reassigned) reserve their number.  This lets the
+    assignment phase skip over numbers that established, correct symbols hold.
+    """
+    reserved: dict[str, set[int]] = {_POWER_PREFIX: set(), _FLAG_PREFIX: set()}
+    for sym in power_symbols:
+        number = _canonical_number(sym)
+        if number is None:
+            continue
+        reserved[_power_prefix_for(sym)].add(number)
+    return reserved
+
+
+def build_rename_plan(ordered_power_symbols: list[dict]) -> dict[str, dict]:
+    """Build the UUID-keyed rename plan for power/flag symbols.
+
+    *ordered_power_symbols* is the flattened, hierarchy-ordered list of
+    power/flag symbols (each dict as produced by
+    ``_extract_symbols_with_instance_info`` plus a ``uuid`` key).  Globally
+    unique ``#PWR<dd>`` / ``#FLG<dd>`` designators are assigned to every
+    symbol whose reference is not already canonical, skipping numbers held by
+    canonical symbols so no collision is introduced.
+
+    Returns a dict mapping symbol UUID -> ``{"old": str, "new": str}`` for
+    every symbol that actually changes reference (identity renames are
+    omitted).
+    """
+    reserved = _existing_canonical_numbers(ordered_power_symbols)
+    counters: dict[str, int] = {_POWER_PREFIX: 1, _FLAG_PREFIX: 1}
+
+    def _next(prefix: str) -> int:
+        n = counters[prefix]
+        while n in reserved[prefix]:
+            n += 1
+        reserved[prefix].add(n)
+        counters[prefix] = n + 1
+        return n
+
+    plan: dict[str, dict] = {}
+    for sym in ordered_power_symbols:
+        if not _needs_reassignment(sym):
+            continue
+        prefix = _power_prefix_for(sym)
+        new_ref = _format_reference(prefix, _next(prefix))
+        old_ref = str(sym["reference"])
+        if old_ref == new_ref:
+            continue
+        plan[str(sym["uuid"])] = {"old": old_ref, "new": new_ref}
+    return plan
+
+
+def _net_membership(netlist: Netlist) -> dict[frozenset[tuple[str, str]], int]:
+    """Build a value-independent net-membership snapshot.
+
+    Each net becomes a frozenset of ``(reference, pin)`` tuples; we key the
+    snapshot on that membership set (counting duplicates) rather than on the
+    net's display name/code, since renumbering can legitimately change a net's
+    name while leaving the electrical grouping intact.
+
+    Returns a multiset ``{membership_frozenset: count}``.
+    """
+    snapshot: dict[frozenset[tuple[str, str]], int] = {}
+    for net in netlist.nets:
+        membership = frozenset((node.reference, node.pin) for node in net.nodes)
+        snapshot[membership] = snapshot.get(membership, 0) + 1
+    return snapshot
+
+
+def _translate_membership(
+    snapshot: dict[frozenset[tuple[str, str]], int],
+    ref_rename: dict[str, str],
+) -> dict[frozenset[tuple[str, str]], int]:
+    """Translate a ``before`` snapshot's references through *ref_rename*.
+
+    *ref_rename* maps old reference string -> new reference string.  Every
+    ``(reference, pin)`` tuple whose reference was renamed is rewritten so the
+    ``before`` snapshot can be compared against the ``after`` snapshot without
+    spurious diffs on the renamed symbols' own nodes.
+    """
+    translated: dict[frozenset[tuple[str, str]], int] = {}
+    for membership, count in snapshot.items():
+        new_membership = frozenset((ref_rename.get(ref, ref), pin) for (ref, pin) in membership)
+        translated[new_membership] = translated.get(new_membership, 0) + count
+    return translated
+
+
+def diff_net_membership(
+    before: Netlist,
+    after: Netlist,
+    ref_rename: dict[str, str],
+) -> list[str]:
+    """Return a human-readable list of net-membership differences.
+
+    Empty list means the repair was net-neutral.  The *before* snapshot's
+    references are translated through *ref_rename* first so a renamed power
+    symbol's own nodes compare equal.
+    """
+    before_snap = _translate_membership(_net_membership(before), ref_rename)
+    after_snap = _net_membership(after)
+
+    diffs: list[str] = []
+
+    def _fmt(membership: frozenset[tuple[str, str]]) -> str:
+        return "{" + ", ".join(sorted(f"{r}.{p}" for r, p in membership)) + "}"
+
+    for membership, count in sorted(before_snap.items(), key=lambda kv: _fmt(kv[0])):
+        after_count = after_snap.get(membership, 0)
+        if after_count < count:
+            diffs.append(f"  REMOVED (x{count - after_count}): {_fmt(membership)}")
+    for membership, count in sorted(after_snap.items(), key=lambda kv: _fmt(kv[0])):
+        before_count = before_snap.get(membership, 0)
+        if before_count < count:
+            diffs.append(f"  ADDED   (x{count - before_count}): {_fmt(membership)}")
+
+    return diffs
+
+
+def _update_instance_reference(text: str, sym_uuid: str, new_ref: str) -> str:
+    """Update every ``(reference "...")`` inside a symbol's ``(instances)`` block.
+
+    Used when a power symbol is renamed but already carries a well-formed
+    instance for the project — the stale designator inside its instances block
+    must be brought into line with the new ``(property "Reference")`` value.
+    """
+    bounds = _find_symbol_block(text, sym_uuid)
+    if bounds is None:
+        return text
+    start, end = bounds
+    block = text[start:end]
+
+    instances_span, _ = _scan_symbol_children(block)
+    if instances_span is None:
+        return text
+    inst_start, inst_end = instances_span
+    inst_text = block[inst_start:inst_end]
+    new_inst_text = re.sub(
+        r'(\(reference ")[^"]+(")',
+        r"\g<1>" + new_ref + r"\g<2>",
+        inst_text,
+    )
+    new_block = block[:inst_start] + new_inst_text + block[inst_end:]
+    return text[:start] + new_block + text[end:]
+
+
+def _apply_plan_to_texts(
+    all_files: list[Path],
+    file_texts: dict[Path, str],
+    file_symbols: dict[Path, list[dict]],
+    plan: dict[str, dict],
+    project_name: str,
+    file_instance_paths: dict[Path, str],
+) -> dict[Path, str]:
+    """Apply the rename plan + instance-block repair to in-memory buffers.
+
+    Returns a map of file -> modified text for every file that changed.
+    Files whose power symbols need no change are omitted.
+    """
+    modified: dict[Path, str] = {}
+
+    for sch_file in all_files:
+        text = file_texts[sch_file]
+        syms = file_symbols[sch_file]
+        instance_path = file_instance_paths.get(sch_file, "")
+        current = text
+        changed = False
+
+        for sym in syms:
+            if not _is_power_symbol(sym):
+                continue
+            uuid = str(sym["uuid"])
+            entry = plan.get(uuid)
+            new_ref = entry["new"] if entry else str(sym["reference"])
+
+            # Rename the (property "Reference") value (only when the plan
+            # changes it).
+            if entry:
+                current = _apply_uuid_reference_rename(current, uuid, new_ref)
+                changed = True
+
+            # Ensure a correct (instances) block exists.  A power symbol needs
+            # one when it has none, points at the wrong project, or carries
+            # loose sibling project blocks.
+            needs_instance = (
+                not sym.get("has_project_instance")
+                or sym.get("has_wrong_project")
+                or sym.get("has_loose_project_blocks")
+            )
+            if needs_instance and instance_path:
+                current = _insert_project_instance(
+                    current,
+                    uuid,
+                    project_name,
+                    instance_path,
+                    new_ref,
+                    replace_wrong_project=bool(sym.get("has_wrong_project")),
+                    repair_loose_blocks=bool(sym.get("has_loose_project_blocks")),
+                )
+                changed = True
+            elif entry and sym.get("has_project_instance"):
+                # Renamed a symbol that already has a well-formed instance for
+                # this project — the (reference "OLD") inside its instances
+                # block is now stale and must be updated to the new ref, else
+                # kicad-cli keeps reporting the old designator.
+                current = _update_instance_reference(current, uuid, new_ref)
+                changed = True
+
+        if changed:
+            modified[sch_file] = current
+
+    return modified
+
+
+def _run_net_gate(
+    schematic_path: Path,
+    all_files: list[Path],
+    modified_files: dict[Path, str],
+    ref_rename: dict[str, str],
+    kicad_cli: Path,
+) -> tuple[bool, list[str]]:
+    """Run the net-neutrality gate.
+
+    Exports the netlist from the unmodified tree, then from a temporary copy
+    of the hierarchy with *modified_files* applied, and diffs net membership
+    (translating the before snapshot through *ref_rename*).
+
+    Returns ``(is_neutral, diffs)``.  ``is_neutral`` is False when an export
+    fails (fail-closed) or when net membership changed.
+    """
+    # 1. Netlist of the current on-disk (unmodified) tree.
+    with tempfile.TemporaryDirectory() as before_dir:
+        before_out = Path(before_dir) / "before.net"
+        ok, err = export_netlist(schematic_path, before_out, kicad_cli)
+        if not ok:
+            return False, [f"  netlist export (before) failed: {err}"]
+        before_netlist = load_netlist(before_out)
+
+    # 2. Copy the hierarchy to a temp dir, apply modifications, export.
+    with tempfile.TemporaryDirectory() as work_dir:
+        work_root = Path(work_dir)
+        root_dir = schematic_path.parent
+        file_map: dict[Path, Path] = {}
+        for sch_file in all_files:
+            rel = sch_file.resolve().relative_to(root_dir.resolve())
+            dest = work_root / rel
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            if sch_file in modified_files:
+                dest.write_text(modified_files[sch_file], encoding="utf-8")
+            else:
+                shutil.copy2(sch_file, dest)
+            file_map[sch_file] = dest
+
+        after_out = work_root / "after.net"
+        ok, err = export_netlist(file_map[schematic_path], after_out, kicad_cli)
+        if not ok:
+            return False, [f"  netlist export (after) failed: {err}"]
+        after_netlist = load_netlist(after_out)
+
+    diffs = diff_net_membership(before_netlist, after_netlist, ref_rename)
+    return (len(diffs) == 0), diffs
+
+
+def run_fix_annotation(
+    schematic_path: Path,
+    dry_run: bool = False,
+    backup: bool = True,
+    format: str = "text",
+    skip_net_check: bool = False,
+) -> int:
+    """Run hierarchy-aware power/flag annotation repair.
+
+    Args:
+        schematic_path: Path to the *root* .kicad_sch file.
+        dry_run: If True, print the plan and make no changes (the
+            net-neutrality gate is not run, since nothing is written).
+        backup: If True, create ``.bak`` backups before writing.
+        format: Output format ("text" or "json").
+        skip_net_check: If True, skip the net-neutrality gate (unsafe;
+            for environments without kicad-cli).
+
+    Returns:
+        0 on success, 1 on error, 2 if the net-neutrality gate fails.
+    """
+    if not schematic_path.exists():
+        print(f"Error: File not found: {schematic_path}", file=sys.stderr)
+        return 1
+
+    all_files = _collect_schematic_files(schematic_path)
+    if not all_files:
+        print("Error: No schematic files found", file=sys.stderr)
+        return 1
+
+    project_name, root_uuid, file_instance_paths = _detect_project_info(schematic_path, all_files)
+    if not root_uuid:
+        print(
+            "Error: Could not detect project UUID from root schematic",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Phase 1: collect symbols across the hierarchy.
+    file_texts: dict[Path, str] = {}
+    file_symbols: dict[Path, list[dict]] = {}
+    for sch_file in all_files:
+        try:
+            text = sch_file.read_text(encoding="utf-8")
+        except OSError as e:
+            print(f"Error reading {sch_file}: {e}", file=sys.stderr)
+            return 1
+        file_texts[sch_file] = text
+        file_symbols[sch_file] = _extract_all_symbols(text, project_name)
+
+    # Phase 2: build the global rename plan (hierarchy-ordered).
+    ordered_power: list[dict] = []
+    for sch_file in all_files:
+        ordered_power.extend(s for s in file_symbols[sch_file] if _is_power_symbol(s))
+
+    plan = build_rename_plan(ordered_power)
+
+    # Identify power symbols that only need an instances-block repair (no
+    # rename) so we report/act on them too.
+    instance_only: list[dict] = []
+    for sch_file in all_files:
+        for sym in file_symbols[sch_file]:
+            if not _is_power_symbol(sym):
+                continue
+            if str(sym["uuid"]) in plan:
+                continue
+            if (
+                not sym.get("has_project_instance")
+                or sym.get("has_wrong_project")
+                or sym.get("has_loose_project_blocks")
+            ):
+                instance_only.append(sym)
+
+    if not plan and not instance_only:
+        if format == "json":
+            import json
+
+            print(json.dumps({"renames": [], "total": 0, "dry_run": dry_run}))
+        else:
+            print("No power/flag annotation errors found.")
+        return 0
+
+    # Phase 3: report the plan.
+    ref_rename = {info["old"]: info["new"] for info in plan.values()}
+    if format == "json":
+        import json
+
+        output = {
+            "renames": [
+                {"old": info["old"], "new": info["new"], "uuid": uid}
+                for uid, info in sorted(plan.items(), key=lambda x: x[1]["new"])
+            ],
+            "instance_only": len(instance_only),
+            "total": len(plan),
+            "dry_run": dry_run,
+        }
+        print(json.dumps(output, indent=2))
+    else:
+        print(
+            f"Power/flag annotation plan ({len(plan)} rename(s), "
+            f"{len(instance_only)} instance-only repair(s)):"
+        )
+        print()
+        for uid, info in sorted(plan.items(), key=lambda x: x[1]["new"]):
+            print(f"    {info['old']} -> {info['new']}")
+        if instance_only:
+            print()
+            print("  Instance-block repairs (no rename):")
+            for sym in instance_only:
+                print(f"    {sym['reference']}  ({sym['lib_id']})")
+        print()
+
+    if dry_run:
+        if format == "text":
+            print("Dry run: no changes made.")
+        return 0
+
+    # Phase 4: apply changes to in-memory buffers.
+    modified_files = _apply_plan_to_texts(
+        all_files,
+        file_texts,
+        file_symbols,
+        plan,
+        project_name,
+        file_instance_paths,
+    )
+
+    if not modified_files:
+        if format == "text":
+            print("No files needed modification.")
+        return 0
+
+    # Phase 5: net-neutrality gate.
+    if not skip_net_check:
+        kicad_cli = find_kicad_cli()
+        if kicad_cli is None:
+            print(
+                "Error: kicad-cli not found — required for the net-neutrality "
+                "gate.\nInstall KiCad 8+ (https://www.kicad.org/download/) or "
+                "re-run with --skip-net-check to proceed WITHOUT the safety "
+                "gate (unsafe).",
+                file=sys.stderr,
+            )
+            return 1
+
+        is_neutral, diffs = _run_net_gate(
+            schematic_path, all_files, modified_files, ref_rename, kicad_cli
+        )
+        if not is_neutral:
+            print(
+                "Net-neutrality gate FAILED: net membership would change. No files written.",
+                file=sys.stderr,
+            )
+            for line in diffs:
+                print(line, file=sys.stderr)
+            return 2
+        if format == "text":
+            print("Net-neutrality gate passed (net membership unchanged).")
+    elif format == "text":
+        print("WARNING: --skip-net-check set; net-neutrality NOT verified.")
+
+    # Phase 6: write the modified files.
+    for sch_file, new_text in modified_files.items():
+        if backup:
+            bak = create_backup(sch_file)
+            if format == "text":
+                print(f"  Backup: {bak.name}")
+        try:
+            sch_file.write_text(new_text, encoding="utf-8")
+        except OSError as e:
+            print(f"Error writing {sch_file}: {e}", file=sys.stderr)
+            return 1
+
+    if format == "text":
+        print(f"Repaired {len(plan)} power/flag reference(s) across {len(modified_files)} file(s).")
+
+    return 0
+
+
+def _extract_all_symbols(text: str, project_name: str) -> list[dict]:
+    """Extract *all* symbols from *text* with per-project instance metadata.
+
+    This mirrors ``sch_repair_instances._extract_symbols_with_instance_info``
+    but deliberately does **not** skip well-formed power symbols — the
+    fix-annotation workflow needs every ``power:`` symbol so it can renumber
+    malformed refs and detect the ones missing instance blocks.  It reuses the
+    same structural scanners (``_scan_symbol_children`` / ``_find_sub_block_span``)
+    for symbol boundaries and instance-state classification.
+
+    Each returned dict carries: reference, prefix, number, unit_suffix, lib_id,
+    uuid, has_project_instance, has_wrong_project, has_loose_project_blocks,
+    and loose_project_blocks — computed relative to *project_name*.
+    """
+    symbols: list[dict] = []
+    ref_pattern = re.compile(r'\(property "Reference" "([^"]+)"')
+    start_pattern = re.compile(
+        r"(?:^|\n)(" + _WS + r")\(symbol\n" + _WS + r'\(lib_id "([^"]+)"\)',
+        re.DOTALL,
+    )
+
+    for start_match in start_pattern.finditer(text):
+        lib_id = start_match.group(2)
+        paren_start = text.index("(symbol", start_match.start())
+        block_end = _find_sub_block_span(text, paren_start)
+        block = text[paren_start:block_end]
+
+        ref_match = ref_pattern.search(block)
+        if not ref_match:
+            continue
+        ref = ref_match.group(1)
+
+        instances_span, loose_projects = _scan_symbol_children(block)
+        has_instances_block = instances_span is not None
+        if instances_span is not None:
+            inst_start, inst_end = instances_span
+            has_project = f'(project "{project_name}"' in block[inst_start:inst_end]
+        else:
+            has_project = False
+        has_loose_project_blocks = bool(loose_projects)
+        has_wrong_project = has_instances_block and not has_project and not has_loose_project_blocks
+
+        # Locate the symbol-level uuid (the last uuid not inside a (pin ...)).
+        all_uuids = list(re.finditer(r'\(uuid "([^"]+)"\)', block))
+        sym_uuid = ""
+        for uuid_m in reversed(all_uuids):
+            preceding = block[: uuid_m.start()]
+            last_paren_close = preceding.rfind(")")
+            last_pin_open = preceding.rfind("(pin ")
+            if last_pin_open > last_paren_close:
+                continue
+            sym_uuid = uuid_m.group(1)
+            break
+        if not sym_uuid and all_uuids:
+            sym_uuid = all_uuids[-1].group(1)
+
+        prefix, number, unit_suffix = _parse_reference(ref)
+
+        symbols.append(
+            {
+                "reference": ref,
+                "prefix": prefix,
+                "number": number,
+                "unit_suffix": unit_suffix,
+                "lib_id": lib_id,
+                "uuid": sym_uuid,
+                "has_project_instance": has_project,
+                "has_wrong_project": has_wrong_project,
+                "has_loose_project_blocks": has_loose_project_blocks,
+                "loose_project_blocks": loose_projects,
+            }
+        )
+
+    return symbols
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description=("Hierarchy-aware power/flag annotation repair with a net-neutrality gate"),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("schematic", type=Path, help="Path to root .kicad_sch file")
+    parser.add_argument(
+        "--dry-run",
+        "-n",
+        action="store_true",
+        help="Preview changes without modifying files",
+    )
+    parser.add_argument(
+        "--backup",
+        action="store_true",
+        help="Create backup before modifying",
+    )
+    parser.add_argument(
+        "--skip-net-check",
+        action="store_true",
+        help="Skip the net-neutrality gate (unsafe; e.g. no kicad-cli)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+
+    args = parser.parse_args(argv)
+
+    return run_fix_annotation(
+        schematic_path=args.schematic,
+        dry_run=args.dry_run,
+        backup=args.backup,
+        format=args.format,
+        skip_net_check=args.skip_net_check,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_sch_fix_annotation.py
+++ b/tests/test_sch_fix_annotation.py
@@ -1,0 +1,549 @@
+"""Tests for the sch fix-annotation command.
+
+Covers hierarchy-aware power/flag-symbol annotation repair:
+
+- Net-name-styled power refs (#GNDD, #+3.3V) get canonical #PWR0xx designators.
+- Duplicate power refs across sheets get distinct, non-conflicting numbers.
+- Inconsistent zero-padding (#PWR40 vs #PWR040) is normalized.
+- Missing (instances) blocks are created with the correct project + path.
+- The net-neutrality gate detects membership changes (mocked at the
+  netlist boundary, decoupled from kicad-cli availability).
+- --dry-run makes no changes; --backup creates .bak files.
+- Real component refs (R1, C3) are left untouched.
+
+Fixtures are synthetic multi-sheet schematics built in this file — the
+chorus design referenced by the issue is local-only and unavailable in CI.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.export_netlist import Net, Netlist, NetNode
+from kicad_tools.cli.runner import find_kicad_cli
+from kicad_tools.cli.sch_fix_annotation import (
+    _extract_all_symbols,
+    _is_flag_symbol,
+    _is_power_symbol,
+    _needs_reassignment,
+    build_rename_plan,
+    diff_net_membership,
+    run_fix_annotation,
+)
+
+# ---------------------------------------------------------------------------
+# Synthetic hierarchical fixtures
+# ---------------------------------------------------------------------------
+
+ROOT_UUID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+SUB_SHEET_UUID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+
+def _root_schematic(*symbol_blocks: str) -> str:
+    """Build a root schematic containing *symbol_blocks* plus a sub-sheet."""
+    body = "\n".join(symbol_blocks)
+    return f"""\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "{ROOT_UUID}")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+{body}
+\t(sheet
+\t\t(at 150 50)
+\t\t(size 20 15)
+\t\t(uuid "{SUB_SHEET_UUID}")
+\t\t(property "Sheetname" "sub"
+\t\t\t(at 150 49 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Sheetfile" "sub.kicad_sch"
+\t\t\t(at 150 65.5 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t)
+)
+"""
+
+
+def _sub_schematic(*symbol_blocks: str) -> str:
+    body = "\n".join(symbol_blocks)
+    return f"""\
+(kicad_sch
+\t(version 20231120)
+\t(generator "test")
+\t(generator_version "8.0")
+\t(uuid "cccccccc-cccc-cccc-cccc-cccccccccccc")
+\t(paper "A4")
+\t(lib_symbols
+\t)
+{body}
+)
+"""
+
+
+def _power_symbol_no_instance(lib_id: str, ref: str, uuid: str) -> str:
+    """A power symbol with a net-name-styled ref and NO (instances) block."""
+    return f"""\
+\t(symbol
+\t\t(lib_id "{lib_id}")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "{ref}"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "{lib_id.split(":", 1)[1]}"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(pin "1"
+\t\t\t(uuid "pin-{uuid}")
+\t\t)
+\t\t(uuid "{uuid}")
+\t)"""
+
+
+def _power_symbol_with_instance(lib_id: str, ref: str, uuid: str, project: str, path: str) -> str:
+    """A power symbol with a correct (instances) block for *project*."""
+    return f"""\
+\t(symbol
+\t\t(lib_id "{lib_id}")
+\t\t(at 100 50 0)
+\t\t(property "Reference" "{ref}"
+\t\t\t(at 100 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "{lib_id.split(":", 1)[1]}"
+\t\t\t(at 100 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(pin "1"
+\t\t\t(uuid "pin-{uuid}")
+\t\t)
+\t\t(uuid "{uuid}")
+\t\t(instances
+\t\t\t(project "{project}"
+\t\t\t\t(path "{path}"
+\t\t\t\t\t(reference "{ref}")
+\t\t\t\t\t(unit 1)
+\t\t\t\t)
+\t\t\t)
+\t\t)
+\t)"""
+
+
+def _real_component(lib_id: str, ref: str, value: str, uuid: str) -> str:
+    return f"""\
+\t(symbol
+\t\t(lib_id "{lib_id}")
+\t\t(at 120 50 0)
+\t\t(property "Reference" "{ref}"
+\t\t\t(at 120 48 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(property "Value" "{value}"
+\t\t\t(at 120 52 0)
+\t\t\t(effects (font (size 1.27 1.27)))
+\t\t)
+\t\t(pin "1"
+\t\t\t(uuid "pin-a-{uuid}")
+\t\t)
+\t\t(pin "2"
+\t\t\t(uuid "pin-b-{uuid}")
+\t\t)
+\t\t(uuid "{uuid}")
+\t\t(instances
+\t\t\t(project "root"
+\t\t\t\t(path "/{ROOT_UUID}"
+\t\t\t\t\t(reference "{ref}")
+\t\t\t\t\t(unit 1)
+\t\t\t\t)
+\t\t\t)
+\t\t)
+\t)"""
+
+
+# ---------------------------------------------------------------------------
+# Classification helpers
+# ---------------------------------------------------------------------------
+
+
+class TestClassification:
+    def test_is_power_symbol(self):
+        assert _is_power_symbol({"lib_id": "power:GND"})
+        assert _is_power_symbol({"lib_id": "power:+3.3V"})
+        assert not _is_power_symbol({"lib_id": "Device:R"})
+
+    def test_is_flag_symbol(self):
+        assert _is_flag_symbol({"lib_id": "power:PWR_FLAG"})
+        assert not _is_flag_symbol({"lib_id": "power:GND"})
+
+    def test_net_name_styled_needs_reassignment(self):
+        assert _needs_reassignment({"lib_id": "power:GNDD", "reference": "#GNDD"})
+        assert _needs_reassignment({"lib_id": "power:+3.3V", "reference": "#+3.3V"})
+
+    def test_unpadded_needs_reassignment(self):
+        # Single-digit / unpadded numbers are not canonical (KiCad zero-pads).
+        assert _needs_reassignment({"lib_id": "power:GND", "reference": "#PWR2"})
+
+    def test_canonical_ref_ok(self):
+        assert not _needs_reassignment({"lib_id": "power:GND", "reference": "#PWR01"})
+        assert not _needs_reassignment({"lib_id": "power:PWR_FLAG", "reference": "#FLG03"})
+
+    def test_family_mismatch_needs_reassignment(self):
+        # A flag symbol carrying a #PWR ref is wrong; a ground symbol carrying
+        # a #FLG ref is wrong.
+        assert _needs_reassignment({"lib_id": "power:PWR_FLAG", "reference": "#PWR01"})
+        assert _needs_reassignment({"lib_id": "power:GND", "reference": "#FLG01"})
+
+
+# ---------------------------------------------------------------------------
+# Symbol extraction (all symbols, power not skipped)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractAllSymbols:
+    def test_extracts_power_symbol_without_instances(self):
+        text = _sub_schematic(
+            _power_symbol_no_instance("power:GND", "#GNDD", "u-gnd-1"),
+        )
+        syms = _extract_all_symbols(text, "root")
+        assert len(syms) == 1
+        assert syms[0]["reference"] == "#GNDD"
+        assert syms[0]["lib_id"] == "power:GND"
+        assert syms[0]["has_project_instance"] is False
+
+    def test_detects_correct_instance(self):
+        text = _sub_schematic(
+            _power_symbol_with_instance("power:GND", "#PWR01", "u-gnd-2", "root", f"/{ROOT_UUID}"),
+        )
+        syms = _extract_all_symbols(text, "root")
+        assert len(syms) == 1
+        assert syms[0]["has_project_instance"] is True
+
+    def test_detects_wrong_project(self):
+        text = _sub_schematic(
+            _power_symbol_with_instance("power:GND", "#PWR01", "u-gnd-3", "other", f"/{ROOT_UUID}"),
+        )
+        syms = _extract_all_symbols(text, "root")
+        assert syms[0]["has_project_instance"] is False
+        assert syms[0]["has_wrong_project"] is True
+
+
+# ---------------------------------------------------------------------------
+# Rename plan
+# ---------------------------------------------------------------------------
+
+
+class TestBuildRenamePlan:
+    def _power(self, lib_id, ref, uuid):
+        return {"lib_id": lib_id, "reference": ref, "uuid": uuid}
+
+    def test_net_name_styled_gets_canonical(self):
+        plan = build_rename_plan(
+            [self._power("power:GND", "#GNDD", "u1")],
+        )
+        assert plan["u1"]["new"] == "#PWR01"
+
+    def test_duplicate_refs_get_distinct_numbers(self):
+        plan = build_rename_plan(
+            [
+                self._power("power:GND", "#GNDD", "u1"),
+                self._power("power:GND", "#GNDD", "u2"),
+            ],
+        )
+        assert plan["u1"]["new"] == "#PWR01"
+        assert plan["u2"]["new"] == "#PWR02"
+        assert plan["u1"]["new"] != plan["u2"]["new"]
+
+    def test_canonical_numbers_reserved(self):
+        # An existing correct #PWR01 must not collide with a fresh assignment.
+        plan = build_rename_plan(
+            [
+                self._power("power:GND", "#PWR01", "u_ok"),  # canonical, kept
+                self._power("power:+3.3V", "#+3.3V", "u_new"),  # needs number
+            ],
+        )
+        assert "u_ok" not in plan  # unchanged
+        assert plan["u_new"]["new"] == "#PWR02"  # skipped reserved 01
+
+    def test_flag_symbols_get_flg_prefix(self):
+        plan = build_rename_plan(
+            [self._power("power:PWR_FLAG", "#FLG", "u1")],
+        )
+        assert plan["u1"]["new"] == "#FLG01"
+
+    def test_padding_normalization_no_collision(self):
+        # #PWR40 round-trips through the 2-digit convention (canonical, kept),
+        # but #PWR040 does not (it would format to #PWR40) so it is a
+        # duplicate-looking ref that must be normalized to a fresh number
+        # without colliding with the reserved 40.
+        plan = build_rename_plan(
+            [
+                self._power("power:GND", "#PWR40", "u1"),
+                self._power("power:GND", "#PWR040", "u2"),
+            ],
+        )
+        assert "u1" not in plan  # #PWR40 is canonical, unchanged
+        assert plan["u2"]["new"] == "#PWR01"  # #PWR040 normalized, 40 reserved
+
+    def test_real_components_absent(self):
+        # Only power symbols are passed to build_rename_plan by the caller;
+        # a symbol that is already canonical is omitted from the plan.
+        plan = build_rename_plan(
+            [self._power("power:GND", "#PWR01", "u1")],
+        )
+        assert plan == {}
+
+
+# ---------------------------------------------------------------------------
+# Net-neutrality gate comparison logic (mocked at the boundary)
+# ---------------------------------------------------------------------------
+
+
+def _net(name, *nodes):
+    return Net(
+        code=0,
+        name=name,
+        nodes=[NetNode(reference=r, pin=p) for r, p in nodes],
+    )
+
+
+class TestDiffNetMembership:
+    def test_rename_is_neutral_after_translation(self):
+        before = Netlist(nets=[_net("GND", ("#GNDD", "1"), ("R1", "2"))])
+        after = Netlist(nets=[_net("GND", ("#PWR01", "1"), ("R1", "2"))])
+        ref_rename = {"#GNDD": "#PWR01"}
+        diffs = diff_net_membership(before, after, ref_rename)
+        assert diffs == []
+
+    def test_dropped_node_detected(self):
+        before = Netlist(nets=[_net("GND", ("#GNDD", "1"), ("R1", "2"))])
+        # After drops R1.2 — a genuine electrical change.
+        after = Netlist(nets=[_net("GND", ("#PWR01", "1"))])
+        ref_rename = {"#GNDD": "#PWR01"}
+        diffs = diff_net_membership(before, after, ref_rename)
+        assert diffs, "expected the gate to flag the dropped node"
+
+    def test_added_node_detected(self):
+        before = Netlist(nets=[_net("GND", ("#GNDD", "1"))])
+        after = Netlist(nets=[_net("GND", ("#PWR01", "1"), ("R9", "1"))])
+        ref_rename = {"#GNDD": "#PWR01"}
+        diffs = diff_net_membership(before, after, ref_rename)
+        assert diffs
+
+    def test_naive_comparison_would_falsely_diff(self):
+        # Without translation, the rename alone changes (ref, pin) identity;
+        # confirm the translation path (empty rename) *does* diff, proving the
+        # translation is what makes the neutral case pass.
+        before = Netlist(nets=[_net("GND", ("#GNDD", "1"))])
+        after = Netlist(nets=[_net("GND", ("#PWR01", "1"))])
+        diffs_no_translation = diff_net_membership(before, after, {})
+        assert diffs_no_translation  # naive: would (correctly) look changed
+        diffs_translated = diff_net_membership(before, after, {"#GNDD": "#PWR01"})
+        assert diffs_translated == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end run (mocked net gate) — text mutation on disk
+# ---------------------------------------------------------------------------
+
+
+def _write_hierarchy(tmp_path: Path, root_text: str, sub_text: str) -> Path:
+    root = tmp_path / "root.kicad_sch"
+    root.write_text(root_text, encoding="utf-8")
+    (tmp_path / "sub.kicad_sch").write_text(sub_text, encoding="utf-8")
+    return root
+
+
+class TestRunFixAnnotationDryRun:
+    def test_dry_run_makes_no_changes(self, tmp_path, capsys):
+        root_text = _root_schematic(
+            _real_component("Device:R", "R1", "10k", "u-r1"),
+            _power_symbol_no_instance("power:GND", "#GNDD", "u-gnd-root"),
+        )
+        sub_text = _sub_schematic(
+            _power_symbol_no_instance("power:GND", "#GNDD", "u-gnd-sub"),
+        )
+        root = _write_hierarchy(tmp_path, root_text, sub_text)
+        before = root.read_text()
+
+        rc = run_fix_annotation(root, dry_run=True, backup=False)
+        assert rc == 0
+        assert root.read_text() == before  # unchanged
+        out = capsys.readouterr().out
+        assert "#GNDD -> #PWR01" in out
+        assert "Dry run" in out
+
+    def test_dry_run_leaves_real_components_untouched_in_plan(self, tmp_path, capsys):
+        root_text = _root_schematic(
+            _real_component("Device:R", "R1", "10k", "u-r1"),
+            _power_symbol_no_instance("power:GND", "#GNDD", "u-gnd-root"),
+        )
+        sub_text = _sub_schematic()
+        root = _write_hierarchy(tmp_path, root_text, sub_text)
+        run_fix_annotation(root, dry_run=True, backup=False)
+        out = capsys.readouterr().out
+        assert "R1" not in out.replace("#PWR", "")  # R1 never appears as a rename
+
+
+class TestRunFixAnnotationSkipNetCheck:
+    def test_writes_and_renames_power_symbols(self, tmp_path):
+        root_text = _root_schematic(
+            _real_component("Device:R", "R1", "10k", "u-r1"),
+            _power_symbol_no_instance("power:GND", "#GNDD", "u-gnd-root"),
+        )
+        sub_text = _sub_schematic(
+            _power_symbol_no_instance("power:GND", "#GNDD", "u-gnd-sub"),
+            _power_symbol_no_instance("power:+3.3V", "#+3.3V", "u-p3v3"),
+        )
+        root = _write_hierarchy(tmp_path, root_text, sub_text)
+
+        rc = run_fix_annotation(root, backup=False, skip_net_check=True)
+        assert rc == 0
+
+        root_after = root.read_text()
+        sub_after = (tmp_path / "sub.kicad_sch").read_text()
+
+        # Root power ref renamed and given an instances block.
+        assert '(property "Reference" "#PWR01"' in root_after
+        assert "#GNDD" not in root_after
+        assert f'(path "/{ROOT_UUID}"' in root_after
+
+        # Sub-sheet power refs renamed with distinct numbers.
+        assert '(property "Reference" "#PWR02"' in sub_after
+        assert '(property "Reference" "#PWR03"' in sub_after
+        assert "#GNDD" not in sub_after
+        assert "#+3.3V" not in sub_after
+        # Sub-sheet instance path is the hierarchy path (root/sheet).
+        assert f'(path "/{ROOT_UUID}/{SUB_SHEET_UUID}"' in sub_after
+
+        # Real component reference untouched.
+        assert '(property "Reference" "R1"' in root_after
+
+    def test_backup_creates_bak_file(self, tmp_path):
+        root_text = _root_schematic(
+            _power_symbol_no_instance("power:GND", "#GNDD", "u-gnd-root"),
+        )
+        sub_text = _sub_schematic()
+        root = _write_hierarchy(tmp_path, root_text, sub_text)
+
+        rc = run_fix_annotation(root, backup=True, skip_net_check=True)
+        assert rc == 0
+        backups = list(tmp_path.glob("root_backup_*.kicad_sch"))
+        assert len(backups) == 1
+
+    def test_renames_symbol_with_existing_instance(self, tmp_path):
+        # A power symbol with a well-formed instance but a net-name-styled ref
+        # gets renamed AND its instance (reference "...") is updated in step.
+        root_text = _root_schematic(
+            _power_symbol_with_instance(
+                "power:GND", "#GNDD", "u-gnd-root", "root", f"/{ROOT_UUID}"
+            ),
+        )
+        sub_text = _sub_schematic()
+        root = _write_hierarchy(tmp_path, root_text, sub_text)
+
+        rc = run_fix_annotation(root, backup=False, skip_net_check=True)
+        assert rc == 0
+        after = root.read_text()
+        assert '(property "Reference" "#PWR01"' in after
+        assert '(reference "#PWR01")' in after
+        assert "#GNDD" not in after
+
+    def test_nothing_to_fix_reports_clean(self, tmp_path, capsys):
+        root_text = _root_schematic(
+            _power_symbol_with_instance(
+                "power:GND", "#PWR01", "u-gnd-root", "root", f"/{ROOT_UUID}"
+            ),
+        )
+        sub_text = _sub_schematic()
+        root = _write_hierarchy(tmp_path, root_text, sub_text)
+
+        rc = run_fix_annotation(root, backup=False, skip_net_check=True)
+        assert rc == 0
+        assert "No power/flag annotation errors found." in capsys.readouterr().out
+
+
+class TestNetGateIntegration:
+    """Exercise run_fix_annotation with a mocked net gate (no kicad-cli)."""
+
+    def test_gate_failure_aborts_write(self, tmp_path, monkeypatch):
+        root_text = _root_schematic(
+            _power_symbol_no_instance("power:GND", "#GNDD", "u-gnd-root"),
+        )
+        sub_text = _sub_schematic()
+        root = _write_hierarchy(tmp_path, root_text, sub_text)
+        before = root.read_text()
+
+        import kicad_tools.cli.sch_fix_annotation as mod
+
+        monkeypatch.setattr(mod, "find_kicad_cli", lambda: Path("/fake/kicad-cli"))
+        # Simulate the gate detecting a net change.
+        monkeypatch.setattr(
+            mod,
+            "_run_net_gate",
+            lambda *a, **k: (False, ["  REMOVED (x1): {R1.2}"]),
+        )
+
+        rc = run_fix_annotation(root, backup=False)
+        assert rc == 2
+        assert root.read_text() == before  # no write on gate failure
+
+    def test_gate_pass_allows_write(self, tmp_path, monkeypatch):
+        root_text = _root_schematic(
+            _power_symbol_no_instance("power:GND", "#GNDD", "u-gnd-root"),
+        )
+        sub_text = _sub_schematic()
+        root = _write_hierarchy(tmp_path, root_text, sub_text)
+
+        import kicad_tools.cli.sch_fix_annotation as mod
+
+        monkeypatch.setattr(mod, "find_kicad_cli", lambda: Path("/fake/kicad-cli"))
+        monkeypatch.setattr(mod, "_run_net_gate", lambda *a, **k: (True, []))
+
+        rc = run_fix_annotation(root, backup=False)
+        assert rc == 0
+        assert '(property "Reference" "#PWR01"' in root.read_text()
+
+    def test_missing_kicad_cli_errors_without_skip(self, tmp_path, monkeypatch):
+        root_text = _root_schematic(
+            _power_symbol_no_instance("power:GND", "#GNDD", "u-gnd-root"),
+        )
+        sub_text = _sub_schematic()
+        root = _write_hierarchy(tmp_path, root_text, sub_text)
+        before = root.read_text()
+
+        import kicad_tools.cli.sch_fix_annotation as mod
+
+        monkeypatch.setattr(mod, "find_kicad_cli", lambda: None)
+
+        rc = run_fix_annotation(root, backup=False)
+        assert rc == 1
+        assert root.read_text() == before  # nothing written
+
+
+# ---------------------------------------------------------------------------
+# kicad-cli-dependent integration (skipped when kicad-cli unavailable)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(find_kicad_cli() is None, reason="kicad-cli not installed")
+class TestNetGateWithKicadCli:
+    def test_real_gate_passes_on_neutral_rename(self, tmp_path):
+        # A schematic whose only defect is a net-name-styled power ref; the
+        # rename must be net-neutral and the gate must allow the write.
+        root_text = _root_schematic(
+            _power_symbol_no_instance("power:GND", "#GNDD", "u-gnd-root"),
+        )
+        sub_text = _sub_schematic()
+        root = _write_hierarchy(tmp_path, root_text, sub_text)
+
+        rc = run_fix_annotation(root, backup=False)
+        # 0 (neutral, written) is the expected outcome; a non-zero here would
+        # indicate the gate found a spurious diff.
+        assert rc == 0
+        assert "#GNDD" not in root.read_text()


### PR DESCRIPTION
## Summary

Adds `kct sch fix-annotation <root.kicad_sch>`, a new hierarchy-aware repair for the power/flag-symbol annotation errors that `kicad-cli sch export netlist` reports as `schematic has annotation errors`. This unblocks the consumer design (project-shamrock/chorus#24) which cannot re-annotate power symbols headlessly today.

Root cause (confirmed per the curated issue): `re-annotate`'s `_parse_reference()` cannot parse net-name-styled power refs (`#GNDD`, `#+3.3V`) — the whole string becomes the "prefix", so those symbols are permanently invisible even with `--include-power`. The new command classifies power symbols by `lib_id.startswith("power:")` instead of pattern-matching the arbitrary net-name text.

## Changes

- **New `src/kicad_tools/cli/sch_fix_annotation.py`** composing existing building blocks:
  - Walks the hierarchy via `_collect_schematic_files` (reused).
  - Classifies every `power:` symbol; canonicality is a round-trip check through `_format_reference`, so `#PWR40` is kept but `#PWR040` (which would format to `#PWR40`) is normalized.
  - `build_rename_plan` assigns globally-unique `#PWR0xx`/`#FLG0xx` designators, reserving numbers held by already-canonical symbols so no collisions are introduced. Flag symbols get `#FLG`, other power symbols get `#PWR`.
  - Repairs missing / wrong-project / loose `(instances)` blocks via `_insert_project_instance` (reused), and updates the stale `(reference ...)` inside instance blocks of renamed symbols.
  - **Net-neutrality gate**: exports the netlist before/after via `kicad-cli`, applies changes to a temp-dir copy of the hierarchy, and diffs net membership *keyed by (ref, pin) with the before-snapshot translated through the rename mapping* (naive comparison would always diff on renames). Refuses to write (exit 2) on any membership change; fails closed if an export fails.
  - Degrades with a clear, actionable error when `kicad-cli` is absent; `--skip-net-check` bypasses the gate (labeled unsafe). `--dry-run` and `--backup` match existing sch mutators.
- **`parser.py`**: new `sch fix-annotation` subparser.
- **`commands/schematic.py`**: dispatch branch + updated `sch --help` command list.
- **New `tests/test_sch_fix_annotation.py`**: synthetic multi-sheet fixtures (chorus is local-only / not in CI).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Net-name-styled refs (`#GNDD`, `#+3.3V`) get canonical designators | ✅ | `TestBuildRenamePlan::test_net_name_styled_gets_canonical` |
| Duplicate refs across sheets get distinct numbers | ✅ | `test_duplicate_refs_get_distinct_numbers` + e2e `test_writes_and_renames_power_symbols` |
| Inconsistent zero-padding normalized without collision | ✅ | `test_padding_normalization_no_collision` (`#PWR40` kept, `#PWR040`→`#PWR01`) |
| Missing `(instances)` blocks created with correct project + hierarchy path from root | ✅ | e2e asserts `(path "/root")` and `(path "/root/sheet")` |
| Gate allows net-neutral renames | ✅ | `TestDiffNetMembership::test_rename_is_neutral_after_translation`; real kicad-cli `TestNetGateWithKicadCli` |
| Gate detects & aborts on membership change (exit non-zero, no write) | ✅ | `test_dropped_node_detected`, `TestNetGateIntegration::test_gate_failure_aborts_write` (rc==2, file unchanged) |
| `--dry-run` writes nothing | ✅ | `TestRunFixAnnotationDryRun` |
| `--backup` creates `.bak` before write | ✅ | `test_backup_creates_bak_file` |
| Real components (`R1`) untouched | ✅ | e2e asserts `R1` preserved |
| kicad-cli-dependent tests skip gracefully when absent | ✅ | `@pytest.mark.skipif(find_kicad_cli() is None, ...)` |
| Empty/no power symbols → clean exit 0 | ✅ | `test_nothing_to_fix_reports_clean` |

## Test Plan

- `uv run pytest tests/test_sch_fix_annotation.py tests/test_sch_re_annotate.py tests/test_sch_repair_instances.py` → 166 passed (kicad-cli present locally, so the real net-gate integration test ran, not skipped).
- `uv run ruff check` / `ruff format` clean on all changed files.
- `uv run mypy src/kicad_tools/cli/sch_fix_annotation.py` → no issues.
- `uv run kct sch fix-annotation --help` shows the new command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #4135