### PR TITLE
fix(schematic): gate wire-to-wire union on junction-dot presence

### DIFF
--- a/src/kicad_tools/schematic/models/netlist_mixin.py
+++ b/src/kicad_tools/schematic/models/netlist_mixin.py
@@ -95,13 +95,22 @@ class SchematicNetlistMixin:
             # Connect wire endpoints
             union(p1, p2)
 
+        # Junction-dot positions gate wire-to-wire union (issue #4226).
+        junction_points = [(round(j.x, 2), round(j.y, 2)) for j in self.junctions]  # type: ignore[attr-defined]
+
         # Union wires with each other on collinear overlap or mid-segment
-        # T-touch — matching KiCad, which merges the nets of any two touching
-        # or overlapping wire segments, not only those that share an exact
-        # endpoint (issue #4143).  The endpoint case is already handled by the
-        # loop above.  All-pairs O(n^2) is fine at typical schematic sizes
-        # (check_wire_collisions() already scans this way with no reported
-        # slowdown); no spatial index is warranted here.
+        # T-touch — but ONLY where a junction dot is present, matching KiCad
+        # (issue #4226).  KiCad merges the nets of two touching/overlapping
+        # wire segments only when a junction dot sits at the touch/overlap
+        # point; a dot-less graze renders as crossing, unconnected wires.
+        # #4157 unioned on pure geometry and over-merged board-05's
+        # stub-label schematic (85/205 pins on +24V); gating on the junction
+        # set restores KiCad's real connectivity while preserving the #4143
+        # dotted-merge detection.  The exact-shared-endpoint case is already
+        # handled by the endpoint loop above and needs no dot.  All-pairs
+        # O(n^2) is fine at typical schematic sizes (check_wire_collisions()
+        # already scans this way with no reported slowdown); no spatial index
+        # is warranted here.
         #
         # NOTE: this is wire-to-wire unioning only.  It deliberately does NOT
         # relax the pin-to-wire endpoint-only rule from #4020/#4003 — pins
@@ -111,7 +120,9 @@ class SchematicNetlistMixin:
             a_start, a_end = wire_segments[i]
             for j in range(i + 1, len(wire_segments)):
                 b_start, b_end = wire_segments[j]
-                if wire_segments_connect(a_start, a_end, b_start, b_end):
+                if wire_segments_connect(
+                    a_start, a_end, b_start, b_end, junction_points=junction_points
+                ):
                     union(a_start, b_start)
 
         # Helper to check if point is on a wire segment

--- a/src/kicad_tools/schematic/models/validation_mixin.py
+++ b/src/kicad_tools/schematic/models/validation_mixin.py
@@ -534,15 +534,23 @@ class SchematicValidationMixin:
             p2 = (round(wire.x2, 2), round(wire.y2, 2))
             wire_segments.append((p1, p2))
 
+        # Junction-dot positions gate wire-to-wire union (issue #4226) — must
+        # match _build_connectivity_graph() so the two builders don't drift.
+        junction_points = [(round(j.x, 2), round(j.y, 2)) for j in self.junctions]  # type: ignore[attr-defined]
+
         # Union wires with each other on collinear overlap or mid-segment
-        # T-touch, matching KiCad and mirroring the same fix applied to
-        # _build_connectivity_graph() (issue #4143).  This duplicate
-        # connectivity builder had the identical endpoint-only gap.
+        # T-touch, but ONLY where a junction dot is present, matching KiCad
+        # and mirroring the junction-gated fix in _build_connectivity_graph()
+        # (issue #4226; the underlying #4143 dotted-merge detection is
+        # preserved).  This duplicate connectivity builder must not drift from
+        # the netlist builder.
         for i in range(len(wire_segments)):
             a_start, a_end = wire_segments[i]
             for j in range(i + 1, len(wire_segments)):
                 b_start, b_end = wire_segments[j]
-                if wire_segments_connect(a_start, a_end, b_start, b_end):
+                if wire_segments_connect(
+                    a_start, a_end, b_start, b_end, junction_points=junction_points
+                ):
                     union(a_start, b_start)
 
         for junc in self.junctions:
@@ -856,6 +864,16 @@ class SchematicValidationMixin:
         Same-net overlaps (both wires labelled with the same net, or one/both
         unlabelled) are *not* flagged: only a genuine two-different-named-net
         overlap is reported.
+
+        Deliberate warn-vs-union asymmetry (issue #4226): this check calls
+        :func:`wire_segments_connect` with the **ungated** (pure-geometry)
+        predicate — i.e. *without* passing ``junction_points`` — so a
+        differently-labelled graze that lacks a junction dot is still flagged
+        as a suspicious potential-short here, even though
+        :meth:`_build_connectivity_graph` (which *does* pass the junction set)
+        will correctly NOT merge it.  Tighten what *merges* to match KiCad;
+        keep loose what *warns* — better to surface a suspicious dot-less
+        graze than hide it.
         """
         issues: list[dict] = []
         wire_nets = self._wire_net_names()

--- a/src/kicad_tools/schematic/models/wire_geometry.py
+++ b/src/kicad_tools/schematic/models/wire_geometry.py
@@ -1,11 +1,21 @@
 """Wire-vs-wire geometric union primitives for schematic connectivity.
 
-KiCad unions the nets of *any* two touching or overlapping collinear wire
-segments, not just wires that share an exact endpoint.  The schematic
-connectivity model historically unioned wires only at their two endpoints,
-so a generator using the stub-wire+label idiom could produce mid-segment
-overlaps that KiCad merges but kicad-tools kept separate — a silent,
-LVS-grade net-merge divergence (issue #4143).
+KiCad unions the nets of two touching or overlapping collinear wire segments
+**only where a junction dot is present** — not on pure geometry.  A generator
+using the stub-wire+label idiom can legitimately place two wires so their
+bodies graze (a mid-segment T-touch) or share a collinear sub-segment without
+any junction dot there; KiCad renders these as *crossing, unconnected* wires
+and keeps their nets separate.  KiCad only merges the nets at a touch/overlap
+point when a junction dot sits at that point.
+
+Historically the connectivity model unioned wires only at their two exact
+endpoints, so a generator that placed a *dotted* mid-segment overlap that
+KiCad merges was kept separate — a silent, LVS-grade net-merge divergence
+(issue #4143).  #4157 then unioned on *pure geometry* (any collinear overlap
+or mid-segment T-touch), which over-corrected: it merged incidental,
+dot-less grazes that KiCad does NOT union, collapsing distinct nets into one
+(issue #4226 — board-05's stub-label schematic reported 16 false copper-LVS
+shorts, ``+24V`` carrying 85/205 pins).
 
 This module provides the single, tested geometric primitive
 (:func:`wire_segments_connect`) used by both
@@ -17,20 +27,42 @@ Two axis-aligned wire segments A and B are considered electrically
 connected (beyond a shared endpoint) when either:
 
 * **Collinear overlap** — A and B lie on the same infinite line and their
-  projected parametric ranges share a sub-segment of nonzero length.  This
+  projected parametric ranges share a sub-segment of nonzero length, AND a
+  junction dot lies *within that shared sub-segment* (issue #4226).  This
   covers A containing B, B containing A, and partial overlap where neither
-  contains the other (the softstart rev-B repro geometry).
+  contains the other (the softstart rev-B repro geometry — which has a
+  junction dot at the intended join).
 * **Mid-segment T-touch** — one endpoint of A lands in the *interior* of B
-  (not at B's endpoints), or vice-versa.
+  (not at B's endpoints), or vice-versa, AND a junction dot lies *at that
+  touch point* (issue #4226).
 
 A shared endpoint alone is NOT reported here: that case is already handled
-by the endpoint Union-Find in the connectivity builders.  This mirrors, but
-is deliberately distinct from, the pin-endpoint-only semantics of
-#4020/#4003 — *pins* attach to wires only at endpoints/junctions, while
-*wires* union with each other on any overlap/T-touch, matching KiCad.
+by the endpoint Union-Find in the connectivity builders — endpoints connect
+natively in KiCad, no junction dot required.  This mirrors, but is
+deliberately distinct from, the pin-endpoint-only semantics of #4020/#4003 —
+*pins* attach to wires only at endpoints/junctions, while *wires* union with
+each other on a *dotted* overlap/T-touch, matching KiCad.
+
+Junction-gating semantics
+--------------------------
+:func:`wire_segments_connect` accepts an optional ``junction_points`` set:
+
+* When ``junction_points is None`` (the default), the predicate is **pure
+  geometry** — it returns True for any collinear overlap or T-touch
+  regardless of junction dots.  This preserves the ungated behaviour used by
+  ``_check_collinear_net_conflicts`` (issue #4226): a differently-labelled
+  dot-less graze is still a *suspicious* geometry worth flagging as a lint
+  finding even though KiCad would not merge it.
+* When ``junction_points`` is provided, the predicate is **junction-gated**:
+  a T-touch or collinear overlap unions only if a junction dot is present at
+  the qualifying point (the touch coordinate for a T-touch; anywhere inside
+  the shared sub-segment for a collinear overlap).  This matches KiCad's real
+  connectivity and is what the connectivity builders pass.
 """
 
 from __future__ import annotations
+
+from collections.abc import Iterable
 
 # Tolerance (mm) for perpendicular-distance-to-line and endpoint-coincidence
 # checks.  Matches ``SchematicElementsMixin.POINT_TOLERANCE`` (0.1mm) — the
@@ -47,6 +79,15 @@ Point = tuple[float, float]
 def _points_equal(p1: Point, p2: Point, tolerance: float = POINT_TOLERANCE) -> bool:
     """Return True if two points coincide within *tolerance*."""
     return abs(p1[0] - p2[0]) <= tolerance and abs(p1[1] - p2[1]) <= tolerance
+
+
+def _junction_at(
+    point: Point,
+    junction_points: Iterable[Point],
+    tolerance: float = POINT_TOLERANCE,
+) -> bool:
+    """Return True if a junction dot coincides with *point* within *tolerance*."""
+    return any(_points_equal(point, jp, tolerance) for jp in junction_points)
 
 
 def _point_on_segment_interior(
@@ -90,21 +131,21 @@ def _point_on_segment_interior(
     return dist_sq <= tolerance * tolerance
 
 
-def _collinear_overlap(
+def _collinear_overlap_range(
     a_start: Point,
     a_end: Point,
     b_start: Point,
     b_end: Point,
     tolerance: float = POINT_TOLERANCE,
-) -> bool:
-    """Return True if segments A and B collinearly overlap on a sub-segment.
+) -> tuple[float, float] | None:
+    """Return the shared collinear-overlap parameter range on A's line.
 
-    Both segments must lie on the same infinite line (both of B's endpoints
-    within *tolerance* of A's line) AND their projected parametric ranges on
-    A's line must overlap by more than a single point (nonzero-length shared
-    sub-segment).  Handles A⊇B, B⊇A, and partial overlap where neither
+    If segments A and B lie on the same infinite line and their projected
+    parametric ranges (on A's ``[0, 1]`` parameterisation) share a
+    sub-segment of nonzero length, return that ``(lo, hi)`` range; otherwise
+    return ``None``.  Handles A⊇B, B⊇A, and partial overlap where neither
     contains the other.  A pure endpoint touch (zero-length overlap) returns
-    False — that is the shared-endpoint case handled elsewhere.
+    ``None`` — that is the shared-endpoint case handled elsewhere.
     """
     ax, ay = a_start
     bx, by = a_end
@@ -113,7 +154,7 @@ def _collinear_overlap(
     seg_len_sq = dx * dx + dy * dy
 
     if seg_len_sq <= tolerance * tolerance:
-        return False
+        return None
 
     seg_len = seg_len_sq**0.5
 
@@ -121,7 +162,7 @@ def _collinear_overlap(
     for px, py in (b_start, b_end):
         cross = abs((px - ax) * dy - (py - ay) * dx)
         if cross / seg_len > tolerance:
-            return False
+            return None
 
     # Project B's endpoints onto A's parameterised line.
     t_vals: list[float] = []
@@ -136,7 +177,64 @@ def _collinear_overlap(
 
     # Require a shared sub-segment of nonzero length, not just a touch.
     eps_t = tolerance / seg_len
-    return bool((hi - lo) > eps_t)
+    if (hi - lo) > eps_t:
+        return (lo, hi)
+    return None
+
+
+def _collinear_overlap(
+    a_start: Point,
+    a_end: Point,
+    b_start: Point,
+    b_end: Point,
+    tolerance: float = POINT_TOLERANCE,
+) -> bool:
+    """Return True if segments A and B collinearly overlap on a sub-segment.
+
+    Thin boolean wrapper over :func:`_collinear_overlap_range` (kept for the
+    ungated call sites and existing unit coverage).
+    """
+    return _collinear_overlap_range(a_start, a_end, b_start, b_end, tolerance) is not None
+
+
+def _junction_in_overlap_range(
+    a_start: Point,
+    a_end: Point,
+    overlap_range: tuple[float, float],
+    junction_points: Iterable[Point],
+    tolerance: float = POINT_TOLERANCE,
+) -> bool:
+    """Return True if a junction dot projects inside the overlap sub-segment.
+
+    A junction qualifies only when it lies on A's line (within *tolerance*)
+    *and* its projected parameter ``t`` falls inside the shared overlap range
+    ``[lo, hi]`` (with a small ``eps_t`` slack).  A junction sitting merely at
+    a wire's own far endpoint (outside ``[lo, hi]``) does NOT qualify — this
+    is the critical refinement from issue #4226: every rail-drop stub has some
+    junction at its own far end, which is unrelated to whether the *overlap
+    itself* was an intentional connection.
+    """
+    ax, ay = a_start
+    bx, by = a_end
+    dx = bx - ax
+    dy = by - ay
+    seg_len_sq = dx * dx + dy * dy
+    if seg_len_sq <= tolerance * tolerance:
+        return False
+
+    seg_len = seg_len_sq**0.5
+    lo, hi = overlap_range
+    eps_t = tolerance / seg_len
+
+    for jx, jy in junction_points:
+        # Junction must lie on A's infinite line.
+        cross = abs((jx - ax) * dy - (jy - ay) * dx)
+        if cross / seg_len > tolerance:
+            continue
+        t = ((jx - ax) * dx + (jy - ay) * dy) / seg_len_sq
+        if (lo - eps_t) <= t <= (hi + eps_t):
+            return True
+    return False
 
 
 def wire_segments_connect(
@@ -145,6 +243,7 @@ def wire_segments_connect(
     b_start: Point,
     b_end: Point,
     tolerance: float = POINT_TOLERANCE,
+    junction_points: Iterable[Point] | None = None,
 ) -> bool:
     """Return True if two wire segments should union (KiCad wire semantics).
 
@@ -153,19 +252,52 @@ def wire_segments_connect(
     A pure shared endpoint returns False — that connection is already made
     by endpoint Union-Find in the connectivity builders, so reporting it
     here would be redundant.
+
+    ``junction_points`` gates the union to match KiCad (issue #4226):
+
+    * ``None`` (default): **pure-geometry** predicate — any collinear overlap
+      or T-touch returns True regardless of junction dots.  Used by
+      ``_check_collinear_net_conflicts`` to still *flag* a dot-less graze
+      between differently-labelled nets as a suspicious geometry.
+    * a set/iterable of junction ``(x, y)`` points: **junction-gated**
+      predicate — a T-touch unions only if a junction dot sits at the touch
+      point; a collinear overlap unions only if a junction dot projects
+      *inside* the shared sub-segment.  This matches KiCad's real
+      connectivity (a wire-to-wire merge in KiCad requires a junction dot)
+      and is what the connectivity builders pass.
     """
+    juncs = None if junction_points is None else list(junction_points)
+
     # Collinear overlap (covers containment and partial overlap).
-    if _collinear_overlap(a_start, a_end, b_start, b_end, tolerance):
-        return True
+    overlap_range = _collinear_overlap_range(a_start, a_end, b_start, b_end, tolerance)
+    if overlap_range is not None:
+        if juncs is None:
+            return True
+        if _junction_in_overlap_range(a_start, a_end, overlap_range, juncs, tolerance):
+            return True
+        # Collinear overlap without a qualifying junction dot: KiCad does not
+        # merge these (issue #4226).  Fall through — a T-touch check below
+        # cannot also apply to a genuinely collinear pair, so this returns
+        # False for the gated case.
+        return False
 
     # Mid-segment T-touch: an endpoint of one wire on the other's interior.
+    # The touch point is the endpoint that lands in the interior.
+    touch_candidates: list[Point] = []
     if _point_on_segment_interior(b_start, a_start, a_end, tolerance):
-        return True
+        touch_candidates.append(b_start)
     if _point_on_segment_interior(b_end, a_start, a_end, tolerance):
-        return True
+        touch_candidates.append(b_end)
     if _point_on_segment_interior(a_start, b_start, b_end, tolerance):
-        return True
+        touch_candidates.append(a_start)
     if _point_on_segment_interior(a_end, b_start, b_end, tolerance):
+        touch_candidates.append(a_end)
+
+    if not touch_candidates:
+        return False
+
+    if juncs is None:
         return True
 
-    return False
+    # Junction-gated: union only if a junction dot sits at the touch point.
+    return any(_junction_at(pt, juncs, tolerance) for pt in touch_candidates)

--- a/tests/test_board_05_wire_union_regression.py
+++ b/tests/test_board_05_wire_union_regression.py
@@ -1,0 +1,136 @@
+"""Regression guard for the #4157 wire-union over-merge on board-05 (#4226).
+
+PR #4157 (#4143) unioned collinear-overlapping and T-touching wires in the
+schematic connectivity extractor on **pure geometry**, ignoring junction
+dots.  That over-corrected: board-05's stub-wire+label idiom has incidental
+dot-less grazes (rail-drop stubs and diagonal-escape wires whose bodies
+graze each other's X/Y at generator-chosen coordinates) that KiCad does NOT
+merge.  The pure-geometry predicate fused 36 such dot-less pairs through
+Union-Find, collapsing distinct nets into one 85-pin ``+24V`` blob and
+producing 16 false copper-LVS shorts on a previously gallery-READY board.
+
+The fix (issue #4226) gates wire-to-wire union on junction-dot presence,
+matching KiCad's real connectivity: a T-touch/collinear-overlap unions only
+where a junction dot sits.  This test locks in the corrected extraction on
+the committed board-05 schematic, cross-validated against the
+``kicad-cli sch export netlist`` ground truth quoted in the issue:
+
+    C10.1 -> OSC_IN, J2.1 -> PHASE_C, C30.1 -> HALL_A
+    GND=36 (largest), +3V3=27, +24V=13
+
+A synthetic dot-less-graze fixture is also included so the regression guard
+runs even where the local-only board-05 schematic is unavailable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.schematic.models.elements import Junction, Label, Wire
+from kicad_tools.schematic.models.schematic import Schematic
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BOARD_05_SCH = (
+    REPO_ROOT / "boards" / "05-bldc-motor-controller" / "output" / "bldc_controller.kicad_sch"
+)
+
+
+@pytest.mark.skipif(
+    not BOARD_05_SCH.exists(),
+    reason="board-05 schematic (local-only consumer board) not present",
+)
+class TestBoard05WireUnionRegression:
+    """The committed board-05 schematic must extract KiCad's real netlist."""
+
+    @pytest.fixture(scope="class")
+    def sch(self) -> Schematic:
+        return Schematic.load(str(BOARD_05_SCH))
+
+    def test_c10_1_is_osc_in_not_plus24v(self, sch: Schematic) -> None:
+        # The headline corruption: C10.1 was fused to +24V; must be OSC_IN.
+        assert sch.get_net_for_pin("C10", "1") == "OSC_IN"
+
+    def test_j2_1_is_phase_c(self, sch: Schematic) -> None:
+        assert sch.get_net_for_pin("J2", "1") == "PHASE_C"
+
+    def test_c30_1_is_hall_a(self, sch: Schematic) -> None:
+        assert sch.get_net_for_pin("C30", "1") == "HALL_A"
+
+    def test_plus24v_is_not_a_giant_blob(self, sch: Schematic) -> None:
+        # Was 85/205 pins (>40% of the board) under the broken predicate;
+        # KiCad ground truth is 13.  Assert a tight upper bound rather than
+        # the exact count to avoid brittleness on future minor edits.
+        netlist = sch.extract_netlist()
+        plus24 = netlist.get("+24V", [])
+        assert len(plus24) <= 15, (
+            f"+24V carries {len(plus24)} pins — the #4157 over-merge blob "
+            "has recurred (KiCad ground truth is 13)."
+        )
+
+    def test_gnd_is_the_largest_net(self, sch: Schematic) -> None:
+        netlist = sch.extract_netlist()
+        by_size = sorted(netlist.items(), key=lambda kv: len(kv[1]), reverse=True)
+        assert by_size[0][0] == "GND", (
+            f"largest net is {by_size[0][0]} ({len(by_size[0][1])} pins), "
+            "expected GND — a rail over-merge has recurred."
+        )
+        # And GND is genuinely large, not a 2-pin remnant.
+        assert len(netlist["GND"]) >= 30
+
+    def test_c10_2_is_gnd(self, sch: Schematic) -> None:
+        # C10.2 is the decoupling-cap ground return; sanity-check the OSC
+        # cap is not itself corrupted on the other pin.
+        assert sch.get_net_for_pin("C10", "2") == "GND"
+
+
+class TestDotlessGrazeSynthetic:
+    """Minimal synthetic reproduction of the board-05 dot-less-graze pattern.
+
+    Runs everywhere (no local-only board dependency) so the regression guard
+    is always active in CI.  Two independent rails whose stubs graze — one
+    via a mid-segment T-touch, one via a collinear overlap — with NO junction
+    dot at the graze.  KiCad keeps them separate; the junction-gated
+    extractor must too.  Adding a dot at the graze flips it to a real merge,
+    proving the two cases are cleanly separable (the #4143 intent).
+    """
+
+    def _two_rail_graze(self, dotted: bool) -> Schematic:
+        sch = Schematic("graze")
+        # Rail X: horizontal +24V trunk at y=100, spanning [100,140].
+        sch.wires.append(Wire(x1=100, y1=100, x2=140, y2=100))
+        sch.labels.append(Label(text="PLUS24V", x=100, y=100))
+        # Rail Y: a HALL_C-side escape wire whose lower endpoint (120,100)
+        # grazes the interior of the +24V trunk — a mid-segment T-touch.  Its
+        # far end (120,90) carries the HALL_C label.  No dot at the graze
+        # unless ``dotted``.
+        sch.wires.append(Wire(x1=120, y1=100, x2=120, y2=90))
+        sch.labels.append(Label(text="HALL_C", x=120, y=90))
+        if dotted:
+            sch.junctions.append(Junction(x=120, y=100))
+        return sch
+
+    @staticmethod
+    def _root(sch: Schematic, point: tuple[float, float]) -> tuple:
+        parent, _, _ = sch._build_connectivity_graph()
+
+        def find(p):
+            while parent.get(p, p) != p:
+                p = parent[p]
+            return p
+
+        return find(point)
+
+    def test_dotless_t_touch_keeps_rails_separate(self) -> None:
+        # HALL_C far end (120,90) must NOT join the +24V trunk (100,100)
+        # without a junction dot at the (120,100) graze — the board-05
+        # false-short pattern.
+        sch = self._two_rail_graze(dotted=False)
+        assert self._root(sch, (120, 90)) != self._root(sch, (100, 100))
+
+    def test_dotted_t_touch_does_merge(self) -> None:
+        # With a junction dot at the graze, KiCad WOULD merge — the extractor
+        # must union, preserving the #4143 real-merge detection.
+        sch = self._two_rail_graze(dotted=True)
+        assert self._root(sch, (120, 90)) == self._root(sch, (100, 100))

--- a/tests/test_netlist_query.py
+++ b/tests/test_netlist_query.py
@@ -839,12 +839,22 @@ class TestWireToWireCollinearUnion:
         return netlist, a, b
 
     def _two_stub_schematic(
-        self, a_span: tuple[float, float], b_span: tuple[float, float], y: float = 100.0
+        self,
+        a_span: tuple[float, float],
+        b_span: tuple[float, float],
+        y: float = 100.0,
+        junction: bool = True,
     ) -> Schematic:
         """Two horizontal stub wires on ``y`` with a label on each.
 
         Each stub carries a symbol pin at its far end plus a net label, so
         the two labels' merge status is observable in the netlist.
+
+        When ``junction`` is True (default) a junction dot is placed inside
+        the collinear-overlap sub-segment, representing the *intentional*
+        merge a real generator would emit (KiCad requires a dot to merge two
+        overlapping wires — issue #4226).  Pass ``junction=False`` to model a
+        dot-less incidental graze, which KiCad does NOT merge.
         """
         sch = Schematic("Test")
         r_def = make_simple_symbol("Device:R", [("~", "1", -2.54, 0), ("~", "2", 2.54, 0)])
@@ -860,6 +870,12 @@ class TestWireToWireCollinearUnion:
         sch.wires.append(Wire(x1=b_span[0], y1=y, x2=b_span[1], y2=y))
         sch.labels.append(Label(text="NET_A", x=a_span[0], y=y))
         sch.labels.append(Label(text="NET_B", x=b_span[1], y=y))
+        if junction:
+            # Junction dot at the midpoint of the shared overlap sub-segment,
+            # marking the intended wire-to-wire merge (issue #4226/#4143).
+            lo = max(a_span[0], b_span[0])
+            hi = min(a_span[1], b_span[1])
+            sch.junctions.append(Junction(x=(lo + hi) / 2.0, y=y))
         return sch
 
     def test_partial_overlap_neither_contains_the_other(self):
@@ -910,6 +926,9 @@ class TestWireToWireCollinearUnion:
         # B: vertical, lower end T-touches A's interior at (106,100); upper
         # end (106,90) lands on R2 pin 1 (R2 at (106,85), pin1 y-offset).
         sch.wires.append(Wire(x1=106, y1=100, x2=106, y2=90))
+        # Junction dot at the T-touch point marks the intentional connection
+        # (KiCad merges a mid-segment T-touch only where a dot sits — #4226).
+        sch.junctions.append(Junction(x=106, y=100))
         # R2 pin 1 sits at (103.46, 85)?  Recompute: place R2 so pin1 lands
         # on the wire's free end instead — put R2 pin1 at (106,90).
         r2b = SymbolInstance(
@@ -972,6 +991,9 @@ class TestWireToWireCollinearUnion:
         # +3.3V stub [100,108], GND stub [104,112] overlap on [104,108].
         sch.wires.append(Wire(x1=100, y1=100, x2=108, y2=100))
         sch.wires.append(Wire(x1=104, y1=100, x2=112, y2=100))
+        # Junction dot inside the [104,108] overlap marks the intended merge
+        # (KiCad requires a dot to union two overlapping wires — #4226).
+        sch.junctions.append(Junction(x=106, y=100))
         sch.power_symbols.append(PowerSymbol(lib_id="power:+3.3V", x=100, y=100, rotation=0))
         sch.power_symbols.append(PowerSymbol(lib_id="power:GND", x=112, y=100, rotation=0))
         # Add a pin on each end so the merged component surfaces in netlist.
@@ -1001,8 +1023,41 @@ class TestWireToWireCollinearUnion:
         sch.symbols.extend([r1, r2])
         sch.wires.append(Wire(x1=100, y1=100, x2=109, y2=100))
         sch.wires.append(Wire(x1=103, y1=100, x2=112, y2=100))
+        # Junction inside the [103,109] overlap marks the intended merge.
+        sch.junctions.append(Junction(x=106, y=100))
         sch.labels.append(Label(text="VBUS", x=100, y=100))
         sch.labels.append(Label(text="VBUS", x=112, y=100))
         netlist = sch.extract_netlist()
         assert "VBUS" in netlist
         assert {str(p) for p in netlist["VBUS"]} == {"R1.2", "R2.1"}
+
+    def test_dotless_collinear_overlap_does_not_merge(self):
+        """A dot-less collinear graze must NOT merge nets (issue #4226).
+
+        This is the board-05 false-short pattern: two differently-labelled
+        stubs overlap collinearly with NO junction dot at the overlap.
+        KiCad keeps them separate; the junction-gated predicate must too.
+        """
+        sch = self._two_stub_schematic((100.0, 109.0), (103.0, 112.0), junction=False)
+        assert sch.are_connected("R1", "2", "R2", "1") is False
+        net1 = sch.get_net_for_pin("R1", "2")
+        net2 = sch.get_net_for_pin("R2", "1")
+        assert {net1, net2} == {"NET_A", "NET_B"}
+
+    def test_dotless_t_touch_does_not_merge(self):
+        """A dot-less mid-segment T-touch must NOT merge nets (issue #4226)."""
+        sch = Schematic("Test")
+        r_def = make_simple_symbol("Device:R", [("~", "1", -2.54, 0), ("~", "2", 2.54, 0)])
+        r1 = SymbolInstance(
+            symbol_def=r_def, x=97.46, y=100, rotation=0, reference="R1", value="10k"
+        )
+        r3 = SymbolInstance(
+            symbol_def=r_def, x=108.54, y=90, rotation=0, reference="R3", value="10k"
+        )
+        sch.symbols.extend([r1, r3])
+        sch.wires.append(Wire(x1=100, y1=100, x2=112, y2=100))
+        # B's lower end (106,100) T-touches A's interior, but NO junction dot.
+        sch.wires.append(Wire(x1=106, y1=100, x2=106, y2=90))
+        sch.labels.append(Label(text="NET_A", x=100, y=100))
+        sch.labels.append(Label(text="NET_B", x=106, y=90))
+        assert sch.are_connected("R1", "2", "R3", "1") is False

--- a/tests/test_wire_geometry.py
+++ b/tests/test_wire_geometry.py
@@ -70,3 +70,117 @@ class TestWireSegmentsConnect:
 
     def test_disjoint_no_connect(self):
         assert wire_segments_connect((100, 100), (105, 100), (110, 100), (115, 100)) is False
+
+
+class TestJunctionGatedUnion:
+    """Junction-dot gating of wire-to-wire union (issue #4226).
+
+    KiCad merges the nets of two touching/overlapping wires only where a
+    junction dot is present; #4157's pure-geometry union over-merged
+    dot-less grazes (board-05: 85/205 pins on +24V).  When
+    ``junction_points`` is supplied, ``wire_segments_connect`` must union a
+    T-touch / collinear overlap only if a junction dot sits at the
+    touch/overlap point; the identical geometry WITHOUT a dot must NOT
+    union.  Passing ``junction_points=None`` (the default) keeps the
+    ungated pure-geometry predicate for the lint checker.
+    """
+
+    def test_t_touch_with_junction_unions(self):
+        # B's endpoint (106,100) on A's interior WITH a dot at the touch.
+        assert (
+            wire_segments_connect(
+                (100, 100),
+                (112, 100),
+                (106, 100),
+                (106, 90),
+                junction_points={(106, 100)},
+            )
+            is True
+        )
+
+    def test_t_touch_without_junction_does_not_union(self):
+        # Same T-touch geometry, but no dot at (106,100) -> KiCad does NOT
+        # merge (the board-05 dot-less graze that caused the false shorts).
+        assert (
+            wire_segments_connect(
+                (100, 100),
+                (112, 100),
+                (106, 100),
+                (106, 90),
+                junction_points=set(),
+            )
+            is False
+        )
+
+    def test_t_touch_junction_at_wrong_point_does_not_union(self):
+        # A dot exists, but at the far (non-touch) endpoint of B, not at the
+        # touch coordinate -> must NOT union (issue #4226 edge case).
+        assert (
+            wire_segments_connect(
+                (100, 100),
+                (112, 100),
+                (106, 100),
+                (106, 90),
+                junction_points={(106, 90)},
+            )
+            is False
+        )
+
+    def test_collinear_overlap_with_junction_in_range_unions(self):
+        # A=[100,109], B=[103,112] share [103,109]; dot at (105,100) inside
+        # the shared sub-segment -> unions.
+        assert (
+            wire_segments_connect(
+                (100, 100),
+                (109, 100),
+                (103, 100),
+                (112, 100),
+                junction_points={(105, 100)},
+            )
+            is True
+        )
+
+    def test_collinear_overlap_without_junction_does_not_union(self):
+        assert (
+            wire_segments_connect(
+                (100, 100),
+                (109, 100),
+                (103, 100),
+                (112, 100),
+                junction_points=set(),
+            )
+            is False
+        )
+
+    def test_collinear_overlap_junction_at_far_endpoint_does_not_union(self):
+        # The exact board-05 wires-15/16 failure: two rail-drop stubs share
+        # an X column and overlap by coincidence; each has a junction at its
+        # OWN far end (outside the shared sub-segment), but none inside the
+        # overlap -> must NOT union.  A=[100,109], B=[103,112] share
+        # [103,109]; dots only at (100,100) (A's far end) and (112,100)
+        # (B's far end).
+        assert (
+            wire_segments_connect(
+                (100, 100),
+                (109, 100),
+                (103, 100),
+                (112, 100),
+                junction_points={(100, 100), (112, 100)},
+            )
+            is False
+        )
+
+    def test_shared_endpoint_never_needs_junction(self):
+        # Endpoint-only touch is handled by endpoint Union-Find, so it
+        # returns False here regardless of junction gating (no dot required
+        # for legitimate endpoint connections).
+        assert (
+            wire_segments_connect(
+                (100, 100),
+                (106, 100),
+                (106, 100),
+                (112, 100),
+                junction_points=set(),
+            )
+            is False
+        )


### PR DESCRIPTION
## Summary

PR #4157 (#4143) unioned collinear-overlapping and T-touching wires in the schematic connectivity extractor by **pure geometry**, ignoring junction dots. KiCad only merges two touching/overlapping wires where a **junction dot** is present. On board-05 (BLDC motor controller) that over-corrected: 36 incidental **dot-less grazes** (rail-drop stubs and diagonal-escape wires whose bodies graze at generator-chosen coordinates) fused through Union-Find into an 85/205-pin `+24V` blob, producing **16 false copper-LVS shorts** on a previously gallery-READY, LVS-clean board. `kicad-cli sch export netlist` (authoritative) shows 0 real shorts.

This tightens the wire-union predicate to match KiCad's real connectivity — a wire-to-wire merge requires a junction dot — without regressing the #4143 dotted-merge detection.

## Changes

- **`wire_geometry.py`** — `wire_segments_connect()` gains an optional `junction_points` set:
  - **T-touch**: unions only if a junction dot sits at the interior touch point.
  - **Collinear overlap**: unions only if a junction dot *projects inside the shared sub-segment* `[lo,hi]` — not merely at a wire's own far endpoint (the critical board-05 wires-15/16 refinement; every rail-drop stub has a dot at its far end, unrelated to whether the overlap was intended).
  - **Shared endpoints** still connect natively (no dot) via endpoint Union-Find — the junction gate applies ONLY to the T-touch/collinear paths #4157 added.
  - `junction_points=None` (default) keeps the ungated pure-geometry predicate.
- **`netlist_mixin.py` / `validation_mixin.py`** — thread `self.junctions` into both connectivity twins' `wire_segments_connect()` calls so they can't drift.
- **`_check_collinear_net_conflicts`** — deliberately keeps the **ungated** predicate so a differently-labelled dot-less graze still surfaces as a `collinear_net_conflict` lint warning (warn-vs-union asymmetry, per curator guidance): tighten what *merges*, keep loose what *warns*.
- **Tests** — #4143's `TestWireToWireCollinearUnion` / power-vs-power / same-net cases now place an explicit `Junction` at the intended overlap/touch point (a real generator emitting an intentional join always emits a dot), preserving the #4143 regression lock under the new semantics. New junction-gated unit coverage in `test_wire_geometry.py` (with-dot unions / without-dot does not / dot-at-wrong-point does not / dot-at-far-endpoint does not). New dot-less-graze negative cases in `test_netlist_query.py`.
- **New regression fixture** `tests/test_board_05_wire_union_regression.py` — loads the committed board-05 schematic and asserts `C10.1->OSC_IN`, `J2.1->PHASE_C`, `C30.1->HALL_A`, `C10.2->GND`, `+24V<=15` pins, `GND` is the largest net; plus a **synthetic** dot-less-graze fixture that runs in CI even where the local-only board-05 schematic is absent.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| board-05 LVS clean (0 false shorts) | ✅ | `kct check --mfr jlcpcb-tier1` -> `LVS: PASSED (0 mismatch(es))`, `Overall: PASSED` (was FAILED 16) |
| Netlist sane, matches kicad-cli | ✅ | C10.1->OSC_IN, J2.1->PHASE_C, C30.1->HALL_A; +24V=13, GND=36 (largest), +3V3=27 — all 52 nets match ground truth |
| #4143 real-merge still detected | ✅ | `TestWireToWireCollinearUnion` green with explicit junction dots; junction-gated with-dot union test passes |
| Regression fixture added | ✅ | `test_board_05_wire_union_regression.py` (real schematic + CI-safe synthetic) |
| No wholesale #4157 revert | ✅ | Predicate tightened (junction-gated), not removed |
| Committed board PCB unchanged | ✅ | Only extractor + tests changed; no board `.kicad_pcb`/`design.py` touched |

## Fleet LVS re-validation (load-bearing safety check)

| Board | Tier | Before | After |
|-------|------|--------|-------|
| 00-simple-led | jlcpcb | PASSED | PASSED |
| 01-voltage-divider | jlcpcb | PASSED | PASSED |
| 02-charlieplex-led | jlcpcb | PASSED | PASSED |
| 03-usb-joystick | jlcpcb-tier1 | PASSED | PASSED |
| 04-stm32-devboard | jlcpcb-tier1 | PASSED | PASSED |
| **05-bldc-motor-controller** | jlcpcb-tier1 | **FAILED (16 false shorts)** | **PASSED** |
| 06-diffpair-test | jlcpcb | PASSED | PASSED |
| 07-matchgroup-test | jlcpcb | FAILED (5 `open`, pre-existing #3438) | FAILED (5 `open`, **byte-identical** before/after) |

No board regressed. Board-07's 5 mismatches are `open` (unroutable-net), not `short`, and are seed-invariant (#3438) — confirmed identical against a `git stash`ed baseline of the unpatched code.

## Test Plan

- `uv run pytest tests/test_wire_geometry.py tests/test_netlist_query.py tests/test_schematic_models.py tests/test_validate_netlist.py tests/test_board_05_wire_union_regression.py -q` -> **316 passed**
- Wide sweep `-k "wire or netlist or connectivity or lvs or graze or collinear or union or power_net"` -> **1370 passed, 0 failed**
- `ruff check` + `ruff format --check` -> clean
- `scripts/ci/check_mypy_baseline.py` -> **0 NEW errors** (exit 0)
- Fleet LVS table above

Closes #4226