### PR TITLE
docs: rename docs/index.md to README.md and reconcile landing + CLI reference

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -128,7 +128,13 @@ Complete working examples are organized into two directories:
 | `02-bom-generation/` | Generate bills of materials |
 | `03-drc-checking/` | Design rule checking |
 | `04-autorouter/` | Routing strategy comparisons |
+| `05-schematic-to-pcb-workflow/` | End-to-end schematic-to-manufacturing workflow |
 | `06-intelligent-placement/` | Smart component placement |
+| `07-design-feedback/` | Design feedback and rich error reporting |
+| `08-label-based-schematic/` | Build schematics from net labels |
+| `09-manufacturing-export/` | Generate manufacturing packages via the Python API |
+| `10-complete-kct-workflow/` | Complete `.kct` project to manufacturing files |
+| `patterns/` | Reusable circuit-block pattern definitions |
 | `agent-integration/` | Integration with AI agents |
 | `llm-routing/` | LLM-driven routing decisions |
 
@@ -136,10 +142,14 @@ Complete working examples are organized into two directories:
 
 | Board | Complexity | Description |
 |-------|------------|-------------|
+| `00-simple-led/` | Simple | Smallest end-to-end example |
 | `01-voltage-divider/` | Simple | Minimal workflow validation |
 | `02-charlieplex-led/` | Medium | Dense topology, Monte Carlo routing |
 | `03-usb-joystick/` | Complex | Mixed signals, USB differential pairs |
 | `04-stm32-devboard/` | Complex | Programmatic schematic generation |
+| `05-bldc-motor-controller/` | Complex | Three-phase motor drive, thermal + high-current routing |
+| `06-diffpair-test/` | Medium | Differential-pair routing regression testbench |
+| `07-matchgroup-test/` | Medium | N-trace match-group routing regression testbench |
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -176,7 +176,7 @@ Now that you have kicad-tools installed, explore these guides:
 - **[Placement Optimization](guides/placement-optimization.md)** - Optimize component placement
 - **[Routing](guides/routing.md)** - Autoroute PCBs with the A* router
 
-See the [Documentation Index](index.md) for the complete list.
+See the [Documentation Index](README.md) for the complete list.
 
 ## Getting Help
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -23,40 +23,67 @@ kct [--help] [--version] <command> [options]
 |----------|---------|-------------|
 | **Analysis** | `symbols` | List and query schematic symbols |
 | | `nets` | Trace and analyze nets |
+| | `netlist` | Netlist analysis and comparison tools |
 | | `sch` | Schematic analysis tools |
 | | `pcb` | PCB query tools |
-| **Validation** | `erc` | Parse ERC reports |
+| **Validation** | `erc` | ERC validation and analysis |
 | | `drc` | Parse DRC reports with manufacturer rules |
 | | `check` | Pure Python DRC (no kicad-cli) |
-| | `validate` | Schematic-to-PCB sync validation |
+| | `validate` | Validation tools (schematic-to-PCB sync) |
+| | `validate-footprints` | Validate footprints for pad spacing issues |
+| | `net-status` | Report net connectivity status for a PCB |
+| | `constraints` | Constraint conflict detection and management |
+| | `detect-mistakes` | Detect common PCB design mistakes |
+| **Repair** | `fix-drc` | Automated DRC violation repair (clearance + drill) |
+| | `fix-erc` | Automated ERC violation repair (PWR_FLAG + no-connect) |
+| | `fix-vias` | Fix vias to meet manufacturer specifications |
+| | `fix-silkscreen` | Fix silkscreen line widths to meet manufacturer specs |
+| | `fix-footprints` | Fix footprint pad spacing issues |
+| | `repair-clearance` | Repair clearance violations by nudging traces |
+| | `pipeline` | End-to-end repair pipeline for existing PCBs |
+| | `sync` | Reconcile schematic and PCB references |
 | **Manufacturing** | `bom` | Generate bill of materials |
 | | `mfr` | Manufacturer tools and rules |
-| | `fleet status` | Fleet-wide routing + manufacturing readiness survey |
+| | `audit` | Manufacturing readiness audit (ERC, DRC, connectivity) |
+| | `export` | Generate a complete manufacturing package (BOM, CPL, Gerbers) |
+| | `panel` | Create manufacturing panels from board PCBs |
+| | `estimate` | Manufacturing cost estimation |
+| | `impedance` | Transmission line impedance calculations |
+| | `ipc` | Interact with a running KiCad instance via IPC API (KiCad 9.0+) |
+| | `fleet` | Fleet-wide PCB status and operations |
 | | `stitch` | Add via stitching to power planes |
-| | `build` | One-shot pipeline (schematic → PCB → manufacturing) |
-| **Libraries** | `lib` | Symbol library tools |
-| | `footprint` | Footprint generation tools |
+| | `build` | Build from spec to manufacturable design |
+| | `create-pcb` | Create a PCB from a KiCad schematic |
+| | `init` | Initialize a project with manufacturer design rules |
+| | `spec` | Project specification (`.kct`) management |
+| | `clean` | Clean up old/orphaned files from KiCad projects |
+| **Libraries** | `lib` | Symbol and footprint library tools |
+| | `footprint` | Footprint generation and tools |
 | | `parts` | LCSC parts lookup and search |
 | | `datasheet` | Datasheet search and PDF parsing |
 | **PCB Operations** | `route` | Autoroute a PCB |
+| | `route-auto` | Route a net with smart strategy selection |
 | | `zones` | Add copper pour zones |
 | | `placement` | Detect and fix placement conflicts |
 | | `optimize-placement` | CMA-ES placement optimizer (anchor-aware) |
 | | `optimize-traces` | Optimize PCB traces |
+| | `optim` | Placement / routing figure-of-merit tools |
 | **AI Integration** | `reason` | LLM-driven PCB layout reasoning |
 | | `mcp` | MCP server for AI agent integration |
-| **Analysis (v0.7)** | `analyze congestion` | Routing congestion hotspots |
-| | `analyze trace-lengths` | Timing-critical trace analysis |
-| | `analyze thermal` | Thermal hotspot detection |
-| | `analyze signal-integrity` | Crosstalk and impedance analysis |
-| | `erc explain` | ERC root cause analysis |
-| | `constraints check` | Constraint conflict detection |
-| | `net-status` | Net connectivity validation |
-| **Cost (v0.7)** | `estimate cost` | Manufacturing cost estimation |
-| | `parts availability` | LCSC stock checking |
-| | `suggest alternatives` | Alternative part suggestions |
+| | `decisions` | Query design decisions (placement/routing rationale) |
+| | `explain` | Explain design rules and DRC violations |
+| | `suggest` | Part suggestions and recommendations |
+| **Advanced Analysis** | `analyze` | PCB analysis (congestion, thermal, signal integrity) |
+| | `board-metrics` | Emit a normalized `board.json` per board |
+| | `benchmark` | Run routing benchmarks and regression tests |
+| | `calibrate` | Calibrate routing performance settings |
+| **Reporting** | `render` | Render per-board 2D SVGs + 3D PNGs |
+| | `screenshot` | Capture a PNG of a KiCad board or schematic |
+| | `report` | Generate a Markdown design report |
 | **Utilities** | `config` | View/manage configuration |
 | | `interactive` | Launch interactive REPL mode |
+| | `run` | Run a Python script with the kicad-tools interpreter |
+| | `build-native` | Build the C++ router backend (10-100x faster routing) |
 
 ---
 
@@ -868,7 +895,7 @@ See [MCP Documentation](../mcp/README.md) for configuration details.
 
 ---
 
-## Analysis Commands (v0.7)
+## Advanced Analysis Commands
 
 ### `analyze congestion`
 
@@ -986,7 +1013,7 @@ kct net-status board.kicad_pcb --by-class
 
 ---
 
-## Cost Commands (v0.7)
+## Cost Commands
 
 ### `estimate cost`
 


### PR DESCRIPTION
## Summary

Reconcile the `docs/` tree so it renders on GitHub directory browse and its high-traffic pages match the v0.16.0 CLI. GitHub renders `README.md` (not `index.md`) when browsing a directory, and there is no static-site generator in the repo — so `index.md` had zero build value and left `docs/` showing a bare file list. Scope is a bounded accuracy reconcile, not a rewrite (~3 files). Cross-reference link auditing is out of scope (#4236).

## Changes

- **`git mv docs/index.md docs/README.md`** — adopts the `README.md` landing convention already used by `docs/mcp/`, `docs/guides/diff-pairs/`, and `docs/guides/match-groups/`. No duplicate file kept.
- **Board Demos table** — now lists all 8 boards under `boards/` (`00`-`07`), was only `01`-`04`.
- **Feature Examples table** — now lists examples `01`-`10` plus `patterns/`, `agent-integration/`, `llm-routing/` (was missing `05`, `07`, `08`, `09`, `10`, `patterns`).
- **`docs/getting-started.md:179`** — repointed the single inbound `[Documentation Index](index.md)` link to `README.md`.
- **`docs/reference/cli.md`** — removed stale `(v0.7)` tags (overview categories + two detail-section headings, renamed to `Advanced Analysis Commands` to avoid a duplicate heading anchor); expanded the Commands Overview so every top-level v0.16.0 command appears (added the ~23 curator-listed commands plus the `fix-*` / `validate-footprints` / `sync` / `export` repair commands for full coverage).

The dead `contributing/architecture-internals.md` link flagged in the issue was already removed on `main` by #4236 — verified absent, no action taken.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `docs/` renders landing page on GitHub | ✅ | `docs/README.md` now present |
| Rename, not duplicate | ✅ | `test -f docs/README.md && ! test -f docs/index.md` passes |
| No stale inbound `index.md` links | ✅ | `grep -rn 'index.md' docs/` returns nothing |
| Every relative link in README resolves | ✅ | Scripted check: all `.md` targets exist |
| Board Demos table matches `boards/` (excl `external`) | ✅ | Scripted diff: no missing boards |
| Feature Examples table matches `examples/` (excl `README.md`) | ✅ | Scripted diff: no missing examples |
| Every `kct --help` command appears in cli.md | ✅ | Scripted check: all 63 top-level commands present |
| No `(v0.7)` tags remain | ✅ | `grep -n '(v0.7)' docs/reference/cli.md` empty |

## Test Plan

Docs-only change; verified with scripted checks against the filesystem and the live `uv run kct --help` output in the worktree. No automated tests apply.

Closes #4238