### PR TITLE
docs: add orientation READMEs for tests/ and scripts/

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,42 @@
+# scripts/
+
+Developer and CI helper scripts. These are **not** part of the installed `kct`
+package — they support building, deploying, diagnosing, and gating the project.
+
+Run shell scripts with `bash scripts/<name>.sh` (or `./scripts/<name>.sh`) and
+Python helpers with `uv run python scripts/<name>.py`, from the repository root.
+
+## Top-level scripts
+
+| Script | Purpose |
+|--------|---------|
+| `build-cpp.sh` | Build/install the nanobind C++ router extension (`clean`, `check` subcommands). Wrapped by `kct build-native`. |
+| `deploy-site.sh` | Manual one-command deploy of the kicad-tools.org demo gallery to Cloudflare Pages (via a locally authenticated `wrangler`). |
+| `install-kct.sh` | Install kicad-tools into a consumer PCB-design repo (uv dependency + vendored `.claude/commands/kct/` skills and `ci/` gate scripts). |
+| `calibrate_area_estimate.py` | Calibration helper for the sum-of-clearances board-area estimator (#3403). |
+| `check_trace_vs_zone_fills.py` | Verify track segments against foreign-net zone fill copper (clearance/short check DRC cannot yet do; #3527). |
+| `diagnose_b03_diffpair.py` | Diagnostic for why the differential-pair pre-pass fails on board 03 (#2490). |
+| `route_chorus.py` | Canonical chorus-test-revA routing recipe runner with partial-net rescue (#3474). |
+
+## Subdirectories
+
+### `ci/`
+
+Gate scripts invoked by GitHub Actions (and vendored into consumer repos by
+`install-kct.sh`). They take a board path as a CLI argument and gate the build
+on copper-LVS, routed-DRC, diff-pair / match-group coverage, board-specific
+end-to-end checks, the mypy baseline, and route determinism:
+
+`board06_determinism_smoke.sh`, `board_route_determinism_smoke.sh`,
+`check_board_00_e2e.py`, `check_board_05_blocking.py`, `check_copper_lvs.py`,
+`check_diffpair_coverage.py`, `check_matchgroup_coverage.py`,
+`check_mypy_baseline.py`, `check_routed_drc.py`, `net_class_map_resolver.py`.
+
+### `research/`
+
+FOM-calibration and corpus-generation scripts (pair with `data/research/`):
+
+`calibrate_fom.py`, `check_negatives.py`, `demo_integration.py`,
+`generate_negative_controls.py`, `generate_perturbations.py`,
+`run_phase0_corpus.sh`, `run_phase0_fast_corpus.sh`,
+`train_phase0_classifier.py`.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,61 @@
+# tests/
+
+Pytest suite for **kicad-tools** — unit, integration, and benchmark coverage
+of the `src/kicad_tools` package.
+
+## Running the suite
+
+```bash
+uv run pytest                 # full suite (coverage on by default)
+uv run pytest -m "not slow"   # fast subset (skip slow tests)
+uv run pytest -m benchmark    # A/B benchmarks (skipped by default)
+pnpm check:ci                 # pytest + ruff + mypy (the full gate)
+```
+
+Configuration lives in `pyproject.toml` under `[tool.pytest.ini_options]`:
+`testpaths = ["tests"]`, `pythonpath = ["src"]`, and coverage flags
+(`--cov=kicad_tools`) are applied automatically.
+
+## Markers
+
+Declared in `pyproject.toml`:
+
+| Marker | Meaning |
+|--------|---------|
+| `slow` | Slow tests — deselect with `-m "not slow"`. |
+| `integration` | Requires real board fixtures. |
+| `benchmark` | A/B benchmarks — run with `-m benchmark`, skipped by default. |
+
+## Layout
+
+Most of the suite is a flat set of ~740 `test_*.py` modules at the root of
+`tests/`. Focused test data and subsystems live in subpackages:
+
+| Directory | Contents |
+|-----------|----------|
+| `fixtures/` | Shared test data and board fixtures. |
+| `router/` | Router-focused tests (A*, coupled paths, escape, DRC). |
+| `placement/` | Placement and courtyard tests. |
+| `parts/` | Parts / library lookup tests. |
+| `perf/` | Performance and timing tests. |
+| `report/` | Report / feedback rendering tests. |
+| `cost/` | Cost-estimation tests. |
+| `baselines/` | Baseline snapshots for regression checks. |
+| `install/` | Installer / packaging tests. |
+
+Root-level support files: `conftest.py` (shared fixtures), `__init__.py`, and
+`benchmark_results.json`.
+
+## C++ backend caveat
+
+Routing and perf tests assume the native C++ router extension is built in the
+active worktree. Fresh checkouts and new git worktrees need this explicitly —
+`uv sync` does **not** build it:
+
+```bash
+uv run kct build-native          # build the extension
+uv run kct build-native --check  # verify it is available
+```
+
+See the "Fresh worktree checklist" in the repository `README.md` and the
+routing-performance note in `CLAUDE.md` for the full setup sequence.


### PR DESCRIPTION
## Summary

Adds concise, accurate orientation READMEs to two browsable top-level
directories that previously rendered with no README on GitHub: `tests/` and
`scripts/`. Documentation-only; no code paths changed.

Per the curator's scope note, this delivers `tests/` + `scripts/` only. The
other README-less dirs (`benchmarks/`, `data/`, `notebooks/`, `docs/`, `src/`)
are an explicit follow-up, not this issue.

## Changes

- `tests/README.md` (NEW): purpose, how to run (`uv run pytest`, `-m "not slow"`,
  `-m benchmark`, `pnpm check:ci`), the `slow`/`integration`/`benchmark` markers
  from `pyproject.toml`, the subpackage layout table, and the C++-backend
  (`kct build-native`) caveat cross-linked to README/CLAUDE.md.
- `scripts/README.md` (NEW): one-line description per top-level script
  (build-cpp.sh, deploy-site.sh, install-kct.sh, and the four diagnostic `.py`
  helpers) plus notes and full listings for the `ci/` (gate scripts) and
  `research/` (FOM-calibration) subdirs.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `tests/README.md` exists; purpose + run instructions + subdirs | ✅ | File added; lists the 9 subpackages present. |
| `scripts/README.md` exists; per-script one-liners + ci/ + research/ | ✅ | File added; covers all 7 top-level scripts + both subdirs. |
| Every file/subdir named actually exists on main | ✅ | Each ci/, research/, and tests/ subdir path verified with `[ -f ]`/`[ -d ]` and `git ls-tree`; no MISSING entries. |
| READMEs concise, no invented structure | ✅ | ~60 and ~45 lines; only real markers/paths documented. |
| Renders correctly on GitHub | ✅ | Valid Markdown tables and fenced code blocks. |

## Test Plan

- Accuracy: cross-checked every listed path against `git ls-tree` (742 flat
  `test_*.py` at tests root; subpackages fixtures/router/placement/parts/perf/
  report/cost/baselines/install; scripts/ci and scripts/research listings all
  present).
- Markers documented match `[tool.pytest.ini_options].markers` in `pyproject.toml`.
- Documentation only — no automated tests affected (`pytest` ignores `.md`).

Closes #4237