### PR TITLE
fix(route): match --net-class-map bare keys against '/'-prefixed board nets

### DIFF
--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -3533,7 +3533,11 @@ def _add_route_parser(subparsers) -> None:
             "length_match_group) project through to the routing-time "
             "pathfinder.  Without this flag, --differential-pairs falls "
             "back to NetClassRouting defaults and can produce overlapping "
-            "diff-pair sibling traces under tight mfr profiles."
+            "diff-pair sibling traces under tight mfr profiles.  Keys are "
+            "matched against the board net's sheet-local suffix (the "
+            "segment after the last '/'), so a bare key FUSED_LINE matches "
+            "KiCad's '/'-prefixed label net /FUSED_LINE while global power "
+            "nets (GND, +3.3V) stay bare (Issue #4149)."
         ),
     )
     route_parser.add_argument(

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -2879,16 +2879,96 @@ def _apply_net_class_map_sidecar(router: "Autorouter", args, quiet: bool = False
     wrappers) calls this helper to merge the rich per-pair / per-group
     fields onto the router's name-pattern-classified map.
 
+    Issue #4149: board nets carry KiCad's hierarchical sheet prefix
+    (``/FUSED_LINE``) for label-derived nets while power-symbol nets stay
+    bare (``GND``).  Sidecar keys are almost always written bare, so a raw
+    ``.update()`` silently keyed the overrides by names that
+    ``self.net_class_map.get(net_name)`` never looks up.  We now resolve
+    each bare key against the board's actual net names (matching on the
+    suffix after the last ``/``), rekey the overrides to the board net
+    name, and emit an aggregate stderr diagnostic for keys that matched no
+    board net or matched ambiguously.  Ambiguous keys are applied to
+    *neither* candidate — silently picking one would just relocate the bug.
+
     Idempotent and a no-op when the flag was not supplied.
     """
     loaded = getattr(args, "_loaded_net_class_map", None)
     if not loaded:
         return
-    router.net_class_map.update(loaded)
+
+    from kicad_tools.router.net_names import (
+        nearest_net_names,
+        resolve_net_class_map_keys,
+    )
+
+    board_net_names = list(router.net_names.values())
+    resolution = resolve_net_class_map_keys(loaded.keys(), board_net_names)
+
+    # Apply overrides rekeyed to the board's actual net names so
+    # ``self.net_class_map.get(net_name)`` finds them at routing time.
+    for board_net, user_key in resolution.resolved.items():
+        router.net_class_map[board_net] = loaded[user_key]
+
+    _warn_unresolved_net_class_map(resolution, board_net_names, nearest_net_names)
+
     if not quiet:
         from kicad_tools.cli.progress import flush_print
 
-        flush_print(f"  Net-class map: merged {len(loaded)} sidecar entries")
+        flush_print(
+            f"  Net-class map: merged {len(resolution.resolved)}/{resolution.total} sidecar entries"
+        )
+
+
+def _warn_unresolved_net_class_map(resolution, board_net_names, nearest_fn) -> None:
+    """Emit the Issue #4149 misconfiguration diagnostic to stderr.
+
+    Prints an aggregate summary line plus per-key hints when any
+    ``--net-class-map`` key failed to resolve to a board net (zero-match)
+    or matched more than one distinct board net (ambiguous).  A no-op when
+    every key resolved.
+
+    This is always printed (never suppressed by ``--quiet``): the
+    softstart-rev-B incident showed a fully-inert class map runs to exit 0
+    with no signal, so the misconfiguration warning must survive
+    ``--quiet``.  Exit code is unchanged (advisory, not a hard gate).
+    """
+    if not resolution.unmatched and not resolution.ambiguous:
+        return
+
+    import sys
+
+    matched = len(resolution.resolved)
+    total = resolution.total
+    lines: list[str] = [
+        f"WARNING: net-class-map: {matched}/{total} entries matched a board net "
+        f"after normalization."
+    ]
+
+    max_hints = 12
+    shown = 0
+    for key in resolution.unmatched:
+        if shown >= max_hints:
+            break
+        hints = nearest_fn(key, board_net_names)
+        if hints:
+            lines.append(f"    {key!r} -> nearest board net(s): {', '.join(hints)}")
+        else:
+            lines.append(f"    {key!r} -> no similar board net found")
+        shown += 1
+    for key, candidates in resolution.ambiguous.items():
+        if shown >= max_hints:
+            break
+        lines.append(
+            f"    {key!r} -> AMBIGUOUS, matches {len(candidates)} board nets "
+            f"({', '.join(candidates)}); skipped, use the fully-qualified name"
+        )
+        shown += 1
+
+    remaining = (len(resolution.unmatched) + len(resolution.ambiguous)) - shown
+    if remaining > 0:
+        lines.append(f"    ... +{remaining} more")
+
+    print("\n".join(lines), file=sys.stderr)
 
 
 def _resolve_analog_net_names(router: "Autorouter", args) -> set[str]:
@@ -7964,7 +8044,13 @@ def main(argv: list[str] | None = None) -> int:
             "fields (intra_pair_clearance, coupled_routing, "
             "coupled_continuity_threshold, target_diff_impedance, "
             "length_match_group) project through to the routing-time "
-            "pathfinder.  Mirrors the kct check --net-class-map flag."
+            "pathfinder.  Mirrors the kct check --net-class-map flag.  "
+            "Keys are matched against the board net's sheet-local suffix "
+            "(the segment after the last '/'), so a bare key FUSED_LINE "
+            "matches KiCad's '/'-prefixed label net /FUSED_LINE while "
+            "global power nets (GND, +3.3V) stay bare; keys that match no "
+            "board net or match ambiguously are reported on stderr and "
+            "skipped (Issue #4149)."
         ),
     )
     parser.add_argument(

--- a/src/kicad_tools/router/net_names.py
+++ b/src/kicad_tools/router/net_names.py
@@ -1,0 +1,208 @@
+"""Hierarchical net-name normalization and matching (Issue #4149).
+
+KiCad names label-derived nets with the schematic's hierarchical sheet
+path prefix (``/FUSED_LINE`` on the root sheet, ``/PWR/VBUS`` inside a
+sub-sheet), while power-symbol nets stay global and bare (``GND``,
+``+3.3V``).  User-supplied selectors (``--net-class-map`` keys, and in
+future ``--skip-nets`` / ``--power-nets`` / ``--analog-nets``) are almost
+always written with bare names, so a bare key silently matches zero board
+nets whenever the board net carries a ``/`` prefix.
+
+This module provides a single, well-tested normalizer/matcher so those
+selectors resolve a bare user key against the *sheet-local suffix* of each
+board net name (the segment after the last ``/``), while refusing to
+silently guess when a bare key would match more than one distinct board
+net.
+
+Only ``--net-class-map`` adopts this helper today (see
+``cli/route_cmd.py::_apply_net_class_map_sidecar``); the sibling selectors
+are a documented follow-up.  The helper is designed so adopting them later
+is an import-and-swap of the membership test.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+
+
+def net_name_suffix(name: str) -> str:
+    """Return the sheet-local suffix after the last ``/``.
+
+    Root-sheet and bare names are returned unchanged (``rsplit`` on a name
+    with no ``/`` yields the name itself); nested sheet paths collapse to
+    their final segment regardless of nesting depth.
+
+    Examples::
+
+        net_name_suffix("/FUSED_LINE")     -> "FUSED_LINE"
+        net_name_suffix("/A/B/FUSED_LINE") -> "FUSED_LINE"
+        net_name_suffix("GND")             -> "GND"
+    """
+    return name.rsplit("/", 1)[-1]
+
+
+def build_net_name_index(board_net_names: Iterable[str]) -> dict[str, list[str]]:
+    """Map each sheet-local suffix to the board net names sharing it.
+
+    The returned ``suffix -> [raw board net names]`` index is what lets the
+    matcher (a) resolve a bare key to a prefixed board net and (b) detect
+    the ambiguous case where more than one distinct board net shares a
+    suffix (e.g. both ``/A`` and ``A``, or ``/X/A`` and ``/Y/A``).
+
+    Duplicate raw names collapse (a board never has two nets with the exact
+    same name), and insertion order is preserved so warning messages list
+    candidates deterministically.
+    """
+    index: dict[str, list[str]] = {}
+    for raw in board_net_names:
+        suffix = net_name_suffix(raw)
+        bucket = index.setdefault(suffix, [])
+        if raw not in bucket:
+            bucket.append(raw)
+    return index
+
+
+@dataclass(frozen=True)
+class NetKeyResolution:
+    """Outcome of resolving one user-supplied selector key.
+
+    Exactly one of the following holds:
+
+    * ``matched`` is a board net name  -> unambiguous match (exact or
+      unique-suffix); ``ambiguous`` is empty.
+    * ``matched`` is ``None`` and ``ambiguous`` is non-empty -> the bare
+      key matches multiple distinct board nets; caller must NOT apply the
+      override to any of them.
+    * ``matched`` is ``None`` and ``ambiguous`` is empty -> no board net
+      matches (typo / renamed net / wrong sheet prefix).
+    """
+
+    key: str
+    matched: str | None = None
+    ambiguous: tuple[str, ...] = ()
+
+    @property
+    def is_ambiguous(self) -> bool:
+        return self.matched is None and bool(self.ambiguous)
+
+
+def resolve_net_key(user_key: str, index: dict[str, list[str]]) -> NetKeyResolution:
+    """Resolve a single user key against a board-net-name index.
+
+    Resolution order:
+
+    1. **Fully-qualified exact match** — the key contains a ``/`` and is
+       itself a raw board net name (a user who wrote ``/FUSED_LINE`` or
+       ``/X/A`` explicitly).  A qualified key is unambiguous by
+       construction, so it wins outright and is never flagged ambiguous.
+    2. **Unique suffix match** — the key's suffix matches exactly one board
+       net.  This covers both the bare-key-matches-prefixed case
+       (``FUSED_LINE`` -> ``/FUSED_LINE``) and the historical bare-vs-bare
+       case (``GND`` -> ``GND``, the sole ``GND`` bucket entry).
+    3. **Ambiguous suffix** — the key's suffix matches multiple distinct
+       board nets (``A`` when the board has both ``/A`` and ``A``, or
+       ``/X/A`` and ``/Y/A``); returns ``matched=None`` with the candidates
+       listed.  A *bare* key is refused here even if one candidate is an
+       exact string match — silently preferring the exact one would just
+       relocate the misconfiguration this module exists to surface.
+    4. **No match** — returns an empty resolution.
+    """
+    # 1. A fully-qualified key (contains '/') that names a real board net
+    #    is unambiguous by construction — exact match wins.
+    if "/" in user_key:
+        for bucket in index.values():
+            if user_key in bucket:
+                return NetKeyResolution(key=user_key, matched=user_key)
+
+    # 2/3. Suffix match: normalize the key the same way we normalize board
+    #      names, then look it up in the suffix index.  A bare key that
+    #      collides across multiple board nets is ambiguous even if one of
+    #      them is an exact string match.
+    candidates = index.get(net_name_suffix(user_key), [])
+    if len(candidates) == 1:
+        return NetKeyResolution(key=user_key, matched=candidates[0])
+    if len(candidates) > 1:
+        return NetKeyResolution(key=user_key, ambiguous=tuple(candidates))
+
+    # 4. No board net matches.
+    return NetKeyResolution(key=user_key)
+
+
+def nearest_net_names(user_key: str, board_net_names: Iterable[str], limit: int = 3) -> list[str]:
+    """Return board net names that look similar to an unmatched ``user_key``.
+
+    A lightweight, dependency-free hint for the zero-match diagnostic: a
+    board net is a candidate when the key is contained in it, it is
+    contained in the key, or either shares the other's sheet-local suffix.
+    No Levenshtein — the ``/``-prefix case (the actual bug) is handled
+    structurally by :func:`resolve_net_key`; this is only advisory text for
+    genuinely unresolved keys.
+
+    Results preserve board-net iteration order and are capped at ``limit``.
+    """
+    key_suffix = net_name_suffix(user_key)
+    hits: list[str] = []
+    for raw in board_net_names:
+        if raw in hits:
+            continue
+        raw_suffix = net_name_suffix(raw)
+        if (
+            user_key in raw
+            or raw in user_key
+            or key_suffix == raw_suffix
+            or raw.endswith("/" + user_key)
+        ):
+            hits.append(raw)
+        if len(hits) >= limit:
+            break
+    return hits
+
+
+@dataclass
+class NetClassMapResolution:
+    """Aggregate result of resolving an entire ``--net-class-map`` sidecar.
+
+    Attributes:
+        resolved: ``{board_net_name: original_user_key}`` for keys that
+            matched exactly one board net.  The board net name is what the
+            router keys ``net_class_map`` by, so this is the rekeyed map the
+            caller should apply.
+        unmatched: user keys that matched no board net.
+        ambiguous: ``{user_key: (candidate board nets, ...)}`` for keys
+            that matched more than one distinct board net; the caller must
+            apply the override to none of them.
+    """
+
+    resolved: dict[str, str] = field(default_factory=dict)
+    unmatched: list[str] = field(default_factory=list)
+    ambiguous: dict[str, tuple[str, ...]] = field(default_factory=dict)
+
+    @property
+    def total(self) -> int:
+        return len(self.resolved) + len(self.unmatched) + len(self.ambiguous)
+
+
+def resolve_net_class_map_keys(
+    user_keys: Iterable[str],
+    board_net_names: Iterable[str],
+) -> NetClassMapResolution:
+    """Resolve every sidecar key against the board's net names.
+
+    Partitions the keys into resolved / unmatched / ambiguous buckets (see
+    :class:`NetClassMapResolution`).  The board net names are materialized
+    once so the index and the nearest-name hints share a single pass-free
+    view.
+    """
+    board = list(board_net_names)
+    index = build_net_name_index(board)
+    result = NetClassMapResolution()
+    for key in user_keys:
+        resolution = resolve_net_key(key, index)
+        if resolution.matched is not None:
+            result.resolved[resolution.matched] = key
+        elif resolution.is_ambiguous:
+            result.ambiguous[key] = resolution.ambiguous
+        else:
+            result.unmatched.append(key)
+    return result

--- a/tests/test_cli_route_net_class_map.py
+++ b/tests/test_cli_route_net_class_map.py
@@ -337,3 +337,184 @@ class TestRouterNetClassMapMerge:
         assert router.net_class_map["USB_D-"].intra_pair_clearance == pytest.approx(0.10)
         assert router.net_class_map["USB_D+"].diffpair_partner == "USB_D-"
         assert router.net_class_map["USB_D-"].diffpair_partner == "USB_D+"
+
+
+# =============================================================================
+# Issue #4149: hierarchical '/' prefix normalization + zero-match diagnostic
+# =============================================================================
+
+
+def _stub_router(net_names: dict[int, str]) -> SimpleNamespace:
+    """A lightweight router stand-in for ``_apply_net_class_map_sidecar``.
+
+    The helper only touches ``router.net_names`` (board net names) and
+    ``router.net_class_map`` (the mutable overrides dict), so we avoid
+    constructing a full Autorouter for these fast, deterministic tests.
+    """
+    return SimpleNamespace(net_names=dict(net_names), net_class_map={})
+
+
+def _sidecar_entry(name: str, **fields):
+    """Build a ``NetClassRouting`` for a synthetic sidecar entry."""
+    from kicad_tools.router.rules import NetClassRouting
+
+    return NetClassRouting.from_dict({"name": name, **fields})
+
+
+class TestHierarchicalPrefixNormalization:
+    """Bare sidecar keys must resolve against '/'-prefixed board nets.
+
+    Mirrors the softstart-rev-B incident: label-derived nets carry KiCad's
+    root-sheet prefix (``/FUSED_LINE``) while power-symbol nets stay bare
+    (``GND``).  A bare-keyed sidecar previously matched zero prefixed nets
+    silently; the fix normalizes on the sheet-local suffix and warns on
+    genuine misconfiguration.
+    """
+
+    def test_bare_key_matches_prefixed_net(self, capsys):
+        """AC #1: a bare key resolves to the '/'-prefixed board net, no warning."""
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        router = _stub_router({1: "/FUSED_LINE", 2: "/PGND", 3: "GND", 4: "+3.3V"})
+        loaded = {
+            "FUSED_LINE": _sidecar_entry("Heavy", priority=5),
+            "PGND": _sidecar_entry("Heavy", priority=5),
+            "GND": _sidecar_entry("Power", priority=4),
+        }
+        args = SimpleNamespace(_loaded_net_class_map=loaded)
+
+        _apply_net_class_map_sidecar(router, args, quiet=True)
+
+        # Overrides landed under the board's actual (prefixed) net names,
+        # which is what core.py's ``net_class_map.get(net_name)`` looks up.
+        assert router.net_class_map["/FUSED_LINE"].priority == 5
+        assert router.net_class_map["/PGND"].priority == 5
+        assert router.net_class_map["GND"].priority == 4
+        # Bare keys must NOT leak into the map when a prefixed net matched.
+        assert "FUSED_LINE" not in router.net_class_map
+        assert "PGND" not in router.net_class_map
+
+        # No misconfiguration warning when everything resolves.
+        err = capsys.readouterr().err
+        assert "WARNING" not in err
+
+    def test_exact_bare_match_unchanged(self, capsys):
+        """AC #5: bare key vs bare board net still resolves (no regression)."""
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        router = _stub_router({1: "GND", 2: "+3.3V"})
+        loaded = {"GND": _sidecar_entry("Power", priority=4)}
+        args = SimpleNamespace(_loaded_net_class_map=loaded)
+
+        _apply_net_class_map_sidecar(router, args, quiet=True)
+
+        assert router.net_class_map["GND"].priority == 4
+        assert "WARNING" not in capsys.readouterr().err
+
+    def test_zero_match_warns_with_nearest_hint(self, capsys):
+        """AC #2: a typo key warns with a nearest-name hint; others stay silent."""
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        router = _stub_router({1: "/FUSED_LINE", 2: "GND"})
+        loaded = {
+            "FUSED_LINE": _sidecar_entry("Heavy", priority=5),
+            "FUSED_LIN": _sidecar_entry("Heavy", priority=5),  # typo
+        }
+        args = SimpleNamespace(_loaded_net_class_map=loaded)
+
+        _apply_net_class_map_sidecar(router, args, quiet=True)
+
+        # The good key still applied.
+        assert router.net_class_map["/FUSED_LINE"].priority == 5
+        # The typo did not.
+        assert "FUSED_LIN" not in router.net_class_map
+
+        err = capsys.readouterr().err
+        assert "WARNING" in err
+        assert "1/2 entries matched" in err
+        assert "FUSED_LIN" in err
+        assert "/FUSED_LINE" in err  # nearest-name hint
+
+    def test_full_zero_match_aggregate_warning(self, capsys):
+        """AC #3: all-bare keys vs all-prefixed nets -> aggregate warning line."""
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        # Simulate a genuinely unresolvable sidecar: bare keys with no
+        # matching suffix on the board at all.
+        router = _stub_router({1: "/SHEET/OTHER_A", 2: "/SHEET/OTHER_B"})
+        loaded = {
+            "MISSING_A": _sidecar_entry("Heavy", priority=5),
+            "MISSING_B": _sidecar_entry("Heavy", priority=5),
+        }
+        args = SimpleNamespace(_loaded_net_class_map=loaded)
+
+        _apply_net_class_map_sidecar(router, args, quiet=True)
+
+        assert router.net_class_map == {}
+        err = capsys.readouterr().err
+        assert "0/2 entries matched" in err
+
+    def test_ambiguous_key_applied_to_neither(self, capsys):
+        """AC #4: bare key matching both /A and A -> ambiguous warning, no apply."""
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        router = _stub_router({1: "/A", 2: "A", 3: "GND"})
+        loaded = {
+            "A": _sidecar_entry("Heavy", priority=5),
+            "GND": _sidecar_entry("Power", priority=4),
+        }
+        args = SimpleNamespace(_loaded_net_class_map=loaded)
+
+        _apply_net_class_map_sidecar(router, args, quiet=True)
+
+        # Neither candidate for the ambiguous key gets the override.
+        assert "A" not in router.net_class_map
+        assert "/A" not in router.net_class_map
+        # The unambiguous key still resolves.
+        assert router.net_class_map["GND"].priority == 4
+
+        err = capsys.readouterr().err
+        assert "WARNING" in err
+        assert "AMBIGUOUS" in err
+        assert "/A" in err and "A" in err
+
+    def test_warning_not_suppressed_by_quiet(self, capsys):
+        """AC: --quiet must NOT suppress the misconfiguration warning."""
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        router = _stub_router({1: "/FUSED_LINE"})
+        loaded = {"TYPO_KEY": _sidecar_entry("Heavy", priority=5)}
+        args = SimpleNamespace(_loaded_net_class_map=loaded)
+
+        # quiet=True is the softstart-rev-B condition; the warning must
+        # still reach stderr.
+        _apply_net_class_map_sidecar(router, args, quiet=True)
+
+        err = capsys.readouterr().err
+        assert "WARNING" in err
+        assert "TYPO_KEY" in err
+
+    def test_no_op_when_flag_absent(self, capsys):
+        """No sidecar loaded -> no changes, no output."""
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        router = _stub_router({1: "/FUSED_LINE"})
+        args = SimpleNamespace(_loaded_net_class_map=None)
+
+        _apply_net_class_map_sidecar(router, args, quiet=True)
+
+        assert router.net_class_map == {}
+        assert capsys.readouterr().err == ""
+
+    def test_user_supplied_prefix_still_matches(self, capsys):
+        """A user who writes the full '/'-prefixed key still resolves exactly."""
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        router = _stub_router({1: "/FUSED_LINE"})
+        loaded = {"/FUSED_LINE": _sidecar_entry("Heavy", priority=5)}
+        args = SimpleNamespace(_loaded_net_class_map=loaded)
+
+        _apply_net_class_map_sidecar(router, args, quiet=True)
+
+        assert router.net_class_map["/FUSED_LINE"].priority == 5
+        assert "WARNING" not in capsys.readouterr().err

--- a/tests/test_net_names.py
+++ b/tests/test_net_names.py
@@ -1,0 +1,158 @@
+"""Unit tests for the hierarchical net-name normalizer (Issue #4149).
+
+Pure tests for :mod:`kicad_tools.router.net_names` — no CLI plumbing.
+Covers the suffix normalizer, the collision-detecting index, single-key
+resolution (exact / unique-suffix / ambiguous / absent), the nearest-name
+hint, and the aggregate sidecar resolver.
+"""
+
+from __future__ import annotations
+
+from kicad_tools.router.net_names import (
+    NetKeyResolution,
+    build_net_name_index,
+    nearest_net_names,
+    net_name_suffix,
+    resolve_net_class_map_keys,
+    resolve_net_key,
+)
+
+
+class TestNetNameSuffix:
+    def test_root_sheet_prefix_stripped(self):
+        assert net_name_suffix("/FUSED_LINE") == "FUSED_LINE"
+
+    def test_nested_sheet_takes_last_segment(self):
+        assert net_name_suffix("/A/B/FUSED_LINE") == "FUSED_LINE"
+
+    def test_bare_name_unchanged(self):
+        assert net_name_suffix("GND") == "GND"
+
+    def test_power_symbol_with_plus_unchanged(self):
+        assert net_name_suffix("+3.3V") == "+3.3V"
+
+
+class TestBuildNetNameIndex:
+    def test_prefixed_and_bare_grouped_by_suffix(self):
+        index = build_net_name_index(["/FUSED_LINE", "GND", "+3.3V"])
+        assert index["FUSED_LINE"] == ["/FUSED_LINE"]
+        assert index["GND"] == ["GND"]
+        assert index["+3.3V"] == ["+3.3V"]
+
+    def test_collision_lists_both_candidates(self):
+        index = build_net_name_index(["/A", "A"])
+        assert index["A"] == ["/A", "A"]
+
+    def test_nested_collision(self):
+        index = build_net_name_index(["/X/A", "/Y/A"])
+        assert index["A"] == ["/X/A", "/Y/A"]
+
+    def test_duplicate_raw_names_collapse(self):
+        index = build_net_name_index(["/A", "/A"])
+        assert index["A"] == ["/A"]
+
+
+class TestResolveNetKey:
+    def test_bare_key_matches_prefixed_net(self):
+        index = build_net_name_index(["/FUSED_LINE"])
+        res = resolve_net_key("FUSED_LINE", index)
+        assert res.matched == "/FUSED_LINE"
+        assert not res.is_ambiguous
+
+    def test_exact_bare_match_unchanged(self):
+        index = build_net_name_index(["GND", "/FUSED_LINE"])
+        res = resolve_net_key("GND", index)
+        assert res.matched == "GND"
+
+    def test_user_supplied_prefix_exact_match(self):
+        index = build_net_name_index(["/FUSED_LINE"])
+        res = resolve_net_key("/FUSED_LINE", index)
+        assert res.matched == "/FUSED_LINE"
+
+    def test_nested_prefix_bare_key(self):
+        index = build_net_name_index(["/A/B/FUSED_LINE"])
+        res = resolve_net_key("FUSED_LINE", index)
+        assert res.matched == "/A/B/FUSED_LINE"
+
+    def test_ambiguous_key_matches_none(self):
+        index = build_net_name_index(["/A", "A"])
+        res = resolve_net_key("A", index)
+        assert res.matched is None
+        assert res.is_ambiguous
+        assert set(res.ambiguous) == {"/A", "A"}
+
+    def test_exact_wins_over_ambiguity(self):
+        # When the key is itself a raw board net, exact match wins even
+        # though the suffix collides — a fully-qualified key is never
+        # treated as ambiguous.
+        index = build_net_name_index(["/A", "A"])
+        res = resolve_net_key("/A", index)
+        assert res.matched == "/A"
+        assert not res.is_ambiguous
+
+    def test_no_match(self):
+        index = build_net_name_index(["/FUSED_LINE"])
+        res = resolve_net_key("FUSED_LIN", index)
+        assert res.matched is None
+        assert not res.is_ambiguous
+
+    def test_resolution_dataclass_defaults(self):
+        res = NetKeyResolution(key="X")
+        assert res.matched is None
+        assert res.ambiguous == ()
+        assert not res.is_ambiguous
+
+
+class TestNearestNetNames:
+    def test_suffix_hint_for_prefixed_net(self):
+        hits = nearest_net_names("FUSED_LINE", ["/FUSED_LINE", "GND"])
+        assert "/FUSED_LINE" in hits
+
+    def test_typo_prefix_containment(self):
+        hits = nearest_net_names("FUSED_LIN", ["/FUSED_LINE", "GND"])
+        assert "/FUSED_LINE" in hits
+
+    def test_no_similar_returns_empty(self):
+        hits = nearest_net_names("ZZZZ", ["GND", "+3.3V"])
+        assert hits == []
+
+    def test_respects_limit(self):
+        board = ["/A_1", "/A_2", "/A_3", "/A_4"]
+        hits = nearest_net_names("A", board, limit=2)
+        assert len(hits) == 2
+
+
+class TestResolveNetClassMapKeys:
+    def test_mixed_prefixed_and_bare(self):
+        board = ["/FUSED_LINE", "/PGND", "GND", "+3.3V"]
+        res = resolve_net_class_map_keys(["FUSED_LINE", "PGND", "GND"], board)
+        assert res.resolved == {
+            "/FUSED_LINE": "FUSED_LINE",
+            "/PGND": "PGND",
+            "GND": "GND",
+        }
+        assert res.unmatched == []
+        assert res.ambiguous == {}
+
+    def test_unmatched_key(self):
+        board = ["/FUSED_LINE", "GND"]
+        res = resolve_net_class_map_keys(["FUSED_LIN"], board)
+        assert res.resolved == {}
+        assert res.unmatched == ["FUSED_LIN"]
+
+    def test_ambiguous_key_partitioned(self):
+        board = ["/A", "A", "GND"]
+        res = resolve_net_class_map_keys(["A", "GND"], board)
+        # 'A' collides; 'GND' resolves.
+        assert res.resolved == {"GND": "GND"}
+        assert "A" in res.ambiguous
+        assert set(res.ambiguous["A"]) == {"/A", "A"}
+        assert res.unmatched == []
+
+    def test_total_counts_all_buckets(self):
+        board = ["/FUSED_LINE", "/A", "A"]
+        res = resolve_net_class_map_keys(["FUSED_LINE", "TYPO", "A"], board)
+        assert res.total == 3
+        assert len(res.resolved) == 1
+        assert len(res.unmatched) == 1
+        assert len(res.ambiguous) == 1


### PR DESCRIPTION
## Summary

KiCad names label-derived nets with the hierarchical root-sheet prefix (`/FUSED_LINE`) while power-symbol nets stay bare (`GND`, `+3.3V`). A `--net-class-map` sidecar keyed on bare names therefore matched **zero** prefixed board nets and silently ran the route untuned at exit 0 (softstart rev-B incident). This fixes the matching so bare keys resolve to `/`-prefixed nets, and adds a loud misconfiguration diagnostic for keys that still fail to resolve.

Scope is `--net-class-map` **only** (curator decision). The sibling selectors (`--skip-nets` / `--power-nets` / `--analog-nets`) share the same underlying bug; adopting the new shared helper for them is a **documented follow-up** and is intentionally NOT changed here. The helper is built and unit-tested so that follow-up is an import-and-swap.

## Changes

- **New `src/kicad_tools/router/net_names.py`** — shared, dependency-free normalizer/matcher:
  - `net_name_suffix()` — segment after the last `/` (handles arbitrary sheet nesting).
  - `build_net_name_index()` — `suffix -> [raw board nets]`, detects collisions.
  - `resolve_net_key()` — fully-qualified exact match > unique-suffix match > ambiguous > none. A bare key that collides across multiple board nets is refused (not silently assigned).
  - `nearest_net_names()` — lightweight prefix/suffix hint (no Levenshtein).
  - `resolve_net_class_map_keys()` — partitions sidecar keys into resolved / unmatched / ambiguous.
- **`_apply_net_class_map_sidecar` (route_cmd.py)** — resolves each sidecar key against `router.net_names`, rekeys overrides to the board's actual net name so `core.py`'s `net_class_map.get(net_name)` finds them, and emits an aggregate stderr diagnostic (`N/M entries matched a board net`) plus per-key nearest-name / ambiguity hints. Printed regardless of `--quiet`; exit code unchanged (advisory).
- **Docs** — one sentence in the `--net-class-map` help text (route_cmd.py + parser.py) documenting the `/` convention.
- **Tests** — new `tests/test_net_names.py` (pure unit) + `TestHierarchicalPrefixNormalization` in `tests/test_cli_route_net_class_map.py`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| #1 Bare key matches '/'-prefixed net; no warning | ✅ | `test_bare_key_matches_prefixed_net` |
| #2 Zero-match (typo) warns with nearest hint; others silent; exit 0 | ✅ | `test_zero_match_warns_with_nearest_hint` |
| #3 Full-zero-match aggregate warning fires | ✅ | `test_full_zero_match_aggregate_warning` |
| #4 Ambiguity (/A and A) → warning + neither overridden | ✅ | `test_ambiguous_key_applied_to_neither`, `test_ambiguous_key_matches_none` |
| #5 Exact bare match unchanged (no regression) | ✅ | `test_exact_bare_match_unchanged`, full route/net-class-map suite green |
| #6 Help text documents '/' convention | ✅ | route_cmd.py + parser.py help strings |
| #7 All fixtures synthetic | ✅ | Hand-built net maps + `NetClassRouting` entries, no real boards |
| --quiet does not suppress warning | ✅ | `test_warning_not_suppressed_by_quiet` |

## Test Plan

- `uv run pytest tests/test_net_names.py tests/test_cli_route_net_class_map.py` — 42 passed.
- `uv run pytest tests/ -k "net_class_map or route_cmd"` — 303 passed, 7 skipped (route merge path via `load_pcb_for_routing`).
- `uv run ruff check` / `ruff format` — clean.
- `uv run --extra dev python scripts/ci/check_mypy_baseline.py` — 0 new errors (within baseline).

## Follow-up (not in this PR)

Wire the same `net_names` helper into `--skip-nets`, `--power-nets`, and `--analog-nets`. Each has its own downstream consumption pattern (zone generation for `--power-nets`) needing separate regression tests; deferred per curator scope guidance.

Closes #4149