### PR TITLE
fix: delegate placement voltage-map loader to shared creepage parser

### DIFF
--- a/src/kicad_tools/placement/hv_domains.py
+++ b/src/kicad_tools/placement/hv_domains.py
@@ -45,24 +45,32 @@ import json
 from pathlib import Path
 from typing import Mapping, Sequence
 
+from kicad_tools.creepage.engine import voltage_map_from_dict
 from kicad_tools.creepage.standards import get_standard
 
 
 def load_voltage_map(path: str | Path) -> dict[str, float]:
     """Load a ``{net_name: volts}`` voltage map from a JSON file.
 
+    Delegates parsing to :func:`kicad_tools.creepage.engine.voltage_map_from_dict`
+    so the placement ``--voltage-map`` loader honors the exact same parse
+    contract as ``kct creepage --voltage-map`` (the two consumers of the shared
+    sidecar, #4404). That contract skips ``_``-prefixed reserved keys
+    (``_comment`` and friends are documentation) and interprets ``_edge_voltage``
+    as the board-edge reference potential. Placement derives per-ref domains from
+    net magnitudes and has no concept of an edge/earth reference, so the
+    ``edge_voltage`` half of the returned pair is discarded here.
+
     Raises:
-        ValueError: If the file is not a JSON object of ``str -> number``.
+        ValueError: If the file is not a JSON object, or if any net voltage is
+            not a finite real number.
     """
     raw = json.loads(Path(path).read_text())
     if not isinstance(raw, dict):
+        # ``voltage_map_from_dict`` raises ``TypeError`` for a non-dict; keep the
+        # historical ``ValueError`` contract for the placement loader's callers.
         raise ValueError(f"voltage map must be a JSON object, got {type(raw).__name__}")
-    out: dict[str, float] = {}
-    for net, volts in raw.items():
-        if not isinstance(volts, (int, float)) or isinstance(volts, bool):
-            raise ValueError(f"voltage for net {net!r} must be a number, got {volts!r}")
-        out[str(net)] = float(volts)
-    return out
+    return voltage_map_from_dict(raw)[0]
 
 
 def load_hv_domains(path: str | Path) -> dict[str, dict]:

--- a/tests/test_placement_hv_domains.py
+++ b/tests/test_placement_hv_domains.py
@@ -121,6 +121,44 @@ class TestLoaders:
         with pytest.raises(ValueError):
             load_voltage_map(p)
 
+    def test_load_voltage_map_skips_reserved_keys(self, tmp_path) -> None:
+        """`_`-prefixed keys are metadata: `_comment` is dropped, `_edge_voltage`
+        is consumed, and neither leaks into the returned net voltage map (#4404).
+
+        This is the shared-sidecar contract already honored by
+        ``kct creepage --voltage-map`` (``voltage_map_from_dict``); the placement
+        loader now delegates to it so the same file is accepted by both
+        consumers.
+        """
+        p = tmp_path / "v.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "_comment": "softstart rev-C per-net working-voltage map",
+                    "_edge_voltage": 0,
+                    "/AC_LINE": 150,
+                    "/REF": 1.65,
+                }
+            )
+        )
+        result = load_voltage_map(p)
+        assert result == {"/AC_LINE": 150.0, "/REF": 1.65}
+        assert "_comment" not in result
+        assert "_edge_voltage" not in result
+
+    def test_load_voltage_map_only_reserved_keys_is_empty(self, tmp_path) -> None:
+        """A map of only reserved keys yields an empty net map, not an error."""
+        p = tmp_path / "v.json"
+        p.write_text(json.dumps({"_comment": "note", "_edge_voltage": 12.0}))
+        assert load_voltage_map(p) == {}
+
+    def test_load_voltage_map_rejects_non_dict(self, tmp_path) -> None:
+        """A non-dict top-level JSON still raises a clear ``ValueError``."""
+        p = tmp_path / "v.json"
+        p.write_text(json.dumps([150, 1.65]))
+        with pytest.raises(ValueError):
+            load_voltage_map(p)
+
     def test_load_hv_domains(self, tmp_path) -> None:
         p = tmp_path / "d.json"
         p.write_text(json.dumps({"mains": {"refs": ["J1"], "voltage": 150}}))


### PR DESCRIPTION
## Summary

The voltage-map sidecar is a shared contract: one `{net_name: volts}` JSON file feeds both `kct creepage --voltage-map` and `kct optimize-placement --voltage-map`. The documented convention is that `_`-prefixed keys are metadata (`_edge_voltage` is meaningful; `_comment` and other `_`-keys are ignored). Only the creepage loader honored it — the placement loader coerced every key to a float and raised on `_comment`, breaking the "one file, two consumers" guarantee.

This makes the placement loader delegate to the creepage loader (`voltage_map_from_dict`) so there is a single source of truth for the parse contract.

## Changes

- `src/kicad_tools/placement/hv_domains.py`: rewrite `load_voltage_map` to `json.loads` the file and return `voltage_map_from_dict(raw)[0]`, discarding the `edge_voltage` element (placement has no edge/earth reference). This inherits the `_`-prefix skip, `_edge_voltage` handling, bool-rejection and finite-number checks. A top-level `isinstance(raw, dict)` guard preserves the historical `ValueError` (rather than the delegate's `TypeError`) for non-dict JSON.
- `tests/test_placement_hv_domains.py`: add `test_load_voltage_map_skips_reserved_keys`, `test_load_voltage_map_only_reserved_keys_is_empty`, and `test_load_voltage_map_rejects_non_dict`. Existing `rejects_non_numeric`/`rejects_bool` tests match on exception type (`ValueError`) and remain green unchanged.

`optimize_placement_cmd.py` (calls `load_voltage_map`) is untouched and transparently inherits the fix.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `_comment` / `_`-prefixed keys accepted and dropped | ✅ | `test_load_voltage_map_skips_reserved_keys` + manual CLI check |
| `_edge_voltage` not surfaced as a net | ✅ | asserted absent from result; delegate consumes it |
| Same sidecar accepted by both consumers | ✅ | manual: both `load_voltage_map` and `voltage_map_from_dict` return `{'/AC_LINE': 150.0, '/REF': 1.65}` for the shared file |
| Non-numeric/bool still raise; non-dict raises clearly | ✅ | `rejects_non_numeric`, `rejects_bool`, `rejects_non_dict` |
| Single shared parse implementation | ✅ | placement delegates to `voltage_map_from_dict` |

## Test Plan

- `uv run pytest tests/test_placement_hv_domains.py tests/creepage/test_creepage_engine.py` → 91 passed
- `uv run ruff check src/ tests/...` and `ruff format --check` → clean
- `uv run python scripts/ci/check_mypy_baseline.py` → no new type errors (all within baseline)
- Manual: a sidecar with `{"_comment", "_edge_voltage", "/AC_LINE", "/REF"}` is now accepted by the placement loader (no temp-copy stripping) and yields identical net voltages to the creepage loader.

Closes #4404