### PR TITLE
feat(analyze): current-sense / analog layout lint (Phase 1 of #4328)

### DIFF
--- a/src/kicad_tools/analysis/__init__.py
+++ b/src/kicad_tools/analysis/__init__.py
@@ -23,6 +23,10 @@ from .complexity import (
     RoutingComplexity,
 )
 from .congestion import CongestionAnalyzer, CongestionReport, Severity
+from .current_sense import (
+    CurrentSenseAnalyzer,
+    CurrentSenseResult,
+)
 from .net_status import (
     NetStatus,
     NetStatusAnalyzer,
@@ -59,6 +63,8 @@ __all__ = [
     "CongestionAnalyzer",
     "CongestionReport",
     "CrosstalkRisk",
+    "CurrentSenseAnalyzer",
+    "CurrentSenseResult",
     "DifferentialPairReport",
     "ImpedanceDiscontinuity",
     "LayerPrediction",

--- a/src/kicad_tools/analysis/current_sense.py
+++ b/src/kicad_tools/analysis/current_sense.py
@@ -1,0 +1,277 @@
+"""Current-sense / analog layout lint (Phase 1).
+
+Advisory-only analyzer that flags **sense** nets that run parallel and close
+to **high-current / switching** nets on the *same* copper layer. Long parallel
+runs at small gaps inductively/capacitively couple switching noise into a
+high-impedance sense line, corrupting the measured current/voltage. This is the
+metric that would have caught the softstart rev-C finding where ``/OC_TRIP_N``
+ran adjacent to ``/GATE_NEG_A``.
+
+Phase 1 scope (see issue #4328):
+
+* For every sense net, scan all segments of every high-current net on the same
+  layer and report, per sense net, the **maximum parallel-run length** and the
+  **minimum edge-to-edge gap** to the *nearest* high-current net (the blocker
+  with the smallest gap), flagged PASS/FAIL against thresholds.
+* Sense / high-current nets are identified by
+  :func:`kicad_tools.router.net_class.classify_from_name`
+  (``ANALOG`` -> sense; ``HIGH_CURRENT_SIGNAL`` / ``POWER`` -> high-current),
+  **plus** explicit ``sense_nets`` / ``hicur_nets`` name overrides so nets whose
+  prefixes are not yet auto-classified (``GATE_*`` / ``SRC_*`` / ``TRK_*``) can
+  be tagged today. Auto-classification of those prefixes is deferred to Phase 3.
+* Only same-layer pairs are considered. Inner-layer / broadside coupling is
+  Phase 3 (#4331); copper sense-loop area is Phase 2 (#4330).
+
+The pairwise parallel-run + gap geometry is computed by the shared
+:func:`kicad_tools.analysis.signal_integrity.calculate_coupling_geometry`
+primitive (not duplicated here).
+
+**FAIL rule** (physically motivated, documented for the census): a sense net is
+``FAIL`` when, against its nearest high-current blocker, it *both* runs parallel
+for at least ``max_parallel_mm`` **and** is separated by at most ``min_gap_mm``.
+A long run that stays far away, or a close approach that is only momentary
+(short parallel run), is ``PASS``. Both conditions must hold to fail because
+coupling scales with parallel length *and* inverse gap -- either one alone is
+not sufficient to corrupt a sense line.
+
+This module is advisory only: it never raises on malformed geometry and skips
+un-inspectable data.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from kicad_tools.analysis.signal_integrity import calculate_coupling_geometry
+from kicad_tools.router.net_class import NetClass, classify_from_name
+
+if TYPE_CHECKING:
+    from kicad_tools.schema.pcb import PCB, Segment
+
+__all__ = [
+    "CurrentSenseAnalyzer",
+    "CurrentSenseResult",
+    "DEFAULT_MAX_PARALLEL_MM",
+    "DEFAULT_MIN_GAP_MM",
+]
+
+# Default thresholds (mm). A sense net running parallel to a high-current net
+# for >= DEFAULT_MAX_PARALLEL_MM at an edge gap <= DEFAULT_MIN_GAP_MM is FAIL.
+DEFAULT_MAX_PARALLEL_MM = 10.0
+DEFAULT_MIN_GAP_MM = 0.5
+
+
+@dataclass
+class CurrentSenseResult:
+    """Per-sense-net current-sense coupling census row.
+
+    Attributes:
+        sense_net: Name of the sense net.
+        nearest_hicur_net: Name of the nearest high-current net (smallest gap
+            among same-layer parallel neighbors), or ``None`` if the sense net
+            has no same-layer high-current neighbor.
+        layer: Copper layer on which the nearest coupling occurs, or ``None``.
+        max_parallel_mm: Maximum parallel-run length (mm) against the nearest
+            blocker. ``0.0`` when there is no neighbor.
+        min_gap_mm: Minimum edge-to-edge gap (mm) to the nearest blocker, or
+            ``None`` when there is no neighbor.
+        status: ``"FAIL"`` or ``"PASS"``.
+        margin_mm: Gap-clearance margin (``min_gap_mm - min_gap_threshold``);
+            positive means the gap is above the minimum. ``None`` when there is
+            no neighbor. Note a FAIL always has ``margin_mm <= 0`` *and* also
+            exceeded the parallel-run threshold.
+    """
+
+    sense_net: str
+    nearest_hicur_net: str | None
+    layer: str | None
+    max_parallel_mm: float
+    min_gap_mm: float | None
+    status: str
+    margin_mm: float | None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to a JSON-serializable dict (mirrors sibling analyzers)."""
+        return {
+            "sense_net": self.sense_net,
+            "nearest_hicur_net": self.nearest_hicur_net,
+            "layer": self.layer,
+            "max_parallel_mm": round(self.max_parallel_mm, 3),
+            "min_gap_mm": (None if self.min_gap_mm is None else round(self.min_gap_mm, 3)),
+            "status": self.status,
+            "margin": (None if self.margin_mm is None else round(self.margin_mm, 3)),
+        }
+
+
+class CurrentSenseAnalyzer:
+    """Analyze sense-net vs. high-current-net same-layer parallel coupling.
+
+    Advisory only; never raises. Construct with thresholds and optional net
+    name overrides, then call :meth:`analyze` with a loaded :class:`PCB`.
+    """
+
+    def __init__(
+        self,
+        max_parallel_mm: float = DEFAULT_MAX_PARALLEL_MM,
+        min_gap_mm: float = DEFAULT_MIN_GAP_MM,
+        sense_nets: list[str] | None = None,
+        hicur_nets: list[str] | None = None,
+    ) -> None:
+        """Initialize the analyzer.
+
+        Args:
+            max_parallel_mm: Parallel-run threshold (mm) for FAIL.
+            min_gap_mm: Edge-to-edge gap threshold (mm) for FAIL.
+            sense_nets: Explicit sense-net names (override / augment
+                auto-classification).
+            hicur_nets: Explicit high-current-net names (override / augment
+                auto-classification).
+        """
+        self.max_parallel_mm = max_parallel_mm
+        self.min_gap_mm = min_gap_mm
+        self.sense_overrides = {n for n in (sense_nets or []) if n}
+        self.hicur_overrides = {n for n in (hicur_nets or []) if n}
+
+    # ------------------------------------------------------------------
+    # Net classification
+    # ------------------------------------------------------------------
+    def classify_nets(self, pcb: PCB) -> tuple[set[str], set[str]]:
+        """Return ``(sense_net_names, hicur_net_names)`` for a board.
+
+        Auto-classifies by name via ``classify_from_name`` and folds in the
+        explicit overrides. A net named in *both* the sense and high-current
+        sets is treated as sense-only (it is the victim of interest); it is
+        removed from the high-current set to avoid self-comparison noise.
+        """
+        sense: set[str] = set(self.sense_overrides)
+        hicur: set[str] = set(self.hicur_overrides)
+
+        for net in pcb.nets.values():
+            name = net.name
+            if not name:
+                continue
+            net_class = classify_from_name(name)
+            if net_class == NetClass.ANALOG:
+                sense.add(name)
+            elif net_class in (NetClass.HIGH_CURRENT_SIGNAL, NetClass.POWER):
+                hicur.add(name)
+
+        # A net cannot be both victim and aggressor.
+        hicur -= sense
+        return sense, hicur
+
+    # ------------------------------------------------------------------
+    # Analysis
+    # ------------------------------------------------------------------
+    def analyze(self, pcb: PCB) -> list[CurrentSenseResult]:
+        """Produce one :class:`CurrentSenseResult` per sense net.
+
+        Returns an empty list when the board has no sense nets. Never raises.
+        """
+        try:
+            sense_names, hicur_names = self.classify_nets(pcb)
+        except Exception:
+            return []
+
+        if not sense_names:
+            return []
+
+        # Resolve each segment's net name robustly: prefer the segment's own
+        # net_name, else fall back to the board net table by number (handles
+        # number-only ``(net N)`` and KiCad 10 name-only references).
+        num_to_name = {num: net.name for num, net in pcb.nets.items()}
+        try:
+            all_segments = list(pcb.segments)
+        except Exception:
+            all_segments = []
+
+        named: list[tuple[str, Segment]] = []
+        for seg in all_segments:
+            name = seg.net_name or num_to_name.get(seg.net_number, "")
+            if name:
+                named.append((name, seg))
+
+        hicur_named: list[tuple[str, Segment]] = [
+            (name, seg) for name, seg in named if name in hicur_names
+        ]
+
+        results: list[CurrentSenseResult] = []
+        for sense_name in sorted(sense_names):
+            sense_segs = [seg for name, seg in named if name == sense_name]
+            results.append(self._analyze_sense_net(sense_name, sense_segs, hicur_named))
+        return results
+
+    def _analyze_sense_net(
+        self,
+        sense_name: str,
+        sense_segs: list[Segment],
+        hicur_named: list[tuple[str, Segment]],
+    ) -> CurrentSenseResult:
+        """Compute the census row for a single sense net."""
+        # Per high-current net aggregates over coupled (parallel) pairs:
+        #   min gap, the max parallel-run, and the layer of the min-gap pair.
+        per_net_min_gap: dict[str, float] = {}
+        per_net_max_parallel: dict[str, float] = {}
+        per_net_layer: dict[str, str] = {}
+
+        for s_seg in sense_segs:
+            for h_name, h_seg in hicur_named:
+                # Same-layer only (Phase 1).
+                if s_seg.layer != h_seg.layer:
+                    continue
+                # Never compare a net to itself (defensive; hicur excludes
+                # sense names already).
+                if h_name == sense_name:
+                    continue
+
+                try:
+                    parallel, gap = calculate_coupling_geometry(s_seg, h_seg)
+                except Exception:
+                    continue
+
+                # Not actually coupled (non-parallel / degenerate).
+                if parallel <= 0.0:
+                    continue
+
+                prev_max = per_net_max_parallel.get(h_name, 0.0)
+                if parallel > prev_max:
+                    per_net_max_parallel[h_name] = parallel
+
+                prev_gap = per_net_min_gap.get(h_name)
+                if prev_gap is None or gap < prev_gap:
+                    per_net_min_gap[h_name] = gap
+                    per_net_layer[h_name] = h_seg.layer
+
+        if not per_net_min_gap:
+            # No same-layer high-current neighbor: clean PASS.
+            return CurrentSenseResult(
+                sense_net=sense_name,
+                nearest_hicur_net=None,
+                layer=None,
+                max_parallel_mm=0.0,
+                min_gap_mm=None,
+                status="PASS",
+                margin_mm=None,
+            )
+
+        # Nearest blocker = smallest gap.
+        nearest = min(per_net_min_gap, key=lambda n: per_net_min_gap[n])
+        min_gap = per_net_min_gap[nearest]
+        max_parallel = per_net_max_parallel.get(nearest, 0.0)
+        layer = per_net_layer.get(nearest)
+
+        # FAIL rule: long parallel run AND small gap (both must hold).
+        is_fail = max_parallel >= self.max_parallel_mm and min_gap <= self.min_gap_mm
+        status = "FAIL" if is_fail else "PASS"
+        margin = min_gap - self.min_gap_mm
+
+        return CurrentSenseResult(
+            sense_net=sense_name,
+            nearest_hicur_net=nearest,
+            layer=layer,
+            max_parallel_mm=max_parallel,
+            min_gap_mm=min_gap,
+            status=status,
+            margin_mm=margin,
+        )

--- a/src/kicad_tools/analysis/signal_integrity.py
+++ b/src/kicad_tools/analysis/signal_integrity.py
@@ -65,6 +65,74 @@ HIGH_SPEED_NET_PATTERNS = [
 ]
 
 
+def calculate_coupling_geometry(seg1: Segment, seg2: Segment) -> tuple[float, float]:
+    """Calculate parallel-run length and edge-to-edge spacing of two segments.
+
+    Shared geometry primitive reused by both the crosstalk analyzer
+    (:class:`TraceIntegrityAnalyzer`) and the current-sense analyzer so the
+    pairwise math lives in exactly one place.
+
+    The two segments are treated as parallel only when their unit direction
+    vectors are near-collinear (``|dot| >= 0.9``). For parallel pairs, the
+    edge-to-edge spacing is the center-to-center perpendicular distance minus
+    the average of the two half-widths (clamped at 0), and the parallel-run
+    length is the projected overlap of ``seg2`` onto ``seg1``'s direction.
+
+    Degenerate (near zero-length) or non-parallel pairs return
+    ``(0.0, inf)`` so callers can cheaply skip them.
+
+    Args:
+        seg1: First segment.
+        seg2: Second segment.
+
+    Returns:
+        Tuple of (parallel_length_mm, edge_spacing_mm).
+    """
+    # Vector for seg1
+    dx1 = seg1.end[0] - seg1.start[0]
+    dy1 = seg1.end[1] - seg1.start[1]
+    len1 = math.sqrt(dx1 * dx1 + dy1 * dy1)
+
+    # Vector for seg2
+    dx2 = seg2.end[0] - seg2.start[0]
+    dy2 = seg2.end[1] - seg2.start[1]
+    len2 = math.sqrt(dx2 * dx2 + dy2 * dy2)
+
+    if len1 < 0.01 or len2 < 0.01:
+        return 0.0, float("inf")
+
+    # Normalize vectors
+    nx1, ny1 = dx1 / len1, dy1 / len1
+    nx2, ny2 = dx2 / len2, dy2 / len2
+
+    # Check if approximately parallel (dot product close to +/-1)
+    dot = abs(nx1 * nx2 + ny1 * ny2)
+    if dot < 0.9:  # Not parallel enough
+        return 0.0, float("inf")
+
+    # Calculate perpendicular distance between track centerlines
+    # Project seg2.start onto seg1's line
+    px = seg2.start[0] - seg1.start[0]
+    py = seg2.start[1] - seg1.start[1]
+
+    # Distance along seg1's direction
+    proj_along = px * nx1 + py * ny1
+
+    # Perpendicular distance (center-to-center)
+    perp_dist = abs(px * (-ny1) + py * nx1)
+
+    # Edge-to-edge spacing = center distance - half widths
+    spacing = perp_dist - (seg1.width + seg2.width) / 2
+    spacing = max(0.0, spacing)  # Can't be negative
+
+    # Parallel overlap length (simplified - uses projection)
+    overlap_start = max(0, proj_along)
+    overlap_end = min(len1, proj_along + len2)
+    parallel_length = max(0, overlap_end - overlap_start)
+
+    return parallel_length, spacing
+
+
 @dataclass
 class TraceCrosstalkRisk:
     """Crosstalk risk between two nets.
@@ -449,6 +517,11 @@ class TraceIntegrityAnalyzer:
     ) -> tuple[float, float]:
         """Calculate parallel length and spacing between two segments.
 
+        Thin instance-method wrapper around the shared free function
+        :func:`calculate_coupling_geometry` so callers outside this class
+        (e.g. the ``current-sense`` analyzer) can reuse the exact same math
+        without duplicating it.
+
         Args:
             seg1: First segment.
             seg2: Second segment.
@@ -456,49 +529,7 @@ class TraceIntegrityAnalyzer:
         Returns:
             Tuple of (parallel_length_mm, edge_spacing_mm).
         """
-        # Vector for seg1
-        dx1 = seg1.end[0] - seg1.start[0]
-        dy1 = seg1.end[1] - seg1.start[1]
-        len1 = math.sqrt(dx1 * dx1 + dy1 * dy1)
-
-        # Vector for seg2
-        dx2 = seg2.end[0] - seg2.start[0]
-        dy2 = seg2.end[1] - seg2.start[1]
-        len2 = math.sqrt(dx2 * dx2 + dy2 * dy2)
-
-        if len1 < 0.01 or len2 < 0.01:
-            return 0.0, float("inf")
-
-        # Normalize vectors
-        nx1, ny1 = dx1 / len1, dy1 / len1
-        nx2, ny2 = dx2 / len2, dy2 / len2
-
-        # Check if approximately parallel (dot product close to +/-1)
-        dot = abs(nx1 * nx2 + ny1 * ny2)
-        if dot < 0.9:  # Not parallel enough
-            return 0.0, float("inf")
-
-        # Calculate perpendicular distance between track centerlines
-        # Project seg2.start onto seg1's line
-        px = seg2.start[0] - seg1.start[0]
-        py = seg2.start[1] - seg1.start[1]
-
-        # Distance along seg1's direction
-        proj_along = px * nx1 + py * ny1
-
-        # Perpendicular distance (center-to-center)
-        perp_dist = abs(px * (-ny1) + py * nx1)
-
-        # Edge-to-edge spacing = center distance - half widths
-        spacing = perp_dist - (seg1.width + seg2.width) / 2
-        spacing = max(0.0, spacing)  # Can't be negative
-
-        # Parallel overlap length (simplified - uses projection)
-        overlap_start = max(0, proj_along)
-        overlap_end = min(len1, proj_along + len2)
-        parallel_length = max(0, overlap_end - overlap_start)
-
-        return parallel_length, spacing
+        return calculate_coupling_geometry(seg1, seg2)
 
     def _calculate_crosstalk_risk(
         self,

--- a/src/kicad_tools/cli/analyze_cmd.py
+++ b/src/kicad_tools/cli/analyze_cmd.py
@@ -245,6 +245,61 @@ def main(argv: list[str] | None = None) -> int:
         help="Suppress informational output",
     )
 
+    # Current-sense subcommand
+    current_sense_parser = subparsers.add_parser(
+        "current-sense",
+        help="Analyze sense-net vs. high-current-net parallel coupling",
+        description=(
+            "Flag sense/analog nets that run parallel and close to "
+            "high-current/switching nets on the same layer (advisory)"
+        ),
+    )
+    current_sense_parser.add_argument(
+        "pcb",
+        help="PCB file to analyze (.kicad_pcb)",
+    )
+    current_sense_parser.add_argument(
+        "--format",
+        "-f",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    current_sense_parser.add_argument(
+        "--sense-net",
+        action="append",
+        dest="sense_nets",
+        default=[],
+        metavar="NAME",
+        help="Explicitly tag NAME as a sense net (repeatable)",
+    )
+    current_sense_parser.add_argument(
+        "--hicur-net",
+        action="append",
+        dest="hicur_nets",
+        default=[],
+        metavar="NAME",
+        help="Explicitly tag NAME as a high-current net (repeatable)",
+    )
+    current_sense_parser.add_argument(
+        "--max-parallel",
+        type=float,
+        default=10.0,
+        help="Parallel-run FAIL threshold in mm (default: 10.0)",
+    )
+    current_sense_parser.add_argument(
+        "--min-gap",
+        type=float,
+        default=0.5,
+        help="Edge-to-edge gap FAIL threshold in mm (default: 0.5)",
+    )
+    current_sense_parser.add_argument(
+        "--quiet",
+        "-q",
+        action="store_true",
+        help="Suppress informational output",
+    )
+
     if argv is None:
         argv = sys.argv[1:]
 
@@ -268,6 +323,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.subcommand == "complexity":
         return _run_complexity_analysis(args)
+
+    if args.subcommand == "current-sense":
+        return _run_current_sense_analysis(args)
 
     return 0
 
@@ -1134,6 +1192,138 @@ def _output_complexity_text(report, filename: str, quiet: bool = False) -> None:
             console.print(f"  • {rec}")
 
         console.print()
+
+
+# ============================================================================
+# Current-Sense Analysis
+# ============================================================================
+
+
+def _run_current_sense_analysis(args: argparse.Namespace) -> int:
+    """Run current-sense / analog layout lint on a PCB.
+
+    Advisory: returns non-zero only when at least one sense net is FAIL, so
+    it can gate CI. File-not-found / load errors return 1.
+    """
+    from kicad_tools.analysis.current_sense import CurrentSenseAnalyzer
+
+    pcb_path = Path(args.pcb)
+
+    if not pcb_path.exists():
+        print(f"Error: File not found: {pcb_path}", file=sys.stderr)
+        return 1
+
+    if pcb_path.suffix != ".kicad_pcb":
+        print(f"Error: Expected .kicad_pcb file, got: {pcb_path.suffix}", file=sys.stderr)
+        return 1
+
+    # Load PCB
+    try:
+        pcb = PCB.load(str(pcb_path))
+    except Exception as e:
+        print(f"Error loading PCB: {e}", file=sys.stderr)
+        return 1
+
+    analyzer = CurrentSenseAnalyzer(
+        max_parallel_mm=args.max_parallel,
+        min_gap_mm=args.min_gap,
+        sense_nets=list(getattr(args, "sense_nets", []) or []),
+        hicur_nets=list(getattr(args, "hicur_nets", []) or []),
+    )
+    results = analyzer.analyze(pcb)
+
+    if args.format == "json":
+        _output_current_sense_json(results, args.max_parallel, args.min_gap)
+    else:
+        _output_current_sense_text(
+            results,
+            pcb_path.name,
+            args.max_parallel,
+            args.min_gap,
+            quiet=args.quiet,
+        )
+
+    # Non-zero exit when any sense net FAILs (CI-gateable).
+    if any(r.status == "FAIL" for r in results):
+        return 1
+    return 0
+
+
+def _output_current_sense_json(
+    results: list,
+    max_parallel_mm: float,
+    min_gap_mm: float,
+) -> None:
+    """Output current-sense census as JSON (mirrors signal-integrity JSON)."""
+    fail_count = sum(1 for r in results if r.status == "FAIL")
+    output = {
+        "census": [r.to_dict() for r in results],
+        "thresholds": {
+            "max_parallel_mm": max_parallel_mm,
+            "min_gap_mm": min_gap_mm,
+        },
+        "summary": {
+            "total": len(results),
+            "fail": fail_count,
+            "pass": len(results) - fail_count,
+        },
+    }
+    print(json.dumps(output, indent=2))
+
+
+def _output_current_sense_text(
+    results: list,
+    filename: str,
+    max_parallel_mm: float,
+    min_gap_mm: float,
+    quiet: bool = False,
+) -> None:
+    """Output current-sense census as a formatted table."""
+    console = Console()
+
+    if not results:
+        if not quiet:
+            console.print(f"[green]No sense nets found in {filename}[/green]")
+        return
+
+    if not quiet:
+        console.print(f"\n[bold]Current-Sense Layout Lint: {filename}[/bold]")
+        console.print(
+            f"[dim]FAIL when parallel-run >= {max_parallel_mm:.2f}mm AND "
+            f"gap <= {min_gap_mm:.2f}mm (same layer)[/dim]\n"
+        )
+
+    table = Table(show_header=True)
+    table.add_column("sense_net", style="cyan")
+    table.add_column("nearest_hicur_net")
+    table.add_column("layer")
+    table.add_column("max_parallel_mm", justify="right")
+    table.add_column("min_gap_mm", justify="right")
+    table.add_column("status", justify="center")
+
+    for r in results:
+        status_style = "red bold" if r.status == "FAIL" else "green"
+        nearest = r.nearest_hicur_net if r.nearest_hicur_net is not None else "-"
+        layer = r.layer if r.layer is not None else "-"
+        gap_str = "-" if r.min_gap_mm is None else f"{r.min_gap_mm:.3f}"
+        table.add_row(
+            r.sense_net,
+            nearest,
+            layer,
+            f"{r.max_parallel_mm:.3f}",
+            gap_str,
+            f"[{status_style}]{r.status}[/{status_style}]",
+        )
+
+    console.print(table)
+
+    fail_count = sum(1 for r in results if r.status == "FAIL")
+    console.print()
+    summary_style = "red bold" if fail_count else "green"
+    console.print(
+        f"[{summary_style}]Total: {len(results)} sense nets, "
+        f"{fail_count} FAIL, {len(results) - fail_count} PASS[/{summary_style}]"
+    )
 
 
 if __name__ == "__main__":

--- a/src/kicad_tools/cli/commands/analyze.py
+++ b/src/kicad_tools/cli/commands/analyze.py
@@ -7,7 +7,10 @@ def run_analyze_command(args) -> int:
     """Handle analyze command and its subcommands."""
     if not args.analyze_command:
         print("Usage: kicad-tools analyze <command> [options] <file>")
-        print("Commands: complexity, congestion, trace-lengths, signal-integrity, thermal")
+        print(
+            "Commands: complexity, congestion, trace-lengths, signal-integrity, "
+            "thermal, current-sense"
+        )
         return 1
 
     if args.analyze_command == "complexity":
@@ -24,6 +27,9 @@ def run_analyze_command(args) -> int:
 
     if args.analyze_command == "thermal":
         return _run_thermal_command(args)
+
+    if args.analyze_command == "current-sense":
+        return _run_current_sense_command(args)
 
     return 1
 
@@ -99,6 +105,28 @@ def _run_thermal_command(args) -> int:
         sub_argv.extend(["--cluster-radius", str(args.analyze_cluster_radius)])
     if getattr(args, "analyze_min_power", 0.05) != 0.05:
         sub_argv.extend(["--min-power", str(args.analyze_min_power)])
+    if getattr(args, "global_quiet", False):
+        sub_argv.append("--quiet")
+
+    return analyze_main(sub_argv)
+
+
+def _run_current_sense_command(args) -> int:
+    """Handle analyze current-sense command."""
+    from ..analyze_cmd import main as analyze_main
+
+    sub_argv = ["current-sense", args.pcb]
+
+    if getattr(args, "analyze_format", "text") != "text":
+        sub_argv.extend(["--format", args.analyze_format])
+    for name in getattr(args, "analyze_sense_nets", None) or []:
+        sub_argv.extend(["--sense-net", name])
+    for name in getattr(args, "analyze_hicur_nets", None) or []:
+        sub_argv.extend(["--hicur-net", name])
+    if getattr(args, "analyze_max_parallel", 10.0) != 10.0:
+        sub_argv.extend(["--max-parallel", str(args.analyze_max_parallel)])
+    if getattr(args, "analyze_min_gap", 0.5) != 0.5:
+        sub_argv.extend(["--min-gap", str(args.analyze_min_gap)])
     if getattr(args, "global_quiet", False):
         sub_argv.append("--quiet")
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -5320,6 +5320,55 @@ def _add_analyze_parser(subparsers) -> None:
         help="Grid cell size for density analysis in mm (default: 5.0)",
     )
 
+    # analyze current-sense
+    current_sense_parser = analyze_subparsers.add_parser(
+        "current-sense",
+        help="Analyze sense-net vs. high-current-net parallel coupling",
+        description=(
+            "Flag sense/analog nets that run parallel and close to "
+            "high-current/switching nets on the same layer (advisory)"
+        ),
+    )
+    current_sense_parser.add_argument("pcb", help="PCB file to analyze (.kicad_pcb)")
+    current_sense_parser.add_argument(
+        "--format",
+        "-f",
+        dest="analyze_format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    current_sense_parser.add_argument(
+        "--sense-net",
+        action="append",
+        dest="analyze_sense_nets",
+        default=[],
+        metavar="NAME",
+        help="Explicitly tag NAME as a sense net (repeatable)",
+    )
+    current_sense_parser.add_argument(
+        "--hicur-net",
+        action="append",
+        dest="analyze_hicur_nets",
+        default=[],
+        metavar="NAME",
+        help="Explicitly tag NAME as a high-current net (repeatable)",
+    )
+    current_sense_parser.add_argument(
+        "--max-parallel",
+        dest="analyze_max_parallel",
+        type=float,
+        default=10.0,
+        help="Parallel-run FAIL threshold in mm (default: 10.0)",
+    )
+    current_sense_parser.add_argument(
+        "--min-gap",
+        dest="analyze_min_gap",
+        type=float,
+        default=0.5,
+        help="Edge-to-edge gap FAIL threshold in mm (default: 0.5)",
+    )
+
 
 def _add_constraints_parser(subparsers) -> None:
     """Add constraints subcommand parser with its subcommands."""

--- a/tests/test_current_sense.py
+++ b/tests/test_current_sense.py
@@ -1,0 +1,375 @@
+"""Tests for the Phase-1 current-sense / analog layout lint (#4328).
+
+Covers the analyzer (parallel-run + gap, FAIL/PASS rule, classification,
+overrides, edge cases) and the CLI subcommand (text/json output, exit codes).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.analysis import CurrentSenseAnalyzer, CurrentSenseResult
+from kicad_tools.analysis.current_sense import (
+    DEFAULT_MAX_PARALLEL_MM,
+    DEFAULT_MIN_GAP_MM,
+)
+from kicad_tools.cli.analyze_cmd import main as analyze_main
+from kicad_tools.schema.pcb import PCB
+
+# ---------------------------------------------------------------------------
+# Synthetic board fixtures
+# ---------------------------------------------------------------------------
+
+_HEADER = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (gr_rect (start 0 0) (end 50 50) (stroke (width 0.1)) (layer "Edge.Cuts"))
+"""
+
+# ISENSE (-> ANALOG) runs parallel to PHASE_A (-> HIGH_CURRENT_SIGNAL) for 20mm.
+# Center-to-center 0.3mm, widths 0.2mm each => edge gap 0.1mm. 20 >= 10 AND
+# 0.1 <= 0.5 => FAIL.
+FAIL_PCB = (
+    _HEADER
+    + """
+  (net 0 "")
+  (net 1 "ISENSE")
+  (net 2 "PHASE_A")
+  (net 3 "GND")
+  (segment (start 0 0) (end 20 0) (width 0.2) (layer "F.Cu") (net 1))
+  (segment (start 0 0.3) (end 20 0.3) (width 0.2) (layer "F.Cu") (net 2))
+)
+"""
+)
+
+# Same nets but PHASE_A is 5mm away => edge gap 4.8mm > 0.5mm => PASS.
+PASS_PCB = (
+    _HEADER
+    + """
+  (net 0 "")
+  (net 1 "ISENSE")
+  (net 2 "PHASE_A")
+  (net 3 "GND")
+  (segment (start 0 0) (end 20 0) (width 0.2) (layer "F.Cu") (net 1))
+  (segment (start 0 5.0) (end 20 5.0) (width 0.2) (layer "F.Cu") (net 2))
+)
+"""
+)
+
+# No sense nets at all: only high-current + ground.
+NO_SENSE_PCB = (
+    _HEADER
+    + """
+  (net 0 "")
+  (net 1 "PHASE_A")
+  (net 2 "GND")
+  (segment (start 0 0) (end 20 0) (width 0.2) (layer "F.Cu") (net 1))
+)
+"""
+)
+
+# Sense net with a high-current neighbour on a DIFFERENT layer only => PASS
+# (Phase 1 is same-layer only).
+DIFFERENT_LAYER_PCB = (
+    _HEADER
+    + """
+  (net 0 "")
+  (net 1 "ISENSE")
+  (net 2 "PHASE_A")
+  (segment (start 0 0) (end 20 0) (width 0.2) (layer "F.Cu") (net 1))
+  (segment (start 0 0.3) (end 20 0.3) (width 0.2) (layer "B.Cu") (net 2))
+)
+"""
+)
+
+# Crossing (perpendicular) segments: not a parallel run => PASS, no blocker.
+CROSSING_PCB = (
+    _HEADER
+    + """
+  (net 0 "")
+  (net 1 "ISENSE")
+  (net 2 "PHASE_A")
+  (segment (start 0 10) (end 20 10) (width 0.2) (layer "F.Cu") (net 1))
+  (segment (start 10 0) (end 10 20) (width 0.2) (layer "F.Cu") (net 2))
+)
+"""
+)
+
+# The rev-C scenario: neither name is auto-classified (OC_TRIP_N is not ANALOG,
+# GATE_NEG_A is not HIGH_CURRENT). They must be tagged via explicit overrides.
+OVERRIDE_PCB = (
+    _HEADER
+    + """
+  (net 0 "")
+  (net 1 "/OC_TRIP_N")
+  (net 2 "/GATE_NEG_A")
+  (segment (start 0 0) (end 20 0) (width 0.2) (layer "F.Cu") (net 1))
+  (segment (start 0 0.3) (end 20 0.3) (width 0.2) (layer "F.Cu") (net 2))
+)
+"""
+)
+
+
+def _write(tmp_path: Path, text: str, name: str = "board.kicad_pcb") -> Path:
+    pcb_file = tmp_path / name
+    pcb_file.write_text(text)
+    return pcb_file
+
+
+def _load(tmp_path: Path, text: str) -> PCB:
+    return PCB.load(str(_write(tmp_path, text)))
+
+
+# ---------------------------------------------------------------------------
+# Analyzer: geometry + FAIL/PASS rule
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzerGeometry:
+    def test_parallel_close_fails(self, tmp_path: Path) -> None:
+        pcb = _load(tmp_path, FAIL_PCB)
+        results = CurrentSenseAnalyzer().analyze(pcb)
+        assert len(results) == 1
+        r = results[0]
+        assert r.sense_net == "ISENSE"
+        assert r.nearest_hicur_net == "PHASE_A"
+        assert r.layer == "F.Cu"
+        assert r.max_parallel_mm == pytest.approx(20.0, abs=0.01)
+        assert r.min_gap_mm == pytest.approx(0.1, abs=0.001)
+        assert r.status == "FAIL"
+        # margin = gap - threshold = 0.1 - 0.5 = -0.4 (negative => violated)
+        assert r.margin_mm == pytest.approx(-0.4, abs=0.001)
+
+    def test_well_separated_passes(self, tmp_path: Path) -> None:
+        pcb = _load(tmp_path, PASS_PCB)
+        results = CurrentSenseAnalyzer().analyze(pcb)
+        assert len(results) == 1
+        r = results[0]
+        assert r.sense_net == "ISENSE"
+        # Still the nearest blocker, but gap keeps it PASS.
+        assert r.nearest_hicur_net == "PHASE_A"
+        assert r.max_parallel_mm == pytest.approx(20.0, abs=0.01)
+        assert r.min_gap_mm == pytest.approx(4.8, abs=0.001)
+        assert r.status == "PASS"
+        assert r.margin_mm == pytest.approx(4.3, abs=0.001)
+
+    def test_short_run_at_close_gap_passes(self, tmp_path: Path) -> None:
+        # Close (0.1mm) but only a 3mm parallel run => PASS under the AND rule.
+        text = (
+            _HEADER
+            + """
+  (net 0 "")
+  (net 1 "ISENSE")
+  (net 2 "PHASE_A")
+  (segment (start 0 0) (end 3 0) (width 0.2) (layer "F.Cu") (net 1))
+  (segment (start 0 0.3) (end 3 0.3) (width 0.2) (layer "F.Cu") (net 2))
+)
+"""
+        )
+        pcb = _load(tmp_path, text)
+        r = CurrentSenseAnalyzer().analyze(pcb)[0]
+        assert r.min_gap_mm == pytest.approx(0.1, abs=0.001)
+        assert r.max_parallel_mm == pytest.approx(3.0, abs=0.01)
+        assert r.status == "PASS"  # short run: not enough coupling length
+
+    def test_custom_thresholds(self, tmp_path: Path) -> None:
+        pcb = _load(tmp_path, PASS_PCB)
+        # Loosen the gap threshold above 4.8mm so the 20mm run now FAILs.
+        r = CurrentSenseAnalyzer(max_parallel_mm=5.0, min_gap_mm=5.0).analyze(pcb)[0]
+        assert r.status == "FAIL"
+
+
+# ---------------------------------------------------------------------------
+# Classification + overrides
+# ---------------------------------------------------------------------------
+
+
+class TestClassification:
+    def test_auto_classification(self, tmp_path: Path) -> None:
+        pcb = _load(tmp_path, FAIL_PCB)
+        sense, hicur = CurrentSenseAnalyzer().classify_nets(pcb)
+        assert "ISENSE" in sense  # SENSE -> ANALOG
+        assert "PHASE_A" in hicur  # PHASE_A -> HIGH_CURRENT_SIGNAL
+        assert "ISENSE" not in hicur
+
+    def test_override_tags_rev_c_nets(self, tmp_path: Path) -> None:
+        pcb = _load(tmp_path, OVERRIDE_PCB)
+        # Without overrides the rev-C nets are not recognised.
+        assert CurrentSenseAnalyzer().analyze(pcb) == []
+        # With overrides, /OC_TRIP_N becomes a sense net whose nearest blocker
+        # is /GATE_NEG_A and it FAILs.
+        analyzer = CurrentSenseAnalyzer(
+            sense_nets=["/OC_TRIP_N"],
+            hicur_nets=["/GATE_NEG_A"],
+        )
+        results = analyzer.analyze(pcb)
+        assert len(results) == 1
+        r = results[0]
+        assert r.sense_net == "/OC_TRIP_N"
+        assert r.nearest_hicur_net == "/GATE_NEG_A"
+        assert r.status == "FAIL"
+
+    def test_net_in_both_sets_is_sense_only(self, tmp_path: Path) -> None:
+        pcb = _load(tmp_path, FAIL_PCB)
+        analyzer = CurrentSenseAnalyzer(sense_nets=["PHASE_A"])
+        sense, hicur = analyzer.classify_nets(pcb)
+        assert "PHASE_A" in sense
+        assert "PHASE_A" not in hicur
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_no_sense_nets_returns_empty(self, tmp_path: Path) -> None:
+        pcb = _load(tmp_path, NO_SENSE_PCB)
+        assert CurrentSenseAnalyzer().analyze(pcb) == []
+
+    def test_different_layer_not_coupled(self, tmp_path: Path) -> None:
+        pcb = _load(tmp_path, DIFFERENT_LAYER_PCB)
+        r = CurrentSenseAnalyzer().analyze(pcb)[0]
+        assert r.nearest_hicur_net is None
+        assert r.min_gap_mm is None
+        assert r.max_parallel_mm == 0.0
+        assert r.status == "PASS"
+        assert r.margin_mm is None
+
+    def test_crossing_segments_not_parallel(self, tmp_path: Path) -> None:
+        pcb = _load(tmp_path, CROSSING_PCB)
+        r = CurrentSenseAnalyzer().analyze(pcb)[0]
+        assert r.nearest_hicur_net is None
+        assert r.status == "PASS"
+
+    def test_defaults(self) -> None:
+        a = CurrentSenseAnalyzer()
+        assert a.max_parallel_mm == DEFAULT_MAX_PARALLEL_MM
+        assert a.min_gap_mm == DEFAULT_MIN_GAP_MM
+
+
+# ---------------------------------------------------------------------------
+# Result serialization
+# ---------------------------------------------------------------------------
+
+
+class TestResultDict:
+    def test_to_dict_keys(self, tmp_path: Path) -> None:
+        pcb = _load(tmp_path, FAIL_PCB)
+        d = CurrentSenseAnalyzer().analyze(pcb)[0].to_dict()
+        assert set(d) == {
+            "sense_net",
+            "nearest_hicur_net",
+            "layer",
+            "max_parallel_mm",
+            "min_gap_mm",
+            "status",
+            "margin",
+        }
+        assert d["status"] == "FAIL"
+
+    def test_to_dict_no_neighbor_is_json_safe(self, tmp_path: Path) -> None:
+        pcb = _load(tmp_path, DIFFERENT_LAYER_PCB)
+        d = CurrentSenseAnalyzer().analyze(pcb)[0].to_dict()
+        # No inf/NaN that would break json.dumps.
+        assert d["min_gap_mm"] is None
+        assert d["margin"] is None
+        json.dumps(d)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+class TestCli:
+    def test_cli_fail_exit_code(self, tmp_path: Path, capsys) -> None:
+        pcb = _write(tmp_path, FAIL_PCB)
+        rc = analyze_main(["current-sense", str(pcb)])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "ISENSE" in out
+        assert "FAIL" in out
+
+    def test_cli_pass_exit_code(self, tmp_path: Path, capsys) -> None:
+        pcb = _write(tmp_path, PASS_PCB)
+        rc = analyze_main(["current-sense", str(pcb)])
+        assert rc == 0
+
+    def test_cli_no_sense_clean_exit(self, tmp_path: Path, capsys) -> None:
+        pcb = _write(tmp_path, NO_SENSE_PCB)
+        rc = analyze_main(["current-sense", str(pcb)])
+        assert rc == 0
+        assert "No sense nets" in capsys.readouterr().out
+
+    def test_cli_json_shape(self, tmp_path: Path, capsys) -> None:
+        pcb = _write(tmp_path, FAIL_PCB)
+        rc = analyze_main(["current-sense", str(pcb), "--format", "json"])
+        assert rc == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert set(payload) == {"census", "thresholds", "summary"}
+        assert payload["summary"] == {"total": 1, "fail": 1, "pass": 0}
+        assert payload["thresholds"]["max_parallel_mm"] == 10.0
+        assert payload["thresholds"]["min_gap_mm"] == 0.5
+        row = payload["census"][0]
+        assert row["sense_net"] == "ISENSE"
+        assert row["nearest_hicur_net"] == "PHASE_A"
+        assert row["status"] == "FAIL"
+
+    def test_cli_overrides(self, tmp_path: Path, capsys) -> None:
+        pcb = _write(tmp_path, OVERRIDE_PCB)
+        rc = analyze_main(
+            [
+                "current-sense",
+                str(pcb),
+                "--sense-net",
+                "/OC_TRIP_N",
+                "--hicur-net",
+                "/GATE_NEG_A",
+                "--format",
+                "json",
+            ]
+        )
+        assert rc == 1
+        payload = json.loads(capsys.readouterr().out)
+        row = payload["census"][0]
+        assert row["sense_net"] == "/OC_TRIP_N"
+        assert row["nearest_hicur_net"] == "/GATE_NEG_A"
+
+    def test_cli_custom_thresholds(self, tmp_path: Path, capsys) -> None:
+        pcb = _write(tmp_path, PASS_PCB)
+        rc = analyze_main(["current-sense", str(pcb), "--max-parallel", "5", "--min-gap", "5"])
+        assert rc == 1
+
+    def test_cli_missing_file(self, tmp_path: Path) -> None:
+        rc = analyze_main(["current-sense", str(tmp_path / "nope.kicad_pcb")])
+        assert rc == 1
+
+    def test_cli_quiet(self, tmp_path: Path, capsys) -> None:
+        pcb = _write(tmp_path, NO_SENSE_PCB)
+        rc = analyze_main(["current-sense", str(pcb), "--quiet"])
+        assert rc == 0
+        # Quiet suppresses the informational "no sense nets" chrome.
+        assert capsys.readouterr().out.strip() == ""
+
+
+def test_result_dataclass_direct() -> None:
+    r = CurrentSenseResult(
+        sense_net="S",
+        nearest_hicur_net=None,
+        layer=None,
+        max_parallel_mm=0.0,
+        min_gap_mm=None,
+        status="PASS",
+        margin_mm=None,
+    )
+    assert r.to_dict()["status"] == "PASS"


### PR DESCRIPTION
## Summary

Implements **Phase 1 (MVP)** of #4328: a new `kct analyze current-sense <board.kicad_pcb>` subcommand that produces a per-sense-net census of same-layer parallel coupling to high-current/switching nets. This is the metric that would have caught the softstart rev-C finding where `/OC_TRIP_N` ran adjacent to `/GATE_NEG_A`.

Closes #4328

This is **Phase 1 of a phased feature**. Explicitly out of scope (tracked as follow-ups):
- #4330 — copper sense-loop area (Phase 2)
- #4331 — Kelvin-tap-at-metallization + inner-layer/broadside coupling (Phase 3)

## What Phase 1 covers

For each **sense** net, scan every segment of every **high-current** net on the **same layer** and report, per sense net:
`sense_net | nearest_hicur_net | layer | max_parallel_mm | min_gap_mm | status`

- **Classification:** `router.net_class.classify_from_name` — `ANALOG` → sense; `HIGH_CURRENT_SIGNAL`/`POWER` → high-current. Plus repeatable `--sense-net NAME` / `--hicur-net NAME` overrides so `GATE_*`/`SRC_*`/`TRK_*` (not yet auto-classified) can be tagged today. A net named in both sets is treated as sense-only.
- **Shared geometry (no duplication):** extracted `calculate_coupling_geometry(seg1, seg2)` as a module-level free function in `signal_integrity.py`; the existing `_calculate_coupling_geometry` method now delegates to it. The current-sense analyzer imports the free function.
- **FAIL rule (AND — documented):** a sense net is **FAIL** when, against its *nearest* high-current blocker (smallest edge gap), it **both** runs parallel for `>= --max-parallel` (default **10.0 mm**) **and** is separated by `<= --min-gap` (default **0.5 mm**). A long run that stays far away, or a momentary close approach (short parallel run), is **PASS**. Both must hold because coupling scales with parallel length *and* inverse gap — either alone is insufficient to corrupt a high-impedance sense line. The census shows the gap-clearance `margin` (`min_gap - min_gap_threshold`).
- **`--format json`:** emits `census` (list of `{sense_net, nearest_hicur_net, layer, max_parallel_mm, min_gap_mm, status, margin}`) + `thresholds` + `summary` (`total`/`fail`/`pass`), mirroring `_output_signal_integrity_json`.
- **Advisory / robust:** never raises; a board with no sense nets prints a clean message and exits 0. **Non-zero exit** when any sense net FAILs (CI-gateable). `--quiet` supported. **Same-layer only** in Phase 1.
- **CLI triple-wired:** `parser.py`, `commands/analyze.py`, `analyze_cmd.py`.

## Parallel-run FAIL/PASS verification

Synthetic ISENSE net running 20 mm parallel to PHASE_A:
- gap 0.1 mm (center 0.3 mm, 0.2 mm widths) → `max_parallel=20.0`, `min_gap=0.1` → **FAIL** (exit 1). ✅
- same nets, blocker moved to 5.0 mm → `min_gap=4.8` → **PASS** (exit 0). ✅
- close (0.1 mm) but only a 3 mm run → **PASS** (short run, AND rule). ✅
- override test: `/OC_TRIP_N` + `/GATE_NEG_A` (neither auto-classified) → with `--sense-net`/`--hicur-net`, `/OC_TRIP_N` FAILs with nearest blocker `/GATE_NEG_A`. ✅
- no-sense board → clean exit 0. ✅

## Local checks

- `uv run pytest tests/test_current_sense.py` — **22 passed**
- `uv run pytest tests/test_analysis_signal_integrity.py tests/test_signal_integrity.py` — **64 passed** (shared-geometry extraction is behavior-preserving)
- `uv run ruff check .` — clean (only pre-existing unrelated MFR001 noqa warning)
- `uv run ruff format . --check` — clean
- mypy baseline gate (`scripts/ci/check_mypy_baseline.py`) — **OK: no new type errors** (1473 ≤ 1474 allowed). De-duplicating the geometry removed one baseline error; left the baseline untouched (gate fails only on NEW errors) to avoid the documented `--update` native-trap — a follow-up can tighten the floor by one line.

## Affected files

- `src/kicad_tools/analysis/current_sense.py` (new)
- `src/kicad_tools/analysis/signal_integrity.py` (shared `calculate_coupling_geometry`)
- `src/kicad_tools/analysis/__init__.py` (exports)
- `src/kicad_tools/cli/analyze_cmd.py`, `src/kicad_tools/cli/parser.py`, `src/kicad_tools/cli/commands/analyze.py`
- `tests/test_current_sense.py` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)