### PR TITLE
feat(net-status): add --strict real-geometry connectivity mode (#4176)

### DIFF
--- a/src/kicad_tools/analysis/net_status.py
+++ b/src/kicad_tools/analysis/net_status.py
@@ -369,14 +369,35 @@ class NetStatusAnalyzer:
         >>> print(result.summary())
     """
 
-    # Tolerance for matching point positions (in mm)
+    # Tolerance for matching point positions (in mm).
+    #
+    # This is an endpoint-proximity radius, NOT a geometric-contact test:
+    # in the default (non-strict) mode, two copper elements (segment
+    # endpoints, pad centers, via centers) are unioned whenever their
+    # reference points land within this radius, even if their actual copper
+    # shapes (segment width, pad size) do not touch.  KiCad's connectivity
+    # engine instead requires real geometric overlap, so the default model
+    # can report a net "complete" that KiCad (``kicad-cli pcb drc``) reports
+    # as having unconnected items (Issue #4176).  Pass ``strict=True`` to use
+    # real shapely copper-shape intersection and match KiCad.
     POSITION_TOLERANCE = 0.01
 
-    def __init__(self, pcb: str | Path | PCB) -> None:
+    def __init__(self, pcb: str | Path | PCB, *, strict: bool = False) -> None:
         """Initialize the analyzer.
 
         Args:
-            pcb: Path to PCB file or loaded PCB object
+            pcb: Path to PCB file or loaded PCB object.
+            strict: When ``True``, segment↔segment, segment↔pad, and
+                segment↔via connectivity is decided by real geometric copper
+                contact (shapely polygon intersection: a segment is its
+                centerline buffered by ``width / 2``; a pad/via is its copper
+                shape) instead of the ``POSITION_TOLERANCE`` endpoint-proximity
+                radius.  This matches KiCad's connectivity semantics
+                (Issue #4176).  The default (``False``) preserves the legacy
+                tolerance-based behavior so existing consumers are unaffected.
+                Requires ``shapely``; strict mode fails loud (rather than
+                silently degrading to the tolerance model) if it is
+                unavailable.
         """
         from kicad_tools.schema.pcb import PCB as PCBClass
 
@@ -384,6 +405,17 @@ class NetStatusAnalyzer:
             self.pcb = PCBClass.load(str(pcb))
         else:
             self.pcb = pcb
+        self.strict = strict
+        # Strict-mode geometry caches (Issue #4176), keyed by object id.
+        self._segment_poly_cache: dict[int, Any] = {}
+        self._via_geom_cache: dict[int, Any] = {}
+        # Per-analyzer pad copper polygon cache (keyed ``REF.PAD``); ``None``
+        # until first built lazily in :meth:`_pad_polys`.
+        self._pad_poly_cache: dict[str, Any] | None = None
+        if strict:
+            from kicad_tools._shapely import require_shapely
+
+            require_shapely("net-status --strict real-geometry connectivity")
 
     def analyze(self) -> NetStatusResult:
         """Analyze all nets and return status result.
@@ -648,13 +680,24 @@ class NetStatusAnalyzer:
         # Build segment components for reuse
         segment_components = self._build_segment_components(segments)
 
-        # Connect pads through segment chains
+        # Connect pads through segment chains.
+        #
+        # Default mode: a pad joins the chain when its center is within
+        # POSITION_TOLERANCE of a segment endpoint.  Strict mode (Issue #4176):
+        # a pad joins the chain when its real copper polygon intersects any
+        # segment's copper polygon in the chain — an endpoint landing merely
+        # *near* a pad's copper edge no longer bonds.
         for component in segment_components:
             component_pads: set[str] = set()
             for seg_idx in component:
                 seg = segments[seg_idx]
-                component_pads.update(self._find_pads_at_point(seg.start, pad_positions))
-                component_pads.update(self._find_pads_at_point(seg.end, pad_positions))
+                if self.strict:
+                    component_pads.update(
+                        self._find_pads_touching_geom(self._segment_poly(seg), pad_positions)
+                    )
+                else:
+                    component_pads.update(self._find_pads_at_point(seg.start, pad_positions))
+                    component_pads.update(self._find_pads_at_point(seg.end, pad_positions))
 
             pad_list = list(component_pads)
             for i, pad in enumerate(pad_list):
@@ -662,9 +705,14 @@ class NetStatusAnalyzer:
                     graph[pad].add(other)
                     graph[other].add(pad)
 
-        # Connect pads through vias (pads at same via position)
+        # Connect pads through vias (pads whose copper the via barrel pierces).
+        # Default: pad center within POSITION_TOLERANCE of the via center.
+        # Strict (Issue #4176): pad copper polygon intersects the via copper.
         for via in vias:
-            via_pads = self._find_pads_at_point(via.position, pad_positions)
+            if self.strict:
+                via_pads = self._find_pads_touching_geom(self._via_geom(via), pad_positions)
+            else:
+                via_pads = self._find_pads_at_point(via.position, pad_positions)
             for pad in via_pads:
                 for other in via_pads:
                     if pad != other:
@@ -684,20 +732,42 @@ class NetStatusAnalyzer:
                 component_endpoints.append(seg.start)
                 component_endpoints.append(seg.end)
 
-            # Check if any endpoint of this segment chain touches a via
+            # Check if this segment chain's copper touches a via.
+            # Default: an endpoint within POSITION_TOLERANCE of the via center.
+            # Strict (Issue #4176): a segment copper polygon in the chain
+            # intersects the via copper geometry.
             for via in vias:
-                touches_via = any(
-                    self._points_close(ep, via.position) for ep in component_endpoints
-                )
+                if self.strict:
+                    via_geom = self._via_geom(via)
+                    touches_via = any(
+                        self._geoms_touch(self._segment_poly(segments[seg_idx]), via_geom)
+                        for seg_idx in component
+                    )
+                else:
+                    touches_via = any(
+                        self._points_close(ep, via.position) for ep in component_endpoints
+                    )
                 if touches_via:
                     # Collect all pads in this segment chain
                     chain_pads: set[str] = set()
                     for seg_idx in component:
                         seg = segments[seg_idx]
-                        chain_pads.update(self._find_pads_at_point(seg.start, pad_positions))
-                        chain_pads.update(self._find_pads_at_point(seg.end, pad_positions))
+                        if self.strict:
+                            chain_pads.update(
+                                self._find_pads_touching_geom(
+                                    self._segment_poly(seg), pad_positions
+                                )
+                            )
+                        else:
+                            chain_pads.update(self._find_pads_at_point(seg.start, pad_positions))
+                            chain_pads.update(self._find_pads_at_point(seg.end, pad_positions))
                     # Also include any pads at the via position itself
-                    chain_pads.update(self._find_pads_at_point(via.position, pad_positions))
+                    if self.strict:
+                        chain_pads.update(
+                            self._find_pads_touching_geom(self._via_geom(via), pad_positions)
+                        )
+                    else:
+                        chain_pads.update(self._find_pads_at_point(via.position, pad_positions))
                     # Connect all pads in this chain through the via
                     chain_list = list(chain_pads)
                     for i, pad in enumerate(chain_list):
@@ -730,23 +800,38 @@ class NetStatusAnalyzer:
             zone_boundaries,
         )
 
-        # Connect pads at same copper positions (segments and vias only).
+        # Connect pads that share a piece of copper (segments and vias only).
         # Zone polygon vertices are NOT sampled here because the pad-to-zone
         # and via-to-zone polygon containment checks above already handle zone
         # connectivity properly.  The previous zone_points[:1000] sampling cap
         # caused false-positive incomplete reports on boards with many filled
         # polygons (Issue #2035).
-        all_copper = [seg.start for seg in segments] + [seg.end for seg in segments]
-        all_copper.extend([via.position for via in vias])
+        #
+        # Default: two pads bond when both centers land within
+        # POSITION_TOLERANCE of the same segment endpoint / via center.
+        # Strict (Issue #4176): two pads bond when both copper polygons
+        # intersect the same segment / via copper geometry.
+        if self.strict:
+            copper_geoms = [self._segment_poly(seg) for seg in segments]
+            copper_geoms.extend(self._via_geom(via) for via in vias)
+            for geom in copper_geoms:
+                touching = self._find_pads_touching_geom(geom, pad_positions)
+                for i, pad_id in enumerate(touching):
+                    for other_id in touching[i + 1 :]:
+                        graph[pad_id].add(other_id)
+                        graph[other_id].add(pad_id)
+        else:
+            all_copper = [seg.start for seg in segments] + [seg.end for seg in segments]
+            all_copper.extend([via.position for via in vias])
 
-        for pad_id, pad_pos in pad_positions.items():
-            for copper_pos in all_copper:
-                if self._points_close(pad_pos, copper_pos):
-                    # Find other pads at this copper point
-                    for other_id, other_pos in pad_positions.items():
-                        if other_id != pad_id and self._points_close(copper_pos, other_pos):
-                            graph[pad_id].add(other_id)
-                            graph[other_id].add(pad_id)
+            for pad_id, pad_pos in pad_positions.items():
+                for copper_pos in all_copper:
+                    if self._points_close(pad_pos, copper_pos):
+                        # Find other pads at this copper point
+                        for other_id, other_pos in pad_positions.items():
+                            if other_id != pad_id and self._points_close(copper_pos, other_pos):
+                                graph[pad_id].add(other_id)
+                                graph[other_id].add(pad_id)
 
         return graph
 
@@ -1030,21 +1115,36 @@ class NetStatusAnalyzer:
 
         Returns:
             List of sets, each containing segment indices in a connected component
+
+        In the default mode two segments are chained when any of their
+        endpoints land within ``POSITION_TOLERANCE`` of each other.  In
+        ``strict`` mode (Issue #4176) they are chained iff their real copper
+        polygons (each segment's centerline buffered by ``width / 2``)
+        intersect — matching KiCad, which does not bond two traces whose
+        copper does not physically touch even when their endpoints are within
+        the snap tolerance.
         """
         if not segments:
             return []
+
+        if self.strict:
+            polys = [self._segment_poly(seg) for seg in segments]
 
         # Build segment adjacency graph
         segment_graph: dict[int, set[int]] = defaultdict(set)
         for i, seg_a in enumerate(segments):
             for j, seg_b in enumerate(segments):
                 if i != j:
-                    if (
-                        self._points_close(seg_a.start, seg_b.start)
-                        or self._points_close(seg_a.start, seg_b.end)
-                        or self._points_close(seg_a.end, seg_b.start)
-                        or self._points_close(seg_a.end, seg_b.end)
-                    ):
+                    if self.strict:
+                        connected = self._geoms_touch(polys[i], polys[j])
+                    else:
+                        connected = (
+                            self._points_close(seg_a.start, seg_b.start)
+                            or self._points_close(seg_a.start, seg_b.end)
+                            or self._points_close(seg_a.end, seg_b.start)
+                            or self._points_close(seg_a.end, seg_b.end)
+                        )
+                    if connected:
                         segment_graph[i].add(j)
                         segment_graph[j].add(i)
 
@@ -1097,6 +1197,96 @@ class NetStatusAnalyzer:
         dx = p1[0] - p2[0]
         dy = p1[1] - p2[1]
         return (dx * dx + dy * dy) < (self.POSITION_TOLERANCE * self.POSITION_TOLERANCE)
+
+    # ------------------------------------------------------------------
+    # Strict-mode real-geometry copper contact (Issue #4176)
+    # ------------------------------------------------------------------
+    # These helpers back ``strict=True`` connectivity: segment↔segment,
+    # segment↔pad, and segment↔via unions require the copper *shapes* to
+    # actually intersect (KiCad semantics) rather than the endpoint-proximity
+    # radius the default model uses.  Pad and via copper polygons are reused
+    # from ``ConnectivityValidator`` (``_pad_copper_polygon`` / ``_via_copper_geom``)
+    # via ``_connectivity_geometry()``; the trace-segment polygon is the one
+    # missing primitive, provided by ``geometry.copper.segment_copper_polygon``.
+    # All caches are keyed off the object ``id`` of the segment/via so repeated
+    # per-net calls do not rebuild the same polygon.
+
+    @staticmethod
+    def _geoms_touch(a: Any, b: Any) -> bool:
+        """Return ``True`` when two shapely geometries intersect/touch.
+
+        ``None`` (a degenerate/unbuildable geometry) never touches anything.
+        """
+        if a is None or b is None:
+            return False
+        return bool(a.intersects(b))
+
+    def _segment_poly(self, seg: Any) -> Any:
+        """Cached real copper polygon for a trace segment (strict mode)."""
+        cache = self._segment_poly_cache
+        key = id(seg)
+        poly = cache.get(key)
+        if poly is None and key not in cache:
+            from kicad_tools.geometry.copper import segment_copper_polygon
+
+            poly = segment_copper_polygon(seg.start, seg.end, seg.width)
+            cache[key] = poly
+        return poly
+
+    def _via_geom(self, via: Any) -> Any:
+        """Cached real copper geometry for a via (strict mode).
+
+        Reuses :meth:`ConnectivityValidator._via_copper_geom` so the via copper
+        model stays consistent with the reference partition extractor.
+        """
+        cache = self._via_geom_cache
+        key = id(via)
+        geom = cache.get(key)
+        if geom is None and key not in cache:
+            cv = self._connectivity_geometry()
+            radius = max(getattr(via, "size", 0.0) or 0.0, 0.0) / 2.0
+            geom = cv._via_copper_geom(via.position, radius)
+            cache[key] = geom
+        return geom
+
+    def _pad_polys(self) -> dict[str, Any]:
+        """Board-frame copper polygon per pad, keyed by ``REF.PAD`` (strict).
+
+        Built once per analyzer over every footprint pad, reusing
+        :meth:`ConnectivityValidator._pad_copper_polygon` for shape/rotation
+        parity with the reference partition extractor.  Pads with unbuildable
+        geometry are stored as ``None`` and simply never match.
+        """
+        if self._pad_poly_cache is not None:
+            return self._pad_poly_cache
+        cache: dict[str, Any] = {}
+        cv = self._connectivity_geometry()
+        for fp in self.pcb.footprints:
+            if not fp.reference or fp.reference.startswith("#"):
+                continue
+            for pad in fp.pads:
+                if pad.number is None or pad.number == "":
+                    continue
+                cache[f"{fp.reference}.{pad.number}"] = cv._pad_copper_polygon(fp, pad)
+        self._pad_poly_cache = cache
+        return cache
+
+    def _find_pads_touching_geom(
+        self,
+        geom: Any,
+        pad_positions: dict[str, tuple[float, float]],
+    ) -> list[str]:
+        """Strict analogue of ``_find_pads_at_point``: pads whose copper touches ``geom``.
+
+        Only pads present in ``pad_positions`` (i.e. on the net being analyzed)
+        are considered, matching the point-based helper's contract.
+        """
+        if geom is None:
+            return []
+        pad_polys = self._pad_polys()
+        return [
+            pad_id for pad_id in pad_positions if self._geoms_touch(geom, pad_polys.get(pad_id))
+        ]
 
     # Canonical copper layer ordering from top to bottom.
     # Promoted to ``kicad_tools.core.layers`` in Issue #3487 so the DRC

--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -417,6 +417,8 @@ def _dispatch_command(args) -> int:
             sub_argv.append("--verbose")
         if hasattr(args, "net_status_why") and args.net_status_why:
             sub_argv.append("--why")
+        if hasattr(args, "net_status_strict") and args.net_status_strict:
+            sub_argv.append("--strict")
         return net_status_cmd(sub_argv)
 
     elif args.command == "clean":

--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -700,6 +700,22 @@ def main(argv: list[str] | None = None) -> int:
         help="Exit with error code 2 on warnings",
     )
     parser.add_argument(
+        "--strict-connectivity",
+        dest="strict_connectivity",
+        action="store_true",
+        help=(
+            "Decide the connectivity DRC rule by REAL geometric copper contact "
+            "(shapely polygon intersection) instead of the default 0.01mm "
+            "endpoint-proximity tolerance. The default model unions a segment "
+            "endpoint with a pad/via/segment whenever their reference points "
+            "land within 0.01mm, even when the actual copper (segment width, "
+            "pad shape) does not touch -- so it can pass a net that "
+            "'kicad-cli pcb drc' reports as unconnected. --strict-connectivity "
+            "matches KiCad's connectivity semantics (issue #4176). Requires "
+            "shapely. (Distinct from --strict, which makes warnings fatal.)"
+        ),
+    )
+    parser.add_argument(
         "--refill-zones",
         dest="refill_zones",
         action="store_true",
@@ -1095,6 +1111,7 @@ def main(argv: list[str] | None = None) -> int:
             # graceful no-op (AC5).
             emit_measurements=True,
             courtyard_waivers=courtyard_waivers,
+            strict_connectivity=args.strict_connectivity,
         )
     except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)

--- a/src/kicad_tools/cli/commands/validation.py
+++ b/src/kicad_tools/cli/commands/validation.py
@@ -211,6 +211,9 @@ def run_check_command(args) -> int:
         sub_argv.append("--errors-only")
     if args.strict:
         sub_argv.append("--strict")
+    # Issue #4176: forward the connectivity real-geometry opt-in.
+    if getattr(args, "strict_connectivity", False):
+        sub_argv.append("--strict-connectivity")
     if args.mfr != "jlcpcb":
         sub_argv.extend(["--mfr", args.mfr])
     if args.layers != 2:

--- a/src/kicad_tools/cli/net_status_cmd.py
+++ b/src/kicad_tools/cli/net_status_cmd.py
@@ -9,6 +9,17 @@ Usage:
     kicad-net-status board.kicad_pcb --net GND
     kicad-net-status board.kicad_pcb --by-class
     kicad-net-status board.kicad_pcb --format json
+    kicad-net-status board.kicad_pcb --strict
+
+Connectivity model:
+    By default, connectivity is decided by a 0.01mm endpoint-proximity
+    tolerance: a segment endpoint is unioned with a pad / via / other segment
+    whenever their reference points land within 0.01mm, without testing
+    whether the real copper (segment width, pad shape) actually touches. This
+    can over-connect relative to KiCad, reporting a net "complete" that
+    ``kicad-cli pcb drc`` reports as having unconnected items (issue #4176).
+    Pass ``--strict`` to decide connectivity by real geometric copper contact
+    (shapely polygon intersection), which matches KiCad's semantics.
 
 Exit Codes:
     0 - No incomplete nets
@@ -61,6 +72,20 @@ def main(argv: list[str] | None = None) -> int:
         help="Show all pads with coordinates",
     )
     parser.add_argument(
+        "--strict",
+        action="store_true",
+        help=(
+            "Decide connectivity by REAL geometric copper contact (shapely "
+            "polygon intersection) instead of the default 0.01mm endpoint "
+            "proximity tolerance. The default model unions a segment endpoint "
+            "with a pad/via/segment whenever their reference points land "
+            "within 0.01mm, even if the actual copper (segment width, pad "
+            "shape) does not touch -- so it can report a net 'complete' that "
+            "'kicad-cli pcb drc' reports as unconnected. --strict matches "
+            "KiCad's connectivity semantics (issue #4176). Requires shapely."
+        ),
+    )
+    parser.add_argument(
         "--why",
         action="store_true",
         help=(
@@ -81,7 +106,7 @@ def main(argv: list[str] | None = None) -> int:
 
     # Run analysis
     try:
-        analyzer = NetStatusAnalyzer(pcb_path)
+        analyzer = NetStatusAnalyzer(pcb_path, strict=args.strict)
         result = analyzer.analyze()
     except Exception as e:
         print(f"Error during analysis: {e}", file=sys.stderr)

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -428,6 +428,17 @@ def _add_check_parser(subparsers) -> None:
     check_parser.add_argument("--errors-only", action="store_true")
     check_parser.add_argument("--strict", action="store_true", help="Exit with code 2 on warnings")
     check_parser.add_argument(
+        "--strict-connectivity",
+        dest="strict_connectivity",
+        action="store_true",
+        help=(
+            "Decide the connectivity DRC rule by REAL geometric copper contact "
+            "(shapely polygon intersection) instead of the default 0.01mm "
+            "endpoint-proximity tolerance, matching KiCad (issue #4176). "
+            "Requires shapely. Distinct from --strict (warnings fatal)."
+        ),
+    )
+    check_parser.add_argument(
         "--mfr",
         "-m",
         choices=get_all_manufacturer_names(),
@@ -5363,6 +5374,21 @@ def _add_net_status_parser(subparsers) -> None:
             "(ESCAPE_BLOCKED / CONGESTION_SATURATED / BUDGET_STARVED / "
             "PLACEMENT_BOUND) with supporting evidence. Read-only diagnostic "
             "(issue #3863)."
+        ),
+    )
+    net_status_parser.add_argument(
+        "--strict",
+        dest="net_status_strict",
+        action="store_true",
+        help=(
+            "Decide connectivity by REAL geometric copper contact (shapely "
+            "polygon intersection) instead of the default 0.01mm endpoint "
+            "proximity tolerance. The default model unions a segment endpoint "
+            "with a pad/via/segment whenever their reference points land "
+            "within 0.01mm even if the actual copper (segment width, pad "
+            "shape) does not touch -- so it can report a net 'complete' that "
+            "'kicad-cli pcb drc' reports as unconnected. --strict matches "
+            "KiCad's connectivity semantics (issue #4176). Requires shapely."
         ),
     )
 

--- a/src/kicad_tools/geometry/copper.py
+++ b/src/kicad_tools/geometry/copper.py
@@ -1,0 +1,85 @@
+"""Shared, checker-agnostic trace-copper geometry (Issue #4176).
+
+This module is the single source of truth for "what copper does a PCB trace
+segment actually occupy" — the real shapely polygon of a segment's copper,
+built as the segment centerline (``LineString``) buffered outward by half its
+``width``.  It mirrors the courtyard-polygon precedent (#4182,
+:mod:`kicad_tools.geometry.courtyard`) that swapped a bbox/tolerance
+approximation for real shapely polygon intersection.
+
+Why this exists
+---------------
+
+``NetStatusAnalyzer`` (and ``kct check``'s connectivity rule, which defers to
+it) historically unioned trace copper on *endpoint proximity* — a
+``POSITION_TOLERANCE = 0.01`` mm Euclidean radius between segment endpoints,
+pad centers, and via centers — never testing whether the copper *shapes*
+actually touch.  A segment endpoint landing near-but-not-on a pad's copper
+therefore blessed an electrically-open net (kct reported "complete" while
+KiCad's ``pcb drc`` reported the pad unconnected; see Issue #4176).
+
+KiCad's connectivity engine bonds two conductors only when their copper
+geometry physically overlaps or touches.  The pad/via/zone copper polygons
+already exist in :mod:`kicad_tools.validate.connectivity`
+(``_pad_copper_polygon`` / ``_fill_solid_region`` / ``_via_copper_geom``); the
+only missing primitive was the trace-segment polygon this module provides.
+
+``shapely`` is a core dependency (see :mod:`kicad_tools._shapely`); this
+helper returns ``None`` when it is unavailable so callers on a real-geometry
+path can fail loud rather than silently degrade.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from kicad_tools._shapely import has_shapely as _has_shapely
+
+if _has_shapely():  # pragma: no cover - import guard exercised by environment
+    from shapely.geometry import LineString as _ShapelyLineString  # type: ignore[import-untyped]
+    from shapely.geometry import Point as _ShapelyPoint
+
+
+def segment_copper_polygon(
+    start: tuple[float, float],
+    end: tuple[float, float],
+    width: float,
+) -> Any | None:
+    """Build a board-frame shapely polygon approximating a trace's copper.
+
+    A KiCad trace segment is a rectangle of length ``|end - start|`` and
+    thickness ``width`` with semicircular end caps (round line caps).  That is
+    exactly ``LineString([start, end]).buffer(width / 2)``, matching the
+    ``buffer()`` idiom :meth:`ConnectivityValidator._via_copper_geom` already
+    uses for via circles.
+
+    Two trace copper polygons are electrically bonded iff they
+    ``intersects()`` — including the near-miss case Issue #4176 reports, where
+    an endpoint sits just outside neighboring copper.
+
+    Degenerate inputs are handled defensively (mirroring the ``w <= 0 or
+    h <= 0`` guard in :meth:`ConnectivityValidator._pad_copper_polygon`):
+
+    * ``width <= 0`` — a zero/negative-width segment has no copper thickness;
+      return the bare centerline geometry (a ``LineString``, or a ``Point``
+      when the segment is also zero-length) so an exact endpoint coincidence
+      still registers as contact without manufacturing spurious area.
+    * ``start == end`` (zero length) with positive width — return the round
+      copper pad (a disk of radius ``width / 2``) the trace's end cap would
+      occupy.
+
+    Returns ``None`` when shapely is unavailable.
+    """
+    if not _has_shapely():
+        return None
+
+    if start == end:
+        point = _ShapelyPoint(start)
+        if width <= 0:
+            return point
+        return point.buffer(width / 2)
+
+    line = _ShapelyLineString([start, end])
+    if width <= 0:
+        return line
+    return line.buffer(width / 2)

--- a/src/kicad_tools/validate/checker.py
+++ b/src/kicad_tools/validate/checker.py
@@ -74,6 +74,7 @@ class DRCChecker:
         verbose: bool = False,
         emit_measurements: bool = False,
         courtyard_waivers: CourtyardWaivers | None = None,
+        strict_connectivity: bool = False,
     ) -> None:
         """Initialize the DRC checker.
 
@@ -124,6 +125,16 @@ class DRCChecker:
                 entry (instead of blocking errors), and an ``info`` "unused
                 waiver" finding for entries naming an absent component.  When
                 omitted, every overlap is a blocking error (Issue #4137).
+            strict_connectivity: When True, ``check_connectivity`` decides
+                segment↔segment / segment↔pad / segment↔via unions by real
+                geometric copper contact (shapely polygon intersection)
+                instead of the default 0.01mm endpoint-proximity tolerance,
+                matching KiCad's connectivity semantics (Issue #4176).  A net
+                whose copper the default model over-connects (reported
+                "complete" while ``kicad-cli pcb drc`` finds it unconnected)
+                then correctly fires the connectivity rule.  Default False
+                preserves the legacy tolerance model so existing ``kct check``
+                output is unchanged.
 
         Raises:
             ValueError: If manufacturer ID is not recognized
@@ -135,6 +146,11 @@ class DRCChecker:
         self.suppress_library = suppress_library
         self.net_class_map = net_class_map
         self.courtyard_waivers = courtyard_waivers
+        # Issue #4176: when True, the connectivity rule decides segment /
+        # pad / via unions by real geometric copper contact (shapely polygon
+        # intersection) instead of the default 0.01mm endpoint-proximity
+        # tolerance, matching KiCad.  Default False preserves legacy behavior.
+        self.strict_connectivity = strict_connectivity
         self.warn_on_inactive_skew_rules = warn_on_inactive_skew_rules
         self.verbose = verbose
         self.emit_measurements = emit_measurements
@@ -432,7 +448,7 @@ class DRCChecker:
             DRCResults containing one error per incomplete or unrouted
             multi-pad net (severity error).
         """
-        rule = ConnectivityRule()
+        rule = ConnectivityRule(strict=self.strict_connectivity)
         return self._absolutize(rule.check(self.pcb, self.design_rules))
 
     def check_diffpair_clearance_intra(self) -> DRCResults:

--- a/src/kicad_tools/validate/rules/connectivity.py
+++ b/src/kicad_tools/validate/rules/connectivity.py
@@ -71,6 +71,22 @@ class ConnectivityRule(DRCRule):
     name = "Net Connectivity"
     description = "Detects multi-pad nets that are not fully connected by traces, vias, or zones"
 
+    def __init__(self, *, strict: bool = False) -> None:
+        """Create the connectivity rule.
+
+        Args:
+            strict: Forwarded to :class:`NetStatusAnalyzer` as its ``strict``
+                flag (Issue #4176).  When ``True``, segment↔segment /
+                segment↔pad / segment↔via connectivity is decided by real
+                geometric copper contact (shapely polygon intersection)
+                instead of the default 0.01mm endpoint-proximity tolerance, so
+                a net kct's default model over-connects (reported "complete"
+                while ``kicad-cli pcb drc`` finds it unconnected) correctly
+                fires here.  The default (``False``) preserves the legacy
+                tolerance model so existing ``kct check`` output is unchanged.
+        """
+        self.strict = strict
+
     def check(
         self,
         pcb: PCB,
@@ -93,7 +109,7 @@ class ConnectivityRule(DRCRule):
         results.rules_checked = 1
         results.rules_checked_by_rule[self.rule_id] = 1
 
-        analyzer = NetStatusAnalyzer(pcb)
+        analyzer = NetStatusAnalyzer(pcb, strict=self.strict)
         analysis = analyzer.analyze()
 
         for net_status in analysis.nets:

--- a/tests/test_connectivity_rule.py
+++ b/tests/test_connectivity_rule.py
@@ -605,3 +605,63 @@ class TestConnectivityRuleRegistry:
         from kicad_tools.drc.violation import ViolationType
 
         assert ViolationType.from_string("connectivity") is ViolationType.CONNECTIVITY
+
+
+class TestConnectivityRuleStrict:
+    """Issue #4176: ``ConnectivityRule(strict=True)`` uses real geometric
+    copper contact, so a net the default tolerance model over-connects fires."""
+
+    # Two pads joined by two thin segments whose inner endpoints are 0.009mm
+    # apart (< 0.01 tolerance) on perpendicular headings.  At 0.001mm width the
+    # buffered copper does NOT bridge the gap, so KiCad (and strict mode) see
+    # the net as incomplete while the default tolerance model unions it.
+    _OVER_CONNECT_PCB = (
+        _PCB_HEADER
+        + """
+  (net 0 "")
+  (net 1 "SIG")
+  (footprint "R" (layer "F.Cu") (uuid "fp1") (at 100 100)
+    (property "Reference" "R1" (at 0 0 0) (layer "F.SilkS") (uuid "r1"))
+    (pad "1" smd rect (at 0 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "SIG")))
+  (footprint "R" (layer "F.Cu") (uuid "fp2") (at 105 105)
+    (property "Reference" "R2" (at 0 0 0) (layer "F.SilkS") (uuid "r2"))
+    (pad "1" smd rect (at 0 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "SIG")))
+  (segment (start 100 100) (end 105 100) (width 0.001) (layer "F.Cu") (net 1) (uuid "sa"))
+  (segment (start 105 100.009) (end 105 105) (width 0.001) (layer "F.Cu") (net 1) (uuid "sb"))
+)
+"""
+    )
+
+    def test_default_passes_strict_fires(self, tmp_path: Path) -> None:
+        import pytest
+
+        pytest.importorskip("shapely")
+        from kicad_tools.manufacturers import get_profile
+        from kicad_tools.schema.pcb import PCB
+        from kicad_tools.validate.rules.connectivity import ConnectivityRule
+
+        pcb_path = tmp_path / "over_connect.kicad_pcb"
+        pcb_path.write_text(self._OVER_CONNECT_PCB)
+        pcb = PCB.load(pcb_path)
+        rules = get_profile("jlcpcb").get_design_rules(2, 1.0)
+
+        # Default (tolerance) model over-connects: no error.
+        assert ConnectivityRule().check(pcb, rules).error_count == 0
+        # Strict (real geometry) model: the pads are on separate copper -> error.
+        strict = ConnectivityRule(strict=True).check(pcb, rules)
+        assert strict.error_count == 1
+        assert strict.errors[0].nets == ("SIG",)
+
+    def test_checker_forwards_strict_connectivity(self, tmp_path: Path) -> None:
+        import pytest
+
+        pytest.importorskip("shapely")
+        from kicad_tools.schema.pcb import PCB
+        from kicad_tools.validate import DRCChecker
+
+        pcb_path = tmp_path / "over_connect.kicad_pcb"
+        pcb_path.write_text(self._OVER_CONNECT_PCB)
+        pcb = PCB.load(pcb_path)
+
+        assert DRCChecker(pcb).check_connectivity().error_count == 0
+        assert DRCChecker(pcb, strict_connectivity=True).check_connectivity().error_count == 1

--- a/tests/test_geometry_copper.py
+++ b/tests/test_geometry_copper.py
@@ -1,0 +1,49 @@
+"""Tests for the trace-copper polygon helper (Issue #4176)."""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.geometry.copper import segment_copper_polygon
+
+pytest.importorskip("shapely")
+
+
+def test_segment_polygon_has_expected_area():
+    # A 10mm-long, 0.25mm-wide trace: rectangle 10 x 0.25 = 2.5 plus two
+    # semicircular end caps of radius 0.125 (area pi * 0.125**2 ~= 0.049).
+    poly = segment_copper_polygon((0.0, 0.0), (10.0, 0.0), 0.25)
+    assert poly is not None
+    expected = 10.0 * 0.25 + 3.141592653589793 * 0.125**2
+    assert poly.area == pytest.approx(expected, rel=1e-3)
+
+
+def test_two_touching_segments_intersect():
+    a = segment_copper_polygon((0.0, 0.0), (5.0, 0.0), 0.25)
+    b = segment_copper_polygon((5.0, 0.0), (5.0, 5.0), 0.25)
+    assert a.intersects(b)
+
+
+def test_two_apart_segments_do_not_intersect():
+    # Endpoints 0.009mm apart but width 0.001 (buffer 0.0005 each side): the
+    # copper does not bridge the gap.
+    a = segment_copper_polygon((0.0, 0.0), (5.0, 0.0), 0.001)
+    b = segment_copper_polygon((5.0, 0.009), (5.0, 5.0), 0.001)
+    assert not a.intersects(b)
+
+
+def test_zero_width_returns_line_geometry():
+    poly = segment_copper_polygon((0.0, 0.0), (10.0, 0.0), 0.0)
+    assert poly is not None
+    assert poly.area == 0.0
+    # A zero-length + zero-width segment reduces to a point.
+    pt = segment_copper_polygon((1.0, 1.0), (1.0, 1.0), 0.0)
+    assert pt is not None
+    assert pt.area == 0.0
+
+
+def test_zero_length_positive_width_is_disk():
+    disk = segment_copper_polygon((1.0, 1.0), (1.0, 1.0), 0.5)
+    assert disk is not None
+    # Round end cap disk of radius 0.25.
+    assert disk.area == pytest.approx(3.141592653589793 * 0.25**2, rel=1e-2)

--- a/tests/test_net_status_strict.py
+++ b/tests/test_net_status_strict.py
@@ -1,0 +1,202 @@
+"""Tests for ``NetStatusAnalyzer(strict=True)`` real-geometry connectivity.
+
+Issue #4176: the default net-status connectivity model unions copper on a
+0.01mm endpoint-proximity radius (``_points_close``) without testing whether
+the real copper shapes (segment width, pad size) actually touch, so it can
+report a net "complete" that ``kicad-cli pcb drc`` reports as unconnected
+(over-connecting relative to KiCad).  ``strict=True`` decides connectivity by
+real shapely copper-shape intersection instead, matching KiCad.
+
+These fixtures are minimal synthetic PCBs built from S-expression strings (no
+external board files), following the convention in ``test_net_status.py``.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.analysis.net_status import NetStatusAnalyzer
+
+shapely = pytest.importorskip("shapely")
+
+
+def _analyze(pcb_text: str, *, strict: bool):
+    """Load a synthetic .kicad_pcb string and return the analyzed result."""
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / "board.kicad_pcb"
+        path.write_text(pcb_text)
+        return NetStatusAnalyzer(path, strict=strict).analyze()
+
+
+def _status(pcb_text: str, net: str, *, strict: bool) -> str:
+    result = _analyze(pcb_text, strict=strict)
+    net_status = result.get_net(net)
+    assert net_status is not None, f"net {net!r} not found"
+    return net_status.status
+
+
+def _analyzer(pcb_text: str, tmp_path: Path, *, strict: bool = False) -> NetStatusAnalyzer:
+    """Build a ``NetStatusAnalyzer`` from a synthetic PCB string.
+
+    ``NetStatusAnalyzer`` treats a ``str``/``Path`` argument as a file path, so
+    the board text is written to a real file first (mirroring ``_analyze``).
+    """
+    path = tmp_path / "board.kicad_pcb"
+    path.write_text(pcb_text)
+    return NetStatusAnalyzer(path, strict=strict)
+
+
+def _pad_seg_board(seg_end_x: float) -> str:
+    """Two single-pad footprints on net SIG.
+
+    R1.1 copper is centered at (100, 100); R2.1 copper at (110, 100), each a
+    0.6x0.6 SMD rect.  A single trace runs from R1.1's center to ``seg_end_x``.
+    When ``seg_end_x`` reaches into R2.1's copper the net is complete; when it
+    stops short (near-miss) the copper does not touch R2.1.
+    """
+    return f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal) (44 "Edge.Cuts" user))
+  (net 0 "")
+  (net 1 "SIG")
+  (footprint "R" (layer "F.Cu") (uuid "fp1") (at 100 100)
+    (property "Reference" "R1" (at 0 0 0) (layer "F.SilkS") (uuid "r1"))
+    (pad "1" smd rect (at 0 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "SIG")))
+  (footprint "R" (layer "F.Cu") (uuid "fp2") (at 110 100)
+    (property "Reference" "R2" (at 0 0 0) (layer "F.SilkS") (uuid "r2"))
+    (pad "1" smd rect (at 0 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "SIG")))
+  (segment (start 100 100) (end {seg_end_x} 100) (width 0.25) (layer "F.Cu") (net 1) (uuid "s1"))
+)
+"""
+
+
+def _two_segment_board(gap: float, width: float) -> str:
+    """Two pads joined by two thin segments whose inner endpoints are ``gap`` apart.
+
+    R1.1 is at (100, 100); R2.1 at (105, 105).  Segment A runs (100,100)->(105,100);
+    segment B runs (105, 100+gap)->(105, 105).  The two segments' inner endpoints
+    are ``gap`` mm apart on perpendicular headings.  With a small ``gap`` (< 0.01)
+    the default endpoint-tolerance model chains them; with a thin ``width`` their
+    buffered copper does NOT overlap across the gap, so strict mode does not.
+    """
+    return f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal) (44 "Edge.Cuts" user))
+  (net 0 "")
+  (net 1 "SIG")
+  (footprint "R" (layer "F.Cu") (uuid "fp1") (at 100 100)
+    (property "Reference" "R1" (at 0 0 0) (layer "F.SilkS") (uuid "r1"))
+    (pad "1" smd rect (at 0 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "SIG")))
+  (footprint "R" (layer "F.Cu") (uuid "fp2") (at 105 105)
+    (property "Reference" "R2" (at 0 0 0) (layer "F.SilkS") (uuid "r2"))
+    (pad "1" smd rect (at 0 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "SIG")))
+  (segment (start 100 100) (end 105 100) (width {width}) (layer "F.Cu") (net 1) (uuid "sa"))
+  (segment (start 105 {100 + gap}) (end 105 105) (width {width}) (layer "F.Cu") (net 1) (uuid "sb"))
+)
+"""
+
+
+# --------------------------------------------------------------------------
+# AC #2 / #3: segment endpoint near vs. touching a pad's copper.
+# --------------------------------------------------------------------------
+
+
+def test_strict_reports_incomplete_when_segment_stops_short_of_pad():
+    # R2.1 copper spans x in [109.7, 110.3]; the trace ends at 109.5 (0.2mm
+    # short of the pad copper edge, well outside any real overlap).  Strict
+    # geometry must leave R2.1 stranded -> incomplete, matching kicad-cli.
+    board = _pad_seg_board(seg_end_x=109.5)
+    assert _status(board, "SIG", strict=True) == "incomplete"
+
+
+def test_strict_reports_complete_when_segment_reaches_into_pad():
+    # The trace now ends at 109.9, inside R2.1's copper (>= 109.7 edge, and
+    # inside the eroded pad polygon) -> real copper contact -> complete.
+    board = _pad_seg_board(seg_end_x=109.9)
+    assert _status(board, "SIG", strict=True) == "complete"
+
+
+# --------------------------------------------------------------------------
+# AC #4: segment endpoints within the old 0.01mm tolerance but with
+# non-overlapping copper.  Proves the mode flag changes behavior AND that the
+# default is preserved.
+# --------------------------------------------------------------------------
+
+
+def test_default_over_connects_endpoints_within_tolerance():
+    # gap 0.009mm (< 0.01 tolerance), width 0.001mm (buffered copper 0.0005mm
+    # each side, so the copper is ~0.008mm short of touching).  The default
+    # endpoint-proximity model unions the two chains -> complete.
+    board = _two_segment_board(gap=0.009, width=0.001)
+    assert _status(board, "SIG", strict=False) == "complete"
+
+
+def test_strict_rejects_endpoints_within_tolerance_but_copper_apart():
+    # Same geometry: strict mode sees the copper does not overlap across the
+    # 0.009mm gap -> incomplete (matches KiCad).
+    board = _two_segment_board(gap=0.009, width=0.001)
+    assert _status(board, "SIG", strict=True) == "incomplete"
+
+
+def test_strict_and_default_agree_when_copper_actually_overlaps():
+    # gap 0.0 (endpoints coincide) with realistic 0.25mm width: copper truly
+    # overlaps, so BOTH modes report complete.
+    board = _two_segment_board(gap=0.0, width=0.25)
+    assert _status(board, "SIG", strict=False) == "complete"
+    assert _status(board, "SIG", strict=True) == "complete"
+
+
+# --------------------------------------------------------------------------
+# strict wiring / edge cases
+# --------------------------------------------------------------------------
+
+
+def test_analyzer_defaults_to_non_strict(tmp_path: Path):
+    analyzer = _analyzer(_pad_seg_board(seg_end_x=109.9), tmp_path)
+    assert analyzer.strict is False
+
+
+def test_strict_flag_is_recorded(tmp_path: Path):
+    analyzer = _analyzer(_pad_seg_board(seg_end_x=109.9), tmp_path, strict=True)
+    assert analyzer.strict is True
+
+
+def test_zero_width_segment_does_not_crash_strict():
+    # A degenerate zero-width segment must not crash the strict polygon
+    # builder (mirrors the _pad_copper_polygon guard).  The segment reduces to
+    # its centerline; with the trace ending short of the pad, the net is
+    # incomplete rather than raising.
+    board = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal) (44 "Edge.Cuts" user))
+  (net 0 "")
+  (net 1 "SIG")
+  (footprint "R" (layer "F.Cu") (uuid "fp1") (at 100 100)
+    (property "Reference" "R1" (at 0 0 0) (layer "F.SilkS") (uuid "r1"))
+    (pad "1" smd rect (at 0 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "SIG")))
+  (footprint "R" (layer "F.Cu") (uuid "fp2") (at 110 100)
+    (property "Reference" "R2" (at 0 0 0) (layer "F.SilkS") (uuid "r2"))
+    (pad "1" smd rect (at 0 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "SIG")))
+  (segment (start 100 100) (end 105 100) (width 0) (layer "F.Cu") (net 1) (uuid "s1"))
+)
+"""
+    # Should not raise; R2.1 is stranded.
+    assert _status(board, "SIG", strict=True) == "incomplete"
+
+
+def test_strict_requires_shapely(monkeypatch, tmp_path: Path):
+    # If shapely is unavailable, strict mode must fail loud rather than
+    # silently degrading to the tolerance model.
+    import kicad_tools._shapely as shp
+
+    monkeypatch.setattr(shp, "has_shapely", lambda: False)
+    path = tmp_path / "board.kicad_pcb"
+    path.write_text(_pad_seg_board(seg_end_x=109.9))
+    with pytest.raises(ModuleNotFoundError):
+        NetStatusAnalyzer(path, strict=True)


### PR DESCRIPTION
## Summary

Closes #4176 (Phase 1).

`kct net-status` and `kct check`'s connectivity rule historically unioned trace copper on a **0.01mm endpoint-proximity radius** (`_points_close`) without testing whether the real copper shapes (segment width, pad size) actually touch. KiCad's connectivity engine instead requires real geometric overlap, so the default model can bless a net "complete" that `kicad-cli pcb drc` reports as unconnected (the softstart rev-B repro: 75/77-complete while kicad-cli finds 58 unconnected items).

This PR adds an **opt-in `--strict` mode** that decides segment↔segment, segment↔pad, and segment↔via unions by **real shapely copper-shape intersection**, matching KiCad. The tolerance-based default is left **UNCHANGED**.

## Scope — Phase 1 only (default deliberately NOT flipped)

`net-status` is the completion oracle for route loops, `--why`, `kct check`, the router stuck-classifier/placement-nudge, build/pipeline/fleet CLI, design reports, and MCP tools. Flipping the default would ripple through all of them without their own regression pass, so per the curator's phased plan the default stays tolerance-based and `--strict` is the opt-in KiCad-parity path.

**Deferred to Phase 2 (separate issue):**
- Making strict the default once it has run clean against fixture boards.
- Unifying/fixing `ConnectivityValidator`'s own parallel segment chainer (`_segments_chain_at_shared_point`), consumed by `copper_lvs.py` / `ground_topology.py` / `audit/auditor.py`, which still use the legacy tolerance model.

## Changes

- **New shared primitive** `kicad_tools.geometry.copper.segment_copper_polygon` — `LineString([start, end]).buffer(width/2)`, mirroring the courtyard-polygon precedent (#4182). This was the one missing piece; pad/via/zone copper polygons already exist in `ConnectivityValidator` and are reused via `_connectivity_geometry()` for shape/rotation parity.
- `NetStatusAnalyzer(pcb, strict=True)` — strict-mode geometric-contact path for the segment chainer and all pad/via unions, with per-analyzer caches. Fails loud (`require_shapely`) rather than silently degrading if shapely is absent.
- `kct net-status --strict` CLI flag (threaded through parser dispatch).
- `kct check --strict-connectivity` (distinct from `--strict`, which makes warnings fatal) → `DRCChecker(strict_connectivity=...)` → `ConnectivityRule(strict=...)`, since that rule defers to `NetStatusAnalyzer` for its verdict.
- Documented the 0.01mm tolerance and its non-KiCad-parity default in the net-status CLI help + module docstring.

## Verification

End-to-end on a synthetic "endpoints within 0.01mm tolerance but copper does not overlap" fixture (two 0.001mm-wide traces, inner endpoints 0.009mm apart):
- **default** `kct net-status` → `Complete: 1` (over-connects, current behavior preserved)
- **`--strict`** `kct net-status` → `Incomplete: 1` (matches KiCad)

An actually-overlapping fixture reports `complete` in both modes.

## Tests

- `tests/test_net_status_strict.py` (new) — near-but-not-touching (strict=incomplete), touching (both=complete), within-tolerance-but-copper-apart (default=complete / strict=incomplete), shapely-required fail-loud, zero-width degenerate no-crash.
- `tests/test_geometry_copper.py` (new) — segment polygon area / intersection / degenerate cases.
- `tests/test_connectivity_rule.py` — strict cases for `ConnectivityRule` and `DRCChecker` forwarding.

Results: `pytest -k "net_status or connectivity"` → 377 passed, 1 skipped. Adjacent geometry/lvs/ground-topology suites → 213 passed. Default-mode suite unchanged (no regressions). `ruff check`/`format` clean; mypy baseline gate exit 0 (0 new errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)