### PR TITLE
fix: treat non-listed copper as a fixed obstacle for route --nets

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -8431,6 +8431,26 @@ def _resolve_route_only_nets(args, pcb_path: Path) -> int:
     # Marker: route-only mode.  The (large) inverted skip set must NOT be
     # forwarded as force_pour_nets (that would try to pour ~every net).
     args._route_only_nets = requested_unique
+
+    # Issue #4355: --nets promises (per --help) that every OTHER board net is a
+    # "fixed obstacle" -- its copper must be RETAINED in the output AND honored
+    # for clearance.  Both flow through the --preserve-existing machinery:
+    # ``load_existing_routes`` ingests the non-listed segment/via copper and the
+    # writer re-emits it verbatim (route_cmd.py `_write_routed_pcb`).  Without
+    # this, a plain ``--nets`` run is DESTRUCTIVE -- the skipped nets' copper is
+    # never loaded and never re-emitted, stranding the rest of the board as
+    # 1-pad islands.  Mirror how --region implies preserve-existing.  This is an
+    # IMPLICATION, not an override: an explicit ``--preserve-existing`` is a
+    # harmless no-op, so passing both is never an error.
+    already_preserving = bool(getattr(args, "preserve_existing", False))
+    args.preserve_existing = True
+    if not already_preserving and not getattr(args, "quiet", False):
+        print(
+            "Note: --nets implies --preserve-existing "
+            "(every non-listed net's copper is retained and treated as a fixed "
+            "obstacle).",
+            file=sys.stderr,
+        )
     return 0
 
 

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -2642,8 +2642,21 @@ class Autorouter:
         # coupled connections are present (issue #4270).  The default 8
         # is preserved exactly for pair-free boards.
         max_iterations = 12 if coupled else 8
+        # Issue #4355: the preserved copper of NON-listed nets
+        # (``existing_routes`` loaded under --preserve-existing / --nets /
+        # --region, keyed by their real net ids) must be a HARD clearance
+        # obstacle in the lattice -- not just marked on the legacy grid the
+        # lattice never consults.  Feed only the copper whose net is NOT in the
+        # routable set (``self.nets``): a listed net being re-routed replaces
+        # its own stale copper, so it must not fix itself in place.  Without
+        # this the lattice sees the non-listed pads but not the traces between
+        # them and legally crosses foreign copper -> segment-segment shorts.
+        fixed_copper = [r for r in self.existing_routes if r.net not in self.nets]
         routes_by_key, stats = pf.route_netset(
-            connections, coupled=coupled, max_iterations=max_iterations
+            connections,
+            coupled=coupled,
+            fixed_copper=fixed_copper,
+            max_iterations=max_iterations,
         )
         self._lattice_negotiation_stats = stats
 

--- a/src/kicad_tools/router/lattice/pathfinder.py
+++ b/src/kicad_tools/router/lattice/pathfinder.py
@@ -254,6 +254,16 @@ class LatticePathfinder:
         # Per-diff-pair outcome for the best pass: "coupled" or a decline
         # reason, keyed by ``CoupledConnection.key`` (issue #4270).
         self.pair_outcomes: dict[object, str] = {}
+        # Issue #4355: immovable copper from NON-listed nets (the preserved
+        # ``router.existing_routes``), pre-processed into per-segment seed
+        # tuples ``(layer_idx, a, b, net, half_width)`` plus via sites
+        # ``(point, net)``.  Every fresh CommittedCopper model is pre-seeded
+        # with these so a negotiated net spaces against the fixed copper as a
+        # HARD geometric block -- routes around it or is honestly reported
+        # unroutable, never shipped as a short.  Empty (the default) preserves
+        # the pre-#4355 behavior byte-for-byte.
+        self._fixed_runs: list[tuple[int, Pt, Pt, int, float]] = []
+        self._fixed_vias: list[tuple[Pt, int]] = []
 
     # -- construction from a board ----------------------------------------
 
@@ -360,7 +370,7 @@ class LatticePathfinder:
             return tuple(range(self.num_layers))
 
     def _fresh_committed(self) -> CommittedCopper:
-        return CommittedCopper(
+        committed = CommittedCopper(
             self.num_layers,
             trace_half=self._trace_half,
             clearance=self.rules.trace_clearance,
@@ -368,6 +378,61 @@ class LatticePathfinder:
             via_via_gap=self._via_via_gap,
             same_net_via_gap=self._same_net_via_gap,
         )
+        # Issue #4355: pre-seed immovable non-listed copper so EVERY fresh
+        # model (per-pass negotiation, isolated stub/pair probes, and the
+        # desired-corridor history bumps) spaces against it consistently.  The
+        # seed set is empty unless ``route_netset`` was given ``fixed_copper``,
+        # so this is a no-op on the pre-#4355 paths.
+        self._seed_fixed_copper(committed)
+        return committed
+
+    def _seed_fixed_copper(self, committed: CommittedCopper) -> None:
+        """Commit the preserved non-listed copper into ``committed`` (#4355).
+
+        Each preserved segment is committed under its OWN net id at its emitted
+        half-width and the board-global clearance floor -- a hard geometric
+        block that ``route_netset`` declines to cross (never shipped as a
+        short).  Same-net exemption in :meth:`CommittedCopper.seg_clear` means
+        seeding a listed net's own stale copper (if any slipped into the fixed
+        set) cannot block that net's fresh route.  Each preserved via seeds
+        ``committed.vias`` (a through-via blocks every layer).
+        """
+        clr = self.rules.trace_clearance
+        for layer_idx, a, b, net, half in self._fixed_runs:
+            committed.add_run(layer_idx, [a, b], net, half, clr)
+        for point, net in self._fixed_vias:
+            committed.add_via(point, net)
+
+    def _set_fixed_copper(self, routes: list[Route] | None) -> None:
+        """Pre-process preserved ``Route``s into flat seed tuples (#4355).
+
+        Called once by :meth:`route_netset`; maps each segment's layer enum to
+        a lattice layer index (dropping copper on non-routing layers) and each
+        via to a site.  ``None``/empty resets the seed set so a reused
+        pathfinder does not carry stale fixed copper.
+        """
+        runs: list[tuple[int, Pt, Pt, int, float]] = []
+        vias: list[tuple[Pt, int]] = []
+        for route in routes or []:
+            for seg in getattr(route, "segments", []):
+                try:
+                    layer_idx = self.layer_stack.layer_enum_to_index(seg.layer)
+                except Exception:
+                    # Copper on a layer outside this routing stack cannot
+                    # collide with a lattice trace; skip it silently.
+                    continue
+                if not (0 <= layer_idx < self.num_layers):
+                    continue
+                a = (seg.x1, seg.y1)
+                b = (seg.x2, seg.y2)
+                if dist(a, b) <= 1e-9:
+                    continue
+                half = (getattr(seg, "width", None) or self.rules.trace_width) / 2.0
+                runs.append((layer_idx, a, b, seg.net, half))
+            for via in getattr(route, "vias", []):
+                vias.append(((via.x, via.y), via.net))
+        self._fixed_runs = runs
+        self._fixed_vias = vias
 
     def _conn_geometry(self, net_class: object | None) -> tuple[float, float]:
         """Per-connection ``(trace half-width, clearance)`` (issue #4271).
@@ -1492,6 +1557,7 @@ class LatticePathfinder:
         connections: list[Connection],
         *,
         coupled: list[CoupledConnection] | None = None,
+        fixed_copper: list[Route] | None = None,
         max_iterations: int = 8,
         present_cost_initial: float = 1.0,
         present_cost_growth: float = 1.6,
@@ -1526,7 +1592,14 @@ class LatticePathfinder:
         Returns ``(routes_by_key, stats)`` for the best pass seen;
         :attr:`failure_reasons` carries the per-connection decline diagnosis
         for that pass.
+
+        Issue #4355: ``fixed_copper`` is the preserved copper of NON-listed
+        nets (``router.existing_routes`` minus the routable set).  It is
+        pre-seeded into every per-pass :class:`CommittedCopper` model as an
+        immovable hard obstacle, so a negotiated net routes AROUND it or is
+        honestly declined -- it is never emitted overlapping foreign copper.
         """
+        self._set_fixed_copper(fixed_copper)
         self.build()
         pairs = list(coupled or [])
 

--- a/tests/router/lattice/test_preserve_existing_obstacle.py
+++ b/tests/router/lattice/test_preserve_existing_obstacle.py
@@ -1,0 +1,165 @@
+"""Lattice honors preserved (non-listed) copper as a hard obstacle (#4355).
+
+Mode B of issue #4355: the lattice negotiation used to seed its clearance
+model from PADS ONLY -- it never ingested ``router.existing_routes``, so a
+newly-routed net legally crossed the preserved copper of a non-listed net and
+shipped a ``clearance_segment_segment`` SHORT.
+
+``LatticePathfinder.route_netset`` now accepts ``fixed_copper`` (the preserved
+``Route``s), pre-seeds each per-pass ``CommittedCopper`` with it as an immovable
+hard block, and therefore either routes AROUND the fixed copper or declines the
+connection as unroutable -- it never emits copper overlapping the fixed net.
+
+These are fast unit-level checks (a handful of pads, no full board or
+``kicad-cli``): they pin the seed contract that the CLI ``--nets`` /
+``--preserve-existing`` paths depend on.
+"""
+
+from __future__ import annotations
+
+from kicad_tools.router.lattice.geometry import seg_seg_dist
+from kicad_tools.router.lattice.pathfinder import LatticePathfinder
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.primitives import Pad, Route, Segment
+from kicad_tools.router.rules import DesignRules
+
+_OUTLINE = [(0.0, 0.0), (20.0, 0.0), (20.0, 20.0), (0.0, 20.0)]
+
+
+def _pad(x: float, y: float, net: int, *, ref: str) -> Pad:
+    return Pad(
+        x=x,
+        y=y,
+        width=1.0,
+        height=1.0,
+        net=net,
+        net_name=f"N{net}",
+        layer=Layer.F_CU,
+        ref=ref,
+        pin="1",
+    )
+
+
+def _wall_segment(layer: Layer, *, y1: float, y2: float, width: float = 0.5) -> Segment:
+    """A vertical foreign-net (net 2) copper wall at x=10 on ``layer``."""
+    return Segment(
+        x1=10.0,
+        y1=y1,
+        x2=10.0,
+        y2=y2,
+        width=width,
+        layer=layer,
+        net=2,
+        net_name="N2",
+    )
+
+
+def _shorts_against(
+    routes: dict[object, Route],
+    wall: Segment,
+    *,
+    trace_half: float,
+    clearance: float,
+) -> bool:
+    """True if any routed segment overlaps ``wall`` below the required gap.
+
+    Mirrors ``clearance_segment_segment``: a same-layer, cross-net segment whose
+    centreline distance to the wall is under ``trace_half + wall_half +
+    clearance`` is an emitted short.
+    """
+    wall_half = wall.width / 2.0
+    gap = trace_half + wall_half + clearance
+    wa = (wall.x1, wall.y1)
+    wb = (wall.x2, wall.y2)
+    for route in routes.values():
+        for seg in route.segments:
+            if seg.layer != wall.layer or seg.net == wall.net:
+                continue
+            d = seg_seg_dist((seg.x1, seg.y1), (seg.x2, seg.y2), wa, wb)
+            if d < gap - 1e-6:
+                return True
+    return False
+
+
+def _fixture():
+    rules = DesignRules()
+    stack = LayerStack.two_layer()
+    # Net 1: two pads straddling the wall at x=10; the shortest route is a
+    # straight F_CU trace at y=10 that crosses the wall dead-centre.
+    pads = [_pad(2.0, 10.0, 1, ref="A"), _pad(18.0, 10.0, 1, ref="B")]
+    conns = [((1, 0), pads[0], pads[1], None)]
+    return rules, stack, pads, conns
+
+
+def test_baseline_without_fixed_copper_shorts_through_wall() -> None:
+    """Without ``fixed_copper`` the straight route crosses the wall (the bug)."""
+    rules, stack, pads, conns = _fixture()
+    wall = _wall_segment(Layer.F_CU, y1=2.0, y2=18.0)
+
+    pf = LatticePathfinder(_OUTLINE, pads, rules, layer_stack=stack)
+    routes, stats = pf.route_netset(conns, max_iterations=6)
+
+    # The net routes (straight, shortest) and -- because the lattice never saw
+    # the wall's copper -- it crosses it: a segment-segment short.
+    assert stats.routed == 1
+    assert _shorts_against(
+        routes, wall, trace_half=rules.trace_width / 2.0, clearance=rules.trace_clearance
+    )
+
+
+def test_fixed_copper_prevents_short_through_preserved_net() -> None:
+    """Seeding the wall as ``fixed_copper`` -> the route detours; never a short."""
+    rules, stack, pads, conns = _fixture()
+    wall = _wall_segment(Layer.F_CU, y1=2.0, y2=18.0)
+
+    pf = LatticePathfinder(_OUTLINE, pads, rules, layer_stack=stack)
+    routes, _stats = pf.route_netset(
+        conns, fixed_copper=[Route(net=2, net_name="N2", segments=[wall])], max_iterations=6
+    )
+
+    # Whether the net detours (via to B_CU, across, back) or is declined, it is
+    # NEVER emitted overlapping the F_CU wall.
+    assert not _shorts_against(
+        routes, wall, trace_half=rules.trace_width / 2.0, clearance=rules.trace_clearance
+    )
+
+
+def test_fixed_copper_full_partition_declines_not_shorts() -> None:
+    """A wall on EVERY layer (no via detour) -> honest decline, not a short."""
+    rules, stack, pads, conns = _fixture()
+    # Full-height walls (beyond the board on both ends) on both routing layers:
+    # no same-layer detour and no via crossing is possible.
+    walls = [
+        _wall_segment(Layer.F_CU, y1=-2.0, y2=22.0),
+        _wall_segment(Layer.B_CU, y1=-2.0, y2=22.0),
+    ]
+    fixed = [Route(net=2, net_name="N2", segments=walls)]
+
+    pf = LatticePathfinder(_OUTLINE, pads, rules, layer_stack=stack)
+    routes, stats = pf.route_netset(conns, fixed_copper=fixed, max_iterations=6)
+
+    # Reported unroutable rather than shorted.
+    assert stats.routed == 0
+    for wall in walls:
+        assert not _shorts_against(
+            routes, wall, trace_half=rules.trace_width / 2.0, clearance=rules.trace_clearance
+        )
+
+
+def test_fixed_copper_empty_is_byte_identical_noop() -> None:
+    """``fixed_copper=None`` / ``[]`` leaves negotiation exactly as before."""
+    rules, stack, pads, conns = _fixture()
+
+    pf_none = LatticePathfinder(_OUTLINE, pads, rules, layer_stack=stack)
+    routes_none, stats_none = pf_none.route_netset(conns, max_iterations=6)
+
+    pf_empty = LatticePathfinder(_OUTLINE, pads, rules, layer_stack=stack)
+    routes_empty, stats_empty = pf_empty.route_netset(conns, fixed_copper=[], max_iterations=6)
+
+    assert stats_none.routed == stats_empty.routed == 1
+    # Same key set and same emitted geometry (the seed set is empty either way).
+    assert routes_none.keys() == routes_empty.keys()
+    for key in routes_none:
+        segs_a = [(s.x1, s.y1, s.x2, s.y2, s.layer) for s in routes_none[key].segments]
+        segs_b = [(s.x1, s.y1, s.x2, s.y2, s.layer) for s in routes_empty[key].segments]
+        assert segs_a == segs_b

--- a/tests/test_cli_route_nets_flag.py
+++ b/tests/test_cli_route_nets_flag.py
@@ -189,6 +189,62 @@ def test_nets_sub_two_pad_net_is_reported(fake_board, capsys):
 
 
 # ---------------------------------------------------------------------------
+# Issue #4355: --nets must RETAIN all non-listed copper (imply preserve-existing)
+#
+# Without this, a plain ``--nets`` run is destructive -- the skipped nets' copper
+# is never loaded and never re-emitted, stranding the rest of the board as 1-pad
+# islands.  Retention flows through the --preserve-existing load + re-emit path,
+# so --nets must imply it.
+# ---------------------------------------------------------------------------
+def test_nets_implies_preserve_existing(fake_board, capsys):
+    """``--nets`` sets ``preserve_existing`` so non-listed copper is retained."""
+    from pathlib import Path
+
+    from kicad_tools.cli.route_cmd import _resolve_route_only_nets
+
+    args = _route_args(nets="/A,/B", preserve_existing=False, quiet=False)
+    rc = _resolve_route_only_nets(args, Path("dummy.kicad_pcb"))
+
+    assert rc == 0
+    assert args.preserve_existing is True
+    # The implied flag is visible (non-quiet).
+    assert "implies --preserve-existing" in capsys.readouterr().err
+
+
+def test_nets_with_explicit_preserve_existing_is_noop(fake_board, capsys):
+    """Passing ``--preserve-existing`` alongside ``--nets`` is not an error.
+
+    The implication is a no-op when the flag is already set, and no redundant
+    notice is printed.
+    """
+    from pathlib import Path
+
+    from kicad_tools.cli.route_cmd import _resolve_route_only_nets
+
+    args = _route_args(nets="/A,/B", preserve_existing=True, quiet=False)
+    rc = _resolve_route_only_nets(args, Path("dummy.kicad_pcb"))
+
+    assert rc == 0
+    assert args.preserve_existing is True
+    # Already preserving -> no duplicate implied-flag notice.
+    assert "implies --preserve-existing" not in capsys.readouterr().err
+
+
+def test_nets_quiet_suppresses_implied_flag_notice(fake_board, capsys):
+    """``--quiet`` suppresses the implied-flag notice but still sets the flag."""
+    from pathlib import Path
+
+    from kicad_tools.cli.route_cmd import _resolve_route_only_nets
+
+    args = _route_args(nets="/A,/B", preserve_existing=False, quiet=True)
+    rc = _resolve_route_only_nets(args, Path("dummy.kicad_pcb"))
+
+    assert rc == 0
+    assert args.preserve_existing is True
+    assert "implies --preserve-existing" not in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
 # Parser wiring (drift-adjacent): --nets present on both route parsers + shim.
 # ---------------------------------------------------------------------------
 def test_nets_flag_on_outer_route_parser():


### PR DESCRIPTION
## Summary

`kct route --nets N[,N...]` on an already-routed board contradicted its own
`--help` ("treat every OTHER board net as a fixed obstacle") in two independent
ways. This PR fixes both so non-listed nets' copper is retained in the output
AND respected for clearance -- listed nets route around it or are reported
unroutable, never dropped and never shorted.

## Changes

**Mode A (drop) -- `--nets` now implies `--preserve-existing`.**
`_resolve_route_only_nets` (route_cmd.py) inverted `--nets` into `--skip-nets`
but never set `preserve_existing`, so the skipped nets' copper was neither
loaded nor re-emitted -- a plain `--nets` run silently stranded the rest of the
board as 1-pad islands. It now sets `args.preserve_existing = True` (mirroring
how `--region` already does), routing the non-listed copper through the existing
load + re-emit path. It is an *implication*, not an override: an explicit
`--preserve-existing` is a no-op (passing both is not an error), and a one-line
notice is printed unless `--quiet`.

**Mode B (short) -- the lattice engine now honors preserved copper.**
The lattice negotiation seeded its clearance model from PADS ONLY; it never
ingested `router.existing_routes`, so a newly-routed net legally crossed a
non-listed net's preserved copper and emitted a `clearance_segment_segment`
SHORT. `LatticePathfinder.route_netset` gains a `fixed_copper` argument;
`core._negotiate_lattice_netset` passes the preserved copper of nets NOT in the
routable set (`self.nets`), and every per-pass `CommittedCopper` model is
pre-seeded with it as an immovable hard block. A listed net that cannot avoid it
is honestly declined instead of shorted. Empty `fixed_copper` is a
byte-identical no-op.

- `src/kicad_tools/cli/route_cmd.py` -- `--nets` implies `--preserve-existing` + notice.
- `src/kicad_tools/router/core.py` -- feed non-listed `existing_routes` into `route_netset`.
- `src/kicad_tools/router/lattice/pathfinder.py` -- `fixed_copper` seed threaded through every `_fresh_committed()`.
- `tests/test_cli_route_nets_flag.py` -- Mode A implication + no-op + quiet cases.
- `tests/router/lattice/test_preserve_existing_obstacle.py` -- Mode B: baseline reproduces the short; seed prevents it; full-partition declines; empty is a no-op.

The grid engine already inflates a clearance halo for loaded copper via
`grid.mark_route`, so Fix 1 alone closes Mode B there -- consistent grid+lattice
behavior. Mesh parity is a documented follow-up (its `existing_routes` is
seeded the same way), not touched here to keep this a single reviewable PR.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `--nets` retains ALL non-listed copper (no new 1-pad islands) | ✅ | `--nets` sets `preserve_existing`; retention flows through the unchanged load + re-emit path. New CLI tests assert the flag + notice. |
| Non-listed copper is a HARD lattice obstacle (route around or unroutable, never shorted) | ✅ | `test_fixed_copper_prevents_short_through_preserved_net` (detours), `test_fixed_copper_full_partition_declines_not_shorts` (honest decline); baseline test proves the short exists without the seed. |
| `--nets` implies `--preserve-existing`; both together not an error; notice printed | ✅ | `test_nets_implies_preserve_existing`, `test_nets_with_explicit_preserve_existing_is_noop`, `test_nets_quiet_suppresses_implied_flag_notice`. |
| Consistent for `--route-engine grid` and `lattice`; mesh a follow-up | ✅ | Grid honors loaded copper via `grid.mark_route` (Fix 1 enables load); lattice via Fix 2. |
| `--skip-nets` / `--region` / full-reroute unchanged | ✅ | Empty `fixed_copper` is byte-identical (`test_fixed_copper_empty_is_byte_identical_noop`); region + negotiation suites (77) and lattice + preserve-existing suites (133) green. |

## Test Plan

- `tests/router/lattice/test_preserve_existing_obstacle.py` + `tests/test_cli_route_nets_flag.py`: 27 passed.
- `tests/router/lattice/` + `tests/router/test_preserve_existing.py`: 133 passed, 2 skipped.
- `tests/router/test_region_bounded.py`, `test_region_resolve.py`, `test_route_zones_preserved.py`, `test_route_cmd_input_preservation.py`, `test_negotiated_ripup.py`: 77 passed.
- ruff check + format: clean. mypy baseline gate: no new type errors.
- C++ backend built in the worktree (`kct build-native`); the fixed path is pure-Python lattice.

Closes #4355