### PR TITLE
feat(router): reconnect bare boundary stubs in region-bounded routing (Phase 2b-1)

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -1257,6 +1257,15 @@ def _finalize_routes(
         source_routes = preserved_routes if preserved_routes is not None else router.existing_routes
         if source_routes:
             routed_net_ids = {r.net for r in router.routes}
+            # Issue #4170 (Phase 2b-1): a stub net IS routed (the in-region
+            # reconnection) but its OUTSIDE boundary-stub copper must still be
+            # preserved -- the new in-region trace joins the stub, it does not
+            # replace it.  The router records its stub net ids in
+            # ``_stub_terminals``; keep those nets' existing copper by removing
+            # them from the exclusion set.
+            stub_net_ids = set(getattr(router, "_stub_terminals", {}) or {})
+            if stub_net_ids:
+                routed_net_ids = routed_net_ids - stub_net_ids
             preserved_sexp = _serialize_preserved_routes(
                 source_routes, exclude_net_ids=routed_net_ids
             )
@@ -3596,6 +3605,10 @@ def route_with_layer_escalation(
                     # Issue #4148: region-bounded routing.  When set, cells
                     # outside the board-relative box are marked as obstacles.
                     region=getattr(args, "_region_box", None),
+                    # Issue #4170 (Phase 2b-1): board-relative boundary stub
+                    # terminals whose tip cells are carved open as same-net
+                    # reconnection targets (None when no --region / no stubs).
+                    stub_terminals=getattr(args, "_stub_terminals", None),
                     # Issue #3877: thread the C++ iteration backstop through the
                     # layer-escalation sub-router too.  Without this the
                     # escalation-mode Autorouter (board-01/03 et al.) routes with
@@ -4515,6 +4528,10 @@ def route_with_rule_relaxation(
                     load_existing_routes=getattr(args, "preserve_existing", False),
                     # Issue #4148: region-bounded routing (see main()).
                     region=getattr(args, "_region_box", None),
+                    # Issue #4170 (Phase 2b-1): board-relative boundary stub
+                    # terminals whose tip cells are carved open as same-net
+                    # reconnection targets (None when no --region / no stubs).
+                    stub_terminals=getattr(args, "_stub_terminals", None),
                 )
         except Exception as e:
             if not quiet:
@@ -6620,6 +6637,10 @@ def route_with_combined_escalation(
                         load_existing_routes=getattr(args, "preserve_existing", False),
                         # Issue #4148: region-bounded routing (see main()).
                         region=getattr(args, "_region_box", None),
+                        # Issue #4170 (Phase 2b-1): board-relative boundary stub
+                        # terminals whose tip cells are carved open as same-net
+                        # reconnection targets (None when no --region / no stubs).
+                        stub_terminals=getattr(args, "_stub_terminals", None),
                     )
             except Exception as e:
                 if not quiet:
@@ -7217,6 +7238,76 @@ def _parse_region_box(
     return (x1, y1, x2, y2)
 
 
+def _detect_region_stub_terminals(pcb, region_box: tuple[float, float, float, float], skip: set):
+    """Run the shared boundary-stub detector against a loaded schema ``PCB``.
+
+    Issue #4170 (Phase 2b-1).  Adapts the board-relative schema geometry
+    (``pcb._segments`` / ``pcb._vias`` / footprint pads -- all rebased to
+    ``pcb._board_origin``) into the pure detector's plain-data shapes and returns
+    ``{net_id: [StubTerminal, ...]}`` in the SAME board-relative frame as
+    ``region_box``.  ``load_pcb_for_routing`` adds the board origin when it
+    carves the tips, so the whole pipeline stays in board-relative coordinates
+    (matching ``pcb strip --region`` / ``route --region``).
+
+    Both ``route`` (this function) and the future ``route-auto`` orchestrator
+    (Phase 2c, #4173) call the SAME ``detect_boundary_stub_terminals`` producer,
+    so stub geometry is never re-derived independently (the #3428 foot-gun).
+    """
+    from kicad_tools.core.types import CopperLayer
+    from kicad_tools.router.stub_terminals import (
+        PadLocation,
+        RegionBox,
+        StubSegment,
+        detect_boundary_stub_terminals,
+    )
+
+    rx1, ry1, rx2, ry2 = region_box
+    region = RegionBox(rx1, ry1, rx2, ry2)
+
+    def _layer(name: str):
+        try:
+            return CopperLayer.from_kicad_name(name)
+        except ValueError:
+            return None
+
+    seg_inputs: list[StubSegment] = []
+    for seg in pcb._segments:
+        if not seg.net_name or seg.net_name in skip:
+            continue
+        layer = _layer(seg.layer)
+        if layer is None:
+            continue
+        seg_inputs.append(
+            StubSegment(
+                net_id=seg.net_number,
+                net_name=seg.net_name,
+                x1=seg.start[0],
+                y1=seg.start[1],
+                x2=seg.end[0],
+                y2=seg.end[1],
+                layer=layer,
+                uuid=getattr(seg, "uuid", "") or None,
+            )
+        )
+
+    pad_inputs: list[PadLocation] = []
+    for fp in pcb.footprints:
+        for pad in fp.pads:
+            net_name = getattr(pad, "net_name", "") or ""
+            if not net_name:
+                continue
+            pos = pcb.get_pad_position(fp.reference, pad.number)
+            if pos is None:
+                continue
+            pad_inputs.append(PadLocation(net_id=pad.net_number, x=pos[0], y=pos[1]))
+    # Vias are coincidence-rejection reference points too (a via on the boundary
+    # routes "for free" and must not be double-targeted as a bare stub).
+    for via in pcb._vias:
+        pad_inputs.append(PadLocation(net_id=via.net_number, x=via.position[0], y=via.position[1]))
+
+    return detect_boundary_stub_terminals(seg_inputs, pad_inputs, region)
+
+
 def _parse_and_apply_region(args, pcb_path: Path, region_arg: str) -> int:
     """Validate --region, stamp ``args._region_box``, and gate unreachable nets.
 
@@ -7302,10 +7393,30 @@ def _parse_and_apply_region(args, pcb_path: Path, region_arg: str) -> int:
     def _inside(px: float, py: float) -> bool:
         return x1 <= px <= x2 and y1 <= py <= y2
 
+    # Issue #4170 (Phase 2b-1): run the shared boundary-stub detector so a net
+    # with pad(s) outside the region can still be routed when a bare boundary
+    # stub on the same net provides in-region reconnection access.  The detector
+    # already applies the four-part spec (boundary endpoint, other-end-outside,
+    # not pad-coincident, net straddles the boundary), so a returned terminal
+    # means "this net has a reconnectable stub".
+    try:
+        stub_terminals = _detect_region_stub_terminals(pcb, (x1, y1, x2, y2), skip)
+    except Exception as e:  # pragma: no cover - detector should not raise
+        print(f"Error detecting boundary stub terminals for --region: {e}", file=sys.stderr)
+        return 1
+    # Map net_id -> net_name so we can key stub reachability by name.
+    stub_net_names: set[str] = set()
+    for terminals in stub_terminals.values():
+        for term in terminals:
+            stub_net_names.add(term.net_name)
+    # Stash for the load_pcb_for_routing call sites to forward (board-relative).
+    args._stub_terminals = stub_terminals or None
+
     # A net is routable in-region only if it has >= 2 pads AND every pad is
     # inside the box.  Single-pad nets have nothing to route.  Nets with zero
     # in-region pads are simply not this region's concern (ignored).  Nets
-    # with SOME pads inside and SOME outside need outside access -> fail.
+    # with SOME pads inside and SOME outside need outside access; Phase 2b-1
+    # reconnects them when a same-net boundary stub exists, else they fail.
     unreachable: list[str] = []
     routable_nets: list[str] = []
     skip_outside: list[str] = []
@@ -7318,8 +7429,17 @@ def _parse_and_apply_region(args, pcb_path: Path, region_arg: str) -> int:
             skip_outside.append(net_name)
             continue
         if len(inside) != len(positions):
-            unreachable.append(net_name)
+            # Pad(s) outside the region.  Reachable in Phase 2b-1 iff a same-net
+            # boundary stub gives in-region reconnection access.
+            if net_name in stub_net_names:
+                routable_nets.append(net_name)
+            else:
+                unreachable.append(net_name)
         elif len(positions) >= 2:
+            routable_nets.append(net_name)
+        elif net_name in stub_net_names:
+            # A single in-region pad plus a boundary stub is routable: the stub
+            # tip is the second target.
             routable_nets.append(net_name)
         else:
             # Single in-region pad -- nothing to route; skip so it is left as-is.
@@ -7332,8 +7452,8 @@ def _parse_and_apply_region(args, pcb_path: Path, region_arg: str) -> int:
         more = "" if len(unreachable) <= 10 else f" (+{len(unreachable) - 10} more)"
         print(
             "Error: --region cannot route the following net(s) because they "
-            "have pad(s) outside the region and Phase 2a does not reconnect to "
-            f"bare boundary stubs (deferred to Phase 2b): {preview}{more}",
+            "have pad(s) outside the region with no same-net boundary stub to "
+            f"reconnect to: {preview}{more}",
             file=sys.stderr,
         )
         return 1
@@ -8707,6 +8827,11 @@ def main(argv: list[str] | None = None) -> int:
     # rejected here (mirroring the ``pcb strip --region`` CLI validation) so
     # no routing budget is spent on an invalid request.
     args._region_box = None
+    # Issue #4170 (Phase 2b-1): board-relative boundary stub terminals detected
+    # during region validation, forwarded to load_pcb_for_routing so their tip
+    # cells are carved open as same-net reconnection targets.  None when no
+    # --region or no stubs.
+    args._stub_terminals = None
     _region_arg = getattr(args, "region", None)
     if _region_arg:
         rc = _parse_and_apply_region(args, pcb_path, _region_arg)
@@ -9274,6 +9399,10 @@ def main(argv: list[str] | None = None) -> int:
                 load_existing_routes=getattr(args, "preserve_existing", False),
                 # Issue #4148: region-bounded routing (see main()).
                 region=getattr(args, "_region_box", None),
+                # Issue #4170 (Phase 2b-1): board-relative boundary stub
+                # terminals whose tip cells are carved open as same-net
+                # reconnection targets (None when no --region / no stubs).
+                stub_terminals=getattr(args, "_stub_terminals", None),
                 # Issue #2610: thread --max-search-iterations through.
                 # The inner parser declares this flag with default=0 (Issue
                 # #2819), so the attribute is guaranteed to exist; the
@@ -9328,6 +9457,10 @@ def main(argv: list[str] | None = None) -> int:
                 load_existing_routes=getattr(args, "preserve_existing", False),
                 # Issue #4148: region-bounded routing (see main()).
                 region=getattr(args, "_region_box", None),
+                # Issue #4170 (Phase 2b-1): board-relative boundary stub
+                # terminals whose tip cells are carved open as same-net
+                # reconnection targets (None when no --region / no stubs).
+                stub_terminals=getattr(args, "_stub_terminals", None),
                 max_search_iterations=args.max_search_iterations or 0,
                 per_net_iterations=getattr(args, "per_net_iterations", 0) or 0,
             )

--- a/src/kicad_tools/mcp/tools/routing.py
+++ b/src/kicad_tools/mcp/tools/routing.py
@@ -500,8 +500,7 @@ def route_net_auto(
         region_box = (rx1, ry1, rx2, ry2)
 
         # Reachability gate: every pad of the routed net must lie inside the box
-        # (board-relative).  A pad outside needs outside access we do not
-        # provide in Phase 2a (bare-stub reconnection is Phase 2b).
+        # (board-relative).  A pad outside needs outside access.
         outside_pads = []
         for fp_ in pcb.footprints:
             for pad in fp_.pads:
@@ -513,7 +512,75 @@ def route_net_auto(
                 if not (rx1 <= pos[0] <= rx2 and ry1 <= pos[1] <= ry2):
                     outside_pads.append((fp_.reference, pad.number))
         if outside_pads:
+            # Issue #4170 (Phase 2b-1) deferral gate: bare-stub reconnection is
+            # wired for ``kct route --region`` but NOT for the ``route-auto``
+            # orchestrator surface -- that is Phase 2c (#4173).  Detect whether
+            # this net actually has a same-net boundary stub so the message is
+            # accurate: a stub-endpoint net is explicitly deferred to Phase 2c
+            # (it must NOT silently fall back to pad-only and drop the stub);
+            # a net with no stub is simply unreachable.
+            has_stub = False
+            try:
+                from kicad_tools.core.types import CopperLayer as _CopperLayer
+                from kicad_tools.router.stub_terminals import (
+                    PadLocation as _PadLoc,
+                )
+                from kicad_tools.router.stub_terminals import (
+                    RegionBox as _RegionBox,
+                )
+                from kicad_tools.router.stub_terminals import (
+                    StubSegment as _StubSeg,
+                )
+                from kicad_tools.router.stub_terminals import (
+                    detect_boundary_stub_terminals as _detect,
+                )
+
+                _region = _RegionBox(rx1, ry1, rx2, ry2)
+                _segs = []
+                for _s in pcb._segments:
+                    try:
+                        _layer = _CopperLayer.from_kicad_name(_s.layer)
+                    except ValueError:
+                        continue
+                    _segs.append(
+                        _StubSeg(
+                            net_id=_s.net_number,
+                            net_name=_s.net_name,
+                            x1=_s.start[0],
+                            y1=_s.start[1],
+                            x2=_s.end[0],
+                            y2=_s.end[1],
+                            layer=_layer,
+                            uuid=getattr(_s, "uuid", "") or None,
+                        )
+                    )
+                _pads = []
+                for _fp in pcb.footprints:
+                    for _pad in _fp.pads:
+                        _pos = pcb.get_pad_position(_fp.reference, _pad.number)
+                        if _pos is not None:
+                            _pads.append(_PadLoc(net_id=_pad.net_number, x=_pos[0], y=_pos[1]))
+                _detected = _detect(_segs, _pads, _region)
+                has_stub = any(
+                    t.net_name == net_name for terms in _detected.values() for t in terms
+                )
+            except Exception:
+                has_stub = False
+
             preview = ", ".join(f"{r}.{p}" for r, p in outside_pads[:6])
+            if has_stub:
+                msg = (
+                    f"--region: net '{net_name}' has a same-net boundary stub, but "
+                    "stub reconnection is not yet wired for route-auto "
+                    "(orchestrator parity is deferred to Phase 2c, #4173). Use "
+                    "'kct route --region' for stub reconnection."
+                )
+            else:
+                msg = (
+                    f"--region cannot route net '{net_name}': pad(s) {preview} "
+                    "lie outside the region with no same-net boundary stub to "
+                    "reconnect to."
+                )
             return {
                 "success": False,
                 "net_name": net_name,
@@ -522,11 +589,7 @@ def route_net_auto(
                 "repair_actions": [],
                 "warnings": [],
                 "performance": {},
-                "error_message": (
-                    f"--region cannot route net '{net_name}': pad(s) {preview} "
-                    "lie outside the region, and Phase 2a does not reconnect to "
-                    "bare boundary stubs (deferred to Phase 2b)."
-                ),
+                "error_message": msg,
                 "alternative_strategies": [],
             }
 

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 
     from .io import FineZone
     from .pathfinder import Router
+    from .stub_terminals import StubTerminal
 
 from kicad_tools.cli.progress import flush_print
 
@@ -1047,6 +1048,20 @@ class Autorouter:
 
         self.pads: dict[tuple[str, str], Pad] = {}
         self.nets: dict[int, list[tuple[str, str]]] = {}
+        # Issue #4170 (Phase 2b-1): route-scoped bare boundary stub endpoints to
+        # reconnect, keyed by net id.  Populated by ``set_stub_terminals`` from
+        # ``load_pcb_for_routing(stub_terminals=...)``.  These are an ADDITIVE
+        # source of per-net routing targets merged in via ``_stub_target_pads``;
+        # they are NEVER inserted into ``self.pads`` / ``self.nets`` (they are
+        # not real pads -- no footprint, no metal, no drill).
+        self._stub_terminals: dict[int, list[StubTerminal]] = {}
+        # Issue #4170: the WORLD-coordinate region box for stub-reconnection
+        # routing.  When set, per-net target expansion for a stub net drops pads
+        # that fall OUTSIDE the box -- those pads are already electrically the
+        # far end of the boundary stub, so routing to them directly would both
+        # duplicate the connection AND escape the region.  The reachable target
+        # is the stub tip, not the outside pad.
+        self._stub_region_world: tuple[float, float, float, float] | None = None
         self.net_names: dict[int, str] = {}
         self.routes: list[Route] = []
         # Issue #3002 (PR #3006 perf): single-slot cache for the
@@ -1633,6 +1648,95 @@ class Autorouter:
 
             self.grid.add_pad(pad, pin_pitch=pin_pitch)
 
+    def set_stub_terminals(
+        self,
+        stub_terminals: dict[int, list[StubTerminal]],
+        region_world: tuple[float, float, float, float] | None = None,
+    ) -> None:
+        """Register route-scoped bare boundary stub terminals (Issue #4170).
+
+        Called by ``load_pcb_for_routing(stub_terminals=...)`` after the stub
+        tip cells have been carved open on the grid.  The stored map is an
+        ADDITIVE source of per-net routing targets consumed by
+        :meth:`_stub_target_pads`; it is never turned into a :class:`Pad` and
+        never inserted into ``self.pads`` / ``self.nets``.  A shallow copy is
+        kept so later mutation of the caller's dict does not leak in.
+
+        Args:
+            stub_terminals: ``{net_id: [StubTerminal, ...]}`` in WORLD coords.
+            region_world: WORLD-coordinate ``(x1, y1, x2, y2)`` region box.  When
+                given, per-net target expansion for a stub net drops pads outside
+                the box (see :meth:`_region_filtered_pad_keys`).
+        """
+        self._stub_terminals = {net_id: list(terms) for net_id, terms in stub_terminals.items()}
+        self._stub_region_world = region_world
+
+    def _region_filtered_pad_keys(
+        self, net: int, pad_keys: list[tuple[str, str]]
+    ) -> list[tuple[str, str]]:
+        """Drop outside-region pad keys for a stub net (Issue #4170).
+
+        Only filters when BOTH a region box is set AND ``net`` has registered
+        stub terminals -- otherwise returns ``pad_keys`` unchanged (byte-for-byte
+        the non-region behaviour).  For a stub net, a pad OUTSIDE the region is
+        the far end of the boundary stub already; the reachable target is the
+        stub tip, so routing to the outside pad directly would duplicate the
+        connection and escape the region.  A pad exactly on the boundary counts
+        as inside (inclusive box, matching Phase 2a).
+        """
+        region = self._stub_region_world
+        if region is None or net not in self._stub_terminals:
+            return pad_keys
+        x1, y1, x2, y2 = region
+        lo_x, hi_x = (x1, x2) if x1 <= x2 else (x2, x1)
+        lo_y, hi_y = (y1, y2) if y1 <= y2 else (y2, y1)
+        filtered: list[tuple[str, str]] = []
+        for key in pad_keys:
+            pad = self.pads.get(key)
+            if pad is None:
+                filtered.append(key)
+                continue
+            if lo_x <= pad.x <= hi_x and lo_y <= pad.y <= hi_y:
+                filtered.append(key)
+        return filtered
+
+    def _stub_target_pads(self, net: int) -> list[Pad]:
+        """Build route-scoped target :class:`Pad` objects for a net's stubs.
+
+        Issue #4170 (Phase 2b-1): each bare boundary stub endpoint is exposed to
+        the A* router as an additional target position.  A tiny transient
+        :class:`Pad` (SMD, ~one grid cell) is synthesized at the stub tip PURELY
+        to feed the MST/A* target list -- it is created fresh on each call, is
+        never stored in ``self.pads`` / ``self.nets``, and carries a ``_stub``
+        ref so it is distinguishable in diagnostics.  The tip cell itself was
+        already carved open as a same-net-reachable target by
+        :meth:`RoutingGrid.reopen_stub_terminal`, so A* can actually land on it.
+
+        Returns an empty list when the net has no registered stub terminals
+        (the common case), so callers can unconditionally extend their pad list.
+        """
+        terminals = self._stub_terminals.get(net)
+        if not terminals:
+            return []
+        pads: list[Pad] = []
+        for i, term in enumerate(terminals):
+            pads.append(
+                Pad(
+                    x=term.x,
+                    y=term.y,
+                    # A ~single-cell footprint so the A* pad-approach box hugs
+                    # the carved tip cell rather than a wide metal rectangle.
+                    width=self.grid.resolution,
+                    height=self.grid.resolution,
+                    net=term.net_id,
+                    net_name=term.net_name,
+                    layer=term.layer,
+                    ref="_stub",
+                    pin=f"{term.net_name}_{i}",
+                )
+            )
+        return pads
+
     @staticmethod
     def _compute_component_pitch(pads: list[dict]) -> float | None:
         """Compute minimum pin pitch from a component's pad list.
@@ -2178,11 +2282,19 @@ class Autorouter:
         Returns:
             List of Route objects for this net
         """
-        if net not in self.nets:
+        # Issue #4170 (Phase 2b-1): bare boundary stub terminals are an additive
+        # source of per-net targets.  A net may have only ONE in-region pad plus
+        # a boundary stub (or even zero pads registered here but a stub target),
+        # so the pad-count gate must include stub targets.
+        stub_targets = self._stub_target_pads(net)
+        if net not in self.nets and not stub_targets:
             return []
 
-        pads = self.nets[net]
-        if len(pads) < 2:
+        # Issue #4170: for a stub net, drop pads outside the region -- the stub
+        # tip (added via stub_targets) is the reachable target, not the outside
+        # pad it terminates at.
+        pads = self._region_filtered_pad_keys(net, self.nets.get(net, []))
+        if len(pads) + len(stub_targets) < 2:
             return []
 
         # Issue #1019: Update router with unrouted pad info for via impact scoring
@@ -2225,13 +2337,19 @@ class Autorouter:
 
         # Build reduced pad list for inter-IC routing
         pads_for_routing = reduce_pads_after_intra_ic(pads, connected_indices, pad_lookup=self.pads)
-        if len(pads_for_routing) < 2:
+        # Issue #4170 (Phase 2b-1): bare boundary stub terminals count toward the
+        # inter-IC target list, so a single in-region pad plus a stub still has
+        # >= 2 targets to connect.
+        if len(pads_for_routing) + len(stub_targets) < 2:
             return routes
 
         # Issue #2401: Substitute escaped pads with virtual pads at escape
         # endpoints so RSMT + A* route between escape endpoints, not original
         # pad centers.
+        # Issue #4170: merge in the route-scoped stub-terminal target pads as an
+        # ADDITIVE source of per-net targets (never stored in self.pads).
         pad_objs = [self._escape_pad_overrides.get(p, self.pads[p]) for p in pads_for_routing]
+        pad_objs.extend(stub_targets)
 
         # Issue #2336: Try sub-problem pattern cache before A* search.
         # Compute a position/rotation-invariant signature and check for a
@@ -7800,13 +7918,19 @@ class Autorouter:
         hard_fail_rescue_threshold = 2
         for net in net_order:
             if net in self.nets:
-                pads_for_routing = self.nets[net]
-                if len(pads_for_routing) >= 2:
+                # Issue #4170 (Phase 2b-1): drop outside-region pads for stub
+                # nets (the stub tip is the reachable target, not the outside
+                # pad) and add the stub tips as additive targets, so a single
+                # in-region pad plus a stub still has >= 2 targets and is not
+                # treated as a single-pad (unroutable) net.
+                pads_for_routing = self._region_filtered_pad_keys(net, self.nets[net])
+                stub_targets = self._stub_target_pads(net)
+                if len(pads_for_routing) + len(stub_targets) >= 2:
                     # Issue #2401: Substitute escaped pads with virtual pads
                     # at escape endpoints.
                     pads_by_net[net] = [
                         self._escape_pad_overrides.get(p, self.pads[p]) for p in pads_for_routing
-                    ]
+                    ] + stub_targets
                 else:
                     single_pad_nets.add(net)
             else:
@@ -10945,11 +11069,14 @@ class Autorouter:
             per_net_timeout: Optional wall-clock timeout in seconds for each
                 A* search within this net (Issue #1605)
         """
-        if net not in self.nets:
+        # Issue #4170 (Phase 2b-1): bare boundary stub terminals are additive
+        # per-net targets on the negotiated per-net chokepoint too.
+        stub_targets = self._stub_target_pads(net)
+        if net not in self.nets and not stub_targets:
             return []
 
-        pads = self.nets[net]
-        if len(pads) < 2:
+        pads = self._region_filtered_pad_keys(net, self.nets.get(net, []))
+        if len(pads) + len(stub_targets) < 2:
             return []
 
         # Issue #2953: push foreign-net pad / track context so
@@ -10977,13 +11104,16 @@ class Autorouter:
         connected_indices |= block_connected
 
         pads_for_routing = reduce_pads_after_intra_ic(pads, connected_indices, pad_lookup=self.pads)
-        if len(pads_for_routing) < 2:
+        # Issue #4170: stub tips count toward the inter-IC target list.
+        if len(pads_for_routing) + len(stub_targets) < 2:
             return routes
 
         # Issue #2401: Substitute escaped pads with virtual pads at escape
         # endpoints so RSMT + A* route between escape endpoints, not original
         # pad centers.
+        # Issue #4170: merge in the route-scoped stub-terminal target pads.
         pad_objs = [self._escape_pad_overrides.get(p, self.pads[p]) for p in pads_for_routing]
+        pad_objs.extend(stub_targets)
         neg_router = NegotiatedRouter(
             self.grid,
             self.router,

--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -2748,6 +2748,71 @@ class RoutingGrid:
                             )
             return blocked_count
 
+    def reopen_stub_terminal(self, x: float, y: float, layer: Layer, net: int) -> tuple[int, int]:
+        """Carve a bare boundary stub endpoint open as a same-net A* target.
+
+        Issue #4170 (region-bounded routing, Phase 2b-1): after
+        ``load_pcb_for_routing`` runs ``mark_route`` on every surviving stub
+        segment, the stub's boundary endpoint cell is ``blocked`` with a
+        per-segment clearance halo.  ``_mark_segment`` sets ``cell.net`` to the
+        stub's net on FIRST block, so a stub sitting alone is already reachable
+        by its own net (the pathfinder passes own-net blocked cells).  But when
+        a FOREIGN net's copper halo paints the tip cell first, ``_mark_segment``
+        leaves ``cell.net`` foreign ("already blocked, don't change net"), and
+        the stub tip is no longer a valid landing for its own net -- A* lands on
+        a nearby own-net cell inside the default pad-approach box instead of the
+        true tip, so the reconnection is geometrically wrong.
+
+        This method makes the exact tip cell a same-net-reachable target by
+        re-asserting ``cell.net = net`` (keeping it ``blocked`` so foreign nets
+        still see it as a hard obstacle -- identical semantics to a pad's own
+        cell).  Only ONE cell (the tip) is touched; the rest of the stub halo
+        stays intact, so this never opens a clearance gap for a different net.
+        Both the Python grid and the paired C++ mirror are updated so the
+        production A* sees the same reachable target.
+
+        Args:
+            x, y: WORLD (sheet-absolute) coordinates of the stub tip.
+            layer: Copper layer the stub is on.
+            net: The stub's net id -- the only net for which the cell becomes
+                reachable.
+
+        Returns:
+            The ``(gx, gy)`` grid cell that was reopened.
+        """
+        with self._acquire_lock():
+            # Capture the static-blockage snapshot before mutating so rip-up
+            # restores the reopened tip rather than re-blocking it mid-route
+            # (parity with mark_route / mark_region_bound, Issue #3545 / #4170).
+            self._ensure_static_blockage_snapshot()
+
+            gx, gy = self.world_to_grid(x, y)
+            layer_idx = self.layer_to_index(layer.value)
+            cell = self.grid[layer_idx][gy][gx]
+            # Keep the cell blocked (it is real stub copper) but own it for the
+            # stub's net so the pathfinder treats it as an own-net -- reachable --
+            # cell while foreign nets still see a hard obstacle.
+            cell.blocked = True
+            cell.net = net
+            cell.original_net = net
+            # Not pad metal, not a keepout: leave is_obstacle/pad_blocked False so
+            # the own-net pathfinder can traverse and land on it.
+            cell.is_obstacle = False
+            cell.pad_blocked = False
+
+            cpp_grid = getattr(self, "_cpp_grid", None)
+            if cpp_grid is not None:
+                # Mirror to the C++ grid: blocked, owned by ``net``, not pad metal.
+                cpp_grid._impl.mark_blocked(
+                    int(gx),
+                    int(gy),
+                    int(layer_idx),
+                    int(net),
+                    False,  # not is_obstacle
+                    False,  # not pad_blocked
+                )
+            return (gx, gy)
+
     def is_blocked(self, gx: int, gy: int, layer: Layer, net: int = 0) -> bool:
         """Check if a cell is blocked for routing."""
         if not (0 <= gx < self.cols and 0 <= gy < self.rows):

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
     from kicad_tools.progress import ProgressCallback
 
     from .primitives import Pad
+    from .stub_terminals import StubTerminal
 
 from .core import Autorouter
 from .geometry import (
@@ -3345,6 +3346,7 @@ def load_pcb_for_routing(
     max_search_iterations: int = 0,
     per_net_iterations: int = 0,
     region: tuple[float, float, float, float] | None = None,
+    stub_terminals: dict[int, list[StubTerminal]] | None = None,
 ) -> tuple[Autorouter, dict[str, int]]:
     """
     Load a KiCad PCB file and create an Autorouter with all components.
@@ -3404,6 +3406,20 @@ def load_pcb_for_routing(
                 immovable.  Region mode implies preserve-existing semantics --
                 callers should pass ``load_existing_routes=True`` so outside
                 copper is never re-routed.  The box is normalized internally.
+        stub_terminals: Optional ``{net_id: [StubTerminal, ...]}`` map of bare
+                boundary stub endpoints to reconnect (Issue #4170, Phase 2b-1).
+                Produced once by
+                :func:`~kicad_tools.router.stub_terminals.detect_boundary_stub_terminals`
+                (the shared detector) and threaded here alongside ``region``.
+                For each terminal the tip cell is carved open as a same-net A*
+                target (:meth:`RoutingGrid.reopen_stub_terminal`) AFTER existing
+                copper and the region bound are marked, and the map is stored on
+                ``router._stub_terminals`` so the Autorouter target-merge shim
+                can add each tip as an additional per-net routing target.  These
+                terminals are route-scoped and ephemeral: they never become a
+                :class:`Pad` and are never inserted into ``router.pads`` /
+                ``router.nets``.  Requires ``load_existing_routes=True`` (the
+                stub copper must be loaded first).
 
     Returns:
         Tuple of (Autorouter instance, net_map dict)
@@ -3832,6 +3848,89 @@ def load_pcb_for_routing(
             max(rx1, rx2),
             max(ry1, ry2),
             blocked,
+        )
+
+    # Issue #4170 (Phase 2b-1): carve bare boundary stub endpoints open as
+    # same-net A* targets and store them for the Autorouter target-merge shim.
+    # MUST run AFTER both load_existing_routes (the stub copper's own halo) and
+    # mark_region_bound, so the re-asserted tip cell is not re-blocked by a
+    # later marking pass.  StubTerminal coordinates are BOARD-RELATIVE (matching
+    # the ``region`` convention), so the board origin is added to reach the
+    # sheet-absolute world frame the grid consumes -- exactly as ``region`` does
+    # above.  StubTerminals are route-scoped/ephemeral: they are never turned
+    # into Pads or inserted into router.pads / router.nets.
+    if stub_terminals:
+        import dataclasses as _dc
+
+        world_terminals: dict[int, list[StubTerminal]] = {}
+        carved = 0
+        for net_id, terminals in stub_terminals.items():
+            world_list = []
+            for term in terminals:
+                wx = term.x + origin_x
+                wy = term.y + origin_y
+                router.grid.reopen_stub_terminal(wx, wy, term.layer, term.net_id)
+                world_list.append(_dc.replace(term, x=wx, y=wy))
+                carved += 1
+            world_terminals[net_id] = world_list
+        # Region box in WORLD coords (add origin, matching the region marking
+        # above) so the Autorouter can drop outside-region pads for stub nets.
+        region_world = None
+        if region is not None:
+            rx1, ry1, rx2, ry2 = region
+            region_world = (
+                rx1 + origin_x,
+                ry1 + origin_y,
+                rx2 + origin_x,
+                ry2 + origin_y,
+            )
+        router.set_stub_terminals(world_terminals, region_world=region_world)
+
+        # Issue #4170: prune outside-region pads from ``router.nets`` for stub
+        # nets.  An outside pad is the far end of a boundary stub -- it is
+        # already electrically connected via the preserved stub copper, and it
+        # sits in a region-blocked cell.  Routing to it would BOTH duplicate the
+        # connection AND emit new copper outside the region (breaking the
+        # zero-copper-modified-outside contract).  ``self.nets`` is the single
+        # source every route variant reads, so pruning here confines all
+        # variants at once; the stub tip (added as a synthetic target by
+        # ``_stub_target_pads``) is the in-region reconnection target instead.
+        # The pruned pads' copper is preserved untouched (it is loaded as an
+        # existing route / boundary stub, never re-routed).
+        if region_world is not None:
+            lo_x, hi_x = (
+                min(region_world[0], region_world[2]),
+                max(region_world[0], region_world[2]),
+            )
+            lo_y, hi_y = (
+                min(region_world[1], region_world[3]),
+                max(region_world[1], region_world[3]),
+            )
+            pruned = 0
+            for net_id in world_terminals:
+                keys = router.nets.get(net_id)
+                if not keys:
+                    continue
+                kept = []
+                for key in keys:
+                    pad = router.pads.get(key)
+                    if pad is None or (lo_x <= pad.x <= hi_x and lo_y <= pad.y <= hi_y):
+                        kept.append(key)
+                    else:
+                        pruned += 1
+                router.nets[net_id] = kept
+            if pruned:
+                logger.info(
+                    "Region-bounded routing: pruned %d outside-region pad(s) from "
+                    "%d stub net(s); reconnection targets the boundary stub tip",
+                    pruned,
+                    len(world_terminals),
+                )
+
+        logger.info(
+            "Region-bounded routing: carved %d bare stub terminal(s) open as "
+            "same-net reconnection targets (Phase 2b-1)",
+            carved,
         )
 
     return router, net_map

--- a/src/kicad_tools/router/stub_terminals.py
+++ b/src/kicad_tools/router/stub_terminals.py
@@ -80,17 +80,6 @@ class RegionBox:
         """Inclusive membership test (matches Phase 2a's inclusive box)."""
         return self.x1 <= x <= self.x2 and self.y1 <= y <= self.y2
 
-    def contains_strict(self, x: float, y: float, epsilon: float = EPSILON) -> bool:
-        """Strictly-inside test: inside the box and not on/near any edge.
-
-        Used to decide whether the *other* endpoint of a stub segment is
-        strictly OUTSIDE the region. An endpoint sitting on the boundary line
-        (within ``epsilon``) is treated as on-boundary, not strictly inside.
-        """
-        return (
-            self.x1 + epsilon < x < self.x2 - epsilon and self.y1 + epsilon < y < self.y2 - epsilon
-        )
-
 
 @dataclass(frozen=True)
 class StubSegment:
@@ -126,7 +115,7 @@ class PadLocation:
     y: float
 
 
-@dataclass
+@dataclass(frozen=True)
 class StubTerminal:
     """A bare copper stub endpoint on the region boundary to be reconnected.
 
@@ -134,6 +123,10 @@ class StubTerminal:
     ``Autorouter.pads`` / ``nets``. ``source_segment_uuid`` and
     ``boundary_edge`` are provenance for the detector's own correctness checks
     and downstream diagnostics.
+
+    Frozen to match its frozen input dataclasses (``StubSegment`` /
+    ``PadLocation`` / ``RegionBox``) so terminals are safely hashable and cannot
+    be mutated after detection.
     """
 
     net_id: int

--- a/tests/router/test_region_bounded.py
+++ b/tests/router/test_region_bounded.py
@@ -20,8 +20,16 @@ These tests follow ``tests/router/test_preserve_existing.py`` conventions
 the spirit of ``tests/test_pcb.py``'s ``test_strip_region_*`` since the router
 API takes a ``.kicad_pcb`` path and the chorus fixture is NOT available in CI.
 
-Phase 2b (bare mid-trace stub reconnection) is explicitly OUT of scope here
-and is deferred to a follow-up issue.
+Phase 2b-1 scope (Issue #4170)
+------------------------------
+
+``TestStubReconnection`` covers bare mid-trace stub-endpoint reconnection for
+``kct route --region``: a genuine boundary-clipped stub (produced by
+``PCB.add_trace`` + ``strip_traces(region=...)``) is reconnected to its
+in-region pad, zero copper is modified outside the region, the hole-to-hole
+floor is respected, and multi-stub same-net cases reconnect.  The ``route-auto``
+orchestrator surface is NOT wired for stub reconnection here -- it fails fast
+with a Phase 2c deferral message (#4173).
 """
 
 from __future__ import annotations
@@ -626,6 +634,311 @@ class TestRouteAutoRegion:
             # any failure here must be the output-confinement or a normal
             # routing failure, not the reachability rejection.
             assert "lie outside the region" not in msg
+
+
+# ---------------------------------------------------------------------------
+# Phase 2b-1: bare boundary stub-endpoint reconnection (Issue #4170)
+# ---------------------------------------------------------------------------
+
+
+def _make_stripped_stub_board(
+    tmp_path: Path,
+    *,
+    name: str,
+    footprints: list[str],
+    traces: list[tuple[tuple[str, str], tuple[str, str], str]],
+    strip_region: tuple[float, float, float, float],
+    strip_nets: list[str],
+    edge: tuple[float, float, float, float] = (100, 100, 160, 160),
+    nets: list[tuple[int, str]] | None = None,
+) -> Path:
+    """Build a board, route ``traces``, then ``strip_traces(region=...)``.
+
+    Produces a GENUINE boundary-clipped stub (the surviving outside portion of
+    each clipped trace, its inside endpoint moved onto the region boundary) --
+    exactly what Phase 2b-1 must reconnect.  Returns the path to the stripped
+    ``.kicad_pcb`` on disk.
+    """
+    board = _board(footprints, edge=edge, nets=nets)
+    src = _write(tmp_path, board, name + "_src.kicad_pcb")
+    pcb = PCB.load(str(src))
+    for start, end, net_name in traces:
+        pcb.add_trace(start, end, width=0.2, layer="F.Cu", net=net_name)
+    stats = pcb.strip_traces(region=strip_region, nets=strip_nets)
+    assert stats["segments_clipped"] >= 1, f"expected a boundary-clipped stub, got stats={stats}"
+    stripped = tmp_path / (name + ".kicad_pcb")
+    pcb.save(str(stripped))
+    return stripped
+
+
+def _touches_cell(segs, x: float, y: float, tol: float = 0.30) -> bool:
+    """True if any segment endpoint is within ``tol`` mm of ``(x, y)``.
+
+    The A* joint lands on the reopened tip GRID CELL, so its emitted vertex is
+    within roughly one grid cell of the world tip -- assert cell-level, not
+    exact-vertex, coincidence.
+    """
+    for s in segs:
+        for px, py in ((s.x1, s.y1), (s.x2, s.y2)):
+            if abs(px - x) <= tol and abs(py - y) <= tol:
+                return True
+    return False
+
+
+class TestStubReconnection:
+    """Phase 2b-1: ``route --region`` reconnects bare boundary stubs."""
+
+    def test_route_region_reconnects_stripped_stub(self, tmp_path):
+        """A genuine stripped stub is reconnected to the in-region pad.
+
+        R1 (world 115,120) inside the box; R2 (world 145,120) outside.  A
+        straight R1->R2 trace clipped by ``strip_traces(region=(0,0,30,20))``
+        leaves a stub running boundary (world 130,120) -> outside (145,120).
+        ``route --region 0,0,30,20`` must reconnect R1 to that boundary tip.
+        """
+        stripped = _make_stripped_stub_board(
+            tmp_path,
+            name="stub1",
+            footprints=[
+                _footprint("R1", 115, 120, 1, "SIG_A"),
+                _footprint("R2", 145, 120, 1, "SIG_A"),
+            ],
+            traces=[(("R1", "1"), ("R2", "1"), "SIG_A")],
+            strip_region=(0.0, 0.0, 30.0, 20.0),
+            strip_nets=["SIG_A"],
+            nets=[(1, "SIG_A")],
+        )
+        out_path = tmp_path / "stub1_out.kicad_pcb"
+        rc = route_main(
+            [
+                str(stripped),
+                "--output",
+                str(out_path),
+                "--no-optimize",
+                "--force",
+                "--quiet",
+                "--no-auto-layers",
+                "--backend",
+                "cpp",
+                "--skip-drc",
+                "--region",
+                "0,0,30,20",
+            ]
+        )
+        assert rc == 0, f"route --region exited {rc}"
+        segs = parse_segments(out_path.read_text()).get("SIG_A", [])
+        assert segs, "SIG_A produced no copper"
+        # New routing reaches R1's pad (world 115,120)...
+        assert _touches_cell(segs, 115.0, 120.0), "route did not reach R1 pad"
+        # ...and joins the stub boundary tip cell (world 130,120).
+        assert _touches_cell(segs, 130.0, 120.0), "route did not reconnect to the boundary stub tip"
+
+    def test_reconnection_preserves_outside_copper_byte_identical(self, tmp_path):
+        """Region-bounded stub reconnection modifies zero copper outside the box.
+
+        Mirrors ``test_region_confines_routing_and_preserves_outside``: the
+        surviving stub copper OUTSIDE the region (world x>130) must be
+        byte/geometry-identical before and after the reconnection route.
+        """
+        stripped = _make_stripped_stub_board(
+            tmp_path,
+            name="stub2",
+            footprints=[
+                _footprint("R1", 115, 120, 1, "SIG_A"),
+                _footprint("R2", 145, 120, 1, "SIG_A"),
+            ],
+            traces=[(("R1", "1"), ("R2", "1"), "SIG_A")],
+            strip_region=(0.0, 0.0, 30.0, 20.0),
+            strip_nets=["SIG_A"],
+            nets=[(1, "SIG_A")],
+        )
+        # Snapshot the OUTSIDE portion of the stub before routing (world x>=130).
+        before = parse_segments(stripped.read_text()).get("SIG_A", [])
+        before_outside = sorted(
+            (round(s.x1, 4), round(s.y1, 4), round(s.x2, 4), round(s.y2, 4))
+            for s in before
+            if min(s.x1, s.x2) >= 130.0 - 1e-6
+        )
+        assert before_outside, "expected an outside stub before routing"
+
+        out_path = tmp_path / "stub2_out.kicad_pcb"
+        rc = route_main(
+            [
+                str(stripped),
+                "--output",
+                str(out_path),
+                "--no-optimize",
+                "--force",
+                "--quiet",
+                "--no-auto-layers",
+                "--backend",
+                "cpp",
+                "--skip-drc",
+                "--region",
+                "0,0,30,20",
+            ]
+        )
+        assert rc == 0, f"route --region exited {rc}"
+        after = parse_segments(out_path.read_text()).get("SIG_A", [])
+        after_outside = sorted(
+            (round(s.x1, 4), round(s.y1, 4), round(s.x2, 4), round(s.y2, 4))
+            for s in after
+            if min(s.x1, s.x2) >= 130.0 - 1e-6
+        )
+        # The outside stub survives geometry-identically; no NEW copper landed
+        # strictly outside the box (all new routing stays at x<=130).
+        assert after_outside == before_outside, (
+            "copper outside the region was modified during stub reconnection"
+        )
+
+    def test_reconnection_respects_hole_to_hole_floor(self, tmp_path):
+        """The hole-to-hole floor is threaded on the stub-reconnection path.
+
+        Loads a stripped-stub board (a SIG_A boundary stub + a pre-existing PTH
+        drill inside the region on a foreign net) with ``stub_terminals=`` set,
+        routes the stub net, then asserts -- via the same
+        ``_TraceResolverTransaction._via_clears_hole_to_hole`` predicate the
+        Phase 2a main router uses -- that a candidate via placed at the stub
+        joint within the floor of the pre-existing drill is REJECTED.  This
+        confirms the floor is enforced on the region/stub path, not just the
+        plain route path (mirrors ``test_via_too_close_to_pth_drill_is_rejected``).
+        """
+        from kicad_tools.router.core import _TraceResolverTransaction
+        from kicad_tools.router.stub_terminals import StubTerminal
+
+        # SIG_A stub running world (130,118)->(145,118); R1 the in-region pad;
+        # J1 a foreign PTH drill inside the region near the reconnection corridor.
+        board = _board(
+            [
+                _footprint("R1", 115, 118, 1, "SIG_A"),
+                _tht_footprint("J1", 122, 118, 2, "SIG_B", drill=0.3),
+            ],
+            edge=(100, 100, 160, 160),
+            nets=[(1, "SIG_A"), (2, "SIG_B")],
+            extra='  (segment (start 130 118) (end 145 118) (width 0.2) (layer "F.Cu") (net 1))',
+        )
+        router, _ = load_pcb_for_routing(
+            str(_write(tmp_path, board, "stub3.kicad_pcb")),
+            validate_drc=False,
+            strict_drc=False,
+            load_existing_routes=True,
+            region=(0.0, 0.0, 30.0, 25.0),
+            stub_terminals={
+                1: [
+                    StubTerminal(
+                        net_id=1,
+                        net_name="SIG_A",
+                        x=30.0,  # board-relative boundary tip -> world (130,118)
+                        y=18.0,
+                        layer=Layer.F_CU,
+                    )
+                ]
+            },
+        )
+        router.rules.min_hole_to_hole = 0.5
+
+        # Route the stub net -- confirms the reconnection succeeds end-to-end.
+        result = router.route_net(1)
+        assert result, "stub net did not reconnect"
+
+        # The Phase 2a hole-to-hole predicate still gates vias on this path: a
+        # candidate via 0.3mm from J1's drill (edge gap 0.0 << 0.5) is rejected.
+        transaction = _TraceResolverTransaction(router)
+        transaction.begin()
+        near_via = Via(
+            x=122.3, y=118.0, drill=0.3, diameter=0.6, layers=(Layer.F_CU, Layer.B_CU), net=1
+        )
+        assert transaction._via_clears_hole_to_hole(near_via, 0.5) is False
+        # A via comfortably clear of every drill passes.
+        far_via = Via(
+            x=118.0, y=112.0, drill=0.3, diameter=0.6, layers=(Layer.F_CU, Layer.B_CU), net=1
+        )
+        assert transaction._via_clears_hole_to_hole(far_via, 0.5) is True
+
+    def test_multi_stub_same_net_reconnects(self, tmp_path):
+        """2+ simultaneous stub endpoints on the SAME net are all reconnected.
+
+        SIG_A fans out from an in-region pad R1 to TWO outside pads (R2, R3),
+        both clipped at the boundary.  The detector returns two StubTerminals
+        for SIG_A; the Autorouter must add BOTH as targets so both boundary tips
+        are reconnected into the net island.
+        """
+        # Two SEPARATE in-region source pads (R1a, R1b) each fan out to an
+        # outside pad along a horizontal line, so each clip lands the boundary
+        # tip at a predictable axis-aligned point (world 130, y).
+        stripped = _make_stripped_stub_board(
+            tmp_path,
+            name="stub4",
+            footprints=[
+                _footprint("R1a", 115, 112, 1, "SIG_A"),
+                _footprint("R1b", 115, 122, 1, "SIG_A"),
+                _footprint("R2", 145, 112, 1, "SIG_A"),
+                _footprint("R3", 145, 122, 1, "SIG_A"),
+            ],
+            traces=[
+                (("R1a", "1"), ("R2", "1"), "SIG_A"),
+                (("R1b", "1"), ("R3", "1"), "SIG_A"),
+            ],
+            strip_region=(0.0, 0.0, 30.0, 30.0),
+            strip_nets=["SIG_A"],
+            nets=[(1, "SIG_A")],
+        )
+        # Two horizontal clips -> two boundary tips at world (130,112),(130,122).
+        out_path = tmp_path / "stub4_out.kicad_pcb"
+        rc = route_main(
+            [
+                str(stripped),
+                "--output",
+                str(out_path),
+                "--no-optimize",
+                "--force",
+                "--quiet",
+                "--no-auto-layers",
+                "--backend",
+                "cpp",
+                "--skip-drc",
+                "--region",
+                "0,0,30,30",
+            ]
+        )
+        assert rc == 0, f"route --region exited {rc}"
+        segs = parse_segments(out_path.read_text()).get("SIG_A", [])
+        assert segs, "SIG_A produced no copper"
+        assert _touches_cell(segs, 130.0, 112.0), "first stub tip not reconnected"
+        assert _touches_cell(segs, 130.0, 122.0), "second stub tip not reconnected"
+
+    def test_route_auto_region_stub_defers_to_phase_2c(self, tmp_path):
+        """``route-auto --region`` on a stub-endpoint net fails fast (Phase 2c).
+
+        The orchestrator surface is NOT wired for stub reconnection in Phase
+        2b-1 (deferred to #4173).  It must fail fast with an explicit Phase 2c
+        message rather than silently falling back to pad-only and dropping the
+        stub.
+        """
+        from kicad_tools.mcp.tools.routing import route_net_auto
+
+        stripped = _make_stripped_stub_board(
+            tmp_path,
+            name="stub5",
+            footprints=[
+                _footprint("R1", 115, 120, 1, "SIG_A"),
+                _footprint("R2", 145, 120, 1, "SIG_A"),
+            ],
+            traces=[(("R1", "1"), ("R2", "1"), "SIG_A")],
+            strip_region=(0.0, 0.0, 30.0, 20.0),
+            strip_nets=["SIG_A"],
+            nets=[(1, "SIG_A")],
+        )
+        result = route_net_auto(
+            str(stripped),
+            "SIG_A",
+            output_path=None,
+            region="0,0,30,20",
+        )
+        assert result["success"] is False
+        msg = result.get("error_message") or ""
+        assert "Phase 2c" in msg, f"expected a Phase 2c deferral message, got: {msg}"
+        assert "SIG_A" in msg
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary

Phase 2b-1 of region-bounded routing (#4170): the Autorouter now reconnects **bare mid-trace stub endpoints** left by `pcb strip --region`. `kct route --region <box>` reconnects a clipped net's in-region pad to the copper stub sitting on the region boundary — the crux of the chorus#16 escape re-dress that Phase 2a (`--region`, #4169) deliberately deferred.

This consumes the merged #4172 shared detector (`detect_boundary_stub_terminals`) as the single source of stub geometry (the anti-#3428 keystone) and does **not** touch `router/cpp/`.

**Phase 2c (route-auto / orchestrator parity) is explicitly deferred to #4173.** `route-auto --region` on a stub-endpoint net fails fast with a clear Phase 2c message rather than silently misbehaving.

## Changes

- **CLI gate relaxation** (`cli/route_cmd.py`): `_parse_and_apply_region` runs the shared detector and reclassifies "pad outside + same-net boundary stub" nets as routable instead of hard-failing; nets with an outside pad and NO stub still fail fast.
- **Threading** (`router/io.py`): `load_pcb_for_routing(stub_terminals=...)` carves each stub tip open, stores the terminals + region box on the router, and prunes outside-region pads from stub nets (the stub tip is the reachable target). Preserves the outside stub copper even though the net is routed.
- **Carve-out** (`router/grid.py`): `reopen_stub_terminal` re-asserts `cell.net` on the exact stub tip cell (Python grid **and** C++ mirror) so A* lands on the true tip as an own-net-reachable target while foreign nets still see a hard obstacle. Fixes the foreign-halo-clobber case (verified: without it, A* lands on a wrong nearby cell).
- **Target-merge shim** (`router/core.py`): `StubTerminal`s become route-scoped/ephemeral synthetic `Pad`s added as additive per-net targets at `route_net` and the negotiated per-net chokepoint (`_route_net_negotiated`). Never inserted into `self.pads` / `self.nets`.
- **route-auto deferral gate** (`mcp/tools/routing.py`): stub-endpoint nets fail fast with a Phase 2c (#4173) message; non-stub outside-pad nets get the plain unreachable message.
- **Judge nits from #4174**: removed unused `RegionBox.contains_strict`; made `StubTerminal` a frozen dataclass.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Thread `stub_terminals` through Autorouter as additive per-net targets, never a Pad/`self.pads`/`self.nets` | ✅ | `set_stub_terminals` + `_stub_target_pads` merge shim; terminals stay ephemeral |
| Obstacle carve-out reopens exactly the tip cell for the stub's own net | ✅ | `reopen_stub_terminal`; foreign nets still blocked (`cell.net != net`) |
| Relax CLI reachability gate for on-boundary stub nets | ✅ | `_parse_and_apply_region` reclassifies via the detector |
| route-auto deferral gate (Phase 2c fail-fast) | ✅ | `test_route_auto_region_stub_defers_to_phase_2c` |
| Hole-to-hole floor applies on the stub path | ✅ | `test_reconnection_respects_hole_to_hole_floor` |
| Drop `contains_strict`; freeze `StubTerminal` | ✅ | stub_terminals.py diff |
| Genuine strip_traces stub reconnects | ✅ | `test_route_region_reconnects_stripped_stub` |
| Zero copper modified outside region | ✅ | `test_reconnection_preserves_outside_copper_byte_identical` |
| Multi-stub same-net | ✅ | `test_multi_stub_same_net_reconnects` |

## Does the carve-out work end-to-end?

**Yes.** A* actually reconnects a stub in the tests. `test_route_region_reconnects_stripped_stub` builds a genuine boundary-clipped stub via `PCB.add_trace` + `strip_traces(region=...)`, then `route --region` produces new in-region copper that reaches both the in-region pad and the boundary stub tip cell — verified end-to-end on the C++ backend. The foreign-halo-clobber case (where the tip cell's net is overwritten by a neighboring net) is the load-bearing reason the carve-out exists and is exercised by the hole-to-hole test's fixture.

## Test Plan

- `pytest tests/router/test_region_bounded.py tests/router/test_stub_terminals.py` → 45 passed (5 new stub-reconnection cases).
- `pytest tests/router/ -k "region or stub or preserve or via"` → 135 passed.
- Broader router smoke (`-k "not slow and not benchmark and not chorus and not board"`) → 557 passed, 1 skipped.
- `tests/test_mcp_routing.py` → 37 passed.
- `ruff check` + `ruff format` clean; `check_mypy_baseline.py` → 0 new errors (1475 ≤ 1514).

Closes #4170