### PR TITLE
feat(physics): derive net-class min-width from target current via IPC-2221

### DIFF
--- a/src/kicad_tools/manufacturers/dru_generator.py
+++ b/src/kicad_tools/manufacturers/dru_generator.py
@@ -16,12 +16,18 @@ Usage:
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Sequence
+
 from .base import DesignRules
+
+if TYPE_CHECKING:
+    from kicad_tools.router.rules import NetClassRouting
 
 
 def generate_dru(
     rules: DesignRules,
     manufacturer_name: str = "",
+    net_classes: Sequence[NetClassRouting] | None = None,
 ) -> str:
     """
     Generate KiCad .kicad_dru file content from a DesignRules instance.
@@ -33,6 +39,15 @@ def generate_dru(
     Args:
         rules: DesignRules instance containing manufacturer constraints.
         manufacturer_name: Optional manufacturer name for rule labels.
+        net_classes: Optional sequence of net-class routing configs.  For
+            each class whose ``target_ampacity`` is set, two net-scoped
+            minimum-width rules (external + internal layers) are appended,
+            with the widths derived via IPC-2221 from ``rules.outer_copper_oz``
+            / ``rules.inner_copper_oz`` (see
+            :func:`kicad_tools.physics.ampacity.width_for_current`).  When
+            ``None`` (or when no class sets ``target_ampacity``), the output
+            is byte-for-byte identical to the board-wide rule set --
+            preserving the drift-prevention pass-through contract.
 
     Returns:
         String content of a valid .kicad_dru file.
@@ -123,5 +138,51 @@ def generate_dru(
         f'(rule "Solder Mask Dam{label_suffix}"\n'
         f"  (constraint physical_hole_clearance (min {rules.min_solder_mask_dam_mm}mm)))"
     )
+
+    # --- Ampacity-derived net-scoped minimum trace widths (#4216) ---
+    #
+    # For each net class carrying a target current, emit two net-scoped
+    # min-width rules: one for external copper (F.Cu / B.Cu, k=0.048) and
+    # one for internal copper (all other copper layers, k=0.024).  The
+    # widths come from the IPC-2221 closed-form inversion using the board's
+    # copper weights (outer for external, inner for internal).
+    #
+    # KiCad's custom-rule condition grammar scopes to a net class via the
+    # ``A.NetClass`` token (KiCad 7/8/9 "Custom Design Rules" reference).
+    # These rules are appended only when at least one class sets
+    # ``target_ampacity``; otherwise the output is byte-for-byte identical to
+    # the board-wide rule set above (drift-prevention pass-through).
+    if net_classes:
+        from kicad_tools.physics.ampacity import width_for_current
+
+        for nc in net_classes:
+            if nc.target_ampacity is None:
+                continue
+
+            external_width_mm = width_for_current(
+                nc.target_ampacity,
+                copper_weight_oz=rules.outer_copper_oz,
+                layer="external",
+            )
+            internal_width_mm = width_for_current(
+                nc.target_ampacity,
+                copper_weight_oz=rules.inner_copper_oz,
+                layer="internal",
+            )
+
+            # External copper: front and back layers.
+            lines.append(
+                f'(rule "Ampacity Min Width ({nc.name}, external){label_suffix}"\n'
+                f"  (condition \"A.NetClass == '{nc.name}' && A.Type == 'track'"
+                f" && (A.Layer == 'F.Cu' || A.Layer == 'B.Cu')\")\n"
+                f"  (constraint track_width (min {external_width_mm:.4f}mm)))"
+            )
+            # Internal copper: any track that is not on an external layer.
+            lines.append(
+                f'(rule "Ampacity Min Width ({nc.name}, internal){label_suffix}"\n'
+                f"  (condition \"A.NetClass == '{nc.name}' && A.Type == 'track'"
+                f" && A.Layer != 'F.Cu' && A.Layer != 'B.Cu'\")\n"
+                f"  (constraint track_width (min {internal_width_mm:.4f}mm)))"
+            )
 
     return "\n".join(lines) + "\n"

--- a/src/kicad_tools/physics/__init__.py
+++ b/src/kicad_tools/physics/__init__.py
@@ -50,6 +50,9 @@ Note:
     electromagnetic simulation, use dedicated tools like openEMS or HFSS.
 """
 
+from .ampacity import (
+    width_for_current,
+)
 from .constants import (
     COPPER_1OZ,
     COPPER_2OZ,
@@ -101,6 +104,8 @@ __all__ = [
     "COPPER_1OZ",
     "COPPER_2OZ",
     "copper_thickness_from_oz",
+    # Ampacity (IPC-2221)
+    "width_for_current",
     # Materials
     "DielectricMaterial",
     "FR4_STANDARD",

--- a/src/kicad_tools/physics/ampacity.py
+++ b/src/kicad_tools/physics/ampacity.py
@@ -1,0 +1,110 @@
+"""IPC-2221 ampacity: derive minimum trace width from target current.
+
+This module provides a closed-form inversion of the IPC-2221 empirical
+current-carrying-capacity formula, giving the minimum trace width (mm)
+needed to carry a target current at a given temperature rise and copper
+weight.
+
+Unlike :func:`kicad_tools.physics.TransmissionLine.width_for_impedance`
+(a stackup bisection solver), the ampacity width is a direct closed-form
+computation and does NOT depend on the board stackup or
+:class:`TransmissionLine`.
+
+The IPC-2221 formula relates current to copper cross-sectional area:
+
+    I = k * delta_t_c**0.44 * A**0.725
+
+where
+
+    - I: current in amps
+    - delta_t_c: temperature rise above ambient, in degrees Celsius
+    - A: copper cross-sectional area in mils**2 (1 mil = 0.001 inch)
+    - k = 0.048 for external (outer) copper layers
+    - k = 0.024 for internal copper layers (internal traces shed heat
+      less effectively, so they need much more copper for the same
+      current / temperature rise)
+
+Inverting for the required area given a target current:
+
+    A = (I / (k * delta_t_c**0.44))**(1/0.725)
+
+The area is then converted to a width via the copper thickness (derived
+from the copper weight in oz/ft**2).
+
+Example:
+    >>> from kicad_tools.physics.ampacity import width_for_current
+    >>> # 15 A on a 2 oz external layer at a 10 C rise wants ~6.3 mm.
+    >>> round(width_for_current(15, copper_weight_oz=2, delta_t_c=10), 2)
+    6.29
+"""
+
+from __future__ import annotations
+
+# IPC-2221 empirical constant k, by layer position.
+_K_EXTERNAL = 0.048
+_K_INTERNAL = 0.024
+
+# IPC-2221 exponents.
+_DELTA_T_EXPONENT = 0.44
+_AREA_EXPONENT = 0.725
+
+# Unit conversions.
+_MILS_PER_OZ = 1.378  # 1 oz/ft**2 copper ~= 1.378 mils (~= 0.035 mm) thick
+_MM_PER_MIL = 0.0254  # 1 mil = 0.001 inch = 0.0254 mm
+
+_VALID_LAYERS = ("external", "internal")
+
+
+def width_for_current(
+    current_a: float,
+    copper_weight_oz: float,
+    delta_t_c: float = 10.0,
+    layer: str = "external",
+) -> float:
+    """Derive the minimum trace width (mm) for a target current via IPC-2221.
+
+    Solves the IPC-2221 current-capacity formula
+    ``I = k * delta_t_c**0.44 * A**0.725`` for the copper cross-sectional
+    area ``A`` given a target current ``I``, then converts that area to a
+    trace width using the copper thickness implied by ``copper_weight_oz``.
+
+    Args:
+        current_a: Target current in amps (must be > 0).
+        copper_weight_oz: Copper foil weight in oz/ft**2 (must be > 0).
+            External-layer nets typically use ``DesignRules.outer_copper_oz``;
+            internal-layer nets use ``DesignRules.inner_copper_oz``.
+        delta_t_c: Allowed temperature rise above ambient, in degrees
+            Celsius (must be > 0). Defaults to ``10.0``, the conservative
+            value used by most commercial IPC-2221 calculators.
+        layer: ``"external"`` (k = 0.048) or ``"internal"`` (k = 0.024).
+            Internal layers shed heat less effectively and therefore need
+            a wider trace for the same current / temperature rise.
+
+    Returns:
+        Minimum trace width in millimeters.
+
+    Raises:
+        ValueError: If ``current_a``, ``copper_weight_oz``, or
+            ``delta_t_c`` is non-positive, or if ``layer`` is not one of
+            ``{"external", "internal"}``.
+    """
+    if current_a <= 0:
+        raise ValueError(f"current_a must be positive, got {current_a}")
+    if copper_weight_oz <= 0:
+        raise ValueError(f"copper_weight_oz must be positive, got {copper_weight_oz}")
+    if delta_t_c <= 0:
+        raise ValueError(f"delta_t_c must be positive, got {delta_t_c}")
+    if layer not in _VALID_LAYERS:
+        raise ValueError(f"layer must be one of {_VALID_LAYERS}, got {layer!r}")
+
+    k = _K_EXTERNAL if layer == "external" else _K_INTERNAL
+
+    # Invert IPC-2221 for the required cross-sectional area (mils**2).
+    area_mils2 = (current_a / (k * delta_t_c**_DELTA_T_EXPONENT)) ** (1.0 / _AREA_EXPONENT)
+
+    # Copper thickness for this weight, in mils.
+    thickness_mils = copper_weight_oz * _MILS_PER_OZ
+
+    # width = area / thickness, converted mils -> mm.
+    width_mils = area_mils2 / thickness_mils
+    return float(width_mils * _MM_PER_MIL)

--- a/src/kicad_tools/router/rules.py
+++ b/src/kicad_tools/router/rules.py
@@ -903,6 +903,27 @@ class NetClassRouting:
     literal is used.
     """
 
+    target_ampacity: float | None = None
+    """Target current-carrying capacity in amps (e.g. 15.0 for a 15 A fused line).
+
+    When set, DRU generation (see
+    :func:`kicad_tools.manufacturers.dru_generator.generate_dru`) derives a
+    net-scoped minimum trace-width rule via
+    :func:`kicad_tools.physics.ampacity.width_for_current`, using the board's
+    :attr:`~kicad_tools.manufacturers.base.DesignRules.outer_copper_oz` /
+    ``inner_copper_oz`` and a default 10 C temperature rise (see
+    ``physics/ampacity.py``).  When ``None`` (the default), no net-scoped
+    width rule is emitted for this class -- byte-for-byte pass-through,
+    matching :attr:`target_single_impedance`'s drift-prevention contract.
+
+    Independent of :attr:`target_single_impedance` /
+    :attr:`target_diff_impedance` -- a class may combine an ampacity floor
+    with an impedance target (e.g. a 15 A single-ended power net with a soft
+    impedance target); the DRU generator emits both rules as separate named
+    rules and lets KiCad's rule engine enforce the tightest (max) width where
+    they overlap.
+    """
+
     impedance_tolerance_percent: float = 10.0
     """Allowed deviation (in percent) from the target impedance that the
     DRC :class:`~kicad_tools.validate.rules.impedance.ImpedanceRule` fires
@@ -1143,6 +1164,7 @@ class NetClassRouting:
         - ``diffpair_partner`` (Phase 1B / #2558)
         - ``target_diff_impedance`` (Phase 3K / #2650)
         - ``target_single_impedance`` (Phase 3K / #2650)
+        - ``target_ampacity`` (#4216, Part 1 of #4215)
         - ``intra_pair_clearance`` (Phase 1A / #2557)
         - ``escape_clearance`` (Issue #3371 / P_FP1)
         - ``length_match_group`` / ``length_match_reference`` /
@@ -1189,6 +1211,7 @@ class NetClassRouting:
             "coupled_routing": self.coupled_routing,
             "target_diff_impedance": self.target_diff_impedance,
             "target_single_impedance": self.target_single_impedance,
+            "target_ampacity": self.target_ampacity,
             "impedance_tolerance_percent": self.impedance_tolerance_percent,
             "coupled_continuity_threshold": self.coupled_continuity_threshold,
             "skew_tolerance_mm": self.skew_tolerance_mm,
@@ -1241,6 +1264,7 @@ class NetClassRouting:
             coupled_routing=data.get("coupled_routing", False),
             target_diff_impedance=data.get("target_diff_impedance"),
             target_single_impedance=data.get("target_single_impedance"),
+            target_ampacity=data.get("target_ampacity"),
             impedance_tolerance_percent=data.get("impedance_tolerance_percent", 10.0),
             coupled_continuity_threshold=data.get("coupled_continuity_threshold"),
             skew_tolerance_mm=data.get("skew_tolerance_mm"),

--- a/tests/test_ampacity.py
+++ b/tests/test_ampacity.py
@@ -1,0 +1,110 @@
+"""Tests for IPC-2221 ampacity width derivation (physics/ampacity.py, #4216)."""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.physics import width_for_current as width_for_current_exported
+from kicad_tools.physics.ampacity import width_for_current
+
+
+class TestWidthForCurrentGoldenValues:
+    """Golden numeric checks against curator-verified IPC-2221 results."""
+
+    def test_golden_15a_2oz_external(self):
+        """15 A / 2 oz / 10 C / external -> 6.29 mm (curator-verified golden)."""
+        w = width_for_current(15, copper_weight_oz=2, delta_t_c=10, layer="external")
+        assert w == pytest.approx(6.29, abs=0.05)
+
+    def test_golden_15a_2oz_internal(self):
+        """Internal layer (k=0.024) is much wider than external for the same inputs."""
+        w = width_for_current(15, copper_weight_oz=2, delta_t_c=10, layer="internal")
+        assert w == pytest.approx(16.37, abs=0.05)
+
+    def test_internal_wider_than_external(self):
+        """Sanity: internal layer always needs a wider trace (k=0.024 < 0.048)."""
+        ext = width_for_current(15, copper_weight_oz=2, delta_t_c=10, layer="external")
+        internal = width_for_current(15, copper_weight_oz=2, delta_t_c=10, layer="internal")
+        assert internal > ext
+
+    def test_golden_15a_1oz_external(self):
+        """Thinner copper -> wider trace: 15 A / 1 oz / external ~= 12.585 mm."""
+        w = width_for_current(15, copper_weight_oz=1, delta_t_c=10, layer="external")
+        assert w == pytest.approx(12.585, abs=0.05)
+
+    def test_golden_15a_half_oz_internal(self):
+        """Thin inner copper on an internal layer is impractically wide (~65.48 mm)."""
+        w = width_for_current(15, copper_weight_oz=0.5, delta_t_c=10, layer="internal")
+        assert w == pytest.approx(65.48, abs=0.1)
+
+
+class TestWidthForCurrentBehavior:
+    """Monotonicity and default-argument behavior."""
+
+    def test_default_delta_t_is_10c(self):
+        """Omitting delta_t_c uses the documented 10 C default."""
+        implicit = width_for_current(15, copper_weight_oz=2, layer="external")
+        explicit = width_for_current(15, copper_weight_oz=2, delta_t_c=10.0, layer="external")
+        assert implicit == pytest.approx(explicit)
+
+    def test_default_layer_is_external(self):
+        """Omitting layer uses the external (k=0.048) default."""
+        implicit = width_for_current(15, copper_weight_oz=2)
+        explicit = width_for_current(15, copper_weight_oz=2, layer="external")
+        assert implicit == pytest.approx(explicit)
+
+    def test_higher_current_needs_wider_trace(self):
+        narrow = width_for_current(5, copper_weight_oz=1)
+        wide = width_for_current(20, copper_weight_oz=1)
+        assert wide > narrow
+
+    def test_thicker_copper_needs_narrower_trace(self):
+        thin = width_for_current(15, copper_weight_oz=1)
+        thick = width_for_current(15, copper_weight_oz=2)
+        assert thick < thin
+
+    def test_larger_delta_t_needs_narrower_trace(self):
+        cold = width_for_current(15, copper_weight_oz=2, delta_t_c=10)
+        hot = width_for_current(15, copper_weight_oz=2, delta_t_c=20)
+        assert hot < cold
+
+    def test_returns_positive_float(self):
+        w = width_for_current(1, copper_weight_oz=1)
+        assert isinstance(w, float)
+        assert w > 0
+
+    def test_exported_from_physics_package(self):
+        """The function is re-exported from kicad_tools.physics."""
+        assert width_for_current_exported is width_for_current
+
+
+class TestWidthForCurrentValidation:
+    """Invalid inputs raise ValueError."""
+
+    def test_zero_current_raises(self):
+        with pytest.raises(ValueError, match="current_a"):
+            width_for_current(0, copper_weight_oz=2)
+
+    def test_negative_current_raises(self):
+        with pytest.raises(ValueError, match="current_a"):
+            width_for_current(-5, copper_weight_oz=2)
+
+    def test_zero_copper_weight_raises(self):
+        with pytest.raises(ValueError, match="copper_weight_oz"):
+            width_for_current(15, copper_weight_oz=0)
+
+    def test_negative_copper_weight_raises(self):
+        with pytest.raises(ValueError, match="copper_weight_oz"):
+            width_for_current(15, copper_weight_oz=-1)
+
+    def test_zero_delta_t_raises(self):
+        with pytest.raises(ValueError, match="delta_t_c"):
+            width_for_current(15, copper_weight_oz=2, delta_t_c=0)
+
+    def test_negative_delta_t_raises(self):
+        with pytest.raises(ValueError, match="delta_t_c"):
+            width_for_current(15, copper_weight_oz=2, delta_t_c=-10)
+
+    def test_invalid_layer_raises(self):
+        with pytest.raises(ValueError, match="layer"):
+            width_for_current(15, copper_weight_oz=2, layer="middle")

--- a/tests/test_mfr.py
+++ b/tests/test_mfr.py
@@ -907,3 +907,184 @@ class TestDruGenerator:
 
         actual = (rules_dir / "jlcpcb-2layer-1oz.kicad_dru").read_text()
         assert actual == expected, "Static DRU file does not match dynamic generation"
+
+
+class TestDruGeneratorAmpacity:
+    """Net-scoped ampacity min-width rule emission (#4216, Part 1 of #4215)."""
+
+    def _rules_2oz(self) -> DesignRules:
+        """A 4-layer JLCPCB profile with 2 oz outer copper for a ~6.3 mm width."""
+        profile = get_profile("jlcpcb")
+        rules = profile.get_design_rules(layers=4, copper_oz=2.0)
+        # Force known copper weights so the derived widths are deterministic.
+        rules.outer_copper_oz = 2.0
+        rules.inner_copper_oz = 0.5
+        return rules
+
+    def _fused_net_class(self):
+        from kicad_tools.router.rules import NetClassRouting
+
+        return NetClassRouting(name="FUSED_LINE", target_ampacity=15.0)
+
+    def test_pass_through_when_net_classes_none(self):
+        """net_classes=None -> byte-for-byte identical to the board-wide output."""
+        from kicad_tools.manufacturers.dru_generator import generate_dru
+
+        rules = self._rules_2oz()
+        without = generate_dru(rules, manufacturer_name="JLCPCB")
+        with_none = generate_dru(rules, manufacturer_name="JLCPCB", net_classes=None)
+        assert with_none == without
+
+    def test_pass_through_when_no_target_ampacity(self):
+        """A class with target_ampacity=None emits no ampacity rule (pass-through)."""
+        from kicad_tools.manufacturers.dru_generator import generate_dru
+        from kicad_tools.router.rules import NetClassRouting
+
+        rules = self._rules_2oz()
+        baseline = generate_dru(rules, manufacturer_name="JLCPCB")
+        nc = NetClassRouting(name="PLAIN", target_ampacity=None)
+        with_plain = generate_dru(rules, manufacturer_name="JLCPCB", net_classes=[nc])
+        assert with_plain == baseline
+        assert "Ampacity Min Width" not in with_plain
+
+    def test_ampacity_rules_emitted_external_and_internal(self):
+        """A target_ampacity class emits both external and internal net-scoped rules."""
+        import re
+
+        from kicad_tools.manufacturers.dru_generator import generate_dru
+        from kicad_tools.physics.ampacity import width_for_current
+
+        rules = self._rules_2oz()
+        nc = self._fused_net_class()
+        content = generate_dru(rules, manufacturer_name="JLCPCB", net_classes=[nc])
+
+        # Two new rules exist, both net-scoped to FUSED_LINE.
+        assert '"Ampacity Min Width (FUSED_LINE, external) - JLCPCB"' in content
+        assert '"Ampacity Min Width (FUSED_LINE, internal) - JLCPCB"' in content
+        assert "A.NetClass == 'FUSED_LINE'" in content
+
+        # External condition scopes to the two outer copper layers.
+        assert "(A.Layer == 'F.Cu' || A.Layer == 'B.Cu')" in content
+        # Internal condition excludes the outer copper layers.
+        assert "A.Layer != 'F.Cu' && A.Layer != 'B.Cu'" in content
+
+        # Widths derive from IPC-2221 against the board copper weights.
+        expected_ext = width_for_current(15.0, copper_weight_oz=2.0, layer="external")
+        expected_int = width_for_current(15.0, copper_weight_oz=0.5, layer="internal")
+
+        ext_block = content.split("external) - JLCPCB", 1)[1]
+        ext_match = re.search(r"track_width \(min ([\d.]+)mm\)", ext_block)
+        assert ext_match
+        assert float(ext_match.group(1)) == pytest.approx(expected_ext, abs=0.01)
+
+        int_block = content.split("internal) - JLCPCB", 1)[1]
+        int_match = re.search(r"track_width \(min ([\d.]+)mm\)", int_block)
+        assert int_match
+        assert float(int_match.group(1)) == pytest.approx(expected_int, abs=0.01)
+
+        # The external golden value (2 oz, 15 A, 10 C) is ~6.29 mm.
+        assert float(ext_match.group(1)) == pytest.approx(6.29, abs=0.05)
+
+    def test_ampacity_and_impedance_emit_separate_rules(self):
+        """A class with both target_ampacity and target_single_impedance keeps
+        the ampacity rules separate (not merged) -- per the Out-of-Scope note.
+        """
+        from kicad_tools.manufacturers.dru_generator import generate_dru
+        from kicad_tools.router.rules import NetClassRouting
+
+        rules = self._rules_2oz()
+        nc = NetClassRouting(
+            name="FUSED_LINE",
+            target_ampacity=15.0,
+            target_single_impedance=50.0,
+        )
+        content = generate_dru(rules, manufacturer_name="JLCPCB", net_classes=[nc])
+        # Two (and only two) ampacity rules; the DRU generator does not emit
+        # impedance rules (that lives in the router sizing path), so we only
+        # assert the ampacity pair is present and distinct.
+        assert content.count("Ampacity Min Width (FUSED_LINE") == 2
+
+    def test_multiple_net_classes(self):
+        """Only classes with target_ampacity set produce rules."""
+        from kicad_tools.manufacturers.dru_generator import generate_dru
+        from kicad_tools.router.rules import NetClassRouting
+
+        rules = self._rules_2oz()
+        classes = [
+            NetClassRouting(name="FUSED_LINE", target_ampacity=15.0),
+            NetClassRouting(name="SIGNAL", target_ampacity=None),
+            NetClassRouting(name="MOTOR", target_ampacity=8.0),
+        ]
+        content = generate_dru(rules, manufacturer_name="JLCPCB", net_classes=classes)
+        assert content.count("Ampacity Min Width (FUSED_LINE") == 2
+        assert content.count("Ampacity Min Width (MOTOR") == 2
+        assert "SIGNAL" not in content
+
+    def test_ampacity_dru_accepted_by_kicad_cli(self, tmp_path):
+        """Synthetic round-trip: the net-scoped DRU is accepted by kicad-cli DRC.
+
+        Verifies the ``A.NetClass`` condition token is valid KiCad custom-rule
+        syntax by running ``kicad-cli pcb drc`` against a minimal board with
+        the generated .kicad_dru.  If kicad-cli is unavailable, falls back to
+        asserting the DRU text is well-formed.
+        """
+        import shutil
+        import subprocess
+
+        from kicad_tools.manufacturers.dru_generator import generate_dru
+
+        rules = self._rules_2oz()
+        nc = self._fused_net_class()
+        dru_content = generate_dru(rules, manufacturer_name="JLCPCB", net_classes=[nc])
+
+        kicad_cli = shutil.which("kicad-cli")
+        if kicad_cli is None:
+            # Fallback: assert the rule is well-formed KiCad DRU syntax.
+            assert dru_content.startswith("(version 1)")
+            assert "A.NetClass == 'FUSED_LINE'" in dru_content
+            assert dru_content.count("(rule ") >= 13
+            # Balanced parentheses per rule line group.
+            assert dru_content.count("(") == dru_content.count(")")
+            pytest.skip("kicad-cli not available; asserted DRU text structure only")
+
+        # Minimal 2-layer board with one FUSED_LINE net and a short track so
+        # the DRC engine actually parses and evaluates the rule condition.
+        board = tmp_path / "amp.kicad_pcb"
+        board.write_text(
+            "(kicad_pcb (version 20240108) (generator test)\n"
+            '  (net 0 "")\n'
+            '  (net 1 "FUSED_LINE")\n'
+            '  (net_class FUSED_LINE "" (clearance 0.2) (trace_width 0.25)\n'
+            '    (add_net "FUSED_LINE"))\n'
+            '  (segment (start 10 10) (end 20 10) (width 0.25) (layer "F.Cu") (net 1))\n'
+            ")\n"
+        )
+
+        dru_path = tmp_path / "amp.kicad_dru"
+        dru_path.write_text(dru_content)
+
+        report = tmp_path / "drc.json"
+        result = subprocess.run(
+            [
+                kicad_cli,
+                "pcb",
+                "drc",
+                "--format",
+                "json",
+                "-o",
+                str(report),
+                str(board),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        combined = (result.stdout + result.stdout + result.stderr).lower()
+        # The rule condition must PARSE cleanly -- KiCad reports malformed
+        # rule syntax on stderr/stdout.  A rule violation is fine (exit != 0);
+        # a syntax error is not.
+        for bad in ("unexpected", "syntax error", "expecting", "unrecognized"):
+            assert bad not in combined, (
+                f"kicad-cli reported a rule-syntax problem ({bad!r}) for the "
+                f"net-scoped ampacity DRU:\n{result.stdout}\n{result.stderr}"
+            )

--- a/tests/test_net_class_serialization.py
+++ b/tests/test_net_class_serialization.py
@@ -286,6 +286,7 @@ class TestDriftPrevention:
             "coupled_routing": True,
             "target_diff_impedance": 87.5,
             "target_single_impedance": 47.5,
+            "target_ampacity": 15.0,
             "impedance_tolerance_percent": 7.5,
             "coupled_continuity_threshold": 0.65,
             "skew_tolerance_mm": 0.35,


### PR DESCRIPTION
## Summary

Part 1 of #4215: declare a net's target current (e.g. `FUSED_LINE: 15A`) as a
net-class attribute and DERIVE its minimum trace-width rule from the board's
copper weight via the IPC-2221 empirical formula, instead of hand-picking
widths. Feeds the `.kicad_dru` generator.

Scope is Part 1 ONLY. The ampacity DRC check (#4217) and reinforcement
provisions (#4218) are separate follow-ups.

## Changes

- **NEW `src/kicad_tools/physics/ampacity.py`** — `width_for_current(current_a,
  copper_weight_oz, delta_t_c=10.0, layer="external") -> float` (mm). Closed-form
  inversion of `I = k * dT^0.44 * A^0.725` (k=0.048 external, 0.024 internal),
  converting the required copper cross-section to a width via the copper
  thickness. No stackup/`TransmissionLine` dependency (that solver is bisection;
  this is closed-form). Exported from `kicad_tools.physics`.
- **`src/kicad_tools/router/rules.py`** — `NetClassRouting.target_ampacity:
  float | None = None`, with `to_dict()`/`from_dict()` round-trip mirroring
  `target_single_impedance`. Drift-prevention sentinel map updated in
  `tests/test_net_class_serialization.py`.
- **`src/kicad_tools/manufacturers/dru_generator.py`** — `generate_dru()` gains
  an optional `net_classes` parameter. For each class with `target_ampacity`
  set, emits two net-scoped min-width rules (external + internal) using KiCad's
  `A.NetClass == '<name>'` condition token, widths derived from
  `rules.outer_copper_oz` / `inner_copper_oz`. Byte-for-byte unchanged output
  when `net_classes=None` or no class sets `target_ampacity`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `ampacity.py` with `width_for_current(...) -> float` (mm) | ✅ | New module, exported from `physics/__init__.py` |
| `width_for_current(15, 2, 10, "external") ≈ 6.29 mm` (±0.05) | ✅ | Golden test `test_golden_15a_2oz_external`; computes 6.2926 mm |
| `ValueError` on non-positive current/oz/dT and bad layer | ✅ | `TestWidthForCurrentValidation` (7 cases) |
| Default `delta_t_c=10.0` documented + parameterized | ✅ | Docstring + `test_default_delta_t_is_10c` |
| `NetClassRouting.target_ampacity` + round-trip | ✅ | Field + to/from_dict; `test_net_class_serialization` drift tests pass |
| `generate_dru()` net-scoped ampacity rule (ext+int) | ✅ | `test_ampacity_rules_emitted_external_and_internal` |
| Pass-through when unset / `net_classes=None` | ✅ | `test_pass_through_when_net_classes_none`, `test_pass_through_when_no_target_ampacity` |
| Synthetic `kicad-cli pcb drc` round-trip accepts syntax | ✅ | `test_ampacity_dru_accepted_by_kicad_cli` (ran against kicad-cli 10.0.4, exit 0, no rule-syntax errors) |

## Test Plan

- `uv run pytest tests/test_ampacity.py tests/test_mfr.py::TestDruGeneratorAmpacity
  tests/test_net_class_serialization.py` — all pass.
- Golden IPC-2221 values match the curator's verified numbers exactly:
  15A/2oz/10C external = 6.2926 mm, internal = 16.370 mm, 1oz external = 12.585 mm,
  0.5oz internal = 65.479 mm.
- `kicad-cli pcb drc` round-trip confirms `A.NetClass == 'FUSED_LINE'` is valid
  KiCad 10 custom-rule syntax (exit 0; only the expected malformed-outline /
  unconnected-track violations on the minimal synthetic board).
- `ruff check` + `ruff format --check` clean; `check_mypy_baseline.py` reports 0
  new errors.

## Deferred (noted per spec)

CLI plumbing to source a real net-class map into `mfr.py` / `fab_rules_cmd.py`
call sites is intentionally NOT included — `generate_dru(net_classes=...)` lands
as a library-level capability exercised directly by tests, per the issue's
explicit "acceptable fast-follow" note. Callers still invoke `generate_dru(rules,
manufacturer_name=...)` unchanged (byte-for-byte identical output).

Closes #4216