### PR TITLE
fix(creepage): correct clearance-table field-condition label to Case A (inhomogeneous)

### DIFF
--- a/src/kicad_tools/creepage/standards.py
+++ b/src/kicad_tools/creepage/standards.py
@@ -42,7 +42,7 @@ Table provenance (transcribed values -- spot-check before certifying)
   occur), so a single PD1 column is tabulated.  The two standards are
   harmonised on the tracking physics, so their creepage values are identical
   over the range encoded here.
-* **Clearance** -- IEC 60664-1:2020 Table F.2 (inhomogeneous-field / "case B",
+* **Clearance** -- IEC 60664-1:2020 Table F.2 (inhomogeneous-field / "case A",
   basic insulation) with the pollution-degree minimum floors of clause 6.1,
   at altitude **<= 2000 m**; IEC 62368-1:2018 Table 14 is the harmonised
   counterpart.  Keyed on the **peak** value of the working voltage plus the
@@ -272,7 +272,7 @@ _CREEPAGE_MM[2]["IIIb"] = _CREEPAGE_MM[2]["IIIa"]
 # ---------------------------------------------------------------------------
 
 # Ascending peak-voltage rows for the clearance table.
-# IEC 60664-1:2020 Table F.2 (inhomogeneous field / "case B", <= 2000 m).
+# IEC 60664-1:2020 Table F.2 (inhomogeneous field / "case A", <= 2000 m).
 _CLEARANCE_PEAK_ROWS: tuple[float, ...] = (
     330.0,
     500.0,
@@ -476,7 +476,7 @@ _IEC_60664_1 = CreepageStandard(
     creepage_table_id="Table F.4",
     creepage_clause="clause 6.2 (creepage, keyed on RMS working voltage)",
     clearance_table_id="Table F.2",
-    clearance_clause="clause 6.1 (clearance, inhomogeneous field / case B)",
+    clearance_clause="clause 6.1 (clearance, inhomogeneous field / case A)",
 )
 
 _IEC_62368_1 = CreepageStandard(


### PR DESCRIPTION
## Summary

Corrects a provenance/citation-text mislabel in `src/kicad_tools/creepage/standards.py` (added by PR #4338). The IEC 60664-1 Table F.2 clearance table transcribes the conservative **inhomogeneous-field** clearance values (correct, safe choice for a layout gate), but the docstring, inline comment, and emitted `clearance_clause` provenance labeled them **"case B"**. Inhomogeneous field is **Case A**, so the letter was wrong.

**This is a citation-text fix only. No numeric table value changed. Exit codes and all derived numbers are unaffected.**

## Evidence (controlled EN/IEC 60664-1:2007)

From the owner's controlled copy (`en_60664_1_2007.pdf`):

> "Inhomogeneous field conditions (case A of Table F.2)"

> "The homogeneous field condition is referred to as case B"

Therefore the conservative inhomogeneous-field clearance values are **Case A**, not Case B.

## Changes (before → after, all in `standards.py`)

| Location | Before | After |
|----------|--------|-------|
| Module docstring (Table provenance, ~L45) | `inhomogeneous-field / "case B"` | `inhomogeneous-field / "case A"` |
| `_CLEARANCE_PEAK_ROWS` comment (~L275) | `inhomogeneous field / "case B"` | `inhomogeneous field / "case A"` |
| `_IEC_60664_1.clearance_clause` (~L479) | `clause 6.1 (clearance, inhomogeneous field / case B)` | `clause 6.1 (clearance, inhomogeneous field / case A)` |

The `clearance_clause` string is surfaced in the emitted clearance provenance dict (`clause` key), so CLI/JSON consumers now see the correct case letter.

Confirmed not affected:
- `_IEC_62368_1.clearance_clause` references no case letter (harmonised-with note only) — unchanged.
- Creepage (Table F.4) provenance does not use the Case A/B distinction — unchanged.
- The "engineering aid, NOT a certification" disclaimer is intact.
- No numeric value in `_CLEARANCE_BASE_MM`, `_CLEARANCE_PEAK_ROWS`, `_CREEPAGE_MM`, or the PD floors changed.

No unit test asserted on the case text (tests only check that a `clause` key is present in provenance), so no test changes were required.

## Local checks

- `uv run pytest tests/creepage/` — 89 passed
- `uv run ruff check .` — All checks passed
- `uv run ruff format . --check` — 1656 files already formatted
- mypy baseline gate (`tests/test_ci_mypy_baseline.py`) — 19 passed; `creepage/standards.py` is clean (comment/string-only change cannot shift mypy)

Closes #4340

🤖 Generated with [Claude Code](https://claude.com/claude-code)