### PR TITLE
fix(router): scope auto-grid memory-cap clearance warning to fine-pitch boards

### DIFF
--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -1454,7 +1454,13 @@ def auto_select_grid_resolution(
                 f"backstop.",
                 stacklevel=2,
             )
-        else:
+        elif has_fine_pitch:
+            # Genuine #3911 risk: the memory cap coerced a grid > clearance/2
+            # AND the board carries fine-pitch pads whose inter-pad channel the
+            # coarse grid cannot honour (e.g. board 05's 0.5mm-pitch DRV8301).
+            # This is the sole memory-cap path that can actually short, so it
+            # keeps the alarming "may produce clearance violations" wording and
+            # mirrors ``memory_forced_unsafe_grid`` / the CLI hard-error gate.
             warnings.warn(
                 f"Auto-grid: memory budget cap forces grid {best_resolution}mm > "
                 f"clearance/2 ({recommended_max}mm) even at "
@@ -1463,6 +1469,25 @@ def auto_select_grid_resolution(
                 f"capped at {BUMP_CEILING:,} by the auto-grid retry) or use a "
                 f"looser manufacturer profile.",
                 stacklevel=2,
+            )
+        else:
+            # Issue #3942: the memory cap coerced a grid > clearance/2 but the
+            # board has NO fine-pitch pads (e.g. board 01 @2.54mm, board 07
+            # @0.8mm > FINE_PITCH_SPACING_MM = 0.65mm).  The coarse grid is
+            # <= clearance and these boards route DRC-clean, so the "may
+            # produce clearance violations at fine-pitch pads" alarm is a
+            # false positive -- its own precondition (fine-pitch pads present)
+            # is unmet, exactly matching ``memory_forced_unsafe_grid=False``.
+            # Demote to an informational note that makes NO risk claim, so
+            # downstream tooling can still observe the grid-selection event
+            # without alarming users on provably-clean boards.
+            logger.info(
+                "Auto-grid: memory budget cap selected grid %smm > clearance/2 "
+                "(%smm) even at max_cells=%s; no fine-pitch pads present, so no "
+                "clearance risk is expected.",
+                best_resolution,
+                recommended_max,
+                f"{effective_max_cells:,}",
             )
 
     return GridAutoSelection(
@@ -3681,10 +3706,25 @@ def load_pcb_for_routing(
 
     # Validate grid resolution for DRC compliance
     if validate_drc:
+        # Issue #3942: the "grid > clearance/2 may cause clearance violations"
+        # heads-up is only a genuine risk when the board carries fine-pitch pads
+        # whose inter-pad channel the coarse grid cannot honour -- the same
+        # predicate as the #3911 auto-grid gate.  On boards with NO fine-pitch
+        # pads (e.g. board 01 @2.54mm, board 07 @0.8mm > FINE_PITCH_SPACING_MM =
+        # 0.65mm) a coarse-but-<=clearance grid routes DRC-clean, so this generic
+        # warning is a duplicate false alarm (the auto-grid selector already owns
+        # the authoritative message).  Scope the warning emission to at-risk
+        # fine-pitch boards; the strict-mode raise is unchanged (still gated on
+        # ``strict_drc``), so this is a diagnostics-only narrowing.
+        _pad_positions = [
+            PadPosition(x=pad["x"], y=pad["y"]) for comp in components for pad in comp["pads"]
+        ]
+        _min_spacing = _min_pad_center_spacing(_pad_positions)
+        _has_fine_pitch = _min_spacing is not None and _min_spacing <= FINE_PITCH_SPACING_MM
         validate_grid_resolution(
             rules.grid_resolution,
             rules.trace_clearance,
-            warn=True,
+            warn=_has_fine_pitch,
             strict=strict_drc,
         )
 

--- a/tests/test_grid_safety_gate_fleet.py
+++ b/tests/test_grid_safety_gate_fleet.py
@@ -103,3 +103,58 @@ def test_exactly_one_board_is_gated() -> None:
     assert gated == ["05-bldc-motor-controller"], (
         f"Expected board 05 to be the sole gated board, got {gated}"
     )
+
+
+#: The verbatim substring of the alarming auto-grid warning (issue #3942).
+#: It literally claims risk "at fine-pitch pads", so it must fire ONLY on the
+#: fine-pitch memory-coerced board (05) -- never on a clean, no-fine-pitch board
+#: that routes DRC-clean (boards 01 / 07 tripped it before the #3942 gate fix).
+_MEMORY_CAP_WARNING = "memory budget cap forces grid"
+
+
+@pytest.mark.parametrize("budget", [500_000, 2_000_000])
+@pytest.mark.parametrize("board_dir,stem,expected", FLEET)
+def test_fleet_memory_cap_warning_matches_gate(
+    board_dir: str, stem: str, expected: bool, budget: int
+) -> None:
+    """Issue #3942: the alarming "may produce clearance violations at fine-pitch
+    pads" warning fires iff the board actually trips the gate.
+
+    Before the fix the warning fired on *every* memory-coerced board -- even
+    boards 01 (2.54mm divider) and 07 (0.8mm match group) that carry no
+    fine-pitch pads and route DRC-clean -- because it was gated on the looser
+    ``grid_unsafe_by_memory_cap`` predicate instead of the ``has_fine_pitch``
+    term that ``memory_forced_unsafe_grid`` carries.  The warning's own
+    precondition ("at fine-pitch pads") was unmet, so users of provably-clean
+    boards were told the board was at risk.  This locks the warning to the same
+    condition as the gate: emitted for board 05 only.
+    """
+    pcb = _input_pcb(board_dir, stem)
+    if not pcb.exists():
+        pytest.skip(f"input PCB not committed: {pcb}")
+
+    pads = extract_pad_positions(pcb)
+    dims = extract_board_dimensions(pcb)
+    assert dims is not None, f"{board_dir}: no board dimensions"
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        auto_select_grid_resolution(
+            pads=pads,
+            clearance=ROUTE_DEFAULT_CLEARANCE,
+            board_width=dims[0],
+            board_height=dims[1],
+            max_cells=budget,
+        )
+
+    warning_texts = [str(w.message) for w in caught]
+    fired = any(_MEMORY_CAP_WARNING in t for t in warning_texts)
+
+    assert fired is expected, (
+        f"{board_dir} @ max_cells={budget:,}: memory-cap clearance warning "
+        f"fired={fired} (expected {expected}). The warning claims risk 'at "
+        f"fine-pitch pads' and must track the gate exactly -- a True on a "
+        f"non-05 board is the #3942 false alarm that tells a DRC-clean board "
+        f"it is at risk; a False on board 05 drops a genuine warning. "
+        f"Warnings seen: {warning_texts}"
+    )

--- a/tests/test_router_io.py
+++ b/tests/test_router_io.py
@@ -2067,7 +2067,15 @@ class TestLoadPcbForRoutingDrcCompliance:
         assert router.rules.grid_resolution == 0.1  # Default
 
     def test_validate_drc_emits_warning(self, tmp_path):
-        """Test that validate_drc=True emits warnings for bad grid resolution."""
+        """Test that validate_drc=True emits warnings for bad grid resolution.
+
+        Issue #3942: the "grid > clearance/2 may cause clearance violations"
+        warning is now scoped to boards that actually carry fine-pitch pads
+        (the only zones a coarse-but-<=clearance grid can short).  The fixture
+        therefore uses two pads at 0.5mm centre spacing (<= FINE_PITCH_SPACING_MM
+        = 0.65mm) so the at-risk condition is met and the warning still fires --
+        exercising the contract that a genuine risk is still reported.
+        """
         pcb_content = """(kicad_pcb
   (version 20240108)
   (generator "test")
@@ -2080,7 +2088,8 @@ class TestLoadPcbForRoutingDrcCompliance:
     (layer "F.Cu")
     (at 120 120)
     (fp_text reference "R1" (at 0 0) (layer "F.SilkS"))
-    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 0 ""))
+    (pad "1" smd rect (at 0 0) (size 0.3 0.3) (layers "F.Cu") (net 0 ""))
+    (pad "2" smd rect (at 0.5 0) (size 0.3 0.3) (layers "F.Cu") (net 0 ""))
   )
 )"""
         pcb_file = tmp_path / "test_drc.kicad_pcb"
@@ -2100,6 +2109,50 @@ class TestLoadPcbForRoutingDrcCompliance:
             # Should emit a warning
             assert len(w) >= 1
             assert "clearance" in str(w[0].message).lower()
+
+    def test_validate_drc_no_warning_without_fine_pitch(self, tmp_path):
+        """Issue #3942: a coarse-but-<=clearance grid on a board with NO
+        fine-pitch pads must NOT emit the "may cause clearance violations"
+        warning.
+
+        Two pads at 2.54mm centre spacing (>> FINE_PITCH_SPACING_MM) route
+        DRC-clean on a 0.15mm grid, so the generic heads-up is a false alarm
+        (this is the board 01 / board 07 case the issue reopened on).  The
+        strict-mode raise is unaffected -- only the advisory warning is scoped.
+        """
+        pcb_content = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+  )
+  (gr_rect (start 100 100) (end 150 140) (layer "Edge.Cuts"))
+  (net 0 "")
+  (footprint "Test"
+    (layer "F.Cu")
+    (at 120 120)
+    (fp_text reference "R1" (at 0 0) (layer "F.SilkS"))
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 0 ""))
+    (pad "2" smd rect (at 2.54 0) (size 1 1) (layers "F.Cu") (net 0 ""))
+  )
+)"""
+        pcb_file = tmp_path / "test_drc_coarse.kicad_pcb"
+        pcb_file.write_text(pcb_content)
+
+        # grid=0.15 > clearance/2 (0.1) but <= clearance (0.2): pre-#3942 this
+        # warned; post-#3942 it must not, because no fine-pitch pads are at risk.
+        rules = DesignRules(grid_resolution=0.15, trace_clearance=0.2)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            load_pcb_for_routing(str(pcb_file), rules=rules, validate_drc=True, strict_drc=False)
+
+        clearance_warnings = [
+            msg for msg in (str(x.message) for x in w) if "may cause clearance" in msg.lower()
+        ]
+        assert clearance_warnings == [], (
+            f"Expected no clearance warning on a non-fine-pitch board, got: {clearance_warnings}"
+        )
 
     def test_validate_drc_false_no_warning(self, tmp_path):
         """Test that validate_drc=False suppresses warnings."""


### PR DESCRIPTION
## Summary

The auto-grid selector's "memory budget cap forces grid > clearance/2 ... **Routing may produce clearance violations at fine-pitch pads**" warning fired on the looser `grid_unsafe_by_memory_cap` predicate, **omitting the `has_fine_pitch` term** that the actual route-refusal flag `memory_forced_unsafe_grid` requires (io.py). As a result, boards with no fine-pitch pads — board 01 (2.54mm divider) and board 07 (0.8mm match group, > 0.65mm `FINE_PITCH_SPACING_MM`) — route DRC-clean (`kicad-cli --refill-zones` = 0 violations) yet were told they were at risk. The warning's own precondition ("at fine-pitch pads") was unmet.

This is diagnostics-only: no routing behavior or grid-selection change (root-cause sibling #3911 selects the grid; this PR only fixes how that already-correct selection is *reported*).

## Changes

- **Primary (`io.py`, auto-grid selector):** gate the alarming `warnings.warn()` on `has_fine_pitch` (equivalently `memory_forced_unsafe_grid`). When the memory cap coerced a coarse grid but no fine-pitch pads are present, demote to a `logger.info` note that makes **no** risk claim (so downstream tooling can still observe the selection event).
- **Secondary (`io.py`, `load_pcb_for_routing` call site):** the same-class duplicate `validate_grid_resolution()` heads-up ("Grid resolution 0.1mm may cause clearance violations") also fired on boards 01/07. Scope its warning emission to fine-pitch boards using the already-parsed pad list; the strict-mode raise is **unchanged** (still gated on `strict_drc`).
- **Tests:** extend `test_grid_safety_gate_fleet.py` to assert the warning fires **iff** the board trips the gate (board 05 only); add `load_pcb_for_routing` tests locking the no-warning-without-fine-pitch behavior; update the single-pad `test_validate_drc_emits_warning` fixture to be fine-pitch so the "genuine risk still reported" contract holds.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Boards 01/07 emit no memory-cap/clearance warning | ✅ | `kct route` on both: no `budget cap`/`may produce`/`may cause clearance` lines; both route SUCCESS / exit 0 |
| Board 05 genuine-risk path intact (warn AND hard-error) | ✅ | `kct route boards/05/...` still emits the warning and refuses with the `--allow-unsafe-grid` error |
| `memory_forced_unsafe_grid` gate signal unchanged | ✅ | `test_grid_safety_gate_fleet.py` still green (board 05 sole gated board, both budgets) |
| Diagnostics-only, no routing behavior change | ✅ | Only warning/log emission gated; grid selection and `strict_drc` raise untouched |
| Fleet test asserts warning suppressed on clean boards | ✅ | New `test_fleet_memory_cap_warning_matches_gate` (warning fires iff `expected`) |

## Test Plan

- `pytest tests/test_grid_auto_selection.py tests/test_route_grid_safety_gate.py tests/test_router_io.py tests/test_grid_safety_gate_fleet.py tests/test_board_05_routing_regression.py` → **326 passed**
- `ruff check` + `ruff format --check` on changed files → clean
- mypy baseline gate: **0 new errors** in `router/io.py` (remaining gate noise is pre-existing/env-only: missing optional deps + native-build unused-ignore artifacts)
- Manual: `kct route` on boards 01 (SUCCESS, no warnings), 07 (exit 0, no warnings), 05 (warns + hard-errors)

Closes #3942