### PR TITLE
feat(router): add pure boundary stub-terminal detector

### DIFF
--- a/src/kicad_tools/router/stub_terminals.py
+++ b/src/kicad_tools/router/stub_terminals.py
@@ -1,0 +1,283 @@
+"""Boundary stub-terminal detection for region-bounded routing (Phase 2b-0).
+
+When ``pcb strip --region`` clips traces at a routing-region boundary
+(``schema/pcb.py`` boundary-crossing branch, lines ~5200-5227), every
+boundary-crossing segment is rewritten so that its *inside* endpoint moves
+onto the region boundary while its *outside* endpoint is retained unchanged.
+The result is a bare copper "stub" that runs boundary -> outside with no pad
+at the boundary end. Phase 2a's inclusive-box routing has no abstraction for
+these bare stub endpoints, so nets that own pads both inside and outside the
+region cannot be reconnected to the pre-existing external copper.
+
+This module provides the *single shared producer* that both pad-sourcing
+surfaces (``Autorouter`` and ``RoutingOrchestrator``) will consume in later
+phases (#4170 / #4173), so stub geometry is never re-derived independently
+(the #3428 foot-gun). It is intentionally **pure**: it holds no grid or router
+state and takes all segment/pad/net data as plain arguments.
+
+The clipped-geometry UUID map that ``strip_traces`` builds is ephemeral and is
+not persisted on ``PCB``, so this detector deliberately re-derives stub
+endpoints from *loaded* segments rather than querying the PCB for "which
+segments are stubs" -- this is by design (see the note in #4172 / #4170).
+
+``StubTerminal`` objects are **route-scoped and ephemeral**: they are never a
+``Pad`` and must never be inserted into ``Autorouter.pads`` / ``nets``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+from kicad_tools.core.types import CopperLayer
+
+# Proximity tolerance in millimeters. Mirrors the local ``EPSILON = 0.01``
+# used by ``core.py::_index_block_internal_traces`` (defined there as a
+# function-local variable, so it cannot be imported by name). Matching the
+# value and its semantic role -- pad/endpoint proximity tolerance -- keeps the
+# stub detector consistent with the router's existing coincidence checks.
+EPSILON = 0.01
+
+
+class BoundaryEdge(Enum):
+    """Which edge of the rectangular routing region a stub endpoint lies on.
+
+    Recorded on :class:`StubTerminal` for the detector's own correctness
+    checks and downstream diagnostics; it is not a routing input.
+    """
+
+    LEFT = "left"
+    RIGHT = "right"
+    TOP = "top"
+    BOTTOM = "bottom"
+
+
+@dataclass(frozen=True)
+class RegionBox:
+    """Axis-aligned routing region in board-relative millimeters.
+
+    Endpoints are classified against ``[x1, x2] x [y1, y2]``. The box is
+    normalized on construction so ``x1 <= x2`` and ``y1 <= y2`` regardless of
+    the order the corners are supplied in.
+    """
+
+    x1: float
+    y1: float
+    x2: float
+    y2: float
+
+    def __post_init__(self) -> None:
+        if self.x1 > self.x2:
+            lo, hi = self.x2, self.x1
+            object.__setattr__(self, "x1", lo)
+            object.__setattr__(self, "x2", hi)
+        if self.y1 > self.y2:
+            lo, hi = self.y2, self.y1
+            object.__setattr__(self, "y1", lo)
+            object.__setattr__(self, "y2", hi)
+
+    def contains(self, x: float, y: float) -> bool:
+        """Inclusive membership test (matches Phase 2a's inclusive box)."""
+        return self.x1 <= x <= self.x2 and self.y1 <= y <= self.y2
+
+    def contains_strict(self, x: float, y: float, epsilon: float = EPSILON) -> bool:
+        """Strictly-inside test: inside the box and not on/near any edge.
+
+        Used to decide whether the *other* endpoint of a stub segment is
+        strictly OUTSIDE the region. An endpoint sitting on the boundary line
+        (within ``epsilon``) is treated as on-boundary, not strictly inside.
+        """
+        return (
+            self.x1 + epsilon < x < self.x2 - epsilon and self.y1 + epsilon < y < self.y2 - epsilon
+        )
+
+
+@dataclass(frozen=True)
+class StubSegment:
+    """A loaded copper segment, reduced to what the detector needs.
+
+    Callers (``Autorouter`` / ``RoutingOrchestrator``) adapt their own segment
+    representation -- e.g. ``schema.pcb.Segment`` or ``router.primitives.Segment``
+    -- into this plain-data shape so the detector stays router-agnostic and
+    pure. Coordinates are board-relative millimeters.
+    """
+
+    net_id: int
+    net_name: str
+    x1: float
+    y1: float
+    x2: float
+    y2: float
+    layer: CopperLayer
+    uuid: str | None = None
+
+
+@dataclass(frozen=True)
+class PadLocation:
+    """Center of a pad or via, used only for coincidence rejection.
+
+    A stub endpoint that coincides (within :data:`EPSILON`) with any pad/via
+    center routes "for free" under Phase 2a's inclusive box test and is not a
+    stub terminal.
+    """
+
+    net_id: int
+    x: float
+    y: float
+
+
+@dataclass
+class StubTerminal:
+    """A bare copper stub endpoint on the region boundary to be reconnected.
+
+    Route-scoped and ephemeral: NEVER a ``Pad``, and never inserted into
+    ``Autorouter.pads`` / ``nets``. ``source_segment_uuid`` and
+    ``boundary_edge`` are provenance for the detector's own correctness checks
+    and downstream diagnostics.
+    """
+
+    net_id: int
+    net_name: str
+    x: float
+    y: float
+    layer: CopperLayer
+    source_segment_uuid: str | None = None
+    boundary_edge: BoundaryEdge | None = field(default=None)
+
+
+def _edge_for_point(x: float, y: float, region: RegionBox, epsilon: float) -> BoundaryEdge | None:
+    """Return the region edge a point lies on, or ``None``.
+
+    A point is "on the boundary line" when it is within ``epsilon`` of one of
+    the four edge lines AND within the box's extent along that edge (so a point
+    far off the end of an edge line does not count). When a point is near a
+    corner it may satisfy two edges; the nearer edge is chosen deterministically.
+    """
+    # Must be within the (epsilon-expanded) box extent to be "on" the boundary.
+    if not (
+        region.x1 - epsilon <= x <= region.x2 + epsilon
+        and region.y1 - epsilon <= y <= region.y2 + epsilon
+    ):
+        return None
+
+    # Distance to each edge line, considering only edges whose span the point
+    # falls within (with epsilon slack at the corners).
+    candidates: list[tuple[float, BoundaryEdge]] = []
+    on_x_span = region.x1 - epsilon <= x <= region.x2 + epsilon
+    on_y_span = region.y1 - epsilon <= y <= region.y2 + epsilon
+    if on_y_span:
+        candidates.append((abs(x - region.x1), BoundaryEdge.LEFT))
+        candidates.append((abs(x - region.x2), BoundaryEdge.RIGHT))
+    if on_x_span:
+        candidates.append((abs(y - region.y1), BoundaryEdge.TOP))
+        candidates.append((abs(y - region.y2), BoundaryEdge.BOTTOM))
+
+    best: tuple[float, BoundaryEdge] | None = None
+    for dist, edge in candidates:
+        if dist <= epsilon and (best is None or dist < best[0]):
+            best = (dist, edge)
+    return best[1] if best is not None else None
+
+
+def _coincident_with_pad(x: float, y: float, pads: list[PadLocation], epsilon: float) -> bool:
+    """True if ``(x, y)`` is within ``epsilon`` of any pad/via center."""
+    eps_sq = epsilon * epsilon
+    for pad in pads:
+        dx = pad.x - x
+        dy = pad.y - y
+        if dx * dx + dy * dy <= eps_sq:
+            return True
+    return False
+
+
+def detect_boundary_stub_terminals(
+    segments: list[StubSegment],
+    pads: list[PadLocation],
+    region: RegionBox,
+    *,
+    epsilon: float = EPSILON,
+) -> dict[int, list[StubTerminal]]:
+    """Detect bare boundary stub endpoints that need reconnection.
+
+    Pure function -- no grid, no router, no ``PCB`` state. Both ``Autorouter``
+    and ``RoutingOrchestrator`` can call it identically by adapting their data
+    into :class:`StubSegment` / :class:`PadLocation`.
+
+    A segment endpoint is a boundary stub terminal when ALL of the following
+    hold (the four-part detection spec from the #4170 design):
+
+    1. The endpoint lies on the region-boundary line within ``epsilon``.
+    2. The segment's OTHER endpoint is strictly OUTSIDE the region (surviving
+       clipped stubs always run boundary -> outside).
+    3. The endpoint is NOT coincident (within ``epsilon``) with any pad/via
+       center (such endpoints route "for free" under Phase 2a's inclusive box).
+    4. The endpoint's net has pad(s) OUTSIDE the region AND at least one pad
+       INSIDE it (exactly the nets Phase 2a currently fails to reconnect).
+
+    Args:
+        segments: Loaded copper segments (board-relative mm), adapted to
+            :class:`StubSegment`.
+        pads: Pad/via centers (board-relative mm), adapted to
+            :class:`PadLocation`. Used both for coincidence rejection (part 3)
+            and for the per-net inside/outside census (part 4).
+        region: The routing region box (board-relative mm).
+        epsilon: Proximity tolerance in mm (defaults to :data:`EPSILON`).
+
+    Returns:
+        Mapping of ``net_id -> list[StubTerminal]``. Nets with no detected
+        stub terminals are omitted. Terminals are returned in input-segment
+        order for determinism.
+    """
+    # Part 4 precondition: per-net census of pads inside vs. outside the region.
+    # A pad exactly on the boundary counts as inside (inclusive box), matching
+    # Phase 2a semantics.
+    nets_with_pad_inside: set[int] = set()
+    nets_with_pad_outside: set[int] = set()
+    for pad in pads:
+        if region.contains(pad.x, pad.y):
+            nets_with_pad_inside.add(pad.net_id)
+        else:
+            nets_with_pad_outside.add(pad.net_id)
+    eligible_nets = nets_with_pad_inside & nets_with_pad_outside
+
+    result: dict[int, list[StubTerminal]] = {}
+
+    for seg in segments:
+        # Part 4: only nets that straddle the boundary can produce a stub that
+        # needs reconnection.
+        if seg.net_id not in eligible_nets:
+            continue
+
+        # Evaluate both endpoints; a clipped stub places the boundary end at
+        # exactly one endpoint, with the other strictly outside.
+        for bx, by, ox, oy in (
+            (seg.x1, seg.y1, seg.x2, seg.y2),
+            (seg.x2, seg.y2, seg.x1, seg.y1),
+        ):
+            # Part 1: boundary endpoint on the region-boundary line.
+            edge = _edge_for_point(bx, by, region, epsilon)
+            if edge is None:
+                continue
+
+            # Part 2: the OTHER endpoint must be strictly outside the region.
+            if region.contains(ox, oy) or _edge_for_point(ox, oy, region, epsilon):
+                # Other endpoint is inside or itself on the boundary -> not a
+                # boundary -> outside stub.
+                continue
+
+            # Part 3: boundary endpoint not coincident with any pad/via center.
+            if _coincident_with_pad(bx, by, pads, epsilon):
+                continue
+
+            terminal = StubTerminal(
+                net_id=seg.net_id,
+                net_name=seg.net_name,
+                x=bx,
+                y=by,
+                layer=seg.layer,
+                source_segment_uuid=seg.uuid,
+                boundary_edge=edge,
+            )
+            result.setdefault(seg.net_id, []).append(terminal)
+
+    return result

--- a/tests/router/test_stub_terminals.py
+++ b/tests/router/test_stub_terminals.py
@@ -1,0 +1,308 @@
+"""Tests for Issue #4172: boundary stub-terminal detection (Phase 2b-0).
+
+``detect_boundary_stub_terminals`` is a *pure* function (no grid/router/PCB
+state). These tests feed hand-built clipped segments and pad locations
+directly to the detector -- no chorus fixture, no full ``PCB`` round-trip --
+which is the right level of isolation for a pure-function unit.
+
+The detector implements the four-part spec from the #4170 design:
+
+1. endpoint on the region-boundary line within ``EPSILON``
+2. the segment's OTHER endpoint strictly OUTSIDE the region
+3. endpoint NOT coincident with any pad/via center (within ``EPSILON``)
+4. net has pad(s) OUTSIDE the region AND >=1 pad INSIDE
+
+Each negative case below isolates the failure of exactly one part.
+"""
+
+from __future__ import annotations
+
+from kicad_tools.core.types import CopperLayer
+from kicad_tools.router.stub_terminals import (
+    EPSILON,
+    BoundaryEdge,
+    PadLocation,
+    RegionBox,
+    StubSegment,
+    StubTerminal,
+    detect_boundary_stub_terminals,
+)
+
+# A simple 10x10 region at the origin used throughout.
+REGION = RegionBox(0.0, 0.0, 10.0, 10.0)
+
+
+def _straddling_pads(net_id: int) -> list[PadLocation]:
+    """Pads for a net that owns copper both inside and outside REGION."""
+    return [
+        PadLocation(net_id=net_id, x=5.0, y=5.0),  # inside
+        PadLocation(net_id=net_id, x=20.0, y=5.0),  # outside
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# Positive detection cases
+# --------------------------------------------------------------------------- #
+
+
+def test_detects_stub_on_right_edge():
+    """A boundary->outside stub on a straddling net is detected."""
+    seg = StubSegment(
+        net_id=1,
+        net_name="NET1",
+        x1=10.0,  # on right edge (boundary)
+        y1=5.0,
+        x2=20.0,  # strictly outside
+        y2=5.0,
+        layer=CopperLayer.F_CU,
+        uuid="seg-1",
+    )
+    result = detect_boundary_stub_terminals([seg], _straddling_pads(1), REGION)
+
+    assert set(result.keys()) == {1}
+    terminals = result[1]
+    assert len(terminals) == 1
+    t = terminals[0]
+    assert isinstance(t, StubTerminal)
+    assert t.net_id == 1
+    assert t.net_name == "NET1"
+    assert (t.x, t.y) == (10.0, 5.0)
+    assert t.layer is CopperLayer.F_CU
+    assert t.source_segment_uuid == "seg-1"
+    assert t.boundary_edge is BoundaryEdge.RIGHT
+
+
+def test_detects_stub_when_boundary_end_is_second_endpoint():
+    """Detection is endpoint-order independent (boundary end is x2/y2)."""
+    seg = StubSegment(
+        net_id=1,
+        net_name="NET1",
+        x1=-5.0,  # strictly outside (left)
+        y1=5.0,
+        x2=0.0,  # on left edge (boundary)
+        y2=5.0,
+        layer=CopperLayer.B_CU,
+        uuid="seg-2",
+    )
+    result = detect_boundary_stub_terminals([seg], _straddling_pads(1), REGION)
+
+    assert set(result.keys()) == {1}
+    t = result[1][0]
+    assert (t.x, t.y) == (0.0, 5.0)
+    assert t.boundary_edge is BoundaryEdge.LEFT
+    assert t.layer is CopperLayer.B_CU
+
+
+def test_detects_stub_within_epsilon_of_boundary_line():
+    """An endpoint within EPSILON of the edge line still counts as on-boundary."""
+    seg = StubSegment(
+        net_id=1,
+        net_name="NET1",
+        x1=10.0 + EPSILON / 2.0,  # just inside epsilon of the right edge
+        y1=3.0,
+        x2=25.0,  # strictly outside
+        y2=3.0,
+        layer=CopperLayer.F_CU,
+        uuid="seg-eps",
+    )
+    result = detect_boundary_stub_terminals([seg], _straddling_pads(1), REGION)
+    assert set(result.keys()) == {1}
+    assert result[1][0].boundary_edge is BoundaryEdge.RIGHT
+
+
+def test_detects_stub_on_top_and_bottom_edges():
+    """Vertical stubs are classified onto TOP / BOTTOM edges."""
+    top_seg = StubSegment(
+        net_id=1,
+        net_name="NET1",
+        x1=4.0,
+        y1=0.0,  # top edge
+        x2=4.0,
+        y2=-8.0,  # strictly outside
+        layer=CopperLayer.F_CU,
+        uuid="top",
+    )
+    bottom_seg = StubSegment(
+        net_id=1,
+        net_name="NET1",
+        x1=6.0,
+        y1=10.0,  # bottom edge
+        x2=6.0,
+        y2=18.0,  # strictly outside
+        layer=CopperLayer.F_CU,
+        uuid="bottom",
+    )
+    result = detect_boundary_stub_terminals([top_seg, bottom_seg], _straddling_pads(1), REGION)
+    edges = {t.boundary_edge for t in result[1]}
+    assert edges == {BoundaryEdge.TOP, BoundaryEdge.BOTTOM}
+
+
+def test_multiple_nets_grouped_by_net_id():
+    """Terminals are grouped per net; unrelated nets are independent."""
+    seg1 = StubSegment(1, "NET1", 10.0, 2.0, 22.0, 2.0, CopperLayer.F_CU, "a")
+    seg2 = StubSegment(2, "NET2", 10.0, 8.0, 22.0, 8.0, CopperLayer.F_CU, "b")
+    pads = _straddling_pads(1) + _straddling_pads(2)
+    result = detect_boundary_stub_terminals([seg1, seg2], pads, REGION)
+    assert set(result.keys()) == {1, 2}
+    assert result[1][0].boundary_edge is BoundaryEdge.RIGHT
+    assert result[2][0].boundary_edge is BoundaryEdge.RIGHT
+
+
+# --------------------------------------------------------------------------- #
+# Negative cases -- each isolates the failure of exactly one detection part
+# --------------------------------------------------------------------------- #
+
+
+def test_rejects_pad_coincident_endpoint():
+    """Part 3: a boundary endpoint sitting on a pad center is not a stub."""
+    seg = StubSegment(
+        net_id=1,
+        net_name="NET1",
+        x1=10.0,  # on right edge -- but a pad sits here
+        y1=5.0,
+        x2=20.0,  # strictly outside
+        y2=5.0,
+        layer=CopperLayer.F_CU,
+        uuid="seg-1",
+    )
+    pads = _straddling_pads(1) + [
+        PadLocation(net_id=1, x=10.0 + EPSILON / 2.0, y=5.0),  # coincident pad
+    ]
+    result = detect_boundary_stub_terminals([seg], pads, REGION)
+    assert result == {}
+
+
+def test_rejects_outside_outside_segment():
+    """Part 2: a segment with both endpoints outside is not a boundary stub.
+
+    This mirrors ``strip_traces``'s both-endpoints-outside branch, which is
+    skipped rather than clipped -- so it never yields a boundary endpoint.
+    """
+    seg = StubSegment(
+        net_id=1,
+        net_name="NET1",
+        x1=-5.0,  # outside (left)
+        y1=5.0,
+        x2=20.0,  # outside (right)
+        y2=5.0,
+        layer=CopperLayer.F_CU,
+        uuid="seg-oo",
+    )
+    result = detect_boundary_stub_terminals([seg], _straddling_pads(1), REGION)
+    assert result == {}
+
+
+def test_rejects_all_inside_net():
+    """Part 4: a net whose pads are all inside the region is ineligible.
+
+    Even if a segment presents a boundary endpoint, a net that does not
+    straddle the region needs no reconnection.
+    """
+    seg = StubSegment(
+        net_id=1,
+        net_name="NET1",
+        x1=10.0,  # on right edge
+        y1=5.0,
+        x2=20.0,  # strictly outside
+        y2=5.0,
+        layer=CopperLayer.F_CU,
+        uuid="seg-1",
+    )
+    inside_only_pads = [
+        PadLocation(net_id=1, x=3.0, y=3.0),
+        PadLocation(net_id=1, x=7.0, y=7.0),
+    ]
+    result = detect_boundary_stub_terminals([seg], inside_only_pads, REGION)
+    assert result == {}
+
+
+def test_rejects_all_outside_net():
+    """Part 4 (other half): a net with no pad inside is also ineligible."""
+    seg = StubSegment(
+        net_id=1,
+        net_name="NET1",
+        x1=10.0,
+        y1=5.0,
+        x2=20.0,
+        y2=5.0,
+        layer=CopperLayer.F_CU,
+        uuid="seg-1",
+    )
+    outside_only_pads = [
+        PadLocation(net_id=1, x=20.0, y=5.0),
+        PadLocation(net_id=1, x=25.0, y=5.0),
+    ]
+    result = detect_boundary_stub_terminals([seg], outside_only_pads, REGION)
+    assert result == {}
+
+
+def test_rejects_near_boundary_but_not_on_line_endpoint():
+    """Part 1: an endpoint near the region but not on any edge line is rejected.
+
+    The inside endpoint here is well inside the box (not on a boundary line),
+    and the outside endpoint is outside -- but neither endpoint lies on the
+    boundary line, so this is a normal boundary-crossing trace, not a clipped
+    stub. (In practice ``strip_traces`` would have clipped this; the detector
+    must not fabricate a terminal from an un-clipped interior endpoint.)
+    """
+    seg = StubSegment(
+        net_id=1,
+        net_name="NET1",
+        x1=5.0,  # strictly inside, not on any edge line
+        y1=5.0,
+        x2=20.0,  # strictly outside
+        y2=5.0,
+        layer=CopperLayer.F_CU,
+        uuid="seg-nb",
+    )
+    result = detect_boundary_stub_terminals([seg], _straddling_pads(1), REGION)
+    assert result == {}
+
+
+def test_rejects_endpoint_just_beyond_epsilon_of_line():
+    """Part 1 boundary: an endpoint just beyond EPSILON of the edge is rejected."""
+    seg = StubSegment(
+        net_id=1,
+        net_name="NET1",
+        x1=10.0 - 2.0 * EPSILON,  # inside, more than EPSILON from the right edge
+        y1=5.0,
+        x2=20.0,  # strictly outside
+        y2=5.0,
+        layer=CopperLayer.F_CU,
+        uuid="seg-far",
+    )
+    result = detect_boundary_stub_terminals([seg], _straddling_pads(1), REGION)
+    assert result == {}
+
+
+# --------------------------------------------------------------------------- #
+# Purity / signature guarantees
+# --------------------------------------------------------------------------- #
+
+
+def test_region_box_normalizes_corner_order():
+    """RegionBox normalizes so callers may pass corners in any order."""
+    a = RegionBox(0.0, 0.0, 10.0, 10.0)
+    b = RegionBox(10.0, 10.0, 0.0, 0.0)
+    assert (a.x1, a.y1, a.x2, a.y2) == (b.x1, b.y1, b.x2, b.y2)
+
+
+def test_pad_exactly_on_boundary_counts_as_inside():
+    """Inclusive box: a pad on the boundary line is inside (Phase 2a parity).
+
+    A net with one pad on the boundary and one strictly outside owns NO pad
+    strictly inside... but the boundary pad counts as inside under the
+    inclusive test, so the net is eligible and its stub is detected.
+    """
+    seg = StubSegment(1, "NET1", 10.0, 4.0, 20.0, 4.0, CopperLayer.F_CU, "s")
+    pads = [
+        PadLocation(net_id=1, x=0.0, y=5.0),  # on left boundary -> counts inside
+        PadLocation(net_id=1, x=20.0, y=5.0),  # outside
+    ]
+    result = detect_boundary_stub_terminals([seg], pads, REGION)
+    assert set(result.keys()) == {1}
+
+
+def test_empty_inputs_return_empty_mapping():
+    result = detect_boundary_stub_terminals([], [], REGION)
+    assert result == {}


### PR DESCRIPTION
## Summary

Phase 2b-0 prerequisite for #4170. Adds a new **pure** module,
`src/kicad_tools/router/stub_terminals.py`, that detects bare copper stub
endpoints left on a routing-region boundary by `pcb strip --region` clipping.
Such endpoints have no pad and are invisible to Phase 2a's inclusive-box
routing, so nets that own pads both inside and outside the region cannot be
reconnected to pre-existing external copper.

The module is the **single shared producer** both future pad-sourcing surfaces
(`Autorouter` and `RoutingOrchestrator`) will consume, so stub geometry is
never re-derived independently (the #3428 foot-gun). No router/grid/CLI wiring
is added here — that is #4170 (Autorouter) and #4173 (orchestrator).

## Changes

- NEW `src/kicad_tools/router/stub_terminals.py`:
  - `StubTerminal` dataclass (`net_id`, `net_name`, `x`, `y`, `layer: CopperLayer`,
    provenance `source_segment_uuid`, `boundary_edge`) — route-scoped/ephemeral,
    never a `Pad`.
  - `detect_boundary_stub_terminals(segments, pads, region)` — pure, no
    grid/router/PCB state; both future callers can invoke it identically by
    adapting their data into plain `StubSegment` / `PadLocation` / `RegionBox`.
  - Module-level `EPSILON = 0.01` mirroring the function-local constant in
    `core.py::_index_block_internal_traces` (that value is a local variable, not
    importable — matched by value + semantic role, with a comment).
- NEW `tests/router/test_stub_terminals.py`: hand-built clipped segments fed
  directly to the detector (no chorus fixture, no PCB round-trip).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Positive detection cases asserted | ✅ | right/left/top/bottom edges, within-epsilon, multi-net grouping |
| Negative: pad-coincident endpoint rejected | ✅ | `test_rejects_pad_coincident_endpoint` |
| Negative: outside-outside segment rejected | ✅ | `test_rejects_outside_outside_segment` |
| Negative: all-inside net rejected | ✅ | `test_rejects_all_inside_net` (+ all-outside half) |
| Negative: near-boundary-but-not-on-line rejected | ✅ | `test_rejects_near_boundary_but_not_on_line_endpoint` + just-beyond-epsilon |
| Producer is pure (no grid/router state) | ✅ | function takes plain `StubSegment`/`PadLocation`/`RegionBox` args only |
| `EPSILON` reused (value 0.01), not re-invented | ✅ | module-level `EPSILON = 0.01` with comment referencing `core.py` |

## Test Plan

- `uv run pytest tests/router/test_stub_terminals.py -q` → 14 passed
- `uv run ruff check` + `ruff format --check` on both changed files → clean
- `uv run --extra dev python scripts/ci/check_mypy_baseline.py` → 0 new errors
  (1475 within the 1514 baseline)

Closes #4172