### PR TITLE
feat(creepage): add kct creepage HV surface-path census command

### DIFF
--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -57,6 +57,7 @@ from .commands import (
     run_config_command,
     run_constraints_command,
     run_create_pcb_command,
+    run_creepage_command,
     run_datasheet_command,
     run_decisions_command,
     run_estimate_command,
@@ -285,6 +286,9 @@ def _dispatch_command(args) -> int:
 
     elif args.command == "check":
         return run_check_command(args)
+
+    elif args.command == "creepage":
+        return run_creepage_command(args)
 
     elif args.command == "sch":
         return run_sch_command(args)

--- a/src/kicad_tools/cli/commands/__init__.py
+++ b/src/kicad_tools/cli/commands/__init__.py
@@ -21,6 +21,7 @@ from .board_metrics import run_board_metrics_command
 from .build import run_build_command
 from .config import run_config_command, run_interactive_command
 from .create_pcb import run_create_pcb_command
+from .creepage import run_creepage_command
 from .datasheet import run_datasheet_command
 from .decisions import run_decisions_command
 from .estimate import run_estimate_command
@@ -85,6 +86,7 @@ __all__ = [
     "run_benchmark_command",
     # Validation
     "run_check_command",
+    "run_creepage_command",
     "run_validate_command",
     "run_validate_footprints_command",
     "run_fix_footprints_command",

--- a/src/kicad_tools/cli/commands/creepage.py
+++ b/src/kicad_tools/cli/commands/creepage.py
@@ -1,0 +1,129 @@
+"""``kct creepage`` command handler (Issue #4327, phase 1 MVP).
+
+Measures per-pair surface-path (creepage) distance between an HV net group
+and every other conductor / board edge, honoring milled Edge.Cuts slots, and
+reports a **census** (all pairs + margin, not just violations) with clearance
+(through-air) and creepage (over-surface) reported as distinct values.
+
+The required minimum is supplied by the operator via ``--min`` (phase 1 does
+not know IEC table values -- that is #4332).  Exit is non-zero iff any pair's
+creepage falls below ``--min``.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from kicad_tools.creepage.engine import CreepageReport
+
+
+def run_creepage_command(args) -> int:
+    """Handle the ``creepage`` command.  Returns the process exit code."""
+    from kicad_tools._shapely import has_shapely
+    from kicad_tools.creepage.engine import compute_creepage_census, resolve_hv_nets
+    from kicad_tools.schema.pcb import PCB
+
+    fmt = getattr(args, "format", "table") or "table"
+
+    if not has_shapely():
+        # Consistent with segment_copper_polygon returning None: fail loud.
+        print(
+            "Error: creepage analysis requires shapely (a core dependency); "
+            "it is not importable in this environment.",
+            file=sys.stderr,
+        )
+        return 1
+
+    pcb_path = Path(args.pcb)
+    if not pcb_path.exists():
+        print(f"Error: PCB file not found: {pcb_path}", file=sys.stderr)
+        return 1
+
+    # Load the optional net-class map sidecar (reuses net_class_map_from_dict).
+    net_class_map = None
+    ncm_arg = getattr(args, "net_class_map", None)
+    if ncm_arg:
+        from kicad_tools.router.rules import net_class_map_from_dict
+
+        ncm_path = Path(ncm_arg)
+        if not ncm_path.exists():
+            print(f"Error: net-class-map file not found: {ncm_path}", file=sys.stderr)
+            return 1
+        try:
+            net_class_map = net_class_map_from_dict(json.loads(ncm_path.read_text()))
+        except json.JSONDecodeError as e:
+            print(f"Error: parsing net-class-map JSON: {e}", file=sys.stderr)
+            return 1
+        except (TypeError, ValueError) as e:
+            print(f"Error: invalid net-class-map structure: {e}", file=sys.stderr)
+            return 1
+
+    pcb = PCB.load(pcb_path)
+    net_class = getattr(args, "net_class", "HV") or "HV"
+    min_mm = float(args.min)
+
+    hv_nets = resolve_hv_nets(pcb, net_class, net_class_map)
+    report = compute_creepage_census(
+        pcb,
+        hv_nets,
+        min_mm,
+        net_class=net_class,
+        board=str(pcb_path),
+    )
+
+    if fmt == "json":
+        print(json.dumps(report.to_dict(), indent=2))
+    else:
+        _render_table(report)
+
+    # Non-zero exit iff any pair's creepage < --min.  An empty census
+    # (no HV nets, or HV nets with no neighbors) is a clean exit 0.
+    return 0 if report.passed else 1
+
+
+def _render_table(report: CreepageReport) -> None:
+    """Print the human-readable census table."""
+    if not report.has_hv_nets:
+        print(
+            f"No '{report.net_class}' nets found "
+            "(supply --net-class-map to classify HV nets, or check --net-class)."
+        )
+        print(f"Board: {report.board}")
+        print("Census: 0 pairs.  Nothing to audit -- exit 0.")
+        return
+
+    print(f"HV creepage/clearance census  (net-class '{report.net_class}')")
+    print(f"Board: {report.board}")
+    print(f"Required minimum creepage (--min): {report.min_mm:.3f} mm")
+    print(f"HV nets ({len(report.hv_nets)}): {', '.join(report.hv_nets)}")
+    print()
+
+    if not report.pairs:
+        print("Census: 0 pairs (HV nets present but no other conductors / edge found).")
+        return
+
+    header = (
+        f"{'HV net':<16} {'Against':<16} {'Layer':<7} "
+        f"{'Clearance':>10} {'Creepage':>10} {'Margin':>10} {'Result':>7}"
+    )
+    print(header)
+    print("-" * len(header))
+    for p in report.pairs:
+        result = "PASS" if p.passed else "FAIL"
+        print(
+            f"{p.net_a:<16} {p.net_b:<16} {p.layer:<7} "
+            f"{p.clearance_mm:>9.3f}  {p.creepage_mm:>9.3f}  "
+            f"{p.margin_mm:>9.3f}  {result:>7}"
+        )
+
+    print()
+    failures = [p for p in report.pairs if not p.passed]
+    total = len(report.pairs)
+    if failures:
+        print(f"FAIL: {len(failures)}/{total} pair(s) below {report.min_mm:.3f} mm creepage.")
+    else:
+        print(f"PASS: all {total} pair(s) clear {report.min_mm:.3f} mm creepage.")

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -141,6 +141,7 @@ def create_parser() -> argparse.ArgumentParser:
     _add_drc_parser(subparsers)
     _add_bom_parser(subparsers)
     _add_check_parser(subparsers)
+    _add_creepage_parser(subparsers)
     _add_sch_parser(subparsers)
     _add_pcb_parser(subparsers)
     _add_lib_parser(subparsers)
@@ -417,6 +418,48 @@ def _add_bom_parser(subparsers) -> None:
     bom_parser.add_argument("--include-dnp", action="store_true")
     bom_parser.add_argument(
         "--sort", choices=["reference", "value", "footprint"], default="reference"
+    )
+
+
+def _add_creepage_parser(subparsers) -> None:
+    """Add creepage subcommand parser (HV surface-path audit, Issue #4327)."""
+    creepage_parser = subparsers.add_parser(
+        "creepage",
+        help="HV creepage/clearance census (surface-path distance)",
+    )
+    creepage_parser.add_argument("pcb", help="Path to .kicad_pcb file")
+    creepage_parser.add_argument(
+        "--net-class",
+        dest="net_class",
+        default="HV",
+        help="Net class to treat as the HV group (default: HV)",
+    )
+    creepage_parser.add_argument(
+        "--net-class-map",
+        dest="net_class_map",
+        default=None,
+        help=(
+            "Path to a JSON sidecar mapping net names to NetClassRouting "
+            "fields (parsed by net_class_map_from_dict); nets whose class "
+            "name matches --net-class are the HV group.  Falls back to "
+            "name-pattern classification for unmapped nets."
+        ),
+    )
+    creepage_parser.add_argument(
+        "--min",
+        type=float,
+        required=True,
+        help=(
+            "Required minimum creepage (surface-path) distance in mm.  Exit "
+            "is non-zero if any pair's creepage falls below this value.  "
+            "Phase 1 has no IEC tables (see #4332); the operator supplies it."
+        ),
+    )
+    creepage_parser.add_argument(
+        "--format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table)",
     )
 
 

--- a/src/kicad_tools/creepage/__init__.py
+++ b/src/kicad_tools/creepage/__init__.py
@@ -1,0 +1,31 @@
+"""HV creepage/clearance audit engine (Issue #4327, phase 1).
+
+This package computes **surface-path (creepage)** distances between a
+high-voltage (HV) net group and every other conductor / board edge, honoring
+milled Edge.Cuts slots that lengthen the surface path.  It complements the
+straight-line copper *clearance* that ``kct check`` already measures.
+
+Phase 1 (this package) takes the required minimum from the operator via
+``--min``.  IEC 60664-1 / 62368-1 standard-table lookup (#4332) and
+``kct audit`` integration (#4333) are tracked as follow-ups.
+
+See :mod:`kicad_tools.creepage.engine` for the public API.
+"""
+
+from __future__ import annotations
+
+from .engine import (
+    CreepagePair,
+    CreepageReport,
+    compute_creepage_census,
+    resolve_hv_nets,
+    surface_path_length,
+)
+
+__all__ = [
+    "CreepagePair",
+    "CreepageReport",
+    "compute_creepage_census",
+    "resolve_hv_nets",
+    "surface_path_length",
+]

--- a/src/kicad_tools/creepage/engine.py
+++ b/src/kicad_tools/creepage/engine.py
@@ -1,0 +1,534 @@
+"""Creepage / clearance census engine (Issue #4327, phase 1 MVP).
+
+Clearance vs creepage
+---------------------
+
+* **Clearance** is the shortest straight-line, through-air gap between two
+  conductors -- exactly what ``kct check``'s clearance rule already measures.
+* **Creepage** is the shortest path *along the board surface* between two
+  conductors.  A milled slot/cutout in ``Edge.Cuts`` lying between the two
+  conductors **lengthens** that path (the surface route must detour around
+  the slot), so ``creepage >= clearance``.  IEC 60664-1 / 62368-1 govern
+  creepage for HV, so the two values are reported distinctly.
+
+This module reuses the existing shapely copper primitives rather than
+reinventing them:
+
+* trace segments -> :func:`kicad_tools.geometry.copper.segment_copper_polygon`
+* pads           -> :func:`kicad_tools.validate.rules.clearance._pad_polygon`
+  (true roundrect/oval outline in board coordinates)
+* vias           -> a circular disc of the via's copper radius
+* zone fills     -> :meth:`ConnectivityValidator._fill_solid_region`
+
+and derives slot/cutout obstacles from the ``Edge.Cuts`` outline
+(:meth:`PCB.get_board_outline_segments` + :meth:`PCB._edge_cuts_poly_chains_sexp`).
+
+The MVP surface-path model is an honest approximation: if the straight
+nearest-points segment between two conductors does NOT cross an interior
+Edge.Cuts cutout, ``creepage == clearance``; if it DOES, a visibility graph
+over the intervening slot polygons' vertices yields the shortest detour
+around them.
+"""
+
+from __future__ import annotations
+
+import heapq
+import math
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from kicad_tools._shapely import has_shapely, require_shapely
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from kicad_tools.router.rules import NetClassRouting
+    from kicad_tools.schema.pcb import PCB
+
+
+# Sentinel used as the "net B" name for HV-vs-board-edge pairs.
+BOARD_EDGE_LABEL = "<board edge>"
+
+# Geometry epsilons (mm).  Well below any manufacturing precision but above
+# IEEE-754 noise for the coordinate space we operate in.
+_EPS = 1e-9
+_INTERIOR_SHRINK = 1e-6  # shrink a slot before the "crosses interior" test
+# A pair is a PASS when creepage >= min within this tolerance (mm).  Mirrors
+# the spirit of DRC_TOLERANCE -- a sub-micron shortfall is not a real defect.
+_PASS_TOLERANCE = 1e-4
+
+
+# ---------------------------------------------------------------------------
+# Result model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CreepagePair:
+    """One evaluated (HV-net, other-conductor | board-edge) census row.
+
+    ``clearance_mm`` is the straight-line copper gap; ``creepage_mm`` is the
+    slot-aware surface path (``>= clearance_mm``).  ``min_mm`` is the operator
+    supplied required value.
+    """
+
+    net_a: str
+    net_b: str
+    kind: str  # "conductor" | "edge"
+    layer: str  # copper layer of the binding measurement, or "*" for edges
+    clearance_mm: float
+    creepage_mm: float
+    min_mm: float
+
+    @property
+    def margin_mm(self) -> float:
+        """Creepage headroom over the required minimum (negative == fail)."""
+        return self.creepage_mm - self.min_mm
+
+    @property
+    def passed(self) -> bool:
+        """``True`` when the surface path clears the required minimum."""
+        return self.creepage_mm >= self.min_mm - _PASS_TOLERANCE
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "net_a": self.net_a,
+            "net_b": self.net_b,
+            "kind": self.kind,
+            "layer": self.layer,
+            "clearance_mm": round(self.clearance_mm, 4),
+            "creepage_mm": round(self.creepage_mm, 4),
+            "margin_mm": round(self.margin_mm, 4),
+            "pass": self.passed,
+        }
+
+
+@dataclass
+class CreepageReport:
+    """Full census of HV creepage/clearance pairs for a board."""
+
+    net_class: str
+    min_mm: float
+    hv_nets: list[str] = field(default_factory=list)
+    pairs: list[CreepagePair] = field(default_factory=list)
+    board: str = ""
+
+    @property
+    def passed(self) -> bool:
+        """``True`` when every pair clears ``min_mm`` (vacuously true if empty)."""
+        return all(p.passed for p in self.pairs)
+
+    @property
+    def has_hv_nets(self) -> bool:
+        return bool(self.hv_nets)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "board": self.board,
+            "net_class": self.net_class,
+            "min_mm": self.min_mm,
+            "hv_nets": list(self.hv_nets),
+            "pair_count": len(self.pairs),
+            "pairs": [p.to_dict() for p in self.pairs],
+            "passed": self.passed,
+        }
+
+
+# ---------------------------------------------------------------------------
+# HV net selection (reuses existing net-class plumbing -- no new classifier)
+# ---------------------------------------------------------------------------
+
+
+def resolve_hv_nets(
+    pcb: PCB,
+    net_class: str,
+    net_class_map: dict[str, NetClassRouting] | None = None,
+) -> dict[int, str]:
+    """Return ``{net_number: net_name}`` for nets belonging to ``net_class``.
+
+    Selection order (no new classification mechanism is introduced):
+
+    1. **Explicit map** -- when ``net_class_map`` is supplied (parsed by
+       :func:`kicad_tools.router.rules.net_class_map_from_dict`), a net whose
+       name maps to a :class:`NetClassRouting` whose ``name`` matches
+       ``net_class`` (case-insensitive) is selected.
+    2. **Name-pattern fallback** -- for any net NOT resolved by the map, the
+       existing :func:`kicad_tools.router.net_class.classify_from_name` is
+       consulted and its :class:`NetClass` value compared to ``net_class``
+       (case-insensitive).  This lets ``--net-class power`` work without a map
+       while ``--net-class HV`` (which has no built-in pattern) relies on the
+       map, exactly as the phase-1 spec intends.
+    """
+    from kicad_tools.router.net_class import classify_from_name
+
+    target = net_class.strip().lower()
+    net_class_map = net_class_map or {}
+
+    selected: dict[int, str] = {}
+    for net in pcb.nets.values():
+        if net.number == 0 or not net.name:
+            continue
+        routing = net_class_map.get(net.name)
+        if routing is not None:
+            if (routing.name or "").strip().lower() == target:
+                selected[net.number] = net.name
+            continue
+        # Name-pattern fallback for nets not covered by the map.
+        classification = classify_from_name(net.name)
+        if classification is not None and classification.value.strip().lower() == target:
+            selected[net.number] = net.name
+    return selected
+
+
+# ---------------------------------------------------------------------------
+# Copper geometry (reuses the existing shapely primitives)
+# ---------------------------------------------------------------------------
+
+
+def _net_geoms_on_layer(pcb: PCB, layer_name: str) -> dict[int, list[Any]]:
+    """Collect per-net copper shapely geometries on a single copper layer.
+
+    Reuses ``segment_copper_polygon`` (traces), ``_pad_polygon`` (pads, true
+    outline), a buffered point (vias), and ``_fill_solid_region`` (zone fills).
+    """
+    from shapely.geometry import Point  # type: ignore[import-untyped]
+
+    from kicad_tools.core.layers import via_spans_layer
+    from kicad_tools.geometry.copper import segment_copper_polygon
+    from kicad_tools.validate.connectivity import ConnectivityValidator
+    from kicad_tools.validate.rules.clearance import _pad_polygon
+
+    geoms: dict[int, list[Any]] = {}
+
+    def _add(net_number: int, geom: Any | None) -> None:
+        if geom is None or getattr(geom, "is_empty", False):
+            return
+        geoms.setdefault(net_number, []).append(geom)
+
+    # Trace segments
+    for seg in pcb.segments_on_layer(layer_name):
+        _add(seg.net_number, segment_copper_polygon(seg.start, seg.end, seg.width))
+
+    # Pads (true roundrect/oval outline)
+    for fp in pcb.footprints:
+        for pad in fp.pads:
+            if layer_name in pad.layers or "*.Cu" in pad.layers:
+                _add(pad.net_number, _pad_polygon(pad, fp))
+
+    # Vias (circular copper barrel on every spanned layer)
+    for via in pcb.vias:
+        if via_spans_layer(via.layers, layer_name):
+            radius = max(getattr(via, "size", 0.0) or 0.0, 0.0) / 2.0
+            if radius > 0:
+                _add(via.net_number, Point(via.position).buffer(radius))
+
+    # Zone fills (resolved to their net; hole-aware solid region)
+    name_to_number = {net.name: net.number for net in pcb.nets.values() if net.name}
+    for zone in pcb.zones:
+        net_number = zone.net_number
+        if net_number == 0 and zone.net_name:
+            net_number = name_to_number.get(zone.net_name, 0)
+        if net_number == 0:
+            continue
+        for i, pts in enumerate(zone.filled_polygons):
+            if zone.filled_polygon_layer(i) != layer_name:
+                continue
+            _add(net_number, ConnectivityValidator._fill_solid_region(pts))
+
+    return geoms
+
+
+def _net_union_on_layer(pcb: PCB, layer_name: str) -> dict[int, Any]:
+    """Union each net's copper geometries on ``layer_name`` into one shape."""
+    from shapely.ops import unary_union  # type: ignore[import-untyped]
+
+    return {
+        net_number: unary_union(parts)
+        for net_number, parts in _net_geoms_on_layer(pcb, layer_name).items()
+        if parts
+    }
+
+
+# ---------------------------------------------------------------------------
+# Edge.Cuts slot / board-edge geometry
+# ---------------------------------------------------------------------------
+
+
+def _edge_line_segments(pcb: PCB) -> list[tuple[tuple[float, float], tuple[float, float]]]:
+    """All Edge.Cuts segments (outer boundary + interior slots/cutouts).
+
+    Combines the parsed ``gr_line``/``gr_arc``/``gr_rect`` segments
+    (:meth:`PCB.get_board_outline_segments`) with any ``gr_poly``/``gr_curve``
+    vertex chains (:meth:`PCB._edge_cuts_poly_chains_sexp`, closed into
+    segments and shifted into the board frame).
+    """
+    segments = list(pcb.get_board_outline_segments())
+
+    chains = pcb._edge_cuts_poly_chains_sexp()
+    if chains:
+        ox, oy = pcb._board_origin
+        for chain in chains:
+            if len(chain) < 2:
+                continue
+            pts = [(x - ox, y - oy) for x, y in chain]
+            # Close the ring so a polygon can be recovered from it.
+            if pts[0] != pts[-1]:
+                pts.append(pts[0])
+            for a, b in zip(pts, pts[1:], strict=False):
+                segments.append((a, b))
+    return segments
+
+
+def board_slot_obstacles(pcb: PCB) -> list[Any]:
+    """Return shapely polygons for interior Edge.Cuts slots / cutouts.
+
+    The Edge.Cuts linework is polygonized; the largest-area face is the board
+    body, and every interior ring (hole) of that face is a milled void that
+    can lengthen a surface path.  Standalone interior faces (a slot drawn as
+    its own closed loop) are also returned.  Returns ``[]`` when shapely is
+    unavailable or no interior geometry exists.
+    """
+    if not has_shapely():
+        return []
+    from shapely.geometry import LineString, Polygon
+    from shapely.ops import polygonize, unary_union
+
+    raw_segments = _edge_line_segments(pcb)
+    lines = [LineString([a, b]) for a, b in raw_segments if math.dist(a, b) > _EPS]
+    if not lines:
+        return []
+
+    faces = list(polygonize(unary_union(lines)))
+    if not faces:
+        return []
+
+    # Largest face is the board body; its interior rings are the cutouts.
+    board = max(faces, key=lambda f: f.area)
+    obstacles: list[Any] = []
+    for ring in board.interiors:
+        poly = Polygon(ring)
+        if poly.area > _EPS:
+            obstacles.append(poly)
+
+    # A slot drawn as an independent closed loop polygonizes to its own small
+    # face that is spatially inside the board body -- include those too.
+    for face in faces:
+        if face is board:
+            continue
+        if board.contains(face.representative_point()):
+            obstacles.append(face)
+
+    return obstacles
+
+
+def board_edge_geometry(pcb: PCB) -> Any | None:
+    """A shapely geometry of all Edge.Cuts linework, for edge-distance."""
+    if not has_shapely():
+        return None
+    from shapely.geometry import LineString
+    from shapely.ops import unary_union
+
+    lines = [LineString([a, b]) for a, b in _edge_line_segments(pcb) if math.dist(a, b) > _EPS]
+    if not lines:
+        return None
+    return unary_union(lines)
+
+
+# ---------------------------------------------------------------------------
+# Core surface-path (creepage) computation
+# ---------------------------------------------------------------------------
+
+
+def _crosses_any_obstacle(line: Any, obstacles: list[Any]) -> bool:
+    """True when ``line`` passes through the interior of any obstacle."""
+    for obs in obstacles:
+        interior = obs.buffer(-_INTERIOR_SHRINK)
+        if interior.is_empty:
+            continue
+        crossing = line.intersection(interior)
+        if not crossing.is_empty and getattr(crossing, "length", 0.0) > _EPS:
+            return True
+    return False
+
+
+def _shortest_detour(
+    pa: tuple[float, float], pb: tuple[float, float], obstacles: list[Any]
+) -> float:
+    """Shortest visibility-graph path from ``pa`` to ``pb`` around obstacles.
+
+    Nodes are the two endpoints plus every obstacle-polygon exterior vertex.
+    An edge between two nodes is admissible when the connecting segment does
+    not pass through the interior of any obstacle (segments that merely run
+    along a slot boundary are allowed -- that is the surface path hugging the
+    milled edge).  Returns the Euclidean length of the shortest admissible
+    path, or the straight-line distance if no path is found (defensive).
+    """
+    from shapely.geometry import LineString
+
+    nodes: list[tuple[float, float]] = [pa, pb]
+    for obs in obstacles:
+        for x, y in list(obs.exterior.coords)[:-1]:
+            nodes.append((x, y))
+
+    n = len(nodes)
+
+    def _admissible(i: int, j: int) -> bool:
+        seg = LineString([nodes[i], nodes[j]])
+        return not _crosses_any_obstacle(seg, obstacles)
+
+    # Dense O(n^2) adjacency -- n is tiny (a handful of slot corners).
+    adj: list[list[tuple[int, float]]] = [[] for _ in range(n)]
+    for i in range(n):
+        for j in range(i + 1, n):
+            if _admissible(i, j):
+                w = math.dist(nodes[i], nodes[j])
+                adj[i].append((j, w))
+                adj[j].append((i, w))
+
+    # Dijkstra from node 0 (pa) to node 1 (pb).
+    dist = [math.inf] * n
+    dist[0] = 0.0
+    pq: list[tuple[float, int]] = [(0.0, 0)]
+    while pq:
+        d, u = heapq.heappop(pq)
+        if d > dist[u]:
+            continue
+        if u == 1:
+            return d
+        for v, w in adj[u]:
+            nd = d + w
+            if nd < dist[v]:
+                dist[v] = nd
+                heapq.heappush(pq, (nd, v))
+
+    if dist[1] != math.inf:
+        return dist[1]
+    return math.dist(pa, pb)
+
+
+def surface_path_length(
+    geom_a: Any,
+    geom_b: Any,
+    obstacles: list[Any] | None = None,
+) -> tuple[float, float]:
+    """Return ``(clearance, creepage)`` between two shapely geometries.
+
+    ``clearance`` is the straight-line ``geom_a.distance(geom_b)``.
+    ``creepage`` equals ``clearance`` when the straight nearest-points segment
+    does not cross an interior Edge.Cuts cutout; otherwise it is the shortest
+    path routing around the intervening slot polygon(s) (``> clearance``).
+
+    Overlapping / touching geometries (``clearance <= 0``) have no meaningful
+    surface detour, so ``creepage == clearance`` there too.
+    """
+    require_shapely("creepage surface-path geometry")
+    from shapely.geometry import LineString
+    from shapely.ops import nearest_points
+
+    obstacles = obstacles or []
+    clearance = geom_a.distance(geom_b)
+    if clearance <= 0.0 or not obstacles:
+        return clearance, clearance
+
+    pa_pt, pb_pt = nearest_points(geom_a, geom_b)
+    pa = (pa_pt.x, pa_pt.y)
+    pb = (pb_pt.x, pb_pt.y)
+    straight = LineString([pa, pb])
+    if not _crosses_any_obstacle(straight, obstacles):
+        return clearance, clearance
+
+    creepage = _shortest_detour(pa, pb, obstacles)
+    # The detour can never be shorter than the straight clearance.
+    return clearance, max(creepage, clearance)
+
+
+# ---------------------------------------------------------------------------
+# Census assembly
+# ---------------------------------------------------------------------------
+
+
+def compute_creepage_census(
+    pcb: PCB,
+    hv_nets: dict[int, str],
+    min_mm: float,
+    net_class: str = "HV",
+    board: str = "",
+) -> CreepageReport:
+    """Build the full HV creepage/clearance census for a board.
+
+    For every HV net the census records one row per non-HV conductor (the
+    binding, smallest-creepage layer) and one row for the board edge.
+    """
+    require_shapely("creepage census")
+
+    report = CreepageReport(
+        net_class=net_class,
+        min_mm=min_mm,
+        hv_nets=[hv_nets[num] for num in sorted(hv_nets)],
+        board=board,
+    )
+    if not hv_nets:
+        return report
+
+    number_to_name = {net.number: net.name for net in pcb.nets.values()}
+    obstacles = board_slot_obstacles(pcb)
+
+    # Per-layer per-net copper unions.
+    layer_unions: dict[str, dict[int, Any]] = {}
+    for layer in pcb.copper_layers:
+        layer_unions[layer.name] = _net_union_on_layer(pcb, layer.name)
+
+    # --- HV-vs-other-conductor pairs (binding layer = smallest creepage) ---
+    # (hv_number, other_number) -> (clearance, creepage, layer)
+    best: dict[tuple[int, int], tuple[float, float, str]] = {}
+    for layer_name, unions in layer_unions.items():
+        for hv_num in hv_nets:
+            hv_geom = unions.get(hv_num)
+            if hv_geom is None:
+                continue
+            for other_num, other_geom in unions.items():
+                if other_num == 0 or other_num in hv_nets:
+                    continue
+                clearance, creepage = surface_path_length(hv_geom, other_geom, obstacles)
+                key = (hv_num, other_num)
+                prev = best.get(key)
+                if prev is None or creepage < prev[1]:
+                    best[key] = (clearance, creepage, layer_name)
+
+    for (hv_num, other_num), (clearance, creepage, layer_name) in best.items():
+        report.pairs.append(
+            CreepagePair(
+                net_a=hv_nets[hv_num],
+                net_b=number_to_name.get(other_num, f"net{other_num}"),
+                kind="conductor",
+                layer=layer_name,
+                clearance_mm=clearance,
+                creepage_mm=creepage,
+                min_mm=min_mm,
+            )
+        )
+
+    # --- HV-vs-board-edge pairs (copper union across all layers) ---
+    edge_geom = board_edge_geometry(pcb)
+    if edge_geom is not None and not edge_geom.is_empty:
+        from shapely.ops import unary_union
+
+        for hv_num in hv_nets:
+            parts = [unions[hv_num] for unions in layer_unions.values() if hv_num in unions]
+            if not parts:
+                continue
+            hv_all = unary_union(parts)
+            clearance, creepage = surface_path_length(hv_all, edge_geom, obstacles)
+            report.pairs.append(
+                CreepagePair(
+                    net_a=hv_nets[hv_num],
+                    net_b=BOARD_EDGE_LABEL,
+                    kind="edge",
+                    layer="*",
+                    clearance_mm=clearance,
+                    creepage_mm=creepage,
+                    min_mm=min_mm,
+                )
+            )
+
+    # Deterministic ordering: by net A, then edge last, then net B.
+    report.pairs.sort(key=lambda p: (p.net_a, p.kind == "edge", p.net_b))
+    return report

--- a/tests/creepage/fixtures.py
+++ b/tests/creepage/fixtures.py
@@ -1,0 +1,84 @@
+"""Synthetic PCB fixtures for the creepage engine/CLI tests (Issue #4327).
+
+Each fixture is a minimal-but-real KiCad S-expression board so the tests
+double as end-to-end ``PCB.load`` smoke tests.  The boards deliberately use
+large millimetre gaps so the straight clearance and the slot-detour creepage
+are numerically obvious and deterministic.
+"""
+
+from __future__ import annotations
+
+_HEADER = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test_creepage")
+  (general (thickness 1.6))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (36 "B.SilkS" user)
+    (37 "F.SilkS" user)
+    (38 "B.Mask" user)
+    (39 "F.Mask" user)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "L_MAINS")
+  (net 2 "GND")
+"""
+
+# Outer board outline: rectangle (100,100) -> (140,120).
+_OUTLINE = """\
+  (gr_line (start 100 100) (end 140 100) (layer "Edge.Cuts") (width 0.1))
+  (gr_line (start 140 100) (end 140 120) (layer "Edge.Cuts") (width 0.1))
+  (gr_line (start 140 120) (end 100 120) (layer "Edge.Cuts") (width 0.1))
+  (gr_line (start 100 120) (end 100 100) (layer "Edge.Cuts") (width 0.1))
+"""
+
+# Interior milled slot: a tall thin rectangle at x in [119.8, 120.2],
+# y in [103, 117], lying directly between the two pads (which sit at y=110).
+_SLOT = """\
+  (gr_line (start 119.8 103) (end 120.2 103) (layer "Edge.Cuts") (width 0.1))
+  (gr_line (start 120.2 103) (end 120.2 117) (layer "Edge.Cuts") (width 0.1))
+  (gr_line (start 120.2 117) (end 119.8 117) (layer "Edge.Cuts") (width 0.1))
+  (gr_line (start 119.8 117) (end 119.8 103) (layer "Edge.Cuts") (width 0.1))
+"""
+
+
+def _footprint(ref: str, x: float, y: float, net_number: int, net_name: str) -> str:
+    """A single-pad SMD footprint: 2x2 mm rect pad centered at (x, y)."""
+    return f"""\
+  (footprint "test:pad" (layer "F.Cu") (at {x} {y})
+    (pad "1" smd rect (at 0 0) (size 2 2) (layers "F.Cu")
+      (net {net_number} "{net_name}"))
+  )
+"""
+
+
+def board_source(with_slot: bool) -> str:
+    """Two 2x2 pads (L_MAINS at x=110, GND at x=130) inside a 40x20 board.
+
+    Pad copper edges sit at x=111 (L_MAINS) and x=129 (GND), so the
+    straight-line clearance is 18 mm.  When ``with_slot`` is True a milled
+    slot lies on the straight path between them, so the creepage surface path
+    must detour around it (creepage > clearance); otherwise creepage == 18.
+    """
+    parts = [_HEADER, _OUTLINE]
+    if with_slot:
+        parts.append(_SLOT)
+    parts.append(_footprint("U1", 110, 110, 1, "L_MAINS"))
+    parts.append(_footprint("U2", 130, 110, 2, "GND"))
+    parts.append(")\n")
+    return "".join(parts)
+
+
+def board_no_hv_source() -> str:
+    """Board whose only assigned nets are GND / SIG -- no HV net exists."""
+    header = _HEADER.replace('(net 1 "L_MAINS")', '(net 1 "SIG")')
+    parts = [header, _OUTLINE]
+    parts.append(_footprint("U1", 110, 110, 1, "SIG"))
+    parts.append(_footprint("U2", 130, 110, 2, "GND"))
+    parts.append(")\n")
+    return "".join(parts)

--- a/tests/creepage/test_creepage_cli.py
+++ b/tests/creepage/test_creepage_cli.py
@@ -1,0 +1,140 @@
+"""CLI tests for ``kct creepage`` (Issue #4327, phase 1 MVP).
+
+Covers exit codes (0 when all pairs clear ``--min``, non-zero when one is
+below), the ``--format json`` census schema (all pairs present, per-pair pass
+flag, distinct numeric clearance/creepage/margin), and the "no HV nets found"
+path (clean exit 0, no crash).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from kicad_tools._shapely import has_shapely
+from kicad_tools.cli.commands.creepage import run_creepage_command
+from kicad_tools.cli.parser import create_parser
+
+from .fixtures import board_no_hv_source, board_source
+
+pytestmark = pytest.mark.skipif(not has_shapely(), reason="creepage requires shapely")
+
+
+def _write(tmp_path, source, name="board.kicad_pcb"):
+    p = tmp_path / name
+    p.write_text(source)
+    return p
+
+
+def _hv_map_file(tmp_path):
+    p = tmp_path / "net_class_map.json"
+    p.write_text(json.dumps({"L_MAINS": {"name": "HV"}}))
+    return p
+
+
+def _run(argv):
+    args = create_parser().parse_args(argv)
+    return run_creepage_command(args)
+
+
+def test_exit_zero_when_all_pairs_clear(tmp_path, capsys):
+    pcb = _write(tmp_path, board_source(with_slot=False))
+    ncm = _hv_map_file(tmp_path)
+    rc = _run(["creepage", str(pcb), "--net-class-map", str(ncm), "--min", "1.5"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "PASS" in out
+    assert "L_MAINS" in out
+    # Distinction is explicit in the human output.
+    assert "Clearance" in out and "Creepage" in out
+
+
+def test_exit_nonzero_when_a_pair_below_min(tmp_path, capsys):
+    pcb = _write(tmp_path, board_source(with_slot=False))
+    ncm = _hv_map_file(tmp_path)
+    # Require 100 mm creepage -- the 18 mm pad gap cannot satisfy it.
+    rc = _run(["creepage", str(pcb), "--net-class-map", str(ncm), "--min", "100"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "FAIL" in out
+
+
+def test_json_census_schema(tmp_path, capsys):
+    pcb = _write(tmp_path, board_source(with_slot=True))
+    ncm = _hv_map_file(tmp_path)
+    rc = _run(
+        ["creepage", str(pcb), "--net-class-map", str(ncm), "--min", "1.5", "--format", "json"]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+
+    assert payload["net_class"] == "HV"
+    assert payload["min_mm"] == 1.5
+    assert payload["hv_nets"] == ["L_MAINS"]
+    assert payload["pair_count"] == len(payload["pairs"])
+    assert payload["pair_count"] >= 2  # HV-vs-GND and HV-vs-edge
+    assert payload["passed"] is True
+
+    kinds = {p["kind"] for p in payload["pairs"]}
+    assert {"conductor", "edge"} <= kinds
+
+    for pair in payload["pairs"]:
+        # Full census: every pair carries numeric fields + a pass flag.
+        assert isinstance(pair["clearance_mm"], (int, float))
+        assert isinstance(pair["creepage_mm"], (int, float))
+        assert isinstance(pair["margin_mm"], (int, float))
+        assert isinstance(pair["pass"], bool)
+        assert pair["creepage_mm"] >= pair["clearance_mm"] - 1e-6
+
+    gnd = next(p for p in payload["pairs"] if p["kind"] == "conductor" and p["net_b"] == "GND")
+    # The slot makes clearance and creepage genuinely different values.
+    assert gnd["creepage_mm"] > gnd["clearance_mm"] + 2.0
+
+
+def test_json_census_no_slot_equals(tmp_path, capsys):
+    pcb = _write(tmp_path, board_source(with_slot=False))
+    ncm = _hv_map_file(tmp_path)
+    _run(["creepage", str(pcb), "--net-class-map", str(ncm), "--min", "1.5", "--format", "json"])
+    payload = json.loads(capsys.readouterr().out)
+    gnd = next(p for p in payload["pairs"] if p["kind"] == "conductor" and p["net_b"] == "GND")
+    assert gnd["creepage_mm"] == pytest.approx(gnd["clearance_mm"], abs=1e-4)
+
+
+def test_no_hv_nets_message_and_exit_zero(tmp_path, capsys):
+    pcb = _write(tmp_path, board_no_hv_source())
+    ncm = _hv_map_file(tmp_path)
+    rc = _run(["creepage", str(pcb), "--net-class-map", str(ncm), "--min", "1.5"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "No 'HV' nets found" in out
+
+
+def test_no_hv_nets_json_empty_census(tmp_path, capsys):
+    pcb = _write(tmp_path, board_no_hv_source())
+    ncm = _hv_map_file(tmp_path)
+    rc = _run(
+        ["creepage", str(pcb), "--net-class-map", str(ncm), "--min", "1.5", "--format", "json"]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["pairs"] == []
+    assert payload["pair_count"] == 0
+    assert payload["passed"] is True
+
+
+def test_missing_pcb_file_errors(tmp_path, capsys):
+    rc = _run(["creepage", str(tmp_path / "nope.kicad_pcb"), "--min", "1.5"])
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "not found" in err
+
+
+def test_missing_net_class_map_errors(tmp_path, capsys):
+    pcb = _write(tmp_path, board_source(with_slot=False))
+    rc = _run(
+        ["creepage", str(pcb), "--net-class-map", str(tmp_path / "absent.json"), "--min", "1.5"]
+    )
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "net-class-map file not found" in err

--- a/tests/creepage/test_creepage_engine.py
+++ b/tests/creepage/test_creepage_engine.py
@@ -1,0 +1,193 @@
+"""Engine unit tests for the HV creepage/clearance audit (Issue #4327).
+
+Covers:
+
+* the pure surface-path geometry (``surface_path_length``): creepage ==
+  clearance with no intervening slot; creepage > clearance (by the detour
+  length) when a slot lies on the straight path; a mounting-hole cutout that
+  is NOT between the pair does not lengthen the path; multiple slots in
+  series.
+* the board-level census (``compute_creepage_census``): a slot between the HV
+  net and a neighbor yields creepage > clearance; the same board without the
+  slot yields creepage == clearance; a board with no HV nets yields an empty
+  census.
+* HV net selection via a net-class map with a name-pattern fallback.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from kicad_tools._shapely import has_shapely
+from kicad_tools.creepage.engine import (
+    BOARD_EDGE_LABEL,
+    compute_creepage_census,
+    resolve_hv_nets,
+    surface_path_length,
+)
+
+from .fixtures import board_no_hv_source, board_source
+
+pytestmark = pytest.mark.skipif(not has_shapely(), reason="creepage requires shapely")
+
+
+# ---------------------------------------------------------------------------
+# Pure geometry: surface_path_length
+# ---------------------------------------------------------------------------
+
+
+def _box(x0, y0, x1, y1):
+    from shapely.geometry import box
+
+    return box(x0, y0, x1, y1)
+
+
+def test_no_obstacle_creepage_equals_clearance():
+    a = _box(0.0, -0.5, 1.0, 0.5)
+    b = _box(9.0, -0.5, 10.0, 0.5)
+    clearance, creepage = surface_path_length(a, b, obstacles=[])
+    assert clearance == pytest.approx(8.0, abs=1e-6)
+    assert creepage == pytest.approx(clearance, abs=1e-9)
+
+
+def test_slot_on_path_lengthens_creepage():
+    # Thin copper centered on y=0 so nearest points are (0,0) and (10,0).
+    a = _box(-1.0, -1e-3, 0.0, 1e-3)
+    b = _box(10.0, -1e-3, 11.0, 1e-3)
+    slot = _box(4.9, -3.0, 5.1, 3.0)  # tall bar straddling the straight path
+
+    clearance, creepage = surface_path_length(a, b, obstacles=[slot])
+    assert clearance == pytest.approx(10.0, abs=1e-3)
+    # Detour: (0,0)->(4.9,3)->(5.1,3)->(10,0) (or the symmetric bottom route).
+    expected = 2 * math.hypot(4.9, 3.0) + 0.2
+    assert creepage > clearance
+    assert creepage == pytest.approx(expected, abs=0.05)
+
+
+def test_offset_cutout_not_between_pair_does_not_lengthen():
+    # A mounting-hole cutout well above the straight path must not detour it.
+    a = _box(0.0, -0.5, 1.0, 0.5)
+    b = _box(9.0, -0.5, 10.0, 0.5)
+    hole = _box(4.5, 5.0, 5.5, 6.0)  # entirely off the y~0 straight line
+
+    clearance, creepage = surface_path_length(a, b, obstacles=[hole])
+    assert creepage == pytest.approx(clearance, abs=1e-9)
+
+
+def test_multiple_slots_in_series_sum_detours():
+    a = _box(-1.0, -1e-3, 0.0, 1e-3)
+    b = _box(20.0, -1e-3, 21.0, 1e-3)
+    slot1 = _box(4.9, -3.0, 5.1, 3.0)
+    slot2 = _box(14.9, -3.0, 15.1, 3.0)
+
+    clearance, creepage = surface_path_length(a, b, obstacles=[slot1, slot2])
+    assert clearance == pytest.approx(20.0, abs=1e-3)
+    # Two slots each force a detour up to y=3 and back -- creepage exceeds the
+    # single-slot detour and, of course, the straight clearance.
+    assert creepage > clearance + 1.0
+
+
+def test_overlapping_geometries_have_zero_creepage():
+    a = _box(0.0, 0.0, 5.0, 5.0)
+    b = _box(4.0, 0.0, 9.0, 5.0)  # overlaps a
+    clearance, creepage = surface_path_length(a, b, obstacles=[_box(2.0, 2.0, 3.0, 3.0)])
+    assert clearance <= 0.0
+    assert creepage == clearance
+
+
+# ---------------------------------------------------------------------------
+# Board-level census
+# ---------------------------------------------------------------------------
+
+
+def _load(tmp_path, source, name="board.kicad_pcb"):
+    from kicad_tools.schema.pcb import PCB
+
+    p = tmp_path / name
+    p.write_text(source)
+    return PCB.load(p)
+
+
+def _hv_map():
+    from kicad_tools.router.rules import net_class_map_from_dict
+
+    return net_class_map_from_dict({"L_MAINS": {"name": "HV"}})
+
+
+def _conductor_pair(report, net_b):
+    for pair in report.pairs:
+        if pair.kind == "conductor" and pair.net_b == net_b:
+            return pair
+    raise AssertionError(f"no conductor pair against {net_b!r} in census")
+
+
+def test_census_no_slot_creepage_equals_clearance(tmp_path):
+    pcb = _load(tmp_path, board_source(with_slot=False))
+    hv = resolve_hv_nets(pcb, "HV", _hv_map())
+    assert set(hv.values()) == {"L_MAINS"}
+
+    report = compute_creepage_census(pcb, hv, min_mm=1.5)
+    pair = _conductor_pair(report, "GND")
+    assert pair.clearance_mm == pytest.approx(18.0, abs=1e-3)
+    assert pair.creepage_mm == pytest.approx(pair.clearance_mm, abs=1e-6)
+
+
+def test_census_slot_lengthens_creepage(tmp_path):
+    pcb = _load(tmp_path, board_source(with_slot=True))
+    hv = resolve_hv_nets(pcb, "HV", _hv_map())
+    report = compute_creepage_census(pcb, hv, min_mm=1.5)
+
+    pair = _conductor_pair(report, "GND")
+    assert pair.clearance_mm == pytest.approx(18.0, abs=1e-3)
+    # The milled slot forces the surface path to detour around it.
+    assert pair.creepage_mm > pair.clearance_mm + 2.0
+    # Clearance and creepage are genuinely distinct values.
+    assert pair.creepage_mm != pytest.approx(pair.clearance_mm)
+
+
+def test_census_reports_board_edge_pair(tmp_path):
+    pcb = _load(tmp_path, board_source(with_slot=False))
+    hv = resolve_hv_nets(pcb, "HV", _hv_map())
+    report = compute_creepage_census(pcb, hv, min_mm=1.5)
+
+    edge_pairs = [p for p in report.pairs if p.kind == "edge"]
+    assert len(edge_pairs) == 1
+    assert edge_pairs[0].net_b == BOARD_EDGE_LABEL
+    assert edge_pairs[0].net_a == "L_MAINS"
+    # L_MAINS pad edge at x=111 vs board edge at x=100 -> 11 mm to the wall.
+    assert edge_pairs[0].clearance_mm == pytest.approx(9.0, abs=1.5)
+
+
+def test_pass_flag_and_margin(tmp_path):
+    pcb = _load(tmp_path, board_source(with_slot=False))
+    hv = resolve_hv_nets(pcb, "HV", _hv_map())
+
+    report = compute_creepage_census(pcb, hv, min_mm=1.5)
+    assert report.passed  # all gaps are >> 1.5 mm
+    pair = _conductor_pair(report, "GND")
+    assert pair.margin_mm == pytest.approx(pair.creepage_mm - 1.5, abs=1e-6)
+
+    strict = compute_creepage_census(pcb, hv, min_mm=100.0)
+    assert not strict.passed  # 18 mm < 100 mm required
+    assert not _conductor_pair(strict, "GND").passed
+
+
+def test_no_hv_nets_yields_empty_census(tmp_path):
+    pcb = _load(tmp_path, board_no_hv_source())
+    hv = resolve_hv_nets(pcb, "HV", _hv_map())
+    assert hv == {}
+
+    report = compute_creepage_census(pcb, hv, min_mm=1.5)
+    assert report.pairs == []
+    assert report.hv_nets == []
+    assert report.passed  # vacuously true -> exit 0
+
+
+def test_name_pattern_fallback_without_map(tmp_path):
+    # No map: 'GND' matches the built-in GROUND name pattern, so --net-class
+    # ground selects it via classify_from_name (no new classifier).
+    pcb = _load(tmp_path, board_source(with_slot=False))
+    hv = resolve_hv_nets(pcb, "ground", net_class_map=None)
+    assert set(hv.values()) == {"GND"}


### PR DESCRIPTION
## Summary

Phase 1 of a phased feature (#4327). Adds a new `kct creepage` command that
measures **surface-path (creepage)** distance -- the shortest path *along the
board surface* between conductors, which a milled Edge.Cuts slot lengthens --
distinct from the straight-line, through-air **clearance** that `kct check`
already measures. IEC governs creepage for HV, so the two limits are reported
separately.

```
kct creepage <board> --net-class HV --min <mm> [--net-class-map map.json] [--format json]
```

For each (HV-net, other-conductor) and (HV-net, board-edge) pair it reports a
**census** (all pairs + margin, not just violations) with clearance, creepage,
and margin columns. Exit is non-zero iff any pair's creepage falls below
`--min`.

This is phase 1 only. Follow-ups (do NOT build here): IEC 60664-1 / 62368-1
standard-table lookup + required-value derivation (#4332); `kct audit`
HV/isolation section + manufacturing-readiness gate wiring (#4333).

## Changes

- **NEW** `src/kicad_tools/creepage/{__init__,engine}.py` -- copper-union
  construction (reusing `segment_copper_polygon`, `_pad_polygon`,
  `_fill_solid_region`, and a disc for vias), interior Edge.Cuts slot
  extraction (polygonize the outline; interior rings are cutouts), a pure
  `surface_path_length(a, b, obstacles)` that returns `(clearance, creepage)`
  via a visibility-graph detour around any intervening slot, and census
  assembly. HV nets resolved via `net_class_map_from_dict` with a
  `classify_from_name` name-pattern fallback -- no new classifier.
- **NEW** `src/kicad_tools/cli/commands/creepage.py` -- `run_creepage_command`
  handler with human table + `--format json` rendering.
- `src/kicad_tools/cli/parser.py` -- `_add_creepage_parser` (mirrors
  `_add_check_parser`): `--net-class`, `--net-class-map`, `--min`, `--format`.
- `src/kicad_tools/cli/__init__.py` + `cli/commands/__init__.py` -- dispatch
  and export wiring.
- **NEW** `tests/creepage/` -- engine geometry unit tests (incl. the
  slot-detour case) and CLI/JSON/exit-code tests, with deterministic synthetic
  board fixtures.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Per-pair census (HV-vs-other and HV-vs-edge) with clearance/creepage/margin columns | ✅ | `_render_table`; `test_census_reports_board_edge_pair`, manual run |
| A slot between HV net and neighbor -> creepage > clearance; no slot -> creepage == clearance | ✅ | `test_census_slot_lengthens_creepage` (21.702 > 18.000), `test_census_no_slot_creepage_equals_clearance` |
| Clearance and creepage reported as separate values (human + JSON) | ✅ | distinct table columns + JSON `clearance_mm`/`creepage_mm`; `test_json_census_schema` |
| Non-zero exit iff any pair's creepage < --min; zero when all clear | ✅ | `test_exit_zero_when_all_pairs_clear`, `test_exit_nonzero_when_a_pair_below_min` |
| `--format json` emits full census (all pairs) + numeric fields + per-pair pass flag | ✅ | `test_json_census_schema` |
| HV nets via `--net-class-map` (reuse `net_class_map_from_dict`) with name-pattern fallback; no new classifier | ✅ | `resolve_hv_nets`; `test_name_pattern_fallback_without_map` |
| No HV nets -> empty census + clear message, exit 0, no crash | ✅ | `test_no_hv_nets_message_and_exit_zero`, `test_no_hv_nets_json_empty_census` |

## Test Plan

- `uv run pytest tests/creepage/` -> **19 passed**.
- `uv run ruff check` + `ruff format --check` on all touched files -> clean.
- `uv run mypy` on the new modules -> clean; the baseline gate reports **zero**
  new errors attributable to any touched file (remaining baseline-gate diffs
  are pre-existing, mypy-version-sensitive noise in untouched files).
- Manual: slot board shows `L_MAINS -> GND` creepage **21.702 mm** > clearance
  **18.000 mm** (PASS at `--min 1.5`); same board without the slot shows
  creepage == clearance == 18.000 mm; exit codes verified 0 / 1.

Closes #4327