### PR TITLE
feat(analyze): current-sense phase 3 — Kelvin-tap integrity + census surfacing

### DIFF
--- a/src/kicad_tools/analysis/current_sense.py
+++ b/src/kicad_tools/analysis/current_sense.py
@@ -23,8 +23,11 @@ Phase 1 scope (see issue #4328):
   **plus** explicit ``sense_nets`` / ``hicur_nets`` name overrides so nets whose
   prefixes are not yet auto-classified (``GATE_*`` / ``SRC_*`` / ``TRK_*``) can
   be tagged today. Auto-classification of those prefixes is deferred to Phase 3.
-* Only same-layer pairs are considered. Inner-layer / broadside coupling is
-  Phase 3 (#4331); copper sense-loop area is Phase 2 (#4330).
+* Only same-layer pairs are considered. Copper sense-loop area is Phase 2
+  (#4330); Kelvin-tap integrity (does the sense line tap the force node at the
+  pad metallization, or mistakenly mid-trace where it picks up IR drop?) is
+  Phase 3 (#4331). Inner-layer / broadside coupling and GATE/SRC/TRK
+  auto-classification are deferred to a possible Phase 3b.
 
 The pairwise parallel-run + gap geometry is computed by the shared
 :func:`kicad_tools.analysis.signal_integrity.calculate_coupling_geometry`
@@ -61,6 +64,7 @@ if TYPE_CHECKING:
 __all__ = [
     "CurrentSenseAnalyzer",
     "CurrentSenseResult",
+    "DEFAULT_KELVIN_TOL_MM",
     "DEFAULT_MAX_LOOP_AREA_MM2",
     "DEFAULT_MAX_PARALLEL_MM",
     "DEFAULT_MIN_GAP_MM",
@@ -76,6 +80,13 @@ DEFAULT_MIN_GAP_MM = 0.5
 # conservative starting value pending EE confirmation (see the issue's note).
 DEFAULT_MAX_LOOP_AREA_MM2 = 10.0
 
+# Phase 3 (#4331): default Kelvin-tap coincidence tolerance (mm). A correct
+# Kelvin sense tap lands on a force-net pad's metallization (KiCad routes a
+# trace's endpoint to the pad anchor, so distance-to-pad is 0). This tolerance
+# is tight because proper taps are exactly coincident; it exists only to absorb
+# sub-micron floating-point noise, not to bless real gaps.
+DEFAULT_KELVIN_TOL_MM = 0.05
+
 # Endpoint-snapping tolerance (mm) used when merging a conductor's segments into
 # ordered polylines. Numerically-coincident joints (and via transitions, whose
 # two layers' segments meet at the shared via position) are merged within this
@@ -90,6 +101,42 @@ _AUTO_PAIR_SUFFIXES: tuple[tuple[str, str], ...] = (
     ("+", "-"),
     ("_H", "_L"),
 )
+
+# Phase 3 (#4331): suffix conventions for auto-pairing a Kelvin *sense* net with
+# its *force* (current-carrying) conductor: ``(sense_suffix, force_suffix)``.
+# ``/I_SENSE`` pairs with ``/I_FORCE``, ``ISNS`` with ``IFRC``. This is a
+# distinct pairing from ``_AUTO_PAIR_SUFFIXES`` (which pairs a sense net with its
+# loop *return*): a sense net's shunt force conductor and its loop return are
+# different partners, so force pairing has its own convention and its own
+# ``--kelvin-pair`` override rather than overloading the loop-return pairing.
+_FORCE_PAIR_SUFFIXES: tuple[tuple[str, str], ...] = (
+    ("_SENSE", "_FORCE"),
+    ("SNS", "FRC"),
+)
+
+
+def _normalize_pairs(
+    raw: list[tuple[str, str]] | list[list[str]] | list[str] | None,
+) -> list[tuple[str, str]]:
+    """Normalize explicit pairings to a list of ``(a, b)`` string 2-tuples.
+
+    Accepts 2-sequences (``("SENSE", "FORCE")``) *and* colon-joined strings
+    (``"SENSE:FORCE"``, the ``--kelvin-pair`` CLI form). Malformed entries are
+    dropped defensively (the analyzer is advisory-only).
+    """
+    out: list[tuple[str, str]] = []
+    for p in raw or []:
+        if p is None:
+            continue
+        if isinstance(p, str):
+            if ":" in p:
+                a, b = p.split(":", 1)
+                if a and b:
+                    out.append((a, b))
+            continue
+        if len(p) == 2 and p[0] and p[1]:
+            out.append((str(p[0]), str(p[1])))
+    return out
 
 
 @dataclass
@@ -123,6 +170,20 @@ class CurrentSenseResult:
         loop_reason: Human-readable reason the loop area is ``None`` (e.g. no
             return conductor, or the loop did not close). ``None`` when a loop
             area was measured.
+        kelvin_status: Phase 3 (#4331). ``"PASS"`` when the sense tap lands on a
+            force-net pad's metallization (proper Kelvin connection),
+            ``"FAIL"`` when the tap coincides with force copper only mid-trace
+            (never at a pad -- it picks up the trace's IR drop), or ``None``
+            when there is no force partner or the connection is indirect
+            (advisory graceful-degrade, no verdict).
+        kelvin_force_net: The resolved force (current-carrying) partner net the
+            tap was checked against, or ``None`` when none resolved.
+        kelvin_tap_gap_mm: On ``FAIL``, how far (mm) the mid-trace tap sits from
+            the nearest force pad (0 would be a PASS); ~0 on ``PASS``; ``None``
+            when there is no verdict.
+        kelvin_reason: Human-readable reason ``kelvin_status`` is ``None`` (e.g.
+            no force pair, tap not coincident with force copper). ``None`` when
+            a Kelvin verdict was reached.
     """
 
     sense_net: str
@@ -137,12 +198,20 @@ class CurrentSenseResult:
     loop_area_mm2: float | None = None
     loop_status: str | None = None
     loop_reason: str | None = None
+    # Phase 3 (#4331) -- additive; default None so Phase-1/2 construction and any
+    # sense net with no resolvable force partner carries null Kelvin fields.
+    kelvin_status: str | None = None
+    kelvin_force_net: str | None = None
+    kelvin_tap_gap_mm: float | None = None
+    kelvin_reason: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to a JSON-serializable dict (mirrors sibling analyzers).
 
         Phase-1 keys are emitted unchanged; Phase-2 adds ``loop_area_mm2`` and
-        ``loop_status`` (always), plus ``loop_reason`` only when it is set.
+        ``loop_status`` (always), plus ``loop_reason`` only when it is set;
+        Phase-3 appends ``kelvin_status``/``kelvin_force_net``/
+        ``kelvin_tap_gap_mm`` (always) and ``kelvin_reason`` only when it is set.
         """
         out: dict[str, Any] = {
             "sense_net": self.sense_net,
@@ -157,6 +226,13 @@ class CurrentSenseResult:
         }
         if self.loop_reason is not None:
             out["loop_reason"] = self.loop_reason
+        out["kelvin_status"] = self.kelvin_status
+        out["kelvin_force_net"] = self.kelvin_force_net
+        out["kelvin_tap_gap_mm"] = (
+            None if self.kelvin_tap_gap_mm is None else round(self.kelvin_tap_gap_mm, 3)
+        )
+        if self.kelvin_reason is not None:
+            out["kelvin_reason"] = self.kelvin_reason
         return out
 
 
@@ -176,6 +252,8 @@ class CurrentSenseAnalyzer:
         max_loop_area_mm2: float = DEFAULT_MAX_LOOP_AREA_MM2,
         sense_pairs: list[tuple[str, str]] | list[list[str]] | None = None,
         sense_return: str | None = None,
+        kelvin_tol_mm: float = DEFAULT_KELVIN_TOL_MM,
+        kelvin_pairs: list[tuple[str, str]] | list[list[str]] | list[str] | None = None,
     ) -> None:
         """Initialize the analyzer.
 
@@ -188,11 +266,17 @@ class CurrentSenseAnalyzer:
                 auto-classification).
             max_loop_area_mm2: Phase 2 (#4330) enclosed-loop-area threshold
                 (mm^2) for the loop FAIL rule.
-            sense_pairs: Explicit Kelvin pairings ``[(sense, return), ...]``.
+            sense_pairs: Explicit Kelvin loop pairings ``[(sense, return), ...]``.
                 Either order matches; the partner conductor closes the loop.
             sense_return: A single shared return-conductor name (e.g. a Kelvin
                 ground) used to close any sense net that has no explicit or
                 auto-detected partner.
+            kelvin_tol_mm: Phase 3 (#4331) Kelvin-tap coincidence tolerance
+                (mm) for PASS/FAIL discrimination.
+            kelvin_pairs: Phase 3 (#4331) explicit sense->force pairings, each a
+                ``(sense, force)`` 2-tuple or a ``"SENSE:FORCE"`` string. Used
+                when the ``_SENSE``/``_FORCE`` (or ``SNS``/``FRC``) suffix
+                convention does not apply.
         """
         self.max_parallel_mm = max_parallel_mm
         self.min_gap_mm = min_gap_mm
@@ -201,12 +285,10 @@ class CurrentSenseAnalyzer:
         self.max_loop_area_mm2 = max_loop_area_mm2
         # Normalize explicit pairs to a list of 2-tuples, dropping malformed
         # entries defensively (advisory-only contract).
-        self.sense_pairs: list[tuple[str, str]] = [
-            (str(p[0]), str(p[1]))
-            for p in (sense_pairs or [])
-            if p is not None and len(p) == 2 and p[0] and p[1]
-        ]
+        self.sense_pairs: list[tuple[str, str]] = _normalize_pairs(sense_pairs)
         self.sense_return = sense_return or None
+        self.kelvin_tol_mm = kelvin_tol_mm
+        self.kelvin_pairs: list[tuple[str, str]] = _normalize_pairs(kelvin_pairs)
 
     # ------------------------------------------------------------------
     # Net classification
@@ -287,6 +369,23 @@ class CurrentSenseAnalyzer:
 
         conductor_names = set(segs_by_name)
 
+        # Phase 3 (#4331): index each net's pad copper (footprint pads) so the
+        # Kelvin check can build force-pad polygons. Advisory: any footprint /
+        # pad access failure degrades to an empty index (all Kelvin None).
+        pads_by_name: dict[str, list[tuple[Any, Any]]] = {}
+        try:
+            for fp in pcb.footprints:
+                for pad in fp.pads:
+                    pname = pad.net_name or num_to_name.get(pad.net_number, "")
+                    if pname:
+                        pads_by_name.setdefault(pname, []).append((pad, fp))
+        except Exception:
+            pads_by_name = {}
+
+        # A net can serve as a force partner if it has any force copper -- a pad
+        # to land on (PASS) or a routed trace to mistakenly T into (FAIL).
+        force_capable_names = set(pads_by_name) | set(segs_by_name)
+
         results: list[CurrentSenseResult] = []
         for sense_name in sorted(sense_names):
             sense_segs = segs_by_name.get(sense_name, [])
@@ -297,6 +396,18 @@ class CurrentSenseAnalyzer:
             result.loop_area_mm2 = area
             result.loop_status = status
             result.loop_reason = reason
+            k_status, k_force, k_gap, k_reason = self._analyze_kelvin(
+                sense_name,
+                sense_segs,
+                vias_by_name.get(sense_name, []),
+                force_capable_names,
+                pads_by_name,
+                segs_by_name,
+            )
+            result.kelvin_status = k_status
+            result.kelvin_force_net = k_force
+            result.kelvin_tap_gap_mm = k_gap
+            result.kelvin_reason = k_reason
             results.append(result)
         return results
 
@@ -459,6 +570,143 @@ class CurrentSenseAnalyzer:
         if len(lines) == 1:
             return lines[0]
         return linemerge(lines)
+
+    # ------------------------------------------------------------------
+    # Phase 3: Kelvin-tap integrity
+    # ------------------------------------------------------------------
+    def _resolve_force_partner(self, sense_name: str, force_capable_names: set[str]) -> str | None:
+        """Return the force (current-carrying) partner net for a sense net.
+
+        Resolution order mirrors :meth:`_resolve_partner`: explicit
+        ``kelvin_pairs`` (directional ``sense -> force``) -> ``_SENSE``/
+        ``_FORCE`` (and ``SNS``/``FRC``) suffix convention. The partner must
+        have force copper (be in ``force_capable_names``) and differ from the
+        sense net. Returns ``None`` when no force partner resolves.
+        """
+        for s, f in self.kelvin_pairs:
+            if sense_name == s and f != sense_name and f in force_capable_names:
+                return f
+
+        for sfx_s, sfx_f in _FORCE_PAIR_SUFFIXES:
+            if sense_name.endswith(sfx_s):
+                cand = sense_name[: -len(sfx_s)] + sfx_f
+                if cand != sense_name and cand in force_capable_names:
+                    return cand
+        return None
+
+    @staticmethod
+    def _sense_endpoints(
+        sense_segs: list[Segment], sense_vias: list[Via]
+    ) -> list[tuple[float, float]]:
+        """Return candidate tap points: the free ends of the sense conductor.
+
+        When the sense segments merge into one contiguous polyline, its two
+        endpoints are the candidates. Otherwise (branched / un-mergeable
+        conductor) fall back to every segment endpoint, so the end nearest the
+        force copper can still be chosen as the tap.
+        """
+        merged = CurrentSenseAnalyzer._merge_conductor(sense_segs, sense_vias)
+        if merged is not None and getattr(merged, "geom_type", None) == "LineString":
+            coords = list(merged.coords)
+            if len(coords) >= 2:
+                first, last = coords[0], coords[-1]
+                return [
+                    (float(first[0]), float(first[1])),
+                    (float(last[0]), float(last[1])),
+                ]
+        pts: list[tuple[float, float]] = []
+        for seg in sense_segs:
+            pts.append(seg.start)
+            pts.append(seg.end)
+        return pts
+
+    def _analyze_kelvin(
+        self,
+        sense_name: str,
+        sense_segs: list[Segment],
+        sense_vias: list[Via],
+        force_capable_names: set[str],
+        pads_by_name: dict[str, list[tuple[Any, Any]]],
+        segs_by_name: dict[str, list[Segment]],
+    ) -> tuple[str | None, str | None, float | None, str | None]:
+        """Return ``(kelvin_status, force_net, tap_gap_mm, reason)`` for a net.
+
+        Discriminates a proper Kelvin tap (sense trace ends on a force-net pad's
+        metallization -> ``d_pad <= tol`` -> PASS) from a mid-trace tap (sense
+        trace T's into the force *trace* interior, far from every force pad ->
+        ``d_pad > tol`` and ``d_seg <= tol`` -> FAIL). An indirect connection
+        (tap coincident with neither -> ``min(d_pad, d_seg) > tol``) yields no
+        verdict. Advisory-only: any failure degrades to ``(None, force, None,
+        reason)`` and never raises.
+        """
+        force_name = self._resolve_force_partner(sense_name, force_capable_names)
+        if force_name is None:
+            return None, None, None, "no force pair"
+
+        try:
+            from kicad_tools._shapely import has_shapely
+
+            if not has_shapely():
+                return None, force_name, None, "shapely unavailable"
+
+            from shapely.geometry import Point
+
+            from kicad_tools.geometry.copper import segment_copper_polygon
+            from kicad_tools.validate.rules.clearance import _pad_polygon
+
+            force_pad_polys = []
+            for pad, fp in pads_by_name.get(force_name, []):
+                try:
+                    poly = _pad_polygon(pad, fp)
+                except Exception:
+                    poly = None
+                if poly is not None:
+                    force_pad_polys.append(poly)
+
+            force_seg_polys = []
+            for seg in segs_by_name.get(force_name, []):
+                try:
+                    poly = segment_copper_polygon(seg.start, seg.end, seg.width)
+                except Exception:
+                    poly = None
+                if poly is not None:
+                    force_seg_polys.append(poly)
+
+            if not force_pad_polys:
+                # No force-pad metallization (no footprints, or all force pads
+                # degenerate): the Kelvin reference point is undefined, so a
+                # mid-trace tap cannot be judged against "where it should have
+                # landed". No verdict rather than a spurious FAIL.
+                return None, force_name, None, "no force pad metallization"
+
+            candidates = self._sense_endpoints(sense_segs, sense_vias)
+            if not candidates:
+                return None, force_name, None, "no sense conductor geometry"
+
+            # Choose the sense free-end nearest the force copper as the tap.
+            best: tuple[float, float, float] | None = None
+            for cand in candidates:
+                pt = Point(cand)
+                d_pad = min((pt.distance(poly) for poly in force_pad_polys), default=math.inf)
+                d_seg = min((pt.distance(poly) for poly in force_seg_polys), default=math.inf)
+                key = min(d_pad, d_seg)
+                if best is None or key < best[0]:
+                    best = (key, d_pad, d_seg)
+
+            assert best is not None  # candidates non-empty
+            _, d_pad, d_seg = best
+            tol = self.kelvin_tol_mm
+
+            if d_pad <= tol:
+                # Proper Kelvin tap: coincides with a force pad's metallization.
+                return "PASS", force_name, d_pad, None
+            if d_seg <= tol:
+                # Mid-trace tap: on force copper, but never at a pad.
+                gap = None if math.isinf(d_pad) else d_pad
+                return "FAIL", force_name, gap, None
+            return None, force_name, None, "tap not coincident with force copper"
+        except Exception:
+            return None, force_name, None, "kelvin analysis failed"
 
     def _analyze_sense_net(
         self,

--- a/src/kicad_tools/cli/analyze_cmd.py
+++ b/src/kicad_tools/cli/analyze_cmd.py
@@ -321,6 +321,24 @@ def main(argv: list[str] | None = None) -> int:
         help="Shared return conductor (e.g. Kelvin ground) to close sense loops",
     )
     current_sense_parser.add_argument(
+        "--kelvin-tol",
+        dest="kelvin_tol",
+        type=float,
+        default=0.05,
+        help="Kelvin-tap coincidence tolerance in mm (default: 0.05)",
+    )
+    current_sense_parser.add_argument(
+        "--kelvin-pair",
+        action="append",
+        dest="kelvin_pairs",
+        default=[],
+        metavar="SENSE:FORCE",
+        help=(
+            "Kelvin force pairing: check SENSE taps FORCE at a pad "
+            "(repeatable). Nets ending _SENSE/_FORCE, SNS/FRC auto-pair."
+        ),
+    )
+    current_sense_parser.add_argument(
         "--quiet",
         "-q",
         action="store_true",
@@ -1259,12 +1277,18 @@ def _run_current_sense_analysis(args: argparse.Namespace) -> int:
         max_loop_area_mm2=getattr(args, "max_loop_area", 10.0),
         sense_pairs=list(getattr(args, "sense_pairs", []) or []),
         sense_return=getattr(args, "sense_return", None),
+        kelvin_tol_mm=getattr(args, "kelvin_tol", 0.05),
+        kelvin_pairs=list(getattr(args, "kelvin_pairs", []) or []),
     )
     results = analyzer.analyze(pcb)
 
     if args.format == "json":
         _output_current_sense_json(
-            results, args.max_parallel, args.min_gap, getattr(args, "max_loop_area", 10.0)
+            results,
+            args.max_parallel,
+            args.min_gap,
+            getattr(args, "max_loop_area", 10.0),
+            getattr(args, "kelvin_tol", 0.05),
         )
     else:
         _output_current_sense_text(
@@ -1273,13 +1297,16 @@ def _run_current_sense_analysis(args: argparse.Namespace) -> int:
             args.max_parallel,
             args.min_gap,
             getattr(args, "max_loop_area", 10.0),
+            getattr(args, "kelvin_tol", 0.05),
             quiet=args.quiet,
         )
 
-    # Non-zero exit when any Phase-1 parallel/gap FAIL OR any loop-area FAIL is
-    # present (both are CI-gateable). No closable loop (loop_status None) does
-    # not gate.
-    if any(r.status == "FAIL" or r.loop_status == "FAIL" for r in results):
+    # Non-zero exit when any Phase-1 parallel/gap FAIL, any loop-area FAIL, OR
+    # any Kelvin-tap FAIL is present (all three are CI-gateable). A null verdict
+    # (loop_status / kelvin_status None) does not gate.
+    if any(
+        r.status == "FAIL" or r.loop_status == "FAIL" or r.kelvin_status == "FAIL" for r in results
+    ):
         return 1
     return 0
 
@@ -1289,22 +1316,26 @@ def _output_current_sense_json(
     max_parallel_mm: float,
     min_gap_mm: float,
     max_loop_area_mm2: float,
+    kelvin_tol_mm: float = 0.05,
 ) -> None:
     """Output current-sense census as JSON (mirrors signal-integrity JSON)."""
     fail_count = sum(1 for r in results if r.status == "FAIL")
     loop_fail_count = sum(1 for r in results if r.loop_status == "FAIL")
+    kelvin_fail_count = sum(1 for r in results if r.kelvin_status == "FAIL")
     output = {
         "census": [r.to_dict() for r in results],
         "thresholds": {
             "max_parallel_mm": max_parallel_mm,
             "min_gap_mm": min_gap_mm,
             "max_loop_area_mm2": max_loop_area_mm2,
+            "kelvin_tol_mm": kelvin_tol_mm,
         },
         "summary": {
             "total": len(results),
             "fail": fail_count,
             "pass": len(results) - fail_count,
             "loop_fail": loop_fail_count,
+            "kelvin_fail": kelvin_fail_count,
         },
     }
     print(json.dumps(output, indent=2))
@@ -1316,6 +1347,7 @@ def _output_current_sense_text(
     max_parallel_mm: float,
     min_gap_mm: float,
     max_loop_area_mm2: float,
+    kelvin_tol_mm: float = 0.05,
     quiet: bool = False,
 ) -> None:
     """Output current-sense census as a formatted table."""
@@ -1331,11 +1363,14 @@ def _output_current_sense_text(
         console.print(
             f"[dim]FAIL when parallel-run >= {max_parallel_mm:.2f}mm AND "
             f"gap <= {min_gap_mm:.2f}mm (same layer); "
-            f"loop FAIL when enclosed area > {max_loop_area_mm2:.2f}mm^2[/dim]\n"
+            f"loop FAIL when enclosed area > {max_loop_area_mm2:.2f}mm^2; "
+            f"Kelvin FAIL when tap is mid-trace (>{kelvin_tol_mm:.2f}mm from a "
+            f"force pad)[/dim]\n"
         )
 
     table = Table(show_header=True)
-    # Phase-1 columns (order preserved); loop_area_mm2 is appended (Phase 2).
+    # Phase-1 columns (order preserved); loop_area_mm2 is appended (Phase 2);
+    # kelvin_status / kelvin_force_net are appended after that (Phase 3).
     table.add_column("sense_net", style="cyan")
     table.add_column("nearest_hicur_net")
     table.add_column("layer")
@@ -1343,6 +1378,8 @@ def _output_current_sense_text(
     table.add_column("min_gap_mm", justify="right")
     table.add_column("status", justify="center")
     table.add_column("loop_area_mm2", justify="right")
+    table.add_column("kelvin_status", justify="center")
+    table.add_column("kelvin_force_net")
 
     for r in results:
         status_style = "red bold" if r.status == "FAIL" else "green"
@@ -1354,6 +1391,12 @@ def _output_current_sense_text(
         else:
             loop_style = "red bold" if r.loop_status == "FAIL" else "green"
             loop_str = f"[{loop_style}]{r.loop_area_mm2:.3f}[/{loop_style}]"
+        if r.kelvin_status is None:
+            kelvin_str = "-"
+        else:
+            kelvin_style = "red bold" if r.kelvin_status == "FAIL" else "green"
+            kelvin_str = f"[{kelvin_style}]{r.kelvin_status}[/{kelvin_style}]"
+        kelvin_net = r.kelvin_force_net if r.kelvin_force_net is not None else "-"
         table.add_row(
             r.sense_net,
             nearest,
@@ -1362,18 +1405,21 @@ def _output_current_sense_text(
             gap_str,
             f"[{status_style}]{r.status}[/{status_style}]",
             loop_str,
+            kelvin_str,
+            kelvin_net,
         )
 
     console.print(table)
 
     fail_count = sum(1 for r in results if r.status == "FAIL")
     loop_fail_count = sum(1 for r in results if r.loop_status == "FAIL")
+    kelvin_fail_count = sum(1 for r in results if r.kelvin_status == "FAIL")
     console.print()
-    summary_style = "red bold" if (fail_count or loop_fail_count) else "green"
+    summary_style = "red bold" if (fail_count or loop_fail_count or kelvin_fail_count) else "green"
     console.print(
         f"[{summary_style}]Total: {len(results)} sense nets, "
         f"{fail_count} FAIL, {len(results) - fail_count} PASS "
-        f"({loop_fail_count} loop-area FAIL)[/{summary_style}]"
+        f"({loop_fail_count} loop-area FAIL, {kelvin_fail_count} Kelvin FAIL)[/{summary_style}]"
     )
 
 

--- a/src/kicad_tools/cli/commands/analyze.py
+++ b/src/kicad_tools/cli/commands/analyze.py
@@ -133,6 +133,10 @@ def _run_current_sense_command(args) -> int:
         sub_argv.extend(["--sense-pair", pair[0], pair[1]])
     if getattr(args, "analyze_sense_return", None):
         sub_argv.extend(["--sense-return", args.analyze_sense_return])
+    if getattr(args, "analyze_kelvin_tol", 0.05) != 0.05:
+        sub_argv.extend(["--kelvin-tol", str(args.analyze_kelvin_tol)])
+    for kpair in getattr(args, "analyze_kelvin_pairs", None) or []:
+        sub_argv.extend(["--kelvin-pair", kpair])
     if getattr(args, "global_quiet", False):
         sub_argv.append("--quiet")
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -5487,6 +5487,24 @@ def _add_analyze_parser(subparsers) -> None:
         metavar="NAME",
         help="Shared return conductor (e.g. Kelvin ground) to close sense loops",
     )
+    current_sense_parser.add_argument(
+        "--kelvin-tol",
+        dest="analyze_kelvin_tol",
+        type=float,
+        default=0.05,
+        help="Kelvin-tap coincidence tolerance in mm (default: 0.05)",
+    )
+    current_sense_parser.add_argument(
+        "--kelvin-pair",
+        action="append",
+        dest="analyze_kelvin_pairs",
+        default=[],
+        metavar="SENSE:FORCE",
+        help=(
+            "Kelvin force pairing: check SENSE taps FORCE at a pad "
+            "(repeatable). Nets ending _SENSE/_FORCE, SNS/FRC auto-pair."
+        ),
+    )
 
 
 def _add_constraints_parser(subparsers) -> None:

--- a/tests/test_current_sense.py
+++ b/tests/test_current_sense.py
@@ -296,7 +296,9 @@ class TestAnalyzerGeometry:
         assert r.nearest_hicur_net == "PHASE_A"
         assert r.min_gap_mm == pytest.approx(0.1, abs=0.001)
         assert r.max_parallel_mm == pytest.approx(3.0, abs=0.01)
-        # The whole census row matches the phase-1 nearest-by-gap contract.
+        # The Phase-1 nearest-by-gap contract is preserved; Phase-2 (loop) and
+        # Phase-3 (kelvin) keys are appended. ISENSE has no return conductor and
+        # no force partner here, so both degrade to null with a reason.
         assert r.to_dict() == {
             "sense_net": "ISENSE",
             "nearest_hicur_net": "PHASE_A",
@@ -305,6 +307,13 @@ class TestAnalyzerGeometry:
             "min_gap_mm": 0.1,
             "status": "PASS",
             "margin": -0.4,
+            "loop_area_mm2": None,
+            "loop_status": None,
+            "loop_reason": "no return conductor (single-ended, not closable)",
+            "kelvin_status": None,
+            "kelvin_force_net": None,
+            "kelvin_tap_gap_mm": None,
+            "kelvin_reason": "no force pair",
         }
 
 
@@ -444,11 +453,19 @@ class TestCli:
         assert rc == 1
         payload = json.loads(capsys.readouterr().out)
         assert set(payload) == {"census", "thresholds", "summary"}
-        # Phase-1 summary keys unchanged; Phase-2 adds loop_fail.
-        assert payload["summary"] == {"total": 1, "fail": 1, "pass": 0, "loop_fail": 0}
+        # Phase-1 summary keys unchanged; Phase-2 adds loop_fail; Phase-3 adds
+        # kelvin_fail.
+        assert payload["summary"] == {
+            "total": 1,
+            "fail": 1,
+            "pass": 0,
+            "loop_fail": 0,
+            "kelvin_fail": 0,
+        }
         assert payload["thresholds"]["max_parallel_mm"] == 10.0
         assert payload["thresholds"]["min_gap_mm"] == 0.5
         assert payload["thresholds"]["max_loop_area_mm2"] == 10.0
+        assert payload["thresholds"]["kelvin_tol_mm"] == 0.05
         row = payload["census"][0]
         assert row["sense_net"] == "ISENSE"
         assert row["nearest_hicur_net"] == "PHASE_A"
@@ -767,3 +784,257 @@ class TestLoopAreaCli:
         assert "40.000" in out
         assert "loop-area FAIL" in out
         assert "2 PASS" in out
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 (#4331): Kelvin-tap integrity
+# ---------------------------------------------------------------------------
+#
+# Each fixture has a 1x1mm force pad (footprint R1) centred at board (10,10) on
+# net I_FORCE, plus a 20mm force trace I_FORCE from the pad to (30,10). The sense
+# net I_SENSE auto-pairs to I_FORCE via the _SENSE/_FORCE suffix convention. The
+# only variable is where the sense trace ends (the "tap"):
+#   PASS     -> ends on the force pad centre (10,10): d_pad = 0.
+#   FAIL     -> T's into the force trace mid-span (20,10): on copper, but 9.5mm
+#               from the pad.
+#   INDIRECT -> ends well away from all force copper (20,25): no verdict.
+
+_KELVIN_FP = """
+  (footprint "R_shunt" (layer "F.Cu") (at 10 10)
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 1 "I_FORCE"))
+  )
+"""
+
+KELVIN_PASS_PCB = (
+    _HEADER
+    + """
+  (net 0 "")
+  (net 1 "I_FORCE")
+  (net 2 "I_SENSE")
+"""
+    + _KELVIN_FP
+    + """
+  (segment (start 10 10) (end 30 10) (width 0.2) (layer "F.Cu") (net 1))
+  (segment (start 10 10) (end 10 20) (width 0.2) (layer "F.Cu") (net 2))
+)
+"""
+)
+
+KELVIN_FAIL_PCB = (
+    _HEADER
+    + """
+  (net 0 "")
+  (net 1 "I_FORCE")
+  (net 2 "I_SENSE")
+"""
+    + _KELVIN_FP
+    + """
+  (segment (start 10 10) (end 30 10) (width 0.2) (layer "F.Cu") (net 1))
+  (segment (start 20 10) (end 20 20) (width 0.2) (layer "F.Cu") (net 2))
+)
+"""
+)
+
+KELVIN_INDIRECT_PCB = (
+    _HEADER
+    + """
+  (net 0 "")
+  (net 1 "I_FORCE")
+  (net 2 "I_SENSE")
+"""
+    + _KELVIN_FP
+    + """
+  (segment (start 10 10) (end 30 10) (width 0.2) (layer "F.Cu") (net 1))
+  (segment (start 20 25) (end 20 35) (width 0.2) (layer "F.Cu") (net 2))
+)
+"""
+)
+
+# Force pad has zero size -> skipped; force trace still present. No force-pad
+# metallization means no Kelvin reference point -> null verdict (never crash).
+KELVIN_DEGENERATE_PAD_PCB = (
+    _HEADER
+    + """
+  (net 0 "")
+  (net 1 "I_FORCE")
+  (net 2 "I_SENSE")
+  (footprint "R_shunt" (layer "F.Cu") (at 10 10)
+    (pad "1" smd rect (at 0 0) (size 0 0) (layers "F.Cu") (net 1 "I_FORCE"))
+  )
+  (segment (start 10 10) (end 30 10) (width 0.2) (layer "F.Cu") (net 1))
+  (segment (start 20 10) (end 20 20) (width 0.2) (layer "F.Cu") (net 2))
+)
+"""
+)
+
+# Names that do NOT match the _SENSE/_FORCE convention; paired explicitly. VDROP
+# has a pad at (10,10); VMEAS taps it -> PASS only when --kelvin-pair is given.
+KELVIN_EXPLICIT_PAIR_PCB = (
+    _HEADER
+    + """
+  (net 0 "")
+  (net 1 "VDROP")
+  (net 2 "VMEAS")
+  (footprint "R_shunt" (layer "F.Cu") (at 10 10)
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 1 "VDROP"))
+  )
+  (segment (start 10 10) (end 30 10) (width 0.2) (layer "F.Cu") (net 1))
+  (segment (start 10 10) (end 10 20) (width 0.2) (layer "F.Cu") (net 2))
+)
+"""
+)
+
+
+def _kelvin(pcb, **kwargs):
+    """Analyze with I_SENSE tagged, return the I_SENSE row."""
+    analyzer = CurrentSenseAnalyzer(sense_nets=["I_SENSE"], **kwargs)
+    rows = {r.sense_net: r for r in analyzer.analyze(pcb)}
+    return rows["I_SENSE"]
+
+
+class TestKelvin:
+    def test_tap_on_pad_passes(self, tmp_path: Path) -> None:
+        r = _kelvin(_load(tmp_path, KELVIN_PASS_PCB))
+        assert r.kelvin_status == "PASS"
+        assert r.kelvin_force_net == "I_FORCE"
+        assert r.kelvin_tap_gap_mm == pytest.approx(0.0, abs=0.05)
+        assert r.kelvin_reason is None
+
+    def test_mid_trace_tap_fails(self, tmp_path: Path) -> None:
+        r = _kelvin(_load(tmp_path, KELVIN_FAIL_PCB))
+        assert r.kelvin_status == "FAIL"
+        assert r.kelvin_force_net == "I_FORCE"
+        # Tap sits ~9.5mm up the force trace from the pad edge (10.5,10).
+        assert r.kelvin_tap_gap_mm == pytest.approx(9.5, abs=0.1)
+        assert r.kelvin_tap_gap_mm > 0.05
+        assert r.kelvin_reason is None
+
+    def test_indirect_tap_is_null(self, tmp_path: Path) -> None:
+        r = _kelvin(_load(tmp_path, KELVIN_INDIRECT_PCB))
+        assert r.kelvin_status is None
+        assert r.kelvin_tap_gap_mm is None
+        assert r.kelvin_reason == "tap not coincident with force copper"
+
+    def test_no_force_pair_is_null(self, tmp_path: Path) -> None:
+        # ISENSE has no _SENSE suffix and no explicit pairing -> no partner.
+        pcb = _load(tmp_path, FAIL_PCB)
+        r = {x.sense_net: x for x in CurrentSenseAnalyzer().analyze(pcb)}["ISENSE"]
+        assert r.kelvin_status is None
+        assert r.kelvin_force_net is None
+        assert r.kelvin_reason == "no force pair"
+
+    def test_degenerate_force_pad_is_null_no_crash(self, tmp_path: Path) -> None:
+        r = _kelvin(_load(tmp_path, KELVIN_DEGENERATE_PAD_PCB))
+        assert r.kelvin_status is None  # never a spurious FAIL
+        assert r.kelvin_reason == "no force pad metallization"
+
+    def test_explicit_kelvin_pair(self, tmp_path: Path) -> None:
+        pcb = _load(tmp_path, KELVIN_EXPLICIT_PAIR_PCB)
+        # Without the explicit pair, VMEAS has no force partner.
+        base = CurrentSenseAnalyzer(sense_nets=["VMEAS"])
+        r0 = {x.sense_net: x for x in base.analyze(pcb)}["VMEAS"]
+        assert r0.kelvin_status is None
+        assert r0.kelvin_reason == "no force pair"
+        # With it, VMEAS taps VDROP's pad -> PASS.
+        paired = CurrentSenseAnalyzer(sense_nets=["VMEAS"], kelvin_pairs=[("VMEAS", "VDROP")])
+        r1 = {x.sense_net: x for x in paired.analyze(pcb)}["VMEAS"]
+        assert r1.kelvin_status == "PASS"
+        assert r1.kelvin_force_net == "VDROP"
+
+    def test_kelvin_pair_colon_string_form(self, tmp_path: Path) -> None:
+        # The "SENSE:FORCE" CLI string form normalizes the same as a 2-tuple.
+        pcb = _load(tmp_path, KELVIN_EXPLICIT_PAIR_PCB)
+        paired = CurrentSenseAnalyzer(sense_nets=["VMEAS"], kelvin_pairs=["VMEAS:VDROP"])
+        r = {x.sense_net: x for x in paired.analyze(pcb)}["VMEAS"]
+        assert r.kelvin_status == "PASS"
+
+    def test_custom_tol_flips_pass_to_fail(self, tmp_path: Path) -> None:
+        # A negative-ish tight tolerance can't flip PASS (d_pad==0), but a large
+        # tolerance turns the mid-trace FAIL into a PASS (tap within tol of pad).
+        r = _kelvin(_load(tmp_path, KELVIN_FAIL_PCB), kelvin_tol_mm=20.0)
+        assert r.kelvin_status == "PASS"
+
+    def test_shapely_unavailable_is_null(self, tmp_path: Path, monkeypatch) -> None:
+        import kicad_tools._shapely as _shp
+
+        monkeypatch.setattr(_shp, "has_shapely", lambda: False)
+        r = _kelvin(_load(tmp_path, KELVIN_PASS_PCB))
+        assert r.kelvin_status is None
+        assert r.kelvin_reason == "shapely unavailable"
+
+    def test_additive_output_guard(self, tmp_path: Path) -> None:
+        # Every Phase-1/2 key is still present; Phase-3 keys are appended.
+        r = _kelvin(_load(tmp_path, KELVIN_PASS_PCB))
+        d = r.to_dict()
+        for key in (
+            "sense_net",
+            "nearest_hicur_net",
+            "layer",
+            "max_parallel_mm",
+            "min_gap_mm",
+            "status",
+            "margin",
+            "loop_area_mm2",
+            "loop_status",
+        ):
+            assert key in d
+        assert d["kelvin_status"] == "PASS"
+        assert d["kelvin_force_net"] == "I_FORCE"
+        assert "kelvin_tap_gap_mm" in d
+        # PASS reached a verdict -> no reason key (mirrors loop_reason).
+        assert "kelvin_reason" not in d
+        json.dumps(d)  # JSON-safe (no inf/NaN)
+
+
+class TestKelvinCli:
+    def test_cli_fail_exit_code(self, tmp_path: Path, capsys) -> None:
+        pcb = _write(tmp_path, KELVIN_FAIL_PCB)
+        rc = analyze_main(["current-sense", str(pcb), "--sense-net", "I_SENSE"])
+        assert rc == 1  # Kelvin FAIL gates the exit
+        out = capsys.readouterr().out
+        assert "Kelvin FAIL" in out
+
+    def test_cli_pass_exit_zero(self, tmp_path: Path, capsys) -> None:
+        pcb = _write(tmp_path, KELVIN_PASS_PCB)
+        rc = analyze_main(["current-sense", str(pcb), "--sense-net", "I_SENSE"])
+        assert rc == 0
+
+    def test_cli_json_additive_keys(self, tmp_path: Path, capsys) -> None:
+        pcb = _write(tmp_path, KELVIN_FAIL_PCB)
+        rc = analyze_main(["current-sense", str(pcb), "--sense-net", "I_SENSE", "--format", "json"])
+        assert rc == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["thresholds"]["kelvin_tol_mm"] == 0.05
+        assert payload["summary"]["kelvin_fail"] == 1
+        row = {r["sense_net"]: r for r in payload["census"]}["I_SENSE"]
+        assert row["kelvin_status"] == "FAIL"
+        assert row["kelvin_force_net"] == "I_FORCE"
+        assert row["kelvin_tap_gap_mm"] > 0.05
+
+    def test_cli_kelvin_pair_flag(self, tmp_path: Path, capsys) -> None:
+        pcb = _write(tmp_path, KELVIN_EXPLICIT_PAIR_PCB)
+        rc = analyze_main(
+            [
+                "current-sense",
+                str(pcb),
+                "--sense-net",
+                "VMEAS",
+                "--kelvin-pair",
+                "VMEAS:VDROP",
+                "--format",
+                "json",
+            ]
+        )
+        assert rc == 0  # PASS
+        payload = json.loads(capsys.readouterr().out)
+        row = {r["sense_net"]: r for r in payload["census"]}["VMEAS"]
+        assert row["kelvin_status"] == "PASS"
+        assert row["kelvin_force_net"] == "VDROP"
+
+    def test_cli_kelvin_tol_flag(self, tmp_path: Path, capsys) -> None:
+        pcb = _write(tmp_path, KELVIN_FAIL_PCB)
+        # Loosen tolerance above the 9.5mm gap -> the mid-trace tap now PASSes.
+        rc = analyze_main(
+            ["current-sense", str(pcb), "--sense-net", "I_SENSE", "--kelvin-tol", "20"]
+        )
+        assert rc == 0


### PR DESCRIPTION
## Summary

Phase 3 of the current-sense / analog layout lint (**#4328**), building on the merged Phase-1 (parallel-run/gap, #4328) and Phase-2 (copper sense-loop area, #4330) census. This PR adds **Kelvin-tap integrity** detection and the census/JSON surfacing it forces, satisfying the "unified census polish" goal by adding a Kelvin column alongside the existing parallel-run + loop-area columns.

Closes #4331.

### What this checks (the EE value)
Does a current-sense line tap the force (current-carrying) node **at the pad metallization** (a proper Kelvin connection), or mistakenly **mid-trace** where it picks up the force trace's IR drop and corrupts the measurement? KiCad routes a trace endpoint to the pad anchor, so a correct Kelvin tap lands *inside* the force pad polygon.

### Detection (reuses existing primitives, nothing duplicated)
- **Force-pad copper:** `validate/rules/clearance._pad_polygon` (board-frame shapely polygon, honoring pad shape + absolute rotation).
- **Force-trace copper:** `geometry/copper.segment_copper_polygon`.
- **Sense polyline:** the module's own `_merge_conductor`; the sense free-end **nearest the force copper** is taken as the tap.

Discrimination against `--kelvin-tol` (default **0.05 mm**):
- **PASS** — `d_pad <= tol` (tap on a force pad's metallization), `kelvin_tap_gap_mm ≈ 0`.
- **FAIL** — `d_pad > tol` **and** `d_seg <= tol` (on force copper, but only mid-trace); reports `kelvin_force_net` and `kelvin_tap_gap_mm = d_pad` (how far up the trace the tap landed).
- **None (no verdict)** — indirect connection (`min(d_pad, d_seg) > tol`), no force partner, or no force-pad metallization (no footprints / all force pads degenerate). Advisory, never a spurious FAIL.

Force pairing mirrors the Phase-2 `_resolve_partner` infra via a new `_resolve_force_partner()`: `_SENSE`↔`_FORCE` / `SNS`↔`FRC` suffix convention + explicit `--kelvin-pair SENSE:FORCE` (repeatable).

### Surfacing (all additive)
- `CurrentSenseResult` gains `kelvin_status` / `kelvin_force_net` / `kelvin_tap_gap_mm` / `kelvin_reason`; `to_dict()` appends them (reason only when set, mirroring `loop_reason`). All Phase-1/2 keys unchanged/unreordered.
- `--kelvin-tol` + `--kelvin-pair` wired through **all three** CLI layers (`parser.py`, `analyze_cmd.py`, `commands/analyze.py`).
- Text census gains a `kelvin_status` + `kelvin_force_net` column appended after the loop-area column; summary line adds a Kelvin-FAIL tally.
- JSON gains `thresholds.kelvin_tol_mm` and `summary.kelvin_fail`.
- **Exit code:** a Kelvin FAIL gates the CLI exit (parity with Phase-1/2 FAILs).

Advisory-only throughout: shapely-unavailable, degenerate pads, no footprints, single-ended sense nets, and un-mergeable conductors all degrade to `kelvin_status=None` + a reason. No exception escapes `analyze()`.

## Deferred to a possible Phase-3b (not filed, per curator)
- **Inner-layer / broadside coupling** — needs a genuinely different geometric primitive (vertical XY-overlap length via polygon intersection) + copper-layer adjacency; independent of Kelvin.
- **GATE/SRC/TRK auto-classification** + the `analyze coupling` alias — touches `router/net_class.py` (broad router blast radius). The same-layer guard and `net_class.py` are left unchanged.

## Tests
New `TestKelvin` / `TestKelvinCli` in `tests/test_current_sense.py` (synthetic boards with a 1×1 mm force pad + force trace):
- tap on force pad → **PASS** (`gap ≈ 0`); mid-trace tap → **FAIL** (`gap ≈ 9.5 mm`); indirect → **None**; no force pair → None; degenerate force pad → None (no crash); explicit `--kelvin-pair` (tuple + `SENSE:FORCE` string forms); `--kelvin-tol` flips FAIL→PASS; shapely-unavailable (monkeypatched) → None; additive-output guard (all Phase-1/2 keys present, JSON-safe); CLI exit codes + JSON `kelvin_fail`/`kelvin_tol_mm`.

Two **stale Phase-2 assertions** were refreshed for the additive keys: `test_multi_blocker_all_pass_reports_nearest_by_gap` (an exact-dict assertion that was **already red on origin/main** because Phase-2's loop keys were never folded in) and `test_cli_json_shape`'s summary dict.

## Local checks
- `uv run pytest tests/test_current_sense.py` → **56 passed** (was 40 passed + 1 pre-existing failure).
- `tests/test_build_parser_parity.py` + `tests/test_cli_parser_drift.py` → 28 passed (both parser layers stay in sync).
- `uv run ruff check .` → passes; `uv run ruff format . --check` → clean.
- mypy baseline gate → no new type errors (all within baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)