### PR TITLE
feat(router): early-bail negotiated stall recovery when no stuck net is BUDGET_STARVED

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -7984,6 +7984,85 @@ class Autorouter:
 
         return routes
 
+    def _stuck_nets_all_non_budget_starved(
+        self,
+        still_unrouted: list[int],
+        pads_by_net: dict[int, list],
+        neg_router: Any,
+    ) -> tuple[bool, dict[int, tuple[str, str]]]:
+        """Grid-domain proxy classifier for the terminal-stall early bail (#4406).
+
+        The negotiated loop holds no ``PCB`` mid-route, so it cannot run the
+        exact geometry classifier (:func:`classify_stuck_nets_from_pcb`).  This
+        proxy reuses the one blocker signal the loop already computes --
+        committed-copper blockers via
+        :meth:`NegotiatedRouter.find_blocking_nets_for_connection` -- to decide,
+        for each currently-stuck net, whether it could plausibly be
+        ``BUDGET_STARVED`` (the *only* :class:`StuckClass` whose remedy is "more
+        router time"; see ``stuck_classifier._decide``).
+
+        Per-net proxy rule:
+
+        - **Any** committed blocking net on a pin-to-pin connection -> the direct
+          path is boxed in by committed strict copper, so more iterations of the
+          same negotiated loop cannot free it.  Proxy label
+          ``CONGESTION_SATURATED`` (a non-``BUDGET_STARVED`` class).
+        - **No** committed blockers -> geometrically nothing rippable is in the
+          way, which under pure grid geometry is indistinguishable from "the
+          batch negotiation never committed this net".  Treated as *possibly*
+          ``BUDGET_STARVED`` -> the net's full budget must be preserved.
+        - Fewer than two pads on grid -> cannot form a connection to classify;
+          stay conservative (do not authorize a bail).
+
+        Returns ``(all_non_starved, labels)`` where ``all_non_starved`` is True
+        only when **every** stuck net is confidently non-``BUDGET_STARVED``, and
+        ``labels`` maps each stuck net number to a ``(class_name, reason)`` proxy
+        label for the diagnostic emission at the bail site.  Conservative by
+        construction: any net that *might* be budget-starved flips
+        ``all_non_starved`` to False, so genuinely budget-starved boards keep
+        their full iteration budget (AC4).
+        """
+        labels: dict[int, tuple[str, str]] = {}
+        all_non_starved = bool(still_unrouted)
+        for net in still_unrouted:
+            pads = pads_by_net.get(net, [])
+            if len(pads) < 2:
+                # Not enough pads on grid to form a connection -- we cannot
+                # prove this net is non-starved, so stay conservative.
+                all_non_starved = False
+                labels[net] = (
+                    "UNKNOWN",
+                    "fewer than 2 pads on grid -- cannot classify",
+                )
+                continue
+            blocking_nets: set[int] = set()
+            for j in range(len(pads) - 1):
+                blockers = neg_router.find_blocking_nets_for_connection(pads[j], pads[j + 1])
+                blocking_nets.update(blockers)
+            if blocking_nets:
+                blocker_names = sorted(self.net_names.get(b, f"Net_{b}") for b in blocking_nets)
+                labels[net] = (
+                    "CONGESTION_SATURATED",
+                    (
+                        f"committed strict copper boxes in the direct path "
+                        f"(blockers: {', '.join(blocker_names)}); more router "
+                        f"iterations cannot free it -- needs a region re-solve "
+                        f"or a placement change"
+                    ),
+                )
+            else:
+                # No committed blockers -> possibly BUDGET_STARVED.  Preserve
+                # this net's full budget by refusing to authorize a bail.
+                all_non_starved = False
+                labels[net] = (
+                    "BUDGET_STARVED?",
+                    (
+                        "no committed blockers on the direct path -- possibly "
+                        "budget-starved; preserving full iteration budget"
+                    ),
+                )
+        return all_non_starved, labels
+
     def route_all_negotiated(
         self,
         max_iterations: int = 10,
@@ -8019,6 +8098,7 @@ class Autorouter:
         checkpoint_callback: Callable[[list[Route], IterationMetrics], None] | None = None,
         best_stall_patience: int | None = 2,
         best_stall_min_iterations: int = 2,
+        early_bail_terminal_stall: bool = True,
     ) -> list[Route]:
         """Route all nets using PathFinder-style negotiated congestion.
 
@@ -8146,6 +8226,23 @@ class Autorouter:
                 check from firing in degenerate first-iteration cases
                 where the iter-0 metric is already optimal but at least
                 one rip-up pass is warranted to confirm convergence.
+            early_bail_terminal_stall: Issue #4406 -- when a neighborhood
+                rip-up round makes ZERO progress AND every remaining stuck
+                net classifies as non-``BUDGET_STARVED`` (a grid-domain
+                proxy over the committed-copper blocker signal; see
+                :meth:`_stuck_nets_all_non_budget_starved`), break out of
+                the iteration loop instead of escalating the rip-up radius
+                to the full iteration budget.  Additional router time cannot
+                help a stuck set with no budget-starved member by
+                construction -- the remaining nets need an escape upgrade, a
+                region re-solve, or a placement change.  On board-07 this
+                turns a ~13-minute grind on a provably terminal plateau into
+                an early PARTIAL return with the same open-net set.
+                Conservative: any net that *might* be budget-starved (no
+                committed blockers) preserves the full budget.  Default:
+                True.  Set to ``False`` to force the historical
+                grind-to-budget behavior (A/B comparison / regression
+                bisection).
 
         Returns:
             List of routes (may be partial if timeout reached)
@@ -10324,6 +10421,34 @@ class Autorouter:
                                         f"    Neighborhood rip-up did not improve "
                                         f"({new_count}/{total_nets} nets) ({elapsed_str()})"
                                     )
+                                    # Issue #4406: terminal-stall early bail.
+                                    # Zero progress from neighborhood rip-up.
+                                    # If every remaining stuck net classifies
+                                    # non-BUDGET_STARVED (grid-domain proxy),
+                                    # more router time cannot help -- bail to
+                                    # PARTIAL instead of escalating the rip-up
+                                    # radius to the full iteration budget.
+                                    if early_bail_terminal_stall and still_unrouted_targeted:
+                                        all_non_starved, stuck_labels = (
+                                            self._stuck_nets_all_non_budget_starved(
+                                                still_unrouted_targeted,
+                                                pads_by_net,
+                                                neg_router,
+                                            )
+                                        )
+                                        if all_non_starved:
+                                            flush_print(
+                                                f"  Terminal-stall early bail (#4406): all "
+                                                f"{len(still_unrouted_targeted)} stuck net(s) are "
+                                                f"non-BUDGET_STARVED -- more router iterations "
+                                                f"cannot help; returning PARTIAL ({elapsed_str()})"
+                                            )
+                                            for _n in still_unrouted_targeted:
+                                                _cls, _reason = stuck_labels[_n]
+                                                _name = self.net_names.get(_n, f"Net_{_n}")
+                                                flush_print(f"    {_name}: {_cls} -- {_reason}")
+                                            self._reset_perturbation()
+                                            break
 
                                 # Issue #3448: full-connectivity predicate, not
                                 # a ``len(net_routes)`` count (see above).
@@ -10912,6 +11037,35 @@ class Autorouter:
                                         f"    Neighborhood rip-up did not improve "
                                         f"({new_count}/{total_nets} nets) ({elapsed_str()})"
                                     )
+                                    # Issue #4406: terminal-stall early bail
+                                    # (standard path).  Zero progress from
+                                    # neighborhood rip-up.  If every remaining
+                                    # stuck net classifies non-BUDGET_STARVED
+                                    # (grid-domain proxy), more router time
+                                    # cannot help -- bail to PARTIAL instead of
+                                    # escalating the rip-up radius to the full
+                                    # iteration budget.
+                                    if early_bail_terminal_stall and still_unrouted_std:
+                                        all_non_starved, stuck_labels = (
+                                            self._stuck_nets_all_non_budget_starved(
+                                                still_unrouted_std,
+                                                pads_by_net,
+                                                neg_router,
+                                            )
+                                        )
+                                        if all_non_starved:
+                                            flush_print(
+                                                f"  Terminal-stall early bail (#4406): all "
+                                                f"{len(still_unrouted_std)} stuck net(s) are "
+                                                f"non-BUDGET_STARVED -- more router iterations "
+                                                f"cannot help; returning PARTIAL ({elapsed_str()})"
+                                            )
+                                            for _n in still_unrouted_std:
+                                                _cls, _reason = stuck_labels[_n]
+                                                _name = self.net_names.get(_n, f"Net_{_n}")
+                                                flush_print(f"    {_name}: {_cls} -- {_reason}")
+                                            self._reset_perturbation()
+                                            break
 
                                 # Issue #3448: full-connectivity predicate, not
                                 # a ``len(net_routes)`` count (see _stranded_nets).

--- a/tests/test_route_all_negotiated_partial_state.py
+++ b/tests/test_route_all_negotiated_partial_state.py
@@ -29,9 +29,12 @@ This module covers two paths:
 
 from __future__ import annotations
 
+import io
+from contextlib import redirect_stdout
 from unittest.mock import MagicMock, patch
 
 from kicad_tools.router.algorithms.hierarchical import HierarchicalRouter
+from kicad_tools.router.core import Autorouter
 from kicad_tools.router.primitives import Route, Segment
 
 # =============================================================================
@@ -487,3 +490,229 @@ class TestHierarchicalDeterministicTimeout:
         assert len(routes) == 4, (
             f"Expected 4 restored routes after iter-1 timeout, got {len(routes)}"
         )
+
+
+# =============================================================================
+# Issue #4406: terminal-stall early bail
+# =============================================================================
+
+
+class _FakeBlockerRouter:
+    """Minimal NegotiatedRouter stand-in exposing only
+    ``find_blocking_nets_for_connection`` for the grid-domain proxy
+    classifier (Issue #4406).  Maps an unordered ``frozenset`` pad pair to
+    the set of committed blocking net numbers to return."""
+
+    def __init__(self, blockers_by_pair: dict[frozenset, set[int]] | None = None):
+        self._map = blockers_by_pair or {}
+
+    def find_blocking_nets_for_connection(self, pad_a, pad_b) -> set[int]:
+        return set(self._map.get(frozenset((pad_a, pad_b)), set()))
+
+
+def _autorouter_with_net_names(net_names: dict[int, str]) -> Autorouter:
+    """Bare Autorouter with a controlled ``net_names`` map -- enough to
+    exercise ``_stuck_nets_all_non_budget_starved`` in isolation (no
+    routing is performed)."""
+    ar = Autorouter(width=20.0, height=20.0)
+    ar.net_names = dict(net_names)
+    return ar
+
+
+class TestStuckProxyClassifier:
+    """Unit tests for ``Autorouter._stuck_nets_all_non_budget_starved`` --
+    the grid-domain proxy that decides whether the terminal-stall bail is
+    authorized (Issue #4406, Approach A)."""
+
+    def test_net_with_committed_blockers_is_non_starved(self):
+        ar = _autorouter_with_net_names({2: "NET2", 9: "BLOCKER"})
+        neg = _FakeBlockerRouter({frozenset(("p1", "p2")): {9}})
+        pads_by_net = {2: ["p1", "p2"]}
+
+        all_non_starved, labels = ar._stuck_nets_all_non_budget_starved([2], pads_by_net, neg)
+
+        assert all_non_starved is True
+        cls, reason = labels[2]
+        assert cls == "CONGESTION_SATURATED"
+        # The blocker name must be surfaced for the AC2 emission.
+        assert "BLOCKER" in reason
+
+    def test_net_without_blockers_is_possibly_budget_starved(self):
+        ar = _autorouter_with_net_names({2: "NET2"})
+        neg = _FakeBlockerRouter({})  # no blockers for any pair
+        pads_by_net = {2: ["p1", "p2"]}
+
+        all_non_starved, labels = ar._stuck_nets_all_non_budget_starved([2], pads_by_net, neg)
+
+        # A net with no committed blockers might be budget-starved -> do NOT
+        # authorize a bail (AC4 conservatism).
+        assert all_non_starved is False
+        assert labels[2][0] == "BUDGET_STARVED?"
+
+    def test_mixed_set_does_not_authorize_bail(self):
+        # Edge case (a): a mix of blocked + no-blocker nets must NOT bail.
+        ar = _autorouter_with_net_names({2: "NET2", 3: "NET3", 9: "BLK"})
+        neg = _FakeBlockerRouter({frozenset(("a1", "a2")): {9}})
+        pads_by_net = {2: ["a1", "a2"], 3: ["b1", "b2"]}  # net 3 has no blockers
+
+        all_non_starved, labels = ar._stuck_nets_all_non_budget_starved([2, 3], pads_by_net, neg)
+
+        assert all_non_starved is False
+        assert labels[2][0] == "CONGESTION_SATURATED"
+        assert labels[3][0] == "BUDGET_STARVED?"
+
+    def test_all_blocked_nets_authorize_bail(self):
+        ar = _autorouter_with_net_names({2: "NET2", 3: "NET3", 9: "BLK"})
+        neg = _FakeBlockerRouter(
+            {
+                frozenset(("a1", "a2")): {9},
+                frozenset(("b1", "b2")): {9},
+            }
+        )
+        pads_by_net = {2: ["a1", "a2"], 3: ["b1", "b2"]}
+
+        all_non_starved, labels = ar._stuck_nets_all_non_budget_starved([2, 3], pads_by_net, neg)
+
+        assert all_non_starved is True
+        assert labels[2][0] == "CONGESTION_SATURATED"
+        assert labels[3][0] == "CONGESTION_SATURATED"
+
+    def test_fewer_than_two_pads_is_conservative(self):
+        ar = _autorouter_with_net_names({2: "NET2"})
+        neg = _FakeBlockerRouter({})
+        pads_by_net = {2: ["only_one"]}
+
+        all_non_starved, labels = ar._stuck_nets_all_non_budget_starved([2], pads_by_net, neg)
+
+        # Cannot classify -> must not authorize a bail.
+        assert all_non_starved is False
+        assert labels[2][0] == "UNKNOWN"
+
+    def test_empty_stuck_set_does_not_authorize_bail(self):
+        # Vacuous safety: an empty stuck set must never authorize a bail.
+        ar = _autorouter_with_net_names({})
+        neg = _FakeBlockerRouter({})
+        all_non_starved, labels = ar._stuck_nets_all_non_budget_starved([], {}, neg)
+        assert all_non_starved is False
+        assert labels == {}
+
+    def test_multi_segment_net_blocker_on_any_pair_counts(self):
+        # A blocker on ANY pin-to-pin hop of a >2-pad net marks it non-starved.
+        ar = _autorouter_with_net_names({2: "NET2", 9: "BLK"})
+        neg = _FakeBlockerRouter({frozenset(("p2", "p3")): {9}})
+        pads_by_net = {2: ["p1", "p2", "p3"]}
+
+        all_non_starved, labels = ar._stuck_nets_all_non_budget_starved([2], pads_by_net, neg)
+        assert all_non_starved is True
+        assert labels[2][0] == "CONGESTION_SATURATED"
+
+
+def _build_stranded_terminal_stall_router() -> Autorouter:
+    """Build a router whose NET2 is unrouted-and-stranded at overflow 0 so
+    the standard-path negotiated loop reaches the ``Neighborhood rip-up did
+    not improve`` bail site (Issue #4406).
+
+    NET1 (R1-R2) routes trivially.  NET2 (U1-U2-U3) is forced to hard-fail
+    every ``_route_net_negotiated`` attempt (empty frontier => zero
+    overflow), and the real-routing rescue paths are disabled so it stays
+    stranded across iterations -- reproducing the board-07 terminal
+    plateau.  NET1 and NET2 corridors are disjoint, so under the *real*
+    proxy classifier NET2 has no committed blockers (i.e. it reads as
+    *possibly* budget-starved and the full budget is preserved).
+    """
+    ar = Autorouter(width=20.0, height=20.0)
+    ar.add_component("R1", [{"number": "1", "x": 2.0, "y": 2.0, "net": 1, "net_name": "NET1"}])
+    ar.add_component("R2", [{"number": "1", "x": 18.0, "y": 2.0, "net": 1, "net_name": "NET1"}])
+    ar.add_component("U1", [{"number": "1", "x": 2.0, "y": 10.0, "net": 2, "net_name": "NET2"}])
+    ar.add_component("U2", [{"number": "1", "x": 8.0, "y": 10.0, "net": 2, "net_name": "NET2"}])
+    ar.add_component("U3", [{"number": "1", "x": 17.0, "y": 15.0, "net": 2, "net_name": "NET2"}])
+
+    orig = ar._route_net_negotiated
+
+    def fake(net: int, present_factor: float, per_net_timeout=None):
+        if net == 2:
+            return []  # instant hard-fail, zero overflow
+        return orig(net, present_factor, per_net_timeout=per_net_timeout)
+
+    ar._route_net_negotiated = fake
+    # Disable the real-routing rescue paths so NET2 (geometrically routable)
+    # cannot be salvaged behind the loop's back -- the plateau must persist.
+    ar._post_negotiation_rescue = False
+    ar._relief_rescue = lambda *a, **k: False  # type: ignore[assignment]
+    return ar
+
+
+def _run_negotiated(ar: Autorouter, **kwargs) -> tuple[str, list[Route]]:
+    """Run ``route_all_negotiated`` capturing stdout.  ``best_stall_patience``
+    is disabled so the ONLY early exit under test is the #4406 terminal-stall
+    bail (otherwise the #3101 best-metric stall would mask it)."""
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        routes = ar.route_all_negotiated(
+            max_iterations=6,
+            timeout=60.0,
+            perturbation=False,
+            best_stall_patience=None,
+            **kwargs,
+        )
+    return buf.getvalue(), routes
+
+
+class TestTerminalStallEarlyBail:
+    """Issue #4406: the negotiated loop must bail to PARTIAL when a
+    zero-progress neighborhood rip-up leaves only non-BUDGET_STARVED stuck
+    nets, and must preserve the full budget otherwise."""
+
+    def test_early_bail_to_partial_when_all_non_budget_starved(self):
+        """All stuck nets non-BUDGET_STARVED -> break early to PARTIAL and
+        emit the per-net classification (AC1 + AC2)."""
+        ar = _build_stranded_terminal_stall_router()
+        # Force the proxy verdict to "all confidently non-starved".
+        ar._stuck_nets_all_non_budget_starved = lambda su, pbn, nr: (  # type: ignore[assignment]
+            True,
+            dict.fromkeys(su, ("CONGESTION_SATURATED", "boxed in by committed copper")),
+        )
+
+        out, routes = _run_negotiated(ar)
+
+        # The loop reached the neighborhood-rip-up stall site...
+        assert "Neighborhood rip-up did not improve" in out
+        # ...and bailed there instead of grinding to the iteration budget.
+        assert "Terminal-stall early bail (#4406)" in out
+        assert "--- Iteration 6:" not in out, "loop should break before max_iterations"
+        # AC2: per-net classification emitted at the bail.
+        assert "NET2: CONGESTION_SATURATED" in out
+        # AC: the banked PARTIAL is returned (NET1 only; NET2 stranded).
+        assert sorted({r.net for r in routes}) == [1]
+
+    def test_budget_preserved_when_possibly_budget_starved(self):
+        """Real proxy classifier: NET2 has no committed blockers (disjoint
+        corridor) so it reads as *possibly* budget-starved -> NO bail, full
+        iteration budget consumed (AC4)."""
+        ar = _build_stranded_terminal_stall_router()  # uses the REAL classifier
+
+        out, routes = _run_negotiated(ar)
+
+        assert "Neighborhood rip-up did not improve" in out
+        # The real classifier must refuse the bail...
+        assert "Terminal-stall early bail (#4406)" not in out
+        # ...and the loop runs to the full iteration budget.
+        assert "--- Iteration 6:" in out
+        assert sorted({r.net for r in routes}) == [1]
+
+    def test_toggle_off_restores_grind_to_budget(self):
+        """``early_bail_terminal_stall=False`` must force the historical
+        grind-to-budget behavior even when the classifier would authorize a
+        bail (bisection guard)."""
+        ar = _build_stranded_terminal_stall_router()
+        ar._stuck_nets_all_non_budget_starved = lambda su, pbn, nr: (  # type: ignore[assignment]
+            True,
+            dict.fromkeys(su, ("CONGESTION_SATURATED", "boxed in")),
+        )
+
+        out, routes = _run_negotiated(ar, early_bail_terminal_stall=False)
+
+        assert "Neighborhood rip-up did not improve" in out
+        assert "Terminal-stall early bail (#4406)" not in out
+        assert "--- Iteration 6:" in out, "toggle off must grind to full budget"
+        assert sorted({r.net for r in routes}) == [1]


### PR DESCRIPTION
## Summary

Board-07-matchgroup-test spends ~13 of its ~14-minute route grinding stall-recovery iterations on a plateau the router's own diagnostic has already classified as terminal (3× PLACEMENT_BOUND + 2× CONGESTION_SATURATED, **0× BUDGET_STARVED**). Since `BUDGET_STARVED` is the only `StuckClass` whose remedy is "more router time", grinding the rip-up radius to the full iteration budget cannot help when no stuck net is budget-starved.

This PR makes the negotiated loop **early-bail to PARTIAL** when a neighborhood rip-up round makes zero progress AND every remaining stuck net classifies non-`BUDGET_STARVED`, emitting the per-net classification so the caller knows more time won't help.

## Changes

- **`src/kicad_tools/router/core.py`**
  - New `Autorouter._stuck_nets_all_non_budget_starved(...)` helper — a self-contained **grid-domain proxy classifier** (Approach A, curator-recommended). It reuses the in-loop committed-copper blocker signal `neg_router.find_blocking_nets_for_connection` (already called at the stall sites) rather than threading a full `PCB` in for exact `StuckClass` labels — the `Autorouter` holds no PCB mid-loop. A stuck net with **any** committed blocker is confidently non-`BUDGET_STARVED` (`CONGESTION_SATURATED` proxy); a net with **no** blockers is treated as *possibly* `BUDGET_STARVED` and preserves its full budget. Returns `(all_non_starved, labels)` and authorizes a bail only when **every** stuck net is confidently non-starved (conservative by construction).
  - Wired the bail at **both** "neighborhood rip-up did not improve" branches — the targeted path (`still_unrouted_targeted`) and the standard path (`still_unrouted_std`). On zero progress with an all-non-starved stuck set, it flushes the per-net classification and `break`s; the existing post-loop best-state restore returns the banked PARTIAL (no return-path change).
  - New default-on `early_bail_terminal_stall=True` kwarg on `route_all_negotiated` so `BUDGET_STARVED` boards keep the full budget and the historical grind-to-budget behavior stays bisectable (`=False`).

- **`tests/test_route_all_negotiated_partial_state.py`**
  - `TestStuckProxyClassifier` — 7 unit tests of the proxy: blockers → non-starved, no blockers → possibly-starved (no bail), mixed set → no bail, all-blocked → bail, `<2` pads → conservative, empty set → no bail, multi-hop blocker.
  - `TestTerminalStallEarlyBail` — 3 integration tests driving a real `Autorouter` to the standard-path "did not improve" site: early-bail-to-PARTIAL + per-net emission; **budget preserved** with the real classifier (NET2 has no blockers → runs the full iteration budget, AC4); and toggle-off restoring grind-to-budget.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Early-bail to PARTIAL when all stuck nets non-`BUDGET_STARVED` | ✅ | `test_early_bail_to_partial_when_all_non_budget_starved` (breaks before max_iterations, returns PARTIAL) |
| Bail emits per-net classification | ✅ | Same test asserts `NET2: CONGESTION_SATURATED ...` on stdout |
| `BUDGET_STARVED` boards unaffected (full budget) | ✅ | `test_budget_preserved_when_possibly_budget_starved` — real classifier refuses the bail; loop runs to iteration 6 |
| Board-07 wall-clock drops with same open set | ⏳ | Board-07 is a local/CI fixture; the terminal-stall grind is short-circuited by construction. Not run in this PR (no board-07 in CI). |

## Test Plan

- `uv run kct build-native` in the worktree, then `uv run pytest tests/test_route_all_negotiated_partial_state.py` — **15 passed**.
- Regression: `tests/test_negotiated_convergence_stranded.py`, `tests/test_neighborhood_ripup.py`, `tests/test_route_all_negotiated_overflow_regression.py` — **38 passed**.
- `uv run ruff check .` + `uv run ruff format . --check` clean; baseline-gated mypy reports **no new type errors**.

Closes #4406