### PR TITLE
feat(schematic): add collision-aware add_stub_label helper

### DIFF
--- a/src/kicad_tools/schematic/exceptions.py
+++ b/src/kicad_tools/schematic/exceptions.py
@@ -157,6 +157,44 @@ class SymbolNotFoundError(ValueError):
         super().__init__("".join(msg_parts))
 
 
+class StubPlacementError(ValueError):
+    """Raised when a collision-aware stub+label cannot be placed.
+
+    :meth:`SchematicElementsMixin.add_stub_label` searches a small, bounded
+    set of candidate stub geometries (outward, longer, shorter, perpendicular
+    jogs, opposite) and places the first one that does not collinearly overlap
+    or T-touch an existing wire carrying a *different* named net.  When every
+    candidate would collide it raises this error rather than silently placing
+    a stub that KiCad would merge into a foreign net (the issue #4143 failure
+    mode).  The message identifies the pin's absolute position, the requested
+    net, and every candidate endpoint that was tried so a generator author can
+    see why placement failed and adjust the layout.
+
+    Subclasses ``ValueError`` for continuity with the ``_emit_pin_net_stub``
+    precedent in ``blocks/_stub_helpers.py`` (which raises ``ValueError`` when
+    both of its candidate sides collide).
+    """
+
+    def __init__(
+        self,
+        pin_position: tuple[float, float],
+        net: str,
+        tried_endpoints: list[tuple[float, float]],
+    ):
+        self.pin_position = pin_position
+        self.net = net
+        self.tried_endpoints = tried_endpoints
+
+        candidates = ", ".join(f"({x}, {y})" for x, y in tried_endpoints)
+        super().__init__(
+            f"Cannot place stub+label for net '{net}' at pin "
+            f"{pin_position}: every candidate stub endpoint collinearly "
+            f"overlaps or T-touches an existing wire carrying a different "
+            f"net. Tried endpoints: {candidates}. Move the neighboring "
+            f"symbol/wire or pass an explicit direction=/length= to resolve."
+        )
+
+
 class LibraryNotFoundError(FileNotFoundError):
     """Raised when a KiCad library file cannot be found."""
 

--- a/src/kicad_tools/schematic/models/elements_mixin.py
+++ b/src/kicad_tools/schematic/models/elements_mixin.py
@@ -7,9 +7,11 @@ and grid snapping functionality.
 
 from __future__ import annotations
 
+import math
 import warnings
 from typing import TYPE_CHECKING
 
+from ..exceptions import StubPlacementError
 from ..grid import is_on_grid, snap_to_grid
 from ..logging import _log_debug, _log_info
 from .elements import (
@@ -22,9 +24,44 @@ from .elements import (
     Wire,
 )
 from .symbol import SymbolDef, SymbolInstance
+from .wire_geometry import wire_segments_connect
 
 if TYPE_CHECKING:
     pass
+
+
+# Mapping of the four cardinal stub directions to their outward unit vector in
+# schematic (Y-down) coordinates: +x is right, +y is down.
+_DIRECTION_VECTORS: dict[str, tuple[float, float]] = {
+    "right": (1.0, 0.0),
+    "up": (0.0, -1.0),
+    "left": (-1.0, 0.0),
+    "down": (0.0, 1.0),
+}
+
+# Label rotation (degrees) so the label text reads outward along each stub
+# direction, matching KiCad's convention (0=text extends right, 90=up, ...).
+_DIRECTION_LABEL_ROTATION: dict[str, float] = {
+    "right": 0.0,
+    "up": 90.0,
+    "left": 180.0,
+    "down": 270.0,
+}
+
+# Perpendicular jog directions tried when the outward candidate collides.
+_PERPENDICULAR: dict[str, tuple[str, str]] = {
+    "right": ("up", "down"),
+    "left": ("up", "down"),
+    "up": ("right", "left"),
+    "down": ("right", "left"),
+}
+
+_OPPOSITE_DIRECTION: dict[str, str] = {
+    "right": "left",
+    "left": "right",
+    "up": "down",
+    "down": "up",
+}
 
 
 class SchematicElementsMixin:
@@ -884,6 +921,215 @@ class SchematicElementsMixin:
         label = Label(text=text, x=x, y=y, rotation=rotation)
         self.labels.append(label)
         return label
+
+    def _pin_outward_direction(self, symbol: SymbolInstance, pin_name_or_number: str) -> str:
+        """Compute the cardinal outward stub direction for a symbol pin.
+
+        The direction a stub travels *away* from a pin is the opposite of the
+        pin's library ``angle`` (which points *into* the symbol body), rotated
+        by the symbol's placement ``rotation`` and converted from library Y-up
+        to schematic Y-down space -- the exact transform
+        :meth:`SymbolInstance.pin_position` applies to the pin *position*, now
+        applied to the pin's *direction vector* as well (issue #4161).
+
+        Returns one of ``"left"``/``"right"``/``"up"``/``"down"`` (the nearest
+        cardinal, snapped with a +-1 degree tolerance).  KiCad generator code
+        places symbols at 0/90/180/270 rotation, so the rotated outward angle
+        always lands on a cardinal in practice; a non-cardinal result (from an
+        arbitrary-angle rotation) snaps to the nearest cardinal.
+        """
+        pin = symbol.find_pin(pin_name_or_number)
+
+        # Outward direction in library (Y-up) space: opposite of the pin's
+        # into-body angle.
+        outward_lib = math.radians((pin.angle + 180.0) % 360.0)
+        vx = math.cos(outward_lib)
+        vy = math.sin(outward_lib)
+
+        # Apply the symbol rotation (standard CCW matrix, library Y-up).
+        rad = math.radians(symbol.rotation)
+        cos_r = math.cos(rad)
+        sin_r = math.sin(rad)
+        rvx = vx * cos_r - vy * sin_r
+        rvy = vx * sin_r + vy * cos_r
+
+        # Convert library Y-up to schematic Y-down by negating the Y component,
+        # mirroring pin_position()'s ``ry = -ry`` flip.
+        rvy = -rvy
+
+        # Snap to the nearest cardinal direction (schematic Y-down space).
+        best_dir = "right"
+        best_dot = float("-inf")
+        for name, (ux, uy) in _DIRECTION_VECTORS.items():
+            dot = rvx * ux + rvy * uy
+            if dot > best_dot:
+                best_dot = dot
+                best_dir = name
+        return best_dir
+
+    def _stub_would_collide(
+        self,
+        start: tuple[float, float],
+        end: tuple[float, float],
+        net: str,
+    ) -> bool:
+        """Return True if a stub segment would union with a foreign-net wire.
+
+        A collision is a :func:`wire_segments_connect` overlap or T-touch with
+        an existing wire that independently carries at least one *named* net
+        different from ``net``.  Same-net overlaps (and overlaps with unnamed
+        wires) are allowed -- they merge into the intended net, which is the
+        expected stub-fanout behaviour and NOT the issue #4143 short.
+        """
+        # Collect the net names attached to each existing wire (a label / power
+        # symbol sitting on the wire within POINT_TOLERANCE), mirroring
+        # ``_wire_net_names`` but computed locally so this method does not
+        # depend on the validation mixin's private helper.
+        # ``wires``/``labels``/... live on the concrete ``Schematic`` that mixes
+        # this in, so mypy cannot see them from the mixin body (false positive).
+        named_points: list[tuple[float, float, str]] = []
+        for label in self.labels:  # type: ignore[attr-defined]
+            named_points.append((label.x, label.y, label.text))
+        for gl in self.global_labels:  # type: ignore[attr-defined]
+            named_points.append((gl.x, gl.y, gl.text))
+        for hl in self.hier_labels:  # type: ignore[attr-defined]
+            named_points.append((hl.x, hl.y, hl.text))
+        for pwr in self.power_symbols:  # type: ignore[attr-defined]
+            pwr_net = pwr.lib_id.split(":")[1] if ":" in pwr.lib_id else pwr.lib_id
+            named_points.append((pwr.x, pwr.y, pwr_net))
+
+        for wire in self.wires:  # type: ignore[attr-defined]
+            names = {name for x, y, name in named_points if self._point_on_wire(x, y, wire)}
+            # Only wires carrying a *different* named net matter.  A wire whose
+            # only named net is ``net`` (or that is unnamed) is allowed to
+            # overlap -- that is intended same-net fanout, not a #4143 short.
+            if names <= {net}:
+                continue
+            if wire_segments_connect((wire.x1, wire.y1), (wire.x2, wire.y2), start, end):
+                return True
+        return False
+
+    def add_stub_label(
+        self,
+        symbol: SymbolInstance,
+        pin: str,
+        net: str,
+        *,
+        length: float = 2.54,
+        direction: str | None = None,
+        snap: bool = True,
+    ) -> tuple[Wire, Label]:
+        """Place a collision-aware stub wire + net label at a symbol pin.
+
+        Draws a short stub wire outward from ``symbol``'s ``pin`` and anchors a
+        net label at the stub's far endpoint (KiCad requires labels to sit on a
+        wire endpoint to establish connectivity).  Unlike the hand-rolled
+        stub+label idiom in ``blocks/motor.py`` and ``blocks/_stub_helpers.py``,
+        the stub direction is derived from the pin's ``angle`` rotated by the
+        symbol's ``rotation`` (not a fixed side), and a bounded, deterministic
+        candidate search avoids collinearly overlapping a neighboring stub that
+        carries a *different* net -- the silent net-merge failure mode fixed by
+        issue #4143.
+
+        The candidate search order is deterministic (same input -> same chosen
+        stub, for reproducible generator output):
+
+        1. Outward direction at ``length``.
+        2. Outward direction at ``length * 2`` (reach past the obstruction).
+        3. Outward direction at ``length / 2`` (pull back before it).
+        4. The two perpendicular directions at ``length`` (a small jog).
+        5. The opposite direction at ``length`` (last resort).
+
+        A candidate is rejected when its stub segment would union (via
+        :func:`wire_segments_connect`) with an existing wire that independently
+        carries a different named net.  If *every* candidate collides, a
+        :class:`StubPlacementError` is raised (no wire/label is appended) --
+        silently placing a colliding stub is exactly the bug this helper
+        exists to eliminate.
+
+        Args:
+            symbol: The placed symbol instance owning the pin.
+            pin: Pin name or number (passed through to the symbol's fuzzy pin
+                lookup; raises ``PinNotFoundError`` for an unknown pin).
+            net: Net label text to attach at the stub endpoint.
+            length: Stub length in mm (default ``2.54`` = one KiCad grid step).
+            direction: Optional override (``"left"``/``"right"``/``"up"``/
+                ``"down"``).  When ``None`` (default) the outward direction is
+                computed from the pin angle + symbol rotation.  An explicit
+                direction still runs the collision search.
+            snap: Whether to grid-snap the created wire/label (default True).
+
+        Returns:
+            ``(wire, label)`` -- the created :class:`Wire` and :class:`Label`.
+            Both are appended to ``self.wires`` / ``self.labels``.  Callers who
+            only need the endpoint can read ``label.x, label.y``.
+
+        Raises:
+            StubPlacementError: If no candidate stub avoids collision.
+            PinNotFoundError: If ``pin`` does not exist on ``symbol``.
+            ValueError: If an explicit ``direction`` is not a cardinal name.
+        """
+        if direction is not None and direction not in _DIRECTION_VECTORS:
+            raise ValueError(
+                f"direction must be one of {sorted(_DIRECTION_VECTORS)} or None, got {direction!r}"
+            )
+
+        raw_pin_pos = symbol.pin_position(pin)
+        primary = direction if direction is not None else self._pin_outward_direction(symbol, pin)
+
+        # Snap the stub start once so the collision search and the placed wire
+        # share identical geometry (otherwise ``add_wire``'s own snapping could
+        # shift an endpoint onto a foreign wire the search didn't see).  The
+        # stub start stays coincident with the pin under normal on-grid symbol
+        # placement; we pass ``snap=False`` downstream since we snap here.
+        if snap:
+            pin_pos = self._snap_point(raw_pin_pos, "stub start")
+        else:
+            pin_pos = (round(raw_pin_pos[0], 2), round(raw_pin_pos[1], 2))
+
+        def _endpoint(dir_name: str, dist: float) -> tuple[float, float]:
+            ux, uy = _DIRECTION_VECTORS[dir_name]
+            end = (raw_pin_pos[0] + ux * dist, raw_pin_pos[1] + uy * dist)
+            if snap:
+                return self._snap_point(end, "stub end")
+            return (round(end[0], 2), round(end[1], 2))
+
+        # Bounded, deterministic candidate list: (direction, length).
+        candidates: list[tuple[str, float]] = [
+            (primary, length),
+            (primary, length * 2.0),
+            (primary, length / 2.0),
+        ]
+        for perp in _PERPENDICULAR[primary]:
+            candidates.append((perp, length))
+        candidates.append((_OPPOSITE_DIRECTION[primary], length))
+
+        tried: list[tuple[float, float]] = []
+        for dir_name, dist in candidates:
+            # Floor guard: a stub shorter than the snap tolerance is useless.
+            if dist <= self.POINT_TOLERANCE:
+                continue
+            end = _endpoint(dir_name, dist)
+            # A degenerate stub (endpoint snapped back onto the start) is not a
+            # usable candidate.
+            if end == pin_pos:
+                continue
+            tried.append(end)
+            if self._stub_would_collide(pin_pos, end, net):
+                continue
+
+            wire = self.add_wire(pin_pos, end, snap=False, warn_on_collision=False)
+            label = self.add_label(
+                net,
+                end[0],
+                end[1],
+                rotation=_DIRECTION_LABEL_ROTATION[dir_name],
+                snap=False,
+                validate_connection=False,
+            )
+            return wire, label
+
+        raise StubPlacementError(pin_position=pin_pos, net=net, tried_endpoints=tried)
 
     def add_hier_label(
         self,

--- a/src/kicad_tools/schematic/models/symbol.py
+++ b/src/kicad_tools/schematic/models/symbol.py
@@ -584,18 +584,23 @@ class SymbolInstance:
     footprint: str = ""
     properties: dict[str, str] = field(default_factory=dict)
 
-    def pin_position(self, pin_name_or_number: str) -> tuple[float, float]:
-        """Get absolute position of a pin after placement and rotation.
+    def find_pin(self, pin_name_or_number: str) -> Pin:
+        """Resolve a pin name/number to its :class:`Pin` on this instance.
+
+        Shares the exact-match / unit-aware / case-insensitive / alias /
+        fuzzy-suggestion machinery used by :meth:`pin_position`, so callers
+        that need the pin object itself (e.g. its ``angle`` for outward stub
+        direction, issue #4161) do not reimplement the lookup.
 
         Args:
             pin_name_or_number: Pin name (e.g., "SCK") or number (e.g., "20")
 
         Returns:
-            (x, y) tuple of absolute pin position, rounded to 2 decimal places
+            The matching :class:`Pin`.
 
         Raises:
             PinNotFoundError: If no pin matches the given name/number, with
-                suggestions for similar pin names
+                suggestions for similar pin names.
         """
 
         # Find the pin by exact match on name or number.  For multi-unit
@@ -679,6 +684,23 @@ class SymbolInstance:
                 available_pins=self.symbol_def.pins,
                 suggestions=suggestions,
             )
+
+        return pin
+
+    def pin_position(self, pin_name_or_number: str) -> tuple[float, float]:
+        """Get absolute position of a pin after placement and rotation.
+
+        Args:
+            pin_name_or_number: Pin name (e.g., "SCK") or number (e.g., "20")
+
+        Returns:
+            (x, y) tuple of absolute pin position, rounded to 2 decimal places
+
+        Raises:
+            PinNotFoundError: If no pin matches the given name/number, with
+                suggestions for similar pin names
+        """
+        pin = self.find_pin(pin_name_or_number)
 
         # Get the wire connection point (end of pin) in symbol-local coordinates.
         # KiCad library symbols store pin positions in Y-UP coordinates (math

--- a/tests/test_schematic_models.py
+++ b/tests/test_schematic_models.py
@@ -2937,6 +2937,239 @@ class TestCollinearNetConflict:
         assert conflicts == []
 
 
+def _stub_symbol(
+    pins: list[tuple[str, str, float, float, float]],
+    x: float,
+    y: float,
+    ref: str,
+    rotation: float = 0,
+    lib_id: str = "Device:R",
+) -> SymbolInstance:
+    """Build a synthetic SymbolInstance for add_stub_label tests.
+
+    ``pins`` entries are (name, number, x, y, angle) in library Y-up coords.
+    """
+    sd = SymbolDef(
+        lib_id=lib_id,
+        name=lib_id.split(":")[-1],
+        raw_sexp="",
+        pins=[
+            Pin(name=n, number=num, x=px, y=py, angle=a, length=2.54, pin_type="passive")
+            for n, num, px, py, a in pins
+        ],
+    )
+    return SymbolInstance(symbol_def=sd, x=x, y=y, rotation=rotation, reference=ref, value="10k")
+
+
+class TestAddStubLabel:
+    """Tests for the collision-aware ``add_stub_label`` helper (issue #4161)."""
+
+    # A horizontal resistor: pin 1 at library (-2.54, 0) angle=0 (into body =
+    # right, so outward = left); pin 2 at (2.54, 0) angle=180 (outward = right).
+    _R_PINS = [("~", "1", -2.54, 0, 0), ("~", "2", 2.54, 0, 180)]
+
+    def test_happy_path_single_pin(self):
+        """A stub in open space appends a wire+label with the label on the wire end."""
+        sch = Schematic(title="T", snap_mode=SnapMode.OFF)
+        r1 = _stub_symbol(self._R_PINS, 100.0, 100.0, "R1")
+        sch.symbols.append(r1)
+
+        wire, label = sch.add_stub_label(r1, "1", "NET_A")
+
+        assert wire in sch.wires
+        assert label in sch.labels
+        # Label sits on the wire's far endpoint.
+        assert (label.x, label.y) == (wire.x2, wire.y2)
+        # Wire starts at the pin.
+        assert (wire.x1, wire.y1) == r1.pin_position("1")
+        conflicts = [i for i in sch.validate() if i["type"] == "collinear_net_conflict"]
+        assert conflicts == []
+
+    def test_default_length_is_one_grid_step(self):
+        """Default stub length is 2.54 mm; overridable via length=."""
+        sch = Schematic(title="T", snap_mode=SnapMode.OFF)
+        r1 = _stub_symbol(self._R_PINS, 100.0, 100.0, "R1")
+        sch.symbols.append(r1)
+
+        wire, _ = sch.add_stub_label(r1, "1", "NET_A")
+        length = abs(wire.x2 - wire.x1) + abs(wire.y2 - wire.y1)
+        assert length == pytest.approx(2.54)
+
+        wire2, _ = sch.add_stub_label(r1, "2", "NET_B", length=5.08)
+        length2 = abs(wire2.x2 - wire2.x1) + abs(wire2.y2 - wire2.y1)
+        assert length2 == pytest.approx(5.08)
+
+    def test_direction_from_pin_angle_zero_rotation(self):
+        """Outward direction follows pin angle (not into the symbol body)."""
+        sch = Schematic(title="T", snap_mode=SnapMode.OFF)
+        r1 = _stub_symbol(self._R_PINS, 100.0, 100.0, "R1")
+        sch.symbols.append(r1)
+
+        # Pin 1 (angle 0, outward = left): stub extends to smaller x.
+        w1, _ = sch.add_stub_label(r1, "1", "NET_A")
+        assert w1.x2 < w1.x1
+        assert w1.y2 == pytest.approx(w1.y1)
+
+        # Pin 2 (angle 180, outward = right): stub extends to larger x.
+        w2, _ = sch.add_stub_label(r1, "2", "NET_B")
+        assert w2.x2 > w2.x1
+        assert w2.y2 == pytest.approx(w2.y1)
+
+    def test_direction_rotates_with_symbol_90(self):
+        """Rotation-aware: a 90 deg symbol rotation rotates the stub direction.
+
+        This is the critical guard: an implementation that ignores
+        symbol.rotation passes the 0 deg case but fails here.
+        """
+        sch = Schematic(title="T", snap_mode=SnapMode.OFF)
+        r0 = _stub_symbol(self._R_PINS, 100.0, 100.0, "R0", rotation=0)
+        r90 = _stub_symbol(self._R_PINS, 130.0, 100.0, "R90", rotation=90)
+        sch.symbols.extend([r0, r90])
+
+        # At 0 deg, pin 1 stubs horizontally (left).
+        assert sch._pin_outward_direction(r0, "1") == "left"
+        # At 90 deg CCW (library) + Y-flip to schematic, that left becomes down.
+        assert sch._pin_outward_direction(r90, "1") == "down"
+
+        w90, _ = sch.add_stub_label(r90, "1", "NET_R90")
+        # Vertical stub (x unchanged, y increases = downward in schematic space).
+        assert w90.x2 == pytest.approx(w90.x1)
+        assert w90.y2 > w90.y1
+
+    def test_4143_repro_via_add_stub_label_no_merge(self):
+        """The #4143 geometry built via add_stub_label yields distinct nets.
+
+        Two resistors ~8 mm apart, each pin stub-labelled with a *different*
+        net. The naive hand-rolled version overlapped collinearly and merged;
+        the helper's collision avoidance keeps them distinct.
+        """
+        sch = Schematic(title="T", snap_mode=SnapMode.OFF)
+        # R1 pin 2 at (102.54,100) stubs right toward R2; R2 pin 1 at
+        # (107.46,100) stubs left toward R1 — the naive both-2.54 stubs would
+        # overlap on y=100 across [105.08, 105.08]... place them closer to force
+        # the search only in the dedicated forced-collision test; here assert
+        # the outcome is clean regardless.
+        r1 = _stub_symbol(self._R_PINS, 100.0, 100.0, "R1")
+        r2 = _stub_symbol(self._R_PINS, 108.0, 100.0, "R2")
+        sch.symbols.extend([r1, r2])
+
+        sch.add_stub_label(r1, "2", "NET_A")
+        sch.add_stub_label(r2, "1", "NET_B")
+
+        conflicts = [i for i in sch.validate() if i["type"] == "collinear_net_conflict"]
+        assert conflicts == []
+
+        netlist = sch.extract_netlist()
+        net_a = sch.get_net_for_pin("R1", "2")
+        net_b = sch.get_net_for_pin("R2", "1")
+        assert net_a != net_b
+        assert "NET_A" in netlist
+        assert "NET_B" in netlist
+
+    def test_forced_collision_selects_alternative(self):
+        """When the default candidate collides, the search picks another."""
+        sch = Schematic(title="T", snap_mode=SnapMode.OFF)
+        r1 = _stub_symbol(self._R_PINS, 100.0, 100.0, "R1")
+        sch.symbols.append(r1)
+
+        # Pre-place a foreign-net wire+label exactly where R1 pin 2's default
+        # rightward 2.54 stub would land, so the primary candidate collides.
+        pin2 = r1.pin_position("2")  # (102.54, 100)
+        sch.wires.append(Wire(x1=pin2[0], y1=pin2[1], x2=pin2[0] + 2.54, y2=pin2[1]))
+        sch.labels.append(Label(text="FOREIGN", x=pin2[0] + 2.54, y=pin2[1]))
+
+        naive_end = (pin2[0] + 2.54, pin2[1])
+        wire, label = sch.add_stub_label(r1, "2", "NET_B")
+
+        # The chosen candidate differs from the naive primary endpoint.
+        assert (wire.x2, wire.y2) != naive_end
+        conflicts = [i for i in sch.validate() if i["type"] == "collinear_net_conflict"]
+        assert conflicts == []
+
+    def test_no_solution_raises_and_leaves_no_partial_state(self):
+        """Boxing a pin in on all sides raises StubPlacementError, no side effects."""
+        from kicad_tools.schematic.exceptions import StubPlacementError
+
+        sch = Schematic(title="T", snap_mode=SnapMode.OFF)
+        r1 = _stub_symbol(self._R_PINS, 100.0, 100.0, "R1")
+        sch.symbols.append(r1)
+        px, py = r1.pin_position("2")  # (102.54, 100)
+
+        # Occupy every candidate direction (default + 2x + perpendiculars +
+        # opposite) with foreign-net wires that pass through the pin so any
+        # stub from it collinearly overlaps or T-touches.
+        for x2, y2 in [
+            (px + 6.0, py),  # right (covers 2.54, 5.08, opposite crossings)
+            (px - 6.0, py),  # left / opposite
+            (px, py + 6.0),  # down
+            (px, py - 6.0),  # up
+        ]:
+            w = Wire(x1=px, y1=py, x2=x2, y2=y2)
+            sch.wires.append(w)
+            sch.labels.append(Label(text=f"F_{x2}_{y2}", x=x2, y=y2))
+
+        n_wires = len(sch.wires)
+        n_labels = len(sch.labels)
+        with pytest.raises(StubPlacementError) as exc:
+            sch.add_stub_label(r1, "2", "NET_B")
+
+        # Message identifies the net and lists tried endpoints.
+        assert "NET_B" in str(exc.value)
+        assert exc.value.net == "NET_B"
+        assert exc.value.tried_endpoints
+        # No partial state appended on the raising path.
+        assert len(sch.wires) == n_wires
+        assert len(sch.labels) == n_labels
+
+    def test_same_net_overlap_is_allowed(self):
+        """A same-net overlap does not trigger the search or raise."""
+        sch = Schematic(title="T", snap_mode=SnapMode.OFF)
+        r1 = _stub_symbol(self._R_PINS, 100.0, 100.0, "R1")
+        sch.symbols.append(r1)
+        px, py = r1.pin_position("2")
+
+        # Foreign wire carrying the SAME net right where the default stub lands.
+        sch.wires.append(Wire(x1=px, y1=py, x2=px + 2.54, y2=py))
+        sch.labels.append(Label(text="NET_B", x=px + 2.54, y=py))
+
+        # Default rightward candidate overlaps a SAME-net wire -> allowed, so
+        # the primary candidate is chosen (no jog to an alternative).
+        wire, label = sch.add_stub_label(r1, "2", "NET_B")
+        assert wire.x2 == pytest.approx(px + 2.54)
+        assert wire.y2 == pytest.approx(py)
+        conflicts = [i for i in sch.validate() if i["type"] == "collinear_net_conflict"]
+        assert conflicts == []
+
+    def test_explicit_direction_override(self):
+        """An explicit direction skips angle derivation but still searches."""
+        sch = Schematic(title="T", snap_mode=SnapMode.OFF)
+        r1 = _stub_symbol(self._R_PINS, 100.0, 100.0, "R1")
+        sch.symbols.append(r1)
+
+        wire, _ = sch.add_stub_label(r1, "1", "NET_A", direction="up")
+        assert wire.x2 == pytest.approx(wire.x1)
+        assert wire.y2 < wire.y1  # up = smaller y in schematic space
+
+    def test_invalid_direction_raises(self):
+        """A non-cardinal explicit direction is a ValueError."""
+        sch = Schematic(title="T", snap_mode=SnapMode.OFF)
+        r1 = _stub_symbol(self._R_PINS, 100.0, 100.0, "R1")
+        sch.symbols.append(r1)
+        with pytest.raises(ValueError, match="direction"):
+            sch.add_stub_label(r1, "1", "NET_A", direction="northeast")
+
+    def test_returns_wire_and_label_types(self):
+        """Return value is (Wire, Label)."""
+        sch = Schematic(title="T", snap_mode=SnapMode.OFF)
+        r1 = _stub_symbol(self._R_PINS, 100.0, 100.0, "R1")
+        sch.symbols.append(r1)
+        result = sch.add_stub_label(r1, "1", "NET_A")
+        assert isinstance(result, tuple) and len(result) == 2
+        wire, label = result
+        assert isinstance(wire, Wire)
+        assert isinstance(label, Label)
+
+
 class TestSymbolDefParsing:
     """Tests for SymbolDef parsing methods."""
 


### PR DESCRIPTION
## Summary

Adds a built-in `Schematic.add_stub_label(symbol, pin, net)` helper that draws a short stub wire outward from a symbol pin and anchors a net label at its far endpoint, with **rotation-aware** outward direction and a **bounded, deterministic collision search** that avoids collinearly overlapping a neighboring stub carrying a *different* net — the silent net-merge failure mode fixed by #4143. This generalizes and supersedes the hand-rolled stub+label idioms in `blocks/motor.py` and `blocks/_stub_helpers.py`.

Item 3 of #4143 (deferred by the curator as purely additive).

## Changes

- **`elements_mixin.py`**: new `add_stub_label(symbol, pin, net, *, length=2.54, direction=None, snap=True) -> tuple[Wire, Label]`. Chose `SchematicElementsMixin` (next to `add_wire`/`add_label`) over `wiring_mixin.py` since the helper is fundamentally an element-creation primitive that composes those two methods.
  - Outward direction computed from `Pin.angle` (opposite of into-body angle) rotated by `SymbolInstance.rotation` via the same CCW-then-Y-flip transform `pin_position()` uses, snapped to the nearest cardinal.
  - Deterministic candidate order: outward @ `length`, outward @ `length*2`, outward @ `length/2`, the two perpendicular jogs @ `length`, then opposite @ `length` (<=6 candidates).
  - Collision = `wire_segments_connect()` overlap/T-touch with an existing wire independently carrying a *different* named net (net-name extraction mirrors `_wire_net_names` locally to avoid depending on the validation mixin's private helper). Same-net and unnamed overlaps are allowed.
  - Passes `warn_on_collision=False` to `add_wire` (does its own pre-flight search); snaps geometry once so the search and placed wire share identical coordinates. On the no-solution path raises before appending anything (no partial state).
- **`symbol.py`**: extract `SymbolInstance.find_pin()` from `pin_position()` so the helper reuses the existing exact/unit-aware/alias/fuzzy pin lookup instead of reimplementing it; `pin_position()` now calls it.
- **`exceptions.py`**: new `StubPlacementError(ValueError)` (subclasses `ValueError` for continuity with the `_emit_pin_net_stub` precedent) carrying `pin_position`, `net`, and `tried_endpoints` in the message.
- **`tests/test_schematic_models.py`**: new `TestAddStubLabel` (11 cases).
- Two `# type: ignore[attr-defined]` on mixin references to `self.wires`/`labels`/... (genuine false positives — those live on the concrete `Schematic`; the same references pre-exist in the mypy baseline). No baseline changes.

`_stub_helpers.py` callers are intentionally **not** migrated (out of scope per the issue).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `add_stub_label` exists on `Schematic` | ✅ | `SchematicElementsMixin.add_stub_label`; `test_happy_path_single_pin` |
| Direction from pin angle + rotation (0° & 90°) | ✅ | `test_direction_from_pin_angle_zero_rotation`, `test_direction_rotates_with_symbol_90` |
| Default length 2.54mm, `length=` override | ✅ | `test_default_length_is_one_grid_step` |
| #4143 repro via helper → 0 conflicts, distinct nets | ✅ | `test_4143_repro_via_add_stub_label_no_merge` (asserts `validate()` clean + `extract_netlist` distinct) |
| Forced-collision picks non-naive alternative | ✅ | `test_forced_collision_selects_alternative` |
| No-solution raises, no partial state | ✅ | `test_no_solution_raises_and_leaves_no_partial_state` |
| Return `(Wire, Label)` present in `sch.wires`/`sch.labels` | ✅ | `test_returns_wire_and_label_types`, `test_happy_path_single_pin` |
| Same-net overlap allowed (no raise/search) | ✅ | `test_same_net_overlap_is_allowed` |
| No regression in named suites | ✅ | 288 passed across the 3 suites |

## Test Plan

- `uv run pytest tests/test_schematic_models.py tests/test_pin_nets_stub_collision.py tests/test_netlist_query.py` → **288 passed**
- `TestAddStubLabel` (11) + `tests/test_pin_nets_stub_collision.py` (11) → **22 passed**
- `ruff check` + `ruff format --check` on changed files → clean
- `uv run --extra dev python scripts/ci/check_mypy_baseline.py` → **exit 0, 0 NEW errors** (pre-existing "39 no longer occur" warning is unchanged from clean main)

Closes #4161