### PR TITLE
board-07 [Track A / A4]: integration + regression gate — measured TMDS residual is PLACEMENT_BOUND (#4257)

### DIFF
--- a/boards/07-matchgroup-test/README.md
+++ b/boards/07-matchgroup-test/README.md
@@ -204,6 +204,52 @@ artifact, so the committed artifact remains the shipping truth and is
 left unchanged (regen diverges only in trace geometry/UUIDs, not in which
 nets close).
 
+### Track A bundle-plan allocator — measured seed-42 verdict (#4257, A4)
+
+Track A (#4252) built the "joint bundle corridor allocation" fix named
+below as the genuine remedy for the `CONGESTION_SATURATED` TMDS 1:1
+trades: an **atomic diff-pair rip-up/relief transaction** (A2, #4255) so a
+committed "P-routed / N-stranded" state is unrepresentable, plus a
+**discrete `BundlePlan` allocator with HARD (foreign-net keep-out) per-member
+lane reservation** (A3, #4256).  A4 (#4257) wired both through all three
+negotiated entry points (`route_all`, `route_all_negotiated`,
+`TwoPhaseRouter`) behind the default-OFF `--bundle-river-planner`
+(`enable_bundle_river_planner`) flag and ran the board-07 acceptance gate.
+
+**Honest outcome: the TMDS opens do NOT close; the residual is
+placement-bound.**  A solo seed-42 A/B on one host (C++ backend built,
+`--deterministic-budget`, `PYTHONHASHSEED=42`) measured:
+
+| Run | Reach | Open set |
+|-----|-------|----------|
+| flag **OFF** (default / shipping) | **26/31** | `DQ3`, `DQ4`, `MIPI_DAT0_N`, `TMDS_D0_N`, `TMDS_D1_N` |
+| flag **ON** (`--bundle-river-planner`) | **23/31** | the 5 above **+** `MIPI_CLK_N`, `TMDS_D0_P`, `TMDS_D1_P` |
+
+The reason is the load-bearing A3 finding, now re-confirmed against the
+committed placement: the allocator returns the HDMI TMDS bundle
+**FEASIBLE with 6 trivial in-order OUTER lanes and 0 via-hops** — the two
+facing rows (J2 / U4) carry `D0..D2` co-oriented, so there is **no
+forced-crossing contention for the allocator to resolve**.  Reserving the
+resulting HARD lanes (12 keep-out lanes / 3780 grid cells across the TMDS
+and MIPI bundles) therefore does not open the stuck TMDS N-legs; it only
+walls off cells the congested single-ended negotiator needed, stranding
+the *partners* (`TMDS_D0_P`, `TMDS_D1_P`, `MIPI_CLK_N`) — a **regression**,
+not a gain.
+
+Conclusion: `TMDS_D0_N` / `TMDS_D1_N` are **`PLACEMENT_BOUND`**, not
+coupling-contention-bound.  No HARD-lane reservation closes them; the
+residual is the same "a part must move" limit as `DQ3` / `DQ4` /
+`MIPI_DAT0_N`, tracked under **Track B / #4253** (placement rework).  The
+board-07 reach is therefore **unchanged at 26/31** and **the committed
+routed artifact is not refreshed** (the flag stays OFF by default and
+flag-off is byte-identical to pre-A4 `main`).  Track A still ships its
+real deliverable — the general, verified coupled-bundle capability (atomic
+pair transaction + discrete allocator + HARD lane reservation, exercised
+end-to-end from all three negotiated entry points in
+`tests/router/test_bundle_plan_three_path_integration.py`) — available for
+future geometries where a bundle *is* crossing-contended, behind the
+default-OFF flag so production routing is unperturbed.
+
 ### Required class of fix (follow-up, out of scope here)
 
 None of the four gaps is a knob the single-ended negotiated router can

--- a/tests/router/test_bundle_plan_three_path_integration.py
+++ b/tests/router/test_bundle_plan_three_path_integration.py
@@ -1,0 +1,166 @@
+"""A4 (#4257): the BundlePlan HARD-lane allocator is driven by ALL THREE
+negotiated entry points, not just a direct ``_apply_byte_lane_inner_priority``
+call.
+
+A3 (#4256) placed the discrete-allocator seam inside
+``Autorouter._apply_byte_lane_inner_priority`` and pinned it with a test that
+calls that helper directly (``test_bundle_plan_integration.py``).  A4's
+integration contract is that the three negotiated routing entry points the
+curator enumerated —
+
+  * ``route_all``                (core.py:6292),
+  * ``route_all_negotiated``     (core.py:7539),
+  * ``TwoPhaseRouter`` built by ``_create_two_phase_router`` (core.py:12421),
+
+— each actually reach that gated block, so the HARD-lane reservation is
+honoured identically on every negotiated route.  All three share the SAME
+bound ``self._apply_byte_lane_inner_priority`` on the SAME ``Autorouter``
+instance and the SAME ``self.grid``, so a plan reserved on one is reserved on
+the grid the route actually uses.
+
+Each entry point is asserted twice:
+
+  * flag OFF (default): NO stored plan, NO HARD lanes — byte-identical to
+    pre-#4256 main (the flag-off invariant the board-07 gate depends on);
+  * flag ON, planar TMDS bundle: a FEASIBLE ``BundlePlan`` is stored under the
+    group name and HARD per-member lanes are reserved on the shared grid.
+
+The planar-TMDS geometry mirrors the load-bearing board-07 finding (A3): the
+committed placement carries the bundle co-oriented, so the allocator returns 6
+trivial in-order OUTER lanes (0 via-hops).  This is why closing the board-07
+TMDS opens is NOT guaranteed by the allocator — see the board-07 README
+"Routing Plateau" section for the measured seed-42 verdict.
+"""
+
+from __future__ import annotations
+
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.layers import LayerStack
+from kicad_tools.router.rules import NetClassRouting
+
+GROUP_NAME = "TMDS"
+
+
+def _make_planar_tmds_router() -> tuple[Autorouter, list[int]]:
+    """Mirrored, co-oriented TMDS coupled group (3 diff pairs = 6 nets).
+
+    Both facing columns (U1, U2) carry the members in the SAME x-order, so the
+    allocator's crossing set is empty and the plan is FEASIBLE with 6 in-order
+    outer lanes — the board-07 planar topology.
+    """
+    cls = NetClassRouting(
+        name=GROUP_NAME,
+        priority=1,
+        trace_width=0.15,
+        clearance=0.10,
+        length_critical=True,
+        length_match_group=GROUP_NAME,
+        length_match_reference=None,
+        length_match_tolerance_mm=0.1,
+    )
+    net_class_map: dict[str, NetClassRouting] = {}
+    router = Autorouter(
+        width=120.0,
+        height=80.0,
+        net_class_map=net_class_map,
+        layer_stack=LayerStack.four_layer_all_signal(),
+    )
+
+    names = [
+        "TMDS_D0_P",
+        "TMDS_D0_N",
+        "TMDS_D1_P",
+        "TMDS_D1_N",
+        "TMDS_D2_P",
+        "TMDS_D2_N",
+    ]
+    n = len(names)
+    pitch = 0.8
+    base_y = 40.0 - (n - 1) * pitch / 2.0
+    net_ids: list[int] = []
+    for i, name in enumerate(names):
+        net_id = i + 1
+        net_ids.append(net_id)
+        y = base_y + i * pitch
+        router.add_component(
+            "U1",
+            [{"number": str(1 + i), "x": 40.0, "y": y, "net": net_id, "net_name": name}],
+        )
+        router.add_component(
+            "U2",
+            [{"number": str(1 + i), "x": 80.0, "y": y, "net": net_id, "net_name": name}],
+        )
+        net_class_map[name] = cls
+
+    router.net_class_map = net_class_map
+    return router, net_ids
+
+
+def _assert_flag_off_no_reservation(router: Autorouter) -> None:
+    assert router.enable_bundle_river_planner is False
+    assert router._last_bundle_plans == {}
+    assert router._escape.bundle_plan_corridor_reservations == 0
+
+
+def _assert_flag_on_feasible_reserved(router: Autorouter) -> None:
+    plan = router._last_bundle_plans.get(GROUP_NAME)
+    assert plan is not None, "allocator did not fire on this entry point"
+    assert plan.feasible is True
+    assert plan.infeasible is False
+    assert len(plan.lanes) == 6
+    assert all(lane.layer == "outer" and not lane.via_hop for lane in plan.lanes)
+    # HARD per-member lanes reserved on the SHARED grid the route uses.
+    assert router._escape.bundle_plan_corridor_reservations > 0
+    assert router._escape.bundle_plan_corridor_reserved_cells > 0
+    assert router.grid.reserved_cell_count() > 0
+
+
+# ---------------------------------------------------------------------------
+# Entry point 1: route_all  (core.py:6292 -> :6472 helper call)
+# ---------------------------------------------------------------------------
+class TestRouteAllDrivesAllocator:
+    def test_route_all_flag_off_no_hard_lanes(self) -> None:
+        router, net_ids = _make_planar_tmds_router()
+        router.route_all(net_order=list(net_ids), suppress_no_timeout_warning=True)
+        _assert_flag_off_no_reservation(router)
+
+    def test_route_all_flag_on_reserves_hard_lanes(self) -> None:
+        router, net_ids = _make_planar_tmds_router()
+        router.enable_bundle_river_planner = True
+        router.route_all(net_order=list(net_ids), suppress_no_timeout_warning=True)
+        _assert_flag_on_feasible_reserved(router)
+
+
+# ---------------------------------------------------------------------------
+# Entry point 2: route_all_negotiated  (core.py:7539 -> :7986 helper call)
+# ---------------------------------------------------------------------------
+class TestRouteAllNegotiatedDrivesAllocator:
+    def test_negotiated_flag_off_no_hard_lanes(self) -> None:
+        router, _ = _make_planar_tmds_router()
+        router.route_all_negotiated(max_iterations=1, timeout=30.0)
+        _assert_flag_off_no_reservation(router)
+
+    def test_negotiated_flag_on_reserves_hard_lanes(self) -> None:
+        router, _ = _make_planar_tmds_router()
+        router.enable_bundle_river_planner = True
+        router.route_all_negotiated(max_iterations=1, timeout=30.0)
+        _assert_flag_on_feasible_reserved(router)
+
+
+# ---------------------------------------------------------------------------
+# Entry point 3: TwoPhaseRouter via _create_two_phase_router
+# (core.py:12421 -> two_phase.py:312 callback into the shared helper)
+# ---------------------------------------------------------------------------
+class TestTwoPhaseRouterDrivesAllocator:
+    def test_two_phase_flag_off_no_hard_lanes(self) -> None:
+        router, net_ids = _make_planar_tmds_router()
+        two_phase = router._create_two_phase_router()
+        two_phase.route_all(list(net_ids))
+        _assert_flag_off_no_reservation(router)
+
+    def test_two_phase_flag_on_reserves_hard_lanes(self) -> None:
+        router, net_ids = _make_planar_tmds_router()
+        router.enable_bundle_river_planner = True
+        two_phase = router._create_two_phase_router()
+        two_phase.route_all(list(net_ids))
+        _assert_flag_on_feasible_reserved(router)

--- a/tests/router/test_bundle_plan_three_path_integration.py
+++ b/tests/router/test_bundle_plan_three_path_integration.py
@@ -121,13 +121,35 @@ def _assert_flag_on_feasible_reserved(router: Autorouter) -> None:
 class TestRouteAllDrivesAllocator:
     def test_route_all_flag_off_no_hard_lanes(self) -> None:
         router, net_ids = _make_planar_tmds_router()
-        router.route_all(net_order=list(net_ids), suppress_no_timeout_warning=True)
+        # Bound each net's A* (per_net_timeout) plus an outer wall-clock cap.
+        # This entry point asserts only the allocator seam, which runs in the
+        # pre-pass *before* the per-net loop; the loop itself just exercises
+        # the seam.  Unbounded, the coupled ``_N`` partners fail C++ clearance
+        # validation and fall back to the slow pure-Python A* (~19s locally,
+        # over CI's 60s cap).  A tight per-net deadline keeps the test fast and
+        # bounded (~1.5s) without touching what it verifies (#4257).
+        router.route_all(
+            net_order=list(net_ids),
+            per_net_timeout=1.0,
+            timeout=15.0,
+            suppress_no_timeout_warning=True,
+        )
         _assert_flag_off_no_reservation(router)
 
     def test_route_all_flag_on_reserves_hard_lanes(self) -> None:
         router, net_ids = _make_planar_tmds_router()
         router.enable_bundle_river_planner = True
-        router.route_all(net_order=list(net_ids), suppress_no_timeout_warning=True)
+        # Bounded per-net + outer budget (see flag-off sibling): the FEASIBLE
+        # plan is stored and the HARD lanes are reserved by the allocator
+        # pre-pass ahead of the per-net loop, so bounding the loop does not
+        # touch the reservation assertions -- it only caps the unbounded A*
+        # fallback time so the test passes under CI's ``--timeout=60``.
+        router.route_all(
+            net_order=list(net_ids),
+            per_net_timeout=1.0,
+            timeout=15.0,
+            suppress_no_timeout_warning=True,
+        )
         _assert_flag_on_feasible_reserved(router)
 
 


### PR DESCRIPTION
## A4 — integration + board-07 regression gate (Track A, final deliverable)

Closes #4257

Wires A2's atomic diff-pair transaction (#4255) + A3's discrete `BundlePlan` allocator with HARD lane reservation (#4256) through the negotiated router behind the default-OFF `enable_bundle_river_planner` flag, and runs the board-07 acceptance gate. **This is an honest outcome-2 closure: the TMDS opens do NOT close; the residual is placement-bound (Track B / #4253).** I did not force a 28/31.

### 1. Measured seed-42 open-set (flag ON) and which outcome occurred

Solo A/B on one host, C++ backend built (`v1.0.0`), `--deterministic-budget`, `PYTHONHASHSEED=42`:

| Run | Reach | Open set |
|-----|-------|----------|
| flag **OFF** (default / shipping) | **26/31** | `DQ3`, `DQ4`, `MIPI_DAT0_N`, `TMDS_D0_N`, `TMDS_D1_N` |
| flag **ON** (`--bundle-river-planner`) | **23/31** | the 5 above **+** `MIPI_CLK_N`, `TMDS_D0_P`, `TMDS_D1_P` |

**Outcome 2: the opens did not move — flag-ON actually regresses.** A no-routing diagnostic on the committed placement shows why: the allocator returns the HDMI TMDS bundle **FEASIBLE with 6 trivial in-order OUTER lanes and 0 via-hops** (the two facing rows J2/U4 carry `D0..D2` co-oriented — no forced crossing). Reserving the resulting HARD lanes (12 keep-out lanes / 3780 grid cells across TMDS + MIPI) resolves no contention; it only walls off cells the single-ended negotiator needed, stranding the *partners*. So `TMDS_D0_N`/`TMDS_D1_N` are **`PLACEMENT_BOUND`**, not coupling-contention-bound — no HARD-lane reservation closes them.

Per the issue's outcome-2 contract: reach is **unchanged at the flag-OFF default (26/31)**, the **committed routed artifact is NOT refreshed**, and the README "Routing Plateau" section records the measured verdict.

### 2. Flag-off byte-identical

Confirmed. The flag is OFF by default and this PR has **zero production-source changes** — A3 already placed the allocator seam in the shared `_apply_byte_lane_inner_priority`, which all three curator-enumerated entry points (`route_all` core.py:6472, `route_all_negotiated` core.py:7986, `TwoPhaseRouter` two_phase.py:312) already drive on the same `Autorouter` + grid. `test_byte_lane_priority.py`, `test_byte_lane_corridor_reservation.py`, and the A2/A3 identity tests stay green (66 passed). The committed artifact is untouched.

The new `tests/router/test_bundle_plan_three_path_integration.py` locks the integration: each of the three entry points stores a FEASIBLE plan + reserves HARD lanes with the flag ON, and reserves **nothing** (byte-identical) with it OFF.

### 3. No board 00–07 regression

Per-board routing regression suites run green (not the router unit suite alone — the #4065/#4069 lesson):
- Boards 00, 01, 02: 22 passed
- Boards 03, 04, 05, 06 routing/copper-LVS regression + new integration: green (exit 0)
- Board 07 match-group + coverage: 147 passed
- Byte-lane identity + A2 relief-rescue/atomic + A3 allocator/hard-reservation/integration: green

`pnpm check:ci` gates: `ruff format --check .` (1595 files formatted) + `ruff check .` (all checks passed) green. mypy on `src/` is unchanged from `main` (no src edits).

### 4. Outcome-2 placement-bound verdict

`TMDS_D0_N` / `TMDS_D1_N` are `PLACEMENT_BOUND` — the same "a part must move" limit as `DQ3` / `DQ4` / `MIPI_DAT0_N`, tracked under **Track B / #4253** (placement rework). Track A still ships its real deliverable: the general, verified coupled-bundle capability (atomic pair transaction + discrete allocator + HARD lane reservation, exercised end-to-end from all three negotiated entry points), available behind the default-OFF flag for future geometries where a bundle *is* crossing-contended, so production routing is unperturbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)