### PR TITLE
fix(pcb): net every same-numbered pad in assign_net_to_footprint_pad

### DIFF
--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -5036,14 +5036,22 @@ class PCB:
         # Ensure net exists and get its number
         net = self.add_net(net_name)
 
-        # Update the in-memory pad
+        # Update every in-memory pad sharing this number.
+        #
+        # KiCad models EP/thermal groups (QFN exposed pads, RF-module
+        # heatsink grids, DPAK tabs) as many pads that share a single pad
+        # number. All pads with the same number are one logical pin and must
+        # carry the same net, so we assign to every match rather than stopping
+        # at the first (see issue #4186). Empty/blank pad numbers are never
+        # passed here for a real schematic pin, and grouping only ever keys on
+        # a specific non-empty number, so unrelated unnumbered mechanical pads
+        # are never netted together.
         pad_found = False
         for pad in fp.pads:
             if pad.number == pad_number:
                 pad.net_number = net.number
                 pad.net_name = net.name
                 pad_found = True
-                break
 
         if not pad_found:
             return False
@@ -5069,7 +5077,12 @@ class PCB:
             if ref_value != reference:
                 continue
 
-            # Found the footprint, now find the pad
+            # Found the footprint, now update every pad sharing this number.
+            # Same rationale as the in-memory loop above (issue #4186): all
+            # pads with a given number are one logical pin and must all carry
+            # the net, so we visit every match instead of returning on the
+            # first one.
+            sexp_pad_found = False
             for pad_sexp in fp_sexp.find_all("pad"):
                 if pad_sexp.get_string(0) == pad_number:
                     # Remove existing net node if present
@@ -5080,7 +5093,9 @@ class PCB:
                     # Add new net node
                     new_net_node = SExp.list("net", net.number, net.name)
                     pad_sexp.append(new_net_node)
-                    return True
+                    sexp_pad_found = True
+
+            return sexp_pad_found
 
         return False
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -107,6 +107,158 @@ class TestPCBNetAssignment:
         assert "U1" in result["missing_footprints"]
         assert len(result["assigned"]) == 0
 
+    @staticmethod
+    def _write_multipad_footprint(tmp_path: Path) -> Path:
+        """Write a synthetic footprint with a same-numbered multi-pad group.
+
+        Models the EP/thermal-via pattern (issue #4186):
+        - pad "1": a single unique SMD pad
+        - pad "19": a thermal group of 3 pads sharing the number, mixing
+          smd (paste) and thru_hole (PTH via) types like a real paste+PTH EP
+        - pad "": a mechanical / no-connect pad with an empty number that must
+          never be netted
+        """
+        footprint = """\
+(footprint "Multipad_Test"
+	(version 20240108)
+	(generator "pcbnew")
+	(layer "F.Cu")
+	(attr smd)
+	(pad "1" smd roundrect
+		(at -2 0)
+		(size 1 1)
+		(layers "F.Cu" "F.Paste" "F.Mask")
+		(roundrect_rratio 0.25)
+	)
+	(pad "19" smd rect
+		(at 0 0)
+		(size 2 2)
+		(layers "F.Cu" "F.Paste" "F.Mask")
+	)
+	(pad "19" thru_hole circle
+		(at -0.5 -0.5)
+		(size 0.6 0.6)
+		(drill 0.3)
+		(layers "*.Cu")
+	)
+	(pad "19" thru_hole circle
+		(at 0.5 0.5)
+		(size 0.6 0.6)
+		(drill 0.3)
+		(layers "*.Cu")
+	)
+	(pad "" np_thru_hole circle
+		(at 3 0)
+		(size 1.5 1.5)
+		(drill 1.5)
+		(layers "*.Cu" "*.Mask")
+	)
+)
+"""
+        mod_path = tmp_path / "Multipad_Test.kicad_mod"
+        mod_path.write_text(footprint)
+        return mod_path
+
+    def test_multipad_group_all_pads_get_net_in_memory(self, tmp_path: Path):
+        """Every same-numbered pad carries the net on the in-memory objects."""
+        pcb = PCB.create(width=100, height=100)
+        mod_path = self._write_multipad_footprint(tmp_path)
+        pcb.add_footprint_from_file(str(mod_path), reference="U1", x=50, y=50)
+
+        result = pcb.assign_net_to_footprint_pad("U1", "19", "GND")
+        assert result is True
+
+        fp = pcb.get_footprint("U1")
+        assert fp is not None
+        gnd = pcb.get_net_by_name("GND")
+        assert gnd is not None
+
+        pads_19 = [p for p in fp.pads if p.number == "19"]
+        # The fixture defines three pads numbered "19".
+        assert len(pads_19) == 3
+        # ALL of them must carry the same net after assignment.
+        for pad in pads_19:
+            assert pad.net_number == gnd.number
+            assert pad.net_name == "GND"
+
+    def test_multipad_group_all_pads_get_net_in_sexp(self, tmp_path: Path):
+        """Every serialized (pad "19") block carries the same net node."""
+        pcb = PCB.create(width=100, height=100)
+        mod_path = self._write_multipad_footprint(tmp_path)
+        pcb.add_footprint_from_file(str(mod_path), reference="U1", x=50, y=50)
+
+        pcb.assign_net_to_footprint_pad("U1", "19", "GND")
+        gnd = pcb.get_net_by_name("GND")
+        assert gnd is not None
+
+        # Re-serialize the board and inspect the S-expression tree directly:
+        # every (pad "19" ...) node must contain the same (net N "GND").
+        fp_sexp = None
+        for candidate in pcb._sexp.find_all("footprint"):
+            for prop in candidate.find_all("property"):
+                if prop.get_string(0) == "Reference" and prop.get_string(1) == "U1":
+                    fp_sexp = candidate
+            for fp_text in candidate.find_all("fp_text"):
+                if fp_text.get_string(0) == "reference" and fp_text.get_string(1) == "U1":
+                    fp_sexp = candidate
+        assert fp_sexp is not None
+
+        pad_19_sexps = [pad for pad in fp_sexp.find_all("pad") if pad.get_string(0) == "19"]
+        assert len(pad_19_sexps) == 3
+        for pad_sexp in pad_19_sexps:
+            net_node = pad_sexp.find("net")
+            assert net_node is not None, "same-numbered pad left with no net node"
+            assert net_node.get_int(0) == gnd.number
+            assert net_node.get_string(1) == "GND"
+
+    def test_multipad_unique_pad_unaffected(self, tmp_path: Path):
+        """A unique-numbered pad is assigned once and not touched by the group."""
+        pcb = PCB.create(width=100, height=100)
+        mod_path = self._write_multipad_footprint(tmp_path)
+        pcb.add_footprint_from_file(str(mod_path), reference="U1", x=50, y=50)
+
+        assert pcb.assign_net_to_footprint_pad("U1", "1", "SIG") is True
+        pcb.assign_net_to_footprint_pad("U1", "19", "GND")
+
+        fp = pcb.get_footprint("U1")
+        assert fp is not None
+        sig = pcb.get_net_by_name("SIG")
+        assert sig is not None
+
+        pads_1 = [p for p in fp.pads if p.number == "1"]
+        assert len(pads_1) == 1
+        assert pads_1[0].net_name == "SIG"
+        assert pads_1[0].net_number == sig.number
+
+    def test_multipad_empty_number_pad_stays_unnetted(self, tmp_path: Path):
+        """The empty-number NC / mechanical pad is never netted."""
+        pcb = PCB.create(width=100, height=100)
+        mod_path = self._write_multipad_footprint(tmp_path)
+        pcb.add_footprint_from_file(str(mod_path), reference="U1", x=50, y=50)
+
+        pcb.assign_net_to_footprint_pad("U1", "1", "SIG")
+        pcb.assign_net_to_footprint_pad("U1", "19", "GND")
+
+        fp = pcb.get_footprint("U1")
+        assert fp is not None
+        nc_pads = [p for p in fp.pads if p.number == ""]
+        assert len(nc_pads) == 1
+        assert nc_pads[0].net_number == 0
+
+        # And its serialized form carries no (net ...) node.
+        fp_sexp = None
+        for candidate in pcb._sexp.find_all("footprint"):
+            for prop in candidate.find_all("property"):
+                if prop.get_string(0) == "Reference" and prop.get_string(1) == "U1":
+                    fp_sexp = candidate
+            for fp_text in candidate.find_all("fp_text"):
+                if fp_text.get_string(0) == "reference" and fp_text.get_string(1) == "U1":
+                    fp_sexp = candidate
+        assert fp_sexp is not None
+        empty_pad_sexps = [pad for pad in fp_sexp.find_all("pad") if pad.get_string(0) == ""]
+        assert len(empty_pad_sexps) == 1
+        assert empty_pad_sexps[0].find("net") is None
+
 
 class TestComponentInfo:
     """Tests for ComponentInfo dataclass."""


### PR DESCRIPTION
## Summary

`kct create-pcb` assigned the schematic net to only the **first** pad of a same-numbered multi-pad group. Footprints that model an EP / thermal pad as many same-numbered sub-pads (e.g. an RF-module heatsink grid where pad `"19"` is 1 SMD paste pad + 21 PTH thermal vias, all numbered `19`) came out with one netted pad and the rest `<no net>`, producing `shorting_items` DRC errors and — worse — a copper plane that connects to sub-pads the netlist says are nothing.

Root cause: `PCB.assign_net_to_footprint_pad` (`src/kicad_tools/schema/pcb.py`) stopped at the first match in **both** loops — the in-memory `Pad` loop (`break`) and the S-expression loop (`return True`). This fix applies the pin's net to **every** pad sharing the number in both loops, keeping the `Pad` objects and the serialized tree consistent.

## Changes

- `src/kicad_tools/schema/pcb.py`: `assign_net_to_footprint_pad` — dropped the in-memory `break`; set net on every `Pad` where `pad.number == pad_number`. Dropped the sexp `return True`; strip/replace `(net ...)` on every matching `pad` node and return `True` only after the full pass (still `False` if none matched, preserving current failure semantics).
- `tests/test_workflow.py`: added 4 regression tests to `TestPCBNetAssignment` using a synthetic inline footprint fixture.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| 1. Synthetic footprint fixture (unique `"1"`, 3-pad `"19"` smd+thru_hole group, empty-number NC), loaded via `add_footprint_from_file`, run through `assign_net_to_footprint_pad` | ✅ | `_write_multipad_footprint` writes the fixture inline; no ESP32 stock lib, no kicad-cli, no #4185 dependency |
| 2. Every `"19"` pad carries same net (in-memory + sexp) | ✅ | `test_multipad_group_all_pads_get_net_in_memory` checks all 3 `fp.pads`; `test_multipad_group_all_pads_get_net_in_sexp` greps all 3 `(pad "19")` sexp nodes for `(net N "GND")` |
| 3. Unique `"1"` pad assigned once, unaffected | ✅ | `test_multipad_unique_pad_unaffected` |
| 4. Empty-number NC pad stays unnetted (no `(net ...)`, `net_number == 0`) | ✅ | `test_multipad_empty_number_pad_stays_unnetted` (both Pad object and sexp) |
| 5. Return value / stats shape unchanged (one assignment per group) | ✅ | `assign_net_to_footprint_pad` still returns a single bool; `assign_nets_from_netlist` caller loop untouched; existing tests unmodified |
| 6. Regression: `TestPCBNetAssignment` + `tests/test_pin_to_pad_mapping.py` pass unchanged | ✅ | 47 passed across both files; no assertion changes |

## Test Plan

- `uv run pytest tests/test_workflow.py -k TestPCBNetAssignment` → 6 passed (2 pre-existing + 4 new)
- `uv run pytest tests/test_workflow.py tests/test_pin_to_pad_mapping.py` → 47 passed
- `uv run pytest tests/ -k "create_pcb or assign_net or net_assignment or multipad"` → 18 passed, 6 skipped
- `ruff check` + `ruff format --check` clean on both files
- `scripts/ci/check_mypy_baseline.py` → 0 new type errors (1475 within 1514 baseline)

Closes #4186