### PR TITLE
fix: seed preserved non-listed copper as a hard obstacle in the mesh router

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -2404,7 +2404,16 @@ class Autorouter:
         if not connections:
             return {}
 
-        routes_by_key, stats = pf.route_netset(connections)
+        # Issue #4364: mirror the lattice driver (#4355) -- the preserved copper
+        # of NON-listed nets (``existing_routes`` loaded under --preserve-existing
+        # / --nets, keyed by their real net ids) must be a HARD obstacle in the
+        # mesh negotiation, else a listed net legally crosses foreign copper ->
+        # segment-segment short.  Feed only copper whose net is NOT in the
+        # routable set: a listed net being re-routed replaces its own stale
+        # copper, so it must not fix itself in place (byte-identical filter to
+        # ``_negotiate_lattice_netset``).
+        fixed_copper = [r for r in self.existing_routes if r.net not in self.nets]
+        routes_by_key, stats = pf.route_netset(connections, fixed_copper=fixed_copper)
         self._mesh_negotiation_stats = stats
 
         by_net: dict[int, list[Route]] = {}

--- a/src/kicad_tools/router/mesh/pathfinder.py
+++ b/src/kicad_tools/router/mesh/pathfinder.py
@@ -345,6 +345,7 @@ class MeshPathfinder:
         self,
         connections: list[Connection],
         *,
+        fixed_copper: list[Route] | None = None,
         max_iterations: int = 8,
         present_cost_initial: float = 0.5,
         present_cost_growth: float = 1.6,
@@ -364,6 +365,20 @@ class MeshPathfinder:
         stops early when every net routes or the routed set stops improving.
         The mesh is built **once** (see :meth:`build`); only portal cost changes
         between passes -- never the triangulation (risk (e)).
+
+        Issue #4364: ``fixed_copper`` is the preserved copper of NON-listed
+        nets (``Autorouter.existing_routes`` minus the routable set, loaded
+        under ``--nets`` / ``--preserve-existing`` after #4355).  Because the
+        per-pass ``committed_by_layer`` obstacle dict is reset empty at the top
+        of every pass, the fixed copper is **re-seeded into it each pass** via
+        the same :meth:`_route_obstacles_by_layer` capsule conversion the
+        commit loop uses -- so a negotiated net routes AROUND foreign copper or
+        is honestly declined, never emitted overlapping it.  The mesh committed
+        model is net-AGNOSTIC (plain polygons, no same-net exemption); this is
+        safe only because ``fixed_copper`` is pre-filtered to non-listed nets
+        by the driver, so a net being routed never self-blocks on its own seed.
+        ``fixed_copper=None`` / ``[]`` seeds nothing and is a byte-identical
+        no-op relative to the pre-#4364 negotiation.
 
         Returns ``(routes_by_key, stats)`` for the best iteration seen.
         """
@@ -396,6 +411,14 @@ class MeshPathfinder:
             # blocked by another net's B.Cu cross-under.  Reset each pass so a
             # rip-up genuinely frees the corridor.
             committed_by_layer: dict[int, list[list[Pt]]] = {}
+            # Issue #4364: pre-seed the preserved copper of NON-listed nets as
+            # an immovable hard obstacle.  The dict is reset every pass (so a
+            # rip-up frees listed-net corridors), therefore the fixed seed must
+            # be re-applied every pass.  Reusing ``_route_obstacles_by_layer``
+            # inflates and layer-buckets it identically to same-pass committed
+            # copper, so both the in-layer fit and ``_route_via_injection``
+            # (which reads the whole dict) honor it.
+            self._seed_fixed_copper(committed_by_layer, fixed_copper)
             for key, start, end, net_class in ordered:
                 start_L = self._layer_index(start.layer) or 0
                 # Issue #4274: the net's own-layer committed copper doubles as
@@ -864,6 +887,24 @@ class MeshPathfinder:
             if poly is not None:
                 out.setdefault(lidx, []).append(poly)
         return out
+
+    def _seed_fixed_copper(
+        self,
+        committed_by_layer: dict[int, list[list[Pt]]],
+        fixed_copper: list[Route] | None,
+    ) -> None:
+        """Pre-seed ``committed_by_layer`` with preserved non-listed copper (#4364).
+
+        Mirrors the same-pass commit loop's use of
+        :meth:`_route_obstacles_by_layer`: each fixed route's segments become
+        inflated per-layer capsule polygons so later listed nets clear them.
+        Called at the top of every negotiation pass (the dict is reset each
+        pass), so the seed is re-applied per pass.  A ``None`` / empty seed adds
+        nothing and is a byte-identical no-op.
+        """
+        for route in fixed_copper or []:
+            for lidx, polys in self._route_obstacles_by_layer(route).items():
+                committed_by_layer.setdefault(lidx, []).extend(polys)
 
     def _build_route(self, start: Pad, net: int, trace_w: float, fitted: list[Pt]) -> Route:
         route = Route(net=net, net_name=start.net_name)

--- a/tests/router/mesh/test_preserve_existing_obstacle.py
+++ b/tests/router/mesh/test_preserve_existing_obstacle.py
@@ -1,0 +1,180 @@
+"""Mesh honors preserved (non-listed) copper as a hard obstacle (#4364).
+
+Follow-up to #4355 (lattice/grid). The mesh negotiator tracked cross-net
+copper only in a **per-pass** ``committed_by_layer`` dict that was reset empty
+every pass and only ever held copper laid by *listed* nets earlier in the same
+pass -- the preserved copper of NON-listed nets
+(``Autorouter.existing_routes``, loaded under ``--nets`` /
+``--preserve-existing`` after #4355) was never seeded. So a listed net's
+octilinear fit saw no foreign trace and legally crossed it -> a
+``clearance_segment_segment`` short.
+
+``MeshPathfinder.route_netset`` now accepts ``fixed_copper`` (the preserved
+``Route``s) and re-seeds each pass's ``committed_by_layer`` with it -- via the
+same ``_route_obstacles_by_layer`` capsule conversion the commit loop uses --
+so a negotiated net routes AROUND the fixed copper or is honestly declined; it
+never emits copper overlapping the fixed net.
+
+These mirror ``tests/router/lattice/test_preserve_existing_obstacle.py`` for
+the mesh engine. The mesh engine HARD-REQUIRES the native C++ triangulation
+(no Python fallback), so this whole module ``importorskip``s
+``router_cpp`` -- run ``uv run kct build-native`` first or these silently skip.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.router.lattice.geometry import seg_seg_dist
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.mesh.pathfinder import MeshPathfinder
+from kicad_tools.router.primitives import Pad, Route, Segment
+from kicad_tools.router.rules import DesignRules
+
+# The mesh engine calls ``router_cpp.constrained_delaunay`` with no Python
+# fallback (``pathfinder.build()``); without the native extension these tests
+# cannot exercise the fix at all.
+router_cpp = pytest.importorskip("kicad_tools.router.router_cpp")
+
+_OUTLINE = [(0.0, 0.0), (20.0, 0.0), (20.0, 20.0), (0.0, 20.0)]
+
+
+def _pad(x: float, y: float, net: int, *, ref: str) -> Pad:
+    return Pad(
+        x=x,
+        y=y,
+        width=1.0,
+        height=1.0,
+        net=net,
+        net_name=f"N{net}",
+        layer=Layer.F_CU,
+        ref=ref,
+        pin="1",
+    )
+
+
+def _wall_segment(layer: Layer, *, y1: float, y2: float, width: float = 0.5) -> Segment:
+    """A vertical foreign-net (net 2) copper wall at x=10 on ``layer``."""
+    return Segment(
+        x1=10.0,
+        y1=y1,
+        x2=10.0,
+        y2=y2,
+        width=width,
+        layer=layer,
+        net=2,
+        net_name="N2",
+    )
+
+
+def _shorts_against(
+    routes: dict[object, Route],
+    wall: Segment,
+    *,
+    trace_half: float,
+    clearance: float,
+) -> bool:
+    """True if any routed segment overlaps ``wall`` below the required gap.
+
+    Mirrors ``clearance_segment_segment``: a same-layer, cross-net segment whose
+    centreline distance to the wall is under ``trace_half + wall_half +
+    clearance`` is an emitted short.
+    """
+    wall_half = wall.width / 2.0
+    gap = trace_half + wall_half + clearance
+    wa = (wall.x1, wall.y1)
+    wb = (wall.x2, wall.y2)
+    for route in routes.values():
+        for seg in route.segments:
+            if seg.layer != wall.layer or seg.net == wall.net:
+                continue
+            d = seg_seg_dist((seg.x1, seg.y1), (seg.x2, seg.y2), wa, wb)
+            if d < gap - 1e-6:
+                return True
+    return False
+
+
+def _fixture():
+    rules = DesignRules()
+    stack = LayerStack.two_layer()
+    # Net 1: two pads straddling the wall at x=10; the shortest route is a
+    # straight F_CU trace at y=10 that crosses the wall dead-centre.
+    pads = [_pad(2.0, 10.0, 1, ref="A"), _pad(18.0, 10.0, 1, ref="B")]
+    conns = [((1, 0), pads[0], pads[1], None)]
+    return rules, stack, pads, conns
+
+
+def test_baseline_without_fixed_copper_shorts_through_wall() -> None:
+    """Without ``fixed_copper`` the straight route crosses the wall (the bug)."""
+    rules, stack, pads, conns = _fixture()
+    wall = _wall_segment(Layer.F_CU, y1=2.0, y2=18.0)
+
+    pf = MeshPathfinder(_OUTLINE, pads, rules, layer_stack=stack)
+    routes, stats = pf.route_netset(conns, max_iterations=6)
+
+    # The net routes (straight, shortest) and -- because the mesh never saw the
+    # wall's copper -- it crosses it: a segment-segment short.
+    assert stats.routed == 1
+    assert _shorts_against(
+        routes, wall, trace_half=rules.trace_width / 2.0, clearance=rules.trace_clearance
+    )
+
+
+def test_fixed_copper_prevents_short_through_preserved_net() -> None:
+    """Seeding the wall as ``fixed_copper`` -> the route detours; never a short."""
+    rules, stack, pads, conns = _fixture()
+    wall = _wall_segment(Layer.F_CU, y1=2.0, y2=18.0)
+
+    pf = MeshPathfinder(_OUTLINE, pads, rules, layer_stack=stack)
+    routes, _stats = pf.route_netset(
+        conns,
+        fixed_copper=[Route(net=2, net_name="N2", segments=[wall])],
+        max_iterations=6,
+    )
+
+    # Whether the net detours (via to B_CU, across, back) or is declined, it is
+    # NEVER emitted overlapping the F_CU wall.
+    assert not _shorts_against(
+        routes, wall, trace_half=rules.trace_width / 2.0, clearance=rules.trace_clearance
+    )
+
+
+def test_fixed_copper_full_partition_declines_not_shorts() -> None:
+    """A wall on EVERY layer (no via detour) -> honest decline, not a short."""
+    rules, stack, pads, conns = _fixture()
+    # Full-height walls (beyond the board on both ends) on both routing layers:
+    # no same-layer detour and no via crossing is possible.
+    walls = [
+        _wall_segment(Layer.F_CU, y1=-2.0, y2=22.0),
+        _wall_segment(Layer.B_CU, y1=-2.0, y2=22.0),
+    ]
+    fixed = [Route(net=2, net_name="N2", segments=walls)]
+
+    pf = MeshPathfinder(_OUTLINE, pads, rules, layer_stack=stack)
+    routes, stats = pf.route_netset(conns, fixed_copper=fixed, max_iterations=6)
+
+    # Reported unroutable rather than shorted.
+    assert stats.routed == 0
+    for wall in walls:
+        assert not _shorts_against(
+            routes, wall, trace_half=rules.trace_width / 2.0, clearance=rules.trace_clearance
+        )
+
+
+def test_fixed_copper_empty_is_byte_identical_noop() -> None:
+    """``fixed_copper=None`` / ``[]`` leaves negotiation exactly as before."""
+    rules, stack, pads, conns = _fixture()
+
+    pf_none = MeshPathfinder(_OUTLINE, pads, rules, layer_stack=stack)
+    routes_none, stats_none = pf_none.route_netset(conns, max_iterations=6)
+
+    pf_empty = MeshPathfinder(_OUTLINE, pads, rules, layer_stack=stack)
+    routes_empty, stats_empty = pf_empty.route_netset(conns, fixed_copper=[], max_iterations=6)
+
+    assert stats_none.routed == stats_empty.routed == 1
+    # Same key set and same emitted geometry (the seed set is empty either way).
+    assert routes_none.keys() == routes_empty.keys()
+    for key in routes_none:
+        segs_a = [(s.x1, s.y1, s.x2, s.y2, s.layer) for s in routes_none[key].segments]
+        segs_b = [(s.x1, s.y1, s.x2, s.y2, s.layer) for s in routes_empty[key].segments]
+        assert segs_a == segs_b


### PR DESCRIPTION
## Summary
Applies the #4355 / PR #4361 `route --nets` fixed-obstacle fix to the **mesh** router engine (lattice + grid were already done). When `route --nets` runs on an already-routed board, the preserved copper of non-listed nets is now seeded into the mesh negotiator's per-pass clearance/obstacle model, so listed nets route **around** foreign copper (or are honestly declined) instead of legally crossing it and shipping a `clearance_segment_segment` short.

## Root cause
`MeshPathfinder.route_netset` tracks cross-net copper only in a per-pass `committed_by_layer` dict that is reset empty at the top of every negotiation pass and only ever holds copper laid by *listed* nets earlier in the same pass. The preserved copper of non-listed nets (`Autorouter.existing_routes`, loaded under `--nets` / `--preserve-existing` after #4355) was never seeded — the same structural gap #4355 fixed for the lattice, one obstacle-container over.

## Changes
- `src/kicad_tools/router/mesh/pathfinder.py`: `route_netset` gains a `fixed_copper: list[Route] | None = None` kwarg and a `_seed_fixed_copper` helper. At the top of **each** pass (the dict is reset per pass) the fixed copper is re-seeded via the existing `_route_obstacles_by_layer` capsule conversion — identical inflation and layer-bucketing to same-pass committed copper — so both the in-layer octilinear fit and `_route_via_injection` (which reads the whole dict) honor it.
- `src/kicad_tools/router/core.py`: `_negotiate_mesh_netset` computes `fixed_copper = [r for r in self.existing_routes if r.net not in self.nets]` (byte-identical to the lattice driver at `_negotiate_lattice_netset`) and passes it through.
- `tests/router/mesh/test_preserve_existing_obstacle.py` (new): mirrors the lattice regression test for the mesh engine.

## Correctness notes
- The filter is load-bearing: the mesh committed model is net-agnostic (plain polygons, no same-net exemption). Pre-filtering the seed to non-listed nets is what prevents a routed net self-blocking on its own stale copper.
- Empty/`None` `fixed_copper` seeds nothing into the (already-empty) dict → byte-identical no-op relative to the pre-#4364 negotiation.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Preserved non-listed copper seeded into mesh obstacle model | ✅ | `_seed_fixed_copper` re-seeds `committed_by_layer` each pass |
| Listed nets route around / declined, never shorted | ✅ | `test_fixed_copper_prevents_short_through_preserved_net`, `test_fixed_copper_full_partition_declines_not_shorts` |
| Empty `fixed_copper` byte-identical no-op | ✅ | `test_fixed_copper_empty_is_byte_identical_noop` (routed count, key set, per-segment geometry all equal) |
| Regression test reproduces the short without the seed | ✅ | `test_baseline_without_fixed_copper_shorts_through_wall` |
| Driver filter byte-identical to lattice | ✅ | `[r for r in self.existing_routes if r.net not in self.nets]` |
| Test runs (not skipped) with native backend | ✅ | `kct build-native --check` → available; 4/4 PASSED |

## Test Plan
- `uv run kct build-native --check` → "C++ backend: available (version 1.0.0)".
- `uv run pytest tests/router/mesh/test_preserve_existing_obstacle.py -v` → 4 passed (not skipped).
- `uv run pytest tests/router/mesh/` → 54 passed (full mesh suite, no regressions).
- `uv run ruff check` + `ruff format --check` on changed files → clean.
- `uv run python scripts/ci/check_mypy_baseline.py` → exit 0, no new type errors.

Closes #4364