### PR TITLE
fix(datasheet): validate PDF payload and fall through to next source

### DIFF
--- a/src/kicad_tools/datasheet/manager.py
+++ b/src/kicad_tools/datasheet/manager.py
@@ -234,8 +234,32 @@ class DatasheetManager:
         if not search_result.has_results:
             raise DatasheetSearchError(f"No datasheet found for '{part_number}'")
 
-        # Download the best match
-        return self.download(search_result.results[0], output_dir=output_dir)
+        # Try each candidate in confidence order, falling through to the next
+        # whenever a download fails (e.g. a source returns an HTML wrapper page
+        # instead of a PDF, or a transient network error). Only raise once every
+        # candidate has been exhausted, aggregating a per-candidate reason so the
+        # caller can see why each source failed rather than just the last error.
+        failures: dict[str, str] = {}
+        for index, result in enumerate(search_result.results):
+            try:
+                return self.download(result, output_dir=output_dir, force=force)
+            except DatasheetDownloadError as e:
+                # Key by source; disambiguate multiple candidates from the same
+                # source so one failure does not overwrite another's reason.
+                key = result.source
+                if key in failures:
+                    key = f"{result.source}#{index}"
+                failures[key] = str(e)
+                logger.warning(
+                    f"Download candidate {index} ({result.source}) failed for '{part_number}': {e}"
+                )
+
+        # Every candidate failed — surface all per-source reasons, not just the last.
+        reasons = "; ".join(f"{source}: {reason}" for source, reason in failures.items())
+        raise DatasheetDownloadError(
+            f"Failed to download datasheet for '{part_number}' from any source. "
+            f"Tried {len(search_result.results)} candidate(s): {reasons}"
+        )
 
     def is_cached(self, part_number: str) -> bool:
         """

--- a/src/kicad_tools/datasheet/sources/base.py
+++ b/src/kicad_tools/datasheet/sources/base.py
@@ -5,6 +5,8 @@ Base interface for datasheet sources.
 from __future__ import annotations
 
 import logging
+import os
+import tempfile
 from abc import ABC, abstractmethod
 from functools import wraps
 from pathlib import Path
@@ -18,6 +20,109 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 F = TypeVar("F", bound=Callable)
+
+# PDF files begin with the magic bytes "%PDF-" (per the PDF spec these must
+# appear within the first 1024 bytes; in practice every source this project
+# talks to places them at byte 0). We validate this before treating a
+# streamed response body as a successful download so that HTML wrapper/SPA
+# pages returned with HTTP 200 are never written to disk as ".pdf".
+PDF_MAGIC = b"%PDF-"
+
+
+def _validate_pdf_payload(
+    leading_bytes: bytes,
+    source_name: str,
+    url: str,
+    content_type: str | None = None,
+) -> None:
+    """
+    Validate that a downloaded payload is actually a PDF.
+
+    Args:
+        leading_bytes: The first bytes of the response body (at least the first
+            chunk). Only the leading portion is needed to check the magic bytes.
+        source_name: Name of the source the payload came from (for error text).
+        url: The URL the payload was fetched from (for error text).
+        content_type: The response ``Content-Type`` header, if available. Used
+            only to enrich the error message; the magic-byte check is the
+            authoritative signal.
+
+    Raises:
+        DatasheetDownloadError: If the payload does not start with the PDF
+            magic bytes.
+    """
+    from ..exceptions import DatasheetDownloadError
+
+    if leading_bytes[: len(PDF_MAGIC)] == PDF_MAGIC:
+        return
+
+    snippet = leading_bytes[:32].decode("utf-8", errors="replace").replace("\n", " ")
+    ct_part = f"Content-Type: {content_type}, " if content_type else ""
+    raise DatasheetDownloadError(
+        f"{source_name} returned non-PDF content from {url} ({ct_part}first bytes: {snippet!r})"
+    )
+
+
+def _stream_to_validated_pdf(
+    response: Any,
+    output_path: Path,
+    source_name: str,
+    url: str,
+    content_type: str | None = None,
+    chunk_size: int = 8192,
+) -> None:
+    """
+    Stream a response body to ``output_path`` only if it is a valid PDF.
+
+    The payload is written to a temporary file first; its leading bytes are
+    checked against the PDF magic bytes. Only if validation passes is the temp
+    file atomically moved into place. A non-PDF payload raises
+    ``DatasheetDownloadError`` and never leaves a file at ``output_path``.
+
+    Args:
+        response: A streaming ``requests`` response (supports ``iter_content``).
+        output_path: Final destination for the validated PDF.
+        source_name: Source name for error messages.
+        url: Source URL for error messages.
+        content_type: Response ``Content-Type`` header, if available.
+        chunk_size: Chunk size for streaming.
+
+    Raises:
+        DatasheetDownloadError: If the payload is not a PDF.
+    """
+    output_path = Path(output_path)
+    tmp_fd, tmp_name = tempfile.mkstemp(
+        dir=str(output_path.parent),
+        prefix=f".{output_path.name}.",
+        suffix=".partial",
+    )
+    tmp_path = Path(tmp_name)
+    validated = False
+    try:
+        leading = b""
+        with os.fdopen(tmp_fd, "wb") as f:
+            for chunk in response.iter_content(chunk_size=chunk_size):
+                if not chunk:
+                    continue
+                if not validated:
+                    leading += chunk
+                    if len(leading) >= len(PDF_MAGIC):
+                        _validate_pdf_payload(leading, source_name, url, content_type)
+                        validated = True
+                f.write(chunk)
+
+        # Payloads shorter than the magic-byte prefix (e.g. an empty body)
+        # were never validated above — validate whatever we captured now.
+        if not validated:
+            _validate_pdf_payload(leading, source_name, url, content_type)
+
+        os.replace(tmp_path, output_path)
+    finally:
+        if tmp_path.exists():
+            try:
+                tmp_path.unlink()
+            except OSError:
+                logger.debug("Failed to remove temp download file %s", tmp_path)
 
 
 def requires_requests(func: F) -> F:
@@ -126,10 +231,14 @@ class DatasheetSource(ABC):
 
             ensure_parent_dir(output_path)
 
-            # Write to file in chunks
-            with open(output_path, "wb") as f:
-                for chunk in response.iter_content(chunk_size=8192):
-                    f.write(chunk)
+            content_type = response.headers.get("Content-Type") if response.headers else None
+            _stream_to_validated_pdf(
+                response=response,
+                output_path=output_path,
+                source_name=self.name,
+                url=url,
+                content_type=content_type,
+            )
 
             logger.info(f"Downloaded datasheet to {output_path}")
             return output_path
@@ -216,10 +325,17 @@ class HTTPDatasheetSource(DatasheetSource):
             # Ensure parent directory exists
             output_path.parent.mkdir(parents=True, exist_ok=True)
 
-            # Write to file
-            with open(output_path, "wb") as f:
-                for chunk in response.iter_content(chunk_size=8192):
-                    f.write(chunk)
+            # Validate the payload is actually a PDF before it lands on disk.
+            # LCSC's SPA returns HTTP 200 with an HTML body; without this guard
+            # it would be written as ".pdf" and reported as a success.
+            content_type = response.headers.get("Content-Type") if response.headers else None
+            _stream_to_validated_pdf(
+                response=response,
+                output_path=output_path,
+                source_name=self.name,
+                url=result.datasheet_url,
+                content_type=content_type,
+            )
 
             logger.info(f"Downloaded datasheet to {output_path}")
             return output_path

--- a/tests/test_datasheet.py
+++ b/tests/test_datasheet.py
@@ -512,6 +512,102 @@ class TestLCSCDatasheetSource:
 
             assert downloaded == output_path
             assert output_path.exists()
+            # The written file must actually be a PDF (magic bytes preserved).
+            assert output_path.read_bytes().startswith(b"%PDF-")
+
+    def test_download_rejects_html_payload(self, tmp_path):
+        """An HTML wrapper page (HTTP 200) must fail, not be saved as .pdf."""
+        from kicad_tools.datasheet.models import DatasheetResult
+        from kicad_tools.datasheet.sources import LCSCDatasheetSource
+
+        source = LCSCDatasheetSource()
+
+        with patch.object(source, "_get_session") as mock_session:
+            mock_resp = MagicMock()
+            mock_resp.iter_content.return_value = [
+                b'<!doctype html>\n<html data-n-head-ssr lang="en_US">'
+            ]
+            mock_resp.headers = {"Content-Type": "text/html"}
+            mock_resp.raise_for_status = MagicMock()
+            mock_session.return_value.get.return_value = mock_resp
+
+            result = DatasheetResult(
+                part_number="TEST",
+                manufacturer="Test",
+                description="Test",
+                datasheet_url="https://example.com/test.pdf",
+                source="lcsc",
+            )
+
+            output_path = tmp_path / "test.pdf"
+            with pytest.raises(DatasheetDownloadError) as exc_info:
+                source.download(result, output_path)
+
+            # The error names the source and includes a reason.
+            assert "lcsc" in str(exc_info.value)
+            # No partial/garbage file left behind.
+            assert not output_path.exists()
+            # No leftover temp files in the target directory either.
+            assert list(tmp_path.iterdir()) == []
+
+    def test_download_rejects_empty_payload(self, tmp_path):
+        """An empty body (no magic bytes) must fail rather than write 0 bytes."""
+        from kicad_tools.datasheet.models import DatasheetResult
+        from kicad_tools.datasheet.sources import LCSCDatasheetSource
+
+        source = LCSCDatasheetSource()
+
+        with patch.object(source, "_get_session") as mock_session:
+            mock_resp = MagicMock()
+            mock_resp.iter_content.return_value = []
+            mock_resp.headers = {}
+            mock_resp.raise_for_status = MagicMock()
+            mock_session.return_value.get.return_value = mock_resp
+
+            result = DatasheetResult(
+                part_number="TEST",
+                manufacturer="Test",
+                description="Test",
+                datasheet_url="https://example.com/test.pdf",
+                source="lcsc",
+            )
+
+            output_path = tmp_path / "test.pdf"
+            with pytest.raises(DatasheetDownloadError):
+                source.download(result, output_path)
+            assert not output_path.exists()
+
+    def test_download_file_helper_validates_pdf(self, tmp_path):
+        """The shared _download_file helper also guards against non-PDF payloads."""
+        from kicad_tools.datasheet.sources import LCSCDatasheetSource
+
+        source = LCSCDatasheetSource()
+
+        # Valid PDF passes through.
+        good_session = MagicMock()
+        good_resp = MagicMock()
+        good_resp.iter_content.return_value = [b"%PDF-1.5 body"]
+        good_resp.headers = {"Content-Type": "application/pdf"}
+        good_resp.raise_for_status = MagicMock()
+        good_session.get.return_value = good_resp
+
+        good_path = tmp_path / "good.pdf"
+        returned = source._download_file(good_session, "https://x/good.pdf", good_path, 30.0)
+        assert returned == good_path
+        assert good_path.read_bytes().startswith(b"%PDF-")
+
+        # HTML payload is rejected and no file is left behind.
+        bad_session = MagicMock()
+        bad_resp = MagicMock()
+        bad_resp.iter_content.return_value = [b"<!doctype html>"]
+        bad_resp.headers = {"Content-Type": "text/html"}
+        bad_resp.raise_for_status = MagicMock()
+        bad_session.get.return_value = bad_resp
+
+        bad_path = tmp_path / "bad.pdf"
+        with pytest.raises(DatasheetDownloadError):
+            source._download_file(bad_session, "https://x/bad.pdf", bad_path, 30.0)
+        assert not bad_path.exists()
 
     def test_download_failure(self, tmp_path):
         """Test download failure handling."""
@@ -585,6 +681,36 @@ class TestOctopartDatasheetSource:
             assert len(results) == 1
             assert results[0].part_number == "STM32F103C8T6"
             assert results[0].source == "octopart"
+
+    def test_download_rejects_html_payload(self, tmp_path):
+        """Octopart inherits the shared PDF guard via super().download()."""
+        from kicad_tools.datasheet.models import DatasheetResult
+        from kicad_tools.datasheet.sources import OctopartDatasheetSource
+
+        source = OctopartDatasheetSource(api_key="test-key")
+        source._last_request_time = 0.0  # avoid real sleep in _rate_limit
+
+        with patch.object(source, "_get_session") as mock_session:
+            mock_resp = MagicMock()
+            mock_resp.iter_content.return_value = [b"<!doctype html><html></html>"]
+            mock_resp.headers = {"Content-Type": "text/html"}
+            mock_resp.raise_for_status = MagicMock()
+            mock_session.return_value.get.return_value = mock_resp
+
+            result = DatasheetResult(
+                part_number="TEST",
+                manufacturer="Test",
+                description="Test",
+                datasheet_url="https://example.com/test.pdf",
+                source="octopart",
+            )
+
+            output_path = tmp_path / "test.pdf"
+            with pytest.raises(DatasheetDownloadError) as exc_info:
+                source.download(result, output_path)
+
+            assert "octopart" in str(exc_info.value)
+            assert not output_path.exists()
 
     def test_rate_limiting(self):
         """Test that rate limiting enforces delay."""
@@ -772,6 +898,127 @@ class TestDatasheetManager:
 
             with pytest.raises(DatasheetSearchError):
                 manager.download_by_part("NOTFOUND")
+
+    def test_download_by_part_falls_through_to_next_candidate(self, manager):
+        """First candidate fails validation; second candidate succeeds."""
+        from kicad_tools.datasheet.models import DatasheetResult
+
+        first = DatasheetResult(
+            part_number="STM32",
+            manufacturer="ST",
+            description="MCU",
+            datasheet_url="https://lcsc.example/shell.pdf",
+            source="lcsc",
+            confidence=0.9,
+        )
+        second = DatasheetResult(
+            part_number="STM32",
+            manufacturer="ST",
+            description="MCU",
+            datasheet_url="https://octo.example/real.pdf",
+            source="octopart",
+            confidence=0.8,
+        )
+
+        good = MagicMock(part_number="STM32", source="octopart")
+
+        with patch.object(manager, "search") as mock_search:
+            with patch.object(manager, "download") as mock_download:
+                mock_search.return_value = MagicMock(
+                    has_results=True,
+                    results=[first, second],
+                )
+                mock_download.side_effect = [
+                    DatasheetDownloadError("lcsc returned non-PDF content"),
+                    good,
+                ]
+
+                datasheet = manager.download_by_part("STM32")
+
+                assert datasheet is good
+                assert mock_download.call_count == 2
+
+    def test_download_by_part_all_candidates_fail(self, manager):
+        """When every candidate fails, error aggregates all per-source reasons."""
+        from kicad_tools.datasheet.models import DatasheetResult
+
+        first = DatasheetResult(
+            part_number="STM32",
+            manufacturer="ST",
+            description="MCU",
+            datasheet_url="https://lcsc.example/shell.pdf",
+            source="lcsc",
+            confidence=0.9,
+        )
+        second = DatasheetResult(
+            part_number="STM32",
+            manufacturer="ST",
+            description="MCU",
+            datasheet_url="https://octo.example/broken.pdf",
+            source="octopart",
+            confidence=0.8,
+        )
+
+        with patch.object(manager, "search") as mock_search:
+            with patch.object(manager, "download") as mock_download:
+                mock_search.return_value = MagicMock(
+                    has_results=True,
+                    results=[first, second],
+                )
+                mock_download.side_effect = [
+                    DatasheetDownloadError("lcsc returned non-PDF content"),
+                    DatasheetDownloadError("octopart network timeout"),
+                ]
+
+                with pytest.raises(DatasheetDownloadError) as exc_info:
+                    manager.download_by_part("STM32")
+
+                message = str(exc_info.value)
+                # Both sources' reasons must be present, not just the last.
+                assert "lcsc" in message
+                assert "octopart" in message
+                assert "non-PDF" in message
+                assert "timeout" in message
+                assert mock_download.call_count == 2
+
+    def test_download_by_part_same_source_two_candidates(self, manager):
+        """Two failing candidates from the same source each get a reason."""
+        from kicad_tools.datasheet.models import DatasheetResult
+
+        first = DatasheetResult(
+            part_number="STM32",
+            manufacturer="ST",
+            description="MCU",
+            datasheet_url="https://lcsc.example/a.pdf",
+            source="lcsc",
+            confidence=0.9,
+        )
+        second = DatasheetResult(
+            part_number="STM32",
+            manufacturer="ST",
+            description="MCU",
+            datasheet_url="https://lcsc.example/b.pdf",
+            source="lcsc",
+            confidence=0.8,
+        )
+
+        with patch.object(manager, "search") as mock_search:
+            with patch.object(manager, "download") as mock_download:
+                mock_search.return_value = MagicMock(
+                    has_results=True,
+                    results=[first, second],
+                )
+                mock_download.side_effect = [
+                    DatasheetDownloadError("candidate a failed"),
+                    DatasheetDownloadError("candidate b failed"),
+                ]
+
+                with pytest.raises(DatasheetDownloadError) as exc_info:
+                    manager.download_by_part("STM32")
+
+                message = str(exc_info.value)
+                assert "candidate a failed" in message
+                assert "candidate b failed" in message
 
     def test_list_cached(self, manager, tmp_path):
         """Test list_cached method."""
@@ -1121,6 +1368,29 @@ class TestDatasheetCLI:
             assert result == 1
             captured = capsys.readouterr()
             assert "No datasheets found" in captured.out
+
+    def test_download_command_all_sources_fail(self, capsys):
+        """download exits non-zero and prints per-source reasons on total failure."""
+        from kicad_tools.cli.datasheet_cmd import main
+        from kicad_tools.datasheet.exceptions import DatasheetDownloadError
+
+        with patch("kicad_tools.datasheet.manager.DatasheetManager") as MockManager:
+            mock_manager = MagicMock()
+            MockManager.return_value = mock_manager
+            mock_manager.download_by_part.side_effect = DatasheetDownloadError(
+                "Failed to download datasheet for 'XC6206' from any source. "
+                "Tried 2 candidate(s): lcsc: returned non-PDF content; "
+                "octopart: network timeout"
+            )
+
+            result = main(["download", "XC6206"])
+
+            assert result == 1
+            captured = capsys.readouterr()
+            # Aggregated per-source detail must be legible on stderr.
+            assert "lcsc" in captured.err
+            assert "octopart" in captured.err
+            assert "non-PDF" in captured.err
 
     def test_list_command_empty(self, capsys):
         """Test list command with no cached datasheets."""


### PR DESCRIPTION
## Summary

`kct datasheet download <part>` frequently received an LCSC SPA/wrapper HTML page (HTTP 200, `text/html` body), wrote it to disk as `<part>.pdf`, and reported success with exit 0 — silently poisoning the datasheet cache with HTML-as-PDF. This PR validates the payload before it is trusted and adds per-candidate fallthrough so a bad top hit no longer sinks the whole download.

## Changes

- **`datasheet/sources/base.py`** — Added `%PDF-` magic-byte validation. New module helper `_stream_to_validated_pdf()` streams the response to a temp file, validates the leading bytes against `PDF_MAGIC`, and only `os.replace()`s into place on success; a non-PDF payload raises `DatasheetDownloadError` naming the source (and Content-Type/first-bytes snippet) and leaves **no** file at `output_path`. Both `HTTPDatasheetSource.download()` (inherited by LCSC and Octopart) and the previously-unused `DatasheetSource._download_file()` helper now route through this guard.
- **`datasheet/manager.py`** — `download_by_part()` now iterates **every** `search_result.results` candidate in confidence order (previously only `results[0]`), catching `DatasheetDownloadError` per attempt and aggregating `{source: reason}`. When all candidates fail it raises a combined per-source summary rather than a single error.
- **`tests/test_datasheet.py`** — Added mock-based tests (no live network): HTML payload rejected + no file left behind (LCSC and Octopart, proving the shared guard), empty-payload rejection, `_download_file` guard, happy-path magic-byte assertion, manager fallthrough (first fails → second succeeds), all-candidates-fail aggregation (incl. two candidates from the same source), and a CLI-level `_run_download` exit-1 test asserting per-source detail on stderr.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `download()` (+ `_download_file`) validates `%PDF-` before success; non-PDF raises naming source, leaves no file | Done | `test_download_rejects_html_payload` (LCSC+Octopart), `test_download_rejects_empty_payload`, `test_download_file_helper_validates_pdf` |
| `download_by_part()` iterates candidates, trying next on `DatasheetDownloadError` | Done | `test_download_by_part_falls_through_to_next_candidate` |
| All-fail exits non-zero with per-source reasons (not just last) | Done | `test_download_by_part_all_candidates_fail`, `test_download_by_part_same_source_two_candidates`, `test_download_command_all_sources_fail` |
| Valid `%PDF-` payload still succeeds unchanged; no new required flags | Done | `test_download_success` (+ magic-byte assertion); existing cache tests unmodified |
| No `--force-html-ok` flag added | Done | No CLI/argparse changes |

## Test Plan

`uv run --extra dev pytest tests/test_datasheet.py -q` → **142 passed** (0 skipped with `requests` present). `ruff check` + `ruff format` clean on changed files. `scripts/ci/check_mypy_baseline.py` (with `--extra dev`) reports 0 NEW errors attributable to this change (the single flagged `cmaes_strategy.py` import-stub error reproduces on clean `main` with these changes stashed).

Scope kept to payload validation + download fallthrough; #4139 (search-side ImportError masking) intentionally untouched.

Closes #4138