### PR TITLE
fix: resolve schematic for versioned board stems and warn on skipped LVS gate

### DIFF
--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -153,6 +153,12 @@ class MetaCheckResult:
     lvs: SubCheckResult
     manifest: SubCheckResult
     overall: Literal["PASSED", "FAILED", "INCOMPLETE"] = "PASSED"
+    # Issue #4350: True when ERC/LVS are NOT RUN specifically because no
+    # schematic could be discovered next to the PCB (as opposed to kicad-cli
+    # being unavailable).  Drives the loud "skipped LVS hard gate" warning and
+    # a machine-detectable JSON field so a skipped gate is never mistaken for a
+    # clean one.
+    schematic_missing: bool = False
 
     def _subs(self) -> tuple[SubCheckResult, ...]:
         return (self.drc, self.erc, self.lvs, self.manifest)
@@ -189,6 +195,7 @@ class MetaCheckResult:
             "lvs": self.lvs.to_dict(),
             "manifest": self.manifest.to_dict(),
             "overall": self.overall,
+            "schematic_missing": self.schematic_missing,
         }
 
 
@@ -693,7 +700,27 @@ def run_meta_checks(
     lvs = _lvs_subcheck(resolved_sch, pcb_path)
     manifest = _manifest_subcheck(pcb_path)
 
-    result = MetaCheckResult(drc=drc_status, erc=erc, lvs=lvs, manifest=manifest)
+    # Issue #4350: when discovery turned up no schematic, ERC and (critically)
+    # the LVS *manufacturing hard gate* are silently NOT RUN.  Emit a loud
+    # one-line warning to stderr so a skipped hard gate is never mistaken for a
+    # clean comparison, and record a machine-detectable flag for JSON consumers.
+    schematic_missing = resolved_sch is None
+    if schematic_missing:
+        print(
+            "WARNING: no schematic discovered next to "
+            f"{pcb_path.name}; ERC and the LVS manufacturing hard gate were "
+            "SKIPPED (not run) -- copper was NOT compared to any schematic. "
+            "Pass --schematic <path.kicad_sch> to run them.",
+            file=sys.stderr,
+        )
+
+    result = MetaCheckResult(
+        drc=drc_status,
+        erc=erc,
+        lvs=lvs,
+        manifest=manifest,
+        schematic_missing=schematic_missing,
+    )
     result.compute_overall()
     return result
 

--- a/src/kicad_tools/sync/discover.py
+++ b/src/kicad_tools/sync/discover.py
@@ -5,14 +5,36 @@ path, but schematic/PCB drift detection (the :class:`Reconciler`) needs both
 files.  This module factors out the single schematic-resolution heuristic so
 ``route``, ``check``, and ``audit`` all agree on where the schematic lives.
 
-Resolution order (matches the historical ``Auditor._resolve_schematic_path``):
+Resolution order (matches the historical ``Auditor._resolve_schematic_path``,
+extended by issue #4350 to tolerate versioned board basenames):
     1. ``project.kct`` ``artifacts.schematic`` (looked up next to the PCB, then
        one directory up), if it points at an existing file.
-    2. Sibling ``<pcb-basename>.kicad_sch``.
+    2. Sibling ``<pcb-basename>.kicad_sch`` (stage-stripped stem first, then the
+       raw stem).
+    3. Project-pairing fallback: a sibling ``<pro-stem>.kicad_sch`` that is
+       paired with a ``<pro-stem>.kicad_pro`` project file.  A KiCad
+       ``.kicad_pro`` does not store the root-schematic path as an explicit
+       field -- the root schematic is the by-convention ``<project-stem>.kicad_sch``
+       paired with ``<project-stem>.kicad_pro`` -- so pairing on the project
+       stem is how "the schematic referenced by the board's project" is
+       realized in practice.  Child/sub-sheets have ``.kicad_sch`` files but no
+       matching ``.kicad_pro``, so this naturally excludes them.  Only fires
+       when exactly one distinct paired root schematic exists.
+    4. Sole-schematic fallback: if no paired root schematic is found and there
+       is exactly one ``*.kicad_sch`` in the directory, use it (flat
+       single-file projects).
 
 A PCB basename may carry pipeline-stage suffixes (``_routed``, ``_optimized``,
 ``_stitched``, ``_phase1``) that the schematic never has, so those are stripped
-before the sibling lookup.
+before the sibling lookup.  Version suffixes (``_v24``, ``_v23_mfg``, ...) are
+*not* stripped -- arbitrary version schemes are too brittle to enumerate -- so
+versioned board artifacts are resolved via the scheme-agnostic ``.kicad_pro``
+pairing (step 3) instead.
+
+**Ambiguity guard:** when steps 3-4 find more than one candidate root schematic
+and none matches the board stem, this returns ``None`` rather than guessing.
+Comparing copper against the *wrong* schematic is worse than skipping; callers
+should require an explicit ``--schematic`` in that case.
 
 Returns ``None`` when no schematic can be found -- callers should treat that as
 "skip silently" rather than an error, since many PCB-only workflows are
@@ -38,6 +60,22 @@ def _strip_stage_suffix(stem: str) -> str:
         if stem.endswith(suffix):
             return stem[: -len(suffix)]
     return stem
+
+
+def _paired_root_schematics(project_dir: Path) -> list[Path]:
+    """Return sibling ``.kicad_sch`` files paired with a matching ``.kicad_pro``.
+
+    A KiCad root schematic is paired with a project file of the same stem
+    (``foo.kicad_pro`` + ``foo.kicad_sch``).  Child/sub-sheets have a
+    ``.kicad_sch`` but no matching ``.kicad_pro``, so pairing on the stem
+    isolates the root schematic(s).  Returns a de-duplicated, sorted list.
+    """
+    candidates: set[Path] = set()
+    for pro in project_dir.glob("*.kicad_pro"):
+        sch = pro.with_suffix(".kicad_sch")
+        if sch.exists():
+            candidates.add(sch)
+    return sorted(candidates)
 
 
 def resolve_schematic_for_pcb(pcb_path: str | Path) -> Path | None:
@@ -81,5 +119,35 @@ def resolve_schematic_for_pcb(pcb_path: str | Path) -> Path | None:
         if candidate.exists():
             logger.debug("Using sibling schematic: %s", candidate)
             return candidate
+
+    # 3. Project-pairing fallback (issue #4350).  Versioned board basenames
+    #    (``board_v24.kicad_pcb``) never match the unversioned root schematic
+    #    by stem, so look for a ``.kicad_sch`` paired with a sibling
+    #    ``.kicad_pro`` of the same stem -- the by-convention root schematic.
+    #    Only resolve when exactly one distinct candidate exists; more than one
+    #    (and none matched the board stem in step 2) is genuinely ambiguous, so
+    #    return ``None`` rather than comparing copper against the wrong design.
+    paired = _paired_root_schematics(project_dir)
+    if len(paired) == 1:
+        logger.debug("Using project-paired root schematic: %s", paired[0])
+        return paired[0]
+    if len(paired) > 1:
+        logger.debug(
+            "Ambiguous schematic discovery: %d paired root schematics, none "
+            "matching board stem %r; returning None (pass --schematic)",
+            len(paired),
+            pcb_path.stem,
+        )
+        return None
+
+    # 4. Sole-schematic fallback.  A flat single-file project has one
+    #    ``.kicad_sch`` and (perhaps) no paired ``.kicad_pro`` at all; if there
+    #    is exactly one schematic in the directory, use it.  Guard on count == 1
+    #    -- hierarchical designs have several sibling child sheets and must not
+    #    be resolved by guessing.
+    all_sch = sorted(project_dir.glob("*.kicad_sch"))
+    if len(all_sch) == 1:
+        logger.debug("Using sole schematic in directory: %s", all_sch[0])
+        return all_sch[0]
 
     return None

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -709,11 +709,20 @@ class TestCheckMetaCheck:
         # New: meta_checks envelope.
         assert "meta_checks" in data
         meta = data["meta_checks"]
-        assert set(meta.keys()) == {"drc", "erc", "lvs", "manifest", "overall"}
+        assert set(meta.keys()) == {
+            "drc",
+            "erc",
+            "lvs",
+            "manifest",
+            "overall",
+            "schematic_missing",
+        }
         for name in ("drc", "erc", "lvs", "manifest"):
             assert "status" in meta[name]
             assert "detail" in meta[name]
         assert meta["overall"] == "PASSED"
+        # Schematic was present in this fixture, so the LVS gate was not skipped.
+        assert meta["schematic_missing"] is False
 
     def test_meta_checks_omitted_under_drc_only_in_json(self, drc_clean_pcb: Path, capsys):
         """--drc-only must NOT add meta_checks to the JSON envelope."""

--- a/tests/test_discover_schematic.py
+++ b/tests/test_discover_schematic.py
@@ -1,0 +1,123 @@
+"""Tests for versioned-basename schematic discovery (issue #4350).
+
+``resolve_schematic_for_pcb`` must resolve the root ``.kicad_sch`` even when the
+board artifact carries a *version* suffix (``_v24``, ``_v23_mfg``, ...) that is
+not a known pipeline-stage suffix.  It does so via ``.kicad_pro``/``.kicad_sch``
+stem pairing (step 3) and a sole-schematic fallback (step 4), while an ambiguity
+guard returns ``None`` rather than comparing copper against the wrong design.
+
+These tests only care about *which path* is resolved, so the fixture files are
+empty placeholders -- discovery keys on existence, not content.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from kicad_tools.sync.discover import resolve_schematic_for_pcb
+
+
+def _touch(path: Path) -> Path:
+    path.write_text("")
+    return path
+
+
+class TestVersionedBasenameDiscovery:
+    def test_versioned_board_resolves_root_via_pro_pairing(self, tmp_path):
+        # Repro layout: versioned board + its own .kicad_pro (no matching
+        # .kicad_sch), plus an unversioned root project pair.
+        _touch(tmp_path / "chorus-test-revA.kicad_sch")
+        _touch(tmp_path / "chorus-test-revA.kicad_pro")
+        _touch(tmp_path / "chorus-test-revA_v24.kicad_pro")
+        pcb = _touch(tmp_path / "chorus-test-revA_v24.kicad_pcb")
+
+        resolved = resolve_schematic_for_pcb(pcb)
+        assert resolved == tmp_path / "chorus-test-revA.kicad_sch"
+
+    def test_hierarchical_children_do_not_defeat_pro_pairing(self, tmp_path):
+        # Root project pair + child sub-sheets (which have .kicad_sch but no
+        # matching .kicad_pro).  Pairing must pick the root, not a child.
+        _touch(tmp_path / "board.kicad_sch")
+        _touch(tmp_path / "board.kicad_pro")
+        _touch(tmp_path / "mcu.kicad_sch")
+        _touch(tmp_path / "power.kicad_sch")
+        _touch(tmp_path / "board_v3.kicad_pro")
+        pcb = _touch(tmp_path / "board_v3.kicad_pcb")
+
+        resolved = resolve_schematic_for_pcb(pcb)
+        assert resolved == tmp_path / "board.kicad_sch"
+
+    def test_sole_schematic_fallback_without_pro(self, tmp_path):
+        # Flat project: a single .kicad_sch with no paired .kicad_pro at all.
+        sch = _touch(tmp_path / "root.kicad_sch")
+        pcb = _touch(tmp_path / "root_v2.kicad_pcb")
+
+        resolved = resolve_schematic_for_pcb(pcb)
+        assert resolved == sch
+
+
+class TestAmbiguityGuard:
+    def test_two_paired_roots_none_matching_returns_none(self, tmp_path):
+        # Two distinct root project pairs, neither matching the board stem ->
+        # ambiguous, must not guess.
+        _touch(tmp_path / "alpha.kicad_sch")
+        _touch(tmp_path / "alpha.kicad_pro")
+        _touch(tmp_path / "beta.kicad_sch")
+        _touch(tmp_path / "beta.kicad_pro")
+        pcb = _touch(tmp_path / "gamma_v1.kicad_pcb")
+
+        assert resolve_schematic_for_pcb(pcb) is None
+
+    def test_multiple_schematics_no_pairing_returns_none(self, tmp_path):
+        # Several child .kicad_sch files, no root .kicad_pro pairing -> the
+        # sole-schematic fallback must not fire.
+        _touch(tmp_path / "mcu.kicad_sch")
+        _touch(tmp_path / "power.kicad_sch")
+        pcb = _touch(tmp_path / "board_v1.kicad_pcb")
+
+        assert resolve_schematic_for_pcb(pcb) is None
+
+    def test_empty_directory_returns_none(self, tmp_path):
+        pcb = _touch(tmp_path / "board_v9.kicad_pcb")
+        assert resolve_schematic_for_pcb(pcb) is None
+
+
+class TestPrecedencePreserved:
+    def test_exact_stem_match_wins_over_pairing(self, tmp_path):
+        # An exact <stem>.kicad_sch still wins even when another paired root
+        # exists.  (Board stem match takes precedence over the fallback.)
+        _touch(tmp_path / "board.kicad_sch")
+        _touch(tmp_path / "board.kicad_pro")
+        _touch(tmp_path / "other.kicad_sch")
+        _touch(tmp_path / "other.kicad_pro")
+        pcb = _touch(tmp_path / "board.kicad_pcb")
+
+        resolved = resolve_schematic_for_pcb(pcb)
+        assert resolved == tmp_path / "board.kicad_sch"
+
+    def test_stage_suffix_strip_still_resolves(self, tmp_path):
+        _touch(tmp_path / "board.kicad_sch")
+        pcb = _touch(tmp_path / "board_routed.kicad_pcb")
+
+        resolved = resolve_schematic_for_pcb(pcb)
+        assert resolved == tmp_path / "board.kicad_sch"
+
+    def test_project_kct_artifacts_schematic_wins(self, tmp_path):
+        # project.kct artifacts.schematic must take precedence over both the
+        # pro-pairing and sole-schematic fallbacks.
+        _touch(tmp_path / "custom_name.kicad_sch")
+        # A distractor root pair the fallback would otherwise resolve.
+        _touch(tmp_path / "board.kicad_sch")
+        _touch(tmp_path / "board.kicad_pro")
+        pcb = _touch(tmp_path / "board_v5.kicad_pcb")
+        (tmp_path / "project.kct").write_text(
+            'kct_version: "1.0"\n'
+            "project:\n"
+            '  name: "test"\n'
+            "  artifacts:\n"
+            '    schematic: "custom_name.kicad_sch"\n'
+            '    pcb: "board_v5.kicad_pcb"\n'
+        )
+
+        resolved = resolve_schematic_for_pcb(pcb)
+        assert resolved == tmp_path / "custom_name.kicad_sch"

--- a/tests/test_netlist_sync_gate.py
+++ b/tests/test_netlist_sync_gate.py
@@ -257,5 +257,75 @@ class TestValueSuffixNotesRendering:
         assert "same value, PCB adds rating suffix" in report
 
 
+# ---------------------------------------------------------------------------
+# Versioned-basename discovery + loud skipped-gate warning (issue #4350)
+# ---------------------------------------------------------------------------
+
+
+class TestVersionedBasenameCheck:
+    """``kct check`` on a versioned board (``board_v24.kicad_pcb``) must
+    auto-discover the unversioned root schematic and actually run LVS instead
+    of reporting ``NOT RUN``; when no schematic is found, it must warn loudly.
+    """
+
+    def _write_versioned_layout(self, directory: Path, schematic: str, pcb: str) -> Path:
+        """Repro layout: versioned board + its own .kicad_pro, plus an
+        unversioned root project pair (.kicad_sch + .kicad_pro).  Returns the
+        versioned PCB path.
+        """
+        (directory / "board.kicad_sch").write_text(schematic)
+        (directory / "board.kicad_pro").write_text("")
+        (directory / "board_v24.kicad_pro").write_text("")
+        pcb_path = directory / "board_v24.kicad_pcb"
+        pcb_path.write_text(pcb)
+        return pcb_path
+
+    def test_versioned_board_runs_lvs(self, tmp_path, capsys):
+        import json
+
+        pcb = self._write_versioned_layout(tmp_path, MINIMAL_SCHEMATIC, MINIMAL_PCB_MATCHING)
+        check_main([str(pcb), "--format", "json"])
+        captured = capsys.readouterr()
+        payload = json.loads(captured.out)
+        meta = payload["meta_checks"]
+        # LVS is pure-python (no kicad-cli dependency); it must have run and
+        # compared copper -- not report the "no schematic discovered" skip.
+        assert meta["lvs"]["status"] != "NOT RUN"
+        assert "no schematic discovered" not in meta["lvs"]["detail"]
+        assert meta["schematic_missing"] is False
+        # No skipped-gate warning when the schematic was discovered.
+        assert "manufacturing hard gate" not in captured.err
+
+    def test_no_schematic_warns_loudly_and_flags_json(self, tmp_path, capsys):
+        import json
+
+        # Bare board, no schematic and no project pairing anywhere.
+        pcb = tmp_path / "orphan_v24.kicad_pcb"
+        pcb.write_text(MINIMAL_PCB_MATCHING)
+        rc = check_main([str(pcb), "--format", "json"])
+        captured = capsys.readouterr()
+        # Loud warning to stderr naming the skipped LVS hard gate.
+        assert "WARNING:" in captured.err
+        assert "LVS manufacturing hard gate" in captured.err
+        assert "SKIPPED" in captured.err
+        # Machine-detectable JSON flag.
+        payload = json.loads(captured.out)
+        assert payload["meta_checks"]["schematic_missing"] is True
+        assert payload["meta_checks"]["lvs"]["status"] == "NOT RUN"
+        # Default policy: INCOMPLETE rollup exits non-zero.
+        assert rc == 2
+
+    def test_allow_incomplete_still_exits_zero(self, tmp_path):
+        # Skip the connectivity DRC check so the minimal fixture's unrouted-net
+        # error does not mask the INCOMPLETE (schematic-missing) rollup we are
+        # asserting: default -> exit 2, --allow-incomplete -> exit 0.
+        pcb = tmp_path / "orphan_v24.kicad_pcb"
+        pcb.write_text(MINIMAL_PCB_MATCHING)
+        rc_default = check_main([str(pcb), "--skip", "connectivity"])
+        assert rc_default == 2
+        rc_allow = check_main([str(pcb), "--skip", "connectivity", "--allow-incomplete"])
+        assert rc_allow == 0
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary
`kct check` failed to auto-discover a sibling root schematic when the board used a **versioned basename** (`board_v24.kicad_pcb`), so it **silently skipped both ERC and the LVS hard gate** (`NOT RUN`). Root cause: `resolve_schematic_for_pcb` only stripped pipeline-stage suffixes (`_routed`, `_optimized`, …); a version suffix like `_v24` never matched the unversioned `board.kicad_sch`, so the helper returned `None`.

This makes discovery robust to versioned artifacts via scheme-agnostic `.kicad_pro`/`.kicad_sch` stem pairing, and makes a skipped LVS hard gate **loud** so a never-ran comparison is never mistaken for a clean one.

## Changes
- `src/kicad_tools/sync/discover.py`: after the exact/stage-stripped stem lookup, add
  - **project-pairing fallback** — a `<stem>.kicad_sch` paired with a sibling `<stem>.kicad_pro` (child sub-sheets lack a paired `.kicad_pro`, so they are excluded); fires only when exactly one distinct paired root exists.
  - **sole-`.kicad_sch` fallback** — for flat single-file projects with exactly one schematic.
  - **ambiguity guard** — returns `None` (rather than guessing) when ≥2 candidate roots exist and none matches the board stem. Updated the module docstring's resolution order. Version suffixes are intentionally *not* stripped (arbitrary schemes like `_v23_mfg`/`_rc2` are too brittle).
- `src/kicad_tools/cli/check_cmd.py`: emit a loud stderr `WARNING:` naming the skipped **LVS manufacturing hard gate** (and hinting `--schematic <path>`) when no schematic is discovered; add a machine-detectable `schematic_missing` boolean to the `meta_checks` JSON envelope. Default `INCOMPLETE` → exit 2 policy unchanged.
- `tests/test_discover_schematic.py` (new): versioned-basename, hierarchical, sole-schematic, ambiguity, and precedence (project.kct / exact stem / stage-suffix) cases.
- `tests/test_netlist_sync_gate.py`: CLI tests — versioned board runs LVS; no-schematic emits the loud warning + JSON flag; `--allow-incomplete` still exits 0 while default `INCOMPLETE` exits 2.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `resolve_schematic_for_pcb(...revA_v24.kicad_pcb)` returns the root `.kicad_sch` with a single sibling project | ✅ | `test_versioned_board_resolves_root_via_pro_pairing` |
| `kct check <board>_v24` runs ERC/LVS (not `NOT RUN`) | ✅ | `test_versioned_board_runs_lvs` (LVS status ≠ NOT RUN, `schematic_missing` False) |
| Precedence preserved: `project.kct` wins, exact stem wins, stage-suffix still works | ✅ | `TestPrecedencePreserved` (3 tests) |
| Ambiguity not silently resolved (≥2 roots, none matching → `None`) | ✅ | `TestAmbiguityGuard` (3 tests) |
| Loud stderr `WARNING` + JSON skipped-gate signal when no schematic found | ✅ | `test_no_schematic_warns_loudly_and_flags_json` |
| Default `INCOMPLETE` exits 2; `--allow-incomplete` exits 0 | ✅ | `test_allow_incomplete_still_exits_zero` |

## Test Plan
- `pytest tests/test_discover_schematic.py tests/test_netlist_sync_gate.py tests/test_check_cmd_coverage.py` → 42 passed.
- `pytest tests/test_board_05_drift_regression.py tests/test_pcb_sync_netlist.py` → 129 passed (drift path shares the helper; no regression).
- `ruff format --check .` and `ruff check .` clean; `mypy src/kicad_tools/sync/discover.py src/kicad_tools/cli/check_cmd.py` clean.

Closes #4350

🤖 Generated with [Claude Code](https://claude.com/claude-code)