### PR TITLE
fix(routing): dedupe copper at emission time + add `kct pcb dedupe` (#4175)

### DIFF
--- a/src/kicad_tools/cli/commands/pcb.py
+++ b/src/kicad_tools/cli/commands/pcb.py
@@ -13,7 +13,7 @@ def run_pcb_command(args) -> int:
     if not args.pcb_command:
         print("Usage: kicad-tools pcb <command> [options] <file>")
         print(
-            "Commands: summary, footprints, nets, traces, stackup, zones, strip, reannotate, sync-netlist, add-3d-models, remove-footprint, move-footprint, page-fit, center-on-sheet, lock-footprints, unlock-footprints, add-zone, snap-rotation, edit-outline, net-audit, export-dsn, import-ses"
+            "Commands: summary, footprints, nets, traces, stackup, zones, strip, dedupe, reannotate, sync-netlist, add-3d-models, remove-footprint, move-footprint, page-fit, center-on-sheet, lock-footprints, unlock-footprints, add-zone, snap-rotation, edit-outline, net-audit, export-dsn, import-ses"
         )
         return 1
 
@@ -29,6 +29,10 @@ def run_pcb_command(args) -> int:
     # Handle strip command separately (doesn't use pcb_query)
     if args.pcb_command == "strip":
         return _run_strip_command(args, pcb_path)
+
+    # Handle dedupe command (remove exact-duplicate copper; issue #4175)
+    if args.pcb_command == "dedupe":
+        return _run_dedupe_command(args, pcb_path)
 
     # Handle reannotate command separately (doesn't use pcb_query)
     if args.pcb_command == "reannotate":
@@ -369,6 +373,73 @@ def _run_strip_command(args, pcb_path: Path) -> int:
 
     # Save unless dry-run
     if not dry_run:
+        try:
+            pcb.save(output_path)
+            if output_format == "text":
+                print()
+                print(f"  Saved to: {output_path}")
+        except Exception as e:
+            print(f"Error saving PCB: {e}", file=sys.stderr)
+            return 1
+
+    return 0
+
+
+def _run_dedupe_command(args, pcb_path: Path) -> int:
+    """Handle the 'pcb dedupe' command (issue #4175).
+
+    Removes pre-existing exact-duplicate copper (segments + vias with the same
+    net/geometry/layer, differing only in uuid) from an already-bloated board.
+    In-place by default (consistent with the in-place convention established by
+    #4166/#4195); ``-o`` writes to a separate file instead.
+    """
+    from kicad_tools.schema.pcb import PCB
+
+    try:
+        pcb = PCB.load(pcb_path)
+    except Exception as e:
+        print(f"Error loading PCB: {e}", file=sys.stderr)
+        return 1
+
+    before_segments = len(pcb.segments)
+    before_vias = len(pcb.vias)
+
+    stats = pcb.dedupe_copper()
+
+    output_format = getattr(args, "format", "text")
+    dry_run = getattr(args, "dry_run", False)
+    output_path = Path(args.output) if getattr(args, "output", None) else pcb_path
+
+    result: dict[str, Any] = {
+        "input": str(pcb_path),
+        "output": str(output_path) if not dry_run else None,
+        "dry_run": dry_run,
+        "before": {"segments": before_segments, "vias": before_vias},
+        "removed": stats,
+        "after": {
+            "segments": before_segments - stats["segments"],
+            "vias": before_vias - stats["vias"],
+        },
+    }
+
+    if output_format == "json":
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"PCB Dedupe {'(dry run)' if dry_run else ''}")
+        print(f"  Input:  {pcb_path}")
+        if not dry_run:
+            print(f"  Output: {output_path}")
+        print()
+        print("  Removed exact-duplicate copper:")
+        print(f"    Segments: {stats['segments']:,}")
+        print(f"    Vias:     {stats['vias']:,}")
+        print()
+        print("  Remaining:")
+        print(f"    Segments: {result['after']['segments']:,}")
+        print(f"    Vias:     {result['after']['vias']:,}")
+
+    # Save only when something changed and not a dry-run.
+    if not dry_run and (stats["segments"] or stats["vias"]):
         try:
             pcb.save(output_path)
             if output_format == "text":

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1610,6 +1610,37 @@ def _add_pcb_parser(subparsers) -> None:
         help="Show what would be removed without modifying files",
     )
 
+    # pcb dedupe (issue #4175)
+    pcb_dedupe = pcb_subparsers.add_parser(
+        "dedupe",
+        help="Remove exact-duplicate copper (segments + vias)",
+        description="Remove pre-existing exact-duplicate copper from a board: "
+        "segments and vias that share the same net, geometry, and layer(s) "
+        "(differing only in uuid). Such duplicates are invisible to netlist "
+        "connectivity but silently bloat the file and slow later DRC/optimize "
+        "passes. One instance of each distinct geometry is kept, so net "
+        "connectivity is unchanged. In-place by default; use -o to write "
+        "elsewhere.",
+    )
+    pcb_dedupe.add_argument("pcb", help="Path to .kicad_pcb file")
+    pcb_dedupe.add_argument(
+        "-o",
+        "--output",
+        dest="output",
+        help="Output file path (default: overwrite input in place)",
+    )
+    pcb_dedupe.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format for results",
+    )
+    pcb_dedupe.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report duplicates without modifying files",
+    )
+
     # pcb reannotate
     pcb_reannotate = pcb_subparsers.add_parser(
         "reannotate",

--- a/src/kicad_tools/mcp/tools/routing.py
+++ b/src/kicad_tools/mcp/tools/routing.py
@@ -817,11 +817,26 @@ def route_net_auto(
     # before saving, and surface a clear failure when the orchestrator
     # reports success but produced no physical segments.
     if output_path and should_persist:
-        segments_written, vias_written = _persist_routing_result_to_pcb(pcb, result, net_name)
+        (
+            segments_written,
+            vias_written,
+            segments_deduplicated,
+            vias_deduplicated,
+        ) = _persist_routing_result_to_pcb(pcb, result, net_name)
         result_dict["segments_written"] = segments_written
         result_dict["vias_written"] = vias_written
+        # Issue #4175: report how much copper was skipped as an exact duplicate
+        # already present on the board, so a fully-duplicate retry prints an
+        # honest "0 written / N deduplicated" instead of implying new copper.
+        result_dict["segments_deduplicated"] = segments_deduplicated
+        result_dict["vias_deduplicated"] = vias_deduplicated
 
-        if segments_written == 0 and vias_written == 0:
+        # A retry that reproduces geometry already fully present on the board
+        # writes nothing new but is NOT a failure -- the net is already routed.
+        produced_or_deduped = (
+            segments_written + vias_written + segments_deduplicated + vias_deduplicated
+        )
+        if segments_written == 0 and vias_written == 0 and produced_or_deduped == 0:
             # Orchestrator claimed success but produced nothing physical.
             # Refuse to silently save an empty PCB -- mark the call as a
             # failure with a clear error message instead.
@@ -844,7 +859,7 @@ def route_net_auto(
     return result_dict
 
 
-def _persist_routing_result_to_pcb(pcb: PCB, result, net_name: str) -> tuple[int, int]:
+def _persist_routing_result_to_pcb(pcb: PCB, result, net_name: str) -> tuple[int, int, int, int]:
     """Persist orchestrator result segments + vias into the PCB object.
 
     Issue #2913: the orchestrator returns segments/vias on the
@@ -852,16 +867,24 @@ def _persist_routing_result_to_pcb(pcb: PCB, result, net_name: str) -> tuple[int
     materialises them via ``pcb.add_trace`` / ``pcb.add_via`` so a
     subsequent ``pcb.save`` writes the physical traces to disk.
 
+    Issue #4175: ``add_trace``/``add_via`` now deduplicate against copper
+    already on the board, so a completion-loop retry that re-solves the same
+    corridor appends nothing new.  This helper distinguishes genuinely-written
+    copper from skipped duplicates and returns both counts.
+
     Args:
         pcb: Loaded PCB object (will be mutated).
         result: Orchestrator ``RoutingResult`` (carries ``segments``/``vias``).
         net_name: Net name to associate with the new traces.
 
     Returns:
-        Tuple of ``(segments_written, vias_written)``.
+        Tuple of ``(segments_written, vias_written, segments_deduplicated,
+        vias_deduplicated)``.
     """
     segments_written = 0
     vias_written = 0
+    segments_deduplicated = 0
+    vias_deduplicated = 0
 
     # Persist segments.  The orchestrator's Segment uses router.layers.Layer
     # (KiCad name accessor: ``layer.kicad_name``).  ``add_trace`` accepts
@@ -871,14 +894,18 @@ def _persist_routing_result_to_pcb(pcb: PCB, result, net_name: str) -> tuple[int
             layer_name = (
                 seg.layer.kicad_name if hasattr(seg.layer, "kicad_name") else str(seg.layer)
             )
-            pcb.add_trace(
+            added = pcb.add_trace(
                 start=(float(seg.x1), float(seg.y1)),
                 end=(float(seg.x2), float(seg.y2)),
                 width=float(getattr(seg, "width", 0.2)),
                 layer=layer_name,
                 net=net_name,
             )
-            segments_written += 1
+            if added:
+                segments_written += 1
+            else:
+                # add_trace returned an empty list -> exact-duplicate skipped.
+                segments_deduplicated += 1
         except Exception as e:  # pragma: no cover - defensive
             logger.warning("Failed to persist segment for net %s: %s", net_name, e)
 
@@ -893,7 +920,7 @@ def _persist_routing_result_to_pcb(pcb: PCB, result, net_name: str) -> tuple[int
                 )
             else:
                 layer_pair = ("F.Cu", "B.Cu")
-            pcb.add_via(
+            added_via = pcb.add_via(
                 x=float(via.x),
                 y=float(via.y),
                 size=float(getattr(via, "diameter", 0.6)),
@@ -901,11 +928,15 @@ def _persist_routing_result_to_pcb(pcb: PCB, result, net_name: str) -> tuple[int
                 layers=layer_pair,
                 net=net_name,
             )
-            vias_written += 1
+            if added_via is not None:
+                vias_written += 1
+            else:
+                # add_via returned None -> exact-duplicate skipped.
+                vias_deduplicated += 1
         except Exception as e:  # pragma: no cover - defensive
             logger.warning("Failed to persist via for net %s: %s", net_name, e)
 
-    return segments_written, vias_written
+    return segments_written, vias_written, segments_deduplicated, vias_deduplicated
 
 
 def _build_pad_positions(pcb: PCB) -> dict[int, list[tuple[float, float]]]:

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -50,6 +50,59 @@ def _is_power_net(name: str, pattern: re.Pattern[str] | None = None) -> bool:
     return pat.search(name) is not None
 
 
+# Copper-deduplication support (issue #4175).
+#
+# ``route-auto`` (and any completion-loop caller) re-solves the same corridor
+# on every external retry and appends a geometrically-identical, uuid-distinct
+# copy of the same copper.  ``add_trace``/``add_via`` deduplicate against an
+# incrementally-maintained key set so the same net-geometry is never appended
+# twice; ``dedupe_copper`` cleans up boards that were already bloated.
+#
+# ``_DEDUP_QUANT`` = 3 decimal places rounds coordinates/widths to ~1 micron at
+# mm scale, matching the ``EPS = 1e-3`` mm coincidence tolerance established by
+# ``router/connectivity.py`` (#4165) rather than inventing a second epsilon.
+_DEDUP_QUANT = 3
+
+# Type aliases for the dedup keys.
+_SegmentKey = tuple[int, str, tuple[tuple[float, float], tuple[float, float]], float]
+_ViaKey = tuple[int, float, float, tuple[str, ...]]
+
+
+def _segment_dedup_key(
+    net_number: int,
+    layer: str,
+    start: tuple[float, float],
+    end: tuple[float, float],
+    width: float,
+) -> _SegmentKey:
+    """Order-insensitive dedup key for a trace segment.
+
+    Two segments are duplicates only when they share net, layer, width, and the
+    same *unordered* pair of endpoints (a re-solved corridor may walk the same
+    two points in either direction).  Segments that merely share one endpoint,
+    or that differ in layer/width/net, are NOT duplicates.
+    """
+    p1 = (round(start[0], _DEDUP_QUANT), round(start[1], _DEDUP_QUANT))
+    p2 = (round(end[0], _DEDUP_QUANT), round(end[1], _DEDUP_QUANT))
+    endpoints = (p1, p2) if p1 <= p2 else (p2, p1)
+    return (net_number, layer, endpoints, round(width, _DEDUP_QUANT))
+
+
+def _via_dedup_key(
+    net_number: int,
+    x: float,
+    y: float,
+    layers: tuple[str, ...] | list[str],
+) -> _ViaKey:
+    """Dedup key for a via: net + rounded position + order-insensitive layers."""
+    return (
+        net_number,
+        round(x, _DEDUP_QUANT),
+        round(y, _DEDUP_QUANT),
+        tuple(sorted(layers)),
+    )
+
+
 def _segment_span_intersects_region(
     start: tuple[float, float],
     end: tuple[float, float],
@@ -1439,6 +1492,12 @@ class PCB:
         self._footprints: list[Footprint] = []
         self._segments: list[Segment] = []
         self._vias: list[Via] = []
+        # Incrementally-maintained dedup key sets (issue #4175).  Built lazily
+        # from _segments/_vias on first add_trace/add_via, then updated on each
+        # append.  Reset to None whenever the underlying lists are bulk-mutated
+        # (strip_traces, dedupe_copper, segments/vias reload) so they rebuild.
+        self._segment_keys: set[_SegmentKey] | None = None
+        self._via_keys: set[_ViaKey] | None = None
         self._zones: list[Zone] = []
         self._graphic_lines: list[GraphicLine] = []
         self._graphic_arcs: list[GraphicArc] = []
@@ -2560,6 +2619,7 @@ class PCB:
         self._footprints = []
         self._segments = []
         self._vias = []
+        self._invalidate_dedup_keys()
         self._zones = []
         self._graphic_lines = []
         self._graphic_arcs = []
@@ -2813,6 +2873,7 @@ class PCB:
             if not should_remove:
                 remaining.append(seg)
         self._segments = remaining
+        self._invalidate_dedup_keys()
 
         return removed_count
 
@@ -4541,6 +4602,33 @@ class PCB:
 
         return None
 
+    def _invalidate_dedup_keys(self) -> None:
+        """Drop the cached copper dedup key sets (issue #4175).
+
+        Call after any bulk mutation of ``_segments``/``_vias`` (strip,
+        dedupe, reload) so the next ``add_trace``/``add_via`` rebuilds them.
+        """
+        self._segment_keys = None
+        self._via_keys = None
+
+    def _ensure_segment_keys(self) -> set[_SegmentKey]:
+        """Return the segment dedup key set, building it lazily if needed."""
+        if self._segment_keys is None:
+            self._segment_keys = {
+                _segment_dedup_key(seg.net_number, seg.layer, seg.start, seg.end, seg.width)
+                for seg in self._segments
+            }
+        return self._segment_keys
+
+    def _ensure_via_keys(self) -> set[_ViaKey]:
+        """Return the via dedup key set, building it lazily if needed."""
+        if self._via_keys is None:
+            self._via_keys = {
+                _via_dedup_key(via.net_number, via.position[0], via.position[1], via.layers)
+                for via in self._vias
+            }
+        return self._via_keys
+
     def add_trace(
         self,
         start: tuple[float, float] | tuple[str, str],
@@ -4549,6 +4637,7 @@ class PCB:
         layer: str = "F.Cu",
         net: str | None = None,
         waypoints: list[tuple[float, float]] | None = None,
+        dedupe: bool = True,
     ) -> list[Segment]:
         """
         Add a trace (one or more segments) between two points or pads.
@@ -4563,9 +4652,15 @@ class PCB:
             layer: Copper layer name (default "F.Cu")
             net: Net name for the trace. Auto-detected from pads if not specified.
             waypoints: Optional list of (x, y) intermediate points
+            dedupe: When True (default, issue #4175), skip appending any
+                segment whose (net, layer, unordered endpoints, width) key
+                already exists on the board.  Prevents route-auto retries from
+                accumulating exact-duplicate copper.  Set False only if you
+                deliberately need identical-geometry duplicates.
 
         Returns:
-            List of Segment objects that were created
+            List of Segment objects that were created (skipped duplicates are
+            excluded, so this may be shorter than the number of point-pairs).
 
         Raises:
             ValueError: If pad references are invalid or positions cannot be determined
@@ -4630,7 +4725,16 @@ class PCB:
         # we add the board origin offset when constructing the sexp node.
         ox, oy = self._board_origin
         segments = []
+        seg_keys = self._ensure_segment_keys() if dedupe else None
         for i in range(len(points) - 1):
+            if seg_keys is not None:
+                key = _segment_dedup_key(net_number, layer, points[i], points[i + 1], width)
+                if key in seg_keys:
+                    # Exact-duplicate copper already on the board (issue #4175):
+                    # skip appending rather than accumulating a uuid-distinct
+                    # copy.  Connectivity is unaffected (identical geometry).
+                    continue
+                seg_keys.add(key)
             seg = Segment(
                 start=points[i],
                 end=points[i + 1],
@@ -4664,7 +4768,8 @@ class PCB:
         drill: float = 0.3,
         layers: tuple[str, str] = ("F.Cu", "B.Cu"),
         net: str | None = None,
-    ) -> Via:
+        dedupe: bool = True,
+    ) -> Via | None:
         """
         Add a via at the specified position.
 
@@ -4678,9 +4783,13 @@ class PCB:
             drill: Via drill diameter in mm (default 0.3)
             layers: Tuple of layer names to connect (default ("F.Cu", "B.Cu"))
             net: Net name for the via (optional)
+            dedupe: When True (default, issue #4175), skip appending a via
+                whose (net, rounded position, unordered layers) key already
+                exists on the board.
 
         Returns:
-            The Via object that was created
+            The Via object that was created, or None if an identical via was
+            already present and was skipped as a duplicate.
 
         Example:
             >>> pcb = PCB.load("board.kicad_pcb")
@@ -4691,6 +4800,14 @@ class PCB:
         if net:
             net_obj = self.add_net(net)
             net_number = net_obj.number
+
+        if dedupe:
+            via_keys = self._ensure_via_keys()
+            key = _via_dedup_key(net_number, x, y, layers)
+            if key in via_keys:
+                # Exact-duplicate via already on the board (issue #4175): skip.
+                return None
+            via_keys.add(key)
 
         via = Via(
             position=(x, y),
@@ -4718,6 +4835,72 @@ class PCB:
             self._sexp.append(via.to_sexp())
 
         return via
+
+    def dedupe_copper(self) -> dict[str, int]:
+        """Remove pre-existing exact-duplicate copper (issue #4175).
+
+        Scans existing segments and vias, groups them by the same dedup keys
+        used by ``add_trace``/``add_via`` (net + geometry + layer/width, with
+        order-insensitive endpoints and ~1 micron rounding), keeps the first
+        element of each group, and drops the rest from both the in-memory
+        lists and the S-expression tree (so ``save()`` persists the cleanup).
+
+        Because every removed element is geometrically and electrically
+        identical to a copy that remains, net connectivity is unchanged.
+
+        Returns:
+            ``{"segments": n_seg_removed, "vias": n_via_removed}``.
+        """
+        # Determine which segment/via uuids to drop (keep first per key).
+        seg_uuids_to_remove: set[str] = set()
+        seen_seg_keys: set[_SegmentKey] = set()
+        kept_segments: list[Segment] = []
+        for seg in self._segments:
+            skey = _segment_dedup_key(seg.net_number, seg.layer, seg.start, seg.end, seg.width)
+            if skey in seen_seg_keys:
+                if seg.uuid:
+                    seg_uuids_to_remove.add(seg.uuid)
+            else:
+                seen_seg_keys.add(skey)
+                kept_segments.append(seg)
+
+        via_uuids_to_remove: set[str] = set()
+        seen_via_keys: set[_ViaKey] = set()
+        kept_vias: list[Via] = []
+        for via in self._vias:
+            vkey = _via_dedup_key(via.net_number, via.position[0], via.position[1], via.layers)
+            if vkey in seen_via_keys:
+                if via.uuid:
+                    via_uuids_to_remove.add(via.uuid)
+            else:
+                seen_via_keys.add(vkey)
+                kept_vias.append(via)
+
+        n_seg_removed = len(self._segments) - len(kept_segments)
+        n_via_removed = len(self._vias) - len(kept_vias)
+
+        # Remove duplicate S-expression nodes by uuid.
+        if seg_uuids_to_remove or via_uuids_to_remove:
+            sexp_to_remove = []
+            for child in self._sexp.children:
+                if child.is_atom:
+                    continue
+                if child.name == "segment":
+                    uuid_node = child.find("uuid")
+                    if uuid_node and (uuid_node.get_string(0) or "") in seg_uuids_to_remove:
+                        sexp_to_remove.append(child)
+                elif child.name == "via":
+                    uuid_node = child.find("uuid")
+                    if uuid_node and (uuid_node.get_string(0) or "") in via_uuids_to_remove:
+                        sexp_to_remove.append(child)
+            for node in sexp_to_remove:
+                self._sexp.remove(node)
+
+        self._segments = kept_segments
+        self._vias = kept_vias
+        self._invalidate_dedup_keys()
+
+        return {"segments": n_seg_removed, "vias": n_via_removed}
 
     def routing_status(self) -> dict:
         """
@@ -5481,6 +5664,10 @@ class PCB:
                     for vl in v.layers
                 )
             ]
+
+        # Copper lists were bulk-mutated: drop cached dedup keys (issue #4175)
+        # so a later add_trace/add_via rebuilds them from the surviving copper.
+        self._invalidate_dedup_keys()
 
         return {
             "segments": removed_segments,

--- a/tests/test_cli_pcb.py
+++ b/tests/test_cli_pcb.py
@@ -1313,6 +1313,203 @@ def kicad7_multi_fp_pcb(tmp_path: Path) -> Path:
     return pcb_file
 
 
+class TestPcbDedupe:
+    """Tests for 'kicad-tools pcb dedupe' command (issue #4175)."""
+
+    def _bloated_board(self, path: Path):
+        """Create a board with pre-seeded exact-duplicate segments + vias."""
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.create(width=100, height=100)
+        # 4 identical segments (route-auto retry pattern) + 1 distinct one.
+        for _ in range(4):
+            pcb.add_trace(
+                start=(10.0, 10.0),
+                end=(50.0, 10.0),
+                width=0.25,
+                layer="F.Cu",
+                net="Sig1",
+                dedupe=False,
+            )
+        pcb.add_trace(
+            start=(50.0, 10.0),
+            end=(50.0, 40.0),
+            width=0.25,
+            layer="F.Cu",
+            net="Sig1",
+            dedupe=False,
+        )
+        # 3 identical vias + 1 distinct via.
+        for _ in range(3):
+            pcb.add_via(x=50.0, y=10.0, net="Sig1", dedupe=False)
+        pcb.add_via(x=60.0, y=30.0, net="Sig1", dedupe=False)
+        pcb.save(path)
+        return pcb
+
+    def test_dedupe_removes_duplicates_in_place(self, tmp_path, capsys):
+        from argparse import Namespace
+
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+        from kicad_tools.schema.pcb import PCB
+
+        board = tmp_path / "bloated.kicad_pcb"
+        self._bloated_board(board)
+
+        # Sanity: the seeded board is genuinely bloated.
+        seeded = PCB.load(board)
+        assert len(seeded.segments) == 5
+        assert len(seeded.vias) == 4
+
+        args = Namespace(
+            pcb=str(board),
+            pcb_command="dedupe",
+            output=None,
+            format="text",
+            dry_run=False,
+        )
+        assert run_pcb_command(args) == 0
+
+        captured = capsys.readouterr()
+        assert "Segments: 3" in captured.out  # 3 duplicate segments removed
+        assert "Vias:     2" in captured.out  # 2 duplicate vias removed
+
+        # In-place: the input file now has one instance per geometry.
+        cleaned = PCB.load(board)
+        assert len(cleaned.segments) == 2
+        assert len(cleaned.vias) == 2
+
+    def test_dedupe_output_override(self, tmp_path):
+        from argparse import Namespace
+
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+        from kicad_tools.schema.pcb import PCB
+
+        board = tmp_path / "bloated.kicad_pcb"
+        self._bloated_board(board)
+        out = tmp_path / "cleaned.kicad_pcb"
+
+        args = Namespace(
+            pcb=str(board),
+            pcb_command="dedupe",
+            output=str(out),
+            format="text",
+            dry_run=False,
+        )
+        assert run_pcb_command(args) == 0
+
+        # Input untouched, output deduplicated.
+        assert len(PCB.load(board).segments) == 5
+        assert len(PCB.load(out).segments) == 2
+        assert len(PCB.load(out).vias) == 2
+
+    def test_dedupe_json_reports_counts(self, tmp_path, capsys):
+        from argparse import Namespace
+
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+
+        board = tmp_path / "bloated.kicad_pcb"
+        self._bloated_board(board)
+
+        args = Namespace(
+            pcb=str(board),
+            pcb_command="dedupe",
+            output=None,
+            format="json",
+            dry_run=False,
+        )
+        assert run_pcb_command(args) == 0
+
+        data = json.loads(capsys.readouterr().out)
+        assert data["removed"]["segments"] == 3
+        assert data["removed"]["vias"] == 2
+        assert data["after"]["segments"] == 2
+        assert data["after"]["vias"] == 2
+
+    def test_dedupe_noop_on_clean_board(self, tmp_path, capsys):
+        from argparse import Namespace
+
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(start=(10.0, 10.0), end=(50.0, 10.0), net="Sig1")
+        pcb.add_via(x=30.0, y=20.0, net="Sig1")
+        board = tmp_path / "clean.kicad_pcb"
+        pcb.save(board)
+
+        args = Namespace(
+            pcb=str(board),
+            pcb_command="dedupe",
+            output=None,
+            format="json",
+            dry_run=False,
+        )
+        assert run_pcb_command(args) == 0
+
+        data = json.loads(capsys.readouterr().out)
+        assert data["removed"] == {"segments": 0, "vias": 0}
+        # Board is unchanged.
+        reloaded = PCB.load(board)
+        assert len(reloaded.segments) == 1
+        assert len(reloaded.vias) == 1
+
+    def test_dedupe_preserves_connectivity(self, tmp_path):
+        """Deduping keeps one copy of each distinct geometry, so nets stay wired."""
+        from argparse import Namespace
+
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+        from kicad_tools.schema.pcb import PCB
+
+        board = tmp_path / "bloated.kicad_pcb"
+        self._bloated_board(board)
+        before = PCB.load(board)
+        net_num = next(n.number for n in before.nets.values() if n.name == "Sig1")
+        before_geom = {
+            (round(s.start[0], 3), round(s.start[1], 3), round(s.end[0], 3), round(s.end[1], 3))
+            for s in before.segments_in_net(net_num)
+        }
+
+        args = Namespace(
+            pcb=str(board),
+            pcb_command="dedupe",
+            output=None,
+            format="text",
+            dry_run=False,
+        )
+        assert run_pcb_command(args) == 0
+
+        after = PCB.load(board)
+        after_geom = {
+            (round(s.start[0], 3), round(s.start[1], 3), round(s.end[0], 3), round(s.end[1], 3))
+            for s in after.segments_in_net(net_num)
+        }
+        # No distinct segment geometry lost -> connectivity unchanged.
+        assert before_geom == after_geom
+
+    def test_dedupe_dry_run_does_not_modify(self, tmp_path, capsys):
+        from argparse import Namespace
+
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+        from kicad_tools.schema.pcb import PCB
+
+        board = tmp_path / "bloated.kicad_pcb"
+        self._bloated_board(board)
+
+        args = Namespace(
+            pcb=str(board),
+            pcb_command="dedupe",
+            output=None,
+            format="text",
+            dry_run=True,
+        )
+        assert run_pcb_command(args) == 0
+        assert "dry run" in capsys.readouterr().out.lower()
+
+        # File untouched.
+        assert len(PCB.load(board).segments) == 5
+        assert len(PCB.load(board).vias) == 4
+
+
 class TestPcbReannotate:
     """Tests for pcb reannotate command."""
 

--- a/tests/test_pcb.py
+++ b/tests/test_pcb.py
@@ -4105,3 +4105,176 @@ class TestAddFootprintNumericPropertyQuoting:
         assert "(size 1 1)" in contents or "(size " in contents
         assert '(size "1" "1")' not in contents
         assert '(thickness "0.15")' not in contents
+
+
+class TestCopperDedup:
+    """Issue #4175: emission-time copper dedup + dedupe_copper() cleanup.
+
+    ``route-auto`` retries re-solve the same corridor and previously appended
+    an exact-duplicate, uuid-distinct copy of the same copper on every call
+    (717 duplicates observed on one board).  ``add_trace``/``add_via`` now skip
+    exact duplicates by default, and ``dedupe_copper()`` cleans up boards that
+    were already bloated.
+    """
+
+    def _seg_kwargs(self, **overrides):
+        base = {
+            "start": (10.0, 10.0),
+            "end": (50.0, 10.0),
+            "width": 0.25,
+            "layer": "F.Cu",
+            "net": "Sig1",
+        }
+        base.update(overrides)
+        return base
+
+    def test_add_trace_skips_exact_duplicate(self):
+        """A second identical add_trace is a no-op (skipped, not appended)."""
+        pcb = PCB.create(width=100, height=100)
+        first = pcb.add_trace(**self._seg_kwargs())
+        assert len(first) == 1
+        assert len(pcb.segments) == 1
+
+        # Identical geometry -> skipped, returns empty list, count unchanged.
+        second = pcb.add_trace(**self._seg_kwargs())
+        assert second == []
+        assert len(pcb.segments) == 1
+
+    def test_add_trace_dedup_is_order_insensitive(self):
+        """Reversed start/end is treated as the same segment (duplicate)."""
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(**self._seg_kwargs())
+        reversed_seg = pcb.add_trace(**self._seg_kwargs(start=(50.0, 10.0), end=(10.0, 10.0)))
+        assert reversed_seg == []
+        assert len(pcb.segments) == 1
+
+    def test_add_trace_different_layer_not_deduped(self):
+        """Same endpoints on a different layer are distinct (via transition)."""
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(**self._seg_kwargs(layer="F.Cu"))
+        pcb.add_trace(**self._seg_kwargs(layer="B.Cu"))
+        assert len(pcb.segments) == 2
+
+    def test_add_trace_different_net_not_deduped(self):
+        """Identical geometry on different nets is not deduped."""
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(**self._seg_kwargs(net="Sig1"))
+        pcb.add_trace(**self._seg_kwargs(net="Sig2"))
+        assert len(pcb.segments) == 2
+
+    def test_add_trace_different_width_not_deduped(self):
+        """Same endpoints but different width is a distinct segment (neck-down)."""
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(**self._seg_kwargs(width=0.25))
+        pcb.add_trace(**self._seg_kwargs(width=0.5))
+        assert len(pcb.segments) == 2
+
+    def test_add_trace_shared_endpoint_not_deduped(self):
+        """Two segments sharing one endpoint (different other end) are distinct."""
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(start=(10.0, 10.0), end=(50.0, 10.0), net="Sig1")
+        pcb.add_trace(start=(50.0, 10.0), end=(50.0, 40.0), net="Sig1")
+        assert len(pcb.segments) == 2
+
+    def test_add_trace_dedup_can_be_disabled(self):
+        """dedupe=False preserves the historical always-append behavior."""
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(**self._seg_kwargs())
+        pcb.add_trace(**self._seg_kwargs(dedupe=False))
+        assert len(pcb.segments) == 2
+
+    def test_add_via_skips_exact_duplicate(self):
+        """A second identical add_via is skipped and returns None."""
+        pcb = PCB.create(width=100, height=100)
+        via1 = pcb.add_via(x=50.0, y=30.0, net="GND")
+        assert via1 is not None
+        assert len(pcb.vias) == 1
+
+        via2 = pcb.add_via(x=50.0, y=30.0, net="GND")
+        assert via2 is None
+        assert len(pcb.vias) == 1
+
+    def test_add_via_different_net_not_deduped(self):
+        """Same position on a different net is not a duplicate."""
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_via(x=50.0, y=30.0, net="GND")
+        pcb.add_via(x=50.0, y=30.0, net="VCC")
+        assert len(pcb.vias) == 2
+
+    def test_add_via_different_position_not_deduped(self):
+        """Different positions are distinct vias."""
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_via(x=50.0, y=30.0, net="GND")
+        pcb.add_via(x=50.0, y=31.0, net="GND")
+        assert len(pcb.vias) == 2
+
+    def test_dedup_persists_across_save_reload(self, tmp_path):
+        """Dedup at emission time leaves exactly one instance after save."""
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(**self._seg_kwargs())
+        pcb.add_trace(**self._seg_kwargs())  # duplicate, skipped
+        pcb.add_via(x=50.0, y=30.0, net="GND")
+        pcb.add_via(x=50.0, y=30.0, net="GND")  # duplicate, skipped
+
+        out = tmp_path / "deduped.kicad_pcb"
+        pcb.save(out)
+        reloaded = PCB.load(out)
+        assert len(reloaded.segments) == 1
+        assert len(reloaded.vias) == 1
+
+    def test_dedupe_copper_removes_preexisting_duplicates(self, tmp_path):
+        """dedupe_copper() cleans up a board bloated with exact duplicates."""
+        pcb = PCB.create(width=100, height=100)
+        # Seed exact-duplicate copper using dedupe=False so the bloat exists.
+        for _ in range(4):
+            pcb.add_trace(**self._seg_kwargs(dedupe=False))
+        for _ in range(3):
+            pcb.add_via(x=50.0, y=30.0, net="GND", dedupe=False)
+        # A genuinely-distinct segment/via must survive.
+        pcb.add_trace(**self._seg_kwargs(end=(50.0, 40.0), dedupe=False))
+        pcb.add_via(x=60.0, y=30.0, net="GND", dedupe=False)
+
+        assert len(pcb.segments) == 5
+        assert len(pcb.vias) == 4
+
+        stats = pcb.dedupe_copper()
+        assert stats["segments"] == 3  # 4 identical -> 1 kept
+        assert stats["vias"] == 2  # 3 identical -> 1 kept
+        assert len(pcb.segments) == 2
+        assert len(pcb.vias) == 2
+
+        # Cleanup persists across save/reload (sexp nodes removed too).
+        out = tmp_path / "cleaned.kicad_pcb"
+        pcb.save(out)
+        reloaded = PCB.load(out)
+        assert len(reloaded.segments) == 2
+        assert len(reloaded.vias) == 2
+
+    def test_dedupe_copper_noop_on_clean_board(self):
+        """dedupe_copper() reports zero removed on a board with no duplicates."""
+        pcb = PCB.create(width=100, height=100)
+        pcb.add_trace(**self._seg_kwargs())
+        pcb.add_via(x=50.0, y=30.0, net="GND")
+        stats = pcb.dedupe_copper()
+        assert stats == {"segments": 0, "vias": 0}
+        assert len(pcb.segments) == 1
+        assert len(pcb.vias) == 1
+
+    def test_dedupe_preserves_net_connectivity(self):
+        """Removing a duplicate keeps an identical copy, so nets stay linked."""
+        pcb = PCB.create(width=100, height=100)
+        net_num = pcb.add_net("Sig1").number
+        for _ in range(3):
+            pcb.add_trace(**self._seg_kwargs(dedupe=False))
+
+        before = {
+            (round(s.start[0], 3), round(s.start[1], 3), round(s.end[0], 3), round(s.end[1], 3))
+            for s in pcb.segments_in_net(net_num)
+        }
+        pcb.dedupe_copper()
+        after = {
+            (round(s.start[0], 3), round(s.start[1], 3), round(s.end[0], 3), round(s.end[1], 3))
+            for s in pcb.segments_in_net(net_num)
+        }
+        # The set of distinct segment geometries is unchanged: no net edge lost.
+        assert before == after

--- a/tests/test_route_auto_persistence.py
+++ b/tests/test_route_auto_persistence.py
@@ -249,3 +249,104 @@ class TestRouteAutoPersistsToPCB:
         assert a0_status.status == "complete", (
             f"Issue #2913: A0 is {a0_status.status} after route-auto success"
         )
+
+
+class _FakeSeg:
+    """Minimal stand-in for an orchestrator RoutingResult segment."""
+
+    def __init__(self, x1, y1, x2, y2, width=0.2, layer="F.Cu"):
+        self.x1 = x1
+        self.y1 = y1
+        self.x2 = x2
+        self.y2 = y2
+        self.width = width
+        self.layer = layer  # plain KiCad string; add_trace accepts str
+
+
+class _FakeVia:
+    """Minimal stand-in for an orchestrator RoutingResult via."""
+
+    def __init__(self, x, y, diameter=0.6, drill=0.3, layers=("F.Cu", "B.Cu")):
+        self.x = x
+        self.y = y
+        self.diameter = diameter
+        self.drill = drill
+        self.layers = layers
+
+
+class _FakeResult:
+    def __init__(self, segments, vias=None):
+        self.segments = segments
+        self.vias = vias or []
+
+
+class TestPersistIsIdempotent:
+    """Issue #4175: persisting an identical route twice must not double copper.
+
+    A completion-loop caller re-invokes ``route_net_auto`` per attempt; each
+    call re-solves the same corridor and previously appended an exact-duplicate
+    copy of the same copper.  ``_persist_routing_result_to_pcb`` now relies on
+    the schema-level dedup in ``add_trace``/``add_via`` so the second persist is
+    a no-op for copper while surfacing the dedup counts.
+    """
+
+    def _fresh_pcb(self):
+        from kicad_tools.schema.pcb import PCB
+
+        return PCB.create(width=100, height=100)
+
+    def test_second_persist_does_not_double_segments(self):
+        from kicad_tools.mcp.tools.routing import _persist_routing_result_to_pcb
+
+        pcb = self._fresh_pcb()
+        result = _FakeResult(
+            segments=[
+                _FakeSeg(10.0, 10.0, 50.0, 10.0),
+                _FakeSeg(50.0, 10.0, 50.0, 40.0),
+            ],
+            vias=[_FakeVia(50.0, 10.0)],
+        )
+
+        segs1, vias1, dsegs1, dvias1 = _persist_routing_result_to_pcb(pcb, result, "NetA")
+        assert (segs1, vias1) == (2, 1)
+        assert (dsegs1, dvias1) == (0, 0)
+        net_num = pcb.add_net("NetA").number
+        assert len(list(pcb.segments_in_net(net_num))) == 2
+        assert len(list(pcb.vias_in_net(net_num))) == 1
+
+        # Second identical persist: nothing new written, all deduplicated.
+        segs2, vias2, dsegs2, dvias2 = _persist_routing_result_to_pcb(pcb, result, "NetA")
+        assert (segs2, vias2) == (0, 0)
+        assert (dsegs2, dvias2) == (2, 1)
+        # Copper counts are unchanged -> emission is idempotent.
+        assert len(list(pcb.segments_in_net(net_num))) == 2
+        assert len(list(pcb.vias_in_net(net_num))) == 1
+
+    def test_route_net_auto_twice_is_idempotent(self, tmp_path):
+        """route_net_auto on the same net twice does not increase copper."""
+        from kicad_tools.mcp.tools.routing import (
+            _persist_routing_result_to_pcb,
+            route_net_auto,  # noqa: F401  (import guards the public entrypoint)
+        )
+        from kicad_tools.schema.pcb import PCB
+
+        # Build a board, persist a route once, save.
+        pcb = self._fresh_pcb()
+        result = _FakeResult(segments=[_FakeSeg(5.0, 5.0, 45.0, 5.0)])
+        _persist_routing_result_to_pcb(pcb, result, "V_TH_HI")
+        out = tmp_path / "board.kicad_pcb"
+        pcb.save(out)
+
+        first = out.read_text().count("(segment")
+        assert first >= 1
+
+        # Reload and persist the identical route again (simulating a retry).
+        pcb2 = PCB.load(out)
+        segs, vias, dsegs, dvias = _persist_routing_result_to_pcb(pcb2, result, "V_TH_HI")
+        assert segs == 0 and dsegs == 1
+        pcb2.save(out)
+
+        second = out.read_text().count("(segment")
+        assert second == first, (
+            f"Issue #4175: route-auto retry doubled copper ({first} -> {second} segments)"
+        )


### PR DESCRIPTION
## Summary

Closes #4175.

`route-auto` re-solves the same MST edge on every external invocation (#4165) and, before this fix, appended a geometrically-identical, uuid-distinct copy of the same copper each time. Duplicates are invisible to netlist connectivity (same net) but silently bloat the file, quadruple copper where clearances are already tight, and slow every later DRC/optimize pass. A dedupe pass previously removed **717 exact-duplicate copper elements** from one softstart rev-B board.

Ships **both** curator-recommended pieces (the CLI wrapper is thin once the key logic is shared):

### 1. Emission-time dedup (root-cause fix, benefits every caller)

- `PCB.add_trace` / `PCB.add_via` (`src/kicad_tools/schema/pcb.py`) now skip appending a segment/via whose dedup key already exists on the board:
  - **segment**: `(net, layer, order-insensitive endpoints, width)`
  - **via**: `(net, rounded position, order-insensitive layers)`
  - Coordinates/widths round to ~1 micron, reusing the `EPS = 1e-3` mm coincidence precedent from `router/connectivity.py` (shipped in #4165) rather than inventing a second epsilon.
- **Skip-on-match**, `dedupe=True` by default (the safe default the reporter wanted). `add_trace` returns `[]` and `add_via` returns `None` when a duplicate is skipped; `dedupe=False` preserves the historical always-append behavior for the rare case that needs it.
- A lazily-built, incrementally-maintained per-board key set avoids O(N²) rescans during a bulk persist; it is invalidated on any bulk copper mutation (`strip_traces`, `remove_segments`, `clear`).
- `_persist_routing_result_to_pcb` (`src/kicad_tools/mcp/tools/routing.py`) now returns `(segments_written, vias_written, segments_deduplicated, vias_deduplicated)`; `route_net_auto` threads the dedup counts into `result_dict` so a fully-duplicate retry reports `0 written / N deduplicated` honestly. A retry that reproduces existing copper is no longer misclassified as the #2913 empty-save failure.

**Correctness guardrails** (tested): segments sharing only one endpoint, or differing in layer / net / width, are NOT deduped — only fully-identical geometry (with reversed endpoints treated as identical) is.

### 2. Cleanup command for already-bloated boards

- `PCB.dedupe_copper()` groups existing copper by the same keys, keeps one instance per group, and drops the rest from both the in-memory lists and the S-expression tree (so `save()` persists the cleanup). Connectivity is unchanged because every removed element is identical to a kept copy.
- `kct pcb dedupe <pcb>` (sibling to `pcb strip`; `src/kicad_tools/cli/commands/pcb.py` + `parser.py`): **in-place by default** (matching the #4166/#4195 convention), `-o` override, `--dry-run`, `text`/`json`. Reports segments/vias removed; no-op (exit 0, 0 removed) on a clean board.

## Route-auto no longer doubles copper

Confirmed: `_persist_routing_result_to_pcb` invoked twice on the same net produces `(2,1)` written on the first call and `(0,0)` written / `(2,1)` deduplicated on the second, with `segments_in_net`/`vias_in_net` counts unchanged — copper emission is idempotent (`tests/test_route_auto_persistence.py::TestPersistIsIdempotent`).

## Tests

New tests (all green), using synthetic in-repo boards (softstart is local-only):
- `tests/test_pcb.py::TestCopperDedup` — exact-dup skipped; order-insensitive; different layer/net/width/shared-endpoint NOT deduped; `dedupe=False` escape hatch; `dedupe_copper()` cleanup + no-op + connectivity preservation; survives save/reload.
- `tests/test_route_auto_persistence.py::TestPersistIsIdempotent` — persist twice does not double copper.
- `tests/test_cli_pcb.py::TestPcbDedupe` — in-place, `-o`, json counts, no-op, dry-run, connectivity preserved.

Results:
- `tests/test_pcb.py tests/test_route_auto_persistence.py tests/test_cli_pcb.py`: **332 passed** (310 pre-existing + 22 new).
- Broad sweep `-k "strip or route_auto or add_trace or add_via or persist or merge_routes or dedupe"`: **330 passed, 6 skipped**.
- ruff check + format: clean. `check_mypy_baseline.py`: **0 new errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)