### PR TITLE
fix(lattice): reject 0.000mm segment-to-via copper + opt-in cleanup + net split

### DIFF
--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -68,7 +68,24 @@ _MEASUREMENT_RULE_IDS: frozenset[str] = frozenset(
 # ``nets[0] == nets[1]`` would mislabel two *distinct* floating pins as
 # ``same-net``.  Floating pins share no electrical identity, so any pair
 # involving a floating endpoint is ``different-net``.
-_NET_RELATIONSHIP_RULE_IDS: frozenset[str] = frozenset({"dimension_drill_clearance"})
+# Issue #4318: the copper-copper clearance rules carry the same
+# ``nets=(net_a, net_b)`` pair (set in ``_create_violation``,
+# ``validate/rules/clearance.py``), so an agent reading a ``clearance_segment_via``
+# report needs the same same-net / different-net split ``dimension_drill_clearance``
+# already gets -- a different-net 0.000mm coincidence is a genuine short to
+# prioritize, while a same-net coincidence is a lower-risk (still-defective)
+# malformed-copper artifact.  The classifier (``_net_relationship`` /
+# ``_is_floating_net``) is floating-aware, so a floating (``net:0``) endpoint in a
+# segment-via pair classifies as ``different-net`` (#4127) with no extra work.
+_NET_RELATIONSHIP_RULE_IDS: frozenset[str] = frozenset(
+    {
+        "dimension_drill_clearance",
+        "clearance_segment_via",
+        "clearance_segment_segment",
+        "clearance_via_via",
+        "clearance_pad_via",
+    }
+)
 
 
 def _is_floating_net(net: str) -> bool:

--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -496,6 +496,11 @@ def run_route_command(args) -> int:
     # (grid) run stays byte-identical to the pre-mesh sub-invocation.
     if getattr(args, "route_engine", "grid") != "grid":
         sub_argv.extend(["--route-engine", args.route_engine])
+    # Issue #4318: forward --lattice-optimize (opt-in geometric post-passes on
+    # non-grid copper).  Both parsers declare it as store_true defaulting to
+    # False, so only forward when the user set it -- flag-off is byte-identical.
+    if getattr(args, "lattice_optimize", False):
+        sub_argv.append("--lattice-optimize")
     # Issue #2589: forward --seed for deterministic runs.  Default is None
     # (router uses os.urandom-derived state, existing behaviour).
     if getattr(args, "seed", None) is not None:

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -3544,6 +3544,20 @@ def _add_route_parser(subparsers) -> None:
         ),
     )
     route_parser.add_argument(
+        "--lattice-optimize",
+        action="store_true",
+        help=(
+            "Opt in to the geometric optimize/nudge post-passes on lattice "
+            "(and mesh) copper (issue #4318). By default these passes are "
+            "SKIPPED for non-grid engines (#4281): lattice copper is committed "
+            "as-is, so the byte output of a plain '--route-engine lattice' run "
+            "is unchanged. With this flag the optimize/DRC-nudge post-passes "
+            "are allowed to run so 'repair-clearance'/'fix-drc'-style cleanup "
+            "can operate on lattice output. Off by default; has no effect for "
+            "'--route-engine grid' (grid always runs the post-passes)."
+        ),
+    )
+    route_parser.add_argument(
         "--seed",
         type=int,
         default=None,

--- a/src/kicad_tools/cli/repair_clearance_cmd.py
+++ b/src/kicad_tools/cli/repair_clearance_cmd.py
@@ -410,6 +410,21 @@ def _print_text(
         print(f"{unrepaired} violation(s) require manual repair")
         if result.skipped_exceeds_max > 0:
             print(f"  Try increasing --max-displacement (currently {max_displacement}mm)")
+        if result.skipped_infeasible > 0:
+            # Issue #4318: a coincident (0.000mm) segment-body-crosses-via
+            # overlap -- the malformed copper a lattice run could leave behind --
+            # is NOT a displacement-nudge fix: translating the segment just
+            # slides the crossing or shorts a neighbour (that is how raising
+            # --max-displacement regressed 33 -> 34 on the softstart repro).
+            # Steer the operator to the right remedy instead of the dead-end
+            # knob.  (Tier 1 now declines such copper at the source, so a fresh
+            # 'kct route --route-engine lattice' run does not emit it.)
+            print(
+                "  Coincident (0.000mm) copper cannot be nudged apart -- raising "
+                "--max-displacement will not help.  Re-route the offending net "
+                "(dogleg/split off the via center); a fresh 'kct route "
+                "--route-engine lattice' run declines such copper (#4318)."
+            )
 
 
 def _print_nudge(nudge: NudgeResult) -> None:

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -66,7 +66,7 @@ import textwrap
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -996,19 +996,67 @@ def _engine_post_passes_enabled(
     four optimize+nudge call-site pairs (mirroring the
     ``_finalize_committed_copper_or_demote`` shared-helper pattern).  The
     #4208 backstop itself stays unconditional as defense in depth.
-    Eventual unification -- non-grid engines committing via
-    ``_mark_route`` plus a foreign-segment nudge destination gate -- is
-    out of scope here (see #4281 curation, option (b)).
+
+    Issue #4318: ``--lattice-optimize`` opts back in.  When it is set, a
+    non-grid engine is treated like grid and the optimize/DRC-nudge
+    post-passes run, so ``repair-clearance``/``fix-drc``-style cleanup can
+    operate on lattice output.  The flag defaults to ``False``, so the
+    absent-flag path is exactly the #4281 skip (byte-identical output for a
+    plain ``--route-engine lattice`` run).
     """
     engine = getattr(args, "route_engine", "grid") or "grid"
     if engine == "grid":
         return True
+    if getattr(args, "lattice_optimize", False):
+        if not quiet:
+            print(
+                f"\n  --lattice-optimize: running optimize/nudge post-passes "
+                f"on --route-engine {engine} copper (#4318)"
+            )
+        return True
     if not quiet:
         print(
             f"\n  Skipping optimize/nudge post-passes for --route-engine "
-            f"{engine}: non-grid copper is committed as-is (#4281)"
+            f"{engine}: non-grid copper is committed as-is (#4281; "
+            f"pass --lattice-optimize to opt in)"
         )
     return False
+
+
+def _mark_nongrid_routes_for_post_pass(
+    router: Any,
+    args: argparse.Namespace,
+    *,
+    quiet: bool = False,
+) -> None:
+    """Populate the grid obstacle model with committed non-grid copper (#4318).
+
+    The lattice / mesh engines append their routes to ``router.routes`` WITHOUT
+    calling ``_mark_route`` (#4281), so the grid's cell-occupancy + per-layer
+    segment R-tree carry no route copper.  The optimize pass' collision checker
+    is built from that model, so under ``--lattice-optimize`` it would validate
+    every move as "clear" even across another net -- the exact blindness #4281
+    describes.  Marking the already-committed routes onto the grid (``_mark_route``
+    only populates the grid; it does NOT re-append to ``router.routes``, so it is
+    idempotent here) gives the collision checker real copper to see before the
+    opt-in post-passes run.
+
+    No-op unless the engine is non-grid AND ``--lattice-optimize`` is set, so the
+    default path (and every grid run) is completely untouched.
+    """
+    engine = getattr(args, "route_engine", "grid") or "grid"
+    if engine == "grid" or not getattr(args, "lattice_optimize", False):
+        return
+    marked = 0
+    for route in router.routes:
+        router._mark_route(route)
+        marked += 1
+    if not quiet and marked:
+        print(
+            f"  --lattice-optimize: marked {marked} committed {engine} route(s) "
+            f"into the grid obstacle model so the optimizer collision checker "
+            f"is not blind (#4318)"
+        )
 
 
 def _make_checkpoint_callback(
@@ -4682,6 +4730,8 @@ def route_with_layer_escalation(
     # Issue #4281: the geometric post-passes (optimize + DRC nudge) are
     # grid-engine-only -- lattice/mesh copper must not be touched.
     _post_passes_enabled = _engine_post_passes_enabled(args, quiet=quiet)
+    if _post_passes_enabled:
+        _mark_nongrid_routes_for_post_pass(final_result.router, args, quiet=quiet)
 
     # Optimize traces
     if _post_passes_enabled and not args.no_optimize and final_result.router.routes:
@@ -5375,6 +5425,8 @@ def route_with_rule_relaxation(
     # Issue #4281: the geometric post-passes (optimize + DRC nudge) are
     # grid-engine-only -- lattice/mesh copper must not be touched.
     _post_passes_enabled = _engine_post_passes_enabled(args, quiet=quiet)
+    if _post_passes_enabled:
+        _mark_nongrid_routes_for_post_pass(final_result.router, args, quiet=quiet)
 
     # Optimize traces
     if _post_passes_enabled and not args.no_optimize and final_result.router.routes:
@@ -7579,6 +7631,8 @@ def route_with_combined_escalation(
     # Issue #4281: the geometric post-passes (optimize + DRC nudge) are
     # grid-engine-only -- lattice/mesh copper must not be touched.
     _post_passes_enabled = _engine_post_passes_enabled(args, quiet=quiet)
+    if _post_passes_enabled:
+        _mark_nongrid_routes_for_post_pass(final_result.router, args, quiet=quiet)
 
     # Optimize traces
     if _post_passes_enabled and not args.no_optimize and final_result.router.routes:
@@ -9149,6 +9203,19 @@ def main(argv: list[str] | None = None) -> int:
             "monte-carlo, evolutionary, --two-phase, --multi-resolution, or "
             "--escape-routing is rejected (issue #4280). Grid remains the "
             "production default and works with every strategy."
+        ),
+    )
+    parser.add_argument(
+        "--lattice-optimize",
+        action="store_true",
+        help=(
+            "Opt in to the geometric optimize/nudge post-passes on lattice "
+            "(and mesh) copper (issue #4318). By default these passes are "
+            "SKIPPED for non-grid engines (#4281): lattice copper is committed "
+            "as-is, so a plain '--route-engine lattice' run is byte-identical. "
+            "With this flag the optimize/DRC-nudge post-passes are allowed to "
+            "run so repair-style cleanup can operate on lattice output. Off by "
+            "default; no effect for '--route-engine grid'."
         ),
     )
     parser.add_argument(
@@ -11542,6 +11609,8 @@ def main(argv: list[str] | None = None) -> int:
     # Issue #4281: the geometric post-passes (optimize + DRC nudge) are
     # grid-engine-only -- lattice/mesh copper must not be touched.
     _post_passes_enabled = _engine_post_passes_enabled(args, quiet=quiet)
+    if _post_passes_enabled:
+        _mark_nongrid_routes_for_post_pass(router, args, quiet=quiet)
 
     # Optimize traces (unless --no-optimize/--raw flag is set)
     if _post_passes_enabled and not args.no_optimize and router.routes:

--- a/src/kicad_tools/router/lattice/obstacles.py
+++ b/src/kicad_tools/router/lattice/obstacles.py
@@ -38,6 +38,31 @@ from .quadtree import EdgeKey, NodeKey, OctilinearLattice
 
 _BUCKET = 4.0  # mm; pad-lookup acceleration grid
 
+# Manufacturing co-location epsilon (matches ``_COLOCATION_EPSILON_MM`` in
+# ``validate/rules/clearance.py``).  A segment ENDPOINT coincident with a via
+# center within this distance is the legitimate in-pad-escape router invariant
+# (#2706) and is NOT a defect.  A segment whose INTERIOR (body) crosses a via
+# center *is* malformed copper: for different-net pairs the DRC checker flags
+# it at 0.000mm, and for same-net pairs it is an octilinear segment running
+# across an unrelated via node that no nudge post-pass can clean (issue #4318).
+_COLOCATION_EPSILON_MM = 1e-4
+
+
+def seg_body_crosses_pt(a: Pt, b: Pt, p: Pt, eps: float = _COLOCATION_EPSILON_MM) -> bool:
+    """True iff ``p`` coincides with segment ``a-b``'s INTERIOR, not an endpoint.
+
+    Distinguishes the malformed "segment body crosses a via center" case
+    (rejected) from the legitimate in-pad-escape endpoint-at-via-center
+    invariant (#2706, permitted).  ``p`` counts as a body crossing only when it
+    is within ``eps`` of the segment yet farther than ``eps`` from BOTH
+    endpoints -- so a via tapped at a segment endpoint (the router invariant) is
+    never treated as malformed, while a via center the segment merely runs over
+    mid-span is.  See issue #4318.
+    """
+    if seg_pt_dist(a, b, p) >= eps:
+        return False
+    return dist(a, p) >= eps and dist(b, p) >= eps
+
 
 class LatticeObstacleModel:
     """Static per-layer pad masks over a built lattice (built once per board).
@@ -252,7 +277,17 @@ class CommittedCopper:
                 return False
         via_gap = self.via_radius + own_clr + own_half
         for point, vnet in self.vias:
-            if vnet != net and seg_pt_dist(a, b, point) < via_gap - 1e-9:
+            if vnet != net:
+                if seg_pt_dist(a, b, point) < via_gap - 1e-9:
+                    return False
+            elif seg_body_crosses_pt(a, b, point):
+                # Same-net octilinear segment whose BODY runs across a same-net
+                # via center is malformed lattice copper (#4318).  The DRC
+                # checker skips same-net pairs, so this coincidence would never
+                # surface downstream and no nudge post-pass could clean it --
+                # the negotiator must simply not emit it.  The legal
+                # endpoint-at-via-center in-pad invariant (#2706) is preserved
+                # by ``seg_body_crosses_pt``'s endpoint exemption.
                 return False
         return True
 

--- a/src/kicad_tools/router/lattice/pathfinder.py
+++ b/src/kicad_tools/router/lattice/pathfinder.py
@@ -52,7 +52,7 @@ from ..quantize import dogleg_points
 from ..rules import DesignRules
 from .coupled import CoupledConnection
 from .geometry import Pt, Rect, dist, pt_in_rect, seg_seg_dist
-from .obstacles import CommittedCopper, LatticeObstacleModel
+from .obstacles import CommittedCopper, LatticeObstacleModel, seg_body_crosses_pt
 from .quadtree import EdgeKey, NodeKey, OctilinearLattice, RefineRegion
 
 # A negotiation connection: (opaque hashable key, start pad, end pad, net_class)
@@ -1455,6 +1455,38 @@ class LatticePathfinder:
 
     # -- multi-net negotiation ------------------------------------------------
 
+    def _self_drc_reason(self, result: _RouteResult) -> str | None:
+        """Final self-DRC gate over ONE net's freshly emitted geometry (#4318).
+
+        The per-move A* predicates (:meth:`CommittedCopper.seg_clear` /
+        :meth:`via_clear`) validate each new segment / via against the
+        *committed* model -- copper that is already placed, and (within a pass)
+        almost always foreign-net.  A net's own via and its own octilinear
+        segments, however, are emitted together and are never cross-checked
+        against one another: nothing rejects a segment whose body runs across
+        THIS net's own via center.  That is a 0.000mm segment-to-via
+        coincidence -- malformed copper the downstream ``kct check`` DRC cannot
+        nudge away (and, being same-net, would not even surface, yet is still a
+        manufacturing defect).
+
+        Reuse the same body-vs-endpoint predicate the tightened committed-copper
+        model uses (:func:`seg_body_crosses_pt`) so the router's accept gate and
+        the checker agree by construction.  Returns a decline reason string when
+        the route is malformed (flowing into the lattice ``decline[...]``
+        census), or ``None`` when it is clean.  The legitimate in-pad-escape
+        endpoint-at-via-center invariant (#2706) is exempt by construction.
+        """
+        if not result.via_points:
+            return None
+        for _layer_idx, points, _widths in result.runs:
+            for a, b in zip(points, points[1:], strict=False):
+                if dist(a, b) <= 1e-9:
+                    continue
+                for via_pt in result.via_points:
+                    if seg_body_crosses_pt(a, b, via_pt):
+                        return "self-drc-segment-via-coincident"
+        return None
+
     def route_netset(
         self,
         connections: list[Connection],
@@ -1555,6 +1587,15 @@ class LatticePathfinder:
                 )
                 if result is None:
                     reasons[key] = reason
+                    failed.append((kind, item))
+                    continue
+                # Final self-DRC gate (#4318): a route whose own segment body
+                # runs across its own via center is malformed copper the
+                # checker cannot repair -- decline it honestly rather than
+                # ship a 0.000mm segment-to-via coincidence.
+                self_reason = self._self_drc_reason(result)
+                if self_reason is not None:
+                    reasons[key] = self_reason
                     failed.append((kind, item))
                     continue
                 routed_items += 1

--- a/tests/router/lattice/test_post_pass_gating.py
+++ b/tests/router/lattice/test_post_pass_gating.py
@@ -66,6 +66,91 @@ def test_quiet_suppresses_skip_notice(engine: str, capsys: pytest.CaptureFixture
 
 
 # ---------------------------------------------------------------------------
+# #4318: --lattice-optimize opt-in flips the gate for non-grid engines.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("engine", ["lattice", "mesh"])
+def test_lattice_optimize_flag_enables_post_passes(
+    engine: str, capsys: pytest.CaptureFixture
+) -> None:
+    args = argparse.Namespace(route_engine=engine, lattice_optimize=True)
+    assert _engine_post_passes_enabled(args) is True
+    out = capsys.readouterr().out
+    assert "--lattice-optimize" in out
+    assert engine in out
+    assert "#4318" in out
+
+
+@pytest.mark.parametrize("engine", ["lattice", "mesh"])
+def test_lattice_optimize_absent_preserves_skip(engine: str, capsys: pytest.CaptureFixture) -> None:
+    # Flag explicitly False (as argparse store_true yields) == the #4281 skip:
+    # the byte-identical-output guarantee for a plain --route-engine run.
+    args = argparse.Namespace(route_engine=engine, lattice_optimize=False)
+    assert _engine_post_passes_enabled(args) is False
+    assert "Skipping optimize/nudge post-passes" in capsys.readouterr().out
+
+
+def test_lattice_optimize_flag_ignored_for_grid(capsys: pytest.CaptureFixture) -> None:
+    # Grid always runs the passes and stays silent; the flag adds no notice.
+    args = argparse.Namespace(route_engine="grid", lattice_optimize=True)
+    assert _engine_post_passes_enabled(args) is True
+    assert capsys.readouterr().out == ""
+
+
+def test_lattice_optimize_quiet_suppresses_optin_notice(capsys: pytest.CaptureFixture) -> None:
+    args = argparse.Namespace(route_engine="lattice", lattice_optimize=True)
+    assert _engine_post_passes_enabled(args, quiet=True) is True
+    assert capsys.readouterr().out == ""
+
+
+def test_mark_nongrid_routes_noop_without_flag() -> None:
+    """The grid-marking helper is inert unless engine is non-grid AND flag set."""
+    from kicad_tools.cli.route_cmd import _mark_nongrid_routes_for_post_pass
+
+    class _Router:
+        def __init__(self) -> None:
+            self.routes = [object(), object()]
+            self.marked: list[object] = []
+
+        def _mark_route(self, route: object) -> None:  # pragma: no cover - guarded off
+            self.marked.append(route)
+
+    # grid engine: no-op regardless of flag.
+    r = _Router()
+    _mark_nongrid_routes_for_post_pass(
+        r, argparse.Namespace(route_engine="grid", lattice_optimize=True), quiet=True
+    )
+    assert r.marked == []
+
+    # lattice, flag absent: no-op (byte-identical default path).
+    r = _Router()
+    _mark_nongrid_routes_for_post_pass(
+        r, argparse.Namespace(route_engine="lattice", lattice_optimize=False), quiet=True
+    )
+    assert r.marked == []
+
+
+def test_mark_nongrid_routes_marks_when_opted_in() -> None:
+    """With --lattice-optimize the committed lattice routes are marked into the grid."""
+    from kicad_tools.cli.route_cmd import _mark_nongrid_routes_for_post_pass
+
+    class _Router:
+        def __init__(self) -> None:
+            self.routes = [object(), object(), object()]
+            self.marked: list[object] = []
+
+        def _mark_route(self, route: object) -> None:
+            self.marked.append(route)
+
+    r = _Router()
+    _mark_nongrid_routes_for_post_pass(
+        r, argparse.Namespace(route_engine="lattice", lattice_optimize=True), quiet=True
+    )
+    assert r.marked == r.routes
+
+
+# ---------------------------------------------------------------------------
 # CLI tail integration: lattice copper never reaches optimize/nudge; the
 # unconditional #4208 backstop finds nothing to demote (board 02 is 8/8).
 # ---------------------------------------------------------------------------
@@ -137,6 +222,56 @@ def test_cli_lattice_skips_both_passes_and_demotes_nothing(
     assert "Skipping optimize/nudge post-passes for --route-engine lattice" in out
     # The unconditional #4208 backstop ran and found nothing to demote
     # (pre-fix: 'Post-optimize backstop demoted 1 net(s) ...' -> 7/8).
+    assert "Post-optimize backstop demoted" not in out
+    assert "Nets routed:     8/8" in out
+    assert out_pcb.exists()
+
+
+def test_cli_lattice_optimize_runs_passes_without_demotion(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """#4318 AC T2: ``--lattice-optimize`` runs the post-passes on lattice copper.
+
+    The opt-in must (a) actually run BOTH geometric passes on the non-grid
+    copper (the #4281 skip is lifted), (b) first mark the committed lattice
+    routes into the grid so the optimizer's collision checker is not blind, and
+    (c) NOT trigger the #3989/#4208 backstop demotion -- board-02 stays 8/8 with
+    no completion loss (the exact regression the marking prevents).
+    """
+    from kicad_tools.cli import route_cmd
+
+    calls = _spy_post_passes(monkeypatch)
+    out_pcb = tmp_path / "routed.kicad_pcb"
+    rc = route_cmd.main(
+        [
+            str(_CHARLIEPLEX),
+            "--route-engine",
+            "lattice",
+            "--strategy",
+            "basic",
+            "--seed",
+            "42",
+            "--lattice-optimize",
+            "--skip-drc",
+            "-o",
+            str(out_pcb),
+        ]
+    )
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    # Both passes ran (the opt-in lifted the #4281 skip).
+    assert calls["optimize"] >= 1, "--lattice-optimize must run the optimizer on lattice copper"
+    assert calls["nudge"] >= 1, "--lattice-optimize must run the DRC nudge on lattice copper"
+    assert "--lattice-optimize: running optimize/nudge post-passes" in out
+    # The committed lattice routes were marked into the grid obstacle model so
+    # the collision checker is not blind (the #4281 root cause).
+    assert "marked" in out and "into the grid obstacle model" in out
+    assert "Skipping optimize/nudge post-passes" not in out
+    # No backstop demotion: completion is preserved (8/8), NOT a cross-net short
+    # demoted to a completion loss.
     assert "Post-optimize backstop demoted" not in out
     assert "Nets routed:     8/8" in out
     assert out_pcb.exists()

--- a/tests/router/lattice/test_self_drc.py
+++ b/tests/router/lattice/test_self_drc.py
@@ -1,0 +1,231 @@
+"""#4318: the lattice engine must never emit 0.000mm segment-to-via copper.
+
+A lattice octilinear segment whose *body* runs across a via center at 0.000mm
+slipped through a complementary blind spot: the committed-copper predicates
+only enforced clearance against *different-net* elements (so a same-net segment
+landing on a via center was never rejected), and the DRC checker's co-location
+suppression is *endpoint-only* (so a segment whose interior crosses a via center
+was not exempt).  Net effect: an unfixable ``clearance_segment_via`` at 0.000mm
+that no nudge post-pass could clean.
+
+Two guards close the hole, both reusing ONE body-vs-endpoint predicate
+(``seg_body_crosses_pt``) so the router accept gate and ``kct check`` agree:
+
+1. ``CommittedCopper.seg_clear`` rejects a segment whose body crosses a
+   *same-net* via center (different-net was already rejected by the gap check),
+   while preserving the legitimate in-pad-escape endpoint-at-via-center
+   invariant (#2706).
+2. ``LatticePathfinder._self_drc_reason`` is a final gate over one net's OWN
+   emitted geometry -- a segment crossing the net's own via is committed
+   together with that via and is never cross-checked during A*.
+"""
+
+from __future__ import annotations
+
+import math
+
+from kicad_tools.router.lattice.obstacles import (
+    _COLOCATION_EPSILON_MM,
+    CommittedCopper,
+    seg_body_crosses_pt,
+)
+
+
+def _committed(num_layers: int = 2) -> CommittedCopper:
+    return CommittedCopper(
+        num_layers,
+        trace_half=0.1,
+        clearance=0.2,
+        via_radius=0.3,
+        via_via_gap=0.65,
+        same_net_via_gap=0.8,
+    )
+
+
+# ---------------------------------------------------------------------------
+# seg_body_crosses_pt: the shared body-vs-endpoint predicate.
+# ---------------------------------------------------------------------------
+
+
+def test_body_crossing_detected_mid_span() -> None:
+    # (0,0)->(2,0) with a point at its midpoint (1,0) is a body crossing.
+    assert seg_body_crosses_pt((0.0, 0.0), (2.0, 0.0), (1.0, 0.0)) is True
+
+
+def test_endpoint_coincidence_is_exempt() -> None:
+    # A via tapped at either segment endpoint is the legal in-pad invariant.
+    assert seg_body_crosses_pt((0.0, 0.0), (2.0, 0.0), (0.0, 0.0)) is False
+    assert seg_body_crosses_pt((0.0, 0.0), (2.0, 0.0), (2.0, 0.0)) is False
+
+
+def test_point_off_the_line_is_not_a_crossing() -> None:
+    # Well clear of the segment: not a coincidence at all.
+    assert seg_body_crosses_pt((0.0, 0.0), (2.0, 0.0), (1.0, 0.5)) is False
+
+
+def test_near_endpoint_within_epsilon_is_exempt() -> None:
+    # Just inside epsilon of an endpoint still counts as the endpoint (legal).
+    p = (_COLOCATION_EPSILON_MM / 2.0, 0.0)
+    assert seg_body_crosses_pt((0.0, 0.0), (2.0, 0.0), p) is False
+
+
+# ---------------------------------------------------------------------------
+# CommittedCopper.seg_clear: same-net body-crossing is now rejected.
+# ---------------------------------------------------------------------------
+
+
+def test_seg_clear_rejects_same_net_body_crossing_via() -> None:
+    c = _committed()
+    net = 7
+    c.add_via((1.0, 0.0), net)  # same-net via at the segment's midpoint
+    # A same-net segment whose BODY runs across that via center is malformed.
+    assert c.seg_clear((0.0, 0.0), (2.0, 0.0), 0, net) is False
+
+
+def test_seg_clear_allows_same_net_via_at_endpoint() -> None:
+    c = _committed()
+    net = 7
+    c.add_via((0.0, 0.0), net)  # same-net via AT the segment endpoint (in-pad)
+    # The legitimate in-pad-escape endpoint-at-via-center invariant (#2706).
+    assert c.seg_clear((0.0, 0.0), (2.0, 0.0), 0, net) is True
+
+
+def test_seg_clear_still_rejects_different_net_via() -> None:
+    c = _committed()
+    c.add_via((1.0, 0.0), 3)  # different-net via on the segment body
+    # Different-net was already caught by the positive gap; still rejected.
+    assert c.seg_clear((0.0, 0.0), (2.0, 0.0), 0, 7) is False
+
+
+def test_seg_clear_allows_same_net_via_well_clear() -> None:
+    c = _committed()
+    net = 7
+    c.add_via((1.0, 5.0), net)  # far from the segment
+    assert c.seg_clear((0.0, 0.0), (2.0, 0.0), 0, net) is True
+
+
+# ---------------------------------------------------------------------------
+# _self_drc_reason: final gate over a net's OWN emitted geometry.
+# ---------------------------------------------------------------------------
+
+
+def _pathfinder():
+    """A LatticePathfinder instance is not needed to drive _self_drc_reason:
+    it is a pure method over a _RouteResult.  Build a minimal stand-in via the
+    class' unbound method to avoid constructing a full board lattice."""
+    from kicad_tools.router.lattice.pathfinder import LatticePathfinder
+
+    return LatticePathfinder.__new__(LatticePathfinder)
+
+
+def _route_result(runs, via_points):
+    from kicad_tools.router.lattice.pathfinder import _RouteResult
+
+    # ``route`` and ``resources`` are unused by _self_drc_reason.
+    return _RouteResult(route=None, runs=runs, via_points=via_points, resources=())
+
+
+def test_self_drc_declines_segment_crossing_own_via() -> None:
+    pf = _pathfinder()
+    # One run on layer 0 from (0,0) to (2,0); the net's own via sits mid-body.
+    runs = [(0, [(0.0, 0.0), (2.0, 0.0)], [0.2])]
+    result = _route_result(runs, via_points=[(1.0, 0.0)])
+    assert pf._self_drc_reason(result) == "self-drc-segment-via-coincident"
+
+
+def test_self_drc_accepts_via_at_run_endpoint() -> None:
+    pf = _pathfinder()
+    # A layer transition: the via sits at the run's endpoint (the normal case).
+    runs = [(0, [(0.0, 0.0), (2.0, 0.0)], [0.2])]
+    result = _route_result(runs, via_points=[(2.0, 0.0)])
+    assert pf._self_drc_reason(result) is None
+
+
+def test_self_drc_accepts_via_free_route() -> None:
+    pf = _pathfinder()
+    runs = [(0, [(0.0, 0.0), (2.0, 0.0)], [0.2])]
+    result = _route_result(runs, via_points=[])
+    assert pf._self_drc_reason(result) is None
+
+
+# ---------------------------------------------------------------------------
+# Router-vs-checker agreement (#4318 AC T1.3): the DRC checker flags a
+# different-net body-crossing that the lattice predicate also rejects, and the
+# checker (correctly) exempts the endpoint coincidence the predicate exempts.
+# ---------------------------------------------------------------------------
+
+
+_HEADER_2L = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (2 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "SIG1")
+  (net 2 "SIG2")
+"""
+
+
+def _checker_flags_segment_via(seg_ep, via_center, seg_net, via_net, tmp_path) -> bool:
+    """Run the real DRC ClearanceRule over one segment + one via and report
+    whether a ``clearance_segment_via`` error is produced.  Exercises the
+    checker's own edge-to-edge predicate + endpoint-only co-location
+    suppression (the same behavior ``kct check`` uses)."""
+    from kicad_tools.schema.pcb import PCB
+    from kicad_tools.validate import DRCChecker
+
+    (x1, y1), (x2, y2) = seg_ep
+    content = (
+        _HEADER_2L
+        + f"  (via (at {via_center[0]} {via_center[1]}) (size 0.6) (drill 0.3)"
+        + f'   (layers "F.Cu" "B.Cu") (net {via_net} "SIG{via_net}") (uuid "via-1"))\n'
+        + f"  (segment (start {x1} {y1}) (end {x2} {y2}) (width 0.2)"
+        + f'   (layer "F.Cu") (net {seg_net} "SIG{seg_net}") (uuid "seg-1"))\n'
+        + ")\n"
+    )
+    pcb_path = tmp_path / "seg_via.kicad_pcb"
+    pcb_path.write_text(content)
+    pcb = PCB.load(pcb_path)
+    checker = DRCChecker(pcb, manufacturer="jlcpcb", layers=2, copper_oz=1.0)
+    results = checker.check_clearances()
+    return any(v.rule_id == "clearance_segment_via" for v in results.violations)
+
+
+def test_checker_and_router_agree_on_body_crossing(tmp_path) -> None:
+    # Different-net body crossing: both the checker AND the lattice predicate
+    # reject it -- no router-vs-checker disagreement.
+    seg = ((100.0, 100.0), (102.0, 100.0))
+    via = (101.0, 100.0)
+    assert _checker_flags_segment_via(seg, via, 1, 2, tmp_path) is True
+
+    c = _committed()
+    c.add_via(via, 2)
+    assert c.seg_clear(seg[0], seg[1], 0, 1) is False
+
+
+def test_checker_and_router_agree_on_endpoint_exemption(tmp_path) -> None:
+    # Endpoint coincidence (in-pad invariant, #2706): the checker suppresses it
+    # AND the lattice predicate permits it (same-net) -- both agree it is legal.
+    seg = ((100.0, 100.0), (102.0, 100.0))
+    via = (100.0, 100.0)
+    assert _checker_flags_segment_via(seg, via, 1, 2, tmp_path) is False
+
+    c = _committed()
+    c.add_via(via, 1)  # same-net endpoint tap
+    assert c.seg_clear(seg[0], seg[1], 0, 1) is True
+
+
+def test_colocation_epsilon_matches_checker() -> None:
+    # The lattice epsilon must equal the DRC checker's co-location epsilon so
+    # the accept gate and kct check agree by construction.
+    from kicad_tools.validate.rules import clearance as clearance_mod
+
+    assert math.isclose(_COLOCATION_EPSILON_MM, clearance_mod._COLOCATION_EPSILON_MM)

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -1135,3 +1135,104 @@ class TestDrillClearanceNetRelationship:
         output_table(violations, results, Path("board.kicad_pcb"), "jlcpcb", 2, False)
         out = capsys.readouterr().out
         assert "dimension_drill_clearance: 3 errors (2 different-net, 1 same-net)" in out
+
+
+class TestClearanceSegmentViaNetRelationship:
+    """Issue #4318: same-net / different-net split for copper-copper clearance.
+
+    ``clearance_segment_via`` (and the sibling ``clearance_segment_segment`` /
+    ``clearance_via_via`` / ``clearance_pad_via`` rules) already carry
+    ``nets=(net_a, net_b)`` (set in ``_create_violation``,
+    ``validate/rules/clearance.py``), also serialized in ``--format json``.
+    Adding them to ``_NET_RELATIONSHIP_RULE_IDS`` gives them the same
+    presentational split ``dimension_drill_clearance`` gets: a per-finding
+    qualifier + unconditional ``Nets:`` line and a ``BY RULE`` sub-count.  An
+    agent can then triage a genuine different-net short ahead of a lower-risk
+    same-net coincidence.  Presentational only; severity is unchanged.
+    """
+
+    @staticmethod
+    def _violation(nets, rule_id="clearance_segment_via", severity="error"):
+        from kicad_tools.validate import DRCViolation
+
+        return DRCViolation(
+            rule_id=rule_id,
+            severity=severity,
+            message="Segment to via clearance 0.000mm < minimum 0.200mm",
+            location=(10.0, 20.0),
+            layer="F.Cu",
+            actual_value=0.0,
+            required_value=0.200,
+            items=("seg-1", "via-1"),
+            nets=tuple(nets),
+        )
+
+    def test_rule_ids_registered(self):
+        from kicad_tools.cli.check_cmd import _NET_RELATIONSHIP_RULE_IDS
+
+        for rid in (
+            "clearance_segment_via",
+            "clearance_segment_segment",
+            "clearance_via_via",
+            "clearance_pad_via",
+        ):
+            assert rid in _NET_RELATIONSHIP_RULE_IDS
+
+    def test_different_net_header_and_nets_default(self, capsys):
+        from kicad_tools.cli.check_cmd import _print_violation
+
+        _print_violation(self._violation(("SIG1", "SIG2")), verbose=False)
+        out = capsys.readouterr().out
+        assert "clearance_segment_via (different-net)" in out
+        assert "Nets: SIG1 / SIG2" in out
+
+    def test_same_net_header_and_nets_default(self, capsys):
+        from kicad_tools.cli.check_cmd import _print_violation
+
+        _print_violation(self._violation(("SIG1", "SIG1")), verbose=False)
+        out = capsys.readouterr().out
+        assert "clearance_segment_via (same-net)" in out
+        assert "Nets: SIG1 / SIG1" in out
+
+    def test_floating_endpoint_is_different_net(self, capsys):
+        from kicad_tools.cli.check_cmd import _print_violation
+
+        # A floating (net:0) endpoint in a segment-via pair classifies as
+        # different-net (#4127) -- never same-net.
+        _print_violation(self._violation(("net:0", "SIG1")), verbose=False)
+        out = capsys.readouterr().out
+        assert "clearance_segment_via (different-net)" in out
+
+    def test_by_rule_summary_split(self, capsys):
+        from pathlib import Path
+
+        from kicad_tools.cli.check_cmd import output_table
+        from kicad_tools.validate import DRCResults
+
+        results = DRCResults()
+        violations = [
+            self._violation(("SIG1", "SIG2")),  # different-net
+            self._violation(("SIG3", "SIG4")),  # different-net
+            self._violation(("SIG1", "SIG1")),  # same-net
+        ]
+        for v in violations:
+            results.add(v)
+        results.rules_checked = 1
+
+        output_table(violations, results, Path("board.kicad_pcb"), "jlcpcb", 2, False)
+        out = capsys.readouterr().out
+        assert "clearance_segment_via: 3 errors (2 different-net, 1 same-net)" in out
+
+    def test_json_still_carries_nets(self):
+        # AC T3: --format json must keep the nets pair (no schema regression).
+        v = self._violation(("SIG1", "SIG2"))
+        d = v.to_dict()
+        assert d["nets"] == ["SIG1", "SIG2"]
+
+    def test_sibling_rules_also_split(self, capsys):
+        from kicad_tools.cli.check_cmd import _print_violation
+
+        for rid in ("clearance_segment_segment", "clearance_via_via", "clearance_pad_via"):
+            _print_violation(self._violation(("A", "B"), rule_id=rid), verbose=False)
+            out = capsys.readouterr().out
+            assert f"{rid} (different-net)" in out


### PR DESCRIPTION
## Summary

Closes the complementary blind spot that let the octilinear `--route-engine lattice` engine emit **0.000mm `clearance_segment_via`** copper that no automated tool (`kct fix-drc`, `kct repair-clearance` at any `--max-displacement`) could clean — the single wall blocking a zero-human-GUI autonomous PCB flow (issue #4318). All three tiers are implemented.

The root cause was a two-sided gap: the lattice committed-copper predicates only enforced clearance against *different-net* elements (so a same-net segment landing on a via center was never rejected), and the DRC checker's co-location suppression is *endpoint-only* (so a segment whose *body* crosses a via center was not exempt). Net effect: an unfixable finding at 0.000mm.

## Changes

**Tier 1 — lattice must not emit clearance-violating copper (prevent at source)**
- `router/lattice/obstacles.py`: new `seg_body_crosses_pt` — the single body-vs-endpoint predicate (a point within epsilon of a segment *interior* but not either endpoint). `CommittedCopper.seg_clear` now rejects a **same-net** segment whose body crosses a same-net via center (different-net was already rejected by the positive gap), while preserving the legitimate in-pad-escape endpoint-at-via-center invariant (#2706). `_COLOCATION_EPSILON_MM` matches the DRC checker's constant so the accept gate and `kct check` agree by construction.
- `router/lattice/pathfinder.py`: new `LatticePathfinder._self_drc_reason`, a **final self-DRC gate** in `route_netset` over each net's own emitted geometry — a segment crossing the net's *own* via is committed together with that via and is never cross-checked during A*. Offenders **DECLINE** with `self-drc-segment-via-coincident`, which flows into the existing lattice `decline[...]` census (`core.py`); malformed copper is never committed.

**Tier 2 — opt-in cleanup (`--lattice-optimize`, off by default)**
- `cli/parser.py` + `cli/route_cmd.py`: new `--lattice-optimize` flag (both parsers); `cli/commands/routing.py` forwards it only when set (flag-off argv byte-identical).
- `_engine_post_passes_enabled` honors the flag: with it set, the optimize/DRC-nudge post-passes run on non-grid copper; absent, the #4281 skip is preserved exactly (**byte-identical** plain-lattice output).
- New `_mark_nongrid_routes_for_post_pass` marks committed lattice routes into the grid obstacle model **before** the passes so the optimizer collision checker is not blind (the specific #4281 root cause). Verified: board-02 `--lattice-optimize` runs both passes, marks 22 routes, and stays **8/8 with no backstop demotion**.
- `cli/repair_clearance_cmd.py`: steer the manual-repair guidance away from the `--max-displacement` dead end for coincident (0.000mm) copper (which regressed 33→34), pointing at re-route / the now-declining lattice engine.

**Tier 3 — same-net / different-net split for `clearance_segment_via`**
- `cli/check_cmd.py`: add `clearance_segment_via` (+ siblings `clearance_segment_segment`, `clearance_via_via`, `clearance_pad_via`) to `_NET_RELATIONSHIP_RULE_IDS`. The findings already carry `nets=(net_a, net_b)`, so BY RULE gains `(N different-net, M same-net)` and each finding header gains the `(same-net)`/`(different-net)` tag + `Nets:` line. `--format json` still carries `nets` (no schema change).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| T1: no 0.000mm segment-body-crosses-via committed (same or different net), in-pad endpoint (#2706) still exempt | ✅ | `test_self_drc.py` predicate + `seg_clear` + `_self_drc_reason` tests; body vs endpoint distinguished |
| T1: uncommittable connection declines with a census reason | ✅ | `_self_drc_reason` returns `self-drc-segment-via-coincident` → existing `decline[...]` census |
| T1: router accept gate uses same predicate as `kct check` | ✅ | `test_checker_and_router_agree_*` (checker flags a different-net body-crossing the lattice predicate also rejects; both exempt the endpoint case); epsilon-equality test |
| T2: `--lattice-optimize` runs a pass without backstop demotion | ✅ | `test_cli_lattice_optimize_runs_passes_without_demotion` — board-02 8/8, both passes ran, routes marked, no demotion |
| T2: flag absent → byte-identical (skip preserved) | ✅ | gating unit tests + `test_cli_lattice_skips_both_passes_and_demotes_nothing` |
| T2: repair-clearance no `33→34` regression on coincident copper | ✅ (guidance) | coincident copper is not a nudge fix; guidance no longer dead-ends on `--max-displacement`; Tier 1 prevents the emission at source so a fresh lattice run never produces it |
| T3: BY RULE shows `(N different-net, M same-net)` | ✅ | `test_by_rule_summary_split` |
| T3: per-finding qualifier + `Nets:` at default verbosity | ✅ | `test_different_net_header_and_nets_default`, `test_same_net_...`, floating→different-net |
| T3: `--format json` still carries `nets` | ✅ | `test_json_still_carries_nets` (`to_dict` unchanged) |

## Scope notes (honest partial)

- **Tier 1 is pure Python** — the lattice `CommittedCopper`/pathfinder are Python; the C++ backend (built + verified `available` in this worktree) is the grid router only, so no C++ edit was required.
- **Tier 2 deeper repair (`repair-clearance` dogleg/split of coincident copper)** is intentionally *not* implemented as a new geometric fixer: a global coincident-nudge change broke 18 legitimate enlarged-via repairs (the +x nudge is the correct in-pad endpoint repair), so I reverted it. Tier 1 makes it moot for lattice output — coincident copper is declined at the source and never emitted — and the manual-repair guidance is corrected so an agent is not sent down the `--max-displacement` dead end. The `#4281`-option-(b) full optimizer unification for arbitrary non-grid copper remains future work; `--lattice-optimize` delivers the safe opt-in (grid-marked, no demotion).

## Test Plan

New/extended: `tests/router/lattice/test_self_drc.py` (T1), `tests/router/lattice/test_post_pass_gating.py` (T2 flag + opt-in integration), `tests/test_cli_check.py::TestClearanceSegmentViaNetRelationship` (T3). Local: `ruff format --check` + `ruff check .` clean repo-wide; mypy within baseline (no new errors; baseline untouched per native-env guidance); targeted suites green (lattice 123, gating 18, self-DRC/check 46, check_cmd 70, repair+fix-drc 203, parser-drift 15, route smoke 31). Manual: `kct route --route-engine lattice --lattice-optimize` on board-02 → 8/8, no demotion; plain lattice run preserves the #4281 skip.

Closes #4318