### PR TITLE
fix(lcsc): coerce explicit-null API list so no-match search returns empty

### DIFF
--- a/src/kicad_tools/cost/suggest.py
+++ b/src/kicad_tools/cost/suggest.py
@@ -557,7 +557,7 @@ class PartSuggester:
 
             # Filter and rank results
             candidates = []
-            for part in results.parts:
+            for part in results.parts or []:
                 # Skip parts with insufficient stock
                 if part.stock < self.min_stock:
                     continue

--- a/src/kicad_tools/parts/lcsc.py
+++ b/src/kicad_tools/parts/lcsc.py
@@ -783,9 +783,16 @@ class LCSCClient:
             logger.warning(f"Search API returned error: {message}")
             return SearchResult(query=query)
 
-        result_data = data.get("data", {})
-        components = result_data.get("componentPageInfo", {}).get("list", [])
-        total = result_data.get("componentPageInfo", {}).get("total", 0)
+        result_data = data.get("data") or {}
+        # The live JLCPCB API returns the keys present but explicitly null for a
+        # no-match query (e.g. "componentPageInfo": {"list": null, "total": 0}).
+        # dict.get(key, default) only substitutes the default when the key is
+        # ABSENT, not when it is present-but-null, so use `... or {}` / `... or []`
+        # to coerce explicit null. A genuine no-match then flows through the
+        # existing unmatched path instead of raising 'NoneType' is not iterable.
+        page_info = result_data.get("componentPageInfo") or {}
+        components = page_info.get("list") or []
+        total = page_info.get("total") or 0
 
         parts = []
         for comp in components:

--- a/tests/test_bom_enrich.py
+++ b/tests/test_bom_enrich.py
@@ -160,6 +160,60 @@ class TestEnrichBomLcsc:
         assert len(report.unmatched_entries) == 1
         assert report.unmatched_entries[0].value == "STM32C011F4P6"
 
+    @patch("kicad_tools.cost.suggest.PartSuggester._get_client")
+    @patch("kicad_tools.parts.lcsc.LCSCClient._get_session")
+    def test_null_list_yields_clean_unmatched_reason(self, mock_session, mock_get_client):
+        """A no-match query (API ``"list": null``) reports a clean reason.
+
+        End-to-end regression for #4407: previously the null candidate list
+        raised ``TypeError: 'NoneType' object is not iterable`` inside
+        ``LCSCClient.search()``; that TypeError was swallowed by
+        ``suggest_for_component``'s broad ``except`` and stored verbatim as the
+        per-part reason, so ``summary_lines()`` printed
+        ``... (J1) ('NoneType' object is not iterable)``. With the parse-site
+        guard the query flows through the normal unmatched path and reports the
+        user-facing ``"no matching parts found"`` reason instead.
+        """
+        from kicad_tools.parts import LCSCClient
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "code": 200,
+            "data": {"componentPageInfo": {"list": None, "total": 0}},
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_session.return_value.post.return_value = mock_resp
+
+        # Real client (no cache / no offline catalog / no rate limit) so the
+        # real search() + parse path runs against the mocked null response.
+        client = LCSCClient(use_cache=False, use_local_catalog=False, rate_limit=0)
+        mock_get_client.return_value = client
+
+        items = [
+            _make_item(
+                "J1",
+                "PinHeader_1x02",
+                "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical",
+            ),
+        ]
+
+        report = enrich_bom_lcsc(items)
+
+        # The live search was actually exercised (not short-circuited).
+        assert mock_session.return_value.post.called
+
+        # Clean unmatched outcome, no leaked exception.
+        assert items[0].lcsc == ""
+        assert report.unmatched == 1
+        entry = report.unmatched_entries[0]
+        assert entry.source == "unmatched"
+        assert entry.error == "no matching parts found"
+
+        # The raw exception string must never reach user-facing output.
+        summary = "\n".join(report.summary_lines())
+        assert "not iterable" not in summary
+        assert "no matching parts found" in summary
+
     @patch("kicad_tools.export.bom_enrich.PartSuggester")
     def test_skips_dnp_items(self, MockSuggester):
         """DNP items are not searched."""

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -868,6 +868,60 @@ class TestLCSCClientExtended:
             assert payload["currentPage"] == 2
             assert payload["pageSize"] == 50
 
+    def test_search_null_list_returns_empty(self, tmp_path):
+        """A no-match query where the API returns ``"list": null`` must not raise.
+
+        Regression for #4407: the live JLCPCB API returns the
+        ``componentPageInfo`` keys present but explicitly null for a generic
+        no-match query (e.g. a ``PinHeader_1x02`` connector). ``dict.get(key,
+        default)`` only substitutes the default when the key is *absent*, so
+        the old parser set ``components = None`` and ``for comp in components``
+        raised ``TypeError: 'NoneType' object is not iterable``. That leaked
+        verbatim into the BOM-enrichment "reason" field.
+        """
+        with patch("kicad_tools.parts.lcsc.LCSCClient._get_session") as mock_session:
+            mock_resp = MagicMock()
+            mock_resp.json.return_value = {
+                "code": 200,
+                "data": {"componentPageInfo": {"list": None, "total": 0}},
+            }
+            mock_resp.raise_for_status = MagicMock()
+            mock_session.return_value.post.return_value = mock_resp
+
+            from kicad_tools.parts import LCSCClient
+
+            client = LCSCClient(use_cache=False, use_local_catalog=False)
+
+            result = client.search("PinHeader_1x02")
+
+            assert result.parts == []
+            assert result.total_count == 0
+
+    def test_search_null_component_page_info_returns_empty(self, tmp_path):
+        """``componentPageInfo: null`` must also coerce to an empty result.
+
+        Regression for #4407: guarding only the inner ``list`` key would still
+        raise ``AttributeError`` on ``None.get("list")`` if the whole
+        ``componentPageInfo`` object comes back null.
+        """
+        with patch("kicad_tools.parts.lcsc.LCSCClient._get_session") as mock_session:
+            mock_resp = MagicMock()
+            mock_resp.json.return_value = {
+                "code": 200,
+                "data": {"componentPageInfo": None},
+            }
+            mock_resp.raise_for_status = MagicMock()
+            mock_session.return_value.post.return_value = mock_resp
+
+            from kicad_tools.parts import LCSCClient
+
+            client = LCSCClient(use_cache=False, use_local_catalog=False)
+
+            result = client.search("PinHeader_1x02")
+
+            assert result.parts == []
+            assert result.total_count == 0
+
     def test_context_manager(self, tmp_path):
         """Test LCSCClient as context manager."""
         from kicad_tools.parts import LCSCClient, PartsCache


### PR DESCRIPTION
## Summary

The BOM/LCSC enrichment step leaked a raw `TypeError: 'NoneType' object is not iterable` into the user-facing per-part reason (`... (J1) ('NoneType' object is not iterable)`) instead of a clean no-match message.

Root cause: `LCSCClient.search()` parsed the live JLCPCB response with `dict.get("list", [])`, which only substitutes the default when the key is **absent**. For a generic no-match query the API returns the key present but explicitly null (`"list": null`), so `components` became `None` and `for comp in components` raised. That TypeError was swallowed by `PartSuggester.suggest_for_component`'s broad `except` and stored verbatim as `suggestion.error`, then surfaced by `EnrichmentReport.summary_lines()`.

## Changes

- `src/kicad_tools/parts/lcsc.py` — coerce `componentPageInfo` / `list` / `total` against explicit null at the search-response parse site (`... or {}` / `... or []`). Also guards `componentPageInfo: null`, which would otherwise raise `AttributeError` on `.get`. A genuine no-match now flows through the existing unmatched path (`"no matching parts found"`).
- `src/kicad_tools/cost/suggest.py` — defensive `for part in results.parts or []` so any future null-parts source can't re-trigger the leak. No change to `except` semantics — a null list is a normal no-match, not an error.
- `tests/test_parts.py` — regression tests: `search()` with `"list": null` and with `componentPageInfo: null` returns an empty `SearchResult` without raising.
- `tests/test_bom_enrich.py` — end-to-end regression: a no-candidate group (real `PartSuggester` + real `search()` over a mocked null response) yields `source="unmatched"` with reason `"no matching parts found"`; asserts `"not iterable"` never appears in `summary_lines()`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `search()` returns empty `SearchResult` (no raise) on `"list": null` and `componentPageInfo: null` | ✅ | `test_search_null_list_returns_empty`, `test_search_null_component_page_info_returns_empty` |
| `enrich_bom_lcsc` reports no-candidate as `source="unmatched"` with clean reason, never a raw exception | ✅ | `test_null_list_yields_clean_unmatched_reason` asserts reason `"no matching parts found"` and no `"not iterable"` in `summary_lines()` |
| Board 01 (J1 `PinHeader_1x02`) summary shows clean no-match, not `('NoneType' object is not iterable)` | ✅ | Reproduced exactly in the enrich test; reverting the fix makes all 3 tests fail with the leaked message |
| `except` semantics unchanged (null list is a normal no-match, not relabeled) | ✅ | Only the parse site + defensive iteration guard changed |

## Test Plan

- `uv run pytest tests/test_parts.py tests/test_bom_enrich.py` → 132 passed.
- Verified genuine regression coverage: temporarily reverting the parse-site guard makes all 3 new tests fail, reproducing `Search failed for J1: 'NoneType' object is not iterable`.
- `uv run ruff check` / `ruff format --check` on all 4 files clean.
- mypy baseline gate (`scripts/ci/check_mypy_baseline.py`) exits 0: no new type errors (the 4 mypy findings in the touched files are pre-existing baseline debt on unrelated lines).

Closes #4407