### PR TITLE
fix: rename drill-clearance rule_id to hole_to_hole_clearance

### DIFF
--- a/.github/routed-drc-tolerance.yml
+++ b/.github/routed-drc-tolerance.yml
@@ -74,7 +74,7 @@ tolerances:
   # are the dominant failure mode tracked in #2756).  Per-rule
   # (post-fix): 38 clearance_pad_segment, 9 clearance_segment_segment,
   # 4 clearance_segment_via, 1 diffpair_clearance_intra,
-  # 1 dimension_drill_clearance.  Tracked in #2756 for re-routing,
+  # 1 hole_to_hole_clearance.  Tracked in #2756 for re-routing,
   # #2542 for full clean state.
   #
   # Tightened 53 -> 9 by Issue #3127 (M-E Round 3).  PR enlarges
@@ -1042,7 +1042,7 @@ tolerances:
   # ``min_hole_to_hole_mm`` spec (canonical 0.5 mm fab default; the old
   # code keyed off ``min_clearance_mm`` and never fired below 0.5 mm).  The
   # corrected rule surfaces 6 genuine pre-existing sub-0.5 mm
-  # ``dimension_drill_clearance`` drill pairs that were ALWAYS present on
+  # ``hole_to_hole_clearance`` drill pairs that were ALWAYS present on
   # board 06 but invisible to the broken check.  They are TRUE POSITIVES,
   # NOT new regressions from this PR; the board-layout fix (re-spacing the
   # drills to >= 0.5 mm) is tracked in **#3847**, rule change refs
@@ -1053,7 +1053,7 @@ tolerances:
   #       9 diffpair_routing_continuity -- unchanged)
   #     + 5 non-diff-pair clearance near-misses from the imperfect coupled
   #       re-route fan-out + pour-repair vias (unchanged, #3829)
-  #     + 6 dimension_drill_clearance sub-0.5 mm true-positives (NEW to the
+  #     + 6 hole_to_hole_clearance sub-0.5 mm true-positives (NEW to the
   #       count only because the gate was broken; #3842 surfaces them).
   #   * COMMITTED strict gate (``Routed PCB DRC Check``, advisory filtered):
   #     18 -> 24 (= 18 diff-pair + 6 drill).  Pinned by
@@ -1062,7 +1062,7 @@ tolerances:
   #     admits the committed artifact and the strict gate emits its
   #     by-design tightening ::warning:: (9 slack).
   # The diff-pair-ONLY slice is STILL exactly 18 -- the 6 drill errors are
-  # ``dimension_drill_clearance`` (a DISTINCT family), so
+  # ``hole_to_hole_clearance`` (a DISTINCT family), so
   # DIFFPAIR_VIOLATION_BASELINE (18) in check_diffpair_coverage.py is
   # UNCHANGED and a 19th diff-pair violation still fails the gate.  This
   # floor (33) governs only the TOTAL error count; it does NOT loosen the
@@ -1820,7 +1820,7 @@ tolerances:
   #
   # !!! RE-BASELINE CLOSED: 2 -> strict-0 (Issue #4017, July 09 2026) !!!
   # ----------------------------------------------------------------------
-  # The 2 ``dimension_drill_clearance`` violations grandfathered at 2 by
+  # The 2 ``hole_to_hole_clearance`` violations grandfathered at 2 by
   # #3842 (a 0.350 mm hole-to-hole micro-via pair on the LQFP-48 west
   # escape: GND/NRST and OSC_OUT/NRST, both in-pad ``(via micro ...)``
   # structures at 0.5 mm pin pitch) have been re-spaced.  The middle NRST

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1744,7 +1744,7 @@ jobs:
     #
     # Board 04 has a committed output/lvs.json (clean: true), so this reuses
     # the board-03 --lvs-only asserter pattern (NOT the full asserter: board 04
-    # carries 2 grandfathered dimension_drill_clearance drills + 1 advisory
+    # carries 2 grandfathered hole_to_hole_clearance drills + 1 advisory
     # connectivity finding, so board-metrics classifies it status:partial /
     # drc_violations:2, which the full status:ok / drc_violations:0 assertion
     # would FAIL).
@@ -1844,7 +1844,7 @@ jobs:
         #     .github/routed-drc-tolerance.yml, so the committed-artifact
         #     "Routed PCB DRC Check" job ratchets it at strict-0.
         #   * The FRESH regen still routes the LEGACY 0.350mm pair (2
-        #     dimension_drill_clearance errors), because the recipe geometry
+        #     hole_to_hole_clearance errors), because the recipe geometry
         #     was intentionally untouched (curation constraint).
         #
         # A single YAML value can't satisfy both (both resolve to the same

--- a/boards/04-stm32-devboard/generate_design.py
+++ b/boards/04-stm32-devboard/generate_design.py
@@ -1785,16 +1785,20 @@ def generate_manufacturing(routed_path: Path, output_dir: Path) -> bool:
 #   * advisory ``connectivity`` (1 stranded GND-stitch pad; in
 #     ``DRCChecker.ADVISORY_RULE_IDS``, filtered from every CI gate).
 #
-# The 2 ``dimension_drill_clearance`` errors that #3842 grandfathered at 2
+# The 2 ``hole_to_hole_clearance`` errors that #3842 grandfathered at 2
 # (a 0.350mm hole-to-hole micro-via pair on the LQFP-48 west escape) were
 # re-spaced to >= 0.500mm edge-to-edge by Issue #4017 (artifact-only nudge:
 # the NRST in-pad via relocated 0.5mm east onto its B.Cu escape node and
 # bonded back to pad U2.7 with a short F.Cu stub).  With that fix the
 # drill-clearance allowance is now strict-0 and the CI tolerance entry is
-# removed -- ANY ``dimension_drill_clearance`` error, or any other blocking
+# removed -- ANY ``hole_to_hole_clearance`` error, or any other blocking
 # rule, fails the gate so a real DRC regression cannot ship 0.
 _ADVISORY_DRC_RULE_IDS: frozenset[str] = frozenset({"connectivity"})
-_DRILL_CLEARANCE_RULE_ID = "dimension_drill_clearance"
+# Issue #4353: the emitted rule_id was renamed from
+# ``hole_to_hole_clearance`` to ``hole_to_hole_clearance`` so the report
+# label matches the "Hole-to-hole clearance ..." message text.  This gate
+# parses the raw JSON ``rule_id`` string, so it must track the new value.
+_DRILL_CLEARANCE_RULE_ID = "hole_to_hole_clearance"
 _DRILL_CLEARANCE_ALLOWANCE = 0  # strict-0 since #4017 re-spaced the drill pair
 
 
@@ -1824,7 +1828,7 @@ def run_drc(pcb_path: Path) -> bool:
     Issue #3839: the return value now gates ``main()``'s exit code, so it
     is **allowlist-aware** rather than a raw ``returncode == 0`` check.
     ``kct check --drc-only`` exits 2 on the 2 grandfathered
-    ``dimension_drill_clearance`` drills (#3842/#3847) and on the advisory
+    ``hole_to_hole_clearance`` drills (#3842/#3847) and on the advisory
     ``connectivity`` finding, neither of which should fail the recipe.
     Instead of trusting the exit code we parse the emitted JSON and count
     *blocking* violations the same way the CI gate
@@ -2174,7 +2178,7 @@ def main() -> int:
         # the ``write_lvs_report`` return -- so a board with a NEW blocking DRC
         # error or a copper-LVS short could print SUCCESS and exit 0.  The gate
         # now ANDs ``drc_success`` (allowlist-aware per ``run_drc``: tolerates
-        # the 2 grandfathered ``dimension_drill_clearance`` drills (#3847) +
+        # the 2 grandfathered ``hole_to_hole_clearance`` drills (#3847) +
         # advisory ``connectivity`` but fails on a 3rd drill or any new rule)
         # and ``copper_clean`` (the copper-LVS verdict) so a real DRC/LVS
         # regression exits non-zero.  The current committed board -- 2

--- a/boards/06-diffpair-test/generate_design.py
+++ b/boards/06-diffpair-test/generate_design.py
@@ -668,7 +668,7 @@ def _repair_pour_connectivity(pcb_path: Path, net_names: list[str]) -> tuple[int
     # hardcoded center-to-center constant -- the same defect class #3851
     # fixed in ``generate_pcb._via_ok``.  The old ``DRILL_CC = 0.45`` (c-c)
     # let two 0.25 mm-drill vias sit 0.20 mm edge-to-edge (a
-    # ``dimension_drill_clearance`` true positive); 0.5 mm edge-to-edge is
+    # ``hole_to_hole_clearance`` true positive); 0.5 mm edge-to-edge is
     # the manufacturable floor checked by the DRC rule (#3842).
     REPAIR_VIA_DRILL = 0.25  # matches the "(drill 0.25)" emitted below
     MIN_HOLE_TO_HOLE = 0.5  # fab drill-to-drill edge-to-edge floor
@@ -1068,7 +1068,7 @@ def _repair_pour_connectivity(pcb_path: Path, net_names: list[str]) -> tuple[int
 # pipeline on this board.  Both are SAME-NET via-placement artifacts (no
 # short risk), and both block the manufacturing bundle's "Errors = 0" gate:
 #
-#   1. ``dimension_drill_clearance`` -- the A* leaves a two-via "staple"
+#   1. ``hole_to_hole_clearance`` -- the A* leaves a two-via "staple"
 #      (via -> short inter-via chain on one layer -> via) whose drills sit
 #      closer than the 0.5 mm fab hole-to-hole floor.  This is the #3855
 #      holdout (the guard covers the via PLACERS, not the A* path builder).
@@ -1205,7 +1205,7 @@ def _legalize_signal_vias(pcb_path: Path) -> int:
     Strategy per defect class (both validated with shapely against ALL
     copper; every new segment is axis/45-aligned by construction):
 
-    * **Staple collapse** (``dimension_drill_clearance``, same-net pair):
+    * **Staple collapse** (``hole_to_hole_clearance``, same-net pair):
       find the single-layer chain of same-net segments joining the two
       vias.  Delete one via (the "victim") plus the chain, and re-draw
       the link on the victim's OTHER attached layer as a 1-2 leg

--- a/boards/07-matchgroup-test/generate_design.py
+++ b/boards/07-matchgroup-test/generate_design.py
@@ -685,7 +685,7 @@ def _repair_pour_connectivity(pcb_path: Path, net_names: list[str]) -> tuple[int
     BRIDGE_W = 0.2
     # Fab hole-to-hole floor, EDGE-to-edge (mirrors the jlcpcb
     # ``min_hole_to_hole_mm`` = 0.5 that ``kct check`` enforces as
-    # ``dimension_drill_clearance``).  The old constant here was a bare
+    # ``hole_to_hole_clearance``).  The old constant here was a bare
     # 0.45 mm CENTER-to-center -- for a 0.25 mm repair drill next to a
     # 0.20 mm stitch drill that allowed an edge gap of just 0.225 mm and
     # shipped two ~0.39 mm violations on the re-routed artifact.

--- a/docs/install-pilot-chorus.md
+++ b/docs/install-pilot-chorus.md
@@ -159,7 +159,7 @@ Followed the vendored `/kct:manufacturing-readiness` playbook.
 |------:|---------|
 | 692 | `clearance_segment_zone` |
 | 385 | `clearance_via_zone` |
-| 49 | `dimension_drill_clearance` |
+| 49 | `hole_to_hole_clearance` |
 | 21 | `clearance_pad_zone` |
 | 19 | `clearance_pad_segment` |
 | 1 | `edge_clearance_pad_hole` |
@@ -219,7 +219,7 @@ artifact-first).
 |-------|----------------|-----|
 | 1117 `clearance_*_zone` (kct) / 507 `clearance` + zone shorts (kicad-cli) | **Board-file provenance**, not a defect | Stale pours + generic embedded rules; the board is a routed static artifact whose `(setup)` never carried tier1 rules. 2026-07-04 checked with a refilled tier1 capability project. |
 | 199 `track_width` / 199 `drill_out_of_range` / 199 `via_diameter` / 5 `copper_edge_clearance` | **Tier-config mismatch** | KiCad's generic defaults (0.2/0.3/0.5) are stricter than tier1's real floors (0.13/0.2/0.45). These are legal tier1 geometry flagged only because the board embeds no tier1 rules. |
-| 49 `dimension_drill_clearance` (kct) / 27 `hole_clearance` (kicad-cli) | **Board-file provenance / known referee items** | Hole-to-hole spacing; LAYOUT_NOTES carried `hole 1` as an accepted NT3 net-tie artifact at sign-off. Bare-default checking amplifies these. |
+| 49 `hole_to_hole_clearance` (kct) / 27 `hole_clearance` (kicad-cli) | **Board-file provenance / known referee items** | Hole-to-hole spacing; LAYOUT_NOTES carried `hole 1` as an accepted NT3 net-tie artifact at sign-off. Bare-default checking amplifies these. |
 | 11 `courtyards_overlap`, 95 unconnected (referee) | **Advisory / known-accepted** | Present and accepted at 2026-07-04 sign-off per LAYOUT_NOTES. |
 | kct-vs-kicad count difference (1167 vs 1147) | **kct drift (benign)** | Two independent DRC engines with different rule taxonomies and sliver/zone accounting; both agree on the *root cause* (rules + stale fills), not on exact counts. |
 

--- a/scripts/ci/check_diffpair_coverage.py
+++ b/scripts/ci/check_diffpair_coverage.py
@@ -131,7 +131,7 @@ DIFFPAIR_RULE_IDS: tuple[str, ...] = (
 # reproducibility gap tracked in #3829): the re-route's TOTAL error count is
 # 33 (= these 18 diff-pair errors + 5 extra non-diff-pair ``clearance_*``
 # errors from the imperfect coupled fan-out + pour-repair vias + 6
-# pre-existing sub-0.5 mm ``dimension_drill_clearance`` true-positives newly
+# pre-existing sub-0.5 mm ``hole_to_hole_clearance`` true-positives newly
 # surfaced by Issue #3842's corrected ``min_hole_to_hole_mm`` gate -- board
 # layout fix tracked in #3847), whereas the committed artifact totals 24.
 # The total-count floor was re-baselined to the re-route's 33 in
@@ -140,7 +140,7 @@ DIFFPAIR_RULE_IDS: tuple[str, ...] = (
 # (18 = 9 length_skew + 9 routing_continuity), which is IDENTICAL on the
 # committed artifact and the re-route.  ``check_zero_violations`` sums only
 # the DIFFPAIR_RULE_IDS slice, so neither the 5 extra ``clearance_*`` errors
-# NOR the 6 ``dimension_drill_clearance`` drills leak into this assertion --
+# NOR the 6 ``hole_to_hole_clearance`` drills leak into this assertion --
 # a 19th diff-pair violation still fails the gate even though the total floor
 # has 0 headroom over the re-route's 33.
 #
@@ -149,7 +149,7 @@ DIFFPAIR_VIOLATION_BASELINE: dict[str, int] = {
     # Coupled diff-pair convergence is 0/9 on BOTH the committed artifact and
     # the deterministic seed-42 re-route; 9 diffpair_length_skew +
     # 9 diffpair_routing_continuity = 18.  The re-route's extra errors are
-    # ``clearance_*`` (5) and ``dimension_drill_clearance`` (6, the sub-0.5mm
+    # ``clearance_*`` (5) and ``hole_to_hole_clearance`` (6, the sub-0.5mm
     # drill true-positives surfaced by Issue #3842's min_hole_to_hole gate;
     # board-layout fix tracked in #3847) -- NONE are diffpair_*, so they are
     # all excluded from this slice and the baseline stays 18.

--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -52,7 +52,8 @@ _MEASUREMENT_RULE_IDS: frozenset[str] = frozenset(
     }
 )
 
-# Issue #4102: ``dimension_drill_clearance`` hole-to-hole findings carry both
+# Issue #4102: ``hole_to_hole_clearance`` (formerly ``dimension_drill_clearance``,
+# renamed in #4353) hole-to-hole findings carry both
 # endpoints' resolved net names in ``nets=(net1, net2)``.  A user reading the
 # report needs to separate the fab's real concern (different-net pairs, where a
 # drill-wall break creates a short) from same-net pairs.  The data is
@@ -71,7 +72,7 @@ _MEASUREMENT_RULE_IDS: frozenset[str] = frozenset(
 # Issue #4318: the copper-copper clearance rules carry the same
 # ``nets=(net_a, net_b)`` pair (set in ``_create_violation``,
 # ``validate/rules/clearance.py``), so an agent reading a ``clearance_segment_via``
-# report needs the same same-net / different-net split ``dimension_drill_clearance``
+# report needs the same same-net / different-net split ``hole_to_hole_clearance``
 # already gets -- a different-net 0.000mm coincidence is a genuine short to
 # prioritize, while a same-net coincidence is a lower-risk (still-defective)
 # malformed-copper artifact.  The classifier (``_net_relationship`` /
@@ -79,7 +80,7 @@ _MEASUREMENT_RULE_IDS: frozenset[str] = frozenset(
 # segment-via pair classifies as ``different-net`` (#4127) with no extra work.
 _NET_RELATIONSHIP_RULE_IDS: frozenset[str] = frozenset(
     {
-        "dimension_drill_clearance",
+        "hole_to_hole_clearance",
         "clearance_segment_via",
         "clearance_segment_segment",
         "clearance_via_via",
@@ -1740,7 +1741,7 @@ def output_table(
         else [v for v in violations if not (v.is_info and v.rule_id in _MEASUREMENT_RULE_IDS)]
     )
     by_rule: dict[str, dict[str, int]] = {}
-    # Issue #4102: for net-relationship rules (dimension_drill_clearance),
+    # Issue #4102: for net-relationship rules (hole_to_hole_clearance),
     # additionally tally a same-net / different-net breakdown so the BY RULE
     # summary line is immediately actionable -- directly answering the
     # "49-finding wall" complaint without scrolling the detail list.
@@ -1787,7 +1788,7 @@ def output_table(
         line = f"  {rule_id}: {', '.join(parts)}"
         # Issue #4102: append the same-net / different-net breakdown for
         # net-relationship rules, e.g.
-        #   dimension_drill_clearance: 49 errors (32 different-net, 17 same-net)
+        #   hole_to_hole_clearance: 49 errors (32 different-net, 17 same-net)
         rel = by_rule_relationship.get(rule_id)
         if rel:
             diff_n = rel["different-net"]

--- a/src/kicad_tools/cli/fix_drc_cmd.py
+++ b/src/kicad_tools/cli/fix_drc_cmd.py
@@ -4,7 +4,8 @@
 This command repairs multiple types of DRC violations:
 - clearance_segment_segment: nudge traces via ClearanceRepairer
 - clearance_segment_via: nudge traces away from enlarged vias via ClearanceRepairer
-- dimension_drill_clearance: de-duplicate or slide vias via DrillClearanceRepairer
+- hole_to_hole_clearance (formerly dimension_drill_clearance, #4353): de-duplicate
+  or slide vias via DrillClearanceRepairer
 
 Usage:
     kct fix-drc board.kicad_pcb --drc-report board-drc.rpt

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -627,7 +627,7 @@ def _strip_route_blocks(pcb_content: str) -> tuple[str, int, int]:
     current route s-expression on top of stale segments/vias from the prior
     write, doubling (or worse) the via population in the output file.
 
-    The duplicated vias trigger ``dimension_drill_clearance`` errors --
+    The duplicated vias trigger ``hole_to_hole_clearance`` errors --
     -0.300mm clearance == two coincident drills on the same net -- because
     they are literally the same physical via emitted twice with different
     UUIDs.

--- a/src/kicad_tools/cli/stitch_cmd.py
+++ b/src/kicad_tools/cli/stitch_cmd.py
@@ -45,7 +45,7 @@ from kicad_tools.sexp.builders import segment_node, via_node
 KICAD_HOLE_TO_COPPER_CLEARANCE = 0.25
 
 #: Default minimum drill edge-to-edge spacing, in mm, for the hole-to-hole
-#: guard (``dimension_drill_clearance`` fab floor, Issue #3855).  Matches the
+#: guard (``hole_to_hole_clearance`` fab floor, Issue #3855).  Matches the
 #: ``calculate_via_position`` default and the local checks in
 #: ``run_stitch``'s connectivity fallback.  Used by the thermal/blanket
 #: stitch paths (Issue #4010) so a stitch via never lands within this floor
@@ -1235,7 +1235,7 @@ def find_all_drills(
     :func:`find_all_board_vias` (which reports pad SIZE).  A stitch via
     dropped within ``min_hole_to_hole`` (drill edge-to-edge) of a
     through-hole pad drill (the J1-S2 case -- the GND stitch via vs the GND
-    connector pad's plated hole) trips a ``dimension_drill_clearance`` DRC
+    connector pad's plated hole) trips a ``hole_to_hole_clearance`` DRC
     error even when copper clears, so the placement loop must reject it.
 
     Only plated drilled holes are included: ``thru_hole`` pads with a
@@ -1804,7 +1804,7 @@ def calculate_via_position(
             # COPPER geometry; they do not enforce the fab's drill-to-drill
             # minimum.  A stitch via dropped within ``min_hole_to_hole``
             # (drill edge-to-edge) of an other-net through-hole pad / via
-            # drill (the J1-S2 case) trips ``dimension_drill_clearance``
+            # drill (the J1-S2 case) trips ``hole_to_hole_clearance``
             # even when copper clears -- reject and try the next offset.
             if other_net_drills and via_drill > 0:
                 cand_drill_radius = via_drill / 2
@@ -2237,7 +2237,7 @@ def calculate_dogleg_via_position(
                     # fab's drill-to-drill minimum.  A dog-leg stitch via
                     # dropped within ``min_hole_to_hole`` (drill edge-to-
                     # edge) of an other-net through-hole pad / via drill
-                    # trips ``dimension_drill_clearance`` even when copper
+                    # trips ``hole_to_hole_clearance`` even when copper
                     # clears -- exactly the coincident-hole short reported
                     # in the congested regions where dog-leg placement is
                     # used.  Reject and try the next candidate.
@@ -2486,7 +2486,7 @@ def calculate_extended_escape_position(
         # Issue #4177: drill hole-to-hole guard.  The checks above use
         # COPPER geometry; a via dropped within ``min_hole_to_hole`` (drill
         # edge-to-edge) of an other-net through-hole pad / via drill trips
-        # ``dimension_drill_clearance`` even when copper clears.  Extended-
+        # ``hole_to_hole_clearance`` even when copper clears.  Extended-
         # escape is the deepest congestion fallback -- the exact path where
         # coincident-hole collisions were slipping through unchecked.
         if other_net_drills and via_drill > 0:

--- a/src/kicad_tools/drc/violation.py
+++ b/src/kicad_tools/drc/violation.py
@@ -69,7 +69,7 @@ def _init_type_category_map() -> None:
             ViolationType.TRACK_WIDTH: ViolationCategory.ROUTING,
             ViolationType.TRACK_ANGLE: ViolationCategory.ROUTING,
             ViolationType.DIMENSION_TRACE_WIDTH: ViolationCategory.ROUTING,
-            ViolationType.DIMENSION_DRILL_CLEARANCE: ViolationCategory.ROUTING,
+            ViolationType.HOLE_TO_HOLE_CLEARANCE: ViolationCategory.ROUTING,
             # Placement: inherent to component placement
             ViolationType.CLEARANCE_PAD_PAD: ViolationCategory.PLACEMENT,
             ViolationType.COURTYARD_OVERLAP: ViolationCategory.PLACEMENT,
@@ -217,7 +217,14 @@ class ViolationType(Enum):
     DIMENSION_VIA_DRILL = "dimension_via_drill"
     DIMENSION_VIA_DIAMETER = "dimension_via_diameter"
     DIMENSION_ANNULAR_RING = "dimension_annular_ring"
-    DIMENSION_DRILL_CLEARANCE = "dimension_drill_clearance"
+    # Hole-to-hole (drill center-to-center minus both radii) clearance from the
+    # dimensions checker (``validate/rules/dimensions.py``).  Issue #4353: the
+    # emitted ``rule_id`` was renamed from ``dimension_drill_clearance`` to
+    # ``hole_to_hole_clearance`` so the report label matches the physically
+    # accurate "Hole-to-hole clearance ..." message text.  The old string is
+    # retained as a backwards-compat alias in ``from_string`` below so saved
+    # JSON reports and ``kct fix-drc dimension_drill_clearance`` keep working.
+    HOLE_TO_HOLE_CLEARANCE = "hole_to_hole_clearance"
 
     # Hole issues
     DRILL_HOLE_TOO_SMALL = "drill_hole_too_small"
@@ -357,7 +364,17 @@ class ViolationType(Enum):
             "dimension_via_drill": cls.DIMENSION_VIA_DRILL,
             "dimension_via_diameter": cls.DIMENSION_VIA_DIAMETER,
             "dimension_annular_ring": cls.DIMENSION_ANNULAR_RING,
-            "dimension_drill_clearance": cls.DIMENSION_DRILL_CLEARANCE,
+            # Hole-to-hole clearance (Issue #4353).  The new canonical id
+            # ``hole_to_hole_clearance`` matches the enum value directly, but
+            # is aliased here explicitly (mirroring the other dimension rules)
+            # so the fuzzy ``"clearance"`` fallback at the bottom of
+            # from_string() can never mis-route it to the generic CLEARANCE
+            # type.  The old ``dimension_drill_clearance`` string is retained
+            # below it as a backwards-compat alias so previously-saved JSON
+            # reports and ``kct fix-drc dimension_drill_clearance`` still
+            # parse.  Do NOT delete either entry as "redundant".
+            "hole_to_hole_clearance": cls.HOLE_TO_HOLE_CLEARANCE,
+            "dimension_drill_clearance": cls.HOLE_TO_HOLE_CLEARANCE,
             # silkscreen rules from validate silkscreen checker
             "silkscreen_line_width": cls.SILKSCREEN_LINE_WIDTH,
             "silkscreen_text_height": cls.SILKSCREEN_TEXT_HEIGHT,

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -690,7 +690,7 @@ class _TraceResolverTransaction:
         # Build the board-wide existing-drill registry once (foreign-net PTH
         # pad drills + all pre-existing / other newly-committed via drills) so a
         # via the main router just placed cannot sit within ``min_hole_to_hole``
-        # of another drill and later trip a ``dimension_drill_clearance`` DRC.
+        # of another drill and later trip a ``hole_to_hole_clearance`` DRC.
         min_h2h = float(getattr(self._router.rules, "min_hole_to_hole", 0.5))
 
         # Validate against the CURRENT grid state (post-rip, post-
@@ -735,7 +735,7 @@ class _TraceResolverTransaction:
         main A* router.  Compares the candidate via drill against every
         foreign-net through-hole pad drill and every other via drill (existing
         + committed) using the canonical edge-to-edge predicate shared with the
-        DRC ``dimension_drill_clearance`` rule and the escape router
+        DRC ``hole_to_hole_clearance`` rule and the escape router
         (:func:`kicad_tools.router.via_clearance.drill_hole_to_hole_clear`).
 
         Same-drill self-comparison (the via against itself) is excluded by an

--- a/src/kicad_tools/router/escape.py
+++ b/src/kicad_tools/router/escape.py
@@ -6886,7 +6886,7 @@ class EscapeRouter:
         # above operates on PAD diameters; it does not enforce the fab's
         # drill-to-drill (hole-to-hole) minimum, so an escape via could land
         # within ``min_hole_to_hole`` of a through-hole pad / existing via
-        # drill and trip a ``dimension_drill_clearance`` DRC error.  Reject
+        # drill and trip a ``hole_to_hole_clearance`` DRC error.  Reject
         # such candidates (callers treat ``False`` as "try the next site").
         if existing_drills:
             from .via_clearance import drill_hole_to_hole_clear

--- a/src/kicad_tools/router/mfr_limits.py
+++ b/src/kicad_tools/router/mfr_limits.py
@@ -40,7 +40,7 @@ class MfrLimits:
             fan-out, escape, stitching) to reject candidates that would
             emit a sub-fab-minimum drill pair, matching the validate-side
             ``DesignRules.min_hole_to_hole_mm`` (#3846) and the DRC
-            ``dimension_drill_clearance`` rule (#3842).
+            ``hole_to_hole_clearance`` rule (#3842).
         via_in_pad_supported: Whether the manufacturer supports via-in-pad
             (vias drilled directly inside SMD pads, requiring filled and
             plated-over via processing).  Default ``False`` (conservative).

--- a/src/kicad_tools/router/rules.py
+++ b/src/kicad_tools/router/rules.py
@@ -78,7 +78,7 @@ class DesignRules:
     # candidate via whose drill would sit within ``min_hole_to_hole`` edge-to-edge
     # of any existing drill (via OR through-hole pad, ANY net).  Mirrors the
     # validate-side ``manufacturers.base.DesignRules.min_hole_to_hole_mm`` (#3846)
-    # and the DRC ``dimension_drill_clearance`` rule (#3842) so the router
+    # and the DRC ``hole_to_hole_clearance`` rule (#3842) so the router
     # pre-check and the DRC post-check agree.  Defaults to 0.5 so behavior is
     # correct even when no manufacturer profile is threaded in.
     min_hole_to_hole: float = 0.5  # mm

--- a/src/kicad_tools/router/via_clearance.py
+++ b/src/kicad_tools/router/via_clearance.py
@@ -78,7 +78,7 @@ class FilledPolygonLike(Protocol):
 
 #: Default manufacturer hole-to-hole (drill-to-drill) minimum, in mm.  Mirrors
 #: ``manufacturers.base.DesignRules.min_hole_to_hole_mm`` and the canonical fab
-#: floor used by the DRC ``dimension_drill_clearance`` rule.
+#: floor used by the DRC ``hole_to_hole_clearance`` rule.
 DEFAULT_MIN_HOLE_TO_HOLE = 0.5
 
 #: Numerical tolerance for the hole-to-hole comparison, mirroring
@@ -98,7 +98,7 @@ def drill_hole_to_hole_clear(
     existing drill by at least ``min_hole_to_hole`` edge-to-edge.
 
     This mirrors the canonical edge-to-edge formula used by the DRC
-    ``dimension_drill_clearance`` rule
+    ``hole_to_hole_clearance`` rule
     (:meth:`validate.rules.dimensions.DimensionRules._check_drill_clearance`)
     so a candidate via the router accepts here will not trip a hole-to-hole
     DRC error later::
@@ -306,7 +306,7 @@ def point_clear_of_copper(
             When supplied with ``via_drill > 0`` and
             ``min_hole_to_hole > 0``, the candidate drill must clear
             every foreign drill edge-to-edge by ``min_hole_to_hole``
-            (fab ``dimension_drill_clearance`` floor, Issue #3855).
+            (fab ``hole_to_hole_clearance`` floor, Issue #3855).
         hole_to_copper_clearance: KiCad ``hole_clearance`` band in mm
             (typically :data:`kicad_tools.cli.stitch_cmd.KICAD_HOLE_TO_COPPER_CLEARANCE`).
             Only consulted when ``via_drill > 0``.
@@ -391,7 +391,7 @@ def point_clear_of_copper(
     # Drill hole-to-hole guard (Issue #3855): the copper checks above do
     # not enforce the fab's drill-to-drill minimum.  A via dropped within
     # ``min_hole_to_hole`` (drill edge-to-edge) of a foreign through-hole
-    # pad / via drill trips ``dimension_drill_clearance`` even when copper
+    # pad / via drill trips ``hole_to_hole_clearance`` even when copper
     # clears.  Reuses the canonical edge-to-edge predicate.
     if via_drill > 0 and min_hole_to_hole > 0 and other_net_drills:
         if not drill_hole_to_hole_clear(

--- a/src/kicad_tools/validate/rules/dimensions.py
+++ b/src/kicad_tools/validate/rules/dimensions.py
@@ -270,7 +270,14 @@ class DimensionRules(DRCRule):
 
                     results.add(
                         DRCViolation(
-                            rule_id="dimension_drill_clearance",
+                            # Issue #4353: the emitted rule_id is
+                            # ``hole_to_hole_clearance`` (was
+                            # ``dimension_drill_clearance``) so the report
+                            # label matches the "Hole-to-hole clearance ..."
+                            # message text below.  The old id still parses via
+                            # the backwards-compat alias in
+                            # ``ViolationType.from_string``.
+                            rule_id="hole_to_hole_clearance",
                             severity=severity,
                             message=(
                                 f"{message_prefix}Hole-to-hole clearance "

--- a/tests/router/test_strip_route_blocks.py
+++ b/tests/router/test_strip_route_blocks.py
@@ -4,7 +4,7 @@ Background
 ----------
 
 Running ``kct route`` on board 05 with the proven 2-layer recipe produced
-14 ``dimension_drill_clearance`` errors reading "-0.300mm < minimum
+14 ``hole_to_hole_clearance`` errors reading "-0.300mm < minimum
 0.127mm" between two vias on the **same** logical net (e.g. HALL_A vs
 HALL_A).  Negative clearance == two same-net drills literally on top of
 each other -- a manufacturing fault that breaks the drill file.
@@ -17,7 +17,7 @@ route s-expression is *appended* on top of stale segments and vias from
 the prior write.  Two checkpoint writes + one final write yields three
 copies of every via in the output PCB.  The duplicates carry distinct
 UUIDs but identical (net, x, y, drill) tuples, so the DRC validator sees
-overlapping drills on the same net and flags ``dimension_drill_clearance``.
+overlapping drills on the same net and flags ``hole_to_hole_clearance``.
 
 Fix: ``_insert_sexp_before_closing`` now calls ``_strip_route_blocks``
 before inserting the new route s-expression.  The strip removes any

--- a/tests/router/test_via_hole_to_hole_guard.py
+++ b/tests/router/test_via_hole_to_hole_guard.py
@@ -10,7 +10,7 @@ manufacturer ``min_hole_to_hole`` (canonical 0.5 mm) drill-to-drill floor:
 Each now rejects a candidate via whose DRILL would sit within
 ``min_hole_to_hole`` (edge-to-edge) of any existing drill (via OR
 through-hole pad, any net), reusing the canonical edge-to-edge formula
-from the DRC ``dimension_drill_clearance`` rule.
+from the DRC ``hole_to_hole_clearance`` rule.
 """
 
 from __future__ import annotations

--- a/tests/test_board_04_main_gate.py
+++ b/tests/test_board_04_main_gate.py
@@ -7,7 +7,7 @@ error or a copper-LVS short printed SUCCESS and exited 0.  Issue #3839 wires
 both into the gate.  ``run_drc`` is now ALLOWLIST-AWARE: it parses the DRC
 JSON and tolerates exactly the grandfathered violations the CI gate tolerates.
 Since Issue #4017 re-spaced the LQFP-48 west-escape drill pair, the
-``dimension_drill_clearance`` allowance is strict-0 -- the only remaining
+``hole_to_hole_clearance`` allowance is strict-0 -- the only remaining
 grandfathered rule is the advisory ``connectivity`` finding; ANY drill error
 or any other blocking rule fails the gate.
 
@@ -120,7 +120,7 @@ def test_run_drc_fails_on_any_drill(
         board04,
         monkeypatch,
         tmp_path,
-        ["dimension_drill_clearance"],
+        ["hole_to_hole_clearance"],
     )
     pcb = tmp_path / "stm32_devboard_routed.kicad_pcb"
     pcb.write_text("(kicad_pcb)")
@@ -135,7 +135,7 @@ def test_run_drc_fails_on_non_drill_blocking_rule(
         board04,
         monkeypatch,
         tmp_path,
-        ["dimension_drill_clearance", "clearance_segment_zone"],
+        ["hole_to_hole_clearance", "clearance_segment_zone"],
     )
     pcb = tmp_path / "stm32_devboard_routed.kicad_pcb"
     pcb.write_text("(kicad_pcb)")

--- a/tests/test_board_04_mfr_gate.py
+++ b/tests/test_board_04_mfr_gate.py
@@ -15,7 +15,7 @@ the same gate the CI ``routed-pcb-drc-check`` job uses
 2. The gate's blocking error count stays at or below the floor declared
    for board 04 in the same YAML.  The floor is strict-0: Issue #3842
    re-baselined it to 2 for the pre-existing TRUE-POSITIVE sub-0.5mm
-   ``dimension_drill_clearance`` drills (a 0.350mm pair at
+   ``hole_to_hole_clearance`` drills (a 0.350mm pair at
    [26.84, 22.5]/[26.84, 22.0]), and Issue #4017 re-spaced that pair to
    >= 0.500mm edge-to-edge (artifact-only nudge: the NRST in-pad via
    relocated 0.5mm east onto its B.Cu escape node, re-bonded to pad U2.7

--- a/tests/test_board_06_diffpair_test.py
+++ b/tests/test_board_06_diffpair_test.py
@@ -789,11 +789,11 @@ class TestBoard06StrictGateGuard:
     spec (canonical 0.5 mm fab default; the old code keyed off
     ``min_clearance_mm`` and never fired below 0.5 mm).  The committed
     board-06 artifact carries 6 genuine pre-existing
-    ``dimension_drill_clearance`` violations -- sub-0.5 mm drill pairs that
+    ``hole_to_hole_clearance`` violations -- sub-0.5 mm drill pairs that
     were always present but invisible to the broken check.  These are TRUE
     POSITIVES, NOT new regressions from this PR; the board-layout fix
     (re-spacing the drills to >= 0.5 mm) is tracked in **#3847**, the rule
-    change refs #3842 / #3830.  The +6 are ``dimension_drill_clearance``,
+    change refs #3842 / #3830.  The +6 are ``hole_to_hole_clearance``,
     a DISTINCT family from the 18 diff-pair quality defects
     (``diffpair_length_skew`` / ``diffpair_routing_continuity``), so the
     diff-pair-only baseline (``DIFFPAIR_VIOLATION_BASELINE`` = 18 in
@@ -811,7 +811,7 @@ class TestBoard06StrictGateGuard:
     #   * 18 diff-pair quality defects (9 ``diffpair_length_skew`` + 9
     #     ``diffpair_routing_continuity``) -- UNCHANGED; coupled
     #     convergence is tracked in #3540-#3544.
-    #   * ``dimension_drill_clearance`` dropped 6 -> 1.  The router /
+    #   * ``hole_to_hole_clearance`` dropped 6 -> 1.  The router /
     #     recipe via placers now reject sub-0.5mm drill pairs (#3855), so
     #     5 of the 6 prior drill true-positives are gone.  The lone
     #     remainder is a same-net USB2_D+ coupled-route via pair placed by
@@ -839,7 +839,7 @@ class TestBoard06StrictGateGuard:
     # shorts (a USB_CC1 In1.Cu track through the USB2_D-/USB3_RX1- via
     # barrels) and the U2-F1 clearance pair do not re-appear on the fresh
     # route, and the residual same-net via_in_pad (USB_CC1 at U1-12) + 2
-    # ``dimension_drill_clearance`` staples (USB2_D+, MIPI_RST) are
+    # ``hole_to_hole_clearance`` staples (USB2_D+, MIPI_RST) are
     # repaired by step 13.  kicad-cli reports 0 errors / 0 unconnected and
     # the manufacturing bundle's report.md shows Errors = 0.  What remains
     # is EXACTLY the diff-pair quality block: 9 ``diffpair_length_skew`` +
@@ -945,7 +945,7 @@ class TestBoard06StrictGateGuard:
           (currently 24 = 18 diff-pair + 6 drill; the strict gate's drift
           warning will be your guide).  Driving the 18 diff-pair errors to
           0 is the coupled-convergence work tracked in #3540-#3544; the 6
-          ``dimension_drill_clearance`` true-positives (Issue #3842 gate)
+          ``hole_to_hole_clearance`` true-positives (Issue #3842 gate)
           are the board-layout fix tracked in #3847.
         """
         from kicad_tools.validate.checker import DRCChecker

--- a/tests/test_clearance_net_names.py
+++ b/tests/test_clearance_net_names.py
@@ -621,7 +621,7 @@ class TestDrillClearanceNets:
         results = checker.check_dimensions()
 
         drill_violations = [
-            v for v in results.violations if v.rule_id == "dimension_drill_clearance"
+            v for v in results.violations if v.rule_id == "hole_to_hole_clearance"
         ]
         assert len(drill_violations) > 0
 

--- a/tests/test_clearance_net_names.py
+++ b/tests/test_clearance_net_names.py
@@ -620,9 +620,7 @@ class TestDrillClearanceNets:
         checker = DRCChecker(pcb, manufacturer="jlcpcb", layers=2, copper_oz=1.0)
         results = checker.check_dimensions()
 
-        drill_violations = [
-            v for v in results.violations if v.rule_id == "hole_to_hole_clearance"
-        ]
+        drill_violations = [v for v in results.violations if v.rule_id == "hole_to_hole_clearance"]
         assert len(drill_violations) > 0
 
         v = drill_violations[0]

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -981,7 +981,7 @@ def main_(pcb: Path) -> int:
 
 
 class TestDrillClearanceNetRelationship:
-    """Issue #4102: net-relationship enrichment for dimension_drill_clearance.
+    """Issue #4102: net-relationship enrichment for hole_to_hole_clearance.
 
     The findings already carry both endpoints' nets (``nets=(net1, net2)``,
     also serialized in ``--format json`` via ``DRCViolation.to_dict``).  These
@@ -995,7 +995,7 @@ class TestDrillClearanceNetRelationship:
         from kicad_tools.validate import DRCViolation
 
         return DRCViolation(
-            rule_id="dimension_drill_clearance",
+            rule_id="hole_to_hole_clearance",
             severity=severity,
             message="Hole-to-hole clearance 0.113mm < minimum 0.500mm",
             location=(10.0, 20.0),
@@ -1048,7 +1048,7 @@ class TestDrillClearanceNetRelationship:
 
         _print_violation(self._violation(("HALL_A", "GND")), verbose=False)
         out = capsys.readouterr().out
-        assert "dimension_drill_clearance (different-net)" in out
+        assert "hole_to_hole_clearance (different-net)" in out
         assert "Nets: HALL_A / GND" in out
 
     def test_same_net_finding_shows_label_and_nets_default(self, capsys):
@@ -1057,7 +1057,7 @@ class TestDrillClearanceNetRelationship:
 
         _print_violation(self._violation(("HALL_A", "HALL_A")), verbose=False)
         out = capsys.readouterr().out
-        assert "dimension_drill_clearance (same-net)" in out
+        assert "hole_to_hole_clearance (same-net)" in out
         assert "Nets: HALL_A / HALL_A" in out
 
     def test_verbose_keeps_label_and_nets(self, capsys):
@@ -1066,7 +1066,7 @@ class TestDrillClearanceNetRelationship:
 
         _print_violation(self._violation(("HALL_A", "GND")), verbose=True)
         out = capsys.readouterr().out
-        assert "dimension_drill_clearance (different-net)" in out
+        assert "hole_to_hole_clearance (different-net)" in out
         # Net endpoints rendered exactly once, in the net-relationship form.
         assert out.count("Nets:") == 1
         assert "Nets: HALL_A / GND" in out
@@ -1108,7 +1108,7 @@ class TestDrillClearanceNetRelationship:
 
         output_table(violations, results, Path("board.kicad_pcb"), "jlcpcb", 2, False)
         out = capsys.readouterr().out
-        assert "dimension_drill_clearance: 3 errors (2 different-net, 1 same-net)" in out
+        assert "hole_to_hole_clearance: 3 errors (2 different-net, 1 same-net)" in out
 
     def test_by_rule_summary_floating_pair_counts_as_different(self, capsys):
         """Issue #4127: floating/floating pairs count as different-net in BY RULE.
@@ -1134,7 +1134,7 @@ class TestDrillClearanceNetRelationship:
 
         output_table(violations, results, Path("board.kicad_pcb"), "jlcpcb", 2, False)
         out = capsys.readouterr().out
-        assert "dimension_drill_clearance: 3 errors (2 different-net, 1 same-net)" in out
+        assert "hole_to_hole_clearance: 3 errors (2 different-net, 1 same-net)" in out
 
 
 class TestClearanceSegmentViaNetRelationship:
@@ -1145,7 +1145,7 @@ class TestClearanceSegmentViaNetRelationship:
     ``nets=(net_a, net_b)`` (set in ``_create_violation``,
     ``validate/rules/clearance.py``), also serialized in ``--format json``.
     Adding them to ``_NET_RELATIONSHIP_RULE_IDS`` gives them the same
-    presentational split ``dimension_drill_clearance`` gets: a per-finding
+    presentational split ``hole_to_hole_clearance`` gets: a per-finding
     qualifier + unconditional ``Nets:`` line and a ``BY RULE`` sub-count.  An
     agent can then triage a genuine different-net short ahead of a lower-risk
     same-net coincidence.  Presentational only; severity is unchanged.

--- a/tests/test_drc_tolerance.py
+++ b/tests/test_drc_tolerance.py
@@ -320,6 +320,6 @@ class TestDimensionRulesTolerance:
         rules = MockDesignRules(min_clearance_mm=0.127)
         result = DimensionRules().check(pcb, rules)
         drill_violations = [
-            v for v in result.violations if v.rule_id == "dimension_drill_clearance"
+            v for v in result.violations if v.rule_id == "hole_to_hole_clearance"
         ]
         assert len(drill_violations) == 1

--- a/tests/test_drc_tolerance.py
+++ b/tests/test_drc_tolerance.py
@@ -319,7 +319,5 @@ class TestDimensionRulesTolerance:
         pcb = MockPCB(vias=[via1, via2], nets=[MockNet(1, "VCC"), MockNet(2, "GND")])
         rules = MockDesignRules(min_clearance_mm=0.127)
         result = DimensionRules().check(pcb, rules)
-        drill_violations = [
-            v for v in result.violations if v.rule_id == "hole_to_hole_clearance"
-        ]
+        drill_violations = [v for v in result.violations if v.rule_id == "hole_to_hole_clearance"]
         assert len(drill_violations) == 1

--- a/tests/test_drc_violation_type_validate.py
+++ b/tests/test_drc_violation_type_validate.py
@@ -67,11 +67,28 @@ class TestValidateRuleIdMapping:
             ("dimension_via_drill", ViolationType.DIMENSION_VIA_DRILL),
             ("dimension_via_diameter", ViolationType.DIMENSION_VIA_DIAMETER),
             ("dimension_annular_ring", ViolationType.DIMENSION_ANNULAR_RING),
-            ("dimension_drill_clearance", ViolationType.DIMENSION_DRILL_CLEARANCE),
+            # Issue #4353: canonical id is now ``hole_to_hole_clearance``; the
+            # legacy ``dimension_drill_clearance`` still resolves via the
+            # backwards-compat alias (asserted in test_hole_to_hole_compat_alias).
+            ("hole_to_hole_clearance", ViolationType.HOLE_TO_HOLE_CLEARANCE),
         ],
     )
     def test_dimension_rules(self, rule_id: str, expected: ViolationType):
         assert ViolationType.from_string(rule_id) == expected
+
+    def test_hole_to_hole_compat_alias(self):
+        """Issue #4353: the legacy ``dimension_drill_clearance`` rule_id must
+        still resolve to the renamed member so previously-saved JSON reports
+        and ``kct fix-drc dimension_drill_clearance`` keep working."""
+        assert (
+            ViolationType.from_string("dimension_drill_clearance")
+            == ViolationType.HOLE_TO_HOLE_CLEARANCE
+        )
+        # And the new canonical string resolves to the same member.
+        assert (
+            ViolationType.from_string("hole_to_hole_clearance")
+            == ViolationType.HOLE_TO_HOLE_CLEARANCE
+        )
 
     # -- silkscreen rules ----------------------------------------------------
 
@@ -127,6 +144,8 @@ class TestValidateRuleIdMapping:
             "dimension_via_drill",
             "dimension_via_diameter",
             "dimension_annular_ring",
+            "hole_to_hole_clearance",
+            # Issue #4353: legacy alias must still resolve (never UNKNOWN).
             "dimension_drill_clearance",
             "silkscreen_line_width",
             "silkscreen_text_height",

--- a/tests/test_fix_drc_cmd.py
+++ b/tests/test_fix_drc_cmd.py
@@ -675,11 +675,20 @@ class TestViolationTypeMapping:
         """Should parse 'drill_clearance' to DRILL_CLEARANCE."""
         assert ViolationType.from_string("drill_clearance") == ViolationType.DRILL_CLEARANCE
 
-    def test_dimension_drill_clearance(self):
-        """Should parse 'dimension_drill_clearance' to DIMENSION_DRILL_CLEARANCE."""
+    def test_hole_to_hole_clearance(self):
+        """Should parse 'hole_to_hole_clearance' to HOLE_TO_HOLE_CLEARANCE (#4353)."""
+        assert (
+            ViolationType.from_string("hole_to_hole_clearance")
+            == ViolationType.HOLE_TO_HOLE_CLEARANCE
+        )
+
+    def test_dimension_drill_clearance_compat_alias(self):
+        """Legacy 'dimension_drill_clearance' still routes to the renamed member
+        (#4353 backwards-compat alias) so ``kct fix-drc dimension_drill_clearance``
+        keeps reaching DrillClearanceRepairer."""
         assert (
             ViolationType.from_string("dimension_drill_clearance")
-            == ViolationType.DIMENSION_DRILL_CLEARANCE
+            == ViolationType.HOLE_TO_HOLE_CLEARANCE
         )
 
     def test_clearance_still_works(self):

--- a/tests/test_stitch_cmd.py
+++ b/tests/test_stitch_cmd.py
@@ -7769,7 +7769,7 @@ class TestMultiNetPreexistingHoleGuard:
     def test_no_different_net_drill_pair_within_floor_after_stitch(self, tmp_path: Path) -> None:
         """Whole-board invariant: after a multi-net stitch, NO two drills on
         DIFFERENT nets sit within the hole-to-hole floor (the
-        ``dimension_drill_clearance`` different-net check), and specifically no
+        ``hole_to_hole_clearance`` different-net check), and specifically no
         coincident (-0.000mm) pairs.  Load-bearing: the fixture places the GND
         pad's straight-line escape directly onto a pre-existing +3.3V VIA, so a
         clean board proves the guard machinery relocated the GND via."""

--- a/tests/test_validate_dimensions.py
+++ b/tests/test_validate_dimensions.py
@@ -469,7 +469,7 @@ class TestDrillClearanceCheck:
         results = rule.check(pcb, rules)
 
         clearance_violations = [
-            v for v in results.violations if v.rule_id == "dimension_drill_clearance"
+            v for v in results.violations if v.rule_id == "hole_to_hole_clearance"
         ]
         assert len(clearance_violations) == 0
 
@@ -491,7 +491,7 @@ class TestDrillClearanceCheck:
         results = rule.check(pcb, rules)
 
         clearance_violations = [
-            v for v in results.violations if v.rule_id == "dimension_drill_clearance"
+            v for v in results.violations if v.rule_id == "hole_to_hole_clearance"
         ]
         assert len(clearance_violations) == 1
         assert clearance_violations[0].actual_value == pytest.approx(0.1)
@@ -531,7 +531,7 @@ class TestDrillClearanceCheck:
         results = rule.check(pcb, rules)
 
         clearance_violations = [
-            v for v in results.violations if v.rule_id == "dimension_drill_clearance"
+            v for v in results.violations if v.rule_id == "hole_to_hole_clearance"
         ]
         assert len(clearance_violations) == 1
 
@@ -586,7 +586,7 @@ class TestDrillClearanceCheck:
         results = rule.check(pcb, rules)
 
         clearance_violations = [
-            v for v in results.violations if v.rule_id == "dimension_drill_clearance"
+            v for v in results.violations if v.rule_id == "hole_to_hole_clearance"
         ]
         # Buggy code would find the via 0.7mm from the (10,14) pad -> flag.
         # Correct code measures against (14,10) -> 5.77mm edge -> no flag.
@@ -632,7 +632,7 @@ class TestDrillClearanceCheck:
         results = rule.check(pcb, rules)
 
         clearance_violations = [
-            v for v in results.violations if v.rule_id == "dimension_drill_clearance"
+            v for v in results.violations if v.rule_id == "hole_to_hole_clearance"
         ]
         assert len(clearance_violations) == 1
         assert clearance_violations[0].actual_value == pytest.approx(0.3)
@@ -668,7 +668,7 @@ class TestDrillClearanceCheck:
         results = rule.check(pcb, rules)
 
         clearance_violations = [
-            v for v in results.violations if v.rule_id == "dimension_drill_clearance"
+            v for v in results.violations if v.rule_id == "hole_to_hole_clearance"
         ]
         assert len(clearance_violations) == 0
 
@@ -692,7 +692,7 @@ class TestDrillClearanceCheck:
         results = rule.check(pcb, rules)
 
         clearance_violations = [
-            v for v in results.violations if v.rule_id == "dimension_drill_clearance"
+            v for v in results.violations if v.rule_id == "hole_to_hole_clearance"
         ]
         assert len(clearance_violations) == 1
         assert clearance_violations[0].actual_value == pytest.approx(0.3)
@@ -715,7 +715,7 @@ class TestDrillClearanceCheck:
         results = rule.check(pcb, rules)
 
         clearance_violations = [
-            v for v in results.violations if v.rule_id == "dimension_drill_clearance"
+            v for v in results.violations if v.rule_id == "hole_to_hole_clearance"
         ]
         assert len(clearance_violations) == 0
 
@@ -754,7 +754,7 @@ class TestDrillClearanceCheck:
         results = rule.check(pcb, rules)
 
         clearance_violations = [
-            v for v in results.violations if v.rule_id == "dimension_drill_clearance"
+            v for v in results.violations if v.rule_id == "hole_to_hole_clearance"
         ]
         assert len(clearance_violations) == 1
         assert clearance_violations[0].severity == "error"
@@ -802,7 +802,7 @@ class TestSameFootprintDrillClearance:
         results = rule.check(pcb, rules)
 
         clearance_violations = [
-            v for v in results.violations if v.rule_id == "dimension_drill_clearance"
+            v for v in results.violations if v.rule_id == "hole_to_hole_clearance"
         ]
         assert len(clearance_violations) == 1
         assert clearance_violations[0].severity == "warning"
@@ -850,7 +850,7 @@ class TestSameFootprintDrillClearance:
         results = rule.check(pcb, rules)
 
         clearance_violations = [
-            v for v in results.violations if v.rule_id == "dimension_drill_clearance"
+            v for v in results.violations if v.rule_id == "hole_to_hole_clearance"
         ]
         assert len(clearance_violations) == 1
         assert clearance_violations[0].severity == "error"
@@ -887,7 +887,7 @@ class TestSameFootprintDrillClearance:
         results = rule.check(pcb, rules)
 
         clearance_violations = [
-            v for v in results.violations if v.rule_id == "dimension_drill_clearance"
+            v for v in results.violations if v.rule_id == "hole_to_hole_clearance"
         ]
         assert len(clearance_violations) == 1
         assert clearance_violations[0].severity == "error"
@@ -908,7 +908,7 @@ class TestSameFootprintDrillClearance:
         results = rule.check(pcb, rules)
 
         clearance_violations = [
-            v for v in results.violations if v.rule_id == "dimension_drill_clearance"
+            v for v in results.violations if v.rule_id == "hole_to_hole_clearance"
         ]
         assert len(clearance_violations) == 1
         assert clearance_violations[0].severity == "error"
@@ -936,7 +936,7 @@ class TestSameFootprintDrillClearance:
         results = rule.check(pcb, rules)
 
         clearance_violations = [
-            v for v in results.violations if v.rule_id == "dimension_drill_clearance"
+            v for v in results.violations if v.rule_id == "hole_to_hole_clearance"
         ]
         assert len(clearance_violations) == 1
         v = clearance_violations[0]
@@ -972,7 +972,7 @@ class TestSameFootprintDrillClearance:
         results = rule.check(pcb, rules)
 
         clearance_violations = [
-            v for v in results.violations if v.rule_id == "dimension_drill_clearance"
+            v for v in results.violations if v.rule_id == "hole_to_hole_clearance"
         ]
         assert len(clearance_violations) == 0
 
@@ -1011,7 +1011,7 @@ class TestSameFootprintDrillClearance:
         results = rule.check(pcb, rules)
 
         clearance_violations = [
-            v for v in results.violations if v.rule_id == "dimension_drill_clearance"
+            v for v in results.violations if v.rule_id == "hole_to_hole_clearance"
         ]
         assert len(clearance_violations) == 0
 
@@ -1128,7 +1128,7 @@ class TestViolationLocation:
         results = rule.check(pcb, rules)
 
         clearance_violations = [
-            v for v in results.violations if v.rule_id == "dimension_drill_clearance"
+            v for v in results.violations if v.rule_id == "hole_to_hole_clearance"
         ]
         assert len(clearance_violations) == 1
         # Midpoint of (0,0) and (0.4, 0) is (0.2, 0)

--- a/uv.lock
+++ b/uv.lock
@@ -1766,7 +1766,7 @@ wheels = [
 
 [[package]]
 name = "kicad-tools"
-version = "0.16.0"
+version = "0.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary
`kct check` DRC output labeled a category `dimension_drill_clearance` while
its findings read `Hole-to-hole clearance X mm < minimum ...`. The
`dimension_` prefix is a checker-module naming convention, but a reader
parses `dimension_drill` as a drill-to-board-edge check, so the `BY RULE:`
label (which prints the raw `rule_id`) contradicted the physically accurate
message text. This costs triage time.

The check is genuinely hole-to-hole (drill center-to-center minus both
radii) and the message text is correct. This PR renames the emitted
`rule_id` to `hole_to_hole_clearance` so the label and message agree, with
a backwards-compat alias for the old string.

## Changes
- `drc/violation.py`: rename `ViolationType.DIMENSION_DRILL_CLEARANCE` ->
  `HOLE_TO_HOLE_CLEARANCE` (value `"hole_to_hole_clearance"`); update the
  category map entry; add an **explicit** `from_string` alias for the new
  id (so the fuzzy `"clearance"` fallback can't mis-route it) and **retain**
  `"dimension_drill_clearance"` as a backwards-compat alias.
- `validate/rules/dimensions.py`: emit the new `rule_id`. Message text
  unchanged (already correct).
- `cli/check_cmd.py`: update `_NET_RELATIONSHIP_RULE_IDS` so the #4102
  same-net / different-net breakdown still renders for the renamed rule.
- `boards/04-stm32-devboard/generate_design.py`: update the DRC-gate
  constant `_DRILL_CLEARANCE_RULE_ID` (parses the raw JSON `rule_id`).
- `cli/fix_drc_cmd.py`: docstring update (routing works via the compat
  alias, no functional change).
- Tests: update all string-keyed assertions to the new id; add `from_string`
  tests asserting both `hole_to_hole_clearance` **and** the legacy
  `dimension_drill_clearance` (compat) resolve to the same member.
- Comment/docstring sweep across router, cli, boards, scripts, docs, and CI
  YAML comments for consistency (CI gating unaffected — the YAML references
  were comment-only).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `BY RULE:` + detail lines label these `hole_to_hole_clearance` | ✅ | Emission site renamed; `test_cli_check.py` asserts `hole_to_hole_clearance (different-net)` / `... (same-net)` and `hole_to_hole_clearance: 3 errors (...)` |
| Message text at `dimensions.py` unchanged | ✅ | Only `rule_id=` changed; message lines untouched |
| #4102 same-net/different-net breakdown still renders | ✅ | New id added to `_NET_RELATIONSHIP_RULE_IDS`; `test_by_rule_summary_includes_breakdown` green |
| `from_string("hole_to_hole_clearance")` returns the member | ✅ | New test `test_hole_to_hole_compat_alias` |
| `from_string("dimension_drill_clearance")` still returns the member | ✅ | New compat tests in `test_drc_violation_type_validate.py` + `test_fix_drc_cmd.py` |
| `kct fix-drc` still routes to `DrillClearanceRepairer` | ✅ | Routing goes through `from_string`; compat alias retained |
| No stray old-id refs in load-bearing code/tests | ✅ | `git grep dimension_drill_clearance` in `src/` returns only the compat alias + rename-doc comments |

## Test Plan
- `uv run pytest tests/test_validate_dimensions.py tests/test_cli_check.py tests/test_drc_violation_type_validate.py tests/test_fix_drc_cmd.py tests/test_board_04_main_gate.py tests/test_clearance_net_names.py tests/test_drc_tolerance.py` — **343 passed**.
- `ruff check` / `ruff format --check` — clean.
- `mypy` on changed files — no new errors (the one `fix_drc_cmd.py:742` arg-type error is pre-existing in `.github/mypy-baseline.txt`).

## Backwards compatibility
`--format json` `rule_id` value changes from `dimension_drill_clearance` to
`hole_to_hole_clearance`. The `from_string` compat alias keeps
previously-saved reports and `kct fix-drc dimension_drill_clearance`
working.

Closes #4353

🤖 Generated with [Claude Code](https://claude.com/claude-code)