### PR TITLE
fix(sexp): guarantee writer never emits crash-form pad chamfer corners

### DIFF
--- a/src/kicad_tools/sexp/__init__.py
+++ b/src/kicad_tools/sexp/__init__.py
@@ -29,6 +29,7 @@ from .parser import (
     SExp,
     SExpParser,
     SExpSerializer,
+    normalize_chamfer,
     parse_file,
     parse_sexp,
     parse_string,
@@ -43,6 +44,8 @@ __all__ = [
     "Document",
     "parse_file",
     "parse_string",
+    # Pad chamfer writer-safety normalizer (issue #4393)
+    "normalize_chamfer",
     # Backward compatibility with core/sexp.py
     "parse_sexp",
     "serialize_sexp",

--- a/src/kicad_tools/sexp/parser.py
+++ b/src/kicad_tools/sexp/parser.py
@@ -643,6 +643,18 @@ class SExp:
             "roundrect",
             "trapezoid",
             "custom",
+            # Pad chamfer corners (issue #4393). KiCad emits these as bare
+            # symbols inside a pad's (chamfer ...) node, e.g.
+            # (chamfer top_left bottom_right). They are absent from this
+            # allowlist, so a *programmatically constructed* corner atom
+            # (SExp(value="top_left"), which carries no parse-time
+            # _originally_bare flag) would otherwise be quoted by the
+            # "quote everything else" fallback below — a non-canonical form.
+            # Same rationale as the not_allowed/chamfer_rect enum tokens.
+            "top_left",
+            "top_right",
+            "bottom_left",
+            "bottom_right",
             # fp_text types
             "reference",
             "value",
@@ -1437,6 +1449,58 @@ def serialize_sexp(sexp: SExp, indent: str = "  ") -> str:
         Serialized S-expression string
     """
     return sexp.to_string()
+
+
+# Pad chamfer corner tokens (issue #4393). KiCad emits these as bare symbols
+# inside a pad's (chamfer ...) node, e.g. (chamfer top_left bottom_right).
+_CHAMFER_CORNERS = frozenset({"top_left", "top_right", "bottom_left", "bottom_right"})
+
+
+def normalize_chamfer(node: SExp) -> SExp:
+    """Repair malformed pad-chamfer corner children into bare atoms in place.
+
+    Pad chamfer corners have no dedicated serializer — they flow through the
+    generic ``SExp.to_string()`` writer, so the emitted byte content depends
+    entirely on *how* each corner child was constructed:
+
+    - ``SExp(value="top_left", _originally_bare=True)`` (what the parser builds
+      from a correctly-authored ``(chamfer top_left)``) emits bare ``top_left``.
+    - ``SExp(value="top_left")`` emits bare too, now that the four corner
+      tokens are on the ``_needs_quoting()`` allowlist (issue #4393 item 1).
+    - ``SExp(name="top_left")`` — a *childless named/list* node — emits
+      ``(top_left)``. KiCad-10's ``pcb drc`` loader **segfaults (exit 139)** on
+      that parenthesized-corner form rather than reporting a parse error.
+
+    The allowlist alone does not stop the segfault form: a childless *named*
+    node is a list, not an atom, so it never reaches the quoting heuristic.
+    This helper closes that gap. For every ``chamfer`` node in the tree it
+    rewrites any childless named corner child into a bare atom
+    (``SExp(value=<corner>, _originally_bare=True)``), guaranteeing the writer
+    never *originates* — and repairing, if present — the crash form regardless
+    of how it entered the tree.
+
+    The pass is:
+
+    - **Scoped** to ``chamfer`` parents only — an unrelated childless named
+      node elsewhere in the tree (e.g. ``(fill)``) is left untouched.
+    - **Idempotent** — a chamfer already carrying bare corner atoms is a no-op.
+    - **Opt-in** — it is *not* wired into ``to_string()``/``write()``, so it
+      does not disturb the round-trip fidelity of a hand-authored malformed
+      fixture (issue #4380); callers invoke it explicitly on the write path.
+
+    Args:
+        node: The root of the tree (or subtree) to normalize. Mutated in place.
+
+    Returns:
+        The same ``node``, for convenient chaining.
+    """
+    if node.name == "chamfer":
+        for i, child in enumerate(node.children):
+            if not child.is_atom and not child.children and child.name in _CHAMFER_CORNERS:
+                node.children[i] = SExp(value=child.name, _originally_bare=True)
+    for child in node.children:
+        normalize_chamfer(child)
+    return node
 
 
 def parse_file(path: str | Path, track_positions: bool = False) -> SExp:

--- a/tests/test_sexp.py
+++ b/tests/test_sexp.py
@@ -14,7 +14,12 @@ from kicad_tools.core.sexp_file import (
 )
 from kicad_tools.exceptions import FileFormatError
 from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
-from kicad_tools.sexp import SExp, parse_string, serialize_sexp
+from kicad_tools.sexp import (
+    SExp,
+    normalize_chamfer,
+    parse_string,
+    serialize_sexp,
+)
 
 
 class TestSExpBasicParsing:
@@ -497,6 +502,104 @@ class TestSExpSerialization:
                 f"bare token '{token}' should not be quoted, got: {result}"
             )
             assert f"(field {token})" == result
+
+    def test_programmatic_chamfer_corners_emit_bare(self):
+        """Programmatically-built chamfer corner atoms must emit bare.
+
+        Pad chamfer corners flow through the generic writer with no dedicated
+        serializer. Before issue #4393 the four corner tokens were absent from
+        the _needs_quoting() allowlist, so a programmatically-constructed
+        SExp(value="top_left") (which carries no parse-time _originally_bare
+        flag) was wrongly quoted as (chamfer "top_left") — a non-canonical
+        grammar. Allowlisting the corners makes them emit bare.
+        """
+        for corner in ("top_left", "top_right", "bottom_left", "bottom_right"):
+            node = SExp(name="chamfer", children=[SExp(value=corner)])
+            result = node.to_string(compact=True)
+            assert result == f"(chamfer {corner})", (
+                f"programmatic corner must emit bare, got: {result}"
+            )
+            assert '"' not in result
+
+    def test_programmatic_multi_corner_chamfer_all_bare(self):
+        """A multi-corner chamfer emits every corner bare."""
+        node = SExp(
+            name="chamfer",
+            children=[
+                SExp(value="top_left"),
+                SExp(value="top_right"),
+                SExp(value="bottom_left"),
+                SExp(value="bottom_right"),
+            ],
+        )
+        result = node.to_string(compact=True)
+        assert result == "(chamfer top_left top_right bottom_left bottom_right)"
+        assert '"' not in result
+
+    def test_normalize_chamfer_repairs_segfault_form(self):
+        """normalize_chamfer() rewrites the (chamfer (top_left)) crash form.
+
+        A childless *named* corner node emits the parenthesized-corner form
+        (chamfer (top_left)) that segfaults KiCad-10's `pcb drc` loader
+        (exit 139). The allowlist alone does not repair this — a named node is
+        a list, not an atom, so it never reaches the quoting heuristic. The
+        normalizer rewrites it into a bare atom so (top_left) never survives
+        export (issue #4393).
+        """
+        for corner in ("top_left", "top_right", "bottom_left", "bottom_right"):
+            # The malformed segfault form before repair.
+            malformed = SExp(name="chamfer", children=[SExp(name=corner)])
+            assert malformed.to_string(compact=True) == f"(chamfer ({corner}))"
+            # After repair it emits the canonical bare corner.
+            normalize_chamfer(malformed)
+            assert malformed.to_string(compact=True) == f"(chamfer {corner})"
+
+    def test_normalize_chamfer_is_idempotent_on_bare_corners(self):
+        """Normalizing a chamfer that already holds bare corners is a no-op."""
+        text = "(pad (chamfer top_left bottom_right))"
+        node = parse_string(text)
+        before = node.to_string()
+        normalize_chamfer(node)
+        assert node.to_string() == before
+        assert "(top_left)" not in node.to_string()
+
+    def test_normalize_chamfer_scoped_to_chamfer_parents(self):
+        """The normalizer must not touch childless named nodes elsewhere.
+
+        An unrelated childless named node (e.g. (fill)) outside a chamfer must
+        be left untouched — the repair is scoped to chamfer parents only.
+        """
+        node = SExp(
+            name="pad",
+            children=[
+                SExp(name="fill"),  # unrelated childless named node
+                SExp(name="chamfer", children=[SExp(name="top_left")]),
+            ],
+        )
+        normalize_chamfer(node)
+        # The chamfer corner was repaired to a bare atom...
+        chamfer = node.children[1]
+        assert chamfer.children[0].is_atom
+        assert chamfer.children[0].value == "top_left"
+        # ...but the unrelated (fill) node is left as a childless named node.
+        fill = node.children[0]
+        assert not fill.is_atom
+        assert fill.name == "fill"
+        assert fill.to_string(compact=True) == "(fill)"
+
+    def test_authored_chamfer_round_trips_bare(self):
+        """A correctly-authored chamfer still round-trips byte-identically.
+
+        Guard against regressing the existing bare-token behavior: parsing and
+        re-emitting a canonical (chamfer top_left bottom_right) must preserve
+        the bare corners exactly (issue #4393 must not disturb #4380's
+        round-trip fidelity).
+        """
+        text = "(pad (chamfer top_left bottom_right))"
+        result = parse_string(text).to_string()
+        assert "(chamfer top_left bottom_right)" in result
+        assert '"top_left"' not in result
+        assert "(top_left)" not in result
 
     def test_parsed_quoted_string_stays_quoted(self):
         """An originally-quoted string must stay quoted on round-trip.


### PR DESCRIPTION
## Summary

Pad chamfer corners have **no dedicated serializer** — they flow through the generic `SExp.to_string()` writer in `src/kicad_tools/sexp/parser.py`, so the emitted bytes depend entirely on how each corner child was constructed. Two non-canonical forms could be originated by programmatic construction:

- `SExp(value="top_left")` → `(chamfer "top_left")` — quoted, because the four corner tokens were absent from the `_needs_quoting()` allowlist, so an atom lacking the parse-time `_originally_bare` flag hit the "quote everything else" fallback.
- `SExp(name="top_left")` — a childless *named* node → `(chamfer (top_left))` — the parenthesized-corner form that **segfaults KiCad-10's `pcb drc` loader (exit 139)**.

This PR guarantees our writer never *originates* the crash form, and provides an opt-in repair for one that entered the tree by any means.

## Changes

- **`_needs_quoting()` allowlist** — add `top_left`, `top_right`, `bottom_left`, `bottom_right` so programmatically-built corner atoms emit **bare** (matches the existing `not_allowed`/`chamfer_rect` enum pattern). Closes the quoted-variant gap.
- **`normalize_chamfer(node)`** — new pure, chamfer-scoped, idempotent helper that rewrites any childless *named* corner child into a bare atom (`SExp(value=<corner>, _originally_bare=True)`). The allowlist alone cannot fix the segfault form — a named node is a *list*, not an atom, so it never reaches the quoting heuristic. Exported from `kicad_tools.sexp`.
- **Deliberately un-wired** from `to_string()`/`write()` so it does **not** disturb #4380's round-trip fidelity of a hand-authored malformed fixture; callers invoke it explicitly on the write path.
- **6 writer unit tests** in `tests/test_sexp.py`.

## Distinction from #4380

#4380 is a round-trip *fidelity* test that hand-authors a malformed chamfer and asserts parse→emit preserves it verbatim (correct for that goal). #4393 is the complementary *writer-safety* guarantee: our writer must never originate the crash form. The normalizer is scoped to programmatic repair and left off the default write path, so #4380's preservation is untouched.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Bare emission for all four corners | ✅ | `test_programmatic_chamfer_corners_emit_bare` — `(chamfer top_left)` etc., no quotes |
| No parenthesized corner survives export | ✅ | `test_normalize_chamfer_repairs_segfault_form` — `(chamfer (top_left))` → `(chamfer top_left)` |
| Round-trip of correct form preserved | ✅ | `test_authored_chamfer_round_trips_bare` |
| Multi-corner all bare | ✅ | `test_programmatic_multi_corner_chamfer_all_bare` |
| Idempotent normalization | ✅ | `test_normalize_chamfer_is_idempotent_on_bare_corners` |
| Normalizer scoped to `chamfer` parents only | ✅ | `test_normalize_chamfer_scoped_to_chamfer_parents` — unrelated `(fill)` untouched |

## Test Plan

- `uv run pytest tests/test_sexp.py` → **95 passed** (6 new).
- `uv run ruff check .` and `uv run ruff format . --check` → clean.
- `uv run mypy src/kicad_tools/sexp/` → no new errors on the added code (pre-existing baseline errors only).

Closes #4393