### PR TITLE
feat(route): add real --nets flag to route/route-auto

### DIFF
--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -133,35 +133,27 @@ def _print_effective_via_geometry(
     print(f"  Via diameter: {_fmt(eff_diameter, override_diameter)}")
 
 
-def run_route_auto_command(args) -> int:
-    """Handle route-auto command using RoutingOrchestrator."""
+def _route_auto_one(args, net_name: str, pcb_path: str, output_path: str | None) -> int:
+    """Route a single net via RoutingOrchestrator and print the result.
+
+    Extracted from ``run_route_auto_command`` (Issue #4322) so the ``--net``
+    single-net path and each iteration of the ``--nets`` multi-net loop share
+    identical routing + reporting.  ``pcb_path`` / ``output_path`` are passed
+    explicitly so the loop can chain outputs (route net N+1 from net N's
+    output, accumulating copper).  Returns the per-net exit code.
+    """
     import sys
 
     via_drill = getattr(args, "via_drill", None)
     via_diameter = getattr(args, "via_diameter", None)
 
-    # Dry-run: preview strategy selection without routing
-    if args.dry_run:
-        print(f"[dry-run] Would route net '{args.net}' on '{args.pcb}' using RoutingOrchestrator")
-        print(f"  Strategy override: {args.strategy}")
-        print(f"  Repair enabled: {not args.no_repair}")
-        print(f"  Via resolution enabled: {not args.no_via_resolution}")
-        # Report the effective via geometry that would be used (Issue #4247):
-        # an explicit CLI override, or the value derived from the board's
-        # net-class via constraints.
-        eff_drill, eff_diameter = _effective_via_geometry(args.pcb, via_drill, via_diameter)
-        _print_effective_via_geometry(eff_drill, via_drill, eff_diameter, via_diameter)
-        if args.output:
-            print(f"  Output: {args.output}")
-        return 0
-
     from kicad_tools.mcp.tools.routing import route_net_auto
 
     try:
         result = route_net_auto(
-            pcb_path=args.pcb,
-            net_name=args.net,
-            output_path=args.output,
+            pcb_path=pcb_path,
+            net_name=net_name,
+            output_path=output_path,
             strategy=args.strategy,
             enable_repair=not args.no_repair,
             enable_via_resolution=not args.no_via_resolution,
@@ -261,6 +253,108 @@ def run_route_auto_command(args) -> int:
         return 1
 
 
+def _route_auto_dry_run(args, net_name: str) -> None:
+    """Print the strategy-selection preview for one net (no routing)."""
+    via_drill = getattr(args, "via_drill", None)
+    via_diameter = getattr(args, "via_diameter", None)
+    print(f"[dry-run] Would route net '{net_name}' on '{args.pcb}' using RoutingOrchestrator")
+    print(f"  Strategy override: {args.strategy}")
+    print(f"  Repair enabled: {not args.no_repair}")
+    print(f"  Via resolution enabled: {not args.no_via_resolution}")
+    # Report the effective via geometry that would be used (Issue #4247):
+    # an explicit CLI override, or the value derived from the board's
+    # net-class via constraints.
+    eff_drill, eff_diameter = _effective_via_geometry(args.pcb, via_drill, via_diameter)
+    _print_effective_via_geometry(eff_drill, via_drill, eff_diameter, via_diameter)
+    if args.output:
+        print(f"  Output: {args.output}")
+
+
+def _parse_route_auto_targets(args) -> tuple[list[str] | None, int]:
+    """Resolve the net(s) route-auto should route -- Issue #4322.
+
+    Exactly one of ``--net`` (single) / ``--nets`` (comma-separated list) must
+    be given.  Returns ``(net_list, rc)``: on success ``net_list`` is the
+    ordered, de-duplicated, whitespace-trimmed list of nets and ``rc`` is 0; on
+    a usage error ``net_list`` is ``None`` and ``rc`` is a non-zero exit code
+    (an error has already been printed).
+    """
+    import sys
+
+    net = getattr(args, "net", None)
+    nets_raw = getattr(args, "nets", None)
+
+    if net and nets_raw:
+        print(
+            "Error: --net and --nets are mutually exclusive (use --net for a "
+            "single net or --nets for a comma-separated list).",
+            file=sys.stderr,
+        )
+        return None, 2
+    if not net and not nets_raw:
+        print(
+            "Error: route-auto requires --net NAME or --nets NAME[,NAME...].",
+            file=sys.stderr,
+        )
+        return None, 2
+
+    if net:
+        return [net], 0
+
+    # Reachable only when nets_raw is truthy (the guards above returned for the
+    # net / neither cases); ``or ""`` keeps the type checker happy.
+    parsed = [n.strip() for n in (nets_raw or "").split(",") if n.strip()]
+    if not parsed:
+        print(
+            "Error: --nets was given but lists no net names "
+            '(expected a comma-separated list, e.g. --nets "/A,/B").',
+            file=sys.stderr,
+        )
+        return None, 2
+    # De-duplicate while preserving first-seen order.
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for n in parsed:
+        if n not in seen:
+            seen.add(n)
+            ordered.append(n)
+    return ordered, 0
+
+
+def run_route_auto_command(args) -> int:
+    """Handle route-auto command using RoutingOrchestrator.
+
+    Routes a single net (``--net``) or several nets in sequence (``--nets``,
+    Issue #4322).  For the multi-net path each net is routed independently and
+    the exit code is non-zero if ANY net fails or is left partial; when an
+    output path is given, copper accumulates (net N+1 routes from net N's
+    output).  The single-net ``--net`` path is unchanged.
+    """
+    net_list, rc = _parse_route_auto_targets(args)
+    if rc != 0:
+        return rc
+    assert net_list is not None  # rc == 0 guarantees a list
+
+    # Dry-run: preview strategy selection without routing (per net).
+    if args.dry_run:
+        for net_name in net_list:
+            _route_auto_dry_run(args, net_name)
+        return 0
+
+    output_path = args.output
+    overall_rc = 0
+    for i, net_name in enumerate(net_list):
+        # Chain outputs so multi-net copper accumulates: the first net routes
+        # from the original board; subsequent nets route from the prior output
+        # (only possible when an output path was given -- otherwise nothing is
+        # persisted and each net routes independently against the input).
+        source = args.pcb if (i == 0 or not output_path) else output_path
+        net_rc = _route_auto_one(args, net_name, source, output_path)
+        if net_rc != 0:
+            overall_rc = 1
+    return overall_rc
+
+
 def run_route_command(args) -> int:
     """Handle route command."""
     from ..route_cmd import main as route_main
@@ -272,6 +366,12 @@ def run_route_command(args) -> int:
         sub_argv.extend(["--strategy", args.strategy])
     if args.skip_nets:
         sub_argv.extend(["--skip-nets", args.skip_nets])
+    # Issue #4322: forward --nets (route ONLY the listed nets).  The inner
+    # route_cmd handler validates it, enforces mutual exclusion with
+    # --skip-nets, and inverts it into the skip machinery.  Declared on BOTH
+    # parsers + here so tests/test_cli_parser_drift.py stays green.
+    if getattr(args, "nets", None):
+        sub_argv.extend(["--nets", args.nets])
     # Issue #3155: forward --preserve-existing (incremental routing).  Both
     # outer (parser.py) and inner (route_cmd.py) parsers declare it as a
     # store_true defaulting to False, so only forward when the user set it.

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2847,6 +2847,19 @@ def _add_route_parser(subparsers) -> None:
     )
     route_parser.add_argument("--skip-nets", help="Comma-separated nets to skip")
     route_parser.add_argument(
+        "--nets",
+        metavar="NET[,NET...]",
+        help=(
+            "Comma-separated nets to route EXCLUSIVELY (Issue #4322): route "
+            "only the listed nets and treat every OTHER board net as a fixed "
+            "obstacle -- the inverse of --skip-nets. Mutually exclusive with "
+            "--skip-nets (passing both is an error). Names must match the "
+            "board's net names exactly (e.g. 'GND', '/SPI_CLK'); an unknown "
+            "name is an error that names the missing net. Whitespace around "
+            "each name is trimmed."
+        ),
+    )
+    route_parser.add_argument(
         "--preserve-existing",
         action="store_true",
         default=False,
@@ -2868,7 +2881,9 @@ def _add_route_parser(subparsers) -> None:
             "convention as 'pcb strip --region'). Every cell outside the box "
             "is treated as a fixed obstacle, and existing copper outside is "
             "preserved unchanged (implies --preserve-existing semantics). "
-            "Composable with --nets/--skip-nets. NOTE: unrelated to "
+            "Composable with --nets (route only the listed nets) or "
+            "--skip-nets (route all but the listed nets); --nets and "
+            "--skip-nets are themselves mutually exclusive. NOTE: unrelated to "
             "--region-parallel (which partitions the grid for PARALLEL "
             "routing); --region is a spatial bound, not a parallelism knob. "
             "Nets whose pads all lie inside the box route normally; a net "
@@ -3799,11 +3814,26 @@ def _add_route_auto_parser(subparsers) -> None:
         help="Route a net using RoutingOrchestrator smart strategy selection",
     )
     route_auto_parser.add_argument("pcb", help="Path to .kicad_pcb file")
+    # Issue #4322: --net is no longer unconditionally required because --nets
+    # (route several nets in sequence) is an alternative.  Exactly one of
+    # --net / --nets must be given; the handler enforces this and errors if
+    # both (or neither) are supplied.
     route_auto_parser.add_argument(
         "--net",
-        required=True,
+        required=False,
         metavar="NAME",
-        help="Net to route (e.g., 'GND', 'SPI_CLK')",
+        help="Net to route (e.g., 'GND', 'SPI_CLK'). Mutually exclusive with --nets.",
+    )
+    route_auto_parser.add_argument(
+        "--nets",
+        metavar="NAME[,NAME...]",
+        help=(
+            "Comma-separated nets to route in sequence (Issue #4322). Each net "
+            "is routed independently via RoutingOrchestrator, accumulating "
+            "copper into the output; the exit code is non-zero if ANY net "
+            "fails or is left partial. Whitespace around each name is trimmed. "
+            "Mutually exclusive with --net."
+        ),
     )
     route_auto_parser.add_argument(
         "--region",

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -3971,7 +3971,11 @@ def route_with_layer_escalation(
             pcb_path,
             quiet=quiet,
             edge_clearance=getattr(args, "edge_clearance", None),
-            force_pour_nets=skip_nets,
+            # Issue #4322: in --nets (route-only) mode ``skip_nets`` is the
+            # large INVERTED set (every net except the ones being routed); it
+            # must NOT be forwarded as pour intent, or auto-pour would try to
+            # zone ~every net.  Keep the user's explicit pour intent empty.
+            force_pour_nets=([] if getattr(args, "_route_only_nets", None) else skip_nets),
         )
 
     # Auto-classify pour nets and extend skip_nets
@@ -5015,7 +5019,11 @@ def route_with_rule_relaxation(
             pcb_path,
             quiet=quiet,
             edge_clearance=getattr(args, "edge_clearance", None),
-            force_pour_nets=skip_nets,
+            # Issue #4322: in --nets (route-only) mode ``skip_nets`` is the
+            # large INVERTED set (every net except the ones being routed); it
+            # must NOT be forwarded as pour intent, or auto-pour would try to
+            # zone ~every net.  Keep the user's explicit pour intent empty.
+            force_pour_nets=([] if getattr(args, "_route_only_nets", None) else skip_nets),
         )
 
     # Auto-classify pour nets and extend skip_nets
@@ -7118,7 +7126,11 @@ def route_with_combined_escalation(
             pcb_path,
             quiet=quiet,
             edge_clearance=getattr(args, "edge_clearance", None),
-            force_pour_nets=skip_nets,
+            # Issue #4322: in --nets (route-only) mode ``skip_nets`` is the
+            # large INVERTED set (every net except the ones being routed); it
+            # must NOT be forwarded as pour intent, or auto-pour would try to
+            # zone ~every net.  Keep the user's explicit pour intent empty.
+            force_pour_nets=([] if getattr(args, "_route_only_nets", None) else skip_nets),
         )
 
     # Auto-classify pour nets and extend skip_nets
@@ -8321,6 +8333,107 @@ def _offboard_preflight(pcb_path: Path) -> int:
     return 2
 
 
+def _resolve_route_only_nets(args, pcb_path: Path) -> int:
+    """Resolve ``--nets`` (route ONLY the listed nets) -- Issue #4322.
+
+    ``--nets`` is the inverse of ``--skip-nets``: it names the nets to route
+    and treats every OTHER board net as an obstacle.  Rather than thread a new
+    ``only_nets`` parameter through ``load_pcb_for_routing`` (and its several
+    call sites), we invert the request into the existing ``--skip-nets``
+    machinery -- ``effective_skip = all_board_nets - requested_nets`` -- so the
+    downstream router is unchanged.  A marker (``args._route_only_nets``) is set
+    so the auto-pour forwarding does NOT treat the (large) inverted skip set as
+    pour intent.
+
+    Enforced here (the single inner-parser source of truth, so the rule holds
+    whether invoked as ``kct route`` or the inner ``route`` entrypoint):
+
+    * ``--nets`` and ``--skip-nets`` are mutually exclusive.
+    * Every requested net must exist on the board (unknown names error and are
+      named); whitespace around each name is trimmed and an empty list errors.
+    * Nets with fewer than 2 pads are reported (nothing to route) rather than
+      silently dropped.
+
+    Returns 0 on success (or when ``--nets`` is absent) and a non-zero exit
+    code (with a printed error) otherwise.
+    """
+    requested_raw = getattr(args, "nets", None)
+    if not requested_raw:
+        return 0
+
+    # Mutually exclusive with --skip-nets: --nets fully specifies the route set.
+    if getattr(args, "skip_nets", None):
+        print(
+            "Error: --nets and --skip-nets are mutually exclusive "
+            "(--nets already limits routing to the listed nets).",
+            file=sys.stderr,
+        )
+        return 2
+
+    requested = [n.strip() for n in requested_raw.split(",") if n.strip()]
+    if not requested:
+        print(
+            "Error: --nets was given but lists no net names "
+            '(expected a comma-separated list, e.g. --nets "/A,/B").',
+            file=sys.stderr,
+        )
+        return 2
+
+    # De-duplicate while preserving first-seen order.
+    seen: set[str] = set()
+    requested_unique: list[str] = []
+    for n in requested:
+        if n not in seen:
+            seen.add(n)
+            requested_unique.append(n)
+
+    # Load the board and count pads per net name.
+    try:
+        from kicad_tools.schema.pcb import PCB as _SchemaPCB
+
+        pcb = _SchemaPCB.load(str(pcb_path))
+    except Exception as e:  # pragma: no cover - load errors also surface later
+        print(f"Error loading PCB for --nets validation: {e}", file=sys.stderr)
+        return 1
+
+    net_pad_counts: dict[str, int] = {}
+    for fp in pcb.footprints:
+        for pad in fp.pads:
+            net_name = getattr(pad, "net_name", "") or ""
+            if net_name:
+                net_pad_counts[net_name] = net_pad_counts.get(net_name, 0) + 1
+    board_nets = set(net_pad_counts)
+
+    unknown = [n for n in requested_unique if n not in board_nets]
+    if unknown:
+        preview = ", ".join(unknown)
+        print(
+            f"Error: --nets names net(s) not present on the board: {preview}. "
+            "Net names must match the board exactly (e.g. 'GND', '/SPI_CLK').",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Report requested nets that cannot be routed (fewer than 2 pads) rather
+    # than silently dropping them; they still contribute nothing to route.
+    under_two = [n for n in requested_unique if net_pad_counts.get(n, 0) < 2]
+    if under_two:
+        print(
+            "Warning: --nets includes net(s) with fewer than 2 pads (nothing "
+            f"to route): {', '.join(under_two)}.",
+            file=sys.stderr,
+        )
+
+    # Invert into the skip machinery: skip every board net NOT requested.
+    requested_set = set(requested_unique)
+    effective_skip = sorted(board_nets - requested_set)
+    args.skip_nets = ",".join(effective_skip)
+    # Marker: route-only mode.  The (large) inverted skip set must NOT be
+    # forwarded as force_pour_nets (that would try to pour ~every net).
+    args._route_only_nets = requested_unique
+    return 0
+
+
 # ---------------------------------------------------------------------------
 # Issue #4263: analytical --dry-run grid/cell/budget plan.
 #
@@ -8583,6 +8696,17 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--skip-nets",
         help="Comma-separated nets to skip (e.g., GND,VCC,VBUS)",
+    )
+    parser.add_argument(
+        "--nets",
+        metavar="NET[,NET...]",
+        help=(
+            "Comma-separated nets to route EXCLUSIVELY (Issue #4322): route "
+            "only the listed nets and treat every other board net as an "
+            "obstacle (the inverse of --skip-nets). Mutually exclusive with "
+            "--skip-nets. Unknown net names are an error; whitespace is "
+            "trimmed."
+        ),
     )
     parser.add_argument(
         "--preserve-existing",
@@ -9996,6 +10120,16 @@ def main(argv: list[str] | None = None) -> int:
     if pcb_path.suffix != ".kicad_pcb":
         print(f"Warning: Expected .kicad_pcb file, got {pcb_path.suffix}")
 
+    # Issue #4322: resolve --nets (route ONLY the listed nets) by inverting it
+    # into the --skip-nets machinery.  Validates mutual exclusion with
+    # --skip-nets and that every requested net exists on the board, then sets
+    # ``args.skip_nets`` to every OTHER board net.  Runs BEFORE --region so a
+    # spatial bound composes on top of the net selection.
+    args._route_only_nets = None
+    _nets_rc = _resolve_route_only_nets(args, pcb_path)
+    if _nets_rc != 0:
+        return _nets_rc
+
     # Issue #4148: parse + validate --region (SPATIAL routing bound).  Stores a
     # normalized board-relative box on ``args._region_box`` that the
     # ``load_pcb_for_routing`` call sites forward.  Region mode implies
@@ -10452,7 +10586,11 @@ def main(argv: list[str] | None = None) -> int:
             pcb_path,
             quiet=args.quiet,
             edge_clearance=getattr(args, "edge_clearance", None),
-            force_pour_nets=skip_nets,
+            # Issue #4322: in --nets (route-only) mode ``skip_nets`` is the
+            # large INVERTED set (every net except the ones being routed); it
+            # must NOT be forwarded as pour intent, or auto-pour would try to
+            # zone ~every net.  Keep the user's explicit pour intent empty.
+            force_pour_nets=([] if getattr(args, "_route_only_nets", None) else skip_nets),
         )
 
     # Auto-classify pour nets and extend skip_nets

--- a/tests/test_cli_route_nets_flag.py
+++ b/tests/test_cli_route_nets_flag.py
@@ -1,0 +1,357 @@
+"""Tests for the ``--nets`` route-only flag (Issue #4322).
+
+``kct route --nets "/A,/B"`` routes ONLY the listed nets and treats every
+other board net as an obstacle -- the inverse of ``--skip-nets``.  It is
+implemented at the CLI layer by inverting the request into the existing
+``--skip-nets`` machinery (skip every board net NOT listed), so the router is
+unchanged.  ``kct route-auto`` gains a matching ``--nets`` that routes several
+nets in sequence.
+
+The issue this fixes: ``kct route --region``'s help advertised a ``--nets``
+flag that did not exist, so ``kct route board.kicad_pcb --nets "/GND"`` failed
+with ``error: unrecognized arguments``.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# A tiny fake board so the net-selection logic can be tested without a real
+# .kicad_pcb file or the C++ router backend.
+# ---------------------------------------------------------------------------
+class _Pad:
+    def __init__(self, net_name: str) -> None:
+        self.net_name = net_name
+
+
+class _FP:
+    def __init__(self, pads: list[_Pad]) -> None:
+        self.pads = pads
+
+
+class _FakePCB:
+    """Board with nets: /A(2), /B(2), /C(2), GND(3), /SOLO(1)."""
+
+    def __init__(self) -> None:
+        self.footprints = [
+            _FP([_Pad("/A"), _Pad("/A")]),
+            _FP([_Pad("/B"), _Pad("/B")]),
+            _FP([_Pad("/C"), _Pad("/C")]),
+            _FP([_Pad("GND"), _Pad("GND"), _Pad("GND")]),
+            _FP([_Pad("/SOLO")]),  # single-pad net -- nothing to route
+        ]
+
+
+ALL_NETS = {"/A", "/B", "/C", "GND", "/SOLO"}
+
+
+@pytest.fixture
+def fake_board(monkeypatch):
+    """Patch ``PCB.load`` so ``_resolve_route_only_nets`` sees ``_FakePCB``."""
+    from kicad_tools.schema import pcb as pcb_mod
+
+    monkeypatch.setattr(pcb_mod.PCB, "load", lambda _path: _FakePCB())
+    return _FakePCB()
+
+
+def _route_args(**overrides):
+    ns = argparse.Namespace(nets=None, skip_nets=None)
+    for k, v in overrides.items():
+        setattr(ns, k, v)
+    return ns
+
+
+# ---------------------------------------------------------------------------
+# --nets inversion into the skip set
+# ---------------------------------------------------------------------------
+def test_nets_selects_only_listed_nets(fake_board):
+    """``--nets`` routes only the listed nets; all others become the skip set."""
+    from pathlib import Path
+
+    from kicad_tools.cli.route_cmd import _resolve_route_only_nets
+
+    args = _route_args(nets="/A,/B")
+    rc = _resolve_route_only_nets(args, Path("dummy.kicad_pcb"))
+
+    assert rc == 0
+    # The route-only marker records exactly the requested nets.
+    assert args._route_only_nets == ["/A", "/B"]
+    # Every OTHER board net is skipped (inverse of --skip-nets).
+    skip_set = set(args.skip_nets.split(","))
+    assert skip_set == ALL_NETS - {"/A", "/B"}
+    # The routable set is precisely the requested nets.
+    assert ALL_NETS - skip_set == {"/A", "/B"}
+
+
+def test_nets_absent_is_noop(fake_board):
+    """No ``--nets`` -> untouched skip set, no route-only marker."""
+    from pathlib import Path
+
+    from kicad_tools.cli.route_cmd import _resolve_route_only_nets
+
+    args = _route_args(nets=None, skip_nets="GND")
+    rc = _resolve_route_only_nets(args, Path("dummy.kicad_pcb"))
+
+    assert rc == 0
+    assert args.skip_nets == "GND"  # unchanged
+    assert getattr(args, "_route_only_nets", None) is None
+
+
+def test_nets_whitespace_is_trimmed(fake_board):
+    """Whitespace around each name is trimmed, like ``--skip-nets``."""
+    from pathlib import Path
+
+    from kicad_tools.cli.route_cmd import _resolve_route_only_nets
+
+    args = _route_args(nets="  /A , /B  ")
+    rc = _resolve_route_only_nets(args, Path("dummy.kicad_pcb"))
+
+    assert rc == 0
+    assert args._route_only_nets == ["/A", "/B"]
+    assert set(args.skip_nets.split(",")) == ALL_NETS - {"/A", "/B"}
+
+
+def test_nets_deduplicates_preserving_order(fake_board):
+    from pathlib import Path
+
+    from kicad_tools.cli.route_cmd import _resolve_route_only_nets
+
+    args = _route_args(nets="/B,/A,/B")
+    rc = _resolve_route_only_nets(args, Path("dummy.kicad_pcb"))
+
+    assert rc == 0
+    assert args._route_only_nets == ["/B", "/A"]
+
+
+def test_nets_unknown_net_errors_clearly(fake_board, capsys):
+    """An unknown net name exits non-zero and NAMES the missing net."""
+    from pathlib import Path
+
+    from kicad_tools.cli.route_cmd import _resolve_route_only_nets
+
+    args = _route_args(nets="/A,/DOES_NOT_EXIST")
+    rc = _resolve_route_only_nets(args, Path("dummy.kicad_pcb"))
+
+    assert rc != 0
+    err = capsys.readouterr().err
+    assert "/DOES_NOT_EXIST" in err
+    assert "not present on the board" in err
+
+
+def test_nets_mutually_exclusive_with_skip_nets(fake_board, capsys):
+    """``--nets`` + ``--skip-nets`` together is a clear, non-zero error."""
+    from pathlib import Path
+
+    from kicad_tools.cli.route_cmd import _resolve_route_only_nets
+
+    args = _route_args(nets="/A", skip_nets="GND")
+    rc = _resolve_route_only_nets(args, Path("dummy.kicad_pcb"))
+
+    assert rc != 0
+    err = capsys.readouterr().err
+    assert "mutually exclusive" in err
+
+
+def test_nets_empty_list_errors(fake_board, capsys):
+    """``--nets`` with only whitespace/commas names no nets -> error."""
+    from pathlib import Path
+
+    from kicad_tools.cli.route_cmd import _resolve_route_only_nets
+
+    args = _route_args(nets="  ,  ")
+    rc = _resolve_route_only_nets(args, Path("dummy.kicad_pcb"))
+
+    assert rc != 0
+    err = capsys.readouterr().err
+    assert "no net names" in err
+
+
+def test_nets_sub_two_pad_net_is_reported(fake_board, capsys):
+    """A listed net with <2 pads is reported (can't route), not silently dropped."""
+    from pathlib import Path
+
+    from kicad_tools.cli.route_cmd import _resolve_route_only_nets
+
+    args = _route_args(nets="/A,/SOLO")
+    rc = _resolve_route_only_nets(args, Path("dummy.kicad_pcb"))
+
+    assert rc == 0  # still proceeds -- the net just contributes nothing
+    err = capsys.readouterr().err
+    assert "/SOLO" in err
+    assert "fewer than 2 pads" in err
+    # Both requested nets are still in the route set (neither skipped).
+    assert args._route_only_nets == ["/A", "/SOLO"]
+    assert "/SOLO" not in args.skip_nets.split(",")
+
+
+# ---------------------------------------------------------------------------
+# Parser wiring (drift-adjacent): --nets present on both route parsers + shim.
+# ---------------------------------------------------------------------------
+def test_nets_flag_on_outer_route_parser():
+    from kicad_tools.cli.parser import create_parser
+
+    parser = create_parser()
+    args = parser.parse_args(["route", "board.kicad_pcb", "--nets", "/A,/B"])
+    assert args.nets == "/A,/B"
+
+
+def test_nets_flag_on_inner_route_parser():
+    """The inner route_cmd parser accepts --nets (no 'unrecognized arguments')."""
+    import argparse as _argparse
+    from unittest.mock import patch
+
+    from kicad_tools.cli.route_cmd import main as route_main
+
+    captured: dict[str, _argparse.Namespace] = {}
+    real_parse_args = _argparse.ArgumentParser.parse_args
+
+    def fake_parse_args(self, *a, **k):
+        ns = real_parse_args(self, *a, **k)
+        if getattr(self, "prog", "") == "kicad-tools route":
+            captured["ns"] = ns
+            raise SystemExit(0)
+        return ns
+
+    with patch.object(_argparse.ArgumentParser, "parse_args", fake_parse_args):
+        with pytest.raises(SystemExit):
+            route_main(["board.kicad_pcb", "--nets", "/A,/B"])
+
+    assert captured["ns"].nets == "/A,/B"
+
+
+def test_route_command_shim_forwards_nets(monkeypatch):
+    """run_route_command forwards --nets into the inner argv."""
+    from kicad_tools.cli import route_cmd
+    from kicad_tools.cli.commands import routing
+
+    seen: dict[str, list[str]] = {}
+
+    def fake_main(argv):
+        seen["argv"] = argv
+        return 0
+
+    monkeypatch.setattr(route_cmd, "main", fake_main)
+
+    from kicad_tools.cli.parser import create_parser
+
+    parser = create_parser()
+    args = parser.parse_args(["route", "board.kicad_pcb", "--nets", "/A,/B"])
+    routing.run_route_command(args)
+
+    assert "--nets" in seen["argv"]
+    assert seen["argv"][seen["argv"].index("--nets") + 1] == "/A,/B"
+
+
+# ---------------------------------------------------------------------------
+# route-auto --nets orchestration
+# ---------------------------------------------------------------------------
+def _auto_args(**overrides):
+    ns = argparse.Namespace(net=None, nets=None)
+    for k, v in overrides.items():
+        setattr(ns, k, v)
+    return ns
+
+
+def test_route_auto_net_singular_still_works():
+    from kicad_tools.cli.commands.routing import _parse_route_auto_targets
+
+    net_list, rc = _parse_route_auto_targets(_auto_args(net="GND"))
+    assert rc == 0
+    assert net_list == ["GND"]
+
+
+def test_route_auto_nets_parses_and_dedups():
+    from kicad_tools.cli.commands.routing import _parse_route_auto_targets
+
+    net_list, rc = _parse_route_auto_targets(_auto_args(nets=" /A , /B , /A "))
+    assert rc == 0
+    assert net_list == ["/A", "/B"]
+
+
+def test_route_auto_net_and_nets_mutually_exclusive(capsys):
+    from kicad_tools.cli.commands.routing import _parse_route_auto_targets
+
+    net_list, rc = _parse_route_auto_targets(_auto_args(net="GND", nets="/A"))
+    assert net_list is None
+    assert rc != 0
+    assert "mutually exclusive" in capsys.readouterr().err
+
+
+def test_route_auto_requires_net_or_nets(capsys):
+    from kicad_tools.cli.commands.routing import _parse_route_auto_targets
+
+    net_list, rc = _parse_route_auto_targets(_auto_args())
+    assert net_list is None
+    assert rc != 0
+    assert "requires --net" in capsys.readouterr().err
+
+
+def test_route_auto_empty_nets_errors(capsys):
+    from kicad_tools.cli.commands.routing import _parse_route_auto_targets
+
+    net_list, rc = _parse_route_auto_targets(_auto_args(nets="  ,  "))
+    assert net_list is None
+    assert rc != 0
+    assert "no net names" in capsys.readouterr().err
+
+
+def test_route_auto_nets_on_parser_and_net_optional():
+    """route-auto declares --nets and --net is no longer required."""
+    from kicad_tools.cli.parser import create_parser
+
+    parser = create_parser()
+    # --nets alone parses (previously --net was required=True).
+    args = parser.parse_args(["route-auto", "board.kicad_pcb", "--nets", "/A,/B"])
+    assert args.nets == "/A,/B"
+    assert args.net is None
+
+
+def test_route_auto_nets_loop_aggregates_exit_code(monkeypatch):
+    """--nets routes each net; exit code is non-zero if ANY net fails."""
+    from kicad_tools.cli.commands import routing
+
+    calls: list[str] = []
+
+    def fake_one(args, net_name, pcb_path, output_path):
+        calls.append(net_name)
+        return 0 if net_name == "/A" else 1  # /B "fails"
+
+    monkeypatch.setattr(routing, "_route_auto_one", fake_one)
+
+    args = _auto_args(nets="/A,/B", dry_run=False, output=None, pcb="board.kicad_pcb")
+    rc = routing.run_route_auto_command(args)
+
+    assert calls == ["/A", "/B"]
+    assert rc == 1  # aggregated non-zero because /B failed
+
+
+def test_route_auto_nets_all_success_returns_zero(monkeypatch):
+    from kicad_tools.cli.commands import routing
+
+    monkeypatch.setattr(routing, "_route_auto_one", lambda *a, **k: 0)
+
+    args = _auto_args(nets="/A,/B", dry_run=False, output=None, pcb="board.kicad_pcb")
+    assert routing.run_route_auto_command(args) == 0
+
+
+def test_route_auto_nets_chains_output(monkeypatch):
+    """With an output path, net N+1 routes from net N's output (accumulation)."""
+    from kicad_tools.cli.commands import routing
+
+    sources: list[str] = []
+
+    def fake_one(args, net_name, pcb_path, output_path):
+        sources.append(pcb_path)
+        return 0
+
+    monkeypatch.setattr(routing, "_route_auto_one", fake_one)
+
+    args = _auto_args(nets="/A,/B,/C", dry_run=False, output="out.kicad_pcb", pcb="board.kicad_pcb")
+    routing.run_route_auto_command(args)
+
+    # First net from the original board; subsequent nets from the output.
+    assert sources == ["board.kicad_pcb", "out.kicad_pcb", "out.kicad_pcb"]


### PR DESCRIPTION
## Summary

`kct route --region`'s help advertised a `--nets` flag that did not exist, so `kct route board.kicad_pcb --nets "/GND"` failed with `error: unrecognized arguments`. Per the operator decision (Option 2), this adds a **real** `--nets NET[,NET...]` flag — the inverse of `--skip-nets` (route only the listed nets, treat every other board net as an obstacle) — on both `route` and `route-auto`, and fixes the misleading help text.

## Changes

- **`route` — three synchronized sites + handler (drift-guard safe):**
  - Outer parser (`parser.py`) and inner parser (`route_cmd.py`) both declare `--nets`; the shim (`commands/routing.py :: run_route_command`) forwards it. This keeps `tests/test_cli_parser_drift.py` green (the exact #2817/#2819 bug class).
  - Resolved once in `route_cmd.main()` via new `_resolve_route_only_nets()`: loads the board, validates each requested net exists, then inverts into the existing skip machinery (`effective_skip = all board nets − requested nets`). **No change to `io.py`** (curator's Option A).
  - A route-only marker (`args._route_only_nets`) keeps the large inverted skip set **out of** the auto-pour `force_pour_nets` forwarding (avoids trying to pour ~every net).
  - `--nets` and `--skip-nets` are **mutually exclusive** (clear non-zero error). Unknown net names error and are named. Whitespace trimmed. `<2`-pad nets reported, not silently dropped.
- **`route-auto`:** `--net` is no longer `required=True`; `--net`/`--nets` are mutually exclusive (exactly one required). `--nets` routes each net in sequence via `route_net_auto`, **chaining outputs** so copper accumulates, and **aggregates** a non-zero exit if any net fails/partials. The single-net `--net` path is unchanged (extracted into `_route_auto_one` with byte-identical reporting).
- **Help text:** the `route --region` help now accurately describes the real `--nets` and its mutual exclusion with `--skip-nets`.

### How route-auto's required `--net` was handled

`route-auto` is a single-command handler (no inner/outer parser split, so the drift guard does not apply). I relaxed `--net` to `required=False` and enforce "exactly one of `--net`/`--nets`" in the handler (`_parse_route_auto_targets`). Multi-net routing chains each net's output into the next so accumulated copper persists (routing all nets against the original board would otherwise only keep the last net's copper).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `--nets "/A,/B"` routes only listed nets (inverse of `--skip-nets`) | ✅ | `test_nets_selects_only_listed_nets`: skip set == all nets − requested |
| Unknown net errors clearly (non-zero, names net) | ✅ | `test_nets_unknown_net_errors_clearly` |
| `--nets` + `--skip-nets` mutually exclusive | ✅ | `test_nets_mutually_exclusive_with_skip_nets` |
| `--region` help fixed on `route` | ✅ | help text updated; `test_route_cmd_help_string.py` green |
| Parser-drift guard stays green | ✅ | `tests/test_cli_parser_drift.py` (7 tests) pass; `--nets` on both parsers + shim |
| Whitespace trim | ✅ | `test_nets_whitespace_is_trimmed` |
| `<2`-pad edge case covered | ✅ | `test_nets_sub_two_pad_net_is_reported` |
| route-auto `--net`/`--nets` mutual exclusion + loop aggregation | ✅ | `test_route_auto_*` (exclusion, empty, loop exit-code, output chaining) |

## Test Plan

- `uv run pytest tests/test_cli_route_nets_flag.py` — 24 new tests pass.
- `uv run pytest tests/test_cli_parser_drift.py tests/test_route_cmd_help_string.py tests/test_route_auto_partial_cli_4165.py tests/test_route_auto_via_flags_cli_4247.py tests/test_route_cmd_params.py` — 112 pass (no regressions).
- `uv run ruff check .` — clean; `uv run ruff format . --check` — clean.
- `uv run python scripts/ci/check_mypy_baseline.py` — "No new type errors" (within baseline).

Closes #4322