### PR TITLE
fix(router): gate optimize/DRC-nudge post-passes off for non-grid engines (#4281)

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 4261
-# Branch: feature/issue-4261
+# Issue: 4281
+# Branch: feature/issue-4281
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -971,6 +971,46 @@ def _finalize_committed_copper_or_demote(
         )
 
 
+def _engine_post_passes_enabled(
+    args: argparse.Namespace,
+    *,
+    quiet: bool = False,
+) -> bool:
+    """Whether the geometric post-passes (TraceOptimizer + DRC nudge) may run.
+
+    Issue #4281: the lattice and mesh engines commit copper by appending
+    to ``router.routes`` without calling ``_mark_route``, so after a
+    non-grid run the grid's obstacle model (cell occupancy + per-layer
+    segment R-tree) contains no route copper.  The optimizer's collision
+    checker is built from that empty model -- every move validates
+    "clear", even across another net's copper -- and the DRC-nudge repair
+    has no foreign-SEGMENT destination gate (only vias, #3028 Part A), so
+    both passes can corrupt correct non-grid copper into cross-net
+    shorts, which the #3989/#4208 backstop then (correctly) demotes:
+    completion loss instead of a shipped short.
+
+    Non-grid copper is 45-degree-legal by construction and negotiated at
+    capacity 1, so the passes' value there is nil while their validation
+    model is structurally blind: skip BOTH passes whenever
+    ``--route-engine`` is not ``grid``.  One shared predicate for all
+    four optimize+nudge call-site pairs (mirroring the
+    ``_finalize_committed_copper_or_demote`` shared-helper pattern).  The
+    #4208 backstop itself stays unconditional as defense in depth.
+    Eventual unification -- non-grid engines committing via
+    ``_mark_route`` plus a foreign-segment nudge destination gate -- is
+    out of scope here (see #4281 curation, option (b)).
+    """
+    engine = getattr(args, "route_engine", "grid") or "grid"
+    if engine == "grid":
+        return True
+    if not quiet:
+        print(
+            f"\n  Skipping optimize/nudge post-passes for --route-engine "
+            f"{engine}: non-grid copper is committed as-is (#4281)"
+        )
+    return False
+
+
 def _make_checkpoint_callback(
     pcb_path: Path,
     output_path: Path,
@@ -4410,8 +4450,12 @@ def route_with_layer_escalation(
         stall_label="layer escalation",
     )
 
+    # Issue #4281: the geometric post-passes (optimize + DRC nudge) are
+    # grid-engine-only -- lattice/mesh copper must not be touched.
+    _post_passes_enabled = _engine_post_passes_enabled(args, quiet=quiet)
+
     # Optimize traces
-    if not args.no_optimize and final_result.router.routes:
+    if _post_passes_enabled and not args.no_optimize and final_result.router.routes:
         from kicad_tools.router.optimizer import (
             OptimizationConfig,
             TraceOptimizer,
@@ -4457,8 +4501,9 @@ def route_with_layer_escalation(
             quiet=quiet,
         )
 
-    # Post-optimization DRC nudge pass
-    if final_result.router.routes:
+    # Post-optimization DRC nudge pass (#4281: gated like the optimizer --
+    # the nudge is NOT covered by --no-optimize, so it needs its own gate)
+    if _post_passes_enabled and final_result.router.routes:
         from kicad_tools.router.drc_nudge import drc_verify_and_nudge
 
         # Issue #2596: snapshot connectivity again before nudge.  The
@@ -4479,10 +4524,13 @@ def route_with_layer_escalation(
             quiet=quiet,
         )
 
-        # Issue #4208 (Unit 3): re-run the Unit-2 seg-seg finalize gate
-        # over the post-optimize/post-nudge copper.  An rtree-less
-        # optimizer can introduce a cross-net crossing the pre-optimize
-        # finalize gate never saw; demote it before the canonical write.
+    # Issue #4208 (Unit 3): re-run the Unit-2 seg-seg finalize gate
+    # over the post-optimize/post-nudge copper.  An rtree-less
+    # optimizer can introduce a cross-net crossing the pre-optimize
+    # finalize gate never saw; demote it before the canonical write.
+    # Issue #4281: unconditional -- runs even when the geometric
+    # post-passes are skipped for non-grid engines (defense in depth).
+    if final_result.router.routes:
         _finalize_committed_copper_or_demote(final_result.router, quiet=quiet)
 
     # Finalize: cleanup -> sexp -> stats (canonical ordering)
@@ -5086,8 +5134,12 @@ def route_with_rule_relaxation(
         print(f"\nWARNING: Design uses {args.manufacturer.upper()} minimum tolerances.")
         print("Consider adding layers for more manufacturing margin.")
 
+    # Issue #4281: the geometric post-passes (optimize + DRC nudge) are
+    # grid-engine-only -- lattice/mesh copper must not be touched.
+    _post_passes_enabled = _engine_post_passes_enabled(args, quiet=quiet)
+
     # Optimize traces
-    if not args.no_optimize and final_result.router.routes:
+    if _post_passes_enabled and not args.no_optimize and final_result.router.routes:
         from kicad_tools.router.optimizer import (
             OptimizationConfig,
             TraceOptimizer,
@@ -5130,8 +5182,9 @@ def route_with_rule_relaxation(
             quiet=quiet,
         )
 
-    # Post-optimization DRC nudge pass
-    if final_result.router.routes:
+    # Post-optimization DRC nudge pass (#4281: gated like the optimizer --
+    # the nudge is NOT covered by --no-optimize, so it needs its own gate)
+    if _post_passes_enabled and final_result.router.routes:
         from kicad_tools.router.drc_nudge import drc_verify_and_nudge
 
         # Issue #2596: snapshot connectivity before nudge.
@@ -5150,10 +5203,13 @@ def route_with_rule_relaxation(
             quiet=quiet,
         )
 
-        # Issue #4208 (Unit 3): re-run the Unit-2 seg-seg finalize gate
-        # over the post-optimize/post-nudge copper.  An rtree-less
-        # optimizer can introduce a cross-net crossing the pre-optimize
-        # finalize gate never saw; demote it before the canonical write.
+    # Issue #4208 (Unit 3): re-run the Unit-2 seg-seg finalize gate
+    # over the post-optimize/post-nudge copper.  An rtree-less
+    # optimizer can introduce a cross-net crossing the pre-optimize
+    # finalize gate never saw; demote it before the canonical write.
+    # Issue #4281: unconditional -- runs even when the geometric
+    # post-passes are skipped for non-grid engines (defense in depth).
+    if final_result.router.routes:
         _finalize_committed_copper_or_demote(final_result.router, quiet=quiet)
 
     # Finalize: cleanup -> sexp -> stats (canonical ordering)
@@ -7277,8 +7333,12 @@ def route_with_combined_escalation(
         print(f"\nWARNING: Design uses {args.manufacturer.upper()} minimum tolerances.")
         print("Consider redesigning placement for more margin.")
 
+    # Issue #4281: the geometric post-passes (optimize + DRC nudge) are
+    # grid-engine-only -- lattice/mesh copper must not be touched.
+    _post_passes_enabled = _engine_post_passes_enabled(args, quiet=quiet)
+
     # Optimize traces
-    if not args.no_optimize and final_result.router.routes:
+    if _post_passes_enabled and not args.no_optimize and final_result.router.routes:
         from kicad_tools.router.optimizer import (
             OptimizationConfig,
             TraceOptimizer,
@@ -7321,8 +7381,9 @@ def route_with_combined_escalation(
             quiet=quiet,
         )
 
-    # Post-optimization DRC nudge pass
-    if final_result.router.routes:
+    # Post-optimization DRC nudge pass (#4281: gated like the optimizer --
+    # the nudge is NOT covered by --no-optimize, so it needs its own gate)
+    if _post_passes_enabled and final_result.router.routes:
         from kicad_tools.router.drc_nudge import drc_verify_and_nudge
 
         # Issue #2596: snapshot connectivity before nudge.
@@ -7341,10 +7402,13 @@ def route_with_combined_escalation(
             quiet=quiet,
         )
 
-        # Issue #4208 (Unit 3): re-run the Unit-2 seg-seg finalize gate
-        # over the post-optimize/post-nudge copper.  An rtree-less
-        # optimizer can introduce a cross-net crossing the pre-optimize
-        # finalize gate never saw; demote it before the canonical write.
+    # Issue #4208 (Unit 3): re-run the Unit-2 seg-seg finalize gate
+    # over the post-optimize/post-nudge copper.  An rtree-less
+    # optimizer can introduce a cross-net crossing the pre-optimize
+    # finalize gate never saw; demote it before the canonical write.
+    # Issue #4281: unconditional -- runs even when the geometric
+    # post-passes are skipped for non-grid engines (defense in depth).
+    if final_result.router.routes:
         _finalize_committed_copper_or_demote(final_result.router, quiet=quiet)
 
     # Finalize: cleanup -> sexp -> stats (canonical ordering)
@@ -11088,8 +11152,12 @@ def main(argv: list[str] | None = None) -> int:
     pre_segments = sum(len(r.segments) for r in router.routes)
     pre_vias = sum(len(r.vias) for r in router.routes)
 
+    # Issue #4281: the geometric post-passes (optimize + DRC nudge) are
+    # grid-engine-only -- lattice/mesh copper must not be touched.
+    _post_passes_enabled = _engine_post_passes_enabled(args, quiet=quiet)
+
     # Optimize traces (unless --no-optimize/--raw flag is set)
-    if not args.no_optimize and router.routes:
+    if _post_passes_enabled and not args.no_optimize and router.routes:
         from kicad_tools.router.optimizer import (
             OptimizationConfig,
             TraceOptimizer,
@@ -11132,8 +11200,9 @@ def main(argv: list[str] | None = None) -> int:
             quiet=quiet,
         )
 
-    # Post-optimization DRC nudge pass
-    if router.routes:
+    # Post-optimization DRC nudge pass (#4281: gated like the optimizer --
+    # the nudge is NOT covered by --no-optimize, so it needs its own gate)
+    if _post_passes_enabled and router.routes:
         from kicad_tools.router.drc_nudge import drc_verify_and_nudge
 
         # Issue #2596: snapshot connectivity before nudge.
@@ -11152,12 +11221,16 @@ def main(argv: list[str] | None = None) -> int:
             quiet=quiet,
         )
 
-        # Issue #4208 (Unit 3): re-run the Unit-2 seg-seg finalize gate
-        # over the post-optimize/post-nudge copper.  An rtree-less
-        # optimizer can introduce a cross-net crossing the pre-optimize
-        # finalize gate never saw; demote it before the canonical write.
+    # Issue #4208 (Unit 3): re-run the Unit-2 seg-seg finalize gate
+    # over the post-optimize/post-nudge copper.  An rtree-less
+    # optimizer can introduce a cross-net crossing the pre-optimize
+    # finalize gate never saw; demote it before the canonical write.
+    # Issue #4281: unconditional -- runs even when the geometric
+    # post-passes are skipped for non-grid engines (defense in depth).
+    if router.routes:
         _finalize_committed_copper_or_demote(router, quiet=quiet)
 
+    if _post_passes_enabled and router.routes:
         # Get post-optimization statistics
         post_segments = sum(len(r.segments) for r in router.routes)
         post_vias = sum(len(r.vias) for r in router.routes)

--- a/tests/router/lattice/test_post_pass_gating.py
+++ b/tests/router/lattice/test_post_pass_gating.py
@@ -1,0 +1,173 @@
+"""#4281: geometric post-passes (optimize + DRC nudge) are grid-engine-only.
+
+The lattice and mesh engines commit copper by appending to ``router.routes``
+without calling ``_mark_route``, so the grid's obstacle model (cell occupancy
++ per-layer segment R-tree) contains no route copper after a non-grid run.
+The CLI's post-route TraceOptimizer validates every move against that empty
+model (everything is "clear"), and the DRC-nudge repair has no
+foreign-segment destination gate -- both passes corrupted correct lattice
+copper into cross-net shorts, which the #3989/#4208 backstop then demoted
+(board 02: 7/8 instead of 8/8; LINE_A demoted even under ``--no-optimize``
+because the nudge is not covered by that flag).
+
+Fix under test: one shared predicate, ``_engine_post_passes_enabled``, gates
+BOTH passes at all four optimize+nudge call-site pairs; the #4208 backstop
+stays unconditional (defense in depth).
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.route_cmd import _engine_post_passes_enabled
+
+_REPO = Path(__file__).resolve().parents[3]
+_CHARLIEPLEX = _REPO / "boards/02-charlieplex-led/output/charlieplex_3x3.kicad_pcb"
+_VOLTAGE_DIVIDER = _REPO / "boards/01-voltage-divider/output/voltage_divider.kicad_pcb"
+
+
+# ---------------------------------------------------------------------------
+# Shared predicate unit behavior.
+# ---------------------------------------------------------------------------
+
+
+def test_grid_enables_post_passes_silently(capsys: pytest.CaptureFixture) -> None:
+    args = argparse.Namespace(route_engine="grid")
+    assert _engine_post_passes_enabled(args) is True
+    # Grid must be a strict no-op: no notice printed (byte-identical output).
+    assert capsys.readouterr().out == ""
+
+
+def test_missing_route_engine_defaults_to_grid() -> None:
+    # Callers that never defined --route-engine keep today's behavior.
+    assert _engine_post_passes_enabled(argparse.Namespace()) is True
+    assert _engine_post_passes_enabled(argparse.Namespace(route_engine=None)) is True
+
+
+@pytest.mark.parametrize("engine", ["lattice", "mesh"])
+def test_non_grid_engines_disable_post_passes(engine: str, capsys: pytest.CaptureFixture) -> None:
+    args = argparse.Namespace(route_engine=engine)
+    assert _engine_post_passes_enabled(args) is False
+    out = capsys.readouterr().out
+    # One-line notice so users know why no optimize pass ran.
+    assert "Skipping optimize/nudge post-passes" in out
+    assert engine in out
+    assert "#4281" in out
+
+
+@pytest.mark.parametrize("engine", ["lattice", "mesh"])
+def test_quiet_suppresses_skip_notice(engine: str, capsys: pytest.CaptureFixture) -> None:
+    args = argparse.Namespace(route_engine=engine)
+    assert _engine_post_passes_enabled(args, quiet=True) is False
+    assert capsys.readouterr().out == ""
+
+
+# ---------------------------------------------------------------------------
+# CLI tail integration: lattice copper never reaches optimize/nudge; the
+# unconditional #4208 backstop finds nothing to demote (board 02 is 8/8).
+# ---------------------------------------------------------------------------
+
+
+def _spy_post_passes(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]:
+    """Wrap the two post-pass entry points with call counters.
+
+    ``route_cmd`` imports both lazily (``from ... import ...`` inside the
+    gated blocks), so patching the source modules observes exactly what the
+    CLI tail executes.
+    """
+    import kicad_tools.router.drc_nudge as drc_nudge_mod
+    import kicad_tools.router.optimizer as optimizer_mod
+
+    calls = {"optimize": 0, "nudge": 0}
+    real_optimize = optimizer_mod.optimize_routes_grid_synced
+    real_nudge = drc_nudge_mod.drc_verify_and_nudge
+
+    def spy_optimize(*args: object, **kwargs: object) -> object:
+        calls["optimize"] += 1
+        return real_optimize(*args, **kwargs)
+
+    def spy_nudge(*args: object, **kwargs: object) -> object:
+        calls["nudge"] += 1
+        return real_nudge(*args, **kwargs)
+
+    monkeypatch.setattr(optimizer_mod, "optimize_routes_grid_synced", spy_optimize)
+    monkeypatch.setattr(drc_nudge_mod, "drc_verify_and_nudge", spy_nudge)
+    return calls
+
+
+@pytest.mark.parametrize("extra", [[], ["--no-optimize"]], ids=["default", "no-optimize"])
+def test_cli_lattice_skips_both_passes_and_demotes_nothing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+    extra: list[str],
+) -> None:
+    """Board-02 lattice run: 8/8, no optimize, no nudge, no backstop demotion.
+
+    Covers both holes: the optimizer pass (NODE_A short, default flags) and
+    the nudge pass, which is NOT covered by ``--no-optimize`` (the LINE_A
+    demotion) -- hence the parametrization.
+    """
+    from kicad_tools.cli import route_cmd
+
+    calls = _spy_post_passes(monkeypatch)
+    out_pcb = tmp_path / "routed.kicad_pcb"
+    rc = route_cmd.main(
+        [
+            str(_CHARLIEPLEX),
+            "--route-engine",
+            "lattice",
+            "--strategy",
+            "basic",
+            "--seed",
+            "42",
+            "--skip-drc",
+            "-o",
+            str(out_pcb),
+            *extra,
+        ]
+    )
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert calls == {"optimize": 0, "nudge": 0}, "post-passes must not touch lattice copper"
+    assert "Skipping optimize/nudge post-passes for --route-engine lattice" in out
+    # The unconditional #4208 backstop ran and found nothing to demote
+    # (pre-fix: 'Post-optimize backstop demoted 1 net(s) ...' -> 7/8).
+    assert "Post-optimize backstop demoted" not in out
+    assert "Nets routed:     8/8" in out
+    assert out_pcb.exists()
+
+
+def test_cli_grid_still_runs_both_passes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Default (grid) engine keeps today's tail: optimize AND nudge both run."""
+    from kicad_tools.cli import route_cmd
+
+    calls = _spy_post_passes(monkeypatch)
+    out_pcb = tmp_path / "routed.kicad_pcb"
+    rc = route_cmd.main(
+        [
+            str(_VOLTAGE_DIVIDER),
+            "--strategy",
+            "basic",
+            "--seed",
+            "42",
+            "--skip-drc",
+            "-o",
+            str(out_pcb),
+        ]
+    )
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert calls["optimize"] >= 1, "grid engine must still optimize"
+    assert calls["nudge"] >= 1, "grid engine must still run the DRC nudge"
+    assert "Skipping optimize/nudge post-passes" not in out
+    assert out_pcb.exists()


### PR DESCRIPTION
Closes #4281

## Problem

The lattice and mesh engines commit copper by appending to `router.routes` only — they never call `_mark_route`, so after a non-grid run the grid's obstacle model (cell occupancy + per-layer segment R-tree) contains **zero route copper**. Two post-pass holes followed:

- **Optimizer (Hole 1):** the CLI collision checker is built from that empty grid (`VectorCollisionChecker` finds no R-tree entries, falls back to `GridCollisionChecker` over empty occupancy) — every optimizer move validated "clear", even across another net's copper. Board-02 lattice: NODE_A corrupted into a cross-net short, demoted by the #3989 backstop → **7/8**.
- **DRC nudge (Hole 2, evades `--no-optimize`):** the nudge pass is gated only on `router.routes`, and `_try_nudge_seg_seg` has no foreign-SEGMENT destination check (only vias, #3028 Part A) — it slid lattice segments into third-net copper (the LINE_A demotion under `--no-optimize`).

## Fix (curation option (a))

One shared predicate, `_engine_post_passes_enabled(args)`, skips **both** passes when `getattr(args, "route_engine", "grid") != "grid"` (mesh gets the same protection — identical commit provenance). Applied at all four optimize+nudge call-site pairs (layer-escalation / rule-relaxation / combined-escalation wrappers + the base `main()` path), printing a one-line notice when skipping. The #4208 `_finalize_committed_copper_or_demote` backstop is hoisted out of the nudge blocks and stays **unconditional** (defense in depth). Option (b) (`_mark_route` for non-grid commits + foreign-segment nudge gate) is deliberately out of scope per curation.

## Measured acceptance

| Check | Before | After |
|---|---|---|
| `kct route boards/02-charlieplex-led/output/charlieplex_3x3.kicad_pcb --route-engine lattice --strategy basic --seed 42` | 7/8 (NODE_A demoted by backstop) | **8/8**, no demotion line |
| `kicad-cli pcb drc --refill-zones` on the output | — | **0 violations, 0 unconnected** |
| Same command + `--no-optimize` | LINE_A demoted | **8/8**, DRC 0 (Hole 2 gated) |
| Grid default path | — | **byte-identical** (board-01, `--strategy basic --seed 42`, pre-fix vs fixed in the same worktree: identical modulo kicad-cli zone-fill UUIDs, which differ run-to-run even on unchanged code; skip notice absent; optimize+nudge both run) |

## Tests

`tests/router/lattice/test_post_pass_gating.py` (9 tests):
- predicate unit behavior: grid → True silently; lattice/mesh → False + notice; missing/None attr → grid default; `quiet` suppresses notice
- CLI tail integration on real board-02: lattice run (default AND `--no-optimize`) — optimize/nudge spies never called, no backstop demotion, 8/8
- grid CLI run still calls **both** passes (spies ≥ 1 each)

## Gates

- `tests/router/lattice/` + `tests/router/mesh/` + `tests/test_manufacturer_propagation_lint.py` (MFR001): 97 passed, 1 skipped
- mypy `route_cmd.py`: 30 pre-existing errors on main, identical set on branch (0 new)
- ruff check + format: clean
- No changes to `parser.py` or the top of `main()` (clean merge with sibling #4280)

🤖 Generated with [Claude Code](https://claude.com/claude-code)