### PR TITLE
feat(pcb): add `pcb reinforce` anchor-PTH row along a named net

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 4126
-# Branch: feature/issue-4126
+# Issue: 4220
+# Branch: feature/issue-4220
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/src/kicad_tools/cli/commands/pcb.py
+++ b/src/kicad_tools/cli/commands/pcb.py
@@ -13,7 +13,7 @@ def run_pcb_command(args) -> int:
     if not args.pcb_command:
         print("Usage: kicad-tools pcb <command> [options] <file>")
         print(
-            "Commands: summary, footprints, nets, traces, stackup, zones, strip, dedupe, reannotate, sync-netlist, add-3d-models, remove-footprint, move-footprint, page-fit, center-on-sheet, lock-footprints, unlock-footprints, add-zone, snap-rotation, edit-outline, net-audit, export-dsn, import-ses"
+            "Commands: summary, footprints, nets, traces, stackup, zones, strip, reinforce, dedupe, reannotate, sync-netlist, add-3d-models, remove-footprint, move-footprint, page-fit, center-on-sheet, lock-footprints, unlock-footprints, add-zone, snap-rotation, edit-outline, net-audit, export-dsn, import-ses"
         )
         return 1
 
@@ -29,6 +29,10 @@ def run_pcb_command(args) -> int:
     # Handle strip command separately (doesn't use pcb_query)
     if args.pcb_command == "strip":
         return _run_strip_command(args, pcb_path)
+
+    # Handle reinforce command (Unit A of #4218; issue #4220)
+    if args.pcb_command == "reinforce":
+        return _run_reinforce_command(args, pcb_path)
 
     # Handle dedupe command (remove exact-duplicate copper; issue #4175)
     if args.pcb_command == "dedupe":
@@ -440,6 +444,120 @@ def _run_dedupe_command(args, pcb_path: Path) -> int:
 
     # Save only when something changed and not a dry-run.
     if not dry_run and (stats["segments"] or stats["vias"]):
+        try:
+            pcb.save(output_path)
+            if output_format == "text":
+                print()
+                print(f"  Saved to: {output_path}")
+        except Exception as e:
+            print(f"Error saving PCB: {e}", file=sys.stderr)
+            return 1
+
+    return 0
+
+
+def _run_reinforce_command(args, pcb_path: Path) -> int:
+    """Handle the 'pcb reinforce' command (Unit A of #4218; issue #4220).
+
+    Post-route pass that walks a routed net's segments into ordered
+    polylines and emits a spaced row of same-net plated-PTH anchor vias
+    along the longest run, sized to a wire gauge. Anchors that would
+    collide with a different net are refused and reported, never placed.
+    In-place by default; ``-o`` writes elsewhere; ``--dry-run`` reports
+    without writing.
+    """
+    from kicad_tools.pcb.reinforce import ReinforceError, reinforce_net
+    from kicad_tools.schema.pcb import PCB
+
+    net_name = getattr(args, "net", None)
+    if not net_name:
+        print("Error: --net is required", file=sys.stderr)
+        return 1
+
+    wire_gauge = getattr(args, "wire_gauge", 16)
+    spacing = getattr(args, "spacing", 15.0)
+    layer = getattr(args, "layer", None)
+    dry_run = getattr(args, "dry_run", False)
+    output_format = getattr(args, "format", "text")
+    output_path = Path(args.output) if getattr(args, "output", None) else pcb_path
+
+    try:
+        pcb = PCB.load(pcb_path)
+    except Exception as e:
+        print(f"Error loading PCB: {e}", file=sys.stderr)
+        return 1
+
+    try:
+        outcome = reinforce_net(
+            pcb,
+            net_name,
+            wire_gauge_awg=wire_gauge,
+            spacing_mm=spacing,
+            layer=layer,
+            dry_run=dry_run,
+        )
+    except ReinforceError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    result: dict[str, Any] = {
+        "input": str(pcb_path),
+        "output": str(output_path) if not dry_run else None,
+        "dry_run": dry_run,
+        "net": outcome.net_name,
+        "layer": outcome.layer,
+        "wire_gauge_awg": outcome.wire_gauge_awg,
+        "anchor_drill_mm": round(outcome.anchor_drill_mm, 4),
+        "anchor_pad_mm": round(outcome.anchor_pad_mm, 4),
+        "spacing_mm": outcome.spacing_mm,
+        "run_segment_count": outcome.run_segment_count,
+        "run_length_mm": round(outcome.run_length_mm, 4),
+        "unhandled_runs": outcome.unhandled_runs,
+        "anchors_placed": outcome.placed_count,
+        "anchors_refused": outcome.refused_count,
+        "refused": [
+            {"x": round(r.x, 4), "y": round(r.y, 4), "reason": r.reason} for r in outcome.refused
+        ],
+    }
+
+    if output_format == "json":
+        print(json.dumps(result, indent=2))
+    else:
+        label = " (dry run)" if dry_run else ""
+        print(f"PCB Reinforce{label}")
+        print(f"  Input:  {pcb_path}")
+        if not dry_run:
+            print(f"  Output: {output_path}")
+        print()
+        print(f"  Net:            {outcome.net_name}")
+        print(f"  Layer:          {outcome.layer}")
+        print(f"  Wire gauge:     {outcome.wire_gauge_awg} AWG")
+        print(f"  Anchor drill:   {outcome.anchor_drill_mm:.3f} mm")
+        print(f"  Anchor pad:     {outcome.anchor_pad_mm:.3f} mm")
+        print(f"  Spacing:        {outcome.spacing_mm:.1f} mm")
+        print(
+            f"  Anchored run:   {outcome.run_segment_count} segment(s), "
+            f"{outcome.run_length_mm:.1f} mm"
+        )
+        if outcome.unhandled_runs:
+            print(
+                f"  Unhandled runs: {outcome.unhandled_runs} "
+                "(branch/disconnected run(s) on this net NOT anchored)"
+            )
+        print()
+        print(f"  Anchors placed:  {outcome.placed_count}")
+        print(f"  Anchors refused: {outcome.refused_count}")
+        for r in outcome.refused:
+            print(f"    refused at ({r.x:.2f}, {r.y:.2f}): {r.reason}")
+        if not dry_run and outcome.placed_count:
+            print()
+            print(
+                "  NOTE: anchors are same-net vias -- refill zone pours "
+                "afterward (e.g. `kicad-cli pcb drc --refill-zones`)."
+            )
+
+    # Save unless dry-run and at least one anchor was placed.
+    if not dry_run and outcome.placed_count:
         try:
             pcb.save(output_path)
             if output_format == "text":

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1610,6 +1610,63 @@ def _add_pcb_parser(subparsers) -> None:
         help="Show what would be removed without modifying files",
     )
 
+    # pcb reinforce (issue #4220 -- Unit A of #4218)
+    pcb_reinforce = pcb_subparsers.add_parser(
+        "reinforce",
+        help="Emit a spaced same-net PTH anchor row along a routed net",
+        description="Post-route buttress-wire reinforcement (Unit A of #4218). "
+        "Walks a routed net's segments into ordered polylines and emits a "
+        "spaced row of same-net plated through-hole (PTH) anchor vias along the "
+        "longest run, sized to a wire gauge and respecting the annular-ring "
+        "floor. A solid-core wire is later soldered through the anchor row to "
+        "carry additional current. Anchors are same-net (no shorts); a candidate "
+        "that would collide with a DIFFERENT net is refused and reported, not "
+        "placed. NOTE: anchors are same-net vias -- existing zone pours must be "
+        "refilled afterward (e.g. `kicad-cli pcb drc --refill-zones`) so the "
+        "pours knock out around them. In-place by default; use -o to write "
+        "elsewhere.",
+    )
+    pcb_reinforce.add_argument("pcb", help="Path to .kicad_pcb file")
+    pcb_reinforce.add_argument(
+        "--net",
+        required=True,
+        help="Net name to reinforce (must have routed copper)",
+    )
+    pcb_reinforce.add_argument(
+        "--wire-gauge",
+        type=int,
+        default=16,
+        help="Buttress-wire gauge in AWG (default: 16; also supports 14, 12)",
+    )
+    pcb_reinforce.add_argument(
+        "--spacing",
+        type=float,
+        default=15.0,
+        help="Arc-length spacing between mid-run anchors, in mm (default: 15.0)",
+    )
+    pcb_reinforce.add_argument(
+        "--layer",
+        help="Restrict to a copper layer (default: layer with the most "
+        "cumulative routed length for the net)",
+    )
+    pcb_reinforce.add_argument(
+        "-o",
+        "--output",
+        dest="output",
+        help="Output file path (default: modify in place)",
+    )
+    pcb_reinforce.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format for results",
+    )
+    pcb_reinforce.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report anchors that would be placed/refused without writing files",
+    )
+
     # pcb dedupe (issue #4175)
     pcb_dedupe = pcb_subparsers.add_parser(
         "dedupe",

--- a/src/kicad_tools/pcb/reinforce.py
+++ b/src/kicad_tools/pcb/reinforce.py
@@ -65,7 +65,7 @@ DEFAULT_ANCHOR_SPACING_MM = 15.0
 # JLCPCB-tier-typical values; the annular-ring floor is what actually sizes
 # the anchor pad. The reinforce pass NEVER hardcodes the annular ring at a
 # call site -- it always reads it from these rules (real or fallback).
-_FALLBACK_DESIGN_RULES = DesignRules(
+_FALLBACK_DESIGN_RULES = DesignRules(  # noqa: MFR001 reason="intentional manufacturer-agnostic fallback: reinforce is a post-route pass that runs when no manufacturer profile is supplied; a real profile overrides these JLCPCB-tier-typical defaults when threaded in"
     min_trace_width_mm=0.127,
     min_clearance_mm=0.2,
     min_via_drill_mm=0.3,

--- a/src/kicad_tools/pcb/reinforce.py
+++ b/src/kicad_tools/pcb/reinforce.py
@@ -1,0 +1,519 @@
+"""Buttress-wire reinforcement: anchor-PTH row along a named net.
+
+Unit A (MVP) of the #4218 buttress-wire reinforcement design (Part 2 of
+the #4215 ampacity feature). This is a **post-route** pass that reads an
+already-routed board, walks the routed copper of one named net into
+ordered polylines, and emits a spaced row of **same-net** plated
+through-hole (PTH) anchor vias along the longest run. A solid-core copper
+wire ("buttress wire") is later soldered through the anchor row by hand to
+carry additional current.
+
+Structural template: ``kct stitch`` (``cli/stitch_cmd.py``) -- a
+load -> add-geometry-to-a-named-net -> save pass. Anchors are emitted via
+:meth:`kicad_tools.schema.pcb.PCB.add_via` (a large plated via IS a PTH).
+
+Key properties:
+
+* **Same-net, no shorts.** Anchors carry the target net, so they never
+  short the trace to itself.
+* **Clearance-refuse, not silent short.** Before committing each anchor,
+  the pass runs
+  :func:`kicad_tools.router.via_clearance.point_clear_of_copper` against
+  all *other*-net copper (tracks / vias / pads / filled zone polygons) and
+  the manufacturer hole-to-hole floor. A colliding anchor is REFUSED and
+  reported -- never silently placed (a short) and never silently dropped.
+* **Junction-aware chaining.** Segment chaining reuses the hardened
+  junction-splitting chainer
+  (:func:`kicad_tools.router.optimizer.chain.sort_into_chains`) via a thin
+  adapter from :class:`kicad_tools.schema.pcb.Segment` to
+  :class:`kicad_tools.router.primitives.Segment`. For the MVP the longest
+  run is anchored and any additional branches are *reported* as unhandled.
+
+Out of scope (later units, tracked on #4218): mask-opening channel
+(Unit B), net-class ``reinforced`` wiring (Unit C), HV keep-away
+(Unit D), ampacity-credit coupling in #4217 (Unit E), first-class
+HV/creepage model (Unit F).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+from kicad_tools.core.types import CopperLayer
+from kicad_tools.manufacturers.base import DesignRules
+from kicad_tools.physics.wire_gauge import (
+    DEFAULT_WIRE_GAUGE_AWG,
+    anchor_drill_for_awg,
+    anchor_pad_for_drill,
+)
+from kicad_tools.router.optimizer.chain import sort_into_chains
+from kicad_tools.router.primitives import Segment as RouterSegment
+from kicad_tools.router.via_clearance import (
+    FilledPolygonLike,
+    ForeignPadTuple,
+    TrackSegmentLike,
+    point_clear_of_copper,
+)
+from kicad_tools.schema.pcb import PCB, Segment
+
+# Default spacing between mid-run anchors (mm). Matches the architect's
+# ``ReinforcementSpec.anchor_spacing_mm`` default.
+DEFAULT_ANCHOR_SPACING_MM = 15.0
+
+# Fallback design rules when no manufacturer profile is supplied. These are
+# JLCPCB-tier-typical values; the annular-ring floor is what actually sizes
+# the anchor pad. The reinforce pass NEVER hardcodes the annular ring at a
+# call site -- it always reads it from these rules (real or fallback).
+_FALLBACK_DESIGN_RULES = DesignRules(
+    min_trace_width_mm=0.127,
+    min_clearance_mm=0.2,
+    min_via_drill_mm=0.3,
+    min_via_diameter_mm=0.6,
+    min_annular_ring_mm=0.25,
+    min_hole_to_hole_mm=0.5,
+)
+
+
+@dataclass
+class RefusedAnchor:
+    """An anchor position that was refused for clearance reasons."""
+
+    x: float
+    y: float
+    reason: str
+
+
+@dataclass
+class PlacedAnchor:
+    """An anchor via that was placed."""
+
+    x: float
+    y: float
+
+
+@dataclass
+class ReinforceResult:
+    """Outcome of a :func:`reinforce_net` pass."""
+
+    net_name: str
+    wire_gauge_awg: int
+    anchor_drill_mm: float
+    anchor_pad_mm: float
+    spacing_mm: float
+    layer: str = ""
+    #: Segments chained into the anchored (longest) run.
+    run_segment_count: int = 0
+    #: Cumulative arc length of the anchored run, in mm.
+    run_length_mm: float = 0.0
+    #: Number of additional linear runs on this net that were NOT anchored
+    #: (branches / disconnected runs -- reported, not silently dropped).
+    unhandled_runs: int = 0
+    placed: list[PlacedAnchor] = field(default_factory=list)
+    refused: list[RefusedAnchor] = field(default_factory=list)
+
+    @property
+    def placed_count(self) -> int:
+        return len(self.placed)
+
+    @property
+    def refused_count(self) -> int:
+        return len(self.refused)
+
+
+class ReinforceError(ValueError):
+    """Raised when the reinforce pass cannot proceed (e.g. unknown net)."""
+
+
+def _seg_length(seg: Segment) -> float:
+    (x1, y1), (x2, y2) = seg.start, seg.end
+    return math.hypot(x2 - x1, y2 - y1)
+
+
+def _to_router_segment(seg: Segment) -> RouterSegment:
+    """Adapt a schema ``Segment`` to the chainer's ``router`` ``Segment``.
+
+    The junction-aware chainer (:func:`sort_into_chains`) operates on
+    :class:`kicad_tools.router.primitives.Segment` (``x1/y1/x2/y2``), while
+    a parsed board yields :class:`kicad_tools.schema.pcb.Segment`
+    (``start``/``end`` tuples). This trivial field mapping lets the pass
+    reuse the single hardened chaining implementation rather than fork it.
+    """
+    (x1, y1), (x2, y2) = seg.start, seg.end
+    # ``sort_into_chains`` only reads the ``x1/y1/x2/y2`` endpoints; the
+    # ``layer`` field (a ``CopperLayer`` enum on the router type) is carried
+    # along but never consulted, so a placeholder is fine. Callers pre-filter
+    # segments to a single layer before chaining.
+    return RouterSegment(
+        x1=x1,
+        y1=y1,
+        x2=x2,
+        y2=y2,
+        width=seg.width,
+        layer=CopperLayer.F_CU,
+        net=seg.net_number,
+        net_name=seg.net_name,
+    )
+
+
+def _chain_polylines(segments: list[Segment]) -> list[list[Segment]]:
+    """Chain schema segments into ordered, junction-split polylines.
+
+    Returns a list of runs, each an ordered list of the *original* schema
+    ``Segment`` objects walked endpoint-to-endpoint. Junctions (degree>=3)
+    split runs so branched nets are not silently merged.
+    """
+    if not segments:
+        return []
+
+    router_segs = [_to_router_segment(s) for s in segments]
+    chains = sort_into_chains(router_segs)
+
+    # Map each returned (possibly flipped) router segment back to the
+    # original schema segment by index. ``sort_into_chains`` preserves the
+    # ``width``/``layer``/``net`` fields and only ever flips endpoints, so we
+    # match on the unordered endpoint pair + width to recover the index.
+    remaining = list(range(len(segments)))
+
+    def _match(rseg: RouterSegment) -> int:
+        target_pts = frozenset(
+            {
+                (round(rseg.x1, 6), round(rseg.y1, 6)),
+                (round(rseg.x2, 6), round(rseg.y2, 6)),
+            }
+        )
+        for idx in remaining:
+            s = segments[idx]
+            pts = frozenset(
+                {
+                    (round(s.start[0], 6), round(s.start[1], 6)),
+                    (round(s.end[0], 6), round(s.end[1], 6)),
+                }
+            )
+            if pts == target_pts and abs(s.width - rseg.width) < 1e-9:
+                return idx
+        # Fallback: endpoint-only match (width drift tolerance).
+        for idx in remaining:
+            s = segments[idx]
+            pts = frozenset(
+                {
+                    (round(s.start[0], 6), round(s.start[1], 6)),
+                    (round(s.end[0], 6), round(s.end[1], 6)),
+                }
+            )
+            if pts == target_pts:
+                return idx
+        return -1
+
+    result: list[list[Segment]] = []
+    for chain in chains:
+        run: list[Segment] = []
+        for rseg in chain:
+            idx = _match(rseg)
+            if idx < 0:
+                continue
+            remaining.remove(idx)
+            # Re-orient the original schema segment to match the chained
+            # walk direction so the arc-length walk is continuous.
+            orig = segments[idx]
+            if abs(orig.start[0] - rseg.x1) < 1e-6 and abs(orig.start[1] - rseg.y1) < 1e-6:
+                run.append(orig)
+            else:
+                run.append(
+                    Segment(
+                        start=orig.end,
+                        end=orig.start,
+                        width=orig.width,
+                        layer=orig.layer,
+                        net_number=orig.net_number,
+                        net_name=orig.net_name,
+                        uuid=orig.uuid,
+                    )
+                )
+        if run:
+            result.append(run)
+    return result
+
+
+def _run_length(run: list[Segment]) -> float:
+    return sum(_seg_length(s) for s in run)
+
+
+def _ordered_points(run: list[Segment]) -> list[tuple[float, float]]:
+    """Return the ordered vertex list of an oriented run polyline."""
+    if not run:
+        return []
+    pts: list[tuple[float, float]] = [run[0].start]
+    for seg in run:
+        pts.append(seg.end)
+    return pts
+
+
+def _anchor_positions(
+    points: list[tuple[float, float]], spacing: float
+) -> list[tuple[float, float]]:
+    """Sample anchor positions along a polyline by arc length.
+
+    Places anchors at arc-length 0, ``spacing``, ``2*spacing``, ... and
+    always at the final endpoint (so both true endpoints are anchored even
+    if the last interval is shorter than ``spacing``).
+    """
+    if len(points) < 2:
+        return list(points)
+    if spacing <= 0:
+        raise ReinforceError(f"spacing must be positive, got {spacing}")
+
+    # Cumulative arc length at each vertex.
+    cum: list[float] = [0.0]
+    for i in range(1, len(points)):
+        (x0, y0), (x1, y1) = points[i - 1], points[i]
+        cum.append(cum[-1] + math.hypot(x1 - x0, y1 - y0))
+    total = cum[-1]
+
+    targets: list[float] = []
+    d = 0.0
+    while d < total - 1e-9:
+        targets.append(d)
+        d += spacing
+    targets.append(total)  # always the final endpoint
+
+    positions: list[tuple[float, float]] = []
+    seg_i = 0
+    for t in targets:
+        # Advance to the polyline segment containing arc length ``t``.
+        while seg_i < len(cum) - 2 and cum[seg_i + 1] < t:
+            seg_i += 1
+        seg_len = cum[seg_i + 1] - cum[seg_i]
+        if seg_len <= 1e-12:
+            positions.append(points[seg_i])
+            continue
+        frac = (t - cum[seg_i]) / seg_len
+        frac = max(0.0, min(1.0, frac))
+        (x0, y0), (x1, y1) = points[seg_i], points[seg_i + 1]
+        positions.append((x0 + frac * (x1 - x0), y0 + frac * (y1 - y0)))
+    return positions
+
+
+class _TrackObstacle:
+    """Minimal duck-typed track for ``point_clear_of_copper``."""
+
+    __slots__ = ("start_x", "start_y", "end_x", "end_y", "width")
+
+    def __init__(self, sx: float, sy: float, ex: float, ey: float, width: float) -> None:
+        self.start_x = sx
+        self.start_y = sy
+        self.end_x = ex
+        self.end_y = ey
+        self.width = width
+
+
+class _FilledPolyObstacle:
+    """Minimal duck-typed filled polygon for ``point_clear_of_copper``."""
+
+    __slots__ = ("points", "min_x", "min_y", "max_x", "max_y")
+
+    def __init__(self, points: list[tuple[float, float]]) -> None:
+        self.points = points
+        xs = [p[0] for p in points]
+        ys = [p[1] for p in points]
+        self.min_x = min(xs)
+        self.min_y = min(ys)
+        self.max_x = max(xs)
+        self.max_y = max(ys)
+
+
+@dataclass
+class _OtherNetCopper:
+    """Collected other-net copper for the clearance re-check."""
+
+    tracks: list[TrackSegmentLike] = field(default_factory=list)
+    vias: list[tuple[float, float, float, int]] = field(default_factory=list)
+    pads: list[ForeignPadTuple] = field(default_factory=list)
+    filled_polygons: list[FilledPolygonLike] = field(default_factory=list)
+    drills: list[tuple[float, float, float, int]] = field(default_factory=list)
+
+
+def _collect_other_net_copper(pcb: PCB, target_net: int) -> _OtherNetCopper:
+    """Build the other-net obstacle set (everything NOT on ``target_net``)."""
+    other = _OtherNetCopper()
+
+    for seg in pcb.segments:
+        if seg.net_number == target_net:
+            continue
+        (sx, sy), (ex, ey) = seg.start, seg.end
+        other.tracks.append(_TrackObstacle(sx, sy, ex, ey, seg.width))
+
+    for via in pcb.vias:
+        if via.net_number == target_net:
+            continue
+        vx, vy = via.position
+        other.vias.append((vx, vy, via.size, via.net_number))
+        if via.drill > 0:
+            other.drills.append((vx, vy, via.drill, via.net_number))
+
+    for fp in pcb.footprints:
+        for pad in fp.pads:
+            if pad.net_number == target_net:
+                continue
+            pos = pcb.get_pad_position(fp.reference, pad.number)
+            if pos is None:
+                continue
+            px, py = pos
+            # Effective bounding radius of the pad (disc model).
+            radius = max(pad.size) / 2.0 if pad.size else 0.0
+            other.pads.append((px, py, radius, pad.net_number))
+            if pad.drill > 0:
+                other.drills.append((px, py, pad.drill, pad.net_number))
+
+    for zone in pcb.zones:
+        if zone.net_number == target_net:
+            continue
+        for poly in zone.filled_polygons:
+            if len(poly) >= 3:
+                other.filled_polygons.append(_FilledPolyObstacle(list(poly)))
+
+    return other
+
+
+def reinforce_net(
+    pcb: PCB,
+    net_name: str,
+    *,
+    wire_gauge_awg: int = DEFAULT_WIRE_GAUGE_AWG,
+    spacing_mm: float = DEFAULT_ANCHOR_SPACING_MM,
+    design_rules: DesignRules | None = None,
+    layer: str | None = None,
+    dry_run: bool = False,
+) -> ReinforceResult:
+    """Emit a spaced same-net PTH anchor row along a routed net's trace.
+
+    Post-route pass: chains the target net's routed segments into ordered
+    polylines, selects the longest linear run, and places gauge-sized
+    plated-PTH anchor vias at both endpoints and every ``spacing_mm`` along
+    it. Each candidate anchor is clearance-checked against all other-net
+    copper; colliding anchors are refused (reported, not placed).
+
+    Args:
+        pcb: A loaded :class:`~kicad_tools.schema.pcb.PCB`.
+        net_name: Target net name (must have routed copper).
+        wire_gauge_awg: Buttress-wire gauge (default 16 AWG). Sizes the
+            anchor drill/pad.
+        spacing_mm: Arc-length spacing between mid-run anchors (mm).
+        design_rules: Manufacturer :class:`DesignRules` supplying
+            ``min_annular_ring_mm`` (anchor pad sizing), ``min_clearance_mm``
+            (other-net clearance), and ``min_hole_to_hole_mm``. Falls back to
+            JLCPCB-tier-typical values when ``None``.
+        layer: Restrict to this copper layer. When ``None``, the layer with
+            the most cumulative segment length for the net is chosen.
+        dry_run: When True, compute the placed/refused plan without
+            mutating the board (no vias added).
+
+    Returns:
+        A :class:`ReinforceResult` summarising placed/refused anchors and
+        the anchored run.
+
+    Raises:
+        ReinforceError: If the net does not exist, has no routed copper, or
+            ``spacing_mm`` is non-positive.
+    """
+    if spacing_mm <= 0:
+        raise ReinforceError(f"spacing_mm must be positive, got {spacing_mm}")
+
+    rules = design_rules or _FALLBACK_DESIGN_RULES
+
+    # Resolve the net. Accept a net that exists in the net table OR that has
+    # segments carrying its name (some boards carry name-only segments).
+    net_obj = pcb.get_net_by_name(net_name)
+    net_segments = [
+        s
+        for s in pcb.segments
+        if s.net_name == net_name or (net_obj is not None and s.net_number == net_obj.number)
+    ]
+    if net_obj is None and not net_segments:
+        raise ReinforceError(f"net {net_name!r} not found on board")
+
+    target_net_number = (
+        net_obj.number
+        if net_obj is not None
+        else (net_segments[0].net_number if net_segments else 0)
+    )
+
+    anchor_drill = anchor_drill_for_awg(wire_gauge_awg)
+    anchor_pad = anchor_pad_for_drill(anchor_drill, rules.min_annular_ring_mm)
+
+    result = ReinforceResult(
+        net_name=net_name,
+        wire_gauge_awg=wire_gauge_awg,
+        anchor_drill_mm=anchor_drill,
+        anchor_pad_mm=anchor_pad,
+        spacing_mm=spacing_mm,
+    )
+
+    if not net_segments:
+        raise ReinforceError(f"net {net_name!r} has no routed copper to reinforce")
+
+    # Group by layer; pick the layer with the most cumulative length (MVP).
+    by_layer: dict[str, list[Segment]] = {}
+    for s in net_segments:
+        by_layer.setdefault(s.layer, []).append(s)
+
+    if layer is not None:
+        if layer not in by_layer:
+            raise ReinforceError(f"net {net_name!r} has no routed copper on layer {layer!r}")
+        target_layer = layer
+    else:
+        target_layer = max(by_layer, key=lambda lay: sum(_seg_length(s) for s in by_layer[lay]))
+    result.layer = target_layer
+
+    runs = _chain_polylines(by_layer[target_layer])
+    if not runs:
+        raise ReinforceError(f"net {net_name!r} produced no walkable polyline")
+
+    runs.sort(key=_run_length, reverse=True)
+    anchored_run = runs[0]
+    result.run_segment_count = len(anchored_run)
+    result.run_length_mm = _run_length(anchored_run)
+    result.unhandled_runs = len(runs) - 1
+
+    points = _ordered_points(anchored_run)
+    positions = _anchor_positions(points, spacing_mm)
+
+    other = _collect_other_net_copper(pcb, target_net_number)
+
+    for x, y in positions:
+        clear = point_clear_of_copper(
+            x,
+            y,
+            via_size=anchor_pad,
+            clearance=rules.min_clearance_mm,
+            other_net_tracks=other.tracks,
+            other_net_vias=other.vias,
+            other_net_pads=other.pads,
+            other_net_filled_polygons=other.filled_polygons,
+            via_drill=anchor_drill,
+            other_net_drills=other.drills,
+            min_hole_to_hole=rules.min_hole_to_hole_mm,
+        )
+        if not clear:
+            result.refused.append(
+                RefusedAnchor(
+                    x=x,
+                    y=y,
+                    reason="other-net clearance/hole-to-hole violation",
+                )
+            )
+            continue
+
+        if not dry_run:
+            pcb.add_via(
+                x,
+                y,
+                size=anchor_pad,
+                drill=anchor_drill,
+                layers=("F.Cu", "B.Cu"),
+                net=net_name,
+                dedupe=True,
+            )
+        result.placed.append(PlacedAnchor(x=x, y=y))
+
+    return result

--- a/src/kicad_tools/physics/__init__.py
+++ b/src/kicad_tools/physics/__init__.py
@@ -93,6 +93,15 @@ from .transmission_line import (
     ImpedanceResult,
     TransmissionLine,
 )
+from .wire_gauge import (
+    DEFAULT_SLIP_FIT_CLEARANCE_MM,
+    DEFAULT_WIRE_GAUGE_AWG,
+    anchor_drill_for_awg,
+    anchor_pad_for_drill,
+    bare_copper_diameter_mm,
+    supported_gauges,
+    wire_ampacity,
+)
 
 __all__ = [
     # Constants
@@ -106,6 +115,14 @@ __all__ = [
     "copper_thickness_from_oz",
     # Ampacity (IPC-2221)
     "width_for_current",
+    # Wire gauge (AWG) / buttress-wire reinforcement
+    "DEFAULT_SLIP_FIT_CLEARANCE_MM",
+    "DEFAULT_WIRE_GAUGE_AWG",
+    "bare_copper_diameter_mm",
+    "anchor_drill_for_awg",
+    "anchor_pad_for_drill",
+    "supported_gauges",
+    "wire_ampacity",
     # Materials
     "DielectricMaterial",
     "FR4_STANDARD",

--- a/src/kicad_tools/physics/wire_gauge.py
+++ b/src/kicad_tools/physics/wire_gauge.py
@@ -1,0 +1,195 @@
+"""Wire-gauge (AWG) physical constants for buttress-wire reinforcement.
+
+This module houses the standard American Wire Gauge (AWG) bare-copper
+diameter table plus the derived anchor-hole geometry used by the
+``kct pcb reinforce`` pass (Unit A of the #4218 buttress-wire
+reinforcement design, Part 2 of the #4215 ampacity feature).
+
+A "buttress wire" is a solid-core copper wire soldered along a
+high-current trace to carry additional current. To anchor it, the
+reinforce pass drills a spaced row of plated through-holes sized so the
+wire drops through and solders. This module provides:
+
+* :func:`bare_copper_diameter_mm` -- AWG -> bare-copper diameter (mm).
+* :func:`anchor_drill_for_awg` -- drill diameter = wire diameter plus a
+  small slip-fit clearance so the wire drops in and solders.
+* :func:`anchor_pad_for_drill` -- pad diameter that satisfies the active
+  manufacturer's minimum annular-ring floor.
+* :func:`wire_ampacity` -- pure ampacity helper (bare/insulated wire of a
+  given gauge). Unit E (#4217 follow-up) will import this to credit a
+  reinforced trace's effective ampacity; it is *defined and unit-tested*
+  here but intentionally NOT wired into any check in this issue.
+
+The AWG diameter table lives here (next to :mod:`physics.ampacity`) so
+all "physical wire" constants stay in :mod:`physics`, consistent with
+``CopperWeight`` living in :mod:`physics.constants`.
+
+Example:
+    >>> from kicad_tools.physics.wire_gauge import (
+    ...     bare_copper_diameter_mm,
+    ...     anchor_drill_for_awg,
+    ...     anchor_pad_for_drill,
+    ... )
+    >>> round(bare_copper_diameter_mm(16), 3)
+    1.291
+    >>> drill = anchor_drill_for_awg(16)
+    >>> round(drill, 3)
+    1.416
+    >>> round(anchor_pad_for_drill(drill, min_annular_ring_mm=0.25), 3)
+    1.916
+"""
+
+from __future__ import annotations
+
+# Standard AWG bare (solid) copper diameters, in millimeters.
+#
+# AWG diameter follows the geometric progression
+# ``d(n) = 0.127 mm * 92 ** ((36 - n) / 39)`` (an AWG step multiplies the
+# diameter by ~1.1229). The values below are that formula rounded to
+# 3 decimals, matching published standard wire-gauge tables. Only the
+# gauges the reinforce pass supports are enumerated; add rows here to
+# support more.
+_AWG_DIAMETER_MM: dict[int, float] = {
+    12: 2.053,
+    14: 1.628,
+    16: 1.291,
+}
+
+# Slip-fit clearance added to the bare-copper diameter to size the anchor
+# drill. ~0.1-0.15 mm gives a hand-solderable drop-in fit (the wire seats
+# with a small solder fillet rather than an interference press).
+DEFAULT_SLIP_FIT_CLEARANCE_MM = 0.125
+
+#: Default wire gauge for the reinforce pass (16 AWG solid core).
+DEFAULT_WIRE_GAUGE_AWG = 16
+
+# IPC-2221-style ampacity constants for a free-standing/insulated round
+# wire. ``wire_ampacity`` reuses the same empirical form as
+# :func:`kicad_tools.physics.ampacity.width_for_current` (external-layer
+# constant, since a buttress wire sheds heat on all sides like an outer
+# trace) applied to the wire's circular cross-section.
+_AMPACITY_K = 0.048  # external / free-air constant
+_DELTA_T_EXPONENT = 0.44
+_AREA_EXPONENT = 0.725
+_MM2_PER_MIL2 = 1.0 / (0.0254**2)  # 1 mil = 0.0254 mm -> mm**2 -> mils**2
+
+_MATH_PI = 3.141592653589793
+
+
+def supported_gauges() -> tuple[int, ...]:
+    """Return the AWG gauges this module knows about, largest wire first."""
+    return tuple(sorted(_AWG_DIAMETER_MM, reverse=False))
+
+
+def bare_copper_diameter_mm(awg: int) -> float:
+    """Return the bare (solid) copper diameter for an AWG gauge, in mm.
+
+    Args:
+        awg: American Wire Gauge number (e.g. ``16``). Only the gauges in
+            :func:`supported_gauges` are known.
+
+    Returns:
+        Bare-copper diameter in millimeters.
+
+    Raises:
+        ValueError: If ``awg`` is not a supported gauge.
+    """
+    try:
+        return _AWG_DIAMETER_MM[int(awg)]
+    except KeyError:
+        supported = ", ".join(str(g) for g in supported_gauges())
+        raise ValueError(
+            f"unsupported wire gauge {awg} AWG; supported gauges: {supported}"
+        ) from None
+
+
+def anchor_drill_for_awg(
+    awg: int,
+    slip_fit_clearance_mm: float = DEFAULT_SLIP_FIT_CLEARANCE_MM,
+) -> float:
+    """Return the anchor drill diameter for a wire gauge, in mm.
+
+    The drill is the bare-copper diameter plus a small slip-fit clearance
+    so the solid-core wire drops through the plated hole and solders.
+
+    Args:
+        awg: American Wire Gauge number.
+        slip_fit_clearance_mm: Extra diameter over the bare wire (default
+            :data:`DEFAULT_SLIP_FIT_CLEARANCE_MM`). Must be >= 0.
+
+    Returns:
+        Anchor drill diameter in millimeters.
+
+    Raises:
+        ValueError: If ``awg`` is unsupported or ``slip_fit_clearance_mm``
+            is negative.
+    """
+    if slip_fit_clearance_mm < 0:
+        raise ValueError(f"slip_fit_clearance_mm must be >= 0, got {slip_fit_clearance_mm}")
+    return bare_copper_diameter_mm(awg) + slip_fit_clearance_mm
+
+
+def anchor_pad_for_drill(drill_mm: float, min_annular_ring_mm: float) -> float:
+    """Return the anchor pad diameter that satisfies the annular-ring floor.
+
+    The annular ring is ``(pad_diameter - drill_diameter) / 2``. To meet
+    the manufacturer's minimum, the pad must be at least
+    ``drill + 2 * min_annular_ring``. This mirrors the constraint
+    ``validate/rules/solder_mask.py::_check_pth_annular_ring`` enforces.
+
+    Args:
+        drill_mm: Anchor drill diameter in mm (must be > 0).
+        min_annular_ring_mm: Minimum annular ring from the active
+            manufacturer profile's ``DesignRules.min_annular_ring_mm``
+            (NOT a hardcoded constant). Must be >= 0.
+
+    Returns:
+        Anchor pad diameter in millimeters.
+
+    Raises:
+        ValueError: If ``drill_mm`` is non-positive or
+            ``min_annular_ring_mm`` is negative.
+    """
+    if drill_mm <= 0:
+        raise ValueError(f"drill_mm must be positive, got {drill_mm}")
+    if min_annular_ring_mm < 0:
+        raise ValueError(f"min_annular_ring_mm must be >= 0, got {min_annular_ring_mm}")
+    return drill_mm + 2.0 * min_annular_ring_mm
+
+
+def wire_ampacity(awg: int, temp_rise_c: float = 10.0) -> float:
+    """Return the ampacity (amps) of a bare/insulated wire of this gauge.
+
+    Pure helper. Applies the IPC-2221 external/free-air current-capacity
+    form ``I = k * delta_t**0.44 * A**0.725`` to the wire's circular
+    copper cross-section, where ``A`` is in mils**2. A free-standing wire
+    sheds heat on all sides, so the external constant (``k = 0.048``) is
+    used.
+
+    .. note::
+        Unit E / #4217 follow-up will import this to credit a reinforced
+        trace's effective ampacity (trace copper + buttress wire). It is
+        defined and unit-tested here but is intentionally NOT wired into
+        #4217's ampacity check in this issue.
+
+    Args:
+        awg: American Wire Gauge number.
+        temp_rise_c: Allowed temperature rise above ambient, degrees C
+            (must be > 0). Defaults to the conservative ``10.0`` used by
+            :func:`kicad_tools.physics.ampacity.width_for_current`.
+
+    Returns:
+        Ampacity in amps.
+
+    Raises:
+        ValueError: If ``awg`` is unsupported or ``temp_rise_c`` <= 0.
+    """
+    if temp_rise_c <= 0:
+        raise ValueError(f"temp_rise_c must be positive, got {temp_rise_c}")
+
+    diameter_mm = bare_copper_diameter_mm(awg)
+    radius_mm = diameter_mm / 2.0
+    area_mm2 = _MATH_PI * radius_mm * radius_mm
+    area_mils2 = area_mm2 * _MM2_PER_MIL2
+
+    return float(_AMPACITY_K * temp_rise_c**_DELTA_T_EXPONENT * area_mils2**_AREA_EXPONENT)

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -4836,6 +4836,55 @@ class PCB:
 
         return via
 
+    def reinforce_net(
+        self,
+        net_name: str,
+        *,
+        wire_gauge_awg: int = 16,
+        spacing_mm: float = 15.0,
+        design_rules: object | None = None,
+        layer: str | None = None,
+        dry_run: bool = False,
+    ) -> object:
+        """Emit a spaced same-net PTH anchor row along a routed net.
+
+        Thin wrapper around
+        :func:`kicad_tools.pcb.reinforce.reinforce_net` (Unit A of the
+        #4218 buttress-wire reinforcement design). Chains the target net's
+        routed segments into ordered polylines, selects the longest run,
+        and places gauge-sized plated-PTH anchor vias at both endpoints and
+        every ``spacing_mm`` along it. Anchors are same-net (no shorts); a
+        candidate that would collide with a different net is refused and
+        reported rather than placed.
+
+        Args:
+            net_name: Target net name (must have routed copper).
+            wire_gauge_awg: Buttress-wire gauge in AWG (default 16).
+            spacing_mm: Arc-length spacing between mid-run anchors (mm).
+            design_rules: Manufacturer ``DesignRules`` supplying the
+                annular-ring / clearance / hole-to-hole floors. ``None``
+                uses JLCPCB-tier-typical fallback values.
+            layer: Restrict to a copper layer; ``None`` picks the layer with
+                the most cumulative routed length for the net.
+            dry_run: Compute the placement plan without adding vias.
+
+        Returns:
+            A ``kicad_tools.pcb.reinforce.ReinforceResult``.
+        """
+        from kicad_tools.manufacturers.base import DesignRules
+        from kicad_tools.pcb.reinforce import reinforce_net as _reinforce_net
+
+        rules = design_rules if isinstance(design_rules, DesignRules) else None
+        return _reinforce_net(
+            self,
+            net_name,
+            wire_gauge_awg=wire_gauge_awg,
+            spacing_mm=spacing_mm,
+            design_rules=rules,
+            layer=layer,
+            dry_run=dry_run,
+        )
+
     def dedupe_copper(self) -> dict[str, int]:
         """Remove pre-existing exact-duplicate copper (issue #4175).
 

--- a/tests/test_pcb_reinforce.py
+++ b/tests/test_pcb_reinforce.py
@@ -1,0 +1,530 @@
+"""Tests for buttress-wire reinforcement (Unit A of #4218; issue #4220).
+
+Covers the physics wire-gauge table, the polyline chaining + arc-length
+anchor walk, the clearance-refuse path, and the ``kct pcb reinforce`` CLI
+integration on synthetic routed boards.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.manufacturers.base import DesignRules
+from kicad_tools.pcb.reinforce import (
+    ReinforceError,
+    _anchor_positions,
+    _chain_polylines,
+    reinforce_net,
+)
+from kicad_tools.physics.wire_gauge import (
+    anchor_drill_for_awg,
+    anchor_pad_for_drill,
+    bare_copper_diameter_mm,
+    supported_gauges,
+    wire_ampacity,
+)
+from kicad_tools.schema.pcb import PCB, Segment
+
+# --------------------------------------------------------------------------
+# Physics: wire-gauge table
+# --------------------------------------------------------------------------
+
+
+class TestWireGauge:
+    def test_bare_copper_diameters(self):
+        assert bare_copper_diameter_mm(16) == pytest.approx(1.291, abs=1e-3)
+        assert bare_copper_diameter_mm(14) == pytest.approx(1.628, abs=1e-3)
+        assert bare_copper_diameter_mm(12) == pytest.approx(2.053, abs=1e-3)
+
+    def test_supported_gauges(self):
+        assert set(supported_gauges()) == {12, 14, 16}
+
+    def test_unsupported_gauge_raises(self):
+        with pytest.raises(ValueError, match="unsupported wire gauge"):
+            bare_copper_diameter_mm(10)
+
+    def test_anchor_drill_16awg(self):
+        # 1.291 bare + 0.125 slip-fit => ~1.416 mm, within the issue's
+        # ~1.40-1.45 mm band.
+        drill = anchor_drill_for_awg(16)
+        assert drill == pytest.approx(1.416, abs=1e-3)
+        assert 1.40 <= drill <= 1.45
+
+    def test_anchor_drill_14_12(self):
+        assert 1.75 <= anchor_drill_for_awg(14) <= 1.80
+        assert 2.15 <= anchor_drill_for_awg(12) <= 2.20
+
+    def test_anchor_drill_custom_clearance(self):
+        assert anchor_drill_for_awg(16, slip_fit_clearance_mm=0.0) == pytest.approx(1.291, abs=1e-3)
+
+    def test_anchor_drill_negative_clearance_raises(self):
+        with pytest.raises(ValueError, match="slip_fit_clearance_mm"):
+            anchor_drill_for_awg(16, slip_fit_clearance_mm=-0.1)
+
+    def test_anchor_pad_meets_annular_ring(self):
+        drill = anchor_drill_for_awg(16)
+        pad = anchor_pad_for_drill(drill, min_annular_ring_mm=0.25)
+        # pad within the issue's ~1.90-1.95 mm band at 0.25 annular ring.
+        assert pad == pytest.approx(1.916, abs=1e-3)
+        assert 1.90 <= pad <= 1.95
+        # Annular ring formula must hold.
+        assert (pad - drill) / 2 == pytest.approx(0.25, abs=1e-6)
+
+    def test_anchor_pad_sources_annular_from_rules(self):
+        drill = anchor_drill_for_awg(16)
+        # A larger annular-ring floor => larger pad (not hardcoded).
+        pad_small = anchor_pad_for_drill(drill, 0.15)
+        pad_large = anchor_pad_for_drill(drill, 0.30)
+        assert pad_large > pad_small
+        assert (pad_large - drill) / 2 == pytest.approx(0.30, abs=1e-6)
+
+    def test_anchor_pad_invalid_args(self):
+        with pytest.raises(ValueError):
+            anchor_pad_for_drill(0.0, 0.25)
+        with pytest.raises(ValueError):
+            anchor_pad_for_drill(1.4, -0.1)
+
+    def test_wire_ampacity_monotonic_and_positive(self):
+        # Larger wire (lower AWG) carries more current.
+        a16 = wire_ampacity(16)
+        a14 = wire_ampacity(14)
+        a12 = wire_ampacity(12)
+        assert 0 < a16 < a14 < a12
+        # Sanity magnitude for 16 AWG at a 10 C rise.
+        assert 20 <= a16 <= 45
+
+    def test_wire_ampacity_scales_with_temp_rise(self):
+        assert wire_ampacity(16, temp_rise_c=20) > wire_ampacity(16, temp_rise_c=10)
+
+    def test_wire_ampacity_invalid_temp(self):
+        with pytest.raises(ValueError):
+            wire_ampacity(16, temp_rise_c=0)
+
+
+# --------------------------------------------------------------------------
+# Fixtures: synthetic routed boards
+# --------------------------------------------------------------------------
+
+
+def _straight_run_pcb(net: str = "FUSED_LINE", length: float = 100.0) -> PCB:
+    """A board with a single straight horizontal run on ``net``.
+
+    Segments run left-to-right from (20, 50) to (20+length, 50) split into
+    four equal pieces so chaining is exercised.
+    """
+    pcb = PCB.create(width=200, height=100, center=False)
+    x0, y = 20.0, 50.0
+    n = 4
+    step = length / n
+    for i in range(n):
+        pcb.add_trace(
+            (x0 + i * step, y),
+            (x0 + (i + 1) * step, y),
+            width=2.0,
+            layer="F.Cu",
+            net=net,
+        )
+    return pcb
+
+
+def _branched_run_pcb(net: str = "FUSED_LINE") -> PCB:
+    """A Y-junction net with a clearly-longest linear run.
+
+    A degree-3 junction at (100, 50) fans into three linear runs; the
+    junction-aware chainer splits them (it does NOT merge across the
+    junction). Lengths are distinct so the longest run is unambiguous:
+      - west arm:  (20,50)  -> (100,50)  = 80 mm  (longest)
+      - east arm:  (100,50) -> (150,50)  = 50 mm
+      - branch:    (100,50) -> (100,70)  = 20 mm
+    """
+    pcb = PCB.create(width=200, height=120, center=False)
+    pcb.add_trace((20, 50), (100, 50), width=2.0, layer="F.Cu", net=net)
+    pcb.add_trace((100, 50), (150, 50), width=2.0, layer="F.Cu", net=net)
+    pcb.add_trace((100, 50), (100, 70), width=2.0, layer="F.Cu", net=net)
+    return pcb
+
+
+def _net_segments(pcb: PCB, net_name: str) -> list[Segment]:
+    """Return segments for ``net_name`` (``add_trace`` leaves seg net_name empty)."""
+    net_obj = pcb.get_net_by_name(net_name)
+    assert net_obj is not None
+    return [s for s in pcb.segments if s.net_number == net_obj.number]
+
+
+# --------------------------------------------------------------------------
+# Chaining + arc-length walk
+# --------------------------------------------------------------------------
+
+
+class TestChaining:
+    def test_straight_run_chains_to_single_ordered_polyline(self):
+        pcb = _straight_run_pcb(length=100.0)
+        segs = _net_segments(pcb, "FUSED_LINE")
+        runs = _chain_polylines(segs)
+        assert len(runs) == 1
+        run = runs[0]
+        assert len(run) == 4
+        # Ordered endpoint-to-endpoint.
+        for a, b in zip(run, run[1:], strict=False):
+            assert a.end == pytest.approx(b.start)
+        total = sum(math.dist(s.start, s.end) for s in run)
+        assert total == pytest.approx(100.0, abs=1e-6)
+
+    def test_branched_net_splits_and_longest_selected(self):
+        pcb = _branched_run_pcb()
+        segs = _net_segments(pcb, "FUSED_LINE")
+        runs = _chain_polylines(segs)
+        # Junction split => the three arms are separate linear runs (the
+        # chainer does NOT merge across the degree-3 junction).
+        assert len(runs) == 3
+        runs.sort(key=lambda r: sum(math.dist(s.start, s.end) for s in r), reverse=True)
+        longest_len = sum(math.dist(s.start, s.end) for s in runs[0])
+        assert longest_len == pytest.approx(80.0, abs=1e-6)
+
+    def test_anchor_positions_endpoints_and_spacing(self):
+        points = [(0.0, 0.0), (100.0, 0.0)]
+        positions = _anchor_positions(points, spacing=15.0)
+        xs = [p[0] for p in positions]
+        # 0,15,...,90 then the final endpoint 100.
+        assert xs[0] == pytest.approx(0.0)
+        assert xs[-1] == pytest.approx(100.0)
+        # Evenly spaced by arc length in the interior.
+        interior = xs[:-1]
+        for i in range(1, len(interior)):
+            assert interior[i] - interior[i - 1] == pytest.approx(15.0)
+
+    def test_anchor_positions_short_run_only_endpoints(self):
+        points = [(0.0, 0.0), (5.0, 0.0)]
+        positions = _anchor_positions(points, spacing=15.0)
+        assert len(positions) == 2
+        assert positions[0] == pytest.approx((0.0, 0.0))
+        assert positions[-1] == pytest.approx((5.0, 0.0))
+
+
+# --------------------------------------------------------------------------
+# reinforce_net API
+# --------------------------------------------------------------------------
+
+
+class TestReinforceNet:
+    def test_places_evenly_spaced_same_net_anchors(self):
+        pcb = _straight_run_pcb(length=100.0)
+        before = len(pcb.vias)
+        result = reinforce_net(pcb, "FUSED_LINE", spacing_mm=15.0)
+
+        assert result.refused_count == 0
+        assert result.placed_count >= 2
+        # A via was added per placed anchor.
+        assert len(pcb.vias) == before + result.placed_count
+
+        # All placed anchors carry the target net.
+        net_obj = pcb.get_net_by_name("FUSED_LINE")
+        assert net_obj is not None
+        added = pcb.vias[before:]
+        assert all(v.net_number == net_obj.number for v in added)
+
+        # Positions evenly spaced along the run by arc length (x increases
+        # monotonically; interior gaps == spacing).
+        xs = sorted(a.x for a in result.placed)
+        assert xs[0] == pytest.approx(20.0)
+        assert xs[-1] == pytest.approx(120.0)
+        interior = xs[:-1]
+        for i in range(1, len(interior)):
+            assert interior[i] - interior[i - 1] == pytest.approx(15.0)
+
+    def test_anchor_dimensions_from_gauge_and_rules(self):
+        pcb = _straight_run_pcb()
+        rules = DesignRules(
+            min_trace_width_mm=0.127,
+            min_clearance_mm=0.2,
+            min_via_drill_mm=0.3,
+            min_via_diameter_mm=0.6,
+            min_annular_ring_mm=0.25,
+        )
+        result = reinforce_net(pcb, "FUSED_LINE", wire_gauge_awg=16, design_rules=rules)
+        assert result.anchor_drill_mm == pytest.approx(1.416, abs=1e-3)
+        assert result.anchor_pad_mm == pytest.approx(1.916, abs=1e-3)
+
+    def test_dry_run_places_nothing(self):
+        pcb = _straight_run_pcb()
+        before = len(pcb.vias)
+        result = reinforce_net(pcb, "FUSED_LINE", dry_run=True)
+        assert result.placed_count >= 2
+        assert len(pcb.vias) == before  # no mutation
+
+    def test_single_segment_net(self):
+        pcb = PCB.create(width=100, height=100, center=False)
+        pcb.add_trace((10, 50), (40, 50), width=2.0, layer="F.Cu", net="FUSED_LINE")
+        result = reinforce_net(pcb, "FUSED_LINE", spacing_mm=15.0)
+        assert result.run_segment_count == 1
+        # Endpoints anchored at least.
+        assert result.placed_count >= 2
+        xs = sorted(a.x for a in result.placed)
+        assert xs[0] == pytest.approx(10.0)
+        assert xs[-1] == pytest.approx(40.0)
+
+    def test_branched_net_anchors_longest_and_reports_branch(self):
+        pcb = _branched_run_pcb()
+        result = reinforce_net(pcb, "FUSED_LINE", spacing_mm=15.0)
+        # Longest linear run (west arm, 80mm) anchored; the other two arms
+        # reported unhandled (not silently dropped).
+        assert result.run_length_mm == pytest.approx(80.0, abs=1e-6)
+        assert result.unhandled_runs == 2
+
+    def test_net_with_no_routed_copper_errors(self):
+        pcb = PCB.create(width=100, height=100, center=False)
+        pcb.add_net("FUSED_LINE")  # net exists but nothing routed
+        with pytest.raises(ReinforceError, match="no routed copper"):
+            reinforce_net(pcb, "FUSED_LINE")
+
+    def test_unknown_net_errors(self):
+        pcb = _straight_run_pcb()
+        with pytest.raises(ReinforceError, match="not found"):
+            reinforce_net(pcb, "DOES_NOT_EXIST")
+
+    def test_nonpositive_spacing_errors(self):
+        pcb = _straight_run_pcb()
+        with pytest.raises(ReinforceError, match="spacing"):
+            reinforce_net(pcb, "FUSED_LINE", spacing_mm=0.0)
+
+    def test_idempotent_second_run_adds_no_new_anchors(self):
+        pcb = _straight_run_pcb()
+        reinforce_net(pcb, "FUSED_LINE", spacing_mm=15.0)
+        count_after_first = len(pcb.vias)
+        reinforce_net(pcb, "FUSED_LINE", spacing_mm=15.0)
+        # add_via(dedupe=True) rejects the identical anchors.
+        assert len(pcb.vias) == count_after_first
+
+
+# --------------------------------------------------------------------------
+# Clearance-refuse
+# --------------------------------------------------------------------------
+
+
+class TestClearanceRefuse:
+    def test_refuses_anchor_on_foreign_net_drill(self):
+        """A foreign-net through-hole pad where an anchor would land is refused."""
+        pcb = _straight_run_pcb(length=100.0)
+        # An anchor lands at x=35 (arc-length 15 from x0=20). Drop a foreign
+        # through-hole pad right there so the hole-to-hole / clearance check
+        # must refuse it.
+        _add_th_pad_footprint(pcb, ref="TP1", x=35.0, y=50.0, net="OTHER", drill=1.0, size=2.0)
+
+        result = reinforce_net(pcb, "FUSED_LINE", spacing_mm=15.0)
+
+        assert result.refused_count >= 1
+        # The refused anchor is at/near the foreign pad, and NOT placed there.
+        refused_pts = [(r.x, r.y) for r in result.refused]
+        assert any(abs(rx - 35.0) < 0.5 and abs(ry - 50.0) < 0.5 for rx, ry in refused_pts)
+        placed_pts = [(a.x, a.y) for a in result.placed]
+        assert not any(abs(px - 35.0) < 0.5 and abs(py - 50.0) < 0.5 for px, py in placed_pts)
+
+    def test_same_net_pad_does_not_refuse(self):
+        """A pad on the SAME net does not trigger a refusal."""
+        pcb = _straight_run_pcb(length=100.0)
+        _add_th_pad_footprint(pcb, ref="TP2", x=35.0, y=50.0, net="FUSED_LINE", drill=1.0, size=2.0)
+        result = reinforce_net(pcb, "FUSED_LINE", spacing_mm=15.0)
+        # No refusals from same-net copper.
+        assert result.refused_count == 0
+
+
+def _add_th_pad_footprint(
+    pcb: PCB, *, ref: str, x: float, y: float, net: str, drill: float, size: float
+) -> None:
+    """Append an in-memory footprint carrying one through-hole pad on ``net``.
+
+    Built directly (no KiCad library lookup) so tests run in CI. The
+    reinforce clearance check reads pads via ``pcb.footprints`` +
+    ``pcb.get_pad_position`` + ``pad.net_number``/``pad.drill``, all of which
+    resolve from the in-memory ``Footprint``/``Pad`` objects.
+    """
+    from kicad_tools.schema.pcb import Footprint, Pad
+
+    net_obj = pcb.add_net(net)
+    pad = Pad(
+        number="1",
+        type="thru_hole",
+        shape="circle",
+        position=(0.0, 0.0),  # footprint-local; the footprint sits at (x, y)
+        size=(size, size),
+        layers=["*.Cu"],
+        net_number=net_obj.number,
+        net_name=net,
+        drill=drill,
+    )
+    fp = Footprint(
+        name="TH:Pad",
+        layer="F.Cu",
+        position=(x, y),
+        rotation=0.0,
+        reference=ref,
+        value="TP",
+        pads=[pad],
+    )
+    pcb._footprints.append(fp)
+
+
+# --------------------------------------------------------------------------
+# CLI integration
+# --------------------------------------------------------------------------
+
+
+def _reinforce_args(pcb_path: Path, **overrides) -> argparse.Namespace:
+    base = {
+        "pcb_command": "reinforce",
+        "pcb": str(pcb_path),
+        "net": "FUSED_LINE",
+        "wire_gauge": 16,
+        "spacing": 15.0,
+        "layer": None,
+        "output": None,
+        "format": "text",
+        "dry_run": False,
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+class TestReinforceCLI:
+    def test_cli_in_place_places_anchors(self, tmp_path, capsys):
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+
+        pcb_path = tmp_path / "board.kicad_pcb"
+        _straight_run_pcb(length=100.0).save(pcb_path)
+        before_vias = len(PCB.load(pcb_path).vias)
+
+        rc = run_pcb_command(_reinforce_args(pcb_path))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Anchors placed:" in out
+        assert "refill" in out.lower()
+
+        after = PCB.load(pcb_path)
+        assert len(after.vias) > before_vias
+        # All added vias same-net.
+        net_obj = after.get_net_by_name("FUSED_LINE")
+        assert net_obj is not None
+        assert any(v.net_number == net_obj.number for v in after.vias)
+
+    def test_cli_output_file_leaves_input_untouched(self, tmp_path):
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+
+        pcb_path = tmp_path / "in.kicad_pcb"
+        out_path = tmp_path / "out.kicad_pcb"
+        _straight_run_pcb(length=100.0).save(pcb_path)
+        in_before = len(PCB.load(pcb_path).vias)
+
+        rc = run_pcb_command(_reinforce_args(pcb_path, output=str(out_path)))
+        assert rc == 0
+        # Input unchanged; output has anchors.
+        assert len(PCB.load(pcb_path).vias) == in_before
+        assert out_path.exists()
+        assert len(PCB.load(out_path).vias) > in_before
+
+    def test_cli_dry_run_does_not_write(self, tmp_path, capsys):
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+
+        pcb_path = tmp_path / "board.kicad_pcb"
+        _straight_run_pcb(length=100.0).save(pcb_path)
+        before = len(PCB.load(pcb_path).vias)
+
+        rc = run_pcb_command(_reinforce_args(pcb_path, dry_run=True))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "dry run" in out.lower()
+        assert len(PCB.load(pcb_path).vias) == before
+
+    def test_cli_json_output(self, tmp_path, capsys):
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+
+        pcb_path = tmp_path / "board.kicad_pcb"
+        _straight_run_pcb(length=100.0).save(pcb_path)
+
+        rc = run_pcb_command(_reinforce_args(pcb_path, format="json"))
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["net"] == "FUSED_LINE"
+        assert data["wire_gauge_awg"] == 16
+        assert data["anchors_placed"] >= 2
+        assert data["anchor_drill_mm"] == pytest.approx(1.416, abs=1e-3)
+
+    def test_cli_unknown_net_errors(self, tmp_path, capsys):
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+
+        pcb_path = tmp_path / "board.kicad_pcb"
+        _straight_run_pcb(length=100.0).save(pcb_path)
+
+        rc = run_pcb_command(_reinforce_args(pcb_path, net="NOPE"))
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "not found" in err
+
+    def test_drc_clean_after_reinforce(self, tmp_path):
+        """Cross-gate: kicad-cli DRC finds no shorts on the reinforced board.
+
+        Anchors are same-net vias, so they must not introduce shorts or
+        clearance violations. Skipped when kicad-cli is unavailable.
+        """
+        from kicad_tools.export import find_kicad_cli
+
+        if find_kicad_cli() is None:
+            pytest.skip("kicad-cli not available")
+
+        import subprocess
+
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+
+        pcb_path = tmp_path / "board.kicad_pcb"
+        _straight_run_pcb(length=100.0).save(pcb_path)
+        rc = run_pcb_command(_reinforce_args(pcb_path))
+        assert rc == 0
+
+        report = tmp_path / "drc.json"
+        cli = find_kicad_cli()
+        try:
+            subprocess.run(
+                [
+                    cli,
+                    "pcb",
+                    "drc",
+                    "--format",
+                    "json",
+                    "--output",
+                    str(report),
+                    str(pcb_path),
+                ],
+                check=False,
+                capture_output=True,
+                timeout=120,
+            )
+        except (subprocess.TimeoutExpired, OSError) as e:
+            pytest.skip(f"kicad-cli drc failed to run: {e}")
+
+        if not report.exists():
+            pytest.skip("kicad-cli drc produced no report")
+
+        data = json.loads(report.read_text())
+        violations = data.get("violations", [])
+        # No shorting / clearance / hole violations may be attributed to the
+        # same-net anchors we placed.
+        offending = [
+            v
+            for v in violations
+            if v.get("type") in {"shorting_items", "clearance", "hole_clearance", "hole_to_hole"}
+        ]
+        assert not offending, f"reinforce introduced DRC violations: {offending}"
+
+    def test_parser_registers_reinforce(self):
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(["pcb", "reinforce", "board.kicad_pcb", "--net", "FUSED_LINE"])
+        assert args.pcb_command == "reinforce"
+        assert args.net == "FUSED_LINE"
+        assert args.wire_gauge == 16
+        assert args.spacing == 15.0


### PR DESCRIPTION
## Summary

Implements **Unit A (MVP)** of the #4218 buttress-wire reinforcement design (Part 2 of the #4215 ampacity feature): a post-route `kct pcb reinforce --net <NAME>` pass + `PCB.reinforce_net()` API. It walks an already-routed net's segments into ordered, junction-split polylines and emits a spaced row of **same-net** plated-PTH anchor vias along the longest run, sized to a wire gauge and respecting the manufacturer annular-ring floor. A solid-core copper wire is later hand-soldered through the anchor row to carry additional current.

Structural template followed: `kct stitch` (load → add geometry to a named net → save). Anchors are emitted as large plated vias via `PCB.add_via` (a large plated via IS a PTH).

**Units B–F deferred to #4218**: mask-opening channel (B), net-class `reinforced` wiring (C), HV keep-away (D), ampacity-credit coupling in #4217 (E), first-class HV/creepage model (F).

## Changes

- **`src/kicad_tools/physics/wire_gauge.py`** (new) — AWG bare-copper diameter table (16/14/12), `anchor_drill_for_awg` (bare + slip-fit), `anchor_pad_for_drill` (sources `min_annular_ring_mm` from the manufacturer profile, NOT hardcoded), and a pure `wire_ampacity(awg)` helper. Co-located next to the merged `physics/ampacity.py`. `wire_ampacity` is **defined and unit-tested here but intentionally NOT wired into any check** — Unit E / #4217 will consume it later.
- **`src/kicad_tools/pcb/reinforce.py`** (new) — `reinforce_net()` core: a thin `schema.pcb.Segment → router.primitives.Segment` adapter that **reuses the hardened junction-aware chainer** `router/optimizer/chain.py::sort_into_chains` (rather than forking the junction-splitting logic from #4167/#4176); an arc-length anchor walk that always anchors both true endpoints; and a **clearance-refuse loop** via `router/via_clearance.py::point_clear_of_copper` (tracks/vias/pads/filled polygons + hole-to-hole floor) that REFUSES and reports any anchor colliding with a different net — never silently placing a short and never silently dropping.
- **`src/kicad_tools/schema/pcb.py`** — thin `PCB.reinforce_net()` wrapper method.
- **`src/kicad_tools/cli/parser.py`** + **`cli/commands/pcb.py`** — register `pcb reinforce` (`--net` required, `--wire-gauge` default 16, `--spacing` default 15.0, `--layer`, `-o/--output`, `--dry-run`, `--format text|json`), in-place default mirroring `pcb strip`, with placed/refused + run summary reporting. Help/output notes zone pours must be refilled after (same-net vias).
- **`tests/test_pcb_reinforce.py`** (new) — 35 tests on synthetic routed boards.

### Curator/architect options called out
- **Chaining type mismatch**: chose **Option 1 (thin adapter)** around the existing public chainer API — smallest surface change, single source of truth for junction-splitting.
- **API shape**: `reinforce_net()` lives in `pcb/reinforce.py` with a thin bound `PCB.reinforce_net()` wrapper (symmetry with `add_via`/`add_trace`).
- **Clearance predicate**: used `point_clear_of_copper` (the fuller canonical check), not `drill_hole_to_hole_clear` alone.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `kct pcb reinforce --net FUSED_LINE` emits spaced same-net PTH anchors | ✅ | `test_cli_in_place_places_anchors`, end-to-end CLI run: 8 anchors on a 100mm run at 15mm spacing |
| Anchors evenly spaced by arc length, all same-net | ✅ | `test_places_evenly_spaced_same_net_anchors` (interior gaps == spacing, both endpoints; all vias carry target net number) |
| Different-net drill collision REFUSED (not placed, reported) | ✅ | `test_refuses_anchor_on_foreign_net_drill` — foreign TH pad at an anchor site is refused, not placed |
| Same-net copper does not refuse | ✅ | `test_same_net_pad_does_not_refuse` |
| `kct check` / `kicad-cli drc` clean (no shorts) | ✅ | `test_drc_clean_after_reinforce` runs `kicad-cli pcb drc` → 0 shorting/clearance/hole violations |
| Edge: single-segment net | ✅ | `test_single_segment_net` |
| Edge: branched net (longest run anchored, branch reported) | ✅ | `test_branched_net_anchors_longest_and_reports_branch` (`unhandled_runs == 2`) |
| Edge: net with no routed copper | ✅ | `test_net_with_no_routed_copper_errors` (clear error, no crash) |
| Wire-gauge constants + `wire_ampacity()` in `physics/` | ✅ | 16 AWG → 1.416mm drill / 1.916mm pad @ 0.25mm ring; 14/12 supported; `TestWireGauge` |
| `-o` / in-place / `--dry-run` | ✅ | `test_cli_output_file_leaves_input_untouched`, `test_cli_dry_run_does_not_write` |
| Idempotent re-run (no duplicate anchors) | ✅ | `test_idempotent_second_run_adds_no_new_anchors` (via `add_via(dedupe=True)`) |

## Test Plan

- `uv run pytest tests/test_pcb_reinforce.py` → **35 passed** (incl. kicad-cli DRC cross-gate).
- `uv run pytest tests/test_cli_pcb.py` → 95 passed; `tests/test_ampacity.py` + physics → 69 passed.
- `uv run pytest -k "reinforce or wire_gauge or physics"` → 87 passed, 6 skipped.
- `ruff check` + `ruff format --check` clean; `scripts/ci/check_mypy_baseline.py` → **0 new type errors**.

Closes #4220