### PR TITLE
feat(router): adaptive octilinear lattice engine (--route-engine lattice) — mesh-router P2.7

### DIFF
--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -3516,16 +3516,19 @@ def _add_route_parser(subparsers) -> None:
     )
     route_parser.add_argument(
         "--route-engine",
-        choices=["grid", "mesh"],
+        choices=["grid", "mesh", "lattice"],
         default="grid",
         help=(
-            "Routing substrate (issue #4268), orthogonal to --backend and "
-            "--strategy: 'grid' = uniform-grid A* (default, unchanged); "
-            "'mesh' = navmesh single-net router (poly2tri CDT + funnel + "
-            "clearance-aware 45deg fit). Mesh is P1/experimental: single-net "
-            "only, no multi-net negotiation, capacity, vias or matched routing. "
-            "(The name 'strategy' was already taken by the negotiation-algorithm "
-            "flag above, so the substrate selector is --route-engine.)"
+            "Routing substrate (issues #4268/#4278), orthogonal to --backend "
+            "and --strategy: 'grid' = uniform-grid A* (default, unchanged); "
+            "'mesh' = navmesh router (poly2tri CDT + funnel + clearance-aware "
+            "45deg fit, multi-net portal negotiation); 'lattice' = adaptive "
+            "octilinear lattice (balanced quadtree, paths are 45deg-legal by "
+            "construction, negotiated multi-net, through-vias at free-space "
+            "lattice nodes). Mesh and lattice are experimental engines; grid "
+            "remains the production default. (The name 'strategy' was already "
+            "taken by the negotiation-algorithm flag above, so the substrate "
+            "selector is --route-engine.)"
         ),
     )
     route_parser.add_argument(

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -8735,14 +8735,17 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "--route-engine",
-        choices=["grid", "mesh"],
+        choices=["grid", "mesh", "lattice"],
         default="grid",
         help=(
-            "Routing substrate (issue #4268), orthogonal to --backend and "
-            "--strategy: 'grid' = uniform-grid A* (default, unchanged); "
-            "'mesh' = navmesh single-net router (poly2tri CDT + funnel + "
-            "clearance-aware 45deg fit). Mesh is P1/experimental: single-net "
-            "only, no multi-net negotiation, capacity, vias or matched routing."
+            "Routing substrate (issues #4268/#4278), orthogonal to --backend "
+            "and --strategy: 'grid' = uniform-grid A* (default, unchanged); "
+            "'mesh' = navmesh router (poly2tri CDT + funnel + clearance-aware "
+            "45deg fit, multi-net portal negotiation); 'lattice' = adaptive "
+            "octilinear lattice (balanced quadtree, paths are 45deg-legal by "
+            "construction, negotiated multi-net, through-vias at free-space "
+            "lattice nodes). Mesh and lattice are experimental engines; grid "
+            "remains the production default."
         ),
     )
     parser.add_argument(

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -922,6 +922,10 @@ class Autorouter:
                 cannot monopolise the budget, and a capped net's Python fallback
                 is skipped.  Plumbed via the ``--per-net-iterations`` CLI flag
                 (defaulted by ``--deterministic-budget``).
+            strategy: Routing substrate selector (``--route-engine``):
+                ``"grid"`` (default, uniform-grid A*), ``"mesh"`` (navmesh,
+                #4268/#4269), or ``"lattice"`` (adaptive octilinear lattice,
+                #4278).
         """
         self.rules = rules or DesignRules()
         # Issue #3524: copy the default map instead of aliasing it.  The
@@ -1069,6 +1073,15 @@ class Autorouter:
         self._mesh_net_routes: dict[int, list[Route]] | None = None
         self._mesh_served: set[int] = set()
         self._mesh_negotiation_stats: Any = None
+        # Issue #4278 (mesh-router P2.7): the adaptive octilinear lattice
+        # engine (``--route-engine lattice``), the third substrate beside
+        # ``grid`` and ``mesh``.  Same caching discipline as the mesh: the
+        # whole net set is negotiated once on the first lattice route and
+        # the per-net results are served net-by-net from this cache.
+        self._lattice_pathfinder: Any = None
+        self._lattice_net_routes: dict[int, list[Route]] | None = None
+        self._lattice_served: set[int] = set()
+        self._lattice_negotiation_stats: Any = None
 
         # Initialize grid and routers using shared helper
         # Issue #972: Helper includes adaptive grid resolution for large boards
@@ -2382,6 +2395,91 @@ class Autorouter:
                 by_net.setdefault(net_id, []).append(route)
         return by_net
 
+    def _route_net_lattice(self, net: int) -> list[Route]:
+        """Route a net with the lattice engine (issue #4278, mesh-router P2.7).
+
+        Mirrors :meth:`_route_net_mesh`: builds (once, lazily) a
+        :class:`~kicad_tools.router.lattice.LatticePathfinder`, negotiates the
+        WHOLE net set through the shared static lattice a single time, caches
+        the per-net results, and serves + commits each net's routes exactly
+        once.  The emission / DRC tail is identical to the grid path.
+        """
+        if self._lattice_net_routes is None:
+            self._lattice_net_routes = self._negotiate_lattice_netset()
+
+        routes = self._lattice_net_routes.get(net, [])
+        if net not in self._lattice_served:
+            self._lattice_served.add(net)
+            for route in routes:
+                if route.segments:
+                    self.routes.append(route)
+        return [r for r in routes if r.segments]
+
+    def _ensure_lattice_pathfinder(self) -> Any:
+        """Lazily construct the per-board :class:`LatticePathfinder` (built once).
+
+        Outer boundary resolution is identical to
+        :meth:`_ensure_mesh_pathfinder`: the Edge.Cuts bbox when the board has
+        an outline, else the grid origin/dimensions fallback.
+        """
+        from .lattice.pathfinder import LatticePathfinder
+
+        if self._lattice_pathfinder is None:
+            if self._board_bbox is not None:
+                bx0, by0, bx1, by1 = self._board_bbox
+            else:
+                bx0 = self.grid.origin_x
+                by0 = self.grid.origin_y
+                bx1 = self.grid.origin_x + self.grid.width
+                by1 = self.grid.origin_y + self.grid.height
+            outline = [(bx0, by0), (bx1, by0), (bx1, by1), (bx0, by1)]
+            # The lattice is replicated across the board's REAL copper stack
+            # (issue #4278 acceptance 6) -- never hardcoded to 2 layers.
+            self._lattice_pathfinder = LatticePathfinder(
+                outline,
+                list(self.pads.values()),
+                self.rules,
+                layer_stack=self.layer_stack,
+            )
+        return self._lattice_pathfinder
+
+    def _negotiate_lattice_netset(self) -> dict[int, list[Route]]:
+        """Negotiate every routable net through the shared lattice (#4278).
+
+        Gathers a star-wise 2-pad connection per net (the same topology the
+        mesh negotiation uses) and runs the capacity-1 lattice negotiation
+        once; the lattice is built a single time for the whole board inside
+        :meth:`LatticePathfinder.route_netset` (``lattice_builds == 1``).
+        Unlike the mesh path, cross-layer connections are NOT skipped -- the
+        lattice's (node, layer) graph handles layer transitions natively.
+        """
+        pf = self._ensure_lattice_pathfinder()
+
+        connections: list[tuple[object, Pad, Pad, object]] = []
+        for net, pad_keys in self.nets.items():
+            if net == 0:
+                continue
+            pads = [self.pads[k] for k in pad_keys if k in self.pads]
+            if len(pads) < 2:
+                continue
+            anchor = pads[0]
+            for seq, other in enumerate(pads[1:]):
+                connections.append(((net, seq), anchor, other, None))
+
+        if not connections:
+            return {}
+
+        routes_by_key, stats = pf.route_netset(connections)
+        self._lattice_negotiation_stats = stats
+
+        by_net: dict[int, list[Route]] = {}
+        for key, route in routes_by_key.items():
+            assert isinstance(key, tuple)
+            net_id = int(key[0])
+            if route.segments:
+                by_net.setdefault(net_id, []).append(route)
+        return by_net
+
     def route_net(
         self,
         net: int,
@@ -2416,6 +2514,10 @@ class Autorouter:
         # Default ``"grid"`` skips this branch entirely (byte-identical).
         if getattr(self, "_strategy", "grid") == "mesh":
             return self._route_net_mesh(net)
+        # Issue #4278 (mesh-router P2.7): the adaptive octilinear lattice
+        # engine.  Same dispatch seam; ``grid`` and ``mesh`` are untouched.
+        if getattr(self, "_strategy", "grid") == "lattice":
+            return self._route_net_lattice(net)
 
         # Issue #4170 (Phase 2b-1): bare boundary stub terminals are an additive
         # source of per-net targets.  A net may have only ONE in-region pad plus

--- a/src/kicad_tools/router/lattice/__init__.py
+++ b/src/kicad_tools/router/lattice/__init__.py
@@ -1,0 +1,37 @@
+"""Adaptive octilinear lattice route engine (issue #4278, epic #4267 P2.7).
+
+Third routing substrate behind ``--route-engine {grid,mesh,lattice}``: a
+balanced-quadtree octilinear lattice replicated per copper layer, where an
+A* path IS 45-degree-legal copper by construction -- no funnel, no
+octilinear post-fit.  Staged replacement candidate for the navmesh+funnel
+line (``router/mesh/``), which remains untouched and fully working; any
+supersession is a later owner decision gated on the P4 large-board proof.
+
+Package layout:
+
+* :mod:`.quadtree` -- balanced quadtree lattice generator (<=1-level jumps,
+  octilinear edges by construction), built ONCE per board.
+* :mod:`.obstacles` -- static per-layer pad masks + the geometric
+  committed-copper model (the #3906 never-blind-fit discipline).
+* :mod:`.pathfinder` -- pad dogleg stubs, negotiated (node, layer) A*,
+  emission to ordinary :class:`~kicad_tools.router.primitives.Route`.
+
+Via gating documentation (issue #4278 acceptance 7): vias land only on
+free-space lattice nodes, so **via-in-pad is N/A-by-construction** (not a
+disabled feature -- it cannot occur), and only **through-vias** are ever
+generated (blind/buried are likewise N/A; a committed through-via masks its
+node on ALL layers).
+"""
+
+from .obstacles import CommittedCopper, LatticeObstacleModel
+from .pathfinder import LatticeNegotiationStats, LatticePathfinder
+from .quadtree import OctilinearLattice, RefineRegion
+
+__all__ = [
+    "CommittedCopper",
+    "LatticeNegotiationStats",
+    "LatticeObstacleModel",
+    "LatticePathfinder",
+    "OctilinearLattice",
+    "RefineRegion",
+]

--- a/src/kicad_tools/router/lattice/geometry.py
+++ b/src/kicad_tools/router/lattice/geometry.py
@@ -1,0 +1,126 @@
+"""Geometry helpers for the octilinear lattice engine (issue #4278).
+
+Small, dependency-free primitives: point/segment distances, segment
+intersection, rectangle tests, and a spatial hash for committed copper.
+The lattice package keeps its own copies (rather than importing from
+``router.mesh``) so the two engines stay independently removable --
+supersession of either substrate must not orphan the other's helpers.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from collections.abc import Iterator
+
+Pt = tuple[float, float]
+Rect = tuple[float, float, float, float]  # (xmin, ymin, xmax, ymax)
+
+
+def dist(a: Pt, b: Pt) -> float:
+    """Euclidean distance between two points."""
+    return math.hypot(a[0] - b[0], a[1] - b[1])
+
+
+def seg_pt_dist(a: Pt, b: Pt, p: Pt) -> float:
+    """Minimum distance from point ``p`` to segment ``a-b``."""
+    ax, ay = a
+    bx, by = b
+    px, py = p
+    dx, dy = bx - ax, by - ay
+    length2 = dx * dx + dy * dy
+    if length2 <= 1e-18:
+        return math.hypot(px - ax, py - ay)
+    t = ((px - ax) * dx + (py - ay) * dy) / length2
+    t = max(0.0, min(1.0, t))
+    return math.hypot(px - (ax + t * dx), py - (ay + t * dy))
+
+
+def _orient(a: Pt, b: Pt, c: Pt) -> float:
+    return (b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0])
+
+
+def segs_intersect(a: Pt, b: Pt, c: Pt, d: Pt) -> bool:
+    """True if open segments ``a-b`` and ``c-d`` properly cross."""
+    o1, o2 = _orient(a, b, c), _orient(a, b, d)
+    o3, o4 = _orient(c, d, a), _orient(c, d, b)
+    return ((o1 > 0) != (o2 > 0)) and ((o3 > 0) != (o4 > 0))
+
+
+def seg_seg_dist(a: Pt, b: Pt, c: Pt, d: Pt) -> float:
+    """Minimum distance between segments ``a-b`` and ``c-d`` (0 if crossing)."""
+    if segs_intersect(a, b, c, d):
+        return 0.0
+    return min(
+        seg_pt_dist(a, b, c),
+        seg_pt_dist(a, b, d),
+        seg_pt_dist(c, d, a),
+        seg_pt_dist(c, d, b),
+    )
+
+
+def pt_in_rect(p: Pt, rect: Rect) -> bool:
+    """True if ``p`` lies inside axis-aligned ``rect`` (inclusive)."""
+    x0, y0, x1, y1 = rect
+    return x0 <= p[0] <= x1 and y0 <= p[1] <= y1
+
+
+def rects_overlap(a: Rect, b: Rect) -> bool:
+    """True if two AABBs overlap (touching edges count)."""
+    return not (a[2] < b[0] or b[2] < a[0] or a[3] < b[1] or b[3] < a[1])
+
+
+def seg_rect_intersect(a: Pt, b: Pt, rect: Rect) -> bool:
+    """True if segment ``a-b`` enters axis-aligned ``rect``.
+
+    Covers the three cases: an endpoint inside, a proper crossing of a
+    rectangle side, and a collinear graze (distance-zero touch).
+    """
+    if pt_in_rect(a, rect) or pt_in_rect(b, rect):
+        return True
+    x0, y0, x1, y1 = rect
+    corners = [(x0, y0), (x1, y0), (x1, y1), (x0, y1)]
+    for c1, c2 in zip(corners, corners[1:] + corners[:1], strict=False):
+        if segs_intersect(a, b, c1, c2):
+            return True
+        if seg_seg_dist(a, b, c1, c2) < 1e-12:
+            return True
+    return False
+
+
+class SegHash:
+    """Uniform-bucket spatial hash over committed copper segments.
+
+    Buckets are keyed by integer cells of ``cell`` mm.  Each stored item is
+    ``(a, b, net, half_width)``; queries return every item whose inflated
+    bounding box touches the query segment's cells, deduplicated by identity.
+    """
+
+    def __init__(self, cell: float = 2.0) -> None:
+        self.cell = cell
+        self.buckets: dict[tuple[int, int], list[tuple[Pt, Pt, int, float]]] = defaultdict(list)
+
+    def _cells_for_seg(self, a: Pt, b: Pt, pad: float = 0.0) -> Iterator[tuple[int, int]]:
+        x0 = min(a[0], b[0]) - pad
+        x1 = max(a[0], b[0]) + pad
+        y0 = min(a[1], b[1]) - pad
+        y1 = max(a[1], b[1]) + pad
+        c = self.cell
+        for ix in range(int(math.floor(x0 / c)), int(math.floor(x1 / c)) + 1):
+            for iy in range(int(math.floor(y0 / c)), int(math.floor(y1 / c)) + 1):
+                yield (ix, iy)
+
+    def add(self, a: Pt, b: Pt, net: int, half_width: float) -> None:
+        """Insert segment ``a-b`` of net ``net`` with copper ``half_width``."""
+        for key in self._cells_for_seg(a, b, pad=half_width + 0.5):
+            self.buckets[key].append((a, b, net, half_width))
+
+    def query_seg(self, a: Pt, b: Pt, pad: float = 1.0) -> Iterator[tuple[Pt, Pt, int, float]]:
+        """Yield stored segments near ``a-b`` (each item exactly once)."""
+        seen: set[int] = set()
+        for key in self._cells_for_seg(a, b, pad=pad):
+            for item in self.buckets[key]:
+                iid = id(item)
+                if iid not in seen:
+                    seen.add(iid)
+                    yield item

--- a/src/kicad_tools/router/lattice/obstacles.py
+++ b/src/kicad_tools/router/lattice/obstacles.py
@@ -1,0 +1,208 @@
+"""Per-layer lattice masking + committed-copper model (issue #4278).
+
+Two legality sources gate every lattice resource, mirroring the mesh
+``ObstacleModel`` discipline (``router/mesh/obstacles.py``) extended
+per copper layer:
+
+* **Static pad masks** (:class:`LatticeObstacleModel`) -- built ONCE with
+  the lattice.  Every lattice node/edge records which inflated pad
+  keep-outs cover it, per layer: an SMD pad masks only its own copper
+  layer, a through-hole pad masks EVERY layer.  Same-net pads are not
+  obstacles, so the masks store pad *indices* and the per-net predicate
+  resolves net membership at query time (no per-net rebuild).
+
+* **Committed copper** (:class:`CommittedCopper`) -- the dynamic model a
+  negotiation pass accumulates.  Checks are geometric (segment-segment /
+  segment-point distance against real gaps), not merely discrete
+  node-occupancy: adjacent fine-lattice rows can sit closer than the
+  copper gap, so occupancy alone could ship a clearance violation.  This
+  is the #3906 "consult the obstacle model, never blind-fit" lesson.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from ..primitives import Pad
+from .geometry import (
+    Pt,
+    Rect,
+    SegHash,
+    dist,
+    pt_in_rect,
+    seg_pt_dist,
+    seg_rect_intersect,
+    seg_seg_dist,
+)
+from .quadtree import EdgeKey, NodeKey, OctilinearLattice
+
+_BUCKET = 4.0  # mm; pad-lookup acceleration grid
+
+
+class LatticeObstacleModel:
+    """Static per-layer pad masks over a built lattice (built once per board).
+
+    Args:
+        lattice: the built :class:`OctilinearLattice`.
+        pads: every pad on the board.
+        pad_layer_indices: for each pad, the routing-layer indices its copper
+            occupies (SMD: its own layer; PTH: all layers) -- resolved by the
+            caller against the real :class:`~kicad_tools.router.layers.LayerStack`.
+        num_layers: copper layer count of the stack.
+        agent_radius: half trace width + clearance (Minkowski inflation).
+    """
+
+    def __init__(
+        self,
+        lattice: OctilinearLattice,
+        pads: list[Pad],
+        pad_layer_indices: list[tuple[int, ...]],
+        num_layers: int,
+        agent_radius: float,
+    ) -> None:
+        self.lattice = lattice
+        self.pads = pads
+        self.pad_layer_indices = pad_layer_indices
+        self.num_layers = num_layers
+        self.agent_radius = agent_radius
+
+        # Inflated keep-out rectangle per pad (pad half-extent + agent radius).
+        self.pad_rects: list[Rect] = []
+        for pad in pads:
+            hx = pad.width / 2.0 + agent_radius
+            hy = pad.height / 2.0 + agent_radius
+            self.pad_rects.append((pad.x - hx, pad.y - hy, pad.x + hx, pad.y + hy))
+
+        # Pad-lookup buckets.
+        self._pad_buckets: dict[tuple[int, int], list[int]] = defaultdict(list)
+        for idx, rect in enumerate(self.pad_rects):
+            for ix in range(int(rect[0] // _BUCKET), int(rect[2] // _BUCKET) + 1):
+                for iy in range(int(rect[1] // _BUCKET), int(rect[3] // _BUCKET) + 1):
+                    self._pad_buckets[(ix, iy)].append(idx)
+
+        # node_pads[L][key] / edge_pads[L][edge] -> pad indices whose keep-out
+        # covers that resource on layer L.
+        self.node_pads: list[dict[NodeKey, list[int]]] = [{} for _ in range(num_layers)]
+        self.edge_pads: list[dict[EdgeKey, list[int]]] = [{} for _ in range(num_layers)]
+        for key, point in lattice.nodes.items():
+            for idx in self.pads_near(point[0], point[1], point[0], point[1]):
+                if pt_in_rect(point, self.pad_rects[idx]):
+                    for layer in pad_layer_indices[idx]:
+                        self.node_pads[layer].setdefault(key, []).append(idx)
+        for edge in lattice.edges:
+            a = lattice.node_point(edge[0])
+            b = lattice.node_point(edge[1])
+            x0, x1 = min(a[0], b[0]), max(a[0], b[0])
+            y0, y1 = min(a[1], b[1]), max(a[1], b[1])
+            for idx in self.pads_near(x0, y0, x1, y1):
+                if seg_rect_intersect(a, b, self.pad_rects[idx]):
+                    for layer in pad_layer_indices[idx]:
+                        self.edge_pads[layer].setdefault(edge, []).append(idx)
+
+    # -- queries -------------------------------------------------------------
+
+    def pads_near(self, x0: float, y0: float, x1: float, y1: float) -> set[int]:
+        """Pad indices whose inflated rect may touch the query box."""
+        out: set[int] = set()
+        for ix in range(int(x0 // _BUCKET), int(x1 // _BUCKET) + 1):
+            for iy in range(int(y0 // _BUCKET), int(y1 // _BUCKET) + 1):
+                out.update(self._pad_buckets.get((ix, iy), ()))
+        return out
+
+    def node_blocked(self, key: NodeKey, layer: int, net: int) -> bool:
+        """True if the node sits in an OTHER-net pad keep-out on ``layer``."""
+        return any(self.pads[idx].net != net for idx in self.node_pads[layer].get(key, ()))
+
+    def edge_blocked(self, edge: EdgeKey, layer: int, net: int) -> bool:
+        """True if the edge crosses an OTHER-net pad keep-out on ``layer``."""
+        return any(self.pads[idx].net != net for idx in self.edge_pads[layer].get(edge, ()))
+
+    def segment_blocked(self, a: Pt, b: Pt, layer: int, net: int) -> bool:
+        """True if free segment ``a-b`` (e.g. a stub leg) enters an other-net
+        pad keep-out on ``layer`` (geometric, not lattice-resource, check)."""
+        x0, x1 = min(a[0], b[0]), max(a[0], b[0])
+        y0, y1 = min(a[1], b[1]), max(a[1], b[1])
+        for idx in self.pads_near(x0, y0, x1, y1):
+            if self.pads[idx].net == net:
+                continue
+            if layer not in self.pad_layer_indices[idx]:
+                continue
+            if seg_rect_intersect(a, b, self.pad_rects[idx]):
+                return True
+        return False
+
+
+class CommittedCopper:
+    """Copper committed by already-routed nets in one negotiation pass.
+
+    Geometric per-layer model: traces live in per-layer :class:`SegHash`
+    structures, vias in a flat list (a through-via blocks EVERY layer).
+    All clearance predicates are centreline distances against the real
+    gaps supplied by the pathfinder.
+    """
+
+    def __init__(
+        self,
+        num_layers: int,
+        *,
+        copper_gap: float,
+        via_copper_gap: float,
+        via_via_gap: float,
+        same_net_via_gap: float,
+    ) -> None:
+        self.num_layers = num_layers
+        self.copper_gap = copper_gap  # min trace centre-to-centre (w + clr)
+        self.via_copper_gap = via_copper_gap  # via centre to trace centre
+        self.via_via_gap = via_via_gap  # via centre to via centre (cross-net)
+        self.same_net_via_gap = same_net_via_gap  # hole-to-hole floor
+        self.copper: list[SegHash] = [SegHash() for _ in range(num_layers)]
+        self.vias: list[tuple[Pt, int]] = []
+
+    # -- mutation --------------------------------------------------------
+
+    def add_run(self, layer: int, points: list[Pt], net: int, half_width: float) -> None:
+        """Commit a polyline of copper on ``layer``."""
+        for a, b in zip(points, points[1:], strict=False):
+            if dist(a, b) > 1e-9:
+                self.copper[layer].add(a, b, net, half_width)
+
+    def add_via(self, point: Pt, net: int) -> None:
+        """Commit a through-via (blocks the site on ALL layers)."""
+        self.vias.append((point, net))
+
+    # -- predicates --------------------------------------------------------
+
+    def seg_clear(self, a: Pt, b: Pt, layer: int, net: int) -> bool:
+        """True if segment ``a-b`` on ``layer`` clears other-net copper + vias."""
+        for c, d, cnet, _hw in self.copper[layer].query_seg(a, b, pad=self.copper_gap):
+            if cnet != net and seg_seg_dist(a, b, c, d) < self.copper_gap - 1e-9:
+                return False
+        for point, vnet in self.vias:
+            if vnet != net and seg_pt_dist(a, b, point) < self.via_copper_gap - 1e-9:
+                return False
+        return True
+
+    def node_clear(self, point: Pt, layer: int, net: int) -> bool:
+        """True if a node site on ``layer`` clears other-net copper + vias."""
+        for c, d, cnet, _hw in self.copper[layer].query_seg(point, point, pad=self.copper_gap):
+            if cnet != net and seg_pt_dist(c, d, point) < self.copper_gap - 1e-9:
+                return False
+        for vpt, vnet in self.vias:
+            if vnet != net and dist(point, vpt) < self.via_copper_gap - 1e-9:
+                return False
+        return True
+
+    def via_clear(self, point: Pt, net: int) -> bool:
+        """True if a through-via at ``point`` clears committed copper (ALL
+        layers) and committed vias (cross-net body gap, same-net hole gap)."""
+        for layer in range(self.num_layers):
+            for c, d, cnet, _hw in self.copper[layer].query_seg(
+                point, point, pad=self.via_copper_gap
+            ):
+                if cnet != net and seg_pt_dist(c, d, point) < self.via_copper_gap - 1e-9:
+                    return False
+        for vpt, vnet in self.vias:
+            gap = self.via_via_gap if vnet != net else self.same_net_via_gap
+            if dist(point, vpt) < gap - 1e-9:
+                return False
+        return True

--- a/src/kicad_tools/router/lattice/pathfinder.py
+++ b/src/kicad_tools/router/lattice/pathfinder.py
@@ -1,0 +1,748 @@
+"""``LatticePathfinder`` -- the adaptive octilinear lattice engine (#4278).
+
+Third route engine (``--route-engine lattice``), validated by the lattice
+substrate spike on #4267.  The full pipeline:
+
+    balanced quadtree lattice (built ONCE per board)   (quadtree.py)
+      -> per-layer pad masking                          (obstacles.py)
+      -> clearance-checked dogleg pad stubs             (quantize.dogleg_points)
+      -> negotiated A* over the (node, layer) graph     (this module)
+      -> Route of 45-legal Segments + through Vias      (path IS copper)
+
+There is **no funnel stage and no octilinear post-fit stage**: every lattice
+edge is 0/45/90/135 by construction, so an A* path over the lattice is
+already 45-degree-legal copper and is emitted directly through the #3907
+by-construction choke (``primitives.Segment`` 45-degree enforcement).
+
+**Static substrate invariant (mirrors the mesh's ``triangulation_calls``
+discipline):** the lattice + its per-layer static masks are built **once per
+board** (:meth:`build`, counted by :attr:`lattice_builds`); negotiation only
+mutates committed-copper state and history costs -- never the lattice.
+
+**Via model -- N/A-by-construction gates:** via edges join *matching
+free-space lattice nodes on adjacent layers* and every emitted via is a
+through-via spanning the whole stack.  Because vias can only land on
+free-space lattice nodes (a node inside any pad keep-out is masked),
+**via-in-pad can never occur** -- the ``MfrLimits.via_in_pad_supported``
+tier gate is moot for this engine rather than merely disabled.  Likewise
+**blind/buried vias are out of scope by construction**: only through-via
+edges are generated, and a committed through-via masks its node on ALL
+layers.
+
+**Never-ship-a-short (#3906):** every stub leg and every lattice resource is
+validated against BOTH the static per-layer pad masks and a geometric
+committed-copper model before acceptance; a connection that cannot clear
+DECLINES (``None``) -- it is never emitted crossing copper.
+"""
+
+from __future__ import annotations
+
+import heapq
+import math
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..layers import LayerStack
+from ..primitives import Pad, Route, Segment, Via
+from ..quantize import dogleg_points
+from ..rules import DesignRules
+from .geometry import Pt, Rect, dist, pt_in_rect
+from .obstacles import CommittedCopper, LatticeObstacleModel
+from .quadtree import EdgeKey, NodeKey, OctilinearLattice, RefineRegion
+
+# A negotiation connection: (opaque hashable key, start pad, end pad, net_class)
+# -- the same shape as ``mesh.pathfinder.Connection``.
+Connection = tuple[object, Pad, Pad, object]
+
+# A congestion resource: ("e", edge_key, layer) or ("v", node_key).
+Resource = tuple[object, ...]
+
+# A* state: (node_key, layer_index).
+_State = tuple[NodeKey, int]
+_GOAL: _State = (("GOAL",), -1)  # type: ignore[assignment]
+
+
+@dataclass(frozen=True)
+class LatticeNegotiationStats:
+    """Outcome of a :meth:`LatticePathfinder.route_netset` negotiation run."""
+
+    iterations: int
+    converged: bool
+    routed: int
+    total: int
+    lattice_builds: int
+
+    @property
+    def completion(self) -> float:
+        return self.routed / self.total if self.total else 0.0
+
+
+@dataclass
+class _RouteResult:
+    """Internal per-connection result: emitted route + commit geometry."""
+
+    route: Route
+    runs: list[tuple[int, list[Pt]]]  # (layer_index, polyline) per copper run
+    via_points: list[Pt]
+    resources: set[Resource]  # lattice edges/via-nodes consumed (history keys)
+
+
+class LatticePathfinder:
+    """Adaptive octilinear lattice pathfinder returning ``Route`` objects.
+
+    The lattice is built once per board and reused; per-net legality consults
+    the static per-layer pad masks plus a per-pass committed-copper model --
+    no lattice rebuild, ever (:attr:`lattice_builds` stays 1).
+    """
+
+    # Mirrors ``MeshPathfinder.supports_waypoint_injection``: pads attach via
+    # exact dogleg stubs, so the grid waypoint machinery does not apply.
+    supports_waypoint_injection: bool = False
+
+    def __init__(
+        self,
+        outline: list[Pt],
+        pads: list[Pad],
+        rules: DesignRules | None = None,
+        layer_stack: LayerStack | None = None,
+        *,
+        coarse: float = 3.2,
+        fine: float = 0.4,
+        margin: float = 0.8,
+        via_cost: float = 3.0,
+    ) -> None:
+        self.outline = outline
+        self.pads = pads
+        self.rules = rules or DesignRules()
+        # Real copper stack (issue #4278 acceptance 6): the lattice is
+        # replicated across the board's actual routing-layer count -- never
+        # hardcoded to 2.
+        self.layer_stack = layer_stack or LayerStack.two_layer()
+        self.coarse = coarse
+        self.fine = fine
+        self.margin = margin
+        # Per-via-hop layer-change cost (mm-equivalent; spike default 3.0).
+        self.via_cost = via_cost
+
+        xs = [p[0] for p in outline]
+        ys = [p[1] for p in outline]
+        self._bbox: Rect = (min(xs), min(ys), max(xs), max(ys))
+
+        # Derived clearance gaps (centreline distances).
+        tw = self.rules.trace_width
+        clr = self.rules.trace_clearance
+        via_r = self.rules.via_diameter / 2.0
+        self._trace_half = tw / 2.0
+        self._agent_radius = tw / 2.0 + clr
+        self._copper_gap = tw + clr
+        self._via_copper_gap = via_r + clr + tw / 2.0
+        self._via_via_gap = self.rules.via_diameter + clr
+        self._same_net_via_gap = self.rules.via_drill + self.rules.min_hole_to_hole
+        self._via_pad_grow = via_r + clr - self._agent_radius
+
+        # Static substrate, built lazily ONCE (the #4278 acceptance counter).
+        self._lattice: OctilinearLattice | None = None
+        self._obstacles: LatticeObstacleModel | None = None
+        self.lattice_builds: int = 0
+        # Per-connection decline reasons for the best negotiation pass
+        # (honest shortfall diagnosis; reset by :meth:`route_netset`).
+        self.failure_reasons: dict[object, str] = {}
+
+    # -- construction from a board ----------------------------------------
+
+    @classmethod
+    def from_board(
+        cls,
+        pcb_path_or_text: str | Path,
+        rules: DesignRules | None = None,
+        layer_stack: LayerStack | None = None,
+        **knobs: float,
+    ) -> LatticePathfinder:
+        """Build a pathfinder from a ``.kicad_pcb`` file or text."""
+        from ..io import _extract_edge_segments, load_pads_for_analysis
+
+        if isinstance(pcb_path_or_text, Path):
+            text = pcb_path_or_text.read_text()
+        elif not pcb_path_or_text.lstrip().startswith("("):
+            text = Path(pcb_path_or_text).read_text()
+        else:
+            text = pcb_path_or_text
+
+        pads = load_pads_for_analysis(text)
+        segments = _extract_edge_segments(text)
+        outline = _outline_from_edges(segments)
+        return cls(outline, pads, rules, layer_stack, **knobs)
+
+    # -- static substrate ---------------------------------------------------
+
+    @property
+    def num_layers(self) -> int:
+        return self.layer_stack.num_layers
+
+    def build(self) -> OctilinearLattice:
+        """Build (once) and return the static per-board lattice + masks.
+
+        Refine regions are pitch-derived per pad (issue #4278 risk 5): each
+        pad requests a local cell size of half its nearest-neighbour pad
+        distance, clamped to ``[fine / 2, fine]`` -- dense clusters densify
+        locally, open space stays coarse.  Subsequent negotiation passes
+        mutate only committed copper / history, never this substrate.
+        """
+        if self._lattice is not None:
+            return self._lattice
+        self.lattice_builds += 1
+        self._lattice = OctilinearLattice(self._bbox, self._refine_regions(), coarse=self.coarse)
+        self._obstacles = LatticeObstacleModel(
+            self._lattice,
+            self.pads,
+            [self._pad_layer_indices(p) for p in self.pads],
+            self.num_layers,
+            self._agent_radius,
+        )
+        return self._lattice
+
+    @property
+    def obstacles(self) -> LatticeObstacleModel:
+        """The static per-layer pad-mask model (builds the lattice on demand)."""
+        self.build()
+        assert self._obstacles is not None
+        return self._obstacles
+
+    def _refine_regions(self) -> list[RefineRegion]:
+        """Pad keep-out rectangles inflated by ``margin``, pitch-derived fine."""
+        centers = [(p.x, p.y) for p in self.pads]
+        regions: list[RefineRegion] = []
+        for i, pad in enumerate(self.pads):
+            nn = math.inf
+            for j, other in enumerate(centers):
+                if j == i:
+                    continue
+                d = math.hypot(other[0] - pad.x, other[1] - pad.y)
+                if d > 1e-9:
+                    nn = min(nn, d)
+            fine_i = (
+                self.fine
+                if not math.isfinite(nn)
+                else min(self.fine, max(nn / 2.0, self.fine / 2.0))
+            )
+            hx = pad.width / 2.0 + self.margin
+            hy = pad.height / 2.0 + self.margin
+            regions.append(RefineRegion((pad.x - hx, pad.y - hy, pad.x + hx, pad.y + hy), fine_i))
+        return regions
+
+    def _pad_layer_indices(self, pad: Pad) -> tuple[int, ...]:
+        """Routing-layer indices a pad's copper occupies.
+
+        SMD pads mask only their own layer; through-hole pads mask every
+        layer.  A pad whose layer is off the stack is treated conservatively
+        as through-blocking (never under-mask -- the #3906 direction).
+        """
+        if pad.through_hole:
+            return tuple(range(self.num_layers))
+        try:
+            return (self.layer_stack.layer_enum_to_index(pad.layer),)
+        except Exception:
+            return tuple(range(self.num_layers))
+
+    def _fresh_committed(self) -> CommittedCopper:
+        return CommittedCopper(
+            self.num_layers,
+            copper_gap=self._copper_gap,
+            via_copper_gap=self._via_copper_gap,
+            via_via_gap=self._via_via_gap,
+            same_net_via_gap=self._same_net_via_gap,
+        )
+
+    # -- pad stubs ------------------------------------------------------------
+
+    def pad_stubs(
+        self,
+        pad: Pad,
+        net: int,
+        committed: CommittedCopper | None = None,
+        *,
+        kmax: int = 4,
+        search_radius: float | None = None,
+    ) -> list[tuple[NodeKey, int, list[Pt], float]]:
+        """Legal dogleg stubs ``(node_key, layer, polyline pad->node, length)``.
+
+        Each stub is a 45-degree-legal two-segment dogleg
+        (:func:`~kicad_tools.router.quantize.dogleg_points`) from the EXACT
+        pad position to a nearby unmasked lattice node, with **every leg
+        clearance-checked before acceptance** against the static per-layer
+        pad masks AND committed copper (the ``subgrid.py`` reject-and-retry
+        discipline -- the standing #3906 lesson).  A pad none of whose
+        candidate stubs clears yields ``[]`` -> the connection declines.
+        """
+        lattice = self.build()
+        obstacles = self.obstacles
+        if committed is None:
+            committed = self._fresh_committed()
+        if search_radius is None:
+            search_radius = max(3.0 * lattice.fine + max(pad.width, pad.height), 2.0)
+
+        layers = self._pad_layer_indices(pad)
+        candidates: list[tuple[float, NodeKey, Pt]] = []
+        pad_pt = (pad.x, pad.y)
+        for key, point in lattice.nodes.items():
+            d = dist(point, pad_pt)
+            if d <= search_radius:
+                candidates.append((d, key, point))
+        candidates.sort()
+
+        out: list[tuple[NodeKey, int, list[Pt], float]] = []
+        for _d, key, point in candidates:
+            for layer in layers:
+                if obstacles.node_blocked(key, layer, net):
+                    continue
+                if not committed.node_clear(point, layer, net):
+                    continue
+                accepted: list[Pt] | None = None
+                for axis_first in (False, True):
+                    poly = dogleg_points(pad.x, pad.y, point[0], point[1], axis_first=axis_first)
+                    ok = True
+                    for a, b in zip(poly, poly[1:], strict=False):
+                        if obstacles.segment_blocked(a, b, layer, net):
+                            ok = False
+                            break
+                        if not committed.seg_clear(a, b, layer, net):
+                            ok = False
+                            break
+                    if ok:
+                        accepted = poly
+                        break
+                if accepted is not None:
+                    length = sum(dist(a, b) for a, b in zip(accepted, accepted[1:], strict=False))
+                    out.append((key, layer, accepted, length))
+            if len(out) >= kmax * len(layers):
+                break
+        return out
+
+    # -- via legality -----------------------------------------------------------
+
+    def _via_ok(self, key: NodeKey, net: int, committed: CommittedCopper) -> bool:
+        """Through-via legality at a lattice node.
+
+        Static part: the via body (inflated beyond the trace keep-out by
+        ``via_radius + clearance - agent_radius``) must clear every OTHER-net
+        pad on ANY layer (a through-via exists on all of them), and keep the
+        hole-to-hole floor from through-hole pads of any net.  Because pads
+        mask their surrounding nodes, free-space nodes pass by default -- the
+        gate exists to prune boundary sites.  Dynamic part: committed copper
+        on all layers + committed vias (:meth:`CommittedCopper.via_clear`).
+        """
+        lattice = self.build()
+        obstacles = self.obstacles
+        point = lattice.node_point(key)
+        grow = max(self._via_pad_grow, 0.0)
+        window = grow + 0.5
+        for idx in obstacles.pads_near(
+            point[0] - window, point[1] - window, point[0] + window, point[1] + window
+        ):
+            pad = self.pads[idx]
+            if pad.through_hole:
+                # Hole-to-hole floor applies regardless of net.
+                min_cc = self.rules.via_drill / 2.0 + pad.drill / 2.0 + self.rules.min_hole_to_hole
+                if dist(point, (pad.x, pad.y)) < min_cc - 1e-9:
+                    return False
+            if pad.net == net:
+                continue
+            rect = obstacles.pad_rects[idx]
+            grown = (rect[0] - grow, rect[1] - grow, rect[2] + grow, rect[3] + grow)
+            if pt_in_rect(point, grown):
+                return False
+        return committed.via_clear(point, net)
+
+    # -- the route contract ------------------------------------------------------
+
+    def route(
+        self,
+        start: Pad,
+        end: Pad,
+        net_class: object | None = None,
+        **_ignored: object,
+    ) -> Route | None:
+        """Route a single net between two pads; ``None`` if it cannot.
+
+        Single-net contract mirroring ``MeshPathfinder.route``: no committed
+        copper, no history.  Multi-net work goes through :meth:`route_netset`.
+        """
+        result, _reason = self._route_impl(
+            start, end, net_class, committed=self._fresh_committed(), history={}, present=0.0
+        )
+        return result.route if result is not None else None
+
+    def _route_impl(
+        self,
+        start: Pad,
+        end: Pad,
+        net_class: object | None,
+        *,
+        committed: CommittedCopper,
+        history: dict[Resource, float],
+        present: float,
+        allow_vias: bool = True,
+    ) -> tuple[_RouteResult | None, str]:
+        """A* over the (node, layer) graph; returns ``(result, reason)``.
+
+        Octilinear geometric edge costs + ``via_cost`` per layer hop +
+        congestion penalties (``present * history[resource]``) on capacity-1
+        lattice resources.  Hard legality (static masks + geometric committed
+        copper) is never traded against cost: an illegal resource is simply
+        not expanded, so the search can only DECLINE, never ship a short.
+        """
+        lattice = self.build()
+        obstacles = self.obstacles
+        net = start.net
+
+        stubs_a = self.pad_stubs(start, net, committed)
+        if not stubs_a:
+            return None, "pad-escape-start"
+        stubs_b = self.pad_stubs(end, net, committed)
+        if not stubs_b:
+            return None, "pad-escape-end"
+
+        goal: dict[_State, tuple[float, list[Pt]]] = {}
+        for key, layer, poly, length in stubs_b:
+            state = (key, layer)
+            if state not in goal or length < goal[state][0]:
+                goal[state] = (length, poly)
+        end_pt = (end.x, end.y)
+
+        def h(key: NodeKey) -> float:
+            return dist(lattice.node_point(key), end_pt)
+
+        g_score: dict[_State, float] = {}
+        came: dict[_State, tuple[_State, str]] = {}
+        start_stub: dict[_State, list[Pt]] = {}
+        heap: list[tuple[float, int, _State]] = []
+        counter = 0
+        for key, layer, poly, length in stubs_a:
+            state = (key, layer)
+            if state not in g_score or length < g_score[state]:
+                g_score[state] = length
+                start_stub[state] = poly
+                heapq.heappush(heap, (length + h(key), counter, state))
+                counter += 1
+
+        edge_ok: dict[tuple[EdgeKey, int], bool] = {}
+        node_ok: dict[_State, bool] = {}
+        via_ok: dict[NodeKey, bool] = {}
+        end_state: _State | None = None
+
+        while heap:
+            f, _c, state = heapq.heappop(heap)
+            if state == _GOAL:
+                end_state = came[_GOAL][0]
+                break
+            key, layer = state
+            g = g_score.get(state, math.inf)
+            if f > g + h(key) + 1e-9:
+                continue  # stale heap entry
+            if state in goal:
+                total = g + goal[state][0]
+                if total < g_score.get(_GOAL, math.inf) - 1e-12:
+                    g_score[_GOAL] = total
+                    came[_GOAL] = (state, "arrive")
+                    heapq.heappush(heap, (total, counter, _GOAL))
+                    counter += 1
+            for nbr, elen in lattice.adj.get(key, ()):
+                edge = (min(key, nbr), max(key, nbr))
+                ek = (edge, layer)
+                ok = edge_ok.get(ek)
+                if ok is None:
+                    ok = not obstacles.edge_blocked(edge, layer, net) and committed.seg_clear(
+                        lattice.node_point(edge[0]), lattice.node_point(edge[1]), layer, net
+                    )
+                    edge_ok[ek] = ok
+                if not ok:
+                    continue
+                nstate = (nbr, layer)
+                nok = node_ok.get(nstate)
+                if nok is None:
+                    nok = not obstacles.node_blocked(nbr, layer, net) and committed.node_clear(
+                        lattice.node_point(nbr), layer, net
+                    )
+                    node_ok[nstate] = nok
+                if not nok:
+                    continue
+                step = elen + present * history.get(("e", edge, layer), 0.0)
+                tentative = g + step
+                if tentative < g_score.get(nstate, math.inf) - 1e-12:
+                    g_score[nstate] = tentative
+                    came[nstate] = (state, "move")
+                    heapq.heappush(heap, (tentative + h(nbr), counter, nstate))
+                    counter += 1
+            if allow_vias and self.num_layers > 1:
+                vok = via_ok.get(key)
+                if vok is None:
+                    vok = self._via_ok(key, net, committed)
+                    via_ok[key] = vok
+                if vok:
+                    # Via edges join matching nodes on ADJACENT layers only
+                    # (issue #4278 acceptance 6).  The emitted via is still a
+                    # through-via; a multi-layer dip pays via_cost per hop.
+                    for nl in (layer - 1, layer + 1):
+                        if nl < 0 or nl >= self.num_layers:
+                            continue
+                        nstate = (key, nl)
+                        nok = node_ok.get(nstate)
+                        if nok is None:
+                            nok = not obstacles.node_blocked(key, nl, net) and committed.node_clear(
+                                lattice.node_point(key), nl, net
+                            )
+                            node_ok[nstate] = nok
+                        if not nok:
+                            continue
+                        step = self.via_cost + present * history.get(("v", key), 0.0)
+                        tentative = g + step
+                        if tentative < g_score.get(nstate, math.inf) - 1e-12:
+                            g_score[nstate] = tentative
+                            came[nstate] = (state, "via")
+                            heapq.heappush(heap, (tentative + h(key), counter, nstate))
+                            counter += 1
+
+        if end_state is None:
+            return None, "no-path"
+
+        # -- reconstruct ---------------------------------------------------
+        chain: list[_State] = [end_state]
+        moves: list[str] = []
+        cur = end_state
+        while cur in came:
+            prev, move = came[cur]
+            chain.append(prev)
+            moves.append(move)
+            cur = prev
+        chain.reverse()
+        moves.reverse()
+        start_state = chain[0]
+
+        resources: set[Resource] = set()
+        runs: list[tuple[int, list[Pt]]] = []
+        via_points: list[Pt] = []
+        cur_layer = start_state[1]
+        cur_pts: list[Pt] = list(start_stub[start_state])  # pad -> first node
+        for idx in range(1, len(chain)):
+            key, layer = chain[idx]
+            move = moves[idx - 1]
+            if move == "via":
+                runs.append((cur_layer, cur_pts))
+                via_points.append(lattice.node_point(key))
+                resources.add(("v", key))
+                cur_layer = layer
+                cur_pts = [lattice.node_point(key)]
+            else:
+                prev_key = chain[idx - 1][0]
+                resources.add(("e", (min(prev_key, key), max(prev_key, key)), layer))
+                cur_pts.append(lattice.node_point(key))
+        _stub_len, stub_b_poly = goal[end_state]
+        cur_pts.extend(reversed(stub_b_poly[:-1]))  # last node -> pad (exact)
+        runs.append((cur_layer, cur_pts))
+
+        route = self._emit(start, net, net_class, runs, via_points)
+        if route is None:
+            return None, "empty-route"
+        return _RouteResult(route, runs, via_points, resources), "ok"
+
+    # -- emission ---------------------------------------------------------------
+
+    def _emit(
+        self,
+        start: Pad,
+        net: int,
+        net_class: object | None,
+        runs: list[tuple[int, list[Pt]]],
+        via_points: list[Pt],
+    ) -> Route | None:
+        """Lattice path + stubs -> ``Segment`` / ``Via`` (path IS copper).
+
+        Emission goes straight through the #3907 by-construction choke
+        (``Segment.to_sexp`` 45-degree enforcement) with
+        :func:`~kicad_tools.router.optimizer.algorithms.merge_collinear`
+        fusing the node-by-node steps; there is no post-fit stage.
+        """
+        from ..optimizer.algorithms import merge_collinear
+        from ..optimizer.config import OptimizationConfig
+
+        trace_w = getattr(net_class, "trace_width", None) or self.rules.trace_width
+        config = OptimizationConfig()
+        route = Route(net=net, net_name=start.net_name)
+        for layer_idx, points in runs:
+            try:
+                layer_enum = self.layer_stack.index_to_layer_enum(layer_idx)
+            except Exception:
+                return None
+            segments = [
+                Segment(
+                    x1=a[0],
+                    y1=a[1],
+                    x2=b[0],
+                    y2=b[1],
+                    width=trace_w,
+                    layer=layer_enum,
+                    net=net,
+                    net_name=start.net_name,
+                )
+                for a, b in zip(points, points[1:], strict=False)
+                if dist(a, b) > 1e-9
+            ]
+            # Collinear merging is geometry-preserving (same centreline), so
+            # no clearance re-check is needed.
+            route.segments.extend(merge_collinear(segments, config))
+
+        if not route.segments:
+            return None
+
+        # One through-via per distinct site (the default manufacturable via;
+        # blind/buried are N/A-by-construction for this engine).
+        top = self.layer_stack.index_to_layer_enum(0)
+        bottom = self.layer_stack.index_to_layer_enum(self.num_layers - 1)
+        seen: set[tuple[float, float]] = set()
+        for site in via_points:
+            key = (round(site[0], 4), round(site[1], 4))
+            if key in seen:
+                continue
+            seen.add(key)
+            route.vias.append(
+                Via(
+                    x=site[0],
+                    y=site[1],
+                    drill=self.rules.via_drill,
+                    diameter=self.rules.via_diameter,
+                    layers=(top, bottom),
+                    net=net,
+                    net_name=start.net_name,
+                )
+            )
+        return route
+
+    # -- multi-net negotiation ------------------------------------------------
+
+    def route_netset(
+        self,
+        connections: list[Connection],
+        *,
+        max_iterations: int = 8,
+        present_cost_initial: float = 1.0,
+        present_cost_growth: float = 1.6,
+        history_increment_factor: float = 1.0,
+    ) -> tuple[dict[object, Route], LatticeNegotiationStats]:
+        """PathFinder/VPR-style negotiation over capacity-1 lattice resources.
+
+        Each pass routes every connection shortest-first against committed
+        copper (hard geometric blocking -- a net that would cross committed
+        copper is declined, never shipped as a short) plus soft history
+        penalties on contested lattice edges / via nodes.  Between passes the
+        *desired* (uncongested) corridor of every FAILED connection accrues
+        history (increment ``history_increment_factor * rules.cost_congestion
+        * present``, the grid's congestion-cost knob), pressuring whoever
+        occupies it to detour next pass; ``present`` grows geometrically so
+        later passes push harder.  ``rules.congestion_threshold`` is
+        degenerate here: lattice resources have capacity 1, so ANY sharing is
+        over-threshold and blocking is hard rather than cost-mediated.
+
+        The lattice is built **once** (:attr:`lattice_builds` == 1 across the
+        whole negotiation); rip-up resets only the committed-copper model.
+        Returns ``(routes_by_key, stats)`` for the best pass seen;
+        :attr:`failure_reasons` carries the per-connection decline diagnosis
+        for that pass.
+        """
+        self.build()
+
+        ordered = sorted(
+            connections,
+            key=lambda c: math.hypot(c[1].x - c[2].x, c[1].y - c[2].y),
+        )
+
+        history: dict[Resource, float] = {}
+        best_routes: dict[object, Route] = {}
+        best_reasons: dict[object, str] = {}
+        best_count = -1
+        converged = False
+        iterations_run = 0
+        present = present_cost_initial
+
+        for it in range(max_iterations):
+            iterations_run = it + 1
+            committed = self._fresh_committed()
+            routes: dict[object, Route] = {}
+            reasons: dict[object, str] = {}
+            failed: list[Connection] = []
+            for key, start, end, net_class in ordered:
+                result, reason = self._route_impl(
+                    start, end, net_class, committed=committed, history=history, present=present
+                )
+                if result is None:
+                    reasons[key] = reason
+                    failed.append((key, start, end, net_class))
+                    continue
+                routes[key] = result.route
+                half = self._trace_half
+                for layer_idx, points in result.runs:
+                    committed.add_run(layer_idx, points, start.net, half)
+                for via_pt in result.via_points:
+                    committed.add_via(via_pt, start.net)
+
+            if len(routes) > best_count:
+                best_count = len(routes)
+                best_routes = routes
+                best_reasons = reasons
+
+            if not failed:
+                converged = True
+                break
+            if it == max_iterations - 1:
+                break
+
+            # Failed-net demand: bump history on the resources each blocked
+            # net WANTS (its corridor with no committed copper in the way) so
+            # the occupying nets are pressured to detour next pass.
+            increment = history_increment_factor * self.rules.cost_congestion * present
+            for _key, start, end, net_class in failed:
+                desired, _reason = self._route_impl(
+                    start,
+                    end,
+                    net_class,
+                    committed=self._fresh_committed(),
+                    history=history,
+                    present=present,
+                )
+                if desired is None:
+                    continue
+                for resource in desired.resources:
+                    history[resource] = history.get(resource, 0.0) + increment
+            present *= present_cost_growth
+
+        self.failure_reasons = best_reasons
+        stats = LatticeNegotiationStats(
+            iterations=iterations_run,
+            converged=converged,
+            routed=len(best_routes),
+            total=len(connections),
+            lattice_builds=self.lattice_builds,
+        )
+        return best_routes, stats
+
+
+def _outline_from_edges(
+    segments: list[tuple[tuple[float, float], tuple[float, float]]],
+) -> list[Pt]:
+    """Board outline as a CCW bbox rectangle from Edge.Cuts segments.
+
+    Same contract as the mesh engine's outline reader: every committed fleet
+    board in scope is rectangular, so the bbox is the exact outline.
+    """
+    if not segments:
+        return []
+    xs: list[float] = []
+    ys: list[float] = []
+    for (x1, y1), (x2, y2) in segments:
+        xs.extend((x1, x2))
+        ys.extend((y1, y2))
+    return [
+        (min(xs), min(ys)),
+        (max(xs), min(ys)),
+        (max(xs), max(ys)),
+        (min(xs), max(ys)),
+    ]

--- a/src/kicad_tools/router/lattice/quadtree.py
+++ b/src/kicad_tools/router/lattice/quadtree.py
@@ -1,0 +1,310 @@
+"""Balanced-quadtree octilinear lattice generator (issue #4278, P2.7).
+
+The lattice is a quadtree decomposition of the board bounding box into
+square cells: coarse in open space, fine near pads (fine size is a
+*per-region* parameter -- :class:`RefineRegion` -- so pad clusters with
+different pitches can request different densities, issue #4278 risk 5).
+
+Graph shape (the substrate the #4267 lattice spike validated):
+
+* **nodes** = cell corners + cell centers (+ balanced T-junction side
+  midpoints);
+* **edges** = axis-aligned cell sides (split at the midpoint when the
+  neighbor across is one level finer) + the 4 corner->center
+  half-diagonals.
+
+Every edge is 0/45/90/135 degrees **by construction**, and edges meet only
+at shared nodes (planar), so an A* path over the lattice IS 45-degree-legal
+copper -- no funnel stage, no octilinear post-fit stage exists downstream.
+
+The load-bearing invariant is **balanced refinement**: adjacent leaves
+differ by at most one level, so every T-junction splits a side exactly at
+its midpoint and the corner->midpoint sub-edges remain axis-aligned.
+Octilinearity survives refinement boundaries because of this invariant --
+it is property-tested before any routing test
+(``tests/router/lattice/test_quadtree_properties.py``).
+"""
+
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from dataclasses import dataclass
+
+from .geometry import Pt, Rect, dist, rects_overlap
+
+NodeKey = tuple[int, int]
+EdgeKey = tuple[NodeKey, NodeKey]
+
+# Quadtree cell identifier: (level, i, j) with cell size = coarse / 2**level.
+CellKey = tuple[int, int, int]
+
+_SIDES: dict[str, tuple[int, int]] = {"E": (1, 0), "W": (-1, 0), "N": (0, 1), "S": (0, -1)}
+
+
+@dataclass(frozen=True)
+class RefineRegion:
+    """A rectangular region requesting a local cell size of ``fine`` mm.
+
+    Density is a per-region parameter (not a global constant) so pad
+    clusters can request pitch-derived cell sizes (issue #4278 risk 5).
+    The generator refines any cell intersecting ``rect`` until the cell
+    size is <= ``fine`` (snapped to the nearest power-of-two division of
+    the coarse cell).
+    """
+
+    rect: Rect
+    fine: float
+
+    def level_for(self, coarse: float) -> int:
+        """Quadtree level whose cell size first reaches ``fine``."""
+        if self.fine >= coarse:
+            return 0
+        return max(0, math.ceil(math.log2(coarse / self.fine) - 1e-9))
+
+
+class OctilinearLattice:
+    """Balanced quadtree lattice over a rectangular board region.
+
+    Attributes:
+        nodes: node key -> exact (x, y) coordinate.  Node keys are integer
+            multiples of :attr:`unit` from :attr:`origin`, so coincident
+            corners/midpoints/centers from different cells snap to the SAME
+            node (this is what makes the graph planar).
+        adj: node key -> list of ``(neighbor_key, edge_length)``.
+        edges: set of undirected edges as ``(min_key, max_key)`` tuples.
+        leaves: the balanced quadtree leaf cells (for tests/diagnostics).
+    """
+
+    def __init__(
+        self,
+        bbox: Rect,
+        refine_regions: list[RefineRegion],
+        *,
+        coarse: float = 3.2,
+    ) -> None:
+        if coarse <= 0:
+            raise ValueError(f"coarse cell size must be positive, got {coarse}")
+        self.bbox = bbox
+        self.coarse = coarse
+        self.refine_regions = list(refine_regions)
+        self.max_level = max((r.level_for(coarse) for r in self.refine_regions), default=0)
+        # Finest cell size actually representable, and the node-coordinate
+        # quantum (half the finest cell: centers sit at half-cell offsets).
+        self.fine = coarse / (2**self.max_level)
+        self.unit = self.fine / 2.0
+        self.origin: Pt = (bbox[0], bbox[1])
+        width = bbox[2] - bbox[0]
+        height = bbox[3] - bbox[1]
+        self.nx = max(1, math.ceil(width / coarse - 1e-9))
+        self.ny = max(1, math.ceil(height / coarse - 1e-9))
+        self._region_levels: list[tuple[Rect, int]] = [
+            (r.rect, r.level_for(coarse)) for r in self.refine_regions
+        ]
+
+        self.leaves: set[CellKey] = self._build_quadtree()
+        self._balance()
+        self.nodes: dict[NodeKey, Pt]
+        self.adj: dict[NodeKey, list[tuple[NodeKey, float]]]
+        self.edges: set[EdgeKey]
+        self.nodes, self.adj, self.edges = self._build_graph()
+
+    # -- quadtree ----------------------------------------------------------
+
+    def cell_rect(self, level: int, i: int, j: int) -> tuple[Rect, float]:
+        """World-coordinate rectangle and side length of cell ``(level, i, j)``."""
+        s = self.coarse / (2**level)
+        x0 = self.origin[0] + i * s
+        y0 = self.origin[1] + j * s
+        return (x0, y0, x0 + s, y0 + s), s
+
+    def _needs_refine(self, rect: Rect, level: int) -> bool:
+        """True if a refine region intersecting ``rect`` wants a finer level."""
+        return any(
+            region_level > level and rects_overlap(rect, region_rect)
+            for region_rect, region_level in self._region_levels
+        )
+
+    def _cell_in_bounds(self, rect: Rect) -> bool:
+        """False for cells whose origin already lies past the board bbox."""
+        return rect[0] < self.bbox[2] - 1e-9 and rect[1] < self.bbox[3] - 1e-9
+
+    def _build_quadtree(self) -> set[CellKey]:
+        leaves: set[CellKey] = set()
+        stack: list[CellKey] = [(0, i, j) for i in range(self.nx) for j in range(self.ny)]
+        while stack:
+            level, i, j = stack.pop()
+            rect, _s = self.cell_rect(level, i, j)
+            if not self._cell_in_bounds(rect):
+                continue
+            if level < self.max_level and self._needs_refine(rect, level):
+                for di in (0, 1):
+                    for dj in (0, 1):
+                        stack.append((level + 1, 2 * i + di, 2 * j + dj))
+            else:
+                leaves.add((level, i, j))
+        return leaves
+
+    def neighbor_max_level(self, level: int, i: int, j: int, direction: str) -> int:
+        """Finest leaf level adjacent across one side (-1 if none).
+
+        Looks for the neighbor first among coarser-or-equal ancestors, then
+        descends into the finer children adjacent to the shared side.
+        """
+        di, dj = _SIDES[direction]
+        ni, nj = i + di, j + dj
+        if ni < 0 or nj < 0:
+            return -1
+        # Coarser ancestors (including the same level).
+        ll = level
+        while ll >= 0:
+            if (ll, ni >> (level - ll), nj >> (level - ll)) in self.leaves:
+                return ll
+            ll -= 1
+        # Descend into finer children adjacent to the shared side.
+        best = -1
+        frontier: list[CellKey] = [(level, ni, nj)]
+        while frontier:
+            cl, ci, cj = frontier.pop()
+            if (cl, ci, cj) in self.leaves:
+                best = max(best, cl)
+                continue
+            if cl >= self.max_level:
+                continue
+            if direction == "E":  # neighbor's west children face back at us
+                kids = [(cl + 1, 2 * ci, 2 * cj), (cl + 1, 2 * ci, 2 * cj + 1)]
+            elif direction == "W":
+                kids = [(cl + 1, 2 * ci + 1, 2 * cj), (cl + 1, 2 * ci + 1, 2 * cj + 1)]
+            elif direction == "N":
+                kids = [(cl + 1, 2 * ci, 2 * cj), (cl + 1, 2 * ci + 1, 2 * cj)]
+            else:  # "S"
+                kids = [(cl + 1, 2 * ci, 2 * cj + 1), (cl + 1, 2 * ci + 1, 2 * cj + 1)]
+            frontier.extend(kids)
+        return best
+
+    def _balance(self) -> None:
+        """Enforce the <=1-level jump invariant between adjacent leaves.
+
+        Any leaf with a neighbor two or more levels finer is split; splitting
+        can create new violations on the *other* sides, so affected coarser
+        neighbors re-enter the queue until a fixpoint is reached.  This
+        invariant is what keeps every T-junction split at an exact side
+        midpoint (octilinearity across refinement boundaries).
+        """
+        queue = list(self.leaves)
+        while queue:
+            cell = queue.pop()
+            if cell not in self.leaves:
+                continue  # already split by a prior iteration
+            level, i, j = cell
+            if not any(self.neighbor_max_level(level, i, j, d) >= level + 2 for d in _SIDES):
+                continue
+            self.leaves.discard(cell)
+            for di in (0, 1):
+                for dj in (0, 1):
+                    kid = (level + 1, 2 * i + di, 2 * j + dj)
+                    rect, _s = self.cell_rect(*kid)
+                    if not self._cell_in_bounds(rect):
+                        continue
+                    self.leaves.add(kid)
+                    queue.append(kid)
+            # Splitting may push a coarser neighbor out of balance in turn.
+            for d in _SIDES:
+                di, dj = _SIDES[d]
+                ll, ii, jj = level, i + di, j + dj
+                while ll >= 0:
+                    if (ll, ii, jj) in self.leaves:
+                        queue.append((ll, ii, jj))
+                        break
+                    ll -= 1
+                    ii >>= 1
+                    jj >>= 1
+
+    # -- graph --------------------------------------------------------------
+
+    def node_key(self, x: float, y: float) -> NodeKey:
+        """Integer node key for a world coordinate (multiple of :attr:`unit`)."""
+        return (
+            round((x - self.origin[0]) / self.unit),
+            round((y - self.origin[1]) / self.unit),
+        )
+
+    def node_point(self, key: NodeKey) -> Pt:
+        """Exact world coordinate of a node key."""
+        return (
+            self.origin[0] + key[0] * self.unit,
+            self.origin[1] + key[1] * self.unit,
+        )
+
+    def _inside(self, x: float, y: float) -> bool:
+        return (
+            self.bbox[0] - 1e-9 <= x <= self.bbox[2] + 1e-9
+            and self.bbox[1] - 1e-9 <= y <= self.bbox[3] + 1e-9
+        )
+
+    def _build_graph(
+        self,
+    ) -> tuple[dict[NodeKey, Pt], dict[NodeKey, list[tuple[NodeKey, float]]], set[EdgeKey]]:
+        nodes: dict[NodeKey, Pt] = {}
+        edges: set[EdgeKey] = set()
+
+        def add_node(x: float, y: float) -> NodeKey | None:
+            if not self._inside(x, y):
+                return None  # board outline (bbox) clips the lattice
+            k = self.node_key(x, y)
+            nodes[k] = self.node_point(k)
+            return k
+
+        def add_edge(k1: NodeKey | None, k2: NodeKey | None) -> None:
+            if k1 is None or k2 is None or k1 == k2:
+                return
+            edges.add((min(k1, k2), max(k1, k2)))
+
+        for level, i, j in self.leaves:
+            rect, _s = self.cell_rect(level, i, j)
+            x0, y0, x1, y1 = rect
+            c00 = add_node(x0, y0)
+            c10 = add_node(x1, y0)
+            c01 = add_node(x0, y1)
+            c11 = add_node(x1, y1)
+            center = add_node((x0 + x1) / 2, (y0 + y1) / 2)
+            # The 4 corner->center half-diagonals (exact 45 degrees).
+            for corner in (c00, c10, c01, c11):
+                add_edge(corner, center)
+            # Sides: split at the midpoint when the neighbor across is finer.
+            # Balance guarantees the finer neighbor is exactly ONE level down,
+            # so the midpoint coincides with that neighbor's shared corner and
+            # both sub-edges stay exactly axis-aligned.
+            sides: list[tuple[str, NodeKey | None, NodeKey | None, Pt]] = [
+                ("S", c00, c10, ((x0 + x1) / 2, y0)),
+                ("N", c01, c11, ((x0 + x1) / 2, y1)),
+                ("W", c00, c01, (x0, (y0 + y1) / 2)),
+                ("E", c10, c11, (x1, (y0 + y1) / 2)),
+            ]
+            for direction, ca, cb, midpoint in sides:
+                if self.neighbor_max_level(level, i, j, direction) >= level + 1:
+                    mid = add_node(*midpoint)
+                    add_edge(ca, mid)
+                    add_edge(mid, cb)
+                else:
+                    add_edge(ca, cb)
+
+        adj: dict[NodeKey, list[tuple[NodeKey, float]]] = defaultdict(list)
+        for k1, k2 in edges:
+            length = dist(self.node_point(k1), self.node_point(k2))
+            adj[k1].append((k2, length))
+            adj[k2].append((k1, length))
+        return nodes, dict(adj), edges
+
+    # -- sizing --------------------------------------------------------------
+
+    def memory_estimate(self, n_layers: int) -> tuple[int, int, int]:
+        """``(n_nodes, n_edges, bytes)`` for ``n_layers`` lattice replicas.
+
+        Accounting mirrors the #4267 sizing spikes so numbers are comparable
+        across the epic: 16 B coordinates + 8 B mask word per node per layer,
+        plus 2 x (8 B index + 8 B length) per undirected edge per layer.
+        """
+        n = len(self.nodes)
+        m = len(self.edges)
+        return n, m, n_layers * (n * (16 + 8) + m * 32)

--- a/tests/router/lattice/test_engine_dispatch.py
+++ b/tests/router/lattice/test_engine_dispatch.py
@@ -1,0 +1,155 @@
+"""Engine dispatch + dormant-path tests for ``--route-engine lattice`` (#4278).
+
+Acceptance 3: ``--route-engine grid`` AND ``--route-engine mesh`` stay
+byte-identical to pre-phase -- neither dormant path may construct or even
+import the lattice engine; the mesh regression suite (``tests/router/mesh``)
+proves the mesh engine itself is untouched.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.primitives import Pad
+
+
+def _add_pad(router: Autorouter, pad: Pad) -> None:
+    key = (pad.ref, pad.pin)
+    router.pads[key] = pad
+    router.nets.setdefault(pad.net, []).append(key)
+
+
+def _two_pad_router(strategy: str) -> Autorouter:
+    router = Autorouter(50, 40, strategy=strategy)
+    _add_pad(
+        router,
+        Pad(
+            x=10, y=10, width=1, height=1, net=1, net_name="N1", layer=Layer.F_CU, ref="R1", pin="1"
+        ),
+    )
+    _add_pad(
+        router,
+        Pad(
+            x=30, y=25, width=1, height=1, net=1, net_name="N1", layer=Layer.F_CU, ref="R2", pin="1"
+        ),
+    )
+    return router
+
+
+# ---------------------------------------------------------------------------
+# The lattice engine routes through the standard dispatch seam.
+# ---------------------------------------------------------------------------
+
+
+def test_route_net_lattice_routes_and_commits() -> None:
+    router = _two_pad_router("lattice")
+    # No Edge.Cuts -> grid-derived bbox fallback (same guard as the mesh).
+    assert router._board_bbox is None
+
+    routes = router.route_net(1)
+
+    assert router._lattice_pathfinder is not None
+    assert len(routes) == 1
+    assert routes[0].segments
+    assert router.routes, "committed routes must land in router.routes"
+    # Negotiation stats recorded; the lattice was built exactly once.
+    assert router._lattice_negotiation_stats is not None
+    assert router._lattice_negotiation_stats.lattice_builds == 1
+    # Serving the same net again must not duplicate committed copper.
+    n_committed = len(router.routes)
+    router.route_net(1)
+    assert len(router.routes) == n_committed
+
+
+def test_lattice_serves_cached_netset_per_net() -> None:
+    router = _two_pad_router("lattice")
+    _add_pad(
+        router,
+        Pad(
+            x=12, y=30, width=1, height=1, net=2, net_name="N2", layer=Layer.F_CU, ref="R3", pin="1"
+        ),
+    )
+    _add_pad(
+        router,
+        Pad(
+            x=38, y=12, width=1, height=1, net=2, net_name="N2", layer=Layer.F_CU, ref="R4", pin="1"
+        ),
+    )
+    routes1 = router.route_net(1)
+    pf = router._lattice_pathfinder
+    routes2 = router.route_net(2)
+    # Second net is served from the SAME negotiated cache and pathfinder --
+    # no rebuild, no re-negotiation.
+    assert router._lattice_pathfinder is pf
+    assert pf.lattice_builds == 1
+    assert routes1 and routes2
+
+
+# ---------------------------------------------------------------------------
+# Dormant paths: grid and mesh never touch the lattice engine.
+# ---------------------------------------------------------------------------
+
+
+def test_grid_strategy_never_constructs_lattice_state() -> None:
+    router = _two_pad_router("grid")
+    router.route_net(1)
+    assert router._lattice_pathfinder is None
+    assert router._lattice_net_routes is None
+    assert router._lattice_served == set()
+    # The mesh engine is equally dormant on the grid path.
+    assert router._mesh_pathfinder is None
+
+
+def test_mesh_strategy_never_constructs_lattice_state() -> None:
+    pytest.importorskip("kicad_tools.router.router_cpp")
+    router = _two_pad_router("mesh")
+    router.route_net(1)
+    assert router._mesh_pathfinder is not None
+    assert router._lattice_pathfinder is None
+    assert router._lattice_net_routes is None
+
+
+# ---------------------------------------------------------------------------
+# CLI flag shape: third engine value, default unchanged.
+# ---------------------------------------------------------------------------
+
+
+def test_route_engine_flag_accepts_lattice_and_defaults_to_grid() -> None:
+    from kicad_tools.cli.parser import create_parser
+
+    parser = create_parser()
+    args = parser.parse_args(["route", "board.kicad_pcb"])
+    assert args.route_engine == "grid"
+    for engine in ("grid", "mesh", "lattice"):
+        args = parser.parse_args(["route", "board.kicad_pcb", "--route-engine", engine])
+        assert args.route_engine == engine
+
+
+def test_route_cmd_mirror_parser_accepts_lattice(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The duplicate ``--route-engine`` definition in ``route_cmd.main`` is
+    built inside the function; capture the parser at parse time to check it."""
+    import argparse
+
+    from kicad_tools.cli import route_cmd
+
+    captured: dict[str, argparse.ArgumentParser] = {}
+
+    class _Captured(Exception):
+        pass
+
+    def fake_parse_args(self: argparse.ArgumentParser, *a: object, **k: object) -> None:
+        captured["parser"] = self
+        raise _Captured
+
+    monkeypatch.setattr(argparse.ArgumentParser, "parse_args", fake_parse_args)
+    with pytest.raises(_Captured):
+        route_cmd.main(["board.kicad_pcb"])
+    monkeypatch.undo()
+
+    parser = captured["parser"]
+    args = parser.parse_args(["board.kicad_pcb", "--route-engine", "lattice"])
+    assert args.route_engine == "lattice"
+    args = parser.parse_args(["board.kicad_pcb"])
+    assert args.route_engine == "grid"

--- a/tests/router/lattice/test_negotiation.py
+++ b/tests/router/lattice/test_negotiation.py
@@ -1,0 +1,296 @@
+"""Lattice-engine negotiation + acceptance tests (issue #4278).
+
+The load-bearing acceptance criteria from the issue:
+
+1. Board 02 charlieplex under REAL negotiation + REAL ``kicad-cli pcb drc
+   --refill-zones``: 0 shorts (hard), >= 17/24 completion (hard floor),
+   24/24 target.
+2. ``lattice_builds == 1`` across the whole negotiation (static substrate).
+4. Never-ship-a-short: a connection that cannot clear DECLINES.
+6. N-layer via the real ``LayerStack``; via edges adjacent-layer only,
+   emitted vias are through-vias.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.drc.geometric import run_geometric_drc
+from kicad_tools.router.lattice.geometry import seg_seg_dist
+from kicad_tools.router.lattice.pathfinder import LatticePathfinder
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import DesignRules
+
+_REPO = Path(__file__).resolve().parents[3]
+_CHARLIEPLEX = _REPO / "boards/02-charlieplex-led/output/charlieplex_3x3.kicad_pcb"
+
+
+def _pads_by_net(pads: list[Pad]) -> dict[int, list[Pad]]:
+    bynet: dict[int, list[Pad]] = {}
+    for p in pads:
+        if p.net > 0:
+            bynet.setdefault(p.net, []).append(p)
+    return bynet
+
+
+def _connections(pads: list[Pad]) -> list[tuple[object, Pad, Pad, object]]:
+    """Star-wise 2-pad connections keyed (net, seq) -- the dispatch topology."""
+    conns: list[tuple[object, Pad, Pad, object]] = []
+    for net, ps in _pads_by_net(pads).items():
+        anchor = ps[0]
+        for seq, other in enumerate(ps[1:]):
+            conns.append(((net, seq), anchor, other, None))
+    return conns
+
+
+def _pad(
+    x: float,
+    y: float,
+    net: int,
+    *,
+    ref: str,
+    layer: Layer = Layer.F_CU,
+    width: float = 1.0,
+    height: float = 1.0,
+) -> Pad:
+    return Pad(
+        x=x,
+        y=y,
+        width=width,
+        height=height,
+        net=net,
+        net_name=f"N{net}",
+        layer=layer,
+        ref=ref,
+        pin="1",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Static substrate: the lattice is built ONCE per board (acceptance 2).
+# ---------------------------------------------------------------------------
+
+
+def test_lattice_builds_exactly_once_across_negotiation() -> None:
+    from kicad_tools.router.io import load_pads_for_analysis
+
+    text = _CHARLIEPLEX.read_text()
+    pads = load_pads_for_analysis(text)
+    conns = _connections(pads)
+    assert len(conns) >= 3, "need several nets to prove once != per-net"
+
+    pf = LatticePathfinder.from_board(text)
+    _routes, stats = pf.route_netset(conns, max_iterations=4)
+
+    # ONE lattice build for the whole board, across every net AND every
+    # negotiation iteration -- the static-substrate invariant (mirrors the
+    # mesh's triangulation_calls == 1 discipline).
+    assert pf.lattice_builds == 1
+    assert stats.lattice_builds == 1
+
+
+def test_build_is_idempotent_single_lattice() -> None:
+    text = _CHARLIEPLEX.read_text()
+    pf = LatticePathfinder.from_board(text)
+    lat1 = pf.build()
+    lat2 = pf.build()
+    assert lat1 is lat2
+    assert pf.lattice_builds == 1
+
+
+# ---------------------------------------------------------------------------
+# Board 02 acceptance: completion floor + real kicad-cli DRC (acceptance 1).
+# ---------------------------------------------------------------------------
+
+
+def test_charlieplex_negotiation_meets_completion_floor() -> None:
+    from kicad_tools.router.io import load_pads_for_analysis
+
+    text = _CHARLIEPLEX.read_text()
+    pads = load_pads_for_analysis(text)
+    conns = _connections(pads)
+    assert len(conns) == 24
+
+    pf = LatticePathfinder.from_board(text)
+    routes, stats = pf.route_netset(conns, max_iterations=8)
+    assert stats.total == 24
+    # Hard floor from the issue: >= 17/24 (strictly above everything the
+    # navmesh line ever measured); the spike-parity target is 24/24.
+    assert stats.routed >= 17, (
+        f"completion {stats.routed}/24 below the hard floor; declines: {pf.failure_reasons}"
+    )
+    # Every shortfall must be a decline with a diagnosis, never a short.
+    assert len(pf.failure_reasons) == 24 - stats.routed
+    assert stats.lattice_builds == 1
+
+
+def test_charlieplex_netset_is_drc_clean(tmp_path: Path) -> None:
+    """The whole negotiated net set emits DRC-clean copper (0 shorts).
+
+    ``kicad-cli pcb drc --refill-zones`` is the authoritative gate
+    (``drc/geometric.py``) -- ``kct check`` alone is insufficient (standing
+    process rule).
+    """
+    from kicad_tools.router.io import load_pads_for_analysis, merge_routes_into_pcb
+
+    text = _CHARLIEPLEX.read_text()
+    pads = load_pads_for_analysis(text)
+    conns = _connections(pads)
+
+    base_pcb = tmp_path / "base.kicad_pcb"
+    base_pcb.write_text(text)
+    base = run_geometric_drc(base_pcb)
+    if not base.ran:
+        pytest.skip(f"kicad-cli DRC unavailable: {base.reason}")
+
+    pf = LatticePathfinder.from_board(text)
+    routes, stats = pf.route_netset(conns, max_iterations=8)
+    assert stats.routed >= 17
+    sexp = "".join(r.to_sexp() for r in routes.values() if r.segments)
+
+    out = tmp_path / "routed.kicad_pcb"
+    out.write_text(merge_routes_into_pcb(text, sexp))
+    res = run_geometric_drc(out)
+    assert res.ran
+    assert res.error_count <= base.error_count, (
+        f"lattice net set introduced DRC errors: base={base.error_count} "
+        f"routed={res.error_count} types={dict(res.by_type)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Never-ship-a-short (acceptance 4, #3906-modeled).
+# ---------------------------------------------------------------------------
+
+
+def test_committed_copper_forces_detour_or_decline_never_a_cross() -> None:
+    """Two nets through one narrow slot: the second must detour around the
+    first's committed copper or decline -- emitted copper never crosses."""
+    outline = [(0.0, 0.0), (30.0, 0.0), (30.0, 12.0), (0.0, 12.0)]
+    # Other-net wall pads pinch the middle of the board into a slot barely
+    # wider than one trace pitch.
+    walls = [
+        _pad(15.0, 9.0, 9, ref="WT", width=1.0, height=6.0),
+        _pad(15.0, 2.0, 9, ref="WB", width=1.0, height=4.0),
+    ]
+    a1, a2 = _pad(3.0, 5.5, 1, ref="A1"), _pad(27.0, 5.5, 1, ref="A2")
+    b1, b2 = _pad(3.0, 6.5, 2, ref="B1"), _pad(27.0, 6.5, 2, ref="B2")
+    pads = [a1, a2, b1, b2] + walls
+    pf = LatticePathfinder(outline, pads, DesignRules(), LayerStack.two_layer())
+    conns = [((1, 0), a1, a2, None), ((2, 0), b1, b2, None)]
+    routes, stats = pf.route_netset(conns, max_iterations=6)
+    assert stats.lattice_builds == 1
+    assert stats.routed >= 1
+
+    # THE invariant: whatever routed, no two different-net segments on the
+    # same layer sit closer than the copper gap (a crossing would be 0).
+    copper_gap = pf.rules.trace_width + pf.rules.trace_clearance
+    flat: list[tuple[int, object, tuple, tuple]] = []
+    for key, route in routes.items():
+        for seg in route.segments:
+            flat.append((route.net, seg.layer, (seg.x1, seg.y1), (seg.x2, seg.y2)))
+    for i in range(len(flat)):
+        for j in range(i + 1, len(flat)):
+            n1, l1, p1, q1 = flat[i]
+            n2, l2, p2, q2 = flat[j]
+            if n1 == n2 or l1 != l2:
+                continue
+            d = seg_seg_dist(p1, q1, p2, q2)
+            assert d >= copper_gap - 1e-6, (
+                f"nets {n1}/{n2} shipped copper {d:.4f}mm apart (< {copper_gap})"
+            )
+
+
+def test_unroutable_connection_declines_with_reason() -> None:
+    """A pad fully boxed in by other-net keep-outs must DECLINE (None).
+
+    The walls overlap at the corners (no diagonal pinhole), so no path out
+    of the box exists on the pad's layer and the box is sealed against a
+    dip too (the walls block both attach layers of any via inside).
+    """
+    outline = [(0.0, 0.0), (20.0, 0.0), (20.0, 20.0), (0.0, 20.0)]
+    target = _pad(10.0, 10.0, 1, ref="U1", width=0.6, height=0.6)
+    mate = _pad(3.0, 3.0, 1, ref="U2")
+    # Sealed ring: two full-width horizontal bars + two vertical bars whose
+    # keep-outs overlap the horizontal ones at every corner, duplicated on
+    # BOTH layers so the boxed pad cannot dip out either.
+    walls = []
+    for layer in (Layer.F_CU, Layer.B_CU):
+        walls += [
+            _pad(10.0, 11.2, 2, ref=f"WN{layer}", width=4.0, height=0.8, layer=layer),
+            _pad(10.0, 8.8, 2, ref=f"WS{layer}", width=4.0, height=0.8, layer=layer),
+            _pad(11.2, 10.0, 2, ref=f"WE{layer}", width=0.8, height=4.0, layer=layer),
+            _pad(8.8, 10.0, 2, ref=f"WW{layer}", width=0.8, height=4.0, layer=layer),
+        ]
+    pf = LatticePathfinder(outline, [target, mate] + walls, DesignRules())
+    assert pf.route(target, mate) is None
+
+    routes, stats = pf.route_netset([((1, 0), target, mate, None)], max_iterations=2)
+    assert stats.routed == 0
+    assert routes == {}
+    # Declined with a diagnosis -- never emitted crossing the walls.
+    assert pf.failure_reasons[(1, 0)] in ("no-path", "pad-escape-start", "pad-escape-end")
+
+
+# ---------------------------------------------------------------------------
+# N-layer (acceptance 6): real LayerStack, adjacent-layer via edges,
+# through-via emission.
+# ---------------------------------------------------------------------------
+
+
+def test_cross_layer_route_on_four_layer_stack_uses_through_vias() -> None:
+    outline = [(0.0, 0.0), (20.0, 0.0), (20.0, 10.0), (0.0, 10.0)]
+    stack = LayerStack.four_layer_all_signal()
+    a = _pad(3.0, 5.0, 1, ref="A1", layer=Layer.F_CU)
+    b = _pad(17.0, 5.0, 1, ref="A2", layer=Layer.B_CU)
+    pf = LatticePathfinder(outline, [a, b], DesignRules(), stack)
+    assert pf.num_layers == 4
+
+    route = pf.route(a, b)
+    assert route is not None
+    assert route.vias, "cross-layer connection needs at least one via"
+    for via in route.vias:
+        # Only through-vias are ever generated (blind/buried N/A by
+        # construction): every via spans the full stack.
+        assert via.layers == (Layer.F_CU, Layer.B_CU)
+    layers_used = {seg.layer for seg in route.segments}
+    assert Layer.F_CU in layers_used and Layer.B_CU in layers_used
+
+
+def test_via_hops_join_adjacent_layers_only() -> None:
+    """The (node, layer) A* exposes via hops to L +/- 1 only; a 4-layer
+    F.Cu -> B.Cu transition therefore traverses every intermediate layer
+    state (and still emits a single deduplicated through-via per site)."""
+    outline = [(0.0, 0.0), (20.0, 0.0), (20.0, 10.0), (0.0, 10.0)]
+    stack = LayerStack.four_layer_all_signal()
+    a = _pad(3.0, 5.0, 1, ref="A1", layer=Layer.F_CU)
+    b = _pad(17.0, 5.0, 1, ref="A2", layer=Layer.B_CU)
+    pf = LatticePathfinder(outline, [a, b], DesignRules(), stack)
+
+    result, reason = pf._route_impl(
+        a, b, None, committed=pf._fresh_committed(), history={}, present=0.0
+    )
+    assert result is not None, reason
+    via_resources = [r for r in result.resources if r[0] == "v"]
+    assert via_resources, "expected via resources on a cross-layer route"
+    # 3 adjacent-layer hops share one node key -> ONE emitted through-via.
+    distinct_sites = {(round(p[0], 4), round(p[1], 4)) for p in result.via_points}
+    assert len(result.via_points) >= 3, "adjacent-layer hops: F->In1->In2->B"
+    assert len(result.route.vias) == len(distinct_sites)
+
+
+def test_two_layer_dip_resolves_a_blocked_crossing() -> None:
+    """A wall blocking F.Cu entirely forces a dip to B.Cu and back."""
+    outline = [(0.0, 0.0), (24.0, 0.0), (24.0, 10.0), (0.0, 10.0)]
+    wall = _pad(12.0, 5.0, 9, ref="W", width=1.0, height=10.0, layer=Layer.F_CU)
+    a = _pad(3.0, 5.0, 1, ref="A1")
+    b = _pad(21.0, 5.0, 1, ref="A2")
+    pf = LatticePathfinder(outline, [a, b, wall], DesignRules())
+    route = pf.route(a, b)
+    assert route is not None
+    assert len(route.vias) >= 2, "expected a dip (down + up)"
+    layers_used = {seg.layer for seg in route.segments}
+    assert layers_used == {Layer.F_CU, Layer.B_CU}

--- a/tests/router/lattice/test_quadtree_properties.py
+++ b/tests/router/lattice/test_quadtree_properties.py
@@ -1,0 +1,237 @@
+"""Property tests for the octilinear lattice substrate (issue #4278).
+
+These run BEFORE any routing test (the issue's mandated order): the
+<=1-level balance invariant and octilinearity-across-T-junctions are
+load-bearing for everything downstream -- a bug here emits off-angle or
+overlapping copper, so the properties are pinned first.
+"""
+
+from __future__ import annotations
+
+import math
+
+from kicad_tools.router.lattice.geometry import dist, segs_intersect
+from kicad_tools.router.lattice.obstacles import LatticeObstacleModel
+from kicad_tools.router.lattice.quadtree import OctilinearLattice, RefineRegion
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.quantize import is_45_aligned
+
+_SIDES = ("E", "W", "N", "S")
+
+
+def _lattice_with_t_junctions() -> OctilinearLattice:
+    """A lattice whose refine regions force multi-level T-junction boundaries."""
+    bbox = (0.0, 0.0, 25.6, 19.2)
+    regions = [
+        RefineRegion((4.0, 4.0, 7.0, 7.0), 0.4),  # 3 levels below coarse
+        RefineRegion((15.0, 9.0, 18.0, 12.0), 0.8),  # 2 levels
+        RefineRegion((20.0, 2.0, 22.0, 4.0), 1.6),  # 1 level
+    ]
+    return OctilinearLattice(bbox, regions, coarse=3.2)
+
+
+# ---------------------------------------------------------------------------
+# Property 1: every lattice edge is octilinear, INCLUDING across refinement
+# boundaries / T-junctions.
+# ---------------------------------------------------------------------------
+
+
+def test_every_edge_is_octilinear_including_t_junctions() -> None:
+    lattice = _lattice_with_t_junctions()
+    assert len(lattice.leaves) > 60, "refinement did not happen"
+    # Sanity: refinement produced more than one level (T-junctions exist).
+    levels = {leaf[0] for leaf in lattice.leaves}
+    assert len(levels) >= 3
+
+    assert lattice.edges, "empty lattice"
+    for k1, k2 in lattice.edges:
+        a = lattice.node_point(k1)
+        b = lattice.node_point(k2)
+        dx, dy = b[0] - a[0], b[1] - a[1]
+        assert is_45_aligned(dx, dy), f"off-angle edge {a} -> {b}"
+
+
+def test_edges_are_axis_or_exact_diagonal_in_key_space() -> None:
+    """Integer-key check (no float tolerance): |dx| == |dy| or axis-aligned."""
+    lattice = _lattice_with_t_junctions()
+    for k1, k2 in lattice.edges:
+        dx = abs(k2[0] - k1[0])
+        dy = abs(k2[1] - k1[1])
+        assert dx == 0 or dy == 0 or dx == dy, f"non-octilinear key delta {k1} -> {k2}"
+
+
+# ---------------------------------------------------------------------------
+# Property 2: balanced refinement -- adjacent leaves differ by <= 1 level.
+# ---------------------------------------------------------------------------
+
+
+def test_balance_invariant_adjacent_leaves_differ_at_most_one_level() -> None:
+    lattice = _lattice_with_t_junctions()
+    for level, i, j in lattice.leaves:
+        for direction in _SIDES:
+            neighbor_level = lattice.neighbor_max_level(level, i, j, direction)
+            assert neighbor_level <= level + 1, (
+                f"balance violated: leaf ({level},{i},{j}) has {direction} "
+                f"neighbor at level {neighbor_level}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Property 3: planarity -- edges meet only at shared nodes.
+# ---------------------------------------------------------------------------
+
+
+def test_edges_intersect_only_at_shared_nodes() -> None:
+    # Small lattice (one refined pocket) so the O(E^2) sweep stays cheap.
+    bbox = (0.0, 0.0, 9.6, 9.6)
+    lattice = OctilinearLattice(bbox, [RefineRegion((3.0, 3.0, 5.0, 5.0), 0.8)], coarse=3.2)
+    edges = [(lattice.node_point(k1), lattice.node_point(k2), k1, k2) for k1, k2 in lattice.edges]
+    assert 50 < len(edges) < 2500
+    for x in range(len(edges)):
+        a, b, ka, kb = edges[x]
+        for y in range(x + 1, len(edges)):
+            c, d, kc, kd = edges[y]
+            if {ka, kb} & {kc, kd}:
+                continue  # shared node: touching there is legal
+            assert not segs_intersect(a, b, c, d), f"edges cross: {a}-{b} x {c}-{d}"
+            # Collinear-overlap guard: no interior point of one edge may lie
+            # on the other (proper crossings are caught above).
+            for p in (c, d):
+                assert not _interior_point_on_segment(a, b, p), (
+                    f"edge endpoint {p} lies inside edge {a}-{b}"
+                )
+            for p in (a, b):
+                assert not _interior_point_on_segment(c, d, p), (
+                    f"edge endpoint {p} lies inside edge {c}-{d}"
+                )
+
+
+def _interior_point_on_segment(a, b, p) -> bool:
+    if dist(a, p) < 1e-9 or dist(b, p) < 1e-9:
+        return False
+    return abs(dist(a, p) + dist(p, b) - dist(a, b)) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Property 4: node coordinates are exact multiples of the lattice unit.
+# ---------------------------------------------------------------------------
+
+
+def test_node_coordinates_are_quantized_to_unit() -> None:
+    lattice = _lattice_with_t_junctions()
+    for key, point in lattice.nodes.items():
+        expected = lattice.node_point(key)
+        assert point == expected
+        rx = (point[0] - lattice.origin[0]) / lattice.unit
+        ry = (point[1] - lattice.origin[1]) / lattice.unit
+        assert abs(rx - round(rx)) < 1e-9
+        assert abs(ry - round(ry)) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Property 5: per-layer masking.
+# ---------------------------------------------------------------------------
+
+
+def _pad(x: float, y: float, net: int, *, layer: Layer = Layer.F_CU, through: bool = False) -> Pad:
+    return Pad(
+        x=x,
+        y=y,
+        width=1.0,
+        height=1.0,
+        net=net,
+        net_name=f"N{net}",
+        layer=layer,
+        ref=f"P{net}",
+        pin="1",
+        through_hole=through,
+        drill=0.3 if through else 0.0,
+    )
+
+
+def _masked_model(
+    pads: list[Pad], num_layers: int = 2
+) -> tuple[OctilinearLattice, LatticeObstacleModel]:
+    bbox = (0.0, 0.0, 12.8, 12.8)
+    regions = [RefineRegion((p.x - 1.3, p.y - 1.3, p.x + 1.3, p.y + 1.3), 0.4) for p in pads]
+    lattice = OctilinearLattice(bbox, regions, coarse=3.2)
+    stack = LayerStack.two_layer() if num_layers == 2 else LayerStack.four_layer_all_signal()
+
+    def indices(pad: Pad) -> tuple[int, ...]:
+        if pad.through_hole:
+            return tuple(range(num_layers))
+        return (stack.layer_enum_to_index(pad.layer),)
+
+    model = LatticeObstacleModel(
+        lattice, pads, [indices(p) for p in pads], num_layers, agent_radius=0.3
+    )
+    return lattice, model
+
+
+def test_smd_pad_masks_only_its_own_layer() -> None:
+    pad = _pad(6.4, 6.4, net=7, layer=Layer.F_CU)
+    lattice, model = _masked_model([pad])
+    inside = [
+        key
+        for key, point in lattice.nodes.items()
+        if abs(point[0] - pad.x) <= 0.5 + 0.3 - 1e-9 and abs(point[1] - pad.y) <= 0.5 + 0.3 - 1e-9
+    ]
+    assert inside, "no lattice node landed inside the pad keep-out"
+    for key in inside:
+        # Blocked for another net on the pad's layer (F.Cu = index 0)...
+        assert model.node_blocked(key, 0, net=99)
+        # ... present (unmasked) on the other layer ...
+        assert not model.node_blocked(key, 1, net=99)
+        # ... and never an obstacle to its OWN net.
+        assert not model.node_blocked(key, 0, net=7)
+
+
+def test_through_hole_pad_masks_every_layer() -> None:
+    pad = _pad(6.4, 6.4, net=7, through=True)
+    lattice, model = _masked_model([pad], num_layers=4)
+    inside = [
+        key
+        for key, point in lattice.nodes.items()
+        if abs(point[0] - pad.x) <= 0.5 + 0.3 - 1e-9 and abs(point[1] - pad.y) <= 0.5 + 0.3 - 1e-9
+    ]
+    assert inside
+    for key in inside:
+        for layer in range(4):
+            assert model.node_blocked(key, layer, net=99)
+
+
+def test_edge_crossing_pad_keepout_is_masked_per_layer() -> None:
+    pad = _pad(6.4, 6.4, net=7, layer=Layer.B_CU)
+    lattice, model = _masked_model([pad])
+    crossing = [
+        edge for edge in lattice.edges if edge in model.edge_pads[1] or edge in model.edge_pads[0]
+    ]
+    assert crossing, "no lattice edge crosses the pad keep-out"
+    b_idx = LayerStack.two_layer().layer_enum_to_index(Layer.B_CU)
+    assert b_idx == 1
+    blocked_on_b = [e for e in crossing if model.edge_blocked(e, 1, net=99)]
+    assert blocked_on_b
+    for edge in blocked_on_b:
+        assert not model.edge_blocked(edge, 0, net=99), "SMD B.Cu pad leaked onto F.Cu"
+
+
+# ---------------------------------------------------------------------------
+# Property 6: refinement actually responds to RefineRegion density requests.
+# ---------------------------------------------------------------------------
+
+
+def test_refine_regions_densify_locally_not_globally() -> None:
+    bbox = (0.0, 0.0, 25.6, 25.6)
+    plain = OctilinearLattice(bbox, [], coarse=3.2)
+    refined = OctilinearLattice(bbox, [RefineRegion((10.0, 10.0, 12.0, 12.0), 0.4)], coarse=3.2)
+    assert len(refined.nodes) > len(plain.nodes)
+    # Far-away coarse cells are untouched: level-0 leaves survive far from
+    # the refine region.
+    coarse_leaves = [leaf for leaf in refined.leaves if leaf[0] == 0]
+    assert coarse_leaves, "refinement leaked into open space"
+    # Memory estimate scales with layers.
+    n2, m2, by2 = refined.memory_estimate(2)
+    n4, m4, by4 = refined.memory_estimate(4)
+    assert (n2, m2) == (n4, m4)
+    assert math.isclose(by4, 2 * by2)

--- a/tests/router/lattice/test_softstart_memory.py
+++ b/tests/router/lattice/test_softstart_memory.py
@@ -1,0 +1,45 @@
+"""Softstart rev-C lattice sizing proof (issue #4278 acceptance 5).
+
+The whole point of the epic (#4267) is breaking the uniform-grid memory
+wall: the grid needs 1.14 GB for softstart rev-C (160x100 mm, 4 layers);
+the lattice must stay at or under ~5% of that at default density.
+Routing softstart is NOT in scope for this phase (that is P4 #4271) --
+this is the substrate-size proof only.
+
+The board is a local-only external fixture (``boards/external/softstart``
+is a symlink that dangles in CI and fresh worktrees), so the test skips
+cleanly when it is absent -- exactly like the chorus fixtures.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.router.lattice.pathfinder import LatticePathfinder
+from kicad_tools.router.layers import LayerStack
+
+_REPO = Path(__file__).resolve().parents[3]
+_SOFTSTART = _REPO / "boards/external/softstart/output_revc/softstart_revc.kicad_pcb"
+
+_GRID_BYTES = 1.14e9  # measured grid footprint for softstart rev-C (#4267 P0)
+_BUDGET = 0.05  # "<= ~5 % of the grid" (issue #4278 acceptance 5)
+
+
+@pytest.mark.skipif(not _SOFTSTART.exists(), reason="local-only softstart fixture absent")
+def test_softstart_revc_lattice_memory_under_five_percent_of_grid() -> None:
+    text = _SOFTSTART.read_text()
+    pf = LatticePathfinder.from_board(text, layer_stack=LayerStack.four_layer_all_signal())
+    lattice = pf.build()
+    assert pf.lattice_builds == 1
+    assert pf.num_layers == 4
+
+    n_nodes, n_edges, n_bytes = lattice.memory_estimate(pf.num_layers)
+    assert n_nodes > 10_000, "suspiciously small lattice -- did the board load?"
+    ratio = n_bytes / _GRID_BYTES
+    assert ratio <= _BUDGET, (
+        f"softstart lattice {n_bytes / 1e6:.1f} MB = {100 * ratio:.2f}% of the "
+        f"1.14 GB grid, above the {100 * _BUDGET:.0f}% budget "
+        f"({n_nodes} nodes, {n_edges} edges/layer)"
+    )

--- a/tests/router/lattice/test_stubs.py
+++ b/tests/router/lattice/test_stubs.py
@@ -1,0 +1,120 @@
+"""Pad dogleg-stub property tests (issue #4278).
+
+Stubs are the pad<->lattice bridge: 45-degree-legal two-segment doglegs
+from the EXACT pad position to nearby unmasked lattice nodes, every leg
+clearance-checked before acceptance (the subgrid reject-and-retry
+discipline; standing #3906 lesson).  These properties are pinned before
+the routing tests, per the issue's mandated order.
+"""
+
+from __future__ import annotations
+
+from kicad_tools.router.lattice.geometry import dist
+from kicad_tools.router.lattice.pathfinder import LatticePathfinder
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.quantize import is_45_aligned
+from kicad_tools.router.rules import DesignRules
+
+
+def _pad(
+    x: float,
+    y: float,
+    net: int,
+    *,
+    ref: str,
+    layer: Layer = Layer.F_CU,
+    width: float = 1.0,
+    height: float = 1.0,
+    through: bool = False,
+) -> Pad:
+    return Pad(
+        x=x,
+        y=y,
+        width=width,
+        height=height,
+        net=net,
+        net_name=f"N{net}",
+        layer=layer,
+        ref=ref,
+        pin="1",
+        through_hole=through,
+        drill=0.3 if through else 0.0,
+    )
+
+
+def _pathfinder(pads: list[Pad], size: float = 20.0) -> LatticePathfinder:
+    outline = [(0.0, 0.0), (size, 0.0), (size, size), (0.0, size)]
+    return LatticePathfinder(outline, pads, DesignRules())
+
+
+def test_stub_legs_are_45_legal_and_start_at_exact_pad_position() -> None:
+    pad = _pad(7.3, 9.1, net=1, ref="U1")  # deliberately off-lattice
+    pf = _pathfinder([pad])
+    stubs = pf.pad_stubs(pad, net=1)
+    assert stubs, "open board: pad must attach"
+    for _key, _layer, poly, length in stubs:
+        assert poly[0] == (pad.x, pad.y), "pad end must stay exact (no quantization)"
+        assert len(poly) <= 3, "dogleg is at most two legs"
+        for a, b in zip(poly, poly[1:], strict=False):
+            assert is_45_aligned(b[0] - a[0], b[1] - a[1]), f"off-angle stub leg {a}->{b}"
+        assert length > 0.0
+
+
+def test_stub_lands_on_lattice_node_and_respects_pad_layer() -> None:
+    pad = _pad(7.3, 9.1, net=1, ref="U1", layer=Layer.B_CU)
+    pf = _pathfinder([pad])
+    lattice = pf.build()
+    b_idx = pf.layer_stack.layer_enum_to_index(Layer.B_CU)
+    stubs = pf.pad_stubs(pad, net=1)
+    assert stubs
+    for key, layer, poly, _length in stubs:
+        assert layer == b_idx, "SMD pad stubs must stay on the pad's own layer"
+        assert dist(poly[-1], lattice.node_point(key)) < 1e-9
+
+
+def test_through_hole_pad_attaches_on_every_layer() -> None:
+    pad = _pad(10.0, 10.0, net=1, ref="J1", through=True)
+    pf = _pathfinder([pad])
+    stubs = pf.pad_stubs(pad, net=1)
+    layers = {layer for _k, layer, _p, _l in stubs}
+    assert layers == {0, 1}, f"PTH pad must offer stubs on all layers, got {layers}"
+
+
+def test_stub_legs_are_clearance_checked_against_other_net_pads() -> None:
+    # A wall of other-net pads to the east: accepted stubs must not cross it.
+    pad = _pad(10.0, 10.0, net=1, ref="U1")
+    wall = [
+        _pad(11.2, 10.0 + dy, net=2, ref=f"W{i}", width=0.8, height=3.0)
+        for i, dy in enumerate((-3.0, 0.0, 3.0))
+    ]
+    pf = _pathfinder([pad] + wall)
+    obstacles = pf.obstacles
+    stubs = pf.pad_stubs(pad, net=1)
+    assert stubs, "west side is open: pad must still attach"
+    for _key, layer, poly, _length in stubs:
+        for a, b in zip(poly, poly[1:], strict=False):
+            assert not obstacles.segment_blocked(a, b, layer, net=1), (
+                f"accepted stub leg {a}->{b} crosses an other-net keep-out"
+            )
+
+
+def test_stub_blocked_by_committed_copper_declines_never_blind_fits() -> None:
+    """#3906-modeled: committed OTHER-net copper running straight through the
+    pad's escape field must yield NO stubs -- every candidate dogleg would
+    violate the copper gap, so the engine declines instead of emitting a
+    short.  (A blind fit that ignored the committed model would happily
+    return the geometrically-shortest dogleg here.)"""
+    pad = _pad(10.0, 10.0, net=1, ref="U1", width=0.6, height=0.6)
+    pf = _pathfinder([pad])
+    committed = pf._fresh_committed()
+    # Other-net trace directly through the pad centre, spanning well past the
+    # stub search radius on the pad's layer.
+    committed.add_run(0, [(2.0, 10.0), (18.0, 10.0)], net=2, half_width=0.1)
+
+    stubs = pf.pad_stubs(pad, net=1, committed=committed)
+    assert stubs == [], "stub across committed other-net copper must decline"
+
+    # Without the committed copper the same pad attaches fine (the decline
+    # above is the obstacle consult, not a general inability).
+    assert pf.pad_stubs(pad, net=1)

--- a/tests/test_manufacturer_propagation_lint.py
+++ b/tests/test_manufacturer_propagation_lint.py
@@ -101,6 +101,20 @@ _ALLOWLIST: dict[str, dict[str, tuple[int, str]]] = {
     "router/mesh/pathfinder.py": {
         "MeshPathfinder.__init__": (1, "MeshPathfinder.__init__ rules-arg default fallback"),
     },
+    # Lattice-engine pathfinder (#4278) -- identical constructor rules-arg
+    # default fallback shape as MeshPathfinder/Autorouter.  The dispatch
+    # caller, ``Autorouter._ensure_lattice_pathfinder`` in router/core.py,
+    # always passes ``self.rules`` (manufacturer already propagated); the
+    # bare default is only reached by direct unit-test construction or
+    # ``LatticePathfinder.from_board(rules=None)``, where no manufacturer
+    # context exists to thread.  Via-in-pad is additionally moot for this
+    # engine (vias land only on free-space lattice nodes, never in pads).
+    "router/lattice/pathfinder.py": {
+        "LatticePathfinder.__init__": (
+            1,
+            "LatticePathfinder.__init__ rules-arg default fallback",
+        ),
+    },
     # Library API: ``route_pcb()`` synthesises default rules only when
     # the caller explicitly passes ``rules=None`` (no PCB rules either).
     # The CLI always supplies its own rules with manufacturer wired in.


### PR DESCRIPTION
Closes #4278 (epic #4267, P2.7)

Implements the adaptive octilinear lattice as a **third route engine** — `--route-engine {grid,mesh,lattice}`, default `grid` unchanged — per the spike-validated design on #4267. The design point: every lattice edge is 0/45/90/135 **by construction**, so an A* path over the lattice IS 45°-legal copper. There is **no funnel stage and no octilinear post-fit stage** in this pipeline; emission goes straight through the #3907 `Segment` choke + `merge_collinear`.

## What's in the diff

**New package `src/kicad_tools/router/lattice/`** (sibling of `mesh/`, which is untouched):
- `quadtree.py` — balanced quadtree lattice generator. **≤1-level jump invariant** (load-bearing for octilinearity across T-junctions) enforced to a fixpoint; density is a per-region parameter (`RefineRegion`) with pad-pitch-derived fine sizes (risk 5 from the issue). Built **once per board**.
- `obstacles.py` — static per-layer pad masks (SMD masks its own layer, PTH masks all; same-net pads resolved at query time, no per-net rebuild) + a **geometric** committed-copper model (segment-distance checks against real gaps — discrete occupancy alone could ship a clearance violation between adjacent fine lattice rows; the #3906 lesson).
- `pathfinder.py` — exact-pad dogleg stubs (`quantize.dogleg_points`, every leg clearance-checked, reject-and-retry), negotiated A* over the (node, layer) graph (octilinear costs + `via_cost`, PathFinder-style failed-net history using `rules.cost_congestion`, hard geometric blocking within a pass so a conflicted net **declines, never crosses**), emission to ordinary `Route`.

**Dispatch** — exactly at the P1 seam: `--route-engine` choices extended in `cli/parser.py` + the `route_cmd.py` mirror (parser-parity test green); one new branch in `Autorouter.route_net` beside `_route_net_mesh` with the same netset-cache discipline.

**Tests `tests/router/lattice/`** — property tests written FIRST (octilinearity incl. T-junctions in float and exact integer-key space; balance invariant; planarity; per-layer masking; stub 45°-legality + clearance), then negotiation/acceptance/dispatch/memory tests. 29 passed + 1 skip (softstart fixture is local-only and its symlink dangles in worktrees — same pattern as the chorus fixtures; validated against the real path below).

## Measured acceptance (honest numbers)

| Criterion | Result |
|---|---|
| Board 02 charlieplex, REAL negotiation + REAL `kicad-cli pcb drc --refill-zones` | **24/24 connections routed, 0 DRC errors** (converged in 1 pass; floor was ≥17/24, 0-shorts hard). Base board: 0 errors; routed board: 0 errors. |
| CLI end-to-end (board 02) — **corrected after Judge verification** | Under the default `--strategy negotiated`, `--route-engine lattice` is **silently inert**: `route_all_negotiated` bypasses the `route_net` dispatch seam (`core.py:2515-2520`), so the earlier "8/8, DRC 0" run was **grid copper** (grid-vs-lattice outputs identical except UUIDs; same pre-existing P1 seam property as mesh — follow-up filed). Through `--strategy basic` (the only stock strategy reaching the seam) the lattice genuinely engages: **7/8 nets, all-octilinear copper, `kicad-cli pcb drc --refill-zones`: 0 errors**. The 8th (NODE_A) routes clean but the post-route optimize/nudge pass corrupts its copper into a cross-net short, which the #3989 backstop correctly demotes (pre-existing optimizer issue, follow-up filed). Mesh at the same seam lands 3/8. |
| `lattice_builds == 1` | Asserted in tests across the whole negotiation (mirrors the mesh `triangulation_calls` discipline) |
| `--route-engine grid` / `--route-engine mesh` dormant | **Byte-identical** main-vs-branch on the voltage-divider board with `--seed 42`, both engines (`cmp` clean); full `tests/router/mesh/` suite green (59 passed); dispatch tests assert neither path constructs lattice state |
| Softstart rev-C lattice memory (4L, real `LayerStack`) | **67,007 nodes / 195,438 edges per layer = 31.4 MB ×4L = 2.76 %** of the grid's 1.14 GB (budget ≤ ~5 %; spike said 2.7 %) |
| N-layer | 4-layer `LayerStack` exercised in tests; via edges adjacent-layer only; a 4-layer F→B transition traverses every intermediate layer state and emits ONE deduplicated through-via |
| Never-ship-a-short (#3906-modeled) | Stub across committed other-net copper declines (test); sealed-box pad declines with a diagnosis (test); two-nets-one-slot test asserts no different-net copper closer than the copper gap |
| Via-in-pad / blind-buried | **N/A-by-construction** and documented (package + pathfinder docstrings): vias land only on free-space lattice nodes, so via-in-pad cannot occur; only through-via edges are generated |

## Deviations / notes

- `rules.congestion_threshold` is documented as degenerate for this engine (capacity-1 resources: any sharing is over-threshold, blocking is hard rather than cost-mediated); `rules.cost_congestion` is the history increment unit, mirroring the mesh negotiator.
- On a 4-layer stack a multi-layer dip pays `via_cost` per adjacent-layer hop while physically being one through-via — a mild cost overcount, documented in the A* comment.
- Board outline = Edge.Cuts bbox (same contract and rationale as the mesh engine's P1 outline reader).
- `tests/test_manufacturer_propagation_lint.py` gets a scope-keyed allowlist entry for `LatticePathfinder.__init__` (identical rules-arg default-fallback shape as `MeshPathfinder.__init__`; the dispatch caller always passes `self.rules`).

## Gates run

- `tests/router/lattice/` under `-W error::UserWarning`: 29 passed, 1 skipped (local-only fixture)
- `tests/router/mesh/`: 59 passed (mesh untouched)
- `tests/test_manufacturer_propagation_lint.py`, `tests/test_build_parser_parity.py`, `tests/test_cli.py`: green
- `uv run ruff check` + `ruff format --check` on all touched files: clean
- `uv run python scripts/ci/check_mypy_baseline.py`: **0 new errors**, baseline untouched
- `uv run kct build-native` first in the fresh worktree (grid byte-identity runs used the C++ backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
