### PR TITLE
fix(route): wire --placement-feedback into rule-relaxation & combined-escalation paths (#4151)

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -2029,7 +2029,7 @@ def _auto_detect_anchored_refs(pcb) -> set[str]:
     return anchored
 
 
-def _resolve_placement_feedback_anchors(pcb, args) -> set[str]:
+def _resolve_placement_feedback_anchors(pcb, args, quiet: bool = False) -> set[str]:
     """Compute the final set of anchored refs for the feedback loop.
 
     Combines auto-detected anchors (connectors, locked footprints) with
@@ -2037,16 +2037,40 @@ def _resolve_placement_feedback_anchors(pcb, args) -> set[str]:
     any refs the user explicitly opted out via
     ``--placement-feedback-no-anchor``.
 
+    Issue #4151: user-supplied ``--placement-feedback-anchor`` /
+    ``--placement-feedback-no-anchor`` refs are validated against the
+    board's actual footprint references.  A typo'd ref that matches no
+    footprint used to be silently absorbed into the set with no signal;
+    we now emit a tolerant warning naming the unmatched ref(s) (same
+    silently-inert-configuration failure class as #4149).
+
     Args:
         pcb: Loaded PCB object.
         args: Parsed CLI args.
+        quiet: When True, suppress the unmatched-ref warning.
 
     Returns:
         Set of refs to anchor.
     """
+    board_refs = {
+        (getattr(fp, "reference", "") or "") for fp in getattr(pcb, "footprints", []) or []
+    }
+    board_refs.discard("")
+
+    requested_anchor = _parse_ref_list(getattr(args, "placement_feedback_anchor", None))
+    requested_no_anchor = _parse_ref_list(getattr(args, "placement_feedback_no_anchor", None))
+
+    if not quiet:
+        unknown = sorted((requested_anchor | requested_no_anchor) - board_refs)
+        if unknown:
+            print(
+                "Warning: --placement-feedback-anchor/--placement-feedback-no-anchor "
+                f"ref(s) not found on board: {', '.join(unknown)}"
+            )
+
     anchors = _auto_detect_anchored_refs(pcb)
-    anchors |= _parse_ref_list(getattr(args, "placement_feedback_anchor", None))
-    anchors -= _parse_ref_list(getattr(args, "placement_feedback_no_anchor", None))
+    anchors |= requested_anchor
+    anchors -= requested_no_anchor
     return anchors
 
 
@@ -2112,7 +2136,7 @@ def _run_placement_feedback(
             print(f"  Warning: could not load PCB for feedback ({exc}); skipping")
         return None
 
-    anchored = _resolve_placement_feedback_anchors(pcb, args)
+    anchored = _resolve_placement_feedback_anchors(pcb, args, quiet=quiet)
     if not quiet and anchored:
         print(f"  Anchored refs ({len(anchored)}): {', '.join(sorted(anchored))}")
 
@@ -2142,12 +2166,21 @@ def _run_placement_feedback(
     if _remaining is not None:
         outer_timeout = _remaining if outer_timeout is None else min(outer_timeout, _remaining)
 
+    # Issue #4151: gate the per-iteration firehose (candidate breakdowns,
+    # per-move deltas emitted by ``PlacementFeedbackLoop`` under
+    # ``self.verbose``) on ``-v``/``--verbose`` specifically, rather than
+    # on ``not quiet``.  The always-on one-line summary below
+    # (iterations / exit reason / components moved / final failed nets)
+    # is emitted independently whenever ``not quiet``, so a default run
+    # still gets telemetry -- just without the noisy per-iteration detail.
+    loop_verbose = (not quiet) and bool(getattr(args, "verbose", False))
+
     try:
         result = router.route_with_placement_feedback(
             pcb=pcb,
             max_adjustments=budget,
             use_negotiated=use_negotiated,
-            verbose=not quiet,
+            verbose=loop_verbose,
             fixed_refs=anchored,
             max_movement=max_movement,
             timeout=timeout,
@@ -2185,6 +2218,107 @@ def _run_placement_feedback(
             print(f"  Warning: could not write placement diff ({exc})")
 
     return diff_data
+
+
+def _maybe_run_placement_feedback_escalation(
+    final_result,
+    successful_result,
+    pcb_path: Path,
+    args,
+    quiet: bool,
+    *,
+    stall_label: str,
+) -> None:
+    """Engage placement-routing feedback at the tail of an escalation loop.
+
+    This is the shared hook used by ``route_with_layer_escalation`` and,
+    via this helper, by ``route_with_rule_relaxation`` and
+    ``route_with_combined_escalation`` (issue #4151).  Before this helper
+    existed, the latter two dispatch paths never referenced
+    ``_run_placement_feedback`` at all, so ``--placement-feedback`` was
+    parsed, forwarded, and silently dropped on the floor.
+
+    Behaviour:
+
+    * When ``--placement-feedback`` is not requested, this is a no-op
+      (byte-identical routing preserved).
+    * When requested and the escalation already fully succeeded
+      (``successful_result is not None``), the loop is not needed -- we
+      stay silent (this is the "not needed" state, distinct from the
+      "not supported" DISABLED state).
+    * When requested and there are still failed nets on a partial result,
+      the feedback loop runs and ``_run_placement_feedback`` emits its
+      one-line summary; ``final_result``'s completion stats are refreshed
+      from the post-feedback router state so optimize/save/summary all see
+      the correct numbers.
+    * When requested but the router produced no routes at all (nothing to
+      feed back into), emit an explicit
+      ``placement-feedback: DISABLED (...)`` line so the request is never
+      silently swallowed.
+
+    Args:
+        final_result: The chosen result object (mutated in place on run).
+        successful_result: The fully-successful result, or None.
+        pcb_path: Path to the (staged) input PCB.
+        args: Parsed CLI args.
+        quiet: Suppress output when True.
+        stall_label: Human-readable name of the escalation strategy for
+            the "Engaging" banner (e.g. "rule relaxation").
+    """
+    if not getattr(args, "placement_feedback", False):
+        return
+
+    # Fully-succeeded escalation: feedback is simply not needed.  Stay
+    # silent so "not needed" remains textually distinguishable from the
+    # "not supported / disabled" state below.
+    if successful_result is not None:
+        return
+
+    router = final_result.router
+
+    # No routes at all -> nothing to feed placement changes back into.
+    # Make the (previously silent) drop explicit rather than swallowing it.
+    if router.routes is None:
+        if not quiet:
+            print(
+                "placement-feedback: DISABLED (no routes produced by "
+                f"{stall_label}; nothing to feed back)"
+            )
+        return
+
+    if not router.get_failed_nets():
+        # All nets already routed on this partial-but-complete result; the
+        # loop has nothing to improve.  Not a DISABLED case.
+        return
+
+    if not quiet:
+        print(
+            f"\n--- Engaging placement-routing feedback "
+            f"({stall_label} stalled at {final_result.completion * 100:.0f}%) ---"
+        )
+    _run_placement_feedback(
+        router=router,
+        pcb_path=pcb_path,
+        args=args,
+        quiet=quiet,
+    )
+    # Refresh completion stats from the post-feedback router state so
+    # optimize/save/summary all see the correct numbers.
+    _refreshed_multi_pad_ids = {n for n, p in router.nets.items() if n > 0 and len(p) >= 2}
+    _refreshed = router.get_statistics(nets_to_route_ids=_refreshed_multi_pad_ids)
+    final_result.nets_routed = _refreshed["nets_routed"]
+    final_result.completion = (
+        final_result.nets_routed / final_result.nets_to_route
+        if final_result.nets_to_route > 0
+        else 1.0
+    )
+    final_result.success = final_result.completion >= args.min_completion
+    if not quiet:
+        print(
+            f"  Post-feedback: {final_result.nets_routed}/"
+            f"{final_result.nets_to_route} "
+            f"({final_result.completion * 100:.0f}%)"
+        )
 
 
 def _fill_zones_after_route(output_path: Path, quiet: bool = False) -> None:
@@ -4178,42 +4312,14 @@ def route_with_layer_escalation(
     #   * only when there are still failed nets to address.
     # The loop mutates ``final_result.router.routes`` in place, so we
     # refresh ``final_result``'s stats afterwards before optimize/save.
-    if (
-        successful_result is None
-        and getattr(args, "placement_feedback", False)
-        and final_result.router.routes is not None
-        and final_result.router.get_failed_nets()
-    ):
-        if not quiet:
-            print(
-                f"\n--- Engaging placement-routing feedback "
-                f"(escalation stalled at {final_result.completion * 100:.0f}%) ---"
-            )
-        _run_placement_feedback(
-            router=final_result.router,
-            pcb_path=pcb_path,
-            args=args,
-            quiet=quiet,
-        )
-        # Refresh completion stats from the post-feedback router state so
-        # optimize/save/summary all see the correct numbers.
-        _refreshed_multi_pad_ids = {
-            n for n, p in final_result.router.nets.items() if n > 0 and len(p) >= 2
-        }
-        _refreshed = final_result.router.get_statistics(nets_to_route_ids=_refreshed_multi_pad_ids)
-        final_result.nets_routed = _refreshed["nets_routed"]
-        final_result.completion = (
-            final_result.nets_routed / final_result.nets_to_route
-            if final_result.nets_to_route > 0
-            else 1.0
-        )
-        final_result.success = final_result.completion >= args.min_completion
-        if not quiet:
-            print(
-                f"  Post-feedback: {final_result.nets_routed}/"
-                f"{final_result.nets_to_route} "
-                f"({final_result.completion * 100:.0f}%)"
-            )
+    _maybe_run_placement_feedback_escalation(
+        final_result,
+        successful_result,
+        pcb_path,
+        args,
+        quiet,
+        stall_label="layer escalation",
+    )
 
     # Optimize traces
     if not args.no_optimize and final_result.router.routes:
@@ -4853,6 +4959,19 @@ def route_with_rule_relaxation(
         if not quiet:
             print("Error: No routing attempts succeeded")
         return 1
+
+    # Issue #4151: engage placement-routing feedback when --placement-feedback
+    # is set and rule relaxation stalled with unrouted nets.  Before this
+    # hook, --placement-feedback was silently dropped on the rule-relaxation
+    # dispatch path (--adaptive-rules without effective --auto-layers).
+    _maybe_run_placement_feedback_escalation(
+        final_result,
+        successful_result,
+        pcb_path,
+        args,
+        quiet,
+        stall_label="rule relaxation",
+    )
 
     # Check if at manufacturer minimum
     from kicad_tools.router import get_mfr_limits
@@ -7018,6 +7137,20 @@ def route_with_combined_escalation(
         if not quiet:
             print("Error: No routing attempts succeeded")
         return 1
+
+    # Issue #4151: engage placement-routing feedback when --placement-feedback
+    # is set and the combined layer x rule-tier search stalled with unrouted
+    # nets.  Before this hook, --placement-feedback was silently dropped on
+    # the combined-escalation dispatch path (--auto-layers --adaptive-rules
+    # together).
+    _maybe_run_placement_feedback_escalation(
+        final_result,
+        successful_result,
+        pcb_path,
+        args,
+        quiet,
+        stall_label="combined escalation",
+    )
 
     # Check if at manufacturer minimum
     from kicad_tools.router import get_mfr_limits

--- a/tests/test_route_cmd_placement_feedback.py
+++ b/tests/test_route_cmd_placement_feedback.py
@@ -572,6 +572,65 @@ class TestResolvePlacementFeedbackAnchors:
         assert anchors == set()
 
 
+class TestAnchorRefValidation:
+    """Issue #4151: warn on --placement-feedback-anchor refs that match
+    no footprint on the board (same silently-inert-configuration failure
+    class as #4149)."""
+
+    def test_unknown_anchor_ref_warns(self, capsys):
+        from kicad_tools.cli.route_cmd import _resolve_placement_feedback_anchors
+
+        pcb = _MockPCB([_MockFootprint("U1"), _MockFootprint("J1")])
+        args = SimpleNamespace(
+            placement_feedback_anchor="U1,NOTAREALREF",
+            placement_feedback_no_anchor=None,
+        )
+        anchors = _resolve_placement_feedback_anchors(pcb, args)
+        # Matched ref still anchors correctly.
+        assert "U1" in anchors
+        assert "NOTAREALREF" in anchors  # still absorbed (tolerant, non-fatal)
+        out = capsys.readouterr().out
+        assert "not found on board" in out
+        assert "NOTAREALREF" in out
+
+    def test_unknown_no_anchor_ref_warns(self, capsys):
+        from kicad_tools.cli.route_cmd import _resolve_placement_feedback_anchors
+
+        pcb = _MockPCB([_MockFootprint("J1")])
+        args = SimpleNamespace(
+            placement_feedback_anchor=None,
+            placement_feedback_no_anchor="TYPO9",
+        )
+        _resolve_placement_feedback_anchors(pcb, args)
+        out = capsys.readouterr().out
+        assert "not found on board" in out
+        assert "TYPO9" in out
+
+    def test_all_known_refs_no_warning(self, capsys):
+        from kicad_tools.cli.route_cmd import _resolve_placement_feedback_anchors
+
+        pcb = _MockPCB([_MockFootprint("U1"), _MockFootprint("U2")])
+        args = SimpleNamespace(
+            placement_feedback_anchor="U1",
+            placement_feedback_no_anchor="U2",
+        )
+        _resolve_placement_feedback_anchors(pcb, args)
+        out = capsys.readouterr().out
+        assert "not found on board" not in out
+
+    def test_quiet_suppresses_warning(self, capsys):
+        from kicad_tools.cli.route_cmd import _resolve_placement_feedback_anchors
+
+        pcb = _MockPCB([_MockFootprint("U1")])
+        args = SimpleNamespace(
+            placement_feedback_anchor="GHOST1",
+            placement_feedback_no_anchor=None,
+        )
+        _resolve_placement_feedback_anchors(pcb, args, quiet=True)
+        out = capsys.readouterr().out
+        assert out == ""
+
+
 class TestPlacementDiffPath:
     def test_explicit_output(self, tmp_path: Path):
         from kicad_tools.cli.route_cmd import _placement_diff_path
@@ -992,3 +1051,303 @@ class TestInnerParserPlacementFeedbackFlags:
         assert isinstance(call_kwargs["stagnation_patience"], int)
         assert call_kwargs["outer_timeout"] == 42.5
         assert isinstance(call_kwargs["outer_timeout"], float)
+
+
+# ---------------------------------------------------------------------------
+# Issue #4151: escalation-path wiring + -v gating
+# ---------------------------------------------------------------------------
+
+
+def _pf_args(**overrides):
+    """Args namespace sufficient for _run_placement_feedback / the
+    escalation hook helper."""
+    defaults = {
+        "placement_feedback": True,
+        "placement_feedback_budget": 3,
+        "placement_feedback_max_movement": 5.0,
+        "placement_feedback_anchor": None,
+        "placement_feedback_no_anchor": None,
+        "placement_feedback_stagnation_patience": 3,
+        "placement_feedback_outer_timeout": None,
+        "strategy": "negotiated",
+        "timeout": None,
+        "per_net_timeout": None,
+        "output": None,
+        "verbose": False,
+        "min_completion": 0.95,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _pf_result(**overrides):
+    """A minimal stand-in for RuleRelaxationResult / EscalationResult that
+    the shared hook mutates in place."""
+    defaults = {
+        "router": None,
+        "nets_routed": 10,
+        "nets_to_route": 20,
+        "completion": 0.5,
+        "success": False,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+class TestPlacementFeedbackEscalationHook:
+    """Issue #4151: the shared hook drives placement feedback on the
+    rule-relaxation and combined-escalation dispatch paths, which
+    previously dropped ``--placement-feedback`` on the floor silently."""
+
+    def _mock_router(self, failed_nets, routes="__default__"):
+        from unittest.mock import MagicMock
+
+        router = MagicMock()
+        router.routes = object() if routes == "__default__" else routes
+        router.get_failed_nets.return_value = list(failed_nets)
+        router.nets = {1: [object(), object()], 2: [object(), object()]}
+        router.get_statistics.return_value = {"nets_routed": 15}
+        return router
+
+    def test_runs_and_emits_summary_on_partial(self, capsys, tmp_path):
+        """Partial result with failed nets -> loop runs, one-line summary
+        (iterations / exit reason / components moved / final failed nets)
+        is emitted, and the result's completion stats are refreshed."""
+        from unittest.mock import MagicMock, patch
+
+        from kicad_tools.cli.route_cmd import (
+            _maybe_run_placement_feedback_escalation,
+        )
+
+        router = self._mock_router(failed_nets=[5, 6])
+        router.route_with_placement_feedback.return_value = MagicMock(
+            iterations=2,
+            exit_reason="pf_stagnated",
+            total_components_moved=3,
+            failed_nets=[6],
+            placement_diff=[],
+        )
+        result = _pf_result(router=router)
+        stub_pcb = MagicMock()
+        stub_pcb.footprints = []
+
+        with (
+            patch("kicad_tools.schema.pcb.PCB.load", return_value=stub_pcb),
+            patch("pathlib.Path.write_text", return_value=None),
+        ):
+            _maybe_run_placement_feedback_escalation(
+                result,
+                None,  # successful_result -> partial
+                tmp_path / "board.kicad_pcb",
+                _pf_args(),
+                quiet=False,
+                stall_label="rule relaxation",
+            )
+
+        out = capsys.readouterr().out
+        assert "Engaging placement-routing feedback" in out
+        assert "rule relaxation stalled" in out
+        assert "Feedback iterations: 2" in out
+        assert "Exit reason:" in out
+        assert "Components moved:   3" in out
+        assert "Final failed nets:" in out
+        # The loop actually ran (not just reported).
+        assert router.route_with_placement_feedback.called
+        # Completion stats refreshed from post-feedback router state.
+        assert result.nets_routed == 15
+        assert result.completion == 15 / 20
+
+    def test_combined_label_runs(self, capsys, tmp_path):
+        """Same hook, combined-escalation label -> loop runs."""
+        from unittest.mock import MagicMock, patch
+
+        from kicad_tools.cli.route_cmd import (
+            _maybe_run_placement_feedback_escalation,
+        )
+
+        router = self._mock_router(failed_nets=[7])
+        router.route_with_placement_feedback.return_value = MagicMock(
+            iterations=1,
+            exit_reason="pf_converged",
+            total_components_moved=1,
+            failed_nets=[],
+            placement_diff=[],
+        )
+        result = _pf_result(router=router)
+        stub_pcb = MagicMock()
+        stub_pcb.footprints = []
+
+        with (
+            patch("kicad_tools.schema.pcb.PCB.load", return_value=stub_pcb),
+            patch("pathlib.Path.write_text", return_value=None),
+        ):
+            _maybe_run_placement_feedback_escalation(
+                result,
+                None,
+                tmp_path / "board.kicad_pcb",
+                _pf_args(),
+                quiet=False,
+                stall_label="combined escalation",
+            )
+
+        out = capsys.readouterr().out
+        assert "combined escalation stalled" in out
+        assert router.route_with_placement_feedback.called
+
+    def test_disabled_line_when_no_routes(self, capsys, tmp_path):
+        """Requested but no routes produced -> explicit DISABLED line,
+        never silent."""
+        from kicad_tools.cli.route_cmd import (
+            _maybe_run_placement_feedback_escalation,
+        )
+
+        router = self._mock_router(failed_nets=[1], routes=None)
+        result = _pf_result(router=router)
+
+        _maybe_run_placement_feedback_escalation(
+            result,
+            None,
+            tmp_path / "board.kicad_pcb",
+            _pf_args(),
+            quiet=False,
+            stall_label="rule relaxation",
+        )
+
+        out = capsys.readouterr().out
+        assert "placement-feedback: DISABLED" in out
+        assert not router.route_with_placement_feedback.called
+
+    def test_silent_when_not_requested(self, capsys, tmp_path):
+        """--placement-feedback not set -> byte-identical no-op, no output."""
+        from kicad_tools.cli.route_cmd import (
+            _maybe_run_placement_feedback_escalation,
+        )
+
+        router = self._mock_router(failed_nets=[1])
+        result = _pf_result(router=router)
+
+        _maybe_run_placement_feedback_escalation(
+            result,
+            None,
+            tmp_path / "board.kicad_pcb",
+            _pf_args(placement_feedback=False),
+            quiet=False,
+            stall_label="rule relaxation",
+        )
+
+        assert capsys.readouterr().out == ""
+        assert not router.route_with_placement_feedback.called
+
+    def test_silent_when_fully_succeeded(self, capsys, tmp_path):
+        """Escalation fully succeeded -> feedback not needed; no DISABLED
+        line (distinct from the not-supported state)."""
+        from kicad_tools.cli.route_cmd import (
+            _maybe_run_placement_feedback_escalation,
+        )
+
+        router = self._mock_router(failed_nets=[])
+        result = _pf_result(router=router)
+        successful = _pf_result(router=router, completion=1.0, success=True)
+
+        _maybe_run_placement_feedback_escalation(
+            result,
+            successful,
+            tmp_path / "board.kicad_pcb",
+            _pf_args(),
+            quiet=False,
+            stall_label="rule relaxation",
+        )
+
+        out = capsys.readouterr().out
+        assert "DISABLED" not in out
+        assert not router.route_with_placement_feedback.called
+
+    def test_silent_when_no_failed_nets(self, capsys, tmp_path):
+        """Partial result but zero failed nets -> nothing to improve; the
+        loop does not run and no DISABLED line prints (not-needed state)."""
+        from kicad_tools.cli.route_cmd import (
+            _maybe_run_placement_feedback_escalation,
+        )
+
+        router = self._mock_router(failed_nets=[])
+        result = _pf_result(router=router)
+
+        _maybe_run_placement_feedback_escalation(
+            result,
+            None,
+            tmp_path / "board.kicad_pcb",
+            _pf_args(),
+            quiet=False,
+            stall_label="rule relaxation",
+        )
+
+        out = capsys.readouterr().out
+        assert "DISABLED" not in out
+        assert not router.route_with_placement_feedback.called
+
+    def test_escalation_functions_call_the_hook(self):
+        """Guard against a future regression that removes the hook call
+        from either previously-silent dispatch path."""
+        import inspect
+
+        from kicad_tools.cli import route_cmd
+
+        for fn_name in (
+            "route_with_rule_relaxation",
+            "route_with_combined_escalation",
+            "route_with_layer_escalation",
+        ):
+            src = inspect.getsource(getattr(route_cmd, fn_name))
+            assert "_maybe_run_placement_feedback_escalation(" in src, (
+                f"{fn_name} must invoke the placement-feedback hook"
+            )
+
+
+class TestPlacementFeedbackVerboseGating:
+    """Issue #4151: per-iteration firehose is gated on -v; the always-on
+    summary line is independent of -v."""
+
+    def _run(self, verbose):
+        from unittest.mock import MagicMock, patch
+
+        from kicad_tools.cli.route_cmd import _run_placement_feedback
+
+        args = _pf_args(verbose=verbose)
+        router = MagicMock()
+        router.get_failed_nets.return_value = [1]
+        router.route_with_placement_feedback.return_value = MagicMock(
+            iterations=1,
+            exit_reason="pf_converged",
+            total_components_moved=0,
+            failed_nets=[],
+            placement_diff=[],
+        )
+        stub_pcb = MagicMock()
+        stub_pcb.footprints = []
+
+        with (
+            patch("kicad_tools.schema.pcb.PCB.load", return_value=stub_pcb),
+            patch("pathlib.Path.write_text", return_value=None),
+        ):
+            _run_placement_feedback(
+                router=router,
+                pcb_path=Path("/tmp/does_not_matter.kicad_pcb"),
+                args=args,
+                quiet=False,
+            )
+        return router.route_with_placement_feedback.call_args.kwargs
+
+    def test_loop_verbose_false_without_v(self):
+        kwargs = self._run(verbose=False)
+        assert kwargs["verbose"] is False
+
+    def test_loop_verbose_true_with_v(self):
+        kwargs = self._run(verbose=True)
+        assert kwargs["verbose"] is True
+
+    def test_summary_present_regardless_of_v(self, capsys):
+        """The one-line summary is emitted whether or not -v is passed."""
+        self._run(verbose=False)
+        out = capsys.readouterr().out
+        assert "Feedback iterations: 1" in out
+        assert "Exit reason:" in out


### PR DESCRIPTION
## Summary

`kct route --placement-feedback` was silently dropped on two of the five routing-dispatch paths. The flag was parsed, forwarded through `cli/commands/routing.py`, and then **never executed and emitted no output at all** when dispatch landed on:

- `route_with_rule_relaxation` — reached via `--adaptive-rules` without effective `--auto-layers` (`--no-auto-layers --adaptive-rules`)
- `route_with_combined_escalation` — reached via `--auto-layers --adaptive-rules` together

This is the "silently-inert configuration" failure class named in the issue (same as `--net-class-map` in #4149).

## What changed

1. **Fix the silent-disable (Option B — full wiring, per issue's stated preference to actually run the feature).** Extracted the existing `route_with_layer_escalation` placement-feedback hook into a shared `_maybe_run_placement_feedback_escalation()` helper and invoked it at the terminal (post-results) branch of `route_with_rule_relaxation` and `route_with_combined_escalation`. `--placement-feedback` now **runs** on all dispatch paths.
2. **Never-silent telemetry.** When the loop runs, the one-line summary (`Feedback iterations` / `Exit reason` / `Components moved` / `Final failed nets` / `Placement diff saved to`) is emitted. When placement feedback is requested but the router produced no routes, an explicit `placement-feedback: DISABLED (<reason>)` line prints. "Not needed" (fully succeeded / zero failed nets) stays silent and remains textually distinct from "not supported".
3. **`-v` gating.** The per-iteration firehose from `PlacementFeedbackLoop` is now gated on `-v`/`--verbose` (was `not quiet`); the always-on summary line is independent of `-v`.
4. **Anchor validation.** `--placement-feedback-anchor` / `--placement-feedback-no-anchor` refs are validated against the board's footprints; unmatched refs produce a tolerant warning (`Warning: ... not found on board: ...`), matching #4149's class.

## Manual verification

Ran `kct route tests/fixtures/routing-diagnostic.kicad_pcb --no-auto-layers --adaptive-rules --placement-feedback` (the previously-silent `route_with_rule_relaxation` path):

```
ADAPTIVE RULES SUMMARY
Result: Best result at tier 1 (75% completion)
--- Engaging placement-routing feedback (rule relaxation stalled at 75%) ---
  Feedback iterations: 2
  Exit reason:        pf_timeout
  Components moved:   1
  Final failed nets:  1
  Placement diff saved to: .../rr2_placement_diff.json
  Post-feedback: 3/4 (75%)
```

The loop **runs and moves a component** — not just reports. The combined-escalation path shares the identical helper.

## Tests

- `tests/test_route_cmd_placement_feedback.py`: escalation-hook runs + emits summary on both previously-silent paths (rule-relaxation and combined labels); DISABLED-line-on-no-routes; silent-when-not-requested; silent-when-fully-succeeded; silent-when-no-failed-nets; a static guard that all three escalation functions invoke the hook; anchor-ref validation warnings (unknown anchor / no-anchor / all-known / quiet); `-v` verbose gating + summary-present-regardless-of-`-v`.
- `tests/test_placement_feedback.py`: unchanged, still passing (loop verbosity is constructor-injected, unaffected by the route_cmd default change).

`uv run pytest tests/test_route_cmd_placement_feedback.py tests/test_placement_feedback.py -q` → 128 passed. `tests/test_chorus_test_placement_feedback.py` (local-only fixture) → 3 passed, 1 skipped, no regression. ruff clean; mypy: 0 new errors vs baseline.

Closes #4151

🤖 Generated with [Claude Code](https://claude.com/claude-code)