### PR TITLE
docs: repoint broken internal cross-references under docs/

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 4220
-# Branch: feature/issue-4220
+# Issue: 4236
+# Branch: feature/issue-4236
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/docs/guides/query-api.md
+++ b/docs/guides/query-api.md
@@ -440,5 +440,5 @@ for symbol in sch.symbols.order_by("reference"):
 ## Next Steps
 
 - **[Schematic Analysis](schematic-analysis.md)** - More schematic operations
-- **[DRC with Manufacturer Rules](drc-manufacturer-rules.md)** - Design validation
+- **[DRC with Manufacturer Rules](drc-and-validation.md)** - Design validation
 - **[Manufacturing Export](manufacturing-export.md)** - Generate production files

--- a/docs/guides/schematic-analysis.md
+++ b/docs/guides/schematic-analysis.md
@@ -353,6 +353,6 @@ if __name__ == "__main__":
 
 ## Next Steps
 
-- **[DRC with Manufacturer Rules](drc-manufacturer-rules.md)** - Validate your PCB design
+- **[DRC with Manufacturer Rules](drc-and-validation.md)** - Validate your PCB design
 - **[Manufacturing Export](manufacturing-export.md)** - Export for fabrication
 - **[Query API](query-api.md)** - Advanced filtering techniques

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,6 @@ Detailed reference documentation:
 
 ### For Contributors
 - [Development Guide](contributing/development.md) - Setup, testing, code style
-- [Architecture Deep Dive](contributing/architecture-internals.md) - Internal design decisions
 
 ---
 


### PR DESCRIPTION
## Summary
Fixes three dead relative markdown links under `docs/` surfaced by a link scan. Documentation-only change; no code paths affected.

## Changes
- `docs/index.md` (line 42): removed the dead "Architecture Deep Dive" bullet pointing at the nonexistent `contributing/architecture-internals.md`. `architecture.md` is already linked as "Architecture Overview" (line 13), so no information is lost and no stub doc is needed.
- `docs/guides/query-api.md` (line 443): repointed `drc-manufacturer-rules.md` -> `drc-and-validation.md`.
- `docs/guides/schematic-analysis.md` (line 356): repointed `drc-manufacturer-rules.md` -> `drc-and-validation.md`.

Left unchanged (per issue guidance): the Python generic-method signature in a fenced code block in `docs/research/faebryk-component-library.md:70` is a scanner false positive, not a real link.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| index.md dead architecture-internals link fixed | ✅ | Bullet removed; `architecture.md` still linked on line 13 |
| query-api.md link swapped to drc-and-validation.md | ✅ | `docs/guides/drc-and-validation.md` confirmed to exist |
| schematic-analysis.md link swapped to drc-and-validation.md | ✅ | Same target confirmed present |
| Zero genuine broken relative links under docs/ | ✅ | Scan reports only the faebryk code-block false positive (TOTAL: 1) |
| faebryk false positive left unchanged | ✅ | No edit to faebryk-component-library.md |

## Test Plan
Ran the curator's repo-wide relative-link scan over `docs/**/*.md`. Before: 3 genuine breaks + 1 false positive. After: only the expected faebryk code-block false positive remains (`self, special: T, ...`), all 3 real breaks resolved. Corrected targets (`architecture.md`, `docs/guides/drc-and-validation.md`) verified to exist on disk.

Closes #4236