### PR TITLE
fix(cli): hard-error on --route-engine mesh/lattice with incompatible strategies

### DIFF
--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -3519,16 +3519,20 @@ def _add_route_parser(subparsers) -> None:
         choices=["grid", "mesh", "lattice"],
         default="grid",
         help=(
-            "Routing substrate (issues #4268/#4278), orthogonal to --backend "
-            "and --strategy: 'grid' = uniform-grid A* (default, unchanged); "
+            "Routing substrate (issues #4268/#4278), orthogonal to --backend: "
+            "'grid' = uniform-grid A* (default, unchanged); "
             "'mesh' = navmesh router (poly2tri CDT + funnel + clearance-aware "
             "45deg fit, multi-net portal negotiation); 'lattice' = adaptive "
             "octilinear lattice (balanced quadtree, paths are 45deg-legal by "
             "construction, negotiated multi-net, through-vias at free-space "
-            "lattice nodes). Mesh and lattice are experimental engines; grid "
-            "remains the production default. (The name 'strategy' was already "
-            "taken by the negotiation-algorithm flag above, so the substrate "
-            "selector is --route-engine.)"
+            "lattice nodes). Mesh and lattice are experimental engines that "
+            "run their own whole-netset negotiation and REQUIRE --strategy "
+            "basic; combining them with the default negotiated strategy, "
+            "monte-carlo, evolutionary, --two-phase, --multi-resolution, or "
+            "--escape-routing is rejected (issue #4280). Grid remains the "
+            "production default and works with every strategy. (The name "
+            "'strategy' was already taken by the negotiation-algorithm flag "
+            "above, so the substrate selector is --route-engine.)"
         ),
     )
     route_parser.add_argument(

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -7490,6 +7490,83 @@ def _resolve_escape_routing_flag(args) -> bool | None:
     return None
 
 
+def _validate_route_engine_strategy(args) -> int:
+    """Hard compatibility gate for ``--route-engine mesh|lattice`` (#4280).
+
+    The mesh/lattice engines dispatch through ``Autorouter.route_net`` --
+    the ONLY seam that consults the engine selector (``core.py``
+    ``route_net``).  Every other stock strategy/modifier bypasses that seam:
+
+    - ``--strategy negotiated`` (the DEFAULT) goes ``route_all_negotiated``
+      -> ``_route_net_negotiated``, which builds a grid ``NegotiatedRouter``
+      directly and never calls ``route_net`` -- the engine flag is silently
+      inert and the run ships grid copper labeled as mesh/lattice output.
+    - ``--strategy monte-carlo`` / ``evolutionary`` reach the seam but the
+      engines negotiate the whole netset ONCE and cache; per-trial resets
+      never clear that cache, so every trial after the first is vacuous.
+    - ``--two-phase`` and ``--multi-resolution`` wrap or bypass the seam.
+    - Escape routing commits grid escape stubs the engines' whole-netset
+      negotiation cannot see (mixed/incoherent copper).
+
+    Rather than silently shipping grid copper (or silently swapping the
+    user's negotiation algorithm), any such combination is rejected loudly
+    BEFORE any board loading or output writing.  ``--strategy basic`` is
+    the supported combination.
+
+    Escape AUTO-detect (dense packages, no flag) is not an error -- the
+    user didn't ask for it -- so it is forced off with a printed notice by
+    stamping ``args.no_escape_routing``; every dispatch site resolves the
+    tri-state via :func:`_resolve_escape_routing_flag`, so one stamp covers
+    all of them.
+
+    Returns 0 when the combination is valid (ALWAYS for ``--route-engine
+    grid`` -- this gate is a strict no-op on the production default), or 2
+    (usage error) with a message on stderr naming the remedy.
+    """
+    engine = getattr(args, "route_engine", "grid")
+    if engine == "grid":
+        return 0
+
+    conflicts: list[str] = []
+    if args.strategy != "basic":
+        default_note = " (the default)" if args.strategy == "negotiated" else ""
+        conflicts.append(f"--strategy {args.strategy}{default_note}")
+    if getattr(args, "two_phase", False):
+        conflicts.append("--two-phase")
+    if getattr(args, "multi_resolution", False):
+        conflicts.append("--multi-resolution")
+    if _resolve_escape_routing_flag(args) is True:
+        conflicts.append("--escape-routing")
+
+    if conflicts:
+        print(
+            f"Error: --route-engine {engine} is incompatible with "
+            f"{', '.join(conflicts)}.\n"
+            f"The {engine} engine runs its own whole-netset negotiation and "
+            "dispatches only through the basic per-net routing path; the "
+            "negotiated/monte-carlo/evolutionary strategies and the "
+            "--two-phase/--multi-resolution/--escape-routing modifiers "
+            "bypass that path, so the engine selection would be silently "
+            "ignored and grid copper shipped (issue #4280).\n"
+            "Supported combination:\n"
+            f"    kct route <board> --route-engine {engine} --strategy basic",
+            file=sys.stderr,
+        )
+        return 2
+
+    # engine != grid with --strategy basic: suppress escape auto-detect
+    # (tri-state None -> forced off).  Explicit --no-escape-routing needs
+    # no notice; explicit --escape-routing was rejected above.
+    if _resolve_escape_routing_flag(args) is None:
+        args.no_escape_routing = True
+        if not getattr(args, "quiet", False):
+            print(
+                f"  Escape routing: auto-detect disabled (--route-engine {engine} "
+                "performs whole-netset negotiation that cannot see grid escape stubs)"
+            )
+    return 0
+
+
 def _build_diffpair_config(args):
     """Build a ``DifferentialPairConfig`` from parsed CLI args, or ``None``.
 
@@ -8738,14 +8815,18 @@ def main(argv: list[str] | None = None) -> int:
         choices=["grid", "mesh", "lattice"],
         default="grid",
         help=(
-            "Routing substrate (issues #4268/#4278), orthogonal to --backend "
-            "and --strategy: 'grid' = uniform-grid A* (default, unchanged); "
+            "Routing substrate (issues #4268/#4278), orthogonal to --backend: "
+            "'grid' = uniform-grid A* (default, unchanged); "
             "'mesh' = navmesh router (poly2tri CDT + funnel + clearance-aware "
             "45deg fit, multi-net portal negotiation); 'lattice' = adaptive "
             "octilinear lattice (balanced quadtree, paths are 45deg-legal by "
             "construction, negotiated multi-net, through-vias at free-space "
-            "lattice nodes). Mesh and lattice are experimental engines; grid "
-            "remains the production default."
+            "lattice nodes). Mesh and lattice are experimental engines that "
+            "run their own whole-netset negotiation and REQUIRE --strategy "
+            "basic; combining them with the default negotiated strategy, "
+            "monte-carlo, evolutionary, --two-phase, --multi-resolution, or "
+            "--escape-routing is rejected (issue #4280). Grid remains the "
+            "production default and works with every strategy."
         ),
     )
     parser.add_argument(
@@ -9452,6 +9533,16 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     args = parser.parse_args(argv)
+
+    # Issue #4280: hard compatibility gate for --route-engine mesh|lattice.
+    # Runs before ANY other work (env stamping, board loading, escalation
+    # dispatch) so an inert engine flag can never silently ship grid copper.
+    # This single chokepoint covers every routing path -- all five
+    # load_pcb_for_routing sites and the escalation wrappers are reached
+    # from main().  Strict no-op for --route-engine grid (the default).
+    _engine_gate_rc = _validate_route_engine_strategy(args)
+    if _engine_gate_rc != 0:
+        return _engine_gate_rc
 
     # Issue #3033 / #3062: When --strict-in-pad-clearance is set, stamp the
     # env var so EscapeRouter (lazily constructed several layers below the

--- a/tests/test_route_engine_strategy_gate.py
+++ b/tests/test_route_engine_strategy_gate.py
@@ -1,0 +1,280 @@
+"""Tests for the ``--route-engine mesh|lattice`` compatibility gate (#4280).
+
+``--route-engine mesh|lattice`` used to be SILENTLY INERT under the default
+``--strategy negotiated``: ``route_all_negotiated`` -> ``_route_net_negotiated``
+builds a grid ``NegotiatedRouter`` directly and never consults the engine
+selector, so a "lattice" run shipped grid copper identical-except-UUIDs to a
+grid run (the judge's board-02 repro).  Monte-carlo/evolutionary reach the
+dispatch seam but are cache-vacuous, and --two-phase / --multi-resolution /
+escape routing bypass or corrupt it.
+
+``kct route`` therefore hard-errors (exit 2) BEFORE any board loading when
+``--route-engine != grid`` is combined with any strategy/modifier other than
+``--strategy basic``, and force-disables escape auto-detect (with a notice)
+for the supported combination.  ``--route-engine grid`` is a strict no-op
+through the gate.
+
+Boards are built fully synthetically (gr_rect Edge.Cuts outline + one 0402),
+mirroring ``test_route_offboard_gate.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli import main as kct_main
+from kicad_tools.cli.route_cmd import (
+    _resolve_escape_routing_flag,
+    _validate_route_engine_strategy,
+)
+from kicad_tools.cli.route_cmd import main as route_main
+
+BOARD = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general
+    (thickness 1.6)
+  )
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup
+    (pad_to_mask_clearance 0)
+  )
+  (net 0 "")
+  (net 1 "NET1")
+  (gr_rect (start 100 100) (end 120 110)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000010")
+    (at 110 105)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "NET1"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "NET1"))
+  )
+)
+"""
+
+
+@pytest.fixture
+def pcb(tmp_path: Path) -> Path:
+    board = tmp_path / "gate.kicad_pcb"
+    board.write_text(BOARD)
+    return board
+
+
+def _gate_args(**overrides) -> argparse.Namespace:
+    """Namespace with the gate-relevant flags at their parser defaults."""
+    base = {
+        "route_engine": "grid",
+        "strategy": "negotiated",
+        "two_phase": False,
+        "multi_resolution": False,
+        "escape_routing": None,
+        "no_escape_routing": False,
+        "quiet": False,
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+# Every incompatible strategy/modifier combination (acceptance 1/5): each must
+# hard-error at the CLI boundary -- no combination may silently ship grid
+# copper labeled as mesh/lattice output.
+INCOMPATIBLE_COMBOS = [
+    pytest.param([], id="default-negotiated"),
+    pytest.param(["--strategy", "negotiated"], id="explicit-negotiated"),
+    pytest.param(["--strategy", "monte-carlo"], id="monte-carlo"),
+    pytest.param(["--strategy", "evolutionary"], id="evolutionary"),
+    pytest.param(["--strategy", "basic", "--two-phase"], id="basic-two-phase"),
+    pytest.param(
+        ["--strategy", "basic", "--multi-resolution"],
+        id="basic-multi-resolution",
+    ),
+    pytest.param(
+        ["--strategy", "basic", "--escape-routing"],
+        id="basic-explicit-escape",
+    ),
+    pytest.param(
+        ["--strategy", "negotiated", "--two-phase"],
+        id="negotiated-two-phase",
+    ),
+]
+
+
+class TestIncompatibleCombosHardError:
+    """Acceptance 1 + 5: every (engine != grid) x incompatible combo fails loudly."""
+
+    @pytest.mark.parametrize("engine", ["mesh", "lattice"])
+    @pytest.mark.parametrize("extra", INCOMPATIBLE_COMBOS)
+    def test_hard_error_no_output(self, pcb: Path, capsys, engine: str, extra: list[str]):
+        rc = route_main([str(pcb), "--route-engine", engine, *extra])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert f"--route-engine {engine}" in err
+        assert "--strategy basic" in err
+        assert "#4280" in err
+        # The gate fires before ANY board loading or routing: no output file
+        # (default <input>_routed.kicad_pcb or anything else) may be written.
+        outputs = [p for p in pcb.parent.iterdir() if p != pcb]
+        assert outputs == [], f"gate must not write outputs, found {outputs}"
+
+    @pytest.mark.parametrize("engine", ["mesh", "lattice"])
+    def test_gate_fires_before_file_validation(self, tmp_path: Path, capsys, engine: str):
+        """Flag incompatibility is reported even for a nonexistent board --
+        proof the gate runs before any filesystem/board work."""
+        rc = route_main([str(tmp_path / "missing.kicad_pcb"), "--route-engine", engine])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "--strategy basic" in err
+        assert "not found" not in err
+
+    def test_outer_kct_entry_hard_errors(self, pcb: Path, capsys):
+        """The real ``kct route`` dispatch path funnels through the same gate
+        (``commands/routing.py`` forwards --route-engine and --strategy)."""
+        rc = kct_main(["route", str(pcb), "--route-engine", "lattice"])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "--route-engine lattice" in err
+        assert "--strategy basic" in err
+
+    def test_error_names_all_conflicts(self, pcb: Path, capsys):
+        rc = route_main(
+            [
+                str(pcb),
+                "--route-engine",
+                "lattice",
+                "--strategy",
+                "monte-carlo",
+                "--two-phase",
+                "--multi-resolution",
+                "--escape-routing",
+            ]
+        )
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "--strategy monte-carlo" in err
+        assert "--two-phase" in err
+        assert "--multi-resolution" in err
+        assert "--escape-routing" in err
+
+
+class TestGridIsUntouched:
+    """Acceptance 4: the gate is a strict no-op for --route-engine grid."""
+
+    def test_validator_noop_for_grid(self, capsys):
+        """Grid returns 0 immediately and mutates NOTHING -- even with every
+        incompatible modifier set (byte-identical default path)."""
+        args = _gate_args(
+            route_engine="grid",
+            strategy="monte-carlo",
+            two_phase=True,
+            multi_resolution=True,
+            escape_routing=True,
+        )
+        before = vars(args).copy()
+        assert _validate_route_engine_strategy(args) == 0
+        assert vars(args) == before
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert captured.err == ""
+
+    @pytest.mark.parametrize(
+        "extra",
+        [
+            [],
+            ["--route-engine", "grid"],
+            ["--route-engine", "grid", "--strategy", "monte-carlo"],
+            ["--route-engine", "grid", "--two-phase", "--escape-routing"],
+        ],
+    )
+    def test_grid_cli_passes_gate(self, pcb: Path, capsys, extra: list[str]):
+        """Grid runs (implicit or explicit) never trip the gate (--dry-run
+        short-circuits before routing, as in test_route_offboard_gate.py)."""
+        rc = route_main([str(pcb), "--dry-run", *extra])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "#4280" not in captured.err
+        assert "Escape routing: auto-detect disabled" not in captured.out
+
+
+class TestEscapeAutoDetectSuppression:
+    """Acceptance 3: escape AUTO-detect is forced off (with notice) for
+    engine != grid + --strategy basic."""
+
+    @pytest.mark.parametrize("engine", ["mesh", "lattice"])
+    def test_auto_escape_forced_off_with_notice(self, capsys, engine: str):
+        args = _gate_args(route_engine=engine, strategy="basic")
+        assert _resolve_escape_routing_flag(args) is None  # auto-detect
+        assert _validate_route_engine_strategy(args) == 0
+        # All dispatch sites resolve the tri-state through
+        # _resolve_escape_routing_flag, so this single stamp guarantees the
+        # auto-detect branch in _should_use_escape_routing is unreachable.
+        assert _resolve_escape_routing_flag(args) is False
+        out = capsys.readouterr().out
+        assert "Escape routing: auto-detect disabled" in out
+        assert engine in out
+
+    def test_explicit_no_escape_no_notice(self, capsys):
+        args = _gate_args(route_engine="lattice", strategy="basic", no_escape_routing=True)
+        assert _validate_route_engine_strategy(args) == 0
+        assert "Escape routing" not in capsys.readouterr().out
+
+    def test_quiet_suppresses_notice_but_still_forces_off(self, capsys):
+        args = _gate_args(route_engine="lattice", strategy="basic", quiet=True)
+        assert _validate_route_engine_strategy(args) == 0
+        assert _resolve_escape_routing_flag(args) is False
+        assert capsys.readouterr().out == ""
+
+
+class TestWorkingCombosEndToEnd:
+    """Acceptance 2: --strategy basic + engine still routes end-to-end."""
+
+    def _route(self, pcb: Path, engine: str) -> Path:
+        out = pcb.parent / f"routed_{engine}.kicad_pcb"
+        rc = route_main(
+            [
+                str(pcb),
+                "--route-engine",
+                engine,
+                "--strategy",
+                "basic",
+                "--layers",
+                "2",
+                "--skip-drc",
+                "-o",
+                str(out),
+            ]
+        )
+        assert rc == 0
+        assert out.exists()
+        assert "(segment" in out.read_text()
+        return out
+
+    def test_lattice_basic_routes(self, pcb: Path, capsys):
+        self._route(pcb, "lattice")
+        out = capsys.readouterr().out
+        # The gate ran (engine recognized), suppressed auto-escape, and
+        # routing completed through the lattice engine.
+        assert "Escape routing: auto-detect disabled" in out
+
+    def test_mesh_basic_routes(self, pcb: Path, capsys):
+        pytest.importorskip("kicad_tools.router.router_cpp")
+        self._route(pcb, "mesh")
+        out = capsys.readouterr().out
+        assert "Escape routing: auto-detect disabled" in out
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Closes #4280

## What

`--route-engine mesh|lattice` was **silently inert** under the default `--strategy negotiated`: `route_all_negotiated` -> `_route_net_negotiated` builds a grid `NegotiatedRouter` directly and never consults the engine selector (`Autorouter.route_net` is the only dispatch seam), so a "lattice" run shipped grid copper identical-except-UUIDs to a grid run (the judge's board-02 repro). Monte-carlo/evolutionary reach the seam but are cache-vacuous; `--two-phase` / `--multi-resolution` / escape routing bypass or corrupt it.

Per the curation's settled recommendation, this implements **option (b): a loud validator**, not silent grid copper and not an auto-switch of the user's strategy.

## How

**`_validate_route_engine_strategy(args)`** (`src/kicad_tools/cli/route_cmd.py`), called as the FIRST thing in `route_cmd.main()` after `parse_args` — the single chokepoint every routing path flows through (all five `load_pcb_for_routing` sites and the size/mfr-tier/auto-layers/adaptive-rules escalation wrappers are reached from `main()`; the outer `kct route` entry funnels through it via `commands/routing.py` sub-argv forwarding, which forwards both `--strategy` and `--route-engine`):

- **engine != grid** with `--strategy != basic`, `--two-phase`, `--multi-resolution`, or **explicit** `--escape-routing` → **exit 2** with a message naming every conflicting flag and the working combination (`kct route <board> --route-engine <engine> --strategy basic`), before any board loading or output writing.
- **engine != grid + `--strategy basic`**: escape **auto**-detect is forced off with a one-line printed notice (a notice, not an error — the user didn't ask for it) by stamping `args.no_escape_routing`; every dispatch site resolves the tri-state through `_resolve_escape_routing_flag`, so one stamp covers all of them.
- **`--route-engine grid` (the default)**: strict no-op — early return, zero mutation, zero output (asserted byte-for-byte in the tests via a `vars(args)` snapshot).

**Help text** (`cli/parser.py` + the mirrored definition in `route_cmd.py`): the false claim that `--route-engine` is "orthogonal to --backend **and --strategy**" is corrected to document the `--strategy basic` requirement and the rejected combinations. Orthogonality to `--backend` (true) is retained.

## The `_post_negotiation_sweep` landmine (curator's landmine #1) — confirmed unreachable

`route_all_negotiated` -> `_post_negotiation_sweep` -> `self.route_net(...)` (`core.py:12368`) is a hidden route into the dispatch seam that would trigger a full-board lattice/mesh netset negotiation mid-sweep and commit mixed-engine copper on top of grid routes. With this gate in place it is unreachable for engine != grid:

- Every CLI entry into `route_all_negotiated` / `route_all_two_phase` / `route_with_escape` sits behind `args.strategy == "negotiated"` checks (route_cmd.py dispatch blocks) or the two-phase/escape modifiers — all inside `main()`, all now hard-errored for engine != grid. Engine != grid can only run `--strategy basic`, which dispatches `route_all` -> `route_net` and never calls `route_all_negotiated`.
- Non-CLI callers of `route_all_negotiated` (`benchmark/runner.py:144`, `router/adaptive.py:246` — `AdaptiveAutorouter._create_autorouter`, `core.py:522` — the monte-carlo trial worker's reconstructed router, `router/auto_pour.py`) all construct their own routers **without** threading `--route-engine`, i.e. default grid strategy. No other entry reaches the sweep with engine != grid, so no additional guard was added (keeping the diff to validator + help text + tests, per the curation).

## Out of scope (per curation)

Option (a) — route_all-level dispatch making "negotiated + lattice" use the lattice's own `route_netset` negotiator — and the monte-carlo/evolutionary per-trial cache invalidation (`_reset_for_new_trial` never clears `_lattice_net_routes`/`_mesh_net_routes`). Both are noted in the issue for P4 #4271 / follow-up. #4281 (post-route optimizer corrupting non-grid copper) is tracked separately.

## Acceptance criteria coverage (tests/test_route_engine_strategy_gate.py, 31 tests)

1. **Every incompatible combo fails loudly** — parametrized over {mesh, lattice} x {default negotiated, explicit negotiated, monte-carlo, evolutionary, basic+--two-phase, basic+--multi-resolution, basic+--escape-routing, negotiated+--two-phase}: exit 2, message names the engine flag and `--strategy basic`, and **no output file is written** (asserted by directory listing). The gate fires even for a nonexistent board path — proof it runs before any filesystem/board work. Also verified through the real `kct route` outer entry.
2. **Working combos untouched** — `--route-engine lattice --strategy basic` and `--route-engine mesh --strategy basic` route the synthetic board end-to-end through the CLI (exit 0, `(segment` in output); `tests/router/lattice/test_engine_dispatch.py` + the full mesh/lattice suites stay green (99 passed, 1 skipped).
3. **Escape auto-detect suppressed with notice** under engine != grid + basic; explicit `--no-escape-routing` produces no redundant notice; `--quiet` suppresses the notice but still forces auto-detect off.
4. **Grid byte-identical** — validator no-op asserted with a full `vars(args)` before/after snapshot even with every incompatible modifier set; grid CLI runs (implicit and explicit, with modifiers) never trip the gate.
5. **Parametrized no-silent-grid-copper test** — item 1's matrix is exactly this.
6. **Help text corrected** in both parsers.

## Gates

- `uv run kct build-native` — C++ backend built in the worktree
- `tests/test_route_engine_strategy_gate.py` — 31 passed
- `tests/router/mesh/` + `tests/router/lattice/` + `tests/test_cli_parser_drift.py` + `tests/test_route_offboard_gate.py` — 99 passed, 1 skipped
- `tests/test_route_cmd_success_output.py` + `tests/test_route_dry_run_analytical_plan_4263.py` (grid main-path regression) — passed
- `scripts/ci/check_mypy_baseline.py` — OK, 0 new errors (baseline untouched)
- MFR001 lint (`tests/test_manufacturer_propagation_lint.py`) — 9 passed
- `ruff check` + `ruff format --check` on changed files — clean

Refs: epic #4267, PR #4279 (filing source), #4159 (`_post_negotiation_sweep`), #4271 (P4, unblocked), #4281 (sibling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)