### PR TITLE
fix(datasheet): surface install guidance when optional deps are missing

### DIFF
--- a/src/kicad_tools/cli/datasheet_cmd.py
+++ b/src/kicad_tools/cli/datasheet_cmd.py
@@ -363,6 +363,19 @@ def _run_search(args) -> int:
         print(json.dumps(output, indent=2))
     else:
         if not results.has_results:
+            # When every source failed because an optional dependency is
+            # missing, the real problem is a missing install, not a lookup
+            # miss — surface install guidance rather than "no datasheets found"
+            # (issue #4139).
+            if results.all_failures_are_import_errors:
+                message = next(iter(set(results.import_errors.values())), "")
+                print(f"Error: {message}", file=sys.stderr)
+                print(
+                    "Install with: pip install kicad-tools[parts]",
+                    file=sys.stderr,
+                )
+                return 1
+
             print(f"No datasheets found for '{args.part}'")
             if results.errors:
                 print("\nSource errors:")
@@ -413,6 +426,17 @@ def _run_download(args) -> int:
 
         return 0
 
+    except ImportError as e:
+        # Every source failed because an optional dependency is missing.
+        # Surface install guidance instead of a misleading "no datasheet found",
+        # mirroring how main()/_info()/_extract_package() already report missing
+        # dependencies (issue #4139).
+        print(f"Error: {e}", file=sys.stderr)
+        print(
+            "Install with: pip install kicad-tools[parts]",
+            file=sys.stderr,
+        )
+        return 1
     except Exception as e:
         print(f"Failed to download datasheet: {e}", file=sys.stderr)
         return 1
@@ -831,24 +855,56 @@ def _info(args) -> int:
     try:
         parser = DatasheetParser(pdf_path)
 
-        # Count images and tables for quick summary
-        images = parser.extract_images(min_width=100, min_height=100)
-        tables = parser.extract_tables()
+        # page_count is the minimal viable info output; it genuinely requires
+        # PyMuPDF (no lighter PDF-metadata path exists in this codebase). If
+        # that dependency is missing the error now names the actual operation
+        # ("reading PDF page count") rather than "image extraction" (#4139).
+        page_count = parser.page_count
+
+        # Image and table counts are best-effort: a caller who only wants page
+        # count/metadata should not have the whole command fail because *one*
+        # of the optional extraction libraries (fitz / pdfplumber) is missing.
+        image_count: int | None
+        table_count: int | None
+        image_error: str | None = None
+        table_error: str | None = None
+
+        try:
+            image_count = len(parser.extract_images(min_width=100, min_height=100))
+        except Exception as e:
+            image_count = None
+            image_error = str(e)
+
+        try:
+            table_count = len(parser.extract_tables())
+        except Exception as e:
+            table_count = None
+            table_error = str(e)
 
         if args.format == "json":
-            data = {
+            data: dict = {
                 "path": str(pdf_path),
                 "filename": pdf_path.name,
-                "page_count": parser.page_count,
-                "image_count": len(images),
-                "table_count": len(tables),
+                "page_count": page_count,
+                "image_count": image_count,
+                "table_count": table_count,
             }
+            if image_error is not None:
+                data["image_error"] = image_error
+            if table_error is not None:
+                data["table_error"] = table_error
             print(json.dumps(data, indent=2))
         else:
             print(f"File:    {pdf_path.name}")
-            print(f"Pages:   {parser.page_count}")
-            print(f"Images:  {len(images)} (>= 100x100 px)")
-            print(f"Tables:  {len(tables)}")
+            print(f"Pages:   {page_count}")
+            if image_count is not None:
+                print(f"Images:  {image_count} (>= 100x100 px)")
+            else:
+                print(f"Images:  unavailable ({image_error})")
+            if table_count is not None:
+                print(f"Tables:  {table_count}")
+            else:
+                print(f"Tables:  unavailable ({table_error})")
 
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)

--- a/src/kicad_tools/datasheet/manager.py
+++ b/src/kicad_tools/datasheet/manager.py
@@ -24,6 +24,22 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _missing_dependency_message(import_errors: dict[str, str]) -> str:
+    """Build a single install-guidance message from per-source ImportErrors.
+
+    Every configured datasheet source failed because an optional dependency is
+    missing. The per-source messages are effectively identical (they come from
+    the same ``@requires_requests`` guard), so collapse them into one clear
+    line when they agree, and fall back to listing each source otherwise.
+    """
+    unique = set(import_errors.values())
+    if len(unique) == 1:
+        # All sources reported the same missing dependency.
+        return next(iter(unique))
+    detail = "; ".join(f"{source}: {msg}" for source, msg in import_errors.items())
+    return f"Datasheet operations require an optional dependency that is not installed: {detail}"
+
+
 class DatasheetManager:
     """
     Unified manager for datasheet search and download.
@@ -102,12 +118,21 @@ class DatasheetManager:
         """
         all_results = []
         errors = {}
+        import_errors: dict[str, str] = {}
 
         for source in self.sources:
             try:
                 results = source.search(part_number)
                 all_results.extend(results)
                 logger.debug(f"Source {source.name}: found {len(results)} results")
+            except ImportError as e:
+                # A missing optional dependency (e.g. ``requests`` guarded by
+                # ``@requires_requests``). Track separately from ordinary
+                # search failures so the caller can surface install guidance
+                # instead of a misleading "no datasheet found".
+                logger.warning(f"Source {source.name} failed: {e}")
+                errors[source.name] = str(e)
+                import_errors[source.name] = str(e)
             except Exception as e:
                 logger.warning(f"Source {source.name} failed: {e}")
                 errors[source.name] = str(e)
@@ -127,6 +152,7 @@ class DatasheetManager:
             query=part_number,
             results=unique_results,
             errors=errors,
+            import_errors=import_errors,
         )
 
     def download(
@@ -232,6 +258,13 @@ class DatasheetManager:
         search_result = self.search(part_number)
 
         if not search_result.has_results:
+            # Distinguish "no results because nothing matched" from "no results
+            # because every configured source is missing an optional dependency".
+            # In the latter case the real problem is a missing install, not a
+            # lookup miss, so surface install guidance instead of the misleading
+            # "No datasheet found" (issue #4139).
+            if search_result.all_failures_are_import_errors:
+                raise ImportError(_missing_dependency_message(search_result.import_errors))
             raise DatasheetSearchError(f"No datasheet found for '{part_number}'")
 
         # Try each candidate in confidence order, falling through to the next

--- a/src/kicad_tools/datasheet/models.py
+++ b/src/kicad_tools/datasheet/models.py
@@ -68,11 +68,27 @@ class DatasheetSearchResult:
     query: str
     results: list[DatasheetResult] = field(default_factory=list)
     errors: dict[str, str] = field(default_factory=dict)  # source -> error message
+    # Subset of ``errors`` whose failures were caused by a missing optional
+    # dependency (an ``ImportError`` raised by a source's ``@requires_requests``
+    # guard). Tracked separately so callers can distinguish "no results because
+    # nothing matched" from "no results because every source is missing a
+    # dependency" without string-sniffing ``errors``.
+    import_errors: dict[str, str] = field(default_factory=dict)  # source -> message
 
     @property
     def has_results(self) -> bool:
         """Check if any results were found."""
         return len(self.results) > 0
+
+    @property
+    def all_failures_are_import_errors(self) -> bool:
+        """True when at least one source failed and every failure was an ImportError.
+
+        Used to detect the "no configured datasheet source could even run
+        because an optional dependency is missing" condition, so the CLI can
+        surface install guidance instead of a misleading "no datasheet found".
+        """
+        return bool(self.errors) and set(self.import_errors) == set(self.errors)
 
     @property
     def sources_searched(self) -> list[str]:

--- a/src/kicad_tools/datasheet/parser.py
+++ b/src/kicad_tools/datasheet/parser.py
@@ -22,35 +22,50 @@ if TYPE_CHECKING:
     from fitz import Page as FitzPage
 
 
-def _check_markitdown() -> None:
-    """Check if markitdown is available."""
+def _check_markitdown(context: str = "PDF to markdown conversion") -> None:
+    """Check if markitdown is available.
+
+    Args:
+        context: Name of the operation requiring the dependency, used to make
+            the error message name the actual failing operation.
+    """
     try:
         import markitdown  # noqa: F401
     except ImportError as e:
         raise ImportError(
-            "markitdown is required for PDF to markdown conversion. "
+            f"markitdown is required for {context}. "
             "Install with: pip install kicad-tools[datasheet]"
         ) from e
 
 
-def _check_pymupdf() -> None:
-    """Check if PyMuPDF is available."""
+def _check_pymupdf(context: str = "image extraction") -> None:
+    """Check if PyMuPDF is available.
+
+    Args:
+        context: Name of the operation requiring the dependency, used to make
+            the error message name the actual failing operation (e.g. "reading
+            PDF page count") rather than always saying "image extraction".
+    """
     try:
         import fitz  # noqa: F401
     except ImportError as e:
         raise ImportError(
-            "PyMuPDF is required for image extraction. "
-            "Install with: pip install kicad-tools[datasheet]"
+            f"PyMuPDF is required for {context}. Install with: pip install kicad-tools[datasheet]"
         ) from e
 
 
-def _check_pdfplumber() -> None:
-    """Check if pdfplumber is available."""
+def _check_pdfplumber(context: str = "table extraction") -> None:
+    """Check if pdfplumber is available.
+
+    Args:
+        context: Name of the operation requiring the dependency, used to make
+            the error message name the actual failing operation.
+    """
     try:
         import pdfplumber  # noqa: F401
     except ImportError as e:
         raise ImportError(
-            "pdfplumber is required for table extraction. "
+            f"pdfplumber is required for {context}. "
             "Install with: pip install kicad-tools[datasheet]"
         ) from e
 
@@ -122,7 +137,7 @@ class DatasheetParser:
     def page_count(self) -> int:
         """Get the total number of pages in the PDF."""
         if self._page_count is None:
-            _check_pymupdf()
+            _check_pymupdf(context="reading PDF page count")
             import fitz
 
             with fitz.open(self.path) as doc:

--- a/tests/test_datasheet.py
+++ b/tests/test_datasheet.py
@@ -2,7 +2,7 @@
 
 import importlib.util
 from datetime import datetime, timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
@@ -156,6 +156,32 @@ class TestDatasheetSearchResult:
     def test_has_no_results(self):
         result = DatasheetSearchResult(query="NOTFOUND")
         assert result.has_results is False
+
+    def test_all_failures_are_import_errors_true(self):
+        """Every failing source failed with a missing-dependency ImportError."""
+        msg = "The 'requests' library is required for datasheet operations."
+        result = DatasheetSearchResult(
+            query="UCC27211",
+            results=[],
+            errors={"lcsc": msg, "octopart": msg},
+            import_errors={"lcsc": msg, "octopart": msg},
+        )
+        assert result.all_failures_are_import_errors is True
+
+    def test_all_failures_are_import_errors_mixed(self):
+        """A non-import failure alongside an import failure does not trigger."""
+        result = DatasheetSearchResult(
+            query="UCC27211",
+            results=[],
+            errors={"lcsc": "requests is required", "octopart": "network timeout"},
+            import_errors={"lcsc": "requests is required"},
+        )
+        assert result.all_failures_are_import_errors is False
+
+    def test_all_failures_are_import_errors_no_failures(self):
+        """No failures at all should not report an import-error condition."""
+        result = DatasheetSearchResult(query="NOTFOUND", results=[])
+        assert result.all_failures_are_import_errors is False
 
     def test_sources_searched(self):
         result = DatasheetSearchResult(
@@ -893,11 +919,81 @@ class TestDatasheetManager:
 
     def test_download_by_part_not_found(self, manager):
         """Test download_by_part raises error when not found."""
+        from kicad_tools.datasheet.models import DatasheetSearchResult
+
         with patch.object(manager, "search") as mock_search:
-            mock_search.return_value = MagicMock(has_results=False, results=[])
+            mock_search.return_value = DatasheetSearchResult(query="NOTFOUND", results=[])
 
             with pytest.raises(DatasheetSearchError):
                 manager.download_by_part("NOTFOUND")
+
+    def test_search_captures_import_errors_separately(self, manager):
+        """A source raising ImportError is tracked in import_errors, not just errors."""
+        import_msg = (
+            "The 'requests' library is required for datasheet operations. "
+            "Install with: pip install kicad-tools[parts]"
+        )
+        with patch.object(manager.sources[0], "search") as mock_lcsc:
+            with patch.object(manager.sources[1], "search") as mock_octopart:
+                mock_lcsc.side_effect = ImportError(import_msg)
+                mock_octopart.side_effect = ImportError(import_msg)
+
+                results = manager.search("UCC27211")
+
+                assert not results.has_results
+                assert set(results.import_errors) == {"lcsc", "octopart"}
+                assert results.errors == results.import_errors
+                assert results.all_failures_are_import_errors is True
+
+    def test_search_mixed_import_and_search_failure(self, manager):
+        """A non-import failure prevents the all-import-errors condition."""
+        with patch.object(manager.sources[0], "search") as mock_lcsc:
+            with patch.object(manager.sources[1], "search") as mock_octopart:
+                mock_lcsc.side_effect = ImportError("requests is required")
+                mock_octopart.side_effect = RuntimeError("network timeout")
+
+                results = manager.search("UCC27211")
+
+                assert set(results.import_errors) == {"lcsc"}
+                assert set(results.errors) == {"lcsc", "octopart"}
+                assert results.all_failures_are_import_errors is False
+
+    def test_download_by_part_raises_import_error_when_all_deps_missing(self, manager):
+        """download_by_part surfaces install guidance, not 'No datasheet found'."""
+        from kicad_tools.datasheet.models import DatasheetSearchResult
+
+        import_msg = (
+            "The 'requests' library is required for datasheet operations. "
+            "Install with: pip install kicad-tools[parts]"
+        )
+        with patch.object(manager, "search") as mock_search:
+            mock_search.return_value = DatasheetSearchResult(
+                query="UCC27211",
+                results=[],
+                errors={"lcsc": import_msg, "octopart": import_msg},
+                import_errors={"lcsc": import_msg, "octopart": import_msg},
+            )
+
+            with pytest.raises(ImportError) as exc_info:
+                manager.download_by_part("UCC27211")
+
+            assert "requests" in str(exc_info.value)
+            assert "No datasheet found" not in str(exc_info.value)
+
+    def test_download_by_part_mixed_failure_keeps_search_error(self, manager):
+        """Mixed failures still raise the legacy 'No datasheet found' error."""
+        from kicad_tools.datasheet.models import DatasheetSearchResult
+
+        with patch.object(manager, "search") as mock_search:
+            mock_search.return_value = DatasheetSearchResult(
+                query="UCC27211",
+                results=[],
+                errors={"lcsc": "requests is required", "octopart": "network timeout"},
+                import_errors={"lcsc": "requests is required"},
+            )
+
+            with pytest.raises(DatasheetSearchError):
+                manager.download_by_part("UCC27211")
 
     def test_download_by_part_falls_through_to_next_candidate(self, manager):
         """First candidate fails validation; second candidate succeeds."""
@@ -1312,6 +1408,29 @@ class TestDatasheetParserDependencies:
             with pytest.raises(ImportError, match="pdfplumber is required"):
                 _check_pdfplumber()
 
+    def test_pymupdf_import_error_names_context(self, tmp_path):
+        """The check error names the operation passed by the caller."""
+        from kicad_tools.datasheet.parser import _check_pymupdf
+
+        with patch.dict("sys.modules", {"fitz": None}):
+            with pytest.raises(ImportError, match="reading PDF page count"):
+                _check_pymupdf(context="reading PDF page count")
+
+    def test_page_count_import_error_names_page_count(self, tmp_path):
+        """page_count error names page count, not 'image extraction' (#4139)."""
+        from kicad_tools.datasheet.parser import DatasheetParser
+
+        pdf_file = tmp_path / "test.pdf"
+        pdf_file.write_bytes(b"%PDF-1.4")
+        parser = DatasheetParser(pdf_file)
+
+        with patch.dict("sys.modules", {"fitz": None}):
+            with pytest.raises(ImportError) as exc_info:
+                _ = parser.page_count
+
+        assert "page count" in str(exc_info.value)
+        assert "image extraction" not in str(exc_info.value)
+
 
 # ============================================================================
 # CLI Tests
@@ -1391,6 +1510,95 @@ class TestDatasheetCLI:
             assert "lcsc" in captured.err
             assert "octopart" in captured.err
             assert "non-PDF" in captured.err
+
+    def test_download_command_missing_dependency(self, capsys):
+        """download surfaces install guidance when every source lacks a dependency."""
+        from kicad_tools.cli.datasheet_cmd import main
+
+        import_msg = (
+            "The 'requests' library is required for datasheet operations. "
+            "Install with: pip install kicad-tools[parts]"
+        )
+        with patch("kicad_tools.datasheet.manager.DatasheetManager") as MockManager:
+            mock_manager = MagicMock()
+            MockManager.return_value = mock_manager
+            mock_manager.download_by_part.side_effect = ImportError(import_msg)
+
+            result = main(["download", "UCC27211"])
+
+            assert result == 1
+            captured = capsys.readouterr()
+            # Must name the missing dependency / install path, not a lookup miss.
+            assert "requests" in captured.err
+            assert "pip install" in captured.err
+            assert "No datasheet found" not in captured.err
+
+    def test_search_command_missing_dependency(self, capsys):
+        """search surfaces install guidance instead of 'No datasheets found'."""
+        from kicad_tools.cli.datasheet_cmd import main
+        from kicad_tools.datasheet.models import DatasheetSearchResult
+
+        import_msg = (
+            "The 'requests' library is required for datasheet operations. "
+            "Install with: pip install kicad-tools[parts]"
+        )
+        with patch("kicad_tools.datasheet.manager.DatasheetManager") as MockManager:
+            mock_manager = MagicMock()
+            MockManager.return_value = mock_manager
+            mock_manager.search.return_value = DatasheetSearchResult(
+                query="UCC27211",
+                results=[],
+                errors={"lcsc": import_msg, "octopart": import_msg},
+                import_errors={"lcsc": import_msg, "octopart": import_msg},
+            )
+
+            result = main(["search", "UCC27211"])
+
+            assert result == 1
+            captured = capsys.readouterr()
+            combined = captured.out + captured.err
+            assert "requests" in combined
+            assert "pip install" in combined
+            assert "No datasheets found" not in combined
+
+    def test_info_command_missing_pymupdf_names_page_count(self, tmp_path, capsys):
+        """info error names page count, not image extraction, when fitz missing (#4139)."""
+        from kicad_tools.cli.datasheet_cmd import main
+
+        pdf_file = tmp_path / "test.pdf"
+        pdf_file.write_bytes(b"%PDF-1.4")
+
+        with patch.dict("sys.modules", {"fitz": None}):
+            result = main(["info", str(pdf_file)])
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "page count" in captured.err
+        assert "image extraction" not in captured.err
+
+    def test_info_command_table_extraction_best_effort(self, tmp_path, capsys):
+        """info still prints page count when only table extraction fails."""
+        from kicad_tools.cli.datasheet_cmd import main
+        from kicad_tools.datasheet.parser import DatasheetParser
+
+        pdf_file = tmp_path / "test.pdf"
+        pdf_file.write_bytes(b"%PDF-1.4")
+
+        with patch.object(DatasheetParser, "page_count", new_callable=PropertyMock) as mock_pages:
+            mock_pages.return_value = 7
+            with patch.object(DatasheetParser, "extract_images", return_value=[]):
+                with patch.object(
+                    DatasheetParser,
+                    "extract_tables",
+                    side_effect=ImportError("pdfplumber is required for table extraction."),
+                ):
+                    result = main(["info", str(pdf_file)])
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "Pages:   7" in captured.out
+        assert "unavailable" in captured.out
+        assert "pdfplumber" in captured.out
 
     def test_list_command_empty(self, capsys):
         """Test list command with no cached datasheets."""


### PR DESCRIPTION
## Summary

`kct datasheet download <part>` (and `search`) swallowed a missing-optional-dependency error into a misleading "No datasheet found" / "No datasheets found" conclusion when `kicad-tools` was installed without the `[parts]` extra. Separately, `kct datasheet info <valid.pdf>` reported `PyMuPDF is required for image extraction` even for page-count/metadata, and failed the whole command if only one extraction library was missing. This PR fixes both (single-PR scope per the curator's recommendation).

## Changes

**Part 1 — search/download misreporting**
- `DatasheetSearchResult` gains an `import_errors` dict and an `all_failures_are_import_errors` property to distinguish "nothing matched" from "every source is missing an optional dependency" without string-sniffing (`models.py`).
- `DatasheetManager.search()` catches `ImportError` before the generic `except Exception`, recording it in both `errors` (unchanged display behavior) and the new `import_errors` (`manager.py`).
- `download_by_part()` raises `ImportError` with collapsed install guidance instead of `DatasheetSearchError("No datasheet found...")` when *all* sources failed on a missing dependency; genuine/mixed misses are unchanged (`manager.py`).
- `_run_download()` gains an `except ImportError` branch before its generic `except Exception` (which previously shadowed `main()`'s well-behaved outer handler), and `_run_search()` surfaces the same install guidance instead of a bare "No datasheets found" (`datasheet_cmd.py`).

**Part 2 — info / PyMuPDF error scoping**
- `_check_pymupdf` / `_check_pdfplumber` / `_check_markitdown` accept a `context` argument so the `ImportError` names the actual operation; `page_count` now reports `"reading PDF page count"` rather than `"image extraction"` (`parser.py`).
- `_info()` computes image/table counts best-effort: a missing `pdfplumber` (or `fitz` for images) no longer aborts the whole command — page count still prints and unavailable counts show a friendly note (`datasheet_cmd.py`).

No new dependencies added (`pypdf`/`PyPDF2` explicitly not introduced — no lighter path exists).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `download` prints install guidance (not "No datasheet found"), exits 1, on uniform missing-dep failure | ✅ | `test_download_command_missing_dependency`, `test_download_by_part_raises_import_error_when_all_deps_missing` |
| `search` surfaces missing-dep cause instead of "No datasheets found" | ✅ | `test_search_command_missing_dependency` |
| Mixed-failure case preserved (legacy "No datasheet found" retained) | ✅ | `test_download_by_part_mixed_failure_keeps_search_error`, `test_search_mixed_import_and_search_failure`, `test_all_failures_are_import_errors_mixed` |
| `info` error names the real operation ("page count"), not "image extraction" | ✅ | `test_info_command_missing_pymupdf_names_page_count`, `test_page_count_import_error_names_page_count`, `test_pymupdf_import_error_names_context` |
| `_info()` best-effort: one missing extraction lib does not abort the command | ✅ | `test_info_command_table_extraction_best_effort` |
| No new hard dependency added | ✅ | Only message-scoping + exception-type tracking; no `pyproject.toml` change |

## Test Plan

- `uv run pytest tests/test_datasheet.py -q` → 126 passed, 29 skipped (skips are pre-existing dependency-gated tests; the `TestDatasheetManager` suite is class-skipped when `requests` is absent in this env — its logic was additionally verified with a stubbed `requests` module).
- `uv run ruff check` + `ruff format` clean on all changed files.
- `mypy` on the four changed source files: 0 new errors (the 17 reported are all pre-existing, on lines untouched by this PR).
- All dependency-missing scenarios use `patch.dict("sys.modules", {...: None})` / `DatasheetSearchResult(import_errors={...})` — no live network, no `pip uninstall`.

Closes #4139