### PR TITLE
fix(datasheet): sanitize resolved part number before using it as a filename

### DIFF
--- a/src/kicad_tools/datasheet/cache.py
+++ b/src/kicad_tools/datasheet/cache.py
@@ -17,6 +17,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 from .models import Datasheet
+from .utils import sanitize_filename_component
 
 logger = logging.getLogger(__name__)
 
@@ -170,8 +171,10 @@ class DatasheetCache:
 
     def get_datasheet_path(self, part_number: str) -> Path:
         """Get the expected path for a datasheet file."""
-        # Normalize part number for filesystem
-        safe_name = "".join(c if c.isalnum() or c in "-_" else "_" for c in part_number)
+        # Normalize part number for filesystem using the shared sanitizer so
+        # the '-o'/output-dir branch in DatasheetManager.download() and the
+        # cache path stay consistent (both reject path separators / traversal).
+        safe_name = sanitize_filename_component(part_number)
         return self.cache_dir / safe_name / "datasheet.pdf"
 
     def is_cached(self, part_number: str, ignore_expiry: bool = False) -> bool:

--- a/src/kicad_tools/datasheet/manager.py
+++ b/src/kicad_tools/datasheet/manager.py
@@ -17,6 +17,7 @@ from .cache import DatasheetCache
 from .exceptions import DatasheetDownloadError, DatasheetSearchError
 from .models import Datasheet, DatasheetResult, DatasheetSearchResult
 from .sources import DatasheetSource, LCSCDatasheetSource, OctopartDatasheetSource
+from .utils import sanitize_filename_component
 
 if TYPE_CHECKING:
     pass
@@ -186,7 +187,22 @@ class DatasheetManager:
         if output_dir:
             output_dir = Path(output_dir)
             output_dir.mkdir(parents=True, exist_ok=True)
-            output_path = output_dir / f"{result.part_number}.pdf"
+            # Sanitize the resolved part number before using it as a filename:
+            # source-resolved names commonly contain '/' (e.g. Microchip
+            # "MCP6001UT-I/OT"), which would otherwise silently create a
+            # subdirectory, and a hostile/buggy source could return a
+            # traversal-shaped name that escapes output_dir.
+            safe_name = sanitize_filename_component(result.part_number)
+            output_path = output_dir / f"{safe_name}.pdf"
+            # Belt-and-suspenders: confirm the constructed path stays inside
+            # output_dir. Redundant given the allowlist sanitizer above, but
+            # guards against a future regression that loosens it.
+            resolved = output_path.resolve()
+            output_dir_resolved = output_dir.resolve()
+            if output_dir_resolved not in resolved.parents and resolved != output_dir_resolved:
+                raise DatasheetDownloadError(
+                    f"Refusing to write outside output directory: {output_path}"
+                )
         else:
             output_path = self.cache.get_datasheet_path(result.part_number)
 

--- a/src/kicad_tools/datasheet/utils.py
+++ b/src/kicad_tools/datasheet/utils.py
@@ -4,7 +4,46 @@ Utility functions for datasheet processing.
 
 from __future__ import annotations
 
+import re
+
 from kicad_tools.utils.scoring import calculate_string_confidence
+
+# Characters that are safe to keep verbatim in a single filename/directory
+# component. Everything else (path separators, whitespace, shell/FS-hostile
+# characters, unicode look-alikes, NTFS ADS ':', etc.) is replaced with '_'.
+_UNSAFE_FILENAME_CHARS = re.compile(r"[^A-Za-z0-9._-]")
+
+
+def sanitize_filename_component(name: str) -> str:
+    """
+    Sanitize a string for safe use as a single filename/directory component.
+
+    Uses a character allowlist (``A-Za-z0-9._-``): path separators ('/', '\\\\',
+    ``os.sep``) and every other filesystem-unsafe character are replaced with
+    '_'. Leading dots are then stripped so the result can never resolve to '.'
+    or '..' (preventing a path-traversal escape when this value is joined onto
+    a base output directory). Falls back to ``"unnamed_part"`` if the result
+    would otherwise be empty.
+
+    Examples::
+
+        sanitize_filename_component("MCP6001UT-I/OT")  # -> "MCP6001UT-I_OT"
+        sanitize_filename_component("../../escape")     # -> "_.._escape"
+        sanitize_filename_component("STM32F103C8T6")    # -> "STM32F103C8T6"
+
+    Args:
+        name: The raw string to sanitize (e.g. a source-resolved part number).
+
+    Returns:
+        A safe single filename component containing only allowlisted characters
+        and never a leading dot.
+    """
+    # The allowlist handles '/', '\\', os.sep, and anything else unsafe.
+    safe = _UNSAFE_FILENAME_CHARS.sub("_", name)
+    # Strip leading '.' sequences so "..", ".", "...foo" cannot produce a
+    # relative-path escape or a hidden file.
+    safe = safe.lstrip(".")
+    return safe or "unnamed_part"
 
 
 def calculate_part_confidence(query: str, part_number: str) -> float:

--- a/tests/test_datasheet.py
+++ b/tests/test_datasheet.py
@@ -18,7 +18,10 @@ from kicad_tools.datasheet.models import (
     DatasheetSearchResult,
 )
 from kicad_tools.datasheet.tables import ExtractedTable
-from kicad_tools.datasheet.utils import calculate_part_confidence
+from kicad_tools.datasheet.utils import (
+    calculate_part_confidence,
+    sanitize_filename_component,
+)
 
 
 class TestCalculatePartConfidence:
@@ -54,6 +57,43 @@ class TestCalculatePartConfidence:
         """Test None part number is handled gracefully as empty string."""
         # None is converted to empty string, which is a substring of any string
         assert calculate_part_confidence("STM32", None) == 0.9
+
+
+class TestSanitizeFilenameComponent:
+    """Tests for sanitize_filename_component utility function."""
+
+    def test_normal_part_number_passthrough(self):
+        """A part number with only safe characters is unchanged."""
+        assert sanitize_filename_component("STM32F103C8T6") == "STM32F103C8T6"
+
+    def test_allows_dot_dash_underscore(self):
+        """Dots, dashes, and underscores are preserved (readable names)."""
+        assert sanitize_filename_component("ATmega328P-PU") == "ATmega328P-PU"
+        assert sanitize_filename_component("part_v1.2") == "part_v1.2"
+
+    def test_replaces_forward_slash(self):
+        """Forward slashes are replaced with '_' (no subdirectory)."""
+        assert sanitize_filename_component("MCP6001UT-I/OT") == "MCP6001UT-I_OT"
+
+    def test_replaces_backslash(self):
+        """Backslashes are replaced with '_'."""
+        assert sanitize_filename_component("foo\\bar") == "foo_bar"
+
+    def test_replaces_other_unsafe_chars(self):
+        """Whitespace, colons, and other unsafe characters become '_'."""
+        assert sanitize_filename_component("a b:c") == "a_b_c"
+
+    def test_strips_leading_dots_traversal(self):
+        """Leading-dot traversal payloads cannot escape via the result."""
+        # '/' is replaced first, then leading dots are stripped.
+        assert sanitize_filename_component("../../something") == "_.._something"
+        assert sanitize_filename_component("..secrets") == "secrets"
+        assert sanitize_filename_component(".hidden") == "hidden"
+
+    def test_empty_after_sanitization_fallback(self):
+        """An all-dots (or empty) input falls back to a safe name."""
+        assert sanitize_filename_component("...") == "unnamed_part"
+        assert sanitize_filename_component("") == "unnamed_part"
 
 
 class TestDatasheetResult:
@@ -891,6 +931,91 @@ class TestDatasheetManager:
             # Should not have called download
             mock_download.assert_not_called()
             assert datasheet.part_number == "CACHED"
+
+    def test_download_sanitizes_slash_in_part_number(self, manager, tmp_path):
+        """A '/' in the resolved part number is sanitized to a single file.
+
+        Part numbers like Microchip's "MCP6001UT-I/OT" must not silently
+        create a subdirectory under the output directory.
+        """
+        from kicad_tools.datasheet.models import DatasheetResult
+
+        output_dir = tmp_path / "out"
+        result = DatasheetResult(
+            part_number="MCP6001UT-I/OT",
+            manufacturer="Microchip",
+            description="Op-amp",
+            datasheet_url="https://example.com/mcp6001.pdf",
+            source="lcsc",
+        )
+
+        def fake_download(res, output_path):
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(b"%PDF content")
+            return output_path
+
+        with patch.object(manager.sources[0], "download", side_effect=fake_download):
+            datasheet = manager.download(result, output_dir=output_dir, force=True)
+
+        assert datasheet.local_path == output_dir / "MCP6001UT-I_OT.pdf"
+        assert datasheet.local_path.suffix == ".pdf"
+        assert datasheet.local_path.exists()
+        # No unintended subdirectory was created.
+        assert not (output_dir / "MCP6001UT-I").exists()
+
+    def test_download_rejects_path_traversal_in_part_number(self, manager, tmp_path):
+        """A traversal-shaped part number is confined to the output directory."""
+        from kicad_tools.datasheet.models import DatasheetResult
+
+        output_dir = tmp_path / "out"
+        result = DatasheetResult(
+            part_number="../../escape",
+            manufacturer="Evil",
+            description="Malicious",
+            datasheet_url="https://example.com/evil.pdf",
+            source="lcsc",
+        )
+
+        def fake_download(res, output_path):
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(b"%PDF content")
+            return output_path
+
+        with patch.object(manager.sources[0], "download", side_effect=fake_download):
+            datasheet = manager.download(result, output_dir=output_dir, force=True)
+
+        # The file lives directly inside output_dir, never above/outside it.
+        assert datasheet.local_path.resolve().parent == output_dir.resolve()
+        assert datasheet.local_path.suffix == ".pdf"
+        assert datasheet.local_path.exists()
+        # Nothing was written outside output_dir.
+        assert not (tmp_path / "escape.pdf").exists()
+        assert not (tmp_path.parent / "escape.pdf").exists()
+
+    def test_download_normal_part_number_unaffected(self, manager, tmp_path):
+        """A part number with no unsafe characters keeps its exact filename."""
+        from kicad_tools.datasheet.models import DatasheetResult
+
+        output_dir = tmp_path / "out"
+        result = DatasheetResult(
+            part_number="STM32F103C8T6",
+            manufacturer="ST",
+            description="MCU",
+            datasheet_url="https://example.com/stm32.pdf",
+            source="lcsc",
+        )
+
+        def fake_download(res, output_path):
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(b"%PDF content")
+            return output_path
+
+        with patch.object(manager.sources[0], "download", side_effect=fake_download):
+            datasheet = manager.download(result, output_dir=output_dir, force=True)
+
+        assert datasheet.local_path == output_dir / "STM32F103C8T6.pdf"
+        assert datasheet.local_path.suffix == ".pdf"
+        assert datasheet.local_path.exists()
 
     def test_download_by_part(self, manager):
         """Test download_by_part convenience method."""


### PR DESCRIPTION
## Summary

`kct datasheet download -o <dir>` derived the output filename directly from the
source-resolved part number without sanitization. Part numbers containing `/`
(e.g. Microchip's `MCP6001UT-I/OT`) silently created a subdirectory
(`MCP6001UT-I/` containing `OT.pdf`), and a hostile/buggy source returning a
traversal-shaped name (`../../something`) could write outside `-o`. The cache
path branch already sanitized inline, so this was an inconsistency between the
two output-path branches, not a missing concept.

## Changes

- **`datasheet/utils.py`**: add shared `sanitize_filename_component()` — allowlist
  (`A-Za-z0-9._-`), replaces path separators / other unsafe chars with `_`, and
  `lstrip(".")` so a name can never resolve to `.`/`..`; falls back to
  `unnamed_part` if empty.
- **`datasheet/manager.py`**: apply the helper at the `output_dir` filename site
  (`MCP6001UT-I/OT` → `MCP6001UT-I_OT.pdf`, single file, no subdir). Add a
  belt-and-suspenders `resolve()`/`parents` confinement check that raises
  `DatasheetDownloadError` if the constructed path would escape `output_dir`.
- **`datasheet/cache.py`**: refactor `get_datasheet_path()` to reuse the shared
  helper for consistency (behavior-equivalent for real part numbers; the only
  difference is `.` is now preserved, which no real cache key relies on).
- **`tests/test_datasheet.py`**: `TestSanitizeFilenameComponent` unit tests +
  three `TestDatasheetManager` download tests (slash, traversal, normal).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `/`-containing part → single sanitized file, no subdir | ✅ | `test_download_sanitizes_slash_in_part_number` asserts `MCP6001UT-I_OT.pdf` and `not (out/"MCP6001UT-I").exists()` |
| Traversal-shaped part confined to `-o` | ✅ | `test_download_rejects_path_traversal_in_part_number` asserts resolved parent == output_dir, nothing written outside |
| Normal part number unaffected | ✅ | `test_download_normal_part_number_unaffected` asserts `STM32F103C8T6.pdf` unchanged |
| `.pdf` extension preserved | ✅ | each download test asserts `.suffix == ".pdf"` |
| Cache `get_datasheet_path()` behavior unchanged | ✅ | `test_get_datasheet_path` + full `TestDatasheetCache` still pass |

## Test Plan

- `uv run pytest tests/test_datasheet.py -q` → 165 passed
- `uv run ruff check` + `ruff format --check` → clean
- `uv run --extra dev python scripts/ci/check_mypy_baseline.py` → 0 new errors (within baseline)

Closes #4183