### PR TITLE
fix(sexp): preserve bare atoms symmetrically so keepout enums round-trip unquoted

### DIFF
--- a/src/kicad_tools/sexp/parser.py
+++ b/src/kicad_tools/sexp/parser.py
@@ -69,6 +69,7 @@ class SExp:
         "_inline",
         "_original_str",
         "_originally_quoted",
+        "_originally_bare",
         "_line",
         "_column",
     )
@@ -81,6 +82,7 @@ class SExp:
         _inline: bool = False,
         _original_str: str | None = None,
         _originally_quoted: bool = False,
+        _originally_bare: bool = False,
         _line: int = 0,
         _column: int = 0,
     ):
@@ -98,6 +100,16 @@ class SExp:
         # constructed atoms default to False so existing keyword/round-trip
         # behavior is unchanged.
         self._originally_quoted = _originally_quoted
+        # Tracks whether a string atom was parsed from a *bare* (unquoted) token.
+        # When True, the serializer preserves the bare form as long as the value
+        # does not *structurally* require quoting (whitespace, parens, quote
+        # chars, empty). This is the symmetric counterpart to _originally_quoted:
+        # it lets bare KiCad enum symbols that are absent from the unquoted
+        # keyword allowlist (e.g. `not_allowed`, `chamfer_rect`) round-trip bare
+        # rather than being wrongly quoted (issue #4185). Programmatically
+        # constructed atoms default to False so they still go through the
+        # allowlist heuristic in _needs_quoting().
+        self._originally_bare = _originally_bare
         self._line = _line
         self._column = _column
 
@@ -490,7 +502,21 @@ class SExp:
             # preserves the type distinction between (field "9.0") and
             # (field 9.0) on round-trip — KiCad strict-typed string fields
             # like generator_version would otherwise be silently downgraded.
-            if self._originally_quoted or self._needs_quoting(self.value):
+            #
+            # Symmetric bare handling (issue #4185): an atom parsed as a *bare*
+            # symbol must stay bare unless it *structurally* requires quoting
+            # (whitespace, parens, quote chars, empty). This preserves KiCad enum
+            # symbols like `not_allowed`/`chamfer_rect` that are absent from the
+            # unquoted-keyword allowlist and would otherwise be wrongly quoted by
+            # the "quote everything else" fallback in _needs_quoting(). Values
+            # that structurally require quotes are still always quoted, for
+            # correctness. _originally_quoted always wins (a value parsed quoted
+            # stays quoted), so the two flags never conflict.
+            if self._originally_bare and not self._must_quote(self.value):
+                needs_quote = False
+            else:
+                needs_quote = self._originally_quoted or self._needs_quoting(self.value)
+            if needs_quote:
                 escaped = self.value.replace("\\", "\\\\").replace('"', '\\"')
                 escaped = escaped.replace("\n", "\\n").replace("\t", "\\t")
                 return f'"{escaped}"'
@@ -504,6 +530,22 @@ class SExp:
                 return str(int(self.value))
             return f"{self.value:.6g}"
         return str(self.value)
+
+    @staticmethod
+    def _must_quote(s: str) -> bool:
+        """Whether a string atom *structurally* requires quoting.
+
+        These are values that cannot be represented as a bare S-expression
+        token at all — an empty string, or one containing whitespace, parens,
+        or a double-quote character. Such values must always be quoted for
+        correctness, regardless of parse-time bare/quoted state. This is the
+        narrow "genuinely requires quotes" test used by the symmetric bare
+        handling in _format_atom() (issue #4185); it is intentionally distinct
+        from the KiCad-keyword allowlist heuristic in _needs_quoting().
+        """
+        if not s:
+            return True
+        return any(c in s for c in ' \t\n\r"()')
 
     @staticmethod
     def _is_valid_name(s: str) -> bool:
@@ -1243,7 +1285,10 @@ class Parser:
                 return node
             except ValueError:
                 pass
-        return SExp(value=token)
+        # A bare (unquoted) string token: record that it was parsed bare so the
+        # serializer can keep it bare on round-trip rather than re-quoting it via
+        # the keyword allowlist heuristic (issue #4185).
+        return SExp(value=token, _originally_bare=True)
 
     def _skip_whitespace(self):
         """Skip whitespace and comments."""

--- a/tests/test_sexp.py
+++ b/tests/test_sexp.py
@@ -452,6 +452,87 @@ class TestSExpSerialization:
             )
             assert f"(mirror {axis})" == result
 
+    def test_parsed_bare_keepout_enum_stays_bare(self):
+        """Keepout rule-area enum tokens parsed bare must re-emit bare.
+
+        KiCad emits `(tracks not_allowed)` (bare symbol) in footprint keepout
+        rule areas, and pcbnew's parser hard-rejects the quoted form
+        `(tracks "not_allowed")` — a board containing it fails to load. The
+        tokens `not_allowed`/`allowed` are absent from the unquoted-keyword
+        allowlist, so before issue #4185 the serializer wrongly quoted them on
+        round-trip. An atom parsed as a bare symbol must stay bare.
+        """
+        text = (
+            "(keepout (tracks not_allowed) (vias not_allowed) (pads not_allowed) "
+            "(copperpour not_allowed) (footprints not_allowed))"
+        )
+        result = parse_string(text).to_string()
+        assert '"not_allowed"' not in result, f"keepout enum must not be quoted, got: {result}"
+        assert '"allowed"' not in result
+        for field in ("tracks", "vias", "pads", "copperpour", "footprints"):
+            assert f"({field} not_allowed)" in result, (
+                f"expected bare ({field} not_allowed) in: {result}"
+            )
+
+    def test_parsed_bare_sibling_enum_tokens_stay_bare(self):
+        """Sibling bare enum tokens must also round-trip bare.
+
+        These KiCad zone/pad enum symbols share the identical latent gap with
+        the keepout tokens: they are absent from the unquoted-keyword allowlist,
+        so the symmetric bare/quoted fix (issue #4185) must keep them bare when
+        they were parsed bare, rather than requiring a token-by-token allowlist
+        patch.
+        """
+        for token in [
+            "chamfer_rect",
+            "chamfer",
+            "fillet",
+            "poly",
+            "castellated",
+            "heatsink",
+            "bga",
+        ]:
+            result = parse_string(f"(field {token})").to_string()
+            assert f'"{token}"' not in result, (
+                f"bare token '{token}' should not be quoted, got: {result}"
+            )
+            assert f"(field {token})" == result
+
+    def test_parsed_quoted_string_stays_quoted(self):
+        """An originally-quoted string must stay quoted on round-trip.
+
+        The bare/quoted distinction is symmetric: a value parsed from a quoted
+        token (e.g. a strict-typed field that looks numeric) must not be
+        downgraded to a bare atom by the bare-handling path (issue #4185).
+        """
+        result = parse_string('(generator_version "9.0")').to_string()
+        assert '"9.0"' in result, f"quoted value must stay quoted, got: {result}"
+
+    def test_parsed_bare_value_requiring_quotes_still_quoted(self):
+        """Values that structurally require quotes are always quoted.
+
+        Whitespace, parentheses, and empty strings cannot be represented as
+        bare tokens, so they must always be quoted regardless of parse-time
+        bare/quoted state (issue #4185). Such values only ever reach the parser
+        as quoted tokens, but the serializer must not emit them bare even if the
+        bare flag were somehow set.
+        """
+        # Quoted-source values containing structural characters stay quoted.
+        for value in ["has space", "with(paren", ""]:
+            node = SExp("field")
+            node.add(SExp.quoted_atom(value))
+            result = serialize_sexp(node)
+            assert f'"{value}"' in result, (
+                f"value {value!r} requiring quotes must stay quoted, got: {result}"
+            )
+
+        # A bare-flagged atom whose value structurally requires quoting must
+        # still be quoted (the bare path defers to _must_quote()).
+        bare = SExp(value="has space", _originally_bare=True)
+        assert bare._format_atom() == '"has space"'
+        empty = SExp(value="", _originally_bare=True)
+        assert empty._format_atom() == '""'
+
 
 class TestSExpFileIO:
     """Tests for file I/O functions."""

--- a/tests/test_sexp_roundtrip.py
+++ b/tests/test_sexp_roundtrip.py
@@ -11,9 +11,40 @@ from pathlib import Path
 import pytest
 
 from kicad_tools.sexp import parse_file
+from kicad_tools.sexp.parser import parse_string
 
 # Check if kicad-cli is available
 KICAD_CLI = shutil.which("kicad-cli")
+
+
+# Synthetic minimal footprint carrying an embedded keepout rule area, matching
+# the shape KiCad emits for footprints like RF_Module:ESP32-C3-WROOM-02. Used
+# instead of a stock-library fixture so the test has no dependency on a specific
+# KiCad library install being present (issue #4185).
+SYNTHETIC_KEEPOUT_FOOTPRINT = """(footprint "TEST:Keepout"
+	(layer "F.Cu")
+	(uuid "00000000-0000-0000-0000-000000000abc")
+	(at 5 5)
+	(zone
+		(net 0)
+		(net_name "")
+		(layers "F&B.Cu")
+		(hatch full 0.508)
+		(keepout
+			(tracks not_allowed)
+			(vias not_allowed)
+			(pads not_allowed)
+			(copperpour not_allowed)
+			(footprints not_allowed)
+		)
+		(polygon
+			(pts
+				(xy 0 0) (xy 1 0) (xy 1 1) (xy 0 1)
+			)
+		)
+	)
+)
+"""
 
 
 @pytest.fixture
@@ -87,6 +118,64 @@ class TestSExpRoundTripWithKiCad:
 
         assert "Failed to load board" not in result.stderr, (
             f"KiCad failed to load serialized file.\n"
+            f"stdout: {result.stdout}\n"
+            f"stderr: {result.stderr}"
+        )
+
+    def test_keepout_footprint_roundtrips_bare(self):
+        """A footprint keepout rule area must round-trip with bare enum tokens.
+
+        KiCad emits `(tracks not_allowed)` as bare symbols; the quoted form
+        `(tracks "not_allowed")` is a hard parse error that makes the board
+        unloadable. Before issue #4185 the serializer quoted these tokens
+        because they were absent from the unquoted-keyword allowlist. This test
+        uses a synthetic footprint fixture (no stock-library dependency).
+        """
+        output = parse_string(SYNTHETIC_KEEPOUT_FOOTPRINT).to_string()
+        assert '"not_allowed"' not in output, (
+            f"keepout enum tokens must round-trip bare, got: {output}"
+        )
+        for field in ("tracks", "vias", "pads", "copperpour", "footprints"):
+            assert f"({field} not_allowed)" in output, (
+                f"expected bare ({field} not_allowed) in: {output}"
+            )
+
+    @pytest.mark.skipif(KICAD_CLI is None, reason="kicad-cli not installed")
+    def test_keepout_board_loads_in_kicad(self, tmp_path):
+        """A board carrying a keepout footprint must load after round-trip.
+
+        Injects a synthetic footprint with an embedded keepout rule area into a
+        real demo board, serializes it, and asserts kicad-cli can load it. Before
+        issue #4185 the keepout tokens were quoted, causing "Failed to load
+        board" (verified: the quoted form is a hard pcbnew parse error).
+        """
+        demo = (
+            Path(__file__).parent.parent
+            / "boards"
+            / "00-simple-led"
+            / "output"
+            / "simple_led.kicad_pcb"
+        )
+        if not demo.exists():
+            pytest.skip(f"Demo board not found: {demo}")
+
+        doc = parse_file(demo)
+        # The synthetic footprint already carries a uuid so KiCad accepts it.
+        doc.children.append(parse_string(SYNTHETIC_KEEPOUT_FOOTPRINT))
+
+        output = doc.to_string()
+        assert '"not_allowed"' not in output, "keepout tokens must be bare before load"
+
+        output_path = tmp_path / "keepout_board.kicad_pcb"
+        output_path.write_text(output)
+
+        result = subprocess.run(
+            [KICAD_CLI, "pcb", "drc", str(output_path), "-o", str(tmp_path / "drc.json")],
+            capture_output=True,
+            text=True,
+        )
+        assert "Failed to load board" not in result.stderr, (
+            f"KiCad failed to load board with keepout footprint.\n"
             f"stdout: {result.stdout}\n"
             f"stderr: {result.stderr}"
         )


### PR DESCRIPTION
## Summary

`SExp._format_atom()` was a one-way quoting ratchet: it honored the parse-time `_originally_quoted` flag to *add* quotes on serialize, but never used the inverse (atom parsed **bare**) to *skip* the `_needs_quoting()` keyword-allowlist fallback. Bare KiCad enum symbols that are absent from the `unquoted_keywords` allowlist — `not_allowed`/`allowed` and the sibling tokens `chamfer_rect`, `chamfer`, `fillet`, `poly`, `castellated`, `heatsink`, `bga` — hit the "quote everything else" default and were re-emitted quoted. So a footprint's `(tracks not_allowed)` keepout rule area became `(tracks "not_allowed")`, which pcbnew hard-rejects: `kicad-cli pcb drc` reports `Failed to load board`, making the emitted board unloadable by KiCad (surfaced via `kct create-pcb` for footprints like `RF_Module:ESP32-C3-WROOM-02`).

This applies the curator's "Right" tier fix: respect the parser's bare/quoted distinction **symmetrically**, which fixes the keepout tokens and all the sibling tokens at once rather than special-casing keepout or patching the allowlist token-by-token.

## Changes

- `src/kicad_tools/sexp/parser.py`:
  - Add an `_originally_bare` slot/flag (symmetric counterpart to `_originally_quoted`), set in `Parser._parse_atom()` for bare string tokens.
  - Add `SExp._must_quote()` — the narrow "genuinely requires quotes" test (empty string, whitespace, parens, or quote char) that must always force quoting for correctness, distinct from the KiCad-keyword allowlist heuristic.
  - In `_format_atom()`: an atom parsed bare stays bare unless `_must_quote()` is true. `_originally_quoted` still wins (a value parsed quoted stays quoted), and programmatically constructed atoms (`_originally_bare=False`) still use the `_needs_quoting()` allowlist heuristic, so existing keyword/round-trip behavior is unchanged.
- `tests/test_sexp.py`: 4 unit tests — parsed-bare keepout enums stay bare, sibling tokens stay bare, originally-quoted strings stay quoted, and values that structurally require quotes (spaces, parens, empty) are always quoted.
- `tests/test_sexp_roundtrip.py`: a synthetic minimal keepout footprint fixture (no stock-library dependency); a round-trip test asserting bare tokens; and a `kicad-cli`-gated test injecting the keepout footprint into a real demo board and asserting the serialized board loads (no "Failed to load board").

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Parsed-bare `(tracks not_allowed)` re-emits bare | ✅ | `test_parsed_bare_keepout_enum_stays_bare`; direct parser repro no longer quotes |
| Keepout block round-trips bare | ✅ | `test_keepout_footprint_roundtrips_bare` (synthetic fixture) |
| Originally-quoted string stays quoted | ✅ | `test_parsed_quoted_string_stays_quoted` (`generator_version "9.0"`) |
| Values requiring quotes (spaces/parens/empty) still quoted | ✅ | `test_parsed_bare_value_requiring_quotes_still_quoted` |
| Sibling tokens (chamfer_rect, fillet, poly, ...) stay bare | ✅ | `test_parsed_bare_sibling_enum_tokens_stay_bare` — fix generalizes, no special-casing |
| Emitted board loads in KiCad | ✅ | `test_keepout_board_loads_in_kicad` (kicad-cli-gated); confirmed the quoted form fails and the bare form loads |
| No serialization regressions (high blast radius) | ✅ | `test_serialize_kicad_keywords_unquoted`, `test_mirror_values_unquoted`, and the full broad sweep all pass unchanged |

## Test Plan

- `uv run pytest tests/test_sexp.py tests/test_sexp_roundtrip.py -q` → 90 passed, 5 skipped (pre-existing skips from a stale demo-fixture path).
- Broad regression sweep `uv run pytest tests/ -q -k "sexp or serialize or roundtrip or create_pcb or footprint"` → **1526 passed, 23 skipped, 0 failed** — zero serialization regressions.
- `ruff check` + `ruff format --check` clean on changed files.
- `uv run --extra dev python scripts/ci/check_mypy_baseline.py` → 0 new type errors (1475 within 1514 baseline).

Closes #4185