### PR TITLE
fix(router): rescue budget-starved stranded nets after negotiation (#4159)

### DIFF
--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -217,6 +217,11 @@ def run_route_command(args) -> int:
     # what makes flag-off byte-identical (sub_argv unchanged when absent).
     if getattr(args, "monotone_certificate_order", False):
         sub_argv.append("--monotone-certificate-order")
+    # Issue #4159: forward --no-rescue-pass.  Both parsers declare it as
+    # store_true defaulting to False (rescue sweep ON by default), so only
+    # forward when the user set it (byte-identical when absent).
+    if getattr(args, "no_rescue_pass", False):
+        sub_argv.append("--no-rescue-pass")
     if getattr(args, "cross_package_pair_corridor", False):
         sub_argv.append("--cross-package-pair-corridor")
     if getattr(args, "slack_corridor_widening", False):

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2858,6 +2858,20 @@ def _add_route_parser(subparsers) -> None:
         ),
     )
     route_parser.add_argument(
+        "--no-rescue-pass",
+        action="store_true",
+        default=False,
+        help=(
+            "Disable the post-negotiation rescue sweep (Issue #4159).  ON by "
+            "default: after the negotiated batch loop converges/stalls/times "
+            "out, each still-stranded net is re-attempted SOLO on the live "
+            "grid, recovering long-haul nets the batch loop starved on per-net "
+            "search budget.  Bounded and strictly additive (failed attempts "
+            "roll back), so it can only raise the routed count.  Pass this "
+            "flag for the raw negotiated result (e.g. A/B comparison)."
+        ),
+    )
+    route_parser.add_argument(
         "--cross-package-pair-corridor",
         action="store_true",
         default=False,

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -2928,6 +2928,21 @@ def _apply_ripup_budget_override(router: "Autorouter", args) -> None:
     router.stall_ripup_budget = budget
 
 
+def _apply_rescue_pass_override(router: "Autorouter", args) -> None:
+    """Disable the post-negotiation rescue sweep when requested (Issue #4159).
+
+    ON by default (``router._post_negotiation_rescue`` initialised True): after
+    the negotiated batch loop converges/stalls/times out, each still-stranded
+    net is re-attempted SOLO on the live grid, recovering long-hauls the batch
+    loop starved on per-net budget.  The pass is bounded and strictly additive
+    (failed attempts roll back), so it only raises the routed count.
+    ``--no-rescue-pass`` sets the flag False for A/B comparison or when a caller
+    wants the raw negotiated result.  A no-op when the flag is absent.
+    """
+    if getattr(args, "no_rescue_pass", False):
+        router._post_negotiation_rescue = False
+
+
 def _apply_bundle_river_planner(router: "Autorouter", args) -> None:
     """Enable the scoped bundle river planner when requested (Issue #4053).
 
@@ -3848,6 +3863,7 @@ def route_with_layer_escalation(
         # Issue #3470: thread --max-ripups-per-net into the destructive
         # rip-up budgets (route_all + two-phase stall recovery).
         _apply_ripup_budget_override(router, args)
+        _apply_rescue_pass_override(router, args)
         _apply_bundle_river_planner(router, args)
         _apply_monotone_certificate_order(router, args)
         _apply_cross_package_pair_corridor(router, args)
@@ -4729,6 +4745,7 @@ def route_with_rule_relaxation(
         # Issue #3470: thread --max-ripups-per-net into the destructive
         # rip-up budgets (route_all + two-phase stall recovery).
         _apply_ripup_budget_override(router, args)
+        _apply_rescue_pass_override(router, args)
         _apply_bundle_river_planner(router, args)
         _apply_monotone_certificate_order(router, args)
         _apply_cross_package_pair_corridor(router, args)
@@ -6852,6 +6869,7 @@ def route_with_combined_escalation(
             # Issue #3470: thread --max-ripups-per-net into the destructive
             # rip-up budgets (route_all + two-phase stall recovery).
             _apply_ripup_budget_override(router, args)
+            _apply_rescue_pass_override(router, args)
             _apply_bundle_river_planner(router, args)
             _apply_monotone_certificate_order(router, args)
             _apply_cross_package_pair_corridor(router, args)
@@ -7933,6 +7951,20 @@ def main(argv: list[str] | None = None) -> int:
             "certificate finds the bundle infeasible as-pinned, order is left "
             "at IDENTITY (no regression vs. flag-off).  Default OFF "
             "(byte-identical to prior behaviour when absent)."
+        ),
+    )
+    parser.add_argument(
+        "--no-rescue-pass",
+        action="store_true",
+        help=(
+            "Disable the post-negotiation rescue sweep (Issue #4159).  ON by "
+            "default: after the negotiated batch loop converges/stalls/times "
+            "out, each still-stranded net is re-attempted SOLO on the live "
+            "grid, recovering long-haul nets the batch loop starved on per-net "
+            "search budget (each such net routes in <1s alone).  The pass is "
+            "bounded and strictly additive (failed attempts roll back), so it "
+            "can only raise the routed count.  Pass this flag to get the raw "
+            "negotiated result (e.g. for A/B comparison)."
         ),
     )
     parser.add_argument(
@@ -9716,6 +9748,7 @@ def main(argv: list[str] | None = None) -> int:
     # Issue #3470: thread --max-ripups-per-net into the destructive
     # rip-up budgets (route_all + two-phase stall recovery).
     _apply_ripup_budget_override(router, args)
+    _apply_rescue_pass_override(router, args)
     _apply_bundle_river_planner(router, args)
     _apply_monotone_certificate_order(router, args)
     _apply_cross_package_pair_corridor(router, args)

--- a/src/kicad_tools/router/algorithms/__init__.py
+++ b/src/kicad_tools/router/algorithms/__init__.py
@@ -23,6 +23,8 @@ from .negotiated import (
     GRACE_PASS_TIER_CAPS_S,
     PER_NET_CAP_FLOOR_S,
     PER_NET_CAP_STAGE_FRACTION,
+    POST_NEGOTIATION_SWEEP_BUDGET_S,
+    POST_NEGOTIATION_SWEEP_PER_NET_S,
     NegotiatedRouter,
     calculate_congestion_tuned_params,
     calculate_history_increment,
@@ -52,6 +54,9 @@ __all__ = [
     "GRACE_PASS_PER_NET_S",
     "GRACE_PASS_TIER_CAPS_S",
     "run_initial_pass_grace",
+    # Post-negotiation rescue sweep (Issue #4159)
+    "POST_NEGOTIATION_SWEEP_BUDGET_S",
+    "POST_NEGOTIATION_SWEEP_PER_NET_S",
     # Per-net A* cap derivation (Issue #3474 R1)
     "PER_NET_CAP_FLOOR_S",
     "PER_NET_CAP_STAGE_FRACTION",

--- a/src/kicad_tools/router/algorithms/negotiated.py
+++ b/src/kicad_tools/router/algorithms/negotiated.py
@@ -60,6 +60,18 @@ GRACE_PASS_BUDGET_S = 60.0
 # that reason about the upper bound of any single grace attempt.
 GRACE_PASS_PER_NET_S = GRACE_PASS_TIER_CAPS_S[-1]
 
+# Issue #4159: post-negotiation rescue-sweep bounds.  After the negotiated
+# batch loop converges/stalls/times out, one bounded pass re-attempts every
+# still-stranded net SOLO on the live grid (existing committed copper is
+# already present as obstacles).  The issue's own evidence is that each such
+# net routes in <1s alone, so a generous but hard wall-clock ceiling plus a
+# per-net cap keeps the whole sweep bounded even when a genuinely-impossible
+# net is in the stranded set.  The overall ceiling mirrors GRACE_PASS_BUDGET_S
+# (they are the same shape of bounded post-loop sweep); the per-net cap is
+# clamped so one pathological solo search cannot eat the whole sweep.
+POST_NEGOTIATION_SWEEP_BUDGET_S = 60.0
+POST_NEGOTIATION_SWEEP_PER_NET_S = 10.0
+
 # Issue #3474 R1: abort threshold for a single grace attempt that grossly
 # overruns its cap.  ``route_fn`` legally spends a small multiple of the
 # per-call cap (see the ~15x note above), but a 100x+ overrun means a

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -37,6 +37,8 @@ from .algorithms import (
     GRACE_PASS_BUDGET_S,
     GRACE_PASS_TIER_CAPS_S,
     PER_NET_CAP_STAGE_FRACTION,
+    POST_NEGOTIATION_SWEEP_BUDGET_S,
+    POST_NEGOTIATION_SWEEP_PER_NET_S,
     HierarchicalRouter,
     MonteCarloRouter,
     MSTRouter,
@@ -1300,6 +1302,15 @@ class Autorouter:
         # (``route_with_escape`` -> ``route_all_two_phase``).
         self._route_all_max_ripups_per_net: int = 2
         self.stall_ripup_budget: int | None = None
+
+        # Issue #4159: post-negotiation rescue sweep.  After the negotiated
+        # batch loop converges/stalls/times out, re-attempt each still-
+        # stranded net SOLO on the live grid (a long-haul the batch loop
+        # starved on budget routes in <1s alone).  ON by default -- the
+        # pass is bounded and strictly additive (failed attempts roll back)
+        # so it can only raise the routed count.  ``--no-rescue-pass`` sets
+        # this to False.
+        self._post_negotiation_rescue: bool = True
 
         # Pre-route congestion estimator (Issue #2278)
         # Computed lazily before net ordering; provides RUDY-based
@@ -10603,6 +10614,55 @@ class Autorouter:
                 f"(now {successful_nets}/{total_nets} routed)"
             )
 
+        # Issue #4159: post-negotiation rescue sweep.  On a sparse board the
+        # negotiated batch loop can exhaust a long-haul net's per-net search
+        # budget under negotiation pressure and strand it, even though the
+        # net routes solo in <1s on the identical copper.  After the loop
+        # converges/stalls/times out AND the demote safety nets above have
+        # run, re-attempt each still-stranded net SOLO on the LIVE grid (every
+        # committed route is already an obstacle) via ``route_net``.  The pass
+        # is strictly additive and bounded (one attempt per net, per-net cap,
+        # overall wall-clock ceiling) and rolls back any failed attempt, so it
+        # can only ever raise the routed count -- never regress it.  On by
+        # default (it is a strict improvement); ``--no-rescue-pass`` disables
+        # it.  Runs AFTER the demotes so it never re-attempts a net that was
+        # just demoted for an unrepairable clearance violation.
+        if self._post_negotiation_rescue:
+            sweep_stranded = _stranded_nets()
+            if sweep_stranded:
+                # Bound the whole sweep.  Solo long-hauls are sub-second (the
+                # issue's evidence), so a generous ceiling is ample; when the
+                # loop already timed out the remaining budget is spent, so the
+                # sweep runs on its own contained allowance.  The per-net cap
+                # keeps one genuinely-impossible net from eating the sweep.
+                sweep_remaining: float | None = None
+                if timeout is not None:
+                    sweep_remaining = timeout - (time.time() - start_time)
+                if sweep_remaining is not None and sweep_remaining > 0 and not timed_out:
+                    sweep_budget = min(POST_NEGOTIATION_SWEEP_BUDGET_S, sweep_remaining)
+                else:
+                    sweep_budget = POST_NEGOTIATION_SWEEP_BUDGET_S
+                sweep_deadline = time.time() + max(0.0, sweep_budget)
+                sweep_per_net = per_net_timeout
+                if sweep_per_net is None:
+                    sweep_per_net = POST_NEGOTIATION_SWEEP_PER_NET_S
+                else:
+                    sweep_per_net = min(sweep_per_net, POST_NEGOTIATION_SWEEP_PER_NET_S)
+                sweep_rescued = self._post_negotiation_sweep(
+                    stranded_nets=sweep_stranded,
+                    net_routes=net_routes,
+                    pads_by_net=pads_by_net,
+                    per_net_timeout=sweep_per_net,
+                    deadline=sweep_deadline,
+                )
+                if sweep_rescued:
+                    successful_nets = sum(1 for routes in net_routes.values() if routes)
+                    flush_print(
+                        f"\n  ✓ Post-negotiation rescue recovered "
+                        f"{len(sweep_rescued)} stranded net(s): {sorted(sweep_rescued)} "
+                        f"(now {successful_nets}/{total_nets} routed)"
+                    )
+
         if progress_callback is not None:
             # Issue #2597: Distinguish ``stagnated`` from ``timeout`` and
             # bare ``f"overflow={N}"`` so callers (and CI) can pick the
@@ -11680,6 +11740,127 @@ class Autorouter:
                 break
 
         return total_corrected
+
+    def _post_negotiation_sweep(
+        self,
+        stranded_nets: list[int],
+        net_routes: dict[int, list[Route]],
+        pads_by_net: dict[int, list[Pad]],
+        per_net_timeout: float | None,
+        deadline: float | None,
+    ) -> list[int]:
+        """Rescue stranded nets solo on the live grid after negotiation.
+
+        Issue #4159: on a sparse board the negotiated batch loop can exhaust
+        a long-haul net's per-net search budget under negotiation pressure
+        and leave it stranded even though the geometry is trivial -- the same
+        net routes solo in <1s on the identical copper.  After the loop
+        converges/stalls/times out (and the demote safety nets above have
+        run), this bounded pass re-attempts every still-stranded net SOLO via
+        :meth:`route_net` on the **current** grid: every other net's
+        committed copper is already marked as an obstacle, so a solo attempt
+        settles into the free space the batch loop never committed.
+
+        The pass is strictly additive and bounded:
+
+        * Each net gets ONE attempt, capped by ``per_net_timeout`` (a solo
+          long-haul is sub-second per the issue's evidence).
+        * The whole pass respects ``deadline`` -- a genuinely-impossible net
+          that also fails solo cannot make the sweep hang.
+        * On success the net's routes are committed into ``net_routes`` and
+          its stale :class:`RoutingFailure` records are cleared.
+        * On failure the attempt is rolled back verbatim -- any partial
+          copper :meth:`route_net` marked for this net is ripped up and the
+          ``routing_failures`` list is truncated to its pre-attempt length --
+          so a failed rescue can never regress already-routed copper or leave
+          orphan geometry on the grid.  This mirrors the all-or-nothing
+          rollback discipline of :meth:`_post_route_clearance_correction`.
+
+        Args:
+            stranded_nets: Net IDs the loop left disconnected (from the
+                ``_stranded_nets`` closure in ``route_all_negotiated``).
+            net_routes: Mapping of net ID to its current routes (mutated on
+                a successful rescue).
+            pads_by_net: Mapping of net ID to its pads (used to verify a
+                rescued net is fully connected before committing).
+            per_net_timeout: Per-net A* budget for each solo attempt.
+            deadline: Optional absolute ``time.time()`` ceiling for the
+                whole sweep.  Checked before each net.
+
+        Returns:
+            The list of net IDs successfully rescued (committed).
+        """
+        import time as _time
+
+        from .observability import validate_net_connectivity as _validate_conn
+
+        rescued: list[int] = []
+        if not stranded_nets:
+            return rescued
+
+        # A NegotiatedRouter is only used here for its transactional
+        # ``rip_up_nets`` helper (grid unmark + routes_list removal), so a
+        # failed solo attempt unwinds exactly what it marked.
+        # ``self.router`` is ``CppPathfinder | Router`` at the type level but
+        # a concrete ``Router``/``CppPathfinder`` at runtime; every sibling
+        # ``NegotiatedRouter(self.grid, self.router, ...)`` construction in
+        # this file carries the same accepted-debt arg-type mismatch.
+        neg_router = NegotiatedRouter(
+            self.grid,
+            self.router,  # type: ignore[arg-type]
+            self.rules,
+            self.net_class_map,
+            congestion_estimator=self._ensure_congestion_estimator(),
+        )
+
+        for net in stranded_nets:
+            if deadline is not None and _time.time() >= deadline:
+                break
+            pads = pads_by_net.get(net)
+            if not pads or len(pads) < 2:
+                continue
+
+            # Snapshot the pre-attempt state so a failed solo route unwinds
+            # verbatim.  ``route_net`` marks any routes it produces onto the
+            # grid AND appends them to ``self.routes``; it also appends fresh
+            # RoutingFailure diagnostics on failure.  Both are reverted below
+            # when the net does not come back fully connected.
+            pre_routes = list(net_routes.get(net, []))
+            failures_len = len(self.routing_failures)
+
+            new_routes = self.route_net(net, per_net_timeout=per_net_timeout)
+
+            # ``route_net`` returns this net's routes (existing + new) and has
+            # marked the new ones on the grid.  Verify the net is now fully
+            # connected before committing -- a partial route is NOT a rescue.
+            candidate = list(net_routes.get(net, []))
+            candidate.extend(r for r in new_routes if r not in candidate)
+            conn = _validate_conn(candidate, {net: pads})
+            connected = bool(conn.get(net, {}).get("connected", False))
+
+            if connected and candidate:
+                net_routes[net] = candidate
+                # Clear this net's stale failure records (it is routed now).
+                self.routing_failures = [f for f in self.routing_failures if f.net != net]
+                rescued.append(net)
+            else:
+                # Roll back: rip up everything ``route_net`` just marked for
+                # this net (grid unmark + remove from self.routes), restore
+                # the pre-attempt net_routes entry, and drop the fresh failure
+                # diagnostics so the sweep leaves no residue.
+                to_unwind = list(net_routes.get(net, []))
+                to_unwind.extend(r for r in new_routes if r not in to_unwind)
+                temp_map = {net: to_unwind}
+                neg_router.rip_up_nets([net], temp_map, self.routes)
+                net_routes[net] = pre_routes
+                for route in pre_routes:
+                    # Re-mark any pre-existing copper the rip-up cleared.
+                    self._mark_route(route)
+                    if route not in self.routes:
+                        self.routes.append(route)
+                del self.routing_failures[failures_len:]
+
+        return rescued
 
     # =========================================================================
     # TWO-PHASE ROUTING (GLOBAL + DETAILED)

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -11813,11 +11813,29 @@ class Autorouter:
             congestion_estimator=self._ensure_congestion_estimator(),
         )
 
+        # Issue #4159 (Judge #4192): a differential-pair LEG must never be
+        # rescued by this SOLO ``route_net`` pass.  ``route_net`` is
+        # single-ended -- it ignores the pair's coupled length-matching and
+        # within-pair spacing -- so solo-routing one leg of a stranded pair
+        # produces exactly the board-07 regression: a leg that connects but
+        # then fails ``diffpair_length_skew`` / ``diffpair_routing_continuity``
+        # (and, when it drifts onto its partner, ``diffpair_clearance_intra``),
+        # raising the blocking-DRC count 8 -> 13.  A stranded diff-pair leg is
+        # the coupled router's job, not this sweep's; skipping legs keeps the
+        # sweep additive-for-DRC while still rescuing the single-ended
+        # power/long-haul nets it targets (the softstart motivating case).
+        diffpair_leg_names = set(self.get_diff_pair_map().keys())
+
         for net in stranded_nets:
             if deadline is not None and _time.time() >= deadline:
                 break
             pads = pads_by_net.get(net)
             if not pads or len(pads) < 2:
+                continue
+
+            # Skip differential-pair legs (see above): a solo re-route cannot
+            # honour the pair's coupling and would inject diff-pair DRC errors.
+            if self.net_names.get(net, "") in diffpair_leg_names:
                 continue
 
             # Snapshot the pre-attempt state so a failed solo route unwinds
@@ -11838,7 +11856,27 @@ class Autorouter:
             conn = _validate_conn(candidate, {net: pads})
             connected = bool(conn.get(net, {}).get("connected", False))
 
+            # Issue #4159 (Judge #4192): the sweep must be additive for the
+            # DRC-error count too, not only the net-completion count.  A solo
+            # ``route_net`` re-route skips the negotiated loop's clearance
+            # scrubbing (the ``_demote_*`` safety nets ran BEFORE the sweep),
+            # so a connected rescue can still commit copper that violates a
+            # foreign net's / partner leg's clearance -- exactly the board-07
+            # regression (within-pair coupling clearance -0.375mm < 0.100mm).
+            # A stranded net contributes ZERO copper pre-rescue, so any
+            # blocking clearance violation attributable to its freshly-marked
+            # copper is NET-NEW; if it introduces one, roll the net back
+            # verbatim (same path as a connectivity failure) and leave it
+            # stranded.  This restores the invariant: the sweep can raise the
+            # routed count AND never increases the blocking-DRC-error count.
+            drc_clean = True
             if connected and candidate:
+                candidate_new = [r for r in candidate if r not in pre_routes]
+                drc_clean = not self._rescued_net_adds_blocking_drc(
+                    net, candidate_new, net_routes, neg_router
+                )
+
+            if connected and candidate and drc_clean:
                 net_routes[net] = candidate
                 # Clear this net's stale failure records (it is routed now).
                 self.routing_failures = [f for f in self.routing_failures if f.net != net]
@@ -11847,7 +11885,9 @@ class Autorouter:
                 # Roll back: rip up everything ``route_net`` just marked for
                 # this net (grid unmark + remove from self.routes), restore
                 # the pre-attempt net_routes entry, and drop the fresh failure
-                # diagnostics so the sweep leaves no residue.
+                # diagnostics so the sweep leaves no residue.  Fires for a
+                # partial route (not connected) OR a connected-but-DRC-dirty
+                # rescue (net-new blocking clearance violation).
                 to_unwind = list(net_routes.get(net, []))
                 to_unwind.extend(r for r in new_routes if r not in to_unwind)
                 temp_map = {net: to_unwind}
@@ -11861,6 +11901,188 @@ class Autorouter:
                 del self.routing_failures[failures_len:]
 
         return rescued
+
+    def _rescued_net_adds_blocking_drc(
+        self,
+        net: int,
+        new_routes: list[Route],
+        net_routes: dict[int, list[Route]],
+        neg_router: NegotiatedRouter,
+    ) -> bool:
+        """Return True if a rescued net's fresh copper adds a blocking DRC error.
+
+        Issue #4159 (Judge #4192): the post-negotiation sweep re-routes a
+        stranded net SOLO via :meth:`route_net`, which does NOT run the
+        negotiated loop's clearance-scrubbing ``_demote_*`` safety nets (they
+        executed BEFORE the sweep).  A connected-but-DRC-dirty rescue would
+        raise the board's blocking-DRC-error count -- exactly the board-07
+        regression (within-pair coupling clearance ``-0.375mm < 0.100mm``).
+
+        This gate reuses the SAME per-net clearance validators the three
+        ``_demote_*`` finalization safety nets use, so the sweep's commit
+        decision agrees bit-for-bit with the checks the negotiated path
+        already trusts as "blocking":
+
+        * :meth:`NegotiatedRouter.find_segment_segment_violation_pairs`
+          (``copper_overlap_only=True``) -- the rescued net's copper
+          physically overlaps a FOREIGN net's copper (unmanufacturable
+          short; mirrors :meth:`_demote_seg_seg_overlap_nets`).  A negative
+          within-pair coupling clearance (the board-07 mode) is a physical
+          overlap between the two diff-pair legs -- distinct nets -- so it
+          is caught here.
+        * :meth:`RoutingGrid.worst_segment_pad_deficit` /
+          :meth:`RoutingGrid.worst_via_pad_deficit` -- copper vs a foreign
+          pad beyond nudge reach (mirrors
+          :meth:`_demote_pad_clearance_violation_nets`).
+        * :meth:`RoutingGrid.worst_via_segment_deficit` -- a via barrel
+          shorting a foreign-net trace (mirrors
+          :meth:`_demote_via_segment_violation_nets`).
+        * :func:`diffpair_routing.find_intra_pair_clearance_violations` --
+          the rescued net is one leg of a differential pair and its solo
+          re-route violated the per-pair intra-pair clearance floor against
+          its partner leg (catches positive-but-sub-floor within-pair gaps
+          the physical-overlap seg-seg check would miss).
+
+        A stranded net contributes ZERO copper before the rescue, so any
+        blocking violation attributable to ``new_routes`` is NET-NEW: the
+        caller rolls the net back rather than commit it, keeping the sweep's
+        additive guarantee true for the DRC-error count as well as the
+        net-completion count.
+
+        Args:
+            net: The rescued net id.
+            new_routes: The routes ``route_net`` freshly marked for ``net``
+                (the pre-existing routes are excluded by the caller).
+            net_routes: The current committed routes (the rescued copper is
+                already present in ``net_routes[net]`` and on the grid).
+            neg_router: A :class:`NegotiatedRouter` for the seg-seg
+                pair-detection engine (the same helper the demote passes use).
+
+        Returns:
+            ``True`` when the fresh copper introduces at least one net-new
+            blocking clearance violation; ``False`` when it is clean.
+        """
+        if not new_routes:
+            return False
+
+        nudge_reach = self.grid.resolution
+        pitches = self.component_pitches
+        own_refs = {ref for ref, _pin in self.nets.get(net, [])}
+
+        # --- Segment-vs-foreign-copper physical overlap (mirrors #3433) ---
+        # Restrict the seg-seg pair scan to the rescued net vs the rest of the
+        # committed universe.  ``copper_overlap_only=True`` fires only on
+        # physical overlap (negative edge-to-edge clearance), so it never
+        # false-positives on a legitimately-coupled diff-pair near-miss; a
+        # NEGATIVE within-pair coupling clearance (board-07) IS an overlap and
+        # is caught here.
+        extra = self._collect_extra_routes_for_revalidation(net_routes)
+        overlap_pairs = neg_router.find_segment_segment_violation_pairs(
+            net_routes,
+            trace_clearance=self.rules.trace_clearance,
+            extra_routes=extra,
+            copper_overlap_only=True,
+        )
+        if any(net in pair for pair in overlap_pairs):
+            return True
+
+        # --- Copper-vs-foreign-pad clearance beyond nudge reach (#3545/#3566) ---
+        for route in new_routes:
+            for seg in route.segments:
+                deficit, _loc = self.grid.worst_segment_pad_deficit(
+                    seg,
+                    exclude_net=net,
+                    component_pitches=pitches,
+                    exclude_refs=own_refs or None,
+                )
+                if deficit > nudge_reach:
+                    return True
+            for via in route.vias:
+                deficit, _loc = self.grid.worst_via_pad_deficit(
+                    via,
+                    exclude_net=net,
+                    component_pitches=pitches,
+                    exclude_refs=own_refs or None,
+                )
+                if deficit > nudge_reach:
+                    return True
+
+        # --- Via barrel shorting a foreign-net trace (#3486) ---
+        committed = [r for routes in net_routes.values() for r in routes]
+        for route in new_routes:
+            for via in route.vias:
+                deficit, _loc = self.grid.worst_via_segment_deficit(
+                    via,
+                    exclude_net=net,
+                    extra_routes=extra,
+                    foreign_routes=committed,
+                )
+                if deficit > nudge_reach:
+                    return True
+
+        # --- Differential-pair intra-pair clearance (#3023 / board-07) ---
+        # A solo ``route_net`` re-route of a diff-pair leg ignores the coupled
+        # within-pair spacing floor; check the rescued leg against its partner.
+        if self._rescued_leg_breaks_intra_pair_clearance(net, net_routes):
+            return True
+
+        return False
+
+    def _rescued_leg_breaks_intra_pair_clearance(
+        self,
+        net: int,
+        net_routes: dict[int, list[Route]],
+    ) -> bool:
+        """Return True if ``net`` is a diff-pair leg whose copper breaks the
+        per-pair intra-pair clearance floor against its partner leg.
+
+        Issue #4159 (Judge #4192): the board-07 rescue regression was a
+        within-pair coupling clearance violation -- a solo-rerouted diff-pair
+        leg drifting too close to (or overlapping) its partner.  This reuses
+        :func:`diffpair_routing.find_intra_pair_clearance_violations` with the
+        per-pair ``effective_intra_pair_clearance()`` threshold, the same
+        detector :meth:`diffpair_intra_clearance_violations` surfaces.
+        """
+        from .diffpair_routing import find_intra_pair_clearance_violations
+
+        net_name = self.net_names.get(net)
+        if not net_name:
+            return False
+
+        pair_map = self.get_diff_pair_map()
+        partner_name = pair_map.get(net_name)
+        if not partner_name:
+            return False
+
+        # Resolve the partner net id (reverse the net_names map).
+        partner_net: int | None = None
+        for nid, nname in self.net_names.items():
+            if nname == partner_name:
+                partner_net = nid
+                break
+        if partner_net is None:
+            return False
+
+        my_routes = net_routes.get(net, [])
+        partner_routes = net_routes.get(partner_net, [])
+        if not my_routes or not partner_routes:
+            return False
+
+        net_class = self.net_class_map.get(net_name)
+        if net_class is None:
+            return False
+        threshold = float(net_class.effective_intra_pair_clearance())
+        if threshold <= 0.0:
+            return False
+
+        for p_route in my_routes:
+            for n_route in partner_routes:
+                violation = find_intra_pair_clearance_violations(
+                    p_route, n_route, threshold, pair_name=net_name
+                )
+                if violation is not None:
+                    return True
+        return False
 
     # =========================================================================
     # TWO-PHASE ROUTING (GLOBAL + DETAILED)

--- a/tests/router/test_post_negotiation_sweep.py
+++ b/tests/router/test_post_negotiation_sweep.py
@@ -34,7 +34,8 @@ from kicad_tools.router.algorithms import (
 )
 from kicad_tools.router.algorithms.negotiated import NegotiatedRouter
 from kicad_tools.router.core import Autorouter
-from kicad_tools.router.primitives import Route
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.primitives import Route, Segment
 
 
 def _build_two_net_router() -> Autorouter:
@@ -196,6 +197,191 @@ class TestSweepMechanism:
         assert net_routes[2] == net2_before, "other nets must be untouched"
         assert len(ar.routes) == routes_len_before, "no orphan copper committed"
         assert len(ar.routing_failures) == failures_before, "no orphan failure records"
+
+    def test_drc_dirty_rescue_rolls_back(self, monkeypatch):
+        """Issue #4159 (Judge #4192): a rescue that CONNECTS the net but
+        commits copper physically overlapping a FOREIGN net's committed
+        trace is DRC-dirty (a net-new blocking clearance violation) and must
+        be rolled back verbatim -- the sweep is additive for the DRC-error
+        count, not only the net-completion count.
+
+        Repro: net 2 routes as a vertical trace at x=10 on F_CU.  Strand net
+        1, then patch its solo ``route_net`` to return a horizontal trace at
+        y=10 that CONNECTS net 1's two pads (2,10)->(38,10) but crosses net
+        2's copper at (10,10) with zero edge-to-edge clearance -- a physical
+        overlap the ``copper_overlap_only`` seg-seg gate flags as blocking.
+        The sweep must detect the net-new violation and leave net 1 stranded.
+        """
+        ar = _build_two_net_router()
+        ar.route_all_negotiated(max_iterations=2, timeout=30.0, adaptive=False, perturbation=False)
+        net_routes, pads_by_net = _snapshot_net_state(ar)
+
+        neg = NegotiatedRouter(
+            ar.grid,
+            ar.router,
+            ar.rules,
+            ar.net_class_map,
+            congestion_estimator=ar._ensure_congestion_estimator(),
+        )
+        neg.rip_up_nets([1], net_routes, ar.routes)
+        assert net_routes[1] == []
+        net2_before = list(net_routes[2])
+        routes_len_before = len(ar.routes)
+
+        # A connected-BUT-overlapping solo route for net 1: one horizontal
+        # segment joining both net-1 pads that lies on top of net 2's
+        # vertical trace at the (10,10) crossing (same layer, physical
+        # overlap => net-new blocking seg-seg violation).
+        def dirty_route_net(net, per_net_timeout=None):
+            seg = Segment(
+                x1=2.0,
+                y1=10.0,
+                x2=38.0,
+                y2=10.0,
+                width=0.2,
+                layer=Layer.F_CU,
+                net=net,
+                net_name="LONGHAUL",
+            )
+            route = Route(net=net, net_name="LONGHAUL", segments=[seg], vias=[])
+            ar._mark_route(route)
+            ar.routes.append(route)
+            net_routes.setdefault(net, []).append(route)
+            return [route]
+
+        monkeypatch.setattr(ar, "route_net", dirty_route_net)
+
+        rescued = ar._post_negotiation_sweep(
+            stranded_nets=[1],
+            net_routes=net_routes,
+            pads_by_net=pads_by_net,
+            per_net_timeout=POST_NEGOTIATION_SWEEP_PER_NET_S,
+            deadline=time.time() + POST_NEGOTIATION_SWEEP_BUDGET_S,
+        )
+        assert rescued == [], "DRC-dirty rescue must NOT be committed"
+        assert net_routes[1] == [], "DRC-dirty rescue must leave the net stranded"
+        assert net_routes[2] == net2_before, "foreign net must be untouched"
+        assert len(ar.routes) == routes_len_before, "no DRC-dirty copper committed"
+
+    def test_drc_clean_rescue_is_committed(self, monkeypatch):
+        """Control for ``test_drc_dirty_rescue_rolls_back``: a rescue that
+        connects the net WITHOUT overlapping foreign copper is committed --
+        the DRC gate must not reject a clean solo route.
+
+        Net 1's solo route runs along y=19.5 (clear of net 2's x=10 vertical
+        trace, which spans y=2..18), then drops to its pads: connected AND
+        clean, so the sweep commits it.
+        """
+        ar = _build_two_net_router()
+        ar.route_all_negotiated(max_iterations=2, timeout=30.0, adaptive=False, perturbation=False)
+        net_routes, pads_by_net = _snapshot_net_state(ar)
+
+        neg = NegotiatedRouter(
+            ar.grid,
+            ar.router,
+            ar.rules,
+            ar.net_class_map,
+            congestion_estimator=ar._ensure_congestion_estimator(),
+        )
+        neg.rip_up_nets([1], net_routes, ar.routes)
+
+        def clean_route_net(net, per_net_timeout=None):
+            # Detour below net 2's trace: (2,10)->(2,19.5)->(38,19.5)->(38,10).
+            segs = [
+                Segment(
+                    x1=2.0,
+                    y1=10.0,
+                    x2=2.0,
+                    y2=19.5,
+                    width=0.2,
+                    layer=Layer.F_CU,
+                    net=net,
+                    net_name="LONGHAUL",
+                ),
+                Segment(
+                    x1=2.0,
+                    y1=19.5,
+                    x2=38.0,
+                    y2=19.5,
+                    width=0.2,
+                    layer=Layer.F_CU,
+                    net=net,
+                    net_name="LONGHAUL",
+                ),
+                Segment(
+                    x1=38.0,
+                    y1=19.5,
+                    x2=38.0,
+                    y2=10.0,
+                    width=0.2,
+                    layer=Layer.F_CU,
+                    net=net,
+                    net_name="LONGHAUL",
+                ),
+            ]
+            route = Route(net=net, net_name="LONGHAUL", segments=segs, vias=[])
+            ar._mark_route(route)
+            ar.routes.append(route)
+            net_routes.setdefault(net, []).append(route)
+            return [route]
+
+        monkeypatch.setattr(ar, "route_net", clean_route_net)
+
+        rescued = ar._post_negotiation_sweep(
+            stranded_nets=[1],
+            net_routes=net_routes,
+            pads_by_net=pads_by_net,
+            per_net_timeout=POST_NEGOTIATION_SWEEP_PER_NET_S,
+            deadline=time.time() + POST_NEGOTIATION_SWEEP_BUDGET_S,
+        )
+        assert rescued == [1], "a clean, connected rescue must be committed"
+        assert net_routes[1], "rescued net must have committed routes"
+
+    def test_diffpair_leg_is_skipped(self, monkeypatch):
+        """Issue #4159 (Judge #4192): a stranded DIFFERENTIAL-PAIR LEG must
+        NOT be solo-rescued.  ``route_net`` is single-ended -- it ignores the
+        pair's coupled length-matching / within-pair spacing -- so rescuing
+        one leg produces the board-07 regression (a connected leg that then
+        fails ``diffpair_length_skew`` / ``diffpair_routing_continuity``,
+        raising the blocking-DRC count).  The sweep must skip the leg and
+        never call ``route_net`` for it.
+        """
+        ar = Autorouter(width=40.0, height=20.0)
+        # DAT_P / DAT_N are suffix-detected as a differential pair.
+        ar.add_component(
+            "U1",
+            [
+                {"number": "1", "x": 2.0, "y": 9.0, "net": 1, "net_name": "DAT_P"},
+                {"number": "2", "x": 38.0, "y": 9.0, "net": 1, "net_name": "DAT_P"},
+                {"number": "3", "x": 2.0, "y": 11.0, "net": 2, "net_name": "DAT_N"},
+                {"number": "4", "x": 38.0, "y": 11.0, "net": 2, "net_name": "DAT_N"},
+            ],
+        )
+        assert "DAT_P" in ar.get_diff_pair_map(), "test setup: DAT_P must be a diff-pair leg"
+
+        attempts: list[int] = []
+        orig = ar.route_net
+
+        def counting_route_net(net, per_net_timeout=None):
+            attempts.append(net)
+            return orig(net, per_net_timeout=per_net_timeout)
+
+        monkeypatch.setattr(ar, "route_net", counting_route_net)
+
+        # Net 1 (DAT_P) is stranded (no committed copper) and is a diff-pair
+        # leg; the sweep must skip it without ever invoking ``route_net``.
+        rescued = ar._post_negotiation_sweep(
+            stranded_nets=[1],
+            net_routes={1: [], 2: []},
+            pads_by_net={
+                1: [ar.pads[k] for k in ar.nets[1]],
+                2: [ar.pads[k] for k in ar.nets[2]],
+            },
+            per_net_timeout=POST_NEGOTIATION_SWEEP_PER_NET_S,
+            deadline=time.time() + POST_NEGOTIATION_SWEEP_BUDGET_S,
+        )
+        assert rescued == [], "a diff-pair leg must not be rescued"
+        assert attempts == [], "the sweep must not solo-route a diff-pair leg"
 
     def test_bounded_by_deadline(self):
         """A deadline already in the past terminates the sweep immediately

--- a/tests/router/test_post_negotiation_sweep.py
+++ b/tests/router/test_post_negotiation_sweep.py
@@ -1,0 +1,335 @@
+"""Tests for the post-negotiation rescue sweep (Issue #4159).
+
+Measured failure (rjwalters/softstart PR #28, sparse 160x100 4-layer,
+103 parts / 76 nets, C++ backend): ``kct route --strategy negotiated``
+plateaus at ~24-30/76 complete, dominated by cross-board power/long-haul
+nets.  Each such net then routes SOLO in <1s on the identical copper
+(``kct route-auto --net /FUSED_LINE`` -> instant success), so the geometry
+is trivial -- the batch negotiation exhausts the long net's per-net search
+budget under negotiation pressure and never commits it.
+
+The fix (suggested direction 1, curator-confirmed MVP): after the
+negotiated batch loop converges/stalls/times out and the demote safety
+nets have run, re-attempt every still-stranded net SOLO on the LIVE grid
+via ``Autorouter.route_net`` (every committed route is already an obstacle,
+so the solo attempt settles into free space the batch loop never used).
+The pass is bounded (one attempt per net, per-net cap, overall wall-clock
+ceiling) and strictly additive: a failed attempt rolls back verbatim, so
+it can only ever raise the routed count.
+
+The softstart repro fixture is local-only (not in CI), so these tests use
+synthetic boards.  The starvation is reproduced by patching the batch's
+internal per-net path (``_route_net_negotiated``) to hard-fail a specific
+net while leaving the sweep's ``route_net`` path real -- the exact split
+the curator identified (two structurally different single-net code paths).
+"""
+
+from __future__ import annotations
+
+import time
+
+from kicad_tools.router.algorithms import (
+    POST_NEGOTIATION_SWEEP_BUDGET_S,
+    POST_NEGOTIATION_SWEEP_PER_NET_S,
+)
+from kicad_tools.router.algorithms.negotiated import NegotiatedRouter
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.primitives import Route
+
+
+def _build_two_net_router() -> Autorouter:
+    """A long-haul 2-pad net (net 1, spans the board) plus an easy net 2.
+
+    Both route trivially on the open 40x20 grid; the long net is the one
+    the real softstart repro starves on under negotiation pressure.
+    """
+    router = Autorouter(width=40.0, height=20.0)
+    router.add_component(
+        "R1",
+        [
+            {"number": "1", "x": 2.0, "y": 10.0, "net": 1, "net_name": "LONGHAUL"},
+            {"number": "2", "x": 38.0, "y": 10.0, "net": 1, "net_name": "LONGHAUL"},
+        ],
+    )
+    router.add_component(
+        "R2",
+        [
+            {"number": "1", "x": 10.0, "y": 2.0, "net": 2, "net_name": "NET2"},
+            {"number": "2", "x": 10.0, "y": 18.0, "net": 2, "net_name": "NET2"},
+        ],
+    )
+    return router
+
+
+def _snapshot_net_state(ar: Autorouter) -> tuple[dict[int, list[Route]], dict]:
+    """Rebuild the ``net_routes`` / ``pads_by_net`` maps the loop hands the
+    sweep, from the router's live state after ``route_all_negotiated``."""
+    net_routes: dict[int, list[Route]] = {}
+    for r in ar.routes:
+        net_routes.setdefault(r.net, []).append(r)
+    pads_by_net = {net: [ar.pads[k] for k in keys] for net, keys in ar.nets.items()}
+    return net_routes, pads_by_net
+
+
+# ---------------------------------------------------------------------------
+# Bounds constants
+# ---------------------------------------------------------------------------
+
+
+class TestSweepConstants:
+    def test_budget_is_bounded(self):
+        assert 0 < POST_NEGOTIATION_SWEEP_BUDGET_S <= 120.0
+
+    def test_per_net_cap_is_small(self):
+        """A solo long-haul is sub-second per the issue's evidence; the
+        per-net cap must stay small so one genuinely-impossible net cannot
+        eat the whole sweep."""
+        assert 0 < POST_NEGOTIATION_SWEEP_PER_NET_S <= 30.0
+        assert POST_NEGOTIATION_SWEEP_PER_NET_S <= POST_NEGOTIATION_SWEEP_BUDGET_S
+
+
+# ---------------------------------------------------------------------------
+# Direct sweep-mechanism tests
+# ---------------------------------------------------------------------------
+
+
+class TestSweepMechanism:
+    def test_rescues_a_stranded_routable_net(self):
+        """Given a net that is stranded but routable solo on the live grid,
+        the sweep commits it and clears its failure records."""
+        ar = _build_two_net_router()
+        ar.route_all_negotiated(max_iterations=2, timeout=30.0, adaptive=False, perturbation=False)
+        net_routes, pads_by_net = _snapshot_net_state(ar)
+
+        # Strand net 1: rip it up so it is absent from the committed copper,
+        # exactly as a budget-starved batch loop would leave it.
+        neg = NegotiatedRouter(
+            ar.grid,
+            ar.router,
+            ar.rules,
+            ar.net_class_map,
+            congestion_estimator=ar._ensure_congestion_estimator(),
+        )
+        neg.rip_up_nets([1], net_routes, ar.routes)
+        assert net_routes[1] == []
+
+        rescued = ar._post_negotiation_sweep(
+            stranded_nets=[1],
+            net_routes=net_routes,
+            pads_by_net=pads_by_net,
+            per_net_timeout=POST_NEGOTIATION_SWEEP_PER_NET_S,
+            deadline=time.time() + POST_NEGOTIATION_SWEEP_BUDGET_S,
+        )
+        assert rescued == [1]
+        assert net_routes[1], "rescued net must have committed routes"
+        assert not any(f.net == 1 for f in ar.routing_failures)
+
+    def test_does_not_touch_already_routed_nets(self):
+        """The sweep is additive-only: nets not in the stranded set keep
+        their exact routes."""
+        ar = _build_two_net_router()
+        ar.route_all_negotiated(max_iterations=2, timeout=30.0, adaptive=False, perturbation=False)
+        net_routes, pads_by_net = _snapshot_net_state(ar)
+
+        neg = NegotiatedRouter(
+            ar.grid,
+            ar.router,
+            ar.rules,
+            ar.net_class_map,
+            congestion_estimator=ar._ensure_congestion_estimator(),
+        )
+        neg.rip_up_nets([1], net_routes, ar.routes)
+        net2_before = list(net_routes[2])
+
+        ar._post_negotiation_sweep(
+            stranded_nets=[1],
+            net_routes=net_routes,
+            pads_by_net=pads_by_net,
+            per_net_timeout=POST_NEGOTIATION_SWEEP_PER_NET_S,
+            deadline=time.time() + POST_NEGOTIATION_SWEEP_BUDGET_S,
+        )
+        assert net_routes[2] == net2_before, "untouched net must be byte-identical"
+
+    def test_failed_attempt_rolls_back_without_regression(self, monkeypatch):
+        """When a solo attempt cannot connect the net, the sweep rolls back
+        verbatim: no partial copper committed, no orphan failure records,
+        and other nets are untouched."""
+        ar = _build_two_net_router()
+        ar.route_all_negotiated(max_iterations=2, timeout=30.0, adaptive=False, perturbation=False)
+        net_routes, pads_by_net = _snapshot_net_state(ar)
+
+        neg = NegotiatedRouter(
+            ar.grid,
+            ar.router,
+            ar.rules,
+            ar.net_class_map,
+            congestion_estimator=ar._ensure_congestion_estimator(),
+        )
+        neg.rip_up_nets([1], net_routes, ar.routes)
+        net2_before = list(net_routes[2])
+        routes_len_before = len(ar.routes)
+        failures_before = len(ar.routing_failures)
+
+        # Simulate a route_net that marks a DISCONNECTED fragment (a stub
+        # that does not connect the net's two pads) and records a failure --
+        # the batch-starvation partial-route case.  The sweep must detect the
+        # net is not fully connected and unwind everything.
+        def fake_route_net(net, per_net_timeout=None):
+            frag = Route(net=net, net_name="LONGHAUL", segments=[], vias=[])
+            ar._mark_route(frag)
+            ar.routes.append(frag)
+            net_routes.setdefault(net, []).append(frag)
+            ar.routing_failures.append(_make_failure(net))
+            return [frag]
+
+        monkeypatch.setattr(ar, "route_net", fake_route_net)
+
+        rescued = ar._post_negotiation_sweep(
+            stranded_nets=[1],
+            net_routes=net_routes,
+            pads_by_net=pads_by_net,
+            per_net_timeout=POST_NEGOTIATION_SWEEP_PER_NET_S,
+            deadline=time.time() + POST_NEGOTIATION_SWEEP_BUDGET_S,
+        )
+        assert rescued == []
+        assert net_routes[1] == [], "failed attempt must leave net stranded"
+        assert net_routes[2] == net2_before, "other nets must be untouched"
+        assert len(ar.routes) == routes_len_before, "no orphan copper committed"
+        assert len(ar.routing_failures) == failures_before, "no orphan failure records"
+
+    def test_bounded_by_deadline(self):
+        """A deadline already in the past terminates the sweep immediately
+        without attempting any net (the hard bound that keeps a genuinely-
+        impossible stranded net from hanging the pass)."""
+        ar = _build_two_net_router()
+        ar.route_all_negotiated(max_iterations=2, timeout=30.0, adaptive=False, perturbation=False)
+        net_routes, pads_by_net = _snapshot_net_state(ar)
+
+        neg = NegotiatedRouter(
+            ar.grid,
+            ar.router,
+            ar.rules,
+            ar.net_class_map,
+            congestion_estimator=ar._ensure_congestion_estimator(),
+        )
+        neg.rip_up_nets([1], net_routes, ar.routes)
+
+        attempts: list[int] = []
+        orig = ar.route_net
+
+        def counting_route_net(net, per_net_timeout=None):
+            attempts.append(net)
+            return orig(net, per_net_timeout=per_net_timeout)
+
+        ar.route_net = counting_route_net
+        rescued = ar._post_negotiation_sweep(
+            stranded_nets=[1],
+            net_routes=net_routes,
+            pads_by_net=pads_by_net,
+            per_net_timeout=POST_NEGOTIATION_SWEEP_PER_NET_S,
+            deadline=time.time() - 1.0,  # already expired
+        )
+        assert rescued == []
+        assert attempts == [], "past deadline must skip all net attempts"
+
+    def test_empty_stranded_list_is_noop(self):
+        ar = _build_two_net_router()
+        ar.route_all_negotiated(max_iterations=2, timeout=30.0, adaptive=False, perturbation=False)
+        net_routes, pads_by_net = _snapshot_net_state(ar)
+        rescued = ar._post_negotiation_sweep(
+            stranded_nets=[],
+            net_routes=net_routes,
+            pads_by_net=pads_by_net,
+            per_net_timeout=POST_NEGOTIATION_SWEEP_PER_NET_S,
+            deadline=time.time() + POST_NEGOTIATION_SWEEP_BUDGET_S,
+        )
+        assert rescued == []
+
+
+def _make_failure(net: int):
+    from kicad_tools.router.core import RoutingFailure
+
+    return RoutingFailure(
+        net=net,
+        net_name="LONGHAUL",
+        source_pad=("R1", "1"),
+        target_pad=("R1", "2"),
+        source_coords=(2.0, 10.0),
+        target_coords=(38.0, 10.0),
+        blocking_nets=set(),
+        blocking_components=[],
+        reason="synthetic",
+    )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end integration: batch starves a net, sweep rescues it
+# ---------------------------------------------------------------------------
+
+
+def _starve_batch_net(ar: Autorouter, starved_net: int) -> None:
+    """Patch the batch's internal per-net path to hard-fail ``starved_net``.
+
+    ``_route_net_negotiated`` is the fine-grained A* the batch loop calls
+    (curator's path 1); the rescue sweep uses ``route_net`` (a separate
+    MST/RSMT path).  Failing only the former reproduces the reported
+    budget-starvation without breaking the sweep's ability to route the
+    same net solo.
+    """
+    orig = ar._route_net_negotiated
+
+    def patched(net, pf, per_net_timeout=None):
+        if net == starved_net:
+            return []
+        return orig(net, pf, per_net_timeout=per_net_timeout)
+
+    ar._route_net_negotiated = patched
+
+
+class TestEndToEndStarvationRescue:
+    def test_starved_long_haul_is_rescued(self):
+        """The batch loop strands the long net (its internal path is starved),
+        but the post-negotiation sweep recovers it -- final completion is 2/2."""
+        ar = _build_two_net_router()
+        _starve_batch_net(ar, starved_net=1)
+        routes = ar.route_all_negotiated(
+            max_iterations=2, timeout=30.0, adaptive=False, perturbation=False
+        )
+        routed_nets = {r.net for r in routes}
+        assert routed_nets == {1, 2}, (
+            f"post-negotiation sweep must rescue the starved long-haul; got {sorted(routed_nets)}"
+        )
+
+    def test_completion_count_rises_after_sweep(self, capsys):
+        ar = _build_two_net_router()
+        _starve_batch_net(ar, starved_net=1)
+        ar.route_all_negotiated(max_iterations=2, timeout=30.0, adaptive=False, perturbation=False)
+        out = capsys.readouterr().out
+        # The batch summary reports 1/2 (long net stranded); the sweep line
+        # reports the rise to 2/2.
+        assert "Post-negotiation rescue recovered" in out
+        assert "now 2/2 routed" in out
+
+    def test_disabled_flag_leaves_net_stranded(self):
+        """``--no-rescue-pass`` (``_post_negotiation_rescue=False``) gives the
+        raw negotiated result: the starved net stays unrouted."""
+        ar = _build_two_net_router()
+        _starve_batch_net(ar, starved_net=1)
+        ar._post_negotiation_rescue = False
+        routes = ar.route_all_negotiated(
+            max_iterations=2, timeout=30.0, adaptive=False, perturbation=False
+        )
+        routed_nets = {r.net for r in routes}
+        assert routed_nets == {2}, "disabled sweep must not rescue the starved net"
+
+    def test_no_starvation_is_byte_identical(self, capsys):
+        """When nothing is stranded the sweep never engages (no rescue line)
+        and the board routes exactly as before."""
+        ar = _build_two_net_router()
+        routes = ar.route_all_negotiated(
+            max_iterations=2, timeout=30.0, adaptive=False, perturbation=False
+        )
+        routed_nets = {r.net for r in routes}
+        assert routed_nets == {1, 2}
+        out = capsys.readouterr().out
+        assert "Post-negotiation rescue" not in out

--- a/tests/test_negotiated_convergence_stranded.py
+++ b/tests/test_negotiated_convergence_stranded.py
@@ -148,6 +148,13 @@ class TestPartialNetBlocksCompletion:
         ``converged`` while a net is stranded at overflow == 0.
         """
         ar = _build_two_net_router_with_three_pad_net2()
+        # Issue #4159: disable the post-negotiation rescue sweep here.  The
+        # sweep re-attempts NET2 SOLO via the REAL ``route_net`` (all three
+        # pads, not the patched partial ``_route_net_negotiated``) and would
+        # legitimately rescue it -- flipping the terminal status to
+        # ``converged`` and defeating this test's purpose, which is to pin the
+        # RAW negotiated status-string logic for a genuinely stranded net.
+        ar._post_negotiation_rescue = False
         _patch_net2(ar, fail_after=10_000)
         messages: list[str] = []
 


### PR DESCRIPTION
## Summary

On a sparse board the negotiated batch loop can exhaust a long-haul net's per-net search budget under negotiation pressure and strand it, even though the net routes solo in <1s on the identical copper (the reported softstart rev-B symptom: ~27/76 complete, then each failed net routes instantly via a solo attempt). This is **budget exhaustion, not congestion** (sparse board, 0 obstructions).

This PR adds a bounded, strictly-additive **post-negotiation rescue sweep** (fix 1, the curator-confirmed MVP). After the negotiated batch loop converges/stalls/times out AND the demote safety nets have run, `route_all_negotiated` re-attempts every still-stranded net **SOLO on the LIVE grid** via `Autorouter.route_net()` — every committed route is already an obstacle, so the solo attempt settles into the free space the batch loop never used. It reuses the **in-process fine-grained pathfinder** (per the curator's correction), NOT a `route-auto` shell-out to the separate coarse `GlobalRouter`.

## Behavior

Follows the sibling bounded post-loop pattern (`_post_route_clearance_correction`, the `_demote_*` safety nets):

- One attempt per net, capped by a per-net budget (`POST_NEGOTIATION_SWEEP_PER_NET_S`).
- Overall wall-clock ceiling (`POST_NEGOTIATION_SWEEP_BUDGET_S`) so a genuinely-impossible stranded net cannot hang the sweep.
- Success commits the net into `net_routes` and clears its stale `RoutingFailure` records; a partial (not-fully-connected) result is **not** a rescue.
- Failure rolls back verbatim (rip up any copper the attempt marked, restore pre-attempt state, drop fresh failure diagnostics) — the sweep can only ever **raise** the routed count, never regress it. Already-successful routes are never touched.
- **ON by default** (strict improvement). `--no-rescue-pass` disables it (both parsers + forwarding shim wired). Emits a summary line when it recovers nets.

## Hook site

`src/kicad_tools/router/core.py`, inside `route_all_negotiated`, right after the `_demote_*` safety nets and before `progress_callback` / `_finalize_routing()`, reusing the in-scope `_stranded_nets()`, `net_routes`, `pads_by_net`, and `self.routing_failures`.

## Reproduction status

**Reproduced end-to-end synthetically.** The batch's internal `_route_net_negotiated` is patched to hard-fail a specific net while the sweep's `route_net` path stays real — the exact two-path split the curator identified. The batch loop strands the long net; the rescue sweep recovers it (final 2/2). Also unit-tested the mechanism directly: rescue a routable stranded net, roll back an unroutable/partial attempt without regression, additive-only, bounded-by-deadline. The softstart repro fixture is local-only (not in CI), so all tests are synthetic.

## Out of scope (deferred, per curator)

- **Fix (2) bbox/HPWL budget scaling**: touches the historically fragile budget-derivation subsystem (#3474/#3877/#3881/#3956/#3989); warrants its own issue + architect scoping.
- **Fix (3) priority-ordering**: confirmed a non-issue — `_get_net_priority` already sorts by net-class priority as the primary key. No code change.

## Tests

- New `tests/router/test_post_negotiation_sweep.py` (11 tests): constants, direct sweep mechanism (rescue / rollback / additive-only / bounded / no-op), end-to-end starvation-then-rescue, disabled flag, summary log, no-op-when-nothing-stranded.
- Updated `tests/test_negotiated_convergence_stranded.py::test_final_status_is_stranded_not_converged` to disable the sweep (it pins the RAW negotiated `stranded` status; the sweep would legitimately rescue that fixture's net).
- `tests/router/` full suite: green except one **pre-existing, change-unrelated** platform baseline drift (`test_board02_manufacturable_baseline::test_routing_output_deterministic_across_seeds` — 476 segments vs documented band [390,398]; verified identical failure on clean origin/main via stash; board 02 routes 8/8 so the sweep is a no-op there).
- `ruff check`/`format` clean; `check_mypy_baseline.py` → 0 new errors.

Closes #4159

🤖 Generated with [Claude Code](https://claude.com/claude-code)