### PR TITLE
fix(check): resolve --net-class-map keys so target_ampacity is enforced

### DIFF
--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -689,6 +689,74 @@ CHECK_CATEGORIES = [
 ]
 
 
+def _warn_unevaluated_ampacity(
+    declared_ampacity_targets: dict[str, float],
+    ampacity_resolution: object,
+    pcb: PCB,
+    only_set: set[str] | None,
+    skip_set: set[str],
+) -> None:
+    """Warn when a declared ``target_ampacity`` was never actually evaluated.
+
+    Issue #4321 (Tier 3).  ``AmpacityRule`` matches routed segments by net
+    name, so a declared target contributes a violation *only* when the net
+    both resolves to a real board net **and** carries at least one routed
+    segment **and** the ``ampacity`` category ran.  When none of those hold
+    the report shows 0 ampacity errors -- indistinguishable from a genuinely
+    compliant board.  This emits a loud stderr warning naming every declared
+    net whose rule never engaged, so a hand-authored ``--net-class-map`` that
+    silently fails to match cannot pass green.
+
+    Args:
+        declared_ampacity_targets: ``{user_key: target_ampacity}`` for every
+            net-class-map entry that declared a ``target_ampacity`` (keyed by
+            the *original* user key, before board-name resolution).
+        ampacity_resolution: the ``NetClassMapResolution`` returned by
+            ``resolve_net_class_map_keys`` (``resolved`` is
+            ``{board_net: user_key}``).
+        pcb: the loaded board (source of routed-segment net names).
+        only_set: optional ``--only`` whitelist of check categories.
+        skip_set: ``--skip`` set of check categories.
+    """
+    ampacity_active = (only_set is None or "ampacity" in only_set) and "ampacity" not in skip_set
+
+    # Invert {board_net: user_key} so we can look up each declared user key's
+    # resolved board net (absent => the key matched no board net or matched
+    # ambiguously, i.e. it was dropped from the resolved map).
+    resolved = getattr(ampacity_resolution, "resolved", {}) or {}
+    key_to_board = {user_key: board_net for board_net, user_key in resolved.items()}
+
+    segment_nets = {getattr(seg, "net_name", "") for seg in getattr(pcb, "segments", [])}
+
+    unevaluated: list[str] = []
+    for user_key in sorted(declared_ampacity_targets):
+        board_net = key_to_board.get(user_key)
+        if board_net is None:
+            # Resolution miss / ambiguous: the rule can never see this net.
+            unevaluated.append(user_key)
+        elif not ampacity_active:
+            # Net resolved but the whole category was skipped/excluded.
+            unevaluated.append(board_net)
+        elif board_net not in segment_nets:
+            # Net resolved but carries no routed segment for the rule to size.
+            unevaluated.append(board_net)
+
+    # Deduplicate while preserving first-seen order.
+    unevaluated = list(dict.fromkeys(unevaluated))
+    if not unevaluated:
+        return
+
+    print(
+        "WARNING: ampacity rule declared but not evaluated for net(s): "
+        f"{', '.join(unevaluated)}. "
+        "A declared target_ampacity that matched zero routed segments is "
+        "reported as 0 ampacity errors but was never actually checked "
+        "(post-resolution key miss, unrouted net, or the ampacity category "
+        "was excluded via --skip/--only).",
+        file=sys.stderr,
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     """Main entry point for kct check command."""
     parser = argparse.ArgumentParser(
@@ -1108,6 +1176,42 @@ def main(argv: list[str] | None = None) -> int:
                     file=sys.stderr,
                 )
 
+    # Issue #4321 (Tier 1/2): resolve the loaded net-class-map's user keys
+    # onto the board's actual net names *before* handing the map to
+    # DRCChecker, mirroring ``route_cmd._apply_net_class_map_sidecar``.
+    #
+    # ``kct check`` reaches ampacity via
+    # ``DRCChecker.check_ampacity`` -> ``derive_ampacity_specs(net_class_map)``
+    # -> ``AmpacityRule.check``, which matches segments by
+    # ``segment.net_name in self.specs`` -- i.e. only when the map's keys
+    # land exactly on the board's segment net names.  ``route`` resolves the
+    # map's keys onto board net names before use; ``check`` historically did
+    # NOT.  A hand-authored ``--net-class-map`` (bare keys, or keys lacking
+    # KiCad's hierarchical ``/`` sheet prefix) therefore matched ZERO
+    # segments, so ``derive_ampacity_specs`` produced specs that never fired
+    # -> 0 errors -> a silent false PASS on a dangerously under-width
+    # high-current trace.  After resolution the ampacity verdict is a pure
+    # function of ``(board segments, resolved map, DesignRules copper
+    # weights)`` and no longer depends on how the board was produced (route
+    # mode / ``.kicad_dru`` presence).  This applies to both the explicit
+    # ``--net-class-map`` path and the auto-discovered route sidecar (whose
+    # keys are already board-resolved, so re-resolution is idempotent).
+    declared_ampacity_targets: dict[str, float] = {}
+    ampacity_resolution = None
+    if net_class_map is not None:
+        from kicad_tools.router.net_names import resolve_net_class_map_keys
+
+        for key, nc in net_class_map.items():
+            target = getattr(nc, "target_ampacity", None)
+            if target is not None:
+                declared_ampacity_targets[key] = float(target)
+        board_net_names = [net.name for net in pcb.nets.values() if net.name]
+        ampacity_resolution = resolve_net_class_map_keys(net_class_map.keys(), board_net_names)
+        net_class_map = {
+            board_net: net_class_map[user_key]
+            for board_net, user_key in ampacity_resolution.resolved.items()
+        }
+
     # Create checker with manufacturer rules
     try:
         checker = DRCChecker(
@@ -1155,6 +1259,23 @@ def main(argv: list[str] | None = None) -> int:
         pad_grid_threshold=pad_grid_threshold,
         pad_grid_auto_derive=pad_grid_auto_derive,
     )
+
+    # Issue #4321 (Tier 3): fail loud when an ampacity target was declared
+    # but never evaluated.  A declared ``target_ampacity`` that matched zero
+    # segments is indistinguishable, in the report, from "genuinely 0
+    # violations" -- yet it usually means the rule never engaged: a
+    # post-resolution key miss, an unrouted net, or the ``ampacity`` category
+    # excluded via ``--skip``/``--only``.  Emit a loud stderr warning naming
+    # the net(s) so a hand-authored map that silently fails to match cannot
+    # sail through green (mirrors the INACTIVE-skew-rules warning above).
+    if declared_ampacity_targets and ampacity_resolution is not None:
+        _warn_unevaluated_ampacity(
+            declared_ampacity_targets,
+            ampacity_resolution,
+            pcb,
+            only_set,
+            skip_set,
+        )
 
     # Apply errors-only filter
     violations = list(results.violations)

--- a/tests/test_cli_check_ampacity_net_class_map.py
+++ b/tests/test_cli_check_ampacity_net_class_map.py
@@ -1,0 +1,248 @@
+"""Regression tests for ``kct check --net-class-map`` ampacity enforcement.
+
+Issue #4321 (SAFETY): ``kct check`` reaches ampacity via
+``DRCChecker.check_ampacity`` -> ``derive_ampacity_specs(net_class_map)``;
+``AmpacityRule.check`` matches segments by ``segment.net_name in self.specs``.
+``route`` resolves the map's user keys onto board net names before use, but
+``check`` historically did NOT -- it passed the raw map straight to
+``DRCChecker``.  A hand-authored ``--net-class-map`` (bare keys, or keys
+lacking KiCad's hierarchical ``/`` sheet prefix) therefore matched zero
+segments -> 0 errors -> a silent false PASS on a dangerously under-width
+high-current trace.
+
+These tests cover all three fix tiers:
+
+* **Tier 1** -- ``check --net-class-map`` resolves keys onto board net names
+  and reports the expected non-zero ampacity error count (not 0).
+* **Tier 2** -- the verdict is deterministic: identical geometry + map yields
+  identical ampacity error counts regardless of ``.kicad_dru`` presence
+  (``kct check`` never consults ``.kicad_dru``).
+* **Tier 3** -- a declared ``target_ampacity`` that never matched a routed
+  segment triggers a loud "declared but not evaluated" stderr warning; a
+  declared target that DOES match routed segments does not.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+# A board net keyed with KiCad's hierarchical sheet prefix (``/FUSED_LINE``).
+# The sidecar below keys the same net *bare* (``FUSED_LINE``), so without
+# key resolution the ampacity rule matches ZERO segments.  Two 0.2 mm F.Cu
+# segments on that net are both grossly under-width for 15 A (required
+# external width at 1 oz is ~12.585 mm), so a correct check reports exactly
+# 2 ampacity errors.
+BOARD_WITH_HIERARCHICAL_NET = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "/FUSED_LINE")
+  (net 2 "GND")
+  (gr_rect (start 100 100) (end 200 200)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+  (segment (start 110 120) (end 140 120) (width 0.2) (layer "F.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-000000000001"))
+  (segment (start 140 120) (end 170 120) (width 0.2) (layer "F.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-000000000002"))
+  (segment (start 110 160) (end 170 160) (width 0.5) (layer "F.Cu") (net 2)
+    (uuid "00000000-0000-0000-0000-000000000003"))
+)
+"""
+
+UNDER_WIDTH_SEGMENT_COUNT = 2
+
+
+def _write_board(dir_path: Path, name: str = "board.kicad_pcb") -> Path:
+    pcb_file = dir_path / name
+    pcb_file.write_text(BOARD_WITH_HIERARCHICAL_NET)
+    return pcb_file
+
+
+def _write_net_class_map(dir_path: Path, entries: dict, name: str = "ncm.json") -> Path:
+    """Write a hand-authored --net-class-map sidecar JSON file."""
+    ncm_file = dir_path / name
+    ncm_file.write_text(json.dumps(entries))
+    return ncm_file
+
+
+def _ampacity_errors(report_path: Path) -> list[dict]:
+    """Return the ampacity error violations from a check JSON report."""
+    data = json.loads(report_path.read_text())
+    return [
+        v
+        for v in data["violations"]
+        if v.get("rule_id") == "ampacity" and v.get("severity") == "error"
+    ]
+
+
+def _run_check(
+    pcb: Path,
+    ncm: Path,
+    report: Path,
+    *,
+    extra: list[str] | None = None,
+) -> int:
+    from kicad_tools.cli.check_cmd import main
+
+    argv = [
+        str(pcb),
+        "--mfr",
+        "jlcpcb",
+        "--net-class-map",
+        str(ncm),
+        "--output",
+        str(report),
+        "--format",
+        "json",
+    ]
+    if extra:
+        argv.extend(extra)
+    return main(argv)
+
+
+class TestTier1AppliesTargetAmpacity:
+    """Tier 1: --net-class-map applies target_ampacity, sidecar-independent."""
+
+    def test_bare_key_under_width_15A_net_is_flagged(self, tmp_path: Path, capsys):
+        """A 0.2 mm / 15 A net (bare sidecar key) reports N ampacity errors, not 0.
+
+        This is the exact false-PASS the issue describes: before the fix the
+        bare ``FUSED_LINE`` key never matched the board's ``/FUSED_LINE``
+        segments, so the rule reported 0 errors and the board PASSED despite
+        two grossly under-width 15 A traces.
+        """
+        pcb = _write_board(tmp_path)
+        ncm = _write_net_class_map(
+            tmp_path, {"FUSED_LINE": {"name": "FUSED_LINE", "target_ampacity": 15.0}}
+        )
+        report = tmp_path / "report.json"
+
+        _run_check(pcb, ncm, report)
+
+        errors = _ampacity_errors(report)
+        # Non-zero is the core regression assertion (was 0 -> false PASS).
+        assert len(errors) > 0
+        # Exactly one error per under-width segment on the net.
+        assert len(errors) == UNDER_WIDTH_SEGMENT_COUNT
+        # The required width must be the IPC-2221 external 15 A / 1 oz floor.
+        for err in errors:
+            assert err["required_value"] == pytest.approx(12.585, abs=0.01)
+            assert err["actual_value"] == pytest.approx(0.2, abs=1e-6)
+
+    def test_fully_qualified_key_also_matches(self, tmp_path: Path):
+        """A fully-qualified ``/FUSED_LINE`` key resolves and flags the same segments."""
+        pcb = _write_board(tmp_path)
+        ncm = _write_net_class_map(
+            tmp_path, {"/FUSED_LINE": {"name": "/FUSED_LINE", "target_ampacity": 15.0}}
+        )
+        report = tmp_path / "report.json"
+
+        _run_check(pcb, ncm, report)
+
+        assert len(_ampacity_errors(report)) == UNDER_WIDTH_SEGMENT_COUNT
+
+
+class TestTier2DeterministicVerdict:
+    """Tier 2: the ampacity verdict is independent of .kicad_dru presence."""
+
+    def test_kicad_dru_presence_does_not_change_error_count(self, tmp_path: Path):
+        """Identical geometry + map yields identical counts with/without a .kicad_dru.
+
+        ``kct check`` never consults ``.kicad_dru`` (it is emitted by
+        ``route`` for KiCad's own DRC engine), so a sibling ``.kicad_dru``
+        carrying an ampacity ``track_width`` rule must not shift the verdict.
+        """
+        # Board A: a sibling .kicad_dru with an ampacity-style track_width rule.
+        dir_a = tmp_path / "with_dru"
+        dir_a.mkdir()
+        pcb_a = _write_board(dir_a)
+        (dir_a / "board.kicad_dru").write_text(
+            '(version 1)\n(rule "ampacity /FUSED_LINE"\n'
+            "  (condition \"A.NetName == '/FUSED_LINE'\")\n"
+            "  (constraint track_width (min 12.585mm)))\n"
+        )
+        ncm_a = _write_net_class_map(
+            dir_a, {"FUSED_LINE": {"name": "FUSED_LINE", "target_ampacity": 15.0}}
+        )
+        report_a = dir_a / "report.json"
+        _run_check(pcb_a, ncm_a, report_a)
+
+        # Board B: identical copper + map, no .kicad_dru at all.
+        dir_b = tmp_path / "no_dru"
+        dir_b.mkdir()
+        pcb_b = _write_board(dir_b)
+        ncm_b = _write_net_class_map(
+            dir_b, {"FUSED_LINE": {"name": "FUSED_LINE", "target_ampacity": 15.0}}
+        )
+        report_b = dir_b / "report.json"
+        _run_check(pcb_b, ncm_b, report_b)
+
+        count_a = len(_ampacity_errors(report_a))
+        count_b = len(_ampacity_errors(report_b))
+        assert count_a == count_b == UNDER_WIDTH_SEGMENT_COUNT
+
+
+class TestTier3FailLoudWhenUnevaluated:
+    """Tier 3: warn when a declared target_ampacity was never evaluated."""
+
+    _WARN_SUBSTR = "ampacity rule declared but not evaluated for net(s):"
+
+    def test_nonexistent_net_triggers_warning(self, tmp_path: Path, capsys):
+        """A target_ampacity for a net absent from the board warns loudly."""
+        pcb = _write_board(tmp_path)
+        ncm = _write_net_class_map(
+            tmp_path,
+            {"NO_SUCH_NET": {"name": "NO_SUCH_NET", "target_ampacity": 15.0}},
+        )
+        report = tmp_path / "report.json"
+
+        _run_check(pcb, ncm, report)
+
+        err = capsys.readouterr().err
+        assert self._WARN_SUBSTR in err
+        assert "NO_SUCH_NET" in err
+        # It genuinely evaluated nothing, so there are no ampacity errors.
+        assert _ampacity_errors(report) == []
+
+    def test_matching_routed_net_does_not_warn(self, tmp_path: Path, capsys):
+        """A target_ampacity that matches routed segments does NOT warn."""
+        pcb = _write_board(tmp_path)
+        ncm = _write_net_class_map(
+            tmp_path, {"FUSED_LINE": {"name": "FUSED_LINE", "target_ampacity": 15.0}}
+        )
+        report = tmp_path / "report.json"
+
+        _run_check(pcb, ncm, report)
+
+        err = capsys.readouterr().err
+        assert self._WARN_SUBSTR not in err
+
+    def test_skip_ampacity_still_warns_for_declared_target(self, tmp_path: Path, capsys):
+        """``--skip ampacity`` with a declared target still fires the warning."""
+        pcb = _write_board(tmp_path)
+        ncm = _write_net_class_map(
+            tmp_path, {"FUSED_LINE": {"name": "FUSED_LINE", "target_ampacity": 15.0}}
+        )
+        report = tmp_path / "report.json"
+
+        _run_check(pcb, ncm, report, extra=["--skip", "ampacity"])
+
+        err = capsys.readouterr().err
+        assert self._WARN_SUBSTR in err
+        # The net resolves, so the warning names the board-resolved net.
+        assert "/FUSED_LINE" in err


### PR DESCRIPTION
## Summary

`kct check --net-class-map <map>` silently ignored each net's
`target_ampacity` rule whenever the map's keys did not land *exactly* on the
board's segment net names. A hand-authored map keying a net bare
(`FUSED_LINE`) or without KiCad's hierarchical `/` sheet prefix matched zero
segments, so the ampacity rule derived specs that never fired: **0 errors ->
a false PASS on a dangerously under-width high-current trace** (e.g. a 15 A
net routed at 0.2 mm, ~63x under the IPC-2221 external floor of 12.585 mm).

Root cause: `route` resolves the map's user keys onto board net names before
use (`resolve_net_class_map_keys`), but `check` passed the raw map straight
to `DRCChecker`. This was **not** a `.kicad_dru` dependency — the sidecar
correlation reported upstream was because route-written sidecars happen to
carry board-resolved keys.

All three fix tiers land in this one PR (per operator decision).

## Changes

- **Tier 1** — `check_cmd.py` now runs `resolve_net_class_map_keys` on the
  loaded map and rekeys it onto the board's actual net names **before**
  constructing `DRCChecker`, mirroring `route_cmd._apply_net_class_map_sidecar`.
  Applies to both the explicit `--net-class-map` path and the auto-discovered
  route sidecar (whose keys are already board-resolved, so re-resolution is
  idempotent).
- **Tier 2** — the ampacity verdict is now a pure function of `(board
  segments, resolved map, DesignRules copper weights)` and no longer depends
  on how the board was produced. `kct check` never consults `.kicad_dru`, so
  a sibling `.kicad_dru` (or its absence) cannot shift the count.
- **Tier 3** — new `_warn_unevaluated_ampacity` extends the existing
  fail-loud pattern: when a declared `target_ampacity` matched **zero** routed
  segments (post-resolution key miss, unrouted net, or `ampacity` excluded via
  `--skip`/`--only`), `check` emits `WARNING: ampacity rule declared but not
  evaluated for net(s): ...` to stderr instead of silently reporting 0.
- Adds `tests/test_cli_check_ampacity_net_class_map.py` (5 tests).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Tier 1: keys resolved before `DRCChecker`, both explicit + auto paths | ✅ | Resolution block wraps the loaded `net_class_map` prior to checker construction |
| Tier 1: verdict independent of `.kicad_dru` | ✅ | `check` reads no `.dru`; Tier 2 test asserts equal counts with/without one |
| Tier 1 regression test: 0.2 mm / 15 A net -> N ampacity errors, non-zero | ✅ | `test_bare_key_under_width_15A_net_is_flagged`: 2 errors (was 0), required_value ~12.585 mm |
| Tier 2: identical geometry+map -> identical counts regardless of `.kicad_dru` | ✅ | `test_kicad_dru_presence_does_not_change_error_count`: both == 2 |
| Tier 3: declared-but-unevaluated warns; matched net does not | ✅ | `test_nonexistent_net_triggers_warning`, `test_matching_routed_net_does_not_warn`, `test_skip_ampacity_still_warns_for_declared_target` |

## Test Plan

- `uv run pytest tests/test_cli_check_ampacity_net_class_map.py tests/test_cli_check_ampacity.py` — 11 passed. The false-PASS is now a real FAIL: a bare-keyed 15 A / 0.2 mm net reports **2** ampacity errors (was 0).
- Regression sweep (80 passed): `test_cli_check_impedance`, `test_cli_check_net_class_map`, `test_check_cmd_coverage`, `test_net_class_serialization` + the CLI skew/diffpair-continuity suites (11 passed) — confirms rekeying is idempotent for board-resolved sidecars and does not disturb the impedance/skew rules.
- `uv run ruff check .` clean; `uv run ruff format . --check` clean; `mypy` clean on `check_cmd.py` (pre-existing repo-wide baseline errors unchanged, unrelated files only).

Closes #4321