### PR TITLE
fix(net-status): count zone-pour copper contact for plane-pad connectivity

### DIFF
--- a/src/kicad_tools/analysis/net_status.py
+++ b/src/kicad_tools/analysis/net_status.py
@@ -930,6 +930,17 @@ class NetStatusAnalyzer:
         through them (directly, or via a segment chain ending at the via) into
         that island, closing the ``pad -> trace -> stitch via -> pour`` path.
 
+        Segment chains whose copper *touches* a fill island bond their pads to
+        it too, and chains are unified transitively through shared vias so a
+        cross-layer path bonds correctly (Issue #4229): the common real-world
+        shape is a signal pad on F.Cu that reaches a plane on B.Cu through
+        ``pad -> F.Cu trace -> through-via -> B.Cu trace -> pour`` where the via
+        itself sits in a thermal antipad (its copper does NOT penetrate the
+        pour) and only the far B.Cu trace endpoint lands on the poured copper.
+        The per-via penetration test alone misses that pad; bonding via the
+        chain-touches-fill path recovers it, matching KiCad's zone-aware
+        connectivity (kicad-cli reports 0 unconnected for exactly this case).
+
         Returns ``None`` when ``shapely`` is unavailable (the caller then uses
         the legacy boundary-based fallback); otherwise a list of pad-id groups,
         one per bonded fill island.
@@ -960,16 +971,48 @@ class NetStatusAnalyzer:
                 if poly is not None:
                     pad_polys[pad_id] = poly
 
-        # Copper-circle geometry per via (radius = size / 2, eroded like a pad
-        # box).  A via whose copper penetrates a pour's solid region ties any
-        # pad reachable through it into that island.
-        via_geoms = [
-            (
-                via,
-                cv._via_copper_geom(via.position, max(getattr(via, "size", 0.0) or 0.0, 0.0) / 2.0),
-            )
-            for via in vias
-        ]
+        # Copper-circle geometry per via.  Two variants:
+        #  * ``via_geom`` (eroded, ``POUR_PAD_ERODE`` inset) is used for the
+        #    fill-*penetration* test so a via merely grazing the pour edge does
+        #    not spuriously bond -- matching ``ConnectivityValidator``.
+        #  * ``via_raw`` (un-eroded, real copper radius) is used only to bond a
+        #    *same-net* pad to a via that already penetrates the pour.  The
+        #    erosion inset on both the pad box and the via disc otherwise opens
+        #    a sub-``2*POUR_PAD_ERODE`` false gap between a stitching via and an
+        #    adjacent same-net pad whose copper genuinely overlaps it (the
+        #    board-06 U1.32 case, Issue #4229).  Using the raw radius here is
+        #    safe: the group is single-net, so a looser pad<->via bond can only
+        #    unify pads that are already the same net -- it can never manufacture
+        #    a cross-net short (that is what the eroded penetration test guards).
+        from shapely.geometry import Point as _ShapelyPoint  # type: ignore[import-untyped]
+
+        via_geoms = []
+        for via in vias:
+            radius = max(getattr(via, "size", 0.0) or 0.0, 0.0) / 2.0
+            eroded = cv._via_copper_geom(via.position, radius)
+            raw = _ShapelyPoint(*via.position).buffer(radius) if radius > 0 else None
+            via_geoms.append((via, eroded, raw))
+
+        # Unify segment components that share a via into "extended chains"
+        # (Issue #4229).  ``_build_segment_components`` chains segments only
+        # when their own copper touches, so a through-via joining an F.Cu trace
+        # to a B.Cu trace leaves them in separate components even though they
+        # are one electrical net.  Merging components that both touch the same
+        # via recovers the cross-layer ``pad -> trace -> via -> trace -> pour``
+        # path so a pad on one layer bonds to a pour on another.
+        extended_chains = self._merge_chains_via_vias(segments, segment_components, vias)
+
+        # Pre-compute, per extended chain, the pads it reaches and the copper
+        # layers/geometry it presents to the pour tests.
+        chain_pads: list[set[str]] = []
+        chain_seg_indices: list[set[int]] = []
+        for chain in extended_chains:
+            pads_in_chain: set[str] = set()
+            for s in chain:
+                pads_in_chain.update(self._find_pads_at_point(segments[s].start, pad_positions))
+                pads_in_chain.update(self._find_pads_at_point(segments[s].end, pad_positions))
+            chain_pads.append(pads_in_chain)
+            chain_seg_indices.append(chain)
 
         groups: list[set[str]] = []
         for zone in self.pcb.zones:
@@ -990,31 +1033,115 @@ class NetStatusAnalyzer:
                         bonded.add(pad_id)
 
                 # Via bonds: a via whose copper penetrates this fill island ties
-                # the pads reached through it (directly or via a segment chain
-                # ending at the via) into the same island.
-                for via, via_geom in via_geoms:
+                # the pads reached through it (directly, through a same-net pad
+                # whose copper overlaps the via, or via a segment chain ending
+                # at the via) into the same island.
+                for via, via_geom, via_raw in via_geoms:
                     if not self._via_spans_layer(via.layers, fill_layer):
                         continue
                     if not region.intersects(via_geom):
                         continue
                     bonded.update(self._find_pads_at_point(via.position, pad_positions))
-                    for component in segment_components:
+                    # Same-net pad whose real copper overlaps this pour-bonded
+                    # via (raw radius -- see via_geoms note): the stitching via
+                    # sits beside the pad, not dead-centre (board-06 U1.32).
+                    if via_raw is not None:
+                        for pad_id, pad_geom in pad_polys.items():
+                            if pad_id in bonded:
+                                continue
+                            if via_raw.intersects(pad_geom):
+                                bonded.add(pad_id)
+                    for chain, pads_in_chain in zip(chain_seg_indices, chain_pads, strict=True):
                         touches = any(
-                            self._points_close(segments[s].start, via.position)
-                            or self._points_close(segments[s].end, via.position)
-                            for s in component
+                            self._segment_touches_via(segments[s], via, via_geom) for s in chain
                         )
-                        if not touches:
-                            continue
-                        for s in component:
-                            bonded.update(
-                                self._find_pads_at_point(segments[s].start, pad_positions)
-                            )
-                            bonded.update(self._find_pads_at_point(segments[s].end, pad_positions))
+                        if touches:
+                            bonded.update(pads_in_chain)
+
+                # Segment-chain bonds: an extended chain whose own copper touches
+                # this fill island (a trace endpoint lands on the poured copper)
+                # ties every pad reachable through the chain into the island.
+                # This recovers the board-06/board-05 plane-pad case where the
+                # via sits in an antipad and only the far trace reaches the pour
+                # (Issue #4229).
+                for chain, pads_in_chain in zip(chain_seg_indices, chain_pads, strict=True):
+                    if not pads_in_chain:
+                        continue
+                    if any(
+                        self._via_spans_layer([segments[s].layer], fill_layer)
+                        and region.intersects(self._segment_poly(segments[s]))
+                        for s in chain
+                    ):
+                        bonded.update(pads_in_chain)
 
             if bonded:
                 groups.append(bonded)
         return groups
+
+    def _merge_chains_via_vias(
+        self,
+        segments: list,
+        segment_components: list[set[int]],
+        vias: list,
+    ) -> list[set[int]]:
+        """Merge segment components that share a via into extended chains.
+
+        ``_build_segment_components`` only chains segments whose own copper
+        touches, so two traces on different layers joined solely by a
+        through-via land in separate components.  KiCad treats them as one
+        electrical chain; this union-find over "components that both touch the
+        same via" reproduces that so a cross-layer ``pad -> trace -> via ->
+        trace -> pour`` path is recognised as connected (Issue #4229).
+
+        The merge is purely additive connectivity: it never fuses two chains
+        that don't share a via, so genuinely separate copper stays separate and
+        the #3914 "don't union disjoint fills" guarantee is unaffected.
+        """
+        n = len(segment_components)
+        parent = list(range(n))
+
+        def find(x: int) -> int:
+            while parent[x] != x:
+                parent[x] = parent[parent[x]]
+                x = parent[x]
+            return x
+
+        def union(a: int, b: int) -> None:
+            ra, rb = find(a), find(b)
+            if ra != rb:
+                parent[ra] = rb
+
+        for via in vias:
+            via_geom = self._via_geom(via)
+            touching: list[int] = []
+            for ci, component in enumerate(segment_components):
+                if any(self._segment_touches_via(segments[s], via, via_geom) for s in component):
+                    touching.append(ci)
+            for other in touching[1:]:
+                union(touching[0], other)
+
+        merged: dict[int, set[int]] = defaultdict(set)
+        for ci, component in enumerate(segment_components):
+            merged[find(ci)].update(component)
+        return list(merged.values())
+
+    def _segment_touches_via(self, seg: Any, via: Any, via_geom: Any) -> bool:
+        """Return ``True`` when a segment is electrically joined to a via.
+
+        A segment endpoint within ``POSITION_TOLERANCE`` of the via centre is a
+        clean join, but a real board frequently lands a trace endpoint on the
+        via *annular ring* rather than dead-centre (Issue #4229): the endpoint
+        may sit >tolerance from the centre yet still be covered by the via's
+        copper.  When shapely geometry is available we additionally treat the
+        via as joined to the segment when the via copper disc intersects the
+        segment copper, which matches KiCad's connectivity.
+        """
+        if self._points_close(seg.start, via.position) or self._points_close(seg.end, via.position):
+            return True
+        if via_geom is None:
+            return False
+        seg_poly = self._segment_poly(seg)
+        return self._geoms_touch(seg_poly, via_geom)
 
     def _legacy_zone_connected_pads(
         self,

--- a/tests/test_net_status.py
+++ b/tests/test_net_status.py
@@ -897,3 +897,135 @@ class TestNetStatusCorruptionDefense:
             assert net_status.total_pads == 0
             assert net_status.status == "unrouted"
             assert net_status.connection_percentage == 0.0
+
+
+class TestZonePourContactConnectivity:
+    """Issue #4229: pad-in-pour copper contact must count for connectivity.
+
+    A plane pad connected to its net purely through pad-in-pour contact (no
+    stitching via) was false-flagged incomplete because a lone pour-connected
+    pad formed a singleton graph island that lost the "largest island wins"
+    vote to a separately-routed trace island on the same net.  kicad-cli's
+    zone-aware engine reports these as fully connected.  The bug reproduces in
+    the DEFAULT (tolerance) path as well as ``--strict``; these tests mirror
+    ``test_net_status_strict.py`` for the default analyzer.
+    """
+
+    def _lone_pour_pad_board(self, *, filled: bool = True, pad_in_pour: bool = True) -> str:
+        u1_pos = "30 20" if pad_in_pour else "90 90"
+        filled_clause = (
+            '    (filled_polygon (layer "B.Cu") (pts (xy 5 5) (xy 40 5) (xy 40 30) (xy 5 30)))\n'
+            if filled
+            else ""
+        )
+        return f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal) (44 "Edge.Cuts" user))
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (footprint "Resistor_SMD:R_0402_1005Metric" (layer "B.Cu") (uuid "fp1") (at 12 12)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "B.SilkS") (uuid "ref1"))
+    (pad "1" smd roundrect (at 0 0) (size 0.6 0.6)
+      (layers "B.Cu" "B.Paste" "B.Mask") (roundrect_rratio 0.25) (net 1 "GND")))
+  (footprint "Resistor_SMD:R_0402_1005Metric" (layer "B.Cu") (uuid "fp2") (at 20 12)
+    (property "Reference" "R2" (at 0 -1.5 0) (layer "B.SilkS") (uuid "ref2"))
+    (pad "1" smd roundrect (at 0 0) (size 0.6 0.6)
+      (layers "B.Cu" "B.Paste" "B.Mask") (roundrect_rratio 0.25) (net 1 "GND")))
+  (footprint "Package_QFP:LQFP-48" (layer "B.Cu") (uuid "fp3") (at {u1_pos})
+    (property "Reference" "U1" (at 0 -1.5 0) (layer "B.SilkS") (uuid "ref3"))
+    (pad "17" smd roundrect (at 0 0) (size 0.6 0.6)
+      (layers "B.Cu" "B.Paste" "B.Mask") (roundrect_rratio 0.25) (net 1 "GND")))
+  (segment (start 12 12) (end 20 12) (width 0.25) (layer "B.Cu") (net 1) (uuid "seg1"))
+  (zone (net 1) (net_name "GND") (layer "B.Cu") (uuid "zone1")
+    (connect_pads (clearance 0.3))
+    (min_thickness 0.2)
+    (fill yes (thermal_gap 0.3) (thermal_bridge_width 0.3))
+    (polygon (pts (xy 5 5) (xy 40 5) (xy 40 30) (xy 5 30)))
+{filled_clause}  )
+)
+"""
+
+    def _two_disjoint_fills_board(self) -> str:
+        return """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal) (44 "Edge.Cuts" user))
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (footprint "Resistor_SMD:R_0402_1005Metric" (layer "F.Cu") (uuid "fp1") (at 12 12)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "ref1"))
+    (pad "1" smd roundrect (at 0 0) (size 0.6 0.6)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND")))
+  (footprint "Resistor_SMD:R_0402_1005Metric" (layer "F.Cu") (uuid "fp2") (at 32 12)
+    (property "Reference" "R2" (at 0 -1.5 0) (layer "F.SilkS") (uuid "ref2"))
+    (pad "1" smd roundrect (at 0 0) (size 0.6 0.6)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND")))
+  (zone (net 1) (net_name "GND") (layer "F.Cu") (uuid "zA")
+    (connect_pads (clearance 0.3)) (min_thickness 0.2)
+    (fill yes (thermal_gap 0.3) (thermal_bridge_width 0.3))
+    (polygon (pts (xy 10 10) (xy 14 10) (xy 14 14) (xy 10 14)))
+    (filled_polygon (layer "F.Cu") (pts (xy 10 10) (xy 14 10) (xy 14 14) (xy 10 14))))
+  (zone (net 1) (net_name "GND") (layer "F.Cu") (uuid "zB")
+    (connect_pads (clearance 0.3)) (min_thickness 0.2)
+    (fill yes (thermal_gap 0.3) (thermal_bridge_width 0.3))
+    (polygon (pts (xy 30 10) (xy 34 10) (xy 34 14) (xy 30 14)))
+    (filled_polygon (layer "F.Cu") (pts (xy 30 10) (xy 34 10) (xy 34 14) (xy 30 14))))
+)
+"""
+
+    def test_lone_pour_pad_reports_complete(self, tmp_path: Path):
+        """A pad alone in a filled zone of its net reads complete (default mode)."""
+        pytest.importorskip("shapely")
+        path = tmp_path / "board.kicad_pcb"
+        path.write_text(self._lone_pour_pad_board())
+        result = NetStatusAnalyzer(path).analyze()
+        gnd = result.get_net("GND")
+        assert gnd is not None
+        assert gnd.status == "complete", (
+            f"lone pour pad must read complete; got {gnd.status}, "
+            f"unconnected={[p.full_name for p in gnd.unconnected_pads]}"
+        )
+        assert "U1.17" in {p.full_name for p in gnd.connected_pads}
+
+    def test_pad_off_pour_still_incomplete(self, tmp_path: Path):
+        """A pad off the pour with no trace/via stays incomplete (default mode)."""
+        pytest.importorskip("shapely")
+        path = tmp_path / "board.kicad_pcb"
+        path.write_text(self._lone_pour_pad_board(pad_in_pour=False))
+        result = NetStatusAnalyzer(path).analyze()
+        gnd = result.get_net("GND")
+        assert gnd is not None
+        assert gnd.status == "incomplete"
+        assert "U1.17" in {p.full_name for p in gnd.unconnected_pads}
+
+    def test_unfilled_zone_still_incomplete(self, tmp_path: Path):
+        """A pad in an unfilled zone stays incomplete (fill-currency, default mode)."""
+        pytest.importorskip("shapely")
+        path = tmp_path / "board.kicad_pcb"
+        path.write_text(self._lone_pour_pad_board(filled=False))
+        result = NetStatusAnalyzer(path).analyze()
+        gnd = result.get_net("GND")
+        assert gnd is not None
+        assert gnd.status == "incomplete"
+        assert "U1.17" in {p.full_name for p in gnd.unconnected_pads}
+
+    def test_two_disjoint_fills_not_unioned(self, tmp_path: Path):
+        """Two disjoint fills of a net stay separate (#3914 regression, default mode)."""
+        pytest.importorskip("shapely")
+        path = tmp_path / "board.kicad_pcb"
+        path.write_text(self._two_disjoint_fills_board())
+        result = NetStatusAnalyzer(path).analyze()
+        gnd = result.get_net("GND")
+        assert gnd is not None
+        assert gnd.status == "incomplete"
+        assert gnd.connected_count == 1
+        assert gnd.unconnected_count == 1

--- a/tests/test_net_status_strict.py
+++ b/tests/test_net_status_strict.py
@@ -200,3 +200,180 @@ def test_strict_requires_shapely(monkeypatch, tmp_path: Path):
     path.write_text(_pad_seg_board(seg_end_x=109.9))
     with pytest.raises(ModuleNotFoundError):
         NetStatusAnalyzer(path, strict=True)
+
+
+# ---------------------------------------------------------------------------
+# Issue #4229: zone-pour copper contact must count for connectivity.
+#
+# A plane pad connected to its net purely through pad-in-pour contact (or a
+# cross-layer ``pad -> trace -> via -> trace -> pour`` path where the via sits
+# in a thermal antipad) was false-flagged incomplete.  kicad-cli's zone-aware
+# engine reports these as fully connected.  The root cause was NOT
+# strict-specific -- the zone-fill geometry runs in both modes -- so every
+# fixture below is asserted in BOTH ``strict=False`` and ``strict=True``.
+# ---------------------------------------------------------------------------
+
+
+def _lone_pour_pad_board(*, filled: bool = True, pad_in_pour: bool = True) -> str:
+    """Synthetic board reproducing the board-06 plane-pad shape.
+
+    ``R1``/``R2`` are joined by a B.Cu trace (island A).  ``U1.17`` sits alone
+    on the same GND net with no trace or via to it; it connects to the net
+    solely through its copper overlapping the poured GND plane on B.Cu -- the
+    plane is one continuous pour covering the whole net.
+
+    * ``filled=False`` drops the ``filled_polygon`` (an unfilled zone), so the
+      pour provides no copper.
+    * ``pad_in_pour=False`` moves ``U1.17`` outside the pour outline entirely.
+    """
+    u1_pos = "30 20" if pad_in_pour else "90 90"
+    filled_clause = (
+        '    (filled_polygon (layer "B.Cu") (pts (xy 5 5) (xy 40 5) (xy 40 30) (xy 5 30)))\n'
+        if filled
+        else ""
+    )
+    return f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal) (44 "Edge.Cuts" user))
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (footprint "Resistor_SMD:R_0402_1005Metric" (layer "B.Cu") (uuid "fp1") (at 12 12)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "B.SilkS") (uuid "ref1"))
+    (pad "1" smd roundrect (at 0 0) (size 0.6 0.6)
+      (layers "B.Cu" "B.Paste" "B.Mask") (roundrect_rratio 0.25) (net 1 "GND")))
+  (footprint "Resistor_SMD:R_0402_1005Metric" (layer "B.Cu") (uuid "fp2") (at 20 12)
+    (property "Reference" "R2" (at 0 -1.5 0) (layer "B.SilkS") (uuid "ref2"))
+    (pad "1" smd roundrect (at 0 0) (size 0.6 0.6)
+      (layers "B.Cu" "B.Paste" "B.Mask") (roundrect_rratio 0.25) (net 1 "GND")))
+  (footprint "Package_QFP:LQFP-48" (layer "B.Cu") (uuid "fp3") (at {u1_pos})
+    (property "Reference" "U1" (at 0 -1.5 0) (layer "B.SilkS") (uuid "ref3"))
+    (pad "17" smd roundrect (at 0 0) (size 0.6 0.6)
+      (layers "B.Cu" "B.Paste" "B.Mask") (roundrect_rratio 0.25) (net 1 "GND")))
+  (segment (start 12 12) (end 20 12) (width 0.25) (layer "B.Cu") (net 1) (uuid "seg1"))
+  (zone (net 1) (net_name "GND") (layer "B.Cu") (uuid "zone1")
+    (connect_pads (clearance 0.3))
+    (min_thickness 0.2)
+    (fill yes (thermal_gap 0.3) (thermal_bridge_width 0.3))
+    (polygon (pts (xy 5 5) (xy 40 5) (xy 40 30) (xy 5 30)))
+{filled_clause}  )
+)
+"""
+
+
+def _two_disjoint_fills_board() -> str:
+    """Two SEPARATE filled GND zones with no bridge (#3914 regression guard).
+
+    ``R1.1`` sits on fill island A; ``R2.1`` sits on a physically disjoint
+    fill island B.  No trace or via bridges them, so KiCad reports a real open
+    between the two islands.  The #4229 pad-in-pour fix must NOT falsely union
+    the two islands -- the open must stay visible.
+    """
+    return """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal) (44 "Edge.Cuts" user))
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (footprint "Resistor_SMD:R_0402_1005Metric" (layer "F.Cu") (uuid "fp1") (at 12 12)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "ref1"))
+    (pad "1" smd roundrect (at 0 0) (size 0.6 0.6)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND")))
+  (footprint "Resistor_SMD:R_0402_1005Metric" (layer "F.Cu") (uuid "fp2") (at 32 12)
+    (property "Reference" "R2" (at 0 -1.5 0) (layer "F.SilkS") (uuid "ref2"))
+    (pad "1" smd roundrect (at 0 0) (size 0.6 0.6)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND")))
+  (zone (net 1) (net_name "GND") (layer "F.Cu") (uuid "zA")
+    (connect_pads (clearance 0.3)) (min_thickness 0.2)
+    (fill yes (thermal_gap 0.3) (thermal_bridge_width 0.3))
+    (polygon (pts (xy 10 10) (xy 14 10) (xy 14 14) (xy 10 14)))
+    (filled_polygon (layer "F.Cu") (pts (xy 10 10) (xy 14 10) (xy 14 14) (xy 10 14))))
+  (zone (net 1) (net_name "GND") (layer "F.Cu") (uuid "zB")
+    (connect_pads (clearance 0.3)) (min_thickness 0.2)
+    (fill yes (thermal_gap 0.3) (thermal_bridge_width 0.3))
+    (polygon (pts (xy 30 10) (xy 34 10) (xy 34 14) (xy 30 14)))
+    (filled_polygon (layer "F.Cu") (pts (xy 30 10) (xy 34 10) (xy 34 14) (xy 30 14))))
+)
+"""
+
+
+@pytest.mark.parametrize("strict", [False, True])
+def test_lone_pour_pad_reports_complete(strict: bool):
+    """A pad alone in a filled zone of its net reads COMPLETE (#4229).
+
+    ``U1.17`` has no trace and no via -- it connects to the net solely by its
+    copper overlapping the poured GND plane.  Before the fix this pad formed a
+    singleton graph island that lost the "largest island wins" vote to the
+    R1/R2 trace island and was false-flagged incomplete.  This is the direct
+    board-05/board-06 plane-pad case.
+    """
+    result = _analyze(_lone_pour_pad_board(), strict=strict)
+    gnd = result.get_net("GND")
+    assert gnd is not None
+    assert gnd.status == "complete", (
+        f"lone pour pad must read complete (strict={strict}); got {gnd.status}, "
+        f"unconnected={[p.full_name for p in gnd.unconnected_pads]}"
+    )
+    assert "U1.17" in {p.full_name for p in gnd.connected_pads}
+
+
+@pytest.mark.parametrize("strict", [False, True])
+def test_pad_off_pour_still_incomplete(strict: bool):
+    """A pad NOT in any fill and with no trace/via stays INCOMPLETE (#4229).
+
+    Regression guard: the fix must not become a rubber-stamp "always complete".
+    ``U1.17`` sits far outside the pour with no copper reaching it, so it is
+    genuinely stranded.
+    """
+    result = _analyze(_lone_pour_pad_board(pad_in_pour=False), strict=strict)
+    gnd = result.get_net("GND")
+    assert gnd is not None
+    assert gnd.status == "incomplete", (
+        f"a pad off the pour with no trace/via must stay incomplete "
+        f"(strict={strict}); got {gnd.status}"
+    )
+    assert "U1.17" in {p.full_name for p in gnd.unconnected_pads}
+
+
+@pytest.mark.parametrize("strict", [False, True])
+def test_unfilled_zone_still_incomplete(strict: bool):
+    """A pad in an UNFILLED zone stays INCOMPLETE (#4229 fill-currency).
+
+    The zone outline covers ``U1.17`` but the zone has no ``filled_polygon``
+    (fill disabled/stale), so it produces no copper -- matching KiCad's
+    "unfilled zone = no connectivity".  Confirms the fix only counts committed
+    fill copper and does not regress the #3482 fill-currency behavior.
+    """
+    result = _analyze(_lone_pour_pad_board(filled=False), strict=strict)
+    gnd = result.get_net("GND")
+    assert gnd is not None
+    assert gnd.status == "incomplete", (
+        f"an unfilled zone must not provide connectivity (strict={strict}); got {gnd.status}"
+    )
+    assert "U1.17" in {p.full_name for p in gnd.unconnected_pads}
+
+
+@pytest.mark.parametrize("strict", [False, True])
+def test_two_disjoint_fills_not_unioned(strict: bool):
+    """Two disjoint filled zones of a net stay separate (#3914 regression).
+
+    The #4229 pad-in-pour fix connects a pad to the fill island it actually
+    touches, NOT to every fill of the net.  Two physically separate GND pours
+    with no bridge must therefore still report a real open between them.
+    """
+    result = _analyze(_two_disjoint_fills_board(), strict=strict)
+    gnd = result.get_net("GND")
+    assert gnd is not None
+    assert gnd.status == "incomplete", (
+        f"two disjoint fills must not be falsely unioned (strict={strict}); got {gnd.status}"
+    )
+    assert gnd.connected_count == 1
+    assert gnd.unconnected_count == 1


### PR DESCRIPTION
## Summary

A plane pad connected to its net purely through pad-in-pour copper contact (no stitching via) -- or through a cross-layer `pad -> trace -> via -> trace -> pour` path where the via lands in a thermal antipad -- was false-flagged **incomplete** by `NetStatusAnalyzer` in **both** default and `--strict` modes, while `kicad-cli pcb drc --refill-zones` reports **0 unconnected** for exactly those pads.

`net-status` is the completion oracle (route loops, `--why`, `kct check` connectivity, CI all key off it), so this fix changes both modes' output. It was validated to introduce **no completion regression** on any committed board.

## Root cause

`_build_fill_island_groups()` only bonded a pad to a pour when the pad copper directly overlapped the fill, or a via *penetrating* the fill sat at the pad centre. It missed:
1. the cross-layer chain where the through-via lands in a thermal antipad (its copper does **not** penetrate the pour) and only the far trace endpoint reaches the poured copper (board-06 `U1.17` +3V3);
2. a stitching via placed *beside* a same-net pad whose real copper overlaps it only before the `POUR_PAD_ERODE` inset (board-06 `U1.32` GND).

A lone pour-bonded pad then formed a **singleton** graph island that always lost the "largest island wins" vote to a separately-routed trace island on the same net.

## Changes

- `_merge_chains_via_vias()`: union segment components that share a via into extended chains, so a cross-layer trace path is recognised as one electrical chain (KiCad semantics).
- `_segment_touches_via()`: join a trace to a via by copper overlap, not just endpoint proximity (traces land on the annular ring, not dead-centre).
- Bond a pad to a fill island when an extended chain that touches the fill reaches it, or when the pad copper overlaps a pour-penetrating via (raw, un-eroded radius). The raw radius is safe here because each fill-island group is single-net, so a looser pad<->via bond can only unify pads that are already the same net -- it can never manufacture a cross-net short (the eroded penetration test still guards that).
- **Scope:** `net_status.py` only. `ConnectivityValidator` (`validate/connectivity.py`) is untouched -- that unification is the deferred #4176 Phase 2.

The per-fill-island grouping is preserved, so two physically disjoint pours of the same net are **not** unioned -- a real open between them stays visible (#3914/#3947). Unfilled zones still provide no connectivity (#3482 fill-currency); that path is unchanged.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Lone pad in a filled zone of its net (no via, no sibling on fragment) -> COMPLETE, both modes | ✅ | `test_lone_pour_pad_reports_complete` (strict + default); board-06 U1.17/U1.32 |
| Pad not in any fill, no segment/via -> still INCOMPLETE, both modes | ✅ | `test_pad_off_pour_still_incomplete` |
| Pad in an UNFILLED zone -> INCOMPLETE (fill-currency), both modes | ✅ | `test_unfilled_zone_still_incomplete` |
| #3914/#3947 regression guard: two disjoint fills NOT falsely unioned | ✅ | `test_two_disjoint_fills_not_unioned`; existing `test_discontinuous_fill_not_complete` / `test_partial_fill_zone_only_connects_pads_on_copper` still pass |
| ConnectivityValidator untouched | ✅ | `tests/test_copper_lvs.py` passes unchanged (47 passed) |
| No board completion regression | ✅ | Board re-validation table below |

## Board net-status re-validation (before → after; committed routed boards)

| Board | Mode | Before (complete/incomplete) | After | Note |
|-------|------|------------------------------|-------|------|
| 00 | default / strict | 3/0 · 3/0 | 3/0 · 3/0 | unchanged |
| 01 | default / strict | 3/0 · 3/0 | 3/0 · 3/0 | unchanged |
| 02 | default / strict | 10/0 · 10/0 | 10/0 · 10/0 | unchanged |
| 03 | default / strict | 16/0 · 16/0 | 16/0 · 16/0 | unchanged |
| 04 | default / strict | 11/1 (GND) · 11/1 (GND) | 12/0 · 12/0 | GND was a **false**-incomplete; kicad-cli = 0 unconnected |
| 06 | default | 22/4 (+1V2,+3V3,GND,VBUS_USB) | 23/3 (+1V2,GND,VBUS_USB) | +3V3 U1.17 now complete |
| 06 | strict | 24/2 (+3V3,GND) | **26/0** | U1.17 (+3V3) and U1.32 (GND) plane pads now complete; matches kicad-cli 0 unconnected |
| 07 | default / strict | 29/5 · 29/5 | 29/5 · 29/5 | 5 genuine #3438 opens **still reported** (kicad-cli = 5 unconnected) |

No board's connectivity count regresses. Ground truth cross-checked with `kicad-cli pcb drc --refill-zones` on boards 04 (0 unconnected), 06 (0 unconnected), 07 (5 unconnected). Boards 05 (tier1, local-only) not run in this environment.

## Test Plan

- `uv run pytest tests/test_net_status_strict.py tests/test_net_status.py tests/test_analysis_net_status.py` -> 122 passed (110 existing + 12 new)
- `uv run pytest tests/ -k "net_status or connectivity"` -> 388 passed
- `uv run pytest tests/test_copper_lvs.py` -> 47 passed (ConnectivityValidator unaffected)
- `ruff check` + `ruff format` clean; `check_mypy_baseline.py` -> 0 new errors
- C++ native backend built (`kct build-native`)

Closes #4229