### PR TITLE
fix(sync): compare component values by parsed magnitude, not raw strings

### DIFF
--- a/src/kicad_tools/sync/drift.py
+++ b/src/kicad_tools/sync/drift.py
@@ -71,13 +71,36 @@ def _drift_summary_parts(analysis: SyncAnalysis) -> list[str]:
 
 
 def has_drift(analysis: SyncAnalysis) -> bool:
-    """True when any of the four drift axes is non-empty."""
+    """True when any of the four drift axes is non-empty.
+
+    ``value_suffix_notes`` are intentionally excluded: a value that differs only
+    by a rating/tolerance suffix ('100nF' vs '100nF 25V') is informational and
+    must never affect the drift verdict or the ``--netlist-sync`` exit code.
+    """
     return bool(
         analysis.schematic_orphans
         or analysis.pcb_orphans
         or analysis.value_mismatches
         or analysis.footprint_mismatches
     )
+
+
+def _render_suffix_notes(analysis: SyncAnalysis) -> list[str]:
+    """Render the informational "same value, PCB adds rating suffix" section.
+
+    Returns an empty list when there are no suffix notes.  These rows are
+    informational only -- they are excluded from ``has_drift`` and the summary
+    fragments so they never affect the drift verdict or exit code.
+    """
+    notes = getattr(analysis, "value_suffix_notes", None)
+    if not notes:
+        return []
+    lines: list[str] = ["", f"Informational: same value, PCB adds rating suffix [{len(notes)}]:"]
+    for m in notes:
+        lines.append(
+            f"  - {m['reference']}: schematic={m['schematic_value']!r} pcb={m['pcb_value']!r}"
+        )
+    return lines
 
 
 def format_drift_banner(analysis: SyncAnalysis, pcb_path: str | Path) -> str | None:
@@ -110,6 +133,7 @@ def render_drift_report(analysis: SyncAnalysis, pcb_path: str | Path, schematic_
     if not has_drift(analysis):
         lines.append("")
         lines.append("IN SYNC - schematic and PCB component sets match.")
+        lines.extend(_render_suffix_notes(analysis))
         return "\n".join(lines)
 
     parts = _drift_summary_parts(analysis)
@@ -146,6 +170,8 @@ def render_drift_report(analysis: SyncAnalysis, pcb_path: str | Path, schematic_
                 f"  - {m['reference']}: schematic={m['schematic_footprint']!r} "
                 f"pcb={m['pcb_footprint']!r}"
             )
+
+    lines.extend(_render_suffix_notes(analysis))
 
     lines.append("")
     lines.append("Remediation:")

--- a/src/kicad_tools/sync/reconciler.py
+++ b/src/kicad_tools/sync/reconciler.py
@@ -29,7 +29,49 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from kicad_tools.cost.suggest import parse_component_value
 from kicad_tools.schema.bom import extract_bom
+
+# Relative tolerance for comparing parsed passive magnitudes.  Mirrors
+# ``kicad_tools.export.lcsc_value_check.VALUE_REL_TOLERANCE`` so both consumers
+# interpret numeric component values identically.
+_VALUE_REL_TOLERANCE = 0.05
+
+
+def _values_equivalent(sch_value: str, pcb_value: str, reference: str) -> bool:
+    """Return True when two value strings denote the same component value.
+
+    Numeric passives (R/L/C) are compared by parsed SI magnitude within
+    ``_VALUE_REL_TOLERANCE``, so a trailing voltage/tolerance/rating token
+    (``'100nF'`` vs ``'100nF 25V'``) is NOT treated as a mismatch.  Case- and
+    whitespace-only differences (``'100nF'`` vs ``'100NF'``) are equivalent for
+    all component types.  Non-numeric parts (ICs, connectors) and unparseable
+    exotic values fall back to case-insensitive string equality, preserving
+    raw-string strictness so genuinely different parts still flag.
+
+    Args:
+        sch_value: Schematic-side value string.
+        pcb_value: PCB-side value string.
+        reference: Reference designator, used to hint the component type
+            (e.g. ``C13`` -> capacitor) for the numeric parser.
+
+    Returns:
+        True when the two values are electrically equivalent.
+    """
+    s = (sch_value or "").strip()
+    p = (pcb_value or "").strip()
+    if s.casefold() == p.casefold():
+        return True
+    ps = parse_component_value(s, reference)
+    pp = parse_component_value(p, reference)
+    if (
+        ps.numeric_value is not None
+        and pp.numeric_value is not None
+        and ps.component_type is pp.component_type
+    ):
+        return math.isclose(ps.numeric_value, pp.numeric_value, rel_tol=_VALUE_REL_TOLERANCE)
+    return False  # non-numeric or unparseable -> keep raw-string strictness
+
 
 # Mechanical mounting holes (and similar fiducial/mechanical features) have no
 # schematic symbol by convention, so they always appear as PCB-only footprints.
@@ -139,6 +181,10 @@ class SyncAnalysis:
         schematic_orphans: References in schematic with no PCB match.
         pcb_orphans: References in PCB with no schematic match.
         value_mismatches: Components matched by reference but with different values.
+        value_suffix_notes: Components whose schematic/PCB values are electrically
+            equivalent but differ only by a trailing rating/tolerance suffix
+            (e.g. ``'100nF'`` vs ``'100nF 25V'``).  Informational only -- these
+            are NOT counted as mismatches and do NOT affect exit codes.
         footprint_mismatches: Components matched by reference but with different footprints.
         add_footprint_actions: Proposed add_footprint actions for schematic orphans
             that have a footprint assigned and could be placed on the PCB.
@@ -148,6 +194,7 @@ class SyncAnalysis:
     schematic_orphans: list[str] = field(default_factory=list)
     pcb_orphans: list[str] = field(default_factory=list)
     value_mismatches: list[dict[str, str]] = field(default_factory=list)
+    value_suffix_notes: list[dict[str, str]] = field(default_factory=list)
     footprint_mismatches: list[dict[str, str]] = field(default_factory=list)
     add_footprint_actions: list[dict[str, str]] = field(default_factory=list)
 
@@ -218,6 +265,7 @@ class SyncAnalysis:
             "schematic_orphans": self.schematic_orphans,
             "pcb_orphans": self.pcb_orphans,
             "value_mismatches": self.value_mismatches,
+            "value_suffix_notes": self.value_suffix_notes,
             "footprint_mismatches": self.footprint_mismatches,
             "add_footprint_actions": self.add_footprint_actions,
             "summary": {
@@ -340,25 +388,38 @@ class Reconciler:
             pcb = pcb_components[ref]
             actions = []
 
-            # Check value mismatch
+            # Check value mismatch.  A PCB value that merely appends a
+            # voltage/tolerance/rating suffix ('100nF' vs '100nF 25V') is NOT a
+            # mismatch -- compare parsed magnitude, not raw strings.  Such
+            # suffix-only differences are surfaced as informational notes so the
+            # rating signal is preserved without polluting value_mismatches.
             sch_value = sch.get("value", "")
             pcb_value = pcb.get("value", "")
             if sch_value and pcb_value and sch_value != pcb_value:
-                actions.append(
-                    {
-                        "type": "update_value",
-                        "reference": ref,
-                        "old_value": pcb_value,
-                        "new_value": sch_value,
-                    }
-                )
-                analysis.value_mismatches.append(
-                    {
-                        "reference": ref,
-                        "schematic_value": sch_value,
-                        "pcb_value": pcb_value,
-                    }
-                )
+                if _values_equivalent(sch_value, pcb_value, ref):
+                    analysis.value_suffix_notes.append(
+                        {
+                            "reference": ref,
+                            "schematic_value": sch_value,
+                            "pcb_value": pcb_value,
+                        }
+                    )
+                else:
+                    actions.append(
+                        {
+                            "type": "update_value",
+                            "reference": ref,
+                            "old_value": pcb_value,
+                            "new_value": sch_value,
+                        }
+                    )
+                    analysis.value_mismatches.append(
+                        {
+                            "reference": ref,
+                            "schematic_value": sch_value,
+                            "pcb_value": pcb_value,
+                        }
+                    )
 
             # Check footprint mismatch
             sch_fp = sch.get("footprint", "")
@@ -424,7 +485,7 @@ class Reconciler:
                 pcb_fp = pcb.get("footprint", "")
                 pcb_fp_name = pcb_fp.split(":")[-1] if ":" in pcb_fp else pcb_fp
 
-                if sch_value == pcb_value and sch_fp_name == pcb_fp_name:
+                if _values_equivalent(sch_value, pcb_value, sch_ref) and sch_fp_name == pcb_fp_name:
                     candidates.append(pcb_ref)
 
             if len(candidates) == 1:
@@ -481,11 +542,16 @@ class Reconciler:
                         "new_value": sch_ref,
                     },
                 ]
-                # Also update value if different
+                # Also update value if genuinely different (a suffix-only
+                # rating difference is not a value change worth rewriting).
                 pcb = pcb_components[pcb_ref]
                 sch_value = sch.get("value", "")
                 pcb_value = pcb.get("value", "")
-                if sch_value and pcb_value and sch_value != pcb_value:
+                if (
+                    sch_value
+                    and pcb_value
+                    and not _values_equivalent(sch_value, pcb_value, sch_ref)
+                ):
                     actions_list.append(
                         {
                             "type": "update_value",

--- a/tests/test_netlist_sync_gate.py
+++ b/tests/test_netlist_sync_gate.py
@@ -201,5 +201,61 @@ class TestAdvisoryBanner:
         assert "out of sync" not in capsys.readouterr().out.lower()
 
 
+# ---------------------------------------------------------------------------
+# Value suffix notes are informational, not drift (issue #4351)
+# ---------------------------------------------------------------------------
+
+
+class TestValueSuffixNotesRendering:
+    def _analysis_with_suffix_note(self):
+        from kicad_tools.sync.reconciler import SyncAnalysis
+
+        return SyncAnalysis(
+            value_suffix_notes=[
+                {"reference": "C13", "schematic_value": "100nF", "pcb_value": "100nF 25V"},
+            ]
+        )
+
+    def test_has_drift_excludes_suffix_notes(self):
+        from kicad_tools.sync.drift import has_drift
+
+        # A board whose only difference is a rating suffix is NOT out of sync.
+        assert has_drift(self._analysis_with_suffix_note()) is False
+
+    def test_render_shows_informational_section_when_in_sync(self, tmp_path):
+        from kicad_tools.sync.drift import render_drift_report
+
+        report = render_drift_report(
+            self._analysis_with_suffix_note(),
+            tmp_path / "board.kicad_pcb",
+            tmp_path / "board.kicad_sch",
+        )
+        # In sync (suffix note is not drift) but the note is still surfaced.
+        assert "IN SYNC" in report
+        assert "same value, PCB adds rating suffix" in report
+        assert "C13" in report
+        assert "100nF 25V" in report
+
+    def test_render_shows_informational_section_alongside_real_drift(self, tmp_path):
+        from kicad_tools.sync.drift import render_drift_report
+        from kicad_tools.sync.reconciler import SyncAnalysis
+
+        analysis = SyncAnalysis(
+            value_mismatches=[
+                {"reference": "C15", "schematic_value": "100nF", "pcb_value": "2.2nF 50V"},
+            ],
+            value_suffix_notes=[
+                {"reference": "C13", "schematic_value": "100nF", "pcb_value": "100nF 25V"},
+            ],
+        )
+        report = render_drift_report(
+            analysis, tmp_path / "board.kicad_pcb", tmp_path / "board.kicad_sch"
+        )
+        assert "OUT OF SYNC" in report
+        assert "1 value mismatch(es)" in report  # only the genuine one counts
+        assert "Value mismatches [1]" in report
+        assert "same value, PCB adds rating suffix" in report
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -15,7 +15,47 @@ from kicad_tools.sync.reconciler import (
     SyncChange,
     SyncMatch,
     _is_mounting_hole,
+    _values_equivalent,
 )
+
+
+class TestValuesEquivalent:
+    """Tests for the value-equivalence helper (issue #4351).
+
+    A PCB value that merely appends a voltage/tolerance/rating suffix must not
+    be reported as a value mismatch, while genuinely different values still are.
+    """
+
+    def test_suffix_only_capacitor_is_equivalent(self):
+        assert _values_equivalent("100nF", "100nF 25V", "C13")
+        assert _values_equivalent("10uF", "10uF 16V", "C14")
+
+    def test_tolerance_suffix_resistor_is_equivalent(self):
+        assert _values_equivalent("4.7k", "4.7k 1%", "R1")
+
+    def test_unit_normalized_capacitor_is_equivalent(self):
+        # 0.1uF == 100nF -> not a mismatch.
+        assert _values_equivalent("100nF", "0.1uF", "C1")
+
+    def test_genuinely_different_capacitor_is_mismatch(self):
+        assert not _values_equivalent("100nF", "2.2nF 50V", "C15")
+        assert not _values_equivalent("100nF", "10nF", "C36")
+        assert not _values_equivalent("10uF", "1uF 25V", "C39")
+
+    def test_non_numeric_ic_values_fall_back_to_string_strictness(self):
+        # Different part numbers must still flag.
+        assert not _values_equivalent("AP2112K-3.3", "XC6206-3.3V", "U1")
+        # Identical IC values are equivalent.
+        assert _values_equivalent("AP2112K-3.3", "AP2112K-3.3", "U2")
+
+    def test_whitespace_and_case_only_differences_are_equivalent(self):
+        assert _values_equivalent("100nF", "100NF", "C1")
+        assert _values_equivalent("  100nF ", "100nF", "C1")
+        assert _values_equivalent("LM358", "lm358", "U5")
+
+    def test_empty_value_is_not_equivalent_to_nonempty(self):
+        assert not _values_equivalent("", "100nF", "C1")
+        assert not _values_equivalent("100nF", "", "C1")
 
 
 class TestIsMountingHole:
@@ -414,6 +454,59 @@ class TestReconcilerAnalyze:
         assert len(analysis.value_mismatches) == 1
         assert analysis.value_mismatches[0]["schematic_value"] == "10k"
         assert analysis.value_mismatches[0]["pcb_value"] == "4.7k"
+
+        Path(sch_path).unlink()
+        Path(pcb_path).unlink()
+
+    def test_analyze_suffix_only_value_is_not_a_mismatch(self):
+        """Issue #4351: a PCB rating suffix is informational, not a mismatch."""
+        bom_items = [self._make_bom_item("C13", "100nF", "Capacitor_SMD:C_0402")]
+        footprints = [self._make_mock_footprint("C13", "100nF 25V", "Capacitor_SMD:C_0402")]
+
+        reconciler, mock_bom, mock_pcb, sch_path, pcb_path = self._make_reconciler_with_mocks(
+            bom_items, footprints
+        )
+
+        analysis = self._run_analyze(reconciler, mock_bom, mock_pcb)
+
+        # No genuine value mismatch, and no update_value action queued.
+        assert analysis.value_mismatches == []
+        assert not any(a["type"] == "update_value" for m in analysis.matches for a in m.actions)
+        # Surfaced as an informational suffix note instead.
+        assert len(analysis.value_suffix_notes) == 1
+        note = analysis.value_suffix_notes[0]
+        assert note["reference"] == "C13"
+        assert note["schematic_value"] == "100nF"
+        assert note["pcb_value"] == "100nF 25V"
+        # Suffix notes are informational -> board is still in sync.
+        assert analysis.is_in_sync
+
+        Path(sch_path).unlink()
+        Path(pcb_path).unlink()
+
+    def test_analyze_genuine_mismatch_still_flagged_amid_suffix_notes(self):
+        """Genuine value divergence remains visible while suffix-only rows do not."""
+        bom_items = [
+            self._make_bom_item("C13", "100nF", "Capacitor_SMD:C_0402"),  # suffix-only
+            self._make_bom_item("C15", "100nF", "Capacitor_SMD:C_0402"),  # genuine
+            self._make_bom_item("U1", "AP2112K-3.3", "Package_TO_SOT_SMD:SOT-23-5"),  # genuine
+        ]
+        footprints = [
+            self._make_mock_footprint("C13", "100nF 25V", "Capacitor_SMD:C_0402"),
+            self._make_mock_footprint("C15", "2.2nF 50V", "Capacitor_SMD:C_0402"),
+            self._make_mock_footprint("U1", "XC6206-3.3V", "Package_TO_SOT_SMD:SOT-23-5"),
+        ]
+
+        reconciler, mock_bom, mock_pcb, sch_path, pcb_path = self._make_reconciler_with_mocks(
+            bom_items, footprints
+        )
+
+        analysis = self._run_analyze(reconciler, mock_bom, mock_pcb)
+
+        mismatched_refs = {m["reference"] for m in analysis.value_mismatches}
+        assert mismatched_refs == {"C15", "U1"}
+        suffix_refs = {m["reference"] for m in analysis.value_suffix_notes}
+        assert suffix_refs == {"C13"}
 
         Path(sch_path).unlink()
         Path(pcb_path).unlink()


### PR DESCRIPTION
## Summary

`kct check --netlist-sync` compared schematic vs PCB component **value strings by naive equality**, so a PCB value that merely appends a voltage/tolerance/rating suffix (`100nF` vs `100nF 25V`) was reported as a value mismatch. On `chorus-test-revA_v24` this produced 26 reported mismatches, the majority suffix-only false positives that buried the ~4-6 genuinely wrong values. A netlist-sync report that cries wolf trains users to ignore it.

This routes the reconciler's value comparisons through a parsed-magnitude equivalence check so suffix-only differences are no longer mismatches, while genuinely different values (and different IC part numbers) still flag.

## Changes

- **`src/kicad_tools/sync/reconciler.py`**
  - Add `_values_equivalent(sch, pcb, ref)`: numeric passives (R/L/C) compare by parsed SI magnitude within `_VALUE_REL_TOLERANCE = 0.05` (mirrors `export/lcsc_value_check.VALUE_REL_TOLERANCE`); case/whitespace-only differences are equivalent for all types; non-numeric or unparseable values fall back to case-insensitive string equality (raw-string strictness preserved).
  - Route all three comparison sites through it: the exact-ref value check (populates `value_mismatches`), the value+footprint candidate match, and the footprint-only rename pass.
  - Add informational `value_suffix_notes` list (+ `to_dict`): suffix-only equivalences are surfaced, not dropped. No `update_value` action is queued for them (sync won't strip the PCB's rating).
- **`src/kicad_tools/sync/drift.py`**
  - Render a new "Informational: same value, PCB adds rating suffix [N]" section in `render_drift_report` (both in-sync and out-of-sync paths).
  - `has_drift()` explicitly excludes `value_suffix_notes` so they never affect the `--netlist-sync` exit code (keeps #4352's future gate honest).
- **Tests**: `tests/test_sync.py` (helper unit cases + analyze-level suffix/genuine behavior), `tests/test_netlist_sync_gate.py` (`has_drift` exclusion + render output).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `100nF`/`100nF 25V`, `10uF`/`10uF 16V`, `4.7k`/`4.7k 1%` NOT mismatches | ✅ | `TestValuesEquivalent`, `test_analyze_suffix_only_value_is_not_a_mismatch` |
| `100nF`/`2.2nF 50V`, `100nF`/`10nF`, `10uF`/`1uF 25V` ARE mismatches | ✅ | `test_genuinely_different_capacitor_is_mismatch`, `test_analyze_genuine_mismatch_still_flagged_amid_suffix_notes` |
| `AP2112K-3.3`/`XC6206-3.3V` (non-numeric ICs) ARE mismatches | ✅ | `test_non_numeric_ic_values_fall_back_to_string_strictness` |
| Whitespace/case-only differences treated as equivalent | ✅ | `test_whitespace_and_case_only_differences_are_equivalent` |
| Value+footprint candidate match (line ~427) uses same equivalence | ✅ | Site routed through `_values_equivalent` |
| Real mismatches remain visible; suffix rows excluded | ✅ | `test_analyze_genuine_mismatch_still_flagged_amid_suffix_notes` |
| No change to orphan/footprint-mismatch behavior | ✅ | Existing `test_sync` / `test_netlist_sync_gate` suites green |
| Suffix-only equivalences appear as info note, excluded from `has_drift()` | ✅ | `TestValueSuffixNotesRendering` |

## Test Plan

- `uv run pytest tests/test_sync.py tests/test_netlist_sync.py tests/test_netlist_sync_gate.py tests/test_board_05_drift_regression.py tests/test_pcb_sync_netlist.py` — 297 passed.
- `uv run ruff check` + `uv run ruff format --check` — clean on changed files.
- `uv run python scripts/ci/check_mypy_baseline.py` — exit 0, no new type errors within baseline.

## Related

- #4352 (netlist-sync exit-code gate) depends on this suffix-normalization and is intentionally left to a separate PR; `value_suffix_notes` is excluded from `has_drift()` so that gate never trips on informational notes.

Closes #4351