### PR TITLE
board-07 [Track A / A2]: coupled diff-pair atomic rip-up/relief transaction

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -10967,7 +10967,9 @@ class Autorouter:
         # Issue #4255: rip the diff-pair partner alongside it (when folded in
         # above) so the probe explores the freed corridor with the partner's
         # copper absent -- otherwise the partner re-boxes the failed leg.
-        clean_slate_nets = [n for n in (failed_net, pair_partner) if original_routes.get(n)]
+        clean_slate_nets = [
+            n for n in (failed_net, pair_partner) if n is not None and original_routes.get(n)
+        ]
         if clean_slate_nets:
             neg_router.rip_up_nets(clean_slate_nets, net_routes, self.routes)
 

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -10917,6 +10917,34 @@ class Autorouter:
         ripped: list[int] = []
         failed_name = self.net_names.get(failed_net, f"Net_{failed_net}")
 
+        # Issue #4255 (Track A / A2): a diff pair is an ATOMIC unit.  When the
+        # failing net belongs to a diff pair whose partner is ALREADY routed,
+        # fold the partner into this transaction so a committed
+        # "P-routed / N-stranded" state becomes structurally unrepresentable
+        # -- the N-1 corridor-contention trade the classifier reports for
+        # TMDS_D0_N / TMDS_D1_N.  Three additive effects, all reusing the
+        # existing snapshot / rip / re-land machinery:
+        #   * snapshot_nets + original_routes cover the partner, so the
+        #     verbatim rollback restores the partner's exact Route objects too;
+        #   * the partner is ripped alongside the failed net at the clean-slate
+        #     below, so the probe explores the corridor with the partner
+        #     absent (otherwise the partner's own copper re-boxes the failed
+        #     leg -- the whole point of the fix);
+        #   * the partner joins ``ripped``, making it a MANDATORY member of the
+        #     commit gate -- the transaction commits only if BOTH legs re-land,
+        #     else it rolls back all copper verbatim.
+        # No-op when the net has no diff-pair partner (partner is None) OR the
+        # partner is not yet routed: snapshot_nets stays {failed_net}, ``ripped``
+        # is untouched, and every downstream loop is byte-identical to today
+        # (protects the per-net byte-lane identity / reservation-count tests).
+        pair_partner: int | None = self._diff_pair_partner_net(failed_net)
+        if pair_partner is not None and net_routes.get(pair_partner):
+            snapshot_nets.add(pair_partner)
+            original_routes[pair_partner] = list(net_routes.get(pair_partner, []))
+            ripped.append(pair_partner)
+        else:
+            pair_partner = None
+
         def _rollback() -> None:
             for net in snapshot_nets:
                 for route in list(net_routes.get(net, [])):
@@ -10936,8 +10964,12 @@ class Autorouter:
 
         # Clear any stale partial copper the failed net is holding so the
         # probe starts from a clean slate (mirrors targeted_ripup #3470).
-        if original_routes.get(failed_net):
-            neg_router.rip_up_nets([failed_net], net_routes, self.routes)
+        # Issue #4255: rip the diff-pair partner alongside it (when folded in
+        # above) so the probe explores the freed corridor with the partner's
+        # copper absent -- otherwise the partner re-boxes the failed leg.
+        clean_slate_nets = [n for n in (failed_net, pair_partner) if original_routes.get(n)]
+        if clean_slate_nets:
+            neg_router.rip_up_nets(clean_slate_nets, net_routes, self.routes)
 
         # Probes that succeed do so in well under a second (the relief
         # graph always has SOME path unless foreign pad metal seals the

--- a/tests/router/test_relief_rescue.py
+++ b/tests/router/test_relief_rescue.py
@@ -42,6 +42,7 @@ from unittest.mock import patch
 
 import pytest
 
+from kicad_tools.router.algorithms.negotiated import NegotiatedRouter
 from kicad_tools.router.core import Autorouter
 from kicad_tools.router.layers import Layer
 from kicad_tools.router.pathfinder import Router
@@ -461,3 +462,250 @@ class TestCppReliefBindings:
         grid.decrement_usage(5, 5, 0)
         cell = grid.at(5, 5, 0)
         assert cell.usage_count == 0
+
+
+def _make_diff_pair_router() -> Autorouter:
+    """Autorouter with one suffix-inferred diff pair on a small board.
+
+    Net 1 = ``TMDS_D0_P`` (the leg that routes cleanly in normal mode),
+    net 2 = ``TMDS_D0_N`` (the leg that hard-fails into ``_relief_rescue``).
+    Suffix-based detection resolves them as partners so
+    ``_diff_pair_partner_net(2) == 1`` without any explicit declaration.
+    """
+    router = Autorouter(width=40.0, height=20.0)
+    for name, net_id, y in (("TMDS_D0_P", 1, 4.0), ("TMDS_D0_N", 2, 8.0)):
+        pads = [
+            {
+                "number": "1",
+                "x": 5.0,
+                "y": y,
+                "width": 0.5,
+                "height": 0.5,
+                "net": net_id,
+                "net_name": name,
+            },
+            {
+                "number": "2",
+                "x": 35.0,
+                "y": y,
+                "width": 0.5,
+                "height": 0.5,
+                "net": net_id,
+                "net_name": name,
+            },
+        ]
+        router.add_component(name, pads)
+    return router
+
+
+def _seg_route(net: int, name: str, y: float) -> Route:
+    return Route(
+        net=net,
+        net_name=name,
+        segments=[
+            Segment(x1=5.0, y1=y, x2=35.0, y2=y, width=0.2, layer=Layer.F_CU, net=net),
+        ],
+    )
+
+
+class TestReliefRescueDiffPairAtomicTransaction:
+    """Issue #4255 (Track A / A2): a diff pair is an ATOMIC rescue unit.
+
+    The N-1 invariant these tests pin down: when one leg (``TMDS_D0_P``)
+    routes cleanly in the normal pass and its partner (``TMDS_D0_N``)
+    later hard-fails into ``_relief_rescue``, the rescue must commit BOTH
+    legs or NEITHER -- a committed "P-routed / N-stranded" state is
+    unrepresentable.  The fixtures deliberately model "P committed /
+    N rescues" (NOT "both legs fail together", which would pass without
+    proving the coupling).
+    """
+
+    def _fixture(self):
+        router = _make_diff_pair_router()
+        # Sanity: suffix detection resolves the pair both ways.
+        assert router._diff_pair_partner_net(2) == 1
+        assert router._diff_pair_partner_net(1) == 2
+
+        neg_router = NegotiatedRouter(
+            grid=router.grid,
+            router=router.router,
+            rules=router.rules,
+            net_class_map={},
+        )
+        # P (net 1) is COMMITTED by normal routing.
+        route_p = _seg_route(1, "TMDS_D0_P", 4.0)
+        router._mark_route(route_p)
+        router.grid.mark_route_usage(route_p)
+        router.routes.append(route_p)
+        # N (net 2) has hard-failed: no committed copper.
+        net_routes: dict[int, list[Route]] = {1: [route_p], 2: []}
+        pads_by_net = {
+            net_id: [router.pads[p] for p in pad_ids] for net_id, pad_ids in router.nets.items()
+        }
+        return router, neg_router, net_routes, pads_by_net, route_p
+
+    def test_partner_reland_failure_rolls_back_both_legs(self):
+        """P committed, N rescues, but P cannot re-land -> BOTH roll back.
+
+        This is the load-bearing fixture: N's conflict-free relief would
+        commit (the "one leg wins" state the pre-#4255 per-net rescue
+        produced), but because its partner P is now folded in as a
+        mandatory member of the commit gate and fails to re-land, the
+        whole transaction rolls back verbatim.  On pre-#4255 code this
+        rescue returned True with N committed and P untouched (both
+        routed) -- so asserting a verbatim rollback with N NOT committed
+        distinguishes the fix.
+        """
+        router, neg_router, net_routes, pads_by_net, route_p = self._fixture()
+        committed_n = _seg_route(2, "TMDS_D0_N", 8.0)
+        probe_n = _seg_route(2, "TMDS_D0_N", 8.0)
+
+        def probe_side_effect(net_id, present_factor, per_net_timeout=None):
+            # N gets a conflict-free relief; the partner P has no relief
+            # path (its 1:1-traded corridor is now held by N).
+            if net_id == 2:
+                return ([probe_n], set())
+            return ([], set())
+
+        def route_side_effect(net_id, present_cost_factor, per_net_timeout=None):
+            if net_id == 2:
+                return [committed_n]
+            return []  # P (net 1) cannot re-land
+
+        with (
+            patch.object(Autorouter, "_relief_probe", side_effect=probe_side_effect),
+            patch.object(Autorouter, "_route_net_negotiated", side_effect=route_side_effect),
+        ):
+            ok = router._relief_rescue(
+                failed_net=2,
+                neg_router=neg_router,
+                net_routes=net_routes,
+                pads_by_net=pads_by_net,
+                present_factor=1.0,
+                per_net_timeout=2.0,
+                flush_print_fn=lambda *_: None,
+                elapsed_fn=lambda: "0s",
+            )
+
+        assert ok is False, "one-leg-wins must be rejected -> rescue fails"
+        # Both legs restored verbatim.
+        assert net_routes[1] == [route_p], "partner P must be restored to its exact Route"
+        assert route_p in router.routes
+        assert net_routes[2] == [], "failed leg N must NOT be committed (never one leg)"
+        assert committed_n not in router.routes, "N's copper must be rolled back"
+
+    def test_partner_relands_commits_both_legs(self):
+        """P committed, N rescues, P re-lands -> BOTH commit atomically."""
+        router, neg_router, net_routes, pads_by_net, route_p = self._fixture()
+        committed_n = _seg_route(2, "TMDS_D0_N", 8.0)
+        probe_n = _seg_route(2, "TMDS_D0_N", 8.0)
+        route_p_new = _seg_route(1, "TMDS_D0_P", 5.0)
+
+        route_calls: list[int] = []
+
+        def probe_side_effect(net_id, present_factor, per_net_timeout=None):
+            if net_id == 2:
+                return ([probe_n], set())
+            return ([], set())
+
+        def route_side_effect(net_id, present_cost_factor, per_net_timeout=None):
+            route_calls.append(net_id)
+            if net_id == 2:
+                return [committed_n]
+            return [route_p_new]  # P re-lands into a freed lane
+
+        with (
+            patch.object(Autorouter, "_relief_probe", side_effect=probe_side_effect),
+            patch.object(Autorouter, "_route_net_negotiated", side_effect=route_side_effect),
+        ):
+            ok = router._relief_rescue(
+                failed_net=2,
+                neg_router=neg_router,
+                net_routes=net_routes,
+                pads_by_net=pads_by_net,
+                present_factor=1.0,
+                per_net_timeout=2.0,
+                flush_print_fn=lambda *_: None,
+                elapsed_fn=lambda: "0s",
+            )
+
+        assert ok is True
+        # Partner was folded in: its re-land was attempted (proves it was
+        # ripped at clean-slate as a mandatory member, not left untouched).
+        assert 1 in route_calls, "partner P must be re-landed inside the transaction"
+        assert net_routes[2] == [committed_n], "failed leg N committed"
+        assert net_routes[1] == [route_p_new], "partner P re-routed and committed"
+        assert committed_n in router.routes
+        assert route_p_new in router.routes
+        assert route_p not in router.routes, "P's original copper was ripped and replaced"
+
+    def test_no_partner_path_is_byte_identical(self):
+        """A single-ended failing net takes the unchanged per-net path.
+
+        With no diff-pair partner the clean-slate rip must target exactly
+        ``[failed_net]`` (never a partner), ``snapshot_nets`` stays
+        single-net, and the commit proceeds as on pre-#4255 ``main``.
+        """
+        router = Autorouter(width=40.0, height=20.0)
+        pads = [
+            {
+                "number": "1",
+                "x": 5.0,
+                "y": 4.0,
+                "width": 0.5,
+                "height": 0.5,
+                "net": 1,
+                "net_name": "SINGLE_A",
+            },
+            {
+                "number": "2",
+                "x": 35.0,
+                "y": 4.0,
+                "width": 0.5,
+                "height": 0.5,
+                "net": 1,
+                "net_name": "SINGLE_A",
+            },
+        ]
+        router.add_component("SINGLE_A", pads)
+        assert router._diff_pair_partner_net(1) is None
+
+        neg_router = NegotiatedRouter(
+            grid=router.grid,
+            router=router.router,
+            rules=router.rules,
+            net_class_map={},
+        )
+        # A stale partial route so the clean-slate rip fires.
+        stale = _seg_route(1, "SINGLE_A", 4.0)
+        router._mark_route(stale)
+        router.grid.mark_route_usage(stale)
+        router.routes.append(stale)
+        net_routes: dict[int, list[Route]] = {1: [stale]}
+        pads_by_net = {
+            net_id: [router.pads[p] for p in pad_ids] for net_id, pad_ids in router.nets.items()
+        }
+        committed = _seg_route(1, "SINGLE_A", 4.0)
+
+        with (
+            patch.object(Autorouter, "_relief_probe", return_value=([committed], set())),
+            patch.object(Autorouter, "_route_net_negotiated", return_value=[committed]),
+            patch.object(neg_router, "rip_up_nets", wraps=neg_router.rip_up_nets) as rip_spy,
+        ):
+            ok = router._relief_rescue(
+                failed_net=1,
+                neg_router=neg_router,
+                net_routes=net_routes,
+                pads_by_net=pads_by_net,
+                present_factor=1.0,
+                per_net_timeout=2.0,
+                flush_print_fn=lambda *_: None,
+                elapsed_fn=lambda: "0s",
+            )
+
+        assert ok is True
+        # Clean-slate rip is byte-identical to the pre-change single-net form.
+        assert rip_spy.call_count == 1
+        assert rip_spy.call_args.args[0] == [1], "no partner may be folded into the rip"
+        assert net_routes[1] == [committed]
+        assert committed in router.routes


### PR DESCRIPTION
Closes #4255

## Summary

Board-07 Track A, deliverable **A2**. Generalizes `Autorouter._relief_rescue` (`src/kicad_tools/router/core.py`) so a diff pair is rescued as an **atomic unit**, targeting the N−1 invariant behind the two `CONGESTION_SATURATED` opens (`TMDS_D0_N`, `TMDS_D1_N`): today's per-net rescue lets a sibling re-colonize a freed corridor before the boxed net re-lands, so "P routed / N stranded" is a representable committed state.

The change is **additive**, reusing the existing transactional snapshot/rip/rollback machinery and the existing partner primitive `_diff_pair_partner_net` (no new diff-pair detection). When the failing net has a diff-pair partner that is **already routed**:

- the partner is added to `snapshot_nets` + `original_routes`, so the verbatim no-net-loss rollback restores the partner's exact `Route` objects too;
- the partner is ripped alongside the failed net at the clean-slate, so the probe explores the freed corridor with the partner's copper absent (otherwise the partner re-boxes the failed leg);
- the partner joins `ripped`, becoming a **mandatory member of the commit gate** — the transaction commits only if BOTH legs re-land, else it rolls back all copper verbatim.

This makes a committed "P-routed / N-stranded" state structurally unrepresentable.

**No-op when the net has no partner (`None`) or the partner is not yet routed:** `snapshot_nets` stays `{failed_net}`, `ripped` is untouched, and every downstream loop is byte-identical to today.

## Acceptance criteria

- [x] **Unit test — the N−1 "P committed / N hard-fails into rescue" fixture.** `TestReliefRescueDiffPairAtomicTransaction` builds a suffix-inferred diff pair where P (`TMDS_D0_P`) is committed by normal routing and N (`TMDS_D0_N`) hard-fails into `_relief_rescue`. When N's relief would strand P (P cannot re-land), the whole transaction rolls back — N is **not** committed either (both legs or neither, never one). On pre-#4255 code this rescue returned `True` with N committed and P untouched, so the assertion distinguishes the fix. A companion test covers the both-re-land → both-commit path.
- [x] **Byte-identical when no pair partner.** `test_no_partner_path_is_byte_identical`: a single-ended failing net's clean-slate rip targets exactly `[failed_net]` (never a partner) and the commit proceeds as before. The existing byte-lane identity / reservation-count tests stay green.
- [x] **Both-legs-or-neither commit.** Rollback restores the exact original `Route` objects for the whole group.
- [x] **No cross-board regression.** Full `pytest` run: the routing surface is green (`tests/router/`, board-07 match-group, diff-pair, match-group tuning, negotiated-convergence — 788 passed in the targeted routing run; all routing tests pass in the full suite). Board-07 full-board seed-42 route holds at baseline (below). The 39 pre-existing full-suite failures are unrelated to routing and reproduce identically with `core.py` reverted to base `73fe085c` (missing optional deps `[visualization]`=matplotlib / `[report]`=markdown, plus pre-existing placement / check-parity assertions) — this change introduces **zero** new failures.
- [x] **Honest board-07 seed-42 measurement (C++ backend built, deterministic budget).**

## Board-07 seed-42 measurement (honest)

`generate_design.py --step route --seed 42`, C++ backend `available (version 1.0.0)`, `--deterministic-budget`:

**Reach: 26/31. Open set: `{DQ3, DQ4, MIPI_DAT0_N, TMDS_D0_N, TMDS_D1_N}` — identical to the CI-asserted baseline open set.**

A2 **alone does not move** `TMDS_D0_N` / `TMDS_D1_N`. This is the expected "A3 required" outcome from the A1 design (#4254): A2 is the coupling **enforcement** half. The iteration logs confirm the atomic coupling engaged — e.g. `Relief rescue: TMDS_D0_P routed but only 2/3 displaced victim(s) re-landed -- rolling back (no-net-loss guarantee)` — the router now refuses to commit one TMDS leg while its partner strands, rather than banking a "one-leg-wins" partial. Closing the opens needs the HARD discrete lane allocation (A3, #4256-track) to free a simultaneously-feasible corridor; A2 without it keeps both legs coupled but still open. Reach is unchanged from baseline (no regression, no improvement) — reported to inform A4.

## Scope

Coupling **enforcement** only. Does not add the discrete lane allocator (A3). Diff kept to the atomic-transaction change + its tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)