### PR TITLE
fix(net-status --why): correct PLACEMENT_BOUND misattribution + add ranked fix recommendation (#4261)

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 4236
-# Branch: feature/issue-4236
+# Issue: 4261
+# Branch: feature/issue-4261
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/src/kicad_tools/cli/net_status_cmd.py
+++ b/src/kicad_tools/cli/net_status_cmd.py
@@ -27,6 +27,8 @@ Exit Codes:
     2 - Incomplete nets found
 """
 
+from __future__ import annotations
+
 import argparse
 import json
 import sys

--- a/src/kicad_tools/cli/net_status_cmd.py
+++ b/src/kicad_tools/cli/net_status_cmd.py
@@ -352,7 +352,15 @@ def output_why(pcb_path: Path, fmt: str) -> int:
         print(f"[{diag.classification.value.upper()}] {diag.net_name}")
         print(f"  unconnected pads: {pads}")
         if diag.blocking_nets:
-            print(f"  blocking nets:    {', '.join(diag.blocking_nets)}")
+            # Defect 2 (#4261): flag which blockers are the net's OWN match-group
+            # siblings rather than foreign copper.
+            note = ""
+            if diag.same_group_blockers and diag.match_group:
+                note = (
+                    f"        (same match-group {diag.match_group}: "
+                    f"{', '.join(diag.same_group_blockers)})"
+                )
+            print(f"  blocking nets:    {', '.join(diag.blocking_nets)}{note}")
         print(f"  evidence:         {diag.evidence}")
         print()
 

--- a/src/kicad_tools/cli/net_status_cmd.py
+++ b/src/kicad_tools/cli/net_status_cmd.py
@@ -31,8 +31,12 @@ import argparse
 import json
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from kicad_tools.analysis.net_status import NetStatus, NetStatusAnalyzer, NetStatusResult
+
+if TYPE_CHECKING:
+    from kicad_tools.router.stuck_classifier import StuckNetDiagnosis
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -307,6 +311,33 @@ def output_json(
     print(json.dumps(data, indent=2))
 
 
+_ACTION_LABELS = {
+    "de_reverse_bundle": "de-reverse the bundle",
+    "reorder_pins": "re-order pins",
+    "widen_channel": "widen the channel",
+    "move_part": "move a part",
+    "accept_plateau": "accept plateau",
+}
+
+
+def _print_recommendation(diag: StuckNetDiagnosis) -> None:
+    """Render the additive ranked fix ladder for one stuck net (issue #4261).
+
+    Only called when ``diag`` has a non-empty ``recommendation``.
+    """
+    confidence = diag.recommendation[0].confidence.value.upper()
+    if diag.topology == "self_crossing_bundle":
+        group = diag.match_group or "bundle"
+        headline = f"self-crossing {group} bundle"
+    else:
+        headline = "foreign-cluster congestion"
+    print(f"  recommendation:   [{confidence}] {headline}")
+    for i, ranked in enumerate(diag.recommendation, start=1):
+        label = _ACTION_LABELS.get(ranked.action.value, ranked.action.value)
+        preferred = "  [preferred]" if i == 1 else ""
+        print(f"                    {i}. {label} ({ranked.rationale}){preferred}")
+
+
 def output_why(pcb_path: Path, fmt: str) -> int:
     """Classify incomplete signal nets by why they are stuck and print them.
 
@@ -362,6 +393,8 @@ def output_why(pcb_path: Path, fmt: str) -> int:
                 )
             print(f"  blocking nets:    {', '.join(diag.blocking_nets)}{note}")
         print(f"  evidence:         {diag.evidence}")
+        if diag.recommendation:
+            _print_recommendation(diag)
         print()
 
     return 2

--- a/src/kicad_tools/router/stuck_classifier.py
+++ b/src/kicad_tools/router/stuck_classifier.py
@@ -711,7 +711,7 @@ def _decide(
             f"pad reachable ({open_deg:.0f} deg lane) but in a dense cluster "
             f"({local_congestion} foreign obstructions, {nb}); ripping the few "
             f"strict blockers cannot clear the surrounding copper -- a part "
-            f"must move (analog/codec cluster)"
+            f"must move"
         )
         return StuckNetDiagnosis(
             net_name=net_name,

--- a/src/kicad_tools/router/stuck_classifier.py
+++ b/src/kicad_tools/router/stuck_classifier.py
@@ -72,6 +72,9 @@ if TYPE_CHECKING:
 
 __all__ = [
     "StuckClass",
+    "RecommendedAction",
+    "Confidence",
+    "RankedAction",
     "StuckNetDiagnosis",
     "StuckClassifierResult",
     "classify_stuck_nets",
@@ -198,6 +201,56 @@ class StuckClass(Enum):
         }[self.value]
 
 
+class RecommendedAction(Enum):
+    """Closed taxonomy of fix moves the recommendation engine may rank.
+
+    READ-ONLY advice to a human/agent -- the classifier never performs any of
+    these; it only ranks them.  ``DE_REVERSE_BUNDLE`` / ``REORDER_PINS`` are the
+    topology remedies for a self-crossing bus; ``MOVE_PART`` / ``WIDEN_CHANNEL``
+    address genuinely foreign congestion; ``ACCEPT_PLATEAU`` acknowledges a
+    topological limit no placement lever removes.
+    """
+
+    DE_REVERSE_BUNDLE = "de_reverse_bundle"
+    REORDER_PINS = "reorder_pins"
+    WIDEN_CHANNEL = "widen_channel"
+    MOVE_PART = "move_part"
+    ACCEPT_PLATEAU = "accept_plateau"
+
+
+class Confidence(Enum):
+    """How much trust to place in a recommendation.
+
+    * ``HIGH``   -- match group from an explicit source, or a confirmed
+      pad-order crossing proxy (neither available from a bare ``.kicad_pcb``
+      today, so reserved for a future config-threaded caller).
+    * ``MEDIUM`` -- match group inferred from a bus-suffix pattern and the share
+      test fired; the geometry is a heuristic (board-07 lands here).
+    * ``LOW``    -- group inferred from a borderline / high-false-positive suffix
+      pattern (e.g. the generic ``A\\d+`` address bus).
+    """
+
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+@dataclass
+class RankedAction:
+    """One entry in a ranked fix ladder."""
+
+    action: RecommendedAction
+    rationale: str
+    confidence: Confidence
+
+    def to_dict(self) -> dict:
+        return {
+            "action": self.action.value,
+            "rationale": self.rationale,
+            "confidence": self.confidence.value,
+        }
+
+
 @dataclass
 class StuckNetDiagnosis:
     """Per-net classification result with supporting evidence."""
@@ -224,6 +277,12 @@ class StuckNetDiagnosis:
     # Subset of ``blocking_nets`` that are members of ``match_group`` -- these are
     # the net's own siblings, NOT foreign copper (Defect 2 relabel).
     same_group_blockers: list[str] = field(default_factory=list)
+    # Defect 3 (#4261): detected obstruction topology and the ranked fix ladder.
+    # ``topology`` is ``TOPOLOGY_SELF_CROSSING`` | ``TOPOLOGY_FOREIGN_CLUSTER`` |
+    # "" (not applicable).  ``recommendation`` is empty unless a recommendation
+    # is warranted (PLACEMENT_BOUND / CONGESTION_SATURATED).
+    topology: str = ""
+    recommendation: list[RankedAction] = field(default_factory=list)
 
     @property
     def classification_value(self) -> str:
@@ -246,6 +305,8 @@ class StuckNetDiagnosis:
             "same_group_congestion": self.same_group_congestion,
             "foreign_congestion": self.foreign_congestion,
             "match_group": self.match_group,
+            "topology": self.topology,
+            "recommendation": [a.to_dict() for a in self.recommendation],
         }
 
     def one_line(self) -> str:
@@ -659,6 +720,29 @@ def classify_stuck_nets_from_pcb(
         # which blockers are the net's own bundle siblings.
         diag.match_group = target_group
         diag.same_group_blockers = same_group_blockers
+
+        # Defect 3: detect self-crossing-bundle vs foreign-cluster topology and
+        # emit the ranked fix ladder (only for the two placement/congestion
+        # classes; other classes keep topology="" and recommendation=[]).
+        if diag.classification in (
+            StuckClass.PLACEMENT_BOUND,
+            StuckClass.CONGESTION_SATURATED,
+        ):
+            diag.topology = _detect_topology(
+                match_group=target_group,
+                group_size=len(group_ids),
+                same_group_congestion=same_group_congestion,
+                foreign_congestion=foreign_congestion,
+                blockers=blockers,
+                same_group_blockers=same_group_blockers,
+            )
+            confidence = _grade_confidence(target_group)
+            diag.recommendation = _build_recommendation(
+                classification=diag.classification,
+                topology=diag.topology,
+                match_group=target_group,
+                confidence=confidence,
+            )
         diagnoses.append(diag)
 
     # Second pass: pour-carried incomplete nets.  Their connectivity is closed
@@ -719,6 +803,136 @@ def _nearest_blocker_distance(
             if d <= window and d < best:
                 best = d
     return None if best is math.inf else best
+
+
+def _grade_confidence(match_group: str) -> Confidence:
+    """Grade a suffix-inferred self-crossing detection.
+
+    HIGH is reserved for an explicit match-group source or a confirmed pad-order
+    crossing proxy -- neither is reachable from a bare ``.kicad_pcb`` in v1, so
+    this returns MEDIUM for a normal bus-suffix group and LOW for the generic
+    ``ADDR_BUS`` pattern (``A\\d+``), documented as the highest-false-positive
+    inference in ``match_group_detection``.
+    """
+    if match_group == "ADDR_BUS":
+        return Confidence.LOW
+    return Confidence.MEDIUM
+
+
+def _detect_topology(
+    *,
+    match_group: str,
+    group_size: int,
+    same_group_congestion: int,
+    foreign_congestion: int,
+    blockers: list[str],
+    same_group_blockers: list[str],
+) -> str:
+    """Return the obstruction topology of a stuck net (issue #4261 Defect 3).
+
+    ``TOPOLOGY_SELF_CROSSING`` when the copper crowding the pad is predominantly
+    the net's OWN match-group siblings -- either the same-group share of nearby
+    obstruction copper OR the same-group share of ranked strict blockers reaches
+    :data:`SELF_CROSS_THRESHOLD`, and the group has at least three members
+    (``detect_match_groups`` already refuses smaller groups).  Otherwise
+    ``TOPOLOGY_FOREIGN_CLUSTER``.
+    """
+    if not match_group or group_size < 3:
+        return TOPOLOGY_FOREIGN_CLUSTER
+    total_congestion = same_group_congestion + foreign_congestion
+    same_group_share = same_group_congestion / total_congestion if total_congestion else 0.0
+    blocking_share = len(same_group_blockers) / len(blockers) if blockers else 0.0
+    if same_group_share >= SELF_CROSS_THRESHOLD or blocking_share >= SELF_CROSS_THRESHOLD:
+        return TOPOLOGY_SELF_CROSSING
+    return TOPOLOGY_FOREIGN_CLUSTER
+
+
+def _build_recommendation(
+    *,
+    classification: StuckClass,
+    topology: str,
+    match_group: str,
+    confidence: Confidence,
+) -> list[RankedAction]:
+    """Rank the fix ladder for one stuck net (issue #4261 Defect 3).
+
+    Policy table keyed on ``(stuck_class x topology)`` -- see the architect
+    design on #4261.  A recommendation is emitted only for PLACEMENT_BOUND and
+    CONGESTION_SATURATED; every other class returns ``[]``.
+
+    Board-07 hard evidence: for PLACEMENT_BOUND + SELF_CROSSING_BUNDLE,
+    ``WIDEN_CHANNEL`` is DELIBERATELY OMITTED -- widening the U1/U2 channel
+    regressed that board 28->27/31, so the engine must never suggest the move
+    known to backfire on a reversed bundle.
+    """
+    grp = match_group or "the bundle"
+
+    if classification is StuckClass.PLACEMENT_BOUND:
+        if topology == TOPOLOGY_SELF_CROSSING:
+            # NOTE: WIDEN_CHANNEL intentionally absent (regresses a reversed bus).
+            return [
+                RankedAction(
+                    RecommendedAction.DE_REVERSE_BUNDLE,
+                    f"the {grp} bus is reversed at the facing part -- co-orient "
+                    f"(flip/re-order) its pad column so the bundle stops "
+                    f"self-crossing",
+                    confidence,
+                ),
+                RankedAction(
+                    RecommendedAction.REORDER_PINS,
+                    "re-order pins to un-cross the byte",
+                    confidence,
+                ),
+                RankedAction(
+                    RecommendedAction.ACCEPT_PLATEAU,
+                    "topological limit; do NOT widen the channel -- widening "
+                    "regressed board-07 28->27/31",
+                    confidence,
+                ),
+            ]
+        return [
+            RankedAction(
+                RecommendedAction.MOVE_PART,
+                "genuinely foreign copper walls the pad -- relocate the crowded part",
+                confidence,
+            ),
+            RankedAction(
+                RecommendedAction.WIDEN_CHANNEL,
+                "open the routing corridor around the pad",
+                confidence,
+            ),
+            RankedAction(
+                RecommendedAction.ACCEPT_PLATEAU,
+                "if no placement lever helps, this is a plateau",
+                confidence,
+            ),
+        ]
+
+    if classification is StuckClass.CONGESTION_SATURATED:
+        if topology == TOPOLOGY_SELF_CROSSING:
+            return [
+                RankedAction(
+                    RecommendedAction.REORDER_PINS,
+                    f"{grp} siblings box each other in a 1:1 trade -- re-order "
+                    f"pins to remove the trade",
+                    confidence,
+                ),
+                RankedAction(
+                    RecommendedAction.DE_REVERSE_BUNDLE,
+                    f"co-orient the {grp} bundle so siblings stop crossing",
+                    confidence,
+                ),
+            ]
+        return [
+            RankedAction(
+                RecommendedAction.WIDEN_CHANNEL,
+                "foreign strict blocker -- widen the corridor (region "
+                "rip-up-and-reroute is the primary existing remedy)",
+                confidence,
+            ),
+        ]
+
+    return []
 
 
 def _decide(

--- a/src/kicad_tools/router/stuck_classifier.py
+++ b/src/kicad_tools/router/stuck_classifier.py
@@ -125,6 +125,20 @@ DEFAULT_CONGESTION_THRESHOLD = 6
 # at 2-15, so 20 lands in the natural gap between the two populations.
 DEFAULT_DENSE_CLUSTER_THRESHOLD = 20
 
+# --- match-group topology (issue #4261 Defect 2 & 3) ------------------------
+#
+# A stuck net is flagged SELF_CROSSING_BUNDLE when the copper crowding its
+# stranded pad is predominantly its OWN length-match-group siblings (a reversed
+# / self-crossing bus), rather than genuinely foreign copper.  The share is the
+# fraction of same-group obstruction copper (or the fraction of same-group
+# strict blockers) around the pad; at or above this threshold the topology is
+# self-crossing.  0.5 == "the majority of what boxes the pad in is its own bus".
+SELF_CROSS_THRESHOLD = 0.5
+
+# Topology labels attached to a diagnosis (empty string == not applicable).
+TOPOLOGY_SELF_CROSSING = "self_crossing_bundle"
+TOPOLOGY_FOREIGN_CLUSTER = "foreign_cluster"
+
 
 class StuckClass(Enum):
     """Why an unfinished signal net is stuck.
@@ -198,6 +212,18 @@ class StuckNetDiagnosis:
     escape_lane_deg: float = 0.0
     local_congestion: int = 0
     nearest_blocker_mm: float | None = None
+    # Defect 2 (#4261): the local-congestion count split by match-group identity.
+    # ``same_group_congestion`` counts obstruction copper belonging to the target
+    # net's own length-match group (e.g. its DDR data-byte siblings); the rest is
+    # genuinely ``foreign_congestion``.  ``same_group_congestion +
+    # foreign_congestion == local_congestion``.
+    same_group_congestion: int = 0
+    foreign_congestion: int = 0
+    # Name of the target net's inferred match group ("" when it belongs to none).
+    match_group: str = ""
+    # Subset of ``blocking_nets`` that are members of ``match_group`` -- these are
+    # the net's own siblings, NOT foreign copper (Defect 2 relabel).
+    same_group_blockers: list[str] = field(default_factory=list)
 
     @property
     def classification_value(self) -> str:
@@ -217,6 +243,9 @@ class StuckNetDiagnosis:
             "nearest_blocker_mm": (
                 round(self.nearest_blocker_mm, 4) if self.nearest_blocker_mm is not None else None
             ),
+            "same_group_congestion": self.same_group_congestion,
+            "foreign_congestion": self.foreign_congestion,
+            "match_group": self.match_group,
         }
 
     def one_line(self) -> str:
@@ -375,24 +404,28 @@ def _foreign_obstructions(
     target_net: int,
     point: tuple[float, float],
     radius_mm: float,
-) -> list[tuple[float, float, float]]:
+) -> list[tuple[float, float, float, int]]:
     """Foreign obstructions within *radius_mm* of *point*.
 
-    Returns a list of ``(x, y, dist)`` for foreign-net pad centres and foreign
-    copper segment closest-points near *point*.  Used both for escape-sector
-    analysis and for the local-congestion count.  "Foreign" == any net other
-    than *target_net* (net 0 / unassigned copper counts as an obstruction too,
-    since it still occupies the lane).
+    Returns a list of ``(x, y, dist, obstruction_net_number)`` for foreign-net
+    pad centres and foreign copper segment closest-points near *point*.  Used
+    both for escape-sector analysis and for the local-congestion count.
+    "Foreign" == any net other than *target_net* (net 0 / unassigned copper
+    counts as an obstruction too, since it still occupies the lane).
+
+    The trailing ``obstruction_net_number`` is carried so callers can split the
+    congestion count into same-match-group vs genuinely-foreign copper (issue
+    #4261 Defect 2).  ``_widest_open_arc`` ignores the field.
     """
     px, py = point
-    obstructions: list[tuple[float, float, float]] = []
+    obstructions: list[tuple[float, float, float, int]] = []
 
     for net_number, (bx, by), _size in _iter_board_pads(pcb):
         if net_number == target_net:
             continue
         d = math.hypot(bx - px, by - py)
         if d <= radius_mm:
-            obstructions.append((bx, by, d))
+            obstructions.append((bx, by, d, net_number))
 
     for seg in pcb.segments:
         if seg.net_number == target_net:
@@ -405,7 +438,7 @@ def _foreign_obstructions(
             # is the true point-to-segment distance.
             mx = (ax + ex) / 2.0
             my = (ay + ey) / 2.0
-            obstructions.append((mx, my, d))
+            obstructions.append((mx, my, d, seg.net_number))
 
     for via in pcb.vias:
         if via.net_number == target_net:
@@ -413,13 +446,13 @@ def _foreign_obstructions(
         vx, vy = via.position
         d = math.hypot(vx - px, vy - py)
         if d <= radius_mm:
-            obstructions.append((vx, vy, d))
+            obstructions.append((vx, vy, d, via.net_number))
 
     return obstructions
 
 
 def _widest_open_arc(
-    obstructions: list[tuple[float, float, float]],
+    obstructions: list[tuple[float, float, float, int]],
     point: tuple[float, float],
     sectors: int,
     escape_clearance_mm: float,
@@ -436,7 +469,7 @@ def _widest_open_arc(
     """
     px, py = point
     blocked = [False] * sectors
-    for ox, oy, d in obstructions:
+    for ox, oy, d, _net in obstructions:
         if d > escape_clearance_mm:
             continue
         ang = math.atan2(oy - py, ox - px)
@@ -458,6 +491,39 @@ def _widest_open_arc(
             run += 1
             best = max(best, run)
     return min(best, sectors)
+
+
+def _resolve_match_groups(
+    pcb: PCB,
+) -> tuple[dict[int, str], dict[str, set[int]]]:
+    """Infer length-match groups from a bare PCB (issue #4261 Defect 2 & 3).
+
+    Returns ``(net_number -> group_name, group_name -> {member net_numbers})``.
+
+    Uses the in-tree suffix-inference detector
+    (:func:`kicad_tools.router.match_group_detection.detect_match_groups` with
+    ``enable_suffix_inference=True``): board-07's ``DQ\\d+`` nets group as
+    ``DDR_DATA``, TMDS lanes as ``HDMI_TMDS_DATA``, etc.  Explicit
+    ``NetClassRouting`` groups are NOT available here (a raw ``.kicad_pcb`` has
+    no router config), so this is a MEDIUM-confidence signal by construction --
+    see the confidence grading in :func:`_grade_confidence`.
+    """
+    from kicad_tools.router.match_group_detection import detect_match_groups
+
+    net_names = {nid: net.name for nid, net in pcb.nets.items() if net.name}
+    groups = detect_match_groups(net_names, enable_suffix_inference=True)
+
+    net_to_group: dict[int, str] = {}
+    group_members: dict[str, set[int]] = {}
+    for group in groups:
+        members = set(group.net_ids)
+        for p_id, n_id in group.pair_ids:
+            members.add(p_id)
+            members.add(n_id)
+        group_members[group.name] = members
+        for member in members:
+            net_to_group[member] = group.name
+    return net_to_group, group_members
 
 
 def classify_stuck_nets_from_pcb(
@@ -495,6 +561,11 @@ def classify_stuck_nets_from_pcb(
 
     # Map net name -> net number for richer output.
     number_by_name = {net.name: nid for nid, net in pcb.nets.items() if net.name}
+
+    # Match-group membership (issue #4261 Defect 2 & 3): resolve once per board.
+    # Feeds BOTH the same-group-vs-foreign congestion split and the self-crossing
+    # topology detection that drives the fix recommendation.
+    net_to_group, group_members = _resolve_match_groups(pcb)
 
     # Pour-carried incomplete nets: connectivity is expected to be closed by
     # copper fill (zone/pour), so a signal-geometry analysis would misclassify
@@ -548,11 +619,23 @@ def classify_stuck_nets_from_pcb(
         )
 
         # 3) Local congestion = densest foreign-obstruction count over the
-        #    stranded pads (wider radius than the escape ring).
+        #    stranded pads (wider radius than the escape ring).  Defect 2
+        #    (#4261): at the densest pad, split the count by match-group
+        #    identity so same-bundle siblings are not mislabelled "foreign".
+        target_group = net_to_group.get(net_number, "")
+        group_ids = group_members.get(target_group, set())
         local_congestion = 0
+        same_group_congestion = 0
+        foreign_congestion = 0
         for pt in pad_points:
             obstr = _foreign_obstructions(pcb, net_number, pt, congestion_radius_mm)
-            local_congestion = max(local_congestion, len(obstr))
+            if len(obstr) >= local_congestion:
+                local_congestion = len(obstr)
+                same_group_congestion = sum(1 for o in obstr if o[3] in group_ids)
+                foreign_congestion = local_congestion - same_group_congestion
+
+        # Which ranked strict blockers are the net's OWN match-group siblings.
+        same_group_blockers = [b for b in blockers if number_by_name.get(b) in group_ids]
 
         # nearest blocker distance for evidence
         nearest_blocker_mm = _nearest_blocker_distance(
@@ -569,7 +652,13 @@ def classify_stuck_nets_from_pcb(
             nearest_blocker_mm=nearest_blocker_mm,
             congestion_threshold=congestion_threshold,
             dense_cluster_threshold=dense_cluster_threshold,
+            same_group_congestion=same_group_congestion,
+            foreign_congestion=foreign_congestion,
         )
+        # Attach match-group identity (Defect 2): same-group vs foreign split and
+        # which blockers are the net's own bundle siblings.
+        diag.match_group = target_group
+        diag.same_group_blockers = same_group_blockers
         diagnoses.append(diag)
 
     # Second pass: pour-carried incomplete nets.  Their connectivity is closed
@@ -643,6 +732,8 @@ def _decide(
     nearest_blocker_mm: float | None,
     congestion_threshold: int,
     dense_cluster_threshold: int,
+    same_group_congestion: int = 0,
+    foreign_congestion: int = 0,
 ) -> StuckNetDiagnosis:
     """Apply the decision tree to one net's diagnostics.
 
@@ -699,6 +790,8 @@ def _decide(
             escape_lane_deg=open_deg,
             local_congestion=local_congestion,
             nearest_blocker_mm=nearest_blocker_mm,
+            same_group_congestion=same_group_congestion,
+            foreign_congestion=foreign_congestion,
         )
 
     if local_congestion >= dense_cluster_threshold:
@@ -709,9 +802,9 @@ def _decide(
         )
         evidence = (
             f"pad reachable ({open_deg:.0f} deg lane) but in a dense cluster "
-            f"({local_congestion} foreign obstructions, {nb}); ripping the few "
-            f"strict blockers cannot clear the surrounding copper -- a part "
-            f"must move"
+            f"({same_group_congestion} same-group + {foreign_congestion} foreign "
+            f"obstructions, {nb}); ripping the few strict blockers cannot clear "
+            f"the surrounding copper"
         )
         return StuckNetDiagnosis(
             net_name=net_name,
@@ -723,6 +816,8 @@ def _decide(
             escape_lane_deg=open_deg,
             local_congestion=local_congestion,
             nearest_blocker_mm=nearest_blocker_mm,
+            same_group_congestion=same_group_congestion,
+            foreign_congestion=foreign_congestion,
         )
 
     if blockers:
@@ -742,6 +837,8 @@ def _decide(
             escape_lane_deg=open_deg,
             local_congestion=local_congestion,
             nearest_blocker_mm=nearest_blocker_mm,
+            same_group_congestion=same_group_congestion,
+            foreign_congestion=foreign_congestion,
         )
 
     nb = (
@@ -774,12 +871,15 @@ def _decide(
             escape_lane_deg=open_deg,
             local_congestion=local_congestion,
             nearest_blocker_mm=nearest_blocker_mm,
+            same_group_congestion=same_group_congestion,
+            foreign_congestion=foreign_congestion,
         )
 
     evidence = (
         f"pad reachable ({open_deg:.0f} deg lane), no adjacent rippable strict "
-        f"copper ({nb}); moderate local congestion ({local_congestion} foreign "
-        f"obstructions) -- ripping cannot help, a part must move"
+        f"copper ({nb}); moderate local congestion ({same_group_congestion} "
+        f"same-group + {foreign_congestion} foreign obstructions) -- ripping "
+        f"cannot help, a part must move"
     )
     return StuckNetDiagnosis(
         net_name=net_name,
@@ -791,6 +891,8 @@ def _decide(
         escape_lane_deg=open_deg,
         local_congestion=local_congestion,
         nearest_blocker_mm=nearest_blocker_mm,
+        same_group_congestion=same_group_congestion,
+        foreign_congestion=foreign_congestion,
     )
 
 

--- a/tests/router/test_stuck_classifier.py
+++ b/tests/router/test_stuck_classifier.py
@@ -228,6 +228,49 @@ def _placement_bound_board() -> str:
     return body
 
 
+# --- DENSE CLUSTER (Defect 1 negative test) ---------------------------------
+# An all-digital dense cluster: a stranded pad surrounded by >= 20 foreign
+# single-pad nets (dense-cluster PLACEMENT_BOUND) with an open escape gap.  No
+# net on this board carries any analog/codec signal, so the classifier must not
+# emit the old hardcoded "(analog/codec cluster)" parenthetical (issue #4261
+# Defect 1).
+
+
+def _dense_cluster_board() -> str:
+    body = (
+        _HEADER
+        + (
+            '  (net 0 "")\n'
+            '  (net 1 "TGT")\n'
+            # TGT island
+            '  (footprint "R_0402" (layer "F.Cu") (at 10 10)\n'
+            '    (property "Reference" "R1")\n'
+            '    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "TGT"))\n'
+            '    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "TGT"))\n'
+            "  )\n"
+            # stranded TGT pad in a very busy neighbourhood
+            '  (footprint "U_SOT" (layer "F.Cu") (at 80 80)\n'
+            '    (property "Reference" "U1")\n'
+            '    (pad "1" smd circle (at 0 0) (size 0.2 0.2) (layers "F.Cu") (net 1 "TGT"))\n'
+            "  )\n"
+            # 24 foreign single-pad nets at 1.5mm packing the congestion radius
+            # (dense, >= dense_cluster_threshold=20), leaving a small open arc so
+            # the pad still escapes.
+            + _placement_bound_ring(80, 80, 1.5, count=24, gap=2)
+            + '  (segment (start 9.5 10) (end 10.5 10) (width 0.25) (layer "F.Cu") (net 1))\n'
+            ")\n"
+        )
+    )
+    return body
+
+
+@pytest.fixture
+def dense_cluster_pcb(tmp_path: Path) -> Path:
+    p = tmp_path / "dense.kicad_pcb"
+    p.write_text(_dense_cluster_board())
+    return p
+
+
 @pytest.fixture
 def escape_blocked_pcb(tmp_path: Path) -> Path:
     p = tmp_path / "escape.kicad_pcb"
@@ -303,6 +346,19 @@ class TestPlacementBound:
         assert 6 <= d.local_congestion < 20
         assert d.escape_lane_deg >= 45.0
         assert "a part must move" in d.evidence
+
+
+class TestDefect1NoAnalogCodecString:
+    def test_dense_cluster_evidence_has_no_analog_codec(self, dense_cluster_pcb: Path):
+        """Defect 1 (#4261): the dense-cluster PLACEMENT_BOUND branch must NOT
+        append the hardcoded "(analog/codec cluster)" parenthetical.  This board
+        is all-digital, so an analog cause is factually wrong."""
+        result = classify_stuck_nets(dense_cluster_pcb)
+        tgt = next(d for d in result.diagnoses if d.net_name == "TGT")
+        assert tgt.classification is StuckClass.PLACEMENT_BOUND
+        assert tgt.local_congestion >= 20
+        assert "analog" not in tgt.evidence.lower()
+        assert "codec" not in tgt.evidence.lower()
 
 
 class TestBudgetStarved:

--- a/tests/router/test_stuck_classifier.py
+++ b/tests/router/test_stuck_classifier.py
@@ -19,6 +19,8 @@ from pathlib import Path
 import pytest
 
 from kicad_tools.router.stuck_classifier import (
+    Confidence,
+    RecommendedAction,
     StuckClass,
     classify_stuck_nets,
 )
@@ -271,6 +273,86 @@ def dense_cluster_pcb(tmp_path: Path) -> Path:
     return p
 
 
+# --- REVERSED BUNDLE (Defect 2 + 3 self-crossing path) ----------------------
+# DQ0/DQ1/DQ2 form a DDR_DATA match group (suffix inference). The stranded DQ2
+# pad is crowded by a dense ring of its OWN DDR siblings' copper (DQ0 pads) plus
+# a strict DQ1 blocker -- a self-crossing/reversed bundle. The classifier must
+# label the crowding copper as same-group (NOT foreign) and recommend
+# de-reversal / re-order OVER a channel-widen (which never appears here).
+
+
+def _same_group_ring(cx: float, cy: float, radius: float, count: int, gap: int) -> str:
+    """`count` DQ0 pads around (cx, cy) -- same-match-group siblings of DQ2.
+
+    All pads share net 2 (DQ0) so they are DDR_DATA siblings of the stranded
+    DQ2 pad, not foreign copper. Placed at *radius* mm (outside the 1.0mm escape
+    ring, inside the 2.0mm congestion ring) with an angular gap so the pad still
+    escapes.
+    """
+    import math
+
+    out = []
+    slots = count + gap
+    for i in range(count):
+        ang = 2 * math.pi * i / slots
+        px = cx + radius * math.cos(ang)
+        py = cy + radius * math.sin(ang)
+        out.append(
+            f'  (footprint "dq0_{i}" (layer "F.Cu") (at {px:.4f} {py:.4f})\n'
+            f'    (property "Reference" "S{i}")\n'
+            f'    (pad "1" smd circle (at 0 0) (size 0.2 0.2) '
+            f'(layers "F.Cu") (net 2 "DQ0"))\n'
+            f"  )\n"
+        )
+    return "".join(out)
+
+
+def _reversed_bundle_board() -> str:
+    body = (
+        _HEADER
+        + (
+            '  (net 0 "")\n'
+            '  (net 1 "DQ2")\n'
+            '  (net 2 "DQ0")\n'
+            '  (net 3 "DQ1")\n'
+            # DQ2 island (routed) far from the stranded pad
+            '  (footprint "R_0402" (layer "F.Cu") (at 10 10)\n'
+            '    (property "Reference" "R1")\n'
+            '    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "DQ2"))\n'
+            '    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "DQ2"))\n'
+            "  )\n"
+            # stranded DQ2 pad, surrounded by DDR siblings
+            '  (footprint "U_SOT" (layer "F.Cu") (at 80 80)\n'
+            '    (property "Reference" "U1")\n'
+            '    (pad "1" smd circle (at 0 0) (size 0.2 0.2) (layers "F.Cu") (net 1 "DQ2"))\n'
+            "  )\n"
+            # 22 same-group (DQ0) obstruction pads -> dense, all same-match-group
+            + _same_group_ring(80, 80, 1.5, count=22, gap=2)
+            # DQ1: a complete (strict) 2-pad DDR sibling whose committed copper
+            # passes ~0.2mm from the stranded DQ2 pad -> a same-group strict blocker.
+            + '  (footprint "R_0402" (layer "F.Cu") (at 78 80.2)\n'
+            '    (property "Reference" "R2")\n'
+            '    (pad "1" smd rect (at 0 0) (size 0.3 0.3) (layers "F.Cu") (net 3 "DQ1"))\n'
+            "  )\n"
+            '  (footprint "R_0402" (layer "F.Cu") (at 82 80.2)\n'
+            '    (property "Reference" "R3")\n'
+            '    (pad "1" smd rect (at 0 0) (size 0.3 0.3) (layers "F.Cu") (net 3 "DQ1"))\n'
+            "  )\n"
+            + '  (segment (start 9.5 10) (end 10.5 10) (width 0.25) (layer "F.Cu") (net 1))\n'
+            + '  (segment (start 78 80.2) (end 82 80.2) (width 0.25) (layer "F.Cu") (net 3))\n'
+            ")\n"
+        )
+    )
+    return body
+
+
+@pytest.fixture
+def reversed_bundle_pcb(tmp_path: Path) -> Path:
+    p = tmp_path / "reversed.kicad_pcb"
+    p.write_text(_reversed_bundle_board())
+    return p
+
+
 @pytest.fixture
 def escape_blocked_pcb(tmp_path: Path) -> Path:
     p = tmp_path / "escape.kicad_pcb"
@@ -359,6 +441,73 @@ class TestDefect1NoAnalogCodecString:
         assert tgt.local_congestion >= 20
         assert "analog" not in tgt.evidence.lower()
         assert "codec" not in tgt.evidence.lower()
+
+
+class TestReversedBundleSelfCrossing:
+    """Defect 2 + 3 (#4261): a stuck net crowded by its OWN match-group siblings
+    is a self-crossing/reversed bundle -- same-group copper must NOT be called
+    'foreign', and the fix ladder must recommend de-reversal / re-order and
+    NEVER a channel-widen (which regresses a reversed bus)."""
+
+    def test_self_crossing_topology_and_recommendation(self, reversed_bundle_pcb: Path):
+        result = classify_stuck_nets(reversed_bundle_pcb)
+        d = next(x for x in result.diagnoses if x.net_name == "DQ2")
+
+        assert d.classification is StuckClass.PLACEMENT_BOUND
+        assert d.topology == "self_crossing_bundle"
+        assert d.match_group == "DDR_DATA"
+
+        # Defect 2: the surrounding copper is same-group, not foreign.
+        assert d.same_group_congestion >= 3
+        assert d.same_group_congestion > d.foreign_congestion
+        # The strict blocker is a named DDR sibling, flagged as same-group.
+        assert "DQ1" in d.same_group_blockers
+
+        # Defect 3: ranked ladder de-reverses/re-orders, WIDEN_CHANNEL omitted.
+        actions = [a.action for a in d.recommendation]
+        assert actions[0] is RecommendedAction.DE_REVERSE_BUNDLE
+        assert RecommendedAction.REORDER_PINS in actions
+        assert RecommendedAction.WIDEN_CHANNEL not in actions
+        # suffix-inferred group with no crossing proxy -> MEDIUM.
+        assert d.recommendation[0].confidence is Confidence.MEDIUM
+
+        # Defect 1: no analog/codec claim on this all-digital board.
+        assert "analog" not in d.evidence.lower()
+        assert "codec" not in d.evidence.lower()
+
+    def test_json_serializes_recommendation(self, reversed_bundle_pcb: Path):
+        result = classify_stuck_nets(reversed_bundle_pcb)
+        d = next(x for x in result.diagnoses if x.net_name == "DQ2")
+        data = d.to_dict()
+        assert data["topology"] == "self_crossing_bundle"
+        assert data["match_group"] == "DDR_DATA"
+        assert data["same_group_congestion"] >= 3
+        rec = data["recommendation"]
+        assert rec[0]["action"] == "de_reverse_bundle"
+        assert rec[0]["confidence"] == "medium"
+        assert all(a["action"] != "widen_channel" for a in rec)
+
+
+class TestGenuinelyForeignCluster:
+    """Defect 3 (#4261): a stuck net surrounded by UNRELATED foreign nets (no
+    same-suffix siblings) is a foreign cluster -- recommend MOVE_PART, never a
+    de-reversal, and same_group_congestion must be 0."""
+
+    def test_foreign_cluster_topology_and_recommendation(self, dense_cluster_pcb: Path):
+        result = classify_stuck_nets(dense_cluster_pcb)
+        d = next(x for x in result.diagnoses if x.net_name == "TGT")
+
+        assert d.classification is StuckClass.PLACEMENT_BOUND
+        assert d.topology == "foreign_cluster"
+        # No siblings -> nothing same-group.
+        assert d.same_group_congestion == 0
+        assert d.foreign_congestion >= 20
+        assert d.match_group == ""
+
+        actions = [a.action for a in d.recommendation]
+        assert actions[0] is RecommendedAction.MOVE_PART
+        assert RecommendedAction.WIDEN_CHANNEL in actions
+        assert RecommendedAction.DE_REVERSE_BUNDLE not in actions
 
 
 class TestBudgetStarved:


### PR DESCRIPTION
Closes #4261

Fixes three defects in `kct net-status --why` (`stuck_classifier.py`) where the stuck-net diagnostic reported the end state but misattributed the cause and offered no treatment plan. Built as one PR in three commits per the architect design on the issue.

## Defect 1 — wrong hardcoded cause string
The dense-cluster `PLACEMENT_BOUND` branch appended the literal `"(analog/codec cluster)"` to every verdict (a chorus `AUDIO_R` docstring leftover). Removed unconditionally — the classifier has no analog-vs-digital signal to key it on. On the all-digital board-07 fixture this was factually wrong.

## Defect 2 — same-bundle copper mislabelled "foreign"
`_foreign_obstructions` discarded per-obstruction net identity, so `local_congestion` was a bare count and "24 foreign obstructions" could not distinguish same-match-group siblings from foreign copper. Now:
- the obstruction tuple carries `net_number`;
- match-group membership is resolved once per board from the bare PCB via `detect_match_groups(..., enable_suffix_inference=True)` (`DQ\d+` → `DDR_DATA`);
- congestion is split into `same_group_congestion` vs `foreign_congestion`, the dense/moderate evidence is relabelled "N same-group + M foreign obstructions", and the `--why` blocking-nets line names which blockers are the net's own siblings.

## Defect 3 — ranked fix recommendation (read-only, additive)
New closed enum `RecommendedAction {DE_REVERSE_BUNDLE, REORDER_PINS, WIDEN_CHANNEL, MOVE_PART, ACCEPT_PLATEAU}`, ranked by (stuck_class × topology). Topology `self_crossing_bundle` fires when the same-group congestion share OR the same-group strict-blocker share ≥ 0.5 (|group| ≥ 3); otherwise `foreign_cluster`. Three confidence grades; a bare `.kicad_pcb` yields suffix-inferred groups only, so board-07 lands at **MEDIUM** (HIGH reserved for an explicit source / crossing proxy a future config-threaded caller could supply).

**For `PLACEMENT_BOUND + self_crossing_bundle`, `WIDEN_CHANNEL` is deliberately omitted** — board-07's own log (`generate_design.py:1494`) records widening the U1/U2 channel regressing 28→27/31, so the engine never suggests the move known to backfire on a reversed bus. Foreign clusters get `MOVE_PART → WIDEN_CHANNEL → ACCEPT_PLATEAU` instead.

Rendered additively: a `recommendation:` block in text `--why` and structured `topology` + `recommendation` fields in `--format json`. All existing JSON keys unchanged except the Defect-2 evidence relabel.

### Scope discipline
Pure classification: **never** moves a part, edits the board, re-pours, or triggers a route. `DE_REVERSE_BUNDLE` / `REORDER_PINS` are advice to the human/agent — no mutation entry points added. The other four classification branches (ESCAPE_BLOCKED / CONGESTION_SATURATED / BUDGET_STARVED / the moderate PLACEMENT_BOUND) keep their behaviour; evidence is enriched, not re-classified.

## New board-07 DQ3 `--why` output (all 3 defects fixed)
```
[PLACEMENT_BOUND] DQ3
  unconnected pads: U2.4
  blocking nets:    DQ2, DM0, DQS_P        (same match-group DDR_DATA: DQ2)
  evidence:         pad reachable (360 deg lane) but in a dense cluster (13 same-group + 11 foreign obstructions, nearest strict blocker 0.800mm); ripping the few strict blockers cannot clear the surrounding copper
  recommendation:   [MEDIUM] self-crossing DDR_DATA bundle
                    1. de-reverse the bundle (the DDR_DATA bus is reversed at the facing part -- co-orient (flip/re-order) its pad column so the bundle stops self-crossing)  [preferred]
                    2. re-order pins (re-order pins to un-cross the byte)
                    3. accept plateau (topological limit; do NOT widen the channel -- widening regressed board-07 28->27/31)
```
No `analog/codec` (Defect 1); DDR-sibling blocker `DQ2` labelled same-group and evidence split 13 same-group + 11 foreign (Defect 2); de-reversal ranked above accept-plateau with `WIDEN_CHANNEL` omitted (Defect 3). DQ4 behaves identically; the MIPI net (no suffix group) correctly falls to `foreign_cluster → MOVE_PART`, and the TMDS `CONGESTION_SATURATED` nets get the self-crossing congestion ladder — confirming the two paths distinguish.

## Tests
- Reversed-bundle fixture (blockers same-match-group) → `self_crossing_bundle`, first action `DE_REVERSE_BUNDLE`, `WIDEN_CHANNEL` absent, same-group sibling named, no analog/codec, JSON serialises.
- Genuinely-foreign fixture → `foreign_cluster`, first action `MOVE_PART`, `same_group_congestion == 0`.
- Defect-1 negative test on an all-digital dense cluster.
- `pnpm check:ci` inputs green (ruff format + ruff check); changed source files mypy-clean (types narrowed explicitly, no baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
