### PR TITLE
fix(net-status --why): verify facing-row pin order before recommending DE_REVERSE_BUNDLE

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 4281
-# Branch: feature/issue-4281
+# Issue: 4286
+# Branch: feature/issue-4286
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/src/kicad_tools/cli/net_status_cmd.py
+++ b/src/kicad_tools/cli/net_status_cmd.py
@@ -331,6 +331,11 @@ def _print_recommendation(diag: StuckNetDiagnosis) -> None:
     if diag.topology == "self_crossing_bundle":
         group = diag.match_group or "bundle"
         headline = f"self-crossing {group} bundle"
+    elif diag.topology == "co_oriented_bundle":
+        # Issue #4286: same-group congestion with a MEASURED co-oriented pin
+        # order -- the bundle is planar, so de-reversal is never suggested.
+        group = diag.match_group or "bundle"
+        headline = f"co-oriented {group} bundle (saturated corridor)"
     else:
         headline = "foreign-cluster congestion"
     print(f"  recommendation:   [{confidence}] {headline}")

--- a/src/kicad_tools/router/stuck_classifier.py
+++ b/src/kicad_tools/router/stuck_classifier.py
@@ -141,6 +141,44 @@ SELF_CROSS_THRESHOLD = 0.5
 # Topology labels attached to a diagnosis (empty string == not applicable).
 TOPOLOGY_SELF_CROSSING = "self_crossing_bundle"
 TOPOLOGY_FOREIGN_CLUSTER = "foreign_cluster"
+# Issue #4286: a bundle whose facing pad rows carry the nets in the SAME order.
+# Same-group blocker share fires for this topology too (co-oriented siblings
+# saturate the corridor without crossing), but de-reversal would CREATE the
+# crossing pathology instead of fixing it, so it gets its own label + ladder.
+TOPOLOGY_CO_ORIENTED = "co_oriented_bundle"
+
+# --- pin-order (inversion) verification (issue #4286) -----------------------
+#
+# Same-match-group blocker share alone cannot distinguish a genuinely REVERSED
+# bundle (board-07's DDR byte: the facing pin columns carry the nets in
+# opposite order, so every pair must cross) from a CO-ORIENTED bundle in a
+# saturated corridor (board-07's TMDS lanes: both facing rows carry the nets in
+# the SAME order; siblings compete for lanes without crossing).  Before
+# recommending DE_REVERSE_BUNDLE the engine therefore measures the actual
+# pad-order inversion count between the two facing components, reusing the
+# ``bundle_river`` projection/inversion machinery (#4053).
+#
+# The verdict thresholds on the *inversion fraction* f = inversions / C(n, 2):
+# a full reversal yields f == 1.0 and a co-oriented bundle f == 0.0.  The
+# break-even point is exactly 0.5 -- de-reversing one row maps f -> 1 - f, so
+# the move can only REDUCE crossings when f > 0.5.  We treat f >=
+# REVERSAL_INVERSION_THRESHOLD as "reversed" (keep the de-reversal
+# recommendation) and anything below as "co-oriented" (suppress it: at f < 0.5
+# de-reversal adds more crossings than it removes).  Board-07 measures f = 1.0
+# for DQ0..DQ7 (U1<->U2) and f = 0.0 for the TMDS lanes (J2<->U4), so both
+# populations sit far from the boundary.
+REVERSAL_INVERSION_THRESHOLD = 0.5
+
+# Facing rows are only comparable when the two components share at least this
+# many of the group's nets: below 3 the inversion fraction is degenerate
+# (C(2,2)=1 pair -> f is 0 or 1 on a single coin flip) and
+# ``detect_match_groups`` refuses groups smaller than 3 anyway.
+MIN_FACING_ROW_NETS = 3
+
+# Orientation verdicts (issue #4286).
+ORIENT_REVERSED = "reversed"
+ORIENT_CO_ORIENTED = "co_oriented"
+ORIENT_UNRESOLVED = "unresolved"
 
 
 class StuckClass(Enum):
@@ -249,6 +287,30 @@ class RankedAction:
             "rationale": self.rationale,
             "confidence": self.confidence.value,
         }
+
+
+@dataclass
+class BundleOrientation:
+    """Measured pad-order orientation of a match-group bundle (issue #4286).
+
+    Produced by :func:`_resolve_bundle_orientation`; consumed by the
+    recommendation stage to verify a self-crossing claim before recommending
+    DE_REVERSE_BUNDLE.  ``verdict`` is one of :data:`ORIENT_REVERSED`,
+    :data:`ORIENT_CO_ORIENTED` or :data:`ORIENT_UNRESOLVED`; the remaining
+    fields carry the evidence (``inverted_pairs`` of ``total_pairs`` facing pad
+    pairs flip order between ``primary_ref`` and ``secondary_ref``).  When the
+    facing rows cannot be resolved the verdict is UNRESOLVED and ``detail``
+    explains why -- the caller then makes NO pin-order claim either way.
+    """
+
+    verdict: str
+    inverted_pairs: int = 0
+    total_pairs: int = 0
+    member_count: int = 0
+    inversion_fraction: float = 0.0
+    primary_ref: str = ""
+    secondary_ref: str = ""
+    detail: str = ""
 
 
 @dataclass
@@ -440,11 +502,13 @@ def _find_blocking_strict_nets_from_pcb(
 
 
 def _iter_board_pads(pcb: PCB):
-    """Yield ``(net_number, (x, y), (w, h))`` for every real pad in board frame.
+    """Yield ``(reference, net_number, (x, y), (w, h))`` for every real pad.
 
-    Mirrors the footprint->board transform used by
-    :class:`kicad_tools.analysis.net_status.NetStatusAnalyzer` (KiCad negates
-    the footprint orientation vs standard CCW math, issue #3739).
+    Positions are in the board frame.  Mirrors the footprint->board transform
+    used by :class:`kicad_tools.analysis.net_status.NetStatusAnalyzer` (KiCad
+    negates the footprint orientation vs standard CCW math, issue #3739).  The
+    leading footprint reference lets the facing-row resolver (#4286) group a
+    bundle's pads by component.
     """
     for fp in pcb.footprints:
         if not fp.reference or fp.reference.startswith("#"):
@@ -457,7 +521,7 @@ def _iter_board_pads(pcb: PCB):
             px, py = pad.position
             bx = fp_x + (px * cos_a - py * sin_a)
             by = fp_y + (px * sin_a + py * cos_a)
-            yield pad.net_number, (bx, by), pad.size
+            yield fp.reference, pad.net_number, (bx, by), pad.size
 
 
 def _foreign_obstructions(
@@ -481,7 +545,7 @@ def _foreign_obstructions(
     px, py = point
     obstructions: list[tuple[float, float, float, int]] = []
 
-    for net_number, (bx, by), _size in _iter_board_pads(pcb):
+    for _ref, net_number, (bx, by), _size in _iter_board_pads(pcb):
         if net_number == target_net:
             continue
         d = math.hypot(bx - px, by - py)
@@ -585,6 +649,132 @@ def _resolve_match_groups(
         for member in members:
             net_to_group[member] = group.name
     return net_to_group, group_members
+
+
+def _resolve_bundle_orientation(
+    pcb: PCB,
+    group_ids: set[int],
+) -> BundleOrientation:
+    """Measure the pad-order orientation of a match-group bundle (issue #4286).
+
+    Resolves the group's two facing pad rows and computes the inversion count
+    between their net orders, REUSING the ``bundle_river`` projection/inversion
+    primitives (:class:`~kicad_tools.router.bundle_river.RowMember` /
+    :func:`~kicad_tools.router.bundle_river.compute_facing_row_inversions`,
+    #4053) rather than reinventing them.
+
+    Row resolution: the two components hosting the most *distinct* group nets
+    are taken as the facing rows (deterministic: count desc, reference asc).
+    A net with several pads on one component contributes its pad centroid.
+    Each row is projected onto its own long axis (the axis with the larger
+    coordinate spread -- y for a vertical pin column, x for a horizontal row);
+    only relative order matters, so the absolute frame is irrelevant.
+
+    Verdict (see :data:`REVERSAL_INVERSION_THRESHOLD` for the break-even
+    rationale): inversion fraction ``>= 0.5`` -> :data:`ORIENT_REVERSED`,
+    below -> :data:`ORIENT_CO_ORIENTED`.
+
+    Returns :data:`ORIENT_UNRESOLVED` (with ``detail``) instead of guessing
+    when the rows are not comparable: fewer than two host components, fewer
+    than :data:`MIN_FACING_ROW_NETS` shared nets, rows with different long
+    axes (an L-shaped bundle, where crossing depends on chirality the 1-D
+    projection cannot see), or a degenerate row with no spread.  Never raises.
+    """
+    from kicad_tools.router.bundle_river import RowMember, compute_facing_row_inversions
+
+    name_by_id = {nid: net.name for nid, net in pcb.nets.items() if net.name}
+
+    # (reference -> net_id -> pad positions) for the group's nets only.
+    by_ref: dict[str, dict[int, list[tuple[float, float]]]] = {}
+    for ref, net_number, (bx, by), _size in _iter_board_pads(pcb):
+        if net_number not in group_ids:
+            continue
+        by_ref.setdefault(ref, {}).setdefault(net_number, []).append((bx, by))
+
+    if len(by_ref) < 2:
+        return BundleOrientation(
+            ORIENT_UNRESOLVED,
+            detail=(
+                f"group pads found on {len(by_ref)} component(s); two facing rows are required"
+            ),
+        )
+
+    # The two components hosting the most distinct group nets are the facing
+    # rows (reference-name tiebreak keeps the choice deterministic).
+    ranked = sorted(by_ref.items(), key=lambda kv: (-len(kv[1]), kv[0]))
+    (ref_a, pads_a), (ref_b, pads_b) = ranked[0], ranked[1]
+    shared = set(pads_a) & set(pads_b)
+    if len(shared) < MIN_FACING_ROW_NETS:
+        return BundleOrientation(
+            ORIENT_UNRESOLVED,
+            detail=(
+                f"components {ref_a}/{ref_b} share only {len(shared)} group "
+                f"net(s); need >= {MIN_FACING_ROW_NETS} for a pin-order verdict"
+            ),
+        )
+
+    def _row(pads: dict[int, list[tuple[float, float]]]) -> tuple[list[RowMember], str] | None:
+        """Project one component's shared-net pad centroids onto its long axis."""
+        centroids: dict[int, tuple[float, float]] = {}
+        for nid in shared:
+            pts = pads[nid]
+            centroids[nid] = (
+                sum(p[0] for p in pts) / len(pts),
+                sum(p[1] for p in pts) / len(pts),
+            )
+        xs = [c[0] for c in centroids.values()]
+        ys = [c[1] for c in centroids.values()]
+        spread_x = max(xs) - min(xs)
+        spread_y = max(ys) - min(ys)
+        if max(spread_x, spread_y) < 1e-6:
+            return None  # degenerate row: all pads coincide, no order exists
+        axis = "x" if spread_x >= spread_y else "y"
+        members = [
+            RowMember(
+                net_id=nid,
+                net_name=name_by_id.get(nid, str(nid)),
+                projection=c[0] if axis == "x" else c[1],
+            )
+            for nid, c in centroids.items()
+        ]
+        return members, axis
+
+    row_a = _row(pads_a)
+    row_b = _row(pads_b)
+    if row_a is None or row_b is None:
+        return BundleOrientation(
+            ORIENT_UNRESOLVED,
+            primary_ref=ref_a,
+            secondary_ref=ref_b,
+            detail=f"a facing row on {ref_a}/{ref_b} has no spatial spread",
+        )
+    members_a, axis_a = row_a
+    members_b, axis_b = row_b
+    if axis_a != axis_b:
+        return BundleOrientation(
+            ORIENT_UNRESOLVED,
+            primary_ref=ref_a,
+            secondary_ref=ref_b,
+            detail=(
+                f"facing rows on {ref_a}/{ref_b} run along different axes "
+                f"({axis_a} vs {axis_b}); pin order is not 1-D comparable"
+            ),
+        )
+
+    inversions = compute_facing_row_inversions(members_a, members_b)
+    n = len(shared)
+    total_pairs = n * (n - 1) // 2
+    fraction = len(inversions) / total_pairs if total_pairs else 0.0
+    verdict = ORIENT_REVERSED if fraction >= REVERSAL_INVERSION_THRESHOLD else ORIENT_CO_ORIENTED
+    return BundleOrientation(
+        verdict=verdict,
+        inverted_pairs=len(inversions),
+        total_pairs=total_pairs,
+        member_count=n,
+        inversion_fraction=fraction,
+        primary_ref=ref_a,
+        secondary_ref=ref_b,
+    )
 
 
 def classify_stuck_nets_from_pcb(
@@ -736,12 +926,31 @@ def classify_stuck_nets_from_pcb(
                 blockers=blockers,
                 same_group_blockers=same_group_blockers,
             )
+            # Pin-order verification (issue #4286): same-group blocker share
+            # alone fires on BOTH a reversed bundle and a co-oriented bundle in
+            # a saturated corridor.  Measure the actual facing-row inversion
+            # count before letting the ladder recommend de-reversal; a measured
+            # co-oriented bundle gets its own topology + ladder instead.  An
+            # UNRESOLVED measurement keeps the share-based ladder unchanged (no
+            # pin-order claim either way) -- and never crashes the diagnostic.
+            orientation: BundleOrientation | None = None
+            if diag.topology == TOPOLOGY_SELF_CROSSING:
+                try:
+                    orientation = _resolve_bundle_orientation(pcb, group_ids)
+                except Exception as exc:  # pragma: no cover - defensive only
+                    orientation = BundleOrientation(
+                        ORIENT_UNRESOLVED,
+                        detail=f"orientation resolution failed: {exc}",
+                    )
+                if orientation.verdict == ORIENT_CO_ORIENTED:
+                    diag.topology = TOPOLOGY_CO_ORIENTED
             confidence = _grade_confidence(target_group)
             diag.recommendation = _build_recommendation(
                 classification=diag.classification,
                 topology=diag.topology,
                 match_group=target_group,
                 confidence=confidence,
+                orientation=orientation,
             )
         diagnoses.append(diag)
 
@@ -847,12 +1056,70 @@ def _detect_topology(
     return TOPOLOGY_FOREIGN_CLUSTER
 
 
+def _orientation_note(orientation: BundleOrientation | None) -> str:
+    """Evidence suffix describing the measured pin order (issue #4286).
+
+    Appended to the DE_REVERSE_BUNDLE rationale so a human can see whether the
+    reversal claim was actually verified against the facing pad rows or merely
+    inherited from the same-group-share heuristic (unresolved rows).
+    """
+    if orientation is None:
+        return ""
+    if orientation.verdict == ORIENT_REVERSED:
+        return (
+            f" (pin order verified: {orientation.inverted_pairs}/"
+            f"{orientation.total_pairs} facing pad pairs invert between "
+            f"{orientation.primary_ref} and {orientation.secondary_ref})"
+        )
+    if orientation.verdict == ORIENT_UNRESOLVED:
+        return f" (pin order not verified: {orientation.detail})"
+    return ""
+
+
+def _co_oriented_ladder(
+    grp: str,
+    confidence: Confidence,
+    orientation: BundleOrientation,
+) -> list[RankedAction]:
+    """The fix ladder for a measured co-oriented saturated bundle (#4286).
+
+    De-reversal / pin re-ordering are DELIBERATELY ABSENT: the facing rows
+    already carry the nets in the same order, so flipping one row would CREATE
+    the crossing pathology (board-07 TMDS evidence, #4252 A3 / #4253).
+    WIDEN_CHANNEL stays absent too -- same-group congestion did not respond to
+    widening on board-07 (28->27/31 regression).
+    """
+    measured = (
+        f"{orientation.inverted_pairs}/{orientation.total_pairs} facing pad "
+        f"pairs invert between {orientation.primary_ref} and "
+        f"{orientation.secondary_ref}"
+    )
+    return [
+        RankedAction(
+            RecommendedAction.MOVE_PART,
+            f"the {grp} bundle is already co-oriented ({measured}) -- "
+            f"de-reversing it would CREATE crossings, not remove them; the "
+            f"corridor is saturated by co-oriented siblings, so relocate a "
+            f"part to open more lanes",
+            confidence,
+        ),
+        RankedAction(
+            RecommendedAction.ACCEPT_PLATEAU,
+            "if no placement lever helps, this is a topological plateau; do "
+            "NOT widen the channel -- same-group congestion does not respond "
+            "to widening (board-07 evidence, 28->27/31)",
+            confidence,
+        ),
+    ]
+
+
 def _build_recommendation(
     *,
     classification: StuckClass,
     topology: str,
     match_group: str,
     confidence: Confidence,
+    orientation: BundleOrientation | None = None,
 ) -> list[RankedAction]:
     """Rank the fix ladder for one stuck net (issue #4261 Defect 3).
 
@@ -864,8 +1131,20 @@ def _build_recommendation(
     ``WIDEN_CHANNEL`` is DELIBERATELY OMITTED -- widening the U1/U2 channel
     regressed that board 28->27/31, so the engine must never suggest the move
     known to backfire on a reversed bundle.
+
+    Issue #4286: *orientation* carries the measured facing-row pin order.  The
+    caller has already re-labelled a measured co-oriented bundle as
+    :data:`TOPOLOGY_CO_ORIENTED`, which routes to :func:`_co_oriented_ladder`
+    (no de-reversal -- it would create crossings).  For a still-SELF_CROSSING
+    topology the measurement (verified reversal, or unresolved rows) is folded
+    into the DE_REVERSE_BUNDLE rationale via :func:`_orientation_note`.
     """
     grp = match_group or "the bundle"
+
+    if topology == TOPOLOGY_CO_ORIENTED and orientation is not None:
+        if classification in (StuckClass.PLACEMENT_BOUND, StuckClass.CONGESTION_SATURATED):
+            return _co_oriented_ladder(grp, confidence, orientation)
+        return []
 
     if classification is StuckClass.PLACEMENT_BOUND:
         if topology == TOPOLOGY_SELF_CROSSING:
@@ -875,7 +1154,7 @@ def _build_recommendation(
                     RecommendedAction.DE_REVERSE_BUNDLE,
                     f"the {grp} bus is reversed at the facing part -- co-orient "
                     f"(flip/re-order) its pad column so the bundle stops "
-                    f"self-crossing",
+                    f"self-crossing" + _orientation_note(orientation),
                     confidence,
                 ),
                 RankedAction(
@@ -919,7 +1198,8 @@ def _build_recommendation(
                 ),
                 RankedAction(
                     RecommendedAction.DE_REVERSE_BUNDLE,
-                    f"co-orient the {grp} bundle so siblings stop crossing",
+                    f"co-orient the {grp} bundle so siblings stop crossing"
+                    + _orientation_note(orientation),
                     confidence,
                 ),
             ]

--- a/tests/router/test_stuck_classifier.py
+++ b/tests/router/test_stuck_classifier.py
@@ -353,6 +353,79 @@ def reversed_bundle_pcb(tmp_path: Path) -> Path:
     return p
 
 
+# --- FACING-ROW FIXTURES (issue #4286 pin-order verification) ----------------
+# Same self-crossing setup as _reversed_bundle_board (stranded DQ2 pad crowded
+# by a dense ring of DQ0 siblings -> PLACEMENT_BOUND + same-group share), but
+# with two added multi-net components UA/UB that each host one pad of every
+# DDR_DATA net in a clean vertical column.  UA/UB are the two components with
+# the most distinct group nets, so the #4286 orientation resolver reads THEM as
+# the facing rows:
+#
+# * co-oriented variant: both columns carry DQ0/DQ1/DQ2 top-to-bottom in the
+#   SAME order -> 0/3 inversions -> DE_REVERSE_BUNDLE must be suppressed.
+# * reversed variant: UB's column is flipped -> 3/3 inversions -> the
+#   de-reversal recommendation must be KEPT (and marked verified).
+
+
+def _facing_rows_bundle_board(*, reversed_rows: bool) -> str:
+    ua_order = ["DQ0", "DQ1", "DQ2"]
+    ub_order = list(reversed(ua_order)) if reversed_rows else ua_order
+    net_num = {"DQ2": 1, "DQ0": 2, "DQ1": 3}
+
+    def _column(ref: str, cx: float, order: list[str]) -> str:
+        pads = "".join(
+            f'    (pad "{i + 1}" smd circle (at 0 {float(i - 1):.1f}) (size 0.2 0.2) '
+            f'(layers "F.Cu") (net {net_num[name]} "{name}"))\n'
+            for i, name in enumerate(order)
+        )
+        return (
+            f'  (footprint "col_{ref}" (layer "F.Cu") (at {cx:.1f} 50)\n'
+            f'    (property "Reference" "{ref}")\n' + pads + "  )\n"
+        )
+
+    body = (
+        _HEADER
+        + (
+            '  (net 0 "")\n'
+            '  (net 1 "DQ2")\n'
+            '  (net 2 "DQ0")\n'
+            '  (net 3 "DQ1")\n'
+            # DQ2 island (routed) far from the stranded pad
+            '  (footprint "R_0402" (layer "F.Cu") (at 10 10)\n'
+            '    (property "Reference" "R1")\n'
+            '    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "DQ2"))\n'
+            '    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "DQ2"))\n'
+            "  )\n"
+            # stranded DQ2 pad, surrounded by DDR siblings (dense same-group ring)
+            '  (footprint "U_SOT" (layer "F.Cu") (at 80 80)\n'
+            '    (property "Reference" "U1")\n'
+            '    (pad "1" smd circle (at 0 0) (size 0.2 0.2) (layers "F.Cu") (net 1 "DQ2"))\n'
+            "  )\n"
+            + _same_group_ring(80, 80, 1.5, count=22, gap=2)
+            # the two facing columns the orientation resolver must find
+            + _column("UA", 30.0, ua_order)
+            + _column("UB", 50.0, ub_order)
+            + '  (segment (start 9.5 10) (end 10.5 10) (width 0.25) (layer "F.Cu") (net 1))\n'
+            ")\n"
+        )
+    )
+    return body
+
+
+@pytest.fixture
+def co_oriented_bundle_pcb(tmp_path: Path) -> Path:
+    p = tmp_path / "co_oriented.kicad_pcb"
+    p.write_text(_facing_rows_bundle_board(reversed_rows=False))
+    return p
+
+
+@pytest.fixture
+def verified_reversed_bundle_pcb(tmp_path: Path) -> Path:
+    p = tmp_path / "verified_reversed.kicad_pcb"
+    p.write_text(_facing_rows_bundle_board(reversed_rows=True))
+    return p
+
+
 @pytest.fixture
 def escape_blocked_pcb(tmp_path: Path) -> Path:
     p = tmp_path / "escape.kicad_pcb"
@@ -508,6 +581,132 @@ class TestGenuinelyForeignCluster:
         assert actions[0] is RecommendedAction.MOVE_PART
         assert RecommendedAction.WIDEN_CHANNEL in actions
         assert RecommendedAction.DE_REVERSE_BUNDLE not in actions
+
+
+class TestPinOrderVerification:
+    """Issue #4286: the self-crossing detector must verify the actual facing-row
+    pin order before recommending DE_REVERSE_BUNDLE.  Same-group blocker share
+    fires on BOTH a reversed bundle and a co-oriented bundle in a saturated
+    corridor -- but de-reversing a co-oriented bundle would CREATE the crossing
+    pathology, so the recommendation must be suppressed there."""
+
+    def test_verified_reversed_bundle_keeps_de_reversal(self, verified_reversed_bundle_pcb: Path):
+        """Facing rows resolvable and genuinely reversed (3/3 inversions) ->
+        the de-reversal recommendation is kept and marked verified."""
+        result = classify_stuck_nets(verified_reversed_bundle_pcb)
+        d = next(x for x in result.diagnoses if x.net_name == "DQ2")
+
+        assert d.classification is StuckClass.PLACEMENT_BOUND
+        assert d.topology == "self_crossing_bundle"
+        actions = [a.action for a in d.recommendation]
+        assert actions[0] is RecommendedAction.DE_REVERSE_BUNDLE
+        assert RecommendedAction.WIDEN_CHANNEL not in actions
+        rationale = d.recommendation[0].rationale
+        assert "pin order verified" in rationale
+        assert "3/3" in rationale
+        assert "UA" in rationale and "UB" in rationale
+
+    def test_co_oriented_bundle_suppresses_de_reversal(self, co_oriented_bundle_pcb: Path):
+        """Facing rows resolvable and co-oriented (0/3 inversions) -> NO
+        de-reversal / pin re-order; the co-oriented-saturation ladder
+        (MOVE_PART / ACCEPT_PLATEAU) is emitted instead, still without
+        WIDEN_CHANNEL (same-group congestion does not respond to widening)."""
+        result = classify_stuck_nets(co_oriented_bundle_pcb)
+        d = next(x for x in result.diagnoses if x.net_name == "DQ2")
+
+        assert d.classification is StuckClass.PLACEMENT_BOUND
+        assert d.topology == "co_oriented_bundle"
+        assert d.match_group == "DDR_DATA"
+
+        actions = [a.action for a in d.recommendation]
+        assert RecommendedAction.DE_REVERSE_BUNDLE not in actions
+        assert RecommendedAction.REORDER_PINS not in actions
+        assert RecommendedAction.WIDEN_CHANNEL not in actions
+        assert actions[0] is RecommendedAction.MOVE_PART
+        assert RecommendedAction.ACCEPT_PLATEAU in actions
+
+        rationale = d.recommendation[0].rationale
+        assert "already co-oriented" in rationale
+        assert "0/3" in rationale
+
+    def test_unresolvable_rows_degrade_gracefully(self, reversed_bundle_pcb: Path):
+        """The original #4261 fixture has no component hosting more than one
+        group net, so the facing rows cannot be resolved.  The classifier must
+        not crash and must make NO pin-order claim: the share-based ladder is
+        retained unchanged, with the rationale honestly noting the pin order
+        was not verified."""
+        result = classify_stuck_nets(reversed_bundle_pcb)
+        d = next(x for x in result.diagnoses if x.net_name == "DQ2")
+
+        assert d.topology == "self_crossing_bundle"
+        actions = [a.action for a in d.recommendation]
+        assert actions[0] is RecommendedAction.DE_REVERSE_BUNDLE
+        assert "pin order not verified" in d.recommendation[0].rationale
+
+    def test_co_oriented_json_schema_unchanged(
+        self, co_oriented_bundle_pcb: Path, reversed_bundle_pcb: Path
+    ):
+        """The co-oriented verdict changes recommendation content and the
+        topology VALUE only -- the JSON field set is identical to the existing
+        self-crossing output."""
+        co = next(
+            x for x in classify_stuck_nets(co_oriented_bundle_pcb).diagnoses if x.net_name == "DQ2"
+        ).to_dict()
+        rev = next(
+            x for x in classify_stuck_nets(reversed_bundle_pcb).diagnoses if x.net_name == "DQ2"
+        ).to_dict()
+        assert set(co.keys()) == set(rev.keys())
+        assert co["topology"] == "co_oriented_bundle"
+        assert set(co["recommendation"][0].keys()) == set(rev["recommendation"][0].keys())
+        assert all(a["action"] != "de_reverse_bundle" for a in co["recommendation"])
+
+
+# Committed real-board acceptance evidence (issue #4286): board-07's DDR byte is
+# a measured full reversal (28/28 facing pad pairs invert between U1 and U2)
+# while its TMDS lanes are measured co-oriented (0/15 between J2 and U4).  The
+# classifier must keep DE_REVERSE_BUNDLE for the former and suppress it for the
+# latter -- asserted against the committed routed artifact, not a synthetic.
+
+_BOARD07_ARTIFACT = (
+    Path(__file__).resolve().parents[2]
+    / "boards"
+    / "07-matchgroup-test"
+    / "output"
+    / "matchgroup_test_routed.kicad_pcb"
+)
+
+
+@pytest.mark.skipif(
+    not _BOARD07_ARTIFACT.exists(), reason="board-07 committed artifact not present"
+)
+class TestBoard07PinOrderVerification:
+    @pytest.fixture(scope="class")
+    def board07(self):
+        return classify_stuck_nets(_BOARD07_ARTIFACT)
+
+    def test_reversed_ddr_nets_keep_de_reversal(self, board07):
+        """DQ3/DQ4 (genuinely reversed DDR byte) still get DE_REVERSE_BUNDLE."""
+        for name in ("DQ3", "DQ4"):
+            d = next(x for x in board07.diagnoses if x.net_name == name)
+            assert d.topology == "self_crossing_bundle"
+            actions = [a.action for a in d.recommendation]
+            assert actions[0] is RecommendedAction.DE_REVERSE_BUNDLE
+            assert RecommendedAction.WIDEN_CHANNEL not in actions
+            assert "pin order verified" in d.recommendation[0].rationale
+
+    def test_co_oriented_tmds_nets_lose_de_reversal(self, board07):
+        """TMDS nets (measured co-oriented, #4252 A3) must NOT be told to
+        de-reverse -- the false recommendation this issue exists to remove."""
+        tmds = [d for d in board07.diagnoses if d.net_name.startswith("TMDS_")]
+        assert tmds, "expected stuck TMDS nets on the committed board-07 artifact"
+        for d in tmds:
+            assert d.topology == "co_oriented_bundle"
+            actions = [a.action for a in d.recommendation]
+            assert RecommendedAction.DE_REVERSE_BUNDLE not in actions
+            assert RecommendedAction.REORDER_PINS not in actions
+            assert RecommendedAction.WIDEN_CHANNEL not in actions
+            assert RecommendedAction.MOVE_PART in actions
+            assert "already co-oriented" in d.recommendation[0].rationale
 
 
 class TestBudgetStarved:


### PR DESCRIPTION
Closes #4286

## Problem

The #4261/#4262 recommendation engine flagged "self-crossing bundle -> de-reverse" on **same-match-group blocker share alone**. Same-group blockers occur in BOTH topologies: a reversed bundle crosses itself, but a co-oriented bundle in a saturated corridor also blocks its own siblings *without* crossing. On board-07's committed artifact this produced a false DE_REVERSE_BUNDLE on the TMDS lanes — a recommendation that, if followed, would CREATE the crossing pathology (#4253 experiment; #4252 A3 measured TMDS as planar/co-oriented).

## Fix

Before emitting DE_REVERSE_BUNDLE, `stuck_classifier.py` now resolves the stuck net's match-group facing pad rows and measures the actual pin-order inversion count, **reusing** the `bundle_river` primitives (`RowMember` projections + `compute_facing_row_inversions`, #4053) — nothing reinvented.

**Threshold (documented in-module):** inversion fraction `f = inversions / C(n,2)`. De-reversing one row maps `f -> 1-f`, so the move can only reduce crossings when `f > 0.5` — the break-even point. `REVERSAL_INVERSION_THRESHOLD = 0.5`:

- `f >= 0.5` (board-07 DDR: **28/28**, f=1.0) → keep DE_REVERSE_BUNDLE; rationale now carries the verified measurement ("pin order verified: 28/28 facing pad pairs invert between U1 and U2").
- `f < 0.5` (board-07 TMDS: **0/15**, f=0.0) → new topology label `co_oriented_bundle` + co-oriented-saturation ladder (MOVE_PART / ACCEPT_PLATEAU). De-reversal, REORDER_PINS and WIDEN_CHANNEL all deliberately absent (widening regressed board-07 28->27/31 on same-group congestion).
- Facing rows unresolvable (<2 host components, <3 shared nets, rows on different long axes, degenerate spread) → graceful: share-based ladder retained unchanged with an honest "pin order not verified: ..." note; the resolver never raises (defensive catch on top).

Row resolution: the two components hosting the most distinct group nets are the facing rows (deterministic tiebreak); each row projects onto its own long axis; multi-pad nets contribute their centroid.

## Acceptance evidence (all measured, not synthetic-only)

1. **Committed board-07 artifact** (`boards/07-matchgroup-test/output/matchgroup_test_routed.kicad_pcb`), asserted in `TestBoard07PinOrderVerification`:
   - DQ3/DQ4 keep DE_REVERSE_BUNDLE, verified 28/28 (U1<->U2)
   - TMDS_D0_N/TMDS_D1_N: topology `co_oriented_bundle`, DE_REVERSE/REORDER/WIDEN all absent, MOVE_PART present (0/15, J2<->U4)
   - MIPI_DAT0_N unchanged (foreign_cluster)
2. **Unit fixtures** (`TestPinOrderVerification`): resolvable reversed → kept + verified; resolvable co-oriented saturated → de-reversal absent, MOVE_PART/ACCEPT_PLATEAU ladder; unresolvable rows (the original #4261 fixture) → graceful, ladder retained, "pin order not verified" note.
3. **Existing #4261 tests untouched and green**; JSON field set unchanged (`to_dict` schema identical; `topology` gains one new possible *value*, recommendation content changes only).
4. **Boards 05/06 `--why --format json` byte-identical** before/after (verified by diff; they only emit pour-discontinuous diagnoses, which never carry recommendations).

## Gates

- `tests/router/test_stuck_classifier.py` 21 passed (incl. 6 new)
- `tests/test_net_status.py` + `test_net_status_cmd.py` + `test_net_status_strict.py` 75 passed
- `tests/router/test_placement_nudge.py` + `test_bundle_river_inversions.py` + `test_bundle_plan_allocator.py` 54 passed
- `scripts/ci/check_mypy_baseline.py`: 0 new errors, baseline untouched
- MFR001 propagation lint tests: 9 passed
- `ruff check .` clean, `ruff format --check` clean
- Read-only contract intact: no board mutation, no routing triggered (pure-geometry resolver; `TestReadOnly` green)

CLI note: `_print_recommendation` in `net_status_cmd.py` gains a headline for the new topology ("co-oriented {group} bundle (saturated corridor)") so a co-oriented verdict is not mislabeled "foreign-cluster congestion".

🤖 Generated with [Claude Code](https://claude.com/claude-code)