### PR TITLE
feat(fix-vias): relocate plane-stitch in-pad vias off-pad into same-net zone

### DIFF
--- a/src/kicad_tools/cli/relocate_in_pad_vias.py
+++ b/src/kicad_tools/cli/relocate_in_pad_vias.py
@@ -2,6 +2,7 @@
 """Relocate via-in-pad vias off-pad (connectivity-preserving).
 
 Issue #4359 -- Phase 1 (signal-via slide-out).
+Issue #4367 -- Phase 2 (plane-stitch off-pad placement).
 
 When a board is routed for a manufacturer that supports via-in-pad
 (``jlcpcb-tier1``, ``pcbway``) and then re-targeted to a profile that does
@@ -18,17 +19,28 @@ each connected segment's layer).  No existing copper is mutated -- only the
 via's ``(at ...)`` position moves and new stub segments are appended -- so an
 already-routed board is never regressed.
 
-Deferred to follow-ups (explicitly out of scope for Phase 1):
+**Phase 2** (issue #4367) extends this to **plane-stitch** vias -- a via tying
+a power/ground SMD pad to a same-net copper pour, with no routed escape track.
+These have no slide direction, so instead the pass walks the
+``stitch --avoid-pad-overlap`` candidate ladder (8 directions x 3 escape
+offsets from the pad edge) and picks the first off-pad location that (a) clears
+the pad by ``min_clearance_mm``, (b) clears all other-net copper + the
+hole-to-hole floor, and (c) lands **inside a same-net zone boundary polygon**
+on a layer the via spans.  Because plane connectivity is realized by pour
+overlap -- not a discrete track -- a plane-stitch move needs **no stub**: after
+the operator re-floods the pour (``kicad-cli pcb drc --refill-zones``) the
+zone reconnects to the via's annular ring at its new location.  When no
+plane-legal, clearance-safe candidate exists (no same-net zone, or every
+candidate is boxed in) the via is reported *unresolvable* and left in place --
+never mis-placed into a short.
 
-* **Phase 2** -- plane-stitch vias (a via tying a power/ground pad to a pour
-  with no routed track).  These have no escape direction; relocating them needs
-  the ``stitch --avoid-pad-overlap`` candidate-offset engine.  They are reported
-  as *unresolvable* here, never left silently in-pad.
+Deferred to follow-ups (explicitly out of scope):
+
 * **Phase 3** -- multi-branch fan-out, non-cardinal rotated pads, and
   dense-pitch pads with no clearing location.  Each is reported as
   *unresolvable* / *skipped* rather than mis-placed.
 
-Any via Phase 1 cannot safely handle is counted in the report (skipped or
+Any via this pass cannot safely handle is counted in the report (skipped or
 unresolvable) -- it is never left in-pad without being surfaced.
 """
 
@@ -39,6 +51,7 @@ import math
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from kicad_tools.cli.stitch_cmd import point_in_polygon
 from kicad_tools.validate.rules.via_pad_geometry import (
     is_smd_pad,
     pad_absolute_bbox,
@@ -47,7 +60,7 @@ from kicad_tools.validate.rules.via_pad_geometry import (
 
 if TYPE_CHECKING:
     from kicad_tools.manufacturers.base import DesignRules
-    from kicad_tools.schema.pcb import PCB, Footprint, Pad, Segment, Via
+    from kicad_tools.schema.pcb import PCB, Footprint, Pad, Segment, Via, Zone
 
 # Coincidence tolerance for "a track endpoint lands on the via center", mirroring
 # the 0.001 mm test used by fix_vias_cmd.find_nearby_items.
@@ -56,7 +69,14 @@ _COINCIDENT_TOL = 1e-3
 
 @dataclass
 class ViaRelocation:
-    """Record of an in-pad via that was slid off-pad."""
+    """Record of an in-pad via that was moved off-pad.
+
+    ``kind`` is ``"signal"`` for a Phase-1 slide-along-track move (which appends
+    connectivity stubs -- see :attr:`stub_layers`) or ``"plane-stitch"`` for a
+    Phase-2 pour-overlap move (which appends **no** stub; the net reconnects on
+    the next zone refill).  Plane-stitch moves therefore always have an empty
+    :attr:`stub_layers`.
+    """
 
     old_x: float
     old_y: float
@@ -67,6 +87,7 @@ class ViaRelocation:
     pad_ref: str
     uuid: str
     stub_layers: list[str] = field(default_factory=list)
+    kind: str = "signal"
 
 
 @dataclass
@@ -179,6 +200,113 @@ def _pad_copper_layer(pad: Pad) -> str:
         if layer.endswith(".Cu") and not layer.startswith("*"):
             return layer
     return "F.Cu"
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: plane-stitch off-pad placement helpers
+# ---------------------------------------------------------------------------
+
+# Candidate directions from the pad centre (unit vectors) -- the 8-direction
+# ladder mirrored from stitch_cmd.calculate_via_position.
+_PLANE_DIRECTIONS: tuple[tuple[float, float], ...] = (
+    (1.0, 0.0),
+    (0.0, 1.0),
+    (-1.0, 0.0),
+    (0.0, -1.0),
+    (0.707, 0.707),
+    (-0.707, 0.707),
+    (-0.707, -0.707),
+    (0.707, -0.707),
+)
+
+
+def _via_spans_zone_layer(via: Via, zone: Zone) -> bool:
+    """True when ``zone.layer`` is a copper layer the ``via`` connects on.
+
+    A candidate is only plane-legal on layers the via actually touches.  A via
+    whose ``layers`` list names the zone layer clearly spans it; a full
+    through-hole via (both ``F.Cu`` and ``B.Cu`` present) passes through every
+    copper layer, so any copper zone layer counts.
+    """
+    via_layers = set(via.layers)
+    if zone.layer in via_layers:
+        return True
+    if "F.Cu" in via_layers and "B.Cu" in via_layers and zone.layer.endswith(".Cu"):
+        return True
+    return False
+
+
+def _same_net_zone_boundaries(pcb: PCB, via: Via, net_name: str) -> list[list[tuple[float, float]]]:
+    """Return boundary polygons of same-net zones on a layer the via spans.
+
+    Uses each zone's ``polygon`` (the pour *boundary*, not the stale
+    ``filled_polygons``): connectivity is realized only after a zone refill, so
+    the boundary is the correct membership target for a relocated stitch via.
+    Net matching is by number when both are non-zero, falling back to name
+    (KiCad 10 may emit ``(net "GND")`` with no numeric id).
+    """
+    polygons: list[list[tuple[float, float]]] = []
+    for zone in pcb.zones:
+        net_matches = (via.net_number != 0 and zone.net_number == via.net_number) or (
+            bool(net_name) and zone.net_name == net_name
+        )
+        if not net_matches:
+            continue
+        if not _via_spans_zone_layer(via, zone):
+            continue
+        if zone.polygon:
+            polygons.append(zone.polygon)
+    return polygons
+
+
+def _first_offpad_plane_candidate(
+    pcb: PCB,
+    via: Via,
+    bbox: tuple[float, float, float, float],
+    pads_by_net: dict[int, list[tuple[Footprint, Pad, tuple[float, float, float, float]]]],
+    min_clearance: float,
+    min_hole_to_hole: float,
+    zone_polygons: list[list[tuple[float, float]]],
+) -> tuple[float, float] | None:
+    """Find the first plane-legal, clearance-safe off-pad location for a via.
+
+    Walks the 8-direction x 3-offset ladder from the pad centre.  A candidate is
+    accepted only when it (a) clears the pad bbox edge by ``min_clearance`` (via
+    copper radius), (b) lands inside a same-net zone boundary polygon, and (c)
+    introduces no other-net clearance or hole-to-hole violation
+    (:func:`_check_clearance`).  Returns ``None`` when every candidate fails --
+    the caller then reports the via as ``unresolvable`` and leaves it in place.
+    """
+    pad_cx = (bbox[0] + bbox[2]) / 2.0
+    pad_cy = (bbox[1] + bbox[3]) / 2.0
+    via_r = via.size / 2.0
+    # Extra push-out beyond the guaranteed pad-clearing distance, to dodge
+    # obstacles farther from the pad edge (mirrors stitch's offset*{1,1.5,2}).
+    step = via.size + min_clearance
+    extra_offsets = (0.0, step * 0.5, step)
+
+    for extra in extra_offsets:
+        for dx, dy in _PLANE_DIRECTIONS:
+            t_exit = _ray_aabb_exit_distance(pad_cx, pad_cy, dx, dy, bbox)
+            slide = t_exit + via_r + min_clearance + extra
+            nx = pad_cx + dx * slide
+            ny = pad_cy + dy * slide
+
+            # (a) via copper must clear the pad bbox edge by min_clearance.
+            if _dist_point_to_aabb(nx, ny, bbox) - via_r < min_clearance - 1e-6:
+                continue
+            # (b) must land inside a same-net zone boundary (pour overlap).
+            if not any(point_in_polygon(nx, ny, poly) for poly in zone_polygons):
+                continue
+            # (c) must not violate other-net copper / hole-to-hole.
+            if (
+                _check_clearance(pcb, via, nx, ny, pads_by_net, min_clearance, min_hole_to_hole)
+                is not None
+            ):
+                continue
+            return (nx, ny)
+
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -331,20 +459,85 @@ def relocate_in_pad_vias(
                 connected.append((seg, far))
 
         if not connected:
-            # No routed track -> plane-stitch or unconnected via (Phase 2).
-            result.unresolvable.append(
-                ViaRelocationSkip(
-                    x=vx,
-                    y=vy,
+            # No routed track -> plane-stitch via (Phase 2).  Its only electrical
+            # path is pour overlap, so relocation stays inside a same-net zone
+            # boundary and adds NO stub -- connectivity re-realizes on the next
+            # zone refill.  Fall back to unresolvable only when placement fails.
+            zone_polygons = _same_net_zone_boundaries(pcb, via, net_name)
+            if not zone_polygons:
+                result.unresolvable.append(
+                    ViaRelocationSkip(
+                        x=vx,
+                        y=vy,
+                        net=via.net_number,
+                        net_name=net_name,
+                        pad_ref=pad_ref,
+                        reason=(
+                            "plane-stitch via has no same-net zone on a via layer to relocate into"
+                        ),
+                        uuid=via.uuid,
+                        category="unresolvable",
+                    )
+                )
+                continue
+
+            target = _first_offpad_plane_candidate(
+                pcb,
+                via,
+                bbox,
+                pads_by_net,
+                min_clearance,
+                min_hole_to_hole,
+                zone_polygons,
+            )
+            if target is None:
+                result.unresolvable.append(
+                    ViaRelocationSkip(
+                        x=vx,
+                        y=vy,
+                        net=via.net_number,
+                        net_name=net_name,
+                        pad_ref=pad_ref,
+                        reason=(
+                            "plane-stitch via: no clearance-legal off-pad location "
+                            "inside the same-net zone boundary (boxed in)"
+                        ),
+                        uuid=via.uuid,
+                        category="unresolvable",
+                    )
+                )
+                continue
+
+            new_x, new_y = target
+            if not dry_run:
+                moved_ok = pcb.relocate_via(via, (new_x, new_y))
+                if not moved_ok:
+                    result.unresolvable.append(
+                        ViaRelocationSkip(
+                            x=vx,
+                            y=vy,
+                            net=via.net_number,
+                            net_name=net_name,
+                            pad_ref=pad_ref,
+                            reason="could not locate backing (via ...) node to persist move",
+                            uuid=via.uuid,
+                            category="unresolvable",
+                        )
+                    )
+                    continue
+
+            result.moved.append(
+                ViaRelocation(
+                    old_x=vx,
+                    old_y=vy,
+                    new_x=new_x,
+                    new_y=new_y,
                     net=via.net_number,
                     net_name=net_name,
                     pad_ref=pad_ref,
-                    reason=(
-                        "no connected routed track (plane-stitch via -- deferred to "
-                        "Phase 2 stitch-engine relocation)"
-                    ),
                     uuid=via.uuid,
-                    category="unresolvable",
+                    stub_layers=[],
+                    kind="plane-stitch",
                 )
             )
             continue
@@ -513,6 +706,7 @@ def print_relocation_results(
                     "pad": m.pad_ref,
                     "uuid": m.uuid,
                     "stub_layers": m.stub_layers,
+                    "kind": m.kind,
                 }
                 for m in result.moved
             ],
@@ -569,13 +763,24 @@ def print_relocation_results(
     action = "Would move" if dry_run else "Moved"
     print(f"{action} {len(result.moved)} in-pad via(s) off-pad:")
     for m in result.moved[:10]:
+        if m.stub_layers:
+            tie = f"stubs on {', '.join(m.stub_layers)}"
+        else:
+            tie = "plane-stitch (no stub; pour overlap re-realized on zone refill)"
         print(
             f"  Via {m.uuid[:8] or '?'} (net '{m.net_name}') on pad {m.pad_ref}: "
             f"({m.old_x:.3f}, {m.old_y:.3f}) -> ({m.new_x:.3f}, {m.new_y:.3f}); "
-            f"stubs on {', '.join(m.stub_layers)}"
+            f"{tie}"
         )
     if len(result.moved) > 10:
         print(f"  ... and {len(result.moved) - 10} more")
+
+    if any(m.kind == "plane-stitch" for m in result.moved):
+        print(
+            "\nNote: plane-stitch vias were moved without a stub -- run "
+            "`kicad-cli pcb drc --refill-zones` to re-establish the pour "
+            "connection at each via's new location."
+        )
 
     if result.skipped:
         print(f"\nSkipped {len(result.skipped)} via(s) (would violate clearance):")

--- a/tests/test_fix_vias.py
+++ b/tests/test_fix_vias.py
@@ -1828,6 +1828,75 @@ _PCB_BOXED_IN = """(kicad_pcb
 )
 """
 
+# Plane-stitch in-pad via WITH a same-net pour whose boundary extends well
+# beyond the pad -- Phase 2 can slide the via off-pad into the zone (no stub).
+_PCB_PLANE_STITCH_WITH_ZONE = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (paper "A4")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal) (44 "Edge.Cuts" user))
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (footprint "test:pad" (layer "F.Cu") (at 100 100)
+    (pad "1" smd rect (at 0 0) (size 1.0 1.0) (layers "F.Cu") (net 1 "GND"))
+  )
+  (via (at 100 100) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 1) (uuid "via-stitch"))
+  (zone (net 1) (net_name "GND") (layer "F.Cu") (uuid "zone-gnd")
+    (polygon (pts (xy 95 95) (xy 108 95) (xy 108 108) (xy 95 108)))
+  )
+)
+"""
+
+# Plane-stitch in-pad via whose same-net pour is only a thin strip to the +X of
+# the pad, and a foreign-net pad occupies that strip -> every zone-legal
+# candidate collides with foreign copper, so the via is unresolvable (never
+# mis-placed outside the pour or into a short).
+_PCB_PLANE_STITCH_BOXED_IN = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (paper "A4")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal) (44 "Edge.Cuts" user))
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "SIG2")
+  (footprint "test:pad" (layer "F.Cu") (at 100 100)
+    (pad "1" smd rect (at 0 0) (size 1.0 1.0) (layers "F.Cu") (net 1 "GND"))
+  )
+  (footprint "test:pad" (layer "F.Cu") (at 102 100)
+    (pad "1" smd rect (at 0 0) (size 2.0 1.0) (layers "F.Cu") (net 2 "SIG2"))
+  )
+  (via (at 100 100) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 1) (uuid "via-stitch"))
+  (zone (net 1) (net_name "GND") (layer "F.Cu") (uuid "zone-gnd")
+    (polygon (pts (xy 100.5 99.7) (xy 104 99.7) (xy 104 100.3) (xy 100.5 100.3)))
+  )
+)
+"""
+
+# Plane-stitch via with a same-net pour, but the via is already clear of the
+# pad -> nothing to relocate (clean no-op even though a zone exists).
+_PCB_PLANE_STITCH_CLEAR_OF_PAD = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (paper "A4")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal) (44 "Edge.Cuts" user))
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (footprint "test:pad" (layer "F.Cu") (at 100 100)
+    (pad "1" smd rect (at 0 0) (size 1.0 1.0) (layers "F.Cu") (net 1 "GND"))
+  )
+  (via (at 104 104) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 1) (uuid "via-clear"))
+  (zone (net 1) (net_name "GND") (layer "F.Cu") (uuid "zone-gnd")
+    (polygon (pts (xy 95 95) (xy 108 95) (xy 108 108) (xy 95 108)))
+  )
+)
+"""
+
 # Board with a via that is NOT inside any pad (well clear of it).
 _PCB_NO_IN_PAD = """(kicad_pcb
   (version 20240108)
@@ -2031,3 +2100,176 @@ class TestRelocateInPadVias:
         assert data["dry_run"] is True
         assert len(data["moved"]) == 1
         assert "skipped" in data and "unresolvable" in data
+
+
+# ===========================================================================
+# Issue #4367 -- fix-vias --relocate-in-pad (Phase 2: plane-stitch off-pad)
+# ===========================================================================
+
+from kicad_tools.cli.stitch_cmd import point_in_polygon  # noqa: E402
+
+
+class TestPlaneStitchRelocation:
+    """Phase-2 plane-stitch in-pad via relocation (issue #4367)."""
+
+    def test_plane_stitch_via_moved_into_zone(self, tmp_path: Path):
+        """A plane-stitch via is slid off-pad into the same-net zone, no stub."""
+        p = _write(tmp_path, _PCB_PLANE_STITCH_WITH_ZONE)
+        pcb = PCB.load(p)
+        assert _via_in_pad_count(pcb) == 1  # precondition: it IS in-pad
+
+        rules = get_mfr_design_rules("jlcpcb", 2, 1.0)
+        result = relocate_in_pad_vias(pcb, rules, dry_run=False)
+
+        assert len(result.moved) == 1
+        assert not result.skipped
+        assert not result.unresolvable
+
+        moved = result.moved[0]
+        # Plane-stitch move: NO stub (pour overlap carries the net after refill).
+        assert moved.stub_layers == []
+        assert moved.kind == "plane-stitch"
+
+        via = pcb.vias[0]
+        fp = pcb.footprints[0]
+        pad = fp.pads[0]
+        bbox = _pad_absolute_bbox(pad, fp)
+
+        # Via drill is now fully OUTSIDE the pad bbox.
+        assert not _via_inside_pad(via, bbox)
+        # Drill edge clears the pad edge by at least min_clearance (any side).
+        drill_edge_gap = (
+            min(
+                abs(via.position[0] - bbox[0]),
+                abs(via.position[0] - bbox[2]),
+                abs(via.position[1] - bbox[1]),
+                abs(via.position[1] - bbox[3]),
+            )
+            - via.drill / 2.0
+        )
+        assert drill_edge_gap >= rules.min_clearance_mm - 1e-6
+
+        # The new position lies inside the same-net zone boundary polygon.
+        zone = pcb.zones[0]
+        assert point_in_polygon(via.position[0], via.position[1], zone.polygon)
+
+        # No stub segment was appended (plane-stitch relies on pour overlap).
+        assert len(pcb.segments) == 0
+
+    def test_plane_stitch_move_persists_through_save(self, tmp_path: Path):
+        """The plane-stitch move round-trips to disk and clears the DRC count."""
+        p = _write(tmp_path, _PCB_PLANE_STITCH_WITH_ZONE)
+        pcb = PCB.load(p)
+        rules = get_mfr_design_rules("jlcpcb", 2, 1.0)
+        relocate_in_pad_vias(pcb, rules, dry_run=False)
+        moved_pos = pcb.vias[0].position
+        pcb.save(p)
+
+        reloaded = PCB.load(p)
+        assert reloaded.vias[0].position == pytest.approx(moved_pos)
+        assert _via_in_pad_count(reloaded) == 0
+
+    def test_plane_stitch_dry_run_mutates_nothing(self, tmp_path: Path):
+        """--dry-run reports the plane-stitch move but writes nothing."""
+        p = _write(tmp_path, _PCB_PLANE_STITCH_WITH_ZONE)
+        pcb = PCB.load(p)
+        n_segments_before = len(pcb.segments)
+        via_pos_before = pcb.vias[0].position
+
+        rules = get_mfr_design_rules("jlcpcb", 2, 1.0)
+        result = relocate_in_pad_vias(pcb, rules, dry_run=True)
+
+        assert len(result.moved) == 1
+        assert result.moved[0].kind == "plane-stitch"
+        # ...but nothing was mutated.
+        assert pcb.vias[0].position == via_pos_before
+        assert len(pcb.segments) == n_segments_before
+
+    def test_plane_stitch_dry_run_via_main_no_file_write(self, tmp_path: Path):
+        """The CLI --dry-run path leaves the file byte-identical for a stitch move."""
+        p = _write(tmp_path, _PCB_PLANE_STITCH_WITH_ZONE)
+        original = p.read_text()
+        rc = main([str(p), "--mfr", "jlcpcb", "--relocate-in-pad", "--dry-run", "-q"])
+        assert rc in (0, 2)
+        assert p.read_text() == original
+
+    def test_plane_stitch_no_zone_reported_unresolvable(self, tmp_path: Path):
+        """A plane-stitch via with NO same-net zone stays unresolvable, untouched."""
+        p = _write(tmp_path, _PCB_PLANE_STITCH_IN_PAD)
+        pcb = PCB.load(p)
+        rules = get_mfr_design_rules("jlcpcb", 2, 1.0)
+        result = relocate_in_pad_vias(pcb, rules, dry_run=False)
+
+        assert not result.moved
+        assert len(result.unresolvable) == 1
+        assert result.unresolvable[0].category == "unresolvable"
+        assert "no same-net zone" in result.unresolvable[0].reason
+        # The via is left untouched (still in-pad, but reported).
+        assert pcb.vias[0].position == (100.0, 100.0)
+
+    def test_plane_stitch_boxed_in_unresolvable(self, tmp_path: Path):
+        """A plane-stitch via whose only in-zone candidates hit foreign copper
+        is unresolvable, never mis-placed outside the pour or into a short."""
+        p = _write(tmp_path, _PCB_PLANE_STITCH_BOXED_IN)
+        pcb = PCB.load(p)
+        rules = get_mfr_design_rules("jlcpcb", 2, 1.0)
+        result = relocate_in_pad_vias(pcb, rules, dry_run=False)
+
+        assert not result.moved
+        assert len(result.unresolvable) == 1
+        assert result.unresolvable[0].category == "unresolvable"
+        # Untouched: never emit a worse board.
+        assert pcb.vias[0].position == (100.0, 100.0)
+
+    def test_plane_stitch_clear_of_pad_clean_noop(self, tmp_path: Path):
+        """A via already clear of its pad is a clean no-op even with a zone."""
+        p = _write(tmp_path, _PCB_PLANE_STITCH_CLEAR_OF_PAD)
+        pcb = PCB.load(p)
+        rules = get_mfr_design_rules("jlcpcb", 2, 1.0)
+        result = relocate_in_pad_vias(pcb, rules, dry_run=False)
+
+        assert not result.moved
+        assert not result.skipped
+        assert not result.unresolvable
+        assert pcb.vias[0].position == (104.0, 104.0)
+
+    def test_plane_stitch_supported_mfr_is_noop(self, tmp_path: Path):
+        """On jlcpcb-tier1 (via-in-pad supported) nothing is relocated."""
+        p = _write(tmp_path, _PCB_PLANE_STITCH_WITH_ZONE)
+        pcb = PCB.load(p)
+        rules = get_mfr_design_rules("jlcpcb-tier1", 2, 1.0)
+        assert rules.via_in_pad_supported is True
+        result = relocate_in_pad_vias(pcb, rules, dry_run=False)
+
+        assert result.supported_noop is True
+        assert not result.moved
+        assert pcb.vias[0].position == (100.0, 100.0)
+
+    def test_plane_stitch_net_scoping(self, tmp_path: Path):
+        """--net scoping excludes/includes the plane net as expected."""
+        p = _write(tmp_path, _PCB_PLANE_STITCH_WITH_ZONE)
+        rules = get_mfr_design_rules("jlcpcb", 2, 1.0)
+
+        # Excluded: no move.
+        pcb = PCB.load(p)
+        result = relocate_in_pad_vias(pcb, rules, nets={"OTHER_NET"}, dry_run=False)
+        assert not result.moved
+        assert pcb.vias[0].position == (100.0, 100.0)
+
+        # Included: moved.
+        pcb2 = PCB.load(p)
+        result2 = relocate_in_pad_vias(pcb2, rules, nets={"GND"}, dry_run=False)
+        assert len(result2.moved) == 1
+        assert result2.moved[0].kind == "plane-stitch"
+
+    def test_plane_stitch_json_report_includes_kind(self, tmp_path: Path, capsys):
+        """--format json marks the plane-stitch move with kind + empty stub_layers."""
+        import json as _json
+
+        p = _write(tmp_path, _PCB_PLANE_STITCH_WITH_ZONE)
+        rc = main([str(p), "--mfr", "jlcpcb", "--relocate-in-pad", "--dry-run", "--format", "json"])
+        assert rc in (0, 2)
+        data = _json.loads(capsys.readouterr().out)
+        assert len(data["moved"]) == 1
+        assert data["moved"][0]["kind"] == "plane-stitch"
+        assert data["moved"][0]["stub_layers"] == []


### PR DESCRIPTION
## Summary

Phase 2 of `kct fix-vias --relocate-in-pad` (follow-up to #4359 / PR #4363).
Phase 1 relocated **signal** in-pad vias (slide along the escape track + append
a stub) and reported **plane-stitch** vias -- an in-pad via on a power/ground
pad with no routed track -- as `unresolvable`. This PR replaces that dead-end
branch with a real off-pad placement that preserves the plane connection.

The load-bearing difference from Phase 1: a plane-stitch via's only electrical
path is **pour overlap**, not a discrete track. So the via needs **no stub** --
it just has to land inside a same-net zone, and connectivity re-realizes when
the operator re-floods the pour with `kicad-cli pcb drc --refill-zones` (the
repo's standing cross-gate). The safe membership target is the zone **boundary**
polygon (`Zone.polygon`), never the stale `filled_polygons`, which go stale the
instant the via moves.

## Changes

- `src/kicad_tools/cli/relocate_in_pad_vias.py`
  - Replaced the `if not connected:` -> `unresolvable` branch with a plane-stitch
    placement attempt (Option A from the issue -- placement stays in-module).
  - New `_first_offpad_plane_candidate` walks the stitch `--avoid-pad-overlap`
    ladder (8 directions x 3 escape offsets from the pad edge) and accepts the
    first candidate that (a) clears the pad bbox by `min_clearance_mm`, (b) is
    inside a same-net zone boundary polygon on a layer the via spans, and (c)
    passes the existing `_check_clearance` gate (other-net copper + hole-to-hole).
  - New `_same_net_zone_boundaries` / `_via_spans_zone_layer` helpers gate on
    `PCB.zones` boundary membership (net matched by number, falling back to name;
    full through-hole vias count every copper zone layer). Reuses
    `stitch_cmd.point_in_polygon`.
  - Plane-stitch moves add **no stub**; `PCB.relocate_via` failure -> `unresolvable`.
  - `ViaRelocation` gains a `kind` field (`"signal"` | `"plane-stitch"`); plane
    moves carry `stub_layers=[]`. JSON/text reports surface `kind` and print the
    `--refill-zones` reminder when any plane-stitch via moved.
- `tests/test_fix_vias.py` -- new `_PCB_PLANE_STITCH_WITH_ZONE` (happy path),
  `_PCB_PLANE_STITCH_BOXED_IN`, and `_PCB_PLANE_STITCH_CLEAR_OF_PAD` fixtures +
  `TestPlaneStitchRelocation` (9 tests).

`fix_vias_cmd._run_relocate_in_pad` already surfaces counts + exit codes; no CLI
change was needed.

## Acceptance Criteria Verification

| Criterion (from issue) | Status | Verification |
|-----------|--------|--------------|
| Plane-stitch in-pad via relocated to a clearance-legal off-pad spot on the same plane net; via_in_pad count drops | ✅ | `test_plane_stitch_via_moved_into_zone` + `test_plane_stitch_move_persists_through_save` (`_via_in_pad_count` -> 0 after save/reload) |
| Connectivity preserved; no new shorts/clearance violations; else `unresolvable`, never mis-placed | ✅ | Moves stay inside `Zone.polygon`; `_check_clearance` gate; `test_plane_stitch_boxed_in_unresolvable` leaves the via untouched |
| `--dry-run` mutates nothing; no-plane-stitch board is a clean no-op | ✅ | `test_plane_stitch_dry_run_mutates_nothing`, `test_plane_stitch_dry_run_via_main_no_file_write` (byte-identical), `test_plane_stitch_clear_of_pad_clean_noop` |
| Tests with a plane-stitch in-pad fixture | ✅ | 3 new fixtures + 9 tests; existing zero-zone `test_plane_stitch_via_reported_unresolvable` kept as the "no same-net zone" guard |
| No same-net zone -> still unresolvable | ✅ | `test_plane_stitch_no_zone_reported_unresolvable` |
| Supported-mfr no-op / net scoping | ✅ | `test_plane_stitch_supported_mfr_is_noop`, `test_plane_stitch_net_scoping` |
| No `--refill-zones` invoked inside the tool | ✅ | Tool only moves the via; reminder printed for the operator |

## Test Plan

- `uv run pytest tests/test_fix_vias.py` -> 93 passed (includes 9 new Phase-2 tests).
- `uv run pytest tests/test_stitch_cmd.py tests/test_validate_via_in_pad.py tests/test_stitch_mfr.py` -> 314 passed (no regression in the reused stitch/via engines).
- `ruff check` + `ruff format` clean on both files.
- mypy baseline wrapper: all within baseline, no new type errors (baseline not updated).
- Manual chorus verification (48 plane-stitch vias) is local-only / not in CI, per the issue.

Closes #4367