### PR TITLE
fix: block value/footprint mismatches by default in --netlist-sync gate

### DIFF
--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -369,16 +369,35 @@ def run_netlist_sync_gate(
     footprint set, then prints a full add/drop/orphan report.
 
     Exit codes (mirroring ``kct check``'s convention):
-        0 - in sync, or only PCB-only/value/footprint drift without --strict
+        0 - in sync, or only PCB-only extras / suffix-note drift without
+            --strict
         1 - no schematic could be resolved (cannot run the gate)
-        2 - components present in the schematic are missing from the PCB
-            (unbuildable BOM), or any drift with --strict
+        2 - a matched component's value or footprint diverges from the
+            schematic (wrong part / wrong package placed), or a schematic
+            component is missing from the PCB (unbuildable BOM); also any
+            drift with --strict
+
+    Drift-axis policy (issue #4352):
+        schematic_orphans    -> exit 2 by default (unbuildable BOM)
+        value_mismatches     -> exit 2 by default (real, suffix notes excluded)
+        footprint_mismatches -> exit 2 by default (wrong package placed)
+        pcb_orphans          -> advisory (exit 0) unless --strict
+        value_suffix_notes   -> informational only, never affects the exit code
+
+    Value/footprint mismatches block by default because ``--netlist-sync`` is
+    documented as a *blocking* gate: a CI job wired on its exit status must
+    fail when the placed part set diverges from the schematic/BOM.  Benign
+    rating-suffix diffs ('100nF' vs '100nF 25V') are surfaced as informational
+    ``value_suffix_notes`` (issue #4351) and never counted in
+    ``value_mismatches``, so they do not trip this gate.  A recipe that wants
+    advisory-only value/footprint reporting should drop ``--netlist-sync`` and
+    rely on the plain ``kct check`` drift banner (same text, exit 0).
 
     Args:
         pcb_path: Path to the ``.kicad_pcb`` file.
         schematic: Optional explicit schematic path override.
-        strict: When True, any drift (including PCB-only/value/footprint)
-            yields exit code 2.
+        strict: When True, PCB-only extras also yield exit code 2 (i.e. any
+            drift is fatal).
     """
     from kicad_tools.sync.drift import analyze_drift, has_drift, render_drift_report
 
@@ -398,11 +417,15 @@ def run_netlist_sync_gate(
 
     print(render_drift_report(analysis, pcb_path, resolved))
 
-    # Schematic-only drift == unbuildable BOM == blocking (mirrors the
-    # auditor's NOT_READY verdict rule).  PCB-only / value / footprint drift
-    # is advisory unless --strict.
-    if analysis.schematic_orphans:
+    # Real component-identity drift is blocking by default (issue #4352):
+    # schematic-only (unbuildable BOM) OR a matched component whose value /
+    # footprint diverges (wrong part / wrong package placed).  Benign
+    # rating-suffix diffs are surfaced as value_suffix_notes (issue #4351)
+    # and already excluded from value_mismatches, so they never trip this.
+    if analysis.schematic_orphans or analysis.value_mismatches or analysis.footprint_mismatches:
         return 2
+    # PCB-only extras (test points, fiducials, DNP alternates) remain advisory
+    # unless the caller opts into --strict.
     if strict and has_drift(analysis):
         return 2
     return 0
@@ -1009,8 +1032,11 @@ def main(argv: list[str] | None = None) -> int:
             "Run a blocking schematic/PCB netlist-sync gate (issue #3154). "
             "Compares the schematic component set against the PCB footprint set "
             "via the Reconciler and prints a full add/drop/orphan report. Exits "
-            "with code 2 when components present in the schematic are missing "
-            "from the PCB (unbuildable BOM). PCB-only/value/footprint drift is a "
+            "with code 2 when a schematic component is missing from the PCB "
+            "(unbuildable BOM) OR a matched component's value or footprint "
+            "diverges (wrong part / wrong package placed). Benign rating-suffix "
+            "value diffs ('100nF' vs '100nF 25V', issue #4351) are "
+            "informational and do not fail the gate. PCB-only extras stay a "
             "warning unless --strict. Skips silently if no schematic is found."
         ),
     )

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -591,8 +591,12 @@ def _add_check_parser(subparsers) -> None:
         help=(
             "Run a blocking schematic/PCB netlist-sync gate (issue #3154): "
             "compares the schematic component set against the PCB footprint "
-            "set and exits with code 2 when schematic components are missing "
-            "from the PCB. Skips silently if no schematic is found."
+            "set and exits with code 2 when a schematic component is missing "
+            "from the PCB (unbuildable BOM) or a matched component's value or "
+            "footprint diverges (wrong part / wrong package). Benign "
+            "rating-suffix value diffs (issue #4351) do not fail the gate; "
+            "PCB-only extras stay a warning unless --strict. Skips silently "
+            "if no schematic is found."
         ),
     )
     check_parser.add_argument(

--- a/tests/test_netlist_sync_gate.py
+++ b/tests/test_netlist_sync_gate.py
@@ -31,7 +31,10 @@ sys.path.insert(0, str(Path(__file__).parent))
 from test_pcb_sync_netlist import (  # noqa: E402
     MINIMAL_PCB_MATCHING,
     MINIMAL_SCHEMATIC,
+    PCB_FOOTPRINT_MISMATCH,
     PCB_MISSING_R1,
+    PCB_VALUE_MISMATCH,
+    PCB_VALUE_SUFFIX_ONLY,
     PCB_WITH_ORPHAN,
 )
 
@@ -104,6 +107,39 @@ class TestNetlistSyncGate:
         assert "R1" in out
         assert "1 schematic-only" in out
         assert "OUT OF SYNC" in out
+
+    def test_value_mismatch_exits_nonzero_by_default(self, tmp_path, capsys):
+        # R1 value diverges (10k schematic vs 4.7k PCB): a real value mismatch
+        # must fail the blocking gate by default, no --strict required (#4352).
+        pcb = _write_pair(tmp_path, "board", MINIMAL_SCHEMATIC, PCB_VALUE_MISMATCH)
+        rc = check_main([str(pcb), "--netlist-sync"])
+        assert rc == 2
+        out = capsys.readouterr().out
+        assert "OUT OF SYNC" in out
+        assert "R1" in out
+        assert "1 value mismatch(es)" in out
+
+    def test_footprint_mismatch_exits_nonzero_by_default(self, tmp_path, capsys):
+        # C1 footprint diverges (C_0402 schematic vs C_0805 PCB): a real
+        # footprint mismatch must fail the blocking gate by default (#4352).
+        pcb = _write_pair(tmp_path, "board", MINIMAL_SCHEMATIC, PCB_FOOTPRINT_MISMATCH)
+        rc = check_main([str(pcb), "--netlist-sync"])
+        assert rc == 2
+        out = capsys.readouterr().out
+        assert "OUT OF SYNC" in out
+        assert "C1" in out
+        assert "1 footprint mismatch(es)" in out
+
+    def test_value_suffix_only_diff_stays_zero(self, tmp_path, capsys):
+        # C1 differs only by a benign rating suffix (100n vs 100n 25V): this is
+        # surfaced as an informational suffix note (#4351), NOT a value
+        # mismatch, so the gate must stay exit 0 (guards a #4351 regression).
+        pcb = _write_pair(tmp_path, "board", MINIMAL_SCHEMATIC, PCB_VALUE_SUFFIX_ONLY)
+        rc = check_main([str(pcb), "--netlist-sync"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "IN SYNC" in out
+        assert "C1" in out
 
     def test_in_sync_exits_zero(self, tmp_path, capsys):
         pcb = _write_pair(tmp_path, "board", MINIMAL_SCHEMATIC, MINIMAL_PCB_MATCHING)

--- a/tests/test_pcb_sync_netlist.py
+++ b/tests/test_pcb_sync_netlist.py
@@ -140,6 +140,103 @@ PCB_WITH_ORPHAN = """(kicad_pcb
 )
 """
 
+# PCB where R1's value diverges from the schematic (10k sch vs 4.7k pcb).
+# Same refs, same footprints -- a genuine value mismatch (wrong part placed).
+PCB_VALUE_MISMATCH = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (uuid "fp-r1")
+    (at 100 100)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "4.7k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 0 ""))
+  )
+  (footprint "Capacitor_SMD:C_0402"
+    (layer "F.Cu")
+    (uuid "fp-c1")
+    (at 120 100)
+    (property "Reference" "C1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "100n" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 0 ""))
+  )
+)
+"""
+
+# PCB where C1's footprint diverges from the schematic (C_0402 sch vs C_0805
+# pcb). Same refs, same values -- a genuine footprint mismatch (wrong package).
+PCB_FOOTPRINT_MISMATCH = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (uuid "fp-r1")
+    (at 100 100)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 0 ""))
+  )
+  (footprint "Capacitor_SMD:C_0805"
+    (layer "F.Cu")
+    (uuid "fp-c1")
+    (at 120 100)
+    (property "Reference" "C1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "100n" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 0 ""))
+  )
+)
+"""
+
+# PCB where C1 differs only by a benign rating suffix (100n sch vs 100n 25V
+# pcb). Surfaced as an informational value_suffix_note (issue #4351), NOT a
+# value_mismatch -- must not trip the blocking gate.
+PCB_VALUE_SUFFIX_ONLY = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (footprint "Resistor_SMD:R_0402"
+    (layer "F.Cu")
+    (uuid "fp-r1")
+    (at 100 100)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 0 ""))
+  )
+  (footprint "Capacitor_SMD:C_0402"
+    (layer "F.Cu")
+    (uuid "fp-c1")
+    (at 120 100)
+    (property "Reference" "C1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "100n 25V" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.5 0) (size 0.5 0.5) (layers "F.Cu") (net 0 ""))
+  )
+)
+"""
+
 # PCB with R99 (renamed to R1 in schematic)
 PCB_WITH_RENAMED_REF = """(kicad_pcb
   (version 20240108)


### PR DESCRIPTION
## Summary

`kct check --netlist-sync` is documented as a **blocking** schematic/PCB netlist-sync gate, but `run_netlist_sync_gate()` returned **exit 0** on real value and footprint mismatches — only schematic-only orphans (and the overloaded global `--strict`) drove exit 2. A CI job wired on the gate's exit status would green-light a board whose placed parts diverge from the schematic/BOM (the reported case: `U1` schematic `AP2112K-3.3` vs pcb `XC6206-3.3V` — a different regulator — and 0402→0805 package swaps).

This implements **Option A** from the curation: make real value/footprint mismatches block **by default** under `--netlist-sync`, with no new flag. Benign rating-suffix diffs stay advisory via the already-merged #4351 suffix-note exclusion.

## Changes

- `src/kicad_tools/cli/check_cmd.py` — `run_netlist_sync_gate()` now returns exit 2 by default when `value_mismatches` or `footprint_mismatches` is non-empty (in addition to `schematic_orphans`). PCB-only extras remain advisory unless `--strict`. Updated the docstring exit-code table + drift-axis policy and the `--netlist-sync` argparse help.
- `src/kicad_tools/cli/parser.py` — updated the `--netlist-sync` help text for the main `kct check` parser to document the new contract.
- `tests/test_pcb_sync_netlist.py` — added `PCB_VALUE_MISMATCH` (R1 10k→4.7k), `PCB_FOOTPRINT_MISMATCH` (C1 C_0402→C_0805), and `PCB_VALUE_SUFFIX_ONLY` (C1 100n vs 100n 25V) fixtures.
- `tests/test_netlist_sync_gate.py` — added gate assertions: exit 2 for real value + footprint mismatches, exit 0 for the suffix-only diff (guards a #4351 regression).

**Blast radius:** no in-repo consumer invokes `--netlist-sync` beyond the CLI forwarders (`validation.py`, `parser.py`) and tests — grepped `.github/`, `boards/`, and `examples/`. No board E2E job or CI workflow uses the flag, so no currently-green job turns red from this change.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Value mismatch → exit 2, names ref, prints OUT OF SYNC | ✅ | `test_value_mismatch_exits_nonzero_by_default` + manual CLI run (exit=2, `R1: schematic='10k' pcb='4.7k'`) |
| Real footprint mismatch → exit 2 | ✅ | `test_footprint_mismatch_exits_nonzero_by_default` (C1 C_0402 vs C_0805) |
| Suffix-only diff (100n vs 100n 25V) stays exit 0 | ✅ | `test_value_suffix_only_diff_stays_zero` (IN SYNC, informational note) |
| Schematic-only orphan still exit 2 | ✅ | `test_schematic_only_drift_exits_nonzero` (unchanged, passing) |
| In-sync board still exit 0 | ✅ | `test_in_sync_exits_zero` (unchanged, passing) |
| PCB-only orphan exit 0 without `--strict`, exit 2 with | ✅ | `test_pcb_only_orphan_nonfatal_without_strict` / `_fatal_with_strict` (unchanged, passing) |
| No schematic → exit 1 | ✅ | `test_no_schematic_exits_one` (unchanged, passing) |
| Help text updated in check_cmd.py + parser.py + docstring | ✅ | All three updated to state value/footprint mismatches block by default |

## Test Plan

- `uv run pytest tests/test_netlist_sync_gate.py tests/test_pcb_sync_netlist.py -q` → **152 passed**.
- `uv run ruff check` + `ruff format --check` on all 4 changed files → clean.
- mypy baseline (`scripts/ci/check_mypy_baseline.py`) → OK, no new type errors.
- Manual: `kct check <value-mismatch>.kicad_pcb --netlist-sync` → `OUT OF SYNC - 1 value mismatch(es)`, `exit=2`.

Closes #4352