### PR TITLE
feat(route): analytical --dry-run grid/cell/budget plan (no grid alloc, cannot OOM)

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -7862,6 +7862,237 @@ def _offboard_preflight(pcb_path: Path) -> int:
     return 2
 
 
+# ---------------------------------------------------------------------------
+# Issue #4263: analytical --dry-run grid/cell/budget plan.
+#
+# A plain ``route --dry-run`` used to *construct* the full RoutingGrid (inside
+# ``load_pcb_for_routing``) before it could report anything, so on a large
+# board it ran >45s and got OOM-killed -- exactly when the user is trying to
+# discover whether the board even fits the budget.  These helpers compute the
+# same plan the user wants (selected grid, cell count, memory estimate, budget
+# verdict, finer/coarser lattice candidates) using pure selection arithmetic
+# (``auto_select_grid_resolution`` + ``estimate_memory_bytes``), allocating NO
+# grid, so the answer returns in well under a second regardless of board size.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DryRunGridCandidate:
+    """One lattice-aligned candidate grid in the analytical dry-run plan.
+
+    All fields are derived analytically -- no RoutingGrid is allocated.
+    """
+
+    resolution: float
+    cols: int
+    rows: int
+    cells: int
+    est_memory_bytes: int
+    fits: bool
+    off_grid_pads: int
+
+
+@dataclass
+class DryRunGridPlan:
+    """Analytical grid/cell/budget plan for ``route --dry-run`` (issue #4263).
+
+    Every field is computed from board dimensions + pad positions + the
+    grid-selection arithmetic, without constructing a ``RoutingGrid``.
+    """
+
+    board_width: float
+    board_height: float
+    resolution: float
+    num_layers: int
+    cols: int
+    rows: int
+    cells: int
+    est_memory_bytes: int
+    max_cells: int
+    fits: bool
+    auto_resolution: float
+    grid_explicit: bool
+    memory_capped: bool
+    memory_forced_unsafe_grid: bool
+    candidates: list[DryRunGridCandidate]
+
+
+def _grid_dims_for(width: float, height: float, resolution: float) -> tuple[int, int]:
+    """Canonical grid dimensions for a board (``grid.py:739-740`` formula).
+
+    ``cols = int(width / res) + 1``, ``rows = int(height / res) + 1``.  Kept
+    in one place so the analytical dry-run plan matches the real grid exactly.
+    """
+    cols = int(width / resolution) + 1
+    rows = int(height / resolution) + 1
+    return cols, rows
+
+
+def compute_dry_run_grid_plan(
+    pcb_path: Path,
+    selected_grid: float,
+    clearance: float,
+    num_layers: int,
+    max_cells: int,
+) -> DryRunGridPlan | None:
+    """Compute the analytical grid/cell/budget plan for ``--dry-run``.
+
+    Reuses the allocation-free selection math (``auto_select_grid_resolution``)
+    and the canonical cells/memory formulas.  Constructs **no** RoutingGrid, so
+    it returns in well under a second and cannot OOM on large boards.
+
+    Args:
+        pcb_path: Path to the .kicad_pcb file.
+        selected_grid: The resolved grid resolution in mm (explicit ``--grid``
+            value or the auto-selected float).
+        clearance: Trace clearance in mm (feeds the candidate DRC filter).
+        num_layers: Number of routing layers (``layer_stack.num_layers``).
+        max_cells: Cell budget from ``--max-cells``.
+
+    Returns:
+        A ``DryRunGridPlan``, or ``None`` if the board has no detectable
+        outline (in which case the caller should fall through to the normal
+        load path rather than guess dimensions).
+    """
+    from kicad_tools.acceleration.backend import estimate_memory_bytes
+    from kicad_tools.router.io import (
+        auto_select_grid_resolution,
+        extract_board_dimensions,
+        extract_pad_positions,
+    )
+
+    dims = extract_board_dimensions(pcb_path)
+    if dims is None:
+        return None
+    board_width, board_height = dims
+
+    pads = extract_pad_positions(pcb_path)
+
+    # Pure pad + area arithmetic -- allocates NO grid (io.py:1097).  Used both
+    # for the finer/coarser candidate lattice and to report what "auto" would
+    # pick alongside an explicit --grid.
+    selection = auto_select_grid_resolution(
+        pads=pads,
+        clearance=clearance,
+        board_width=board_width,
+        board_height=board_height,
+        max_cells=max_cells,
+    )
+
+    # Off-grid counts keyed by resolution, from the selector's candidate trials.
+    off_grid_by_res = dict(selection.candidates_tried)
+
+    def _make_candidate(resolution: float) -> DryRunGridCandidate:
+        cols, rows = _grid_dims_for(board_width, board_height, resolution)
+        cells = cols * rows * num_layers
+        return DryRunGridCandidate(
+            resolution=resolution,
+            cols=cols,
+            rows=rows,
+            cells=cells,
+            est_memory_bytes=estimate_memory_bytes(cols, rows, num_layers),
+            fits=cells <= max_cells,
+            off_grid_pads=off_grid_by_res.get(resolution, -1),
+        )
+
+    # Candidate lattice: the canonical PCB grid lattice (io.py:1158) restricted
+    # to DRC-compliant resolutions (``<= clearance``, the selector's own
+    # ``valid_candidates`` filter at io.py:1186), unioned with the selected and
+    # auto-recommended resolutions so the report always brackets the selection
+    # with its finer/coarser neighbours.  The memory filter is intentionally
+    # NOT applied here -- showing coarser grids that *do* fit the budget is the
+    # whole point of the finer/coarser candidate list.
+    canonical_lattice = [0.5, 0.25, 0.127, 0.1, 0.065, 0.05, 0.0508]
+    candidate_set = {res for res in canonical_lattice if res <= clearance}
+    candidate_set.add(selected_grid)
+    candidate_set.add(selection.resolution)
+    candidate_resolutions = sorted(candidate_set, reverse=True)
+    candidates = [_make_candidate(res) for res in candidate_resolutions]
+
+    selected = _make_candidate(selected_grid)
+
+    return DryRunGridPlan(
+        board_width=board_width,
+        board_height=board_height,
+        resolution=selected_grid,
+        num_layers=num_layers,
+        cols=selected.cols,
+        rows=selected.rows,
+        cells=selected.cells,
+        est_memory_bytes=selected.est_memory_bytes,
+        max_cells=max_cells,
+        fits=selected.fits,
+        auto_resolution=selection.resolution,
+        grid_explicit=abs(selected_grid - selection.resolution) > 1e-9,
+        memory_capped=selection.memory_capped,
+        memory_forced_unsafe_grid=selection.memory_forced_unsafe_grid,
+        candidates=candidates,
+    )
+
+
+def format_dry_run_grid_plan(plan: DryRunGridPlan) -> str:
+    """Render a ``DryRunGridPlan`` as the human-readable dry-run report."""
+    bar = "=" * 60
+
+    def _mb(nbytes: int) -> str:
+        return f"{nbytes / 1e6:,.1f} MB"
+
+    verdict = "FITS" if plan.fits else "EXCEEDS"
+    if plan.fits:
+        budget_line = (
+            f"Budget:         max-cells={plan.max_cells:,} -> FITS "
+            f"({plan.max_cells - plan.cells:,} cells to spare)"
+        )
+    else:
+        budget_line = (
+            f"Budget:         max-cells={plan.max_cells:,} -> EXCEEDS "
+            f"by {plan.cells - plan.max_cells:,} cells"
+        )
+
+    if plan.grid_explicit:
+        auto_line = f"Auto would use: {plan.auto_resolution}mm"
+    else:
+        cap = " (memory-capped)" if plan.memory_capped else ""
+        auto_line = f"Grid source:    auto-selected{cap}"
+
+    lines = [
+        bar,
+        "Dry Run - Analytical Grid Plan (no grid allocated)",
+        bar,
+        f"Board:          {plan.board_width:g}mm x {plan.board_height:g}mm",
+        f"Selected grid:  {plan.resolution}mm",
+        f"Grid cells:     {plan.cols:,} x {plan.rows:,} x {plan.num_layers} = {plan.cells:,} cells",
+        f"Est. memory:    {_mb(plan.est_memory_bytes)} (18 bytes/cell)",
+        budget_line,
+        auto_line,
+    ]
+
+    if plan.memory_forced_unsafe_grid:
+        lines.append(
+            "Warning:        memory cap forced a grid coarser than "
+            "clearance/2 (DRC-short risk; see --allow-unsafe-grid)"
+        )
+
+    lines.append("")
+    lines.append("Lattice-aligned candidates (coarse -> fine):")
+    for cand in plan.candidates:
+        marker = " <- selected" if abs(cand.resolution - plan.resolution) <= 1e-9 else ""
+        rel = ""
+        if not marker:
+            rel = "finer " if cand.resolution < plan.resolution else "coarser"
+        tag = "FITS   " if cand.fits else "EXCEEDS"
+        lines.append(
+            f"  {rel:7s} {cand.resolution:<8g}mm  "
+            f"{cand.cols:,} x {cand.rows:,} x {plan.num_layers} = {cand.cells:,} cells  "
+            f"({_mb(cand.est_memory_bytes)})  {tag}{marker}"
+        )
+
+    lines.append(bar)
+    lines.append(f"Verdict: {plan.resolution}mm grid {verdict} the {plan.max_cells:,}-cell budget.")
+    lines.append(bar)
+    return "\n".join(lines)
+
+
 def main(argv: list[str] | None = None) -> int:
     """Main entry point for route command."""
     parser = argparse.ArgumentParser(
@@ -9838,6 +10069,34 @@ def main(argv: list[str] | None = None) -> int:
             print(f"  Signal layers:  {', '.join(signal_layers)}")
             if plane_layers:
                 print(f"  Plane layers:   {', '.join(plane_layers)}")
+
+    # Issue #4263: analytical --dry-run short-circuit.
+    #
+    # A plain ``--dry-run`` only needs the strategy/grid selection verdict, so
+    # report it analytically and return BEFORE ``load_pcb_for_routing`` (which
+    # allocates the full RoutingGrid at route_cmd's load site and, on a large
+    # board, is the >45s / OOM step).  ``args.grid`` is already a float here
+    # (explicit value, or resolved from ``--grid auto`` above) and
+    # ``layer_stack`` is known, so the plan reuses the allocation-free
+    # selection math without touching the router.
+    #
+    # ``--analyze --dry-run`` is intentionally left to the downstream
+    # complexity/routability path (route_cmd:~10183), which needs a loaded
+    # ``router``; only the plain dry run short-circuits here.
+    if args.dry_run and not args.analyze:
+        dry_run_plan = compute_dry_run_grid_plan(
+            pcb_path=pcb_path,
+            selected_grid=args.grid,
+            clearance=args.clearance,
+            num_layers=layer_stack.num_layers,
+            max_cells=getattr(args, "max_cells", 500_000),
+        )
+        if dry_run_plan is not None:
+            if not quiet:
+                print(format_dry_run_grid_plan(dry_run_plan))
+            return 0
+        # No detectable board outline: fall through to the normal load path
+        # rather than guess dimensions (the pre-#4263 dry-run behavior).
 
     # Load PCB
     if not quiet:

--- a/tests/test_route_dry_run_analytical_plan_4263.py
+++ b/tests/test_route_dry_run_analytical_plan_4263.py
@@ -1,0 +1,206 @@
+"""Analytical ``route --dry-run`` grid/cell/budget plan (Issue #4263).
+
+A plain ``route --dry-run`` used to construct the full ``RoutingGrid`` (inside
+``load_pcb_for_routing``) before it could report anything, so on a large board
+it ran >45s and got OOM-killed -- exactly when the user is trying to discover
+whether the board fits the memory budget.  The fix short-circuits ``--dry-run``
+*before* the load and computes the verdict analytically.
+
+These tests pin the two load-bearing guarantees:
+  1. The analytical plan is returned WITHOUT constructing a ``RoutingGrid``
+     (patched-to-explode grid ctor + load path), quickly, and cannot OOM.
+  2. The plan composes with ``--max-cells`` and an explicit ``--grid``.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kicad_tools.cli import route_cmd
+
+
+def _write_large_board(path: Path, width: float = 160.0, height: float = 100.0) -> Path:
+    """Write a 160x100mm board whose fine 0.127mm grid would OOM the dry-run.
+
+    At 0.127mm on a 160x100 board a 4-layer uniform grid is ~4M cells; the
+    pre-#4263 dry-run allocated exactly that before it could print anything.
+    """
+    footprints = []
+    for gx in range(10, int(width) - 5, 15):
+        for gy in range(10, int(height) - 5, 15):
+            pads = "\n".join(
+                f'    (pad "{i + 1}" smd rect (at {-1.905 + i * 1.27:.3f} 0) '
+                f'(size 0.6 1.5) (layers "F.Cu"))'
+                for i in range(4)
+            )
+            footprints.append(f'  (footprint "SOIC" (layer "F.Cu") (at {gx} {gy})\n{pads}\n  )')
+    board = (
+        "(kicad_pcb (version 20221018) (generator test)\n"
+        "  (general (thickness 1.6))\n"
+        '  (layers (0 "F.Cu" signal) (31 "B.Cu" signal) (44 "Edge.Cuts" user))\n'
+        f"  (gr_rect (start 0 0) (end {width:g} {height:g}) "
+        '(layer "Edge.Cuts") (width 0.1))\n' + "\n".join(footprints) + "\n)\n"
+    )
+    path.write_text(board)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# The pure analytical helper.
+# ---------------------------------------------------------------------------
+
+
+def test_compute_plan_is_allocation_free_and_correct(tmp_path):
+    """The plan math matches the canonical cols/rows/cells + 18 bytes/cell."""
+    pcb = _write_large_board(tmp_path / "big.kicad_pcb")
+
+    plan = route_cmd.compute_dry_run_grid_plan(
+        pcb_path=pcb,
+        selected_grid=0.127,
+        clearance=0.15,
+        num_layers=4,
+        max_cells=500_000,
+    )
+    assert plan is not None
+    assert plan.board_width == pytest.approx(160.0)
+    assert plan.board_height == pytest.approx(100.0)
+    # Canonical grid dims: int(w/res)+1, int(h/res)+1 (grid.py:739-740).
+    assert plan.cols == int(160.0 / 0.127) + 1
+    assert plan.rows == int(100.0 / 0.127) + 1
+    assert plan.cells == plan.cols * plan.rows * 4
+    # estimate_memory_bytes == cells * 18 (backend.py:774).
+    assert plan.est_memory_bytes == plan.cols * plan.rows * 4 * 18
+    # ~4M cells against a 500k budget -> exceeds.
+    assert plan.cells > 500_000
+    assert plan.fits is False
+    # Finer/coarser lattice candidates are reported.
+    assert len(plan.candidates) >= 2
+    resolutions = [c.resolution for c in plan.candidates]
+    assert 0.127 in resolutions  # the selected grid brackets the list
+
+
+def test_plan_composes_with_max_cells(tmp_path):
+    """The budget verdict flips when --max-cells is raised past the cell count."""
+    pcb = _write_large_board(tmp_path / "big.kicad_pcb")
+
+    tight = route_cmd.compute_dry_run_grid_plan(
+        pcb_path=pcb, selected_grid=0.127, clearance=0.15, num_layers=4, max_cells=500_000
+    )
+    roomy = route_cmd.compute_dry_run_grid_plan(
+        pcb_path=pcb, selected_grid=0.127, clearance=0.15, num_layers=4, max_cells=5_000_000
+    )
+    assert tight is not None and roomy is not None
+    assert tight.cells == roomy.cells  # same board/grid -> same cell count
+    assert tight.fits is False
+    assert roomy.fits is True
+    assert roomy.max_cells == 5_000_000
+
+
+def test_plan_honors_explicit_grid(tmp_path):
+    """An explicit --grid drives the selected resolution, not the auto pick."""
+    pcb = _write_large_board(tmp_path / "big.kicad_pcb")
+
+    plan = route_cmd.compute_dry_run_grid_plan(
+        pcb_path=pcb, selected_grid=0.1, clearance=0.15, num_layers=2, max_cells=500_000
+    )
+    assert plan is not None
+    assert plan.resolution == 0.1
+    assert plan.num_layers == 2
+    assert plan.cols == int(160.0 / 0.1) + 1
+    # Rendering is stable and mentions the verdict.
+    text = route_cmd.format_dry_run_grid_plan(plan)
+    assert "Analytical Grid Plan" in text
+    assert "0.1mm" in text
+
+
+def test_plan_returns_none_without_board_outline(tmp_path):
+    """No detectable outline -> None so the caller falls through to the load."""
+    pcb = tmp_path / "no_outline.kicad_pcb"
+    pcb.write_text("(kicad_pcb (version 20221018) (generator test))\n")
+    plan = route_cmd.compute_dry_run_grid_plan(
+        pcb_path=pcb, selected_grid=0.127, clearance=0.15, num_layers=4, max_cells=500_000
+    )
+    assert plan is None
+
+
+# ---------------------------------------------------------------------------
+# End-to-end CLI: --dry-run must NOT build the grid.
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_cli_builds_no_grid_and_reports_quickly(tmp_path, capsys):
+    """``route --dry-run`` on a would-OOM board: analytical plan, no grid, fast.
+
+    Both the load path and the ``RoutingGrid`` constructor are patched to
+    explode; reaching either would mean the dry-run tried to allocate the very
+    grid whose feasibility is in question (the OOM #4263 fixes).
+    """
+    pcb = _write_large_board(tmp_path / "big.kicad_pcb")
+
+    def _explode_load(*a, **k):
+        raise AssertionError("load_pcb_for_routing must not run for a plain --dry-run")
+
+    def _explode_grid(*a, **k):
+        raise AssertionError("RoutingGrid must not be constructed for a plain --dry-run")
+
+    with (
+        patch("kicad_tools.router.io.load_pcb_for_routing", side_effect=_explode_load),
+        patch("kicad_tools.router.grid.RoutingGrid.__init__", side_effect=_explode_grid),
+    ):
+        start = time.perf_counter()
+        rc = route_cmd.main(
+            [
+                str(pcb),
+                "--dry-run",
+                "--grid",
+                "0.127",
+                "--layers",
+                "4",
+                "--max-cells",
+                "500000",
+            ]
+        )
+        elapsed = time.perf_counter() - start
+
+    assert rc == 0
+    # No grid allocation means it is near-instant; generous bound for slow CI.
+    assert elapsed < 5.0
+
+    out = capsys.readouterr().out
+    assert "Analytical Grid Plan" in out
+    assert "Selected grid:  0.127mm" in out
+    assert "cells" in out
+    assert "MB" in out
+    assert "EXCEEDS" in out  # ~4M cells vs a 500k budget
+    assert "max-cells=500,000" in out
+
+
+def test_dry_run_cli_fits_verdict(tmp_path, capsys):
+    """A roomy --max-cells yields a FITS verdict via the same analytical path."""
+    pcb = _write_large_board(tmp_path / "big.kicad_pcb")
+
+    with patch(
+        "kicad_tools.router.io.load_pcb_for_routing",
+        side_effect=AssertionError("must not load for --dry-run"),
+    ):
+        rc = route_cmd.main(
+            [
+                str(pcb),
+                "--dry-run",
+                "--grid",
+                "0.127",
+                "--layers",
+                "4",
+                "--max-cells",
+                "5000000",
+            ]
+        )
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "FITS" in out
+    assert "max-cells=5,000,000" in out


### PR DESCRIPTION
## Summary

`route --dry-run` used to construct the full `RoutingGrid` (inside `load_pcb_for_routing`) before it could print anything. On a large board (160x100mm, 4-layer, ~4M cells) that was the >45s / **OOM-killed** step reported in #4242 — exactly when the user is trying to *discover* whether the board fits the memory budget.

This PR makes a plain `--dry-run` short-circuit **before** the load and compute the grid/cell/budget verdict **analytically**, reusing the existing allocation-free selection math. It returns in well under a second regardless of board size and cannot OOM.

## What changed

`src/kicad_tools/cli/route_cmd.py`:
- New pure helpers `compute_dry_run_grid_plan(...)` + `format_dry_run_grid_plan(...)` (and `DryRunGridPlan`/`DryRunGridCandidate` dataclasses). They reuse:
  - `auto_select_grid_resolution` (`io.py:1097`) — candidate lattice + memory flags, allocates no grid.
  - canonical grid dims `cols=int(w/res)+1`, `rows=int(h/res)+1` (`grid.py:739-740`).
  - `estimate_memory_bytes` = cells × 18 (`backend.py:774`).
- An `if args.dry_run and not args.analyze:` short-circuit inserted **after** grid/`layer_stack` resolution and **before** `load_pcb_for_routing`, which prints the plan and returns 0. If the board has no detectable outline it returns `None` and falls through to the old load path.

The plan reports: **selected grid, total cells (cols×rows×layers), estimated memory, budget verdict vs `--max-cells`, and the finer/coarser lattice-aligned candidates.** Composes with `--max-cells` (#4249) and explicit `--grid`.

`--analyze --dry-run` is intentionally left to the downstream complexity/routability path (it needs a loaded `router`, which does not allocate the routing grid).

## Non-dry-run is byte-identical

All new work is gated behind `if args.dry_run and not args.analyze`. When `dry_run` is False the branch is skipped entirely — identical control flow and output. Confirmed by the existing route suites (162 route/exit-code/params/analog/partial tests green) and a same-file mypy baseline (30 pre-existing errors before and after — zero introduced).

## Example (160x100mm board, explicit `--grid 0.127 --layers 4 --max-cells 500000`)

```
============================================================
Dry Run - Analytical Grid Plan (no grid allocated)
============================================================
Board:          160mm x 100mm
Selected grid:  0.127mm
Grid cells:     1,260 x 788 x 4 = 3,971,520 cells
Est. memory:    71.5 MB (18 bytes/cell)
Budget:         max-cells=500,000 -> EXCEEDS by 3,471,520 cells
Grid source:    auto-selected (memory-capped)

Lattice-aligned candidates (coarse -> fine):
          0.127   mm  1,260 x 788 x 4 = 3,971,520 cells  (71.5 MB)  EXCEEDS <- selected
  finer   0.1     mm  1,601 x 1,001 x 4 = 6,410,404 cells  (115.4 MB)  EXCEEDS
  finer   0.065   mm  2,462 x 1,539 x 4 = 15,156,072 cells  (272.8 MB)  EXCEEDS
  finer   0.0508  mm  3,150 x 1,969 x 4 = 24,809,400 cells  (446.6 MB)  EXCEEDS
  finer   0.05    mm  3,201 x 2,001 x 4 = 25,620,804 cells  (461.2 MB)  EXCEEDS
============================================================
Verdict: 0.127mm grid EXCEEDS the 500,000-cell budget.
============================================================
```

Raising `--max-cells 5000000` flips the same board to `FITS (1,028,480 cells to spare)`.

## Tests

`tests/test_route_dry_run_analytical_plan_4263.py` (6 tests):
- The end-to-end CLI test runs `route --dry-run` on a would-OOM 160x100mm board with **both** `load_pcb_for_routing` and `RoutingGrid.__init__` patched to raise — proving **no grid is constructed** — asserts exit 0, <5s wall clock (measures ~0.5s), and the plan fields.
- Pure-helper tests pin the canonical cells/18-bytes math, the `--max-cells` verdict flip, explicit-`--grid` selection, and the no-outline fall-through.

## Acceptance
- [x] Large board returns the analytical plan in <1s, builds NO grid, cannot OOM
- [x] Reports selected grid, cells, est. memory, budget verdict, finer/coarser candidates
- [x] Composes with `--max-cells` and explicit `--grid`
- [x] Non-dry-run routing byte-identical (branch only taken when `args.dry_run`)
- [x] Unit test asserts no `RoutingGrid` is constructed

Closes #4263

🤖 Generated with [Claude Code](https://claude.com/claude-code)