### PR TITLE
fix: honor board via geometry in route-auto and expose --via-drill/--via-diameter

### DIFF
--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -82,9 +82,63 @@ def run_zones_command(args) -> int:
     return 1
 
 
+def _effective_via_geometry(
+    pcb_path: str,
+    via_drill: float | None,
+    via_diameter: float | None,
+) -> tuple[float | None, float | None]:
+    """Resolve the via drill/diameter route-auto would actually use.
+
+    An explicit CLI override wins; otherwise the value is derived from the
+    board's net-class via constraints (Issue #4247).  Returns ``(None, None)``
+    for any field that can be neither overridden nor derived (e.g. the board
+    file is unreadable during a dry-run preview).
+    """
+    eff_drill = via_drill
+    eff_diameter = via_diameter
+    if eff_drill is not None and eff_diameter is not None:
+        return eff_drill, eff_diameter
+    try:
+        from pathlib import Path
+
+        from kicad_tools.router.io import parse_pcb_design_rules
+
+        pcb_rules = parse_pcb_design_rules(Path(pcb_path).read_text())
+        if eff_drill is None:
+            eff_drill = pcb_rules.min_via_drill
+        if eff_diameter is None:
+            eff_diameter = pcb_rules.min_via_diameter
+    except Exception:
+        # Dry-run preview must never fail on a missing/unreadable board file;
+        # fall back to reporting only the explicit overrides (possibly None).
+        pass
+    return eff_drill, eff_diameter
+
+
+def _print_effective_via_geometry(
+    eff_drill: float | None,
+    override_drill: float | None,
+    eff_diameter: float | None,
+    override_diameter: float | None,
+) -> None:
+    """Print the effective via geometry for the dry-run preview (Issue #4247)."""
+
+    def _fmt(value: float | None, override: float | None) -> str:
+        if value is None:
+            return "board-derived (unavailable)"
+        source = "explicit override" if override is not None else "board-derived"
+        return f"{value:.4g}mm ({source})"
+
+    print(f"  Via drill: {_fmt(eff_drill, override_drill)}")
+    print(f"  Via diameter: {_fmt(eff_diameter, override_diameter)}")
+
+
 def run_route_auto_command(args) -> int:
     """Handle route-auto command using RoutingOrchestrator."""
     import sys
+
+    via_drill = getattr(args, "via_drill", None)
+    via_diameter = getattr(args, "via_diameter", None)
 
     # Dry-run: preview strategy selection without routing
     if args.dry_run:
@@ -92,6 +146,11 @@ def run_route_auto_command(args) -> int:
         print(f"  Strategy override: {args.strategy}")
         print(f"  Repair enabled: {not args.no_repair}")
         print(f"  Via resolution enabled: {not args.no_via_resolution}")
+        # Report the effective via geometry that would be used (Issue #4247):
+        # an explicit CLI override, or the value derived from the board's
+        # net-class via constraints.
+        eff_drill, eff_diameter = _effective_via_geometry(args.pcb, via_drill, via_diameter)
+        _print_effective_via_geometry(eff_drill, via_drill, eff_diameter, via_diameter)
         if args.output:
             print(f"  Output: {args.output}")
         return 0
@@ -111,6 +170,9 @@ def run_route_auto_command(args) -> int:
             region=getattr(args, "region", None),
             # Issue #4165: persist partial multi-pad copper only when opted in.
             allow_partial=getattr(args, "allow_partial", False),
+            # Issue #4247: explicit via-geometry overrides (None => board-derived).
+            via_drill=via_drill,
+            via_diameter=via_diameter,
         )
     except FileNotFoundError as e:
         print(f"Error: {e}", file=sys.stderr)

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -3784,6 +3784,28 @@ def _add_route_auto_parser(subparsers) -> None:
         action="store_true",
         help="Disable via conflict resolution (enabled by default)",
     )
+    route_auto_parser.add_argument(
+        "--via-drill",
+        type=float,
+        default=None,
+        metavar="MM",
+        help=(
+            "Via drill size in mm. Overrides the board-derived via drill "
+            "(Issue #4247). When omitted, route-auto derives the drill from "
+            "the board's net-class via constraints."
+        ),
+    )
+    route_auto_parser.add_argument(
+        "--via-diameter",
+        type=float,
+        default=None,
+        metavar="MM",
+        help=(
+            "Via pad diameter in mm. Overrides the board-derived via diameter "
+            "(Issue #4247). When omitted, route-auto derives the diameter from "
+            "the board's net-class via constraints."
+        ),
+    )
     route_auto_parser.add_argument("-o", "--output", help="Output PCB file path")
     route_auto_parser.add_argument(
         "--dry-run",

--- a/src/kicad_tools/mcp/tools/routing.py
+++ b/src/kicad_tools/mcp/tools/routing.py
@@ -471,6 +471,8 @@ def route_net_auto(
     enable_via_resolution: bool = True,
     region: str | tuple[float, float, float, float] | None = None,
     allow_partial: bool = False,
+    via_drill: float | None = None,
+    via_diameter: float | None = None,
 ) -> dict:
     """Route a specific net using the RoutingOrchestrator.
 
@@ -522,6 +524,13 @@ def route_net_auto(
                 outside fails with a clear message (bare-stub reconnection is
                 deferred to Phase 2b).  Any produced segment/via that escapes
                 the box fails the route rather than writing out-of-region copper.
+        via_drill: Optional via drill override in mm (Issue #4247).  When given,
+                overrides the via drill derived from the board's net-class via
+                constraints.  When None, the board-derived value is used.
+        via_diameter: Optional via pad diameter override in mm (Issue #4247).
+                When given, overrides the via diameter derived from the board's
+                net-class via constraints.  When None, the board-derived value
+                is used.
 
     Returns:
         Dictionary with routing result including:
@@ -657,6 +666,14 @@ def route_net_auto(
     pcb_text = path.read_text()
     pcb_rules = parse_pcb_design_rules(pcb_text)
     design_rules = pcb_rules.to_design_rules()
+
+    # Apply explicit via-geometry overrides (Issue #4247).  Only the fields the
+    # caller explicitly passes are overridden; the rest still derive from the
+    # board's net-class via constraints.
+    if via_drill is not None:
+        design_rules.via_drill = via_drill
+    if via_diameter is not None:
+        design_rules.via_diameter = via_diameter
 
     # Build a lightweight PCB-like object for the orchestrator
     # The orchestrator needs pcb.width, pcb.height, and optionally pcb.grid

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -392,12 +392,21 @@ def parse_pcb_design_rules(pcb_text: str) -> PCBDesignRules:
                     rules.min_track_width = trace_width
                     found_track_width = True
 
+        # Via geometry aggregation uses max(), NOT min() (Issue #4247).
+        # For clearance/trace_width (above) "tightest wins" is conservative:
+        # a smaller value is never a DRC violation.  For via geometry the
+        # opposite is true — a via SMALLER than a net class's stated minimum
+        # is a DRC violation, so taking the global min across net classes
+        # would let a single small-via class (e.g. an unused fine-pitch or
+        # differential-pair class) poison the derived via size for every net.
+        # Taking the max() guarantees the derived default is never smaller
+        # than any net class's stated minimum.
         via_dia_match = re.search(r"\(via_dia\s+([\d.]+)\)", nc_block)
         if via_dia_match:
             via_dia = float(via_dia_match.group(1))
             if via_dia > 0:
                 if found_via_diameter:
-                    rules.min_via_diameter = min(rules.min_via_diameter, via_dia)
+                    rules.min_via_diameter = max(rules.min_via_diameter, via_dia)
                 else:
                     rules.min_via_diameter = via_dia
                     found_via_diameter = True
@@ -407,7 +416,7 @@ def parse_pcb_design_rules(pcb_text: str) -> PCBDesignRules:
             via_drill = float(via_drill_match.group(1))
             if via_drill > 0:
                 if found_via_drill:
-                    rules.min_via_drill = min(rules.min_via_drill, via_drill)
+                    rules.min_via_drill = max(rules.min_via_drill, via_drill)
                 else:
                     rules.min_via_drill = via_drill
                     found_via_drill = True

--- a/tests/test_mcp_routing.py
+++ b/tests/test_mcp_routing.py
@@ -770,6 +770,185 @@ class TestRouteAutoCommandErrorHandling:
 
 
 # ---------------------------------------------------------------------------
+# Tests: route_net_auto via-geometry override + board-derived aggregation (#4247)
+# ---------------------------------------------------------------------------
+
+
+def _two_pad_pcb_text(extra_net_classes: str = "") -> str:
+    """A minimal 2-pad net PCB that reaches the RoutingOrchestrator.
+
+    ``extra_net_classes`` is injected verbatim so a test can add net-class
+    blocks that drive ``parse_pcb_design_rules`` via-geometry aggregation.
+    """
+    return f"""\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+{extra_net_classes}
+  (net 0 "")
+  (net 1 "NET1")
+  (gr_line (start 0 0) (end 50 0) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (gr_line (start 50 0) (end 50 40) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (gr_line (start 50 40) (end 0 40) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (gr_line (start 0 40) (end 0 0) (layer "Edge.Cuts") (stroke (width 0.1)))
+  (footprint "R_0603"
+    (layer "F.Cu")
+    (at 10 10)
+    (attr smd)
+    (property "Reference" "R1")
+    (property "Value" "10k")
+    (pad "1" smd rect (at 0 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "NET1"))
+  )
+  (footprint "R_0603"
+    (layer "F.Cu")
+    (at 30 10)
+    (attr smd)
+    (property "Reference" "R2")
+    (property "Value" "10k")
+    (pad "1" smd rect (at 0 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "NET1"))
+  )
+)
+"""
+
+
+class _FakeVia:
+    """Stand-in orchestrator via carrying the design-rule via geometry."""
+
+    def __init__(self, x: float, y: float, diameter: float, drill: float) -> None:
+        self.x = x
+        self.y = y
+        self.diameter = diameter
+        self.drill = drill
+        self.layers = None  # persist path falls back to ("F.Cu", "B.Cu")
+
+
+class _FakeResult:
+    """Minimal RoutingResult stand-in that emits a single via from the rules."""
+
+    def __init__(self, diameter: float, drill: float) -> None:
+        self.success = True
+        self.partial = False
+        self.strategy_used = "global"
+        self.segments: list = []
+        self.vias = [_FakeVia(20.0, 10.0, diameter, drill)]
+
+    def to_dict(self) -> dict:
+        return {
+            "success": True,
+            "strategy_used": self.strategy_used,
+            "metrics": {"via_count": 1},
+            "repair_actions": [],
+            "warnings": [],
+            "performance": {},
+        }
+
+
+def _install_capturing_orchestrator(monkeypatch):
+    """Patch RoutingOrchestrator to record the rules it receives.
+
+    The fake emits one via whose geometry mirrors the (possibly overridden)
+    ``rules`` so we can verify both the plumbing and that the geometry lands
+    on the persisted via.
+    """
+    captured: dict = {}
+
+    class _FakeOrchestrator:
+        max_strategy_retries = 3
+
+        def __init__(self, pcb, rules, **kwargs):
+            captured["rules"] = rules
+            self._select_strategy = None
+
+        def route_net(self, net, pads):
+            return _FakeResult(captured["rules"].via_diameter, captured["rules"].via_drill)
+
+    import kicad_tools.router.orchestrator as orch_mod
+
+    monkeypatch.setattr(orch_mod, "RoutingOrchestrator", _FakeOrchestrator)
+    return captured
+
+
+class TestRouteNetAutoViaOverride:
+    """route_net_auto via-drill/diameter override + max()-aggregation (#4247)."""
+
+    def test_explicit_override_reaches_orchestrator_and_via(self, tmp_path, monkeypatch):
+        """Explicit via_drill/via_diameter override board-derived geometry."""
+        from kicad_tools.mcp.tools.routing import route_net_auto
+
+        captured = _install_capturing_orchestrator(monkeypatch)
+
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(_two_pad_pcb_text())
+        out_file = tmp_path / "out.kicad_pcb"
+
+        result = route_net_auto(
+            pcb_path=str(pcb_file),
+            net_name="NET1",
+            output_path=str(out_file),
+            via_drill=0.4,
+            via_diameter=0.8,
+        )
+
+        # Plumbing: the override reached the DesignRules handed to the orchestrator.
+        assert captured["rules"].via_drill == 0.4
+        assert captured["rules"].via_diameter == 0.8
+
+        # Landed on a persisted via.
+        assert result["success"] is True
+        assert result.get("vias_written", 0) == 1
+        saved = out_file.read_text()
+        assert "(size 0.8)" in saved
+        assert "(drill 0.4)" in saved
+
+    def test_partial_override_only_touches_given_field(self, tmp_path, monkeypatch):
+        """Passing only via_drill leaves the diameter board-derived."""
+        from kicad_tools.mcp.tools.routing import route_net_auto
+
+        captured = _install_capturing_orchestrator(monkeypatch)
+
+        # Board Default net class => via_dia 0.6 / via_drill 0.3.
+        nc = '  (net_class "Default" (via_dia 0.6) (via_drill 0.3))\n'
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(_two_pad_pcb_text(extra_net_classes=nc))
+
+        route_net_auto(
+            pcb_path=str(pcb_file),
+            net_name="NET1",
+            via_drill=0.35,  # only drill overridden
+        )
+
+        assert captured["rules"].via_drill == 0.35
+        # Diameter still derives from the board's Default net class.
+        assert captured["rules"].via_diameter == 0.6
+
+    def test_board_derived_via_uses_max_aggregation(self, tmp_path, monkeypatch):
+        """With no override, a small-via class does not shrink the derived via (#4247)."""
+        from kicad_tools.mcp.tools.routing import route_net_auto
+
+        captured = _install_capturing_orchestrator(monkeypatch)
+
+        nc = (
+            '  (net_class "Default" (via_dia 0.6) (via_drill 0.3))\n'
+            '  (net_class "Micro" (via_dia 0.45) (via_drill 0.2))\n'
+        )
+        pcb_file = tmp_path / "board.kicad_pcb"
+        pcb_file.write_text(_two_pad_pcb_text(extra_net_classes=nc))
+
+        route_net_auto(pcb_path=str(pcb_file), net_name="NET1")
+
+        # max() aggregation: the larger (spec-compliant) geometry wins, not the
+        # 0.45/0.20 that reproduced the original board-wide DRC violation.
+        assert captured["rules"].via_diameter == 0.6
+        assert captured["rules"].via_drill == 0.3
+
+
+# ---------------------------------------------------------------------------
 # Tests: _build_pads_for_net forward-rotation sign convention (issue #2788)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_route_auto_via_flags_cli_4247.py
+++ b/tests/test_route_auto_via_flags_cli_4247.py
@@ -1,0 +1,130 @@
+"""CLI-surface tests for route-auto via-geometry flags (Issue #4247).
+
+``kct route-auto`` must expose ``--via-drill``/``--via-diameter`` (parity with
+``kct route``) and forward them into ``route_net_auto``.  Absent the flags, the
+values default to ``None`` so route-auto keeps deriving via geometry from the
+board's net-class via constraints instead of a hardcoded constant.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from kicad_tools.cli.commands.routing import run_route_auto_command
+from kicad_tools.cli.parser import create_parser
+
+
+def _args(**overrides):
+    base = {
+        "pcb": "/tmp/does-not-matter.kicad_pcb",
+        "net": "NET1",
+        "output": None,
+        "strategy": "auto",
+        "no_repair": False,
+        "no_via_resolution": False,
+        "dry_run": False,
+        "region": None,
+        "allow_partial": False,
+        "via_drill": None,
+        "via_diameter": None,
+        "verbose": False,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+# --- Parser surface --------------------------------------------------------
+
+
+def test_parser_accepts_via_flags():
+    parser = create_parser()
+    args = parser.parse_args(
+        [
+            "route-auto",
+            "board.kicad_pcb",
+            "--net",
+            "GND",
+            "--via-drill",
+            "0.3",
+            "--via-diameter",
+            "0.6",
+        ]
+    )
+    assert args.via_drill == 0.3
+    assert args.via_diameter == 0.6
+
+
+def test_parser_via_flags_default_none():
+    """Unset flags default to None so the board-derived value is not overridden."""
+    parser = create_parser()
+    args = parser.parse_args(["route-auto", "board.kicad_pcb", "--net", "GND"])
+    assert args.via_drill is None
+    assert args.via_diameter is None
+
+
+# --- Forwarding into route_net_auto ---------------------------------------
+
+
+def test_flags_forwarded_to_route_net_auto():
+    success = {
+        "success": True,
+        "net_name": "NET1",
+        "strategy_used": "global",
+        "metrics": {},
+        "warnings": [],
+    }
+    with patch("kicad_tools.mcp.tools.routing.route_net_auto", return_value=success) as mock_route:
+        rc = run_route_auto_command(_args(via_drill=0.3, via_diameter=0.6))
+
+    assert rc == 0
+    _, kwargs = mock_route.call_args
+    assert kwargs["via_drill"] == 0.3
+    assert kwargs["via_diameter"] == 0.6
+
+
+def test_omitting_flags_forwards_none():
+    """No via flags => None passed through, preserving board-derived defaults."""
+    success = {
+        "success": True,
+        "net_name": "NET1",
+        "strategy_used": "global",
+        "metrics": {},
+        "warnings": [],
+    }
+    with patch("kicad_tools.mcp.tools.routing.route_net_auto", return_value=success) as mock_route:
+        rc = run_route_auto_command(_args())
+
+    assert rc == 0
+    _, kwargs = mock_route.call_args
+    assert kwargs["via_drill"] is None
+    assert kwargs["via_diameter"] is None
+
+
+# --- Dry-run reporting -----------------------------------------------------
+
+
+def test_dry_run_reports_explicit_override(capsys):
+    rc = run_route_auto_command(_args(dry_run=True, via_drill=0.3, via_diameter=0.6))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Via drill: 0.3mm (explicit override)" in out
+    assert "Via diameter: 0.6mm (explicit override)" in out
+
+
+def test_dry_run_reports_board_derived_default(tmp_path, capsys):
+    """Without overrides, dry-run reports the board-derived via geometry."""
+    pcb_file = tmp_path / "board.kicad_pcb"
+    pcb_file.write_text(
+        """(kicad_pcb
+  (version 20240108)
+  (net_class "Default" (via_dia 0.6) (via_drill 0.3))
+  (net_class "Micro" (via_dia 0.45) (via_drill 0.2))
+)"""
+    )
+    rc = run_route_auto_command(_args(pcb=str(pcb_file), dry_run=True))
+    assert rc == 0
+    out = capsys.readouterr().out
+    # max()-aggregated board default (0.6/0.3), not the smaller Micro class.
+    assert "Via drill: 0.3mm (board-derived)" in out
+    assert "Via diameter: 0.6mm (board-derived)" in out

--- a/tests/test_router_io.py
+++ b/tests/test_router_io.py
@@ -746,6 +746,54 @@ class TestParsePcbDesignRules:
         assert rules.min_clearance == 0.1
         assert rules.min_track_width == 0.15
 
+    def test_uses_maximum_via_geometry_across_net_classes(self):
+        """Via geometry aggregates with max(), not min() (Issue #4247).
+
+        A smaller-via net class must NOT poison the derived via size for the
+        whole board.  Regression test for route-auto emitting sub-spec vias.
+        """
+        pcb_text = """(kicad_pcb
+  (version 20240108)
+  (net_class "Default"
+    (clearance 0.2)
+    (trace_width 0.25)
+    (via_dia 0.6)
+    (via_drill 0.3)
+  )
+  (net_class "Micro"
+    (clearance 0.1)
+    (trace_width 0.1)
+    (via_dia 0.45)
+    (via_drill 0.2)
+    (add_net "SOME_UNRELATED_NET")
+  )
+)"""
+        rules = parse_pcb_design_rules(pcb_text)
+
+        # Via geometry must take the LARGER (safe) value so no net is
+        # under-sized below any class's stated minimum.
+        assert rules.min_via_diameter == 0.6
+        assert rules.min_via_drill == 0.3
+
+        # Clearance/track width still aggregate with min() (unchanged policy).
+        assert rules.min_clearance == 0.1
+        assert rules.min_track_width == 0.1
+
+    def test_via_geometry_max_independent_of_net_class_order(self):
+        """max() via aggregation is order-independent (Issue #4247)."""
+        smaller_first = """(kicad_pcb
+  (net_class "Micro" (via_dia 0.45) (via_drill 0.2))
+  (net_class "Default" (via_dia 0.6) (via_drill 0.3))
+)"""
+        larger_first = """(kicad_pcb
+  (net_class "Default" (via_dia 0.6) (via_drill 0.3))
+  (net_class "Micro" (via_dia 0.45) (via_drill 0.2))
+)"""
+        for pcb_text in (smaller_first, larger_first):
+            rules = parse_pcb_design_rules(pcb_text)
+            assert rules.min_via_diameter == 0.6
+            assert rules.min_via_drill == 0.3
+
     def test_to_design_rules_conversion(self):
         """Test converting PCBDesignRules to DesignRules."""
         pcb_rules = PCBDesignRules(


### PR DESCRIPTION
## Summary

`kct route-auto` emitted vias at 0.45mm dia / 0.20mm drill — below both the board DRU (0.6/0.3) and board-setup minimums — so every via-bearing net failed DRC on via geometry alone (Issue #4247, found on softstart rev-C's 51 via nets).

Two verified gaps combined to produce this:

1. **Latent aggregation bug (root cause).** `parse_pcb_design_rules()` aggregated net-class `via_dia`/`via_drill` across *every* net class using `min()`. A single smaller-via class anywhere in the file (fine-pitch, diff-pair, or unused leftover) poisoned the derived via size for every net — reproducing the exact 0.45/0.20 numbers. For via geometry `min()` is backwards: a via *smaller* than a class's stated minimum is a DRC violation, not a conservative choice.
2. **No CLI lever.** `route-auto` exposed neither `--via-drill` nor `--via-diameter` (only `route` did), and `route_net_auto()` had no params to receive them.

Building a `.kicad_dru` reader is explicitly out of scope — the `max()` aggregation fix resolves the numeric defect because `.kicad_pcb` net-class via minimums mirror the DRU.

## Changes

- **`router/io.py`**: aggregate net-class `via_dia`/`via_drill` with `max()` instead of `min()`, so the derived default is never smaller than any class's stated minimum. Clearance/`trace_width` keep `min()` (intentional, conservative, independently tested).
- **`cli/parser.py`**: add `--via-drill`/`--via-diameter` to `_add_route_auto_parser()`, defaulting to `None` so the board-derived value wins unless the user explicitly overrides.
- **`mcp/tools/routing.py`**: `route_net_auto()` gains `via_drill`/`via_diameter` params, applied as overrides on the `DesignRules` derived at the `parse_pcb_design_rules(...).to_design_rules()` site.
- **`cli/commands/routing.py`**: thread the flags through `run_route_auto_command()` and report the effective via geometry (explicit override vs board-derived) in `--dry-run` output.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| route-auto accepts `--via-drill`/`--via-diameter`, default None | ✅ | `test_parser_accepts_via_flags`, `test_parser_via_flags_default_none` |
| Flags threaded through into `route_net_auto()` as overrides | ✅ | `test_flags_forwarded_to_route_net_auto`, `test_explicit_override_reaches_orchestrator_and_via` |
| `--dry-run` reports effective via drill/diameter | ✅ | `test_dry_run_reports_explicit_override`, `test_dry_run_reports_board_derived_default` |
| `min()`→`max()` for via geometry only; clearance/width unchanged | ✅ | `test_uses_maximum_via_geometry_across_net_classes`; `test_uses_minimum_from_multiple_net_classes` still green |
| test_router_io covers max() via + unchanged clearance/width | ✅ | new `TestParsePcbDesignRules` cases |
| test_mcp_routing covers override + landing on routed vias | ✅ | `TestRouteNetAutoViaOverride` (override reaches orchestrator + persisted via geometry) |
| CLI-level test for new flags + no regression when omitted | ✅ | `tests/test_route_auto_via_flags_cli_4247.py` |
| Multi-net-class fixture: no via under-sizing without flags | ✅ | `test_board_derived_via_uses_max_aggregation` |
| ruff check + format pass | ✅ | see Test Plan |

## Test Plan

- New/updated tests: `tests/test_router_io.py` (max() via aggregation, order-independence, clearance/width still min()), `tests/test_mcp_routing.py::TestRouteNetAutoViaOverride` (explicit override reaches orchestrator + lands on persisted via; partial override; board-derived max()), `tests/test_route_auto_via_flags_cli_4247.py` (parser + forwarding + dry-run).
- `uv run pytest tests/test_router_io.py tests/test_mcp_routing.py tests/test_route_auto_partial_cli_4165.py tests/test_route_auto_via_flags_cli_4247.py` → 237 passed (C++ router backend built via `kct build-native`; without it, an unrelated pre-existing fixture-routing test flips to full-route).
- `uv run ruff check .` and `uv run ruff format . --check` pass.
- `uv run mypy src/` reports 11 errors, all pre-existing in unrelated code (verified identical count with changes stashed); this PR adds zero new mypy errors.

Closes #4247