### PR TITLE
fix(parts): parse delimited jlcparts price column so tiers surface

### DIFF
--- a/src/kicad_tools/parts/jlcparts_catalog.py
+++ b/src/kicad_tools/parts/jlcparts_catalog.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import sqlite3
 import struct
 import zipfile
@@ -316,9 +317,11 @@ def _row_to_part(row: sqlite3.Row) -> Part:
     """Translate a ``jlc_components`` row into a :class:`Part`.
 
     Maps the stable jlcparts schema columns onto the existing ``Part``
-    dataclass. The ``price`` column is a JSON array of price breaks
-    (``[{"qFrom": n, "price": p}, ...]``); ``library_type`` distinguishes
-    JLCPCB Basic/Preferred parts.
+    dataclass. The ``price`` column holds tier pricing -- in the published
+    dataset a delimited ``"<qFrom>-<qTo>:<unitPrice>,..."`` string, though
+    older datasets ship a JSON array (both forms parse, see
+    :func:`_parse_price_column`). ``library_type`` distinguishes JLCPCB
+    Basic/Preferred parts.
     """
     keys = set(row.keys())
 
@@ -345,7 +348,7 @@ def _row_to_part(row: sqlite3.Row) -> Part:
     package = col_str("package")
     library_type = col_str("library_type").lower()
 
-    prices = _parse_price_json(col("price"))
+    prices = _parse_price_column(col("price"))
 
     return Part(
         lcsc_part=lcsc_part,
@@ -366,24 +369,75 @@ def _row_to_part(row: sqlite3.Row) -> Part:
     )
 
 
-def _parse_price_json(raw: object) -> list[PartPrice]:
-    """Parse the jlcparts ``price`` JSON column into price breaks.
+def _parse_price_column(raw: object) -> list[PartPrice]:
+    """Parse the jlcparts ``price`` column into price breaks.
 
-    The column holds a JSON array of ``{"qFrom": <int>, "price": <float>}``
-    objects (``qTo`` may also be present). Malformed or empty values yield an
-    empty list.
+    The published ``yaqwsx/jlcparts`` dataset stores this column as a
+    **delimited string** of ``<qFrom>-<qTo>:<unitPrice>`` tiers joined by
+    commas, e.g. ``"1-49:0.2776,50-149:0.2161,5000-:0.1395"`` -- the final
+    tier is open-ended (``"5000-:..."`` or ``"5000+:..."``). Older/alternate
+    datasets ship a JSON array of ``{"qFrom": <int>, "price": <float>}``
+    objects instead; both forms are accepted. Malformed, empty, or absent
+    values yield an empty list (this never raises).
     """
     if not raw:
         return []
 
-    try:
-        data = json.loads(raw) if isinstance(raw, str | bytes | bytearray) else raw
-    except (json.JSONDecodeError, TypeError):
-        return []
+    # Already-parsed list (JSON decoded upstream) passes straight through.
+    if isinstance(raw, list):
+        return _parse_price_list(raw)
 
-    if not isinstance(data, list):
-        return []
+    if isinstance(raw, str | bytes | bytearray):
+        text = raw.decode() if isinstance(raw, bytes | bytearray) else raw
+        text = text.strip()
+        if not text:
+            return []
+        # JSON array form (legacy / alternate datasets).
+        if text.startswith("["):
+            try:
+                data = json.loads(text)
+            except (json.JSONDecodeError, TypeError):
+                return []
+            return _parse_price_list(data) if isinstance(data, list) else []
+        # Delimited tier form (the current published dataset).
+        return _parse_price_tiers(text)
 
+    return []
+
+
+def _parse_price_tiers(text: str) -> list[PartPrice]:
+    """Parse the delimited ``"<qFrom>-<qTo>:<unitPrice>,..."`` tier form.
+
+    Each comma-separated segment carries a quantity range and a per-unit
+    price. Only the lower bound (``qFrom``) is retained as the price break's
+    quantity; the upper bound may be a number (``"1-49"``), open-ended
+    (``"5000-"``), or absent (``"5000+"``). Malformed segments are skipped.
+    """
+    prices: list[PartPrice] = []
+    for segment in text.split(","):
+        segment = segment.strip()
+        if not segment or ":" not in segment:
+            continue
+        qty_range, _, price_str = segment.rpartition(":")
+        # Lower bound = leading integer of the range ("1-49" -> 1,
+        # "5000-" -> 5000, "500+" -> 500).
+        lo_match = re.match(r"\s*(\d+)", qty_range)
+        if lo_match is None:
+            continue
+        try:
+            qty_i = int(lo_match.group(1))
+            price_f = float(price_str.strip())
+        except (TypeError, ValueError):
+            continue
+        if qty_i > 0 and price_f > 0:
+            prices.append(PartPrice(quantity=qty_i, unit_price=price_f))
+
+    prices.sort(key=lambda p: p.quantity)
+    return prices
+
+
+def _parse_price_list(data: list[object]) -> list[PartPrice]:
+    """Parse a JSON-array style list of price-break dicts into tiers."""
     prices: list[PartPrice] = []
     for entry in data:
         if not isinstance(entry, dict):

--- a/tests/parts/test_jlcparts_catalog.py
+++ b/tests/parts/test_jlcparts_catalog.py
@@ -24,7 +24,7 @@ from kicad_tools.parts.jlcparts_catalog import (
     _extract_catalog,
     _is_split_archive,
     _normalize_lcsc_id,
-    _parse_price_json,
+    _parse_price_column,
     get_catalog_path,
     sync_catalog,
 )
@@ -64,7 +64,7 @@ def test_normalize_lcsc_id():
 
 
 def test_parse_price_json_variants():
-    prices = _parse_price_json('[{"qFrom": 10, "price": 0.005}, {"qFrom": 100, "price": 0.002}]')
+    prices = _parse_price_column('[{"qFrom": 10, "price": 0.005}, {"qFrom": 100, "price": 0.002}]')
     assert len(prices) == 2
     assert prices[0].quantity == 10
     assert prices[0].unit_price == 0.005
@@ -72,14 +72,55 @@ def test_parse_price_json_variants():
     assert prices[1].quantity == 100
 
     # Already-parsed list passes through.
-    assert _parse_price_json([{"qFrom": 5, "price": 1.0}])[0].quantity == 5
+    assert _parse_price_column([{"qFrom": 5, "price": 1.0}])[0].quantity == 5
 
     # Bad / empty inputs degrade to empty list, never raise.
-    assert _parse_price_json(None) == []
-    assert _parse_price_json("") == []
-    assert _parse_price_json("not json") == []
-    assert _parse_price_json("{}") == []
-    assert _parse_price_json('[{"qFrom": 0, "price": 0}]') == []
+    assert _parse_price_column(None) == []
+    assert _parse_price_column("") == []
+    assert _parse_price_column("{}") == []
+    assert _parse_price_column('[{"qFrom": 0, "price": 0}]') == []
+
+
+def test_parse_price_column_delimited():
+    """The published jlcparts dataset ships tiers as a delimited string."""
+    # Curator's real C185857 catalog value.
+    raw = "1-49:0.2776,50-149:0.2161,150-499:0.1897,500-2499:0.1629,2500-4999:0.1483,5000-:0.1395"
+    prices = _parse_price_column(raw)
+    assert [(p.quantity, p.unit_price) for p in prices] == [
+        (1, 0.2776),
+        (50, 0.2161),
+        (150, 0.1897),
+        (500, 0.1629),
+        (2500, 0.1483),
+        (5000, 0.1395),  # open-ended top tier ("5000-:...")
+    ]
+
+
+def test_parse_price_column_edge_cases():
+    # Single tier.
+    single = _parse_price_column("1-49:0.2776")
+    assert [(p.quantity, p.unit_price) for p in single] == [(1, 0.2776)]
+
+    # Open-ended top tier expressed with a trailing '+'.
+    plus = _parse_price_column("500+:0.15")
+    assert [(p.quantity, p.unit_price) for p in plus] == [(500, 0.15)]
+
+    # Open-ended top tier expressed with a trailing '-'.
+    dash = _parse_price_column("5000-:0.1395")
+    assert [(p.quantity, p.unit_price) for p in dash] == [(5000, 0.1395)]
+
+    # Unsorted input is returned ascending by quantity.
+    unsorted = _parse_price_column("100-499:0.002,1-99:0.005")
+    assert [p.quantity for p in unsorted] == [1, 100]
+
+    # Empty / malformed segments degrade to an empty list, never raise.
+    assert _parse_price_column("") == []
+    assert _parse_price_column("not a price") == []
+    assert _parse_price_column("1-49:notaprice") == []
+    assert _parse_price_column("garbage,:,,") == []
+    # Zero quantity or zero price segments are dropped.
+    assert _parse_price_column("0-49:0.5") == []
+    assert _parse_price_column("1-49:0") == []
 
 
 # --------------------------------------------------------------------------
@@ -122,6 +163,47 @@ def test_catalog_lookup_translates_row(catalog_db: Path):
     # Price breaks parsed and sorted.
     assert [p.quantity for p in part.prices] == [10, 100]
     assert part.best_price == 0.002
+
+
+def test_catalog_lookup_surfaces_delimited_prices(tmp_path: Path):
+    """A synced-catalog row with the delimited price string surfaces tiers.
+
+    Regression for #4297: the published jlcparts ``price`` column is a
+    delimited ``"lo-hi:price,..."`` string, not JSON. ``lookup`` must expose
+    the full tier list instead of an empty ``prices``.
+    """
+    rows = [
+        {
+            "lcsc": 185857,  # -> C185857
+            "mfr": "GRM155R71C104KA88D",
+            "package": "0402",
+            "manufacturer": "muRata",
+            "library_type": "basic",
+            "description": "100nF 16V X7R 0402 MLCC",
+            "datasheet": "https://example.com/grm155.pdf",
+            "stock": 300000,
+            # Real on-disk delimited format (curator-verified), open-ended top tier.
+            "price": (
+                "1-49:0.2776,50-149:0.2161,150-499:0.1897,"
+                "500-2499:0.1629,2500-4999:0.1483,5000-:0.1395"
+            ),
+        },
+    ]
+    db = _builder.build_fixture(tmp_path / "delimited.sqlite3", rows=rows)
+
+    catalog = JlcpartsCatalog(db)
+    part = catalog.lookup("C185857")
+    assert part is not None
+    assert [(p.quantity, p.unit_price) for p in part.prices] == [
+        (1, 0.2776),
+        (50, 0.2161),
+        (150, 0.1897),
+        (500, 0.1629),
+        (2500, 0.1483),
+        (5000, 0.1395),
+    ]
+    # Cheapest break is the open-ended top tier.
+    assert part.best_price == 0.1395
 
 
 def test_catalog_lookup_normalizes_and_missing(catalog_db: Path):


### PR DESCRIPTION
## Summary

Fixes the offline parts pricing bug from #4297: `parts lookup`/`search` reported `prices: []` even though the synced jlcparts catalog carries full tier pricing on disk.

**Root cause (curator-verified):** the published `yaqwsx/jlcparts` `price` column is a *delimited* string, not JSON —
`1-49:0.2776,50-149:0.2161,150-499:0.1897,500-2499:0.1629,2500-4999:0.1483,5000-:0.1395`
(open-ended top tier `5000-:...`). `_parse_price_json` called `json.loads()` on it → `JSONDecodeError` → `[]`, silently dropping every tier.

## Fix

- Rename `_parse_price_json` → `_parse_price_column` and make it **format-tolerant**:
  - Delimited tier form (`<lo>-<hi>:price` / open-ended `<lo>-:` / `<lo>+:`) is the primary path (via new `_parse_price_tiers`).
  - JSON-array form retained for legacy/alternate datasets (via extracted `_parse_price_list`).
  - Empty / malformed / absent input → `[]` (never raises).
- Update the `_row_to_part` caller and the schema docstring.
- Output shape unchanged: sorted `list[PartPrice]`, so all `prices` consumers (`lookup`/`search`/`best_price`) surface tiers unchanged downstream.

Diff scoped to `jlcparts_catalog.py` (`_parse_price_column`/`_row_to_part`) + tests — no conflict with the sibling #4295/#4296 work on `search()`.

## Tests (offline, no live JLC API)

- `test_parse_price_column_delimited` — curator's real C185857 string parses to the full 6-tier list including the open-ended `5000-:0.1395`.
- `test_parse_price_column_edge_cases` — single tier, `500+:` and `5000-:` open-ended forms, unsorted input, empty/malformed/zero-qty/zero-price → `[]`.
- `test_catalog_lookup_surfaces_delimited_prices` — end-to-end: a fixture SQLite row with the delimited string surfaces non-empty `prices` via `lookup("C185857")`, `best_price == 0.1395`.
- Back-compat JSON-array test retained. Full parts suite + MFR001 lint green (94 passed); ruff + mypy clean.

Closes #4297

🤖 Generated with [Claude Code](https://claude.com/claude-code)