### PR TITLE
fix(pcb): default add-zone output to in-place, matching zones add (#4195)

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -150,11 +150,26 @@ kct pcb <subcommand> <pcb_file> [options]
 |------------|-------------|
 | `query` | Query footprints and tracks |
 | `modify` | Modify PCB elements |
+| `add-zone` | Add a copper pour zone |
+
+**`add-zone` output-path behavior:** `-o`/`--output` is optional and
+**defaults to overwriting the input in place** — consistent with `zones add`,
+`zones fill`, and `optimize-placement`. Because each in-place `add-zone` reads
+its own prior output, chaining `pcb add-zone` calls against one file
+accumulates zones instead of silently discarding earlier ones. Pass an
+explicit `-o <path>` to write a side file and leave the input untouched.
+
+| Option | Description |
+|--------|-------------|
+| `-o`, `--output PATH` | Output PCB (default: overwrite input) |
 
 **Examples:**
 ```bash
 kct pcb query board.kicad_pcb --footprints
 kct pcb query board.kicad_pcb --tracks --net GND
+kct pcb add-zone board.kicad_pcb --net GND --layer B.Cu     # modifies board.kicad_pcb in place
+kct pcb add-zone board.kicad_pcb --net +3.3V --layer In2.Cu # accumulates onto the GND zone
+kct pcb add-zone board.kicad_pcb --net GND --layer B.Cu -o with_zones.kicad_pcb  # side file
 ```
 
 ---

--- a/src/kicad_tools/cli/commands/pcb.py
+++ b/src/kicad_tools/cli/commands/pcb.py
@@ -911,12 +911,14 @@ def _run_add_zone_command(args, pcb_path: Path) -> int:
             (x0, y0 + h),
         ]
 
-    # Determine output path
+    # Determine output path. No -o means overwrite the input in place,
+    # consistent with `zones add`, `zones fill`, and `optimize-placement`.
+    # ZoneGenerator.from_pcb() fully loads/parses the PCB into memory before
+    # any save(), so self-overwrite is safe. This makes a chained
+    # `pcb add-zone ... && pcb add-zone ...` accumulate zones, since each call
+    # reads its own prior output instead of the pristine input.
     output = getattr(args, "output", None)
-    if output:
-        output_path = Path(output)
-    else:
-        output_path = pcb_path.with_stem(pcb_path.stem + "_zones")
+    output_path = Path(output) if output else pcb_path
 
     dry_run = getattr(args, "dry_run", False)
     output_format = getattr(args, "format", "text")

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2072,7 +2072,7 @@ def _add_pcb_parser(subparsers) -> None:
         "-o",
         "--output",
         dest="output",
-        help="Output file path (default: <input>_zones.kicad_pcb)",
+        help="Output file path (default: overwrite input, consistent with 'zones add')",
     )
     pcb_add_zone.add_argument(
         "--dry-run",

--- a/tests/test_pcb_add_zone.py
+++ b/tests/test_pcb_add_zone.py
@@ -67,6 +67,14 @@ def _make_args(pcb_path, **kwargs):
     return Namespace(**defaults)
 
 
+def _zone_keys(pcb_path):
+    """Return the set of (net_name, layer) tuples for all zones in a PCB."""
+    from kicad_tools.schema.pcb import PCB
+
+    pcb = PCB.load(str(pcb_path))
+    return {(z.net_name, z.layer) for z in pcb.zones}
+
+
 class TestPcbAddZoneDryRun:
     """Test pcb add-zone in dry-run mode (no file writes)."""
 
@@ -230,13 +238,21 @@ class TestPcbAddZoneWrite:
         assert '"GND"' in content
 
     def test_default_output_path(self, sample_pcb, capsys):
-        """Default output path adds _zones suffix."""
+        """Default output overwrites the input in place; no _zones side file."""
+        original_bytes = sample_pcb.read_bytes()
+        assert ("GND", "B.Cu") not in _zone_keys(sample_pcb)
+
         args = _make_args(sample_pcb)
         rc = run_pcb_command(args)
         assert rc == 0
 
-        expected = sample_pcb.with_stem(sample_pcb.stem + "_zones")
-        assert expected.exists()
+        # Input was mutated in place with the new zone.
+        assert sample_pcb.read_bytes() != original_bytes
+        assert ("GND", "B.Cu") in _zone_keys(sample_pcb)
+
+        # No <stem>_zones.kicad_pcb side file was created (old behavior).
+        side_file = sample_pcb.with_stem(sample_pcb.stem + "_zones")
+        assert not side_file.exists()
 
     def test_custom_thermal_params(self, sample_pcb, tmp_path, capsys):
         """Custom thermal relief parameters are passed through."""
@@ -280,3 +296,77 @@ class TestPcbAddZoneErrors:
 
         captured = capsys.readouterr()
         assert "not found" in captured.err or "Error" in captured.err
+
+
+class TestPcbAddZoneInPlaceDefault:
+    """`pcb add-zone` with no -o overwrites the input in place (issue #4195)."""
+
+    def test_add_no_output_modifies_input(self, sample_pcb):
+        """No -o writes the new zone back into the input file itself."""
+        assert ("GND", "B.Cu") not in _zone_keys(sample_pcb)
+
+        rc = run_pcb_command(_make_args(sample_pcb, net="GND", layer="B.Cu"))
+        assert rc == 0
+
+        assert ("GND", "B.Cu") in _zone_keys(sample_pcb)
+
+    def test_add_no_output_does_not_create_side_file(self, sample_pcb):
+        """No <stem>_zones.kicad_pcb side file is created (old behavior)."""
+        rc = run_pcb_command(_make_args(sample_pcb, net="GND", layer="B.Cu"))
+        assert rc == 0
+
+        side_file = sample_pcb.with_stem(sample_pcb.stem + "_zones")
+        assert not side_file.exists()
+
+    def test_dry_run_reports_in_place_target_and_writes_nothing(self, sample_pcb, capsys):
+        """--dry-run names the in-place target and creates no files."""
+        original_bytes = sample_pcb.read_bytes()
+        rc = run_pcb_command(
+            _make_args(sample_pcb, net="GND", layer="B.Cu", dry_run=True, format="json")
+        )
+        assert rc == 0
+
+        # Nothing written: input unchanged, no side file.
+        assert sample_pcb.read_bytes() == original_bytes
+        side_file = sample_pcb.with_stem(sample_pcb.stem + "_zones")
+        assert not side_file.exists()
+
+        data = json.loads(capsys.readouterr().out)
+        assert data["dry_run"] is True
+        assert data["output"] is None
+
+
+class TestPcbAddZoneChainedAccumulates:
+    """Two sequential in-place `pcb add-zone` calls accumulate both zones.
+
+    Regression test for the compounding data-loss bug (issue #4195): previously
+    each call read the pristine input and wrote the same <stem>_zones side file,
+    so the second call silently discarded the first zone.
+    """
+
+    def test_two_sequential_adds_keep_both_zones(self, sample_pcb):
+        rc1 = run_pcb_command(_make_args(sample_pcb, net="GND", layer="B.Cu"))
+        assert rc1 == 0
+        rc2 = run_pcb_command(_make_args(sample_pcb, net="+3.3V", layer="F.Cu"))
+        assert rc2 == 0
+
+        keys = _zone_keys(sample_pcb)
+        assert ("GND", "B.Cu") in keys  # first add survived the second
+        assert ("+3.3V", "F.Cu") in keys  # second add landed too
+
+
+class TestPcbAddZoneExplicitOutputUnaffected:
+    """Explicit -o still writes the target and leaves the input untouched."""
+
+    def test_explicit_output_writes_target_leaves_input_unchanged(self, sample_pcb, tmp_path):
+        out = tmp_path / "with_zones.kicad_pcb"
+        original_bytes = sample_pcb.read_bytes()
+        assert ("GND", "B.Cu") not in _zone_keys(sample_pcb)
+
+        rc = run_pcb_command(_make_args(sample_pcb, net="GND", layer="B.Cu", output=str(out)))
+        assert rc == 0
+
+        # Input is byte-for-byte unchanged.
+        assert sample_pcb.read_bytes() == original_bytes
+        # Target got the new zone.
+        assert ("GND", "B.Cu") in _zone_keys(out)


### PR DESCRIPTION
## Summary

Mirror of #4166 / PR #4193, applied to the sibling `kct pcb add-zone` command (the `pcb` subcommand family, distinct from the already-fixed `zones` family).

Previously `pcb add-zone` with no `-o` wrote a `<stem>_zones.kicad_pcb` side file. Two sequential no-`-o` calls both read the pristine input, so the second silently discarded the zone added by the first, and any downstream `fill`/`drc` ran on an incomplete board — the same compounding data-loss hazard #4166 fixed for `zones add`/`batch`.

Now, omitting `-o` overwrites the input in place, consistent with `zones add`, `zones batch`, `zones fill`, and `optimize-placement`. `ZoneGenerator.from_pcb()` fully loads/parses the PCB into memory before any `save()`, so self-overwrite is safe.

## Changes

- **`src/kicad_tools/cli/commands/pcb.py`** (`_run_add_zone_command`): `output_path = Path(output) if output else pcb_path` (in-place default).
- **`src/kicad_tools/cli/parser.py`** (`_add_pcb_parser`): `-o`/`--output` help now `"(default: overwrite input, consistent with 'zones add')"`; dropped the `_zones` suffix mention.
- **`docs/reference/cli.md`**: added a `pcb add-zone` row + output-path behavior note and examples (previously no row existed).
- **`tests/test_pcb_add_zone.py`**:
  - `test_default_output_path` now asserts in-place mutation and that no `_zones` side file is created.
  - Added `TestPcbAddZoneChainedAccumulates::test_two_sequential_adds_keep_both_zones` — the key data-loss regression guard.
  - Added explicit-`-o` (input byte-unchanged) and `--dry-run` (writes nothing, reports `output: null`) guards.
  - `test_write_zone_to_output` (explicit `-o`) kept green.

Did not touch `zones_cmd.py` (already fixed by #4193).

## Test results

`uv run pytest tests/test_pcb_add_zone.py -q` — **20 passed**. The two-sequential-adds accumulation test passes: both `(GND, B.Cu)` and `(+3.3V, F.Cu)` survive. ruff check + format clean; mypy baseline check reports 0 new errors. Synthetic boards only (no fixture-repo dependency).

Closes #4195

🤖 Generated with [Claude Code](https://claude.com/claude-code)