### PR TITLE
fix(router): stop nanobind PadBounds ref-leak on kct build-native (#4346)

### DIFF
--- a/src/kicad_tools/router/cpp/src/bindings.cpp
+++ b/src/kicad_tools/router/cpp/src/bindings.cpp
@@ -274,7 +274,53 @@ NB_MODULE(router_cpp, m) {
     nb::class_<Pathfinder>(m, "Pathfinder")
         .def(nb::init<Grid3D&, const DesignRules&, bool>(),
              "grid"_a, "rules"_a, "diagonal_routing"_a = true)
-        .def("route", &Pathfinder::route,
+        // Issue #4346: ``start_pad_bounds`` / ``end_pad_bounds`` are bound via a
+        // thin lambda taking ``std::optional<PadBounds>`` defaulting to
+        // ``nb::none()`` instead of a materialized ``PadBounds{}`` default arg.
+        // A *bound-type* default argument makes nanobind cast the sentinel into a
+        // persistent Python object held for the module's lifetime; because CPython
+        // does not deallocate extension modules at interpreter finalization, those
+        // objects are still live when nanobind's teardown leak checker runs -- the
+        // exact source of the "leaked 4 instances of PadBounds" report on
+        // ``kct build-native``. Defaulting to None keeps zero tracked instances;
+        // the omitted case substitutes an all-zero ``PadBounds{}`` inside the
+        // lambda, preserving pre-#4346 Python-visible behavior identically.
+        .def("route",
+             [](Pathfinder& self,
+                float start_x, float start_y, int start_layer,
+                float end_x, float end_y, int end_layer,
+                int net,
+                const std::vector<int>& start_layers,
+                const std::vector<int>& end_layers,
+                bool negotiated_mode,
+                float present_cost_factor,
+                float weight,
+                int trace_radius_cells,
+                int via_radius_cells,
+                std::optional<PadBounds> start_pad_bounds,
+                std::optional<PadBounds> end_pad_bounds,
+                int partner_net,
+                int intra_pair_radius_cells,
+                double per_net_timeout_seconds,
+                int max_search_iterations,
+                float emit_trace_width,
+                float emit_via_diameter,
+                float emit_via_drill,
+                const std::vector<PadChannelBudget>& pad_channel_budgets) {
+                 return self.route(
+                     start_x, start_y, start_layer,
+                     end_x, end_y, end_layer,
+                     net,
+                     start_layers, end_layers,
+                     negotiated_mode, present_cost_factor, weight,
+                     trace_radius_cells, via_radius_cells,
+                     start_pad_bounds.value_or(PadBounds{}),
+                     end_pad_bounds.value_or(PadBounds{}),
+                     partner_net, intra_pair_radius_cells,
+                     per_net_timeout_seconds, max_search_iterations,
+                     emit_trace_width, emit_via_diameter, emit_via_drill,
+                     pad_channel_budgets);
+             },
              "start_x"_a, "start_y"_a, "start_layer"_a,
              "end_x"_a, "end_y"_a, "end_layer"_a,
              "net"_a,
@@ -285,8 +331,8 @@ NB_MODULE(router_cpp, m) {
              "weight"_a = 1.0f,
              "trace_radius_cells"_a = 0,
              "via_radius_cells"_a = 0,
-             "start_pad_bounds"_a = PadBounds{},
-             "end_pad_bounds"_a = PadBounds{},
+             "start_pad_bounds"_a = nb::none(),
+             "end_pad_bounds"_a = nb::none(),
              // Issue #2559 / Epic #2556 Phase 1C: diff-pair within-pair clearance.
              "partner_net"_a = -1,
              "intra_pair_radius_cells"_a = 0,
@@ -301,7 +347,42 @@ NB_MODULE(router_cpp, m) {
              "emit_via_drill"_a = 0.0f,
              // Issue #3143: per-pad lateral-channel budget (empty = inert).
              "pad_channel_budgets"_a = std::vector<PadChannelBudget>{})
-        .def("route_resumable", &Pathfinder::route_resumable,
+        .def("route_resumable",
+             [](Pathfinder& self,
+                float start_x, float start_y, int start_layer,
+                float end_x, float end_y, int end_layer,
+                int net,
+                const std::vector<int>& start_layers,
+                const std::vector<int>& end_layers,
+                bool negotiated_mode,
+                float present_cost_factor,
+                float weight,
+                int trace_radius_cells,
+                int via_radius_cells,
+                std::optional<PadBounds> start_pad_bounds,
+                std::optional<PadBounds> end_pad_bounds,
+                int partner_net,
+                int intra_pair_radius_cells,
+                double per_net_timeout_seconds,
+                int max_search_iterations,
+                float emit_trace_width,
+                float emit_via_diameter,
+                float emit_via_drill,
+                const std::vector<PadChannelBudget>& pad_channel_budgets) {
+                 return self.route_resumable(
+                     start_x, start_y, start_layer,
+                     end_x, end_y, end_layer,
+                     net,
+                     start_layers, end_layers,
+                     negotiated_mode, present_cost_factor, weight,
+                     trace_radius_cells, via_radius_cells,
+                     start_pad_bounds.value_or(PadBounds{}),
+                     end_pad_bounds.value_or(PadBounds{}),
+                     partner_net, intra_pair_radius_cells,
+                     per_net_timeout_seconds, max_search_iterations,
+                     emit_trace_width, emit_via_diameter, emit_via_drill,
+                     pad_channel_budgets);
+             },
              "start_x"_a, "start_y"_a, "start_layer"_a,
              "end_x"_a, "end_y"_a, "end_layer"_a,
              "net"_a,
@@ -312,8 +393,8 @@ NB_MODULE(router_cpp, m) {
              "weight"_a = 1.0f,
              "trace_radius_cells"_a = 0,
              "via_radius_cells"_a = 0,
-             "start_pad_bounds"_a = PadBounds{},
-             "end_pad_bounds"_a = PadBounds{},
+             "start_pad_bounds"_a = nb::none(),
+             "end_pad_bounds"_a = nb::none(),
              // Issue #2559 / Epic #2556 Phase 1C: diff-pair within-pair clearance.
              "partner_net"_a = -1,
              "intra_pair_radius_cells"_a = 0,

--- a/tests/test_router_cpp_padbounds_leak_4346.py
+++ b/tests/test_router_cpp_padbounds_leak_4346.py
@@ -1,0 +1,118 @@
+"""Regression tests for issue #4346.
+
+``kct build-native`` dumped a ``nanobind: leaked 4 instances!`` banner of
+type ``PadBounds`` at interpreter teardown right after a *successful* build.
+
+Root cause: ``Pathfinder.route`` / ``Pathfinder.route_resumable`` declared
+their two pad-bounds parameters with a materialized bound-type default arg
+(``"start_pad_bounds"_a = PadBounds{}`` etc.).  When a nanobind default
+argument is a *bound* (``nb::class_``) type, nanobind casts the sentinel
+into a persistent Python object held for the module's lifetime; because
+CPython does not deallocate extension modules at interpreter finalization,
+those objects are still live when nanobind's teardown leak checker runs --
+hence the "leaked 4 instances of PadBounds" report.
+
+The fix binds ``route`` / ``route_resumable`` via a thin lambda whose two
+pad-bounds params are ``std::optional<PadBounds>`` defaulting to
+``nb::none()``; the omitted case substitutes an all-zero ``PadBounds{}``
+inside the lambda, so there are zero tracked instances and Python-visible
+behavior is unchanged.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+from kicad_tools.router.cpp_backend import is_cpp_available
+
+pytestmark = pytest.mark.skipif(
+    not is_cpp_available(),
+    reason="C++ router backend not built (run `kct build-native`)",
+)
+
+
+def test_import_router_cpp_reports_no_nanobind_leak() -> None:
+    """Importing ``router_cpp`` in a fresh interpreter must not leak.
+
+    The nanobind leak checker only runs at interpreter finalization, so the
+    reliable signal is a subprocess whose stderr we scrape after it exits.
+    Before the #4346 fix this printed ``nanobind: leaked 4 instances!`` for
+    the four ``PadBounds{}`` default-argument sentinels.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", "import kicad_tools.router.router_cpp"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"Importing router_cpp failed:\nstdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+    assert "nanobind: leaked" not in result.stderr, (
+        "nanobind reported a leak at teardown after importing router_cpp -- "
+        "a bound-type default argument (or similar retained instance) has "
+        f"regressed issue #4346.\nstderr={result.stderr!r}"
+    )
+
+
+def test_route_pad_bounds_defaults_are_none() -> None:
+    """The Python-facing pad-bounds defaults must be ``None``, not a
+    materialized ``PadBounds`` sentinel.
+
+    Guards against re-introducing a bound-type default argument (the root
+    cause of the #4346 instance leak).
+    """
+    from kicad_tools.router import router_cpp
+
+    for method in (router_cpp.Pathfinder.route, router_cpp.Pathfinder.route_resumable):
+        doc = method.__doc__ or ""
+        assert "start_pad_bounds: kicad_tools.router.router_cpp.PadBounds | None = None" in doc, (
+            f"{method.__name__} start_pad_bounds default is not None:\n{doc}"
+        )
+        assert "end_pad_bounds: kicad_tools.router.router_cpp.PadBounds | None = None" in doc, (
+            f"{method.__name__} end_pad_bounds default is not None:\n{doc}"
+        )
+
+
+def _make_pathfinder():
+    from kicad_tools.router import router_cpp
+
+    grid = router_cpp.Grid3D(100, 100, 2, 0.5, 0.0, 0.0)
+    rules = router_cpp.DesignRules()
+    rules.trace_width = 0.2
+    rules.trace_clearance = 0.2
+    rules.via_diameter = 0.6
+    rules.via_drill = 0.3
+    rules.via_clearance = 0.2
+    rules.grid_resolution = 0.5
+    return router_cpp.Pathfinder(grid, rules, True)
+
+
+def test_omitted_pad_bounds_matches_explicit_all_zero() -> None:
+    """Omitting the pad-bounds args must route identically to passing an
+    explicit all-zero ``PadBounds()`` -- preserving pre-#4346 behavior.
+    """
+    from kicad_tools.router import router_cpp
+
+    kwargs = {
+        "start_x": 5.0 * 0.5,
+        "start_y": 50.0 * 0.5,
+        "start_layer": 0,
+        "end_x": 95.0 * 0.5,
+        "end_y": 50.0 * 0.5,
+        "end_layer": 0,
+        "net": 1,
+    }
+
+    # Omitted (new default None -> all-zero PadBounds inside the binding).
+    r_omitted = _make_pathfinder().route(**kwargs)
+    # Explicit all-zero PadBounds (the historical default value).
+    r_explicit = _make_pathfinder().route(
+        start_pad_bounds=router_cpp.PadBounds(),
+        end_pad_bounds=router_cpp.PadBounds(),
+        **kwargs,
+    )
+
+    assert r_omitted.success and r_explicit.success
+    assert len(r_omitted.segments) == len(r_explicit.segments)
+    assert len(r_omitted.vias) == len(r_explicit.vias)


### PR DESCRIPTION
## Summary

`kct build-native` dumped a `nanobind: leaked 4 instances!` banner (type `PadBounds`) at interpreter teardown right after printing "installed successfully!". This fixes the root cause.

**Root cause:** `Pathfinder.route` / `route_resumable` each declared their two pad-bounds params with a materialized bound-type default arg (`"start_pad_bounds"_a = PadBounds{}`, L288/289 + L315/316 of `bindings.cpp`) — exactly 4. When a nanobind default argument is a *bound* (`nb::class_`) type, nanobind casts the sentinel into a persistent Python object held for the module's lifetime. CPython does not deallocate extension modules at interpreter finalization, so those 4 objects are still live when nanobind's teardown leak checker runs. `build-native` reloads the fresh `.so` in-process to verify it, so the dump fires on the exact command consumers are told to run.

**Fix:** bind both methods via a thin lambda whose two pad-bounds params are `std::optional<PadBounds>` defaulting to `nb::none()`, substituting an all-zero `PadBounds{}` inside the lambda when unset. The C++ overloads already default `= {}` (`pathfinder.hpp`), so no engine-signature change is needed and Python-visible behavior (default = all-zero PadBounds) is byte-identical.

## Verification

- Fresh `import kicad_tools.router.router_cpp` (subprocess) → empty stderr, no `nanobind: leaked`.
- `uv run kct build-native --force` (with the fixed `.so` on disk) → clean output, **no leak banner at all** — 0 instances, and the 13-types/218-functions banner is gone too. (The types/functions banner only accompanied the leaked instances; nanobind finalizes its internals cleanly once no live instances remain.)
- Note: the very first `build-native` run *after* the fix still showed the 4-instance banner because CLI startup loaded the OLD leaky `.so` on disk; its default sentinels leaked at teardown. Once the fixed `.so` is on disk, the banner is fully gone. This is a one-time transitional artifact for anyone upgrading from a pre-fix `.so`.

## Tests

New `tests/test_router_cpp_padbounds_leak_4346.py`:
- subprocess-stderr scrape asserting no `nanobind: leaked` on `import router_cpp` (the reliable signal, since the check only runs at interpreter finalization);
- guard that the pad-bounds Python defaults are `None` (not a re-introduced `PadBounds{}` sentinel);
- parity check: omitting the pad-bounds args routes identically (same segment/via counts) to passing an explicit all-zero `PadBounds()`.

## Local checks
- `pytest` router/cpp suites (380+ tests) + new regression file: green
- `ruff check .` / `ruff format . --check`: clean
- mypy baseline gate (`scripts/ci/check_mypy_baseline.py`): OK, no new type errors (change touches no `src/` Python). Baseline intentionally left unmodified (native-worktree `--update` trap).

Closes #4346

🤖 Generated with [Claude Code](https://claude.com/claude-code)