### PR TITLE
fix: allow underscore-prefixed provenance keys in net-class-map sidecar

### DIFF
--- a/src/kicad_tools/router/rules.py
+++ b/src/kicad_tools/router/rules.py
@@ -1460,18 +1460,30 @@ def net_class_map_from_dict(
     Round-trip companion to :func:`net_class_map_to_dict`.  Each entry
     is deserialized via :meth:`NetClassRouting.from_dict`.
 
+    Top-level keys whose name starts with an underscore (``_``) are
+    reserved for in-band documentation/provenance and are skipped: they
+    are never turned into routed nets.  This lets a hand-authored sidecar
+    self-document without a sibling README, e.g. a ``_comment`` string or
+    a ``_meta`` dict block (issue #4248).  Because KiCad net names do not
+    start with ``_`` in practice, this cannot shadow a real net entry.
+
     Args:
         data: Mapping of ``net_name -> NetClassRouting-dict``.  Must be a
-            dict-of-dicts.
+            dict; non-``_``-prefixed values must each be a dict.  Any
+            ``_``-prefixed key is ignored regardless of its value type.
 
     Raises:
-        ValueError: If any entry is malformed (missing 'name' field).
-        TypeError: If ``data`` is not a dict-of-dicts.
+        ValueError: If any (non-``_``-prefixed) entry is malformed
+            (missing 'name' field).
+        TypeError: If ``data`` is not a dict, or if a non-``_``-prefixed
+            entry is not a dict.
     """
     if not isinstance(data, dict):
         raise TypeError(f"net_class_map_from_dict expects a dict, got {type(data).__name__}")
     result: dict[str, NetClassRouting] = {}
     for net_name, entry in data.items():
+        if isinstance(net_name, str) and net_name.startswith("_"):
+            continue  # reserved for in-band documentation (_comment, _meta, ...)
         if not isinstance(entry, dict):
             raise TypeError(
                 f"net_class_map entry for {net_name!r} must be a dict, got {type(entry).__name__}"

--- a/tests/test_net_class_serialization.py
+++ b/tests/test_net_class_serialization.py
@@ -343,3 +343,31 @@ class TestNetClassMapHelpers:
     def test_from_dict_rejects_missing_name(self):
         with pytest.raises(ValueError, match="requires a 'name' field"):
             net_class_map_from_dict({"USB_D+": {"priority": 1}})
+
+    def test_from_dict_skips_underscore_comment_key(self):
+        """A ``_comment`` string key is in-band documentation, not a net (#4248)."""
+        m = create_net_class_map(power_nets=["GND"])
+        wire = net_class_map_to_dict(m)
+        wire["_comment"] = "rev-C board, 2026-07"
+        result = net_class_map_from_dict(wire)
+        # The comment key is excluded; the real net survives unchanged.
+        assert "_comment" not in result
+        assert set(result) == {"GND"}
+        assert result == m
+
+    def test_from_dict_skips_underscore_meta_dict(self):
+        """A ``_meta`` dict block is in-band provenance, not a net (#4248)."""
+        m = create_net_class_map(power_nets=["GND"])
+        wire = net_class_map_to_dict(m)
+        wire["_meta"] = {"board": "rev-C", "date": "2026-07-15"}
+        result = net_class_map_from_dict(wire)
+        # The _meta dict is skipped even though it *is* a dict.
+        assert "_meta" not in result
+        assert set(result) == {"GND"}
+        assert result == m
+
+    def test_from_dict_skips_underscore_key_regardless_of_value_type(self):
+        """Any ``_``-prefixed key is ignored uniformly (str, list, None, dict)."""
+        for reserved_value in ("a string", ["a", "list"], None, {"nested": 1}):
+            result = net_class_map_from_dict({"_reserved": reserved_value})
+            assert result == {}


### PR DESCRIPTION
## Summary

A `--net-class-map` JSON sidecar previously rejected any top-level key whose value was not a net→dict entry, so a hand-authored file could not carry an in-band comment or provenance block (`Error: invalid net-class-map structure: net_class_map entry for '_comment' must be a dict, got str`). This adds the underscore-prefix convention: top-level keys starting with `_` are treated as in-band documentation and skipped, so `_comment` (string) and `_meta` (dict) can live next to real net entries.

## Changes

- `src/kicad_tools/router/rules.py` — `net_class_map_from_dict()` now skips any top-level key whose name starts with `_` **before** the `isinstance(entry, dict)` check. Reserved keys are excluded from the returned `dict[str, NetClassRouting]` and never become routed nets. Docstring updated to document the convention. Non-`_`-prefixed keys with non-dict values are still rejected.
- `tests/test_net_class_serialization.py` — added cases for a `_comment` string, a `_meta` dict, and a uniform "any value type is ignored" check for `_`-prefixed keys.

No CLI changes: both `kct check --net-class-map` and `kct route --net-class-map` funnel through `net_class_map_from_dict`, so the single-function fix covers both.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `_comment` string key parses without exception | ✅ | `test_from_dict_skips_underscore_comment_key` |
| `_meta` dict key parses without exception | ✅ | `test_from_dict_skips_underscore_meta_dict` |
| `_`-prefixed keys excluded from result (not routed) | ✅ | Both new tests assert `set(result) == {"GND"}` |
| Existing net entries parsed exactly as before | ✅ | `result == m` in new tests; existing roundtrip tests still pass |
| `test_from_dict_rejects_non_dict_entry` still raises | ✅ | Non-`_` key skip is scoped to the literal prefix; test passes |
| `_`-prefixed key ignored regardless of value type | ✅ | `test_from_dict_skips_underscore_key_regardless_of_value_type` (str/list/None/dict) |

## Test Plan

- `uv run pytest tests/test_net_class_serialization.py` — 24 passed.
- `uv run ruff check .` — clean (pre-existing unrelated MFR001 noqa warning only).
- `uv run ruff format . --check` — all files formatted.
- `uv run mypy src/kicad_tools/router/rules.py` — no issues.

Closes #4248