### PR TITLE
feat(router): mesh P2.6 — 2.5D via injection (portal-midpoint dips over N-layer mesh)

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -2334,7 +2334,15 @@ class Autorouter:
                 bx1 = self.grid.origin_x + self.grid.width
                 by1 = self.grid.origin_y + self.grid.height
             outline = [(bx0, by0), (bx1, by0), (bx1, by1), (bx0, by1)]
-            self._mesh_pathfinder = MeshPathfinder(outline, list(self.pads.values()), self.rules)
+            # Issue #4276: hand the mesh the board's real copper stack so the
+            # 2.5D via injection replicates the mesh across the actual routing
+            # layer count instead of assuming 2.
+            self._mesh_pathfinder = MeshPathfinder(
+                outline,
+                list(self.pads.values()),
+                self.rules,
+                layer_stack=self.layer_stack,
+            )
         return self._mesh_pathfinder
 
     def _negotiate_mesh_netset(self) -> dict[int, list[Route]]:

--- a/src/kicad_tools/router/mesh/navmesh.py
+++ b/src/kicad_tools/router/mesh/navmesh.py
@@ -16,11 +16,29 @@ from __future__ import annotations
 
 import heapq
 import math
+from collections.abc import Callable
 
 from .funnel import Portal
 from .geometry import EPS, Pt, centroid, merge_intervals, point_in_triangle
 
 Triangle = tuple[int, int, int]
+
+# A step of a multi-layer corridor (issue #4276): the triangle, the copper
+# layer index it is traversed on, the point at which the corridor entered that
+# ``(triangle, layer)`` node, and whether the entering edge was a via (a
+# layer-change hop) rather than an in-layer portal crossing.
+LayeredStep = tuple[int, int, Pt, bool]
+
+# Callables the 2.5D A* consults so the navmesh stays geometry-only and the
+# per-layer obstacle / manufacturability policy lives in the pathfinder:
+#   * ``PortalBlockedFn(edge, layer)`` -> True if committed copper on ``layer``
+#     crosses that portal (the per-layer analogue of P2's committed copper, so
+#     A* has a cost reason to dip to a clear layer, issue #4276 section 3).
+#   * ``ViaAllowedFn(site, layer_a, layer_b)`` -> True if a via at ``site`` is
+#     DRC-legal on BOTH layers it joins (obstacle-aware placement at *search*
+#     time -- the #3906 lesson, issue #4276 section 5).
+PortalBlockedFn = Callable[[tuple[int, int], int], bool]
+ViaAllowedFn = Callable[[Pt, int, int], bool]
 
 
 class NavMesh:
@@ -269,6 +287,135 @@ class NavMesh:
             corridor.append(tri)
         corridor.reverse()
         return corridor
+
+    # -- multi-layer A* over identically-meshed layers (issue #4276) -------
+
+    def astar_layered(
+        self,
+        start: Pt,
+        goal: Pt,
+        start_layer: int,
+        goal_layer: int,
+        num_layers: int,
+        portal_blocked: PortalBlockedFn,
+        via_allowed: ViaAllowedFn,
+        via_cost: float,
+        *,
+        present_cost_factor: float = 0.0,
+        cost_congestion: float = 0.0,
+        congestion_threshold: float = 0.0,
+    ) -> list[LayeredStep] | None:
+        """A* over the ``(triangle, layer)`` graph -- the 2.5D via-injection core.
+
+        The single static triangulation is *replicated* across ``num_layers``
+        identically-meshed copper layers (no per-layer re-triangulation -- the
+        static-mesh-once invariant holds).  A* nodes are ``(triangle, layer)``;
+        edges are:
+
+        * **in-layer** triangle adjacency, skipped when ``portal_blocked(edge,
+          layer)`` reports committed copper crosses that portal on that layer
+          (this is what gives the search a cost reason to *dip* rather than
+          plough through the blocked corridor); and
+        * **via** hops connecting ``(tri, L) <-> (tri, L+/-1)`` at the current
+          **portal-midpoint** site, cost ``via_cost``, admitted only when
+          ``via_allowed(site, L, L')`` proves the via DRC-legal on both layers.
+
+        Vias are only taken at portal midpoints (never at the start pad), so an
+        injected via is a free-space through-via by construction.  Returns the
+        corridor as a list of :data:`LayeredStep` (``(tri, layer, entry, via)``)
+        from ``start`` to ``goal``, or ``None`` if disconnected.  With a single
+        layer (``num_layers == 1``) no via edge is ever generated and the result
+        reduces to a same-layer corridor.
+        """
+        start_tris = self.locate(start)
+        goal_tris = set(self.locate(goal))
+        if not start_tris or not goal_tris:
+            return None
+
+        negotiating = present_cost_factor != 0.0 or bool(self._history)
+
+        def edge_mid(edge: tuple[int, int]) -> Pt:
+            a = self.vertices[edge[0]]
+            b = self.vertices[edge[1]]
+            return ((a[0] + b[0]) / 2.0, (a[1] + b[1]) / 2.0)
+
+        def h(point: Pt) -> float:
+            return math.hypot(goal[0] - point[0], goal[1] - point[1])
+
+        State = tuple[int, int]  # (triangle, layer)
+        g_score: dict[State, float] = {}
+        # came_from[state] = (prev_state, entry_point_at_state, via_into_state)
+        came_from: dict[State, tuple[State, Pt, bool]] = {}
+        counter = 0
+        # heap item: (f, unique, tri, layer, entry, at_portal)
+        open_heap: list[tuple[float, int, int, int, Pt, bool]] = []
+        for t in start_tris:
+            g_score[(t, start_layer)] = 0.0
+            heapq.heappush(open_heap, (h(start), counter, t, start_layer, start, False))
+            counter += 1
+
+        while open_heap:
+            f, _cnt, tri, layer, entry, at_portal = heapq.heappop(open_heap)
+            st: State = (tri, layer)
+            g = g_score.get(st, math.inf)
+            if f - h(entry) > g + 1e-6:
+                continue
+            if tri in goal_tris and layer == goal_layer:
+                return self._reconstruct_layered(came_from, st, start)
+
+            # In-layer triangle adjacency (masked per layer by committed copper).
+            for nbr, edge in self._adj[tri]:
+                if portal_blocked(edge, layer):
+                    continue
+                mid = edge_mid(edge)
+                step = math.hypot(mid[0] - entry[0], mid[1] - entry[1])
+                if negotiating:
+                    penalty = self.portal_penalty(
+                        edge, present_cost_factor, cost_congestion, congestion_threshold
+                    )
+                    step = step * (1.0 + penalty)
+                tentative = g + step
+                nst: State = (nbr, layer)
+                if tentative < g_score.get(nst, math.inf) - 1e-9:
+                    g_score[nst] = tentative
+                    came_from[nst] = (st, mid, False)
+                    heapq.heappush(open_heap, (tentative + h(mid), counter, nbr, layer, mid, True))
+                    counter += 1
+
+            # Via hops: only at a genuine portal-midpoint site (never the pad).
+            if at_portal and num_layers > 1:
+                for target in (layer - 1, layer + 1):
+                    if target < 0 or target >= num_layers:
+                        continue
+                    if not via_allowed(entry, layer, target):
+                        continue
+                    tentative = g + via_cost
+                    nst = (tri, target)
+                    if tentative < g_score.get(nst, math.inf) - 1e-9:
+                        g_score[nst] = tentative
+                        came_from[nst] = (st, entry, True)
+                        heapq.heappush(
+                            open_heap, (tentative + h(entry), counter, tri, target, entry, True)
+                        )
+                        counter += 1
+        return None
+
+    @staticmethod
+    def _reconstruct_layered(
+        came_from: dict[tuple[int, int], tuple[tuple[int, int], Pt, bool]],
+        goal_st: tuple[int, int],
+        start_pt: Pt,
+    ) -> list[LayeredStep]:
+        chain: list[LayeredStep] = []
+        st = goal_st
+        while st in came_from:
+            prev_st, entry_at_st, via_into = came_from[st]
+            chain.append((st[0], st[1], entry_at_st, via_into))
+            st = prev_st
+        # ``st`` is now a start node: its entry point is the start pad.
+        chain.append((st[0], st[1], start_pt, False))
+        chain.reverse()
+        return chain
 
     # -- corridor -> oriented portals -------------------------------------
 

--- a/src/kicad_tools/router/mesh/pathfinder.py
+++ b/src/kicad_tools/router/mesh/pathfinder.py
@@ -29,9 +29,15 @@ import math
 from dataclasses import dataclass
 from pathlib import Path
 
-from ..primitives import Pad, Route, Segment
+from ..layers import LayerStack
+from ..primitives import Pad, Route, Segment, Via
 from ..rules import DesignRules
-from .geometry import Pt, merge_intervals, segment_polygon_interval
+from .geometry import (
+    Pt,
+    merge_intervals,
+    point_in_polygon,
+    segment_polygon_interval,
+)
 from .navmesh import NavMesh
 from .obstacles import ObstacleModel, Rect
 from .octilinear import octilinear_fit
@@ -76,10 +82,19 @@ class MeshPathfinder:
         pads: list[Pad],
         rules: DesignRules | None = None,
         pours: list[list[Pt]] | None = None,
+        layer_stack: LayerStack | None = None,
     ) -> None:
         self.outline = outline
         self.pads = pads
         self.rules = rules or DesignRules()
+        # Copper stack the 2.5D via injection replicates the mesh across
+        # (issue #4276).  Consumed from the board's real routing-layer count --
+        # NOT hardcoded to 2 -- so via edges span any number of adjacent layers.
+        self.layer_stack = layer_stack or LayerStack.two_layer()
+        # Per-via-hop layer-change cost (mm-equivalent).  Kept well above a
+        # typical in-layer portal step so the search only dips when a layer is
+        # actually blocked, never gratuitously (the via-soup guard, risk 3).
+        self.via_cost = 5.0
         # Filled-copper pour outlines (issue #4269).  Modeled BOTH as poly2tri
         # mesh holes (so corridors route around them) and as obstacle-model
         # polygons (so the 45-fit declines any leg entering a pour).
@@ -101,6 +116,7 @@ class MeshPathfinder:
         pcb_path_or_text: str | Path,
         rules: DesignRules | None = None,
         pours: list[list[Pt]] | None = None,
+        layer_stack: LayerStack | None = None,
     ) -> MeshPathfinder:
         """Build a pathfinder from a ``.kicad_pcb`` file or text."""
         from ..io import _extract_edge_segments, load_pads_for_analysis
@@ -115,7 +131,7 @@ class MeshPathfinder:
         pads = load_pads_for_analysis(text)
         segments = _extract_edge_segments(text)
         outline = _outline_from_edges(segments)
-        return cls(outline, pads, rules, pours)
+        return cls(outline, pads, rules, pours, layer_stack)
 
     # -- static mesh ------------------------------------------------------
 
@@ -374,25 +390,39 @@ class MeshPathfinder:
             navmesh.reset_occupancy()
             routes: dict[object, Route] = {}
             failed: list[Connection] = []
-            # Inflated copper committed by earlier nets THIS pass -- later nets
-            # must clear it (net-vs-net short avoidance).  Reset each pass so a
+            # Inflated copper committed by earlier nets THIS pass, bucketed by
+            # routing-graph layer index (issue #4276) -- later nets must clear
+            # it (net-vs-net short avoidance).  Per-layer so an F.Cu net is not
+            # blocked by another net's B.Cu cross-under.  Reset each pass so a
             # rip-up genuinely frees the corridor.
-            committed: list[list[Pt]] = []
+            committed_by_layer: dict[int, list[list[Pt]]] = {}
             for key, start, end, net_class in ordered:
-                # Issue #4274: ``committed`` doubles as the lane-assignment
-                # model -- ``_route_with_portals`` narrows this net's portals by
-                # the copper already committed this pass so its funnel produces a
+                start_L = self._layer_index(start.layer) or 0
+                # Issue #4274: the net's own-layer committed copper doubles as
+                # the lane-assignment model -- ``_route_with_portals`` narrows
+                # this net's portals by that copper so its funnel produces a
                 # parallel lane rather than the geodesic a prior net occupies.
-                # Reset each pass so a rip-up frees the lane as well as the
-                # copper.
                 result = self._route_with_portals(
                     start,
                     end,
                     net_class,
                     negotiated_mode=True,
                     present_cost_factor=present,
-                    committed=committed,
+                    committed=committed_by_layer.get(start_L, []),
                 )
+                # Issue #4276: when the in-layer attempt declines (a transverse
+                # crossing the lane allocator cannot resolve), retry by dipping
+                # layers -- via down, cross under, via up.  Additive: the
+                # single-layer geodesic was already tried, so completion can only
+                # rise and a dip that still cannot clear declines, never crosses.
+                if result is None:
+                    result = self._route_via_injection(
+                        start,
+                        end,
+                        net_class,
+                        committed_by_layer,
+                        present_cost_factor=present,
+                    )
                 if result is None:
                     failed.append((key, start, end, net_class))
                     continue
@@ -400,7 +430,8 @@ class MeshPathfinder:
                 routes[key] = route
                 for edge in portals:
                     navmesh.commit_portal(edge)
-                committed.extend(self._route_obstacles(route))
+                for lidx, polys in self._route_obstacles_by_layer(route).items():
+                    committed_by_layer.setdefault(lidx, []).extend(polys)
 
             if len(routes) > best_count:
                 best_count = len(routes)
@@ -468,6 +499,339 @@ class MeshPathfinder:
 
         return merge_overlapping(raw)
 
+    # -- 2.5D via injection (issue #4276) ---------------------------------
+
+    @property
+    def _via_in_pad_allowed(self) -> bool:
+        """Whether the configured fab tier permits via-in-pad (else OFF).
+
+        Read from the real fab model exactly as the grid escape router does:
+        ``rules.manufacturer`` -> ``MfrLimits.via_in_pad_supported`` (base
+        ``jlcpcb`` = False, ``jlcpcb-tier1`` = True).  With no manufacturer
+        configured the conservative default is False, so pad-site vias are
+        pruned and only free-space portal-midpoint through-vias are injected.
+        """
+        mfr = self.rules.manufacturer
+        if not mfr:
+            return False
+        try:
+            from ..mfr_limits import get_mfr_limits
+
+            return bool(get_mfr_limits(mfr).via_in_pad_supported)
+        except Exception:
+            return False
+
+    def _layer_index(self, layer: object) -> int | None:
+        """Routing-graph layer index for a KiCad layer enum (None if off-stack)."""
+        try:
+            return self.layer_stack.layer_enum_to_index(layer)  # type: ignore[arg-type]
+        except Exception:
+            return None
+
+    def _keepouts_layer(self, net: int, agent_radius: float, layer_idx: int) -> list[Rect]:
+        """Per-layer inflated pad keep-outs (issue #4276 section 3).
+
+        An SMD pad blocks only its own copper layer; a through-hole pad blocks
+        EVERY layer.  Same-net copper is never an obstacle.  The triangulation
+        is shared across layers -- only this obstacle mask is per-layer.
+        """
+        from .obstacles import merge_overlapping
+
+        try:
+            layer_enum = self.layer_stack.index_to_layer_enum(layer_idx)
+        except Exception:
+            layer_enum = None
+
+        raw: list[Rect] = []
+        bx0, by0, bx1, by1 = self._bbox
+        margin = 1e-3
+        for pad in self.pads:
+            if pad.net == net:
+                continue
+            # SMD pad on another layer does not block this one; PTH blocks all.
+            if not pad.through_hole and layer_enum is not None and pad.layer != layer_enum:
+                continue
+            hx = pad.width / 2.0 + agent_radius
+            hy = pad.height / 2.0 + agent_radius
+            r = (
+                max(pad.x - hx, bx0 + margin),
+                max(pad.y - hy, by0 + margin),
+                min(pad.x + hx, bx1 - margin),
+                min(pad.y + hy, by1 - margin),
+            )
+            if r[2] - r[0] < margin or r[3] - r[1] < margin:
+                continue
+            raw.append(r)
+        return merge_overlapping(raw)
+
+    def _via_allowed_at(
+        self,
+        site: Pt,
+        net: int,
+        via_radius: float,
+        layers: tuple[int, int],
+        committed_by_layer: dict[int, list[list[Pt]]],
+    ) -> bool:
+        """Obstacle-aware via placement test (issue #4276 section 5, #3906).
+
+        A via at ``site`` joining ``layers`` is admitted only when its body is
+        DRC-legal on BOTH layers it spans:
+
+        * inside a DIFFERENT net's pad -> a short, never allowed;
+        * inside its OWN net's pad -> via-in-pad, allowed only when the fab tier
+          permits it (default OFF -> pruned, so pad-site vias never ship);
+        * over copper another net committed on either spanned layer -> declined.
+
+        Portal midpoints are free-space by construction, so the default result
+        is "allowed"; this gate exists to prune the pathological sites.
+        """
+        for pad in self.pads:
+            hx = pad.width / 2.0 + via_radius
+            hy = pad.height / 2.0 + via_radius
+            if abs(site[0] - pad.x) <= hx and abs(site[1] - pad.y) <= hy:
+                if pad.net == net:
+                    if not self._via_in_pad_allowed:
+                        return False
+                else:
+                    return False
+        # A through-via spans every copper layer, so its body must clear
+        # committed cross-net copper on ALL layers -- not just the two the A*
+        # hop nominally joins.  Check every layer with committed copper.
+        for caps in committed_by_layer.values():
+            for poly in caps:
+                if point_in_polygon(site, poly):
+                    return False
+        return True
+
+    def _route_via_injection(
+        self,
+        start: Pad,
+        end: Pad,
+        net_class: object | None,
+        committed_by_layer: dict[int, list[list[Pt]]],
+        *,
+        present_cost_factor: float,
+    ) -> tuple[Route, list[tuple[int, int]]] | None:
+        """Route by dipping layers when the in-layer geodesic is blocked (#4276).
+
+        This is the 2.5D fallback the negotiator reaches for only after the
+        single-layer attempt declines: it runs the ``(triangle, layer)`` A*
+        (mesh replicated across ``layer_stack.num_layers``), splits the returned
+        multi-layer corridor at its via sites, funnels + 45-fits EACH per-layer
+        run against that layer's own obstacle model, and stitches the runs with
+        through-vias.  If ANY run cannot be made clearance-clean the whole route
+        declines (``None``) -- never a short (the authoritative octilinear gate
+        stays in force per layer).
+        """
+        navmesh = self.build()
+        num_layers = self.layer_stack.num_layers
+        if not navmesh.triangles or num_layers < 2:
+            return None
+
+        start_layer = self._layer_index(start.layer)
+        goal_layer = self._layer_index(end.layer)
+        if start_layer is None or goal_layer is None:
+            return None
+
+        trace_w = getattr(net_class, "trace_width", None) or self.rules.trace_width
+        clearance = self.rules.trace_clearance
+        agent_radius = trace_w / 2.0 + clearance
+        via_radius = self.rules.via_diameter / 2.0 + clearance
+        net = start.net
+        start_pt: Pt = (start.x, start.y)
+        end_pt: Pt = (end.x, end.y)
+
+        # Per-layer obstacle model for the authoritative octilinear fit.
+        obstacles_by_layer: dict[int, ObstacleModel] = {}
+        for lidx in range(num_layers):
+            keepouts = self._keepouts_layer(net, agent_radius, lidx)
+            pour_obstacles = self.pours + committed_by_layer.get(lidx, [])
+            obstacles_by_layer[lidx] = ObstacleModel(self.outline, keepouts, pour_obstacles)
+
+        # Per-layer portal blocking (issue #4276 section 3): a portal is blocked
+        # on a layer when a trace cannot thread it there -- tested with the SAME
+        # per-layer obstacle model the octilinear fit uses, on the segment
+        # joining the two incident triangle centroids.  This gives A* a cost
+        # reason to DIP where a layer is obstructed (by committed copper OR an
+        # other-net pad on that layer) to a clear layer, rather than ploughing on
+        # and declining at the fit.  Same-net pads are not obstacles, so a net's
+        # own pad-escape portals stay open.  The authoritative per-layer fit
+        # still gates every emitted leg, so this heuristic can only steer, never
+        # ship a short.
+        centroids = navmesh._centroids
+
+        def portal_blocked(edge: tuple[int, int], layer: int) -> bool:
+            tris = navmesh._edge_tris.get(edge)
+            if not tris or len(tris) < 2:
+                return False
+            return not obstacles_by_layer[layer].is_clear(centroids[tris[0]], centroids[tris[1]])
+
+        def via_allowed(site: Pt, layer_a: int, layer_b: int) -> bool:
+            return self._via_allowed_at(
+                site, net, via_radius, (layer_a, layer_b), committed_by_layer
+            )
+
+        pcf = present_cost_factor
+        corridor = navmesh.astar_layered(
+            start_pt,
+            end_pt,
+            start_layer,
+            goal_layer,
+            num_layers,
+            portal_blocked,
+            via_allowed,
+            self.via_cost,
+            present_cost_factor=pcf,
+            cost_congestion=self.rules.cost_congestion if pcf else 0.0,
+            congestion_threshold=self.rules.congestion_threshold,
+        )
+        if corridor is None:
+            return None
+
+        route = self._build_multilayer_route(
+            navmesh, corridor, start, end, net, trace_w, obstacles_by_layer, committed_by_layer
+        )
+        if route is None:
+            return None
+
+        portals = [
+            edge
+            for i in range(len(corridor) - 1)
+            if not corridor[i + 1][3]
+            and (edge := navmesh._shared_edge(corridor[i][0], corridor[i + 1][0])) is not None
+        ]
+        return route, portals
+
+    def _fit_layer_run(
+        self,
+        navmesh: NavMesh,
+        tris: list[int],
+        s_pt: Pt,
+        e_pt: Pt,
+        obstacles: ObstacleModel,
+        committed_on_layer: list[list[Pt]],
+    ) -> list[Pt] | None:
+        """Funnel + 45-fit one per-layer run, with the P2.5 lane-narrowing retry.
+
+        Mirrors the single-layer re-funnel (``_route_with_portals``): try the
+        taut geodesic first, and if it collides copper committed on THIS layer,
+        narrow the run's portals to their residual openings and retry the widest
+        gap then each one-wall packing.  Every candidate is validated against the
+        authoritative per-layer obstacle model, so a run that still cannot clear
+        declines (``None``) rather than shipping a short.
+        """
+        fitted = self._fit_corridor(navmesh, tris, s_pt, e_pt, obstacles, None)
+        if fitted is not None:
+            return fitted
+        if not committed_on_layer:
+            return None
+        derived: dict[tuple[int, int], list[tuple[float, float]]] = {}
+        for edge in navmesh.corridor_portals(tris):
+            bands = _edge_consumed_bands(navmesh, edge, committed_on_layer)
+            if bands:
+                derived[edge] = bands
+        if not derived:
+            return None
+        for pack in ("largest", "left", "right"):
+            fitted = self._fit_corridor(navmesh, tris, s_pt, e_pt, obstacles, derived, pack)
+            if fitted is not None:
+                return fitted
+        return None
+
+    def _build_multilayer_route(
+        self,
+        navmesh: NavMesh,
+        corridor: list[tuple[int, int, Pt, bool]],
+        start: Pad,
+        end: Pad,
+        net: int,
+        trace_w: float,
+        obstacles_by_layer: dict[int, ObstacleModel],
+        committed_by_layer: dict[int, list[list[Pt]]],
+    ) -> Route | None:
+        """Split a layered corridor into per-layer runs; funnel/fit/stitch (#4276)."""
+        start_pt: Pt = (start.x, start.y)
+        end_pt: Pt = (end.x, end.y)
+
+        # Break the corridor into maximal same-layer runs, recording the
+        # portal-midpoint via site at each layer change.
+        runs: list[tuple[int, list[int], Pt, Pt]] = []
+        via_sites: list[Pt] = []
+        cur_layer = corridor[0][1]
+        cur_tris = [corridor[0][0]]
+        run_start = start_pt
+        for k in range(1, len(corridor)):
+            tri, layer, entry, via_into = corridor[k]
+            if via_into:
+                runs.append((cur_layer, cur_tris, run_start, entry))
+                via_sites.append(entry)
+                cur_layer = layer
+                cur_tris = [tri]
+                run_start = entry
+            else:
+                cur_tris.append(tri)
+        runs.append((cur_layer, cur_tris, run_start, end_pt))
+
+        route = Route(net=net, net_name=start.net_name)
+        for layer_idx, tris, s_pt, e_pt in runs:
+            if math.hypot(e_pt[0] - s_pt[0], e_pt[1] - s_pt[1]) < 1e-6:
+                continue  # degenerate run (through-via passing this layer)
+            try:
+                layer_enum = self.layer_stack.index_to_layer_enum(layer_idx)
+            except Exception:
+                return None
+            fitted = self._fit_layer_run(
+                navmesh,
+                tris,
+                s_pt,
+                e_pt,
+                obstacles_by_layer[layer_idx],
+                committed_by_layer.get(layer_idx, []),
+            )
+            if fitted is None or len(fitted) < 2:
+                return None
+            for i in range(len(fitted) - 1):
+                a, b = fitted[i], fitted[i + 1]
+                route.segments.append(
+                    Segment(
+                        x1=a[0],
+                        y1=a[1],
+                        x2=b[0],
+                        y2=b[1],
+                        width=trace_w,
+                        layer=layer_enum,
+                        net=net,
+                        net_name=start.net_name,
+                    )
+                )
+
+        if not route.segments or not via_sites:
+            return None
+
+        # Through-via per distinct site (default manufacturable via).  Blind /
+        # buried are tier-gated and out of scope -- a placed via spans the whole
+        # copper stack, so one Via joins the top and bottom outer layers.
+        top = self.layer_stack.index_to_layer_enum(0)
+        bottom = self.layer_stack.index_to_layer_enum(self.layer_stack.num_layers - 1)
+        seen: set[tuple[float, float]] = set()
+        for site in via_sites:
+            key = (round(site[0], 4), round(site[1], 4))
+            if key in seen:
+                continue
+            seen.add(key)
+            route.vias.append(
+                Via(
+                    x=site[0],
+                    y=site[1],
+                    drill=self.rules.via_drill,
+                    diameter=self.rules.via_diameter,
+                    layers=(top, bottom),
+                    net=net,
+                    net_name=start.net_name,
+                )
+            )
+        return route
+
     def _route_obstacles(self, route: Route) -> list[list[Pt]]:
         """Inflated capsule polygons for each segment of a committed route.
 
@@ -482,6 +846,24 @@ class MeshPathfinder:
             if poly is not None:
                 polys.append(poly)
         return polys
+
+    def _route_obstacles_by_layer(self, route: Route) -> dict[int, list[list[Pt]]]:
+        """Committed-copper capsules bucketed by routing-graph layer index (#4276).
+
+        A via-injected route lays copper on several layers; committed copper
+        must be tracked per layer so later nets see it only where it actually
+        sits (an F.Cu net is not blocked by another net's B.Cu cross-under).
+        """
+        half = self.rules.trace_width + self.rules.trace_clearance
+        out: dict[int, list[list[Pt]]] = {}
+        for seg in route.segments:
+            lidx = self._layer_index(seg.layer)
+            if lidx is None:
+                continue
+            poly = _segment_capsule((seg.x1, seg.y1), (seg.x2, seg.y2), half)
+            if poly is not None:
+                out.setdefault(lidx, []).append(poly)
+        return out
 
     def _build_route(self, start: Pad, net: int, trace_w: float, fitted: list[Pt]) -> Route:
         route = Route(net=net, net_name=start.net_name)

--- a/tests/router/mesh/test_lane_assignment.py
+++ b/tests/router/mesh/test_lane_assignment.py
@@ -56,16 +56,24 @@ def _pad(x: float, y: float, net: int, ref: str, w: float = 0.6, h: float = 0.6)
 
 
 def _cross_net_intersections(routes: dict[object, object]) -> int:
-    """Count intersecting segments belonging to DIFFERENT nets (net-vs-net shorts)."""
-    segs: list[tuple[object, tuple[float, float], tuple[float, float]]] = []
+    """Count intersecting DIFFERENT-net segments **on the same layer** (shorts).
+
+    Layer-aware (issue #4276): with 2.5D via injection two nets may cross in the
+    XY projection when they sit on different copper layers -- that is the whole
+    point of dipping, not a short.  Only a same-layer crossing is a net-vs-net
+    short, so the count keys on ``(net, layer)`` and compares within a layer.
+    """
+    segs: list[tuple[object, object, tuple[float, float], tuple[float, float]]] = []
     for key, route in routes.items():
         for s in route.segments:  # type: ignore[attr-defined]
-            segs.append((key, (s.x1, s.y1), (s.x2, s.y2)))
+            segs.append((key, s.layer, (s.x1, s.y1), (s.x2, s.y2)))
     count = 0
     for i in range(len(segs)):
         for j in range(i + 1, len(segs)):
-            if segs[i][0] != segs[j][0] and segments_intersect(
-                segs[i][1], segs[i][2], segs[j][1], segs[j][2]
+            if (
+                segs[i][0] != segs[j][0]
+                and segs[i][1] == segs[j][1]
+                and segments_intersect(segs[i][2], segs[i][3], segs[j][2], segs[j][3])
             ):
                 count += 1
     return count

--- a/tests/router/mesh/test_via_injection.py
+++ b/tests/router/mesh/test_via_injection.py
@@ -1,0 +1,292 @@
+"""2.5D via-injection acceptance for mesh-router P2.6 (issue #4276).
+
+Portal-midpoint via sites over identically-meshed layers resolve transverse
+crossings the in-layer lane allocator (P2.5) cannot: a net whose F.Cu geodesic
+genuinely crosses committed copper dips a layer -- via down, cross under, via
+up -- instead of declining.  These tests cover the load-bearing guarantees:
+
+* board 02 completion rises **past P2.5's 7/24**, DRC-clean, zero same-layer
+  shorts, triangulation still built once per board;
+* the graph generalises to **N layers** (a 2-layer board AND a >=3-layer
+  synthetic case where A* composes a multi-layer span from adjacent via hops);
+* **never ship a short** -- a via whose stub cannot clear declines (``None``);
+* **via-in-pad is OFF by default**, tier-gated by ``MfrLimits`` -- injected vias
+  are free-space portal midpoints, never dropped onto pads.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.drc.geometric import run_geometric_drc
+from kicad_tools.router.io import load_pads_for_analysis, merge_routes_into_pcb
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.mesh.pathfinder import MeshPathfinder
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import DesignRules
+
+pytest.importorskip("kicad_tools.router.router_cpp")
+
+_REPO = Path(__file__).resolve().parents[3]
+_CHARLIEPLEX = _REPO / "boards/02-charlieplex-led/output/charlieplex_3x3.kicad_pcb"
+
+# P2.5's committed completion on the charlieplex 3x3 fixture (issue #4276).
+_P25_BASELINE = 7
+
+
+def _pad(x, y, net, ref, layer=Layer.F_CU, through_hole=False, w=1.0, h=1.0):
+    return Pad(
+        x=x,
+        y=y,
+        width=w,
+        height=h,
+        net=net,
+        net_name=f"N{net}",
+        layer=layer,
+        ref=ref,
+        pin="1",
+        through_hole=through_hole,
+    )
+
+
+def _pads_by_net(pads):
+    bynet: dict[int, list] = {}
+    for p in pads:
+        if p.net > 0:
+            bynet.setdefault(p.net, []).append(p)
+    return bynet
+
+
+def _connections(pads):
+    conns = []
+    for net, ps in _pads_by_net(pads).items():
+        anchor = ps[0]
+        for seq, other in enumerate(ps[1:]):
+            if anchor.layer == other.layer:
+                conns.append(((net, seq), anchor, other, None))
+    return conns
+
+
+def _same_layer_shorts(routes) -> int:
+    """Different-net segments intersecting ON THE SAME layer (real shorts)."""
+    from kicad_tools.router.mesh.geometry import segments_intersect
+
+    segs = []
+    for key, route in routes.items():
+        for s in route.segments:
+            segs.append((key, s.layer, (s.x1, s.y1), (s.x2, s.y2)))
+    count = 0
+    for i in range(len(segs)):
+        for j in range(i + 1, len(segs)):
+            if (
+                segs[i][0] != segs[j][0]
+                and segs[i][1] == segs[j][1]
+                and segments_intersect(segs[i][2], segs[i][3], segs[j][2], segs[j][3])
+            ):
+                count += 1
+    return count
+
+
+# ---------------------------------------------------------------------------
+# Board 02: completion rises past P2.5's 7/24, DRC-clean, once-per-board.
+# ---------------------------------------------------------------------------
+
+
+def test_via_injection_lifts_board02_past_p25(tmp_path) -> None:
+    text = _CHARLIEPLEX.read_text()
+    pads = load_pads_for_analysis(text)
+    conns = _connections(pads)
+
+    pf = MeshPathfinder.from_board(text)
+    routes, stats = pf.route_netset(conns, max_iterations=8)
+
+    # Completion strictly past the P2.5 ceiling, by dipping layers.
+    assert stats.routed > _P25_BASELINE, (
+        f"2.5D did not lift completion past P2.5: {stats.routed} <= {_P25_BASELINE}"
+    )
+    # At least one net routed by an actual layer dip (a via was emitted).
+    assert any(r.vias for r in routes.values()), "expected >=1 net resolved by a via dip"
+    # The static-mesh-once invariant survives via injection.
+    assert stats.triangulation_calls == 1
+    # No same-layer net-vs-net short (cross-layer XY overlaps are legal dips).
+    assert _same_layer_shorts(routes) == 0
+
+
+def test_via_injection_board02_is_drc_clean(tmp_path) -> None:
+    """The injected multi-layer copper (segments + vias) passes kicad-cli DRC."""
+    text = _CHARLIEPLEX.read_text()
+    pads = load_pads_for_analysis(text)
+    conns = _connections(pads)
+
+    base_pcb = tmp_path / "base.kicad_pcb"
+    base_pcb.write_text(text)
+    base = run_geometric_drc(base_pcb)
+    if not base.ran:
+        pytest.skip(f"kicad-cli DRC unavailable: {base.reason}")
+
+    pf = MeshPathfinder.from_board(text)
+    routes, stats = pf.route_netset(conns, max_iterations=8)
+    assert any(r.vias for r in routes.values())
+    sexp = "".join(r.to_sexp() for r in routes.values() if r.segments)
+
+    out = tmp_path / "routed.kicad_pcb"
+    out.write_text(merge_routes_into_pcb(text, sexp))
+    res = run_geometric_drc(out)
+    assert res.ran
+    # No NEW error-severity findings vs the unrouted baseline (via / hole /
+    # annular rules exercised on real multi-layer copper).
+    assert res.error_count <= base.error_count, (
+        f"via injection introduced DRC errors: base={base.error_count} "
+        f"routed={res.error_count} types={dict(res.by_type)}"
+    )
+
+
+def test_injected_vias_are_free_space_not_in_pad() -> None:
+    """Every injected via sits at a free-space portal midpoint, never on a pad.
+
+    Via-in-pad is OFF by default, so an injected via must clear every pad.  This
+    is the geometric proof of the default-off policy on the real board.
+    """
+    text = _CHARLIEPLEX.read_text()
+    pads = load_pads_for_analysis(text)
+    conns = _connections(pads)
+    pf = MeshPathfinder.from_board(text)
+    routes, _stats = pf.route_netset(conns, max_iterations=8)
+
+    vias = [v for r in routes.values() for v in r.vias]
+    assert vias, "expected at least one injected via to test"
+    for v in vias:
+        for pad in pads:
+            hx = pad.width / 2.0
+            hy = pad.height / 2.0
+            in_pad = abs(v.x - pad.x) <= hx and abs(v.y - pad.y) <= hy
+            assert not in_pad, f"via at ({v.x:.2f},{v.y:.2f}) landed on pad {pad.ref}"
+
+
+# ---------------------------------------------------------------------------
+# N-layer generality: 2-layer AND a >=3-layer synthetic case.
+# ---------------------------------------------------------------------------
+
+
+def test_via_edges_compose_multilayer_span_on_4layer_board() -> None:
+    """A 4-layer board: A* composes a multi-layer span from adjacent via hops.
+
+    Start pad on F.Cu (index 0), end pad on B.Cu (index 3): reaching the goal
+    layer requires the ``(triangle, layer)`` A* to compose adjacent-layer via
+    hops (0->1->2->3), emitted as a single through-via.  Proves the mesh is
+    replicated across the board's actual layer count, not hardcoded to 2.
+    """
+    stack = LayerStack.four_layer_all_signal()
+    outline = [(0.0, 0.0), (40.0, 0.0), (40.0, 30.0), (0.0, 30.0)]
+    start = _pad(5.0, 15.0, 1, "A1", layer=Layer.F_CU)
+    end = _pad(35.0, 15.0, 1, "A2", layer=Layer.B_CU)
+    pf = MeshPathfinder(outline, [start, end], DesignRules(), layer_stack=stack)
+
+    res = pf._route_via_injection(start, end, None, {}, present_cost_factor=0.0)
+    assert res is not None, "cross-layer net should route by composing via hops"
+    route, _portals = res
+    # A layer change was composed -> at least one through-via emitted.
+    assert route.vias, "expected a via to compose the F.Cu -> B.Cu span"
+    for v in route.vias:
+        assert v.layers == (Layer.F_CU, Layer.B_CU), "default via is a through-via"
+        assert v.in_pad is False, "free-space via is never a via-in-pad"
+    # Copper landed on both the entry and exit layers.
+    layers = {s.layer for s in route.segments}
+    assert Layer.F_CU in layers and Layer.B_CU in layers
+    # Static mesh: one triangulation across the whole N-layer graph.
+    assert pf.triangulation_calls == 1
+
+
+def test_two_layer_board_default_stack() -> None:
+    """The 2-layer path (board 02's stack) still composes a dip end-to-end."""
+    text = _CHARLIEPLEX.read_text()
+    pf = MeshPathfinder.from_board(text)
+    assert pf.layer_stack.num_layers == 2
+    conns = _connections(load_pads_for_analysis(text))
+    routes, _stats = pf.route_netset(conns, max_iterations=8)
+    dipped = [r for r in routes.values() if r.vias]
+    assert dipped, "expected a 2-layer dip"
+    for r in dipped:
+        layers = {s.layer for s in r.segments}
+        assert layers == {Layer.F_CU, Layer.B_CU}
+
+
+# ---------------------------------------------------------------------------
+# Never ship a short: a via/stub that cannot clear declines (#3906).
+# ---------------------------------------------------------------------------
+
+
+def test_via_that_cannot_clear_declines_never_shorts() -> None:
+    """A through-hole wall blocks BOTH layers: injection declines, never crosses.
+
+    Net 1 must cross the board centre; a large other-net through-hole pad there
+    is a keep-out on EVERY layer, so no dip can land clear.  The obstacle-aware
+    placement + authoritative per-layer fit must decline (``None``) rather than
+    ship copper over the blocker (the #3906 invariant, on the 2.5D path).
+    """
+    outline = [(0.0, 0.0), (40.0, 0.0), (40.0, 20.0), (0.0, 20.0)]
+    start = _pad(2.0, 10.0, 1, "A1")
+    end = _pad(38.0, 10.0, 1, "A2")
+    # A tall PTH pad wall spanning the full height at mid-board -> no route on
+    # any layer (through_hole=True blocks F.Cu AND B.Cu).
+    wall = _pad(20.0, 10.0, 2, "W1", through_hole=True, w=2.0, h=20.0)
+    pf = MeshPathfinder(outline, [start, end, wall], DesignRules())
+
+    res = pf._route_via_injection(start, end, None, {}, present_cost_factor=0.0)
+    assert res is None, "a dip that cannot clear the blocker must decline, not short"
+
+
+def test_negotiated_netset_never_ships_same_layer_short() -> None:
+    """Whole negotiated set (with injection) has zero same-layer cross-net shorts."""
+    text = _CHARLIEPLEX.read_text()
+    pads = load_pads_for_analysis(text)
+    conns = _connections(pads)
+    pf = MeshPathfinder.from_board(text)
+    routes, _stats = pf.route_netset(conns, max_iterations=8)
+    assert _same_layer_shorts(routes) == 0
+
+
+# ---------------------------------------------------------------------------
+# Via-in-pad OFF by default, tier-gated by MfrLimits.
+# ---------------------------------------------------------------------------
+
+
+def test_via_in_pad_off_by_default_and_tier_gated() -> None:
+    outline = [(0.0, 0.0), (40.0, 0.0), (40.0, 20.0), (0.0, 20.0)]
+    own = _pad(10.0, 10.0, 1, "A1")
+    other = _pad(30.0, 10.0, 2, "B1")
+    via_r = DesignRules().via_diameter / 2.0 + DesignRules().trace_clearance
+
+    # Default / base jlcpcb: via-in-pad NOT supported -> a via on the net's own
+    # pad is pruned (declined).
+    for mfr in (None, "jlcpcb"):
+        pf = MeshPathfinder(outline, [own, other], DesignRules(manufacturer=mfr))
+        assert pf._via_in_pad_allowed is False
+        assert pf._via_allowed_at((own.x, own.y), own.net, via_r, (0, 1), {}) is False
+        # An other-net pad is a short on ANY tier -> never allowed.
+        assert pf._via_allowed_at((other.x, other.y), own.net, via_r, (0, 1), {}) is False
+        # Free space is fine.
+        assert pf._via_allowed_at((20.0, 5.0), own.net, via_r, (0, 1), {}) is True
+
+    # jlcpcb-tier1: via-in-pad supported -> a via on the OWN pad is permitted,
+    # but an other-net pad is still a short.
+    pf_t1 = MeshPathfinder(outline, [own, other], DesignRules(manufacturer="jlcpcb-tier1"))
+    assert pf_t1._via_in_pad_allowed is True
+    assert pf_t1._via_allowed_at((own.x, own.y), own.net, via_r, (0, 1), {}) is True
+    assert pf_t1._via_allowed_at((other.x, other.y), own.net, via_r, (0, 1), {}) is False
+
+
+def test_single_net_route_is_inert_no_vias() -> None:
+    """The single-net ``route()`` contract is unchanged: no committed copper to
+    dip around means no via machinery fires (P1/P2 behaviour preserved)."""
+    text = _CHARLIEPLEX.read_text()
+    pads = load_pads_for_analysis(text)
+    pf = MeshPathfinder.from_board(text)
+    for _net, ps in _pads_by_net(pads).items():
+        if len(ps) == 2 and ps[0].layer == ps[1].layer:
+            r = pf.route(ps[0], ps[1])
+            if r is not None and r.segments:
+                assert not r.vias, "single-net route must not inject vias"
+                break


### PR DESCRIPTION
Closes #4276

Phase **P2.6 — 2.5D via injection** for the mesh router. Resolves transverse crossings that P2.5's in-layer lane allocator cannot: a net whose F.Cu geodesic genuinely crosses committed copper now **dips a layer** (via down → cross under → via up) instead of declining.

## What changed
- **`navmesh.py`** — `astar_layered()`: A* over the `(triangle, layer)` graph. ONE static triangulation is *replicated* across `LayerStack.num_layers` (the board's **real** layer count, not hardcoded 2). Edges are in-layer triangle adjacency (masked per-layer) + **via edges** joining adjacent layers at **portal-midpoint** sites, cost `via_cost`. Vias are only taken at genuine portal midpoints (never the start pad → free-space through-vias by construction).
- **`pathfinder.py`** — `_route_via_injection()` + `_build_multilayer_route()` + `_fit_layer_run()`: split the layered corridor at its via sites, funnel + 45-fit **each per-layer run** against that layer's own obstacle model (with the P2.5 lane-narrowing retry), stitch with through-vias. Per-layer keep-outs (`_keepouts_layer`: SMD blocks its layer, PTH blocks all), obstacle-aware via placement (`_via_allowed_at`), and tier-gated via-in-pad (`_via_in_pad_allowed`).
- Wired as an **additive fallback** in `route_netset` — fires only when the single-layer attempt declines, with committed copper now tracked **per layer**.
- **`core.py`** — hand the mesh the board's real `layer_stack`.
- **`test_lane_assignment.py`** — the cross-net short metric is now **layer-aware** (cross-layer XY overlaps are legal dips; only same-layer crossings are shorts).
- New **`test_via_injection.py`** (9 tests).

## Honest results vs acceptance criteria
- **Board 02 completion: 7/24 → 9/24**, DRC-clean under `kicad-cli pcb drc --refill-zones` (0 errors), **0 same-layer shorts**. The +2 nets route by genuine layer dips (free-space portal-midpoint vias). The remaining 15 failures are **F.Cu pad-escape** declines — the inherent single-layer limitation, not a transverse-crossing 2.5D is scoped to fix.
- **Vias are portal-midpoint free-space** (via-in-pad OFF); a test asserts no injected via lands on any pad, and the tier gate is unit-tested (base jlcpcb prunes own-pad sites, jlcpcb-tier1 permits them, other-net pad sites are always pruned).
- **N-layer general**: works on the 2-layer board (board 02) AND a synthetic **4-layer** case where A* composes an adjacent-hop multi-layer span (F.Cu→B.Cu) emitted as one through-via.
- **Triangulation once per board** — `triangulation_calls == 1` asserted through the injection path.
- **Never ship a short** — a via whose stub can't clear declines (`None`); #3906-modeled test with a PTH wall blocking both layers.
- **`--route-engine grid` byte-identical** — all new machinery lives in `mesh/`; the grid path and the single-net `route()` contract are untouched (a test asserts `route()` injects no vias).

## Testing
- `tests/router/mesh/` — **50 passed** under `-W error::UserWarning`.
- `ruff check` / `ruff format --check` — clean on changed files.
- `check_mypy_baseline.py` — changed mesh files are mypy-clean (the 10 "new" errors the local run reports are all missing-optional-dep artifacts — matplotlib/mcp/cmaes/weasyprint — in files this PR does not touch).
- `test_manufacturer_propagation_lint.py` — 9 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)