### PR TITLE
fix(lattice): enforce hole-to-hole floor for cross-net vias and large-drill pads (#4291)

### DIFF
--- a/src/kicad_tools/router/lattice/obstacles.py
+++ b/src/kicad_tools/router/lattice/obstacles.py
@@ -270,7 +270,17 @@ class CommittedCopper:
                 if cnet != net and seg_pt_dist(c, d, point) < gap - 1e-9:
                     return False
         for vpt, vnet in self.vias:
-            gap = self.via_via_gap if vnet != net else self.same_net_via_gap
+            # Cross-net vias must honor BOTH the copper gap (via_via_gap =
+            # via diameter + clearance, centre-to-centre) AND the drill
+            # hole-to-hole floor (same_net_via_gap = via_drill +
+            # min_hole_to_hole).  At JLC defaults the copper gap alone puts
+            # two 0.3mm drills only 0.45mm hole-edge-to-edge -- under the
+            # 0.5mm floor (issue #4291: 16 hole_to_hole DRC warnings on the
+            # softstart P4 run of record).
+            if vnet != net:
+                gap = max(self.via_via_gap, self.same_net_via_gap)
+            else:
+                gap = self.same_net_via_gap
             if dist(point, vpt) < gap - 1e-9:
                 return False
         return True

--- a/src/kicad_tools/router/lattice/pathfinder.py
+++ b/src/kicad_tools/router/lattice/pathfinder.py
@@ -224,6 +224,12 @@ class LatticePathfinder:
         self._via_via_gap = self.rules.via_diameter + clr
         self._same_net_via_gap = self.rules.via_drill + self.rules.min_hole_to_hole
         self._via_pad_grow = via_r + clr - self._agent_radius
+        # Largest drilled hole on the board (PTH or NPTH), computed once:
+        # the _via_ok pad query window must reach via_drill/2 + pad_drill/2
+        # + min_hole_to_hole or large-drill pads silently escape the
+        # hole-to-hole check (issue #4291 -- softstart's 1.3mm terminal
+        # drills sat beyond the old ~0.8mm window).
+        self._max_pad_drill = max((p.drill for p in pads), default=0.0)
 
         # Static substrate, built lazily ONCE (the #4278 acceptance counter).
         self._lattice: OctilinearLattice | None = None
@@ -532,7 +538,15 @@ class LatticePathfinder:
         point = lattice.node_point(key)
         via_radius = self.rules.via_diameter / 2.0
         grow = max(self._via_pad_grow, 0.0)
-        window = max(grow, via_radius) + 0.5
+        # The query window must cover the farthest centre distance any check
+        # below can reject at.  The hole-to-hole floor against the board's
+        # largest drill needs via_drill/2 + max_drill/2 + min_hole_to_hole
+        # -- beyond the copper-derived window for large-drill PTH/NPTH pads
+        # (issue #4291), which the old window silently left unchecked.
+        hole_window = (
+            self.rules.via_drill / 2.0 + self._max_pad_drill / 2.0 + self.rules.min_hole_to_hole
+        )
+        window = max(max(grow, via_radius) + 0.5, hole_window)
         for idx in obstacles.pads_near(
             point[0] - window, point[1] - window, point[0] + window, point[1] + window
         ):

--- a/tests/router/lattice/test_via_hole_floor.py
+++ b/tests/router/lattice/test_via_hole_floor.py
@@ -1,0 +1,171 @@
+"""Lattice via hole-to-hole legality (issue #4291).
+
+Two gaps produced 16 ``hole_to_hole`` DRC warnings on the softstart P4 run
+of record (#4271 / PR #4289), all involving lattice via holes:
+
+1. ``CommittedCopper.via_clear`` sized the CROSS-net via-via gap from copper
+   alone (``via_diameter + clearance`` centre-to-centre) with no drill
+   floor: at the softstart rules (0.6/0.3 via, 0.127-0.15 clearance) two
+   0.3 mm drills could sit 0.45 mm hole-edge-to-edge, under the 0.5 mm
+   ``rules.min_hole_to_hole`` floor the same-net branch already enforced.
+   Fix: cross-net gap = ``max(via_via_gap, same_net_via_gap)``.
+
+2. ``LatticePathfinder._via_ok`` queried ``pads_near`` with a copper-derived
+   window (~0.8 mm) while the hole-to-hole check against a PTH/NPTH pad can
+   reject out to ``via_drill/2 + pad_drill/2 + min_hole_to_hole`` (1.3 mm
+   for softstart's 1.3 mm terminal drills) -- pads whose keep-out rect falls
+   outside the query's bucket range were silently unchecked.  Fix: the
+   window now covers the board's largest drill (computed once in
+   ``__init__``).
+"""
+
+from __future__ import annotations
+
+import math
+
+from kicad_tools.router.lattice.obstacles import CommittedCopper
+from kicad_tools.router.lattice.pathfinder import LatticePathfinder
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import DesignRules
+
+# Softstart-shaped rules (softstart_revc.kicad_dru): via 0.6/0.3, clearance
+# under the 0.35 hole-floor delta so the copper gap (0.6 + 0.15 = 0.75 cc)
+# sits BELOW the hole floor (0.3 + 0.5 = 0.8 cc) -- the regime where fix 1
+# changes the verdict.
+_SOFTSTART_RULES = {
+    "trace_width": 0.2,
+    "trace_clearance": 0.15,
+    "via_diameter": 0.6,
+    "via_drill": 0.3,
+    "min_hole_to_hole": 0.5,
+}
+
+
+def _committed(**overrides: float) -> CommittedCopper:
+    kwargs: dict[str, float] = {
+        "trace_half": 0.1,
+        "clearance": 0.15,
+        "via_radius": 0.3,
+        "via_via_gap": 0.75,  # via_diameter + clearance (copper cc gap)
+        "same_net_via_gap": 0.8,  # via_drill + min_hole_to_hole (hole cc floor)
+    }
+    kwargs.update(overrides)
+    return CommittedCopper(2, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Fix 1: CommittedCopper.via_clear cross-net hole floor.
+# ---------------------------------------------------------------------------
+
+
+def test_cross_net_via_pair_under_hole_floor_is_illegal() -> None:
+    """0.77 mm cc clears the copper gap (0.75) but leaves only 0.47 mm
+    hole-edge-to-edge for two 0.3 mm drills -- under the 0.5 mm floor.
+    Pre-#4291 this was accepted (the run-of-record warning geometry)."""
+    cc = _committed()
+    cc.add_via((5.0, 5.0), net=1)
+    assert not cc.via_clear((5.77, 5.0), net=2)
+
+
+def test_cross_net_via_pair_at_hole_floor_is_legal() -> None:
+    """0.82 mm cc = 0.52 mm hole gap: legal (stays legal after the fix)."""
+    cc = _committed()
+    cc.add_via((5.0, 5.0), net=1)
+    assert cc.via_clear((5.82, 5.0), net=2)
+
+
+def test_cross_net_copper_gap_still_governs_when_larger() -> None:
+    """When the copper gap exceeds the hole floor (the JLC-default regime:
+    0.7 + 0.2 = 0.9 cc copper vs 0.35 + 0.5 = 0.85 cc holes) the fix must
+    not LOOSEN anything: 0.87 cc clears the holes but not the copper."""
+    cc = _committed(via_via_gap=0.9, via_radius=0.35, same_net_via_gap=0.85)
+    cc.add_via((5.0, 5.0), net=1)
+    assert not cc.via_clear((5.87, 5.0), net=2)
+    assert cc.via_clear((5.91, 5.0), net=2)
+
+
+def test_same_net_via_gap_unchanged() -> None:
+    """The same-net branch keeps its hole floor exactly as before."""
+    cc = _committed()
+    cc.add_via((5.0, 5.0), net=1)
+    assert not cc.via_clear((5.77, 5.0), net=1)
+    assert cc.via_clear((5.82, 5.0), net=1)
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: _via_ok pad query window covers the largest drill on the board.
+# ---------------------------------------------------------------------------
+
+_OUTLINE = [(0.0, 0.0), (20.0, 0.0), (20.0, 10.0), (0.0, 10.0)]
+
+
+def _pf(pads: list[Pad], **knobs: float) -> LatticePathfinder:
+    return LatticePathfinder(_OUTLINE, pads, DesignRules(**_SOFTSTART_RULES), **knobs)
+
+
+def _assert_hole_floor_everywhere(pf: LatticePathfinder, pad: Pad) -> None:
+    """Property check on the REAL lattice: every node whose centre distance
+    to ``pad`` is under the hole-to-hole minimum must be via-illegal."""
+    lattice = pf.build()
+    committed = pf._fresh_committed()
+    min_cc = pf.rules.via_drill / 2.0 + pad.drill / 2.0 + pf.rules.min_hole_to_hole
+    other_net = pad.net + 1000
+    checked = 0
+    for key, pt in lattice.nodes.items():
+        if math.dist(pt, (pad.x, pad.y)) < min_cc - 1e-9:
+            checked += 1
+            assert not pf._via_ok(key, other_net, committed), (
+                f"via allowed at {pt} only {math.dist(pt, (pad.x, pad.y)):.3f} mm "
+                f"from a {pad.drill} mm drill (hole floor needs {min_cc:.3f} mm cc)"
+            )
+    assert checked > 0, "no lattice nodes inside the hole-floor annulus; fixture broken"
+
+
+def test_via_ok_hole_floor_against_large_drill_pth_pad() -> None:
+    """Softstart's failure shape: a 1.3 mm-drill PTH terminal pad.  The
+    rejection radius (1.3 mm cc) exceeds the old copper-derived query
+    window (~0.8 mm)."""
+    pad = Pad(
+        x=10.0, y=5.0, width=2.0, height=2.0, net=7, net_name="TERM", through_hole=True, drill=1.3
+    )
+    _assert_hole_floor_everywhere(_pf([pad]), pad)
+
+
+def test_via_ok_hole_floor_bucket_separated_narrow_npth() -> None:
+    """The geometry that genuinely escaped the old window: a pad whose
+    COPPER keep-out rect is much smaller than its drill (NPTH slot-style;
+    ``drill > 0`` with ``through_hole=False``, the #4271 loader shape) and
+    whose rect sits in a different 4 mm lookup bucket than the old query
+    box.  The pad-lookup buckets accidentally cover fat pads (their
+    keep-out rect reaches the query's bucket range), but a 3.0 mm drill
+    with 0.4 mm copper rejects out to 2.15 mm cc while its rect only spans
+    +/-0.45 mm -- the old ~0.8 mm window's bucket range never touched the
+    pad's, so the hole-to-hole branch simply never ran.
+
+    Concretely (bucket boundary at x = 4.0): pad rect x in [4.0, 4.9]
+    (bucket 1); the coarse=0.8 lattice has a node at (2.4, 2.4) whose old
+    query box [1.6, 3.2] stays in bucket 0 -- disjoint -- at 2.05 mm cc,
+    under the 2.15 mm hole floor."""
+    pad = Pad(
+        x=4.45, y=2.4, width=0.4, height=0.4, net=7, net_name="NPTH", through_hole=False, drill=3.0
+    )
+    _assert_hole_floor_everywhere(_pf([pad], coarse=0.8), pad)
+
+
+def test_via_ok_legal_beyond_hole_floor() -> None:
+    """Nodes past the hole floor (and outside every keep-out) stay legal --
+    the enlarged window must not over-reject."""
+    pad = Pad(
+        x=10.0, y=5.0, width=2.0, height=2.0, net=7, net_name="TERM", through_hole=True, drill=1.3
+    )
+    pf = _pf([pad])
+    lattice = pf.build()
+    committed = pf._fresh_committed()
+    min_cc = pf.rules.via_drill / 2.0 + pad.drill / 2.0 + pf.rules.min_hole_to_hole
+    legal = [
+        key
+        for key, pt in lattice.nodes.items()
+        if 1.5 * min_cc < math.dist(pt, (10.0, 5.0)) < 3.0 * min_cc
+    ]
+    assert legal, "no probe nodes in the legal annulus; fixture broken"
+    assert all(pf._via_ok(key, pad.net + 1000, committed) for key in legal)


### PR DESCRIPTION
## Summary

Closes #4291. Fixes both via-legality gaps diagnosed on the softstart P4 run of record, with unit tests that fail pre-fix, and a full P4 protocol re-run with an honest measurement — including a **corrected attribution for the 16 hole_to_hole warnings**: they turn out to be the fixture's own U14 thermal-drill array, not router copper (proof below). The code gaps were nonetheless real and are now closed.

## The two fixes

**1. Cross-net via-via hole floor** (`src/kicad_tools/router/lattice/obstacles.py`, `CommittedCopper.via_clear`)
The OTHER-net branch used `via_via_gap = via_diameter + clearance` (copper centre-to-centre) with no drill floor: at softstart-shaped rules (0.6/0.3 via, 0.15 clearance) two 0.3mm drills could sit at 0.75mm cc = 0.45mm hole-edge-to-edge, under the 0.5mm `rules.min_hole_to_hole` floor the same-net branch already enforced. Cross-net gap is now `max(via_via_gap, same_net_via_gap)`.

**2. `_via_ok` pad query window** (`src/kicad_tools/router/lattice/pathfinder.py`)
The `pads_near` window was `max(via_pad_grow, via_radius) + 0.5` (~0.8mm), but the hole-to-hole check against a PTH/NPTH pad rejects out to `via_drill/2 + pad_drill/2 + min_hole_to_hole` (1.3mm+ for softstart's terminal drills). The window now also covers the board's largest drill (`_max_pad_drill`, computed once in `__init__`). The 4mm pad-lookup buckets accidentally covered fat pads; the genuine escape shape is a narrow-copper large-drill (NPTH slot-style) pad in a disjoint bucket — captured by a regression test.

## Tests (`tests/router/lattice/test_via_hole_floor.py`, 7 new)

- Cross-net via pair at 0.77mm cc (0.47mm hole gap) → now illegal; 0.82mm cc → legal. **Fails pre-fix.**
- JLC-default regime (copper gap 0.9 > hole floor 0.85): behavior asserted unchanged — the fix never loosens.
- Same-net branch asserted unchanged.
- `_via_ok` property check on the real lattice: every node under the hole floor of a 1.3mm-drill PTH pad is rejected; bucket-separated narrow-copper 3.0mm-drill NPTH at 2.05mm cc → now rejected. **Fails pre-fix.**
- Legal annulus beyond the floor stays legal (no over-rejection).

## Softstart P4 protocol re-run (seed 42, solo host, run to completion)

`--route-engine lattice --strategy basic --seed 42 --net-class-map ... --allow-offboard --no-auto-layers` (exact #4271 protocol):

| Metric | Run of record (#4289) | This re-run | Delta |
|---|---|---|---|
| Connections | 195/205 (8 iters, lattice_builds=1) | **195/205** (8 iters, lattice_builds=1) | none |
| Signal nets fully connected | 71/77 | **71/77** | none |
| Decline census | no-path x2 (/GATE_NEG_B, /OC_TRIP_N); pad-escape-end x8 (/AC_NEUTRAL, /FUSED_LINE, /NRST, /PGND) | **identical** | none |
| kicad-cli DRC errors (`.dru`-armed, `--refill-zones`) | 0 | **0** | none |
| Wall-clock | 34.9 min | 33.4 min | noise |

**hole_to_hole: 0 from router copper — measured, with corrected attribution.** The routed output shows 16 hole_to_hole warnings, but ALL 16 are `PTH pad 19 [GND] of U14` vs `PTH pad 19 [GND] of U14` — the ESP32-C3 thermal-via array baked into the fixture footprint (staggered 0.778mm cc, 0.3mm drills = 0.478mm edge gap, under the 0.4995mm board-setup floor). Proof: (a) none of the 12 violating hole positions matches any of the 136 router vias; (b) the **unrouted** input board, DRC'd with the same project constraints armed, shows the **same 16**. The run of record compared against a baseline without the `.kicad_pro` constraint sidecar (which `kct route` writes for the output basename), so the 16 appeared route-induced and were misattributed to "lattice via holes". Router-copper contribution: 16 − 16 = **0**, before and after this fix — the acceptance target is met, and the fixture footprint issue belongs to the softstart repo, not the router.

Because the completion delta is zero and the decline census identical, stricter via legality converted **no** connections to declines on this board at this seed (the board's active regimes never exercised the closed gaps at emitted via sites — they are latent-hazard fixes, proven by the pre-fix-failing unit tests).

## Non-regression

- Fixture-gated proof test `test_softstart_routing.py` re-run post-fix: **identical** (267/287 connections, 63/79 nets at `max_iterations=2`, same census, passed in 24:55) — measured floors unchanged, no floor edits needed.
- Board-02 lattice still 8/8 (`test_post_pass_gating` in-suite); lattice suite 133 passed, mesh suite 50 passed, engine/strategy gates + MFR001 lint green.
- Grid/mesh byte-identity: diff touches only `lattice/obstacles.py`, `lattice/pathfinder.py`, and the new test file.
- ruff check + format clean; mypy 0 new errors on both touched files.
- Pre-existing (on main, unrelated): `test_post_pass_gating.py::test_cli_lattice_skips_both_passes_and_demotes_nothing[default]` fails under `-W error::UserWarning` because the CLI path emits grid-resolution/timeout UserWarnings — verified identical on unmodified main; passes under the normal CI invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
