### PR TITLE
fix(router): widen finalize demote to full DRC SHORT threshold (#4202 Unit 1)

### DIFF
--- a/src/kicad_tools/router/algorithms/two_phase.py
+++ b/src/kicad_tools/router/algorithms/two_phase.py
@@ -1226,20 +1226,29 @@ class TwoPhaseRouter:
             net_routes.clear()
             net_routes.update(best_net_routes)
 
-        # Issue #3433 (safety net): never commit physically-overlapping
-        # copper.  Even with seg-seg violators in the comparator and the
-        # mid-iteration rip-up feed, the loop can exit (stagnation,
-        # early-stop, timeout) with every observed snapshot containing
-        # cross-net same-layer FULL overlaps.  Overlapping copper is an
-        # unmanufacturable hard-gate DRC failure; an unrouted net is an
-        # advisory connectivity finding -- enforce the trade in the
-        # right direction by demoting the greedy-cover victims to
-        # unrouted rather than committing them.
+        # Issue #3433 / #4202 (safety net): never commit copper that
+        # would be a cross-net DRC short.  Even with seg-seg violators in
+        # the comparator and the mid-iteration rip-up feed, the loop can
+        # exit (stagnation, early-stop, timeout) with every observed
+        # snapshot containing cross-net same-layer FULL overlaps OR
+        # sub-clearance grazing pairs (positive edge gap but
+        # ``< trace_clearance`` -- a real ``kicad-cli SHORT`` that
+        # polygon-intersection misses).  Both are hard-gate DRC failures
+        # the post-route gate rejects; an unrouted net is an advisory
+        # connectivity finding -- enforce the trade in the right
+        # direction by demoting the greedy-cover victims to unrouted
+        # rather than committing them.  This is the FINALIZE position
+        # (loop has exited, negotiation's iterative repair is done), so
+        # ``copper_overlap_only=False`` widens the threshold to the FULL
+        # DRC SHORT class ``(w_a+w_b)/2 + trace_clearance`` -- mirroring
+        # the ``finalize=True`` path in ``core._demote_seg_seg_overlap_nets``.
+        # The wide threshold MUST stay out of the negotiation loop, where
+        # transient sub-clearance is expected and repaired by iteration.
         _overlap_pairs = neg_router.find_segment_segment_violation_pairs(
             net_routes,
             trace_clearance=self.rules.trace_clearance,
             extra_routes=self._collect_extra_routes_for_revalidation(net_routes),
-            copper_overlap_only=True,
+            copper_overlap_only=False,
         )
         if _overlap_pairs:
             _demotable = {n for n, r in net_routes.items() if r}
@@ -1254,8 +1263,8 @@ class TwoPhaseRouter:
                     net_routes[_net] = []
                 _victim_names = [self.net_names.get(n, f"Net_{n}") for n in _victims]
                 flush_print(
-                    f"  ⚠ Demoted {len(_victims)} net(s) with physically "
-                    f"overlapping copper to unrouted: {', '.join(_victim_names)}"
+                    f"  ⚠ Demoted {len(_victims)} net(s) with cross-net "
+                    f"shorting copper to unrouted: {', '.join(_victim_names)}"
                 )
 
         # Issue #2597: Surface the iteration-loop exit reason to the caller

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -10557,18 +10557,24 @@ class Autorouter:
                     f"({total_elapsed:.1f}s)"
                 )
 
-        # Issue #3433 (safety net): never commit physically-overlapping
-        # copper.  Even with seg-seg violators in the lex tuple, the
-        # loop can exit (stall patience, stagnation, timeout) with a
-        # best snapshot that still contains cross-net same-layer
-        # full overlaps (board-04 SWCLK/SWO, actual -0.200 mm).  Those
-        # are unmanufacturable hard-gate failures, whereas an unrouted
-        # net is an advisory connectivity finding -- the trade is
-        # strictly better.  Runs AFTER the correction pass (which gets
-        # first chance to actually fix the geometry; since issue #3413
-        # the correction pass also runs -- single-pass bounded -- on the
-        # ``timed_out`` exit).
-        demoted = self._demote_seg_seg_overlap_nets(net_routes, neg_router)
+        # Issue #3433 / #4202 (safety net): never commit copper that
+        # would be a cross-net DRC short.  Even with seg-seg violators in
+        # the lex tuple, the loop can exit (stall patience, stagnation,
+        # timeout) with a best snapshot that still contains cross-net
+        # same-layer full overlaps (board-04 SWCLK/SWO, actual -0.200 mm)
+        # OR sub-clearance grazing pairs (positive edge gap but
+        # ``< trace_clearance`` -- a real ``kicad-cli SHORT`` that
+        # polygon-intersection misses; board-05 grid-snap marginals sat
+        # exactly on this 0.1000-vs-0.1016 mm boundary).  Both are
+        # hard-gate DRC failures the post-route gate rejects, whereas an
+        # unrouted net is an advisory connectivity finding -- the trade
+        # is strictly better.  ``finalize=True`` widens the threshold to
+        # the FULL DRC SHORT class (``copper_overlap_only=False``).  Runs
+        # AFTER the correction pass (which gets first chance to actually
+        # fix repairable near-misses; since issue #3413 the correction
+        # pass also runs -- single-pass bounded -- on the ``timed_out``
+        # exit), so what remains at finalize is unrepaired-and-shipping.
+        demoted = self._demote_seg_seg_overlap_nets(net_routes, neg_router, finalize=True)
         if demoted:
             successful_nets = sum(1 for routes in net_routes.values() if routes)
             flush_print(
@@ -11198,6 +11204,7 @@ class Autorouter:
         self,
         net_routes: dict[int, list[Route]],
         neg_router: NegotiatedRouter,
+        finalize: bool = False,
     ) -> list[int]:
         """Strip nets whose committed copper physically overlaps a foreign net.
 
@@ -11212,16 +11219,39 @@ class Autorouter:
         the greedy cover over copper-overlap pairs is demoted to
         unrouted (grid unmarked, routes removed) rather than committed.
 
-        Only fires for PHYSICAL overlap (``copper_overlap_only=True``),
-        never for positive-clearance near-misses -- those remain the
-        province of ``_post_route_clearance_correction`` and the DRC
-        nudge pass, which can actually repair them.
+        Two thresholds, keyed on ``finalize``:
+
+        * ``finalize=False`` (default -- the in-loop / pre-repair
+          position): ``copper_overlap_only=True`` -- only the
+          unmanufacturable PHYSICAL overlaps (negative edge-to-edge)
+          fire, never positive-clearance near-misses, which remain the
+          province of ``_post_route_clearance_correction`` and the DRC
+          nudge pass, which can actually repair them.
+        * ``finalize=True`` (Issue #4202, the FINALIZE position -- runs
+          AFTER ``_post_route_clearance_correction`` has had its repair
+          opportunity): ``copper_overlap_only=False`` -- the FULL DRC
+          SHORT threshold ``(w_a+w_b)/2 + trace_clearance``.  The
+          overlap-only threshold ``(w_a+w_b)/2`` is polygon-intersection
+          only, but ``kicad-cli`` fires ``clearance_segment_segment:
+          SHORT`` at ``(w_a+w_b)/2 + trace_clearance``.  A different-net
+          pair whose edge-to-edge gap is POSITIVE but ``< trace_clearance``
+          is a REAL DRC short that falls below the overlap-only
+          threshold and ships.  Running the WIDE threshold at finalize --
+          after the repair passes have already fixed genuinely-nudgeable
+          near-misses -- means any still-violating pair is
+          unrepaired-and-shipping copper: demote it to honestly-unrouted
+          rather than emit a short the DRC gate will later reject.  MUST
+          NOT run inside the negotiation loop, where transient
+          sub-clearance is expected and is repaired by iteration.
 
         Args:
             net_routes: Mapping of net ID to committed routes (mutated:
                 demoted nets are reset to ``[]``).
             neg_router: Negotiated router (pair detection + grid unmark
                 conventions live there).
+            finalize: When True, use the full DRC SHORT threshold
+                (``copper_overlap_only=False``); see above.  Only pass
+                this AFTER the repair passes have run.
 
         Returns:
             Sorted list of demoted net ids (empty when the result is
@@ -11232,7 +11262,7 @@ class Autorouter:
             net_routes,
             trace_clearance=self.rules.trace_clearance,
             extra_routes=extra,
-            copper_overlap_only=True,
+            copper_overlap_only=not finalize,
         )
         if not overlap_pairs:
             return []

--- a/tests/router/test_seg_seg_quality_tuple.py
+++ b/tests/router/test_seg_seg_quality_tuple.py
@@ -510,6 +510,144 @@ class TestDemoteSegSegOverlapNets:
         assert net_routes[1] == [r1] and net_routes[2] == [r2]
 
 
+class TestDemoteSegSegFinalizeThreshold:
+    """Issue #4202: at FINALIZE (``finalize=True``) the demote widens to
+    the full ``kicad-cli`` SHORT threshold ``(w_a+w_b)/2 + trace_clearance``.
+
+    The negotiated/two-phase loops grid-snap different-net traces one
+    quantum inside ``trace_clearance`` on ``--allow-unsafe-grid`` boards:
+    a POSITIVE edge-to-edge gap ``0 < g < trace_clearance`` is a real
+    ``clearance_segment_segment: SHORT`` that the polygon-intersection
+    (``copper_overlap_only=True``) threshold misses -- so it shipped a
+    short today.  The finalize demote strips it to honestly-unrouted
+    instead.  The default (in-loop) mode is unchanged: it must NOT
+    demote such a repairable near-miss, since the correction/nudge
+    passes get first chance.
+    """
+
+    def _make_autorouter(self) -> Autorouter:
+        ar = Autorouter(
+            width=20.0,
+            height=20.0,
+            origin_x=0.0,
+            origin_y=0.0,
+            rules=_make_rules(),
+            layer_stack=LayerStack.two_layer(),
+        )
+        return ar
+
+    def _sub_clearance_pair(self):
+        """A different-net pair with edge gap 0 < g < trace_clearance.
+
+        trace_width=0.2 -> half-widths sum 0.2; trace_clearance=0.15.
+        Centerline dy = 0.306 -> edge gap = 0.306 - 0.2 = 0.106 mm,
+        which is POSITIVE (no polygon overlap) but below the 0.15 mm
+        clearance: a real kicad-cli SHORT that copper_overlap_only misses.
+        """
+        r1 = _route(1, [_seg(2.0, 5.0, 12.0, 5.0, 1)], "NETA")
+        r2 = _route(2, [_seg(2.0, 5.306, 12.0, 5.306, 2)], "NETB")
+        return r1, r2
+
+    def test_sub_clearance_short_demoted_at_finalize(self):
+        """The core gap: a committed sub-clearance different-net pair is
+        REJECTED (demoted) at finalize, where it shipped before."""
+        ar = self._make_autorouter()
+        neg = _make_neg_router(ar.grid, ar.rules)
+        r1, r2 = self._sub_clearance_pair()
+        for r in (r1, r2):
+            ar.grid.mark_route(r)
+            ar.grid.mark_route_usage(r)
+            ar.routes.append(r)
+        net_routes = {1: [r1], 2: [r2]}
+
+        # In-loop mode (default): NOT demoted -- correction gets first shot.
+        assert ar._demote_seg_seg_overlap_nets(net_routes, neg) == []
+        assert net_routes[1] == [r1] and net_routes[2] == [r2]
+
+        # Finalize mode: the SHORT is stripped to honestly-unrouted.
+        demoted = ar._demote_seg_seg_overlap_nets(net_routes, neg, finalize=True)
+        assert demoted == [1]
+        assert net_routes[1] == []  # honestly-unrouted, not silently dropped
+        assert net_routes[2] == [r2]  # partner survives
+        assert r1 not in ar.routes
+        assert r2 in ar.routes
+        # Post-demotion: no full-threshold violation remains.
+        assert (
+            neg.find_segment_segment_violation_pairs(
+                net_routes,
+                trace_clearance=ar.rules.trace_clearance,
+                copper_overlap_only=False,
+            )
+            == []
+        )
+
+    def test_clean_gap_not_demoted_at_finalize(self):
+        """Edge gap >= trace_clearance (genuinely clean) is NOT demoted:
+        no over-demotion of clean routes at finalize."""
+        ar = self._make_autorouter()
+        neg = _make_neg_router(ar.grid, ar.rules)
+        # Centerline dy = 0.35 -> edge gap = 0.15 == trace_clearance: clean.
+        r1 = _route(1, [_seg(2.0, 5.0, 12.0, 5.0, 1)])
+        r2 = _route(2, [_seg(2.0, 5.35, 12.0, 5.35, 2)])
+        for r in (r1, r2):
+            ar.grid.mark_route(r)
+            ar.grid.mark_route_usage(r)
+            ar.routes.append(r)
+        net_routes = {1: [r1], 2: [r2]}
+
+        assert ar._demote_seg_seg_overlap_nets(net_routes, neg, finalize=True) == []
+        assert net_routes[1] == [r1] and net_routes[2] == [r2]
+
+    def test_hard_overlap_still_demoted_at_finalize(self):
+        """The finalize threshold is a superset of copper-overlap-only,
+        so a full physical overlap (g < 0, board-04 mode) is still
+        demoted -- Unit 1 must not regress the existing #3433 catch."""
+        ar = self._make_autorouter()
+        neg = _make_neg_router(ar.grid, ar.rules)
+        r1 = _route(1, [_seg(2.0, 5.0, 12.0, 5.0, 1)], "SWCLK")
+        r2 = _route(2, [_seg(4.0, 5.0, 10.0, 5.0, 2)], "SWO")
+        r3 = _route(3, [_seg(2.0, 10.0, 12.0, 10.0, 3)], "CLEAN")
+        for r in (r1, r2, r3):
+            ar.grid.mark_route(r)
+            ar.grid.mark_route_usage(r)
+            ar.routes.append(r)
+        net_routes = {1: [r1], 2: [r2], 3: [r3]}
+
+        demoted = ar._demote_seg_seg_overlap_nets(net_routes, neg, finalize=True)
+        assert demoted == [1]
+        assert net_routes[1] == []
+        assert net_routes[2] == [r2] and net_routes[3] == [r3]
+
+    def test_coupled_diffpair_legs_not_over_demoted(self):
+        """A tightly-coupled diff pair (both legs PREROUTED -> both enter
+        the foreign universe as non-rippable ``extra_routes``) is NOT
+        flagged by the finalize threshold, even though its intra spacing
+        is below ``trace_clearance``.  The ``extra``-vs-``extra`` skip in
+        ``find_segment_segment_violation_pairs`` is what prevents Unit 1
+        from over-demoting legitimately-coupled pairs -- both legs live
+        in ``self.routes`` (prerouted), never in the demotable
+        ``net_routes``.
+        """
+        rules = _make_rules()
+        neg = _make_neg_router(None, rules)
+        # Coupled: centerline dy 0.25 -> edge gap 0.05 mm < 0.15 clearance.
+        # Both legs are extra (prerouted diff-pair infra), so no pair fires.
+        net_routes: dict[int, list[Route]] = {}
+        extra = [
+            _route(1, [_seg(0.0, 5.0, 10.0, 5.0, 1)], "USB_D+"),
+            _route(2, [_seg(0.0, 5.25, 10.0, 5.25, 2)], "USB_D-"),
+        ]
+        assert (
+            neg.find_segment_segment_violation_pairs(
+                net_routes,
+                trace_clearance=rules.trace_clearance,
+                extra_routes=extra,
+                copper_overlap_only=False,
+            )
+            == []
+        )
+
+
 # ---------------------------------------------------------------------------
 # Issue #3413: correction pass must run BEFORE demotion on the timeout exit
 # ---------------------------------------------------------------------------
@@ -556,8 +694,8 @@ class TestCorrectionBeforeDemotionOnTimeout:
             calls.append(("correction", kwargs.get("max_correction_passes")))
             return 0
 
-        def _fake_demotion(self, net_routes, neg_router):
-            calls.append(("demotion", None))
+        def _fake_demotion(self, net_routes, neg_router, finalize=False):
+            calls.append(("demotion", finalize))
             return []
 
         monkeypatch.setattr(Autorouter, "_post_route_clearance_correction", _fake_correction)
@@ -605,6 +743,13 @@ class TestCorrectionBeforeDemotionOnTimeout:
         assert correction_passes == 1, (
             f"Timed-out exit must bound the correction to a single pass, "
             f"got max_correction_passes={correction_passes}"
+        )
+        # Issue #4202: the post-loop seg-seg demote runs in FINALIZE mode
+        # (full DRC SHORT threshold), i.e. after the repair pass.
+        demotion_flag = dict(calls)["demotion"]
+        assert demotion_flag is True, (
+            "The post-correction seg-seg demote must run at the finalize "
+            "(full-clearance) threshold, not the in-loop overlap-only one"
         )
 
     def test_correction_unbounded_on_clean_exit(self, monkeypatch):


### PR DESCRIPTION
## Summary

Unit 1 (the M1 fix) of #4202. The negotiated/A* router **emits** same-layer different-net crossing copper that the post-route DRC gate then rejects, wasting the route. This closes the primary mechanism.

The post-loop seg-seg demote safety net (`_demote_seg_seg_overlap_nets` in `core.py`, and its mirror in `two_phase._detailed_negotiated`) called `find_segment_segment_violation_pairs(copper_overlap_only=True)` — a **polygon-intersection** threshold `(w_a+w_b)/2`. But `kicad-cli` fires `clearance_segment_segment: SHORT` at `(w_a+w_b)/2 + trace_clearance`. A committed different-net pair whose edge-to-edge gap is **positive but < `trace_clearance`** is a real DRC short that fell **below** the demote threshold and shipped (the architect measured grid-snap marginals landing exactly on the 0.1000-vs-0.1016mm boundary).

## Fix

Add a `finalize=True` mode to the demote that uses the **full DRC SHORT threshold** (`copper_overlap_only=False`), applied at **FINALIZE time** — after `_post_route_clearance_correction` has had its repair opportunity, so genuinely-nudgeable near-misses are already fixed and only unrepaired-and-shipping copper remains. The negotiation loop itself is unchanged (transient sub-clearance is expected there and repaired by iteration — the M2 relief-probe/negotiation dynamics are out of scope). Applied to **both** the `core.py` demote and the `two_phase.py` mirror.

The trade (architect-endorsed, #3433): a net that today ships a short becomes **honestly-unrouted** (advisory connectivity finding) — strictly better. Verified the demoted net is reset to `[]` (reported incomplete), not silently dropped.

## Over-demotion safety (coupled diff pairs)

A tightly-coupled diff pair has intra spacing < `trace_clearance`, so the widened threshold *would* flag it in isolation — but both legs are **prerouted** (they live in `self.routes`, never in the demotable `net_routes`), so they enter `find_segment_segment_violation_pairs` as non-rippable `extra_routes`, and the existing extra-vs-extra skip never flags them. No diff-pair carve-out needed in Unit 1.

## Tests

- `TestDemoteSegSegFinalizeThreshold` (new, `tests/router/test_seg_seg_quality_tuple.py`):
  - sub-clearance different-net pair (edge gap 0.106mm < 0.15mm clearance) → **NOT** demoted in-loop (correction gets first shot), **demoted** at finalize → honestly-unrouted; partner survives.
  - edge gap == `trace_clearance` (clean) → NOT demoted at finalize (no over-demotion).
  - full physical overlap (g < 0, board-04 mode) → still demoted at finalize (superset; no regression of the #3433 catch).
  - coupled diff pair (both legs extra) → NOT flagged even at finalize.
- Existing timeout-ordering test extended to assert the post-correction demote runs with `finalize=True` (i.e. after repair).
- Regressions (all pass): `tests/router/test_seg_seg_quality_tuple.py`, board-04 routing (2 passed, still >=8/9 clean — validates the two_phase mirror), board-05 routing (2 passed, >= floors), diff-pair routing integration / coupled-cpp-parity / engagement, post-negotiation sweep, partial-route fastfail.

## Board regression completion counts

No baseline shift: board-04 uses a `>=8/9` floor and board-05 uses `>=` completion-pct / `>=15` nets floors — both robust to the honest-unroute trade and both passed unchanged. No exact-count baseline needed adjusting.

## Verification checklist

- [x] Sub-clearance different-net short now demoted at finalize (was shipping).
- [x] Clean routes (gap >= clearance) unaffected.
- [x] Repaired near-misses unaffected (widened check runs AFTER correction).
- [x] `ruff check` + `ruff format --check` clean on changed files.
- [x] `check_mypy_baseline.py`: 0 new errors (pre-existing 39-error floor drift confirmed identical on clean main; baseline untouched).
- [x] C++ backend built (`kct build-native --check` → available 1.0.0).

## Scope

Unit 1 (M1) only. **Deferred follow-ups** per the architect design pass (issues/4202#issuecomment-4982885099): Unit 2 (M3 — unify the four `_demote_*` passes + rescue gate into one `_committed_copper_blocking_drc`), Unit 3 (M4 — post-optimize/post-nudge rtree-less backstop in `route_cmd.py`), Unit 4 (C++ negotiation hardening — explicitly higher-risk, do-not-start).

🤖 Generated with [Claude Code](https://claude.com/claude-code)