### PR TITLE
fix(schematic): thread local_symbol_libs through load(); accept ref str in print_symbol_pins

### DIFF
--- a/src/kicad_tools/schematic/models/io_mixin.py
+++ b/src/kicad_tools/schematic/models/io_mixin.py
@@ -39,14 +39,49 @@ class SchematicIOMixin:
         _PWR_SYNTH_LIB_PREFIX: str
         _synthesized_pwr_defs: dict[str, SExp]
 
+        # ``_from_sexp`` constructs the concrete ``Schematic`` via ``cls(...)``.
+        # Declaring the constructor signature here lets mypy validate those
+        # keyword arguments against the real ``Schematic.__init__`` shape
+        # instead of the empty ``object`` init (resolves the spurious
+        # ``call-arg`` errors on the ``cls(...)`` call site).
+        def __init__(
+            self,
+            title: str = "",
+            date: str = "2025-01",
+            revision: str = "A",
+            company: str = "",
+            comment1: str = "",
+            comment2: str = "",
+            paper: str = "A4",
+            project_name: str = "project",
+            sheet_uuid: str | None = None,
+            parent_uuid: str | None = None,
+            page: str = "1",
+            grid: float = ...,
+            snap_mode: object = ...,
+            local_symbol_libs: list[Path] | None = None,
+        ) -> None: ...
+
     @classmethod
-    def load(cls, path: str | Path) -> Schematic:
+    def load(
+        cls,
+        path: str | Path,
+        local_symbol_libs: list[Path] | None = None,
+    ) -> Schematic:
         """Load a schematic from a .kicad_sch file.
 
         This enables round-trip editing: load -> modify -> save.
 
         Args:
             path: Path to the .kicad_sch file
+            local_symbol_libs: Optional list of project-local ``.kicad_sym``
+                files to register on the loaded schematic (mirrors the
+                ``Schematic(...)`` constructor argument).  These are consulted
+                by :meth:`resolve_lib_path` during subsequent ``add_symbol()``
+                calls so a reloaded schematic can resolve ``LIBNAME:SYMNAME``
+                ids against project-local libraries, matching the constructor
+                path.  Default ``None`` preserves prior behavior (stock libs
+                only) for all existing callers.
 
         Returns:
             A Schematic instance populated with all elements from the file
@@ -55,6 +90,12 @@ class SchematicIOMixin:
             sch = Schematic.load("power.kicad_sch")
             sch.add_symbol("Device:R", 100, 100, "R5", "10k")
             sch.write("power.kicad_sch")
+
+            # Reload with a project-local symbol library registered:
+            sch = Schematic.load(
+                "power.kicad_sch",
+                local_symbol_libs=[Path("libs/custom.kicad_sym")],
+            )
         """
         from kicad_tools.sexp import parse_file
 
@@ -63,7 +104,7 @@ class SchematicIOMixin:
             raise FileNotFoundError(f"Schematic file not found: {path}")
 
         doc = parse_file(path)
-        sch = cls._from_sexp(doc)
+        sch = cls._from_sexp(doc, local_symbol_libs=local_symbol_libs)
         # Track the source path so operations that need to walk
         # sub-sheets (e.g., extract_netlist(hierarchical=True), run_erc)
         # can resolve relative sheet references.
@@ -71,10 +112,20 @@ class SchematicIOMixin:
         return sch
 
     @classmethod
-    def _from_sexp(cls, doc: SExp) -> Schematic:
+    def _from_sexp(
+        cls,
+        doc: SExp,
+        local_symbol_libs: list[Path] | None = None,
+    ) -> Schematic:
         """Create a Schematic from a parsed S-expression tree.
 
         This is the internal method that does the actual parsing.
+
+        Args:
+            doc: Parsed S-expression tree for the schematic.
+            local_symbol_libs: Optional project-local ``.kicad_sym`` files to
+                register on the constructed schematic (threaded through from
+                :meth:`load`).  Default ``None`` preserves prior behavior.
         """
         from .schematic import SnapMode
 
@@ -140,6 +191,7 @@ class SchematicIOMixin:
             paper=paper,
             sheet_uuid=sheet_uuid,
             snap_mode=SnapMode.OFF,  # Preserve original coordinates
+            local_symbol_libs=local_symbol_libs,
         )
 
         # Store embedded lib_symbols for round-trip

--- a/src/kicad_tools/schematic/models/wiring_mixin.py
+++ b/src/kicad_tools/schematic/models/wiring_mixin.py
@@ -704,13 +704,34 @@ class SchematicWiringMixin:
 
         return wires
 
-    def print_symbol_pins(self, symbol: SymbolInstance, name: str = None):
-        """Debug helper: Print all pin positions for a symbol."""
-        display_name = name or symbol.reference
-        print(f"\n{display_name} pins at ({symbol.x}, {symbol.y}) rot={symbol.rotation}:")
-        for pin in symbol.symbol_def.pins:
+    def print_symbol_pins(self, symbol: str | SymbolInstance, name: str = None):
+        """Debug helper: Print all pin positions for a symbol.
+
+        Args:
+            symbol: Either a placed :class:`SymbolInstance` or a bare
+                reference designator string (e.g. ``"U1"``).  A string is
+                resolved to its instance via ``find_symbol()``.
+            name: Optional display name override for the printed header;
+                defaults to the symbol's reference designator.
+
+        Raises:
+            KeyError: If ``symbol`` is a string that does not match any
+                placed symbol's reference designator.
+        """
+        if isinstance(symbol, str):
+            # find_symbol is provided by SchematicQueryMixin (sibling in the
+            # Schematic MRO); it is not visible on this mixin in isolation.
+            resolved = self.find_symbol(symbol)  # type: ignore[attr-defined]
+            if resolved is None:
+                raise KeyError(f"No symbol with reference {symbol!r} in schematic")
+            instance = resolved
+        else:
+            instance = symbol
+        display_name = name or instance.reference
+        print(f"\n{display_name} pins at ({instance.x}, {instance.y}) rot={instance.rotation}:")
+        for pin in instance.symbol_def.pins:
             # Use pin.number for unique identification (many symbols have pins all named "~")
-            pos = symbol.pin_position(pin.number)
+            pos = instance.pin_position(pin.number)
             pin_display = pin.name if pin.name and pin.name != "~" else pin.number
             print(f"  {pin_display} ({pin.number}): ({pos[0]:.2f}, {pos[1]:.2f})")
 

--- a/tests/test_schematic_models.py
+++ b/tests/test_schematic_models.py
@@ -1647,6 +1647,126 @@ class TestSchematicLoadAndParse:
         assert sch._pwr_counter == 2
 
 
+_LOCAL_LIB_SEXP = """(kicad_symbol_lib
+	(version 20231120)
+	(generator "kicad_symbol_editor")
+	(generator_version "8.0")
+	(symbol "WIDGET"
+		(property "Reference" "U" (at 0 5.08 0) (effects (font (size 1.27 1.27))))
+		(property "Value" "WIDGET" (at 0 2.54 0) (effects (font (size 1.27 1.27))))
+		(symbol "WIDGET_1_1"
+			(pin input line (at -7.62 2.54 0) (length 2.54) (name "IN" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+			(pin output line (at 7.62 0 180) (length 2.54) (name "OUT" (effects (font (size 1.27 1.27)))) (number "2" (effects (font (size 1.27 1.27)))))
+		)
+	)
+)
+"""
+
+
+def _write_local_lib(tmp_path, stem="custom_widgets"):
+    """Write a synthetic project-local .kicad_sym fixture, return its Path."""
+    lib_path = tmp_path / f"{stem}.kicad_sym"
+    lib_path.write_text(_LOCAL_LIB_SEXP)
+    return lib_path
+
+
+class TestSchematicLoadLocalSymbolLibs:
+    """Regression tests for local_symbol_libs on Schematic.load() (issue #4144)."""
+
+    def test_load_accepts_local_symbol_libs(self, tmp_path):
+        """load() accepts local_symbol_libs and populates the attribute."""
+        lib_path = _write_local_lib(tmp_path)
+
+        # Minimal on-disk schematic to reload.
+        src = Schematic(title="RoundTrip", local_symbol_libs=[lib_path])
+        sch_path = tmp_path / "rt.kicad_sch"
+        src.write(sch_path)
+
+        loaded = Schematic.load(sch_path, local_symbol_libs=[lib_path])
+        assert loaded.local_symbol_libs == [lib_path]
+
+    def test_load_local_lib_resolves_via_resolve_lib_path(self, tmp_path):
+        """A reloaded schematic resolves the local lib stem to its file path."""
+        lib_path = _write_local_lib(tmp_path)
+
+        src = Schematic(title="RoundTrip", local_symbol_libs=[lib_path])
+        sch_path = tmp_path / "rt.kicad_sch"
+        src.write(sch_path)
+
+        loaded = Schematic.load(sch_path, local_symbol_libs=[lib_path])
+        assert loaded.resolve_lib_path("custom_widgets") == lib_path
+
+    def test_round_trip_add_symbol_against_local_lib(self, tmp_path):
+        """Generate with a local lib, write, reload, and re-add from the lib.
+
+        Exercises the full round-trip parity path: the reloaded schematic
+        must resolve ``LIBNAME:SYMNAME`` ids against the registered local lib
+        just like the constructor path does.
+        """
+        lib_path = _write_local_lib(tmp_path)
+
+        src = Schematic(title="RoundTrip", local_symbol_libs=[lib_path])
+        src.add_symbol("custom_widgets:WIDGET", 100, 100, "U1", "WIDGET")
+        sch_path = tmp_path / "rt.kicad_sch"
+        src.write(sch_path)
+
+        loaded = Schematic.load(sch_path, local_symbol_libs=[lib_path])
+        # Reloading resolved the placed U1 symbol from embedded lib_symbols.
+        assert loaded.find_symbol("U1") is not None
+        # And a *new* placement resolves against the registered local lib.
+        u2 = loaded.add_symbol("custom_widgets:WIDGET", 150, 100, "U2", "WIDGET")
+        assert u2.reference == "U2"
+        assert {p.number for p in u2.symbol_def.pins} == {"1", "2"}
+
+    def test_load_without_local_symbol_libs_defaults_empty(self, tmp_path):
+        """load() without local_symbol_libs keeps the default empty list."""
+        src = Schematic(title="Plain")
+        sch_path = tmp_path / "plain.kicad_sch"
+        src.write(sch_path)
+
+        loaded = Schematic.load(sch_path)
+        assert loaded.local_symbol_libs == []
+
+
+class TestPrintSymbolPins:
+    """Tests for print_symbol_pins accepting str or SymbolInstance (issue #4144)."""
+
+    @staticmethod
+    def _schematic_with_widget(tmp_path):
+        lib_path = _write_local_lib(tmp_path)
+        sch = Schematic(title="Pins", local_symbol_libs=[lib_path])
+        sch.add_symbol("custom_widgets:WIDGET", 100, 100, "U1", "WIDGET")
+        return sch
+
+    def test_print_symbol_pins_by_string_ref(self, tmp_path, capsys):
+        """Passing a reference string resolves and prints without raising."""
+        sch = self._schematic_with_widget(tmp_path)
+        sch.print_symbol_pins("U1")
+        out = capsys.readouterr().out
+        assert "U1 pins" in out
+        # Both pins printed.
+        assert "IN" in out
+        assert "OUT" in out
+
+    def test_print_symbol_pins_str_matches_instance(self, tmp_path, capsys):
+        """String-ref output is identical to passing the SymbolInstance."""
+        sch = self._schematic_with_widget(tmp_path)
+
+        sch.print_symbol_pins("U1")
+        by_str = capsys.readouterr().out
+
+        sch.print_symbol_pins(sch.find_symbol("U1"))
+        by_instance = capsys.readouterr().out
+
+        assert by_str == by_instance
+
+    def test_print_symbol_pins_unknown_ref_raises_keyerror(self, tmp_path):
+        """An unknown reference raises a clear KeyError, not AttributeError."""
+        sch = self._schematic_with_widget(tmp_path)
+        with pytest.raises(KeyError, match="DOES_NOT_EXIST"):
+            sch.print_symbol_pins("DOES_NOT_EXIST")
+
+
 class TestSchematicSnapModeAdvanced:
     """Advanced tests for snap modes."""
 


### PR DESCRIPTION
## Summary

Fixes two small schematic-API bugs reported in #4144:

1. **`Schematic.load()` rejected `local_symbol_libs`.** The constructor
   accepts `local_symbol_libs`, but `load()`/`_from_sexp()` never accepted
   or threaded it into the `cls(...)` construction, so passing it raised
   `TypeError`. Any round-trip workflow (generate → write → load → analyze)
   using a project-local `.kicad_sym` library couldn't reload its own output
   with the custom lib registered.

2. **`print_symbol_pins(ref)` crashed on a `str`.** The method dereferenced
   `symbol.reference` assuming a `SymbolInstance`, raising `AttributeError`
   when handed a bare reference designator like `"U1"`.

## Changes

- `io_mixin.py`: `load()` and `_from_sexp()` now accept
  `local_symbol_libs: list[Path] | None = None` and thread it into the
  `cls(...)` construction alongside the existing kwargs. Docstrings updated.
  A `TYPE_CHECKING` `__init__` declaration on `SchematicIOMixin` lets mypy
  validate the `cls(...)` kwargs against the real `Schematic.__init__` shape
  (avoids a spurious `call-arg` error on the new keyword; also clears the
  9 pre-existing baselined `call-arg` false positives on the same call site).
- `wiring_mixin.py`: `print_symbol_pins` now accepts `str | SymbolInstance`.
  String refs are resolved via the existing `find_symbol()` (sibling query
  mixin, already in the MRO); unknown refs raise a clear, catchable
  `KeyError`. Existing `SymbolInstance` callers are unaffected.
- `tests/test_schematic_models.py`: added `TestSchematicLoadLocalSymbolLibs`
  (round-trip with a synthetic project-local `.kicad_sym`, default-`None`
  regression guard) and `TestPrintSymbolPins` (str vs instance parity,
  unknown-ref `KeyError`). All fixtures synthetic/in-repo.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `load(path, local_symbol_libs=[...])` no longer raises, populates attr | ✅ | `test_load_accepts_local_symbol_libs` |
| Round-trip parity: reloaded schematic resolves lib via `resolve_lib_path()` | ✅ | `test_load_local_lib_resolves_via_resolve_lib_path`, `test_round_trip_add_symbol_against_local_lib` |
| `load(path)` (no arg) unchanged, defaults to empty list | ✅ | `test_load_without_local_symbol_libs_defaults_empty` + existing `test_load_from_file` |
| `print_symbol_pins("U1")` == `print_symbol_pins(instance)` output | ✅ | `test_print_symbol_pins_str_matches_instance` |
| `print_symbol_pins(instance)` unaffected | ✅ | Same test compares both paths |
| unknown ref raises clear catchable `KeyError` | ✅ | `test_print_symbol_pins_unknown_ref_raises_keyerror` |
| No other `wiring_mixin.py` signatures changed | ✅ | Only `print_symbol_pins` touched (out-of-scope methods left as `SymbolInstance`-only) |

## Out of scope (deliberately deferred, per curator)

- Threading `parent_uuid` / `grid` through `load()`/`_from_sexp()` — no current
  caller, no crash; needs its own design discussion (load-time inference vs.
  explicit override).
- Broadening `str | SymbolInstance` acceptance to other `wiring_mixin.py`
  methods (`wire_pins`, `wire_pin_to_point`, `wire_ferrite_bead`,
  `wire_oscillator`) — consistent `SymbolInstance`-only convention; cross-cutting.

## Test Plan

- `uv run pytest tests/test_schematic_models.py -k "load or symbol_pins"` → 10 passed
- `uv run pytest tests/test_schematic_models.py tests/test_board_05_drv8301_pin_nets.py` → 230 passed
- `uv run ruff check` + `ruff format --check` on all changed files → clean
- `uv run python scripts/ci/check_mypy_baseline.py` → 0 new errors from the
  changed files (the only "new" line is a pre-existing `cmaes` import-stub
  env artifact present on the base branch too, verified by stashing the diff).

Closes #4144