### PR TITLE
feat(lattice): per-net-class widths/clearances + softstart rev-C P4 proof (71/77 nets, 0 DRC errors)

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -9922,7 +9922,24 @@ def main(argv: list[str] | None = None) -> int:
         # the grid and routing reliably produces cross-net clearance shorts.
         # Refuse to route rather than silently ship shorts; require an explicit
         # opt-in (--allow-unsafe-grid or --force) to override.
-        if grid_auto_result.memory_forced_unsafe_grid and not (
+        #
+        # Issue #4271: the gate is grid-engine-only.  Under --route-engine
+        # mesh/lattice NO copper is ever emitted from the grid -- the grid
+        # object is a coordinate substrate (bbox fallback), the engines route
+        # on their own exact-geometry structures, and the optimize/DRC-nudge
+        # grid post-passes are already gated off (#4283).  Hard-erroring here
+        # blocked exactly the boards those engines exist for (softstart rev-C
+        # falls in the #4242 grid gap: safe grid 0.0635mm exceeds every cell
+        # budget).  The #3911 refusal stays fully intact for the grid engine.
+        _route_engine = getattr(args, "route_engine", "grid")
+        if grid_auto_result.memory_forced_unsafe_grid and _route_engine != "grid":
+            if not args.quiet:
+                print(
+                    f"  Auto-grid safety gate: skipped for --route-engine "
+                    f"{_route_engine} (no copper is routed on the grid; the "
+                    f"{_route_engine} engine uses exact geometry)"
+                )
+        elif grid_auto_result.memory_forced_unsafe_grid and not (
             args.force or getattr(args, "allow_unsafe_grid", False)
         ):
             recommended = args.clearance / 2

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -2584,6 +2584,12 @@ class Autorouter:
             keyed = [(k, self.pads[k]) for k in pad_keys if k in self.pads]
             if len(keyed) < 2:
                 continue
+            # Issue #4271: thread the net's class (name-pattern classified +
+            # --net-class-map sidecar overrides) into every connection so the
+            # lattice emits AND spaces its copper at the class width/clearance
+            # (a 2.6 mm HV_HICUR net must be 2.6 mm copper, spaced as such).
+            net_name = self.net_names.get(net) or keyed[0][1].net_name
+            net_class = self.net_class_map.get(net_name) if net_name else None
             res_keys = reserved.get(net)
             if res_keys:
                 # Main run handled by the coupled connection; each extra pad
@@ -2595,12 +2601,12 @@ class Autorouter:
                         res_pads,
                         key=lambda rp: math.hypot(rp.x - other.x, rp.y - other.y),
                     )
-                    connections.append(((net, seq), anchor, other, None))
+                    connections.append(((net, seq), anchor, other, net_class))
                 continue
             pads = [p for _k, p in keyed]
             anchor = pads[0]
             for seq, other in enumerate(pads[1:]):
-                connections.append(((net, seq), anchor, other, None))
+                connections.append(((net, seq), anchor, other, net_class))
 
         if not connections and not coupled:
             return {}

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -2621,6 +2621,31 @@ class Autorouter:
         )
         self._lattice_negotiation_stats = stats
 
+        # Issue #4271: the shortfall must be DIAGNOSABLE from the run output
+        # (honest decline census), not buried on the pathfinder object.
+        print(
+            f"  Lattice negotiation: {stats.routed}/{stats.total} connections "
+            f"(iterations={stats.iterations}, converged={stats.converged}, "
+            f"lattice_builds={stats.lattice_builds})"
+        )
+        if pf.failure_reasons:
+            by_reason: dict[str, list[str]] = {}
+            for key, reason in pf.failure_reasons.items():
+                # Single-ended keys are (net_id, seq); pair keys (#4270) are
+                # ("pair", p_net, n_net) and are named by their pair below.
+                net_id = key[0] if isinstance(key, tuple) else None
+                if isinstance(net_id, int):
+                    name = self.net_names.get(net_id, str(net_id))
+                else:
+                    name = str(key)
+                by_reason.setdefault(reason, []).append(name)
+            for reason, names in sorted(by_reason.items()):
+                uniq = sorted(set(names))
+                print(
+                    f"    decline[{reason}]: {len(names)} connection(s) "
+                    f"on {len(uniq)} net(s): {', '.join(uniq)}"
+                )
+
         # Honest per-pair reporting (issue #4270 acceptance): engaged /
         # coupled / declined-with-reason, mirroring failure_reasons.
         if coupled or self._lattice_pair_outcomes:
@@ -16539,6 +16564,21 @@ class Autorouter:
         # C++ backend (no waypoint support) it returns False and the
         # pre-pass runs for genuinely unreachable pads.
         if self.use_waypoint_injection:
+            return []
+
+        # Issue #4271: the pre-pass is GRID copper -- direct escape stubs
+        # committed into ``self.routes`` before routing.  The mesh/lattice
+        # engines negotiate the whole netset on their own exact-geometry
+        # substrates and CANNOT see these stubs (the same seam as the
+        # #4280 escape-routing gate and the #4281 post-pass gate), so the
+        # stubs ship as cross-net shorts against engine copper and drag
+        # whole nets into the #4208 demotion backstop.  Measured on
+        # softstart rev-C: every DRC error in the P4 run (12 shorts, 3
+        # clearance, 16 mask bridges) was pre-pass stub copper, and 34
+        # clean lattice nets were demoted for conflicting with it.  The
+        # engines attach pads by exact dogleg stubs instead; grid-engine
+        # behavior is unchanged.
+        if getattr(self, "_strategy", "grid") in ("mesh", "lattice"):
             return []
 
         uncovered = [p for p in self.pads.values() if not self._pad_metal_covers_grid_cell(p)]

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -1093,6 +1093,11 @@ class Autorouter:
         )
 
         self.pads: dict[tuple[str, str], Pad] = {}
+        # Issue #4271: every pad, DUPLICATE pad numbers included (thermal-via
+        # arrays / EP paddles share a number and collapse in the (ref, pin)
+        # dict above).  Obstacle input for the exact-geometry engines
+        # (lattice/mesh); the grid marks pads directly and never reads this.
+        self.all_pads: list[Pad] = []
         self.nets: dict[int, list[tuple[str, str]]] = {}
         # Issue #4170 (Phase 2b-1): route-scoped bare boundary stub endpoints to
         # reconnect, keyed by net id.  Populated by ``set_stub_terminals`` from
@@ -1692,6 +1697,18 @@ class Autorouter:
                 drill=pad_info.get("drill", 0.0),
             )
             key = (ref, pin)
+            # Issue #4271: ``self.pads`` is keyed (ref, pin), so a footprint
+            # with DUPLICATE pad numbers (thermal-via arrays / EP paddles --
+            # softstart's ESP32-C3 module has 13 pads named "19" and 9 named
+            # "") keeps only ONE of them.  The grid engine is unaffected
+            # (every pad is marked on the grid below, before the dict
+            # overwrite), but the exact-geometry engines build their
+            # obstacle models from the pad OBJECTS, so the collapsed
+            # duplicates were invisible and copper routed straight through
+            # them (measured: every remaining short in the P4 run).
+            # ``all_pads`` preserves every pad for those engines; the
+            # (ref, pin) dict keeps its historical semantics for topology.
+            self.all_pads.append(pad)
             self.pads[key] = pad
 
             if pad.net > 0:
@@ -2438,9 +2455,14 @@ class Autorouter:
             outline = [(bx0, by0), (bx1, by0), (bx1, by1), (bx0, by1)]
             # The lattice is replicated across the board's REAL copper stack
             # (issue #4278 acceptance 6) -- never hardcoded to 2 layers.
+            # Obstacles come from ``all_pads`` (issue #4271): duplicate pad
+            # numbers collapse in the (ref, pin) dict, and the collapsed
+            # thermal/EP pads shipped as shorts on softstart rev-C.  The
+            # fallback covers routers assembled without add_component
+            # (tests, deserialization).
             self._lattice_pathfinder = LatticePathfinder(
                 outline,
-                list(self.pads.values()),
+                self.all_pads or list(self.pads.values()),
                 self.rules,
                 layer_stack=self.layer_stack,
             )
@@ -2581,7 +2603,11 @@ class Autorouter:
         for net, pad_keys in self.nets.items():
             if net == 0:
                 continue
-            keyed = [(k, self.pads[k]) for k in pad_keys if k in self.pads]
+            # ``dict.fromkeys``: nets whose footprint repeats a pad number
+            # (thermal-via arrays) append the same (ref, pin) key once per
+            # copy -- without dedup the star topology would route the same
+            # pad pair repeatedly (issue #4271).
+            keyed = [(k, self.pads[k]) for k in dict.fromkeys(pad_keys) if k in self.pads]
             if len(keyed) < 2:
                 continue
             # Issue #4271: thread the net's class (name-pattern classified +

--- a/src/kicad_tools/router/lattice/coupled.py
+++ b/src/kicad_tools/router/lattice/coupled.py
@@ -174,12 +174,19 @@ def committed_seg_clear_grown(
     extra: float,
 ) -> bool:
     """``CommittedCopper.seg_clear`` with gaps grown by ``extra`` and the
-    whole pair-net set treated as "self"."""
-    gap = committed.copper_gap + extra
-    for c, d, cnet, _hw in committed.copper[layer].query_seg(a, b, pad=gap):
+    whole pair-net set treated as "self".
+
+    Issue #4271: committed segments carry their TRUE per-class half-width
+    and clearance, so the per-item gap is ``trace_half + stored_half +
+    max(clearance, stored_clearance) + extra`` -- the fat envelope is
+    spaced honestly even against oversize (e.g. 2.6 mm HV) copper.
+    """
+    pad = committed.trace_half + committed.clearance + extra + 0.5
+    for c, d, cnet, hw, iclr in committed.copper[layer].query_seg(a, b, pad=pad):
+        gap = committed.trace_half + hw + max(committed.clearance, iclr) + extra
         if cnet not in nets and seg_seg_dist(a, b, c, d) < gap - _EPS:
             return False
-    vgap = committed.via_copper_gap + extra
+    vgap = committed.via_radius + committed.clearance + committed.trace_half + extra
     for point, vnet in committed.vias:
         if vnet not in nets and seg_pt_dist(a, b, point) < vgap - _EPS:
             return False
@@ -194,11 +201,12 @@ def committed_point_clear_grown(
     extra: float,
 ) -> bool:
     """``CommittedCopper.node_clear`` with gaps grown by ``extra``."""
-    gap = committed.copper_gap + extra
-    for c, d, cnet, _hw in committed.copper[layer].query_seg(point, point, pad=gap):
+    pad = committed.trace_half + committed.clearance + extra + 0.5
+    for c, d, cnet, hw, iclr in committed.copper[layer].query_seg(point, point, pad=pad):
+        gap = committed.trace_half + hw + max(committed.clearance, iclr) + extra
         if cnet not in nets and seg_pt_dist(c, d, point) < gap - _EPS:
             return False
-    vgap = committed.via_copper_gap + extra
+    vgap = committed.via_radius + committed.clearance + committed.trace_half + extra
     for vpt, vnet in committed.vias:
         if vnet not in nets and dist(point, vpt) < vgap - _EPS:
             return False

--- a/src/kicad_tools/router/lattice/geometry.py
+++ b/src/kicad_tools/router/lattice/geometry.py
@@ -92,13 +92,17 @@ class SegHash:
     """Uniform-bucket spatial hash over committed copper segments.
 
     Buckets are keyed by integer cells of ``cell`` mm.  Each stored item is
-    ``(a, b, net, half_width)``; queries return every item whose inflated
+    ``(a, b, net, half_width, clearance)`` -- the copper half-width AND the
+    clearance the owning net class requires (issue #4271: per-net-class
+    widths/clearances) -- and queries return every item whose inflated
     bounding box touches the query segment's cells, deduplicated by identity.
     """
 
     def __init__(self, cell: float = 2.0) -> None:
         self.cell = cell
-        self.buckets: dict[tuple[int, int], list[tuple[Pt, Pt, int, float]]] = defaultdict(list)
+        self.buckets: dict[tuple[int, int], list[tuple[Pt, Pt, int, float, float]]] = defaultdict(
+            list
+        )
 
     def _cells_for_seg(self, a: Pt, b: Pt, pad: float = 0.0) -> Iterator[tuple[int, int]]:
         x0 = min(a[0], b[0]) - pad
@@ -110,12 +114,15 @@ class SegHash:
             for iy in range(int(math.floor(y0 / c)), int(math.floor(y1 / c)) + 1):
                 yield (ix, iy)
 
-    def add(self, a: Pt, b: Pt, net: int, half_width: float) -> None:
-        """Insert segment ``a-b`` of net ``net`` with copper ``half_width``."""
-        for key in self._cells_for_seg(a, b, pad=half_width + 0.5):
-            self.buckets[key].append((a, b, net, half_width))
+    def add(self, a: Pt, b: Pt, net: int, half_width: float, clearance: float = 0.0) -> None:
+        """Insert segment ``a-b`` of net ``net`` with copper ``half_width``
+        and the clearance its net class requires around that copper."""
+        for key in self._cells_for_seg(a, b, pad=half_width + clearance + 0.5):
+            self.buckets[key].append((a, b, net, half_width, clearance))
 
-    def query_seg(self, a: Pt, b: Pt, pad: float = 1.0) -> Iterator[tuple[Pt, Pt, int, float]]:
+    def query_seg(
+        self, a: Pt, b: Pt, pad: float = 1.0
+    ) -> Iterator[tuple[Pt, Pt, int, float, float]]:
         """Yield stored segments near ``a-b`` (each item exactly once)."""
         seen: set[int] = set()
         for key in self._cells_for_seg(a, b, pad=pad):

--- a/src/kicad_tools/router/lattice/obstacles.py
+++ b/src/kicad_tools/router/lattice/obstacles.py
@@ -117,17 +117,27 @@ class LatticeObstacleModel:
         """True if the edge crosses an OTHER-net pad keep-out on ``layer``."""
         return any(self.pads[idx].net != net for idx in self.edge_pads[layer].get(edge, ()))
 
-    def segment_blocked(self, a: Pt, b: Pt, layer: int, net: int) -> bool:
+    def segment_blocked(self, a: Pt, b: Pt, layer: int, net: int, extra: float = 0.0) -> bool:
         """True if free segment ``a-b`` (e.g. a stub leg) enters an other-net
-        pad keep-out on ``layer`` (geometric, not lattice-resource, check)."""
+        pad keep-out on ``layer`` (geometric, not lattice-resource, check).
+
+        ``extra`` (issue #4271) inflates every pad keep-out beyond the
+        global ``agent_radius`` -- the per-connection surcharge for a net
+        class wider (or more cleared) than the board default, so oversize
+        copper is spaced from other-net pads at its TRUE half-width.  The
+        degenerate ``a == b`` form doubles as a point (lattice-node) probe.
+        """
         x0, x1 = min(a[0], b[0]), max(a[0], b[0])
         y0, y1 = min(a[1], b[1]), max(a[1], b[1])
-        for idx in self.pads_near(x0, y0, x1, y1):
+        for idx in self.pads_near(x0 - extra, y0 - extra, x1 + extra, y1 + extra):
             if self.pads[idx].net == net:
                 continue
             if layer not in self.pad_layer_indices[idx]:
                 continue
-            if seg_rect_intersect(a, b, self.pad_rects[idx]):
+            rect = self.pad_rects[idx]
+            if extra > 0.0:
+                rect = (rect[0] - extra, rect[1] - extra, rect[2] + extra, rect[3] + extra)
+            if seg_rect_intersect(a, b, rect):
                 return True
         return False
 
@@ -139,20 +149,35 @@ class CommittedCopper:
     structures, vias in a flat list (a through-via blocks EVERY layer).
     All clearance predicates are centreline distances against the real
     gaps supplied by the pathfinder.
+
+    Issue #4271 (net-class widths): every committed segment carries its TRUE
+    ``half_width`` and its class ``clearance``, and every predicate takes the
+    querying connection's own ``half`` / ``clearance``.  The required
+    centreline gap between two traces is::
+
+        own_half + stored_half + max(own_clearance, stored_clearance)
+
+    so 2.6 mm HV_HICUR copper is spaced as 2.6 mm copper and a 0.3 mm HV
+    class clearance is honored from EITHER side of the pair (mirroring
+    KiCad's conditional-rule semantics, where the wider constraint governs
+    when either net is in the class).  ``None`` arguments fall back to the
+    board-global trace geometry -- the pre-#4271 behavior, byte-for-byte.
     """
 
     def __init__(
         self,
         num_layers: int,
         *,
-        copper_gap: float,
-        via_copper_gap: float,
+        trace_half: float,
+        clearance: float,
+        via_radius: float,
         via_via_gap: float,
         same_net_via_gap: float,
     ) -> None:
         self.num_layers = num_layers
-        self.copper_gap = copper_gap  # min trace centre-to-centre (w + clr)
-        self.via_copper_gap = via_copper_gap  # via centre to trace centre
+        self.trace_half = trace_half  # global default copper half-width
+        self.clearance = clearance  # global default (floor) clearance
+        self.via_radius = via_radius  # via body radius
         self.via_via_gap = via_via_gap  # via centre to via centre (cross-net)
         self.same_net_via_gap = same_net_via_gap  # hole-to-hole floor
         self.copper: list[SegHash] = [SegHash() for _ in range(num_layers)]
@@ -160,11 +185,20 @@ class CommittedCopper:
 
     # -- mutation --------------------------------------------------------
 
-    def add_run(self, layer: int, points: list[Pt], net: int, half_width: float) -> None:
-        """Commit a polyline of copper on ``layer``."""
+    def add_run(
+        self,
+        layer: int,
+        points: list[Pt],
+        net: int,
+        half_width: float,
+        clearance: float | None = None,
+    ) -> None:
+        """Commit a polyline of copper on ``layer`` at its TRUE half-width
+        and class clearance (``None`` -> the board-global clearance)."""
+        clr = self.clearance if clearance is None else clearance
         for a, b in zip(points, points[1:], strict=False):
             if dist(a, b) > 1e-9:
-                self.copper[layer].add(a, b, net, half_width)
+                self.copper[layer].add(a, b, net, half_width, clr)
 
     def add_via(self, point: Pt, net: int) -> None:
         """Commit a through-via (blocks the site on ALL layers)."""
@@ -172,34 +206,68 @@ class CommittedCopper:
 
     # -- predicates --------------------------------------------------------
 
-    def seg_clear(self, a: Pt, b: Pt, layer: int, net: int) -> bool:
+    def _own(self, half: float | None, clearance: float | None) -> tuple[float, float]:
+        """Resolve the querying connection's (half-width, clearance)."""
+        own_half = self.trace_half if half is None else half
+        own_clr = self.clearance if clearance is None else clearance
+        return own_half, own_clr
+
+    def seg_clear(
+        self,
+        a: Pt,
+        b: Pt,
+        layer: int,
+        net: int,
+        half: float | None = None,
+        clearance: float | None = None,
+    ) -> bool:
         """True if segment ``a-b`` on ``layer`` clears other-net copper + vias."""
-        for c, d, cnet, _hw in self.copper[layer].query_seg(a, b, pad=self.copper_gap):
-            if cnet != net and seg_seg_dist(a, b, c, d) < self.copper_gap - 1e-9:
+        own_half, own_clr = self._own(half, clearance)
+        pad = own_half + own_clr + 0.5
+        for c, d, cnet, hw, iclr in self.copper[layer].query_seg(a, b, pad=pad):
+            gap = own_half + hw + max(own_clr, iclr)
+            if cnet != net and seg_seg_dist(a, b, c, d) < gap - 1e-9:
                 return False
+        via_gap = self.via_radius + own_clr + own_half
         for point, vnet in self.vias:
-            if vnet != net and seg_pt_dist(a, b, point) < self.via_copper_gap - 1e-9:
+            if vnet != net and seg_pt_dist(a, b, point) < via_gap - 1e-9:
                 return False
         return True
 
-    def node_clear(self, point: Pt, layer: int, net: int) -> bool:
+    def node_clear(
+        self,
+        point: Pt,
+        layer: int,
+        net: int,
+        half: float | None = None,
+        clearance: float | None = None,
+    ) -> bool:
         """True if a node site on ``layer`` clears other-net copper + vias."""
-        for c, d, cnet, _hw in self.copper[layer].query_seg(point, point, pad=self.copper_gap):
-            if cnet != net and seg_pt_dist(c, d, point) < self.copper_gap - 1e-9:
+        own_half, own_clr = self._own(half, clearance)
+        pad = own_half + own_clr + 0.5
+        for c, d, cnet, hw, iclr in self.copper[layer].query_seg(point, point, pad=pad):
+            gap = own_half + hw + max(own_clr, iclr)
+            if cnet != net and seg_pt_dist(c, d, point) < gap - 1e-9:
                 return False
+        via_gap = self.via_radius + own_clr + own_half
         for vpt, vnet in self.vias:
-            if vnet != net and dist(point, vpt) < self.via_copper_gap - 1e-9:
+            if vnet != net and dist(point, vpt) < via_gap - 1e-9:
                 return False
         return True
 
     def via_clear(self, point: Pt, net: int) -> bool:
         """True if a through-via at ``point`` clears committed copper (ALL
-        layers) and committed vias (cross-net body gap, same-net hole gap)."""
+        layers) and committed vias (cross-net body gap, same-net hole gap).
+
+        The via-to-trace gap honors each stored segment's TRUE half-width
+        and class clearance (#4271): ``via_radius + stored_half +
+        max(global_clearance, stored_clearance)``.
+        """
+        pad = self.via_radius + self.clearance + self.trace_half + 2.0
         for layer in range(self.num_layers):
-            for c, d, cnet, _hw in self.copper[layer].query_seg(
-                point, point, pad=self.via_copper_gap
-            ):
-                if cnet != net and seg_pt_dist(c, d, point) < self.via_copper_gap - 1e-9:
+            for c, d, cnet, hw, iclr in self.copper[layer].query_seg(point, point, pad=pad):
+                gap = self.via_radius + hw + max(self.clearance, iclr)
+                if cnet != net and seg_pt_dist(c, d, point) < gap - 1e-9:
                     return False
         for vpt, vnet in self.vias:
             gap = self.via_via_gap if vnet != net else self.same_net_via_gap

--- a/src/kicad_tools/router/lattice/pathfinder.py
+++ b/src/kicad_tools/router/lattice/pathfinder.py
@@ -211,14 +211,16 @@ class LatticePathfinder:
         ys = [p[1] for p in outline]
         self._bbox: Rect = (min(xs), min(ys), max(xs), max(ys))
 
-        # Derived clearance gaps (centreline distances).
+        # Derived clearance gaps (centreline distances).  These are the
+        # BOARD-GLOBAL defaults; per-connection widths/clearances from a
+        # threaded net class (issue #4271) are resolved by
+        # :meth:`_conn_geometry` and carried through the committed-copper
+        # model per segment.
         tw = self.rules.trace_width
         clr = self.rules.trace_clearance
         via_r = self.rules.via_diameter / 2.0
         self._trace_half = tw / 2.0
         self._agent_radius = tw / 2.0 + clr
-        self._copper_gap = tw + clr
-        self._via_copper_gap = via_r + clr + tw / 2.0
         self._via_via_gap = self.rules.via_diameter + clr
         self._same_net_via_gap = self.rules.via_drill + self.rules.min_hole_to_hole
         self._via_pad_grow = via_r + clr - self._agent_radius
@@ -333,11 +335,25 @@ class LatticePathfinder:
     def _fresh_committed(self) -> CommittedCopper:
         return CommittedCopper(
             self.num_layers,
-            copper_gap=self._copper_gap,
-            via_copper_gap=self._via_copper_gap,
+            trace_half=self._trace_half,
+            clearance=self.rules.trace_clearance,
+            via_radius=self.rules.via_diameter / 2.0,
             via_via_gap=self._via_via_gap,
             same_net_via_gap=self._same_net_via_gap,
         )
+
+    def _conn_geometry(self, net_class: object | None) -> tuple[float, float]:
+        """Per-connection ``(trace half-width, clearance)`` (issue #4271).
+
+        Width follows the class exactly as :meth:`_emit` does (the copper is
+        spaced at the SAME width it is emitted at -- the #4271 invariant);
+        clearance takes ``max(class, rules)`` so a class can only GROW the
+        gap, never shrink below the design rules.  ``None`` -> global
+        geometry, preserving the single-width pre-#4271 behavior exactly.
+        """
+        tw = getattr(net_class, "trace_width", None) or self.rules.trace_width
+        clr = getattr(net_class, "clearance", None) or 0.0
+        return tw / 2.0, max(clr, self.rules.trace_clearance)
 
     # -- pad stubs ------------------------------------------------------------
 
@@ -353,6 +369,7 @@ class LatticePathfinder:
         partner_net: int | None = None,
         layers: tuple[int, ...] | None = None,
         exempt_pads: frozenset[int] | None = None,
+        net_class: object | None = None,
     ) -> list[tuple[NodeKey, int, list[Pt], float]]:
         """Legal dogleg stubs ``(node_key, layer, polyline pad->node, length)``.
 
@@ -371,6 +388,12 @@ class LatticePathfinder:
         grown pad rects (no second mask build -- ``lattice_builds`` stays 1)
         and ``layers`` restricts candidates to layers every pair endpoint
         pad owns (the v1 coupled run is planar).
+
+        ``net_class`` (issue #4271) sizes every clearance check at the
+        connection's TRUE half-width/clearance: committed-copper predicates
+        take the per-class geometry, and the static pad checks are inflated
+        by the surcharge over the global agent radius (single-ended path;
+        the fat-agent path carries its own grown envelope).
         """
         lattice = self.build()
         obstacles = self.obstacles
@@ -395,6 +418,8 @@ class LatticePathfinder:
                 pads_block_point_grown,
                 pads_block_segment_grown,
             )
+        half, clr = self._conn_geometry(net_class)
+        extra = max(0.0, half + clr - self._agent_radius)
 
         candidates: list[tuple[float, NodeKey, Pt]] = []
         pad_pt = (pad.x, pad.y)
@@ -419,7 +444,9 @@ class LatticePathfinder:
                 else:
                     if obstacles.node_blocked(key, layer, net):
                         continue
-                    if not committed.node_clear(point, layer, net):
+                    if extra > 0.0 and obstacles.segment_blocked(point, point, layer, net, extra):
+                        continue
+                    if not committed.node_clear(point, layer, net, half, clr):
                         continue
                 accepted: list[Pt] | None = None
                 # Fat mode prefers the axis-first dogleg: its first leg is
@@ -438,10 +465,10 @@ class LatticePathfinder:
                                 ok = False
                                 break
                         else:
-                            if obstacles.segment_blocked(a, b, layer, net):
+                            if obstacles.segment_blocked(a, b, layer, net, extra):
                                 ok = False
                                 break
-                            if not committed.seg_clear(a, b, layer, net):
+                            if not committed.seg_clear(a, b, layer, net, half, clr):
                                 ok = False
                                 break
                     if ok:
@@ -581,6 +608,12 @@ class LatticePathfinder:
         lattice = self.build()
         obstacles = self.obstacles
         net = start.net
+        # Per-connection copper geometry (issue #4271): the class half-width
+        # and clearance size EVERY legality check below, and ``extra`` is the
+        # keep-out surcharge over the global agent radius for the static pad
+        # masks (0.0 for default-width nets -> pre-#4271 behavior exactly).
+        half, clr = self._conn_geometry(net_class)
+        extra = max(0.0, half + clr - self._agent_radius)
 
         fat = extra_clearance > 0.0 or partner_net is not None
         if fat:
@@ -608,6 +641,7 @@ class LatticePathfinder:
                 partner_net=partner_net,
                 layers=stub_layers,
                 exempt_pads=exempt_pads,
+                net_class=net_class,
             )
             stubs_b = self.pad_stubs(
                 end,
@@ -618,6 +652,7 @@ class LatticePathfinder:
                 partner_net=partner_net,
                 layers=stub_layers,
                 exempt_pads=exempt_pads,
+                net_class=net_class,
             )
         if not stubs_a:
             return None, "pad-escape-start"
@@ -682,8 +717,14 @@ class LatticePathfinder:
                             committed, pa, pb, layer, pair_nets, extra_clearance
                         )
                     else:
-                        ok = not obstacles.edge_blocked(edge, layer, net) and committed.seg_clear(
-                            lattice.node_point(edge[0]), lattice.node_point(edge[1]), layer, net
+                        ea = lattice.node_point(edge[0])
+                        eb = lattice.node_point(edge[1])
+                        ok = (
+                            not obstacles.edge_blocked(edge, layer, net)
+                            and not (
+                                extra > 0.0 and obstacles.segment_blocked(ea, eb, layer, net, extra)
+                            )
+                            and committed.seg_clear(ea, eb, layer, net, half, clr)
                         )
                     edge_ok[ek] = ok
                 if not ok:
@@ -699,8 +740,14 @@ class LatticePathfinder:
                             committed, npt, layer, pair_nets, extra_clearance
                         )
                     else:
-                        nok = not obstacles.node_blocked(nbr, layer, net) and committed.node_clear(
-                            lattice.node_point(nbr), layer, net
+                        npt = lattice.node_point(nbr)
+                        nok = (
+                            not obstacles.node_blocked(nbr, layer, net)
+                            and not (
+                                extra > 0.0
+                                and obstacles.segment_blocked(npt, npt, layer, net, extra)
+                            )
+                            and committed.node_clear(npt, layer, net, half, clr)
                         )
                     node_ok[nstate] = nok
                 if not nok:
@@ -727,8 +774,14 @@ class LatticePathfinder:
                         nstate = (key, nl)
                         nok = node_ok.get(nstate)
                         if nok is None:
-                            nok = not obstacles.node_blocked(key, nl, net) and committed.node_clear(
-                                lattice.node_point(key), nl, net
+                            kpt = lattice.node_point(key)
+                            nok = (
+                                not obstacles.node_blocked(key, nl, net)
+                                and not (
+                                    extra > 0.0
+                                    and obstacles.segment_blocked(kpt, kpt, nl, net, extra)
+                                )
+                                and committed.node_clear(kpt, nl, net, half, clr)
                             )
                             node_ok[nstate] = nok
                         if not nok:
@@ -1297,9 +1350,12 @@ class LatticePathfinder:
                     routed_items += 1
                     routes[(item.key, "P")] = pres.routes[0]
                     routes[(item.key, "N")] = pres.routes[1]
-                    half = self._trace_half
+                    # Legs are EMITTED at the pair class width (#4270), so
+                    # commit them at the same width + clearance (#4271) --
+                    # emission and spacing must agree.
+                    half, clr = self._conn_geometry(item.net_class)
                     for leg_net, layer_idx, points in pres.runs:
-                        committed.add_run(layer_idx, points, leg_net, half)
+                        committed.add_run(layer_idx, points, leg_net, half, clr)
                     continue
                 key, start, end, net_class = item
                 result, reason = self._route_impl(
@@ -1311,9 +1367,12 @@ class LatticePathfinder:
                     continue
                 routed_items += 1
                 routes[key] = result.route
-                half = self._trace_half
+                # Commit at the connection's TRUE half-width + class
+                # clearance (issue #4271) so later nets are spaced against
+                # 2.6 mm copper as 2.6 mm copper, never the global default.
+                half, clr = self._conn_geometry(net_class)
                 for layer_idx, points in result.runs:
-                    committed.add_run(layer_idx, points, start.net, half)
+                    committed.add_run(layer_idx, points, start.net, half, clr)
                 for via_pt in result.via_points:
                     committed.add_via(via_pt, start.net)
 

--- a/src/kicad_tools/router/lattice/pathfinder.py
+++ b/src/kicad_tools/router/lattice/pathfinder.py
@@ -324,8 +324,16 @@ class LatticePathfinder:
         SMD pads mask only their own layer; through-hole pads mask every
         layer.  A pad whose layer is off the stack is treated conservatively
         as through-blocking (never under-mask -- the #3906 direction).
+
+        ``drill > 0`` also blocks every layer regardless of the
+        ``through_hole`` flag (issue #4271): NPTH mounting holes load as
+        ``np_thru_hole`` pads with ``through_hole=False`` on a single
+        copper layer, but the DRILLED BARREL physically exists on every
+        layer -- softstart rev-C shipped an inner-layer track through the
+        fuse holder's 2.7 mm NPTH hole (kicad-cli ``hole_clearance``)
+        before this.
         """
-        if pad.through_hole:
+        if pad.through_hole or pad.drill > 0:
             return tuple(range(self.num_layers))
         try:
             return (self.layer_stack.layer_enum_to_index(pad.layer),)
@@ -529,8 +537,9 @@ class LatticePathfinder:
             point[0] - window, point[1] - window, point[0] + window, point[1] + window
         ):
             pad = self.pads[idx]
-            if pad.through_hole:
-                # Hole-to-hole floor applies regardless of net.
+            if pad.through_hole or pad.drill > 0:
+                # Hole-to-hole floor applies regardless of net (and to NPTH
+                # holes, whose through_hole flag is False -- issue #4271).
                 min_cc = self.rules.via_drill / 2.0 + pad.drill / 2.0 + self.rules.min_hole_to_hole
                 if dist(point, (pad.x, pad.y)) < min_cc - 1e-9:
                     return False

--- a/tests/router/lattice/test_engine_dispatch.py
+++ b/tests/router/lattice/test_engine_dispatch.py
@@ -153,3 +153,19 @@ def test_route_cmd_mirror_parser_accepts_lattice(monkeypatch: pytest.MonkeyPatch
     assert args.route_engine == "lattice"
     args = parser.parse_args(["board.kicad_pcb"])
     assert args.route_engine == "grid"
+
+
+def test_subgrid_prepass_dormant_for_non_grid_engines(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The sub-grid escape pre-pass is GRID copper the mesh/lattice netset
+    negotiation cannot see (issue #4271): on softstart rev-C its stubs were
+    every DRC error in the P4 run and demoted 34 clean lattice nets.  It
+    must return [] before analyzing a single pad under non-grid engines."""
+    from kicad_tools.router.core import Autorouter as _A
+
+    def _boom(self: object, pad: object) -> bool:
+        raise AssertionError("sub-grid pre-pass must not analyze pads for non-grid engines")
+
+    monkeypatch.setattr(_A, "_pad_metal_covers_grid_cell", _boom)
+    for strategy in ("lattice", "mesh"):
+        router = _two_pad_router(strategy)
+        assert router._run_subgrid_prepass() == []

--- a/tests/router/lattice/test_engine_dispatch.py
+++ b/tests/router/lattice/test_engine_dispatch.py
@@ -169,3 +169,27 @@ def test_subgrid_prepass_dormant_for_non_grid_engines(monkeypatch: pytest.Monkey
     for strategy in ("lattice", "mesh"):
         router = _two_pad_router(strategy)
         assert router._run_subgrid_prepass() == []
+
+
+def test_all_pads_preserves_duplicate_pad_numbers_for_lattice_obstacles() -> None:
+    """Footprints with REPEATED pad numbers (thermal-via arrays, EP paddles)
+    collapse in the (ref, pin) ``router.pads`` dict; the lattice obstacle
+    model must still see every copy (issue #4271: the collapsed ESP32-C3
+    "19" pads shipped as every remaining short on softstart rev-C)."""
+    router = Autorouter(50, 40, strategy="lattice")
+    router.add_component(
+        "U9",
+        [
+            {"number": "1", "x": 10.0, "y": 10.0, "net": 1, "net_name": "N1"},
+            {"number": "19", "x": 20.0, "y": 20.0, "net": 2, "net_name": "GNDX"},
+            {"number": "19", "x": 24.0, "y": 20.0, "net": 2, "net_name": "GNDX"},
+            {"number": "19", "x": 28.0, "y": 20.0, "net": 2, "net_name": "GNDX"},
+        ],
+    )
+    # The dict collapses the duplicates ...
+    assert len(router.pads) == 2
+    # ... but all_pads keeps every physical pad, and the lattice engine
+    # builds its obstacle model from it.
+    assert len(router.all_pads) == 4
+    pf = router._ensure_lattice_pathfinder()
+    assert len(pf.pads) == 4

--- a/tests/router/lattice/test_net_class_widths.py
+++ b/tests/router/lattice/test_net_class_widths.py
@@ -1,0 +1,252 @@
+"""Net-class width/clearance plumbing through the lattice engine (issue #4271).
+
+Phase A of the softstart rev-C large-board proof: the lattice dispatch used
+to hardwire ``net_class=None`` for every connection, every committed segment
+was recorded at the board-global half-width, and ``CommittedCopper.seg_clear``
+discarded the stored per-segment half-width.  A 2.6 mm HV_HICUR net was
+emitted at the default width AND spaced as default-width copper.
+
+These tests pin the fixed invariants:
+
+1. Committed copper blocks at its TRUE half-width (a wide net's copper is
+   spaced as wide copper).
+2. A class ``clearance`` (softstart HV = 0.3 mm) is honored from EITHER side
+   of a pair (KiCad conditional-rule semantics).
+3. Emission and spacing use the SAME class width end-to-end through
+   ``route_netset``.
+4. The dispatch threads ``router.net_class_map`` into the connections.
+5. Default single-width behavior is unchanged when no class applies.
+"""
+
+from __future__ import annotations
+
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.lattice.geometry import seg_seg_dist
+from kicad_tools.router.lattice.obstacles import CommittedCopper
+from kicad_tools.router.lattice.pathfinder import LatticePathfinder
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import DesignRules, NetClassRouting
+
+
+def _pad(
+    x: float,
+    y: float,
+    net: int,
+    *,
+    ref: str,
+    net_name: str | None = None,
+    layer: Layer = Layer.F_CU,
+    width: float = 1.0,
+    height: float = 1.0,
+) -> Pad:
+    return Pad(
+        x=x,
+        y=y,
+        width=width,
+        height=height,
+        net=net,
+        net_name=net_name or f"N{net}",
+        layer=layer,
+        ref=ref,
+        pin="1",
+    )
+
+
+def _fresh(rules: DesignRules) -> CommittedCopper:
+    return CommittedCopper(
+        2,
+        trace_half=rules.trace_width / 2.0,
+        clearance=rules.trace_clearance,
+        via_radius=rules.via_diameter / 2.0,
+        via_via_gap=rules.via_diameter + rules.trace_clearance,
+        same_net_via_gap=rules.via_drill + rules.min_hole_to_hole,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Committed copper blocks at its TRUE half-width.
+# ---------------------------------------------------------------------------
+
+
+def test_committed_wide_run_blocks_at_true_half_width() -> None:
+    """2.6 mm copper must be spaced as 2.6 mm copper, not the global default."""
+    rules = DesignRules()  # trace_width 0.2, trace_clearance 0.15 (defaults)
+    committed = _fresh(rules)
+    wide_half = 1.3  # a 2.6 mm HV_HICUR run
+    committed.add_run(0, [(0.0, 5.0), (20.0, 5.0)], net=1, half_width=wide_half)
+
+    default_half = rules.trace_width / 2.0
+    legacy_gap = rules.trace_width + rules.trace_clearance  # the old single gap
+    true_gap = default_half + wide_half + rules.trace_clearance
+
+    # A default-width segment at the LEGACY gap would have been accepted
+    # pre-#4271 -- it must now be rejected (it overlaps the wide copper).
+    y_legacy = 5.0 + legacy_gap + 0.05
+    assert y_legacy < 5.0 + true_gap
+    assert not committed.seg_clear((0.0, y_legacy), (20.0, y_legacy), 0, net=2)
+
+    # At the TRUE gap it clears.
+    y_true = 5.0 + true_gap + 0.01
+    assert committed.seg_clear((0.0, y_true), (20.0, y_true), 0, net=2)
+
+    # Same-net copper is never an obstacle.
+    assert committed.seg_clear((0.0, y_legacy), (20.0, y_legacy), 0, net=1)
+
+
+def test_node_clear_honors_stored_half_width() -> None:
+    rules = DesignRules()
+    committed = _fresh(rules)
+    committed.add_run(0, [(0.0, 5.0), (20.0, 5.0)], net=1, half_width=1.3)
+    default_half = rules.trace_width / 2.0
+    true_gap = default_half + 1.3 + rules.trace_clearance
+    assert not committed.node_clear((10.0, 5.0 + true_gap - 0.05), 0, net=2)
+    assert committed.node_clear((10.0, 5.0 + true_gap + 0.05), 0, net=2)
+
+
+def test_via_clear_honors_stored_half_width() -> None:
+    """A via next to committed WIDE copper needs the wide gap, not the
+    global ``via_copper_gap`` derived from the default trace width."""
+    rules = DesignRules()
+    committed = _fresh(rules)
+    committed.add_run(0, [(0.0, 5.0), (20.0, 5.0)], net=1, half_width=1.3)
+    via_r = rules.via_diameter / 2.0
+    legacy_gap = via_r + rules.trace_clearance + rules.trace_width / 2.0
+    true_gap = via_r + 1.3 + rules.trace_clearance
+    y_legacy = 5.0 + legacy_gap + 0.05
+    assert y_legacy < 5.0 + true_gap
+    assert not committed.via_clear((10.0, y_legacy), net=2)
+    assert committed.via_clear((10.0, 5.0 + true_gap + 0.05), net=2)
+
+
+# ---------------------------------------------------------------------------
+# 2. Class clearance honored from EITHER side of the pair.
+# ---------------------------------------------------------------------------
+
+
+def test_hv_clearance_honored_when_committed_side_carries_it() -> None:
+    """An HV run committed with clearance=0.3 pushes DEFAULT nets to 0.3."""
+    rules = DesignRules()
+    committed = _fresh(rules)
+    half = rules.trace_width / 2.0
+    committed.add_run(0, [(0.0, 5.0), (20.0, 5.0)], net=1, half_width=half, clearance=0.3)
+    gap_default_clr = 2 * half + rules.trace_clearance
+    gap_hv_clr = 2 * half + 0.3
+    y = 5.0 + gap_default_clr + 0.01  # clears the default gap only
+    assert y < 5.0 + gap_hv_clr
+    assert not committed.seg_clear((0.0, y), (20.0, y), 0, net=2)
+    assert committed.seg_clear(
+        (0.0, 5.0 + gap_hv_clr + 0.01), (20.0, 5.0 + gap_hv_clr + 0.01), 0, net=2
+    )
+
+
+def test_hv_clearance_honored_when_querying_side_carries_it() -> None:
+    """A default run committed first: an HV query (clearance=0.3) must keep
+    the HV gap away from it."""
+    rules = DesignRules()
+    committed = _fresh(rules)
+    half = rules.trace_width / 2.0
+    committed.add_run(0, [(0.0, 5.0), (20.0, 5.0)], net=1, half_width=half)
+    gap_hv = 2 * half + 0.3
+    y = 5.0 + gap_hv - 0.05
+    assert not committed.seg_clear((0.0, y), (20.0, y), 0, net=2, half=half, clearance=0.3)
+    y2 = 5.0 + gap_hv + 0.01
+    assert committed.seg_clear((0.0, y2), (20.0, y2), 0, net=2, half=half, clearance=0.3)
+
+
+# ---------------------------------------------------------------------------
+# 3. End-to-end: emission AND spacing at the class width through route_netset.
+# ---------------------------------------------------------------------------
+
+
+def test_route_netset_emits_and_spaces_at_class_width() -> None:
+    outline = [(0.0, 0.0), (40.0, 0.0), (40.0, 20.0), (0.0, 20.0)]
+    a1, a2 = _pad(4.0, 8.0, 1, ref="A1"), _pad(36.0, 8.0, 1, ref="A2")
+    b1, b2 = _pad(4.0, 12.0, 2, ref="B1"), _pad(36.0, 12.0, 2, ref="B2")
+    rules = DesignRules()
+    pf = LatticePathfinder(outline, [a1, a2, b1, b2], rules, LayerStack.two_layer())
+
+    hv = NetClassRouting(name="HV_HICUR", trace_width=1.0, clearance=0.3)
+    conns = [((1, 0), a1, a2, hv), ((2, 0), b1, b2, None)]
+    routes, stats = pf.route_netset(conns, max_iterations=6)
+    assert stats.lattice_builds == 1
+    assert (1, 0) in routes and (2, 0) in routes, f"declines: {pf.failure_reasons}"
+
+    # Emission at the class width; the default net stays at the global width.
+    assert all(abs(s.width - 1.0) < 1e-9 for s in routes[(1, 0)].segments)
+    assert all(abs(s.width - rules.trace_width) < 1e-9 for s in routes[(2, 0)].segments)
+
+    # Spacing: no cross-net pair on the same layer closer than
+    # own_half + other_half + max(HV clearance, global clearance).
+    min_gap = 1.0 / 2.0 + rules.trace_width / 2.0 + max(0.3, rules.trace_clearance)
+    for s1 in routes[(1, 0)].segments:
+        for s2 in routes[(2, 0)].segments:
+            if s1.layer != s2.layer:
+                continue
+            d = seg_seg_dist((s1.x1, s1.y1), (s1.x2, s1.y2), (s2.x1, s2.y1), (s2.x2, s2.y2))
+            assert d >= min_gap - 1e-6, f"HV/default pair shipped {d:.4f}mm apart (< {min_gap:.4f})"
+
+
+def test_default_connections_match_pre_class_behavior() -> None:
+    """With ``net_class=None`` everywhere, geometry falls back to the global
+    rules -- the pre-#4271 single-width behavior."""
+    outline = [(0.0, 0.0), (40.0, 0.0), (40.0, 20.0), (0.0, 20.0)]
+    a1, a2 = _pad(4.0, 8.0, 1, ref="A1"), _pad(36.0, 8.0, 1, ref="A2")
+    rules = DesignRules()
+    pf = LatticePathfinder(outline, [a1, a2], rules, LayerStack.two_layer())
+    assert pf._conn_geometry(None) == (rules.trace_width / 2.0, rules.trace_clearance)
+    routes, stats = pf.route_netset([((1, 0), a1, a2, None)], max_iterations=2)
+    assert stats.routed == 1
+    assert all(abs(s.width - rules.trace_width) < 1e-9 for s in routes[(1, 0)].segments)
+
+
+def test_conn_geometry_clearance_floor_is_the_design_rules() -> None:
+    """A class can only GROW clearance -- never shrink below the rules."""
+    rules = DesignRules()
+    pf = LatticePathfinder(
+        [(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)],
+        [_pad(2.0, 5.0, 1, ref="A1"), _pad(8.0, 5.0, 1, ref="A2")],
+        rules,
+    )
+    tight = NetClassRouting(name="tight", trace_width=0.3, clearance=0.01)
+    half, clr = pf._conn_geometry(tight)
+    assert half == 0.15
+    assert clr == rules.trace_clearance  # floored, not 0.01
+
+
+# ---------------------------------------------------------------------------
+# 4. The dispatch threads router.net_class_map into the connections.
+# ---------------------------------------------------------------------------
+
+
+def _add_pad(router: Autorouter, pad: Pad) -> None:
+    key = (pad.ref, pad.pin)
+    router.pads[key] = pad
+    router.nets.setdefault(pad.net, []).append(key)
+
+
+def test_dispatch_threads_net_class_from_map() -> None:
+    """``_negotiate_lattice_netset`` resolves each net's class by name (the
+    ``--net-class-map`` sidecar merges into ``router.net_class_map``) instead
+    of hardwiring ``None`` -- the load-bearing #4271 gap."""
+    router = Autorouter(50, 40, strategy="lattice")
+    _add_pad(router, _pad(10.0, 10.0, 1, ref="R1", net_name="FUSED_LINE"))
+    _add_pad(router, _pad(30.0, 25.0, 1, ref="R2", net_name="FUSED_LINE"))
+    router.net_class_map["FUSED_LINE"] = NetClassRouting(
+        name="HV_HICUR", trace_width=1.2, clearance=0.3
+    )
+
+    routes = router.route_net(1)
+    assert routes and routes[0].segments
+    assert all(abs(s.width - 1.2) < 1e-9 for s in routes[0].segments)
+
+
+def test_dispatch_unclassified_net_stays_at_global_width() -> None:
+    router = Autorouter(50, 40, strategy="lattice")
+    _add_pad(router, _pad(10.0, 10.0, 1, ref="R1", net_name="PLAIN"))
+    _add_pad(router, _pad(30.0, 25.0, 1, ref="R2", net_name="PLAIN"))
+    assert "PLAIN" not in router.net_class_map
+
+    routes = router.route_net(1)
+    assert routes and routes[0].segments
+    assert all(abs(s.width - router.rules.trace_width) < 1e-9 for s in routes[0].segments)

--- a/tests/router/lattice/test_softstart_routing.py
+++ b/tests/router/lattice/test_softstart_routing.py
@@ -1,0 +1,174 @@
+"""Softstart rev-C lattice ROUTING proof (issue #4271, epic #4267 P4).
+
+The substrate-size proof lives in ``test_softstart_memory.py``; this is the
+routing half: the lattice engine negotiates the real 160x100mm 4-layer board
+the grid cannot route at pad-exact fidelity (#4242), with the net-class
+sidecar threaded (Phase A of #4271) so HV_HICUR copper is emitted AND spaced
+at its true 2.6mm width.
+
+The board is a local-only external fixture (``boards/external/softstart``
+is a symlink that dangles in CI and fresh worktrees), so the whole module
+skips cleanly when it is absent -- exactly like the memory test.
+
+Assertions (pinned to the measured 2026-07-16 P4 verdict; see #4271):
+
+1. ``lattice_builds == 1`` at 287-connection scale (static substrate).
+2. Zero cross-net short in the emitted copper (the #3906 invariant checked
+   pairwise at the per-class copper gap).
+3. Completion >= the measured floor.
+4. Net-class honesty: every HV_HICUR connection that routes is emitted at
+   its 2.6mm class width.
+
+NOTE: this test runs the REAL whole-netset negotiation (minutes of wall
+clock, local-only).  ``max_iterations`` is capped to keep it bounded; the
+floor below is derived from the measured run at that cap.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.router.lattice.geometry import seg_seg_dist
+from kicad_tools.router.lattice.pathfinder import LatticePathfinder
+from kicad_tools.router.layers import LayerStack
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import DesignRules, NetClassRouting
+
+_REPO = Path(__file__).resolve().parents[3]
+_SOFTSTART_DIR = _REPO / "boards/external/softstart/output_revc"
+_SOFTSTART = _SOFTSTART_DIR / "softstart_revc.kicad_pcb"
+_SIDECAR = _SOFTSTART_DIR / "net_class_map.json"
+
+# Measured floors -- pinned from the 2026-07-17 #4271 P4 measurement
+# (deterministic negotiation; measured 267/287 connections and 63/79 nets
+# fully connected at max_iterations=2, declines {no-path: 13,
+# pad-escape-end: 7}).  Floors sit below the measurement for stability but
+# above the epic acceptance floor (>= 40/79 nets), so a regression to the
+# pre-#4271 behavior (or below the epic floor) fails loudly.
+_CONNECTION_FLOOR = 255
+_NET_FLOOR = 55
+
+pytestmark = pytest.mark.skipif(
+    not _SOFTSTART.exists(), reason="local-only softstart fixture absent"
+)
+
+
+def _load_connections() -> tuple[list, dict[int, str], dict[str, NetClassRouting]]:
+    """The dispatch topology (core.py ``_negotiate_lattice_netset``) with the
+    net-class sidecar resolved exactly like the CLI (issue #4149 rekeying)."""
+    from kicad_tools.router.io import load_pads_for_analysis
+    from kicad_tools.router.net_names import resolve_net_class_map_keys
+
+    text = _SOFTSTART.read_text()
+    pads = load_pads_for_analysis(text)
+
+    fields = NetClassRouting.__dataclass_fields__
+    raw = json.loads(_SIDECAR.read_text())
+    loaded = {
+        key: NetClassRouting(**{f: v for f, v in entry.items() if f in fields})
+        for key, entry in raw.items()
+    }
+    board_net_names = sorted({p.net_name for p in pads if p.net > 0})
+    resolution = resolve_net_class_map_keys(loaded.keys(), board_net_names)
+    class_by_name = {bn: loaded[uk] for bn, uk in resolution.resolved.items()}
+
+    by_net: dict[int, list[Pad]] = defaultdict(list)
+    name_by_net: dict[int, str] = {}
+    for p in pads:
+        if p.net > 0:
+            by_net[p.net].append(p)
+            name_by_net[p.net] = p.net_name
+
+    conns = []
+    for net, ps in by_net.items():
+        if len(ps) < 2:
+            continue
+        anchor = ps[0]
+        nc = class_by_name.get(name_by_net[net])
+        for seq, other in enumerate(ps[1:]):
+            conns.append(((net, seq), anchor, other, nc))
+    return conns, name_by_net, class_by_name
+
+
+def test_softstart_lattice_routing_proof() -> None:
+    conns, name_by_net, class_by_name = _load_connections()
+    assert len(conns) == 287, "anchor-star topology of the rev-C fixture"
+
+    pf = LatticePathfinder.from_board(
+        _SOFTSTART.read_text(),
+        DesignRules(),
+        layer_stack=LayerStack.four_layer_all_signal(),
+    )
+    routes, stats = pf.route_netset(conns, max_iterations=2)
+
+    # Measurement visibility (pytest -s): the honest census.
+    from collections import Counter
+
+    print(
+        f"\n[softstart proof] connections {stats.routed}/{stats.total} "
+        f"iterations={stats.iterations} converged={stats.converged} "
+        f"declines={dict(Counter(pf.failure_reasons.values()))}"
+    )
+
+    # 1. Static substrate at scale.
+    assert stats.lattice_builds == 1
+
+    # 3. Completion floor (measured; every shortfall is a decline+reason).
+    assert stats.routed >= _CONNECTION_FLOOR, (
+        f"connections {stats.routed}/{stats.total} below the measured floor; "
+        f"declines: {dict(list(pf.failure_reasons.items())[:10])}..."
+    )
+    assert len(pf.failure_reasons) == stats.total - stats.routed
+
+    # Net-level completion.
+    keys_by_net: dict[int, list] = defaultdict(list)
+    for key, *_ in conns:
+        keys_by_net[key[0]].append(key)
+    full = [net for net, keys in keys_by_net.items() if all(k in routes for k in keys)]
+    print(f"[softstart proof] nets fully connected: {len(full)}/{len(keys_by_net)}")
+    assert len(full) >= _NET_FLOOR, f"nets fully connected {len(full)} below floor"
+
+    # 4. Net-class honesty: routed HV_HICUR connections carry 2.6mm copper.
+    hv_checked = 0
+    for key, route in routes.items():
+        nc = class_by_name.get(name_by_net[key[0]])
+        if nc is not None and nc.name == "HV_HICUR":
+            hv_checked += 1
+            assert all(abs(s.width - nc.trace_width) < 1e-9 for s in route.segments)
+
+    # 2. Zero cross-net short: pairwise per-class copper gap on same layer.
+    flat: list[tuple[int, object, tuple, tuple, float, float]] = []
+    rules = pf.rules
+    for key, route in routes.items():
+        nc = class_by_name.get(name_by_net[key[0]])
+        clr = max(getattr(nc, "clearance", 0.0) or 0.0, rules.trace_clearance)
+        for seg in route.segments:
+            flat.append(
+                (route.net, seg.layer, (seg.x1, seg.y1), (seg.x2, seg.y2), seg.width / 2, clr)
+            )
+    # Bucket by layer to keep the pairwise check tractable.
+    by_layer: dict[object, list] = defaultdict(list)
+    for item in flat:
+        by_layer[item[1]].append(item)
+    for items in by_layer.values():
+        for i in range(len(items)):
+            n1, _l1, p1, q1, h1, c1 = items[i]
+            for j in range(i + 1, len(items)):
+                n2, _l2, p2, q2, h2, c2 = items[j]
+                if n1 == n2:
+                    continue
+                # Cheap bbox prefilter.
+                gap = h1 + h2 + max(c1, c2)
+                if (
+                    min(p1[0], q1[0]) > max(p2[0], q2[0]) + gap
+                    or min(p2[0], q2[0]) > max(p1[0], q1[0]) + gap
+                    or min(p1[1], q1[1]) > max(p2[1], q2[1]) + gap
+                    or min(p2[1], q2[1]) > max(p1[1], q1[1]) + gap
+                ):
+                    continue
+                d = seg_seg_dist(p1, q1, p2, q2)
+                assert d >= gap - 1e-6, f"nets {n1}/{n2} copper {d:.4f}mm apart (< {gap:.4f}mm)"

--- a/tests/router/lattice/test_stubs.py
+++ b/tests/router/lattice/test_stubs.py
@@ -118,3 +118,30 @@ def test_stub_blocked_by_committed_copper_declines_never_blind_fits() -> None:
     # Without the committed copper the same pad attaches fine (the decline
     # above is the obstacle consult, not a general inability).
     assert pf.pad_stubs(pad, net=1)
+
+
+def test_npth_drilled_pad_blocks_every_layer() -> None:
+    """NPTH mounting holes load as np_thru_hole pads with
+    ``through_hole=False`` on one copper layer, but the drilled barrel
+    exists on EVERY layer (issue #4271: softstart shipped an In1.Cu track
+    through a 2.7mm fuse-holder hole).  ``drill > 0`` must through-block."""
+    from kicad_tools.router.lattice.pathfinder import LatticePathfinder
+    from kicad_tools.router.layers import Layer, LayerStack
+    from kicad_tools.router.primitives import Pad
+
+    npth = Pad(
+        x=10.0,
+        y=5.0,
+        width=2.7,
+        height=2.7,
+        net=0,
+        net_name="",
+        layer=Layer.F_CU,
+        ref="F1",
+        pin="",
+        through_hole=False,
+        drill=2.7,
+    )
+    outline = [(0.0, 0.0), (20.0, 0.0), (20.0, 10.0), (0.0, 10.0)]
+    pf = LatticePathfinder(outline, [npth], layer_stack=LayerStack.four_layer_all_signal())
+    assert pf._pad_layer_indices(npth) == (0, 1, 2, 3)

--- a/tests/test_route_grid_safety_gate.py
+++ b/tests/test_route_grid_safety_gate.py
@@ -127,3 +127,41 @@ def test_safe_grid_never_triggers_gate(tmp_path):
     code, gate_reached = _run_main_to_gate(tmp_path, _safe_selection(), [])
     assert gate_reached is True, "A safe grid must not be gated"
     assert code is None
+
+
+def test_lattice_engine_bypasses_gate(tmp_path):
+    """--route-engine lattice must NOT be refused by the unsafe-grid gate.
+
+    Issue #4271: the lattice engine never emits copper from the grid (the
+    grid object is a coordinate substrate only), so the #3911 refusal is
+    grid-engine-only.  Softstart rev-C falls in the #4242 grid gap -- the
+    gate used to block exactly the boards the lattice engine exists for.
+    """
+    code, gate_reached = _run_main_to_gate(
+        tmp_path,
+        _unsafe_selection(),
+        ["--route-engine", "lattice", "--strategy", "basic"],
+    )
+    assert gate_reached is True, "lattice engine must bypass the grid safety gate"
+    assert code is None
+
+
+def test_mesh_engine_bypasses_gate(tmp_path):
+    """--route-engine mesh equally never routes on the grid (issue #4271)."""
+    code, gate_reached = _run_main_to_gate(
+        tmp_path,
+        _unsafe_selection(),
+        ["--route-engine", "mesh", "--strategy", "basic"],
+    )
+    assert gate_reached is True, "mesh engine must bypass the grid safety gate"
+    assert code is None
+
+
+def test_grid_engine_gate_unchanged_by_engine_bypass(tmp_path, capsys):
+    """The explicit grid engine still refuses -- #3911 behavior intact."""
+    code, gate_reached = _run_main_to_gate(
+        tmp_path, _unsafe_selection(), ["--route-engine", "grid"]
+    )
+    assert code == 1
+    assert gate_reached is False
+    assert "--allow-unsafe-grid" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Epic #4267 P4. Phase A threads net-class widths/clearances through the lattice engine end-to-end (the curator-verified load-bearing gap: dispatch hardwired `net_class=None`, committed copper recorded at global half-width, `seg_clear` discarded stored widths). Phase B is the measured softstart rev-C proof: **71/77 signal nets fully connected, 0 error-severity kicad-cli DRC violations (`.kicad_dru`-armed, `--refill-zones`), 0 shorts, wall-clock 34.9 min**, with an honest per-connection decline census for every shortfall.

Three lattice-blocking bugs surfaced by the big board were fixed in-scope (each measured, each tested): the #3911 unsafe-auto-grid gate fired for non-grid engines; the sub-grid escape pre-pass committed grid copper invisible to the lattice; duplicate-numbered pads (ESP32-C3 thermal array) collapsed out of the obstacle model. Plus NPTH holes now through-block.

**Sibling note:** #4270 (diff-pair fat-agent, PR #4288) merged mid-build; this branch is rebased onto it. The width plumbing and the fat-agent path are merged surgically: single-ended checks take per-class geometry, fat checks keep their grown-envelope predicates (now honest against oversize committed copper via the per-segment stored widths), and pair legs are committed at the same class width they are emitted at.

## Changes

**Phase A — net-class width/clearance plumbing**
- `core.py`: dispatch resolves each net's class from `router.net_class_map` (sidecar merges in via #4149 rekeying) and threads it into every lattice connection (including #4270 pair-extra attachments); connection keys deduped for duplicate pad numbers.
- `lattice/pathfinder.py`: `_conn_geometry` derives per-connection (half-width, clearance); width follows the class exactly as `_emit` does, clearance floored at the design rules. Used in pad stubs, A* edge/node/via legality, and the committed-copper commit. Static pad checks gain an `extra` inflation for oversize classes.
- `lattice/obstacles.py`: `CommittedCopper` stores per-segment `(half_width, clearance)`; every predicate sizes the gap as `own_half + stored_half + max(own_clr, stored_clr)` (HV 0.3mm honored from either side, KiCad conditional-rule semantics); `via_clear` honors stored widths.
- `lattice/geometry.py`: `SegHash` items carry clearance.
- `lattice/coupled.py`: grown predicates adapted to the per-segment model (fat envelopes spaced honestly against 2.6mm copper).

**Discovered-bug fixes (all measured on the P4 board)**
- `cli/route_cmd.py`: #3911 unsafe-auto-grid hard error is grid-engine-only (lattice/mesh never emit grid copper; softstart sits in the #4242 grid gap and was refused before the lattice ran). Grid behavior byte-identical.
- `core.py`: sub-grid escape pre-pass gated off for mesh/lattice (same seam family as #4280/#4281). Ungated it produced EVERY DRC error of the first run (12 shorts + 3 clearance + 16 mask bridges) and demoted 34 clean lattice nets.
- `core.py`: `Autorouter.all_pads` preserves duplicate-numbered pads for exact-geometry engine obstacles (the `(ref,pin)` dict collapsed 20 of U14's 40 pads; every remaining short traced to them). Grid unaffected (pads are marked on the grid before the dict overwrite).
- `lattice/pathfinder.py`: `drill > 0` through-blocks (NPTH mounting holes; killed the final 2 `hole_clearance` errors) and engages the via hole-to-hole floor.
- `core.py`: lattice negotiation stats + per-reason decline census printed from the dispatch (shortfalls diagnosable from run output).

**Tests** (18 new)
- `tests/router/lattice/test_net_class_widths.py` (10): true-half-width blocking, HV clearance from either side, end-to-end emission+spacing at class width, dispatch threading, default behavior unchanged, clearance floor.
- `tests/router/lattice/test_engine_dispatch.py` (+2): sub-grid pre-pass dormant for non-grid engines; `all_pads` duplicate preservation.
- `tests/router/lattice/test_stubs.py` (+1): NPTH through-block.
- `tests/test_route_grid_safety_gate.py` (+3): lattice/mesh bypass the gate, grid refusal unchanged.
- `tests/router/lattice/test_softstart_routing.py` (NEW, fixture-gated): the P4 proof — skips cleanly when `boards/external/softstart` dangles (mirrors `test_softstart_memory.py`); asserts `lattice_builds == 1` at 287-connection scale, >= 255/287 connections and >= 55/79 nets (measured 267 and 63 at `max_iterations=2`), zero cross-net short at per-class gaps, HV_HICUR emitted at 2.6mm. ~25 min local wall-clock, local-only.

## Measured verdict (run of record, seed 42)

Protocol: issue commands + `--allow-offboard` (a placement-check frame false-positive flags U14 as off-board; follow-up filed) + `--no-auto-layers` (single 4-layer attempt matching the board's real stackup; avoids the 3x escalation ladder).

| Metric | Result | Criterion | Verdict |
|---|---|---|---|
| Nets fully connected | **71/77 signal (92%)**; 6 partial, 0 unrouted; GND/+3.3V plane-served by auto-pour | >= 40/79 clean | **PASS** |
| Connections | 195/205 (8 iterations, lattice_builds=1) | census for shortfall | PASS |
| kicad-cli DRC (`--refill-zones`, DRU armed) | **0 error-severity violations** (baseline unrouted board: 0) | 0 errors, 0 shorts | **PASS** |
| Shorts | 0 — every shortfall is a decline with a reason | never a short | PASS |
| Wall-clock | 34.9 min (2092 s) | <= 2 h | PASS |
| Peak RSS (full CLI run) | **1.85 GB — FAILS the 512 MB rail** | <= 512 MB | **FAIL (attributed)** |
| Peak RSS (lattice engine alone, `route_netset` run) | **433.6 MB** | — | under the rail |
| `kct check --mfr jlcpcb` | FAILED: 101 ampacity + 6 connectivity + 7 sliver warnings (details below) | reported honestly | reported |

**Decline census (10/205):** `pad-escape-end` x8 on 4 nets — /AC_NEUTRAL, /FUSED_LINE (both 2.6mm HV_HICUR; the oversize keep-out surcharge cannot clear the dense fuse/terminal pad fields), /NRST, /PGND; `no-path` x2 — /GATE_NEG_B, /OC_TRIP_N. DRC warnings: 16 hole_to_hole (lattice via holes; cross-net via-via gap has no hole floor — follow-up), 6 silk (5 pre-existing).

**RSS attribution:** the negotiation phase held ~400-500 MB (observed live); the 1.85 GB peak is the post-routing CLI tail (result cache + internal DRC + zone machinery) — orthogonal to the lattice engine, follow-up filed. The epic's motivating wall (grid substrate 1.14 GB) vs lattice substrate 31 MB stands per the standing memory test.

**`kct check` detail:** 101 ampacity errors are the 2.6mm HV copper vs IPC-2221 15 A @ 1.0 oz (12.6mm) — the copper IS at its class width (Phase A working as specified); the owner's documented plan is post-route 16 AWG buttress reinforcement (`kct pcb reinforce`) and the board is 2 oz. 6 connectivity errors = exactly the 6 partial nets. 

**Grid baseline on this exact board (#4242):** batch negotiated router cannot run at all; greedy per-net gave <=28/79 genuine nets buried in 1266 violations (0 usable). The lattice result strictly dominates on every axis.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| 1. >= 40/79 nets connected AND DRC-clean, 0 shorts, decline census | ✅ | 71/77 full, 0 DRC errors, census above |
| 2. Peak RSS <= 512 MB | ❌ full CLI (1.85 GB) / ✅ engine (433 MB) | honest split + follow-up; owner call on the epic |
| 3. Wall-clock <= 2 h | ✅ | 34.9 min |
| 4. Net-class honesty (HV at 2.6mm, HV clearances) | ✅ | DRU-armed DRC clean; proof test asserts widths |
| 5. `kct check --mfr jlcpcb` reported honestly | ✅ | itemized above |
| 6. Flag discipline: default stays grid; CI green | ✅ | gate/byte-identity suites green; no default change |
| 7. New test skips cleanly without fixture | ✅ | `skipif(not _SOFTSTART.exists())` module-level |
| 8. Discovered bugs small->in-scope, else filed | ✅ | 4 fixed in-scope (~50 LOC each, tested); follow-ups filed for the rest |

## Test Plan

- `tests/router/` full tree: 755 passed (pre-rebase), lattice suite 86 passed post-rebase (includes #4288 pair tests against the merged plumbing).
- Board-02 lattice still 8/8 (`test_post_pass_gating`), #4283/#4284 invariants green, mesh suite + engine gates + MFR001 green.
- mypy: 0 new errors (75 pre-existing baseline in core.py/route_cmd.py, identical on main). ruff clean.
- Proof test re-run on the REBASED tree: identical numbers (267/287 connections, 63/79 nets, same census) — the measurement stands on the merged code.

The measured verdict is also posted on epic #4267.

Closes #4271