### PR TITLE
mesh-router P1: single-net end-to-end (poly2tri CDT -> navmesh A*+funnel -> clearance-aware 45deg fit -> emission+DRC), --route-engine mesh default OFF

### DIFF
--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -492,6 +492,10 @@ def run_route_command(args) -> int:
         sub_argv.append("--no-cache")
     if getattr(args, "backend", "auto") != "auto":
         sub_argv.extend(["--backend", args.backend])
+    # Issue #4268: forward --route-engine only when non-default so a default
+    # (grid) run stays byte-identical to the pre-mesh sub-invocation.
+    if getattr(args, "route_engine", "grid") != "grid":
+        sub_argv.extend(["--route-engine", args.route_engine])
     # Issue #2589: forward --seed for deterministic runs.  Default is None
     # (router uses os.urandom-derived state, existing behaviour).
     if getattr(args, "seed", None) is not None:

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -3515,6 +3515,20 @@ def _add_route_parser(subparsers) -> None:
         ),
     )
     route_parser.add_argument(
+        "--route-engine",
+        choices=["grid", "mesh"],
+        default="grid",
+        help=(
+            "Routing substrate (issue #4268), orthogonal to --backend and "
+            "--strategy: 'grid' = uniform-grid A* (default, unchanged); "
+            "'mesh' = navmesh single-net router (poly2tri CDT + funnel + "
+            "clearance-aware 45deg fit). Mesh is P1/experimental: single-net "
+            "only, no multi-net negotiation, capacity, vias or matched routing. "
+            "(The name 'strategy' was already taken by the negotiation-algorithm "
+            "flag above, so the substrate selector is --route-engine.)"
+        ),
+    )
+    route_parser.add_argument(
         "--seed",
         type=int,
         default=None,

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -3896,6 +3896,8 @@ def route_with_layer_escalation(
                     edge_clearance=args.edge_clearance,
                     layer_stack=layer_stack,
                     force_python=force_python,
+                    # Issue #4268: thread the mesh-router strategy selector through.
+                    strategy=getattr(args, "route_engine", "grid"),
                     validate_drc=not args.force,
                     strict_drc=False,
                     # Issue #3155: incremental routing.  When set, existing
@@ -4804,6 +4806,8 @@ def route_with_rule_relaxation(
                     edge_clearance=args.edge_clearance,
                     layer_stack=layer_stack,
                     force_python=force_python,
+                    # Issue #4268: thread the mesh-router strategy selector through.
+                    strategy=getattr(args, "route_engine", "grid"),
                     validate_drc=not args.force,
                     strict_drc=False,
                     # Issue #3155: incremental routing (see route_with_layer_escalation).
@@ -6936,6 +6940,8 @@ def route_with_combined_escalation(
                         edge_clearance=args.edge_clearance,
                         layer_stack=layer_stack,
                         force_python=force_python,
+                        # Issue #4268: thread the mesh-router strategy selector through.
+                        strategy=getattr(args, "route_engine", "grid"),
                         validate_drc=not args.force,
                         strict_drc=False,
                         # Issue #3155: incremental routing (see route_with_layer_escalation).
@@ -8728,6 +8734,18 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--route-engine",
+        choices=["grid", "mesh"],
+        default="grid",
+        help=(
+            "Routing substrate (issue #4268), orthogonal to --backend and "
+            "--strategy: 'grid' = uniform-grid A* (default, unchanged); "
+            "'mesh' = navmesh single-net router (poly2tri CDT + funnel + "
+            "clearance-aware 45deg fit). Mesh is P1/experimental: single-net "
+            "only, no multi-net negotiation, capacity, vias or matched routing."
+        ),
+    )
+    parser.add_argument(
         "--no-auto-build-native",
         action="store_true",
         help=(
@@ -10110,6 +10128,8 @@ def main(argv: list[str] | None = None) -> int:
                 edge_clearance=args.edge_clearance,
                 layer_stack=layer_stack,
                 force_python=force_python,
+                # Issue #4268: thread the mesh-router strategy selector through.
+                strategy=getattr(args, "route_engine", "grid"),
                 validate_drc=not args.force,
                 strict_drc=False,  # Only fail on hard constraint (grid > clearance)
                 # Issue #3155: incremental routing (see route_with_layer_escalation).
@@ -10170,6 +10190,8 @@ def main(argv: list[str] | None = None) -> int:
                 edge_clearance=args.edge_clearance,
                 layer_stack=layer_stack,
                 force_python=force_python,
+                # Issue #4268: thread the mesh-router strategy selector through.
+                strategy=getattr(args, "route_engine", "grid"),
                 validate_drc=not args.force,
                 strict_drc=False,
                 load_existing_routes=getattr(args, "preserve_existing", False),

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -894,6 +894,7 @@ class Autorouter:
         record_decisions: bool = False,
         max_search_iterations: int = 0,
         per_net_iterations: int = 0,
+        strategy: str = "grid",
     ):
         """Initialize the autorouter.
 
@@ -1050,6 +1051,22 @@ class Autorouter:
         # witness after a routing pass.  Populated by
         # ``_apply_byte_lane_inner_priority`` whenever the certificate runs.
         self._last_monotone_certificates: dict[str, Any] = {}
+
+        # Issue #4268 (mesh-router P1): routing strategy selector, orthogonal
+        # to ``force_python`` (which picks the GRID engine).  ``"grid"`` (the
+        # default) is byte-identical to the pre-mesh router; ``"mesh"`` routes
+        # each net through the navmesh single-net pathfinder (``route_net``
+        # dispatches to ``_route_net_mesh``).  The board bbox is retained so the
+        # mesh pathfinder can build its outer boundary; the pathfinder itself is
+        # built lazily on first mesh route.
+        self._strategy = strategy
+        self._board_bbox: tuple[float, float, float, float] = (
+            origin_x,
+            origin_y,
+            origin_x + width,
+            origin_y + height,
+        )
+        self._mesh_pathfinder: Any = None
 
         # Initialize grid and routers using shared helper
         # Issue #972: Helper includes adaptive grid resolution for large boards
@@ -2273,6 +2290,39 @@ class Autorouter:
                 tracked_ids.add(id(r))
         return [r for r in self.routes if id(r) not in tracked_ids]
 
+    def _route_net_mesh(self, net: int) -> list[Route]:
+        """Route a net with the mesh strategy (issue #4268, single-net P1).
+
+        Builds (once, lazily) a :class:`~kicad_tools.router.mesh.MeshPathfinder`
+        from the board outline + pads + rules, then routes each connection of
+        the net star-wise from its first pad.  Each successful route is a normal
+        45-legal :class:`Route` committed to ``self.routes`` -- the emission /
+        DRC tail is identical to the grid path.  Multi-net negotiation,
+        capacity, vias and matched routing are explicitly out of P1 scope.
+        """
+        from .mesh.pathfinder import MeshPathfinder
+
+        if self._mesh_pathfinder is None:
+            bx0, by0, bx1, by1 = self._board_bbox
+            outline = [(bx0, by0), (bx1, by0), (bx1, by1), (bx0, by1)]
+            self._mesh_pathfinder = MeshPathfinder(outline, list(self.pads.values()), self.rules)
+
+        pad_keys = self.nets.get(net, [])
+        pads = [self.pads[k] for k in pad_keys if k in self.pads]
+        if len(pads) < 2:
+            return []
+
+        routes: list[Route] = []
+        anchor = pads[0]
+        for other in pads[1:]:
+            if anchor.layer != other.layer:
+                continue  # single-layer P1: skip cross-layer connections
+            route = self._mesh_pathfinder.route(anchor, other)
+            if route is not None and route.segments:
+                self.routes.append(route)
+                routes.append(route)
+        return routes
+
     def route_net(
         self,
         net: int,
@@ -2302,6 +2352,12 @@ class Autorouter:
         Returns:
             List of Route objects for this net
         """
+        # Issue #4268 (mesh-router P1): under ``--strategy mesh`` the net is
+        # routed by the navmesh single-net pathfinder instead of the grid A*.
+        # Default ``"grid"`` skips this branch entirely (byte-identical).
+        if getattr(self, "_strategy", "grid") == "mesh":
+            return self._route_net_mesh(net)
+
         # Issue #4170 (Phase 2b-1): bare boundary stub terminals are an additive
         # source of per-net targets.  A net may have only ONE in-region pad plus
         # a boundary stub (or even zero pads registered here but a stub target),

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -1056,16 +1056,11 @@ class Autorouter:
         # to ``force_python`` (which picks the GRID engine).  ``"grid"`` (the
         # default) is byte-identical to the pre-mesh router; ``"mesh"`` routes
         # each net through the navmesh single-net pathfinder (``route_net``
-        # dispatches to ``_route_net_mesh``).  The board bbox is retained so the
-        # mesh pathfinder can build its outer boundary; the pathfinder itself is
-        # built lazily on first mesh route.
+        # dispatches to ``_route_net_mesh``).  The mesh pathfinder's outer
+        # boundary comes from ``self._board_bbox`` (the edge-cuts bbox when
+        # available, else a grid-derived fallback -- see ``_route_net_mesh``);
+        # the pathfinder itself is built lazily on first mesh route.
         self._strategy = strategy
-        self._board_bbox: tuple[float, float, float, float] = (
-            origin_x,
-            origin_y,
-            origin_x + width,
-            origin_y + height,
-        )
         self._mesh_pathfinder: Any = None
 
         # Initialize grid and routers using shared helper
@@ -2303,7 +2298,19 @@ class Autorouter:
         from .mesh.pathfinder import MeshPathfinder
 
         if self._mesh_pathfinder is None:
-            bx0, by0, bx1, by1 = self._board_bbox
+            # ``_board_bbox`` is only populated from Edge.Cuts (io.py) when the
+            # board actually has an outline; a board routed under
+            # ``--route-engine mesh`` with no edge cuts leaves it ``None``.
+            # Fall back to the grid origin/dimensions so the navmesh still gets
+            # a valid outer boundary instead of crashing on a ``None`` unpack
+            # (mirrors the guarded reader in ``cleanup_artifacts``).
+            if self._board_bbox is not None:
+                bx0, by0, bx1, by1 = self._board_bbox
+            else:
+                bx0 = self.grid.origin_x
+                by0 = self.grid.origin_y
+                bx1 = self.grid.origin_x + self.grid.width
+                by1 = self.grid.origin_y + self.grid.height
             outline = [(bx0, by0), (bx1, by0), (bx1, by1), (bx0, by1)]
             self._mesh_pathfinder = MeshPathfinder(outline, list(self.pads.values()), self.rules)
 

--- a/src/kicad_tools/router/cpp/CMakeLists.txt
+++ b/src/kicad_tools/router/cpp/CMakeLists.txt
@@ -46,9 +46,20 @@ endif()
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 file(GLOB_RECURSE SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 
+# Vendored poly2tri (BSD-3) constrained-Delaunay mesher (issue #4268).
+# poly2tri sources are ``.cc`` (not picked up by the ``src/*.cpp`` glob), so
+# they are added explicitly.  Its headers include each other relative to the
+# ``poly2tri/`` directory (e.g. ``#include "common/shapes.h"``), so that
+# directory is the include root.  ``P2T_STATIC_EXPORTS`` neutralises the
+# DLL import/export decoration for a static in-module link.
+set(POLY2TRI_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/third_party/poly2tri/poly2tri)
+include_directories(${POLY2TRI_ROOT})
+file(GLOB_RECURSE POLY2TRI_SOURCES "${POLY2TRI_ROOT}/*.cc")
+
 # Build nanobind module
-nanobind_add_module(${PROJECT_NAME} ${SOURCE_FILES})
+nanobind_add_module(${PROJECT_NAME} ${SOURCE_FILES} ${POLY2TRI_SOURCES})
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
+target_compile_definitions(${PROJECT_NAME} PRIVATE P2T_STATIC_EXPORTS)
 
 install(TARGETS ${PROJECT_NAME} DESTINATION kicad_tools/router)
 

--- a/src/kicad_tools/router/cpp/src/bindings.cpp
+++ b/src/kicad_tools/router/cpp/src/bindings.cpp
@@ -19,6 +19,11 @@ namespace nb = nanobind;
 using namespace nb::literals;
 using namespace router;
 
+// Defined in mesh.cpp (issue #4268): registers the poly2tri constrained-
+// Delaunay mesh binding onto the module. Kept in its own translation unit so
+// the vendored poly2tri headers stay out of the main bindings compile.
+void register_mesh(nb::module_& m);
+
 NB_MODULE(router_cpp, m) {
     m.doc() = "C++ router core for high-performance PCB routing";
 
@@ -451,4 +456,8 @@ NB_MODULE(router_cpp, m) {
     // "kct build-native" hint.
     m.attr("BUILD_VERSION") = router::ROUTER_CPP_BUILD_VERSION;
     m.def("build_version", []() { return router::ROUTER_CPP_BUILD_VERSION; });
+
+    // Issue #4268: poly2tri constrained-Delaunay mesh binding for the
+    // mesh-router navigation substrate.
+    register_mesh(m);
 }

--- a/src/kicad_tools/router/cpp/src/mesh.cpp
+++ b/src/kicad_tools/router/cpp/src/mesh.cpp
@@ -1,0 +1,149 @@
+/*
+ * Router C++ Core - poly2tri constrained-Delaunay mesh binding
+ *
+ * Part of the mesh-router P1 vertical slice (issue #4268, epic #4267).
+ *
+ * The mesh-router navigation model (ADR on #4267) is a triangle-dual
+ * navmesh: a plain *constrained Delaunay triangulation with holes* of the
+ * board (outline as the outer boundary, pad keep-outs as interior holes),
+ * with the two net endpoints inserted as Steiner points so A* can start and
+ * end on real mesh vertices.  No quality refinement is needed -- the funnel
+ * string-pull straightens the corridor regardless of triangle size (P0.5
+ * spike), which is exactly why the license-simplest BSD-3 poly2tri suffices.
+ *
+ * poly2tri is a polygon-with-holes triangulator, so the "constraint edges"
+ * are precisely the outer-boundary loop and each hole loop -- there is no
+ * general arbitrary-segment constraint facility.  That matches the P1 need:
+ * the only constraints we require are the board outline and the pad keep-out
+ * boundaries.
+ */
+
+#include "poly2tri.h"
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/vector.h>
+#include <nanobind/stl/pair.h>
+#include <nanobind/stl/tuple.h>
+
+#include <cmath>
+#include <memory>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+namespace nb = nanobind;
+
+namespace {
+
+using Coord = std::pair<double, double>;
+using Tri = std::tuple<int, int, int>;
+using MeshResult = std::pair<std::vector<Coord>, std::vector<Tri>>;
+
+// Constrained Delaunay triangulation of a polygon with holes (poly2tri).
+//
+//   outer   : the board-outline boundary as a closed loop of (x, y) with NO
+//             repeated first/last vertex (poly2tri requirement).
+//   holes   : each an interior keep-out loop (same no-repeat rule); triangles
+//             inside a hole are excluded from the output.
+//   steiner : interior points forced to become mesh vertices (net endpoints).
+//
+// Returns (vertices, triangles) where each triangle is an index triple into
+// vertices.  On any poly2tri failure (collinear/duplicate/degenerate input)
+// the result is empty rather than a crash -- callers treat empty as "meshing
+// failed, fall back".
+MeshResult constrained_delaunay(const std::vector<Coord>& outer,
+                                const std::vector<std::vector<Coord>>& holes,
+                                const std::vector<Coord>& steiner)
+{
+    MeshResult result;
+    if (outer.size() < 3) {
+        return result;  // not a polygon
+    }
+
+    // We own every p2t::Point for the lifetime of the triangulation; the CDT
+    // stores raw pointers and the output triangles reference these same
+    // pointers, so pointer identity maps a triangle vertex back to its coord.
+    std::vector<std::unique_ptr<p2t::Point>> storage;
+    storage.reserve(outer.size() + steiner.size() + 16);
+
+    auto make_point = [&](double x, double y) -> p2t::Point* {
+        storage.push_back(std::make_unique<p2t::Point>(x, y));
+        return storage.back().get();
+    };
+
+    std::vector<p2t::Point*> polyline;
+    polyline.reserve(outer.size());
+    for (const auto& c : outer) {
+        polyline.push_back(make_point(c.first, c.second));
+    }
+
+    // hole_lines must outlive Triangulate(): CDT keeps the pointers.
+    std::vector<std::vector<p2t::Point*>> hole_lines;
+    hole_lines.reserve(holes.size());
+
+    std::unique_ptr<p2t::CDT> cdt;
+    try {
+        cdt = std::make_unique<p2t::CDT>(polyline);
+        for (const auto& h : holes) {
+            if (h.size() < 3) {
+                continue;  // a degenerate hole cannot be a polygon
+            }
+            std::vector<p2t::Point*> hl;
+            hl.reserve(h.size());
+            for (const auto& c : h) {
+                hl.push_back(make_point(c.first, c.second));
+            }
+            hole_lines.push_back(std::move(hl));
+            cdt->AddHole(hole_lines.back());
+        }
+        for (const auto& c : steiner) {
+            cdt->AddPoint(make_point(c.first, c.second));
+        }
+        cdt->Triangulate();
+    } catch (...) {
+        return MeshResult();  // empty => caller falls back
+    }
+
+    std::vector<p2t::Triangle*> tris = cdt->GetTriangles();
+
+    std::vector<Coord> verts;
+    std::vector<Tri> out_tris;
+    out_tris.reserve(tris.size());
+    std::unordered_map<p2t::Point*, int> index_of;
+    index_of.reserve(tris.size() * 2);
+
+    auto vidx = [&](p2t::Point* p) -> int {
+        auto it = index_of.find(p);
+        if (it != index_of.end()) {
+            return it->second;
+        }
+        int idx = static_cast<int>(verts.size());
+        index_of.emplace(p, idx);
+        verts.emplace_back(p->x, p->y);
+        return idx;
+    };
+
+    for (p2t::Triangle* t : tris) {
+        const int a = vidx(t->GetPoint(0));
+        const int b = vidx(t->GetPoint(1));
+        const int c = vidx(t->GetPoint(2));
+        out_tris.emplace_back(a, b, c);
+    }
+
+    result.first = std::move(verts);
+    result.second = std::move(out_tris);
+    return result;
+}
+
+}  // namespace
+
+// Declared in bindings.cpp; called from NB_MODULE(router_cpp, ...).
+void register_mesh(nb::module_& m)
+{
+    m.def("constrained_delaunay", &constrained_delaunay, nb::arg("outer"),
+          nb::arg("holes"), nb::arg("steiner"),
+          "Constrained Delaunay triangulation (poly2tri) of a polygon with "
+          "holes plus interior Steiner points. Returns (vertices, triangles) "
+          "where each triangle is an index triple into vertices. Empty result "
+          "signals a meshing failure (degenerate input).");
+}

--- a/src/kicad_tools/router/cpp/third_party/poly2tri/AUTHORS
+++ b/src/kicad_tools/router/cpp/third_party/poly2tri/AUTHORS
@@ -1,0 +1,8 @@
+Primary Contributors:
+
+  Mason Green <mason.green@gmail.com> (C++, Python)
+  Thomas Åhlén <thahlen@gmail.com>    (Java)
+
+Other Contributors:
+
+  

--- a/src/kicad_tools/router/cpp/third_party/poly2tri/LICENSE
+++ b/src/kicad_tools/router/cpp/third_party/poly2tri/LICENSE
@@ -1,0 +1,26 @@
+Copyright (c) 2009-2018, Poly2Tri Contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Poly2Tri nor the names of its contributors may be
+  used to endorse or promote products derived from this software without specific
+  prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/kicad_tools/router/cpp/third_party/poly2tri/README.md
+++ b/src/kicad_tools/router/cpp/third_party/poly2tri/README.md
@@ -1,0 +1,101 @@
+﻿Since there are no Input validation of the data given for triangulation you need
+to think about this. Poly2Tri does not support repeat points within epsilon.
+
+* If you have a cyclic function that generates random points make sure you don't
+  add the same coordinate twice.
+* If you are given input and aren't sure same point exist twice you need to
+  check for this yourself.
+* Only simple polygons are supported. You may add holes or interior Steiner points
+* Interior holes must not touch other holes, nor touch the polyline boundary
+* Use the library in this order:
+  1. Initialize CDT with a simple polyline (this defines the constrained edges)
+  2. Add holes if necessary (also simple polylines)
+  3. Add Steiner points
+  4. Triangulate
+
+Make sure you understand the preceding notice before posting an issue. If you have
+an issue not covered by the above, include your data-set with the problem.
+The only easy day was yesterday; have a nice day. <Mason Green>
+
+TESTBED INSTALLATION GUIDE
+==========================
+
+Dependencies
+------------
+
+Core poly2tri lib:
+
+* Standard Template Library (STL)
+
+Unit tests:
+* Boost (filesystem, test framework)
+
+Testbed:
+
+* OpenGL
+* [GLFW](http://glfw.sf.net)
+
+Build the library
+-----------------
+
+With the ninja build system installed:
+
+```
+mkdir build && cd build
+cmake -GNinja ..
+cmake --build .
+```
+
+Build and run with unit tests
+----------------------------
+
+With the ninja build system:
+
+```
+mkdir build && cd build
+cmake -GNinja -DP2T_BUILD_TESTS=ON ..
+cmake --build .
+ctest --output-on-failure
+```
+
+Build with the testbed
+-----------------
+
+```
+mkdir build && cd build
+cmake -GNinja -DP2T_BUILD_TESTBED=ON ..
+cmake --build .
+```
+
+Running the Examples
+--------------------
+
+Load data points from a file:
+```
+build/testbed/p2t <filename> <center_x> <center_y> <zoom>
+```
+Load data points from a file and automatically fit the geometry to the window:
+```
+build/testbed/p2t <filename>
+```
+Random distribution of points inside a constrained box:
+```
+build/testbed/p2t random <num_points> <box_radius> <zoom>
+```
+Examples:
+```
+build/testbed/p2t testbed/data/dude.dat 350 500 3
+
+build/testbed/p2t testbed/data/nazca_monkey.dat
+
+build/testbed/p2t random 10 100 5.0
+build/testbed/p2t random 1000 20000 0.025
+```
+
+References
+==========
+
+- Domiter V. and Zalik B. (2008) Sweep‐line algorithm for constrained Delaunay triangulation
+- FlipScan by library author Thomas Åhlén
+
+![FlipScan](doc/FlipScan.png)

--- a/src/kicad_tools/router/cpp/third_party/poly2tri/poly2tri/common/dll_symbol.h
+++ b/src/kicad_tools/router/cpp/third_party/poly2tri/poly2tri/common/dll_symbol.h
@@ -1,0 +1,53 @@
+/*
+ * Poly2Tri Copyright (c) 2009-2022, Poly2Tri Contributors
+ * https://github.com/jhasse/poly2tri
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * * Neither the name of Poly2Tri nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if defined(_WIN32)
+#  define P2T_COMPILER_DLLEXPORT __declspec(dllexport)
+#  define P2T_COMPILER_DLLIMPORT __declspec(dllimport)
+#elif defined(__GNUC__)
+#  define P2T_COMPILER_DLLEXPORT __attribute__ ((visibility ("default")))
+#  define P2T_COMPILER_DLLIMPORT __attribute__ ((visibility ("default")))
+#else
+#  define P2T_COMPILER_DLLEXPORT
+#  define P2T_COMPILER_DLLIMPORT
+#endif
+
+#ifndef P2T_DLL_SYMBOL
+#  if defined(P2T_STATIC_EXPORTS)
+#    define P2T_DLL_SYMBOL
+#  elif defined(P2T_SHARED_EXPORTS)
+#    define P2T_DLL_SYMBOL P2T_COMPILER_DLLEXPORT
+#  else
+#    define P2T_DLL_SYMBOL P2T_COMPILER_DLLIMPORT
+#  endif
+#endif

--- a/src/kicad_tools/router/cpp/third_party/poly2tri/poly2tri/common/shapes.cc
+++ b/src/kicad_tools/router/cpp/third_party/poly2tri/poly2tri/common/shapes.cc
@@ -1,0 +1,411 @@
+/*
+ * Poly2Tri Copyright (c) 2009-2018, Poly2Tri Contributors
+ * https://github.com/jhasse/poly2tri
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * * Neither the name of Poly2Tri nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "shapes.h"
+
+#include <cassert>
+#include <iostream>
+
+namespace p2t {
+
+Point::Point(double x, double y) : x(x), y(y)
+{
+}
+
+std::ostream& operator<<(std::ostream& out, const Point& point) {
+  return out << point.x << "," << point.y;
+}
+
+Triangle::Triangle(Point& a, Point& b, Point& c)
+{
+  points_[0] = &a; points_[1] = &b; points_[2] = &c;
+  neighbors_[0] = nullptr; neighbors_[1] = nullptr; neighbors_[2] = nullptr;
+  constrained_edge[0] = constrained_edge[1] = constrained_edge[2] = false;
+  delaunay_edge[0] = delaunay_edge[1] = delaunay_edge[2] = false;
+  interior_ = false;
+}
+
+// Update neighbor pointers
+void Triangle::MarkNeighbor(Point* p1, Point* p2, Triangle* t)
+{
+  if ((p1 == points_[2] && p2 == points_[1]) || (p1 == points_[1] && p2 == points_[2]))
+    neighbors_[0] = t;
+  else if ((p1 == points_[0] && p2 == points_[2]) || (p1 == points_[2] && p2 == points_[0]))
+    neighbors_[1] = t;
+  else if ((p1 == points_[0] && p2 == points_[1]) || (p1 == points_[1] && p2 == points_[0]))
+    neighbors_[2] = t;
+  else
+    assert(0);
+}
+
+// Exhaustive search to update neighbor pointers
+void Triangle::MarkNeighbor(Triangle& t)
+{
+  if (t.Contains(points_[1], points_[2])) {
+    neighbors_[0] = &t;
+    t.MarkNeighbor(points_[1], points_[2], this);
+  } else if (t.Contains(points_[0], points_[2])) {
+    neighbors_[1] = &t;
+    t.MarkNeighbor(points_[0], points_[2], this);
+  } else if (t.Contains(points_[0], points_[1])) {
+    neighbors_[2] = &t;
+    t.MarkNeighbor(points_[0], points_[1], this);
+  }
+}
+
+/**
+ * Clears all references to all other triangles and points
+ */
+void Triangle::Clear()
+{
+    Triangle *t;
+    for (auto& neighbor : neighbors_) {
+      t = neighbor;
+      if (t != nullptr) {
+        t->ClearNeighbor(this);
+      }
+    }
+    ClearNeighbors();
+    points_[0]=points_[1]=points_[2] = nullptr;
+}
+
+void Triangle::ClearNeighbor(const Triangle *triangle )
+{
+    if( neighbors_[0] == triangle )
+    {
+        neighbors_[0] = nullptr;
+    }
+    else if( neighbors_[1] == triangle )
+    {
+        neighbors_[1] = nullptr;
+    }
+    else
+    {
+        neighbors_[2] = nullptr;
+    }
+}
+
+void Triangle::ClearNeighbors()
+{
+  neighbors_[0] = nullptr;
+  neighbors_[1] = nullptr;
+  neighbors_[2] = nullptr;
+}
+
+void Triangle::ClearDelunayEdges()
+{
+  delaunay_edge[0] = delaunay_edge[1] = delaunay_edge[2] = false;
+}
+
+Point* Triangle::OppositePoint(Triangle& t, const Point& p)
+{
+  Point *cw = t.PointCW(p);
+  return PointCW(*cw);
+}
+
+// Legalized triangle by rotating clockwise around point(0)
+void Triangle::Legalize(Point& point)
+{
+  points_[1] = points_[0];
+  points_[0] = points_[2];
+  points_[2] = &point;
+}
+
+// Legalize triagnle by rotating clockwise around oPoint
+void Triangle::Legalize(Point& opoint, Point& npoint)
+{
+  if (&opoint == points_[0]) {
+    points_[1] = points_[0];
+    points_[0] = points_[2];
+    points_[2] = &npoint;
+  } else if (&opoint == points_[1]) {
+    points_[2] = points_[1];
+    points_[1] = points_[0];
+    points_[0] = &npoint;
+  } else if (&opoint == points_[2]) {
+    points_[0] = points_[2];
+    points_[2] = points_[1];
+    points_[1] = &npoint;
+  } else {
+    assert(0);
+  }
+}
+
+int Triangle::Index(const Point* p)
+{
+  if (p == points_[0]) {
+    return 0;
+  } else if (p == points_[1]) {
+    return 1;
+  } else if (p == points_[2]) {
+    return 2;
+  }
+  assert(0);
+  return -1;
+}
+
+int Triangle::EdgeIndex(const Point* p1, const Point* p2)
+{
+  if (points_[0] == p1) {
+    if (points_[1] == p2) {
+      return 2;
+    } else if (points_[2] == p2) {
+      return 1;
+    }
+  } else if (points_[1] == p1) {
+    if (points_[2] == p2) {
+      return 0;
+    } else if (points_[0] == p2) {
+      return 2;
+    }
+  } else if (points_[2] == p1) {
+    if (points_[0] == p2) {
+      return 1;
+    } else if (points_[1] == p2) {
+      return 0;
+    }
+  }
+  return -1;
+}
+
+void Triangle::MarkConstrainedEdge(int index)
+{
+  constrained_edge[index] = true;
+}
+
+void Triangle::MarkConstrainedEdge(Edge& edge)
+{
+  MarkConstrainedEdge(edge.p, edge.q);
+}
+
+// Mark edge as constrained
+void Triangle::MarkConstrainedEdge(Point* p, Point* q)
+{
+  if ((q == points_[0] && p == points_[1]) || (q == points_[1] && p == points_[0])) {
+    constrained_edge[2] = true;
+  } else if ((q == points_[0] && p == points_[2]) || (q == points_[2] && p == points_[0])) {
+    constrained_edge[1] = true;
+  } else if ((q == points_[1] && p == points_[2]) || (q == points_[2] && p == points_[1])) {
+    constrained_edge[0] = true;
+  }
+}
+
+// The point counter-clockwise to given point
+Point* Triangle::PointCW(const Point& point)
+{
+  if (&point == points_[0]) {
+    return points_[2];
+  } else if (&point == points_[1]) {
+    return points_[0];
+  } else if (&point == points_[2]) {
+    return points_[1];
+  }
+  assert(0);
+  return nullptr;
+}
+
+// The point counter-clockwise to given point
+Point* Triangle::PointCCW(const Point& point)
+{
+  if (&point == points_[0]) {
+    return points_[1];
+  } else if (&point == points_[1]) {
+    return points_[2];
+  } else if (&point == points_[2]) {
+    return points_[0];
+  }
+  assert(0);
+  return nullptr;
+}
+
+// The neighbor across to given point
+Triangle* Triangle::NeighborAcross(const Point& point)
+{
+  if (&point == points_[0]) {
+    return neighbors_[0];
+  } else if (&point == points_[1]) {
+    return neighbors_[1];
+  }
+  return neighbors_[2];
+}
+
+// The neighbor clockwise to given point
+Triangle* Triangle::NeighborCW(const Point& point)
+{
+  if (&point == points_[0]) {
+    return neighbors_[1];
+  } else if (&point == points_[1]) {
+    return neighbors_[2];
+  }
+  return neighbors_[0];
+}
+
+// The neighbor counter-clockwise to given point
+Triangle* Triangle::NeighborCCW(const Point& point)
+{
+  if (&point == points_[0]) {
+    return neighbors_[2];
+  } else if (&point == points_[1]) {
+    return neighbors_[0];
+  }
+  return neighbors_[1];
+}
+
+bool Triangle::GetConstrainedEdgeCCW(const Point& p)
+{
+  if (&p == points_[0]) {
+    return constrained_edge[2];
+  } else if (&p == points_[1]) {
+    return constrained_edge[0];
+  }
+  return constrained_edge[1];
+}
+
+bool Triangle::GetConstrainedEdgeCW(const Point& p)
+{
+  if (&p == points_[0]) {
+    return constrained_edge[1];
+  } else if (&p == points_[1]) {
+    return constrained_edge[2];
+  }
+  return constrained_edge[0];
+}
+
+void Triangle::SetConstrainedEdgeCCW(const Point& p, bool ce)
+{
+  if (&p == points_[0]) {
+    constrained_edge[2] = ce;
+  } else if (&p == points_[1]) {
+    constrained_edge[0] = ce;
+  } else {
+    constrained_edge[1] = ce;
+  }
+}
+
+void Triangle::SetConstrainedEdgeCW(const Point& p, bool ce)
+{
+  if (&p == points_[0]) {
+    constrained_edge[1] = ce;
+  } else if (&p == points_[1]) {
+    constrained_edge[2] = ce;
+  } else {
+    constrained_edge[0] = ce;
+  }
+}
+
+bool Triangle::GetDelunayEdgeCCW(const Point& p)
+{
+  if (&p == points_[0]) {
+    return delaunay_edge[2];
+  } else if (&p == points_[1]) {
+    return delaunay_edge[0];
+  }
+  return delaunay_edge[1];
+}
+
+bool Triangle::GetDelunayEdgeCW(const Point& p)
+{
+  if (&p == points_[0]) {
+    return delaunay_edge[1];
+  } else if (&p == points_[1]) {
+    return delaunay_edge[2];
+  }
+  return delaunay_edge[0];
+}
+
+void Triangle::SetDelunayEdgeCCW(const Point& p, bool e)
+{
+  if (&p == points_[0]) {
+    delaunay_edge[2] = e;
+  } else if (&p == points_[1]) {
+    delaunay_edge[0] = e;
+  } else {
+    delaunay_edge[1] = e;
+  }
+}
+
+void Triangle::SetDelunayEdgeCW(const Point& p, bool e)
+{
+  if (&p == points_[0]) {
+    delaunay_edge[1] = e;
+  } else if (&p == points_[1]) {
+    delaunay_edge[2] = e;
+  } else {
+    delaunay_edge[0] = e;
+  }
+}
+
+void Triangle::DebugPrint()
+{
+  std::cout << *points_[0] << " " << *points_[1] << " " << *points_[2] << std::endl;
+}
+
+bool Triangle::CircumcicleContains(const Point& point) const
+{
+  assert(IsCounterClockwise());
+  const double dx = points_[0]->x - point.x;
+  const double dy = points_[0]->y - point.y;
+  const double ex = points_[1]->x - point.x;
+  const double ey = points_[1]->y - point.y;
+  const double fx = points_[2]->x - point.x;
+  const double fy = points_[2]->y - point.y;
+
+  const double ap = dx * dx + dy * dy;
+  const double bp = ex * ex + ey * ey;
+  const double cp = fx * fx + fy * fy;
+
+  return (dx * (fy * bp - cp * ey) - dy * (fx * bp - cp * ex) + ap * (fx * ey - fy * ex)) < 0;
+}
+
+bool Triangle::IsCounterClockwise() const
+{
+  return (points_[1]->x - points_[0]->x) * (points_[2]->y - points_[0]->y) -
+             (points_[2]->x - points_[0]->x) * (points_[1]->y - points_[0]->y) >
+         0;
+}
+
+bool IsDelaunay(const std::vector<p2t::Triangle*>& triangles)
+{
+  for (const auto triangle : triangles) {
+    for (const auto other : triangles) {
+      if (triangle == other) {
+        continue;
+      }
+      for (int i = 0; i < 3; ++i) {
+        if (triangle->CircumcicleContains(*other->GetPoint(i))) {
+          return false;
+        }
+      }
+    }
+  }
+  return true;
+}
+
+} // namespace p2t

--- a/src/kicad_tools/router/cpp/third_party/poly2tri/poly2tri/common/shapes.h
+++ b/src/kicad_tools/router/cpp/third_party/poly2tri/poly2tri/common/shapes.h
@@ -1,0 +1,329 @@
+/*
+ * Poly2Tri Copyright (c) 2009-2018, Poly2Tri Contributors
+ * https://github.com/jhasse/poly2tri
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * * Neither the name of Poly2Tri nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "dll_symbol.h"
+
+#include <cmath>
+#include <cstddef>
+#include <stdexcept>
+#include <vector>
+
+namespace p2t {
+
+struct Edge;
+
+struct P2T_DLL_SYMBOL Point {
+
+  double x, y;
+
+  /// Default constructor does nothing (for performance).
+  Point()
+  {
+    x = 0.0;
+    y = 0.0;
+  }
+
+  /// The edges this point constitutes an upper ending point
+  std::vector<Edge*> edge_list;
+
+  /// Construct using coordinates.
+  Point(double x, double y);
+
+  /// Set this point to all zeros.
+  void set_zero()
+  {
+    x = 0.0;
+    y = 0.0;
+  }
+
+  /// Set this point to some specified coordinates.
+  void set(double x_, double y_)
+  {
+    x = x_;
+    y = y_;
+  }
+
+  /// Negate this point.
+  Point operator -() const
+  {
+    Point v;
+    v.set(-x, -y);
+    return v;
+  }
+
+  /// Add a point to this point.
+  void operator +=(const Point& v)
+  {
+    x += v.x;
+    y += v.y;
+  }
+
+  /// Subtract a point from this point.
+  void operator -=(const Point& v)
+  {
+    x -= v.x;
+    y -= v.y;
+  }
+
+  /// Multiply this point by a scalar.
+  void operator *=(double a)
+  {
+    x *= a;
+    y *= a;
+  }
+
+  /// Get the length of this point (the norm).
+  double Length() const
+  {
+    return sqrt(x * x + y * y);
+  }
+
+  /// Convert this point into a unit point. Returns the Length.
+  double Normalize()
+  {
+    const double len = Length();
+    x /= len;
+    y /= len;
+    return len;
+  }
+
+};
+
+P2T_DLL_SYMBOL std::ostream& operator<<(std::ostream&, const Point&);
+
+// Represents a simple polygon's edge
+struct P2T_DLL_SYMBOL Edge {
+
+  Point* p, *q;
+
+  /// Constructor
+  Edge(Point& p1, Point& p2) : p(&p1), q(&p2)
+  {
+    if (p1.y > p2.y) {
+      q = &p1;
+      p = &p2;
+    } else if (p1.y == p2.y) {
+      if (p1.x > p2.x) {
+        q = &p1;
+        p = &p2;
+      } else if (p1.x == p2.x) {
+        // Repeat points
+        throw std::runtime_error("Edge::Edge: p1 == p2");
+      }
+    }
+
+    q->edge_list.push_back(this);
+  }
+};
+
+// Triangle-based data structures are know to have better performance than quad-edge structures
+// See: J. Shewchuk, "Triangle: Engineering a 2D Quality Mesh Generator and Delaunay Triangulator"
+//      "Triangulations in CGAL"
+class P2T_DLL_SYMBOL Triangle {
+public:
+
+/// Constructor
+Triangle(Point& a, Point& b, Point& c);
+
+/// Flags to determine if an edge is a Constrained edge
+bool constrained_edge[3];
+/// Flags to determine if an edge is a Delauney edge
+bool delaunay_edge[3];
+
+Point* GetPoint(int index);
+Point* PointCW(const Point& point);
+Point* PointCCW(const Point& point);
+Point* OppositePoint(Triangle& t, const Point& p);
+
+Triangle* GetNeighbor(int index);
+void MarkNeighbor(Point* p1, Point* p2, Triangle* t);
+void MarkNeighbor(Triangle& t);
+
+void MarkConstrainedEdge(int index);
+void MarkConstrainedEdge(Edge& edge);
+void MarkConstrainedEdge(Point* p, Point* q);
+
+int Index(const Point* p);
+int EdgeIndex(const Point* p1, const Point* p2);
+
+Triangle* NeighborAcross(const Point& point);
+Triangle* NeighborCW(const Point& point);
+Triangle* NeighborCCW(const Point& point);
+bool GetConstrainedEdgeCCW(const Point& p);
+bool GetConstrainedEdgeCW(const Point& p);
+void SetConstrainedEdgeCCW(const Point& p, bool ce);
+void SetConstrainedEdgeCW(const Point& p, bool ce);
+bool GetDelunayEdgeCCW(const Point& p);
+bool GetDelunayEdgeCW(const Point& p);
+void SetDelunayEdgeCCW(const Point& p, bool e);
+void SetDelunayEdgeCW(const Point& p, bool e);
+
+bool Contains(const Point* p);
+bool Contains(const Edge& e);
+bool Contains(const Point* p, const Point* q);
+void Legalize(Point& point);
+void Legalize(Point& opoint, Point& npoint);
+/**
+ * Clears all references to all other triangles and points
+ */
+void Clear();
+void ClearNeighbor(const Triangle *triangle);
+void ClearNeighbors();
+void ClearDelunayEdges();
+
+inline bool IsInterior();
+inline void IsInterior(bool b);
+
+void DebugPrint();
+
+bool CircumcicleContains(const Point&) const;
+
+private:
+
+bool IsCounterClockwise() const;
+
+/// Triangle points
+Point* points_[3];
+/// Neighbor list
+Triangle* neighbors_[3];
+
+/// Has this triangle been marked as an interior triangle?
+bool interior_;
+};
+
+inline bool cmp(const Point* a, const Point* b)
+{
+  if (a->y < b->y) {
+    return true;
+  } else if (a->y == b->y) {
+    // Make sure q is point with greater x value
+    if (a->x < b->x) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/// Add two points_ component-wise.
+inline Point operator +(const Point& a, const Point& b)
+{
+  return Point(a.x + b.x, a.y + b.y);
+}
+
+/// Subtract two points_ component-wise.
+inline Point operator -(const Point& a, const Point& b)
+{
+  return Point(a.x - b.x, a.y - b.y);
+}
+
+/// Multiply point by scalar
+inline Point operator *(double s, const Point& a)
+{
+  return Point(s * a.x, s * a.y);
+}
+
+inline bool operator ==(const Point& a, const Point& b)
+{
+  return a.x == b.x && a.y == b.y;
+}
+
+inline bool operator !=(const Point& a, const Point& b)
+{
+  return !(a.x == b.x) || !(a.y == b.y);
+}
+
+/// Peform the dot product on two vectors.
+inline double Dot(const Point& a, const Point& b)
+{
+  return a.x * b.x + a.y * b.y;
+}
+
+/// Perform the cross product on two vectors. In 2D this produces a scalar.
+inline double Cross(const Point& a, const Point& b)
+{
+  return a.x * b.y - a.y * b.x;
+}
+
+/// Perform the cross product on a point and a scalar. In 2D this produces
+/// a point.
+inline Point Cross(const Point& a, double s)
+{
+  return Point(s * a.y, -s * a.x);
+}
+
+/// Perform the cross product on a scalar and a point. In 2D this produces
+/// a point.
+inline Point Cross(double s, const Point& a)
+{
+  return Point(-s * a.y, s * a.x);
+}
+
+inline Point* Triangle::GetPoint(int index)
+{
+  return points_[index];
+}
+
+inline Triangle* Triangle::GetNeighbor(int index)
+{
+  return neighbors_[index];
+}
+
+inline bool Triangle::Contains(const Point* p)
+{
+  return p == points_[0] || p == points_[1] || p == points_[2];
+}
+
+inline bool Triangle::Contains(const Edge& e)
+{
+  return Contains(e.p) && Contains(e.q);
+}
+
+inline bool Triangle::Contains(const Point* p, const Point* q)
+{
+  return Contains(p) && Contains(q);
+}
+
+inline bool Triangle::IsInterior()
+{
+  return interior_;
+}
+
+inline void Triangle::IsInterior(bool b)
+{
+  interior_ = b;
+}
+
+/// Is this set a valid delaunay triangulation?
+P2T_DLL_SYMBOL bool IsDelaunay(const std::vector<p2t::Triangle*>&);
+
+}

--- a/src/kicad_tools/router/cpp/third_party/poly2tri/poly2tri/common/utils.h
+++ b/src/kicad_tools/router/cpp/third_party/poly2tri/poly2tri/common/utils.h
@@ -1,0 +1,130 @@
+/*
+ * Poly2Tri Copyright (c) 2009-2018, Poly2Tri Contributors
+ * https://github.com/jhasse/poly2tri
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * * Neither the name of Poly2Tri nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+// Otherwise #defines like M_PI are undeclared under Visual Studio
+#define _USE_MATH_DEFINES
+
+#include "shapes.h"
+
+#include <cmath>
+#include <exception>
+
+// C99 removes M_PI from math.h
+#ifndef M_PI
+#define M_PI 3.14159265358979323846264338327
+#endif
+
+namespace p2t {
+
+const double PI_3div4 = 3 * M_PI / 4;
+const double PI_div2 = 1.57079632679489661923;
+const double EPSILON = 1e-12;
+
+enum Orientation { CW, CCW, COLLINEAR };
+
+/**
+ * Forumla to calculate signed area<br>
+ * Positive if CCW<br>
+ * Negative if CW<br>
+ * 0 if collinear<br>
+ * <pre>
+ * A[P1,P2,P3]  =  (x1*y2 - y1*x2) + (x2*y3 - y2*x3) + (x3*y1 - y3*x1)
+ *              =  (x1-x3)*(y2-y3) - (y1-y3)*(x2-x3)
+ * </pre>
+ */
+Orientation Orient2d(const Point& pa, const Point& pb, const Point& pc)
+{
+  double detleft = (pa.x - pc.x) * (pb.y - pc.y);
+  double detright = (pa.y - pc.y) * (pb.x - pc.x);
+  double val = detleft - detright;
+
+// Using a tolerance here fails on concave-by-subepsilon boundaries
+//   if (val > -EPSILON && val < EPSILON) {
+// Using == on double makes -Wfloat-equal warnings yell at us
+  if (std::fpclassify(val) == FP_ZERO) {
+    return COLLINEAR;
+  } else if (val > 0) {
+    return CCW;
+  }
+  return CW;
+}
+
+/*
+bool InScanArea(Point& pa, Point& pb, Point& pc, Point& pd)
+{
+  double pdx = pd.x;
+  double pdy = pd.y;
+  double adx = pa.x - pdx;
+  double ady = pa.y - pdy;
+  double bdx = pb.x - pdx;
+  double bdy = pb.y - pdy;
+
+  double adxbdy = adx * bdy;
+  double bdxady = bdx * ady;
+  double oabd = adxbdy - bdxady;
+
+  if (oabd <= EPSILON) {
+    return false;
+  }
+
+  double cdx = pc.x - pdx;
+  double cdy = pc.y - pdy;
+
+  double cdxady = cdx * ady;
+  double adxcdy = adx * cdy;
+  double ocad = cdxady - adxcdy;
+
+  if (ocad <= EPSILON) {
+    return false;
+  }
+
+  return true;
+}
+
+*/
+
+bool InScanArea(const Point& pa, const Point& pb, const Point& pc, const Point& pd)
+{
+  double oadb = (pa.x - pb.x)*(pd.y - pb.y) - (pd.x - pb.x)*(pa.y - pb.y);
+  if (oadb >= -EPSILON) {
+    return false;
+  }
+
+  double oadc = (pa.x - pc.x)*(pd.y - pc.y) - (pd.x - pc.x)*(pa.y - pc.y);
+  if (oadc <= EPSILON) {
+    return false;
+  }
+  return true;
+}
+
+}

--- a/src/kicad_tools/router/cpp/third_party/poly2tri/poly2tri/poly2tri.h
+++ b/src/kicad_tools/router/cpp/third_party/poly2tri/poly2tri/poly2tri.h
@@ -1,0 +1,35 @@
+/*
+ * Poly2Tri Copyright (c) 2009-2018, Poly2Tri Contributors
+ * https://github.com/jhasse/poly2tri
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * * Neither the name of Poly2Tri nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "common/shapes.h"
+#include "sweep/cdt.h"

--- a/src/kicad_tools/router/cpp/third_party/poly2tri/poly2tri/sweep/advancing_front.cc
+++ b/src/kicad_tools/router/cpp/third_party/poly2tri/poly2tri/sweep/advancing_front.cc
@@ -1,0 +1,110 @@
+/*
+ * Poly2Tri Copyright (c) 2009-2018, Poly2Tri Contributors
+ * https://github.com/jhasse/poly2tri
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * * Neither the name of Poly2Tri nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "advancing_front.h"
+
+#include <cassert>
+
+namespace p2t {
+
+AdvancingFront::AdvancingFront(Node& head, Node& tail)
+{
+  head_ = &head;
+  tail_ = &tail;
+  search_node_ = &head;
+}
+
+Node* AdvancingFront::LocateNode(double x)
+{
+  Node* node = search_node_;
+
+  if (x < node->value) {
+    while ((node = node->prev) != nullptr) {
+      if (x >= node->value) {
+        search_node_ = node;
+        return node;
+      }
+    }
+  } else {
+    while ((node = node->next) != nullptr) {
+      if (x < node->value) {
+        search_node_ = node->prev;
+        return node->prev;
+      }
+    }
+  }
+  return nullptr;
+}
+
+Node* AdvancingFront::FindSearchNode(double x)
+{
+  (void)x; // suppress compiler warnings "unused parameter 'x'"
+  // TODO: implement BST index
+  return search_node_;
+}
+
+Node* AdvancingFront::LocatePoint(const Point* point)
+{
+  const double px = point->x;
+  Node* node = FindSearchNode(px);
+  const double nx = node->point->x;
+
+  if (px == nx) {
+    if (point != node->point) {
+      // We might have two nodes with same x value for a short time
+      if (point == node->prev->point) {
+        node = node->prev;
+      } else if (point == node->next->point) {
+        node = node->next;
+      } else {
+        assert(0);
+      }
+    }
+  } else if (px < nx) {
+    while ((node = node->prev) != nullptr) {
+      if (point == node->point) {
+        break;
+      }
+    }
+  } else {
+    while ((node = node->next) != nullptr) {
+      if (point == node->point)
+        break;
+    }
+  }
+  if(node) search_node_ = node;
+  return node;
+}
+
+AdvancingFront::~AdvancingFront()
+{
+}
+
+} // namespace p2t

--- a/src/kicad_tools/router/cpp/third_party/poly2tri/poly2tri/sweep/advancing_front.h
+++ b/src/kicad_tools/router/cpp/third_party/poly2tri/poly2tri/sweep/advancing_front.h
@@ -1,0 +1,115 @@
+/*
+ * Poly2Tri Copyright (c) 2009-2018, Poly2Tri Contributors
+ * https://github.com/jhasse/poly2tri
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * * Neither the name of Poly2Tri nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "../common/shapes.h"
+
+namespace p2t {
+
+struct Node;
+
+// Advancing front node
+struct Node {
+  Point* point;
+  Triangle* triangle;
+
+  Node* next;
+  Node* prev;
+
+  double value;
+
+  Node(Point& p) : point(&p), triangle(NULL), next(NULL), prev(NULL), value(p.x)
+  {
+  }
+
+  Node(Point& p, Triangle& t) : point(&p), triangle(&t), next(NULL), prev(NULL), value(p.x)
+  {
+  }
+
+};
+
+// Advancing front
+class AdvancingFront {
+public:
+
+AdvancingFront(Node& head, Node& tail);
+// Destructor
+~AdvancingFront();
+
+Node* head();
+void set_head(Node* node);
+Node* tail();
+void set_tail(Node* node);
+Node* search();
+void set_search(Node* node);
+
+/// Locate insertion point along advancing front
+Node* LocateNode(double x);
+
+Node* LocatePoint(const Point* point);
+
+private:
+
+Node* head_, *tail_, *search_node_;
+
+Node* FindSearchNode(double x);
+};
+
+inline Node* AdvancingFront::head()
+{
+  return head_;
+}
+inline void AdvancingFront::set_head(Node* node)
+{
+  head_ = node;
+}
+
+inline Node* AdvancingFront::tail()
+{
+  return tail_;
+}
+inline void AdvancingFront::set_tail(Node* node)
+{
+  tail_ = node;
+}
+
+inline Node* AdvancingFront::search()
+{
+  return search_node_;
+}
+
+inline void AdvancingFront::set_search(Node* node)
+{
+  search_node_ = node;
+}
+
+}

--- a/src/kicad_tools/router/cpp/third_party/poly2tri/poly2tri/sweep/cdt.cc
+++ b/src/kicad_tools/router/cpp/third_party/poly2tri/poly2tri/sweep/cdt.cc
@@ -1,0 +1,71 @@
+/*
+ * Poly2Tri Copyright (c) 2009-2021, Poly2Tri Contributors
+ * https://github.com/jhasse/poly2tri
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * * Neither the name of Poly2Tri nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "cdt.h"
+
+namespace p2t {
+
+CDT::CDT(const std::vector<Point*>& polyline)
+{
+  sweep_context_ = new SweepContext(polyline);
+  sweep_ = new Sweep;
+}
+
+void CDT::AddHole(const std::vector<Point*>& polyline)
+{
+  sweep_context_->AddHole(polyline);
+}
+
+void CDT::AddPoint(Point* point) {
+  sweep_context_->AddPoint(point);
+}
+
+void CDT::Triangulate()
+{
+  sweep_->Triangulate(*sweep_context_);
+}
+
+std::vector<p2t::Triangle*> CDT::GetTriangles()
+{
+  return sweep_context_->GetTriangles();
+}
+
+std::list<p2t::Triangle*> CDT::GetMap()
+{
+  return sweep_context_->GetMap();
+}
+
+CDT::~CDT()
+{
+  delete sweep_context_;
+  delete sweep_;
+}
+
+} // namespace p2t

--- a/src/kicad_tools/router/cpp/third_party/poly2tri/poly2tri/sweep/cdt.h
+++ b/src/kicad_tools/router/cpp/third_party/poly2tri/poly2tri/sweep/cdt.h
@@ -1,0 +1,104 @@
+/*
+ * Poly2Tri Copyright (c) 2009-2018, Poly2Tri Contributors
+ * https://github.com/jhasse/poly2tri
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * * Neither the name of Poly2Tri nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "advancing_front.h"
+#include "sweep_context.h"
+#include "sweep.h"
+
+#include "../common/dll_symbol.h"
+
+/**
+ *
+ * @author Mason Green <mason.green@gmail.com>
+ *
+ */
+
+namespace p2t {
+
+class P2T_DLL_SYMBOL CDT
+{
+public:
+
+  /**
+   * Constructor - add polyline with non repeating points
+   *
+   * @param polyline
+   */
+  CDT(const std::vector<Point*>& polyline);
+
+   /**
+   * Destructor - clean up memory
+   */
+  ~CDT();
+
+  /**
+   * Add a hole
+   *
+   * @param polyline
+   */
+  void AddHole(const std::vector<Point*>& polyline);
+
+  /**
+   * Add a steiner point
+   *
+   * @param point
+   */
+  void AddPoint(Point* point);
+
+  /**
+   * Triangulate - do this AFTER you've added the polyline, holes, and Steiner points
+   */
+  void Triangulate();
+
+  /**
+   * Get CDT triangles
+   */
+  std::vector<Triangle*> GetTriangles();
+
+  /**
+   * Get triangle map
+   */
+  std::list<Triangle*> GetMap();
+
+  private:
+
+  /**
+   * Internals
+   */
+
+  SweepContext* sweep_context_;
+  Sweep* sweep_;
+
+};
+
+}

--- a/src/kicad_tools/router/cpp/third_party/poly2tri/poly2tri/sweep/sweep.cc
+++ b/src/kicad_tools/router/cpp/third_party/poly2tri/poly2tri/sweep/sweep.cc
@@ -1,0 +1,860 @@
+/*
+ * Poly2Tri Copyright (c) 2009-2018, Poly2Tri Contributors
+ * https://github.com/jhasse/poly2tri
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * * Neither the name of Poly2Tri nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "sweep.h"
+#include "sweep_context.h"
+#include "advancing_front.h"
+#include "../common/utils.h"
+
+#include <cassert>
+#include <stdexcept>
+
+namespace p2t {
+
+// Triangulate simple polygon with holes
+void Sweep::Triangulate(SweepContext& tcx)
+{
+  tcx.InitTriangulation();
+  tcx.CreateAdvancingFront();
+  // Sweep points; build mesh
+  SweepPoints(tcx);
+  // Clean up
+  FinalizationPolygon(tcx);
+}
+
+void Sweep::SweepPoints(SweepContext& tcx)
+{
+  for (size_t i = 1; i < tcx.point_count(); i++) {
+    Point& point = *tcx.GetPoint(i);
+    Node* node = &PointEvent(tcx, point);
+    for (auto& j : point.edge_list) {
+      EdgeEvent(tcx, j, node);
+    }
+  }
+}
+
+void Sweep::FinalizationPolygon(SweepContext& tcx)
+{
+  // Get an Internal triangle to start with
+  Triangle* t = tcx.front()->head()->next->triangle;
+  Point* p = tcx.front()->head()->next->point;
+  while (t && !t->GetConstrainedEdgeCW(*p)) {
+    t = t->NeighborCCW(*p);
+  }
+
+  // Collect interior triangles constrained by edges
+  if (t) {
+    tcx.MeshClean(*t);
+  }
+}
+
+Node& Sweep::PointEvent(SweepContext& tcx, Point& point)
+{
+  Node* node_ptr = tcx.LocateNode(point);
+  if (!node_ptr || !node_ptr->point || !node_ptr->next || !node_ptr->next->point)
+  {
+    throw std::runtime_error("PointEvent - null node");
+  }
+
+  Node& node = *node_ptr;
+  Node& new_node = NewFrontTriangle(tcx, point, node);
+
+  // Only need to check +epsilon since point never have smaller
+  // x value than node due to how we fetch nodes from the front
+  if (point.x <= node.point->x + EPSILON) {
+    Fill(tcx, node);
+  }
+
+  //tcx.AddNode(new_node);
+
+  FillAdvancingFront(tcx, new_node);
+  return new_node;
+}
+
+void Sweep::EdgeEvent(SweepContext& tcx, Edge* edge, Node* node)
+{
+  tcx.edge_event.constrained_edge = edge;
+  tcx.edge_event.right = (edge->p->x > edge->q->x);
+
+  if (IsEdgeSideOfTriangle(*node->triangle, *edge->p, *edge->q)) {
+    return;
+  }
+
+  // For now we will do all needed filling
+  // TODO: integrate with flip process might give some better performance
+  //       but for now this avoid the issue with cases that needs both flips and fills
+  FillEdgeEvent(tcx, edge, node);
+  EdgeEvent(tcx, *edge->p, *edge->q, node->triangle, *edge->q);
+}
+
+void Sweep::EdgeEvent(SweepContext& tcx, Point& ep, Point& eq, Triangle* triangle, Point& point)
+{
+  if (triangle == nullptr) {
+    throw std::runtime_error("EdgeEvent - null triangle");
+  }
+  if (IsEdgeSideOfTriangle(*triangle, ep, eq)) {
+    return;
+  }
+
+  Point* p1 = triangle->PointCCW(point);
+  Orientation o1 = Orient2d(eq, *p1, ep);
+  if (o1 == COLLINEAR) {
+    if (triangle->Contains(&eq, p1)) {
+      triangle->MarkConstrainedEdge(&eq, p1);
+      // We are modifying the constraint maybe it would be better to
+      // not change the given constraint and just keep a variable for the new constraint
+      tcx.edge_event.constrained_edge->q = p1;
+      triangle = triangle->NeighborAcross(point);
+      EdgeEvent(tcx, ep, *p1, triangle, *p1);
+    } else {
+      throw std::runtime_error("EdgeEvent - collinear points not supported");
+    }
+    return;
+  }
+
+  Point* p2 = triangle->PointCW(point);
+  Orientation o2 = Orient2d(eq, *p2, ep);
+  if (o2 == COLLINEAR) {
+    if (triangle->Contains(&eq, p2)) {
+      triangle->MarkConstrainedEdge(&eq, p2);
+      // We are modifying the constraint maybe it would be better to
+      // not change the given constraint and just keep a variable for the new constraint
+      tcx.edge_event.constrained_edge->q = p2;
+      triangle = triangle->NeighborAcross(point);
+      EdgeEvent(tcx, ep, *p2, triangle, *p2);
+    } else {
+      throw std::runtime_error("EdgeEvent - collinear points not supported");
+    }
+    return;
+  }
+
+  if (o1 == o2) {
+    // Need to decide if we are rotating CW or CCW to get to a triangle
+    // that will cross edge
+    if (o1 == CW) {
+      triangle = triangle->NeighborCCW(point);
+    } else {
+      triangle = triangle->NeighborCW(point);
+    }
+    EdgeEvent(tcx, ep, eq, triangle, point);
+  } else {
+    // This triangle crosses constraint so lets flippin start!
+    assert(triangle);
+    FlipEdgeEvent(tcx, ep, eq, triangle, point);
+  }
+}
+
+bool Sweep::IsEdgeSideOfTriangle(Triangle& triangle, Point& ep, Point& eq)
+{
+  const int index = triangle.EdgeIndex(&ep, &eq);
+
+  if (index != -1) {
+    triangle.MarkConstrainedEdge(index);
+    Triangle* t = triangle.GetNeighbor(index);
+    if (t) {
+      t->MarkConstrainedEdge(&ep, &eq);
+    }
+    return true;
+  }
+  return false;
+}
+
+Node& Sweep::NewFrontTriangle(SweepContext& tcx, Point& point, Node& node)
+{
+  Triangle* triangle = new Triangle(point, *node.point, *node.next->point);
+
+  triangle->MarkNeighbor(*node.triangle);
+  tcx.AddToMap(triangle);
+
+  Node* new_node = new Node(point);
+  nodes_.push_back(new_node);
+
+  new_node->next = node.next;
+  new_node->prev = &node;
+  node.next->prev = new_node;
+  node.next = new_node;
+
+  if (!Legalize(tcx, *triangle)) {
+    tcx.MapTriangleToNodes(*triangle);
+  }
+
+  return *new_node;
+}
+
+void Sweep::Fill(SweepContext& tcx, Node& node)
+{
+  Triangle* triangle = new Triangle(*node.prev->point, *node.point, *node.next->point);
+
+  // TODO: should copy the constrained_edge value from neighbor triangles
+  //       for now constrained_edge values are copied during the legalize
+  triangle->MarkNeighbor(*node.prev->triangle);
+  triangle->MarkNeighbor(*node.triangle);
+
+  tcx.AddToMap(triangle);
+
+  // Update the advancing front
+  node.prev->next = node.next;
+  node.next->prev = node.prev;
+
+  // If it was legalized the triangle has already been mapped
+  if (!Legalize(tcx, *triangle)) {
+    tcx.MapTriangleToNodes(*triangle);
+  }
+}
+
+void Sweep::FillAdvancingFront(SweepContext& tcx, Node& n)
+{
+
+  // Fill right holes
+  Node* node = n.next;
+
+  while (node && node->next) {
+    // if HoleAngle exceeds 90 degrees then break.
+    if (LargeHole_DontFill(node)) break;
+    Fill(tcx, *node);
+    node = node->next;
+  }
+
+  // Fill left holes
+  node = n.prev;
+
+  while (node && node->prev) {
+    // if HoleAngle exceeds 90 degrees then break.
+    if (LargeHole_DontFill(node)) break;
+    Fill(tcx, *node);
+    node = node->prev;
+  }
+
+  // Fill right basins
+  if (n.next && n.next->next) {
+    const double angle = BasinAngle(n);
+    if (angle < PI_3div4) {
+      FillBasin(tcx, n);
+    }
+  }
+}
+
+// True if HoleAngle exceeds 90 degrees.
+// LargeHole_DontFill checks if the advancing front has a large hole.
+// A "Large hole" is a triangle formed by a sequence of points in the advancing
+// front where three neighbor points form a triangle.
+// And angle between left-top, bottom, and right-top points is more than 90 degrees.
+// The first part of the algorithm reviews only three neighbor points, e.g. named A, B, C.
+// Additional part of this logic reviews a sequence of 5 points -
+// additionally reviews one point before and one after the sequence of three (A, B, C),
+// e.g. named X and Y.
+// In this case, angles are XBC and ABY and this if angles are negative or more
+// than 90 degrees LargeHole_DontFill returns true.
+// But there is a configuration when ABC has a negative angle but XBC or ABY is less
+// than 90 degrees and positive.
+// Then function LargeHole_DontFill return false and initiates filling.
+// This filling creates a triangle ABC and adds it to the advancing front.
+// But in the case when angle ABC is negative this triangle goes inside the advancing front
+// and can intersect previously created triangles.
+// This triangle leads to making wrong advancing front and problems in triangulation in the future.
+// Looks like such a triangle should not be created.
+// The simplest way to check and fix it is to check an angle ABC.
+// If it is negative LargeHole_DontFill should return true and
+// not initiate creating the ABC triangle in the advancing front.
+// X______A         Y
+//        \        /
+//         \      /
+//          \ B  /
+//           |  /
+//           | /
+//           |/
+//           C
+bool Sweep::LargeHole_DontFill(const Node* node) const {
+
+  const Node* nextNode = node->next;
+  const Node* prevNode = node->prev;
+  if (!AngleExceeds90Degrees(node->point, nextNode->point, prevNode->point))
+          return false;
+
+  if (AngleIsNegative(node->point, nextNode->point, prevNode->point))
+          return true;
+
+  // Check additional points on front.
+  const Node* next2Node = nextNode->next;
+  // "..Plus.." because only want angles on same side as point being added.
+  if ((next2Node != nullptr) && !AngleExceedsPlus90DegreesOrIsNegative(node->point, next2Node->point, prevNode->point))
+          return false;
+
+  const Node* prev2Node = prevNode->prev;
+  // "..Plus.." because only want angles on same side as point being added.
+  if ((prev2Node != nullptr) && !AngleExceedsPlus90DegreesOrIsNegative(node->point, nextNode->point, prev2Node->point))
+          return false;
+
+  return true;
+}
+
+bool Sweep::AngleIsNegative(const Point* origin, const Point* pa, const Point* pb) const {
+    const double angle = Angle(origin, pa, pb);
+    return angle < 0;
+}
+
+bool Sweep::AngleExceeds90Degrees(const Point* origin, const Point* pa, const Point* pb) const {
+  const double angle = Angle(origin, pa, pb);
+  return ((angle > PI_div2) || (angle < -PI_div2));
+}
+
+bool Sweep::AngleExceedsPlus90DegreesOrIsNegative(const Point* origin, const Point* pa, const Point* pb) const {
+  const double angle = Angle(origin, pa, pb);
+  return (angle > PI_div2) || (angle < 0);
+}
+
+double Sweep::Angle(const Point* origin, const Point* pa, const Point* pb) const {
+  /* Complex plane
+   * ab = cosA +i*sinA
+   * ab = (ax + ay*i)(bx + by*i) = (ax*bx + ay*by) + i(ax*by-ay*bx)
+   * atan2(y,x) computes the principal value of the argument function
+   * applied to the complex number x+iy
+   * Where x = ax*bx + ay*by
+   *       y = ax*by - ay*bx
+   */
+  const double px = origin->x;
+  const double py = origin->y;
+  const double ax = pa->x - px;
+  const double ay = pa->y - py;
+  const double bx = pb->x - px;
+  const double by = pb->y - py;
+  const double x = ax * by - ay * bx;
+  const double y = ax * bx + ay * by;
+  return atan2(x, y);
+}
+
+double Sweep::BasinAngle(const Node& node) const
+{
+  const double ax = node.point->x - node.next->next->point->x;
+  const double ay = node.point->y - node.next->next->point->y;
+  return atan2(ay, ax);
+}
+
+double Sweep::HoleAngle(const Node& node) const
+{
+  /* Complex plane
+   * ab = cosA +i*sinA
+   * ab = (ax + ay*i)(bx + by*i) = (ax*bx + ay*by) + i(ax*by-ay*bx)
+   * atan2(y,x) computes the principal value of the argument function
+   * applied to the complex number x+iy
+   * Where x = ax*bx + ay*by
+   *       y = ax*by - ay*bx
+   */
+  const double ax = node.next->point->x - node.point->x;
+  const double ay = node.next->point->y - node.point->y;
+  const double bx = node.prev->point->x - node.point->x;
+  const double by = node.prev->point->y - node.point->y;
+  return atan2(ax * by - ay * bx, ax * bx + ay * by);
+}
+
+bool Sweep::Legalize(SweepContext& tcx, Triangle& t)
+{
+  // To legalize a triangle we start by finding if any of the three edges
+  // violate the Delaunay condition
+  for (int i = 0; i < 3; i++) {
+    if (t.delaunay_edge[i])
+      continue;
+
+    Triangle* ot = t.GetNeighbor(i);
+
+    if (ot) {
+      Point* p = t.GetPoint(i);
+      Point* op = ot->OppositePoint(t, *p);
+      int oi = ot->Index(op);
+
+      // If this is a Constrained Edge or a Delaunay Edge(only during recursive legalization)
+      // then we should not try to legalize
+      if (ot->constrained_edge[oi] || ot->delaunay_edge[oi]) {
+        t.constrained_edge[i] = ot->constrained_edge[oi];
+        continue;
+      }
+
+      bool inside = Incircle(*p, *t.PointCCW(*p), *t.PointCW(*p), *op);
+
+      if (inside) {
+        // Lets mark this shared edge as Delaunay
+        t.delaunay_edge[i] = true;
+        ot->delaunay_edge[oi] = true;
+
+        // Lets rotate shared edge one vertex CW to legalize it
+        RotateTrianglePair(t, *p, *ot, *op);
+
+        // We now got one valid Delaunay Edge shared by two triangles
+        // This gives us 4 new edges to check for Delaunay
+
+        // Make sure that triangle to node mapping is done only one time for a specific triangle
+        bool not_legalized = !Legalize(tcx, t);
+        if (not_legalized) {
+          tcx.MapTriangleToNodes(t);
+        }
+
+        not_legalized = !Legalize(tcx, *ot);
+        if (not_legalized)
+          tcx.MapTriangleToNodes(*ot);
+
+        // Reset the Delaunay edges, since they only are valid Delaunay edges
+        // until we add a new triangle or point.
+        // XXX: need to think about this. Can these edges be tried after we
+        //      return to previous recursive level?
+        t.delaunay_edge[i] = false;
+        ot->delaunay_edge[oi] = false;
+
+        // If triangle have been legalized no need to check the other edges since
+        // the recursive legalization will handles those so we can end here.
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+bool Sweep::Incircle(const Point& pa, const Point& pb, const Point& pc, const Point& pd) const
+{
+  const double adx = pa.x - pd.x;
+  const double ady = pa.y - pd.y;
+  const double bdx = pb.x - pd.x;
+  const double bdy = pb.y - pd.y;
+
+  const double adxbdy = adx * bdy;
+  const double bdxady = bdx * ady;
+  const double oabd = adxbdy - bdxady;
+
+  if (oabd <= 0)
+    return false;
+
+  const double cdx = pc.x - pd.x;
+  const double cdy = pc.y - pd.y;
+
+  const double cdxady = cdx * ady;
+  const double adxcdy = adx * cdy;
+  const double ocad = cdxady - adxcdy;
+
+  if (ocad <= 0)
+    return false;
+
+  const double bdxcdy = bdx * cdy;
+  const double cdxbdy = cdx * bdy;
+
+  const double alift = adx * adx + ady * ady;
+  const double blift = bdx * bdx + bdy * bdy;
+  const double clift = cdx * cdx + cdy * cdy;
+
+  const double det = alift * (bdxcdy - cdxbdy) + blift * ocad + clift * oabd;
+
+  return det > 0;
+}
+
+void Sweep::RotateTrianglePair(Triangle& t, Point& p, Triangle& ot, Point& op) const
+{
+  Triangle* n1, *n2, *n3, *n4;
+  n1 = t.NeighborCCW(p);
+  n2 = t.NeighborCW(p);
+  n3 = ot.NeighborCCW(op);
+  n4 = ot.NeighborCW(op);
+
+  bool ce1, ce2, ce3, ce4;
+  ce1 = t.GetConstrainedEdgeCCW(p);
+  ce2 = t.GetConstrainedEdgeCW(p);
+  ce3 = ot.GetConstrainedEdgeCCW(op);
+  ce4 = ot.GetConstrainedEdgeCW(op);
+
+  bool de1, de2, de3, de4;
+  de1 = t.GetDelunayEdgeCCW(p);
+  de2 = t.GetDelunayEdgeCW(p);
+  de3 = ot.GetDelunayEdgeCCW(op);
+  de4 = ot.GetDelunayEdgeCW(op);
+
+  t.Legalize(p, op);
+  ot.Legalize(op, p);
+
+  // Remap delaunay_edge
+  ot.SetDelunayEdgeCCW(p, de1);
+  t.SetDelunayEdgeCW(p, de2);
+  t.SetDelunayEdgeCCW(op, de3);
+  ot.SetDelunayEdgeCW(op, de4);
+
+  // Remap constrained_edge
+  ot.SetConstrainedEdgeCCW(p, ce1);
+  t.SetConstrainedEdgeCW(p, ce2);
+  t.SetConstrainedEdgeCCW(op, ce3);
+  ot.SetConstrainedEdgeCW(op, ce4);
+
+  // Remap neighbors
+  // XXX: might optimize the markNeighbor by keeping track of
+  //      what side should be assigned to what neighbor after the
+  //      rotation. Now mark neighbor does lots of testing to find
+  //      the right side.
+  t.ClearNeighbors();
+  ot.ClearNeighbors();
+  if (n1) ot.MarkNeighbor(*n1);
+  if (n2) t.MarkNeighbor(*n2);
+  if (n3) t.MarkNeighbor(*n3);
+  if (n4) ot.MarkNeighbor(*n4);
+  t.MarkNeighbor(ot);
+}
+
+void Sweep::FillBasin(SweepContext& tcx, Node& node)
+{
+  if (Orient2d(*node.point, *node.next->point, *node.next->next->point) == CCW) {
+    tcx.basin.left_node = node.next->next;
+  } else {
+    tcx.basin.left_node = node.next;
+  }
+
+  // Find the bottom and right node
+  tcx.basin.bottom_node = tcx.basin.left_node;
+  while (tcx.basin.bottom_node->next
+         && tcx.basin.bottom_node->point->y >= tcx.basin.bottom_node->next->point->y) {
+    tcx.basin.bottom_node = tcx.basin.bottom_node->next;
+  }
+  if (tcx.basin.bottom_node == tcx.basin.left_node) {
+    // No valid basin
+    return;
+  }
+
+  tcx.basin.right_node = tcx.basin.bottom_node;
+  while (tcx.basin.right_node->next
+         && tcx.basin.right_node->point->y < tcx.basin.right_node->next->point->y) {
+    tcx.basin.right_node = tcx.basin.right_node->next;
+  }
+  if (tcx.basin.right_node == tcx.basin.bottom_node) {
+    // No valid basins
+    return;
+  }
+
+  tcx.basin.width = tcx.basin.right_node->point->x - tcx.basin.left_node->point->x;
+  tcx.basin.left_highest = tcx.basin.left_node->point->y > tcx.basin.right_node->point->y;
+
+  FillBasinReq(tcx, tcx.basin.bottom_node);
+}
+
+void Sweep::FillBasinReq(SweepContext& tcx, Node* node)
+{
+  // if shallow stop filling
+  if (IsShallow(tcx, *node)) {
+    return;
+  }
+
+  Fill(tcx, *node);
+
+  if (node->prev == tcx.basin.left_node && node->next == tcx.basin.right_node) {
+    return;
+  } else if (node->prev == tcx.basin.left_node) {
+    Orientation o = Orient2d(*node->point, *node->next->point, *node->next->next->point);
+    if (o == CW) {
+      return;
+    }
+    node = node->next;
+  } else if (node->next == tcx.basin.right_node) {
+    Orientation o = Orient2d(*node->point, *node->prev->point, *node->prev->prev->point);
+    if (o == CCW) {
+      return;
+    }
+    node = node->prev;
+  } else {
+    // Continue with the neighbor node with lowest Y value
+    if (node->prev->point->y < node->next->point->y) {
+      node = node->prev;
+    } else {
+      node = node->next;
+    }
+  }
+
+  FillBasinReq(tcx, node);
+}
+
+bool Sweep::IsShallow(SweepContext& tcx, Node& node)
+{
+  double height;
+
+  if (tcx.basin.left_highest) {
+    height = tcx.basin.left_node->point->y - node.point->y;
+  } else {
+    height = tcx.basin.right_node->point->y - node.point->y;
+  }
+
+  // if shallow stop filling
+  if (tcx.basin.width > height) {
+    return true;
+  }
+  return false;
+}
+
+void Sweep::FillEdgeEvent(SweepContext& tcx, Edge* edge, Node* node)
+{
+  if (tcx.edge_event.right) {
+    FillRightAboveEdgeEvent(tcx, edge, node);
+  } else {
+    FillLeftAboveEdgeEvent(tcx, edge, node);
+  }
+}
+
+void Sweep::FillRightAboveEdgeEvent(SweepContext& tcx, Edge* edge, Node* node)
+{
+  while (node->next->point->x < edge->p->x) {
+    // Check if next node is below the edge
+    if (Orient2d(*edge->q, *node->next->point, *edge->p) == CCW) {
+      FillRightBelowEdgeEvent(tcx, edge, *node);
+    } else {
+      node = node->next;
+    }
+  }
+}
+
+void Sweep::FillRightBelowEdgeEvent(SweepContext& tcx, Edge* edge, Node& node)
+{
+  if (node.point->x < edge->p->x) {
+    if (Orient2d(*node.point, *node.next->point, *node.next->next->point) == CCW) {
+      // Concave
+      FillRightConcaveEdgeEvent(tcx, edge, node);
+    } else {
+      // Convex
+      FillRightConvexEdgeEvent(tcx, edge, node);
+      // Retry this one
+      FillRightBelowEdgeEvent(tcx, edge, node);
+    }
+  }
+}
+
+void Sweep::FillRightConcaveEdgeEvent(SweepContext& tcx, Edge* edge, Node& node)
+{
+  Fill(tcx, *node.next);
+  if (node.next->point != edge->p) {
+    // Next above or below edge?
+    if (Orient2d(*edge->q, *node.next->point, *edge->p) == CCW) {
+      // Below
+      if (Orient2d(*node.point, *node.next->point, *node.next->next->point) == CCW) {
+        // Next is concave
+        FillRightConcaveEdgeEvent(tcx, edge, node);
+      } else {
+        // Next is convex
+      }
+    }
+  }
+}
+
+void Sweep::FillRightConvexEdgeEvent(SweepContext& tcx, Edge* edge, Node& node)
+{
+  // Next concave or convex?
+  if (Orient2d(*node.next->point, *node.next->next->point, *node.next->next->next->point) == CCW) {
+    // Concave
+    FillRightConcaveEdgeEvent(tcx, edge, *node.next);
+  } else {
+    // Convex
+    // Next above or below edge?
+    if (Orient2d(*edge->q, *node.next->next->point, *edge->p) == CCW) {
+      // Below
+      FillRightConvexEdgeEvent(tcx, edge, *node.next);
+    } else {
+      // Above
+    }
+  }
+}
+
+void Sweep::FillLeftAboveEdgeEvent(SweepContext& tcx, Edge* edge, Node* node)
+{
+  while (node->prev->point->x > edge->p->x) {
+    // Check if next node is below the edge
+    if (Orient2d(*edge->q, *node->prev->point, *edge->p) == CW) {
+      FillLeftBelowEdgeEvent(tcx, edge, *node);
+    } else {
+      node = node->prev;
+    }
+  }
+}
+
+void Sweep::FillLeftBelowEdgeEvent(SweepContext& tcx, Edge* edge, Node& node)
+{
+  if (node.point->x > edge->p->x) {
+    if (Orient2d(*node.point, *node.prev->point, *node.prev->prev->point) == CW) {
+      // Concave
+      FillLeftConcaveEdgeEvent(tcx, edge, node);
+    } else {
+      // Convex
+      FillLeftConvexEdgeEvent(tcx, edge, node);
+      // Retry this one
+      FillLeftBelowEdgeEvent(tcx, edge, node);
+    }
+  }
+}
+
+void Sweep::FillLeftConvexEdgeEvent(SweepContext& tcx, Edge* edge, Node& node)
+{
+  // Next concave or convex?
+  if (Orient2d(*node.prev->point, *node.prev->prev->point, *node.prev->prev->prev->point) == CW) {
+    // Concave
+    FillLeftConcaveEdgeEvent(tcx, edge, *node.prev);
+  } else {
+    // Convex
+    // Next above or below edge?
+    if (Orient2d(*edge->q, *node.prev->prev->point, *edge->p) == CW) {
+      // Below
+      FillLeftConvexEdgeEvent(tcx, edge, *node.prev);
+    } else {
+      // Above
+    }
+  }
+}
+
+void Sweep::FillLeftConcaveEdgeEvent(SweepContext& tcx, Edge* edge, Node& node)
+{
+  Fill(tcx, *node.prev);
+  if (node.prev->point != edge->p) {
+    // Next above or below edge?
+    if (Orient2d(*edge->q, *node.prev->point, *edge->p) == CW) {
+      // Below
+      if (Orient2d(*node.point, *node.prev->point, *node.prev->prev->point) == CW) {
+        // Next is concave
+        FillLeftConcaveEdgeEvent(tcx, edge, node);
+      } else {
+        // Next is convex
+      }
+    }
+  }
+}
+
+void Sweep::FlipEdgeEvent(SweepContext& tcx, Point& ep, Point& eq, Triangle* t, Point& p)
+{
+  assert(t);
+  Triangle* ot_ptr = t->NeighborAcross(p);
+  if (ot_ptr == nullptr)
+  {
+    throw std::runtime_error("FlipEdgeEvent - null neighbor across");
+  }
+  Triangle& ot = *ot_ptr;
+  Point& op = *ot.OppositePoint(*t, p);
+
+  if (InScanArea(p, *t->PointCCW(p), *t->PointCW(p), op)) {
+    // Lets rotate shared edge one vertex CW
+    RotateTrianglePair(*t, p, ot, op);
+    tcx.MapTriangleToNodes(*t);
+    tcx.MapTriangleToNodes(ot);
+
+    if (p == eq && op == ep) {
+      if (eq == *tcx.edge_event.constrained_edge->q && ep == *tcx.edge_event.constrained_edge->p) {
+        t->MarkConstrainedEdge(&ep, &eq);
+        ot.MarkConstrainedEdge(&ep, &eq);
+        Legalize(tcx, *t);
+        Legalize(tcx, ot);
+      } else {
+        // XXX: I think one of the triangles should be legalized here?
+      }
+    } else {
+      Orientation o = Orient2d(eq, op, ep);
+      t = &NextFlipTriangle(tcx, (int)o, *t, ot, p, op);
+      FlipEdgeEvent(tcx, ep, eq, t, p);
+    }
+  } else {
+    Point& newP = NextFlipPoint(ep, eq, ot, op);
+    FlipScanEdgeEvent(tcx, ep, eq, *t, ot, newP);
+    EdgeEvent(tcx, ep, eq, t, p);
+  }
+}
+
+Triangle& Sweep::NextFlipTriangle(SweepContext& tcx, int o, Triangle& t, Triangle& ot, Point& p, Point& op)
+{
+  if (o == CCW) {
+    // ot is not crossing edge after flip
+    int edge_index = ot.EdgeIndex(&p, &op);
+    ot.delaunay_edge[edge_index] = true;
+    Legalize(tcx, ot);
+    ot.ClearDelunayEdges();
+    return t;
+  }
+
+  // t is not crossing edge after flip
+  int edge_index = t.EdgeIndex(&p, &op);
+
+  t.delaunay_edge[edge_index] = true;
+  Legalize(tcx, t);
+  t.ClearDelunayEdges();
+  return ot;
+}
+
+Point& Sweep::NextFlipPoint(Point& ep, Point& eq, Triangle& ot, Point& op)
+{
+  Orientation o2d = Orient2d(eq, op, ep);
+  if (o2d == CW) {
+    // Right
+    return *ot.PointCCW(op);
+  } else if (o2d == CCW) {
+    // Left
+    return *ot.PointCW(op);
+  }
+  throw std::runtime_error("[Unsupported] Opposing point on constrained edge");
+}
+
+void Sweep::FlipScanEdgeEvent(SweepContext& tcx, Point& ep, Point& eq, Triangle& flip_triangle,
+                              Triangle& t, Point& p)
+{
+  Triangle* ot_ptr = t.NeighborAcross(p);
+  if (ot_ptr == nullptr) {
+    throw std::runtime_error("FlipScanEdgeEvent - null neighbor across");
+  }
+
+  Point* op_ptr = ot_ptr->OppositePoint(t, p);
+  if (op_ptr == nullptr) {
+    throw std::runtime_error("FlipScanEdgeEvent - null opposing point");
+  }
+
+  Point* p1 = flip_triangle.PointCCW(eq);
+  Point* p2 = flip_triangle.PointCW(eq);
+  if (p1 == nullptr || p2 == nullptr) {
+    throw std::runtime_error("FlipScanEdgeEvent - null on either of points");
+  }
+
+  Triangle& ot = *ot_ptr;
+  Point& op = *op_ptr;
+
+  if (InScanArea(eq, *p1, *p2, op)) {
+    // flip with new edge op->eq
+    FlipEdgeEvent(tcx, eq, op, &ot, op);
+    // TODO: Actually I just figured out that it should be possible to
+    //       improve this by getting the next ot and op before the the above
+    //       flip and continue the flipScanEdgeEvent here
+    // set new ot and op here and loop back to inScanArea test
+    // also need to set a new flip_triangle first
+    // Turns out at first glance that this is somewhat complicated
+    // so it will have to wait.
+  } else {
+    Point& newP = NextFlipPoint(ep, eq, ot, op);
+    FlipScanEdgeEvent(tcx, ep, eq, flip_triangle, ot, newP);
+  }
+}
+
+Sweep::~Sweep() {
+
+    // Clean up memory
+    for (auto& node : nodes_) {
+      delete node;
+    }
+}
+
+} // namespace p2t

--- a/src/kicad_tools/router/cpp/third_party/poly2tri/poly2tri/sweep/sweep.h
+++ b/src/kicad_tools/router/cpp/third_party/poly2tri/poly2tri/sweep/sweep.h
@@ -1,0 +1,283 @@
+/*
+ * Poly2Tri Copyright (c) 2009-2018, Poly2Tri Contributors
+ * https://github.com/jhasse/poly2tri
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * * Neither the name of Poly2Tri nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * Sweep-line, Constrained Delauney Triangulation (CDT) See: Domiter, V. and
+ * Zalik, B.(2008)'Sweep-line algorithm for constrained Delaunay triangulation',
+ * International Journal of Geographical Information Science
+ *
+ * "FlipScan" Constrained Edge Algorithm invented by Thomas Åhlén, thahlen@gmail.com
+ */
+
+#pragma once
+
+#include <vector>
+
+namespace p2t {
+
+class SweepContext;
+struct Node;
+struct Point;
+struct Edge;
+class Triangle;
+
+class Sweep
+{
+public:
+
+  /**
+   * Triangulate
+   *
+   * @param tcx
+   */
+  void Triangulate(SweepContext& tcx);
+
+  /**
+   * Destructor - clean up memory
+   */
+  ~Sweep();
+
+private:
+
+  /**
+   * Start sweeping the Y-sorted point set from bottom to top
+   *
+   * @param tcx
+   */
+  void SweepPoints(SweepContext& tcx);
+
+  /**
+   * Find closes node to the left of the new point and
+   * create a new triangle. If needed new holes and basins
+   * will be filled to.
+   *
+   * @param tcx
+   * @param point
+   * @return
+   */
+  Node& PointEvent(SweepContext& tcx, Point& point);
+
+   /**
+     *
+     *
+     * @param tcx
+     * @param edge
+     * @param node
+     */
+  void EdgeEvent(SweepContext& tcx, Edge* edge, Node* node);
+
+  void EdgeEvent(SweepContext& tcx, Point& ep, Point& eq, Triangle* triangle, Point& point);
+
+  /**
+   * Creates a new front triangle and legalize it
+   *
+   * @param tcx
+   * @param point
+   * @param node
+   * @return
+   */
+  Node& NewFrontTriangle(SweepContext& tcx, Point& point, Node& node);
+
+  /**
+   * Adds a triangle to the advancing front to fill a hole.
+   * @param tcx
+   * @param node - middle node, that is the bottom of the hole
+   */
+  void Fill(SweepContext& tcx, Node& node);
+
+  /**
+   * Returns true if triangle was legalized
+   */
+  bool Legalize(SweepContext& tcx, Triangle& t);
+
+  /**
+   * <b>Requirement</b>:<br>
+   * 1. a,b and c form a triangle.<br>
+   * 2. a and d is know to be on opposite side of bc<br>
+   * <pre>
+   *                a
+   *                +
+   *               / \
+   *              /   \
+   *            b/     \c
+   *            +-------+
+   *           /    d    \
+   *          /           \
+   * </pre>
+   * <b>Fact</b>: d has to be in area B to have a chance to be inside the circle formed by
+   *  a,b and c<br>
+   *  d is outside B if orient2d(a,b,d) or orient2d(c,a,d) is CW<br>
+   *  This preknowledge gives us a way to optimize the incircle test
+   * @param a - triangle point, opposite d
+   * @param b - triangle point
+   * @param c - triangle point
+   * @param d - point opposite a
+   * @return true if d is inside circle, false if on circle edge
+   */
+  bool Incircle(const Point& pa, const Point& pb, const Point& pc, const Point& pd) const;
+
+  /**
+   * Rotates a triangle pair one vertex CW
+   *<pre>
+   *       n2                    n2
+   *  P +-----+             P +-----+
+   *    | t  /|               |\  t |
+   *    |   / |               | \   |
+   *  n1|  /  |n3           n1|  \  |n3
+   *    | /   |    after CW   |   \ |
+   *    |/ oT |               | oT \|
+   *    +-----+ oP            +-----+
+   *       n4                    n4
+   * </pre>
+   */
+  void RotateTrianglePair(Triangle& t, Point& p, Triangle& ot, Point& op) const;
+
+  /**
+   * Fills holes in the Advancing Front
+   *
+   *
+   * @param tcx
+   * @param n
+   */
+  void FillAdvancingFront(SweepContext& tcx, Node& n);
+
+  // Decision-making about when to Fill hole.
+  // Contributed by ToolmakerSteve2
+  bool LargeHole_DontFill(const Node* node) const;
+  bool AngleIsNegative(const Point* origin, const Point* pa, const Point* pb) const;
+  bool AngleExceeds90Degrees(const Point* origin, const Point* pa, const Point* pb) const;
+  bool AngleExceedsPlus90DegreesOrIsNegative(const Point* origin, const Point* pa, const Point* pb) const;
+  double Angle(const Point* origin, const Point* pa, const Point* pb) const;
+
+  /**
+   *
+   * @param node - middle node
+   * @return the angle between 3 front nodes
+   */
+  double HoleAngle(const Node& node) const;
+
+  /**
+   * The basin angle is decided against the horizontal line [1,0]
+   */
+  double BasinAngle(const Node& node) const;
+
+  /**
+   * Fills a basin that has formed on the Advancing Front to the right
+   * of given node.<br>
+   * First we decide a left,bottom and right node that forms the
+   * boundaries of the basin. Then we do a reqursive fill.
+   *
+   * @param tcx
+   * @param node - starting node, this or next node will be left node
+   */
+  void FillBasin(SweepContext& tcx, Node& node);
+
+  /**
+   * Recursive algorithm to fill a Basin with triangles
+   *
+   * @param tcx
+   * @param node - bottom_node
+   * @param cnt - counter used to alternate on even and odd numbers
+   */
+  void FillBasinReq(SweepContext& tcx, Node* node);
+
+  bool IsShallow(SweepContext& tcx, Node& node);
+
+  bool IsEdgeSideOfTriangle(Triangle& triangle, Point& ep, Point& eq);
+
+  void FillEdgeEvent(SweepContext& tcx, Edge* edge, Node* node);
+
+  void FillRightAboveEdgeEvent(SweepContext& tcx, Edge* edge, Node* node);
+
+  void FillRightBelowEdgeEvent(SweepContext& tcx, Edge* edge, Node& node);
+
+  void FillRightConcaveEdgeEvent(SweepContext& tcx, Edge* edge, Node& node);
+
+  void FillRightConvexEdgeEvent(SweepContext& tcx, Edge* edge, Node& node);
+
+  void FillLeftAboveEdgeEvent(SweepContext& tcx, Edge* edge, Node* node);
+
+  void FillLeftBelowEdgeEvent(SweepContext& tcx, Edge* edge, Node& node);
+
+  void FillLeftConcaveEdgeEvent(SweepContext& tcx, Edge* edge, Node& node);
+
+  void FillLeftConvexEdgeEvent(SweepContext& tcx, Edge* edge, Node& node);
+
+  void FlipEdgeEvent(SweepContext& tcx, Point& ep, Point& eq, Triangle* t, Point& p);
+
+  /**
+   * After a flip we have two triangles and know that only one will still be
+   * intersecting the edge. So decide which to contiune with and legalize the other
+   *
+   * @param tcx
+   * @param o - should be the result of an orient2d( eq, op, ep )
+   * @param t - triangle 1
+   * @param ot - triangle 2
+   * @param p - a point shared by both triangles
+   * @param op - another point shared by both triangles
+   * @return returns the triangle still intersecting the edge
+   */
+  Triangle& NextFlipTriangle(SweepContext& tcx, int o, Triangle&  t, Triangle& ot, Point& p, Point& op);
+
+   /**
+     * When we need to traverse from one triangle to the next we need
+     * the point in current triangle that is the opposite point to the next
+     * triangle.
+     *
+     * @param ep
+     * @param eq
+     * @param ot
+     * @param op
+     * @return
+     */
+  Point& NextFlipPoint(Point& ep, Point& eq, Triangle& ot, Point& op);
+
+   /**
+     * Scan part of the FlipScan algorithm<br>
+     * When a triangle pair isn't flippable we will scan for the next
+     * point that is inside the flip triangle scan area. When found
+     * we generate a new flipEdgeEvent
+     *
+     * @param tcx
+     * @param ep - last point on the edge we are traversing
+     * @param eq - first point on the edge we are traversing
+     * @param flipTriangle - the current triangle sharing the point eq with edge
+     * @param t
+     * @param p
+     */
+  void FlipScanEdgeEvent(SweepContext& tcx, Point& ep, Point& eq, Triangle& flip_triangle, Triangle& t, Point& p);
+
+  void FinalizationPolygon(SweepContext& tcx);
+
+  std::vector<Node*> nodes_;
+
+};
+
+}

--- a/src/kicad_tools/router/cpp/third_party/poly2tri/poly2tri/sweep/sweep_context.cc
+++ b/src/kicad_tools/router/cpp/third_party/poly2tri/poly2tri/sweep/sweep_context.cc
@@ -1,0 +1,206 @@
+/*
+ * Poly2Tri Copyright (c) 2009-2022, Poly2Tri Contributors
+ * https://github.com/jhasse/poly2tri
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * * Neither the name of Poly2Tri nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "sweep_context.h"
+#include <algorithm>
+#include "advancing_front.h"
+
+namespace p2t {
+
+SweepContext::SweepContext(std::vector<Point*> polyline) : points_(std::move(polyline)),
+  front_(nullptr),
+  head_(nullptr),
+  tail_(nullptr),
+  af_head_(nullptr),
+  af_middle_(nullptr),
+  af_tail_(nullptr)
+{
+  InitEdges(points_);
+}
+
+void SweepContext::AddHole(const std::vector<Point*>& polyline)
+{
+  InitEdges(polyline);
+  for (auto i : polyline) {
+    points_.push_back(i);
+  }
+}
+
+void SweepContext::AddPoint(Point* point) {
+  points_.push_back(point);
+}
+
+std::vector<Triangle*> &SweepContext::GetTriangles()
+{
+  return triangles_;
+}
+
+std::list<Triangle*> &SweepContext::GetMap()
+{
+  return map_;
+}
+
+void SweepContext::InitTriangulation()
+{
+  double xmax(points_[0]->x), xmin(points_[0]->x);
+  double ymax(points_[0]->y), ymin(points_[0]->y);
+
+  // Calculate bounds.
+  for (auto& point : points_) {
+    Point& p = *point;
+    if (p.x > xmax)
+      xmax = p.x;
+    if (p.x < xmin)
+      xmin = p.x;
+    if (p.y > ymax)
+      ymax = p.y;
+    if (p.y < ymin)
+      ymin = p.y;
+  }
+
+  double dx = kAlpha * (xmax - xmin);
+  double dy = kAlpha * (ymax - ymin);
+  head_ = new Point(xmin - dx, ymin - dy);
+  tail_ = new Point(xmax + dx, ymin - dy);
+
+  // Sort points along y-axis
+  std::sort(points_.begin(), points_.end(), cmp);
+
+}
+
+void SweepContext::InitEdges(const std::vector<Point*>& polyline)
+{
+  size_t num_points = polyline.size();
+  for (size_t i = 0; i < num_points; i++) {
+    size_t j = i < num_points - 1 ? i + 1 : 0;
+    edge_list.push_back(new Edge(*polyline[i], *polyline[j]));
+  }
+}
+
+Point* SweepContext::GetPoint(size_t index)
+{
+  return points_[index];
+}
+
+void SweepContext::AddToMap(Triangle* triangle)
+{
+  map_.push_back(triangle);
+}
+
+Node* SweepContext::LocateNode(const Point& point)
+{
+  // TODO implement search tree
+  return front_->LocateNode(point.x);
+}
+
+void SweepContext::CreateAdvancingFront()
+{
+
+  // Initial triangle
+  Triangle* triangle = new Triangle(*points_[0], *head_, *tail_);
+
+  map_.push_back(triangle);
+
+  af_head_ = new Node(*triangle->GetPoint(1), *triangle);
+  af_middle_ = new Node(*triangle->GetPoint(0), *triangle);
+  af_tail_ = new Node(*triangle->GetPoint(2));
+  front_ = new AdvancingFront(*af_head_, *af_tail_);
+
+  // TODO: More intuitive if head is middles next and not previous?
+  //       so swap head and tail
+  af_head_->next = af_middle_;
+  af_middle_->next = af_tail_;
+  af_middle_->prev = af_head_;
+  af_tail_->prev = af_middle_;
+}
+
+void SweepContext::RemoveNode(Node* node)
+{
+  delete node;
+}
+
+void SweepContext::MapTriangleToNodes(Triangle& t)
+{
+  for (int i = 0; i < 3; i++) {
+    if (!t.GetNeighbor(i)) {
+      Node* n = front_->LocatePoint(t.PointCW(*t.GetPoint(i)));
+      if (n)
+        n->triangle = &t;
+    }
+  }
+}
+
+void SweepContext::RemoveFromMap(Triangle* triangle)
+{
+  map_.remove(triangle);
+}
+
+void SweepContext::MeshClean(Triangle& triangle)
+{
+  std::vector<Triangle *> triangles;
+  triangles.push_back(&triangle);
+
+  while(!triangles.empty()){
+	Triangle *t = triangles.back();
+	triangles.pop_back();
+
+    if (t != nullptr && !t->IsInterior()) {
+      t->IsInterior(true);
+      triangles_.push_back(t);
+      for (int i = 0; i < 3; i++) {
+        if (!t->constrained_edge[i])
+          triangles.push_back(t->GetNeighbor(i));
+      }
+    }
+  }
+}
+
+SweepContext::~SweepContext()
+{
+
+    // Clean up memory
+
+    delete head_;
+    delete tail_;
+    delete front_;
+    delete af_head_;
+    delete af_middle_;
+    delete af_tail_;
+
+    for (auto ptr : map_) {
+      delete ptr;
+    }
+
+    for (auto& i : edge_list) {
+      delete i;
+    }
+}
+
+} // namespace p2t

--- a/src/kicad_tools/router/cpp/third_party/poly2tri/poly2tri/sweep/sweep_context.h
+++ b/src/kicad_tools/router/cpp/third_party/poly2tri/poly2tri/sweep/sweep_context.h
@@ -1,0 +1,184 @@
+/*
+ * Poly2Tri Copyright (c) 2009-2022, Poly2Tri Contributors
+ * https://github.com/jhasse/poly2tri
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * * Neither the name of Poly2Tri nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <list>
+#include <vector>
+#include <cstddef>
+
+namespace p2t {
+
+// Inital triangle factor, seed triangle will extend 30% of
+// PointSet width to both left and right.
+const double kAlpha = 0.3;
+
+struct Point;
+class Triangle;
+struct Node;
+struct Edge;
+class AdvancingFront;
+
+class SweepContext {
+public:
+
+/// Constructor
+explicit SweepContext(std::vector<Point*> polyline);
+/// Destructor
+~SweepContext();
+
+void set_head(Point* p1);
+
+Point* head() const;
+
+void set_tail(Point* p1);
+
+Point* tail() const;
+
+size_t point_count() const;
+
+Node* LocateNode(const Point& point);
+
+void RemoveNode(Node* node);
+
+void CreateAdvancingFront();
+
+/// Try to map a node to all sides of this triangle that don't have a neighbor
+void MapTriangleToNodes(Triangle& t);
+
+void AddToMap(Triangle* triangle);
+
+Point* GetPoint(size_t index);
+
+Point* GetPoints();
+
+void RemoveFromMap(Triangle* triangle);
+
+void AddHole(const std::vector<Point*>& polyline);
+
+void AddPoint(Point* point);
+
+AdvancingFront* front() const;
+
+void MeshClean(Triangle& triangle);
+
+std::vector<Triangle*> &GetTriangles();
+std::list<Triangle*> &GetMap();
+
+std::vector<Edge*> edge_list;
+
+struct Basin {
+  Node* left_node;
+  Node* bottom_node;
+  Node* right_node;
+  double width;
+  bool left_highest;
+
+  Basin()
+  : left_node(nullptr), bottom_node(nullptr), right_node(nullptr), width(0.0), left_highest(false)
+  {
+  }
+
+  void Clear()
+  {
+    left_node = nullptr;
+    bottom_node = nullptr;
+    right_node = nullptr;
+    width = 0.0;
+    left_highest = false;
+  }
+};
+
+struct EdgeEvent {
+  Edge* constrained_edge;
+  bool right;
+
+  EdgeEvent() : constrained_edge(NULL), right(false)
+  {
+  }
+};
+
+Basin basin;
+EdgeEvent edge_event;
+
+private:
+
+friend class Sweep;
+
+std::vector<Triangle*> triangles_;
+std::list<Triangle*> map_;
+std::vector<Point*> points_;
+
+// Advancing front
+AdvancingFront* front_;
+// head point used with advancing front
+Point* head_;
+// tail point used with advancing front
+Point* tail_;
+
+Node *af_head_, *af_middle_, *af_tail_;
+
+void InitTriangulation();
+void InitEdges(const std::vector<Point*>& polyline);
+
+};
+
+inline AdvancingFront* SweepContext::front() const
+{
+  return front_;
+}
+
+inline size_t SweepContext::point_count() const
+{
+  return points_.size();
+}
+
+inline void SweepContext::set_head(Point* p1)
+{
+  head_ = p1;
+}
+
+inline Point* SweepContext::head() const
+{
+  return head_;
+}
+
+inline void SweepContext::set_tail(Point* p1)
+{
+  tail_ = p1;
+}
+
+inline Point* SweepContext::tail() const
+{
+  return tail_;
+}
+
+}

--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -157,7 +157,7 @@ def _sync_pad_to_cpp_grid(
     # Avoid hard dependency on cpp_backend at import time (cpp_backend
     # imports grid.py).  Defer the router_cpp import to call time.
     try:
-        from . import router_cpp  # type: ignore[attr-defined]
+        from . import router_cpp
     except ImportError:
         return
 
@@ -253,7 +253,7 @@ def _sync_pad_cells_to_cpp_grid(
             caller's ``_add_pad_unsafe`` loop.
     """
     try:
-        from . import router_cpp  # type: ignore[attr-defined]  # noqa: F401
+        from . import router_cpp  # noqa: F401
     except ImportError:
         return
 

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -3361,6 +3361,7 @@ def load_pcb_for_routing(
     per_net_iterations: int = 0,
     region: tuple[float, float, float, float] | None = None,
     stub_terminals: dict[int, list[StubTerminal]] | None = None,
+    strategy: str = "grid",
 ) -> tuple[Autorouter, dict[str, int]]:
     """
     Load a KiCad PCB file and create an Autorouter with all components.
@@ -3739,6 +3740,8 @@ def load_pcb_for_routing(
         max_search_iterations=max_search_iterations,
         # Issue #3881: thread the tuned per-net iteration cap through too.
         per_net_iterations=per_net_iterations,
+        # Issue #4268: mesh-router strategy selector (default "grid").
+        strategy=strategy,
     )
 
     # Issue #3371 / P_FP3 -- fine-pitch escape region detection.  Must run

--- a/src/kicad_tools/router/mesh/__init__.py
+++ b/src/kicad_tools/router/mesh/__init__.py
@@ -1,0 +1,33 @@
+"""Mesh-router navigation substrate (issue #4268, epic #4267).
+
+The mesh strategy is an alternative to the uniform-grid router that trades the
+grid's ``area / resolution^2`` memory wall for a triangle-dual navmesh whose
+node count scales with feature complexity (~3,500x less memory on softstart
+rev-C in the P0 spike).  P1 is the single-net vertical slice, default OFF
+behind ``--strategy mesh``:
+
+    poly2tri constrained-Delaunay (with pad keep-out holes)
+      -> triangle-dual portal-midpoint A*        (navmesh.py)
+      -> Simple Stupid Funnel string-pull        (funnel.py)
+      -> clearance-aware 45-degree best-fit       (octilinear.py)
+      -> ordinary Route -> existing emission + DRC tail
+
+Multi-net negotiation, capacity, and matched routing are explicitly out of
+scope for P1 (epic children P2/P3).
+"""
+
+from __future__ import annotations
+
+from .funnel import string_pull
+from .navmesh import NavMesh
+from .obstacles import ObstacleModel
+from .octilinear import octilinear_fit
+from .pathfinder import MeshPathfinder
+
+__all__ = [
+    "MeshPathfinder",
+    "NavMesh",
+    "ObstacleModel",
+    "octilinear_fit",
+    "string_pull",
+]

--- a/src/kicad_tools/router/mesh/funnel.py
+++ b/src/kicad_tools/router/mesh/funnel.py
@@ -1,0 +1,113 @@
+"""Simple Stupid Funnel (Mononen string-pull) for the mesh router (#4268).
+
+Given a corridor of *portals* (the shared triangle edges along a navmesh A*
+path, each oriented ``(left, right)`` relative to travel direction), the
+funnel algorithm returns the Euclidean taut geodesic through the corridor --
+the shortest path a point agent can take.  This is the ~40-line component the
+P0.5 spike wrote and unit-tested (straight channel collapses to two points;
+L-channel pulls taut around the inner reflex corner); those two tests ship
+alongside in ``tests/router/mesh/test_funnel.py``.
+
+The funnel produces an *arbitrary-angle* geodesic; converting it to 45-legal
+copper is a separate downstream stage (``octilinear.py``), per the ADR's
+Option-1 resolution of the octilinear-geometry fork.
+"""
+
+from __future__ import annotations
+
+from .geometry import Pt, point_equal
+
+Portal = tuple[Pt, Pt]
+
+
+def _area(a: Pt, b: Pt, c: Pt) -> float:
+    """Mononen's ``triarea2`` sign convention (used verbatim below).
+
+    This is the negation of :func:`geometry.tri_area2`; the funnel's tighten /
+    cross comparisons are transcribed directly from Mononen's reference
+    implementation, so they must use his sign.
+    """
+    ax = b[0] - a[0]
+    ay = b[1] - a[1]
+    bx = c[0] - a[0]
+    by = c[1] - a[1]
+    return bx * ay - ax * by
+
+
+def string_pull(portals: list[Portal]) -> list[Pt]:
+    """Return the taut geodesic through an oriented portal corridor.
+
+    ``portals`` must start with a degenerate portal ``(start, start)`` and end
+    with ``(goal, goal)``; each intermediate portal is ``(left, right)`` with
+    ``left`` on the left-hand side of travel.  The returned polyline begins at
+    ``start`` and ends at ``goal``.
+    """
+    if not portals:
+        return []
+
+    path: list[Pt] = []
+
+    portal_apex = portals[0][0]
+    portal_left = portals[0][0]
+    portal_right = portals[0][1]
+    apex_index = 0
+    left_index = 0
+    right_index = 0
+
+    path.append(portal_apex)
+
+    i = 1
+    while i < len(portals):
+        left, right = portals[i]
+
+        # --- tighten / cross the RIGHT side -------------------------------
+        if _area(portal_apex, portal_right, right) <= 0.0:
+            if point_equal(portal_apex, portal_right) or (
+                _area(portal_apex, portal_left, right) > 0.0
+            ):
+                # Tighten the funnel on the right.
+                portal_right = right
+                right_index = i
+            else:
+                # Right crossed over left: left becomes the new apex.
+                if not path or not point_equal(path[-1], portal_left):
+                    path.append(portal_left)
+                portal_apex = portal_left
+                apex_index = left_index
+                # Restart scan from the new apex.
+                portal_left = portal_apex
+                portal_right = portal_apex
+                left_index = apex_index
+                right_index = apex_index
+                i = apex_index + 1
+                continue
+
+        # --- tighten / cross the LEFT side --------------------------------
+        if _area(portal_apex, portal_left, left) >= 0.0:
+            if point_equal(portal_apex, portal_left) or (
+                _area(portal_apex, portal_right, left) < 0.0
+            ):
+                # Tighten the funnel on the left.
+                portal_left = left
+                left_index = i
+            else:
+                # Left crossed over right: right becomes the new apex.
+                if not path or not point_equal(path[-1], portal_right):
+                    path.append(portal_right)
+                portal_apex = portal_right
+                apex_index = right_index
+                portal_left = portal_apex
+                portal_right = portal_apex
+                left_index = apex_index
+                right_index = apex_index
+                i = apex_index + 1
+                continue
+
+        i += 1
+
+    # Append the goal apex.
+    goal = portals[-1][0]
+    if not path or not point_equal(path[-1], goal):
+        path.append(goal)
+
+    return path

--- a/src/kicad_tools/router/mesh/geometry.py
+++ b/src/kicad_tools/router/mesh/geometry.py
@@ -1,0 +1,144 @@
+"""Small 2-D geometry primitives for the mesh router (issue #4268).
+
+Kept dependency-free (pure ``math``) and side-effect-free so the navmesh /
+funnel / octilinear-fit stages can each be unit-tested in isolation.  All
+coordinates are ``(x, y)`` float tuples in board millimetres.
+"""
+
+from __future__ import annotations
+
+import math
+
+Pt = tuple[float, float]
+
+# Distances below this (mm) are treated as coincident. Board features live at
+# the ~0.1 mm scale; 1e-9 mm is far below any manufacturable tolerance.
+EPS = 1e-9
+
+
+def tri_area2(a: Pt, b: Pt, c: Pt) -> float:
+    """Twice the signed area of triangle ``(a, b, c)``.
+
+    Positive when ``a, b, c`` wind counter-clockwise.  This is the sign
+    primitive the funnel string-pull turns on.
+    """
+    return (b[0] - a[0]) * (c[1] - a[1]) - (c[0] - a[0]) * (b[1] - a[1])
+
+
+def dist(a: Pt, b: Pt) -> float:
+    """Euclidean distance between two points."""
+    return math.hypot(b[0] - a[0], b[1] - a[1])
+
+
+def point_equal(a: Pt, b: Pt, eps: float = EPS) -> bool:
+    """True if two points coincide within ``eps``."""
+    return abs(a[0] - b[0]) <= eps and abs(a[1] - b[1]) <= eps
+
+
+def centroid(a: Pt, b: Pt, c: Pt) -> Pt:
+    """Centroid of a triangle."""
+    return ((a[0] + b[0] + c[0]) / 3.0, (a[1] + b[1] + c[1]) / 3.0)
+
+
+def point_in_triangle(p: Pt, a: Pt, b: Pt, c: Pt) -> bool:
+    """True if ``p`` lies inside or on the boundary of triangle ``(a, b, c)``.
+
+    Winding-agnostic: accepts either orientation.
+    """
+    d1 = tri_area2(p, a, b)
+    d2 = tri_area2(p, b, c)
+    d3 = tri_area2(p, c, a)
+    has_neg = (d1 < -EPS) or (d2 < -EPS) or (d3 < -EPS)
+    has_pos = (d1 > EPS) or (d2 > EPS) or (d3 > EPS)
+    return not (has_neg and has_pos)
+
+
+def point_in_polygon(p: Pt, poly: list[Pt]) -> bool:
+    """Ray-cast point-in-polygon test (boundary counts as inside).
+
+    ``poly`` is a closed ring given as an ordered vertex list WITHOUT a
+    repeated final vertex.
+    """
+    n = len(poly)
+    if n < 3:
+        return False
+    inside = False
+    j = n - 1
+    for i in range(n):
+        xi, yi = poly[i]
+        xj, yj = poly[j]
+        # On-edge check: treat boundary as inside.
+        if _point_on_segment(p, poly[i], poly[j]):
+            return True
+        intersects = ((yi > p[1]) != (yj > p[1])) and (
+            p[0] < (xj - xi) * (p[1] - yi) / (yj - yi + 0.0) + xi
+        )
+        if intersects:
+            inside = not inside
+        j = i
+    return inside
+
+
+def _point_on_segment(p: Pt, a: Pt, b: Pt, eps: float = 1e-7) -> bool:
+    """True if ``p`` lies on segment ``a-b`` within ``eps``."""
+    cross = tri_area2(a, b, p)
+    if abs(cross) > eps * max(1.0, dist(a, b)):
+        return False
+    # Within the bounding box of the segment (with slack).
+    return (
+        min(a[0], b[0]) - eps <= p[0] <= max(a[0], b[0]) + eps
+        and min(a[1], b[1]) - eps <= p[1] <= max(a[1], b[1]) + eps
+    )
+
+
+def _orient(a: Pt, b: Pt, c: Pt) -> int:
+    v = tri_area2(a, b, c)
+    if v > EPS:
+        return 1
+    if v < -EPS:
+        return -1
+    return 0
+
+
+def segments_intersect(a1: Pt, a2: Pt, b1: Pt, b2: Pt) -> bool:
+    """True if segment ``a1-a2`` intersects segment ``b1-b2`` (incl. touching)."""
+    o1 = _orient(a1, a2, b1)
+    o2 = _orient(a1, a2, b2)
+    o3 = _orient(b1, b2, a1)
+    o4 = _orient(b1, b2, a2)
+    if o1 != o2 and o3 != o4:
+        return True
+    # Collinear-overlap cases.
+    if o1 == 0 and _point_on_segment(b1, a1, a2):
+        return True
+    if o2 == 0 and _point_on_segment(b2, a1, a2):
+        return True
+    if o3 == 0 and _point_on_segment(a1, b1, b2):
+        return True
+    if o4 == 0 and _point_on_segment(a2, b1, b2):
+        return True
+    return False
+
+
+def segment_intersects_rect(
+    p1: Pt, p2: Pt, xmin: float, ymin: float, xmax: float, ymax: float
+) -> bool:
+    """True if segment ``p1-p2`` intersects (or lies within) an AABB.
+
+    Used as the clearance predicate against inflated pad keep-out
+    rectangles: a segment leg that enters an inflated keep-out is a
+    clearance violation (the #3906 discipline applied per leg).
+    """
+    # Either endpoint inside the box.
+    if xmin <= p1[0] <= xmax and ymin <= p1[1] <= ymax:
+        return True
+    if xmin <= p2[0] <= xmax and ymin <= p2[1] <= ymax:
+        return True
+    # Otherwise test against the four box edges.
+    corners = [
+        (xmin, ymin),
+        (xmax, ymin),
+        (xmax, ymax),
+        (xmin, ymax),
+    ]
+    return any(segments_intersect(p1, p2, corners[i], corners[(i + 1) % 4]) for i in range(4))

--- a/src/kicad_tools/router/mesh/navmesh.py
+++ b/src/kicad_tools/router/mesh/navmesh.py
@@ -1,0 +1,187 @@
+"""Triangle-dual navmesh + portal-midpoint A* for the mesh router (#4268).
+
+Given the ``(vertices, triangles)`` output of the poly2tri constrained-
+Delaunay mesh, this builds the triangle adjacency graph and runs A* over the
+triangle dual using the **portal-midpoint** step cost.  The ADR (P0.5 spike,
+CASE 2) settled on portal-midpoint cost over naive centroid cost: centroid A*
+picks suboptimal corridors (1.341x straight-line) while portal-midpoint keeps
+it near-optimal (1.055x) with no mesh refinement.
+
+The A* result is a *corridor* (triangle sequence), converted to an oriented
+``(left, right)`` portal list for the funnel string-pull, which produces the
+actual Euclidean geodesic.
+"""
+
+from __future__ import annotations
+
+import heapq
+import math
+
+from .funnel import Portal
+from .geometry import EPS, Pt, centroid, point_in_triangle
+
+Triangle = tuple[int, int, int]
+
+
+class NavMesh:
+    """Triangle-dual navmesh over a constrained-Delaunay triangulation."""
+
+    def __init__(self, vertices: list[Pt], triangles: list[Triangle]) -> None:
+        self.vertices = vertices
+        self.triangles = triangles
+        self._centroids: list[Pt] = [
+            centroid(vertices[a], vertices[b], vertices[c]) for (a, b, c) in triangles
+        ]
+        # edge (sorted vertex-index pair) -> list of incident triangle indices
+        self._edge_tris: dict[tuple[int, int], list[int]] = {}
+        for ti, (a, b, c) in enumerate(triangles):
+            for u, v in ((a, b), (b, c), (c, a)):
+                key = (u, v) if u < v else (v, u)
+                self._edge_tris.setdefault(key, []).append(ti)
+        # adjacency: triangle -> list of (neighbor triangle, shared edge)
+        self._adj: list[list[tuple[int, tuple[int, int]]]] = [[] for _ in triangles]
+        for key, tris in self._edge_tris.items():
+            if len(tris) == 2:
+                t0, t1 = tris
+                self._adj[t0].append((t1, key))
+                self._adj[t1].append((t0, key))
+        # vertex index -> incident triangles (for endpoint location)
+        self._vertex_tris: dict[int, list[int]] = {}
+        for ti, (a, b, c) in enumerate(triangles):
+            for v in (a, b, c):
+                self._vertex_tris.setdefault(v, []).append(ti)
+
+    # -- endpoint location -------------------------------------------------
+
+    def _vertex_index(self, p: Pt) -> int | None:
+        """Return the vertex index coincident with ``p`` (or None)."""
+        best: int | None = None
+        best_d = EPS
+        for i, v in enumerate(self.vertices):
+            d = math.hypot(v[0] - p[0], v[1] - p[1])
+            if d <= best_d:
+                best_d = d
+                best = i
+        return best
+
+    def locate(self, p: Pt) -> list[int]:
+        """Triangles that ``p`` belongs to.
+
+        A Steiner endpoint is a mesh vertex shared by a fan of triangles; a
+        free point falls inside exactly one.  Returns all candidate triangles
+        so A* can seed / terminate on any of them.
+        """
+        vi = self._vertex_index(p)
+        if vi is not None and vi in self._vertex_tris:
+            return list(self._vertex_tris[vi])
+        hits = [
+            ti
+            for ti, (a, b, c) in enumerate(self.triangles)
+            if point_in_triangle(p, self.vertices[a], self.vertices[b], self.vertices[c])
+        ]
+        return hits
+
+    # -- A* over the triangle dual ----------------------------------------
+
+    def astar(self, start: Pt, goal: Pt) -> list[int] | None:
+        """Return a corridor (triangle-index sequence) from ``start`` to ``goal``.
+
+        Portal-midpoint step cost with a straight-line-to-goal heuristic.
+        Returns ``None`` if the two points are in disconnected mesh regions.
+        """
+        start_tris = self.locate(start)
+        goal_tris = set(self.locate(goal))
+        if not start_tris or not goal_tris:
+            return None
+
+        def edge_mid(edge: tuple[int, int]) -> Pt:
+            a = self.vertices[edge[0]]
+            b = self.vertices[edge[1]]
+            return ((a[0] + b[0]) / 2.0, (a[1] + b[1]) / 2.0)
+
+        def h(point: Pt) -> float:
+            return math.hypot(goal[0] - point[0], goal[1] - point[1])
+
+        # Priority queue of (f, unique, triangle, entry_point).
+        g_score: dict[int, float] = {}
+        came_from: dict[int, int] = {}
+        counter = 0
+        open_heap: list[tuple[float, int, int, Pt]] = []
+        for t in start_tris:
+            g_score[t] = 0.0
+            heapq.heappush(open_heap, (h(start), counter, t, start))
+            counter += 1
+
+        while open_heap:
+            f, _cnt, tri, entry = heapq.heappop(open_heap)
+            g = g_score.get(tri, math.inf)
+            # Stale-entry guard: f encodes g at push time; recompute is cheap.
+            if f - h(entry) > g + 1e-6:
+                continue
+            if tri in goal_tris:
+                return self._reconstruct(came_from, tri, start_tris)
+            for nbr, edge in self._adj[tri]:
+                mid = edge_mid(edge)
+                step = math.hypot(mid[0] - entry[0], mid[1] - entry[1])
+                tentative = g + step
+                if tentative < g_score.get(nbr, math.inf) - 1e-9:
+                    g_score[nbr] = tentative
+                    came_from[nbr] = tri
+                    heapq.heappush(open_heap, (tentative + h(mid), counter, nbr, mid))
+                    counter += 1
+        return None
+
+    @staticmethod
+    def _reconstruct(came_from: dict[int, int], tri: int, start_tris: list[int]) -> list[int]:
+        start_set = set(start_tris)
+        corridor = [tri]
+        while tri not in start_set and tri in came_from:
+            tri = came_from[tri]
+            corridor.append(tri)
+        corridor.reverse()
+        return corridor
+
+    # -- corridor -> oriented portals -------------------------------------
+
+    def corridor_to_portals(self, corridor: list[int], start: Pt, goal: Pt) -> list[Portal]:
+        """Convert a triangle corridor into oriented ``(left, right)`` portals.
+
+        Each portal is the shared edge between consecutive corridor triangles,
+        oriented so ``left`` sits on the left-hand side of travel (the funnel's
+        sign convention).  The near-triangle centroid is the orientation
+        reference: it always lies on the traveling-from side of the edge.
+        """
+        portals: list[Portal] = [(start, start)]
+        for i in range(len(corridor) - 1):
+            cur = corridor[i]
+            nxt = corridor[i + 1]
+            edge = self._shared_edge(cur, nxt)
+            if edge is None:
+                continue
+            p = self.vertices[edge[0]]
+            q = self.vertices[edge[1]]
+            ref = self._centroids[cur]
+            # Mononen sign: _area(ref, left, right) > 0 for correct orientation.
+            if _mononen_area(ref, p, q) > 0.0:
+                portals.append((p, q))
+            else:
+                portals.append((q, p))
+        portals.append((goal, goal))
+        return portals
+
+    def _shared_edge(self, t0: int, t1: int) -> tuple[int, int] | None:
+        s0 = set(self.triangles[t0])
+        s1 = set(self.triangles[t1])
+        common = tuple(sorted(s0 & s1))
+        if len(common) == 2:
+            return (common[0], common[1])
+        return None
+
+
+def _mononen_area(a: Pt, b: Pt, c: Pt) -> float:
+    """Mononen ``triarea2`` sign (matches :func:`funnel._area`)."""
+    ax = b[0] - a[0]
+    ay = b[1] - a[1]
+    bx = c[0] - a[0]
+    by = c[1] - a[1]
+    return bx * ay - ax * by

--- a/src/kicad_tools/router/mesh/obstacles.py
+++ b/src/kicad_tools/router/mesh/obstacles.py
@@ -1,0 +1,100 @@
+"""Obstacle model shared by the mesh substrate and the 45-fit (issue #4268).
+
+The #3906 lesson is *consult the same obstacle model* the mesh was built from
+when validating the octilinear legs.  This module is that single source of
+truth: the inflated pad keep-out rectangles here are BOTH the poly2tri mesh
+holes and the clearance predicate the 45-fit rejects bulging doglegs against.
+
+Clearance is handled by obstacle inflation (Minkowski growth by the agent
+radius = half-trace + clearance).  Growing the obstacles and planning for a
+point centreline is mathematically equivalent to the "agent-radius portal
+narrowing" the ADR names, and composes cleanly with poly2tri holes.
+"""
+
+from __future__ import annotations
+
+from .geometry import Pt, point_in_polygon, segment_intersects_rect
+
+Rect = tuple[float, float, float, float]  # (xmin, ymin, xmax, ymax)
+
+
+def rect_contains(r: Rect, p: Pt) -> bool:
+    """True if point ``p`` is inside rectangle ``r`` (inclusive)."""
+    return r[0] <= p[0] <= r[2] and r[1] <= p[1] <= r[3]
+
+
+def rects_overlap(a: Rect, b: Rect) -> bool:
+    """True if two AABBs overlap (touching edges count)."""
+    return not (a[2] < b[0] or b[2] < a[0] or a[3] < b[1] or b[3] < a[1])
+
+
+def merge_overlapping(rects: list[Rect]) -> list[Rect]:
+    """Union-find cluster overlapping rects into their bounding boxes.
+
+    poly2tri holes must be disjoint and simple; a dense pin-field produces
+    overlapping inflated keep-outs.  Merging each overlap-cluster into its
+    bounding box keeps the holes disjoint while staying *conservative*
+    (the merged keep-out only ever grows the avoided region).
+    """
+    n = len(rects)
+    parent = list(range(n))
+
+    def find(i: int) -> int:
+        while parent[i] != i:
+            parent[i] = parent[parent[i]]
+            i = parent[i]
+        return i
+
+    def union(i: int, j: int) -> None:
+        parent[find(i)] = find(j)
+
+    # Iterate to a fixpoint: merging can create new overlaps.
+    changed = True
+    while changed:
+        changed = False
+        boxes = _cluster_boxes(rects, parent, find, n)
+        roots = list(boxes.keys())
+        for a in range(len(roots)):
+            for b in range(a + 1, len(roots)):
+                ra, rb = roots[a], roots[b]
+                if find(ra) != find(rb) and rects_overlap(boxes[ra], boxes[rb]):
+                    union(ra, rb)
+                    changed = True
+    return list(_cluster_boxes(rects, parent, find, n).values())
+
+
+def _cluster_boxes(rects: list[Rect], parent: list[int], find, n: int) -> dict[int, Rect]:
+    boxes: dict[int, Rect] = {}
+    for i in range(n):
+        r = find(i)
+        if r not in boxes:
+            boxes[r] = rects[i]
+        else:
+            cur = boxes[r]
+            boxes[r] = (
+                min(cur[0], rects[i][0]),
+                min(cur[1], rects[i][1]),
+                max(cur[2], rects[i][2]),
+                max(cur[3], rects[i][3]),
+            )
+    return boxes
+
+
+class ObstacleModel:
+    """Board outline plus inflated pad keep-out rectangles."""
+
+    def __init__(self, outline: list[Pt], keepouts: list[Rect]) -> None:
+        self.outline = outline
+        self.keepouts = keepouts
+
+    def is_clear(self, a: Pt, b: Pt) -> bool:
+        """True if straight leg ``a-b`` is inside the board and clears keep-outs.
+
+        This is the exact predicate the 45-fit checks each dogleg leg against
+        (the generalised ``subgrid.py:1004-1030`` per-leg obstacle consult).
+        """
+        if self.outline and not (
+            point_in_polygon(a, self.outline) and point_in_polygon(b, self.outline)
+        ):
+            return False
+        return not any(segment_intersects_rect(a, b, r[0], r[1], r[2], r[3]) for r in self.keepouts)

--- a/src/kicad_tools/router/mesh/octilinear.py
+++ b/src/kicad_tools/router/mesh/octilinear.py
@@ -1,0 +1,99 @@
+"""Clearance-aware 45-degree best-fit for the mesh router (issue #4268).
+
+This is the one genuinely-new algorithm in the mesh vertical slice and the
+biggest risk (the #3906 board-05 3-way-short is the standing proof that an
+obstacle-*blind* octilinear fit ships a defect).  It generalises the
+already-shipped ``SubGrid._try_candidates_with_clearance`` discipline
+(``subgrid.py:1004-1030``) from "the pad-escape chord" to "each chord of the
+funnel polyline":
+
+  * split an off-angle chord into a 45-legal two-leg dogleg via
+    :func:`kicad_tools.router.quantize.dogleg_points`, then
+  * clearance-check EACH leg against the same obstacle model the straight
+    chord used, and **reject the candidate if either leg collides** -- trying
+    the other dogleg orientation, then subdividing to hug the geodesic more
+    tightly, before finally failing the chord.
+
+The returned polyline is guaranteed 45-legal (feeds the #3907 ``to_sexp``
+choke without raising) AND clearance-clean leg-by-leg (never emits a bulge
+into a keep-out).  A chord that cannot be made clear returns ``None`` -- the
+route fails rather than shipping a short.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from ..quantize import dogleg_points, is_45_aligned
+from .geometry import Pt
+
+# Clearance predicate: True if a straight leg from a to b is obstacle-free.
+ClearFn = Callable[[Pt, Pt], bool]
+
+# Recursion cap on chord subdivision. Each level halves the dogleg bulge
+# (bounded by min(|dx|,|dy|)); 8 levels shrink a full-board chord to <1um.
+_MAX_SUBDIVISION = 8
+
+
+def octilinear_fit(
+    polyline: list[Pt], is_clear: ClearFn, *, max_subdivision: int = _MAX_SUBDIVISION
+) -> list[Pt] | None:
+    """Convert an arbitrary-angle geodesic into a clearance-clean 45-legal path.
+
+    Returns the 45-legal vertex list (starting at ``polyline[0]``), or ``None``
+    if any chord cannot be octilinearised without a leg entering an obstacle.
+    """
+    if len(polyline) < 2:
+        return list(polyline)
+
+    out: list[Pt] = [polyline[0]]
+    for i in range(len(polyline) - 1):
+        legs = _fit_chord(polyline[i], polyline[i + 1], is_clear, max_subdivision)
+        if legs is None:
+            return None
+        out.extend(legs)
+    return _dedupe(out)
+
+
+def _fit_chord(a: Pt, b: Pt, is_clear: ClearFn, depth: int) -> list[Pt] | None:
+    """Return the 45-legal points from ``a`` to ``b`` (EXCLUDING ``a``).
+
+    Tries: straight (if already aligned) -> default dogleg -> flipped dogleg
+    -> midpoint subdivision.  Every emitted leg is clearance-checked.
+    """
+    dx = b[0] - a[0]
+    dy = b[1] - a[1]
+
+    if is_45_aligned(dx, dy):
+        # Already on a legal angle; only a clearance check remains.  A straight
+        # aligned chord that collides cannot be repaired by doglegging (a
+        # dogleg of an aligned chord is collinear), so this is a hard fail.
+        return [b] if is_clear(a, b) else None
+
+    # Off-angle: try both dogleg orientations (bulge on opposite sides).
+    for axis_first in (False, True):
+        pts = dogleg_points(a[0], a[1], b[0], b[1], axis_first=axis_first)
+        if len(pts) != 3:
+            continue
+        mid = pts[1]
+        if is_clear(a, mid) and is_clear(mid, b):
+            return [mid, b]
+
+    # Both doglegs bulge into an obstacle -> subdivide to hug the geodesic.
+    if depth > 0:
+        m = ((a[0] + b[0]) / 2.0, (a[1] + b[1]) / 2.0)
+        first = _fit_chord(a, m, is_clear, depth - 1)
+        if first is not None:
+            second = _fit_chord(m, b, is_clear, depth - 1)
+            if second is not None:
+                return first + second
+    return None
+
+
+def _dedupe(pts: list[Pt]) -> list[Pt]:
+    """Drop consecutive duplicate vertices (zero-length legs)."""
+    out: list[Pt] = []
+    for p in pts:
+        if not out or abs(out[-1][0] - p[0]) > 1e-9 or abs(out[-1][1] - p[1]) > 1e-9:
+            out.append(p)
+    return out

--- a/src/kicad_tools/router/mesh/pathfinder.py
+++ b/src/kicad_tools/router/mesh/pathfinder.py
@@ -91,7 +91,7 @@ class MeshPathfinder:
         parity with ``CppPathfinder.route`` but only the trace width is read
         (single-net P1 does no congestion negotiation).
         """
-        import kicad_tools.router.router_cpp as router_cpp
+        import kicad_tools.router.router_cpp as router_cpp  # type: ignore[import-not-found]
 
         trace_w = getattr(net_class, "trace_width", None) or self.rules.trace_width
         clearance = self.rules.trace_clearance

--- a/src/kicad_tools/router/mesh/pathfinder.py
+++ b/src/kicad_tools/router/mesh/pathfinder.py
@@ -1,0 +1,209 @@
+"""``MeshPathfinder`` -- the mesh-router single-net route contract (#4268).
+
+Exposes the same "route between two pads" contract as
+``CppPathfinder.route`` (``cpp_backend.py:1322``) and returns an ordinary
+:class:`~kicad_tools.router.primitives.Route`, so the emission tail and DRC
+gate see a normal route object.  The full pipeline:
+
+    inflated pad keep-outs  (ObstacleModel)
+      -> poly2tri CDT with holes            (router_cpp.constrained_delaunay)
+      -> triangle-dual portal-midpoint A*    (NavMesh.astar)
+      -> Simple Stupid Funnel                (string_pull)
+      -> clearance-aware 45-degree best-fit  (octilinear_fit)
+      -> Route of 45-legal Segments
+
+Single-net only.  Multi-net negotiation, capacity, vias/layer-stitching, and
+matched routing are explicitly out of scope for P1 (epic children P2/P3):
+routing is confined to the start pad's layer and no vias are emitted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..primitives import Pad, Route, Segment
+from ..rules import DesignRules
+from .geometry import Pt
+from .navmesh import NavMesh
+from .obstacles import ObstacleModel, Rect, rect_contains
+from .octilinear import octilinear_fit
+
+
+class MeshPathfinder:
+    """Navmesh single-net pathfinder returning ordinary ``Route`` objects."""
+
+    # Capability flag mirroring ``CppPathfinder.supports_waypoint_injection``
+    # (cpp_backend.py:819).  The mesh strategy does its own off-grid handling
+    # (pads enter the mesh as exact Steiner vertices), so the grid waypoint /
+    # sub-grid escape machinery does not apply.
+    supports_waypoint_injection: bool = False
+
+    def __init__(
+        self,
+        outline: list[Pt],
+        pads: list[Pad],
+        rules: DesignRules | None = None,
+    ) -> None:
+        self.outline = outline
+        self.pads = pads
+        self.rules = rules or DesignRules()
+        # Slightly-inset outline bbox used to clamp keep-out holes so poly2tri
+        # never sees a hole that pokes through the outer boundary.
+        xs = [p[0] for p in outline]
+        ys = [p[1] for p in outline]
+        self._bbox: Rect = (min(xs), min(ys), max(xs), max(ys))
+
+    # -- construction from a board ----------------------------------------
+
+    @classmethod
+    def from_board(
+        cls,
+        pcb_path_or_text: str | Path,
+        rules: DesignRules | None = None,
+    ) -> MeshPathfinder:
+        """Build a pathfinder from a ``.kicad_pcb`` file or text."""
+        from ..io import _extract_edge_segments, load_pads_for_analysis
+
+        if isinstance(pcb_path_or_text, Path):
+            text = pcb_path_or_text.read_text()
+        elif not pcb_path_or_text.lstrip().startswith("("):
+            text = Path(pcb_path_or_text).read_text()
+        else:
+            text = pcb_path_or_text
+
+        pads = load_pads_for_analysis(text)
+        segments = _extract_edge_segments(text)
+        outline = _outline_from_edges(segments)
+        return cls(outline, pads, rules)
+
+    # -- the route contract -----------------------------------------------
+
+    def route(
+        self,
+        start: Pad,
+        end: Pad,
+        net_class: object | None = None,
+        **_ignored: object,
+    ) -> Route | None:
+        """Route a single net between two pads; ``None`` if it cannot.
+
+        ``net_class`` and any negotiation kwargs are accepted for contract
+        parity with ``CppPathfinder.route`` but only the trace width is read
+        (single-net P1 does no congestion negotiation).
+        """
+        import kicad_tools.router.router_cpp as router_cpp
+
+        trace_w = getattr(net_class, "trace_width", None) or self.rules.trace_width
+        clearance = self.rules.trace_clearance
+        agent_radius = trace_w / 2.0 + clearance
+
+        net = start.net
+        start_pt: Pt = (start.x, start.y)
+        end_pt: Pt = (end.x, end.y)
+
+        # Authoritative obstacle model: EVERY other-net pad, inflated. This is
+        # the model the octilinear fit validates every leg against -- a route
+        # that cannot clear it is declined (None), never emitted as a short.
+        keepouts = self._keepouts(net, agent_radius)
+        obstacles = ObstacleModel(self.outline, keepouts)
+
+        # The poly2tri mesh needs its holes disjoint from the Steiner endpoints,
+        # so the *mesh* drops any keep-out that swallows an endpoint (a dense
+        # pad-escape region).  The authoritative ``obstacles`` above still
+        # carries those keep-outs, so the octilinear fit will decline the net
+        # if the relaxed corridor cannot actually be cleared.
+        mesh_holes = [
+            [(r[0], r[1]), (r[2], r[1]), (r[2], r[3]), (r[0], r[3])]
+            for r in keepouts
+            if not (rect_contains(r, start_pt) or rect_contains(r, end_pt))
+        ]
+
+        verts, tris = router_cpp.constrained_delaunay(self.outline, mesh_holes, [start_pt, end_pt])
+        if not verts or not tris:
+            return None
+
+        navmesh = NavMesh([tuple(v) for v in verts], [tuple(t) for t in tris])
+        corridor = navmesh.astar(start_pt, end_pt)
+        if corridor is None:
+            return None
+
+        geodesic = _pull(navmesh, corridor, start_pt, end_pt)
+        fitted = octilinear_fit(geodesic, obstacles.is_clear)
+        if fitted is None or len(fitted) < 2:
+            return None
+
+        return self._build_route(start, net, trace_w, fitted)
+
+    # -- helpers ----------------------------------------------------------
+
+    def _keepouts(self, net: int, agent_radius: float) -> list[Rect]:
+        """Inflated keep-out rects for every OTHER-net pad, clamped + merged."""
+        from .obstacles import merge_overlapping
+
+        raw: list[Rect] = []
+        bx0, by0, bx1, by1 = self._bbox
+        # Keep holes a hair inside the outer boundary (poly2tri requirement).
+        margin = 1e-3
+        for pad in self.pads:
+            if pad.net == net:
+                continue  # same-net copper is not an obstacle
+            hx = pad.width / 2.0 + agent_radius
+            hy = pad.height / 2.0 + agent_radius
+            r = (pad.x - hx, pad.y - hy, pad.x + hx, pad.y + hy)
+            r = (
+                max(r[0], bx0 + margin),
+                max(r[1], by0 + margin),
+                min(r[2], bx1 - margin),
+                min(r[3], by1 - margin),
+            )
+            if r[2] - r[0] < margin or r[3] - r[1] < margin:
+                continue  # clamped away to nothing
+            raw.append(r)
+
+        return merge_overlapping(raw)
+
+    def _build_route(self, start: Pad, net: int, trace_w: float, fitted: list[Pt]) -> Route:
+        route = Route(net=net, net_name=start.net_name)
+        layer = start.layer
+        for i in range(len(fitted) - 1):
+            a, b = fitted[i], fitted[i + 1]
+            route.segments.append(
+                Segment(
+                    x1=a[0],
+                    y1=a[1],
+                    x2=b[0],
+                    y2=b[1],
+                    width=trace_w,
+                    layer=layer,
+                    net=net,
+                    net_name=start.net_name,
+                )
+            )
+        return route
+
+
+def _pull(navmesh: NavMesh, corridor: list[int], start: Pt, end: Pt) -> list[Pt]:
+    from .funnel import string_pull
+
+    return string_pull(navmesh.corridor_to_portals(corridor, start, end))
+
+
+def _outline_from_edges(
+    segments: list[tuple[tuple[float, float], tuple[float, float]]],
+) -> list[Pt]:
+    """Board outline as a CCW bbox rectangle from Edge.Cuts segments.
+
+    P1 uses the Edge.Cuts bounding box as the outer boundary.  Every committed
+    fleet board in scope is rectangular, so the bbox is the exact outline; a
+    concave outline would only over-constrain the free space conservatively.
+    """
+    if not segments:
+        return []
+    xs: list[float] = []
+    ys: list[float] = []
+    for (x1, y1), (x2, y2) in segments:
+        xs.extend((x1, x2))
+        ys.extend((y1, y2))
+    xmin, xmax = min(xs), max(xs)
+    ymin, ymax = min(ys), max(ys)
+    return [(xmin, ymin), (xmax, ymin), (xmax, ymax), (xmin, ymax)]

--- a/tests/router/mesh/test_core_no_edge_cuts.py
+++ b/tests/router/mesh/test_core_no_edge_cuts.py
@@ -1,0 +1,61 @@
+"""Regression: mesh routing on a board with no Edge.Cuts (#4268).
+
+``Autorouter._board_bbox`` is only populated from the board outline when the
+PCB actually has edge cuts (``router/io.py`` writes it from the extracted
+Edge.Cuts bbox).  A board routed under ``--route-engine mesh`` with no edge
+cuts therefore leaves ``_board_bbox`` at its ``None`` default.
+
+Before the fix, ``_route_net_mesh`` unpacked ``self._board_bbox`` with no
+None guard (``bx0, by0, bx1, by1 = self._board_bbox``), so the None default
+crashed with "cannot unpack non-iterable NoneType".  The guard now falls back
+to the grid origin/dimensions (mirroring the guarded reader in
+``cleanup_artifacts``) so the navmesh still gets a valid outer boundary.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.primitives import Pad
+
+# The mesh pathfinder routes through the compiled C++ backend; skip where the
+# extension is not built (matches the other tests/router/mesh acceptance runs).
+pytest.importorskip("kicad_tools.router.router_cpp")
+
+
+def _add_pad(router: Autorouter, pad: Pad) -> None:
+    key = (pad.ref, pad.pin)
+    router.pads[key] = pad
+    router.nets.setdefault(pad.net, []).append(key)
+
+
+def test_route_net_mesh_no_edge_cuts_uses_grid_bbox_fallback() -> None:
+    """No Edge.Cuts (``_board_bbox is None``) must route, not crash."""
+    router = Autorouter(50, 40, strategy="mesh")
+    # Precondition: a bare board (no io.py edge-cuts population) leaves the
+    # bbox at its None default -- the exact state that used to crash.
+    assert router._board_bbox is None
+
+    _add_pad(
+        router,
+        Pad(
+            x=10, y=10, width=1, height=1, net=1, net_name="N1", layer=Layer.F_CU, ref="R1", pin="1"
+        ),
+    )
+    _add_pad(
+        router,
+        Pad(
+            x=30, y=25, width=1, height=1, net=1, net_name="N1", layer=Layer.F_CU, ref="R2", pin="1"
+        ),
+    )
+
+    # Must not raise "cannot unpack non-iterable NoneType".
+    routes = router._route_net_mesh(1)
+
+    # The pathfinder was built with a grid-derived outer boundary and produced
+    # a single-net route for the two same-layer pads.
+    assert router._mesh_pathfinder is not None
+    assert len(routes) == 1
+    assert routes[0].segments

--- a/tests/router/mesh/test_funnel.py
+++ b/tests/router/mesh/test_funnel.py
@@ -1,0 +1,60 @@
+"""Funnel string-pull unit tests (issue #4268).
+
+Ports the two synthetic corridors the P0.5 spike used to validate the Simple
+Stupid Funnel before trusting it on the board:
+
+* a straight channel must collapse to two points (start, goal), and
+* an L-channel must pull taut around the inner reflex corner.
+"""
+
+from __future__ import annotations
+
+import math
+
+from kicad_tools.router.mesh.funnel import string_pull
+from kicad_tools.router.mesh.geometry import dist
+
+
+def _length(path: list[tuple[float, float]]) -> float:
+    return sum(dist(path[i], path[i + 1]) for i in range(len(path) - 1))
+
+
+def test_straight_channel_collapses_to_two_points() -> None:
+    """A straight open channel yields exactly [start, goal]."""
+    portals: list[tuple[tuple[float, float], tuple[float, float]]] = [
+        ((0.0, 0.0), (0.0, 0.0)),  # start
+    ]
+    for x in range(1, 10):
+        portals.append(((float(x), 1.0), (float(x), -1.0)))  # left top, right bottom
+    portals.append(((10.0, 0.0), (10.0, 0.0)))  # goal
+
+    path = string_pull(portals)
+
+    assert len(path) == 2
+    assert path[0] == (0.0, 0.0)
+    assert path[-1] == (10.0, 0.0)
+    assert math.isclose(_length(path), 10.0, abs_tol=1e-9)
+
+
+def test_l_channel_pulls_taut_around_inner_corner() -> None:
+    """An L-shaped corridor pulls taut around the inner reflex corner (4, 2)."""
+    portals = [
+        ((1.0, 1.0), (1.0, 1.0)),  # start inside horizontal leg
+        ((2.0, 2.0), (2.0, 0.0)),  # travel +x: left=top, right=bottom
+        ((4.0, 2.0), (4.0, 0.0)),  # inner corner is the top vertex here
+        ((4.0, 2.0), (6.0, 2.0)),  # travel +y: left=x4 (inner corner), right=x6
+        ((4.0, 4.0), (6.0, 4.0)),
+        ((4.0, 6.0), (6.0, 6.0)),
+        ((5.0, 7.0), (5.0, 7.0)),  # goal inside vertical leg
+    ]
+
+    path = string_pull(portals)
+
+    assert path[0] == (1.0, 1.0)
+    assert path[-1] == (5.0, 7.0)
+    # The taut path bends exactly once, at the inner reflex corner.
+    assert len(path) == 3
+    assert path[1] == (4.0, 2.0)
+    # And it is shorter than routing through any portal midpoint sequence.
+    straight = dist((1.0, 1.0), (4.0, 2.0)) + dist((4.0, 2.0), (5.0, 7.0))
+    assert math.isclose(_length(path), straight, abs_tol=1e-9)

--- a/tests/router/mesh/test_navmesh.py
+++ b/tests/router/mesh/test_navmesh.py
@@ -1,0 +1,85 @@
+"""Navmesh A* + funnel integration tests over a real poly2tri mesh (#4268).
+
+Exercises the whole substrate below the octilinear fit: poly2tri CDT with a
+hole -> triangle-dual portal-midpoint A* -> oriented portals -> funnel.  The
+geodesic must route around the interior hole without crossing its interior.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from kicad_tools.router.mesh.funnel import string_pull
+from kicad_tools.router.mesh.geometry import dist
+from kicad_tools.router.mesh.navmesh import NavMesh
+
+router_cpp = pytest.importorskip("kicad_tools.router.router_cpp")
+
+
+def _point_strictly_in_rect(p, xmin, ymin, xmax, ymax, eps=1e-6):
+    return (xmin + eps) < p[0] < (xmax - eps) and (ymin + eps) < p[1] < (ymax - eps)
+
+
+def _leg_crosses_hole_interior(a, b, hole, samples=50):
+    # Sample the leg; if any interior sample lands strictly inside the hole
+    # the geodesic clipped the obstacle (a real violation, not a corner graze).
+    xmin, ymin, xmax, ymax = hole
+    for k in range(1, samples):
+        t = k / samples
+        p = (a[0] + (b[0] - a[0]) * t, a[1] + (b[1] - a[1]) * t)
+        if _point_strictly_in_rect(p, xmin, ymin, xmax, ymax):
+            return True
+    return False
+
+
+def test_funnel_routes_around_interior_hole() -> None:
+    outer = [(0.0, 0.0), (20.0, 0.0), (20.0, 20.0), (0.0, 20.0)]
+    hole = [(6.0, 6.0), (14.0, 6.0), (14.0, 14.0), (6.0, 14.0)]
+    hole_rect = (6.0, 6.0, 14.0, 14.0)
+    start, goal = (2.0, 2.0), (18.0, 18.0)
+
+    verts, tris = router_cpp.constrained_delaunay(outer, [hole], [start, goal])
+    assert verts and tris
+
+    nm = NavMesh([tuple(v) for v in verts], [tuple(t) for t in tris])
+    corridor = nm.astar(start, goal)
+    assert corridor is not None
+
+    portals = nm.corridor_to_portals(corridor, start, goal)
+    path = string_pull(portals)
+
+    assert path[0] == start
+    assert path[-1] == goal
+    # The straight diagonal is blocked by the hole, so the path must detour.
+    length = sum(dist(path[i], path[i + 1]) for i in range(len(path) - 1))
+    assert length > dist(start, goal) + 1e-6
+    # And no leg may cut through the hole interior.
+    for i in range(len(path) - 1):
+        assert not _leg_crosses_hole_interior(path[i], path[i + 1], hole_rect)
+
+
+def test_astar_returns_none_when_goal_walled_off() -> None:
+    # A hole spanning the full width splits the board; the far side is
+    # unreachable, so A* must report no corridor.
+    outer = [(0.0, 0.0), (20.0, 0.0), (20.0, 20.0), (0.0, 20.0)]
+    wall = [(0.0, 9.0), (20.0, 9.0), (20.0, 11.0), (0.0, 11.0)]
+    start, goal = (10.0, 4.0), (10.0, 16.0)
+    verts, tris = router_cpp.constrained_delaunay(outer, [wall], [start, goal])
+    nm = NavMesh([tuple(v) for v in verts], [tuple(t) for t in tris])
+    assert nm.astar(start, goal) is None
+
+
+def test_portal_midpoint_cost_is_near_optimal_in_open_region() -> None:
+    # No hole: the funnel across a wide-open board collapses to the straight
+    # line (the portal-midpoint A* corridor does not force a detour).
+    outer = [(0.0, 0.0), (40.0, 0.0), (40.0, 30.0), (0.0, 30.0)]
+    start, goal = (3.0, 3.0), (37.0, 27.0)
+    verts, tris = router_cpp.constrained_delaunay(outer, [], [start, goal])
+    nm = NavMesh([tuple(v) for v in verts], [tuple(t) for t in tris])
+    corridor = nm.astar(start, goal)
+    assert corridor is not None
+    path = string_pull(nm.corridor_to_portals(corridor, start, goal))
+    length = sum(dist(path[i], path[i + 1]) for i in range(len(path) - 1))
+    assert math.isclose(length, dist(start, goal), rel_tol=1e-6)

--- a/tests/router/mesh/test_octilinear.py
+++ b/tests/router/mesh/test_octilinear.py
@@ -1,0 +1,71 @@
+"""Clearance-aware 45-fit regression tests, modeled on the #3906 short.
+
+The load-bearing invariant: the octilinear best-fit must NEVER emit a leg that
+bulges into a keep-out.  When the default dogleg orientation collides it must
+try the other orientation (and subdivide) rather than shipping the colliding
+leg -- the exact obstacle-consult discipline generalised from
+``subgrid.py:1004-1030``.
+"""
+
+from __future__ import annotations
+
+from kicad_tools.router.mesh.geometry import segment_intersects_rect
+from kicad_tools.router.mesh.obstacles import ObstacleModel
+from kicad_tools.router.mesh.octilinear import octilinear_fit
+
+# Keep-out that the DEFAULT (diagonal-first) dogleg of the chord (0,0)->(10,4)
+# bulges into, but the FLIPPED (axis-first) dogleg avoids.
+_KEEPOUT = (2.0, 2.0, 3.0, 5.0)
+
+
+def _no_leg_enters(path: list[tuple[float, float]], rect) -> bool:
+    return not any(
+        segment_intersects_rect(path[i], path[i + 1], rect[0], rect[1], rect[2], rect[3])
+        for i in range(len(path) - 1)
+    )
+
+
+def test_default_dogleg_into_keepout_is_rejected_and_flipped() -> None:
+    """The bulging default dogleg is rejected; the clear orientation is used."""
+    obstacles = ObstacleModel(outline=[], keepouts=[_KEEPOUT])
+    chord = [(0.0, 0.0), (10.0, 4.0)]
+
+    result = octilinear_fit(chord, obstacles.is_clear)
+
+    assert result is not None
+    # Anti-#3906 invariant: no emitted leg enters the keep-out.
+    assert _no_leg_enters(result, _KEEPOUT)
+    # It should have chosen the axis-first orientation whose bend is at (6, 0).
+    assert (6.0, 0.0) in result
+
+
+def test_every_leg_is_45_legal() -> None:
+    """Every emitted leg lies on the {0,45,90,135} angle set."""
+    from kicad_tools.router.quantize import is_45_aligned
+
+    obstacles = ObstacleModel(outline=[], keepouts=[_KEEPOUT])
+    result = octilinear_fit([(0.0, 0.0), (10.0, 4.0)], obstacles.is_clear)
+    assert result is not None
+    for i in range(len(result) - 1):
+        dx = result[i + 1][0] - result[i][0]
+        dy = result[i + 1][1] - result[i][1]
+        assert is_45_aligned(dx, dy), f"leg {i} off-angle: {dx},{dy}"
+
+
+def test_both_orientations_blocked_subdivides_clear() -> None:
+    """When both doglegs clip a small keep-out, subdivision threads a clear path."""
+    # A small keep-out sitting on the geodesic midpoint; both full-chord
+    # doglegs bulge across it, but a subdivided staircase hugs the diagonal.
+    small = (4.6, 1.6, 5.4, 2.4)
+    obstacles = ObstacleModel(outline=[], keepouts=[small])
+    result = octilinear_fit([(0.0, 0.0), (10.0, 4.0)], obstacles.is_clear)
+    assert result is not None
+    assert _no_leg_enters(result, small)
+
+
+def test_fully_walled_chord_fails_rather_than_shorting() -> None:
+    """A keep-out wall across the whole span yields None, not a colliding leg."""
+    wall = (1.0, -5.0, 9.0, 5.0)  # spans the full y-band between the endpoints
+    obstacles = ObstacleModel(outline=[], keepouts=[wall])
+    result = octilinear_fit([(0.0, 0.0), (10.0, 4.0)], obstacles.is_clear)
+    assert result is None

--- a/tests/router/mesh/test_pathfinder.py
+++ b/tests/router/mesh/test_pathfinder.py
@@ -1,0 +1,152 @@
+"""End-to-end MeshPathfinder acceptance tests on committed fleet boards (#4268).
+
+Proves the P1 vertical slice on real geometry: parse a board -> mesh route one
+net -> 45-legal copper (passes the #3907 ``to_sexp`` choke with enforcement
+ON) -> DRC-clean under ``kicad-cli pcb drc --refill-zones``.
+
+The issue names softstart rev-C as the motivating board, but softstart is a
+local-only external symlink that dangles in fresh worktrees / CI, so the
+committed acceptance runs on in-repo fleet boards (charlieplex, stm32).  The
+softstart rev-C run is exercised manually and reported in the PR body.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.drc.geometric import run_geometric_drc
+from kicad_tools.router.io import (
+    _extract_edge_segments,
+    load_pads_for_analysis,
+    merge_routes_into_pcb,
+)
+from kicad_tools.router.mesh.pathfinder import MeshPathfinder
+from kicad_tools.router.primitives import (
+    is_segment_45_enforcement_enabled,
+)
+
+pytest.importorskip("kicad_tools.router.router_cpp")
+
+_REPO = Path(__file__).resolve().parents[3]
+_CHARLIEPLEX = _REPO / "boards/02-charlieplex-led/output/charlieplex_3x3.kicad_pcb"
+_STM32 = _REPO / "boards/04-stm32-devboard/output/stm32_devboard.kicad_pcb"
+
+
+def _pads_by_net(pads):
+    bynet: dict[int, list] = {}
+    for p in pads:
+        if p.net > 0:
+            bynet.setdefault(p.net, []).append(p)
+    return bynet
+
+
+def _two_pad_nets(pads):
+    """2-pad, single-layer nets sorted by separation (farthest first)."""
+    out = []
+    for net, ps in _pads_by_net(pads).items():
+        if len(ps) == 2 and ps[0].layer == ps[1].layer:
+            d = ((ps[0].x - ps[1].x) ** 2 + (ps[0].y - ps[1].y) ** 2) ** 0.5
+            out.append((d, net, ps))
+    out.sort(reverse=True)
+    return out
+
+
+def test_mesh_binding_available() -> None:
+    import kicad_tools.router.router_cpp as rc
+
+    assert hasattr(rc, "constrained_delaunay")
+
+
+def test_routes_single_net_emits_45_legal_drc_clean_charlieplex(tmp_path) -> None:
+    """Route one real net end-to-end; assert 45-legal AND DRC-clean.
+
+    All file I/O (including kicad-cli ``.kicad_prl`` sidecars) is confined to
+    ``tmp_path`` so the committed board tree is never polluted.
+    """
+    assert is_segment_45_enforcement_enabled(), "the #3907 choke must be ON"
+    text = _CHARLIEPLEX.read_text()
+    pads = load_pads_for_analysis(text)
+    pf = MeshPathfinder.from_board(text)
+
+    routed = None
+    for _d, _net, (a, b) in _two_pad_nets(pads):
+        r = pf.route(a, b)
+        if r is not None and r.segments:
+            routed = r
+            break
+    assert routed is not None, "expected at least one routable net"
+
+    # 45-legality by construction: serialization raises on off-angle copper
+    # when enforcement is on (it is, asserted above).
+    sexp = routed.to_sexp()
+    assert "(segment" in sexp
+
+    out = tmp_path / "charlieplex_routed.kicad_pcb"
+    out.write_text(merge_routes_into_pcb(text, sexp))
+    res = run_geometric_drc(out)
+    if not res.ran:
+        pytest.skip(f"kicad-cli DRC unavailable: {res.reason}")
+    assert res.error_count == 0, f"DRC errors: {dict(res.by_type)}"
+
+
+def test_mesh_route_never_shorts_on_dense_board_stm32(tmp_path) -> None:
+    """The #3906 guarantee on real geometry: no emitted route adds DRC errors.
+
+    stm32 has dense fine-pitch pads; the clearance gate must EITHER decline a
+    net (return None) or emit a route that introduces zero new DRC violations
+    -- it must never ship a short.  (An obstacle-blind fit shorted here.)
+
+    File I/O is confined to ``tmp_path`` (the baseline board is copied there so
+    kicad-cli's ``.kicad_prl`` sidecar never lands in the committed tree).
+    """
+    text = _STM32.read_text()
+    pads = load_pads_for_analysis(text)
+    pf = MeshPathfinder.from_board(text)
+
+    base_pcb = tmp_path / "stm32_base.kicad_pcb"
+    base_pcb.write_text(text)
+    base = run_geometric_drc(base_pcb)
+    if not base.ran:
+        pytest.skip(f"kicad-cli DRC unavailable: {base.reason}")
+
+    # Take the single farthest net; if declined, take the next routable one.
+    route = None
+    for _d, _net, (a, b) in _two_pad_nets(pads):
+        r = pf.route(a, b)
+        if r is not None and r.segments:
+            route = r
+            break
+    assert route is not None
+
+    out = tmp_path / "stm32_routed.kicad_pcb"
+    out.write_text(merge_routes_into_pcb(text, route.to_sexp()))
+    res = run_geometric_drc(out)
+    assert res.ran
+    # No NEW error-severity findings vs the unrouted baseline.
+    assert res.error_count <= base.error_count, (
+        f"route introduced DRC errors: base={base.error_count} "
+        f"routed={res.error_count} types={dict(res.by_type)}"
+    )
+
+
+def test_node_count_is_orders_below_grid() -> None:
+    """Criterion 6: mesh substrate node count is far below the grid's 63.5M."""
+    import kicad_tools.router.router_cpp as rc
+
+    text = _STM32.read_text()
+    pads = load_pads_for_analysis(text)
+    segs = _extract_edge_segments(text)
+    xs = [c for s in segs for c in (s[0][0], s[1][0])]
+    ys = [c for s in segs for c in (s[0][1], s[1][1])]
+    outline = [
+        (min(xs), min(ys)),
+        (max(xs), min(ys)),
+        (max(xs), max(ys)),
+        (min(xs), max(ys)),
+    ]
+    steiner = [(p.x, p.y) for p in pads]
+    verts, tris = rc.constrained_delaunay(outline, [], steiner)
+    assert 0 < len(verts) < 100_000  # << 63.5M grid cells
+    assert 0 < len(tris) < 200_000

--- a/tests/test_manufacturer_propagation_lint.py
+++ b/tests/test_manufacturer_propagation_lint.py
@@ -90,6 +90,17 @@ _ALLOWLIST: dict[str, dict[str, tuple[int, str]]] = {
     "router/adaptive.py": {
         "AdaptiveAutorouter.__init__": (1, "AdaptiveAutorouter.__init__ default fallback"),
     },
+    # Mesh-router single-net pathfinder (#4268) — same constructor rules-arg
+    # default fallback shape as Autorouter.__init__.  The sole caller,
+    # ``Autorouter._route_net_mesh`` in router/core.py, always passes
+    # ``self.rules`` (manufacturer already propagated from the Autorouter),
+    # so this bare default is only reached when a caller constructs the
+    # pathfinder with no rules (direct unit-test construction or
+    # ``MeshPathfinder.from_board(rules=None)``), where no manufacturer
+    # context exists to thread.
+    "router/mesh/pathfinder.py": {
+        "MeshPathfinder.__init__": (1, "MeshPathfinder.__init__ rules-arg default fallback"),
+    },
     # Library API: ``route_pcb()`` synthesises default rules only when
     # the caller explicitly passes ``rules=None`` (no PCB rules either).
     # The CLI always supplies its own rules with manufacturer wired in.


### PR DESCRIPTION
Implements the mesh-router **P1** vertical slice (epic #4267). Routes one real net end-to-end through the mesh paradigm behind a **default-OFF** flag, reusing the shipped emission + DRC tail.

Closes #4268

## Pipeline
poly2tri constrained-Delaunay (with pad keep-out holes) -> triangle-dual **portal-midpoint** A* -> Simple Stupid Funnel string-pull -> **clearance-aware 45-degree best-fit** -> ordinary `Route` -> `Segment.to_sexp` #3907 choke -> `kicad-cli pcb drc --refill-zones`.

## What landed (in the issue's seam order)
1. **Vendored poly2tri (BSD-3)** under `cpp/third_party/poly2tri/` (LICENSE + AUTHORS intact) into the existing nanobind `router_cpp` ext. Thin binding `cpp/src/mesh.cpp` (declared in `bindings.cpp`) exposes `constrained_delaunay(outer, holes, steiner) -> (vertices, triangles)`. CMake wires it: `P2T_STATIC_EXPORTS`, include dir, `.cc` glob.
2. **Built + verified**: `kct build-native --check` reports available after adding poly2tri.
3. **`src/kicad_tools/router/mesh/` package**: `geometry`, `funnel` (Mononen SSF), `navmesh` (portal-midpoint A*), `octilinear` (the 45-fit), `obstacles`, `MeshPathfinder`.
4. **Clearance-aware 45-fit** generalises the shipped `subgrid.py:1004-1030` obstacle-consult-per-leg discipline from the pad-escape chord to *each funnel chord*: reject a dogleg whose leg enters a keep-out, try the flipped orientation, subdivide to hug the geodesic, else **decline the net (None) — never emit a short**. The authoritative obstacle model (every other-net pad, inflated by agent radius) is the same model the mesh holes come from (the #3906 lesson).
5. **`MeshPathfinder.route(start, end, ...)`** mirrors `CppPathfinder.route`'s contract + `supports_waypoint_injection` capability flag; dispatched from `Autorouter.route_net` via `_route_net_mesh`.
6. **`--route-engine {grid,mesh}` flag, default `grid`**, orthogonal to `--backend`. Plumbed at both parser sites + forwarded in `commands/routing.py`, threaded through `load_pcb_for_routing` -> `Autorouter(strategy=...)`.
7. **Emission tail reused verbatim**: 45-legal segments flow through the `_ENFORCE_SEGMENT_45` choke and `kicad-cli --refill-zones` DRC.

## Acceptance results
- **Routes one real net, 45-legal, DRC-clean**: verified end-to-end via CLI (`--route-engine mesh` on voltage-divider = 40 segments, internal + kicad-cli DRC both clean) and pytest (charlieplex net routed, `error_count == 0` under `--refill-zones`). Motivating **softstart rev-C** run (from the readable main-worktree copy) routed net `/PM12_L` DRC-clean.
- **Clearance regression (#3906-modeled)**: `test_octilinear.py` proves a bulging default dogleg into a keep-out is **rejected** (flipped orientation chosen), every emitted leg is 45-legal, subdivision threads tight gaps, and a fully-walled chord returns `None` rather than shorting. On real geometry, `test_mesh_route_never_shorts_on_dense_board_stm32` shows the gate declines the net that an obstacle-blind fit shorted and adds **zero** new DRC errors.
- **`--route-engine grid` byte-identical**: voltage-divider fully byte-identical (fixed seed); charlieplex identical modulo pre-existing UUID randomness (two default runs differ by UUIDs alone). Grid path skips the mesh branch entirely.
- **Memory bounded**: mesh node count is hundreds–thousands (test asserts `< 100k`), orders below the grid's 63.5M cells.
- **Single-net only**: multi-net negotiation, capacity, pours/zones, vias and matched routing are explicitly P2/P3.

## poly2tri interior-hole fidelity verdict (the P0.5 open question)
**Confirmed adequate.** `AddHole` produces zero triangles inside pad keep-outs (verified in the smoke test and `test_navmesh`). No contingency (spade / roll-our-own) needed.

## Deviations (noted honestly)
- **Flag name**: the issue asked for `--strategy {grid,mesh}`, but `--strategy` already exists on `kct route` for the negotiation algorithm (`basic/negotiated/monte-carlo/evolutionary`). The substrate selector is therefore **`--route-engine {grid,mesh}`** (orthogonal to both `--backend` and `--strategy`).
- **Acceptance board**: softstart rev-C is a local-only symlink that dangles in fresh worktrees, so the committed pytest runs on in-repo fleet boards (charlieplex, stm32); the softstart run is manual (reported above). The softstart board is **not** committed.
- **Clearance model**: pad keep-outs only. Copper **pours/zones are not yet modeled** as obstacles (a signal trace crossing a foreign GND pour would short) — the pathfinder declines or the DRC gate catches it; pour-aware routing is P2.
- **Mesh dispatch** routes each net single-net (no negotiation/rip-up); full negotiation-loop integration is P2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)