### PR TITLE
fix(parts): non-circular missing-requests advice + MPN catalog search (#4295, #4296)

### DIFF
--- a/src/kicad_tools/cli/parts_cmd.py
+++ b/src/kicad_tools/cli/parts_cmd.py
@@ -265,18 +265,26 @@ def _search(args) -> int:
     """Handle parts search command."""
     try:
         from ..parts import LCSCClient
+        from ..parts.lcsc import LCSCDependencyMissingError
     except ImportError as e:
         print(f"Error: {e}", file=sys.stderr)
         print("Install with: pip install kicad-tools[parts]", file=sys.stderr)
         return 1
 
     client = LCSCClient()
-    results = client.search(
-        args.query,
-        page_size=args.limit,
-        in_stock=args.in_stock,
-        basic_only=args.basic,
-    )
+    try:
+        results = client.search(
+            args.query,
+            page_size=args.limit,
+            in_stock=args.in_stock,
+            basic_only=args.basic,
+        )
+    except LCSCDependencyMissingError as e:
+        # Backend genuinely unavailable (no ``requests`` extra AND no synced
+        # offline catalog).  Surface this distinctly from a legitimate empty
+        # result so the user isn't misled by a bare "No parts found" (#4296).
+        print(f"Error: parts search backend unavailable: {e}", file=sys.stderr)
+        return 1
 
     if not results.parts:
         print(f"No parts found for: {args.query}", file=sys.stderr)

--- a/src/kicad_tools/parts/jlcparts_catalog.py
+++ b/src/kicad_tools/parts/jlcparts_catalog.py
@@ -51,7 +51,11 @@ from datetime import datetime
 from pathlib import Path
 
 from .cache import get_default_cache_path
-from .lcsc import PARTS_INSTALL_HINT, _categorize_part, _guess_package_type
+from .lcsc import (
+    PARTS_DOWNLOAD_INSTALL_HINT,
+    _categorize_part,
+    _guess_package_type,
+)
 from .models import Part, PartPrice
 
 logger = logging.getLogger(__name__)
@@ -198,12 +202,16 @@ class JlcpartsCatalog:
     ) -> list[Part]:
         """Parametrically search the catalog by free-text value + package.
 
-        The jlcparts schema has *no* dedicated value column, so the query terms
-        are matched against the free-text ``description`` column (the same field
-        the live-API path scores against). Each whitespace-separated term must
-        appear in ``description`` (AND-combined, case-insensitive), optionally
-        constrained to a known ``package``. Filtering is pushed into SQL rather
-        than post-filtered in Python because the real catalog is ~600k+ rows.
+        The jlcparts schema has *no* dedicated value column, so each
+        whitespace-separated term is matched against the free-text
+        ``description`` column *or* the ``mfr`` (manufacturer part number)
+        column -- ``description LIKE ? OR mfr LIKE ?`` per term. Matching
+        ``mfr`` lets MPN queries (e.g. ``"UCC27524"``, ``"IRFB4110"``) resolve
+        even though the MPN never appears in ``description`` (issue #4296);
+        description matching is retained so value/spec queries still work.
+        Terms are AND-combined (case-insensitive), optionally constrained to a
+        known ``package``. Filtering is pushed into SQL rather than
+        post-filtered in Python because the real catalog is ~600k+ rows.
 
         Results are ordered ``library_type`` basic > preferred > extended (the
         JLCPCB assembly tier, matching the downstream
@@ -213,9 +221,10 @@ class JlcpartsCatalog:
         only returns a *candidate pool* shaped like the live-API path.
 
         Args:
-            query: Free-text search string (e.g. ``"10k 0402"``). Split on
-                whitespace into AND-combined ``description LIKE`` terms. An
-                empty/blank query yields an empty list (no unbounded scan).
+            query: Free-text search string (e.g. ``"10k 0402"`` or an MPN like
+                ``"UCC27524"``). Split on whitespace into AND-combined terms,
+                each matched against ``description`` OR ``mfr``. An empty/blank
+                query yields an empty list (no unbounded scan).
             package: Optional exact package filter (e.g. ``"0402"``,
                 ``"LQFP-48"``), matched case-insensitively against ``package``.
             min_stock: Minimum ``stock`` to include (pushed into SQL). Default
@@ -234,8 +243,20 @@ class JlcpartsCatalog:
         if not terms:
             return []
 
-        conditions = ["description LIKE ? ESCAPE '\\' COLLATE NOCASE"] * len(terms)
-        params: list[object] = [f"%{_escape_like(t)}%" for t in terms]
+        # Each term must match the free-text ``description`` *or* the ``mfr``
+        # (manufacturer part number) column.  jlcparts' ``description`` is a
+        # spec string with no MPN, so an MPN query (the most common
+        # BOM-resolution shape, e.g. ``UCC27524``) only resolves via ``mfr``
+        # (issue #4296).  AND-across-terms semantics are preserved; the OR is
+        # per-term.  ``_escape_like`` wildcard escaping is applied to both.
+        conditions = [
+            "(description LIKE ? ESCAPE '\\' COLLATE NOCASE "
+            "OR mfr LIKE ? ESCAPE '\\' COLLATE NOCASE)"
+        ] * len(terms)
+        params: list[object] = []
+        for t in terms:
+            like = f"%{_escape_like(t)}%"
+            params.extend((like, like))
 
         if package:
             conditions.append("package = ? COLLATE NOCASE")
@@ -472,7 +493,7 @@ def sync_catalog(
     except ImportError as e:
         raise ImportError(
             f"Downloading the jlcparts catalog requires the 'requests' library. "
-            f"{PARTS_INSTALL_HINT}"
+            f"{PARTS_DOWNLOAD_INSTALL_HINT}"
         ) from e
 
     dest = dest or get_catalog_path()

--- a/src/kicad_tools/parts/lcsc.py
+++ b/src/kicad_tools/parts/lcsc.py
@@ -43,13 +43,27 @@ logger = logging.getLogger(__name__)
 # ``uv sync`` and ``pip install`` incantations so a base-install failure is
 # actionable rather than a silent degrade.  Unlike ``cmaes``, ``parts`` is
 # NOT pulled in transitively by the ``dev`` or ``all`` extras.
-PARTS_INSTALL_HINT = (
+# Base install incantation shared by every parts-extra error.  Kept separate so
+# download-context callers (``sync-catalog``) can surface *only* the actionable
+# install advice without the self-referential "run sync-catalog" clause below
+# (issue #4295 -- that command is the very one failing on missing ``requests``).
+PARTS_EXTRA_INSTALL_HINT = (
     "The 'requests' library is required for LCSC API access. "
     "Install it with the 'parts' extra: uv sync --extra parts "
-    '(or: pip install "kicad-tools[parts]"). '
-    "Alternatively, sync the offline jlcparts catalog with "
-    "`kct parts sync-catalog` to look up parts without the live API."
+    '(or: pip install "kicad-tools[parts]").'
 )
+
+# General hint for lookup/search, where the offline jlcparts catalog *is* a
+# valid fallback, so pointing the user at ``kct parts sync-catalog`` is helpful.
+PARTS_INSTALL_HINT = (
+    PARTS_EXTRA_INSTALL_HINT + " Alternatively, sync the offline jlcparts catalog "
+    "with `kct parts sync-catalog` to look up parts without the live API."
+)
+
+# Hint for the *downloader* itself (``sync_catalog``).  ``requests`` is required
+# unconditionally to run it, so the offline-catalog suggestion would be circular
+# (issue #4295): it cannot recommend the command that is currently failing.
+PARTS_DOWNLOAD_INSTALL_HINT = PARTS_EXTRA_INSTALL_HINT
 
 
 class LCSCForbiddenError(Exception):

--- a/tests/parts/test_jlcparts_catalog.py
+++ b/tests/parts/test_jlcparts_catalog.py
@@ -308,6 +308,37 @@ def test_catalog_search_escapes_like_wildcards(catalog_db: Path):
     assert catalog.search("_") == []
 
 
+def test_catalog_search_matches_mfr_mpn(catalog_db: Path):
+    """Search resolves parts by MPN via the ``mfr`` column (#4296).
+
+    The MPN lives in ``mfr`` and never appears in ``description``; before the
+    fix these queries returned zero hits (description-only matching).
+    """
+    catalog = JlcpartsCatalog(catalog_db)
+
+    # Full MPN -- present only in `mfr`, absent from the description string.
+    results = catalog.search("STM32F103C8T6")
+    assert [p.lcsc_part for p in results] == ["C8734"]
+    assert results[0].mfr_part == "STM32F103C8T6"
+
+    # A partial MPN prefix also matches (LIKE %term%), still only via `mfr`.
+    results = catalog.search("RC0402FR")
+    assert [p.lcsc_part for p in results] == ["C25804"]
+
+
+def test_catalog_search_mpn_and_description_terms(catalog_db: Path):
+    """Multi-term queries keep AND semantics across the mfr/description OR (#4296)."""
+    catalog = JlcpartsCatalog(catalog_db)
+
+    # "STM32F103C8T6" matches only via `mfr`; "Microcontroller" only via
+    # `description`. Both must be present (AND) -> the single MCU row.
+    results = catalog.search("STM32F103C8T6 Microcontroller")
+    assert [p.lcsc_part for p in results] == ["C8734"]
+
+    # A second term matching neither column on that row excludes it entirely.
+    assert catalog.search("STM32F103C8T6 Resistor") == []
+
+
 # --------------------------------------------------------------------------
 # LCSCClient fallback path
 # --------------------------------------------------------------------------
@@ -776,6 +807,59 @@ def test_cli_dispatch_sync_catalog(catalog_db: Path, tmp_path: Path, monkeypatch
     rc = run_parts_command(args)
     assert rc == 0
     assert JlcpartsCatalog(dest).count() == 4
+
+
+def test_cli_sync_catalog_missing_requests_non_circular(tmp_path: Path, monkeypatch, capsys):
+    """sync-catalog without requests exits non-zero with NON-circular advice (#4295).
+
+    The failure must not recommend running ``kct parts sync-catalog`` -- that is
+    the very command failing on the missing dependency. It should name only the
+    actionable ``parts``-extra install incantation.
+    """
+    from kicad_tools.cli import parts_cmd
+
+    dest = tmp_path / "out" / "jlcparts.sqlite3"
+    monkeypatch.setattr("kicad_tools.parts.jlcparts_catalog.get_catalog_path", lambda: dest)
+    # Block `import requests` at import time inside sync_catalog.
+    monkeypatch.setitem(sys.modules, "requests", None)
+
+    rc = parts_cmd.main(["sync-catalog"])
+    # Regression lock: a fatal missing-dep must NOT exit 0.
+    assert rc != 0
+
+    err = capsys.readouterr().err
+    # Advice is actionable (names the extra + an install command)...
+    assert "parts" in err
+    assert ("pip install" in err) or ("uv sync" in err)
+    # ...and NOT circular: never tells the user to run the failing command.
+    assert "sync-catalog" not in err
+    assert "sync the offline jlcparts catalog" not in err
+    # And no partial catalog was written.
+    assert not dest.exists()
+
+
+def test_cli_search_missing_backend_is_loud(tmp_path: Path, monkeypatch, capsys):
+    """search with no requests AND no catalog fails loudly, not silent-empty (#4296a).
+
+    A genuinely-unavailable backend must be surfaced distinctly from a
+    legitimate zero-match result (bare "No parts found").
+    """
+    from kicad_tools.cli import parts_cmd
+
+    monkeypatch.setattr("kicad_tools.parts.lcsc._requests_installed", lambda: False)
+    # Point the default catalog path at a nonexistent file: no offline fallback.
+    monkeypatch.setattr(
+        "kicad_tools.parts.jlcparts_catalog.get_catalog_path",
+        lambda: tmp_path / "missing.sqlite3",
+    )
+
+    rc = parts_cmd.main(["search", "UCC27524"])
+    assert rc != 0
+
+    err = capsys.readouterr().err
+    assert "backend unavailable" in err
+    # Must NOT masquerade as an ordinary empty result.
+    assert "No parts found" not in err
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Implements two grouped issues in one PR (shared `PARTS_INSTALL_HINT` root).

## #4295 — circular missing-`requests` advice on `sync-catalog`
`sync_catalog` raised its missing-`requests` error with the general
`PARTS_INSTALL_HINT`, whose final sentence recommends running
`kct parts sync-catalog` — the very command that just failed. The hint is now
split:
- `PARTS_EXTRA_INSTALL_HINT` — actionable install incantation (`uv sync --extra parts` / `pip install "kicad-tools[parts]"`).
- `PARTS_INSTALL_HINT` — the general hint (extra + offline-catalog suggestion), **byte-identical** to before, still used by `lookup`/`search` where the offline catalog is a valid fallback.
- `PARTS_DOWNLOAD_INSTALL_HINT` — extra-only, used by the downloader; no self-referential clause.

The fatal missing-dep already exited non-zero; a regression test now locks that
(`rc != 0`) and asserts the advice is non-circular (no `sync-catalog` mention).

## #4296(a) — `parts search` silent degradation
`kct parts search` printed a bare `No parts found` when the backend was
genuinely unavailable (no `requests` **and** no synced catalog),
indistinguishable from a real empty result. `_search` now catches
`LCSCDependencyMissingError` and emits a distinct "backend unavailable" error
with a non-zero exit, keeping `No parts found` for genuine zero-match cases.

## #4296(b) — offline catalog couldn't match MPNs
`JlcpartsCatalog.search()` matched the `description` column only, but jlcparts
`description` carries no MPN — the MPN lives in `mfr`. Each term now matches
`(description LIKE ? OR mfr LIKE ?)`, so `search("UCC27524")` /
`search("STM32F103C8T6")` resolve via the MPN. AND-across-terms semantics are
preserved (OR is per-term), and `_escape_like` is applied to the new `mfr`
param. This also fixes the `kct parts suggest` named-semiconductor misses,
which route through the same `search()`.

## Tests (offline/mock — no live JLC API)
- `test_cli_sync_catalog_missing_requests_non_circular` — non-zero exit + non-circular advice.
- `test_cli_search_missing_backend_is_loud` — loud "backend unavailable" + non-zero, not silent empty.
- `test_catalog_search_matches_mfr_mpn` / `test_catalog_search_mpn_and_description_terms` — MPN match via `mfr`, AND semantics intact.
- Full parts suite green (116 passed); existing wildcard-escape and hint-text tests unaffected.

## Gates
ruff check + format clean; mypy 0 new (4 pre-existing baseline errors, line-shifted only); MFR001 lint test green.

Closes #4295
Closes #4296

🤖 Generated with [Claude Code](https://claude.com/claude-code)