### PR TITLE
feat(creepage): derive required creepage/clearance from IEC 60664-1 / 62368-1 tables

### DIFF
--- a/src/kicad_tools/cli/commands/creepage.py
+++ b/src/kicad_tools/cli/commands/creepage.py
@@ -1,13 +1,24 @@
-"""``kct creepage`` command handler (Issue #4327, phase 1 MVP).
+"""``kct creepage`` command handler (Issue #4327 phase 1, #4332 phase 2).
 
 Measures per-pair surface-path (creepage) distance between an HV net group
 and every other conductor / board edge, honoring milled Edge.Cuts slots, and
 reports a **census** (all pairs + margin, not just violations) with clearance
 (through-air) and creepage (over-surface) reported as distinct values.
 
-The required minimum is supplied by the operator via ``--min`` (phase 1 does
-not know IEC table values -- that is #4332).  Exit is non-zero iff any pair's
-creepage falls below ``--min``.
+The required threshold comes from one of two sources:
+
+* ``--min`` -- the operator supplies the required creepage directly (phase 1).
+* ``--standard`` -- the required creepage AND clearance are *derived* from an
+  IEC 60664-1 / 62368-1 table for a ``(working voltage, pollution degree,
+  material group)`` triple (phase 2, #4332).
+
+When both are supplied the stricter (larger) creepage bound governs per pair.
+Exit is non-zero iff any pair fails its governing creepage bound or (in
+standard mode) its derived clearance bound.
+
+.. warning::
+   The derived values are an engineering aid, NOT a certification.  The
+   governing standard and a qualified engineer are authoritative.
 """
 
 from __future__ import annotations
@@ -25,6 +36,11 @@ def run_creepage_command(args) -> int:
     """Handle the ``creepage`` command.  Returns the process exit code."""
     from kicad_tools._shapely import has_shapely
     from kicad_tools.creepage.engine import compute_creepage_census, resolve_hv_nets
+    from kicad_tools.creepage.standards import (
+        RMS_TO_PEAK,
+        StandardLookupError,
+        get_standard,
+    )
     from kicad_tools.schema.pcb import PCB
 
     fmt = getattr(args, "format", "table") or "table"
@@ -42,6 +58,51 @@ def run_creepage_command(args) -> int:
     if not pcb_path.exists():
         print(f"Error: PCB file not found: {pcb_path}", file=sys.stderr)
         return 1
+
+    # --- Threshold-source resolution (phase 1 --min vs phase 2 --standard) ---
+    min_arg = getattr(args, "min", None)
+    min_mm = float(min_arg) if min_arg is not None else None
+    standard_id = getattr(args, "standard", None)
+
+    if standard_id is None and min_mm is None:
+        print(
+            "Error: provide either --standard (with --working-voltage and "
+            "--pollution-degree) or --min.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Phase-2 derived requirements (None in phase-1 mode).
+    required_creepage_mm: float | None = None
+    required_clearance_mm: float | None = None
+    creepage_prov: dict | None = None
+    clearance_prov: dict | None = None
+    standard_edition: str | None = None
+    working_voltage = getattr(args, "working_voltage", None)
+    pollution_degree = getattr(args, "pollution_degree", None)
+    material_group = getattr(args, "material_group", "IIIa")
+
+    if standard_id is not None:
+        if working_voltage is None or pollution_degree is None:
+            print(
+                "Error: --standard requires both --working-voltage and --pollution-degree.",
+                file=sys.stderr,
+            )
+            return 1
+        try:
+            std = get_standard(standard_id)
+            required_creepage_mm, creepage_prov = std.required_creepage(
+                float(working_voltage), int(pollution_degree), material_group
+            )
+            peak_voltage = float(working_voltage) * RMS_TO_PEAK
+            required_clearance_mm, clearance_prov = std.required_clearance(
+                peak_voltage, int(pollution_degree)
+            )
+            standard_edition = std.edition
+        except StandardLookupError as e:
+            # Safety-critical: fail LOUD, never emit a guessed number.
+            print(f"Error: standard-table lookup failed: {e}", file=sys.stderr)
+            return 1
 
     # Load the optional net-class map sidecar (reuses net_class_map_from_dict).
     net_class_map = None
@@ -64,7 +125,6 @@ def run_creepage_command(args) -> int:
 
     pcb = PCB.load(pcb_path)
     net_class = getattr(args, "net_class", "HV") or "HV"
-    min_mm = float(args.min)
 
     hv_nets = resolve_hv_nets(pcb, net_class, net_class_map)
     report = compute_creepage_census(
@@ -73,20 +133,31 @@ def run_creepage_command(args) -> int:
         min_mm,
         net_class=net_class,
         board=str(pcb_path),
+        required_creepage_mm=required_creepage_mm,
+        required_clearance_mm=required_clearance_mm,
+        standard=standard_id,
+        standard_edition=standard_edition,
+        working_voltage=working_voltage,
+        pollution_degree=pollution_degree,
+        material_group=material_group if standard_id is not None else None,
+        creepage_provenance=creepage_prov,
+        clearance_provenance=clearance_prov,
     )
 
     if fmt == "json":
         print(json.dumps(report.to_dict(), indent=2))
+    elif report.uses_standard:
+        _render_table_standard(report)
     else:
         _render_table(report)
 
-    # Non-zero exit iff any pair's creepage < --min.  An empty census
+    # Non-zero exit iff any pair fails its governing bound(s).  An empty census
     # (no HV nets, or HV nets with no neighbors) is a clean exit 0.
     return 0 if report.passed else 1
 
 
 def _render_table(report: CreepageReport) -> None:
-    """Print the human-readable census table."""
+    """Print the human-readable census table (phase-1 / manual --min mode)."""
     if not report.has_hv_nets:
         print(
             f"No '{report.net_class}' nets found "
@@ -127,3 +198,80 @@ def _render_table(report: CreepageReport) -> None:
         print(f"FAIL: {len(failures)}/{total} pair(s) below {report.min_mm:.3f} mm creepage.")
     else:
         print(f"PASS: all {total} pair(s) clear {report.min_mm:.3f} mm creepage.")
+
+
+def _render_table_standard(report: CreepageReport) -> None:
+    """Print the census table with IEC-derived requirements (phase-2 mode)."""
+    from kicad_tools.creepage.standards import DISCLAIMER
+
+    if not report.has_hv_nets:
+        print(
+            f"No '{report.net_class}' nets found "
+            "(supply --net-class-map to classify HV nets, or check --net-class)."
+        )
+        print(f"Board: {report.board}")
+        print("Census: 0 pairs.  Nothing to audit -- exit 0.")
+        return
+
+    cp = report.creepage_provenance or {}
+    clp = report.clearance_provenance or {}
+    std_name = cp.get("standard", report.standard)
+    print(f"HV creepage/clearance census  (net-class '{report.net_class}')")
+    print(f"Board: {report.board}")
+    print(f"Standard: {std_name} {report.standard_edition}  (--standard {report.standard})")
+    print(
+        f"Working voltage: {report.working_voltage:g} V RMS  "
+        f"(peak ~ {clp.get('peak_voltage_v', 0.0):.0f} V)  |  "
+        f"Pollution degree: {report.pollution_degree}  |  "
+        f"Material group: {report.material_group}"
+    )
+    if report.required_creepage_mm is not None:
+        print(
+            f"Derived required creepage: {report.required_creepage_mm:.3f} mm  "
+            f"[{cp.get('table_id', '?')}, {cp.get('voltage_row_used_v', '?')} V row, "
+            f"step-up]"
+        )
+    if report.required_clearance_mm is not None:
+        print(
+            f"Derived required clearance: {report.required_clearance_mm:.3f} mm  "
+            f"[{clp.get('table_id', '?')}, {clp.get('governing_component', '?')}, "
+            f"altitude {clp.get('altitude_assumption', '?')}]"
+        )
+    if report.min_mm is not None:
+        print(f"Manual override (--min): {report.min_mm:.3f} mm  (stricter governs)")
+    print(f"HV nets ({len(report.hv_nets)}): {', '.join(report.hv_nets)}")
+    print(f"NOTE: {DISCLAIMER}")
+    print()
+
+    if not report.pairs:
+        print("Census: 0 pairs (HV nets present but no other conductors / edge found).")
+        return
+
+    header = (
+        f"{'HV net':<14} {'Against':<14} {'Layer':<6} "
+        f"{'Clnce':>8} {'ReqCl':>8} {'Creep':>8} {'ReqCr':>8} "
+        f"{'Margin':>8} {'Govern':>8} {'Result':>7}"
+    )
+    print(header)
+    print("-" * len(header))
+    for p in report.pairs:
+        result = "PASS" if p.passed else "FAIL"
+        req_cl = p.required_clearance_mm if p.required_clearance_mm is not None else 0.0
+        req_cr = p.required_creepage_mm if p.required_creepage_mm is not None else 0.0
+        print(
+            f"{p.net_a:<14} {p.net_b:<14} {p.layer:<6} "
+            f"{p.clearance_mm:>8.3f} {req_cl:>8.3f} "
+            f"{p.creepage_mm:>8.3f} {req_cr:>8.3f} "
+            f"{p.margin_mm:>8.3f} {p.governing_bound:>8} {result:>7}"
+        )
+
+    print()
+    failures = [p for p in report.pairs if not p.passed]
+    total = len(report.pairs)
+    if failures:
+        print(
+            f"FAIL: {len(failures)}/{total} pair(s) fail the derived creepage/clearance "
+            "requirement."
+        )
+    else:
+        print(f"PASS: all {total} pair(s) clear the derived creepage/clearance requirement.")

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -448,11 +448,59 @@ def _add_creepage_parser(subparsers) -> None:
     creepage_parser.add_argument(
         "--min",
         type=float,
-        required=True,
+        default=None,
         help=(
-            "Required minimum creepage (surface-path) distance in mm.  Exit "
-            "is non-zero if any pair's creepage falls below this value.  "
-            "Phase 1 has no IEC tables (see #4332); the operator supplies it."
+            "Required minimum creepage (surface-path) distance in mm.  Manual "
+            "override / phase-1 mode.  Optional when --standard is supplied; "
+            "when BOTH are given the stricter (larger) of {manual, derived} "
+            "governs per pair.  Provide either --standard or --min."
+        ),
+    )
+    # Phase 2 (#4332): derive the required creepage/clearance from an IEC table.
+    creepage_parser.add_argument(
+        "--standard",
+        choices=["iec60664", "iec62368"],
+        default=None,
+        help=(
+            "Derive the required creepage (and clearance) from an IEC "
+            "standard table instead of --min: iec60664 (IEC 60664-1 Table F.4 "
+            "creepage / Table F.2 clearance) or iec62368 (IEC 62368-1 Table 17 "
+            "/ Table 14).  Requires --working-voltage and --pollution-degree.  "
+            "Engineering aid, NOT a certification."
+        ),
+    )
+    creepage_parser.add_argument(
+        "--pollution-degree",
+        dest="pollution_degree",
+        type=int,
+        choices=[1, 2, 3],
+        default=None,
+        help=(
+            "IEC pollution degree (1=sealed, 2=typical indoor/office FR-4, "
+            "3=conductive pollution).  Required with --standard."
+        ),
+    )
+    creepage_parser.add_argument(
+        "--working-voltage",
+        dest="working_voltage",
+        type=float,
+        default=None,
+        help=(
+            "RMS working voltage in volts.  Creepage keys on this RMS value "
+            "directly (step-up to the next-higher tabulated row, never "
+            "interpolated); clearance keys on its peak (RMS x sqrt(2), "
+            "sinusoidal assumption).  Required with --standard."
+        ),
+    )
+    creepage_parser.add_argument(
+        "--material-group",
+        dest="material_group",
+        choices=["I", "II", "IIIa", "IIIb"],
+        default="IIIa",
+        help=(
+            "Insulation material group by CTI (I: CTI>=600, II: 400<=CTI<600, "
+            "IIIa: 175<=CTI<400, IIIb: 100<=CTI<175).  Default IIIa -- the "
+            "conservative assumption for common FR-4."
         ),
     )
     creepage_parser.add_argument(

--- a/src/kicad_tools/creepage/__init__.py
+++ b/src/kicad_tools/creepage/__init__.py
@@ -5,9 +5,11 @@ high-voltage (HV) net group and every other conductor / board edge, honoring
 milled Edge.Cuts slots that lengthen the surface path.  It complements the
 straight-line copper *clearance* that ``kct check`` already measures.
 
-Phase 1 (this package) takes the required minimum from the operator via
-``--min``.  IEC 60664-1 / 62368-1 standard-table lookup (#4332) and
-``kct audit`` integration (#4333) are tracked as follow-ups.
+Phase 1 took the required minimum from the operator via ``--min``.  Phase 2
+(#4332) adds IEC 60664-1 / 62368-1 standard-table lookup so the required
+creepage *and* clearance are derived from working voltage + pollution degree +
+material group (see :mod:`kicad_tools.creepage.standards`).  ``kct audit``
+integration (#4333) remains a follow-up.
 
 See :mod:`kicad_tools.creepage.engine` for the public API.
 """
@@ -21,11 +23,23 @@ from .engine import (
     resolve_hv_nets,
     surface_path_length,
 )
+from .standards import (
+    DISCLAIMER,
+    STANDARDS,
+    CreepageStandard,
+    StandardLookupError,
+    get_standard,
+)
 
 __all__ = [
+    "DISCLAIMER",
+    "STANDARDS",
     "CreepagePair",
     "CreepageReport",
+    "CreepageStandard",
+    "StandardLookupError",
     "compute_creepage_census",
+    "get_standard",
     "resolve_hv_nets",
     "surface_path_length",
 ]

--- a/src/kicad_tools/creepage/engine.py
+++ b/src/kicad_tools/creepage/engine.py
@@ -66,8 +66,20 @@ class CreepagePair:
     """One evaluated (HV-net, other-conductor | board-edge) census row.
 
     ``clearance_mm`` is the straight-line copper gap; ``creepage_mm`` is the
-    slot-aware surface path (``>= clearance_mm``).  ``min_mm`` is the operator
-    supplied required value.
+    slot-aware surface path (``>= clearance_mm``).
+
+    Threshold sources (phase 2, #4332):
+
+    * ``min_mm`` -- the operator's manual override (``--min``), or ``None``.
+    * ``required_creepage_mm`` -- creepage derived from an IEC standard table,
+      or ``None`` when no ``--standard`` was supplied.
+    * ``required_clearance_mm`` -- clearance derived from the standard, or
+      ``None`` (phase-1 mode never thresholds clearance).
+
+    When both a manual ``min_mm`` and a derived ``required_creepage_mm`` are
+    present, the **stricter (larger)** governs (see :attr:`governing_creepage_mm`
+    and :attr:`governing_bound`).  ``provenance`` carries the structured
+    standard citation for the derived requirements (empty in phase-1 mode).
     """
 
     net_a: str
@@ -76,20 +88,74 @@ class CreepagePair:
     layer: str  # copper layer of the binding measurement, or "*" for edges
     clearance_mm: float
     creepage_mm: float
-    min_mm: float
+    min_mm: float | None = None
+    required_creepage_mm: float | None = None
+    required_clearance_mm: float | None = None
+    provenance: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def governing_creepage_mm(self) -> float:
+        """The effective required creepage: the stricter of manual / derived.
+
+        At least one of ``min_mm`` / ``required_creepage_mm`` is always set
+        (validated by the CLI before the census is built).
+        """
+        candidates = [v for v in (self.min_mm, self.required_creepage_mm) if v is not None]
+        if not candidates:
+            # Defensive: no threshold supplied -> nothing to clear.
+            return 0.0
+        return max(candidates)
+
+    @property
+    def governing_bound(self) -> str:
+        """Which threshold governs the creepage pass/fail decision."""
+        has_min = self.min_mm is not None
+        has_derived = self.required_creepage_mm is not None
+        if has_min and has_derived:
+            # Tie or derived-larger -> derived governs (conservative default).
+            if self.required_creepage_mm >= self.min_mm:  # type: ignore[operator]
+                return "derived"
+            return "manual (--min)"
+        if has_derived:
+            return "derived"
+        return "manual (--min)"
 
     @property
     def margin_mm(self) -> float:
-        """Creepage headroom over the required minimum (negative == fail)."""
-        return self.creepage_mm - self.min_mm
+        """Creepage headroom over the governing requirement (negative == fail)."""
+        return self.creepage_mm - self.governing_creepage_mm
+
+    @property
+    def clearance_margin_mm(self) -> float | None:
+        """Clearance headroom over the derived requirement, or ``None``."""
+        if self.required_clearance_mm is None:
+            return None
+        return self.clearance_mm - self.required_clearance_mm
+
+    @property
+    def creepage_passed(self) -> bool:
+        """``True`` when the surface path clears the governing creepage bound."""
+        return self.creepage_mm >= self.governing_creepage_mm - _PASS_TOLERANCE
+
+    @property
+    def clearance_passed(self) -> bool:
+        """``True`` when through-air clearance clears its derived requirement.
+
+        Vacuously ``True`` in phase-1 mode (no clearance requirement).
+        """
+        if self.required_clearance_mm is None:
+            return True
+        return self.clearance_mm >= self.required_clearance_mm - _PASS_TOLERANCE
 
     @property
     def passed(self) -> bool:
-        """``True`` when the surface path clears the required minimum."""
-        return self.creepage_mm >= self.min_mm - _PASS_TOLERANCE
+        """``True`` only when BOTH creepage and clearance clear their bounds."""
+        return self.creepage_passed and self.clearance_passed
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        # Phase-1 backward compatibility: with no derived requirement (manual
+        # --min only) the JSON schema is byte-for-byte identical to phase 1.
+        base = {
             "net_a": self.net_a,
             "net_b": self.net_b,
             "kind": self.kind,
@@ -99,32 +165,94 @@ class CreepagePair:
             "margin_mm": round(self.margin_mm, 4),
             "pass": self.passed,
         }
+        if self.required_creepage_mm is None:
+            return base
+        # Phase-2 (standard) mode: attach the derived requirements + provenance.
+        base["required_creepage_mm"] = round(self.required_creepage_mm, 4)
+        base["governing_bound"] = self.governing_bound
+        if self.min_mm is not None:
+            base["min_mm"] = self.min_mm
+        if self.required_clearance_mm is not None:
+            base["required_clearance_mm"] = round(self.required_clearance_mm, 4)
+            cm = self.clearance_margin_mm
+            base["clearance_margin_mm"] = round(cm, 4) if cm is not None else None
+            base["clearance_pass"] = self.clearance_passed
+        base["provenance"] = self.provenance
+        return base
 
 
 @dataclass
 class CreepageReport:
-    """Full census of HV creepage/clearance pairs for a board."""
+    """Full census of HV creepage/clearance pairs for a board.
+
+    In phase-1 mode (manual ``--min`` only) ``standard`` is ``None`` and the
+    serialized schema is byte-for-byte identical to phase 1.  In phase-2 mode a
+    ``standard`` context (id/edition/PD/material group + derived-requirement
+    provenance) is attached.
+    """
 
     net_class: str
-    min_mm: float
+    min_mm: float | None
     hv_nets: list[str] = field(default_factory=list)
     pairs: list[CreepagePair] = field(default_factory=list)
     board: str = ""
+    # Phase-2 (#4332) standard context -- None in phase-1 (manual --min) mode.
+    standard: str | None = None
+    standard_edition: str | None = None
+    working_voltage: float | None = None
+    pollution_degree: int | None = None
+    material_group: str | None = None
+    required_creepage_mm: float | None = None
+    required_clearance_mm: float | None = None
+    creepage_provenance: dict[str, Any] = field(default_factory=dict)
+    clearance_provenance: dict[str, Any] = field(default_factory=dict)
 
     @property
     def passed(self) -> bool:
-        """``True`` when every pair clears ``min_mm`` (vacuously true if empty)."""
+        """``True`` when every pair clears its bounds (vacuously true if empty)."""
         return all(p.passed for p in self.pairs)
 
     @property
     def has_hv_nets(self) -> bool:
         return bool(self.hv_nets)
 
+    @property
+    def uses_standard(self) -> bool:
+        return self.standard is not None
+
     def to_dict(self) -> dict[str, Any]:
+        # Phase-1 backward compatibility: no standard -> exact phase-1 schema.
+        if self.standard is None:
+            return {
+                "board": self.board,
+                "net_class": self.net_class,
+                "min_mm": self.min_mm,
+                "hv_nets": list(self.hv_nets),
+                "pair_count": len(self.pairs),
+                "pairs": [p.to_dict() for p in self.pairs],
+                "passed": self.passed,
+            }
         return {
             "board": self.board,
             "net_class": self.net_class,
             "min_mm": self.min_mm,
+            "standard": self.standard,
+            "standard_edition": self.standard_edition,
+            "working_voltage_v": self.working_voltage,
+            "pollution_degree": self.pollution_degree,
+            "material_group": self.material_group,
+            "required_creepage_mm": (
+                round(self.required_creepage_mm, 4)
+                if self.required_creepage_mm is not None
+                else None
+            ),
+            "required_clearance_mm": (
+                round(self.required_clearance_mm, 4)
+                if self.required_clearance_mm is not None
+                else None
+            ),
+            "creepage_provenance": self.creepage_provenance,
+            "clearance_provenance": self.clearance_provenance,
             "hv_nets": list(self.hv_nets),
             "pair_count": len(self.pairs),
             "pairs": [p.to_dict() for p in self.pairs],
@@ -448,14 +576,31 @@ def surface_path_length(
 def compute_creepage_census(
     pcb: PCB,
     hv_nets: dict[int, str],
-    min_mm: float,
+    min_mm: float | None = None,
     net_class: str = "HV",
     board: str = "",
+    *,
+    required_creepage_mm: float | None = None,
+    required_clearance_mm: float | None = None,
+    standard: str | None = None,
+    standard_edition: str | None = None,
+    working_voltage: float | None = None,
+    pollution_degree: int | None = None,
+    material_group: str | None = None,
+    creepage_provenance: dict[str, Any] | None = None,
+    clearance_provenance: dict[str, Any] | None = None,
 ) -> CreepageReport:
     """Build the full HV creepage/clearance census for a board.
 
     For every HV net the census records one row per non-HV conductor (the
     binding, smallest-creepage layer) and one row for the board edge.
+
+    The pass/fail threshold comes from either the operator's ``min_mm``
+    (phase 1) or a standard-derived ``required_creepage_mm`` /
+    ``required_clearance_mm`` (phase 2, #4332), or both -- in which case the
+    stricter creepage bound governs per pair.  The derived requirement is
+    identical for every pair (it depends only on the standard + voltage + PD +
+    material group, not on geometry), so it is stamped onto each row.
     """
     require_shapely("creepage census")
 
@@ -464,7 +609,33 @@ def compute_creepage_census(
         min_mm=min_mm,
         hv_nets=[hv_nets[num] for num in sorted(hv_nets)],
         board=board,
+        standard=standard,
+        standard_edition=standard_edition,
+        working_voltage=working_voltage,
+        pollution_degree=pollution_degree,
+        material_group=material_group,
+        required_creepage_mm=required_creepage_mm,
+        required_clearance_mm=required_clearance_mm,
+        creepage_provenance=creepage_provenance or {},
+        clearance_provenance=clearance_provenance or {},
     )
+
+    # Merged per-pair provenance (creepage + clearance citations together).
+    pair_provenance: dict[str, Any] = {}
+    if creepage_provenance:
+        pair_provenance["creepage"] = creepage_provenance
+    if clearance_provenance:
+        pair_provenance["clearance"] = clearance_provenance
+
+    def _make_pair(**kw: Any) -> CreepagePair:
+        return CreepagePair(
+            min_mm=min_mm,
+            required_creepage_mm=required_creepage_mm,
+            required_clearance_mm=required_clearance_mm,
+            provenance=pair_provenance,
+            **kw,
+        )
+
     if not hv_nets:
         return report
 
@@ -495,14 +666,13 @@ def compute_creepage_census(
 
     for (hv_num, other_num), (clearance, creepage, layer_name) in best.items():
         report.pairs.append(
-            CreepagePair(
+            _make_pair(
                 net_a=hv_nets[hv_num],
                 net_b=number_to_name.get(other_num, f"net{other_num}"),
                 kind="conductor",
                 layer=layer_name,
                 clearance_mm=clearance,
                 creepage_mm=creepage,
-                min_mm=min_mm,
             )
         )
 
@@ -518,14 +688,13 @@ def compute_creepage_census(
             hv_all = unary_union(parts)
             clearance, creepage = surface_path_length(hv_all, edge_geom, obstacles)
             report.pairs.append(
-                CreepagePair(
+                _make_pair(
                     net_a=hv_nets[hv_num],
                     net_b=BOARD_EDGE_LABEL,
                     kind="edge",
                     layer="*",
                     clearance_mm=clearance,
                     creepage_mm=creepage,
-                    min_mm=min_mm,
                 )
             )
 

--- a/src/kicad_tools/creepage/standards.py
+++ b/src/kicad_tools/creepage/standards.py
@@ -1,0 +1,505 @@
+"""IEC 60664-1 / 62368-1 creepage + clearance standard-table lookup (Issue #4332).
+
+Phase 2 of ``kct creepage`` (phase 1: #4327).  Phase 1 required the operator
+to supply the required creepage via ``--min``; this module lets that required
+value be *derived* from the governing standard for a
+``(working voltage, pollution degree, material group)`` triple, plus a
+peak-voltage/pollution-degree *clearance* requirement.
+
+.. warning::
+
+   **Engineering aid -- NOT a certification.**  The values encoded here are a
+   careful transcription of published IEC creepage/clearance tables intended
+   to catch gross layout mistakes early.  They are **not** a substitute for
+   the controlled copy of the governing standard or the judgement of a
+   qualified engineer, who remain authoritative.  Spot-check every derived
+   number against the standard before relying on it for a certifiable design.
+
+Safety-critical transcription rules honoured here
+-------------------------------------------------
+
+* Every tabulated value cites its standard, edition, table and axis inline
+  (see the module-level table constants below).
+* Lookups **step UP** to the next-higher tabulated voltage row -- creepage is
+  never linearly interpolated (IEC 60664-1 :cite:`clause 6.2` / IEC 62368-1
+  Table 17 are defined on discrete rows; interpolation is not permitted for
+  creepage).  Rounding is therefore always toward the *more conservative*
+  (larger) value.
+* An out-of-range voltage (above the highest tabulated row) or an undocumented
+  ``(pollution degree, material group)`` combination raises a loud, actionable
+  :class:`StandardLookupError` -- the module never extrapolates or emits a
+  guessed number.
+
+Table provenance (transcribed values -- spot-check before certifying)
+---------------------------------------------------------------------
+
+* **Creepage** -- IEC 60664-1:2020 Table F.4 (the "Table 4" of older
+  editions) and the harmonised IEC 62368-1:2018 (3rd ed.) Table 17.  Keyed on
+  **RMS working voltage**, pollution degree, and material group
+  (I: CTI >= 600, II: 400 <= CTI < 600, IIIa: 175 <= CTI < 400,
+  IIIb: 100 <= CTI < 175).  For pollution degree 1 the standard does not
+  subdivide by material group (no conductive pollution -> tracking does not
+  occur), so a single PD1 column is tabulated.  The two standards are
+  harmonised on the tracking physics, so their creepage values are identical
+  over the range encoded here.
+* **Clearance** -- IEC 60664-1:2020 Table F.2 (inhomogeneous-field / "case B",
+  basic insulation) with the pollution-degree minimum floors of clause 6.1,
+  at altitude **<= 2000 m**; IEC 62368-1:2018 Table 14 is the harmonised
+  counterpart.  Keyed on the **peak** value of the working voltage plus the
+  pollution degree.  The required clearance is ``max(table value, PD floor)``.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Public disclaimer (rendered by the CLI + carried in provenance)
+# ---------------------------------------------------------------------------
+
+DISCLAIMER = (
+    "Engineering aid, NOT a certification: derived from a transcription of IEC "
+    "creepage/clearance tables. The governing standard and a qualified engineer "
+    "are authoritative -- spot-check every value before relying on it."
+)
+
+# Canonical material-group labels (ascending required creepage for a fixed
+# voltage/PD): I < II < IIIa <= IIIb.
+MATERIAL_GROUPS: tuple[str, ...] = ("I", "II", "IIIa", "IIIb")
+
+# Sentinel key used for the pollution-degree-1 column, which the standard does
+# not subdivide by material group.
+_PD1_ANY = "*"
+
+
+class StandardLookupError(ValueError):
+    """Raised for an out-of-range or undocumented standard-table lookup.
+
+    Subclasses :class:`ValueError` so callers that already catch ``ValueError``
+    keep working, but is a distinct type so the CLI can render an actionable,
+    safety-critical message rather than silently emitting a guessed number.
+    """
+
+
+def normalize_material_group(group: str) -> str:
+    """Return the canonical material-group label, or raise loudly.
+
+    Accepts case-insensitive ``I``/``II``/``IIIa``/``IIIb`` (and the common
+    ``3a``/``3b`` shorthands).
+    """
+    raw = (group or "").strip()
+    lowered = raw.lower()
+    alias = {
+        "i": "I",
+        "ii": "II",
+        "iii": "IIIa",  # bare "III" -> conservative IIIa
+        "iiia": "IIIa",
+        "iiib": "IIIb",
+        "3a": "IIIa",
+        "3b": "IIIb",
+    }
+    if lowered in alias:
+        return alias[lowered]
+    raise StandardLookupError(
+        f"unknown material group {group!r}; expected one of {', '.join(MATERIAL_GROUPS)} "
+        "(I: CTI>=600, II: 400<=CTI<600, IIIa: 175<=CTI<400, IIIb: 100<=CTI<175)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Creepage tables (keyed on RMS working voltage)
+# ---------------------------------------------------------------------------
+
+# Ascending RMS working-voltage rows shared by every creepage column below.
+# IEC 60664-1:2020 Table F.4 / IEC 62368-1:2018 Table 17 (voltage axis).
+_CREEPAGE_VOLTAGE_ROWS: tuple[float, ...] = (
+    50.0,
+    63.0,
+    80.0,
+    100.0,
+    125.0,
+    160.0,
+    200.0,
+    250.0,
+    320.0,
+    400.0,
+    500.0,
+    630.0,
+    800.0,
+    1000.0,
+)
+
+# Creepage distances in mm, aligned index-for-index with _CREEPAGE_VOLTAGE_ROWS.
+# Source: IEC 60664-1:2020 Table F.4 (== IEC 62368-1:2018 Table 17, harmonised).
+# PD1 is material-group independent (single column); PD2/PD3 subdivide by group.
+# Rows read left-to-right at: 50, 63, 80, 100, 125, 160, 200, 250, 320, 400,
+# 500, 630, 800, 1000 V.
+_CREEPAGE_MM: dict[int, dict[str, tuple[float, ...]]] = {
+    # Pollution degree 1 -- Table F.4, PD1 column (no material-group split).
+    1: {
+        _PD1_ANY: (
+            0.18,  # 50 V
+            0.20,  # 63 V
+            0.22,  # 80 V
+            0.25,  # 100 V
+            0.28,  # 125 V
+            0.32,  # 160 V
+            0.42,  # 200 V
+            0.56,  # 250 V
+            0.75,  # 320 V
+            1.0,  # 400 V
+            1.3,  # 500 V
+            1.8,  # 630 V
+            2.4,  # 800 V
+            3.2,  # 1000 V
+        ),
+    },
+    # Pollution degree 2 -- Table F.4, PD2 columns.
+    2: {
+        "I": (
+            0.6,  # 50 V
+            0.63,  # 63 V
+            0.67,  # 80 V
+            0.71,  # 100 V
+            0.75,  # 125 V
+            0.8,  # 160 V
+            1.0,  # 200 V
+            1.25,  # 250 V
+            1.6,  # 320 V
+            2.0,  # 400 V
+            2.5,  # 500 V
+            3.2,  # 630 V
+            4.0,  # 800 V
+            5.0,  # 1000 V
+        ),
+        "II": (
+            0.85,  # 50 V
+            0.9,  # 63 V
+            0.9,  # 80 V
+            1.0,  # 100 V
+            1.05,  # 125 V
+            1.1,  # 160 V
+            1.4,  # 200 V
+            1.8,  # 250 V
+            2.2,  # 320 V
+            2.8,  # 400 V
+            3.6,  # 500 V
+            4.5,  # 630 V
+            5.6,  # 800 V
+            7.1,  # 1000 V
+        ),
+        "IIIa": (
+            1.2,  # 50 V
+            1.25,  # 63 V
+            1.3,  # 80 V
+            1.4,  # 100 V
+            1.5,  # 125 V
+            1.6,  # 160 V
+            2.0,  # 200 V
+            2.5,  # 250 V
+            3.2,  # 320 V
+            4.0,  # 400 V
+            5.0,  # 500 V
+            6.3,  # 630 V
+            8.0,  # 800 V
+            10.0,  # 1000 V
+        ),
+    },
+    # Pollution degree 3 -- Table F.4, PD3 columns.  Material group IIIb is not
+    # tabulated for PD3 over this range (its use is restricted), so a IIIb/PD3
+    # lookup fails loud rather than aliasing to IIIa.
+    3: {
+        "I": (
+            1.5,  # 50 V
+            1.6,  # 63 V
+            1.7,  # 80 V
+            1.8,  # 100 V
+            1.9,  # 125 V
+            2.0,  # 160 V
+            2.5,  # 200 V
+            3.2,  # 250 V
+            4.0,  # 320 V
+            5.0,  # 400 V
+            6.3,  # 500 V
+            8.0,  # 630 V
+            10.0,  # 800 V
+            12.5,  # 1000 V
+        ),
+        "II": (
+            1.7,  # 50 V
+            1.8,  # 63 V
+            1.9,  # 80 V
+            2.0,  # 100 V
+            2.1,  # 125 V
+            2.2,  # 160 V
+            2.8,  # 200 V
+            3.6,  # 250 V
+            4.5,  # 320 V
+            5.6,  # 400 V
+            7.1,  # 500 V
+            9.0,  # 630 V
+            11.0,  # 800 V
+            14.0,  # 1000 V
+        ),
+        "IIIa": (
+            1.9,  # 50 V
+            2.0,  # 63 V
+            2.1,  # 80 V
+            2.2,  # 100 V
+            2.4,  # 125 V
+            2.5,  # 160 V
+            3.2,  # 200 V
+            4.0,  # 250 V
+            5.0,  # 320 V
+            6.3,  # 400 V
+            8.0,  # 500 V
+            10.0,  # 630 V
+            12.5,  # 800 V
+            16.0,  # 1000 V
+        ),
+    },
+}
+
+# Material group IIIb shares the IIIa creepage column for PD1/PD2 over the
+# encoded range (IEC 60664-1 Table F.4 tabulates them identically there).
+_CREEPAGE_MM[2]["IIIb"] = _CREEPAGE_MM[2]["IIIa"]
+
+
+# ---------------------------------------------------------------------------
+# Clearance table (keyed on peak working voltage + pollution degree)
+# ---------------------------------------------------------------------------
+
+# Ascending peak-voltage rows for the clearance table.
+# IEC 60664-1:2020 Table F.2 (inhomogeneous field / "case B", <= 2000 m).
+_CLEARANCE_PEAK_ROWS: tuple[float, ...] = (
+    330.0,
+    500.0,
+    800.0,
+    1000.0,
+    1500.0,
+    2000.0,
+    2500.0,
+    3200.0,
+    4000.0,
+    5000.0,
+    6300.0,
+    8000.0,
+    10000.0,
+)
+
+# Base clearance in mm (inhomogeneous field, basic insulation, altitude
+# <= 2000 m), aligned with _CLEARANCE_PEAK_ROWS.  IEC 60664-1:2020 Table F.2.
+# Rows: 330, 500, 800, 1000, 1500, 2000, 2500, 3200, 4000, 5000, 6300, 8000,
+# 10000 V peak.  Below ~1.5 kV the pollution-degree floor below dominates.
+_CLEARANCE_BASE_MM: tuple[float, ...] = (
+    0.01,  # 330 V
+    0.04,  # 500 V
+    0.10,  # 800 V
+    0.15,  # 1000 V
+    0.5,  # 1500 V
+    1.0,  # 2000 V
+    1.5,  # 2500 V
+    2.0,  # 3200 V
+    3.0,  # 4000 V
+    4.0,  # 5000 V
+    5.5,  # 6300 V
+    8.0,  # 8000 V
+    11.0,  # 10000 V
+)
+
+# Pollution-degree minimum clearance floors (mm), IEC 60664-1 clause 6.1.
+# The required clearance is max(base-table value, this floor).
+_CLEARANCE_PD_FLOOR_MM: dict[int, float] = {
+    1: 0.2,  # PD1
+    2: 0.2,  # PD2
+    3: 0.8,  # PD3
+}
+
+# Sinusoidal RMS -> peak conversion for deriving the clearance axis from an
+# RMS working voltage when no explicit peak is supplied.
+RMS_TO_PEAK = math.sqrt(2.0)
+
+
+# ---------------------------------------------------------------------------
+# Standard descriptor
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CreepageStandard:
+    """A structured, self-describing creepage/clearance standard table set.
+
+    Carries the metadata (``standard_id``, ``edition``, table ids, clauses)
+    alongside the numeric tables so every derived value can be traced back to
+    its source row.
+    """
+
+    standard_id: str
+    edition: str
+    creepage_table_id: str
+    creepage_clause: str
+    clearance_table_id: str
+    clearance_clause: str
+    altitude_assumption: str = "<= 2000 m"
+    # Ascending RMS working-voltage rows for creepage.
+    creepage_voltage_rows: tuple[float, ...] = field(default=_CREEPAGE_VOLTAGE_ROWS)
+    # creepage_values[pollution_degree][material_group] aligned to the rows.
+    creepage_values: dict[int, dict[str, tuple[float, ...]]] = field(
+        default_factory=lambda: _CREEPAGE_MM
+    )
+    clearance_peak_rows: tuple[float, ...] = field(default=_CLEARANCE_PEAK_ROWS)
+    clearance_base_values: tuple[float, ...] = field(default=_CLEARANCE_BASE_MM)
+    clearance_pd_floor: dict[int, float] = field(default_factory=lambda: _CLEARANCE_PD_FLOOR_MM)
+
+    # ------------------------------------------------------------------
+    # Lookup helpers
+    # ------------------------------------------------------------------
+
+    def _step_up_index(self, rows: tuple[float, ...], voltage: float, axis_label: str) -> int:
+        """Return the index of the smallest row ``>= voltage`` (step-up rule).
+
+        Raises :class:`StandardLookupError` if ``voltage`` is non-positive or
+        exceeds the highest tabulated row (no extrapolation).
+        """
+        if not math.isfinite(voltage) or voltage <= 0.0:
+            raise StandardLookupError(
+                f"{axis_label} must be a positive, finite voltage; got {voltage!r}"
+            )
+        for i, row in enumerate(rows):
+            if voltage <= row + 1e-9:
+                return i
+        raise StandardLookupError(
+            f"{axis_label} {voltage:g} V exceeds the highest tabulated row "
+            f"({rows[-1]:g} V) for {self.standard_id} {self.edition}; the standard's "
+            "clause does not permit extrapolation -- consult the controlled standard "
+            "or supply an explicit --min."
+        )
+
+    def required_creepage(
+        self, working_voltage_rms: float, pollution_degree: int, material_group: str
+    ) -> tuple[float, dict[str, Any]]:
+        """Derive the required creepage (mm) plus structured provenance.
+
+        ``working_voltage_rms`` keys the table directly (step-up to the next
+        higher row; never interpolated).  Raises :class:`StandardLookupError`
+        for an out-of-range voltage or an undocumented ``(PD, group)`` combo.
+        """
+        group = normalize_material_group(material_group)
+        pd_columns = self.creepage_values.get(pollution_degree)
+        if pd_columns is None:
+            raise StandardLookupError(
+                f"pollution degree {pollution_degree!r} is not tabulated for "
+                f"{self.standard_id} {self.edition} (expected 1, 2 or 3)"
+            )
+        # PD1 is material-group independent.
+        column_key = _PD1_ANY if pollution_degree == 1 else group
+        column = pd_columns.get(column_key)
+        if column is None:
+            raise StandardLookupError(
+                f"material group {group!r} is not tabulated under pollution degree "
+                f"{pollution_degree} for {self.standard_id} {self.edition} "
+                f"({self.creepage_table_id}); its use is restricted there -- "
+                "use a lower material group or supply an explicit --min."
+            )
+        idx = self._step_up_index(
+            self.creepage_voltage_rows, working_voltage_rms, "working voltage (RMS)"
+        )
+        value = column[idx]
+        row_used = self.creepage_voltage_rows[idx]
+        provenance = {
+            "standard": self.standard_id,
+            "edition": self.edition,
+            "table_id": self.creepage_table_id,
+            "clause": self.creepage_clause,
+            "quantity": "creepage",
+            "voltage_axis": "rms_working_voltage",
+            "working_voltage_v": working_voltage_rms,
+            "voltage_row_used_v": row_used,
+            "pollution_degree": pollution_degree,
+            "material_group": group if pollution_degree != 1 else "n/a (PD1)",
+            "lookup_rule": "step-up to next-higher row (no interpolation)",
+            "altitude_assumption": "n/a (creepage)",
+            "value_mm": value,
+            "disclaimer": DISCLAIMER,
+        }
+        return value, provenance
+
+    def required_clearance(
+        self, peak_voltage: float, pollution_degree: int
+    ) -> tuple[float, dict[str, Any]]:
+        """Derive the required clearance (mm) plus structured provenance.
+
+        Keyed on the **peak** working voltage and pollution degree at altitude
+        ``<= 2000 m``.  The result is ``max(base-table value, PD floor)``.
+        """
+        floor = self.clearance_pd_floor.get(pollution_degree)
+        if floor is None:
+            raise StandardLookupError(
+                f"pollution degree {pollution_degree!r} has no clearance floor for "
+                f"{self.standard_id} {self.edition} (expected 1, 2 or 3)"
+            )
+        idx = self._step_up_index(self.clearance_peak_rows, peak_voltage, "peak working voltage")
+        base = self.clearance_base_values[idx]
+        row_used = self.clearance_peak_rows[idx]
+        value = max(base, floor)
+        governing = "pollution-degree floor" if floor >= base else "peak-voltage table row"
+        provenance = {
+            "standard": self.standard_id,
+            "edition": self.edition,
+            "table_id": self.clearance_table_id,
+            "clause": self.clearance_clause,
+            "quantity": "clearance",
+            "voltage_axis": "peak_working_voltage",
+            "peak_voltage_v": peak_voltage,
+            "voltage_row_used_v": row_used,
+            "pollution_degree": pollution_degree,
+            "base_table_mm": base,
+            "pd_floor_mm": floor,
+            "governing_component": governing,
+            "lookup_rule": "step-up to next-higher row (no interpolation)",
+            "altitude_assumption": self.altitude_assumption,
+            "value_mm": value,
+            "disclaimer": DISCLAIMER,
+        }
+        return value, provenance
+
+
+# ---------------------------------------------------------------------------
+# Registered standards
+# ---------------------------------------------------------------------------
+
+_IEC_60664_1 = CreepageStandard(
+    standard_id="IEC 60664-1",
+    edition="2020 (Ed. 3.0)",
+    creepage_table_id="Table F.4",
+    creepage_clause="clause 6.2 (creepage, keyed on RMS working voltage)",
+    clearance_table_id="Table F.2",
+    clearance_clause="clause 6.1 (clearance, inhomogeneous field / case B)",
+)
+
+_IEC_62368_1 = CreepageStandard(
+    standard_id="IEC 62368-1",
+    edition="2018 (Ed. 3.0)",
+    creepage_table_id="Table 17",
+    creepage_clause="5.4.3 (creepage; harmonised with IEC 60664-1 Table F.4)",
+    clearance_table_id="Table 14",
+    clearance_clause="5.4.2 (clearance; harmonised with IEC 60664-1 Table F.2)",
+)
+
+STANDARDS: dict[str, CreepageStandard] = {
+    "iec60664": _IEC_60664_1,
+    "iec62368": _IEC_62368_1,
+}
+
+
+def get_standard(standard_id: str) -> CreepageStandard:
+    """Return the :class:`CreepageStandard` for a CLI ``--standard`` value."""
+    key = (standard_id or "").strip().lower()
+    std = STANDARDS.get(key)
+    if std is None:
+        raise StandardLookupError(
+            f"unknown standard {standard_id!r}; expected one of {', '.join(STANDARDS)}"
+        )
+    return std

--- a/tests/creepage/test_creepage_standards_cli.py
+++ b/tests/creepage/test_creepage_standards_cli.py
@@ -1,0 +1,296 @@
+"""CLI tests for the phase-2 standard-derived creepage flags (Issue #4332).
+
+Covers the new ``--standard`` / ``--pollution-degree`` / ``--working-voltage``
+/ ``--material-group`` flags: derived-requirement census output (no ``--min``),
+both-flags precedence, structured JSON provenance, loud errors for
+over-range / undocumented lookups, the "provide --standard or --min" guard,
+and phase-1 backward compatibility (``--min``-only output unchanged).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from kicad_tools._shapely import has_shapely
+from kicad_tools.cli.commands.creepage import run_creepage_command
+from kicad_tools.cli.parser import create_parser
+
+from .fixtures import board_source
+
+pytestmark = pytest.mark.skipif(not has_shapely(), reason="creepage requires shapely")
+
+
+def _write(tmp_path, source, name="board.kicad_pcb"):
+    p = tmp_path / name
+    p.write_text(source)
+    return p
+
+
+def _hv_map_file(tmp_path):
+    p = tmp_path / "net_class_map.json"
+    p.write_text(json.dumps({"L_MAINS": {"name": "HV"}}))
+    return p
+
+
+def _run(argv):
+    args = create_parser().parse_args(argv)
+    return run_creepage_command(args)
+
+
+# ---------------------------------------------------------------------------
+# Derived-requirement census (no --min)
+# ---------------------------------------------------------------------------
+
+
+def test_standard_derives_requirement_without_min(tmp_path, capsys):
+    pcb = _write(tmp_path, board_source(with_slot=False))
+    ncm = _hv_map_file(tmp_path)
+    rc = _run(
+        [
+            "creepage",
+            str(pcb),
+            "--net-class-map",
+            str(ncm),
+            "--standard",
+            "iec62368",
+            "--working-voltage",
+            "170",
+            "--pollution-degree",
+            "2",
+        ]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0  # 18 mm gaps clear the ~2 mm derived requirement
+    assert "IEC 62368-1" in out
+    assert "Derived required creepage" in out
+    # The 170 V RMS step-up lands on the 200 V row -> 2.0 mm (in EE envelope).
+    assert "2.000 mm" in out
+
+
+def test_standard_json_carries_provenance(tmp_path, capsys):
+    pcb = _write(tmp_path, board_source(with_slot=False))
+    ncm = _hv_map_file(tmp_path)
+    rc = _run(
+        [
+            "creepage",
+            str(pcb),
+            "--net-class-map",
+            str(ncm),
+            "--standard",
+            "iec60664",
+            "--working-voltage",
+            "170",
+            "--pollution-degree",
+            "2",
+            "--material-group",
+            "IIIa",
+            "--format",
+            "json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["standard"] == "iec60664"
+    assert payload["pollution_degree"] == 2
+    assert payload["material_group"] == "IIIa"
+    assert payload["required_creepage_mm"] == 2.0
+    assert payload["required_clearance_mm"] == 0.2  # PD2 floor
+    cp = payload["creepage_provenance"]
+    assert cp["table_id"] == "Table F.4"
+    assert cp["voltage_row_used_v"] == 200.0
+    assert "disclaimer" in cp
+    # Every pair carries the derived requirement + governing bound.
+    for pair in payload["pairs"]:
+        assert pair["required_creepage_mm"] == 2.0
+        assert pair["governing_bound"] == "derived"
+        assert pair["required_clearance_mm"] == 0.2
+        assert "clearance_pass" in pair
+        assert "provenance" in pair
+
+
+def test_standard_fail_when_requirement_not_met(tmp_path, capsys):
+    pcb = _write(tmp_path, board_source(with_slot=False))
+    ncm = _hv_map_file(tmp_path)
+    # 1000 V PD3 IIIa -> 16 mm required creepage; the 18 mm pad gap clears it
+    # but the board-edge pair (~11 mm) does not.
+    rc = _run(
+        [
+            "creepage",
+            str(pcb),
+            "--net-class-map",
+            str(ncm),
+            "--standard",
+            "iec60664",
+            "--working-voltage",
+            "1000",
+            "--pollution-degree",
+            "3",
+        ]
+    )
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "FAIL" in out
+
+
+# ---------------------------------------------------------------------------
+# Precedence: both --min and --standard supplied
+# ---------------------------------------------------------------------------
+
+
+def test_precedence_min_stricter_than_derived(tmp_path, capsys):
+    pcb = _write(tmp_path, board_source(with_slot=False))
+    ncm = _hv_map_file(tmp_path)
+    rc = _run(
+        [
+            "creepage",
+            str(pcb),
+            "--net-class-map",
+            str(ncm),
+            "--standard",
+            "iec62368",
+            "--working-voltage",
+            "170",
+            "--pollution-degree",
+            "2",
+            "--min",
+            "100",  # far stricter than the 2 mm derived value
+            "--format",
+            "json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 1  # 100 mm cannot be met by an 18 mm gap
+    for pair in payload["pairs"]:
+        assert pair["governing_bound"] == "manual (--min)"
+
+
+def test_precedence_derived_stricter_than_min(tmp_path, capsys):
+    pcb = _write(tmp_path, board_source(with_slot=False))
+    ncm = _hv_map_file(tmp_path)
+    rc = _run(
+        [
+            "creepage",
+            str(pcb),
+            "--net-class-map",
+            str(ncm),
+            "--standard",
+            "iec62368",
+            "--working-voltage",
+            "170",
+            "--pollution-degree",
+            "2",
+            "--min",
+            "0.5",  # weaker than the 2 mm derived value
+            "--format",
+            "json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    for pair in payload["pairs"]:
+        assert pair["governing_bound"] == "derived"
+
+
+# ---------------------------------------------------------------------------
+# Loud errors
+# ---------------------------------------------------------------------------
+
+
+def test_neither_standard_nor_min_errors(tmp_path, capsys):
+    pcb = _write(tmp_path, board_source(with_slot=False))
+    ncm = _hv_map_file(tmp_path)
+    rc = _run(["creepage", str(pcb), "--net-class-map", str(ncm)])
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "provide either --standard" in err
+
+
+def test_standard_without_voltage_errors(tmp_path, capsys):
+    pcb = _write(tmp_path, board_source(with_slot=False))
+    ncm = _hv_map_file(tmp_path)
+    rc = _run(["creepage", str(pcb), "--net-class-map", str(ncm), "--standard", "iec60664"])
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "requires both --working-voltage and --pollution-degree" in err
+
+
+def test_over_range_voltage_fails_loud(tmp_path, capsys):
+    pcb = _write(tmp_path, board_source(with_slot=False))
+    ncm = _hv_map_file(tmp_path)
+    rc = _run(
+        [
+            "creepage",
+            str(pcb),
+            "--net-class-map",
+            str(ncm),
+            "--standard",
+            "iec60664",
+            "--working-voltage",
+            "5000",
+            "--pollution-degree",
+            "2",
+        ]
+    )
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "standard-table lookup failed" in err
+    assert "exceeds the highest tabulated row" in err
+
+
+def test_undocumented_combo_fails_loud(tmp_path, capsys):
+    pcb = _write(tmp_path, board_source(with_slot=False))
+    ncm = _hv_map_file(tmp_path)
+    rc = _run(
+        [
+            "creepage",
+            str(pcb),
+            "--net-class-map",
+            str(ncm),
+            "--standard",
+            "iec60664",
+            "--working-voltage",
+            "200",
+            "--pollution-degree",
+            "3",
+            "--material-group",
+            "IIIb",
+        ]
+    )
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "standard-table lookup failed" in err
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility: --min-only output unchanged (phase-1 schema)
+# ---------------------------------------------------------------------------
+
+
+def test_min_only_json_schema_unchanged(tmp_path, capsys):
+    pcb = _write(tmp_path, board_source(with_slot=False))
+    ncm = _hv_map_file(tmp_path)
+    _run(["creepage", str(pcb), "--net-class-map", str(ncm), "--min", "1.5", "--format", "json"])
+    payload = json.loads(capsys.readouterr().out)
+    # Exactly the phase-1 top-level keys -- no phase-2 fields leak in.
+    assert set(payload.keys()) == {
+        "board",
+        "net_class",
+        "min_mm",
+        "hv_nets",
+        "pair_count",
+        "pairs",
+        "passed",
+    }
+    for pair in payload["pairs"]:
+        assert set(pair.keys()) == {
+            "net_a",
+            "net_b",
+            "kind",
+            "layer",
+            "clearance_mm",
+            "creepage_mm",
+            "margin_mm",
+            "pass",
+        }

--- a/tests/creepage/test_standards.py
+++ b/tests/creepage/test_standards.py
@@ -1,0 +1,329 @@
+"""Unit tests for the IEC standard-table lookup (Issue #4332, phase 2).
+
+Covers:
+
+* Hand-verified creepage data points across PD1/PD2/PD3 and material groups
+  I/II/IIIa (exact expected mm per the encoded IEC 60664-1 Table F.4 /
+  IEC 62368-1 Table 17).
+* Boundary / step-up behaviour: exactly-on-row returns that row; between rows
+  steps UP (never interpolated); above the highest row fails loud.
+* Undocumented (voltage, PD, material-group) combinations raise the loud
+  ``StandardLookupError`` -- never a silent guessed number.
+* Clearance derivation: peak-voltage keying + pollution-degree floor +
+  structured provenance.
+* Internal consistency (monotonic in voltage, across material groups, and
+  across pollution degrees) as a transcription self-check.
+* Precedence in ``CreepagePair`` (stricter of manual --min / derived governs,
+  and the reported governing bound is correct in both directions).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.creepage.engine import CreepagePair
+from kicad_tools.creepage.standards import (
+    MATERIAL_GROUPS,
+    RMS_TO_PEAK,
+    StandardLookupError,
+    get_standard,
+    normalize_material_group,
+)
+
+STDS = ("iec60664", "iec62368")
+
+
+# ---------------------------------------------------------------------------
+# Hand-verified creepage data points (IEC 60664-1 Table F.4 / 62368-1 Table 17)
+# ---------------------------------------------------------------------------
+
+# (working_voltage_rms, pollution_degree, material_group) -> expected mm
+_HAND_VERIFIED = {
+    # PD2, group I
+    (200, 2, "I"): 1.0,
+    (250, 2, "I"): 1.25,
+    (1000, 2, "I"): 5.0,
+    # PD2, group II
+    (100, 2, "II"): 1.0,
+    (200, 2, "II"): 1.4,
+    (1000, 2, "II"): 7.1,
+    # PD2, group IIIa
+    (100, 2, "IIIa"): 1.4,
+    (200, 2, "IIIa"): 2.0,
+    (250, 2, "IIIa"): 2.5,
+    (1000, 2, "IIIa"): 10.0,
+    # PD3, group I / II / IIIa
+    (200, 3, "I"): 2.5,
+    (200, 3, "II"): 2.8,
+    (200, 3, "IIIa"): 3.2,
+    (1000, 3, "IIIa"): 16.0,
+    # PD1 is material-group independent
+    (100, 1, "I"): 0.25,
+    (400, 1, "IIIa"): 1.0,
+}
+
+
+@pytest.mark.parametrize("standard_id", STDS)
+@pytest.mark.parametrize(("key", "expected"), list(_HAND_VERIFIED.items()))
+def test_hand_verified_creepage(standard_id, key, expected):
+    voltage, pd, group = key
+    std = get_standard(standard_id)
+    value, prov = std.required_creepage(voltage, pd, group)
+    assert value == pytest.approx(expected)
+    assert prov["quantity"] == "creepage"
+    assert prov["pollution_degree"] == pd
+    assert prov["voltage_row_used_v"] >= voltage
+
+
+def test_pd1_is_material_group_independent():
+    std = get_standard("iec60664")
+    for group in ("I", "II", "IIIa"):
+        value, prov = std.required_creepage(160, 1, group)
+        assert value == pytest.approx(0.32)  # PD1, 160 V row
+        assert "PD1" in prov["material_group"]
+
+
+def test_two_standards_are_harmonised():
+    a = get_standard("iec60664")
+    b = get_standard("iec62368")
+    for pd in (1, 2, 3):
+        for group in ("I", "II", "IIIa"):
+            if pd == 1 and group != "I":
+                continue
+            for v in (100, 200, 630, 1000):
+                va, _ = a.required_creepage(v, pd, group)
+                vb, _ = b.required_creepage(v, pd, group)
+                assert va == vb, f"mismatch at {v}V PD{pd} {group}"
+
+
+# ---------------------------------------------------------------------------
+# Boundary / step-up behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_exact_row_returns_that_row():
+    std = get_standard("iec60664")
+    value, prov = std.required_creepage(200, 2, "IIIa")
+    assert prov["voltage_row_used_v"] == 200.0
+    assert value == pytest.approx(2.0)
+
+
+def test_between_rows_steps_up_not_interpolated():
+    std = get_standard("iec60664")
+    # 201 V sits between the 200 and 250 rows -> must step UP to 250 (2.5 mm),
+    # NOT interpolate to ~2.01 mm.
+    value, prov = std.required_creepage(201, 2, "IIIa")
+    assert prov["voltage_row_used_v"] == 250.0
+    assert value == pytest.approx(2.5)
+
+
+def test_below_lowest_row_steps_up_to_lowest():
+    std = get_standard("iec60664")
+    value, prov = std.required_creepage(12, 2, "IIIa")
+    assert prov["voltage_row_used_v"] == 50.0  # lowest tabulated row
+    assert value == pytest.approx(1.2)
+
+
+def test_above_highest_row_fails_loud():
+    std = get_standard("iec60664")
+    with pytest.raises(StandardLookupError, match="exceeds the highest tabulated row"):
+        std.required_creepage(1500, 2, "IIIa")
+
+
+def test_nonpositive_voltage_fails_loud():
+    std = get_standard("iec60664")
+    with pytest.raises(StandardLookupError):
+        std.required_creepage(0, 2, "IIIa")
+    with pytest.raises(StandardLookupError):
+        std.required_creepage(-100, 2, "IIIa")
+
+
+# ---------------------------------------------------------------------------
+# Undocumented combinations fail loud (never a silent number)
+# ---------------------------------------------------------------------------
+
+
+def test_pd3_iiib_is_undocumented_and_fails_loud():
+    std = get_standard("iec60664")
+    with pytest.raises(StandardLookupError, match="material group"):
+        std.required_creepage(200, 3, "IIIb")
+
+
+def test_unknown_pollution_degree_fails_loud():
+    std = get_standard("iec60664")
+    with pytest.raises(StandardLookupError, match="pollution degree"):
+        std.required_creepage(200, 4, "IIIa")
+
+
+def test_unknown_material_group_fails_loud():
+    with pytest.raises(StandardLookupError, match="unknown material group"):
+        normalize_material_group("IV")
+
+
+def test_unknown_standard_fails_loud():
+    with pytest.raises(StandardLookupError, match="unknown standard"):
+        get_standard("iec99999")
+
+
+def test_material_group_aliases():
+    assert normalize_material_group("iiia") == "IIIa"
+    assert normalize_material_group("3b") == "IIIb"
+    assert normalize_material_group(" II ") == "II"
+
+
+# ---------------------------------------------------------------------------
+# Softstart rev-C envelope (~170 Vpk / PD2 -> ~1.5-2.5 mm)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("standard_id", STDS)
+def test_softstart_revc_envelope(standard_id):
+    std = get_standard(standard_id)
+    value, _ = std.required_creepage(170, 2, "IIIa")
+    assert 1.5 <= value <= 2.5, f"{standard_id}: {value} mm outside EE_REVIEW envelope"
+
+
+# ---------------------------------------------------------------------------
+# Clearance derivation + provenance
+# ---------------------------------------------------------------------------
+
+
+def test_clearance_floored_by_pollution_degree():
+    std = get_standard("iec60664")
+    # 170 Vpk is below the lowest peak row -> the PD floor governs.
+    value, prov = std.required_clearance(170 * RMS_TO_PEAK, 2)
+    assert value == pytest.approx(0.2)  # PD2 floor
+    assert prov["governing_component"] == "pollution-degree floor"
+    assert prov["altitude_assumption"] == "<= 2000 m"
+    assert prov["quantity"] == "clearance"
+
+
+def test_clearance_pd3_floor_is_higher():
+    std = get_standard("iec60664")
+    value, _ = std.required_clearance(200 * RMS_TO_PEAK, 3)
+    assert value == pytest.approx(0.8)  # PD3 floor
+
+
+def test_clearance_high_voltage_uses_table_row():
+    std = get_standard("iec60664")
+    value, prov = std.required_clearance(5000, 1)
+    assert prov["governing_component"] == "peak-voltage table row"
+    assert value >= 0.8
+
+
+def test_clearance_above_highest_peak_row_fails_loud():
+    std = get_standard("iec60664")
+    with pytest.raises(StandardLookupError):
+        std.required_clearance(20000, 2)
+
+
+def test_clearance_provenance_carries_full_citation():
+    std = get_standard("iec62368")
+    _, prov = std.required_clearance(1000, 2)
+    for key in (
+        "standard",
+        "edition",
+        "table_id",
+        "clause",
+        "voltage_axis",
+        "pollution_degree",
+        "altitude_assumption",
+        "disclaimer",
+    ):
+        assert key in prov
+
+
+# ---------------------------------------------------------------------------
+# Internal consistency (transcription self-check)
+# ---------------------------------------------------------------------------
+
+
+def test_creepage_monotonic_in_voltage():
+    std = get_standard("iec60664")
+    rows = std.creepage_voltage_rows
+    for pd in (1, 2, 3):
+        groups = ("I",) if pd == 1 else ("I", "II", "IIIa")
+        for group in groups:
+            vals = [std.required_creepage(v, pd, group)[0] for v in rows]
+            assert vals == sorted(vals), f"non-monotone PD{pd} {group}"
+
+
+def test_creepage_monotonic_across_material_groups():
+    std = get_standard("iec60664")
+    for pd in (2, 3):
+        for v in std.creepage_voltage_rows:
+            i = std.required_creepage(v, pd, "I")[0]
+            ii = std.required_creepage(v, pd, "II")[0]
+            iiia = std.required_creepage(v, pd, "IIIa")[0]
+            assert i <= ii <= iiia, f"non-monotone groups at {v}V PD{pd}"
+
+
+def test_creepage_monotonic_across_pollution_degrees():
+    std = get_standard("iec60664")
+    for v in std.creepage_voltage_rows:
+        pd1 = std.required_creepage(v, 1, "I")[0]
+        pd2 = std.required_creepage(v, 2, "IIIa")[0]
+        pd3 = std.required_creepage(v, 3, "IIIa")[0]
+        assert pd1 < pd2 < pd3, f"non-monotone PD ladder at {v}V"
+
+
+def test_all_material_groups_constant_defined():
+    assert MATERIAL_GROUPS == ("I", "II", "IIIa", "IIIb")
+
+
+# ---------------------------------------------------------------------------
+# Precedence: stricter of manual --min / derived governs (CreepagePair)
+# ---------------------------------------------------------------------------
+
+
+def _pair(min_mm=None, required=None, creepage=5.0, clearance=5.0, req_clearance=None):
+    return CreepagePair(
+        net_a="HV",
+        net_b="GND",
+        kind="conductor",
+        layer="F.Cu",
+        clearance_mm=clearance,
+        creepage_mm=creepage,
+        min_mm=min_mm,
+        required_creepage_mm=required,
+        required_clearance_mm=req_clearance,
+    )
+
+
+def test_precedence_derived_stricter_governs():
+    p = _pair(min_mm=1.0, required=3.0, creepage=2.5)
+    assert p.governing_creepage_mm == pytest.approx(3.0)
+    assert p.governing_bound == "derived"
+    assert not p.creepage_passed  # 2.5 < 3.0
+
+
+def test_precedence_manual_stricter_governs():
+    p = _pair(min_mm=4.0, required=2.0, creepage=3.0)
+    assert p.governing_creepage_mm == pytest.approx(4.0)
+    assert p.governing_bound == "manual (--min)"
+    assert not p.creepage_passed  # 3.0 < 4.0
+
+
+def test_precedence_manual_only():
+    p = _pair(min_mm=2.0, required=None, creepage=3.0)
+    assert p.governing_creepage_mm == pytest.approx(2.0)
+    assert p.governing_bound == "manual (--min)"
+    assert p.passed
+
+
+def test_precedence_derived_only():
+    p = _pair(min_mm=None, required=2.0, creepage=3.0)
+    assert p.governing_creepage_mm == pytest.approx(2.0)
+    assert p.governing_bound == "derived"
+    assert p.passed
+
+
+def test_passed_gates_on_both_creepage_and_clearance():
+    # Creepage clears, but clearance does not -> overall FAIL.
+    p = _pair(required=2.0, creepage=3.0, clearance=0.1, req_clearance=0.2)
+    assert p.creepage_passed
+    assert not p.clearance_passed
+    assert not p.passed
+    # Both clear -> PASS.
+    ok = _pair(required=2.0, creepage=3.0, clearance=0.5, req_clearance=0.2)
+    assert ok.passed


### PR DESCRIPTION
## Summary

Phase 2 of `kct creepage` (phase 1 merged via #4334, parent #4327). Adds IEC
standard-table lookup so the required creepage — and, newly, a required
**clearance** — is *derived* from working voltage + pollution degree + material
group, instead of only via `--min`. The shapely surface-path geometry is
untouched; only the *source* of the threshold changes, plus a second
(clearance) gate.

Phase 3 (`kct audit` HV/isolation gate) is #4333 — out of scope here.

> **Engineering aid, NOT a certification.** The encoded values are a careful
> transcription of published IEC tables to catch gross layout mistakes early.
> The controlled standard and a qualified engineer remain authoritative. This
> disclaimer is carried in the module docstring, CLI output, and JSON
> provenance.

## Changes

- **NEW `src/kicad_tools/creepage/standards.py`** — IEC creepage + clearance
  tables as structured, self-describing data (`CreepageStandard`), step-up
  lookup with structured provenance, and a loud `StandardLookupError` on
  over-range / undocumented combos (never a guessed number).
- **`creepage/engine.py`** — `CreepagePair`/`CreepageReport` gain
  `required_creepage_mm`, `required_clearance_mm`, `provenance`, and
  governing-bound logic; `passed` now requires **both** creepage ≥ required
  creepage **and** clearance ≥ required clearance. `min_mm` kept as the manual
  override.
- **`cli/parser.py`** — new `--standard {iec60664,iec62368}`,
  `--pollution-degree {1,2,3}`, `--working-voltage <V>`,
  `--material-group {I,II,IIIa,IIIb}` (default `IIIa`); `--min` relaxed to
  optional.
- **`cli/commands/creepage.py`** — resolves the threshold source, enforces
  "provide `--standard` or `--min`", derives requirements, and renders the
  derived requirement + provenance in a new standard-mode table (phase-1
  table/JSON untouched when no standard is given).
- **Tests** — `tests/creepage/test_standards.py` (unit) and
  `tests/creepage/test_creepage_standards_cli.py` (CLI).

## Lookup rules (safety-critical)

- **Creepage** keys on **RMS working voltage**; **clearance** keys on **peak**
  (RMS × √2, sinusoidal assumption, stated in provenance).
- **Step UP** to the next-higher tabulated voltage row — creepage is **never**
  interpolated. Rounding is always toward the more conservative (larger) value.
- Voltage above the highest row, or an undocumented (PD, material-group) combo,
  **fails loud**.
- Clearance = `max(peak-voltage table row, pollution-degree floor)`, altitude
  ≤ 2000 m.

## IEC tables / rows transcribed (please spot-check against a controlled copy)

Encoded editions: **IEC 60664-1:2020 (Ed. 3.0)** and **IEC 62368-1:2018
(Ed. 3.0)**. The two standards are harmonised on the tracking physics, so their
creepage values are identical over the encoded range.

**Creepage — IEC 60664-1 Table F.4 / IEC 62368-1 Table 17** (mm), RMS working
voltage rows: 50, 63, 80, 100, 125, 160, 200, 250, 320, 400, 500, 630, 800,
1000 V.

- PD1 (material-group independent): 0.18, 0.20, 0.22, 0.25, 0.28, 0.32, 0.42,
  0.56, 0.75, 1.0, 1.3, 1.8, 2.4, 3.2
- PD2 group I: 0.6, 0.63, 0.67, 0.71, 0.75, 0.8, 1.0, 1.25, 1.6, 2.0, 2.5, 3.2, 4.0, 5.0
- PD2 group II: 0.85, 0.9, 0.9, 1.0, 1.05, 1.1, 1.4, 1.8, 2.2, 2.8, 3.6, 4.5, 5.6, 7.1
- PD2 group IIIa (= IIIb over this range): 1.2, 1.25, 1.3, 1.4, 1.5, 1.6, 2.0, 2.5, 3.2, 4.0, 5.0, 6.3, 8.0, 10.0
- PD3 group I: 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 2.5, 3.2, 4.0, 5.0, 6.3, 8.0, 10.0, 12.5
- PD3 group II: 1.7, 1.8, 1.9, 2.0, 2.1, 2.2, 2.8, 3.6, 4.5, 5.6, 7.1, 9.0, 11.0, 14.0
- PD3 group IIIa: 1.9, 2.0, 2.1, 2.2, 2.4, 2.5, 3.2, 4.0, 5.0, 6.3, 8.0, 10.0, 12.5, 16.0
- PD3 group IIIb: **not tabulated** (restricted) → lookup fails loud.

**Clearance — IEC 60664-1 Table F.2 / IEC 62368-1 Table 14** (inhomogeneous
field / case B, ≤ 2000 m), peak-voltage rows: 330, 500, 800, 1000, 1500, 2000,
2500, 3200, 4000, 5000, 6300, 8000, 10000 V → base 0.01, 0.04, 0.10, 0.15, 0.5,
1.0, 1.5, 2.0, 3.0, 4.0, 5.5, 8.0, 11.0 mm; pollution-degree minimum floors
(clause 6.1): PD1 0.2, PD2 0.2, PD3 0.8 mm.

The values are internally consistent (monotonic in voltage, across material
groups I<II<IIIa, and across PD1<PD2<PD3 — asserted by unit tests) and follow
the R10 preferred-number progression at the top of each column.

## Sample derived value

`--standard iec62368 --working-voltage 170 --pollution-degree 2` (material group
IIIa): 170 V RMS steps up to the 200 V row → **required creepage 2.0 mm**
(inside the softstart rev-C EE_REVIEW ~1.5–2.5 mm envelope); peak ≈ 240 V is
below the lowest clearance row so the PD2 floor governs → **required clearance
0.2 mm**.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| New flags `--standard/--pollution-degree/--working-voltage/--material-group` (default IIIa) | ✅ | `cli/parser.py`; CLI tests |
| `--min` optional; require `--standard` or `--min` | ✅ | `test_neither_standard_nor_min_errors` |
| Stricter-governs precedence when both given; governing bound reported | ✅ | `test_precedence_*` (both directions) |
| `--min`-only byte-identical to phase 1 | ✅ | `test_min_only_json_schema_unchanged` + phase-1 suite green |
| Encode 60664-1 (F.4/F.2) + 62368-1 (17/14) as structured data w/ provenance | ✅ | `standards.py`; `test_standard_json_carries_provenance` |
| Step-up lookup (no creepage interpolation); fail loud over-range | ✅ | `test_between_rows_steps_up_not_interpolated`, `test_above_highest_row_fails_loud` |
| Undocumented combo raises actionable error | ✅ | `test_pd3_iiib_*`, `test_unknown_*` |
| `passed` gates on both creepage AND clearance | ✅ | `test_passed_gates_on_both_creepage_and_clearance` |
| Per-pair required-vs-actual + provenance in table/JSON | ✅ | standard-mode renderer + JSON |
| Softstart ~170 Vpk / PD2 → 1.5–2.5 mm | ✅ | `test_softstart_revc_envelope` |

## Test Plan

- `uv run pytest tests/creepage/` → **89 passed**
- `uv run pytest -k "parser or creepage"` → 432 passed, 8 skipped
- `uv run ruff check .` → clean; `uv run ruff format . --check` → clean
- `uv run mypy src/kicad_tools/creepage/ …/commands/creepage.py` → no issues;
  mypy baseline test green (no new baseline entries)

Closes #4332