### PR TITLE
fix: guard creepage/audit against silent HV false-pass on mains boards

### DIFF
--- a/src/kicad_tools/audit/auditor.py
+++ b/src/kicad_tools/audit/auditor.py
@@ -248,7 +248,14 @@ class IsolationStatus:
     * ``could_not_verify=True`` -- shapely is unavailable or a standard-table
       lookup failed; HV present but not evaluated -> ``WARNING`` (fail-loud,
       never a hard crash of the whole audit).
-    * ``hv_present=False`` -- no HV-class nets; inert, no verdict change.
+    * ``mains_suspected_unclassified=True`` (issue #4354) -- HV-net resolution
+      returned EMPTY, but the board carries mains-named copper (or a mains-level
+      working voltage was supplied), so the HV path was never evaluated ->
+      ``NOT_READY`` (hard fail).  This is the direct analog of the LVS
+      zero-bound-pad vacuity guard (#4011): a mains board with an un-evaluated
+      HV path must not ship.
+    * ``hv_present=False`` and NOT mains-suspected -- no HV-class nets on a
+      genuinely low-voltage board; inert, no verdict change.
     """
 
     # Whether HV nets were present AND a threshold source was supplied AND the
@@ -260,6 +267,12 @@ class IsolationStatus:
     threshold_supplied: bool = False
     # HV present but could not be evaluated (shapely absent / lookup error).
     could_not_verify: bool = False
+    # Zero HV nets resolved on a board that looks like mains/HV (issue #4354).
+    # Hard-gates the verdict to NOT_READY -- an un-evaluated HV path is a
+    # safety-gate false pass, never a silent skip.
+    mains_suspected_unclassified: bool = False
+    # Net names that tripped the mains/HV suspicion (for the report + provenance).
+    mains_suspect_nets: list[str] = field(default_factory=list)
     passed: bool = True
     hv_nets: list[str] = field(default_factory=list)
     pair_count: int = 0
@@ -281,6 +294,8 @@ class IsolationStatus:
             "hv_present": self.hv_present,
             "threshold_supplied": self.threshold_supplied,
             "could_not_verify": self.could_not_verify,
+            "mains_suspected_unclassified": self.mains_suspected_unclassified,
+            "mains_suspect_nets": list(self.mains_suspect_nets),
             "passed": self.passed,
             "hv_nets": list(self.hv_nets),
             "pair_count": self.pair_count,
@@ -388,6 +403,14 @@ class AuditResult:
         # governing creepage/clearance bound is a manufacturing-blocking defect
         # -- fold it into NOT_READY so ``kct audit`` exits 2 (the gate FAILs).
         if self.isolation.checked and not self.isolation.passed:
+            return AuditVerdict.NOT_READY
+
+        # HV / isolation vacuity hard fail (issue #4354): HV-net resolution
+        # returned EMPTY on a board that looks like mains/HV -- the insulation
+        # path was never evaluated.  Treat it exactly like the LVS zero-bound
+        # vacuity guard (#4011): un-evaluated safety evidence is a hard FAIL,
+        # NOT a silent skip.
+        if self.isolation.mains_suspected_unclassified:
             return AuditVerdict.NOT_READY
 
         # Schematic refs missing from PCB == unbuildable BOM == hard fail.
@@ -1232,7 +1255,41 @@ class ManufacturingAudit:
             return status
 
         if not hv_nets:
-            # No HV-class nets -> inert; no section, no verdict change.
+            # Vacuity guard (issue #4354): an empty HV group is only legitimately
+            # "inert" on a genuinely low-voltage board.  When the board carries
+            # mains-named copper OR a mains-level working voltage was supplied,
+            # the HV insulation path was never evaluated -- a safety-gate false
+            # pass.  Hard-fail the verdict (mirrors the LVS zero-bound guard,
+            # #4011) rather than silently reporting READY.
+            from kicad_tools.creepage.engine import (
+                SELV_WORKING_VOLTAGE_V,
+                mains_suspect_nets,
+            )
+
+            suspects = mains_suspect_nets(pcb)
+            wv = self.hv_working_voltage
+            high_working_voltage = wv is not None and float(wv) >= SELV_WORKING_VOLTAGE_V
+            if suspects or high_working_voltage:
+                status.mains_suspected_unclassified = True
+                status.mains_suspect_nets = suspects
+                reasons = []
+                if suspects:
+                    shown = ", ".join(suspects[:8])
+                    more = "" if len(suspects) <= 8 else f" (+{len(suspects) - 8} more)"
+                    reasons.append(f"mains-named nets present ({shown}{more})")
+                if high_working_voltage and wv is not None:
+                    reasons.append(
+                        f"working voltage {float(wv):g} V >= "
+                        f"{SELV_WORKING_VOLTAGE_V:g} V SELV boundary"
+                    )
+                status.details = (
+                    f"0 '{self.hv_net_class}' nets resolved but the board looks "
+                    f"like mains/HV ({'; '.join(reasons)}) -- the HV insulation "
+                    "path was NOT evaluated.  Map the mains nets to the HV class "
+                    "(--net-class-map) or set --hv-net-class.  NOT_READY."
+                )
+                return status
+            # No HV-class nets on a genuinely low-voltage board -> inert.
             status.details = f"No '{self.hv_net_class}' nets found -- HV/isolation audit skipped."
             return status
 

--- a/src/kicad_tools/cli/audit_cmd.py
+++ b/src/kicad_tools/cli/audit_cmd.py
@@ -394,9 +394,10 @@ def output_table(result: AuditResult, verbose: bool = False) -> None:
         layers_icon = "OK" if layers[2] else "X"
         print(f"    [{layers_icon}] Layers: {layers[0]} (supported: {layers[1]})")
 
-    # HV / Isolation (creepage) -- only when HV nets were present (Issue #4333).
+    # HV / Isolation (creepage) -- when HV nets were present (Issue #4333) OR
+    # when the mains-suspect vacuity guard fired on an empty HV group (#4354).
     iso = result.isolation
-    if iso.hv_present:
+    if iso.hv_present or getattr(iso, "mains_suspected_unclassified", False):
         _output_isolation_section(iso)
 
     # Layer utilization
@@ -446,6 +447,22 @@ def _output_isolation_section(iso) -> None:
     against the IEC-derived (or manual) required values with distinct margins,
     plus the governing standard citation and the standards DISCLAIMER.
     """
+    # Vacuity guard (issue #4354): 0 HV nets resolved on a mains-looking board.
+    # This is a hard FAIL (NOT_READY), rendered before the normal states so the
+    # report explains why an apparently HV-free board is not shippable.
+    if getattr(iso, "mains_suspected_unclassified", False):
+        print("\n[X] HV / Isolation (creepage): FAIL (mains nets unclassified)")
+        suspects = getattr(iso, "mains_suspect_nets", []) or []
+        if suspects:
+            shown = ", ".join(suspects[:8])
+            more = "" if len(suspects) <= 8 else f" (+{len(suspects) - 8} more)"
+            print(f"    Mains/HV-suspect nets: {shown}{more}")
+        else:
+            print("    Mains/HV working voltage supplied but 0 HV nets classified.")
+        if iso.details:
+            print(f"    Note: {iso.details}")
+        return
+
     if iso.could_not_verify:
         icon, verdict = "!!", "COULD NOT VERIFY"
     elif not iso.threshold_supplied:
@@ -546,7 +563,9 @@ def output_summary(result: AuditResult) -> None:
         )
     print(f"  Net completion: {summary['net_completion']:.0f}%")
     print(f"  Manufacturer compatible: {'Yes' if summary['manufacturer_compatible'] else 'No'}")
-    if result.isolation.hv_present:
+    if getattr(result.isolation, "mains_suspected_unclassified", False):
+        print("  HV isolation: FAIL (mains nets unclassified)")
+    elif result.isolation.hv_present:
         if result.isolation.checked:
             iso_state = "PASS" if result.isolation.passed else "FAIL"
         elif result.isolation.could_not_verify:

--- a/src/kicad_tools/cli/commands/creepage.py
+++ b/src/kicad_tools/cli/commands/creepage.py
@@ -31,11 +31,22 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from kicad_tools.creepage.engine import CreepageReport
 
+# Distinct exit code for "could not classify any HV net on a board that looks
+# like mains" (issue #4354).  Kept separate from 1 ("a measured pair failed its
+# bound") so CI / agent gates can tell an unclassifiable-HV vacuity from a real
+# creepage failure.
+EXIT_HV_UNCLASSIFIED = 2
+
 
 def run_creepage_command(args) -> int:
     """Handle the ``creepage`` command.  Returns the process exit code."""
     from kicad_tools._shapely import has_shapely
-    from kicad_tools.creepage.engine import compute_creepage_census, resolve_hv_nets
+    from kicad_tools.creepage.engine import (
+        SELV_WORKING_VOLTAGE_V,
+        compute_creepage_census,
+        mains_suspect_nets,
+        resolve_hv_nets,
+    )
     from kicad_tools.creepage.standards import (
         RMS_TO_PEAK,
         StandardLookupError,
@@ -144,19 +155,75 @@ def run_creepage_command(args) -> int:
         clearance_provenance=clearance_prov,
     )
 
+    # Vacuity guard (issue #4354): a census that resolves ZERO HV nets is only
+    # legitimately "nothing to audit" on a genuinely low-voltage board.  When
+    # the board carries mains-named copper OR a mains-level working voltage was
+    # supplied, an empty HV group means the HV path was never evaluated -- a
+    # safety-gate FALSE PASS.  Fire loud and exit non-zero (distinct code) so
+    # this is never mistaken for a clean board.
+    mains_suspects: list[str] = []
+    guard_triggered = False
+    if not report.has_hv_nets:
+        mains_suspects = mains_suspect_nets(pcb)
+        high_working_voltage = (
+            working_voltage is not None and float(working_voltage) >= SELV_WORKING_VOLTAGE_V
+        )
+        guard_triggered = bool(mains_suspects) or high_working_voltage
+
     if fmt == "json":
         print(json.dumps(report.to_dict(), indent=2))
     elif report.uses_standard:
-        _render_table_standard(report)
+        _render_table_standard(report, guard_triggered=guard_triggered)
     else:
-        _render_table(report)
+        _render_table(report, guard_triggered=guard_triggered)
+
+    if guard_triggered:
+        _warn_hv_unclassified(report, mains_suspects, working_voltage)
+        return EXIT_HV_UNCLASSIFIED
 
     # Non-zero exit iff any pair fails its governing bound(s).  An empty census
-    # (no HV nets, or HV nets with no neighbors) is a clean exit 0.
+    # on a genuinely low-voltage board (no mains names, no HV working voltage)
+    # is a clean exit 0.
     return 0 if report.passed else 1
 
 
-def _render_table(report: CreepageReport) -> None:
+def _warn_hv_unclassified(
+    report: CreepageReport,
+    mains_suspects: list[str],
+    working_voltage: float | None,
+) -> None:
+    """Loud stderr warning when the HV group is empty on a mains-looking board."""
+    from kicad_tools.creepage.engine import SELV_WORKING_VOLTAGE_V
+
+    print(
+        "WARNING: creepage resolved 0 HV nets, but this board looks like a "
+        "mains/HV design -- the HV insulation path was NOT evaluated.",
+        file=sys.stderr,
+    )
+    if mains_suspects:
+        shown = ", ".join(mains_suspects[:12])
+        more = "" if len(mains_suspects) <= 12 else f" (+{len(mains_suspects) - 12} more)"
+        print(f"  Mains/HV-suspect nets on the board: {shown}{more}", file=sys.stderr)
+    if working_voltage is not None and float(working_voltage) >= SELV_WORKING_VOLTAGE_V:
+        print(
+            f"  Working voltage {float(working_voltage):g} V is at/above the "
+            f"{SELV_WORKING_VOLTAGE_V:g} V SELV boundary -- an HV path is implied.",
+            file=sys.stderr,
+        )
+    print(
+        f"  None of these nets were classified as '{report.net_class}'.  Supply "
+        "--net-class-map (mapping the mains nets to the HV class) or --net-class "
+        "so the census can actually audit them.",
+        file=sys.stderr,
+    )
+    print(
+        f"  Exiting {EXIT_HV_UNCLASSIFIED} (HV-unclassified) rather than 0 to "
+        "avoid a safety-gate false pass.",
+        file=sys.stderr,
+    )
+
+
+def _render_table(report: CreepageReport, *, guard_triggered: bool = False) -> None:
     """Print the human-readable census table (phase-1 / manual --min mode)."""
     if not report.has_hv_nets:
         print(
@@ -164,7 +231,15 @@ def _render_table(report: CreepageReport) -> None:
             "(supply --net-class-map to classify HV nets, or check --net-class)."
         )
         print(f"Board: {report.board}")
-        print("Census: 0 pairs.  Nothing to audit -- exit 0.")
+        if guard_triggered:
+            # #4354: mains-looking board with an empty HV group -- do NOT claim
+            # a clean exit; the loud WARNING + non-zero exit follow.
+            print(
+                "Census: 0 pairs, but the board looks like mains/HV -- "
+                "HV classification FAILED (see WARNING below)."
+            )
+        else:
+            print("Census: 0 pairs.  Nothing to audit -- exit 0.")
         return
 
     print(f"HV creepage/clearance census  (net-class '{report.net_class}')")
@@ -200,7 +275,7 @@ def _render_table(report: CreepageReport) -> None:
         print(f"PASS: all {total} pair(s) clear {report.min_mm:.3f} mm creepage.")
 
 
-def _render_table_standard(report: CreepageReport) -> None:
+def _render_table_standard(report: CreepageReport, *, guard_triggered: bool = False) -> None:
     """Print the census table with IEC-derived requirements (phase-2 mode)."""
     from kicad_tools.creepage.standards import DISCLAIMER
 
@@ -210,7 +285,15 @@ def _render_table_standard(report: CreepageReport) -> None:
             "(supply --net-class-map to classify HV nets, or check --net-class)."
         )
         print(f"Board: {report.board}")
-        print("Census: 0 pairs.  Nothing to audit -- exit 0.")
+        if guard_triggered:
+            # #4354: mains-looking board with an empty HV group -- do NOT claim
+            # a clean exit; the loud WARNING + non-zero exit follow.
+            print(
+                "Census: 0 pairs, but the board looks like mains/HV -- "
+                "HV classification FAILED (see WARNING below)."
+            )
+        else:
+            print("Census: 0 pairs.  Nothing to audit -- exit 0.")
         return
 
     cp = report.creepage_provenance or {}

--- a/src/kicad_tools/creepage/engine.py
+++ b/src/kicad_tools/creepage/engine.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import heapq
 import math
+import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -54,6 +55,50 @@ _INTERIOR_SHRINK = 1e-6  # shrink a slot before the "crosses interior" test
 # A pair is a PASS when creepage >= min within this tolerance (mm).  Mirrors
 # the spirit of DRC_TOLERANCE -- a sub-micron shortfall is not a real defect.
 _PASS_TOLERANCE = 1e-4
+
+# IEC 60664-1 SELV boundary: below ~50 V RMS a design is not a mains/HV
+# safety concern.  A working-voltage argument at or above this threshold is a
+# strong signal that the operator IS analysing a mains/HV insulation path, so
+# a census that resolves ZERO HV nets at such a voltage is a vacuity red flag
+# (issue #4354) rather than an inert "nothing to audit" -- the same contract as
+# the LVS zero-bound-pad guard (#4011).
+SELV_WORKING_VOLTAGE_V = 50.0
+
+# Strong mains/HV net-name signals (case-insensitive, whole-token boundaries so
+# substrings like ONLINE / REMAINS / GND do NOT trip).  Used both to broaden the
+# HV name-pattern fallback (the ``NetClass`` enum deliberately has no HV member,
+# so :func:`classify_from_name` can never return ``"HV"``) and to power the
+# vacuity guard (issue #4354).  Net names frequently carry a leading ``/``
+# (hierarchical sheet path), so ``/`` is an accepted token boundary.
+MAINS_NAME_RE = re.compile(
+    r"(?:^|[_/])"
+    r"(?:"
+    r"AC[_-]?LINE|AC[_-]?NEUT(?:RAL)?|L[_-]?LINE|N[_-]?LINE|LINE(?:_IN)?|"
+    r"LIVE|NEUTRAL|MAINS|FUSED(?:_[A-Z0-9]+)?|HV[_A-Z0-9]*|PRIMARY|HOT"
+    r")"
+    r"(?:$|[_/])",
+    re.IGNORECASE,
+)
+
+
+def is_mains_suspect_name(name: str | None) -> bool:
+    """True when ``name`` carries a strong mains/HV signal (see MAINS_NAME_RE)."""
+    return bool(name) and MAINS_NAME_RE.search(name) is not None  # type: ignore[arg-type]
+
+
+def mains_suspect_nets(pcb: PCB) -> list[str]:
+    """Sorted board net names that strongly imply a mains/HV conductor.
+
+    Powers the issue #4354 vacuity guard: when HV-net *resolution* returns
+    empty but the board clearly carries mains-named copper, the creepage census
+    must NOT silently pass -- the operator most likely just needs a
+    ``--net-class-map`` (or ``--net-class``) that actually names the HV group.
+    """
+    return sorted(
+        n.name
+        for n in pcb.nets.values()
+        if n.number != 0 and n.name and MAINS_NAME_RE.search(n.name)
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -281,9 +326,16 @@ def resolve_hv_nets(
     2. **Name-pattern fallback** -- for any net NOT resolved by the map, the
        existing :func:`kicad_tools.router.net_class.classify_from_name` is
        consulted and its :class:`NetClass` value compared to ``net_class``
-       (case-insensitive).  This lets ``--net-class power`` work without a map
-       while ``--net-class HV`` (which has no built-in pattern) relies on the
-       map, exactly as the phase-1 spec intends.
+       (case-insensitive).  This lets ``--net-class power`` work without a map.
+    3. **Mains/HV name fallback** -- when ``net_class`` is ``HV`` (the default),
+       the :class:`NetClass` enum has no HV member, so ``classify_from_name``
+       can never return ``"HV"`` and step 2 is unreachable for the HV group
+       (issue #4354).  Any unmapped net whose name carries a strong mains/HV
+       signal (:data:`MAINS_NAME_RE` -- ``AC_LINE``, ``AC_NEUTRAL``,
+       ``FUSED_LINE``, ``*MAINS*``, ``HV*``, ``LIVE``, ``NEUTRAL``,
+       ``PRIMARY`` ...) is therefore selected here.  An explicit map entry
+       always wins (step 1), so operator-supplied classification is never
+       overridden by this fallback.
     """
     from kicad_tools.router.net_class import classify_from_name
 
@@ -302,6 +354,11 @@ def resolve_hv_nets(
         # Name-pattern fallback for nets not covered by the map.
         classification = classify_from_name(net.name)
         if classification is not None and classification.value.strip().lower() == target:
+            selected[net.number] = net.name
+            continue
+        # Broadened mains/HV fallback for the HV group (issue #4354): there is
+        # no NetClass.HV, so classify_from_name never yields "hv" above.
+        if target == "hv" and MAINS_NAME_RE.search(net.name):
             selected[net.number] = net.name
     return selected
 

--- a/tests/creepage/fixtures.py
+++ b/tests/creepage/fixtures.py
@@ -97,3 +97,44 @@ def board_no_hv_source() -> str:
     parts.append(_footprint("U2", 130, 110, 2, "GND"))
     parts.append(")\n")
     return "".join(parts)
+
+
+# Header for the mains-named fixture: unmistakable mains net names (AC_LINE /
+# AC_NEUTRAL / FUSED_LINE) that the broadened HV name-pattern fallback (#4354)
+# must classify as HV without any net-class-map.
+_MAINS_HEADER = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test_creepage")
+  (general (thickness 1.6))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "AC_LINE")
+  (net 2 "GND")
+  (net 3 "AC_NEUTRAL")
+  (net 4 "FUSED_LINE")
+"""
+
+
+def board_mains_named_source() -> str:
+    """Board with mains net names (``AC_LINE`` / ``AC_NEUTRAL`` / ``FUSED_LINE``).
+
+    Deliberately ships **no** net-class-map so the broadened HV name-pattern
+    fallback (issue #4354) is the only thing that can classify the mains nets.
+    ``AC_LINE`` (x=110) and ``GND`` (x=113) sit ~1 mm apart -- far below any
+    realistic mains creepage requirement -- so once the fallback classifies the
+    mains nets the resulting census FAILS (rather than silently exiting 0).
+    """
+    parts = [_MAINS_HEADER, _OUTLINE]
+    parts.append(_footprint("U1", 110, 110, 1, "AC_LINE"))
+    parts.append(_footprint("U2", 113, 110, 2, "GND"))
+    parts.append(_footprint("U3", 135, 110, 3, "AC_NEUTRAL"))
+    parts.append(_footprint("U4", 105, 110, 4, "FUSED_LINE"))
+    parts.append(")\n")
+    return "".join(parts)

--- a/tests/creepage/test_creepage_cli.py
+++ b/tests/creepage/test_creepage_cli.py
@@ -16,7 +16,7 @@ from kicad_tools._shapely import has_shapely
 from kicad_tools.cli.commands.creepage import run_creepage_command
 from kicad_tools.cli.parser import create_parser
 
-from .fixtures import board_no_hv_source, board_source
+from .fixtures import board_mains_named_source, board_no_hv_source, board_source
 
 pytestmark = pytest.mark.skipif(not has_shapely(), reason="creepage requires shapely")
 
@@ -121,6 +121,123 @@ def test_no_hv_nets_json_empty_census(tmp_path, capsys):
     assert payload["pairs"] == []
     assert payload["pair_count"] == 0
     assert payload["passed"] is True
+
+
+# ---------------------------------------------------------------------------
+# #4354 vacuity guard: a mains-looking board must never silently exit 0.
+# ---------------------------------------------------------------------------
+
+
+def test_mains_named_board_no_map_exits_nonzero(tmp_path, capsys):
+    # Realistic invocation #1 from the report: NO net-class-map.  The broadened
+    # HV name fallback classifies AC_LINE/AC_NEUTRAL/FUSED_LINE, the ~1 mm
+    # AC_LINE<->GND gap fails the 250 V IIIa/PD2 requirement -> exit 1 (a real
+    # measured failure), NOT a silent exit 0.
+    pcb = _write(tmp_path, board_mains_named_source())
+    rc = _run(
+        [
+            "creepage",
+            str(pcb),
+            "--standard",
+            "iec60664",
+            "--working-voltage",
+            "250",
+            "--pollution-degree",
+            "2",
+            "--material-group",
+            "IIIa",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc != 0
+    assert "Nothing to audit -- exit 0" not in captured.out
+    # The mains nets were actually classified and audited.
+    assert "AC_LINE" in captured.out
+
+
+def test_generic_map_hiding_mains_fires_vacuity_guard(tmp_path, capsys):
+    # Realistic invocation #2 from the report: a GENERIC net-class-map that
+    # names Power/Digital but never HV.  The mains nets are mapped away from HV,
+    # so 0 HV nets resolve -- but the board is obviously mains, so the vacuity
+    # guard fires with the distinct exit code 2 (NOT a silent 0).
+    pcb = _write(tmp_path, board_mains_named_source())
+    gmap = tmp_path / "generic_map.json"
+    gmap.write_text(
+        json.dumps(
+            {
+                "AC_LINE": {"name": "Power"},
+                "AC_NEUTRAL": {"name": "Power"},
+                "FUSED_LINE": {"name": "Power"},
+            }
+        )
+    )
+    rc = _run(
+        [
+            "creepage",
+            str(pcb),
+            "--net-class-map",
+            str(gmap),
+            "--standard",
+            "iec60664",
+            "--working-voltage",
+            "250",
+            "--pollution-degree",
+            "2",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 2  # distinct "HV unclassified" code, not 0 and not 1
+    assert "Nothing to audit -- exit 0" not in captured.out
+    assert "WARNING" in captured.err
+    assert "AC_LINE" in captured.err
+    assert "--net-class-map" in captured.err
+
+
+def test_high_working_voltage_without_mains_names_fires_guard(tmp_path, capsys):
+    # The repro board's real HV nets (TRK_POS/V_RSV_POS) do NOT match mains
+    # name patterns.  A mains-level --working-voltage with 0 resolved HV nets
+    # must still fire the guard (exit 2), never silent 0.
+    pcb = _write(tmp_path, board_no_hv_source())
+    rc = _run(
+        [
+            "creepage",
+            str(pcb),
+            "--standard",
+            "iec60664",
+            "--working-voltage",
+            "250",
+            "--pollution-degree",
+            "2",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "WARNING" in captured.err
+    assert "250" in captured.err
+    assert "Nothing to audit -- exit 0" not in captured.out
+
+
+def test_low_voltage_non_hv_board_still_exits_zero(tmp_path, capsys):
+    # Negative control: a genuinely low-voltage board (no mains names, working
+    # voltage below the 50 V SELV boundary) must still exit 0 with the inert
+    # "Nothing to audit" message -- no false alarms.
+    pcb = _write(tmp_path, board_no_hv_source())
+    rc = _run(
+        [
+            "creepage",
+            str(pcb),
+            "--standard",
+            "iec60664",
+            "--working-voltage",
+            "24",
+            "--pollution-degree",
+            "2",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "Nothing to audit -- exit 0" in captured.out
+    assert "WARNING" not in captured.err
 
 
 def test_missing_pcb_file_errors(tmp_path, capsys):

--- a/tests/creepage/test_creepage_engine.py
+++ b/tests/creepage/test_creepage_engine.py
@@ -24,11 +24,13 @@ from kicad_tools._shapely import has_shapely
 from kicad_tools.creepage.engine import (
     BOARD_EDGE_LABEL,
     compute_creepage_census,
+    is_mains_suspect_name,
+    mains_suspect_nets,
     resolve_hv_nets,
     surface_path_length,
 )
 
-from .fixtures import board_no_hv_source, board_source
+from .fixtures import board_mains_named_source, board_no_hv_source, board_source
 
 pytestmark = pytest.mark.skipif(not has_shapely(), reason="creepage requires shapely")
 
@@ -191,3 +193,92 @@ def test_name_pattern_fallback_without_map(tmp_path):
     pcb = _load(tmp_path, board_source(with_slot=False))
     hv = resolve_hv_nets(pcb, "ground", net_class_map=None)
     assert set(hv.values()) == {"GND"}
+
+
+# ---------------------------------------------------------------------------
+# Mains/HV name detection + broadened HV fallback (issue #4354)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "AC_LINE",
+        "AC_NEUTRAL",
+        "ACLINE",
+        "FUSED_LINE",
+        "FUSED",
+        "MAINS_L",
+        "L_MAINS",
+        "HV_BUS",
+        "HV",
+        "LIVE",
+        "NEUTRAL",
+        "PRIMARY",
+        "LINE",
+        "/AC_LINE",  # hierarchical leading slash
+    ],
+)
+def test_is_mains_suspect_name_positive(name):
+    assert is_mains_suspect_name(name) is True
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "GND",
+        "SDA",
+        "SCL",
+        "USB_DP",
+        "USB_DM",
+        "SIG",
+        "VCC",
+        "ONLINE",  # 'LINE' substring, no token boundary -> must NOT match
+        "REMAINS",  # 'MAINS' substring, no token boundary -> must NOT match
+        "",
+        None,
+    ],
+)
+def test_is_mains_suspect_name_negative(name):
+    assert is_mains_suspect_name(name) is False
+
+
+def test_mains_suspect_nets_lists_only_mains_named(tmp_path):
+    pcb = _load(tmp_path, board_mains_named_source())
+    # GND is excluded; the three mains nets are listed (sorted).
+    assert mains_suspect_nets(pcb) == ["AC_LINE", "AC_NEUTRAL", "FUSED_LINE"]
+
+
+def test_broadened_hv_fallback_classifies_mains_without_map(tmp_path):
+    # The NetClass enum has no HV member, so this only works via the #4354
+    # broadened mains/HV name fallback -- with NO net-class-map at all.
+    pcb = _load(tmp_path, board_mains_named_source())
+    hv = resolve_hv_nets(pcb, "HV", net_class_map=None)
+    assert set(hv.values()) == {"AC_LINE", "AC_NEUTRAL", "FUSED_LINE"}
+    assert "GND" not in set(hv.values())
+
+
+def test_explicit_map_still_governs_over_fallback(tmp_path):
+    # A map that classifies the mains nets as a NON-HV class must exclude them
+    # from the HV group (explicit operator classification wins; the broadened
+    # fallback never double-adds a mapped net).
+    from kicad_tools.router.rules import net_class_map_from_dict
+
+    pcb = _load(tmp_path, board_mains_named_source())
+    generic = net_class_map_from_dict(
+        {
+            "AC_LINE": {"name": "Power"},
+            "AC_NEUTRAL": {"name": "Power"},
+            "FUSED_LINE": {"name": "Power"},
+        }
+    )
+    hv = resolve_hv_nets(pcb, "HV", generic)
+    assert hv == {}
+
+
+def test_broadened_fallback_only_applies_to_hv_target(tmp_path):
+    # Asking for a non-HV class must NOT pull in mains-named nets via the #4354
+    # fallback (it is gated on target == "hv").
+    pcb = _load(tmp_path, board_mains_named_source())
+    hv = resolve_hv_nets(pcb, "power", net_class_map=None)
+    assert "AC_LINE" not in set(hv.values())

--- a/tests/test_audit_hv_isolation.py
+++ b/tests/test_audit_hv_isolation.py
@@ -33,6 +33,7 @@ from kicad_tools.audit import AuditResult, AuditVerdict, IsolationStatus, Manufa
 from kicad_tools.cli import audit_cmd
 from tests.creepage.fixtures import (
     board_close_hv_source,
+    board_mains_named_source,
     board_no_hv_source,
     board_source,
 )
@@ -213,14 +214,18 @@ def test_hv_present_no_threshold_not_checked(tmp_path, capsys):
 
 
 def test_no_hv_nets_no_section(tmp_path, capsys):
-    """A non-HV board: no section, checked=False, hv_present=False."""
+    """A genuinely low-voltage non-HV board: no section, inert isolation.
+
+    Uses a below-SELV working voltage (24 V) with no mains-named nets so the
+    #4354 vacuity guard stays quiet -- the legitimately-inert path.
+    """
     pcb = _write(tmp_path, board_no_hv_source())
     ncm = _hv_map_file(tmp_path)
     result = _audit(
         pcb,
         ncm,
         hv_standard="iec60664",
-        hv_working_voltage=250.0,
+        hv_working_voltage=24.0,  # below the 50 V SELV boundary
         hv_pollution_degree=2,
     ).run()
     iso = result.isolation
@@ -228,10 +233,78 @@ def test_no_hv_nets_no_section(tmp_path, capsys):
     assert iso.hv_present is False
     assert iso.checked is False
     assert iso.passed is True
+    assert iso.mains_suspected_unclassified is False
 
     audit_cmd.output_table(result)
     out = capsys.readouterr().out
     assert "HV / Isolation" not in out
+
+
+def test_mains_named_board_empty_hv_group_is_not_ready(tmp_path, capsys):
+    """#4354: a mains-named board whose HV group resolves EMPTY -> NOT_READY.
+
+    A GENERIC net-class-map names the mains nets Power (never HV), so HV
+    resolution returns empty -- but the board is obviously mains, so the audit
+    vacuity guard fires (mains_suspected_unclassified) and the verdict hard-fails
+    rather than silently reporting READY.
+    """
+    pcb = _write(tmp_path, board_mains_named_source())
+    gmap = tmp_path / "generic_map.json"
+    gmap.write_text(
+        json.dumps(
+            {
+                "AC_LINE": {"name": "Power"},
+                "AC_NEUTRAL": {"name": "Power"},
+                "FUSED_LINE": {"name": "Power"},
+            }
+        )
+    )
+    result = _audit(
+        pcb,
+        str(gmap),
+        hv_standard="iec60664",
+        hv_working_voltage=250.0,
+        hv_pollution_degree=2,
+    ).run()
+    iso = result.isolation
+
+    assert iso.mains_suspected_unclassified is True
+    assert iso.hv_present is False
+    assert "AC_LINE" in iso.mains_suspect_nets
+    assert result.verdict == AuditVerdict.NOT_READY
+
+    audit_cmd.output_table(result)
+    out = capsys.readouterr().out
+    assert "HV / Isolation" in out
+    assert "mains nets unclassified" in out
+    assert "AC_LINE" in out
+
+
+def test_mains_suspected_unclassified_json(tmp_path):
+    """#4354: the vacuity-guard state is serialized in the isolation JSON."""
+    pcb = _write(tmp_path, board_mains_named_source())
+    gmap = tmp_path / "generic_map.json"
+    gmap.write_text(
+        json.dumps(
+            {
+                "AC_LINE": {"name": "Power"},
+                "AC_NEUTRAL": {"name": "Power"},
+                "FUSED_LINE": {"name": "Power"},
+            }
+        )
+    )
+    result = _audit(
+        pcb,
+        str(gmap),
+        hv_standard="iec60664",
+        hv_working_voltage=250.0,
+        hv_pollution_degree=2,
+    ).run()
+    data = result.to_dict()
+
+    assert data["isolation"]["mains_suspected_unclassified"] is True
+    assert "AC_LINE" in data["isolation"]["mains_suspect_nets"]
+    assert data["verdict"] == AuditVerdict.NOT_READY.value
 
 
 def test_no_hv_nets_json_isolation_inert(tmp_path):
@@ -391,6 +464,16 @@ class TestVerdictRollup:
             hv_present=True, threshold_supplied=True, could_not_verify=True
         )
         assert result.verdict == AuditVerdict.WARNING
+
+    def test_mains_suspected_unclassified_not_ready(self):
+        """#4354: empty HV group on a mains-looking board -> NOT_READY."""
+        result = self._clean_result()
+        result.isolation = IsolationStatus(
+            hv_present=False,
+            mains_suspected_unclassified=True,
+            mains_suspect_nets=["AC_LINE"],
+        )
+        assert result.verdict == AuditVerdict.NOT_READY
 
     def test_exit_code_maps_from_verdict(self, tmp_path, monkeypatch, capsys):
         """The CLI exit code reflects the isolation-driven verdict.


### PR DESCRIPTION
## Summary

`kct creepage` and the `kct audit` manufacturing-readiness gate could **silently exit 0 / report READY** on a mains board whose HV nets were never classified — a safety-gate false pass. Root cause (four linked defects, all verified on `origin/main`):

1. `NetClass` has no `HV` member, so `classify_from_name()` can never return `"HV"` → the name-pattern fallback in `resolve_hv_nets` was unreachable for the HV group.
2. An empty `hv_nets` collapses to `report.passed = all([]) = True`.
3. The CLI prints "Nothing to audit -- exit 0" and returns 0.
4. The audit treated an empty HV resolution as inert → READY.

This is the same vacuity-guard class already fixed for LVS (#4011), ampacity (#4324), and current-sense (#4339). Per curation, HV detection is kept **local to the creepage/audit layer** — `NetClass` (which drives routing) is intentionally left unchanged.

## Changes

- **`creepage/engine.py`**: add `MAINS_NAME_RE`, `is_mains_suspect_name()`, `mains_suspect_nets()`, and `SELV_WORKING_VOLTAGE_V`. Broaden the `resolve_hv_nets` fallback so an unmapped mains/HV-named net (`AC_LINE`, `AC_NEUTRAL`, `FUSED_LINE`, `*MAINS*`, `HV*`, `LIVE`, `NEUTRAL`, `PRIMARY`, `LINE` …) is selected when `--net-class HV`. An explicit map entry always wins.
- **`cli/commands/creepage.py`**: vacuity guard — when 0 HV nets resolve but the board has mains-suspect net names **or** a `>= 50 V` (SELV) working voltage was supplied, emit a loud `WARNING:` to stderr (naming the suspect nets and pointing at `--net-class-map`/`--net-class`) and exit with the **distinct code `2`** ("HV unclassified"), separate from `1` ("a measured pair failed"). Render functions no longer unconditionally print "Nothing to audit -- exit 0".
- **`audit/auditor.py`**: new `IsolationStatus.mains_suspected_unclassified` (+ `mains_suspect_nets`) folds into `AuditResult.verdict` as **`NOT_READY`**. `_check_isolation` replaces the inert empty-HV branch with the guard.
- **`cli/audit_cmd.py`**: render the new vacuous-audit / mains-suspected state in the HV/Isolation block and the summary line.
- **Tests + fixture**: `board_mains_named_source()` in `tests/creepage/fixtures.py`; engine, CLI, and audit cases.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Mains-named board, no map, 250 V → non-zero (not "Nothing to audit") | ✅ | `test_mains_named_board_no_map_exits_nonzero` (fallback classifies, 1 mm pair FAILs → exit 1) |
| Broadened fallback classifies AC_LINE/AC_NEUTRAL/FUSED_LINE/*MAINS*/HV*/LIVE/NEUTRAL/PRIMARY as HV | ✅ | `test_broadened_hv_fallback_classifies_mains_without_map`, parametrized `test_is_mains_suspect_name_positive` |
| 0 HV nets + no mains names + no high working voltage → still exit 0 | ✅ | `test_low_voltage_non_hv_board_still_exits_zero` (24 V), existing `test_no_hv_nets_message_and_exit_zero` |
| Vacuity WARNING names suspects + points at `--net-class-map`; distinct code 2 | ✅ | `test_generic_map_hiding_mains_fires_vacuity_guard` asserts rc==2, stderr WARNING/AC_LINE/--net-class-map |
| Generic-map board where HV resolution is empty → audit NOT_READY | ✅ | `test_mains_named_board_empty_hv_group_is_not_ready`, `TestVerdictRollup::test_mains_suspected_unclassified_not_ready` |
| Explicit map still governs; fallback never overrides | ✅ | `test_explicit_map_still_governs_over_fallback`, `test_broadened_fallback_only_applies_to_hv_target` |
| Genuinely non-HV board → inert isolation, unchanged verdict | ✅ | `test_no_hv_nets_no_section` (updated to 24 V), `test_no_hv_nets_json_isolation_inert` |
| High working voltage without mains names still fires guard (repro's TRK_POS case) | ✅ | `test_high_working_voltage_without_mains_names_fires_guard` (rc==2) |

## Test Plan

- `pytest tests/creepage/ tests/test_audit_hv_isolation.py tests/test_fleet_status.py` → 199 passed.
- `pytest -k audit` → 349 passed, 11 skipped.
- `ruff check` + `ruff format --check` clean on all touched files.
- mypy baseline gate: the 4 changed source files add **no** new errors. The one "new" error the gate reports (`recovery/strategy.py`, a file this PR does not touch) reproduces identically on the clean base branch via `git stash` — it is pre-existing environment/mypy nondeterminism, not from this diff.

Closes #4354