### PR TITLE
feat(kct): add introspective /kct:help meta-skill, vendored unconditionally

### DIFF
--- a/.claude/commands/kct/README.md
+++ b/.claude/commands/kct/README.md
@@ -19,6 +19,7 @@ invoked as `/kct:<name>`. Do not place them under `.claude/commands/loom/` or `.
 
 | Command | Purpose | Model |
 |---------|---------|-------|
+| `/kct:help [<command>]` | Explain the installed `/kct:*` skills — what each does, how to invoke it, and the load-bearing conventions — by reading the files actually vendored in this repo. Introspective and strictly read-only; no board argument. | sonnet |
 | `/kct:ee-review <issue-or-board>` | Produce an EE decision document (escalating intervention ladder + binding constraints, cited and confidence-graded) for an analog/placement-blocked board. Advisory only — decisions, not copper. | opus |
 | `/kct:manufacturing-readiness <board-path>` | Sign off a routed board for fabrication: `kct check` + the mandatory `kicad-cli pcb drc --refill-zones` cross-gate + a `kct export` bundle at the board's fab tier. Refuses sign-off if any gate is skipped. | sonnet |
 | `/kct:board-recipe-scaffold <board-path>` | Scaffold a new consumer board recipe (`generate_design.py`) following the artifact-first convention: project → schematic+ERC → PCB → route+pour → check → LVS hard gate → export, with circuit-specific parts left as fill-in points. | sonnet |

--- a/.claude/commands/kct/help.md
+++ b/.claude/commands/kct/help.md
@@ -1,0 +1,133 @@
+---
+name: help
+invocation: /kct:help
+suggestedModel: sonnet
+description: Explain the installed /kct:* skills — what each does, how to invoke it, and the load-bearing conventions — by reading the files actually vendored in this repo. Introspective and strictly read-only.
+---
+
+# kct help
+
+Orient a user inside a consumer PCB-design repo that has kicad-tools installed:
+**which `/kct:*` skills are present, what each one is for, the load-bearing
+conventions, and where to start.** This is a *meta-skill* — it describes the
+other skills by reading the files actually vendored under
+`.claude/commands/kct/`, so it never drifts from a version-skewed or
+`--skills=`-filtered install.
+
+> **The `kct` namespace.** This skill lives in `.claude/commands/kct/` — the
+> kicad-tools-native, harness-agnostic agent-tool namespace, invoked as
+> `/kct:help`. It runs from inside a **consumer repo** and assumes nothing
+> about the current directory being the kicad-tools source checkout.
+
+> **Strictly read-only.** This skill only *reads* `.md` files and (optionally)
+> `.kct/install-metadata.json` to describe what is installed. It **never**
+> invokes another `/kct:*` skill, never opens/modifies/routes/checks/exports a
+> `.kicad_pcb`, and **never writes any file**. It takes no board argument
+> because it never touches a board. See the Notes section.
+
+## Model selection
+
+`suggestedModel: sonnet`. Reading frontmatter and rendering an orientation
+table is summarization, not frontier judgment. Model resolves through the
+harness's normal precedence chain (explicit dispatch param → harness role
+config → this doc's frontmatter `suggestedModel` → session default).
+
+## Arguments
+
+**Arguments**: `$ARGUMENTS`
+
+`$ARGUMENTS` is `[<command>]` — an *optional* skill name (e.g. `ee-review`).
+It is **not** a board path: this skill takes no board argument and touches no
+board.
+
+| Token | Meaning |
+|-------|---------|
+| *(none)* | **Overview mode.** Render a one-screen orientation: every installed `/kct:*` skill (one line each from its frontmatter), the load-bearing conventions, and a "start here" pointer. |
+| `<command>` | **Detail mode.** Summarize exactly one installed skill (`<command>.md`): its usage/arguments, what it does, one concrete example invocation, and whether it is read-only or writes to the board. If `<command>.md` does not exist, say so and fall back to the overview's skill list. |
+
+## Overview mode (no argument) — introspect, never hardcode
+
+Do **not** hardcode the skill list in this document. Build it at run time from
+the files actually present:
+
+1. **List the vendored skills.** Read the directory of this namespace:
+
+   ```bash
+   ls .claude/commands/kct/*.md
+   ```
+
+   For each `<name>.md` **other than** `README.md` and `help.md` itself, read
+   its YAML frontmatter block (the `name`, `invocation`, `suggestedModel`,
+   `description` keys between the leading `---` fences). Render one row per
+   skill — mirroring the table in `.claude/commands/kct/README.md` rather than
+   inventing a new format:
+
+   | Skill | Purpose (from `description`) | Model |
+   |-------|------------------------------|-------|
+   | `/kct:<invocation>` | one-line `description` | `suggestedModel` |
+
+   Skip `README.md` (it is the namespace index, not a skill) and `help.md`
+   (this file — describing yourself in the table is noise).
+
+2. **Caption with install metadata, if present.** If
+   `.kct/install-metadata.json` exists, read it and caption the overview with
+   its `kct_version`, `install_date`, and `skills_selected` fields, e.g.
+   *"kicad-tools v0.15.1, installed 2026-07-11, skills: ee-review,
+   manufacturing-readiness, …"*.
+
+   ```bash
+   cat .kct/install-metadata.json   # optional — absent on some installs
+   ```
+
+   **Fallback (metadata absent):** a `--path` dev-mode install predating this
+   file, or reading from the kicad-tools *source* checkout itself, may have no
+   `.kct/install-metadata.json`. Do **not** error — just omit the version/date
+   caption and list whatever `.md` files are present.
+
+3. **Surface the load-bearing conventions.** Point the user at the vendored
+   convention files rather than restating them here (they are owned by the
+   installer and must not be duplicated a third time):
+
+   - **`.kct/CONVENTIONS.md`** — the three load-bearing Epic #4054 conventions
+     verbatim (build the native router backend, cross-gate DRC with
+     `kicad-cli pcb drc --refill-zones`, artifact-first). Read this before
+     routing or manufacturing sign-off. If `.kct/CONVENTIONS.md` is absent
+     (an install predating it), fall back to the guarded kicad-tools block in
+     the repo's `CLAUDE.md`, which carries the same pointer.
+   - **`.claude/commands/kct/README.md`** — why the `kct` namespace exists and
+     the canonical skills table.
+
+4. **Start here.** Close with a short pointer: read `.kct/CONVENTIONS.md`
+   first, then run `/kct:help <command>` for details on any single skill, or
+   read `.claude/commands/kct/README.md` for the namespace overview.
+
+## Detail mode (`/kct:help <command>`)
+
+Read `.claude/commands/kct/<command>.md` and **summarize** it — do not
+reproduce it:
+
+- **Usage / arguments** — the `## Arguments` table (what `$ARGUMENTS` accepts).
+- **What it does** — two or three sentences from the body, not a copy of it.
+- **One concrete example** — a single realistic invocation, e.g.
+  `/kct:<command> <its-argument>`.
+- **Read-only or writes?** — state plainly whether the skill only reads, or
+  writes an artifact / edits a `.kicad_pcb`.
+
+This is a *summary*, not a reimplementation — do not execute the skill.
+
+If `.claude/commands/kct/<command>.md` does not exist, say so plainly and list
+what **is** installed (the same introspective list as overview mode) so the
+user can pick a real one.
+
+## Notes
+
+- **Read-only, always.** This skill reads `.md` files and optionally
+  `.kct/install-metadata.json`. It never invokes another skill, never runs
+  `kct check` / `kct export` / routing, never opens or modifies a
+  `.kicad_pcb`, and writes nothing.
+- **No board argument.** Unlike the per-board skills, `/kct:help` takes no
+  board path — it describes tools, it does not operate on a board.
+- **Introspective, never hardcoded.** The skill list always comes from the
+  files present under `.claude/commands/kct/`, so adding or removing a skill
+  file changes the overview automatically — there is no second list to keep in
+  sync.

--- a/scripts/install-kct.sh
+++ b/scripts/install-kct.sh
@@ -214,12 +214,14 @@ ok "source_mode=$SOURCE_MODE"
 info "Stage 4: enumerate source skills"
 # Glob *.md under the source skills dir at install time (Curator: never
 # hardcode the file list — Child 3 additions must be picked up automatically).
-# README.md documents the namespace and is always vendored; the remaining *.md
-# files are the selectable skills.
+# README.md documents the namespace and help.md is the introspective meta-skill;
+# both are always vendored (see Stage 6) and are NOT selectable skills. The
+# remaining *.md files are the selectable per-board skills.
 ALL_SKILLS=()
 while IFS= read -r -d '' md; do
   base="$(basename "$md" .md)"
   [[ "$base" == "README" ]] && continue
+  [[ "$base" == "help" ]] && continue
   ALL_SKILLS+=("$base")
 done < <(find "$SKILLS_SRC" -maxdepth 1 -name '*.md' -type f -print0 | LC_ALL=C sort -z)
 
@@ -357,8 +359,8 @@ else
 fi
 
 # ----- Stage 6: vendor .claude/commands/kct/ skills -------------------------
-# Copy README.md (always) plus each selected skill's <name>.md. NEVER touch
-# .claude/commands/loom/ (coexist additively with Loom).
+# Copy README.md and help.md (both always) plus each selected skill's <name>.md.
+# NEVER touch .claude/commands/loom/ (coexist additively with Loom).
 info "Stage 6: vendor .claude/commands/kct/ skills"
 DST_SKILLS_DIR="$TARGET/.claude/commands/kct"
 VENDORED_FILES=()  # target-relative paths, for the metadata manifest.
@@ -370,10 +372,17 @@ vendor_file() {
   chmod 0644 "$dst"
 }
 
-# README.md is always vendored (documents the namespace convention).
+# README.md and help.md are always vendored, regardless of --skills= filtering.
+# README.md documents the namespace convention; help.md is the introspective
+# meta-skill (/kct:help) that describes whatever skills are present, so it must
+# exist for every install exactly like README.md (not opt-in via --skills=).
 do_action "vendor .claude/commands/kct/README.md" \
   vendor_file "$SKILLS_SRC/README.md" "$DST_SKILLS_DIR/README.md"
 VENDORED_FILES+=(".claude/commands/kct/README.md")
+
+do_action "vendor .claude/commands/kct/help.md" \
+  vendor_file "$SKILLS_SRC/help.md" "$DST_SKILLS_DIR/help.md"
+VENDORED_FILES+=(".claude/commands/kct/help.md")
 
 for s in "${SELECTED_SKILLS[@]}"; do
   do_action "vendor .claude/commands/kct/$s.md" \

--- a/tests/install/test_install_kct.py
+++ b/tests/install/test_install_kct.py
@@ -197,8 +197,9 @@ def test_path_install_produces_all_artifacts(
     assert "[tool.uv.sources]" in pyproject
     assert "path" in pyproject.split("[tool.uv.sources]", 1)[1]
 
-    # Vendored skills byte-identical to source.
-    for name in ("README.md", "ee-review.md"):
+    # Vendored skills byte-identical to source. README.md and help.md are the
+    # always-vendored meta files (help.md is the introspective /kct:help skill).
+    for name in ("README.md", "help.md", "ee-review.md"):
         dst = target_repo / ".claude" / "commands" / "kct" / name
         assert dst.exists()
         assert dst.read_bytes() == (SKILLS_SRC / name).read_bytes()
@@ -229,7 +230,11 @@ def test_path_install_produces_all_artifacts(
     assert "ee-review" in meta["skills_selected"]
     assert ".claude/commands/kct/ee-review.md" in meta["installed_files"]
     assert ".claude/commands/kct/README.md" in meta["installed_files"]
+    assert ".claude/commands/kct/help.md" in meta["installed_files"]
     assert ".kct/CONVENTIONS.md" in meta["installed_files"]
+    # help.md is a meta-skill, not a per-board skill: it is always vendored, so
+    # it must NOT appear in skills_selected (like README.md, it is not selectable).
+    assert "help" not in meta["skills_selected"]
 
 
 # --- idempotent re-run -------------------------------------------------------
@@ -348,16 +353,37 @@ def test_skills_filter_selects_named_skill(target_repo: Path, fake_uv_env: dict[
     assert result.returncode == 0, result.stderr
     kct_dir = target_repo / ".claude" / "commands" / "kct"
     assert (kct_dir / "ee-review.md").exists()
-    # README is always vendored (documents the namespace).
+    # README and help are always vendored regardless of --skills= filtering:
+    # README documents the namespace; help.md is the introspective /kct:help
+    # meta-skill that must exist even when only one per-board skill was selected.
     assert (kct_dir / "README.md").exists()
+    assert (kct_dir / "help.md").exists()
+    # A per-board skill NOT named in --skills= must be absent — proves help.md's
+    # presence is unconditional, not just a side effect of vendoring everything.
+    assert not (kct_dir / "tapeout.md").exists()
     meta = json.loads((target_repo / ".kct" / "install-metadata.json").read_text())
     assert meta["skills_selected"] == ["ee-review"]
+    assert "help" not in meta["skills_selected"]
+    # help.md is still recorded in installed_files (always-vendored, like README).
+    assert ".claude/commands/kct/help.md" in meta["installed_files"]
 
 
 def test_unknown_skill_errors(target_repo: Path, fake_uv_env: dict[str, str]) -> None:
     result = run_installer(
         target_repo, "--skills=does-not-exist", "--path", str(REPO_ROOT), env=fake_uv_env
     )
+    assert result.returncode != 0
+    assert "unknown skill" in result.stderr
+
+
+def test_help_is_not_a_selectable_skill(target_repo: Path, fake_uv_env: dict[str, str]) -> None:
+    """--skills=help must be rejected, exactly like --skills=README today.
+
+    help.md is always vendored (a meta-skill), never opt-in via --skills=. It is
+    excluded from ALL_SKILLS the same way README.md is, so requesting it by name
+    is an unknown-skill error, not a way to select it.
+    """
+    result = run_installer(target_repo, "--skills=help", "--path", str(REPO_ROOT), env=fake_uv_env)
     assert result.returncode != 0
     assert "unknown skill" in result.stderr
 

--- a/tests/test_kct_skills_consumer_generic.py
+++ b/tests/test_kct_skills_consumer_generic.py
@@ -31,6 +31,13 @@ NEW_SKILLS = (
     "tapeout",
 )
 
+# Meta-skills (#4189): they describe the *other* skills and take no <board-path>
+# argument, so they are exempt from the per-board-skill contract
+# (test_board_path_is_a_parameter). The consumer-generic gates that DO apply to
+# any vendored .md — frontmatter house style, no repo-internal path literals, no
+# CI-workflow assumptions — still run against them via META_SKILLS below.
+META_SKILLS = ("help",)
+
 # The manufacturing-readiness skill is the one that must not enumerate fab tiers.
 MFR_SKILL = "manufacturing-readiness"
 
@@ -60,7 +67,7 @@ def _lines(name: str) -> list[str]:
     return _skill_path(name).read_text(encoding="utf-8").splitlines()
 
 
-@pytest.mark.parametrize("skill", NEW_SKILLS)
+@pytest.mark.parametrize("skill", NEW_SKILLS + META_SKILLS)
 def test_no_repo_internal_path_literals(skill: str) -> None:
     """Gate 1: no boards/0N-, hardware/board-0N, scripts/ci/board0N, chorus, softstart."""
     hits = [
@@ -111,7 +118,7 @@ def test_mfr_skill_defers_to_registry() -> None:
     )
 
 
-@pytest.mark.parametrize("skill", NEW_SKILLS)
+@pytest.mark.parametrize("skill", NEW_SKILLS + META_SKILLS)
 def test_no_ci_workflow_assumptions(skill: str) -> None:
     """Gate 4: no directive reference to .github/workflows/* or scripts/ci/*.
 
@@ -125,7 +132,7 @@ def test_no_ci_workflow_assumptions(skill: str) -> None:
     assert not hits, "CI-workflow assumption found:\n" + "\n".join(hits)
 
 
-@pytest.mark.parametrize("skill", NEW_SKILLS)
+@pytest.mark.parametrize("skill", NEW_SKILLS + META_SKILLS)
 def test_frontmatter_matches_house_style(skill: str) -> None:
     """Every skill carries the ee-review.md frontmatter block."""
     text = _skill_path(skill).read_text(encoding="utf-8")
@@ -148,11 +155,33 @@ def test_mfr_skill_states_cross_gate_is_mandatory() -> None:
     )
 
 
-@pytest.mark.parametrize("skill", NEW_SKILLS)
+@pytest.mark.parametrize("skill", NEW_SKILLS + META_SKILLS)
 def test_readme_indexes_every_new_skill(skill: str) -> None:
     """Gate: README table lists every new skill in the same table as ee-review."""
     readme = (KCT_DIR / "README.md").read_text(encoding="utf-8")
     assert f"/kct:{skill}" in readme, f"README.md does not index /kct:{skill}"
+
+
+@pytest.mark.parametrize("skill", META_SKILLS)
+def test_meta_skill_has_no_board_path_contract(skill: str) -> None:
+    """Meta-skills describe other skills and must NOT take a <board-path>.
+
+    This is the explicit carve-out from test_board_path_is_a_parameter: help.md
+    (and any future meta-skill) operates on the skill *files*, never on a board,
+    so it deliberately does not define a <board-path> token. Asserting its
+    absence keeps the meta-skill honest (a meta-skill that grew a board argument
+    would be a design regression).
+    """
+    text = _skill_path(skill).read_text(encoding="utf-8")
+    assert "<board-path>" not in text, (
+        f"{skill}.md is a meta-skill and must not take a <board-path> argument"
+    )
+
+
+def test_meta_skill_is_read_only(skill: str = "help") -> None:
+    """help.md must declare itself strictly read-only (never touches a board)."""
+    text = _skill_path(skill).read_text(encoding="utf-8").lower()
+    assert "read-only" in text, f"{skill}.md must state it is read-only"
 
 
 def test_manufacturer_registry_is_the_authoritative_source() -> None:


### PR DESCRIPTION
## Summary

Adds a user-invocable `/kct:help` slash command (`.claude/commands/kct/help.md`) that orients a user inside a consumer PCB repo with kicad-tools installed: which `/kct:*` skills are present, what each does, the load-bearing conventions, and where to start. It is **introspective** (reads the actual vendored frontmatter, no hardcoded skill list), **strictly read-only**, and is **vendored unconditionally** by `install-kct.sh` exactly like `README.md`. Builds on #4190/PR #4209 — the conventions section points at the vendored `.kct/CONVENTIONS.md`.

## Changes

- **`.claude/commands/kct/help.md`** (new): kct-house-style frontmatter (`name`/`invocation`/`suggestedModel`/`description`). No-arg overview introspects `.claude/commands/kct/*.md` + `.kct/install-metadata.json` (degrades gracefully if metadata absent), surfaces conventions via `.kct/CONVENTIONS.md` + README, and gives a "start here" pointer. `/kct:help <command>` summarizes one skill. Read-only; no board argument.
- **`.claude/commands/kct/README.md`**: added a `/kct:help` row to the skills table.
- **`scripts/install-kct.sh`**: Stage 4 excludes `help` from `ALL_SKILLS` (like `README`); Stage 6 adds `help.md` to the always-vendored `vendor_file` calls alongside `README.md`. Stage 6c/7 (#4190's territory) untouched.
- **`tests/install/test_install_kct.py`**: help.md vendored unconditionally (incl. under `--skills=ee-review`), recorded in `installed_files` but not `skills_selected`; `--skills=help` rejected as unknown.
- **`tests/test_kct_skills_consumer_generic.py`**: new `META_SKILLS` set runs frontmatter/path-literal/CI-assumption gates against help.md, carves it out of the `<board-path>` per-board contract, and asserts help.md declares itself read-only + takes no board path.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `/kct:help` lists every vendored skill from actual frontmatter (not hardcoded) | ✅ | help.md body reads `ls .claude/commands/kct/*.md` + each frontmatter; no skill list literal in the body |
| `/kct:help <command>` summarizes one skill; unknown → lists installed | ✅ | Detail-mode section specifies summarize-not-reproduce + fallback |
| Strictly read-only (no skill invoke, no board I/O, no writes) | ✅ | Notes section + `test_meta_skill_is_read_only` |
| `install-kct.sh` vendors help.md unconditionally under any `--skills=` | ✅ | dry-run with `--skills=ee-review` shows help.md; `test_skills_filter_selects_named_skill` asserts presence + `tapeout.md` absence |
| help.md excluded from `--skills=` selectable set | ✅ | Stage 4 `[[ "$base" == "help" ]] && continue`; `test_help_is_not_a_selectable_skill` |
| README table gets a `/kct:help` row | ✅ | README edit + `test_readme_indexes_every_new_skill[help]` |
| install test asserts unconditional vendoring (incl. filtered-out) | ✅ | `test_path_install_produces_all_artifacts`, `test_skills_filter_selects_named_skill` |
| consumer-generic frontmatter/house-style coverage without breaking `test_board_path_is_a_parameter` | ✅ | `META_SKILLS` parametrization; per-board contract still `NEW_SKILLS`-only |

## Test Plan

- `uv run pytest tests/install/test_install_kct.py tests/test_kct_skills_consumer_generic.py -q` → 51 passed.
- `shellcheck scripts/install-kct.sh` → clean.
- `ruff check` + `ruff format --check` on both test files → clean.
- `uv run --extra dev python scripts/ci/check_mypy_baseline.py` → 0 new errors (within baseline).
- Manual: `install-kct.sh --dry-run --skills=ee-review --path .` confirms `vendor .claude/commands/kct/help.md` is planned even though only `ee-review` was selected.

Closes #4189