### PR TITLE
feat(route): add --region spatial routing bound (Phase 2a of #4136)

### DIFF
--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -106,6 +106,9 @@ def run_route_auto_command(args) -> int:
             strategy=args.strategy,
             enable_repair=not args.no_repair,
             enable_via_resolution=not args.no_via_resolution,
+            # Issue #4148: spatial routing bound.  Confines the routed net to the
+            # board-relative box and fails if the net has an endpoint outside it.
+            region=getattr(args, "region", None),
         )
     except FileNotFoundError as e:
         print(f"Error: {e}", file=sys.stderr)
@@ -383,6 +386,11 @@ def run_route_command(args) -> int:
     # tuning flags to the inner parser.  All four flags are opt-in and only
     # forwarded when set to non-default values, so existing scripts using
     # ``kct route`` without these flags produce byte-identical output.
+    # Issue #4148: forward --region (SPATIAL routing bound).  Distinct from
+    # --region-parallel above.  Default None; only forward when the user set
+    # it so byte-identical output is preserved when absent.
+    if getattr(args, "region", None) is not None:
+        sub_argv.extend(["--region", str(args.region)])
     if getattr(args, "region_parallel", False):
         sub_argv.append("--region-parallel")
     if getattr(args, "partition_rows", 2) != 2:

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2737,6 +2737,25 @@ def _add_route_parser(subparsers) -> None:
         ),
     )
     route_parser.add_argument(
+        "--region",
+        metavar="X1,Y1,X2,Y2",
+        help=(
+            "SPATIAL routing bound (Issue #4148): confine all new routing to "
+            "the axis-aligned box 'x1,y1,x2,y2' (board-relative mm, same "
+            "convention as 'pcb strip --region'). Every cell outside the box "
+            "is treated as a fixed obstacle, and existing copper outside is "
+            "preserved unchanged (implies --preserve-existing semantics). "
+            "Composable with --nets/--skip-nets. NOTE: unrelated to "
+            "--region-parallel (which partitions the grid for PARALLEL "
+            "routing); --region is a spatial bound, not a parallelism knob. "
+            "Nets whose pads all lie inside the box route normally; a net "
+            "with an endpoint outside fails with a clear per-net message. "
+            "Reconnecting to bare mid-trace stubs left by 'pcb strip --region' "
+            "is NOT supported here (deferred to a Phase 2b follow-up); stubs "
+            "that coincide with a pad/via still work."
+        ),
+    )
+    route_parser.add_argument(
         "--grid",
         type=str,
         default="auto",
@@ -3556,6 +3575,19 @@ def _add_route_auto_parser(subparsers) -> None:
         required=True,
         metavar="NAME",
         help="Net to route (e.g., 'GND', 'SPI_CLK')",
+    )
+    route_auto_parser.add_argument(
+        "--region",
+        metavar="X1,Y1,X2,Y2",
+        help=(
+            "SPATIAL routing bound (Issue #4148): confine routing of --net to "
+            "the axis-aligned box 'x1,y1,x2,y2' (board-relative mm, same "
+            "convention as 'pcb strip --region' and 'route --region'). Every "
+            "cell outside the box is a fixed obstacle and existing copper "
+            "outside is preserved unchanged. If --net has an endpoint outside "
+            "the box the route fails with a clear message. Bare mid-trace "
+            "stub reconnection is deferred to a Phase 2b follow-up."
+        ),
     )
     route_auto_parser.add_argument(
         "--strategy",

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -3593,6 +3593,9 @@ def route_with_layer_escalation(
                     # copper is loaded as grid obstacles + populated into
                     # router.existing_routes so it survives the route pass.
                     load_existing_routes=getattr(args, "preserve_existing", False),
+                    # Issue #4148: region-bounded routing.  When set, cells
+                    # outside the board-relative box are marked as obstacles.
+                    region=getattr(args, "_region_box", None),
                     # Issue #3877: thread the C++ iteration backstop through the
                     # layer-escalation sub-router too.  Without this the
                     # escalation-mode Autorouter (board-01/03 et al.) routes with
@@ -4510,6 +4513,8 @@ def route_with_rule_relaxation(
                     strict_drc=False,
                     # Issue #3155: incremental routing (see route_with_layer_escalation).
                     load_existing_routes=getattr(args, "preserve_existing", False),
+                    # Issue #4148: region-bounded routing (see main()).
+                    region=getattr(args, "_region_box", None),
                 )
         except Exception as e:
             if not quiet:
@@ -6613,6 +6618,8 @@ def route_with_combined_escalation(
                         strict_drc=False,
                         # Issue #3155: incremental routing (see route_with_layer_escalation).
                         load_existing_routes=getattr(args, "preserve_existing", False),
+                        # Issue #4148: region-bounded routing (see main()).
+                        region=getattr(args, "_region_box", None),
                     )
             except Exception as e:
                 if not quiet:
@@ -7184,6 +7191,183 @@ def _should_use_escape_routing(router, escape_flag: bool | None, quiet: bool) ->
             print(f"  Escape routing: auto-enabled (dense packages: {refs})")
         return True
     return False
+
+
+def _parse_region_box(
+    region_arg: str,
+) -> tuple[float, float, float, float] | str:
+    """Parse a ``--region`` string into a normalized board-relative box.
+
+    Issue #4148.  Mirrors the ``pcb strip --region`` CLI validation
+    (``cli/commands/pcb.py``) so both commands accept exactly the same
+    ``x1,y1,x2,y2`` strings and reject the same degenerate inputs.
+
+    Returns the normalized ``(x1, y1, x2, y2)`` tuple (x1<x2, y1<y2) on
+    success, or a human-readable error string on failure.
+    """
+    parts = [p.strip() for p in region_arg.split(",")]
+    if len(parts) != 4:
+        return f"--region expects 'x1,y1,x2,y2' (four comma-separated numbers), got {region_arg!r}"
+    try:
+        x1, y1, x2, y2 = (float(p) for p in parts)
+    except ValueError:
+        return f"--region values must be numeric, got {region_arg!r}"
+    if x1 >= x2 or y1 >= y2:
+        return f"--region must satisfy x1 < x2 and y1 < y2 (got x1={x1}, y1={y1}, x2={x2}, y2={y2})"
+    return (x1, y1, x2, y2)
+
+
+def _parse_and_apply_region(args, pcb_path: Path, region_arg: str) -> int:
+    """Validate --region, stamp ``args._region_box``, and gate unreachable nets.
+
+    Issue #4148 (region-bounded routing, Phase 2a).  On success returns 0 and
+    sets ``args._region_box`` to the normalized board-relative box (plus forces
+    ``args.preserve_existing = True`` so outside copper is preserved).  On any
+    validation / reachability failure prints a clear message to stderr and
+    returns a non-zero exit code so no routing budget is spent.
+
+    Reachability rule: a net can only be routed inside the region when ALL of
+    its pads lie within the box.  A net with a pad outside the region needs
+    outside access we cannot provide in Phase 2a (bare-stub reconnection is
+    deferred to Phase 2b), so it is reported per-net and the run fails fast.
+    Pads / vias that coincide with the boundary work "for free" (inclusive
+    box test).
+    """
+    parsed = _parse_region_box(region_arg)
+    if isinstance(parsed, str):
+        print(f"Error: {parsed}", file=sys.stderr)
+        return 1
+
+    x1, y1, x2, y2 = parsed
+    args._region_box = (x1, y1, x2, y2)
+    # Region mode implies preserve-existing so copper outside the box is loaded
+    # as fixed obstacles and re-emitted unchanged.
+    args.preserve_existing = True
+    # Region mode implies --no-cache: the routing cache key
+    # (``CacheKey.compute(pcb_content, rules, grid)``) does not incorporate the
+    # region box or the derived skip-net set, so a full-board cached result
+    # from a prior non-region run would otherwise be (incorrectly) reused and
+    # re-route nets that must stay outside the region.  A region route is a
+    # distinct operation; skip the cache entirely.
+    args.no_cache = True
+
+    quiet = getattr(args, "quiet", False)
+
+    # Load the board (board-relative pad frame) to check bounds + reachability.
+    try:
+        from kicad_tools.schema.pcb import PCB as _SchemaPCB
+
+        pcb = _SchemaPCB.load(str(pcb_path))
+    except Exception as e:  # pragma: no cover - load errors surface later too
+        print(f"Error loading PCB for --region validation: {e}", file=sys.stderr)
+        return 1
+
+    # A region entirely outside the board's outline is a documented no-op:
+    # there is nothing to route inside it.  Report clearly rather than spend a
+    # routing budget that can only fail.
+    outline = pcb.get_board_outline()
+    if outline:
+        bx1 = min(p[0] for p in outline)
+        by1 = min(p[1] for p in outline)
+        bx2 = max(p[0] for p in outline)
+        by2 = max(p[1] for p in outline)
+        if x2 <= bx1 or x1 >= bx2 or y2 <= by1 or y1 >= by2:
+            print(
+                "Error: --region "
+                f"({x1}, {y1})-({x2}, {y2}) is entirely outside the board "
+                f"bounds ({bx1:.3f}, {by1:.3f})-({bx2:.3f}, {by2:.3f}); "
+                "nothing to route.",
+                file=sys.stderr,
+            )
+            return 1
+
+    # Nets the user explicitly skipped are not candidates for reachability.
+    skip = set()
+    if getattr(args, "skip_nets", None):
+        skip = {n.strip() for n in args.skip_nets.split(",")}
+
+    # Collect board-relative pad positions per net.
+    net_pads: dict[str, list[tuple[float, float]]] = {}
+    for fp in pcb.footprints:
+        ref = fp.reference
+        for pad in fp.pads:
+            net_name = getattr(pad, "net_name", "") or ""
+            if not net_name or net_name in skip:
+                continue
+            pos = pcb.get_pad_position(ref, pad.number)
+            if pos is None:
+                continue
+            net_pads.setdefault(net_name, []).append(pos)
+
+    def _inside(px: float, py: float) -> bool:
+        return x1 <= px <= x2 and y1 <= py <= y2
+
+    # A net is routable in-region only if it has >= 2 pads AND every pad is
+    # inside the box.  Single-pad nets have nothing to route.  Nets with zero
+    # in-region pads are simply not this region's concern (ignored).  Nets
+    # with SOME pads inside and SOME outside need outside access -> fail.
+    unreachable: list[str] = []
+    routable_nets: list[str] = []
+    skip_outside: list[str] = []
+    for net_name, positions in net_pads.items():
+        inside = [p for p in positions if _inside(p[0], p[1])]
+        if not inside:
+            # Net lives entirely outside this region -- do NOT route it (its
+            # pads sit in region-blocked cells).  Skip it so its existing
+            # copper is preserved untouched rather than re-routed.
+            skip_outside.append(net_name)
+            continue
+        if len(inside) != len(positions):
+            unreachable.append(net_name)
+        elif len(positions) >= 2:
+            routable_nets.append(net_name)
+        else:
+            # Single in-region pad -- nothing to route; skip so it is left as-is.
+            skip_outside.append(net_name)
+
+    routable_in_region = len(routable_nets)
+
+    if unreachable:
+        preview = ", ".join(sorted(unreachable)[:10])
+        more = "" if len(unreachable) <= 10 else f" (+{len(unreachable) - 10} more)"
+        print(
+            "Error: --region cannot route the following net(s) because they "
+            "have pad(s) outside the region and Phase 2a does not reconnect to "
+            f"bare boundary stubs (deferred to Phase 2b): {preview}{more}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if routable_in_region == 0:
+        print(
+            "Error: --region "
+            f"({x1}, {y1})-({x2}, {y2}) contains no routable multi-pad net; "
+            "nothing to route inside the region.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Auto-skip every net that has no routable work inside the region (fully
+    # outside, or a single in-region pad).  Their pads sit in region-blocked
+    # cells, so routing them would fail; skipping keeps their existing copper
+    # untouched (region mode implies --preserve-existing).  Merge with any
+    # user-supplied --skip-nets.
+    if skip_outside:
+        existing = (
+            [n.strip() for n in args.skip_nets.split(",") if n.strip()]
+            if getattr(args, "skip_nets", None)
+            else []
+        )
+        merged = existing + [n for n in skip_outside if n not in existing]
+        args.skip_nets = ",".join(merged)
+
+    if not quiet:
+        print(
+            f"[region] Confining routing to board-relative box "
+            f"({x1}, {y1})-({x2}, {y2}); {routable_in_region} net(s) routable "
+            "inside (implies --preserve-existing)."
+        )
+    return 0
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -8322,6 +8506,25 @@ def main(argv: list[str] | None = None) -> int:
         metavar="N",
         help=("Maximum parallel workers per region group for --region-parallel (default: 4)."),
     )
+    # Issue #4148: region-bounded routing.  SPATIAL routing bound -- confine all
+    # new routing to an axis-aligned box.  Deliberately distinct from
+    # --region-parallel (above), which is a parallelism-partitioning knob, NOT
+    # a spatial bound.  argparse resolves the exact string ``--region`` to THIS
+    # flag even though it is a prefix of ``--region-parallel`` (exact matches
+    # take priority over abbreviation), so there is no ambiguity for the exact
+    # spelling; only a shorter abbreviation like ``--regio`` is ambiguous.
+    parser.add_argument(
+        "--region",
+        metavar="X1,Y1,X2,Y2",
+        default=None,
+        help=(
+            "SPATIAL routing bound (Issue #4148): confine all new routing to "
+            "the axis-aligned box 'x1,y1,x2,y2' (board-relative mm, same "
+            "convention as 'pcb strip --region'). Cells outside the box are "
+            "fixed obstacles; existing copper outside is preserved unchanged "
+            "(implies --preserve-existing). Unrelated to --region-parallel."
+        ),
+    )
 
     # Power plane stitching
     parser.add_argument(
@@ -8495,6 +8698,20 @@ def main(argv: list[str] | None = None) -> int:
 
     if pcb_path.suffix != ".kicad_pcb":
         print(f"Warning: Expected .kicad_pcb file, got {pcb_path.suffix}")
+
+    # Issue #4148: parse + validate --region (SPATIAL routing bound).  Stores a
+    # normalized board-relative box on ``args._region_box`` that the
+    # ``load_pcb_for_routing`` call sites forward.  Region mode implies
+    # --preserve-existing so copper outside the box is loaded as fixed
+    # obstacles and re-emitted unchanged.  Degenerate / non-numeric boxes are
+    # rejected here (mirroring the ``pcb strip --region`` CLI validation) so
+    # no routing budget is spent on an invalid request.
+    args._region_box = None
+    _region_arg = getattr(args, "region", None)
+    if _region_arg:
+        rc = _parse_and_apply_region(args, pcb_path, _region_arg)
+        if rc != 0:
+            return rc
 
     # Issue #3154: advisory schematic/PCB drift banner.  Non-blocking -- the
     # hard gate lives behind 'kct check --netlist-sync'.  Skips silently when
@@ -9055,6 +9272,8 @@ def main(argv: list[str] | None = None) -> int:
                 strict_drc=False,  # Only fail on hard constraint (grid > clearance)
                 # Issue #3155: incremental routing (see route_with_layer_escalation).
                 load_existing_routes=getattr(args, "preserve_existing", False),
+                # Issue #4148: region-bounded routing (see main()).
+                region=getattr(args, "_region_box", None),
                 # Issue #2610: thread --max-search-iterations through.
                 # The inner parser declares this flag with default=0 (Issue
                 # #2819), so the attribute is guaranteed to exist; the
@@ -9107,6 +9326,8 @@ def main(argv: list[str] | None = None) -> int:
                 validate_drc=not args.force,
                 strict_drc=False,
                 load_existing_routes=getattr(args, "preserve_existing", False),
+                # Issue #4148: region-bounded routing (see main()).
+                region=getattr(args, "_region_box", None),
                 max_search_iterations=args.max_search_iterations or 0,
                 per_net_iterations=getattr(args, "per_net_iterations", 0) or 0,
             )

--- a/src/kicad_tools/mcp/tools/routing.py
+++ b/src/kicad_tools/mcp/tools/routing.py
@@ -403,6 +403,7 @@ def route_net_auto(
     strategy: str = "auto",
     enable_repair: bool = True,
     enable_via_resolution: bool = True,
+    region: str | tuple[float, float, float, float] | None = None,
 ) -> dict:
     """Route a specific net using the RoutingOrchestrator.
 
@@ -420,6 +421,14 @@ def route_net_auto(
                   Use "auto" for smart selection.
         enable_repair: Whether to enable automatic clearance repair after routing
         enable_via_resolution: Whether to enable via conflict resolution
+        region: Optional spatial routing bound (Issue #4148, Phase 2a).  Either
+                a ``"x1,y1,x2,y2"`` string or a ``(x1, y1, x2, y2)`` tuple in
+                BOARD-RELATIVE mm (same convention as ``pcb strip --region``
+                and ``route --region``).  When given, the net is only routed if
+                ALL of its pads lie inside the box; a net with an endpoint
+                outside fails with a clear message (bare-stub reconnection is
+                deferred to Phase 2b).  Any produced segment/via that escapes
+                the box fails the route rather than writing out-of-region copper.
 
     Returns:
         Dictionary with routing result including:
@@ -467,6 +476,59 @@ def route_net_auto(
 
     if net_number is None:
         raise ValueError(f"Net '{net_name}' not found in design")
+
+    # Issue #4148: parse + validate the spatial region bound (board-relative).
+    region_box: tuple[float, float, float, float] | None = None
+    if region is not None:
+        if isinstance(region, str):
+            parts = [p.strip() for p in region.split(",")]
+            if len(parts) != 4:
+                raise ValueError(
+                    f"--region expects 'x1,y1,x2,y2' (four comma-separated numbers), got {region!r}"
+                )
+            try:
+                rx1, ry1, rx2, ry2 = (float(p) for p in parts)
+            except ValueError as _e:
+                raise ValueError(f"--region values must be numeric, got {region!r}") from _e
+        else:
+            rx1, ry1, rx2, ry2 = (float(v) for v in region)
+        if rx1 >= rx2 or ry1 >= ry2:
+            raise ValueError(
+                "--region must satisfy x1 < x2 and y1 < y2 "
+                f"(got x1={rx1}, y1={ry1}, x2={rx2}, y2={ry2})"
+            )
+        region_box = (rx1, ry1, rx2, ry2)
+
+        # Reachability gate: every pad of the routed net must lie inside the box
+        # (board-relative).  A pad outside needs outside access we do not
+        # provide in Phase 2a (bare-stub reconnection is Phase 2b).
+        outside_pads = []
+        for fp_ in pcb.footprints:
+            for pad in fp_.pads:
+                if (getattr(pad, "net_name", "") or "") != net_name:
+                    continue
+                pos = pcb.get_pad_position(fp_.reference, pad.number)
+                if pos is None:
+                    continue
+                if not (rx1 <= pos[0] <= rx2 and ry1 <= pos[1] <= ry2):
+                    outside_pads.append((fp_.reference, pad.number))
+        if outside_pads:
+            preview = ", ".join(f"{r}.{p}" for r, p in outside_pads[:6])
+            return {
+                "success": False,
+                "net_name": net_name,
+                "strategy_used": "region-bounded",
+                "metrics": {},
+                "repair_actions": [],
+                "warnings": [],
+                "performance": {},
+                "error_message": (
+                    f"--region cannot route net '{net_name}': pad(s) {preview} "
+                    "lie outside the region, and Phase 2a does not reconnect to "
+                    "bare boundary stubs (deferred to Phase 2b)."
+                ),
+                "alternative_strategies": [],
+            }
 
     # Import router components
     try:
@@ -558,6 +620,49 @@ def route_net_auto(
 
     # Route the net
     result = orchestrator.route_net(net=net_name, pads=pads)
+
+    # Issue #4148: confine the produced geometry to the region box.  The
+    # orchestrator's grid is not region-marked at cell level in Phase 2a, so we
+    # enforce the bound on its OUTPUT: any routed segment/via endpoint that
+    # escapes the box (world coords = board-relative + board origin) fails the
+    # route rather than writing out-of-region copper.
+    if region_box is not None and result.success:
+        ox, oy = pcb._board_origin
+        wx1 = region_box[0] + ox
+        wy1 = region_box[1] + oy
+        wx2 = region_box[2] + ox
+        wy2 = region_box[3] + oy
+        tol = 1e-3
+
+        def _in_box(px: float, py: float) -> bool:
+            return wx1 - tol <= px <= wx2 + tol and wy1 - tol <= py <= wy2 + tol
+
+        escaped = False
+        for seg in getattr(result, "segments", []) or []:
+            if not (_in_box(seg.x1, seg.y1) and _in_box(seg.x2, seg.y2)):
+                escaped = True
+                break
+        if not escaped:
+            for via in getattr(result, "vias", []) or []:
+                if not _in_box(via.x, via.y):
+                    escaped = True
+                    break
+        if escaped:
+            return {
+                "success": False,
+                "net_name": net_name,
+                "strategy_used": getattr(result.strategy_used, "name", str(result.strategy_used)),
+                "metrics": {},
+                "repair_actions": [],
+                "warnings": [],
+                "performance": {},
+                "error_message": (
+                    f"--region: routing net '{net_name}' produced geometry "
+                    "outside the region box; refusing to write out-of-region "
+                    "copper (Phase 2a confines route-auto output to the region)."
+                ),
+                "alternative_strategies": [],
+            }
 
     # Convert to dict with net_name included
     result_dict = result.to_dict()

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -85,7 +85,7 @@ from .parallel import (
 )
 from .path import create_intra_ic_routes, reduce_pads_after_intra_ic
 from .placement_feedback import PlacementFeedbackLoop, PlacementFeedbackResult
-from .primitives import Obstacle, Pad, Route
+from .primitives import Obstacle, Pad, Route, Via
 from .rules import (
     DEFAULT_NET_CLASS_MAP,
     SIMPLE_NET_THRESHOLD_MM,
@@ -676,6 +676,18 @@ class _TraceResolverTransaction:
 
         grid = self._router.grid
 
+        # Issue #4148: drill hole-to-hole (drill-to-drill) floor for NEW vias.
+        # ``validate_via_clearance`` / ``validate_via_to_via_clearance`` above
+        # enforce COPPER edge-to-edge clearance (annular ring vs. copper); they
+        # do NOT enforce the fab's mechanical drill-to-drill minimum.  Escape /
+        # diff-pair routers already apply ``min_hole_to_hole`` (escape.py,
+        # diffpair_routing.py) but the main A* via-placement path never did.
+        # Build the board-wide existing-drill registry once (foreign-net PTH
+        # pad drills + all pre-existing / other newly-committed via drills) so a
+        # via the main router just placed cannot sit within ``min_hole_to_hole``
+        # of another drill and later trip a ``dimension_drill_clearance`` DRC.
+        min_h2h = float(getattr(self._router.rules, "min_hole_to_hole", 0.5))
+
         # Validate against the CURRENT grid state (post-rip, post-
         # reroute).  ``validate_segment_clearance`` walks
         # ``self.routes`` internally and excludes same-net entries
@@ -707,7 +719,64 @@ class _TraceResolverTransaction:
                 )
                 if not is_valid_v2v:
                     return False
+                if not self._via_clears_hole_to_hole(via, min_h2h):
+                    return False
         return True
+
+    def _via_clears_hole_to_hole(self, via: Via, min_hole_to_hole: float) -> bool:
+        """Return True iff ``via``'s drill clears every OTHER drill by the floor.
+
+        Issue #4148: the drill-to-drill (hole-to-hole) mechanical floor for the
+        main A* router.  Compares the candidate via drill against every
+        foreign-net through-hole pad drill and every other via drill (existing
+        + committed) using the canonical edge-to-edge predicate shared with the
+        DRC ``dimension_drill_clearance`` rule and the escape router
+        (:func:`kicad_tools.router.via_clearance.drill_hole_to_hole_clear`).
+
+        Same-drill self-comparison (the via against itself) is excluded by an
+        exact-coordinate skip so a via never conflicts with its own hole.
+        """
+        from .via_clearance import drill_hole_to_hole_clear
+
+        router = self._router
+        via_drill = float(getattr(via, "drill", 0.0)) or float(router.rules.via_drill)
+
+        existing_drills: list[tuple[float, float, float]] = []
+
+        # Foreign-net (and same-net) through-hole PAD drills.  A drill floor is
+        # a mechanical constraint, so it applies regardless of net.
+        for pad in router.pads.values():
+            if getattr(pad, "through_hole", False):
+                d = float(getattr(pad, "drill", 0.0))
+                if d > 0.0:
+                    existing_drills.append((float(pad.x), float(pad.y), d))
+
+        # Pre-existing (preserved / fixed) via drills.
+        for route in router.existing_routes:
+            for ev in route.vias:
+                existing_drills.append((float(ev.x), float(ev.y), float(ev.drill) or via_drill))
+
+        # Other committed via drills (all routes except this via's own hole).
+        for route in router.routes:
+            for ov in route.vias:
+                if ov is via:
+                    continue
+                # Skip the exact same drill center (a via cannot conflict with
+                # itself even across route-object identity).
+                if (
+                    abs(float(ov.x) - float(via.x)) < 1e-9
+                    and abs(float(ov.y) - float(via.y)) < 1e-9
+                ):
+                    continue
+                existing_drills.append((float(ov.x), float(ov.y), float(ov.drill) or via_drill))
+
+        return drill_hole_to_hole_clear(
+            float(via.x),
+            float(via.y),
+            via_drill,
+            existing_drills,
+            min_hole_to_hole,
+        )
 
     def rollback(self, reason: str = "") -> None:
         """Restore the pre-``begin`` state.

--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -2666,6 +2666,88 @@ class RoutingGrid:
                         if 0 <= gx < self.cols and 0 <= gy < self.rows:
                             self.grid[layer_idx][gy][gx].blocked = True
 
+    def mark_region_bound(
+        self,
+        x1: float,
+        y1: float,
+        x2: float,
+        y2: float,
+    ) -> int:
+        """Confine routing to an axis-aligned box by blocking everything outside.
+
+        Issue #4148 (region-bounded routing, Phase 2a): the routing grid is
+        always sized to the full board (:meth:`Autorouter._create_grid_and_routers`),
+        so region-bounding is implemented as the COMPLEMENT of a keepout --
+        every routable-layer cell whose world position falls OUTSIDE the box
+        ``(x1, y1, x2, y2)`` is marked ``blocked`` (an obstacle with ``net=0``).
+        The C++ pathfinder hard-blocks any ``blocked`` foreign-net / net-0 cell
+        in both standard and negotiated modes, so no ``router/cpp/`` edits are
+        needed.
+
+        The box is given in WORLD (sheet-absolute) coordinates -- the same
+        frame :meth:`world_to_grid` consumes.  Callers holding a board-relative
+        region (matching ``pcb strip --region``'s convention) must add the
+        board origin before calling.
+
+        A cell inside the box is left untouched (so pads / existing copper
+        already loaded inside the region keep their state).  This is a
+        one-pass ``O(rows*cols*layers)`` scan -- the same order of magnitude as
+        the ``--preserve-existing`` obstacle marking already performed on every
+        route pass -- so it is cheap at typical board sizes.
+
+        When a C++ grid mirror is attached (``self._cpp_grid``, established by
+        ``CppGrid.from_routing_grid`` at router construction, BEFORE this runs),
+        each blocked cell is mirrored to it via ``mark_blocked`` so the
+        production C++ A* sees the bound.  This follows the same incremental
+        mirror pattern as :meth:`reserve_corridor_cells` (#4071).
+
+        Args:
+            x1, y1, x2, y2: World-coordinate box (mm).  Normalized internally
+                so inverted coordinates are tolerated.
+
+        Returns:
+            Number of grid cells newly blocked (summed across layers).
+        """
+        with self._acquire_lock():
+            # Capture the static-blockage snapshot before any region copper is
+            # marked so rip-up restores the region bound rather than erasing it
+            # (parity with mark_route / add_keepout consumers, Issue #3545).
+            self._ensure_static_blockage_snapshot()
+
+            nx1, ny1 = min(x1, x2), min(y1, y2)
+            nx2, ny2 = max(x1, x2), max(y1, y2)
+            gx1, gy1 = self.world_to_grid(nx1, ny1)
+            gx2, gy2 = self.world_to_grid(nx2, ny2)
+
+            layer_indices = self.get_routable_indices()
+            cpp_grid = getattr(self, "_cpp_grid", None)
+
+            blocked_count = 0
+            for layer_idx in layer_indices:
+                for gy in range(self.rows):
+                    inside_y = gy1 <= gy <= gy2
+                    for gx in range(self.cols):
+                        if inside_y and gx1 <= gx <= gx2:
+                            continue  # inside the region -- leave untouched
+                        cell = self.grid[layer_idx][gy][gx]
+                        if cell.blocked:
+                            # Already an obstacle (pad halo / existing copper /
+                            # board edge).  Nothing to add, and mirroring is
+                            # handled by whoever set it.
+                            continue
+                        cell.blocked = True
+                        blocked_count += 1
+                        if cpp_grid is not None:
+                            cpp_grid._impl.mark_blocked(
+                                int(gx),
+                                int(gy),
+                                int(layer_idx),
+                                0,  # net 0 -> hard obstacle for every routing net
+                                False,  # not is_obstacle (a keepout, not pad metal)
+                                False,  # not pad_blocked
+                            )
+            return blocked_count
+
     def is_blocked(self, gx: int, gy: int, layer: Layer, net: int = 0) -> bool:
         """Check if a cell is blocked for routing."""
         if not (0 <= gx < self.cols and 0 <= gy < self.rows):

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -3344,6 +3344,7 @@ def load_pcb_for_routing(
     load_existing_routes: bool = False,
     max_search_iterations: int = 0,
     per_net_iterations: int = 0,
+    region: tuple[float, float, float, float] | None = None,
 ) -> tuple[Autorouter, dict[str, int]]:
     """
     Load a KiCad PCB file and create an Autorouter with all components.
@@ -3391,6 +3392,18 @@ def load_pcb_for_routing(
                      multi-pass routing where Pass 2 must see Pass 1 geometry
                      to avoid overlapping traces and co-located vias.
                      Default is False for backward compatibility.
+        region: Optional ``(x1, y1, x2, y2)`` bounding box in BOARD-RELATIVE
+                mm coordinates (Issue #4148, region-bounded routing).  Matches
+                ``pcb strip --region``'s convention exactly: the box is
+                board-relative (origin at the Edge.Cuts rect start), so the
+                same ``x1,y1,x2,y2`` string can be reused across both commands.
+                When given, every routable-layer grid cell OUTSIDE the box is
+                marked as a fixed obstacle after existing copper is loaded, so
+                the router confines all new segments/vias to the region while
+                treating everything outside (copper and empty grid alike) as
+                immovable.  Region mode implies preserve-existing semantics --
+                callers should pass ``load_existing_routes=True`` so outside
+                copper is never re-routed.  The box is normalized internally.
 
     Returns:
         Tuple of (Autorouter instance, net_map dict)
@@ -3794,6 +3807,32 @@ def load_pcb_for_routing(
                 total_segs,
                 total_vias,
             )
+
+    # Region-bounded routing (Issue #4148, Phase 2a): confine all new routing
+    # to an axis-aligned box by marking every cell OUTSIDE it as a fixed
+    # obstacle.  The grid always covers the full board, so this is the
+    # complement of a keepout.  MUST run AFTER load_existing_routes so
+    # outside copper is first loaded as obstacles (and the region marking then
+    # blocks the empty gaps between it too).  The ``region`` box is
+    # board-relative (matching ``pcb strip --region``); the grid consumes
+    # sheet-absolute world coords, so add the board origin (== ``origin_x`` /
+    # ``origin_y`` == ``PCB._board_origin``) before marking.
+    if region is not None:
+        rx1, ry1, rx2, ry2 = region
+        wx1 = rx1 + origin_x
+        wy1 = ry1 + origin_y
+        wx2 = rx2 + origin_x
+        wy2 = ry2 + origin_y
+        blocked = router.grid.mark_region_bound(wx1, wy1, wx2, wy2)
+        logger.info(
+            "Region-bounded routing: confined to board-relative box "
+            "(%.3f, %.3f)-(%.3f, %.3f); %d cells outside marked as obstacles",
+            min(rx1, rx2),
+            min(ry1, ry2),
+            max(rx1, rx2),
+            max(ry1, ry2),
+            blocked,
+        )
 
     return router, net_map
 

--- a/tests/router/test_region_bounded.py
+++ b/tests/router/test_region_bounded.py
@@ -1,0 +1,632 @@
+"""Tests for Issue #4148: region-bounded routing (``--region`` on route/route-auto).
+
+Phase 2a scope
+--------------
+
+``kct route --region x1,y1,x2,y2`` confines all new routing to an
+axis-aligned box (board-relative mm, matching ``pcb strip --region``'s
+convention exactly).  Everything outside the box -- empty grid AND existing
+copper -- is treated as a fixed obstacle, so the router never adds, modifies,
+or removes copper outside the region.
+
+Implementation (option (a) from the curator's enhancement): the routing grid
+always covers the full board, so region-bounding marks every routable-layer
+cell OUTSIDE the box as an obstacle (:meth:`RoutingGrid.mark_region_bound`),
+the COMPLEMENT of a keepout.  No ``router/cpp/`` edits are needed -- the C++
+pathfinder hard-blocks any blocked foreign-net / net-0 cell.
+
+These tests follow ``tests/router/test_preserve_existing.py`` conventions
+(byte-identical outside-copper assertion) but build small synthetic boards in
+the spirit of ``tests/test_pcb.py``'s ``test_strip_region_*`` since the router
+API takes a ``.kicad_pcb`` path and the chorus fixture is NOT available in CI.
+
+Phase 2b (bare mid-trace stub reconnection) is explicitly OUT of scope here
+and is deferred to a follow-up issue.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.route_cmd import _parse_region_box
+from kicad_tools.cli.route_cmd import main as route_main
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.io import load_pcb_for_routing
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.optimizer.pcb import parse_segments, parse_vias
+from kicad_tools.router.primitives import Via
+from kicad_tools.router.rules import DesignRules
+from kicad_tools.schema.pcb import PCB
+
+# ---------------------------------------------------------------------------
+# Synthetic board construction
+# ---------------------------------------------------------------------------
+
+
+def _footprint(ref: str, x: float, y: float, net_num: int, net_name: str) -> str:
+    """A minimal single-pad SMD footprint the router's loader accepts."""
+    return (
+        f'  (footprint "R_0402" (layer "F.Cu") (at {x} {y})\n'
+        f'    (property "Reference" "{ref}" (at 0 0) (layer "F.SilkS"))\n'
+        f'    (pad "1" smd rect (at 0 0) (size 0.5 0.5) (layers "F.Cu") '
+        f'(net {net_num} "{net_name}")))'
+    )
+
+
+def _tht_footprint(
+    ref: str, x: float, y: float, net_num: int, net_name: str, drill: float = 0.3
+) -> str:
+    """A minimal through-hole footprint (carries a drill for hole-to-hole tests)."""
+    return (
+        f'  (footprint "R_THT" (layer "F.Cu") (at {x} {y})\n'
+        f'    (property "Reference" "{ref}" (at 0 0) (layer "F.SilkS"))\n'
+        f'    (pad "1" thru_hole circle (at 0 0) (size 0.9 0.9) (drill {drill}) '
+        f'(layers "*.Cu") (net {net_num} "{net_name}")))'
+    )
+
+
+def _board(
+    footprints: list[str],
+    *,
+    edge: tuple[float, float, float, float] = (100, 100, 140, 140),
+    nets: list[tuple[int, str]] | None = None,
+    extra: str = "",
+) -> str:
+    """Assemble a minimal but router-loadable ``.kicad_pcb`` string.
+
+    ``edge`` is the Edge.Cuts ``gr_rect`` (start_x, start_y, end_x, end_y);
+    its start becomes both ``PCB._board_origin`` and the router's grid origin,
+    so pad ``(at ...)`` coordinates are sheet-absolute and region boxes are
+    board-relative (start subtracted).
+    """
+    if nets is None:
+        nets = [(1, "SIG_A"), (2, "SIG_B")]
+    net_lines = '  (net 0 "")\n' + "\n".join(f'  (net {n} "{name}")' for n, name in nets)
+    ex1, ey1, ex2, ey2 = edge
+    return (
+        "(kicad_pcb (version 20240108) (generator test)\n"
+        f"{net_lines}\n"
+        f"  (gr_rect (start {ex1} {ey1}) (end {ex2} {ey2}) "
+        '(layer "Edge.Cuts") (width 0.1))\n'
+        + "\n".join(footprints)
+        + ("\n" + extra if extra else "")
+        + "\n)\n"
+    )
+
+
+def _write(tmp_path: Path, text: str, name: str = "in.kicad_pcb") -> Path:
+    p = tmp_path / name
+    p.write_text(text)
+    return p
+
+
+# A default two-net board: SIG_A pads both inside the region box
+# (10,10)-(20,20) [board-relative], SIG_B pads both outside it.
+def _two_net_board() -> str:
+    return _board(
+        [
+            # board origin is (100,100); board-relative (10,10) == absolute (110,110)
+            _footprint("R1", 110, 110, 1, "SIG_A"),
+            _footprint("R2", 118, 110, 1, "SIG_A"),
+            # SIG_B pads at board-relative (30,30)/(35,30) == absolute (130,130)/(135,130)
+            _footprint("R3", 130, 130, 2, "SIG_B"),
+            _footprint("R4", 135, 130, 2, "SIG_B"),
+        ]
+    )
+
+
+_REGION_A = (10.0, 10.0, 20.0, 20.0)  # board-relative box enclosing SIG_A only
+
+
+# ---------------------------------------------------------------------------
+# CLI region-string parsing / validation
+# ---------------------------------------------------------------------------
+
+
+class TestRegionStringParsing:
+    def test_valid_box_normalized(self):
+        assert _parse_region_box("10,10,20,20") == (10.0, 10.0, 20.0, 20.0)
+
+    def test_whitespace_tolerated(self):
+        assert _parse_region_box(" 1, 2 , 3, 4 ") == (1.0, 2.0, 3.0, 4.0)
+
+    def test_wrong_arity_rejected(self):
+        err = _parse_region_box("1,2,3")
+        assert isinstance(err, str) and "four" in err
+
+    def test_non_numeric_rejected(self):
+        err = _parse_region_box("1,2,three,4")
+        assert isinstance(err, str) and "numeric" in err
+
+    def test_degenerate_zero_width_rejected(self):
+        err = _parse_region_box("10,10,10,20")
+        assert isinstance(err, str) and "x1 < x2" in err
+
+    def test_degenerate_zero_height_rejected(self):
+        err = _parse_region_box("10,10,20,10")
+        assert isinstance(err, str) and "y1 < y2" in err
+
+    def test_inverted_rejected(self):
+        # x1 > x2 is rejected exactly like pcb strip --region (no silent swap).
+        err = _parse_region_box("20,10,10,20")
+        assert isinstance(err, str) and "x1 < x2" in err
+
+
+# ---------------------------------------------------------------------------
+# Grid-level: mark_region_bound
+# ---------------------------------------------------------------------------
+
+
+class TestMarkRegionBound:
+    def _grid(self) -> RoutingGrid:
+        rules = DesignRules(grid_resolution=0.5, trace_width=0.2, trace_clearance=0.15)
+        # 40x40 board with origin (100,100): world box == board-relative + 100.
+        return RoutingGrid(width=40.0, height=40.0, rules=rules, origin_x=100.0, origin_y=100.0)
+
+    def test_outside_cells_blocked_inside_free(self):
+        grid = self._grid()
+        # World box (110,110)-(120,120) (== board-relative (10,10)-(20,20)).
+        grid.mark_region_bound(110.0, 110.0, 120.0, 120.0)
+
+        layer = Layer.F_CU
+        # A cell well inside the box is NOT blocked.
+        igx, igy = grid.world_to_grid(115.0, 115.0)
+        assert not grid.is_blocked(igx, igy, layer, net=1)
+        # A cell well outside the box IS blocked (for any net).
+        ogx, ogy = grid.world_to_grid(130.0, 130.0)
+        assert grid.is_blocked(ogx, ogy, layer, net=1)
+        assert grid.is_blocked(ogx, ogy, layer, net=2)
+
+    def test_returns_positive_blocked_count(self):
+        grid = self._grid()
+        n = grid.mark_region_bound(110.0, 110.0, 120.0, 120.0)
+        assert n > 0
+
+    def test_inverted_box_tolerated(self):
+        grid = self._grid()
+        # Passing the box inverted must normalize to the same result.
+        grid.mark_region_bound(120.0, 120.0, 110.0, 110.0)
+        igx, igy = grid.world_to_grid(115.0, 115.0)
+        assert not grid.is_blocked(igx, igy, Layer.F_CU, net=1)
+        ogx, ogy = grid.world_to_grid(105.0, 105.0)
+        assert grid.is_blocked(ogx, ogy, Layer.F_CU, net=1)
+
+
+# ---------------------------------------------------------------------------
+# Router-level: load_pcb_for_routing(region=...)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadRegionMarking:
+    def test_outside_net_pads_land_in_blocked_zone(self, tmp_path):
+        """Cells around the outside net's pads are region-blocked."""
+        path = _write(tmp_path, _two_net_board())
+        router, _ = load_pcb_for_routing(
+            str(path),
+            validate_drc=False,
+            strict_drc=False,
+            load_existing_routes=True,
+            region=_REGION_A,
+        )
+        # SIG_B pad at absolute (130,130) is outside the region -> its cell is
+        # blocked to a foreign net (net 1) by the region bound.
+        gx, gy = router.grid.world_to_grid(130.0, 130.0)
+        assert router.grid.is_blocked(gx, gy, Layer.F_CU, net=1)
+
+        # SIG_A pad at absolute (110,110) is inside the region; the empty grid
+        # just next to it (still inside) is free for routing SIG_A.
+        gx2, gy2 = router.grid.world_to_grid(114.0, 110.0)
+        assert not router.grid.is_blocked(gx2, gy2, Layer.F_CU, net=1)
+
+    def test_in_region_net_routes(self, tmp_path):
+        """An in-region net routes normally under the region bound."""
+        path = _write(tmp_path, _two_net_board())
+        router, _ = load_pcb_for_routing(
+            str(path),
+            validate_drc=False,
+            strict_drc=False,
+            load_existing_routes=True,
+            region=_REGION_A,
+        )
+        result = router.route_net(1)  # SIG_A, both pads inside region
+        assert result, "in-region net SIG_A should route"
+        assert any(r.net == 1 and r.segments for r in router.routes)
+
+    def test_all_new_geometry_inside_region(self, tmp_path):
+        """Every routed segment stays within the region box (world coords)."""
+        path = _write(tmp_path, _two_net_board())
+        router, _ = load_pcb_for_routing(
+            str(path),
+            validate_drc=False,
+            strict_drc=False,
+            load_existing_routes=True,
+            region=_REGION_A,
+        )
+        router.route_net(1)
+        # region world box == board-relative + origin (100,100)
+        wx1, wy1, wx2, wy2 = 110.0, 110.0, 120.0, 120.0
+        tol = 1e-3
+        for route in router.routes:
+            for seg in route.segments:
+                for x, y in ((seg.x1, seg.y1), (seg.x2, seg.y2)):
+                    assert wx1 - tol <= x <= wx2 + tol, f"seg x={x} escaped region"
+                    assert wy1 - tol <= y <= wy2 + tol, f"seg y={y} escaped region"
+
+
+# ---------------------------------------------------------------------------
+# CLI end-to-end
+# ---------------------------------------------------------------------------
+
+
+def _run_route_region(
+    tmp_path: Path,
+    pcb_text: str,
+    region: str | None,
+    *,
+    extra_argv: list[str] | None = None,
+) -> tuple[int, str | None]:
+    """Run ``kct route`` (inner main) with optional --region; return (rc, out_text)."""
+    in_path = _write(tmp_path, pcb_text)
+    out_path = tmp_path / "out.kicad_pcb"
+    argv = [
+        str(in_path),
+        "--output",
+        str(out_path),
+        "--no-optimize",
+        "--force",
+        "--quiet",
+        "--no-auto-layers",
+        "--backend",
+        "cpp",
+        # These tests assert on region-confinement / preservation GEOMETRY, not
+        # manufacturing DRC.  Synthetic 0.5mm-pad boards at a jlcpcb tier can
+        # trip grid-quantization clearance findings unrelated to region logic,
+        # so skip the DRC gate to keep the assertions focused and deterministic.
+        "--skip-drc",
+    ]
+    if region is not None:
+        argv += ["--region", region]
+    if extra_argv:
+        argv += extra_argv
+    rc = route_main(argv)
+    out_text = out_path.read_text() if out_path.exists() else None
+    return rc, out_text
+
+
+class TestRouteRegionCLI:
+    def test_region_confines_routing_and_preserves_outside(self, tmp_path):
+        """Route SIG_A in-region; SIG_B (outside) copper is byte-identical.
+
+        We pre-route SIG_B by hand (add an outside trace + via), then run
+        ``route --region`` over just the SIG_A region and assert the outside
+        SIG_B geometry is unchanged and no new copper landed outside the box.
+        """
+        # Board with existing outside SIG_B copper (a trace + a via) placed
+        # OUTSIDE the region, plus an unrouted SIG_A inside the region.
+        outside_copper = (
+            "  (segment (start 130 130) (end 135 130) (width 0.2) "
+            '(layer "F.Cu") (net 2))\n'
+            "  (via (at 132 130) (size 0.6) (drill 0.3) "
+            '(layers "F.Cu" "B.Cu") (net 2))'
+        )
+        board = _board(
+            [
+                _footprint("R1", 110, 110, 1, "SIG_A"),
+                _footprint("R2", 118, 110, 1, "SIG_A"),
+                _footprint("R3", 130, 130, 2, "SIG_B"),
+                _footprint("R4", 135, 130, 2, "SIG_B"),
+            ],
+            extra=outside_copper,
+        )
+        rc, out_text = _run_route_region(tmp_path, board, "10,10,20,20")
+        assert rc == 0, f"route --region exited {rc}"
+        assert out_text is not None
+
+        out_segs = parse_segments(out_text)
+        out_vias = parse_vias(out_text)
+
+        # SIG_B's outside trace + via survived byte-identically.
+        assert "SIG_B" in out_segs
+        b_seg = out_segs["SIG_B"]
+        assert len(b_seg) == 1
+        s = b_seg[0]
+        assert (round(s.x1, 3), round(s.y1, 3), round(s.x2, 3), round(s.y2, 3)) == (
+            130.0,
+            130.0,
+            135.0,
+            130.0,
+        )
+        assert "SIG_B" in out_vias and len(out_vias["SIG_B"]) == 1
+        assert round(out_vias["SIG_B"][0].x, 3) == 132.0
+
+        # SIG_A got routed inside the region.
+        assert "SIG_A" in out_segs and len(out_segs["SIG_A"]) > 0
+
+        # No NEW copper landed outside the region box (world (110,110)-(120,120)).
+        for net_name, segs in out_segs.items():
+            for seg in segs:
+                if net_name == "SIG_B":
+                    continue  # preserved existing outside copper is expected
+                for x, y in ((seg.x1, seg.y1), (seg.x2, seg.y2)):
+                    assert 110.0 - 1e-3 <= x <= 120.0 + 1e-3, (
+                        f"{net_name} segment x={x} escaped region"
+                    )
+                    assert 110.0 - 1e-3 <= y <= 120.0 + 1e-3, (
+                        f"{net_name} segment y={y} escaped region"
+                    )
+
+    def test_region_composes_with_skip_nets(self, tmp_path):
+        """--region ANDed with --skip-nets: a skipped in-region net is not routed."""
+        # Two in-region nets: SIG_A (top) and SIG_C (well below it), both inside
+        # a generous box (5,5)-(35,35).  The wide vertical separation keeps the
+        # routed traces DRC-clean on this synthetic board.
+        board = _board(
+            [
+                _footprint("R1", 110, 110, 1, "SIG_A"),
+                _footprint("R2", 118, 110, 1, "SIG_A"),
+                _footprint("R5", 110, 128, 3, "SIG_C"),
+                _footprint("R6", 118, 128, 3, "SIG_C"),
+            ],
+            nets=[(1, "SIG_A"), (3, "SIG_C")],
+        )
+        rc, out_text = _run_route_region(
+            tmp_path, board, "5,5,35,35", extra_argv=["--skip-nets", "SIG_C"]
+        )
+        assert rc == 0
+        out_segs = parse_segments(out_text or "")
+        # SIG_A routed, SIG_C skipped (no fresh geometry).
+        assert "SIG_A" in out_segs and len(out_segs["SIG_A"]) > 0
+        assert "SIG_C" not in out_segs or len(out_segs["SIG_C"]) == 0
+
+    def test_unreachable_net_fails_with_clear_message(self, tmp_path, capsys):
+        """A net with a pad outside the region fails fast with a per-net message."""
+        # SIG_A: one pad inside (110,110), one pad OUTSIDE (135,110 == rel 35,10).
+        board = _board(
+            [
+                _footprint("R1", 110, 110, 1, "SIG_A"),
+                _footprint("R2", 135, 110, 1, "SIG_A"),
+            ],
+            nets=[(1, "SIG_A")],
+        )
+        rc, _ = _run_route_region(tmp_path, board, "5,5,20,20")
+        assert rc != 0
+        err = capsys.readouterr().err
+        assert "SIG_A" in err
+        assert "outside the region" in err or "Phase 2b" in err
+
+    def test_region_outside_board_bounds_is_error(self, tmp_path, capsys):
+        """A region entirely outside the board bounds fails with a clear message."""
+        board = _two_net_board()
+        # board is (100,100)-(140,140) => board-relative bounds (0,0)-(40,40).
+        # A box at board-relative (60,60)-(70,70) is entirely outside.
+        rc, _ = _run_route_region(tmp_path, board, "60,60,70,70")
+        assert rc != 0
+        err = capsys.readouterr().err
+        assert "outside the board" in err
+
+    def test_degenerate_region_cli_error(self, tmp_path, capsys):
+        board = _two_net_board()
+        rc, _ = _run_route_region(tmp_path, board, "10,10,10,20")
+        assert rc != 0
+        err = capsys.readouterr().err
+        assert "x1 < x2" in err
+
+    def test_region_with_no_routable_net_fails_gracefully(self, tmp_path, capsys):
+        """A region containing zero pads for any net fails gracefully."""
+        board = _two_net_board()
+        # Empty corner of the board (board-relative (2,2)-(5,5)) has no pads.
+        rc, _ = _run_route_region(tmp_path, board, "2,2,5,5")
+        assert rc != 0
+        err = capsys.readouterr().err
+        assert "no routable" in err or "nothing to route" in err
+
+    def test_region_implies_preserve_existing(self, tmp_path):
+        """Region mode preserves outside copper even without --preserve-existing.
+
+        The outside SIG_B trace is NOT passed with an explicit
+        --preserve-existing flag; region mode must imply it so the trace
+        survives (default route mode would strip skipped-net copper).
+        """
+        outside_copper = (
+            '  (segment (start 130 130) (end 138 130) (width 0.2) (layer "F.Cu") (net 2))'
+        )
+        board = _board(
+            [
+                _footprint("R1", 110, 110, 1, "SIG_A"),
+                _footprint("R2", 118, 110, 1, "SIG_A"),
+                _footprint("R3", 130, 130, 2, "SIG_B"),
+                _footprint("R4", 138, 130, 2, "SIG_B"),
+            ],
+            extra=outside_copper,
+        )
+        rc, out_text = _run_route_region(tmp_path, board, "10,10,20,20")
+        assert rc == 0
+        out_segs = parse_segments(out_text or "")
+        assert "SIG_B" in out_segs and len(out_segs["SIG_B"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Coordinate parity with pcb strip --region
+# ---------------------------------------------------------------------------
+
+
+class TestCoordinateParity:
+    def test_same_box_selects_same_geometry_nonzero_origin(self, tmp_path):
+        """The same x1,y1,x2,y2 means the same box for strip and route.
+
+        Build a board with a non-zero origin (Edge.Cuts start != 0,0).  A trace
+        at board-relative (10,10)-(15,10) is INSIDE box (5,5,20,20) for both:
+        ``pcb strip --region`` removes it, and ``route --region`` treats the
+        same absolute cells as in-region (the outside cells are blocked).
+        """
+        # Origin (50,50): board-relative (10,10) == absolute (60,60).
+        board = _board(
+            [
+                _footprint("R1", 60, 60, 1, "SIG_A"),
+                _footprint("R2", 65, 60, 1, "SIG_A"),
+            ],
+            edge=(50, 50, 90, 90),
+            nets=[(1, "SIG_A")],
+            extra=('  (segment (start 60 60) (end 65 60) (width 0.2) (layer "F.Cu") (net 1))'),
+        )
+        pcb = PCB.load(str(_write(tmp_path, board, "parity.kicad_pcb")))
+        # The board-relative box (5,5,20,20): the trace at board-relative
+        # (10,10)-(15,10) is fully inside, so strip removes it.
+        stats = pcb.strip_traces(region=(5, 5, 20, 20), nets=["SIG_A"])
+        assert stats["segments"] == 1, "strip --region should remove the in-box trace"
+
+        # Now the router loads the SAME box: the outside cells are blocked and
+        # the in-box pad cells are free.  The router's grid origin equals the
+        # board origin (50,50), so board-relative (5,5)-(20,20) maps to world
+        # (55,55)-(70,70).
+        router, _ = load_pcb_for_routing(
+            str(_write(tmp_path, board, "parity2.kicad_pcb")),
+            validate_drc=False,
+            strict_drc=False,
+            load_existing_routes=True,
+            region=(5, 5, 20, 20),
+        )
+        # Inside cell (absolute 62,60 == board-relative 12,10) is free for SIG_A.
+        igx, igy = router.grid.world_to_grid(62.0, 60.0)
+        assert not router.grid.is_blocked(igx, igy, Layer.F_CU, net=1)
+        # Outside cell (absolute 80,80 == board-relative 30,30) is blocked.
+        ogx, ogy = router.grid.world_to_grid(80.0, 80.0)
+        assert router.grid.is_blocked(ogx, ogy, Layer.F_CU, net=1)
+
+
+# ---------------------------------------------------------------------------
+# Hole-to-hole floor for main-router vias
+# ---------------------------------------------------------------------------
+
+
+class TestHoleToHoleFloor:
+    def _router_with_pth(self, tmp_path):
+        """Router whose only existing drill is a THT pad near a candidate site."""
+        board = _board(
+            [
+                _tht_footprint("J1", 115, 115, 2, "SIG_B", drill=0.3),
+            ],
+            nets=[(2, "SIG_B")],
+        )
+        router, _ = load_pcb_for_routing(
+            str(_write(tmp_path, board, "h2h.kicad_pcb")),
+            validate_drc=False,
+            strict_drc=False,
+            load_existing_routes=True,
+        )
+        return router
+
+    def test_via_too_close_to_pth_drill_is_rejected(self, tmp_path):
+        """A committed via within min_hole_to_hole of a PTH drill fails validation."""
+        from kicad_tools.router.core import _TraceResolverTransaction
+        from kicad_tools.router.primitives import Route
+
+        router = self._router_with_pth(tmp_path)
+        router.rules.min_hole_to_hole = 0.5
+
+        transaction = _TraceResolverTransaction(router)
+        # Snapshot the empty pre-state, THEN commit a new via so it counts as
+        # "newly committed" during validation.
+        transaction.begin()
+
+        # Candidate via 0.3mm center-to-center from the PTH pad drill (0.3mm):
+        # edge = 0.3 - 0.15 - 0.15 = 0.0 << 0.5 floor -> must be rejected.
+        via = Via(x=115.3, y=115.0, drill=0.3, diameter=0.6, layers=(Layer.F_CU, Layer.B_CU), net=2)
+        route = Route(net=2, net_name="SIG_B", segments=[], vias=[via])
+        router.routes.append(route)
+
+        # The direct predicate rejects it...
+        assert transaction._via_clears_hole_to_hole(via, 0.5) is False
+        # ...and the full committed-geometry gate rejects the transaction.
+        assert transaction.validate_committed_geometry() is False
+
+    def test_via_clear_of_drills_passes(self, tmp_path):
+        """A via comfortably clear of every drill passes the hole-to-hole floor."""
+        from kicad_tools.router.core import _TraceResolverTransaction
+
+        router = self._router_with_pth(tmp_path)
+        router.rules.min_hole_to_hole = 0.5
+
+        transaction = _TraceResolverTransaction(router)
+        transaction.begin()
+        # 5mm away from the only PTH drill -> comfortably clear.
+        via = Via(x=120.0, y=120.0, drill=0.3, diameter=0.6, layers=(Layer.F_CU, Layer.B_CU), net=2)
+        assert transaction._via_clears_hole_to_hole(via, 0.5) is True
+
+
+# ---------------------------------------------------------------------------
+# route-auto --region
+# ---------------------------------------------------------------------------
+
+
+class TestRouteAutoRegion:
+    def test_unreachable_net_fails_with_message(self, tmp_path):
+        """route_net_auto rejects a net with a pad outside the region."""
+        from kicad_tools.mcp.tools.routing import route_net_auto
+
+        board = _board(
+            [
+                _footprint("R1", 110, 110, 1, "SIG_A"),
+                _footprint("R2", 135, 110, 1, "SIG_A"),  # outside box
+            ],
+            nets=[(1, "SIG_A")],
+        )
+        path = _write(tmp_path, board, "auto.kicad_pcb")
+        result = route_net_auto(
+            str(path),
+            "SIG_A",
+            output_path=None,
+            region="5,5,20,20",
+        )
+        assert result["success"] is False
+        assert "SIG_A" in result["error_message"]
+        assert "outside the region" in result["error_message"]
+
+    def test_degenerate_region_raises(self, tmp_path):
+        """route_net_auto raises ValueError on a degenerate region box."""
+        from kicad_tools.mcp.tools.routing import route_net_auto
+
+        board = _board(
+            [
+                _footprint("R1", 110, 110, 1, "SIG_A"),
+                _footprint("R2", 118, 110, 1, "SIG_A"),
+            ],
+            nets=[(1, "SIG_A")],
+        )
+        path = _write(tmp_path, board, "auto2.kicad_pcb")
+        with pytest.raises(ValueError, match="x1 < x2"):
+            route_net_auto(str(path), "SIG_A", region="10,10,10,20")
+
+    def test_tuple_region_accepted(self, tmp_path):
+        """route_net_auto accepts a pre-parsed (x1,y1,x2,y2) tuple region."""
+        from kicad_tools.mcp.tools.routing import route_net_auto
+
+        board = _board(
+            [
+                _footprint("R1", 110, 110, 1, "SIG_A"),
+                _footprint("R2", 118, 110, 1, "SIG_A"),
+            ],
+            nets=[(1, "SIG_A")],
+        )
+        path = _write(tmp_path, board, "auto3.kicad_pcb")
+        # Both pads inside the box -> passes the reachability gate.  Routing may
+        # still fail on this minimal board (or be confined-out), but it must NOT
+        # be rejected for the UNREACHABLE-PAD reason.
+        result = route_net_auto(
+            str(path),
+            "SIG_A",
+            output_path=None,
+            region=(5.0, 5.0, 25.0, 25.0),
+        )
+        if not result["success"]:
+            msg = result.get("error_message") or ""
+            # The reachability gate names specific pads (e.g. "pad(s) R2.1");
+            # any failure here must be the output-confinement or a normal
+            # routing failure, not the reachability rejection.
+            assert "lie outside the region" not in msg
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/uv.lock
+++ b/uv.lock
@@ -1766,7 +1766,7 @@ wheels = [
 
 [[package]]
 name = "kicad-tools"
-version = "0.15.0"
+version = "0.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

Phase 2a of region-bounded routing (#4136). Adds `--region x1,y1,x2,y2` to
`route` and `route-auto`, confining all new routing to an axis-aligned
board-relative box that matches `pcb strip --region`'s coordinate convention
exactly (PR #4147). Everything outside the box -- empty grid AND existing
copper -- is treated as a fixed obstacle, so the router never adds, modifies,
or removes copper outside the region.

**Phase 2b (bare mid-trace stub-endpoint reconnection) is explicitly OUT of
scope and deferred to a follow-up issue.** Stubs that coincide with a pad/via
already work (pads/vias are routing targets); bare boundary stubs are not.

## Changes

- **`router/grid.py`** — `RoutingGrid.mark_region_bound(x1,y1,x2,y2)`: marks
  every routable-layer cell OUTSIDE the world box as a fixed obstacle (the
  complement of a keepout), mirroring to the C++ grid via `mark_blocked`. No
  `router/cpp/` edits — the pathfinder already hard-blocks net-0 blocked cells
  in both standard and negotiated modes.
- **`router/io.py`** — `load_pcb_for_routing(region=...)`: after
  `load_existing_routes` loads outside copper as obstacles, marks the
  outside-region cells; the box is board-relative and converted to world by
  adding the grid origin (== `PCB._board_origin`).
- **`cli/route_cmd.py`** — parse/validate `--region` (mirrors the `strip
  --region` CLI checks), imply `--preserve-existing` + `--no-cache` (the route
  cache key ignores the region/skip set), auto-skip nets with no in-region
  work, and fail fast with a clear per-net message when a routed net has a pad
  outside the region. Threaded `region=` into all five `load_pcb_for_routing`
  call sites.
- **`router/core.py`** — thread `min_hole_to_hole` into the MAIN router's via
  validation (`_TraceResolverTransaction.validate_committed_geometry`). The
  drill-to-drill floor was previously only applied by `escape.py` /
  `diffpair_routing.py`; the main A* path now rejects a committed via whose
  drill sits within the fab floor of any pad/via drill, via the canonical
  `via_clearance.drill_hole_to_hole_clear`.
- **`cli/parser.py`** — `--region` on `route` + `route-auto`; help text
  explicitly distinguishes the spatial bound from the unrelated
  `--region-parallel` family. argparse resolves the exact `--region` string to
  the new flag (exact match beats abbreviation); `--regio` remains ambiguous.
- **`cli/commands/routing.py` / `mcp/tools/routing.py`** — forward `--region`;
  `route_net_auto(region=...)` enforces a pad-reachability gate + output
  confinement at the orchestrator boundary.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `route --region` routes only inside the region; no outside copper added/modified/removed | ✅ | `test_region_confines_routing_and_preserves_outside` asserts SIG_B outside trace+via byte-identical and no new copper outside the box |
| Outside copper respected as fixed obstacle | ✅ | Region implies preserve-existing; `test_region_implies_preserve_existing`, `TestLoadRegionMarking` |
| `--region` board-relative, parity with `pcb strip --region` | ✅ | `TestCoordinateParity.test_same_box_selects_same_geometry_nonzero_origin` (non-zero origin: strip removes the in-box trace; router blocks the same outside cells) |
| New vias honor `min_hole_to_hole` vs existing PTH/via drills | ✅ | `TestHoleToHoleFloor` (via 0.0mm edge-to-edge from a 0.3mm PTH drill rejected; 5mm-clear via passes) |
| Degenerate region (`x1==x2`/`y1==y2`) → clear CLI error | ✅ | `test_degenerate_region_cli_error`, `TestRegionStringParsing`; route-auto `test_degenerate_region_raises` |
| Region fully outside board bounds → clear message, no crash | ✅ | `test_region_outside_board_bounds_is_error` |
| Region with zero routable pads → graceful failure | ✅ | `test_region_with_no_routable_net_fails_gracefully` |
| Unreachable net (pad outside) → clear per-net message | ✅ | `test_unreachable_net_fails_with_clear_message`; route-auto `test_unreachable_net_fails_with_message` |
| `--nets`/net-filter composition | ✅ | `test_region_composes_with_skip_nets` (region ANDed with `--skip-nets`) |
| Naming: no `--region-parallel` collision | ✅ | Verified argparse exact-match resolution; distinct help text |
| Phase 2b (bare-stub reconnection) documented OUT of scope | ✅ | CLI help + docstrings note the limitation; deferred to a follow-up issue |

## Test Plan

New `tests/router/test_region_bounded.py` (26 tests) following
`test_preserve_existing.py` conventions with synthetic `PCB.create`-style
boards (no chorus fixture — local-only, not in CI). Covers grid-level marking,
router-level confinement, CLI end-to-end (byte-identical outside copper,
skip-net composition, all error paths), coordinate parity, hole-to-hole floor,
and route-auto region.

- `uv run pytest tests/router -k "region or preserve"` → 46 passed
- Board 02/03 routing baselines → 10 passed (no route regression from the
  new h2h via check)
- Parser/CLI suite (`-k "route_parser or route_auto or region_parallel or
  parser"`) → 460 passed, 1 skipped
- ruff check + format clean; `check_mypy_baseline.py` → 0 new errors

Closes #4148