### PR TITLE
docs(site): add 0.19.0 capabilities section and milestone markers

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -29,6 +29,10 @@ parts, cost). Badges follow the data contract's omit-when-absent rule — a badg
 appears only when its backing field is present. Cards link to `/<slug>`, the
 per-board detail route (issue #3681; that route 404s until it lands).
 
+The index also carries a static release-capabilities section (with a version
+badge) and a footer milestone marker; keep both in sync with the current
+release at each milestone.
+
 ## Board detail pages
 
 Each board also has a per-board detail page at the static route `/<slug>`

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -40,6 +40,8 @@ const year = new Date().getFullYear();
     <a href={commitUrl} target="_blank" rel="noopener noreferrer">
       <code>{sha}</code>
     </a>
+    <span class="sep" aria-hidden="true">·</span>
+    Milestone: <code>v0.19.0</code>
   </p>
   <p class="line">© {year} Robb Walters / kicad-tools contributors</p>
   <p class="line disclaimer">

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -40,7 +40,7 @@ const hasPcbFor = (slug: string): boolean =>
     <title>kicad-tools demo gallery</title>
     <meta
       name="description"
-      content="A gallery of PCB designs produced end-to-end by kicad-tools' automated agent pipeline."
+      content="A gallery of PCB designs produced end-to-end by kicad-tools' automated agent pipeline, with design-verification and HV-isolation capabilities (v0.19.0)."
     />
   </head>
   <body>
@@ -49,7 +49,8 @@ const hasPcbFor = (slug: string): boolean =>
       <header class="page-header">
         <h1>kicad-tools demo gallery</h1>
         <p class="tagline">
-          PCB designs produced end-to-end by the kicad-tools automated pipeline.
+          PCB designs produced end-to-end by the kicad-tools automated
+          pipeline — with design-verification and HV-isolation capabilities.
         </p>
         <p class="count">
           {boards.length} board{boards.length === 1 ? "" : "s"}
@@ -63,6 +64,47 @@ const hasPcbFor = (slug: string): boolean =>
           <code>uv run kct board-metrics --all</code> to populate data.
         </p>
       )}
+
+      <section class="capabilities">
+        <div class="capabilities-head">
+          <h2>Capabilities</h2>
+          <span class="version-badge">v0.19.0</span>
+        </div>
+        <p class="section-copy">
+          Beyond placement and routing, the 0.19.0 pipeline adds a
+          high-voltage isolation design loop and electrical-rating checks that
+          run against real KiCad designs.
+        </p>
+        <ul class="capability-list" role="list">
+          <li>
+            <strong>HV-isolation design loop</strong> —
+            <code>kct creepage --voltage-map</code>,
+            <code>kct zones hv-keepout</code>, HV-aware
+            <code>optimize-placement</code>, and the
+            <code>/kct:hv-isolation-loop</code> skill.
+          </li>
+          <li>
+            <strong>Electrical-rating analysis</strong> —
+            <code>kct analyze electrical-rating</code> flags LED overcurrent
+            and capacitor voltage-derating violations.
+          </li>
+          <li>
+            <strong>Design-rule constraint export</strong> —
+            <code>kct check --emit-dru</code> /
+            <code>--emit-drc-constraints</code> emit KiCad design-rule and DRC
+            constraint files.
+          </li>
+          <li>
+            <strong>Smarter via repair</strong> —
+            <code>kct fix-vias</code> relocates off-pad vias and repairs
+            through-hole hole-to-hole clearance.
+          </li>
+          <li>
+            <strong>KiCad-10 format-stamp centralization</strong> — a
+            single-source format stamp guarded by DRC and round-trip tests.
+          </li>
+        </ul>
+      </section>
 
       {demoBoards.length > 0 && (
         <section class="board-section">
@@ -164,6 +206,64 @@ const hasPcbFor = (slug: string): boolean =>
     margin: 0.5rem 0 0;
     color: var(--muted);
     font-size: 0.85rem;
+  }
+
+  .capabilities {
+    margin-top: 2.5rem;
+    padding: 1.5rem;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--card-bg);
+  }
+
+  .capabilities-head {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    margin: 0 0 0.3rem;
+  }
+
+  .capabilities-head h2 {
+    margin: 0;
+    font-size: 1.3rem;
+  }
+
+  .version-badge {
+    display: inline-block;
+    padding: 0.1rem 0.5rem;
+    border: 1px solid var(--accent);
+    border-radius: 999px;
+    color: var(--accent);
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+  }
+
+  .capability-list {
+    list-style: none;
+    margin: 1rem 0 0;
+    padding: 0;
+    display: grid;
+    gap: 0.75rem;
+    max-width: 80ch;
+  }
+
+  .capability-list li {
+    color: var(--muted);
+    font-size: 0.92rem;
+  }
+
+  .capability-list strong {
+    color: var(--text);
+    font-weight: 600;
+  }
+
+  .capability-list code {
+    background: var(--badge-bg);
+    padding: 0.05rem 0.3rem;
+    border-radius: 4px;
+    font-size: 0.85em;
+    color: var(--text);
   }
 
   .board-section {


### PR DESCRIPTION
## Summary

Refreshes the kicad-tools.org demo gallery front page for the v0.19.0 milestone. The site source lives in-repo under `site/` (Astro). Previously the front page carried only a generic tagline and a board grid with no capabilities section and no version reference anywhere. This PR surfaces the 0.19.0 feature set as an additive, content-only change — the data-driven board gallery is untouched.

**Redeploy of kicad-tools.org is a manual/operator step performed outside this repo.** No CI workflow builds or deploys `site/`, so this PR delivers the in-repo content change only; publishing to Cloudflare Pages via `./scripts/deploy-site.sh` remains a separate operator action.

## Changes

- `site/src/pages/index.astro`: added a static "Capabilities" section (with a `v0.19.0` version badge) listing the five 0.19.0 feature groups; refreshed the `.tagline` and `<meta name="description">` to mention design-verification / HV-isolation capabilities; added scoped `<style>` rules reusing the existing CSS custom properties and `.section-copy` pattern.
- `site/src/components/Footer.astro`: added a static `Milestone: v0.19.0` marker beside the build-SHA line.
- `site/README.md`: one-line note that the index carries a release-capabilities section + footer milestone marker to keep in sync at milestones.

No changes to `loadBoards.ts`, `types.ts`, the copy-renders script, or any `.github/workflows/`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Capabilities section lists the five 0.19.0 feature groups | ✅ | New `<section class="capabilities">` with HV-isolation loop, `analyze electrical-rating`, `check --emit-dru/--emit-drc-constraints`, `fix-vias` off-pad + THT hole-to-hole, KiCad-10 format-stamp centralization |
| Tagline + meta description refreshed | ✅ | Both now reference design-verification / HV-isolation capabilities |
| "0.19.0" marker visible on front page or footer | ✅ | Version badge in the section header AND a footer milestone line |
| No board-gallery data contract violated | ✅ | No `board.json` entries or placeholder cards added; `no_artifacts` behavior unchanged; build passes with zero board.json files |
| Trademark-safe, consistent with footer disclaimer | ✅ | Copy makes no KiCad affiliation claim; existing disclaimer untouched |
| PR notes redeploy is a manual operator step | ✅ | See Summary above |

## Test Plan

Run from `site/`:
- `npm run build` → succeeded; 9 pages built (with zero committed `board.json` files, satisfying the fresh-checkout guarantee).
- `npm run check` → 0 errors, 0 warnings (98 pre-existing hints in `public/vendor/kicanvas.js` and `[slug].astro`, unrelated to this change).
- `npm test` → 28 tests passed (2 files); loader tests remain green (no loader/types changes).

Closes #4398