### PR TITLE
feat(creepage): per-net voltage map + pairwise |ΔV| requirement

### DIFF
--- a/src/kicad_tools/cli/commands/creepage.py
+++ b/src/kicad_tools/cli/commands/creepage.py
@@ -46,6 +46,7 @@ def run_creepage_command(args) -> int:
         compute_creepage_census,
         mains_suspect_nets,
         resolve_hv_nets,
+        voltage_map_from_dict,
     )
     from kicad_tools.creepage.standards import (
         RMS_TO_PEAK,
@@ -83,33 +84,78 @@ def run_creepage_command(args) -> int:
         )
         return 1
 
+    # --- Optional per-net voltage map (#4371) --------------------------------
+    # When supplied, the required creepage/clearance is derived PER PAIR from
+    # |V_a - V_b| instead of a single global --working-voltage.  It requires a
+    # --standard (the table is the only source of a derived requirement) but
+    # makes --working-voltage optional (unmapped nets default to 0 V).
+    voltage_map: dict | None = None
+    edge_voltage = 0.0
+    vmap_arg = getattr(args, "voltage_map", None)
+    if vmap_arg:
+        if standard_id is None:
+            print(
+                "Error: --voltage-map requires --standard (and --pollution-degree); "
+                "the per-pair requirement is derived from an IEC table.",
+                file=sys.stderr,
+            )
+            return 1
+        vmap_path = Path(vmap_arg)
+        if not vmap_path.exists():
+            print(f"Error: voltage-map file not found: {vmap_path}", file=sys.stderr)
+            return 1
+        try:
+            voltage_map, edge_voltage = voltage_map_from_dict(json.loads(vmap_path.read_text()))
+        except json.JSONDecodeError as e:
+            print(f"Error: parsing voltage-map JSON: {e}", file=sys.stderr)
+            return 1
+        except (TypeError, ValueError) as e:
+            print(f"Error: invalid voltage-map structure: {e}", file=sys.stderr)
+            return 1
+
     # Phase-2 derived requirements (None in phase-1 mode).
     required_creepage_mm: float | None = None
     required_clearance_mm: float | None = None
     creepage_prov: dict | None = None
     clearance_prov: dict | None = None
     standard_edition: str | None = None
+    std = None
     working_voltage = getattr(args, "working_voltage", None)
     pollution_degree = getattr(args, "pollution_degree", None)
     material_group = getattr(args, "material_group", "IIIa")
 
     if standard_id is not None:
-        if working_voltage is None or pollution_degree is None:
-            print(
-                "Error: --standard requires both --working-voltage and --pollution-degree.",
-                file=sys.stderr,
-            )
-            return 1
+        if voltage_map is None:
+            # Single-voltage mode: preserve the exact phase-2 requirement/message.
+            if working_voltage is None or pollution_degree is None:
+                print(
+                    "Error: --standard requires both --working-voltage and --pollution-degree.",
+                    file=sys.stderr,
+                )
+                return 1
+        else:
+            # Per-net voltage mode (#4371): --working-voltage is optional (each
+            # pair keys on its own |ΔV|), but --pollution-degree is still needed.
+            if pollution_degree is None:
+                print(
+                    "Error: --standard (with --voltage-map) requires --pollution-degree.",
+                    file=sys.stderr,
+                )
+                return 1
         try:
             std = get_standard(standard_id)
-            required_creepage_mm, creepage_prov = std.required_creepage(
-                float(working_voltage), int(pollution_degree), material_group
-            )
-            peak_voltage = float(working_voltage) * RMS_TO_PEAK
-            required_clearance_mm, clearance_prov = std.required_clearance(
-                peak_voltage, int(pollution_degree)
-            )
             standard_edition = std.edition
+            if voltage_map is None:
+                # Single-voltage mode: derive the one global requirement up front.
+                # (working_voltage / pollution_degree were validated non-None above.)
+                assert working_voltage is not None and pollution_degree is not None
+                required_creepage_mm, creepage_prov = std.required_creepage(
+                    float(working_voltage), int(pollution_degree), material_group
+                )
+                peak_voltage = float(working_voltage) * RMS_TO_PEAK
+                required_clearance_mm, clearance_prov = std.required_clearance(
+                    peak_voltage, int(pollution_degree)
+                )
         except StandardLookupError as e:
             # Safety-critical: fail LOUD, never emit a guessed number.
             print(f"Error: standard-table lookup failed: {e}", file=sys.stderr)
@@ -138,22 +184,33 @@ def run_creepage_command(args) -> int:
     net_class = getattr(args, "net_class", "HV") or "HV"
 
     hv_nets = resolve_hv_nets(pcb, net_class, net_class_map)
-    report = compute_creepage_census(
-        pcb,
-        hv_nets,
-        min_mm,
-        net_class=net_class,
-        board=str(pcb_path),
-        required_creepage_mm=required_creepage_mm,
-        required_clearance_mm=required_clearance_mm,
-        standard=standard_id,
-        standard_edition=standard_edition,
-        working_voltage=working_voltage,
-        pollution_degree=pollution_degree,
-        material_group=material_group if standard_id is not None else None,
-        creepage_provenance=creepage_prov,
-        clearance_provenance=clearance_prov,
-    )
+    try:
+        report = compute_creepage_census(
+            pcb,
+            hv_nets,
+            min_mm,
+            net_class=net_class,
+            board=str(pcb_path),
+            # In map mode the requirement varies per pair, so the report-level
+            # scalar requirement / working voltage are null (per-pair).
+            required_creepage_mm=required_creepage_mm,
+            required_clearance_mm=required_clearance_mm,
+            standard=standard_id,
+            standard_edition=standard_edition,
+            working_voltage=None if voltage_map is not None else working_voltage,
+            pollution_degree=pollution_degree,
+            material_group=material_group if standard_id is not None else None,
+            creepage_provenance=creepage_prov,
+            clearance_provenance=clearance_prov,
+            voltage_map=voltage_map,
+            standard_obj=std if voltage_map is not None else None,
+            edge_voltage=edge_voltage,
+        )
+    except StandardLookupError as e:
+        # A per-pair |ΔV| out of the table's range (map mode): fail LOUD, never
+        # silently pass a safety-critical audit.
+        print(f"Error: standard-table lookup failed: {e}", file=sys.stderr)
+        return 1
 
     # Vacuity guard (issue #4354): a census that resolves ZERO HV nets is only
     # legitimately "nothing to audit" on a genuinely low-voltage board.  When
@@ -302,24 +359,39 @@ def _render_table_standard(report: CreepageReport, *, guard_triggered: bool = Fa
     print(f"HV creepage/clearance census  (net-class '{report.net_class}')")
     print(f"Board: {report.board}")
     print(f"Standard: {std_name} {report.standard_edition}  (--standard {report.standard})")
-    print(
-        f"Working voltage: {report.working_voltage:g} V RMS  "
-        f"(peak ~ {clp.get('peak_voltage_v', 0.0):.0f} V)  |  "
-        f"Pollution degree: {report.pollution_degree}  |  "
-        f"Material group: {report.material_group}"
-    )
-    if report.required_creepage_mm is not None:
+    if report.uses_voltage_map:
+        # Per-net voltage mode (#4371): the requirement is derived per pair from
+        # |ΔV|, so there is no single working voltage / derived requirement.
+        n_mapped = len(report.voltage_map or {})
         print(
-            f"Derived required creepage: {report.required_creepage_mm:.3f} mm  "
-            f"[{cp.get('table_id', '?')}, {cp.get('voltage_row_used_v', '?')} V row, "
-            f"step-up]"
+            f"Voltage source: per-pair |dV| (voltage-map, {n_mapped} net(s) mapped, "
+            f"edge/earth = {report.edge_voltage:g} V)  |  "
+            f"Pollution degree: {report.pollution_degree}  |  "
+            f"Material group: {report.material_group}"
         )
-    if report.required_clearance_mm is not None:
         print(
-            f"Derived required clearance: {report.required_clearance_mm:.3f} mm  "
-            f"[{clp.get('table_id', '?')}, {clp.get('governing_component', '?')}, "
-            f"altitude {clp.get('altitude_assumption', '?')}]"
+            "Derived requirement: per pair (see the ReqCr / ReqCl columns; nets at "
+            "equal potential require ~0)."
         )
+    else:
+        print(
+            f"Working voltage: {report.working_voltage:g} V RMS  "
+            f"(peak ~ {clp.get('peak_voltage_v', 0.0):.0f} V)  |  "
+            f"Pollution degree: {report.pollution_degree}  |  "
+            f"Material group: {report.material_group}"
+        )
+        if report.required_creepage_mm is not None:
+            print(
+                f"Derived required creepage: {report.required_creepage_mm:.3f} mm  "
+                f"[{cp.get('table_id', '?')}, {cp.get('voltage_row_used_v', '?')} V row, "
+                f"step-up]"
+            )
+        if report.required_clearance_mm is not None:
+            print(
+                f"Derived required clearance: {report.required_clearance_mm:.3f} mm  "
+                f"[{clp.get('table_id', '?')}, {clp.get('governing_component', '?')}, "
+                f"altitude {clp.get('altitude_assumption', '?')}]"
+            )
     if report.min_mm is not None:
         print(f"Manual override (--min): {report.min_mm:.3f} mm  (stricter governs)")
     print(f"HV nets ({len(report.hv_nets)}): {', '.join(report.hv_nets)}")

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -490,7 +490,27 @@ def _add_creepage_parser(subparsers) -> None:
             "RMS working voltage in volts.  Creepage keys on this RMS value "
             "directly (step-up to the next-higher tabulated row, never "
             "interpolated); clearance keys on its peak (RMS x sqrt(2), "
-            "sinusoidal assumption).  Required with --standard."
+            "sinusoidal assumption).  Required with --standard unless "
+            "--voltage-map is supplied."
+        ),
+    )
+    # Per-net voltage model (#4371): derive the requirement per pair from |ΔV|.
+    creepage_parser.add_argument(
+        "--voltage-map",
+        dest="voltage_map",
+        default=None,
+        help=(
+            "Path to a JSON sidecar mapping net names to their RMS working "
+            'potential (volts) about a common reference, e.g. {"/AC_LINE": 150, '
+            '"/AC_NEUTRAL": 0, "/SCAP_POS": 90}.  With --standard, the required '
+            "creepage/clearance is derived PER PAIR from |V_a - V_b| instead of "
+            "one global --working-voltage: same-potential nets require ~0 and "
+            "cross-domain pairs use their real difference.  Unmapped nets default "
+            "to 0 V; the reserved key _edge_voltage sets the board-edge/earth "
+            "reference (default 0 V); other _-prefixed keys (e.g. _comment) are "
+            "ignored.  Potentials are worst-case DC-equivalent magnitudes -- AC "
+            "phase is not modelled, so |ΔV| is conservative for in-phase nets.  "
+            "Requires --standard (and --pollution-degree)."
         ),
     )
     creepage_parser.add_argument(

--- a/src/kicad_tools/creepage/engine.py
+++ b/src/kicad_tools/creepage/engine.py
@@ -41,6 +41,7 @@ from typing import TYPE_CHECKING, Any
 from kicad_tools._shapely import has_shapely, require_shapely
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
+    from kicad_tools.creepage.standards import CreepageStandard
     from kicad_tools.router.rules import NetClassRouting
     from kicad_tools.schema.pcb import PCB
 
@@ -55,6 +56,71 @@ _INTERIOR_SHRINK = 1e-6  # shrink a slot before the "crosses interior" test
 # A pair is a PASS when creepage >= min within this tolerance (mm).  Mirrors
 # the spirit of DRC_TOLERANCE -- a sub-micron shortfall is not a real defect.
 _PASS_TOLERANCE = 1e-4
+
+# Per-net voltage model (#4371): two conductors whose mapped potentials differ
+# by less than this (volts) are treated as the SAME node -> required creepage
+# 0.0 (trivial PASS), short-circuiting the standard-table lookup.  The IEC
+# creepage tables start at 50 V and ``_step_up_index`` raises for ``V <= 0``, so
+# a same-potential pair (``dv == 0``) must never reach the lookup.
+_ZERO_DV_EPS = 1e-6
+
+
+def _norm_net_key(name: str) -> str:
+    """Normalise a net name for voltage-map lookup (drop one leading ``/``).
+
+    KiCad emits hierarchical net names with a leading ``/`` (``/AC_LINE``);
+    hand-authored voltage maps may or may not include it.  Stripping a single
+    leading slash on both sides makes the lookup robust to either convention.
+    """
+    return name[1:] if name.startswith("/") else name
+
+
+# Reserved voltage-map key (#4371): the board-edge / earth reference potential.
+_EDGE_VOLTAGE_KEY = "_edge_voltage"
+
+
+def voltage_map_from_dict(data: Any) -> tuple[dict[str, float], float]:
+    """Parse a per-net voltage map sidecar (#4371).
+
+    ``data`` maps net names to their **RMS working potential relative to a
+    common reference** (volts), e.g.
+    ``{"/AC_LINE": 150, "/AC_NEUTRAL": 0, "/SCAP_POS": 90}``.  Keys starting
+    with ``_`` are reserved for in-band metadata and are NOT treated as nets
+    (mirrors :func:`kicad_tools.router.rules.net_class_map_from_dict`).  The one
+    recognised reserved key is ``_edge_voltage`` -- the board-edge / earth
+    reference potential (default ``0.0`` V).
+
+    Returns ``(voltages, edge_voltage)``.
+
+    Raises:
+        TypeError: if ``data`` is not a dict.
+        ValueError: if any net voltage (or ``_edge_voltage``) is not a finite
+            real number.
+    """
+    if not isinstance(data, dict):
+        raise TypeError(f"voltage_map_from_dict expects a dict, got {type(data).__name__}")
+    voltages: dict[str, float] = {}
+    edge_voltage = 0.0
+    for key, value in data.items():
+        if isinstance(key, str) and key.startswith("_"):
+            if key == _EDGE_VOLTAGE_KEY:
+                edge_voltage = _coerce_voltage(key, value)
+            continue  # other _-prefixed keys are documentation (_comment, ...)
+        voltages[str(key)] = _coerce_voltage(key, value)
+    return voltages, edge_voltage
+
+
+def _coerce_voltage(key: Any, value: Any) -> float:
+    """Coerce a voltage-map value to a finite float or raise ``ValueError``."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(
+            f"voltage-map entry for {key!r} must be a number (volts), got {type(value).__name__}"
+        )
+    v = float(value)
+    if not math.isfinite(v):
+        raise ValueError(f"voltage-map entry for {key!r} must be finite, got {value!r}")
+    return v
+
 
 # IEC 60664-1 SELV boundary: below ~50 V RMS a design is not a mains/HV
 # safety concern.  A working-voltage argument at or above this threshold is a
@@ -251,6 +317,12 @@ class CreepageReport:
     required_clearance_mm: float | None = None
     creepage_provenance: dict[str, Any] = field(default_factory=dict)
     clearance_provenance: dict[str, Any] = field(default_factory=dict)
+    # Per-net voltage model (#4371).  None in single-voltage / phase-1 modes;
+    # a ``{net_name: volts}`` map when the requirement is derived per pair from
+    # ``|ΔV|`` instead of one global working voltage.  When set, the report-level
+    # ``required_creepage_mm`` / ``working_voltage`` are ``None`` (per-pair).
+    voltage_map: dict[str, float] | None = None
+    edge_voltage: float = 0.0
 
     @property
     def passed(self) -> bool:
@@ -265,6 +337,11 @@ class CreepageReport:
     def uses_standard(self) -> bool:
         return self.standard is not None
 
+    @property
+    def uses_voltage_map(self) -> bool:
+        """``True`` when the requirement is derived per pair from ``|ΔV|``."""
+        return self.voltage_map is not None
+
     def to_dict(self) -> dict[str, Any]:
         # Phase-1 backward compatibility: no standard -> exact phase-1 schema.
         if self.standard is None:
@@ -277,7 +354,7 @@ class CreepageReport:
                 "pairs": [p.to_dict() for p in self.pairs],
                 "passed": self.passed,
             }
-        return {
+        d: dict[str, Any] = {
             "board": self.board,
             "net_class": self.net_class,
             "min_mm": self.min_mm,
@@ -303,6 +380,15 @@ class CreepageReport:
             "pairs": [p.to_dict() for p in self.pairs],
             "passed": self.passed,
         }
+        # Per-net voltage mode (#4371): the requirement varies per pair, so the
+        # report-level scalar requirement / working voltage are null (already set
+        # to None by the caller) and we echo the voltage source instead.  These
+        # keys are added ONLY in map mode, so single-voltage output is unchanged.
+        if self.voltage_map is not None:
+            d["voltage_source"] = "per-pair |dV| (voltage-map)"
+            d["voltage_map"] = dict(self.voltage_map)
+            d["edge_voltage_v"] = self.edge_voltage
+        return d
 
 
 # ---------------------------------------------------------------------------
@@ -646,6 +732,9 @@ def compute_creepage_census(
     material_group: str | None = None,
     creepage_provenance: dict[str, Any] | None = None,
     clearance_provenance: dict[str, Any] | None = None,
+    voltage_map: dict[str, float] | None = None,
+    standard_obj: CreepageStandard | None = None,
+    edge_voltage: float = 0.0,
 ) -> CreepageReport:
     """Build the full HV creepage/clearance census for a board.
 
@@ -655,11 +744,33 @@ def compute_creepage_census(
     The pass/fail threshold comes from either the operator's ``min_mm``
     (phase 1) or a standard-derived ``required_creepage_mm`` /
     ``required_clearance_mm`` (phase 2, #4332), or both -- in which case the
-    stricter creepage bound governs per pair.  The derived requirement is
+    stricter creepage bound governs per pair.
+
+    Per-net voltage model (#4371)
+    -----------------------------
+    When ``voltage_map`` (``{net_name: volts}``) **and** ``standard_obj`` are
+    supplied, the requirement is derived **per pair** from the pairwise voltage
+    difference ``dv = |V(a) - V(b)|`` (unmapped nets default to ``0 V``; the
+    board edge uses ``edge_voltage``, default ``0 V`` == earth), instead of one
+    global working voltage.  Same-potential pairs (``dv <= _ZERO_DV_EPS``) get a
+    required creepage/clearance of ``0.0`` and are a trivial PASS -- this
+    short-circuits the standard-table lookup (which starts at 50 V and raises
+    for ``V <= 0``).  In map mode the HV-vs-HV pairing skip is relaxed so that
+    same-class nets at different potentials (bank-vs-bank, phase-vs-phase) are
+    also evaluated.  Voltages are treated as worst-case DC-equivalent magnitudes
+    about a common reference; AC phase relationships are NOT modelled, so
+    ``|dv|`` is conservative for in-phase nets.
+
+    In single-voltage mode (no ``voltage_map``) the derived requirement is
     identical for every pair (it depends only on the standard + voltage + PD +
-    material group, not on geometry), so it is stamped onto each row.
+    material group, not on geometry), so it is stamped onto each row -- byte-for
+    -byte unchanged from phase 2.
     """
     require_shapely("creepage census")
+
+    # Per-net voltage mode (#4371) requires BOTH a map and a resolved standard
+    # table (the table is the only source of a derived requirement).
+    map_mode = voltage_map is not None and standard_obj is not None
 
     report = CreepageReport(
         net_class=net_class,
@@ -675,6 +786,8 @@ def compute_creepage_census(
         required_clearance_mm=required_clearance_mm,
         creepage_provenance=creepage_provenance or {},
         clearance_provenance=clearance_provenance or {},
+        voltage_map=dict(voltage_map) if (map_mode and voltage_map is not None) else None,
+        edge_voltage=edge_voltage,
     )
 
     # Merged per-pair provenance (creepage + clearance citations together).
@@ -684,14 +797,80 @@ def compute_creepage_census(
     if clearance_provenance:
         pair_provenance["clearance"] = clearance_provenance
 
-    def _make_pair(**kw: Any) -> CreepagePair:
+    def _make_pair(
+        *,
+        req_creep: float | None = required_creepage_mm,
+        req_clear: float | None = required_clearance_mm,
+        prov: dict[str, Any] | None = None,
+        **kw: Any,
+    ) -> CreepagePair:
         return CreepagePair(
             min_mm=min_mm,
-            required_creepage_mm=required_creepage_mm,
-            required_clearance_mm=required_clearance_mm,
-            provenance=pair_provenance,
+            required_creepage_mm=req_creep,
+            required_clearance_mm=req_clear,
+            provenance=pair_provenance if prov is None else prov,
             **kw,
         )
+
+    # --- Per-pair |dV| requirement machinery (map mode only, #4371) ---------
+    norm_vmap: dict[str, float] = {}
+    if map_mode:
+        assert voltage_map is not None
+        norm_vmap = {_norm_net_key(k): float(v) for k, v in voltage_map.items()}
+    _req_cache: dict[float, tuple[float, float, dict[str, Any], dict[str, Any]]] = {}
+
+    def _voltage(name: str) -> float:
+        return norm_vmap.get(_norm_net_key(name), 0.0)
+
+    def _required_for_dv(
+        dv: float,
+    ) -> tuple[float, float, dict[str, Any], dict[str, Any]]:
+        """Derive ``(req_creepage, req_clearance, creep_prov, clear_prov)`` at ``dv``.
+
+        Memoised by ``dv`` (rounded) so the ~1500-pair census performs at most
+        one table lookup per distinct voltage difference.  ``dv <= _ZERO_DV_EPS``
+        short-circuits to a trivial ``0.0`` requirement (no lookup).  An
+        out-of-range ``dv`` propagates ``StandardLookupError`` (fail loud).
+        """
+        from kicad_tools.creepage.standards import RMS_TO_PEAK
+
+        key = round(dv, 6)
+        cached = _req_cache.get(key)
+        if cached is not None:
+            return cached
+        if dv <= _ZERO_DV_EPS:
+            res: tuple[float, float, dict[str, Any], dict[str, Any]] = (0.0, 0.0, {}, {})
+        else:
+            assert standard_obj is not None and pollution_degree is not None
+            creep, cprov = standard_obj.required_creepage(
+                dv, int(pollution_degree), material_group or "IIIa"
+            )
+            clr, clprov = standard_obj.required_clearance(dv * RMS_TO_PEAK, int(pollution_degree))
+            res = (creep, clr, cprov, clprov)
+        _req_cache[key] = res
+        return res
+
+    def _pair_requirement(
+        name_a: str, name_b: str | None, *, edge: bool = False
+    ) -> tuple[float, float, dict[str, Any]]:
+        """Per-pair ``(req_creepage, req_clearance, provenance)`` from ``|dV|``."""
+        va = _voltage(name_a)
+        vb = edge_voltage if edge else _voltage(name_b or "")
+        dv = abs(va - vb)
+        req_creep, req_clear, cprov, clprov = _required_for_dv(dv)
+        prov: dict[str, Any] = {
+            "voltage": {
+                "net_a_v": va,
+                "net_b_v": vb,
+                "delta_v_v": round(dv, 4),
+                "same_potential": dv <= _ZERO_DV_EPS,
+            }
+        }
+        if cprov:
+            prov["creepage"] = cprov
+        if clprov:
+            prov["clearance"] = clprov
+        return req_creep, req_clear, prov
 
     if not hv_nets:
         return report
@@ -706,6 +885,12 @@ def compute_creepage_census(
 
     # --- HV-vs-other-conductor pairs (binding layer = smallest creepage) ---
     # (hv_number, other_number) -> (clearance, creepage, layer)
+    #
+    # In single-voltage mode HV-vs-HV pairs are skipped (an HV net has no
+    # meaningful requirement against another net in its own group).  In per-net
+    # voltage mode (#4371) that skip is relaxed so same-class nets at different
+    # potentials (bank-vs-bank, phase-vs-phase) ARE evaluated; such pairs are
+    # deduplicated to a single canonical direction (smaller net number first).
     best: dict[tuple[int, int], tuple[float, float, str]] = {}
     for layer_name, unions in layer_unions.items():
         for hv_num in hv_nets:
@@ -713,8 +898,14 @@ def compute_creepage_census(
             if hv_geom is None:
                 continue
             for other_num, other_geom in unions.items():
-                if other_num == 0 or other_num in hv_nets:
+                if other_num == 0 or other_num == hv_num:
                     continue
+                if other_num in hv_nets:
+                    if not map_mode:
+                        continue
+                    # Canonical dedup: evaluate each HV-HV pair once.
+                    if other_num < hv_num:
+                        continue
                 clearance, creepage = surface_path_length(hv_geom, other_geom, obstacles)
                 key = (hv_num, other_num)
                 prev = best.get(key)
@@ -722,16 +913,34 @@ def compute_creepage_census(
                     best[key] = (clearance, creepage, layer_name)
 
     for (hv_num, other_num), (clearance, creepage, layer_name) in best.items():
-        report.pairs.append(
-            _make_pair(
-                net_a=hv_nets[hv_num],
-                net_b=number_to_name.get(other_num, f"net{other_num}"),
-                kind="conductor",
-                layer=layer_name,
-                clearance_mm=clearance,
-                creepage_mm=creepage,
+        net_a_name = hv_nets[hv_num]
+        net_b_name = number_to_name.get(other_num, f"net{other_num}")
+        if map_mode:
+            req_creep, req_clear, prov = _pair_requirement(net_a_name, net_b_name)
+            report.pairs.append(
+                _make_pair(
+                    req_creep=req_creep,
+                    req_clear=req_clear,
+                    prov=prov,
+                    net_a=net_a_name,
+                    net_b=net_b_name,
+                    kind="conductor",
+                    layer=layer_name,
+                    clearance_mm=clearance,
+                    creepage_mm=creepage,
+                )
             )
-        )
+        else:
+            report.pairs.append(
+                _make_pair(
+                    net_a=net_a_name,
+                    net_b=net_b_name,
+                    kind="conductor",
+                    layer=layer_name,
+                    clearance_mm=clearance,
+                    creepage_mm=creepage,
+                )
+            )
 
     # --- HV-vs-board-edge pairs (copper union across all layers) ---
     edge_geom = board_edge_geometry(pcb)
@@ -744,16 +953,32 @@ def compute_creepage_census(
                 continue
             hv_all = unary_union(parts)
             clearance, creepage = surface_path_length(hv_all, edge_geom, obstacles)
-            report.pairs.append(
-                _make_pair(
-                    net_a=hv_nets[hv_num],
-                    net_b=BOARD_EDGE_LABEL,
-                    kind="edge",
-                    layer="*",
-                    clearance_mm=clearance,
-                    creepage_mm=creepage,
+            if map_mode:
+                req_creep, req_clear, prov = _pair_requirement(hv_nets[hv_num], None, edge=True)
+                report.pairs.append(
+                    _make_pair(
+                        req_creep=req_creep,
+                        req_clear=req_clear,
+                        prov=prov,
+                        net_a=hv_nets[hv_num],
+                        net_b=BOARD_EDGE_LABEL,
+                        kind="edge",
+                        layer="*",
+                        clearance_mm=clearance,
+                        creepage_mm=creepage,
+                    )
                 )
-            )
+            else:
+                report.pairs.append(
+                    _make_pair(
+                        net_a=hv_nets[hv_num],
+                        net_b=BOARD_EDGE_LABEL,
+                        kind="edge",
+                        layer="*",
+                        clearance_mm=clearance,
+                        creepage_mm=creepage,
+                    )
+                )
 
     # Deterministic ordering: by net A, then edge last, then net B.
     report.pairs.sort(key=lambda p: (p.net_a, p.kind == "edge", p.net_b))

--- a/tests/creepage/test_creepage_engine.py
+++ b/tests/creepage/test_creepage_engine.py
@@ -294,3 +294,176 @@ def test_broadened_fallback_only_applies_to_hv_target(tmp_path):
     pcb = _load(tmp_path, board_mains_named_source())
     hv = resolve_hv_nets(pcb, "power", net_class_map=None)
     assert "AC_LINE" not in set(hv.values())
+
+
+# ---------------------------------------------------------------------------
+# Per-net voltage model + pairwise |dV| requirement (Issue #4371)
+# ---------------------------------------------------------------------------
+
+
+def _std():
+    from kicad_tools.creepage.standards import get_standard
+
+    return get_standard("iec60664")
+
+
+def _census_map(pcb, hv, vmap, *, edge=0.0, pd=2, mg="IIIa"):
+    std = _std()
+    return compute_creepage_census(
+        pcb,
+        hv,
+        None,
+        standard="iec60664",
+        standard_edition=std.edition,
+        pollution_degree=pd,
+        material_group=mg,
+        voltage_map=vmap,
+        standard_obj=std,
+        edge_voltage=edge,
+    )
+
+
+def _both_hv_map():
+    from kicad_tools.router.rules import net_class_map_from_dict
+
+    return net_class_map_from_dict({"L_MAINS": {"name": "HV"}, "GND": {"name": "HV"}})
+
+
+def test_voltage_map_from_dict_parses_nets_reserved_keys_and_edge():
+    from kicad_tools.creepage.engine import voltage_map_from_dict
+
+    voltages, edge = voltage_map_from_dict(
+        {
+            "/AC_LINE": 150,
+            "/AC_NEUTRAL": 0,
+            "_edge_voltage": 12.0,
+            "_comment": "ignored documentation",
+        }
+    )
+    assert voltages == {"/AC_LINE": 150.0, "/AC_NEUTRAL": 0.0}
+    assert edge == 12.0
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        {"NET": "not-a-number"},
+        {"NET": True},  # bool is not a voltage
+        {"NET": None},
+        {"NET": float("nan")},
+        {"_edge_voltage": "x"},
+    ],
+)
+def test_voltage_map_from_dict_rejects_non_numeric(bad):
+    from kicad_tools.creepage.engine import voltage_map_from_dict
+
+    with pytest.raises((ValueError, TypeError)):
+        voltage_map_from_dict(bad)
+
+
+def test_voltage_map_from_dict_rejects_non_dict():
+    from kicad_tools.creepage.engine import voltage_map_from_dict
+
+    with pytest.raises(TypeError):
+        voltage_map_from_dict([("A", 1)])
+
+
+def test_same_potential_pair_requires_zero_and_skips_lookup(tmp_path):
+    # Two nets at equal mapped voltage -> dv == 0 -> required 0.0, trivial PASS,
+    # and NO standard-table lookup (no creepage provenance attached).
+    pcb = _load(tmp_path, board_source(with_slot=False))
+    hv = resolve_hv_nets(pcb, "HV", _hv_map())
+    report = _census_map(pcb, hv, {"L_MAINS": 90.0, "GND": 90.0})
+    pair = _conductor_pair(report, "GND")
+    assert pair.required_creepage_mm == 0.0
+    assert pair.required_clearance_mm == 0.0
+    assert pair.passed is True
+    v = pair.provenance["voltage"]
+    assert v["delta_v_v"] == 0.0
+    assert v["same_potential"] is True
+    assert "creepage" not in pair.provenance  # lookup was short-circuited
+
+
+def test_cross_domain_pair_matches_flat_voltage_lookup(tmp_path):
+    # V_a=150, V_b=0 -> requirement equals the flat-150V step-up row.
+    pcb = _load(tmp_path, board_source(with_slot=False))
+    hv = resolve_hv_nets(pcb, "HV", _hv_map())
+    report = _census_map(pcb, hv, {"L_MAINS": 150.0})  # GND unmapped -> 0 V
+    pair = _conductor_pair(report, "GND")
+    expected, _ = _std().required_creepage(150.0, 2, "IIIa")
+    assert pair.required_creepage_mm == pytest.approx(expected)
+    assert pair.provenance["voltage"]["delta_v_v"] == 150.0
+
+
+def test_sub_table_floor_steps_up_to_fifty_volt_row(tmp_path):
+    # dv=30 V (< the 50 V lowest row) conservatively uses the 50 V row.
+    pcb = _load(tmp_path, board_source(with_slot=False))
+    hv = resolve_hv_nets(pcb, "HV", _hv_map())
+    report = _census_map(pcb, hv, {"L_MAINS": 30.0})
+    pair = _conductor_pair(report, "GND")
+    expected, _ = _std().required_creepage(50.0, 2, "IIIa")
+    assert pair.required_creepage_mm == pytest.approx(expected)
+    assert pair.provenance["creepage"]["voltage_row_used_v"] == 50.0
+
+
+def test_board_edge_uses_edge_voltage_default_zero(tmp_path):
+    pcb = _load(tmp_path, board_source(with_slot=False))
+    hv = resolve_hv_nets(pcb, "HV", _hv_map())
+    report = _census_map(pcb, hv, {"L_MAINS": 90.0})
+    edge = next(p for p in report.pairs if p.kind == "edge")
+    assert edge.provenance["voltage"]["delta_v_v"] == 90.0  # |90 - 0|
+
+
+def test_board_edge_voltage_override(tmp_path):
+    pcb = _load(tmp_path, board_source(with_slot=False))
+    hv = resolve_hv_nets(pcb, "HV", _hv_map())
+    report = _census_map(pcb, hv, {"L_MAINS": 90.0}, edge=90.0)
+    edge = next(p for p in report.pairs if p.kind == "edge")
+    assert edge.provenance["voltage"]["delta_v_v"] == 0.0  # |90 - 90|
+    assert edge.required_creepage_mm == 0.0
+
+
+def test_map_present_net_absent_from_copper_is_ignored(tmp_path):
+    # A net named in the map but with no copper must not crash or add pairs.
+    pcb = _load(tmp_path, board_source(with_slot=False))
+    hv = resolve_hv_nets(pcb, "HV", _hv_map())
+    report = _census_map(pcb, hv, {"L_MAINS": 150.0, "NOT_ON_BOARD": 300.0})
+    assert all(p.net_a != "NOT_ON_BOARD" and p.net_b != "NOT_ON_BOARD" for p in report.pairs)
+
+
+def test_hv_vs_hv_pair_formed_in_map_mode(tmp_path):
+    # With BOTH nets in the HV class, map mode relaxes the HV-vs-HV skip so a
+    # same-class pair at different potentials is evaluated (bank-vs-bank).
+    pcb = _load(tmp_path, board_source(with_slot=False))
+    hv = resolve_hv_nets(pcb, "HV", _both_hv_map())
+    assert set(hv.values()) == {"L_MAINS", "GND"}
+    report = _census_map(pcb, hv, {"L_MAINS": 150.0, "GND": 0.0})
+    conductor = [p for p in report.pairs if p.kind == "conductor"]
+    # Exactly one canonical HV-HV conductor pair (not both directions).
+    assert len(conductor) == 1
+    assert conductor[0].provenance["voltage"]["delta_v_v"] == 150.0
+
+
+def test_hv_vs_hv_skipped_without_map(tmp_path):
+    # Legacy single-voltage mode still skips HV-vs-HV pairs entirely.
+    pcb = _load(tmp_path, board_source(with_slot=False))
+    hv = resolve_hv_nets(pcb, "HV", _both_hv_map())
+    report = compute_creepage_census(pcb, hv, min_mm=1.5)
+    assert [p for p in report.pairs if p.kind == "conductor"] == []
+
+
+def test_over_range_delta_v_raises_loud(tmp_path):
+    from kicad_tools.creepage.standards import StandardLookupError
+
+    pcb = _load(tmp_path, board_source(with_slot=False))
+    hv = resolve_hv_nets(pcb, "HV", _hv_map())
+    with pytest.raises(StandardLookupError):
+        _census_map(pcb, hv, {"L_MAINS": 1_000_000.0})
+
+
+def test_no_voltage_map_leaves_report_in_single_voltage_mode(tmp_path):
+    pcb = _load(tmp_path, board_source(with_slot=False))
+    hv = resolve_hv_nets(pcb, "HV", _hv_map())
+    report = compute_creepage_census(pcb, hv, min_mm=1.5)
+    assert report.voltage_map is None
+    assert report.uses_voltage_map is False

--- a/tests/creepage/test_creepage_standards_cli.py
+++ b/tests/creepage/test_creepage_standards_cli.py
@@ -294,3 +294,194 @@ def test_min_only_json_schema_unchanged(tmp_path, capsys):
             "margin_mm",
             "pass",
         }
+
+
+# ---------------------------------------------------------------------------
+# Per-net voltage map + pairwise |dV| requirement (Issue #4371)
+# ---------------------------------------------------------------------------
+
+
+def _vmap_file(tmp_path, data, name="voltage_map.json"):
+    p = tmp_path / name
+    p.write_text(json.dumps(data))
+    return p
+
+
+def _run_map(tmp_path, capsys, vmap_data, *, fmt="json", pd="2", extra=None):
+    pcb = _write(tmp_path, board_source(with_slot=False))
+    ncm = _hv_map_file(tmp_path)
+    vmap = _vmap_file(tmp_path, vmap_data)
+    argv = [
+        "creepage",
+        str(pcb),
+        "--net-class-map",
+        str(ncm),
+        "--standard",
+        "iec60664",
+        "--pollution-degree",
+        pd,
+        "--voltage-map",
+        str(vmap),
+        "--format",
+        fmt,
+    ]
+    if extra:
+        argv.extend(extra)
+    rc = run_creepage_command(create_parser().parse_args(argv))
+    return rc, capsys.readouterr()
+
+
+def test_voltage_map_same_potential_passes(tmp_path, capsys):
+    # L_MAINS and GND both at 90 V -> that pair requires ~0 and PASSes.
+    rc, cap = _run_map(tmp_path, capsys, {"L_MAINS": 90, "GND": 90})
+    assert rc == 0
+    payload = json.loads(cap.out)
+    cond = next(p for p in payload["pairs"] if p["kind"] == "conductor")
+    assert cond["required_creepage_mm"] == 0.0
+    assert cond["pass"] is True
+
+
+def test_voltage_map_cross_domain_uses_real_delta(tmp_path, capsys):
+    # L_MAINS 150 V vs GND (unmapped -> 0 V): the ~1 mm gap FAILs the 150 V req.
+    rc, cap = _run_map(tmp_path, capsys, {"L_MAINS": 150})
+    payload = json.loads(cap.out)
+    cond = next(p for p in payload["pairs"] if p["kind"] == "conductor")
+    assert cond["required_creepage_mm"] > 1.0
+    assert cond["provenance"]["voltage"]["delta_v_v"] == 150.0
+
+
+def test_voltage_map_json_report_fields(tmp_path, capsys):
+    rc, cap = _run_map(tmp_path, capsys, {"L_MAINS": 150, "_edge_voltage": 5})
+    payload = json.loads(cap.out)
+    # Report-level scalar requirement / working voltage are null in map mode.
+    assert payload["working_voltage_v"] is None
+    assert payload["required_creepage_mm"] is None
+    assert payload["voltage_source"] == "per-pair |dV| (voltage-map)"
+    assert payload["voltage_map"] == {"L_MAINS": 150.0}
+    assert payload["edge_voltage_v"] == 5.0
+
+
+def test_voltage_map_table_header_mentions_per_pair(tmp_path, capsys):
+    rc, cap = _run_map(tmp_path, capsys, {"L_MAINS": 150}, fmt="table")
+    assert "per-pair |dV| (voltage-map" in cap.out
+
+
+def test_voltage_map_without_working_voltage_is_allowed(tmp_path, capsys):
+    # --working-voltage is NOT required when --voltage-map is supplied.
+    rc, cap = _run_map(tmp_path, capsys, {"L_MAINS": 90, "GND": 90})
+    assert rc == 0
+    assert "requires both --working-voltage" not in cap.err
+
+
+def test_voltage_map_requires_standard(tmp_path, capsys):
+    pcb = _write(tmp_path, board_source(with_slot=False))
+    vmap = _vmap_file(tmp_path, {"L_MAINS": 150})
+    rc = _run(["creepage", str(pcb), "--voltage-map", str(vmap), "--min", "1.5"])
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "--voltage-map requires --standard" in err
+
+
+def test_voltage_map_requires_pollution_degree(tmp_path, capsys):
+    pcb = _write(tmp_path, board_source(with_slot=False))
+    vmap = _vmap_file(tmp_path, {"L_MAINS": 150})
+    rc = _run(["creepage", str(pcb), "--standard", "iec60664", "--voltage-map", str(vmap)])
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "requires --pollution-degree" in err
+
+
+def test_voltage_map_missing_file_fails_loud(tmp_path, capsys):
+    pcb = _write(tmp_path, board_source(with_slot=False))
+    rc = _run(
+        [
+            "creepage",
+            str(pcb),
+            "--standard",
+            "iec60664",
+            "--pollution-degree",
+            "2",
+            "--voltage-map",
+            str(tmp_path / "does_not_exist.json"),
+        ]
+    )
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "voltage-map file not found" in err
+
+
+def test_voltage_map_malformed_json_fails_loud(tmp_path, capsys):
+    pcb = _write(tmp_path, board_source(with_slot=False))
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not valid json")
+    rc = _run(
+        [
+            "creepage",
+            str(pcb),
+            "--standard",
+            "iec60664",
+            "--pollution-degree",
+            "2",
+            "--voltage-map",
+            str(bad),
+        ]
+    )
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "parsing voltage-map JSON" in err
+
+
+def test_voltage_map_non_numeric_value_fails_loud(tmp_path, capsys):
+    pcb = _write(tmp_path, board_source(with_slot=False))
+    vmap = _vmap_file(tmp_path, {"L_MAINS": "high"})
+    rc = _run(
+        [
+            "creepage",
+            str(pcb),
+            "--standard",
+            "iec60664",
+            "--pollution-degree",
+            "2",
+            "--voltage-map",
+            str(vmap),
+        ]
+    )
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "invalid voltage-map structure" in err
+
+
+def test_voltage_map_over_range_delta_fails_loud(tmp_path, capsys):
+    # A per-pair |ΔV| beyond the highest tabulated row must fail loud (never
+    # silently pass a safety-critical audit).
+    rc, cap = _run_map(tmp_path, capsys, {"L_MAINS": 1_000_000})
+    assert rc == 1
+    assert "standard-table lookup failed" in cap.err
+
+
+def test_single_voltage_json_does_not_leak_map_keys(tmp_path, capsys):
+    # Backward compat: the single --working-voltage (no map) phase-2 JSON must
+    # NOT gain any of the #4371 map-mode keys.
+    pcb = _write(tmp_path, board_source(with_slot=False))
+    ncm = _hv_map_file(tmp_path)
+    _run(
+        [
+            "creepage",
+            str(pcb),
+            "--net-class-map",
+            str(ncm),
+            "--standard",
+            "iec60664",
+            "--working-voltage",
+            "150",
+            "--pollution-degree",
+            "2",
+            "--format",
+            "json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["working_voltage_v"] == 150
+    assert payload["required_creepage_mm"] is not None
+    for leaked in ("voltage_source", "voltage_map", "edge_voltage_v"):
+        assert leaked not in payload


### PR DESCRIPTION
## Summary

`kct creepage` (0.18.0) derived one required creepage from a **single** `--working-voltage` applied to the whole HV group, so it over-flagged same-potential nets (e.g. `SCAP_POS` / `SCAP_POS_RTN`, ΔV≈0) and could not audit mixed voltage domains in one pass.

This adds a per-net voltage model: a `--voltage-map <json>` sidecar keys each conductor pair on the **pairwise voltage difference** `|V_a − V_b|` and derives the required creepage/clearance from the IEC table at that ΔV. Nets at equal potential require ~0 (skip); cross-domain pairs use their real difference. The single `--working-voltage` path is retained, byte-for-byte unchanged, as the fallback when no map is supplied.

The per-pair data model already supported per-pair requirements (`CreepagePair` carries its own `required_creepage_mm` and `passed` evaluates against it), so this only changes how the requirement is *computed* in the census loops — the pass/fail machinery is untouched.

## Changes

- **`creepage/engine.py`**
  - `compute_creepage_census` gains `voltage_map`, `standard_obj`, `edge_voltage` params. In map mode each pair's requirement is looked up at its own `|ΔV|` (memoized by ΔV across the ~1500-pair census).
  - Same-potential pairs (`dv <= 1e-6`) short-circuit to a required `0.0` (trivial PASS) **before** the table lookup — avoids the `_step_up_index` `V<=0` raise and the 50 V table floor.
  - The `other_num in hv_nets` HV-vs-HV pairing skip is relaxed **only in map mode** (with canonical dedup) so same-class nets at different potentials (bank-vs-bank, phase-vs-phase) are evaluated. Legacy single-voltage pairing is unchanged.
  - Per-pair voltage provenance (`net_a_v`, `net_b_v`, `delta_v_v`, `same_potential`, table row). Board-edge pairs use `edge_voltage` (default `0 V` = earth). Out-of-range `dv` still raises `StandardLookupError` (fail loud).
  - New `voltage_map_from_dict` parses `{net: volts}` with reserved `_`-prefixed keys (`_edge_voltage`; `_comment` etc. ignored), mirroring `net_class_map_from_dict`.
  - `CreepageReport` gains `voltage_map` / `edge_voltage`; phase-2 JSON adds `voltage_source` / `voltage_map` / `edge_voltage_v` **only** in map mode.
- **`cli/commands/creepage.py`** — load/plumb `--voltage-map` (mirrors `--net-class-map` error handling); require `--standard` + `--pollution-degree` but make `--working-voltage` optional in map mode; report-level requirement / working voltage serialize as `null`; `_render_table_standard` header shows per-pair mode; per-pair `StandardLookupError` caught and failed loud.
- **`cli/parser.py`** — `--voltage-map` argument documenting the JSON format and the worst-case DC-equivalent (AC phase not modelled) assumption.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Same-potential → `required ≈ 0`, PASS, no lookup | ✅ | `test_same_potential_pair_requires_zero_and_skips_lookup` (no creepage provenance attached) |
| Cross-domain → requirement == flat-ΔV row | ✅ | `test_cross_domain_pair_matches_flat_voltage_lookup` (150 V matches `required_creepage(150,…)`) |
| Sub-50 V floor → 50 V row, provenance records it | ✅ | `test_sub_table_floor_steps_up_to_fifty_volt_row` (`voltage_row_used_v == 50.0`) |
| Backward-compat: no map → output unchanged | ✅ | `test_single_voltage_json_does_not_leak_map_keys` + existing phase-2 suite green |
| CLI errors: missing / malformed / non-numeric map | ✅ | `test_voltage_map_missing_file/_malformed_json/_non_numeric_value_fails_loud` |
| Net in map absent from copper ignored | ✅ | `test_map_present_net_absent_from_copper_is_ignored` |
| Board-edge pair uses `V_edge=0` default (+ override) | ✅ | `test_board_edge_uses_edge_voltage_default_zero` / `_override` |
| Over-range ΔV raises loud `StandardLookupError` | ✅ | `test_over_range_delta_v_raises_loud` + CLI `test_voltage_map_over_range_delta_fails_loud` |
| HV-vs-HV relaxed in map mode only | ✅ | `test_hv_vs_hv_pair_formed_in_map_mode` / `test_hv_vs_hv_skipped_without_map` |

Scope guard honored: no `NetClassRouting.voltage` field, no `kct audit` wiring, no schematic-derived voltages (deferred follow-ups). The `NetClassRouting` drift guard (`tests/test_net_class_serialization.py`) passes untouched.

## Test Plan

- `uv run pytest tests/creepage/ tests/test_net_class_serialization.py` → 186 passed.
- `uv run ruff check src/ tests/` and `ruff format --check` → clean.
- `uv run mypy src/kicad_tools/creepage/ .../creepage.py .../parser.py` → no issues; full `mypy src/` baseline test green (no new errors).

Closes #4371