### PR TITLE
fix(placement): warn instead of error on courtyard-artwork edge overhang; unblock offset boards (#4290)

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -7975,12 +7975,18 @@ def _offboard_preflight(pcb_path: Path) -> int:
     indistinguishable from routing congestion.  This preflight surfaces the
     real cause up front (issue #4156).
 
+    Only ERROR-severity off-board conflicts block.  WARNING-severity
+    ``OFF_BOARD`` findings (courtyard artwork overhanging the edge while every
+    pad is on-board — antenna modules, edge connectors; issue #4290) are
+    routable by construction and must not force ``--allow-offboard``, which
+    would also disable this gate for genuinely off-board parts.
+
     Returns 0 when the placement is on-board (or the board has no outline, or
     the check cannot run), and 2 (matching the blocking netlist-sync gate's
     exit convention) when off-board footprints are found.
     """
     try:
-        from kicad_tools.placement import ConflictType, PlacementAnalyzer
+        from kicad_tools.placement import ConflictSeverity, ConflictType, PlacementAnalyzer
 
         analyzer = PlacementAnalyzer()
         conflicts = analyzer.find_conflicts(pcb_path)
@@ -7988,7 +7994,11 @@ def _offboard_preflight(pcb_path: Path) -> int:
         # A preflight that cannot run must never block routing outright.
         return 0
 
-    offboard = [c for c in conflicts if c.type == ConflictType.OFF_BOARD]
+    offboard = [
+        c
+        for c in conflicts
+        if c.type == ConflictType.OFF_BOARD and c.severity == ConflictSeverity.ERROR
+    ]
     if not offboard:
         return 0
 

--- a/src/kicad_tools/placement/analyzer.py
+++ b/src/kicad_tools/placement/analyzer.py
@@ -81,6 +81,10 @@ class PlacementAnalyzer:
         self.verbose = verbose
         self._components: list[ComponentInfo] = []
         self._board_edge: Rectangle | None = None
+        # Sheet-absolute position of the board-relative frame's origin (the
+        # PCB's detected board origin).  Used only to echo sheet coordinates
+        # in off-board messages on offset boards (issue #4290).
+        self._board_origin_offset: tuple[float, float] = (0.0, 0.0)
 
     def find_conflicts(
         self,
@@ -586,13 +590,21 @@ class PlacementAnalyzer:
     def _check_off_board(self) -> Iterator[Conflict]:
         """Flag components whose courtyard falls outside the board outline.
 
-        This is a hard-invalid placement, qualitatively different from the
-        "inside but too close to the edge" case handled by
-        :meth:`_check_edge_clearance`.  A footprint whose courtyard is
-        *fully* outside the outline (the common "everything shifted N mm off
-        the board" incident, issue #4156) or *partially* straddling the edge
-        cannot be manufactured or routed as placed, so both are unconditional
-        ``ERROR`` severity, independent of ``min_edge_clearance``.
+        A footprint whose courtyard is *fully* outside the outline (the common
+        "everything shifted N mm off the board" incident, issue #4156), or
+        whose **pads** extend past the edge, cannot be manufactured or routed
+        as placed — those are unconditional ``ERROR`` severity, independent of
+        ``min_edge_clearance``.
+
+        A footprint whose courtyard *artwork* overhangs the edge while every
+        pad sits on the board is different (issue #4290): edge-overhang parts
+        — chip-antenna / RF modules (e.g. ESP32-C3-WROOM-02, whose antenna
+        keepout courtyard is *supposed* to protrude past Edge.Cuts per the
+        datasheet), card-edge USB, and overhanging connectors — do this by
+        design.  Those are reported as ``WARNING`` so ``kct placement check``
+        still surfaces them without invalidating the placement (and without
+        forcing ``kct route --allow-offboard``, which would also disable the
+        real off-board gate).
 
         Uses an axis-aligned bounding-box test against the outline bbox — the
         same cheap approach as ``place_unplaced._get_board_bounds``.  A true
@@ -600,11 +612,23 @@ class PlacementAnalyzer:
         is a future refinement (see issue #4182); the bbox test covers the
         reported incident and never false-negatives on a shifted-off-board
         row.
+
+        All comparisons happen in a single coordinate frame: both the outline
+        bbox (:meth:`_extract_board_edge`) and every pad/courtyard coordinate
+        come from the same board-relative frame that ``schema.PCB`` normalizes
+        on load.  The message additionally reports the outline in
+        sheet-absolute coordinates when the board origin is non-zero, so the
+        printed bounds match what KiCad displays for offset boards instead of
+        the misleading-looking ``0.0,0.0 to W,H``.
         """
         if not self._board_edge:
             return
 
         edge = self._board_edge
+        # Float-noise tolerance for the pads-on-board containment test (the
+        # board-relative frame is produced by subtraction, so exact equality
+        # at the edge is not guaranteed).
+        eps = 1e-6
 
         for comp in self._components:
             if not comp.courtyard:
@@ -628,6 +652,46 @@ class PlacementAnalyzer:
             if not fully_outside and not partially_outside:
                 continue
 
+            # Which side(s) overhang, and by how much — makes the real cause
+            # (e.g. a 2.35 mm antenna-courtyard overhang) instantly visible.
+            overhangs: list[str] = []
+            if cy.min_x < edge.min_x:
+                overhangs.append(f"left {edge.min_x - cy.min_x:.2f}mm")
+            if cy.max_x > edge.max_x:
+                overhangs.append(f"right {cy.max_x - edge.max_x:.2f}mm")
+            if cy.min_y < edge.min_y:
+                overhangs.append(f"top {edge.min_y - cy.min_y:.2f}mm")
+            if cy.max_y > edge.max_y:
+                overhangs.append(f"bottom {cy.max_y - edge.max_y:.2f}mm")
+            overhang_txt = ", ".join(overhangs)
+
+            board_txt = self._board_bounds_text(edge)
+
+            pads_on_board = comp.pads_bbox is not None and (
+                comp.pads_bbox.min_x >= edge.min_x - eps
+                and comp.pads_bbox.max_x <= edge.max_x + eps
+                and comp.pads_bbox.min_y >= edge.min_y - eps
+                and comp.pads_bbox.max_y <= edge.max_y + eps
+            )
+
+            if not fully_outside and pads_on_board:
+                # Courtyard-artwork-only edge overhang with every pad on the
+                # board: probable intentional overhang (issue #4290).
+                yield Conflict(
+                    type=ConflictType.OFF_BOARD,
+                    severity=ConflictSeverity.WARNING,
+                    component1=comp.reference,
+                    component2="board_outline",
+                    message=(
+                        f"courtyard overhangs Edge.Cuts outline ({overhang_txt}; "
+                        f"{board_txt}) but all pads are on-board — probable "
+                        "intentional edge overhang (antenna/connector); verify "
+                        "mechanical fit"
+                    ),
+                    location=cy.center,
+                )
+                continue
+
             descriptor = "fully outside" if fully_outside else "partially outside"
             yield Conflict(
                 type=ConflictType.OFF_BOARD,
@@ -636,11 +700,29 @@ class PlacementAnalyzer:
                 component2="board_outline",
                 message=(
                     f"courtyard {descriptor} Edge.Cuts outline "
-                    f"(board {edge.min_x:.1f},{edge.min_y:.1f} to "
-                    f"{edge.max_x:.1f},{edge.max_y:.1f}) — placement invalid"
+                    f"({overhang_txt}; {board_txt}) — placement invalid"
                 ),
                 location=cy.center,
             )
+
+    def _board_bounds_text(self, edge: Rectangle) -> str:
+        """Human-readable outline bounds for off-board messages.
+
+        Reports the board-relative bbox, plus the sheet-absolute bbox when the
+        detected board origin is non-zero.  On an offset board (Edge.Cuts min
+        corner not at the sheet origin) a bare ``board 0.0,0.0 to 160.0,100.0``
+        reads as if the checker normalized the outline while leaving pads
+        absolute (issue #4290); echoing the sheet coordinates KiCad displays
+        removes that ambiguity.
+        """
+        ox, oy = self._board_origin_offset
+        text = f"board {edge.min_x:.1f},{edge.min_y:.1f} to {edge.max_x:.1f},{edge.max_y:.1f}"
+        if ox != 0.0 or oy != 0.0:
+            text += (
+                f" board-relative = sheet {edge.min_x + ox:.1f},{edge.min_y + oy:.1f}"
+                f" to {edge.max_x + ox:.1f},{edge.max_y + oy:.1f}"
+            )
+        return text
 
     def _check_edge_clearance(self, min_clearance: float) -> Iterator[Conflict]:
         """Check clearance from components to board edge.
@@ -758,6 +840,14 @@ class PlacementAnalyzer:
         outline = pcb.get_board_outline()
         if not outline:
             return None
+
+        # Remember where the board-relative frame sits on the sheet so
+        # off-board messages can echo sheet-absolute coordinates (#4290).
+        try:
+            origin = pcb.board_origin
+            self._board_origin_offset = (float(origin[0]), float(origin[1]))
+        except Exception:
+            self._board_origin_offset = (0.0, 0.0)
 
         # get_board_outline() already returns board-relative coordinates.
         all_x = [p[0] for p in outline]

--- a/tests/test_placement.py
+++ b/tests/test_placement.py
@@ -1403,3 +1403,197 @@ class TestFpTextReferenceFormat:
         original = fp_text_format_pcb.read_text()
         modified = output_path.read_text()
         assert original != modified, "Fix command should modify the file with fp_text format"
+
+
+# --- Offset-origin boards and courtyard edge overhang (issue #4290) -----------
+#
+# Softstart rev-C's Edge.Cuts spans (68.5, 55) -> (228.5, 155): a 160x100 board
+# whose min corner is NOT the sheet origin.  #4290 reported U14 (an
+# ESP32-C3-WROOM-02 whose antenna-keepout courtyard intentionally protrudes
+# past the edge) as a blocking OFF_BOARD error, forcing `kct route
+# --allow-offboard`.  Two guarantees are pinned here:
+#
+# 1. Pads and outline are compared in ONE coordinate frame, so a footprint
+#    fully inside an offset outline is never flagged (and a genuinely
+#    off-board footprint on the same offset board still errors).
+# 2. Courtyard-artwork-only edge overhang with every pad on-board is a
+#    WARNING (probable intentional overhang: antenna/connector), not a
+#    placement-invalidating ERROR.
+
+# 160x100 outline with min corner (50, 40) -> (210, 140), drawn as chained
+# gr_line segments exactly like the softstart board (exercises the
+# _detect_board_origin gr_line fallback path, not the gr_rect path).
+_OFFSET_OUTLINE = """  (gr_line (start 50 40) (end 210 40)
+    (stroke (width 0.1) (type default)) (layer "Edge.Cuts"))
+  (gr_line (start 210 40) (end 210 140)
+    (stroke (width 0.1) (type default)) (layer "Edge.Cuts"))
+  (gr_line (start 210 140) (end 50 140)
+    (stroke (width 0.1) (type default)) (layer "Edge.Cuts"))
+  (gr_line (start 50 140) (end 50 40)
+    (stroke (width 0.1) (type default)) (layer "Edge.Cuts"))
+"""
+
+
+def _offset_board_pcb(footprints: str) -> str:
+    """Synthetic offset-origin board (Edge.Cuts min corner at (50, 40))."""
+    return f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general
+    (thickness 1.6)
+  )
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+    (47 "F.CrtYd" user "F.Courtyard")
+  )
+  (setup
+    (pad_to_mask_clearance 0)
+  )
+  (net 0 "")
+  (net 1 "NET1")
+{_OFFSET_OUTLINE}{footprints})
+"""
+
+
+def _r0402_at(ref: str, x: float, y: float, uuid_n: int) -> str:
+    """R_0402 footprint at sheet-absolute (x, y); no courtyard artwork."""
+    return f"""  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000{uuid_n:02d}")
+    (at {x} {y})
+    (property "Reference" "{ref}" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "NET1"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (net 0 ""))
+  )
+"""
+
+
+def _antenna_module_at(ref: str, x: float, y: float) -> str:
+    """Footprint whose real F.CrtYd artwork extends 2mm above its pads.
+
+    Models an antenna module: pads sit at (x, y) but the courtyard rectangle
+    spans y-7 .. y+2 relative to the anchor, so placing it near the top edge
+    leaves every pad on-board while the courtyard overhangs the outline.
+    """
+    return f"""  (footprint "RF_Module:Fake_Antenna_Module"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000099")
+    (at {x} {y})
+    (property "Reference" "{ref}" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "ANT" (at 0 1.5 0) (layer "F.Fab"))
+    (fp_rect (start -2 -7) (end 2 2)
+      (stroke (width 0.05) (type default)) (fill none) (layer "F.CrtYd"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "NET1"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (net 0 ""))
+  )
+"""
+
+
+class TestOffsetOriginOffBoard:
+    """Off-board detection on boards whose Edge.Cuts min corner is not (0,0)."""
+
+    def _conflicts(self, tmp_path: Path, footprints: str):
+        pcb_file = tmp_path / "offset_board.kicad_pcb"
+        pcb_file.write_text(_offset_board_pcb(footprints))
+        return PlacementAnalyzer().find_conflicts(pcb_file)
+
+    def test_inside_far_corner_is_clean(self, tmp_path: Path):
+        """Footprint near the far corner but fully inside -> no OFF_BOARD.
+
+        Sheet (205, 135) is board-relative (155, 95) on the 160x100 outline.
+        A checker that normalized the outline to the origin while leaving pad
+        coordinates sheet-absolute (the #4290 mis-diagnosis scenario) would
+        flag this footprint (205 > 160); comparing both in one frame must not.
+        """
+        conflicts = self._conflicts(tmp_path, _r0402_at("R1", 205, 135, 10))
+        assert not [c for c in conflicts if c.type == ConflictType.OFF_BOARD]
+
+    def test_fully_offboard_still_errors(self, tmp_path: Path):
+        """Genuinely off-board footprint on the offset board -> ERROR."""
+        conflicts = self._conflicts(tmp_path, _r0402_at("R1", 230, 150, 10))
+        off = [c for c in conflicts if c.type == ConflictType.OFF_BOARD]
+        assert len(off) == 1
+        assert off[0].severity == ConflictSeverity.ERROR
+        assert "fully outside" in off[0].message
+        # The message reports the outline in both frames so offset boards do
+        # not read as origin-normalized (the confusion that produced #4290).
+        assert "sheet 50.0,40.0 to 210.0,140.0" in off[0].message
+
+    def test_straddling_pads_still_errors(self, tmp_path: Path):
+        """Footprint whose pads cross the offset outline edge -> ERROR."""
+        # At sheet x=209.9 the right pad spans 210.14..210.68 -> past 210.
+        conflicts = self._conflicts(tmp_path, _r0402_at("R1", 209.9, 90, 10))
+        off = [c for c in conflicts if c.type == ConflictType.OFF_BOARD]
+        assert len(off) == 1
+        assert off[0].severity == ConflictSeverity.ERROR
+        assert "partially outside" in off[0].message
+
+    def test_pads_inside_margin_overhang_is_warning(self, tmp_path: Path):
+        """Pads on-board, only the courtyard margin overhangs -> WARNING.
+
+        The fallback courtyard is the pads bbox expanded by 0.25mm; a pad
+        0.1mm from the edge keeps all copper on-board while the margin pokes
+        out.  This must warn (it routes and fabs fine), not invalidate.
+        """
+        # Right pad extent: 209.0 + 0.51 + 0.27 = 209.78 (inside the 210
+        # edge); the fallback courtyard adds 0.25 -> 210.03 (0.03mm overhang).
+        conflicts = self._conflicts(tmp_path, _r0402_at("R1", 209.0, 90, 10))
+        off = [c for c in conflicts if c.type == ConflictType.OFF_BOARD]
+        assert len(off) == 1
+        assert off[0].severity == ConflictSeverity.WARNING
+        assert "all pads are on-board" in off[0].message
+        # Warnings alone must not fail `kct placement check` (exit code is
+        # driven by ERROR-severity conflicts only).
+        assert not [c for c in off if c.severity == ConflictSeverity.ERROR]
+
+    def test_real_courtyard_overhang_pads_inside_is_warning(self, tmp_path: Path):
+        """Antenna-style F.CrtYd artwork past the edge, pads inside -> WARNING.
+
+        This is the exact softstart rev-C U14 shape: every pad on-board, the
+        module's courtyard protruding past the outline by design.
+        """
+        pytest.importorskip("shapely")
+        # Anchor at sheet (100, 45): pads at y=45 (board-relative 5, inside);
+        # courtyard spans sheet y 38..47 -> 2mm past the top edge (40).
+        conflicts = self._conflicts(tmp_path, _antenna_module_at("U14", 100, 45))
+        off = [c for c in conflicts if c.type == ConflictType.OFF_BOARD]
+        assert len(off) == 1
+        assert off[0].severity == ConflictSeverity.WARNING
+        assert off[0].component1 == "U14"
+        assert "top 2.00mm" in off[0].message
+        assert "all pads are on-board" in off[0].message
+
+
+class TestSoftstartRevCOffBoard:
+    """Live check against the local-only softstart rev-C fixture (#4290)."""
+
+    _SOFTSTART_REVC = (
+        Path(__file__).resolve().parent.parent
+        / "boards"
+        / "external"
+        / "softstart"
+        / "output_revc"
+        / "softstart_revc.kicad_pcb"
+    )
+
+    def test_u14_antenna_overhang_is_not_an_error(self):
+        """U14's antenna courtyard overhang must not invalidate the placement."""
+        board = self._SOFTSTART_REVC
+        try:
+            available = board.exists()
+        except OSError:
+            available = False
+        if not available:
+            pytest.skip("softstart fixture not available on this host (local-only symlink)")
+
+        conflicts = PlacementAnalyzer().find_conflicts(board)
+        off_errors = [
+            c
+            for c in conflicts
+            if c.type == ConflictType.OFF_BOARD and c.severity == ConflictSeverity.ERROR
+        ]
+        assert off_errors == []

--- a/tests/test_route_offboard_gate.py
+++ b/tests/test_route_offboard_gate.py
@@ -143,5 +143,98 @@ class TestRouteOffboardGateOuterEntry:
         assert "placement invalid" not in capsys.readouterr().err
 
 
+class TestRouteOffboardGateOffsetOrigin:
+    """Gate behavior on offset-origin boards and edge-overhang parts (#4290).
+
+    Softstart rev-C (Edge.Cuts min corner at (68.5, 55), an ESP32-C3-WROOM-02
+    whose antenna courtyard protrudes past the edge by design) was blocked by
+    the gate, forcing ``--allow-offboard`` -- which also disables the gate for
+    genuinely off-board parts.  WARNING-severity OFF_BOARD findings (courtyard
+    artwork overhanging while every pad is on-board) must not block; ERROR
+    findings on the same offset board still must.
+    """
+
+    def _offset_board(self, footprint: str) -> str:
+        """Offset-origin board: gr_line outline (50,40)-(210,140)."""
+        return f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general
+    (thickness 1.6)
+  )
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+    (47 "F.CrtYd" user "F.Courtyard")
+  )
+  (setup
+    (pad_to_mask_clearance 0)
+  )
+  (net 0 "")
+  (net 1 "NET1")
+  (gr_line (start 50 40) (end 210 40)
+    (stroke (width 0.1) (type default)) (layer "Edge.Cuts"))
+  (gr_line (start 210 40) (end 210 140)
+    (stroke (width 0.1) (type default)) (layer "Edge.Cuts"))
+  (gr_line (start 210 140) (end 50 140)
+    (stroke (width 0.1) (type default)) (layer "Edge.Cuts"))
+  (gr_line (start 50 140) (end 50 40)
+    (stroke (width 0.1) (type default)) (layer "Edge.Cuts"))
+{footprint})
+"""
+
+    def _r0402(self, x: float, y: float, crtyd: str = "") -> str:
+        return f"""  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000010")
+    (at {x} {y})
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+{crtyd}    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "NET1"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "NET1"))
+  )
+"""
+
+    def test_inside_offset_board_routes_without_allow_offboard(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """Footprint near the far corner of an offset board -> gate passes."""
+        pcb = tmp_path / "offset_inside.kicad_pcb"
+        # Sheet (205, 135) = board-relative (155, 95) on the 160x100 outline:
+        # fully inside, but flagged by any absolute-vs-normalized frame mixup.
+        pcb.write_text(self._offset_board(self._r0402(205, 135)))
+        rc = route_main([str(pcb), "--dry-run"])
+        assert rc == 0
+        err = capsys.readouterr().err
+        assert "placement invalid" not in err
+
+    def test_courtyard_overhang_warning_does_not_block(self, tmp_path: Path, capsys) -> None:
+        """Antenna-style courtyard overhang (pads on-board) -> gate passes."""
+        pytest.importorskip("shapely")
+        pcb = tmp_path / "offset_overhang.kicad_pcb"
+        # Real F.CrtYd artwork spanning sheet y 38..47 (2mm past the top edge
+        # at 40) while the pads sit at y=45, fully on-board.
+        crtyd = """    (fp_rect (start -2 -7) (end 2 2)
+      (stroke (width 0.05) (type default)) (fill none) (layer "F.CrtYd"))
+"""
+        pcb.write_text(self._offset_board(self._r0402(100, 45, crtyd)))
+        rc = route_main([str(pcb), "--dry-run"])
+        assert rc == 0
+        err = capsys.readouterr().err
+        assert "placement invalid" not in err
+
+    def test_genuinely_offboard_on_offset_board_still_aborts(self, tmp_path: Path, capsys) -> None:
+        """Fully off-board footprint on the same offset board -> exit 2."""
+        pcb = tmp_path / "offset_offboard.kicad_pcb"
+        pcb.write_text(self._offset_board(self._r0402(230, 150)))
+        rc = route_main([str(pcb), "--dry-run"])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "outside Edge.Cuts" in err
+        assert "placement invalid" in err
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Closes #4290

## What the bug actually was

The issue diagnosed a coordinate-frame mismatch (absolute pads vs origin-normalized outline). Investigation shows that mismatch **does not exist**: `schema.PCB` normalizes footprints, pads, and the Edge.Cuts outline into one board-relative frame on load, and `PlacementAnalyzer` compares them in that single frame. A synthetic offset-origin board (min corner (50,40), footprint near the far corner) already passed before this change — that property is now pinned by regression tests.

The real cause of the softstart rev-C block was U14 (ESP32-C3-WROOM-02): its **antenna-keepout courtyard protrudes 2.35mm past the top edge by design** (sheet y 52.65 < board top 55; per the module datasheet the antenna should overhang Edge.Cuts). `_check_off_board` treated any courtyard bbox overhang as an unconditional ERROR, and the message printed the outline in board-relative coordinates (`board 0.0,0.0 to 160.0,100.0`), which on an offset board *reads* like origin-normalization against absolute pads — the exact mis-diagnosis in the issue.

## Fix

- `placement/analyzer.py::_check_off_board`: courtyard-artwork-only edge overhang with **every pad on-board** is now a WARNING ("probable intentional edge overhang (antenna/connector)"). Courtyard fully outside, or **any pad past the outline**, remains an ERROR — the #4156 shifted-board gate is not weakened.
- Off-board messages now name the overhanging side(s) and distance (e.g. `top 2.35mm`) and echo the **sheet-absolute** bounds when the board origin is non-zero (`board 0.0,0.0 to 160.0,100.0 board-relative = sheet 68.5,55.0 to 228.5,155.0`), removing the frame ambiguity.
- `cli/route_cmd.py::_offboard_preflight`: blocks only on ERROR-severity `OFF_BOARD` conflicts, so warning-level overhangs route without `--allow-offboard` (which would also have disabled the gate for genuinely off-board parts).

## Acceptance evidence

- **Softstart rev-C** (local fixture): `kct placement check` exits 0 with one warning (`courtyard overhangs Edge.Cuts outline (top 2.35mm; ...) but all pads are on-board`); `kct route --dry-run` passes **without** `--allow-offboard`. Covered by a skip-cleanly local-only test.
- **Offset-origin board still catches genuine off-board**: fully-outside footprint → ERROR; pads straddling the edge → ERROR (analyzer tests + route-gate exit-2 test).
- **One-frame guarantee pinned**: footprint at sheet (205,135) inside a (50,40)–(210,140) outline → clean (would be flagged under any absolute-vs-normalized mixup).
- **Fleet unchanged**: placement-check output on boards 00/02/04/05 routed boards is byte-identical to main (04 keeps its one pre-existing warning).

## Gates

- `tests/test_placement.py`, `tests/test_route_offboard_gate.py`, `tests/test_placement_containment.py`: 78 passed
- Adjacent suites (`test_place_route_optimizer`, `test_placement_courtyard_geometry`, `test_placement_nudge`, `test_report_offboard_and_census`): 92 passed; `test_route_engine_strategy_gate`: 31 passed
- MFR001 lint (`test_manufacturer_propagation_lint.py`): 9 passed
- ruff check + format: clean on changed files
- mypy: 0 new errors (30 pre-existing in `route_cmd.py`, identical on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)