### PR TITLE
feat(analyze): current-sense phase 2 -- copper sense-loop area metric

### DIFF
--- a/src/kicad_tools/analysis/current_sense.py
+++ b/src/kicad_tools/analysis/current_sense.py
@@ -40,6 +40,7 @@ un-inspectable data.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -47,11 +48,12 @@ from kicad_tools.analysis.signal_integrity import calculate_coupling_geometry
 from kicad_tools.router.net_class import NetClass, classify_from_name
 
 if TYPE_CHECKING:
-    from kicad_tools.schema.pcb import PCB, Segment
+    from kicad_tools.schema.pcb import PCB, Segment, Via
 
 __all__ = [
     "CurrentSenseAnalyzer",
     "CurrentSenseResult",
+    "DEFAULT_MAX_LOOP_AREA_MM2",
     "DEFAULT_MAX_PARALLEL_MM",
     "DEFAULT_MIN_GAP_MM",
 ]
@@ -60,6 +62,26 @@ __all__ = [
 # for >= DEFAULT_MAX_PARALLEL_MM at an edge gap <= DEFAULT_MIN_GAP_MM is FAIL.
 DEFAULT_MAX_PARALLEL_MM = 10.0
 DEFAULT_MIN_GAP_MM = 0.5
+
+# Phase 2 (#4330): default enclosed copper sense-loop area threshold (mm^2). A
+# Kelvin sense loop whose enclosed area exceeds this is FAIL. 10.0 mm^2 is a
+# conservative starting value pending EE confirmation (see the issue's note).
+DEFAULT_MAX_LOOP_AREA_MM2 = 10.0
+
+# Endpoint-snapping tolerance (mm) used when merging a conductor's segments into
+# ordered polylines. Numerically-coincident joints (and via transitions, whose
+# two layers' segments meet at the shared via position) are merged within this
+# tolerance so ``shapely.ops.linemerge`` can chain them into one polyline.
+_SNAP_TOL_MM = 1e-3
+
+# Suffix conventions for auto-pairing a Kelvin sense net with its return
+# conductor: ``(positive_suffix, negative_suffix)``. ``/I_SENSE_P`` pairs with
+# ``/I_SENSE_N``, ``VSNS+`` with ``VSNS-``, ``FB_H`` with ``FB_L``.
+_AUTO_PAIR_SUFFIXES: tuple[tuple[str, str], ...] = (
+    ("_P", "_N"),
+    ("+", "-"),
+    ("_H", "_L"),
+)
 
 
 @dataclass
@@ -81,6 +103,15 @@ class CurrentSenseResult:
             positive means the gap is above the minimum. ``None`` when there is
             no neighbor. Note a FAIL always has ``margin_mm <= 0`` *and* also
             exceeded the parallel-run threshold.
+        loop_area_mm2: Phase 2 (#4330). Enclosed copper area (mm^2) of the
+            Kelvin sense loop this net belongs to (sense conductor + its return
+            conductor closed at both terminals), or ``None`` when no loop could
+            be identified/closed (advisory graceful-degrade).
+        loop_status: ``"FAIL"`` when ``loop_area_mm2 > max_loop_area``,
+            ``"PASS"`` when ``<=``, or ``None`` when no loop was measured.
+        loop_reason: Human-readable reason the loop area is ``None`` (e.g. no
+            return conductor, or the loop did not close). ``None`` when a loop
+            area was measured.
     """
 
     sense_net: str
@@ -90,10 +121,19 @@ class CurrentSenseResult:
     min_gap_mm: float | None
     status: str
     margin_mm: float | None
+    # Phase 2 (#4330) -- additive; default None so Phase-1 construction and any
+    # sense net not part of an identified loop carries null loop fields.
+    loop_area_mm2: float | None = None
+    loop_status: str | None = None
+    loop_reason: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        """Convert to a JSON-serializable dict (mirrors sibling analyzers)."""
-        return {
+        """Convert to a JSON-serializable dict (mirrors sibling analyzers).
+
+        Phase-1 keys are emitted unchanged; Phase-2 adds ``loop_area_mm2`` and
+        ``loop_status`` (always), plus ``loop_reason`` only when it is set.
+        """
+        out: dict[str, Any] = {
             "sense_net": self.sense_net,
             "nearest_hicur_net": self.nearest_hicur_net,
             "layer": self.layer,
@@ -101,7 +141,12 @@ class CurrentSenseResult:
             "min_gap_mm": (None if self.min_gap_mm is None else round(self.min_gap_mm, 3)),
             "status": self.status,
             "margin": (None if self.margin_mm is None else round(self.margin_mm, 3)),
+            "loop_area_mm2": (None if self.loop_area_mm2 is None else round(self.loop_area_mm2, 3)),
+            "loop_status": self.loop_status,
         }
+        if self.loop_reason is not None:
+            out["loop_reason"] = self.loop_reason
+        return out
 
 
 class CurrentSenseAnalyzer:
@@ -117,6 +162,9 @@ class CurrentSenseAnalyzer:
         min_gap_mm: float = DEFAULT_MIN_GAP_MM,
         sense_nets: list[str] | None = None,
         hicur_nets: list[str] | None = None,
+        max_loop_area_mm2: float = DEFAULT_MAX_LOOP_AREA_MM2,
+        sense_pairs: list[tuple[str, str]] | list[list[str]] | None = None,
+        sense_return: str | None = None,
     ) -> None:
         """Initialize the analyzer.
 
@@ -127,11 +175,27 @@ class CurrentSenseAnalyzer:
                 auto-classification).
             hicur_nets: Explicit high-current-net names (override / augment
                 auto-classification).
+            max_loop_area_mm2: Phase 2 (#4330) enclosed-loop-area threshold
+                (mm^2) for the loop FAIL rule.
+            sense_pairs: Explicit Kelvin pairings ``[(sense, return), ...]``.
+                Either order matches; the partner conductor closes the loop.
+            sense_return: A single shared return-conductor name (e.g. a Kelvin
+                ground) used to close any sense net that has no explicit or
+                auto-detected partner.
         """
         self.max_parallel_mm = max_parallel_mm
         self.min_gap_mm = min_gap_mm
         self.sense_overrides = {n for n in (sense_nets or []) if n}
         self.hicur_overrides = {n for n in (hicur_nets or []) if n}
+        self.max_loop_area_mm2 = max_loop_area_mm2
+        # Normalize explicit pairs to a list of 2-tuples, dropping malformed
+        # entries defensively (advisory-only contract).
+        self.sense_pairs: list[tuple[str, str]] = [
+            (str(p[0]), str(p[1]))
+            for p in (sense_pairs or [])
+            if p is not None and len(p) == 2 and p[0] and p[1]
+        ]
+        self.sense_return = sense_return or None
 
     # ------------------------------------------------------------------
     # Net classification
@@ -187,20 +251,203 @@ class CurrentSenseAnalyzer:
             all_segments = []
 
         named: list[tuple[str, Segment]] = []
+        segs_by_name: dict[str, list[Segment]] = {}
         for seg in all_segments:
             name = seg.net_name or num_to_name.get(seg.net_number, "")
             if name:
                 named.append((name, seg))
+                segs_by_name.setdefault(name, []).append(seg)
+
+        # Name-indexed vias (Phase 2) so a via-transitioned conductor can be
+        # bridged at the shared via position when merging its polyline.
+        vias_by_name: dict[str, list[Via]] = {}
+        try:
+            all_vias = list(pcb.vias)
+        except Exception:
+            all_vias = []
+        for via in all_vias:
+            vname = via.net_name or num_to_name.get(via.net_number, "")
+            if vname:
+                vias_by_name.setdefault(vname, []).append(via)
 
         hicur_named: list[tuple[str, Segment]] = [
             (name, seg) for name, seg in named if name in hicur_names
         ]
 
+        conductor_names = set(segs_by_name)
+
         results: list[CurrentSenseResult] = []
         for sense_name in sorted(sense_names):
-            sense_segs = [seg for name, seg in named if name == sense_name]
-            results.append(self._analyze_sense_net(sense_name, sense_segs, hicur_named))
+            sense_segs = segs_by_name.get(sense_name, [])
+            result = self._analyze_sense_net(sense_name, sense_segs, hicur_named)
+            area, status, reason = self._analyze_loop(
+                sense_name, conductor_names, segs_by_name, vias_by_name
+            )
+            result.loop_area_mm2 = area
+            result.loop_status = status
+            result.loop_reason = reason
+            results.append(result)
         return results
+
+    # ------------------------------------------------------------------
+    # Phase 2: copper sense-loop area
+    # ------------------------------------------------------------------
+    def _resolve_partner(self, sense_name: str, conductor_names: set[str]) -> str | None:
+        """Return the return-conductor net name closing ``sense_name``'s loop.
+
+        Resolution order: explicit ``sense_pairs`` -> shared ``sense_return``
+        -> suffix auto-pair convention. The partner must itself be a routed
+        conductor (present in ``conductor_names``) and distinct from the sense
+        net. Returns ``None`` when no partner is found.
+        """
+        for a, b in self.sense_pairs:
+            if sense_name == a and b != sense_name and b in conductor_names:
+                return b
+            if sense_name == b and a != sense_name and a in conductor_names:
+                return a
+
+        if (
+            self.sense_return
+            and self.sense_return != sense_name
+            and self.sense_return in conductor_names
+        ):
+            return self.sense_return
+
+        for pos, neg in _AUTO_PAIR_SUFFIXES:
+            if sense_name.endswith(pos):
+                cand = sense_name[: -len(pos)] + neg
+                if cand != sense_name and cand in conductor_names:
+                    return cand
+            if sense_name.endswith(neg):
+                cand = sense_name[: -len(neg)] + pos
+                if cand != sense_name and cand in conductor_names:
+                    return cand
+        return None
+
+    def _analyze_loop(
+        self,
+        sense_name: str,
+        conductor_names: set[str],
+        segs_by_name: dict[str, list[Segment]],
+        vias_by_name: dict[str, list[Via]],
+    ) -> tuple[float | None, str | None, str | None]:
+        """Return ``(loop_area_mm2, loop_status, loop_reason)`` for one net.
+
+        Advisory-only: any failure degrades to ``(None, None, reason)`` and
+        never raises.
+        """
+        partner = self._resolve_partner(sense_name, conductor_names)
+        if partner is None:
+            return None, None, "no return conductor (single-ended, not closable)"
+
+        try:
+            area, reason = self._compute_loop_area(
+                segs_by_name.get(sense_name, []),
+                segs_by_name.get(partner, []),
+                vias_by_name.get(sense_name, []),
+                vias_by_name.get(partner, []),
+            )
+        except Exception:
+            return None, None, "loop area computation failed"
+
+        if area is None:
+            return None, None, reason
+
+        status = "FAIL" if area > self.max_loop_area_mm2 else "PASS"
+        return area, status, None
+
+    def _compute_loop_area(
+        self,
+        sense_segs: list[Segment],
+        partner_segs: list[Segment],
+        sense_vias: list[Via],
+        partner_vias: list[Via],
+    ) -> tuple[float | None, str | None]:
+        """Compute the enclosed area (mm^2) of the sense<->return copper loop.
+
+        Each conductor's segments are merged into a single ordered polyline
+        (``shapely.ops.linemerge``, endpoints snapped within ``_SNAP_TOL_MM``
+        and to any shared via position). The two polylines are closed with the
+        nearest-endpoint terminals and the enclosed polygon area is returned.
+        Returns ``(None, reason)`` on any non-closable geometry.
+        """
+        try:
+            from shapely.geometry import Polygon  # type: ignore[import-untyped]
+        except Exception:
+            return None, "shapely unavailable"
+
+        if not sense_segs or not partner_segs:
+            return None, "no return conductor (single-ended, not closable)"
+
+        merged_s = self._merge_conductor(sense_segs, sense_vias)
+        merged_p = self._merge_conductor(partner_segs, partner_vias)
+        if merged_s is None or merged_p is None:
+            return None, "loop did not close (empty conductor geometry)"
+        if merged_s.geom_type != "LineString" or merged_p.geom_type != "LineString":
+            return None, "loop did not close (conductor is not a single contiguous run)"
+
+        s_coords = list(merged_s.coords)
+        p_coords = list(merged_p.coords)
+        if len(s_coords) < 2 or len(p_coords) < 2:
+            return None, "loop did not close (degenerate conductor)"
+
+        s0, s1 = s_coords[0], s_coords[-1]
+        p0, p1 = p_coords[0], p_coords[-1]
+
+        def _d(a: tuple[float, float], b: tuple[float, float]) -> float:
+            return math.hypot(a[0] - b[0], a[1] - b[1])
+
+        # Pick the terminal pairing (straight vs. crossed) that yields the
+        # shorter total closing length -- i.e. the simple, non-self-crossing
+        # polygon -- then walk sense forward and return backward.
+        straight = _d(s0, p0) + _d(s1, p1)
+        crossed = _d(s0, p1) + _d(s1, p0)
+        if straight <= crossed:
+            ring = s_coords + p_coords[::-1]
+        else:
+            ring = s_coords + p_coords
+
+        poly = Polygon(ring)
+        if not poly.is_valid:
+            poly = poly.buffer(0)
+        area = float(poly.area)
+        if area <= 0.0:
+            return None, "loop did not close (zero enclosed area)"
+        return area, None
+
+    @staticmethod
+    def _merge_conductor(segs: list[Segment], vias: list[Via]) -> Any:
+        """Merge a net's segments into ordered polyline(s).
+
+        Endpoints are rounded to ``_SNAP_TOL_MM`` and snapped to any nearby via
+        position so numerically-coincident joints and via transitions chain
+        into one polyline via ``shapely.ops.linemerge``. Returns a shapely
+        ``LineString`` / ``MultiLineString``, or ``None`` if there is no usable
+        geometry.
+        """
+        from shapely.geometry import LineString
+        from shapely.ops import linemerge  # type: ignore[import-untyped]
+
+        via_positions = [tuple(v.position) for v in vias]
+
+        def snap(pt: tuple[float, float]) -> tuple[float, float]:
+            for vp in via_positions:
+                if abs(pt[0] - vp[0]) <= _SNAP_TOL_MM and abs(pt[1] - vp[1]) <= _SNAP_TOL_MM:
+                    return (round(vp[0], 3), round(vp[1], 3))
+            return (round(pt[0], 3), round(pt[1], 3))
+
+        lines = []
+        for seg in segs:
+            a = snap(seg.start)
+            b = snap(seg.end)
+            if a != b:
+                lines.append(LineString([a, b]))
+
+        if not lines:
+            return None
+        if len(lines) == 1:
+            return lines[0]
+        return linemerge(lines)
 
     def _analyze_sense_net(
         self,

--- a/src/kicad_tools/cli/analyze_cmd.py
+++ b/src/kicad_tools/cli/analyze_cmd.py
@@ -294,6 +294,33 @@ def main(argv: list[str] | None = None) -> int:
         help="Edge-to-edge gap FAIL threshold in mm (default: 0.5)",
     )
     current_sense_parser.add_argument(
+        "--max-loop-area",
+        type=float,
+        default=10.0,
+        help=(
+            "Enclosed copper sense-loop area FAIL threshold in mm^2 (default: 10.0; EE-confirmable)"
+        ),
+    )
+    current_sense_parser.add_argument(
+        "--sense-pair",
+        action="append",
+        nargs=2,
+        dest="sense_pairs",
+        default=[],
+        metavar=("SENSE", "RETURN"),
+        help=(
+            "Kelvin loop pairing: close SENSE's loop with RETURN conductor "
+            "(repeatable). Nets ending _P/_N, +/-, _H/_L auto-pair."
+        ),
+    )
+    current_sense_parser.add_argument(
+        "--sense-return",
+        dest="sense_return",
+        default=None,
+        metavar="NAME",
+        help="Shared return conductor (e.g. Kelvin ground) to close sense loops",
+    )
+    current_sense_parser.add_argument(
         "--quiet",
         "-q",
         action="store_true",
@@ -1229,22 +1256,30 @@ def _run_current_sense_analysis(args: argparse.Namespace) -> int:
         min_gap_mm=args.min_gap,
         sense_nets=list(getattr(args, "sense_nets", []) or []),
         hicur_nets=list(getattr(args, "hicur_nets", []) or []),
+        max_loop_area_mm2=getattr(args, "max_loop_area", 10.0),
+        sense_pairs=list(getattr(args, "sense_pairs", []) or []),
+        sense_return=getattr(args, "sense_return", None),
     )
     results = analyzer.analyze(pcb)
 
     if args.format == "json":
-        _output_current_sense_json(results, args.max_parallel, args.min_gap)
+        _output_current_sense_json(
+            results, args.max_parallel, args.min_gap, getattr(args, "max_loop_area", 10.0)
+        )
     else:
         _output_current_sense_text(
             results,
             pcb_path.name,
             args.max_parallel,
             args.min_gap,
+            getattr(args, "max_loop_area", 10.0),
             quiet=args.quiet,
         )
 
-    # Non-zero exit when any sense net FAILs (CI-gateable).
-    if any(r.status == "FAIL" for r in results):
+    # Non-zero exit when any Phase-1 parallel/gap FAIL OR any loop-area FAIL is
+    # present (both are CI-gateable). No closable loop (loop_status None) does
+    # not gate.
+    if any(r.status == "FAIL" or r.loop_status == "FAIL" for r in results):
         return 1
     return 0
 
@@ -1253,19 +1288,23 @@ def _output_current_sense_json(
     results: list,
     max_parallel_mm: float,
     min_gap_mm: float,
+    max_loop_area_mm2: float,
 ) -> None:
     """Output current-sense census as JSON (mirrors signal-integrity JSON)."""
     fail_count = sum(1 for r in results if r.status == "FAIL")
+    loop_fail_count = sum(1 for r in results if r.loop_status == "FAIL")
     output = {
         "census": [r.to_dict() for r in results],
         "thresholds": {
             "max_parallel_mm": max_parallel_mm,
             "min_gap_mm": min_gap_mm,
+            "max_loop_area_mm2": max_loop_area_mm2,
         },
         "summary": {
             "total": len(results),
             "fail": fail_count,
             "pass": len(results) - fail_count,
+            "loop_fail": loop_fail_count,
         },
     }
     print(json.dumps(output, indent=2))
@@ -1276,6 +1315,7 @@ def _output_current_sense_text(
     filename: str,
     max_parallel_mm: float,
     min_gap_mm: float,
+    max_loop_area_mm2: float,
     quiet: bool = False,
 ) -> None:
     """Output current-sense census as a formatted table."""
@@ -1290,22 +1330,30 @@ def _output_current_sense_text(
         console.print(f"\n[bold]Current-Sense Layout Lint: {filename}[/bold]")
         console.print(
             f"[dim]FAIL when parallel-run >= {max_parallel_mm:.2f}mm AND "
-            f"gap <= {min_gap_mm:.2f}mm (same layer)[/dim]\n"
+            f"gap <= {min_gap_mm:.2f}mm (same layer); "
+            f"loop FAIL when enclosed area > {max_loop_area_mm2:.2f}mm^2[/dim]\n"
         )
 
     table = Table(show_header=True)
+    # Phase-1 columns (order preserved); loop_area_mm2 is appended (Phase 2).
     table.add_column("sense_net", style="cyan")
     table.add_column("nearest_hicur_net")
     table.add_column("layer")
     table.add_column("max_parallel_mm", justify="right")
     table.add_column("min_gap_mm", justify="right")
     table.add_column("status", justify="center")
+    table.add_column("loop_area_mm2", justify="right")
 
     for r in results:
         status_style = "red bold" if r.status == "FAIL" else "green"
         nearest = r.nearest_hicur_net if r.nearest_hicur_net is not None else "-"
         layer = r.layer if r.layer is not None else "-"
         gap_str = "-" if r.min_gap_mm is None else f"{r.min_gap_mm:.3f}"
+        if r.loop_area_mm2 is None:
+            loop_str = "-"
+        else:
+            loop_style = "red bold" if r.loop_status == "FAIL" else "green"
+            loop_str = f"[{loop_style}]{r.loop_area_mm2:.3f}[/{loop_style}]"
         table.add_row(
             r.sense_net,
             nearest,
@@ -1313,16 +1361,19 @@ def _output_current_sense_text(
             f"{r.max_parallel_mm:.3f}",
             gap_str,
             f"[{status_style}]{r.status}[/{status_style}]",
+            loop_str,
         )
 
     console.print(table)
 
     fail_count = sum(1 for r in results if r.status == "FAIL")
+    loop_fail_count = sum(1 for r in results if r.loop_status == "FAIL")
     console.print()
-    summary_style = "red bold" if fail_count else "green"
+    summary_style = "red bold" if (fail_count or loop_fail_count) else "green"
     console.print(
         f"[{summary_style}]Total: {len(results)} sense nets, "
-        f"{fail_count} FAIL, {len(results) - fail_count} PASS[/{summary_style}]"
+        f"{fail_count} FAIL, {len(results) - fail_count} PASS "
+        f"({loop_fail_count} loop-area FAIL)[/{summary_style}]"
     )
 
 

--- a/src/kicad_tools/cli/commands/analyze.py
+++ b/src/kicad_tools/cli/commands/analyze.py
@@ -127,6 +127,12 @@ def _run_current_sense_command(args) -> int:
         sub_argv.extend(["--max-parallel", str(args.analyze_max_parallel)])
     if getattr(args, "analyze_min_gap", 0.5) != 0.5:
         sub_argv.extend(["--min-gap", str(args.analyze_min_gap)])
+    if getattr(args, "analyze_max_loop_area", 10.0) != 10.0:
+        sub_argv.extend(["--max-loop-area", str(args.analyze_max_loop_area)])
+    for pair in getattr(args, "analyze_sense_pairs", None) or []:
+        sub_argv.extend(["--sense-pair", pair[0], pair[1]])
+    if getattr(args, "analyze_sense_return", None):
+        sub_argv.extend(["--sense-return", args.analyze_sense_return])
     if getattr(args, "global_quiet", False):
         sub_argv.append("--quiet")
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -5411,6 +5411,34 @@ def _add_analyze_parser(subparsers) -> None:
         default=0.5,
         help="Edge-to-edge gap FAIL threshold in mm (default: 0.5)",
     )
+    current_sense_parser.add_argument(
+        "--max-loop-area",
+        dest="analyze_max_loop_area",
+        type=float,
+        default=10.0,
+        help=(
+            "Enclosed copper sense-loop area FAIL threshold in mm^2 (default: 10.0; EE-confirmable)"
+        ),
+    )
+    current_sense_parser.add_argument(
+        "--sense-pair",
+        action="append",
+        nargs=2,
+        dest="analyze_sense_pairs",
+        default=[],
+        metavar=("SENSE", "RETURN"),
+        help=(
+            "Kelvin loop pairing: close SENSE's loop with RETURN conductor "
+            "(repeatable). Nets ending _P/_N, +/-, _H/_L auto-pair."
+        ),
+    )
+    current_sense_parser.add_argument(
+        "--sense-return",
+        dest="analyze_sense_return",
+        default=None,
+        metavar="NAME",
+        help="Shared return conductor (e.g. Kelvin ground) to close sense loops",
+    )
 
 
 def _add_constraints_parser(subparsers) -> None:

--- a/tests/test_current_sense.py
+++ b/tests/test_current_sense.py
@@ -266,7 +266,10 @@ class TestResultDict:
     def test_to_dict_keys(self, tmp_path: Path) -> None:
         pcb = _load(tmp_path, FAIL_PCB)
         d = CurrentSenseAnalyzer().analyze(pcb)[0].to_dict()
-        assert set(d) == {
+        # Phase-1 keys are all still present (additive-output guarantee); the
+        # Phase-2 keys are added alongside them. ISENSE has no return conductor
+        # here, so loop_reason is present.
+        assert {
             "sense_net",
             "nearest_hicur_net",
             "layer",
@@ -274,8 +277,12 @@ class TestResultDict:
             "min_gap_mm",
             "status",
             "margin",
-        }
+        }.issubset(set(d))
         assert d["status"] == "FAIL"
+        # Phase-2 additive keys.
+        assert d["loop_area_mm2"] is None
+        assert d["loop_status"] is None
+        assert d["loop_reason"]
 
     def test_to_dict_no_neighbor_is_json_safe(self, tmp_path: Path) -> None:
         pcb = _load(tmp_path, DIFFERENT_LAYER_PCB)
@@ -317,9 +324,11 @@ class TestCli:
         assert rc == 1
         payload = json.loads(capsys.readouterr().out)
         assert set(payload) == {"census", "thresholds", "summary"}
-        assert payload["summary"] == {"total": 1, "fail": 1, "pass": 0}
+        # Phase-1 summary keys unchanged; Phase-2 adds loop_fail.
+        assert payload["summary"] == {"total": 1, "fail": 1, "pass": 0, "loop_fail": 0}
         assert payload["thresholds"]["max_parallel_mm"] == 10.0
         assert payload["thresholds"]["min_gap_mm"] == 0.5
+        assert payload["thresholds"]["max_loop_area_mm2"] == 10.0
         row = payload["census"][0]
         assert row["sense_net"] == "ISENSE"
         assert row["nearest_hicur_net"] == "PHASE_A"
@@ -373,3 +382,268 @@ def test_result_dataclass_direct() -> None:
         margin_mm=None,
     )
     assert r.to_dict()["status"] == "PASS"
+    # Phase-2 fields default to null on direct construction.
+    assert r.loop_area_mm2 is None
+    assert r.loop_status is None
+    assert r.loop_reason is None
+    d = r.to_dict()
+    assert d["loop_area_mm2"] is None
+    assert d["loop_status"] is None
+    assert "loop_reason" not in d  # omitted when null
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 (#4330): copper sense-loop area
+# ---------------------------------------------------------------------------
+
+# A Kelvin sense pair ISENSE_P / ISENSE_N forming a 20mm x 2mm rectangle:
+# enclosed area = 40 mm^2 (well above the 10 mm^2 default) => loop FAIL.
+LARGE_LOOP_PCB = (
+    _HEADER
+    + """
+  (net 0 "")
+  (net 1 "ISENSE_P")
+  (net 2 "ISENSE_N")
+  (segment (start 0 0) (end 20 0) (width 0.2) (layer "F.Cu") (net 1))
+  (segment (start 0 2) (end 20 2) (width 0.2) (layer "F.Cu") (net 2))
+)
+"""
+)
+
+# Same topology but 2mm x 0.3mm => 0.6 mm^2 => loop PASS.
+TIGHT_LOOP_PCB = (
+    _HEADER
+    + """
+  (net 0 "")
+  (net 1 "ISENSE_P")
+  (net 2 "ISENSE_N")
+  (segment (start 0 0) (end 2 0) (width 0.2) (layer "F.Cu") (net 1))
+  (segment (start 0 0.3) (end 2 0.3) (width 0.2) (layer "F.Cu") (net 2))
+)
+"""
+)
+
+# Each conductor drawn as two collinear segments that linemerge must join into
+# a single 20mm polyline before closure. Same 20mm x 2mm = 40 mm^2 loop.
+MULTI_SEGMENT_LOOP_PCB = (
+    _HEADER
+    + """
+  (net 0 "")
+  (net 1 "ISENSE_P")
+  (net 2 "ISENSE_N")
+  (segment (start 0 0) (end 10 0) (width 0.2) (layer "F.Cu") (net 1))
+  (segment (start 10 0) (end 20 0) (width 0.2) (layer "F.Cu") (net 1))
+  (segment (start 0 2) (end 10 2) (width 0.2) (layer "F.Cu") (net 2))
+  (segment (start 10 2) (end 20 2) (width 0.2) (layer "F.Cu") (net 2))
+)
+"""
+)
+
+# ISENSE_P split across F.Cu / B.Cu joined by a via at the shared position
+# (10,0); ISENSE_N is a single 20mm return. Same 40 mm^2 loop when bridged.
+VIA_LOOP_PCB = (
+    _HEADER
+    + """
+  (net 0 "")
+  (net 1 "ISENSE_P")
+  (net 2 "ISENSE_N")
+  (segment (start 0 0) (end 10 0) (width 0.2) (layer "F.Cu") (net 1))
+  (segment (start 10 0) (end 20 0) (width 0.2) (layer "B.Cu") (net 1))
+  (via (at 10 0) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 1))
+  (segment (start 0 2) (end 20 2) (width 0.2) (layer "F.Cu") (net 2))
+)
+"""
+)
+
+# A lone sense net with no pair/return => single-ended, not closable.
+SINGLE_ENDED_PCB = (
+    _HEADER
+    + """
+  (net 0 "")
+  (net 1 "ISENSE_P")
+  (segment (start 0 0) (end 20 0) (width 0.2) (layer "F.Cu") (net 1))
+)
+"""
+)
+
+
+class TestLoopArea:
+    def test_large_loop_fails(self, tmp_path: Path) -> None:
+        pcb = _load(tmp_path, LARGE_LOOP_PCB)
+        results = CurrentSenseAnalyzer().analyze(pcb)
+        by_net = {r.sense_net: r for r in results}
+        r = by_net["ISENSE_P"]
+        assert r.loop_area_mm2 == pytest.approx(40.0, rel=0.01)
+        assert r.loop_status == "FAIL"
+        assert r.loop_reason is None
+        # The auto-paired partner row reports the same loop.
+        assert by_net["ISENSE_N"].loop_area_mm2 == pytest.approx(40.0, rel=0.01)
+        assert by_net["ISENSE_N"].loop_status == "FAIL"
+
+    def test_tight_loop_passes(self, tmp_path: Path) -> None:
+        pcb = _load(tmp_path, TIGHT_LOOP_PCB)
+        r = {x.sense_net: x for x in CurrentSenseAnalyzer().analyze(pcb)}["ISENSE_P"]
+        assert r.loop_area_mm2 == pytest.approx(0.6, rel=0.01)
+        assert r.loop_status == "PASS"
+        assert r.loop_reason is None
+
+    def test_multi_segment_loop_merges(self, tmp_path: Path) -> None:
+        pcb = _load(tmp_path, MULTI_SEGMENT_LOOP_PCB)
+        r = {x.sense_net: x for x in CurrentSenseAnalyzer().analyze(pcb)}["ISENSE_P"]
+        # Matches the single-polyline 40 mm^2 equivalent.
+        assert r.loop_area_mm2 == pytest.approx(40.0, rel=0.01)
+        assert r.loop_status == "FAIL"
+
+    def test_via_transitioned_loop(self, tmp_path: Path) -> None:
+        pcb = _load(tmp_path, VIA_LOOP_PCB)
+        r = {x.sense_net: x for x in CurrentSenseAnalyzer().analyze(pcb)}["ISENSE_P"]
+        # Bridged at the via position => correct 40 mm^2 area (never a crash).
+        assert r.loop_area_mm2 == pytest.approx(40.0, rel=0.01)
+        assert r.loop_status == "FAIL"
+
+    def test_single_ended_is_null_with_reason(self, tmp_path: Path) -> None:
+        pcb = _load(tmp_path, SINGLE_ENDED_PCB)
+        r = {x.sense_net: x for x in CurrentSenseAnalyzer().analyze(pcb)}["ISENSE_P"]
+        assert r.loop_area_mm2 is None
+        assert r.loop_status is None  # never a default FAIL
+        assert r.loop_reason  # a reason is set
+        assert "closable" in r.loop_reason or "close" in r.loop_reason
+
+    def test_explicit_sense_pair(self, tmp_path: Path) -> None:
+        # Two sense nets whose names do NOT auto-pair, joined explicitly.
+        text = (
+            _HEADER
+            + """
+  (net 0 "")
+  (net 1 "ISENSE")
+  (net 2 "IRETURN")
+  (segment (start 0 0) (end 20 0) (width 0.2) (layer "F.Cu") (net 1))
+  (segment (start 0 2) (end 20 2) (width 0.2) (layer "F.Cu") (net 2))
+)
+"""
+        )
+        pcb = _load(tmp_path, text)
+        analyzer = CurrentSenseAnalyzer(
+            sense_nets=["ISENSE", "IRETURN"],
+            sense_pairs=[("ISENSE", "IRETURN")],
+        )
+        r = {x.sense_net: x for x in analyzer.analyze(pcb)}["ISENSE"]
+        assert r.loop_area_mm2 == pytest.approx(40.0, rel=0.01)
+        assert r.loop_status == "FAIL"
+
+    def test_sense_return_shared_conductor(self, tmp_path: Path) -> None:
+        text = (
+            _HEADER
+            + """
+  (net 0 "")
+  (net 1 "ISENSE")
+  (net 2 "AGND")
+  (segment (start 0 0) (end 2 0) (width 0.2) (layer "F.Cu") (net 1))
+  (segment (start 0 0.3) (end 2 0.3) (width 0.2) (layer "F.Cu") (net 2))
+)
+"""
+        )
+        pcb = _load(tmp_path, text)
+        analyzer = CurrentSenseAnalyzer(sense_nets=["ISENSE"], sense_return="AGND")
+        r = {x.sense_net: x for x in analyzer.analyze(pcb)}["ISENSE"]
+        assert r.loop_area_mm2 == pytest.approx(0.6, rel=0.01)
+        assert r.loop_status == "PASS"
+
+    def test_custom_max_loop_area_flips_status(self, tmp_path: Path) -> None:
+        pcb = _load(tmp_path, LARGE_LOOP_PCB)
+        # Raise the threshold above 40 mm^2 => the same loop now PASSes.
+        r = {x.sense_net: x for x in CurrentSenseAnalyzer(max_loop_area_mm2=100.0).analyze(pcb)}[
+            "ISENSE_P"
+        ]
+        assert r.loop_area_mm2 == pytest.approx(40.0, rel=0.01)
+        assert r.loop_status == "PASS"
+
+
+class TestLoopAreaCli:
+    def test_additive_json_keys(self, tmp_path: Path, capsys) -> None:
+        pcb = _write(tmp_path, LARGE_LOOP_PCB)
+        rc = analyze_main(["current-sense", str(pcb), "--format", "json"])
+        assert rc == 1  # loop-area FAIL gates
+        payload = json.loads(capsys.readouterr().out)
+        # Phase-1 census keys still present alongside the new ones.
+        row = payload["census"][0]
+        for key in (
+            "sense_net",
+            "nearest_hicur_net",
+            "layer",
+            "max_parallel_mm",
+            "min_gap_mm",
+            "status",
+            "margin",
+        ):
+            assert key in row
+        assert "loop_area_mm2" in row
+        assert "loop_status" in row
+        assert payload["thresholds"]["max_loop_area_mm2"] == 10.0
+        assert payload["summary"]["loop_fail"] >= 1
+
+    def test_loop_only_fail_exit_code(self, tmp_path: Path, capsys) -> None:
+        # Loop FAIL with NO Phase-1 parallel/gap FAIL still exits non-zero.
+        pcb = _write(tmp_path, LARGE_LOOP_PCB)
+        rc = analyze_main(["current-sense", str(pcb), "--format", "json"])
+        assert rc == 1
+        payload = json.loads(capsys.readouterr().out)
+        # Confirm no Phase-1 FAIL drove the exit (nets are 2mm apart, parallel
+        # 20mm: gap 1.8mm > 0.5mm default => Phase-1 PASS).
+        assert payload["summary"]["fail"] == 0
+        assert payload["summary"]["loop_fail"] >= 1
+
+    def test_tight_loop_all_pass_exit_zero(self, tmp_path: Path, capsys) -> None:
+        pcb = _write(tmp_path, TIGHT_LOOP_PCB)
+        rc = analyze_main(["current-sense", str(pcb)])
+        assert rc == 0
+
+    def test_max_loop_area_flag(self, tmp_path: Path, capsys) -> None:
+        pcb = _write(tmp_path, LARGE_LOOP_PCB)
+        rc = analyze_main(["current-sense", str(pcb), "--max-loop-area", "100"])
+        assert rc == 0  # threshold raised above the 40 mm^2 loop
+
+    def test_sense_pair_flag(self, tmp_path: Path, capsys) -> None:
+        text = (
+            _HEADER
+            + """
+  (net 0 "")
+  (net 1 "ISENSE")
+  (net 2 "IRETURN")
+  (segment (start 0 0) (end 20 0) (width 0.2) (layer "F.Cu") (net 1))
+  (segment (start 0 2) (end 20 2) (width 0.2) (layer "F.Cu") (net 2))
+)
+"""
+        )
+        pcb = _write(tmp_path, text)
+        rc = analyze_main(
+            [
+                "current-sense",
+                str(pcb),
+                "--sense-net",
+                "ISENSE",
+                "--sense-net",
+                "IRETURN",
+                "--sense-pair",
+                "ISENSE",
+                "IRETURN",
+                "--format",
+                "json",
+            ]
+        )
+        assert rc == 1
+        payload = json.loads(capsys.readouterr().out)
+        row = {r["sense_net"]: r for r in payload["census"]}["ISENSE"]
+        assert row["loop_area_mm2"] == pytest.approx(40.0, rel=0.01)
+        assert row["loop_status"] == "FAIL"
+
+    def test_text_output_has_loop_column(self, tmp_path: Path, capsys) -> None:
+        pcb = _write(tmp_path, LARGE_LOOP_PCB)
+        rc = analyze_main(["current-sense", str(pcb)])
+        assert rc == 1
+        out = capsys.readouterr().out
+        # The enclosed loop area is rendered and the loop-area FAIL is counted
+        # in the summary alongside the (unchanged) Phase-1 PASS/FAIL tally.
+        assert "40.000" in out
+        assert "loop-area FAIL" in out
+        assert "2 PASS" in out


### PR DESCRIPTION
## Summary

Phase 2 of #4328 (Phase 1 merged via #4335). Additively extends `kct analyze current-sense` with an enclosed **copper sense-loop area** metric. A large-area Kelvin sense loop couples magnetic switching noise into the measurement; this flags it, advisory-only, alongside the Phase-1 parallel-run/gap census.

All Phase-1 output (fields, `to_dict` keys, the six text columns, JSON `thresholds`/`summary` keys, exit-code semantics) is preserved unchanged — everything here is additive.

## What changed

- **`analysis/current_sense.py`**
  - `CurrentSenseResult` gains optional `loop_area_mm2` / `loop_status` / `loop_reason` (default `None`). `to_dict()` adds `loop_area_mm2` + `loop_status` always, `loop_reason` only when set.
  - `CurrentSenseAnalyzer` resolves each sense net's return conductor via explicit `--sense-pair`, shared `--sense-return`, or the `_P`/`_N`, `+`/`-`, `_H`/`_L` suffix auto-pair convention. Each conductor's segments are merged into an ordered polyline with `shapely.ops.linemerge` (endpoints snapped ~1e-3 mm and to shared `Via.position` to bridge via transitions), closed at the nearest terminals, and measured via `Polygon.area` (mm²). Reuses the `board_geometry` shapely precedent rather than hand-rolling a shoelace. Any geometry failure degrades to `loop_area_mm2=None` + `loop_reason` and **never raises**.
- **CLI (all three layers)**: new `--max-loop-area` (default **10.0 mm²**, EE-confirmable) + `--sense-pair SENSE RETURN` (repeatable) + `--sense-return NAME`, wired through `analyze_cmd.py` (subparser, runner, JSON, text), `parser.py`, and the `commands/analyze.py` forwarder. JSON `thresholds` gains `max_loop_area_mm2`; `summary` gains `loop_fail`; the text table gains a right-justified `loop_area_mm2` column (no reordering) rendering loop FAIL in red. Exit code is non-zero on a Phase-1 **or** a loop-area FAIL.

## Tests (`tests/test_current_sense.py`)

Large-loop → FAIL (40 mm², matches hand computation exactly), tight-loop → PASS (0.6 mm²), multi-segment `linemerge`, via-transitioned bridge, single-ended → `None`+reason (no crash, no default FAIL), explicit `--sense-pair`/`--sense-return`, threshold flip, additive-output guard, loop-only-FAIL exit code. Existing exact-set assertions updated to reflect the additive keys.

## Local checks
- `uv run pytest tests/test_current_sense.py` → **36 passed**
- analyze/board_geometry suites → **342 passed, 13 skipped**
- `uv run ruff check .` / `ruff format . --check` → clean
- mypy baseline gate (`scripts/ci/check_mypy_baseline.py`) → **no new errors** (1473 ≤ 1474 allowed)

Closes #4330

🤖 Generated with [Claude Code](https://claude.com/claude-code)