### PR TITLE
board-07 [Track A / A3]: discrete BundlePlan allocator + HARD lane reservation (#4256)

### DIFF
--- a/src/kicad_tools/router/bundle_river.py
+++ b/src/kicad_tools/router/bundle_river.py
@@ -218,3 +218,377 @@ def via_hop_loser_nets(inversions: list[InvertedPair]) -> list[int]:
             seen.add(pair.loser_net_id)
             out.append(pair.loser_net_id)
     return out
+
+
+# ===========================================================================
+# Issue #4256 (A3, Track A / epic #4243): the discrete BundlePlan allocator.
+#
+# A2 (#4255, merged) made a diff-pair rip-up/relief transaction atomic so a
+# committed "P-routed / N-stranded" state is unrepresentable.  A3 adds the
+# multi-net half: a DISCRETE, combinatorial corridor allocator that assigns
+# simultaneously-feasible escape lanes to a whole ``CoupledGroup`` (the TMDS
+# D0/D1/D2 bundle = 6 nets) BEFORE any A* search, so greedy N-1 contention is
+# removed by construction.
+#
+# Why discrete, not joint A*: #4065 proved even the 2-net coupled joint
+# search basin-floods identically in Python and C++; a 6-net joint search is
+# exponentially worse.  The multi-net reasoning is ordered interval packing
+# over the shared escape strip + an inner-layer via-hop budget for the
+# crossing ("losing") nets, solved by exact graph colouring with
+# backtracking over the tiny (~6) member set — NOT grid A*.
+#
+# The allocator emits either a simultaneously-feasible ``BundlePlan`` (every
+# member gets a lane; no two lanes share a cell on a layer) OR an explicit
+# ``infeasible`` verdict — NEVER a silent partial.  Infeasibility is a
+# first-class output: if the committed placement over-subscribes the inner
+# via-hop budget, the honest answer is "no feasible joint assignment exists
+# at this placement," which is exactly the signal A4 needs before it chases a
+# topological impossibility.
+# ===========================================================================
+
+# Lane layer tags.  A lane lives either on the shared outer escape strip
+# (F.Cu) or on a reserved inner-layer via-hop channel (a "losing" net that
+# dips under its crossing partner).
+LANE_LAYER_OUTER = "outer"
+LANE_LAYER_INNER = "inner"
+
+
+@dataclass(frozen=True)
+class CoupledMember:
+    """One net of a ``CoupledGroup`` (a length-match / diff-pair bundle).
+
+    Attributes:
+        net_id: The net's integer id.
+        net_name: The net's name (used to match the two facing rows and to
+            break projection ties deterministically).
+        primary_projection: The member's 1-D coordinate along the primary
+            facing column's long axis (only relative order matters).
+        secondary_projection: The same net's 1-D coordinate on the mirrored
+            (secondary) facing column.  A member whose relative order flips
+            between the two columns must cross its partner (an inversion).
+        pair_partner_id: For a diff-pair member, the net id of its partner
+            leg (``None`` for a single-ended member).  The allocator carries
+            this so a plan assigns lanes to BOTH legs or NEITHER — the
+            coupling constraint that, together with A2's atomic transaction,
+            makes a committed "P-routed / N-stranded" state unrepresentable.
+    """
+
+    net_id: int
+    net_name: str
+    primary_projection: float
+    secondary_projection: float
+    pair_partner_id: int | None = None
+
+
+@dataclass(frozen=True)
+class CoupledGroup:
+    """The set of nets allocated together (e.g. TMDS D0/D1/D2 = 6 nets).
+
+    A ``CoupledGroup`` is the unit the discrete allocator reasons over: its
+    members' primary/secondary projections determine the inversion set, and
+    its diff-pair links determine the atomic coupling constraint.
+    """
+
+    group_name: str
+    members: tuple[CoupledMember, ...]
+
+    def primary_row(self) -> list[RowMember]:
+        """The primary facing column as ``RowMember`` projections."""
+        return [RowMember(m.net_id, m.net_name, m.primary_projection) for m in self.members]
+
+    def secondary_row(self) -> list[RowMember]:
+        """The mirrored (secondary) facing column as ``RowMember`` projections."""
+        return [RowMember(m.net_id, m.net_name, m.secondary_projection) for m in self.members]
+
+
+@dataclass(frozen=True)
+class EscapeLane:
+    """One member's assigned escape lane in a ``BundlePlan``.
+
+    Attributes:
+        net_id: The owning net's id.
+        net_name: The owning net's name.
+        layer: ``LANE_LAYER_OUTER`` (shared F.Cu escape strip) or
+            ``LANE_LAYER_INNER`` (a reserved inner-layer via-hop channel for
+            a crossing/losing net).
+        order_index: The lane's ordered slot WITHIN its layer (the interval
+            packing position).  Slots are unique per layer, so no two lanes
+            share a cell on the same layer — the feasibility invariant.
+        via_hop: ``True`` iff this is a losing net that dips to the inner
+            layer to pass under its crossing partner.
+        pair_partner_id: The diff-pair partner leg (``None`` if single-ended).
+    """
+
+    net_id: int
+    net_name: str
+    layer: str
+    order_index: int
+    via_hop: bool
+    pair_partner_id: int | None = None
+
+
+@dataclass(frozen=True)
+class BundlePlan:
+    """The allocator's verdict for one ``CoupledGroup``.
+
+    Either ``feasible`` (every member carries an ``EscapeLane`` and no two
+    lanes share a cell on a layer) or infeasible (``lanes`` empty, ``reason``
+    explains the over-subscription).  There is no partial state: a feasible
+    plan lanes EVERY member; an infeasible plan lanes NONE — this is the
+    "both legs or neither" guarantee at plan granularity.
+    """
+
+    group_name: str
+    feasible: bool
+    lanes: tuple[EscapeLane, ...] = ()
+    reason: str = ""
+    inner_lanes_required: int = 0
+    inner_lane_budget: int = 0
+
+    @property
+    def infeasible(self) -> bool:
+        """Convenience inverse of ``feasible``."""
+        return not self.feasible
+
+    def lane_for(self, net_id: int) -> EscapeLane | None:
+        """Return the lane assigned to ``net_id`` (``None`` if unassigned)."""
+        for lane in self.lanes:
+            if lane.net_id == net_id:
+                return lane
+        return None
+
+    def via_hop_lanes(self) -> list[EscapeLane]:
+        """The lanes that dip to the inner layer (losing nets)."""
+        return [lane for lane in self.lanes if lane.via_hop]
+
+    @classmethod
+    def infeasible_plan(
+        cls,
+        group_name: str,
+        reason: str,
+        *,
+        inner_lanes_required: int = 0,
+        inner_lane_budget: int = 0,
+    ) -> BundlePlan:
+        """Build an explicit infeasibility verdict (no lanes)."""
+        return cls(
+            group_name=group_name,
+            feasible=False,
+            lanes=(),
+            reason=reason,
+            inner_lanes_required=inner_lanes_required,
+            inner_lane_budget=inner_lane_budget,
+        )
+
+
+def _min_graph_colouring(
+    nodes: list[int],
+    edges: list[tuple[int, int]],
+) -> dict[int, int]:
+    """Exact minimum vertex colouring by backtracking (tiny N only).
+
+    Assigns each node a colour in ``0..k-1`` such that no edge joins two
+    same-coloured nodes, using the MINIMUM number of colours ``k``.  For the
+    coupled-group allocator the node set is a handful of "losing" nets and
+    the edges are their mutual crossings, so an exact backtracking search
+    (iterative deepening on ``k``) is instant and gives an HONEST inner-layer
+    lane count for the feasibility verdict — a greedy upper bound could
+    over-report and declare a feasible bundle infeasible.
+
+    ``nodes`` order is respected (callers pass a deterministic order), so the
+    colouring is reproducible.
+    """
+    if not nodes:
+        return {}
+    adj: dict[int, set[int]] = {n: set() for n in nodes}
+    for a, b in edges:
+        if a in adj and b in adj and a != b:
+            adj[a].add(b)
+            adj[b].add(a)
+
+    def _try(i: int, k: int, colouring: dict[int, int]) -> bool:
+        if i == len(nodes):
+            return True
+        node = nodes[i]
+        for colour in range(k):
+            if all(colouring.get(nb) != colour for nb in adj[node]):
+                colouring[node] = colour
+                if _try(i + 1, k, colouring):
+                    return True
+                del colouring[node]
+        return False
+
+    for k in range(1, len(nodes) + 1):
+        colouring: dict[int, int] = {}
+        if _try(0, k, colouring):
+            return colouring
+    # Unreachable (k == len(nodes) always succeeds), but keep the type total.
+    return {n: i for i, n in enumerate(nodes)}
+
+
+def allocate_bundle_plan(
+    group: CoupledGroup,
+    *,
+    inner_lane_budget: int = 1,
+) -> BundlePlan:
+    """Discretely allocate simultaneously-feasible escape lanes for a group.
+
+    This is the multi-net half of Track A (#4256): a combinatorial corridor
+    allocator that runs ONCE per coupled group (not a hot A* loop).  It
+    formulates escape-lane assignment as ordered interval packing over the
+    shared outer escape strip plus an inner-layer via-hop budget for the
+    crossing ("losing") nets, and reasons over the tiny member set exactly.
+
+    Algorithm:
+
+    1. **Clean-bus guard.**  If the two facing rows are not a clean
+       one-to-one name-matched bus (``compute_row_permutation`` is ``None``),
+       return an explicit infeasible verdict — the same #4053 non-goal
+       discipline (partial / non-matched buses belong to the shelved #3673
+       general planner, not here).
+    2. **Coupling guard.**  Every referenced diff-pair partner must be a
+       member of the group; otherwise the group cannot be allocated
+       atomically (a leg would be routed elsewhere) — infeasible.
+    3. **Planar case.**  When the inversion set is empty (a co-oriented
+       bundle), assign trivial in-order lanes on the outer strip — no via
+       hops.  This is the over-trigger guard: a planar bundle must not
+       reserve inner-layer channels.
+    4. **Reversal case.**  Each crossing pair's ``loser`` (``choose_via_hop_loser``)
+       must dip to the inner layer.  Two losing nets that ALSO cross each
+       other cannot share one inner lane, so the losers' mutual-crossing
+       graph is coloured exactly: the colour count is the number of inner
+       via-hop lanes the plan needs.  If that exceeds ``inner_lane_budget``
+       the bundle is genuinely over-subscribed at this placement →
+       **infeasible** (a first-class output, NOT a silent partial).  The
+       non-losing nets keep the outer strip in projection order (they no
+       longer cross anything, so the interval packing is trivially conflict
+       free), and each losing net takes its coloured inner lane.
+
+    Args:
+        group: The coupled group (TMDS bundle, etc.) to allocate.
+        inner_lane_budget: How many independent inner-layer via-hop channels
+            are available at this placement.  On board 07's 4-layer tier-1
+            stack the inner copper layers are PLANES, so the only alternate
+            routing surface is B.Cu → a realistic budget of ``1``.
+
+    Returns:
+        A feasible ``BundlePlan`` (every member laned, no two lanes sharing a
+        cell on a layer) or an explicit infeasible ``BundlePlan``.
+    """
+    members = list(group.members)
+    if len(members) < 2:
+        return BundlePlan.infeasible_plan(
+            group.group_name,
+            f"coupled group has {len(members)} member(s); nothing to allocate",
+        )
+
+    primary_row = group.primary_row()
+    secondary_row = group.secondary_row()
+
+    perm = compute_row_permutation(primary_row, secondary_row)
+    if perm is None:
+        return BundlePlan.infeasible_plan(
+            group.group_name,
+            "coupled group is not a clean one-to-one name-matched bus "
+            "(partial / non-matched reversals are out of scope for A3)",
+        )
+
+    ids = {m.net_id for m in members}
+    for m in members:
+        if m.pair_partner_id is not None and m.pair_partner_id not in ids:
+            return BundlePlan.infeasible_plan(
+                group.group_name,
+                f"diff-pair partner {m.pair_partner_id} of net {m.net_id} "
+                "is not a member of the coupled group; cannot allocate atomically",
+            )
+
+    # Interval-packing order on the shared strip = primary projection order.
+    primary_sorted = sorted(members, key=lambda m: (m.primary_projection, m.net_name))
+
+    inversions = compute_facing_row_inversions(primary_row, secondary_row)
+
+    if not inversions:
+        # Planar bundle: trivial in-order lanes, no inner via hops.
+        lanes = tuple(
+            EscapeLane(
+                net_id=m.net_id,
+                net_name=m.net_name,
+                layer=LANE_LAYER_OUTER,
+                order_index=i,
+                via_hop=False,
+                pair_partner_id=m.pair_partner_id,
+            )
+            for i, m in enumerate(primary_sorted)
+        )
+        return BundlePlan(
+            group_name=group.group_name,
+            feasible=True,
+            lanes=lanes,
+            inner_lanes_required=0,
+            inner_lane_budget=inner_lane_budget,
+        )
+
+    # Reversal: the loser of each crossing dips to an inner via-hop lane.
+    losers = set(via_hop_loser_nets(inversions))
+
+    # Inner-layer conflict graph: two losers that ALSO cross each other
+    # cannot share one inner lane.
+    inner_conflicts = [
+        (p.net_a_id, p.net_b_id)
+        for p in inversions
+        if p.net_a_id in losers and p.net_b_id in losers
+    ]
+    # Colour the losers in a deterministic (primary-projection) order.
+    loser_order = [m.net_id for m in primary_sorted if m.net_id in losers]
+    colouring = _min_graph_colouring(loser_order, inner_conflicts)
+    inner_lanes_required = (max(colouring.values()) + 1) if colouring else 0
+
+    if inner_lanes_required > inner_lane_budget:
+        return BundlePlan.infeasible_plan(
+            group.group_name,
+            f"{inner_lanes_required} inner via-hop lane(s) required to resolve "
+            f"{len(inner_conflicts)} mutual crossing(s) among {len(losers)} "
+            f"losing net(s), but the inner-layer via-hop budget is "
+            f"{inner_lane_budget}: no simultaneously-feasible single-strip "
+            "assignment exists at this placement",
+            inner_lanes_required=inner_lanes_required,
+            inner_lane_budget=inner_lane_budget,
+        )
+
+    # Feasible.  Non-losers hold the outer strip in projection order (they
+    # no longer cross anything); losers take their coloured inner lane.
+    partner_of = {m.net_id: m.pair_partner_id for m in members}
+    lanes_list: list[EscapeLane] = []
+    outer_index = 0
+    for m in primary_sorted:
+        if m.net_id in losers:
+            lanes_list.append(
+                EscapeLane(
+                    net_id=m.net_id,
+                    net_name=m.net_name,
+                    layer=LANE_LAYER_INNER,
+                    order_index=colouring[m.net_id],
+                    via_hop=True,
+                    pair_partner_id=partner_of.get(m.net_id),
+                )
+            )
+        else:
+            lanes_list.append(
+                EscapeLane(
+                    net_id=m.net_id,
+                    net_name=m.net_name,
+                    layer=LANE_LAYER_OUTER,
+                    order_index=outer_index,
+                    via_hop=False,
+                    pair_partner_id=partner_of.get(m.net_id),
+                )
+            )
+            outer_index += 1
+
+    return BundlePlan(
+        group_name=group.group_name,
+        feasible=True,
+        lanes=tuple(lanes_list),
+        inner_lanes_required=inner_lanes_required,
+        inner_lane_budget=inner_lane_budget,
+    )

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -969,6 +969,13 @@ class Autorouter:
         # (see ``_apply_byte_lane_inner_priority`` / ``bundle_river.py``).
         self.enable_bundle_river_planner = False
 
+        # Issue #4256 (A3, Track A): the most recent discrete ``BundlePlan``
+        # per coupled group (keyed by group name), populated by
+        # ``_reserve_bundle_plan_lanes`` when ``enable_bundle_river_planner``
+        # is set.  Exposed for A4 wiring + the board-07 feasibility
+        # measurement (feasible vs explicit "infeasible" verdict).
+        self._last_bundle_plans: dict[str, Any] = {}
+
         # Issue #4084 (Phase 1, epic #4049): monotonic feasibility
         # certificate + constructive escape ordering (Tomioka & Takahashi,
         # ASP-DAC 2006).  OFF by default, following the #4051 /
@@ -5425,6 +5432,32 @@ class Autorouter:
                         exc_info=True,
                     )
 
+                # Issue #4256 (A3): the discrete BundlePlan allocator + HARD
+                # per-member lane reservation.  Scoped TMDS-only-first: it
+                # only fires for a coupled (diff-pair-bearing) group so the
+                # single-ended DDR byte — whose C++ corridor honouring #4079
+                # measured to regress — is untouched.  Advisory: any failure
+                # degrades to the via-hop-only behaviour above.
+                try:
+                    self._reserve_bundle_plan_lanes(
+                        escape=escape,
+                        primary_ref=primary_ref,
+                        comp_pad_count=comp_pad_count,
+                        primary_net_to_pad=net_to_pad,
+                        sorted_nets=sorted_nets,
+                        vertical_row=(y_span >= x_span),
+                        cx=cx,
+                        cy=cy,
+                        grp_name=grp_name,
+                    )
+                except Exception:
+                    logger.debug(
+                        "Bundle-plan allocator failed for group %s; "
+                        "continuing without HARD per-member lanes",
+                        grp_name,
+                        exc_info=True,
+                    )
+
         # Issue #4084 (Phase 1, epic #4049): monotonic feasibility
         # certificate + constructive ordering (Tomioka & Takahashi,
         # ASP-DAC 2006).  This is the *untried lever* the three prior
@@ -5733,6 +5766,202 @@ class Autorouter:
             grp_name,
             len(inversions),
             len(losers),
+            reserved,
+        )
+        return reserved
+
+    def _build_coupled_group(
+        self,
+        *,
+        primary_ref: str,
+        comp_pad_count: dict[str, list[tuple[int, float, float]]],
+        primary_net_to_pad: dict[int, tuple[float, float]],
+        sorted_nets: list[int],
+        vertical_row: bool,
+        grp_name: str,
+    ) -> Any:
+        """Assemble a ``CoupledGroup`` from a detected byte-lane group.
+
+        Issue #4256 (A3).  Resolves the secondary facing component (same rule
+        as ``_reserve_bundle_river_via_hops``), matches each net's primary +
+        secondary projections, and links diff-pair partners by the ``_P`` /
+        ``_N`` net-name convention among the group's members (TMDS
+        ``TMDS_D0_P`` <-> ``TMDS_D0_N``).  Only nets present on BOTH facing
+        columns are included, so the result is the clean matched bus the
+        allocator requires.
+
+        Returns ``None`` when there is no secondary row, or when the group
+        carries no diff-pair partner (the TMDS-only-first scope guard: a
+        single-ended byte lane such as the DDR DQ byte is left to the
+        Python-only via-hop path and never gets HARD C++-mirrored lanes,
+        preserving #4079's measured board-07 result).
+        """
+        from .bundle_river import CoupledGroup, CoupledMember
+
+        proj_index = 1 if vertical_row else 0
+
+        secondary_candidates = {
+            ref: pads for ref, pads in comp_pad_count.items() if ref != primary_ref
+        }
+        if not secondary_candidates:
+            return None
+        secondary_ref = max(
+            secondary_candidates.keys(),
+            key=lambda r: (len(secondary_candidates[r]), -ord(r[0]) if r else 0),
+        )
+        secondary_net_to_pad: dict[int, tuple[float, float]] = {}
+        for nid, px, py in secondary_candidates[secondary_ref]:
+            if nid not in secondary_net_to_pad:
+                secondary_net_to_pad[nid] = (px, py)
+
+        # Nets present on BOTH rows (the matched bus), in primary order.
+        matched = [
+            nid for nid in sorted_nets if nid in primary_net_to_pad and nid in secondary_net_to_pad
+        ]
+        if not matched:
+            return None
+
+        # Resolve diff-pair partners by the _P/_N convention among members.
+        name_by_id = {nid: self.net_names.get(nid, str(nid)) for nid in matched}
+        id_by_name = {name: nid for nid, name in name_by_id.items()}
+
+        def _partner_id(nid: int) -> int | None:
+            name = name_by_id[nid]
+            if name.endswith("_P"):
+                cand = name[:-2] + "_N"
+            elif name.endswith("_N"):
+                cand = name[:-2] + "_P"
+            else:
+                return None
+            return id_by_name.get(cand)
+
+        members: list[Any] = []
+        has_pair = False
+        for nid in matched:
+            partner = _partner_id(nid)
+            if partner is not None:
+                has_pair = True
+            members.append(
+                CoupledMember(
+                    net_id=nid,
+                    net_name=name_by_id[nid],
+                    primary_projection=primary_net_to_pad[nid][proj_index],
+                    secondary_projection=secondary_net_to_pad[nid][proj_index],
+                    pair_partner_id=partner,
+                )
+            )
+
+        # TMDS-only-first scope guard: require at least one diff pair.
+        if not has_pair:
+            return None
+
+        return CoupledGroup(group_name=grp_name, members=tuple(members))
+
+    def _reserve_bundle_plan_lanes(
+        self,
+        *,
+        escape: Any,
+        primary_ref: str,
+        comp_pad_count: dict[str, list[tuple[int, float, float]]],
+        primary_net_to_pad: dict[int, tuple[float, float]],
+        sorted_nets: list[int],
+        vertical_row: bool,
+        cx: float,
+        cy: float,
+        grp_name: str,
+    ) -> int:
+        """Allocate a ``BundlePlan`` and reserve its per-member HARD lanes.
+
+        Issue #4256 (A3).  Builds the coupled group, runs the discrete
+        allocator (:func:`bundle_river.allocate_bundle_plan`), stores the
+        verdict on ``self._last_bundle_plans[grp_name]`` (feasible or an
+        explicit "infeasible" result — never a silent partial), and, when
+        feasible, reserves one **HARD** (foreign-net keep-out, C++-mirrored)
+        inner-layer lane per member via
+        ``escape.reserve_inner_corner_lane_corridor(soft=False,
+        mirror_to_cpp=True)``.
+
+        The HARD flip (vs the SOFT single-ended default) is the load-bearing
+        A3 change: a bundle-plan lane must be a keep-out foreign nets cannot
+        colonise (``is_reserved_excluding`` on the C++ grid), which is what
+        removes the greedy N-1 contention by construction.  The existing
+        single-ended ``reserve_inner_corner_lane_corridor`` call in the
+        detection scan stays ``soft=True, mirror_to_cpp=False`` — untouched.
+
+        Returns the number of HARD lanes reserved (0 when the group is not a
+        coupled diff-pair bundle, or the plan is infeasible).
+        """
+        from .bundle_river import allocate_bundle_plan
+
+        group = self._build_coupled_group(
+            primary_ref=primary_ref,
+            comp_pad_count=comp_pad_count,
+            primary_net_to_pad=primary_net_to_pad,
+            sorted_nets=sorted_nets,
+            vertical_row=vertical_row,
+            grp_name=grp_name,
+        )
+        if group is None:
+            return 0
+
+        # Inner via-hop budget: on board 07's 4-layer tier-1 stack the inner
+        # copper layers are PLANES, so B.Cu is the only alternate routing
+        # surface -> a realistic budget of 1.
+        plan = allocate_bundle_plan(group, inner_lane_budget=1)
+        self._last_bundle_plans[grp_name] = plan
+
+        if plan.infeasible:
+            logger.info(
+                "Bundle-plan allocator (group %s): INFEASIBLE - %s",
+                grp_name,
+                plan.reason,
+            )
+            return 0
+
+        # Feasible: reserve one HARD lane per member.  Launch outward from
+        # the primary centroid, perpendicular to the row (same convention as
+        # the single-ended inner-corner reservation).
+        reserved = 0
+        for lane in plan.lanes:
+            pad_obj = None
+            for _pkey, p in self.pads.items():
+                if p.ref == primary_ref and p.net is not None and int(p.net) == lane.net_id:
+                    pad_obj = p
+                    break
+            if pad_obj is None:
+                continue
+            px, py = primary_net_to_pad.get(lane.net_id, (pad_obj.x, pad_obj.y))
+            if vertical_row:
+                launch_dx = 1.0 if px >= cx else -1.0
+                launch_dy = 0.0
+            else:
+                launch_dx = 0.0
+                launch_dy = 1.0 if py >= cy else -1.0
+            try:
+                count = escape.reserve_inner_corner_lane_corridor(
+                    pad=pad_obj,
+                    launch_dx=launch_dx,
+                    launch_dy=launch_dy,
+                    soft=False,
+                    mirror_to_cpp=True,
+                )
+            except Exception:
+                logger.debug(
+                    "Bundle-plan HARD lane reservation failed for net %d (group %s); continuing",
+                    lane.net_id,
+                    grp_name,
+                    exc_info=True,
+                )
+                continue
+            if count > 0:
+                reserved += 1
+
+        logger.debug(
+            "Bundle-plan allocator (group %s): FEASIBLE, %d member lanes, "
+            "%d inner via-hop lane(s); reserved %d HARD lanes",
+            grp_name,
+            len(plan.lanes),
+            plan.inner_lanes_required,
             reserved,
         )
         return reserved

--- a/src/kicad_tools/router/escape.py
+++ b/src/kicad_tools/router/escape.py
@@ -1269,6 +1269,17 @@ class EscapeRouter:
         self.byte_lane_corridor_reservations: int = 0
         self.byte_lane_corridor_reserved_cells: int = 0
 
+        # Issue #4256 (A3): instrumentation for the discrete BundlePlan
+        # allocator's per-member HARD lanes.  These are the generalisation of
+        # the #2983 single-ended inner-corner corridor to one HARD
+        # (foreign-net keep-out, C++-mirrored) lane per ``CoupledGroup``
+        # member.  Tracked separately from ``byte_lane_corridor_*`` (which
+        # counts the SOFT, Python-only single-ended default) so the flag-off
+        # identity tests stay byte-identical while the new HARD path has its
+        # own asserts.
+        self.bundle_plan_corridor_reservations: int = 0
+        self.bundle_plan_corridor_reserved_cells: int = 0
+
         # Issue #3900: set by ``_escape_sop_staggered`` when it takes the
         # rescue-only-band path with the rescue cap disabled
         # (``_sop_rescue_row_cap() == 0``).  ``generate_escapes`` reads it to
@@ -2748,6 +2759,9 @@ class EscapeRouter:
         target_inner_layer: Layer | None = None,
         corridor_length: float | None = None,
         corridor_half_width: float | None = None,
+        *,
+        soft: bool = True,
+        mirror_to_cpp: bool = False,
     ) -> int:
         """Reserve an inner-layer lateral corridor for a single-ended pad.
 
@@ -2807,11 +2821,34 @@ class EscapeRouter:
                 Defaults to ``3 * (escape_clearance + 2 * trace_w)``.
             corridor_half_width: Optional override for lateral
                 half-width.  Defaults to ``escape_clearance + trace_w``.
+            soft: Issue #4256.  Keep-out STRENGTH for the reservation.
+                Defaults to ``True`` (SOFT, attractor-only) — the
+                byte-identical #2983 single-ended default, whose C++
+                honouring #4079 measured to regress board 07's reversed DDR
+                byte.  The discrete ``BundlePlan`` allocator (A3) passes
+                ``soft=False`` to make a member's lane a HARD keep-out that
+                foreign nets are fenced out of (``is_reserved_excluding``).
+            mirror_to_cpp: Issue #4256.  Whether the reservation is mirrored
+                onto the production C++ grid.  Defaults to ``False`` (the
+                #2983 single-ended default stays Python-only, per #4079).
+                The A3 bundle-plan lanes pass ``mirror_to_cpp=True`` so the
+                HARD keep-out actually fences foreign nets out on the C++
+                A* — a SOFT/unmirrored reservation cannot meet the
+                "foreign net provably excluded" acceptance bar.
 
         Returns:
             Number of grid cells reserved.  Returns 0 if the helper is
             a no-op (e.g. zero net id, layer not in stack, 2-layer
             board, zero launch vector).
+
+        Note:
+            The two defaults (``soft=True, mirror_to_cpp=False``) are
+            load-bearing: they keep the existing single-ended byte-lane call
+            site (``_apply_byte_lane_inner_priority``) byte-identical to
+            pre-#4256 ``main``.  Only the new HARD bundle-plan callers flip
+            them — #4079 measured that honouring the single-ended default on
+            C++ (hard OR soft) regresses board 07, so the default must NOT
+            change.
         """
         # Skip no-op cases up front.
         net_id = int(pad.net) if pad.net else 0
@@ -2904,10 +2941,20 @@ class EscapeRouter:
         if not cells:
             return 0
 
-        # Issue #4079: this #2983 inner-corner reservation stays Python-only
-        # (``mirror_to_cpp=False``, PR #4078's "Path B").  #4079 investigated
-        # honouring it on the C++ backend two ways and MEASURED both to
-        # regress board 07's fully-reversed DDR byte on the CI recipe
+        # Issue #4256: this method is now parameterised on ``soft`` /
+        # ``mirror_to_cpp``.  The DEFAULTS below (``soft=True,
+        # mirror_to_cpp=False``) keep the #2983 single-ended inner-corner
+        # reservation Python-only and byte-identical, for the reason #4079
+        # measured; the A3 discrete BundlePlan lanes override both to
+        # ``soft=False, mirror_to_cpp=True`` (HARD, C++-mirrored) via a
+        # DIFFERENT topology (coupled diff-pair bundle, not the reversed DDR
+        # byte), so the regression below does not apply to them.
+        #
+        # Issue #4079 (the single-ended DEFAULT rationale): keeping this
+        # reservation Python-only (``mirror_to_cpp=False``, PR #4078's
+        # "Path B").  #4079 investigated honouring it on the C++ backend two
+        # ways and MEASURED both to regress board 07's fully-reversed DDR
+        # byte on the CI recipe
         # (`generate_design.py ... --step all --seed 42`, out-of-process
         # copper-LVS re-check):
         #
@@ -2938,16 +2985,26 @@ class EscapeRouter:
             layer_idx=target_idx,
             cells=cells,
             net_ids={net_id},
-            soft=True,
-            mirror_to_cpp=False,
+            soft=soft,
+            mirror_to_cpp=mirror_to_cpp,
         )
         if count > 0:
-            self.byte_lane_corridor_reservations += 1
-            self.byte_lane_corridor_reserved_cells += count
+            # Issue #4256: the SOFT single-ended default (#2983) and the new
+            # HARD bundle-plan lanes (A3) track separate counters so the
+            # flag-off identity tests keep asserting exactly 2 on the SOFT
+            # counter while the HARD path exposes its own instrumentation.
+            if soft:
+                self.byte_lane_corridor_reservations += 1
+                self.byte_lane_corridor_reserved_cells += count
+            else:
+                self.bundle_plan_corridor_reservations += 1
+                self.bundle_plan_corridor_reserved_cells += count
             logger.debug(
-                "Byte-lane inner-corner corridor reserved: "
+                "Inner-corner lane corridor reserved (%s%s): "
                 "layer=%s cells=%d net=%d pad=%s.%s launch=(%.2f,%.2f) "
                 "length=%.2fmm half_width=%.2fmm",
+                "soft" if soft else "HARD",
+                ", C++-mirrored" if mirror_to_cpp else "",
                 target_inner_layer.name,
                 count,
                 net_id,

--- a/tests/router/test_bundle_plan_allocator.py
+++ b/tests/router/test_bundle_plan_allocator.py
@@ -1,0 +1,238 @@
+"""Unit tests for the discrete BundlePlan allocator (Issue #4256, A3).
+
+These pin the search-free combinatorial corridor allocator on small
+synthetic coupled-group fixtures — no full router or board geometry
+required — per the curated acceptance criteria:
+
+  * a **full reversal** yields either a conflict-free assignment (given a
+    generous inner via-hop budget) or an explicit **"infeasible"** verdict
+    (given a tight budget) — NEVER a silent partial;
+  * a **planar (co-oriented)** bundle yields trivial in-order lanes with no
+    via hops (the over-trigger guard);
+  * infeasibility is a **first-class** output (an explicit ``BundlePlan``
+    with ``feasible=False`` and a reason, empty lanes);
+  * the diff-pair coupling constraint is enforced (both legs laned or the
+    whole plan is infeasible — never one leg dropped).
+
+Fixture convention mirrors ``test_bundle_river_inversions.py``: names sort
+in the same order as primary projections; a reversed secondary places
+name[i] at the mirrored projection.
+"""
+
+from __future__ import annotations
+
+from kicad_tools.router.bundle_river import (
+    LANE_LAYER_INNER,
+    LANE_LAYER_OUTER,
+    BundlePlan,
+    CoupledGroup,
+    CoupledMember,
+    allocate_bundle_plan,
+)
+
+
+def _tmds_names() -> list[str]:
+    """The board-07 TMDS bundle: 3 diff pairs = 6 nets."""
+    return [
+        "TMDS_D0_P",
+        "TMDS_D0_N",
+        "TMDS_D1_P",
+        "TMDS_D1_N",
+        "TMDS_D2_P",
+        "TMDS_D2_N",
+    ]
+
+
+def _partner_map(names: list[str]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for name in names:
+        if name.endswith("_P"):
+            out[name] = name[:-2] + "_N"
+        elif name.endswith("_N"):
+            out[name] = name[:-2] + "_P"
+    return out
+
+
+def _coupled_group(
+    names: list[str],
+    *,
+    reversed_secondary: bool,
+    group_name: str = "TMDS",
+) -> CoupledGroup:
+    """Build a coupled group; secondary column optionally fully reversed."""
+    n = len(names)
+    id_by_name = {name: i + 1 for i, name in enumerate(names)}
+    partners = _partner_map(names)
+    members: list[CoupledMember] = []
+    for i, name in enumerate(names):
+        j = (n - 1 - i) if reversed_secondary else i
+        partner_name = partners.get(name)
+        members.append(
+            CoupledMember(
+                net_id=id_by_name[name],
+                net_name=name,
+                primary_projection=float(i),
+                secondary_projection=float(j),
+                pair_partner_id=id_by_name.get(partner_name) if partner_name else None,
+            )
+        )
+    return CoupledGroup(group_name=group_name, members=tuple(members))
+
+
+class TestPlanarTrivialLanes:
+    """A co-oriented bundle => trivial in-order outer lanes, no via hops."""
+
+    def test_planar_yields_in_order_outer_lanes(self) -> None:
+        group = _coupled_group(_tmds_names(), reversed_secondary=False)
+        plan = allocate_bundle_plan(group, inner_lane_budget=1)
+
+        assert plan.feasible is True
+        assert plan.infeasible is False
+        # Every member laned exactly once.
+        assert len(plan.lanes) == 6
+        assert {lane.net_id for lane in plan.lanes} == {1, 2, 3, 4, 5, 6}
+        # All on the outer strip, no via hops.
+        assert all(lane.layer == LANE_LAYER_OUTER for lane in plan.lanes)
+        assert all(lane.via_hop is False for lane in plan.lanes)
+        assert plan.inner_lanes_required == 0
+        # Lanes are in primary-projection order with unique slots.
+        outer = sorted(plan.lanes, key=lambda ln: ln.order_index)
+        assert [ln.net_id for ln in outer] == [1, 2, 3, 4, 5, 6]
+        assert len({ln.order_index for ln in outer}) == 6
+
+    def test_planar_lanes_do_not_share_a_cell_on_a_layer(self) -> None:
+        """The feasibility invariant: unique (layer, order_index) per lane."""
+        group = _coupled_group(_tmds_names(), reversed_secondary=False)
+        plan = allocate_bundle_plan(group, inner_lane_budget=1)
+        keys = {(lane.layer, lane.order_index) for lane in plan.lanes}
+        assert len(keys) == len(plan.lanes)
+
+
+class TestFullReversalBudgetDependent:
+    """A full reversal: conflict-free with a generous budget, else infeasible."""
+
+    def test_full_reversal_infeasible_with_tight_budget(self) -> None:
+        # Full reversal of 6 nets: every pair crosses, so the losing nets
+        # (5 of them) all mutually cross -> need 5 inner lanes. Budget 1 =>
+        # explicit infeasible verdict, never a silent partial.
+        group = _coupled_group(_tmds_names(), reversed_secondary=True)
+        plan = allocate_bundle_plan(group, inner_lane_budget=1)
+
+        assert plan.feasible is False
+        assert plan.infeasible is True
+        assert plan.lanes == ()  # no silent partial
+        assert plan.reason  # non-empty explanation
+        assert plan.inner_lanes_required > plan.inner_lane_budget
+        assert "infeasible" in plan.reason.lower() or "budget" in plan.reason.lower()
+
+    def test_full_reversal_feasible_with_generous_budget(self) -> None:
+        # With enough inner lanes the same full reversal IS conflict-free:
+        # every member laned, losers on distinct inner lanes.
+        group = _coupled_group(_tmds_names(), reversed_secondary=True)
+        plan = allocate_bundle_plan(group, inner_lane_budget=6)
+
+        assert plan.feasible is True
+        assert len(plan.lanes) == 6
+        assert {lane.net_id for lane in plan.lanes} == {1, 2, 3, 4, 5, 6}
+        # No two lanes share a cell on a layer.
+        keys = {(lane.layer, lane.order_index) for lane in plan.lanes}
+        assert len(keys) == len(plan.lanes)
+        # The losing nets dip to the inner layer; each inner lane is unique.
+        inner = [lane for lane in plan.lanes if lane.layer == LANE_LAYER_INNER]
+        assert all(lane.via_hop for lane in inner)
+        assert len({lane.order_index for lane in inner}) == len(inner)
+        # Inner-lane crossings among losers are resolved (distinct colours).
+        assert plan.inner_lanes_required <= plan.inner_lane_budget
+
+    def test_full_reversal_is_never_silent_partial(self) -> None:
+        """Whatever the budget, the plan lanes ALL members or NONE."""
+        for budget in range(0, 8):
+            group = _coupled_group(_tmds_names(), reversed_secondary=True)
+            plan = allocate_bundle_plan(group, inner_lane_budget=budget)
+            if plan.feasible:
+                assert len(plan.lanes) == 6
+            else:
+                assert plan.lanes == ()
+
+
+class TestSingleAdjacentSwapFeasible:
+    """A single crossing needs exactly one inner lane => feasible at budget 1."""
+
+    def test_one_crossing_feasible_budget_one(self) -> None:
+        # A(0) B(1) C(2) D(3) primary; secondary swaps B<->C only.
+        members = [
+            CoupledMember(1, "A", 0.0, 0.0),
+            CoupledMember(2, "B", 1.0, 2.0),
+            CoupledMember(3, "C", 2.0, 1.0),
+            CoupledMember(4, "D", 3.0, 3.0),
+        ]
+        group = CoupledGroup(group_name="SWAP", members=tuple(members))
+        plan = allocate_bundle_plan(group, inner_lane_budget=1)
+
+        assert plan.feasible is True
+        assert len(plan.lanes) == 4
+        # Exactly one net dips to the inner layer (the crossing loser).
+        inner = [lane for lane in plan.lanes if lane.via_hop]
+        assert len(inner) == 1
+        assert plan.inner_lanes_required == 1
+
+
+class TestCouplingConstraint:
+    """Diff-pair partners must all be group members; else infeasible."""
+
+    def test_missing_partner_is_infeasible(self) -> None:
+        # net 1 claims a partner id (99) that is not in the group.
+        members = [
+            CoupledMember(1, "X_P", 0.0, 0.0, pair_partner_id=99),
+            CoupledMember(2, "Y", 1.0, 1.0),
+            CoupledMember(3, "Z", 2.0, 2.0),
+            CoupledMember(4, "W", 3.0, 3.0),
+            CoupledMember(5, "V", 4.0, 4.0),
+        ]
+        group = CoupledGroup(group_name="BROKEN", members=tuple(members))
+        plan = allocate_bundle_plan(group)
+        assert plan.infeasible is True
+        assert "partner" in plan.reason.lower()
+        assert plan.lanes == ()
+
+    def test_tmds_partners_are_carried_on_lanes(self) -> None:
+        group = _coupled_group(_tmds_names(), reversed_secondary=False)
+        plan = allocate_bundle_plan(group, inner_lane_budget=1)
+        # Every TMDS member is half a diff pair, so every lane carries a
+        # partner id that is itself a group member.
+        member_ids = {m.net_id for m in group.members}
+        for lane in plan.lanes:
+            assert lane.pair_partner_id is not None
+            assert lane.pair_partner_id in member_ids
+
+
+class TestNonMatchedBusRejected:
+    """A non-clean matched bus is an explicit infeasible verdict."""
+
+    def test_mismatched_rows_infeasible(self) -> None:
+        # Secondary carries a net name not on the primary -> not a matched
+        # bus. Build directly (the helper always matches by construction).
+        members = [
+            CoupledMember(1, "A", 0.0, 0.0),
+            CoupledMember(1, "A", 1.0, 1.0),  # duplicate net id on the row
+        ]
+        group = CoupledGroup(group_name="DUP", members=tuple(members))
+        plan = allocate_bundle_plan(group)
+        assert plan.infeasible is True
+        assert plan.lanes == ()
+
+
+class TestInfeasibleFactory:
+    """The explicit infeasibility constructor is well-formed."""
+
+    def test_infeasible_plan_shape(self) -> None:
+        plan = BundlePlan.infeasible_plan(
+            "G", "because", inner_lanes_required=3, inner_lane_budget=1
+        )
+        assert plan.feasible is False
+        assert plan.infeasible is True
+        assert plan.lanes == ()
+        assert plan.reason == "because"
+        assert plan.inner_lanes_required == 3
+        assert plan.inner_lane_budget == 1
+        assert plan.lane_for(7) is None

--- a/tests/router/test_bundle_plan_hard_reservation.py
+++ b/tests/router/test_bundle_plan_hard_reservation.py
@@ -1,0 +1,144 @@
+"""HARD bundle-plan lane reservation on the C++ grid (Issue #4256, A3).
+
+Acceptance criterion 2: a bundle-plan lane must be a HARD keep-out that
+foreign nets are PROVABLY excluded from on the production C++ grid — not
+merely biased (as #4053's SOFT attractor was, which the greedy A* "paid
+through").  The proof uses the same instrument the #4079 parity gate uses:
+``CppPathfinder.is_trace_blocked`` returns ``True`` for a foreign net on a
+HARD-reserved cell and ``False`` for the owning net, and the two backends
+agree.  A SOFT reservation of the same cell does NOT block the foreign net —
+that contrast is what makes the HARD flip load-bearing.
+
+These tests require the C++ backend (``kct build-native``); they skip when
+it is unavailable so Python-only environments stay green.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.router.cpp_backend import is_cpp_available
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.rules import DesignRules
+
+pytestmark = pytest.mark.skipif(
+    not is_cpp_available(),
+    reason="C++ router backend not built (run: kct build-native)",
+)
+
+
+def _rules() -> DesignRules:
+    return DesignRules(
+        trace_width=0.2,
+        trace_clearance=0.15,
+        via_drill=0.3,
+        via_diameter=0.6,
+        via_clearance=0.15,
+        grid_resolution=0.1,
+    )
+
+
+def _grid_4layer() -> RoutingGrid:
+    stack = LayerStack.four_layer_all_signal()
+    return RoutingGrid(50, 50, _rules(), origin_x=0, origin_y=0, layer_stack=stack)
+
+
+def _inner_layer_idx(grid: RoutingGrid) -> int:
+    for idx in range(grid.num_layers):
+        layer_enum = grid.index_to_layer(idx)
+        if layer_enum not in (Layer.F_CU.value, Layer.B_CU.value):
+            return idx
+    raise AssertionError("4-layer all-signal stack should expose an inner layer")
+
+
+class TestHardReservationExcludesForeignNetOnCpp:
+    """A HARD, C++-mirrored bundle-plan lane fences a foreign net out."""
+
+    def test_foreign_net_provably_excluded(self) -> None:
+        from kicad_tools.router.cpp_backend import CppGrid, CppPathfinder
+        from kicad_tools.router.pathfinder import Router
+
+        grid = _grid_4layer()
+        rules = grid.rules
+        inner = _inner_layer_idx(grid)
+        gx, gy = 25, 25
+        owner = 21  # TMDS_D0_P-style member net id
+
+        # HARD (soft=False) + C++-mirrored (mirror_to_cpp=True): exactly the
+        # args the A3 bundle-plan lanes use.
+        n = grid.reserve_corridor_cells(
+            inner, [(gx, gy)], frozenset({owner}), soft=False, mirror_to_cpp=True
+        )
+        assert n == 1
+        # AC2 part 1: reservation actually lands.
+        assert grid.reserved_cell_count() > 0
+
+        cpp_grid = CppGrid.from_routing_grid(grid)
+        assert cpp_grid._impl.reserved_cell_count() > 0, (
+            "HARD bundle-plan reservation must marshal onto the C++ grid."
+        )
+
+        cpp_pf = CppPathfinder(cpp_grid, rules, diagonal_routing=True)
+        cpp_pf.set_routable_layers(cpp_grid.get_routable_indices())
+        py_router = Router(grid, rules, diagonal_routing=True)
+
+        # AC2 part 2: a foreign net is PROVABLY excluded (blocked), the owner
+        # passes, and the two backends agree.
+        for probe, expect_blocked in ((owner, False), (9999, True)):
+            cpp_blocked = cpp_pf._impl.is_trace_blocked(gx, gy, inner, probe, False)
+            py_blocked = py_router._is_trace_blocked(gx, gy, inner, probe, False)
+            assert cpp_blocked == py_blocked, (
+                f"net {probe}: backends diverge (cpp={cpp_blocked}, py={py_blocked})"
+            )
+            assert cpp_blocked is expect_blocked, (
+                f"net {probe}: expected C++ blocked={expect_blocked}, got {cpp_blocked}"
+            )
+
+    def test_foreign_exclusion_is_hard_even_in_relief_mode(self) -> None:
+        """The HARD keep-out is not soft-negotiable (allow_sharing=True)."""
+        from kicad_tools.router.cpp_backend import CppGrid, CppPathfinder
+
+        grid = _grid_4layer()
+        rules = grid.rules
+        inner = _inner_layer_idx(grid)
+        gx, gy = 25, 25
+
+        grid.reserve_corridor_cells(
+            inner, [(gx, gy)], frozenset({21}), soft=False, mirror_to_cpp=True
+        )
+        cpp_grid = CppGrid.from_routing_grid(grid)
+        cpp_pf = CppPathfinder(cpp_grid, rules, diagonal_routing=True)
+        cpp_pf.set_routable_layers(cpp_grid.get_routable_indices())
+
+        # allow_sharing=True (relief/negotiated mode) must still block.
+        assert cpp_pf._impl.is_trace_blocked(gx, gy, inner, 9999, True) is True
+
+
+class TestSoftReservationDoesNotExclude:
+    """Contrast: a SOFT reservation does NOT fence a foreign net out.
+
+    This is the #4053 failure mode the A3 HARD flip fixes — a SOFT lane is a
+    mere attractor bias the greedy A* pays through, so foreign traffic is not
+    excluded.  Proving the SOFT case does NOT block confirms the HARD flip is
+    load-bearing (not incidentally passing).
+    """
+
+    def test_soft_reservation_leaves_foreign_passable(self) -> None:
+        from kicad_tools.router.cpp_backend import CppGrid, CppPathfinder
+
+        grid = _grid_4layer()
+        rules = grid.rules
+        inner = _inner_layer_idx(grid)
+        gx, gy = 25, 25
+
+        # SOFT + mirrored: reserved, but attractor-only.
+        grid.reserve_corridor_cells(
+            inner, [(gx, gy)], frozenset({21}), soft=True, mirror_to_cpp=True
+        )
+        cpp_grid = CppGrid.from_routing_grid(grid)
+        cpp_pf = CppPathfinder(cpp_grid, rules, diagonal_routing=True)
+        cpp_pf.set_routable_layers(cpp_grid.get_routable_indices())
+
+        # Foreign net is NOT blocked by a SOFT reservation.
+        assert cpp_pf._impl.is_trace_blocked(gx, gy, inner, 9999, False) is False

--- a/tests/router/test_bundle_plan_integration.py
+++ b/tests/router/test_bundle_plan_integration.py
@@ -1,0 +1,188 @@
+"""Integration: the BundlePlan HARD-lane path through the router (#4256, A3).
+
+Drives ``Autorouter._apply_byte_lane_inner_priority`` on synthetic coupled
+(diff-pair) byte-lane fixtures and pins the A3 wiring contract:
+
+  * flag OFF (default): NO bundle-plan HARD lanes, NO stored plan —
+    byte-identical to pre-#4256 main (the existing SOFT single-ended
+    reservation counters are unchanged, asserted in
+    ``test_byte_lane_corridor_reservation.py``);
+  * flag ON, **planar** TMDS bundle: a FEASIBLE ``BundlePlan`` is stored and
+    HARD per-member lanes are reserved (``bundle_plan_corridor_reservations``
+    > 0, grid cells reserved);
+  * flag ON, **reversed** TMDS bundle at inner budget 1: an explicit
+    **INFEASIBLE** verdict is stored and NO HARD lanes are reserved (never a
+    silent partial);
+  * flag ON, **single-ended** DDR byte (no diff pairs): the TMDS-only-first
+    scope guard skips the bundle-plan path entirely, so the single-ended
+    #4079 board-07 behaviour is untouched.
+"""
+
+from __future__ import annotations
+
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.layers import LayerStack
+from kicad_tools.router.rules import NetClassRouting
+
+
+def _make_tmds_router(
+    *,
+    reversed_secondary: bool,
+    layer_stack: LayerStack | None = None,
+    pitch: float = 0.8,
+) -> tuple[Autorouter, list[int]]:
+    """Build a mirrored TMDS coupled-group router (3 diff pairs = 6 nets)."""
+    group_name = "TMDS"
+    cls = NetClassRouting(
+        name=group_name,
+        priority=1,
+        trace_width=0.15,
+        clearance=0.10,
+        length_critical=True,
+        length_match_group=group_name,
+        length_match_reference=None,
+        length_match_tolerance_mm=0.1,
+    )
+    net_class_map: dict[str, NetClassRouting] = {}
+    router = Autorouter(
+        width=120.0, height=80.0, net_class_map=net_class_map, layer_stack=layer_stack
+    )
+
+    names = [
+        "TMDS_D0_P",
+        "TMDS_D0_N",
+        "TMDS_D1_P",
+        "TMDS_D1_N",
+        "TMDS_D2_P",
+        "TMDS_D2_N",
+    ]
+    n = len(names)
+    centre_y = 40.0
+    base_y = centre_y - (n - 1) * pitch / 2.0
+
+    net_ids: list[int] = []
+    for i, name in enumerate(names):
+        net_id = i + 1
+        net_ids.append(net_id)
+        y_primary = base_y + i * pitch
+        j = (n - 1 - i) if reversed_secondary else i
+        y_secondary = base_y + j * pitch
+        router.add_component(
+            "U1",
+            [{"number": str(1 + i), "x": 40.0, "y": y_primary, "net": net_id, "net_name": name}],
+        )
+        router.add_component(
+            "U2",
+            [{"number": str(1 + i), "x": 80.0, "y": y_secondary, "net": net_id, "net_name": name}],
+        )
+        net_class_map[name] = cls
+
+    router.net_class_map = net_class_map
+    return router, net_ids
+
+
+def _make_ddr_router(
+    *,
+    layer_stack: LayerStack | None = None,
+    pitch: float = 0.8,
+) -> tuple[Autorouter, list[int]]:
+    """Single-ended DDR byte (no diff pairs) — the scope-guard control."""
+    group_name = "DDR_DATA_BYTE_0"
+    cls = NetClassRouting(
+        name=group_name,
+        priority=1,
+        trace_width=0.15,
+        clearance=0.10,
+        length_critical=True,
+        length_match_group=group_name,
+        length_match_reference=None,
+        length_match_tolerance_mm=0.1,
+    )
+    net_class_map: dict[str, NetClassRouting] = {}
+    router = Autorouter(
+        width=120.0, height=80.0, net_class_map=net_class_map, layer_stack=layer_stack
+    )
+
+    n = 8
+    centre_y = 40.0
+    base_y = centre_y - (n - 1) * pitch / 2.0
+    net_ids: list[int] = []
+    for i in range(n):
+        net_id = i + 1
+        name = f"DQ{i}"
+        net_ids.append(net_id)
+        y = base_y + i * pitch
+        router.add_component(
+            "U1", [{"number": str(1 + i), "x": 40.0, "y": y, "net": net_id, "net_name": name}]
+        )
+        router.add_component(
+            "U2", [{"number": str(1 + i), "x": 80.0, "y": y, "net": net_id, "net_name": name}]
+        )
+        net_class_map[name] = cls
+    router.net_class_map = net_class_map
+    return router, net_ids
+
+
+class TestFlagOffNoBundlePlan:
+    def test_flag_off_reserves_no_hard_lanes(self) -> None:
+        stack = LayerStack.four_layer_all_signal()
+        router, net_ids = _make_tmds_router(reversed_secondary=False, layer_stack=stack)
+        assert router.enable_bundle_river_planner is False
+        router._apply_byte_lane_inner_priority(net_ids)
+        assert router._escape.bundle_plan_corridor_reservations == 0
+        assert router._last_bundle_plans == {}
+
+
+class TestFlagOnPlanarFeasible:
+    def test_planar_tmds_feasible_hard_lanes_reserved(self) -> None:
+        stack = LayerStack.four_layer_all_signal()
+        router, net_ids = _make_tmds_router(reversed_secondary=False, layer_stack=stack)
+        router.enable_bundle_river_planner = True
+        router._apply_byte_lane_inner_priority(net_ids)
+
+        plan = router._last_bundle_plans.get("TMDS")
+        assert plan is not None
+        assert plan.feasible is True
+        assert len(plan.lanes) == 6
+        # HARD per-member lanes were reserved on their own counter.
+        assert router._escape.bundle_plan_corridor_reservations > 0
+        assert router._escape.bundle_plan_corridor_reserved_cells > 0
+        assert router.grid.reserved_cell_count() > 0
+
+
+class TestFlagOnReversedInfeasible:
+    def test_reversed_tmds_infeasible_no_hard_lanes(self) -> None:
+        stack = LayerStack.four_layer_all_signal()
+        router, net_ids = _make_tmds_router(reversed_secondary=True, layer_stack=stack)
+        router.enable_bundle_river_planner = True
+        router._apply_byte_lane_inner_priority(net_ids)
+
+        plan = router._last_bundle_plans.get("TMDS")
+        assert plan is not None
+        # A full reversal of 6 nets over an inner budget of 1 is a genuine
+        # over-subscription: an explicit infeasible verdict, never a partial.
+        assert plan.infeasible is True
+        assert plan.reason
+        assert plan.lanes == ()
+        assert router._escape.bundle_plan_corridor_reservations == 0
+
+
+class TestScopeGuardSingleEnded:
+    def test_single_ended_ddr_byte_skips_bundle_plan(self) -> None:
+        stack = LayerStack.four_layer_all_signal()
+        router, net_ids = _make_ddr_router(layer_stack=stack)
+        router.enable_bundle_river_planner = True
+        router._apply_byte_lane_inner_priority(net_ids)
+        # No diff pairs -> no coupled group -> no HARD lanes, no stored plan.
+        assert router._escape.bundle_plan_corridor_reservations == 0
+        assert "DDR_DATA_BYTE_0" not in router._last_bundle_plans
+
+
+class TestOrderUnchanged:
+    def test_bundle_plan_is_pure_side_effect(self) -> None:
+        stack = LayerStack.four_layer_all_signal()
+        router, net_ids = _make_tmds_router(reversed_secondary=False, layer_stack=stack)
+        router.enable_bundle_river_planner = True
+        out = router._apply_byte_lane_inner_priority(net_ids)
+        # The allocator reserves lanes; it does not reorder nets.
+        assert out == net_ids


### PR DESCRIPTION
## A3 — Bundle corridor allocation + HARD lane reservation

Closes #4256. Track A / #4252; design #4254 (A1); sibling of A2 (#4255, merged).

Implements the multi-net half of Track A: a **discrete, combinatorial**
corridor allocator (not joint A*) that assigns simultaneously-feasible escape
lanes to a whole `CoupledGroup`, plus the generalization of the inner-corner
lane reservation to **HARD** (foreign-net keep-out, C++-mirrored) per-member
lanes. Both are gated behind the existing default-OFF
`enable_bundle_river_planner` flag; TMDS-only-first.

### Part (a) — the discrete `BundlePlan` allocator (`bundle_river.py`)

New `CoupledMember` / `CoupledGroup` / `EscapeLane` / `BundlePlan` types and
`allocate_bundle_plan()`. The allocator formulates escape-lane assignment as
**ordered interval packing** over the shared outer strip + an **inner-layer
via-hop budget** for the crossing ("losing") nets, reusing `bundle_river`'s
`RowMember` / `InvertedPair` / `choose_via_hop_loser` / inversion set. The
losers' mutual-crossing graph is coloured **exactly** (backtracking over the
tiny ~6 member set) so the inner-lane count is honest. Output is either a
simultaneously-feasible `BundlePlan` (every member laned; no two lanes share a
cell on a layer) **or an explicit `infeasible` verdict** — never a silent
partial. Infeasibility is first-class (`BundlePlan.infeasible` + a `reason`).

### Part (b) — HARD per-member lane reservation (`escape.py` + `core.py`)

`reserve_inner_corner_lane_corridor` is generalized with `soft` /
`mirror_to_cpp` kwargs whose **defaults preserve the existing single-ended
byte-lane call byte-for-byte** (`soft=True, mirror_to_cpp=False`). The new
`_reserve_bundle_plan_lanes` reserves one lane per `BundlePlan` member with
`soft=False, mirror_to_cpp=True` — the shipped HARD pattern (`escape.py:2531`)
— so foreign nets are hard-excluded on the C++ grid via
`is_reserved_excluding`. **The existing `escape.py` single-ended call is
untouched** (per #4079, flipping it on C++ regresses board-07). HARD lanes use
a separate counter (`bundle_plan_corridor_reservations`) so the flag-off
identity tests keep asserting exactly 2 on the SOFT counter. A `_P`/`_N`
scope-guard means the single-ended DDR byte never gets HARD C++-mirrored lanes.

### Acceptance

- [x] **Allocator unit coverage** (`test_bundle_plan_allocator.py`): full
  reversal → conflict-free assignment (generous budget) **or** explicit
  infeasible (tight budget); planar bundle → trivial in-order lanes; never a
  silent partial; coupling constraint enforced.
- [x] **HARD reservation verified on the C++ grid**
  (`test_bundle_plan_hard_reservation.py`): `reserved_cell_count() > 0` and a
  foreign net is **provably excluded** — `CppPathfinder.is_trace_blocked`
  returns `True` for a foreign net on a bundle-plan lane cell and `False` for
  the owner, both backends agreeing, even in relief mode; a SOFT reservation
  does **not** exclude (proving the HARD flip is load-bearing). Requires the
  C++ backend (built in this worktree).
- [x] **Flag-off byte-identical** to `main`: `test_byte_lane_priority.py`,
  `test_byte_lane_corridor_reservation.py`, `test_bundle_river_*` all green
  unchanged (49 tests).
- [x] **Infeasibility is first-class** — explicit verdict, scope not widened.

### A4-informing measurement — board-07 seed-42 TMDS

Extracted the committed TMDS pad geometry
(`matchgroup_test_routed.kicad_pcb`) and ran the allocator at the realistic
board-07 inner via-hop budget of 1 (In1/In2 are planes; B.Cu is the only
alternate surface):

**Verdict: FEASIBLE** (0 inner via-hop lanes required, at every budget 1–6).

Both facing rows carry `TMDS_D0_P, D0_N, D1_P, D1_N, D2_P, D2_N` in the **same
x-order** — the bundle is **co-oriented / planar**, not a bus reversal. So the
allocator produces a feasible `BundlePlan` of 6 trivial in-order HARD lanes.

**Implication for A4:** the TMDS opens (`TMDS_D0_N` / `TMDS_D1_N`,
`CONGESTION_SATURATED`) are **not** caused by a forced crossing the allocator
can resolve with via-hops — the topology is planar. A4 gets a concrete set of
6 HARD in-order lanes to reserve and route inside; whether pre-committing them
removes the greedy N−1 channel contention that strands D0_N/D1_N is what A4's
router integration + board-07 gate will measure. If the HARD lanes do not
close them, the residual is channel/placement congestion → Track B.

### Notes

- C++ backend built in-worktree (`kct build-native`); **no C++ source
  changed** — the HARD keep-out (`is_reserved_excluding`) already ships.
- `pnpm check:ci` scope green: `ruff format --check .`, `ruff check .`, and the
  full touched-area test suite (allocator + HARD reservation + integration +
  byte-lane identity + bundle-river + grid C++ parity = 80 passed). mypy adds
  no new errors in the changed regions (`Any` explicitly narrowed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
