### PR TITLE
feat: add kct doctor version-record drift check

### DIFF
--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -60,6 +60,7 @@ from .commands import (
     run_creepage_command,
     run_datasheet_command,
     run_decisions_command,
+    run_doctor_command,
     run_estimate_command,
     run_fix_footprints_command,
     run_fleet_command,
@@ -454,6 +455,9 @@ def _dispatch_command(args) -> int:
 
     elif args.command == "build-native":
         return run_build_native_command(args)
+
+    elif args.command == "doctor":
+        return run_doctor_command(args)
 
     elif args.command == "spec":
         return run_spec_command(args)

--- a/src/kicad_tools/cli/commands/__init__.py
+++ b/src/kicad_tools/cli/commands/__init__.py
@@ -24,6 +24,7 @@ from .create_pcb import run_create_pcb_command
 from .creepage import run_creepage_command
 from .datasheet import run_datasheet_command
 from .decisions import run_decisions_command
+from .doctor import run_doctor_command
 from .estimate import run_estimate_command
 from .fleet import run_fleet_command
 from .footprint import run_footprint_command
@@ -139,6 +140,8 @@ __all__ = [
     "run_mcp_command",
     # Native build
     "run_build_native_command",
+    # Doctor
+    "run_doctor_command",
     # Run
     "run_run_command",
     # Panel

--- a/src/kicad_tools/cli/commands/doctor.py
+++ b/src/kicad_tools/cli/commands/doctor.py
@@ -1,0 +1,41 @@
+"""``kct doctor`` command handler.
+
+Thin CLI glue over :mod:`kicad_tools.doctor`. The first (currently only) check
+is version-record drift (issue #4347): compare the installed package version
+against the version records the installer stamps into a consumer repo.
+"""
+
+import json
+from pathlib import Path
+
+__all__ = ["run_doctor_command"]
+
+
+def run_doctor_command(args) -> int:
+    """Handle the ``doctor`` command.
+
+    Advisory by default (always exits 0 so it can be run informationally). With
+    ``--strict`` it exits 1 when any version record has drifted -- mirroring
+    ``build-native --check`` so it is gateable in CI / pre-commit hooks.
+    """
+    from kicad_tools import __version__
+    from kicad_tools.doctor import (
+        check_version_drift,
+        render_text,
+        report_to_dict,
+    )
+
+    root = Path(getattr(args, "doctor_root", None) or ".")
+    output_format = getattr(args, "doctor_format", "text")
+    strict = getattr(args, "doctor_strict", False)
+
+    report = check_version_drift(root, __version__)
+
+    if output_format == "json":
+        print(json.dumps(report_to_dict(report), indent=2))
+    else:
+        print(render_text(report))
+
+    if strict and report.has_drift:
+        return 1
+    return 0

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -187,6 +187,7 @@ def create_parser() -> argparse.ArgumentParser:
     _add_create_pcb_parser(subparsers)
     _add_build_parser(subparsers)
     _add_build_native_parser(subparsers)
+    _add_doctor_parser(subparsers)
     _add_spec_parser(subparsers)
     _add_benchmark_parser(subparsers)
     _add_sync_parser(subparsers)
@@ -7006,6 +7007,42 @@ def _add_build_native_parser(subparsers) -> None:
         dest="build_native_check",
         action="store_true",
         help="Just check if C++ backend is available, don't build",
+    )
+
+
+def _add_doctor_parser(subparsers) -> None:
+    """Add doctor subcommand parser for environment/installation health checks."""
+    doctor_parser = subparsers.add_parser(
+        "doctor",
+        help="Diagnose kicad-tools installation health (version-record drift)",
+        description=(
+            "Check the health of a kicad-tools installation. The first check is "
+            "version-record drift: the installed package version (ground truth) is "
+            "compared against the records the installer stamps into a consumer repo "
+            "(pyproject.toml dependency pin, .kct/install-metadata.json, and the "
+            "CLAUDE.md marker block). Advisory by default; use --strict to exit "
+            "non-zero on drift so it can gate CI / pre-commit hooks."
+        ),
+    )
+    doctor_parser.add_argument(
+        "--root",
+        dest="doctor_root",
+        default=".",
+        metavar="DIR",
+        help="Directory to look for the version records in (default: current dir)",
+    )
+    doctor_parser.add_argument(
+        "--format",
+        dest="doctor_format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    doctor_parser.add_argument(
+        "--strict",
+        dest="doctor_strict",
+        action="store_true",
+        help="Exit 1 when any version record has drifted (default: advisory exit 0)",
     )
 
 

--- a/src/kicad_tools/doctor.py
+++ b/src/kicad_tools/doctor.py
@@ -1,0 +1,602 @@
+"""Environment / installation health checks for kicad-tools (``kct doctor``).
+
+The first and currently only check is **version-record drift** (issue #4347).
+
+When ``kicad-tools`` is installed into a consumer repo by
+``scripts/install-kct.sh``, the installer stamps the resolved version into
+several *records* that live in the consumer's tree:
+
+1. ``pyproject.toml`` -- the ``kicad-tools`` uv dependency pin
+   (git ``tag = "vX"``, ``rev = "<sha>"``, or a local ``path`` install).
+2. ``.kct/install-metadata.json`` -- the ``kct_version`` field.
+3. ``CLAUDE.md`` -- the ``## kicad-tools (X)`` header inside the
+   ``<!-- BEGIN KICAD-TOOLS -->`` / ``<!-- END KICAD-TOOLS -->`` markers.
+
+A fourth record type is the kicad-tools **source checkout** itself, whose
+``pyproject.toml`` carries the canonical ``[project] version`` (record type
+``pyproject-project-version``). Records 1 and 4 are mutually exclusive: a repo
+is either a consumer that *depends on* kicad-tools, or the kicad-tools source
+checkout.
+
+``uv``-bumping the installed package (or checking out a new source tag) updates
+the ground-truth version -- ``importlib.metadata.version("kicad-tools")``,
+surfaced as :data:`kicad_tools.__version__` -- but the records above are only
+rewritten when the installer is re-run. They silently go stale. This module
+compares each record against the installed version (ground truth) and reports
+``ok`` / ``drift`` / ``not_present`` (plus a few informational states) per
+record, names the stale record(s), and prints the reconcile command.
+
+The core is intentionally CLI-free so it can be unit-tested against synthetic
+fixtures rooted at a temporary ``--root`` directory.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - exercised only on Python < 3.11
+    try:
+        import tomli as tomllib  # type: ignore[import-not-found]
+    except ImportError:
+        tomllib = None
+
+__all__ = [
+    "RecordStatus",
+    "RecordResult",
+    "DriftReport",
+    "check_version_drift",
+    "normalize_version",
+    "render_text",
+    "report_to_dict",
+    "PACKAGE_NAME",
+    "PYPROJECT_PROJECT_VERSION",
+    "PYPROJECT_DEPENDENCY",
+    "INSTALL_METADATA",
+    "CLAUDE_MD",
+]
+
+PACKAGE_NAME = "kicad-tools"
+
+# Record-type identifiers (stable keys for the JSON shape).
+PYPROJECT_PROJECT_VERSION = "pyproject-project-version"
+PYPROJECT_DEPENDENCY = "pyproject-dependency"
+INSTALL_METADATA = "install-metadata"
+CLAUDE_MD = "claude-md"
+
+# CLAUDE.md marker pair (must match scripts/install-kct.sh KCT_MARK_BEGIN/END).
+_CLAUDE_MARK_BEGIN = "<!-- BEGIN KICAD-TOOLS -->"
+_CLAUDE_MARK_END = "<!-- END KICAD-TOOLS -->"
+# Header line inside the marker block: "## kicad-tools (X)".
+_CLAUDE_HEADER_RE = re.compile(r"^\s*##\s+kicad-tools\s*\(([^)]+)\)\s*$")
+
+# The reconcile command template. Records are only rewritten by the installer,
+# so re-running it at the installed tag reconciles every stale record at once.
+_RECONCILE_TEMPLATE = "install-kct.sh --tag v{version}"
+
+# A version that looks like a release tag (e.g. "0.18.0", "v1.2.3rc1"). Used to
+# distinguish a git ``tag`` pin from a bare commit sha / branch name.
+_VERSION_LIKE_RE = re.compile(r"^v?\d+\.\d+")
+
+
+class RecordStatus(str, Enum):
+    """Per-record drift status.
+
+    Only :attr:`DRIFT` is failure-worthy under ``--strict``; every other
+    status is advisory (a missing / editable / sha-pinned record is a normal,
+    non-error condition).
+    """
+
+    OK = "ok"
+    """Recorded version matches the installed version."""
+
+    DRIFT = "drift"
+    """Recorded version differs from the installed version (stale record)."""
+
+    NOT_PRESENT = "not_present"
+    """The record's file / marker / dependency is absent."""
+
+    UNPINNED_TO_SHA = "unpinned-to-sha"
+    """Dependency pinned to a git sha / branch / rev -- no comparable version."""
+
+    EDITABLE = "editable"
+    """Local path / editable dependency, or a floating spec -- no version pin."""
+
+    MALFORMED = "malformed"
+    """The record exists but could not be parsed (e.g. broken CLAUDE.md markers)."""
+
+
+@dataclass
+class RecordResult:
+    """The drift-check outcome for a single version record."""
+
+    name: str
+    """Record-type identifier (one of the module-level constants)."""
+
+    path: str
+    """Repo-relative path of the file that holds (or would hold) the record."""
+
+    status: RecordStatus
+    """The drift status for this record."""
+
+    recorded_version: str | None
+    """The version stamped in the record, or ``None`` when not applicable."""
+
+    detail: str
+    """Human-readable explanation of the status."""
+
+    @property
+    def is_drift(self) -> bool:
+        return self.status is RecordStatus.DRIFT
+
+
+@dataclass
+class DriftReport:
+    """Aggregate result of a version-record drift check."""
+
+    installed_version: str
+    """Ground-truth installed package version."""
+
+    root: str
+    """Absolute path of the directory the records were resolved against."""
+
+    records: list[RecordResult]
+    """One :class:`RecordResult` per known record type (always all four)."""
+
+    @property
+    def has_drift(self) -> bool:
+        """True when any record's recorded version is stale."""
+        return any(r.is_drift for r in self.records)
+
+    @property
+    def stale_records(self) -> list[RecordResult]:
+        """The records that are in :attr:`RecordStatus.DRIFT`."""
+        return [r for r in self.records if r.is_drift]
+
+    @property
+    def reconcile_command(self) -> str | None:
+        """The command that reconciles stale records, or ``None`` when clean."""
+        if not self.has_drift:
+            return None
+        return _RECONCILE_TEMPLATE.format(version=self.installed_version)
+
+
+def normalize_version(version: str) -> str:
+    """Normalize a version string for comparison.
+
+    Strips a leading ``v``/``V`` prefix and surrounding whitespace so that
+    ``v0.18.0`` and ``0.18.0`` compare equal.
+    """
+    v = version.strip()
+    if v[:1] in ("v", "V"):
+        v = v[1:]
+    return v
+
+
+def _versions_match(recorded: str, installed: str) -> bool:
+    return normalize_version(recorded) == normalize_version(installed)
+
+
+# ---------------------------------------------------------------------------
+# pyproject.toml parsing (records 1 and 2)
+# ---------------------------------------------------------------------------
+
+
+def _load_pyproject(path: Path) -> dict | None:
+    """Parse a pyproject.toml, returning ``None`` on any read/parse failure."""
+    if tomllib is None:  # pragma: no cover - only on Python < 3.11 w/o tomli
+        return None
+    try:
+        with path.open("rb") as fh:
+            data = tomllib.load(fh)
+    except (OSError, ValueError):
+        # ValueError covers tomllib.TOMLDecodeError (its base class).
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _dependency_requirement_name(spec: str) -> str:
+    """Extract the distribution name from a PEP 508 requirement string.
+
+    ``"kicad-tools @ git+..."`` -> ``"kicad-tools"``;
+    ``"kicad-tools>=1.0"`` -> ``"kicad-tools"``.
+    """
+    # The name is everything up to the first of: whitespace, @, comparison, [.
+    match = re.match(r"^\s*([A-Za-z0-9._-]+)", spec)
+    return match.group(1) if match else ""
+
+
+def _find_dependency_spec(project: dict) -> str | None:
+    """Return the raw requirement string for the kicad-tools dependency."""
+    deps = project.get("dependencies")
+    if not isinstance(deps, list):
+        return None
+    for dep in deps:
+        if isinstance(dep, str) and _dependency_requirement_name(dep) == PACKAGE_NAME:
+            return dep
+    return None
+
+
+def _classify_git_ref(ref: str) -> tuple[RecordStatus, str | None, str]:
+    """Classify a git ``@<ref>`` pin into (status, recorded_version, detail)."""
+    if _VERSION_LIKE_RE.match(ref):
+        return (RecordStatus.OK, ref, "")  # caller compares to decide ok/drift
+    return (
+        RecordStatus.UNPINNED_TO_SHA,
+        None,
+        f"pinned to git rev '{ref}' (not a version tag); cannot check for drift",
+    )
+
+
+def _classify_uv_source(source: dict) -> tuple[RecordStatus, str | None, str]:
+    """Classify a ``[tool.uv.sources].kicad-tools`` table entry."""
+    if "path" in source:
+        return (
+            RecordStatus.EDITABLE,
+            None,
+            f"local path dependency ({source['path']}); no version pin to check",
+        )
+    if "tag" in source:
+        return (RecordStatus.OK, str(source["tag"]), "")
+    for key in ("rev", "branch"):
+        if key in source:
+            return (
+                RecordStatus.UNPINNED_TO_SHA,
+                None,
+                f"pinned to git {key} '{source[key]}'; cannot check for drift",
+            )
+    if "git" in source:
+        return (
+            RecordStatus.UNPINNED_TO_SHA,
+            None,
+            "git source without a tag pin; cannot check for drift",
+        )
+    return (RecordStatus.EDITABLE, None, "dependency source has no version pin")
+
+
+def _classify_dependency_spec(spec: str) -> tuple[RecordStatus, str | None, str]:
+    """Classify a PEP 508 requirement string for the kicad-tools dependency."""
+    # git+URL@ref form: "kicad-tools @ git+https://.../kicad-tools@v0.18.0"
+    at_git = re.search(r"git\+[^@\s]+@([^\s#]+)", spec)
+    if at_git:
+        return _classify_git_ref(at_git.group(1))
+    # Exact PyPI pin: "kicad-tools==0.18.0"
+    exact = re.search(r"==\s*([^\s,;]+)", spec)
+    if exact:
+        return (RecordStatus.OK, exact.group(1), "")
+    # Bare name or a range spec (>=, ~=, ...): no exact version to compare.
+    return (
+        RecordStatus.EDITABLE,
+        None,
+        "dependency present but not pinned to an exact version; no drift check",
+    )
+
+
+def _check_pyproject_records(root: Path, installed: str) -> tuple[RecordResult, RecordResult]:
+    """Resolve both pyproject-derived records (project-version + dependency)."""
+    rel = "pyproject.toml"
+    pyproject_path = root / rel
+    project_result = RecordResult(
+        PYPROJECT_PROJECT_VERSION,
+        rel,
+        RecordStatus.NOT_PRESENT,
+        None,
+        "no pyproject.toml at root",
+    )
+    dep_result = RecordResult(
+        PYPROJECT_DEPENDENCY,
+        rel,
+        RecordStatus.NOT_PRESENT,
+        None,
+        "no pyproject.toml at root",
+    )
+
+    if not pyproject_path.is_file():
+        return project_result, dep_result
+
+    data = _load_pyproject(pyproject_path)
+    if data is None:
+        malformed = "pyproject.toml is missing or could not be parsed"
+        return (
+            RecordResult(PYPROJECT_PROJECT_VERSION, rel, RecordStatus.MALFORMED, None, malformed),
+            RecordResult(PYPROJECT_DEPENDENCY, rel, RecordStatus.MALFORMED, None, malformed),
+        )
+
+    project = data.get("project", {}) if isinstance(data.get("project"), dict) else {}
+
+    # Record 4: is this the kicad-tools SOURCE checkout?
+    if project.get("name") == PACKAGE_NAME:
+        recorded = project.get("version")
+        if isinstance(recorded, str):
+            if _versions_match(recorded, installed):
+                project_result = RecordResult(
+                    PYPROJECT_PROJECT_VERSION,
+                    rel,
+                    RecordStatus.OK,
+                    recorded,
+                    "source [project] version matches the installed package",
+                )
+            else:
+                project_result = RecordResult(
+                    PYPROJECT_PROJECT_VERSION,
+                    rel,
+                    RecordStatus.DRIFT,
+                    recorded,
+                    (
+                        f"source [project] version {recorded!r} != installed "
+                        f"{installed!r} (rebuild/reinstall the package: 'uv sync')"
+                    ),
+                )
+        else:
+            project_result = RecordResult(
+                PYPROJECT_PROJECT_VERSION,
+                rel,
+                RecordStatus.MALFORMED,
+                None,
+                "[project] has no string version field",
+            )
+        # A source checkout is never also a consumer of itself.
+        dep_result = RecordResult(
+            PYPROJECT_DEPENDENCY,
+            rel,
+            RecordStatus.NOT_PRESENT,
+            None,
+            "this is the kicad-tools source checkout, not a consumer",
+        )
+        return project_result, dep_result
+
+    # Otherwise this is (potentially) a consumer: record 1 not present.
+    project_result = RecordResult(
+        PYPROJECT_PROJECT_VERSION,
+        rel,
+        RecordStatus.NOT_PRESENT,
+        None,
+        "pyproject.toml is not the kicad-tools source (no matching [project] name)",
+    )
+
+    # Record 1: the kicad-tools dependency pin. Prefer the uv source table,
+    # which is where `uv add` records the git tag / rev / path.
+    tool = data.get("tool", {})
+    uv_sources = {}
+    if isinstance(tool, dict):
+        uv = tool.get("uv", {})
+        if isinstance(uv, dict) and isinstance(uv.get("sources"), dict):
+            uv_sources = uv["sources"]
+
+    status: RecordStatus
+    recorded_version: str | None
+    detail: str
+    source_entry = uv_sources.get(PACKAGE_NAME)
+    if isinstance(source_entry, dict):
+        status, recorded_version, detail = _classify_uv_source(source_entry)
+    else:
+        spec = _find_dependency_spec(project)
+        if spec is None:
+            return project_result, dep_result  # dep_result stays NOT_PRESENT
+        status, recorded_version, detail = _classify_dependency_spec(spec)
+
+    dep_result = _finalize_versioned_record(
+        PYPROJECT_DEPENDENCY, rel, status, recorded_version, detail, installed
+    )
+    return project_result, dep_result
+
+
+def _finalize_versioned_record(
+    name: str,
+    rel: str,
+    status: RecordStatus,
+    recorded_version: str | None,
+    detail: str,
+    installed: str,
+) -> RecordResult:
+    """Turn a provisional (status, version) into ok/drift when comparable.
+
+    When ``status`` came back as :attr:`RecordStatus.OK` with a
+    ``recorded_version`` string, this compares it to ``installed`` and demotes
+    to :attr:`RecordStatus.DRIFT` on mismatch. Informational statuses
+    (unpinned/editable/malformed) pass through unchanged.
+    """
+    if status is RecordStatus.OK and recorded_version is not None:
+        if _versions_match(recorded_version, installed):
+            return RecordResult(
+                name,
+                rel,
+                RecordStatus.OK,
+                recorded_version,
+                f"records v{normalize_version(recorded_version)} (matches installed)",
+            )
+        return RecordResult(
+            name,
+            rel,
+            RecordStatus.DRIFT,
+            recorded_version,
+            (
+                f"records v{normalize_version(recorded_version)} but installed is "
+                f"v{normalize_version(installed)}"
+            ),
+        )
+    return RecordResult(name, rel, status, recorded_version, detail)
+
+
+# ---------------------------------------------------------------------------
+# .kct/install-metadata.json (record 2)
+# ---------------------------------------------------------------------------
+
+
+def _check_install_metadata(root: Path, installed: str) -> RecordResult:
+    rel = ".kct/install-metadata.json"
+    path = root / ".kct" / "install-metadata.json"
+    if not path.is_file():
+        return RecordResult(
+            INSTALL_METADATA, rel, RecordStatus.NOT_PRESENT, None, "file not present"
+        )
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return RecordResult(INSTALL_METADATA, rel, RecordStatus.MALFORMED, None, "invalid JSON")
+    recorded = data.get("kct_version") if isinstance(data, dict) else None
+    if not isinstance(recorded, str):
+        return RecordResult(
+            INSTALL_METADATA,
+            rel,
+            RecordStatus.MALFORMED,
+            None,
+            "no string 'kct_version' field",
+        )
+    return _finalize_versioned_record(
+        INSTALL_METADATA, rel, RecordStatus.OK, recorded, "", installed
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLAUDE.md marker block (record 3)
+# ---------------------------------------------------------------------------
+
+
+def _extract_claude_md_version(text: str) -> tuple[str | None, str | None]:
+    """Extract the kicad-tools header version from CLAUDE.md text.
+
+    Returns ``(version, error)``. Exactly one is non-None:
+    - ``(version, None)`` -- header found inside a well-formed marker block.
+    - ``(None, None)`` -- no kicad-tools marker block at all.
+    - ``(None, error)`` -- markers present but malformed / no header.
+    """
+    if _CLAUDE_MARK_BEGIN not in text:
+        return None, None
+
+    depth = 0
+    header_version: str | None = None
+    for line in text.splitlines():
+        if _CLAUDE_MARK_BEGIN in line:
+            depth += 1
+            continue
+        if _CLAUDE_MARK_END in line:
+            if depth == 0:
+                return None, "END marker appears before BEGIN marker"
+            depth -= 1
+            continue
+        if depth > 0 and header_version is None:
+            m = _CLAUDE_HEADER_RE.match(line)
+            if m:
+                header_version = m.group(1).strip()
+    if depth != 0:
+        return None, "unterminated BEGIN marker (no matching END)"
+    if header_version is None:
+        return None, "marker block present but no '## kicad-tools (X)' header"
+    return header_version, None
+
+
+def _check_claude_md(root: Path, installed: str) -> RecordResult:
+    rel = "CLAUDE.md"
+    path = root / rel
+    if not path.is_file():
+        return RecordResult(CLAUDE_MD, rel, RecordStatus.NOT_PRESENT, None, "file not present")
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return RecordResult(CLAUDE_MD, rel, RecordStatus.MALFORMED, None, "could not read file")
+
+    version, error = _extract_claude_md_version(text)
+    if error is not None:
+        return RecordResult(CLAUDE_MD, rel, RecordStatus.MALFORMED, None, error)
+    if version is None:
+        return RecordResult(
+            CLAUDE_MD, rel, RecordStatus.NOT_PRESENT, None, "no kicad-tools marker block"
+        )
+    return _finalize_versioned_record(CLAUDE_MD, rel, RecordStatus.OK, version, "", installed)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def check_version_drift(root: Path | str, installed_version: str) -> DriftReport:
+    """Check every version record under ``root`` against ``installed_version``.
+
+    ``installed_version`` is the ground truth -- normally
+    :data:`kicad_tools.__version__`. Passing it in (rather than reading it
+    here) keeps the core testable with synthetic versions.
+
+    Never raises for missing / malformed records: each degrades to a
+    ``not_present`` or ``malformed`` :class:`RecordResult`.
+    """
+    root_path = Path(root).resolve()
+    project_result, dep_result = _check_pyproject_records(root_path, installed_version)
+    records = [
+        dep_result,
+        _check_install_metadata(root_path, installed_version),
+        _check_claude_md(root_path, installed_version),
+        project_result,
+    ]
+    return DriftReport(
+        installed_version=installed_version,
+        root=str(root_path),
+        records=records,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+_STATUS_GLYPH = {
+    RecordStatus.OK: "ok       ",
+    RecordStatus.DRIFT: "DRIFT    ",
+    RecordStatus.NOT_PRESENT: "n/a      ",
+    RecordStatus.UNPINNED_TO_SHA: "info     ",
+    RecordStatus.EDITABLE: "info     ",
+    RecordStatus.MALFORMED: "malformed",
+}
+
+
+def report_to_dict(report: DriftReport) -> dict:
+    """Serialize a :class:`DriftReport` to the agent-facing JSON shape."""
+    return {
+        "check": "version-drift",
+        "installed_version": report.installed_version,
+        "root": report.root,
+        "has_drift": report.has_drift,
+        "ok": not report.has_drift,
+        "reconcile_command": report.reconcile_command,
+        "records": [
+            {
+                "name": r.name,
+                "path": r.path,
+                "status": r.status.value,
+                "recorded_version": r.recorded_version,
+                "detail": r.detail,
+            }
+            for r in report.records
+        ],
+    }
+
+
+def render_text(report: DriftReport) -> str:
+    """Render a :class:`DriftReport` as human-readable text."""
+    lines = [
+        "kct doctor: version-record drift",
+        f"  installed version (ground truth): {report.installed_version}",
+        f"  root: {report.root}",
+        "",
+    ]
+    for r in report.records:
+        glyph = _STATUS_GLYPH.get(r.status, r.status.value)
+        recorded = r.recorded_version if r.recorded_version is not None else "-"
+        lines.append(f"  [{glyph}] {r.name:<26} recorded={recorded}")
+        if r.detail:
+            lines.append(f"              {r.detail}")
+    lines.append("")
+    if report.has_drift:
+        stale = ", ".join(r.name for r in report.stale_records)
+        lines.append(f"DRIFT: stale record(s): {stale}")
+        lines.append(f"Reconcile with: {report.reconcile_command}")
+    else:
+        lines.append("OK: no version-record drift detected.")
+    return "\n".join(lines)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,483 @@
+"""Tests for ``kct doctor`` version-record drift checking (issue #4347).
+
+The core logic in :mod:`kicad_tools.doctor` is exercised against synthetic
+fixtures rooted at ``tmp_path`` so we can construct matching / drifted /
+partial / dev-checkout record sets deterministically without touching the real
+repo. The CLI glue is smoke-tested via ``kicad_tools.cli.main``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from kicad_tools.doctor import (
+    CLAUDE_MD,
+    INSTALL_METADATA,
+    PYPROJECT_DEPENDENCY,
+    PYPROJECT_PROJECT_VERSION,
+    DriftReport,
+    RecordStatus,
+    check_version_drift,
+    normalize_version,
+    render_text,
+    report_to_dict,
+)
+
+INSTALLED = "0.18.0"
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def write_consumer_pyproject_tag(root, version, name="my-board"):
+    """A consumer pyproject with a uv git-tag pin for kicad-tools."""
+    (root / "pyproject.toml").write_text(
+        "[project]\n"
+        f'name = "{name}"\n'
+        'version = "0.1.0"\n'
+        'dependencies = ["kicad-tools"]\n'
+        "\n"
+        "[tool.uv.sources]\n"
+        'kicad-tools = { git = "https://github.com/rjwalters/kicad-tools", '
+        f'tag = "{version}" }}\n',
+        encoding="utf-8",
+    )
+
+
+def write_metadata(root, version):
+    kct = root / ".kct"
+    kct.mkdir(exist_ok=True)
+    (kct / "install-metadata.json").write_text(
+        json.dumps({"kct_version": version, "install_date": "2026-07-18"}),
+        encoding="utf-8",
+    )
+
+
+def write_claude_md(root, version, *, extra_before="# My Board\n\n"):
+    (root / "CLAUDE.md").write_text(
+        f"{extra_before}"
+        "<!-- BEGIN KICAD-TOOLS -->\n"
+        f"## kicad-tools ({version})\n"
+        "\n"
+        "This repo uses kicad-tools.\n"
+        "<!-- END KICAD-TOOLS -->\n",
+        encoding="utf-8",
+    )
+
+
+def get(report: DriftReport, name: str):
+    for r in report.records:
+        if r.name == name:
+            return r
+    raise AssertionError(f"record {name!r} not in report")
+
+
+# ---------------------------------------------------------------------------
+# normalize_version
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("0.18.0", "0.18.0"),
+        ("v0.18.0", "0.18.0"),
+        ("V0.18.0", "0.18.0"),
+        ("  v0.18.0  ", "0.18.0"),
+    ],
+)
+def test_normalize_version(raw, expected):
+    assert normalize_version(raw) == expected
+
+
+# ---------------------------------------------------------------------------
+# Clean / matching consumer
+# ---------------------------------------------------------------------------
+
+
+def test_all_records_match(tmp_path):
+    write_consumer_pyproject_tag(tmp_path, f"v{INSTALLED}")
+    write_metadata(tmp_path, INSTALLED)
+    write_claude_md(tmp_path, INSTALLED)
+
+    report = check_version_drift(tmp_path, INSTALLED)
+
+    assert not report.has_drift
+    assert report.reconcile_command is None
+    assert get(report, PYPROJECT_DEPENDENCY).status is RecordStatus.OK
+    assert get(report, INSTALL_METADATA).status is RecordStatus.OK
+    assert get(report, CLAUDE_MD).status is RecordStatus.OK
+    # A consumer is not the source checkout.
+    assert get(report, PYPROJECT_PROJECT_VERSION).status is RecordStatus.NOT_PRESENT
+
+
+def test_v_prefix_normalizes_across_records(tmp_path):
+    # Dependency tag has the v-prefix; metadata / CLAUDE.md do not.
+    write_consumer_pyproject_tag(tmp_path, f"v{INSTALLED}")
+    write_metadata(tmp_path, INSTALLED)
+    write_claude_md(tmp_path, INSTALLED)
+
+    report = check_version_drift(tmp_path, f"v{INSTALLED}")  # ground truth w/ v
+    assert not report.has_drift
+
+
+# ---------------------------------------------------------------------------
+# Drift
+# ---------------------------------------------------------------------------
+
+
+def test_all_records_drift(tmp_path):
+    write_consumer_pyproject_tag(tmp_path, "v0.16.0")
+    write_metadata(tmp_path, "0.16.0")
+    write_claude_md(tmp_path, "0.16.0")
+
+    report = check_version_drift(tmp_path, INSTALLED)
+
+    assert report.has_drift
+    assert {r.name for r in report.stale_records} == {
+        PYPROJECT_DEPENDENCY,
+        INSTALL_METADATA,
+        CLAUDE_MD,
+    }
+    assert report.reconcile_command == f"install-kct.sh --tag v{INSTALLED}"
+    for name in (PYPROJECT_DEPENDENCY, INSTALL_METADATA, CLAUDE_MD):
+        assert get(report, name).status is RecordStatus.DRIFT
+
+
+def test_partial_drift(tmp_path):
+    # metadata matches, dependency + CLAUDE.md are stale.
+    write_consumer_pyproject_tag(tmp_path, "v0.16.0")
+    write_metadata(tmp_path, INSTALLED)
+    write_claude_md(tmp_path, "0.17.0")
+
+    report = check_version_drift(tmp_path, INSTALLED)
+
+    assert report.has_drift
+    assert get(report, INSTALL_METADATA).status is RecordStatus.OK
+    assert get(report, PYPROJECT_DEPENDENCY).status is RecordStatus.DRIFT
+    assert get(report, CLAUDE_MD).status is RecordStatus.DRIFT
+    assert {r.name for r in report.stale_records} == {PYPROJECT_DEPENDENCY, CLAUDE_MD}
+
+
+# ---------------------------------------------------------------------------
+# Dev / source checkout
+# ---------------------------------------------------------------------------
+
+
+def test_dev_checkout_source_version_ok(tmp_path):
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "kicad-tools"\nversion = "0.18.0"\n',
+        encoding="utf-8",
+    )
+    report = check_version_drift(tmp_path, INSTALLED)
+
+    assert not report.has_drift
+    assert get(report, PYPROJECT_PROJECT_VERSION).status is RecordStatus.OK
+    # Consumer records absent -> not_present, never error.
+    assert get(report, PYPROJECT_DEPENDENCY).status is RecordStatus.NOT_PRESENT
+    assert get(report, INSTALL_METADATA).status is RecordStatus.NOT_PRESENT
+    assert get(report, CLAUDE_MD).status is RecordStatus.NOT_PRESENT
+
+
+def test_dev_checkout_source_version_drift(tmp_path):
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "kicad-tools"\nversion = "0.17.0"\n',
+        encoding="utf-8",
+    )
+    report = check_version_drift(tmp_path, INSTALLED)
+    assert report.has_drift
+    assert get(report, PYPROJECT_PROJECT_VERSION).status is RecordStatus.DRIFT
+
+
+# ---------------------------------------------------------------------------
+# Empty root: everything absent, never errors
+# ---------------------------------------------------------------------------
+
+
+def test_empty_root_all_not_present(tmp_path):
+    report = check_version_drift(tmp_path, INSTALLED)
+    assert not report.has_drift
+    assert all(r.status is RecordStatus.NOT_PRESENT for r in report.records)
+
+
+# ---------------------------------------------------------------------------
+# Dependency-pin edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_sha_pin_is_informational_not_drift(tmp_path):
+    (tmp_path / "pyproject.toml").write_text(
+        "[project]\n"
+        'name = "my-board"\n'
+        'version = "0.1.0"\n'
+        'dependencies = ["kicad-tools"]\n'
+        "\n"
+        "[tool.uv.sources]\n"
+        'kicad-tools = { git = "https://github.com/rjwalters/kicad-tools", '
+        'rev = "deadbeefcafe" }\n',
+        encoding="utf-8",
+    )
+    report = check_version_drift(tmp_path, INSTALLED)
+    rec = get(report, PYPROJECT_DEPENDENCY)
+    assert rec.status is RecordStatus.UNPINNED_TO_SHA
+    assert not report.has_drift
+
+
+def test_editable_path_is_informational_not_drift(tmp_path):
+    (tmp_path / "pyproject.toml").write_text(
+        "[project]\n"
+        'name = "my-board"\n'
+        'version = "0.1.0"\n'
+        'dependencies = ["kicad-tools"]\n'
+        "\n"
+        "[tool.uv.sources]\n"
+        'kicad-tools = { path = "../kicad-tools", editable = true }\n',
+        encoding="utf-8",
+    )
+    report = check_version_drift(tmp_path, INSTALLED)
+    rec = get(report, PYPROJECT_DEPENDENCY)
+    assert rec.status is RecordStatus.EDITABLE
+    assert not report.has_drift
+
+
+def test_inline_git_dependency_string_tag(tmp_path):
+    # No [tool.uv.sources] table; pin lives inline in the dependency string.
+    (tmp_path / "pyproject.toml").write_text(
+        "[project]\n"
+        'name = "my-board"\n'
+        'version = "0.1.0"\n'
+        "dependencies = [\n"
+        '  "kicad-tools @ git+https://github.com/rjwalters/kicad-tools@v0.16.0",\n'
+        "]\n",
+        encoding="utf-8",
+    )
+    report = check_version_drift(tmp_path, INSTALLED)
+    rec = get(report, PYPROJECT_DEPENDENCY)
+    assert rec.status is RecordStatus.DRIFT
+    assert rec.recorded_version == "v0.16.0"
+
+
+def test_inline_git_dependency_sha(tmp_path):
+    (tmp_path / "pyproject.toml").write_text(
+        "[project]\n"
+        'name = "my-board"\n'
+        'version = "0.1.0"\n'
+        "dependencies = [\n"
+        '  "kicad-tools @ git+https://github.com/rjwalters/kicad-tools@abc1234",\n'
+        "]\n",
+        encoding="utf-8",
+    )
+    report = check_version_drift(tmp_path, INSTALLED)
+    assert get(report, PYPROJECT_DEPENDENCY).status is RecordStatus.UNPINNED_TO_SHA
+
+
+def test_exact_pypi_pin(tmp_path):
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "my-board"\nversion = "0.1.0"\ndependencies = ["kicad-tools==0.18.0"]\n',
+        encoding="utf-8",
+    )
+    report = check_version_drift(tmp_path, INSTALLED)
+    assert get(report, PYPROJECT_DEPENDENCY).status is RecordStatus.OK
+
+
+def test_range_pypi_spec_is_informational(tmp_path):
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "my-board"\nversion = "0.1.0"\ndependencies = ["kicad-tools>=0.10"]\n',
+        encoding="utf-8",
+    )
+    report = check_version_drift(tmp_path, INSTALLED)
+    rec = get(report, PYPROJECT_DEPENDENCY)
+    assert rec.status is RecordStatus.EDITABLE
+    assert not report.has_drift
+
+
+def test_no_kicad_tools_dependency(tmp_path):
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "my-board"\nversion = "0.1.0"\ndependencies = ["requests"]\n',
+        encoding="utf-8",
+    )
+    report = check_version_drift(tmp_path, INSTALLED)
+    assert get(report, PYPROJECT_DEPENDENCY).status is RecordStatus.NOT_PRESENT
+
+
+# ---------------------------------------------------------------------------
+# Malformed records never crash
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_claude_md_unterminated(tmp_path):
+    (tmp_path / "CLAUDE.md").write_text(
+        "# Board\n<!-- BEGIN KICAD-TOOLS -->\n## kicad-tools (0.16.0)\n(no end marker)\n",
+        encoding="utf-8",
+    )
+    report = check_version_drift(tmp_path, INSTALLED)
+    rec = get(report, CLAUDE_MD)
+    assert rec.status is RecordStatus.MALFORMED
+    assert not report.has_drift  # malformed is not drift
+
+
+def test_malformed_claude_md_end_before_begin(tmp_path):
+    (tmp_path / "CLAUDE.md").write_text(
+        "# Board\n<!-- END KICAD-TOOLS -->\n<!-- BEGIN KICAD-TOOLS -->\n",
+        encoding="utf-8",
+    )
+    report = check_version_drift(tmp_path, INSTALLED)
+    assert get(report, CLAUDE_MD).status is RecordStatus.MALFORMED
+
+
+def test_claude_md_block_without_header(tmp_path):
+    (tmp_path / "CLAUDE.md").write_text(
+        "# Board\n<!-- BEGIN KICAD-TOOLS -->\nno header here\n<!-- END KICAD-TOOLS -->\n",
+        encoding="utf-8",
+    )
+    report = check_version_drift(tmp_path, INSTALLED)
+    assert get(report, CLAUDE_MD).status is RecordStatus.MALFORMED
+
+
+def test_claude_md_no_marker_block_is_not_present(tmp_path):
+    (tmp_path / "CLAUDE.md").write_text("# Board\n\nJust notes, no kicad-tools block.\n")
+    report = check_version_drift(tmp_path, INSTALLED)
+    assert get(report, CLAUDE_MD).status is RecordStatus.NOT_PRESENT
+
+
+def test_malformed_metadata_json(tmp_path):
+    kct = tmp_path / ".kct"
+    kct.mkdir()
+    (kct / "install-metadata.json").write_text("{ not valid json", encoding="utf-8")
+    report = check_version_drift(tmp_path, INSTALLED)
+    assert get(report, INSTALL_METADATA).status is RecordStatus.MALFORMED
+
+
+def test_metadata_missing_version_field(tmp_path):
+    kct = tmp_path / ".kct"
+    kct.mkdir()
+    (kct / "install-metadata.json").write_text('{"install_date": "2026-07-18"}')
+    report = check_version_drift(tmp_path, INSTALLED)
+    assert get(report, INSTALL_METADATA).status is RecordStatus.MALFORMED
+
+
+def test_malformed_pyproject(tmp_path):
+    (tmp_path / "pyproject.toml").write_text("this is = not [valid toml", encoding="utf-8")
+    report = check_version_drift(tmp_path, INSTALLED)
+    # Both pyproject-derived records degrade to malformed, no crash.
+    assert get(report, PYPROJECT_DEPENDENCY).status is RecordStatus.MALFORMED
+    assert get(report, PYPROJECT_PROJECT_VERSION).status is RecordStatus.MALFORMED
+
+
+# ---------------------------------------------------------------------------
+# JSON shape
+# ---------------------------------------------------------------------------
+
+
+def test_json_shape(tmp_path):
+    write_consumer_pyproject_tag(tmp_path, "v0.16.0")
+    write_metadata(tmp_path, "0.16.0")
+    write_claude_md(tmp_path, "0.16.0")
+
+    payload = report_to_dict(check_version_drift(tmp_path, INSTALLED))
+
+    assert payload["check"] == "version-drift"
+    assert payload["installed_version"] == INSTALLED
+    assert payload["has_drift"] is True
+    assert payload["ok"] is False
+    assert payload["reconcile_command"] == f"install-kct.sh --tag v{INSTALLED}"
+    assert isinstance(payload["records"], list)
+    assert len(payload["records"]) == 4
+    for rec in payload["records"]:
+        assert set(rec) == {"name", "path", "status", "recorded_version", "detail"}
+
+    # Round-trips as JSON.
+    assert json.loads(json.dumps(payload))["has_drift"] is True
+
+
+def test_json_shape_clean(tmp_path):
+    write_consumer_pyproject_tag(tmp_path, f"v{INSTALLED}")
+    payload = report_to_dict(check_version_drift(tmp_path, INSTALLED))
+    assert payload["ok"] is True
+    assert payload["has_drift"] is False
+    assert payload["reconcile_command"] is None
+
+
+# ---------------------------------------------------------------------------
+# Text rendering
+# ---------------------------------------------------------------------------
+
+
+def test_render_text_drift_names_records_and_reconcile(tmp_path):
+    write_consumer_pyproject_tag(tmp_path, "v0.16.0")
+    write_metadata(tmp_path, "0.16.0")
+    text = render_text(check_version_drift(tmp_path, INSTALLED))
+    assert "DRIFT" in text
+    assert f"install-kct.sh --tag v{INSTALLED}" in text
+    assert PYPROJECT_DEPENDENCY in text
+
+
+def test_render_text_clean(tmp_path):
+    write_consumer_pyproject_tag(tmp_path, f"v{INSTALLED}")
+    text = render_text(check_version_drift(tmp_path, INSTALLED))
+    assert "no version-record drift" in text
+
+
+# ---------------------------------------------------------------------------
+# CLI glue + exit codes
+# ---------------------------------------------------------------------------
+
+
+def test_cli_advisory_exit_zero_on_drift(tmp_path, capsys):
+    from kicad_tools.cli import main
+
+    write_consumer_pyproject_tag(tmp_path, "v0.0.1")  # guaranteed drift
+    rc = main(["doctor", "--root", str(tmp_path)])
+    assert rc == 0  # advisory by default
+    assert "DRIFT" in capsys.readouterr().out
+
+
+def test_cli_strict_exit_one_on_drift(tmp_path, capsys):
+    from kicad_tools.cli import main
+
+    write_consumer_pyproject_tag(tmp_path, "v0.0.1")
+    rc = main(["doctor", "--root", str(tmp_path), "--strict"])
+    assert rc == 1
+
+
+def test_cli_strict_exit_zero_when_clean(tmp_path, capsys):
+    from kicad_tools import __version__
+    from kicad_tools.cli import main
+
+    write_consumer_pyproject_tag(tmp_path, f"v{__version__}")
+    rc = main(["doctor", "--root", str(tmp_path), "--strict"])
+    assert rc == 0
+
+
+def test_cli_json_format(tmp_path, capsys):
+    from kicad_tools.cli import main
+
+    write_consumer_pyproject_tag(tmp_path, "v0.0.1")
+    rc = main(["doctor", "--root", str(tmp_path), "--format", "json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["check"] == "version-drift"
+    assert payload["has_drift"] is True
+
+
+def test_cli_strict_exit_zero_on_informational_sha(tmp_path):
+    """--strict must not fail on informational (sha/editable) records."""
+    from kicad_tools.cli import main
+
+    (tmp_path / "pyproject.toml").write_text(
+        "[project]\n"
+        'name = "my-board"\n'
+        'version = "0.1.0"\n'
+        'dependencies = ["kicad-tools"]\n'
+        "\n"
+        "[tool.uv.sources]\n"
+        'kicad-tools = { git = "https://github.com/rjwalters/kicad-tools", '
+        'rev = "deadbeef" }\n',
+        encoding="utf-8",
+    )
+    rc = main(["doctor", "--root", str(tmp_path), "--strict"])
+    assert rc == 0


### PR DESCRIPTION
## Summary

Adds a new `kct doctor` leaf subcommand whose first (currently only) check is **version-record drift**. When `kicad-tools` is installed into a consumer repo by `scripts/install-kct.sh`, the resolved version is stamped into several records. `uv`-bumping the installed package updates the ground-truth version (`importlib.metadata.version("kicad-tools")` → `kicad_tools.__version__`) but leaves those records stale with no detection. `kct doctor` compares each record against the installed version and reports drift.

## Changes

- **`src/kicad_tools/doctor.py`** (new, CLI-free core): `check_version_drift(root, installed_version)` resolves four record types and returns a `DriftReport`; plus `render_text` / `report_to_dict` renderers and `normalize_version`.
- **`src/kicad_tools/cli/commands/doctor.py`** (new): thin CLI glue → `run_doctor_command`.
- **CLI wiring**: `_add_doctor_parser` in `parser.py` (`--root` / `--format` / `--strict`), re-export in `commands/__init__.py`, `elif args.command == "doctor"` dispatch in `cli/__init__.py`.
- **`tests/test_doctor.py`** (new): 34 tests over synthetic fixtures under `tmp_path`.

### Records checked (all four always reported)

| Record | Source |
|--------|--------|
| `pyproject-dependency` | consumer `pyproject.toml` kicad-tools uv pin (git `tag` / `rev` / `path`, or inline `@vX`, or `==X`) |
| `install-metadata` | `.kct/install-metadata.json` `kct_version` |
| `claude-md` | `CLAUDE.md` `## kicad-tools (X)` header inside the `<!-- BEGIN/END KICAD-TOOLS -->` markers |
| `pyproject-project-version` | kicad-tools **source checkout** `[project] version` (dev-repo record) |

Per-record status: `ok` / `drift` / `not_present`, plus informational `unpinned-to-sha` (git rev/branch), `editable` (path/floating), `malformed`. Absent records degrade to `not_present` and never error; dev checkout has records 1–3 as `not_present`.

### Exit-code rule

Advisory **exit 0** by default (informational). `--strict` → **exit 1** only when a record is in `drift` (never on `not_present` / `unpinned-to-sha` / `editable` / `malformed`), mirroring `build-native --check`. On drift it names the stale record(s) and prints the reconcile command `install-kct.sh --tag v<installed>`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| New `kct doctor`; first check = version-record drift; installed version is ground truth | ✅ | `check_version_drift` uses `kicad_tools.__version__`; wired end-to-end |
| Each record ok / drift / not_present; absent never errors; dev-vs-consumer defined | ✅ | `test_empty_root_all_not_present`, `test_dev_checkout_source_version_ok`, `test_all_records_match` |
| `--root <dir>` override | ✅ | all tests drive it; `test_cli_*` |
| `--format json` with defined shape | ✅ | `test_json_shape`, `test_cli_json_format` |
| Advisory exit 0; `--strict` → exit 1 on drift | ✅ | `test_cli_advisory_exit_zero_on_drift`, `test_cli_strict_exit_one_on_drift`, `test_cli_strict_exit_zero_on_informational_sha` |
| On drift: name stale record(s) + reconcile command | ✅ | `test_render_text_drift_names_records_and_reconcile`, `test_all_records_drift` |
| Edge cases: editable/no-pin, sha (`unpinned-to-sha`), v-prefix, malformed markers | ✅ | `test_editable_path_*`, `test_sha_pin_*`, `test_normalize_version`, `test_malformed_claude_md_*`, `test_malformed_pyproject` |
| Core logic in testable `doctor.py` split from CLI glue | ✅ | `src/kicad_tools/doctor.py` is CLI-free |

## Test Plan

- `uv run pytest tests/test_doctor.py` → **34 passed**
- `uv run pytest tests/test_cli.py tests/test_cli_commands.py tests/test_cli_parser_drift.py tests/test_doctor.py` → **136 passed** (parser-drift guard green)
- `uv run ruff check .` + `uv run ruff format . --check` → clean
- `uv run python scripts/ci/check_mypy_baseline.py` → no new type errors (one unavoidable tomli `import-not-found` on the py<3.11 fallback carries a targeted `# type: ignore[import-not-found]`, matching the gate's stated preference over a baseline edit)

Sample (drifted consumer):
```
  [DRIFT    ] pyproject-dependency       recorded=v0.16.0
  [DRIFT    ] install-metadata           recorded=0.16.0
  [DRIFT    ] claude-md                  recorded=0.16.0
  [n/a      ] pyproject-project-version  recorded=-
DRIFT: stale record(s): pyproject-dependency, install-metadata, claude-md
Reconcile with: install-kct.sh --tag v0.18.0
```

Closes #4347