### PR TITLE
feat(check): add courtyard-overlap sub-check with pair-level waiver file

### DIFF
--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -652,6 +652,7 @@ CHECK_CATEGORIES = [
     "segment_zone",
     "via_zone",
     "copper_sliver",
+    "courtyard_overlap",
     "diffpair_clearance_intra",
     "diffpair_length_skew",
     "diffpair_routing_continuity",
@@ -819,6 +820,19 @@ def main(argv: list[str] | None = None) -> int:
             "When supplied, enables the diff-pair routing_continuity and "
             "length_skew rules to fire on routed boards; without it those "
             "rules degrade to no-ops (Issue #2684)."
+        ),
+    )
+    parser.add_argument(
+        "--courtyard-waivers",
+        dest="courtyard_waivers",
+        default=None,
+        help=(
+            "Path to a .courtyard_waivers.json sidecar waiving specific "
+            "courtyard-overlap pairs (see kicad_tools.validate.rules."
+            "courtyard_waivers). When supplied, overlapping courtyard pairs "
+            "matching a waiver entry report as WAIVED instead of failing the "
+            "gate. Auto-discovered next to the board when this flag is "
+            "omitted (Issue #4137)."
         ),
     )
     # Issue #3061: auto-derive the pad_grid tolerance from each board's
@@ -1019,6 +1033,47 @@ def main(argv: list[str] | None = None) -> int:
                 file=sys.stderr,
             )
 
+    # Load optional courtyard-waivers sidecar (Issue #4137).  An explicit
+    # --courtyard-waivers path always wins and a malformed explicit file is a
+    # hard error; an auto-discovered sidecar that fails to parse degrades
+    # gracefully (warn + zero waivers) -- mirroring the --net-class-map
+    # contract above exactly.
+    from kicad_tools.validate.rules.courtyard_waivers import (
+        discover_courtyard_waivers_sidecar,
+        load_courtyard_waivers,
+    )
+
+    courtyard_waivers = None
+    cw_explicit = args.courtyard_waivers is not None
+    if cw_explicit:
+        cw_path: Path | None = Path(args.courtyard_waivers).resolve()
+    else:
+        cw_path = discover_courtyard_waivers_sidecar(pcb_path)
+
+    if cw_path is not None:
+        if not cw_path.exists():
+            # Only reachable via an explicit flag (the auto-probe returns
+            # existing files only).
+            print(f"Error: courtyard-waivers file not found: {cw_path}", file=sys.stderr)
+            return 1
+        try:
+            courtyard_waivers = load_courtyard_waivers(cw_path)
+        except ValueError as e:
+            if cw_explicit:
+                print(f"Error: {e}", file=sys.stderr)
+                return 1
+            print(
+                f"WARNING: ignoring malformed courtyard-waivers sidecar {cw_path}: {e}",
+                file=sys.stderr,
+            )
+            courtyard_waivers = None
+        else:
+            if not cw_explicit:
+                print(
+                    f"[INFO] auto-loaded courtyard-waivers sidecar: {cw_path}",
+                    file=sys.stderr,
+                )
+
     # Create checker with manufacturer rules
     try:
         checker = DRCChecker(
@@ -1039,6 +1094,7 @@ def main(argv: list[str] | None = None) -> int:
             # sidecar the skew rules produce no info findings, so this is a
             # graceful no-op (AC5).
             emit_measurements=True,
+            courtyard_waivers=courtyard_waivers,
         )
     except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)
@@ -1204,6 +1260,7 @@ def run_selected_checks(
         "segment_zone": checker.check_segment_zone_clearances,
         "via_zone": checker.check_via_zone_clearances,
         "copper_sliver": checker.check_copper_slivers,
+        "courtyard_overlap": checker.check_courtyard_overlap,
         "diffpair_clearance_intra": checker.check_diffpair_clearance_intra,
         "diffpair_length_skew": checker.check_diffpair_length_skew,
         "diffpair_routing_continuity": checker.check_diffpair_routing_continuity,
@@ -1313,6 +1370,7 @@ def output_table(
     error_count = sum(1 for v in violations if v.is_error)
     warning_count = sum(1 for v in violations if v.is_warning)
     info_count = sum(1 for v in violations if v.is_info)
+    waived_count = sum(1 for v in violations if v.is_waived)
 
     print(f"\n{'=' * 60}")
     print("PURE PYTHON DRC CHECK")
@@ -1327,6 +1385,8 @@ def output_table(
     print(f"  Warnings:   {warning_count}")
     if info_count > 0:
         print(f"  Infos:      {info_count}")
+    if waived_count > 0:
+        print(f"  Waived:     {waived_count}")
     if results.suppressed_count > 0:
         print(f"  Suppressed: {results.suppressed_count} (standard library footprints)")
 
@@ -1363,8 +1423,10 @@ def output_table(
     by_rule_relationship: dict[str, dict[str, int]] = {}
     for v in by_rule_source:
         if v.rule_id not in by_rule:
-            by_rule[v.rule_id] = {"errors": 0, "warnings": 0, "infos": 0}
-        if v.is_error:
+            by_rule[v.rule_id] = {"errors": 0, "warnings": 0, "infos": 0, "waived": 0}
+        if v.is_waived:
+            by_rule[v.rule_id]["waived"] += 1
+        elif v.is_error:
             by_rule[v.rule_id]["errors"] += 1
         elif v.is_info:
             by_rule[v.rule_id]["infos"] += 1
@@ -1387,7 +1449,7 @@ def output_table(
         print("BY RULE:")
     for rule_id, counts in sorted(
         by_rule.items(),
-        key=lambda x: -(x[1]["errors"] + x[1]["warnings"] + x[1]["infos"]),
+        key=lambda x: -(x[1]["errors"] + x[1]["warnings"] + x[1]["infos"] + x[1].get("waived", 0)),
     ):
         parts = []
         if counts["errors"]:
@@ -1396,6 +1458,8 @@ def output_table(
             parts.append(f"{counts['warnings']} warning{'s' if counts['warnings'] != 1 else ''}")
         if counts["infos"]:
             parts.append(f"{counts['infos']} info{'s' if counts['infos'] != 1 else ''}")
+        if counts.get("waived"):
+            parts.append(f"{counts['waived']} waived")
         line = f"  {rule_id}: {', '.join(parts)}"
         # Issue #4102: append the same-net / different-net breakdown for
         # net-relationship rules, e.g.
@@ -1411,6 +1475,7 @@ def output_table(
     errors = [v for v in violations if v.is_error]
     warnings = [v for v in violations if v.is_warning]
     infos = [v for v in violations if v.is_info]
+    waived = [v for v in violations if v.is_waived]
 
     if errors:
         print(f"\n{'-' * 60}")
@@ -1444,6 +1509,23 @@ def output_table(
             _print_violation(v, verbose)
         if len(display_infos_source) > 10 and not verbose:
             print(f"\n  ... and {len(display_infos_source) - 10} more infos (use --verbose)")
+
+    # Issue #4137: waived findings are visible and counted but non-blocking.
+    # Render them in a dedicated WAIVED section so a reviewer can audit each
+    # documented exception (with its reason / tracking issue).
+    if waived:
+        print(f"\n{'-' * 60}")
+        print("WAIVED (documented exceptions, non-blocking):")
+        for v in waived:
+            print(f"\n  [W] {v.rule_id}")
+            print(f"      {v.message}")
+            if v.waiver_issue:
+                print(f"      Waiver issue: {v.waiver_issue}")
+            if verbose:
+                if v.items:
+                    print(f"      Items: {', '.join(v.items)}")
+                if v.layer:
+                    print(f"      Layer: {v.layer}")
 
     print(f"\n{'=' * 60}")
     if errors:
@@ -1516,11 +1598,15 @@ def output_json(
     error_count = sum(1 for v in violations if v.is_error)
     warning_count = sum(1 for v in violations if v.is_warning)
     info_count = sum(1 for v in violations if v.is_info)
+    waived_count = sum(1 for v in violations if v.is_waived)
 
     summary_data: dict = {
         "errors": error_count,
         "warnings": warning_count,
         "infos": info_count,
+        # Issue #4137: waived findings are counted distinctly and never
+        # contribute to ``passed`` (which keys off ``errors``).
+        "waived": waived_count,
         "rules_checked": results.rules_checked,
         # Issue #2660 / Epic #2556 Phase 4N: per-rule check counter.
         # The single ``rules_checked`` integer cannot tell a CI consumer
@@ -1567,11 +1653,15 @@ def write_json_report(
     error_count = sum(1 for v in violations if v.is_error)
     warning_count = sum(1 for v in violations if v.is_warning)
     info_count = sum(1 for v in violations if v.is_info)
+    waived_count = sum(1 for v in violations if v.is_waived)
 
     summary_data: dict = {
         "errors": error_count,
         "warnings": warning_count,
         "infos": info_count,
+        # Issue #4137: waived findings are counted distinctly and never
+        # contribute to ``passed`` (which keys off ``errors``).
+        "waived": waived_count,
         "rules_checked": results.rules_checked,
         # See ``output_json`` for the rationale on emitting this field
         # alongside the aggregate ``rules_checked`` integer.  Issue

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -408,18 +408,21 @@ class FootprintText:
 
 @dataclass
 class FootprintGraphic:
-    """Graphic element within a footprint (fp_line, fp_rect, fp_circle, fp_arc).
+    """Graphic element within a footprint (fp_line, fp_rect, fp_circle, fp_arc, fp_poly).
 
-    Used for silkscreen outlines and markings on footprints.
+    Used for silkscreen outlines, courtyard outlines, and markings on
+    footprints.  ``fp_poly`` graphics store their vertices in ``points``;
+    all other types leave ``points`` empty.
     """
 
-    graphic_type: str  # line, rect, circle, arc
+    graphic_type: str  # line, rect, circle, arc, poly
     layer: str
     stroke_width: float  # in mm
     start: tuple[float, float] = (0.0, 0.0)
     end: tuple[float, float] = (0.0, 0.0)
     center: tuple[float, float] | None = None
     radius: float | None = None
+    points: list[tuple[float, float]] = field(default_factory=list)
     uuid: str = ""
 
     @classmethod
@@ -452,6 +455,12 @@ class FootprintGraphic:
         if end := sexp.find("end"):
             # For circles, end is a point on the circumference
             pass
+
+        # Polygon vertices (for fp_poly): (pts (xy X Y) ...).
+        if graphic_type == "poly":
+            if pts := sexp.find("pts"):
+                for xy in pts.find_all("xy"):
+                    graphic.points.append((xy.get_float(0) or 0.0, xy.get_float(1) or 0.0))
 
         # UUID
         if uuid := sexp.find("uuid"):
@@ -916,8 +925,8 @@ class Footprint:
             if pad:
                 fp.pads.append(pad)
 
-        # Graphics (fp_line, fp_rect, fp_circle, fp_arc)
-        for graphic_type in ("line", "rect", "circle", "arc"):
+        # Graphics (fp_line, fp_rect, fp_circle, fp_arc, fp_poly)
+        for graphic_type in ("line", "rect", "circle", "arc", "poly"):
             for graphic_sexp in sexp.find_all(f"fp_{graphic_type}"):
                 graphic = FootprintGraphic.from_sexp(graphic_sexp, graphic_type)
                 fp.graphics.append(graphic)

--- a/src/kicad_tools/validate/checker.py
+++ b/src/kicad_tools/validate/checker.py
@@ -15,6 +15,7 @@ from kicad_tools.manufacturers import DesignRules, get_profile
 from .rules.clearance import ClearanceRule, SegmentZoneClearanceRule, ViaZoneClearanceRule
 from .rules.connectivity import ConnectivityRule
 from .rules.copper_sliver import CopperSliverRule
+from .rules.courtyard import CourtyardOverlapRule
 from .rules.diffpair_clearance_intra import DiffPairClearanceIntraRule
 from .rules.diffpair_length_skew import DiffPairLengthSkewRule
 from .rules.diffpair_routing_continuity import DiffPairRoutingContinuityRule
@@ -31,6 +32,7 @@ if TYPE_CHECKING:
     from kicad_tools.router.rules import NetClassRouting
     from kicad_tools.schema.pcb import PCB
     from kicad_tools.validate.filters import ViolationFilter
+    from kicad_tools.validate.rules.courtyard_waivers import CourtyardWaivers
 
 
 class DRCChecker:
@@ -71,6 +73,7 @@ class DRCChecker:
         warn_on_inactive_skew_rules: bool = True,
         verbose: bool = False,
         emit_measurements: bool = False,
+        courtyard_waivers: CourtyardWaivers | None = None,
     ) -> None:
         """Initialize the DRC checker.
 
@@ -114,6 +117,13 @@ class DRCChecker:
                 #3924 AC1).  The ``kct check`` CLI sets this True so it can
                 render a concise measurement summary after the violation
                 table.
+            courtyard_waivers: Optional loaded
+                :class:`~kicad_tools.validate.rules.courtyard_waivers.CourtyardWaivers`.
+                When provided, ``check_courtyard_overlap`` emits ``waived=True``
+                findings for overlapping courtyard pairs that match a waiver
+                entry (instead of blocking errors), and an ``info`` "unused
+                waiver" finding for entries naming an absent component.  When
+                omitted, every overlap is a blocking error (Issue #4137).
 
         Raises:
             ValueError: If manufacturer ID is not recognized
@@ -124,6 +134,7 @@ class DRCChecker:
         self.copper_oz = copper_oz
         self.suppress_library = suppress_library
         self.net_class_map = net_class_map
+        self.courtyard_waivers = courtyard_waivers
         self.warn_on_inactive_skew_rules = warn_on_inactive_skew_rules
         self.verbose = verbose
         self.emit_measurements = emit_measurements
@@ -157,6 +168,7 @@ class DRCChecker:
         "check_segment_zone_clearances",
         "check_via_zone_clearances",
         "check_copper_slivers",
+        "check_courtyard_overlap",
         "check_diffpair_clearance_intra",
         "check_diffpair_length_skew",
         "check_diffpair_routing_continuity",
@@ -376,6 +388,30 @@ class DRCChecker:
         """
         rule = CopperSliverRule()
         return self._absolutize(rule.check(self.pcb, self.design_rules))
+
+    def check_courtyard_overlap(self) -> DRCResults:
+        """Check that footprint courtyards do not overlap on the same side.
+
+        Reads the true ``F.CrtYd`` / ``B.CrtYd`` polygon geometry from each
+        footprint (not the pads-bbox approximation in
+        :mod:`kicad_tools.placement.analyzer`) and flags pairs of footprints
+        on the same board side whose courtyards intersect with positive area.
+
+        Overlapping pairs matched by a loaded ``.courtyard_waivers.json``
+        entry (passed via the ``courtyard_waivers`` constructor kwarg) are
+        emitted with ``waived=True`` -- visible and counted in
+        ``waived_count`` but excluded from ``error_count`` so the gate passes.
+        A courtyard that cannot be resolved to a polygon emits an ``info``
+        finding rather than being silently skipped, and a waiver naming a
+        component absent from the board emits an ``info`` "unused waiver"
+        finding (Issue #4137).
+
+        Returns:
+            DRCResults containing ``courtyards_overlap`` findings (error or
+            waived) plus advisory info findings.
+        """
+        rule = CourtyardOverlapRule(waivers=self.courtyard_waivers)
+        return self._absolutize(rule.check(self.pcb))
 
     def check_connectivity(self) -> DRCResults:
         """Check that every multi-pad net is fully connected.

--- a/src/kicad_tools/validate/models.py
+++ b/src/kicad_tools/validate/models.py
@@ -79,6 +79,11 @@ class BaseViolation(BaseModel):
         """Check if this is an info severity violation."""
         return self.severity == Severity.INFO
 
+    @property
+    def is_waived(self) -> bool:
+        """Pydantic-model violations are never waiver-matched (Issue #4137)."""
+        return False
+
     def to_dict(self) -> dict:
         """Convert to dictionary for backwards-compatible serialization."""
         return self.model_dump(mode="json")

--- a/src/kicad_tools/validate/rules/courtyard.py
+++ b/src/kicad_tools/validate/rules/courtyard.py
@@ -1,0 +1,359 @@
+"""Courtyard-overlap DRC rule with pair-level waiver support (Issue #4137).
+
+This module implements a pure-Python courtyard-overlap check that reads the
+true ``F.CrtYd`` / ``B.CrtYd`` polygon geometry from each footprint (not the
+pads-bbox approximation in :mod:`kicad_tools.placement.analyzer`) and flags
+pairs of footprints on the same board side whose courtyards intersect.
+
+Overlapping pairs that match a loaded waiver entry
+(``.courtyard_waivers.json``) are reported as ``waived=True`` -- visible and
+counted, but excluded from the error count so the gate passes.  This makes the
+courtyard gate fully headless and independent of ``kicad-cli``'s per-instance
+``drc_exclusions`` handling (which is not honored by ``kicad-cli`` 10.0.4
+headless).
+
+Courtyard-outline extraction supports two representations:
+
+* ``fp_rect`` -- a single axis-aligned rectangle (fast path).
+* ``fp_line`` -- a closed loop of line segments chained by endpoint matching.
+
+A courtyard that cannot be resolved from these (e.g. an ``fp_poly``-only
+outline, or an ``fp_line`` chain that does not close) emits an ``info``-severity
+"could not resolve courtyard outline" finding instead of silently skipping the
+footprint, so the gap is visible rather than a silent false negative.
+
+Note on ``fp_poly``: the schema parser now records ``fp_poly`` vertices in
+:attr:`FootprintGraphic.points`.  This rule *does* consume them when present
+(a closed polygon is directly usable), so the "unresolved" info finding is
+reserved for genuinely-degenerate outlines (no CrtYd geometry, non-closing
+line chains, or fewer than three vertices).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, Any
+
+from kicad_tools._shapely import require_shapely
+from kicad_tools.core.types import Layer
+
+from ..violations import DRCResults, DRCViolation
+
+if TYPE_CHECKING:
+    from kicad_tools.schema.pcb import Footprint, FootprintGraphic
+    from kicad_tools.validate.rules.courtyard_waivers import CourtyardWaivers
+
+# Rule id for courtyard-overlap findings.  Matches the ``rule`` field expected
+# in ``.courtyard_waivers.json`` entries and resolves to
+# ``ViolationType.COURTYARD_OVERLAP`` via ``ViolationType.from_string`` (which
+# maps any rule id containing ``"courtyard"``).
+COURTYARD_RULE_ID = "courtyards_overlap"
+
+# Rule id for the advisory "could not resolve courtyard outline" info finding.
+COURTYARD_UNRESOLVED_RULE_ID = "courtyard_outline_unresolved"
+
+# Rule id for the advisory "unused waiver" info finding.
+COURTYARD_UNUSED_WAIVER_RULE_ID = "courtyard_waiver_unused"
+
+# Endpoint-matching tolerance (mm) when chaining ``fp_line`` segments into a
+# closed courtyard ring.  Courtyard vertices are authored on a coarse grid;
+# 1e-3 mm is comfortably below any real feature yet absorbs float noise.
+_CHAIN_EPSILON_MM = 1e-3
+
+
+def _fp_transform(footprint: Footprint):
+    """Return a ``(x, y) -> (X, Y)`` local->board transform for a footprint.
+
+    Mirrors ``validate.rules.silkscreen._fp_transform``: KiCad negates the
+    footprint orientation angle relative to CCW math (verified in #3739), so
+    the rotation applied here is ``radians(-rotation)``.
+    """
+    fp_x, fp_y = footprint.position
+    fp_rotation = math.radians(-footprint.rotation)
+    cos_rot = math.cos(fp_rotation)
+    sin_rot = math.sin(fp_rotation)
+
+    def transform(point: tuple[float, float]) -> tuple[float, float]:
+        lx, ly = point
+        return (
+            fp_x + (lx * cos_rot - ly * sin_rot),
+            fp_y + (lx * sin_rot + ly * cos_rot),
+        )
+
+    return transform
+
+
+def _courtyard_side(layer: str) -> str | None:
+    """Return ``"F"`` / ``"B"`` for a courtyard layer, else ``None``."""
+    if layer == Layer.F_CRTYD.value:
+        return "F"
+    if layer == Layer.B_CRTYD.value:
+        return "B"
+    return None
+
+
+def _rect_ring(graphic: FootprintGraphic) -> list[tuple[float, float]]:
+    """Return the 5-point closed ring for an ``fp_rect`` graphic (local space)."""
+    sx, sy = graphic.start
+    ex, ey = graphic.end
+    return [(sx, sy), (ex, sy), (ex, ey), (sx, ey), (sx, sy)]
+
+
+def _chain_lines(
+    segments: list[tuple[tuple[float, float], tuple[float, float]]],
+) -> list[tuple[float, float]] | None:
+    """Chain line segments into a single closed ring by endpoint matching.
+
+    Returns the ordered ring of vertices (first == last) when the segments
+    form exactly one closed loop, else ``None`` (open chain, branching, or
+    disconnected components -- not a resolvable simple courtyard).
+    """
+    if not segments:
+        return None
+
+    def close(a: tuple[float, float], b: tuple[float, float]) -> bool:
+        return math.hypot(a[0] - b[0], a[1] - b[1]) <= _CHAIN_EPSILON_MM
+
+    remaining = list(segments)
+    start, current = remaining.pop(0)
+    ring: list[tuple[float, float]] = [start, current]
+
+    while remaining:
+        for idx, (a, b) in enumerate(remaining):
+            if close(a, current):
+                current = b
+                ring.append(current)
+                remaining.pop(idx)
+                break
+            if close(b, current):
+                current = a
+                ring.append(current)
+                remaining.pop(idx)
+                break
+        else:
+            # No segment continues the chain -> not a single closed loop.
+            return None
+
+    # A closed loop returns to its start.
+    if not close(ring[0], ring[-1]):
+        return None
+    return ring
+
+
+def _courtyard_polygon(footprint: Footprint, side: str, Polygon: Any):
+    """Build a shapely polygon for a footprint's courtyard on ``side``.
+
+    ``side`` is ``"F"`` or ``"B"``.  Returns ``None`` when no courtyard
+    geometry on that side can be resolved into a valid closed polygon.
+    """
+    target_layer = Layer.F_CRTYD.value if side == "F" else Layer.B_CRTYD.value
+    transform = _fp_transform(footprint)
+
+    rects: list[FootprintGraphic] = []
+    polys: list[FootprintGraphic] = []
+    line_segments: list[tuple[tuple[float, float], tuple[float, float]]] = []
+    for graphic in footprint.graphics:
+        if graphic.layer != target_layer:
+            continue
+        if graphic.graphic_type == "rect":
+            rects.append(graphic)
+        elif graphic.graphic_type == "poly":
+            polys.append(graphic)
+        elif graphic.graphic_type == "line":
+            line_segments.append((graphic.start, graphic.end))
+        # circle / arc courtyards are not modeled (rare for courtyards).
+
+    ring: list[tuple[float, float]] | None = None
+    if rects:
+        # A single rect fully describes the courtyard; if multiple exist we
+        # take the first (the common single-rect case).
+        ring = _rect_ring(rects[0])
+    elif polys and len(polys[0].points) >= 3:
+        ring = list(polys[0].points)
+    elif line_segments:
+        ring = _chain_lines(line_segments)
+
+    if ring is None or len(ring) < 3:
+        return None
+
+    board_ring = [transform(p) for p in ring]
+    polygon = Polygon(board_ring)
+    if not polygon.is_valid:
+        polygon = polygon.buffer(0)
+    if polygon.is_empty or polygon.area <= 0:
+        return None
+    return polygon
+
+
+def _has_courtyard_geometry(footprint: Footprint) -> bool:
+    """True if the footprint has any F/B CrtYd graphic at all."""
+    return any(_courtyard_side(graphic.layer) is not None for graphic in footprint.graphics)
+
+
+class CourtyardOverlapRule:
+    """Detect footprints whose courtyards overlap on the same board side.
+
+    For each unordered pair of footprints on the same side (front/back) the
+    rule builds their real ``F.CrtYd`` / ``B.CrtYd`` polygons and tests for a
+    positive-area intersection.  Overlapping pairs are reported as
+    ``severity="error"`` unless matched by a waiver entry, in which case the
+    finding is emitted with ``waived=True`` (visible, counted, non-blocking).
+
+    Rule IDs generated:
+        - ``courtyards_overlap``: two courtyards overlap (error, or waived).
+        - ``courtyard_outline_unresolved``: a footprint's courtyard could not
+          be resolved to a polygon (info).
+        - ``courtyard_waiver_unused``: a loaded waiver names a pair not present
+          on the board (info).
+    """
+
+    rule_id = COURTYARD_RULE_ID
+    name = "Courtyard Overlap"
+    description = "Check that footprint courtyards do not overlap on the same board side"
+
+    def __init__(self, waivers: CourtyardWaivers | None = None) -> None:
+        self.waivers = waivers
+
+    def check(self, pcb: Any) -> DRCResults:
+        """Check all footprint courtyard pairs for overlap.
+
+        Args:
+            pcb: The PCB to check.
+
+        Returns:
+            DRCResults containing courtyard-overlap findings (error / waived),
+            plus advisory info findings for unresolved outlines and unused
+            waivers.
+        """
+        require_shapely("courtyard-overlap check")
+        from shapely.geometry import Polygon  # type: ignore[import-untyped]
+
+        results = DRCResults()
+        results.rules_checked += 1
+
+        footprints = list(pcb.footprints)
+
+        # Resolve each footprint's courtyard polygon per side.  A footprint
+        # can carry courtyards on both sides (e.g. tall parts), so key by
+        # (reference, side).
+        polygons: dict[tuple[str, str], Any] = {}
+        for fp in footprints:
+            has_geom = _has_courtyard_geometry(fp)
+            resolved_any = False
+            for side in ("F", "B"):
+                # Only attempt sides that actually have geometry.
+                if not any(
+                    graphic.layer == (Layer.F_CRTYD.value if side == "F" else Layer.B_CRTYD.value)
+                    for graphic in fp.graphics
+                ):
+                    continue
+                poly = _courtyard_polygon(fp, side, Polygon)
+                if poly is not None:
+                    polygons[(fp.reference, side)] = poly
+                    resolved_any = True
+            if has_geom and not resolved_any:
+                # Geometry exists on a CrtYd layer but we could not build a
+                # polygon from it -- surface the gap.
+                results.add(
+                    DRCViolation(
+                        rule_id=COURTYARD_UNRESOLVED_RULE_ID,
+                        severity="info",
+                        message=(
+                            f"Could not resolve courtyard outline for "
+                            f"{fp.reference} (unsupported or non-closing "
+                            f"courtyard geometry); pair overlap not checked "
+                            f"for this footprint"
+                        ),
+                        location=fp.position,
+                        layer=fp.layer,
+                        items=(fp.reference,),
+                    )
+                )
+
+        # Pairwise overlap test within each side.
+        keys = list(polygons.keys())
+        for i in range(len(keys)):
+            for j in range(i + 1, len(keys)):
+                ref_a, side_a = keys[i]
+                ref_b, side_b = keys[j]
+                if side_a != side_b:
+                    # Courtyards on different board sides never conflict.
+                    continue
+                if ref_a == ref_b:
+                    continue
+                poly_a = polygons[keys[i]]
+                poly_b = polygons[keys[j]]
+                if not poly_a.intersects(poly_b):
+                    continue
+                inter = poly_a.intersection(poly_b)
+                if inter.is_empty or inter.area <= 0:
+                    # Exactly-touching (zero-area) courtyards do not conflict.
+                    continue
+                self._emit_overlap(results, ref_a, ref_b, side_a, inter.area)
+
+        # Advisory: waivers that did not match any board pair (stale entries).
+        if self.waivers is not None:
+            present_refs = {fp.reference for fp in footprints}
+            for entry in self.waivers.entries:
+                missing = [r for r in entry.refs if r not in present_refs]
+                if missing:
+                    results.add(
+                        DRCViolation(
+                            rule_id=COURTYARD_UNUSED_WAIVER_RULE_ID,
+                            severity="info",
+                            message=(
+                                f"Unused courtyard waiver for "
+                                f"{entry.refs[0]}/{entry.refs[1]}: "
+                                f"component(s) {', '.join(missing)} not present "
+                                f"on the board (stale waiver -- consider "
+                                f"pruning)"
+                            ),
+                            items=tuple(entry.refs),
+                        )
+                    )
+
+        return results
+
+    def _emit_overlap(
+        self,
+        results: DRCResults,
+        ref_a: str,
+        ref_b: str,
+        side: str,
+        overlap_area: float,
+    ) -> None:
+        """Emit a courtyard-overlap finding, waived when a waiver matches."""
+        waiver = None
+        if self.waivers is not None:
+            waiver = self.waivers.match(ref_a, ref_b)
+
+        side_layer = Layer.F_CRTYD.value if side == "F" else Layer.B_CRTYD.value
+        base_message = (
+            f"Courtyards of {ref_a} and {ref_b} overlap ({overlap_area:.3f} mm^2) on {side_layer}"
+        )
+
+        if waiver is not None:
+            results.add(
+                DRCViolation(
+                    rule_id=COURTYARD_RULE_ID,
+                    severity="error",
+                    message=f"{base_message} [WAIVED: {waiver.reason}]",
+                    layer=side_layer,
+                    actual_value=round(overlap_area, 4),
+                    items=(ref_a, ref_b),
+                    waived=True,
+                    waiver_reason=waiver.reason,
+                    waiver_issue=waiver.issue,
+                )
+            )
+        else:
+            results.add(
+                DRCViolation(
+                    rule_id=COURTYARD_RULE_ID,
+                    severity="error",
+                    message=base_message,
+                    layer=side_layer,
+                    actual_value=round(overlap_area, 4),
+                    items=(ref_a, ref_b),
+                )
+            )

--- a/src/kicad_tools/validate/rules/courtyard_waivers.py
+++ b/src/kicad_tools/validate/rules/courtyard_waivers.py
@@ -1,0 +1,193 @@
+"""Loader and validator for the ``.courtyard_waivers.json`` sidecar (Issue #4137).
+
+The waiver file is a versioned, human-editable JSON sidecar committed next to
+the ``.kicad_pcb`` (mirroring the ``.constraints.json`` / ``net_class_map.json``
+precedents).  Each entry waives one *pair* of footprint courtyards from the
+``courtyards_overlap`` gate, so an intentional, EE-mandated exception (e.g. a
+decoupling cap placed tight against its IC) is reported as ``WAIVED`` rather
+than failing the board -- while any *new*, undocumented overlap still fails.
+
+Schema (``version == 1``)::
+
+    {
+      "version": 1,
+      "waivers": [
+        {
+          "rule": "courtyards_overlap",
+          "refs": ["C52", "U10"],
+          "reason": "EE-mandated tight decoupling, cap <=2mm from VCC pin",
+          "issue": "chorus#13"
+        }
+      ]
+    }
+
+The ``refs`` pair is order-insensitive: ``["C52", "U10"]`` matches an overlap
+reported as ``(U10, C52)`` and vice versa.
+
+Discovery / loading contract mirrors ``net_class_map`` exactly:
+
+* An explicit ``--courtyard-waivers <path>`` always wins and a malformed
+  explicit file is a hard error.
+* An auto-discovered sidecar that fails to parse degrades gracefully (the
+  caller warns and continues with zero waivers).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# The only schema version understood by this loader.  Reject other values with
+# a clear error rather than silently misinterpreting a future schema.
+SUPPORTED_VERSION = 1
+
+# The rule id a waiver entry must target.  Kept as a constant so a future rule
+# reusing this waiver format only has to widen this set.
+_VALID_RULES = frozenset({"courtyards_overlap"})
+
+
+@dataclass(frozen=True)
+class CourtyardWaiver:
+    """A single pair-level courtyard-overlap waiver entry.
+
+    Attributes:
+        rule: The rule id this waiver applies to (``"courtyards_overlap"``).
+        refs: The unordered pair of component references, stored sorted so
+            matching is order-insensitive.
+        reason: Human-readable justification (non-empty).
+        issue: Tracking reference, e.g. ``"chorus#13"`` (non-empty).
+    """
+
+    rule: str
+    refs: tuple[str, str]
+    reason: str
+    issue: str
+
+
+@dataclass
+class CourtyardWaivers:
+    """A loaded, validated collection of courtyard waiver entries."""
+
+    entries: list[CourtyardWaiver] = field(default_factory=list)
+
+    def match(self, ref_a: str, ref_b: str) -> CourtyardWaiver | None:
+        """Return the waiver matching the unordered pair, or ``None``.
+
+        Matching is order-insensitive: ``match("A", "B")`` and
+        ``match("B", "A")`` return the same entry.
+        """
+        key = tuple(sorted((ref_a, ref_b)))
+        for entry in self.entries:
+            if entry.refs == key:
+                return entry
+        return None
+
+    def __len__(self) -> int:
+        return len(self.entries)
+
+
+def courtyard_waivers_from_dict(data: Any) -> CourtyardWaivers:
+    """Build :class:`CourtyardWaivers` from parsed JSON data.
+
+    Raises:
+        ValueError: if the top-level structure, ``version``, or any waiver
+            entry is malformed.  The message identifies the offending entry's
+            index / content so a human can fix the file quickly.
+    """
+    if not isinstance(data, dict):
+        raise ValueError(f"courtyard-waivers file must be a JSON object, got {type(data).__name__}")
+
+    if "version" not in data:
+        raise ValueError("courtyard-waivers file is missing the required 'version' key")
+    version = data["version"]
+    if version != SUPPORTED_VERSION:
+        raise ValueError(
+            f"unsupported courtyard-waivers version {version!r} "
+            f"(this build understands version {SUPPORTED_VERSION})"
+        )
+
+    raw_waivers = data.get("waivers", [])
+    if not isinstance(raw_waivers, list):
+        raise ValueError("courtyard-waivers 'waivers' must be a list")
+
+    entries: list[CourtyardWaiver] = []
+    for idx, raw in enumerate(raw_waivers):
+        entries.append(_parse_entry(idx, raw))
+
+    return CourtyardWaivers(entries=entries)
+
+
+def _parse_entry(idx: int, raw: Any) -> CourtyardWaiver:
+    """Validate and build one waiver entry, raising on any defect."""
+    where = f"courtyard waiver #{idx}"
+    if not isinstance(raw, dict):
+        raise ValueError(f"{where} must be an object, got {type(raw).__name__}")
+
+    rule = raw.get("rule")
+    if not isinstance(rule, str) or not rule:
+        raise ValueError(f"{where} is missing a non-empty string 'rule'")
+    if rule not in _VALID_RULES:
+        raise ValueError(
+            f"{where} has unsupported rule {rule!r} (expected one of {sorted(_VALID_RULES)})"
+        )
+
+    refs = raw.get("refs")
+    if not isinstance(refs, list) or len(refs) != 2:
+        raise ValueError(f"{where} 'refs' must be a list of exactly 2 references")
+    if not all(isinstance(r, str) and r for r in refs):
+        raise ValueError(f"{where} 'refs' entries must be non-empty strings")
+    if refs[0] == refs[1]:
+        raise ValueError(f"{where} 'refs' must name two distinct components")
+
+    reason = raw.get("reason")
+    if not isinstance(reason, str) or not reason.strip():
+        raise ValueError(f"{where} is missing a non-empty 'reason'")
+
+    issue = raw.get("issue")
+    if not isinstance(issue, str) or not issue.strip():
+        raise ValueError(f"{where} is missing a non-empty 'issue'")
+
+    ordered = sorted(refs)
+    return CourtyardWaiver(
+        rule=rule,
+        refs=(ordered[0], ordered[1]),
+        reason=reason,
+        issue=issue,
+    )
+
+
+def load_courtyard_waivers(path: Path) -> CourtyardWaivers:
+    """Load and validate a ``.courtyard_waivers.json`` file.
+
+    Raises:
+        ValueError: if the file is not valid JSON or fails schema validation.
+    """
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        raise ValueError(f"parsing courtyard-waivers JSON: {e}") from e
+    return courtyard_waivers_from_dict(data)
+
+
+def discover_courtyard_waivers_sidecar(pcb_path: Path) -> Path | None:
+    """Probe conventional locations for a ``.courtyard_waivers.json`` sidecar.
+
+    Mirrors ``check_cmd._discover_net_class_map_sidecar``: probe the PCB
+    directory, then a sibling ``output/`` subdir, then ``../output/``.
+
+    Returns:
+        The first existing candidate path, or ``None`` when no sidecar found.
+    """
+    pcb_dir = pcb_path.parent
+    filename = ".courtyard_waivers.json"
+    candidates = [
+        pcb_dir / filename,
+        pcb_dir / "output" / filename,
+        pcb_dir.parent / "output" / filename,
+    ]
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None

--- a/src/kicad_tools/validate/violations.py
+++ b/src/kicad_tools/validate/violations.py
@@ -28,6 +28,20 @@ class DRCViolation:
         actual_value: The measured value that violated the rule
         required_value: The minimum/maximum value required by the rule
         items: Tuple of item references involved, e.g., ("D1", "C5")
+        waived: When True, this finding was matched by a pair-level waiver
+            entry (e.g. ``.courtyard_waivers.json``).  Waived findings keep
+            their underlying ``severity`` (typically ``"error"``) but are
+            reported with a distinct ``WAIVED`` status, counted separately
+            in :attr:`DRCResults.waived_count`, and excluded from
+            ``error_count`` / ``warning_count`` / ``info_count`` so they
+            never fail the gate.  This is orthogonal to ``severity`` (Issue
+            #4137): the underlying defect classification is preserved for
+            audit, while the gate treats an intentional, documented
+            exception as non-blocking.
+        waiver_reason: Human-readable justification from the waiver entry
+            (present only when ``waived`` is True).
+        waiver_issue: Tracking reference from the waiver entry, e.g.
+            ``"chorus#13"`` (present only when ``waived`` is True).
     """
 
     rule_id: str
@@ -39,6 +53,9 @@ class DRCViolation:
     required_value: float | None = None
     items: tuple[str, ...] = ()
     nets: tuple[str, ...] = ()
+    waived: bool = False
+    waiver_reason: str | None = None
+    waiver_issue: str | None = None
 
     def __post_init__(self) -> None:
         """Validate severity value."""
@@ -49,18 +66,23 @@ class DRCViolation:
 
     @property
     def is_error(self) -> bool:
-        """Check if this is an error (not a warning or info)."""
-        return self.severity == "error"
+        """Check if this is a blocking error (not waived, warning, or info)."""
+        return self.severity == "error" and not self.waived
 
     @property
     def is_warning(self) -> bool:
-        """Check if this is a warning (not an error or info)."""
-        return self.severity == "warning"
+        """Check if this is a warning (not an error, info, or waived)."""
+        return self.severity == "warning" and not self.waived
 
     @property
     def is_info(self) -> bool:
-        """Check if this is an informational finding (not an error or warning)."""
-        return self.severity == "info"
+        """Check if this is an informational finding (not error/warning/waived)."""
+        return self.severity == "info" and not self.waived
+
+    @property
+    def is_waived(self) -> bool:
+        """Check if this finding was matched by a waiver entry."""
+        return self.waived
 
     def to_dict(self) -> dict:
         """Convert to dictionary for serialization.
@@ -73,7 +95,7 @@ class DRCViolation:
         from kicad_tools.drc.violation import ViolationType
 
         resolved_type = ViolationType.from_string(self.rule_id)
-        return {
+        data: dict = {
             "rule_id": self.rule_id,
             "type": resolved_type.value,
             "severity": self.severity,
@@ -84,7 +106,17 @@ class DRCViolation:
             "required_value": self.required_value,
             "items": list(self.items),
             "nets": list(self.nets),
+            # Status distinguishes a waived finding from an active one at a
+            # glance for JSON consumers.  Waived findings render as
+            # ``"waived"`` regardless of their underlying ``severity`` (Issue
+            # #4137).
+            "status": "waived" if self.waived else self.severity,
+            "waived": self.waived,
         }
+        if self.waived:
+            data["waiver_reason"] = self.waiver_reason
+            data["waiver_issue"] = self.waiver_issue
+        return data
 
 
 @dataclass
@@ -134,6 +166,16 @@ class DRCResults:
         return sum(1 for v in self.violations if v.is_info)
 
     @property
+    def waived_count(self) -> int:
+        """Count of findings matched by a waiver entry (Issue #4137).
+
+        Waived findings are visible and counted here but excluded from
+        ``error_count`` / ``warning_count`` / ``info_count`` so they never
+        contribute to the gate verdict.
+        """
+        return sum(1 for v in self.violations if v.is_waived)
+
+    @property
     def passed(self) -> bool:
         """True if no errors (warnings and infos are allowed)."""
         return self.error_count == 0
@@ -152,6 +194,11 @@ class DRCResults:
     def infos(self) -> list[DRCViolation]:
         """List of only informational violations."""
         return [v for v in self.violations if v.is_info]
+
+    @property
+    def waived(self) -> list[DRCViolation]:
+        """List of only waived findings (Issue #4137)."""
+        return [v for v in self.violations if v.is_waived]
 
     def __iter__(self):
         """Iterate over all violations."""
@@ -199,6 +246,7 @@ class DRCResults:
             "error_count": self.error_count,
             "warning_count": self.warning_count,
             "info_count": self.info_count,
+            "waived_count": self.waived_count,
             "rules_checked": self.rules_checked,
             "rules_checked_by_rule": dict(self.rules_checked_by_rule),
             "violations": [v.to_dict() for v in self.violations],
@@ -208,8 +256,9 @@ class DRCResults:
         """Generate a human-readable summary."""
         status = "PASSED" if self.passed else "FAILED"
         info_part = f", {self.info_count} infos" if self.info_count else ""
+        waived_part = f", {self.waived_count} waived" if self.waived_count else ""
         return (
             f"DRC {status}: {self.error_count} errors, "
-            f"{self.warning_count} warnings{info_part} "
+            f"{self.warning_count} warnings{info_part}{waived_part} "
             f"({self.rules_checked} rules checked)"
         )

--- a/tests/test_validate_courtyard_overlap.py
+++ b/tests/test_validate_courtyard_overlap.py
@@ -1,0 +1,673 @@
+"""Tests for the courtyard-overlap DRC rule and waiver loading (Issue #4137).
+
+Uses in-memory synthetic ``PCB(SExp(...))`` fixtures constructed directly
+(mirroring ``tests/test_validate_silkscreen.py``) -- no dependency on any
+board file or the chorus fixture (local-only, not in CI).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from kicad_tools.cli import check_cmd
+from kicad_tools.schema.pcb import (
+    PCB,
+    Footprint,
+    FootprintGraphic,
+)
+from kicad_tools.sexp import SExp
+from kicad_tools.validate.checker import DRCChecker
+from kicad_tools.validate.rules.courtyard import (
+    COURTYARD_RULE_ID,
+    COURTYARD_UNRESOLVED_RULE_ID,
+    COURTYARD_UNUSED_WAIVER_RULE_ID,
+    CourtyardOverlapRule,
+)
+from kicad_tools.validate.rules.courtyard_waivers import (
+    CourtyardWaivers,
+    courtyard_waivers_from_dict,
+    discover_courtyard_waivers_sidecar,
+    load_courtyard_waivers,
+)
+
+pytest.importorskip("shapely")
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _empty_pcb() -> PCB:
+    return PCB(SExp(name="kicad_pcb"))
+
+
+def _crtyd_rect(
+    *,
+    start: tuple[float, float],
+    end: tuple[float, float],
+    layer: str = "F.CrtYd",
+) -> FootprintGraphic:
+    return FootprintGraphic(
+        graphic_type="rect",
+        layer=layer,
+        stroke_width=0.05,
+        start=start,
+        end=end,
+    )
+
+
+def _crtyd_lines(
+    corners: list[tuple[float, float]],
+    *,
+    layer: str = "F.CrtYd",
+) -> list[FootprintGraphic]:
+    """Build a closed loop of fp_line segments from ordered corner points."""
+    graphics: list[FootprintGraphic] = []
+    n = len(corners)
+    for i in range(n):
+        graphics.append(
+            FootprintGraphic(
+                graphic_type="line",
+                layer=layer,
+                stroke_width=0.05,
+                start=corners[i],
+                end=corners[(i + 1) % n],
+            )
+        )
+    return graphics
+
+
+def _crtyd_poly(
+    points: list[tuple[float, float]],
+    *,
+    layer: str = "F.CrtYd",
+) -> FootprintGraphic:
+    return FootprintGraphic(
+        graphic_type="poly",
+        layer=layer,
+        stroke_width=0.05,
+        points=points,
+    )
+
+
+def _make_footprint(
+    *,
+    reference: str,
+    position: tuple[float, float] = (0.0, 0.0),
+    rotation: float = 0.0,
+    layer: str = "F.Cu",
+    graphics: list[FootprintGraphic] | None = None,
+) -> Footprint:
+    return Footprint(
+        name="TestFP",
+        layer=layer,
+        position=position,
+        rotation=rotation,
+        reference=reference,
+        value="TEST",
+        pads=[],
+        texts=[],
+        graphics=graphics or [],
+    )
+
+
+def _pcb_with(*footprints: Footprint) -> PCB:
+    pcb = _empty_pcb()
+    for fp in footprints:
+        pcb._footprints.append(fp)
+    return pcb
+
+
+def _run(pcb: PCB, waivers: CourtyardWaivers | None = None):
+    return CourtyardOverlapRule(waivers=waivers).check(pcb)
+
+
+# ---------------------------------------------------------------------------
+# Core overlap detection
+# ---------------------------------------------------------------------------
+
+
+class TestCourtyardOverlap:
+    def test_overlapping_rects_error(self):
+        """Two overlapping F.CrtYd rects (no waiver) -> one error violation."""
+        a = _make_footprint(
+            reference="U1",
+            position=(0.0, 0.0),
+            graphics=[_crtyd_rect(start=(-1.0, -1.0), end=(1.0, 1.0))],
+        )
+        b = _make_footprint(
+            reference="C1",
+            position=(1.0, 0.0),  # overlaps U1 in x [0,1]
+            graphics=[_crtyd_rect(start=(-1.0, -1.0), end=(1.0, 1.0))],
+        )
+        results = _run(_pcb_with(a, b))
+        overlaps = results.filter_by_rule(COURTYARD_RULE_ID)
+        assert len(overlaps) == 1
+        v = overlaps[0]
+        assert v.severity == "error"
+        assert not v.is_waived
+        assert set(v.items) == {"U1", "C1"}
+        assert results.error_count == 1
+
+    def test_non_overlapping_no_violation(self):
+        """Well-separated courtyards -> no violation."""
+        a = _make_footprint(
+            reference="U1",
+            position=(0.0, 0.0),
+            graphics=[_crtyd_rect(start=(-1.0, -1.0), end=(1.0, 1.0))],
+        )
+        b = _make_footprint(
+            reference="C1",
+            position=(10.0, 0.0),
+            graphics=[_crtyd_rect(start=(-1.0, -1.0), end=(1.0, 1.0))],
+        )
+        results = _run(_pcb_with(a, b))
+        assert results.filter_by_rule(COURTYARD_RULE_ID) == []
+
+    def test_touching_zero_area_no_violation(self):
+        """Exactly-touching (zero-area intersection) courtyards -> no error."""
+        a = _make_footprint(
+            reference="U1",
+            position=(0.0, 0.0),
+            graphics=[_crtyd_rect(start=(-1.0, -1.0), end=(1.0, 1.0))],
+        )
+        b = _make_footprint(
+            reference="C1",
+            position=(2.0, 0.0),  # left edge at x=1 == U1 right edge
+            graphics=[_crtyd_rect(start=(-1.0, -1.0), end=(1.0, 1.0))],
+        )
+        results = _run(_pcb_with(a, b))
+        assert results.filter_by_rule(COURTYARD_RULE_ID) == []
+
+    def test_opposite_sides_no_violation(self):
+        """F.CrtYd vs B.CrtYd at the same x/y never conflict."""
+        a = _make_footprint(
+            reference="U1",
+            position=(0.0, 0.0),
+            layer="F.Cu",
+            graphics=[_crtyd_rect(start=(-1.0, -1.0), end=(1.0, 1.0), layer="F.CrtYd")],
+        )
+        b = _make_footprint(
+            reference="U2",
+            position=(0.0, 0.0),
+            layer="B.Cu",
+            graphics=[_crtyd_rect(start=(-1.0, -1.0), end=(1.0, 1.0), layer="B.CrtYd")],
+        )
+        results = _run(_pcb_with(a, b))
+        assert results.filter_by_rule(COURTYARD_RULE_ID) == []
+
+    def test_line_chain_courtyard_overlap(self):
+        """A courtyard built from fp_line segments still detects overlap."""
+        square = [(-1.0, -1.0), (1.0, -1.0), (1.0, 1.0), (-1.0, 1.0)]
+        a = _make_footprint(
+            reference="U1",
+            position=(0.0, 0.0),
+            graphics=_crtyd_lines(square),
+        )
+        b = _make_footprint(
+            reference="C1",
+            position=(1.0, 0.0),
+            graphics=_crtyd_lines(square),
+        )
+        results = _run(_pcb_with(a, b))
+        overlaps = results.filter_by_rule(COURTYARD_RULE_ID)
+        assert len(overlaps) == 1
+        assert overlaps[0].severity == "error"
+
+    def test_poly_courtyard_overlap(self):
+        """A courtyard drawn as fp_poly is resolved and overlap detected."""
+        diamond = [(0.0, -1.5), (1.5, 0.0), (0.0, 1.5), (-1.5, 0.0)]
+        a = _make_footprint(
+            reference="U1",
+            position=(0.0, 0.0),
+            graphics=[_crtyd_poly(diamond)],
+        )
+        b = _make_footprint(
+            reference="C1",
+            position=(1.0, 0.0),
+            graphics=[_crtyd_poly(diamond)],
+        )
+        results = _run(_pcb_with(a, b))
+        assert len(results.filter_by_rule(COURTYARD_RULE_ID)) == 1
+
+    def test_rotated_footprint_transform(self):
+        """A rotated footprint's courtyard is transformed to board space.
+
+        U1 is a 4x1 rect; rotating C1 90deg turns its 4x1 rect into a 1x4
+        footprint that reaches across U1.  Without honoring the rotation the
+        two would not overlap.
+        """
+        a = _make_footprint(
+            reference="U1",
+            position=(0.0, 0.0),
+            graphics=[_crtyd_rect(start=(-2.0, -0.5), end=(2.0, 0.5))],
+        )
+        b = _make_footprint(
+            reference="C1",
+            position=(0.0, 1.5),
+            rotation=90.0,
+            graphics=[_crtyd_rect(start=(-2.0, -0.5), end=(2.0, 0.5))],
+        )
+        results = _run(_pcb_with(a, b))
+        assert len(results.filter_by_rule(COURTYARD_RULE_ID)) == 1
+
+    def test_unresolved_fp_arc_courtyard_info(self):
+        """A courtyard with only unsupported geometry -> info finding."""
+        a = _make_footprint(
+            reference="U1",
+            position=(0.0, 0.0),
+            graphics=[
+                FootprintGraphic(
+                    graphic_type="arc",
+                    layer="F.CrtYd",
+                    stroke_width=0.05,
+                    start=(-1.0, 0.0),
+                    end=(1.0, 0.0),
+                )
+            ],
+        )
+        results = _run(_pcb_with(a))
+        infos = results.filter_by_rule(COURTYARD_UNRESOLVED_RULE_ID)
+        assert len(infos) == 1
+        assert infos[0].severity == "info"
+        assert "U1" in infos[0].items
+
+    def test_no_courtyard_geometry_degrades(self):
+        """Boards with no courtyard geometry at all -> clean, no crash."""
+        a = _make_footprint(reference="U1", graphics=[])
+        b = _make_footprint(reference="C1", graphics=[])
+        results = _run(_pcb_with(a, b))
+        assert results.error_count == 0
+        assert results.filter_by_rule(COURTYARD_RULE_ID) == []
+        assert results.filter_by_rule(COURTYARD_UNRESOLVED_RULE_ID) == []
+
+    def test_three_way_overlap_only_one_waived(self):
+        """A-B waived; B-C and A-C still fail independently."""
+        # Three overlapping rects at x=0,1,2 all with width 2 -> A-B, B-C, A-C
+        # all overlap.
+        a = _make_footprint(
+            reference="U1",
+            position=(0.0, 0.0),
+            graphics=[_crtyd_rect(start=(-1.5, -1.0), end=(1.5, 1.0))],
+        )
+        b = _make_footprint(
+            reference="U2",
+            position=(1.0, 0.0),
+            graphics=[_crtyd_rect(start=(-1.5, -1.0), end=(1.5, 1.0))],
+        )
+        c = _make_footprint(
+            reference="U3",
+            position=(2.0, 0.0),
+            graphics=[_crtyd_rect(start=(-1.5, -1.0), end=(1.5, 1.0))],
+        )
+        waivers = courtyard_waivers_from_dict(
+            {
+                "version": 1,
+                "waivers": [
+                    {
+                        "rule": "courtyards_overlap",
+                        "refs": ["U1", "U2"],
+                        "reason": "ok",
+                        "issue": "x#1",
+                    }
+                ],
+            }
+        )
+        results = _run(_pcb_with(a, b, c), waivers=waivers)
+        overlaps = results.filter_by_rule(COURTYARD_RULE_ID)
+        assert len(overlaps) == 3
+        waived = [v for v in overlaps if v.is_waived]
+        errors = [v for v in overlaps if v.is_error]
+        assert len(waived) == 1
+        assert set(waived[0].items) == {"U1", "U2"}
+        # B-C and A-C remain blocking.
+        assert len(errors) == 2
+        assert results.error_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Waiver matching
+# ---------------------------------------------------------------------------
+
+
+class TestWaiverMatching:
+    def _overlapping_pcb(self) -> PCB:
+        a = _make_footprint(
+            reference="C52",
+            position=(0.0, 0.0),
+            graphics=[_crtyd_rect(start=(-1.0, -1.0), end=(1.0, 1.0))],
+        )
+        b = _make_footprint(
+            reference="U10",
+            position=(1.0, 0.0),
+            graphics=[_crtyd_rect(start=(-1.0, -1.0), end=(1.0, 1.0))],
+        )
+        return _pcb_with(a, b)
+
+    def test_waived_pair_not_error(self):
+        waivers = courtyard_waivers_from_dict(
+            {
+                "version": 1,
+                "waivers": [
+                    {
+                        "rule": "courtyards_overlap",
+                        "refs": ["C52", "U10"],
+                        "reason": "EE-mandated tight decoupling",
+                        "issue": "chorus#13",
+                    }
+                ],
+            }
+        )
+        results = _run(self._overlapping_pcb(), waivers=waivers)
+        overlaps = results.filter_by_rule(COURTYARD_RULE_ID)
+        assert len(overlaps) == 1
+        v = overlaps[0]
+        assert v.is_waived
+        assert v.waiver_reason == "EE-mandated tight decoupling"
+        assert v.waiver_issue == "chorus#13"
+        assert results.error_count == 0
+        assert results.waived_count == 1
+        assert results.passed is True  # gate passes
+
+    def test_waiver_order_independent(self):
+        """refs reversed vs iteration order still matches."""
+        waivers = courtyard_waivers_from_dict(
+            {
+                "version": 1,
+                "waivers": [
+                    {
+                        "rule": "courtyards_overlap",
+                        "refs": ["U10", "C52"],  # reversed
+                        "reason": "ok",
+                        "issue": "x#1",
+                    }
+                ],
+            }
+        )
+        results = _run(self._overlapping_pcb(), waivers=waivers)
+        overlaps = results.filter_by_rule(COURTYARD_RULE_ID)
+        assert len(overlaps) == 1
+        assert overlaps[0].is_waived
+
+    def test_unused_waiver_info(self):
+        """A waiver naming an absent component -> info 'unused waiver'."""
+        waivers = courtyard_waivers_from_dict(
+            {
+                "version": 1,
+                "waivers": [
+                    {
+                        "rule": "courtyards_overlap",
+                        "refs": ["C99", "U10"],  # C99 not on board
+                        "reason": "stale",
+                        "issue": "x#1",
+                    }
+                ],
+            }
+        )
+        results = _run(self._overlapping_pcb(), waivers=waivers)
+        unused = results.filter_by_rule(COURTYARD_UNUSED_WAIVER_RULE_ID)
+        assert len(unused) == 1
+        assert unused[0].severity == "info"
+        # The real overlap (C52/U10) is NOT waived by this stale entry.
+        overlaps = results.filter_by_rule(COURTYARD_RULE_ID)
+        assert len(overlaps) == 1
+        assert overlaps[0].is_error
+
+
+# ---------------------------------------------------------------------------
+# Waiver-file schema validation
+# ---------------------------------------------------------------------------
+
+
+class TestWaiverValidation:
+    def test_missing_version_rejected(self):
+        with pytest.raises(ValueError, match="version"):
+            courtyard_waivers_from_dict({"waivers": []})
+
+    def test_unknown_version_rejected(self):
+        with pytest.raises(ValueError, match="unsupported courtyard-waivers version"):
+            courtyard_waivers_from_dict({"version": 99, "waivers": []})
+
+    def test_bad_refs_count_rejected(self):
+        with pytest.raises(ValueError, match="exactly 2"):
+            courtyard_waivers_from_dict(
+                {
+                    "version": 1,
+                    "waivers": [
+                        {
+                            "rule": "courtyards_overlap",
+                            "refs": ["C1"],
+                            "reason": "x",
+                            "issue": "y",
+                        }
+                    ],
+                }
+            )
+
+    def test_missing_reason_rejected(self):
+        with pytest.raises(ValueError, match="reason"):
+            courtyard_waivers_from_dict(
+                {
+                    "version": 1,
+                    "waivers": [
+                        {
+                            "rule": "courtyards_overlap",
+                            "refs": ["C1", "U1"],
+                            "reason": "",
+                            "issue": "y",
+                        }
+                    ],
+                }
+            )
+
+    def test_missing_issue_rejected(self):
+        with pytest.raises(ValueError, match="issue"):
+            courtyard_waivers_from_dict(
+                {
+                    "version": 1,
+                    "waivers": [
+                        {
+                            "rule": "courtyards_overlap",
+                            "refs": ["C1", "U1"],
+                            "reason": "x",
+                        }
+                    ],
+                }
+            )
+
+    def test_unsupported_rule_rejected(self):
+        with pytest.raises(ValueError, match="unsupported rule"):
+            courtyard_waivers_from_dict(
+                {
+                    "version": 1,
+                    "waivers": [
+                        {
+                            "rule": "clearance",
+                            "refs": ["C1", "U1"],
+                            "reason": "x",
+                            "issue": "y",
+                        }
+                    ],
+                }
+            )
+
+    def test_load_from_file(self, tmp_path):
+        path = tmp_path / ".courtyard_waivers.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "waivers": [
+                        {
+                            "rule": "courtyards_overlap",
+                            "refs": ["C52", "U10"],
+                            "reason": "ok",
+                            "issue": "x#1",
+                        }
+                    ],
+                }
+            )
+        )
+        waivers = load_courtyard_waivers(path)
+        assert len(waivers) == 1
+        assert waivers.match("U10", "C52") is not None
+
+    def test_load_malformed_json_raises(self, tmp_path):
+        path = tmp_path / ".courtyard_waivers.json"
+        path.write_text("{not json")
+        with pytest.raises(ValueError, match="parsing courtyard-waivers JSON"):
+            load_courtyard_waivers(path)
+
+    def test_discovery_probes_sidecar(self, tmp_path):
+        pcb_path = tmp_path / "board.kicad_pcb"
+        pcb_path.write_text("(kicad_pcb)")
+        sidecar = tmp_path / ".courtyard_waivers.json"
+        sidecar.write_text('{"version": 1, "waivers": []}')
+        found = discover_courtyard_waivers_sidecar(pcb_path)
+        assert found == sidecar
+
+    def test_discovery_returns_none_when_absent(self, tmp_path):
+        pcb_path = tmp_path / "board.kicad_pcb"
+        pcb_path.write_text("(kicad_pcb)")
+        assert discover_courtyard_waivers_sidecar(pcb_path) is None
+
+
+# ---------------------------------------------------------------------------
+# Checker + CLI integration
+# ---------------------------------------------------------------------------
+
+
+class TestCheckerIntegration:
+    def _board_file(self, tmp_path, *, refs_positions):
+        """Write a minimal .kicad_pcb with overlapping F.CrtYd footprints."""
+        fps = []
+        for ref, (x, y) in refs_positions:
+            fps.append(
+                f"""  (footprint "TestFP" (layer "F.Cu")
+    (at {x} {y})
+    (property "Reference" "{ref}" (at 0 0) (layer "F.SilkS"))
+    (fp_rect (start -1 -1) (end 1 1) (stroke (width 0.05) (type solid)) (layer "F.CrtYd"))
+  )"""
+            )
+        content = (
+            "(kicad_pcb (version 20240108) (generator test)\n"
+            '  (layers (0 "F.Cu" signal) (31 "B.Cu" signal))\n' + "\n".join(fps) + "\n)\n"
+        )
+        path = tmp_path / "board.kicad_pcb"
+        path.write_text(content)
+        return path
+
+    def test_checker_flags_overlap(self, tmp_path):
+        path = self._board_file(
+            tmp_path, refs_positions=[("U1", (10.0, 10.0)), ("C1", (11.0, 10.0))]
+        )
+        pcb = PCB.load(path)
+        checker = DRCChecker(pcb, manufacturer="jlcpcb", layers=2)
+        results = checker.check_courtyard_overlap()
+        assert results.error_count == 1
+
+    def test_cli_waived_json_output(self, tmp_path, capsys):
+        path = self._board_file(
+            tmp_path, refs_positions=[("U1", (10.0, 10.0)), ("C1", (11.0, 10.0))]
+        )
+        waiver = tmp_path / ".courtyard_waivers.json"
+        waiver.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "waivers": [
+                        {
+                            "rule": "courtyards_overlap",
+                            "refs": ["U1", "C1"],
+                            "reason": "intentional",
+                            "issue": "x#1",
+                        }
+                    ],
+                }
+            )
+        )
+        rc = check_cmd.main(
+            [
+                str(path),
+                "--only",
+                "courtyard_overlap",
+                "--format",
+                "json",
+                "--drc-only",
+            ]
+        )
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["summary"]["waived"] == 1
+        assert data["summary"]["errors"] == 0
+        assert data["summary"]["passed"] is True
+        assert rc == 0
+        waived_v = [v for v in data["violations"] if v.get("waived")]
+        assert len(waived_v) == 1
+        assert waived_v[0]["status"] == "waived"
+
+    def test_cli_unwaived_overlap_fails(self, tmp_path, capsys):
+        """A new, unwaived overlap still fails even alongside a waived pair."""
+        path = self._board_file(
+            tmp_path,
+            refs_positions=[
+                ("U1", (10.0, 10.0)),
+                ("C1", (11.0, 10.0)),
+                ("C2", (30.0, 30.0)),
+                ("C3", (31.0, 30.0)),
+            ],
+        )
+        waiver = tmp_path / ".courtyard_waivers.json"
+        waiver.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "waivers": [
+                        {
+                            "rule": "courtyards_overlap",
+                            "refs": ["U1", "C1"],
+                            "reason": "intentional",
+                            "issue": "x#1",
+                        }
+                    ],
+                }
+            )
+        )
+        rc = check_cmd.main(
+            [str(path), "--only", "courtyard_overlap", "--format", "json", "--drc-only"]
+        )
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["summary"]["waived"] == 1
+        assert data["summary"]["errors"] == 1  # C2/C3 unwaived
+        assert data["summary"]["passed"] is False
+        assert rc == 2
+
+    def test_cli_explicit_malformed_waiver_hard_error(self, tmp_path):
+        path = self._board_file(
+            tmp_path, refs_positions=[("U1", (10.0, 10.0)), ("C1", (11.0, 10.0))]
+        )
+        bad = tmp_path / "bad.json"
+        bad.write_text("{not json")
+        rc = check_cmd.main(
+            [str(path), "--only", "courtyard_overlap", "--courtyard-waivers", str(bad)]
+        )
+        assert rc == 1
+
+    def test_cli_auto_malformed_waiver_degrades(self, tmp_path, capsys):
+        path = self._board_file(
+            tmp_path, refs_positions=[("U1", (10.0, 10.0)), ("C1", (11.0, 10.0))]
+        )
+        # Auto-discovered sidecar next to the board is malformed.
+        (tmp_path / ".courtyard_waivers.json").write_text("{not json")
+        rc = check_cmd.main(
+            [str(path), "--only", "courtyard_overlap", "--format", "json", "--drc-only"]
+        )
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        # Degrades to zero waivers -> the overlap is a blocking error.
+        assert data["summary"]["errors"] == 1
+        assert rc == 2


### PR DESCRIPTION
## Summary

Adds a pure-Python **courtyard-overlap** sub-check to `kct check`, gated by a
versioned pair-level waiver file (`.courtyard_waivers.json`). This makes the
courtyard gate fully headless and independent of `kicad-cli`'s per-instance
`drc_exclusions` (not honored by kicad-cli 10.0.4 headless), directly
unblocking the chorus consumer (project-shamrock/chorus#18).

Scope is **option (1) only** per the curator guidance; option (2)
(`drc_exclusions`-aware `kct drc` filtering) is explicitly deferred to a
separate follow-up issue.

## Changes

- **`schema/pcb.py`**: parse `fp_poly` into `FootprintGraphic.points` (new
  `points` field), closing the gap where courtyards drawn as polygons were
  invisible to the schema parser. `fp_poly` is now added to the graphics parse
  loop.
- **`validate/violations.py`**: add orthogonal `waived` / `waiver_reason` /
  `waiver_issue` fields to `DRCViolation` (severity stays `error`), plus
  `is_waived` and a `DRCResults.waived_count`. `error_count` / `warning_count`
  / `info_count` now exclude waived findings, so a waived overlap never fails
  the gate. `to_dict()` emits a `status` field (`"waived"` vs severity).
- **`validate/rules/courtyard.py`** (new): `CourtyardOverlapRule` extracts real
  F.CrtYd/B.CrtYd geometry (single `fp_rect`, closed `fp_line` chains via
  endpoint matching, or `fp_poly`), transforms to board space honoring KiCad's
  negated-rotation convention (`_fp_transform`, per #3739), and tests pairwise
  positive-area intersection per board side. Unresolvable courtyards emit an
  `info` "could not resolve outline" finding; stale waivers emit an `info`
  "unused waiver" finding.
- **`validate/rules/courtyard_waivers.py`** (new): versioned (`version == 1`)
  schema loader/validator with order-insensitive `refs` pair matching and
  sidecar discovery (`.courtyard_waivers.json`, probing pcb dir then
  `output/`).
- **`validate/checker.py`**: `check_courtyard_overlap` method, added to
  `CHECK_ALL_METHODS`, plus a `courtyard_waivers` constructor kwarg.
- **`cli/check_cmd.py`**: register `courtyard_overlap` in `CHECK_CATEGORIES`
  and the `check_methods` dict; add `--courtyard-waivers` flag with the same
  graceful-degrade (auto-discovered) / hard-error (explicit) loading contract
  as `--net-class-map`; render `WAIVED` distinctly in table + JSON output with
  a `waived` count.

### fp_poly note

`fp_poly` courtyards **are** supported (the schema parser now records their
vertices and the rule consumes them). The `info` "unresolved outline" finding
is reserved for genuinely-degenerate cases (non-closing line chains,
arc/circle-only courtyards, < 3 vertices) so a skipped footprint is always
visible rather than a silent false negative.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `courtyard_overlap` category registered in both registries (satisfies `test_check_cmd_coverage.py`) | ✅ | `test_check_cmd_coverage.py` passes (37 passed) |
| Rule extracts true F.CrtYd/B.CrtYd geometry (not pads-bbox); unresolvable -> info | ✅ | `test_line_chain_courtyard_overlap`, `test_poly_courtyard_overlap`, `test_unresolved_fp_arc_courtyard_info` |
| Non-waived overlap -> error, non-zero exit | ✅ | `test_cli_unwaived_overlap_fails` (exit 2); manual CLI exit 2 |
| `.courtyard_waivers.json` auto-discovered + `--courtyard-waivers` override; waived pair reports `waived=True`, in `waived_count`, excluded from `error_count` | ✅ | `test_cli_waived_json_output`, `test_waived_pair_not_error` |
| `refs` order-independent | ✅ | `test_waiver_order_independent` |
| Waiver referencing absent component -> info "unused waiver", not load error | ✅ | `test_unused_waiver_info` |
| Malformed auto sidecar degrades; explicit path is hard error | ✅ | `test_cli_auto_malformed_waiver_degrades` (exit 2), `test_cli_explicit_malformed_waiver_hard_error` (exit 1) |
| Waived never regresses exit code; new overlap always does | ✅ | `test_three_way_overlap_only_one_waived`, `test_cli_unwaived_overlap_fails` |
| Option (2) out of scope | ✅ | Not implemented; deferred per curator |

## Test Plan

- New `tests/test_validate_courtyard_overlap.py`: 28 tests (rule detection,
  rotation, line/poly/rect outlines, waiver matching, schema validation, CLI
  integration incl. exit codes). All pass.
- `pytest -k "courtyard or check_cmd or violations"`: 324 passed, 9 skipped.
- `test_check_cmd_coverage.py` + `test_validate_silkscreen.py`: 37 passed.
- PCB round-trip tests pass (fp_poly parse change).
- `ruff check` + `ruff format --check`: clean on all changed files.
- `scripts/ci/check_mypy_baseline.py`: 0 NEW errors.
- Manual: waived pair -> table shows WAIVED, exit 0; unwaived -> exit 2.

Closes #4137