### PR TITLE
feat(audit): HV/isolation creepage section + manufacturing-readiness gate (phase 3, #4327)

### DIFF
--- a/.claude/commands/kct/manufacturing-readiness.md
+++ b/.claude/commands/kct/manufacturing-readiness.md
@@ -97,15 +97,35 @@ kct export <board.kicad_pcb> --output <dir> --mfr <tier>
 - **Confirm `<dir>/manifest.json` exists and was freshly written** (its mtime should be newer than the routed PCB). No manifest ⇒ no sign-off.
 - Useful variants: `--dry-run` (show what would be generated without writing) and `--no-report`.
 
+### Gate 4 — HV / isolation creepage gate (conditional: mains/HV boards only)
+
+**Skip this gate entirely for boards with no high-voltage / mains net.** For any board carrying an HV net group (mains input, primary-side switcher, etc.), a below-standard creepage/clearance pair is a safety defect that neither Gate 1 nor Gate 2 derives from an insulation standard. Run the isolation audit and require a clean verdict:
+
+```bash
+kct audit <board.kicad_pcb> --mfr <tier> \
+  --net-class-map <net_class_map.json> \
+  --hv-standard <iec60664|iec62368> \
+  --hv-working-voltage <V-rms> \
+  --hv-pollution-degree <1|2|3> \
+  [--hv-material-group <I|II|IIIa|IIIb>]
+```
+
+- HV nets are selected from the `--net-class-map` sidecar (the net whose class name is `HV`, or `--hv-net-class <name>`). Without a map the HV group will not resolve and the section is skipped.
+- The required creepage **and** clearance are derived from the IEC 60664-1 / 62368-1 tables for the `(working voltage, pollution degree, material group)` triple. To gate against a manually specified creepage instead, use `--hv-min <mm>` (phase-1).
+- A below-derived-requirement HV pair makes the audit verdict `NOT_READY`, so **`kct audit` exits 2** — the manufacturing-readiness gate FAILs with a non-zero exit. A compliant board exits 0.
+- If HV nets are present but no threshold source (`--hv-min` / `--hv-standard`) is supplied, the audit downgrades to `WARNING` ("no isolation requirement specified") rather than silently passing — so an HV path is never signed off un-evaluated.
+- The derived values are an engineering aid, **NOT a certification** — the governing standard and a qualified engineer remain authoritative.
+
 ## Sign-off verdict
 
-Sign off **only if all three** hold:
+Sign off **only if all applicable gates** hold:
 
 1. Gate 1 `kct check --mfr <tier>` exits clean at the resolved tier.
 2. Gate 2 `kicad-cli pcb drc --refill-zones` reports **0 new errors** (and actually ran — a missing `kicad-cli` is a blocker, not a pass).
 3. Gate 3 `kct export --mfr <tier>` wrote a fresh `manifest.json`.
+4. **(HV/mains boards only)** Gate 4 `kct audit --hv-standard ...` exits 0 with a clean HV/isolation verdict — a `NOT_READY` (exit 2) isolation gate is a hard blocker; an un-gated HV path (`WARNING`, no requirement specified) is not sign-off either.
 
-If any gate fails or could not run, report **NOT signed off**, name the failing gate, and quote the specific violation(s). Never mark a board fab-ready on a partial run.
+If any applicable gate fails or could not run, report **NOT signed off**, name the failing gate, and quote the specific violation(s). Never mark a board fab-ready on a partial run.
 
 ## What this skill does NOT do
 

--- a/src/kicad_tools/audit/__init__.py
+++ b/src/kicad_tools/audit/__init__.py
@@ -20,6 +20,7 @@ Usage:
 from .auditor import (
     AuditResult,
     AuditVerdict,
+    IsolationStatus,
     ManufacturingAudit,
     SyncStatus,
 )
@@ -34,6 +35,7 @@ __all__ = [
     "ManufacturingAudit",
     "AuditResult",
     "AuditVerdict",
+    "IsolationStatus",
     "SyncStatus",
     "AffectedPad",
     "StaleNetGroup",

--- a/src/kicad_tools/audit/auditor.py
+++ b/src/kicad_tools/audit/auditor.py
@@ -228,6 +228,75 @@ class ManufacturerCompatibility:
 
 
 @dataclass
+class IsolationStatus:
+    """HV creepage/clearance isolation check results (Issue #4333, phase 3).
+
+    Wraps the phase-1/phase-2 creepage engine
+    (:func:`kicad_tools.creepage.engine.resolve_hv_nets` +
+    :func:`~kicad_tools.creepage.engine.compute_creepage_census`).  The audit
+    does NOT reimplement any geometry or standard-table math -- it consumes the
+    engine's :class:`~kicad_tools.creepage.engine.CreepageReport` verbatim.
+
+    Gating semantics (folded into :attr:`AuditResult.verdict`):
+
+    * ``checked=True and passed=False`` -- a resolved HV pair is below its
+      governing creepage/clearance bound -> ``NOT_READY`` (the manufacturing
+      gate fails with a non-zero exit).
+    * ``hv_present=True and threshold_supplied=False`` -- HV nets exist but no
+      ``--hv-min`` / ``--hv-standard`` was supplied, so the path cannot be
+      gated -> ``WARNING`` (never silently green).
+    * ``could_not_verify=True`` -- shapely is unavailable or a standard-table
+      lookup failed; HV present but not evaluated -> ``WARNING`` (fail-loud,
+      never a hard crash of the whole audit).
+    * ``hv_present=False`` -- no HV-class nets; inert, no verdict change.
+    """
+
+    # Whether HV nets were present AND a threshold source was supplied AND the
+    # census was evaluated (the only state that can hard-gate the verdict).
+    checked: bool = False
+    # HV-class nets were resolved on the board (independent of thresholding).
+    hv_present: bool = False
+    # A threshold source (--hv-min or --hv-standard) was supplied.
+    threshold_supplied: bool = False
+    # HV present but could not be evaluated (shapely absent / lookup error).
+    could_not_verify: bool = False
+    passed: bool = True
+    hv_nets: list[str] = field(default_factory=list)
+    pair_count: int = 0
+    min_creepage_mm: float | None = None
+    min_clearance_mm: float | None = None
+    required_creepage_mm: float | None = None
+    required_clearance_mm: float | None = None
+    standard: str | None = None
+    standard_edition: str | None = None
+    failing_pairs: list[dict] = field(default_factory=list)
+    details: str = ""
+    # Full engine census dict (CreepageReport.to_dict()) -- kept verbatim so
+    # JSON provenance matches ``kct creepage --format json``.
+    report: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "checked": self.checked,
+            "hv_present": self.hv_present,
+            "threshold_supplied": self.threshold_supplied,
+            "could_not_verify": self.could_not_verify,
+            "passed": self.passed,
+            "hv_nets": list(self.hv_nets),
+            "pair_count": self.pair_count,
+            "min_creepage_mm": self.min_creepage_mm,
+            "min_clearance_mm": self.min_clearance_mm,
+            "required_creepage_mm": self.required_creepage_mm,
+            "required_clearance_mm": self.required_clearance_mm,
+            "standard": self.standard,
+            "standard_edition": self.standard_edition,
+            "failing_pairs": [dict(p) for p in self.failing_pairs],
+            "details": self.details,
+            "report": self.report,
+        }
+
+
+@dataclass
 class LayerUtilization:
     """PCB layer utilization statistics."""
 
@@ -297,6 +366,7 @@ class AuditResult:
     sync: SyncStatus = field(default_factory=SyncStatus)
     connectivity: ConnectivityStatus = field(default_factory=ConnectivityStatus)
     compatibility: ManufacturerCompatibility = field(default_factory=ManufacturerCompatibility)
+    isolation: IsolationStatus = field(default_factory=IsolationStatus)
     layers: LayerUtilization = field(default_factory=LayerUtilization)
     cost: CostEstimate = field(default_factory=CostEstimate)
 
@@ -312,6 +382,12 @@ class AuditResult:
         if self.drc.blocking_count > 0:
             return AuditVerdict.NOT_READY
         if not self.compatibility.passed:
+            return AuditVerdict.NOT_READY
+
+        # HV / isolation hard fail (issue #4333): a resolved HV pair below its
+        # governing creepage/clearance bound is a manufacturing-blocking defect
+        # -- fold it into NOT_READY so ``kct audit`` exits 2 (the gate FAILs).
+        if self.isolation.checked and not self.isolation.passed:
             return AuditVerdict.NOT_READY
 
         # Schematic refs missing from PCB == unbuildable BOM == hard fail.
@@ -356,6 +432,17 @@ class AuditResult:
         if self.drc.passed and not self.drc.geometric_drc_ran:
             return AuditVerdict.WARNING
 
+        # HV / isolation soft gate (issue #4333): HV nets are present but the
+        # path could NOT be authoritatively gated -- either no requirement was
+        # specified (no --hv-min / --hv-standard) or the census could not be
+        # evaluated (shapely absent / standard-table lookup error).  Mirror the
+        # non-authoritative-DRC policy: downgrade to WARNING so the board is
+        # never silently green on an un-evaluated HV path.
+        if self.isolation.hv_present and (
+            self.isolation.could_not_verify or not self.isolation.threshold_supplied
+        ):
+            return AuditVerdict.WARNING
+
         return AuditVerdict.READY
 
     @property
@@ -379,6 +466,8 @@ class AuditResult:
             "sync_pcb_only": self.sync.pcb_only_count,
             "sync_value_mismatches": self.sync.value_mismatch_count,
             "sync_footprint_mismatches": self.sync.footprint_mismatch_count,
+            "isolation_checked": self.isolation.checked,
+            "isolation_passed": self.isolation.passed,
         }
 
     def to_dict(self) -> dict:
@@ -396,6 +485,7 @@ class AuditResult:
             "sync": self.sync.to_dict(),
             "connectivity": self.connectivity.to_dict(),
             "compatibility": self.compatibility.to_dict(),
+            "isolation": self.isolation.to_dict(),
             "layers": self.layers.to_dict(),
             "cost": self.cost.to_dict(),
             "action_items": [a.to_dict() for a in self.action_items],
@@ -426,6 +516,12 @@ class ManufacturingAudit:
         no_assembly: bool = False,
         pcb_override: Path | None = None,
         net_class_map_path: str | Path | None = None,
+        hv_net_class: str = "HV",
+        hv_min_mm: float | None = None,
+        hv_standard: str | None = None,
+        hv_working_voltage: float | None = None,
+        hv_pollution_degree: int | None = None,
+        hv_material_group: str = "IIIa",
     ):
         """Initialize the audit.
 
@@ -445,6 +541,15 @@ class ManufacturingAudit:
                 When supplied, the diff-pair routing-continuity and
                 length-skew DRC rules can fire on routed boards.  Issue
                 #2684 -- mirrors the ``kct check --net-class-map`` flag.
+            hv_net_class: Net-class name treated as the HV group for the
+                creepage/isolation audit (issue #4333, default ``HV``).
+            hv_min_mm: Manual required creepage in mm (phase-1 override).
+            hv_standard: IEC standard id (``iec60664`` / ``iec62368``) to
+                derive the required creepage AND clearance (phase-2).  Requires
+                ``hv_working_voltage`` and ``hv_pollution_degree``.
+            hv_working_voltage: RMS working voltage (V) for standard derivation.
+            hv_pollution_degree: IEC pollution degree (1/2/3) for derivation.
+            hv_material_group: Insulation material group (default ``IIIa``).
         """
         self.path = Path(project_or_pcb)
         self.manufacturer = manufacturer
@@ -456,6 +561,13 @@ class ManufacturingAudit:
         self.net_class_map_path = (
             Path(net_class_map_path) if net_class_map_path is not None else None
         )
+        # HV / isolation (creepage) audit configuration (issue #4333).
+        self.hv_net_class = hv_net_class or "HV"
+        self.hv_min_mm = hv_min_mm
+        self.hv_standard = hv_standard
+        self.hv_working_voltage = hv_working_voltage
+        self.hv_pollution_degree = hv_pollution_degree
+        self.hv_material_group = hv_material_group
 
         # Resolve paths
         if self.path.suffix == ".kicad_pro":
@@ -639,6 +751,7 @@ class ManufacturingAudit:
             result.compatibility = self._check_compatibility(pcb)
             result.layers = self._check_layer_utilization(pcb)
             result.cost = self._estimate_cost(pcb)
+            result.isolation = self._check_isolation(pcb)
 
         # Run schematic <-> PCB sync drift check before generating action
         # items so the action-item generator can read result.sync and emit
@@ -1069,6 +1182,191 @@ class ManufacturingAudit:
             logger.warning(f"Connectivity check failed: {e}")
             status.details = f"Connectivity check could not run: {e}"
             status.passed = False
+
+        return status
+
+    def _check_isolation(self, pcb: PCB) -> IsolationStatus:
+        """Check HV creepage/clearance isolation (issue #4333, phase 3).
+
+        Reuses the phase-1/phase-2 creepage engine end-to-end -- HV-net
+        resolution (:func:`resolve_hv_nets`), the surface-path census
+        (:func:`compute_creepage_census`), and (in standard mode) the IEC
+        table derivation (:meth:`CreepageStandard.required_creepage` /
+        ``required_clearance``).  No geometry or table math is reimplemented.
+
+        The returned status gates the verdict via :attr:`AuditResult.verdict`:
+        a resolved below-standard pair -> ``NOT_READY``; HV present but not
+        gateable (no threshold / shapely absent / lookup error) -> ``WARNING``;
+        no HV nets -> inert (``checked=False``, no verdict change).
+        """
+        status = IsolationStatus(standard=self.hv_standard)
+
+        # Parse the net-class-map sidecar with the SAME block _check_drc uses
+        # so HV selection agrees with the diff-pair DRC rules (issue #2684).
+        net_class_map = None
+        if self.net_class_map_path is not None:
+            try:
+                import json as _json
+
+                from kicad_tools.router.rules import net_class_map_from_dict
+
+                ncm_data = _json.loads(self.net_class_map_path.read_text())
+                net_class_map = net_class_map_from_dict(ncm_data)
+            except (OSError, ValueError, TypeError) as e:
+                logger.warning(
+                    "Isolation check: failed to load net-class-map from %s: %s",
+                    self.net_class_map_path,
+                    e,
+                )
+
+        from kicad_tools.creepage.engine import resolve_hv_nets
+
+        try:
+            hv_nets = resolve_hv_nets(pcb, self.hv_net_class, net_class_map)
+        except Exception as e:  # pragma: no cover - defensive
+            # Never let HV-net resolution crash the whole audit.
+            logger.warning("Isolation check: HV-net resolution failed: %s", e)
+            status.could_not_verify = True
+            status.hv_present = True
+            status.details = f"HV-net resolution failed: {e}"
+            return status
+
+        if not hv_nets:
+            # No HV-class nets -> inert; no section, no verdict change.
+            status.details = f"No '{self.hv_net_class}' nets found -- HV/isolation audit skipped."
+            return status
+
+        status.hv_present = True
+        status.hv_nets = [hv_nets[num] for num in sorted(hv_nets)]
+
+        threshold_supplied = self.hv_min_mm is not None or self.hv_standard is not None
+        status.threshold_supplied = threshold_supplied
+
+        # Shapely is required for the surface-path census.  Guard it fail-loud
+        # (mirrors the connectivity could-not-verify policy) so a missing core
+        # dependency degrades to WARNING rather than crashing the audit.
+        from kicad_tools._shapely import has_shapely
+
+        if not has_shapely():
+            status.could_not_verify = True
+            status.details = (
+                "HV nets present but creepage analysis requires shapely "
+                "(not importable) -- isolation NOT verified."
+            )
+            return status
+
+        # Derive the required creepage/clearance from an IEC standard table when
+        # requested (phase-2), mirroring the ``kct creepage`` wiring exactly.
+        required_creepage_mm: float | None = None
+        required_clearance_mm: float | None = None
+        creepage_prov: dict | None = None
+        clearance_prov: dict | None = None
+        if self.hv_standard is not None:
+            from kicad_tools.creepage.standards import (
+                RMS_TO_PEAK,
+                StandardLookupError,
+                get_standard,
+            )
+
+            if self.hv_working_voltage is None or self.hv_pollution_degree is None:
+                status.could_not_verify = True
+                status.details = (
+                    "HV standard supplied but --hv-working-voltage and "
+                    "--hv-pollution-degree are both required -- isolation NOT verified."
+                )
+                return status
+            try:
+                std = get_standard(self.hv_standard)
+                required_creepage_mm, creepage_prov = std.required_creepage(
+                    float(self.hv_working_voltage),
+                    int(self.hv_pollution_degree),
+                    self.hv_material_group,
+                )
+                peak_voltage = float(self.hv_working_voltage) * RMS_TO_PEAK
+                required_clearance_mm, clearance_prov = std.required_clearance(
+                    peak_voltage, int(self.hv_pollution_degree)
+                )
+                status.standard_edition = std.edition
+            except StandardLookupError as e:
+                # Safety-critical: fail LOUD, never emit a guessed number.
+                status.could_not_verify = True
+                status.details = f"standard-table lookup failed: {e}"
+                return status
+
+        from kicad_tools.creepage.engine import compute_creepage_census
+
+        try:
+            report = compute_creepage_census(
+                pcb,
+                hv_nets,
+                self.hv_min_mm,
+                net_class=self.hv_net_class,
+                board=str(self.pcb_path),
+                required_creepage_mm=required_creepage_mm,
+                required_clearance_mm=required_clearance_mm,
+                standard=self.hv_standard,
+                standard_edition=status.standard_edition,
+                working_voltage=self.hv_working_voltage,
+                pollution_degree=self.hv_pollution_degree,
+                material_group=(self.hv_material_group if self.hv_standard is not None else None),
+                creepage_provenance=creepage_prov,
+                clearance_provenance=clearance_prov,
+            )
+        except Exception as e:
+            # A genuine census crash must NOT be coerced into a clean PASS.
+            logger.warning("Isolation check: creepage census failed: %s", e)
+            status.could_not_verify = True
+            status.details = f"creepage census could not run: {e}"
+            return status
+
+        status.report = report.to_dict()
+        status.pair_count = len(report.pairs)
+        status.required_creepage_mm = required_creepage_mm
+        status.required_clearance_mm = required_clearance_mm
+        if report.pairs:
+            status.min_creepage_mm = min(p.creepage_mm for p in report.pairs)
+            status.min_clearance_mm = min(p.clearance_mm for p in report.pairs)
+
+        if threshold_supplied:
+            # Fully gated: the verdict can hard-fail on this result.
+            status.checked = True
+            status.passed = report.passed
+            status.failing_pairs = [
+                {
+                    "net_a": p.net_a,
+                    "net_b": p.net_b,
+                    "kind": p.kind,
+                    "creepage_mm": round(p.creepage_mm, 4),
+                    "clearance_mm": round(p.clearance_mm, 4),
+                    "margin_mm": round(p.margin_mm, 4),
+                    "required_creepage_mm": (
+                        round(p.governing_creepage_mm, 4) if p.governing_creepage_mm else None
+                    ),
+                    "required_clearance_mm": (
+                        round(p.required_clearance_mm, 4)
+                        if p.required_clearance_mm is not None
+                        else None
+                    ),
+                }
+                for p in report.pairs
+                if not p.passed
+            ]
+            if status.passed:
+                status.details = (
+                    f"All {status.pair_count} HV pair(s) clear the required creepage/clearance."
+                )
+            else:
+                status.details = (
+                    f"{len(status.failing_pairs)}/{status.pair_count} HV pair(s) "
+                    "below the required creepage/clearance."
+                )
+        else:
+            # HV present, census rendered informationally, but no requirement
+            # was supplied -> cannot gate (verdict downgrades to WARNING).
+            status.details = (
+                "HV nets present but no isolation requirement specified "
+                "(--hv-min / --hv-standard) -- cannot gate."
+            )
 
         return status
 

--- a/src/kicad_tools/cli/audit_cmd.py
+++ b/src/kicad_tools/cli/audit_cmd.py
@@ -102,6 +102,60 @@ def main(argv: list[str] | None = None) -> int:
             "(Issue #2684)."
         ),
     )
+    # HV / isolation (creepage) audit flags (Issue #4333, phase 3).  All
+    # additive; the isolation section only activates when HV nets resolve AND
+    # a threshold source (--hv-min or --hv-standard) is supplied.  HV net
+    # selection reuses the existing --net-class-map sidecar.
+    parser.add_argument(
+        "--hv-net-class",
+        dest="hv_net_class",
+        default="HV",
+        help="Net class treated as the HV group for the isolation audit (default: HV)",
+    )
+    parser.add_argument(
+        "--hv-min",
+        dest="hv_min",
+        type=float,
+        default=None,
+        help=(
+            "Manual required creepage (surface-path) distance in mm (phase-1). "
+            "When combined with --hv-standard the stricter creepage bound governs."
+        ),
+    )
+    parser.add_argument(
+        "--hv-standard",
+        dest="hv_standard",
+        choices=["iec60664", "iec62368"],
+        default=None,
+        help=(
+            "Derive the required creepage AND clearance from an IEC standard "
+            "table (iec60664 / iec62368) instead of --hv-min.  Requires "
+            "--hv-working-voltage and --hv-pollution-degree.  Engineering aid, "
+            "NOT a certification."
+        ),
+    )
+    parser.add_argument(
+        "--hv-working-voltage",
+        dest="hv_working_voltage",
+        type=float,
+        default=None,
+        help="RMS working voltage in volts (required with --hv-standard).",
+    )
+    parser.add_argument(
+        "--hv-pollution-degree",
+        dest="hv_pollution_degree",
+        type=int,
+        choices=[1, 2, 3],
+        default=None,
+        help="IEC pollution degree 1/2/3 (required with --hv-standard).",
+    )
+    parser.add_argument(
+        "--hv-material-group",
+        dest="hv_material_group",
+        choices=["I", "II", "IIIa", "IIIb"],
+        default="IIIa",
+        help="Insulation material group by CTI (default: IIIa, conservative for FR-4).",
+    )
     parser.add_argument(
         "--strict",
         action="store_true",
@@ -141,6 +195,12 @@ def main(argv: list[str] | None = None) -> int:
             no_assembly=args.no_assembly,
             pcb_override=args.pcb,
             net_class_map_path=args.net_class_map,
+            hv_net_class=args.hv_net_class,
+            hv_min_mm=args.hv_min,
+            hv_standard=args.hv_standard,
+            hv_working_voltage=args.hv_working_voltage,
+            hv_pollution_degree=args.hv_pollution_degree,
+            hv_material_group=args.hv_material_group,
         )
         result = audit.run()
     except ValueError as e:
@@ -334,6 +394,11 @@ def output_table(result: AuditResult, verbose: bool = False) -> None:
         layers_icon = "OK" if layers[2] else "X"
         print(f"    [{layers_icon}] Layers: {layers[0]} (supported: {layers[1]})")
 
+    # HV / Isolation (creepage) -- only when HV nets were present (Issue #4333).
+    iso = result.isolation
+    if iso.hv_present:
+        _output_isolation_section(iso)
+
     # Layer utilization
     if verbose and result.layers.utilization:
         print(f"\n{'-' * 70}")
@@ -374,6 +439,79 @@ def output_table(result: AuditResult, verbose: bool = False) -> None:
     print(f"\n{'=' * 70}")
 
 
+def _output_isolation_section(iso) -> None:
+    """Render the HV / Isolation (creepage) audit block (Issue #4333).
+
+    Reports, per HV net group, the measured minimum creepage and clearance
+    against the IEC-derived (or manual) required values with distinct margins,
+    plus the governing standard citation and the standards DISCLAIMER.
+    """
+    if iso.could_not_verify:
+        icon, verdict = "!!", "COULD NOT VERIFY"
+    elif not iso.threshold_supplied:
+        icon, verdict = "!!", "NO REQUIREMENT SPECIFIED"
+    elif iso.passed:
+        icon, verdict = "OK", "PASS"
+    else:
+        icon, verdict = "X", "FAIL"
+
+    print(f"\n[{icon}] HV / Isolation (creepage): {verdict}")
+    hv_nets = ", ".join(iso.hv_nets) if iso.hv_nets else "(none)"
+    print(f"    HV nets ({len(iso.hv_nets)}): {hv_nets}")
+
+    if iso.could_not_verify or not iso.threshold_supplied:
+        if iso.details:
+            print(f"    Note: {iso.details}")
+        # Still surface the measured census informationally when we have it.
+        if iso.min_creepage_mm is not None:
+            print(
+                f"    Measured min creepage: {iso.min_creepage_mm:.3f}mm, "
+                f"min clearance: {iso.min_clearance_mm:.3f}mm "
+                f"({iso.pair_count} pair(s))"
+            )
+        return
+
+    if iso.standard:
+        edition = f" {iso.standard_edition}" if iso.standard_edition else ""
+        print(f"    Standard: {iso.standard}{edition}")
+
+    # Creepage (surface path) -- always thresholded.
+    if iso.min_creepage_mm is not None and iso.required_creepage_mm is not None:
+        margin = iso.min_creepage_mm - iso.required_creepage_mm
+        cr_icon = "OK" if margin >= -1e-4 else "X"
+        print(
+            f"    [{cr_icon}] Creepage: {iso.min_creepage_mm:.3f}mm "
+            f"(required: {iso.required_creepage_mm:.3f}mm, margin: {margin:+.3f}mm)"
+        )
+    elif iso.min_creepage_mm is not None:
+        print(f"    Creepage (min measured): {iso.min_creepage_mm:.3f}mm")
+
+    # Clearance (through-air) -- only thresholded in standard mode.
+    if iso.min_clearance_mm is not None and iso.required_clearance_mm is not None:
+        margin = iso.min_clearance_mm - iso.required_clearance_mm
+        cl_icon = "OK" if margin >= -1e-4 else "X"
+        print(
+            f"    [{cl_icon}] Clearance: {iso.min_clearance_mm:.3f}mm "
+            f"(required: {iso.required_clearance_mm:.3f}mm, margin: {margin:+.3f}mm)"
+        )
+    elif iso.min_clearance_mm is not None:
+        print(f"    Clearance (min measured): {iso.min_clearance_mm:.3f}mm")
+
+    if iso.pair_count == 0:
+        print("    Census: 0 pairs (HV nets present but no other conductors / edge).")
+
+    for fp in iso.failing_pairs[:5]:
+        print(
+            f"    [X] {fp['net_a']} <-> {fp['net_b']} ({fp['kind']}): "
+            f"creepage {fp['creepage_mm']:.3f}mm / clearance {fp['clearance_mm']:.3f}mm"
+        )
+
+    if iso.standard:
+        from kicad_tools.creepage.standards import DISCLAIMER
+
+        print(f"    NOTE: {DISCLAIMER}")
+
+
 def output_json(result: AuditResult) -> None:
     """Output audit results as JSON."""
     print(json.dumps(result.to_dict(), indent=2, default=str))
@@ -408,6 +546,14 @@ def output_summary(result: AuditResult) -> None:
         )
     print(f"  Net completion: {summary['net_completion']:.0f}%")
     print(f"  Manufacturer compatible: {'Yes' if summary['manufacturer_compatible'] else 'No'}")
+    if result.isolation.hv_present:
+        if result.isolation.checked:
+            iso_state = "PASS" if result.isolation.passed else "FAIL"
+        elif result.isolation.could_not_verify:
+            iso_state = "could not verify"
+        else:
+            iso_state = "no requirement specified"
+        print(f"  HV isolation: {iso_state}")
     if summary["estimated_cost"] > 0:
         print(f"  Estimated cost: ${summary['estimated_cost']:.2f}")
     if summary["action_items"] > 0:

--- a/tests/creepage/fixtures.py
+++ b/tests/creepage/fixtures.py
@@ -74,6 +74,21 @@ def board_source(with_slot: bool) -> str:
     return "".join(parts)
 
 
+def board_close_hv_source() -> str:
+    """Two 2x2 pads (L_MAINS at x=110, GND at x=113) -- a ~1 mm HV gap.
+
+    Pad copper edges sit at x=111 (L_MAINS) and x=112 (GND), so the
+    straight-line clearance (and, with no slot, the creepage) is ~1 mm -- far
+    below any realistic IEC-derived mains requirement.  Used for the
+    below-standard gate-FAIL path.
+    """
+    parts = [_HEADER, _OUTLINE]
+    parts.append(_footprint("U1", 110, 110, 1, "L_MAINS"))
+    parts.append(_footprint("U2", 113, 110, 2, "GND"))
+    parts.append(")\n")
+    return "".join(parts)
+
+
 def board_no_hv_source() -> str:
     """Board whose only assigned nets are GND / SIG -- no HV net exists."""
     header = _HEADER.replace('(net 1 "L_MAINS")', '(net 1 "SIG")')

--- a/tests/test_audit_hv_isolation.py
+++ b/tests/test_audit_hv_isolation.py
@@ -1,0 +1,418 @@
+"""Tests for the ``kct audit`` HV/isolation (creepage) section (Issue #4333).
+
+Phase-3 integration of the phase-1/phase-2 creepage engine into the
+manufacturing-readiness audit.  The audit consumes the engine end-to-end
+(``resolve_hv_nets`` + ``compute_creepage_census`` + the IEC standard-table
+derivation) and folds a below-standard HV pair into the ``NOT_READY`` verdict
+so ``kct audit`` exits 2 (the manufacturing-readiness gate FAILs).
+
+Two layers of tests:
+
+* **Behavioral** (via ``ManufacturingAudit.run()``): assert on
+  ``result.isolation.*`` and rendered output.  The synthetic single-pad
+  fixtures are inherently ``NOT_READY`` for unrelated reasons (unrouted nets,
+  no zones), so these tests never assert the *aggregate* verdict.
+* **Verdict roll-up** (``TestVerdictRollup``): construct an otherwise-clean
+  ``AuditResult`` and vary only ``isolation`` to prove its verdict / exit-code
+  contribution in isolation.
+
+CI-safety: these tests use the synthetic creepage fixtures
+(``tests/creepage/fixtures.py``), NEVER the local-only softstart board.  The
+``L_MAINS`` net does not classify to ``HV`` by name, so a ``net_class_map``
+sidecar maps it explicitly (same pattern as ``test_creepage_cli.py``).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from kicad_tools._shapely import has_shapely
+from kicad_tools.audit import AuditResult, AuditVerdict, IsolationStatus, ManufacturingAudit
+from kicad_tools.cli import audit_cmd
+from tests.creepage.fixtures import (
+    board_close_hv_source,
+    board_no_hv_source,
+    board_source,
+)
+
+pytestmark = pytest.mark.skipif(not has_shapely(), reason="creepage requires shapely")
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+
+def _write(tmp_path, source, name="board.kicad_pcb"):
+    p = tmp_path / name
+    p.write_text(source)
+    return p
+
+
+def _hv_map_file(tmp_path):
+    p = tmp_path / "net_class_map.json"
+    p.write_text(json.dumps({"L_MAINS": {"name": "HV"}}))
+    return p
+
+
+def _audit(pcb, ncm, **hv):
+    return ManufacturingAudit(
+        pcb,
+        manufacturer="jlcpcb",
+        net_class_map_path=ncm,
+        **hv,
+    )
+
+
+# --------------------------------------------------------------------------
+# Behavioral: section + PASS (phase-2 standard mode)
+# --------------------------------------------------------------------------
+
+
+def test_standard_mode_pass_section_rendered(tmp_path, capsys):
+    """A compliant HV board: checked + passed, section renders derived values."""
+    pcb = _write(tmp_path, board_source(with_slot=True))
+    ncm = _hv_map_file(tmp_path)
+    # iec60664 @ 250 V RMS, PD2, IIIa -> ~2.5 mm creepage; the ~18 mm gap clears it.
+    audit = _audit(
+        pcb,
+        ncm,
+        hv_standard="iec60664",
+        hv_working_voltage=250.0,
+        hv_pollution_degree=2,
+        hv_material_group="IIIa",
+    )
+    result = audit.run()
+    iso = result.isolation
+
+    assert iso.hv_present is True
+    assert iso.checked is True
+    assert iso.passed is True
+    assert iso.hv_nets == ["L_MAINS"]
+    assert iso.standard == "iec60664"
+    assert iso.required_creepage_mm is not None
+    assert iso.required_clearance_mm is not None
+    # Measured creepage/clearance are distinct, populated values.
+    assert iso.min_creepage_mm is not None and iso.min_clearance_mm is not None
+    # A compliant HV pair does NOT contribute a hard fail.
+    assert not (iso.checked and not iso.passed)
+
+    audit_cmd.output_table(result, verbose=True)
+    out = capsys.readouterr().out
+    assert "HV / Isolation" in out
+    assert "Creepage" in out and "Clearance" in out
+    assert "iec60664" in out
+    # The standards disclaimer must accompany a derived-value section.
+    assert "certification" in out.lower()
+
+
+# --------------------------------------------------------------------------
+# Behavioral: below-standard pair captured (gate-FAIL source)
+# --------------------------------------------------------------------------
+
+
+def test_below_standard_pair_fails_and_is_not_ready(tmp_path):
+    """A too-close HV pair -> isolation FAIL -> verdict NOT_READY."""
+    pcb = _write(tmp_path, board_close_hv_source())
+    ncm = _hv_map_file(tmp_path)
+    audit = _audit(
+        pcb,
+        ncm,
+        hv_standard="iec60664",
+        hv_working_voltage=250.0,
+        hv_pollution_degree=2,
+        hv_material_group="IIIa",
+    )
+    result = audit.run()
+
+    assert result.isolation.checked is True
+    assert result.isolation.passed is False
+    assert result.isolation.failing_pairs  # at least one failing pair captured
+    # Independent of the fixture's other NOT_READY reasons, isolation FAIL is a
+    # hard-fail contributor, so the aggregate verdict is NOT_READY.
+    assert result.verdict == AuditVerdict.NOT_READY
+
+
+def test_gate_exit_code_2_on_fail(tmp_path, capsys):
+    """``kct audit`` returns exit 2 (gate FAIL) for a below-standard HV pair."""
+    pcb = _write(tmp_path, board_close_hv_source())
+    ncm = _hv_map_file(tmp_path)
+    rc = audit_cmd.main(
+        [
+            str(pcb),
+            "--skip-erc",
+            "--net-class-map",
+            str(ncm),
+            "--hv-standard",
+            "iec60664",
+            "--hv-working-voltage",
+            "250",
+            "--hv-pollution-degree",
+            "2",
+        ]
+    )
+    out = capsys.readouterr().out
+    assert rc == 2
+    assert "HV / Isolation" in out
+    assert "FAIL" in out
+
+
+# --------------------------------------------------------------------------
+# Behavioral: phase-1 manual --hv-min governs identically
+# --------------------------------------------------------------------------
+
+
+def test_phase1_min_governs_pass_and_fail(tmp_path):
+    """Manual --hv-min with no standard gates pass/fail; report has no standard."""
+    ncm = _hv_map_file(tmp_path)
+
+    # PASS: 1.5 mm required, ~18 mm measured.
+    pcb_ok = _write(tmp_path, board_source(with_slot=False), name="ok.kicad_pcb")
+    res_ok = _audit(pcb_ok, ncm, hv_min_mm=1.5).run()
+    assert res_ok.isolation.checked is True
+    assert res_ok.isolation.passed is True
+    assert res_ok.isolation.standard is None
+    # Phase-1 dict schema: no 'standard' key in the embedded report.
+    assert "standard" not in res_ok.isolation.report
+
+    # FAIL: 100 mm required, ~18 mm measured.
+    pcb_bad = _write(tmp_path, board_source(with_slot=False), name="bad.kicad_pcb")
+    res_bad = _audit(pcb_bad, ncm, hv_min_mm=100.0).run()
+    assert res_bad.isolation.passed is False
+    assert res_bad.verdict == AuditVerdict.NOT_READY
+
+
+# --------------------------------------------------------------------------
+# Behavioral: HV present but no threshold -> no gate (rendered informationally)
+# --------------------------------------------------------------------------
+
+
+def test_hv_present_no_threshold_not_checked(tmp_path, capsys):
+    """HV nets present but neither --hv-min nor --hv-standard -> not checked."""
+    pcb = _write(tmp_path, board_source(with_slot=False))
+    ncm = _hv_map_file(tmp_path)
+    result = _audit(pcb, ncm).run()
+    iso = result.isolation
+
+    assert iso.hv_present is True
+    assert iso.threshold_supplied is False
+    assert iso.checked is False
+    assert "no isolation requirement" in iso.details.lower()
+
+    audit_cmd.output_table(result)
+    out = capsys.readouterr().out
+    assert "HV / Isolation" in out
+    assert "NO REQUIREMENT SPECIFIED" in out
+
+
+# --------------------------------------------------------------------------
+# Behavioral: no HV nets -> zero regression
+# --------------------------------------------------------------------------
+
+
+def test_no_hv_nets_no_section(tmp_path, capsys):
+    """A non-HV board: no section, checked=False, hv_present=False."""
+    pcb = _write(tmp_path, board_no_hv_source())
+    ncm = _hv_map_file(tmp_path)
+    result = _audit(
+        pcb,
+        ncm,
+        hv_standard="iec60664",
+        hv_working_voltage=250.0,
+        hv_pollution_degree=2,
+    ).run()
+    iso = result.isolation
+
+    assert iso.hv_present is False
+    assert iso.checked is False
+    assert iso.passed is True
+
+    audit_cmd.output_table(result)
+    out = capsys.readouterr().out
+    assert "HV / Isolation" not in out
+
+
+def test_no_hv_nets_json_isolation_inert(tmp_path):
+    """No-HV board: JSON carries an inert isolation object (checked=false)."""
+    pcb = _write(tmp_path, board_no_hv_source())
+    ncm = _hv_map_file(tmp_path)
+    result = _audit(pcb, ncm, hv_min_mm=1.5).run()
+    data = result.to_dict()
+
+    assert "isolation" in data
+    assert data["isolation"]["checked"] is False
+    assert data["isolation"]["hv_present"] is False
+    assert data["isolation"]["report"] == {}
+    # Pre-existing keys remain present (no JSON drift).
+    for key in ("erc", "drc", "sync", "connectivity", "compatibility", "layers", "cost"):
+        assert key in data
+
+
+# --------------------------------------------------------------------------
+# Behavioral: JSON schema -- isolation.report matches standard-mode census
+# --------------------------------------------------------------------------
+
+
+def test_json_isolation_report_standard_schema(tmp_path, capsys):
+    """--format json embeds the standard-mode CreepageReport schema verbatim."""
+    pcb = _write(tmp_path, board_source(with_slot=True))
+    ncm = _hv_map_file(tmp_path)
+    audit_cmd.main(
+        [
+            str(pcb),
+            "--skip-erc",
+            "--format",
+            "json",
+            "--net-class-map",
+            str(ncm),
+            "--hv-standard",
+            "iec60664",
+            "--hv-working-voltage",
+            "250",
+            "--hv-pollution-degree",
+            "2",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["isolation"]["passed"] is True
+
+    report = payload["isolation"]["report"]
+    # Standard-mode schema fields (mirrors `kct creepage --format json`).
+    for key in (
+        "standard",
+        "standard_edition",
+        "required_creepage_mm",
+        "required_clearance_mm",
+        "creepage_provenance",
+        "clearance_provenance",
+        "pairs",
+        "pair_count",
+        "passed",
+    ):
+        assert key in report
+    assert report["standard"] == "iec60664"
+    assert report["hv_nets"] == ["L_MAINS"]
+    # Per-pair clearance-vs-creepage distinction is preserved.
+    assert report["pairs"]
+    for pair in report["pairs"]:
+        assert "clearance_mm" in pair and "creepage_mm" in pair
+
+
+# --------------------------------------------------------------------------
+# Behavioral: edge cases -- StandardLookupError / missing inputs degrade
+# --------------------------------------------------------------------------
+
+
+def test_standard_lookup_error_surfaces_not_crash(tmp_path):
+    """A bad voltage (exceeds tabulated rows) -> could_not_verify, not a crash."""
+    pcb = _write(tmp_path, board_source(with_slot=False))
+    ncm = _hv_map_file(tmp_path)
+    result = _audit(
+        pcb,
+        ncm,
+        hv_standard="iec60664",
+        hv_working_voltage=999999.0,  # far above the highest tabulated row
+        hv_pollution_degree=2,
+    ).run()
+    iso = result.isolation
+
+    assert iso.hv_present is True
+    assert iso.could_not_verify is True
+    assert iso.checked is False
+
+
+def test_standard_without_voltage_could_not_verify(tmp_path):
+    """--hv-standard without working-voltage/PD -> could_not_verify."""
+    pcb = _write(tmp_path, board_source(with_slot=False))
+    ncm = _hv_map_file(tmp_path)
+    result = _audit(pcb, ncm, hv_standard="iec60664").run()
+    iso = result.isolation
+
+    assert iso.hv_present is True
+    assert iso.could_not_verify is True
+    assert iso.checked is False
+
+
+# --------------------------------------------------------------------------
+# Verdict roll-up: isolation's contribution proven on an otherwise-clean result
+# --------------------------------------------------------------------------
+
+
+class TestVerdictRollup:
+    """Prove isolation's verdict/exit-code contribution in isolation.
+
+    A default ``AuditResult`` with ``drc.geometric_drc_ran=True`` and all other
+    sub-checks passing rolls up to ``READY``; varying only ``isolation`` shows
+    each transition without interference from the synthetic fixtures' unrelated
+    ``NOT_READY`` causes (unrouted nets, no zones).
+    """
+
+    @staticmethod
+    def _clean_result() -> AuditResult:
+        result = AuditResult(project_name="clean")
+        # Make the DRC authoritative so the baseline is READY, not WARNING.
+        result.drc.geometric_drc_ran = True
+        return result
+
+    def test_baseline_ready_no_isolation(self):
+        """Zero regression: default (no HV) isolation leaves the verdict READY."""
+        result = self._clean_result()
+        assert result.isolation.hv_present is False
+        assert result.verdict == AuditVerdict.READY
+
+    def test_compliant_isolation_stays_ready(self):
+        """A compliant, checked HV pair keeps the board READY (exit 0)."""
+        result = self._clean_result()
+        result.isolation = IsolationStatus(
+            checked=True, hv_present=True, threshold_supplied=True, passed=True
+        )
+        assert result.verdict == AuditVerdict.READY
+
+    def test_below_standard_isolation_not_ready(self):
+        """A below-standard HV pair (checked, not passed) -> NOT_READY (exit 2)."""
+        result = self._clean_result()
+        result.isolation = IsolationStatus(
+            checked=True, hv_present=True, threshold_supplied=True, passed=False
+        )
+        assert result.verdict == AuditVerdict.NOT_READY
+
+    def test_hv_present_no_threshold_warns(self):
+        """HV present with no requirement specified -> WARNING (no silent green)."""
+        result = self._clean_result()
+        result.isolation = IsolationStatus(checked=False, hv_present=True, threshold_supplied=False)
+        assert result.verdict == AuditVerdict.WARNING
+
+    def test_could_not_verify_warns(self):
+        """HV present but shapely-absent / lookup error -> WARNING (fail-loud)."""
+        result = self._clean_result()
+        result.isolation = IsolationStatus(
+            hv_present=True, threshold_supplied=True, could_not_verify=True
+        )
+        assert result.verdict == AuditVerdict.WARNING
+
+    def test_exit_code_maps_from_verdict(self, tmp_path, monkeypatch, capsys):
+        """The CLI exit code reflects the isolation-driven verdict.
+
+        FAIL -> 2 (no --strict needed); compliant -> 0.
+        """
+        pcb = tmp_path / "b.kicad_pcb"
+        pcb.write_text(board_source(with_slot=False))
+
+        # Force a below-standard isolation FAIL through a stubbed audit run.
+        fail_result = self._clean_result()
+        fail_result.isolation = IsolationStatus(
+            checked=True, hv_present=True, threshold_supplied=True, passed=False
+        )
+        monkeypatch.setattr(audit_cmd.ManufacturingAudit, "run", lambda self: fail_result)
+        assert audit_cmd.main([str(pcb), "--skip-erc"]) == 2
+        capsys.readouterr()
+
+        # A compliant isolation on an otherwise-clean board exits 0.
+        ok_result = self._clean_result()
+        ok_result.isolation = IsolationStatus(
+            checked=True, hv_present=True, threshold_supplied=True, passed=True
+        )
+        monkeypatch.setattr(audit_cmd.ManufacturingAudit, "run", lambda self: ok_result)
+        assert audit_cmd.main([str(pcb), "--skip-erc"]) == 0


### PR DESCRIPTION
## Summary

Phase 3 of #4327 — wires the phase-1/phase-2 creepage engine (phase-2 dep #4332, merged) into `kct audit` so a below-standard HV pair automatically fails the manufacturing-readiness gate. **Pure integration**: the creepage engine and standards tables are consumed unchanged (no geometry or table-lookup reimplementation).

## What was wired

**Audit section (`src/kicad_tools/audit/auditor.py`)**
- New `IsolationStatus` dataclass on `AuditResult` with `to_dict()`; additive `"isolation"` key in `AuditResult.to_dict()` + additive `summary()` fields.
- `AuditResult.verdict` roll-up:
  - isolation `checked and not passed` → **NOT_READY** (hard fail, alongside DRC/compat).
  - HV present but no threshold specified, or `could_not_verify` (shapely absent / `StandardLookupError`) → **WARNING** (never silently green).
  - no HV nets → inert (`checked=False`), no verdict change.
- New `_check_isolation()` reuses the `_check_drc` net-class-map block, guards `has_shapely()` fail-loud, and mirrors `kct creepage`'s `get_standard().required_creepage/clearance` derivation. Called from `run()` after `_estimate_cost`.

**Gate (`src/kicad_tools/cli/audit_cmd.py`)**
- `kct audit`'s exit code IS the gate: `verdict==NOT_READY` → **exit 2**. Folding isolation FAIL into NOT_READY means a below-standard HV pair fails the gate with **no new exit plumbing**.
- New additive flags `--hv-net-class / --hv-min / --hv-standard / --hv-working-voltage / --hv-pollution-degree / --hv-material-group` (reuses existing `--net-class-map` for HV selection).
- New HV/Isolation table block: measured-vs-IEC-derived creepage **and** clearance with **distinct** margins, standard/edition citation, failing pairs, and the standards `DISCLAIMER`. JSON emits `isolation.report` verbatim from `CreepageReport.to_dict()`.

**Skill doc** — conditional HV/isolation **Gate 4** added to `.claude/commands/kct/manufacturing-readiness.md` sign-off ritual + checklist (mains/HV boards only).

## Acceptance criteria — all 8 covered

- [x] HV/Isolation section renders measured-vs-derived creepage/clearance with margins (clearance distinct from creepage).
- [x] Reuses the engine (`resolve_hv_nets` + `compute_creepage_census` + `get_standard`); no reimplementation.
- [x] Below-standard HV pair → NOT_READY / **exit 2** (gate FAIL); compliant → not a hard fail (exit 0 mapping proven).
- [x] HV present but no threshold → WARNING (explicit "no isolation requirement specified" note).
- [x] No-HV zero-regression: no section, `checked=false`, inert JSON key, pre-existing keys intact.
- [x] Additive-only JSON via `CreepageReport.to_dict()` (standard/edition/required/provenance/pairs).
- [x] Skill-doc gate line.
- [x] shapely-absent → `could_not_verify` WARNING, never a hard crash.

## Testing

New CI-safe `tests/test_audit_hv_isolation.py` (16 tests) using the synthetic creepage fixtures (new `board_close_hv_source` for the too-close FAIL case) — **never** the local-only softstart board. Behavioral tests assert on `result.isolation.*` + rendering (the single-pad fixtures are inherently NOT_READY for unrelated reasons); a `TestVerdictRollup` class proves the verdict/exit-code contribution on an otherwise-clean `AuditResult`.

**Gate-FAIL / exit-code result** (`board_close_hv_source`, iec60664 @ 250 V RMS / PD2 / IIIa → required creepage 2.5 mm vs measured 1.0 mm):
```
[X] HV / Isolation (creepage): FAIL
    [X] Creepage: 1.000mm (required: 2.500mm, margin: -1.500mm)
    [OK] Clearance: 1.000mm (required: 0.200mm, margin: +0.800mm)
EXIT 2
```

**Local checks (all green):**
- `pytest tests/test_audit.py tests/creepage/ tests/test_audit_hv_isolation.py` → **264 passed**
- report/collector suites consuming the audit dict → **119 passed**
- `ruff check` + `ruff format --check` on changed files → clean
- mypy baseline (`scripts/ci/check_mypy_baseline.py`) → exit 0, no new type errors (did **not** run `--update` per the known native-env nanobind trap)

Closes #4333 (phase 3 of #4327; builds on #4332).

🤖 Generated with [Claude Code](https://claude.com/claude-code)