### PR TITLE
fix(router): correct nonexistent NetClassRouting.min_trace_width in rationale

### DIFF
--- a/.github/mypy-baseline.txt
+++ b/.github/mypy-baseline.txt
@@ -871,7 +871,6 @@ src/kicad_tools/router/core.py	assignment	Incompatible types in assignment (expr
 src/kicad_tools/router/core.py	assignment	Incompatible types in assignment (expression has type "str | None", variable has type "MatchGroup")
 src/kicad_tools/router/core.py	assignment	Incompatible types in assignment (expression has type "str", variable has type "MatchGroup")
 src/kicad_tools/router/core.py	assignment	Incompatible types in assignment (expression has type "tuple[int, tuple[Any, Any, Any, Any]]", variable has type "tuple[float, float]")
-src/kicad_tools/router/core.py	attr-defined	"NetClassRouting" has no attribute "min_trace_width"; maybe "trace_width" or "neck_trace_width"?
 src/kicad_tools/router/core.py	attr-defined	"Segment" has no attribute "end_x"
 src/kicad_tools/router/core.py	attr-defined	"Segment" has no attribute "end_y"
 src/kicad_tools/router/core.py	attr-defined	"Segment" has no attribute "start_x"; maybe "start"?

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -3227,7 +3227,7 @@ class Autorouter:
         if net_class:
             if net_class.priority <= 1:
                 rationale_parts.append(f"High-priority net ({net_class.__class__.__name__})")
-            rationale_parts.append(f"Routed with {net_class.min_trace_width}mm min trace width")
+            rationale_parts.append(f"Routed with {net_class.trace_width}mm trace width")
             if net_class.clearance:
                 rationale_parts.append(f"{net_class.clearance}mm clearance")
 

--- a/tests/test_router_core.py
+++ b/tests/test_router_core.py
@@ -4844,3 +4844,50 @@ class TestStagnationRecovery:
             assert "Stagnation recovery" in captured.out, (
                 "Stalls were detected without stagnation recovery firing.\n" + captured.out[-2000:]
             )
+
+
+class TestRecordRoutingDecisionRationale:
+    """Regression tests for the routing-rationale builder (Issue #4305).
+
+    ``_record_routing_decision`` read a nonexistent
+    ``NetClassRouting.min_trace_width`` attribute, which would raise
+    ``AttributeError`` whenever a net class was present while assembling the
+    human-readable rationale. No prior test constructed a real ``net_class``
+    and reached that append, so the bug stayed latent (mypy flagged it but the
+    error was suppressed in the baseline). These tests exercise the branch so
+    the fix (``trace_width``) is locked in.
+    """
+
+    def test_rationale_uses_net_class_trace_width(self):
+        """Rationale reaches the trace-width append without raising."""
+        from kicad_tools.explain.decisions import Decision
+        from kicad_tools.router.rules import NetClassRouting
+
+        router = Autorouter(width=50.0, height=40.0, record_decisions=True)
+
+        net_id = 7
+        net_name = "PWR"
+        router.net_names[net_id] = net_name
+        router.net_class_map[net_name] = NetClassRouting(
+            name="power", priority=1, trace_width=0.5, clearance=0.3
+        )
+
+        # ``_record_routing_decision`` guards on ``if not self._decision_store``,
+        # and ``DecisionStore.__len__`` makes an empty store falsy — so the
+        # store must be non-empty for the rationale branch to run at all. Seed
+        # one unrelated decision to get past that guard.
+        store = router.get_decision_store()
+        assert store is not None
+        store.record(Decision.create(action="place", components=["U1"], rationale="seed"))
+
+        # Pre-fix this raised AttributeError on ``min_trace_width``.
+        router._record_routing_decision(net_id, [])
+
+        decisions = store.query(net=net_name, action="route")
+        assert len(decisions) == 1
+
+        rationale = decisions[0].rationale
+        # The correct field value (trace_width=0.5) must appear, phrased as
+        # a plain trace width rather than the bogus "min trace width".
+        assert "0.5mm trace width" in rationale
+        assert "min_trace_width" not in rationale


### PR DESCRIPTION
## Summary
`src/kicad_tools/router/core.py:3230` (the routing-rationale builder in `_record_routing_decision`) read `net_class.min_trace_width`, an attribute that does **not** exist on `NetClassRouting` (its width fields are `trace_width` and `neck_trace_width`, `rules.py:723`). Whenever a `net_class` was present while assembling the human-readable rationale, this raised `AttributeError`. It stayed latent because no test exercised the branch, and mypy's `attr-defined` error was suppressed in `.github/mypy-baseline.txt`.

## Changes
- **`core.py`**: `net_class.min_trace_width` -> `net_class.trace_width` (the per-net-class width), rephrased to `"Routed with {trace_width}mm trace width"`. One-line fix.
- **`tests/test_router_core.py`**: new `TestRecordRoutingDecisionRationale` regression test that constructs an `Autorouter` with a populated `net_class_map` containing a real `NetClassRouting`, reaches the rationale branch, and asserts it does not raise and emits the correct trace-width text. **Fails pre-fix** (`AttributeError: 'NetClassRouting' object has no attribute 'min_trace_width'`), **passes post-fix** — verified both directions.
  - Note: the test seeds one unrelated decision first, because `_record_routing_decision` guards on `if not self._decision_store` and `DecisionStore.__len__` makes an empty store falsy (an unrelated pre-existing quirk); the seed is required to reach the branch at all.
- **`.github/mypy-baseline.txt`**: surgical single-line deletion of the stale `min_trace_width` `attr-defined` entry. Did **not** run `--update` (which, with the native ext built, would also drop the env-agnostic nanobind `import-not-found` line and break CI's no-native Type Check job). Both nanobind signature lines remain byte-untouched.

## Gates
- Native backend built (`kct build-native`).
- `check_mypy_baseline.py` exits 0, "No new type errors"; both nanobind signature lines intact; `min_trace_width` line removed.
- `ruff check` + `ruff format --check`: clean.
- `test_router_core.py` (190 tests) + `test_manufacturer_propagation_lint.py` (MFR001): green.

Closes #4305

🤖 Generated with [Claude Code](https://claude.com/claude-code)