### PR TITLE
fix(lattice): tier-gate same-net via-in-pad like the mesh engine (#4284)

### DIFF
--- a/src/kicad_tools/router/lattice/__init__.py
+++ b/src/kicad_tools/router/lattice/__init__.py
@@ -16,11 +16,15 @@ Package layout:
 * :mod:`.pathfinder` -- pad dogleg stubs, negotiated (node, layer) A*,
   emission to ordinary :class:`~kicad_tools.router.primitives.Route`.
 
-Via gating documentation (issue #4278 acceptance 7): vias land only on
-free-space lattice nodes, so **via-in-pad is N/A-by-construction** (not a
-disabled feature -- it cannot occur), and only **through-vias** are ever
-generated (blind/buried are likewise N/A; a committed through-via masks its
-node on ALL layers).
+Via gating documentation (issue #4278 acceptance 7, revised by #4284):
+only **through-vias** are ever generated (blind/buried are
+N/A-by-construction; a committed through-via masks its node on ALL
+layers).  **Via-in-pad is tier-gated exactly like the mesh engine** -- the
+static masks exclude only other-net pads, so a node under a same-net SMD
+pad is reachable; the via-legality gate rejects a via whose barrel would
+intersect a same-net SMD pad rect unless ``MfrLimits.via_in_pad_supported``
+holds for the configured ``DesignRules.manufacturer`` (default OFF).
+Other-net pad sites are always rejected.
 """
 
 from .obstacles import CommittedCopper, LatticeObstacleModel

--- a/src/kicad_tools/router/lattice/pathfinder.py
+++ b/src/kicad_tools/router/lattice/pathfinder.py
@@ -19,15 +19,18 @@ discipline):** the lattice + its per-layer static masks are built **once per
 board** (:meth:`build`, counted by :attr:`lattice_builds`); negotiation only
 mutates committed-copper state and history costs -- never the lattice.
 
-**Via model -- N/A-by-construction gates:** via edges join *matching
-free-space lattice nodes on adjacent layers* and every emitted via is a
-through-via spanning the whole stack.  Because vias can only land on
-free-space lattice nodes (a node inside any pad keep-out is masked),
-**via-in-pad can never occur** -- the ``MfrLimits.via_in_pad_supported``
-tier gate is moot for this engine rather than merely disabled.  Likewise
-**blind/buried vias are out of scope by construction**: only through-via
+**Via model:** via edges join *matching lattice nodes on adjacent layers*
+and every emitted via is a through-via spanning the whole stack.
+**Blind/buried vias are out of scope by construction**: only through-via
 edges are generated, and a committed through-via masks its node on ALL
-layers.
+layers.  **Via-in-pad is tier-gated, not N/A** (issue #4284): the static
+pad masks exclude only OTHER-net pads, so a lattice node under a same-net
+SMD pad is a legal route node -- :meth:`LatticePathfinder._via_ok`
+therefore rejects any via whose barrel would intersect a same-net SMD pad
+rect unless the configured fab tier sets ``MfrLimits.via_in_pad_supported``
+(``DesignRules.manufacturer``; conservative OFF by default), exactly the
+mesh engine's ``_via_allowed_at`` gate.  Other-net pad sites are always
+rejected.
 
 **Never-ship-a-short (#3906):** every stub leg and every lattice resource is
 validated against BOTH the static per-layer pad masks and a geometric
@@ -320,22 +323,48 @@ class LatticePathfinder:
 
     # -- via legality -----------------------------------------------------------
 
+    @property
+    def _via_in_pad_allowed(self) -> bool:
+        """Whether the configured fab tier permits via-in-pad (else OFF).
+
+        Read from the real fab model exactly as the mesh engine
+        (``mesh/pathfinder.py``) and the grid escape router do:
+        ``rules.manufacturer`` -> ``MfrLimits.via_in_pad_supported`` (base
+        ``jlcpcb`` = False, ``jlcpcb-tier1`` = True).  With no manufacturer
+        configured the conservative default is False, so pad-site vias are
+        pruned and layer changes happen only after a clear escape stub.
+        """
+        mfr = self.rules.manufacturer
+        if not mfr:
+            return False
+        try:
+            from ..mfr_limits import get_mfr_limits
+
+            return bool(get_mfr_limits(mfr).via_in_pad_supported)
+        except Exception:
+            return False
+
     def _via_ok(self, key: NodeKey, net: int, committed: CommittedCopper) -> bool:
         """Through-via legality at a lattice node.
 
         Static part: the via body (inflated beyond the trace keep-out by
         ``via_radius + clearance - agent_radius``) must clear every OTHER-net
         pad on ANY layer (a through-via exists on all of them), and keep the
-        hole-to-hole floor from through-hole pads of any net.  Because pads
-        mask their surrounding nodes, free-space nodes pass by default -- the
-        gate exists to prune boundary sites.  Dynamic part: committed copper
-        on all layers + committed vias (:meth:`CommittedCopper.via_clear`).
+        hole-to-hole floor from through-hole pads of any net.  Additionally
+        (issue #4284) the via barrel must not intersect ANY SMD pad rect
+        (window: pad half-extent + via radius, the mesh engine's window):
+        other-net is always rejected (the grown-rect veto already covers it
+        with clearance on top), and a SAME-net hit is via-in-pad -- admitted
+        only when the fab tier supports it (:attr:`_via_in_pad_allowed`).
+        Dynamic part: committed copper on all layers + committed vias
+        (:meth:`CommittedCopper.via_clear`).
         """
         lattice = self.build()
         obstacles = self.obstacles
         point = lattice.node_point(key)
+        via_radius = self.rules.via_diameter / 2.0
         grow = max(self._via_pad_grow, 0.0)
-        window = grow + 0.5
+        window = max(grow, via_radius) + 0.5
         for idx in obstacles.pads_near(
             point[0] - window, point[1] - window, point[0] + window, point[1] + window
         ):
@@ -344,6 +373,18 @@ class LatticePathfinder:
                 # Hole-to-hole floor applies regardless of net.
                 min_cc = self.rules.via_drill / 2.0 + pad.drill / 2.0 + self.rules.min_hole_to_hole
                 if dist(point, (pad.x, pad.y)) < min_cc - 1e-9:
+                    return False
+            elif (
+                abs(point[0] - pad.x) <= pad.width / 2.0 + via_radius
+                and abs(point[1] - pad.y) <= pad.height / 2.0 + via_radius
+            ):
+                # Via barrel intersects an SMD pad rect (#4284).  Same-net is
+                # via-in-pad: legal only on fab tiers that fill/cap the via
+                # (jlcpcb-tier1, pcbway); the default tier rejects so the
+                # layer change moves off the pad onto the escape stub.
+                # Other-net falls through to the unconditional grown-rect
+                # veto below.
+                if pad.net == net and not self._via_in_pad_allowed:
                     return False
             if pad.net == net:
                 continue

--- a/tests/router/lattice/test_via_in_pad.py
+++ b/tests/router/lattice/test_via_in_pad.py
@@ -1,0 +1,211 @@
+"""Lattice via-in-pad tier gate (issue #4284).
+
+The P2.7 claim "via-in-pad is N/A-by-construction" did not hold: the static
+pad masks exclude only OTHER-net pads, so a lattice node under a same-net
+SMD pad was a legal via site and the cheapest layer change on a net
+departing a pad was often AT the pad itself -- 6 measured ``via_in_pad``
+manufacturability errors on board 02 at the default jlcpcb tier (3 drilled
+dead-center, 3 at 0.283 mm offset, all inside 1.0 x 1.3 mm SMD pads).
+
+The fix mirrors the mesh engine's ``_via_allowed_at`` gate
+(``mesh/pathfinder.py``): a via whose barrel would intersect a same-net SMD
+pad rect (window: pad half-extent + via radius) is rejected unless
+``MfrLimits.via_in_pad_supported`` holds for ``DesignRules.manufacturer``
+(base ``jlcpcb`` = False, ``jlcpcb-tier1`` = True; no manufacturer =
+conservative False).  Other-net pad sites stay unconditionally rejected.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.router.lattice.pathfinder import LatticePathfinder
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import DesignRules
+
+_REPO = Path(__file__).resolve().parents[3]
+_CHARLIEPLEX = _REPO / "boards/02-charlieplex-led/output/charlieplex_3x3.kicad_pcb"
+
+# The 6 measured offenders from issue #4284 (ref, pin): three vias were
+# drilled dead-center in the pad, three at (+/-0.2, +/-0.2) = 0.283 mm from
+# center -- all entirely within the 0.5 x 0.65 mm pad half-extent.
+_AFFECTED_PADS: list[tuple[str, str]] = [
+    ("D1", "2"),  # NODE_A, via at (-0.200, +0.200)
+    ("R1", "2"),  # NODE_A, via at (0.000, -0.200)
+    ("D2", "1"),  # NODE_A, via at (-0.200, +0.200)
+    ("D4", "2"),  # NODE_C, dead center
+    ("D3", "1"),  # NODE_C, dead center
+    ("D7", "1"),  # NODE_C, dead center
+]
+
+
+def _board_text() -> str:
+    return _CHARLIEPLEX.read_text()
+
+
+def _find_pad(pads: list[Pad], ref: str, pin: str) -> Pad:
+    for p in pads:
+        if p.ref == ref and p.pin == pin:
+            return p
+    raise AssertionError(f"pad {ref}-{pin} not found on board 02")
+
+
+def _barrel_nodes(pf: LatticePathfinder, pad: Pad) -> list[tuple]:
+    """Lattice node keys whose via barrel would intersect ``pad``'s rect."""
+    lattice = pf.build()
+    via_r = pf.rules.via_diameter / 2.0
+    hx = pad.width / 2.0 + via_r
+    hy = pad.height / 2.0 + via_r
+    return [
+        key
+        for key, pt in lattice.nodes.items()
+        if abs(pt[0] - pad.x) <= hx and abs(pt[1] - pad.y) <= hy
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Unit gate: _via_ok on the 6 measured board-02 geometries.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("manufacturer", [None, "jlcpcb"])
+def test_via_ok_rejects_same_net_smd_pad_sites_at_default_tier(
+    manufacturer: str | None,
+) -> None:
+    """Every lattice node whose barrel intersects one of the 6 measured
+    same-net SMD pads is via-illegal at the default tier (and with no
+    manufacturer configured -- the conservative default)."""
+    from kicad_tools.router.io import load_pads_for_analysis
+
+    text = _board_text()
+    pads = load_pads_for_analysis(text)
+    pf = LatticePathfinder.from_board(text, rules=DesignRules(manufacturer=manufacturer))
+    committed = pf._fresh_committed()
+
+    for ref, pin in _AFFECTED_PADS:
+        pad = _find_pad(pads, ref, pin)
+        keys = _barrel_nodes(pf, pad)
+        # The refine regions put fine lattice nodes on every pad; the bug
+        # report proves dead-center nodes exist (3 vias drilled at exact
+        # pad centers), so an empty set would mean the fixture broke.
+        assert keys, f"no lattice nodes under pad {ref}-{pin}; fixture broken"
+        for key in keys:
+            assert not pf._via_ok(key, pad.net, committed), (
+                f"via allowed at node {key} inside same-net SMD pad {ref}-{pin} "
+                f"at manufacturer={manufacturer!r}"
+            )
+
+
+def test_via_ok_allows_same_net_pad_site_when_tier_supports_via_in_pad() -> None:
+    """At jlcpcb-tier1 (via_in_pad_supported=True) the gate flips: the
+    dead-center node under a same-net SMD pad becomes via-legal again."""
+    from kicad_tools.router.io import load_pads_for_analysis
+
+    text = _board_text()
+    pads = load_pads_for_analysis(text)
+    pf = LatticePathfinder.from_board(text, rules=DesignRules(manufacturer="jlcpcb-tier1"))
+    committed = pf._fresh_committed()
+    lattice = pf.build()
+
+    flipped = 0
+    for ref, pin in _AFFECTED_PADS:
+        pad = _find_pad(pads, ref, pin)
+        keys = _barrel_nodes(pf, pad)
+        assert keys
+        # The node nearest the pad center (the dead-center attach node) must
+        # pass: nothing but the same-net pad itself is anywhere near it.
+        nearest = min(keys, key=lambda k: math.dist(lattice.node_point(k), (pad.x, pad.y)))
+        if pf._via_ok(nearest, pad.net, committed):
+            flipped += 1
+    assert flipped == len(_AFFECTED_PADS), (
+        f"tier1 gate only flipped {flipped}/{len(_AFFECTED_PADS)} pad-center sites"
+    )
+
+
+def test_via_ok_still_rejects_other_net_pad_sites_at_every_tier() -> None:
+    """The other-net veto is tier-independent: a node under a foreign pad is
+    never a legal via site, even on a via-in-pad-capable tier."""
+    from kicad_tools.router.io import load_pads_for_analysis
+
+    text = _board_text()
+    pads = load_pads_for_analysis(text)
+    for manufacturer in (None, "jlcpcb", "jlcpcb-tier1"):
+        pf = LatticePathfinder.from_board(text, rules=DesignRules(manufacturer=manufacturer))
+        committed = pf._fresh_committed()
+        pad = _find_pad(pads, "D4", "2")
+        foreign_net = pad.net + 1000  # any net that is not the pad's
+        for key in _barrel_nodes(pf, pad):
+            assert not pf._via_ok(key, foreign_net, committed), (
+                f"via allowed under OTHER-net pad D4-2 at manufacturer={manufacturer!r}"
+            )
+
+
+def test_via_in_pad_allowed_property_reads_mfr_limits() -> None:
+    """The gate reads the real fab model (rules.py -> mfr_limits.py)."""
+    outline = [(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)]
+    for manufacturer, expected in [
+        (None, False),
+        ("jlcpcb", False),
+        ("jlcpcb-tier1", True),
+        ("pcbway", True),
+        ("no-such-fab", False),  # unknown tier -> conservative False
+    ]:
+        pf = LatticePathfinder(outline, [], DesignRules(manufacturer=manufacturer))
+        assert pf._via_in_pad_allowed is expected, f"manufacturer={manufacturer!r}"
+
+
+# ---------------------------------------------------------------------------
+# Integration: the negotiated board-02 net set ships zero via-in-pad copper
+# at the default tier (issue acceptance 1) and still meets the completion
+# floor with the static substrate built exactly once.
+# ---------------------------------------------------------------------------
+
+
+def _connections(pads: list[Pad]) -> list[tuple[object, Pad, Pad, object]]:
+    bynet: dict[int, list[Pad]] = {}
+    for p in pads:
+        if p.net > 0:
+            bynet.setdefault(p.net, []).append(p)
+    conns: list[tuple[object, Pad, Pad, object]] = []
+    for net, ps in bynet.items():
+        anchor = ps[0]
+        for seq, other in enumerate(ps[1:]):
+            conns.append(((net, seq), anchor, other, None))
+    return conns
+
+
+def test_charlieplex_netset_ships_no_via_in_pad_at_default_tier() -> None:
+    from kicad_tools.router.io import load_pads_for_analysis
+
+    text = _board_text()
+    pads = load_pads_for_analysis(text)
+    conns = _connections(pads)
+    assert len(conns) == 24
+
+    pf = LatticePathfinder.from_board(text, rules=DesignRules(manufacturer="jlcpcb"))
+    routes, stats = pf.route_netset(conns, max_iterations=8)
+    # The fix must not strand any net (issue stranding check: the 1.2-2.0 mm
+    # annulus around every affected pad keeps plenty of via-legal sites).
+    assert stats.routed >= 17, (
+        f"completion {stats.routed}/24 below the pre-fix floor; declines: {pf.failure_reasons}"
+    )
+    assert stats.lattice_builds == 1
+
+    via_r = pf.rules.via_diameter / 2.0
+    smd_pads = [p for p in pads if not p.through_hole]
+    offenders: list[str] = []
+    for route in routes.values():
+        for via in route.vias:
+            for pad in smd_pads:
+                if (
+                    abs(via.x - pad.x) <= pad.width / 2.0 + via_r
+                    and abs(via.y - pad.y) <= pad.height / 2.0 + via_r
+                ):
+                    offenders.append(
+                        f"via ({via.x:.3f}, {via.y:.3f}) net {route.net} intersects "
+                        f"pad {pad.ref}-{pad.pin} (net {pad.net})"
+                    )
+    assert not offenders, "via-in-pad copper shipped at default tier:\n" + "\n".join(offenders)


### PR DESCRIPTION
Closes #4284

## Root cause (as curated — both anchors confirmed)

1. `lattice/obstacles.py` `node_blocked` masks OTHER-net pads only, so the lattice node dead-center under a same-net SMD pad is a legal attach node.
2. `lattice/pathfinder.py` `_via_ok` skipped same-net pads (`if pad.net == net: continue`) before its SMD-rect veto, and same-net SMD pads never reach the hole-gap check (no drill).

Composed: the pad's own attach node was a legal via site, and the cheapest layer change on a net departing a pad is often AT the pad — hence 3 dead-center and 3 offset (0.283 mm) same-net vias inside 1.0 x 1.3 mm SMD pads on board 02.

## Fix (curation option (i), mirroring mesh `_via_allowed_at`)

- `_via_ok` now rejects any via whose barrel would intersect an SMD pad rect (window: pad half-extent + via radius, the mesh window). Other-net: unconditionally rejected (unchanged — the existing grown-rect veto already covers it with clearance on top). **Same-net: rejected unless the fab tier supports via-in-pad.**
- New `_via_in_pad_allowed` property mirroring `mesh/pathfinder.py` verbatim: `rules.manufacturer` → `MfrLimits.via_in_pad_supported`, conservative False with no manufacturer configured. No new plumbing — the lattice pathfinder already holds `self.rules`.
- Stale "via-in-pad is N/A-by-construction" docs corrected in `lattice/__init__.py`, the `pathfinder.py` module docstring, and the `_via_ok` docstring: via-in-pad is **tier-gated exactly like mesh**.

## Acceptance evidence (all measured on this branch)

**1. Board-02 repro** — `kct route boards/02-charlieplex-led/output/charlieplex_3x3.kicad_pcb --route-engine lattice --strategy basic --seed 42`:

| | pre-fix (b6e2a0cd) | post-fix |
|---|---|---|
| nets | 8/8 (100%) | **8/8 (100%)** — no stranding |
| `kct check --mfr jlcpcb` via_in_pad | **6 errors** | **0 errors** (0 errors total) |
| `kicad-cli pcb drc --refill-zones` | 0 | **0 violations, 0 unconnected** |
| copper_sliver warnings | 6 | 6 (pre-existing, unchanged) |

**2. Tier gate flips end-to-end** — same route with `--manufacturer jlcpcb-tier1`: 8/8, and the **same 6 pad-site vias reappear at identical coordinates** (D4-2/D3-1/D7-1 dead-center included); `kct check --mfr jlcpcb-tier1` → 0 errors (via-in-pad legal at tier1). Plus unit tests proving the `_via_ok` flip directly.

**3. Unit tests** (`tests/router/lattice/test_via_in_pad.py`, 6 tests): the 6 measured (ref, pin) geometries as fixtures — every barrel-intersecting lattice node rejected at `manufacturer=None` and `"jlcpcb"`; nearest-to-center node accepted at `jlcpcb-tier1` for all 6 pads; other-net rejection tier-independent; `_via_in_pad_allowed` reads the real fab model (None/jlcpcb/unknown → False, jlcpcb-tier1/pcbway → True); negotiated board-02 net set ships zero barrel-intersecting vias at default tier with `lattice_builds == 1`.

**4. Mesh not exposed / untouched** — re-confirmed `mesh/pathfinder.py` `_via_allowed_at` at b6e2a0cd checks ALL pads (other-net unconditional reject, own-net gated on `_via_in_pad_allowed`); no mesh or grid file touched (diff is `lattice/pathfinder.py`, `lattice/__init__.py`, new test file only). Grid output byte-identical by construction.

**5. Suites** — `tests/router/lattice/ tests/router/mesh/` under `-W error::UserWarning`: 91 passed, 1 skipped, 3 failed — the 3 failures (`test_post_pass_gating.py` CLI tests) are **pre-existing on a clean tree at b6e2a0cd** (a UserWarning from grid auto-resolution promoted to error; all 9 pass without the flag). Verified by stash/unstash.

## Gates

- `uv run kct build-native` — built first (C++ backend available)
- mypy: `Success: no issues found in 5 source files` (lattice package) — 0 new
- ruff check + format: clean on touched files
- MFR001: no `DesignRules()` construction added in `src/`; new tests pass `manufacturer=` explicitly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
