### PR TITLE
feat(validate): add ampacity DRC check for routed copper width

### DIFF
--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -647,6 +647,7 @@ def print_meta_check_stanza(result: MetaCheckResult) -> None:
 
 
 CHECK_CATEGORIES = [
+    "ampacity",
     "clearance",
     "connectivity",
     "segment_zone",
@@ -1272,6 +1273,7 @@ def run_selected_checks(
     # ``tests/test_check_cmd_coverage.py`` enforces the invariant for
     # Issue #3046.
     check_methods = {
+        "ampacity": checker.check_ampacity,
         "clearance": checker.check_clearances,
         "connectivity": checker.check_connectivity,
         "segment_zone": checker.check_segment_zone_clearances,

--- a/src/kicad_tools/validate/ampacity_specs.py
+++ b/src/kicad_tools/validate/ampacity_specs.py
@@ -1,0 +1,67 @@
+"""Derive per-net ampacity targets from a net-class map.
+
+Issue #4217 (Part 3 of #4215).
+
+Ampacity targets are **declarative**: a net only carries a required
+current when its
+:class:`~kicad_tools.router.rules.NetClassRouting` explicitly sets
+:attr:`~kicad_tools.router.rules.NetClassRouting.target_ampacity`.  Unlike
+single-ended impedance there is no name-pattern heuristic ("ends in CLK
+== 50Ω") equivalent for current — a trace's ampacity requirement is never
+inferred from its net name.
+
+This module is the thin producer-side shim, mirroring
+:func:`kicad_tools.validate.impedance_specs.derive_single_ended_impedance_specs`.
+It maps each class's ``target_ampacity`` to a ``{net_name: current_a}``
+dict which
+:class:`~kicad_tools.validate.rules.ampacity.AmpacityRule` consumes as its
+``specs``.
+
+The result is threaded through the same ``kct check --net-class-map``
+sidecar path that
+:meth:`kicad_tools.validate.checker.DRCChecker.check_impedance` and
+:meth:`~kicad_tools.validate.checker.DRCChecker.check_match_group_length_skew`
+already consume — ``target_ampacity`` is just another field read off the
+same :class:`NetClassRouting` objects already flowing through that map.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from kicad_tools.router.rules import NetClassRouting
+
+
+def derive_ampacity_specs(
+    net_class_map: dict[str, NetClassRouting] | None,
+) -> dict[str, float]:
+    """Build a ``{net_name: target_ampacity}`` map from a net-class map.
+
+    Walks the ``{net_name: NetClassRouting}`` map and, for every net whose
+    class declares a non-``None``
+    :attr:`~kicad_tools.router.rules.NetClassRouting.target_ampacity`,
+    records that current (in amps) against the net name.
+
+    Args:
+        net_class_map: Map of ``{net_name: NetClassRouting}`` (the
+            autorouter convention; deserialized from the
+            ``kct check --net-class-map`` sidecar).  ``None`` or empty
+            returns ``{}`` so the standalone ``kct check`` path degrades
+            gracefully to "no ampacity targets".
+
+    Returns:
+        A ``{net_name: current_a}`` map.  Empty when no class declares
+        ``target_ampacity`` — which is the common case, since no
+        predefined ``NET_CLASS_*`` sets it.
+    """
+    if not net_class_map:
+        return {}
+
+    specs: dict[str, float] = {}
+    for net_name, nc in net_class_map.items():
+        target = getattr(nc, "target_ampacity", None)
+        if target is None:
+            continue
+        specs[net_name] = float(target)
+    return specs

--- a/src/kicad_tools/validate/checker.py
+++ b/src/kicad_tools/validate/checker.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 from kicad_tools.manufacturers import DesignRules, get_profile
 
+from .rules.ampacity import AmpacityRule
 from .rules.clearance import ClearanceRule, SegmentZoneClearanceRule, ViaZoneClearanceRule
 from .rules.connectivity import ConnectivityRule
 from .rules.copper_sliver import CopperSliverRule
@@ -179,6 +180,7 @@ class DRCChecker:
     # dict in ``cli/check_cmd.py``.  The regression test in
     # ``tests/test_check_cmd_coverage.py`` enforces the second half.
     CHECK_ALL_METHODS: tuple[str, ...] = (
+        "check_ampacity",
         "check_clearances",
         "check_connectivity",
         "check_segment_zone_clearances",
@@ -642,6 +644,44 @@ class DRCChecker:
             DRCResults containing edge clearance violations
         """
         rule = EdgeClearanceRule()
+        return self._absolutize(rule.check(self.pcb, self.design_rules))
+
+    def check_ampacity(self) -> DRCResults:
+        """Check routed trace widths against per-net ampacity targets.
+
+        Wires :class:`~kicad_tools.validate.rules.ampacity.AmpacityRule`
+        into the standalone DRC pipeline (Issue #4217, Part 3 of #4215).
+        For each net whose class declares a
+        :attr:`~kicad_tools.router.rules.NetClassRouting.target_ampacity`,
+        the rule derives the IPC-2221 minimum trace width via
+        :func:`kicad_tools.physics.ampacity.width_for_current` — the same
+        function and copper-weight / layer split
+        :func:`kicad_tools.manufacturers.dru_generator.generate_dru` uses,
+        so the check and the emitted ``.kicad_dru`` rule agree — and
+        flags any routed segment narrower than that floor.
+
+        Ampacity targets are **declarative**: they come from the
+        ``kct check --net-class-map`` sidecar (the same mechanism
+        :meth:`check_impedance` and :meth:`check_match_group_length_skew`
+        consume).  When ``self.net_class_map is None`` (standalone
+        ``kct check`` with no sidecar), the derived spec map is empty and
+        the rule is a clean no-op — matching the graceful-degradation
+        contract those sibling checks already establish.
+
+        This rule is intentionally NOT in
+        :attr:`ADVISORY_RULE_IDS`: an under-width high-current trace is a
+        real thermal/fire hazard and MUST block gating consumers
+        (``ManufacturingAudit``, ``kct export`` preflight), unlike
+        ``connectivity``.
+
+        Returns:
+            DRCResults containing per-segment ampacity errors.  Empty when
+            no net declares a target (the standalone-CLI common case).
+        """
+        from .ampacity_specs import derive_ampacity_specs
+
+        specs = derive_ampacity_specs(self.net_class_map)
+        rule = AmpacityRule(specs=specs)
         return self._absolutize(rule.check(self.pcb, self.design_rules))
 
     def check_impedance(self) -> DRCResults:

--- a/src/kicad_tools/validate/rules/ampacity.py
+++ b/src/kicad_tools/validate/rules/ampacity.py
@@ -1,0 +1,238 @@
+"""Ampacity validation DRC rule.
+
+Issue #4217 (Part 3 of #4215).
+
+Verifies that every routed copper segment of a net whose class declares a
+``target_ampacity`` is at least as wide as the IPC-2221-derived minimum
+width required to carry that current at the board's copper weight and for
+the segment's layer position (external vs internal).
+
+The required-width derivation reuses
+:func:`kicad_tools.physics.ampacity.width_for_current` — the *identical*
+function (and the identical ``outer_copper_oz`` / ``inner_copper_oz`` +
+external/internal-layer split) that
+:func:`kicad_tools.manufacturers.dru_generator.generate_dru` uses to emit
+net-scoped ``.kicad_dru`` ``track_width`` rules.  Because both paths feed
+the same inputs to the same closed-form formula, the Python check and the
+emitted KiCad custom rule agree on the required width for a given
+net / copper-weight / layer.
+
+Example::
+
+    from kicad_tools.validate.rules.ampacity import AmpacityRule
+    from kicad_tools.schema.pcb import PCB
+    from kicad_tools.manufacturers import DesignRules
+
+    pcb = PCB.load("board.kicad_pcb")
+    design_rules = DesignRules.jlcpcb_2layer()
+
+    rule = AmpacityRule(specs={"VBUS": 15.0})
+    results = rule.check(pcb, design_rules)
+
+    for err in results.errors:
+        print(f"Ampacity error: {err.message}")
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from kicad_tools.physics.ampacity import width_for_current
+
+from ..violations import DRCResults, DRCViolation
+from .base import DRCRule
+
+if TYPE_CHECKING:
+    from kicad_tools.manufacturers import DesignRules
+    from kicad_tools.schema.pcb import PCB
+
+# Copper layers that shed heat from a single exposed face.  IPC-2221 uses
+# a higher current constant (k=0.048) for these outer layers; everything
+# else (In*.Cu) is treated as internal (k=0.024), buried between
+# dielectric and therefore needing a wider trace for the same current.
+# This binary split matches ``manufacturers/dru_generator.py`` exactly so
+# the check and the emitted ``.kicad_dru`` rule agree.
+_EXTERNAL_LAYERS = ("F.Cu", "B.Cu")
+
+
+class AmpacityRule(DRCRule):
+    """DRC rule verifying routed trace widths meet an ampacity target.
+
+    For each net that declares a ``target_ampacity`` (in amps), derives
+    the IPC-2221 minimum trace width for the board's copper weight and the
+    segment's layer position, then compares each routed segment's actual
+    width against that floor.  A per-segment ``error`` finding is emitted
+    for every segment narrower than the required width — an under-width
+    high-current trace is a real thermal hazard, not a soft tolerance
+    band, so there is no warning tier.
+
+    Attributes:
+        rule_id: ``"ampacity"``
+        name: ``"Ampacity Compliance"``
+        specs: ``{net_name: target_ampacity}`` map of nets to check.
+    """
+
+    rule_id = "ampacity"
+    name = "Ampacity Compliance"
+    description = "Verify routed copper width carries a net's target current (IPC-2221)"
+
+    def __init__(self, specs: dict[str, float] | None = None) -> None:
+        """Initialize the ampacity rule.
+
+        Args:
+            specs: ``{net_name: target_ampacity}`` map (currents in amps).
+                Typically produced by
+                :func:`kicad_tools.validate.ampacity_specs.derive_ampacity_specs`
+                from a ``NetClassRouting`` map.  ``None`` or empty means
+                no net is checked (clean no-op) — the standalone
+                ``kct check`` contract when no sidecar is supplied.
+        """
+        self.specs: dict[str, float] = specs or {}
+
+    @staticmethod
+    def _is_external_layer(layer: str) -> bool:
+        """Return True for outer copper (F.Cu / B.Cu), False for internal.
+
+        Matches the binary external/internal split
+        ``manufacturers/dru_generator.py`` uses: any copper layer that is
+        not ``F.Cu`` / ``B.Cu`` counts as internal for IPC-2221's k
+        constant (there is no third "unknown" bucket).
+        """
+        return layer in _EXTERNAL_LAYERS
+
+    def _required_width_mm(
+        self,
+        current_a: float,
+        design_rules: DesignRules,
+        *,
+        external: bool,
+    ) -> float:
+        """Derive the IPC-2221 minimum trace width (mm) for a target current.
+
+        Deliberately kept as a standalone step, separate from the
+        width-comparison loop in :meth:`check` — a future reinforcement
+        credit (Unit E of #4218/#4220) needs to intercept the per-segment
+        comparison to subtract wire-carried current, which requires these
+        two concerns to stay unfused.
+
+        Reuses the exact ``width_for_current`` call shape from
+        :func:`kicad_tools.manufacturers.dru_generator.generate_dru`
+        (external -> ``outer_copper_oz`` / ``layer="external"``; internal
+        -> ``inner_copper_oz`` / ``layer="internal"``; default 10 C rise)
+        so the check and the ``.kicad_dru`` generator agree.
+        """
+        if external:
+            return width_for_current(
+                current_a,
+                copper_weight_oz=design_rules.outer_copper_oz,
+                layer="external",
+            )
+        return width_for_current(
+            current_a,
+            copper_weight_oz=design_rules.inner_copper_oz,
+            layer="internal",
+        )
+
+    def check(
+        self,
+        pcb: PCB,
+        design_rules: DesignRules,
+    ) -> DRCResults:
+        """Check PCB traces against their nets' ampacity targets.
+
+        Args:
+            pcb: The PCB to check.
+            design_rules: Design rules from the manufacturer profile
+                (supplies ``outer_copper_oz`` / ``inner_copper_oz``).
+
+        Returns:
+            DRCResults with a per-segment ``error`` for every routed
+            segment narrower than its net's IPC-2221 required width.
+            Empty when no net declares a target (the standalone-CLI common
+            case).
+        """
+        results = DRCResults(rules_checked=1)
+
+        if not self.specs:
+            return results
+
+        # Cache the required width per (net, layer-class) so we call the
+        # IPC-2221 solver once per pair rather than once per segment.
+        required_cache: dict[tuple[str, bool], float] = {}
+
+        for segment in getattr(pcb, "segments", []):
+            net_name = getattr(segment, "net_name", None)
+            if not net_name or net_name not in self.specs:
+                continue
+
+            current_a = self.specs[net_name]
+            layer = getattr(segment, "layer", "F.Cu")
+            external = self._is_external_layer(layer)
+
+            cache_key = (net_name, external)
+            required_width_mm = required_cache.get(cache_key)
+            if required_width_mm is None:
+                required_width_mm = self._required_width_mm(
+                    current_a, design_rules, external=external
+                )
+                required_cache[cache_key] = required_width_mm
+
+            actual_width_mm = getattr(segment, "width", 0.0)
+
+            # ``>=``: a segment exactly at the floor passes (meets-or-
+            # exceeds, matching DimensionRules and other width-floor rules).
+            if actual_width_mm >= required_width_mm:
+                continue
+
+            results.add(
+                self._create_violation(
+                    net_name=net_name,
+                    layer=layer,
+                    external=external,
+                    current_a=current_a,
+                    actual_width_mm=actual_width_mm,
+                    required_width_mm=required_width_mm,
+                    design_rules=design_rules,
+                    segment=segment,
+                )
+            )
+
+        return results
+
+    def _create_violation(
+        self,
+        *,
+        net_name: str,
+        layer: str,
+        external: bool,
+        current_a: float,
+        actual_width_mm: float,
+        required_width_mm: float,
+        design_rules: DesignRules,
+        segment: object,
+    ) -> DRCViolation:
+        """Build a per-segment ampacity violation."""
+        layer_class = "external" if external else "internal"
+        copper_weight_oz = (
+            design_rules.outer_copper_oz if external else design_rules.inner_copper_oz
+        )
+
+        start = tuple(getattr(segment, "start", (0.0, 0.0)))
+        end = tuple(getattr(segment, "end", (0.0, 0.0)))
+        loc_x = round((start[0] + end[0]) / 2.0, 3)
+        loc_y = round((start[1] + end[1]) / 2.0, 3)
+
+        return DRCViolation(
+            rule_id=self.rule_id,
+            severity="error",
+            message=(
+                f"Trace on {layer} too narrow for {current_a:.1f}A: "
+                f"width {actual_width_mm:.3f}mm, requires {required_width_mm:.3f}mm "
+                f"(IPC-2221, {copper_weight_oz}oz {layer_class})"
+            ),
+            location=(loc_x, loc_y),
+            layer=layer,
+            actual_value=actual_width_mm,
+            required_value=required_width_mm,
+            items=(net_name,),
+        )

--- a/tests/test_ampacity_check.py
+++ b/tests/test_ampacity_check.py
@@ -1,0 +1,249 @@
+"""Unit tests for the ampacity DRC rule (Issue #4217, Part 3 of #4215).
+
+Exercises :class:`kicad_tools.validate.rules.ampacity.AmpacityRule` and the
+:func:`kicad_tools.validate.ampacity_specs.derive_ampacity_specs` producer
+helper against synthetic in-memory PCBs — no golden-board dependency.
+
+The golden IPC-2221 widths (15 A / 2 oz / 10 C) come from
+``tests/test_ampacity.py``:
+
+* external (k=0.048) ~= 6.29 mm
+* internal (k=0.024) ~= 16.37 mm
+
+so a 15 A net class on 2 oz copper routed at 3 mm on ``F.Cu`` must be
+flagged (3 < 6.29) and the same net routed at >= 6.3 mm must pass.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.manufacturers import DesignRules
+from kicad_tools.physics.ampacity import width_for_current
+from kicad_tools.schema.pcb import PCB
+from kicad_tools.validate.ampacity_specs import derive_ampacity_specs
+from kicad_tools.validate.rules.ampacity import AmpacityRule
+
+# --- Synthetic fixtures -------------------------------------------------
+
+
+def _pcb_with_segment(width_mm: float, layer: str, net: str = "VBUS") -> str:
+    """Build a minimal .kicad_pcb string with one routed segment."""
+    layers_block = (
+        '    (0 "F.Cu" signal)\n'
+        '    (1 "In1.Cu" signal)\n'
+        '    (2 "In2.Cu" signal)\n'
+        '    (31 "B.Cu" signal)\n'
+        '    (44 "Edge.Cuts" user)\n'
+    )
+    return f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+{layers_block}  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "{net}")
+  (gr_rect (start 100 100) (end 150 150)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+  (segment (start 110 120) (end 140 120) (width {width_mm}) (layer "{layer}") (net 1)
+    (uuid "00000000-0000-0000-0000-000000000030"))
+)
+"""
+
+
+def _write_pcb(tmp_path: Path, text: str) -> PCB:
+    pcb_file = tmp_path / "ampacity.kicad_pcb"
+    pcb_file.write_text(text)
+    return PCB.load(str(pcb_file))
+
+
+def _design_rules_2oz() -> DesignRules:
+    """DesignRules with 2 oz outer + inner copper (matches the golden)."""
+    return DesignRules(
+        min_trace_width_mm=0.127,
+        min_clearance_mm=0.127,
+        min_via_drill_mm=0.2,
+        min_via_diameter_mm=0.45,
+        min_annular_ring_mm=0.13,
+        outer_copper_oz=2.0,
+        inner_copper_oz=2.0,
+    )
+
+
+# --- derive_ampacity_specs ---------------------------------------------
+
+
+@dataclass
+class _FakeNetClass:
+    """Minimal stand-in for NetClassRouting with just target_ampacity."""
+
+    target_ampacity: float | None = None
+
+
+class TestDeriveAmpacitySpecs:
+    def test_none_map_returns_empty(self) -> None:
+        assert derive_ampacity_specs(None) == {}
+
+    def test_empty_map_returns_empty(self) -> None:
+        assert derive_ampacity_specs({}) == {}
+
+    def test_extracts_only_nets_with_target(self) -> None:
+        net_map = {
+            "VBUS": _FakeNetClass(target_ampacity=15.0),
+            "SIGNAL": _FakeNetClass(target_ampacity=None),
+        }
+        assert derive_ampacity_specs(net_map) == {"VBUS": 15.0}
+
+
+# --- AmpacityRule -------------------------------------------------------
+
+
+class TestAmpacityRule:
+    def test_under_width_external_segment_flagged(self, tmp_path: Path) -> None:
+        """15 A / 2 oz / F.Cu routed at 3 mm -> 1 error, required ~6.29 mm."""
+        pcb = _write_pcb(tmp_path, _pcb_with_segment(3.0, "F.Cu"))
+        rule = AmpacityRule(specs={"VBUS": 15.0})
+        results = rule.check(pcb, _design_rules_2oz())
+
+        assert len(results.errors) == 1
+        v = results.errors[0]
+        assert v.rule_id == "ampacity"
+        assert v.severity == "error"
+        assert v.layer == "F.Cu"
+        assert v.items == ("VBUS",)
+        assert v.actual_value == pytest.approx(3.0)
+        assert v.required_value == pytest.approx(6.29, abs=0.05)
+
+    def test_compliant_external_segment_passes(self, tmp_path: Path) -> None:
+        """Same net routed at 6.3 mm (>= required) -> no findings."""
+        pcb = _write_pcb(tmp_path, _pcb_with_segment(6.3, "F.Cu"))
+        rule = AmpacityRule(specs={"VBUS": 15.0})
+        results = rule.check(pcb, _design_rules_2oz())
+        assert results.errors == []
+
+    def test_no_target_not_checked(self, tmp_path: Path) -> None:
+        """A net with no ampacity target is never checked, regardless of width."""
+        pcb = _write_pcb(tmp_path, _pcb_with_segment(0.2, "F.Cu"))
+        rule = AmpacityRule(specs={})  # no target for VBUS
+        results = rule.check(pcb, _design_rules_2oz())
+        assert results.errors == []
+
+    def test_boundary_width_passes(self, tmp_path: Path) -> None:
+        """Width exactly at the required floor passes (>=, not >)."""
+        required = width_for_current(15.0, copper_weight_oz=2.0, layer="external")
+        pcb = _write_pcb(tmp_path, _pcb_with_segment(required, "F.Cu"))
+        rule = AmpacityRule(specs={"VBUS": 15.0})
+        results = rule.check(pcb, _design_rules_2oz())
+        assert results.errors == []
+
+    def test_internal_layer_uses_inner_copper_weight(self, tmp_path: Path) -> None:
+        """An internal-layer segment uses the wider internal (k=0.024) floor.
+
+        A 3 mm internal segment is flagged, and its required width matches
+        the internal golden (~16.37 mm) — measurably larger than the
+        external requirement (~6.29 mm) at identical current / copper
+        weight.
+        """
+        pcb = _write_pcb(tmp_path, _pcb_with_segment(3.0, "In1.Cu"))
+        rule = AmpacityRule(specs={"VBUS": 15.0})
+        results = rule.check(pcb, _design_rules_2oz())
+
+        assert len(results.errors) == 1
+        v = results.errors[0]
+        assert v.layer == "In1.Cu"
+        assert v.required_value == pytest.approx(16.37, abs=0.05)
+        # Internal requirement is strictly wider than external at same inputs.
+        external_req = width_for_current(15.0, copper_weight_oz=2.0, layer="external")
+        assert v.required_value > external_req
+
+    def test_multi_segment_only_underwidth_flagged(self, tmp_path: Path) -> None:
+        """Two segments on the same net, one wide one narrow -> exactly 1 error."""
+        text = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "VBUS")
+  (gr_rect (start 100 100) (end 200 200)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+  (segment (start 110 120) (end 140 120) (width 7.0) (layer "F.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-000000000031"))
+  (segment (start 110 130) (end 140 130) (width 3.0) (layer "F.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-000000000032"))
+)
+"""
+        pcb = _write_pcb(tmp_path, text)
+        rule = AmpacityRule(specs={"VBUS": 15.0})
+        results = rule.check(pcb, _design_rules_2oz())
+
+        assert len(results.errors) == 1
+        # The flagged segment is the 3.0 mm one.  The rule reports a
+        # board-relative midpoint (board_origin at the edge-cut corner
+        # 100,100 is subtracted by PCB.load), so its y is 130 - 100 = 30.
+        v = results.errors[0]
+        assert v.actual_value == pytest.approx(3.0)
+        assert v.location is not None
+        assert v.location[1] == pytest.approx(30.0, abs=1e-6)
+
+    def test_empty_specs_no_op(self, tmp_path: Path) -> None:
+        pcb = _write_pcb(tmp_path, _pcb_with_segment(0.1, "F.Cu"))
+        rule = AmpacityRule()  # specs=None -> {}
+        results = rule.check(pcb, _design_rules_2oz())
+        assert results.errors == []
+
+
+class TestCheckDruAgreement:
+    """The check's required width must equal the DRU generator's width.
+
+    Both call ``width_for_current`` with the identical copper-weight /
+    layer split, so for a given (net, copper-weight, layer) the check's
+    ``required_value`` and the DRU generator's emitted min-width agree.
+    """
+
+    def test_check_required_width_matches_dru_external(self, tmp_path: Path) -> None:
+        from kicad_tools.manufacturers.dru_generator import generate_dru
+        from kicad_tools.router.rules import NetClassRouting
+
+        design_rules = _design_rules_2oz()
+        nc = NetClassRouting(name="POWER", target_ampacity=15.0)
+
+        # DRU-emitted external width for this class.
+        dru_text = generate_dru(design_rules, net_classes=[nc])
+        lines = dru_text.splitlines()
+        # Find the external rule block, then the following track_width
+        # constraint line: (constraint track_width (min X.XXXXmm)).
+        idx = next(
+            i for i, line in enumerate(lines) if "Ampacity Min Width (POWER, external)" in line
+        )
+        constraint_line = next(line for line in lines[idx:] if "track_width" in line)
+        dru_width = float(constraint_line.split("min ")[1].split("mm")[0])
+
+        # The check's derived required width for the same inputs.
+        rule = AmpacityRule(specs={"POWER": 15.0})
+        pcb = _write_pcb(tmp_path, _pcb_with_segment(0.5, "F.Cu", net="POWER"))
+        results = rule.check(pcb, design_rules)
+        assert len(results.errors) == 1
+        check_width = results.errors[0].required_value
+
+        assert check_width == pytest.approx(dru_width, abs=1e-4)

--- a/tests/test_cli_check_ampacity.py
+++ b/tests/test_cli_check_ampacity.py
@@ -1,0 +1,100 @@
+"""CLI tests for ``kct check --only/--skip ampacity`` (Issue #4217).
+
+Verifies the new ``ampacity`` category is wired into ``CHECK_CATEGORIES``
+and the ``check_methods`` dispatch dict at ``cli/check_cmd.py``, and that
+``DRCChecker.check_ampacity`` exists.
+
+Mirrors ``tests/test_cli_check_impedance.py``.  Ampacity targets are
+declarative (per-net via the net-class-map sidecar), so a standalone
+``kct check --only ampacity`` on a board with no sidecar is a clean
+no-op: the category dispatches, the rule sees an empty spec map, and the
+CLI exits without an ampacity error.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# Minimal valid PCB with a single wide power net segment.  No net-class
+# sidecar is supplied on the standalone CLI path, so the ampacity rule
+# derives no specs and reports nothing.
+MINIMAL_AMPACITY_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "VBUS")
+  (gr_rect (start 100 100) (end 150 150)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+  (segment (start 110 120) (end 140 120) (width 0.5) (layer "F.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-000000000040"))
+)
+"""
+
+
+@pytest.fixture
+def minimal_ampacity_pcb(tmp_path: Path) -> Path:
+    pcb_file = tmp_path / "ampacity.kicad_pcb"
+    pcb_file.write_text(MINIMAL_AMPACITY_PCB)
+    return pcb_file
+
+
+class TestAmpacityCLI:
+    """CLI-level wiring tests for the new check category."""
+
+    def test_category_in_check_categories_list(self):
+        """``"ampacity"`` is registered in CHECK_CATEGORIES."""
+        from kicad_tools.cli.check_cmd import CHECK_CATEGORIES
+
+        assert "ampacity" in CHECK_CATEGORIES
+
+    def test_only_ampacity_runs(self, minimal_ampacity_pcb: Path, capsys):
+        """``--only ampacity`` is accepted and dispatches cleanly.
+
+        Without a ``--net-class-map`` sidecar the rule is a no-op (0
+        ampacity errors).  The exit code is 0 or 2 (2 = overall
+        INCOMPLETE because no schematic is present for ERC/LVS), but NOT 1
+        (tool-level failure).
+        """
+        from kicad_tools.cli.check_cmd import main
+
+        result = main([str(minimal_ampacity_pcb), "--only", "ampacity"])
+        assert result in (0, 2)
+
+    def test_skip_ampacity_runs(self, minimal_ampacity_pcb: Path, capsys):
+        """``--skip ampacity`` is accepted by the CLI."""
+        from kicad_tools.cli.check_cmd import main
+
+        result = main([str(minimal_ampacity_pcb), "--skip", "ampacity"])
+        assert result in (0, 2)
+
+    def test_ampacity_in_check_methods(self):
+        """``DRCChecker`` exposes ``check_ampacity`` and it is registered."""
+        from kicad_tools.validate import DRCChecker
+
+        assert hasattr(DRCChecker, "check_ampacity")
+        assert callable(DRCChecker.check_ampacity)
+        assert "check_ampacity" in DRCChecker.CHECK_ALL_METHODS
+
+    def test_check_ampacity_no_sidecar_is_clean_noop(self, minimal_ampacity_pcb: Path):
+        """Standalone ``check_ampacity`` (no net_class_map) reports nothing."""
+        from kicad_tools.schema.pcb import PCB
+        from kicad_tools.validate import DRCChecker
+
+        pcb = PCB.load(str(minimal_ampacity_pcb))
+        checker = DRCChecker(pcb, manufacturer="jlcpcb", layers=2)
+        results = checker.check_ampacity()
+        assert results.errors == []


### PR DESCRIPTION
## Summary

Adds a `kct check` ampacity sub-check (Part 3 of #4215) that verifies a
high-current net's ROUTED copper width meets the IPC-2221-derived minimum
width for the net's declared `target_ampacity`, given the board copper
weight and the segment's layer position. Flags every segment of an
ampacity-targeted net that is too narrow to carry its declared current.

The required-width derivation reuses `physics/ampacity.py::width_for_current`
(merged in #4216 / PR #4221) with the identical `outer_copper_oz` /
`inner_copper_oz` + external/internal-layer split that
`manufacturers/dru_generator.py` uses — so the Python check and the
emitted `.kicad_dru` `track_width` rules agree on the required width for
the same net / copper-weight / layer.

## Changes

- **NEW `src/kicad_tools/validate/ampacity_specs.py`** — `derive_ampacity_specs(net_class_map) -> dict[str, float]` producer helper, mirrors `impedance_specs.derive_single_ended_impedance_specs`.
- **NEW `src/kicad_tools/validate/rules/ampacity.py`** — `AmpacityRule`. Per-segment check; `F.Cu`/`B.Cu` → external (`outer_copper_oz`, k=0.048), any other copper layer → internal (`inner_copper_oz`, k=0.024). Required-width derivation (`_required_width_mm`) is kept a separable step from the width-comparison loop in `check()` so a future reinforcement credit (Unit E of #4218/#4220) can intercept it surgically. Findings are per-segment, `error` severity unconditionally (no warning tier).
- **`src/kicad_tools/validate/checker.py`** — `AmpacityRule` module import; `check_ampacity()` method; `"check_ampacity"` added to `CHECK_ALL_METHODS`. NOT added to `ADVISORY_RULE_IDS` (an under-width high-current trace must block gating). No-op when `net_class_map is None`.
- **`src/kicad_tools/cli/check_cmd.py`** — `"ampacity"` in `CHECK_CATEGORIES` and `"ampacity": checker.check_ampacity` in the `check_methods` dispatch dict.
- **NEW `tests/test_ampacity_check.py`** — unit tests (synthetic PCB fixtures).
- **NEW `tests/test_cli_check_ampacity.py`** — CLI wiring tests.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `AmpacityRule` checks routed segments vs IPC-2221 min width | ✅ | `test_under_width_external_segment_flagged` |
| 15A / 2oz / F.Cu @ 3mm → flagged, required ≈ 6.29mm, `error` | ✅ | `test_under_width_external_segment_flagged` asserts `required_value ≈ 6.29`, `severity=="error"` |
| Same net @ ≥6.3mm → passes | ✅ | `test_compliant_external_segment_passes` |
| No `target_ampacity` / no net_class_map → not checked, no crash | ✅ | `test_no_target_not_checked`, `test_check_ampacity_no_sidecar_is_clean_noop` |
| Internal layer uses `inner_copper_oz` + `"internal"`, wider width | ✅ | `test_internal_layer_uses_inner_copper_weight` (≈16.37mm > external) |
| Registered in `CHECK_ALL_METHODS` + `CHECK_CATEGORIES` + `check_methods` | ✅ | `tests/test_check_cmd_coverage.py` passes unmodified |
| Per-segment findings, unconditional `error` | ✅ | `test_multi_segment_only_underwidth_flagged` (exactly 1 finding) |
| `--only ampacity` runs standalone without `--net-class-map` | ✅ | `test_only_ampacity_runs` |
| Reuses `width_for_current` → check/DRU agree | ✅ | `test_check_required_width_matches_dru_external` (check width == DRU-emitted width) |

## Test Plan

- `uv run pytest tests/test_ampacity_check.py tests/test_cli_check_ampacity.py tests/test_check_cmd_coverage.py` → 31 passed.
- Broad related set (`-k "ampacity or check_cmd or check_impedance or check_coverage or dru"`) → 133 passed, 6 skipped.
- `ruff check` + `ruff format` clean on changed files.
- `scripts/ci/check_mypy_baseline.py` → 0 new type errors.

Closes #4217