### PR TITLE
feat(analyze): electrical-rating lint -- LED overcurrent + capacitor voltage derating (#4381)

### DIFF
--- a/src/kicad_tools/analysis/__init__.py
+++ b/src/kicad_tools/analysis/__init__.py
@@ -27,6 +27,11 @@ from .current_sense import (
     CurrentSenseAnalyzer,
     CurrentSenseResult,
 )
+from .electrical_rating import (
+    ElectricalRatingAnalyzer,
+    ElectricalRatingResult,
+    infer_rail_voltage,
+)
 from .net_status import (
     NetStatus,
     NetStatusAnalyzer,
@@ -66,6 +71,8 @@ __all__ = [
     "CurrentSenseAnalyzer",
     "CurrentSenseResult",
     "DifferentialPairReport",
+    "ElectricalRatingAnalyzer",
+    "ElectricalRatingResult",
     "ImpedanceDiscontinuity",
     "LayerPrediction",
     "NetStatus",
@@ -87,4 +94,5 @@ __all__ = [
     "TraceLengthReport",
     "build_zone_net_map",
     "detect_analog_components",
+    "infer_rail_voltage",
 ]

--- a/src/kicad_tools/analysis/electrical_rating.py
+++ b/src/kicad_tools/analysis/electrical_rating.py
@@ -1,0 +1,493 @@
+"""Electrical-rating lint: LED overcurrent + capacitor voltage derating.
+
+Advisory-only analyzer (issue #4381) that reads per-part electrical ratings
+from **schematic symbol fields** and checks two deterministic, textbook
+conditions:
+
+* **LED overcurrent** -- for a single-LED / single-series-resistor branch the
+  forward current is ``I = (V_rail - Vf) / R_series``. The branch ``FAIL``s
+  when ``I > If_max``.
+* **Capacitor voltage derating** -- a cap sitting across a power rail must be
+  rated for the rail voltage plus a headroom margin. It ``FAIL``s when
+  ``rated_V < V_rail * (1 + margin)``.
+
+Spec source (v1, issue #4381): the ratings come from KiCad symbol fields read
+via :meth:`SymbolInstance.get_property` -- ``Vf`` / ``If_max`` for LEDs and
+``Voltage_Rating`` for capacitors (case-insensitive). A part that is missing
+its rating field, or whose rail voltage cannot be inferred from the net name,
+is **SKIPPED and census-counted -- never failed**. This keeps the analyzer at
+zero false positives: silence on a part means "not enough data", surfaced in
+the ``skipped`` count, not a clean bill of health.
+
+Topology is extracted with
+:func:`kicad_tools.operations.netlist.build_netlist_from_schematic`; field and
+resistor values are parsed with
+:func:`kicad_tools.spec.units.parse_unit_value`; the rail voltage is inferred
+from the power-net *name* by :func:`infer_rail_voltage`, whose conventions are
+informed by the rail-name regex prior art in
+:mod:`kicad_tools.analysis.analog_detect`.
+
+This module is advisory only: it **never raises** on malformed geometry, bad
+field values, or un-inspectable data -- every failure path degrades to a SKIP
+row with a human-readable reason (mirroring the advisory contract of
+:mod:`kicad_tools.analysis.current_sense`).
+
+Clean-room provenance (LICENSE-CRITICAL): the idea for these two checks was
+surfaced by the open-sourced Pinscope project (github.com/Faradworks/Pinscope),
+which is **AGPL-3.0**. kicad-tools is MIT. Only the *physics/algorithm*
+(Ohm's-law LED current, a voltage-derating ratio -- both textbook and
+unencumbered) is referenced here. **No Pinscope source, structure, identifiers,
+or test data were read, ported, copied, or paraphrased.** This implementation
+was written clean-room from the equations above.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from kicad_tools.operations.netlist import build_netlist_from_schematic
+from kicad_tools.spec.units import parse_unit_value
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from kicad_tools.operations.netlist import Netlist
+    from kicad_tools.schema.symbol import SymbolInstance
+
+__all__ = [
+    "DEFAULT_DERATE_MARGIN",
+    "ElectricalRatingAnalyzer",
+    "ElectricalRatingResult",
+    "infer_rail_voltage",
+]
+
+# Default capacitor voltage-derating headroom. margin=0.2 means a cap on a 12V
+# rail must be rated >= 12 * 1.2 = 14.4V. Documented, overridable parameter.
+DEFAULT_DERATE_MARGIN = 0.2
+
+# Status / check-kind string constants (kept as plain strings, mirroring the
+# PASS/FAIL vocabulary of the sibling current-sense analyzer).
+STATUS_PASS = "PASS"
+STATUS_FAIL = "FAIL"
+STATUS_SKIP = "SKIP"
+
+CHECK_LED = "led_overcurrent"
+CHECK_CAP = "cap_derating"
+
+# European rail notation (3V3 -> 3.3, 1V8 -> 1.8, 12V0 -> 12.0): digits, a 'V'
+# separator, then fractional digits. Checked before the decimal form so the
+# 'V' is read as the decimal point rather than a unit marker.
+_RAIL_EURO_RE = re.compile(r"(\d+)V(\d+)", re.IGNORECASE)
+
+# Decimal / integer volts with a trailing 'V' unit (+3.3V -> 3.3, +5V -> 5,
+# +12V -> 12, +5VA analog -> 5). The optional analog/marker suffix after 'V'
+# is ignored.
+_RAIL_DECIMAL_RE = re.compile(r"(\d+(?:\.\d+)?)V", re.IGNORECASE)
+
+# Named rails carrying an implied voltage by widely-used convention.
+_NAMED_RAIL_VOLTAGES: dict[str, float] = {
+    "VBUS": 5.0,  # USB bus voltage
+}
+
+# Resistor / LED / capacitor library-part recognition. We look at the part
+# portion of the lib_id (after the last ':') plus the reference prefix so the
+# checks fire on the dominant Device:* conventions without a hard dependency on
+# a specific symbol library.
+_LED_PART_HINTS = ("LED",)
+_CAP_PARTS = frozenset({"C", "CP", "C_SMALL", "CP_SMALL", "C_POLARIZED", "C_POLARISED"})
+_RES_PARTS = frozenset({"R", "R_SMALL", "R_US"})
+
+
+def infer_rail_voltage(net_name: str | None) -> float | None:
+    """Infer a rail's working voltage (V) from its net *name*.
+
+    Deterministic name-based inference for conventional power-rail names:
+    ``+3.3V`` / ``3V3`` -> 3.3, ``+5V`` -> 5.0, ``+12V`` -> 12.0,
+    ``1V8`` -> 1.8, ``+5VA`` (analog) -> 5.0, ``VBUS`` -> 5.0. Names that
+    carry no parseable voltage (``VCC``, ``VBAT``, ``+VIN``, ``GND``, and
+    auto-generated ``Net-(...)`` names) return ``None`` -- the rail voltage is
+    unknown, so the caller SKIPs rather than guesses.
+
+    The magnitude is returned for negative rails (``-12V`` -> 12.0) since it is
+    the stress the cap/LED sees. Never raises.
+    """
+    if not net_name:
+        return None
+    name = net_name.strip().lstrip("/")
+    if not name:
+        return None
+
+    upper = name.upper()
+    if upper in _NAMED_RAIL_VOLTAGES:
+        return _NAMED_RAIL_VOLTAGES[upper]
+
+    try:
+        m = _RAIL_EURO_RE.search(name)
+        if m:
+            return float(f"{m.group(1)}.{m.group(2)}")
+        m = _RAIL_DECIMAL_RE.search(name)
+        if m:
+            return float(m.group(1))
+    except (ValueError, TypeError):
+        return None
+    return None
+
+
+@dataclass
+class ElectricalRatingResult:
+    """One census row for a checked (or skipped) electrical-rating part.
+
+    Attributes:
+        reference: Component reference designator (e.g. ``D1``, ``C3``).
+        check: Which check produced this row -- ``"led_overcurrent"`` or
+            ``"cap_derating"``.
+        status: ``"PASS"``, ``"FAIL"``, or ``"SKIP"``. A SKIP means the part
+            carried the intent (an LED / a capacitor) but lacked the data to
+            judge it -- it is *never* a FAIL.
+        rail_net: The power net whose voltage was used, or ``None``.
+        rail_voltage_v: Inferred rail voltage (V), or ``None``.
+        reason: Human-readable explanation for a SKIP (or an assumption note),
+            or ``None`` for a plain PASS/FAIL.
+        vf_v: LED forward voltage (V) used, or ``None``.
+        if_max_a: LED rated forward current (A), or ``None``.
+        r_series_ohms: Series resistance (ohms) used for the LED, or ``None``.
+        series_ref: Reference of the series resistor, or ``None``.
+        current_a: Computed LED forward current (A), or ``None``.
+        rated_voltage_v: Capacitor rated working voltage (V), or ``None``.
+        required_voltage_v: Minimum acceptable cap rating ``V_rail*(1+margin)``
+            (V), or ``None``.
+    """
+
+    reference: str
+    check: str
+    status: str
+    rail_net: str | None = None
+    rail_voltage_v: float | None = None
+    reason: str | None = None
+    # LED-specific
+    vf_v: float | None = None
+    if_max_a: float | None = None
+    r_series_ohms: float | None = None
+    series_ref: str | None = None
+    current_a: float | None = None
+    # Cap-specific
+    rated_voltage_v: float | None = None
+    required_voltage_v: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to a JSON-serializable dict (mirrors sibling analyzers)."""
+
+        def _r(v: float | None, ndigits: int = 4) -> float | None:
+            return None if v is None else round(v, ndigits)
+
+        out: dict[str, Any] = {
+            "reference": self.reference,
+            "check": self.check,
+            "status": self.status,
+            "rail_net": self.rail_net,
+            "rail_voltage_v": _r(self.rail_voltage_v, 3),
+        }
+        if self.check == CHECK_LED:
+            out["vf_v"] = _r(self.vf_v, 3)
+            out["if_max_a"] = _r(self.if_max_a, 6)
+            out["r_series_ohms"] = _r(self.r_series_ohms, 3)
+            out["series_ref"] = self.series_ref
+            out["current_a"] = _r(self.current_a, 6)
+        else:
+            out["rated_voltage_v"] = _r(self.rated_voltage_v, 3)
+            out["required_voltage_v"] = _r(self.required_voltage_v, 3)
+        if self.reason is not None:
+            out["reason"] = self.reason
+        return out
+
+
+def _lib_part(lib_id: str) -> str:
+    """Return the upper-cased part portion of a lib_id (after the last ':')."""
+    return lib_id.split(":")[-1].upper() if lib_id else ""
+
+
+def _is_led(sym: SymbolInstance) -> bool:
+    part = _lib_part(sym.lib_id)
+    if any(h in part for h in _LED_PART_HINTS):
+        return True
+    return sym.reference.upper().startswith("LED")
+
+
+def _is_cap(sym: SymbolInstance) -> bool:
+    part = _lib_part(sym.lib_id)
+    return part in _CAP_PARTS or part.startswith("C_")
+
+
+def _is_resistor(sym: SymbolInstance) -> bool:
+    part = _lib_part(sym.lib_id)
+    if part in _RES_PARTS or part.startswith("R_"):
+        return True
+    ref = sym.reference.upper()
+    return bool(re.match(r"^R\d", ref))
+
+
+def _get_field(sym: SymbolInstance, *names: str) -> str | None:
+    """Case-insensitively fetch the first present symbol field value.
+
+    ``SymbolInstance.get_property`` is exact-match; designers may write
+    ``If_max`` / ``IF_MAX`` / ``if_max``, so we fall back to a case-insensitive
+    scan of the symbol's properties.
+    """
+    for name in names:
+        val = sym.get_property(name)
+        if val is not None:
+            return val
+    wanted = {n.lower() for n in names}
+    for prop_name, prop in sym.properties.items():
+        if prop_name.lower() in wanted:
+            return prop.value
+    return None
+
+
+def _parse_value(raw: str | None) -> float | None:
+    """Parse a unit string to its base-unit float, or ``None`` on failure."""
+    if raw is None:
+        return None
+    text = raw.strip()
+    if not text:
+        return None
+    try:
+        return float(parse_unit_value(text).value)
+    except (ValueError, TypeError):
+        return None
+
+
+class ElectricalRatingAnalyzer:
+    """LED-overcurrent + capacitor-derating lint over a schematic.
+
+    Advisory only; never raises. Construct with an optional derating margin and
+    a documented ``led_default_vf`` fallback (``None`` -> skip LEDs missing a
+    ``Vf`` field, preserving zero false positives), then call :meth:`analyze`
+    with a ``.kicad_sch`` path.
+    """
+
+    def __init__(
+        self,
+        derate_margin: float = DEFAULT_DERATE_MARGIN,
+        led_default_vf: float | None = None,
+    ) -> None:
+        """Initialize the analyzer.
+
+        Args:
+            derate_margin: Capacitor headroom fraction. ``0.2`` requires a cap
+                on a ``V`` rail to be rated ``>= V * 1.2``.
+            led_default_vf: Fallback LED forward voltage (V) used only when a
+                part has ``If_max`` but no ``Vf`` field. ``None`` (default)
+                skips such parts instead, keeping zero false positives. When a
+                default is supplied it is surfaced as an assumption in the row's
+                ``reason``.
+        """
+        self.derate_margin = derate_margin
+        self.led_default_vf = led_default_vf
+
+    def analyze(self, sch_path: str | Path) -> list[ElectricalRatingResult]:
+        """Return one census row per LED / capacitor candidate. Never raises."""
+        try:
+            netlist = build_netlist_from_schematic(sch_path)
+        except Exception:
+            return []
+
+        try:
+            from kicad_tools.schema.schematic import Schematic
+
+            sch = Schematic.load(sch_path)
+            symbols = [s for s in sch.symbols if s.reference and not s.reference.startswith("#")]
+        except Exception:
+            return []
+
+        # Pre-index resistors for series-resistor lookup.
+        resistors = {s.reference: s for s in symbols if _is_resistor(s)}
+
+        results: list[ElectricalRatingResult] = []
+        for sym in symbols:
+            try:
+                if _is_led(sym):
+                    results.append(self._check_led(sym, netlist, resistors))
+                elif _is_cap(sym):
+                    results.append(self._check_cap(sym, netlist))
+            except Exception:
+                # Advisory contract: never let one part abort the census.
+                results.append(
+                    ElectricalRatingResult(
+                        reference=sym.reference,
+                        check=CHECK_LED if _is_led(sym) else CHECK_CAP,
+                        status=STATUS_SKIP,
+                        reason="analysis error",
+                    )
+                )
+        results.sort(key=lambda r: (r.check, r.reference))
+        return results
+
+    # ------------------------------------------------------------------
+    # Topology helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _pin_nets(netlist: Netlist, ref: str) -> list[str]:
+        """Return the distinct net names touching a component, in pin order."""
+        names: list[str] = []
+        seen: set[str] = set()
+        for net in netlist.nets:
+            for node in net.nodes:
+                if node.reference == ref and net.name not in seen:
+                    seen.add(net.name)
+                    names.append(net.name)
+        return names
+
+    # ------------------------------------------------------------------
+    # Check 1: LED overcurrent
+    # ------------------------------------------------------------------
+    def _check_led(
+        self,
+        sym: SymbolInstance,
+        netlist: Netlist,
+        resistors: dict[str, SymbolInstance],
+    ) -> ElectricalRatingResult:
+        ref = sym.reference
+
+        def skip(reason: str) -> ElectricalRatingResult:
+            return ElectricalRatingResult(
+                reference=ref, check=CHECK_LED, status=STATUS_SKIP, reason=reason
+            )
+
+        if_max = _parse_value(_get_field(sym, "If_max"))
+        if _get_field(sym, "If_max") is None:
+            return skip("no If_max field")
+        if if_max is None or if_max <= 0:
+            return skip("unparseable If_max field")
+
+        # Resolve Vf: field value, else documented default, else skip.
+        vf_raw = _get_field(sym, "Vf")
+        assumption: str | None = None
+        vf: float
+        if vf_raw is None:
+            if self.led_default_vf is None:
+                return skip("no Vf field")
+            vf = self.led_default_vf
+            assumption = f"assumed Vf={vf:g}V (no Vf field)"
+        else:
+            parsed_vf = _parse_value(vf_raw)
+            if parsed_vf is None:
+                return skip("unparseable Vf field")
+            vf = parsed_vf
+
+        led_nets = self._pin_nets(netlist, ref)
+        if len(led_nets) < 2:
+            return skip("LED not connected on two nets")
+
+        # Find the unique series resistor sharing a net with the LED.
+        led_net_set = set(led_nets)
+        candidates: list[tuple[str, SymbolInstance, list[str], str]] = []
+        for r_ref, r_sym in resistors.items():
+            r_nets = self._pin_nets(netlist, r_ref)
+            shared = [n for n in r_nets if n in led_net_set]
+            if shared:
+                candidates.append((r_ref, r_sym, r_nets, shared[0]))
+        if not candidates:
+            return skip("no series resistor")
+        if len(candidates) > 1:
+            return skip("ambiguous topology (multiple series resistors)")
+
+        r_ref, r_sym, r_nets, mid_net = candidates[0]
+        r_series = _parse_value(r_sym.value)
+        if r_series is None or r_series <= 0:
+            return skip(f"unparseable series-resistor value ({r_ref}={r_sym.value!r})")
+
+        # Rail is on the resistor's far pin (high-side R) or the LED's other
+        # pin (low-side R). Prefer the resistor's far net.
+        rail_net: str | None = None
+        rail_v: float | None = None
+        for name in [n for n in r_nets if n != mid_net]:
+            v = infer_rail_voltage(name)
+            if v is not None:
+                rail_net, rail_v = name, v
+                break
+        if rail_v is None:
+            for name in [n for n in led_nets if n != mid_net]:
+                v = infer_rail_voltage(name)
+                if v is not None:
+                    rail_net, rail_v = name, v
+                    break
+        if rail_v is None:
+            return skip("unknown rail voltage")
+
+        current = (rail_v - vf) / r_series
+        if current <= 0:
+            # LED cannot conduct (Vf >= V_rail): not an overcurrent condition.
+            note = "Vf >= V_rail (no forward conduction)"
+            reason = f"{assumption}; {note}" if assumption else note
+            return ElectricalRatingResult(
+                reference=ref,
+                check=CHECK_LED,
+                status=STATUS_PASS,
+                rail_net=rail_net,
+                rail_voltage_v=rail_v,
+                reason=reason,
+                vf_v=vf,
+                if_max_a=if_max,
+                r_series_ohms=r_series,
+                series_ref=r_ref,
+                current_a=current,
+            )
+
+        status = STATUS_FAIL if current > if_max else STATUS_PASS
+        return ElectricalRatingResult(
+            reference=ref,
+            check=CHECK_LED,
+            status=status,
+            rail_net=rail_net,
+            rail_voltage_v=rail_v,
+            reason=assumption,
+            vf_v=vf,
+            if_max_a=if_max,
+            r_series_ohms=r_series,
+            series_ref=r_ref,
+            current_a=current,
+        )
+
+    # ------------------------------------------------------------------
+    # Check 2: capacitor voltage derating
+    # ------------------------------------------------------------------
+    def _check_cap(self, sym: SymbolInstance, netlist: Netlist) -> ElectricalRatingResult:
+        ref = sym.reference
+
+        def skip(reason: str) -> ElectricalRatingResult:
+            return ElectricalRatingResult(
+                reference=ref, check=CHECK_CAP, status=STATUS_SKIP, reason=reason
+            )
+
+        rating_raw = _get_field(sym, "Voltage_Rating")
+        if rating_raw is None:
+            return skip("no Voltage_Rating field")
+        rated_v = _parse_value(rating_raw)
+        if rated_v is None or rated_v <= 0:
+            return skip("unparseable Voltage_Rating field")
+
+        # Infer the rail voltage from the cap's nets; pick the highest-stress
+        # (max) parseable rail. Ground / unknown nets infer to None.
+        rail_net: str | None = None
+        rail_v: float | None = None
+        for name in self._pin_nets(netlist, ref):
+            v = infer_rail_voltage(name)
+            if v is not None and (rail_v is None or v > rail_v):
+                rail_net, rail_v = name, v
+        if rail_v is None:
+            return skip("unknown rail voltage")
+
+        required = rail_v * (1.0 + self.derate_margin)
+        status = STATUS_FAIL if rated_v < required else STATUS_PASS
+        return ElectricalRatingResult(
+            reference=ref,
+            check=CHECK_CAP,
+            status=status,
+            rail_net=rail_net,
+            rail_voltage_v=rail_v,
+            rated_voltage_v=rated_v,
+            required_voltage_v=required,
+        )

--- a/src/kicad_tools/cli/analyze_cmd.py
+++ b/src/kicad_tools/cli/analyze_cmd.py
@@ -345,6 +345,56 @@ def main(argv: list[str] | None = None) -> int:
         help="Suppress informational output",
     )
 
+    # Electrical-rating subcommand (operates on a schematic, not a PCB)
+    elec_parser = subparsers.add_parser(
+        "electrical-rating",
+        help="Check LED overcurrent and capacitor voltage derating (advisory)",
+        description=(
+            "Read Vf/If_max/Voltage_Rating symbol fields from a schematic and "
+            "flag over-driven LEDs (I=(V_rail-Vf)/R_series > If_max) and "
+            "under-rated capacitors (rated_V < V_rail*(1+margin)). Parts "
+            "missing a rating field, or on an unknown rail, are skipped "
+            "(census-counted), never failed."
+        ),
+    )
+    elec_parser.add_argument(
+        "schematic",
+        help="Schematic file to analyze (.kicad_sch)",
+    )
+    elec_parser.add_argument(
+        "--format",
+        "-f",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    elec_parser.add_argument(
+        "--derate-margin",
+        type=float,
+        default=0.2,
+        help=(
+            "Capacitor voltage headroom fraction (default: 0.2; a cap on a "
+            "12V rail must be rated >= 14.4V)"
+        ),
+    )
+    elec_parser.add_argument(
+        "--led-default-vf",
+        type=float,
+        default=None,
+        metavar="VOLTS",
+        help=(
+            "Fallback LED forward voltage (V) for parts with If_max but no Vf "
+            "field. Default: skip such parts (zero false positives). When set, "
+            "the assumption is surfaced in the finding."
+        ),
+    )
+    elec_parser.add_argument(
+        "--quiet",
+        "-q",
+        action="store_true",
+        help="Suppress informational output",
+    )
+
     if argv is None:
         argv = sys.argv[1:]
 
@@ -371,6 +421,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.subcommand == "current-sense":
         return _run_current_sense_analysis(args)
+
+    if args.subcommand == "electrical-rating":
+        return _run_electrical_rating_analysis(args)
 
     return 0
 
@@ -1420,6 +1473,138 @@ def _output_current_sense_text(
         f"[{summary_style}]Total: {len(results)} sense nets, "
         f"{fail_count} FAIL, {len(results) - fail_count} PASS "
         f"({loop_fail_count} loop-area FAIL, {kelvin_fail_count} Kelvin FAIL)[/{summary_style}]"
+    )
+
+
+# ============================================================================
+# Electrical-Rating Analysis
+# ============================================================================
+
+
+def _run_electrical_rating_analysis(args: argparse.Namespace) -> int:
+    """Run LED-overcurrent + capacitor-derating lint on a schematic.
+
+    Advisory: returns non-zero only when at least one check is FAIL (so it can
+    gate CI). SKIP rows (missing field / unknown rail) never gate. File-not-
+    found / bad-suffix errors return 1.
+    """
+    from kicad_tools.analysis.electrical_rating import ElectricalRatingAnalyzer
+
+    sch_path = Path(args.schematic)
+
+    if not sch_path.exists():
+        print(f"Error: File not found: {sch_path}", file=sys.stderr)
+        return 1
+
+    if sch_path.suffix != ".kicad_sch":
+        print(f"Error: Expected .kicad_sch file, got: {sch_path.suffix}", file=sys.stderr)
+        return 1
+
+    analyzer = ElectricalRatingAnalyzer(
+        derate_margin=args.derate_margin,
+        led_default_vf=args.led_default_vf,
+    )
+    results = analyzer.analyze(sch_path)
+
+    if args.format == "json":
+        _output_electrical_rating_json(results, args.derate_margin)
+    else:
+        _output_electrical_rating_text(results, sch_path.name, args.derate_margin, quiet=args.quiet)
+
+    if any(r.status == "FAIL" for r in results):
+        return 1
+    return 0
+
+
+def _output_electrical_rating_json(results: list, derate_margin: float) -> None:
+    """Output electrical-rating census as JSON (mirrors sibling analyzers)."""
+    fail_count = sum(1 for r in results if r.status == "FAIL")
+    skip_count = sum(1 for r in results if r.status == "SKIP")
+    pass_count = sum(1 for r in results if r.status == "PASS")
+    output = {
+        "census": [r.to_dict() for r in results],
+        "parameters": {"derate_margin": derate_margin},
+        "summary": {
+            "total": len(results),
+            "checked": pass_count + fail_count,
+            "pass": pass_count,
+            "fail": fail_count,
+            "skipped": skip_count,
+        },
+    }
+    print(json.dumps(output, indent=2))
+
+
+def _output_electrical_rating_text(
+    results: list,
+    filename: str,
+    derate_margin: float,
+    quiet: bool = False,
+) -> None:
+    """Output electrical-rating census as a formatted table + summary line."""
+    console = Console()
+
+    if not results:
+        if not quiet:
+            console.print(f"[green]No LEDs or capacitors with ratings found in {filename}[/green]")
+        return
+
+    if not quiet:
+        console.print(f"\n[bold]Electrical-Rating Lint: {filename}[/bold]")
+        console.print(
+            "[dim]LED FAIL when I=(V_rail-Vf)/R_series > If_max; "
+            f"cap FAIL when rated_V < V_rail*(1+{derate_margin:.2f}). "
+            "SKIP = missing rating field or unknown rail (never a FAIL).[/dim]\n"
+        )
+
+    table = Table(show_header=True)
+    table.add_column("ref", style="cyan")
+    table.add_column("check")
+    table.add_column("rail")
+    table.add_column("V_rail", justify="right")
+    table.add_column("detail")
+    table.add_column("status", justify="center")
+
+    for r in results:
+        if r.status == "FAIL":
+            status_style = "red bold"
+        elif r.status == "PASS":
+            status_style = "green"
+        else:
+            status_style = "yellow"
+        rail = r.rail_net if r.rail_net is not None else "-"
+        vrail = "-" if r.rail_voltage_v is None else f"{r.rail_voltage_v:.2f}"
+
+        if r.check == "led_overcurrent":
+            if r.current_a is not None:
+                detail = f"I={r.current_a * 1000:.2f}mA vs If_max={r.if_max_a * 1000:.2f}mA"
+            else:
+                detail = r.reason or "-"
+        else:
+            if r.rated_voltage_v is not None and r.required_voltage_v is not None:
+                detail = f"rated={r.rated_voltage_v:.1f}V vs need>={r.required_voltage_v:.2f}V"
+            else:
+                detail = r.reason or "-"
+
+        table.add_row(
+            r.reference,
+            r.check,
+            rail,
+            vrail,
+            detail,
+            f"[{status_style}]{r.status}[/{status_style}]",
+        )
+
+    console.print(table)
+
+    fail_count = sum(1 for r in results if r.status == "FAIL")
+    skip_count = sum(1 for r in results if r.status == "SKIP")
+    checked = len(results) - skip_count
+    console.print()
+    summary_style = "red bold" if fail_count else "green"
+    console.print(
+        f"[{summary_style}]checked={checked}  fail={fail_count}  "
+        f"skipped={skip_count} (no rating field / unknown rail)[/{summary_style}]"
     )
 
 

--- a/src/kicad_tools/cli/commands/analyze.py
+++ b/src/kicad_tools/cli/commands/analyze.py
@@ -9,7 +9,7 @@ def run_analyze_command(args) -> int:
         print("Usage: kicad-tools analyze <command> [options] <file>")
         print(
             "Commands: complexity, congestion, trace-lengths, signal-integrity, "
-            "thermal, current-sense"
+            "thermal, current-sense, electrical-rating"
         )
         return 1
 
@@ -30,6 +30,9 @@ def run_analyze_command(args) -> int:
 
     if args.analyze_command == "current-sense":
         return _run_current_sense_command(args)
+
+    if args.analyze_command == "electrical-rating":
+        return _run_electrical_rating_command(args)
 
     return 1
 
@@ -137,6 +140,24 @@ def _run_current_sense_command(args) -> int:
         sub_argv.extend(["--kelvin-tol", str(args.analyze_kelvin_tol)])
     for kpair in getattr(args, "analyze_kelvin_pairs", None) or []:
         sub_argv.extend(["--kelvin-pair", kpair])
+    if getattr(args, "global_quiet", False):
+        sub_argv.append("--quiet")
+
+    return analyze_main(sub_argv)
+
+
+def _run_electrical_rating_command(args) -> int:
+    """Handle analyze electrical-rating command (operates on a schematic)."""
+    from ..analyze_cmd import main as analyze_main
+
+    sub_argv = ["electrical-rating", args.schematic]
+
+    if getattr(args, "analyze_format", "text") != "text":
+        sub_argv.extend(["--format", args.analyze_format])
+    if getattr(args, "analyze_derate_margin", 0.2) != 0.2:
+        sub_argv.extend(["--derate-margin", str(args.analyze_derate_margin)])
+    if getattr(args, "analyze_led_default_vf", None) is not None:
+        sub_argv.extend(["--led-default-vf", str(args.analyze_led_default_vf)])
     if getattr(args, "global_quiet", False):
         sub_argv.append("--quiet")
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -5671,6 +5671,49 @@ def _add_analyze_parser(subparsers) -> None:
         ),
     )
 
+    # analyze electrical-rating (operates on a schematic, not a PCB)
+    elec_parser = analyze_subparsers.add_parser(
+        "electrical-rating",
+        help="Check LED overcurrent and capacitor voltage derating (advisory)",
+        description=(
+            "Read Vf/If_max/Voltage_Rating symbol fields from a schematic and "
+            "flag over-driven LEDs (I=(V_rail-Vf)/R_series > If_max) and "
+            "under-rated capacitors (rated_V < V_rail*(1+margin)). Parts "
+            "missing a rating field, or on an unknown rail, are skipped "
+            "(census-counted), never failed."
+        ),
+    )
+    elec_parser.add_argument("schematic", help="Schematic file to analyze (.kicad_sch)")
+    elec_parser.add_argument(
+        "--format",
+        "-f",
+        dest="analyze_format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    elec_parser.add_argument(
+        "--derate-margin",
+        dest="analyze_derate_margin",
+        type=float,
+        default=0.2,
+        help=(
+            "Capacitor voltage headroom fraction (default: 0.2; a cap on a "
+            "12V rail must be rated >= 14.4V)"
+        ),
+    )
+    elec_parser.add_argument(
+        "--led-default-vf",
+        dest="analyze_led_default_vf",
+        type=float,
+        default=None,
+        metavar="VOLTS",
+        help=(
+            "Fallback LED forward voltage (V) for parts with If_max but no Vf "
+            "field. Default: skip such parts (zero false positives)."
+        ),
+    )
+
 
 def _add_constraints_parser(subparsers) -> None:
     """Add constraints subcommand parser with its subcommands."""

--- a/tests/fixtures/electrical_rating/caps.kicad_sch
+++ b/tests/fixtures/electrical_rating/caps.kicad_sch
@@ -1,0 +1,196 @@
+(kicad_sch
+	(version 20231120)
+	(generator "kicadtools_test")
+	(uuid "00000000-0000-0000-0000-000000000051")
+	(paper "A4")
+	(lib_symbols
+		(symbol "Device:R"
+			(pin_numbers hide)
+			(pin_names hide)
+			(symbol "R_1_1"
+				(pin passive line (at 0 3.81 270) (length 1.27) (name "~") (number "1"))
+				(pin passive line (at 0 -3.81 90) (length 1.27) (name "~") (number "2"))
+			)
+		)
+		(symbol "Device:LED"
+			(pin_numbers hide)
+			(pin_names hide)
+			(symbol "LED_1_1"
+				(pin passive line (at 0 3.81 270) (length 1.27) (name "K") (number "1"))
+				(pin passive line (at 0 -3.81 90) (length 1.27) (name "A") (number "2"))
+			)
+		)
+		(symbol "Device:C"
+			(pin_numbers hide)
+			(pin_names hide)
+			(symbol "C_1_1"
+				(pin passive line (at 0 3.81 270) (length 2.794) (name "~") (number "1"))
+				(pin passive line (at 0 -3.81 90) (length 2.794) (name "~") (number "2"))
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 100 50 0)
+		(unit 1)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000000000031")
+		(property "Reference" "C1"
+			(at 102 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Value" "100nF"
+			(at 102 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Footprint" ""
+			(at 102 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Datasheet" "~"
+			(at 102 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Voltage_Rating" "16V"
+			(at 102 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(pin "1" (uuid "00000000-0000-0000-0000-000000000032"))
+		(pin "2" (uuid "00000000-0000-0000-0000-000000000033"))
+	)
+	(label "+12V"
+		(at 100 46.19 0)
+		(effects (font (size 1.27 1.27)) (justify left bottom))
+		(uuid "00000000-0000-0000-0000-000000000034")
+	)
+	(label "GND"
+		(at 100 53.81 0)
+		(effects (font (size 1.27 1.27)) (justify left bottom))
+		(uuid "00000000-0000-0000-0000-000000000035")
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 120 50 0)
+		(unit 1)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000000000036")
+		(property "Reference" "C2"
+			(at 122 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Value" "100nF"
+			(at 122 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Footprint" ""
+			(at 122 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Datasheet" "~"
+			(at 122 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Voltage_Rating" "10V"
+			(at 122 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(pin "1" (uuid "00000000-0000-0000-0000-000000000037"))
+		(pin "2" (uuid "00000000-0000-0000-0000-000000000038"))
+	)
+	(label "+12V"
+		(at 120 46.19 0)
+		(effects (font (size 1.27 1.27)) (justify left bottom))
+		(uuid "00000000-0000-0000-0000-000000000039")
+	)
+	(label "GND"
+		(at 120 53.81 0)
+		(effects (font (size 1.27 1.27)) (justify left bottom))
+		(uuid "00000000-0000-0000-0000-000000000040")
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 140 50 0)
+		(unit 1)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000000000041")
+		(property "Reference" "C3"
+			(at 142 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Value" "100nF"
+			(at 142 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Footprint" ""
+			(at 142 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Datasheet" "~"
+			(at 142 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Voltage_Rating" "25V"
+			(at 142 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(pin "1" (uuid "00000000-0000-0000-0000-000000000042"))
+		(pin "2" (uuid "00000000-0000-0000-0000-000000000043"))
+	)
+	(label "VCC"
+		(at 140 46.19 0)
+		(effects (font (size 1.27 1.27)) (justify left bottom))
+		(uuid "00000000-0000-0000-0000-000000000044")
+	)
+	(label "GND"
+		(at 140 53.81 0)
+		(effects (font (size 1.27 1.27)) (justify left bottom))
+		(uuid "00000000-0000-0000-0000-000000000045")
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 160 50 0)
+		(unit 1)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000000000046")
+		(property "Reference" "C4"
+			(at 162 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Value" "100nF"
+			(at 162 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Footprint" ""
+			(at 162 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Datasheet" "~"
+			(at 162 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Voltage_Rating" "junk"
+			(at 162 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(pin "1" (uuid "00000000-0000-0000-0000-000000000047"))
+		(pin "2" (uuid "00000000-0000-0000-0000-000000000048"))
+	)
+	(label "+12V"
+		(at 160 46.19 0)
+		(effects (font (size 1.27 1.27)) (justify left bottom))
+		(uuid "00000000-0000-0000-0000-000000000049")
+	)
+	(label "GND"
+		(at 160 53.81 0)
+		(effects (font (size 1.27 1.27)) (justify left bottom))
+		(uuid "00000000-0000-0000-0000-000000000050")
+	)
+)

--- a/tests/fixtures/electrical_rating/leds.kicad_sch
+++ b/tests/fixtures/electrical_rating/leds.kicad_sch
@@ -1,0 +1,289 @@
+(kicad_sch
+	(version 20231120)
+	(generator "kicadtools_test")
+	(uuid "00000000-0000-0000-0000-000000000030")
+	(paper "A4")
+	(lib_symbols
+		(symbol "Device:R"
+			(pin_numbers hide)
+			(pin_names hide)
+			(symbol "R_1_1"
+				(pin passive line (at 0 3.81 270) (length 1.27) (name "~") (number "1"))
+				(pin passive line (at 0 -3.81 90) (length 1.27) (name "~") (number "2"))
+			)
+		)
+		(symbol "Device:LED"
+			(pin_numbers hide)
+			(pin_names hide)
+			(symbol "LED_1_1"
+				(pin passive line (at 0 3.81 270) (length 1.27) (name "K") (number "1"))
+				(pin passive line (at 0 -3.81 90) (length 1.27) (name "A") (number "2"))
+			)
+		)
+		(symbol "Device:C"
+			(pin_numbers hide)
+			(pin_names hide)
+			(symbol "C_1_1"
+				(pin passive line (at 0 3.81 270) (length 2.794) (name "~") (number "1"))
+				(pin passive line (at 0 -3.81 90) (length 2.794) (name "~") (number "2"))
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 100 50 0)
+		(unit 1)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000000000001")
+		(property "Reference" "R1"
+			(at 102 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Value" "100"
+			(at 102 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Footprint" ""
+			(at 102 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Datasheet" "~"
+			(at 102 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(pin "1" (uuid "00000000-0000-0000-0000-000000000002"))
+		(pin "2" (uuid "00000000-0000-0000-0000-000000000003"))
+	)
+	(symbol
+		(lib_id "Device:LED")
+		(at 100 57.62 0)
+		(unit 1)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000000000004")
+		(property "Reference" "D1"
+			(at 102 57.62 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Value" "LED"
+			(at 102 57.62 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Footprint" ""
+			(at 102 57.62 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Datasheet" "~"
+			(at 102 57.62 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Vf" "2.0V"
+			(at 102 57.62 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "If_max" "20mA"
+			(at 102 57.62 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(pin "1" (uuid "00000000-0000-0000-0000-000000000005"))
+		(pin "2" (uuid "00000000-0000-0000-0000-000000000006"))
+	)
+	(label "+5V"
+		(at 100 46.19 0)
+		(effects (font (size 1.27 1.27)) (justify left bottom))
+		(uuid "00000000-0000-0000-0000-000000000007")
+	)
+	(label "GND"
+		(at 100 61.43 0)
+		(effects (font (size 1.27 1.27)) (justify left bottom))
+		(uuid "00000000-0000-0000-0000-000000000008")
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 120 50 0)
+		(unit 1)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000000000009")
+		(property "Reference" "R2"
+			(at 122 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Value" "220"
+			(at 122 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Footprint" ""
+			(at 122 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Datasheet" "~"
+			(at 122 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(pin "1" (uuid "00000000-0000-0000-0000-000000000010"))
+		(pin "2" (uuid "00000000-0000-0000-0000-000000000011"))
+	)
+	(symbol
+		(lib_id "Device:LED")
+		(at 120 57.62 0)
+		(unit 1)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000000000012")
+		(property "Reference" "D2"
+			(at 122 57.62 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Value" "LED"
+			(at 122 57.62 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Footprint" ""
+			(at 122 57.62 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Datasheet" "~"
+			(at 122 57.62 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Vf" "2.0V"
+			(at 122 57.62 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "If_max" "20mA"
+			(at 122 57.62 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(pin "1" (uuid "00000000-0000-0000-0000-000000000013"))
+		(pin "2" (uuid "00000000-0000-0000-0000-000000000014"))
+	)
+	(label "+5V"
+		(at 120 46.19 0)
+		(effects (font (size 1.27 1.27)) (justify left bottom))
+		(uuid "00000000-0000-0000-0000-000000000015")
+	)
+	(label "GND"
+		(at 120 61.43 0)
+		(effects (font (size 1.27 1.27)) (justify left bottom))
+		(uuid "00000000-0000-0000-0000-000000000016")
+	)
+	(symbol
+		(lib_id "Device:LED")
+		(at 140 50 0)
+		(unit 1)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000000000017")
+		(property "Reference" "D3"
+			(at 142 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Value" "LED"
+			(at 142 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Footprint" ""
+			(at 142 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Datasheet" "~"
+			(at 142 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Vf" "2.0V"
+			(at 142 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(pin "1" (uuid "00000000-0000-0000-0000-000000000018"))
+		(pin "2" (uuid "00000000-0000-0000-0000-000000000019"))
+	)
+	(label "+5V"
+		(at 140 46.19 0)
+		(effects (font (size 1.27 1.27)) (justify left bottom))
+		(uuid "00000000-0000-0000-0000-000000000020")
+	)
+	(label "GND"
+		(at 140 53.81 0)
+		(effects (font (size 1.27 1.27)) (justify left bottom))
+		(uuid "00000000-0000-0000-0000-000000000021")
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 160 50 0)
+		(unit 1)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000000000022")
+		(property "Reference" "R4"
+			(at 162 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Value" "100"
+			(at 162 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Footprint" ""
+			(at 162 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Datasheet" "~"
+			(at 162 50 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(pin "1" (uuid "00000000-0000-0000-0000-000000000023"))
+		(pin "2" (uuid "00000000-0000-0000-0000-000000000024"))
+	)
+	(symbol
+		(lib_id "Device:LED")
+		(at 160 57.62 0)
+		(unit 1)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000000000025")
+		(property "Reference" "D4"
+			(at 162 57.62 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Value" "LED"
+			(at 162 57.62 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Footprint" ""
+			(at 162 57.62 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Datasheet" "~"
+			(at 162 57.62 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Vf" "abc"
+			(at 162 57.62 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "If_max" "20mA"
+			(at 162 57.62 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(pin "1" (uuid "00000000-0000-0000-0000-000000000026"))
+		(pin "2" (uuid "00000000-0000-0000-0000-000000000027"))
+	)
+	(label "+5V"
+		(at 160 46.19 0)
+		(effects (font (size 1.27 1.27)) (justify left bottom))
+		(uuid "00000000-0000-0000-0000-000000000028")
+	)
+	(label "GND"
+		(at 160 61.43 0)
+		(effects (font (size 1.27 1.27)) (justify left bottom))
+		(uuid "00000000-0000-0000-0000-000000000029")
+	)
+)

--- a/tests/test_electrical_rating.py
+++ b/tests/test_electrical_rating.py
@@ -1,0 +1,229 @@
+"""Tests for the advisory electrical-rating analyzer (issue #4381).
+
+Covers LED overcurrent, capacitor voltage derating, rail-voltage inference, the
+skip/census contract (missing field, unknown rail, malformed value), and the
+`kct analyze electrical-rating` CLI (text + json, exit codes).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.analysis import (
+    ElectricalRatingAnalyzer,
+    ElectricalRatingResult,
+    infer_rail_voltage,
+)
+from kicad_tools.cli.analyze_cmd import main as analyze_main
+
+FIXTURES = Path(__file__).parent / "fixtures" / "electrical_rating"
+LEDS = FIXTURES / "leds.kicad_sch"
+CAPS = FIXTURES / "caps.kicad_sch"
+
+
+def _by_ref(results: list[ElectricalRatingResult]) -> dict[str, ElectricalRatingResult]:
+    return {r.reference: r for r in results}
+
+
+# ---------------------------------------------------------------------------
+# Rail-voltage inference
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("+3.3V", 3.3),
+        ("3V3", 3.3),
+        ("+3V3", 3.3),
+        ("1V8", 1.8),
+        ("+5V", 5.0),
+        ("+5VA", 5.0),  # analog rail
+        ("+12V", 12.0),
+        ("12V0", 12.0),
+        ("VBUS", 5.0),  # USB convention
+        ("-12V", 12.0),  # magnitude
+        ("/+5V", 5.0),  # leading slash stripped
+        ("VCC", None),
+        ("VBAT", None),
+        ("+VIN", None),
+        ("GND", None),
+        ("GNDA", None),
+        ("Net-(R1-2)", None),  # auto-generated net name
+        ("", None),
+        (None, None),
+    ],
+)
+def test_infer_rail_voltage(name, expected):
+    assert infer_rail_voltage(name) == expected
+
+
+# ---------------------------------------------------------------------------
+# LED overcurrent
+# ---------------------------------------------------------------------------
+def test_led_overcurrent_fail_and_pass():
+    results = _by_ref(ElectricalRatingAnalyzer().analyze(LEDS))
+
+    # D1: +5V, Vf=2.0V, R=100 -> I=(5-2)/100=30mA > 20mA -> FAIL
+    d1 = results["D1"]
+    assert d1.check == "led_overcurrent"
+    assert d1.status == "FAIL"
+    assert d1.rail_net == "+5V"
+    assert d1.rail_voltage_v == 5.0
+    assert d1.r_series_ohms == 100.0
+    assert d1.series_ref == "R1"
+    assert d1.current_a == pytest.approx(0.03)
+    assert d1.if_max_a == pytest.approx(0.02)
+
+    # D2: R=220 -> I=13.6mA < 20mA -> PASS
+    d2 = results["D2"]
+    assert d2.status == "PASS"
+    assert d2.current_a == pytest.approx((5.0 - 2.0) / 220.0)
+
+
+def test_led_skip_missing_if_max():
+    d3 = _by_ref(ElectricalRatingAnalyzer().analyze(LEDS))["D3"]
+    assert d3.status == "SKIP"
+    assert d3.reason == "no If_max field"
+    # A skip is never a fail.
+    assert d3.status != "FAIL"
+
+
+def test_led_skip_unparseable_vf():
+    d4 = _by_ref(ElectricalRatingAnalyzer().analyze(LEDS))["D4"]
+    assert d4.status == "SKIP"
+    assert "Vf" in (d4.reason or "")
+
+
+def test_led_default_vf_flag_surfaces_assumption():
+    # With a default Vf, D3 still skips (it has no If_max), but a part that has
+    # If_max and no Vf would use the default. D4 has an unparseable Vf, so the
+    # default does NOT apply (parse failure is a skip, not a missing field).
+    results = _by_ref(ElectricalRatingAnalyzer(led_default_vf=2.0).analyze(LEDS))
+    assert results["D3"].status == "SKIP"  # no If_max regardless of default
+    assert results["D4"].status == "SKIP"  # unparseable Vf, default not used
+
+
+# ---------------------------------------------------------------------------
+# Capacitor voltage derating
+# ---------------------------------------------------------------------------
+def test_cap_derating_fail_and_pass():
+    results = _by_ref(ElectricalRatingAnalyzer().analyze(CAPS))
+
+    # C1: +12V, rated 16V, margin 0.2 -> need >=14.4V, 16>=14.4 -> PASS
+    c1 = results["C1"]
+    assert c1.check == "cap_derating"
+    assert c1.status == "PASS"
+    assert c1.rail_voltage_v == 12.0
+    assert c1.rated_voltage_v == 16.0
+    assert c1.required_voltage_v == pytest.approx(14.4)
+
+    # C2: rated 10V < 14.4 -> FAIL
+    c2 = results["C2"]
+    assert c2.status == "FAIL"
+    assert c2.rated_voltage_v == 10.0
+
+
+def test_cap_skip_unknown_rail():
+    c3 = _by_ref(ElectricalRatingAnalyzer().analyze(CAPS))["C3"]
+    assert c3.status == "SKIP"
+    assert c3.reason == "unknown rail voltage"
+
+
+def test_cap_skip_unparseable_rating():
+    c4 = _by_ref(ElectricalRatingAnalyzer().analyze(CAPS))["C4"]
+    assert c4.status == "SKIP"
+    assert "Voltage_Rating" in (c4.reason or "")
+
+
+def test_cap_derate_margin_parameter():
+    # A tighter margin makes the 16V cap on the 12V rail insufficient:
+    # need >= 12 * (1 + 0.4) = 16.8 > 16 -> FAIL.
+    results = _by_ref(ElectricalRatingAnalyzer(derate_margin=0.4).analyze(CAPS))
+    assert results["C1"].status == "FAIL"
+    assert results["C1"].required_voltage_v == pytest.approx(16.8)
+
+
+# ---------------------------------------------------------------------------
+# Census / advisory-robustness contract
+# ---------------------------------------------------------------------------
+def test_census_counts_skips_visibly():
+    results = ElectricalRatingAnalyzer().analyze(LEDS)
+    checked = [r for r in results if r.status in ("PASS", "FAIL")]
+    skipped = [r for r in results if r.status == "SKIP"]
+    assert len(checked) == 2  # D1, D2
+    assert len(skipped) == 2  # D3, D4
+    # No candidate is ever silently dropped.
+    assert len(results) == 4
+
+
+def test_analyzer_never_raises_on_missing_file():
+    # Advisory contract: bad input degrades to an empty census, never raises.
+    assert ElectricalRatingAnalyzer().analyze(FIXTURES / "does_not_exist.kicad_sch") == []
+
+
+def test_analyzer_never_raises_on_garbage(tmp_path):
+    junk = tmp_path / "junk.kicad_sch"
+    junk.write_text("this is not a schematic")
+    assert ElectricalRatingAnalyzer().analyze(junk) == []
+
+
+def test_result_to_dict_serializable():
+    import json
+
+    results = ElectricalRatingAnalyzer().analyze(CAPS)
+    for r in results:
+        d = r.to_dict()
+        json.dumps(d)  # must be JSON-serializable
+        assert d["reference"] == r.reference
+        assert d["status"] in ("PASS", "FAIL", "SKIP")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def test_cli_text_fail_exit_code(capsys):
+    rc = analyze_main(["electrical-rating", str(LEDS)])
+    out = capsys.readouterr().out
+    assert rc == 1  # a FAIL gates
+    assert "D1" in out
+    assert "FAIL" in out
+    assert "skipped=2" in out
+
+
+def test_cli_json_summary(capsys):
+    import json
+
+    rc = analyze_main(["electrical-rating", str(CAPS), "--format", "json"])
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["summary"]["fail"] == 1
+    assert payload["summary"]["skipped"] == 2
+    assert payload["summary"]["checked"] == 2
+    assert payload["parameters"]["derate_margin"] == 0.2
+
+
+def test_cli_missing_file(capsys):
+    rc = analyze_main(["electrical-rating", str(FIXTURES / "nope.kicad_sch")])
+    assert rc == 1
+    assert "File not found" in capsys.readouterr().err
+
+
+def test_cli_bad_suffix(capsys, tmp_path):
+    bad = tmp_path / "board.kicad_pcb"
+    bad.write_text("")
+    rc = analyze_main(["electrical-rating", str(bad)])
+    assert rc == 1
+    assert "kicad_sch" in capsys.readouterr().err
+
+
+def test_cli_via_kct_dispatch(capsys):
+    # Exercise the real parser -> commands.analyze dispatch path.
+    from kicad_tools.cli.commands.analyze import run_analyze_command
+    from kicad_tools.cli.parser import create_parser
+
+    parser = create_parser()
+    args = parser.parse_args(["analyze", "electrical-rating", str(CAPS), "--format", "json"])
+    rc = run_analyze_command(args)
+    assert rc == 1
+    assert '"cap_derating"' in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Implements the advisory `kct analyze electrical-rating` analyzer requested in #4381 (spec source resolved to schematic-field conventions per the curator). No LLM; never raises -- it mirrors the advisory-only contract of `src/kicad_tools/analysis/current_sense.py`.

Two deterministic checks:
- **LED overcurrent** -- `I = (V_rail - Vf) / R_series` vs `If_max`. Single-LED / single-series-resistor topology (high- and low-side resistor both handled).
- **Capacitor voltage derating** -- `rated_V` vs `V_rail * (1 + margin)`, `--derate-margin` (default 0.2 -> a cap on a 12V rail must be rated >= 14.4V).

## Spec source (v1)

Ratings are read from KiCad symbol fields via `SymbolInstance.get_property` (case-insensitive): `Vf` / `If_max` for LEDs, `Voltage_Rating` for caps. Values parsed with `parse_unit_value` (`spec/units.py`). Topology from `build_netlist_from_schematic` (`operations/netlist.py`). Rail voltage inferred from the net **name** via a shared `infer_rail_voltage()` helper (informed by the rail-name regex prior art in `analog_detect.py`): `+3.3V`/`3V3`->3.3, `+12V`->12, `VBUS`->5, `VCC`/`VBAT`/`GND`->None.

## Zero false positives

A part missing its rating field, on an unknown rail, or with an unparseable value is **SKIPPED and census-counted, never FAILed**. The text summary prints `checked=N  fail=X  skipped=Y (no rating field / unknown rail)` so an all-skip run never reads as clean. `--format text|json`; non-zero exit only on a real FAIL (CI-gateable).

## Clean-room (LICENSE-CRITICAL)

The idea originated from Pinscope (AGPL-3.0); kicad-tools is MIT. Only the textbook physics/algorithm (Ohm's-law LED current, a voltage-derating ratio) was referenced -- **no Pinscope source, structure, identifiers, or test data were read or ported**. A provenance comment records this in the new module.

## Files

- `src/kicad_tools/analysis/electrical_rating.py` (new) -- analyzer, result dataclass, `infer_rail_voltage`. Advisory-only.
- `src/kicad_tools/analysis/__init__.py` -- exports.
- `src/kicad_tools/cli/parser.py` + `cli/commands/analyze.py` + `cli/analyze_cmd.py` -- new `electrical-rating` subparser, dispatch, and `_run_*`/output handlers (text + json).
- `tests/fixtures/electrical_rating/{leds,caps}.kicad_sch` (new) -- concrete FAIL + PASS + skip fixtures.
- `tests/test_electrical_rating.py` (new) -- 36 tests.

## Validation

- `tests/test_electrical_rating.py`: **36 passed** (+ `test_current_sense.py` green, 92 total).
- `ruff check` + `ruff format --check`: clean on changed files.
- mypy baseline gate (`scripts/ci/check_mypy_baseline.py`): **no new type errors** (exit 0).

Example:
```
$ kct analyze electrical-rating tests/fixtures/electrical_rating/leds.kicad_sch
 D1 led_overcurrent +5V 5.00 I=30.00mA vs If_max=20.00mA FAIL
 D2 led_overcurrent +5V 5.00 I=13.64mA vs If_max=20.00mA PASS
 D3 led_overcurrent  -    -   no If_max field                SKIP
 D4 led_overcurrent  -    -   unparseable Vf field           SKIP
checked=2  fail=1  skipped=2 (no rating field / unknown rail)
```

Closes #4381

🤖 Generated with [Claude Code](https://claude.com/claude-code)