### PR TITLE
fix(drc): populate violation nets from [NetName] token in kicad-cli JSON

### DIFF
--- a/src/kicad_tools/drc/report.py
+++ b/src/kicad_tools/drc/report.py
@@ -412,7 +412,17 @@ def _parse_kicad_cli_json(data: dict, source_file: str = "") -> DRCReport:
                     )
                 )
 
-            # Extract nets
+            # Extract nets from the [NetName] token(s) in the description.
+            # Real KiCad-cli JSON has no per-item "net" key; the net lives
+            # inside the description, e.g. "Track [Net-(C11-2)] on F.Cu".
+            # Mirrors the plain-text parser above (parse_text_report).
+            net_matches = re.findall(r"\[([^\]]+)\]", desc)
+            for net in net_matches:
+                if net != "<no net>" and net not in nets:
+                    nets.append(net)
+
+            # Forward-compat fallback: honor a per-item "net" key if a
+            # future KiCad schema provides one directly.
             if "net" in item_data:
                 net = item_data["net"]
                 if net and net not in nets:

--- a/tests/test_drc_report_formats.py
+++ b/tests/test_drc_report_formats.py
@@ -351,11 +351,10 @@ class TestKicadCliDrcGoldenSchema:
 
         Note: KiCad 10.0.4 does NOT emit a per-item `net` key nor a
         violation-level `pos` -- the net is embedded in the item
-        `description` as ``[NetName]``. The parser reads `net`/`pos`
-        defensively via `dict.get`/`"net" in item`, so their absence is
-        tolerated (nets end up empty). If a future KiCad ADDS `net`, the
-        parser will start populating `DRCViolation.nets`; this test documents
-        the current real shape so that transition is a visible diff.
+        `description` as ``[NetName]``. The parser extracts nets from that
+        ``[NetName]`` token and also honors a per-item `net` key as a
+        forward-compat fallback if a future KiCad ADDS one. This test
+        documents the current real shape (description + pos, no `net` key).
         """
         data = _load_golden_raw()
         saw_items = False
@@ -447,6 +446,107 @@ class TestKicadCliDrcGoldenSchema:
         # ...but the shape contract would have caught it first.
         missing = [k for k in _REQUIRED_KICAD_CLI_DRC_KEYS if k not in data]
         assert "violations" in missing
+
+    def test_golden_nets_extracted_from_item_descriptions(self):
+        """Nets are populated from the ``[NetName]`` token in real output.
+
+        Regression guard for the silent no-op where `_parse_kicad_cli_json`
+        only read a per-item `net` key that real KiCad 10.0.4 never emits,
+        leaving `DRCViolation.nets` empty and breaking `--net` filtering,
+        `violations_for_net()`, and the DRC fixer/repair targeting. The net
+        lives inside each item's `description` as ``[NetName]``; the parser
+        now extracts it there.
+        """
+        report = parse_json_report(_GOLDEN_FIXTURE.read_text())
+
+        # At least one violation must carry a non-empty net set.
+        assert any(v.nets for v in report.violations), (
+            "No violation had nets populated -- the [NetName] extraction in "
+            "_parse_kicad_cli_json regressed (real output has no `net` key)."
+        )
+
+        # The expected net names from the golden capture are surfaced.
+        all_nets = {net for v in report.violations for net in v.nets}
+        assert "Net-(C11-2)" in all_nets
+        assert "Net-(R1-1)" in all_nets
+
+        # The shorting violations expose BOTH shorted nets (dedup preserved).
+        shorting = [
+            v for v in report.violations if v.nets and set(v.nets) == {"Net-(C11-2)", "Net-(R1-1)"}
+        ]
+        assert shorting, (
+            "Expected a violation carrying both shorted nets Net-(C11-2) and "
+            f"Net-(R1-1); saw net sets {[v.nets for v in report.violations]!r}"
+        )
+
+    def test_kicad_cli_json_extracts_net_without_net_key(self):
+        """A synthetic item with only a ``[NetName]`` description yields nets.
+
+        Unit-level guard: no per-item `net` key, net inferred from the
+        bracket token, ``<no net>`` excluded, duplicates deduped across items.
+        """
+        data = {
+            "source": "board.kicad_pcb",
+            "violations": [
+                {
+                    "type": "clearance",
+                    "description": "Clearance violation",
+                    "severity": "error",
+                    "items": [
+                        {
+                            "description": "Track [Net-(C11-2)] on F.Cu",
+                            "pos": {"x": 1.0, "y": 2.0},
+                        },
+                        {
+                            "description": "Via [Net-(C11-2)] on F.Cu - B.Cu",
+                            "pos": {"x": 3.0, "y": 4.0},
+                        },
+                        {
+                            "description": "Pad 1 [<no net>] of R1 on F.Cu",
+                            "pos": {"x": 5.0, "y": 6.0},
+                        },
+                    ],
+                }
+            ],
+        }
+        report = parse_json_report(json.dumps(data))
+        assert report.violations[0].nets == ["Net-(C11-2)"]
+
+    def test_kicad_cli_json_honors_legacy_net_key_fallback(self):
+        """A forward-compat item carrying a `net` key is still honored."""
+        data = {
+            "source": "board.kicad_pcb",
+            "violations": [
+                {
+                    "type": "clearance",
+                    "description": "Clearance violation",
+                    "severity": "error",
+                    "items": [
+                        {"description": "no bracket here", "net": "GND"},
+                    ],
+                }
+            ],
+        }
+        report = parse_json_report(json.dumps(data))
+        assert report.violations[0].nets == ["GND"]
+
+    def test_kicad_cli_json_no_bracket_yields_empty_nets(self):
+        """An item description with no bracket token produces empty nets."""
+        data = {
+            "source": "board.kicad_pcb",
+            "violations": [
+                {
+                    "type": "silk_over_copper",
+                    "description": "Silk over copper",
+                    "severity": "warning",
+                    "items": [
+                        {"description": "Text item on F.SilkS"},
+                    ],
+                }
+            ],
+        }
+        report = parse_json_report(json.dumps(data))
+        assert report.violations[0].nets == []
 
 
 class TestKicadCliDrcLiveSmoke:


### PR DESCRIPTION
## Summary

`_parse_kicad_cli_json` only extracted nets from a per-item `net` key that real KiCad 10.0.4 output **never emits**. In real `kicad-cli pcb drc --format json` output the net is embedded inside each item's `description` as a `[NetName]` token (e.g. `Track [Net-(C11-2)] on F.Cu`), so `DRCViolation.nets` was always empty — a silent no-op that broke every downstream consumer of `.nets`.

The plain-text DRC parser in the same file already extracted nets correctly (`report.py:254-258`). This PR ports that same `[NetName]` regex into the JSON item loop, keeping the legacy `net`-key branch as a forward-compat fallback.

## Changes

- `src/kicad_tools/drc/report.py` — in the `_parse_kicad_cli_json` item loop, extract nets from each item's `description` via `re.findall(r"\[([^\]]+)\]", desc)`, preserving the `<no net>` filter and cross-item dedup. The existing `if "net" in item_data` branch is retained as a forward-compat fallback.
- `tests/test_drc_report_formats.py` — added a golden-fixture regression test asserting `.nets` is populated (`Net-(C11-2)`, `Net-(R1-1)`) from the real capture, plus unit tests for the legacy-key fallback, `<no net>` exclusion, dedup, and the no-bracket-yields-empty edge case. Updated the now-accurate `test_golden_items_shape` docstring.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Extract `[NetName]` token(s) from item `description` in `_parse_kicad_cli_json` | ✅ | Ported regex from report.py:254-258 into the item loop |
| Keep legacy `net`-key branch as forward-compat fallback | ✅ | `test_kicad_cli_json_honors_legacy_net_key_fallback` passes |
| `<no net>` filtered, duplicates deduped | ✅ | `test_kicad_cli_json_extracts_net_without_net_key` asserts single deduped net |
| Regression test on real golden fixture | ✅ | `test_golden_nets_extracted_from_item_descriptions` asserts non-empty nets + expected names |
| No downstream consumer of `.nets` regresses | ✅ | All consumers guard with membership/`not` tests (per curation); full DRC report suite green |

## Test Plan

- `uv run pytest tests/test_drc_report_formats.py` — 25 passed.
- `uv run ruff check` + `ruff format --check` — clean on both changed files.
- `uv run mypy src/kicad_tools/drc/report.py` via baseline check — "No new type errors" (the 4 pre-existing errors are already baselined; unrelated to this change).

Closes #4392