### PR TITLE
docs(examples): fix broken spec-format link + /repo:all hygiene pass (#4239)

### DIFF
--- a/examples/10-complete-kct-workflow/README.md
+++ b/examples/10-complete-kct-workflow/README.md
@@ -324,4 +324,4 @@ After generating files:
 
 - [API Documentation](../../docs/)
 - [CLI Reference](../../README.md#command-line-usage)
-- [Project Specification Format](../../docs/spec-format.md)
+- [Project Specification Format](#understanding-the-kct-file)


### PR DESCRIPTION
Closes #4239

Ran the full **`/repo:all`** hygiene pass (Repo Skills v0.4.0) end-to-end, applying only the safe, reversible, in-scope fixes and deferring everything owned by the sibling issues (#4236/#4237/#4238) or gated as destructive. This is a stress-test of the composed pass as much as a cleanup, so the primary deliverable is the **upstream funnel record** below.

## REPO:ALL COMPLETE

```
REPO:ALL COMPLETE
=================
Audit:      gitignore healthy — no safe auto-fix needed (node_modules covered by
            site/.gitignore; no tracked build artifacts; only .env.example tracked,
            real .env protected by .gitignore:60-63)
Docs:       1 fixed (examples/10 README broken spec-format link -> in-file anchor);
            all other findings deferred/vendored/false-positive (see funnel)
Tidy:       freed ~6.7 MB (24 __pycache__ dirs, main workspace); .env + .venv + both
            .so native extensions preserved (NOT deleted)
Tools:      Repo Skills 0.4.0 CURRENT; Loom 0.10.7 -> 0.10.8 STALE (report only, gated)
Reset:      on main (up to date w/ origin/main), tree clean, fetch --prune done,
            1 stash KEPT, 3 worktrees preserved (issue-4238 active builder protected)
Skipped:    remote (never part of /repo:all)
```

## Guardrail verification (AC)
- `.env` **byte-for-byte unchanged**: md5 `79b6cd8256ffedbf349e7bb8d17290df`, size 1920, mtime `Jul 13 12:42` — identical before and after the pass.
- `.venv/` present; both `router_cpp.*.so` native extensions preserved.
- A blanket `git clean -fdX` (the naive tidy) **would** have deleted `.env`, `.venv/`, both `.so`, and all board `output/` — so tidy was done by **explicit path**, never `git clean -fdX` (confirms rjwalters/repo#2).
- No `.env` / board-artifact committed; PR diff is a single one-line doc fix.
- No writes to the rjwalters/repo remote.

## Deferred (owned by sibling issues — NOT touched)
- `docs/index.md` — #4236 (merged) / #4238 (in progress)
- `docs/reference/cli.md` — #4238 (in progress)
- `tests/README.md`, `scripts/README.md` — #4237 (merged)
- `docs/` missing top-level README — #4238 territory (index.md↔README.md reconciliation)

## Deferred (report-only, valid follow-up candidates — not fixed here)
- Missing READMEs in browsable top-level dirs: `benchmarks/`, `data/`, `notebooks/`, `src/`. The `/repo:readme` skill never auto-writes a brand-new README (judgment call), so these are report-only. Candidate for a new follow-up issue (extends #4237's tests/+scripts/ work).
- `.loom/locks` empty dir — left in place (active Loom runtime infra, not clutter).

---

# Upstream funnel record — draft rjwalters/repo issues

Per-stage assessment of every `/repo:*` sub-skill invoked. The Builder has no push access to rjwalters/repo; these are ready-to-file drafts for a human.

### Stage assessments
- **audit** — worked correctly. Surfaced no false gitignore findings.
- **gitignore** — worked correctly. Correctly judged private-repo context (`isPrivate=false`... see FP-5 below) and left the intentional `.loom/*` forward-looking runtime rules alone. No rough edge.
- **links** — 3 false positives (see RE-1, RE-2). Otherwise correct.
- **readme** — worked correctly (correctly treats new-README creation as a judgment call, not an auto-fix).
- **orphans** — not exercised for deletion (report-only by design); n/a.
- **branches** — worked correctly: identified issue-4238 worktree as an active builder (loom:building) that must be protected.
- **tidy** — CRITICAL hazard reconfirmed (RE-3).
- **update-tools** — one minor rough edge (RE-4); the curator-predicted "source clone missing" did NOT occur (RE-5, a non-issue this run).
- **reset** — worked correctly: reversible steps only, kept the stash, protected active worktrees.

### RE-1 (severity: medium) — `/repo:links` flags example link syntax inside skill docs as broken links
- **Repro:** run the links checker over `.claude/commands/repo/audit.md` and `links.md`. Both contain the literal template text `[text](path)` describing link syntax.
- **Expected:** the checker recognizes `path` is illustrative (or skips the vendored skill docs themselves) and does not report it.
- **Actual:** reported `audit.md:38 -> path` and `links.md:29 -> path` as broken links.
- **Note:** these files are self-referential skill docs, so the checker is flagging its own documentation.

### RE-2 (severity: medium) — `/repo:links` does not skip fenced code blocks
- **Repro:** a markdown code fence containing Python `def specialize[T: Module](self, special: T, ...) -> T:` (in `docs/research/faebryk-component-library.md:70`).
- **Expected:** links inside ` ``` ` fenced code blocks are not link candidates and are skipped.
- **Actual:** the `[T: Module](self, ...)` fragment is parsed as a markdown link with target `self,` and reported broken.
- **Impact:** any doc with type-parameter / call syntax in code samples yields spurious findings.

### RE-3 (severity: CRITICAL — confirms rjwalters/repo#2) — `/repo:tidy` inventory + `git clean -fdX` would delete `.env`, `.venv/`, native `.so`, and build outputs
- **Repro:** in a repo with a gitignored `.env`, run `git clean -ndX` (the skill's own inventory command).
- **Expected:** gitignored **secrets** (`.env`) and expensive-to-rebuild artifacts (native `.so`) are never in the delete set; the SAFE category excludes them.
- **Actual:** `git clean -ndX` lists `Would remove .env`, `Would remove .venv/`, `Would remove src/kicad_tools/router/router_cpp.*.so`, and all `boards/*/output/`. The tidy skill's step-4 `git clean -fdX` would delete all of them. `.env` here holds live JLCPCB API creds; the `.so` files give a 10-100x router speedup and are costly to rebuild.
- **Fix suggestion:** the SAFE category must be built by an **allowlist of known-regenerable patterns** (`__pycache__`, `.pytest_cache`, `.mypy_cache`, `.ruff_cache`, `.DS_Store`) applied by explicit path — never a blanket `git clean -fdX` over everything gitignored. At minimum, hard-exclude `.env*`, `.venv/`, and `*.so`.

### RE-4 (severity: low) — `/repo:update-tools` version detection assumes a `VERSION` file
- **Repro:** `/repo:update-tools` on Repo Skills — the skill runs `git -C <source> show origin/HEAD:VERSION`.
- **Expected:** falls back to the version in `install-metadata.json` / tags cleanly.
- **Actual:** rjwalters/repo has no `VERSION` file, so `show origin/HEAD:VERSION` is empty; detection works only via the `install-metadata.json` `version` field + `gh api .../tags`. Minor: the primary version probe silently no-ops for this tool family. Suggest documenting `install-metadata.json`'s `version` as the canonical source for Repo Skills.

### RE-5 (severity: informational — non-issue this run) — predicted "source clone missing" did NOT occur
- The curator predicted `/tmp/repo-v0.4.0` might be gone after a restart (a rough edge). This run it **existed** (installed 2026-07-15, same session), so update-tools resolved the source cleanly. Noting for completeness; no defect.

### RE-6 (severity: low — Loom, not Repo Skills) — pre-existing broken link in vendored `.github/CONFIGURATION.md`
- `.github/CONFIGURATION.md:71` links `[WORKFLOWS.md](../../WORKFLOWS.md)` — resolves outside the repo and `WORKFLOWS.md` does not exist. This file is a **Loom-installed template**, so the fix belongs upstream in **rjwalters/loom**, not here (editing it locally would be overwritten by the installer). Not fixed in this PR.

---

## The one applied fix
`examples/10-complete-kct-workflow/README.md` — the "Project Specification Format" bullet pointed to `docs/spec-format.md` (never existed). Repointed to the in-file `#understanding-the-kct-file` section, which actually documents the `.kct` spec format. Confident, mechanical, non-vendored, not sibling-owned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
