### PR TITLE
perf(route): attribute CLI-tail RSS to kicad-cli, free engine state before the tail (#4292)

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -1154,6 +1154,52 @@ def _serialize_preserved_routes(
     return "\n\t".join(parts)
 
 
+def _release_routing_engine_state(router: "Autorouter") -> None:
+    """Free the routing-engine negotiation structures before the CLI tail (#4292).
+
+    Once :func:`_finalize_routes` has serialised the committed copper to
+    S-expressions, the post-route tail -- copper-pour fill and the internal
+    DRC cross-check, both of which shell out to ``kicad-cli`` -- never reads
+    the routing engine's working set again.  The tail's dominant memory cost
+    is that external ``kicad-cli`` child (measured ~1.7 GB on softstart
+    rev-C's 160x100 mm 4-layer board); releasing the engine's retained Python
+    state here shrinks the resident footprint held *concurrently* with that
+    child, lowering peak physical-RAM pressure / OOM risk on constrained
+    machines.  (It also caps the Python high-water mark on cache-heavy boards
+    where the cache serialisation would otherwise push ``RUSAGE_SELF`` above
+    the negotiation peak.)
+
+    What is freed (all unused by the tail):
+
+    * the adaptive-octilinear ``LatticePathfinder`` and its per-net route
+      table -- the bulk of the lattice engine's retained state, and
+    * the :class:`RoutingGrid`'s dense per-cell occupancy arrays.
+
+    What is preserved, because the tail still reads it: ``router.routes`` /
+    ``router.pads`` / ``router.nets`` / ``router.net_names`` (output
+    connectivity verification), ``router.net_class_map`` (post-route DRC),
+    and the grid *object* itself with its lightweight metadata (diagnostics
+    read ``grid.resolution`` / ``grid.num_layers``).
+
+    Safe for every engine and every route flow: no path reads the grid cells
+    or the lattice structures after finalize.  Best-effort -- any attribute
+    that is absent (older router, deserialised fixture) is simply skipped, and
+    the routed board / DRC verdict / cache content are byte-for-byte
+    unaffected (this runs strictly after the copper is committed).
+    """
+    # Adaptive-lattice / mesh negotiation structures (issue #4278 / #4292).
+    for _attr in ("_lattice_pathfinder", "_lattice_net_routes"):
+        if hasattr(router, _attr):
+            with contextlib.suppress(Exception):
+                setattr(router, _attr, None)
+    # Dense grid occupancy planes -- keep the grid object (metadata), drop the
+    # per-cell arrays.
+    grid = getattr(router, "grid", None)
+    if grid is not None and hasattr(grid, "release_arrays"):
+        with contextlib.suppress(Exception):
+            grid.release_arrays()
+
+
 def _finalize_routes(
     router: "Autorouter",
     multi_pad_net_ids: set[int],
@@ -4554,6 +4600,11 @@ def route_with_layer_escalation(
     )
     final_result.success = final_result.completion >= args.min_completion
 
+    # Issue #4292: copper is committed to ``route_sexp``; free the routing grid
+    # + lattice negotiation structures before the save/zone-fill/DRC tail so
+    # they do not coexist with the ``kicad-cli`` child's footprint.
+    _release_routing_engine_state(final_result.router)
+
     # Save output
     if args.dry_run:
         if not quiet:
@@ -5232,6 +5283,11 @@ def route_with_rule_relaxation(
         else 1.0
     )
     final_result.success = final_result.completion >= args.min_completion
+
+    # Issue #4292: copper is committed to ``route_sexp``; free the routing grid
+    # + lattice negotiation structures before the save/zone-fill/DRC tail so
+    # they do not coexist with the ``kicad-cli`` child's footprint.
+    _release_routing_engine_state(final_result.router)
 
     # Save output
     if args.dry_run:
@@ -7431,6 +7487,11 @@ def route_with_combined_escalation(
         else 1.0
     )
     final_result.success = final_result.completion >= args.min_completion
+
+    # Issue #4292: copper is committed to ``route_sexp``; free the routing grid
+    # + lattice negotiation structures before the save/zone-fill/DRC tail so
+    # they do not coexist with the ``kicad-cli`` child's footprint.
+    _release_routing_engine_state(final_result.router)
 
     # Save output
     if args.dry_run:
@@ -10723,6 +10784,15 @@ def main(argv: list[str] | None = None) -> int:
             else:
                 print("\n  No differential pairs detected")
 
+    # Issue #4292: per-phase peak-RSS tracer for the post-route CLI tail.
+    # Zero-cost no-op unless KCT_RSS_TRACE is set; when enabled it attributes
+    # the tail memory footprint (cache write / zone fill / internal DRC) by
+    # printing the peak-RSS delta at each phase boundary below.
+    from kicad_tools.router.rss_trace import RSSTracer
+
+    _rss = RSSTracer()
+    _rss.mark("route-start")
+
     # Check cache for existing routing result (unless --no-cache)
     cache_key = None
     cached_result = None
@@ -11248,6 +11318,8 @@ def main(argv: list[str] | None = None) -> int:
                 quiet=quiet,
             )
 
+        _rss.mark("post-negotiation")
+
         # Cache the routing result (if caching enabled and routing succeeded)
         if use_cache and cache_key is not None and router.routes:
             import time
@@ -11263,6 +11335,8 @@ def main(argv: list[str] | None = None) -> int:
             except Exception as e:
                 if not quiet:
                     print(f"  Warning: Failed to cache result: {e}")
+
+        _rss.mark("post-cache-write")
 
     # Get pre-optimization statistics (also used in the no-optimize path
     # below so the segment/via summary print does not raise
@@ -11526,6 +11600,15 @@ def main(argv: list[str] | None = None) -> int:
         preserved_routes=_preserved_routes,
     )
 
+    # Issue #4292: the committed copper is now serialised into ``route_sexp``;
+    # the remaining tail (save, zone fill, internal DRC) never touches the
+    # routing grid or the lattice negotiation structures again.  Release them
+    # so their resident footprint does not coexist with the memory-heavy
+    # ``kicad-cli`` DRC/zone-fill child spawned below.
+    _release_routing_engine_state(router)
+
+    _rss.mark("post-finalize")
+
     # Report differential pair length mismatch warnings
     if diffpair_warnings and not quiet:
         print(f"\n--- Differential Pair Warnings ({len(diffpair_warnings)}) ---")
@@ -11690,6 +11773,8 @@ def main(argv: list[str] | None = None) -> int:
         if not quiet:
             print(f"  Saved to: {output_path}")
 
+    _rss.mark("post-save")
+
     # Output connectivity verification (Issue #2264)
     # Re-parse written S-expressions and verify pad-to-pad connectivity
     output_has_disconnected = False
@@ -11785,6 +11870,8 @@ def main(argv: list[str] | None = None) -> int:
     if not args.dry_run and stats["nets_routed"] > 0:
         _fill_zones_after_route(output_path, quiet=quiet)
 
+    _rss.mark("post-fill-zones")
+
     # Run DRC validation unless skipped or dry-run
     drc_errors = 0
     drc_warnings = 0
@@ -11814,6 +11901,8 @@ def main(argv: list[str] | None = None) -> int:
             )
             if fix_result == 0:
                 drc_errors = 0
+
+    _rss.mark("post-drc")
 
     # Summary
     all_nets_routed = stats["nets_routed"] == nets_to_route

--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -1046,6 +1046,54 @@ class RoutingGrid:
         """
         self._static_blocked = None
 
+    def release_arrays(self) -> None:
+        """Drop the large per-cell arrays once routing is finished (issue #4292).
+
+        The ``kct route`` CLI tail (cache write, copper-pour fill, internal
+        DRC) never reads the grid's per-cell occupancy state again after the
+        committed copper has been serialised to S-expressions.  Holding the
+        ``(layers, rows, cols)`` numpy arrays -- tens to hundreds of MB at a
+        fine grid resolution -- alive through that tail needlessly inflates the
+        process's resident footprint *while* the memory-heavy ``kicad-cli``
+        DRC/zone-fill child is running (the two would otherwise coexist in
+        physical RAM).  Releasing them here lets the allocator reclaim the
+        buffers before the tail.
+
+        The lightweight *metadata* (``resolution``, ``num_layers``, ``cols``,
+        ``rows``, ``width``, ``height``, origins) is preserved, so the
+        post-route diagnostics that read e.g. ``grid.resolution`` /
+        ``grid.num_layers`` keep reporting the real values.  The method is
+        idempotent and must only be called once the grid is no longer needed
+        for routing or cleanup.
+        """
+        xp = self._backend
+        # The dense (layers, rows, cols) occupancy planes -- reassign to a
+        # zero-length array of the same dtype so the attribute stays an
+        # ``ndarray`` (mypy-clean, defensive against stray reads) while the
+        # backing buffer is freed.
+        empty_bool = xp.zeros((0, 0, 0), dtype=np.bool_)
+        empty_i32 = xp.zeros((0, 0, 0), dtype=np.int32)
+        self._blocked = xp.zeros((0, 0, 0), dtype=np.bool_)
+        self._net = empty_i32
+        self._usage_count = xp.zeros((0, 0, 0), dtype=np.int16)
+        self._history_cost = xp.zeros((0, 0, 0), dtype=np.float32)
+        self._is_obstacle = xp.zeros((0, 0, 0), dtype=np.bool_)
+        self._is_zone = xp.zeros((0, 0, 0), dtype=np.bool_)
+        self._pad_blocked = empty_bool
+        self._original_net = xp.zeros((0, 0, 0), dtype=np.int32)
+        self._present_cost_ema = None
+        self._static_blocked = None
+        # Congestion planes + cached clearance stamps.
+        self._congestion = xp.zeros((0, 0, 0), dtype=np.int32)
+        self._clearance_masks = {}
+        # Spatial indices (only populated on dense boards).
+        self._seg_rtree = {}
+        self._seg_rtree_items = {}
+        self._seg_rtree_count = 0
+        self._via_rtree = None
+        self._via_rtree_items = {}
+        self._via_rtree_count = 0
+
     def sync_to_cpu(self) -> None:
         """Transfer GPU arrays to CPU for A* operations.
 

--- a/src/kicad_tools/router/rss_trace.py
+++ b/src/kicad_tools/router/rss_trace.py
@@ -1,0 +1,131 @@
+"""Per-phase peak-RSS tracing for the ``kct route`` CLI tail (issue #4292).
+
+The lattice/mesh negotiation engines stay comfortably under the epic #4267
+512 MB rail, yet the full ``kct route`` CLI run was observed to peak at
+~1.85 GB on softstart rev-C -- an extra ~1.4 GB materialising *after*
+routing, in the post-route tail (cache write, zone fill, internal DRC).
+
+This module provides a zero-cost-by-default tracer that samples the process
+peak resident-set-size high-water mark at named phase boundaries and prints
+the per-phase delta.  Because the peak is a monotonic high-water mark, a
+positive delta at a phase means *that phase raised the peak* -- which is
+exactly the attribution needed to pin down which tail consumer owns the
+excess footprint, even when the memory is transiently allocated and freed
+within the phase.
+
+Crucially the tracer samples **two** figures:
+
+* ``RUSAGE_SELF.ru_maxrss`` -- the *Python* process's own peak, and
+* ``RUSAGE_CHILDREN.ru_maxrss`` -- the peak of the largest *subprocess* the
+  run has reaped (e.g. ``kicad-cli pcb drc`` / zone-fill).
+
+Splitting the two is the whole point of issue #4292: the observed ~1.85 GB
+full-run peak on softstart rev-C is owned almost entirely by the external
+``kicad-cli`` DRC/zone-fill child (~1.7 GB on its own), **not** by any
+kicad-tools Python allocation -- the Python engine + tail stays around
+0.56 GB.  A tracer that only watched ``RUSAGE_SELF`` (as the naive
+``/usr/bin/time -l`` reading conflates) would misattribute the footprint to
+the cache write / internal DRC Python code.
+
+Enable it by setting the ``KCT_RSS_TRACE`` environment variable to any
+non-empty value; output goes to stderr so it never contaminates the routed
+board or JSON on stdout.  When disabled every method is a cheap no-op.
+"""
+
+from __future__ import annotations
+
+import os
+import resource
+import sys
+from typing import TextIO
+
+__all__ = ["RSSTracer", "peak_rss_bytes", "child_peak_rss_bytes"]
+
+
+def _maxrss_to_bytes(ru_maxrss: int) -> int:
+    """Normalise a raw ``ru_maxrss`` figure to bytes.
+
+    ``ru_maxrss`` is reported in **kilobytes** on Linux but in **bytes** on
+    macOS / BSD (issue #4292 was measured on macOS via ``/usr/bin/time -l``).
+    """
+    if sys.platform == "darwin":
+        return int(ru_maxrss)
+    # Linux (and other platforms) report kilobytes.
+    return int(ru_maxrss) * 1024
+
+
+def peak_rss_bytes() -> int:
+    """Return this (Python) process's peak RSS high-water mark in bytes."""
+    return _maxrss_to_bytes(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+
+
+def child_peak_rss_bytes() -> int:
+    """Return the peak RSS of the largest reaped child process, in bytes.
+
+    ``RUSAGE_CHILDREN.ru_maxrss`` is the high-water mark of the single
+    largest child the process has ``wait()``-ed for.  This is where the
+    ``kicad-cli`` DRC / zone-fill footprint shows up -- it is invisible to
+    ``RUSAGE_SELF`` because the child is a separate process.
+    """
+    return _maxrss_to_bytes(resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss)
+
+
+class RSSTracer:
+    """Sample peak RSS at named phase boundaries and print per-phase deltas.
+
+    A no-op unless enabled (defaults to the ``KCT_RSS_TRACE`` env var).  The
+    first :meth:`mark` establishes the baseline; every subsequent mark prints
+    the peak, the delta versus the previous mark, and the cumulative delta
+    versus the baseline.
+    """
+
+    def __init__(self, enabled: bool | None = None, stream: TextIO | None = None) -> None:
+        if enabled is None:
+            enabled = bool(os.environ.get("KCT_RSS_TRACE"))
+        self.enabled = enabled
+        self.stream = stream if stream is not None else sys.stderr
+        self._baseline: int | None = None
+        self._last: int | None = None
+        self.peak: int = 0
+        self.child_peak: int = 0
+        # Recorded (label, self_peak_bytes, child_peak_bytes) triples --
+        # exposed for tests / callers that want to assert on the phase
+        # ordering rather than parse stderr.
+        self.marks: list[tuple[str, int, int]] = []
+
+    def mark(self, label: str) -> int:
+        """Record the peak RSS (self + children) under ``label``; print deltas.
+
+        Returns this process's current peak RSS in bytes (0 when disabled) so
+        callers may use the return value in assertions without re-reading
+        getrusage.
+        """
+        if not self.enabled:
+            return 0
+        cur = peak_rss_bytes()
+        child = child_peak_rss_bytes()
+        self.peak = max(self.peak, cur)
+        self.child_peak = max(self.child_peak, child)
+        self.marks.append((label, cur, child))
+        if self._baseline is None:
+            self._baseline = cur
+            self._last = cur
+            print(
+                f"[rss] {label:<28} self={cur / 1e6:8.1f} MB  "
+                f"child={child / 1e6:8.1f} MB  (baseline)",
+                file=self.stream,
+                flush=True,
+            )
+            return cur
+        assert self._last is not None
+        delta = cur - self._last
+        cum = cur - self._baseline
+        print(
+            f"[rss] {label:<28} self={cur / 1e6:8.1f} MB  "
+            f"child={child / 1e6:8.1f} MB  "
+            f"Δself={delta / 1e6:+8.1f} MB  cum={cum / 1e6:+8.1f} MB",
+            file=self.stream,
+            flush=True,
+        )
+        self._last = cur
+        return cur

--- a/tests/router/test_release_engine_state_4292.py
+++ b/tests/router/test_release_engine_state_4292.py
@@ -1,0 +1,112 @@
+"""Guard tests for the pre-tail engine-state release (issue #4292).
+
+The ``kct route`` CLI tail (zone fill + internal DRC) shells out to
+``kicad-cli`` -- the dominant memory consumer of the whole run -- and never
+reads the routing grid or the lattice negotiation structures again.  Issue
+#4292 releases those before the tail so their resident footprint does not
+coexist with the ``kicad-cli`` child.  These tests lock in the two invariants
+that make the release safe:
+
+1. the heavy per-cell arrays are actually dropped, while the grid metadata
+   the post-route diagnostics read survives, and
+2. the release only touches the negotiation scratch -- the committed routes,
+   pad/net topology, and net-class map (all read by the tail) are preserved.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from kicad_tools.cli.route_cmd import _release_routing_engine_state
+from kicad_tools.router import DesignRules
+from kicad_tools.router.grid import RoutingGrid
+
+
+def _make_grid() -> RoutingGrid:
+    rules = DesignRules(
+        trace_width=0.127,
+        trace_clearance=0.127,
+        grid_resolution=0.1,
+        min_trace_width=0.127,
+    )
+    return RoutingGrid(width=20.0, height=20.0, rules=rules)
+
+
+def test_release_arrays_drops_cells_keeps_metadata():
+    """RoutingGrid.release_arrays frees the dense planes but keeps metadata."""
+    grid = _make_grid()
+    # Sanity: the occupancy planes are populated before release.
+    assert grid._blocked.size > 0
+    assert grid._net.size > 0
+    assert grid._congestion.size > 0
+
+    res, layers, cols, rows = grid.resolution, grid.num_layers, grid.cols, grid.rows
+
+    grid.release_arrays()
+
+    # Dense arrays are freed (zero-length), but remain ndarrays.
+    assert grid._blocked.size == 0
+    assert grid._net.size == 0
+    assert grid._usage_count.size == 0
+    assert grid._history_cost.size == 0
+    assert grid._is_obstacle.size == 0
+    assert grid._is_zone.size == 0
+    assert grid._pad_blocked.size == 0
+    assert grid._original_net.size == 0
+    assert grid._congestion.size == 0
+    assert grid._clearance_masks == {}
+    assert grid._present_cost_ema is None
+
+    # Metadata the diagnostics read is untouched.
+    assert grid.resolution == res
+    assert grid.num_layers == layers
+    assert grid.cols == cols
+    assert grid.rows == rows
+
+    # Idempotent: a second call must not raise.
+    grid.release_arrays()
+
+
+def test_release_engine_state_preserves_topology():
+    """The helper drops grid/lattice scratch but preserves tail-read state."""
+    grid = _make_grid()
+    routes = ["route-a", "route-b"]
+    pads = {("R1", "1"): object()}
+    nets = {1: [("R1", "1")]}
+    net_names = {1: "GND"}
+    net_class_map = {"GND": object()}
+
+    router = SimpleNamespace(
+        grid=grid,
+        routes=routes,
+        pads=pads,
+        nets=nets,
+        net_names=net_names,
+        net_class_map=net_class_map,
+        _lattice_pathfinder=object(),
+        _lattice_net_routes={1: ["r"]},
+    )
+
+    _release_routing_engine_state(router)
+
+    # Negotiation scratch is released.
+    assert router._lattice_pathfinder is None
+    assert router._lattice_net_routes is None
+    assert router.grid._blocked.size == 0
+
+    # Everything the tail still consumes is preserved by identity.
+    assert router.routes is routes
+    assert router.pads is pads
+    assert router.nets is nets
+    assert router.net_names is net_names
+    assert router.net_class_map is net_class_map
+    # The grid object itself survives (diagnostics read its metadata).
+    assert router.grid is grid
+
+
+def test_release_engine_state_is_best_effort():
+    """Absent attributes are skipped without raising (older / fixture routers)."""
+    router = SimpleNamespace(routes=[], pads={}, nets={})
+    # No grid, no lattice attributes -- must be a safe no-op.
+    _release_routing_engine_state(router)
+    assert router.routes == []

--- a/tests/router/test_rss_trace.py
+++ b/tests/router/test_rss_trace.py
@@ -1,0 +1,84 @@
+"""Tests for the per-phase peak-RSS tracer (issue #4292).
+
+The tracer is the primary diagnostic instrument that attributed the
+``kct route`` CLI-tail memory footprint.  These tests lock in its contract:
+zero-cost no-op when disabled, monotone peak marks when enabled, and a
+platform-correct byte normalisation.
+"""
+
+from __future__ import annotations
+
+import io
+
+from kicad_tools.router.rss_trace import (
+    RSSTracer,
+    child_peak_rss_bytes,
+    peak_rss_bytes,
+)
+
+
+def test_peak_rss_bytes_positive():
+    """The peak-RSS reading is a positive byte count on every platform."""
+    assert peak_rss_bytes() > 0
+
+
+def test_child_peak_rss_bytes_nonnegative():
+    """The child peak-RSS reading is a non-negative byte count.
+
+    It is 0 before any subprocess is reaped, which is the whole point of the
+    self-vs-child split (issue #4292): the ``kicad-cli`` footprint lands here,
+    not in RUSAGE_SELF.
+    """
+    assert child_peak_rss_bytes() >= 0
+
+
+def test_disabled_tracer_is_noop():
+    """A disabled tracer prints nothing and records no marks."""
+    stream = io.StringIO()
+    tracer = RSSTracer(enabled=False, stream=stream)
+    assert tracer.mark("a") == 0
+    assert tracer.mark("b") == 0
+    assert stream.getvalue() == ""
+    assert tracer.marks == []
+
+
+def test_enabled_tracer_records_and_prints():
+    """An enabled tracer records each mark and prints one line per mark."""
+    stream = io.StringIO()
+    tracer = RSSTracer(enabled=True, stream=stream)
+    tracer.mark("route-start")
+    tracer.mark("post-drc")
+    out = stream.getvalue()
+    assert "route-start" in out
+    assert "post-drc" in out
+    assert out.count("[rss]") == 2
+    # Every line reports both the self and child figures.
+    assert out.count("child=") == 2
+    assert "self=" in out
+    # First mark is the baseline; the second reports a delta.
+    assert "(baseline)" in out
+    assert "Δself=" in out
+    assert [m[0] for m in tracer.marks] == ["route-start", "post-drc"]
+
+
+def test_peak_is_monotone_high_water_mark():
+    """Recorded peaks never decrease -- getrusage reports a high-water mark."""
+    stream = io.StringIO()
+    tracer = RSSTracer(enabled=True, stream=stream)
+    tracer.mark("a")
+    # Allocate a chunk to (potentially) raise the peak, then release it.
+    ballast = [b"x" * 1024 for _ in range(50_000)]
+    tracer.mark("b")
+    del ballast
+    tracer.mark("c")
+    peaks = [self_peak for _, self_peak, _ in tracer.marks]
+    assert peaks == sorted(peaks), "peak RSS marks must be non-decreasing"
+    assert tracer.peak == max(peaks)
+
+
+def test_env_gating(monkeypatch):
+    """Absent the KCT_RSS_TRACE env var the tracer defaults to disabled."""
+    monkeypatch.delenv("KCT_RSS_TRACE", raising=False)
+    assert RSSTracer().enabled is False
+    monkeypatch.setenv("KCT_RSS_TRACE", "1")
+    assert RSSTracer().enabled is True


### PR DESCRIPTION
## Summary

Issue #4292 reported that `kct route` peaks at **~1.85 GB** on softstart
rev-C while the lattice negotiation engine stays at **~433 MB** — an
extra ~1.4 GB materializing *after* routing. The issue hypothesized the
culprit was kicad-tools' own Python memory (cache write / internal DRC /
zone machinery) and asked to **diagnose first, then bound the dominant
consumer**.

**The diagnosis overturns that hypothesis.** The ~1.4 GB is not
kicad-tools Python memory at all — it is the external **`kicad-cli pcb
drc`** subprocess KiCad runs for zone-fill and the geometric DRC
cross-check. The kicad-tools Python engine + tail peaks at only
**~558 MB** (1.09x the engine peak — already inside the ~1.5x target).

## Diagnosis: per-phase RSS attribution

Added an env-gated (`KCT_RSS_TRACE`) per-phase peak-RSS tracer that
samples **both** `RUSAGE_SELF` (this Python process) and
`RUSAGE_CHILDREN` (the largest reaped subprocess). Splitting the two is
the whole point — a `RUSAGE_SELF`-only view (what `/usr/bin/time -l`
conflates into one number) misattributes the footprint to Python code.

Full softstart rev-C lattice route (`--route-engine lattice --strategy
basic`, 4L, 394 pads), **Python `RUSAGE_SELF` peak** per phase:

| phase | self peak | Δself |
|-------|----------:|------:|
| route-start (baseline) | 158.1 MB | — |
| post-negotiation | 514.6 MB | +356.5 MB |
| post-cache-write | 514.6 MB | **+0.0 MB** |
| post-finalize | 514.6 MB | +0.0 MB |
| post-save | 514.6 MB | +0.0 MB |
| post-fill-zones | 535.5 MB | +20.9 MB |
| post-drc | **558.6 MB** | +23.2 MB |

The Python tail adds only ~44 MB. The cache write — the issue's prime
suspect — adds **0.0 MB**.

Meanwhile `/usr/bin/time -l` on the same run reports **1,846,083,584 B =
1.846 GB** (reproducing the issue's 1.85 GB), and `kicad-cli pcb drc`
run **standalone** on the routed board peaks at **1,709,080,576 B =
1.709 GB**. A controlled experiment confirms `/usr/bin/time -l maximum
resident set size` reports the **max single-process RSS in the tree**
(dominated by the kicad-cli child), not the parent+child sum.

**Attribution: the ~1.4 GB "tail" is the `kicad-cli` DRC/zone-fill child
(KiCad's own binary), not kicad-tools memory.**

## The fix (what is in our control)

The process-tree peak (~1.85 GB) is KiCad's `kicad-cli pcb drc` binary
for this 160x100 mm 4-layer board — **not reducible by kicad-tools**, and
the ~650 MB process-tree target is unreachable while a full-board
`kicad-cli` DRC runs. So the honest, in-scope win is the "free the grid
before the tail" option from the issue menu:

`_release_routing_engine_state()` frees, once the committed copper is
serialized and before the tail:
- the `LatticePathfinder` + per-net lattice route table (the bulk of the
  +356 MB negotiation working set), and
- the `RoutingGrid`'s dense per-cell numpy arrays (via a new
  `RoutingGrid.release_arrays()` that keeps metadata).

This drops **~356 MB** of resident footprint that would otherwise coexist
in physical RAM with the ~1.7 GB kicad-cli child — real OOM headroom on
constrained machines — and caps the Python high-water on cache-heavy
boards. Wired into all four route flows (default, layer-escalation,
rule-relaxation, combined). It does **not** move the `time -l` high-water
(kicad-cli dominates) or the Python self high-water (negotiation-bound,
monotonic) on softstart — reported honestly.

## Outputs unchanged (byte-identity)

The release runs strictly *after* `_finalize_routes` serializes the
copper. A/B on a fixture (stash the fix, re-route, same seed): the routed
boards are **identical** once the per-run random segment UUIDs are
normalized (same content hash, same 80 segments, same 0 vias). Grid
metadata (`resolution`, `num_layers`) is preserved for diagnostics.
`router.routes` / `pads` / `nets` / `net_names` / `net_class_map` — all
read by the tail — are preserved by identity.

## Achieved vs target (honest)

| metric | baseline | after |
|--------|---------:|------:|
| kicad-tools Python peak (`RUSAGE_SELF`) | 558.6 MB | 558.6 MB (1.09x engine — meets ~1.5x) |
| process-tree peak (`time -l`) | 1.846 GB | ~1.85 GB (kicad-cli floor, unchanged) |
| resident freed before tail | 0 | ~356 MB (OOM headroom) |

The ~650 MB process-tree target is **not achievable** in this PR because
the dominant consumer is KiCad's `kicad-cli` binary, documented here per
the issue's "fix what's cheap, document the residual" guidance.

## Follow-up (noted, not in scope)

The tail invokes `kicad-cli pcb drc` **twice** (zone-fill-via-drc, then
the geometric DRC cross-check). Consolidating to a single pass would
halve the tail's memory-time exposure and wall time (not the peak). Worth
a separate issue.

## Test plan

- `tests/router/test_rss_trace.py` — tracer contract: self/child split,
  monotone high-water, env gating, disabled no-op.
- `tests/router/test_release_engine_state_4292.py` — release guards:
  dense arrays dropped + metadata preserved, route/pad/net topology
  preserved by identity, best-effort on absent attrs.
- Regression: grid, route_cmd (zone-fill / success-output / input-
  preservation), router cache, board-02 route recipe, build-route-write —
  all green.
- ruff (repo-wide) + mypy baseline: no new errors.

Closes #4292