### PR TITLE
fix(check): make declared stackup the ampacity copper-weight source of truth (#4326)

### DIFF
--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -219,6 +219,77 @@ def _find_pcb_file(directory: Path) -> Path | None:
     return None
 
 
+def _parse_copper_weight_arg(raw: str) -> tuple[float | None, float | None]:
+    """Parse a ``--copper`` value into ``(outer_oz, inner_oz)`` (Issue #4326).
+
+    Accepts two forms:
+
+    - **Scalar** -- ``"2"`` / ``"1.0"`` -- applies to both the outer and
+      inner layer classes, returning ``(oz, oz)``.
+    - **Keyed** -- ``"outer=2,inner=0.5"`` -- sets each layer class
+      independently.  A key omitted from the keyed form returns ``None`` for
+      that class, meaning "fall back to the stackup / profile for that layer
+      class" (so ``--copper outer=2`` overrides only the outer weight).
+
+    Raises:
+        ValueError: on empty input, unknown keys, duplicate keys, a
+            non-numeric value, or a non-positive weight -- mirroring the
+            ``--only`` / ``--skip`` category-validation contract (a clear
+            ``Error:`` + exit 1 at the call site).
+    """
+    text = raw.strip()
+    if not text:
+        raise ValueError("--copper value is empty")
+
+    if "=" not in text:
+        # Scalar form: one number for both layer classes.
+        try:
+            oz = float(text)
+        except ValueError:
+            raise ValueError(
+                f"invalid --copper value {raw!r} "
+                "(expected a number like '2' or a keyed form 'outer=2,inner=0.5')"
+            ) from None
+        if oz <= 0:
+            raise ValueError(f"--copper weight must be positive: {oz}")
+        return (oz, oz)
+
+    # Keyed form: comma-separated key=value tokens.
+    outer: float | None = None
+    inner: float | None = None
+    seen: set[str] = set()
+    for token in text.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        if "=" not in token:
+            raise ValueError(f"invalid --copper token {token!r} (expected 'key=value')")
+        key, _, value = token.partition("=")
+        key = key.strip().lower()
+        value = value.strip()
+        if key not in ("outer", "inner"):
+            raise ValueError(f"unknown --copper key {key!r} (expected 'outer' or 'inner')")
+        if key in seen:
+            raise ValueError(f"duplicate --copper key {key!r}")
+        seen.add(key)
+        try:
+            oz = float(value)
+        except ValueError:
+            raise ValueError(
+                f"invalid --copper {key} value {value!r} (expected a number)"
+            ) from None
+        if oz <= 0:
+            raise ValueError(f"--copper {key} weight must be positive: {oz}")
+        if key == "outer":
+            outer = oz
+        else:
+            inner = oz
+
+    if outer is None and inner is None:
+        raise ValueError(f"--copper keyed form set no values: {raw!r}")
+    return (outer, inner)
+
+
 def _discover_net_class_map_sidecar(pcb_path: Path) -> Path | None:
     """Probe conventional locations for a ``net_class_map.json`` sidecar.
 
@@ -833,9 +904,21 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--copper",
         "-c",
-        type=float,
-        default=1.0,
-        help="Copper weight in oz (default: 1.0)",
+        default=None,
+        metavar="OZ",
+        help=(
+            "Copper weight in oz for the ampacity gate. Scalar form "
+            "'--copper 2' applies to both outer and inner layers; keyed "
+            "form '--copper outer=2,inner=0.5' sets each layer class "
+            "independently (e.g. a JLCPCB 2oz-outer / 0.5oz-inner order, "
+            "where the inner stays 0.5oz even on a 2oz build). Precedence: "
+            "explicit --copper (keyed > scalar) > the board's declared "
+            "(setup (stackup ...)) copper weight > profile default "
+            "(1oz outer / 0.5oz inner). When --copper is omitted, an "
+            "explicit board stackup is the source of truth; a stackup that "
+            "disagrees with an explicit --copper emits a WARNING and is "
+            "fatal under --strict."
+        ),
     )
     parser.add_argument(
         "--only",
@@ -1212,13 +1295,89 @@ def main(argv: list[str] | None = None) -> int:
             for board_net, user_key in ampacity_resolution.resolved.items()
         }
 
+    # Issue #4326: resolve the ampacity gate's copper weights (outer / inner
+    # oz).  Precedence, per layer class: an EXPLICIT ``--copper`` (keyed >
+    # scalar) > the board's DECLARED ``(setup (stackup ...))`` copper weight
+    # (Tier 1 -- the new default source of truth) > the profile default.
+    #
+    # This override is scoped to the ampacity copper weights ONLY
+    # (design_rules.outer_copper_oz / inner_copper_oz); the preset's
+    # min-trace-width / clearance rules stay governed by ``--copper`` /
+    # ``--mfr`` exactly as before, so Tier 1 cannot flip unrelated verdicts.
+    cli_copper_outer: float | None = None
+    cli_copper_inner: float | None = None
+    copper_explicit = args.copper is not None
+    if copper_explicit:
+        try:
+            cli_copper_outer, cli_copper_inner = _parse_copper_weight_arg(args.copper)
+        except ValueError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
+
+    # Preset selection still keys on the scalar/outer ``--copper`` (or the
+    # historical 1oz default) -- only the ampacity copper weights follow the
+    # declared stackup.
+    preset_copper_oz = cli_copper_outer if cli_copper_outer is not None else 1.0
+
+    # Tier 1: derive copper weights from the board's declared stackup.
+    stackup_outer: float | None = None
+    stackup_inner: float | None = None
+    try:
+        from kicad_tools.physics.stackup import Stackup
+
+        _derived = Stackup.from_pcb(pcb).outer_inner_copper_oz()
+        if _derived is not None:
+            stackup_outer, stackup_inner = _derived
+    except Exception:  # noqa: BLE001 - never crash `check` on a stackup parse quirk
+        stackup_outer = stackup_inner = None
+
+    # Per-class resolution: explicit --copper wins, else the declared
+    # stackup, else None (leave the profile default in place).
+    resolved_copper_outer = cli_copper_outer if cli_copper_outer is not None else stackup_outer
+    resolved_copper_inner = cli_copper_inner if cli_copper_inner is not None else stackup_inner
+
+    # Tier 2: loud warning when an EXPLICIT --copper disagrees with the
+    # board's declared stackup.  Explicit --copper WINS (a deliberate
+    # operator override), but silently ignoring the board's declaration
+    # would itself be a footgun, so we always warn -- and under --strict the
+    # disagreement is fatal so an autonomous agent cannot sail past it.
+    def _copper_disagrees(cli_oz: float | None, stk_oz: float | None) -> bool:
+        return cli_oz is not None and stk_oz is not None and abs(cli_oz - stk_oz) > 1e-6
+
+    copper_disagreement = False
+    if copper_explicit:
+        if _copper_disagrees(cli_copper_outer, stackup_outer):
+            copper_disagreement = True
+            print(
+                f"WARNING: stackup declares {stackup_outer:g}oz outer but --copper "
+                f"requests {cli_copper_outer:g}oz — ampacity is evaluating at "
+                f"{cli_copper_outer:g}oz. Pass --copper {stackup_outer:g} or fix the stackup.",
+                file=sys.stderr,
+            )
+        if _copper_disagrees(cli_copper_inner, stackup_inner):
+            copper_disagreement = True
+            print(
+                f"WARNING: stackup declares {stackup_inner:g}oz inner but --copper "
+                f"requests {cli_copper_inner:g}oz — ampacity is evaluating at "
+                f"{cli_copper_inner:g}oz. Pass --copper inner={stackup_inner:g} or fix the stackup.",
+                file=sys.stderr,
+            )
+        if copper_disagreement and args.strict:
+            print(
+                "ERROR: --strict: stackup-vs---copper copper-weight disagreement is "
+                "fatal (exit 2). Reconcile --copper with the board's declared stackup.",
+                file=sys.stderr,
+            )
+
     # Create checker with manufacturer rules
     try:
         checker = DRCChecker(
             pcb,
             manufacturer=args.mfr,
             layers=layers,
-            copper_oz=args.copper,
+            copper_oz=preset_copper_oz,
+            copper_oz_outer=resolved_copper_outer,
+            copper_oz_inner=resolved_copper_inner,
             suppress_library=args.suppress_library,
             net_class_map=net_class_map,
             # The CLI already prints its own up-front INACTIVE warning
@@ -1349,6 +1508,14 @@ def main(argv: list[str] | None = None) -> int:
     # exit 2 also when any sub-check is FAILED, and -- per AC #3 --
     # exit 2 when the rollup is INCOMPLETE (any sub-check is NOT RUN)
     # unless the caller opted in to ``--allow-incomplete``.
+    #
+    # Issue #4326 (Tier 2 safety backstop): under --strict, a stackup-vs-
+    # --copper copper-weight disagreement is fatal on its own (a warning
+    # already fired above), so an autonomous agent cannot sail past an
+    # ampacity evaluation that silently ignored the board's declared build.
+    if args.strict and copper_disagreement:
+        return 2
+
     if drc_only:
         if error_count > 0 or (warning_count > 0 and args.strict):
             return 2

--- a/src/kicad_tools/physics/__init__.py
+++ b/src/kicad_tools/physics/__init__.py
@@ -66,6 +66,7 @@ from .constants import (
     SPEED_OF_LIGHT,
     CopperWeight,
     DielectricMaterial,
+    copper_oz_from_thickness,
     copper_thickness_from_oz,
     get_material,
     get_material_or_default,
@@ -113,6 +114,7 @@ __all__ = [
     "COPPER_1OZ",
     "COPPER_2OZ",
     "copper_thickness_from_oz",
+    "copper_oz_from_thickness",
     # Ampacity (IPC-2221)
     "width_for_current",
     # Wire gauge (AWG) / buttress-wire reinforcement

--- a/src/kicad_tools/physics/constants.py
+++ b/src/kicad_tools/physics/constants.py
@@ -148,3 +148,20 @@ def copper_thickness_from_oz(oz: float) -> float:
         Thickness in mm
     """
     return oz * 0.035  # 1 oz = 35 um = 0.035 mm
+
+
+def copper_oz_from_thickness(thickness_mm: float) -> float:
+    """Convert copper thickness (mm) to weight (oz/ft^2).
+
+    Exact inverse of :func:`copper_thickness_from_oz` (35 um = 1 oz), kept
+    here so the oz<->mm constant lives in exactly one place.  Used when
+    deriving a board's copper weight from its declared ``(setup (stackup
+    ...))`` thicknesses (Issue #4326).
+
+    Args:
+        thickness_mm: Copper thickness in mm
+
+    Returns:
+        Copper weight in oz/ft^2
+    """
+    return thickness_mm / 0.035  # 35 um = 0.035 mm = 1 oz

--- a/src/kicad_tools/physics/stackup.py
+++ b/src/kicad_tools/physics/stackup.py
@@ -31,6 +31,7 @@ from .constants import (
     COPPER_1OZ,
     COPPER_HALF_OZ,
     FR4_STANDARD,
+    copper_oz_from_thickness,
     copper_thickness_from_oz,
 )
 
@@ -152,7 +153,7 @@ class Stackup:
             # Infer copper weight from thickness
             if layer_type == LayerType.COPPER and layer.thickness_mm > 0:
                 # Approximate oz from thickness (35um = 1oz)
-                layer.copper_weight_oz = layer.thickness_mm / 0.035
+                layer.copper_weight_oz = copper_oz_from_thickness(layer.thickness_mm)
 
             layers.append(layer)
 
@@ -587,6 +588,74 @@ class Stackup:
     def copper_layers(self) -> list[StackupLayer]:
         """Get all copper layers in order from top to bottom."""
         return [layer for layer in self.layers if layer.is_copper]
+
+    @staticmethod
+    def _copper_layer_oz(layer: StackupLayer) -> float | None:
+        """Copper weight (oz) for a single copper layer, or None if unknown.
+
+        Prefers the layer's physical ``thickness_mm`` (the fab-declared
+        truth) via the centralized 35 um = 1 oz conversion, falling back to
+        a pre-computed ``copper_weight_oz`` when thickness is absent.
+        """
+        if layer.thickness_mm and layer.thickness_mm > 0:
+            return copper_oz_from_thickness(layer.thickness_mm)
+        return layer.copper_weight_oz
+
+    def outer_inner_copper_oz(self) -> tuple[float | None, float | None] | None:
+        """Derive ``(outer_oz, inner_oz)`` copper weights from the stackup.
+
+        This is the Tier-1 source of truth for the ampacity gate (Issue
+        #4326): when a board carries an explicit ``(setup (stackup ...))``
+        block, its declared copper thicknesses -- not the ``--copper``
+        default -- determine the copper weight used for IPC-2221 width
+        checks.
+
+        - **Outer** = the first and last copper layers (``F.Cu`` / ``B.Cu``,
+          matching :meth:`is_outer_layer` and ampacity's own
+          ``_EXTERNAL_LAYERS`` split).  When the two faces declare different
+          weights (asymmetric build), the **thinner** (safer) weight is
+          returned, because thinner copper requires a wider trace for the
+          same current -- the conservative choice for a safety gate.
+        - **Inner** = the ``In*.Cu`` layers (all copper layers between the
+          two faces); again the thinner weight wins on disagreement.
+
+        Returns:
+            ``(outer_oz, inner_oz)`` where each element is the derived oz or
+            ``None`` when that layer class is absent / has no usable
+            thickness (the caller then leaves the profile default in place
+            for that class).  Returns ``None`` entirely when the stackup is
+            not explicit (``has_explicit_data`` is False -- absent or a
+            synthesized default), signalling the caller to fall back to
+            ``--copper`` / profile behaviour with byte-identical output.
+        """
+        # Gate strictly on an explicitly-declared stackup.  A synthesized
+        # default stackup must not silently change any verdict (AC: absent /
+        # default => byte-identical to today).
+        if not self.has_explicit_data:
+            return None
+
+        coppers = self.copper_layers
+        if not coppers:
+            return None
+
+        # Outer faces: first and last copper layer (dedup for a 1-copper
+        # degenerate stackup).
+        outer_layers = [coppers[0]]
+        if len(coppers) > 1 and coppers[-1] is not coppers[0]:
+            outer_layers.append(coppers[-1])
+        outer_ozs = [
+            oz for layer in outer_layers if (oz := self._copper_layer_oz(layer)) is not None
+        ]
+        outer_oz = min(outer_ozs) if outer_ozs else None
+
+        # Inner layers: everything strictly between the two faces.
+        inner_layers = coppers[1:-1]
+        inner_ozs = [
+            oz for layer in inner_layers if (oz := self._copper_layer_oz(layer)) is not None
+        ]
+        inner_oz = min(inner_ozs) if inner_ozs else None
+
+        return (outer_oz, inner_oz)
 
     @property
     def dielectric_layers(self) -> list[StackupLayer]:

--- a/src/kicad_tools/validate/checker.py
+++ b/src/kicad_tools/validate/checker.py
@@ -76,6 +76,8 @@ class DRCChecker:
         emit_measurements: bool = False,
         courtyard_waivers: CourtyardWaivers | None = None,
         strict_connectivity: bool = False,
+        copper_oz_outer: float | None = None,
+        copper_oz_inner: float | None = None,
     ) -> None:
         """Initialize the DRC checker.
 
@@ -136,6 +138,18 @@ class DRCChecker:
                 then correctly fires the connectivity rule.  Default False
                 preserves the legacy tolerance model so existing ``kct check``
                 output is unchanged.
+            copper_oz_outer: Optional override for the *ampacity* gate's
+                outer-layer (F.Cu / B.Cu) copper weight in oz (Issue #4326).
+                When provided, replaces ``design_rules.outer_copper_oz``
+                after the manufacturer preset is loaded, letting the CLI
+                honor the board's declared ``(setup (stackup ...))`` copper
+                weight (or an explicit keyed ``--copper outer=..``) without
+                repointing the preset's min-trace-width / clearance rules.
+                ``None`` leaves the preset default in place.
+            copper_oz_inner: Optional override for the *ampacity* gate's
+                inner-layer (In*.Cu) copper weight in oz (Issue #4326).
+                Same semantics as ``copper_oz_outer`` for
+                ``design_rules.inner_copper_oz``.
 
         Raises:
             ValueError: If manufacturer ID is not recognized
@@ -166,6 +180,31 @@ class DRCChecker:
         # Load manufacturer profile and design rules
         profile = get_profile(manufacturer)
         self.design_rules: DesignRules = profile.get_design_rules(layers, copper_oz)
+
+        # Issue #4326: override the ampacity copper weights ONLY.
+        #
+        # ``copper_oz_outer`` / ``copper_oz_inner`` let the CLI repoint the
+        # IPC-2221 ampacity gate at the board's declared ``(setup (stackup
+        # ...))`` copper weights (or an explicit keyed ``--copper
+        # outer=..,inner=..``) without disturbing the preset's
+        # min-trace-width / clearance rules, which stay governed by
+        # ``copper_oz`` / ``--mfr`` as before.  ``get_design_rules`` may
+        # return a shared preset instance, so replace() a copy rather than
+        # mutating the registry in place.
+        if copper_oz_outer is not None or copper_oz_inner is not None:
+            self.design_rules = replace(
+                self.design_rules,
+                outer_copper_oz=(
+                    copper_oz_outer
+                    if copper_oz_outer is not None
+                    else self.design_rules.outer_copper_oz
+                ),
+                inner_copper_oz=(
+                    copper_oz_inner
+                    if copper_oz_inner is not None
+                    else self.design_rules.inner_copper_oz
+                ),
+            )
 
     # The canonical ordered list of bound-method names that
     # :meth:`check_all` invokes.  Exposed as a class attribute so the CLI

--- a/tests/test_cli_check_ampacity_stackup.py
+++ b/tests/test_cli_check_ampacity_stackup.py
@@ -1,0 +1,305 @@
+"""CLI tests for stackup-derived ampacity copper weight (Issue #4326).
+
+The ampacity gate historically took its copper weight ONLY from ``--copper``
+(default 1 oz) and ignored the board's declared ``(setup (stackup ...))``.
+A board built at 2 oz outer but checked without ``--copper`` was silently
+evaluated at 1 oz -- over-conservative at best, and (for the inverse case)
+capable of masking a real thermal hazard.
+
+This exercises all three tiers of the fix:
+
+* **Tier 1** -- the declared stackup is the default source of truth: a 2 oz
+  outer board checked WITHOUT ``--copper`` evaluates ampacity at 2 oz, and
+  that flips a verdict vs the 1 oz default (guards against a silent no-op).
+* **Tier 2** -- an EXPLICIT ``--copper`` that disagrees with the stackup
+  wins but emits a loud WARNING; agreement is silent; ``--strict`` makes the
+  disagreement fatal (exit 2).
+* **Tier 3** -- ``--copper`` accepts a keyed ``outer=..,inner=..`` form
+  alongside the scalar form, and rejects malformed input with exit 1.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+# 2-layer board declaring an EXPLICIT 2 oz outer stackup (F.Cu / B.Cu at
+# 0.070 mm = 2 oz).  A single F.Cu segment on net ``PWR`` is routed at a
+# width supplied by the template.  The net-class-map sidecar assigns
+# ``target_ampacity = 10 A`` to ``PWR``.
+#
+# IPC-2221 external required widths for 10 A (see the module docstring math):
+#   1 oz -> 7.1941 mm      2 oz -> 3.5970 mm
+_STACKUP_2OZ_BLOCK = """  (setup
+    (stackup
+      (layer "F.Cu" (type "copper") (thickness 0.070))
+      (layer "dielectric 1" (type "core") (thickness 1.46) (material "FR4") (epsilon_r 4.5) (loss_tangent 0.02))
+      (layer "B.Cu" (type "copper") (thickness 0.070))
+      (copper_finish "HASL")
+      (dielectric_constraints no)
+    )
+    (pad_to_mask_clearance 0)
+  )
+"""
+
+_NO_STACKUP_BLOCK = "  (setup (pad_to_mask_clearance 0))\n"
+
+REQ_1OZ_10A = 7.1941
+REQ_2OZ_10A = 3.5970
+
+
+def _board(segment_width_mm: float, *, stackup: bool) -> str:
+    setup_block = _STACKUP_2OZ_BLOCK if stackup else _NO_STACKUP_BLOCK
+    return f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+{setup_block}  (net 0 "")
+  (net 1 "PWR")
+  (gr_rect (start 100 100) (end 200 200)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+  (segment (start 110 120) (end 170 120) (width {segment_width_mm}) (layer "F.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-000000000001"))
+)
+"""
+
+
+def _write_board(dir_path: Path, width_mm: float, *, stackup: bool) -> Path:
+    pcb_file = dir_path / "board.kicad_pcb"
+    pcb_file.write_text(_board(width_mm, stackup=stackup))
+    return pcb_file
+
+
+def _write_ncm(dir_path: Path, amps: float = 10.0) -> Path:
+    ncm_file = dir_path / "ncm.json"
+    ncm_file.write_text(json.dumps({"PWR": {"name": "PWR", "target_ampacity": amps}}))
+    return ncm_file
+
+
+def _ampacity_errors(report_path: Path) -> list[dict]:
+    data = json.loads(report_path.read_text())
+    return [
+        v
+        for v in data["violations"]
+        if v.get("rule_id") == "ampacity" and v.get("severity") == "error"
+    ]
+
+
+def _run_check(pcb: Path, ncm: Path, report: Path, *, extra: list[str] | None = None) -> int:
+    from kicad_tools.cli.check_cmd import main
+
+    argv = [
+        str(pcb),
+        "--mfr",
+        "jlcpcb",
+        "--net-class-map",
+        str(ncm),
+        "--output",
+        str(report),
+        "--format",
+        "json",
+    ]
+    if extra:
+        argv.extend(extra)
+    return main(argv)
+
+
+class TestTier1StackupIsDefaultSourceOfTruth:
+    """Tier 1: a declared 2 oz stackup drives ampacity without --copper."""
+
+    def test_declared_2oz_evaluates_at_2oz(self, tmp_path: Path):
+        """A grossly under-width net reports the 2 oz required width, not 1 oz.
+
+        The 0.5 mm segment fails at any weight; the point is the *required*
+        width printed is the 2 oz IPC-2221 floor (3.597 mm) derived from the
+        declared stackup -- proving the stackup, not the 1 oz default, was
+        the source of truth.
+        """
+        pcb = _write_board(tmp_path, 0.5, stackup=True)
+        ncm = _write_ncm(tmp_path)
+        report = tmp_path / "r.json"
+
+        _run_check(pcb, ncm, report)  # no --copper
+
+        errors = _ampacity_errors(report)
+        assert len(errors) == 1
+        assert errors[0]["required_value"] == pytest.approx(REQ_2OZ_10A, abs=0.01)
+        # And decidedly NOT the 1 oz default value.
+        assert errors[0]["required_value"] != pytest.approx(REQ_1OZ_10A, abs=0.01)
+
+    def test_verdict_flip_vs_1oz_default(self, tmp_path: Path):
+        """A width between the 2 oz and 1 oz floors flips the verdict.
+
+        At 5.0 mm the net PASSES at 2 oz (>= 3.597) but FAILS at 1 oz
+        (< 7.194).  Checked without --copper on the 2 oz board it must PASS;
+        forcing --copper 1 must FAIL -- guarding against a silent no-op.
+        """
+        pcb = _write_board(tmp_path, 5.0, stackup=True)
+        ncm = _write_ncm(tmp_path)
+
+        report_stackup = tmp_path / "stackup.json"
+        _run_check(pcb, ncm, report_stackup)  # 2 oz stackup, no --copper
+        assert len(_ampacity_errors(report_stackup)) == 0
+
+        report_1oz = tmp_path / "one.json"
+        _run_check(pcb, ncm, report_1oz, extra=["--copper", "1"])  # force 1 oz
+        errors_1oz = _ampacity_errors(report_1oz)
+        assert len(errors_1oz) == 1
+        assert errors_1oz[0]["required_value"] == pytest.approx(REQ_1OZ_10A, abs=0.01)
+
+    def test_absent_stackup_falls_back_to_1oz(self, tmp_path: Path):
+        """No declared stackup -> byte-identical 1 oz default behaviour.
+
+        The same 5.0 mm net on a board WITHOUT a stackup block is evaluated
+        at the 1 oz default and therefore FAILS -- confirming the fallback
+        is unchanged when the stackup is absent.
+        """
+        pcb = _write_board(tmp_path, 5.0, stackup=False)
+        ncm = _write_ncm(tmp_path)
+        report = tmp_path / "r.json"
+
+        _run_check(pcb, ncm, report)  # no --copper, no stackup
+
+        errors = _ampacity_errors(report)
+        assert len(errors) == 1
+        assert errors[0]["required_value"] == pytest.approx(REQ_1OZ_10A, abs=0.01)
+
+
+class TestTier2CrossCheckWarning:
+    """Tier 2: explicit --copper wins but warns on stackup disagreement."""
+
+    def test_warning_fires_on_disagreement(self, tmp_path: Path, capsys):
+        """--copper 1 against a 2 oz stackup warns and evaluates at 1 oz."""
+        pcb = _write_board(tmp_path, 0.5, stackup=True)
+        ncm = _write_ncm(tmp_path)
+        report = tmp_path / "r.json"
+
+        _run_check(pcb, ncm, report, extra=["--copper", "1"])
+
+        err = capsys.readouterr().err
+        assert "stackup declares 2oz outer" in err
+        assert "--copper" in err
+        # Explicit --copper wins: evaluated at 1 oz.
+        errors = _ampacity_errors(report)
+        assert errors[0]["required_value"] == pytest.approx(REQ_1OZ_10A, abs=0.01)
+
+    def test_silent_on_agreement(self, tmp_path: Path, capsys):
+        """--copper 2 matching a 2 oz stackup emits no disagreement warning."""
+        pcb = _write_board(tmp_path, 0.5, stackup=True)
+        ncm = _write_ncm(tmp_path)
+        report = tmp_path / "r.json"
+
+        _run_check(pcb, ncm, report, extra=["--copper", "2"])
+
+        err = capsys.readouterr().err
+        assert "stackup declares" not in err
+        errors = _ampacity_errors(report)
+        assert errors[0]["required_value"] == pytest.approx(REQ_2OZ_10A, abs=0.01)
+
+    def test_strict_makes_disagreement_fatal(self, tmp_path: Path):
+        """Under --strict, a stackup-vs---copper disagreement forces exit 2.
+
+        Uses ``--drc-only`` so the meta-check rollup (which would exit 2 on
+        INCOMPLETE for a schematic-less board) cannot mask the result: the
+        8.0 mm net clears the 1 oz floor (0 ampacity errors), so the ONLY
+        thing that flips exit 0 -> 2 between the two runs is ``--strict``
+        acting on the copper disagreement.
+        """
+        pcb = _write_board(tmp_path, 8.0, stackup=True)  # >= 7.194 (1 oz) -> passes
+        ncm = _write_ncm(tmp_path)
+
+        report_lax = tmp_path / "lax.json"
+        rc_lax = _run_check(pcb, ncm, report_lax, extra=["--copper", "1", "--drc-only"])
+        assert len(_ampacity_errors(report_lax)) == 0
+        assert rc_lax == 0  # disagreement warns but is not fatal without --strict
+
+        report_strict = tmp_path / "strict.json"
+        rc_strict = _run_check(
+            pcb, ncm, report_strict, extra=["--copper", "1", "--strict", "--drc-only"]
+        )
+        assert len(_ampacity_errors(report_strict)) == 0
+        assert rc_strict == 2  # Tier 2 strict backstop
+
+    def test_no_warning_without_explicit_copper(self, tmp_path: Path, capsys):
+        """A 2 oz stackup with no --copper is the happy path (no warning)."""
+        pcb = _write_board(tmp_path, 0.5, stackup=True)
+        ncm = _write_ncm(tmp_path)
+        report = tmp_path / "r.json"
+
+        _run_check(pcb, ncm, report)
+
+        assert "stackup declares" not in capsys.readouterr().err
+
+
+class TestTier3KeyedCopper:
+    """Tier 3: keyed --copper form + malformed-input rejection."""
+
+    def test_parse_scalar(self):
+        from kicad_tools.cli.check_cmd import _parse_copper_weight_arg
+
+        assert _parse_copper_weight_arg("2") == (2.0, 2.0)
+        assert _parse_copper_weight_arg("0.5") == (0.5, 0.5)
+
+    def test_parse_keyed_both(self):
+        from kicad_tools.cli.check_cmd import _parse_copper_weight_arg
+
+        assert _parse_copper_weight_arg("outer=2,inner=0.5") == (2.0, 0.5)
+        # Order-independent + whitespace tolerant.
+        assert _parse_copper_weight_arg(" inner=0.5 , outer=2 ") == (2.0, 0.5)
+
+    def test_parse_keyed_partial(self):
+        from kicad_tools.cli.check_cmd import _parse_copper_weight_arg
+
+        assert _parse_copper_weight_arg("outer=2") == (2.0, None)
+        assert _parse_copper_weight_arg("inner=0.5") == (None, 0.5)
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "",
+            "abc",
+            "outer=2,bogus=3",
+            "outer=abc",
+            "outer=2,outer=3",
+            "outer=-1",
+            "outer=",
+        ],
+    )
+    def test_parse_malformed_rejected(self, bad):
+        from kicad_tools.cli.check_cmd import _parse_copper_weight_arg
+
+        with pytest.raises(ValueError):
+            _parse_copper_weight_arg(bad)
+
+    def test_keyed_outer_drives_cli_verdict(self, tmp_path: Path):
+        """``--copper outer=2`` evaluates the external net at 2 oz."""
+        pcb = _write_board(tmp_path, 5.0, stackup=False)  # no stackup
+        ncm = _write_ncm(tmp_path)
+        report = tmp_path / "r.json"
+
+        # Without a stackup and with keyed outer=2, the 5.0 mm net clears the
+        # 2 oz floor (3.597) and PASSES -- whereas the 1 oz default would fail.
+        _run_check(pcb, ncm, report, extra=["--copper", "outer=2"])
+        assert len(_ampacity_errors(report)) == 0
+
+    def test_malformed_copper_exits_1(self, tmp_path: Path, capsys):
+        """A malformed --copper value is a hard Error with exit 1."""
+        pcb = _write_board(tmp_path, 5.0, stackup=False)
+        ncm = _write_ncm(tmp_path)
+        report = tmp_path / "r.json"
+
+        rc = _run_check(pcb, ncm, report, extra=["--copper", "outer=2,bogus=3"])
+        assert rc == 1
+        assert "Error:" in capsys.readouterr().err

--- a/tests/test_physics_stackup.py
+++ b/tests/test_physics_stackup.py
@@ -331,3 +331,92 @@ class TestStackupFromPCB:
         repr_str = repr(stackup)
         assert "4L" in repr_str
         assert "1.6mm" in repr_str
+
+
+class TestOuterInnerCopperOz:
+    """Tests for ``Stackup.outer_inner_copper_oz`` (Issue #4326).
+
+    This is the Tier-1 derivation helper: it converts a declared stackup's
+    copper thicknesses into ``(outer_oz, inner_oz)`` so the ampacity gate can
+    use the board's real build instead of the ``--copper`` default.
+    """
+
+    @staticmethod
+    def _explicit(layers):
+        return Stackup(layers=layers, has_explicit_data=True)
+
+    def _copper(self, name, thickness_mm):
+        return StackupLayer(
+            name=name,
+            layer_type=LayerType.COPPER,
+            thickness_mm=thickness_mm,
+            material="copper",
+        )
+
+    def _diel(self, name="core"):
+        return StackupLayer(
+            name=name,
+            layer_type=LayerType.DIELECTRIC,
+            thickness_mm=0.2,
+            material="FR4",
+        )
+
+    def test_absent_stackup_returns_none(self):
+        """A non-explicit (default/synthesized) stackup derives nothing."""
+        stackup = Stackup.jlcpcb_4layer()  # preset -> has_explicit_data False
+        assert stackup.has_explicit_data is False
+        assert stackup.outer_inner_copper_oz() is None
+
+    def test_two_oz_outer_half_oz_inner_4layer(self):
+        """A 2oz-outer / 0.5oz-inner 4-layer build derives (2.0, 0.5)."""
+        stackup = self._explicit(
+            [
+                self._copper("F.Cu", 0.070),  # 2 oz
+                self._diel("prepreg"),
+                self._copper("In1.Cu", 0.0175),  # 0.5 oz
+                self._diel("core"),
+                self._copper("In2.Cu", 0.0175),  # 0.5 oz
+                self._diel("prepreg2"),
+                self._copper("B.Cu", 0.070),  # 2 oz
+            ]
+        )
+        outer, inner = stackup.outer_inner_copper_oz()
+        assert outer == pytest.approx(2.0, abs=1e-6)
+        assert inner == pytest.approx(0.5, abs=1e-6)
+
+    def test_two_layer_has_no_inner(self):
+        """A 2-layer explicit stackup derives outer only (inner is None)."""
+        stackup = self._explicit(
+            [
+                self._copper("F.Cu", 0.070),  # 2 oz
+                self._diel("core"),
+                self._copper("B.Cu", 0.070),  # 2 oz
+            ]
+        )
+        outer, inner = stackup.outer_inner_copper_oz()
+        assert outer == pytest.approx(2.0, abs=1e-6)
+        assert inner is None
+
+    def test_asymmetric_outer_picks_thinner_safer_face(self):
+        """F.Cu != B.Cu: the thinner (conservative) outer weight wins."""
+        stackup = self._explicit(
+            [
+                self._copper("F.Cu", 0.070),  # 2 oz
+                self._diel("core"),
+                self._copper("B.Cu", 0.035),  # 1 oz (thinner -> safer)
+            ]
+        )
+        outer, _inner = stackup.outer_inner_copper_oz()
+        assert outer == pytest.approx(1.0, abs=1e-6)
+
+    def test_uses_035_conversion(self):
+        """Derived oz uses the established 35um = 1oz conversion."""
+        stackup = self._explicit(
+            [
+                self._copper("F.Cu", 0.105),  # 3 oz
+                self._diel("core"),
+                self._copper("B.Cu", 0.105),
+            ]
+        )
+        outer, _ = stackup.outer_inner_copper_oz()
+        assert outer == pytest.approx(0.105 / 0.035, abs=1e-6)


### PR DESCRIPTION
Closes #4326

## Problem

The ampacity/DRC copper weight came **only** from `--copper` (default 1 oz) → manufacturer preset → `DesignRules.outer_copper_oz`/`inner_copper_oz`. The board's declared `(setup (stackup ...))` was never consulted, so a board built at 2 oz outer but checked without `--copper` was silently evaluated at 1 oz — over-conservative at best, and (for the inverse, thin-copper case) capable of masking a real thermal hazard. This composes with #4321/#4324 (which fixed the net-class-map key resolution feeding the same ampacity verdict).

## What changed (all three tiers, one PR per operator directive)

### Tier 1 — declared stackup is the default source of truth
- New `Stackup.outer_inner_copper_oz()` (`physics/stackup.py`) derives `(outer_oz, inner_oz)` from the declared copper thicknesses using the established 35 µm = 1 oz conversion, **gated on `has_explicit_data`** (returns `None` for absent/synthesized stackups). Outer = first/last copper (F.Cu/B.Cu); inner = In*.Cu. On an asymmetric build (F.Cu ≠ B.Cu) the **thinner/safer** weight wins (thinner copper needs a wider trace — the conservative choice for a safety gate).
- The CLI derives these in the same pre-`DRCChecker` block #4324 added, and passes them as new optional `copper_oz_outer`/`copper_oz_inner` params to `DRCChecker`, which overrides `design_rules.outer/inner_copper_oz` via `dataclasses.replace` on a copy (never mutating the shared preset registry).
- **Scoped to ampacity only**: the preset's min-trace-width/clearance rules stay governed by `--copper`/`--mfr`, so Tier 1 cannot flip unrelated verdicts.
- Absent/synthesized stackup → byte-identical to today.

### Tier 2 — cross-check + loud warning on disagreement
- `--copper`'s argparse default is now a `None` sentinel so an explicit pass is distinguishable from the default.
- When an **explicit** `--copper` disagrees with the declared stackup, an explicit `--copper` **wins** (deliberate operator override) but a loud stderr `WARNING` names both weights and the fix. Silent on agreement, and silent when `--copper` is omitted.
- **Safety backstop**: under `--strict`, the disagreement is fatal (exit 2), so an autonomous agent cannot sail past an ampacity eval that ignored the declared build.

### Tier 3 — per-class keyed `--copper`
- `--copper` accepts both the scalar form (`--copper 2`, both classes) and a keyed form (`--copper outer=2,inner=0.5`, independent). A JLC 4-layer 2 oz-outer/0.5 oz-inner order is now expressible exactly (inner stays 0.5 oz even on a 2 oz build; a scalar `--copper 2` would wrongly inflate inner). Malformed input (unknown/duplicate key, non-numeric, non-positive, empty) is a hard `Error:` + exit 1.
- Precedence documented in `--help`: explicit `--copper` (keyed > scalar) > declared stackup (Tier 1) > profile default.

## `--copper`-vs-stackup precedence (chosen rule)

**Explicit `--copper` wins on disagreement**, always with the Tier 2 warning, escalated to fatal under `--strict`. Rationale: silently ignoring an explicit operator flag would itself be a footgun; the warning + strict escalation prevents a silent unsafe result while preserving the operator's ability to override the board default. The stackup wins only when `--copper` is left at its default.

## Tier-1 fleet before/after finding (verdict-flip risk)

Enumerated every `boards/**/output/*.kicad_pcb` (16 files): **none declare an explicit `(setup (stackup ...))` block** — all resolve to `has_explicit_data=False` / `outer_inner_copper_oz()==None`. Therefore **Tier 1 is a verified no-op across the entire fleet: zero verdict flips**. Concretely confirmed on `05-bldc-motor-controller` (highest-current board): `kct check --drc-only` gives identical output/exit with and without `--copper 1`, and no disagreement warning fires (no stackup to disagree with). The default change only bites a board that actually declares a stackup ≠ 1 oz outer, where each flip is the physically-correct verdict.

## Regression test result (2 oz stackup → correct oz)

`tests/test_cli_check_ampacity_stackup.py`:
- A board declaring 2 oz outer, checked **without** `--copper`, evaluates ampacity at **2 oz**: the reported required width is the 2 oz IPC-2221 floor (3.597 mm for 10 A external), **not** the 1 oz value (7.194 mm).
- **No-op guard / verdict flip**: a 5.0 mm net (between the 2 oz and 1 oz floors) PASSES on the 2 oz stackup but FAILS under `--copper 1` — proving Tier 1 is not a silent no-op.

## Tests
- `tests/test_physics_stackup.py::TestOuterInnerCopperOz` — helper units (2 oz/0.5 oz derivation, absent-stackup `None`, 2-layer no-inner, asymmetric thinner-face tie-break, /0.035 conversion).
- `tests/test_cli_check_ampacity_stackup.py` — Tier 1 (2 oz eval + verdict flip + absent-stackup fallback), Tier 2 (warning fires on disagreement / silent on agreement / silent without explicit `--copper` / `--strict` fatal via `--drc-only` contrast), Tier 3 (scalar + keyed + partial-keyed parsing, malformed rejection, keyed-outer CLI verdict, malformed exit 1).

## Local checks (in worktree)
- `pytest` ampacity + stackup + net-class-map + check-coverage suites: **all green** (112 passed in the focused run; 78 in the ampacity/stackup subset).
- `ruff check .` — All checks passed (pre-existing unrelated MFR001 `# noqa` warning only).
- `ruff format --check .` — all formatted.
- `mypy` baseline gate (`scripts/ci/check_mypy_baseline.py`, clean cache) — **exit 0, zero new errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)