### PR TITLE
fix(sexp): treat backslash as structurally requiring quotes in _must_quote()

### DIFF
--- a/src/kicad_tools/sexp/parser.py
+++ b/src/kicad_tools/sexp/parser.py
@@ -537,15 +537,22 @@ class SExp:
 
         These are values that cannot be represented as a bare S-expression
         token at all — an empty string, or one containing whitespace, parens,
-        or a double-quote character. Such values must always be quoted for
-        correctness, regardless of parse-time bare/quoted state. This is the
-        narrow "genuinely requires quotes" test used by the symmetric bare
-        handling in _format_atom() (issue #4185); it is intentionally distinct
-        from the KiCad-keyword allowlist heuristic in _needs_quoting().
+        a double-quote character, or a backslash. Such values must always be
+        quoted for correctness, regardless of parse-time bare/quoted state.
+        This is the narrow "genuinely requires quotes" test used by the
+        symmetric bare handling in _format_atom() (issue #4185); it is
+        intentionally distinct from the KiCad-keyword allowlist heuristic in
+        _needs_quoting().
+
+        Backslash is included (issue #4213, defense-in-depth follow-on to
+        #4185): a bare token containing a raw backslash is routed into the
+        quoting branch of _format_atom(), whose unconditional
+        ``.replace("\\", "\\\\")`` step doubles it correctly so the emitted
+        quoted form round-trips byte-exact.
         """
         if not s:
             return True
-        return any(c in s for c in ' \t\n\r"()')
+        return any(c in s for c in ' \t\n\r"()\\')
 
     @staticmethod
     def _is_valid_name(s: str) -> bool:

--- a/tests/test_sexp.py
+++ b/tests/test_sexp.py
@@ -533,6 +533,32 @@ class TestSExpSerialization:
         empty = SExp(value="", _originally_bare=True)
         assert empty._format_atom() == '""'
 
+    def test_parsed_bare_backslash_value_forced_quoted(self):
+        """A bare atom containing a raw backslash is forced quoted+escaped.
+
+        Backslash cannot be safely represented as a bare token (issue #4213,
+        defense-in-depth follow-on to #4185): a bare-flagged atom whose value
+        contains a literal backslash must be routed into the quoting branch of
+        _format_atom(), whose unconditional ``.replace("\\", "\\\\")`` step
+        doubles the backslash so the emitted quoted form round-trips byte-exact.
+        Forward slash is intentionally *not* a trigger and stays bare.
+        """
+        # _must_quote() flags any value containing a literal backslash.
+        assert SExp._must_quote("abc\\def") is True
+        assert SExp._must_quote("a\\b\\c") is True
+        # Forward slash is intentionally excluded and must stay bare (#4185).
+        assert SExp._must_quote("my/path") is False
+
+        # A bare-flagged atom with a backslash serializes quoted + escaped.
+        node = SExp(value="abc\\def", _originally_bare=True)
+        assert node._format_atom() == '"abc\\\\def"'
+        # Parsing that emitted form back yields the exact original value.
+        assert parse_string("(field " + node._format_atom() + ")").get_string(0) == "abc\\def"
+
+        # Forward-slash bare atoms remain bare (no over-quoting regression).
+        slash = SExp(value="my/path", _originally_bare=True)
+        assert slash._format_atom() == "my/path"
+
 
 class TestSExpFileIO:
     """Tests for file I/O functions."""

--- a/tests/test_sexp_roundtrip.py
+++ b/tests/test_sexp_roundtrip.py
@@ -140,6 +140,34 @@ class TestSExpRoundTripWithKiCad:
                 f"expected bare ({field} not_allowed) in: {output}"
             )
 
+    def test_bare_backslash_token_roundtrips_quoted_and_escaped(self):
+        """A bare token containing a raw backslash round-trips byte-exact.
+
+        Parsing `(field abc\\def)` yields a bare atom whose value contains a
+        literal backslash. Before issue #4213 the serializer re-emitted it bare
+        and unescaped; with backslash added to _must_quote() it is now forced
+        into the quoting branch, whose unconditional escaping doubles the
+        backslash. The emitted form (`(field "abc\\\\def")`) must re-parse to
+        the identical value, and a second serialize/parse cycle must be a fixed
+        point (byte-exact round-trip).
+        """
+        # Source text: (field abc\def) — a single, unescaped, bare backslash.
+        doc = parse_string("(field abc\\def)")
+        assert doc.get_string(0) == "abc\\def"
+
+        # Serialized output forces quoting and doubles the backslash.
+        output = doc.to_string()
+        assert '(field "abc\\\\def")' in output, (
+            f"bare backslash token must serialize quoted+escaped, got: {output}"
+        )
+
+        # Re-parsing the emitted form yields the exact original value.
+        reparsed = parse_string(output)
+        assert reparsed.get_string(0) == "abc\\def"
+
+        # A second serialize cycle is a fixed point (stable byte-exact).
+        assert reparsed.to_string() == output
+
     @pytest.mark.skipif(KICAD_CLI is None, reason="kicad-cli not installed")
     def test_keepout_board_loads_in_kicad(self, tmp_path):
         """A board carrying a keepout footprint must load after round-trip.


### PR DESCRIPTION
## Summary

Defense-in-depth follow-on to #4185/PR #4212. `SExp._must_quote()` is the structural safety boundary that forces quoting for a parsed-bare atom whose value cannot be represented as a bare token. Its trigger set (`' \t\n\r"()'`) omitted the backslash character, so a bare-parsed token containing a raw backslash (e.g. parsing `(field abc\def)`) was re-emitted bare and unescaped rather than quoted+escaped.

This adds a single character (`\`) to that trigger set. Once a backslash-containing bare atom is routed into the `needs_quote = True` branch of `_format_atom()`, that branch's already-unconditional `.replace("\\", "\\\\")` step doubles the backslash correctly, so the emitted quoted form round-trips byte-exact. No other code changes are required.

This is not a live corruption path today (KiCad only emits backslashes inside already-quoted strings), but it hardens the boundary against a theoretical bare-backslash input.

## Changes

- `src/kicad_tools/sexp/parser.py`: add `\\` (literal backslash) to the character set checked in `SExp._must_quote()`; update its docstring to mention backslash and the composition with `_format_atom()`'s escaping.
- `tests/test_sexp.py`: new `test_parsed_bare_backslash_value_forced_quoted` — asserts `_must_quote()` returns `True` for backslash values, `False` for forward-slash values, and that a bare-flagged backslash atom serializes quoted+escaped and re-parses to the original.
- `tests/test_sexp_roundtrip.py`: new `test_bare_backslash_token_roundtrips_quoted_and_escaped` — parses bare `(field abc\def)`, confirms it emits `(field "abc\\def")`, re-parses to the identical value, and is a serialize fixed point.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `_must_quote()` returns `True` for any string containing a backslash | ✅ | Unit test asserts `SExp._must_quote("abc\def") is True` and `"a\b\c"` |
| Bare-parsed backslash atom serializes quoted+escaped and round-trips | ✅ | `_format_atom()` == `'"abc\\def"'`; re-parse yields `abc\def`; roundtrip test is a fixed point |
| Existing #4185 regression tests pass unmodified | ✅ | `test_sexp.py` + `test_sexp_roundtrip.py` + `test_sexp_parser.py` + `test_sexp_builders.py` all green (241 passed, 5 kicad-cli skips) |
| Forward-slash bare tokens NOT forced to quote | ✅ | `_must_quote("my/path") is False`; `SExp(value="my/path", _originally_bare=True)._format_atom()` == `my/path` |
| `_is_valid_name()` left unchanged | ✅ | Not touched (curator-confirmed dead code, out of scope) |

## Test Plan

- `uv run pytest tests/test_sexp.py tests/test_sexp_roundtrip.py -q` → 92 passed, 5 skipped
- `uv run pytest tests/test_sexp_parser.py tests/test_sexp_builders.py -q` → 149 passed
- `uv run ruff check` + `ruff format --check` on all three files → clean
- `uv run --extra dev python scripts/ci/check_mypy_baseline.py` → 0 new type errors (within baseline)

Closes #4213