### PR TITLE
test(board-05): raise DRC subprocess pytest-timeout to 180s to absorb CI contention

### DIFF
--- a/tests/test_board_05_drc_allowlist.py
+++ b/tests/test_board_05_drc_allowlist.py
@@ -52,6 +52,16 @@ import yaml
 
 from kicad_tools.validate.checker import DRCChecker
 
+# Issue #4160: CI runs the suite with `-n auto --timeout=60`. This DRC
+# subprocess test averages ~19s unloaded but comfortably exceeds 60s under
+# full-suite xdist CPU contention (concurrent routing-regression jobs share
+# the runner pool). The timeout marker overrides the CLI default with a
+# contention-tolerant budget; it does NOT slow the happy path. 180 stays
+# above the inner `subprocess.run(..., timeout=120)` cap so a genuinely
+# hung `kct check` still trips `TimeoutExpired` first (a clear tool-level
+# signal) rather than the bare outer pytest-timeout reaper.
+pytestmark = pytest.mark.timeout(180)
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BOARD_DIR = REPO_ROOT / "boards" / "05-bldc-motor-controller"
 ROUTED_PCB = BOARD_DIR / "output" / "bldc_controller_routed.kicad_pcb"

--- a/tests/test_board_05_drc_hotspot_regression.py
+++ b/tests/test_board_05_drc_hotspot_regression.py
@@ -80,6 +80,16 @@ from pathlib import Path
 
 import pytest
 
+# Issue #4160: CI runs the suite with `-n auto --timeout=60`. These DRC
+# subprocess tests average ~19s unloaded but comfortably exceed 60s under
+# full-suite xdist CPU contention (concurrent routing-regression jobs share
+# the runner pool). The timeout marker overrides the CLI default with a
+# contention-tolerant budget; it does NOT slow the happy path. 180 stays
+# above the inner `subprocess.run(..., timeout=120)` cap so a genuinely
+# hung `kct check` still trips `TimeoutExpired` first (a clear tool-level
+# signal) rather than the bare outer pytest-timeout reaper.
+pytestmark = pytest.mark.timeout(180)
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BOARD_DIR = REPO_ROOT / "boards" / "05-bldc-motor-controller"
 ROUTED_PCB = BOARD_DIR / "output" / "bldc_controller_routed.kicad_pcb"


### PR DESCRIPTION
## Summary

The board-05 DRC subprocess tests intermittently fail CI with a bare `Timeout (>60.0s)` (never an assertion) when the `Test` job shares the runner pool with the concurrent routing-regression matrix. These tests spawn `kct check --mfr jlcpcb-tier1` on the fully-routed board-05 PCB and average ~19-44s unloaded, so the default `-n auto --timeout=60` cap has too little headroom to survive CPU contention. 4 of the last 5 PRs hit this flake (#4157, #4163, #4164).

This mirrors the already-established fix in `tests/test_drc_regression.py` (#3436) for the identical failure mode: a module-level `pytest.mark.timeout` override that gives a contention-tolerant budget without slowing the happy path or moving the tests out of the PR-gating lane.

## Changes

- `tests/test_board_05_drc_hotspot_regression.py`: add `pytestmark = pytest.mark.timeout(180)` after the imports, with a comment explaining the contention rationale and the inner-vs-outer timeout interplay.
- `tests/test_board_05_drc_allowlist.py`: same.

180s stays above each test's inner `subprocess.run(..., timeout=120)` cap, so a genuinely hung `kct check` still trips `TimeoutExpired` first (a clear tool-level signal) rather than the bare outer pytest-timeout reaper.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Both files carry `pytestmark = pytest.mark.timeout(180)` | Yes | `git diff` shows the marker added to both files |
| Neither file gains `@pytest.mark.slow` | Yes | No `slow` marker added; tests stay in the `-n auto -m "not slow"` `Test` job |
| Both files pass locally (6/6) | Yes | `6 passed in 148.40s`; slowest test 44.20s, well under 180s |
| Effective per-test timeout is 180s, not the CLI 60s | Yes | `pytest_timeout._get_item_settings(item).timeout` resolves to `180.0` for all 6 tests under `--timeout=60`; control file `test_drc_regression.py` resolves to `300.0` |
| No other module's effective timeout changes | Yes | Marker is file-scoped to these two files; no `conftest.py` or `ci.yml --timeout` change |
| `.github/workflows/ci.yml` `Test` step unchanged | Yes | Only the two test files are in the diff (`git diff --stat`: 2 files, +20) |

## Test Plan

- Built the C++ router backend (`kct build-native`) so DRC subprocesses run at full speed.
- `uv run pytest tests/test_board_05_drc_hotspot_regression.py tests/test_board_05_drc_allowlist.py -o addopts= --durations=0 -q` -> `6 passed in 148.40s`, per-test durations 21-44s.
- Verified marker precedence: probed `pytest_timeout._get_item_settings(item).timeout` under `--timeout=60`; all 6 target tests resolve to `180.0` (the marker overrides the CLI default rather than being shadowed).
- `ruff check` + `ruff format --check` clean on both changed files.

Closes #4160