### PR TITLE
feat(placement): HV-aware optimize-placement creepage keepout + domain input

### DIFF
--- a/docs/placement-scoring.md
+++ b/docs/placement-scoring.md
@@ -90,3 +90,81 @@ decoded current vector (verified by
 - When you optimize from a good hand placement, **seed the optimizer from it**
   rather than a random population; otherwise CMA-ES searches a layout space
   disconnected from your placement and can regress wirelength substantially.
+
+## HV-aware placement: the creepage-keepout term (issue #4373)
+
+By default the optimizer objective is **voltage-blind**: the wirelength term
+pulls connected pins together and the DRC term enforces a single
+`min_clearance` (0.2 mm) uniformly across every pad pair. Nothing keeps a
+150 V mains net away from a 1.65 V reference. On a mains board this drives the
+optimizer to pack high- and low-voltage copper together, and the only way to
+reach a creepage-feasible floorplan was a hand-authored zoned layout.
+
+`optimize-placement` can now be made **HV-aware** by supplying a voltage or
+domain input. This activates an extra hard-feasibility term,
+`compute_creepage_violation`, alongside overlap/DRC/boundary:
+
+- Each footprint is assigned an HV **domain** (a voltage cluster).
+- For every pair of footprints in **different** domains, the edge-to-edge gap
+  is compared against the **required creepage** for that domain pair, looked up
+  in `kicad_tools.creepage.standards` at the cross-domain `|ΔV|` (step-up rule,
+  no interpolation — the same table `kct creepage` uses).
+- A pair closer than its requirement contributes a shortfall, and any non-zero
+  creepage shortfall makes the placement **infeasible** — so under the default
+  lexicographic mode the optimizer refuses to converge on an HV-too-close
+  layout, exactly as it does for overlap or DRC.
+
+Absent a voltage/domain input the term stays dormant and scores are
+**byte-identical** to the historical objective (regression-safe opt-in,
+mirroring `--anchor-weight`).
+
+### Input contract
+
+Two mutually-exclusive sources:
+
+- **`--voltage-map v.json`** — a flat `{net_name: volts}` object (reuses the
+  per-net ΔV model format). Each footprint's domain is the *name of its
+  highest-magnitude-voltage net* (a footprint touching a 150 V mains net lands
+  in that mains domain); the domain's voltage is that magnitude.
+
+  ```json
+  {"/AC_LINE": 150, "/AC_NEUTRAL": 150, "/REF_1V65": 1.65, "/GATE_BUS": 12}
+  ```
+
+- **`--hv-domains d.json`** — the manual fallback so the feature works
+  standalone. Keys are domain ids; each carries a list of `fnmatch` ref globs
+  and a representative voltage:
+
+  ```json
+  {
+    "mains":  {"refs": ["J1", "F1", "R1", "R2"], "voltage": 150},
+    "signal": {"refs": ["U3", "R10", "C5"],      "voltage": 3.3}
+  }
+  ```
+
+  A ref matching more than one domain resolves to the higher-voltage domain.
+
+### Tuning knobs
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--creepage-standard` | `iec60664` | Standard for the required-distance lookup (`iec60664`/`iec62368`). |
+| `--pollution-degree` | `2` | IEC pollution degree (1/2/3). |
+| `--material-group` | `IIIa` | Insulation material group (I/II/IIIa/IIIb). |
+| `--hv-threshold` | `30.0` | Minimum cross-domain `|ΔV|` (V) that triggers a keepout. Lower-difference domain pairs rely on normal DRC clearance, so low-voltage/low-voltage nets are not over-segregated. |
+| `--weights '{"creepage": …}'` | `1e5` | Weight applied to the creepage shortfall (a hard-feasibility term). |
+
+A `|ΔV|` above the highest tabulated creepage row raises a loud
+`StandardLookupError` (surfaced as an `Error:` and exit code 1) — the tool
+never silently extrapolates a safety distance.
+
+### Guarded sense taps (partial)
+
+Some low-voltage nets are *derived from* an HV net (e.g. `V_AC_SENSE_RAW` off
+`AC_LINE` through a divider) and cannot be pushed away — they need a guard ring
+rather than separation. `compute_creepage_violation` accepts an `exempt_pairs`
+set that excludes such `(HV-ref, tap-ref)` pairs from the keepout while keeping
+the tap constrained against *other* domains. The cost-function mechanism is in
+place; automatic detection of derived taps from the voltage map (and the guard
+advisory) is tracked as follow-up work (see issue #4373 Phase 3, and #4372 for
+the complementary guard-copper generation).

--- a/src/kicad_tools/cli/commands/optimize_placement.py
+++ b/src/kicad_tools/cli/commands/optimize_placement.py
@@ -23,4 +23,10 @@ def run_optimize_placement_command(args) -> int:
         anchor_weight=getattr(args, "anchor_weight", 0.0),
         time_budget=getattr(args, "time_budget", None),
         allow_infeasible=getattr(args, "allow_infeasible", False),
+        voltage_map_path=getattr(args, "voltage_map", None),
+        hv_domains_path=getattr(args, "hv_domains", None),
+        creepage_standard=getattr(args, "creepage_standard", "iec60664"),
+        pollution_degree=getattr(args, "pollution_degree", 2),
+        material_group=getattr(args, "material_group", "IIIa"),
+        hv_threshold=getattr(args, "hv_threshold", 30.0),
     )

--- a/src/kicad_tools/cli/optimize_placement_cmd.py
+++ b/src/kicad_tools/cli/optimize_placement_cmd.py
@@ -168,10 +168,28 @@ def _evaluate(
     board: BoardOutline,
     cost_config: PlacementCostConfig,
     footprint_sizes: dict[str, tuple[float, float]],
+    ref_domains: dict[str, str] | None = None,
+    required_mm_by_domain_pair: dict[tuple[str, str], float] | None = None,
+    exempt_pairs: set[frozenset[str]] | None = None,
 ) -> PlacementScore:
-    """Evaluate a single placement vector and return its score."""
+    """Evaluate a single placement vector and return its score.
+
+    When ``ref_domains`` and ``required_mm_by_domain_pair`` are supplied the
+    HV creepage-keepout term (issue #4373) is active; otherwise the objective
+    is byte-identical to the historical voltage-blind score.
+    """
     placements = _vector_to_placements(vector, components)
-    return evaluate_placement(placements, nets, rules, board, cost_config, footprint_sizes)
+    return evaluate_placement(
+        placements,
+        nets,
+        rules,
+        board,
+        cost_config,
+        footprint_sizes,
+        ref_domains=ref_domains,
+        required_mm_by_domain_pair=required_mm_by_domain_pair,
+        exempt_pairs=exempt_pairs,
+    )
 
 
 def _build_footprint_sizes(
@@ -179,6 +197,77 @@ def _build_footprint_sizes(
 ) -> dict[str, tuple[float, float]]:
     """Build a footprint_sizes dict from component definitions."""
     return {c.reference: (c.width, c.height) for c in components}
+
+
+def _build_hv_context(
+    components: Sequence[ComponentDef],
+    nets: Sequence[Net],
+    *,
+    voltage_map_path: str | None,
+    hv_domains_path: str | None,
+    creepage_standard: str,
+    pollution_degree: int,
+    material_group: str,
+    hv_threshold: float,
+    quiet: bool,
+) -> tuple[dict[str, str] | None, dict[tuple[str, str], float] | None]:
+    """Build the HV creepage-keepout context from the voltage/domain input.
+
+    Returns ``(ref_domains, required_mm_by_domain_pair)``. Both are ``None``
+    when no voltage/domain input is supplied (regression-safe no-op).
+
+    Raises:
+        ValueError: On mutually-exclusive inputs, a malformed input file, or a
+            standard-table lookup that would require extrapolation
+            (``StandardLookupError`` is re-raised as ``ValueError`` with an
+            actionable message).
+    """
+    if voltage_map_path is None and hv_domains_path is None:
+        return None, None
+    if voltage_map_path is not None and hv_domains_path is not None:
+        raise ValueError("--voltage-map and --hv-domains are mutually exclusive; supply only one")
+
+    from kicad_tools.creepage.standards import StandardLookupError
+    from kicad_tools.placement.hv_domains import (
+        build_required_by_domain_pair,
+        derive_ref_domains_from_declaration,
+        derive_ref_domains_from_voltage_map,
+        load_hv_domains,
+        load_voltage_map,
+    )
+
+    if voltage_map_path is not None:
+        voltage_map = load_voltage_map(voltage_map_path)
+        ref_domains, domain_voltages = derive_ref_domains_from_voltage_map(nets, voltage_map)
+        source = f"voltage map ({len(voltage_map)} nets)"
+    else:
+        assert hv_domains_path is not None  # guaranteed by the guards above
+        declaration = load_hv_domains(hv_domains_path)
+        refs = [c.reference for c in components]
+        ref_domains, domain_voltages = derive_ref_domains_from_declaration(refs, declaration)
+        source = f"hv-domains declaration ({len(declaration)} domains)"
+
+    try:
+        required = build_required_by_domain_pair(
+            domain_voltages,
+            standard_id=creepage_standard,
+            pollution_degree=pollution_degree,
+            material_group=material_group,
+            hv_threshold=hv_threshold,
+        )
+    except StandardLookupError as e:
+        raise ValueError(f"creepage lookup failed: {e}") from e
+
+    if not quiet:
+        print(
+            f"  HV domains: {len(set(ref_domains.values()))} domains over "
+            f"{len(ref_domains)} refs from {source}; "
+            f"{len(required)} cross-domain keepout pair(s) "
+            f"(standard={creepage_standard}, PD{pollution_degree}, "
+            f"group={material_group}, threshold={hv_threshold:g}V)"
+        )
+
+    return ref_domains, required
 
 
 def _parse_weights(weights_json: str | None) -> PlacementCostConfig:
@@ -197,6 +286,7 @@ def _parse_weights(weights_json: str | None) -> PlacementCostConfig:
         "boundary_weight": 1e5,
         "wirelength_weight": 1.0,
         "area_weight": 0.1,
+        "creepage_weight": 1e5,
         "mode": CostMode.LEXICOGRAPHIC,
     }
 
@@ -227,6 +317,7 @@ def _parse_weights(weights_json: str | None) -> PlacementCostConfig:
         boundary_weight=data.get("boundary", defaults["boundary_weight"]),
         wirelength_weight=data.get("wirelength", defaults["wirelength_weight"]),
         area_weight=data.get("area", defaults["area_weight"]),
+        creepage_weight=data.get("creepage", defaults["creepage_weight"]),
         mode=mode,
     )
 
@@ -318,10 +409,11 @@ def _print_score(label: str, score: PlacementScore) -> None:
     """Print a score summary line."""
     b = score.breakdown
     feasible = "feasible" if score.is_feasible else "INFEASIBLE"
+    creepage_str = f" crp={b.creepage:.2f}" if b.creepage else ""
     print(
         f"  {label}: {score.total:.4f} ({feasible}) "
         f"[wl={b.wirelength:.2f} ovl={b.overlap:.2f} bnd={b.boundary:.2f} "
-        f"drc={b.drc:.0f} area={b.area:.2f}]"
+        f"drc={b.drc:.0f} area={b.area:.2f}{creepage_str}]"
     )
 
 
@@ -583,6 +675,12 @@ def run_optimize_placement(
     anchor_weight: float = 0.0,
     time_budget: float | None = None,
     allow_infeasible: bool = False,
+    voltage_map_path: str | None = None,
+    hv_domains_path: str | None = None,
+    creepage_standard: str = "iec60664",
+    pollution_degree: int = 2,
+    material_group: str = "IIIa",
+    hv_threshold: float = 30.0,
 ) -> int:
     """Run placement optimization.
 
@@ -612,6 +710,21 @@ def run_optimize_placement(
             if the final placement is infeasible (overlap/DRC/boundary
             violations remain). Default behaviour is to exit 1 with a
             ``FATAL:`` message on stderr in that case (issue #2821).
+        voltage_map_path: Optional path to a ``{net_name: volts}`` JSON voltage
+            map (reusing the #4371 format). Enables the HV-aware creepage
+            keepout: components are grouped into voltage domains and
+            cross-domain footprints are pushed apart to their required creepage
+            (issue #4373). Absent, the objective is byte-identical to today.
+        hv_domains_path: Optional path to an ``--hv-domains`` declaration JSON
+            (manual fallback when no voltage map is available). Mutually
+            exclusive with ``voltage_map_path``.
+        creepage_standard: Creepage standard id for the required-distance
+            lookup (``iec60664`` / ``iec62368``).
+        pollution_degree: IEC pollution degree (1, 2 or 3) for the lookup.
+        material_group: Insulation material group (``I``/``II``/``IIIa``/``IIIb``).
+        hv_threshold: Minimum cross-domain ``|ΔV|`` (volts) that triggers a
+            creepage keepout; lower-difference domain pairs rely on normal DRC
+            clearance (avoids over-segregating low-voltage nets).
 
     Returns:
         Exit code:
@@ -682,6 +795,27 @@ def run_optimize_placement(
         print(f"  Nets: {len(nets)}")
         print(f"  Board: {board_outline.width:.1f} x {board_outline.height:.1f} mm")
 
+    # --- HV-aware placement context (issue #4373) ---
+    # Build the per-ref domain map + per-domain-pair required-creepage table
+    # from the supplied voltage/domain input. When neither is supplied the
+    # structures stay None and the objective is byte-identical to today.
+    try:
+        hv_ref_domains, hv_required = _build_hv_context(
+            components,
+            nets,
+            voltage_map_path=voltage_map_path,
+            hv_domains_path=hv_domains_path,
+            creepage_standard=creepage_standard,
+            pollution_degree=pollution_degree,
+            material_group=material_group,
+            hv_threshold=hv_threshold,
+            quiet=quiet,
+        )
+    except (ValueError, FileNotFoundError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    hv_exempt: set[frozenset[str]] | None = None
+
     footprint_sizes = _build_footprint_sizes(components)
 
     # Compute bounds
@@ -705,6 +839,9 @@ def run_optimize_placement(
             board_outline,
             cost_config,
             footprint_sizes,
+            ref_domains=hv_ref_domains,
+            required_mm_by_domain_pair=hv_required,
+            exempt_pairs=hv_exempt,
         )
         if not quiet:
             _print_score("Current", score)
@@ -784,6 +921,9 @@ def run_optimize_placement(
             board_outline,
             cost_config,
             footprint_sizes,
+            ref_domains=hv_ref_domains,
+            required_mm_by_domain_pair=hv_required,
+            exempt_pairs=hv_exempt,
         )
         if not quiet:
             _print_score("Seed", seed_score)
@@ -805,6 +945,9 @@ def run_optimize_placement(
                 board_outline,
                 cost_config,
                 footprint_sizes,
+                ref_domains=hv_ref_domains,
+                required_mm_by_domain_pair=hv_required,
+                exempt_pairs=hv_exempt,
             )
             initial_scores.append(score.total)
 
@@ -821,6 +964,9 @@ def run_optimize_placement(
             board_outline,
             cost_config,
             footprint_sizes,
+            ref_domains=hv_ref_domains,
+            required_mm_by_domain_pair=hv_required,
+            exempt_pairs=hv_exempt,
         )
 
     # Keep interrupt state up-to-date with best vector for graceful save
@@ -871,6 +1017,9 @@ def run_optimize_placement(
                     board_outline,
                     cost_config,
                     footprint_sizes,
+                    ref_domains=hv_ref_domains,
+                    required_mm_by_domain_pair=hv_required,
+                    exempt_pairs=hv_exempt,
                 )
                 scores.append(score.total)
 
@@ -933,6 +1082,9 @@ def run_optimize_placement(
         board_outline,
         cost_config,
         footprint_sizes,
+        ref_domains=hv_ref_domains,
+        required_mm_by_domain_pair=hv_required,
+        exempt_pairs=hv_exempt,
     )
 
     # Save final checkpoint
@@ -969,6 +1121,8 @@ def run_optimize_placement(
         print(f"    Boundary:      {_delta(si.boundary, sf.boundary)}")
         print(f"    DRC:           {si.drc:.0f} → {sf.drc:.0f} ({sf.drc - si.drc:+.0f})")
         print(f"    Area:          {_delta(si.area, sf.area)}")
+        if si.creepage or sf.creepage:
+            print(f"    Creepage:      {_delta(si.creepage, sf.creepage)}")
 
         # Feasibility transition (categorical, not percent)
         seed_feas = "feasible" if seed_score.is_feasible else "INFEASIBLE"
@@ -1046,6 +1200,8 @@ def run_optimize_placement(
             components_failing.append(f"boundary={b.boundary:.2f}")
         if b.block_boundary > 0:
             components_failing.append(f"block_boundary={b.block_boundary:.2f}")
+        if b.creepage > 0:
+            components_failing.append(f"creepage={b.creepage:.2f}mm")
         detail = ", ".join(components_failing) if components_failing else "unknown"
 
         if not allow_infeasible:

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -5105,7 +5105,64 @@ def _add_optimize_placement_parser(subparsers) -> None:
         metavar="JSON",
         help=(
             'Custom cost weights as JSON, e.g. \'{"wirelength": 2.0, "overlap": 1e6}\'. '
-            "Keys: overlap, drc, boundary, wirelength, area"
+            "Keys: overlap, drc, boundary, wirelength, area, creepage"
+        ),
+    )
+    op_parser.add_argument(
+        "--voltage-map",
+        metavar="FILE",
+        dest="voltage_map",
+        help=(
+            "Path to a JSON voltage map {net_name: volts} (reuses the #4371 "
+            "format). Enables HV-aware placement (issue #4373): footprints are "
+            "grouped into voltage domains and cross-domain footprints are pushed "
+            "apart to their required creepage. Absent, the objective is "
+            "byte-identical to the voltage-blind default. Mutually exclusive "
+            "with --hv-domains."
+        ),
+    )
+    op_parser.add_argument(
+        "--hv-domains",
+        metavar="FILE",
+        dest="hv_domains",
+        help=(
+            "Path to a JSON HV-domains declaration "
+            '{domain_id: {"refs": [globs], "voltage": v}} -- the manual fallback '
+            "for HV-aware placement when no voltage map is available. Mutually "
+            "exclusive with --voltage-map."
+        ),
+    )
+    op_parser.add_argument(
+        "--creepage-standard",
+        dest="creepage_standard",
+        choices=["iec60664", "iec62368"],
+        default="iec60664",
+        help="Creepage standard for the required-distance lookup (default: iec60664)",
+    )
+    op_parser.add_argument(
+        "--pollution-degree",
+        dest="pollution_degree",
+        type=int,
+        choices=[1, 2, 3],
+        default=2,
+        help="IEC pollution degree for the creepage lookup (default: 2)",
+    )
+    op_parser.add_argument(
+        "--material-group",
+        dest="material_group",
+        default="IIIa",
+        help="Insulation material group I/II/IIIa/IIIb for the creepage lookup (default: IIIa)",
+    )
+    op_parser.add_argument(
+        "--hv-threshold",
+        dest="hv_threshold",
+        type=float,
+        default=30.0,
+        metavar="VOLTS",
+        help=(
+            "Minimum cross-domain |ΔV| (volts) that triggers a creepage keepout; "
+            "lower-difference domain pairs rely on normal DRC clearance to avoid "
+            "over-segregating low-voltage nets (default: 30.0)"
         ),
     )
     op_parser.add_argument(

--- a/src/kicad_tools/placement/cost.py
+++ b/src/kicad_tools/placement/cost.py
@@ -50,6 +50,10 @@ class PlacementCostConfig:
         area_weight: Weight for bounding-box area cost.
         block_boundary_weight: Weight for block boundary violation penalty.
         inter_block_spacing: Minimum spacing between block bounding boxes (mm).
+        creepage_weight: Weight for the HV creepage-keepout penalty. Applied to
+            :func:`compute_creepage_violation`. Like ``overlap``/``drc``/
+            ``boundary`` it is treated as a hard-feasibility term: a non-zero
+            creepage shortfall makes the placement infeasible.
         mode: Scoring mode (weighted_sum or lexicographic).
     """
 
@@ -60,6 +64,7 @@ class PlacementCostConfig:
     area_weight: float = 0.1
     block_boundary_weight: float = 1e5
     inter_block_spacing: float = 1.0
+    creepage_weight: float = 1e5
     mode: CostMode = CostMode.WEIGHTED_SUM
 
 
@@ -94,6 +99,9 @@ class CostBreakdown:
         area: Raw bounding-box area of all placements (mm^2).
         block_boundary: Raw block boundary violation penalty (mm).
         inter_block: Raw inter-block spacing violation penalty (mm).
+        creepage: Raw HV creepage-keepout shortfall penalty (mm) -- the sum of
+            required-minus-actual gaps across cross-domain footprint pairs that
+            are closer than their required creepage.
     """
 
     wirelength: float = 0.0
@@ -103,6 +111,7 @@ class CostBreakdown:
     area: float = 0.0
     block_boundary: float = 0.0
     inter_block: float = 0.0
+    creepage: float = 0.0
 
 
 @dataclass(frozen=True)
@@ -112,7 +121,8 @@ class PlacementScore:
     Attributes:
         total: Scalar score (lower is better).
         breakdown: Per-component raw costs before weighting.
-        is_feasible: True if overlap=0, drc=0, and boundary=0.
+        is_feasible: True if overlap=0, drc=0, boundary=0, block_boundary=0,
+            and creepage=0 (HV keepout satisfied).
     """
 
     total: float
@@ -523,6 +533,106 @@ def compute_inter_block_spacing_violation(
     return total
 
 
+def _domain_pair_key(a: str, b: str) -> tuple[str, str]:
+    """Return an order-independent key for a pair of domain ids."""
+    return (a, b) if a <= b else (b, a)
+
+
+def compute_creepage_violation(
+    placements: Sequence[ComponentPlacement],
+    ref_domains: dict[str, str],
+    required_mm_by_domain_pair: dict[tuple[str, str], float],
+    footprint_sizes: dict[str, tuple[float, float]] | None = None,
+    exempt_pairs: set[frozenset[str]] | None = None,
+) -> float:
+    """Compute the HV creepage-keepout shortfall between cross-domain footprints.
+
+    This is the voltage-aware placement term (issue #4373). Each component is
+    assigned an HV *domain* (e.g. ``"mains"``, ``"signal"``) via *ref_domains*.
+    For every pair of footprints that belong to **different** domains, the
+    edge-to-edge gap between their bounding boxes is compared against the
+    required creepage for that domain pair (looked up in
+    *required_mm_by_domain_pair*, keyed by the order-independent
+    ``(min, max)`` domain-id tuple). When the gap is short of the requirement,
+    the shortfall ``required - gap`` is accumulated.
+
+    Same-domain pairs, pairs whose domain combination has no tabulated
+    requirement, and pairs listed in *exempt_pairs* (guarded sense taps that are
+    intentionally close to their parent HV net, issue #4373 Phase 3) contribute
+    zero. Components absent from *ref_domains* are treated as domain-less and
+    skipped.
+
+    The required distances are supplied by the caller -- typically derived from
+    ``kicad_tools.creepage.standards`` at the cross-domain ``|ΔV|`` -- so this
+    function stays a pure numeric penalty with no standards dependency.
+
+    Args:
+        placements: Current component positions.
+        ref_domains: Map from component reference to its HV domain id.
+        required_mm_by_domain_pair: Map from an order-independent
+            ``(domain_a, domain_b)`` tuple to the required creepage in mm.
+        footprint_sizes: Map from reference to (width, height) in mm.
+        exempt_pairs: Optional set of ``frozenset({ref_a, ref_b})`` pairs to
+            exclude from the keepout (guarded sense taps).
+
+    Returns:
+        Sum of creepage shortfalls (mm) across all constrained cross-domain
+        footprint pairs. Zero means every cross-domain pair meets its required
+        creepage.
+    """
+    if not ref_domains or not required_mm_by_domain_pair:
+        return 0.0
+
+    default_size = (1.0, 1.0)
+    exempt = exempt_pairs or set()
+
+    boxes: list[tuple[str, str, float, float, float, float]] = []
+    for p in placements:
+        domain = ref_domains.get(p.reference)
+        if domain is None:
+            continue
+        w, h = (footprint_sizes or {}).get(p.reference, default_size)
+        half_w, half_h = w / 2, h / 2
+        boxes.append(
+            (
+                p.reference,
+                domain,
+                p.x - half_w,
+                p.y - half_h,
+                p.x + half_w,
+                p.y + half_h,
+            )
+        )
+
+    total = 0.0
+    n = len(boxes)
+    for i in range(n):
+        ref_i, dom_i, imin_x, imin_y, imax_x, imax_y = boxes[i]
+        for j in range(i + 1, n):
+            ref_j, dom_j, jmin_x, jmin_y, jmax_x, jmax_y = boxes[j]
+            if dom_i == dom_j:
+                continue
+            required = required_mm_by_domain_pair.get(_domain_pair_key(dom_i, dom_j))
+            if required is None or required <= 0.0:
+                continue
+            if frozenset((ref_i, ref_j)) in exempt:
+                continue
+
+            gap_x = max(imin_x, jmin_x) - min(imax_x, jmax_x)
+            gap_y = max(imin_y, jmin_y) - min(imax_y, jmax_y)
+            if gap_x <= 0 and gap_y <= 0:
+                gap = 0.0
+            elif gap_x > 0 and gap_y > 0:
+                gap = (gap_x**2 + gap_y**2) ** 0.5
+            else:
+                gap = max(gap_x, gap_y)
+
+            if gap < required:
+                total += required - gap
+
+    return total
+
+
 def evaluate_placement(
     placements: Sequence[ComponentPlacement],
     nets: Sequence[Net],
@@ -532,6 +642,9 @@ def evaluate_placement(
     footprint_sizes: dict[str, tuple[float, float]] | None = None,
     block_regions: Sequence[BlockRegion] | None = None,
     block_membership: dict[str, str] | None = None,
+    ref_domains: dict[str, str] | None = None,
+    required_mm_by_domain_pair: dict[tuple[str, str], float] | None = None,
+    exempt_pairs: set[frozenset[str]] | None = None,
 ) -> PlacementScore:
     """Evaluate a placement configuration and return a composite score.
 
@@ -562,6 +675,13 @@ def evaluate_placement(
             Used by overlap, boundary, and DRC sub-functions.
         block_regions: Optional block boundary regions for block-aware scoring.
         block_membership: Optional map from component reference to block_id.
+        ref_domains: Optional map from component reference to its HV domain id.
+            Enables the voltage-aware creepage-keepout term (issue #4373).
+        required_mm_by_domain_pair: Optional map from an order-independent
+            ``(domain_a, domain_b)`` tuple to the required creepage in mm.
+            Required alongside *ref_domains* for the creepage term to fire.
+        exempt_pairs: Optional set of ``frozenset({ref_a, ref_b})`` pairs
+            exempted from the creepage keepout (guarded sense taps).
 
     Returns:
         PlacementScore with total score, per-component breakdown, and
@@ -588,6 +708,19 @@ def evaluate_placement(
             placements, block_membership, config.inter_block_spacing, footprint_sizes
         )
 
+    # HV creepage-keepout term (issue #4373). Only fires when both a domain
+    # map and a required-distance table are supplied -- keeps the default
+    # (voltage-blind) objective byte-identical.
+    creepage = 0.0
+    if ref_domains and required_mm_by_domain_pair:
+        creepage = compute_creepage_violation(
+            placements,
+            ref_domains,
+            required_mm_by_domain_pair,
+            footprint_sizes,
+            exempt_pairs,
+        )
+
     breakdown = CostBreakdown(
         wirelength=wirelength,
         overlap=overlap,
@@ -596,9 +729,16 @@ def evaluate_placement(
         area=area,
         block_boundary=block_boundary,
         inter_block=inter_block,
+        creepage=creepage,
     )
 
-    is_feasible = overlap == 0.0 and drc == 0.0 and boundary == 0.0 and block_boundary == 0.0
+    is_feasible = (
+        overlap == 0.0
+        and drc == 0.0
+        and boundary == 0.0
+        and block_boundary == 0.0
+        and creepage == 0.0
+    )
 
     if config.mode == CostMode.LEXICOGRAPHIC:
         total = _lexicographic_score(breakdown, config, is_feasible)
@@ -622,6 +762,7 @@ def _weighted_sum_score(breakdown: CostBreakdown, config: PlacementCostConfig) -
         + config.area_weight * breakdown.area
         + config.block_boundary_weight * breakdown.block_boundary
         + config.block_boundary_weight * breakdown.inter_block
+        + config.creepage_weight * breakdown.creepage
     )
 
 
@@ -648,6 +789,7 @@ def _lexicographic_score(
             config.overlap_weight * breakdown.overlap
             + config.drc_weight * breakdown.drc
             + config.boundary_weight * breakdown.boundary
+            + config.creepage_weight * breakdown.creepage
         )
     else:
         return config.wirelength_weight * breakdown.wirelength + config.area_weight * breakdown.area

--- a/src/kicad_tools/placement/hv_domains.py
+++ b/src/kicad_tools/placement/hv_domains.py
@@ -1,0 +1,204 @@
+"""HV-domain derivation for voltage-aware placement (issue #4373).
+
+Turns a voltage/domain *input contract* into the two structures the
+placement objective needs for its creepage-keepout term
+(:func:`kicad_tools.placement.cost.compute_creepage_violation`):
+
+* ``ref_domains``  -- map from a component reference to its HV *domain id*.
+* ``required_mm_by_domain_pair`` -- map from an order-independent
+  ``(domain_a, domain_b)`` tuple to the required creepage in mm, derived from
+  the governing standard at the cross-domain ``|ΔV|``.
+
+Two input sources are supported (see ``docs/placement-scoring.md``):
+
+1. **Voltage map** (``--voltage-map v.json``) -- a flat ``{net_name: volts}``
+   object, reusing the format from the per-net ΔV model (#4371). Each
+   component's domain is the *name of its highest-magnitude-voltage net*
+   (a footprint touching a 150 V mains net lands in that mains domain), and
+   the domain's representative voltage is that magnitude. Cross-domain
+   required creepage is looked up at ``|V_a - V_b|``.
+
+2. **HV-domains declaration** (``--hv-domains d.json``) -- the manual fallback
+   so the feature works standalone (before #4371 lands). Schema::
+
+       {
+         "mains":  {"refs": ["J1", "R1", "R2"], "voltage": 150},
+         "signal": {"refs": ["U3", "R10"],      "voltage": 3.3}
+       }
+
+   Keys are domain ids; ``refs`` is a list of ``fnmatch`` ref globs and
+   ``voltage`` is the domain's representative RMS working voltage. When a ref
+   matches more than one domain it resolves to the higher-voltage domain.
+
+The required-distance lookup uses
+``kicad_tools.creepage.standards.get_standard(id).required_creepage(...)`` --
+no hand-rolled table -- and preserves that module's *fail-loud* contract: a
+``|ΔV|`` above the highest tabulated row raises
+:class:`~kicad_tools.creepage.standards.StandardLookupError` rather than
+silently extrapolating.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from kicad_tools.creepage.standards import get_standard
+
+
+def load_voltage_map(path: str | Path) -> dict[str, float]:
+    """Load a ``{net_name: volts}`` voltage map from a JSON file.
+
+    Raises:
+        ValueError: If the file is not a JSON object of ``str -> number``.
+    """
+    raw = json.loads(Path(path).read_text())
+    if not isinstance(raw, dict):
+        raise ValueError(f"voltage map must be a JSON object, got {type(raw).__name__}")
+    out: dict[str, float] = {}
+    for net, volts in raw.items():
+        if not isinstance(volts, (int, float)) or isinstance(volts, bool):
+            raise ValueError(f"voltage for net {net!r} must be a number, got {volts!r}")
+        out[str(net)] = float(volts)
+    return out
+
+
+def load_hv_domains(path: str | Path) -> dict[str, dict]:
+    """Load an ``--hv-domains`` declaration from a JSON file.
+
+    Raises:
+        ValueError: If the file is not a JSON object of the documented shape.
+    """
+    raw = json.loads(Path(path).read_text())
+    if not isinstance(raw, dict):
+        raise ValueError(f"hv-domains declaration must be a JSON object, got {type(raw).__name__}")
+    out: dict[str, dict] = {}
+    for domain_id, spec in raw.items():
+        if not isinstance(spec, dict):
+            raise ValueError(
+                f"hv-domains entry {domain_id!r} must be an object with 'refs'/'voltage', "
+                f"got {spec!r}"
+            )
+        refs = spec.get("refs", [])
+        if not isinstance(refs, list) or not all(isinstance(r, str) for r in refs):
+            raise ValueError(f"hv-domains entry {domain_id!r} 'refs' must be a list of ref globs")
+        out[str(domain_id)] = spec
+    return out
+
+
+def derive_ref_domains_from_voltage_map(
+    nets: Sequence,
+    voltage_map: Mapping[str, float],
+) -> tuple[dict[str, str], dict[str, float]]:
+    """Derive per-ref domains from a net voltage map.
+
+    A component's domain is the name of the highest-|voltage| net it touches
+    (ties resolve to the first-seen net). The returned ``domain_voltages`` maps
+    each such domain id to that net's voltage magnitude.
+
+    Args:
+        nets: Sequence of objects exposing ``name`` and ``pins`` (an iterable of
+            ``(ref, pad)`` tuples) -- e.g. :class:`kicad_tools.placement.cost.Net`.
+        voltage_map: ``{net_name: volts}``.
+
+    Returns:
+        ``(ref_domains, domain_voltages)``.
+    """
+    ref_best: dict[str, tuple[float, str]] = {}
+    for net in nets:
+        volts = voltage_map.get(net.name)
+        if volts is None:
+            continue
+        mag = abs(float(volts))
+        for ref, _pad in net.pins:
+            cur = ref_best.get(ref)
+            if cur is None or mag > cur[0]:
+                ref_best[ref] = (mag, net.name)
+
+    ref_domains = {ref: name for ref, (_mag, name) in ref_best.items()}
+    domain_voltages = {name: mag for _ref, (mag, name) in ref_best.items()}
+    return ref_domains, domain_voltages
+
+
+def derive_ref_domains_from_declaration(
+    refs: Sequence[str],
+    declaration: Mapping[str, dict],
+) -> tuple[dict[str, str], dict[str, float]]:
+    """Derive per-ref domains from an ``--hv-domains`` declaration.
+
+    A ref matching several domains resolves to the higher-voltage domain
+    (matching the voltage-map tie-break). Domains without a ``voltage`` still
+    group refs (for reporting) but contribute no creepage requirement.
+
+    Args:
+        refs: All component references on the board.
+        declaration: ``{domain_id: {"refs": [globs], "voltage": v}}``.
+
+    Returns:
+        ``(ref_domains, domain_voltages)``.
+    """
+    domain_voltages: dict[str, float] = {}
+    for domain_id, spec in declaration.items():
+        volts = spec.get("voltage")
+        if volts is not None:
+            domain_voltages[domain_id] = abs(float(volts))
+
+    ref_domains: dict[str, str] = {}
+    for ref in refs:
+        best: tuple[float, str] | None = None
+        for domain_id, spec in declaration.items():
+            globs = spec.get("refs", [])
+            if any(fnmatch.fnmatchcase(ref, g) for g in globs):
+                mag = domain_voltages.get(domain_id, 0.0)
+                if best is None or mag > best[0]:
+                    best = (mag, domain_id)
+        if best is not None:
+            ref_domains[ref] = best[1]
+
+    return ref_domains, domain_voltages
+
+
+def build_required_by_domain_pair(
+    domain_voltages: Mapping[str, float],
+    *,
+    standard_id: str = "iec60664",
+    pollution_degree: int = 2,
+    material_group: str = "IIIa",
+    hv_threshold: float = 30.0,
+) -> dict[tuple[str, str], float]:
+    """Build the per-domain-pair required-creepage table.
+
+    For every unordered pair of domains whose voltage difference is at least
+    *hv_threshold*, the required creepage is looked up in the governing
+    standard at ``|ΔV|``. Pairs below the threshold are omitted so that
+    low-voltage/low-voltage domain pairs are not over-segregated (normal DRC
+    clearance still applies to them).
+
+    Args:
+        domain_voltages: ``{domain_id: voltage_magnitude}``.
+        standard_id: Creepage standard id (``iec60664`` / ``iec62368``).
+        pollution_degree: IEC pollution degree (1, 2 or 3).
+        material_group: Insulation material group (``I``/``II``/``IIIa``/``IIIb``).
+        hv_threshold: Minimum ``|ΔV|`` (volts) for a pair to receive a keepout.
+
+    Returns:
+        ``{(domain_a, domain_b): required_mm}`` with order-independent keys.
+
+    Raises:
+        StandardLookupError: If a cross-domain ``|ΔV|`` exceeds the highest
+            tabulated row (no silent extrapolation).
+    """
+    std = get_standard(standard_id)
+    ids = sorted(domain_voltages)
+    out: dict[tuple[str, str], float] = {}
+    for i in range(len(ids)):
+        for j in range(i + 1, len(ids)):
+            a, b = ids[i], ids[j]
+            dv = abs(domain_voltages[a] - domain_voltages[b])
+            if dv < hv_threshold:
+                continue
+            required, _prov = std.required_creepage(dv, pollution_degree, material_group)
+            out[(a, b)] = required
+    return out

--- a/tests/test_optimize_placement_cmd.py
+++ b/tests/test_optimize_placement_cmd.py
@@ -13,6 +13,7 @@ pytest.importorskip("cmaes", reason="cmaes not installed (optional 'placement'/'
 
 from kicad_tools.cli.optimize_placement_cmd import (  # noqa: E402
     _build_footprint_sizes,
+    _build_hv_context,
     _create_strategy,
     _evaluate,
     _generate_seed,
@@ -1488,3 +1489,162 @@ class TestCLIFlagsForFeasibilityGate:
         parser = create_parser()
         args = parser.parse_args(["optimize-placement", "board.kicad_pcb"])
         assert args.allow_infeasible is False
+
+
+# ---------------------------------------------------------------------------
+# HV-aware placement (issue #4373)
+# ---------------------------------------------------------------------------
+
+
+class TestHvContext:
+    """_build_hv_context turns the voltage/domain input into cost structures."""
+
+    def _components(self):
+        return [ComponentDef(reference="R1"), ComponentDef(reference="C1")]
+
+    def _nets(self):
+        return [
+            Net(name="/AC_LINE", pins=[("R1", "1")]),
+            Net(name="/REF_1V65", pins=[("C1", "1")]),
+        ]
+
+    def test_no_input_returns_none(self):
+        ref_domains, required = _build_hv_context(
+            self._components(),
+            self._nets(),
+            voltage_map_path=None,
+            hv_domains_path=None,
+            creepage_standard="iec60664",
+            pollution_degree=2,
+            material_group="IIIa",
+            hv_threshold=30.0,
+            quiet=True,
+        )
+        assert ref_domains is None
+        assert required is None
+
+    def test_mutually_exclusive_raises(self, tmp_path):
+        vm = tmp_path / "v.json"
+        vm.write_text(json.dumps({"/AC_LINE": 150}))
+        dm = tmp_path / "d.json"
+        dm.write_text(json.dumps({"mains": {"refs": ["R1"], "voltage": 150}}))
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            _build_hv_context(
+                self._components(),
+                self._nets(),
+                voltage_map_path=str(vm),
+                hv_domains_path=str(dm),
+                creepage_standard="iec60664",
+                pollution_degree=2,
+                material_group="IIIa",
+                hv_threshold=30.0,
+                quiet=True,
+            )
+
+    def test_voltage_map_builds_context(self, tmp_path):
+        vm = tmp_path / "v.json"
+        vm.write_text(json.dumps({"/AC_LINE": 150, "/REF_1V65": 1.65}))
+        ref_domains, required = _build_hv_context(
+            self._components(),
+            self._nets(),
+            voltage_map_path=str(vm),
+            hv_domains_path=None,
+            creepage_standard="iec60664",
+            pollution_degree=2,
+            material_group="IIIa",
+            hv_threshold=30.0,
+            quiet=True,
+        )
+        assert ref_domains == {"R1": "/AC_LINE", "C1": "/REF_1V65"}
+        assert required[("/AC_LINE", "/REF_1V65")] == pytest.approx(1.6)
+
+    def test_hv_domains_declaration_builds_context(self, tmp_path):
+        dm = tmp_path / "d.json"
+        dm.write_text(
+            json.dumps(
+                {
+                    "mains": {"refs": ["R1"], "voltage": 150},
+                    "signal": {"refs": ["C1"], "voltage": 1.65},
+                }
+            )
+        )
+        ref_domains, required = _build_hv_context(
+            self._components(),
+            self._nets(),
+            voltage_map_path=None,
+            hv_domains_path=str(dm),
+            creepage_standard="iec60664",
+            pollution_degree=2,
+            material_group="IIIa",
+            hv_threshold=30.0,
+            quiet=True,
+        )
+        assert ref_domains == {"R1": "mains", "C1": "signal"}
+        assert required[("mains", "signal")] == pytest.approx(1.6)
+
+    def test_out_of_range_voltage_raises_valueerror(self, tmp_path):
+        vm = tmp_path / "v.json"
+        # /AC_LINE at 5000 V exceeds the highest tabulated creepage row.
+        vm.write_text(json.dumps({"/AC_LINE": 5000, "/REF_1V65": 0}))
+        with pytest.raises(ValueError, match="creepage lookup failed"):
+            _build_hv_context(
+                self._components(),
+                self._nets(),
+                voltage_map_path=str(vm),
+                hv_domains_path=None,
+                creepage_standard="iec60664",
+                pollution_degree=2,
+                material_group="IIIa",
+                hv_threshold=30.0,
+                quiet=True,
+            )
+
+
+class TestRunWithVoltageMap:
+    """End-to-end run_optimize_placement wiring for the HV inputs."""
+
+    def test_mutually_exclusive_cli_exit_1(self, tmp_pcb, tmp_path, capsys):
+        vm = tmp_path / "v.json"
+        vm.write_text(json.dumps({"N1": 150}))
+        dm = tmp_path / "d.json"
+        dm.write_text(json.dumps({"mains": {"refs": ["R1"], "voltage": 150}}))
+        result = run_optimize_placement(
+            str(tmp_pcb),
+            voltage_map_path=str(vm),
+            hv_domains_path=str(dm),
+            quiet=True,
+        )
+        assert result == 1
+        assert "mutually exclusive" in capsys.readouterr().err
+
+    def test_voltage_map_run_completes(self, tmp_pcb, tmp_path):
+        vm = tmp_path / "v.json"
+        # N1 is a 150 V mains net, N2 a low-voltage signal.
+        vm.write_text(json.dumps({"N1": 150, "N2": 1.65}))
+        output = tmp_path / "out.kicad_pcb"
+        result = run_optimize_placement(
+            str(tmp_pcb),
+            max_iterations=15,
+            output_path=str(output),
+            voltage_map_path=str(vm),
+            quiet=True,
+            allow_infeasible=True,
+        )
+        # Should run to completion (exit 0 feasible, or non-fatal with
+        # allow_infeasible) and write the board.
+        assert result in (0, 2)
+        assert output.exists()
+
+    def test_dry_run_with_voltage_map_reports_creepage(self, tmp_pcb, tmp_path, capsys):
+        vm = tmp_path / "v.json"
+        vm.write_text(json.dumps({"N1": 150, "N2": 1.65}))
+        result = run_optimize_placement(
+            str(tmp_pcb),
+            dry_run=True,
+            voltage_map_path=str(vm),
+        )
+        assert result == 0
+        # The evidence board's R1 (mains) and C1 (signal) start < 1.6 mm apart,
+        # so the dry-run should flag the current placement as INFEASIBLE.
+        out = capsys.readouterr().out
+        assert "HV domains" in out

--- a/tests/test_placement_cost.py
+++ b/tests/test_placement_cost.py
@@ -11,9 +11,15 @@ from __future__ import annotations
 import pytest
 
 from kicad_tools.placement.cost import (
+    BoardOutline,
     ComponentPlacement,
+    CostMode,
+    DesignRuleSet,
     Net,
+    PlacementCostConfig,
+    compute_creepage_violation,
     compute_wirelength,
+    evaluate_placement,
 )
 
 # ---------------------------------------------------------------------------
@@ -130,3 +136,124 @@ class TestComputeWirelengthZeroWeight:
         placements = _placements()
         net = Net(name="ZERO", pins=[("A", "1"), ("B", "1"), ("C", "1")], weight=0.0)
         assert compute_wirelength(placements, [net]) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# HV creepage-keepout term (issue #4373)
+# ---------------------------------------------------------------------------
+
+# Two 2x2 mm footprints; edge-to-edge gap = |dx| - 2 when placed on the X axis.
+_HV_SIZES = {"A": (2.0, 2.0), "B": (2.0, 2.0)}
+# Reproduces the AC_NEUTRAL <-> REF_1V65 evidence pair: required 1.6 mm.
+_REQ = {("mains", "signal"): 1.6}
+
+
+def _hv_pair(dx: float) -> list[ComponentPlacement]:
+    """A at origin, B at (dx, 0). Both 2x2 mm -> gap = dx - 2 for dx >= 2."""
+    return [
+        ComponentPlacement(reference="A", x=0.0, y=0.0),
+        ComponentPlacement(reference="B", x=dx, y=0.0),
+    ]
+
+
+class TestComputeCreepageViolation:
+    def test_same_domain_pair_is_zero(self) -> None:
+        """Two refs in the same domain never incur a keepout shortfall."""
+        placements = _hv_pair(2.35)  # gap 0.35 mm -- but same domain
+        domains = {"A": "mains", "B": "mains"}
+        assert compute_creepage_violation(placements, domains, _REQ, _HV_SIZES) == 0.0
+
+    def test_cross_domain_below_required_reports_shortfall(self) -> None:
+        placements = _hv_pair(2.35)  # gap 0.35 mm, required 1.6 -> shortfall 1.25
+        domains = {"A": "mains", "B": "signal"}
+        got = compute_creepage_violation(placements, domains, _REQ, _HV_SIZES)
+        assert got == pytest.approx(1.25)
+
+    def test_cross_domain_at_or_above_required_is_zero(self) -> None:
+        placements = _hv_pair(3.6)  # gap exactly 1.6 mm == required -> no shortfall
+        domains = {"A": "mains", "B": "signal"}
+        assert compute_creepage_violation(placements, domains, _REQ, _HV_SIZES) == 0.0
+
+    def test_untabulated_domain_pair_is_zero(self) -> None:
+        """A cross-domain pair with no required-distance entry is unconstrained."""
+        placements = _hv_pair(2.35)
+        domains = {"A": "mains", "B": "other"}  # ("mains","other") absent from _REQ
+        assert compute_creepage_violation(placements, domains, _REQ, _HV_SIZES) == 0.0
+
+    def test_exempt_pair_is_skipped(self) -> None:
+        """Guarded sense taps: an exempt ref pair incurs no shortfall."""
+        placements = _hv_pair(2.35)
+        domains = {"A": "mains", "B": "signal"}
+        exempt = {frozenset(("A", "B"))}
+        got = compute_creepage_violation(placements, domains, _REQ, _HV_SIZES, exempt)
+        assert got == 0.0
+
+    def test_ref_absent_from_domains_is_skipped(self) -> None:
+        placements = _hv_pair(2.35)
+        domains = {"A": "mains"}  # B has no domain -> pair skipped
+        assert compute_creepage_violation(placements, domains, _REQ, _HV_SIZES) == 0.0
+
+    def test_empty_inputs_are_zero(self) -> None:
+        placements = _hv_pair(2.35)
+        assert compute_creepage_violation(placements, {}, _REQ, _HV_SIZES) == 0.0
+        assert compute_creepage_violation(placements, {"A": "mains"}, {}, _HV_SIZES) == 0.0
+
+
+class TestEvaluatePlacementCreepageFeasibility:
+    """The creepage term gates feasibility in evaluate_placement."""
+
+    _BOARD = BoardOutline(min_x=-10.0, min_y=-10.0, max_x=10.0, max_y=10.0)
+    _RULES = DesignRuleSet()
+
+    def test_too_close_is_infeasible(self) -> None:
+        placements = _hv_pair(2.35)  # gap 0.35 < 1.6
+        domains = {"A": "mains", "B": "signal"}
+        score = evaluate_placement(
+            placements,
+            nets=[],
+            rules=self._RULES,
+            board=self._BOARD,
+            config=PlacementCostConfig(mode=CostMode.LEXICOGRAPHIC),
+            footprint_sizes=_HV_SIZES,
+            ref_domains=domains,
+            required_mm_by_domain_pair=_REQ,
+        )
+        assert score.breakdown.creepage == pytest.approx(1.25)
+        assert score.is_feasible is False
+        # Lexicographic: infeasible placements sit above the sentinel offset.
+        assert score.total >= 1e12
+
+    def test_separated_is_feasible(self) -> None:
+        placements = _hv_pair(3.6)  # gap 1.6 == required
+        domains = {"A": "mains", "B": "signal"}
+        score = evaluate_placement(
+            placements,
+            nets=[],
+            rules=self._RULES,
+            board=self._BOARD,
+            config=PlacementCostConfig(mode=CostMode.LEXICOGRAPHIC),
+            footprint_sizes=_HV_SIZES,
+            ref_domains=domains,
+            required_mm_by_domain_pair=_REQ,
+        )
+        assert score.breakdown.creepage == 0.0
+        assert score.is_feasible is True
+
+    def test_no_domain_input_is_byte_identical(self) -> None:
+        """Absent a domain/voltage input the creepage term stays dormant."""
+        placements = _hv_pair(2.35)
+        common = {
+            "nets": [],
+            "rules": self._RULES,
+            "board": self._BOARD,
+            "config": PlacementCostConfig(mode=CostMode.LEXICOGRAPHIC),
+            "footprint_sizes": _HV_SIZES,
+        }
+        baseline = evaluate_placement(placements, **common)
+        # Passing domains but no required table (and vice versa) must also no-op.
+        with_domains_only = evaluate_placement(
+            placements, ref_domains={"A": "mains", "B": "signal"}, **common
+        )
+        assert baseline.breakdown.creepage == 0.0
+        assert with_domains_only.breakdown.creepage == 0.0
+        assert with_domains_only.total == baseline.total

--- a/tests/test_placement_hv_domains.py
+++ b/tests/test_placement_hv_domains.py
@@ -1,0 +1,132 @@
+"""Unit tests for kicad_tools.placement.hv_domains (issue #4373).
+
+Covers the voltage/domain input contract (Phase 0): deriving per-ref domains
+from a voltage map or an --hv-domains declaration, and building the
+per-domain-pair required-creepage table from the governing standard.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from kicad_tools.creepage.standards import StandardLookupError
+from kicad_tools.placement.cost import Net
+from kicad_tools.placement.hv_domains import (
+    build_required_by_domain_pair,
+    derive_ref_domains_from_declaration,
+    derive_ref_domains_from_voltage_map,
+    load_hv_domains,
+    load_voltage_map,
+)
+
+
+class TestDeriveFromVoltageMap:
+    def test_ref_domain_is_highest_voltage_net(self) -> None:
+        """A ref touching a mains net lands in the mains domain (highest |V|)."""
+        nets = [
+            Net(name="/AC_LINE", pins=[("R1", "1"), ("U2", "3")]),
+            Net(name="/REF_1V65", pins=[("U2", "4"), ("C5", "1")]),
+        ]
+        voltage_map = {"/AC_LINE": 150.0, "/REF_1V65": 1.65}
+        ref_domains, domain_voltages = derive_ref_domains_from_voltage_map(nets, voltage_map)
+        # U2 touches both nets -> resolves to the higher-voltage (mains) domain.
+        assert ref_domains["U2"] == "/AC_LINE"
+        assert ref_domains["R1"] == "/AC_LINE"
+        assert ref_domains["C5"] == "/REF_1V65"
+        assert domain_voltages["/AC_LINE"] == pytest.approx(150.0)
+        assert domain_voltages["/REF_1V65"] == pytest.approx(1.65)
+
+    def test_negative_voltage_uses_magnitude(self) -> None:
+        nets = [Net(name="/VNEG", pins=[("U1", "1"), ("U2", "1")])]
+        ref_domains, domain_voltages = derive_ref_domains_from_voltage_map(nets, {"/VNEG": -48.0})
+        assert ref_domains["U1"] == "/VNEG"
+        assert domain_voltages["/VNEG"] == pytest.approx(48.0)
+
+    def test_nets_without_voltage_are_ignored(self) -> None:
+        nets = [Net(name="/UNKNOWN", pins=[("U1", "1"), ("U2", "1")])]
+        ref_domains, domain_voltages = derive_ref_domains_from_voltage_map(nets, {})
+        assert ref_domains == {}
+        assert domain_voltages == {}
+
+
+class TestDeriveFromDeclaration:
+    def test_globs_assign_domains(self) -> None:
+        declaration = {
+            "mains": {"refs": ["J1", "R1*"], "voltage": 150},
+            "signal": {"refs": ["U3"], "voltage": 3.3},
+        }
+        refs = ["J1", "R10", "R11", "U3", "C9"]
+        ref_domains, domain_voltages = derive_ref_domains_from_declaration(refs, declaration)
+        assert ref_domains == {"J1": "mains", "R10": "mains", "R11": "mains", "U3": "signal"}
+        assert "C9" not in ref_domains
+        assert domain_voltages == {"mains": pytest.approx(150.0), "signal": pytest.approx(3.3)}
+
+    def test_ref_matching_two_domains_takes_higher_voltage(self) -> None:
+        declaration = {
+            "mains": {"refs": ["R1"], "voltage": 150},
+            "signal": {"refs": ["R1"], "voltage": 3.3},
+        }
+        ref_domains, _ = derive_ref_domains_from_declaration(["R1"], declaration)
+        assert ref_domains["R1"] == "mains"
+
+
+class TestBuildRequiredByDomainPair:
+    def test_mains_signal_pair_uses_step_up_creepage(self) -> None:
+        # |150 - 1.65| ~ 148 V -> steps up to the 160 V row -> 1.6 mm at PD2/IIIa.
+        required = build_required_by_domain_pair(
+            {"mains": 150.0, "signal": 1.65},
+            standard_id="iec60664",
+            pollution_degree=2,
+            material_group="IIIa",
+        )
+        assert required[("mains", "signal")] == pytest.approx(1.6)
+
+    def test_pairs_below_threshold_are_omitted(self) -> None:
+        # 3.3 V vs 1.65 V -> |dV| 1.65 < 30 V threshold -> no keepout entry.
+        required = build_required_by_domain_pair(
+            {"a": 3.3, "b": 1.65},
+            hv_threshold=30.0,
+        )
+        assert required == {}
+
+    def test_keys_are_order_independent(self) -> None:
+        required = build_required_by_domain_pair({"z": 150.0, "a": 1.65})
+        # sorted() -> key is ("a", "z"), not ("z", "a").
+        assert ("a", "z") in required
+
+    def test_out_of_range_voltage_raises(self) -> None:
+        # |ΔV| above the highest tabulated creepage row must fail loud.
+        with pytest.raises(StandardLookupError):
+            build_required_by_domain_pair({"hv": 5000.0, "gnd": 0.0})
+
+
+class TestLoaders:
+    def test_load_voltage_map(self, tmp_path) -> None:
+        p = tmp_path / "v.json"
+        p.write_text(json.dumps({"/AC_LINE": 150, "/REF": 1.65}))
+        assert load_voltage_map(p) == {"/AC_LINE": 150.0, "/REF": 1.65}
+
+    def test_load_voltage_map_rejects_non_numeric(self, tmp_path) -> None:
+        p = tmp_path / "v.json"
+        p.write_text(json.dumps({"/AC_LINE": "high"}))
+        with pytest.raises(ValueError):
+            load_voltage_map(p)
+
+    def test_load_voltage_map_rejects_bool(self, tmp_path) -> None:
+        p = tmp_path / "v.json"
+        p.write_text(json.dumps({"/AC_LINE": True}))
+        with pytest.raises(ValueError):
+            load_voltage_map(p)
+
+    def test_load_hv_domains(self, tmp_path) -> None:
+        p = tmp_path / "d.json"
+        p.write_text(json.dumps({"mains": {"refs": ["J1"], "voltage": 150}}))
+        assert load_hv_domains(p) == {"mains": {"refs": ["J1"], "voltage": 150}}
+
+    def test_load_hv_domains_rejects_bad_refs(self, tmp_path) -> None:
+        p = tmp_path / "d.json"
+        p.write_text(json.dumps({"mains": {"refs": "J1"}}))
+        with pytest.raises(ValueError):
+            load_hv_domains(p)


### PR DESCRIPTION
## Summary

Makes `kct optimize-placement` **HV-aware**. Today the CMA-ES objective is
voltage-blind: wirelength pulls connected pins together and DRC enforces a
single 0.2 mm clearance uniformly, so the optimizer drives 150 V mains copper
into low-voltage sense nets and a creepage-feasible floorplan can only be reached
by hand. This PR adds an opt-in creepage-keepout term and the voltage/domain
input contract that feeds it.

When a voltage/domain input is supplied, every footprint is assigned an HV
**domain** and cross-domain footprints are pushed apart to their required
creepage (looked up in `kicad_tools.creepage.standards` at the cross-domain
`|ΔV|`). A non-zero creepage shortfall makes the placement **INFEASIBLE**, so
under the default lexicographic mode the optimizer refuses to converge on an
HV-too-close layout — exactly as it does for overlap/DRC. Absent any input the
objective is **byte-identical** to today (regression-safe opt-in).

## Changes

- **`placement/cost.py`**: `compute_creepage_violation` term (per-domain-pair
  keepout with guarded-tap `exempt_pairs`); `creepage_weight` on
  `PlacementCostConfig`; `creepage` on `CostBreakdown`; wired into
  `evaluate_placement`, `is_feasible`, and both `_lexicographic_score`/
  `_weighted_sum_score`.
- **`placement/hv_domains.py`** (new): Phase 0 input contract — derive per-ref
  domains from `--voltage-map` (highest-|V| net wins) or an `--hv-domains`
  declaration; build the per-domain-pair required-creepage table from the
  governing standard at `|ΔV|` (fail-loud on out-of-range, no extrapolation);
  `--hv-threshold` guards against over-segregating LV/LV nets.
- **CLI** (`optimize_placement_cmd.py`, `parser.py`, `commands/optimize_placement.py`):
  `_build_hv_context` + new flags `--voltage-map`, `--hv-domains`,
  `--creepage-standard`, `--pollution-degree`, `--material-group`,
  `--hv-threshold`; `--weights` gains a `creepage` key.
- **`docs/placement-scoring.md`**: new HV-aware section (input contract, knobs).
- **Tests**: `tests/test_placement_hv_domains.py` (new) + additions to
  `tests/test_placement_cost.py` and `tests/test_optimize_placement_cmd.py`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Accepts voltage/domain input; byte-identical absent it | ✅ | `--voltage-map`/`--hv-domains`; `test_no_domain_input_is_byte_identical`, `test_no_input_returns_none` |
| Per-ref domain from highest-voltage net | ✅ | `derive_ref_domains_from_voltage_map`; `test_ref_domain_is_highest_voltage_net` |
| Domain segregation via per-domain-pair spacing | ◑ | `compute_creepage_violation` separates cross-domain pairs at their per-pair required distance (clustering of same-domain refs still relies on wirelength — block-attraction deferred) |
| Too-close cross-domain pair ⇒ `is_feasible=False` | ✅ | `test_too_close_is_infeasible` (lexicographic total ≥ 1e12) |
| Required distances from `creepage.standards` (no hand-rolled table) | ✅ | `build_required_by_domain_pair` calls `get_standard(...).required_creepage`; `test_mains_signal_pair_uses_step_up_creepage` (1.6 mm) |
| Guarded sense taps exempt from parent, constrained elsewhere | ◑ | `exempt_pairs` mechanism + `test_exempt_pair_is_skipped`; CLI auto-detection of derived taps deferred |
| HV-aware run clears the evidence pairs where a blind run does not | ✅ | Cost-level `test_cross_domain_below_required_reports_shortfall` (AC_NEUTRAL↔REF_1V65, 0.35 mm ⇒ shortfall 1.25); end-to-end dry-run shows `crp=1.40` under the map and none without it |
| `docs/placement-scoring.md` documents the term + input | ✅ | New "HV-aware placement" section |
| `|ΔV|` above the top row ⇒ `StandardLookupError`, no extrapolation | ✅ | `test_out_of_range_voltage_raises`, `test_out_of_range_voltage_raises_valueerror` |
| Ref touching two domains ⇒ higher-voltage domain | ✅ | `test_ref_matching_two_domains_takes_higher_voltage` |

## Deferred (noted for follow-up)

This is a coherent Phase 0 + Phase 2 slice (input contract + hard creepage
keepout) plus the Phase 3 exemption *mechanism*. Remaining tracked work:
- **Phase 1** active same-domain *clustering* via block attraction (segregation
  here is achieved by the cross-domain keepout; same-domain packing still leans
  on wirelength).
- **Phase 3** automatic detection of derived sense taps from the voltage map and
  the guard advisory (the cost-function `exempt_pairs` hook is in place). Guard
  copper generation stays out of scope (cross-ref #4372).

## Test Plan

- `pytest tests/test_placement_cost.py tests/test_placement_hv_domains.py tests/test_optimize_placement_cmd.py` → 101 passed.
- Broader placement/MCP/scoring-parity suites green (visualization failures are a
  pre-existing missing-matplotlib environment issue, unrelated).
- `ruff check` + `ruff format --check` clean; mypy adds no new errors over the
  committed baseline (`test_ci_mypy_baseline.py` green).
- Manual: end-to-end `optimize-placement --dry-run --voltage-map` on a synthetic
  mains/signal board reports `crp=1.40` (infeasible) vs. no creepage term without
  the map; a full run separates the pair and exits 0 feasible.

Part of #4373