### PR TITLE
feat(fix-vias): relocate via-in-pad vias off-pad (connectivity-preserving)

### DIFF
--- a/src/kicad_tools/cli/commands/validation.py
+++ b/src/kicad_tools/cli/commands/validation.py
@@ -87,6 +87,10 @@ def run_fix_vias_command(args) -> int:
         sub_argv.append("--quiet")
     if getattr(args, "skip_if_clearance_violation", False):
         sub_argv.append("--skip-if-clearance-violation")
+    if getattr(args, "relocate_in_pad", False):
+        sub_argv.append("--relocate-in-pad")
+    for net in getattr(args, "nets", None) or []:
+        sub_argv.extend(["--net", net])
     return fix_vias_main(sub_argv)
 
 

--- a/src/kicad_tools/cli/fix_vias_cmd.py
+++ b/src/kicad_tools/cli/fix_vias_cmd.py
@@ -143,6 +143,32 @@ def get_design_rules(
     return drill or 0.3, diameter or 0.6, 0.0, 0.2
 
 
+def get_mfr_design_rules(mfr: str, layers: int, copper: float):
+    """Load the full :class:`DesignRules` object for a manufacturer/stackup.
+
+    Unlike :func:`get_design_rules` (which returns only the scalar via
+    drill/diameter/clearance tuple used by the resize path), the relocation
+    path needs the whole rules object -- specifically ``min_clearance_mm``,
+    ``min_hole_to_hole_mm``, and the ``via_in_pad_supported`` capability flag.
+
+    Resolves through the manufacturer *profile* registry (not the raw YAML
+    loader) so capability-tier aliases such as ``jlcpcb-tier1`` /
+    ``jlcpcb_capabilityplus`` resolve correctly and carry the right
+    ``via_in_pad_supported`` flag.
+
+    Returns:
+        The matching ``DesignRules`` for the stackup, or ``None`` when the
+        manufacturer is unknown.
+    """
+    from kicad_tools.manufacturers import get_profile
+
+    try:
+        profile = get_profile(mfr)
+    except ValueError:
+        return None
+    return profile.get_design_rules(layers=layers, copper_oz=copper)
+
+
 def _closest_point_on_segment(
     x1: float, y1: float, x2: float, y2: float, px: float, py: float
 ) -> tuple[float, float, float]:
@@ -722,6 +748,63 @@ def print_fix_results(
             print(f"  ... and {len(warnings) - 5} more")
 
 
+def _run_relocate_in_pad(args, pcb_path: Path, resolved_layers: int) -> int:
+    """Run the --relocate-in-pad pass on the PCB schema and save if changed.
+
+    Returns a process exit code: 0 on success (incl. clean no-op), 1 on
+    load/save error, 2 when some vias could not be relocated (skipped or
+    unresolvable) so the pipeline surfaces the partial result.
+    """
+    from kicad_tools.schema.pcb import PCB
+
+    from .relocate_in_pad_vias import print_relocation_results, relocate_in_pad_vias
+
+    rules = get_mfr_design_rules(args.mfr, resolved_layers, args.copper)
+    if rules is None:
+        print(
+            f"Error: No design rules found for manufacturer '{args.mfr}'",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        pcb = PCB.load(pcb_path)
+    except Exception as e:
+        print(f"Error parsing PCB file: {e}", file=sys.stderr)
+        return 1
+
+    nets = set(args.nets) if getattr(args, "nets", None) else None
+
+    result = relocate_in_pad_vias(pcb, rules, nets=nets, dry_run=args.dry_run)
+
+    if not args.quiet:
+        print_relocation_results(
+            result,
+            output_format=args.format,
+            dry_run=args.dry_run,
+            mfr=args.mfr,
+        )
+
+    # Persist only when vias actually moved and this is not a dry run.
+    if result.changed and not args.dry_run:
+        output_path = Path(args.output) if args.output else pcb_path
+        try:
+            pcb.save(output_path)
+            if not args.quiet and args.format == "text":
+                print(f"\nSaved to: {output_path}")
+        except Exception as e:
+            print(f"Error saving PCB file: {e}", file=sys.stderr)
+            return 1
+
+    # Exit code 2 signals "completed with unhandled vias" (skipped/unresolvable)
+    # so a pipeline treats it as completed-with-warnings, mirroring the resize
+    # path's warning convention.  A clean run (all handled or nothing to do)
+    # returns 0.
+    if result.skipped or result.unresolvable:
+        return 2
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     """Main entry point for fix-vias command."""
     parser = argparse.ArgumentParser(
@@ -799,6 +882,26 @@ Examples:
             "minimum clearance to nearby tracks, pads, or other vias."
         ),
     )
+    parser.add_argument(
+        "--relocate-in-pad",
+        action="store_true",
+        help=(
+            "Relocate via-in-pad vias off-pad (connectivity-preserving) so the "
+            "board can move to a manufacturer profile that disallows via-in-pad "
+            "(e.g. standard jlcpcb). Slides each in-pad signal via just outside "
+            "the pad along its connected escape track and adds short stub "
+            "segments to preserve the net. Vias that cannot be safely relocated "
+            "are reported (skipped/unresolvable), never left silently in-pad. "
+            "This is a distinct pass from via resizing."
+        ),
+    )
+    parser.add_argument(
+        "--net",
+        action="append",
+        dest="nets",
+        metavar="NET",
+        help=("Restrict --relocate-in-pad to the given net name (repeatable). Default: all nets."),
+    )
 
     args = parser.parse_args(argv)
 
@@ -824,6 +927,12 @@ Examples:
             resolved_layers = detected if detected > 0 else 2
         except Exception:
             resolved_layers = 2
+
+    # Relocation is a distinct pass from via resizing: when --relocate-in-pad
+    # is requested we run only the connectivity-preserving off-pad slide and
+    # return, leaving the resize path untouched (issue #4359).
+    if getattr(args, "relocate_in_pad", False):
+        return _run_relocate_in_pad(args, pcb_path, resolved_layers)
 
     # Get target dimensions
     target_drill, target_diameter, min_annular_ring, min_clearance = get_design_rules(

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -4235,6 +4235,24 @@ def _add_fix_vias_parser(subparsers) -> None:
             "minimum clearance to nearby tracks, pads, or other vias."
         ),
     )
+    fix_vias_parser.add_argument(
+        "--relocate-in-pad",
+        action="store_true",
+        help=(
+            "Relocate via-in-pad vias off-pad (connectivity-preserving) so the "
+            "board can move to a manufacturer profile that disallows via-in-pad "
+            "(e.g. standard jlcpcb). Distinct pass from via resizing; slides "
+            "each in-pad signal via just outside the pad along its escape track "
+            "and adds stub segments to preserve the net."
+        ),
+    )
+    fix_vias_parser.add_argument(
+        "--net",
+        action="append",
+        dest="nets",
+        metavar="NET",
+        help=("Restrict --relocate-in-pad to the given net name (repeatable). Default: all nets."),
+    )
 
 
 def _add_fix_silkscreen_parser(subparsers) -> None:

--- a/src/kicad_tools/cli/relocate_in_pad_vias.py
+++ b/src/kicad_tools/cli/relocate_in_pad_vias.py
@@ -1,0 +1,594 @@
+#!/usr/bin/env python3
+"""Relocate via-in-pad vias off-pad (connectivity-preserving).
+
+Issue #4359 -- Phase 1 (signal-via slide-out).
+
+When a board is routed for a manufacturer that supports via-in-pad
+(``jlcpcb-tier1``, ``pcbway``) and then re-targeted to a profile that does
+NOT (``jlcpcb``, ``oshpark``, ``seeed``, ``flashpcb``), every via whose drill
+sits inside an SMD pad becomes an unmanufacturable via-in-pad violation.
+
+This module implements the **signal-via** relocation pass: for each in-pad via
+that has a connected routed track (an "escape track"), the via is slid just
+outside the pad boundary along the track's direction, with drill-edge clearance
+>= the profile's ``min_clearance_mm``.  Connectivity is preserved by adding
+short **stub** segments from the via's original (in-pad) location to its new
+location on every layer that had connected copper (the pad's copper layer plus
+each connected segment's layer).  No existing copper is mutated -- only the
+via's ``(at ...)`` position moves and new stub segments are appended -- so an
+already-routed board is never regressed.
+
+Deferred to follow-ups (explicitly out of scope for Phase 1):
+
+* **Phase 2** -- plane-stitch vias (a via tying a power/ground pad to a pour
+  with no routed track).  These have no escape direction; relocating them needs
+  the ``stitch --avoid-pad-overlap`` candidate-offset engine.  They are reported
+  as *unresolvable* here, never left silently in-pad.
+* **Phase 3** -- multi-branch fan-out, non-cardinal rotated pads, and
+  dense-pitch pads with no clearing location.  Each is reported as
+  *unresolvable* / *skipped* rather than mis-placed.
+
+Any via Phase 1 cannot safely handle is counted in the report (skipped or
+unresolvable) -- it is never left in-pad without being surfaced.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from kicad_tools.validate.rules.via_pad_geometry import (
+    is_smd_pad,
+    pad_absolute_bbox,
+    via_inside_pad,
+)
+
+if TYPE_CHECKING:
+    from kicad_tools.manufacturers.base import DesignRules
+    from kicad_tools.schema.pcb import PCB, Footprint, Pad, Segment, Via
+
+# Coincidence tolerance for "a track endpoint lands on the via center", mirroring
+# the 0.001 mm test used by fix_vias_cmd.find_nearby_items.
+_COINCIDENT_TOL = 1e-3
+
+
+@dataclass
+class ViaRelocation:
+    """Record of an in-pad via that was slid off-pad."""
+
+    old_x: float
+    old_y: float
+    new_x: float
+    new_y: float
+    net: int
+    net_name: str
+    pad_ref: str
+    uuid: str
+    stub_layers: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ViaRelocationSkip:
+    """Record of an in-pad via that could not be relocated in Phase 1.
+
+    ``category`` is ``"skipped"`` (a valid off-pad slide exists in principle but
+    would introduce a new clearance / hole-to-hole violation) or
+    ``"unresolvable"`` (no Phase-1 escape geometry -- plane-stitch, multi-branch,
+    or no clearing location).
+    """
+
+    x: float
+    y: float
+    net: int
+    net_name: str
+    pad_ref: str
+    reason: str
+    uuid: str
+    category: str = "unresolvable"
+
+
+@dataclass
+class RelocationResult:
+    """Aggregate outcome of a relocation pass."""
+
+    moved: list[ViaRelocation] = field(default_factory=list)
+    skipped: list[ViaRelocationSkip] = field(default_factory=list)
+    unresolvable: list[ViaRelocationSkip] = field(default_factory=list)
+    supported_noop: bool = False
+
+    @property
+    def changed(self) -> bool:
+        """True when at least one via was (or would be) moved."""
+        return bool(self.moved)
+
+
+# ---------------------------------------------------------------------------
+# Geometry helpers
+# ---------------------------------------------------------------------------
+
+
+def _ray_aabb_exit_distance(
+    px: float, py: float, dx: float, dy: float, bbox: tuple[float, float, float, float]
+) -> float:
+    """Distance from interior point ``(px, py)`` along unit dir ``(dx, dy)`` to
+    the boundary of axis-aligned ``bbox``.
+
+    Assumes ``(px, py)`` lies inside ``bbox`` and ``(dx, dy)`` is a unit vector.
+    Returns the smallest positive ``t`` at which the ray exits the box.
+    """
+    min_x, min_y, max_x, max_y = bbox
+    t_candidates: list[float] = []
+    if dx > 1e-12:
+        t_candidates.append((max_x - px) / dx)
+    elif dx < -1e-12:
+        t_candidates.append((min_x - px) / dx)
+    if dy > 1e-12:
+        t_candidates.append((max_y - py) / dy)
+    elif dy < -1e-12:
+        t_candidates.append((min_y - py) / dy)
+    positive = [t for t in t_candidates if t > 0]
+    if not positive:
+        return 0.0
+    return min(positive)
+
+
+def _dist_point_to_aabb(px: float, py: float, bbox: tuple[float, float, float, float]) -> float:
+    """Shortest distance from ``(px, py)`` to axis-aligned ``bbox``.
+
+    Returns 0.0 when the point is inside the box.
+    """
+    min_x, min_y, max_x, max_y = bbox
+    ddx = max(min_x - px, 0.0, px - max_x)
+    ddy = max(min_y - py, 0.0, py - max_y)
+    return math.hypot(ddx, ddy)
+
+
+def _dist_point_to_segment(px: float, py: float, seg: Segment) -> float:
+    """Shortest distance from ``(px, py)`` to the line segment ``seg``."""
+    x1, y1 = seg.start
+    x2, y2 = seg.end
+    dx = x2 - x1
+    dy = y2 - y1
+    seg_len_sq = dx * dx + dy * dy
+    if seg_len_sq < 1e-12:
+        return math.hypot(px - x1, py - y1)
+    t = ((px - x1) * dx + (py - y1) * dy) / seg_len_sq
+    t = max(0.0, min(1.0, t))
+    cx = x1 + t * dx
+    cy = y1 + t * dy
+    return math.hypot(px - cx, py - cy)
+
+
+def _endpoint_at(seg: Segment, x: float, y: float) -> tuple[float, float] | None:
+    """Return the *other* endpoint of ``seg`` if one endpoint is at ``(x, y)``.
+
+    Returns ``None`` when neither endpoint coincides with ``(x, y)``.
+    """
+    if abs(seg.start[0] - x) < _COINCIDENT_TOL and abs(seg.start[1] - y) < _COINCIDENT_TOL:
+        return seg.end
+    if abs(seg.end[0] - x) < _COINCIDENT_TOL and abs(seg.end[1] - y) < _COINCIDENT_TOL:
+        return seg.start
+    return None
+
+
+def _pad_copper_layer(pad: Pad) -> str:
+    """Return the pad's copper layer name (first ``*.Cu``), defaulting F.Cu."""
+    for layer in pad.layers:
+        if layer.endswith(".Cu") and not layer.startswith("*"):
+            return layer
+    return "F.Cu"
+
+
+# ---------------------------------------------------------------------------
+# Core relocation pass
+# ---------------------------------------------------------------------------
+
+
+def _collect_smd_pads_by_net(
+    pcb: PCB,
+) -> dict[int, list[tuple[Footprint, Pad, tuple[float, float, float, float]]]]:
+    """Group SMD pads (net != 0) by net number with precomputed AABBs."""
+    pads_by_net: dict[int, list[tuple[Footprint, Pad, tuple[float, float, float, float]]]] = {}
+    for fp in pcb.footprints:
+        for pad in fp.pads:
+            if not is_smd_pad(pad):
+                continue
+            if pad.net_number == 0:
+                continue
+            bbox = pad_absolute_bbox(pad, fp)
+            pads_by_net.setdefault(pad.net_number, []).append((fp, pad, bbox))
+    return pads_by_net
+
+
+def _check_clearance(
+    pcb: PCB,
+    via: Via,
+    new_x: float,
+    new_y: float,
+    pads_by_net: dict[int, list[tuple[Footprint, Pad, tuple[float, float, float, float]]]],
+    min_clearance: float,
+    min_hole_to_hole: float,
+) -> str | None:
+    """Return a human reason string if placing ``via`` at ``(new_x, new_y)``
+    would violate copper clearance or hole-to-hole; ``None`` when clear.
+
+    Same-net copper is exempt (a via may touch its own net).  Only vias, SMD
+    pads, and routed segments are considered (Phase 1 scope).
+    """
+    via_r = via.size / 2.0
+    hole_r = via.drill / 2.0
+
+    # Other vias: hole-to-hole (any net) + copper clearance (different net).
+    for other in pcb.vias:
+        if other is via:
+            continue
+        d = math.hypot(other.position[0] - new_x, other.position[1] - new_y)
+        hole_gap = d - hole_r - other.drill / 2.0
+        if hole_gap < min_hole_to_hole - 1e-6:
+            return (
+                f"hole-to-hole {hole_gap:.3f}mm to via at "
+                f"({other.position[0]:.2f}, {other.position[1]:.2f})"
+            )
+        if other.net_number != via.net_number:
+            cu_gap = d - via_r - other.size / 2.0
+            if cu_gap < min_clearance - 1e-6:
+                return (
+                    f"clearance {cu_gap:.3f}mm to via at "
+                    f"({other.position[0]:.2f}, {other.position[1]:.2f})"
+                )
+
+    # SMD pads on other nets: copper clearance to pad AABB.
+    for net_number, entries in pads_by_net.items():
+        if net_number == via.net_number:
+            continue
+        for fp, pad, bbox in entries:
+            cu_gap = _dist_point_to_aabb(new_x, new_y, bbox) - via_r
+            if cu_gap < min_clearance - 1e-6:
+                return f"clearance {cu_gap:.3f}mm to pad {fp.reference}-{pad.number}"
+
+    # Routed segments on other nets: copper clearance.
+    for seg in pcb.segments:
+        if seg.net_number == via.net_number:
+            continue
+        cu_gap = _dist_point_to_segment(new_x, new_y, seg) - via_r - seg.width / 2.0
+        if cu_gap < min_clearance - 1e-6:
+            return f"clearance {cu_gap:.3f}mm to track on net {seg.net_number}"
+
+    return None
+
+
+def relocate_in_pad_vias(
+    pcb: PCB,
+    design_rules: DesignRules,
+    *,
+    nets: set[str] | None = None,
+    dry_run: bool = False,
+) -> RelocationResult:
+    """Slide signal in-pad vias off-pad, preserving connectivity (Phase 1).
+
+    Args:
+        pcb: The board to operate on (mutated in place unless ``dry_run``).
+        design_rules: Active manufacturer rules.  A no-op when
+            ``via_in_pad_supported`` is True.  ``min_clearance_mm`` and
+            ``min_hole_to_hole_mm`` gate the off-pad placement.
+        nets: Optional set of net *names* to restrict the pass to.  ``None``
+            means all nets.
+        dry_run: When True, compute the report but do not mutate the board.
+
+    Returns:
+        A :class:`RelocationResult` with moved / skipped / unresolvable records.
+        Relocation is always clearance-safe: any via whose only off-pad slide
+        would introduce a new clearance or hole-to-hole violation is recorded
+        as *skipped* and left untouched (an already-routed board is never made
+        worse).
+    """
+    result = RelocationResult()
+
+    # Capability gate: a no-op on profiles that support via-in-pad.
+    if getattr(design_rules, "via_in_pad_supported", False):
+        result.supported_noop = True
+        return result
+
+    min_clearance = design_rules.min_clearance_mm
+    min_hole_to_hole = design_rules.min_hole_to_hole_mm
+
+    pads_by_net = _collect_smd_pads_by_net(pcb)
+
+    # Iterate a snapshot: relocate_via/add_trace mutate the underlying lists.
+    for via in list(pcb.vias):
+        if via.net_number == 0:
+            continue
+
+        candidates = pads_by_net.get(via.net_number)
+        if not candidates:
+            continue
+
+        # First same-net pad whose AABB fully contains the via drill.
+        containing = next(
+            ((fp, pad, bbox) for fp, pad, bbox in candidates if via_inside_pad(via, bbox)),
+            None,
+        )
+        if containing is None:
+            continue
+
+        fp, pad, bbox = containing
+        pad_ref = f"{fp.reference}-{pad.number}"
+        net_name = via.net_name or pad.net_name or ""
+
+        # Net-name scoping.
+        if nets is not None and net_name not in nets:
+            continue
+
+        vx, vy = via.position
+
+        # Classify: enumerate routed segments whose endpoint lands on the via.
+        connected: list[tuple[Segment, tuple[float, float]]] = []
+        for seg in pcb.segments_in_net(via.net_number):
+            far = _endpoint_at(seg, vx, vy)
+            if far is not None:
+                connected.append((seg, far))
+
+        if not connected:
+            # No routed track -> plane-stitch or unconnected via (Phase 2).
+            result.unresolvable.append(
+                ViaRelocationSkip(
+                    x=vx,
+                    y=vy,
+                    net=via.net_number,
+                    net_name=net_name,
+                    pad_ref=pad_ref,
+                    reason=(
+                        "no connected routed track (plane-stitch via -- deferred to "
+                        "Phase 2 stitch-engine relocation)"
+                    ),
+                    uuid=via.uuid,
+                    category="unresolvable",
+                )
+            )
+            continue
+
+        pad_center_x = (bbox[0] + bbox[2]) / 2.0
+        pad_center_y = (bbox[1] + bbox[3]) / 2.0
+
+        # Choose the escape track: the connected segment whose far endpoint is
+        # farthest from the pad center (the one leaving the pad).  Its far
+        # endpoint MUST lie outside the pad AABB, otherwise there is no reliable
+        # exit direction (multi-branch / fully-internal -> Phase 3).
+        escape = max(
+            connected,
+            key=lambda item: math.hypot(item[1][0] - pad_center_x, item[1][1] - pad_center_y),
+        )
+        _, far = escape
+        if _dist_point_to_aabb(far[0], far[1], bbox) <= 1e-6:
+            result.unresolvable.append(
+                ViaRelocationSkip(
+                    x=vx,
+                    y=vy,
+                    net=via.net_number,
+                    net_name=net_name,
+                    pad_ref=pad_ref,
+                    reason=(
+                        "no connected track escapes the pad boundary "
+                        "(multi-branch / internal -- deferred to Phase 3)"
+                    ),
+                    uuid=via.uuid,
+                    category="unresolvable",
+                )
+            )
+            continue
+
+        # Unit escape direction (from via center toward the far endpoint).
+        dir_x = far[0] - vx
+        dir_y = far[1] - vy
+        dir_len = math.hypot(dir_x, dir_y)
+        if dir_len < 1e-9:
+            result.unresolvable.append(
+                ViaRelocationSkip(
+                    x=vx,
+                    y=vy,
+                    net=via.net_number,
+                    net_name=net_name,
+                    pad_ref=pad_ref,
+                    reason="degenerate escape-track direction",
+                    uuid=via.uuid,
+                    category="unresolvable",
+                )
+            )
+            continue
+        dir_x /= dir_len
+        dir_y /= dir_len
+
+        # Slide along the escape direction until the drill circle clears the pad
+        # edge by min_clearance: new_center = via + dir * (t_exit + drill/2 + clr).
+        t_exit = _ray_aabb_exit_distance(vx, vy, dir_x, dir_y, bbox)
+        slide = t_exit + via.drill / 2.0 + min_clearance
+        new_x = vx + dir_x * slide
+        new_y = vy + dir_y * slide
+
+        # Clearance gate: never emit a worse board.
+        reason = _check_clearance(
+            pcb, via, new_x, new_y, pads_by_net, min_clearance, min_hole_to_hole
+        )
+        if reason is not None:
+            result.skipped.append(
+                ViaRelocationSkip(
+                    x=vx,
+                    y=vy,
+                    net=via.net_number,
+                    net_name=net_name,
+                    pad_ref=pad_ref,
+                    reason=reason,
+                    uuid=via.uuid,
+                    category="skipped",
+                )
+            )
+            continue
+
+        # Layers needing a connectivity stub: the pad's copper layer (pad->via
+        # path) plus every connected segment's layer (route->via path).
+        stub_layers: list[str] = []
+        seen_layers: set[str] = set()
+        for layer in [_pad_copper_layer(pad), *(seg.layer for seg, _ in connected)]:
+            if layer and layer not in seen_layers:
+                seen_layers.add(layer)
+                stub_layers.append(layer)
+
+        # Stub width: the escape track's width (fall back to a sane default).
+        stub_width = escape[0].width if escape[0].width > 0 else 0.2
+
+        if not dry_run:
+            # Add stubs from the old (in-pad) location to the new via location
+            # on each connected layer BEFORE moving the via, so connectivity is
+            # continuous at every step.  No existing copper is mutated.
+            for layer in stub_layers:
+                pcb.add_trace(
+                    (vx, vy),
+                    (new_x, new_y),
+                    width=stub_width,
+                    layer=layer,
+                    net=net_name or None,
+                )
+            moved_ok = pcb.relocate_via(via, (new_x, new_y))
+            if not moved_ok:
+                # Could not find the backing S-expression node -- record as
+                # unresolvable rather than claiming a move that will not persist.
+                result.unresolvable.append(
+                    ViaRelocationSkip(
+                        x=vx,
+                        y=vy,
+                        net=via.net_number,
+                        net_name=net_name,
+                        pad_ref=pad_ref,
+                        reason="could not locate backing (via ...) node to persist move",
+                        uuid=via.uuid,
+                        category="unresolvable",
+                    )
+                )
+                continue
+
+        result.moved.append(
+            ViaRelocation(
+                old_x=vx,
+                old_y=vy,
+                new_x=new_x,
+                new_y=new_y,
+                net=via.net_number,
+                net_name=net_name,
+                pad_ref=pad_ref,
+                uuid=via.uuid,
+                stub_layers=stub_layers,
+            )
+        )
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def print_relocation_results(
+    result: RelocationResult,
+    output_format: str = "text",
+    dry_run: bool = False,
+    mfr: str | None = None,
+) -> None:
+    """Print a relocation report in ``text``, ``json``, or ``summary`` form."""
+    if output_format == "json":
+        data = {
+            "manufacturer": mfr,
+            "dry_run": dry_run,
+            "via_in_pad_supported_noop": result.supported_noop,
+            "moved": [
+                {
+                    "old_x": m.old_x,
+                    "old_y": m.old_y,
+                    "new_x": m.new_x,
+                    "new_y": m.new_y,
+                    "net": m.net,
+                    "net_name": m.net_name,
+                    "pad": m.pad_ref,
+                    "uuid": m.uuid,
+                    "stub_layers": m.stub_layers,
+                }
+                for m in result.moved
+            ],
+            "skipped": [
+                {
+                    "x": s.x,
+                    "y": s.y,
+                    "net": s.net,
+                    "net_name": s.net_name,
+                    "pad": s.pad_ref,
+                    "reason": s.reason,
+                    "uuid": s.uuid,
+                }
+                for s in result.skipped
+            ],
+            "unresolvable": [
+                {
+                    "x": u.x,
+                    "y": u.y,
+                    "net": u.net,
+                    "net_name": u.net_name,
+                    "pad": u.pad_ref,
+                    "reason": u.reason,
+                    "uuid": u.uuid,
+                }
+                for u in result.unresolvable
+            ],
+        }
+        print(json.dumps(data, indent=2))
+        return
+
+    if result.supported_noop:
+        msg = (
+            f"Manufacturer profile{f' {mfr}' if mfr else ''} supports via-in-pad; "
+            "no relocation needed."
+        )
+        print(msg)
+        return
+
+    if output_format == "summary":
+        action = "Would move" if dry_run else "Moved"
+        print(f"{action} {len(result.moved)} in-pad via(s) off-pad")
+        if result.skipped:
+            print(f"  {len(result.skipped)} skipped (clearance/hole-to-hole)")
+        if result.unresolvable:
+            print(f"  {len(result.unresolvable)} unresolvable (Phase 2/3)")
+        return
+
+    # Text output.
+    if not result.moved and not result.skipped and not result.unresolvable:
+        print("No via-in-pad vias found; nothing to relocate.")
+        return
+
+    action = "Would move" if dry_run else "Moved"
+    print(f"{action} {len(result.moved)} in-pad via(s) off-pad:")
+    for m in result.moved[:10]:
+        print(
+            f"  Via {m.uuid[:8] or '?'} (net '{m.net_name}') on pad {m.pad_ref}: "
+            f"({m.old_x:.3f}, {m.old_y:.3f}) -> ({m.new_x:.3f}, {m.new_y:.3f}); "
+            f"stubs on {', '.join(m.stub_layers)}"
+        )
+    if len(result.moved) > 10:
+        print(f"  ... and {len(result.moved) - 10} more")
+
+    if result.skipped:
+        print(f"\nSkipped {len(result.skipped)} via(s) (would violate clearance):")
+        for s in result.skipped[:10]:
+            print(f"  Via at ({s.x:.3f}, {s.y:.3f}) on pad {s.pad_ref}: {s.reason}")
+        if len(result.skipped) > 10:
+            print(f"  ... and {len(result.skipped) - 10} more")
+
+    if result.unresolvable:
+        print(
+            f"\nUnresolvable {len(result.unresolvable)} via(s) (deferred to Phase 2/3 follow-ups):"
+        )
+        for u in result.unresolvable[:10]:
+            print(f"  Via at ({u.x:.3f}, {u.y:.3f}) on pad {u.pad_ref}: {u.reason}")
+        if len(result.unresolvable) > 10:
+            print(f"  ... and {len(result.unresolvable) - 10} more")

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -4836,6 +4836,72 @@ class PCB:
 
         return via
 
+    def relocate_via(self, via: Via, new_position: tuple[float, float]) -> bool:
+        """Move an existing via to a new board-relative position.
+
+        Updates BOTH the in-memory :class:`Via` object and the backing
+        ``(via ...)`` S-expression node's ``(at ...)`` child, so the move
+        persists through :meth:`save`.  This is the mutating counterpart the
+        ``vias`` property setter deliberately forbids (direct assignment to
+        ``pcb.vias`` raises, because it would not touch the S-expression tree).
+
+        The via is matched to its S-expression node by UUID when available,
+        falling back to the via's current (pre-move) position.  Inputs are in
+        board-relative coordinates (matching :attr:`Via.position` and
+        :meth:`add_via`); the S-expression form stores sheet-absolute
+        coordinates, so :attr:`_board_origin` is added when writing the node.
+
+        Args:
+            via: The Via object to move (its :attr:`position` is updated in place).
+            new_position: Target ``(x, y)`` in board-relative mm.
+
+        Returns:
+            ``True`` when a backing S-expression node was found and updated;
+            ``False`` when no matching ``(via ...)`` node could be located
+            (in which case the in-memory object is still updated, but the move
+            will not persist -- callers should treat ``False`` as a failure).
+
+        Example:
+            >>> pcb = PCB.load("board.kicad_pcb")
+            >>> v = next(pcb.vias_in_net(5))
+            >>> pcb.relocate_via(v, (v.position[0] + 0.5, v.position[1]))
+            >>> pcb.save()
+        """
+        ox, oy = self._board_origin
+        old_x, old_y = via.position
+        target_uuid = via.uuid
+
+        updated = False
+        for child in self._sexp.children:
+            if child.is_atom or child.name != "via":
+                continue
+
+            at_node = child.find("at")
+            if at_node is None:
+                continue
+
+            if target_uuid:
+                uuid_node = child.find("uuid")
+                if not uuid_node or (uuid_node.get_string(0) or "") != target_uuid:
+                    continue
+            else:
+                # Fallback: match by current (sheet-absolute) position.
+                ax = at_node.get_float(0) or 0.0
+                ay = at_node.get_float(1) or 0.0
+                if abs(ax - (old_x + ox)) > 1e-6 or abs(ay - (old_y + oy)) > 1e-6:
+                    continue
+
+            at_node.set_value(0, new_position[0] + ox)
+            at_node.set_value(1, new_position[1] + oy)
+            updated = True
+            break
+
+        # Update the in-memory object regardless so reads reflect the move.
+        via.position = (new_position[0], new_position[1])
+        # Position changed -> the cached via dedup key set is stale.
+        self._invalidate_dedup_keys()
+        return updated
+
     def reinforce_net(
         self,
         net_name: str,

--- a/src/kicad_tools/validate/rules/via_in_pad.py
+++ b/src/kicad_tools/validate/rules/via_in_pad.py
@@ -37,98 +37,30 @@ check lives entirely in pure-Python ``DRCChecker.check_via_in_pad``.
 
 from __future__ import annotations
 
-import math
 from typing import TYPE_CHECKING
 
 from ..violations import DRCResults, DRCViolation
-from .base import DRC_TOLERANCE, DRCRule
+from .base import DRCRule
+
+# The pad-bbox / containment geometry now lives in a shared module so the
+# ``fix-vias --relocate-in-pad`` command reuses exactly the same detector as
+# this DRC rule (single source of truth -- issue #4359).  The private aliases
+# are retained for backward compatibility with existing references to
+# ``via_in_pad._pad_absolute_bbox`` / ``_via_inside_pad`` (e.g. the router's
+# ``drc_nudge`` and ``stitch_cmd`` docstrings).
+from .via_pad_geometry import (
+    is_smd_pad as _is_smd_pad,
+)
+from .via_pad_geometry import (
+    pad_absolute_bbox as _pad_absolute_bbox,
+)
+from .via_pad_geometry import (
+    via_inside_pad as _via_inside_pad,
+)
 
 if TYPE_CHECKING:
     from kicad_tools.manufacturers import DesignRules
     from kicad_tools.schema.pcb import PCB, Footprint, Pad, Via
-
-
-def _pad_absolute_bbox(
-    pad: Pad,
-    footprint: Footprint,
-) -> tuple[float, float, float, float]:
-    """Return the axis-aligned bounding box for ``pad`` in board coords.
-
-    Mirrors the transformation used by the clearance rule: rotates the
-    pad center about the footprint origin and, for cardinal rotations,
-    swaps width/height (otherwise uses the rotated rectangle's AABB).
-
-    Returns:
-        (min_x, min_y, max_x, max_y) tuple in mm.
-    """
-    from kicad_tools.core.geometry import rotate_pad_offset
-
-    # cos/sin magnitudes for the (orientation-independent) AABB below; the
-    # signed center rotation goes through the shared KiCad-convention helper.
-    angle_rad = math.radians(footprint.rotation)
-    cos_a = math.cos(angle_rad)
-    sin_a = math.sin(angle_rad)
-
-    local_x, local_y = pad.position
-    rotated_x, rotated_y = rotate_pad_offset(local_x, local_y, footprint.rotation)
-    abs_x = footprint.position[0] + rotated_x
-    abs_y = footprint.position[1] + rotated_y
-
-    width, height = pad.size
-    total_rotation = footprint.rotation % 360
-
-    # For cardinal rotations, swap dimensions.
-    if abs(total_rotation - 90) < 0.001 or abs(total_rotation - 270) < 0.001:
-        bbox_w, bbox_h = height, width
-    elif abs(total_rotation) < 0.001 or abs(total_rotation - 180) < 0.001:
-        bbox_w, bbox_h = width, height
-    else:
-        # Axis-aligned bounding box of the rotated rectangle.
-        abs_cos = abs(cos_a)
-        abs_sin = abs(sin_a)
-        bbox_w = width * abs_cos + height * abs_sin
-        bbox_h = width * abs_sin + height * abs_cos
-
-    half_w = bbox_w / 2
-    half_h = bbox_h / 2
-    return (abs_x - half_w, abs_y - half_h, abs_x + half_w, abs_y + half_h)
-
-
-def _is_smd_pad(pad: Pad) -> bool:
-    """Return True if ``pad`` is a surface-mount pad (no plated hole)."""
-    # KiCad pad types: "smd", "thru_hole", "np_thru_hole", "connect"
-    return pad.type == "smd"
-
-
-def _via_inside_pad(via: Via, pad_bbox: tuple[float, float, float, float]) -> bool:
-    """Return True if the via's drill circle is fully inside ``pad_bbox``.
-
-    Args:
-        via: The via to test.  ``via.position`` is the center, ``via.drill``
-            is the drill diameter.
-        pad_bbox: Axis-aligned (min_x, min_y, max_x, max_y) of the pad.
-
-    Returns:
-        ``True`` when every point on the drill circle is on or inside
-        the pad bounding box.  A small DRC tolerance is applied so that
-        edge-touching vias (within manufacturing rounding) are not
-        flagged.
-    """
-    cx, cy = via.position
-    radius = via.drill / 2.0
-    min_x, min_y, max_x, max_y = pad_bbox
-
-    # Every point on the drill circle lies in [cx - r, cx + r] x [cy - r, cy + r].
-    # The drill is fully inside the pad iff the circle's bounding box is.
-    # We require strict containment minus DRC_TOLERANCE so a via whose
-    # drill edge merely touches the pad edge is allowed (it would be a
-    # neckdown rather than an in-pad via).
-    return (
-        cx - radius >= min_x - DRC_TOLERANCE
-        and cx + radius <= max_x + DRC_TOLERANCE
-        and cy - radius >= min_y - DRC_TOLERANCE
-        and cy + radius <= max_y + DRC_TOLERANCE
-    )
 
 
 class ViaInPadRule(DRCRule):

--- a/src/kicad_tools/validate/rules/via_pad_geometry.py
+++ b/src/kicad_tools/validate/rules/via_pad_geometry.py
@@ -1,0 +1,118 @@
+"""Shared geometry helpers for via-in-pad detection.
+
+Single source of truth for the "is this via drilled inside an SMD pad?"
+geometry, reused by:
+
+* the via-in-pad DRC rule (:mod:`kicad_tools.validate.rules.via_in_pad`), and
+* the ``fix-vias --relocate-in-pad`` command
+  (:mod:`kicad_tools.cli.relocate_in_pad_vias`).
+
+Keeping the pad-bbox / containment math in one module prevents the two
+consumers from drifting (the previous copy lived privately in
+``via_in_pad.py``; the DRC rule now imports these functions so both paths
+share exactly one implementation).
+
+Geometry of "via inside pad":
+
+* SMD pads are modelled as axis-aligned rectangles (post footprint
+  rotation transformation).  For rotated footprints the axis-aligned
+  bounding box is used; pads with non-cardinal rotations are
+  conservatively reported when the BB contains the via even if the actual
+  pad polygon does not.
+* A via is "in the pad" when its drill circle is fully contained inside
+  the pad rectangle, i.e. every point on the drill circle lies on or
+  inside the pad edge.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+from .base import DRC_TOLERANCE
+
+if TYPE_CHECKING:
+    from kicad_tools.schema.pcb import Footprint, Pad, Via
+
+
+def pad_absolute_bbox(
+    pad: Pad,
+    footprint: Footprint,
+) -> tuple[float, float, float, float]:
+    """Return the axis-aligned bounding box for ``pad`` in board coords.
+
+    Mirrors the transformation used by the clearance rule: rotates the
+    pad center about the footprint origin and, for cardinal rotations,
+    swaps width/height (otherwise uses the rotated rectangle's AABB).
+
+    Returns:
+        (min_x, min_y, max_x, max_y) tuple in mm.
+    """
+    from kicad_tools.core.geometry import rotate_pad_offset
+
+    # cos/sin magnitudes for the (orientation-independent) AABB below; the
+    # signed center rotation goes through the shared KiCad-convention helper.
+    angle_rad = math.radians(footprint.rotation)
+    cos_a = math.cos(angle_rad)
+    sin_a = math.sin(angle_rad)
+
+    local_x, local_y = pad.position
+    rotated_x, rotated_y = rotate_pad_offset(local_x, local_y, footprint.rotation)
+    abs_x = footprint.position[0] + rotated_x
+    abs_y = footprint.position[1] + rotated_y
+
+    width, height = pad.size
+    total_rotation = footprint.rotation % 360
+
+    # For cardinal rotations, swap dimensions.
+    if abs(total_rotation - 90) < 0.001 or abs(total_rotation - 270) < 0.001:
+        bbox_w, bbox_h = height, width
+    elif abs(total_rotation) < 0.001 or abs(total_rotation - 180) < 0.001:
+        bbox_w, bbox_h = width, height
+    else:
+        # Axis-aligned bounding box of the rotated rectangle.
+        abs_cos = abs(cos_a)
+        abs_sin = abs(sin_a)
+        bbox_w = width * abs_cos + height * abs_sin
+        bbox_h = width * abs_sin + height * abs_cos
+
+    half_w = bbox_w / 2
+    half_h = bbox_h / 2
+    return (abs_x - half_w, abs_y - half_h, abs_x + half_w, abs_y + half_h)
+
+
+def is_smd_pad(pad: Pad) -> bool:
+    """Return True if ``pad`` is a surface-mount pad (no plated hole)."""
+    # KiCad pad types: "smd", "thru_hole", "np_thru_hole", "connect"
+    return pad.type == "smd"
+
+
+def via_inside_pad(via: Via, pad_bbox: tuple[float, float, float, float]) -> bool:
+    """Return True if the via's drill circle is fully inside ``pad_bbox``.
+
+    Args:
+        via: The via to test.  ``via.position`` is the center, ``via.drill``
+            is the drill diameter.
+        pad_bbox: Axis-aligned (min_x, min_y, max_x, max_y) of the pad.
+
+    Returns:
+        ``True`` when every point on the drill circle is on or inside
+        the pad bounding box.  A small DRC tolerance is applied so that
+        edge-touching vias (within manufacturing rounding) are not
+        flagged.
+    """
+    cx, cy = via.position
+    radius = via.drill / 2.0
+    min_x, min_y, max_x, max_y = pad_bbox
+
+    # Every point on the drill circle lies in [cx - r, cx + r] x [cy - r, cy + r].
+    # The drill is fully inside the pad iff the circle's bounding box is.
+    # We require strict containment minus DRC_TOLERANCE so a via whose
+    # drill edge merely touches the pad edge is allowed (it would be a
+    # neckdown rather than an in-pad via).
+    return (
+        cx - radius >= min_x - DRC_TOLERANCE
+        and cx + radius <= max_x + DRC_TOLERANCE
+        and cy - radius >= min_y - DRC_TOLERANCE
+        and cy + radius <= max_y + DRC_TOLERANCE
+    )

--- a/tests/test_fix_vias.py
+++ b/tests/test_fix_vias.py
@@ -1754,3 +1754,280 @@ class TestGetBoardOuterLayers:
         start, end = get_board_outer_layers(doc)
         assert start == "F.Cu"
         assert end == "B.Cu"
+
+
+# ===========================================================================
+# Issue #4359 -- fix-vias --relocate-in-pad (Phase 1: signal-via slide-out)
+# ===========================================================================
+
+from kicad_tools.cli.fix_vias_cmd import get_mfr_design_rules  # noqa: E402
+from kicad_tools.cli.relocate_in_pad_vias import relocate_in_pad_vias  # noqa: E402
+from kicad_tools.schema.pcb import PCB  # noqa: E402
+from kicad_tools.validate.rules.via_in_pad import (  # noqa: E402
+    ViaInPadRule,
+    _pad_absolute_bbox,
+    _via_inside_pad,
+)
+
+# Signal in-pad via: 1x1mm SMD pad U1-1 at (100,100) on net SIG1, a via drilled
+# dead-center inside it, and a B.Cu escape track leaving the pad to (105,100).
+_PCB_SIGNAL_IN_PAD = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (paper "A4")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal) (44 "Edge.Cuts" user))
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "SIG1")
+  (footprint "test:pad" (layer "F.Cu") (at 100 100)
+    (pad "1" smd rect (at 0 0) (size 1.0 1.0) (layers "F.Cu") (net 1 "SIG1"))
+  )
+  (via (at 100 100) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 1) (uuid "via-inpad"))
+  (segment (start 100 100) (end 105 100) (width 0.2) (layer "B.Cu") (net 1) (uuid "seg-escape"))
+)
+"""
+
+# In-pad via with NO connected routed track (plane-stitch style).
+_PCB_PLANE_STITCH_IN_PAD = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (paper "A4")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal) (44 "Edge.Cuts" user))
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (footprint "test:pad" (layer "F.Cu") (at 100 100)
+    (pad "1" smd rect (at 0 0) (size 1.0 1.0) (layers "F.Cu") (net 1 "GND"))
+  )
+  (via (at 100 100) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 1) (uuid "via-stitch"))
+)
+"""
+
+# In-pad signal via whose only off-pad slide (+X) lands inside a foreign-net pad
+# -> relocation would create a clearance violation and must be skipped.
+_PCB_BOXED_IN = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (paper "A4")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal) (44 "Edge.Cuts" user))
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "SIG1")
+  (net 2 "SIG2")
+  (footprint "test:pad" (layer "F.Cu") (at 100 100)
+    (pad "1" smd rect (at 0 0) (size 1.0 1.0) (layers "F.Cu") (net 1 "SIG1"))
+  )
+  (footprint "test:pad" (layer "F.Cu") (at 100.9 100)
+    (pad "1" smd rect (at 0 0) (size 1.0 1.0) (layers "F.Cu") (net 2 "SIG2"))
+  )
+  (via (at 100 100) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 1) (uuid "via-boxed"))
+  (segment (start 100 100) (end 105 100) (width 0.2) (layer "B.Cu") (net 1) (uuid "seg-boxed"))
+)
+"""
+
+# Board with a via that is NOT inside any pad (well clear of it).
+_PCB_NO_IN_PAD = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (paper "A4")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal) (44 "Edge.Cuts" user))
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "SIG1")
+  (footprint "test:pad" (layer "F.Cu") (at 100 100)
+    (pad "1" smd rect (at 0 0) (size 1.0 1.0) (layers "F.Cu") (net 1 "SIG1"))
+  )
+  (via (at 110 110) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 1) (uuid "via-clear"))
+  (segment (start 110 110) (end 115 110) (width 0.2) (layer "B.Cu") (net 1) (uuid "seg-clear"))
+)
+"""
+
+
+def _write(tmp_path: Path, content: str) -> Path:
+    p = tmp_path / "board.kicad_pcb"
+    p.write_text(content)
+    return p
+
+
+def _via_in_pad_count(pcb: PCB, mfr: str = "jlcpcb") -> int:
+    rules = get_mfr_design_rules(mfr, 2, 1.0)
+    return len(ViaInPadRule().check(pcb, rules).violations)
+
+
+class TestRelocateInPadVias:
+    """Phase-1 signal in-pad via relocation (issue #4359)."""
+
+    def test_signal_via_moved_off_pad(self, tmp_path: Path):
+        """In-pad signal via is slid outside the pad with drill-edge clearance."""
+        p = _write(tmp_path, _PCB_SIGNAL_IN_PAD)
+        pcb = PCB.load(p)
+        assert _via_in_pad_count(pcb) == 1  # precondition: it IS in-pad
+
+        rules = get_mfr_design_rules("jlcpcb", 2, 1.0)
+        result = relocate_in_pad_vias(pcb, rules, dry_run=False)
+
+        assert len(result.moved) == 1
+        assert not result.skipped
+        assert not result.unresolvable
+
+        via = pcb.vias[0]
+        fp = pcb.footprints[0]
+        pad = fp.pads[0]
+        bbox = _pad_absolute_bbox(pad, fp)
+
+        # Via drill is now fully OUTSIDE the pad bbox.
+        assert not _via_inside_pad(via, bbox)
+        # Drill edge clears the pad edge by at least min_clearance.
+        drill_edge = via.position[0] - via.drill / 2.0
+        assert drill_edge >= bbox[2] + rules.min_clearance_mm - 1e-6
+
+    def test_stub_and_connectivity_preserved(self, tmp_path: Path):
+        """A stub on the pad layer + escape layer keeps the net connected."""
+        p = _write(tmp_path, _PCB_SIGNAL_IN_PAD)
+        pcb = PCB.load(p)
+        rules = get_mfr_design_rules("jlcpcb", 2, 1.0)
+        result = relocate_in_pad_vias(pcb, rules, dry_run=False)
+
+        moved = result.moved[0]
+        # Stub added on both the pad's copper layer and the escape track layer.
+        assert "F.Cu" in moved.stub_layers
+        assert "B.Cu" in moved.stub_layers
+
+        via = pcb.vias[0]
+        new_x, new_y = via.position
+        # The via net is unchanged (no net rip).
+        assert via.net_number == 1
+        # A same-net segment now lands on the relocated via (connectivity intact).
+        landing = [
+            seg
+            for seg in pcb.segments_in_net(1)
+            if (abs(seg.start[0] - new_x) < 1e-6 and abs(seg.start[1] - new_y) < 1e-6)
+            or (abs(seg.end[0] - new_x) < 1e-6 and abs(seg.end[1] - new_y) < 1e-6)
+        ]
+        assert landing, "no segment lands on the relocated via"
+        # The original in-pad escape segment is untouched (no existing copper mutated).
+        escape = [seg for seg in pcb.segments if seg.uuid == "seg-escape"]
+        assert len(escape) == 1
+        assert escape[0].start == (100.0, 100.0)
+        assert escape[0].end == (105.0, 100.0)
+
+    def test_relocate_persists_through_save(self, tmp_path: Path):
+        """The move round-trips to disk and clears the via-in-pad DRC count."""
+        p = _write(tmp_path, _PCB_SIGNAL_IN_PAD)
+        pcb = PCB.load(p)
+        rules = get_mfr_design_rules("jlcpcb", 2, 1.0)
+        relocate_in_pad_vias(pcb, rules, dry_run=False)
+        moved_pos = pcb.vias[0].position
+        pcb.save(p)
+
+        reloaded = PCB.load(p)
+        assert reloaded.vias[0].position == pytest.approx(moved_pos)
+        assert _via_in_pad_count(reloaded) == 0
+
+    def test_dry_run_mutates_nothing(self, tmp_path: Path):
+        """--dry-run reports the move but writes nothing to the board."""
+        p = _write(tmp_path, _PCB_SIGNAL_IN_PAD)
+        pcb = PCB.load(p)
+        n_segments_before = len(pcb.segments)
+        via_pos_before = pcb.vias[0].position
+
+        rules = get_mfr_design_rules("jlcpcb", 2, 1.0)
+        result = relocate_in_pad_vias(pcb, rules, dry_run=True)
+
+        assert len(result.moved) == 1  # it is reported as movable
+        # ...but nothing was mutated.
+        assert pcb.vias[0].position == via_pos_before
+        assert len(pcb.segments) == n_segments_before
+
+    def test_dry_run_via_main_no_file_write(self, tmp_path: Path):
+        """The CLI --dry-run path leaves the file byte-identical."""
+        p = _write(tmp_path, _PCB_SIGNAL_IN_PAD)
+        original = p.read_text()
+        rc = main([str(p), "--mfr", "jlcpcb", "--relocate-in-pad", "--dry-run", "-q"])
+        assert rc in (0, 2)
+        assert p.read_text() == original
+
+    def test_no_in_pad_vias_clean_noop(self, tmp_path: Path):
+        """A board with no in-pad vias is a clean no-op (no moves, no writes)."""
+        p = _write(tmp_path, _PCB_NO_IN_PAD)
+        original = p.read_text()
+        pcb = PCB.load(p)
+        rules = get_mfr_design_rules("jlcpcb", 2, 1.0)
+        result = relocate_in_pad_vias(pcb, rules, dry_run=False)
+
+        assert not result.moved
+        assert not result.skipped
+        assert not result.unresolvable
+        # main() must not rewrite the file when nothing changed.
+        rc = main([str(p), "--mfr", "jlcpcb", "--relocate-in-pad", "-q"])
+        assert rc == 0
+        assert p.read_text() == original
+
+    def test_supported_mfr_is_noop(self, tmp_path: Path):
+        """On jlcpcb-tier1 (via-in-pad supported) nothing is relocated."""
+        p = _write(tmp_path, _PCB_SIGNAL_IN_PAD)
+        pcb = PCB.load(p)
+        rules = get_mfr_design_rules("jlcpcb-tier1", 2, 1.0)
+        assert rules.via_in_pad_supported is True
+        result = relocate_in_pad_vias(pcb, rules, dry_run=False)
+
+        assert result.supported_noop is True
+        assert not result.moved
+        assert pcb.vias[0].position == (100.0, 100.0)
+
+    def test_plane_stitch_via_reported_unresolvable(self, tmp_path: Path):
+        """An in-pad via with no escape track is surfaced, never left silently."""
+        p = _write(tmp_path, _PCB_PLANE_STITCH_IN_PAD)
+        pcb = PCB.load(p)
+        rules = get_mfr_design_rules("jlcpcb", 2, 1.0)
+        result = relocate_in_pad_vias(pcb, rules, dry_run=False)
+
+        assert not result.moved
+        assert len(result.unresolvable) == 1
+        assert result.unresolvable[0].category == "unresolvable"
+        # The via is left untouched (still in-pad, but reported).
+        assert pcb.vias[0].position == (100.0, 100.0)
+
+    def test_boxed_in_via_skipped(self, tmp_path: Path):
+        """A via that cannot clear a foreign-net pad is skipped, not mis-placed."""
+        p = _write(tmp_path, _PCB_BOXED_IN)
+        pcb = PCB.load(p)
+        rules = get_mfr_design_rules("jlcpcb", 2, 1.0)
+        result = relocate_in_pad_vias(pcb, rules, dry_run=False)
+
+        assert not result.moved
+        assert len(result.skipped) == 1
+        assert result.skipped[0].category == "skipped"
+        # Untouched: never emit a worse board.
+        assert pcb.vias[0].position == (100.0, 100.0)
+
+    def test_net_filter_scopes_pass(self, tmp_path: Path):
+        """--net scoping skips vias whose net is not in the filter set."""
+        p = _write(tmp_path, _PCB_SIGNAL_IN_PAD)
+        pcb = PCB.load(p)
+        rules = get_mfr_design_rules("jlcpcb", 2, 1.0)
+        result = relocate_in_pad_vias(pcb, rules, nets={"OTHER_NET"}, dry_run=False)
+        assert not result.moved
+        assert pcb.vias[0].position == (100.0, 100.0)
+
+        # And the matching net IS processed.
+        pcb2 = PCB.load(p)
+        result2 = relocate_in_pad_vias(pcb2, rules, nets={"SIG1"}, dry_run=False)
+        assert len(result2.moved) == 1
+
+    def test_cli_main_json_report(self, tmp_path: Path, capsys):
+        """--format json emits moved/skipped/unresolvable arrays."""
+        import json as _json
+
+        p = _write(tmp_path, _PCB_SIGNAL_IN_PAD)
+        rc = main([str(p), "--mfr", "jlcpcb", "--relocate-in-pad", "--dry-run", "--format", "json"])
+        assert rc in (0, 2)
+        out = capsys.readouterr().out
+        data = _json.loads(out)
+        assert data["dry_run"] is True
+        assert len(data["moved"]) == 1
+        assert "skipped" in data and "unresolvable" in data


### PR DESCRIPTION
## Summary

Adds `kct fix-vias --relocate-in-pad --mfr <profile> <pcb>` so an
already-routed board can be re-targeted to a manufacturer profile that
disallows via-in-pad (e.g. standard `jlcpcb`) without ripping nets.

This PR is scoped to **Phase 1** of issue #4359 (the curator's recommended
independently-landable core): **signal-via slide-out**. Plane-stitch via
relocation (Phase 2) and hard edge cases (Phase 3) are explicitly deferred to
follow-ups; any via Phase 1 can't safely handle is surfaced in the report
(skipped/unresolvable), never left silently in-pad.

## Algorithm (per in-pad via)

For each via drilled inside a same-net SMD pad, on a profile where
`via_in_pad_supported == False`:

1. **Detect** using the shared via-in-pad geometry (pad AABB + drill containment).
2. **Classify** — a *signal via* has ≥1 routed track whose endpoint lands on the
   via center. A via with no such track is a *plane-stitch* via → reported
   *unresolvable* (Phase 2).
3. **Direction** — the connected escape track (the one whose far endpoint is
   farthest from the pad center and lies outside the pad AABB).
4. **Slide** — `new_center = via + dir * (pad_exit + drill/2 + min_clearance)`,
   so the drill edge clears the pad edge by the profile's `min_clearance`.
5. **Preserve connectivity** — add a short stub from the old (in-pad) location to
   `new_center` on every connected layer (the pad's copper layer + each connected
   segment's layer), then move the via. `pad → stub → via → route` stays intact.
6. **Clearance gate** — reject any candidate that would introduce a new
   copper-clearance or hole-to-hole violation (left untouched, reported *skipped*).

**Design note:** rather than mutating existing segments (the schema has no
segment-endpoint mutator), connectivity is preserved by *adding* stubs on every
connected layer and moving only the via. No existing copper is altered — only
the via's `(at ...)` moves and new stubs are appended — which makes the pass
strictly non-regressing on a routed board.

## Changes

- **New** `src/kicad_tools/validate/rules/via_pad_geometry.py` — shared
  pad-AABB / drill-containment detector; `via_in_pad.py` now imports it (single
  source of truth, no behavior change to the DRC rule).
- **New** `src/kicad_tools/cli/relocate_in_pad_vias.py` — Phase-1 relocation
  engine + `ViaRelocation`/`ViaRelocationSkip`/`RelocationResult` dataclasses +
  text/summary/json reporting.
- `src/kicad_tools/schema/pcb.py` — add `PCB.relocate_via()` mutating BOTH
  `Via.position` and the backing `(via ...)` `(at ...)` SExp node so the move
  round-trips through `save()` (the `vias` setter otherwise raises; no
  move/remove helper existed — the schema gap the curator flagged).
- `src/kicad_tools/cli/fix_vias_cmd.py` — `--relocate-in-pad` + repeatable
  `--net` scoping; `get_mfr_design_rules()` resolves the full `DesignRules`
  (incl. `via_in_pad_supported`, `min_hole_to_hole_mm`) via the profile registry
  so `jlcpcb-tier1` aliases resolve. Relocation is a distinct pass; the resize
  path is untouched.
- `src/kicad_tools/cli/parser.py`, `cli/commands/validation.py` — flag wiring.
- `tests/test_fix_vias.py` — 12 new tests.

## Acceptance Criteria Verification (Phase 1)

| Criterion | Status | Verification |
|-----------|--------|--------------|
| New `--relocate-in-pad --mfr` flag | ✅ | `test_cli_main_json_report`, `test_dry_run_via_main_no_file_write` |
| Reuse via-in-pad geometry (shared helper), gated on `via_in_pad_supported==False` | ✅ | `via_pad_geometry` imported by both DRC rule and command |
| Signal via slid off-pad along escape track with drill-edge clearance ≥ min_clearance | ✅ | `test_signal_via_moved_off_pad` |
| Connectivity-preserving (stub on pad layer + connected layers; net intact) | ✅ | `test_stub_and_connectivity_preserved` |
| No regression (only via + new stubs change; existing copper byte-stable) | ✅ | `test_stub_and_connectivity_preserved` asserts the original escape segment is untouched |
| via-in-pad DRC count drops to 0 for handled vias | ✅ | `test_relocate_persists_through_save` (1→0), end-to-end `kct check` below |
| `--dry-run` mutates nothing | ✅ | `test_dry_run_mutates_nothing`, `test_dry_run_via_main_no_file_write` |
| skip on clearance/hole-to-hole → *skipped* | ✅ | `test_boxed_in_via_skipped` |
| Per-net scoping (`--net`) | ✅ | `test_net_filter_scopes_pass` |
| No-op on `jlcpcb-tier1`/`pcbway` | ✅ | `test_supported_mfr_is_noop` |
| Plane-stitch via reported, never left silently in-pad | ✅ | `test_plane_stitch_via_reported_unresolvable` |
| Clean no-op when no in-pad vias | ✅ | `test_no_in_pad_vias_clean_noop` |

## Test Plan

- `uv run pytest tests/test_fix_vias.py` — 83 passed (12 new).
- Refactor safety: `tests/test_validate_via_in_pad.py`, `test_drc_nudge.py`,
  `test_stitch_cmd.py` — 379 passed.
- `ruff check` / `ruff format --check` clean; mypy baseline gate: no new errors.
- Manual end-to-end on a synthetic in-pad board:
  `kct check --mfr jlcpcb` reports `via_in_pad: 1 error` →
  `kct fix-vias --relocate-in-pad --mfr jlcpcb` moves the via
  `(100.0, 100.0) → (100.777, 100.0)` with stubs on F.Cu/B.Cu →
  `kct check --mfr jlcpcb` reports 0 via-in-pad.

## Deferred (follow-ups)

- **Phase 2** — plane-stitch via relocation via the `stitch --avoid-pad-overlap`
  candidate-offset engine (covers the 48/87 plane-stitch vias in
  `chorus-test-revA_v24`). Reported as *unresolvable* today.
- **Phase 3** — multi-branch fan-out, non-cardinal rotated pads, dense-pitch
  no-clearing-location. Reported *unresolvable*/*skipped*, never mis-placed.

Closes #4359