### PR TITLE
feat(render): accept a direct .kicad_pcb path with -o/--output (#4145)

### DIFF
--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -776,6 +776,7 @@ def _run_render_command(args) -> int:
         path=args.render_path,
         no_3d=getattr(args, "render_no_3d", False),
         format=getattr(args, "render_format", "text"),
+        output=getattr(args, "render_output", None),
     )
     return run_render(render_args)
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -5473,6 +5473,8 @@ def _add_render_parser(subparsers) -> None:
             "via 'kicad-cli pcb render'. Outputs go to a fixed, documented path "
             "(boards/<id>/output/renders/{pcb-front,pcb-back}.svg and "
             "{3d-front,3d-back}.png). "
+            "A bare .kicad_pcb file may also be given: it is rendered directly "
+            "to <pcb-dir>/renders/ (or -o/--output), skipping directory scanning. "
             "The routed PCB is preferred with graceful fallback to the unrouted "
             "PCB. 3D render requires KiCad 8.0.4+ and a display (xvfb on CI)."
         ),
@@ -5480,7 +5482,17 @@ def _add_render_parser(subparsers) -> None:
     render_parser.add_argument(
         "render_path",
         metavar="path",
-        help="Board directory or a root containing board directories",
+        help="Board directory, a root containing board directories, or a .kicad_pcb file",
+    )
+    render_parser.add_argument(
+        "-o",
+        "--output",
+        dest="render_output",
+        default=None,
+        help=(
+            "Output directory for a single .kicad_pcb file "
+            "(default: <pcb-dir>/renders/). Ignored in directory/root scanning mode."
+        ),
     )
     render_parser.add_argument(
         "--no-3d",

--- a/src/kicad_tools/cli/render_cmd.py
+++ b/src/kicad_tools/cli/render_cmd.py
@@ -29,8 +29,16 @@ virtual framebuffer such as ``xvfb-run`` on headless CI).
 Usage:
     kct render boards/01-voltage-divider          # render one board
     kct render boards/                             # render all boards under a root
+    kct render path/to/board.kicad_pcb             # render a single PCB file directly
+    kct render path/to/board.kicad_pcb -o out/dir  # ... to a custom output dir
     kct render boards/01-voltage-divider --no-3d   # skip 3D (headless CI)
     kct render boards/01-voltage-divider --format json
+
+When the positional argument is a ``.kicad_pcb`` file (rather than a board or
+root directory), that PCB is rendered directly and its four artifacts are
+written to ``<pcb-dir>/renders/`` by default, or to the directory given with
+``-o/--output``. Directory/root scanning behavior (and its
+``boards/<id>/output/renders/`` output path) is unchanged.
 """
 
 from __future__ import annotations
@@ -119,42 +127,35 @@ def _discover_boards(root: Path) -> list[Path]:
     return boards
 
 
-def _render_board(
-    board_dir: Path,
+def _render_pcb(
+    pcb_path: Path,
+    renders_dir: Path,
     *,
+    name: str,
     do_3d: bool,
     kicad_cli: Path | None,
     quiet: bool,
 ) -> dict:
-    """Render a single board. Returns a status dict for JSON output.
+    """Write the four render artifacts for *pcb_path* into *renders_dir*.
+
+    Shared by both directory-scanning mode (``_render_board``) and the direct
+    ``.kicad_pcb`` file mode. Returns a status dict for JSON output.
 
     Status entries:
-        board: board directory name
-        pcb: resolved PCB path (or None)
-        status: "ok" | "skipped" | "partial" | "error"
+        board: label used in status output
+        pcb: resolved PCB path
+        status: "ok" | "partial" | "error"
         outputs: {name: path} for files written
         errors: list of error strings
     """
-    name = board_dir.name
     result: dict = {
         "board": name,
-        "pcb": None,
+        "pcb": str(pcb_path),
         "status": "skipped",
         "outputs": {},
         "errors": [],
     }
 
-    output_dir = board_dir / "output"
-    pcb_path = _find_pcb_for_export(output_dir) if output_dir.is_dir() else None
-    if pcb_path is None:
-        # Non-fatal skip — board has no PCB to render yet.
-        result["errors"].append("no .kicad_pcb found")
-        if not quiet:
-            print(f"  {name}: SKIP (no .kicad_pcb found)", file=sys.stderr)
-        return result
-
-    result["pcb"] = str(pcb_path)
-    renders_dir = output_dir / "renders"
     renders_dir.mkdir(parents=True, exist_ok=True)
 
     written: dict[str, str] = {}
@@ -207,6 +208,45 @@ def _render_board(
     return result
 
 
+def _render_board(
+    board_dir: Path,
+    *,
+    do_3d: bool,
+    kicad_cli: Path | None,
+    quiet: bool,
+) -> dict:
+    """Render a single board directory (``boards/<id>/output/`` convention).
+
+    Resolves the PCB inside ``<board_dir>/output/`` and writes artifacts to
+    ``<board_dir>/output/renders/``. Returns a status dict for JSON output.
+    """
+    name = board_dir.name
+
+    output_dir = board_dir / "output"
+    pcb_path = _find_pcb_for_export(output_dir) if output_dir.is_dir() else None
+    if pcb_path is None:
+        # Non-fatal skip — board has no PCB to render yet.
+        result: dict = {
+            "board": name,
+            "pcb": None,
+            "status": "skipped",
+            "outputs": {},
+            "errors": ["no .kicad_pcb found"],
+        }
+        if not quiet:
+            print(f"  {name}: SKIP (no .kicad_pcb found)", file=sys.stderr)
+        return result
+
+    return _render_pcb(
+        pcb_path,
+        output_dir / "renders",
+        name=name,
+        do_3d=do_3d,
+        kicad_cli=kicad_cli,
+        quiet=quiet,
+    )
+
+
 def run_render(args: argparse.Namespace) -> int:
     """Execute the render command. Returns a process exit code."""
     root = Path(args.path)
@@ -236,6 +276,33 @@ def run_render(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             return 1
+
+    output = getattr(args, "output", None)
+
+    # --- Direct .kicad_pcb file mode ---
+    # When the positional arg is a file, render it directly (no board/output
+    # discovery). Output goes to -o/--output if given, else <pcb-dir>/renders/.
+    if root.is_file():
+        if root.suffix != ".kicad_pcb":
+            print(f"Error: Expected .kicad_pcb file, got: {root.name}", file=sys.stderr)
+            print(
+                "Hint: Provide a .kicad_pcb file or a directory containing one.",
+                file=sys.stderr,
+            )
+            return 1
+
+        renders_dir = Path(output) if output else root.parent / "renders"
+        result = _render_pcb(
+            root,
+            renders_dir,
+            name=root.stem,
+            do_3d=do_3d,
+            kicad_cli=kicad_cli,
+            quiet=args.format == "json",
+        )
+        if args.format == "json":
+            print(json.dumps({"boards": [result]}, indent=2))
+        return 1 if result["status"] == "error" else 0
 
     boards = _discover_boards(root)
     if not boards:
@@ -267,7 +334,16 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "path",
-        help="Board directory or a root containing board directories",
+        help="Board directory, a root containing board directories, or a .kicad_pcb file",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default=None,
+        help=(
+            "Output directory for a single .kicad_pcb file "
+            "(default: <pcb-dir>/renders/). Ignored in directory/root scanning mode."
+        ),
     )
     parser.add_argument(
         "--no-3d",

--- a/tests/test_render_cmd.py
+++ b/tests/test_render_cmd.py
@@ -462,6 +462,90 @@ class TestRender3DModelEnv:
 # --------------------------------------------------------------------------
 
 
+# --------------------------------------------------------------------------
+# Direct .kicad_pcb file mode (issue #4145)
+# --------------------------------------------------------------------------
+
+
+class TestFilePathMode:
+    """`kct render path/to/board.kicad_pcb` renders a single PCB directly."""
+
+    def _make_pcb(self, root: Path, name: str = "board.kicad_pcb") -> Path:
+        pcb = root / name
+        pcb.write_text("(kicad_pcb)")
+        return pcb
+
+    def test_bare_file_writes_to_sibling_renders_dir(self, tmp_path, fake_kicad):
+        # A .kicad_pcb not inside any output/ dir renders to <pcb-dir>/renders/.
+        pcb = self._make_pcb(tmp_path)
+        rc = render_main([str(pcb)])
+        assert rc == 0
+
+        renders = tmp_path / "renders"
+        for fname in RENDER_OUTPUTS.values():
+            assert (renders / fname).exists(), f"missing {fname}"
+        assert sorted(p.name for p in renders.iterdir()) == sorted(RENDER_OUTPUTS.values())
+        # The exact PCB file passed was rendered (no discovery).
+        assert {call[0] for call in fake_kicad["svg"]} == {pcb}
+
+    def test_output_flag_overrides_default_dir(self, tmp_path, fake_kicad):
+        pcb = self._make_pcb(tmp_path)
+        custom = tmp_path / "custom" / "dir"
+        rc = render_main([str(pcb), "-o", str(custom)])
+        assert rc == 0
+
+        for fname in RENDER_OUTPUTS.values():
+            assert (custom / fname).exists(), f"missing {fname}"
+        # Nothing landed in the default location.
+        assert not (tmp_path / "renders").exists()
+
+    def test_long_output_flag(self, tmp_path, fake_kicad):
+        pcb = self._make_pcb(tmp_path)
+        custom = tmp_path / "out"
+        rc = render_main([str(pcb), "--output", str(custom)])
+        assert rc == 0
+        assert (custom / "pcb-front.svg").exists()
+
+    def test_wrong_extension_errors(self, tmp_path, fake_kicad, capsys):
+        bad = tmp_path / "board.txt"
+        bad.write_text("not a pcb")
+        rc = render_main([str(bad)])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "Expected .kicad_pcb file" in err
+        assert "board.txt" in err
+
+    def test_nonexistent_file_errors(self, tmp_path, fake_kicad, capsys):
+        rc = render_main([str(tmp_path / "missing.kicad_pcb")])
+        assert rc == 1
+        assert "path not found" in capsys.readouterr().err
+
+    def test_no_3d_writes_only_svgs(self, tmp_path, fake_kicad):
+        pcb = self._make_pcb(tmp_path)
+        rc = render_main([str(pcb), "--no-3d"])
+        assert rc == 0
+
+        renders = tmp_path / "renders"
+        assert (renders / "pcb-front.svg").exists()
+        assert (renders / "pcb-back.svg").exists()
+        assert not (renders / "3d-front.png").exists()
+        assert not (renders / "3d-back.png").exists()
+        assert fake_kicad["render"] == []
+
+    def test_json_uses_pcb_stem_as_board_name(self, tmp_path, fake_kicad, capsys):
+        pcb = self._make_pcb(tmp_path, "softstart_revb.kicad_pcb")
+        rc = render_main([str(pcb), "--format", "json"])
+        assert rc == 0
+
+        payload = json.loads(capsys.readouterr().out)
+        assert "boards" in payload
+        assert len(payload["boards"]) == 1
+        entry = payload["boards"][0]
+        assert entry["board"] == "softstart_revb"
+        assert entry["status"] == "ok"
+        assert set(entry["outputs"]) == set(RENDER_OUTPUTS)
+
+
 class TestEdgeCases:
     def test_board_without_pcb_is_non_fatal(self, tmp_path, fake_kicad, capsys):
         # output/ exists but contains no .kicad_pcb at all.


### PR DESCRIPTION
## Summary

`kct render` previously required the `boards/<id>/output/` directory convention and had no `-o/--output` flag, so pointing it at a bare `.kicad_pcb` (e.g. a consumer repo's `output_revb/softstart_revb.kicad_pcb`) failed with `unrecognized arguments: -o`.

This adds a **direct `.kicad_pcb` file mode**, mirroring the existing `kct export` file-vs-directory pattern:

- When the positional arg is a `.kicad_pcb` file, render it directly (skips `_discover_boards`/directory scanning) and write the four contracted artifacts (`pcb-front.svg`, `pcb-back.svg`, `3d-front.png`, `3d-back.png`) to `<pcb-dir>/renders/` by default.
- `-o/--output` overrides the destination directory (file mode only; ignored in directory/root scanning mode).
- Status/JSON board name = the PCB file **stem**.
- Wrong-extension argument produces a clear `Error: Expected .kicad_pcb file, got: ...` message (mirrors `kct export`), not a stack trace.
- Nonexistent path keeps the existing `path not found` error.

Registered `-o/--output` on both the main render subparser (`parser.py`) and the standalone `render_cmd.main()` parser, and threaded `render_output` through the dispatch `Namespace` (`__init__.py`).

Extracted the shared 2D/3D artifact-writing loop out of `_render_board()` into a new `_render_pcb(pcb_path, renders_dir, *, name, do_3d, kicad_cli, quiet)` helper so directory mode and file mode share a single `RENDER_OUTPUTS` contract.

**Directory/root mode is unchanged** — same discovery logic, same `boards/<id>/output/renders/` output path, same status/JSON shape (regression-covered by the existing test classes, all still passing).

## Test plan

Added `TestFilePathMode` to `tests/test_render_cmd.py` (using the existing `fake_kicad` fixture — no live `kicad-cli`):
- bare file → four artifacts in `<pcb-dir>/renders/`
- `-o` / `--output` override → artifacts in the custom dir, nothing in the default
- wrong extension (`.txt`) → exit 1, clear stderr, no traceback
- nonexistent `.kicad_pcb` → exit 1, `path not found`
- `--no-3d` → only the two SVGs
- `--format json` → valid JSON, board name = PCB stem

Existing `TestDiscoverBoards`, `TestOutputPathContract`, `TestPcbSelection`, `TestJsonOutput`, `TestHelpText` classes unchanged and passing (directory/root regression).

- `uv run pytest tests/test_render_cmd.py -q` → **42 passed**
- `ruff check` + `ruff format --check` on the 4 changed files → clean
- mypy baseline gate → **0 NEW errors** from this change (the single pre-existing `cmaes import-not-found` in `placement/cmaes_strategy.py` is present on `main` too and untouched here)

Closes #4145

🤖 Generated with [Claude Code](https://claude.com/claude-code)