### PR TITLE
mesh-router P2.5: in-corridor lane assignment (portal narrowing + re-funnel) (#4274)

### DIFF
--- a/src/kicad_tools/router/mesh/geometry.py
+++ b/src/kicad_tools/router/mesh/geometry.py
@@ -139,6 +139,72 @@ def segment_intersects_polygon(p1: Pt, p2: Pt, poly: list[Pt]) -> bool:
     return any(segments_intersect(p1, p2, poly[i], poly[(i + 1) % n]) for i in range(n))
 
 
+def _seg_crossing_param(a: Pt, b: Pt, c: Pt, d: Pt) -> float | None:
+    """Parametric ``t`` in ``[0, 1]`` along ``a->b`` where it crosses ``c->d``.
+
+    Returns ``None`` when the two segments are parallel or do not cross within
+    both spans.  Used by :func:`segment_polygon_interval` to clip a portal edge
+    against a committed-copper capsule (issue #4274 in-corridor lane assignment).
+    """
+    rx, ry = b[0] - a[0], b[1] - a[1]
+    sx, sy = d[0] - c[0], d[1] - c[1]
+    denom = rx * sy - ry * sx
+    if abs(denom) < 1e-15:
+        return None
+    qx, qy = c[0] - a[0], c[1] - a[1]
+    t = (qx * sy - qy * sx) / denom
+    u = (qx * ry - qy * rx) / denom
+    if -1e-12 <= t <= 1.0 + 1e-12 and -1e-12 <= u <= 1.0 + 1e-12:
+        return min(1.0, max(0.0, t))
+    return None
+
+
+def segment_polygon_interval(a: Pt, b: Pt, poly: list[Pt]) -> tuple[float, float] | None:
+    """Parametric ``[t0, t1]`` of the part of segment ``a->b`` inside ``poly``.
+
+    Winding-agnostic; ``poly`` is a closed convex ring (the committed-copper
+    capsules are convex quads) given WITHOUT a repeated final vertex.  Returns
+    ``None`` when the segment never enters the polygon.  For a convex polygon the
+    interior span of a segment is contiguous, so a single ``(t0, t1)`` describes
+    the consumed opening a committed trace carves out of a portal edge.
+    """
+    n = len(poly)
+    if n < 3:
+        return None
+    cuts = {0.0, 1.0}
+    for i in range(n):
+        t = _seg_crossing_param(a, b, poly[i], poly[(i + 1) % n])
+        if t is not None:
+            cuts.add(t)
+    ts = sorted(cuts)
+    lo: float | None = None
+    hi = 0.0
+    for j in range(len(ts) - 1):
+        tm = 0.5 * (ts[j] + ts[j + 1])
+        pm = (a[0] + tm * (b[0] - a[0]), a[1] + tm * (b[1] - a[1]))
+        if point_in_polygon(pm, poly):
+            if lo is None:
+                lo = ts[j]
+            hi = ts[j + 1]
+    if lo is None:
+        return None
+    return (lo, hi)
+
+
+def merge_intervals(intervals: list[tuple[float, float]]) -> list[tuple[float, float]]:
+    """Union a set of ``[t0, t1]`` intervals into disjoint, sorted spans."""
+    if not intervals:
+        return []
+    ordered = sorted(intervals)
+    out: list[list[float]] = [list(ordered[0])]
+    for lo, hi in ordered[1:]:
+        if lo <= out[-1][1] + 1e-9:
+            out[-1][1] = max(out[-1][1], hi)
+        else:
+            out.append([lo, hi])
+    return [(lo, hi) for lo, hi in out]
+
+
 def segment_intersects_rect(
     p1: Pt, p2: Pt, xmin: float, ymin: float, xmax: float, ymax: float
 ) -> bool:

--- a/src/kicad_tools/router/mesh/navmesh.py
+++ b/src/kicad_tools/router/mesh/navmesh.py
@@ -18,7 +18,7 @@ import heapq
 import math
 
 from .funnel import Portal
-from .geometry import EPS, Pt, centroid, point_in_triangle
+from .geometry import EPS, Pt, centroid, merge_intervals, point_in_triangle
 
 Triangle = tuple[int, int, int]
 
@@ -272,13 +272,29 @@ class NavMesh:
 
     # -- corridor -> oriented portals -------------------------------------
 
-    def corridor_to_portals(self, corridor: list[int], start: Pt, goal: Pt) -> list[Portal]:
+    def corridor_to_portals(
+        self,
+        corridor: list[int],
+        start: Pt,
+        goal: Pt,
+        consumed: dict[tuple[int, int], list[tuple[float, float]]] | None = None,
+        pack: str = "largest",
+    ) -> list[Portal]:
         """Convert a triangle corridor into oriented ``(left, right)`` portals.
 
         Each portal is the shared edge between consecutive corridor triangles,
         oriented so ``left`` sits on the left-hand side of travel (the funnel's
         sign convention).  The near-triangle centroid is the orientation
         reference: it always lies on the traveling-from side of the edge.
+
+        Issue #4274 (in-corridor lane assignment): ``consumed`` maps each portal
+        edge key to the parametric ``[t0, t1]`` intervals (along
+        ``vertices[edge[0]] -> vertices[edge[1]]``) already occupied by committed
+        copper.  When supplied, each crossed portal's opening is narrowed to the
+        residual sub-segment so the funnel yields a *parallel* geodesic for the
+        next net instead of the same taut path.  ``consumed`` defaults to
+        ``None``, so the single-net P1/P2 contract (full openings) is unchanged
+        byte-for-byte.
         """
         portals: list[Portal] = [(start, start)]
         for i in range(len(corridor) - 1):
@@ -291,10 +307,17 @@ class NavMesh:
             q = self.vertices[edge[1]]
             ref = self._centroids[cur]
             # Mononen sign: _area(ref, left, right) > 0 for correct orientation.
+            # ``reversed_`` records whether ``left`` is ``q`` (edge[1]) so the
+            # consumed intervals (parametric p->q) map into the left->right frame.
             if _mononen_area(ref, p, q) > 0.0:
-                portals.append((p, q))
+                left, right, reversed_ = p, q, False
             else:
-                portals.append((q, p))
+                left, right, reversed_ = q, p, True
+            if consumed:
+                bands = consumed.get(edge)
+                if bands:
+                    left, right = _narrow_portal(left, right, reversed_, bands, pack)
+            portals.append((left, right))
         portals.append((goal, goal))
         return portals
 
@@ -305,6 +328,73 @@ class NavMesh:
         if len(common) == 2:
             return (common[0], common[1])
         return None
+
+
+def _narrow_portal(
+    left: Pt,
+    right: Pt,
+    reversed_: bool,
+    bands: list[tuple[float, float]],
+    pack: str = "largest",
+) -> Portal:
+    """Clip an oriented portal ``(left, right)`` to a residual free opening (#4274).
+
+    ``bands`` are the consumed ``[t0, t1]`` intervals in the *edge* frame
+    (``vertices[edge[0]] -> vertices[edge[1]]``); ``reversed_`` says whether the
+    oriented ``left`` is ``edge[1]`` (so ``s = 1 - t``).  Work in the oriented
+    ``s`` frame (``s = 0`` at ``left``, ``s = 1`` at ``right``): subtract the
+    consumed bands from ``[0, 1]`` to get the free gaps and hand the funnel one
+    of them (still oriented left/right).  ``pack`` selects which gap, giving the
+    re-funnel a small family of parallel-lane candidates:
+
+    * ``"largest"`` -- the widest free gap (the roomiest lane);
+    * ``"left"`` -- the free gap nearest the ``left`` wall (``s = 0``);
+    * ``"right"`` -- the free gap nearest the ``right`` wall (``s = 1``).
+
+    ``"left"`` / ``"right"`` are the **monotone one-wall** disciplines: every
+    portal along the corridor packs against the *same* wall, so the funnel is
+    forced consistently to one side of the committed copper and successive lanes
+    stack in parallel rather than weaving across each other.  A fully-consumed
+    portal collapses to a near-degenerate opening whose funnel path the
+    octilinear fit declines rather than a short.
+    """
+    # Consumed bands -> oriented s-frame, then merged.
+    s_bands: list[tuple[float, float]] = []
+    for t0, t1 in bands:
+        if reversed_:
+            s0, s1 = 1.0 - t1, 1.0 - t0
+        else:
+            s0, s1 = t0, t1
+        s_bands.append((max(0.0, min(1.0, s0)), max(0.0, min(1.0, s1))))
+    consumed = merge_intervals(s_bands)
+    if not consumed:
+        return left, right
+
+    # Complement of the consumed bands within [0, 1] -> free gaps.
+    gaps: list[tuple[float, float]] = []
+    cursor = 0.0
+    for c0, c1 in consumed:
+        if c0 > cursor:
+            gaps.append((cursor, c0))
+        cursor = max(cursor, c1)
+    if cursor < 1.0:
+        gaps.append((cursor, 1.0))
+    if not gaps:
+        # Portal fully consumed: collapse toward the right wall so the funnel
+        # yields a path the octilinear fit declines (never a short).
+        return right, right
+
+    if pack == "left":
+        lo, hi = gaps[0]
+    elif pack == "right":
+        lo, hi = gaps[-1]
+    else:
+        lo, hi = max(gaps, key=lambda g: g[1] - g[0])
+    lx = left[0] + lo * (right[0] - left[0])
+    ly = left[1] + lo * (right[1] - left[1])
+    rx = left[0] + hi * (right[0] - left[0])
+    ry = left[1] + hi * (right[1] - left[1])
+    return (lx, ly), (rx, ry)
 
 
 def _mononen_area(a: Pt, b: Pt, c: Pt) -> float:

--- a/src/kicad_tools/router/mesh/pathfinder.py
+++ b/src/kicad_tools/router/mesh/pathfinder.py
@@ -31,7 +31,7 @@ from pathlib import Path
 
 from ..primitives import Pad, Route, Segment
 from ..rules import DesignRules
-from .geometry import Pt
+from .geometry import Pt, merge_intervals, segment_polygon_interval
 from .navmesh import NavMesh
 from .obstacles import ObstacleModel, Rect
 from .octilinear import octilinear_fit
@@ -215,6 +215,7 @@ class MeshPathfinder:
         negotiated_mode: bool,
         present_cost_factor: float,
         committed: list[list[Pt]] | None = None,
+        consumed: dict[tuple[int, int], list[tuple[float, float]]] | None = None,
     ) -> tuple[Route, list[tuple[int, int]]] | None:
         """Route + report the portal keys the route crosses (for occupancy).
 
@@ -224,6 +225,15 @@ class MeshPathfinder:
         than shipped as a short (the #3906 "never ship a short" invariant, now
         enforced net-vs-net).  The static mesh is untouched -- committed copper
         only narrows the per-net obstacle model, never re-triangulates.
+
+        ``consumed`` (issue #4274) maps each portal edge to the parametric
+        intervals already occupied by committed copper; it narrows this net's
+        portal openings to their residual sub-segments so the funnel yields a
+        *parallel* geodesic (an actual lane) instead of the same taut path a
+        prior net already claimed.  When ``None`` it is derived from
+        ``committed`` for this net's own corridor (each portal edge intersected
+        with every committed capsule); an empty/absent model reproduces the P2
+        full-opening funnel exactly.
         """
         navmesh = self.build()
         if not navmesh.triangles:
@@ -260,13 +270,58 @@ class MeshPathfinder:
         if corridor is None:
             return None
 
-        geodesic = _pull(navmesh, corridor, start_pt, end_pt)
-        fitted = octilinear_fit(geodesic, obstacles.is_clear)
+        # First try the full-opening funnel (the P2 geodesic).  When no copper
+        # is committed yet -- the first net, and every net on ``--route-engine``
+        # paths that never narrow -- this is the only attempt and the result is
+        # byte-identical to P2.
+        fitted = self._fit_corridor(navmesh, corridor, start_pt, end_pt, obstacles, consumed)
+
+        # Issue #4274 re-funnel: if the taut geodesic collides with copper a
+        # prior net committed this pass, narrow this net's portals to their
+        # residual openings and re-run the funnel.  Narrowing only *adds* a lane
+        # candidate -- the straight geodesic was already tried -- so completion
+        # can only rise, never regress, and a lane that still cannot clear
+        # declines (``None``) rather than crossing.
+        if fitted is None and consumed is None and committed:
+            derived: dict[tuple[int, int], list[tuple[float, float]]] = {}
+            for edge in navmesh.corridor_portals(corridor):
+                bands = _edge_consumed_bands(navmesh, edge, committed)
+                if bands:
+                    derived[edge] = bands
+            if derived:
+                # Re-funnel with a small family of parallel-lane candidates
+                # (widest gap, then each one-wall packing); accept the first
+                # that clears.  Every candidate is validated against the true
+                # obstacle model, so a lane that cannot clear still declines.
+                for pack in ("largest", "left", "right"):
+                    fitted = self._fit_corridor(
+                        navmesh, corridor, start_pt, end_pt, obstacles, derived, pack
+                    )
+                    if fitted is not None:
+                        break
+
         if fitted is None or len(fitted) < 2:
             return None
 
         route = self._build_route(start, net, trace_w, fitted)
         return route, navmesh.corridor_portals(corridor)
+
+    def _fit_corridor(
+        self,
+        navmesh: NavMesh,
+        corridor: list[int],
+        start_pt: Pt,
+        end_pt: Pt,
+        obstacles: ObstacleModel,
+        consumed: dict[tuple[int, int], list[tuple[float, float]]] | None,
+        pack: str = "largest",
+    ) -> list[Pt] | None:
+        """Funnel + clearance-clean 45-fit for one corridor (optionally narrowed)."""
+        geodesic = _pull(navmesh, corridor, start_pt, end_pt, consumed, pack)
+        fitted = octilinear_fit(geodesic, obstacles.is_clear)
+        if fitted is None or len(fitted) < 2:
+            return None
+        return fitted
 
     # -- multi-net negotiation (issue #4269) ------------------------------
 
@@ -324,6 +379,12 @@ class MeshPathfinder:
             # rip-up genuinely frees the corridor.
             committed: list[list[Pt]] = []
             for key, start, end, net_class in ordered:
+                # Issue #4274: ``committed`` doubles as the lane-assignment
+                # model -- ``_route_with_portals`` narrows this net's portals by
+                # the copper already committed this pass so its funnel produces a
+                # parallel lane rather than the geodesic a prior net occupies.
+                # Reset each pass so a rip-up frees the lane as well as the
+                # copper.
                 result = self._route_with_portals(
                     start,
                     end,
@@ -492,10 +553,38 @@ def _inflate_polygon(poly: list[Pt], margin: float) -> list[Pt]:
     return out
 
 
-def _pull(navmesh: NavMesh, corridor: list[int], start: Pt, end: Pt) -> list[Pt]:
+def _edge_consumed_bands(
+    navmesh: NavMesh, edge: tuple[int, int], capsules: list[list[Pt]]
+) -> list[tuple[float, float]]:
+    """Parametric ``[t0, t1]`` intervals a route's copper carves out of a portal.
+
+    Intersects each committed capsule (inflated by ``trace_width + clearance``,
+    the same width the octilinear fit clears against) with the portal edge
+    ``vertices[edge[0]] -> vertices[edge[1]]`` and unions the covered spans.
+    These are the openings :func:`NavMesh.corridor_to_portals` subtracts so the
+    next net funnels through the residual sub-segment (issue #4274).
+    """
+    a = navmesh.vertices[edge[0]]
+    b = navmesh.vertices[edge[1]]
+    ivals: list[tuple[float, float]] = []
+    for poly in capsules:
+        iv = segment_polygon_interval(a, b, poly)
+        if iv is not None:
+            ivals.append(iv)
+    return merge_intervals(ivals)
+
+
+def _pull(
+    navmesh: NavMesh,
+    corridor: list[int],
+    start: Pt,
+    end: Pt,
+    consumed: dict[tuple[int, int], list[tuple[float, float]]] | None = None,
+    pack: str = "largest",
+) -> list[Pt]:
     from .funnel import string_pull
 
-    return string_pull(navmesh.corridor_to_portals(corridor, start, end))
+    return string_pull(navmesh.corridor_to_portals(corridor, start, end, consumed, pack))
 
 
 def _outline_from_edges(

--- a/tests/router/mesh/test_lane_assignment.py
+++ b/tests/router/mesh/test_lane_assignment.py
@@ -1,0 +1,316 @@
+"""In-corridor lane assignment (portal narrowing + re-funnel) for P2.5 (#4274).
+
+P2 shipped multi-net negotiation but a capacity-N portal still carried only ONE
+path: the funnel is lane-blind and returns the same taut geodesic per net, so
+committed copper blocks the next net and it declines.  P2.5 narrows each portal
+opening by the copper already committed on it and re-funnels, so net k+1 gets a
+*parallel* geodesic in the residual opening.
+
+These tests cover, from the acceptance criteria:
+
+* the residual-opening geometry (``segment_polygon_interval`` / ``merge_intervals``
+  and ``NavMesh.corridor_to_portals(consumed=...)``);
+* a hand-computed capacity-N portal carrying ``min(N, demand)`` distinct
+  non-overlapping 45-legal lanes (modelled on ``test_portal_capacity.py``);
+* the full-opening funnel staying byte-identical when nothing is committed
+  (the P1/P2 single-net contract, and the ``--route-engine grid`` guarantee that
+  the mesh package is only consulted for ``--route-engine mesh``);
+* completion rising on a dense corridor where lanes ARE parallel-congested,
+  with the triangulation still built once and zero net-vs-net crossings;
+* the #3906 never-ship-a-short invariant: a lane that cannot clear declines
+  (``None``) rather than crossing committed copper.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.mesh.funnel import string_pull
+from kicad_tools.router.mesh.geometry import (
+    merge_intervals,
+    segment_polygon_interval,
+    segments_intersect,
+)
+from kicad_tools.router.mesh.navmesh import NavMesh
+from kicad_tools.router.mesh.obstacles import ObstacleModel
+from kicad_tools.router.mesh.octilinear import octilinear_fit
+from kicad_tools.router.mesh.pathfinder import (
+    MeshPathfinder,
+    _edge_consumed_bands,
+    _segment_capsule,
+)
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.quantize import is_45_aligned
+from kicad_tools.router.rules import DesignRules
+
+router_cpp = pytest.importorskip("kicad_tools.router.router_cpp")
+
+
+def _pad(x: float, y: float, net: int, ref: str, w: float = 0.6, h: float = 0.6) -> Pad:
+    return Pad(
+        x=x, y=y, width=w, height=h, net=net, net_name=f"N{net}", layer=Layer.F_CU, ref=ref, pin="1"
+    )
+
+
+def _cross_net_intersections(routes: dict[object, object]) -> int:
+    """Count intersecting segments belonging to DIFFERENT nets (net-vs-net shorts)."""
+    segs: list[tuple[object, tuple[float, float], tuple[float, float]]] = []
+    for key, route in routes.items():
+        for s in route.segments:  # type: ignore[attr-defined]
+            segs.append((key, (s.x1, s.y1), (s.x2, s.y2)))
+    count = 0
+    for i in range(len(segs)):
+        for j in range(i + 1, len(segs)):
+            if segs[i][0] != segs[j][0] and segments_intersect(
+                segs[i][1], segs[i][2], segs[j][1], segs[j][2]
+            ):
+                count += 1
+    return count
+
+
+# ---------------------------------------------------------------------------
+# Residual-opening geometry primitives.
+# ---------------------------------------------------------------------------
+
+
+def test_segment_polygon_interval_clips_edge_to_capsule() -> None:
+    # A vertical portal edge from (0,0) to (0,10) and a committed capsule that
+    # covers y in [4, 6] -> the consumed parametric interval is [0.4, 0.6].
+    a, b = (0.0, 0.0), (0.0, 10.0)
+    capsule = [(-1.0, 4.0), (1.0, 4.0), (1.0, 6.0), (-1.0, 6.0)]
+    iv = segment_polygon_interval(a, b, capsule)
+    assert iv is not None
+    t0, t1 = iv
+    assert math.isclose(t0, 0.4, abs_tol=1e-9)
+    assert math.isclose(t1, 0.6, abs_tol=1e-9)
+
+
+def test_segment_polygon_interval_none_when_disjoint() -> None:
+    a, b = (0.0, 0.0), (0.0, 10.0)
+    capsule = [(5.0, 4.0), (7.0, 4.0), (7.0, 6.0), (5.0, 6.0)]  # off to the side
+    assert segment_polygon_interval(a, b, capsule) is None
+
+
+def test_merge_intervals_unions_overlaps() -> None:
+    assert merge_intervals([(0.1, 0.3), (0.25, 0.5), (0.8, 0.9)]) == [(0.1, 0.5), (0.8, 0.9)]
+    assert merge_intervals([]) == []
+
+
+# ---------------------------------------------------------------------------
+# corridor_to_portals narrowing.
+# ---------------------------------------------------------------------------
+
+
+def _two_square_channel(
+    channel: float,
+) -> tuple[NavMesh, list[int], tuple[float, float], tuple[float, float]]:
+    """Two unit squares sharing a vertical mid portal ``(2, 3)`` of length 10.
+
+    Vertices: 0=(0,0) 1=(0,10) 2=(10,0) 3=(10,10) 4=(20,0) 5=(20,10).  The
+    shared edge (2,3) is the vertical portal at x=10 spanning y in [0,10].
+    """
+    verts = [(0.0, 0.0), (0.0, 10.0), (10.0, 0.0), (10.0, 10.0), (20.0, 0.0), (20.0, 10.0)]
+    tris = [(0, 2, 3), (0, 3, 1), (2, 4, 5), (2, 5, 3)]
+    nm = NavMesh(verts, tris, channel=channel)
+    start, goal = (1.0, 5.0), (19.0, 5.0)
+    corridor = nm.astar(start, goal)
+    assert corridor is not None
+    assert (2, 3) in nm.corridor_portals(corridor)
+    return nm, corridor, start, goal
+
+
+def test_corridor_to_portals_without_consumed_is_unchanged() -> None:
+    # The P1/P2 contract: no consumed model -> full openings, byte-identical.
+    nm, corridor, start, goal = _two_square_channel(channel=0.4)
+    plain = nm.corridor_to_portals(corridor, start, goal)
+    also_plain = nm.corridor_to_portals(corridor, start, goal, consumed=None)
+    assert plain == also_plain
+    # An empty consumed map is likewise a no-op.
+    assert nm.corridor_to_portals(corridor, start, goal, consumed={}) == plain
+
+
+def test_corridor_to_portals_narrows_to_residual_opening() -> None:
+    nm, corridor, start, goal = _two_square_channel(channel=0.4)
+    # Consume the lower third of the portal (t in [0, 0.3]) -> the largest free
+    # gap is [0.3, 1], so the returned portal opening starts at y=3 (s=0.3).
+    consumed = {(2, 3): [(0.0, 0.3)]}
+    portals = nm.corridor_to_portals(corridor, start, goal, consumed=consumed)
+    # Find the (2,3) portal in the oriented list by matching x==10 endpoints.
+    gate = [p for p in portals if abs(p[0][0] - 10.0) < 1e-9 and abs(p[1][0] - 10.0) < 1e-9]
+    assert gate, "vertical gate portal not found"
+    left, right = gate[0]
+    ys = sorted((left[1], right[1]))
+    # Opening no longer reaches y<3; it spans the residual [3, 10].
+    assert ys[0] >= 3.0 - 1e-6
+    assert ys[1] <= 10.0 + 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Acceptance: a capacity-N portal carries N distinct non-overlapping lanes.
+# ---------------------------------------------------------------------------
+
+
+def test_capacity_portal_carries_multiple_parallel_lanes() -> None:
+    """A hand-computed capacity-N portal carries ``min(N, demand)`` lanes.
+
+    Successive nets share the same corridor; each consumes a band on the portal,
+    and the re-funnel places the next net in the residual opening.  The lanes
+    must be distinct, non-overlapping (centreline pitch >= trace + clearance),
+    all inside the portal, and each 45-legal.
+    """
+    rules = DesignRules()
+    pitch = rules.trace_width + rules.trace_clearance  # 0.4 mm: clean lane pitch
+    nm, corridor, start, goal = _two_square_channel(channel=0.4)
+    assert nm.capacity((2, 3)) >= 10  # a genuinely wide (capacity-N) portal
+
+    clear = lambda _a, _b: True  # noqa: E731 - permissive obstacle model for 45-legality
+    consumed: dict[tuple[int, int], list[tuple[float, float]]] = {}
+    crossings: list[float] = []
+    demand = 6
+    for _lane in range(demand):
+        portals = nm.corridor_to_portals(corridor, start, goal, consumed=consumed, pack="left")
+        geodesic = string_pull(portals)
+        fitted = octilinear_fit(geodesic, clear)
+        assert fitted is not None and len(fitted) >= 2
+        # Every emitted leg is 45-legal.
+        for i in range(len(fitted) - 1):
+            dx = fitted[i + 1][0] - fitted[i][0]
+            dy = fitted[i + 1][1] - fitted[i][1]
+            assert is_45_aligned(dx, dy)
+        # Record where this lane crosses the portal (x == 10).
+        cy = None
+        for i in range(len(geodesic) - 1):
+            (x1, y1), (x2, y2) = geodesic[i], geodesic[i + 1]
+            if (x1 - 10.0) * (x2 - 10.0) <= 0 and x1 != x2:
+                t = (10.0 - x1) / (x2 - x1)
+                cy = y1 + t * (y2 - y1)
+        assert cy is not None
+        crossings.append(cy)
+        # Commit this lane's copper and record the band it consumes on the portal.
+        capsules = [
+            c
+            for c in (
+                _segment_capsule(geodesic[i], geodesic[i + 1], pitch)
+                for i in range(len(geodesic) - 1)
+            )
+            if c is not None
+        ]
+        bands = _edge_consumed_bands(nm, (2, 3), capsules)
+        assert bands
+        consumed.setdefault((2, 3), []).extend(bands)
+
+    # min(N, demand) == demand distinct lanes were placed.
+    assert len(crossings) == demand
+    # All inside the portal.
+    assert all(0.0 <= cy <= 10.0 for cy in crossings)
+    # Monotone and non-overlapping: consecutive centrelines are at least a clean
+    # lane pitch apart (their inflated copper capsules do not overlap).
+    ordered = sorted(crossings)
+    for lo, hi in zip(ordered, ordered[1:], strict=False):
+        assert hi - lo >= pitch - 1e-6, f"lanes overlap: {ordered}"
+
+
+# ---------------------------------------------------------------------------
+# Completion rises on a dense corridor (parallel-congested), DRC-clean.
+# ---------------------------------------------------------------------------
+
+
+def _l_bend_fixture() -> tuple[list, list, list]:
+    """Nets that all round the same reflex corner -> co-linear congestion.
+
+    A square obstacle fills the lower-right, leaving an L-shaped free region.
+    Five nets run from the left strip to the top strip; the funnel pulls each
+    taut around the SAME inner corner, so without lane assignment they collapse
+    onto one geodesic and committed copper blocks all but the first few.
+    """
+    outline = [(0.0, 0.0), (50.0, 0.0), (50.0, 50.0), (0.0, 50.0)]
+    pads = [_pad(36.0, 6.0, 99, "OBS", w=28.0, h=28.0)]  # blocks x>=22, y<=20
+    conns = []
+    for k in range(5):
+        left = _pad(8.0, 4.0 + 2.5 * k, k + 1, f"L{k}")
+        top = _pad(42.0 - 2.5 * k, 44.0, k + 1, f"T{k}")
+        pads += [left, top]
+        conns.append(((k + 1, 0), left, top, None))
+    return outline, pads, conns
+
+
+def _greedy_straight_only(outline: list, pads: list, conns: list) -> int:
+    """First-come greedy that avoids committed copper but never narrows portals.
+
+    This is the P2 behaviour (full-opening funnel only): the fair baseline the
+    lane-assigned negotiation must beat.
+    """
+    rules = DesignRules()
+    pf = MeshPathfinder(outline, pads, rules)
+    nm = pf.build()
+    committed: list = []
+    routed = 0
+    ordered = sorted(conns, key=lambda c: math.hypot(c[1].x - c[2].x, c[1].y - c[2].y))
+    for _key, s, e, _nc in ordered:
+        keep = pf._keepouts(s.net, rules.trace_width / 2.0 + rules.trace_clearance)
+        obst = ObstacleModel(outline, keep, pf.pours + committed)
+        corridor = nm.astar(
+            (s.x, s.y),
+            (e.x, e.y),
+            present_cost_factor=0.5,
+            cost_congestion=2.0,
+            congestion_threshold=0.3,
+        )
+        fit = (
+            None
+            if corridor is None
+            else pf._fit_corridor(nm, corridor, (s.x, s.y), (e.x, e.y), obst, None)
+        )
+        if fit is not None:
+            routed += 1
+            committed.extend(pf._route_obstacles(pf._build_route(s, s.net, rules.trace_width, fit)))
+    return routed
+
+
+def test_lane_assignment_lifts_completion_on_dense_corridor() -> None:
+    outline, pads, conns = _l_bend_fixture()
+    baseline = _greedy_straight_only(outline, pads, conns)
+
+    pf = MeshPathfinder(outline, pads, DesignRules())
+    routes, stats = pf.route_netset(conns, max_iterations=8)
+
+    # A real rise over the full-opening (P2) baseline...
+    assert stats.routed > baseline, (
+        f"lane assignment did not lift completion: {stats.routed} <= {baseline}"
+    )
+    # ...with the triangulation still built exactly once...
+    assert stats.triangulation_calls == 1
+    # ...and zero net-vs-net crossings (never ship a short).
+    assert _cross_net_intersections(routes) == 0
+
+
+# ---------------------------------------------------------------------------
+# #3906: a blocked lane declines rather than shorts.
+# ---------------------------------------------------------------------------
+
+
+def test_blocked_lane_declines_never_shorts() -> None:
+    """Two nets that must cross on a single layer: the second declines.
+
+    Net A spans nearly the full board width; net B must cross it and cannot go
+    around.  Lane assignment cannot manufacture a legal parallel lane here, so
+    the octilinear fit against the true obstacle model declines (``None``) --
+    the #3906 invariant.  Exactly one net routes and there is no crossing.
+    """
+    outline = [(0.0, 0.0), (40.0, 0.0), (40.0, 20.0), (0.0, 20.0)]
+    pads = [
+        _pad(1.0, 10.0, 1, "A1"),
+        _pad(39.0, 10.0, 1, "A2"),
+        _pad(20.0, 1.0, 2, "B1"),
+        _pad(20.0, 19.0, 2, "B2"),
+    ]
+    conns = [((1, 0), pads[0], pads[1], None), ((2, 0), pads[2], pads[3], None)]
+    pf = MeshPathfinder(outline, pads, DesignRules())
+    routes, stats = pf.route_netset(conns, max_iterations=6)
+
+    assert stats.routed == 1, "a blocked transverse lane must decline, not squeeze in"
+    assert _cross_net_intersections(routes) == 0, "never ship a net-vs-net short"
+    assert stats.triangulation_calls == 1


### PR DESCRIPTION
Closes #4274

## What this does

P2 shipped multi-net negotiation but a capacity-N portal still carried only **one** path: the funnel is lane-blind and returns the same taut geodesic per net, so committed copper blocks the next net and it declines. P2.5 narrows each portal opening by the copper already committed on it and **re-funnels**, so net k+1 gets a **parallel** geodesic in the residual opening (Approach 1 from the issue — committed-copper portal narrowing).

## Seam into merged P2 (`0def07c2`)

1. **`geometry.py`** — `segment_polygon_interval()` clips a portal edge to the parametric span a committed inflated capsule covers; `merge_intervals()` unions them.
2. **`navmesh.corridor_to_portals(consumed=..., pack=...)`** — after computing each oriented `(left, right)`, subtract the consumed bands and hand `string_pull` a **residual free sub-segment**. `pack` selects the lane (largest gap / left wall / right wall — monotone one-wall packing) so successive lanes stack parallel rather than weave/cross.
3. **`pathfinder._route_with_portals`** — try the full-opening funnel first (the P2 geodesic, byte-identical), then **re-funnel** through narrowed portals only if the taut geodesic collides with copper committed this pass. Consumed intervals are derived from the committed capsules for exactly this net's corridor. Narrowing purely **adds** a lane candidate, so completion can only rise and `octilinear_fit` against the true obstacle model stays the authoritative never-ship-a-short gate.
4. **Everything else unchanged** — static mesh built once (`triangulation_calls == 1`), `committed` reset each pass, `--route-engine grid` untouched (only `mesh/` files changed), `consumed=None` reproduces the P2 full-opening funnel exactly.

## Acceptance / results

- **Capacity-N portal carries N parallel lanes** — new unit test: a hand-computed capacity-N portal carries `min(N, demand)` distinct, non-overlapping (centreline pitch ≥ trace+clearance), 45-legal lanes.
- **Completion rises on a dense corridor** — new fixture (nets rounding one reflex corner → parallel congestion): lane assignment lifts routed above the full-opening (P2) baseline, triangulation once, **0 net-vs-net crossings**.
- **Triangulation once per board** — asserted (`triangulation_calls == 1`).
- **`--route-engine grid` byte-identical** — grid dispatch untouched; only `mesh/` changed.
- **Never-ship-a-short** — new #3906-modelled test: a transverse lane that cannot clear **declines** (routed 1 of 2), never crosses.

### Honest charlieplex number

Board-02 charlieplex stays at **7/24** (DRC-clean, triangulation once). Its residual blocks are **transverse crossings and pad-fanout congestion**, not the parallel co-linear congestion portal narrowing addresses — instrumentation shows **0 nets rescued by narrowing** there and the count is unchanged across 8/16/24 iterations. So 02 saturates for this mechanism (the issue anticipates this: "A denser fixture may be added if 02 saturates" / "if packing only gets partway, report the true count"). The change **never regresses** 02 (still 7, still DRC-clean) and the rise is demonstrated on the purpose-built dense-corridor fixture.

## Checks
- `tests/router/mesh/` — 41 passed (33 existing + 8 new), including under `-W error::UserWarning`.
- `ruff check` / `ruff format` clean; mypy baseline: no new type errors (baseline untouched); manufacturer-propagation lint passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)