### PR TITLE
fix(creepage): narrow mains-name regex to stop over-matching benign LINE/HOT/PRIMARY tokens

### DIFF
--- a/src/kicad_tools/creepage/engine.py
+++ b/src/kicad_tools/creepage/engine.py
@@ -73,8 +73,8 @@ SELV_WORKING_VOLTAGE_V = 50.0
 MAINS_NAME_RE = re.compile(
     r"(?:^|[_/])"
     r"(?:"
-    r"AC[_-]?LINE|AC[_-]?NEUT(?:RAL)?|L[_-]?LINE|N[_-]?LINE|LINE(?:_IN)?|"
-    r"LIVE|NEUTRAL|MAINS|FUSED(?:_[A-Z0-9]+)?|HV[_A-Z0-9]*|PRIMARY|HOT"
+    r"AC[_-]?LINE|AC[_-]?NEUT(?:RAL)?|L[_-]?LINE|N[_-]?LINE|"
+    r"LIVE|NEUTRAL|MAINS|FUSED(?:_[A-Z0-9]+)?|HV[_A-Z0-9]*"
     r")"
     r"(?:$|[_/])",
     re.IGNORECASE,
@@ -332,8 +332,8 @@ def resolve_hv_nets(
        can never return ``"HV"`` and step 2 is unreachable for the HV group
        (issue #4354).  Any unmapped net whose name carries a strong mains/HV
        signal (:data:`MAINS_NAME_RE` -- ``AC_LINE``, ``AC_NEUTRAL``,
-       ``FUSED_LINE``, ``*MAINS*``, ``HV*``, ``LIVE``, ``NEUTRAL``,
-       ``PRIMARY`` ...) is therefore selected here.  An explicit map entry
+       ``FUSED_LINE``, ``*MAINS*``, ``HV*``, ``LIVE``,
+       ``NEUTRAL`` ...) is therefore selected here.  An explicit map entry
        always wins (step 1), so operator-supplied classification is never
        overridden by this fallback.
     """

--- a/tests/creepage/fixtures.py
+++ b/tests/creepage/fixtures.py
@@ -99,6 +99,48 @@ def board_no_hv_source() -> str:
     return "".join(parts)
 
 
+# Header for the benign-suspect fixture (issue #4365): net names that *look*
+# mains-ish to a naive scanner (LINE / HOT / PRIMARY tokens) but are ordinary
+# signals -- SPI_LINE, HOT_SWAP, PRIMARY_CLK.  The tightened MAINS_NAME_RE must
+# NOT flag any of these, so a board carrying only these nets (and no mains-level
+# working voltage) exits 0 rather than tripping the #4354 vacuity guard.
+_BENIGN_HEADER = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test_creepage")
+  (general (thickness 1.6))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "SPI_LINE")
+  (net 2 "GND")
+  (net 3 "HOT_SWAP")
+  (net 4 "PRIMARY_CLK")
+"""
+
+
+def board_benign_suspect_names_source() -> str:
+    """Board whose only suspect-shaped nets are benign (issue #4365).
+
+    ``SPI_LINE`` / ``HOT_SWAP`` / ``PRIMARY_CLK`` carry the LINE / HOT / PRIMARY
+    tokens that the *old* broad regex over-matched.  With the tightened
+    :data:`kicad_tools.creepage.engine.MAINS_NAME_RE`, none are mains-suspect, so
+    a low-voltage audit of this board must exit 0 (no vacuity guard trip).
+    """
+    parts = [_BENIGN_HEADER, _OUTLINE]
+    parts.append(_footprint("U1", 110, 110, 1, "SPI_LINE"))
+    parts.append(_footprint("U2", 130, 110, 2, "GND"))
+    parts.append(_footprint("U3", 135, 110, 3, "HOT_SWAP"))
+    parts.append(_footprint("U4", 105, 110, 4, "PRIMARY_CLK"))
+    parts.append(")\n")
+    return "".join(parts)
+
+
 # Header for the mains-named fixture: unmistakable mains net names (AC_LINE /
 # AC_NEUTRAL / FUSED_LINE) that the broadened HV name-pattern fallback (#4354)
 # must classify as HV without any net-class-map.

--- a/tests/creepage/test_creepage_cli.py
+++ b/tests/creepage/test_creepage_cli.py
@@ -16,7 +16,12 @@ from kicad_tools._shapely import has_shapely
 from kicad_tools.cli.commands.creepage import run_creepage_command
 from kicad_tools.cli.parser import create_parser
 
-from .fixtures import board_mains_named_source, board_no_hv_source, board_source
+from .fixtures import (
+    board_benign_suspect_names_source,
+    board_mains_named_source,
+    board_no_hv_source,
+    board_source,
+)
 
 pytestmark = pytest.mark.skipif(not has_shapely(), reason="creepage requires shapely")
 
@@ -222,6 +227,30 @@ def test_low_voltage_non_hv_board_still_exits_zero(tmp_path, capsys):
     # voltage below the 50 V SELV boundary) must still exit 0 with the inert
     # "Nothing to audit" message -- no false alarms.
     pcb = _write(tmp_path, board_no_hv_source())
+    rc = _run(
+        [
+            "creepage",
+            str(pcb),
+            "--standard",
+            "iec60664",
+            "--working-voltage",
+            "24",
+            "--pollution-degree",
+            "2",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "Nothing to audit -- exit 0" in captured.out
+    assert "WARNING" not in captured.err
+
+
+def test_benign_suspect_named_board_exits_zero(tmp_path, capsys):
+    # Issue #4365: a board whose only suspect-shaped nets are benign
+    # (SPI_LINE / HOT_SWAP / PRIMARY_CLK) with no mains-level working voltage
+    # must NOT trip the #4354 vacuity guard -- the tightened MAINS_NAME_RE no
+    # longer flags bare LINE / HOT / PRIMARY tokens, so this exits 0.
+    pcb = _write(tmp_path, board_benign_suspect_names_source())
     rc = _run(
         [
             "creepage",

--- a/tests/creepage/test_creepage_engine.py
+++ b/tests/creepage/test_creepage_engine.py
@@ -210,12 +210,13 @@ def test_name_pattern_fallback_without_map(tmp_path):
         "FUSED",
         "MAINS_L",
         "L_MAINS",
+        "MAINS_IN",
         "HV_BUS",
         "HV",
+        "L_LINE",
+        "N_LINE",
         "LIVE",
         "NEUTRAL",
-        "PRIMARY",
-        "LINE",
         "/AC_LINE",  # hierarchical leading slash
     ],
 )
@@ -235,6 +236,17 @@ def test_is_mains_suspect_name_positive(name):
         "VCC",
         "ONLINE",  # 'LINE' substring, no token boundary -> must NOT match
         "REMAINS",  # 'MAINS' substring, no token boundary -> must NOT match
+        # Bare LINE/HOT/PRIMARY tokens no longer match (issue #4365): they
+        # over-matched benign nets and were dropped from MAINS_NAME_RE.
+        "PRIMARY",
+        "LINE",
+        "HOT",
+        "LINE_A",
+        "SPI_LINE",
+        "LINE_IN",
+        "HOT_SWAP",
+        "PRIMARY_CLK",
+        "KEEP_ALIVE",  # 'LIVE' preceded by 'A', not a token boundary
         "",
         None,
     ],


### PR DESCRIPTION
## Summary

Follow-up to #4354 / PR #4362. The mains-name regex `MAINS_NAME_RE` (`src/kicad_tools/creepage/engine.py`) is deliberately safety-biased but over-matched benign token-bearing nets — `LINE_A`, `SPI_LINE`, `HOT_SWAP`, `PRIMARY_CLK` — which could flip a legitimately-non-mains board to a non-zero exit under the opt-in `kct creepage` / `kct audit` vacuity guard. This narrows the regex by dropping exactly the three over-matching bare alternatives while keeping all qualified mains forms intact.

## Changes

- **`engine.py`**: removed bare `LINE(?:_IN)?`, `HOT`, and `PRIMARY` from `MAINS_NAME_RE`. Qualified mains forms survive via their own alternatives (`AC[_-]?LINE`, `AC[_-]?NEUT(?:RAL)?`, `L[_-]?LINE`, `N[_-]?LINE`, `FUSED(?:_[A-Z0-9]+)?`, `MAINS`, `HV[_A-Z0-9]*`, `LIVE`, `NEUTRAL`). Updated the `resolve_hv_nets` docstring to stop advertising bare `PRIMARY`.
- **`test_creepage_engine.py`**: moved the two #4354 cases `"PRIMARY"` and `"LINE"` from the positive parametrize to the negative one; added benign negatives (`LINE_A`, `SPI_LINE`, `LINE_IN`, `HOT_SWAP`, `PRIMARY_CLK`, `HOT`, `KEEP_ALIVE`) and qualified positives (`MAINS_IN`, `L_LINE`, `N_LINE`).
- **`fixtures.py`**: added `board_benign_suspect_names_source()` (`SPI_LINE` / `HOT_SWAP` / `PRIMARY_CLK` + `GND`).
- **`test_creepage_cli.py`**: added a test proving a benign-suspect board with no mains-level working voltage exits 0 (guard does NOT fire).

The safety bias is preserved: the vacuity guard fires on `suspects OR high_working_voltage`, so genuine HV audits still trip via `--hv-working-voltage >= 50` even without a name match. That path was not touched.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `LINE_A`, `SPI_LINE`, `HOT_SWAP`, `PRIMARY_CLK` (and bare `LINE`/`PRIMARY`) no longer trigger mains-suspect | ✅ | New negative parametrize cases in `test_is_mains_suspect_name_negative`, all green |
| `AC_LINE`, `AC_NEUTRAL`, `FUSED_LINE`, `MAINS_IN`, `HV_BUS` still do | ✅ | Positive parametrize cases (incl. added `MAINS_IN`), all green |
| Negative-case tests added for newly-excluded names | ✅ | Engine negatives + CLI benign-board exit-0 test |
| Existing #4354 tests still green (except the two intended positive→negative moves) | ✅ | `pytest tests/creepage/` → 133 passed; `pytest -k audit` → 349 passed |

## Test Plan

- `uv run pytest tests/creepage/` — 133 passed
- `uv run pytest -k audit` — 349 passed, 11 skipped
- `uv run ruff check` + `ruff format --check` — clean
- `uv run mypy src/kicad_tools/creepage/` — no issues (no baseline change needed)

Closes #4365