### PR TITLE
feat(ci): add --expect-unrouted mode to check_copper_lvs asserter

### DIFF
--- a/scripts/ci/check_copper_lvs.py
+++ b/scripts/ci/check_copper_lvs.py
@@ -37,6 +37,21 @@ Sibling of ``scripts/ci/check_board_00_e2e.py`` and
 ``::error::`` annotation pattern, deliberately small so the gate's contract
 stays auditable and unit-testable.
 
+Three inverted contracts also exist for boards whose honest verdict is not
+a plain clean pass, each wired into a mutually-exclusive argparse group:
+
+* ``--expect-vacuous`` -- deliberately-unwired fixture schematics (board 06):
+  assert ``clean=false`` with only ``kind='vacuous'`` mismatches (#4005).
+* ``--expect-opens NET[,...]`` -- wired boards that route PARTIAL by design
+  (board 07): assert ``clean=false`` with only ``kind='open'`` mismatches on
+  exactly the named net set (#4012).
+* ``--expect-unrouted`` -- a freshly-created board with a wired schematic but
+  no copper yet (fresh ``kct create-pcb`` output, softstart rev-B): assert
+  ``clean=false`` with zero shorts and zero vacuous mismatches (opens
+  unconstrained in count and net names).  This is the "birth certificate"
+  gate -- "netlist bound, no miswires" -- for a board before any routing
+  exists (#4146).
+
 Exit codes:
     0 -- The copper-LVS result is clean (no shorts / no opens).
     1 -- Tool/usage error (missing arg, file unreadable, JSON parse
@@ -221,6 +236,69 @@ def assert_known_opens(payload: dict[str, Any], expected_nets: set[str]) -> str 
     return None
 
 
+def assert_unrouted(payload: dict[str, Any]) -> str | None:
+    """Assert a copper-LVS payload is the *freshly-unrouted* verdict (#4146).
+
+    Used for a board just created from a wired schematic with no copper yet
+    (fresh ``kct create-pcb`` output, softstart rev-B): the honest
+    expectation is ``clean: false`` with only ``kind="open"`` mismatches and
+    a positive bound-pad count — the netlist is bound, but no routing exists,
+    so every net is open and there are no miswires.  This is the "birth
+    certificate" gate; opens are unconstrained in count and net names (that
+    is the whole point versus ``--expect-opens``, which would require
+    enumerating every net of an unrouted board).
+
+    The gate fails BOTH ways:
+
+    * ``clean: true`` — a freshly-unrouted board should never self-report
+      clean (that only happens with zero schematic nets, which is
+      degenerate); switch to the plain ``clean`` assertion once routing lands.
+    * the vacuity verdict (``kind="vacuous"``) — vacuity means the *schematic*
+      binds zero pins (an unwired fixture, board 06), which is a categorically
+      different — and still-bad — state.  Passing it here would silently
+      defeat the #4006/#4019 vacuity guard for any consumer who reaches for
+      "unrouted mode" as a generic permissive gate, so it MUST keep failing.
+    * any ``kind="short"`` mismatch — the one hard invariant this mode exists
+      to enforce: a fresh unrouted board has no copper, so it cannot have a
+      copper short; if one appears the schematic/board disagree on connectivity.
+
+    Returns:
+        ``None`` on pass (unrouted verdict as expected).  A human-readable
+        error message otherwise (caller maps to exit 2).
+
+    Raises:
+        KeyError: If ``clean`` is absent (caller maps to exit 1).
+    """
+    clean = payload["clean"]
+    mismatches = payload.get("mismatches", [])
+    if not isinstance(mismatches, list):
+        mismatches = []
+    kinds = sorted({m.get("kind") for m in mismatches if isinstance(m, dict)})
+    if clean:
+        return (
+            "expected an UNROUTED copper-LVS verdict (clean=false with opens "
+            "only) but got clean=true -- a freshly-unrouted board should not "
+            "self-report clean; graduate this CI gate to a plain clean "
+            "assertion now that the board appears routed"
+        )
+    if "vacuous" in kinds:
+        return (
+            "expected an UNROUTED copper-LVS verdict but got the vacuity-guard "
+            "verdict (kind='vacuous') -- the schematic binds zero pins, so the "
+            "board is not merely unrouted, it is UNWIRED; switch to "
+            "--expect-vacuous if this fixture is intentionally unwired, or fix "
+            "the schematic binding"
+        )
+    if "short" in kinds:
+        return (
+            "expected an UNROUTED copper-LVS verdict (zero shorts) but got "
+            f"{_summarize_mismatches(mismatches)} -- a copper short on an "
+            "unrouted board means the schematic and board disagree on "
+            "connectivity; this is a hard regression regardless of the opens"
+        )
+    return None
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="check_copper_lvs.py",
@@ -262,6 +340,19 @@ def main(argv: list[str] | None = None) -> int:
             "verdict, and on any open outside the set."
         ),
     )
+    mode_group.add_argument(
+        "--expect-unrouted",
+        action="store_true",
+        help=(
+            "Birth-certificate contract for a board just created from a wired "
+            "schematic with no copper yet (fresh 'kct create-pcb' output, "
+            "#4146): assert clean=false with zero shorts and zero vacuous "
+            "mismatches (opens unconstrained in count and net names).  Fails "
+            "on clean=true (board appears routed; graduate the gate), on any "
+            "short (schematic/board disagree on connectivity), and on the "
+            "vacuous verdict (schematic is unwired, not merely unrouted)."
+        ),
+    )
     args = parser.parse_args(argv)
 
     raw_path = args.result_json
@@ -300,6 +391,8 @@ def main(argv: list[str] | None = None) -> int:
     try:
         if args.expect_vacuous:
             dirty_msg = assert_vacuous(payload)
+        elif args.expect_unrouted:
+            dirty_msg = assert_unrouted(payload)
         elif expected_open_nets:
             dirty_msg = assert_known_opens(payload, expected_open_nets)
         else:
@@ -322,6 +415,11 @@ def main(argv: list[str] | None = None) -> int:
         print(
             "[ok] copper-LVS vacuity guard fired as expected "
             "(clean=false, kind='vacuous'; unwired fixture schematic)"
+        )
+    elif args.expect_unrouted:
+        print(
+            "[ok] copper-LVS reports a freshly-unrouted board "
+            "(clean=false, opens only, zero shorts; netlist bound, no miswires)"
         )
     elif expected_open_nets:
         print(

--- a/tests/test_ci_check_copper_lvs.py
+++ b/tests/test_ci_check_copper_lvs.py
@@ -396,3 +396,107 @@ def test_expect_opens_mutually_exclusive_with_expect_vacuous(tmp_path: Path) -> 
     p = _write_json(tmp_path, _opens_payload(["DQ3"]))
     with pytest.raises(SystemExit):
         check_copper_lvs.main(["--expect-vacuous", "--expect-opens", "DQ3", str(p)])
+
+
+# --- --expect-unrouted mode (#4146) -----------------------------------------
+#
+# Birth-certificate contract for a board just created from a wired schematic
+# with no copper yet (fresh ``kct create-pcb`` output, softstart rev-B).  The
+# honest verdict is clean=false with opens only (any count, any nets) and a
+# positive bound-pad count -- "netlist bound, no miswires".  The gate passes
+# on opens-only and fails on clean=true (board appears routed), any short
+# (schematic/board disagree), and the vacuous verdict (schematic is unwired,
+# not merely unrouted -- the #4006 vacuity guard must NOT be defeated here).
+
+
+def test_expect_unrouted_passes_on_opens_only(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # A freshly-created board: many opens, positive bound_pad_count, no shorts.
+    p = _write_json(tmp_path, _opens_payload(["NET1", "NET2", "NET3", "NET4"]))
+    assert check_copper_lvs.main(["--expect-unrouted", str(p)]) == 0
+    assert "freshly-unrouted board" in capsys.readouterr().out
+
+
+def test_expect_unrouted_passes_with_zero_mismatches_but_clean_false(tmp_path: Path) -> None:
+    # Edge case: clean=false with an empty mismatches list. Zero shorts is
+    # trivially satisfied, so --expect-unrouted still PASSES (mirrors the
+    # ambiguity noted in the test plan).
+    p = _write_json(tmp_path, {"clean": False, "bound_pad_count": 12, "mismatches": []})
+    assert check_copper_lvs.main(["--expect-unrouted", str(p)]) == 0
+
+
+def test_expect_unrouted_fails_on_clean_true(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # A freshly-unrouted board should never self-report clean; the gate must
+    # point the caller at the plain clean assertion.
+    p = _write_json(tmp_path, {"clean": True, "mismatches": []})
+    assert check_copper_lvs.main(["--expect-unrouted", str(p)]) == 2
+    out = capsys.readouterr().out
+    assert "::error" in out
+    assert "graduate" in out
+
+
+def test_expect_unrouted_fails_on_single_short(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # One short mixed with opens is still a hard regression.
+    p = _write_json(
+        tmp_path,
+        _opens_payload(
+            ["NET1", "NET2"],
+            extra=[{"kind": "short", "net_a": "A", "net_b": "B", "pad_a": "U1.1", "pad_b": "U1.2"}],
+        ),
+    )
+    assert check_copper_lvs.main(["--expect-unrouted", str(p)]) == 2
+    out = capsys.readouterr().out
+    assert "::error" in out
+    assert "1 short" in out
+
+
+def test_expect_unrouted_fails_on_vacuous_verdict(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Vacuity means the schematic binds zero pins -- unwired, not merely
+    # unrouted. --expect-unrouted must keep failing (guards #4006/#4019) and
+    # point at --expect-vacuous as the correct mode.
+    p = _write_json(tmp_path, _VACUOUS_PAYLOAD)
+    assert check_copper_lvs.main(["--expect-unrouted", str(p)]) == 2
+    out = capsys.readouterr().out
+    assert "::error" in out
+    assert "UNWIRED" in out
+    assert "--expect-vacuous" in out
+
+
+def test_expect_unrouted_fails_on_mixed_vacuous_and_open(tmp_path: Path) -> None:
+    # Vacuous mixed with real opens is still the unwired-schematic verdict;
+    # trip regardless of the opens.
+    p = _write_json(
+        tmp_path,
+        {
+            "clean": False,
+            "mismatches": [
+                {"kind": "vacuous", "net_a": "x", "net_b": "x", "pad_a": "a", "pad_b": "b"},
+                {"kind": "open", "net_a": "N", "net_b": "N", "pad_a": "R1.1", "pad_b": "R2.1"},
+            ],
+        },
+    )
+    assert check_copper_lvs.main(["--expect-unrouted", str(p)]) == 2
+
+
+def test_expect_unrouted_missing_clean_key_exits_1(tmp_path: Path) -> None:
+    p = _write_json(tmp_path, {"mismatches": []})
+    assert check_copper_lvs.main(["--expect-unrouted", str(p)]) == 1
+
+
+def test_expect_unrouted_mutually_exclusive_with_expect_vacuous(tmp_path: Path) -> None:
+    p = _write_json(tmp_path, _opens_payload(["NET1"]))
+    with pytest.raises(SystemExit):
+        check_copper_lvs.main(["--expect-unrouted", "--expect-vacuous", str(p)])
+
+
+def test_expect_unrouted_mutually_exclusive_with_expect_opens(tmp_path: Path) -> None:
+    p = _write_json(tmp_path, _opens_payload(["NET1"]))
+    with pytest.raises(SystemExit):
+        check_copper_lvs.main(["--expect-unrouted", "--expect-opens", "NET1", str(p)])


### PR DESCRIPTION
## Summary

Adds a third inverted-contract mode, `--expect-unrouted`, to the independent copper-LVS re-check asserter (`scripts/ci/check_copper_lvs.py`). It gives a board just created from a wired schematic with no copper yet (fresh `kct create-pcb` output, softstart rev-B, #4146) a meaningful passing gate: "netlist bound, no miswires". Neither existing mode fit — the board is not vacuous (pins are bound), and `--expect-opens` would require enumerating every net of a fully-unrouted board.

No `ci.yml` changes: none of the three current invocation sites (board 03/06/07, all routed) fit the new mode; workflow adoption is out of scope per the issue.

## Changes

- New `assert_unrouted(payload)` verdict function following the Args/Returns/Raises docstring convention of its siblings.
  - PASS iff `clean == false`, zero `short`-kind mismatches, zero `vacuous`-kind mismatches (opens unconstrained in count and net names).
  - FAIL on `clean == true` (points to the plain clean assertion; mirrors "graduate" wording).
  - FAIL on any `short` (reports the count via `_summarize_mismatches()`).
  - FAIL on the vacuous verdict — distinguishes "unwired schematic" from "unrouted board" and points at `--expect-vacuous`; deliberately preserves the #4006/#4019 vacuity guard.
  - `KeyError` on missing `clean` propagates to `main()`'s existing exit-1 handling.
- New `--expect-unrouted` flag added to the existing mutually-exclusive `mode_group` (argparse rejects combinations automatically).
- `main()` dispatch and success-message branches extended for the new mode.
- Module docstring updated to document all three inverted modes.
- 10 new unit tests mirroring the `--expect-vacuous`/`--expect-opens` sections.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `--expect-unrouted` in the mutually-exclusive mode group | ✅ | Added to `mode_group`; mutual-exclusivity tests raise `SystemExit` |
| `assert_unrouted()` with Args/Returns/Raises docstring | ✅ | New function mirrors sibling convention |
| PASS iff clean=false, 0 shorts, 0 vacuous (opens unconstrained) | ✅ | `test_expect_unrouted_passes_on_opens_only`, `..._with_zero_mismatches_but_clean_false` |
| FAIL on clean=true (points to clean mode) | ✅ | `test_expect_unrouted_fails_on_clean_true` asserts "graduate" |
| FAIL on any short via `_summarize_mismatches()` | ✅ | `test_expect_unrouted_fails_on_single_short` asserts "1 short" |
| FAIL on vacuous (distinct message, points to --expect-vacuous) | ✅ | `test_expect_unrouted_fails_on_vacuous_verdict` asserts "UNWIRED" + "--expect-vacuous" |
| KeyError on missing clean -> exit 1 | ✅ | `test_expect_unrouted_missing_clean_key_exits_1` |
| main() dispatch + success-message wired | ✅ | Both branches added |
| Mutual exclusivity raises SystemExit | ✅ | Two tests, vs `--expect-vacuous` and `--expect-opens` |
| Module docstring updated | ✅ | Three-mode summary added |
| No ci.yml changes | ✅ | `git diff` touches only the script + its test |

## Test Plan

- `uv run pytest tests/test_ci_check_copper_lvs.py -q` — 39 passed (10 new).
- `uv run ruff check` + `ruff format --check` on both changed files — clean.
- `uv run --extra dev python scripts/ci/check_mypy_baseline.py` — 0 new errors (all within baseline).

Closes #4146