### PR TITLE
docs: fix stale WORKFLOWS.md link + bump What's New to v0.16.0 (/repo:all hygiene)

### DIFF
--- a/.github/CONFIGURATION.md
+++ b/.github/CONFIGURATION.md
@@ -68,7 +68,7 @@ The issue template integrates with Loom's label-based workflow coordination:
 | `loom:reviewing` | Judge is actively reviewing | Judge agent |
 | `loom:pr` | Approved for merge | Judge agent |
 
-See [WORKFLOWS.md](../../WORKFLOWS.md) for complete workflow documentation.
+See [.loom/CLAUDE.md](../.loom/CLAUDE.md) for complete workflow documentation.
 
 ## Benefits
 

--- a/README.md
+++ b/README.md
@@ -592,7 +592,7 @@ All commands support `--format json` for machine-readable output.
 | `mcp` | MCP server for AI agent integration |
 | `layout` | Layout preservation for PCB regeneration |
 
-## What's New (v0.15.0, July 2026)
+## What's New (v0.16.0, July 2026)
 
 Recent additions an agent reading these docs cold should know about:
 


### PR DESCRIPTION
Two stale-reference fixes surfaced by the `/repo:all` documentation audit:

1. **`.github/CONFIGURATION.md:71`** — `See [WORKFLOWS.md](../../WORKFLOWS.md)` pointed to a repo-root `WORKFLOWS.md` that does not exist (the #4240 cross-ref repoint covered `docs/` but not `.github/`). Repointed to `.loom/CLAUDE.md`, which holds the complete label-lifecycle / workflow documentation.
2. **`README.md:595`** — "What's New (**v0.15.0**, July 2026)" was one release behind; `pyproject.toml` and the top CHANGELOG entry are both **0.16.0**. Bumped the marker (content unchanged — a curated "recent additions" list, not a version-bound changelog).

Docs-only, no code. The `docs/` tree itself audited link-clean (no #4240 regressions). Other audit findings (undocumented experimental `--route-engine`, CHANGELOG/WORK_LOG at next release) were judgment/informational and deliberately left for a release pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)