### PR TITLE
fix(parts): quiet live-API-failure fallback to synced catalog (#4299)

### DIFF
--- a/src/kicad_tools/parts/lcsc.py
+++ b/src/kicad_tools/parts/lcsc.py
@@ -611,8 +611,23 @@ class LCSCClient:
 
         return None
 
-    def _fetch_part(self, lcsc_part: str) -> Part | None:
-        """Fetch part from JLCPCB API."""
+    def _fetch_part(
+        self,
+        lcsc_part: str,
+        _failures: list[tuple[str, str]] | None = None,
+    ) -> Part | None:
+        """Fetch part from JLCPCB API.
+
+        Args:
+            lcsc_part: LCSC part number to fetch.
+            _failures: Optional collector for deferred live-API failures. When a
+                list is supplied, a transport-level failure (e.g. a 404 from a
+                drifted endpoint) appends ``(part, reason)`` here instead of
+                emitting a per-part warning, so the caller can summarize the
+                situation once after the offline-catalog fallback runs. The log
+                is demoted to ``debug`` because the failure is transparently
+                handled by that fallback (see issue #4299).
+        """
         import requests
 
         payload = {"componentCode": lcsc_part}
@@ -620,7 +635,9 @@ class LCSCClient:
         try:
             data = self._make_request(PART_LOOKUP_URL, payload)
         except requests.RequestException as e:
-            logger.warning(f"API request failed for {lcsc_part}: {e}")
+            logger.debug(f"API request failed for {lcsc_part}: {e}")
+            if _failures is not None:
+                _failures.append((lcsc_part, str(e)))
             return None
 
         if data is None:
@@ -885,18 +902,27 @@ class LCSCClient:
                             self.cache.put(official_part)
                 parts = [p for p in parts if p not in result]
 
+        # Live-API failures are deferred here and summarized once below, rather
+        # than logged per-part: when the offline catalog then resolves the part
+        # (the common case for a drifted 404 endpoint or a 403 geo-block) the
+        # per-part warnings are pure noise (issue #4299).
+        live_failures: list[tuple[str, str]] = []
+
         if not _requests_installed():
             if catalog is None or not catalog.available:
                 raise LCSCDependencyMissingError(PARTS_INSTALL_HINT)
         else:
             # Fetch remaining from the live API (authoritative when reachable).
-            for part_num in parts:
+            for i, part_num in enumerate(parts):
                 try:
-                    part = self._fetch_part(part_num)
+                    part = self._fetch_part(part_num, _failures=live_failures)
                 except Exception as e:
-                    # 403 circuit breaker or other API failure -- stop hammering
-                    # the API and fall back to the offline catalog for the rest.
-                    logger.warning(f"Live API lookup failed for {part_num}: {e}")
+                    # 403 circuit breaker or other hard API failure -- stop
+                    # hammering the API and fall back to the offline catalog for
+                    # the rest. Every remaining part would hit the same wall, so
+                    # record them all and defer the log to the summary below.
+                    logger.debug(f"Live API lookup failed for {part_num}: {e}")
+                    live_failures.extend((p, str(e)) for p in parts[i:])
                     break
                 if part:
                     result[part_num] = part
@@ -910,6 +936,23 @@ class LCSCClient:
                 result[part_num] = part
                 if self.cache:
                     self.cache.put(part)
+
+        # Summarize any live-API failures in a single line. If the catalog
+        # covered them the failure is transparently handled (one WARNING so the
+        # condition is still visible once, not N times); parts resolved by
+        # neither the live API nor the catalog stay explicitly visible.
+        if live_failures:
+            reason = live_failures[0][1]
+            failed = [p for p, _ in live_failures]
+            resolved = [p for p in failed if p in result]
+            unresolved = [p for p in failed if p not in result]
+            details: list[str] = []
+            if resolved:
+                details.append(f"{len(resolved)} resolved from the offline catalog")
+            if unresolved:
+                preview = ", ".join(sorted(unresolved)[:10])
+                details.append(f"{len(unresolved)} unresolved ({preview})")
+            logger.warning(f"Live JLC API unavailable ({reason}); " + "; ".join(details))
 
         return result
 

--- a/tests/parts/test_jlcparts_catalog.py
+++ b/tests/parts/test_jlcparts_catalog.py
@@ -470,7 +470,7 @@ def test_lookup_many_live_partial_then_catalog(
     cache = PartsCache(db_path=tmp_path / "cache.db")
     client = LCSCClient(cache=cache, catalog_path=catalog_db)
 
-    def fake_fetch(part_num: str):
+    def fake_fetch(part_num: str, _failures=None):
         if part_num == "C1525":
             return Part(lcsc_part="C1525", mfr_part="LIVE-CAP")
         # Everything else "fails" via circuit breaker.

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -1524,3 +1524,183 @@ class TestLCSCClientCircuitBreaker:
         # with the catalog disabled it re-raises as before.
         with pytest.raises(LCSCForbiddenError):
             client.search("100nF 0402")
+
+
+class _FakeCatalog:
+    """Minimal offline-catalog stand-in for live-API-failure tests.
+
+    Resolves whatever part numbers it was seeded with, mirroring the subset of
+    the :class:`JlcpartsCatalog` surface that ``lookup_many`` touches.
+    """
+
+    available = True
+
+    def __init__(self, parts: dict[str, Part]):
+        self._parts = parts
+
+    def lookup(self, lcsc_part: str):
+        return self._parts.get(lcsc_part)
+
+    def lookup_many(self, lcsc_parts):
+        return {p: self._parts[p] for p in lcsc_parts if p in self._parts}
+
+    def search(self, *args, **kwargs):
+        return []
+
+
+class TestLCSCLiveApiFailureNoise:
+    """Live-API failures must fall back to the synced catalog *quietly* (#4299).
+
+    When the live JLC endpoint 404s (drifted endpoint) or 403s (geo-block) but
+    the offline catalog resolves the parts, the user should see a single summary
+    line -- not one WARNING per part. When there is no catalog to fall back to,
+    the failure stays visible.
+    """
+
+    @staticmethod
+    def _per_part_warnings(records):
+        """WARNING records that are the old per-part live-failure noise."""
+        return [
+            r
+            for r in records
+            if r.levelname == "WARNING"
+            and (
+                "API request failed for " in r.message or "Live API lookup failed for " in r.message
+            )
+        ]
+
+    @staticmethod
+    def _summary_warnings(records):
+        return [
+            r
+            for r in records
+            if r.levelname == "WARNING" and "Live JLC API unavailable" in r.message
+        ]
+
+    def _client_with_catalog(self, tmp_path, parts):
+        from kicad_tools.parts import LCSCClient
+
+        cache = PartsCache(db_path=tmp_path / "cache.db")
+        client = LCSCClient(
+            cache=cache,
+            rate_limit=0,
+            use_official_api=False,
+            use_local_catalog=True,
+        )
+        catalog = _FakeCatalog(parts)
+        # Route the offline fallback through our seeded fake.
+        client._catalog = catalog
+        return client, catalog
+
+    def test_404_falls_back_quietly_with_catalog(self, tmp_path, caplog):
+        """A drifted-endpoint 404 with a synced catalog: no per-part noise."""
+        import logging
+
+        import requests
+
+        from kicad_tools.parts import LCSCClient  # noqa: F401 (re-exported)
+
+        part_nums = ["C1", "C2", "C3"]
+        catalog_parts = {p: Part(lcsc_part=p, mfr_part=f"CatalogPart{p}") for p in part_nums}
+        client, _ = self._client_with_catalog(tmp_path, catalog_parts)
+
+        # Real _fetch_part runs; _make_request raises the 404 RequestException
+        # for every part (simulating selectSmtComponentDetail returning 404).
+        err = requests.RequestException("C232604: 404 Client Error for selectSmtComponentDetail")
+        with patch.object(client, "_make_request", side_effect=err):
+            with caplog.at_level(logging.DEBUG, logger="kicad_tools.parts.lcsc"):
+                result = client.lookup_many(part_nums)
+
+        # Availability RESULT unchanged: every part resolved from the catalog.
+        assert set(result) == set(part_nums)
+        for p in part_nums:
+            assert result[p].mfr_part == f"CatalogPart{p}"
+
+        # No per-part WARNING noise -- at most one summary line.
+        assert self._per_part_warnings(caplog.records) == []
+        summaries = self._summary_warnings(caplog.records)
+        assert len(summaries) == 1
+        assert "resolved from the offline catalog" in summaries[0].message
+        # The old per-part message is demoted to DEBUG, not gone entirely.
+        assert any(
+            r.levelname == "DEBUG" and "API request failed for" in r.message for r in caplog.records
+        )
+
+    def test_403_falls_back_quietly_with_catalog(self, tmp_path, caplog):
+        """A 403 geo-block with a synced catalog: single summary, no per-part."""
+        import logging
+
+        from kicad_tools.parts import LCSCClient  # noqa: F401
+        from kicad_tools.parts.lcsc import LCSCForbiddenError
+
+        part_nums = ["C10", "C20", "C30"]
+        catalog_parts = {p: Part(lcsc_part=p, mfr_part=f"CatalogPart{p}") for p in part_nums}
+        client, _ = self._client_with_catalog(tmp_path, catalog_parts)
+
+        err = LCSCForbiddenError("JLCPCB API returned 403 Forbidden -- geo-blocked")
+        with patch.object(client, "_make_request", side_effect=err):
+            with caplog.at_level(logging.DEBUG, logger="kicad_tools.parts.lcsc"):
+                result = client.lookup_many(part_nums)
+
+        assert set(result) == set(part_nums)
+        assert self._per_part_warnings(caplog.records) == []
+        summaries = self._summary_warnings(caplog.records)
+        assert len(summaries) == 1
+        assert "resolved from the offline catalog" in summaries[0].message
+
+    def test_failure_stays_visible_without_catalog(self, tmp_path, caplog):
+        """No catalog to fall back to: the live-API failure remains visible."""
+        import logging
+
+        import requests
+
+        from kicad_tools.parts import LCSCClient, PartsCache
+
+        cache = PartsCache(db_path=tmp_path / "cache.db")
+        client = LCSCClient(
+            cache=cache,
+            rate_limit=0,
+            use_official_api=False,
+            use_local_catalog=False,  # no offline fallback
+        )
+
+        err = requests.RequestException("C232604: 404 Client Error for selectSmtComponentDetail")
+        with patch.object(client, "_make_request", side_effect=err):
+            with caplog.at_level(logging.DEBUG, logger="kicad_tools.parts.lcsc"):
+                result = client.lookup_many(["C1"])
+
+        # Nothing resolved -- and the user is told, once, with the part visible.
+        assert result == {}
+        summaries = self._summary_warnings(caplog.records)
+        assert len(summaries) == 1
+        assert "unresolved" in summaries[0].message
+        assert "C1" in summaries[0].message
+        # Still no per-part duplicate of the old noisy message.
+        assert self._per_part_warnings(caplog.records) == []
+
+    def test_legit_miss_emits_no_summary(self, tmp_path, caplog):
+        """An API that responds but lacks the part is a miss, not a failure.
+
+        Guards against the summary firing for ordinary not-found results (the
+        API transport succeeded), which would be a false 'API unavailable'.
+        """
+        import logging
+
+        from kicad_tools.parts import LCSCClient, PartsCache
+
+        cache = PartsCache(db_path=tmp_path / "cache.db")
+        client = LCSCClient(
+            cache=cache,
+            rate_limit=0,
+            use_official_api=False,
+            use_local_catalog=False,
+        )
+
+        # code 200 + empty data => _fetch_part returns None (a clean miss).
+        with patch.object(client, "_make_request", return_value={"code": 200, "data": None}):
+            with caplog.at_level(logging.DEBUG, logger="kicad_tools.parts.lcsc"):
+                result = client.lookup_many(["C999"])
+
+        assert result == {}
+        assert self._summary_warnings(caplog.records) == []
+        assert self._per_part_warnings(caplog.records) == []


### PR DESCRIPTION
## Summary
`kct parts availability` printed a wall of per-part `logger.warning` lines whenever the live JLC API failed (404 on the drifted `selectSmtComponentDetail` endpoint, or 403 geo-block) — even though the synced jlcparts catalog then resolved every part correctly. The fallback already worked; the noise was the bug (issue #4299).

## Changes (`src/kicad_tools/parts/lcsc.py`)
- `_fetch_part`: the 404/RequestException log is demoted from `warning` to `debug`; an optional `_failures` collector lets the caller defer the report.
- `lookup_many`: live-API failures (404 per-part and the 403 circuit-breaker `break`) are collected instead of logged inline. After the offline-catalog fill, a **single** summary WARNING is emitted:
  - `Live JLC API unavailable (<reason>); N resolved from the offline catalog` when the catalog covered them.
  - Parts resolved by neither live nor catalog are listed as `M unresolved (...)` in the same line, so genuine failures stay visible (including the no-catalog case).
- Legit not-found misses (API responded, part absent) do **not** trigger the summary — no false "API unavailable".

Availability **results** (counts, Available/unavailable) are unchanged — this is a logging/noise fix only.

## Tests (`tests/test_parts.py`, `tests/parts/test_jlcparts_catalog.py`)
New `TestLCSCLiveApiFailureNoise` (mocked, never hits the live API):
- 404 with catalog available → all parts resolved from catalog, **no** per-part WARNING, exactly one summary line (old message present only at DEBUG).
- 403 with catalog available → same single-summary behavior.
- Live failure with **no** catalog → failure stays visible (one summary listing the unresolved part).
- Legit miss → no summary, no noise.
Updated one existing mock's `_fetch_part` signature for the new `_failures` kwarg.

## Gates
- Parts + cost suites green (268 passed).
- ruff check + format clean; MFR001 lint green.
- mypy: 0 new errors (the 3 reported are pre-existing, outside the edited regions).

Closes #4299

🤖 Generated with [Claude Code](https://claude.com/claude-code)