### PR TITLE
feat(pcb): add --region spatial bound to pcb strip

### DIFF
--- a/src/kicad_tools/cli/commands/pcb.py
+++ b/src/kicad_tools/cli/commands/pcb.py
@@ -3,6 +3,7 @@
 import json
 import sys
 from pathlib import Path
+from typing import Any
 
 __all__ = ["run_pcb_command"]
 
@@ -291,7 +292,7 @@ def _run_strip_command(args, pcb_path: Path) -> int:
     output_format = getattr(args, "format", "text")
     dry_run = getattr(args, "dry_run", False)
 
-    result = {
+    result: dict[str, Any] = {
         "input": str(pcb_path),
         "output": str(output_path) if not dry_run else None,
         "dry_run": dry_run,

--- a/src/kicad_tools/cli/commands/pcb.py
+++ b/src/kicad_tools/cli/commands/pcb.py
@@ -226,6 +226,35 @@ def _run_strip_command(args, pcb_path: Path) -> int:
 
     remove_orphan_vias = getattr(args, "remove_orphan_vias", False)
 
+    # Parse and validate the optional --region bounding box.
+    region = None
+    region_arg = getattr(args, "region", None)
+    if region_arg:
+        parts = [p.strip() for p in region_arg.split(",")]
+        if len(parts) != 4:
+            print(
+                "Error: --region expects 'x1,y1,x2,y2' (four comma-separated "
+                f"numbers), got {region_arg!r}",
+                file=sys.stderr,
+            )
+            return 1
+        try:
+            x1, y1, x2, y2 = (float(p) for p in parts)
+        except ValueError:
+            print(
+                f"Error: --region values must be numeric, got {region_arg!r}",
+                file=sys.stderr,
+            )
+            return 1
+        if x1 >= x2 or y1 >= y2:
+            print(
+                "Error: --region must satisfy x1 < x2 and y1 < y2 "
+                f"(got x1={x1}, y1={y1}, x2={x2}, y2={y2})",
+                file=sys.stderr,
+            )
+            return 1
+        region = (x1, y1, x2, y2)
+
     # Load PCB
     try:
         pcb = PCB.load(pcb_path)
@@ -247,6 +276,7 @@ def _run_strip_command(args, pcb_path: Path) -> int:
         exclude_power=exclude_power,
         power_pattern=power_pattern,
         remove_orphan_vias=remove_orphan_vias,
+        region=region,
     )
 
     # Determine output path
@@ -267,6 +297,7 @@ def _run_strip_command(args, pcb_path: Path) -> int:
         "dry_run": dry_run,
         "nets_filtered": nets,
         "layers_filtered": layers,
+        "region": list(region) if region else None,
         "keep_zones": keep_zones,
         "exclude_power": exclude_power,
         "remove_orphan_vias": remove_orphan_vias,
@@ -299,6 +330,8 @@ def _run_strip_command(args, pcb_path: Path) -> int:
             print("  Stripping all nets")
         if layers:
             print(f"  Filtering layers: {', '.join(layers)}")
+        if region:
+            print(f"  Region: ({region[0]}, {region[1]}) to ({region[2]}, {region[3]}) mm")
         print(f"  Exclude power nets: {exclude_power}")
         print(f"  Keep zones: {keep_zones}")
         if remove_orphan_vias:
@@ -310,6 +343,12 @@ def _run_strip_command(args, pcb_path: Path) -> int:
         print(f"    Vias:     {stats['vias']:,}")
         if not keep_zones:
             print(f"    Zones:    {stats['zones']:,}")
+        if region:
+            print(f"    Segments clipped at boundary: {stats['segments_clipped']:,}")
+            print(
+                f"    Segments spanning box (both ends outside) left untouched: "
+                f"{stats['segments_boundary_skipped']:,}"
+            )
         print()
 
         print("  Remaining:")

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1563,6 +1563,17 @@ def _add_pcb_parser(subparsers) -> None:
         "on either of their layers (only meaningful with --layers)",
     )
     pcb_strip.add_argument(
+        "--region",
+        help="Spatially bound the strip to an axis-aligned box "
+        "'x1,y1,x2,y2' (board-relative mm). Only geometry inside the box is "
+        "removed, ANDed with --nets/--layers. Vias are stripped when their "
+        "point is inside; segments fully inside are removed; segments crossing "
+        "the boundary are clipped to the outside portion; segments spanning the "
+        "box with both endpoints outside are left untouched and reported as "
+        "'boundary_skipped'. Zones are only removed (with --no-keep-zones) when "
+        "their whole polygon is inside the box (no polygon clipping).",
+    )
+    pcb_strip.add_argument(
         "--no-keep-zones",
         dest="keep_zones",
         action="store_false",

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -50,6 +50,47 @@ def _is_power_net(name: str, pattern: re.Pattern[str] | None = None) -> bool:
     return pat.search(name) is not None
 
 
+def _segment_span_intersects_region(
+    start: tuple[float, float],
+    end: tuple[float, float],
+    region: tuple[float, float, float, float],
+) -> bool:
+    """Return True if the segment ``start``->``end`` crosses the axis-aligned box.
+
+    All coordinates are board-relative.  ``region`` is a normalized
+    ``(x1, y1, x2, y2)`` box with ``x1 <= x2`` and ``y1 <= y2``.  Uses the
+    Liang-Barsky parametric clip test.  This is only used to decide whether a
+    both-endpoints-outside segment should be *reported* as boundary-skipped
+    (it is never itself modified), so a conservative True on tangency is fine.
+    """
+    x1, y1, x2, y2 = region
+    sx, sy = start
+    ex, ey = end
+    dx = ex - sx
+    dy = ey - sy
+    # Degenerate (zero-length) segment: treat as a point-in-box test.
+    if dx == 0.0 and dy == 0.0:
+        return x1 <= sx <= x2 and y1 <= sy <= y2
+    t0, t1 = 0.0, 1.0
+    for p, q in ((-dx, sx - x1), (dx, x2 - sx), (-dy, sy - y1), (dy, y2 - sy)):
+        if p == 0.0:
+            if q < 0.0:
+                return False  # Parallel to this edge and outside the slab.
+            continue
+        r = q / p
+        if p < 0.0:
+            if r > t1:
+                return False
+            if r > t0:
+                t0 = r
+        else:
+            if r < t0:
+                return False
+            if r < t1:
+                t1 = r
+    return t0 <= t1
+
+
 # ---------------------------------------------------------------------------
 # Power-rail name canonicalisation (issue #3302)
 # ---------------------------------------------------------------------------
@@ -4934,6 +4975,7 @@ class PCB:
         exclude_power: bool = False,
         power_pattern: re.Pattern[str] | None = None,
         remove_orphan_vias: bool = False,
+        region: tuple[float, float, float, float] | None = None,
     ) -> dict[str, int]:
         """Remove trace segments and vias from the PCB.
 
@@ -4964,12 +5006,44 @@ class PCB:
                                 to any remaining segment on either of their
                                 layers after layer-filtered stripping.
                                 Only meaningful when *layers* is specified.
+            region: Optional ``(x1, y1, x2, y2)`` bounding box (board-relative
+                    mm coordinates) that spatially bounds the strip.  When
+                    given, only geometry *inside* the box is removed and the
+                    filter is ANDed with *nets* / *layers* / *exclude_power*:
+
+                    * A **via** is stripped only when its ``(at x y)`` point is
+                      inside the box.
+                    * A **segment** fully inside the box is removed; a segment
+                      fully outside is kept unchanged.  A segment with exactly
+                      one endpoint inside is *clipped* at the box boundary --
+                      the inside portion is removed and the outside portion is
+                      kept as a shortened segment (see ``segments_clipped`` in
+                      the returned stats).  A segment with both endpoints
+                      outside is kept unchanged even if its span happens to
+                      cross the box (a "skip-and-report" fallback -- these are
+                      counted in ``segments_boundary_skipped``), because
+                      splitting a segment into two outside pieces would leave a
+                      dangling gap with no via/pad termination inside the box.
+                    * **Zones** are polygons; region-based zone removal only
+                      triggers (with ``keep_zones=False``) when the zone's
+                      entire polygon is contained in the box (conservative --
+                      no polygon clipping is performed).
+
+                    The box is normalized internally, so inverted/degenerate
+                    coordinates are tolerated by this method; the CLI validates
+                    and rejects ``x1 >= x2`` / ``y1 >= y2`` before calling.
 
         Returns:
             Dictionary with counts of removed elements:
-            - "segments": Number of trace segments removed
+            - "segments": Number of trace segments removed (includes the
+              inside portion of clipped segments)
             - "vias": Number of vias removed
             - "zones": Number of zones removed (0 if keep_zones=True)
+            - "segments_clipped": Number of boundary-crossing segments that
+              were clipped to their outside portion (0 when *region* is None)
+            - "segments_boundary_skipped": Number of segments spanning the box
+              with both endpoints outside that were left untouched (0 when
+              *region* is None)
 
         Example:
             >>> pcb = PCB.load("board.kicad_pcb")
@@ -5001,6 +5075,55 @@ class PCB:
         if layers is not None:
             layer_set = set(layers)
 
+        # Normalize the region bbox (board-relative coords) so x1<x2, y1<y2.
+        # SExp start/end/at nodes store sheet-absolute coords (board-relative +
+        # board_origin), so we convert them to board-relative before comparing.
+        region_box: tuple[float, float, float, float] | None = None
+        if region is not None:
+            rx1, ry1, rx2, ry2 = region
+            region_box = (min(rx1, rx2), min(ry1, ry2), max(rx1, rx2), max(ry1, ry2))
+        ox_region, oy_region = self._board_origin
+
+        def _point_in_region(abs_x: float, abs_y: float) -> bool:
+            """True if a sheet-absolute point falls inside the region box."""
+            if region_box is None:
+                return True
+            rel_x = abs_x - ox_region
+            rel_y = abs_y - oy_region
+            x1, y1, x2, y2 = region_box
+            return x1 <= rel_x <= x2 and y1 <= rel_y <= y2
+
+        def _clip_point_to_region(
+            inside: tuple[float, float], outside: tuple[float, float]
+        ) -> tuple[float, float]:
+            """Intersect the inside->outside segment with the region boundary.
+
+            Both points are sheet-absolute.  Returns the sheet-absolute point
+            on the box boundary (the closest crossing to *inside*).  The
+            returned point becomes the new terminal of the kept outside piece.
+            """
+            assert region_box is not None
+            x1, y1, x2, y2 = region_box
+            ix, iy = inside[0] - ox_region, inside[1] - oy_region
+            oxp, oyp = outside[0] - ox_region, outside[1] - oy_region
+            dx = oxp - ix
+            dy = oyp - iy
+            # Find the smallest t in (0, 1] where the segment exits the box.
+            t_best = 1.0
+            if dx > 0:
+                t_best = min(t_best, (x2 - ix) / dx)
+            elif dx < 0:
+                t_best = min(t_best, (x1 - ix) / dx)
+            if dy > 0:
+                t_best = min(t_best, (y2 - iy) / dy)
+            elif dy < 0:
+                t_best = min(t_best, (y1 - iy) / dy)
+            t_best = max(0.0, min(1.0, t_best))
+            cx = ix + dx * t_best
+            cy = iy + dy * t_best
+            # Convert back to sheet-absolute coordinates.
+            return (cx + ox_region, cy + oy_region)
+
         # Build set of power-net numbers for exclusion
         power_net_numbers: set[int] = set()
         if exclude_power:
@@ -5025,6 +5148,13 @@ class PCB:
         removed_segments = 0
         removed_vias = 0
         removed_zones = 0
+        clipped_segments = 0
+        boundary_skipped_segments = 0
+
+        # Track clipped-segment geometry so the parsed self._segments view can
+        # be updated in lock-step with the S-expression tree below.  Maps the
+        # segment's uuid -> new board-relative (start, end) endpoints.
+        clipped_geometry: dict[str, tuple[tuple[float, float], tuple[float, float]]] = {}
 
         # Filter S-expression children to remove segments, vias, and optionally zones
         new_children = []
@@ -5033,20 +5163,71 @@ class PCB:
 
             if child.name == "segment":
                 net_num = _net_num_from_child(child)
-                if _should_strip_net(net_num):
-                    if layer_set is not None:
-                        # Only remove segments on specified layers
-                        layer_node = child.find("layer")
-                        if layer_node:
-                            seg_layer = layer_node.get_string(0) or ""
-                            if seg_layer in layer_set:
-                                should_remove = True
-                    elif net_numbers_to_strip is not None:
-                        # Net filter only — already passed net check
+                passes_net = _should_strip_net(net_num)
+                passes_layer = True
+                if passes_net and layer_set is not None:
+                    layer_node = child.find("layer")
+                    seg_layer = (layer_node.get_string(0) or "") if layer_node else ""
+                    passes_layer = seg_layer in layer_set
+
+                if passes_net and passes_layer:
+                    if region_box is None:
+                        # No spatial bound: existing whole-segment behavior.
                         should_remove = True
                     else:
-                        # No net or layer filter — remove all (non-power) segments
-                        should_remove = True
+                        # Spatially bounded: classify by endpoint membership.
+                        start_node = child.find("start")
+                        end_node = child.find("end")
+                        if start_node and end_node:
+                            sx = start_node.get_float(0) or 0.0
+                            sy = start_node.get_float(1) or 0.0
+                            ex = end_node.get_float(0) or 0.0
+                            ey = end_node.get_float(1) or 0.0
+                            start_in = _point_in_region(sx, sy)
+                            end_in = _point_in_region(ex, ey)
+                            if start_in and end_in:
+                                # Fully inside the box — remove entirely.
+                                should_remove = True
+                            elif start_in != end_in:
+                                # Boundary-crossing — clip to the outside piece.
+                                inside_pt = (sx, sy) if start_in else (ex, ey)
+                                outside_pt = (ex, ey) if start_in else (sx, sy)
+                                clip_pt = _clip_point_to_region(inside_pt, outside_pt)
+                                # Rewrite the surviving segment: the outside
+                                # endpoint stays, the inside endpoint moves to
+                                # the region boundary.
+                                if start_in:
+                                    start_node.set_value(0, clip_pt[0])
+                                    start_node.set_value(1, clip_pt[1])
+                                    abs_start = clip_pt
+                                    abs_end = (ex, ey)
+                                else:
+                                    end_node.set_value(0, clip_pt[0])
+                                    end_node.set_value(1, clip_pt[1])
+                                    abs_start = (sx, sy)
+                                    abs_end = clip_pt
+                                clipped_segments += 1
+                                uuid_node = child.find("uuid")
+                                seg_uuid = uuid_node.get_string(0) if uuid_node else None
+                                if seg_uuid:
+                                    # Record board-relative endpoints (subtract
+                                    # board origin) for the parsed-view sync.
+                                    clipped_geometry[seg_uuid] = (
+                                        (abs_start[0] - ox_region, abs_start[1] - oy_region),
+                                        (abs_end[0] - ox_region, abs_end[1] - oy_region),
+                                    )
+                            else:
+                                # Both endpoints outside the box.  The span may
+                                # still cross the box, but splitting it would
+                                # leave a dangling gap with no termination
+                                # inside; per the documented policy we skip and
+                                # report it instead of silently mangling copper.
+                                if _segment_span_intersects_region(
+                                    (sx - ox_region, sy - oy_region),
+                                    (ex - ox_region, ey - oy_region),
+                                    region_box,
+                                ):
+                                    boundary_skipped_segments += 1
 
                 if should_remove:
                     removed_segments += 1
@@ -5070,6 +5251,17 @@ class PCB:
                     else:
                         should_remove = True
 
+                # A via is a point: it is only stripped when its (at x y)
+                # position falls inside the region box (ANDed with the above).
+                if should_remove and region_box is not None:
+                    at_node = child.find("at")
+                    if at_node is None:
+                        should_remove = False
+                    else:
+                        vx = at_node.get_float(0) or 0.0
+                        vy = at_node.get_float(1) or 0.0
+                        should_remove = _point_in_region(vx, vy)
+
                 if should_remove:
                     removed_vias += 1
 
@@ -5087,6 +5279,24 @@ class PCB:
                         should_remove = True
                     else:
                         should_remove = True
+
+                # Region: zones are polygons, not lines.  Phase 1 does NOT clip
+                # zone polygons; a zone is only removed when its entire boundary
+                # polygon is contained in the region box (conservative).
+                if should_remove and region_box is not None:
+                    poly_node = child.find("polygon")
+                    pts_node = poly_node.find("pts") if poly_node else None
+                    if pts_node is None:
+                        should_remove = False
+                    else:
+                        xy_nodes = pts_node.find_all("xy")
+                        if not xy_nodes:
+                            should_remove = False
+                        else:
+                            should_remove = all(
+                                _point_in_region(xy.get_float(0) or 0.0, xy.get_float(1) or 0.0)
+                                for xy in xy_nodes
+                            )
 
                 if should_remove:
                     removed_zones += 1
@@ -5160,6 +5370,12 @@ class PCB:
                 return True
             if layer_set is not None and not all(vl in layer_set for vl in via.layers):
                 return True
+            # Region: keep the via if its point is outside the box.
+            if region_box is not None:
+                x1, y1, x2, y2 = region_box
+                vx, vy = via.position
+                if not (x1 <= vx <= x2 and y1 <= vy <= y2):
+                    return True
             return False
 
         def _zone_matches(zone: Zone) -> bool:
@@ -5170,12 +5386,54 @@ class PCB:
                 return True
             if layer_set is not None and zone.layer not in layer_set:
                 return True
+            # Region: keep the zone unless its whole polygon is inside the box.
+            if region_box is not None:
+                x1, y1, x2, y2 = region_box
+                poly = zone.polygon or []
+                if not poly or not all(x1 <= px <= x2 and y1 <= py <= y2 for px, py in poly):
+                    return True
             return False
 
+        def _region_keeps_segment(seg: Segment) -> bool:
+            """Return True if *region* alone would preserve (not fully strip) seg.
+
+            A segment is fully removed only when both endpoints are inside the
+            box.  Crossing segments are clipped (their endpoints are rewritten
+            below), so they are "kept" here in the sense of surviving the list.
+            """
+            if region_box is None:
+                return False
+            x1, y1, x2, y2 = region_box
+            start_in = x1 <= seg.start[0] <= x2 and y1 <= seg.start[1] <= y2
+            end_in = x1 <= seg.end[0] <= x2 and y1 <= seg.end[1] <= y2
+            return not (start_in and end_in)
+
+        def _seg_matches_with_region(seg: Segment) -> bool:
+            """Return True if the segment should be KEPT (region-aware)."""
+            if _seg_matches(seg):
+                return True
+            # Passed the net/layer/power filters — apply the spatial bound.
+            if region_box is not None and _region_keeps_segment(seg):
+                return True
+            return False
+
+        # Rewrite clipped segments' parsed endpoints (board-relative) so the
+        # parsed view matches the S-expression tree.
+        if clipped_geometry:
+            for seg in self._segments:
+                new_geom = clipped_geometry.get(seg.uuid)
+                if new_geom is not None:
+                    seg.start, seg.end = new_geom
+
         # Apply filtering helpers
-        has_any_filter = net_numbers_to_strip is not None or layer_set is not None or exclude_power
+        has_any_filter = (
+            net_numbers_to_strip is not None
+            or layer_set is not None
+            or exclude_power
+            or region_box is not None
+        )
         if has_any_filter:
-            self._segments = [seg for seg in self._segments if _seg_matches(seg)]
+            self._segments = [seg for seg in self._segments if _seg_matches_with_region(seg)]
             self._vias = [via for via in self._vias if _via_matches(via)]
             if not keep_zones:
                 self._zones = [zone for zone in self._zones if _zone_matches(zone)]
@@ -5204,6 +5462,8 @@ class PCB:
             "segments": removed_segments,
             "vias": removed_vias,
             "zones": removed_zones,
+            "segments_clipped": clipped_segments,
+            "segments_boundary_skipped": boundary_skipped_segments,
         }
 
     def save(self, path: str | Path | None = None) -> None:

--- a/tests/test_cli_pcb.py
+++ b/tests/test_cli_pcb.py
@@ -1012,6 +1012,156 @@ class TestPcbStrip:
         assert "dry run" in captured.out.lower()
         assert "Filtering layers: In1.Cu" in captured.out
 
+    def _region_strip_args(self, input_file, output_file, region, **overrides):
+        """Build a Namespace for a region strip invocation with sane defaults."""
+        from argparse import Namespace
+
+        defaults = {
+            "pcb": str(input_file),
+            "pcb_command": "strip",
+            "output": str(output_file) if output_file is not None else None,
+            "nets": None,
+            "layers": None,
+            "region": region,
+            "include_power": True,
+            "power_pattern": None,
+            "remove_orphan_vias": False,
+            "keep_zones": True,
+            "format": "text",
+            "dry_run": False,
+        }
+        defaults.update(overrides)
+        return Namespace(**defaults)
+
+    def test_strip_region_cli_removes_in_region_only(self, tmp_path, capsys):
+        """--region strips only geometry inside the box."""
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(start=(20, 20), end=(30, 20), width=0.25, layer="F.Cu", net="SIG_A")
+        pcb.add_trace(start=(60, 60), end=(70, 60), width=0.25, layer="F.Cu", net="SIG_B")
+
+        input_file = tmp_path / "region_cli.kicad_pcb"
+        pcb.save(input_file)
+        output_file = tmp_path / "stripped.kicad_pcb"
+
+        args = self._region_strip_args(input_file, output_file, "10,10,40,40")
+        result = run_pcb_command(args)
+
+        assert result == 0
+        stripped = PCB.load(output_file)
+        assert len(stripped.segments) == 1  # only the in-region SIG_A removed
+
+    def test_strip_region_cli_json_reports_region_stats(self, tmp_path, capsys):
+        """JSON output includes region and clip/skip counts."""
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.create(width=100, height=100)
+        # Crossing segment: clipped at the x=40 boundary.
+        pcb.add_trace(start=(20, 20), end=(60, 20), width=0.25, layer="F.Cu", net="SIG_A")
+
+        input_file = tmp_path / "region_json.kicad_pcb"
+        pcb.save(input_file)
+        output_file = tmp_path / "stripped.kicad_pcb"
+
+        args = self._region_strip_args(input_file, output_file, "10,10,40,40", format="json")
+        result = run_pcb_command(args)
+
+        assert result == 0
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["region"] == [10.0, 10.0, 40.0, 40.0]
+        assert data["removed"]["segments_clipped"] == 1
+
+    def test_strip_region_cli_dry_run_text(self, tmp_path, capsys):
+        """Dry-run text output mentions the region."""
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(start=(20, 20), end=(30, 20), width=0.25, layer="F.Cu", net="SIG_A")
+
+        input_file = tmp_path / "region_dry.kicad_pcb"
+        pcb.save(input_file)
+
+        args = self._region_strip_args(input_file, None, "10,10,40,40", dry_run=True)
+        result = run_pcb_command(args)
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "dry run" in captured.out.lower()
+        assert "Region:" in captured.out
+
+    def test_strip_region_cli_and_nets_combined(self, tmp_path, capsys):
+        """--region composes with --nets (ANDed) via the CLI."""
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(start=(20, 20), end=(30, 20), width=0.25, layer="F.Cu", net="NET_A")
+        pcb.add_trace(start=(20, 30), end=(30, 30), width=0.25, layer="F.Cu", net="NET_B")
+
+        input_file = tmp_path / "region_nets.kicad_pcb"
+        pcb.save(input_file)
+        output_file = tmp_path / "stripped.kicad_pcb"
+
+        args = self._region_strip_args(input_file, output_file, "10,10,40,40", nets="NET_A")
+        result = run_pcb_command(args)
+
+        assert result == 0
+        stripped = PCB.load(output_file)
+        assert len(stripped.segments) == 1  # NET_B in-region survives the net filter
+
+    def test_strip_region_cli_invalid_wrong_count(self, tmp_path, capsys):
+        """A --region with the wrong number of values fails fast."""
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.create(width=100, height=100)
+        input_file = tmp_path / "bad_region.kicad_pcb"
+        pcb.save(input_file)
+
+        args = self._region_strip_args(input_file, None, "10,10,40")
+        result = run_pcb_command(args)
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "region" in captured.err.lower()
+
+    def test_strip_region_cli_invalid_non_numeric(self, tmp_path, capsys):
+        """A non-numeric --region value fails fast."""
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.create(width=100, height=100)
+        input_file = tmp_path / "bad_region2.kicad_pcb"
+        pcb.save(input_file)
+
+        args = self._region_strip_args(input_file, None, "10,10,foo,40")
+        result = run_pcb_command(args)
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "numeric" in captured.err.lower()
+
+    def test_strip_region_cli_invalid_inverted(self, tmp_path, capsys):
+        """A --region with x1>=x2 or y1>=y2 fails fast (CLI validation)."""
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.create(width=100, height=100)
+        input_file = tmp_path / "bad_region3.kicad_pcb"
+        pcb.save(input_file)
+
+        args = self._region_strip_args(input_file, None, "40,40,10,10")
+        result = run_pcb_command(args)
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "x1 < x2" in captured.err or "region" in captured.err.lower()
+
 
 # PCB with multiple footprints for reannotation testing
 MULTI_FOOTPRINT_PCB = """(kicad_pcb

--- a/tests/test_pcb.py
+++ b/tests/test_pcb.py
@@ -3299,6 +3299,191 @@ class TestStripTraces:
         assert len(reloaded.segments) == 1
         assert reloaded.segments[0].layer == "F.Cu"
 
+    # ------------------------------------------------------------------
+    # Region-scoped stripping (Issue #4136 Phase 1)
+    # ------------------------------------------------------------------
+
+    def test_strip_region_segment_fully_inside_removed(self):
+        """A segment fully inside the region box is removed."""
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(start=(20, 20), end=(30, 20), width=0.25, layer="F.Cu", net="SIG_A")
+
+        stats = pcb.strip_traces(region=(10, 10, 40, 40))
+
+        assert stats["segments"] == 1
+        assert stats["segments_clipped"] == 0
+        assert len(pcb.segments) == 0
+
+    def test_strip_region_segment_fully_outside_kept(self):
+        """A segment entirely outside the region box is untouched."""
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(start=(60, 60), end=(80, 60), width=0.25, layer="F.Cu", net="SIG_A")
+
+        stats = pcb.strip_traces(region=(10, 10, 40, 40))
+
+        assert stats["segments"] == 0
+        assert stats["segments_clipped"] == 0
+        assert len(pcb.segments) == 1
+
+    def test_strip_region_crossing_segment_is_clipped(self):
+        """A segment with one endpoint inside is clipped to the outside piece."""
+        pcb = PCB.create(width=100, height=100)
+        # Horizontal segment from (20,20) inside the box to (60,20) outside;
+        # region right edge is x=40, so the kept piece runs (40,20)->(60,20).
+        pcb.add_trace(start=(20, 20), end=(60, 20), width=0.25, layer="F.Cu", net="SIG_A")
+
+        stats = pcb.strip_traces(region=(10, 10, 40, 40))
+
+        assert stats["segments"] == 0  # not a whole-segment removal
+        assert stats["segments_clipped"] == 1
+        assert len(pcb.segments) == 1
+        seg = pcb.segments[0]
+        # The inside endpoint (20,20) moved to the boundary x=40; the outside
+        # endpoint (60,20) is unchanged.
+        xs = {round(seg.start[0], 3), round(seg.end[0], 3)}
+        assert xs == {40.0, 60.0}
+        ys = {round(seg.start[1], 3), round(seg.end[1], 3)}
+        assert ys == {20.0}
+
+    def test_strip_region_clip_roundtrips_through_save(self, tmp_path: Path):
+        """Clipped segment endpoints persist through save/reload."""
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(start=(20, 20), end=(60, 20), width=0.25, layer="F.Cu", net="SIG_A")
+
+        pcb.strip_traces(region=(10, 10, 40, 40))
+
+        out = tmp_path / "clipped.kicad_pcb"
+        pcb.save(out)
+        reloaded = PCB.load(out)
+        assert len(reloaded.segments) == 1
+        seg = reloaded.segments[0]
+        xs = {round(seg.start[0], 3), round(seg.end[0], 3)}
+        assert xs == {40.0, 60.0}
+
+    def test_strip_region_both_endpoints_outside_spanning_box_skipped(self):
+        """A segment spanning the box with both ends outside is left untouched."""
+        pcb = PCB.create(width=100, height=100)
+        # Runs (5,25) -> (55,25): both endpoints outside the x-range [10,40]
+        # but the span crosses the box horizontally.
+        pcb.add_trace(start=(5, 25), end=(55, 25), width=0.25, layer="F.Cu", net="SIG_A")
+
+        stats = pcb.strip_traces(region=(10, 10, 40, 40))
+
+        assert stats["segments"] == 0
+        assert stats["segments_clipped"] == 0
+        assert stats["segments_boundary_skipped"] == 1
+        assert len(pcb.segments) == 1  # unchanged
+
+    def test_strip_region_via_inside_removed(self):
+        """A via whose point is inside the region is removed."""
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_via(x=25, y=25, layers=("F.Cu", "B.Cu"), net="SIG_A")
+
+        stats = pcb.strip_traces(region=(10, 10, 40, 40))
+
+        assert stats["vias"] == 1
+        assert len(pcb.vias) == 0
+
+    def test_strip_region_via_outside_kept(self):
+        """A via whose point is outside the region is kept."""
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_via(x=70, y=70, layers=("F.Cu", "B.Cu"), net="SIG_A")
+
+        stats = pcb.strip_traces(region=(10, 10, 40, 40))
+
+        assert stats["vias"] == 0
+        assert len(pcb.vias) == 1
+
+    def test_strip_region_and_nets_combined(self):
+        """--region ANDed with --nets: only in-region segments of named net go."""
+        pcb = PCB.create(width=100, height=100)
+        # Inside region, net A — should be removed.
+        pcb.add_trace(start=(20, 20), end=(30, 20), width=0.25, layer="F.Cu", net="NET_A")
+        # Inside region, net B — kept (net filter excludes it).
+        pcb.add_trace(start=(20, 30), end=(30, 30), width=0.25, layer="F.Cu", net="NET_B")
+        # Outside region, net A — kept (spatial filter excludes it).
+        pcb.add_trace(start=(60, 60), end=(70, 60), width=0.25, layer="F.Cu", net="NET_A")
+
+        stats = pcb.strip_traces(region=(10, 10, 40, 40), nets=["NET_A"])
+
+        assert stats["segments"] == 1
+        assert len(pcb.segments) == 2
+        remaining_nets = set()
+        for seg in pcb.segments:
+            for num, net in pcb.nets.items():
+                if num == seg.net_number:
+                    remaining_nets.add(net.name)
+        assert remaining_nets == {"NET_A", "NET_B"}
+
+    def test_strip_region_and_layers_combined(self):
+        """--region ANDed with --layers."""
+        pcb = PCB.create(width=100, height=100)
+        # Inside region, In1.Cu — removed.
+        pcb.add_trace(start=(20, 20), end=(30, 20), width=0.25, layer="In1.Cu", net="SIG_A")
+        # Inside region, F.Cu — kept (layer filter excludes it).
+        pcb.add_trace(start=(20, 25), end=(30, 25), width=0.25, layer="F.Cu", net="SIG_B")
+        # Outside region, In1.Cu — kept (spatial filter excludes it).
+        pcb.add_trace(start=(60, 60), end=(70, 60), width=0.25, layer="In1.Cu", net="SIG_C")
+
+        stats = pcb.strip_traces(region=(10, 10, 40, 40), layers=["In1.Cu"])
+
+        assert stats["segments"] == 1
+        assert len(pcb.segments) == 2
+        remaining_layers = {seg.layer for seg in pcb.segments}
+        assert remaining_layers == {"F.Cu", "In1.Cu"}
+
+    def test_strip_region_triple_and_nets_layers(self):
+        """--region + --nets + --layers all ANDed simultaneously."""
+        pcb = PCB.create(width=100, height=100)
+        # The only match: inside region AND In1.Cu AND net TARGET.
+        pcb.add_trace(start=(20, 20), end=(30, 20), width=0.25, layer="In1.Cu", net="TARGET")
+        # Wrong net.
+        pcb.add_trace(start=(20, 22), end=(30, 22), width=0.25, layer="In1.Cu", net="OTHER")
+        # Wrong layer.
+        pcb.add_trace(start=(20, 24), end=(30, 24), width=0.25, layer="F.Cu", net="TARGET")
+        # Wrong region.
+        pcb.add_trace(start=(60, 60), end=(70, 60), width=0.25, layer="In1.Cu", net="TARGET")
+
+        stats = pcb.strip_traces(region=(10, 10, 40, 40), nets=["TARGET"], layers=["In1.Cu"])
+
+        assert stats["segments"] == 1
+        assert len(pcb.segments) == 3
+
+    def test_strip_region_inverted_coords_normalized(self):
+        """Inverted region coords (x1>x2, y1>y2) are normalized by the API."""
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(start=(20, 20), end=(30, 20), width=0.25, layer="F.Cu", net="SIG_A")
+
+        # Pass the box corners in reversed order — should behave identically.
+        stats = pcb.strip_traces(region=(40, 40, 10, 10))
+
+        assert stats["segments"] == 1
+        assert len(pcb.segments) == 0
+
+    def test_strip_region_no_traces_is_noop(self):
+        """A region containing zero traces removes nothing."""
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(start=(60, 60), end=(70, 60), width=0.25, layer="F.Cu", net="SIG_A")
+
+        stats = pcb.strip_traces(region=(10, 10, 40, 40))
+
+        assert stats["segments"] == 0
+        assert stats["vias"] == 0
+        assert stats["segments_clipped"] == 0
+        assert stats["segments_boundary_skipped"] == 0
+        assert len(pcb.segments) == 1
+
+    def test_strip_region_default_none_is_unbounded(self):
+        """region=None (default) preserves existing whole-board behavior."""
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(start=(20, 20), end=(30, 20), width=0.25, layer="F.Cu", net="SIG_A")
+        pcb.add_trace(start=(60, 60), end=(70, 60), width=0.25, layer="F.Cu", net="SIG_B")
+
+        stats = pcb.strip_traces()
+
+        assert stats["segments"] == 2
+        assert len(pcb.segments) == 0
+
 
 # ---------------------------------------------------------------------------
 # KiCad 10 name-only net format: net_number recovery from PCB headers


### PR DESCRIPTION
## Summary

Phase 1 of #4136: add a spatial bound to `kct pcb strip` so a consumer can surgically rip up only the copper inside an axis-aligned box, leaving the rest of a routed board untouched. This unblocks the rip-up half of chorus#16/#18 (a boxed-in fanout re-dress) without a whole-net strip or a whole-board re-route.

**Phase 2 (region-bounded routing, part (b)) is deferred to a follow-up issue** per the curator's split recommendation in the issue body — this PR is the low-risk, pure-Python, S-expression-level Phase 1 only.

## Changes

- `PCB.strip_traces()` gains a `region: tuple[float,float,float,float] | None` parameter (`src/kicad_tools/schema/pcb.py`):
  - **Via**: stripped only when its `(at x y)` point is inside the box.
  - **Segment fully inside**: removed. **Fully outside**: kept. **Boundary-crossing** (exactly one endpoint inside): clipped to the outside portion (inside endpoint moves to the box edge via a Liang-Barsky-style intersection). **Spanning the box, both ends outside**: left untouched and counted as `segments_boundary_skipped` (splitting would leave a dangling gap with no via/pad termination — the documented skip-and-report fallback).
  - **Zone** (with `--no-keep-zones`): removed only when its whole polygon is inside the box (conservative; no polygon clipping).
  - Coordinates are converted from the sheet-absolute S-expression tree to board-relative before comparison (subtracting `_board_origin`); clipped-segment endpoints are synced back into the parsed `Segment` view so both the tree and the analyzer-facing view agree. Stats gain `segments_clipped` and `segments_boundary_skipped`.
- `--region x1,y1,x2,y2` CLI argument (`src/kicad_tools/cli/parser.py`) with help text documenting the boundary-crossing policy and zone limitation.
- `_run_strip_command()` (`src/kicad_tools/cli/commands/pcb.py`) parses/validates the region (arity, numeric, `x1<x2`/`y1<y2`), fails fast with a clear stderr error + non-zero exit, and threads it through; text and JSON output report the region and clip/skip counts distinctly.
- Tests: 13 API-level (`tests/test_pcb.py::TestStripTraces`) + 7 CLI-level (`tests/test_cli_pcb.py::TestPcbStrip`).

## Acceptance Criteria Verification

| Criterion (Phase 1) | Status | Verification |
|---------------------|--------|--------------|
| Removes only geometry inside the box; outside unchanged | ✅ | `test_strip_region_segment_fully_inside_removed`, `_fully_outside_kept`, `_via_inside_removed`, `_via_outside_kept` |
| Composable with `--nets` (ANDed) and `--layers` | ✅ | `test_strip_region_and_nets_combined`, `_and_layers_combined`, `_triple_and_nets_layers`, CLI `_cli_and_nets_combined` |
| Boundary-crossing handled per documented policy | ✅ | Clip: `test_strip_region_crossing_segment_is_clipped` (+ save round-trip); skip-and-report: `_both_endpoints_outside_spanning_box_skipped` |
| `--dry-run` / `--format json` report region-filtered counts distinctly | ✅ | `test_strip_region_cli_json_reports_region_stats`, `_cli_dry_run_text`; smoke-tested JSON shows `segments_clipped`/`segments_boundary_skipped` |
| Invalid region fails fast with clear error | ✅ | `test_strip_region_cli_invalid_wrong_count`, `_invalid_non_numeric`, `_invalid_inverted` (all exit 1) |
| No regression to `--nets`/`--layers`-only (region defaults None) | ✅ | `test_strip_region_default_none_is_unbounded`; all 284 pcb + cli_pcb tests pass |

## Test Plan

- `uv run pytest tests/test_pcb.py tests/test_cli_pcb.py -q` → **284 passed**.
- `uv run ruff check` + `ruff format --check` on all 5 changed files → clean.
- `uv run mypy` on the 3 changed source files → **zero new errors** (pre-existing baseline unchanged; no error falls within the added region code).
- Manual end-to-end: `kct pcb strip <synthetic>.kicad_pcb --region 10,10,40,40 --dry-run --format json` correctly clips a crossing segment, removes an in-region via, keeps an outside segment, and reports region stats; inverted/short/non-numeric regions exit 1 with clear messages.

Synthetic boards only (chorus is local-only, not in CI).

Closes #4136