### PR TITLE
fix(schematic): union collinear-overlapping and T-touching wires in connectivity

### DIFF
--- a/src/kicad_tools/schematic/models/netlist_mixin.py
+++ b/src/kicad_tools/schematic/models/netlist_mixin.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from .wire_geometry import wire_segments_connect
+
 if TYPE_CHECKING:
     pass
 
@@ -92,6 +94,25 @@ class SchematicNetlistMixin:
             wire_segments.append((p1, p2))
             # Connect wire endpoints
             union(p1, p2)
+
+        # Union wires with each other on collinear overlap or mid-segment
+        # T-touch — matching KiCad, which merges the nets of any two touching
+        # or overlapping wire segments, not only those that share an exact
+        # endpoint (issue #4143).  The endpoint case is already handled by the
+        # loop above.  All-pairs O(n^2) is fine at typical schematic sizes
+        # (check_wire_collisions() already scans this way with no reported
+        # slowdown); no spatial index is warranted here.
+        #
+        # NOTE: this is wire-to-wire unioning only.  It deliberately does NOT
+        # relax the pin-to-wire endpoint-only rule from #4020/#4003 — pins
+        # still attach to wires solely at endpoints/junctions (see
+        # connect_to_wire(endpoint_only=True) below).
+        for i in range(len(wire_segments)):
+            a_start, a_end = wire_segments[i]
+            for j in range(i + 1, len(wire_segments)):
+                b_start, b_end = wire_segments[j]
+                if wire_segments_connect(a_start, a_end, b_start, b_end):
+                    union(a_start, b_start)
 
         # Helper to check if point is on a wire segment
         def point_on_segment(point: tuple, seg_start: tuple, seg_end: tuple) -> bool:

--- a/src/kicad_tools/schematic/models/validation_mixin.py
+++ b/src/kicad_tools/schematic/models/validation_mixin.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 from ..grid import is_on_grid, snap_to_grid
 from ..logging import _log_debug, _log_info, _log_warning
 from .elements import WireCollision
+from .wire_geometry import wire_segments_connect
 
 if TYPE_CHECKING:
     pass
@@ -131,6 +132,10 @@ class SchematicValidationMixin:
         # Check wire connectivity
         connectivity_issues = self._check_wire_connectivity()
         issues.extend(connectivity_issues)
+
+        # Check for cross-net collinear-overlap / T-touch shorts (issue #4143)
+        conflict_issues = self._check_collinear_net_conflicts()
+        issues.extend(conflict_issues)
 
         # Check for unconnected pins (all types, not just power)
         unconnected_pin_issues = self._check_unconnected_pins()
@@ -529,6 +534,17 @@ class SchematicValidationMixin:
             p2 = (round(wire.x2, 2), round(wire.y2, 2))
             wire_segments.append((p1, p2))
 
+        # Union wires with each other on collinear overlap or mid-segment
+        # T-touch, matching KiCad and mirroring the same fix applied to
+        # _build_connectivity_graph() (issue #4143).  This duplicate
+        # connectivity builder had the identical endpoint-only gap.
+        for i in range(len(wire_segments)):
+            a_start, a_end = wire_segments[i]
+            for j in range(i + 1, len(wire_segments)):
+                b_start, b_end = wire_segments[j]
+                if wire_segments_connect(a_start, a_end, b_start, b_end):
+                    union(a_start, b_start)
+
         for junc in self.junctions:
             junc_pos = (round(junc.x, 2), round(junc.y, 2))
             # Connect junction to any wire segment it's on
@@ -790,6 +806,102 @@ class SchematicValidationMixin:
                 _log_debug(f"  {collision}")
 
         return collisions
+
+    def _wire_net_names(self) -> list[set[str]]:
+        """Map each wire to the set of net names directly labelling it.
+
+        A net name is attributed to a wire when a label / global label /
+        hierarchical label / power symbol sits *on* that wire segment (within
+        ``POINT_TOLERANCE``).  This is intentionally per-wire and independent
+        of Union-Find so that :meth:`_check_collinear_net_conflicts` can tell
+        whether two geometrically-touching wires were *each* independently
+        named with a *different* net — the signature of an unintended short
+        (issue #4143) — rather than merely sharing one net after the union.
+
+        Returns:
+            A list parallel to ``self.wires``; entry *i* is the set of net
+            names attached to ``self.wires[i]``.
+        """
+        named_points: list[tuple[float, float, str]] = []
+        for label in self.labels:  # type: ignore[attr-defined]
+            named_points.append((label.x, label.y, label.text))
+        for gl in self.global_labels:  # type: ignore[attr-defined]
+            named_points.append((gl.x, gl.y, gl.text))
+        for hl in self.hier_labels:  # type: ignore[attr-defined]
+            named_points.append((hl.x, hl.y, hl.text))
+        for pwr in self.power_symbols:  # type: ignore[attr-defined]
+            net_name = pwr.lib_id.split(":")[1] if ":" in pwr.lib_id else pwr.lib_id
+            named_points.append((pwr.x, pwr.y, net_name))
+
+        per_wire: list[set[str]] = []
+        for wire in self.wires:  # type: ignore[attr-defined]
+            names: set[str] = set()
+            for x, y, name in named_points:
+                if self._point_on_wire(x, y, wire):  # type: ignore[attr-defined]
+                    names.add(name)
+            per_wire.append(names)
+        return per_wire
+
+    def _check_collinear_net_conflicts(self) -> list[dict]:
+        """Flag two overlapping/T-touching wires that carry *different* nets.
+
+        Once :meth:`_build_connectivity_graph` unions collinear-overlapping /
+        T-touching wires (issue #4143), two stubs labelled with different net
+        names that overlap geometrically end up merged into one net — almost
+        always an unintended short (the softstart rev-B failure: ``+3.3V``
+        shorted to ``GND`` by interleaved decoupling-cap stubs).  This emits
+        an **error** for each such conflicting pair so the short surfaces in
+        ``validate()`` output instead of hiding as a silent merge.
+
+        Same-net overlaps (both wires labelled with the same net, or one/both
+        unlabelled) are *not* flagged: only a genuine two-different-named-net
+        overlap is reported.
+        """
+        issues: list[dict] = []
+        wire_nets = self._wire_net_names()
+        wires = self.wires  # type: ignore[attr-defined]
+
+        reported: set[tuple[str, str, tuple[float, float]]] = set()
+        for i in range(len(wires)):
+            a = wires[i]
+            a_start = (round(a.x1, 2), round(a.y1, 2))
+            a_end = (round(a.x2, 2), round(a.y2, 2))
+            for j in range(i + 1, len(wires)):
+                b = wires[j]
+                b_start = (round(b.x1, 2), round(b.y1, 2))
+                b_end = (round(b.x2, 2), round(b.y2, 2))
+
+                if not wire_segments_connect(a_start, a_end, b_start, b_end):
+                    continue
+
+                # Only a conflict when each wire independently carries a
+                # named net and those net-name sets are disjoint.
+                names_a = wire_nets[i]
+                names_b = wire_nets[j]
+                if not names_a or not names_b or (names_a & names_b):
+                    continue
+
+                for net_a in sorted(names_a):
+                    for net_b in sorted(names_b):
+                        key = (net_a, net_b, a_start)
+                        if key in reported:
+                            continue
+                        reported.add(key)
+                        issues.append(
+                            {
+                                "severity": "error",
+                                "type": "collinear_net_conflict",
+                                "message": (
+                                    f"Wire segments carrying different nets '{net_a}' and "
+                                    f"'{net_b}' overlap collinearly or T-touch near {a_start}, "
+                                    "merging them into one net (likely an unintended short)."
+                                ),
+                                "location": a_start,
+                                "fix_applied": False,
+                            }
+                        )
+
+        return issues
 
 
 def summarize_issues_by_type(issues: list[dict]) -> dict[str, list[dict]]:

--- a/src/kicad_tools/schematic/models/wire_geometry.py
+++ b/src/kicad_tools/schematic/models/wire_geometry.py
@@ -1,0 +1,171 @@
+"""Wire-vs-wire geometric union primitives for schematic connectivity.
+
+KiCad unions the nets of *any* two touching or overlapping collinear wire
+segments, not just wires that share an exact endpoint.  The schematic
+connectivity model historically unioned wires only at their two endpoints,
+so a generator using the stub-wire+label idiom could produce mid-segment
+overlaps that KiCad merges but kicad-tools kept separate — a silent,
+LVS-grade net-merge divergence (issue #4143).
+
+This module provides the single, tested geometric primitive
+(:func:`wire_segments_connect`) used by both
+``SchematicNetlistMixin._build_connectivity_graph`` and
+``SchematicValidationMixin.validate_power_nets`` so the two connectivity
+builders cannot drift apart.
+
+Two axis-aligned wire segments A and B are considered electrically
+connected (beyond a shared endpoint) when either:
+
+* **Collinear overlap** — A and B lie on the same infinite line and their
+  projected parametric ranges share a sub-segment of nonzero length.  This
+  covers A containing B, B containing A, and partial overlap where neither
+  contains the other (the softstart rev-B repro geometry).
+* **Mid-segment T-touch** — one endpoint of A lands in the *interior* of B
+  (not at B's endpoints), or vice-versa.
+
+A shared endpoint alone is NOT reported here: that case is already handled
+by the endpoint Union-Find in the connectivity builders.  This mirrors, but
+is deliberately distinct from, the pin-endpoint-only semantics of
+#4020/#4003 — *pins* attach to wires only at endpoints/junctions, while
+*wires* union with each other on any overlap/T-touch, matching KiCad.
+"""
+
+from __future__ import annotations
+
+# Tolerance (mm) for perpendicular-distance-to-line and endpoint-coincidence
+# checks.  Matches ``SchematicElementsMixin.POINT_TOLERANCE`` (0.1mm) — the
+# same permissive snap tolerance used elsewhere in the connectivity graph.
+# Do NOT use the tighter 0.005mm from ``sch_cleanup_wires``: that value is
+# tuned for a *destructive* wire-deletion decision, whereas connectivity
+# union is non-destructive and should be at least as permissive as KiCad's
+# own snap tolerance.
+POINT_TOLERANCE = 0.1
+
+Point = tuple[float, float]
+
+
+def _points_equal(p1: Point, p2: Point, tolerance: float = POINT_TOLERANCE) -> bool:
+    """Return True if two points coincide within *tolerance*."""
+    return abs(p1[0] - p2[0]) <= tolerance and abs(p1[1] - p2[1]) <= tolerance
+
+
+def _point_on_segment_interior(
+    point: Point, seg_start: Point, seg_end: Point, tolerance: float = POINT_TOLERANCE
+) -> bool:
+    """Return True if *point* lies on the interior of the segment.
+
+    "Interior" excludes the two endpoints (within *tolerance*): a point that
+    only coincides with an endpoint is handled by endpoint Union-Find, not
+    here.  Uses perpendicular distance to the infinite line plus a
+    parametric bounds check, so it works for a point anywhere along the
+    segment body regardless of orientation.
+    """
+    px, py = point
+    ax, ay = seg_start
+    bx, by = seg_end
+
+    dx = bx - ax
+    dy = by - ay
+    seg_len_sq = dx * dx + dy * dy
+
+    if seg_len_sq <= tolerance * tolerance:
+        # Degenerate (zero-length) segment — nothing to be interior to.
+        return False
+
+    # Reject points coincident with either endpoint (not "interior").
+    if _points_equal(point, seg_start, tolerance) or _points_equal(point, seg_end, tolerance):
+        return False
+
+    # Parametric projection of point onto the infinite line through A-B.
+    t = ((px - ax) * dx + (py - ay) * dy) / seg_len_sq
+    seg_len = seg_len_sq**0.5
+    eps_t = tolerance / seg_len
+    if t <= eps_t or t >= 1.0 - eps_t:
+        return False
+
+    # Perpendicular distance from the point to the segment's line.
+    cx = ax + t * dx
+    cy = ay + t * dy
+    dist_sq = (px - cx) ** 2 + (py - cy) ** 2
+    return dist_sq <= tolerance * tolerance
+
+
+def _collinear_overlap(
+    a_start: Point,
+    a_end: Point,
+    b_start: Point,
+    b_end: Point,
+    tolerance: float = POINT_TOLERANCE,
+) -> bool:
+    """Return True if segments A and B collinearly overlap on a sub-segment.
+
+    Both segments must lie on the same infinite line (both of B's endpoints
+    within *tolerance* of A's line) AND their projected parametric ranges on
+    A's line must overlap by more than a single point (nonzero-length shared
+    sub-segment).  Handles A⊇B, B⊇A, and partial overlap where neither
+    contains the other.  A pure endpoint touch (zero-length overlap) returns
+    False — that is the shared-endpoint case handled elsewhere.
+    """
+    ax, ay = a_start
+    bx, by = a_end
+    dx = bx - ax
+    dy = by - ay
+    seg_len_sq = dx * dx + dy * dy
+
+    if seg_len_sq <= tolerance * tolerance:
+        return False
+
+    seg_len = seg_len_sq**0.5
+
+    # Both of B's endpoints must lie on A's infinite line.
+    for px, py in (b_start, b_end):
+        cross = abs((px - ax) * dy - (py - ay) * dx)
+        if cross / seg_len > tolerance:
+            return False
+
+    # Project B's endpoints onto A's parameterised line.
+    t_vals: list[float] = []
+    for px, py in (b_start, b_end):
+        t_vals.append(((px - ax) * dx + (py - ay) * dy) / seg_len_sq)
+
+    b_min, b_max = min(t_vals), max(t_vals)
+
+    # Intersect [0, 1] (A's range) with [b_min, b_max] (B's range).
+    lo = max(0.0, b_min)
+    hi = min(1.0, b_max)
+
+    # Require a shared sub-segment of nonzero length, not just a touch.
+    eps_t = tolerance / seg_len
+    return bool((hi - lo) > eps_t)
+
+
+def wire_segments_connect(
+    a_start: Point,
+    a_end: Point,
+    b_start: Point,
+    b_end: Point,
+    tolerance: float = POINT_TOLERANCE,
+) -> bool:
+    """Return True if two wire segments should union (KiCad wire semantics).
+
+    Reports collinear overlap (nonzero-length shared sub-segment) or a
+    mid-segment T-touch (one segment's endpoint on the other's interior).
+    A pure shared endpoint returns False — that connection is already made
+    by endpoint Union-Find in the connectivity builders, so reporting it
+    here would be redundant.
+    """
+    # Collinear overlap (covers containment and partial overlap).
+    if _collinear_overlap(a_start, a_end, b_start, b_end, tolerance):
+        return True
+
+    # Mid-segment T-touch: an endpoint of one wire on the other's interior.
+    if _point_on_segment_interior(b_start, a_start, a_end, tolerance):
+        return True
+    if _point_on_segment_interior(b_end, a_start, a_end, tolerance):
+        return True
+    if _point_on_segment_interior(a_start, b_start, b_end, tolerance):
+        return True
+    if _point_on_segment_interior(a_end, b_start, b_end, tolerance):
+        return True
+
+    return False

--- a/tests/test_netlist_query.py
+++ b/tests/test_netlist_query.py
@@ -815,3 +815,194 @@ class TestMultiUnitNetResolution:
         sch.wires.append(Wire(x1=100, y1=97.46, x2=100, y2=90))
         sch.labels.append(Label(text="VCC", x=100, y=90))
         assert sch.get_net_for_pin("U1", "8") == "VCC"
+
+
+class TestWireToWireCollinearUnion:
+    """Wire-to-wire collinear overlap and T-touch union (issue #4143).
+
+    KiCad merges the nets of any two touching/overlapping collinear wire
+    segments, not only wires that share an exact endpoint.  The connectivity
+    graph historically unioned wires only at their two endpoints, silently
+    diverging from KiCad on the stub-wire+label idiom that generated the
+    softstart rev-B ``+3.3V``/``GND`` short.  These tests lock in the fix.
+
+    NOTE: this is the mirror image of :class:`TestPinEndpointOnlyWireAttach`.
+    Pins still attach to wires endpoint-only (#4020/#4003); only *wire-to-
+    wire* unions gain collinear-overlap / T-touch semantics.
+    """
+
+    def _labeled_nets(self, sch: Schematic, net_a: str, net_b: str):
+        """Return the (net_a pins, net_b pins) sets from a fresh netlist."""
+        netlist = sch.extract_netlist()
+        a = {str(p) for p in netlist.get(net_a, [])}
+        b = {str(p) for p in netlist.get(net_b, [])}
+        return netlist, a, b
+
+    def _two_stub_schematic(
+        self, a_span: tuple[float, float], b_span: tuple[float, float], y: float = 100.0
+    ) -> Schematic:
+        """Two horizontal stub wires on ``y`` with a label on each.
+
+        Each stub carries a symbol pin at its far end plus a net label, so
+        the two labels' merge status is observable in the netlist.
+        """
+        sch = Schematic("Test")
+        r_def = make_simple_symbol("Device:R", [("~", "1", -2.54, 0), ("~", "2", 2.54, 0)])
+        # R1 pin 2 lands on the start of stub A; R2 pin 1 on the end of B.
+        r1 = SymbolInstance(
+            symbol_def=r_def, x=a_span[0] - 2.54, y=y, rotation=0, reference="R1", value="10k"
+        )
+        r2 = SymbolInstance(
+            symbol_def=r_def, x=b_span[1] + 2.54, y=y, rotation=0, reference="R2", value="10k"
+        )
+        sch.symbols.extend([r1, r2])
+        sch.wires.append(Wire(x1=a_span[0], y1=y, x2=a_span[1], y2=y))
+        sch.wires.append(Wire(x1=b_span[0], y1=y, x2=b_span[1], y2=y))
+        sch.labels.append(Label(text="NET_A", x=a_span[0], y=y))
+        sch.labels.append(Label(text="NET_B", x=b_span[1], y=y))
+        return sch
+
+    def test_partial_overlap_neither_contains_the_other(self):
+        """A=[100,109], B=[103,112] share [103,109]; must union.
+
+        This is the exact softstart repro geometry and the case the old
+        ``_is_collinear_overlap`` (full-containment only) does NOT catch.
+        """
+        sch = self._two_stub_schematic((100.0, 109.0), (103.0, 112.0))
+        netlist, a, b = self._labeled_nets(sch, "NET_A", "NET_B")
+        # Post-fix: both stubs merge into ONE net — extract_netlist collapses
+        # to a single named net carrying both R1.2 and R2.1.
+        merged = a or b
+        assert "R1.2" in merged and "R2.1" in merged
+        assert sch.are_connected("R1", "2", "R2", "1") is True
+
+    def test_full_containment(self):
+        """A=[100,112] fully contains B=[103,109]; must union."""
+        sch = self._two_stub_schematic((100.0, 112.0), (103.0, 109.0))
+        assert sch.are_connected("R1", "2", "R2", "1") is True
+
+    def test_repro_sketch_r1_r2_collinear_stubs(self):
+        """Issue repro: R1/R2 ~8mm apart, overlapping collinear stubs.
+
+        R1 at x=100, R2 at x=108; stub A reaches x=109, stub B reaches back
+        to x=103 — overlapping on y=100.  Pre-fix NET_A/NET_B were distinct;
+        post-fix they are one net (KiCad merges).
+        """
+        sch = self._two_stub_schematic((100.0, 109.0), (103.0, 112.0))
+        assert sch.are_connected("R1", "2", "R2", "1") is True
+
+    def test_mid_segment_t_touch(self):
+        """B's endpoint lands in the interior of A; must union.
+
+        A runs horizontally [100,112] on y=100.  B is vertical from
+        (106,100) up to (106,90): B's lower endpoint (106,100) sits on A's
+        interior — a T-touch KiCad treats as connected.
+        """
+        sch = Schematic("Test")
+        r_def = make_simple_symbol("Device:R", [("~", "1", -2.54, 0), ("~", "2", 2.54, 0)])
+        r1 = SymbolInstance(
+            symbol_def=r_def, x=97.46, y=100, rotation=0, reference="R1", value="10k"
+        )
+        r2 = SymbolInstance(symbol_def=r_def, x=106, y=85, rotation=0, reference="R2", value="10k")
+        sch.symbols.extend([r1, r2])
+        # A: horizontal, R1 pin 2 at (100,100) on its start.
+        sch.wires.append(Wire(x1=100, y1=100, x2=112, y2=100))
+        # B: vertical, lower end T-touches A's interior at (106,100); upper
+        # end (106,90) lands on R2 pin 1 (R2 at (106,85), pin1 y-offset).
+        sch.wires.append(Wire(x1=106, y1=100, x2=106, y2=90))
+        # R2 pin 1 sits at (103.46, 85)?  Recompute: place R2 so pin1 lands
+        # on the wire's free end instead — put R2 pin1 at (106,90).
+        r2b = SymbolInstance(
+            symbol_def=r_def, x=108.54, y=90, rotation=0, reference="R3", value="10k"
+        )
+        sch.symbols.append(r2b)  # R3 pin1 at (106,90)
+        assert sch.symbols[2].pin_position("1") == (106.0, 90.0)
+        assert sch.are_connected("R1", "2", "R3", "1") is True
+
+    def test_same_endpoint_still_connects(self):
+        """The pre-existing shared-endpoint case is unchanged."""
+        sch = Schematic("Test")
+        r_def = make_simple_symbol("Device:R", [("~", "1", -2.54, 0), ("~", "2", 2.54, 0)])
+        r1 = SymbolInstance(
+            symbol_def=r_def, x=97.46, y=100, rotation=0, reference="R1", value="10k"
+        )
+        r2 = SymbolInstance(
+            symbol_def=r_def, x=114.54, y=100, rotation=0, reference="R2", value="10k"
+        )
+        sch.symbols.extend([r1, r2])
+        sch.wires.append(Wire(x1=100, y1=100, x2=106, y2=100))
+        sch.wires.append(Wire(x1=106, y1=100, x2=112, y2=100))
+        assert sch.are_connected("R1", "2", "R2", "1") is True
+
+    def test_no_union_when_parallel_but_not_collinear(self):
+        """Two parallel wires on different Y do NOT union."""
+        sch = Schematic("Test")
+        r_def = make_simple_symbol("Device:R", [("~", "1", -2.54, 0), ("~", "2", 2.54, 0)])
+        r1 = SymbolInstance(
+            symbol_def=r_def, x=97.46, y=100, rotation=0, reference="R1", value="10k"
+        )
+        r2 = SymbolInstance(
+            symbol_def=r_def, x=97.46, y=110, rotation=0, reference="R2", value="10k"
+        )
+        sch.symbols.extend([r1, r2])
+        sch.wires.append(Wire(x1=100, y1=100, x2=112, y2=100))
+        sch.wires.append(Wire(x1=100, y1=110, x2=112, y2=110))  # 10mm below
+        assert sch.are_connected("R1", "2", "R2", "1") is False
+
+    def test_are_connected_and_get_net_for_pin_reflect_fix(self):
+        """are_connected() and get_net_for_pin() inherit the fix (no patch)."""
+        sch = self._two_stub_schematic((100.0, 109.0), (103.0, 112.0))
+        # Both pins land on the merged net; get_net_for_pin returns the same
+        # named net for both.
+        net1 = sch.get_net_for_pin("R1", "2")
+        net2 = sch.get_net_for_pin("R2", "1")
+        assert net1 == net2
+        assert net1 in ("NET_A", "NET_B")
+
+    def test_softstart_power_vs_power_merge_pattern(self):
+        """Interleaved decoupling-cap stubs merge two power rails (class a).
+
+        Synthetic reproduction of the softstart +3.3V/GND geometric class:
+        two power-symbol stubs on the same Y with different X extents that
+        overlap collinearly.  Post-fix the two power nets are unioned.
+        """
+        from kicad_tools.schematic.models.elements import PowerSymbol
+
+        sch = Schematic("Test")
+        # +3.3V stub [100,108], GND stub [104,112] overlap on [104,108].
+        sch.wires.append(Wire(x1=100, y1=100, x2=108, y2=100))
+        sch.wires.append(Wire(x1=104, y1=100, x2=112, y2=100))
+        sch.power_symbols.append(PowerSymbol(lib_id="power:+3.3V", x=100, y=100, rotation=0))
+        sch.power_symbols.append(PowerSymbol(lib_id="power:GND", x=112, y=100, rotation=0))
+        # Add a pin on each end so the merged component surfaces in netlist.
+        r_def = make_simple_symbol("Device:R", [("~", "1", -2.54, 0), ("~", "2", 2.54, 0)])
+        sch.symbols.append(
+            SymbolInstance(symbol_def=r_def, x=97.46, y=100, rotation=0, reference="R1", value="1k")
+        )
+        sch.symbols.append(
+            SymbolInstance(
+                symbol_def=r_def, x=114.54, y=100, rotation=0, reference="R2", value="1k"
+            )
+        )
+        # R1.1 (at 94.92) floats; R1.2 at (100,100) and R2.1 at (112,100)
+        # land on the two overlapping stubs and therefore merge.
+        assert sch.are_connected("R1", "2", "R2", "1") is True
+
+    def test_same_net_overlap_no_conflict(self):
+        """Two overlapping stubs with the SAME label merge uneventfully."""
+        sch = Schematic("Test")
+        r_def = make_simple_symbol("Device:R", [("~", "1", -2.54, 0), ("~", "2", 2.54, 0)])
+        r1 = SymbolInstance(
+            symbol_def=r_def, x=97.46, y=100, rotation=0, reference="R1", value="10k"
+        )
+        r2 = SymbolInstance(
+            symbol_def=r_def, x=114.54, y=100, rotation=0, reference="R2", value="10k"
+        )
+        sch.symbols.extend([r1, r2])
+        sch.wires.append(Wire(x1=100, y1=100, x2=109, y2=100))
+        sch.wires.append(Wire(x1=103, y1=100, x2=112, y2=100))
+        sch.labels.append(Label(text="VBUS", x=100, y=100))
+        sch.labels.append(Label(text="VBUS", x=112, y=100))
+        netlist = sch.extract_netlist()
+        assert "VBUS" in netlist
+        assert {str(p) for p in netlist["VBUS"]} == {"R1.2", "R2.1"}

--- a/tests/test_schematic_models.py
+++ b/tests/test_schematic_models.py
@@ -2725,6 +2725,98 @@ class TestWireCollisionDetection:
         assert "0" in s and "100" in s  # target wire coordinates
 
 
+class TestCollinearNetConflict:
+    """validate() emits an error when overlapping wires carry different nets.
+
+    Issue #4143: once the connectivity graph unions collinear-overlapping /
+    T-touching wires, two stubs labelled with *different* nets that overlap
+    geometrically get merged into one net — almost always an unintended
+    short.  validate() surfaces this as a new ``collinear_net_conflict``
+    error (distinct from the ``missing_junction`` warning).
+    """
+
+    def test_collinear_overlap_different_nets_is_error(self):
+        """Two overlapping stubs with different labels -> error."""
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        sch.wires.append(Wire(x1=100, y1=100, x2=109, y2=100))
+        sch.wires.append(Wire(x1=103, y1=100, x2=112, y2=100))
+        sch.labels.append(Label(text="NET_A", x=100, y=100))
+        sch.labels.append(Label(text="NET_B", x=112, y=100))
+
+        issues = sch.validate()
+        conflicts = [i for i in issues if i["type"] == "collinear_net_conflict"]
+        assert len(conflicts) == 1
+        assert conflicts[0]["severity"] == "error"
+        assert "NET_A" in conflicts[0]["message"]
+        assert "NET_B" in conflicts[0]["message"]
+
+    def test_t_touch_different_nets_is_error(self):
+        """A T-touch merging two different nets -> error."""
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        # Horizontal A [100,112] labelled NET_A; vertical B from interior
+        # point (106,100) up, labelled NET_B at its free end.
+        sch.wires.append(Wire(x1=100, y1=100, x2=112, y2=100))
+        sch.wires.append(Wire(x1=106, y1=100, x2=106, y2=90))
+        sch.labels.append(Label(text="NET_A", x=100, y=100))
+        sch.labels.append(Label(text="NET_B", x=106, y=90))
+
+        issues = sch.validate()
+        conflicts = [i for i in issues if i["type"] == "collinear_net_conflict"]
+        assert len(conflicts) == 1
+        assert conflicts[0]["severity"] == "error"
+
+    def test_same_net_overlap_no_error(self):
+        """Overlapping stubs with the SAME net name are not flagged."""
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        sch.wires.append(Wire(x1=100, y1=100, x2=109, y2=100))
+        sch.wires.append(Wire(x1=103, y1=100, x2=112, y2=100))
+        sch.labels.append(Label(text="VBUS", x=100, y=100))
+        sch.labels.append(Label(text="VBUS", x=112, y=100))
+
+        issues = sch.validate()
+        conflicts = [i for i in issues if i["type"] == "collinear_net_conflict"]
+        assert conflicts == []
+
+    def test_no_overlap_no_error(self):
+        """Non-overlapping stubs with different nets are not flagged."""
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        sch.wires.append(Wire(x1=100, y1=100, x2=105, y2=100))
+        sch.wires.append(Wire(x1=110, y1=100, x2=115, y2=100))  # gap [105,110]
+        sch.labels.append(Label(text="NET_A", x=100, y=100))
+        sch.labels.append(Label(text="NET_B", x=115, y=100))
+
+        issues = sch.validate()
+        conflicts = [i for i in issues if i["type"] == "collinear_net_conflict"]
+        assert conflicts == []
+
+    def test_power_vs_power_overlap_is_error(self):
+        """Interleaved power stubs (+3.3V/GND) overlap -> error (softstart)."""
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        sch.wires.append(Wire(x1=100, y1=100, x2=108, y2=100))
+        sch.wires.append(Wire(x1=104, y1=100, x2=112, y2=100))
+        sch.power_symbols.append(PowerSymbol(lib_id="power:+3.3V", x=100, y=100, rotation=0))
+        sch.power_symbols.append(PowerSymbol(lib_id="power:GND", x=112, y=100, rotation=0))
+
+        issues = sch.validate()
+        conflicts = [i for i in issues if i["type"] == "collinear_net_conflict"]
+        assert len(conflicts) == 1
+        assert conflicts[0]["severity"] == "error"
+        assert "+3.3V" in conflicts[0]["message"]
+        assert "GND" in conflicts[0]["message"]
+
+    def test_one_unlabelled_wire_no_error(self):
+        """Overlap where only one wire is labelled is not a conflict."""
+        sch = Schematic(title="Test", snap_mode=SnapMode.OFF)
+        sch.wires.append(Wire(x1=100, y1=100, x2=109, y2=100))
+        sch.wires.append(Wire(x1=103, y1=100, x2=112, y2=100))
+        sch.labels.append(Label(text="NET_A", x=100, y=100))
+        # second wire carries no label
+
+        issues = sch.validate()
+        conflicts = [i for i in issues if i["type"] == "collinear_net_conflict"]
+        assert conflicts == []
+
+
 class TestSymbolDefParsing:
     """Tests for SymbolDef parsing methods."""
 

--- a/tests/test_wire_geometry.py
+++ b/tests/test_wire_geometry.py
@@ -1,0 +1,72 @@
+"""Unit tests for the wire-vs-wire union geometry primitive (issue #4143).
+
+Directly exercise ``wire_segments_connect`` and its helpers so the geometry
+math is covered independently of the connectivity-graph integration.
+"""
+
+from kicad_tools.schematic.models.wire_geometry import (
+    _collinear_overlap,
+    _point_on_segment_interior,
+    wire_segments_connect,
+)
+
+
+class TestCollinearOverlap:
+    def test_partial_overlap(self):
+        # A=[100,109], B=[103,112] on y=100 share [103,109].
+        assert _collinear_overlap((100, 100), (109, 100), (103, 100), (112, 100)) is True
+
+    def test_full_containment_a_contains_b(self):
+        assert _collinear_overlap((100, 100), (112, 100), (103, 100), (109, 100)) is True
+
+    def test_full_containment_b_contains_a(self):
+        assert _collinear_overlap((103, 100), (109, 100), (100, 100), (112, 100)) is True
+
+    def test_shared_endpoint_only_is_not_overlap(self):
+        # Touch at a single point (109,100) — zero-length overlap.
+        assert _collinear_overlap((100, 100), (109, 100), (109, 100), (120, 100)) is False
+
+    def test_disjoint_collinear_no_overlap(self):
+        # Gap [105,110]: collinear but no shared sub-segment.
+        assert _collinear_overlap((100, 100), (105, 100), (110, 100), (115, 100)) is False
+
+    def test_parallel_but_offset_not_collinear(self):
+        # Same X extent, different Y -> not on the same line.
+        assert _collinear_overlap((100, 100), (112, 100), (100, 110), (112, 110)) is False
+
+    def test_vertical_partial_overlap(self):
+        assert _collinear_overlap((50, 100), (50, 109), (50, 103), (50, 112)) is True
+
+
+class TestPointOnSegmentInterior:
+    def test_interior_point(self):
+        assert _point_on_segment_interior((106, 100), (100, 100), (112, 100)) is True
+
+    def test_endpoint_excluded(self):
+        assert _point_on_segment_interior((100, 100), (100, 100), (112, 100)) is False
+        assert _point_on_segment_interior((112, 100), (100, 100), (112, 100)) is False
+
+    def test_off_segment(self):
+        assert _point_on_segment_interior((106, 105), (100, 100), (112, 100)) is False
+
+
+class TestWireSegmentsConnect:
+    def test_collinear_overlap_connects(self):
+        assert wire_segments_connect((100, 100), (109, 100), (103, 100), (112, 100)) is True
+
+    def test_t_touch_connects(self):
+        # B's lower endpoint (106,100) on A's interior.
+        assert wire_segments_connect((100, 100), (112, 100), (106, 100), (106, 90)) is True
+
+    def test_shared_endpoint_not_reported(self):
+        # Endpoint-only touch is handled by endpoint Union-Find, not here.
+        assert wire_segments_connect((100, 100), (106, 100), (106, 100), (112, 100)) is False
+
+    def test_bare_crossing_does_not_connect(self):
+        # Two wires crossing mid-span (neither endpoint on the other) do NOT
+        # connect in KiCad without a junction dot — only endpoint-on-interior
+        # (T-touch) or collinear overlap unions.
+        assert wire_segments_connect((100, 100), (112, 100), (106, 94), (106, 106)) is False
+
+    def test_disjoint_no_connect(self):
+        assert wire_segments_connect((100, 100), (105, 100), (110, 100), (115, 100)) is False


### PR DESCRIPTION
## Summary

kicad-tools' schematic connectivity model unioned wires only at **exact shared endpoints**, while KiCad unions the nets of **any touching or overlapping collinear wire segments**. A generated schematic whose stub-wire+label geometry overlapped mid-segment therefore had a different netlist in kicad-tools than in KiCad — and `extract_netlist()`/`validate()` reported the *wrong* (unmerged) one, silently hiding LVS-grade net shorts (the softstart rev-B `+3.3V`/`GND` short passed 75/75 pin→net checks while the board was shorted).

This fixes items (1) `extract_netlist()` correctness and (2) `validate()` error emission from #4143. Item (3) `add_stub_label()` is deferred to a separate follow-up per the curation scope note.

## Changes

- **New `schematic/models/wire_geometry.py`** — a single, tested geometry primitive `wire_segments_connect()` (plus `_collinear_overlap` / `_point_on_segment_interior`) so both connectivity builders share one tested rule and cannot drift. Handles collinear overlap (partial *and* full containment, relaxing the full-containment-only `_is_collinear_overlap`) and mid-segment T-touch. A bare endpoint touch returns `False` (already handled by endpoint Union-Find); a bare crossing without a junction returns `False` (KiCad semantics). Tolerance = `POINT_TOLERANCE` (0.1mm), consistent with the connectivity graph.
- **`_build_connectivity_graph()`** — added an all-pairs O(n²) wire-vs-wire union alongside the existing endpoint union. Pin-to-wire attachment stays endpoint-only (#4020/#4003) — only wire-to-wire semantics change.
- **`validate_power_nets()`** — same wire-union fix applied to its duplicate connectivity builder (it had the identical gap).
- **`validate()`** — new error-severity `collinear_net_conflict` issue when two wire segments carrying **different** labeled/power net names overlap collinearly or T-touch (distinct from the `missing_junction` warning). Same-net or one-unlabeled overlaps are not flagged.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `extract_netlist()` unions collinear overlap (partial, not just containment) | ✅ | `TestWireToWireCollinearUnion::test_partial_overlap_neither_contains_the_other` |
| `extract_netlist()` unions mid-segment T-touch | ✅ | `test_mid_segment_t_touch` |
| `are_connected()` / `get_net_for_pin()` inherit the fix | ✅ | `test_are_connected_and_get_net_for_pin_reflect_fix` |
| `validate_power_nets()` gets the same fix | ✅ | Shared `wire_segments_connect` union added to its builder |
| `validate()` emits a new **error** on cross-net overlap | ✅ | `TestCollinearNetConflict` (6 cases incl. power-vs-power) |
| Issue's repro sketch captured as a regression test | ✅ | `test_repro_sketch_r1_r2_collinear_stubs` + manual smoke test |
| No regression in `TestPinEndpointOnlyWireAttach` | ✅ | 5/5 pass unchanged |
| No regression in netlist/validate/connectivity/hierarchical suites | ✅ | 367 pass across the schematic subset; 3309 pass on the broad keyword-filtered run |

## Test Plan

- New: `tests/test_wire_geometry.py` (geometry primitive), `TestWireToWireCollinearUnion` in `test_netlist_query.py` (partial/full/T-touch/same-endpoint/parallel/power-vs-power/same-net synthetic softstart classes), `TestCollinearNetConflict` in `test_schematic_models.py` (validate() error cases).
- `uv run pytest tests/test_wire_geometry.py tests/test_netlist_query.py tests/test_schematic_models.py tests/test_validate_netlist.py tests/test_connectivity.py tests/test_hierarchical_netlist.py` → **367 passed**.
- Broad regression `-k "netlist or connectivity or validate or wire or collision or schematic"` → **3309 passed, 27 skipped**.
- `ruff check` + `ruff format` clean on changed files; `scripts/ci/check_mypy_baseline.py` → **0 new mypy errors**.
- Manual API smoke test of the curator's exact repro: two overlapping labeled stubs now merge to one net AND `validate()` emits one `collinear_net_conflict` error (severity `error`).

Softstart is local-only; only synthetic fixtures reproducing the geometric classes are used.

Closes #4143