### PR TITLE
feat(route): warn when --layers auto strands pour-net/high-ampacity nets on inner layers

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 4308
-# Branch: feature/issue-4308
+# Issue: 4314
+# Branch: feature/issue-4314
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -3165,7 +3165,11 @@ def _add_route_parser(subparsers) -> None:
             "'4' = 4-layer with GND/PWR planes; "
             "'4-sig' = 4-layer with 2 signal layers; "
             "'4-all' = 4-layer with all 4 signal layers (no planes); "
-            "'6' = 6-layer"
+            "'6' = 6-layer. "
+            "Pass '4' when your net-class-map declares is_pour_net / plane "
+            "nets so inner layers are reserved for planes: 'auto' infers "
+            "planes only from zones already in the input PCB and cannot see "
+            "pour nets added post-route."
         ),
     )
     route_parser.add_argument(
@@ -6408,7 +6412,10 @@ def _add_pipeline_parser(subparsers) -> None:
             "'auto' = auto-detect from PCB (default when omitted); "
             "'2' = 2-layer; '4' = 4-layer with GND/PWR planes; "
             "'4-sig' = 4-layer with 2 signal + 1 ground plane; "
-            "'4-all' = 4-layer all-signal; '6' = 6-layer"
+            "'4-all' = 4-layer all-signal; '6' = 6-layer. "
+            "Pass '4' when your net-class-map declares is_pour_net / plane "
+            "nets so inner layers are reserved for planes ('auto' cannot see "
+            "pour nets added post-route)."
         ),
     )
     pipeline_parser.add_argument(

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -3277,6 +3277,73 @@ def _warn_unresolved_net_class_map(resolution, board_net_names, nearest_fn) -> N
     print("\n".join(lines), file=sys.stderr)
 
 
+def _resolve_mfr_design_rules(args, layer_stack):
+    """Resolve the manufacturer :class:`DesignRules` used for ampacity advisories.
+
+    Resolves the *same* manufacturer profile + copper weight the post-route
+    ampacity DRC resolves (:func:`run_post_route_drc` -> ``DRCChecker`` ->
+    ``get_profile(manufacturer).get_design_rules(layers, copper_oz)``), so
+    the route-time Tier-2 advisory (Issue #4314) derives its required
+    internal-copper width from the identical ``inner_copper_oz`` the DRC
+    uses -- the two numbers agree by construction.
+
+    Returns ``None`` (advisory suppressed, never fatal) when the
+    manufacturer is unknown or has no rules for this layer/copper key,
+    mirroring the graceful degradation of the DRC-constraint sidecar writer.
+    """
+    try:
+        from kicad_tools.manufacturers import get_profile
+
+        profile = get_profile(getattr(args, "manufacturer", "jlcpcb"))
+        return profile.get_design_rules(
+            layers=layer_stack.num_layers,
+            copper_oz=float(getattr(args, "copper_oz", 1.0) or 1.0),
+        )
+    except (ValueError, KeyError, OSError):
+        return None
+
+
+def _warn_layer_selection_advisories(args, layer_stack, *, is_auto: bool) -> None:
+    """Emit Issue #4314 route-time layer-selection advisories to stderr.
+
+    Two warn-floor guards, both advisory (printed to stderr, never suppressed
+    by ``--quiet``, exit code unchanged -- matching the #4149 net-class-map
+    diagnostic precedent above):
+
+    * **Tier 1** (``is_auto`` only): ``--layers auto`` picked a stack that
+      routes signal on inner layers while the loaded net-class-map declares
+      pour nets -- ``detect_layer_stack`` never saw that intent. Recommends
+      ``--layers 4``.
+    * **Tier 2** (any ``--layers`` that routes signal on inner layers): a
+      ``target_ampacity`` net whose required internal-copper width is
+      unroutable, predicting the post-route ampacity DRC failure at route
+      time. Uses the exact ``width_for_current`` call shape the DRC uses.
+
+    A pure no-op when the net-class-map declares neither pour nets nor
+    ``target_ampacity`` (drift-prevention contract).
+    """
+    from kicad_tools.router.layer_advisories import (
+        ampacity_inner_layer_conflicts,
+        pour_net_blind_auto_warning,
+    )
+
+    net_class_map = getattr(args, "_loaded_net_class_map", None)
+    lines: list[str] = []
+
+    if is_auto:
+        tier1 = pour_net_blind_auto_warning(layer_stack, net_class_map)
+        if tier1:
+            lines.append(tier1)
+
+    design_rules = _resolve_mfr_design_rules(args, layer_stack)
+    if design_rules is not None:
+        for conflict in ampacity_inner_layer_conflicts(net_class_map, design_rules, layer_stack):
+            lines.append(conflict.message)
+
+    if lines:
+        print("\n".join(lines), file=sys.stderr)
+
+
 def _resolve_analog_net_names(router: "Autorouter", args) -> set[str]:
     """Resolve the set of analog net names selected by the analog flags (#3171).
 
@@ -4817,6 +4884,10 @@ def route_with_rule_relaxation(
             "6": LayerStack.six_layer_sig_gnd_sig_sig_pwr_sig(),
         }
         layer_stack = layer_stack_map[args.layers]
+
+    # Issue #4314: warn if auto is pour-net-blind and/or a target_ampacity
+    # net would be stranded on an inner layer (advisory, never suppressed).
+    _warn_layer_selection_advisories(args, layer_stack, is_auto=args.layers == "auto")
 
     if not quiet:
         flush_print("=" * 60)
@@ -10271,6 +10342,10 @@ def main(argv: list[str] | None = None) -> int:
             "6": LayerStack.six_layer_sig_gnd_sig_sig_pwr_sig(),
         }
         layer_stack = layer_stack_map[args.layers]
+
+    # Issue #4314: warn if auto is pour-net-blind and/or a target_ampacity
+    # net would be stranded on an inner layer (advisory, never suppressed).
+    _warn_layer_selection_advisories(args, layer_stack, is_auto=args.layers == "auto")
 
     # Configure design rules
     grid_origin_offset = getattr(args, "_grid_origin_offset", (0.0, 0.0))

--- a/src/kicad_tools/router/layer_advisories.py
+++ b/src/kicad_tools/router/layer_advisories.py
@@ -1,0 +1,257 @@
+"""Route-time layer-selection advisories (Issue #4314).
+
+Warn-floor guards that surface two silent footguns in ``kct route``. Both
+are *advisory* -- they print to stderr and never change the exit code or
+the routed copper. They are the reporter's "or at minimum warn" floor for
+tiers 1 & 2 of Issue #4314; the deeper structural alternatives (reserving
+pour-net layers, deriving ``allowed_layers`` from ``target_ampacity``,
+making :meth:`LayerDefinition.is_routable` pour-aware) are deliberately
+deferred.
+
+Tier 1 -- pour-net-blind ``--layers auto``
+    :func:`kicad_tools.router.io.detect_layer_stack` infers the stack
+    solely from ``(zone ...)`` s-expressions physically drawn in the input
+    PCB and is never handed the loaded net-class-map. When a map declares
+    ``is_pour_net`` classes (the common workflow of adding GND/PWR planes
+    *post-route*), the input has no inner-layer zones, so auto silently
+    picks a signal-on-inner configuration and the A* engine is free to
+    route signal -- including high-current nets -- onto the layers the user
+    intended to reserve for planes. :func:`pour_net_blind_auto_warning`
+    detects this and recommends ``--layers 4``.
+
+Tier 2 -- ampacity-vs-inner-layer conflict
+    The route-time layer assignment never evaluates a net's
+    ``target_ampacity`` against the candidate inner layer's copper weight,
+    yet the post-route ampacity DRC classifies any non-``F.Cu``/``B.Cu``
+    layer as internal (IPC-2221 ``k = 0.024``) and can flag the router's
+    own inner-layer copper as impossibly under-rated (the reporter's
+    "requires 65.5 mm" self-contradiction).
+    :func:`ampacity_inner_layer_conflicts` predicts that DRC failure at
+    route time, reusing the *exact* ``width_for_current`` call shape the
+    DRC uses (``inner_copper_oz`` / ``layer="internal"``) so the route-time
+    number and the DRC number agree to the last digit.
+
+Drift-prevention contract
+    When the net-class-map declares no ``is_pour_net`` classes and no
+    ``target_ampacity``, every function here is a pure no-op (empty
+    result / ``None``), so a board without those declarations sees
+    byte-identical behavior and no new warnings -- mirroring the
+    declarative drift-prevention contract of the sibling ampacity DRC.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from kicad_tools.physics.ampacity import width_for_current
+from kicad_tools.router.layers import LayerType
+
+if TYPE_CHECKING:
+    from kicad_tools.manufacturers.base import DesignRules
+    from kicad_tools.router.layers import LayerStack
+    from kicad_tools.router.rules import NetClassRouting
+
+# Mirrors ``validate/rules/ampacity.py::_EXTERNAL_LAYERS`` /
+# ``AmpacityRule._is_external_layer`` exactly: any copper layer that is not
+# ``F.Cu`` / ``B.Cu`` is internal for IPC-2221's k constant. Keeping this
+# list identical is what makes the route-time advisory and the post-route
+# DRC bucket every layer the same way (Issue #4314 acceptance criterion).
+_EXTERNAL_LAYERS = ("F.Cu", "B.Cu")
+
+
+def is_external_layer(layer_name: str) -> bool:
+    """Return True for outer copper (``F.Cu`` / ``B.Cu``), False for internal.
+
+    Byte-identical to
+    :meth:`kicad_tools.validate.rules.ampacity.AmpacityRule._is_external_layer`
+    so the route-time advisory and the post-route DRC classify every layer
+    into the same internal/external bucket.
+    """
+    return layer_name in _EXTERNAL_LAYERS
+
+
+def declared_pour_net_names(
+    net_class_map: dict[str, NetClassRouting] | None,
+) -> list[str]:
+    """Return the names of net-class entries that declare ``is_pour_net``.
+
+    Args:
+        net_class_map: The ``{net_name: NetClassRouting}`` map loaded from a
+            ``--net-class-map`` sidecar (``args._loaded_net_class_map``).
+            ``None`` or empty yields ``[]``.
+
+    Returns:
+        Sorted names of entries whose class sets ``is_pour_net=True`` -- the
+        nets the user intends to serve with copper pours / plane layers.
+        Empty when the map is absent or declares no pour nets (the
+        drift-prevention no-op).
+    """
+    if not net_class_map:
+        return []
+    return sorted(name for name, nc in net_class_map.items() if getattr(nc, "is_pour_net", False))
+
+
+def stack_routes_signal_on_inner(layer_stack: LayerStack) -> bool:
+    """Return True if the stack places signal on any inner (non-outer) layer.
+
+    An inner signal layer is any layer that is not an outer (``F.Cu`` /
+    ``B.Cu``) layer and whose :class:`~kicad_tools.router.layers.LayerType`
+    is ``SIGNAL`` or ``MIXED`` (a split plane that still carries signal).
+    Plane layers do not count -- the plane-aware ``--layers 4`` stack
+    (``SIG-GND-PWR-SIG``) returns ``False`` here, which is exactly why
+    passing ``--layers 4`` silences both advisories.
+
+    Args:
+        layer_stack: The resolved stack for this route.
+
+    Returns:
+        True when signal may be routed onto an inner layer.
+    """
+    return any(
+        (not layer.is_outer) and layer.layer_type in (LayerType.SIGNAL, LayerType.MIXED)
+        for layer in layer_stack.layers
+    )
+
+
+def pour_net_blind_auto_warning(
+    layer_stack: LayerStack,
+    net_class_map: dict[str, NetClassRouting] | None,
+) -> str | None:
+    """Build the Tier-1 pour-net-blind-``auto`` warning, or ``None``.
+
+    Fires only when the auto-resolved ``layer_stack`` routes signal on inner
+    layers **and** the loaded net-class-map declares one or more
+    ``is_pour_net`` classes -- the exact combination in which
+    ``detect_layer_stack`` (which never sees the map) silently strands
+    plane intent.
+
+    Args:
+        layer_stack: The stack ``--layers auto`` selected.
+        net_class_map: The loaded ``{net_name: NetClassRouting}`` map.
+
+    Returns:
+        A loud, multi-clause warning string recommending ``--layers 4``, or
+        ``None`` when the condition does not hold (no pour nets, or the
+        stack already reserves its inner layers for planes).
+    """
+    if not stack_routes_signal_on_inner(layer_stack):
+        return None
+    pour_nets = declared_pour_net_names(net_class_map)
+    if not pour_nets:
+        return None
+    joined = ", ".join(pour_nets)
+    return (
+        f"WARNING: --layers auto selected '{layer_stack.name}', which routes "
+        f"signal on inner layers, but the net-class-map declares "
+        f"{len(pour_nets)} pour-net class(es): {joined}. Auto layer selection "
+        "infers planes only from zones already drawn in the input PCB, so "
+        "pour/plane nets you add post-route are invisible to it -- signal "
+        "(including high-current nets) may be routed onto your intended "
+        "plane layers, where it can never be manufactured to spec. "
+        "Pass --layers 4 to reserve the inner layers for GND/PWR planes."
+    )
+
+
+@dataclass(frozen=True)
+class AmpacityLayerConflict:
+    """A route-time ampacity-vs-inner-layer conflict for one net-class.
+
+    Attributes:
+        net_name: The net (net-class map key) that carries the target.
+        current_a: The class's ``target_ampacity`` in amps.
+        required_internal_width_mm: IPC-2221 minimum internal-copper width
+            for ``current_a`` -- identical to the value the post-route
+            ampacity DRC computes for an inner-layer segment of this net.
+        max_routable_width_mm: The widest trace the router will lay for the
+            class (its ``trace_width``) -- the "largest routable width the
+            engine can place on that layer".
+        inner_copper_oz: The internal copper weight used for the derivation
+            (from the resolved manufacturer profile), surfaced in the
+            message so it matches the DRC's ``(IPC-2221, <oz>oz internal)``
+            annotation.
+    """
+
+    net_name: str
+    current_a: float
+    required_internal_width_mm: float
+    max_routable_width_mm: float
+    inner_copper_oz: float
+
+    @property
+    def message(self) -> str:
+        """The loud, DRC-consistent route-time warning line."""
+        return (
+            f"WARNING: net '{self.net_name}' targets {self.current_a:.1f}A but "
+            f"the layer stack routes signal on inner layers. On internal copper "
+            f"this needs a {self.required_internal_width_mm:.3f}mm trace "
+            f"(IPC-2221, {self.inner_copper_oz}oz internal), far above the "
+            f"{self.max_routable_width_mm:.3f}mm the router will lay -- the "
+            "post-route ampacity DRC will flag any inner-layer segment as "
+            "impossibly under-rated (and `kct pcb reinforce` cannot rescue an "
+            "inner-layer high-current net). Pass --layers 4 to reserve the "
+            f'inner layers for planes, or set allowed_layers=["F.Cu","B.Cu"] '
+            f"for the '{self.net_name}' class."
+        )
+
+
+def ampacity_inner_layer_conflicts(
+    net_class_map: dict[str, NetClassRouting] | None,
+    design_rules: DesignRules,
+    layer_stack: LayerStack,
+) -> list[AmpacityLayerConflict]:
+    """Return the Tier-2 ampacity-vs-inner-layer conflicts for this route.
+
+    For each net-class that sets ``target_ampacity`` (and is not itself a
+    pour net -- pour nets become plane fills, not routed signal), computes
+    the IPC-2221 internal-copper required width via the *exact*
+    ``width_for_current`` call shape the ampacity DRC uses
+    (``copper_weight_oz=design_rules.inner_copper_oz``, ``layer="internal"``).
+    A conflict is reported when the stack routes signal on inner layers and
+    that required width exceeds the widest trace the router will lay for the
+    class (its ``trace_width``) -- i.e. the router would produce inner-layer
+    copper its own post-route ampacity DRC flags as impossible.
+
+    Args:
+        net_class_map: The loaded ``{net_name: NetClassRouting}`` map.
+        design_rules: The resolved manufacturer :class:`DesignRules`
+            (supplies ``inner_copper_oz``). Resolve it the same way the
+            post-route DRC does so the numbers agree.
+        layer_stack: The resolved stack for this route.
+
+    Returns:
+        One :class:`AmpacityLayerConflict` per unsatisfiable net-class,
+        empty when no class sets ``target_ampacity`` or the stack reserves
+        its inner layers for planes (the drift-prevention no-op).
+    """
+    if not net_class_map or not stack_routes_signal_on_inner(layer_stack):
+        return []
+
+    conflicts: list[AmpacityLayerConflict] = []
+    for name, nc in net_class_map.items():
+        current = getattr(nc, "target_ampacity", None)
+        if current is None:
+            continue
+        # Pour nets are auto-skipped by the router (they become plane
+        # fills, not routed signal), so an ampacity-on-inner-layer warning
+        # for them would be a false positive.
+        if getattr(nc, "is_pour_net", False):
+            continue
+
+        required_internal = width_for_current(
+            float(current),
+            copper_weight_oz=design_rules.inner_copper_oz,
+            layer="internal",
+        )
+        max_width = float(getattr(nc, "trace_width", 0.2))
+        if required_internal > max_width:
+            conflicts.append(
+                AmpacityLayerConflict(
+                    net_name=name,
+                    current_a=float(current),
+                    required_internal_width_mm=required_internal,
+                    max_routable_width_mm=max_width,
+                    inner_copper_oz=design_rules.inner_copper_oz,
+                )
+            )
+    return conflicts

--- a/tests/test_layer_advisories.py
+++ b/tests/test_layer_advisories.py
@@ -1,0 +1,271 @@
+"""Unit tests for route-time layer-selection advisories (Issue #4314).
+
+Exercises :mod:`kicad_tools.router.layer_advisories`, the warn-floor guards
+that surface two silent ``kct route`` footguns:
+
+* **Tier 1** -- ``--layers auto`` picks a signal-on-inner stack while the
+  net-class-map declares ``is_pour_net`` classes (``detect_layer_stack``
+  never sees that intent).
+* **Tier 2** -- a ``target_ampacity`` net whose required internal-copper
+  width is unroutable on an inner layer, predicting the post-route ampacity
+  DRC failure at route time.
+
+The Tier-2 required-width number is asserted to equal the post-route
+ampacity DRC's number (both call ``width_for_current`` with the identical
+``inner_copper_oz`` / ``layer="internal"`` shape), and the drift-prevention
+contract (no warnings when the map declares neither pour nets nor
+``target_ampacity``) is pinned so the guards stay silent on ordinary boards.
+"""
+
+from __future__ import annotations
+
+from kicad_tools.manufacturers import get_profile
+from kicad_tools.router.layer_advisories import (
+    AmpacityLayerConflict,
+    ampacity_inner_layer_conflicts,
+    declared_pour_net_names,
+    is_external_layer,
+    pour_net_blind_auto_warning,
+    stack_routes_signal_on_inner,
+)
+from kicad_tools.router.layers import LayerStack
+from kicad_tools.router.rules import NetClassRouting
+from kicad_tools.validate.rules.ampacity import AmpacityRule
+
+# --- Fixtures -----------------------------------------------------------
+
+
+def _mfr_rules(layers: int = 4, copper_oz: float = 1.0):
+    """The manufacturer DesignRules the post-route ampacity DRC resolves."""
+    return get_profile("jlcpcb").get_design_rules(layers=layers, copper_oz=copper_oz)
+
+
+def _pour_and_ampacity_map() -> dict[str, NetClassRouting]:
+    """The reporter's net-class-map: two pour nets + a 15 A HV_HICUR class."""
+    return {
+        "GND": NetClassRouting(name="GND", is_pour_net=True),
+        "+3.3V": NetClassRouting(name="+3.3V", is_pour_net=True),
+        "HV_HICUR": NetClassRouting(name="HV_HICUR", target_ampacity=15.0, trace_width=2.6),
+    }
+
+
+# --- is_external_layer mirrors the DRC ----------------------------------
+
+
+def test_is_external_layer_matches_drc_split():
+    """External/internal classification is byte-identical to the DRC's."""
+    for layer in ("F.Cu", "B.Cu"):
+        assert is_external_layer(layer) is True
+        assert AmpacityRule._is_external_layer(layer) is True
+    for layer in ("In1.Cu", "In2.Cu", "In3.Cu"):
+        assert is_external_layer(layer) is False
+        assert AmpacityRule._is_external_layer(layer) is False
+
+
+# --- stack_routes_signal_on_inner ---------------------------------------
+
+
+def test_signal_on_inner_true_for_sig_sig_and_all_signal():
+    assert stack_routes_signal_on_inner(LayerStack.four_layer_sig_sig_gnd_pwr()) is True
+    assert stack_routes_signal_on_inner(LayerStack.four_layer_all_signal()) is True
+
+
+def test_signal_on_inner_false_for_plane_aware_and_two_layer():
+    # --layers 4 (SIG-GND-PWR-SIG): inner layers are PLANE, not signal.
+    assert stack_routes_signal_on_inner(LayerStack.four_layer_sig_gnd_pwr_sig()) is False
+    # 2-layer: both layers are outer, so there is no inner layer at all.
+    assert stack_routes_signal_on_inner(LayerStack.two_layer()) is False
+
+
+# --- declared_pour_net_names --------------------------------------------
+
+
+def test_declared_pour_net_names_sorted():
+    assert declared_pour_net_names(_pour_and_ampacity_map()) == ["+3.3V", "GND"]
+
+
+def test_declared_pour_net_names_empty_when_no_pour_or_none():
+    assert declared_pour_net_names(None) == []
+    assert declared_pour_net_names({"SIG": NetClassRouting(name="SIG")}) == []
+
+
+# --- Tier 1: pour-net-blind auto ----------------------------------------
+
+
+def test_tier1_warning_fires_for_auto_signal_on_inner_with_pour_nets():
+    msg = pour_net_blind_auto_warning(
+        LayerStack.four_layer_sig_sig_gnd_pwr(), _pour_and_ampacity_map()
+    )
+    assert msg is not None
+    assert "--layers 4" in msg
+    # Names both pour nets so the operator knows which layers were meant.
+    assert "GND" in msg and "+3.3V" in msg
+
+
+def test_tier1_silent_when_stack_reserves_inner_layers():
+    # Plane-aware stack (as --layers 4 selects) never strands plane intent.
+    assert (
+        pour_net_blind_auto_warning(
+            LayerStack.four_layer_sig_gnd_pwr_sig(), _pour_and_ampacity_map()
+        )
+        is None
+    )
+
+
+def test_tier1_silent_when_no_pour_nets_declared():
+    plain = {"SIG": NetClassRouting(name="SIG")}
+    assert pour_net_blind_auto_warning(LayerStack.four_layer_sig_sig_gnd_pwr(), plain) is None
+
+
+# --- Tier 2: ampacity-vs-inner-layer conflict ---------------------------
+
+
+def test_tier2_conflict_fires_and_number_matches_drc():
+    rules = _mfr_rules()
+    stack = LayerStack.four_layer_sig_sig_gnd_pwr()
+    conflicts = ampacity_inner_layer_conflicts(_pour_and_ampacity_map(), rules, stack)
+
+    assert len(conflicts) == 1
+    conflict = conflicts[0]
+    assert isinstance(conflict, AmpacityLayerConflict)
+    assert conflict.net_name == "HV_HICUR"
+    assert conflict.current_a == 15.0
+
+    # The route-time required internal width must equal the post-route DRC's
+    # required width to the last digit (same width_for_current call shape).
+    drc_required = AmpacityRule({"HV_HICUR": 15.0})._required_width_mm(15.0, rules, external=False)
+    assert conflict.required_internal_width_mm == drc_required
+
+    # The message carries the DRC-consistent number and copper weight.
+    assert f"{drc_required:.3f}mm" in conflict.message
+    assert f"{rules.inner_copper_oz}oz internal" in conflict.message
+    assert "--layers 4" in conflict.message
+
+
+def test_tier2_silent_on_plane_aware_stack():
+    # With inner layers reserved for planes there is no inner signal layer to
+    # strand the high-current net on -> no route-time warning (matches the
+    # "--layers 4 -> no new warnings" manual acceptance).
+    assert (
+        ampacity_inner_layer_conflicts(
+            _pour_and_ampacity_map(), _mfr_rules(), LayerStack.four_layer_sig_gnd_pwr_sig()
+        )
+        == []
+    )
+
+
+def test_tier2_skips_pour_net_with_ampacity():
+    # A class that is itself a pour net is auto-skipped by the router (becomes
+    # a plane fill, not routed signal), so it must not raise a false positive
+    # even if it declares target_ampacity.
+    ncm = {
+        "GND": NetClassRouting(name="GND", is_pour_net=True, target_ampacity=15.0, trace_width=0.2),
+    }
+    assert (
+        ampacity_inner_layer_conflicts(ncm, _mfr_rules(), LayerStack.four_layer_sig_sig_gnd_pwr())
+        == []
+    )
+
+
+def test_tier2_silent_when_trace_width_satisfies_requirement():
+    # If the class's trace_width already meets the internal requirement, the
+    # router will lay conforming copper -> no conflict.
+    rules = _mfr_rules()
+    required = AmpacityRule({"HV_HICUR": 15.0})._required_width_mm(15.0, rules, external=False)
+    ncm = {
+        "HV_HICUR": NetClassRouting(
+            name="HV_HICUR", target_ampacity=15.0, trace_width=required + 1.0
+        ),
+    }
+    assert ampacity_inner_layer_conflicts(ncm, rules, LayerStack.four_layer_sig_sig_gnd_pwr()) == []
+
+
+# --- Drift-prevention contract ------------------------------------------
+
+
+def test_no_warnings_when_no_pour_nets_and_no_ampacity():
+    """The baseline board (no pour nets, no target_ampacity) stays silent."""
+    plain = {
+        "SIG_A": NetClassRouting(name="SIG_A"),
+        "SIG_B": NetClassRouting(name="SIG_B", trace_width=0.15),
+    }
+    stack = LayerStack.four_layer_sig_sig_gnd_pwr()  # even a signal-on-inner stack
+    assert pour_net_blind_auto_warning(stack, plain) is None
+    assert ampacity_inner_layer_conflicts(plain, _mfr_rules(), stack) == []
+
+
+def test_empty_and_none_maps_are_noops():
+    stack = LayerStack.four_layer_sig_sig_gnd_pwr()
+    for ncm in (None, {}):
+        assert pour_net_blind_auto_warning(stack, ncm) is None
+        assert ampacity_inner_layer_conflicts(ncm, _mfr_rules(), stack) == []
+
+
+# --- route_cmd wiring (both callsites share this helper) ----------------
+
+
+def _args(**overrides):
+    from argparse import Namespace
+
+    base = {
+        "manufacturer": "jlcpcb",
+        "copper_oz": 1.0,
+        "_loaded_net_class_map": _pour_and_ampacity_map(),
+    }
+    base.update(overrides)
+    return Namespace(**base)
+
+
+def test_route_cmd_helper_emits_both_tiers_to_stderr(capsys):
+    from kicad_tools.cli.route_cmd import _warn_layer_selection_advisories
+
+    _warn_layer_selection_advisories(_args(), LayerStack.four_layer_sig_sig_gnd_pwr(), is_auto=True)
+    err = capsys.readouterr().err
+    # Tier 1 (auto pour-net-blind) and Tier 2 (ampacity) both present.
+    assert "--layers auto selected" in err
+    assert "HV_HICUR" in err and "65.479mm" in err
+    assert "--layers 4" in err
+
+
+def test_route_cmd_helper_tier1_suppressed_when_not_auto(capsys):
+    from kicad_tools.cli.route_cmd import _warn_layer_selection_advisories
+
+    # Explicit --layers 4-sig: Tier 1 (auto-only) is silent, but Tier 2 still
+    # fires because the stack routes signal on inner layers.
+    _warn_layer_selection_advisories(
+        _args(), LayerStack.four_layer_sig_sig_gnd_pwr(), is_auto=False
+    )
+    err = capsys.readouterr().err
+    assert "--layers auto selected" not in err
+    assert "HV_HICUR" in err
+
+
+def test_route_cmd_helper_silent_on_plane_stack(capsys):
+    from kicad_tools.cli.route_cmd import _warn_layer_selection_advisories
+
+    # --layers 4 (plane-aware): no new warnings at all.
+    _warn_layer_selection_advisories(
+        _args(), LayerStack.four_layer_sig_gnd_pwr_sig(), is_auto=False
+    )
+    assert capsys.readouterr().err == ""
+
+
+def test_route_cmd_helper_silent_for_baseline_map(capsys):
+    from kicad_tools.cli.route_cmd import _warn_layer_selection_advisories
+
+    # Drift guard: a map with no pour nets and no target_ampacity is silent
+    # even under auto on a signal-on-inner stack.
+    args = _args(_loaded_net_class_map={"SIG": NetClassRouting(name="SIG")})
+    _warn_layer_selection_advisories(args, LayerStack.four_layer_sig_sig_gnd_pwr(), is_auto=True)
+    assert capsys.readouterr().err == ""
+
+
+def test_route_cmd_helper_handles_missing_net_class_map(capsys):
+    from argparse import Namespace
+
+    from kicad_tools.cli.route_cmd import _warn_layer_selection_advisories
+
+    # No _loaded_net_class_map attribute at all -> pure no-op, no crash.
+    args = Namespace(manufacturer="jlcpcb", copper_oz=1.0)
+    _warn_layer_selection_advisories(args, LayerStack.four_layer_sig_sig_gnd_pwr(), is_auto=True)
+    assert capsys.readouterr().err == ""


### PR DESCRIPTION
## Summary

`kct route --layers auto` silently produced a route that stranded a
safety-critical 15 A net on an inner layer its own ampacity DRC then
flagged as impossibly under-rated (65.5 mm required). This adds the
**warn-floor + docs** fix (Issue #4314): route-time advisories that
surface the two silent footguns before the post-route DRC runs, plus
`--layers` help that steers pour-net users to `--layers 4`.

Three composing root causes (all verified against origin/main):
1. `--layers auto` resolves the stack via `detect_layer_stack(pcb_text)`,
   which infers planes only from `(zone ...)` s-exprs already in the input
   PCB and is never handed the loaded net-class-map — so `is_pour_net`
   intent is invisible when planes are added post-route.
2. `LayerDefinition.is_routable` is hardcoded `True` even for PLANE layers.
3. Route-time layer assignment never evaluates `target_ampacity` against
   the candidate layer's copper weight, while the post-route ampacity DRC
   treats any non-F.Cu/B.Cu layer as internal — the self-contradictory
   "requires 65.5 mm" flag on the router's own copper.

## Changes

- **New `src/kicad_tools/router/layer_advisories.py`** — pure, testable
  logic: `declared_pour_net_names`, `stack_routes_signal_on_inner`,
  `pour_net_blind_auto_warning` (Tier 1), `ampacity_inner_layer_conflicts`
  + `AmpacityLayerConflict` (Tier 2), and `is_external_layer` mirroring the
  DRC's internal/external split exactly.
- **`src/kicad_tools/cli/route_cmd.py`** — `_warn_layer_selection_advisories`
  + `_resolve_mfr_design_rules` helpers, wired into **both**
  `detect_layer_stack` callsites (adaptive/relaxation path ~4810 and mirror
  path ~10264). Advisories print to stderr, are non-suppressible by
  `--quiet`, and never change the exit code (matches the #4149 net-class-map
  diagnostic precedent).
- **`src/kicad_tools/cli/parser.py`** — Tier 3 one-line note on the `route`
  and `pipeline` `--layers` help: pass `4` when the net-class-map declares
  `is_pour_net` / plane nets.
- **`tests/test_layer_advisories.py`** — 19 tests (logic + route_cmd wiring).

Tier 2 reuses the **exact** `width_for_current(current, inner_copper_oz,
layer="internal")` call shape the ampacity DRC uses, resolving the same
manufacturer profile the post-route DRC resolves, so the route-time number
equals the DRC number to the last digit (verified: 65.479 mm for the
reporter's 15 A / 0.5 oz internal case).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Tier 1: loud, non-suppressible warning when auto routes signal-on-inner while map declares pour nets; recommends `--layers 4` | ✅ | `pour_net_blind_auto_warning`; tests `test_tier1_*`, `test_route_cmd_helper_emits_both_tiers_to_stderr` |
| Fires on BOTH `detect_layer_stack` callsites | ✅ | `_warn_layer_selection_advisories` wired at route_cmd ~4810 and ~10264 |
| Tier 2: route-time (not just DRC) warning for `target_ampacity` net unsatisfiable on inner copper | ✅ | `ampacity_inner_layer_conflicts`; test `test_tier2_conflict_fires_and_number_matches_drc` |
| Route-time number matches DRC exactly | ✅ | test asserts `conflict.required_internal_width_mm == AmpacityRule._required_width_mm(..., external=False)` |
| Tier 3: `--layers` help steers pour-net users to `4` | ✅ | `kct route --help` shows the note; both parser callsites updated |
| Drift guard: byte-identical, no new warnings when no pour nets AND no `target_ampacity` | ✅ | tests `test_no_warnings_when_no_pour_nets_and_no_ampacity`, `test_route_cmd_helper_silent_for_baseline_map` |
| Edge: pour net that also sets `target_ampacity` is skipped | ✅ | test `test_tier2_skips_pour_net_with_ampacity` |
| `--layers 4` (plane-aware) stays silent | ✅ | tests `test_tier1_silent_when_stack_reserves_inner_layers`, `test_route_cmd_helper_silent_on_plane_stack` |

## Deferred structural alternatives (NOT in this PR)

Per the Curator's scope, the deeper structural rework is deferred pending
separate human approval — it cross-cuts `is_routable` / routable-index
gating and the escalation ladder:
- Tier 1 structural: make `detect_layer_stack` consume the net-class-map,
  return the plane-aware shape, and exclude plane indices from the routable
  set.
- Tier 2 structural: derive `allowed_layers=["F.Cu","B.Cu"]` for any class
  whose `target_ampacity` is unsatisfiable on internal copper so the engine
  *refuses* inner-layer placement instead of merely warning.

## Test Plan

- `uv run pytest tests/test_layer_advisories.py` — 19 passed
- Regression sweep: `test_ampacity_check`, `test_ampacity`,
  `test_router_layers`, `test_layer_escalation`, `test_route_cmd_help_string`,
  `test_route_cmd_params`, `test_cli_check_ampacity` — all green
- `uv run ruff check .` clean, `ruff format --check .` clean
- `uv run python scripts/ci/check_mypy_baseline.py` — no new type errors
  (baseline untouched; the "1 baseline error no longer occurs" note is the
  known native-build nanobind trap — not `--update`-d in a native worktree)

Closes #4314