### PR TITLE
fix(drc): require coupling evidence for diff-pair clearance skip + add --strict-drc

### DIFF
--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -360,6 +360,11 @@ def run_route_command(args) -> int:
         sub_argv.append("--high-performance")
     if getattr(args, "skip_drc", False):
         sub_argv.append("--skip-drc")
+    # Issue #4178: forward --strict-drc so a native DRC that did not run
+    # becomes a hard failure.  Defaults off; forward only when set so the
+    # flag-off path stays byte-identical.
+    if getattr(args, "strict_drc", False):
+        sub_argv.append("--strict-drc")
     # Issue #3154: forward the advisory drift-banner flags.  --sync-check
     # defaults on; forward --no-sync-check only when explicitly disabled.
     if getattr(args, "sync_check", True) is False:

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -3297,6 +3297,23 @@ def _add_route_parser(subparsers) -> None:
             "footprints)."
         ),
     )
+    # Issue #4178: hard-gate on native (kicad-cli) DRC actually running.
+    # Mirror of the inner route_cmd.py flag; both sites must stay in sync per
+    # ``tests/test_cli_parser_drift.py``.
+    route_parser.add_argument(
+        "--strict-drc",
+        action="store_true",
+        default=False,
+        help=(
+            "Treat 'native kicad-cli DRC did not run' (kicad-cli absent, "
+            "timed out, crashed, or produced no report) as a HARD FAILURE "
+            "(non-zero exit) instead of a soft NOTE. By default the post-route "
+            "gate degrades gracefully to an internal-engine-only PASS when "
+            "kicad-cli is unavailable, which is not authoritative. Use this in "
+            "CI / manufacturing pipelines that require the native DRC to have "
+            "actually run and passed."
+        ),
+    )
     route_parser.add_argument(
         "--auto-fix",
         action="store_true",

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -1712,6 +1712,7 @@ def run_post_route_drc(
     quiet: bool = False,
     net_class_map: dict | None = None,
     copper_oz: float = 1.0,
+    strict_drc: bool = False,
 ) -> tuple[int, int]:
     """Run DRC validation on the routed PCB.
 
@@ -1731,6 +1732,14 @@ def run_post_route_drc(
             correct value for all 8 demo boards).  Threaded into both the
             internal :class:`DRCChecker` and the emitted ``.kicad_pro`` /
             ``.kicad_dru`` sidecars so both engines judge consistently.
+        strict_drc: When ``True`` (``kct route --strict-drc``), a native
+            geometric DRC that did NOT actually run (kicad-cli absent,
+            timed out, crashed, produced no report) is treated as a HARD
+            FAILURE -- the returned ``error_count`` is bumped by 1 so the
+            route command exits non-zero, and a prominent message states
+            that the PASS is not authoritative.  Default ``False``
+            preserves the graceful-degradation soft NOTE for KiCad-less
+            environments (Issue #4178).
 
     Returns:
         Tuple of (error_count, warning_count)
@@ -1792,7 +1801,34 @@ def run_post_route_drc(
             # the verdict so PASS requires BOTH engines clean.
             error_count += geo.error_count
 
-        if not quiet:
+        # Issue #4178: under --strict-drc, "kicad-cli DRC did not actually
+        # run" is a HARD FAILURE, not a soft NOTE.  A clean internal verdict
+        # is not authoritative when the native engine never ran, so bump the
+        # error count to force a non-zero exit.  The soft-degradation default
+        # (strict_drc=False) preserves the internal-only PASS for KiCad-less
+        # environments.
+        strict_drc_failed = strict_drc and not geo.ran
+        if strict_drc_failed:
+            error_count += 1
+
+        if not quiet and strict_drc_failed:
+            print("\n--- DRC Validation ---")
+            reason_text = geo.note or "native geometric DRC did not run"
+            print(f"  STRICT DRC FAILURE: native kicad-cli DRC did not run ({reason_text}).")
+            print(
+                "    The internal-engine verdict is NOT authoritative; "
+                "--strict-drc requires kicad-cli DRC to run and pass."
+            )
+            print(
+                "    Re-run without --strict-drc to allow a soft internal-only "
+                "PASS, or install/repair kicad-cli."
+            )
+            if results.error_count > 0 or warning_count > 0:
+                # Also surface any internal findings below the strict banner.
+                print(f"  Internal errors: {results.error_count}")
+                if warning_count > 0:
+                    print(f"  Internal warnings: {warning_count}")
+        elif not quiet:
             print("\n--- DRC Validation ---")
             if error_count == 0 and warning_count == 0:
                 if geo.ran:
@@ -4473,6 +4509,9 @@ def route_with_layer_escalation(
             # net_class_map into the post-route DRC so the diff-pair
             # routing-continuity rule can re-derive its engagement state.
             net_class_map=getattr(final_result.router, "net_class_map", None),
+            # Issue #4178: forward --strict-drc so a native DRC that did
+            # not run becomes a hard failure instead of a soft NOTE.
+            strict_drc=getattr(args, "strict_drc", False),
         )
 
         # Auto-fix DRC violations if requested
@@ -5131,6 +5170,9 @@ def route_with_rule_relaxation(
             # net_class_map into the post-route DRC so the diff-pair
             # routing-continuity rule can re-derive its engagement state.
             net_class_map=getattr(final_result.router, "net_class_map", None),
+            # Issue #4178: forward --strict-drc so a native DRC that did
+            # not run becomes a hard failure instead of a soft NOTE.
+            strict_drc=getattr(args, "strict_drc", False),
         )
 
         # Auto-fix DRC violations if requested
@@ -7310,6 +7352,9 @@ def route_with_combined_escalation(
             # net_class_map into the post-route DRC so the diff-pair
             # routing-continuity rule can re-derive its engagement state.
             net_class_map=getattr(final_result.router, "net_class_map", None),
+            # Issue #4178: forward --strict-drc so a native DRC that did
+            # not run becomes a hard failure instead of a soft NOTE.
+            strict_drc=getattr(args, "strict_drc", False),
         )
 
         # Auto-fix DRC violations if requested
@@ -8402,6 +8447,23 @@ def main(argv: list[str] | None = None) -> int:
             "Skip post-routing DRC validation. By default, the router runs "
             "a DRC check after routing and warns about violations. Use this "
             "flag for performance-critical use or when running separate validation."
+        ),
+    )
+    # Issue #4178: hard-gate on native (kicad-cli) DRC actually running.
+    # Mirror of the outer parser.py flag; both sites must stay in sync per
+    # ``tests/test_cli_parser_drift.py``.
+    parser.add_argument(
+        "--strict-drc",
+        action="store_true",
+        default=False,
+        help=(
+            "Treat 'native kicad-cli DRC did not run' (kicad-cli absent, "
+            "timed out, crashed, or produced no report) as a HARD FAILURE "
+            "(non-zero exit) instead of a soft NOTE. By default the post-route "
+            "gate degrades gracefully to an internal-engine-only PASS when "
+            "kicad-cli is unavailable, which is not authoritative. Use this in "
+            "CI / manufacturing pipelines that require the native DRC to have "
+            "actually run and passed."
         ),
     )
     # Issue #3154: advisory schematic/PCB drift banner.  When a schematic is
@@ -11185,6 +11247,8 @@ def main(argv: list[str] | None = None) -> int:
             quiet=quiet,
             # Issue #2652, Epic #2556 Phase 2.5b: see other call sites.
             net_class_map=getattr(router, "net_class_map", None),
+            # Issue #4178: forward --strict-drc (see other call sites).
+            strict_drc=getattr(args, "strict_drc", False),
         )
 
         # Auto-fix DRC violations if requested

--- a/src/kicad_tools/drc/geometric.py
+++ b/src/kicad_tools/drc/geometric.py
@@ -30,6 +30,15 @@ logger = logging.getLogger(__name__)
 __all__ = ["GeometricDRCResult", "run_geometric_drc"]
 
 
+# Machine-readable skip reasons (Issue #4178).  ``--strict-drc`` uses these
+# to emit an actionable message distinguishing WHY the native DRC did not run.
+REASON_OK = "ok"  # kicad-cli ran and produced a report
+REASON_ABSENT = "kicad_cli_absent"  # kicad-cli not found on PATH
+REASON_TIMEOUT = "kicad_cli_timeout"  # kicad-cli exceeded the timeout budget
+REASON_NO_REPORT = "kicad_cli_no_report"  # kicad-cli ran but wrote no report
+REASON_CRASH = "kicad_cli_crash"  # kicad-cli raised/crashed
+
+
 @dataclass
 class GeometricDRCResult:
     """Outcome of a native ``kicad-cli pcb drc`` reconciliation run.
@@ -48,12 +57,17 @@ class GeometricDRCResult:
         note: A human-readable note describing the outcome -- always set
             for skip paths (e.g. the "kicad-cli not found" fallback) and
             ``None`` on a clean successful run.
+        reason: A machine-readable outcome code (one of ``REASON_*``)
+            distinguishing "kicad-cli not found" from "kicad-cli timed
+            out" from "kicad-cli crashed" so ``kct route --strict-drc``
+            can emit an actionable failure message (Issue #4178).
     """
 
     ran: bool = False
     error_count: int = 0
     by_type: dict[str, int] = field(default_factory=dict)
     note: str | None = None
+    reason: str = REASON_OK
 
     @property
     def has_errors(self) -> bool:
@@ -116,7 +130,7 @@ def run_geometric_drc(
     if kicad_cli is None:
         kicad_cli = find_kicad_cli()
     if kicad_cli is None:
-        return GeometricDRCResult(ran=False, note=KICAD_CLI_ABSENT_NOTE)
+        return GeometricDRCResult(ran=False, note=KICAD_CLI_ABSENT_NOTE, reason=REASON_ABSENT)
 
     report_path: Path | None = None
     try:
@@ -147,6 +161,7 @@ def run_geometric_drc(
             return GeometricDRCResult(
                 ran=False,
                 note="kicad-cli produced no DRC report (geometric DRC skipped)",
+                reason=REASON_NO_REPORT,
             )
 
         from kicad_tools.drc import DRCReport
@@ -166,15 +181,17 @@ def run_geometric_drc(
             error_count=len(cli_errors),
             by_type=by_type,
             note=None,
+            reason=REASON_OK,
         )
     except subprocess.TimeoutExpired:
         return GeometricDRCResult(
             ran=False,
             note="kicad-cli DRC timed out (geometric DRC skipped)",
+            reason=REASON_TIMEOUT,
         )
     except Exception as e:  # pragma: no cover - defensive
         logger.warning("Geometric DRC (kicad-cli) failed: %s", e)
-        return GeometricDRCResult(ran=False, note=f"geometric DRC failed: {e}")
+        return GeometricDRCResult(ran=False, note=f"geometric DRC failed: {e}", reason=REASON_CRASH)
     finally:
         if report_path is not None:
             report_path.unlink(missing_ok=True)

--- a/src/kicad_tools/validate/rules/clearance.py
+++ b/src/kicad_tools/validate/rules/clearance.py
@@ -281,24 +281,166 @@ def _pad_polygon(pad: Pad, footprint: Footprint):
 # from kicad_tools.core.geometry (consolidated in #2349).
 
 
-def _build_diff_pair_set(pcb: PCB) -> set[tuple[int, int]]:
-    """Return ``{(min_net_id, max_net_id)}`` for every detected diff pair.
+# Geometric-coupling corroboration thresholds for the diff-pair
+# clearance-skip exemption (Issue #4178).
+#
+# A pair suffix-inferred as differential (``FOO+``/``FOO-``) is only
+# exempted from the generic same-layer ClearanceRule when there is
+# CORROBORATING evidence it was actually routed *as* a coupled
+# differential pair -- i.e. its two nets run parallel and closely spaced
+# over a meaningful length.  Bare name-suffix inference is NOT sufficient:
+# current-sense Kelvin pairs (``ISENSE_A+``/``ISENSE_A-``) and indicator
+# pairs carry ``+``/``-`` names but route to separate destinations and are
+# NOT intentionally coupled, so a genuine same-layer short between them
+# must still be flagged (kicad-cli has no diff-pair heuristic and would
+# flag it).  See Issue #4178.
+#
+# ``_COUPLING_MAX_GAP_MM``: the maximum edge-to-edge gap at which two
+# opposite-net segments count as "coupled" at a sample point.  A real
+# controlled-impedance diff pair couples at ~0.1-0.3 mm; we allow a
+# generous ceiling so tighter-than-inter-clearance pairs (the whole point
+# of the exemption) still qualify while a Kelvin pair fanned out to
+# separate pads does not.
+_COUPLING_MAX_GAP_MM = 0.5
+# ``_COUPLING_MIN_PARALLEL_LEN_MM``: the two nets must run parallel (within
+# ``_COUPLING_ANGLE_TOL_DEG``) and within ``_COUPLING_MAX_GAP_MM`` for at
+# least this cumulative length before the pair is treated as coupled.  A
+# Kelvin sense pair may briefly parallel near a shared connector but does
+# not maintain coupling; a routed diff pair does.
+_COUPLING_MIN_PARALLEL_LEN_MM = 1.0
+# ``_COUPLING_ANGLE_TOL_DEG``: two segments count as parallel when their
+# direction vectors differ by at most this angle (mod 180 deg).
+_COUPLING_ANGLE_TOL_DEG = 20.0
+
+
+def _segments_are_coupled(
+    seg_a: Segment,
+    seg_b: Segment,
+    max_gap_mm: float,
+    angle_tol_deg: float,
+) -> float:
+    """Return the coupled overlap length (mm) of two opposite-net segments.
+
+    Two segments are "coupled" over the portion where they run parallel
+    (direction vectors within ``angle_tol_deg``) and their edge-to-edge
+    gap stays below ``max_gap_mm``.  The returned value approximates the
+    length of that coupled run -- 0.0 when the segments are not parallel
+    or never come within ``max_gap_mm``.
+
+    The parallel-overlap length is estimated by projecting ``seg_b``'s
+    endpoints onto ``seg_a`` and measuring the overlap of the two
+    endpoint spans along ``seg_a``'s axis; the gap gate uses the
+    minimum edge-to-edge distance between the segments (a conservative
+    proxy -- a real coupled pair keeps a roughly constant small gap).
+    """
+    ax1, ay1 = seg_a.start
+    ax2, ay2 = seg_a.end
+    bx1, by1 = seg_b.start
+    bx2, by2 = seg_b.end
+
+    adx, ady = ax2 - ax1, ay2 - ay1
+    bdx, bdy = bx2 - bx1, by2 - by1
+    a_len = math.hypot(adx, ady)
+    b_len = math.hypot(bdx, bdy)
+    if a_len < 1e-9 or b_len < 1e-9:
+        return 0.0
+
+    # Parallelism: angle between direction vectors (mod 180 deg).
+    cos_theta = abs(adx * bdx + ady * bdy) / (a_len * b_len)
+    cos_theta = max(-1.0, min(1.0, cos_theta))
+    angle = math.degrees(math.acos(cos_theta))
+    if angle > angle_tol_deg:
+        return 0.0
+
+    # Edge-to-edge gap gate (center-line distance minus both half-widths).
+    center_dist = _segment_to_segment_distance(ax1, ay1, ax2, ay2, bx1, by1, bx2, by2)
+    half_w = (seg_a.width + seg_b.width) / 2.0
+    gap = center_dist - half_w
+    if gap > max_gap_mm:
+        return 0.0
+
+    # Parallel-overlap length: project seg_b endpoints onto seg_a's axis.
+    ux, uy = adx / a_len, ady / a_len
+    t_b1 = (bx1 - ax1) * ux + (by1 - ay1) * uy
+    t_b2 = (bx2 - ax1) * ux + (by2 - ay1) * uy
+    lo = max(0.0, min(t_b1, t_b2))
+    hi = min(a_len, max(t_b1, t_b2))
+    overlap = hi - lo
+    return overlap if overlap > 0.0 else 0.0
+
+
+def _pair_is_geometrically_coupled(pcb: PCB, net_a: int, net_b: int) -> bool:
+    """Return ``True`` when two nets are routed as a coupled diff pair.
+
+    Corroborating evidence for the diff-pair clearance-skip exemption
+    (Issue #4178): the two nets must have segments that run parallel and
+    closely spaced (< ``_COUPLING_MAX_GAP_MM``) for a cumulative length of
+    at least ``_COUPLING_MIN_PARALLEL_LEN_MM`` on a shared copper layer.
+
+    Distinguishes a genuine routed differential pair (intentionally
+    coupled, must stay exempt) from a coincidentally ``+``/``-``-named
+    single-ended pair such as a Kelvin current-sense pair (routes to
+    separate destinations, must be clearance-checked).
+    """
+    coupled_len = 0.0
+    for layer in pcb.copper_layers:
+        segs_a: list[Segment] = []
+        segs_b: list[Segment] = []
+        for seg in pcb.segments_on_layer(layer.name):
+            if seg.net_number == net_a:
+                segs_a.append(seg)
+            elif seg.net_number == net_b:
+                segs_b.append(seg)
+        if not segs_a or not segs_b:
+            continue
+        for sa in segs_a:
+            for sb in segs_b:
+                coupled_len += _segments_are_coupled(
+                    sa,
+                    sb,
+                    _COUPLING_MAX_GAP_MM,
+                    _COUPLING_ANGLE_TOL_DEG,
+                )
+                if coupled_len >= _COUPLING_MIN_PARALLEL_LEN_MM:
+                    return True
+    return False
+
+
+def _build_diff_pair_set(
+    pcb: PCB,
+    declared_pairs: set[tuple[int, int]] | None = None,
+) -> set[tuple[int, int]]:
+    """Return ``{(min_net_id, max_net_id)}`` for pairs safe to exempt.
 
     Used by :class:`ClearanceRule` to skip same-pair segment-segment edges
     that are instead validated by ``DiffPairClearanceIntraRule`` against
     the per-class ``intra_pair_clearance`` threshold (see Issue #2560 /
     Epic #2556 Phase 1D).
 
-    Detection currently uses the suffix-inference matcher in
-    ``router/diffpair`` -- this matches what the autorouter sees when no
-    explicit declarations or KiCad-group sources are present, and the
-    refusal patterns (``USB_CC1``/``USB_CC2``, ``SBU1``/``SBU2``) are
-    correctly excluded.  When the upstream rule consumer (the autorouter
-    in #2559) gains the explicit-declaration plumbing, this helper can be
-    extended to honor those sources too without a public API change.
+    Issue #4178 hardening: bare name-suffix inference (``FOO+``/``FOO-``)
+    is NO LONGER sufficient on its own to exempt a pair from the generic
+    same-layer clearance check.  Current-sense Kelvin pairs
+    (``ISENSE_A+``/``ISENSE_A-``) and indicator pairs are ``+``/``-``-named
+    but are NOT differential signals -- they route to separate
+    destinations and a genuine same-layer short between them must be
+    flagged (``kicad-cli`` has no diff-pair heuristic and would flag it).
+    A suffix-inferred pair is therefore only exempted when there is
+    CORROBORATING evidence it was actually routed/declared as a coupled
+    differential pair:
+
+    * an explicit declaration in ``declared_pairs`` (net-class-map /
+      router ``DifferentialPairConfig`` engagement, resolved by the
+      caller to net-number tuples), OR
+    * geometric coupling: the two nets run parallel and closely spaced
+      over a meaningful length (see :func:`_pair_is_geometrically_coupled`).
+
+    Legitimate coupled diff pairs (real ``USB_D+``/``USB_D-`` routed close
+    together) still satisfy the geometric test and stay exempt, so no
+    false positives are introduced for real differential pairs.
     """
     from kicad_tools.router.diffpair import detect_differential_pairs
 
+    declared = declared_pairs or set()
     pairs: set[tuple[int, int]] = set()
     net_names = {net.number: net.name for net in pcb.nets.values()}
     for diff_pair in detect_differential_pairs(net_names):
@@ -307,7 +449,10 @@ def _build_diff_pair_set(pcb: PCB) -> set[tuple[int, int]]:
         if p_id == 0 or n_id == 0:
             continue
         key = (p_id, n_id) if p_id <= n_id else (n_id, p_id)
-        pairs.add(key)
+        # Require corroborating evidence beyond the name suffix before
+        # exempting the pair from the generic clearance check (#4178).
+        if key in declared or _pair_is_geometrically_coupled(pcb, p_id, n_id):
+            pairs.add(key)
     return pairs
 
 

--- a/tests/test_route_post_drc_geometric.py
+++ b/tests/test_route_post_drc_geometric.py
@@ -19,6 +19,9 @@ shells out to kicad-cli is gated behind a skipif.
 
 from __future__ import annotations
 
+import argparse
+import contextlib
+
 import pytest
 
 from kicad_tools.cli import route_cmd
@@ -163,6 +166,169 @@ def test_combined_error_count_sums_both_engines(monkeypatch, tmp_path):
     )
 
     assert errors == 5  # 2 internal + 3 native
+
+
+# ---------------------------------------------------------------------------
+# Issue #4178: --strict-drc turns "kicad-cli DRC did not run" into a HARD
+# failure (non-zero exit) instead of a soft NOTE.  Without the flag, today's
+# graceful-degradation soft PASS is preserved for KiCad-less environments.
+# ---------------------------------------------------------------------------
+
+
+class TestStrictDrc:
+    """run_post_route_drc(strict_drc=...) behaviour (Issue #4178)."""
+
+    def test_strict_drc_hard_fails_when_kicad_cli_absent(self, monkeypatch, tmp_path, capsys):
+        """--strict-drc + kicad-cli absent (ran=False) -> non-zero error count."""
+        _patch_internal(monkeypatch, _FakeResults())  # internal engine clean
+        _patch_geometric(
+            monkeypatch,
+            GeometricDRCResult(ran=False, note="kicad-cli not found; geometric DRC skipped"),
+        )
+
+        errors, _ = route_cmd.run_post_route_drc(
+            output_path=tmp_path / "b.kicad_pcb",
+            manufacturer="jlcpcb",
+            layers=2,
+            strict_drc=True,
+        )
+
+        # A clean internal verdict must NOT bless the route: strict mode
+        # bumps the error count so the caller exits non-zero.
+        assert errors >= 1
+        out = capsys.readouterr().out
+        assert "STRICT DRC FAILURE" in out
+        assert "authoritative" in out
+        # The specific reason (kicad-cli absent) is surfaced.
+        assert "kicad-cli not found" in out
+        # The soft-PASS banner must NOT appear under strict failure.
+        assert "DRC PASSED" not in out
+
+    def test_strict_drc_hard_fails_on_timeout(self, monkeypatch, tmp_path, capsys):
+        """--strict-drc + kicad-cli timeout (ran=False) -> non-zero error count."""
+        _patch_internal(monkeypatch, _FakeResults())
+        _patch_geometric(
+            monkeypatch,
+            GeometricDRCResult(ran=False, note="kicad-cli DRC timed out (geometric DRC skipped)"),
+        )
+
+        errors, _ = route_cmd.run_post_route_drc(
+            output_path=tmp_path / "b.kicad_pcb",
+            manufacturer="jlcpcb",
+            layers=4,
+            strict_drc=True,
+        )
+
+        assert errors >= 1
+        out = capsys.readouterr().out
+        assert "STRICT DRC FAILURE" in out
+        assert "timed out" in out
+
+    def test_without_strict_drc_absent_stays_soft_pass(self, monkeypatch, tmp_path, capsys):
+        """No --strict-drc + kicad-cli absent -> soft NOTE, exit unchanged (0)."""
+        _patch_internal(monkeypatch, _FakeResults())
+        _patch_geometric(
+            monkeypatch,
+            GeometricDRCResult(ran=False, note="kicad-cli not found; geometric DRC skipped"),
+        )
+
+        errors, _ = route_cmd.run_post_route_drc(
+            output_path=tmp_path / "b.kicad_pcb",
+            manufacturer="jlcpcb",
+            layers=2,
+            # strict_drc defaults to False -> graceful degradation preserved.
+        )
+
+        assert errors == 0
+        out = capsys.readouterr().out
+        assert "STRICT DRC FAILURE" not in out
+        assert "DRC PASSED" in out
+        assert "internal-engine-only PASS" in out
+
+    def test_strict_drc_clean_native_run_still_passes(self, monkeypatch, tmp_path, capsys):
+        """--strict-drc + kicad-cli ran clean (ran=True) -> unchanged PASS."""
+        _patch_internal(monkeypatch, _FakeResults())
+        _patch_geometric(monkeypatch, GeometricDRCResult(ran=True, error_count=0))
+
+        errors, _ = route_cmd.run_post_route_drc(
+            output_path=tmp_path / "b.kicad_pcb",
+            manufacturer="jlcpcb",
+            layers=2,
+            strict_drc=True,
+        )
+
+        # Native DRC actually ran and was clean -> no strict failure.
+        assert errors == 0
+        out = capsys.readouterr().out
+        assert "STRICT DRC FAILURE" not in out
+        assert "DRC PASSED" in out
+
+
+def test_strict_drc_reaches_inner_through_outer_kct_route(monkeypatch):
+    """`kct route --strict-drc` forwards the flag to route_cmd.main (Issue #4178).
+
+    Regression guard for the #4187 inner/outer lesson: a flag registered
+    only on the inner parser would be dropped by the outer `kct route`
+    shim.  This parses via the OUTER parser (parser.create_parser), runs
+    the forwarding shim (run_route_command), and asserts the inner
+    route_cmd.main receives --strict-drc in its argv AND parses it onto
+    the namespace as strict_drc=True.
+    """
+    from kicad_tools.cli import route_cmd
+    from kicad_tools.cli.commands.routing import run_route_command
+    from kicad_tools.cli.parser import create_parser
+
+    parser = create_parser()
+    args = parser.parse_args(["route", "board.kicad_pcb", "--strict-drc"])
+
+    captured: dict[str, object] = {}
+    real_main = route_cmd.main
+    real_parse = argparse.ArgumentParser.parse_args
+
+    def _fake_route_main(sub_argv):
+        captured["sub_argv"] = sub_argv
+
+        # The inner parser must ALSO accept --strict-drc onto the namespace.
+        def _grab(self, *a, **k):
+            ns = real_parse(self, *a, **k)
+            if getattr(self, "prog", "") == "kicad-tools route":
+                captured["strict_drc"] = getattr(ns, "strict_drc", None)
+                raise SystemExit(0)
+            return ns
+
+        with monkeypatch.context() as m:
+            m.setattr(argparse.ArgumentParser, "parse_args", _grab)
+            with contextlib.suppress(SystemExit):
+                real_main(sub_argv)
+        return 0
+
+    monkeypatch.setattr(route_cmd, "main", _fake_route_main)
+
+    run_route_command(args)
+
+    assert "sub_argv" in captured, "outer shim never invoked route_cmd.main"
+    assert "--strict-drc" in captured["sub_argv"], (
+        "outer `kct route` shim dropped --strict-drc (regresses the #4187 "
+        "inner/outer forwarding lesson)"
+    )
+    assert captured.get("strict_drc") is True, (
+        "inner route_cmd.py parser must parse --strict-drc onto the namespace as strict_drc=True"
+    )
+
+
+def test_geometric_result_reason_distinguishes_outcomes():
+    """GeometricDRCResult.reason distinguishes absent / timeout / crash (Issue #4178)."""
+    from kicad_tools.drc.geometric import (
+        REASON_ABSENT,
+        REASON_CRASH,
+        REASON_OK,
+        REASON_TIMEOUT,
+    )
+
+    # Default (constructed clean) is OK.
+    assert GeometricDRCResult(ran=True).reason == REASON_OK
+    # The named reasons are distinct machine-readable codes.
+    assert len({REASON_OK, REASON_ABSENT, REASON_TIMEOUT, REASON_CRASH}) == 4
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_validate_diffpair_clearance_intra.py
+++ b/tests/test_validate_diffpair_clearance_intra.py
@@ -451,3 +451,180 @@ class TestDiffPairClearanceIntraRule:
         results = rule.check(pcb, _design_rules())
         assert len(results.violations) == 0
         assert results.rules_checked == 1
+
+
+# ---------------------------------------------------------------------------
+# Issue #4178: diff-pair clearance-skip false-exemption regression.
+#
+# ClearanceRule._build_diff_pair_set() previously exempted ANY suffix-inferred
+# +/- pair from same-layer segment-segment clearance checking.  That silently
+# skipped genuine short detection between current-sense Kelvin pairs
+# (ISENSE_A+/ISENSE_A-) -- +/- named but NOT differential signals -- while
+# kicad-cli, which has no such heuristic, would flag them.  The fix requires
+# CORROBORATING evidence (geometric coupling or an explicit declaration)
+# before exempting a pair, so a Kelvin pair with a real same-layer short is
+# now flagged while a genuinely coupled diff pair stays exempt.
+# ---------------------------------------------------------------------------
+
+
+def _crossing_segments(
+    *,
+    net_a: int,
+    name_a: str,
+    net_b: int,
+    name_b: str,
+    width_mm: float = 0.2,
+) -> list[_StubSegment]:
+    """Two DIFFERENT-net segments that physically cross (a genuine short).
+
+    The two segments intersect near (1, 1) at ~90 degrees, so they are NOT
+    parallel and NOT coupled -- the pattern of a real ``tracks_crossing``
+    short between two nets that route to separate destinations (a Kelvin
+    sense pair), the opposite of an intentionally-coupled diff pair.
+    """
+    return [
+        _StubSegment(
+            start=(0.0, 0.0),
+            end=(2.0, 2.0),
+            width=width_mm,
+            net_number=net_a,
+            net_name=name_a,
+            uuid=f"seg-{name_a}",
+        ),
+        _StubSegment(
+            start=(0.0, 2.0),
+            end=(2.0, 0.0),
+            width=width_mm,
+            net_number=net_b,
+            net_name=name_b,
+            uuid=f"seg-{name_b}",
+        ),
+    ]
+
+
+class TestClearanceRuleDiffPairFalseExemption:
+    """ClearanceRule must NOT exempt suffix-only +/- pairs (Issue #4178)."""
+
+    def test_kelvin_sense_pair_short_is_flagged(self):
+        """A crossing ISENSE_A+/ISENSE_A- short is a real short, not exempt.
+
+        The two segments cross (clearance 0) and are NOT geometrically
+        coupled, so the suffix-only diff-pair inference must not exempt
+        them from ClearanceRule -- the short is flagged.
+        """
+        pcb = _StubPCB(
+            _nets={
+                0: _StubNet(0, ""),
+                19: _StubNet(19, "/ISENSE_A+"),
+                20: _StubNet(20, "/ISENSE_A-"),
+            },
+            _segments=_crossing_segments(
+                net_a=19, name_a="/ISENSE_A+", net_b=20, name_b="/ISENSE_A-"
+            ),
+        )
+        clearance_rule = ClearanceRule()
+        results = clearance_rule.check(pcb, _design_rules(min_clearance_mm=0.127))
+        assert len(results.violations) >= 1, (
+            "A crossing Kelvin-sense (ISENSE_A+/ISENSE_A-) short must be "
+            "flagged -- suffix-only +/- naming is not sufficient to exempt "
+            "it from the generic clearance rule (Issue #4178)."
+        )
+        v = results.violations[0]
+        assert v.rule_id.startswith("clearance")
+        assert "/ISENSE_A+" in v.nets
+        assert "/ISENSE_A-" in v.nets
+
+    def test_kelvin_sense_pair_close_parallel_short_is_flagged(self):
+        """A short parallel Kelvin run below the coupling-length floor fires.
+
+        Two ISENSE segments that briefly parallel at a tight gap (0.05 mm)
+        but only for 0.5 mm -- below the 1.0 mm coupling-length floor -- are
+        NOT a coupled diff pair, so the sub-clearance gap is flagged.
+        """
+        pcb = _StubPCB(
+            _nets={
+                0: _StubNet(0, ""),
+                21: _StubNet(21, "/ISENSE_B+"),
+                22: _StubNet(22, "/ISENSE_B-"),
+            },
+            _segments=[
+                _StubSegment(
+                    start=(0.0, 0.0),
+                    end=(0.5, 0.0),  # only 0.5 mm long -> below 1.0 mm floor
+                    width=0.2,
+                    net_number=21,
+                    net_name="/ISENSE_B+",
+                    uuid="seg-isb-p",
+                ),
+                _StubSegment(
+                    start=(0.0, 0.25),  # gap = 0.05 mm (< 0.127 inter-clearance)
+                    end=(0.5, 0.25),
+                    width=0.2,
+                    net_number=22,
+                    net_name="/ISENSE_B-",
+                    uuid="seg-isb-n",
+                ),
+            ],
+        )
+        clearance_rule = ClearanceRule()
+        results = clearance_rule.check(pcb, _design_rules(min_clearance_mm=0.127))
+        assert len(results.violations) >= 1, (
+            "A short (below coupling-length floor) parallel Kelvin run at a "
+            "sub-clearance gap must be flagged -- it is not a coupled diff "
+            "pair (Issue #4178)."
+        )
+
+    def test_real_coupled_diffpair_stays_exempt(self):
+        """A genuinely coupled USB_D+/USB_D- run remains exempt (no regression).
+
+        The two segments run parallel and closely spaced for 2 mm (well
+        above the coupling-length floor), so ClearanceRule still skips the
+        same-pair edge and delegates to DiffPairClearanceIntraRule -- no
+        false positive introduced for real differential pairs.
+        """
+        pcb = _StubPCB(
+            _nets={
+                0: _StubNet(0, ""),
+                3: _StubNet(3, "USB_D+"),
+                4: _StubNet(4, "USB_D-"),
+            },
+            _segments=_parallel_segments(
+                net_a=3, name_a="USB_D+", net_b=4, name_b="USB_D-", gap_mm=0.090
+            ),
+        )
+        clearance_rule = ClearanceRule()
+        results = clearance_rule.check(pcb, _design_rules(min_clearance_mm=0.127))
+        assert len(results.violations) == 0, (
+            "A genuinely coupled diff pair (USB_D+/USB_D- parallel, tightly "
+            "coupled) must stay exempt from the generic clearance rule "
+            "(delegated to DiffPairClearanceIntraRule) -- Issue #4178 must "
+            "not introduce a false positive for real diff pairs."
+        )
+
+    def test_declared_pair_stays_exempt_even_without_coupling(self):
+        """An explicitly-declared pair is exempt even if not coupled geometry.
+
+        When a pair is corroborated by an explicit declaration (net-class /
+        router diffpair engagement, passed as ``declared_pairs``), it is
+        exempt regardless of geometric coupling -- the declaration is
+        itself the corroborating evidence.
+        """
+        from kicad_tools.validate.rules.clearance import _build_diff_pair_set
+
+        pcb = _StubPCB(
+            _nets={
+                0: _StubNet(0, ""),
+                7: _StubNet(7, "CLK_POS"),
+                8: _StubNet(8, "CLK_NEG"),
+            },
+            # Crossing (uncoupled) geometry -- would NOT be corroborated by
+            # coupling alone.
+            _segments=_crossing_segments(net_a=7, name_a="CLK_POS", net_b=8, name_b="CLK_NEG"),
+        )
+        # Without a declaration and without coupling: NOT exempt.
+        auto = _build_diff_pair_set(pcb)
+        assert (7, 8) not in auto
+
+        # With an explicit declaration: exempt.
+        declared = _build_diff_pair_set(pcb, declared_pairs={(7, 8)})
+        assert (7, 8) in declared


### PR DESCRIPTION
## Summary

Two bounded hardening fixes so the `kct route` post-route DRC gate's internal verdict cannot silently diverge from real kicad-cli DRC. The reconciliation machinery (`run_post_route_drc` + `run_geometric_drc`, PR #3815) already exists; this PR closes two specific soft spots identified by the curator. The deeper "router genuinely emits different-net crossings" concern is **deferred to #4202** (architect).

## Changes

**Fix 1 — diff-pair-suffix false-negative in clearance checking** (`validate/rules/clearance.py`)
- `ClearanceRule._build_diff_pair_set()` previously exempted **any** `+`/`-` name-suffixed pair from same-layer segment-segment clearance. That silently skipped genuine short detection between current-sense Kelvin pairs (`/ISENSE_A+` / `/ISENSE_A-`) — `+`/`-` named but NOT differential signals — while kicad-cli (no such heuristic) would flag them.
- Now a suffix-inferred pair is exempted **only** with corroborating evidence: an explicit declaration (`declared_pairs`) **or** geometric coupling (the two nets run parallel and closely spaced over a meaningful cumulative length). New helpers `_segments_are_coupled` / `_pair_is_geometrically_coupled`.
- Genuinely coupled diff pairs (real `USB_D+`/`USB_D-` routed close together) still satisfy the geometric test and stay exempt — no false positive for real diff pairs (verified: board-07's committed diff pairs are unchanged).

**Fix 2 — `--strict-drc` for "kicad-cli didn't run"** (`drc/geometric.py`, `cli/route_cmd.py`, `cli/parser.py`, `cli/commands/routing.py`)
- `run_geometric_drc()` degrades soft (NOTE-only) when kicad-cli is absent / times out / crashes. `--strict-drc` makes "native DRC did not actually run" a HARD FAILURE (non-zero exit) instead of a soft NOTE. Default OFF preserves graceful degradation for KiCad-less environments.
- Registered on BOTH the outer (`parser.py`) and inner (`route_cmd.py`) parsers and forwarded through the `commands/routing.py` shim, per the #4187 inner/outer lesson (guarded by `test_cli_parser_drift.py`).
- `GeometricDRCResult` gains a machine-readable `reason` field (`kicad_cli_absent` / `kicad_cli_timeout` / `kicad_cli_no_report` / `kicad_cli_crash`) so the strict failure message is actionable.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Suffix-only `+`/`-` pair no longer exempted without corroboration | ✅ | `_build_diff_pair_set` requires coupling or declaration |
| Kelvin sense pair (`ISENSE_A+`/`ISENSE_A-`) with a real same-layer short is flagged | ✅ | `test_kelvin_sense_pair_short_is_flagged`, `..._close_parallel_short_is_flagged` |
| Real coupled diff pair stays exempt (no false positive) | ✅ | `test_real_coupled_diffpair_stays_exempt`; existing `test_clearance_rule_skips_same_pair` still green |
| Explicit declaration exempts even without coupling | ✅ | `test_declared_pair_stays_exempt_even_without_coupling` |
| `--strict-drc` hard-fails when kicad-cli didn't run | ✅ | `test_strict_drc_hard_fails_when_kicad_cli_absent`, `..._on_timeout` |
| Without `--strict-drc`, soft NOTE preserved | ✅ | `test_without_strict_drc_absent_stays_soft_pass` |
| Clean native run under `--strict-drc` still passes | ✅ | `test_strict_drc_clean_native_run_still_passes` |
| `--strict-drc` works through the outer `kct route` entry | ✅ | `test_strict_drc_reaches_inner_through_outer_kct_route` |
| `reason` distinguishes absent/timeout/crash | ✅ | `test_geometric_result_reason_distinguishes_outcomes` |

## Test Plan

```
uv run pytest tests/test_validate_diffpair_clearance_intra.py \
  tests/test_route_post_drc_geometric.py tests/test_cli_parser_drift.py -q
# 48 passed
```
Also green: `test_validate.py`, `test_route_cmd_success_output.py`, `test_audit.py`, `test_drc_constraints_export.py`, and the full `-k "diffpair or clearance"` sweep (1938 passed). Ruff clean + formatted; `check_mypy_baseline.py` reports 0 new type errors.

### Pre-existing failure (out of scope, NOT caused by this PR)

`tests/test_kct_check_parity.py::...::test_board_07_gate_counts_diffpair_and_matchgroup` expects 9 blocking but the committed board-07 artifact now yields 8. This fails **identically on the branch base `bb71056c` with my changes stashed** — it is a pre-existing artifact drift from PR #4204 (dedupe), unrelated to the diff-pair/strict-drc work. My changes leave the board-07 count unchanged (8 with and without them).

Closes #4178