### PR TITLE
feat(schematic): make in_bom/dnp settable on symbol generation (#4303)

### DIFF
--- a/src/kicad_tools/schematic/models/elements.py
+++ b/src/kicad_tools/schematic/models/elements.py
@@ -348,6 +348,11 @@ class PowerSymbol:
     rotation: float = 0
     reference: str = "#PWR?"
     uuid_str: str = field(default_factory=lambda: str(uuid.uuid4()))
+    # BOM / DNP flags.  Defaults preserve historical byte output exactly
+    # (in_bom=True -> "yes", dnp=False -> "no") while letting callers emit
+    # exclude-from-BOM / do-not-populate power symbols (issue #4303).
+    in_bom: bool = True
+    dnp: bool = False
 
     _symbol_def: Optional["SymbolDef"] = field(default=None, repr=False)
 
@@ -362,9 +367,9 @@ class PowerSymbol:
             at(self.x, self.y, self.rotation),
             SExp.list("unit", 1),
             SExp.list("exclude_from_sim", "no"),
-            SExp.list("in_bom", "yes"),
+            SExp.list("in_bom", "yes" if self.in_bom else "no"),
             SExp.list("on_board", "yes"),
-            SExp.list("dnp", "no"),
+            SExp.list("dnp", "yes" if self.dnp else "no"),
             uuid_node(self.uuid_str),
         )
 
@@ -427,8 +432,22 @@ class PowerSymbol:
                 reference = str(atoms[1])
                 break
 
+        # Get BOM / DNP flags (issue #4303); default to historical values
+        # when the token is absent so older schematics round-trip unchanged.
+        in_bom_node = node.get("in_bom")
+        in_bom = str(in_bom_node.get_first_atom()).lower() != "no" if in_bom_node else True
+        dnp_node = node.get("dnp")
+        dnp = str(dnp_node.get_first_atom()).lower() == "yes" if dnp_node else False
+
         return cls(
-            lib_id=lib_id, x=x, y=y, rotation=rotation, reference=reference, uuid_str=uuid_str
+            lib_id=lib_id,
+            x=x,
+            y=y,
+            rotation=rotation,
+            reference=reference,
+            uuid_str=uuid_str,
+            in_bom=in_bom,
+            dnp=dnp,
         )
 
     @staticmethod

--- a/src/kicad_tools/schematic/models/elements_mixin.py
+++ b/src/kicad_tools/schematic/models/elements_mixin.py
@@ -305,6 +305,8 @@ class SchematicElementsMixin:
         auto_footprint: bool = False,
         properties: dict[str, str] = None,
         unit: int = 1,
+        in_bom: bool = True,
+        dnp: bool = False,
     ) -> SymbolInstance:
         """Add a symbol to the schematic.
 
@@ -330,6 +332,14 @@ class SchematicElementsMixin:
                 resolve to the unit-local coordinates so that pin 4
                 (LM393 V-, on unit 3) returns the unit-3 position
                 instead of a phantom unit-1 fallback (issue #3346).
+            in_bom: Whether the symbol appears in the BOM (default True ->
+                ``(in_bom yes)``).  Set False for bare pads that must not
+                be sourced — test points, fiducials, mounting holes,
+                logos, mechanical-only parts — so ``kct parts
+                availability`` does not flag them as unsourced (#4303).
+            dnp: Do-not-populate flag (default False -> ``(dnp no)``).  Set
+                True to emit ``(dnp yes)`` for footprints that should be
+                placed on the board but not populated.
 
         Returns:
             SymbolInstance with pin_position() method
@@ -401,6 +411,8 @@ class SchematicElementsMixin:
             footprint=effective_footprint,
             properties=properties or {},
             unit=unit,
+            in_bom=in_bom,
+            dnp=dnp,
         )
 
         self.symbols.append(instance)
@@ -459,6 +471,8 @@ class SchematicElementsMixin:
         y: float,
         rotation: float = 0,
         snap: bool = True,
+        in_bom: bool = True,
+        dnp: bool = False,
     ) -> PowerSymbol:
         """Add a power symbol whose net name is set by the caller.
 
@@ -488,6 +502,14 @@ class SchematicElementsMixin:
             rotation: Rotation in degrees (0 = arrow up, 180 = arrow
                 down, typical for GND).
             snap: Whether to apply grid snapping (default: True).
+            in_bom: Whether the symbol appears in the BOM (default True ->
+                ``(in_bom yes)``, matching KiCad's stock power symbols).
+                The value is baked into the synthesized ``lib_symbols``
+                entry the first time a given ``net_name`` is used (the
+                entry is cached per net) as well as the placed instance
+                (issue #4303).
+            dnp: Do-not-populate flag for the placed instance (default
+                False -> ``(dnp no)``).
 
         Returns:
             The :class:`PowerSymbol` instance placed in the schematic.
@@ -521,7 +543,7 @@ class SchematicElementsMixin:
 
         # Build (or fetch from cache) the synthesized lib_symbol entry.
         if net_name not in self._synthesized_pwr_defs:
-            sym_node = self._build_synth_pwr_lib_symbol(net_name)
+            sym_node = self._build_synth_pwr_lib_symbol(net_name, in_bom=in_bom)
             self._synthesized_pwr_defs[net_name] = sym_node
             # Register in _embedded_lib_symbols so _build_lib_symbols_node
             # emits the entry on save.  Keyed by lib_id (full prefixed
@@ -535,12 +557,14 @@ class SchematicElementsMixin:
             y=y,
             rotation=rotation,
             reference=ref,
+            in_bom=in_bom,
+            dnp=dnp,
         )
         self.power_symbols.append(pwr)
         _log_info(f"Added synthesized power symbol '{net_name}' at ({x}, {y})")
         return pwr
 
-    def _build_synth_pwr_lib_symbol(self, net_name: str):
+    def _build_synth_pwr_lib_symbol(self, net_name: str, in_bom: bool = True):
         """Construct a synthesized power-symbol lib_symbol S-expression.
 
         The structure mirrors KiCad's stock ``power:+5V`` entry exactly,
@@ -582,7 +606,7 @@ class SchematicElementsMixin:
             (pin_numbers (hide yes))
             (pin_names (offset 0) (hide yes))
             (exclude_from_sim no)
-            (in_bom yes)
+            (in_bom {in_bom_tok})
             (on_board yes)
             (duplicate_pin_numbers_are_jumpers no)
             (property "Reference" "#PWR"
@@ -636,6 +660,7 @@ class SchematicElementsMixin:
             lib_id=f"{self._PWR_SYNTH_LIB_PREFIX}:{net_name}",
             nn=net_name,
             desc_nn=desc_net,
+            in_bom_tok="yes" if in_bom else "no",
         )
 
         # parse_string returns a single top-level node when the input

--- a/src/kicad_tools/schematic/models/symbol.py
+++ b/src/kicad_tools/schematic/models/symbol.py
@@ -583,6 +583,14 @@ class SymbolInstance:
     uuid_str: str = field(default_factory=lambda: str(uuid.uuid4()))
     footprint: str = ""
     properties: dict[str, str] = field(default_factory=dict)
+    # BOM / DNP flags emitted into the placed symbol.  Defaults preserve
+    # historical output exactly: in_bom=True -> "(in_bom yes)",
+    # dnp=False -> "(dnp no)".  Set in_bom=False for bare pads that must
+    # not appear in the BOM (test points, fiducials, mounting holes,
+    # logos, mechanical-only parts); set dnp=True for do-not-populate
+    # parts (issue #4303).
+    in_bom: bool = True
+    dnp: bool = False
 
     def find_pin(self, pin_name_or_number: str) -> Pin:
         """Resolve a pin name/number to its :class:`Pin` on this instance.
@@ -808,9 +816,9 @@ class SymbolInstance:
             at(self.x, self.y, self.rotation),
             SExp.list("unit", self.unit),
             SExp.list("exclude_from_sim", "no"),
-            SExp.list("in_bom", "yes"),
+            SExp.list("in_bom", "yes" if self.in_bom else "no"),
             SExp.list("on_board", "yes"),
-            SExp.list("dnp", "no"),
+            SExp.list("dnp", "yes" if self.dnp else "no"),
             uuid_node(self.uuid_str),
         )
 
@@ -845,6 +853,8 @@ class SymbolInstance:
         y = _fmt_coord(self.y)
         ref_y = _fmt_coord(self.y - 5.08)
         val_y = _fmt_coord(self.y - 2.54)
+        in_bom_tok = "yes" if self.in_bom else "no"
+        dnp_tok = "yes" if self.dnp else "no"
 
         # Generate custom properties (hidden by default)
         custom_props = ""
@@ -865,9 +875,9 @@ class SymbolInstance:
 \t\t(at {x} {y} {int(self.rotation)})
 \t\t(unit {self.unit})
 \t\t(exclude_from_sim no)
-\t\t(in_bom yes)
+\t\t(in_bom {in_bom_tok})
 \t\t(on_board yes)
-\t\t(dnp no)
+\t\t(dnp {dnp_tok})
 \t\t(uuid "{self.uuid_str}")
 \t\t(property "Reference" "{self.reference}"
 \t\t\t(at {x} {ref_y} 0)
@@ -961,6 +971,14 @@ class SymbolInstance:
         uuid_node_elem = node.get("uuid")
         uuid_str = str(uuid_node_elem.get_first_atom()) if uuid_node_elem else str(uuid.uuid4())
 
+        # Get BOM / DNP flags (issue #4303).  KiCad omits or uses "yes"/"no"
+        # tokens; default to the historical in_bom=True / dnp=False when the
+        # token is absent so older schematics round-trip unchanged.
+        in_bom_node = node.get("in_bom")
+        in_bom = str(in_bom_node.get_first_atom()).lower() != "no" if in_bom_node else True
+        dnp_node = node.get("dnp")
+        dnp = str(dnp_node.get_first_atom()).lower() == "yes" if dnp_node else False
+
         # Get properties
         reference = ""
         value = ""
@@ -1021,4 +1039,6 @@ class SymbolInstance:
             unit=unit,
             uuid_str=uuid_str,
             footprint=footprint,
+            in_bom=in_bom,
+            dnp=dnp,
         )

--- a/src/kicad_tools/schematic/symbol_generator.py
+++ b/src/kicad_tools/schematic/symbol_generator.py
@@ -151,6 +151,12 @@ class SymbolDef:
     description: str = ""
     keywords: str = ""
 
+    # BOM flag baked into the generated library symbol.  Default True keeps
+    # historical output ("(in_bom yes)"); set False to generate an
+    # exclude-from-BOM symbol definition — test points, fiducials, mounting
+    # holes, logos, mechanical-only parts (issue #4303).
+    in_bom: bool = True
+
     # Layout options
     pin_length: float = 2.54  # mm
     pin_spacing: float = 2.54  # mm (100 mil)
@@ -519,13 +525,14 @@ def generate_symbol_sexp(sym: SymbolDef) -> str:
 \t\t\t)"""
 
     # Build complete symbol
+    in_bom_tok = "yes" if sym.in_bom else "no"
     sexp = f'''(kicad_symbol_lib
 \t(version 20231120)
 \t(generator "create_symbol.py")
 \t(generator_version "1.0")
 \t(symbol "{sym.name}"
 \t\t(exclude_from_sim no)
-\t\t(in_bom yes)
+\t\t(in_bom {in_bom_tok})
 \t\t(on_board yes)
 \t\t(property "Reference" "{sym.reference}"
 \t\t\t(at 0 {half_h + 2.54:.2f} 0)

--- a/tests/test_schematic_models.py
+++ b/tests/test_schematic_models.py
@@ -3862,3 +3862,168 @@ class TestValidationSummaryHelpers:
         assert "ERROR: Wire endpoint floating" in result
         # Errors are always shown in detail, warnings need verbose
         assert "Wire off grid" not in result
+
+
+class TestSymbolBomDnp:
+    """Exclude-from-BOM / DNP support across every emit path (issue #4303).
+
+    The generated ``(in_bom ...)`` / ``(dnp ...)`` tokens must be driven by
+    the model instead of hardcoded, so recipes can emit test points,
+    fiducials, mounting holes and DNP parts.  Defaults MUST stay
+    byte-identical to the historical ``(in_bom yes)`` / ``(dnp no)`` output.
+    """
+
+    @pytest.fixture
+    def mock_symbol_def(self):
+        pins = [
+            Pin(name="1", number="1", x=-2.54, y=0, angle=0, length=2.54, pin_type="passive"),
+            Pin(name="2", number="2", x=2.54, y=0, angle=180, length=2.54, pin_type="passive"),
+        ]
+        return SymbolDef(lib_id="Device:R", name="R", raw_sexp="(symbol ...)", pins=pins)
+
+    def _tok(self, node, key):
+        child = node.get(key)
+        return str(child.get_first_atom()) if child else None
+
+    # -- SymbolInstance: node emit path (symbol.py to_sexp_node) -----------
+
+    def test_instance_node_default_byte_identity(self, mock_symbol_def):
+        """Default instance node emits (in_bom yes) / (dnp no)."""
+        inst = SymbolInstance(
+            symbol_def=mock_symbol_def, x=0, y=0, rotation=0, reference="R1", value="10k"
+        )
+        assert inst.in_bom is True and inst.dnp is False
+        node = inst.to_sexp_node("proj", "/sheet")
+        assert self._tok(node, "in_bom") == "yes"
+        assert self._tok(node, "dnp") == "no"
+
+    def test_instance_node_exclude_and_dnp(self, mock_symbol_def):
+        """in_bom=False / dnp=True flow through the node emit path."""
+        inst = SymbolInstance(
+            symbol_def=mock_symbol_def,
+            x=0,
+            y=0,
+            rotation=0,
+            reference="TP1",
+            value="TestPoint",
+            in_bom=False,
+            dnp=True,
+        )
+        node = inst.to_sexp_node("proj", "/sheet")
+        assert self._tok(node, "in_bom") == "no"
+        assert self._tok(node, "dnp") == "yes"
+
+    # -- SymbolInstance: template-string emit path (symbol.py to_sexp) -----
+
+    def test_instance_str_default_byte_identity(self, mock_symbol_def):
+        """Default instance template string emits (in_bom yes) / (dnp no)."""
+        inst = SymbolInstance(
+            symbol_def=mock_symbol_def, x=0, y=0, rotation=0, reference="R1", value="10k"
+        )
+        text = inst.to_sexp("proj", "/sheet")
+        assert "(in_bom yes)" in text
+        assert "(dnp no)" in text
+
+    def test_instance_str_exclude_and_dnp(self, mock_symbol_def):
+        """in_bom=False / dnp=True flow through the template-string path."""
+        inst = SymbolInstance(
+            symbol_def=mock_symbol_def,
+            x=0,
+            y=0,
+            rotation=0,
+            reference="TP1",
+            value="TestPoint",
+            in_bom=False,
+            dnp=True,
+        )
+        text = inst.to_sexp("proj", "/sheet")
+        assert "(in_bom no)" in text
+        assert "(dnp yes)" in text
+        assert "(in_bom yes)" not in text
+        assert "(dnp no)" not in text
+
+    def test_instance_roundtrip_reads_back_flags(self, mock_symbol_def):
+        """Serialize -> re-parse recovers the in_bom / dnp flags."""
+        inst = SymbolInstance(
+            symbol_def=mock_symbol_def,
+            x=10,
+            y=20,
+            rotation=0,
+            reference="TP1",
+            value="TestPoint",
+            in_bom=False,
+            dnp=True,
+        )
+        node = inst.to_sexp_node("proj", "/sheet")
+        parsed = SymbolInstance.from_sexp(node, symbol_defs={"Device:R": mock_symbol_def})
+        assert parsed.in_bom is False
+        assert parsed.dnp is True
+
+    def test_instance_from_sexp_defaults_when_tokens_absent(self, mock_symbol_def):
+        """Missing tokens parse as historical defaults (in_bom True, dnp False)."""
+        node = SExp.list(
+            "symbol",
+            SExp.list("lib_id", "Device:R"),
+            SExp.list("at", 0.0, 0.0, 0),
+            SExp.list("uuid", "u"),
+            SExp.list("property", "Reference", "R1"),
+            SExp.list("property", "Value", "10k"),
+        )
+        parsed = SymbolInstance.from_sexp(node, symbol_defs={"Device:R": mock_symbol_def})
+        assert parsed.in_bom is True
+        assert parsed.dnp is False
+
+    # -- PowerSymbol emit paths (elements.py) ------------------------------
+
+    def test_power_node_default_byte_identity(self):
+        pwr = PowerSymbol(lib_id="power:GND", x=0, y=0)
+        assert pwr.in_bom is True and pwr.dnp is False
+        node = pwr.to_sexp_node("proj", "/sheet")
+        assert self._tok(node, "in_bom") == "yes"
+        assert self._tok(node, "dnp") == "no"
+
+    def test_power_node_exclude_and_dnp(self):
+        pwr = PowerSymbol(lib_id="power:GND", x=0, y=0, in_bom=False, dnp=True)
+        node = pwr.to_sexp_node("proj", "/sheet")
+        assert self._tok(node, "in_bom") == "no"
+        assert self._tok(node, "dnp") == "yes"
+
+    def test_power_roundtrip_reads_back_flags(self):
+        pwr = PowerSymbol(lib_id="power:GND", x=0, y=0, in_bom=False, dnp=True)
+        parsed = PowerSymbol.from_sexp(pwr.to_sexp_node("proj", "/sheet"))
+        assert parsed.in_bom is False
+        assert parsed.dnp is True
+
+    # -- Public add_symbol API (elements_mixin.py) -------------------------
+
+    def test_add_symbol_api_default_byte_identity(self, mock_symbol_def):
+        sch = Schematic(title="T", snap_mode=SnapMode.OFF)
+        sch._symbol_defs["Device:R"] = mock_symbol_def
+        inst = sch.add_symbol("Device:R", x=0, y=0, ref="R1", value="10k")
+        assert inst.in_bom is True and inst.dnp is False
+        text = inst.to_sexp("proj", "/sheet")
+        assert "(in_bom yes)" in text and "(dnp no)" in text
+
+    def test_add_symbol_api_exclude_and_dnp(self, mock_symbol_def):
+        sch = Schematic(title="T", snap_mode=SnapMode.OFF)
+        sch._symbol_defs["Device:R"] = mock_symbol_def
+        inst = sch.add_symbol("Device:R", x=0, y=0, ref="TP1", value="TP", in_bom=False, dnp=True)
+        assert inst.in_bom is False and inst.dnp is True
+        text = inst.to_sexp("proj", "/sheet")
+        assert "(in_bom no)" in text and "(dnp yes)" in text
+
+    # -- Synthesized power lib symbol (elements_mixin.py template) ---------
+
+    def test_add_pwr_symbol_default_lib_in_bom_yes(self):
+        sch = Schematic(title="T", snap_mode=SnapMode.OFF)
+        pwr = sch.add_pwr_symbol("VMOTOR", x=0, y=0)
+        assert pwr.in_bom is True
+        lib_node = sch._embedded_lib_symbols["kicad_tools_pwr:VMOTOR"]
+        assert str(lib_node.get("in_bom").get_first_atom()) == "yes"
+
+    def test_add_pwr_symbol_exclude_from_bom(self):
+        sch = Schematic(title="T", snap_mode=SnapMode.OFF)
+        pwr = sch.add_pwr_symbol("VMOTOR", x=0, y=0, in_bom=False, dnp=True)
+        assert pwr.in_bom is False and pwr.dnp is True
+        lib_node = sch._embedded_lib_symbols["kicad_tools_pwr:VMOTOR"]
+        assert str(lib_node.get("in_bom").get_first_atom()) == "no"

--- a/tests/test_symbol_generator.py
+++ b/tests/test_symbol_generator.py
@@ -525,6 +525,28 @@ class TestGenerateSymbolSexp:
         assert "(pin input" in sexp
         assert "(pin output" in sexp
 
+    def test_generate_default_in_bom_yes(self):
+        """Default SymbolDef emits (in_bom yes) — byte-identity guard (#4303)."""
+        sym = SymbolDef(
+            name="TestIC",
+            pins=[PinDef(number="1", name="P1", side=PinSide.LEFT)],
+        )
+        assert sym.in_bom is True
+        sexp = generate_symbol_sexp(sym)
+        assert "(in_bom yes)" in sexp
+        assert "(in_bom no)" not in sexp
+
+    def test_generate_exclude_from_bom(self):
+        """in_bom=False emits (in_bom no) in the generated library symbol (#4303)."""
+        sym = SymbolDef(
+            name="TestPoint",
+            pins=[PinDef(number="1", name="P1", side=PinSide.LEFT)],
+            in_bom=False,
+        )
+        sexp = generate_symbol_sexp(sym)
+        assert "(in_bom no)" in sexp
+        assert "(in_bom yes)" not in sexp
+
     def test_generate_with_properties(self):
         """Test generating symbol with properties."""
         sym = SymbolDef(


### PR DESCRIPTION
Closes #4303

## Problem
The schematic `schematic/models` symbol/element emit paths hardcoded `(in_bom yes)` / `(dnp no)`, so recipes could not emit an exclude-from-BOM or DNP symbol (test points, fiducials, mounting holes, logos, mechanical-only parts). Downstream this forced bare pads into the BOM and made `kct parts availability` flag them as unsourced, with the only workaround being to assign a real part number to a bare pad.

## Fix (issue tiers 1 + 2 + 3)
Drive the `(in_bom ...)` / `(dnp ...)` tokens from the model on **every** emit path the issue listed, instead of stamping literals:

| Path | File | Change |
|------|------|--------|
| `SymbolInstance.to_sexp_node` (model method) | `schematic/models/symbol.py` | reads `self.in_bom` / `self.dnp` |
| `SymbolInstance.to_sexp` (template string) | `schematic/models/symbol.py` | reads `self.in_bom` / `self.dnp` |
| `SymbolInstance.from_sexp` | `schematic/models/symbol.py` | parses tokens back (full round-trip) |
| `PowerSymbol.to_sexp_node` + `from_sexp` | `schematic/models/elements.py` | new `in_bom` / `dnp` fields |
| `generate_symbol_sexp` / `SymbolDef` | `schematic/symbol_generator.py` | library-def `(in_bom ...)` token (lib defs carry no `dnp`) |
| Synthesized power lib symbol template | `schematic/models/elements_mixin.py` | honors `in_bom` |

**Public API (tier 2):** `add_symbol` and `add_pwr_symbol` gain `in_bom: bool = True` and `dnp: bool = False`, threaded into the model. Docstrings document the exclude-from-BOM / DNP pattern (tier 3).

## Acceptance
- `in_bom=False` -> `(in_bom no)` and `dnp=True` -> `(dnp yes)` verified on **all** listed emit paths (model methods AND template strings), plus a serialize -> re-parse round-trip that reads the flags back.
- **Default byte-identity (load-bearing regression guard):** defaults preserve historical output exactly (`in_bom=True` -> `yes`, `dnp=False` -> `no`). Proven two ways:
  - UUID-normalized regeneration diff of board 01 (which exercises `add_symbol` + `add_pwr_symbol` + `add_power`) against its committed schematic is **empty**.
  - Fleet token survey: committed `boards/*/output/*.kicad_sch` contain only `(in_bom yes)` / `(dnp no)`.

## Tests
- New `TestSymbolBomDnp` in `tests/test_schematic_models.py` (SymbolInstance node + string paths, round-trip, defaults; PowerSymbol paths; `add_symbol` / `add_pwr_symbol` API).
- New `generate_symbol_sexp` in_bom cases in `tests/test_symbol_generator.py`.
- Full schematic suites green (`test_schematic_models`, `test_symbol_generator`, `test_schematic_editing`, `test_pwr_symbol_net_match`, `test_schematic`, plus adjacent BOM suites).

## Gates
- ruff check + format clean on touched files.
- mypy: 68 baseline errors on these files (pre-existing mixin `attr-defined`), 68 with changes — **0 new**.
- Diff scoped to schematic symbol-gen files + `add_symbol` API + tests; disjoint from in-flight `router/lattice/` and `parts/` work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)