### PR TITLE
feat(placement): label pad-bbox-fallback courtyard overlaps

### DIFF
--- a/src/kicad_tools/placement/analyzer.py
+++ b/src/kicad_tools/placement/analyzer.py
@@ -440,9 +440,13 @@ class PlacementAnalyzer:
             severity=ConflictSeverity.WARNING,
             component1=c1.reference,
             component2=c2.reference,
-            message=f"courtyards overlap by {overlap_amount:.3f}mm",
+            message=(
+                f"courtyards overlap by {overlap_amount:.3f}mm "
+                "(pad-bbox fallback — no F.CrtYd artwork)"
+            ),
             location=Point(overlap_x, overlap_y),
             overlap_amount=overlap_amount,
+            is_bbox_fallback=True,
         )
 
     def _check_courtyard_overlap_polygon(

--- a/src/kicad_tools/placement/conflict.py
+++ b/src/kicad_tools/placement/conflict.py
@@ -226,6 +226,12 @@ class Conflict:
     actual_clearance: float | None = None  # Current clearance in mm
     required_clearance: float | None = None  # Required clearance in mm
     overlap_amount: float | None = None  # Overlap in mm (for courtyard)
+    # True when a courtyard-overlap finding was derived from the coarse
+    # pads-bbox+margin fallback (at least one footprint had no resolvable
+    # F.CrtYd/B.CrtYd artwork) rather than the real-polygon path (issue #4182).
+    # Fallback findings approximate; KiCad DRC skips courtyard-less footprints
+    # entirely, so the two engines diverge by design here (issue #4227).
+    is_bbox_fallback: bool = False
 
     def __str__(self) -> str:
         if self.actual_clearance is not None and self.required_clearance is not None:
@@ -252,6 +258,7 @@ class Conflict:
             "actual_clearance": self.actual_clearance,
             "required_clearance": self.required_clearance,
             "overlap_amount": self.overlap_amount,
+            "is_bbox_fallback": self.is_bbox_fallback,
         }
 
 

--- a/tests/test_placement.py
+++ b/tests/test_placement.py
@@ -343,6 +343,9 @@ class TestConflictTypes:
         assert d["component1"] == "R1"
         assert d["component2"] == "R2"
         assert d["overlap_amount"] == 0.5
+        # New field defaults to False and serializes for JSON consumers (#4227).
+        assert conflict.is_bbox_fallback is False
+        assert d["is_bbox_fallback"] is False
 
 
 class TestPlacementAnalyzer:
@@ -360,6 +363,10 @@ class TestPlacementAnalyzer:
         conflict = overlap_conflicts[0]
         assert {conflict.component1, conflict.component2} == {"R1", "R2"}
         assert conflict.severity == ConflictSeverity.WARNING
+        # These footprints carry no F.CrtYd artwork, so the finding comes from
+        # the pad-bbox fallback and must be labeled as such (#4227).
+        assert conflict.is_bbox_fallback is True
+        assert "pad-bbox fallback" in conflict.message
 
     def test_find_pad_clearance_violations(self, overlapping_pcb: Path):
         """Test detecting pad clearance violations."""

--- a/tests/test_placement_courtyard_geometry.py
+++ b/tests/test_placement_courtyard_geometry.py
@@ -163,6 +163,12 @@ class TestRealCourtyardOverlap:
         assert len(overlaps) == 1
         assert {overlaps[0].component1, overlaps[0].component2} == {"U1", "U2"}
 
+        # Real-polygon path (issue #4182) is NOT a fallback: it must not be
+        # flagged or annotated (issue #4227). Message stays area-based.
+        assert overlaps[0].is_bbox_fallback is False
+        assert "pad-bbox fallback" not in overlaps[0].message
+        assert "mm^2" in overlaps[0].message
+
         # And it agrees with kct check's courtyard rule.
         assert len(_drc_overlaps(pcb)) == 1
 
@@ -302,6 +308,11 @@ class TestFallbackAndResolution:
         pcb = _pcb_with(a, b)
         overlaps = _courtyard_conflicts(_analyze(pcb))
         assert len(overlaps) == 1
+        # Fallback-derived finding is labeled (issue #4227) so it is not
+        # mistaken for a real-polygon courtyard violation.
+        assert overlaps[0].is_bbox_fallback is True
+        assert "pad-bbox fallback" in overlaps[0].message
+        assert overlaps[0].to_dict()["is_bbox_fallback"] is True
 
     def test_mixed_real_and_fallback(self):
         """One footprint with real courtyard, one pads-only -> the pair falls
@@ -322,6 +333,10 @@ class TestFallbackAndResolution:
         # No crash; bbox-fallback comparison used because R1 has no polygon.
         overlaps = _courtyard_conflicts(_analyze(pcb))
         assert len(overlaps) == 1
+        # Only one footprint resolved a real polygon, so this pair still uses
+        # the bbox fallback and must be labeled accordingly (issue #4227).
+        assert overlaps[0].is_bbox_fallback is True
+        assert "pad-bbox fallback" in overlaps[0].message
 
     def test_line_chain_courtyard_resolves(self):
         """A courtyard authored as an fp_line loop resolves and overlaps are


### PR DESCRIPTION
## Summary

`kct placement check`'s courtyard-overlap check uses a coarse pads-bbox+margin AABB fallback whenever at least one footprint lacks resolvable `F.CrtYd`/`B.CrtYd` artwork (the real-polygon path from #4182 needs both footprints to resolve). That fallback emitted the exact same `courtyards overlap by Xmm` warning as the real-polygon path, so a benign sub-DRC halo graze on a courtyard-less footprint was indistinguishable from a genuine courtyard violation — and since KiCad DRC skips courtyard-less footprints entirely, the two engines diverge here by design. This PR labels the fallback finding so it can't be mistaken for a real courtyard overlap.

Implements Option A (curator-recommended): annotate, keep `severity=WARNING` (no demotion, no new CLI flags).

## Changes

- `src/kicad_tools/placement/conflict.py`: added `is_bbox_fallback: bool = False` field to `Conflict` and included it in `to_dict()` (for `--format json` consumers).
- `src/kicad_tools/placement/analyzer.py`: in `_check_courtyard_overlap`'s bbox-fallback branch, set `is_bbox_fallback=True` and append `" (pad-bbox fallback — no F.CrtYd artwork)"` to the message. `_check_courtyard_overlap_polygon` (the #4182 real-polygon path) is untouched.
- `tests/test_placement_courtyard_geometry.py`: extended `TestFallbackAndResolution` (fallback → `is_bbox_fallback True` + annotated message + `to_dict()` serialization) and `TestRealCourtyardOverlap` (real-polygon → `is_bbox_fallback False`, message unannotated/area-based).
- `tests/test_placement.py`: `test_conflict_to_dict` now covers the new field's default+serialization; `test_find_courtyard_overlap` asserts its courtyard-less fixture is flagged as fallback.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Fallback finding has `is_bbox_fallback is True` + fallback marker in message | ✅ | New assertions in `TestFallbackAndResolution` + `test_find_courtyard_overlap`; CLI smoke test printed `courtyards overlap by 1.140mm (pad-bbox fallback — no F.CrtYd artwork)` |
| Real-polygon finding has `is_bbox_fallback is False`, message unchanged (`...mm^2`) | ✅ | New assertions in `test_courtyard_larger_than_pads_overlaps_but_pads_do_not`; `_check_courtyard_overlap_polygon` untouched |
| Severity remains WARNING (no demotion) | ✅ | Both branches still construct `severity=ConflictSeverity.WARNING`; asserted in tests |
| `to_dict()` includes the new field for JSON | ✅ | Field added to `to_dict()`; asserted in `test_conflict_to_dict` |
| CLI table shows the annotation (prints `conflict.message`) | ✅ | Manual smoke test via `PlacementAnalyzer.find_conflicts` confirmed the annotated message |
| `kct check`'s DRC courtyard rule untouched (out of scope) | ✅ | No changes to `src/kicad_tools/validate/rules/courtyard.py` |

## Test Plan

- `uv run pytest tests/test_placement.py tests/test_placement_courtyard_geometry.py -q` → 64 passed.
- `uv run ruff check` + `ruff format --check` on changed files → clean.
- `uv run --extra dev python scripts/ci/check_mypy_baseline.py` → 0 new errors (within baseline).
- CLI smoke test on a courtyard-less overlapping-pad board confirmed the annotated message and `is_bbox_fallback=True`.

Closes #4227