### PR TITLE
feat(reinforce): anchor all runs of multi-branch nets with nudge-fallback and collinear-merge reporting

### DIFF
--- a/src/kicad_tools/cli/commands/pcb.py
+++ b/src/kicad_tools/cli/commands/pcb.py
@@ -477,6 +477,8 @@ def _run_reinforce_command(args, pcb_path: Path) -> int:
     wire_gauge = getattr(args, "wire_gauge", 16)
     spacing = getattr(args, "spacing", 15.0)
     layer = getattr(args, "layer", None)
+    all_runs = getattr(args, "all_runs", False)
+    min_run_length = getattr(args, "min_run_length", None)
     dry_run = getattr(args, "dry_run", False)
     output_format = getattr(args, "format", "text")
     output_path = Path(args.output) if getattr(args, "output", None) else pcb_path
@@ -495,6 +497,8 @@ def _run_reinforce_command(args, pcb_path: Path) -> int:
             spacing_mm=spacing,
             layer=layer,
             dry_run=dry_run,
+            all_runs=all_runs,
+            min_run_length_mm=min_run_length,
         )
     except ReinforceError as e:
         print(f"Error: {e}", file=sys.stderr)
@@ -517,6 +521,25 @@ def _run_reinforce_command(args, pcb_path: Path) -> int:
         "anchors_refused": outcome.refused_count,
         "refused": [
             {"x": round(r.x, 4), "y": round(r.y, 4), "reason": r.reason} for r in outcome.refused
+        ],
+        # Additive per-run accounting (#4319): existing keys above are
+        # unchanged so current agent consumers keep working.
+        "all_runs": all_runs,
+        "min_run_length_mm": min_run_length,
+        "runs_total": len(outcome.runs),
+        "runs_fully_reinforced": outcome.runs_fully_reinforced,
+        "runs_partial": outcome.runs_partial,
+        "runs_unanchored": outcome.runs_unanchored,
+        "runs": [
+            {
+                "run_index": rs.run_index,
+                "length_mm": round(rs.length_mm, 4),
+                "segment_count": rs.segment_count,
+                "anchors_needed": rs.anchors_needed,
+                "anchors_placed": rs.anchors_placed,
+                "anchors_refused": rs.anchors_refused,
+            }
+            for rs in outcome.runs
         ],
     }
 
@@ -543,6 +566,32 @@ def _run_reinforce_command(args, pcb_path: Path) -> int:
             print(
                 f"  Unhandled runs: {outcome.unhandled_runs} "
                 "(branch/disconnected run(s) on this net NOT anchored)"
+            )
+        print()
+        print(
+            f"  Runs: {len(outcome.runs)} total -- "
+            f"{outcome.runs_fully_reinforced} fully reinforced, "
+            f"{outcome.runs_partial} partial, "
+            f"{outcome.runs_unanchored} unanchored"
+        )
+        if not all_runs and len(outcome.runs) > 1:
+            print(
+                "        (default anchors only the longest run; pass "
+                "--all-runs to anchor every branch)"
+            )
+        for rs in outcome.runs:
+            if rs.fully_reinforced:
+                state = "full"
+            elif rs.partial:
+                state = "partial"
+            else:
+                state = "none"
+            print(
+                f"    run {rs.run_index}: {rs.length_mm:.1f} mm, "
+                f"{rs.segment_count} seg -- {rs.anchors_placed}/{rs.anchors_needed} "
+                f"anchored"
+                + (f", {rs.anchors_refused} refused" if rs.anchors_refused else "")
+                + f" [{state}]"
             )
         print()
         print(f"  Anchors placed:  {outcome.placed_count}")

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1650,6 +1650,22 @@ def _add_pcb_parser(subparsers) -> None:
         "cumulative routed length for the net)",
     )
     pcb_reinforce.add_argument(
+        "--all-runs",
+        dest="all_runs",
+        action="store_true",
+        help="Anchor EVERY chained run on the target layer (multi-branch HV "
+        "nets), not just the single longest run. Default anchors only the "
+        "longest run.",
+    )
+    pcb_reinforce.add_argument(
+        "--min-run-length",
+        dest="min_run_length",
+        type=float,
+        default=None,
+        help="Only anchor runs at least this long, in mm. Shorter runs are "
+        "reported but not anchored. Composes with --all-runs.",
+    )
+    pcb_reinforce.add_argument(
         "-o",
         "--output",
         dest="output",

--- a/src/kicad_tools/pcb/reinforce.py
+++ b/src/kicad_tools/pcb/reinforce.py
@@ -47,7 +47,9 @@ from kicad_tools.physics.wire_gauge import (
     anchor_drill_for_awg,
     anchor_pad_for_drill,
 )
+from kicad_tools.router.optimizer.algorithms import merge_collinear
 from kicad_tools.router.optimizer.chain import sort_into_chains
+from kicad_tools.router.optimizer.config import OptimizationConfig
 from kicad_tools.router.primitives import Segment as RouterSegment
 from kicad_tools.router.via_clearance import (
     FilledPolygonLike,
@@ -60,6 +62,20 @@ from kicad_tools.schema.pcb import PCB, Segment
 # Default spacing between mid-run anchors (mm). Matches the architect's
 # ``ReinforcementSpec.anchor_spacing_mm`` default.
 DEFAULT_ANCHOR_SPACING_MM = 15.0
+
+# Tier-2 nudge-fallback bound (#4319). When a candidate anchor collides with
+# other-net copper, the pass searches along the run's arc-length axis by up to
+# ``NUDGE_MAX_FRACTION_OF_SPACING * spacing_mm`` (symmetric ±), in
+# ``NUDGE_STEPS`` increments each side, and places the first clear position
+# before recording a refusal. A genuinely blocked position (nothing clear in
+# the whole window) is still hard-refused -- the search is finite and cheap.
+NUDGE_MAX_FRACTION_OF_SPACING = 0.5
+NUDGE_STEPS = 4
+
+# Config used for the tier-3 within-run collinear merge (#4319). Only
+# ``tolerance`` is consulted by :func:`merge_collinear`'s connectivity /
+# direction predicates; the rest are inert here.
+_MERGE_CONFIG = OptimizationConfig()
 
 # Fallback design rules when no manufacturer profile is supplied. These are
 # JLCPCB-tier-typical values; the annular-ring floor is what actually sizes
@@ -93,6 +109,44 @@ class PlacedAnchor:
 
 
 @dataclass
+class RunSummary:
+    """Per-run anchoring accounting (#4319, tier 2).
+
+    One entry per chained run on the target layer -- including runs that were
+    NOT anchored (filtered by ``min_run_length_mm`` or, in default mode, every
+    run but the longest). This lets an agent distinguish "fully reinforced"
+    from "2 of 31 runs reinforced" straight from ``--format json``.
+
+    ``segment_count`` and ``length_mm`` reflect the *merged* geometric run
+    (contiguous collinear fragments coalesced -- tier 3), not the raw
+    fragment count.
+    """
+
+    run_index: int
+    length_mm: float
+    segment_count: int
+    #: Number of anchor positions this run demands (endpoints + spacing).
+    anchors_needed: int
+    #: Anchor positions actually covered on this run (placed this pass, or
+    #: already covered by a coincident anchor from another run).
+    anchors_placed: int
+    #: Anchor positions on this run that were hard-refused (no clear nudge).
+    anchors_refused: int
+
+    @property
+    def fully_reinforced(self) -> bool:
+        return self.anchors_needed > 0 and self.anchors_placed >= self.anchors_needed
+
+    @property
+    def partial(self) -> bool:
+        return 0 < self.anchors_placed < self.anchors_needed
+
+    @property
+    def unanchored(self) -> bool:
+        return self.anchors_placed == 0
+
+
+@dataclass
 class ReinforceResult:
     """Outcome of a :func:`reinforce_net` pass."""
 
@@ -102,13 +156,17 @@ class ReinforceResult:
     anchor_pad_mm: float
     spacing_mm: float
     layer: str = ""
-    #: Segments chained into the anchored (longest) run.
+    #: Segments chained into the primary anchored (longest anchored) run,
+    #: after the tier-3 collinear merge.
     run_segment_count: int = 0
-    #: Cumulative arc length of the anchored run, in mm.
+    #: Cumulative arc length of the primary anchored run, in mm.
     run_length_mm: float = 0.0
-    #: Number of additional linear runs on this net that were NOT anchored
-    #: (branches / disconnected runs -- reported, not silently dropped).
+    #: Number of chained runs on this net that were NOT anchored (branches /
+    #: disconnected / below-threshold runs -- reported, not silently dropped).
     unhandled_runs: int = 0
+    #: Per-run anchoring accounting (one entry per chained run). Additive over
+    #: the legacy whole-net fields above.
+    runs: list[RunSummary] = field(default_factory=list)
     placed: list[PlacedAnchor] = field(default_factory=list)
     refused: list[RefusedAnchor] = field(default_factory=list)
 
@@ -119,6 +177,18 @@ class ReinforceResult:
     @property
     def refused_count(self) -> int:
         return len(self.refused)
+
+    @property
+    def runs_fully_reinforced(self) -> int:
+        return sum(1 for r in self.runs if r.fully_reinforced)
+
+    @property
+    def runs_partial(self) -> int:
+        return sum(1 for r in self.runs if r.partial)
+
+    @property
+    def runs_unanchored(self) -> int:
+        return sum(1 for r in self.runs if r.unanchored)
 
 
 class ReinforceError(ValueError):
@@ -239,14 +309,49 @@ def _run_length(run: list[Segment]) -> float:
     return sum(_seg_length(s) for s in run)
 
 
-def _ordered_points(run: list[Segment]) -> list[tuple[float, float]]:
-    """Return the ordered vertex list of an oriented run polyline."""
-    if not run:
-        return []
-    pts: list[tuple[float, float]] = [run[0].start]
-    for seg in run:
-        pts.append(seg.end)
-    return pts
+def _cumulative_arc(points: list[tuple[float, float]]) -> list[float]:
+    """Cumulative arc length at each vertex of a polyline."""
+    cum: list[float] = [0.0]
+    for i in range(1, len(points)):
+        (x0, y0), (x1, y1) = points[i - 1], points[i]
+        cum.append(cum[-1] + math.hypot(x1 - x0, y1 - y0))
+    return cum
+
+
+def _anchor_arc_targets(total: float, spacing: float) -> list[float]:
+    """Arc-length sample points: 0, spacing, 2*spacing, ... and the endpoint.
+
+    Always includes the final endpoint (so both true endpoints are anchored
+    even if the last interval is shorter than ``spacing``).
+    """
+    if total <= 0:
+        return [0.0]
+    targets: list[float] = []
+    d = 0.0
+    while d < total - 1e-9:
+        targets.append(d)
+        d += spacing
+    targets.append(total)
+    return targets
+
+
+def _point_at_arc(
+    points: list[tuple[float, float]], cum: list[float], t: float
+) -> tuple[float, float]:
+    """Interpolate the point at arc length ``t`` along a polyline."""
+    if len(points) < 2:
+        return points[0]
+    total = cum[-1]
+    t = max(0.0, min(total, t))
+    seg_i = 0
+    while seg_i < len(cum) - 2 and cum[seg_i + 1] < t:
+        seg_i += 1
+    seg_len = cum[seg_i + 1] - cum[seg_i]
+    if seg_len <= 1e-12:
+        return points[seg_i]
+    frac = max(0.0, min(1.0, (t - cum[seg_i]) / seg_len))
+    (x0, y0), (x1, y1) = points[seg_i], points[seg_i + 1]
+    return (x0 + frac * (x1 - x0), y0 + frac * (y1 - y0))
 
 
 def _anchor_positions(
@@ -262,36 +367,95 @@ def _anchor_positions(
         return list(points)
     if spacing <= 0:
         raise ReinforceError(f"spacing must be positive, got {spacing}")
+    cum = _cumulative_arc(points)
+    return [_point_at_arc(points, cum, t) for t in _anchor_arc_targets(cum[-1], spacing)]
 
-    # Cumulative arc length at each vertex.
-    cum: list[float] = [0.0]
-    for i in range(1, len(points)):
-        (x0, y0), (x1, y1) = points[i - 1], points[i]
-        cum.append(cum[-1] + math.hypot(x1 - x0, y1 - y0))
-    total = cum[-1]
 
-    targets: list[float] = []
-    d = 0.0
-    while d < total - 1e-9:
-        targets.append(d)
-        d += spacing
-    targets.append(total)  # always the final endpoint
+@dataclass
+class _RunGeom:
+    """Merged geometry of one chained run (tier-3 collinear-coalesced)."""
 
-    positions: list[tuple[float, float]] = []
-    seg_i = 0
-    for t in targets:
-        # Advance to the polyline segment containing arc length ``t``.
-        while seg_i < len(cum) - 2 and cum[seg_i + 1] < t:
-            seg_i += 1
-        seg_len = cum[seg_i + 1] - cum[seg_i]
-        if seg_len <= 1e-12:
-            positions.append(points[seg_i])
-            continue
-        frac = (t - cum[seg_i]) / seg_len
-        frac = max(0.0, min(1.0, frac))
-        (x0, y0), (x1, y1) = points[seg_i], points[seg_i + 1]
-        positions.append((x0 + frac * (x1 - x0), y0 + frac * (y1 - y0)))
-    return positions
+    points: list[tuple[float, float]]
+    segment_count: int
+    length_mm: float
+
+
+def _run_geometry(run: list[Segment]) -> _RunGeom:
+    """Collapse contiguous collinear fragments within an oriented run (#4319).
+
+    Tier 3: the junction-aware chainer (:func:`sort_into_chains`) already
+    walks collinear degree-2 fragments head-to-tail into ONE run, but leaves
+    them as separate ``Segment`` objects, so ``run_segment_count`` reports the
+    raw fragment count (e.g. a straight branch expressed as many short
+    octilinear pieces). This step reuses
+    :func:`kicad_tools.router.optimizer.algorithms.merge_collinear` to coalesce
+    those fragments so the reported ``segment_count`` reflects the true
+    geometric run.
+
+    The merge operates ONLY within an already-split run, so it never bridges a
+    junction (degree>=3) -- the #2389 no-branch-drop guarantee that
+    ``sort_into_chains`` provides is preserved. It removes only *collinear*
+    interior vertices, so the arc-length geometry (and therefore every anchor
+    position) is byte-for-byte unchanged.
+    """
+    if not run:
+        return _RunGeom(points=[], segment_count=0, length_mm=0.0)
+    router_segs = [_to_router_segment(s) for s in run]
+    merged = merge_collinear(router_segs, _MERGE_CONFIG)
+    points: list[tuple[float, float]] = [(merged[0].x1, merged[0].y1)]
+    length = 0.0
+    for m in merged:
+        points.append((m.x2, m.y2))
+        length += math.hypot(m.x2 - m.x1, m.y2 - m.y1)
+    return _RunGeom(points=points, segment_count=len(merged), length_mm=length)
+
+
+def _nudge_arc_candidates(t: float, total: float, spacing: float):
+    """Yield the base arc length then symmetric bounded nudges (#4319, tier 2).
+
+    Order: the base position first, then +/- increments outward, up to
+    ``NUDGE_MAX_FRACTION_OF_SPACING * spacing`` on each side. Candidates are
+    clamped to ``[0, total]``.
+    """
+    yield max(0.0, min(total, t))
+    max_off = spacing * NUDGE_MAX_FRACTION_OF_SPACING
+    if max_off <= 0 or NUDGE_STEPS <= 0:
+        return
+    step = max_off / NUDGE_STEPS
+    for k in range(1, NUDGE_STEPS + 1):
+        off = step * k
+        for cand in (t + off, t - off):
+            if -1e-9 <= cand <= total + 1e-9:
+                yield max(0.0, min(total, cand))
+
+
+def _too_close(p: tuple[float, float], placed: list[tuple[float, float]], floor: float) -> bool:
+    """True when ``p`` is within ``floor`` (center-to-center) of a placed anchor."""
+    return any(math.hypot(p[0] - q[0], p[1] - q[1]) < floor - 1e-9 for q in placed)
+
+
+def _position_clear(
+    x: float,
+    y: float,
+    anchor_pad: float,
+    anchor_drill: float,
+    rules: DesignRules,
+    other: _OtherNetCopper,
+) -> bool:
+    """Clearance re-check of a candidate anchor against all other-net copper."""
+    return point_clear_of_copper(
+        x,
+        y,
+        via_size=anchor_pad,
+        clearance=rules.min_clearance_mm,
+        other_net_tracks=other.tracks,
+        other_net_vias=other.vias,
+        other_net_pads=other.pads,
+        other_net_filled_polygons=other.filled_polygons,
+        via_drill=anchor_drill,
+        other_net_drills=other.drills,
+        min_hole_to_hole=rules.min_hole_to_hole_mm,
+    )
 
 
 class _TrackObstacle:
@@ -384,14 +548,22 @@ def reinforce_net(
     design_rules: DesignRules | None = None,
     layer: str | None = None,
     dry_run: bool = False,
+    all_runs: bool = False,
+    min_run_length_mm: float | None = None,
 ) -> ReinforceResult:
     """Emit a spaced same-net PTH anchor row along a routed net's trace.
 
     Post-route pass: chains the target net's routed segments into ordered
-    polylines, selects the longest linear run, and places gauge-sized
-    plated-PTH anchor vias at both endpoints and every ``spacing_mm`` along
-    it. Each candidate anchor is clearance-checked against all other-net
-    copper; colliding anchors are refused (reported, not placed).
+    polylines and places gauge-sized plated-PTH anchor vias at both endpoints
+    and every ``spacing_mm`` along the selected run(s). Each candidate anchor
+    is clearance-checked against all other-net copper; a colliding candidate is
+    nudged a bounded distance along the run's arc-length axis and, only if no
+    clear position is found, refused (reported, not placed).
+
+    By default (``all_runs=False``) only the single longest run is anchored --
+    the historical MVP behavior. A multi-branch HV net (T/Y fan-out at
+    junctions) splits into several runs; passing ``all_runs=True`` anchors
+    *every* run so N-1 branches are no longer left un-reinforced (#4319).
 
     Args:
         pcb: A loaded :class:`~kicad_tools.schema.pcb.PCB`.
@@ -407,10 +579,16 @@ def reinforce_net(
             the most cumulative segment length for the net is chosen.
         dry_run: When True, compute the placed/refused plan without
             mutating the board (no vias added).
+        all_runs: When True, anchor every chained run on the target layer
+            (subject to ``min_run_length_mm``) instead of only the longest.
+        min_run_length_mm: When set, only runs at least this long (mm) are
+            anchored; shorter runs are still reported (never silently
+            dropped). Composes with ``all_runs`` -- filter first, then anchor
+            all that survive.
 
     Returns:
-        A :class:`ReinforceResult` summarising placed/refused anchors and
-        the anchored run.
+        A :class:`ReinforceResult` summarising placed/refused anchors, the
+        primary anchored run, and a per-run :class:`RunSummary` list.
 
     Raises:
         ReinforceError: If the net does not exist, has no routed copper, or
@@ -469,51 +647,101 @@ def reinforce_net(
     if not runs:
         raise ReinforceError(f"net {net_name!r} produced no walkable polyline")
 
+    # Longest-first so the "primary" run (default mode) is runs[0] and the
+    # per-run summary is stably ordered.
     runs.sort(key=_run_length, reverse=True)
-    anchored_run = runs[0]
-    result.run_segment_count = len(anchored_run)
-    result.run_length_mm = _run_length(anchored_run)
-    result.unhandled_runs = len(runs) - 1
 
-    points = _ordered_points(anchored_run)
-    positions = _anchor_positions(points, spacing_mm)
+    # Tier 3: coalesce contiguous collinear fragments within each run so the
+    # reported segment count reflects true geometric runs (anchor positions
+    # unchanged -- merge only removes collinear interior vertices).
+    geoms = [_run_geometry(run) for run in runs]
+
+    # Selection: filter by min length (report -- do not drop -- shorter runs),
+    # then anchor either all survivors (all_runs) or just the longest.
+    if min_run_length_mm is not None:
+        eligible = [i for i, g in enumerate(geoms) if g.length_mm >= min_run_length_mm]
+    else:
+        eligible = list(range(len(geoms)))
+    anchored_idx: set[int] = set(eligible if all_runs else eligible[:1])
+
+    # Backward-compat whole-net fields describe the primary (longest anchored)
+    # run; zero when everything was filtered out.
+    if anchored_idx:
+        primary = geoms[min(anchored_idx)]
+        result.run_segment_count = primary.segment_count
+        result.run_length_mm = primary.length_mm
+    result.unhandled_runs = len(geoms) - len(anchored_idx)
 
     other = _collect_other_net_copper(pcb, target_net_number)
 
-    for x, y in positions:
-        clear = point_clear_of_copper(
-            x,
-            y,
-            via_size=anchor_pad,
-            clearance=rules.min_clearance_mm,
-            other_net_tracks=other.tracks,
-            other_net_vias=other.vias,
-            other_net_pads=other.pads,
-            other_net_filled_polygons=other.filled_polygons,
-            via_drill=anchor_drill,
-            other_net_drills=other.drills,
-            min_hole_to_hole=rules.min_hole_to_hole_mm,
-        )
-        if not clear:
-            result.refused.append(
-                RefusedAnchor(
-                    x=x,
-                    y=y,
-                    reason="other-net clearance/hole-to-hole violation",
-                )
-            )
-            continue
+    # Cross-run dedup floor: two placed anchors must be at least a pad diameter
+    # apart center-to-center (no overlapping copper), which also satisfies the
+    # hole-to-hole floor. Shared junction vertices between fanned-out runs land
+    # at the same coordinate and are anchored once.
+    dedup_floor = max(anchor_pad, anchor_drill + rules.min_hole_to_hole_mm)
+    placed_positions: list[tuple[float, float]] = []
 
-        if not dry_run:
-            pcb.add_via(
-                x,
-                y,
-                size=anchor_pad,
-                drill=anchor_drill,
-                layers=("F.Cu", "B.Cu"),
-                net=net_name,
-                dedupe=True,
+    for i, g in enumerate(geoms):
+        cum = _cumulative_arc(g.points)
+        targets = _anchor_arc_targets(g.length_mm, spacing_mm)
+        run_placed = 0
+        run_refused = 0
+
+        if i in anchored_idx:
+            for t in targets:
+                base = _point_at_arc(g.points, cum, t)
+                # Already covered by a coincident anchor (e.g. a shared
+                # junction vertex from another run) -- count as reinforced,
+                # not a new placement and not a refusal.
+                if _too_close(base, placed_positions, dedup_floor):
+                    run_placed += 1
+                    continue
+
+                chosen: tuple[float, float] | None = None
+                for cand_t in _nudge_arc_candidates(t, g.length_mm, spacing_mm):
+                    cx, cy = _point_at_arc(g.points, cum, cand_t)
+                    if _too_close((cx, cy), placed_positions, dedup_floor):
+                        continue
+                    if _position_clear(cx, cy, anchor_pad, anchor_drill, rules, other):
+                        chosen = (cx, cy)
+                        break
+
+                if chosen is None:
+                    bx, by = base
+                    result.refused.append(
+                        RefusedAnchor(
+                            x=bx,
+                            y=by,
+                            reason="other-net clearance/hole-to-hole violation",
+                        )
+                    )
+                    run_refused += 1
+                    continue
+
+                cx, cy = chosen
+                if not dry_run:
+                    pcb.add_via(
+                        cx,
+                        cy,
+                        size=anchor_pad,
+                        drill=anchor_drill,
+                        layers=("F.Cu", "B.Cu"),
+                        net=net_name,
+                        dedupe=True,
+                    )
+                result.placed.append(PlacedAnchor(x=cx, y=cy))
+                placed_positions.append((cx, cy))
+                run_placed += 1
+
+        result.runs.append(
+            RunSummary(
+                run_index=i,
+                length_mm=g.length_mm,
+                segment_count=g.segment_count,
+                anchors_needed=len(targets),
+                anchors_placed=run_placed,
+                anchors_refused=run_refused,
             )
-        result.placed.append(PlacedAnchor(x=x, y=y))
+        )
 
     return result

--- a/tests/test_pcb_reinforce.py
+++ b/tests/test_pcb_reinforce.py
@@ -149,6 +149,29 @@ def _branched_run_pcb(net: str = "FUSED_LINE") -> PCB:
     return pcb
 
 
+def _fragmented_straight_pcb(net: str = "FUSED_LINE", pieces: int = 12) -> PCB:
+    """A single straight run expressed as many short collinear fragments.
+
+    Emulates lattice/octilinear output where a straight branch is a chain of
+    many short degree-2 collinear segments. The junction-aware chainer walks
+    them into ONE run but leaves them as ``pieces`` separate segments; the
+    tier-3 collinear merge coalesces them for reporting.
+    """
+    pcb = PCB.create(width=200, height=100, center=False)
+    x0, y = 20.0, 50.0
+    length = 96.0
+    step = length / pieces
+    for i in range(pieces):
+        pcb.add_trace(
+            (x0 + i * step, y),
+            (x0 + (i + 1) * step, y),
+            width=2.0,
+            layer="F.Cu",
+            net=net,
+        )
+    return pcb
+
+
 def _net_segments(pcb: PCB, net_name: str) -> list[Segment]:
     """Return segments for ``net_name`` (``add_trace`` leaves seg net_name empty)."""
     net_obj = pcb.get_net_by_name(net_name)
@@ -307,22 +330,47 @@ class TestReinforceNet:
 
 
 class TestClearanceRefuse:
-    def test_refuses_anchor_on_foreign_net_drill(self):
-        """A foreign-net through-hole pad where an anchor would land is refused."""
+    def test_nudges_off_foreign_net_drill_then_places(self):
+        """A foreign-net pad where an anchor would land triggers a bounded nudge.
+
+        Tier-2 (#4319): rather than immediately refusing, the pass searches a
+        short distance along the run's arc-length axis and places the first
+        clear position. With ample clear copper on either side of the lone
+        foreign pad, the anchor is placed at a nudged spot -- NOT on the pad,
+        and NOT refused.
+        """
         pcb = _straight_run_pcb(length=100.0)
-        # An anchor lands at x=35 (arc-length 15 from x0=20). Drop a foreign
-        # through-hole pad right there so the hole-to-hole / clearance check
-        # must refuse it.
+        # An anchor lands at x=35 (arc-length 15 from x0=20). Drop a lone
+        # foreign through-hole pad right there.
         _add_th_pad_footprint(pcb, ref="TP1", x=35.0, y=50.0, net="OTHER", drill=1.0, size=2.0)
 
         result = reinforce_net(pcb, "FUSED_LINE", spacing_mm=15.0)
 
-        assert result.refused_count >= 1
-        # The refused anchor is at/near the foreign pad, and NOT placed there.
-        refused_pts = [(r.x, r.y) for r in result.refused]
-        assert any(abs(rx - 35.0) < 0.5 and abs(ry - 50.0) < 0.5 for rx, ry in refused_pts)
+        # Nudge found clear space, so nothing was refused ...
+        assert result.refused_count == 0
         placed_pts = [(a.x, a.y) for a in result.placed]
-        assert not any(abs(px - 35.0) < 0.5 and abs(py - 50.0) < 0.5 for px, py in placed_pts)
+        # ... no anchor sits on/near the foreign pad ...
+        assert not any(abs(px - 35.0) < 2.0 and abs(py - 50.0) < 2.0 for px, py in placed_pts)
+        # ... but an anchor was placed at a nudged position near it (within the
+        # +/- spacing/2 search window).
+        assert any(35.0 < px <= 42.5 and abs(py - 50.0) < 1e-6 for px, py in placed_pts)
+
+    def test_hard_blocked_position_still_refuses(self):
+        """A position blocked across the entire nudge window is still refused."""
+        pcb = _straight_run_pcb(length=100.0)
+        # A wide foreign track spanning the whole +/- spacing/2 window around
+        # the x=35 anchor: every nudge candidate collides -> hard refusal.
+        pcb.add_trace((27, 50), (43, 50), width=3.0, layer="F.Cu", net="OTHER")
+
+        result = reinforce_net(pcb, "FUSED_LINE", spacing_mm=15.0)
+
+        assert result.refused_count >= 1
+        refused_pts = [(r.x, r.y) for r in result.refused]
+        # The refusal is recorded at the blocked base position (x=35).
+        assert any(abs(rx - 35.0) < 0.5 and abs(ry - 50.0) < 0.5 for rx, ry in refused_pts)
+        # And no anchor was placed inside the blocked span.
+        placed_pts = [(a.x, a.y) for a in result.placed]
+        assert not any(27.0 <= px <= 43.0 and abs(py - 50.0) < 1e-6 for px, py in placed_pts)
 
     def test_same_net_pad_does_not_refuse(self):
         """A pad on the SAME net does not trigger a refusal."""
@@ -528,3 +576,169 @@ class TestReinforceCLI:
         assert args.net == "FUSED_LINE"
         assert args.wire_gauge == 16
         assert args.spacing == 15.0
+        # New flags default to backward-compatible values (#4319).
+        assert args.all_runs is False
+        assert args.min_run_length is None
+
+    def test_parser_accepts_all_runs_and_min_run_length(self):
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(
+            [
+                "pcb",
+                "reinforce",
+                "board.kicad_pcb",
+                "--net",
+                "FUSED_LINE",
+                "--all-runs",
+                "--min-run-length",
+                "25.5",
+            ]
+        )
+        assert args.all_runs is True
+        assert args.min_run_length == pytest.approx(25.5)
+
+    def test_cli_all_runs_json_is_additive_superset(self, tmp_path, capsys):
+        """`--all-runs --format json` keeps legacy keys and adds per-run detail."""
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+
+        pcb_path = tmp_path / "board.kicad_pcb"
+        _branched_run_pcb().save(pcb_path)
+
+        rc = run_pcb_command(_reinforce_args(pcb_path, format="json", all_runs=True))
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+
+        # Legacy keys still present (AC-12: additive only).
+        for key in (
+            "run_segment_count",
+            "run_length_mm",
+            "unhandled_runs",
+            "anchors_placed",
+            "anchors_refused",
+            "refused",
+        ):
+            assert key in data
+        # New additive per-run keys.
+        assert data["all_runs"] is True
+        assert data["runs_total"] == 3
+        assert isinstance(data["runs"], list) and len(data["runs"]) == 3
+        for rs in data["runs"]:
+            assert {
+                "run_index",
+                "length_mm",
+                "segment_count",
+                "anchors_needed",
+                "anchors_placed",
+                "anchors_refused",
+            } <= set(rs)
+        # An agent can read "N of M runs reinforced" programmatically.
+        assert data["runs_fully_reinforced"] >= 2
+
+
+class TestAllRunsAnchoring:
+    def test_default_mode_anchors_only_longest_run(self):
+        pcb = _branched_run_pcb()
+        result = reinforce_net(pcb, "FUSED_LINE", spacing_mm=15.0)
+        # Three runs reported; only the longest (west, 80mm) is anchored.
+        assert len(result.runs) == 3
+        anchored = [r for r in result.runs if r.anchors_placed > 0]
+        assert len(anchored) == 1
+        # Every placed anchor lies on the west arm (x<=100, y==50).
+        assert all(a.x <= 100.0 + 1e-6 and abs(a.y - 50.0) < 1e-6 for a in result.placed)
+        assert result.unhandled_runs == 2
+
+    def test_all_runs_anchors_every_branch(self):
+        pcb = _branched_run_pcb()
+        default = reinforce_net(_branched_run_pcb(), "FUSED_LINE", spacing_mm=15.0)
+        result = reinforce_net(pcb, "FUSED_LINE", spacing_mm=15.0, all_runs=True)
+
+        # Anchors now land on >=2 distinct runs (the pre-fix code placed on
+        # exactly one). East arm (x>100) and branch (y>50) both anchored.
+        assert any(a.x > 100.0 + 1e-6 for a in result.placed)
+        assert any(a.y > 50.0 + 1e-6 for a in result.placed)
+        anchored_runs = [r for r in result.runs if r.anchors_placed > 0]
+        assert len(anchored_runs) >= 2
+        # Strictly more coverage than default single-longest-run mode.
+        assert result.placed_count > default.placed_count
+        assert result.unhandled_runs == 0
+        assert result.runs_fully_reinforced == 3
+
+    def test_all_runs_dedupes_shared_junction_vertex(self):
+        """The junction vertex shared by all three arms is anchored exactly once."""
+        pcb = _branched_run_pcb()
+        result = reinforce_net(pcb, "FUSED_LINE", spacing_mm=15.0, all_runs=True)
+        junction_hits = [
+            a for a in result.placed if abs(a.x - 100.0) < 1e-6 and abs(a.y - 50.0) < 1e-6
+        ]
+        assert len(junction_hits) == 1
+
+    def test_all_runs_idempotent_second_run_adds_no_new_vias(self):
+        pcb = _branched_run_pcb()
+        reinforce_net(pcb, "FUSED_LINE", spacing_mm=15.0, all_runs=True)
+        after_first = len(pcb.vias)
+        reinforce_net(pcb, "FUSED_LINE", spacing_mm=15.0, all_runs=True)
+        assert len(pcb.vias) == after_first
+
+    def test_min_run_length_filters_short_runs_but_reports_them(self):
+        pcb = _branched_run_pcb()
+        # Threshold 30mm: west (80) and east (50) anchored; branch (20) filtered.
+        result = reinforce_net(
+            pcb, "FUSED_LINE", spacing_mm=15.0, all_runs=True, min_run_length_mm=30.0
+        )
+        # All three runs are still reported (never silently dropped).
+        assert len(result.runs) == 3
+        # The 20mm branch (goes up to y=70) is NOT anchored.
+        assert not any(a.y > 50.0 + 1e-6 for a in result.placed)
+        short = [r for r in result.runs if r.length_mm < 30.0]
+        assert len(short) == 1
+        assert short[0].anchors_placed == 0
+        assert short[0].anchors_needed > 0
+        assert result.unhandled_runs == 1
+
+    def test_all_runs_below_threshold_places_nothing_without_error(self):
+        pcb = _branched_run_pcb()
+        result = reinforce_net(
+            pcb, "FUSED_LINE", spacing_mm=15.0, all_runs=True, min_run_length_mm=500.0
+        )
+        assert result.placed_count == 0
+        assert len(result.runs) == 3
+        assert result.run_segment_count == 0
+        assert result.unhandled_runs == 3
+
+
+class TestCollinearMergeReporting:
+    def test_raw_chain_keeps_fragments_but_report_merges(self):
+        pcb = _fragmented_straight_pcb(pieces=12)
+        segs = _net_segments(pcb, "FUSED_LINE")
+        raw_run = _chain_polylines(segs)[0]
+        # sort_into_chains walks the fragments into ONE run but keeps them as
+        # 12 separate segments ...
+        assert len(raw_run) == 12
+
+        result = reinforce_net(pcb, "FUSED_LINE", spacing_mm=15.0)
+        # ... while the reinforce report coalesces them to a single geometric
+        # segment (materially lower count).
+        assert result.run_segment_count == 1
+        assert result.runs[0].segment_count == 1
+
+    def test_anchor_positions_unchanged_by_merge(self):
+        pcb = _fragmented_straight_pcb(pieces=12)
+        segs = _net_segments(pcb, "FUSED_LINE")
+        raw_run = _chain_polylines(segs)[0]
+        raw_points = [raw_run[0].start] + [s.end for s in raw_run]
+        expected = _anchor_positions(raw_points, 15.0)
+
+        result = reinforce_net(pcb, "FUSED_LINE", spacing_mm=15.0)
+        placed = sorted((round(a.x, 6), round(a.y, 6)) for a in result.placed)
+        exp = sorted((round(x, 6), round(y, 6)) for x, y in expected)
+        # Merge changes reporting, not anchor coverage.
+        assert placed == exp
+
+    def test_merge_does_not_bridge_junctions(self):
+        """Collinear merge must not merge across a degree-3 junction (#2389)."""
+        pcb = _branched_run_pcb()
+        result = reinforce_net(pcb, "FUSED_LINE", spacing_mm=15.0, all_runs=True)
+        # Still three distinct runs after merge -- the junction is never bridged.
+        assert len(result.runs) == 3


### PR DESCRIPTION
## Summary

`kct pcb reinforce` was a #4220 MVP that anchored only the single **longest**
chained run. On a multi-branch HV net (T/Y fan-out at junctions), the chainer
splits copper into several runs, so N-1 branches were dropped into
`unhandled_runs` and left un-reinforced — the reported `/AC_NEUTRAL: 0 placed,
24 unhandled` symptom. This PR lands all three fix tiers from #4319 in one
change, keeping the default (no-new-flags) invocation behaviorally compatible.

## Changes

**Tier 1 — anchor all current-carrying runs**
- `reinforce_net()` gains `all_runs: bool = False` and
  `min_run_length_mm: float | None = None`. With `all_runs=True`, every chained
  run on the target layer is anchored (endpoints + spacing), not just `runs[0]`.
- `min_run_length_mm` filters short runs (still **reported**, never silently
  dropped) and composes with `all_runs` (filter, then anchor all survivors).
- Cross-run dedup at a pad-diameter floor: the junction vertex shared by
  fanned-out branches is anchored exactly once; re-running stays idempotent
  (same-net anchors never block later same-net anchors; `add_via(dedupe=True)`
  rejects identical vias).
- CLI `--all-runs` / `--min-run-length <mm>` flags wired through
  `_run_reinforce_command()`.

**Tier 2 — refusal nudge-fallback + per-run summary**
- On an other-net collision, the pass now searches a **bounded** window along
  the run's arc-length axis (`± NUDGE_MAX_FRACTION_OF_SPACING * spacing` in
  `NUDGE_STEPS` increments — named constants, not literals) and places the first
  clear position before recording a `RefusedAnchor`. Genuinely blocked positions
  still hard-refuse; the search is finite. Applies to the default longest-run
  path too (AC-8).
- New `RunSummary(run_index, length_mm, segment_count, anchors_needed,
  anchors_placed, anchors_refused)` per run on `ReinforceResult`. Text and json
  renderers surface a `runs: X fully reinforced, Y partial, Z unanchored` line
  plus per-run detail, so an agent can read "2 of 31 runs reinforced" from
  `--format json`.

**Tier 3 — within-run collinear merge**
- Before anchoring, contiguous collinear same-net same-layer fragments within an
  **already-split** run are coalesced (reusing
  `router.optimizer.algorithms.merge_collinear`) so `run_segment_count` reflects
  the true geometric run. The merge operates only within a run and never bridges
  a junction (preserves the #2389 no-branch-drop guarantee); it removes only
  collinear interior vertices, so every anchor position is byte-identical to the
  unmerged geometry.

**Is tier 3 a real fix or a no-op?** The curator flagged that `sort_into_chains`
already walks collinear degree-2 fragments into one *run*, so tier 3 might
collapse to a no-op. Validated: chaining coalesces fragments into one run but
leaves them as **separate segments**, so `run_segment_count` still reported the
raw fragment count. Tier 3 is therefore a **real reporting fix** — a straight
run expressed as 12 collinear fragments now reports `segment_count == 1` (proven
by `test_raw_chain_keeps_fragments_but_report_merges`), while anchor coverage is
unchanged. It is a reporting/robustness fix, not a coverage fix (as the curator
predicted for the coverage dimension).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| AC-1 `all_runs` param anchors every run | ✅ | `test_all_runs_anchors_every_branch` |
| AC-2 `min_run_length_mm` filters + reports | ✅ | `test_min_run_length_filters_short_runs_but_reports_them` |
| AC-3 cross-run dedup + idempotent | ✅ | `test_all_runs_dedupes_shared_junction_vertex`, `test_all_runs_idempotent_second_run_adds_no_new_vias`, `test_idempotent_second_run_adds_no_new_anchors` |
| AC-4 CLI flags exist + flow through | ✅ | `test_parser_accepts_all_runs_and_min_run_length`; manual `kct pcb reinforce ... --all-runs --min-run-length 30` |
| AC-5 ≥2 distinct runs anchored | ✅ | `test_all_runs_anchors_every_branch` asserts east arm + branch both anchored |
| AC-6 bounded nudge; hard-block still refuses | ✅ | `test_nudges_off_foreign_net_drill_then_places`, `test_hard_blocked_position_still_refuses` |
| AC-7 per-run summary in result + text/json | ✅ | `test_cli_all_runs_json_is_additive_superset`; manual text render |
| AC-8 nudge on default path too | ✅ | nudge tests run in default (single-run) mode |
| AC-9 within-run merge, never across junctions | ✅ | `test_merge_does_not_bridge_junctions` (3 runs stay 3) |
| AC-10 lower `run_segment_count`, anchors unchanged | ✅ | `test_raw_chain_keeps_fragments_but_report_merges` (12→1), `test_anchor_positions_unchanged_by_merge` |
| AC-11 default byte-compatible (existing tests) | ✅ | `test_branched_net_anchors_longest_and_reports_branch` + all prior tests pass unchanged |
| AC-12 json additive superset | ✅ | `test_cli_all_runs_json_is_additive_superset` checks legacy keys still present |

## Test Plan

- `uv run pytest tests/test_pcb_reinforce.py` — **47 passed** (34 pre-existing + 13 new).
- `uv run pytest tests/test_router_algorithms.py tests/test_trace_optimizer.py` (merge_collinear consumers) — pass.
- `uv run ruff check .` clean; `uv run ruff format --check .` clean.
- mypy baseline gate (`scripts/ci/check_mypy_baseline.py`) — **0 new type errors** (the lone `pcb.py` `object.append` error is pre-existing on main, in the unrelated via-in-pad handler).
- Manual: default vs `--all-runs` on a 3-branch net — default places 7 anchors and reports 2 runs unanchored; `--all-runs` places 13 (shared junction deduped) with all 3 runs "fully reinforced"; `--min-run-length 30` filters the 20mm branch while still reporting it.

Closes #4319