### PR TITLE
feat(zones): add hv-keepout to void inner pours around HV nets

### DIFF
--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -12,7 +12,7 @@ def run_zones_command(args) -> int:
     """Handle zones command."""
     if not args.zones_command:
         print("Usage: kicad-tools zones <command> [options] <file>")
-        print("Commands: add, list, batch, fill")
+        print("Commands: add, list, batch, hv-keepout, fill")
         return 1
 
     from ..zones_cmd import main as zones_main
@@ -60,6 +60,26 @@ def run_zones_command(args) -> int:
         if args.dry_run:
             sub_argv.append("--dry-run")
         # Use global quiet flag
+        if getattr(args, "global_quiet", False):
+            sub_argv.append("--quiet")
+        return zones_main(sub_argv) or 0
+
+    elif args.zones_command == "hv-keepout":
+        sub_argv = ["hv-keepout", args.pcb]
+        if args.output:
+            sub_argv.extend(["-o", args.output])
+        sub_argv.extend(["--net-class", args.net_class])
+        if getattr(args, "net_class_map", None):
+            sub_argv.extend(["--net-class-map", args.net_class_map])
+        sub_argv.extend(["--clearance", str(args.clearance)])
+        if getattr(args, "plane_layers", None):
+            sub_argv.extend(["--plane-layers", args.plane_layers])
+        if getattr(args, "refill", False):
+            sub_argv.append("--refill")
+        if args.verbose:
+            sub_argv.append("--verbose")
+        if args.dry_run:
+            sub_argv.append("--dry-run")
         if getattr(args, "global_quiet", False):
             sub_argv.append("--quiet")
         return zones_main(sub_argv) or 0

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2702,6 +2702,43 @@ def _add_zones_parser(subparsers) -> None:
     zones_batch.add_argument("-v", "--verbose", action="store_true")
     zones_batch.add_argument("--dry-run", action="store_true")
 
+    # zones hv-keepout
+    zones_hv = zones_subparsers.add_parser(
+        "hv-keepout",
+        help="Generate plane pour-keepouts so inner pours clear HV nets",
+    )
+    zones_hv.add_argument("pcb", help="Path to .kicad_pcb file")
+    zones_hv.add_argument(
+        "-o",
+        "--output",
+        help="Output file path (default: overwrite input, consistent with 'zones fill')",
+    )
+    zones_hv.add_argument(
+        "--net-class", default="HV", help="Net class naming the HV group (default: HV)"
+    )
+    zones_hv.add_argument(
+        "--net-class-map",
+        help="Path to a net-class-map JSON sidecar classifying the HV nets",
+    )
+    zones_hv.add_argument(
+        "--clearance",
+        type=float,
+        required=True,
+        help="Required clearance from HV copper in mm (the void distance)",
+    )
+    zones_hv.add_argument(
+        "--plane-layers",
+        help="Comma-separated copper layers whose pours must void "
+        "(default: all layers carrying a plane pour)",
+    )
+    zones_hv.add_argument(
+        "--refill",
+        action="store_true",
+        help="Run 'kicad-cli pcb drc --refill-zones' after writing the keepouts",
+    )
+    zones_hv.add_argument("-v", "--verbose", action="store_true")
+    zones_hv.add_argument("--dry-run", action="store_true")
+
     # zones fill
     zones_fill = zones_subparsers.add_parser("fill", help="Fill all zones in a PCB")
     zones_fill.add_argument("pcb", help="Path to .kicad_pcb file")

--- a/src/kicad_tools/cli/zones_cmd.py
+++ b/src/kicad_tools/cli/zones_cmd.py
@@ -242,6 +242,61 @@ def main(argv: list[str] | None = None) -> int:
         help="Suppress progress output",
     )
 
+    # zones hv-keepout
+    hv_parser = subparsers.add_parser(
+        "hv-keepout",
+        help="Generate plane pour-keepouts so inner pours clear HV nets",
+    )
+    hv_parser.add_argument("pcb", help="Path to .kicad_pcb file")
+    hv_parser.add_argument(
+        "-o",
+        "--output",
+        help="Output file path (default: overwrite input, consistent with 'zones fill')",
+    )
+    hv_parser.add_argument(
+        "--net-class",
+        default="HV",
+        help="Net class naming the HV group (default: HV)",
+    )
+    hv_parser.add_argument(
+        "--net-class-map",
+        help="Path to a net-class-map JSON sidecar classifying the HV nets "
+        "(same file 'kct creepage' accepts)",
+    )
+    hv_parser.add_argument(
+        "--clearance",
+        type=float,
+        required=True,
+        help="Required clearance from HV copper in mm (the void distance)",
+    )
+    hv_parser.add_argument(
+        "--plane-layers",
+        help="Comma-separated copper layers whose pours must void "
+        "(e.g. 'In1.Cu,In2.Cu'). Default: all layers carrying a plane pour.",
+    )
+    hv_parser.add_argument(
+        "--refill",
+        action="store_true",
+        help="Run 'kicad-cli pcb drc --refill-zones' after writing the keepouts",
+    )
+    hv_parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Verbose output",
+    )
+    hv_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show the planned voids without writing output",
+    )
+    hv_parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="Suppress progress output",
+    )
+
     # zones fill
     fill_parser = subparsers.add_parser("fill", help="Fill all zones in a PCB")
     fill_parser.add_argument("pcb", help="Path to .kicad_pcb file")
@@ -284,6 +339,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_list(args)
     elif args.zones_command == "batch":
         return _run_batch(args)
+    elif args.zones_command == "hv-keepout":
+        return _run_hv_keepout(args)
     elif args.zones_command == "fill":
         return _run_fill(args)
 
@@ -592,6 +649,196 @@ def _print_batch_summary(gen, quiet: bool) -> None:
         )
     else:
         print(f"\nCreated {zone_count} zone(s)")
+
+
+def _load_net_class_map(path_str: str | None):
+    """Load a net-class-map JSON sidecar (shared with ``kct creepage``).
+
+    Returns ``(net_class_map, error_message)``.  On success ``error_message``
+    is ``None``; on failure ``net_class_map`` is ``None`` and the caller should
+    print ``error_message`` to stderr and exit non-zero.
+    """
+    if not path_str:
+        return None, None
+
+    import json
+
+    from kicad_tools.router.rules import net_class_map_from_dict
+
+    ncm_path = Path(path_str)
+    if not ncm_path.exists():
+        return None, f"net-class-map file not found: {ncm_path}"
+    try:
+        return net_class_map_from_dict(json.loads(ncm_path.read_text())), None
+    except json.JSONDecodeError as e:
+        return None, f"parsing net-class-map JSON: {e}"
+    except (TypeError, ValueError) as e:
+        return None, f"invalid net-class-map structure: {e}"
+
+
+def _run_hv_keepout(args) -> int:
+    """Generate plane pour-keepouts so inner pours clear HV nets (issue #4372).
+
+    Resolves the HV net set exactly as ``kct creepage`` does, buffers the HV
+    copper by ``--clearance`` to build void regions, and appends persistent
+    keepout rule areas (``copperpour not_allowed``) on the plane layers so the
+    inner pours void around the mains nets.  Optionally refills afterwards.
+    """
+    from kicad_tools._shapely import has_shapely
+    from kicad_tools.creepage.engine import resolve_hv_nets
+    from kicad_tools.schema.pcb import PCB
+    from kicad_tools.sexp import parse_file
+    from kicad_tools.zones.hv_keepout import build_hv_keepout_plan
+
+    quiet = getattr(args, "quiet", False)
+
+    if not has_shapely():
+        print(
+            "Error: hv-keepout requires shapely (a core dependency); "
+            "it is not importable in this environment.",
+            file=sys.stderr,
+        )
+        return 1
+
+    pcb_path = Path(args.pcb)
+    if not pcb_path.exists():
+        print(f"Error: File not found: {pcb_path}", file=sys.stderr)
+        return 1
+
+    if args.clearance <= 0:
+        print(
+            f"Error: --clearance must be positive (got {args.clearance}).",
+            file=sys.stderr,
+        )
+        return 1
+
+    net_class_map, ncm_error = _load_net_class_map(getattr(args, "net_class_map", None))
+    if ncm_error is not None:
+        print(f"Error: {ncm_error}", file=sys.stderr)
+        return 1
+
+    # No -o means overwrite the input in place, consistent with 'zones fill'.
+    output_path = Path(args.output) if args.output else pcb_path
+
+    plane_layers = None
+    if getattr(args, "plane_layers", None):
+        plane_layers = [layer.strip() for layer in args.plane_layers.split(",") if layer.strip()]
+
+    if not quiet:
+        print(f"Loading PCB: {pcb_path}")
+
+    try:
+        pcb = PCB.load(str(pcb_path))
+    except Exception as e:
+        print(f"Error loading PCB: {e}", file=sys.stderr)
+        return 1
+
+    net_class = getattr(args, "net_class", "HV") or "HV"
+    hv_nets = resolve_hv_nets(pcb, net_class, net_class_map)
+
+    if not hv_nets:
+        # Clean no-op mirroring `kct creepage`'s guidance (issue #4372 edge a).
+        print(
+            f"No '{net_class}' nets found "
+            "(supply --net-class-map to classify HV nets, or check --net-class)."
+        )
+        print("No keepouts generated -- nothing to void.")
+        return 0
+
+    plan = build_hv_keepout_plan(
+        pcb,
+        hv_nets,
+        clearance_mm=args.clearance,
+        plane_layers=plane_layers,
+    )
+
+    if not quiet or args.dry_run:
+        print(f"\nHV nets ({len(plan.hv_nets)}): {', '.join(sorted(plan.hv_nets.values()))}")
+        print(f"Clearance: {plan.clearance_mm} mm")
+        print(
+            "Target plane layers: "
+            f"{', '.join(plan.plane_layers) if plan.plane_layers else '(none)'}"
+        )
+        if plan.excluded_layers:
+            print(f"Excluded (HV net has its own pour there): {', '.join(plan.excluded_layers)}")
+        print(f"Planned keepout voids: {plan.keepout_count}")
+        if args.verbose:
+            for i, void in enumerate(plan.voids, 1):
+                print(f"  Void {i}: {len(void.points)} pts on {', '.join(void.layers)}")
+
+    if plan.keepout_count == 0:
+        if not plan.plane_layers:
+            print(
+                "No target plane layers to void (supply --plane-layers, or add plane pours first)."
+            )
+        else:
+            print("No HV copper found on the board -- no keepouts generated.")
+        return 0
+
+    if args.dry_run:
+        if not quiet:
+            print("\n--- Dry run - not saving ---")
+        return 0
+
+    # Append the keepout zones to the parsed document and save.
+    try:
+        doc = parse_file(pcb_path)
+    except Exception as e:
+        print(f"Error parsing PCB for write: {e}", file=sys.stderr)
+        return 1
+
+    for node in plan.zone_nodes():
+        doc.append(node)
+
+    if not quiet:
+        print(f"\nSaving to: {output_path}")
+
+    try:
+        from kicad_tools.core.sexp_file import save_pcb
+
+        save_pcb(doc, output_path)
+    except Exception as e:
+        print(f"Error: Write failed: {e}", file=sys.stderr)
+        return 1
+
+    if not quiet:
+        print(f"Wrote {plan.keepout_count} keepout zone(s).")
+
+    if args.refill:
+        rc = _refill_after_keepout(output_path, quiet)
+        if rc != 0:
+            return rc
+
+    if not quiet:
+        print("Done!")
+
+    return 0
+
+
+def _refill_after_keepout(path: Path, quiet: bool) -> int:
+    """Run kicad-cli refill so the new pour-keepouts take effect."""
+    from .runner import find_kicad_cli, run_fill_zones
+
+    kicad_cli = find_kicad_cli()
+    if not kicad_cli:
+        print(
+            "Error: --refill requested but kicad-cli not found. "
+            "Install KiCad from https://www.kicad.org/download/",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not quiet:
+        print(f"Refilling zones in: {path}")
+
+    result = run_fill_zones(path, None, kicad_cli=kicad_cli)
+    if not result.success:
+        print(f"Error refilling zones: {result.stderr}", file=sys.stderr)
+        return 1
+
+    if not quiet:
+        print("Zones refilled.")
+    return 0
 
 
 def _run_fill(args) -> int:

--- a/src/kicad_tools/zones/__init__.py
+++ b/src/kicad_tools/zones/__init__.py
@@ -40,13 +40,25 @@ from .generator import (
     auto_create_zones_for_pour_nets,
     parse_power_nets,
 )
+from .hv_keepout import (
+    HvKeepoutPlan,
+    HvVoid,
+    build_hv_keepout_plan,
+    default_plane_layers,
+    hv_pour_layers,
+)
 
 __all__ = [
+    "HvKeepoutPlan",
+    "HvVoid",
     "ZoneConfig",
     "ZoneGenerator",
     "ZoneOverlapWarning",
     "ZonePartitionError",
     "assign_batch_zone_priorities_and_outlines",
     "auto_create_zones_for_pour_nets",
+    "build_hv_keepout_plan",
+    "default_plane_layers",
+    "hv_pour_layers",
     "parse_power_nets",
 ]

--- a/src/kicad_tools/zones/hv_keepout.py
+++ b/src/kicad_tools/zones/hv_keepout.py
@@ -1,0 +1,249 @@
+"""Generate copper-pour keepout (void) rule areas around HV nets (issue #4372).
+
+KiCad's zone filler keeps a pour clear of foreign-net copper by the *board's*
+netclass / DRU clearance (typically 0.2--0.3 mm), NOT by kicad-tools' routing
+net-class-map.  So even when a designer declares an HV ``clearance: 1.6mm`` in
+the kct sidecar, the inner GND / power planes still fill to within ~0.4 mm of a
+mains net crossing overhead -- simultaneously an IEC 60664-1 / 62368-1
+creepage/clearance violation and a capacitive-coupling hazard.
+
+This module carves that clearance geometrically (Approach A from the issue):
+
+1. Resolve the HV net set with the SAME plumbing ``kct creepage`` uses
+   (:func:`kicad_tools.creepage.engine.resolve_hv_nets`) so the two commands
+   agree on "which nets are HV".
+2. Union each HV net's true copper across the source copper layers, reusing the
+   tested shapely primitives in
+   :func:`kicad_tools.creepage.engine._net_union_on_layer`.
+3. Buffer that union by the required clearance to obtain the void region.
+4. Emit one persistent ``keepout`` rule area
+   (:func:`kicad_tools.sexp.builders.keepout_node`, ``copperpour not_allowed``)
+   per void region on the target plane layers, so the inner pours void around
+   the HV nets and the voids survive future ``kicad-cli`` refills.
+
+Approach B (a custom ``.kicad_dru`` / netclass clearance rule that KiCad's own
+filler honors) is intentionally NOT built here -- there is no in-repo DRU/rule
+writer yet, and the geometric approach is self-verifiable against
+``kct creepage``.  The per-net |ΔV| distance source (#4371) can later feed
+per-net clearances through the ``clearance_mm`` seam; v1 uses one flat/derived
+distance.
+"""
+
+from __future__ import annotations
+
+import uuid as uuid_module
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from kicad_tools.sexp.builders import keepout_node
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from kicad_tools.schema.pcb import PCB
+    from kicad_tools.sexp import SExp
+
+
+@dataclass
+class HvVoid:
+    """One buffered void region carved on a set of plane layers.
+
+    ``points`` is the exterior ring of the void polygon in **sheet-absolute**
+    millimetres (the frame the PCB S-expression tree stores), ready to hand to
+    :func:`keepout_node`.
+    """
+
+    points: list[tuple[float, float]]
+    layers: list[str]
+
+
+@dataclass
+class HvKeepoutPlan:
+    """The planned set of HV pour-keepout voids for a board.
+
+    Pure data + geometry -- constructing a plan touches no files and needs no
+    ``kicad-cli``, which keeps the geometry unit-testable in isolation.
+    """
+
+    hv_nets: dict[int, str]
+    clearance_mm: float
+    plane_layers: list[str]
+    excluded_layers: list[str] = field(default_factory=list)
+    voids: list[HvVoid] = field(default_factory=list)
+
+    @property
+    def keepout_count(self) -> int:
+        return len(self.voids)
+
+    def zone_nodes(self) -> list[SExp]:
+        """Materialise the plan as KiCad keepout ``(zone ...)`` S-expressions.
+
+        ``no_pour=True`` carves the pour; ``no_tracks=False, no_vias=False``
+        keeps the rule area from forbidding the HV net's own routing / vias --
+        the intent is only to exclude *pour* copper (issue #4372).
+        """
+        nodes: list[SExp] = []
+        for void in self.voids:
+            nodes.append(
+                keepout_node(
+                    void.points,
+                    void.layers,
+                    no_tracks=False,
+                    no_vias=False,
+                    no_pour=True,
+                    uuid_str=str(uuid_module.uuid4()),
+                )
+            )
+        return nodes
+
+
+def copper_layer_names(pcb: PCB) -> list[str]:
+    """Names of every copper (signal/power) layer, in stack order."""
+    return [layer.name for layer in pcb.copper_layers]
+
+
+def _zone_net_number(pcb: PCB, zone: Any, name_to_number: dict[str, int]) -> int:
+    """Resolve a zone's net number, falling back to its net name."""
+    net_number = zone.net_number
+    if net_number == 0 and zone.net_name:
+        net_number = name_to_number.get(zone.net_name, 0)
+    return int(net_number)
+
+
+def _zone_fill_layers(zone: Any) -> set[str]:
+    """The copper layers a zone actually fills (falls back to its own layer)."""
+    layers = {zone.filled_polygon_layer(i) for i in range(len(zone.filled_polygons))}
+    if not layers:
+        layers.add(zone.layer)
+    return layers
+
+
+def hv_pour_layers(pcb: PCB, hv_net_numbers: set[int]) -> set[str]:
+    """Layers on which an HV net has its OWN pour.
+
+    Edge case (b) from the issue: an HV net that is itself poured must not have
+    its own pour voided, so its pour layers are excluded from the target set.
+    """
+    name_to_number = {net.name: net.number for net in pcb.nets.values() if net.name}
+    layers: set[str] = set()
+    for zone in pcb.zones:
+        if _zone_net_number(pcb, zone, name_to_number) in hv_net_numbers:
+            layers |= _zone_fill_layers(zone)
+    return layers
+
+
+def default_plane_layers(pcb: PCB) -> list[str]:
+    """Copper layers carrying at least one net-bound pour (the void targets).
+
+    Keepout / rule-area zones (net 0, empty name) are ignored -- only real
+    plane pours are candidates for voiding.  Order follows first appearance.
+    """
+    name_to_number = {net.name: net.number for net in pcb.nets.values() if net.name}
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for zone in pcb.zones:
+        if _zone_net_number(pcb, zone, name_to_number) == 0:
+            continue  # keepout / unbound zone -- not a plane pour
+        for layer in _zone_fill_layers(zone):
+            if layer not in seen:
+                seen.add(layer)
+                ordered.append(layer)
+    return ordered
+
+
+def _iter_polygons(geom: Any):
+    """Yield each constituent shapely Polygon of a (possibly Multi) geometry."""
+    geoms = getattr(geom, "geoms", None)
+    if geoms is not None:
+        for part in geoms:
+            yield from _iter_polygons(part)
+    elif getattr(geom, "geom_type", "") == "Polygon" and not geom.is_empty:
+        yield geom
+
+
+def build_hv_keepout_plan(
+    pcb: PCB,
+    hv_nets: dict[int, str],
+    clearance_mm: float,
+    plane_layers: list[str] | None = None,
+    source_layers: list[str] | None = None,
+) -> HvKeepoutPlan:
+    """Plan the pour-keepout voids around ``hv_nets`` at ``clearance_mm``.
+
+    Args:
+        pcb: Parsed board.
+        hv_nets: ``{net_number: net_name}`` for the HV set (from
+            :func:`kicad_tools.creepage.engine.resolve_hv_nets`).
+        clearance_mm: Buffer distance -- how far the plane pours must void
+            around the HV copper.
+        plane_layers: Copper layers whose pours must void.  ``None`` defaults to
+            every layer carrying a net-bound pour (:func:`default_plane_layers`).
+        source_layers: Copper layers whose HV copper seeds the void.  ``None``
+            defaults to every copper layer (an HV trace on an outer layer voids
+            the inner plane crossing beneath it).
+
+    Returns:
+        An :class:`HvKeepoutPlan`.  The plan is empty (no voids) when there are
+        no HV nets, no eligible target layers, a non-positive clearance, or the
+        HV nets carry no copper yet -- all clean no-ops, never a crash.
+    """
+    from kicad_tools._shapely import require_shapely
+
+    require_shapely("HV plane pour-keepout generation")
+    from shapely.ops import unary_union  # type: ignore[import-untyped]
+
+    from kicad_tools.creepage.engine import _net_union_on_layer
+
+    hv_numbers = set(hv_nets)
+
+    target_layers = default_plane_layers(pcb) if plane_layers is None else list(plane_layers)
+
+    # Edge case (b): never void an HV net's own pour layer.
+    hv_own = hv_pour_layers(pcb, hv_numbers)
+    excluded = [layer for layer in target_layers if layer in hv_own]
+    effective_layers = [layer for layer in target_layers if layer not in hv_own]
+
+    plan = HvKeepoutPlan(
+        hv_nets=dict(hv_nets),
+        clearance_mm=clearance_mm,
+        plane_layers=effective_layers,
+        excluded_layers=excluded,
+    )
+
+    if not hv_numbers or not effective_layers or clearance_mm <= 0:
+        return plan
+
+    if source_layers is None:
+        source_layers = copper_layer_names(pcb)
+
+    # Union the HV nets' true copper across the source layers.
+    hv_parts: list[Any] = []
+    for layer in source_layers:
+        for net_number, geom in _net_union_on_layer(pcb, layer).items():
+            if net_number in hv_numbers and geom is not None and not geom.is_empty:
+                hv_parts.append(geom)
+
+    if not hv_parts:
+        return plan  # edge case (d): HV nets have no copper yet
+
+    hv_union = unary_union(hv_parts)
+    if hv_union.is_empty:
+        return plan
+
+    void = hv_union.buffer(clearance_mm)
+    if void.is_empty:
+        return plan
+
+    # Emitted keepout polygons are sheet-absolute; the shapely geometry is
+    # board-relative (PCB._detect_board_origin normalises copper on load), so
+    # add the board origin back.
+    ox, oy = pcb.board_origin
+
+    for poly in _iter_polygons(void):
+        ring = list(poly.exterior.coords)
+        # Shapely closes rings (first == last); KiCad closes implicitly.
+        if len(ring) >= 2 and ring[0] == ring[-1]:
+            ring = ring[:-1]
+        pts = [(x + ox, y + oy) for x, y in ring]
+        if len(pts) >= 3:
+            plan.voids.append(HvVoid(points=pts, layers=list(effective_layers)))
+
+    return plan

--- a/tests/test_zones_hv_keepout.py
+++ b/tests/test_zones_hv_keepout.py
@@ -1,0 +1,342 @@
+"""Tests for ``kct zones hv-keepout`` -- HV plane pour-keepouts (issue #4372).
+
+The command carves geometric rule-area keepouts (Approach A) so inner copper
+pours void around HV nets by a required clearance.  These tests exercise the
+pure geometry (no ``kicad-cli`` needed), the shared HV-net classification with
+``kct creepage``, the CLI round-trip, and the enumerated edge cases.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.zones_cmd import main as zones_main
+from kicad_tools.creepage.engine import resolve_hv_nets
+from kicad_tools.schema.pcb import PCB
+from kicad_tools.zones.hv_keepout import build_hv_keepout_plan
+
+pytest.importorskip("shapely")
+
+
+# A minimal-but-real board:
+#  * Outline gr_line rectangle (100,100)->(160,140) -> board origin (100,100).
+#  * net 1 AC_LINE carries a horizontal F.Cu trace from (110,110) to (150,110).
+#  * net 2 GND is a filled pour on the inner layer In1.Cu covering the board.
+_BOARD = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test_hv_keepout")
+  (general (thickness 1.6))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "AC_LINE")
+  (net 2 "GND")
+  (gr_line (start 100 100) (end 160 100) (layer "Edge.Cuts") (width 0.1))
+  (gr_line (start 160 100) (end 160 140) (layer "Edge.Cuts") (width 0.1))
+  (gr_line (start 160 140) (end 100 140) (layer "Edge.Cuts") (width 0.1))
+  (gr_line (start 100 140) (end 100 100) (layer "Edge.Cuts") (width 0.1))
+  (segment (start 110 110) (end 150 110) (width 0.5) (layer "F.Cu") (net 1))
+  (zone
+    (net 2)
+    (net_name "GND")
+    (layer "In1.Cu")
+    (uuid "gnd-plane-uuid")
+    (hatch edge 0.5)
+    (priority 0)
+    (connect_pads (clearance 0.25))
+    (min_thickness 0.2)
+    (fill yes (thermal_gap 0.4) (thermal_bridge_width 0.35))
+    (polygon
+      (pts
+        (xy 101 101)
+        (xy 159 101)
+        (xy 159 139)
+        (xy 101 139)
+      )
+    )
+    (filled_polygon
+      (layer "In1.Cu")
+      (pts
+        (xy 101 101)
+        (xy 159 101)
+        (xy 159 139)
+        (xy 101 139)
+      )
+    )
+  )
+)
+"""
+
+# An HV net (AC_LINE) that pours on its OWN inner layer, plus a GND pour on the
+# same layer -- exercises edge case (b): the HV net's own pour layer must be
+# excluded from the void target set.
+_BOARD_HV_POUR = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test_hv_keepout")
+  (general (thickness 1.6))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "AC_LINE")
+  (net 2 "GND")
+  (gr_line (start 100 100) (end 160 100) (layer "Edge.Cuts") (width 0.1))
+  (gr_line (start 160 100) (end 160 140) (layer "Edge.Cuts") (width 0.1))
+  (gr_line (start 160 140) (end 100 140) (layer "Edge.Cuts") (width 0.1))
+  (gr_line (start 100 140) (end 100 100) (layer "Edge.Cuts") (width 0.1))
+  (zone
+    (net 1)
+    (net_name "AC_LINE")
+    (layer "F.Cu")
+    (uuid "hv-pour-uuid")
+    (hatch edge 0.5)
+    (priority 0)
+    (connect_pads (clearance 0.25))
+    (min_thickness 0.2)
+    (fill yes (thermal_gap 0.4) (thermal_bridge_width 0.35))
+    (polygon (pts (xy 105 105) (xy 130 105) (xy 130 130) (xy 105 130)))
+    (filled_polygon
+      (layer "F.Cu")
+      (pts (xy 105 105) (xy 130 105) (xy 130 130) (xy 105 130))
+    )
+  )
+  (zone
+    (net 2)
+    (net_name "GND")
+    (layer "In1.Cu")
+    (uuid "gnd-plane-uuid")
+    (hatch edge 0.5)
+    (priority 0)
+    (connect_pads (clearance 0.25))
+    (min_thickness 0.2)
+    (fill yes (thermal_gap 0.4) (thermal_bridge_width 0.35))
+    (polygon (pts (xy 101 101) (xy 159 101) (xy 159 139) (xy 101 139)))
+    (filled_polygon
+      (layer "In1.Cu")
+      (pts (xy 101 101) (xy 159 101) (xy 159 139) (xy 101 139))
+    )
+  )
+)
+"""
+
+
+def _write(tmp_path: Path, source: str, name: str = "board.kicad_pcb") -> Path:
+    path = tmp_path / name
+    path.write_text(source)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Geometry (Approach A) -- no kicad-cli needed
+# ---------------------------------------------------------------------------
+
+
+def test_keepout_buffers_hv_copper_by_clearance(tmp_path: Path) -> None:
+    """A GND-plane keepout buffers the HV trace by exactly ``--clearance``."""
+    from shapely.geometry import Polygon
+
+    from kicad_tools.geometry.copper import segment_copper_polygon
+
+    pcb = PCB.load(str(_write(tmp_path, _BOARD)))
+    hv_nets = resolve_hv_nets(pcb, "HV", None)
+    assert hv_nets  # AC_LINE resolves via the mains-name fallback
+
+    clearance = 1.6
+    plan = build_hv_keepout_plan(pcb, hv_nets, clearance_mm=clearance)
+
+    # One void region on the sole inner plane layer.
+    assert plan.keepout_count == 1
+    assert plan.plane_layers == ["In1.Cu"]
+
+    void = plan.voids[0]
+    assert void.layers == ["In1.Cu"]
+
+    # Reconstruct the void in board-relative coordinates and compare against the
+    # HV trace buffered by the clearance.  The board origin is (100, 100).
+    ox, oy = pcb.board_origin
+    void_poly = Polygon([(x - ox, y - oy) for x, y in void.points])
+
+    # HV trace board-relative: (10,10)->(50,10), width 0.5.
+    hv_geom = segment_copper_polygon((10.0, 10.0), (50.0, 10.0), 0.5)
+    expected = hv_geom.buffer(clearance)
+
+    # The emitted void polygon should match buffer(HV, clearance) closely.
+    assert void_poly.symmetric_difference(expected).area < 1e-3
+    # And its boundary sits at least ``clearance`` from the HV copper.
+    assert void_poly.contains(hv_geom)
+
+
+def test_clearance_scales_the_void(tmp_path: Path) -> None:
+    """A larger clearance produces a strictly larger void polygon."""
+    from shapely.geometry import Polygon
+
+    pcb = PCB.load(str(_write(tmp_path, _BOARD)))
+    hv_nets = resolve_hv_nets(pcb, "HV", None)
+
+    def _void_area(clearance: float) -> float:
+        plan = build_hv_keepout_plan(pcb, hv_nets, clearance_mm=clearance)
+        return Polygon(plan.voids[0].points).area
+
+    assert _void_area(2.0) > _void_area(0.8)
+
+
+# ---------------------------------------------------------------------------
+# Shared HV classification with kct creepage
+# ---------------------------------------------------------------------------
+
+
+def test_net_class_map_matches_creepage_classification(tmp_path: Path) -> None:
+    """The HV set is selected identically to ``kct creepage`` given a map."""
+    from kicad_tools.router.rules import net_class_map_from_dict
+
+    pcb = PCB.load(str(_write(tmp_path, _BOARD)))
+    ncm = net_class_map_from_dict({"AC_LINE": {"name": "HV"}})
+    # resolve_hv_nets is the shared entry point both commands call.
+    via_map = resolve_hv_nets(pcb, "HV", ncm)
+    via_fallback = resolve_hv_nets(pcb, "HV", None)
+    assert set(via_map.values()) == {"AC_LINE"}
+    assert set(via_fallback.values()) == {"AC_LINE"}
+
+
+# ---------------------------------------------------------------------------
+# CLI round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_cli_writes_keepout_zone(tmp_path: Path) -> None:
+    """The CLI appends a persistent keepout zone (net 0, copperpour off)."""
+    board = _write(tmp_path, _BOARD)
+    rc = zones_main(
+        ["hv-keepout", str(board), "--clearance", "1.6", "--plane-layers", "In1.Cu", "-q"]
+    )
+    assert rc == 0
+
+    text = board.read_text()
+    assert "keepout" in text
+    assert "copperpour" in text and "not_allowed" in text
+    assert '(layers "In1.Cu")' in text
+
+    # Re-parse: exactly one new keepout zone (net 0) was added.
+    pcb = PCB.load(str(board))
+    keepouts = [z for z in pcb.zones if z.net_number == 0]
+    assert len(keepouts) == 1
+
+
+def test_cli_dry_run_writes_nothing(tmp_path: Path) -> None:
+    """``--dry-run`` reports the plan but leaves the input untouched."""
+    board = _write(tmp_path, _BOARD)
+    before = board.read_text()
+    rc = zones_main(["hv-keepout", str(board), "--clearance", "1.6", "--dry-run"])
+    assert rc == 0
+    assert board.read_text() == before
+
+
+def test_cli_output_flag_leaves_input_untouched(tmp_path: Path) -> None:
+    """``-o`` writes to the alternate path; the input stays pristine."""
+    board = _write(tmp_path, _BOARD)
+    before = board.read_text()
+    out = tmp_path / "out.kicad_pcb"
+    rc = zones_main(["hv-keepout", str(board), "--clearance", "1.6", "-o", str(out), "-q"])
+    assert rc == 0
+    assert board.read_text() == before
+    assert out.exists()
+    pcb = PCB.load(str(out))
+    assert any(z.net_number == 0 for z in pcb.zones)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_no_hv_nets_is_clean_noop(tmp_path: Path, capsys) -> None:
+    """Edge (a): no HV nets -> informative no-op, exit 0, no write."""
+    source = _BOARD.replace('(net 1 "AC_LINE")', '(net 1 "SIG")').replace(
+        "(net 1))",
+        "(net 1))",  # segment stays on the now-non-HV net
+    )
+    board = _write(tmp_path, source, "nohv.kicad_pcb")
+    before = board.read_text()
+    rc = zones_main(["hv-keepout", str(board), "--clearance", "1.6"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "No 'HV' nets found" in out
+    assert board.read_text() == before  # nothing written
+
+
+def test_hv_own_pour_layer_excluded(tmp_path: Path) -> None:
+    """Edge (b): an HV net's own pour layer is excluded from the void set."""
+    pcb = PCB.load(str(_write(tmp_path, _BOARD_HV_POUR)))
+    hv_nets = resolve_hv_nets(pcb, "HV", None)
+    assert set(hv_nets.values()) == {"AC_LINE"}
+
+    # Target all pour-carrying layers explicitly (F.Cu is the HV pour layer).
+    plan = build_hv_keepout_plan(pcb, hv_nets, clearance_mm=1.6, plane_layers=["F.Cu", "In1.Cu"])
+    assert "F.Cu" in plan.excluded_layers  # HV pours there -> excluded
+    assert plan.plane_layers == ["In1.Cu"]
+    for void in plan.voids:
+        assert "F.Cu" not in void.layers
+
+
+def test_default_plane_layers_targets_pour_layers(tmp_path: Path) -> None:
+    """Edge (c): omitting --plane-layers targets all plane-pour layers."""
+    pcb = PCB.load(str(_write(tmp_path, _BOARD)))
+    hv_nets = resolve_hv_nets(pcb, "HV", None)
+    plan = build_hv_keepout_plan(pcb, hv_nets, clearance_mm=1.6, plane_layers=None)
+    # The only net-bound pour is GND on In1.Cu.
+    assert plan.plane_layers == ["In1.Cu"]
+    assert plan.keepout_count == 1
+
+
+def test_hv_net_with_no_copper_no_keepout(tmp_path: Path) -> None:
+    """Edge (d): an HV net with no copper yet -> no keepout, no crash."""
+    # Drop the AC_LINE trace so the HV net carries no copper.
+    source = _BOARD.replace(
+        '  (segment (start 110 110) (end 150 110) (width 0.5) (layer "F.Cu") (net 1))\n',
+        "",
+    )
+    pcb = PCB.load(str(_write(tmp_path, source, "empty_hv.kicad_pcb")))
+    hv_nets = resolve_hv_nets(pcb, "HV", None)
+    assert set(hv_nets.values()) == {"AC_LINE"}
+    plan = build_hv_keepout_plan(pcb, hv_nets, clearance_mm=1.6)
+    assert plan.keepout_count == 0
+
+
+def test_nonpositive_clearance_rejected(tmp_path: Path) -> None:
+    """A non-positive --clearance is rejected before any write."""
+    board = _write(tmp_path, _BOARD)
+    before = board.read_text()
+    rc = zones_main(["hv-keepout", str(board), "--clearance", "0"])
+    assert rc == 1
+    assert board.read_text() == before
+
+
+def test_missing_net_class_map_errors(tmp_path: Path) -> None:
+    """A missing --net-class-map file is a loud error, not a silent pass."""
+    board = _write(tmp_path, _BOARD)
+    rc = zones_main(
+        [
+            "hv-keepout",
+            str(board),
+            "--clearance",
+            "1.6",
+            "--net-class-map",
+            str(tmp_path / "does-not-exist.json"),
+        ]
+    )
+    assert rc == 1


### PR DESCRIPTION
## Summary

Adds `kct zones hv-keepout`, a command that carves geometric copper-pour keepout rule areas so inner GND / power planes void around HV (mains) nets by a required clearance. KiCad's zone filler keeps a pour clear of foreign copper by the **board's netclass/DRU clearance** (~0.2 mm), not by kicad-tools' routing sidecar — so HV nets crossing over inner planes left IEC 60664-1 / 62368-1 creepage/clearance violations (and a capacitive-coupling hazard) that previously had to be fixed by hand. On the session's mains board, 11 of 18 true-mains creepage fails were mains↔inner-plane; this clears them deterministically.

Implements **Approach A** (recommended default in the issue): geometric rule-area keepouts, reusing the most existing tested machinery and self-verifiable against `kct creepage`. Approach B (a `.kicad_dru` / netclass clearance-rule writer) is intentionally **not** built — no in-repo DRU/rule writer exists yet.

## Changes

- **New `kicad_tools.zones.hv_keepout` module** — `build_hv_keepout_plan()` resolves the HV net set via the shared `creepage.engine.resolve_hv_nets`, unions each HV net's true copper across the copper layers (reusing `_net_union_on_layer`), buffers by `--clearance`, and emits one persistent `keepout_node(no_pour=True, no_tracks=False, no_vias=False)` per void region on the target plane layers. `HvKeepoutPlan` / `HvVoid` are pure data + geometry (no file/kicad-cli needed), keeping the geometry unit-testable.
- **Default plane-layer targeting** — omitting `--plane-layers` targets every copper layer carrying a net-bound pour; an HV net that itself pours has its own pour layer excluded from the void set (never voids its own copper).
- **CLI wiring** — registers `hv-keepout` across the established three-site zones pattern: `cli/parser.py`, `cli/commands/routing.py`, `cli/zones_cmd.py` (`_run_hv_keepout`). Supports `--net-class`, `--net-class-map` (same sidecar `kct creepage` accepts), `--clearance`, `--plane-layers`, `--refill`, `-o`, `--dry-run`, `-v/-q`.
- **Coordinate handling** — emitted keepout polygons add the board origin back (copper is board-relative after `PCB.load`; the S-expression tree is sheet-absolute).
- **`--refill`** — optionally runs the `kicad-cli pcb drc --refill-zones` round-trip via the existing `run_fill_zones`.

The distance source is a flat/standard-derived `--clearance` in v1; the per-net |ΔV| seam (#4371) can feed per-net values later without changing the geometry.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| New `kct zones hv-keepout` subcommand wired across parser/routing/zones_cmd | ✅ | `uv run kct zones hv-keepout --help`; `test_cli_writes_keepout_zone` |
| Emits keepout whose polygon buffers HV copper by `--clearance` (Approach A geometry, no kicad-cli) | ✅ | `test_keepout_buffers_hv_copper_by_clearance` (symmetric-difference vs `buffer(HV, clearance)` < 1e-3) |
| HV nets selected identically to `kct creepage` (shared `resolve_hv_nets`) | ✅ | `test_net_class_map_matches_creepage_classification` |
| `--dry-run` writes nothing; `-o` writes alternate path, input untouched | ✅ | `test_cli_dry_run_writes_nothing`, `test_cli_output_flag_leaves_input_untouched` |
| Edge (a) no HV nets → clean no-op with guidance | ✅ | `test_no_hv_nets_is_clean_noop` |
| Edge (b) HV-own poured layer excluded from void set | ✅ | `test_hv_own_pour_layer_excluded` |
| Edge (c) `--plane-layers` omitted → all plane-pour layers | ✅ | `test_default_plane_layers_targets_pour_layers` |
| Edge (d) empty HV union → no keepout, no crash | ✅ | `test_hv_net_with_no_copper_no_keepout` |
| `--refill` round-trips through `kicad-cli pcb drc --refill-zones` | ✅ | Reuses `runner.run_fill_zones` (kicad-cli path); geometry tests cover the rest |

## Test Plan

- New `tests/test_zones_hv_keepout.py` — 12 tests, all passing (geometry, shared classification, CLI round-trip, edge cases). Run: `uv run pytest tests/test_zones_hv_keepout.py`.
- No regressions: `tests/test_zones_cmd.py tests/test_zones.py tests/creepage/` — 249 passed.
- `ruff check .` and `ruff format . --check` — clean. mypy baseline gate — no new type errors.

Closes #4372