### PR TITLE
feat(lattice): tapered neck-down pad escape for oversize net classes (#4293)

### DIFF
--- a/.github/mypy-baseline.txt
+++ b/.github/mypy-baseline.txt
@@ -52,6 +52,11 @@ src/kicad_tools/cli/bom_cmd.py	operator	Unsupported operand types for + ("object
 src/kicad_tools/cli/build_cmd.py	assignment	Incompatible types in assignment (expression has type "Path | None", variable has type "Path")
 src/kicad_tools/cli/build_cmd.py	union-attr	Item "None" of "ProjectArtifacts | Any | None" has no attribute "schematic"
 src/kicad_tools/cli/build_cmd.py	union-attr	Item "None" of "ProjectSpec | None" has no attribute "project"
+# Pre-existing drift (PR #3879 / issue #3877): the nanobind import error text
+# changed across mypy/nanobind versions (import-not-found -> import-untyped when
+# nanobind is installed). Both signatures are kept so the gate is green on any
+# env; not introduced by this PR (build_native_cmd.py is untouched here).
+src/kicad_tools/cli/build_native_cmd.py	import-not-found	Cannot find implementation or library stub for module named "nanobind"
 src/kicad_tools/cli/build_native_cmd.py	import-untyped	Skipping analyzing "nanobind": module is installed, but missing library stubs or py.typed marker
 src/kicad_tools/cli/clean_cmd.py	assignment	Incompatible types in assignment (expression has type "ProtectedFile", variable has type "CleanableFile")
 src/kicad_tools/cli/commands/benchmark.py	var-annotated	Need type annotation for "by_case" (hint: "by_case: dict[<type>, <type>] = ...")

--- a/.github/mypy-baseline.txt
+++ b/.github/mypy-baseline.txt
@@ -52,11 +52,6 @@ src/kicad_tools/cli/bom_cmd.py	operator	Unsupported operand types for + ("object
 src/kicad_tools/cli/build_cmd.py	assignment	Incompatible types in assignment (expression has type "Path | None", variable has type "Path")
 src/kicad_tools/cli/build_cmd.py	union-attr	Item "None" of "ProjectArtifacts | Any | None" has no attribute "schematic"
 src/kicad_tools/cli/build_cmd.py	union-attr	Item "None" of "ProjectSpec | None" has no attribute "project"
-# Pre-existing drift (PR #3879 / issue #3877): the nanobind import error text
-# changed across mypy/nanobind versions (import-not-found -> import-untyped when
-# nanobind is installed). Both signatures are kept so the gate is green on any
-# env; not introduced by this PR (build_native_cmd.py is untouched here).
-src/kicad_tools/cli/build_native_cmd.py	import-not-found	Cannot find implementation or library stub for module named "nanobind"
 src/kicad_tools/cli/build_native_cmd.py	import-untyped	Skipping analyzing "nanobind": module is installed, but missing library stubs or py.typed marker
 src/kicad_tools/cli/clean_cmd.py	assignment	Incompatible types in assignment (expression has type "ProtectedFile", variable has type "CleanableFile")
 src/kicad_tools/cli/commands/benchmark.py	var-annotated	Need type annotation for "by_case" (hint: "by_case: dict[<type>, <type>] = ...")
@@ -66,15 +61,6 @@ src/kicad_tools/cli/commands/impedance.py	operator	Cannot call function of unkno
 src/kicad_tools/cli/commands/ipc.py	import-not-found	Cannot find implementation or library stub for module named "kicad_tools.pcb.parser"
 src/kicad_tools/cli/commands/parts.py	attr-defined	"Collection[str]" has no attribute "append"
 src/kicad_tools/cli/commands/pcb.py	attr-defined	"object" has no attribute "append"
-src/kicad_tools/cli/commands/pcb.py	call-overload	No overload variant of "__getitem__" of "list" matches argument type "str"
-src/kicad_tools/cli/commands/pcb.py	call-overload	No overload variant of "__getitem__" of "list" matches argument type "str"
-src/kicad_tools/cli/commands/pcb.py	call-overload	No overload variant of "__getitem__" of "list" matches argument type "str"
-src/kicad_tools/cli/commands/pcb.py	index	Invalid index type "str" for "str"; expected type "SupportsIndex | slice[Any, Any, Any]"
-src/kicad_tools/cli/commands/pcb.py	index	Invalid index type "str" for "str"; expected type "SupportsIndex | slice[Any, Any, Any]"
-src/kicad_tools/cli/commands/pcb.py	index	Invalid index type "str" for "str"; expected type "SupportsIndex | slice[Any, Any, Any]"
-src/kicad_tools/cli/commands/pcb.py	index	Value of type "dict[str, int] | str | Any | bool | list[Any] | None" is not indexable
-src/kicad_tools/cli/commands/pcb.py	index	Value of type "dict[str, int] | str | Any | bool | list[Any] | None" is not indexable
-src/kicad_tools/cli/commands/pcb.py	index	Value of type "dict[str, int] | str | Any | bool | list[Any] | None" is not indexable
 src/kicad_tools/cli/commands/spec.py	arg-type	Argument "completed" to "add_task" of "Progress" has incompatible type "float"; expected "int"
 src/kicad_tools/cli/constraints_cmd.py	import-untyped	Library stubs not installed for "yaml"
 src/kicad_tools/cli/datasheet_cmd.py	arg-type	Argument "pins" to "generate" of "SymbolGenerator" has incompatible type "PinTable | list[dict[str, Any]]"; expected "PinTable | list[ExtractedPin]"
@@ -386,9 +372,7 @@ src/kicad_tools/drc/report.py	arg-type	Argument N to "apply" of "FilterEngine" h
 src/kicad_tools/drc/report.py	assignment	Incompatible types in assignment (expression has type "list[str]", variable has type "list[FixSuggestion]")
 src/kicad_tools/drc/report.py	assignment	Incompatible types in assignment (expression has type "list[str]", variable has type "list[FixSuggestion]")
 src/kicad_tools/drc/report.py	assignment	Incompatible types in assignment (expression has type "list[str]", variable has type "list[FixSuggestion]")
-src/kicad_tools/drc/report.py	name-defined	Name "ViolationFilter" is not defined
 src/kicad_tools/erc/report.py	arg-type	Argument N to "apply" of "FilterEngine" has incompatible type "list[ERCViolation]"; expected "list[kicad_tools.drc.violation.DRCViolation | ERCViolation | kicad_tools.validate.violations.DRCViolation]"
-src/kicad_tools/erc/report.py	name-defined	Name "ViolationFilter" is not defined
 src/kicad_tools/explain/__init__.py	no-any-return	Returning Any from function declared to return "str"
 src/kicad_tools/explain/__init__.py	no-any-return	Returning Any from function declared to return "str"
 src/kicad_tools/explain/__init__.py	no-any-return	Returning Any from function declared to return "str"
@@ -703,9 +687,7 @@ src/kicad_tools/parts/importer.py	return-value	Incompatible return value type (g
 src/kicad_tools/parts/importer.py	union-attr	Item "list[dict[str, Any]]" of "PinTable | list[dict[str, Any]]" has no attribute "pins"
 src/kicad_tools/parts/lcsc.py	attr-defined	"BOMItem" has no attribute "quantity"
 src/kicad_tools/parts/lcsc.py	attr-defined	"None" has no attribute "headers"
-src/kicad_tools/parts/lcsc.py	import-untyped	Library stubs not installed for "requests"
 src/kicad_tools/parts/lcsc.py	no-any-return	Returning Any from function declared to return "dict[Any, Any] | None"
-src/kicad_tools/parts/models.py	name-defined	Name "ComposedPart" is not defined
 src/kicad_tools/patterns/analog.py	var-annotated	Need type annotation for "errors" (hint: "errors: list[<type>] = ...")
 src/kicad_tools/patterns/checks.py	arg-type	Argument N to "_parse_value" of "ValueMatchCheck" has incompatible type "ValueRangeCheck"; expected "ValueMatchCheck"
 src/kicad_tools/patterns/components.py	assignment	Incompatible types in assignment (expression has type "ComponentRequirements | None", variable has type "ComponentRequirements")
@@ -802,11 +784,7 @@ src/kicad_tools/recovery/applicator.py	index	Value of type "Any | tuple[float, f
 src/kicad_tools/recovery/applicator.py	index	Value of type "Any | tuple[float, float] | None" is not indexable
 src/kicad_tools/recovery/applicator.py	index	Value of type "Any | tuple[float, float] | None" is not indexable
 src/kicad_tools/recovery/applicator.py	index	Value of type "Any | tuple[float, float] | None" is not indexable
-# Pre-existing drift (PR #3879 / issue #3877): mypy's rendering of this bound
-# method signature changed across versions (with/without the method name). Both
-# signatures kept; not introduced by this PR (strategy.py is untouched here).
 src/kicad_tools/recovery/strategy.py	assignment	Incompatible types in assignment (expression has type "def contains_point(self, _x: float, _y: float) -> bool", variable has type "def contains_point(self, x: float, y: float) -> bool")
-src/kicad_tools/recovery/strategy.py	assignment	Incompatible types in assignment (expression has type "def (_x: float, _y: float) -> bool", variable has type "def (x: float, y: float) -> bool")
 src/kicad_tools/recovery/strategy.py	unused-ignore	Unused "type: ignore" comment
 src/kicad_tools/recovery/strategy.py	unused-ignore	Unused "type: ignore" comment
 src/kicad_tools/report/interactive.py	import-not-found	Cannot find implementation or library stub for module named "kicad_tools.drc.runner"
@@ -814,7 +792,6 @@ src/kicad_tools/report/renderers.py	import-untyped	Library stubs not installed f
 src/kicad_tools/report/renderers.py	import-untyped	Skipping analyzing "weasyprint": module is installed, but missing library stubs or py.typed marker
 src/kicad_tools/report/renderers.py	no-any-return	Returning Any from function declared to return "str"
 src/kicad_tools/report/renderers.py	no-any-return	Returning Any from function declared to return "str"
-src/kicad_tools/router/__init__.py	assignment	Incompatible import of "RoutingResult" (imported name has type "type[kicad_tools.router.strategies.RoutingResult]", local name has type "type[kicad_tools.router.adaptive.RoutingResult]")
 src/kicad_tools/router/adaptive_grid.py	union-attr	Item "None" of "Router | None" has no attribute "find_path"
 src/kicad_tools/router/adaptive_grid.py	union-attr	Item "Router" of "Router | None" has no attribute "find_path"
 src/kicad_tools/router/algorithms/evolutionary.py	no-any-return	Returning Any from function declared to return "list[Route]"
@@ -834,16 +811,6 @@ src/kicad_tools/router/algorithms/monte_carlo.py	misc	callable? not callable
 src/kicad_tools/router/algorithms/monte_carlo.py	no-any-return	Returning Any from function declared to return "list[Route]"
 src/kicad_tools/router/algorithms/monte_carlo.py	valid-type	Function "builtins.callable" is not valid as a type
 src/kicad_tools/router/algorithms/monte_carlo.py	valid-type	Function "builtins.callable" is not valid as a type
-src/kicad_tools/router/algorithms/mst.py	misc	callable? not callable
-src/kicad_tools/router/algorithms/mst.py	misc	callable? not callable
-src/kicad_tools/router/algorithms/mst.py	misc	callable? not callable
-src/kicad_tools/router/algorithms/mst.py	misc	callable? not callable
-src/kicad_tools/router/algorithms/mst.py	misc	callable? not callable
-src/kicad_tools/router/algorithms/mst.py	misc	callable? not callable
-src/kicad_tools/router/algorithms/mst.py	valid-type	Function "builtins.callable" is not valid as a type
-src/kicad_tools/router/algorithms/mst.py	valid-type	Function "builtins.callable" is not valid as a type
-src/kicad_tools/router/algorithms/mst.py	valid-type	Function "builtins.callable" is not valid as a type
-src/kicad_tools/router/algorithms/mst.py	valid-type	Function "builtins.callable" is not valid as a type
 src/kicad_tools/router/algorithms/negotiated.py	arg-type	Argument N to "find_blocking_nets_relaxed" of "Router" has incompatible type "ndarray[tuple[Any, ...], dtype[Any]] | None"; expected "ndarray[tuple[Any, ...], dtype[Any]]"
 src/kicad_tools/router/algorithms/negotiated.py	arg-type	Argument N to "find_blocking_nets_relaxed" of "Router" has incompatible type "ndarray[tuple[Any, ...], dtype[Any]] | None"; expected "ndarray[tuple[Any, ...], dtype[Any]]"
 src/kicad_tools/router/algorithms/negotiated.py	misc	callable? not callable
@@ -899,7 +866,7 @@ src/kicad_tools/router/core.py	assignment	Incompatible types in assignment (expr
 src/kicad_tools/router/core.py	assignment	Incompatible types in assignment (expression has type "str | None", variable has type "MatchGroup")
 src/kicad_tools/router/core.py	assignment	Incompatible types in assignment (expression has type "str", variable has type "MatchGroup")
 src/kicad_tools/router/core.py	assignment	Incompatible types in assignment (expression has type "tuple[int, tuple[Any, Any, Any, Any]]", variable has type "tuple[float, float]")
-src/kicad_tools/router/core.py	attr-defined	"NetClassRouting" has no attribute "min_trace_width"; maybe "trace_width"?
+src/kicad_tools/router/core.py	attr-defined	"NetClassRouting" has no attribute "min_trace_width"; maybe "trace_width" or "neck_trace_width"?
 src/kicad_tools/router/core.py	attr-defined	"Segment" has no attribute "end_x"
 src/kicad_tools/router/core.py	attr-defined	"Segment" has no attribute "end_y"
 src/kicad_tools/router/core.py	attr-defined	"Segment" has no attribute "start_x"; maybe "start"?
@@ -911,8 +878,6 @@ src/kicad_tools/router/core.py	index	Invalid index type "MatchGroup" for "dict[s
 src/kicad_tools/router/core.py	misc	Generator has incompatible item type "int"; expected "bool"
 src/kicad_tools/router/core.py	name-defined	Name "Segment" is not defined
 src/kicad_tools/router/core.py	name-defined	Name "Segment" is not defined
-src/kicad_tools/router/core.py	name-defined	Name "Via" is not defined
-src/kicad_tools/router/core.py	name-defined	Name "Via" is not defined
 src/kicad_tools/router/core.py	no-redef	Name "blocking_nets" already defined on line N
 src/kicad_tools/router/core.py	no-redef	Name "blocking_nets" already defined on line N
 src/kicad_tools/router/core.py	union-attr	Item "CppPathfinder" of "CppPathfinder | Router" has no attribute "grid"
@@ -922,7 +887,6 @@ src/kicad_tools/router/core.py	union-attr	Item "None" of "TransmissionLine | Non
 src/kicad_tools/router/core.py	valid-type	Function "builtins.any" is not valid as a type
 src/kicad_tools/router/core.py	valid-type	Function "builtins.any" is not valid as a type
 src/kicad_tools/router/core.py	valid-type	Function "builtins.any" is not valid as a type
-src/kicad_tools/router/cpp_backend.py	attr-defined	Module "kicad_tools.router" has no attribute "router_cpp"
 src/kicad_tools/router/cpp_backend.py	no-any-return	Returning Any from function declared to return "bool"
 src/kicad_tools/router/cpp_backend.py	no-any-return	Returning Any from function declared to return "bool"
 src/kicad_tools/router/cpp_backend.py	no-any-return	Returning Any from function declared to return "float"
@@ -1191,15 +1155,6 @@ src/kicad_tools/schematic/models/io_mixin.py	attr-defined	"SchematicIOMixin" has
 src/kicad_tools/schematic/models/io_mixin.py	attr-defined	"SchematicIOMixin" has no attribute "wires"
 src/kicad_tools/schematic/models/io_mixin.py	attr-defined	"SchematicIOMixin" has no attribute "wires"
 src/kicad_tools/schematic/models/io_mixin.py	attr-defined	"SchematicIOMixin" has no attribute "wires"
-src/kicad_tools/schematic/models/io_mixin.py	call-arg	Unexpected keyword argument "comment1" for "SchematicIOMixin"
-src/kicad_tools/schematic/models/io_mixin.py	call-arg	Unexpected keyword argument "comment2" for "SchematicIOMixin"
-src/kicad_tools/schematic/models/io_mixin.py	call-arg	Unexpected keyword argument "company" for "SchematicIOMixin"
-src/kicad_tools/schematic/models/io_mixin.py	call-arg	Unexpected keyword argument "date" for "SchematicIOMixin"
-src/kicad_tools/schematic/models/io_mixin.py	call-arg	Unexpected keyword argument "paper" for "SchematicIOMixin"
-src/kicad_tools/schematic/models/io_mixin.py	call-arg	Unexpected keyword argument "revision" for "SchematicIOMixin"
-src/kicad_tools/schematic/models/io_mixin.py	call-arg	Unexpected keyword argument "sheet_uuid" for "SchematicIOMixin"
-src/kicad_tools/schematic/models/io_mixin.py	call-arg	Unexpected keyword argument "snap_mode" for "SchematicIOMixin"
-src/kicad_tools/schematic/models/io_mixin.py	call-arg	Unexpected keyword argument "title" for "SchematicIOMixin"
 src/kicad_tools/schematic/models/io_mixin.py	has-type	Cannot determine type of "paper"
 src/kicad_tools/schematic/models/io_mixin.py	has-type	Cannot determine type of "paper"
 src/kicad_tools/schematic/models/io_mixin.py	has-type	Cannot determine type of "paper"
@@ -1249,7 +1204,6 @@ src/kicad_tools/schematic/models/netlist_mixin.py	attr-defined	"SchematicNetlist
 src/kicad_tools/schematic/models/netlist_mixin.py	attr-defined	"SchematicNetlistMixin" has no attribute "junctions"
 src/kicad_tools/schematic/models/netlist_mixin.py	attr-defined	"SchematicNetlistMixin" has no attribute "labels"
 src/kicad_tools/schematic/models/netlist_mixin.py	attr-defined	"SchematicNetlistMixin" has no attribute "power_symbols"
-src/kicad_tools/schematic/models/netlist_mixin.py	attr-defined	"SchematicNetlistMixin" has no attribute "symbols"
 src/kicad_tools/schematic/models/netlist_mixin.py	attr-defined	"SchematicNetlistMixin" has no attribute "symbols"
 src/kicad_tools/schematic/models/netlist_mixin.py	attr-defined	"SchematicNetlistMixin" has no attribute "symbols"
 src/kicad_tools/schematic/models/netlist_mixin.py	attr-defined	"SchematicNetlistMixin" has no attribute "wires"
@@ -1500,7 +1454,6 @@ src/kicad_tools/validate/models.py	type-arg	Missing type parameters for generic 
 src/kicad_tools/validate/rules/clearance.py	import-untyped	Library stubs not installed for "shapely"
 src/kicad_tools/validate/rules/clearance.py	import-untyped	Library stubs not installed for "shapely.geometry"
 src/kicad_tools/validate/rules/clearance.py	import-untyped	Library stubs not installed for "shapely.ops"
-src/kicad_tools/validate/rules/clearance.py	unused-ignore	Unused "type: ignore" comment
 src/kicad_tools/validate/rules/diffpair_length_skew.py	arg-type	Argument N to "add" of "set" has incompatible type "tuple[str, str]"; expected "tuple[int, int]"
 src/kicad_tools/validate/rules/diffpair_length_skew.py	assignment	Incompatible types in assignment (expression has type "int", variable has type "str")
 src/kicad_tools/validate/rules/diffpair_length_skew.py	assignment	Incompatible types in assignment (expression has type "int", variable has type "str")

--- a/src/kicad_tools/router/lattice/obstacles.py
+++ b/src/kicad_tools/router/lattice/obstacles.py
@@ -200,6 +200,28 @@ class CommittedCopper:
             if dist(a, b) > 1e-9:
                 self.copper[layer].add(a, b, net, half_width, clr)
 
+    def add_run_widths(
+        self,
+        layer: int,
+        points: list[Pt],
+        net: int,
+        seg_halves: list[float],
+        clearance: float | None = None,
+    ) -> None:
+        """Commit a polyline whose segments carry PER-SEGMENT half-widths.
+
+        The tapered pad-escape mechanism (issue #4293) emits the escape legs
+        at a narrower neck width than the widened lattice body, so the spacing
+        model must record each segment at the width it was ACTUALLY emitted
+        at -- a neck leg spaced as neck copper, the body spaced at the full
+        class width.  ``seg_halves[i]`` is the half-width of the segment from
+        ``points[i]`` to ``points[i + 1]``.
+        """
+        clr = self.clearance if clearance is None else clearance
+        for (a, b), hw in zip(zip(points, points[1:], strict=False), seg_halves, strict=False):
+            if dist(a, b) > 1e-9:
+                self.copper[layer].add(a, b, net, hw, clr)
+
     def add_via(self, point: Pt, net: int) -> None:
         """Commit a through-via (blocks the site on ALL layers)."""
         self.vias.append((point, net))

--- a/src/kicad_tools/router/lattice/pathfinder.py
+++ b/src/kicad_tools/router/lattice/pathfinder.py
@@ -66,6 +66,16 @@ Resource = tuple[object, ...]
 _State = tuple[NodeKey, int]
 _GOAL: _State = (("GOAL",), -1)  # type: ignore[assignment]
 
+# Escape-fan size for the oversize neck-down retry (issue #4293): a thin neck
+# escapes the pad, but the WIDENED body must then egress at full width, so the
+# useful escape node often sits at the edge of the congested field rather than
+# hugging the pad.  A nearest-first count cap fills up on dead-end near nodes
+# and never reaches that egress node, so the neck retry collects a large
+# radius-bounded fan instead (the count-capped-in-a-pocket failure the pair
+# path also avoids).  A search-tuning knob, not a geometric constant -- it only
+# widens the candidate set, never the copper.
+_OVERSIZE_STUB_KMAX = 4096
+
 
 @dataclass(frozen=True)
 class LatticeNegotiationStats:
@@ -87,7 +97,10 @@ class _RouteResult:
     """Internal per-connection result: emitted route + commit geometry."""
 
     route: Route
-    runs: list[tuple[int, list[Pt]]]  # (layer_index, polyline) per copper run
+    # (layer_index, polyline, per-segment widths) per copper run.  The escape
+    # legs may be a narrower neck than the lattice body (issue #4293), so each
+    # segment carries the width it was emitted at.
+    runs: list[tuple[int, list[Pt], list[float]]]
     via_points: list[Pt]
     resources: set[Resource]  # lattice edges/via-nodes consumed (history keys)
 
@@ -409,6 +422,43 @@ class LatticePathfinder:
         by the surcharge over the global agent radius (single-ended path;
         the fat-agent path carries its own grown envelope).
         """
+        half, clr = self._conn_geometry(net_class)
+        return self._scan_stubs(
+            pad,
+            net,
+            committed,
+            half,
+            clr,
+            kmax=kmax,
+            search_radius=search_radius,
+            extra_clearance=extra_clearance,
+            partner_net=partner_net,
+            layers=layers,
+            exempt_pads=exempt_pads,
+        )
+
+    def _scan_stubs(
+        self,
+        pad: Pad,
+        net: int,
+        committed: CommittedCopper | None,
+        half: float,
+        clr: float,
+        *,
+        kmax: int = 4,
+        search_radius: float | None = None,
+        extra_clearance: float = 0.0,
+        partner_net: int | None = None,
+        layers: tuple[int, ...] | None = None,
+        exempt_pads: frozenset[int] | None = None,
+    ) -> list[tuple[NodeKey, int, list[Pt], float]]:
+        """Candidate scan for :meth:`pad_stubs` at an EXPLICIT ``(half, clr)``.
+
+        Factored out so the tapered pad-escape fallback (issue #4293) can
+        re-run the identical clearance-checked dogleg search at a narrower
+        neck half-width and a wider fan without duplicating the reject-and-
+        retry body.
+        """
         lattice = self.build()
         obstacles = self.obstacles
         if committed is None:
@@ -432,7 +482,6 @@ class LatticePathfinder:
                 pads_block_point_grown,
                 pads_block_segment_grown,
             )
-        half, clr = self._conn_geometry(net_class)
         extra = max(0.0, half + clr - self._agent_radius)
 
         candidates: list[tuple[float, NodeKey, Pt]] = []
@@ -494,6 +543,102 @@ class LatticePathfinder:
             if len(out) >= kmax * len(layers):
                 break
         return out
+
+    # -- tapered pad escape (issue #4293) --------------------------------------
+
+    def _neck_width(self, net_class: object | None) -> float:
+        """Principled neck width for a tapered pad escape (issue #4293).
+
+        Oversize copper cannot always clear a dense pad field at its full
+        class width.  The neck floor is the fab minimum track
+        (``DesignRules.min_trace_width`` if configured, else the board default
+        ``trace_width`` -- both DRC-legal, manufacturable widths), which a
+        class may raise with ``NetClassRouting.neck_trace_width`` for
+        ampacity.  It is never a magic constant and never below the fab min.
+        """
+        dru_min = self.rules.min_trace_width or self.rules.trace_width
+        override = getattr(net_class, "neck_trace_width", None)
+        neck = override if override else dru_min
+        return max(dru_min, float(neck))
+
+    def _escape_stubs(
+        self,
+        pad: Pad,
+        net: int,
+        committed: CommittedCopper | None,
+        *,
+        kmax: int,
+        extra_clearance: float,
+        partner_net: int | None,
+        layers: tuple[int, ...] | None,
+        exempt_pads: frozenset[int] | None,
+        net_class: object | None,
+    ) -> tuple[list[tuple[NodeKey, int, list[Pt], float]], float]:
+        """Escape stubs for one pad, with an oversize neck-down fallback.
+
+        Returns ``(stubs, emitted_width)`` -- the width the returned legs are
+        emitted (and spaced) at.  The FULL-width escape is tried first and,
+        when it yields ANY stub, is returned unchanged: every connection that
+        already escapes is byte-identical to the pre-#4293 behavior.  Only
+        when the oversize keep-out surcharge blocks EVERY full-width dogleg
+        (the honest ``pad-escape-*`` decline of record) does a narrower legal
+        neck retry -- with a WIDER escape fan (grown ``search_radius`` +
+        ``kmax``) so the thin neck can thread past the full-width keep-out
+        ring the oversize body could not clear, then widen back to the class
+        width at the first lattice node.  Never-ship-a-short holds absolutely:
+        the neck legs are clearance-checked at the neck width, exactly as the
+        full-width legs are checked at the full width (#3906).
+        """
+        body_w = getattr(net_class, "trace_width", None) or self.rules.trace_width
+        full_half, clr = self._conn_geometry(net_class)
+        fat = extra_clearance > 0.0 or partner_net is not None
+
+        stubs = self.pad_stubs(
+            pad,
+            net,
+            committed,
+            kmax=kmax,
+            extra_clearance=extra_clearance,
+            partner_net=partner_net,
+            layers=layers,
+            exempt_pads=exempt_pads,
+            net_class=net_class,
+        )
+        # A successful full-width escape, or a fat coupled agent (whose grown
+        # envelope has its own escape discipline), is returned as-is.
+        if stubs or fat:
+            return stubs, body_w
+
+        neck_w = self._neck_width(net_class)
+        neck_half = neck_w / 2.0
+        if neck_half >= full_half - 1e-9:
+            # Not oversize: the neck would not be narrower than the body, so
+            # there is nothing to taper -- the honest decline stands.
+            return stubs, body_w
+
+        lattice = self.build()
+        base_sr = max(3.0 * lattice.fine + max(pad.width, pad.height), 2.0)
+        # Reach past the full-width keep-out ring that blocked the body escape:
+        # a thin neck can clear a node close to the pad, but the widened body
+        # must then EGRESS at full width, so the useful escape node is often
+        # one that sits at the edge of the congested field.  Grow the radius by
+        # the full-width surcharge and collect EVERY clearing node in it (a
+        # radius-bounded fan, not a nearest-first count cap that would exhaust
+        # itself on dead-end near nodes with no full-width egress -- the
+        # count-capped-in-a-pocket failure the pair path also avoids).
+        grown_sr = base_sr + max(0.0, full_half + clr - self._agent_radius)
+        neck_stubs = self._scan_stubs(
+            pad,
+            net,
+            committed,
+            neck_half,
+            clr,
+            kmax=_OVERSIZE_STUB_KMAX,
+            search_radius=grown_sr,
+            layers=layers,
+            exempt_pads=exempt_pads,
+        )
+        return neck_stubs, neck_w
 
     # -- via legality -----------------------------------------------------------
 
@@ -651,11 +796,15 @@ class LatticePathfinder:
 
             pair_nets = {net} if partner_net is None else {net, partner_net}
 
+        # The lattice body is emitted (and spaced) at the full class width;
+        # the pad-escape legs may taper to a narrower neck (issue #4293).
+        body_w = getattr(net_class, "trace_width", None) or self.rules.trace_width
         if stubs_override is not None:
             stubs_a, stubs_b = stubs_override
+            width_a = width_b = body_w
         else:
             stub_kmax = 24 if fat else 4
-            stubs_a = self.pad_stubs(
+            stubs_a, width_a = self._escape_stubs(
                 start,
                 net,
                 committed,
@@ -666,7 +815,7 @@ class LatticePathfinder:
                 exempt_pads=exempt_pads,
                 net_class=net_class,
             )
-            stubs_b = self.pad_stubs(
+            stubs_b, width_b = self._escape_stubs(
                 end,
                 net,
                 committed,
@@ -834,26 +983,35 @@ class LatticePathfinder:
         start_state = chain[0]
 
         resources: set[Resource] = set()
-        runs: list[tuple[int, list[Pt]]] = []
+        runs: list[tuple[int, list[Pt], list[float]]] = []
         via_points: list[Pt] = []
         cur_layer = start_state[1]
-        cur_pts: list[Pt] = list(start_stub[start_state])  # pad -> first node
+        start_poly = list(start_stub[start_state])  # pad -> first node
+        cur_pts: list[Pt] = start_poly
+        # The start escape legs carry ``width_a`` (neck or full); the lattice
+        # body carries ``body_w``; the end escape legs carry ``width_b``.  Each
+        # segment is spaced at the width it is EMITTED at (issue #4293).
+        cur_ws: list[float] = [width_a] * (len(start_poly) - 1)
         for idx in range(1, len(chain)):
             key, layer = chain[idx]
             move = moves[idx - 1]
             if move == "via":
-                runs.append((cur_layer, cur_pts))
+                runs.append((cur_layer, cur_pts, cur_ws))
                 via_points.append(lattice.node_point(key))
                 resources.add(("v", key))
                 cur_layer = layer
                 cur_pts = [lattice.node_point(key)]
+                cur_ws = []
             else:
                 prev_key = chain[idx - 1][0]
                 resources.add(("e", (min(prev_key, key), max(prev_key, key)), layer))
                 cur_pts.append(lattice.node_point(key))
+                cur_ws.append(body_w)
         _stub_len, stub_b_poly = goal[end_state]
-        cur_pts.extend(reversed(stub_b_poly[:-1]))  # last node -> pad (exact)
-        runs.append((cur_layer, cur_pts))
+        tail = list(reversed(stub_b_poly[:-1]))  # last node -> pad (exact)
+        cur_pts.extend(tail)
+        cur_ws.extend([width_b] * len(tail))
+        runs.append((cur_layer, cur_pts, cur_ws))
 
         route = self._emit(start, net, net_class, runs, via_points)
         if route is None:
@@ -867,7 +1025,7 @@ class LatticePathfinder:
         start: Pad,
         net: int,
         net_class: object | None,
-        runs: list[tuple[int, list[Pt]]],
+        runs: list[tuple[int, list[Pt], list[float]]],
         via_points: list[Pt],
     ) -> Route | None:
         """Lattice path + stubs -> ``Segment`` / ``Via`` (path IS copper).
@@ -876,35 +1034,46 @@ class LatticePathfinder:
         (``Segment.to_sexp`` 45-degree enforcement) with
         :func:`~kicad_tools.router.optimizer.algorithms.merge_collinear`
         fusing the node-by-node steps; there is no post-fit stage.
+
+        Each segment is emitted at its own width (issue #4293): the escape
+        legs may be a narrower neck than the widened lattice body.  Collinear
+        merging is done PER contiguous equal-width group so a neck leg and a
+        body segment never fuse into one width -- a uniform-width run (the
+        pre-#4293 case) is one group and merges exactly as before.
         """
         from ..optimizer.algorithms import merge_collinear
         from ..optimizer.config import OptimizationConfig
 
-        trace_w = getattr(net_class, "trace_width", None) or self.rules.trace_width
         config = OptimizationConfig()
         route = Route(net=net, net_name=start.net_name)
-        for layer_idx, points in runs:
+        for layer_idx, points, widths in runs:
             try:
                 layer_enum = self.layer_stack.index_to_layer_enum(layer_idx)
             except Exception:
                 return None
-            segments = [
+            raw = [
                 Segment(
                     x1=a[0],
                     y1=a[1],
                     x2=b[0],
                     y2=b[1],
-                    width=trace_w,
+                    width=w,
                     layer=layer_enum,
                     net=net,
                     net_name=start.net_name,
                 )
-                for a, b in zip(points, points[1:], strict=False)
+                for (a, b), w in zip(zip(points, points[1:], strict=False), widths, strict=False)
                 if dist(a, b) > 1e-9
             ]
-            # Collinear merging is geometry-preserving (same centreline), so
-            # no clearance re-check is needed.
-            route.segments.extend(merge_collinear(segments, config))
+            # Merge only within contiguous equal-width groups (collinear
+            # merging is geometry-preserving, so no clearance re-check).
+            i = 0
+            while i < len(raw):
+                j = i + 1
+                while j < len(raw) and abs(raw[j].width - raw[i].width) < 1e-12:
+                    j += 1
+                route.segments.extend(merge_collinear(raw[i:j], config))
+                i = j
 
         if not route.segments:
             return None
@@ -1165,7 +1334,7 @@ class LatticePathfinder:
             if len(result.runs) != 1 or result.via_points:
                 return None, "pair-not-planar"  # defensive: vias are off
 
-            layer, raw_pts = result.runs[0]
+            layer, raw_pts, _widths = result.runs[0]
             center = merge_collinear_points(raw_pts)
             if len(center) < 2:
                 return None, "pair-degenerate-centerline"
@@ -1390,12 +1559,16 @@ class LatticePathfinder:
                     continue
                 routed_items += 1
                 routes[key] = result.route
-                # Commit at the connection's TRUE half-width + class
-                # clearance (issue #4271) so later nets are spaced against
-                # 2.6 mm copper as 2.6 mm copper, never the global default.
-                half, clr = self._conn_geometry(net_class)
-                for layer_idx, points in result.runs:
-                    committed.add_run(layer_idx, points, start.net, half, clr)
+                # Commit each segment at the width it was EMITTED at (issue
+                # #4293): the widened lattice body is spaced against 2.6 mm
+                # copper as 2.6 mm copper, and a tapered escape neck is spaced
+                # honestly as neck copper -- never the taper cheating the
+                # spacing model.  Clearance stays the class clearance (#4271).
+                _half, clr = self._conn_geometry(net_class)
+                for layer_idx, points, widths in result.runs:
+                    committed.add_run_widths(
+                        layer_idx, points, start.net, [w / 2.0 for w in widths], clr
+                    )
                 for via_pt in result.via_points:
                     committed.add_via(via_pt, start.net)
 

--- a/src/kicad_tools/router/rules.py
+++ b/src/kicad_tools/router/rules.py
@@ -727,6 +727,15 @@ class NetClassRouting:
     priority: int = 5  # 1=highest, 10=lowest
     trace_width: float = 0.2  # Override trace width
     clearance: float = 0.2  # Override clearance
+    # Pad-escape neck-down floor (Issue #4293).  Oversize copper (e.g. 2.6mm
+    # HV_HICUR) carries a large keep-out surcharge that can prevent ANY escape
+    # dogleg from clearing a dense pad field.  When the full-width escape
+    # declines, the lattice engine retries the pad-escape legs at this narrower
+    # legal width and widens back to ``trace_width`` at the first lattice node
+    # (standard heavy-copper neck-down).  ``None`` -> the design-rule floor
+    # (``DesignRules.min_trace_width`` if set, else ``trace_width``); a class
+    # may override with a wider ampacity-driven neck.  Never below the fab min.
+    neck_trace_width: float | None = None
     via_size: float = 0.6  # Override via diameter
     cost_multiplier: float = 1.0  # Cost multiplier (lower = prefer this net)
     length_critical: bool = False  # Must minimize length

--- a/tests/router/lattice/test_oversize_escape.py
+++ b/tests/router/lattice/test_oversize_escape.py
@@ -1,0 +1,234 @@
+"""Tapered (neck-down) pad escape for oversize net classes (issue #4293).
+
+Oversize copper (e.g. 2.6 mm HV_HICUR) carries a large keep-out surcharge
+(``half + clearance - agent_radius``) on every static pad check, so in a
+dense fuse/terminal pad field NO full-width dogleg clears and the connection
+declines honestly (``pad-escape-*``).  The fix emits the pad-escape legs at a
+narrower LEGAL neck width and widens back to the class width at the first
+lattice node -- standard heavy-copper practice.  These tests pin:
+
+* the full-width escape is byte-identical for anything that already escapes
+  (the neck only fires on a genuine full-width decline);
+* an oversize pad buried in a dense field escapes via the neck taper;
+* the neck legs are clearance-checked at the NECK width (never-ship-a-short);
+* the widened body is emitted AND spaced at the full class width, and the
+  committed-copper model records each segment at its EMITTED width (the taper
+  does not cheat the #4289 spacing math);
+* the neck width is a principled legal floor, not a magic constant.
+"""
+
+from __future__ import annotations
+
+from kicad_tools.router.lattice.obstacles import CommittedCopper
+from kicad_tools.router.lattice.pathfinder import LatticePathfinder
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import DesignRules, NetClassRouting
+
+_HV = NetClassRouting(name="HV_HICUR", trace_width=2.6, clearance=0.3)
+
+
+def _pad(x: float, y: float, net: int, ref: str, *, w: float = 0.6, h: float = 0.6) -> Pad:
+    return Pad(
+        x=x,
+        y=y,
+        width=w,
+        height=h,
+        net=net,
+        net_name=f"N{net}",
+        layer=Layer.F_CU,
+        ref=ref,
+        pin="1",
+    )
+
+
+def _dense_field() -> tuple[LatticePathfinder, Pad, Pad]:
+    """An oversize net-1 pad boxed on three sides by an other-net pad field,
+    with an open west corridor to a second net-1 pad.
+
+    At the full 2.6 mm width the keep-out surcharge (~1.45 mm) covers every
+    reachable lattice node, so the pad cannot escape; a 0.2 mm neck clears the
+    open corridor and the body widens west of the field.
+    """
+    pads = [_pad(8.0, 10.0, 1, "U1")]  # the buried oversize pad
+    i = 0
+    for dx in (1.2, 2.0, 2.8):
+        for dy in (-2.0, -1.2, -0.6, 0.6, 1.2, 2.0):
+            pads.append(_pad(8.0 + dx, 10.0 + dy, 2, f"E{i}"))
+            i += 1
+    for dx in (-0.4, 0.4, 1.0):
+        pads.append(_pad(8.0 + dx, 10.0 - 1.6, 2, f"S{i}"))
+        pads.append(_pad(8.0 + dx, 10.0 + 1.6, 2, f"N{i}"))
+        i += 1
+    pads.append(_pad(2.0, 10.0, 1, "U2"))  # far west sink (open)
+    pf = LatticePathfinder(
+        [(0.0, 0.0), (20.0, 0.0), (20.0, 20.0), (0.0, 20.0)],
+        pads,
+        DesignRules(),
+        layer_stack=LayerStack.two_layer(),
+    )
+    return pf, pads[0], pads[-1]
+
+
+def test_full_width_escape_declines_but_neck_taper_escapes() -> None:
+    pf, buried, _sink = _dense_field()
+
+    # Full class width: the surcharge blocks every dogleg -> honest decline.
+    assert pf.pad_stubs(buried, net=1, net_class=_HV) == []
+
+    # The tapered fallback finds neck stubs at the neck width.
+    stubs, width = pf._escape_stubs(
+        buried,
+        1,
+        None,
+        kmax=4,
+        extra_clearance=0.0,
+        partner_net=None,
+        layers=None,
+        exempt_pads=None,
+        net_class=_HV,
+    )
+    assert stubs, "neck taper must find a legal escape the full width could not"
+    assert width == 0.2, "neck width is the DRU floor (rules.trace_width)"
+
+
+def test_neck_legs_are_clearance_checked_at_the_neck_width() -> None:
+    """Never-ship-a-short (#3906): every emitted neck leg clears other-net pad
+    keep-outs when checked at the NECK half-width surcharge."""
+    pf, buried, _sink = _dense_field()
+    obstacles = pf.obstacles
+    neck_half = 0.1  # 0.2 mm neck
+    clr = 0.3
+    extra = max(0.0, neck_half + clr - pf._agent_radius)
+
+    stubs, _w = pf._escape_stubs(
+        buried,
+        1,
+        None,
+        kmax=4,
+        extra_clearance=0.0,
+        partner_net=None,
+        layers=None,
+        exempt_pads=None,
+        net_class=_HV,
+    )
+    assert stubs
+    for _key, layer, poly, _length in stubs:
+        assert poly[0] == (buried.x, buried.y), "escape starts at the exact pad"
+        for a, b in zip(poly, poly[1:], strict=False):
+            assert not obstacles.segment_blocked(a, b, layer, net=1, extra=extra), (
+                f"neck leg {a}->{b} crosses an other-net keep-out at the neck width"
+            )
+
+
+def test_route_emits_neck_escape_and_full_width_body() -> None:
+    pf, buried, sink = _dense_field()
+    route = pf.route(buried, sink, net_class=_HV)
+    assert route is not None, "the oversize net must connect via the neck taper"
+
+    widths = sorted({round(s.width, 4) for s in route.segments})
+    assert widths == [0.2, 2.6], f"expected neck+body widths, got {widths}"
+
+    # The exact pad-touching segment is the neck; the far body is full width.
+    touching = [
+        s
+        for s in route.segments
+        if (abs(s.x1 - buried.x) < 1e-6 and abs(s.y1 - buried.y) < 1e-6)
+        or (abs(s.x2 - buried.x) < 1e-6 and abs(s.y2 - buried.y) < 1e-6)
+    ]
+    assert touching, "a segment must touch the buried pad exactly"
+    assert all(abs(s.width - 0.2) < 1e-9 for s in touching), "pad-touching leg is the neck"
+    assert any(abs(s.width - 2.6) < 1e-9 for s in route.segments), "body widens to class width"
+
+
+def test_default_width_net_escapes_at_full_width_no_taper() -> None:
+    """A net at the board default width escapes at full width -- the neck
+    fallback never fires, so behavior is byte-identical to pre-#4293."""
+    pads = [_pad(10.0, 10.0, 1, "U1"), _pad(4.0, 10.0, 1, "U2")]
+    pf = LatticePathfinder(
+        [(0.0, 0.0), (20.0, 0.0), (20.0, 20.0), (0.0, 20.0)],
+        pads,
+        DesignRules(),
+        layer_stack=LayerStack.two_layer(),
+    )
+    stubs, width = pf._escape_stubs(
+        pads[0],
+        1,
+        None,
+        kmax=4,
+        extra_clearance=0.0,
+        partner_net=None,
+        layers=None,
+        exempt_pads=None,
+        net_class=None,
+    )
+    assert stubs
+    assert width == pf.rules.trace_width, "default net keeps the full width (no taper)"
+    route = pf.route(pads[0], pads[1])
+    assert route is not None
+    assert {round(s.width, 4) for s in route.segments} == {pf.rules.trace_width}
+
+
+def test_committed_copper_spaces_each_segment_at_its_emitted_width() -> None:
+    """The #4289 spacing model must use the ACTUAL emitted width per segment:
+    a neck leg is spaced as neck copper, the widened body as full-width copper.
+    The taper must not let the body cheat the spacing math."""
+    committed = CommittedCopper(
+        num_layers=2,
+        trace_half=0.1,
+        clearance=0.2,
+        via_radius=0.35,
+        via_via_gap=0.9,
+        same_net_via_gap=0.85,
+    )
+    # A neck leg (half 0.1) then a widened body (half 1.3) on net 1.
+    committed.add_run_widths(
+        0, [(0.0, 0.0), (5.0, 0.0), (10.0, 0.0)], net=1, seg_halves=[0.1, 1.3], clearance=0.3
+    )
+
+    # An other-net (2) probe with a 0.1 mm half-width, 0.3 clearance.
+    # Gap to the neck seg  = 0.1 + 0.1 + 0.3 = 0.5 mm.
+    # Gap to the body seg  = 0.1 + 1.3 + 0.3 = 1.7 mm.
+    near_neck = (2.5, 0.6)  # 0.6 mm off the neck seg -> clears (>= 0.5)
+    near_body = (7.5, 0.6)  # 0.6 mm off the body seg -> too close (< 1.7)
+    assert committed.node_clear(near_neck, 0, net=2, half=0.1, clearance=0.3)
+    assert not committed.node_clear(near_body, 0, net=2, half=0.1, clearance=0.3)
+
+
+def test_neck_width_is_a_legal_floor_and_class_can_override() -> None:
+    pads = [_pad(10.0, 10.0, 1, "U1")]
+    pf = LatticePathfinder(
+        [(0.0, 0.0), (20.0, 0.0), (20.0, 20.0), (0.0, 20.0)],
+        pads,
+        DesignRules(min_trace_width=0.15),
+        layer_stack=LayerStack.two_layer(),
+    )
+    # Default: the DRU min-trace floor (0.15), never below it.
+    assert pf._neck_width(_HV) == 0.15
+    # A class may raise the neck for ampacity; still floored at the fab min.
+    wide_neck = NetClassRouting(name="HV", trace_width=2.6, neck_trace_width=1.0)
+    assert pf._neck_width(wide_neck) == 1.0
+    thin_neck = NetClassRouting(name="HV", trace_width=2.6, neck_trace_width=0.05)
+    assert pf._neck_width(thin_neck) == 0.15, "override below the fab min is clamped up"
+
+
+def test_route_netset_converts_oversize_decline_with_zero_short() -> None:
+    """End-to-end: the negotiation routes the oversize net via the neck taper
+    and the emitted copper has no cross-net short at the per-class gaps."""
+    pf, buried, sink = _dense_field()
+    conns = [((1, 0), buried, sink, _HV)]
+    routes, stats = pf.route_netset(conns, max_iterations=2)
+
+    assert stats.lattice_builds == 1
+    assert (1, 0) in routes, f"oversize net must route; declines={pf.failure_reasons}"
+    route = routes[(1, 0)]
+    assert {round(s.width, 4) for s in route.segments} == {0.2, 2.6}
+
+    # No emitted segment intrudes on an other-net pad keep-out at its width.
+    obstacles = pf.obstacles
+    for seg in route.segments:
+        layer = pf.layer_stack.layer_enum_to_index(seg.layer)
+        extra = max(0.0, seg.width / 2.0 + 0.3 - pf._agent_radius)
+        assert not obstacles.segment_blocked(
+            (seg.x1, seg.y1), (seg.x2, seg.y2), layer, net=1, extra=extra
+        ), "emitted copper crosses an other-net pad keep-out"

--- a/tests/router/lattice/test_softstart_routing.py
+++ b/tests/router/lattice/test_softstart_routing.py
@@ -16,8 +16,9 @@ Assertions (pinned to the measured 2026-07-16 P4 verdict; see #4271):
 2. Zero cross-net short in the emitted copper (the #3906 invariant checked
    pairwise at the per-class copper gap).
 3. Completion >= the measured floor.
-4. Net-class honesty: every HV_HICUR connection that routes is emitted at
-   its 2.6mm class width.
+4. Net-class honesty: every HV_HICUR connection that routes carries its
+   2.6mm class width on the widened lattice body; any narrower segment is a
+   legal pad-escape neck at the DRU floor (the #4293 taper).
 
 NOTE: this test runs the REAL whole-netset negotiation (minutes of wall
 clock, local-only).  ``max_iterations`` is capped to keep it bounded; the
@@ -43,14 +44,18 @@ _SOFTSTART_DIR = _REPO / "boards/external/softstart/output_revc"
 _SOFTSTART = _SOFTSTART_DIR / "softstart_revc.kicad_pcb"
 _SIDECAR = _SOFTSTART_DIR / "net_class_map.json"
 
-# Measured floors -- pinned from the 2026-07-17 #4271 P4 measurement
-# (deterministic negotiation; measured 267/287 connections and 63/79 nets
+# Measured floors -- pinned from the 2026-07-17 #4293 P4 re-measurement
+# (deterministic negotiation; measured 273/287 connections and 66/79 nets
 # fully connected at max_iterations=2, declines {no-path: 13,
-# pad-escape-end: 7}).  Floors sit below the measurement for stability but
-# above the epic acceptance floor (>= 40/79 nets), so a regression to the
-# pre-#4271 behavior (or below the epic floor) fails loudly.
-_CONNECTION_FLOOR = 255
-_NET_FLOOR = 55
+# pad-escape-end: 1}).  RAISED from the #4271 floors (255/55, measured
+# 267/63) because the oversize neck-down escape (#4293) converted 6 of the 7
+# pad-escape-end declines: the 2.6 mm HV_HICUR nets that could not exit the
+# dense fuse/terminal pad fields now escape at a legal neck and widen back to
+# the class width at the first lattice node.  Floors sit below the new
+# measurement for stability but above the #4271 reality, so a regression to
+# either the pre-#4293 or the epic floor (>= 40/79 nets) fails loudly.
+_CONNECTION_FLOOR = 265
+_NET_FLOOR = 60
 
 pytestmark = pytest.mark.skipif(
     not _SOFTSTART.exists(), reason="local-only softstart fixture absent"
@@ -132,13 +137,25 @@ def test_softstart_lattice_routing_proof() -> None:
     print(f"[softstart proof] nets fully connected: {len(full)}/{len(keys_by_net)}")
     assert len(full) >= _NET_FLOOR, f"nets fully connected {len(full)} below floor"
 
-    # 4. Net-class honesty: routed HV_HICUR connections carry 2.6mm copper.
+    # 4. Net-class honesty WITH the #4293 taper: routed HV_HICUR connections
+    # carry 2.6mm copper on the widened lattice body, and any narrower segment
+    # is a legal pad-escape neck (== the DRU neck floor, never an arbitrary
+    # width).  Every routed HV connection must show the full class width
+    # somewhere (the body is never all-neck).
+    neck_w = pf._neck_width(class_by_name.get("HV_HICUR"))
     hv_checked = 0
     for key, route in routes.items():
         nc = class_by_name.get(name_by_net[key[0]])
         if nc is not None and nc.name == "HV_HICUR":
             hv_checked += 1
-            assert all(abs(s.width - nc.trace_width) < 1e-9 for s in route.segments)
+            widths = {round(s.width, 6) for s in route.segments}
+            assert widths <= {round(nc.trace_width, 6), round(neck_w, 6)}, (
+                f"HV net {key} has off-class widths {widths} "
+                f"(expected only {nc.trace_width}mm body or {neck_w}mm neck)"
+            )
+            assert any(abs(s.width - nc.trace_width) < 1e-9 for s in route.segments), (
+                f"HV net {key} widened body missing (all-neck emission)"
+            )
 
     # 2. Zero cross-net short: pairwise per-class copper gap on same layer.
     flat: list[tuple[int, object, tuple, tuple, float, float]] = []


### PR DESCRIPTION
## Summary

Closes #4293. The dominant P4 softstart decline class (PR #4289) was `pad-escape-end` — 8 of 10 shortfall connections. Oversize copper (2.6 mm HV_HICUR) carries an ~1.45 mm keep-out surcharge (`half + clearance − agent_radius`) on every static pad check, so in dense fuse/terminal pad fields **no** full-width dogleg clears and the connection declines honestly on `/AC_NEUTRAL`, `/FUSED_LINE` (2.6 mm), `/PGND` (0.8 mm), `/NRST`.

## Mechanism chosen: width-tapered escape (neck-down) + wider oversize fan

Diagnosed first, then combined candidates 1 and 2 from the issue:

- **Neck-down taper.** When the full-width escape declines, the pad-escape legs retry at a narrower **legal** neck — the DRU minimum track (`DesignRules.min_trace_width`, else the board default `trace_width`), overridable per class via the new `NetClassRouting.neck_trace_width` for ampacity — and widen back to the class width at the first lattice node. Principled floor, never a magic constant, never below the fab min.
- **Wider oversize fan.** A thin neck escapes the pad, but the *widened* body must egress at full width, so the useful escape node sits at the edge of the congested field. The neck retry collects a radius-bounded fan (grown by the full-width surcharge) rather than the nearest-first count cap, which would exhaust itself on dead-end near nodes.

The full-width attempt runs first and is returned unchanged whenever it yields any stub, so **every connection that already escapes is byte-identical to pre-#4293** — only genuine oversize declines pay the neck fallback.

### Honesty invariants
- **Never-ship-a-short (#3906):** each neck leg is clearance-checked at the neck width, each body edge at the full width.
- **Spacing model (#4289):** committed copper records **each segment at its emitted width** (`CommittedCopper.add_run_widths`) — the widened body is spaced as 2.6 mm copper, the neck as neck copper. The taper never cheats the gap math. Emission merges collinear segments only within contiguous equal-width groups, so a neck and a body segment never fuse into one width.

## Measured (softstart P4, seed 42, solo host)

`--route-engine lattice --strategy basic --no-auto-layers --allow-offboard`, `max_iterations=8`:

| Metric | Before (#4289) | After (#4293) |
|---|---|---|
| Signal nets fully connected | 71/77 | **74/77** |
| Connections | 195/205 | **201/205** |
| `pad-escape-end` declines | 8 on 4 nets | **2 on /NRST** |
| kicad-cli DRC (`--refill-zones`, DRU-armed) | 0 errors | **0 error-severity clearance/short/hole** |
| `lattice_builds` | 1 | 1 |
| Wall-clock | 34.9 min | 36 min |

**6 of 8 `pad-escape-end` declines converted** — all three oversize nets (`/AC_NEUTRAL`, `/FUSED_LINE`, `/PGND`). `/NRST` is default-width (no class entry), so the neck correctly does **not** apply — its decline is default-width congestion, outside this issue's scope. The 2 `no-path` declines (`/GATE_NEG_B`, `/OC_TRIP_N`) are topological, not escape. No new `hole_to_hole` (the #4298 floor holds).

74/77 is one short of the 75+ stretch target; the residual is honestly a non-oversize net (`/NRST`) the mechanism does not target. Per the issue, a partial conversion honestly reported is acceptable; there are no hidden regressions.

## Changes
- `router/lattice/pathfinder.py`: `pad_stubs` refactored into a reusable `_scan_stubs` core; new `_neck_width` + `_escape_stubs` (full-then-neck fallback with the wider fan); `_route_impl` tracks per-segment escape/body widths through reconstruction; `_emit` emits per-segment widths and merges within equal-width groups.
- `router/lattice/obstacles.py`: `CommittedCopper.add_run_widths` (per-segment half-widths).
- `router/rules.py`: `NetClassRouting.neck_trace_width`.
- `tests/router/lattice/test_oversize_escape.py` (NEW, 7 tests): full-width decline → neck escape; neck legs clearance-checked at the neck width; route emits neck + full-width body; default net unchanged; committed copper spaces per emitted width; neck width is a legal floor with class override; end-to-end netset conversion with zero short.
- `tests/router/lattice/test_softstart_routing.py`: floors raised to the new measured reality (265/60, measured 273/66 at `max_iterations=2`, with comment); net-class honesty check taught the taper.

## Test plan
- New oversize suite: 7 passed. Full lattice + mesh suites (minus the long fixture-gated softstart): 149 passed. Coupled/diff-pair board-06 + engine dispatch: 36 passed. Board-02 8/8 (`test_post_pass_gating`). MFR001 propagation lint: 9 passed.
- Softstart proof test (fixture-gated, `max_iterations=2`): 273/287 connections, 66/79 nets, declines `{no-path: 13, pad-escape-end: 1}` (was 267/63, `pad-escape-end: 7`).
- mypy: clean on changed files (grid/mesh/core untouched). ruff + format: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)