### PR TITLE
fix(router): report partial route-auto completion instead of false success (#4165)

### DIFF
--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -109,6 +109,8 @@ def run_route_auto_command(args) -> int:
             # Issue #4148: spatial routing bound.  Confines the routed net to the
             # board-relative box and fails if the net has an endpoint outside it.
             region=getattr(args, "region", None),
+            # Issue #4165: persist partial multi-pad copper only when opted in.
+            allow_partial=getattr(args, "allow_partial", False),
         )
     except FileNotFoundError as e:
         print(f"Error: {e}", file=sys.stderr)
@@ -152,6 +154,39 @@ def run_route_auto_command(args) -> int:
         if result.get("output_path"):
             print(f"  Saved to: {result['output_path']}")
         return 0
+    elif result.get("partial"):
+        # Issue #4165: routing produced copper but left some pads of a
+        # multi-pad net unconnected.  Report the honest k/n and exit non-zero;
+        # the copper is only saved when --allow-partial was given.
+        pads_connected = result.get("pads_connected")
+        pads_total = result.get("pads_total")
+        kn = (
+            f"{pads_connected}/{pads_total}"
+            if pads_connected is not None and pads_total is not None
+            else "some"
+        )
+        print(
+            f"partially routed net '{result['net_name']}': {kn} pads connected",
+            file=sys.stderr,
+        )
+        print(f"  Strategy: {result.get('strategy_used', 'unknown')}", file=sys.stderr)
+        print(
+            "  A single two-terminal corridor left pad(s) unconnected. "
+            "Retry with --strategy hierarchical (or --strategy auto, which now "
+            "falls back to hierarchical) to complete the net.",
+            file=sys.stderr,
+        )
+        segs_written = result.get("segments_written")
+        if segs_written is not None:
+            print(f"  Partial copper saved: {segs_written} segments", file=sys.stderr)
+        elif not getattr(args, "allow_partial", False):
+            print(
+                "  Partial copper NOT saved (pass --allow-partial to persist it).",
+                file=sys.stderr,
+            )
+        for warning in result.get("warnings", []):
+            print(f"  Warning: {warning}", file=sys.stderr)
+        return 1
     else:
         print(f"Routing failed for net '{result['net_name']}'", file=sys.stderr)
         if result.get("error_message"):

--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -172,8 +172,9 @@ def run_route_auto_command(args) -> int:
         print(f"  Strategy: {result.get('strategy_used', 'unknown')}", file=sys.stderr)
         print(
             "  A single two-terminal corridor left pad(s) unconnected. "
-            "Retry with --strategy hierarchical (or --strategy auto, which now "
-            "falls back to hierarchical) to complete the net.",
+            "Try --strategy hierarchical (or --strategy auto, which attempts a "
+            "hierarchical fallback) to improve completion; note that congested "
+            "or geometrically hard nets may remain partial even then.",
             file=sys.stderr,
         )
         segs_written = result.get("segments_written")

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -3623,13 +3623,16 @@ def _add_route_auto_parser(subparsers) -> None:
         help=(
             "Strategy override (default: auto). "
             "'auto' lets the orchestrator select the best strategy and, on a "
-            "partially-connected multi-pad net, automatically falls back to "
-            "'hierarchical' to complete it (Issue #4165). "
+            "partially-connected multi-pad net, automatically ATTEMPTS the "
+            "'hierarchical' fallback to complete it (Issue #4165); the fallback "
+            "improves completion when it can but does not guarantee it, so a "
+            "hard net may stay partial and route-auto still exits non-zero. "
             "'global'/'escape'/'subgrid' route a SINGLE two-terminal corridor "
             "and may leave intermediate pads of a multi-pad net unconnected "
             "even when they report success (route-auto then reports "
             "'partially routed: k/n pads connected' and exits non-zero). "
-            "'hierarchical' iterates to full net completion."
+            "'hierarchical' iterates toward full net completion but may still "
+            "leave a congested net partial."
         ),
     )
     route_auto_parser.add_argument(

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -3622,8 +3622,23 @@ def _add_route_auto_parser(subparsers) -> None:
         default="auto",
         help=(
             "Strategy override (default: auto). "
-            "'auto' lets the orchestrator select the best strategy. "
-            "Other values force a specific strategy."
+            "'auto' lets the orchestrator select the best strategy and, on a "
+            "partially-connected multi-pad net, automatically falls back to "
+            "'hierarchical' to complete it (Issue #4165). "
+            "'global'/'escape'/'subgrid' route a SINGLE two-terminal corridor "
+            "and may leave intermediate pads of a multi-pad net unconnected "
+            "even when they report success (route-auto then reports "
+            "'partially routed: k/n pads connected' and exits non-zero). "
+            "'hierarchical' iterates to full net completion."
+        ),
+    )
+    route_auto_parser.add_argument(
+        "--allow-partial",
+        action="store_true",
+        help=(
+            "Persist a partially-routed multi-pad net's copper instead of "
+            "refusing to write incomplete copper. Exit code stays non-zero and "
+            "the k/n partial report is still printed (Issue #4165)."
         ),
     )
     route_auto_parser.add_argument(

--- a/src/kicad_tools/mcp/tools/routing.py
+++ b/src/kicad_tools/mcp/tools/routing.py
@@ -470,6 +470,7 @@ def route_net_auto(
     enable_repair: bool = True,
     enable_via_resolution: bool = True,
     region: str | tuple[float, float, float, float] | None = None,
+    allow_partial: bool = False,
 ) -> dict:
     """Route a specific net using the RoutingOrchestrator.
 
@@ -478,15 +479,38 @@ def route_net_auto(
     characteristics (pin pitch, differential pairs, density, via conflicts)
     and automatically selects the optimal routing strategy.
 
+    Per-strategy completion semantics (Issue #4165)
+    -----------------------------------------------
+    The ``global``, ``escape``, and ``subgrid`` strategies route a **single
+    two-terminal corridor** between the two most distant pads of a net.  For a
+    multi-pad net this can leave intermediate pads unconnected even though the
+    strategy's own internal status is "success".  ``route_net_auto`` now runs a
+    real per-pad copper-reachability check after routing (independent of the
+    strategy's self-reported success) and, when a net is only partially
+    connected, reports ``success=False`` with ``partial=True`` and
+    ``pads_connected``/``pads_total`` populated.  With ``strategy="auto"`` the
+    orchestrator automatically falls back to the ``hierarchical`` (iterative
+    negotiated) router, which completes multi-pad nets by construction.  When a
+    partial route cannot be completed, no copper is saved unless
+    ``allow_partial=True``.
+
     Args:
         pcb_path: Absolute path to .kicad_pcb file
         net_name: Name of the net to route (e.g., "GND", "SPI_CLK")
         output_path: Path for output file. If None, result is not saved.
         strategy: Strategy override ("auto", "global", "escape", "hierarchical",
                   "subgrid", "via_resolution", or "multi_resolution").
-                  Use "auto" for smart selection.
+                  Use "auto" for smart selection.  Note: "global"/"escape"/
+                  "subgrid" route a single two-terminal corridor and may leave
+                  a multi-pad net partially connected; "hierarchical" iterates
+                  to full net completion (Issue #4165).
         enable_repair: Whether to enable automatic clearance repair after routing
         enable_via_resolution: Whether to enable via conflict resolution
+        allow_partial: When True, a partially-routed multi-pad net (some pads
+                  still unconnected) is still saved to ``output_path`` instead
+                  of refusing to write incomplete copper.  ``success`` remains
+                  False and ``partial`` True either way; this only controls
+                  whether the partial copper is persisted (Issue #4165).
         region: Optional spatial routing bound (Issue #4148, Phase 2a).  Either
                 a ``"x1,y1,x2,y2"`` string or a ``(x1, y1, x2, y2)`` tuple in
                 BOARD-RELATIVE mm (same convention as ``pcb strip --region``
@@ -691,6 +715,15 @@ def route_net_auto(
 
         orchestrator._select_strategy = _forced_select  # type: ignore[method-assign]
 
+        # Issue #4165: honor the user's explicit strategy choice.  When a
+        # strategy is forced we DO NOT silently fall back to hierarchical on a
+        # partial route -- the caller asked for exactly this strategy, so a
+        # multi-pad net stranded by a single two-terminal corridor is reported
+        # honestly as ``partial`` (k/n) and exits non-zero.  Disabling the
+        # retry loop is what preserves that honest partial; the automatic
+        # hierarchical fallback is reserved for ``strategy="auto"``.
+        orchestrator.max_strategy_retries = 0
+
     # Build pad list from PCB footprints so the orchestrator can
     # perform strategy selection and routing (without pads every
     # strategy returns "Insufficient pads").
@@ -763,6 +796,12 @@ def route_net_auto(
     result_dict = result.to_dict()
     result_dict["net_name"] = net_name
 
+    # Issue #4165: decide whether the produced copper is persistable.  A fully
+    # successful route always persists; a PARTIAL route (multi-pad net with
+    # stranded pads) persists only when the caller opts in via ``allow_partial``
+    # so incomplete copper is not written silently.
+    should_persist = result.success or (getattr(result, "partial", False) and allow_partial)
+
     # Save output if requested and routing succeeded.
     #
     # Issue #2913: the orchestrator's RoutingResult carries the produced
@@ -774,7 +813,7 @@ def route_net_auto(
     # and vias via the PCB schema's ``add_trace`` / ``add_via`` helpers
     # before saving, and surface a clear failure when the orchestrator
     # reports success but produced no physical segments.
-    if output_path and result.success:
+    if output_path and should_persist:
         segments_written, vias_written = _persist_routing_result_to_pcb(pcb, result, net_name)
         result_dict["segments_written"] = segments_written
         result_dict["vias_written"] = vias_written

--- a/src/kicad_tools/mcp/tools/routing.py
+++ b/src/kicad_tools/mcp/tools/routing.py
@@ -489,10 +489,13 @@ def route_net_auto(
     strategy's self-reported success) and, when a net is only partially
     connected, reports ``success=False`` with ``partial=True`` and
     ``pads_connected``/``pads_total`` populated.  With ``strategy="auto"`` the
-    orchestrator automatically falls back to the ``hierarchical`` (iterative
-    negotiated) router, which completes multi-pad nets by construction.  When a
-    partial route cannot be completed, no copper is saved unless
-    ``allow_partial=True``.
+    orchestrator automatically **attempts** the ``hierarchical`` (iterative
+    negotiated) router as a fallback on a partial.  The hierarchical fallback
+    improves completion where it can, but it does **not** guarantee completion
+    on every net — congested or geometrically hard nets may remain partial even
+    after the fallback, in which case ``route_net_auto`` still reports the honest
+    ``success=False``/``partial=True`` result and exits non-zero.  When a partial
+    route cannot be completed, no copper is saved unless ``allow_partial=True``.
 
     Args:
         pcb_path: Absolute path to .kicad_pcb file

--- a/src/kicad_tools/router/connectivity.py
+++ b/src/kicad_tools/router/connectivity.py
@@ -1,0 +1,234 @@
+"""Per-pad copper-reachability check for routed nets (Issue #4165).
+
+The orchestrator's global-family strategies (``global`` / ``escape`` /
+``subgrid``) route a **single two-terminal corridor** between the two most
+distant pads of a net (see :meth:`GlobalRouter.route_net`).  For a multi-pad
+net that leaves intermediate pads stranded, yet the strategy reports
+``success=True`` unconditionally.  This module supplies the missing
+**truth-in-exit** signal: after a strategy produces geometry, verify that every
+pad of the net is actually reachable across the produced copper (unioned with
+pre-existing same-net copper).
+
+Why not reuse ``NetStatusAnalyzer``
+-----------------------------------
+``analysis.net_status.NetStatusAnalyzer`` unions copper on **endpoint-proximity
+tolerance** (Issue #4176), which over-connects relative to KiCad's real
+geometric-contact requirement — reusing it here would just move the false
+"complete" from "no check" to "check with the wrong tolerance".  Instead this
+module walks **actual copper adjacency**: two elements are joined only when
+their geometry truly touches — a shared endpoint (within a tight numeric
+epsilon, not a design-rule clearance), a point lying **on** a segment, or two
+segments crossing/overlapping.  A pad is "connected" only if it lies on a
+copper element that is transitively joined to every other pad.
+
+The epsilon here is a floating-point coincidence tolerance (``EPS`` = 1 µm),
+deliberately far below any trace width or clearance, so the check errs toward
+**under-connecting** (reporting incomplete) rather than over-connecting — the
+safe direction for a completion oracle.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+# Geometric coincidence tolerance in mm.  This is a numeric epsilon for
+# floating-point equality of coordinates, NOT a clearance/tolerance union.
+# 1 micron is well below any realistic trace width, so "touching" here means
+# the copper genuinely overlaps or shares an endpoint.
+EPS = 1e-3
+
+
+@dataclass(frozen=True)
+class _Seg:
+    """Layer-annotated segment endpoints for adjacency testing."""
+
+    x1: float
+    y1: float
+    x2: float
+    y2: float
+    layer: object  # opaque layer key; only equality matters
+
+
+class _UnionFind:
+    """Minimal union-find over integer node ids."""
+
+    def __init__(self) -> None:
+        self._parent: dict[int, int] = {}
+
+    def find(self, a: int) -> int:
+        parent = self._parent
+        while parent.get(a, a) != a:
+            parent[a] = parent.get(parent[a], parent[a])
+            a = parent[a]
+        parent.setdefault(a, a)
+        return a
+
+    def union(self, a: int, b: int) -> None:
+        ra, rb = self.find(a), self.find(b)
+        if ra != rb:
+            self._parent[ra] = rb
+
+
+def _pt_eq(ax: float, ay: float, bx: float, by: float) -> bool:
+    return abs(ax - bx) <= EPS and abs(ay - by) <= EPS
+
+
+def _point_on_segment(px: float, py: float, s: _Seg) -> bool:
+    """True if point (px, py) lies on segment ``s`` (within EPS)."""
+    # Endpoint hits first (cheap + robust for zero-length segments).
+    if _pt_eq(px, py, s.x1, s.y1) or _pt_eq(px, py, s.x2, s.y2):
+        return True
+    dx = s.x2 - s.x1
+    dy = s.y2 - s.y1
+    seg_len_sq = dx * dx + dy * dy
+    if seg_len_sq <= EPS * EPS:
+        return False  # degenerate; already covered by endpoint test
+    # Projection parameter t of P onto the segment.
+    t = ((px - s.x1) * dx + (py - s.y1) * dy) / seg_len_sq
+    if t < -EPS or t > 1.0 + EPS:
+        return False
+    t = max(0.0, min(1.0, t))
+    projx = s.x1 + t * dx
+    projy = s.y1 + t * dy
+    # Perpendicular distance from the point to the segment line.
+    return _pt_eq(px, py, projx, projy)
+
+
+def _segments_touch(a: _Seg, b: _Seg) -> bool:
+    """True if two same-layer segments share any point (endpoint / on-line)."""
+    if a.layer != b.layer:
+        return False
+    # Any endpoint of one lying on the other means the copper is joined.
+    if _point_on_segment(a.x1, a.y1, b) or _point_on_segment(a.x2, a.y2, b):
+        return True
+    if _point_on_segment(b.x1, b.y1, a) or _point_on_segment(b.x2, b.y2, a):
+        return True
+    return False
+
+
+def _seg_layer_key(seg: Any) -> object:
+    """Extract a hashable layer key from a router/PCB segment-like object."""
+    layer = getattr(seg, "layer", None)
+    # Router Layer enums and KiCad layer strings are both hashable; prefer the
+    # KiCad name so a router-Layer segment and an existing-copper string
+    # segment on the SAME physical layer are treated as one layer.
+    name = getattr(layer, "kicad_name", None)
+    if name is not None:
+        return name
+    return layer
+
+
+def check_net_pad_connectivity(
+    pad_positions: list[tuple[float, float]],
+    segments: list[Any],
+    vias: list[Any] | None = None,
+    existing_segments: list[Any] | None = None,
+    existing_vias: list[Any] | None = None,
+) -> tuple[int, int]:
+    """Count how many pads of a net are joined by continuous copper.
+
+    Performs a **real** per-pad reachability walk over the union of the
+    freshly-produced copper (``segments`` / ``vias``) and any pre-existing
+    same-net copper (``existing_segments`` / ``existing_vias``).  Two copper
+    elements are adjacent only when they geometrically touch (shared endpoint,
+    point-on-segment, or crossing) within :data:`EPS`; vias join copper on the
+    two layers they connect at their drill location.
+
+    Args:
+        pad_positions: (x, y) centres of every pad of the net.
+        segments: Newly produced trace segments (objects with x1/y1/x2/y2/layer).
+        vias: Newly produced vias (objects with x/y[/layers]).
+        existing_segments: Pre-existing same-net trace segments, same shape.
+        existing_vias: Pre-existing same-net vias, same shape.
+
+    Returns:
+        ``(pads_connected, pads_total)`` where ``pads_connected`` is the size
+        of the largest single copper component that contains pads, and
+        ``pads_total`` is ``len(pad_positions)``.  If the net has <2 pads the
+        result is ``(pads_total, pads_total)`` (trivially connected).
+    """
+    n = len(pad_positions)
+    if n < 2:
+        return (n, n)
+
+    # Collect all segments (new + existing) as layer-annotated _Seg records.
+    # Accepts two segment shapes: the router primitive (x1/y1/x2/y2 + Layer
+    # enum) and the PCB-schema segment (start/end tuples + layer string).
+    seg_records: list[_Seg] = []
+    for src in (segments or [], existing_segments or []):
+        for s in src:
+            try:
+                if hasattr(s, "x1"):
+                    x1, y1, x2, y2 = (
+                        float(s.x1),
+                        float(s.y1),
+                        float(s.x2),
+                        float(s.y2),
+                    )
+                else:
+                    (x1, y1), (x2, y2) = s.start, s.end
+                    x1, y1, x2, y2 = float(x1), float(y1), float(x2), float(y2)
+                seg_records.append(_Seg(x1=x1, y1=y1, x2=x2, y2=y2, layer=_seg_layer_key(s)))
+            except (AttributeError, TypeError, ValueError):
+                continue
+
+    via_points: list[tuple[float, float]] = []
+    for src in (vias or [], existing_vias or []):
+        for v in src:
+            try:
+                via_points.append((float(v.x), float(v.y)))
+            except (AttributeError, TypeError, ValueError):
+                continue
+
+    # Node id layout:  0..n-1 = pads, then one node per segment, then one node
+    # per via.  Vias join copper regardless of layer (they are through-features
+    # in this coarse model), so they union any segment/pad touching their site.
+    uf = _UnionFind()
+    for i in range(n):
+        uf.find(i)  # ensure pad nodes exist
+
+    seg_base = n
+    for i in range(len(seg_records)):
+        uf.find(seg_base + i)
+
+    via_base = seg_base + len(seg_records)
+    for i in range(len(via_points)):
+        uf.find(via_base + i)
+
+    # Pad -> segment adjacency: a pad joins any segment it lies on.
+    for pi, (px, py) in enumerate(pad_positions):
+        for si, s in enumerate(seg_records):
+            if _point_on_segment(px, py, s):
+                uf.union(pi, seg_base + si)
+
+    # Segment <-> segment adjacency (same layer, touching).
+    for i in range(len(seg_records)):
+        for j in range(i + 1, len(seg_records)):
+            if _segments_touch(seg_records[i], seg_records[j]):
+                uf.union(seg_base + i, seg_base + j)
+
+    # Via adjacency: a via joins any segment endpoint/point at its location and
+    # any pad at its location (through-feature: layer-agnostic here).
+    for vi, (vx, vy) in enumerate(via_points):
+        vnode = via_base + vi
+        for pi, (px, py) in enumerate(pad_positions):
+            if _pt_eq(vx, vy, px, py):
+                uf.union(vnode, pi)
+        for si, s in enumerate(seg_records):
+            # Treat the via as a zero-extent point; test against the segment
+            # ignoring layer (through-feature bridges layers).
+            probe = _Seg(x1=vx, y1=vy, x2=vx, y2=vy, layer=s.layer)
+            if _segments_touch(probe, s) or _point_on_segment(vx, vy, s):
+                uf.union(vnode, seg_base + si)
+
+    # Group pads by their copper component; the net is "complete" only when all
+    # pads share one component.  Report the size of the largest pad-bearing
+    # component as pads_connected.
+    comp_counts: dict[int, int] = {}
+    for pi in range(n):
+        root = uf.find(pi)
+        comp_counts[root] = comp_counts.get(root, 0) + 1
+
+    pads_connected = max(comp_counts.values()) if comp_counts else 0
+    return (pads_connected, n)

--- a/src/kicad_tools/router/orchestrator.py
+++ b/src/kicad_tools/router/orchestrator.py
@@ -528,7 +528,8 @@ class RoutingOrchestrator:
                     strategy=RoutingStrategy.HIERARCHICAL_DIFF_PAIR,
                     reason=(
                         "Global-family corridor left pads unconnected; the "
-                        "iterative negotiated router completes multi-pad nets"
+                        "iterative negotiated router aims to complete multi-pad "
+                        "nets (not guaranteed on congested/hard nets)"
                     ),
                     estimated_cost=1.5,
                     success_probability=0.7,

--- a/src/kicad_tools/router/orchestrator.py
+++ b/src/kicad_tools/router/orchestrator.py
@@ -354,10 +354,25 @@ class RoutingOrchestrator:
         routing_start = time.time()
         result = self._execute_strategy(net, strategy, intent, pads)
 
-        # Phase 2b: Automatic strategy retry on failure
+        # Phase 2a: Truth-in-exit-condition (Issue #4165).
+        # The global-family strategies (global/escape/subgrid) route a single
+        # two-terminal corridor and report unconditional success even when a
+        # multi-pad net has stranded pads.  Verify actual per-pad copper
+        # reachability; if incomplete, demote to a PARTIAL result (success=
+        # False, partial=True) so the retry loop below can fall through to a
+        # completing strategy (hierarchical) instead of blessing a half-routed
+        # net.
+        self._verify_completion(result, pads)
+
+        # Phase 2b: Automatic strategy retry on failure OR partial completion.
         if not result.success and result.alternative_strategies and self.max_strategy_retries > 0:
             retries = result.alternative_strategies[: self.max_strategy_retries]
             strategies_attempted = [strategy.name]
+
+            # Track the best partial result seen (initial or any retry) so that
+            # if nothing fully completes the net we still surface the most-
+            # connected honest partial rather than a bare failure (Issue #4165).
+            best_partial = result if result.partial else None
 
             for alt in retries:
                 logger.info(
@@ -370,6 +385,10 @@ class RoutingOrchestrator:
                 retry_result = self._execute_strategy(net, alt.strategy, intent, pads)
                 strategies_attempted.append(alt.strategy.name)
 
+                # Re-verify per-pad completion on the retry as well: a global-
+                # family retry can itself be partial and must not be blessed.
+                self._verify_completion(retry_result, pads)
+
                 if retry_result.success:
                     retry_result.warnings.append(
                         f"Succeeded on retry with {alt.strategy.name} "
@@ -379,9 +398,20 @@ class RoutingOrchestrator:
                     )
                     result = retry_result
                     break
+
+                # Keep the retry with the most pads connected as the fallback
+                # partial if no later strategy fully completes.
+                if retry_result.partial and (
+                    best_partial is None
+                    or (retry_result.pads_connected or 0) > (best_partial.pads_connected or 0)
+                ):
+                    best_partial = retry_result
             else:
-                # All retries exhausted without success — keep the last
-                # failure result but note what was tried
+                # All retries exhausted without full completion.  Prefer the
+                # best honest partial over a bare no-copper failure so callers
+                # get "k/n pads connected" instead of an opaque failure.
+                if best_partial is not None:
+                    result = best_partial
                 result.warnings.append(
                     f"All strategy retries exhausted (attempted: {', '.join(strategies_attempted)})"
                 )
@@ -405,6 +435,148 @@ class RoutingOrchestrator:
         )
 
         return result
+
+    # Strategies whose "success" is a single two-terminal corridor and thus may
+    # leave a multi-pad net's intermediate pads stranded (Issue #4165).  The
+    # negotiated/hierarchical family completes the net by construction and is
+    # trusted without a post-route reachability check.
+    _GLOBAL_FAMILY_STRATEGIES = frozenset(
+        {
+            RoutingStrategy.GLOBAL_WITH_REPAIR,
+            RoutingStrategy.ESCAPE_THEN_GLOBAL,
+            RoutingStrategy.SUBGRID_ADAPTIVE,
+            RoutingStrategy.MULTI_RESOLUTION,
+        }
+    )
+
+    def _verify_completion(self, result: RoutingResult, pads: list[Pad] | None) -> None:
+        """Verify real per-pad copper reachability and demote partials.
+
+        Issue #4165: the global-family strategies report ``success=True`` once
+        they emit ANY corridor, with no check that every pad of a multi-pad net
+        is actually reached.  This runs a real reachability walk over the
+        produced copper (segments + vias) unioned with pre-existing same-net
+        copper on the PCB.  When fewer than all pads connect, the result is
+        demoted to ``success=False, partial=True`` with ``pads_connected`` /
+        ``pads_total`` populated and ``hierarchical`` injected as an
+        alternative so the retry loop can complete the net.
+
+        The check is a genuine geometric-adjacency walk (see
+        :mod:`kicad_tools.router.connectivity`) -- it does NOT reuse
+        ``NetStatusAnalyzer``'s tolerance-based union (Issue #4176), and errs
+        toward reporting incomplete rather than over-connecting.
+
+        Mutates ``result`` in place; no-op for non-global strategies, failures,
+        or nets with fewer than two pads.
+        """
+        if result.strategy_used not in self._GLOBAL_FAMILY_STRATEGIES:
+            return
+        if not result.success:
+            return
+        if not pads or len(pads) < 2:
+            return
+        # No produced geometry means there is no corridor to under-reach: a
+        # segment-less "success" is the #2913 concern (persistence surfaces it),
+        # not #4165's stranded-pad concern.  Only demote when copper was
+        # actually emitted that fails to reach every pad.
+        if not result.segments and not result.vias:
+            return
+
+        from .connectivity import check_net_pad_connectivity
+
+        pad_positions = [(p.x, p.y) for p in pads]
+
+        # Gather pre-existing same-net copper so pads already joined by earlier
+        # routing (or partial prior calls) count toward completion.
+        existing_segments, existing_vias = self._existing_net_copper(pads)
+
+        try:
+            pads_connected, pads_total = check_net_pad_connectivity(
+                pad_positions=pad_positions,
+                segments=list(result.segments),
+                vias=list(result.vias),
+                existing_segments=existing_segments,
+                existing_vias=existing_vias,
+            )
+        except Exception:  # pragma: no cover - defensive; never mask a route
+            logger.debug("Per-pad connectivity check failed; leaving result unchanged")
+            return
+
+        result.pads_connected = pads_connected
+        result.pads_total = pads_total
+
+        if pads_connected >= pads_total:
+            return  # fully connected — genuine success
+
+        # Incomplete: demote to a partial result.
+        result.partial = True
+        result.success = False
+        result.warnings.append(
+            f"Partial route: {pads_connected}/{pads_total} pads connected by the "
+            f"{result.strategy_used.name} corridor; remaining pad(s) left "
+            "unconnected. This strategy routes a single two-terminal corridor "
+            "and does not complete multi-pad nets (Issue #4165)."
+        )
+        # Steer the retry loop toward a completing strategy.
+        if not any(
+            a.strategy == RoutingStrategy.HIERARCHICAL_DIFF_PAIR
+            for a in result.alternative_strategies
+        ):
+            result.alternative_strategies.insert(
+                0,
+                AlternativeStrategy(
+                    strategy=RoutingStrategy.HIERARCHICAL_DIFF_PAIR,
+                    reason=(
+                        "Global-family corridor left pads unconnected; the "
+                        "iterative negotiated router completes multi-pad nets"
+                    ),
+                    estimated_cost=1.5,
+                    success_probability=0.7,
+                ),
+            )
+
+    def _existing_net_copper(self, pads: list[Pad]) -> tuple[list, list]:
+        """Collect pre-existing same-net segments + vias from the PCB.
+
+        Returns ``([], [])`` when the attached PCB does not expose copper
+        accessors (e.g. the lightweight mock PCBs used in some tests).
+        """
+        net_numbers = {p.net for p in pads if getattr(p, "net", 0)}
+        net_names = {p.net_name for p in pads if getattr(p, "net_name", "")}
+        pcb = self.pcb
+        segments: list = []
+        vias: list = []
+
+        seg_in_net = getattr(pcb, "segments_in_net", None)
+        via_in_net = getattr(pcb, "vias_in_net", None)
+        if callable(seg_in_net) and callable(via_in_net):
+            for num in net_numbers:
+                try:
+                    segments.extend(seg_in_net(num))
+                    vias.extend(via_in_net(num))
+                except Exception:  # pragma: no cover - defensive
+                    continue
+            return segments, vias
+
+        # Fallback: filter the full segment/via lists by net name when the PCB
+        # only exposes flat accessors.
+        all_segs = getattr(pcb, "segments", None)
+        all_vias = getattr(pcb, "vias", None)
+        if isinstance(all_segs, list):
+            for s in all_segs:
+                if (
+                    getattr(s, "net_name", "") in net_names
+                    or getattr(s, "net_number", -1) in net_numbers
+                ):
+                    segments.append(s)
+        if isinstance(all_vias, list):
+            for v in all_vias:
+                if (
+                    getattr(v, "net_name", "") in net_names
+                    or getattr(v, "net_number", -1) in net_numbers
+                ):
+                    vias.append(v)
+        return segments, vias
 
     def _select_strategy(
         self,

--- a/src/kicad_tools/router/strategies.py
+++ b/src/kicad_tools/router/strategies.py
@@ -173,7 +173,8 @@ class RoutingResult:
         pads_connected: Number of the net's pads reached by the produced
             copper (unioned with pre-existing same-net copper).  ``None`` when
             no per-pad connectivity check was performed (e.g. hierarchical,
-            which completes by construction, or an early hard failure).
+            which is trusted to iterate toward completion internally, or an
+            early hard failure).
         pads_total: Total number of the net's pads considered by the check.
     """
 

--- a/src/kicad_tools/router/strategies.py
+++ b/src/kicad_tools/router/strategies.py
@@ -165,6 +165,16 @@ class RoutingResult:
         alternative_strategies: Alternative strategies to try if this failed
         error_message: Error description if success=False
         warnings: Non-fatal warnings about the routing
+        partial: True when routing produced copper but did NOT connect every
+            pad of a multi-pad net (Issue #4165).  A partial result reports
+            ``success=False`` so callers/retry-logic treat it as incomplete,
+            but is distinguished from a hard failure (no copper at all) by
+            this flag plus ``pads_connected``/``pads_total``.
+        pads_connected: Number of the net's pads reached by the produced
+            copper (unioned with pre-existing same-net copper).  ``None`` when
+            no per-pad connectivity check was performed (e.g. hierarchical,
+            which completes by construction, or an early hard failure).
+        pads_total: Total number of the net's pads considered by the check.
     """
 
     success: bool
@@ -179,6 +189,9 @@ class RoutingResult:
     alternative_strategies: list[AlternativeStrategy] = field(default_factory=list)
     error_message: str = ""
     warnings: list[str] = field(default_factory=list)
+    partial: bool = False
+    pads_connected: int | None = None
+    pads_total: int | None = None
 
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON serialization (e.g., MCP tools).
@@ -241,4 +254,7 @@ class RoutingResult:
             "warnings": self.warnings,
             "segment_count": len(self.segments),
             "via_count": len(self.vias),
+            "partial": self.partial,
+            "pads_connected": self.pads_connected,
+            "pads_total": self.pads_total,
         }

--- a/tests/test_connectivity_reachability_4165.py
+++ b/tests/test_connectivity_reachability_4165.py
@@ -1,0 +1,108 @@
+"""Unit tests for the per-pad copper-reachability check (Issue #4165).
+
+``kicad_tools.router.connectivity.check_net_pad_connectivity`` is the real
+geometric-adjacency oracle used by the orchestrator to detect a multi-pad net
+that a single two-terminal corridor left partially connected.  Unlike
+``NetStatusAnalyzer`` (Issue #4176) it does NOT union copper on a clearance
+tolerance -- two elements are joined only when they geometrically touch within a
+tight numeric epsilon, so it errs toward reporting *incomplete* rather than
+over-connecting.
+"""
+
+from __future__ import annotations
+
+from kicad_tools.router.connectivity import check_net_pad_connectivity
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.primitives import Segment, Via
+
+
+def _seg(x1, y1, x2, y2, layer=Layer.F_CU):
+    return Segment(x1=x1, y1=y1, x2=x2, y2=y2, width=0.2, layer=layer)
+
+
+def test_fewer_than_two_pads_is_trivially_complete():
+    assert check_net_pad_connectivity([(0.0, 0.0)], segments=[]) == (1, 1)
+    assert check_net_pad_connectivity([], segments=[]) == (0, 0)
+
+
+def test_two_pads_joined_by_one_segment():
+    pads = [(0.0, 0.0), (10.0, 0.0)]
+    segs = [_seg(0.0, 0.0, 10.0, 0.0)]
+    assert check_net_pad_connectivity(pads, segments=segs) == (2, 2)
+
+
+def test_three_pads_but_corridor_strands_one():
+    """The core repro: a two-terminal corridor connects 2 of 3 pads."""
+    pads = [(0.0, 0.0), (10.0, 0.0), (5.0, 20.0)]
+    # Single corridor between the two most-distant collinear pads; the third
+    # pad at (5, 20) is nowhere on it.
+    segs = [_seg(0.0, 0.0, 10.0, 0.0)]
+    connected, total = check_net_pad_connectivity(pads, segments=segs)
+    assert total == 3
+    assert connected == 2
+
+
+def test_intermediate_pad_lying_on_corridor_counts():
+    """A third pad that happens to sit on the corridor IS connected."""
+    pads = [(0.0, 0.0), (10.0, 0.0), (5.0, 0.0)]
+    segs = [_seg(0.0, 0.0, 10.0, 0.0)]
+    assert check_net_pad_connectivity(pads, segments=segs) == (3, 3)
+
+
+def test_chained_segments_connect_all_three():
+    pads = [(0.0, 0.0), (10.0, 0.0), (10.0, 10.0)]
+    segs = [
+        _seg(0.0, 0.0, 10.0, 0.0),
+        _seg(10.0, 0.0, 10.0, 10.0),
+    ]
+    assert check_net_pad_connectivity(pads, segments=segs) == (3, 3)
+
+
+def test_existing_copper_completes_a_partial_new_route():
+    """Pre-existing same-net copper counts toward completion."""
+    pads = [(0.0, 0.0), (10.0, 0.0), (10.0, 10.0)]
+    new_segs = [_seg(0.0, 0.0, 10.0, 0.0)]
+    existing = [_seg(10.0, 0.0, 10.0, 10.0)]
+    assert check_net_pad_connectivity(pads, segments=new_segs, existing_segments=existing) == (3, 3)
+
+
+def test_via_bridges_layers():
+    """A via joins segments on different layers at its drill point."""
+    pads = [(0.0, 0.0), (10.0, 10.0)]
+    segs = [
+        _seg(0.0, 0.0, 5.0, 0.0, layer=Layer.F_CU),
+        _seg(5.0, 0.0, 10.0, 10.0, layer=Layer.B_CU),
+    ]
+    via = Via(x=5.0, y=0.0, drill=0.3, diameter=0.6, layers=(Layer.F_CU, Layer.B_CU))
+    # Without the via the two segments are on different layers -> disjoint.
+    assert check_net_pad_connectivity(pads, segments=segs) == (1, 2)
+    # With the via they are one net.
+    assert check_net_pad_connectivity(pads, segments=segs, vias=[via]) == (2, 2)
+
+
+def test_near_miss_is_not_over_connected():
+    """A corridor that lands *near* (not touching) a pad must NOT count it.
+
+    This is the anti-#4176 guarantee: a 50 micron gap is far below any
+    clearance/tolerance a proximity-union model would bridge, but it is well
+    above the 1 micron coincidence epsilon, so the pad stays unconnected.
+    """
+    pads = [(0.0, 0.0), (10.0, 0.0), (5.0, 0.05)]
+    segs = [_seg(0.0, 0.0, 10.0, 0.0)]
+    connected, total = check_net_pad_connectivity(pads, segments=segs)
+    assert total == 3
+    assert connected == 2  # the near-miss pad is honestly NOT connected
+
+
+def test_pcb_schema_segment_shape_via_start_end():
+    """Segments exposing start/end tuples (PCB schema) are also accepted."""
+
+    class _PcbSeg:
+        def __init__(self, start, end, layer="F.Cu"):
+            self.start = start
+            self.end = end
+            self.layer = layer
+
+    pads = [(0.0, 0.0), (10.0, 0.0)]
+    segs = [_PcbSeg((0.0, 0.0), (10.0, 0.0))]
+    assert check_net_pad_connectivity(pads, segments=segs) == (2, 2)

--- a/tests/test_mcp_routing.py
+++ b/tests/test_mcp_routing.py
@@ -521,8 +521,13 @@ class TestRouteNetAuto:
         PCB.path property, causing ``AttributeError: can't set attribute 'path'``
         on every real board.
 
-        Strengthened for GH-1282: also asserts routing actually succeeds
-        (not silently failing with 'Insufficient pads').
+        The guard here is specifically "no exception, well-formed result." On
+        this fixture NET1 is a 3-pad net whose two most-distant pads sit on the
+        emitted two-terminal corridor while the middle pad P1=(7.05, 8.45) is
+        genuinely stranded, so the honest completion check (#4165) reports a
+        2/3 partial rather than success. That is the *correct* result — this
+        test therefore tolerates the honest partial and only asserts the call
+        did not raise and returned a well-formed dict.
         """
         from kicad_tools.mcp.tools.routing import route_net_auto
 
@@ -531,23 +536,38 @@ class TestRouteNetAuto:
             pcb_path=str(self.FIXTURE),
             net_name="NET1",
         )
-        # The call must return a dict (not raise).
+        # The call must return a dict (not raise) — this is the GH-1268 guard.
         assert isinstance(result, dict)
         assert "success" in result
         assert result["net_name"] == "NET1"
-        # Routing must actually succeed for a net with 3 pads.
-        assert result["success"] is True, (
-            f"Expected routing success but got error: {result.get('error_message')}"
-        )
-        # Must not contain the old "Insufficient pads" error.
+        # The result must be well-formed regardless of completion: success is a
+        # bool, and if it is not a full success it must be an honest partial
+        # (NOT an AttributeError crash and NOT the old "Insufficient pads" guard
+        # failing before the orchestrator even runs).
+        assert isinstance(result["success"], bool)
         assert "Insufficient pads" not in (result.get("error_message") or "")
+        if not result["success"]:
+            # NET1 is genuinely partial on this fixture (2/3 pads), and that is
+            # the corrected #4165 behavior — assert the honest partial signal
+            # rather than the old false success.
+            assert result.get("partial") is True
+            assert result.get("pads_total") == 3
+            assert result.get("pads_connected", 0) < result["pads_total"]
 
     def test_route_net_auto_routes_multi_pad_net(self) -> None:
-        """A net with 3+ pads in routing-diagnostic.kicad_pcb returns success.
+        """A multi-pad net feeds pads to the orchestrator and reports honestly.
 
         Regression test for GH-1282: route_net_auto() was not passing pad
         positions to the orchestrator, so every strategy guard returned
         'Insufficient pads for global routing' even for nets with many pads.
+        The guard is that the pads DO reach the orchestrator (a strategy is
+        selected and applied) — NOT that every fixture net completes.
+
+        Post-#4165 this fixture's NET1 is a genuine 2/3 partial: the emitted
+        two-terminal corridor joins the two most-distant pads but strands the
+        middle pad P1=(7.05, 8.45). We document that corrected behavior here by
+        asserting the honest partial signal, while still proving the pads were
+        passed through (a real strategy ran, not the "Insufficient pads" guard).
         """
         from kicad_tools.mcp.tools.routing import route_net_auto
 
@@ -558,13 +578,19 @@ class TestRouteNetAuto:
         )
 
         assert isinstance(result, dict)
-        assert result["success"] is True, (
-            f"Routing NET1 (3 pads) should succeed, got: {result.get('error_message')}"
-        )
         assert result["net_name"] == "NET1"
-        # Strategy should have been selected and applied
+        # GH-1282 guard: pads reached the orchestrator and a strategy ran —
+        # this must NOT be the pre-orchestrator "Insufficient pads" failure.
+        assert "Insufficient pads" not in (result.get("error_message") or "")
         assert "strategy_used" in result
         assert result["strategy_used"] != "unknown"
+        # #4165: NET1 is genuinely partial on this fixture. A two-terminal
+        # corridor cannot join all three pads, so the honest completion check
+        # demotes to a 2/3 partial instead of the old false success.
+        assert result["success"] is False
+        assert result.get("partial") is True
+        assert result.get("pads_connected") == 2
+        assert result.get("pads_total") == 3
 
     def test_route_net_auto_single_pad_net_graceful_failure(self, tmp_path: Path) -> None:
         """A net with only 1 pad should fail gracefully, not crash."""

--- a/tests/test_route_auto_partial_4165.py
+++ b/tests/test_route_auto_partial_4165.py
@@ -1,0 +1,265 @@
+"""Orchestrator truth-in-exit-condition tests (Issue #4165).
+
+The global-family strategies (``global`` / ``escape`` / ``subgrid``) route a
+single two-terminal corridor and historically reported ``success=True`` even
+when a multi-pad net had stranded pads.  These tests lock in the fix:
+
+* :meth:`RoutingOrchestrator.route_net` now runs a REAL per-pad reachability
+  check after a global-family strategy and demotes an incomplete route to
+  ``success=False, partial=True`` with ``pads_connected``/``pads_total``.
+* With retries enabled (the ``strategy="auto"`` default) a demoted partial
+  falls back to ``hierarchical``, which completes the net.
+* With retries disabled (a forced ``--strategy global``) the honest partial is
+  surfaced instead of a silent fallback.
+* Fully-routed single corridors, 2-pad nets, and ``hierarchical`` are
+  unaffected (no spurious partial flag).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from kicad_tools.router import (
+    RoutingMetrics,
+    RoutingOrchestrator,
+    RoutingResult,
+    RoutingStrategy,
+)
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.primitives import Pad, Segment
+from kicad_tools.router.rules import DesignRules
+
+
+def _pad(x, y, net=1, net_name="NET1", pin="1"):
+    return Pad(x=x, y=y, width=1.0, height=1.0, net=net, net_name=net_name, ref="U1", pin=pin)
+
+
+def _seg(x1, y1, x2, y2):
+    return Segment(x1=x1, y1=y1, x2=x2, y2=y2, width=0.2, layer=Layer.F_CU, net=1, net_name="NET1")
+
+
+@pytest.fixture
+def design_rules():
+    return DesignRules(trace_width=0.2, trace_clearance=0.2, grid_resolution=0.1)
+
+
+@pytest.fixture
+def bare_pcb():
+    """A mock PCB that exposes NO copper accessors (forces empty existing copper)."""
+    pcb = MagicMock(spec=["width", "height"])
+    pcb.width = 65.0
+    pcb.height = 56.0
+    return pcb
+
+
+# Three collinear-ish pads where a single corridor between the two most-distant
+# ones (P0 <-> P1) strands the third (P2, off the line).
+_THREE_PADS = [
+    _pad(0.0, 0.0, pin="1"),
+    _pad(10.0, 0.0, pin="2"),
+    _pad(5.0, 20.0, pin="3"),
+]
+
+
+def test_global_partial_is_demoted(bare_pcb, design_rules):
+    """A global corridor connecting 2/3 pads is demoted to partial, not success."""
+    orch = RoutingOrchestrator(
+        pcb=bare_pcb, rules=design_rules, backend="cpu", max_strategy_retries=0
+    )
+
+    def fake_execute(net, strategy, intent, pads_arg):
+        # Emulate the global router: one corridor between the two distant pads.
+        return RoutingResult(
+            success=True,
+            net=net,
+            strategy_used=RoutingStrategy.GLOBAL_WITH_REPAIR,
+            segments=[_seg(0.0, 0.0, 10.0, 0.0)],
+            metrics=RoutingMetrics(total_length_mm=10.0),
+        )
+
+    orch._execute_strategy = fake_execute
+    result = orch.route_net("NET1", pads=_THREE_PADS)
+
+    assert result.success is False
+    assert result.partial is True
+    assert result.pads_connected == 2
+    assert result.pads_total == 3
+    assert any("2/3" in w or "partial" in w.lower() for w in result.warnings)
+
+
+def test_global_partial_falls_back_to_hierarchical_when_retries_enabled(bare_pcb, design_rules):
+    """With retries on (auto default), a partial global route retries hierarchical."""
+    orch = RoutingOrchestrator(
+        pcb=bare_pcb, rules=design_rules, backend="cpu", max_strategy_retries=2
+    )
+
+    def fake_execute(net, strategy, intent, pads_arg):
+        if strategy == RoutingStrategy.HIERARCHICAL_DIFF_PAIR:
+            # The iterative router completes the net (all three pads joined).
+            return RoutingResult(
+                success=True,
+                net=net,
+                strategy_used=RoutingStrategy.HIERARCHICAL_DIFF_PAIR,
+                segments=[
+                    _seg(0.0, 0.0, 10.0, 0.0),
+                    _seg(10.0, 0.0, 5.0, 20.0),
+                ],
+                metrics=RoutingMetrics(total_length_mm=32.0),
+            )
+        # Global family: partial corridor.
+        return RoutingResult(
+            success=True,
+            net=net,
+            strategy_used=RoutingStrategy.GLOBAL_WITH_REPAIR,
+            segments=[_seg(0.0, 0.0, 10.0, 0.0)],
+        )
+
+    orch._execute_strategy = fake_execute
+    result = orch.route_net("NET1", pads=_THREE_PADS)
+
+    assert result.success is True
+    assert result.strategy_used == RoutingStrategy.HIERARCHICAL_DIFF_PAIR
+    assert any("retry" in w.lower() for w in result.warnings)
+
+
+def test_partial_kept_when_all_retries_stay_partial(bare_pcb, design_rules):
+    """If no strategy completes the net, the best honest partial is surfaced."""
+    orch = RoutingOrchestrator(
+        pcb=bare_pcb, rules=design_rules, backend="cpu", max_strategy_retries=2
+    )
+
+    def fake_execute(net, strategy, intent, pads_arg):
+        # Every strategy (including the hierarchical fallback) only manages the
+        # same 2/3 corridor -- but it's still reported as global-family so it is
+        # subject to the completion check.
+        return RoutingResult(
+            success=True,
+            net=net,
+            strategy_used=RoutingStrategy.GLOBAL_WITH_REPAIR,
+            segments=[_seg(0.0, 0.0, 10.0, 0.0)],
+        )
+
+    orch._execute_strategy = fake_execute
+    result = orch.route_net("NET1", pads=_THREE_PADS)
+
+    assert result.success is False
+    assert result.partial is True
+    assert result.pads_connected == 2
+    assert result.pads_total == 3
+
+
+def test_lucky_full_corridor_reports_clean_success(bare_pcb, design_rules):
+    """A single corridor that happens to cover all pads reports success, no partial."""
+    orch = RoutingOrchestrator(
+        pcb=bare_pcb, rules=design_rules, backend="cpu", max_strategy_retries=0
+    )
+    # Three pads all on one line -> a single corridor covers all of them.
+    pads = [_pad(0.0, 0.0, pin="1"), _pad(5.0, 0.0, pin="2"), _pad(10.0, 0.0, pin="3")]
+
+    def fake_execute(net, strategy, intent, pads_arg):
+        return RoutingResult(
+            success=True,
+            net=net,
+            strategy_used=RoutingStrategy.GLOBAL_WITH_REPAIR,
+            segments=[_seg(0.0, 0.0, 10.0, 0.0)],
+        )
+
+    orch._execute_strategy = fake_execute
+    result = orch.route_net("NET1", pads=pads)
+
+    assert result.success is True
+    assert result.partial is False
+    assert result.pads_connected == 3
+    assert result.pads_total == 3
+
+
+def test_two_pad_net_not_flagged_partial(bare_pcb, design_rules):
+    """A routed 2-pad net is never demoted (no multi-pad stranding possible)."""
+    orch = RoutingOrchestrator(
+        pcb=bare_pcb, rules=design_rules, backend="cpu", max_strategy_retries=0
+    )
+    pads = [_pad(0.0, 0.0, pin="1"), _pad(10.0, 0.0, pin="2")]
+
+    def fake_execute(net, strategy, intent, pads_arg):
+        return RoutingResult(
+            success=True,
+            net=net,
+            strategy_used=RoutingStrategy.GLOBAL_WITH_REPAIR,
+            segments=[_seg(0.0, 0.0, 10.0, 0.0)],
+        )
+
+    orch._execute_strategy = fake_execute
+    result = orch.route_net("NET1", pads=pads)
+
+    assert result.success is True
+    assert result.partial is False
+
+
+def test_hierarchical_result_not_subject_to_completion_check(bare_pcb, design_rules):
+    """Hierarchical completes by construction; it is trusted without demotion."""
+    orch = RoutingOrchestrator(
+        pcb=bare_pcb, rules=design_rules, backend="cpu", max_strategy_retries=0
+    )
+
+    def fake_execute(net, strategy, intent, pads_arg):
+        # Even though the reported geometry only covers 2/3 pads, a hierarchical
+        # result is trusted (its own iterative logic owns completeness).
+        return RoutingResult(
+            success=True,
+            net=net,
+            strategy_used=RoutingStrategy.HIERARCHICAL_DIFF_PAIR,
+            segments=[_seg(0.0, 0.0, 10.0, 0.0)],
+        )
+
+    orch._execute_strategy = fake_execute
+    result = orch.route_net("NET1", pads=_THREE_PADS)
+
+    assert result.success is True
+    assert result.partial is False
+
+
+def test_hard_failure_stays_failure_not_partial(bare_pcb, design_rules):
+    """A global strategy that produces NO copper stays a hard failure."""
+    orch = RoutingOrchestrator(
+        pcb=bare_pcb, rules=design_rules, backend="cpu", max_strategy_retries=0
+    )
+
+    def fake_execute(net, strategy, intent, pads_arg):
+        return RoutingResult(
+            success=False,
+            net=net,
+            strategy_used=RoutingStrategy.GLOBAL_WITH_REPAIR,
+            error_message="Global router failed to find corridor assignment",
+        )
+
+    orch._execute_strategy = fake_execute
+    result = orch.route_net("NET1", pads=_THREE_PADS)
+
+    assert result.success is False
+    assert result.partial is False
+
+
+def test_to_dict_exposes_partial_fields(bare_pcb, design_rules):
+    """The partial signal is serialized for the CLI/MCP surface."""
+    orch = RoutingOrchestrator(
+        pcb=bare_pcb, rules=design_rules, backend="cpu", max_strategy_retries=0
+    )
+
+    def fake_execute(net, strategy, intent, pads_arg):
+        return RoutingResult(
+            success=True,
+            net=net,
+            strategy_used=RoutingStrategy.GLOBAL_WITH_REPAIR,
+            segments=[_seg(0.0, 0.0, 10.0, 0.0)],
+        )
+
+    orch._execute_strategy = fake_execute
+    result = orch.route_net("NET1", pads=_THREE_PADS)
+    d = result.to_dict()
+
+    assert d["partial"] is True
+    assert d["success"] is False
+    assert d["pads_connected"] == 2
+    assert d["pads_total"] == 3

--- a/tests/test_route_auto_partial_cli_4165.py
+++ b/tests/test_route_auto_partial_cli_4165.py
@@ -1,0 +1,122 @@
+"""CLI-surface tests for partial-route reporting (Issue #4165).
+
+``run_route_auto_command`` must exit non-zero and print a
+``partially routed ... k/n pads connected`` message when the orchestrator
+demotes a multi-pad net to a partial route, rather than the old silent
+``Routed net successfully`` + exit 0.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from kicad_tools.cli.commands.routing import run_route_auto_command
+
+
+def _args(**overrides):
+    base = {
+        "pcb": "/tmp/does-not-matter.kicad_pcb",
+        "net": "NET1",
+        "output": None,
+        "strategy": "global",
+        "no_repair": False,
+        "no_via_resolution": False,
+        "dry_run": False,
+        "region": None,
+        "allow_partial": False,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_partial_result_exits_nonzero_and_reports_kn(capsys):
+    partial = {
+        "success": False,
+        "partial": True,
+        "net_name": "NET1",
+        "pads_connected": 2,
+        "pads_total": 3,
+        "strategy_used": "GLOBAL_WITH_REPAIR",
+        "warnings": [],
+    }
+    with patch("kicad_tools.mcp.tools.routing.route_net_auto", return_value=partial):
+        rc = run_route_auto_command(_args())
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "partially routed" in err
+    assert "2/3 pads connected" in err
+    # Guides the user toward the completing strategy.
+    assert "hierarchical" in err
+
+
+def test_partial_without_allow_partial_notes_copper_not_saved(capsys):
+    partial = {
+        "success": False,
+        "partial": True,
+        "net_name": "NET1",
+        "pads_connected": 2,
+        "pads_total": 3,
+        "strategy_used": "GLOBAL_WITH_REPAIR",
+        "warnings": [],
+    }
+    with patch("kicad_tools.mcp.tools.routing.route_net_auto", return_value=partial):
+        rc = run_route_auto_command(_args(allow_partial=False))
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "NOT saved" in err
+
+
+def test_partial_with_allow_partial_reports_saved_segments(capsys):
+    partial = {
+        "success": False,
+        "partial": True,
+        "net_name": "NET1",
+        "pads_connected": 2,
+        "pads_total": 3,
+        "strategy_used": "GLOBAL_WITH_REPAIR",
+        "segments_written": 4,
+        "warnings": [],
+    }
+    with patch("kicad_tools.mcp.tools.routing.route_net_auto", return_value=partial):
+        rc = run_route_auto_command(_args(allow_partial=True))
+
+    assert rc == 1  # still non-zero: the net is incomplete
+    err = capsys.readouterr().err
+    assert "Partial copper saved: 4 segments" in err
+
+
+def test_full_success_still_exits_zero(capsys):
+    ok = {
+        "success": True,
+        "partial": False,
+        "net_name": "NET1",
+        "strategy_used": "HIERARCHICAL_DIFF_PAIR",
+        "metrics": {"total_length_mm": 12.0, "via_count": 0},
+        "warnings": [],
+    }
+    with patch("kicad_tools.mcp.tools.routing.route_net_auto", return_value=ok):
+        rc = run_route_auto_command(_args(strategy="auto"))
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "successfully" in out.lower()
+
+
+def test_hard_failure_exits_nonzero_without_partial_message(capsys):
+    fail = {
+        "success": False,
+        "partial": False,
+        "net_name": "NET1",
+        "error_message": "Global router failed to find corridor assignment",
+        "warnings": [],
+    }
+    with patch("kicad_tools.mcp.tools.routing.route_net_auto", return_value=fail):
+        rc = run_route_auto_command(_args())
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "Routing failed for net" in err
+    assert "partially routed" not in err


### PR DESCRIPTION
Closes #4165

## Problem

`kct route-auto` printed **"Routed net successfully"** and exited 0 while leaving pads of a multi-pad net unconnected. Root cause: `GlobalRouter.route_net()` is a **two-terminal** corridor planner (`_pick_endpoints` picks the 2 most-distant pads, builds ONE corridor) used for **N-terminal** nets. `RoutingOrchestrator._route_global()` returned `success=True` unconditionally with no per-pad check; `escape`/`subgrid` funnel through it. The retry path in `route_net()` is keyed on `success==False`, so it never fired for a partial. Only `hierarchical` (iterative negotiated router) completed multi-pad nets.

## What this PR does

### Fix (1) — truth in the exit condition (MUST-HAVE)
- New `router/connectivity.py::check_net_pad_connectivity()`: a **real per-pad reachability walk** (union-find over geometric copper adjacency — shared endpoints, point-on-segment, via layer bridges) on produced segments/vias unioned with pre-existing same-net copper.
- **Completion-check approach:** this does **NOT** reuse `NetStatusAnalyzer`'s endpoint-proximity tolerance union. Its coincidence epsilon is 1 µm (far below any clearance), so it errs toward **under-connecting** (reporting incomplete) rather than over-connecting. **It therefore does not inherit #4176's false-positive risk.**
- `RoutingOrchestrator.route_net()` runs `_verify_completion()` after a global-family strategy (and each retry). Fewer-than-all pads → demote to `success=False, partial=True` with `pads_connected`/`pads_total`. `RoutingResult` gains `partial`/`pads_connected`/`pads_total` (surfaced in `to_dict()`).
- CLI prints `partially routed net '<net>': k/n pads connected` and **exits non-zero**.
- `--allow-partial` persists incomplete copper (exit stays non-zero); default refuses to write it silently.

### Fix (2) MVP — fall back to hierarchical on partial (DONE, the cheap MVP)
- With `strategy="auto"` (retries enabled) a demoted partial reuses the existing `alternative_strategies` retry plumbing: `HIERARCHICAL_DIFF_PAIR` is injected as the first alternative and completes the net.
- A **forced** `--strategy global/escape/subgrid` sets `max_strategy_retries=0`, honoring the user's explicit choice and surfacing the honest partial (no silent fallback).
- True multi-terminal surgery inside `GlobalRouter` is **deferred** as the deeper follow-up (this MVP was clean, so it is included).

### Fix (3) — docs (MUST-HAVE)
- `--strategy` help and `route_net_auto()` docstring now state that `global`/`escape`/`subgrid` route a single two-terminal corridor and may leave a multi-pad net partially connected, while `hierarchical` iterates to completion.

## Behavior-compatibility note

Default `--strategy auto` **attempts** the hierarchical fallback on a partial multi-pad net and **completes it when it can** — so existing "route this net" workflows keep working and get *more* complete than the old silent-partial behavior. The fallback is **not** a guarantee: on congested or geometrically hard nets the net can remain partial even after hierarchical (e.g. `NET1` on the in-repo `routing-diagnostic.kicad_pcb` stays 2/3 because a middle pad is genuinely stranded off the two-terminal corridor and hierarchical does not complete it there either). In that case `route-auto` now reports the honest `partial 2/3` and exits **non-zero** — which is the *correct* result (the net really is incomplete), replacing the old false "Routed successfully" + exit 0. Explicitly forcing a global-family strategy also exits **non-zero** on a partial (previously silent 0) — this is the reported bug, and `--allow-partial` is provided as the escape hatch for callers who intentionally route partial corridors.

## Tests

- `tests/test_connectivity_reachability_4165.py` — 9 unit tests for the reachability primitive (2-pad, 3-pad stranded, chained, existing copper, via layer-bridge, near-miss anti-over-connection, PCB-schema segment shape).
- `tests/test_route_auto_partial_4165.py` — 8 orchestrator tests (global partial demoted; auto attempts the hierarchical fallback and completes when it can; best-partial kept when no strategy completes; lucky full corridor stays clean; 2-pad not flagged; hierarchical trusted; hard failure stays failure; `to_dict` exposes partial fields).
- `tests/test_route_auto_partial_cli_4165.py` — 5 CLI tests (non-zero exit + k/n message; NOT-saved note; `--allow-partial` saved-segments; full success exits 0; hard failure path).

All green: `test_routing_orchestrator.py`, `test_route_auto_fix.py`, `test_route_auto_persistence.py`, `test_route_auto_mfr_tier*.py`, `test_mcp_routing.py`, plus the 3 new suites. ruff check + format clean; mypy baseline check reports **0 new errors**.

## Follow-up

Fix (2)'s true multi-terminal (MST/Steiner) corridor planner inside `GlobalRouter` remains a follow-up; the hierarchical fallback is the interim completion path. Related #4175 (duplicate-copper-on-retry) is a separate defect on the same retry path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
