### PR TITLE
refactor(install): move conventions to vendored .kct/CONVENTIONS.md, slim CLAUDE.md block

### DIFF
--- a/scripts/install-kct.sh
+++ b/scripts/install-kct.sh
@@ -473,34 +473,62 @@ do_action "write .kct/ci/README.md" write_ci_readme
 VENDORED_FILES+=(".kct/ci/README.md")
 ok "vendored ${#CI_GATE_FILES[@]} CI gate script(s) + README into .kct/ci/"
 
+# ----- Stage 6c: vendor load-bearing conventions into .kct/CONVENTIONS.md ----
+# The three load-bearing Epic #4054 conventions live here verbatim. This file
+# is the "guaranteed-present, survives CLAUDE.md divergence" artifact: the
+# installer owns it outright and overwrites it on every run (same refresh
+# semantics as .kct/ci/README.md and .kct/install-metadata.json). Moving the
+# substance out of the CLAUDE.md marker block — a file a consumer may hand-edit
+# — into this installer-owned file preserves the divergence guarantee by
+# construction while keeping the root CLAUDE.md block a lightweight pointer.
+info "Stage 6c: vendor load-bearing conventions into .kct/CONVENTIONS.md"
+CONVENTIONS_DST="$TARGET/.kct/CONVENTIONS.md"
+
+write_conventions() {
+  mkdir -p "$TARGET/.kct"
+  cat > "$CONVENTIONS_DST" <<'CONVENTIONS_EOF'
+# kicad-tools load-bearing conventions (`.kct/CONVENTIONS.md`)
+
+These conventions are vendored by `install-kct.sh` (kicad-tools Epic #4054) and
+**installer-managed**: re-running the installer overwrites this file. Edit the
+upstream originals, not this copy. Read these before routing or manufacturing
+sign-off.
+
+1. **Build the C++ router backend after every fresh checkout/worktree.** Run
+   `uv run kct build-native` (verify with `--check`). `uv sync` alone does
+   NOT build the native extension; a missing backend makes routing 10-100x
+   slower (multi-minute-per-net).
+2. **Cross-gate DRC for manufacturing sign-off.** `kct check` alone is
+   insufficient — always also run `kicad-cli pcb drc --refill-zones`. `kct check`
+   can miss marginals (e.g. 0.1000 vs 0.1016 mm) and read stale zone fills.
+3. **Artifact-first.** The committed board artifact is shipping truth. A
+   `generate_design.py`/regeneration may diverge by design and is NOT
+   authoritative over a committed board.
+CONVENTIONS_EOF
+}
+do_action "write .kct/CONVENTIONS.md" write_conventions
+VENDORED_FILES+=(".kct/CONVENTIONS.md")
+ok "vendored load-bearing conventions into .kct/CONVENTIONS.md"
+
 # ----- Stage 7: guarded CLAUDE.md block -------------------------------------
 info "Stage 7: CLAUDE.md guarded block"
 CLAUDE_MD="$TARGET/CLAUDE.md"
 
-# The block literally carries the three load-bearing Epic #4054 conventions.
-# It must survive even if the target's CLAUDE.md diverges from ours, so the
-# substance is inlined, not linked.
+# The block is a lightweight pointer (matching the Loom/Repo-Skills pattern):
+# it references the vendored files rather than inlining their substance. The
+# load-bearing conventions live verbatim in .kct/CONVENTIONS.md — a file the
+# installer owns outright and rewrites on every run (see Stage 6c) — so they
+# survive CLAUDE.md drift by construction, without needing to be inlined into a
+# file the consumer may hand-edit.
 NEW_BLOCK="$KCT_MARK_BEGIN
 ## kicad-tools ($KCT_VERSION)
 
 This repo uses [kicad-tools](https://github.com/rjwalters/kicad-tools) (\`kct\`)
-for PCB design/routing/DRC. Skills live under \`.claude/commands/kct/\` and are
-invoked as \`/kct:<name>\`. Portable CI gates (copper-LVS, routed-DRC) live under
-\`.kct/ci/\` — see \`.kct/ci/README.md\` for consumer-side invocation. This block
-is managed by \`install-kct.sh\` — edit outside the markers only; re-running the
-installer replaces it in place.
-
-### Conventions (load-bearing — do not drop)
-1. **Build the C++ router backend after every fresh checkout/worktree.** Run
-   \`uv run kct build-native\` (verify with \`--check\`). \`uv sync\` alone does
-   NOT build the native extension; a missing backend makes routing 10-100x
-   slower (multi-minute-per-net).
-2. **Cross-gate DRC for manufacturing sign-off.** \`kct check\` alone is
-   insufficient — always also run \`kicad-cli pcb drc --refill-zones\`. \`kct check\`
-   can miss marginals (e.g. 0.1000 vs 0.1016 mm) and read stale zone fills.
-3. **Artifact-first.** The committed board artifact is shipping truth. A
-   \`generate_design.py\`/regeneration may diverge by design and is NOT
-   authoritative over a committed board.
+for PCB design/routing/DRC. Skills: \`/kct:<name>\` (see
+\`.claude/commands/kct/README.md\`). **Load-bearing conventions (native backend
+build, cross-gate DRC, artifact-first): \`.kct/CONVENTIONS.md\` — read before
+routing or sign-off.** Managed by \`install-kct.sh\` — edit outside the markers
+only; re-running the installer replaces it in place.
 $KCT_MARK_END"
 
 # Validate the kicad-tools marker structure of a CLAUDE.md. Echoes a

--- a/tests/install/test_install_kct.py
+++ b/tests/install/test_install_kct.py
@@ -203,14 +203,23 @@ def test_path_install_produces_all_artifacts(
         assert dst.exists()
         assert dst.read_bytes() == (SKILLS_SRC / name).read_bytes()
 
-    # Exactly one guarded CLAUDE.md block, all three conventions present.
+    # Exactly one guarded CLAUDE.md block, slimmed to a pointer (the
+    # load-bearing conventions now live in .kct/CONVENTIONS.md, not inlined).
     claude = (target_repo / "CLAUDE.md").read_text()
     assert claude.count("<!-- BEGIN KICAD-TOOLS -->") == 1
     assert claude.count("<!-- END KICAD-TOOLS -->") == 1
-    assert "build-native" in claude
-    assert "refill-zones" in claude
-    assert "Artifact-first" in claude
+    assert ".kct/CONVENTIONS.md" in claude  # slim pointer references the vendored file
+    assert ".claude/commands/kct/README.md" in claude  # pointer references the skills README
+    # The numbered convention list must NOT be inlined into CLAUDE.md anymore.
+    assert "### Conventions (load-bearing" not in claude
+    assert "refill-zones" not in claude
     assert "Existing content stays." in claude  # pre-existing content preserved
+
+    # The three conventions live verbatim in the vendored .kct/CONVENTIONS.md.
+    conventions = (target_repo / ".kct" / "CONVENTIONS.md").read_text()
+    assert "build-native" in conventions
+    assert "refill-zones" in conventions
+    assert "Artifact-first" in conventions
 
     # Metadata is valid JSON with the schema fields.
     meta = json.loads((target_repo / ".kct" / "install-metadata.json").read_text())
@@ -220,6 +229,7 @@ def test_path_install_produces_all_artifacts(
     assert "ee-review" in meta["skills_selected"]
     assert ".claude/commands/kct/ee-review.md" in meta["installed_files"]
     assert ".claude/commands/kct/README.md" in meta["installed_files"]
+    assert ".kct/CONVENTIONS.md" in meta["installed_files"]
 
 
 # --- idempotent re-run -------------------------------------------------------
@@ -512,3 +522,49 @@ def test_vendored_gates_run_standalone_from_consumer(
         text=True,
     )
     assert dirty_run.returncode == 2, dirty_run.stdout
+
+
+# --- .kct/CONVENTIONS.md vendoring (#4190) -----------------------------------
+
+
+def test_conventions_vendored_with_verbatim_conventions(
+    target_repo: Path, fake_uv_env: dict[str, str]
+) -> None:
+    """The three load-bearing Epic #4054 conventions are vendored verbatim."""
+    result = run_installer(target_repo, "--path", str(REPO_ROOT), env=fake_uv_env)
+    assert result.returncode == 0, result.stderr
+
+    conventions = target_repo / ".kct" / "CONVENTIONS.md"
+    assert conventions.exists()
+    text = conventions.read_text()
+    # (1) native backend build, (2) cross-gate DRC, (3) artifact-first.
+    assert "build-native" in text
+    assert "refill-zones" in text
+    assert "Artifact-first" in text
+
+    # Recorded in the metadata manifest alongside the other vendored artifacts.
+    meta = json.loads((target_repo / ".kct" / "install-metadata.json").read_text())
+    assert meta["installed_files"].count(".kct/CONVENTIONS.md") == 1
+
+
+def test_conventions_dry_run_writes_nothing(target_repo: Path, fake_uv_env: dict[str, str]) -> None:
+    """--dry-run reports the planned .kct/CONVENTIONS.md write without creating it."""
+    result = run_installer(target_repo, "--dry-run", "--path", str(REPO_ROOT), env=fake_uv_env)
+    assert result.returncode == 0, result.stderr
+    assert not (target_repo / ".kct" / "CONVENTIONS.md").exists()
+    assert "write .kct/CONVENTIONS.md" in result.stdout
+
+
+def test_conventions_rerun_idempotent(target_repo: Path, fake_uv_env: dict[str, str]) -> None:
+    """A second install refreshes .kct/CONVENTIONS.md in place, no duplication."""
+    first = run_installer(target_repo, "--path", str(REPO_ROOT), env=fake_uv_env)
+    assert first.returncode == 0, first.stderr
+    conventions = target_repo / ".kct" / "CONVENTIONS.md"
+    first_text = conventions.read_text()
+
+    second = run_installer(target_repo, "--path", str(REPO_ROOT), env=fake_uv_env)
+    assert second.returncode == 0, second.stderr
+    assert conventions.read_text() == first_text  # refreshed in place, identical
+
+    meta = json.loads((target_repo / ".kct" / "install-metadata.json").read_text())
+    assert meta["installed_files"].count(".kct/CONVENTIONS.md") == 1


### PR DESCRIPTION
## Summary

The installer's Stage 7 CLAUDE.md marker block inlined the three load-bearing Epic #4054 conventions (native backend build, cross-gate DRC, artifact-first) in full — the outlier versus the lightweight Loom/Repo-Skills pointer blocks. This PR keeps the conventions verbatim and version-controlled but moves them out of the consumer's root CLAUDE.md into a dedicated installer-owned file, `.kct/CONVENTIONS.md`, and slims the CLAUDE.md block to a short pointer.

The "survives CLAUDE.md divergence" guarantee is preserved by construction: the substance now lives in a file the installer owns outright and rewrites on every run (same refresh semantics as `.kct/ci/README.md`), rather than a block a consumer may hand-edit.

## Changes

- `scripts/install-kct.sh`:
  - New **Stage 6c** writes `.kct/CONVENTIONS.md` verbatim (the three conventions), unconditionally overwritten on every run, via `do_action` (so `--dry-run` reports the planned write without creating the file). Recorded in `VENDORED_FILES` → `installed_files`.
  - **Stage 7** `NEW_BLOCK` reduced to a 1-3 sentence pointer referencing `.claude/commands/kct/README.md` (skills) and `.kct/CONVENTIONS.md` (load-bearing conventions), matching the Loom/Repo-Skills pattern. The `### Conventions (load-bearing — do not drop)` numbered list is removed from the inlined block.
  - Rationale comment updated to describe the new mechanism.
- `tests/install/test_install_kct.py`:
  - `test_path_install_produces_all_artifacts`: moved the `build-native`/`refill-zones`/`Artifact-first` keyword assertions off `CLAUDE.md` onto `.kct/CONVENTIONS.md`; added assertions that the slim pointer references `.kct/CONVENTIONS.md` and does NOT inline the numbered list; asserted `.kct/CONVENTIONS.md` in `installed_files`.
  - New `test_conventions_vendored_with_verbatim_conventions`, `test_conventions_dry_run_writes_nothing`, `test_conventions_rerun_idempotent` mirroring the existing `.kct/ci/*` coverage.

Scope boundary respected: only the Stage 7 region + a new adjacent Stage 6c were touched. Stage 4/6 (skill enumeration/vendoring, #4189's territory) is untouched.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `install-kct.sh` writes `.kct/CONVENTIONS.md` with the 3 conventions verbatim, refreshed on every run | ✅ | Stage 6c uses `cat > ... <<'CONVENTIONS_EOF'` unconditionally; manual install + `test_conventions_rerun_idempotent` |
| CLAUDE.md block reduced to a 1-3 sentence pointer to README.md + CONVENTIONS.md | ✅ | Manual install output shows slim block; `test_path_install_produces_all_artifacts` asserts both refs present |
| Numbered convention list removed from the inlined CLAUDE.md block | ✅ | Test asserts `"### Conventions (load-bearing" not in claude` and `"refill-zones" not in claude` |
| `.kct/CONVENTIONS.md` recorded in `installed_files` | ✅ | `VENDORED_FILES+=(".kct/CONVENTIONS.md")`; asserted in tests + metadata grep |
| Idempotent re-run refreshes in place | ✅ | `test_conventions_rerun_idempotent`; metadata count == 1 |
| `--dry-run` reports planned write, creates nothing | ✅ | `test_conventions_dry_run_writes_nothing`; manual dry-run confirmed no file |

## Test Plan

- `uv run pytest tests/install/test_install_kct.py -q` → 20 passed.
- `shellcheck scripts/install-kct.sh` → clean.
- `uv run ruff check` + `ruff format --check` on the test → clean.
- `uv run --extra dev python scripts/ci/check_mypy_baseline.py` → no new type errors (all within baseline).
- Manual: real install shows the slim CLAUDE.md pointer block and `.kct/CONVENTIONS.md` carrying all three conventions verbatim; dry-run creates no file.

Closes #4190