### PR TITLE
feat(placement): same-domain cohesion term + auto derived-tap creepage exemption

### DIFF
--- a/docs/placement-scoring.md
+++ b/docs/placement-scoring.md
@@ -118,6 +118,26 @@ Absent a voltage/domain input the term stays dormant and scores are
 **byte-identical** to the historical objective (regression-safe opt-in,
 mirroring `--anchor-weight`).
 
+### Same-domain clustering: the cohesion term
+
+The creepage keepout pushes *different* domains **apart**; the complementary
+`compute_domain_cohesion` term pulls a *same* domain **together**. Whenever a
+domain partition is supplied, each domain with two or more member footprints
+contributes a radius-of-gyration-style spread penalty: the centroid of its
+members is computed and each member's Euclidean distance to that centroid is
+summed. Minimizing it packs every voltage domain into a compact zone instead of
+leaning on wirelength to incidentally cluster it.
+
+Unlike creepage, cohesion is a **soft preference, not a feasibility gate**. It
+is deliberately excluded from `is_feasible` and from the infeasible branch of
+the lexicographic score — a spread-out domain is suboptimal, never infeasible —
+so it only shapes the layout once a placement is already feasible. Its weight
+(`cohesion`, default `1.0`) is kept small relative to the hard-constraint
+weights so it can never override feasibility. The term needs only the domain
+partition (no per-pair voltages), so it fires on both the `--voltage-map` and
+`--hv-domains` paths, and stays dormant (contributing `0.0`) when no HV input is
+supplied — preserving the byte-identical guarantee above.
+
 ### Input contract
 
 Two mutually-exclusive sources:
@@ -153,18 +173,36 @@ Two mutually-exclusive sources:
 | `--material-group` | `IIIa` | Insulation material group (I/II/IIIa/IIIb). |
 | `--hv-threshold` | `30.0` | Minimum cross-domain `|ΔV|` (V) that triggers a keepout. Lower-difference domain pairs rely on normal DRC clearance, so low-voltage/low-voltage nets are not over-segregated. |
 | `--weights '{"creepage": …}'` | `1e5` | Weight applied to the creepage shortfall (a hard-feasibility term). |
+| `--weights '{"cohesion": …}'` | `1.0` | Weight applied to the same-domain clustering penalty (a soft preference; see above). |
 
 A `|ΔV|` above the highest tabulated creepage row raises a loud
 `StandardLookupError` (surfaced as an `Error:` and exit code 1) — the tool
 never silently extrapolates a safety distance.
 
-### Guarded sense taps (partial)
+### Guarded sense taps (auto-detected)
 
 Some low-voltage nets are *derived from* an HV net (e.g. `V_AC_SENSE_RAW` off
 `AC_LINE` through a divider) and cannot be pushed away — they need a guard ring
 rather than separation. `compute_creepage_violation` accepts an `exempt_pairs`
 set that excludes such `(HV-ref, tap-ref)` pairs from the keepout while keeping
-the tap constrained against *other* domains. The cost-function mechanism is in
-place; automatic detection of derived taps from the voltage map (and the guard
-advisory) is tracked as follow-up work (see issue #4373 Phase 3, and #4372 for
-the complementary guard-copper generation).
+the tap constrained against *other* domains.
+
+Derived taps are now **auto-detected** from a `--voltage-map` by
+`detect_derived_tap_exempt_pairs` (`placement/hv_domains.py`), reusing the
+existing `--hv-threshold` — no new knob. The heuristic:
+
+1. Each net in the voltage map is HV when `|V| >= --hv-threshold`, else LV.
+2. An LV net `t` is a **derived tap of** HV net `h` when they share at least one
+   common component ref (the bridging divider/limiter resistor touches both
+   nets) and `|V_t| < |V_h|`.
+3. For each derived `(t, h)`, every ref on `t` and ref on `h` whose **domains
+   differ** is added to `exempt_pairs` — so the tap-side footprints are exempt
+   from *their parent* HV domain, while the bridging ref (which resolves to the
+   HV domain) never self-exempts and the tap keeps its keepout against
+   *unrelated* HV domains.
+
+Each detected tap prints a guard advisory (unless `--quiet`), e.g.
+`guarded tap: /V_AC_SENSE_RAW derived from /AC_LINE - route with a guard
+trace/ring`. This path is voltage-map only: the `--hv-domains` declaration has
+no per-net data, so no taps are auto-exempted there. Generating the actual guard
+trace/ring copper remains out of scope (see #4372).

--- a/src/kicad_tools/cli/optimize_placement_cmd.py
+++ b/src/kicad_tools/cli/optimize_placement_cmd.py
@@ -287,6 +287,7 @@ def _parse_weights(weights_json: str | None) -> PlacementCostConfig:
         "wirelength_weight": 1.0,
         "area_weight": 0.1,
         "creepage_weight": 1e5,
+        "cohesion_weight": 1.0,
         "mode": CostMode.LEXICOGRAPHIC,
     }
 
@@ -318,6 +319,7 @@ def _parse_weights(weights_json: str | None) -> PlacementCostConfig:
         wirelength_weight=data.get("wirelength", defaults["wirelength_weight"]),
         area_weight=data.get("area", defaults["area_weight"]),
         creepage_weight=data.get("creepage", defaults["creepage_weight"]),
+        cohesion_weight=data.get("cohesion", defaults["cohesion_weight"]),
         mode=mode,
     )
 
@@ -814,7 +816,26 @@ def run_optimize_placement(
     except (ValueError, FileNotFoundError) as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
+
+    # Derived-tap auto-exemption (issue #4373 Phase 3, auto). Only the
+    # voltage-map path carries the per-net voltages the detector needs; the
+    # --hv-domains declaration path has no per-net data, so hv_exempt stays
+    # empty there. When no HV input is supplied hv_ref_domains is None and this
+    # is skipped entirely (regression-safe no-op).
     hv_exempt: set[frozenset[str]] | None = None
+    if voltage_map_path is not None and hv_ref_domains is not None:
+        from kicad_tools.placement.hv_domains import (
+            detect_derived_tap_exempt_pairs,
+            load_voltage_map,
+        )
+
+        voltage_map = load_voltage_map(voltage_map_path)
+        hv_exempt, hv_advisories = detect_derived_tap_exempt_pairs(
+            nets, hv_ref_domains, voltage_map, hv_threshold=hv_threshold
+        )
+        if not quiet:
+            for advisory in hv_advisories:
+                print(f"  {advisory}")
 
     footprint_sizes = _build_footprint_sizes(components)
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -5190,7 +5190,7 @@ def _add_optimize_placement_parser(subparsers) -> None:
         metavar="JSON",
         help=(
             'Custom cost weights as JSON, e.g. \'{"wirelength": 2.0, "overlap": 1e6}\'. '
-            "Keys: overlap, drc, boundary, wirelength, area, creepage"
+            "Keys: overlap, drc, boundary, wirelength, area, creepage, cohesion"
         ),
     )
     op_parser.add_argument(

--- a/src/kicad_tools/placement/cost.py
+++ b/src/kicad_tools/placement/cost.py
@@ -54,6 +54,12 @@ class PlacementCostConfig:
             :func:`compute_creepage_violation`. Like ``overlap``/``drc``/
             ``boundary`` it is treated as a hard-feasibility term: a non-zero
             creepage shortfall makes the placement infeasible.
+        cohesion_weight: Weight for the same-domain clustering (cohesion)
+            penalty. Applied to :func:`compute_domain_cohesion`. Unlike the
+            creepage term this is a **soft preference** -- it packs footprints
+            that share a voltage domain into a compact zone but never gates
+            feasibility. Kept small relative to the hard-constraint weights so
+            it only shapes the layout once a placement is already feasible.
         mode: Scoring mode (weighted_sum or lexicographic).
     """
 
@@ -65,6 +71,7 @@ class PlacementCostConfig:
     block_boundary_weight: float = 1e5
     inter_block_spacing: float = 1.0
     creepage_weight: float = 1e5
+    cohesion_weight: float = 1.0
     mode: CostMode = CostMode.WEIGHTED_SUM
 
 
@@ -102,6 +109,10 @@ class CostBreakdown:
         creepage: Raw HV creepage-keepout shortfall penalty (mm) -- the sum of
             required-minus-actual gaps across cross-domain footprint pairs that
             are closer than their required creepage.
+        cohesion: Raw same-domain clustering penalty (mm) -- the sum, across
+            every voltage domain with two or more members, of each member's
+            distance to its domain centroid (a radius-of-gyration-style spread
+            penalty). Lower means each domain is packed more tightly.
     """
 
     wirelength: float = 0.0
@@ -112,6 +123,7 @@ class CostBreakdown:
     block_boundary: float = 0.0
     inter_block: float = 0.0
     creepage: float = 0.0
+    cohesion: float = 0.0
 
 
 @dataclass(frozen=True)
@@ -633,6 +645,73 @@ def compute_creepage_violation(
     return total
 
 
+def compute_domain_cohesion(
+    placements: Sequence[ComponentPlacement],
+    ref_domains: dict[str, str] | None,
+    footprint_sizes: dict[str, tuple[float, float]] | None = None,
+) -> float:
+    """Compute the same-domain clustering (cohesion) penalty (issue #4373).
+
+    This is the voltage-aware *attraction* term. It complements
+    :func:`compute_creepage_violation` (which pushes **different** domains
+    apart): cohesion actively packs footprints that share a voltage *domain*
+    into a compact zone so a domain forms a coherent region rather than relying
+    on wirelength to incidentally pull it together.
+
+    For each domain (from *ref_domains*) with two or more member footprints, the
+    centroid of the member positions is computed and each member's Euclidean
+    distance to that centroid is summed; the totals across all domains are
+    added. This is a radius-of-gyration-style spread penalty whose minimum is a
+    tight cluster per domain. It is smooth, needs no voltages (only the domain
+    partition), and depends on nothing but footprint positions.
+
+    Singleton domains (a single member), and components absent from
+    *ref_domains* (domain-less), contribute zero. An empty or ``None``
+    *ref_domains* yields ``0.0`` -- the term is dormant on the no-HV-input path,
+    keeping the voltage-blind objective byte-identical.
+
+    .. note::
+        This is a **soft** preference, not a feasibility gate. It is
+        deliberately excluded from the ``is_feasible`` conjunction in
+        :func:`evaluate_placement` and from the infeasible branch of the
+        lexicographic score -- a spread-out domain is suboptimal, never
+        infeasible.
+
+    Args:
+        placements: Current component positions.
+        ref_domains: Map from component reference to its HV domain id. ``None``
+            or empty disables the term.
+        footprint_sizes: Accepted for signature parity with the other cost
+            terms; unused (cohesion is centroid-of-positions based).
+
+    Returns:
+        Sum of per-domain spread penalties (mm). Zero means every domain is a
+        single point (or has fewer than two members).
+    """
+    del footprint_sizes  # unused: cohesion is measured between footprint centres
+    if not ref_domains:
+        return 0.0
+
+    by_domain: dict[str, list[tuple[float, float]]] = {}
+    for p in placements:
+        domain = ref_domains.get(p.reference)
+        if domain is None:
+            continue
+        by_domain.setdefault(domain, []).append((p.x, p.y))
+
+    total = 0.0
+    for positions in by_domain.values():
+        n = len(positions)
+        if n < 2:
+            continue
+        cx = sum(x for x, _ in positions) / n
+        cy = sum(y for _, y in positions) / n
+        for x, y in positions:
+            total += ((x - cx) ** 2 + (y - cy) ** 2) ** 0.5
+
+    return total
+
+
 def evaluate_placement(
     placements: Sequence[ComponentPlacement],
     nets: Sequence[Net],
@@ -721,6 +800,15 @@ def evaluate_placement(
             exempt_pairs,
         )
 
+    # Same-domain clustering (issue #4373 Phase 1). Fires whenever a domain
+    # partition is supplied -- independent of the required-creepage table, since
+    # clustering needs only the partition, not per-pair voltages. It is a SOFT
+    # preference: computed here and added to the score, but deliberately absent
+    # from the is_feasible gate below.
+    cohesion = 0.0
+    if ref_domains:
+        cohesion = compute_domain_cohesion(placements, ref_domains, footprint_sizes)
+
     breakdown = CostBreakdown(
         wirelength=wirelength,
         overlap=overlap,
@@ -730,8 +818,12 @@ def evaluate_placement(
         block_boundary=block_boundary,
         inter_block=inter_block,
         creepage=creepage,
+        cohesion=cohesion,
     )
 
+    # NOTE: cohesion is intentionally NOT part of this conjunction. It is an
+    # optimization preference (pack same-domain refs), not a feasibility
+    # constraint -- a spread-out domain is suboptimal, never infeasible.
     is_feasible = (
         overlap == 0.0
         and drc == 0.0
@@ -763,6 +855,7 @@ def _weighted_sum_score(breakdown: CostBreakdown, config: PlacementCostConfig) -
         + config.block_boundary_weight * breakdown.block_boundary
         + config.block_boundary_weight * breakdown.inter_block
         + config.creepage_weight * breakdown.creepage
+        + config.cohesion_weight * breakdown.cohesion
     )
 
 
@@ -778,8 +871,11 @@ def _lexicographic_score(
     sum of the infeasibility components (overlap, DRC, boundary) plus a
     large constant offset.
 
-    Feasible placements are scored by the weighted sum of wirelength and
-    area only.
+    Feasible placements are scored by the weighted sum of wirelength, area,
+    and the soft same-domain cohesion term. Cohesion shapes the layout only
+    once a placement is already feasible -- it is absent from the infeasible
+    offset branch so it can never make one infeasible placement outrank
+    another on preference alone.
     """
     if not is_feasible:
         # Large offset ensures any infeasible score > any feasible score.
@@ -792,4 +888,8 @@ def _lexicographic_score(
             + config.creepage_weight * breakdown.creepage
         )
     else:
-        return config.wirelength_weight * breakdown.wirelength + config.area_weight * breakdown.area
+        return (
+            config.wirelength_weight * breakdown.wirelength
+            + config.area_weight * breakdown.area
+            + config.cohesion_weight * breakdown.cohesion
+        )

--- a/src/kicad_tools/placement/hv_domains.py
+++ b/src/kicad_tools/placement/hv_domains.py
@@ -202,3 +202,106 @@ def build_required_by_domain_pair(
             required, _prov = std.required_creepage(dv, pollution_degree, material_group)
             out[(a, b)] = required
     return out
+
+
+def detect_derived_tap_exempt_pairs(
+    nets: Sequence,
+    ref_domains: Mapping[str, str],
+    voltage_map: Mapping[str, float],
+    *,
+    hv_threshold: float = 30.0,
+) -> tuple[set[frozenset[str]], list[str]]:
+    """Detect derived sense taps and build their creepage auto-exemption set.
+
+    This is issue #4373 Phase 3 (auto). A *derived tap* is a low-voltage net
+    that is electrically bound to an HV net through a bridging divider/limiter
+    component (e.g. ``V_AC_SENSE_RAW`` off ``AC_LINE`` through the sense
+    resistor). Such a tap **cannot** be pushed far from its parent HV node, so
+    penalizing it for sitting close would fight its own spring. Instead it is
+    *exempted* from the cross-domain creepage keepout against its parent -- and
+    only its parent -- while staying constrained against every other HV domain
+    (route it with a guard trace/ring, which is out of scope here, cross-ref
+    #4372).
+
+    Detection heuristic (reuses ``hv_threshold`` -- no new required knob):
+
+    1. Each net in *voltage_map* is HV when ``|V| >= hv_threshold`` else LV.
+    2. An LV net ``t`` is a **derived tap of** HV net ``h`` when they share at
+       least one common component ref (the bridging divider/limiter touches
+       both nets) and ``|V_t| < |V_h|``.
+    3. For each derived ``(t, h)`` and every ref ``a`` on ``t`` and ``b`` on
+       ``h`` whose **domains differ** (``ref_domains[a] != ref_domains[b]``),
+       ``frozenset({a, b})`` is added to the exemption set. This exempts exactly
+       the intentionally-close tap-side footprints from their parent HV domain
+       and nothing else -- the bridging ref itself (which resolves to the HV
+       domain) never self-exempts, and the tap keeps its keepout against
+       *unrelated* HV domains.
+
+    Args:
+        nets: Sequence of objects exposing ``name`` and ``pins`` (an iterable of
+            ``(ref, pad)`` tuples) -- e.g. :class:`kicad_tools.placement.cost.Net`.
+        ref_domains: Map from component reference to its HV domain id (as
+            produced by :func:`derive_ref_domains_from_voltage_map`).
+        voltage_map: ``{net_name: volts}`` -- per-net voltages are required, so
+            this path is voltage-map only (the ``--hv-domains`` declaration has
+            no per-net data and yields no exemptions).
+        hv_threshold: Minimum ``|V|`` (volts) at which a net counts as HV.
+
+    Returns:
+        ``(exempt_pairs, advisories)`` where *exempt_pairs* is a set of
+        ``frozenset({ref_a, ref_b})`` cross-domain pairs to skip in the keepout,
+        and *advisories* is a list of human-readable guard notes (one per
+        detected tap-parent relation), deterministically ordered.
+    """
+    if not voltage_map:
+        return set(), []
+
+    # Member refs per net, restricted to nets that carry a voltage.
+    refs_by_net: dict[str, set[str]] = {}
+    for net in nets:
+        name = net.name
+        if name not in voltage_map:
+            continue
+        members = refs_by_net.setdefault(name, set())
+        for ref, _pad in net.pins:
+            members.add(ref)
+
+    hv_nets = sorted(n for n, v in voltage_map.items() if abs(float(v)) >= hv_threshold)
+    lv_nets = sorted(n for n, v in voltage_map.items() if abs(float(v)) < hv_threshold)
+
+    exempt_pairs: set[frozenset[str]] = set()
+    advisories: list[str] = []
+
+    for t in lv_nets:
+        t_refs = refs_by_net.get(t)
+        if not t_refs:
+            continue
+        for h in hv_nets:
+            h_refs = refs_by_net.get(h)
+            if not h_refs:
+                continue
+            # A derived tap shares a bridging ref with its HV parent and sits at
+            # a strictly lower voltage.
+            if t_refs.isdisjoint(h_refs):
+                continue
+            if abs(float(voltage_map[t])) >= abs(float(voltage_map[h])):
+                continue
+
+            added = False
+            for a in t_refs:
+                da = ref_domains.get(a)
+                if da is None:
+                    continue
+                for b in h_refs:
+                    db = ref_domains.get(b)
+                    if db is None or da == db:
+                        continue
+                    exempt_pairs.add(frozenset((a, b)))
+                    added = True
+
+            if added:
+                advisories.append(
+                    f"guarded tap: {t} derived from {h} - route with a guard trace/ring"
+                )
+
+    return exempt_pairs, advisories

--- a/tests/test_optimize_placement_cmd.py
+++ b/tests/test_optimize_placement_cmd.py
@@ -227,6 +227,13 @@ class TestParseWeights:
         assert config.wirelength_weight == 2.5
         assert config.overlap_weight == 500
 
+    def test_cohesion_default(self):
+        assert _parse_weights(None).cohesion_weight == 1.0
+
+    def test_cohesion_override(self):
+        config = _parse_weights('{"cohesion": 5.0}')
+        assert config.cohesion_weight == 5.0
+
     def test_invalid_json_exits(self):
         with pytest.raises(SystemExit):
             _parse_weights("not json at all")
@@ -1648,3 +1655,88 @@ class TestRunWithVoltageMap:
         # so the dry-run should flag the current placement as INFEASIBLE.
         out = capsys.readouterr().out
         assert "HV domains" in out
+
+
+class TestDerivedTapAutoExempt:
+    """Phase 3 (auto): derived-tap detection is wired through the CLI (#4373).
+
+    The ``tmp_pcb`` fixture has N1 = {R1, R2} and N2 = {R1, R2, C1}. With a
+    voltage map ``{N1: 150, N2: 1.65}`` the low-voltage N2 shares divider refs
+    R1/R2 with the high-voltage N1, so N2 is a derived tap of N1 and its
+    signal-side ref C1 is auto-exempted from the mains-domain refs.
+    """
+
+    def test_detected_exempt_pairs_threaded_into_evaluate(self, tmp_pcb, tmp_path, monkeypatch):
+        from kicad_tools.cli import optimize_placement_cmd as mod
+
+        captured: dict = {}
+        real_eval = mod._evaluate
+
+        def spy(*args, **kwargs):
+            captured["exempt_pairs"] = kwargs.get("exempt_pairs")
+            return real_eval(*args, **kwargs)
+
+        monkeypatch.setattr(mod, "_evaluate", spy)
+
+        vm = tmp_path / "v.json"
+        vm.write_text(json.dumps({"N1": 150, "N2": 1.65}))
+        result = run_optimize_placement(
+            str(tmp_pcb), dry_run=True, voltage_map_path=str(vm), quiet=True
+        )
+        assert result == 0
+        ep = captured["exempt_pairs"]
+        # No longer the hardcoded None -- the detected set is threaded through.
+        assert ep is not None
+        assert frozenset({"C1", "R1"}) in ep
+        assert frozenset({"C1", "R2"}) in ep
+
+    def test_advisory_printed_and_suppressed_by_quiet(self, tmp_pcb, tmp_path, capsys):
+        vm = tmp_path / "v.json"
+        vm.write_text(json.dumps({"N1": 150, "N2": 1.65}))
+
+        run_optimize_placement(str(tmp_pcb), dry_run=True, voltage_map_path=str(vm))
+        out = capsys.readouterr().out
+        assert "guarded tap" in out
+        assert "N2" in out
+        assert "N1" in out
+
+        run_optimize_placement(str(tmp_pcb), dry_run=True, voltage_map_path=str(vm), quiet=True)
+        out_quiet = capsys.readouterr().out
+        assert "guarded tap" not in out_quiet
+
+    def test_no_input_prints_no_hv_or_tap_output(self, tmp_pcb, capsys):
+        """Without a voltage/domain input, no HV or tap lines appear (no-op)."""
+        result = run_optimize_placement(str(tmp_pcb), dry_run=True)
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "guarded tap" not in out
+        assert "HV domains" not in out
+
+    def test_hv_domains_declaration_leaves_exempt_empty(self, tmp_pcb, tmp_path, monkeypatch):
+        """The --hv-domains path carries no per-net data -> no auto-exemption."""
+        from kicad_tools.cli import optimize_placement_cmd as mod
+
+        captured: dict = {}
+        real_eval = mod._evaluate
+
+        def spy(*args, **kwargs):
+            captured["exempt_pairs"] = kwargs.get("exempt_pairs")
+            return real_eval(*args, **kwargs)
+
+        monkeypatch.setattr(mod, "_evaluate", spy)
+
+        dm = tmp_path / "d.json"
+        dm.write_text(
+            json.dumps(
+                {
+                    "mains": {"refs": ["R1", "R2"], "voltage": 150},
+                    "signal": {"refs": ["C1"], "voltage": 1.65},
+                }
+            )
+        )
+        result = run_optimize_placement(
+            str(tmp_pcb), dry_run=True, hv_domains_path=str(dm), quiet=True
+        )
+        assert result == 0
+        # No per-net voltages -> detector never runs -> exempt stays None/empty.
+        assert not captured["exempt_pairs"]

--- a/tests/test_placement_cost.py
+++ b/tests/test_placement_cost.py
@@ -18,6 +18,7 @@ from kicad_tools.placement.cost import (
     Net,
     PlacementCostConfig,
     compute_creepage_violation,
+    compute_domain_cohesion,
     compute_wirelength,
     evaluate_placement,
 )
@@ -257,3 +258,141 @@ class TestEvaluatePlacementCreepageFeasibility:
         assert baseline.breakdown.creepage == 0.0
         assert with_domains_only.breakdown.creepage == 0.0
         assert with_domains_only.total == baseline.total
+
+
+# ---------------------------------------------------------------------------
+# Same-domain clustering / cohesion term (issue #4373 Phase 1)
+# ---------------------------------------------------------------------------
+
+
+class TestComputeDomainCohesion:
+    def test_empty_ref_domains_is_zero(self) -> None:
+        placements = _hv_pair(10.0)
+        assert compute_domain_cohesion(placements, {}) == 0.0
+        assert compute_domain_cohesion(placements, None) == 0.0
+
+    def test_single_domain_single_member_is_zero(self) -> None:
+        """A domain with one member has zero spread."""
+        placements = _hv_pair(10.0)
+        assert compute_domain_cohesion(placements, {"A": "mains"}) == 0.0
+
+    def test_all_singleton_domains_is_zero(self) -> None:
+        """Every domain a singleton -> nothing to cluster."""
+        placements = _hv_pair(10.0)
+        domains = {"A": "mains", "B": "signal"}
+        assert compute_domain_cohesion(placements, domains) == 0.0
+
+    def test_monotonic_in_spread(self) -> None:
+        """Two refs in one domain 10 mm apart cost more than 1 mm apart."""
+        domains = {"A": "mains", "B": "mains"}
+        far = compute_domain_cohesion(_hv_pair(10.0), domains)
+        near = compute_domain_cohesion(_hv_pair(1.0), domains)
+        assert far > near
+        # Each member sits at half the separation from the centroid:
+        # 2 members * (dx / 2) = dx.
+        assert far == pytest.approx(10.0)
+        assert near == pytest.approx(1.0)
+
+    def test_domainless_refs_contribute_zero(self) -> None:
+        """A ref absent from ref_domains does not join any cluster."""
+        placements = [
+            ComponentPlacement(reference="A", x=0.0, y=0.0),
+            ComponentPlacement(reference="B", x=10.0, y=0.0),
+            ComponentPlacement(reference="C", x=100.0, y=0.0),
+        ]
+        # C is domain-less; only A,B (same domain) cluster.
+        domains = {"A": "mains", "B": "mains"}
+        assert compute_domain_cohesion(placements, domains) == pytest.approx(10.0)
+
+    def test_footprint_sizes_ignored(self) -> None:
+        """footprint_sizes is accepted for parity but does not change the value."""
+        placements = _hv_pair(10.0)
+        domains = {"A": "mains", "B": "mains"}
+        with_sizes = compute_domain_cohesion(placements, domains, _HV_SIZES)
+        without = compute_domain_cohesion(placements, domains)
+        assert with_sizes == without
+
+
+class TestEvaluatePlacementCohesion:
+    """Cohesion is a soft term: it scores but never gates feasibility."""
+
+    _BOARD = BoardOutline(min_x=-100.0, min_y=-100.0, max_x=100.0, max_y=100.0)
+    _RULES = DesignRuleSet()
+
+    def _common(self, config: PlacementCostConfig) -> dict:
+        return {
+            "nets": [],
+            "rules": self._RULES,
+            "board": self._BOARD,
+            "config": config,
+            "footprint_sizes": _HV_SIZES,
+        }
+
+    def test_cohesion_populated_when_ref_domains_supplied(self) -> None:
+        placements = _hv_pair(10.0)
+        domains = {"A": "mains", "B": "mains"}
+        score = evaluate_placement(
+            placements,
+            ref_domains=domains,
+            **self._common(PlacementCostConfig(mode=CostMode.LEXICOGRAPHIC)),
+        )
+        assert score.breakdown.cohesion == pytest.approx(10.0)
+
+    def test_high_cohesion_keeps_feasible(self) -> None:
+        """A large spread does NOT flip is_feasible (soft-term proof)."""
+        placements = _hv_pair(10.0)  # 8 mm gap -> no overlap/drc/creepage
+        domains = {"A": "mains", "B": "mains"}  # same domain -> no keepout
+        score = evaluate_placement(
+            placements,
+            ref_domains=domains,
+            required_mm_by_domain_pair=_REQ,
+            **self._common(PlacementCostConfig(mode=CostMode.LEXICOGRAPHIC)),
+        )
+        assert score.breakdown.cohesion == pytest.approx(10.0)
+        assert score.breakdown.overlap == 0.0
+        assert score.breakdown.drc == 0.0
+        assert score.breakdown.creepage == 0.0
+        assert score.is_feasible is True
+        # Feasible: total sits below the infeasibility sentinel.
+        assert score.total < 1e12
+
+    def test_cohesion_enters_feasible_branch_only(self) -> None:
+        """Feasible total includes the weighted cohesion term."""
+        placements = _hv_pair(10.0)
+        domains = {"A": "mains", "B": "mains"}
+        config = PlacementCostConfig(mode=CostMode.LEXICOGRAPHIC, cohesion_weight=2.0)
+        score = evaluate_placement(placements, ref_domains=domains, **self._common(config))
+        assert score.is_feasible is True
+        # wirelength=0 (no nets), area = bbox area of the two 2x2 footprints.
+        expected = config.area_weight * score.breakdown.area + 2.0 * score.breakdown.cohesion
+        assert score.total == pytest.approx(expected)
+
+    def test_cohesion_absent_from_infeasible_branch(self) -> None:
+        """An infeasible (overlapping) placement's score excludes cohesion."""
+        placements = _hv_pair(0.5)  # overlapping 2x2 footprints -> infeasible
+        domains = {"A": "mains", "B": "mains"}
+        config = PlacementCostConfig(mode=CostMode.LEXICOGRAPHIC, cohesion_weight=1e9)
+        score = evaluate_placement(placements, ref_domains=domains, **self._common(config))
+        assert score.is_feasible is False
+        # Infeasible offset branch = OFFSET + overlap/drc/boundary/creepage only.
+        # A huge cohesion_weight must NOT leak into the total.
+        expected = 1e12 + (
+            config.overlap_weight * score.breakdown.overlap
+            + config.drc_weight * score.breakdown.drc
+            + config.boundary_weight * score.breakdown.boundary
+            + config.creepage_weight * score.breakdown.creepage
+        )
+        assert score.total == pytest.approx(expected)
+
+    def test_weighted_sum_includes_cohesion(self) -> None:
+        placements = _hv_pair(10.0)
+        domains = {"A": "mains", "B": "mains"}
+        config = PlacementCostConfig(mode=CostMode.WEIGHTED_SUM, cohesion_weight=3.0)
+        score = evaluate_placement(placements, ref_domains=domains, **self._common(config))
+        # Isolate the cohesion contribution against a zero-weight baseline.
+        baseline = evaluate_placement(
+            placements,
+            ref_domains=domains,
+            **self._common(PlacementCostConfig(mode=CostMode.WEIGHTED_SUM, cohesion_weight=0.0)),
+        )
+        assert score.total - baseline.total == pytest.approx(3.0 * score.breakdown.cohesion)

--- a/tests/test_placement_hv_domains.py
+++ b/tests/test_placement_hv_domains.py
@@ -17,6 +17,7 @@ from kicad_tools.placement.hv_domains import (
     build_required_by_domain_pair,
     derive_ref_domains_from_declaration,
     derive_ref_domains_from_voltage_map,
+    detect_derived_tap_exempt_pairs,
     load_hv_domains,
     load_voltage_map,
 )
@@ -130,3 +131,102 @@ class TestLoaders:
         p.write_text(json.dumps({"mains": {"refs": "J1"}}))
         with pytest.raises(ValueError):
             load_hv_domains(p)
+
+
+class TestDetectDerivedTapExemptPairs:
+    """Phase 3 (auto): derived-tap detection -> auto exempt_pairs (#4373)."""
+
+    def _fixture_nets(self):
+        """AC_LINE (HV) and V_AC_SENSE_RAW (LV tap) share divider ref R1.
+
+        R1 bridges both nets; C5 is the signal-side footprint on the tap only;
+        J1 is a second mains-domain footprint on AC_LINE.
+        """
+        return [
+            Net(name="/AC_LINE", pins=[("R1", "1"), ("J1", "2")]),
+            Net(name="/V_AC_SENSE_RAW", pins=[("R1", "2"), ("C5", "1")]),
+        ]
+
+    def _fixture_voltage_map(self):
+        return {"/AC_LINE": 150.0, "/V_AC_SENSE_RAW": 1.65}
+
+    def test_detects_tap_and_returns_cross_domain_pairs(self) -> None:
+        nets = self._fixture_nets()
+        vm = self._fixture_voltage_map()
+        ref_domains, _ = derive_ref_domains_from_voltage_map(nets, vm)
+        # R1 resolves to the mains domain; C5 to the tap domain.
+        assert ref_domains["R1"] == "/AC_LINE"
+        assert ref_domains["C5"] == "/V_AC_SENSE_RAW"
+
+        exempt, advisories = detect_derived_tap_exempt_pairs(
+            nets, ref_domains, vm, hv_threshold=30.0
+        )
+        # The signal-side C5 is exempted from BOTH mains-domain refs it faces.
+        assert frozenset({"C5", "R1"}) in exempt
+        assert frozenset({"C5", "J1"}) in exempt
+        # One advisory naming both the tap and its parent.
+        assert len(advisories) == 1
+        assert "/V_AC_SENSE_RAW" in advisories[0]
+        assert "/AC_LINE" in advisories[0]
+
+    def test_bridging_ref_does_not_self_exempt(self) -> None:
+        """R1 (mains domain) is never exempted against another mains ref."""
+        nets = self._fixture_nets()
+        vm = self._fixture_voltage_map()
+        ref_domains, _ = derive_ref_domains_from_voltage_map(nets, vm)
+        exempt, _ = detect_derived_tap_exempt_pairs(nets, ref_domains, vm)
+        assert frozenset({"R1", "J1"}) not in exempt
+
+    def test_lv_net_sharing_no_hv_ref_yields_no_exemption(self) -> None:
+        nets = [
+            Net(name="/AC_LINE", pins=[("R1", "1"), ("J1", "2")]),
+            # Isolated LV net -- no ref in common with any HV net.
+            Net(name="/REF_1V65", pins=[("U9", "1"), ("C9", "1")]),
+        ]
+        vm = {"/AC_LINE": 150.0, "/REF_1V65": 1.65}
+        ref_domains, _ = derive_ref_domains_from_voltage_map(nets, vm)
+        exempt, advisories = detect_derived_tap_exempt_pairs(nets, ref_domains, vm)
+        assert exempt == set()
+        assert advisories == []
+
+    def test_unrelated_hv_net_is_not_exempted_against_tap(self) -> None:
+        """A second HV domain (BANK+) sharing no ref with the tap keeps keepout."""
+        nets = self._fixture_nets() + [
+            Net(name="/BANK+", pins=[("Q1", "1"), ("D1", "1")]),
+        ]
+        vm = {"/AC_LINE": 150.0, "/V_AC_SENSE_RAW": 1.65, "/BANK+": 400.0}
+        ref_domains, _ = derive_ref_domains_from_voltage_map(nets, vm)
+        exempt, _ = detect_derived_tap_exempt_pairs(nets, ref_domains, vm)
+        # C5 (tap) is NOT exempted against the unrelated BANK+ domain refs.
+        assert frozenset({"C5", "Q1"}) not in exempt
+        assert frozenset({"C5", "D1"}) not in exempt
+        # ...but still exempt against its own parent.
+        assert frozenset({"C5", "R1"}) in exempt
+
+    def test_empty_voltage_map_is_empty(self) -> None:
+        exempt, advisories = detect_derived_tap_exempt_pairs([], {}, {})
+        assert exempt == set()
+        assert advisories == []
+
+    def test_threshold_boundary_net_is_hv_not_tap(self) -> None:
+        """A net exactly at the threshold classifies as HV, so it is no tap."""
+        nets = [
+            Net(name="/AC_LINE", pins=[("R1", "1"), ("J1", "2")]),
+            Net(name="/MID", pins=[("R1", "2"), ("C5", "1")]),
+        ]
+        vm = {"/AC_LINE": 150.0, "/MID": 30.0}
+        ref_domains, _ = derive_ref_domains_from_voltage_map(nets, vm)
+        exempt, advisories = detect_derived_tap_exempt_pairs(
+            nets, ref_domains, vm, hv_threshold=30.0
+        )
+        # /MID at |V| == threshold is HV, not an LV tap -> no exemption.
+        assert exempt == set()
+        assert advisories == []
+
+    def test_deterministic_output(self) -> None:
+        nets = self._fixture_nets()
+        vm = self._fixture_voltage_map()
+        ref_domains, _ = derive_ref_domains_from_voltage_map(nets, vm)
+        a = detect_derived_tap_exempt_pairs(nets, ref_domains, vm)
+        b = detect_derived_tap_exempt_pairs(nets, ref_domains, vm)
+        assert a == b


### PR DESCRIPTION
## Summary

Completes the two deferred phases of HV-aware `optimize-placement`, built on top of the merged creepage keepout from #4384 (Phase 0 input contract, Phase 2 hard keepout, and the `exempt_pairs` mechanism already shipped). This PR adds:

- **Phase 1 — same-domain clustering** (a soft cohesion objective that actively packs a voltage domain into a compact zone), and
- **Phase 3 (auto) — derived-tap detection** that auto-populates `exempt_pairs` (the mechanism existed but was never wired; `hv_exempt` was hardcoded `None`).

## Changes

- **`placement/cost.py`**: new `compute_domain_cohesion(placements, ref_domains, footprint_sizes=None)` — a radius-of-gyration-style per-domain spread penalty (centroid of each domain's members, summed member-to-centroid distances; singletons/domain-less contribute 0). Added `cohesion_weight` (default `1.0`) to `PlacementCostConfig`, `cohesion` to `CostBreakdown`, computed in `evaluate_placement` whenever `ref_domains` is supplied (independent of the required table). It is a **soft** term: added to `_weighted_sum_score` and the **feasible** branch of `_lexicographic_score`, and deliberately **excluded** from `is_feasible` and the infeasible offset branch.
- **`placement/hv_domains.py`**: new `detect_derived_tap_exempt_pairs(nets, ref_domains, voltage_map, *, hv_threshold=30.0) -> (exempt_pairs, advisories)`. An LV net sharing a bridging divider ref with an HV net (and `|V_t| < |V_h|`) is a derived tap; its cross-domain `(tap-ref, HV-ref)` pairs are exempted; one advisory per detected tap. Reuses `--hv-threshold` (no new knob).
- **`cli/optimize_placement_cmd.py`**: replaced the hardcoded `hv_exempt = None` with the detector result (voltage-map path only; the `--hv-domains` declaration path has no per-net data, so it stays empty), prints the guard advisory under `if not quiet`, and extended `_parse_weights` with a `cohesion` key.
- **`cli/parser.py`**: documented the `cohesion` key in `--weights` help.
- **`docs/placement-scoring.md`**: documented the cohesion term; upgraded the guarded-sense-tap note to auto-detection.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Cohesion term clusters same-domain refs; 0 for singletons/empty | ✅ | `TestComputeDomainCohesion` (monotonic in spread; 0 for empty/None/singleton/all-singleton) |
| Cohesion is soft, not a feasibility gate | ✅ | `test_high_cohesion_keeps_feasible` (huge spread stays `is_feasible=True`) |
| Cohesion enters feasible score path only | ✅ | `test_cohesion_enters_feasible_branch_only` + `test_cohesion_absent_from_infeasible_branch` (1e9 weight never leaks) |
| `--weights '{"cohesion": …}'` overrides | ✅ | `TestParseWeights::test_cohesion_override`; `test_weighted_sum_includes_cohesion` |
| Byte-identical when no HV input | ✅ | existing `test_no_domain_input_is_byte_identical` still green; `test_no_input_prints_no_hv_or_tap_output` |
| Derived-tap detection populates `exempt_pairs` + advisory | ✅ | `test_detects_tap_and_returns_cross_domain_pairs` |
| Auto-exempt wired through CLI | ✅ | `test_detected_exempt_pairs_threaded_into_evaluate` (spies the threaded `_evaluate` kwarg) |
| Exemption scoped (parent only, not unrelated HV) | ✅ | `test_unrelated_hv_net_is_not_exempted_against_tap`; `test_bridging_ref_does_not_self_exempt` |
| Advisory surfaced unless `--quiet` | ✅ | `test_advisory_printed_and_suppressed_by_quiet` |
| `--hv-domains` path leaves exempt empty | ✅ | `test_hv_domains_declaration_leaves_exempt_empty` |
| docs updated | ✅ | cohesion subsection + auto-detection rewrite in `docs/placement-scoring.md` |

## Test Plan

- `pytest tests/test_placement_cost.py tests/test_placement_hv_domains.py tests/test_optimize_placement_cmd.py` — **125 passed** (cmaes extra installed so the CLI module runs, not skipped).
- Placement regression: `test_placement_strategy.py test_placement_seed.py test_placement_force_engine.py` — 58 passed, 11 skipped.
- `ruff check` + `ruff format --check` clean on all touched files.
- mypy: `scripts/ci/check_mypy_baseline.py` exits 0 — no new type errors over the committed baseline (the one "no longer occurs" warning is the env-specific native `router_cpp` import line, present because the C++ backend is built locally; baseline intentionally left untouched).

Closes #4373