### PR TITLE
fix(zones): default add/batch output to in-place, matching zones fill

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -660,10 +660,27 @@ kct zones <subcommand> <pcb_file> [options]
 |------------|-------------|
 | `add` | Add a copper zone |
 | `list` | List existing zones |
+| `batch` | Add multiple zones from a `NET:LAYER,...` spec |
+| `fill` | Fill all zones in a PCB (via `kicad-cli`) |
+
+**Output-path behavior:** for the mutating subcommands (`add`, `batch`,
+`fill`), `-o`/`--output` is optional and **defaults to overwriting the input
+in place** — consistent with `optimize-placement`. Because each in-place `add`
+reads its own prior output, chaining `zones add` calls against one file
+accumulates zones instead of silently discarding earlier ones. Pass an
+explicit `-o <path>` to write a side file and leave the input untouched.
+
+| Option | Description |
+|--------|-------------|
+| `-o`, `--output PATH` | Output PCB (default: overwrite input) |
 
 **Examples:**
 ```bash
-kct zones add board.kicad_pcb --net GND --layer B.Cu
+kct zones add board.kicad_pcb --net GND --layer B.Cu     # modifies board.kicad_pcb in place
+kct zones add board.kicad_pcb --net +3.3V --layer In2.Cu # accumulates onto the GND zone
+kct zones batch board.kicad_pcb --power-nets GND:B.Cu,+3.3V:F.Cu
+kct zones fill board.kicad_pcb                           # fills all zones in place
+kct zones add board.kicad_pcb --net GND --layer B.Cu -o with_zones.kicad_pcb  # side file
 kct zones list board.kicad_pcb
 ```
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2452,7 +2452,11 @@ def _add_zones_parser(subparsers) -> None:
     # zones add
     zones_add = zones_subparsers.add_parser("add", help="Add a copper zone")
     zones_add.add_argument("pcb", help="Path to .kicad_pcb file")
-    zones_add.add_argument("-o", "--output", help="Output file path")
+    zones_add.add_argument(
+        "-o",
+        "--output",
+        help="Output file path (default: overwrite input, consistent with 'zones fill')",
+    )
     zones_add.add_argument("--net", required=True, help="Net name (e.g., GND, +3.3V)")
     zones_add.add_argument("--layer", required=True, help="Copper layer (e.g., B.Cu, F.Cu)")
     zones_add.add_argument("--priority", type=int, default=0, help="Zone fill priority")
@@ -2473,7 +2477,11 @@ def _add_zones_parser(subparsers) -> None:
     # zones batch
     zones_batch = zones_subparsers.add_parser("batch", help="Add multiple zones from spec")
     zones_batch.add_argument("pcb", help="Path to .kicad_pcb file")
-    zones_batch.add_argument("-o", "--output", help="Output file path")
+    zones_batch.add_argument(
+        "-o",
+        "--output",
+        help="Output file path (default: overwrite input, consistent with 'zones fill')",
+    )
     zones_batch.add_argument(
         "--power-nets",
         required=True,

--- a/src/kicad_tools/cli/zones_cmd.py
+++ b/src/kicad_tools/cli/zones_cmd.py
@@ -113,7 +113,7 @@ def main(argv: list[str] | None = None) -> int:
     add_parser.add_argument(
         "-o",
         "--output",
-        help="Output file path (default: <input>_zones.kicad_pcb)",
+        help="Output file path (default: overwrite input, consistent with 'zones fill')",
     )
     add_parser.add_argument(
         "--net",
@@ -211,7 +211,7 @@ def main(argv: list[str] | None = None) -> int:
     batch_parser.add_argument(
         "-o",
         "--output",
-        help="Output file path",
+        help="Output file path (default: overwrite input, consistent with 'zones fill')",
     )
     batch_parser.add_argument(
         "--power-nets",
@@ -299,11 +299,11 @@ def _run_add(args) -> int:
         print(f"Error: File not found: {pcb_path}", file=sys.stderr)
         return 1
 
-    # Determine output path
-    if args.output:
-        output_path = Path(args.output)
-    else:
-        output_path = pcb_path.with_stem(pcb_path.stem + "_zones")
+    # Determine output path. No -o means overwrite the input in place,
+    # consistent with `zones fill` and `optimize-placement`. This makes a
+    # chained `zones add ... && zones add ...` accumulate zones, since each
+    # call reads its own prior output instead of the pristine input.
+    output_path = Path(args.output) if args.output else pcb_path
 
     quiet = args.quiet
 
@@ -468,11 +468,9 @@ def _run_batch(args) -> int:
         print("Error: No power nets specified", file=sys.stderr)
         return 1
 
-    # Determine output path
-    if args.output:
-        output_path = Path(args.output)
-    else:
-        output_path = pcb_path.with_stem(pcb_path.stem + "_zones")
+    # Determine output path. No -o means overwrite the input in place,
+    # consistent with `zones fill` and `optimize-placement`.
+    output_path = Path(args.output) if args.output else pcb_path
 
     quiet = args.quiet
 

--- a/tests/test_zones_cmd.py
+++ b/tests/test_zones_cmd.py
@@ -1625,3 +1625,191 @@ class TestAddRegionBoundary:
         out = capsys.readouterr().out
         assert "--bbox" in out
         assert "sheet-absolute" in out
+
+
+# ---------------------------------------------------------------------------
+# Test: default output is in-place (issue #4166)
+# ---------------------------------------------------------------------------
+
+
+def _zone_keys(pcb_path: Path) -> set[tuple[str, str]]:
+    """Return the set of (net_name, layer) tuples for all zones in a PCB."""
+    from kicad_tools.schema.pcb import PCB
+
+    pcb = PCB.load(str(pcb_path))
+    return {(z.net_name, z.layer) for z in pcb.zones}
+
+
+class TestAddInPlaceDefault:
+    """`zones add` with no -o overwrites the input in place (issue #4166)."""
+
+    def test_add_no_output_modifies_input(self, tmp_pcb):
+        """No -o writes the new zone back into the input file itself."""
+        before = _zone_keys(tmp_pcb)
+        assert ("SDA", "F.Cu") not in before
+
+        ret = main(["add", str(tmp_pcb), "--net", "SDA", "--layer", "F.Cu"])
+        assert ret == 0
+
+        after = _zone_keys(tmp_pcb)
+        assert ("SDA", "F.Cu") in after
+
+    def test_add_no_output_does_not_create_side_file(self, tmp_pcb):
+        """No <stem>_zones.kicad_pcb side file is created (old behavior)."""
+        ret = main(["add", str(tmp_pcb), "--net", "SDA", "--layer", "F.Cu"])
+        assert ret == 0
+
+        side_file = tmp_pcb.with_stem(tmp_pcb.stem + "_zones")
+        assert not side_file.exists()
+
+
+class TestAddChainedAccumulates:
+    """Two sequential in-place `zones add` calls accumulate both zones.
+
+    Regression test for the compounding data-loss bug: previously each call
+    read the pristine input and wrote the same side file, so the second call
+    silently discarded the first zone.
+    """
+
+    def test_two_sequential_adds_keep_both_zones(self, tmp_pcb):
+        ret1 = main(["add", str(tmp_pcb), "--net", "SDA", "--layer", "F.Cu"])
+        assert ret1 == 0
+        ret2 = main(["add", str(tmp_pcb), "--net", "SCL", "--layer", "In1.Cu"])
+        assert ret2 == 0
+
+        keys = _zone_keys(tmp_pcb)
+        assert ("SDA", "F.Cu") in keys  # first add survived the second
+        assert ("SCL", "In1.Cu") in keys  # second add landed too
+
+
+class TestAddExplicitOutputUnaffected:
+    """Explicit -o still writes the side file and leaves the input untouched."""
+
+    def test_explicit_output_writes_target_leaves_input_unchanged(self, tmp_pcb, tmp_path):
+        out = tmp_path / "with_zones.kicad_pcb"
+        original_bytes = tmp_pcb.read_bytes()
+        before = _zone_keys(tmp_pcb)
+        assert ("SDA", "F.Cu") not in before
+
+        ret = main(["add", str(tmp_pcb), "--net", "SDA", "--layer", "F.Cu", "-o", str(out)])
+        assert ret == 0
+
+        # Input is byte-for-byte unchanged.
+        assert tmp_pcb.read_bytes() == original_bytes
+        # Target got the new zone.
+        assert ("SDA", "F.Cu") in _zone_keys(out)
+
+
+class TestBatchInPlaceDefault:
+    """`zones batch` with no -o overwrites the input in place (issue #4166)."""
+
+    def test_batch_no_output_modifies_input(self, tmp_pcb):
+        before = _zone_keys(tmp_pcb)
+        assert ("SDA", "F.Cu") not in before
+
+        ret = main(["batch", str(tmp_pcb), "--power-nets", "SDA:F.Cu"])
+        assert ret == 0
+
+        assert ("SDA", "F.Cu") in _zone_keys(tmp_pcb)
+
+    def test_batch_no_output_does_not_create_side_file(self, tmp_pcb):
+        ret = main(["batch", str(tmp_pcb), "--power-nets", "SDA:F.Cu"])
+        assert ret == 0
+
+        side_file = tmp_pcb.with_stem(tmp_pcb.stem + "_zones")
+        assert not side_file.exists()
+
+    def test_batch_explicit_output_leaves_input_unchanged(self, tmp_pcb, tmp_path):
+        out = tmp_path / "batched.kicad_pcb"
+        original_bytes = tmp_pcb.read_bytes()
+
+        ret = main(["batch", str(tmp_pcb), "--power-nets", "SDA:F.Cu", "-o", str(out)])
+        assert ret == 0
+
+        assert tmp_pcb.read_bytes() == original_bytes
+        assert ("SDA", "F.Cu") in _zone_keys(out)
+
+
+class TestBatchChainedWithAdd:
+    """Cross-subcommand accumulation: batch (in place) then add (in place)."""
+
+    def test_batch_then_add_accumulates(self, tmp_pcb):
+        ret1 = main(["batch", str(tmp_pcb), "--power-nets", "SDA:F.Cu"])
+        assert ret1 == 0
+        ret2 = main(["add", str(tmp_pcb), "--net", "SCL", "--layer", "In1.Cu"])
+        assert ret2 == 0
+
+        keys = _zone_keys(tmp_pcb)
+        assert ("SDA", "F.Cu") in keys  # from batch, survived the add
+        assert ("SCL", "In1.Cu") in keys  # from add
+
+
+class TestAddFillPipeline:
+    """The pipeline hole from issue #4166: add (in place) then fill (in place)
+    operate on the same file, so fill sees the zones add just wrote."""
+
+    def test_fill_targets_the_same_file_add_wrote(self, tmp_pcb):
+        ret = main(["add", str(tmp_pcb), "--net", "SDA", "--layer", "F.Cu"])
+        assert ret == 0
+        assert ("SDA", "F.Cu") in _zone_keys(tmp_pcb)
+
+        from kicad_tools.cli.runner import KiCadCLIResult
+
+        mock_result = KiCadCLIResult(success=True, output_path=tmp_pcb, return_code=0)
+        with (
+            patch(_FIND_CLI, return_value=Path("/usr/bin/kicad-cli")),
+            patch(_RUN_FILL, return_value=mock_result) as mock_fill,
+        ):
+            fill_ret = main(["fill", str(tmp_pcb)])
+        assert fill_ret == 0
+        # fill operated on the same file the (in-place) add wrote to, and
+        # no side output path was passed (None => overwrite input).
+        call_args = mock_fill.call_args
+        assert call_args[0][0] == tmp_pcb
+        assert call_args[0][1] is None
+
+
+class TestZonesParserHelpConsistency:
+    """Both parser definitions document the in-place default for add/batch."""
+
+    def test_zones_cmd_add_help_documents_in_place(self, capsys):
+        with pytest.raises(SystemExit):
+            main(["add", "--help"])
+        out = capsys.readouterr().out
+        assert "overwrite input" in out
+        assert "_zones" not in out  # old side-file suffix removed
+
+    def test_zones_cmd_batch_help_documents_in_place(self, capsys):
+        with pytest.raises(SystemExit):
+            main(["batch", "--help"])
+        out = capsys.readouterr().out
+        assert "overwrite input" in out
+
+    def test_top_level_parser_add_batch_help_documents_in_place(self):
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        help_text = parser.format_help()  # smoke: parser builds without error
+        assert isinstance(help_text, str)
+
+        # Inspect the add/batch -o help strings directly on the built parser.
+        for sub in ("add", "batch"):
+            found = False
+            for action in _iter_zones_subparser_actions(parser, sub):
+                if action.option_strings and "-o" in action.option_strings:
+                    assert "overwrite input" in (action.help or "")
+                    assert "_zones" not in (action.help or "")
+                    found = True
+            assert found, f"no -o option found for zones {sub}"
+
+
+def _iter_zones_subparser_actions(parser, sub_name):
+    """Yield argparse actions for the `zones <sub_name>` subparser."""
+    import argparse
+
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction) and "zones" in action.choices:
+            zones = action.choices["zones"]
+            for zaction in zones._actions:
+                if isinstance(zaction, argparse._SubParsersAction) and sub_name in zaction.choices:
+                    yield from zaction.choices[sub_name]._actions


### PR DESCRIPTION
## Summary

`kct zones add` / `kct zones batch` wrote `<stem>_zones.kicad_pcb` when `-o` was omitted, leaving the input untouched — inconsistent with `zones fill` and `optimize-placement`, which overwrite the input. This silently derailed chained pipelines: a natural `zones add → zones add → zones fill → drc` chain operated on the pristine input at each step, so the second `add` discarded the first's zone and `fill` gated a board with no planes. Every step exited 0.

This PR makes no-`-o` mean **overwrite input in place** for both `add` and `batch`, matching the project convention. Each chained in-place `add` now reads its own prior output, so zones accumulate instead of clobbering. Explicit `-o <path>` still writes a side file and leaves the input untouched.

Safe: `ZoneGenerator.from_pcb()` fully loads `PCB.load()` + `parse_file()` into memory before any `save()`, so self-overwrite can't clobber a mid-flight read (same pattern `placement`/`optimize-placement` already rely on).

## Changes

- `src/kicad_tools/cli/zones_cmd.py`: `_run_add` and `_run_batch` resolve `output_path = Path(args.output) if args.output else pcb_path` (was `pcb_path.with_stem(stem + "_zones")`). Updated `-o` help text for add/batch in this module's parser; dropped the `_zones` suffix mention.
- `src/kicad_tools/cli/parser.py::_add_zones_parser`: updated add/batch `-o` help to `"(default: overwrite input, consistent with 'zones fill')"` so both parser definitions agree.
- `docs/reference/cli.md`: documented the in-place default and added the missing `batch`/`fill` subcommand rows.
- `tests/test_zones_cmd.py`: new coverage (see below).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| 1. `add` no `-o` modifies `<pcb>` in place; no `<stem>_zones.kicad_pcb` created | ✅ | `TestAddInPlaceDefault` |
| 2. Two sequential `add` calls accumulate (second doesn't discard first) | ✅ | `TestAddChainedAccumulates` |
| 3. `batch` no `-o` in place; chaining a subsequent `add` accumulates | ✅ | `TestBatchInPlaceDefault`, `TestBatchChainedWithAdd` |
| 4. Explicit `-o` on add and batch writes target, leaves input byte-unchanged | ✅ | `TestAddExplicitOutputUnaffected`, `TestBatchInPlaceDefault::test_batch_explicit_output_leaves_input_unchanged` |
| 5. `fill` picks up zones from a preceding no-`-o` `add` (pipeline hole closed) | ✅ | `TestAddFillPipeline` |
| 6. `--dry-run` still reports correct in-place target | ✅ | Existing `TestFillDryRun` still green; add/batch dry-run unchanged (no write) |
| 7. Help text consistent between both parser definitions | ✅ | `TestZonesParserHelpConsistency` |
| 8. `docs/reference/cli.md` documents in-place default, lists batch/fill | ✅ | Diff |

## Test Plan

`uv run pytest tests/test_zones_cmd.py -q` → **74 passed**. ruff check + format clean. `scripts/ci/check_mypy_baseline.py` → 0 new type errors.

Key regression test — two sequential in-place adds accumulate:

```python
def test_two_sequential_adds_keep_both_zones(self, tmp_pcb):
    main(["add", str(tmp_pcb), "--net", "SDA", "--layer", "F.Cu"])
    main(["add", str(tmp_pcb), "--net", "SCL", "--layer", "In1.Cu"])
    keys = _zone_keys(tmp_pcb)
    assert ("SDA", "F.Cu") in keys    # first add survived the second
    assert ("SCL", "In1.Cu") in keys  # second add landed too
```

Closes #4166