### PR TITLE
feat(lattice): coupled diff-pair routing via fat-agent centerline + geometric offset emission

### DIFF
--- a/src/kicad_tools/router/algorithms/negotiated.py
+++ b/src/kicad_tools/router/algorithms/negotiated.py
@@ -343,6 +343,7 @@ def demote_seg_seg_finalize(
     trace_clearance: float,
     extra_routes: list[Route] | None = None,
     copper_overlap_only: bool = False,
+    exempt_pairs: set[tuple[int, int]] | None = None,
 ) -> tuple[list[int], list[tuple[int, int]]]:
     """Detect + demote nets whose committed copper is a cross-net seg-seg short.
 
@@ -379,6 +380,14 @@ def demote_seg_seg_finalize(
         copper_overlap_only: When ``False`` (the finalize default) use the
             FULL DRC SHORT threshold; when ``True`` use the polygon-overlap
             threshold (the in-loop / pre-repair position).
+        exempt_pairs: Ordered ``(min_net, max_net)`` id pairs whose
+            sub-clearance proximity is legitimate BY DESIGN and already
+            adjudicated elsewhere -- concretely, coupled differential
+            pairs whose copper honors the per-class intra-pair clearance
+            floor (issue #4270; the caller verifies the floor before
+            exempting).  Violation pairs in this set are dropped before
+            victim selection so the wide finalize threshold cannot demote
+            a legitimately-coupled pair as a cross-net short.
 
     Returns:
         ``(victims, non_rippable_pairs)`` where ``victims`` is the sorted
@@ -394,6 +403,8 @@ def demote_seg_seg_finalize(
         copper_overlap_only=copper_overlap_only,
         report_non_rippable_pairs=True,
     )
+    if exempt_pairs:
+        all_pairs = [pair for pair in all_pairs if pair not in exempt_pairs]
     if not all_pairs:
         return [], []
 

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -1082,6 +1082,9 @@ class Autorouter:
         self._lattice_net_routes: dict[int, list[Route]] | None = None
         self._lattice_served: set[int] = set()
         self._lattice_negotiation_stats: Any = None
+        # Issue #4270: per-diff-pair coupled-routing outcomes for the lattice
+        # engine ("coupled" or a decline reason), keyed by pair base name.
+        self._lattice_pair_outcomes: dict[str, str] = {}
 
         # Initialize grid and routers using shared helper
         # Issue #972: Helper includes adaptive grid resolution for large boards
@@ -2443,6 +2446,115 @@ class Autorouter:
             )
         return self._lattice_pathfinder
 
+    def _lattice_coupled_connections(
+        self,
+    ) -> tuple[list[Any], dict[int, list[tuple[str, str]]]]:
+        """Engaged diff pairs as lattice coupled connections (issue #4270).
+
+        Reuses the layered detector (:func:`detect_diff_pairs`, exactly the
+        :meth:`get_diff_pair_map` wiring) and the grid pre-pass engagement
+        gate (:func:`should_engage_coupled` -- ``coupled_routing`` opt-in +
+        the #2527 single-ended refusal).  For each engaged pair the main-run
+        endpoints are chosen by proximity pairing
+        (:func:`choose_pair_endpoints`); extra same-net pads are left to the
+        caller to route as ordinary single-ended connections anchored on the
+        reserved endpoints.
+
+        Returns ``(coupled, reserved)`` where ``reserved`` maps each pair
+        net id to its two reserved main-run pad keys.  Pairs whose pad
+        topology cannot form a coupled main run are recorded in
+        :attr:`_lattice_pair_outcomes` as declined and fall back to the
+        ordinary single-ended star (no coupled attempt was possible).
+        """
+        from .lattice.coupled import CoupledConnection, choose_pair_endpoints
+
+        coupled: list[Any] = []
+        reserved: dict[int, list[tuple[str, str]]] = {}
+        self._lattice_pair_outcomes = {}
+        if not self.net_names:
+            return coupled, reserved
+        try:
+            from .diffpair import should_engage_coupled
+            from .diffpair_detection import detect_diff_pairs
+        except ImportError:
+            return coupled, reserved
+
+        # Both net-name and class-name keyed views (the synth_routing idiom
+        # -- see get_diff_pair_map / Issue #3098).
+        net_to_class: dict[str, str] = {}
+        synth_routing: dict = dict(self.net_class_map)
+        for net_name, net_class in self.net_class_map.items():
+            net_to_class[net_name] = net_class.name
+            synth_routing.setdefault(net_class.name, net_class)
+
+        try:
+            detected = detect_diff_pairs(
+                self.net_names,
+                net_class_routing=synth_routing,
+                net_to_class=net_to_class,
+                kicad_groups=getattr(self, "kicad_diff_pair_groups", None),
+            )
+        except Exception:
+            # Defensive: detection must never break routing.
+            return coupled, reserved
+
+        for d in detected:
+            p_name = d.pair.positive.net_name
+            n_name = d.pair.negative.net_name
+            pair_name = d.pair.name or p_name
+            engaged, _reason = should_engage_coupled(d.pair, synth_routing, net_to_class)
+            if not engaged:
+                continue
+            p_id = d.pair.positive.net_id
+            n_id = d.pair.negative.net_id
+            keyed_p = [(k, self.pads[k]) for k in self.nets.get(p_id, []) if k in self.pads]
+            keyed_n = [(k, self.pads[k]) for k in self.nets.get(n_id, []) if k in self.pads]
+            chosen = choose_pair_endpoints([p for _, p in keyed_p], [p for _, p in keyed_n])
+            if chosen is None:
+                # Degenerate pad topology: no coupled main run is possible,
+                # so the nets stay on the ordinary single-ended star.
+                self._lattice_pair_outcomes[pair_name] = "no-endpoint-couples"
+                continue
+            (ip_a, in_a), (ip_b, in_b) = chosen
+            nc = self.net_class_map.get(p_name) or self.net_class_map.get(n_name)
+            if nc is None:
+                nc = synth_routing.get(net_to_class.get(p_name, ""), None)
+            if nc is None:
+                self._lattice_pair_outcomes[pair_name] = "no-net-class"
+                continue
+            trace_w = nc.trace_width or self.rules.trace_width
+            intra = nc.effective_intra_pair_clearance()
+            # Fab floor (issue #4270): an intra-pair air gap below the
+            # configured manufacturer's minimum copper clearance is
+            # unmanufacturable and would fail the exact kicad-cli DRC gate
+            # the committed board-06 output passes (its grid-quantized
+            # gaps sit above the floor).  Clamp the emitted gap up to the
+            # floor; the class value is honored when it already clears it.
+            mfr = self.rules.manufacturer
+            if mfr:
+                try:
+                    from .mfr_limits import get_mfr_limits
+
+                    intra = max(intra, get_mfr_limits(mfr).min_clearance)
+                except Exception:
+                    pass
+            pitch = trace_w + intra
+            coupled.append(
+                CoupledConnection(
+                    key=("pair", p_id, n_id),
+                    pair_name=pair_name,
+                    pad_p_a=keyed_p[ip_a][1],
+                    pad_n_a=keyed_n[in_a][1],
+                    pad_p_b=keyed_p[ip_b][1],
+                    pad_n_b=keyed_n[in_b][1],
+                    net_class=nc,
+                    pitch=pitch,
+                )
+            )
+            reserved[p_id] = [keyed_p[ip_a][0], keyed_p[ip_b][0]]
+            reserved[n_id] = [keyed_n[in_a][0], keyed_n[in_b][0]]
+        return coupled, reserved
+
     def _negotiate_lattice_netset(self) -> dict[int, list[Route]]:
         """Negotiate every routable net through the shared lattice (#4278).
 
@@ -2452,32 +2564,72 @@ class Autorouter:
         :meth:`LatticePathfinder.route_netset` (``lattice_builds == 1``).
         Unlike the mesh path, cross-layer connections are NOT skipped -- the
         lattice's (node, layer) graph handles layer transitions natively.
+
+        Diff pairs (issue #4270): engaged pairs become coupled fat-agent
+        connections (one per pair main run); their extra same-net pads
+        attach to the nearest reserved endpoint as ordinary single-ended
+        connections.  A pair that cannot complete a coupled planar run
+        DECLINES with a reason (reported below and in
+        :attr:`_lattice_pair_outcomes`) -- it is never split into uncoupled
+        legs.
         """
         pf = self._ensure_lattice_pathfinder()
+
+        coupled, reserved = self._lattice_coupled_connections()
 
         connections: list[tuple[object, Pad, Pad, object]] = []
         for net, pad_keys in self.nets.items():
             if net == 0:
                 continue
-            pads = [self.pads[k] for k in pad_keys if k in self.pads]
-            if len(pads) < 2:
+            keyed = [(k, self.pads[k]) for k in pad_keys if k in self.pads]
+            if len(keyed) < 2:
                 continue
+            res_keys = reserved.get(net)
+            if res_keys:
+                # Main run handled by the coupled connection; each extra pad
+                # attaches single-ended to its nearest reserved endpoint.
+                res_pads = [p for k, p in keyed if k in res_keys]
+                extras = [p for k, p in keyed if k not in res_keys]
+                for seq, other in enumerate(extras):
+                    anchor = min(
+                        res_pads,
+                        key=lambda rp: math.hypot(rp.x - other.x, rp.y - other.y),
+                    )
+                    connections.append(((net, seq), anchor, other, None))
+                continue
+            pads = [p for _k, p in keyed]
             anchor = pads[0]
             for seq, other in enumerate(pads[1:]):
                 connections.append(((net, seq), anchor, other, None))
 
-        if not connections:
+        if not connections and not coupled:
             return {}
 
-        routes_by_key, stats = pf.route_netset(connections)
+        # Pairs consume roughly double the corridor capacity of a single
+        # net, so give the negotiation more rip-up pressure headroom when
+        # coupled connections are present (issue #4270).  The default 8
+        # is preserved exactly for pair-free boards.
+        max_iterations = 12 if coupled else 8
+        routes_by_key, stats = pf.route_netset(
+            connections, coupled=coupled, max_iterations=max_iterations
+        )
         self._lattice_negotiation_stats = stats
 
+        # Honest per-pair reporting (issue #4270 acceptance): engaged /
+        # coupled / declined-with-reason, mirroring failure_reasons.
+        if coupled or self._lattice_pair_outcomes:
+            outcomes = getattr(pf, "pair_outcomes", {})
+            for pc in coupled:
+                self._lattice_pair_outcomes[pc.pair_name] = outcomes.get(pc.key, "not-attempted")
+            n_coupled = sum(1 for v in self._lattice_pair_outcomes.values() if v == "coupled")
+            print(f"  Diff pairs (lattice): {n_coupled}/{len(self._lattice_pair_outcomes)} coupled")
+            for name, outcome in sorted(self._lattice_pair_outcomes.items()):
+                print(f"    {name}: {outcome}")
+
         by_net: dict[int, list[Route]] = {}
-        for key, route in routes_by_key.items():
-            assert isinstance(key, tuple)
-            net_id = int(key[0])
+        for route in routes_by_key.values():
             if route.segments:
-                by_net.setdefault(net_id, []).append(route)
+                by_net.setdefault(route.net, []).append(route)
         return by_net
 
     def route_net(
@@ -11740,6 +11892,35 @@ class Autorouter:
             already overlap-free, the common case).
         """
         extra = self._collect_extra_routes_for_revalidation(net_routes)
+        # Issue #4270: a legitimately-coupled diff pair runs sub-clearance
+        # BY DESIGN (leg-to-leg gap = the per-class intra-pair clearance,
+        # below the global trace clearance), so the wide finalize threshold
+        # would demote one leg as a cross-net short.  Exempt exactly the
+        # partner pairs whose copper VERIFIABLY honors their intra-pair
+        # floor -- the same adjudication split the M3 reporting below uses.
+        # Only the finalize (wide) threshold is exempted: a physically
+        # overlapping pair is a real short regardless of pairing.
+        exempt_pairs: set[tuple[int, int]] = set()
+        if finalize and net_routes:
+            # One detection pass for the whole revalidation (the per-net
+            # _diff_pair_partner_net helper would re-run detection N times).
+            pair_map = self.get_diff_pair_map()
+            if pair_map:
+                name_to_id: dict[str, int] = {}
+                for nid, nname in self.net_names.items():
+                    name_to_id.setdefault(nname, nid)
+                for name_a, name_b in pair_map.items():
+                    net_a = name_to_id.get(name_a)
+                    net_b = name_to_id.get(name_b)
+                    if net_a is None or net_b is None:
+                        continue
+                    if not net_routes.get(net_a) or not net_routes.get(net_b):
+                        continue
+                    key = (net_a, net_b) if net_a < net_b else (net_b, net_a)
+                    if key in exempt_pairs:
+                        continue
+                    if self._coupled_pair_honors_intra_floor(net_a, net_b, net_routes):
+                        exempt_pairs.add(key)
         # Issue #4208 (Unit 2): delegate to the single shared seg-seg
         # finalize gate so ``core`` and ``two_phase`` cannot drift apart.
         victims, non_rippable_pairs = _demote_seg_seg_finalize(
@@ -11750,6 +11931,7 @@ class Autorouter:
             trace_clearance=self.rules.trace_clearance,
             extra_routes=extra,
             copper_overlap_only=not finalize,
+            exempt_pairs=exempt_pairs,
         )
         # M3: a cross-net crossing between two non-rippable escape stubs
         # has no demotable victim (the greedy cover skips it) -- surface
@@ -12584,6 +12766,49 @@ class Autorouter:
             if nname == partner_name:
                 return nid
         return None
+
+    def _coupled_pair_honors_intra_floor(
+        self,
+        net_a: int,
+        net_b: int,
+        net_routes: dict[int, list[Route]],
+    ) -> bool:
+        """True when diff-pair nets ``a``/``b`` honor their intra-pair floor.
+
+        Issue #4270: used by :meth:`_demote_seg_seg_overlap_nets` to decide
+        whether a partner pair's sub-clearance proximity is legitimate
+        coupled routing (exempt from the wide finalize short gate) or a
+        real violation (demotable as usual).  Deliberately conservative:
+        the pair's net class must carry an EXPLICIT ``intra_pair_clearance``
+        (an accidental suffix-detected pair without a coupled design intent
+        never qualifies), and every route-pair combination must pass
+        :func:`diffpair_routing.find_intra_pair_clearance_violations` at
+        that threshold.
+        """
+        from .diffpair_routing import find_intra_pair_clearance_violations
+
+        name_a = self.net_names.get(net_a)
+        name_b = self.net_names.get(net_b)
+        if not name_a or not name_b:
+            return False
+        net_class = self.net_class_map.get(name_a) or self.net_class_map.get(name_b)
+        if net_class is None or net_class.intra_pair_clearance is None:
+            return False
+        threshold = float(net_class.effective_intra_pair_clearance())
+        if threshold <= 0.0:
+            return False
+        routes_a = net_routes.get(net_a, [])
+        routes_b = net_routes.get(net_b, [])
+        if not routes_a or not routes_b:
+            return False
+        for route_a in routes_a:
+            for route_b in routes_b:
+                violation = find_intra_pair_clearance_violations(
+                    route_a, route_b, threshold, pair_name=name_a
+                )
+                if violation is not None:
+                    return False
+        return True
 
     def _rescued_leg_breaks_intra_pair_clearance(
         self,

--- a/src/kicad_tools/router/lattice/__init__.py
+++ b/src/kicad_tools/router/lattice/__init__.py
@@ -15,6 +15,8 @@ Package layout:
   committed-copper model (the #3906 never-blind-fit discipline).
 * :mod:`.pathfinder` -- pad dogleg stubs, negotiated (node, layer) A*,
   emission to ordinary :class:`~kicad_tools.router.primitives.Route`.
+* :mod:`.coupled` -- diff-pair coupled routing (issue #4270): fat-agent
+  centerline legality + geometric ``+/- pitch/2`` offset emission.
 
 Via gating documentation (issue #4278 acceptance 7, revised by #4284):
 only **through-vias** are ever generated (blind/buried are
@@ -27,12 +29,14 @@ holds for the configured ``DesignRules.manufacturer`` (default OFF).
 Other-net pad sites are always rejected.
 """
 
+from .coupled import CoupledConnection
 from .obstacles import CommittedCopper, LatticeObstacleModel
 from .pathfinder import LatticeNegotiationStats, LatticePathfinder
 from .quadtree import OctilinearLattice, RefineRegion
 
 __all__ = [
     "CommittedCopper",
+    "CoupledConnection",
     "LatticeNegotiationStats",
     "LatticeObstacleModel",
     "LatticePathfinder",

--- a/src/kicad_tools/router/lattice/coupled.py
+++ b/src/kicad_tools/router/lattice/coupled.py
@@ -1,0 +1,427 @@
+"""Diff-pair coupled routing on the lattice engine (issue #4270, epic #4267 P3).
+
+**Fat-agent centerline + geometric offset emission.**  An engaged
+differential pair is routed as ONE A* agent over the lattice -- the pair
+*centerline* -- with every legality check inflated by ``pair_pitch / 2``
+(``pair_pitch = trace_width + effective intra-pair clearance``, a
+*geometric* quantity deliberately NOT bound to lattice rows: board-06's
+0.275-0.30 mm pitches are finer than the 0.4 mm minimum adjacent-row
+pitch, so the node-constrained "two adjacent lattice rows" primitive was
+rejected at curation).  P and N are then emitted as perpendicular
+``+/- pitch/2`` offsets of the centerline.
+
+Octilinearity is preserved *by construction*: offsetting a polyline moves
+each segment onto a parallel line and every interior vertex onto the exact
+intersection of the two adjacent offset lines, so segment directions are
+unchanged and the emitted legs pass the #3907 ``Segment`` 45-degree choke
+untouched.  Copper is geometric -- :class:`CommittedCopper` and DRC do not
+care that offset vertices sit off-node.
+
+**v1 pair agents are planar** (``allow_vias=False``): a pair that cannot
+complete a coupled run on one layer DECLINES honestly, with a per-pair
+reason -- it never splits into uncoupled legs and never ships a short
+(#3906 discipline).
+
+This module holds the pure-geometry / model-query halves of the feature so
+:mod:`.pathfinder` only gains a thin fat-agent branch and
+:mod:`.obstacles` stays untouched (issue #4271 threads per-class widths
+through those files in parallel).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from .geometry import (
+    Pt,
+    Rect,
+    dist,
+    pt_in_rect,
+    seg_pt_dist,
+    seg_rect_intersect,
+    seg_seg_dist,
+)
+
+if TYPE_CHECKING:
+    from ..primitives import Pad
+    from .obstacles import CommittedCopper, LatticeObstacleModel
+
+_EPS = 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Connection shape
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CoupledConnection:
+    """One engaged differential pair, routed as a single fat A* agent.
+
+    The four pads are the pair's *main-run* endpoints (P/N at end A, P/N
+    at end B), selected by proximity pairing -- extra same-net pads are
+    routed afterwards as ordinary single-ended connections.
+
+    Attributes:
+        key: Opaque hashable negotiation key (owned by the caller).
+        pair_name: Human-readable pair base name for reporting.
+        pad_p_a / pad_n_a: Positive / negative pads at end A.
+        pad_p_b / pad_n_b: Positive / negative pads at end B.
+        net_class: The pair's ``NetClassRouting`` (trace width source).
+        pitch: P/N centreline pitch in mm --
+            ``trace_width + effective_intra_pair_clearance()``.
+    """
+
+    key: object
+    pair_name: str
+    pad_p_a: Pad
+    pad_n_a: Pad
+    pad_p_b: Pad
+    pad_n_b: Pad
+    net_class: object
+    pitch: float
+
+    @property
+    def mid_a(self) -> Pt:
+        return ((self.pad_p_a.x + self.pad_n_a.x) / 2.0, (self.pad_p_a.y + self.pad_n_a.y) / 2.0)
+
+    @property
+    def mid_b(self) -> Pt:
+        return ((self.pad_p_b.x + self.pad_n_b.x) / 2.0, (self.pad_p_b.y + self.pad_n_b.y) / 2.0)
+
+    @property
+    def length(self) -> float:
+        return dist(self.mid_a, self.mid_b)
+
+
+# ---------------------------------------------------------------------------
+# Fat-agent legality (geometric, no second mask build -- lattice_builds == 1)
+# ---------------------------------------------------------------------------
+
+
+def pads_block_segment_grown(
+    obstacles: LatticeObstacleModel,
+    a: Pt,
+    b: Pt,
+    layer: int,
+    nets: set[int],
+    extra: float,
+    exempt: frozenset[int] | None = None,
+) -> bool:
+    """True if segment ``a-b`` enters any foreign pad keep-out on ``layer``
+    after growing the keep-out rects by ``extra``.
+
+    This is the ``segment_blocked`` pattern from :mod:`.obstacles` with the
+    fat-agent twists: the inflated pad rects are grown by the pair
+    half-envelope, and "self" is either every net in ``nets`` (attach /
+    re-verification mode, ``exempt is None``) or ONLY the pad indices in
+    ``exempt`` (centerline mode).  The centerline mode is deliberately
+    stricter: a non-endpoint pad of a pair net is a real obstacle for the
+    fat agent, because the leg of the OPPOSITE polarity would otherwise be
+    laid straight over it (the board-06 USB2 B-row lesson).  Purely a query
+    against the static model -- no mask rebuild.
+    """
+    x0, x1 = min(a[0], b[0]), max(a[0], b[0])
+    y0, y1 = min(a[1], b[1]), max(a[1], b[1])
+    for idx in obstacles.pads_near(x0 - extra, y0 - extra, x1 + extra, y1 + extra):
+        if exempt is not None:
+            if idx in exempt:
+                continue
+        elif obstacles.pads[idx].net in nets:
+            continue
+        if layer not in obstacles.pad_layer_indices[idx]:
+            continue
+        r = obstacles.pad_rects[idx]
+        grown: Rect = (r[0] - extra, r[1] - extra, r[2] + extra, r[3] + extra)
+        if seg_rect_intersect(a, b, grown):
+            return True
+    return False
+
+
+def pads_block_point_grown(
+    obstacles: LatticeObstacleModel,
+    point: Pt,
+    layer: int,
+    nets: set[int],
+    extra: float,
+    exempt: frozenset[int] | None = None,
+) -> bool:
+    """Point flavour of :func:`pads_block_segment_grown`."""
+    for idx in obstacles.pads_near(
+        point[0] - extra, point[1] - extra, point[0] + extra, point[1] + extra
+    ):
+        if exempt is not None:
+            if idx in exempt:
+                continue
+        elif obstacles.pads[idx].net in nets:
+            continue
+        if layer not in obstacles.pad_layer_indices[idx]:
+            continue
+        r = obstacles.pad_rects[idx]
+        grown: Rect = (r[0] - extra, r[1] - extra, r[2] + extra, r[3] + extra)
+        if pt_in_rect(point, grown):
+            return True
+    return False
+
+
+def committed_seg_clear_grown(
+    committed: CommittedCopper,
+    a: Pt,
+    b: Pt,
+    layer: int,
+    nets: set[int],
+    extra: float,
+) -> bool:
+    """``CommittedCopper.seg_clear`` with gaps grown by ``extra`` and the
+    whole pair-net set treated as "self"."""
+    gap = committed.copper_gap + extra
+    for c, d, cnet, _hw in committed.copper[layer].query_seg(a, b, pad=gap):
+        if cnet not in nets and seg_seg_dist(a, b, c, d) < gap - _EPS:
+            return False
+    vgap = committed.via_copper_gap + extra
+    for point, vnet in committed.vias:
+        if vnet not in nets and seg_pt_dist(a, b, point) < vgap - _EPS:
+            return False
+    return True
+
+
+def committed_point_clear_grown(
+    committed: CommittedCopper,
+    point: Pt,
+    layer: int,
+    nets: set[int],
+    extra: float,
+) -> bool:
+    """``CommittedCopper.node_clear`` with gaps grown by ``extra``."""
+    gap = committed.copper_gap + extra
+    for c, d, cnet, _hw in committed.copper[layer].query_seg(point, point, pad=gap):
+        if cnet not in nets and seg_pt_dist(c, d, point) < gap - _EPS:
+            return False
+    vgap = committed.via_copper_gap + extra
+    for vpt, vnet in committed.vias:
+        if vnet not in nets and dist(point, vpt) < vgap - _EPS:
+            return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Polyline offset (octilinear-preserving by construction)
+# ---------------------------------------------------------------------------
+
+
+def merge_collinear_points(points: list[Pt]) -> list[Pt]:
+    """Drop zero-length steps and interior vertices on straight runs.
+
+    Offsetting is joint-by-joint, so fusing collinear lattice steps first
+    keeps the offset legs free of spurious interior vertices.
+    """
+    out: list[Pt] = []
+    for p in points:
+        if out and dist(out[-1], p) <= _EPS:
+            continue
+        if len(out) >= 2:
+            ax, ay = out[-2]
+            bx, by = out[-1]
+            d1 = (bx - ax, by - ay)
+            d2 = (p[0] - bx, p[1] - by)
+            cross = d1[0] * d2[1] - d1[1] * d2[0]
+            dot = d1[0] * d2[0] + d1[1] * d2[1]
+            if abs(cross) <= _EPS and dot > 0.0:
+                out[-1] = p
+                continue
+        out.append(p)
+    return out
+
+
+def offset_polyline(points: list[Pt], offset: float) -> list[Pt] | None:
+    """Offset ``points`` perpendicular by ``offset`` (left of travel > 0).
+
+    Every offset segment lies on the parallel line of a source segment and
+    every interior vertex is the exact intersection of two of those offset
+    lines, so **emitted directions are a subset of the source directions**
+    -- an octilinear input yields an octilinear output (#3907 by
+    construction).
+
+    Inside miters at tight turns can reverse a short offset segment (the
+    classic miter collapse on fine-lattice jogs).  Such segments are
+    eliminated and the neighbouring offset lines re-intersected, so the
+    offset leg simply cuts the corner one or more source segments short --
+    emitted directions remain a SUBSET of the source directions and the
+    caller's geometric re-verification (masks + committed copper +
+    intra-pair floor) stays the safety authority for collapsed geometry.
+
+    Returns ``None`` when the offset is irrecoverably degenerate: a
+    zero-length source segment, parallel non-collinear offset lines that
+    would have to be joined (U-turn), or a collapse that would move the
+    anchored first/last vertex (the endpoints must stay at the exact
+    ``point +/- offset`` positions the pad-attach doglegs expect).
+    """
+    if len(points) < 2:
+        return None
+    # One offset line per source segment: (anchor point on the line, dir).
+    lines: list[tuple[Pt, Pt]] = []
+    for a, b in zip(points, points[1:], strict=False):
+        length = dist(a, b)
+        if length <= _EPS:
+            return None
+        d = ((b[0] - a[0]) / length, (b[1] - a[1]) / length)
+        n = (-d[1], d[0])
+        lines.append(((a[0] + offset * n[0], a[1] + offset * n[1]), d))
+
+    def isect(l1: tuple[Pt, Pt], l2: tuple[Pt, Pt]) -> Pt | None:
+        (p1, d1), (p2, d2) = l1, l2
+        cross = d1[0] * d2[1] - d1[1] * d2[0]
+        if abs(cross) <= 1e-12:
+            # Parallel offset lines: joinable only when collinear.
+            off = (p2[0] - p1[0]) * d1[1] - (p2[1] - p1[1]) * d1[0]
+            return p2 if abs(off) <= _EPS else None
+        t = ((p2[0] - p1[0]) * d2[1] - (p2[1] - p1[1]) * d2[0]) / cross
+        return (p1[0] + t * d1[0], p1[1] + t * d1[1])
+
+    n_first = (-lines[0][1][1], lines[0][1][0])
+    start: Pt = (points[0][0] + offset * n_first[0], points[0][1] + offset * n_first[1])
+    n_last = (-lines[-1][1][1], lines[-1][1][0])
+    end: Pt = (points[-1][0] + offset * n_last[0], points[-1][1] + offset * n_last[1])
+
+    idxs = list(range(len(lines)))
+    for _guard in range(len(lines) + 1):
+        verts: list[Pt] = [start]
+        broken = False
+        for a_i, b_i in zip(idxs, idxs[1:], strict=False):
+            j = isect(lines[a_i], lines[b_i])
+            if j is None:
+                return None
+            verts.append(j)
+        verts.append(end)
+
+        # Find the first offset segment that no longer advances along its
+        # source direction (inside miter collapsed it).
+        reversed_at: int | None = None
+        for k, line_i in enumerate(idxs):
+            d = lines[line_i][1]
+            adv = (verts[k + 1][0] - verts[k][0]) * d[0] + (verts[k + 1][1] - verts[k][1]) * d[1]
+            if adv <= _EPS:
+                reversed_at = k
+                broken = True
+                break
+        if not broken:
+            return verts
+        if len(idxs) < 3:
+            return None
+        assert reversed_at is not None
+        if reversed_at == 0:
+            # First (anchored) segment reversed: its junction with the next
+            # line sits behind the fixed start vertex -- drop the next line.
+            del idxs[1]
+        elif reversed_at == len(idxs) - 1:
+            # Last (anchored) segment reversed: junction beyond the fixed
+            # end vertex -- drop the previous line.
+            del idxs[-2]
+        else:
+            del idxs[reversed_at]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Polarity
+# ---------------------------------------------------------------------------
+
+
+def side_bit(direction: Pt, pad_p: Pad, pad_n: Pad) -> bool:
+    """True when the P pad sits on the LEFT of ``direction`` relative to N.
+
+    "Left" is the ``offset > 0`` side of :func:`offset_polyline`, so this
+    bit says which offset leg the positive net should own at an endpoint
+    whose local travel direction is ``direction``.
+    """
+    n = (-direction[1], direction[0])
+    return (pad_p.x - pad_n.x) * n[0] + (pad_p.y - pad_n.y) * n[1] > 0.0
+
+
+def assign_polarity(
+    plus_leg: list[Pt],
+    minus_leg: list[Pt],
+    pad_p_a: Pad,
+    pad_n_a: Pad,
+    pad_p_b: Pad,
+    pad_n_b: Pad,
+) -> tuple[list[Pt], list[Pt]] | None:
+    """Map the two offset legs to (P, N) by endpoint proximity.
+
+    Both ends must agree; a disagreement means the pair would need a
+    polarity twist (legs crossing), which a planar coupled run cannot do
+    -- return ``None`` so the caller declines honestly.
+    """
+
+    def side(pp: Pad, pn: Pad, q_plus: Pt, q_minus: Pt) -> bool:
+        direct = dist((pp.x, pp.y), q_plus) + dist((pn.x, pn.y), q_minus)
+        swapped = dist((pp.x, pp.y), q_minus) + dist((pn.x, pn.y), q_plus)
+        return direct <= swapped  # True: P owns the plus leg
+
+    at_a = side(pad_p_a, pad_n_a, plus_leg[0], minus_leg[0])
+    at_b = side(pad_p_b, pad_n_b, plus_leg[-1], minus_leg[-1])
+    if at_a != at_b:
+        return None
+    return (plus_leg, minus_leg) if at_a else (minus_leg, plus_leg)
+
+
+# ---------------------------------------------------------------------------
+# Misc geometry
+# ---------------------------------------------------------------------------
+
+
+def seg_rect_dist(a: Pt, b: Pt, rect: Rect) -> float:
+    """Minimum distance from segment ``a-b`` to axis-aligned ``rect``."""
+    if seg_rect_intersect(a, b, rect):
+        return 0.0
+    x0, y0, x1, y1 = rect
+    corners = [(x0, y0), (x1, y0), (x1, y1), (x0, y1)]
+    return min(
+        seg_seg_dist(a, b, c1, c2)
+        for c1, c2 in zip(corners, corners[1:] + corners[:1], strict=False)
+    )
+
+
+def choose_pair_endpoints(
+    pads_p: list[Pad], pads_n: list[Pad]
+) -> tuple[tuple[int, int], tuple[int, int]] | None:
+    """Pick the pair's main-run endpoints by proximity pairing.
+
+    Greedily couples each P pad with its nearest unclaimed N pad, then
+    returns the two couples whose midpoints are farthest apart as
+    ``((ip_a, in_a), (ip_b, in_b))`` index tuples into the input lists.
+    Returns ``None`` when fewer than two couples exist (degenerate pad
+    topology -- the pair cannot form a coupled main run).
+    """
+    if not pads_p or not pads_n:
+        return None
+    cands = sorted(
+        (dist((p.x, p.y), (n.x, n.y)), i, j)
+        for i, p in enumerate(pads_p)
+        for j, n in enumerate(pads_n)
+    )
+    couples: list[tuple[int, int]] = []
+    used_p: set[int] = set()
+    used_n: set[int] = set()
+    for _d, i, j in cands:
+        if i in used_p or j in used_n:
+            continue
+        couples.append((i, j))
+        used_p.add(i)
+        used_n.add(j)
+    if len(couples) < 2:
+        return None
+
+    def mid(c: tuple[int, int]) -> Pt:
+        p, n = pads_p[c[0]], pads_n[c[1]]
+        return ((p.x + n.x) / 2.0, (p.y + n.y) / 2.0)
+
+    best: tuple[float, int, int] | None = None
+    for x in range(len(couples)):
+        for y in range(x + 1, len(couples)):
+            d = dist(mid(couples[x]), mid(couples[y]))
+            if best is None or d > best[0]:
+                best = (d, x, y)
+    assert best is not None
+    return couples[best[1]], couples[best[2]]

--- a/src/kicad_tools/router/lattice/pathfinder.py
+++ b/src/kicad_tools/router/lattice/pathfinder.py
@@ -44,12 +44,14 @@ import heapq
 import math
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from ..layers import LayerStack
 from ..primitives import Pad, Route, Segment, Via
 from ..quantize import dogleg_points
 from ..rules import DesignRules
-from .geometry import Pt, Rect, dist, pt_in_rect
+from .coupled import CoupledConnection
+from .geometry import Pt, Rect, dist, pt_in_rect, seg_seg_dist
 from .obstacles import CommittedCopper, LatticeObstacleModel
 from .quadtree import EdgeKey, NodeKey, OctilinearLattice, RefineRegion
 
@@ -88,6 +90,84 @@ class _RouteResult:
     runs: list[tuple[int, list[Pt]]]  # (layer_index, polyline) per copper run
     via_points: list[Pt]
     resources: set[Resource]  # lattice edges/via-nodes consumed (history keys)
+
+
+@dataclass
+class _PairResult:
+    """Internal per-pair result: both emitted legs + commit geometry (#4270)."""
+
+    routes: list[Route]  # [P route, N route]
+    runs: list[tuple[int, int, list[Pt]]]  # (net, layer_index, polyline) per leg
+    resources: set[Resource]  # the fat centerline's lattice resources
+
+
+def _diverse_pair_stubs(
+    stubs: list[tuple[NodeKey, int, list[Pt], float]],
+    mid: Pt,
+    pair_pads: tuple[Pad, Pad],
+    *,
+    max_axis_dot: float = 0.5,
+    per_bucket: int = 2,
+    cap: int = 48,
+) -> list[tuple[NodeKey, int, list[Pt], float]]:
+    """Downselect fat pair stubs for direction + distance diversity (#4270).
+
+    Two filters, then a diversity cap:
+
+    * **Perpendicular gate**: the stub's first segment must leave the pad
+      midpoint roughly THROUGH the pair gate, i.e. not nearly parallel to
+      the P-N pad axis (``|dir . axis| <= max_axis_dot`` keeps the first
+      leg within 30 degrees of perpendicular).  An along-axis approach lays one
+      offset leg straight along the partner's endpoint pad -- the emitted
+      geometry then fails the partner-pad floor anyway, so pruning it here
+      lets the A* try approaches that can actually be emitted.  Zero-length
+      stubs (midpoint exactly on a node) are dropped for the same reason:
+      they carry no direction for the parity mechanism.
+    * **Octant x distance-shell diversity**: keep the ``per_bucket``
+      shortest stubs per (direction octant, shell of node distance in
+      {<1 mm, <2 mm, >=2 mm}) so enclosed pockets cannot crowd out the far
+      stubs that escape them.
+    """
+    import math as _math
+
+    px = pair_pads[0].x - pair_pads[1].x
+    py = pair_pads[0].y - pair_pads[1].y
+    axis_len = _math.hypot(px, py)
+    axis = (px / axis_len, py / axis_len) if axis_len > 1e-9 else None
+
+    def first_dir(poly: list[Pt]) -> Pt | None:
+        for a, b in zip(poly, poly[1:], strict=False):
+            d = dist(a, b)
+            if d > 1e-9:
+                return ((b[0] - a[0]) / d, (b[1] - a[1]) / d)
+        return None
+
+    gated: list[tuple[NodeKey, int, list[Pt], float]] = []
+    for stub in stubs:
+        d = first_dir(stub[2])
+        if d is None:
+            continue
+        if axis is not None and abs(d[0] * axis[0] + d[1] * axis[1]) > max_axis_dot:
+            continue
+        gated.append(stub)
+
+    gated.sort(key=lambda s: s[3])
+    buckets: dict[tuple[int, int, int], int] = {}
+    out: list[tuple[NodeKey, int, list[Pt], float]] = []
+    for stub in gated:
+        node_pt = stub[2][-1]
+        dx, dy = node_pt[0] - mid[0], node_pt[1] - mid[1]
+        r = _math.hypot(dx, dy)
+        octant = int(((_math.atan2(dy, dx) + _math.tau) % _math.tau) // (_math.tau / 8))
+        shell = 0 if r < 1.0 else (1 if r < 2.0 else 2)
+        key = (stub[1], octant, shell)
+        if buckets.get(key, 0) >= per_bucket:
+            continue
+        buckets[key] = buckets.get(key, 0) + 1
+        out.append(stub)
+        if len(out) >= cap:
+            break
+    return out
 
 
 class LatticePathfinder:
@@ -150,6 +230,9 @@ class LatticePathfinder:
         # Per-connection decline reasons for the best negotiation pass
         # (honest shortfall diagnosis; reset by :meth:`route_netset`).
         self.failure_reasons: dict[object, str] = {}
+        # Per-diff-pair outcome for the best pass: "coupled" or a decline
+        # reason, keyed by ``CoupledConnection.key`` (issue #4270).
+        self.pair_outcomes: dict[object, str] = {}
 
     # -- construction from a board ----------------------------------------
 
@@ -266,6 +349,10 @@ class LatticePathfinder:
         *,
         kmax: int = 4,
         search_radius: float | None = None,
+        extra_clearance: float = 0.0,
+        partner_net: int | None = None,
+        layers: tuple[int, ...] | None = None,
+        exempt_pads: frozenset[int] | None = None,
     ) -> list[tuple[NodeKey, int, list[Pt], float]]:
         """Legal dogleg stubs ``(node_key, layer, polyline pad->node, length)``.
 
@@ -276,15 +363,39 @@ class LatticePathfinder:
         pad masks AND committed copper (the ``subgrid.py`` reject-and-retry
         discipline -- the standing #3906 lesson).  A pad none of whose
         candidate stubs clears yields ``[]`` -> the connection declines.
+
+        Fat-agent mode (issue #4270 diff pairs): ``extra_clearance`` grows
+        every gap by the pair half-envelope and ``partner_net`` joins the
+        "self" net set, so a pair *centerline* stub reserves room for both
+        offset legs.  The static check becomes a geometric query against the
+        grown pad rects (no second mask build -- ``lattice_builds`` stays 1)
+        and ``layers`` restricts candidates to layers every pair endpoint
+        pad owns (the v1 coupled run is planar).
         """
         lattice = self.build()
         obstacles = self.obstacles
         if committed is None:
             committed = self._fresh_committed()
+        fat = extra_clearance > 0.0 or partner_net is not None
         if search_radius is None:
             search_radius = max(3.0 * lattice.fine + max(pad.width, pad.height), 2.0)
+            if fat:
+                # A fat agent may need to gather farther out of a dense pad
+                # cluster.  The stub is part of the coupled centerline, so a
+                # longer dogleg costs length, not coupling quality.
+                search_radius = max(search_radius, 4.0)
 
-        layers = self._pad_layer_indices(pad)
+        if layers is None:
+            layers = self._pad_layer_indices(pad)
+        pair_nets = {net} if partner_net is None else {net, partner_net}
+        if fat:
+            from .coupled import (
+                committed_point_clear_grown,
+                committed_seg_clear_grown,
+                pads_block_point_grown,
+                pads_block_segment_grown,
+            )
+
         candidates: list[tuple[float, NodeKey, Pt]] = []
         pad_pt = (pad.x, pad.y)
         for key, point in lattice.nodes.items():
@@ -296,21 +407,43 @@ class LatticePathfinder:
         out: list[tuple[NodeKey, int, list[Pt], float]] = []
         for _d, key, point in candidates:
             for layer in layers:
-                if obstacles.node_blocked(key, layer, net):
-                    continue
-                if not committed.node_clear(point, layer, net):
-                    continue
+                if fat:
+                    if pads_block_point_grown(
+                        obstacles, point, layer, pair_nets, extra_clearance, exempt_pads
+                    ):
+                        continue
+                    if not committed_point_clear_grown(
+                        committed, point, layer, pair_nets, extra_clearance
+                    ):
+                        continue
+                else:
+                    if obstacles.node_blocked(key, layer, net):
+                        continue
+                    if not committed.node_clear(point, layer, net):
+                        continue
                 accepted: list[Pt] | None = None
-                for axis_first in (False, True):
+                # Fat mode prefers the axis-first dogleg: its first leg is
+                # axis-aligned, which is what the pair perpendicular gate
+                # (:func:`_diverse_pair_stubs`) needs to see (#4270).
+                for axis_first in (True, False) if fat else (False, True):
                     poly = dogleg_points(pad.x, pad.y, point[0], point[1], axis_first=axis_first)
                     ok = True
                     for a, b in zip(poly, poly[1:], strict=False):
-                        if obstacles.segment_blocked(a, b, layer, net):
-                            ok = False
-                            break
-                        if not committed.seg_clear(a, b, layer, net):
-                            ok = False
-                            break
+                        if fat:
+                            if pads_block_segment_grown(
+                                obstacles, a, b, layer, pair_nets, extra_clearance, exempt_pads
+                            ) or not committed_seg_clear_grown(
+                                committed, a, b, layer, pair_nets, extra_clearance
+                            ):
+                                ok = False
+                                break
+                        else:
+                            if obstacles.segment_blocked(a, b, layer, net):
+                                ok = False
+                                break
+                            if not committed.seg_clear(a, b, layer, net):
+                                ok = False
+                                break
                     if ok:
                         accepted = poly
                         break
@@ -423,6 +556,11 @@ class LatticePathfinder:
         history: dict[Resource, float],
         present: float,
         allow_vias: bool = True,
+        extra_clearance: float = 0.0,
+        partner_net: int | None = None,
+        stub_layers: tuple[int, ...] | None = None,
+        stubs_override: tuple[list, list] | None = None,
+        exempt_pads: frozenset[int] | None = None,
     ) -> tuple[_RouteResult | None, str]:
         """A* over the (node, layer) graph; returns ``(result, reason)``.
 
@@ -431,15 +569,58 @@ class LatticePathfinder:
         lattice resources.  Hard legality (static masks + geometric committed
         copper) is never traded against cost: an illegal resource is simply
         not expanded, so the search can only DECLINE, never ship a short.
+
+        Fat-agent mode (issue #4270): ``extra_clearance`` / ``partner_net``
+        switch every legality check to the grown geometric predicates from
+        :mod:`.coupled`, so the path reserves the whole pair envelope.  Fat
+        agents are planar in v1 -- ``allow_vias`` is forced off (a coupled
+        run that cannot complete on one layer declines honestly).
+        ``stubs_override`` lets :meth:`_route_pair_impl` supply parity-
+        filtered stub sets (``(stubs_a, stubs_b)``) instead of recomputing.
         """
         lattice = self.build()
         obstacles = self.obstacles
         net = start.net
 
-        stubs_a = self.pad_stubs(start, net, committed)
+        fat = extra_clearance > 0.0 or partner_net is not None
+        if fat:
+            # v1 coupled runs are planar; there is no fat via legality.
+            allow_vias = False
+            from .coupled import (
+                committed_point_clear_grown,
+                committed_seg_clear_grown,
+                pads_block_point_grown,
+                pads_block_segment_grown,
+            )
+
+            pair_nets = {net} if partner_net is None else {net, partner_net}
+
+        if stubs_override is not None:
+            stubs_a, stubs_b = stubs_override
+        else:
+            stub_kmax = 24 if fat else 4
+            stubs_a = self.pad_stubs(
+                start,
+                net,
+                committed,
+                kmax=stub_kmax,
+                extra_clearance=extra_clearance,
+                partner_net=partner_net,
+                layers=stub_layers,
+                exempt_pads=exempt_pads,
+            )
+            stubs_b = self.pad_stubs(
+                end,
+                net,
+                committed,
+                kmax=stub_kmax,
+                extra_clearance=extra_clearance,
+                partner_net=partner_net,
+                layers=stub_layers,
+                exempt_pads=exempt_pads,
+            )
         if not stubs_a:
             return None, "pad-escape-start"
-        stubs_b = self.pad_stubs(end, net, committed)
         if not stubs_b:
             return None, "pad-escape-end"
 
@@ -492,18 +673,35 @@ class LatticePathfinder:
                 ek = (edge, layer)
                 ok = edge_ok.get(ek)
                 if ok is None:
-                    ok = not obstacles.edge_blocked(edge, layer, net) and committed.seg_clear(
-                        lattice.node_point(edge[0]), lattice.node_point(edge[1]), layer, net
-                    )
+                    if fat:
+                        pa = lattice.node_point(edge[0])
+                        pb = lattice.node_point(edge[1])
+                        ok = not pads_block_segment_grown(
+                            obstacles, pa, pb, layer, pair_nets, extra_clearance, exempt_pads
+                        ) and committed_seg_clear_grown(
+                            committed, pa, pb, layer, pair_nets, extra_clearance
+                        )
+                    else:
+                        ok = not obstacles.edge_blocked(edge, layer, net) and committed.seg_clear(
+                            lattice.node_point(edge[0]), lattice.node_point(edge[1]), layer, net
+                        )
                     edge_ok[ek] = ok
                 if not ok:
                     continue
                 nstate = (nbr, layer)
                 nok = node_ok.get(nstate)
                 if nok is None:
-                    nok = not obstacles.node_blocked(nbr, layer, net) and committed.node_clear(
-                        lattice.node_point(nbr), layer, net
-                    )
+                    if fat:
+                        npt = lattice.node_point(nbr)
+                        nok = not pads_block_point_grown(
+                            obstacles, npt, layer, pair_nets, extra_clearance, exempt_pads
+                        ) and committed_point_clear_grown(
+                            committed, npt, layer, pair_nets, extra_clearance
+                        )
+                    else:
+                        nok = not obstacles.node_blocked(nbr, layer, net) and committed.node_clear(
+                            lattice.node_point(nbr), layer, net
+                        )
                     node_ok[nstate] = nok
                 if not nok:
                     continue
@@ -658,12 +856,365 @@ class LatticePathfinder:
             )
         return route
 
+    # -- diff-pair coupled routing (issue #4270) --------------------------------
+
+    def _pair_attach(
+        self,
+        pad: Pad,
+        target: Pt,
+        layer: int,
+        net: int,
+        pair_nets: set[int],
+        committed: CommittedCopper,
+    ) -> list[Pt] | None:
+        """Dogleg from the exact pad position to an emitted leg endpoint.
+
+        Ordinary single-trace clearance (``extra = 0``) but with BOTH pair
+        nets as "self" -- the attach necessarily runs between the pair's own
+        pads.  Returns the accepted polyline (pad first) or ``None``.
+        """
+        from .coupled import pads_block_segment_grown
+
+        if dist((pad.x, pad.y), target) <= 1e-9:
+            return [(pad.x, pad.y)]
+        for axis_first in (False, True):
+            poly = dogleg_points(pad.x, pad.y, target[0], target[1], axis_first=axis_first)
+            ok = True
+            for a, b in zip(poly, poly[1:], strict=False):
+                if dist(a, b) <= 1e-9:
+                    continue
+                if pads_block_segment_grown(self.obstacles, a, b, layer, pair_nets, 0.0):
+                    ok = False
+                    break
+                if not committed.seg_clear(a, b, layer, net):
+                    ok = False
+                    break
+            if ok:
+                return poly
+        return None
+
+    def _emit_leg(
+        self, net: int, net_name: str, points: list[Pt], layer_idx: int, trace_w: float
+    ) -> Route | None:
+        """One offset leg -> a via-free ``Route`` (same #3907 choke as _emit)."""
+        from ..optimizer.algorithms import merge_collinear
+        from ..optimizer.config import OptimizationConfig
+
+        try:
+            layer_enum = self.layer_stack.index_to_layer_enum(layer_idx)
+        except Exception:
+            return None
+        segments = [
+            Segment(
+                x1=a[0],
+                y1=a[1],
+                x2=b[0],
+                y2=b[1],
+                width=trace_w,
+                layer=layer_enum,
+                net=net,
+                net_name=net_name,
+            )
+            for a, b in zip(points, points[1:], strict=False)
+            if dist(a, b) > 1e-9
+        ]
+        route = Route(net=net, net_name=net_name)
+        route.segments.extend(merge_collinear(segments, OptimizationConfig()))
+        return route if route.segments else None
+
+    def _route_pair_impl(
+        self,
+        pc: CoupledConnection,
+        *,
+        committed: CommittedCopper,
+        history: dict[Resource, float],
+        present: float,
+    ) -> tuple[_PairResult | None, str]:
+        """Route one engaged diff pair as a fat centerline agent (#4270).
+
+        Pipeline: virtual midpoint pads -> parity-filtered fat stubs ->
+        planar fat A* -> collinear merge -> geometric ``+/- pitch/2`` offset
+        emission -> polarity assignment -> pad-attach doglegs -> full
+        geometric re-verification of both legs (masks + committed copper +
+        intra-pair floor + partner-pad floor) -> emit.  ANY failure declines
+        with a reason; nothing partial is ever committed (#3906).
+
+        Parity filtering: the polarity a coupled run can serve is fixed by
+        the travel direction of its first/last stub segment (offsetting is
+        continuous, so "P on the left" propagates end to end).  Stubs are
+        therefore partitioned by which side P would land on and the A* runs
+        once per consistent parity -- this lets a pair whose direct approach
+        would need a polarity twist hook around an endpoint and approach
+        from the reverse direction instead of declining outright.
+        """
+        from .coupled import (
+            assign_polarity,
+            merge_collinear_points,
+            offset_polyline,
+            seg_rect_dist,
+            side_bit,
+        )
+
+        net_p = pc.pad_p_a.net
+        net_n = pc.pad_n_a.net
+        pair_nets = {net_p, net_n}
+        half_pitch = pc.pitch / 2.0
+
+        layer_sets = [
+            set(self._pad_layer_indices(p))
+            for p in (pc.pad_p_a, pc.pad_n_a, pc.pad_p_b, pc.pad_n_b)
+        ]
+        common = tuple(sorted(set.intersection(*layer_sets)))
+        if not common:
+            return None, "pair-no-common-layer"
+
+        mid_a, mid_b = pc.mid_a, pc.mid_b
+        v_a = Pad(
+            x=mid_a[0],
+            y=mid_a[1],
+            width=0.0,
+            height=0.0,
+            net=net_p,
+            net_name=pc.pad_p_a.net_name,
+            layer=pc.pad_p_a.layer,
+            ref=pc.pad_p_a.ref,
+            pin=pc.pad_p_a.pin,
+        )
+        v_b = Pad(
+            x=mid_b[0],
+            y=mid_b[1],
+            width=0.0,
+            height=0.0,
+            net=net_p,
+            net_name=pc.pad_p_b.net_name,
+            layer=pc.pad_p_b.layer,
+            ref=pc.pad_p_b.ref,
+            pin=pc.pad_p_b.pin,
+        )
+
+        # The four main-run endpoint pads are the ONLY pads the fat
+        # centerline may overlap; every other pad -- including non-endpoint
+        # pads of the pair's own nets -- is an obstacle, because the leg of
+        # the opposite polarity would otherwise land on it (board-06 USB2
+        # B-row lesson).
+        endpoint_sites = {
+            (round(pad.x, 6), round(pad.y, 6), pad.net)
+            for pad in (pc.pad_p_a, pc.pad_n_a, pc.pad_p_b, pc.pad_n_b)
+        }
+        exempt = frozenset(
+            idx
+            for idx, pad in enumerate(self.pads)
+            if (round(pad.x, 6), round(pad.y, 6), pad.net) in endpoint_sites
+        )
+
+        # Collect EVERY legal fat stub in the search radius, then downselect
+        # for geometric diversity.  A count-capped nearest-first scan can
+        # exhaust itself inside an enclosed pocket (the board-06 BGA guard
+        # ring) and never reach the one dogleg that threads the way out.
+        raw_a = self.pad_stubs(
+            v_a,
+            net_p,
+            committed,
+            kmax=10_000,
+            extra_clearance=half_pitch,
+            partner_net=net_n,
+            layers=common,
+            exempt_pads=exempt,
+        )
+        stubs_a = _diverse_pair_stubs(raw_a, pc.mid_a, (pc.pad_p_a, pc.pad_n_a))
+        if not stubs_a:
+            return None, "pair-escape-a"
+        raw_b = self.pad_stubs(
+            v_b,
+            net_p,
+            committed,
+            kmax=10_000,
+            extra_clearance=half_pitch,
+            partner_net=net_n,
+            layers=common,
+            exempt_pads=exempt,
+        )
+        stubs_b = _diverse_pair_stubs(raw_b, pc.mid_b, (pc.pad_p_b, pc.pad_n_b))
+        if not stubs_b:
+            return None, "pair-escape-b"
+
+        def first_dir(poly: list[Pt]) -> Pt | None:
+            for a, b in zip(poly, poly[1:], strict=False):
+                if dist(a, b) > 1e-9:
+                    length = dist(a, b)
+                    return ((b[0] - a[0]) / length, (b[1] - a[1]) / length)
+            return None
+
+        def stub_bit(stub: tuple[NodeKey, int, list[Pt], float], *, at_goal: bool) -> bool | None:
+            d = first_dir(stub[2])
+            if d is None:
+                return None
+            if at_goal:
+                # The goal stub is traversed node -> pad, so the centerline's
+                # final travel direction is the REVERSE of the stub polyline.
+                d = (-d[0], -d[1])
+                return side_bit(d, pc.pad_p_b, pc.pad_n_b)
+            return side_bit(d, pc.pad_p_a, pc.pad_n_a)
+
+        # A zero-length stub (a lattice node exactly at the midpoint) has no
+        # direction of its own, so its polarity side is set by whatever
+        # lattice edge the search takes first -- outside the parity
+        # mechanism's control.  It is EXCLUDED (already dropped by the
+        # perpendicular gate in :func:`_diverse_pair_stubs`); directed
+        # doglegs to the surrounding nodes cover the same connectivity.
+        by_bit_a: dict[bool, list] = {True: [], False: []}
+        for stub in stubs_a:
+            bit = stub_bit(stub, at_goal=False)
+            if bit is not None:
+                by_bit_a[bit].append(stub)
+        by_bit_b: dict[bool, list] = {True: [], False: []}
+        for stub in stubs_b:
+            bit = stub_bit(stub, at_goal=True)
+            if bit is not None:
+                by_bit_b[bit].append(stub)
+
+        # Try the parity with the shortest direct stubs first.
+        def parity_rank(bit: bool) -> float:
+            sa = min((s[3] for s in by_bit_a[bit]), default=math.inf)
+            sb = min((s[3] for s in by_bit_b[bit]), default=math.inf)
+            return sa + sb
+
+        from .coupled import pads_block_segment_grown
+
+        trace_w = getattr(pc.net_class, "trace_width", None) or self.rules.trace_width
+        intra_clearance = pc.pitch - trace_w
+
+        def finish(result: _RouteResult) -> tuple[_PairResult | None, str]:
+            """Offset emission + verification of one fat centerline."""
+            if len(result.runs) != 1 or result.via_points:
+                return None, "pair-not-planar"  # defensive: vias are off
+
+            layer, raw_pts = result.runs[0]
+            center = merge_collinear_points(raw_pts)
+            if len(center) < 2:
+                return None, "pair-degenerate-centerline"
+            plus = offset_polyline(center, +half_pitch)
+            minus = offset_polyline(center, -half_pitch)
+            if plus is None or minus is None:
+                return None, "pair-offset-degenerate"
+            assigned = assign_polarity(plus, minus, pc.pad_p_a, pc.pad_n_a, pc.pad_p_b, pc.pad_n_b)
+            if assigned is None:
+                return None, "pair-polarity-twist"
+            leg_p, leg_n = assigned
+
+            legs: list[tuple[int, str, list[Pt]]] = []
+            for net, pad_a, pad_b, leg in (
+                (net_p, pc.pad_p_a, pc.pad_p_b, leg_p),
+                (net_n, pc.pad_n_a, pc.pad_n_b, leg_n),
+            ):
+                attach_a = self._pair_attach(pad_a, leg[0], layer, net, pair_nets, committed)
+                if attach_a is None:
+                    return None, "pair-pad-attach"
+                attach_b = self._pair_attach(pad_b, leg[-1], layer, net, pair_nets, committed)
+                if attach_b is None:
+                    return None, "pair-pad-attach"
+                full = attach_a[:-1] + leg + list(reversed(attach_b))[1:]
+
+                # Never-ship-a-short re-verification of the emitted leg:
+                # static masks (pair pads are "self") + committed copper at
+                # NORMAL single-trace clearance.  The fat centerline
+                # guarantees the parallel body; this catches miter pokes at
+                # sharp turns and the attach doglegs.
+                for a, b in zip(full, full[1:], strict=False):
+                    if dist(a, b) <= 1e-9:
+                        continue
+                    if pads_block_segment_grown(self.obstacles, a, b, layer, pair_nets, 0.0):
+                        return None, "pair-leg-blocked"
+                    if not committed.seg_clear(a, b, layer, net):
+                        return None, "pair-leg-blocked"
+                legs.append((net, pad_a.net_name, full))
+
+            # Intra-pair floor: leg-to-leg centreline separation must never
+            # dip below the pitch (== trace_width + intra-pair clearance).
+            # The offset body is at exactly the pitch by construction; this
+            # guards the attach doglegs and miter joints.  1e-4 mm slop.
+            full_p, full_n = legs[0][2], legs[1][2]
+            segs_p = [(a, b) for a, b in zip(full_p, full_p[1:], strict=False) if dist(a, b) > 1e-9]
+            segs_n = [(a, b) for a, b in zip(full_n, full_n[1:], strict=False) if dist(a, b) > 1e-9]
+            for a, b in segs_p:
+                for c, d in segs_n:
+                    if seg_seg_dist(a, b, c, d) < pc.pitch - 1e-4:
+                        return None, "pair-intra-clearance"
+
+            # Partner-pad floor: each leg must keep the intra-pair clearance
+            # to the OTHER net's raw pad copper (the pads sit inside the
+            # pair envelope, so the static mask deliberately skipped them).
+            for (net, _nn, full), other_net in ((legs[0], net_n), (legs[1], net_p)):
+                need = intra_clearance + trace_w / 2.0 - 1e-4
+                for idx, pad in enumerate(self.pads):
+                    if pad.net != other_net:
+                        continue
+                    if layer not in self.obstacles.pad_layer_indices[idx]:
+                        continue
+                    rect = (
+                        pad.x - pad.width / 2.0,
+                        pad.y - pad.height / 2.0,
+                        pad.x + pad.width / 2.0,
+                        pad.y + pad.height / 2.0,
+                    )
+                    for a, b in zip(full, full[1:], strict=False):
+                        if dist(a, b) <= 1e-9:
+                            continue
+                        if seg_rect_dist(a, b, rect) < need:
+                            return None, "pair-partner-pad"
+
+            routes: list[Route] = []
+            for net, net_name, full in legs:
+                route = self._emit_leg(net, net_name, full, layer, trace_w)
+                if route is None:
+                    return None, "pair-empty-route"
+                routes.append(route)
+            runs = [(net, layer, full) for net, _nn, full in legs]
+            return _PairResult(routes=routes, runs=runs, resources=result.resources), "ok"
+
+        # Attempt each consistent parity through the FULL pipeline: a parity
+        # whose shortest path emits degenerate/blocked legs must not doom the
+        # pair when the other parity works.
+        reason = "pair-no-path"
+        for bit in sorted((True, False), key=parity_rank):
+            if not by_bit_a[bit] or not by_bit_b[bit]:
+                continue
+            result, search_reason = self._route_impl(
+                v_a,
+                v_b,
+                pc.net_class,
+                committed=committed,
+                history=history,
+                present=present,
+                allow_vias=False,
+                extra_clearance=half_pitch,
+                partner_net=net_n,
+                stubs_override=(by_bit_a[bit], by_bit_b[bit]),
+                # The exemption is for the perpendicular-gated stub doglegs
+                # ONLY: the A* body sees every pad -- including the pair's
+                # own -- as an obstacle, else the shortest fat path hugs an
+                # endpoint pad row and the emitted legs land on the
+                # partner's copper (board-06 MIPI lesson).
+                exempt_pads=frozenset(),
+            )
+            if result is None:
+                reason = (
+                    search_reason if search_reason.startswith("pair-") else f"pair-{search_reason}"
+                )
+                continue
+            pres, finish_reason = finish(result)
+            if pres is not None:
+                return pres, "ok"
+            reason = finish_reason
+        return None, reason
+
     # -- multi-net negotiation ------------------------------------------------
 
     def route_netset(
         self,
         connections: list[Connection],
         *,
+        coupled: list[CoupledConnection] | None = None,
         max_iterations: int = 8,
         present_cost_initial: float = 1.0,
         present_cost_growth: float = 1.6,
@@ -683,6 +1234,16 @@ class LatticePathfinder:
         degenerate here: lattice resources have capacity 1, so ANY sharing is
         over-threshold and blocking is hard rather than cost-mediated.
 
+        Diff pairs (issue #4270): ``coupled`` carries
+        :class:`~kicad_tools.router.lattice.coupled.CoupledConnection`
+        entries, each negotiated as ONE fat centerline agent, all pairs
+        before all singles (shortest-first within each group).  A successful pair contributes two
+        routes keyed ``(pc.key, "P")`` / ``(pc.key, "N")``; both legs commit
+        under their own net ids so every other net sees them at full copper
+        gap while the pair's internal gap stays by-construction.  Per-pair
+        outcomes ("coupled" or a decline reason) land in
+        :attr:`pair_outcomes` for the best pass.
+
         The lattice is built **once** (:attr:`lattice_builds` == 1 across the
         whole negotiation); rip-up resets only the committed-copper model.
         Returns ``(routes_by_key, stats)`` for the best pass seen;
@@ -690,15 +1251,25 @@ class LatticePathfinder:
         for that pass.
         """
         self.build()
+        pairs = list(coupled or [])
 
-        ordered = sorted(
-            connections,
-            key=lambda c: math.hypot(c[1].x - c[2].x, c[1].y - c[2].y),
-        )
+        # Interleave singles and pairs shortest-first (pair length = the
+        # midpoint-to-midpoint distance of its main run).  The sort is
+        # stable, so with no pairs the ordering is exactly the pre-#4270 one.
+        items: list[tuple[float, int, Any]] = [
+            (math.hypot(c[1].x - c[2].x, c[1].y - c[2].y), 0, c) for c in connections
+        ]
+        items.extend((pc.length, 1, pc) for pc in pairs)
+        # Pairs first (kind 1 before kind 0), each group shortest-first: the
+        # fat coupled agents are by far the most constrained, and a pair's
+        # own extra-pad singles must never pre-block its corridor.  With no
+        # pairs this is exactly the pre-#4270 shortest-first ordering.
+        items.sort(key=lambda t: (-t[1], t[0]))
 
         history: dict[Resource, float] = {}
         best_routes: dict[object, Route] = {}
         best_reasons: dict[object, str] = {}
+        best_pair_outcomes: dict[object, str] = {}
         best_count = -1
         converged = False
         iterations_run = 0
@@ -709,15 +1280,36 @@ class LatticePathfinder:
             committed = self._fresh_committed()
             routes: dict[object, Route] = {}
             reasons: dict[object, str] = {}
-            failed: list[Connection] = []
-            for key, start, end, net_class in ordered:
+            pair_outcomes: dict[object, str] = {}
+            routed_items = 0
+            failed: list[tuple[int, Any]] = []
+            for _length, kind, item in items:
+                if kind == 1:
+                    pres, preason = self._route_pair_impl(
+                        item, committed=committed, history=history, present=present
+                    )
+                    if pres is None:
+                        reasons[item.key] = preason
+                        pair_outcomes[item.key] = preason
+                        failed.append((kind, item))
+                        continue
+                    pair_outcomes[item.key] = "coupled"
+                    routed_items += 1
+                    routes[(item.key, "P")] = pres.routes[0]
+                    routes[(item.key, "N")] = pres.routes[1]
+                    half = self._trace_half
+                    for leg_net, layer_idx, points in pres.runs:
+                        committed.add_run(layer_idx, points, leg_net, half)
+                    continue
+                key, start, end, net_class = item
                 result, reason = self._route_impl(
                     start, end, net_class, committed=committed, history=history, present=present
                 )
                 if result is None:
                     reasons[key] = reason
-                    failed.append((key, start, end, net_class))
+                    failed.append((kind, item))
                     continue
+                routed_items += 1
                 routes[key] = result.route
                 half = self._trace_half
                 for layer_idx, points in result.runs:
@@ -725,10 +1317,11 @@ class LatticePathfinder:
                 for via_pt in result.via_points:
                     committed.add_via(via_pt, start.net)
 
-            if len(routes) > best_count:
-                best_count = len(routes)
+            if routed_items > best_count:
+                best_count = routed_items
                 best_routes = routes
                 best_reasons = reasons
+                best_pair_outcomes = pair_outcomes
 
             if not failed:
                 converged = True
@@ -740,27 +1333,36 @@ class LatticePathfinder:
             # net WANTS (its corridor with no committed copper in the way) so
             # the occupying nets are pressured to detour next pass.
             increment = history_increment_factor * self.rules.cost_congestion * present
-            for _key, start, end, net_class in failed:
-                desired, _reason = self._route_impl(
-                    start,
-                    end,
-                    net_class,
-                    committed=self._fresh_committed(),
-                    history=history,
-                    present=present,
-                )
-                if desired is None:
+            for kind, item in failed:
+                if kind == 1:
+                    desired_pair, _r = self._route_pair_impl(
+                        item, committed=self._fresh_committed(), history=history, present=present
+                    )
+                    desired_resources = desired_pair.resources if desired_pair is not None else None
+                else:
+                    key, start, end, net_class = item
+                    desired, _reason = self._route_impl(
+                        start,
+                        end,
+                        net_class,
+                        committed=self._fresh_committed(),
+                        history=history,
+                        present=present,
+                    )
+                    desired_resources = desired.resources if desired is not None else None
+                if desired_resources is None:
                     continue
-                for resource in desired.resources:
+                for resource in desired_resources:
                     history[resource] = history.get(resource, 0.0) + increment
             present *= present_cost_growth
 
         self.failure_reasons = best_reasons
+        self.pair_outcomes = best_pair_outcomes
         stats = LatticeNegotiationStats(
             iterations=iterations_run,
             converged=converged,
-            routed=len(best_routes),
-            total=len(connections),
+            routed=best_count if best_count >= 0 else 0,
+            total=len(connections) + len(pairs),
             lattice_builds=self.lattice_builds,
         )
         return best_routes, stats

--- a/tests/router/lattice/test_coupled_board06.py
+++ b/tests/router/lattice/test_coupled_board06.py
@@ -33,6 +33,10 @@ import pytest
 from kicad_tools.router.lattice.geometry import seg_seg_dist
 from kicad_tools.router.rules import DesignRules
 
+# Runtime-heavy full-board negotiation: excluded from the CI fast lane
+# (`pytest -m "not slow"`); runs in the scheduled/full suites.
+pytestmark = pytest.mark.slow
+
 _REPO = Path(__file__).resolve().parents[3]
 _BOARD = _REPO / "boards/06-diffpair-test/output/diffpair_test.kicad_pcb"
 _CLASS_MAP = _REPO / "boards/06-diffpair-test/output/net_class_map.json"

--- a/tests/router/lattice/test_coupled_board06.py
+++ b/tests/router/lattice/test_coupled_board06.py
@@ -1,0 +1,149 @@
+"""Board-06 diff-pair coupled-routing witness on the lattice engine (#4270).
+
+Negotiates the real ``boards/06-diffpair-test`` signal net set through the
+lattice engine with the production pair grouping
+(:meth:`Autorouter._lattice_coupled_connections` -- detection, engagement,
+endpoint pairing, impedance-solved pitch + fab floor) and asserts the
+honest v1 acceptance measurements:
+
+* >= 5 of the 9 detected pairs route COUPLED (the measured v1 result:
+  USB2_D, PCIE_TX/RX, MIPI_CLK/D0 couple; the four USB3 pairs decline
+  honestly -- the U2 BGA GND guard ring's 0.82 mm gap cannot pass the
+  0.402 mm-pitch pair envelope planar, see the issue's decline census);
+* every non-coupled pair carries a decline reason (never silently split);
+* every coupled pair: 0 intra-pair clearance violations at the CLASS
+  threshold, coupled body at EXACTLY the emitted pitch, via-free legs;
+* ``lattice_builds == 1`` across the whole negotiation.
+
+Power/pour nets are excluded from this witness (the board serves them via
+zones, exactly like the committed grid output); the full-board CLI run is
+the same measurement with GND star routing on top and is exercised
+manually (see PR #4270 test plan).
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import warnings
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.router.lattice.geometry import seg_seg_dist
+from kicad_tools.router.rules import DesignRules
+
+_REPO = Path(__file__).resolve().parents[3]
+_BOARD = _REPO / "boards/06-diffpair-test/output/diffpair_test.kicad_pcb"
+_CLASS_MAP = _REPO / "boards/06-diffpair-test/output/net_class_map.json"
+
+_SIGNAL_ONLY = {"GND", "+3V3", "+1V8", "+1V2", "VBUS_USB"}
+
+# The four USB3 pairs cannot couple planar through the U2 BGA guard ring
+# at their impedance-solved pitch (honest v1 decline; see issue #4270).
+_EXPECTED_COUPLED_FLOOR = 5
+
+
+@pytest.fixture(scope="module")
+def negotiated():
+    from kicad_tools.router.io import load_pcb_for_routing
+    from kicad_tools.router.rules import net_class_map_from_dict
+
+    rules = DesignRules(trace_width=0.2, trace_clearance=0.15, manufacturer="jlcpcb")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        router, _net_map = load_pcb_for_routing(
+            str(_BOARD),
+            rules=rules,
+            use_pcb_rules=False,
+            validate_drc=False,
+            strategy="lattice",
+            skip_nets=sorted(_SIGNAL_ONLY),
+        )
+    router.net_class_map.update(net_class_map_from_dict(json.loads(_CLASS_MAP.read_text())))
+
+    pf = router._ensure_lattice_pathfinder()
+    coupled, reserved = router._lattice_coupled_connections()
+
+    # Signal-only star connections, mirroring _negotiate_lattice_netset's
+    # reserved-aware topology (extras attach to the nearest endpoint).
+    connections = []
+    for net, pad_keys in router.nets.items():
+        if net == 0:
+            continue
+        keyed = [(k, router.pads[k]) for k in pad_keys if k in router.pads]
+        if len(keyed) < 2:
+            continue
+        res_keys = reserved.get(net)
+        if res_keys:
+            res_pads = [p for k, p in keyed if k in res_keys]
+            extras = [p for k, p in keyed if k not in res_keys]
+            for seq, other in enumerate(extras):
+                anchor = min(res_pads, key=lambda rp: math.hypot(rp.x - other.x, rp.y - other.y))
+                connections.append(((net, seq), anchor, other, None))
+            continue
+        pads = [p for _k, p in keyed]
+        for seq, other in enumerate(pads[1:]):
+            connections.append(((net, seq), pads[0], other, None))
+
+    routes, stats = pf.route_netset(connections, coupled=coupled, max_iterations=12)
+    return router, pf, coupled, routes, stats
+
+
+def test_engaged_pair_census_and_coupled_floor(negotiated) -> None:
+    router, pf, coupled, routes, stats = negotiated
+    assert len(coupled) == 9, "board-06 must engage all 9 detected pairs"
+    outcomes = {pc.pair_name: pf.pair_outcomes.get(pc.key, "not-attempted") for pc in coupled}
+    n_coupled = sum(1 for v in outcomes.values() if v == "coupled")
+    assert n_coupled >= _EXPECTED_COUPLED_FLOOR, f"coupled census regressed: {outcomes}"
+    # Honest decline discipline: every shortfall names its reason and no
+    # partial pair copper exists.
+    for pc in coupled:
+        outcome = outcomes[pc.pair_name]
+        if outcome == "coupled":
+            assert (pc.key, "P") in routes and (pc.key, "N") in routes
+        else:
+            assert outcome != "not-attempted"
+            assert (pc.key, "P") not in routes and (pc.key, "N") not in routes
+    assert stats.lattice_builds == 1
+
+
+def test_coupled_pairs_meet_class_intra_floor_and_exact_pitch(negotiated) -> None:
+    from kicad_tools.router.diffpair_routing import find_intra_pair_clearance_violations
+
+    router, pf, coupled, routes, _stats = negotiated
+    checked = 0
+    for pc in coupled:
+        if pf.pair_outcomes.get(pc.key) != "coupled":
+            continue
+        route_p = routes[(pc.key, "P")]
+        route_n = routes[(pc.key, "N")]
+        assert not route_p.vias and not route_n.vias, "v1 coupled runs are planar"
+        # Engine-agnostic validator at the CLASS threshold (issue AC #2).
+        threshold = pc.net_class.effective_intra_pair_clearance()
+        violation = find_intra_pair_clearance_violations(
+            route_p, route_n, threshold, pair_name=pc.pair_name
+        )
+        assert violation is None, f"{pc.pair_name}: {violation}"
+        # The coupled body sits at exactly the emitted pitch.
+        min_sep = min(
+            seg_seg_dist((sp.x1, sp.y1), (sp.x2, sp.y2), (sn.x1, sn.y1), (sn.x2, sn.y2))
+            for sp in route_p.segments
+            for sn in route_n.segments
+        )
+        assert min_sep == pytest.approx(pc.pitch, abs=1e-3), pc.pair_name
+        checked += 1
+    assert checked >= _EXPECTED_COUPLED_FLOOR
+
+
+def test_pitch_carries_solved_width_plus_fab_floor(negotiated) -> None:
+    router, _pf, coupled, _routes, _stats = negotiated
+    from kicad_tools.router.mfr_limits import get_mfr_limits
+
+    floor = get_mfr_limits("jlcpcb").min_clearance
+    by_name = {pc.pair_name: pc for pc in coupled}
+    usb2 = by_name["USB2_D"]
+    # Impedance-solved width 0.25 + max(intra 0.075, jlcpcb floor 0.127).
+    assert usb2.pitch == pytest.approx(0.25 + max(0.075, floor))
+    usb3 = by_name["USB3_TX1"]
+    assert usb3.pitch == pytest.approx(0.275 + max(0.10, floor))

--- a/tests/router/lattice/test_coupled_pairs.py
+++ b/tests/router/lattice/test_coupled_pairs.py
@@ -1,0 +1,396 @@
+"""Diff-pair coupled routing on the lattice engine (issue #4270, P3).
+
+Unit coverage for the fat-agent centerline + geometric offset emission:
+
+* offset octilinearity property (segment directions preserved -> #3907);
+* exact-pitch emission on the coupled body;
+* polarity-side selection (P leg lands on the P pads' side);
+* decline paths: blocked fat envelope, polarity twist, no planar path --
+  every decline carries a reason and emits NOTHING (never split, #3906);
+* engagement gating (``coupled_routing=False`` classes stay single-ended).
+
+The board-06 witness (>= coupled floor, intra-pair validator, DRC) lives in
+``test_coupled_board06.py`` -- it negotiates the full 26-net board and is
+runtime-heavy.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from kicad_tools.router.lattice.coupled import (
+    CoupledConnection,
+    assign_polarity,
+    choose_pair_endpoints,
+    merge_collinear_points,
+    offset_polyline,
+)
+from kicad_tools.router.lattice.geometry import dist, seg_seg_dist
+from kicad_tools.router.lattice.pathfinder import LatticePathfinder
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import DesignRules, NetClassRouting
+
+_RULES = DesignRules(trace_width=0.2, trace_clearance=0.15, manufacturer="jlcpcb")
+
+_HS = NetClassRouting(
+    name="HS",
+    trace_width=0.2,
+    clearance=0.15,
+    intra_pair_clearance=0.1,
+    coupled_routing=True,
+)
+_PITCH = _HS.trace_width + _HS.effective_intra_pair_clearance()  # 0.3
+
+
+def _pad(
+    x: float,
+    y: float,
+    net: int,
+    net_name: str,
+    *,
+    ref: str,
+    width: float = 0.5,
+    height: float = 0.5,
+) -> Pad:
+    return Pad(
+        x=x,
+        y=y,
+        width=width,
+        height=height,
+        net=net,
+        net_name=net_name,
+        layer=Layer.F_CU,
+        ref=ref,
+        pin="1",
+    )
+
+
+def _pair_board(
+    extra_pads: list[Pad] | None = None,
+    *,
+    swap_far_end: bool = False,
+    outline: list[tuple[float, float]] | None = None,
+) -> tuple[LatticePathfinder, CoupledConnection]:
+    """A 30x12 two-layer board with one horizontal diff pair (nets 1/2)."""
+    outline = outline or [(0.0, 0.0), (30.0, 0.0), (30.0, 12.0), (0.0, 12.0)]
+    p_a = _pad(3.0, 5.0, 1, "D+", ref="J1")
+    n_a = _pad(3.0, 6.0, 2, "D-", ref="J1")
+    by, ny = (6.0, 5.0) if swap_far_end else (5.0, 6.0)
+    p_b = _pad(27.0, by, 1, "D+", ref="U1")
+    n_b = _pad(27.0, ny, 2, "D-", ref="U1")
+    pads = [p_a, n_a, p_b, n_b] + list(extra_pads or [])
+    pf = LatticePathfinder(outline, pads, _RULES, LayerStack.two_layer())
+    pc = CoupledConnection(
+        key=("pair", 1, 2),
+        pair_name="D",
+        pad_p_a=p_a,
+        pad_n_a=n_a,
+        pad_p_b=p_b,
+        pad_n_b=n_b,
+        net_class=_HS,
+        pitch=_PITCH,
+    )
+    return pf, pc
+
+
+def _is_octilinear(a: tuple[float, float], b: tuple[float, float]) -> bool:
+    dx, dy = b[0] - a[0], b[1] - a[1]
+    if math.hypot(dx, dy) <= 1e-9:
+        return True
+    ang = math.degrees(math.atan2(dy, dx)) % 45.0
+    return min(ang, 45.0 - ang) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Offset geometry (pure)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "polyline",
+    [
+        [(0.0, 0.0), (10.0, 0.0)],
+        [(0.0, 0.0), (10.0, 0.0), (15.0, 5.0)],
+        [(0.0, 0.0), (5.0, 5.0), (10.0, 5.0), (10.0, 10.0), (6.0, 14.0)],
+        [(0.0, 0.0), (4.0, 0.0), (8.0, 4.0), (8.0, 9.0), (12.0, 13.0), (20.0, 13.0)],
+    ],
+)
+@pytest.mark.parametrize("offset", [0.15, -0.15, 0.1375])
+def test_offset_preserves_octilinear_directions(polyline, offset) -> None:
+    """#3907 by construction: every offset segment keeps its source direction."""
+    out = offset_polyline(polyline, offset)
+    assert out is not None
+    assert len(out) == len(polyline)
+    for (a, b), (c, d) in zip(
+        zip(polyline, polyline[1:], strict=False), zip(out, out[1:], strict=False), strict=True
+    ):
+        assert _is_octilinear(c, d)
+        # Same direction as the source segment (unit-vector match).
+        la, lo = dist(a, b), dist(c, d)
+        assert lo > 0
+        assert math.isclose((b[0] - a[0]) / la, (d[0] - c[0]) / lo, abs_tol=1e-9)
+        assert math.isclose((b[1] - a[1]) / la, (d[1] - c[1]) / lo, abs_tol=1e-9)
+
+
+def test_offset_legs_sit_at_exact_pitch() -> None:
+    """+/- pitch/2 offsets are exactly pitch apart along the whole body."""
+    center = [(0.0, 0.0), (8.0, 0.0), (12.0, 4.0), (20.0, 4.0)]
+    plus = offset_polyline(center, +_PITCH / 2.0)
+    minus = offset_polyline(center, -_PITCH / 2.0)
+    assert plus is not None and minus is not None
+    for (a, b), (c, d) in zip(
+        zip(plus, plus[1:], strict=False), zip(minus, minus[1:], strict=False), strict=True
+    ):
+        assert seg_seg_dist(a, b, c, d) == pytest.approx(_PITCH, abs=1e-9)
+
+
+def test_offset_declines_on_u_turn_and_degenerate() -> None:
+    assert offset_polyline([(0.0, 0.0), (5.0, 0.0), (0.0, 0.0)], 0.15) is None  # U-turn
+    assert offset_polyline([(0.0, 0.0), (0.0, 0.0)], 0.15) is None  # zero-length
+    assert offset_polyline([(0.0, 0.0)], 0.15) is None  # single point
+    # Tight inside turn shorter than the miter -> reversed segment -> None.
+    assert offset_polyline([(0.0, 0.0), (0.05, 0.0), (0.05, 0.05), (0.0, 0.05)], 0.3) is None
+
+
+def test_merge_collinear_points_fuses_straight_runs() -> None:
+    pts = [(0.0, 0.0), (1.0, 0.0), (2.0, 0.0), (3.0, 1.0), (3.0, 1.0), (4.0, 2.0), (5.0, 2.0)]
+    assert merge_collinear_points(pts) == [(0.0, 0.0), (2.0, 0.0), (4.0, 2.0), (5.0, 2.0)]
+
+
+def test_assign_polarity_maps_legs_by_pad_side_and_detects_twist() -> None:
+    center = [(0.0, 5.5), (30.0, 5.5)]
+    plus = offset_polyline(center, +0.15)  # left of +x travel = y+ side
+    minus = offset_polyline(center, -0.15)
+    assert plus is not None and minus is not None
+    p_a = _pad(0.0, 6.0, 1, "D+", ref="A")
+    n_a = _pad(0.0, 5.0, 2, "D-", ref="A")
+    p_b = _pad(30.0, 6.0, 1, "D+", ref="B")
+    n_b = _pad(30.0, 5.0, 2, "D-", ref="B")
+    assigned = assign_polarity(plus, minus, p_a, n_a, p_b, n_b)
+    assert assigned is not None
+    leg_p, _leg_n = assigned
+    assert leg_p == plus  # P pads sit on the +offset side at both ends
+    # Swap P/N at end B -> twist -> None.
+    assert assign_polarity(plus, minus, p_a, n_a, n_b, p_b) is None
+
+
+def test_choose_pair_endpoints_picks_farthest_couples() -> None:
+    ps = [
+        _pad(0.0, 0.0, 1, "D+", ref="A"),
+        _pad(0.1, 2.0, 1, "D+", ref="B"),
+        _pad(20.0, 0.0, 1, "D+", ref="C"),
+    ]
+    ns = [
+        _pad(0.0, 1.0, 2, "D-", ref="A"),
+        _pad(0.1, 3.0, 2, "D-", ref="B"),
+        _pad(20.0, 1.0, 2, "D-", ref="C"),
+    ]
+    chosen = choose_pair_endpoints(ps, ns)
+    assert chosen is not None
+    (ip_a, in_a), (ip_b, in_b) = chosen
+    picked = {ip_a, ip_b}
+    assert 2 in picked, "the far couple must be an endpoint"
+    assert in_a == ip_a and in_b == ip_b, "couples pair nearest P/N"
+    # Degenerate: a single couple cannot form a main run.
+    assert choose_pair_endpoints(ps[:1], ns[:1]) is None
+    assert choose_pair_endpoints([], ns) is None
+
+
+# ---------------------------------------------------------------------------
+# Coupled negotiation on a synthetic board
+# ---------------------------------------------------------------------------
+
+
+def test_pair_routes_coupled_at_exact_pitch_with_correct_polarity() -> None:
+    pf, pc = _pair_board()
+    routes, stats = pf.route_netset([], coupled=[pc])
+    assert pf.pair_outcomes[pc.key] == "coupled", pf.pair_outcomes
+    assert stats.routed == 1 and stats.total == 1
+    assert stats.lattice_builds == 1
+    route_p = routes[(pc.key, "P")]
+    route_n = routes[(pc.key, "N")]
+    assert route_p.net == 1 and route_n.net == 2
+    assert not route_p.vias and not route_n.vias  # planar v1
+    # Legs terminate on their exact pads (polarity-correct attach).
+    ends_p = {(s.x1, s.y1) for s in route_p.segments} | {(s.x2, s.y2) for s in route_p.segments}
+    assert (pc.pad_p_a.x, pc.pad_p_a.y) in ends_p
+    assert (pc.pad_p_b.x, pc.pad_p_b.y) in ends_p
+    # The coupled body sits at exactly the pitch: the straight mid-corridor
+    # segments of the two legs are pitch apart.
+    min_sep = min(
+        seg_seg_dist((sp.x1, sp.y1), (sp.x2, sp.y2), (sn.x1, sn.y1), (sn.x2, sn.y2))
+        for sp in route_p.segments
+        for sn in route_n.segments
+    )
+    assert min_sep == pytest.approx(_PITCH, abs=1e-4)
+    # Emitted at the CLASS trace width (the pitch math depends on it).
+    assert all(s.width == pytest.approx(_HS.trace_width) for s in route_p.segments)
+    # Intra-pair clearance validator (engine-agnostic reuse) finds nothing.
+    from kicad_tools.router.diffpair_routing import find_intra_pair_clearance_violations
+
+    violation = find_intra_pair_clearance_violations(
+        route_p, route_n, _HS.effective_intra_pair_clearance(), pair_name="D"
+    )
+    assert violation is None
+
+
+def test_pair_declines_when_fat_envelope_is_blocked() -> None:
+    # A wall slot 0.8 mm wide: passable for one 0.2/0.15 trace (band 0.3 mm)
+    # but NOT for the 0.3-pitch fat agent (band 0.0 mm).  The pair must
+    # decline with a reason and emit NOTHING -- never split into uncoupled
+    # legs (#4270 v1 semantics).
+    walls = [
+        _pad(15.0, 9.15, 9, "WALL", ref="WT", width=0.5, height=6.5),
+        _pad(15.0, 1.85, 9, "WALL", ref="WB", width=0.5, height=6.5),
+    ]
+    pf, pc = _pair_board(walls)
+    routes, stats = pf.route_netset([], coupled=[pc])
+    assert pf.pair_outcomes[pc.key] != "coupled"
+    assert pf.failure_reasons[pc.key] == pf.pair_outcomes[pc.key]
+    assert routes == {}
+    assert stats.routed == 0 and stats.total == 1
+    # The same corridor IS single-ended routable: the two nets as ordinary
+    # connections complete (proves the decline was the fat envelope, not
+    # the corridor).
+    pf2, pc2 = _pair_board(walls)
+    singles = [
+        ((1, 0), pc2.pad_p_a, pc2.pad_p_b, None),
+        ((2, 0), pc2.pad_n_a, pc2.pad_n_b, None),
+    ]
+    routes2, stats2 = pf2.route_netset(singles)
+    assert stats2.routed == 2, pf2.failure_reasons
+
+
+def test_pair_declines_on_polarity_twist_when_no_hook_room() -> None:
+    # P/N swapped at the far end.  Full-height walls RIGHT behind both end
+    # pad columns (grown keep-outs overlapping the pads' own) leave no hook
+    # corridor to approach from behind, so the twist cannot be resolved ->
+    # honest decline, nothing emitted.
+    walls = [
+        _pad(1.8, 6.0, 9, "WALL", ref="WA", width=0.4, height=12.0),
+        _pad(28.2, 6.0, 9, "WALL", ref="WB", width=0.4, height=12.0),
+    ]
+    pf, pc = _pair_board(walls, swap_far_end=True)
+    routes, _stats = pf.route_netset([], coupled=[pc])
+    assert routes == {}
+    assert pf.pair_outcomes[pc.key] != "coupled"
+
+
+def test_pair_declines_with_no_planar_path() -> None:
+    # A full-height wall between the ends on BOTH layers (the wall net has
+    # a through-hole-like blocking twin on B.Cu) -> no planar corridor at
+    # all; v1 pair agents are via-free so the pair declines.
+    wall_f = _pad(15.0, 6.0, 9, "WALL", ref="WF", width=0.6, height=13.0)
+    wall_b = Pad(
+        x=15.0,
+        y=6.0,
+        width=0.6,
+        height=13.0,
+        net=9,
+        net_name="WALL",
+        layer=Layer.B_CU,
+        ref="WB",
+        pin="1",
+    )
+    pf, pc = _pair_board([wall_f, wall_b])
+    routes, _stats = pf.route_netset([], coupled=[pc])
+    assert routes == {}
+    assert pf.pair_outcomes[pc.key] != "coupled"
+    assert pc.key in pf.failure_reasons
+
+
+def test_polarity_twist_resolves_via_hook_when_room_exists() -> None:
+    # Same twist, but with open board behind the far end: the parity-
+    # filtered stub search may approach from behind and un-twist.  Either
+    # outcome is legal copper; if it couples, polarity must be correct.
+    pf, pc = _pair_board(swap_far_end=True)
+    routes, _stats = pf.route_netset([], coupled=[pc])
+    if pf.pair_outcomes[pc.key] == "coupled":
+        route_p = routes[(pc.key, "P")]
+        ends_p = {(s.x1, s.y1) for s in route_p.segments} | {(s.x2, s.y2) for s in route_p.segments}
+        assert (pc.pad_p_a.x, pc.pad_p_a.y) in ends_p
+        assert (pc.pad_p_b.x, pc.pad_p_b.y) in ends_p
+        from kicad_tools.router.diffpair_routing import find_intra_pair_clearance_violations
+
+        violation = find_intra_pair_clearance_violations(
+            route_p, routes[(pc.key, "N")], _HS.effective_intra_pair_clearance(), pair_name="D"
+        )
+        assert violation is None
+    else:
+        assert routes == {}
+
+
+def test_coupled_pair_blocks_other_nets_at_full_copper_gap() -> None:
+    # A single-ended net negotiated AFTER the pair must respect both legs.
+    pf, pc = _pair_board(
+        [
+            _pad(3.0, 2.0, 7, "S", ref="S1"),
+            _pad(27.0, 9.0, 7, "S", ref="S2"),
+        ]
+    )
+    conns = [((7, 0), pf.pads[4], pf.pads[5], None)]
+    routes, stats = pf.route_netset(conns, coupled=[pc])
+    assert pf.pair_outcomes[pc.key] == "coupled"
+    assert stats.routed == 2
+    copper_gap = _RULES.trace_width + _RULES.trace_clearance
+    single = routes[(7, 0)]
+    for leg_key in ((pc.key, "P"), (pc.key, "N")):
+        leg = routes[leg_key]
+        for s1 in single.segments:
+            for s2 in leg.segments:
+                if s1.layer != s2.layer:
+                    continue
+                d = seg_seg_dist((s1.x1, s1.y1), (s1.x2, s1.y2), (s2.x1, s2.y1), (s2.x2, s2.y2))
+                assert d >= copper_gap - 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Engagement gating through the Autorouter hook (core.py)
+# ---------------------------------------------------------------------------
+
+
+def _autorouter(net_class_map: dict) -> object:
+    from kicad_tools.router.core import Autorouter
+
+    router = Autorouter(30, 12, strategy="lattice", net_class_map=net_class_map)
+    pads = [
+        _pad(3.0, 5.0, 1, "D+", ref="J1"),
+        _pad(3.0, 6.0, 2, "D-", ref="J1"),
+        _pad(27.0, 5.0, 1, "D+", ref="U1"),
+        _pad(27.0, 6.0, 2, "D-", ref="U1"),
+    ]
+    for i, pad in enumerate(pads):
+        key = (pad.ref, f"{i}")
+        router.pads[key] = pad
+        router.nets.setdefault(pad.net, []).append(key)
+        router.net_names[pad.net] = pad.net_name
+    return router
+
+
+def test_core_engages_coupled_for_opted_in_class() -> None:
+    router = _autorouter({"D+": _HS, "D-": _HS})
+    routes = router.route_net(1)
+    assert router._lattice_pair_outcomes == {"D": "coupled"}
+    assert routes and all(r.net == 1 for r in routes)
+    routes_n = router.route_net(2)
+    assert routes_n and all(r.net == 2 for r in routes_n)
+    assert router._lattice_pathfinder.lattice_builds == 1
+
+
+def test_core_stays_single_ended_without_coupled_routing_opt_in() -> None:
+    nc = NetClassRouting(
+        name="HS_OFF",
+        trace_width=0.2,
+        clearance=0.15,
+        intra_pair_clearance=0.1,
+        coupled_routing=False,
+    )
+    router = _autorouter({"D+": nc, "D-": nc})
+    routes = router.route_net(1)
+    assert router._lattice_pair_outcomes == {}
+    assert routes, "single-ended fallback must still route the net"
+    # No coupled keys in the negotiated cache: both nets served as singles.
+    assert router._lattice_negotiation_stats.total == 2

--- a/tests/router/test_optimizer_backstop.py
+++ b/tests/router/test_optimizer_backstop.py
@@ -153,3 +153,67 @@ class TestCliBackstopHelper:
         # No demotion -> no backstop message.
         assert "Post-optimize backstop demoted" not in capsys.readouterr().out
         assert r1 in ar.routes and r2 in ar.routes
+
+
+class TestCoupledDiffPairExemption:
+    """Issue #4270: a legitimately-coupled diff pair (leg-to-leg gap = the
+    per-class intra-pair clearance, deliberately below the global trace
+    clearance) must NOT be demoted by the wide finalize threshold.  The
+    exemption is verified, not assumed: a pair whose copper breaks its own
+    intra floor is still demoted."""
+
+    @staticmethod
+    def _pair_autorouter(gap: float) -> Autorouter:
+        from kicad_tools.router.rules import NetClassRouting
+
+        ar = _make_autorouter()
+        hs = NetClassRouting(
+            name="HS",
+            trace_width=0.2,
+            clearance=0.15,
+            intra_pair_clearance=0.1,
+            coupled_routing=True,
+        )
+        ar.net_class_map["D+"] = hs
+        ar.net_class_map["D-"] = hs
+        ar.net_names[1] = "D+"
+        ar.net_names[2] = "D-"
+        # Two parallel legs 'gap' apart edge-to-edge (centreline 0.2 + gap).
+        sep = 0.2 + gap
+        r_p = _route(1, [_seg(2.0, 5.0, 12.0, 5.0, 1)], "D+")
+        r_n = _route(2, [_seg(2.0, 5.0 + sep, 12.0, 5.0 + sep, 2)], "D-")
+        for r in (r_p, r_n):
+            _commit(ar, r)
+        return ar
+
+    def test_coupled_pair_honoring_intra_floor_is_exempt(self):
+        # Edge gap 0.1 == intra_pair_clearance floor, below the global
+        # 0.15 clearance: the pre-#4270 gate demoted one leg as a short.
+        ar = self._pair_autorouter(gap=0.11)
+        assert ar.revalidate_committed_copper_or_demote() == []
+        assert len(ar.routes) == 2
+
+    def test_pair_breaking_its_own_intra_floor_is_still_demoted(self):
+        # Edge gap 0.05 < intra_pair_clearance 0.1: a REAL violation --
+        # the exemption must not fire.
+        ar = self._pair_autorouter(gap=0.05)
+        demoted = ar.revalidate_committed_copper_or_demote()
+        assert demoted, "sub-intra-floor pair must still be demoted"
+
+    def test_pair_without_explicit_intra_clearance_is_not_exempt(self):
+        from kicad_tools.router.rules import NetClassRouting
+
+        ar = _make_autorouter()
+        nc = NetClassRouting(name="HS", trace_width=0.2, clearance=0.15)
+        ar.net_class_map["D+"] = nc
+        ar.net_class_map["D-"] = nc
+        ar.net_names[1] = "D+"
+        ar.net_names[2] = "D-"
+        r_p = _route(1, [_seg(2.0, 5.0, 12.0, 5.0, 1)], "D+")
+        r_n = _route(2, [_seg(2.0, 5.31, 12.0, 5.31, 2)], "D-")
+        for r in (r_p, r_n):
+            _commit(ar, r)
+        # 0.11 edge gap without a declared intra clearance: an accidental
+        # suffix-detected pair never qualifies for the exemption.
+        demoted = ar.revalidate_committed_copper_or_demote()
+        assert demoted


### PR DESCRIPTION
## Summary

Implements lattice-router P3 (epic #4267): engaged differential pairs route on the lattice engine as **one fat A\* agent** — the pair centerline, with every legality check inflated by `pair_pitch/2` — and P/N are emitted as perpendicular `±pitch/2` geometric offsets of that centerline. Offset vertices are exact intersections of parallel offset lines, so segment directions are unchanged and the legs pass the #3907 octilinear choke by construction. `CommittedCopper` and DRC are geometric, so off-node copper is legal.

v1 pair agents are **planar** (`allow_vias=False`): a pair that cannot complete a coupled single-layer run **declines with a per-pair reason** — it is never split into uncoupled legs and never ships a short (#3906). Length-match/serpentine is the explicit follow-up per the curated issue.

## Changes

- **`router/lattice/coupled.py` (new)** — `CoupledConnection`; miter-collapsing octilinear polyline offset (`offset_polyline`); polarity assignment; grown geometric fat-agent legality queries (static pad model + committed copper; **no second mask build — `lattice_builds` stays 1**); proximity endpoint pairing.
- **`router/lattice/pathfinder.py`** — fat-agent mode on `pad_stubs`/`_route_impl` (`extra_clearance`, partner-net self-set, endpoint-pad exemption for the stub doglegs only — the A\* body sees every pad as an obstacle); **parity-filtered stubs** (the polarity side a run can serve is fixed by its first/last stub direction, so a would-be polarity twist resolves by hooking around an endpoint — this is how both PCIe pairs couple); diverse fat-stub downselect (perpendicular gate + octant×distance-shell caps so enclosed pockets like the board-06 BGA cannot starve the escape); `_route_pair_impl` with full geometric re-verification (masks, committed copper, intra-pair floor, partner-pad floor) before emission; pairs-first negotiation in `route_netset` with `pair_outcomes`.
- **`router/core.py`** — `_lattice_coupled_connections()` reusing `detect_diff_pairs` + `should_engage_coupled` (the grid pre-pass gates); proximity main-run endpoint selection with extra same-net pads routed as ordinary singles anchored on the reserved endpoints; intra gap clamped to the configured fab tier's `min_clearance` floor; per-pair engaged/coupled/declined census in the route summary.
- **`router/algorithms/negotiated.py` + `core.py`** — the #3989/#4208 finalize short-gate demoted legitimately-coupled legs (intra gap < global clearance **by design**). `demote_seg_seg_finalize` gains `exempt_pairs`; the Autorouter exempts exactly the partner pairs whose copper **verifiably honors their declared intra-pair floor** (`find_intra_pair_clearance_violations`); a pair breaking its own floor is still demoted (covered by new tests).
- **Tests** — `tests/router/lattice/test_coupled_pairs.py` (25 unit tests: offset octilinearity property, exact-pitch emission, polarity selection + twist, decline paths never emit partial copper, engagement gating, cross-net copper gap); `tests/router/lattice/test_coupled_board06.py` (board-06 witness through the production core hook); backstop exemption tests in `tests/router/test_optimizer_backstop.py`.

## Board-06 witness (honest numbers)

`kct route boards/06-diffpair-test/output/diffpair_test.kicad_pcb --route-engine lattice --strategy basic --layers 4 --net-class-map … --trace-width 0.2 --clearance 0.15 --manufacturer jlcpcb --skip-nets "GND,+3V3,+1V8,+1V2"` (power via zones, like the committed board):

**Coupled: 5/9 detected pairs** (layered detection finds 9 pairs on this board, not the 11 estimated in the issue). Decline census:

| pair | outcome |
|---|---|
| USB2_D | **coupled** (fraction 0.93 ≥ 0.7, 2 extra pads routed single-ended) |
| PCIE_TX / PCIE_RX | **coupled** (fraction 1.00 ≥ 0.85; both pairs are polarity-twisted at J3 and resolve via the parity hook) |
| MIPI_CLK / MIPI_D0 | **coupled** (fraction 1.00 ≥ 0.85) |
| USB3_TX1/RX1/TX2/RX2 | **declined: `pair-no-path`** — the U2 BGA GND guard ring leaves a 0.82 mm copper gap; the pair envelope at the impedance-solved pitch (0.275 tw + 0.127 floor = 0.402) needs 0.95 mm planar. A coupled layer-dip or escape-then-gather is the sanctioned follow-up (issue “Out of scope”). |

This is below the issue's 8/11 floor; per the acceptance text (“Floor, not target — report the reasons and the owner adjudicates scope vs non-goal, per epic §7”) the four declines share one geometric cause and are reported for adjudication.

- **Intra-pair violations: 0** on all coupled pairs at the class thresholds (`find_intra_pair_clearance_violations`).
- **Coupled continuity rule: all coupled pairs PASS** (0.88–1.00 vs 0.7/0.85 thresholds) — the committed grid output fails this rule on **all 9** pairs (its P–N gaps are 0.3–0.6 mm).
- **Emitted pitch exact**: min centerline separation == pitch on every coupled body.
- **kicad-cli pcb drc --refill-zones: 0 errors** under the board's shipped project rules (same gate the committed grid board passes at 0). Unconnected items are only the honestly-declined USB3 legs + USB_CC1.
- **USB_CC1 (single-ended)**: routes on the pre-PR single-ended baseline but starves next to the widened USB2 pair corridor at J1 — an honest negotiation-capacity casualty, reported (12/21 signal nets vs 13/21 pre-clamp).
- `kct check --mfr jlcpcb` (with sidecar): continuity 0 errors (committed board: 9), skew 4 errors (length-match = explicit follow-up), impedance 5 errors on **single-ended** nets (global-width emission — #4271's exact scope), connectivity = the declined nets above.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Board-06 ≥ 8/11 pairs coupled | ⚠️ 5/9 measured | Honest decline census above; all 4 shortfalls are one geometric cause (BGA guard ring vs solved pitch, planar v1); owner adjudicates per the issue's floor clause |
| Coupled fraction ≥ class threshold, 0 intra violations, exact pitch | ✅ | 0.88–1.00 vs 0.7/0.85; validator 0 findings at class thresholds; min separation == pitch |
| 0 shorts / 0 clearance in emitted copper (kicad-cli --refill-zones) | ✅ | 0 errors with the shipped project rules; matches the committed board's gate |
| Grid + mesh untouched, byte-identical | ✅ | No `router/mesh/` edits; grid route of board-01 byte-identical vs main (modulo uuids); dormant-path tests green |
| `lattice_builds == 1`; #4283/#4284 invariants | ✅ | Asserted in tests; pair agents via-free so the via-in-pad tier gate is never consulted; post-pass gating tests green |
| Unit tests (offset property, pitch, polarity, declines, gating) | ✅ | 25 unit + 3 board-06 integration + 3 backstop tests, all green |
| Length-match/serpentine out of scope | ✅ | Not touched; skew failures reported as follow-up territory |

## Test Plan

- `uv run pytest tests/router/lattice/ tests/router/mesh/ tests/router/test_optimizer_backstop.py tests/router/test_seg_seg_quality_tuple.py tests/test_route_engine_strategy_gate.py tests/test_manufacturer_propagation_lint.py` → **206 passed** (the 3 `test_post_pass_gating` CLI tests fail under `-W error::UserWarning` on main too — pre-existing, not touched).
- `scripts/ci/check_mypy_baseline.py` → 0 new errors, baseline untouched. `ruff check` + `ruff format` clean.
- Full CLI witness run + kicad-cli DRC + `kct check` as above.

## Coordination note

**#4271 (net-class width threading through lattice emission/clearance) is a parallel sibling.** This PR keeps its diff on the pair-agent path: new module + additive fat-agent branches; singles still pass `net_class=None` (their global-width emission — visible as the 5 impedance findings above — is #4271's scope). The pair path already emits at the class trace width because the pitch math requires it.

Closes #4270

🤖 Generated with [Claude Code](https://claude.com/claude-code)