### PR TITLE
fix(router): unify seg-seg finalize gate + post-optimize backstop for different-net shorts

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -936,6 +936,41 @@ def _enforce_connectivity_invariant_or_exit(
         sys.exit(6)
 
 
+def _finalize_committed_copper_or_demote(
+    router: "Autorouter",
+    *,
+    quiet: bool = False,
+) -> None:
+    """Post-optimize/post-nudge different-net-short backstop (Issue #4208 / Unit 3).
+
+    The trace optimizer and DRC-nudge passes run AFTER the negotiated
+    finalize demote (Unit 1/2).  In an **rtree-less** environment the
+    optimizer's :class:`GridCollisionChecker` fallback permits crossing an
+    already-overused foreign cell, so optimize can introduce a cross-net
+    crossing the pre-optimize finalize gate never saw.  This re-runs the
+    Unit-2 seg-seg finalize gate over the CURRENT committed copper
+    (reconstructed from ``router.routes``) and demotes any net that became
+    a short.  A no-op in the common case (clean state / rtree present) --
+    run unconditionally (no ``has_overflow`` / rtree probe) because the
+    whole point is defense-in-depth that does not need to know which
+    collision checker ran.
+
+    Factored into one shared helper called from all four optimize+nudge
+    call sites (``route_with_layer_escalation``,
+    ``route_with_rule_relaxation``, ``route_with_combined_escalation``, and
+    the base ``main()`` path) rather than copy-pasted, mirroring the
+    existing ``_enforce_connectivity_invariant_or_exit`` shared-helper
+    pattern.
+    """
+    demoted = router.revalidate_committed_copper_or_demote()
+    if demoted and not quiet:
+        print(
+            f"  ⚠ Post-optimize backstop demoted {len(demoted)} net(s) whose "
+            f"copper became a cross-net short after optimize/nudge: "
+            f"{sorted(demoted)}"
+        )
+
+
 def _make_checkpoint_callback(
     pcb_path: Path,
     output_path: Path,
@@ -4442,6 +4477,12 @@ def route_with_layer_escalation(
             quiet=quiet,
         )
 
+        # Issue #4208 (Unit 3): re-run the Unit-2 seg-seg finalize gate
+        # over the post-optimize/post-nudge copper.  An rtree-less
+        # optimizer can introduce a cross-net crossing the pre-optimize
+        # finalize gate never saw; demote it before the canonical write.
+        _finalize_committed_copper_or_demote(final_result.router, quiet=quiet)
+
     # Finalize: cleanup -> sexp -> stats (canonical ordering)
     _final_multi_pad_ids = {n for n, p in final_result.router.nets.items() if n > 0 and len(p) >= 2}
     route_sexp, final_stats, _cleanup_stats = _finalize_routes(
@@ -5104,6 +5145,12 @@ def route_with_rule_relaxation(
             args=args,
             quiet=quiet,
         )
+
+        # Issue #4208 (Unit 3): re-run the Unit-2 seg-seg finalize gate
+        # over the post-optimize/post-nudge copper.  An rtree-less
+        # optimizer can introduce a cross-net crossing the pre-optimize
+        # finalize gate never saw; demote it before the canonical write.
+        _finalize_committed_copper_or_demote(final_result.router, quiet=quiet)
 
     # Finalize: cleanup -> sexp -> stats (canonical ordering)
     _final_multi_pad_ids = {n for n, p in final_result.router.nets.items() if n > 0 and len(p) >= 2}
@@ -7287,6 +7334,12 @@ def route_with_combined_escalation(
             args=args,
             quiet=quiet,
         )
+
+        # Issue #4208 (Unit 3): re-run the Unit-2 seg-seg finalize gate
+        # over the post-optimize/post-nudge copper.  An rtree-less
+        # optimizer can introduce a cross-net crossing the pre-optimize
+        # finalize gate never saw; demote it before the canonical write.
+        _finalize_committed_copper_or_demote(final_result.router, quiet=quiet)
 
     # Finalize: cleanup -> sexp -> stats (canonical ordering)
     _final_multi_pad_ids = {n for n, p in final_result.router.nets.items() if n > 0 and len(p) >= 2}
@@ -10795,6 +10848,12 @@ def main(argv: list[str] | None = None) -> int:
             args=args,
             quiet=quiet,
         )
+
+        # Issue #4208 (Unit 3): re-run the Unit-2 seg-seg finalize gate
+        # over the post-optimize/post-nudge copper.  An rtree-less
+        # optimizer can introduce a cross-net crossing the pre-optimize
+        # finalize gate never saw; demote it before the canonical write.
+        _finalize_committed_copper_or_demote(router, quiet=quiet)
 
         # Get post-optimization statistics
         post_segments = sum(len(r.segments) for r in router.routes)

--- a/src/kicad_tools/router/algorithms/__init__.py
+++ b/src/kicad_tools/router/algorithms/__init__.py
@@ -29,6 +29,7 @@ from .negotiated import (
     calculate_congestion_tuned_params,
     calculate_history_increment,
     calculate_present_cost,
+    demote_seg_seg_finalize,
     derive_iter_per_net_cap,
     derive_per_net_cap,
     detect_oscillation,
@@ -70,5 +71,6 @@ __all__ = [
     "detect_oscillation",
     "detect_ripup_stagnation",
     "select_seg_seg_demotion_nets",
+    "demote_seg_seg_finalize",
     "should_terminate_early",
 ]

--- a/src/kicad_tools/router/algorithms/negotiated.py
+++ b/src/kicad_tools/router/algorithms/negotiated.py
@@ -334,6 +334,89 @@ def select_seg_seg_demotion_nets(
     return sorted(demoted)
 
 
+def demote_seg_seg_finalize(
+    net_routes: dict[int, list[Route]],
+    neg_router: NegotiatedRouter,
+    grid: RoutingGrid,
+    self_routes: list[Route],
+    *,
+    trace_clearance: float,
+    extra_routes: list[Route] | None = None,
+    copper_overlap_only: bool = False,
+) -> tuple[list[int], list[tuple[int, int]]]:
+    """Detect + demote nets whose committed copper is a cross-net seg-seg short.
+
+    Issue #4208 (Unit 2): the single shared seg-seg finalize gate used by
+    BOTH :meth:`core.Autorouter._demote_seg_seg_overlap_nets` and
+    :meth:`two_phase.TwoPhaseRouter._detailed_negotiated`, replacing the
+    two hand-synced copies that previously drifted apart (the rescue gate
+    was never widened to the Unit-1 full threshold; this consolidation
+    prevents that class of drift).
+
+    Runs :meth:`NegotiatedRouter.find_segment_segment_violation_pairs`
+    over the committed ``net_routes`` (plus non-rippable ``extra_routes``
+    as foreign obstacles), selects the greedy vertex-cover victim set over
+    the demotable (committed) nets, and demotes each victim in place:
+    every route is unmarked from ``grid`` (usage + envelope) and removed
+    from ``self_routes``, and ``net_routes[victim]`` is reset to ``[]``.
+
+    The M3 escape-infra case is surfaced separately: pairs where BOTH
+    sides are non-rippable escape stubs are collected via
+    ``report_non_rippable_pairs=True`` but are NOT demotable (neither net
+    is in ``demotable``), so they are returned to the caller as a
+    routing-quality signal rather than silently shipped as a short.
+
+    Args:
+        net_routes: Mapping of net id -> committed routes (mutated:
+            demoted nets reset to ``[]``).
+        neg_router: Negotiated router owning the pair-detection engine.
+        grid: The routing grid the victims' copper is unmarked from.
+        self_routes: The owner's ``self.routes`` list (mutated: victim
+            routes removed).
+        trace_clearance: Manufacturer minimum copper-to-copper clearance.
+        extra_routes: Non-rippable escape-phase routes joined into the
+            foreign universe.
+        copper_overlap_only: When ``False`` (the finalize default) use the
+            FULL DRC SHORT threshold; when ``True`` use the polygon-overlap
+            threshold (the in-loop / pre-repair position).
+
+    Returns:
+        ``(victims, non_rippable_pairs)`` where ``victims`` is the sorted
+        list of demoted net ids (empty in the common clean case) and
+        ``non_rippable_pairs`` is the sorted list of both-non-rippable
+        crossing pairs the greedy cover could not resolve (M3 signal;
+        empty in the common case).
+    """
+    all_pairs = neg_router.find_segment_segment_violation_pairs(
+        net_routes,
+        trace_clearance=trace_clearance,
+        extra_routes=extra_routes,
+        copper_overlap_only=copper_overlap_only,
+        report_non_rippable_pairs=True,
+    )
+    if not all_pairs:
+        return [], []
+
+    demotable = {net for net, routes in net_routes.items() if routes}
+    # M3: pairs where neither side is demotable (both non-rippable escape
+    # infra) survive the greedy cover; surface them as a signal.
+    non_rippable_pairs = [
+        pair for pair in all_pairs if pair[0] not in demotable and pair[1] not in demotable
+    ]
+    victims = select_seg_seg_demotion_nets(all_pairs, demotable)
+    if not victims:
+        return [], non_rippable_pairs
+
+    for net in victims:
+        for route in net_routes.get(net, []):
+            grid.unmark_route_usage(route)
+            grid.unmark_route(route)
+            if route in self_routes:
+                self_routes.remove(route)
+        net_routes[net] = []
+    return victims, non_rippable_pairs
+
+
 # =========================================================================
 # Adaptive Parameter Functions (Issue #633)
 # =========================================================================
@@ -1966,6 +2049,7 @@ class NegotiatedRouter:
         trace_clearance: float,
         extra_routes: list[Route] | None = None,
         copper_overlap_only: bool = False,
+        report_non_rippable_pairs: bool = False,
     ) -> list[tuple[int, int]]:
         """Find cross-net same-layer segment pairs that violate clearance.
 
@@ -1996,6 +2080,19 @@ class NegotiatedRouter:
         segments is skipped (escape infra is non-rippable; nothing the
         negotiated loop can do about it here).
 
+        Issue #4208 (Unit 2 -- M3): the both-non-rippable skip means a
+        genuine cross-net crossing between two escape stubs (both
+        ``rippable=False``) never enters the ``pairs`` set, so it is
+        invisible to the demote/rescue consumers and ships as a silent
+        short.  ``report_non_rippable_pairs=True`` includes such pairs
+        in the result so the unified finalize gate can SURFACE them as a
+        routing-quality failure (there is no demotable victim -- the net
+        is honestly reported unrouted rather than committed as a short).
+        The greedy vertex cover naturally skips them (neither member is
+        in the ``demotable`` set), so callers that do not want the
+        signal leave the flag at its ``False`` default and observe no
+        behaviour change.
+
         Performance: segments are bucketed per layer, sorted by
         ``min_x`` and swept -- the inner loop breaks as soon as the
         partner's ``min_x`` exceeds the current segment's reach
@@ -2010,6 +2107,10 @@ class NegotiatedRouter:
                 join the foreign universe but are not rippable.
             copper_overlap_only: When True, only report pairs whose
                 copper physically overlaps (see above).
+            report_non_rippable_pairs: When True, also report pairs
+                where BOTH sides are non-rippable escape infra (Issue
+                #4208 / M3); default False preserves the historical
+                skip.
 
         Returns:
             Sorted list of unique ``(net_lo, net_hi)`` tuples with
@@ -2074,8 +2175,8 @@ class NegotiatedRouter:
                         break  # Sorted by min_x -- no later partner can hit.
                     if a[5] == b[5]:
                         continue  # Same net.
-                    if not a[7] and not b[7]:
-                        continue  # Both non-rippable escape infra.
+                    if not a[7] and not b[7] and not report_non_rippable_pairs:
+                        continue  # Both non-rippable escape infra (M3 skip).
                     pair_key = (a[5], b[5]) if a[5] < b[5] else (b[5], a[5])
                     if pair_key in pairs:
                         continue

--- a/src/kicad_tools/router/algorithms/two_phase.py
+++ b/src/kicad_tools/router/algorithms/two_phase.py
@@ -1265,7 +1265,13 @@ class TwoPhaseRouter:
             )
         # M3: cross-net crossing between two non-rippable escape stubs has
         # no demotable victim -- surface it rather than ship a silent short.
+        # Exclude diff-pair partners: a legitimately-coupled pair runs
+        # sub-clearance by design and is adjudicated by the intra-pair
+        # clearance path, not treated as a cross-net short (mirrors core.py).
+        _partner_of = getattr(self.router, "_diff_pair_partner_net", None)
         for _a, _b in _non_rippable_pairs:
+            if _partner_of is not None and _partner_of(_a) == _b:
+                continue
             flush_print(
                 f"  ⚠ Cross-net crossing between non-rippable escape infra: "
                 f"{self.net_names.get(_a, f'Net_{_a}')} vs "

--- a/src/kicad_tools/router/algorithms/two_phase.py
+++ b/src/kicad_tools/router/algorithms/two_phase.py
@@ -517,8 +517,8 @@ class TwoPhaseRouter:
         """
         from ..algorithms import NegotiatedRouter
         from ..algorithms.negotiated import (
+            demote_seg_seg_finalize,
             detect_ripup_stagnation,
-            select_seg_seg_demotion_nets,
             should_terminate_early,
         )
 
@@ -1244,28 +1244,34 @@ class TwoPhaseRouter:
         # the ``finalize=True`` path in ``core._demote_seg_seg_overlap_nets``.
         # The wide threshold MUST stay out of the negotiation loop, where
         # transient sub-clearance is expected and repaired by iteration.
-        _overlap_pairs = neg_router.find_segment_segment_violation_pairs(
+        # Issue #4208 (Unit 2): delegate to the single shared seg-seg
+        # finalize gate so this inline block and ``core``'s finalize demote
+        # cannot drift apart (the drift is exactly how the rescue gate was
+        # left on the old overlap-only threshold across Unit 1).
+        _victims, _non_rippable_pairs = demote_seg_seg_finalize(
             net_routes,
+            neg_router,
+            self.grid,
+            self.routes,
             trace_clearance=self.rules.trace_clearance,
             extra_routes=self._collect_extra_routes_for_revalidation(net_routes),
             copper_overlap_only=False,
         )
-        if _overlap_pairs:
-            _demotable = {n for n, r in net_routes.items() if r}
-            _victims = select_seg_seg_demotion_nets(_overlap_pairs, _demotable)
-            if _victims:
-                for _net in _victims:
-                    for _route in net_routes.get(_net, []):
-                        self.grid.unmark_route_usage(_route)
-                        self.grid.unmark_route(_route)
-                        if _route in self.routes:
-                            self.routes.remove(_route)
-                    net_routes[_net] = []
-                _victim_names = [self.net_names.get(n, f"Net_{n}") for n in _victims]
-                flush_print(
-                    f"  ⚠ Demoted {len(_victims)} net(s) with cross-net "
-                    f"shorting copper to unrouted: {', '.join(_victim_names)}"
-                )
+        if _victims:
+            _victim_names = [self.net_names.get(n, f"Net_{n}") for n in _victims]
+            flush_print(
+                f"  ⚠ Demoted {len(_victims)} net(s) with cross-net "
+                f"shorting copper to unrouted: {', '.join(_victim_names)}"
+            )
+        # M3: cross-net crossing between two non-rippable escape stubs has
+        # no demotable victim -- surface it rather than ship a silent short.
+        for _a, _b in _non_rippable_pairs:
+            flush_print(
+                f"  ⚠ Cross-net crossing between non-rippable escape infra: "
+                f"{self.net_names.get(_a, f'Net_{_a}')} vs "
+                f"{self.net_names.get(_b, f'Net_{_b}')} -- neither net "
+                f"demotable; reported as a routing failure (M3, #4208)"
+            )
 
         # Issue #2597: Surface the iteration-loop exit reason to the caller
         # so the progress-callback status string can distinguish between

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -47,6 +47,7 @@ from .algorithms import (
     calculate_congestion_tuned_params,
     calculate_history_increment,
     calculate_present_cost,
+    demote_seg_seg_finalize,
     derive_iter_per_net_cap,
     derive_per_net_cap,
     detect_oscillation,
@@ -362,6 +363,7 @@ def _format_pad_ref(pad: Pad) -> str:
 # so the two-phase detailed loop can share it without a circular import;
 # re-bound here for the Autorouter call sites and existing tests.
 _select_seg_seg_demotion_nets = select_seg_seg_demotion_nets
+_demote_seg_seg_finalize = demote_seg_seg_finalize
 
 
 def _should_flush_oscillation_msgs(
@@ -11258,27 +11260,34 @@ class Autorouter:
             already overlap-free, the common case).
         """
         extra = self._collect_extra_routes_for_revalidation(net_routes)
-        overlap_pairs = neg_router.find_segment_segment_violation_pairs(
+        # Issue #4208 (Unit 2): delegate to the single shared seg-seg
+        # finalize gate so ``core`` and ``two_phase`` cannot drift apart.
+        victims, non_rippable_pairs = _demote_seg_seg_finalize(
             net_routes,
+            neg_router,
+            self.grid,
+            self.routes,
             trace_clearance=self.rules.trace_clearance,
             extra_routes=extra,
             copper_overlap_only=not finalize,
         )
-        if not overlap_pairs:
-            return []
-
-        demotable = {net for net, routes in net_routes.items() if routes}
-        victims = _select_seg_seg_demotion_nets(overlap_pairs, demotable)
-        if not victims:
-            return []
-
-        for net in victims:
-            for route in net_routes.get(net, []):
-                self.grid.unmark_route_usage(route)
-                self.grid.unmark_route(route)
-                if route in self.routes:
-                    self.routes.remove(route)
-            net_routes[net] = []
+        # M3: a cross-net crossing between two non-rippable escape stubs
+        # has no demotable victim (the greedy cover skips it) -- surface
+        # it as a routing-quality failure instead of shipping a silent
+        # short.  Only meaningful at finalize (the wide threshold).
+        # Exclude diff-pair partners: a legitimately-coupled pair runs
+        # sub-clearance by design and is adjudicated by the intra-pair
+        # clearance path, not treated as a cross-net short.
+        if finalize and non_rippable_pairs:
+            for a, b in non_rippable_pairs:
+                if self._diff_pair_partner_net(a) == b:
+                    continue
+                flush_print(
+                    f"\n  ⚠ Cross-net crossing between non-rippable escape "
+                    f"infra: {self.net_names.get(a, f'Net_{a}')} vs "
+                    f"{self.net_names.get(b, f'Net_{b}')} -- neither net is "
+                    f"demotable; reported as a routing failure (M3, #4208)"
+                )
         return victims
 
     def _demote_pad_clearance_violation_nets(
@@ -11954,12 +11963,14 @@ class Autorouter:
         already trusts as "blocking":
 
         * :meth:`NegotiatedRouter.find_segment_segment_violation_pairs`
-          (``copper_overlap_only=True``) -- the rescued net's copper
-          physically overlaps a FOREIGN net's copper (unmanufacturable
-          short; mirrors :meth:`_demote_seg_seg_overlap_nets`).  A negative
-          within-pair coupling clearance (the board-07 mode) is a physical
-          overlap between the two diff-pair legs -- distinct nets -- so it
-          is caught here.
+          (``copper_overlap_only=False`` -- Issue #4208 widened this from
+          the old overlap-only threshold, closing the live gap where a
+          sub-clearance short shipped through the rescue gate) -- the
+          rescued net's copper shorts a FOREIGN net's copper at the FULL
+          DRC threshold, mirroring the Unit-1 finalize demote in
+          :meth:`_demote_seg_seg_overlap_nets`.  The rescued leg vs its
+          own diff-pair partner is excluded here (they run close by
+          design) and adjudicated by the intra-pair check below instead.
         * :meth:`RoutingGrid.worst_segment_pad_deficit` /
           :meth:`RoutingGrid.worst_via_pad_deficit` -- copper vs a foreign
           pad beyond nudge reach (mirrors
@@ -11999,21 +12010,37 @@ class Autorouter:
         pitches = self.component_pitches
         own_refs = {ref for ref, _pin in self.nets.get(net, [])}
 
-        # --- Segment-vs-foreign-copper physical overlap (mirrors #3433) ---
-        # Restrict the seg-seg pair scan to the rescued net vs the rest of the
-        # committed universe.  ``copper_overlap_only=True`` fires only on
-        # physical overlap (negative edge-to-edge clearance), so it never
-        # false-positives on a legitimately-coupled diff-pair near-miss; a
-        # NEGATIVE within-pair coupling clearance (board-07) IS an overlap and
-        # is caught here.
+        # --- Segment-vs-foreign-copper clearance short (mirrors #3433) ---
+        # Restrict the seg-seg pair scan to the rescued net vs the rest of
+        # the committed universe.  Issue #4208 (Unit 2, the live gap): this
+        # gate historically used ``copper_overlap_only=True`` (polygon
+        # overlap only), so a rescued net that shipped a sub-clearance
+        # short (positive edge gap but ``< trace_clearance`` -- a real
+        # ``kicad-cli SHORT``) passed the rescue gate uncaught, even after
+        # Unit-1 widened the finalize demote to the FULL DRC threshold.
+        # Use ``copper_overlap_only=False`` here so the rescue gate is at
+        # least as strict as the finalize demote it mirrors.
+        #
+        # Diff-pair carve-out: the wide threshold would flag a legitimately
+        # coupled diff-pair pair (the rescued leg vs its partner, which run
+        # close by design) as a cross-net short.  The dedicated per-pair
+        # intra-clearance check below (``_rescued_leg_breaks_intra_pair_clearance``)
+        # is the authority for that exact pair with the correct
+        # ``effective_intra_pair_clearance()`` threshold, so exclude the
+        # ``(net, partner)`` pair here and let that check adjudicate it.
         extra = self._collect_extra_routes_for_revalidation(net_routes)
         overlap_pairs = neg_router.find_segment_segment_violation_pairs(
             net_routes,
             trace_clearance=self.rules.trace_clearance,
             extra_routes=extra,
-            copper_overlap_only=True,
+            copper_overlap_only=False,
         )
-        if any(net in pair for pair in overlap_pairs):
+        partner_net = self._diff_pair_partner_net(net)
+        for pair in overlap_pairs:
+            if net not in pair:
+                continue
+            if partner_net is not None and partner_net in pair:
+                continue  # Partner leg: adjudicated by the intra-pair check.
             return True
 
         # --- Copper-vs-foreign-pad clearance beyond nudge reach (#3545/#3566) ---
@@ -12058,6 +12085,26 @@ class Autorouter:
 
         return False
 
+    def _diff_pair_partner_net(self, net: int) -> int | None:
+        """Return the diff-pair partner net id of ``net``, or ``None``.
+
+        Issue #4208 (Unit 2): shared partner-resolution used by both the
+        rescue gate's diff-pair carve-out (excluding the partner pair from
+        the widened seg-seg short scan) and
+        :meth:`_rescued_leg_breaks_intra_pair_clearance` (adjudicating that
+        exact pair with the per-pair intra-clearance threshold).
+        """
+        net_name = self.net_names.get(net)
+        if not net_name:
+            return None
+        partner_name = self.get_diff_pair_map().get(net_name)
+        if not partner_name:
+            return None
+        for nid, nname in self.net_names.items():
+            if nname == partner_name:
+                return nid
+        return None
+
     def _rescued_leg_breaks_intra_pair_clearance(
         self,
         net: int,
@@ -12079,17 +12126,7 @@ class Autorouter:
         if not net_name:
             return False
 
-        pair_map = self.get_diff_pair_map()
-        partner_name = pair_map.get(net_name)
-        if not partner_name:
-            return False
-
-        # Resolve the partner net id (reverse the net_names map).
-        partner_net: int | None = None
-        for nid, nname in self.net_names.items():
-            if nname == partner_name:
-                partner_net = nid
-                break
+        partner_net = self._diff_pair_partner_net(net)
         if partner_net is None:
             return False
 
@@ -12874,6 +12911,46 @@ class Autorouter:
         for route in self.routes:
             net_routes.setdefault(route.net, []).append(route)
         return net_routes
+
+    def revalidate_committed_copper_or_demote(self) -> list[int]:
+        """Post-optimize/post-nudge finalize backstop (Issue #4208 / Unit 3).
+
+        The trace optimizer and DRC-nudge passes run in ``route_cmd.py``
+        AFTER the negotiated finalize demote (Unit 1/2) has already run.
+        They mutate committed copper, and in an **rtree-less** environment
+        the optimizer's :class:`GridCollisionChecker` fallback permits a
+        route through an already-overused foreign cell
+        (``collision.py`` ``ignore_overflow`` branch), so optimize can
+        introduce a cross-net crossing that the pre-optimize finalize gate
+        never saw.  With ``rtree`` present the exact
+        :class:`VectorCollisionChecker` prevents this, but it can itself
+        fall back to the grid checker per-layer -- so this backstop is
+        genuine belt-and-suspenders, not purely an rtree-less concern.
+
+        Reconstructs ``net_routes`` from :attr:`routes` via
+        :meth:`_build_net_routes_map` (the Autorouter does not persist
+        ``net_routes`` on ``self`` after routing) and re-runs the SAME
+        Unit-2 seg-seg finalize gate (``finalize=True``, full DRC SHORT
+        threshold).  Any net whose copper became a cross-net short after
+        optimize/nudge is demoted (grid unmarked, routes removed) rather
+        than shipped.  A no-op in the common case (clean state / rtree
+        present), matching the architect's cost model (O(segments),
+        negligible vs. a multi-second route).
+
+        Returns:
+            Sorted list of demoted net ids (empty in the common case).
+        """
+        if not self.routes:
+            return []
+        net_routes = self._build_net_routes_map()
+        neg_router = NegotiatedRouter(
+            self.grid,
+            self.router,  # type: ignore[arg-type]
+            self.rules,
+            self.net_class_map,
+            congestion_estimator=self._ensure_congestion_estimator(),
+        )
+        return self._demote_seg_seg_overlap_nets(net_routes, neg_router, finalize=True)
 
     def route_all_advanced(
         self,

--- a/tests/router/test_optimizer_backstop.py
+++ b/tests/router/test_optimizer_backstop.py
@@ -1,0 +1,155 @@
+"""Tests for the post-optimize/post-nudge re-validation backstop (Issue #4208 / Unit 3).
+
+M4 mechanism (``src/kicad_tools/router/optimizer/collision.py``): the
+``GridCollisionChecker`` fallback's ``ignore_overflow`` branch permits a
+route through an already-overused foreign cell, whereas the rtree-backed
+``VectorCollisionChecker`` does an unconditional exact seg-seg check that
+does not.  So in an **rtree-less** environment the trace optimizer can
+introduce a cross-net crossing AFTER the negotiated finalize demote
+(Unit 1/2) has already run -- the pre-optimize gate never saw it.
+
+Unit 3 adds a backstop in ``route_cmd.py`` that re-runs the Unit-2 seg-seg
+finalize gate over the CURRENT committed copper (reconstructed from
+``router.routes`` via ``_build_net_routes_map``), demoting any net whose
+copper became a short.  These tests exercise the backstop directly by
+simulating the crossing the rtree-less optimizer would have introduced,
+rather than relying on a full route pipeline to land on the fragile
+overflow-tolerant path.
+"""
+
+from __future__ import annotations
+
+from kicad_tools.cli.route_cmd import _finalize_committed_copper_or_demote
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.primitives import Route, Segment
+from kicad_tools.router.rules import DesignRules
+
+
+def _make_rules() -> DesignRules:
+    return DesignRules(
+        trace_width=0.2,
+        trace_clearance=0.15,
+        via_drill=0.3,
+        via_diameter=0.6,
+        via_clearance=0.15,
+        grid_resolution=0.1,
+    )
+
+
+def _make_autorouter() -> Autorouter:
+    return Autorouter(
+        width=20.0,
+        height=20.0,
+        origin_x=0.0,
+        origin_y=0.0,
+        rules=_make_rules(),
+        layer_stack=LayerStack.two_layer(),
+    )
+
+
+def _seg(x1, y1, x2, y2, net):
+    return Segment(x1=x1, y1=y1, x2=x2, y2=y2, width=0.2, layer=Layer.F_CU, net=net)
+
+
+def _route(net, segs, name):
+    return Route(net=net, net_name=name, segments=segs, vias=[])
+
+
+def _commit(ar: Autorouter, route: Route) -> None:
+    ar.grid.mark_route(route)
+    ar.grid.mark_route_usage(route)
+    ar.routes.append(route)
+
+
+class TestRevalidateCommittedCopper:
+    """Router-level backstop: ``revalidate_committed_copper_or_demote``."""
+
+    def test_clean_board_is_noop(self):
+        """No crossing -> no demotion (the common rtree-present case)."""
+        ar = _make_autorouter()
+        r1 = _route(1, [_seg(2.0, 5.0, 12.0, 5.0, 1)], "NETA")
+        r2 = _route(2, [_seg(2.0, 10.0, 12.0, 10.0, 2)], "NETB")
+        for r in (r1, r2):
+            _commit(ar, r)
+
+        assert ar.revalidate_committed_copper_or_demote() == []
+        assert r1 in ar.routes and r2 in ar.routes
+
+    def test_optimizer_introduced_crossing_is_demoted(self):
+        """Simulate an rtree-less optimizer crossing: two committed nets
+        end up physically overlapping on the same layer.  The backstop
+        re-runs the finalize gate and demotes the greedy-cover victim."""
+        ar = _make_autorouter()
+        # Net 1 spans the board; the optimizer "straightened" net 2 across
+        # it, landing net 2's copper on top of net 1 (physical overlap).
+        r1 = _route(1, [_seg(2.0, 5.0, 12.0, 5.0, 1)], "NETA")
+        r2 = _route(2, [_seg(4.0, 5.0, 10.0, 5.0, 2)], "NETB")
+        r3 = _route(3, [_seg(2.0, 12.0, 12.0, 12.0, 3)], "CLEAN")
+        for r in (r1, r2, r3):
+            _commit(ar, r)
+
+        demoted = ar.revalidate_committed_copper_or_demote()
+        assert demoted == [1]  # greedy cover picks the hub (lowest id on tie)
+        # Demoted net's copper is removed from routes; clean net untouched.
+        assert r1 not in ar.routes
+        assert r2 in ar.routes and r3 in ar.routes
+
+    def test_sub_clearance_crossing_demoted_full_threshold(self):
+        """A positive-gap-but-sub-clearance short (0.106mm < 0.15mm) is
+        caught -- the backstop uses the FULL DRC threshold, not just
+        polygon overlap, matching the Unit-2 finalize gate."""
+        ar = _make_autorouter()
+        r1 = _route(1, [_seg(2.0, 5.0, 12.0, 5.0, 1)], "NETA")
+        # dy 0.306 -> edge gap 0.106mm: positive, but sub-clearance.
+        r2 = _route(2, [_seg(2.0, 5.306, 12.0, 5.306, 2)], "NETB")
+        for r in (r1, r2):
+            _commit(ar, r)
+
+        demoted = ar.revalidate_committed_copper_or_demote()
+        assert len(demoted) == 1
+        assert demoted[0] in (1, 2)
+
+    def test_empty_routes_is_noop(self):
+        ar = _make_autorouter()
+        assert ar.revalidate_committed_copper_or_demote() == []
+
+
+class TestCliBackstopHelper:
+    """The shared ``route_cmd`` helper called from all four optimize+nudge
+    call sites."""
+
+    def test_helper_demotes_and_reports(self, capsys):
+        ar = _make_autorouter()
+        r1 = _route(1, [_seg(2.0, 5.0, 12.0, 5.0, 1)], "NETA")
+        r2 = _route(2, [_seg(4.0, 5.0, 10.0, 5.0, 2)], "NETB")
+        for r in (r1, r2):
+            _commit(ar, r)
+
+        _finalize_committed_copper_or_demote(ar, quiet=False)
+
+        out = capsys.readouterr().out
+        assert "Post-optimize backstop demoted" in out
+        assert r1 not in ar.routes  # the short was demoted
+
+    def test_helper_quiet_suppresses_output(self, capsys):
+        ar = _make_autorouter()
+        r1 = _route(1, [_seg(2.0, 5.0, 12.0, 5.0, 1)], "NETA")
+        r2 = _route(2, [_seg(4.0, 5.0, 10.0, 5.0, 2)], "NETB")
+        for r in (r1, r2):
+            _commit(ar, r)
+
+        _finalize_committed_copper_or_demote(ar, quiet=True)
+        assert capsys.readouterr().out == ""
+
+    def test_helper_clean_board_no_output(self, capsys):
+        ar = _make_autorouter()
+        r1 = _route(1, [_seg(2.0, 5.0, 12.0, 5.0, 1)], "NETA")
+        r2 = _route(2, [_seg(2.0, 10.0, 12.0, 10.0, 2)], "NETB")
+        for r in (r1, r2):
+            _commit(ar, r)
+
+        _finalize_committed_copper_or_demote(ar, quiet=False)
+        # No demotion -> no backstop message.
+        assert "Post-optimize backstop demoted" not in capsys.readouterr().out
+        assert r1 in ar.routes and r2 in ar.routes

--- a/tests/router/test_post_negotiation_sweep.py
+++ b/tests/router/test_post_negotiation_sweep.py
@@ -337,6 +337,100 @@ class TestSweepMechanism:
         assert rescued == [1], "a clean, connected rescue must be committed"
         assert net_routes[1], "rescued net must have committed routes"
 
+    def test_sub_clearance_short_rescue_rolls_back(self, monkeypatch):
+        """Issue #4208 (Unit 2, the live gap): the rescue gate historically
+        scanned seg-seg pairs with ``copper_overlap_only=True``, so a rescued
+        net whose copper is a POSITIVE-gap-but-sub-clearance short against a
+        foreign net (a real ``kicad-cli SHORT`` that polygon intersection
+        misses) passed the gate uncaught and SHIPPED -- even after Unit 1
+        widened the finalize demote.  Unit 2 widened the rescue gate to the
+        FULL DRC threshold, so such a rescue is now rolled back.
+
+        Repro: net 2 is a vertical trace at x=10 on F_CU.  Net 1's solo
+        rescue routes as a vertical trace parallel to it at x=10.106 --
+        edge-to-edge gap 0.106mm > 0 (no overlap) but < trace_clearance
+        0.15mm: a sub-clearance short the old overlap-only gate MISSED.
+        """
+        ar = _build_two_net_router()
+        ar.route_all_negotiated(max_iterations=2, timeout=30.0, adaptive=False, perturbation=False)
+        net_routes, pads_by_net = _snapshot_net_state(ar)
+
+        # Force net 2 into a known vertical trace at x=10 on F_CU so we can
+        # position net 1's rescue at a precise sub-clearance offset.
+        neg = NegotiatedRouter(
+            ar.grid,
+            ar.router,
+            ar.rules,
+            ar.net_class_map,
+            congestion_estimator=ar._ensure_congestion_estimator(),
+        )
+        neg.rip_up_nets([1, 2], net_routes, ar.routes)
+        net2_seg = Segment(
+            x1=10.0, y1=2.0, x2=10.0, y2=18.0, width=0.2, layer=Layer.F_CU, net=2, net_name="NET2"
+        )
+        net2_route = Route(net=2, net_name="NET2", segments=[net2_seg], vias=[])
+        ar._mark_route(net2_route)
+        ar.routes.append(net2_route)
+        net_routes[2] = [net2_route]
+        net2_before = list(net_routes[2])
+        routes_len_before = len(ar.routes)
+
+        # Sub-clearance parallel rescue for net 1: vertical trace at
+        # x=10.106, connecting net 1's pads via a short dogleg.  Edge gap to
+        # net 2 is 0.106mm (positive) but below the 0.15mm clearance.
+        def sub_clearance_route_net(net, per_net_timeout=None):
+            segs = [
+                Segment(
+                    x1=2.0,
+                    y1=10.0,
+                    x2=10.106,
+                    y2=10.0,
+                    width=0.2,
+                    layer=Layer.F_CU,
+                    net=net,
+                    net_name="LONGHAUL",
+                ),
+                Segment(
+                    x1=10.106,
+                    y1=2.0,
+                    x2=10.106,
+                    y2=18.0,
+                    width=0.2,
+                    layer=Layer.F_CU,
+                    net=net,
+                    net_name="LONGHAUL",
+                ),
+                Segment(
+                    x1=10.106,
+                    y1=10.0,
+                    x2=38.0,
+                    y2=10.0,
+                    width=0.2,
+                    layer=Layer.F_CU,
+                    net=net,
+                    net_name="LONGHAUL",
+                ),
+            ]
+            route = Route(net=net, net_name="LONGHAUL", segments=segs, vias=[])
+            ar._mark_route(route)
+            ar.routes.append(route)
+            net_routes.setdefault(net, []).append(route)
+            return [route]
+
+        monkeypatch.setattr(ar, "route_net", sub_clearance_route_net)
+
+        rescued = ar._post_negotiation_sweep(
+            stranded_nets=[1],
+            net_routes=net_routes,
+            pads_by_net=pads_by_net,
+            per_net_timeout=POST_NEGOTIATION_SWEEP_PER_NET_S,
+            deadline=time.time() + POST_NEGOTIATION_SWEEP_BUDGET_S,
+        )
+        assert rescued == [], "sub-clearance short rescue must NOT be committed"
+        assert net_routes[1] == [], "sub-clearance short rescue must leave net stranded"
+        assert net_routes[2] == net2_before, "foreign net must be untouched"
+        assert len(ar.routes) == routes_len_before, "no sub-clearance short copper committed"
+
     def test_diffpair_leg_is_skipped(self, monkeypatch):
         """Issue #4159 (Judge #4192): a stranded DIFFERENTIAL-PAIR LEG must
         NOT be solo-rescued.  ``route_net`` is single-ended -- it ignores the

--- a/tests/router/test_seg_seg_quality_tuple.py
+++ b/tests/router/test_seg_seg_quality_tuple.py
@@ -648,6 +648,113 @@ class TestDemoteSegSegFinalizeThreshold:
         )
 
 
+class TestM3EscapeInfraCrossing:
+    """Issue #4208 (Unit 2 / M3): a genuine cross-net crossing between two
+    NON-RIPPABLE escape stubs (both supplied via ``extra_routes``) has no
+    demotable victim -- the greedy vertex cover skips it because neither
+    net is in the committed ``net_routes`` demotable set.  Before Unit 2 it
+    survived every safety net and shipped as a silent short.  The unified
+    finalize gate surfaces it (``report_non_rippable_pairs=True``) so it is
+    reported as a routing failure rather than committed.
+    """
+
+    def _make_autorouter(self) -> Autorouter:
+        return Autorouter(
+            width=20.0,
+            height=20.0,
+            origin_x=0.0,
+            origin_y=0.0,
+            rules=_make_rules(),
+            layer_stack=LayerStack.two_layer(),
+        )
+
+    def test_both_non_rippable_crossing_surfaced_not_skipped(self):
+        """Two crossing escape stubs of different nets, both non-rippable,
+        are reported by the pair engine when ``report_non_rippable_pairs``
+        is set (the M3 signal) but skipped by default (historical)."""
+        rules = _make_rules()
+        neg = _make_neg_router(None, rules)
+        # Two different-net stubs physically overlapping on F_CU.
+        extra = [
+            _route(1, [_seg(2.0, 5.0, 12.0, 5.0, 1)], "ESC_A"),
+            _route(2, [_seg(4.0, 5.0, 10.0, 5.0, 2)], "ESC_B"),
+        ]
+        net_routes: dict[int, list[Route]] = {}
+
+        # Historical default: both-non-rippable pair skipped.
+        assert (
+            neg.find_segment_segment_violation_pairs(
+                net_routes,
+                trace_clearance=rules.trace_clearance,
+                extra_routes=extra,
+                copper_overlap_only=False,
+            )
+            == []
+        )
+        # M3 signal: the crossing is surfaced.
+        assert neg.find_segment_segment_violation_pairs(
+            net_routes,
+            trace_clearance=rules.trace_clearance,
+            extra_routes=extra,
+            copper_overlap_only=False,
+            report_non_rippable_pairs=True,
+        ) == [(1, 2)]
+
+    def test_shared_gate_returns_non_rippable_pair_no_victim(self):
+        """The shared ``demote_seg_seg_finalize`` returns the M3 pair as a
+        signal with NO demotable victim (both stubs are non-rippable)."""
+        from kicad_tools.router.algorithms.negotiated import demote_seg_seg_finalize
+
+        ar = self._make_autorouter()
+        neg = _make_neg_router(ar.grid, ar.rules)
+        # Both stubs are escape infra: on self.routes but NOT in net_routes,
+        # so _collect_extra_routes_for_revalidation folds them in as extra.
+        e1 = _route(1, [_seg(2.0, 5.0, 12.0, 5.0, 1)], "ESC_A")
+        e2 = _route(2, [_seg(4.0, 5.0, 10.0, 5.0, 2)], "ESC_B")
+        for r in (e1, e2):
+            ar.grid.mark_route(r)
+            ar.grid.mark_route_usage(r)
+            ar.routes.append(r)
+        net_routes: dict[int, list[Route]] = {}
+        extra = ar._collect_extra_routes_for_revalidation(net_routes)
+
+        victims, non_rippable = demote_seg_seg_finalize(
+            net_routes,
+            neg,
+            ar.grid,
+            ar.routes,
+            trace_clearance=ar.rules.trace_clearance,
+            extra_routes=extra,
+            copper_overlap_only=False,
+        )
+        assert victims == []  # nothing demotable (both non-rippable)
+        assert non_rippable == [(1, 2)]  # surfaced as the M3 signal
+        # Copper is untouched (nothing to demote), but it is NOT silently
+        # accepted -- the caller has the signal to report it unrouted.
+        assert e1 in ar.routes and e2 in ar.routes
+
+    def test_mixed_rippable_pair_demotes_the_committed_net(self):
+        """When exactly one side of the crossing IS a committed (rippable)
+        net, the greedy cover demotes it -- the M3 skip only fires when
+        BOTH sides are non-rippable."""
+        ar = self._make_autorouter()
+        neg = _make_neg_router(ar.grid, ar.rules)
+        # Committed net 1 (rippable) crosses non-rippable escape stub net 2.
+        r1 = _route(1, [_seg(2.0, 5.0, 12.0, 5.0, 1)], "NETA")
+        e2 = _route(2, [_seg(4.0, 5.0, 10.0, 5.0, 2)], "ESC_B")
+        for r in (r1, e2):
+            ar.grid.mark_route(r)
+            ar.grid.mark_route_usage(r)
+            ar.routes.append(r)
+        net_routes = {1: [r1]}  # only net 1 is committed/demotable
+
+        demoted = ar._demote_seg_seg_overlap_nets(net_routes, neg, finalize=True)
+        assert demoted == [1]
+        assert net_routes[1] == []
+        assert r1 not in ar.routes
+        assert e2 in ar.routes  # escape stub survives (non-rippable)
+
+
 # ---------------------------------------------------------------------------
 # Issue #3413: correction pass must run BEFORE demotion on the timeout exit
 # ---------------------------------------------------------------------------

--- a/tests/test_best_state_tracking.py
+++ b/tests/test_best_state_tracking.py
@@ -109,7 +109,12 @@ class FakeNegotiatedRouter:
         return []
 
     def find_segment_segment_violation_pairs(
-        self, net_routes, trace_clearance, extra_routes=None, copper_overlap_only=False
+        self,
+        net_routes,
+        trace_clearance,
+        extra_routes=None,
+        copper_overlap_only=False,
+        report_non_rippable_pairs=False,
     ):
         return []
 

--- a/tests/test_negotiated_timeout_propagation.py
+++ b/tests/test_negotiated_timeout_propagation.py
@@ -114,7 +114,12 @@ class FakeNegotiatedRouter:
         return []
 
     def find_segment_segment_violation_pairs(
-        self, net_routes, trace_clearance, extra_routes=None, copper_overlap_only=False
+        self,
+        net_routes,
+        trace_clearance,
+        extra_routes=None,
+        copper_overlap_only=False,
+        report_non_rippable_pairs=False,
     ):
         return []
 


### PR DESCRIPTION
## Summary

Phase 2 hardening for different-net crossing emission (Units 2 and 3 of #4202 / #4208). Unit 2 unifies the seg-seg finalize demote and closes the rescue-gate live gap (M3); Unit 3 adds a post-optimize/post-nudge re-validation backstop (M4 for rtree-less envs). **Unit 4 (C++ `pathfinder.cpp` relief-probe hardening) is deferred**, per the issue's explicit narrowing.

Both mechanisms are defense-in-depth: the post-route DRC gate already refuses any residual short, so nothing shipped broken. The value is narrowing the honestly-unrouted-vs-short gap for dense-package (M3) and rtree-less-install (M4) configurations, and closing the threshold drift between the rescue gate and the Unit-1 finalize demote.

## Changes

### Unit 2 — one shared seg-seg finalize gate (closes M3 + the rescue-gate live gap)
- New module-level `demote_seg_seg_finalize()` in `algorithms/negotiated.py`: the single detection+greedy-cover+demote primitive. Both `core._demote_seg_seg_overlap_nets` and `two_phase._detailed_negotiated`'s inline block now delegate to it, so the two hand-synced copies can no longer drift (the exact drift that left the rescue gate on the old threshold across Unit 1).
- **Rescue-gate live gap fixed**: `_rescued_net_adds_blocking_drc` now scans seg-seg pairs with `copper_overlap_only=False` (full DRC SHORT threshold) instead of `True`. A rescued net that shipped a positive-gap-but-sub-clearance short (a real `kicad-cli SHORT` polygon-intersection misses) is now rolled back. A diff-pair-partner carve-out (`_diff_pair_partner_net`, refactored out of the existing intra-pair check) excludes the coupled partner pair, which the dedicated intra-pair clearance check adjudicates with the correct per-pair threshold.
- **M3 mechanism chosen**: `find_segment_segment_violation_pairs(..., report_non_rippable_pairs=True)` now optionally surfaces the both-non-rippable escape-infra crossing (previously skipped unconditionally at `negotiated.py:2077-2078`). Since neither net is demotable, the greedy cover still can't demote it — so it is **surfaced as a routing-quality failure** (logged, honestly-unrouted) rather than shipped as a silent short. This is the architect's own framing ("remains a routing failure, correctly surfaced as unrouted"). Diff-pair partners are excluded from the warning to avoid noise on legitimately-coupled prerouted pairs. The default (`report_non_rippable_pairs=False`) preserves the historical skip, so no existing caller changes behavior.

### Unit 3 — post-optimize/post-nudge re-validation backstop (closes M4 for rtree-less)
- New `Autorouter.revalidate_committed_copper_or_demote()`: reconstructs `net_routes` from `self.routes` via the existing `_build_net_routes_map()` (the Autorouter doesn't persist `net_routes`), then re-runs the Unit-2 finalize gate over the post-optimize copper.
- New shared CLI helper `_finalize_committed_copper_or_demote(router, quiet)` in `route_cmd.py`, called from **all four** post-optimize+nudge blocks (`route_with_layer_escalation`, `route_with_rule_relaxation`, `route_with_combined_escalation`, base `main()` path). Confirmed via `rg "Post-optimization DRC nudge pass"` that exactly 4 sites exist; `route_with_mfr_tier_escalation` / `route_with_size_escalation` delegate to `route_with_layer_escalation` (no 5th/6th site). One shared helper — not a 5th copy-paste.
- Runs unconditionally (no `has_overflow`/rtree probe) — it is a no-op when the copper is clean (common rtree-present case), matching the architect's cost model (O(segments), negligible vs a multi-second route).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Unit 2: M3 both-non-rippable crossing caught by unified gate | ✅ | `TestM3EscapeInfraCrossing` (3 tests): surfaced via `report_non_rippable_pairs`, no demotable victim, mixed-rippable still demotes |
| Unit 2: rescue gate live gap — sub-clearance short now rolled back | ✅ | `test_sub_clearance_short_rescue_rolls_back` (positive-gap 0.106mm < 0.15mm short the old `overlap_only=True` gate missed) |
| Unit 2: `_rescued_net_adds_blocking_drc` bit-for-bit preserved | ✅ | `test_partial_rescue.py` + `test_relief_rescue.py` + full `test_post_negotiation_sweep.py` green |
| Unit 2: finalize demote preserved (incl. Unit-1 `TestDemoteSegSegFinalizeThreshold`) | ✅ | `test_seg_seg_quality_tuple.py` 33 pass |
| Unit 2: diff-pair intra-clearance no regression | ✅ | 4 diffpair suites + board-06 diffpair green |
| Unit 3: rtree-less optimizer crossing caught by backstop | ✅ | `test_optimizer_backstop.py` — router method + CLI helper demote a simulated post-optimize crossing |
| Unit 3: no-op when rtree available | ✅ | `test_route_cmd_success_output.py` green; backstop clean-board no-op tests |
| Unit 3: 4 call sites confirmed | ✅ | `rg "Post-optimization DRC nudge pass"` → 4; mfr/size delegate |
| `ruff check` / `mypy` clean on touched files | ✅ | ruff clean; mypy baseline check: 0 new errors |

## Test Plan
- `tests/router/` full suite: 616 passed, 3 skipped.
- Board 05/06 routing regressions + board-06 determinism + board-route determinism: 49 passed, 2 skipped. **No completion-floor shift** — no board demoted a net (the new gates were no-ops on already-clean committed copper; the honest-unroute trade only fires on a genuine short, which these clean boards don't have).
- Board 07 matchgroup + 4 diffpair intra-clearance suites: 75 passed.
- `route_cmd` suites (success-output, params, total-timeout, power-nets, stale-layer): 134 passed, 1 skipped.
- ruff check + format clean; mypy baseline: 0 new errors (one targeted `# type: ignore[arg-type]` matching the existing `NegotiatedRouter(self.grid, self.router, ...)` pattern in core.py).
- C++ backend built (`kct build-native --check` → available 1.0.0).

Closes #4208