### PR TITLE
test: pin kicad-cli 'pcb drc --format json' schema with a golden fixture

### DIFF
--- a/tests/fixtures/drc/kicad_cli_drc_golden.json
+++ b/tests/fixtures/drc/kicad_cli_drc_golden.json
@@ -1,0 +1,243 @@
+{
+    "$schema": "https://schemas.kicad.org/drc.v1.json",
+    "coordinate_units": "mm",
+    "date": "2026-07-20T16:23:27",
+    "ignored_checks": [
+        {
+            "description": "Footprint has no courtyard defined",
+            "key": "missing_courtyard"
+        },
+        {
+            "description": "Track endpoint not centered on via",
+            "key": "track_not_centered_on_via"
+        },
+        {
+            "description": "Tuning profile track geometries",
+            "key": "tuning_profile_track_geometries"
+        },
+        {
+            "description": "Footprint doesn't match symbol's footprint filters",
+            "key": "footprint_filters_mismatch"
+        },
+        {
+            "description": "Footprint component type doesn't match footprint pads",
+            "key": "footprint_type_mismatch"
+        }
+    ],
+    "included_severities": [
+        "error",
+        "warning"
+    ],
+    "kicad_version": "10.0.4",
+    "schematic_parity": [],
+    "source": "stale_nets.kicad_pcb",
+    "unconnected_items": [],
+    "violations": [
+        {
+            "description": "Items shorting two nets (nets Net-(C11-2) and Net-(R1-1))",
+            "items": [
+                {
+                    "description": "Track [Net-(C11-2)] on F.Cu, length 1.0000 mm",
+                    "pos": {
+                        "x": 19.0,
+                        "y": 10.0
+                    },
+                    "uuid": "427e11ea-c496-4271-bc72-afa6be08644a"
+                },
+                {
+                    "description": "Pad 1 [Net-(R1-1)] of R1 on F.Cu",
+                    "pos": {
+                        "x": 19.0,
+                        "y": 10.0
+                    },
+                    "uuid": "b8c34c4e-d355-408b-b6f3-5d2ac5ad2536"
+                }
+            ],
+            "severity": "error",
+            "type": "shorting_items"
+        },
+        {
+            "description": "Items shorting two nets (nets Net-(C11-2) and Net-(R1-1))",
+            "items": [
+                {
+                    "description": "Track [Net-(C11-2)] on F.Cu, length 8.0000 mm",
+                    "pos": {
+                        "x": 11.0,
+                        "y": 10.0
+                    },
+                    "uuid": "650768da-0cab-450a-9079-5736ca8c1c5d"
+                },
+                {
+                    "description": "Pad 1 [Net-(R1-1)] of R1 on F.Cu",
+                    "pos": {
+                        "x": 19.0,
+                        "y": 10.0
+                    },
+                    "uuid": "b8c34c4e-d355-408b-b6f3-5d2ac5ad2536"
+                }
+            ],
+            "severity": "error",
+            "type": "shorting_items"
+        },
+        {
+            "description": "Clearance violation ( clearance 0.2000 mm; actual 0.0500 mm)",
+            "items": [
+                {
+                    "description": "Via [Net-(C11-2)] on F.Cu - B.Cu",
+                    "pos": {
+                        "x": 19.0,
+                        "y": 11.0
+                    },
+                    "uuid": "6543cf40-d9f5-4e20-be1b-0fe5f7c5ba6a"
+                },
+                {
+                    "description": "Pad 1 [Net-(R1-1)] of R1 on F.Cu",
+                    "pos": {
+                        "x": 19.0,
+                        "y": 10.0
+                    },
+                    "uuid": "b8c34c4e-d355-408b-b6f3-5d2ac5ad2536"
+                }
+            ],
+            "severity": "error",
+            "type": "clearance"
+        },
+        {
+            "description": "Hole clearance violation (board setup constraints hole clearance 0.2500 mm; actual 0.2000 mm)",
+            "items": [
+                {
+                    "description": "Pad 1 [Net-(R1-1)] of R1 on F.Cu",
+                    "pos": {
+                        "x": 19.0,
+                        "y": 10.0
+                    },
+                    "uuid": "b8c34c4e-d355-408b-b6f3-5d2ac5ad2536"
+                },
+                {
+                    "description": "Via [Net-(C11-2)] on F.Cu - B.Cu",
+                    "pos": {
+                        "x": 19.0,
+                        "y": 11.0
+                    },
+                    "uuid": "6543cf40-d9f5-4e20-be1b-0fe5f7c5ba6a"
+                }
+            ],
+            "severity": "error",
+            "type": "hole_clearance"
+        },
+        {
+            "description": "Front solder mask aperture bridges items with different nets",
+            "items": [
+                {
+                    "description": "Track [Net-(C11-2)] on F.Cu, length 1.0000 mm",
+                    "pos": {
+                        "x": 19.0,
+                        "y": 10.0
+                    },
+                    "uuid": "427e11ea-c496-4271-bc72-afa6be08644a"
+                },
+                {
+                    "description": "Pad 1 [Net-(R1-1)] of R1 on F.Cu",
+                    "pos": {
+                        "x": 19.0,
+                        "y": 10.0
+                    },
+                    "uuid": "b8c34c4e-d355-408b-b6f3-5d2ac5ad2536"
+                }
+            ],
+            "severity": "error",
+            "type": "solder_mask_bridge"
+        },
+        {
+            "description": "Front solder mask aperture bridges items with different nets",
+            "items": [
+                {
+                    "description": "Track [Net-(C11-2)] on F.Cu, length 8.0000 mm",
+                    "pos": {
+                        "x": 11.0,
+                        "y": 10.0
+                    },
+                    "uuid": "650768da-0cab-450a-9079-5736ca8c1c5d"
+                },
+                {
+                    "description": "Pad 2 [Net-(C11-Pad2)] of C11 on F.Cu",
+                    "pos": {
+                        "x": 11.0,
+                        "y": 10.0
+                    },
+                    "uuid": "5d6a09c1-8125-40f6-967f-6cfc6c0df3e6"
+                }
+            ],
+            "severity": "error",
+            "type": "solder_mask_bridge"
+        },
+        {
+            "description": "Front solder mask aperture bridges items with different nets",
+            "items": [
+                {
+                    "description": "Track [Net-(C11-2)] on F.Cu, length 8.0000 mm",
+                    "pos": {
+                        "x": 11.0,
+                        "y": 10.0
+                    },
+                    "uuid": "650768da-0cab-450a-9079-5736ca8c1c5d"
+                },
+                {
+                    "description": "Pad 1 [Net-(R1-1)] of R1 on F.Cu",
+                    "pos": {
+                        "x": 19.0,
+                        "y": 10.0
+                    },
+                    "uuid": "b8c34c4e-d355-408b-b6f3-5d2ac5ad2536"
+                }
+            ],
+            "severity": "error",
+            "type": "solder_mask_bridge"
+        },
+        {
+            "description": "Via is not connected or connected on only one layer",
+            "items": [
+                {
+                    "description": "Via [Net-(C11-2)] on F.Cu - B.Cu",
+                    "pos": {
+                        "x": 19.0,
+                        "y": 11.0
+                    },
+                    "uuid": "6543cf40-d9f5-4e20-be1b-0fe5f7c5ba6a"
+                }
+            ],
+            "severity": "warning",
+            "type": "via_dangling"
+        },
+        {
+            "description": "Footprint 'C_0805_2012Metric' does not match copy in library 'Capacitor_SMD'",
+            "items": [
+                {
+                    "description": "Footprint C11",
+                    "pos": {
+                        "x": 10.0,
+                        "y": 10.0
+                    },
+                    "uuid": "2edd07c8-57d8-4edd-8346-6bb78a007f99"
+                }
+            ],
+            "severity": "warning",
+            "type": "lib_footprint_mismatch"
+        },
+        {
+            "description": "Footprint 'R_0805_2012Metric' does not match copy in library 'Resistor_SMD'",
+            "items": [
+                {
+                    "description": "Footprint R1",
+                    "pos": {
+                        "x": 20.0,
+                        "y": 10.0
+                    },
+                    "uuid": "89a547b9-a9a6-41e1-8b1b-667479a2c70b"
+                }
+            ],
+            "severity": "warning",
+            "type": "lib_footprint_mismatch"
+        }
+    ]
+}

--- a/tests/test_drc_report_formats.py
+++ b/tests/test_drc_report_formats.py
@@ -1,6 +1,9 @@
 """Tests for DRC report JSON format parsing (KiCad-cli and kct-check formats)."""
 
 import json
+from pathlib import Path
+
+import pytest
 
 from kicad_tools.drc.report import parse_json_report
 from kicad_tools.drc.violation import Severity, ViolationType
@@ -222,3 +225,282 @@ class TestKicadCliJsonFormat:
         report = parse_json_report(json.dumps(data))
         assert report.violation_count == 1
         assert report.violations[0].items == []
+
+
+# ---------------------------------------------------------------------------
+# Golden-schema contract for real `kicad-cli pcb drc --format json` output.
+#
+# The hand-authored dicts above prove the *parser* handles a given shape, but
+# they cannot catch drift in what `kicad-cli` actually emits -- the fixtures
+# are written by us, not captured from the tool. The golden fixture below is a
+# byte-faithful capture of real `kicad-cli pcb drc --format json` output, so a
+# future KiCad that renames/drops a key we consume (e.g. `violations`,
+# `severity`, or a violation's `type`) breaks these assertions LOUDLY instead
+# of degrading to an empty ("0 errors = clean") report -- the exact silent-pass
+# risk in `_parse_kicad_cli_json`, which reads every field via `dict.get(...)`.
+#
+# ON A KICAD-CLI BUMP: re-capture the golden fixture and reconcile any diff
+# before shipping. Regenerate with (from repo root):
+#
+#     kicad-cli pcb drc --format json --units mm \
+#       --output tests/fixtures/drc/kicad_cli_drc_golden.json \
+#       tests/fixtures/stale_nets.kicad_pcb
+#
+# then bump GOLDEN_KICAD_VERSION below to match `kicad_version` in the payload.
+# ---------------------------------------------------------------------------
+
+# KiCad version the golden fixture was captured from. Bump when re-capturing.
+GOLDEN_KICAD_VERSION = "10.0.4"
+
+_GOLDEN_FIXTURE = Path(__file__).parent / "fixtures" / "drc" / "kicad_cli_drc_golden.json"
+
+# The board the golden fixture was captured from -- also drives the optional
+# live smoke test so a bumped local KiCad is caught immediately.
+_GOLDEN_SOURCE_BOARD = Path(__file__).parent / "fixtures" / "stale_nets.kicad_pcb"
+
+# Top-level keys `_parse_kicad_cli_json` consumes. Absence of `violations` is
+# the headline silent-pass risk: the parser would read it as a clean board.
+_REQUIRED_KICAD_CLI_DRC_KEYS = ("source", "date", "violations")
+
+# Per-violation keys the parser reads without a fallback that would be visible
+# downstream (`type`/`description`/`severity` map to type_str/message/severity).
+_REQUIRED_VIOLATION_KEYS = ("type", "description", "severity")
+
+# The severity enum the contract pins (mirrors `core.types.Severity`).
+_ALLOWED_SEVERITIES = {"error", "warning", "info"}
+
+
+def _load_golden_raw() -> dict:
+    data = json.loads(_GOLDEN_FIXTURE.read_text())
+    assert isinstance(data, dict)
+    return data
+
+
+class TestKicadCliDrcGoldenSchema:
+    """Pin the real `kicad-cli pcb drc --format json` schema against drift.
+
+    Captured from KiCad ``GOLDEN_KICAD_VERSION`` -- see the module comment for
+    the re-capture procedure on a kicad-cli bump.
+    """
+
+    def test_golden_fixture_exists_and_is_json(self):
+        """The golden fixture is present and valid JSON."""
+        assert _GOLDEN_FIXTURE.exists(), (
+            f"Golden fixture missing: {_GOLDEN_FIXTURE}. Re-capture with "
+            "`kicad-cli pcb drc --format json` (see module comment)."
+        )
+        data = _load_golden_raw()
+        assert isinstance(data, dict)
+
+    def test_golden_records_capture_version(self):
+        """The captured payload's KiCad version matches the pinned constant.
+
+        If these diverge, the fixture was re-captured without bumping
+        ``GOLDEN_KICAD_VERSION`` (or vice versa) -- reconcile before shipping.
+        """
+        data = _load_golden_raw()
+        assert data.get("kicad_version") == GOLDEN_KICAD_VERSION
+
+    def test_golden_has_required_top_level_keys(self):
+        """Top-level keys the parser consumes are present.
+
+        A KiCad that drops/renames `violations` would otherwise degrade to an
+        empty, silently-"clean" report.
+        """
+        data = _load_golden_raw()
+        for key in _REQUIRED_KICAD_CLI_DRC_KEYS:
+            assert key in data, (
+                f"Golden fixture missing required top-level key {key!r}. "
+                "KiCad schema may have drifted -- reconcile the parser in "
+                "src/kicad_tools/drc/report.py::_parse_kicad_cli_json."
+            )
+        assert isinstance(data["violations"], list)
+
+    def test_golden_covers_at_least_one_violation(self):
+        """The golden fixture is non-trivial (guards an empty capture)."""
+        data = _load_golden_raw()
+        assert len(data["violations"]) > 0, (
+            "Golden fixture has no violations -- re-capture from a board that "
+            "produces DRC errors so the schema is actually exercised."
+        )
+
+    def test_golden_violation_records_have_required_fields(self):
+        """Every violation carries the fields the parser reads."""
+        data = _load_golden_raw()
+        for i, v in enumerate(data["violations"]):
+            for key in _REQUIRED_VIOLATION_KEYS:
+                assert key in v, f"violations[{i}] missing required key {key!r}: {v!r}"
+
+    def test_golden_severity_enum_is_pinned(self):
+        """Every severity value is one of {error, warning, info}.
+
+        A new/renamed severity (e.g. `critical`) must fail here rather than be
+        silently coerced by `Severity.from_string`.
+        """
+        data = _load_golden_raw()
+        for i, v in enumerate(data["violations"]):
+            sev = v["severity"]
+            assert sev in _ALLOWED_SEVERITIES, (
+                f"violations[{i}] has unpinned severity {sev!r}; "
+                f"expected one of {sorted(_ALLOWED_SEVERITIES)}. Update "
+                "core.types.Severity AND this contract deliberately."
+            )
+
+    def test_golden_items_shape(self):
+        """Where a violation has items, each item exposes description + pos.{x,y}.
+
+        Note: KiCad 10.0.4 does NOT emit a per-item `net` key nor a
+        violation-level `pos` -- the net is embedded in the item
+        `description` as ``[NetName]``. The parser reads `net`/`pos`
+        defensively via `dict.get`/`"net" in item`, so their absence is
+        tolerated (nets end up empty). If a future KiCad ADDS `net`, the
+        parser will start populating `DRCViolation.nets`; this test documents
+        the current real shape so that transition is a visible diff.
+        """
+        data = _load_golden_raw()
+        saw_items = False
+        for i, v in enumerate(data["violations"]):
+            for j, item in enumerate(v.get("items", [])):
+                saw_items = True
+                assert "description" in item, (
+                    f"violations[{i}].items[{j}] missing `description`: {item!r}"
+                )
+                assert "pos" in item, f"violations[{i}].items[{j}] missing `pos`: {item!r}"
+                pos = item["pos"]
+                assert "x" in pos and "y" in pos, (
+                    f"violations[{i}].items[{j}].pos not {{x, y}}: {pos!r}"
+                )
+        assert saw_items, "Golden fixture has no violation items to check shape"
+
+    def test_golden_has_clearance_violation(self):
+        """The captured payload exercises a clearance violation with items.
+
+        Clearance is the workhorse of the geometric cross-gate; pinning it
+        ensures the golden covers the shape that matters most for the
+        manufacturing-readiness verdict.
+        """
+        data = _load_golden_raw()
+        clearance = [v for v in data["violations"] if v.get("type") == "clearance"]
+        assert clearance, "Golden fixture should contain a clearance violation"
+        assert any(v.get("items") for v in clearance), (
+            "Clearance violation should carry dict-style items"
+        )
+
+    def test_golden_round_trips_through_parser(self):
+        """The consumed fields survive `parse_json_report` into `DRCReport`.
+
+        Pins the end-to-end mapping the gate relies on: source -> pcb_name,
+        date -> created_at, and per-violation type_str/severity/locations.
+        """
+        raw = _load_golden_raw()
+        report = parse_json_report(_GOLDEN_FIXTURE.read_text())
+
+        # source -> pcb_name
+        assert report.pcb_name == raw["source"]
+        # date -> created_at (ISO-8601 parsed)
+        assert report.created_at is not None
+        assert report.created_at.isoformat().startswith(raw["date"][:10])
+        # Every violation round-tripped.
+        assert report.violation_count == len(raw["violations"])
+        # type_str / severity map through for each violation.
+        for parsed, rawv in zip(report.violations, raw["violations"], strict=True):
+            assert parsed.type_str == rawv["type"]
+            assert parsed.severity in {
+                Severity.ERROR,
+                Severity.WARNING,
+                Severity.INFO,
+            }
+            assert parsed.severity == Severity.from_string(rawv["severity"])
+            # Item descriptions and their positions become items + locations.
+            assert len(parsed.items) == len(rawv.get("items", []))
+
+    def test_drift_simulation_severity_fails_loudly(self):
+        """A renamed severity in the payload trips the enum contract loudly.
+
+        This is the tripwire behavior the issue requires: schema drift must
+        raise, not degrade to a silently-clean report.
+        """
+        data = _load_golden_raw()
+        # Simulate a KiCad that renames `error` -> `critical`.
+        for v in data["violations"]:
+            if v["severity"] == "error":
+                v["severity"] = "critical"
+
+        # The enum contract must reject the unknown value.
+        offenders = [
+            v["severity"] for v in data["violations"] if v["severity"] not in _ALLOWED_SEVERITIES
+        ]
+        assert offenders, "Drift simulation should introduce an unpinned severity"
+
+    def test_drift_simulation_dropped_violations_key_is_visible(self):
+        """Dropping `violations` is caught by the top-level contract.
+
+        Without this contract the parser would read a missing `violations`
+        key as an empty (clean) report -- the silent-pass this test guards.
+        """
+        data = _load_golden_raw()
+        del data["violations"]
+        assert "violations" not in data
+        # The parser degrades silently (the risk we are pinning against)...
+        report = parse_json_report(json.dumps(data))
+        assert report.violation_count == 0  # <- false "clean" if unguarded
+        # ...but the shape contract would have caught it first.
+        missing = [k for k in _REQUIRED_KICAD_CLI_DRC_KEYS if k not in data]
+        assert "violations" in missing
+
+
+class TestKicadCliDrcLiveSmoke:
+    """Optional live smoke test -- skips cleanly when kicad-cli is absent.
+
+    Catches schema drift the moment the environment's KiCad is bumped by
+    diffing live output against the pinned key set. KiCad-less CI stays green.
+    """
+
+    def _kicad_cli(self):
+        from kicad_tools.cli.runner import find_kicad_cli
+
+        return find_kicad_cli()
+
+    def test_live_output_matches_pinned_schema(self, tmp_path):
+        """Live `kicad-cli pcb drc --format json` still emits the pinned keys."""
+        import subprocess
+
+        kicad_cli = self._kicad_cli()
+        if kicad_cli is None:
+            pytest.skip("kicad-cli not available -- live DRC smoke test skipped")
+        if not _GOLDEN_SOURCE_BOARD.exists():
+            pytest.skip(f"source board missing: {_GOLDEN_SOURCE_BOARD}")
+
+        out = tmp_path / "live_drc.json"
+        subprocess.run(
+            [
+                str(kicad_cli),
+                "pcb",
+                "drc",
+                "--format",
+                "json",
+                "--units",
+                "mm",
+                "--output",
+                str(out),
+                str(_GOLDEN_SOURCE_BOARD),
+            ],
+            capture_output=True,
+            timeout=120,
+            check=False,
+        )
+        if not out.exists():
+            pytest.skip("kicad-cli produced no DRC report")
+
+        data = json.loads(out.read_text())
+        for key in _REQUIRED_KICAD_CLI_DRC_KEYS:
+            assert key in data, (
+                f"LIVE kicad-cli output missing {key!r} -- schema drift! "
+                "Re-capture the golden fixture and reconcile the parser."
+            )
+        for i, v in enumerate(data["violations"]):
+            for key in _REQUIRED_VIOLATION_KEYS:
+                assert key in v, f"LIVE violations[{i}] missing {key!r}: {v!r}"
+            assert v["severity"] in _ALLOWED_SEVERITIES, (
+                f"LIVE violations[{i}] has unpinned severity {v['severity']!r}"
+            )


### PR DESCRIPTION
## Summary

Adds a golden smoke-test that pins the JSON schema shape of real
`kicad-cli pcb drc --format json` output, guarding the silent-pass risk in
`_parse_kicad_cli_json` (`src/kicad_tools/drc/report.py:367-447`). That parser
reads every field via `dict.get(...)`, so a future KiCad that renames/drops
`violations` (or changes the severity enum) would degrade to an empty report —
read downstream as "0 errors = clean", a false pass on the manufacturing-readiness
gate. The new tests fail **loudly** on schema drift instead.

## Changes

- **`tests/fixtures/drc/kicad_cli_drc_golden.json` (new)** — byte-faithful capture
  of real `kicad-cli pcb drc --format json --units mm` output (KiCad **10.0.4**,
  from `tests/fixtures/stale_nets.kicad_pcb`): 10 violations across 6 types
  (clearance, hole_clearance, shorting_items, solder_mask_bridge, via_dangling,
  lib_footprint_mismatch), both `error` and `warning` severities, clearance
  violation with dict-style `items`.
- **`TestKicadCliDrcGoldenSchema`** — shape/enum contract: top-level
  `source`/`date`/`violations`; per-violation `type`/`description`/`severity`;
  severity enum pinned to `{error, warning, info}`; item `description` + `pos.{x,y}`;
  a clearance-with-items check; and a parser round-trip
  (`source`->`pcb_name`, `date`->`created_at`, `type_str`/`severity`/locations).
  Two drift-simulation tripwires confirm a renamed severity and a dropped
  `violations` key are caught rather than silently read as clean.
- **`TestKicadCliDrcLiveSmoke`** — `find_kicad_cli()`-gated live smoke test that
  runs kicad-cli against the fixture board and re-checks the pinned key set;
  skips cleanly when KiCad is absent so KiCad-less CI stays green.
- Documents the re-capture procedure + `GOLDEN_KICAD_VERSION` constant so a
  kicad-cli bump is a deliberate, one-line reconcile.

### Real-capture finding (documented in the test)

KiCad 10.0.4 does **not** emit a per-item `net` key nor a violation-level `pos`
— the net is embedded in the item `description` as `[NetName]`. So the parser's
`net` extraction is currently a no-op for real 10.0.4 output. Rather than
fabricate a `net` key KiCad doesn't emit (which would defeat "captured from real
output"), the golden pins the true shape and documents this, making any future
schema change a visible diff. Fixing the parser's net extraction is out of scope.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Golden fixture from real kicad-cli output, records KiCad version | ✅ | Captured via `kicad-cli` 10.0.4; `GOLDEN_KICAD_VERSION` + `kicad_version` in payload |
| Shape-contract test asserts top-level + per-violation fields | ✅ | `test_golden_has_required_top_level_keys`, `test_golden_violation_records_have_required_fields`, `test_golden_items_shape` |
| Severity enum pinned to {error, warning, info} | ✅ | `test_golden_severity_enum_is_pinned` |
| Parser round-trip maps consumed fields into DRCReport | ✅ | `test_golden_round_trips_through_parser` |
| Tests fail loudly on drift, not silently clean | ✅ | `test_drift_simulation_severity_fails_loudly`, `test_drift_simulation_dropped_violations_key_is_visible` |
| Doc note for kicad-cli bump | ✅ | Module comment with re-capture command + version bump instructions |
| Live KiCad-gated smoke test skips when absent | ✅ | `TestKicadCliDrcLiveSmoke` gated on `find_kicad_cli()` |

## Test Plan

- `uv run pytest tests/test_drc_report_formats.py -v` → **21 passed** (live smoke ran, KiCad present).
- Drift simulation verified in-band and out-of-band: dropping `violations` and renaming `severity` both trip the contract.
- `uv run ruff check` / `ruff format --check` clean; `mypy` clean on the test file.

Closes #4379