### PR TITLE
feat(recipes): shared pipeline success gate so exit code and SUMMARY can't diverge

### DIFF
--- a/boards/04-stm32-devboard/generate_design.py
+++ b/boards/04-stm32-devboard/generate_design.py
@@ -34,6 +34,7 @@ from kicad_tools.core.project_file import create_minimal_project, save_project
 from kicad_tools.dev import warn_if_stale
 from kicad_tools.lvs import write_lvs_report
 from kicad_tools.pcb.center_sheet import centered_origin
+from kicad_tools.recipes.gate import evaluate_pipeline_gate
 from kicad_tools.schematic.blocks import (
     DebugHeader,
     create_crystal_with_loads,
@@ -2029,8 +2030,13 @@ def main() -> int:
         # refreshed pour).
         fill_success = fill_zones(routed_path)
 
-        # Step 7: Run DRC
-        drc_success = run_drc(routed_path)
+        # Step 7: Run DRC.  Issue #3912: run_drc still runs for its
+        # side-effect -- it writes ``output/drc_report.json`` (the sidecar
+        # ``kct fleet ship-ready`` reads, #3765).  Its kct-check return no
+        # longer gates the recipe: the authoritative DRC verdict now comes
+        # from the shared gate's ``kicad-cli pcb drc --refill-zones`` leg
+        # below.
+        run_drc(routed_path)
 
         # Step 7.5: LVS (advisory, #3780) -- board 04 is in
         # ``ADVISORY_LVS_BOARDS``.  The real ``OSC_IN<->OSC_OUT`` B.Cu
@@ -2075,6 +2081,32 @@ def main() -> int:
         # Step 8: Generate manufacturing artifacts (Gerbers, BOM, CPL)
         mfr_success = generate_manufacturing(routed_path, output_dir)
 
+        # Issue #3912: board-04 is the REFERENCE migration to the shared
+        # recipe success gate (kicad_tools.recipes.gate).  The route / DRC /
+        # LVS legs -- previously three hand-rolled booleans (route_success,
+        # drc_success, copper_clean) ANDed by hand into the exit code -- are
+        # now folded into ONE PipelineGateResult that drives BOTH the
+        # SUMMARY lines below and the exit code, so they cannot diverge.
+        #
+        # The gate's DRC leg is authoritative: it runs
+        # ``kicad-cli pcb drc --refill-zones`` (run_geometric_drc) instead of
+        # the ``kct check --drc-only`` that ``run_drc`` uses (run_drc is still
+        # called above so ``output/drc_report.json`` -- the sidecar
+        # ``kct fleet ship-ready`` reads -- keeps being written).  The two
+        # legacy 0.350mm ``hole_clearance`` drills the fresh regen still
+        # routes (#3847 / CI ``--allow 2``) are tolerated via an explicit
+        # per-rule allowance; a 3rd drill or any new blocking rule fails the
+        # gate.  copper-LVS (``copper_clean``) is the LVS leg -- and
+        # ``write_lvs_report(require_clean=True)`` already RAISED above on a
+        # dirty comparator, so a short can't even reach here.
+        gate = evaluate_pipeline_gate(
+            routed_path,
+            route_ok=route_success,
+            route_allowance=0,
+            lvs_ok=copper_clean,
+            rule_allowances={"hole_clearance": 2},
+        )
+
         # Summary
         print("\n" + "=" * 60)
         print("SUMMARY")
@@ -2088,14 +2120,14 @@ def main() -> int:
         print(f"  5. Manufacturing: {(output_dir / 'manufacturing').name}/")
         print("\nResults:")
         print(f"  ERC: {'PASS' if erc_success else 'FAIL'}")
-        print(f"  Routing: {'SUCCESS' if route_success else 'PARTIAL'}")
+        for line in gate.summary_lines():
+            print(line)
         print(f"  OSC escape fix: {'SUCCESS' if osc_success else 'FAIL'}")
         print(f"  45-quantize: {'SUCCESS' if quantize_success else 'FAIL'}")
         print(f"  Stitch: {'SUCCESS' if stitch_success else 'FAIL'}")
         print(f"  Power-pad tie: {'SUCCESS' if tie_success else 'FAIL'}")
         print(f"  Zone fill: {'SUCCESS' if fill_success else 'FAIL'}")
-        print(f"  DRC: {'PASS' if drc_success else 'FAIL'}")
-        print(f"  Manufacturing: {'SUCCESS' if mfr_success else 'FAIL'}")
+        print(f"  Manufacturing bundle: {'WRITTEN' if mfr_success else 'FAILED'}")
         print("\nBoard description:")
         print("  - U1: AMS1117-3.3 LDO (5V to 3.3V)")
         print("  - U2: STM32F103C8T6 MCU (LQFP-48, 0.5mm pitch)")
@@ -2184,18 +2216,21 @@ def main() -> int:
         # regression exits non-zero.  The current committed board -- 2
         # allowlisted drills, 1 advisory connectivity, copper-LVS clean --
         # still exits 0.
+        # Issue #3912: route_success + drc_success + copper_clean are now
+        # subsumed by ``gate.passed`` (route / DRC / LVS legs), derived from
+        # the SAME PipelineGateResult the SUMMARY printed.  The board-04
+        # specific pipeline-step booleans stay ANDed in as before so a failed
+        # stitch / tie / fill / quantize / export still fails the recipe.
         return (
             0
             if (
                 erc_success
-                and route_success
                 and quantize_success
                 and stitch_success
                 and tie_success
                 and fill_success
-                and drc_success
-                and copper_clean
                 and mfr_success
+                and gate.passed
             )
             else 1
         )

--- a/boards/05-bldc-motor-controller/design.py
+++ b/boards/05-bldc-motor-controller/design.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from kicad_tools.core.project_file import create_minimal_project, save_project
 from kicad_tools.dev import warn_if_stale
 from kicad_tools.pcb.center_sheet import centered_origin
+from kicad_tools.recipes.gate import evaluate_pipeline_gate
 from kicad_tools.router.partial_rescue import RescueConfig
 from kicad_tools.router.partial_rescue import rescue_partial_nets as shared_rescue_partial_nets
 from kicad_tools.schematic.blocks import (
@@ -3540,6 +3541,33 @@ def main() -> int:
         # bundle produced" criterion.
         mfg_success = generate_manufacturing(routed_path, output_dir)
 
+        # Issue #3912: derive BOTH the SUMMARY and the exit code from one
+        # shared PipelineGateResult so they cannot diverge.  The previous
+        # gate (``return 0 if erc_success and drc_success else 1``) dropped
+        # route-completion entirely -- an 81%-routed board exited 0 -- and
+        # its ``drc_success`` came from ``run_drc`` shelling
+        # ``kct check --drc-only``, which evaluates the STALE on-disk zone
+        # fills and so missed the 2 real copper shorts that
+        # ``kicad-cli pcb drc --refill-zones`` reports.  The shared gate's
+        # authoritative DRC leg runs exactly that kicad-cli command, so a
+        # fresh regen with copper shorts now fails.  ``run_drc``'s
+        # kct-check verdict is threaded in as a supplemental constraint
+        # (it can only tighten, never loosen).  Route completion is a
+        # first-class leg with no allowance: a PARTIAL route now fails.
+        # LVS is tracked separately for this board (#3762), so it is not a
+        # leg of the recipe gate (``lvs_ok=None``).
+        gate = evaluate_pipeline_gate(
+            routed_path,
+            route_ok=route_success,
+            route_allowance=0,
+            lvs_ok=None,
+            supplemental_drc_ok=drc_success,
+            supplemental_reason=(
+                "kct check --drc-only reported error-level DRC findings "
+                "(see DRC output above)"
+            ),
+        )
+
         # Summary
         print("\n" + "=" * 60)
         print("SUMMARY")
@@ -3553,8 +3581,8 @@ def main() -> int:
         print("\nResults:")
         print(f"  ERC: {'PASS' if erc_success else 'FAIL'}")
         print(f"  Zones: {zones_created} zone(s) created, {zones_filled} filled")
-        print(f"  Routing: {'SUCCESS' if route_success else 'PARTIAL'}")
-        print(f"  DRC: {'PASS' if drc_success else 'FAIL'}")
+        for line in gate.summary_lines():
+            print(line)
         # #3912: mfg_success reflects whether `kct export` wrote a bundle
         # (exit 0), NOT whether the board is DRC-clean.  Board DRC status is
         # reported separately above ("DRC: ...").  Label this line "written"
@@ -3571,9 +3599,10 @@ def main() -> int:
         print("  LEDs: D3-D4, R3-R4")
         print("  Hall filter: R30-R32 (pull-ups), C30-C32 (filters)")
 
-        # For this board, partial routing is acceptable
-        # Success if ERC passes and DRC has no errors (warnings OK)
-        return 0 if erc_success and drc_success else 1
+        # #3912: exit code derives from the same PipelineGateResult that
+        # drives the SUMMARY above.  ERC remains an independent gating leg
+        # (not modelled by the shared route/DRC/LVS gate).
+        return 0 if (erc_success and gate.passed) else 1
 
     except Exception as e:
         print(f"\nError: {e}", file=sys.stderr)

--- a/boards/05-bldc-motor-controller/design.py
+++ b/boards/05-bldc-motor-controller/design.py
@@ -3563,8 +3563,7 @@ def main() -> int:
             lvs_ok=None,
             supplemental_drc_ok=drc_success,
             supplemental_reason=(
-                "kct check --drc-only reported error-level DRC findings "
-                "(see DRC output above)"
+                "kct check --drc-only reported error-level DRC findings (see DRC output above)"
             ),
         )
 

--- a/boards/06-diffpair-test/generate_design.py
+++ b/boards/06-diffpair-test/generate_design.py
@@ -40,6 +40,7 @@ from pathlib import Path
 from kicad_tools.core.project_file import create_minimal_project, save_project
 from kicad_tools.dev import warn_if_stale
 from kicad_tools.lvs import write_lvs_report
+from kicad_tools.recipes.gate import evaluate_pipeline_gate
 from kicad_tools.router.rules import NET_CLASS_HIGH_SPEED, NET_CLASS_POWER, NetClassRouting
 
 # Re-export net definitions and footprint generators from generate_pcb.
@@ -3450,6 +3451,9 @@ def main() -> int:
             # refused to call that clean -- the LVS step was skipped
             # entirely.  #4012 wired the schematic, restoring the hard
             # gate #4004 originally intended.)
+            # write_lvs_report(require_clean=True) RAISES on any short /
+            # open / label divergence, so reaching the next line means the
+            # copper-LVS verdict is clean.
             write_lvs_report(
                 sch_path,
                 routed_path,
@@ -3458,6 +3462,7 @@ def main() -> int:
                 run_copper=True,
                 run_label=True,
             )
+            lvs_ok = True
 
             # Export manufacturing bundle (#3147) so ``kct fleet status``
             # reports ``ship_ready=true`` (the bundle's manifest mtime must
@@ -3465,6 +3470,31 @@ def main() -> int:
             # routing is allowed to be PARTIAL on this board, and a current
             # bundle still clears the ``"artifacts stale"`` blocker.
             mfg_ok = export_manufacturing_bundle(routed_path, output_dir)
+
+            # Issue #3912: the exit code and the SUMMARY are now BOTH derived
+            # from one shared PipelineGateResult so they cannot diverge.  The
+            # previous ``return 0 if route_success else 1`` dropped the DRC
+            # leg entirely -- 18 differential-pair errors printed ``DRC: FAIL``
+            # while the process exited 0.  ``run_drc`` here uses
+            # ``kct check --net-class-map``; that engine is the ONLY one that
+            # can see the diffpair / match-group length-skew rule families
+            # (kicad-cli has no native expression for them), so its verdict is
+            # threaded in as ``supplemental_drc_ok``.  The gate's authoritative
+            # geometric leg (``kicad-cli pcb drc --refill-zones``) catches the
+            # shorts / clearance defects kicad-cli owns; the union of the two
+            # is the real DRC verdict.  Board-06 routes fully by design, so
+            # ``route_allowance=0``.
+            gate = evaluate_pipeline_gate(
+                routed_path,
+                route_ok=route_success,
+                route_allowance=0,
+                lvs_ok=lvs_ok,
+                supplemental_drc_ok=drc_ok,
+                supplemental_reason=(
+                    "kct check --net-class-map reported diffpair / match-group "
+                    "errors (see DRC output above)"
+                ),
+            )
 
             print("\n" + "=" * 60)
             print("SUMMARY")
@@ -3475,11 +3505,14 @@ def main() -> int:
             print(f"  PCB:       {pcb_path.name}")
             print(f"  Routed:    {routed_path.name}")
             print("\nResults:")
-            print(f"  Routing: {'SUCCESS' if route_success else 'PARTIAL'}")
-            print(f"  DRC:     {'PASS' if drc_ok else 'FAIL (see above)'}")
-            print(f"  MFG:     {'PASS' if mfg_ok else 'FAIL (see above)'}")
+            for line in gate.summary_lines():
+                print(line)
+            # ``MFG`` reports whether the bundle was WRITTEN (exit 0 of the
+            # export), NOT whether the board is DRC-clean -- board cleanliness
+            # is the ``DRC``/``Overall`` verdict above (issue #3912 wording).
+            print(f"  MFG bundle: {'WRITTEN' if mfg_ok else 'FAILED'}")
 
-            return 0 if route_success else 1
+            return gate.exit_code()
 
         if args.step == "schematic":
             create_schematic(output_dir)

--- a/src/kicad_tools/recipes/__init__.py
+++ b/src/kicad_tools/recipes/__init__.py
@@ -1,0 +1,32 @@
+"""Shared building blocks for the ``boards/*/*.py`` demo/manufacturing recipes.
+
+Each board recipe (``boards/NN-name/generate_design.py`` or ``design.py``)
+historically hand-rolled its own success gate: an ad-hoc ``main()`` that
+computed a process exit code from a partial AND of route / DRC / LVS
+booleans, and a separately-printed ``SUMMARY`` block.  Because the exit
+expression and the SUMMARY were written independently per board they
+drifted -- and both drifted away from ground truth (issue #3912: board-06
+dropped the DRC leg from its exit code, board-05 dropped route-completion
+and gated on a stale-zone-fill ``kct check`` that missed real copper
+shorts).
+
+This package holds the shared pieces those recipes should call so a single
+verdict drives BOTH the SUMMARY and the exit code, and the authoritative
+``kicad-cli pcb drc --refill-zones`` engine is used for the DRC leg.
+
+See :mod:`kicad_tools.recipes.gate` for the shared pipeline success gate.
+"""
+
+from __future__ import annotations
+
+from kicad_tools.recipes.gate import (
+    DEFAULT_ADVISORY_DRC_TYPES,
+    PipelineGateResult,
+    evaluate_pipeline_gate,
+)
+
+__all__ = [
+    "DEFAULT_ADVISORY_DRC_TYPES",
+    "PipelineGateResult",
+    "evaluate_pipeline_gate",
+]

--- a/src/kicad_tools/recipes/gate.py
+++ b/src/kicad_tools/recipes/gate.py
@@ -1,0 +1,324 @@
+"""Shared pipeline success gate for board recipes (issue #3912).
+
+Every board recipe under ``boards/`` used to hand-roll its own success
+gate: a ``route_pcb()`` bool, a ``run_drc()`` bool, and a ``main()`` that
+computed the process exit code from an *ad-hoc* AND of *some subset* of
+those bools, plus a separately-printed ``SUMMARY`` block.  Because the
+exit-code expression and the SUMMARY were authored independently per board
+they drifted -- and both drifted away from ground truth:
+
+* **board-06** dropped the DRC leg entirely (``return 0 if route_success
+  else 1`` while the SUMMARY printed ``DRC: FAIL``), so a board with 18
+  differential-pair errors exited 0.
+* **board-05** dropped route-completion (81% routed still exited 0) and
+  gated its DRC leg on ``kct check --drc-only``, which evaluates the
+  *stale* on-disk zone fills and therefore missed the 2 real copper shorts
+  that ``kicad-cli pcb drc --refill-zones`` reports.
+
+This module extracts the gold-standard gate (board-04, issues #3839 /
+#4066) into ONE shared helper, :func:`evaluate_pipeline_gate`, that returns
+a single :class:`PipelineGateResult` from which BOTH the SUMMARY and the
+``main()`` exit code are derived.  They can no longer disagree.
+
+Two complementary DRC engines
+-----------------------------
+The DRC leg's *authoritative core* is
+:func:`kicad_tools.drc.geometric.run_geometric_drc`, which shells
+``kicad-cli pcb drc --refill-zones`` (issue #3969) -- exactly the command
+a fab house (and the operator's cross-gate process rule) uses.  It
+re-fills the copper pours from scratch before evaluating clearance, so it
+catches connectivity defects (``shorting_items``) that the internal
+``kct check`` engine is structurally blind to when it trusts stale
+persisted zone-fill polygons.
+
+kicad-cli is, however, blind to a few *kct-internal* rule families that
+have no KiCad-native expression -- notably the differential-pair and
+match-group length-skew / continuity rules, which only fire under
+``kct check --net-class-map``.  Board-06's 18 errors are exactly this
+class.  So the helper accepts an optional caller-supplied
+``supplemental_drc_ok`` verdict (the board's existing ``run_drc`` result)
+and ANDs it into ``drc_ok``.  The union of the two engines is what makes
+the gate catch board-05's shorts AND board-06's diffpair skew.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Collection, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from kicad_tools.drc.geometric import GeometricDRCResult, run_geometric_drc
+
+__all__ = [
+    "DEFAULT_ADVISORY_DRC_TYPES",
+    "PipelineGateResult",
+    "evaluate_pipeline_gate",
+]
+
+
+# kicad-cli error-severity violation ``type`` strings that the DRC leg
+# treats as ADVISORY (surfaced but not gating), mirroring the audit
+# pipeline's advisory-rule classification (issue #3074).
+#
+# ``unconnected_items`` is advisory here because route completeness is a
+# SEPARATE, first-class leg of this gate (``route_ok``): an unrouted net
+# shows up as ``unconnected_items`` under kicad-cli, and counting it as a
+# blocking DRC error too would double-penalise the same fact.  A board that
+# is legitimately PARTIAL declares a ``route_allowance`` on the route leg;
+# it should not additionally trip the DRC leg for the same missing copper.
+#
+# Hard connectivity SHORTS (``shorting_items``) are deliberately NOT in
+# this set -- shipping a shorted board is never safe, so a short always
+# blocks (this is the board-05 defect the whole issue is about).
+DEFAULT_ADVISORY_DRC_TYPES: frozenset[str] = frozenset({"unconnected_items"})
+
+
+@dataclass(frozen=True)
+class PipelineGateResult:
+    """A single structured verdict for a board recipe's success gate.
+
+    Both the recipe's printed ``SUMMARY`` block and its ``main()`` exit
+    code MUST be derived from ONE instance of this class so they cannot
+    diverge (issue #3912).  Use :meth:`summary_lines` for the SUMMARY and
+    :meth:`exit_code` for the process exit code; both read the same
+    :attr:`passed` property.
+
+    Attributes:
+        route_ok: ``True`` when the routed board is complete within its
+            declared ``route_allowance`` (see :func:`evaluate_pipeline_gate`).
+        drc_ok: ``True`` when neither the authoritative geometric DRC leg
+            (``kicad-cli pcb drc --refill-zones``) nor the optional
+            supplemental verdict reports a blocking error.
+        lvs_ok: ``True``/``False`` for the copper-LVS verdict, or ``None``
+            when LVS was not run for this board (an LVS-not-run board is
+            NOT failed by the gate).
+        nets_routed / nets_total / route_allowance: route-leg inputs,
+            retained for reporting.  ``nets_*`` are ``None`` when the
+            caller passed a pre-computed ``route_ok`` bool instead of
+            counts.
+        drc_ran: ``True`` when ``kicad-cli`` actually executed the
+            geometric DRC.  ``False`` on every skip path (kicad-cli absent,
+            timeout, crash); see ``require_drc``.
+        drc_blocking: ``{type_str: count}`` of the geometric error-severity
+            violations that EXCEEDED their allowance (i.e. the ones that
+            gate).  Empty on a clean geometric run.
+        drc_top_types: the most-frequent geometric error types (for logs).
+        supplemental_drc_ok: the optional caller-supplied verdict (e.g. the
+            board's ``kct check --net-class-map`` result for diffpair /
+            match-group rules kicad-cli cannot express), or ``None`` when
+            not provided.
+        reasons: human-readable explanations for every failing / skipped
+            leg, suitable for printing under the SUMMARY.
+    """
+
+    route_ok: bool
+    drc_ok: bool
+    lvs_ok: bool | None
+    nets_routed: int | None = None
+    nets_total: int | None = None
+    route_allowance: int = 0
+    drc_ran: bool = False
+    drc_blocking: dict[str, int] = field(default_factory=dict)
+    drc_top_types: list[tuple[str, int]] = field(default_factory=list)
+    supplemental_drc_ok: bool | None = None
+    reasons: list[str] = field(default_factory=list)
+
+    @property
+    def passed(self) -> bool:
+        """Overall verdict: all gating legs pass.
+
+        ``lvs_ok is not False`` treats ``None`` (LVS not run) as
+        non-blocking, so an LVS-not-run board is not failed by the gate,
+        while a genuine LVS failure (``False``) is.
+        """
+        return self.route_ok and self.drc_ok and (self.lvs_ok is not False)
+
+    def exit_code(self) -> int:
+        """Process exit code derived from :attr:`passed` (0 pass / 1 fail)."""
+        return 0 if self.passed else 1
+
+    def overall_status(self) -> str:
+        """``"PASS"``/``"FAIL"`` derived from :attr:`passed`."""
+        return "PASS" if self.passed else "FAIL"
+
+    def route_status(self) -> str:
+        """``"SUCCESS"``/``"PARTIAL"`` for the ``Routing:`` SUMMARY line."""
+        return "SUCCESS" if self.route_ok else "PARTIAL"
+
+    def drc_status(self) -> str:
+        """``"PASS"``/``"FAIL"`` for the ``DRC:`` SUMMARY line."""
+        return "PASS" if self.drc_ok else "FAIL"
+
+    def lvs_status(self) -> str:
+        """``"PASS"``/``"FAIL"``/``"n/a"`` for the ``LVS:`` SUMMARY line."""
+        if self.lvs_ok is None:
+            return "n/a"
+        return "PASS" if self.lvs_ok else "FAIL"
+
+    def summary_lines(self) -> list[str]:
+        """Render the canonical ``Results:`` block for the recipe SUMMARY.
+
+        Every line here is derived from this same result object, so the
+        printed status and the :meth:`exit_code` cannot diverge -- the
+        divergence-guard invariant issue #3912 requires.
+        """
+        lines = [
+            f"  Routing: {self.route_status()}",
+            f"  DRC:     {self.drc_status()}",
+            f"  LVS:     {self.lvs_status()}",
+            f"  Overall: {self.overall_status()}",
+        ]
+        for reason in self.reasons:
+            lines.append(f"    - {reason}")
+        return lines
+
+
+def evaluate_pipeline_gate(
+    routed_pcb: Path | str,
+    *,
+    nets_routed: int | None = None,
+    nets_total: int | None = None,
+    route_ok: bool | None = None,
+    route_allowance: int = 0,
+    lvs_ok: bool | None = None,
+    advisory_types: Collection[str] = DEFAULT_ADVISORY_DRC_TYPES,
+    rule_allowances: Mapping[str, int] | None = None,
+    supplemental_drc_ok: bool | None = None,
+    supplemental_reason: str = "",
+    require_drc: bool = True,
+    drc_timeout: int = 180,
+    _drc_result: GeometricDRCResult | None = None,
+) -> PipelineGateResult:
+    """Evaluate a board recipe's success gate into one structured verdict.
+
+    The DRC leg's authoritative engine is
+    :func:`kicad_tools.drc.geometric.run_geometric_drc`, which runs
+    ``kicad-cli pcb drc --refill-zones`` (issue #3969) -- NOT
+    ``kct check --drc-only`` (which trusts stale on-disk zone fills and so
+    misses real copper shorts, the board-05 defect this issue fixes).
+
+    Route completion is a **first-class leg**: a board that is legitimately
+    PARTIAL (e.g. board-07's seed-invariant nets #3438, board-06's USB3
+    escape #2677) passes an explicit non-zero ``route_allowance`` rather
+    than silently dropping the term from the exit code.
+
+    Args:
+        routed_pcb: Path to the routed ``.kicad_pcb`` to check.
+        nets_routed: Number of signal nets fully routed.  When both this
+            and ``nets_total`` are given, ``route_ok`` is computed as
+            ``(nets_total - nets_routed) <= route_allowance``.
+        nets_total: Total number of signal nets.
+        route_ok: A pre-computed route verdict, used only when
+            ``nets_routed``/``nets_total`` are not both supplied (for
+            recipes whose ``route_pcb`` returns only a bool).
+        route_allowance: Permitted per-board route shortfall (default 0 =
+            fully routed).  Only meaningful with the counts path.
+        lvs_ok: Copper-LVS verdict, or ``None`` when LVS was not run for
+            this board (``None`` does not fail the gate).
+        advisory_types: kicad-cli error ``type`` strings excluded from the
+            geometric blocking count (defaults to
+            :data:`DEFAULT_ADVISORY_DRC_TYPES`).
+        rule_allowances: Per-``type_str`` grandfathered allowance for the
+            geometric leg (e.g. ``{"hole_clearance": 2}`` for board-04's
+            two legacy drill-clearance errors).  A type is blocking only
+            when its count exceeds its allowance (default 0).
+        supplemental_drc_ok: Optional additional DRC verdict ANDed into
+            ``drc_ok`` -- for rule families kicad-cli cannot express
+            (differential-pair / match-group skew via
+            ``kct check --net-class-map``).  ``None`` means "not supplied"
+            and never fails the gate.
+        supplemental_reason: Message recorded when ``supplemental_drc_ok``
+            is ``False``.
+        require_drc: When ``True`` (default) a geometric DRC that did NOT
+            run (kicad-cli absent/timeout/crash) fails ``drc_ok`` -- the
+            gate refuses to certify a board it could not authoritatively
+            check.  Set ``False`` only for environments that legitimately
+            lack kicad-cli and accept an unverified DRC leg.
+        drc_timeout: Seconds before the kicad-cli DRC run is abandoned.
+        _drc_result: Test seam -- inject a pre-built
+            :class:`GeometricDRCResult` instead of shelling kicad-cli.
+
+    Returns:
+        A :class:`PipelineGateResult` whose :meth:`~PipelineGateResult.passed`
+        drives both the SUMMARY and the exit code.
+    """
+    routed_pcb = Path(routed_pcb)
+    allowances = dict(rule_allowances or {})
+    advisory = frozenset(advisory_types)
+    reasons: list[str] = []
+
+    # ---- Route leg -------------------------------------------------------
+    if nets_routed is not None and nets_total is not None:
+        shortfall = nets_total - nets_routed
+        route_ok_final = shortfall <= route_allowance
+        if not route_ok_final:
+            reasons.append(
+                f"route incomplete: {nets_routed}/{nets_total} nets "
+                f"({shortfall} short, allowance {route_allowance})"
+            )
+    elif route_ok is not None:
+        route_ok_final = route_ok
+        if not route_ok_final:
+            reasons.append("route incomplete (recipe route_pcb returned partial)")
+    else:
+        # No route information supplied: do not block on a leg we cannot
+        # evaluate, but record that it was not checked.
+        route_ok_final = True
+        reasons.append("route completion not evaluated (no counts or route_ok supplied)")
+
+    # ---- DRC leg (authoritative: kicad-cli pcb drc --refill-zones) -------
+    drc = (
+        _drc_result
+        if _drc_result is not None
+        else run_geometric_drc(routed_pcb, timeout=drc_timeout)
+    )
+
+    drc_blocking: dict[str, int] = {}
+    if not drc.ran:
+        if require_drc:
+            geometric_ok = False
+            reasons.append(
+                f"geometric DRC did not run ({drc.note or drc.reason}); "
+                "cannot certify board clean (require_drc=True)"
+            )
+        else:
+            geometric_ok = True
+            reasons.append(
+                f"geometric DRC skipped ({drc.note or drc.reason}); "
+                "DRC leg unverified (require_drc=False)"
+            )
+    else:
+        for type_str, count in drc.by_type.items():
+            if type_str in advisory:
+                continue
+            if count > allowances.get(type_str, 0):
+                drc_blocking[type_str] = count
+        geometric_ok = not drc_blocking
+        if drc_blocking:
+            detail = ", ".join(f"{t}={c}" for t, c in sorted(drc_blocking.items()))
+            reasons.append(f"geometric DRC blocking errors (kicad-cli --refill-zones): {detail}")
+
+    drc_ok = geometric_ok and (supplemental_drc_ok is not False)
+    if supplemental_drc_ok is False:
+        reasons.append(
+            supplemental_reason
+            or "supplemental DRC verdict failed (kct check rule families kicad-cli cannot express)"
+        )
+
+    # ---- LVS leg ---------------------------------------------------------
+    if lvs_ok is False:
+        reasons.append("copper-LVS failed (short/open vs schematic)")
+
+    return PipelineGateResult(
+        route_ok=route_ok_final,
+        drc_ok=drc_ok,
+        lvs_ok=lvs_ok,
+        nets_routed=nets_routed,
+        nets_total=nets_total,
+        route_allowance=route_allowance,
+        drc_ran=drc.ran,
+        drc_blocking=drc_blocking,
+        drc_top_types=drc.top_types(),
+        supplemental_drc_ok=supplemental_drc_ok,
+        reasons=reasons,
+    )

--- a/tests/test_recipes_gate.py
+++ b/tests/test_recipes_gate.py
@@ -1,0 +1,276 @@
+"""Tests for the shared recipe pipeline success gate (issue #3912).
+
+Covers:
+* route completion as a first-class leg (allowance-aware);
+* the authoritative geometric DRC leg (``kicad-cli pcb drc --refill-zones``)
+  including advisory exclusion and per-rule allowances;
+* the supplemental DRC verdict for rule families kicad-cli cannot express
+  (board-06 differential-pair skew);
+* the LVS leg's ``None`` (not-run) vs ``False`` (failed) semantics;
+* the divergence-guard invariant: the SUMMARY status and the exit code are
+  BOTH derived from one ``PipelineGateResult`` and cannot disagree;
+* a guard that the DRC leg really invokes ``--refill-zones`` (regression
+  guard against a slide back to ``kct check --drc-only``).
+"""
+
+from __future__ import annotations
+
+import itertools
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.drc.geometric import GeometricDRCResult
+from kicad_tools.recipes.gate import (
+    DEFAULT_ADVISORY_DRC_TYPES,
+    PipelineGateResult,
+    evaluate_pipeline_gate,
+)
+
+
+def _clean_drc() -> GeometricDRCResult:
+    return GeometricDRCResult(ran=True, error_count=0, by_type={})
+
+
+def _drc(by_type: dict[str, int]) -> GeometricDRCResult:
+    return GeometricDRCResult(ran=True, error_count=sum(by_type.values()), by_type=dict(by_type))
+
+
+PCB = Path("dummy_routed.kicad_pcb")
+
+
+# --------------------------------------------------------------------------
+# Route leg
+# --------------------------------------------------------------------------
+class TestRouteLeg:
+    def test_fully_routed_clean_passes(self):
+        res = evaluate_pipeline_gate(PCB, nets_routed=35, nets_total=35, _drc_result=_clean_drc())
+        assert res.route_ok is True
+        assert res.drc_ok is True
+        assert res.passed is True
+        assert res.exit_code() == 0
+
+    def test_partial_beyond_allowance_fails_route(self):
+        res = evaluate_pipeline_gate(
+            PCB, nets_routed=28, nets_total=35, route_allowance=0, _drc_result=_clean_drc()
+        )
+        assert res.route_ok is False
+        assert res.passed is False
+        assert res.exit_code() == 1
+        assert any("route incomplete" in r for r in res.reasons)
+
+    def test_declared_partial_within_allowance_passes(self):
+        # board-07 #3438 style: 5 seed-invariant nets tolerated explicitly.
+        res = evaluate_pipeline_gate(
+            PCB, nets_routed=46, nets_total=51, route_allowance=5, _drc_result=_clean_drc()
+        )
+        assert res.route_ok is True
+        assert res.passed is True
+
+    def test_route_ok_bool_path(self):
+        # Recipes whose route_pcb returns only a bool.
+        assert evaluate_pipeline_gate(PCB, route_ok=True, _drc_result=_clean_drc()).route_ok
+        assert not evaluate_pipeline_gate(PCB, route_ok=False, _drc_result=_clean_drc()).route_ok
+
+    def test_no_route_info_does_not_block_but_is_noted(self):
+        res = evaluate_pipeline_gate(PCB, _drc_result=_clean_drc())
+        assert res.route_ok is True
+        assert any("route completion not evaluated" in r for r in res.reasons)
+
+
+# --------------------------------------------------------------------------
+# DRC leg (authoritative geometric engine)
+# --------------------------------------------------------------------------
+class TestDrcLeg:
+    def test_copper_short_fails(self):
+        # board-05 defect: shorting_items only visible via --refill-zones.
+        res = evaluate_pipeline_gate(PCB, route_ok=True, _drc_result=_drc({"shorting_items": 2}))
+        assert res.drc_ok is False
+        assert res.passed is False
+        assert res.drc_blocking == {"shorting_items": 2}
+        assert any("shorting_items" in r for r in res.reasons)
+
+    def test_unconnected_items_is_advisory(self):
+        # Route completeness is a separate leg; unrouted nets must not
+        # double-count as a blocking DRC error.
+        assert "unconnected_items" in DEFAULT_ADVISORY_DRC_TYPES
+        res = evaluate_pipeline_gate(
+            PCB, route_ok=True, _drc_result=_drc({"unconnected_items": 12})
+        )
+        assert res.drc_ok is True
+        assert res.passed is True
+
+    def test_rule_allowance_tolerates_grandfathered_drills(self):
+        # board-04 #4017: up to 2 legacy hole_clearance drills tolerated.
+        res = evaluate_pipeline_gate(
+            PCB,
+            route_ok=True,
+            rule_allowances={"hole_clearance": 2},
+            _drc_result=_drc({"hole_clearance": 2}),
+        )
+        assert res.drc_ok is True
+        assert res.passed is True
+
+    def test_rule_allowance_exceeded_fails(self):
+        res = evaluate_pipeline_gate(
+            PCB,
+            route_ok=True,
+            rule_allowances={"hole_clearance": 2},
+            _drc_result=_drc({"hole_clearance": 3}),
+        )
+        assert res.drc_ok is False
+        assert res.drc_blocking == {"hole_clearance": 3}
+
+    def test_non_allowlisted_clearance_fails(self):
+        res = evaluate_pipeline_gate(PCB, route_ok=True, _drc_result=_drc({"clearance": 1}))
+        assert res.drc_ok is False
+
+    def test_drc_not_run_fails_closed_by_default(self):
+        res = evaluate_pipeline_gate(
+            PCB,
+            route_ok=True,
+            _drc_result=GeometricDRCResult(ran=False, note="kicad-cli not found"),
+        )
+        assert res.drc_ran is False
+        assert res.drc_ok is False
+        assert any("did not run" in r for r in res.reasons)
+
+    def test_drc_not_run_can_be_waived(self):
+        res = evaluate_pipeline_gate(
+            PCB,
+            route_ok=True,
+            require_drc=False,
+            _drc_result=GeometricDRCResult(ran=False, note="kicad-cli not found"),
+        )
+        assert res.drc_ok is True
+        assert any("unverified" in r for r in res.reasons)
+
+
+# --------------------------------------------------------------------------
+# Supplemental DRC verdict (kct-check-only rule families)
+# --------------------------------------------------------------------------
+class TestSupplementalDrc:
+    def test_supplemental_false_fails_even_when_geometric_clean(self):
+        # board-06: 18 diffpair-skew errors invisible to kicad-cli but
+        # caught by kct check --net-class-map.
+        res = evaluate_pipeline_gate(
+            PCB,
+            route_ok=True,
+            supplemental_drc_ok=False,
+            supplemental_reason="18 diffpair errors",
+            _drc_result=_clean_drc(),
+        )
+        assert res.drc_ok is False
+        assert res.passed is False
+        assert any("18 diffpair errors" in r for r in res.reasons)
+
+    def test_supplemental_none_does_not_fail(self):
+        res = evaluate_pipeline_gate(
+            PCB, route_ok=True, supplemental_drc_ok=None, _drc_result=_clean_drc()
+        )
+        assert res.drc_ok is True
+
+    def test_supplemental_true_passes(self):
+        res = evaluate_pipeline_gate(
+            PCB, route_ok=True, supplemental_drc_ok=True, _drc_result=_clean_drc()
+        )
+        assert res.drc_ok is True
+
+
+# --------------------------------------------------------------------------
+# LVS leg
+# --------------------------------------------------------------------------
+class TestLvsLeg:
+    def test_lvs_none_is_not_run_and_passes(self):
+        res = evaluate_pipeline_gate(PCB, route_ok=True, lvs_ok=None, _drc_result=_clean_drc())
+        assert res.lvs_status() == "n/a"
+        assert res.passed is True
+
+    def test_lvs_false_fails(self):
+        res = evaluate_pipeline_gate(PCB, route_ok=True, lvs_ok=False, _drc_result=_clean_drc())
+        assert res.passed is False
+        assert res.lvs_status() == "FAIL"
+        assert any("copper-LVS failed" in r for r in res.reasons)
+
+    def test_lvs_true_passes(self):
+        res = evaluate_pipeline_gate(PCB, route_ok=True, lvs_ok=True, _drc_result=_clean_drc())
+        assert res.lvs_status() == "PASS"
+        assert res.passed is True
+
+
+# --------------------------------------------------------------------------
+# Divergence guard: SUMMARY and exit code cannot disagree
+# --------------------------------------------------------------------------
+class TestDivergenceGuard:
+    @pytest.mark.parametrize(
+        "route_ok,drc,lvs_ok",
+        list(
+            itertools.product(
+                [True, False],
+                [_clean_drc(), _drc({"shorting_items": 1})],
+                [None, True, False],
+            )
+        ),
+    )
+    def test_summary_and_exit_code_agree(self, route_ok, drc, lvs_ok):
+        res = evaluate_pipeline_gate(PCB, route_ok=route_ok, lvs_ok=lvs_ok, _drc_result=drc)
+        summary = "\n".join(res.summary_lines())
+        # The SUMMARY overall line and the exit code both read res.passed,
+        # so a board can never print "Overall: PASS" while exiting 1.
+        printed_pass = "Overall: PASS" in summary
+        assert printed_pass == (res.exit_code() == 0)
+        assert printed_pass == res.passed
+        assert res.overall_status() == ("PASS" if res.passed else "FAIL")
+
+    def test_summary_lines_derive_from_same_object(self):
+        res = PipelineGateResult(route_ok=True, drc_ok=False, lvs_ok=None)
+        summary = "\n".join(res.summary_lines())
+        assert "DRC:     FAIL" in summary
+        assert "Overall: FAIL" in summary
+        assert res.exit_code() == 1
+
+
+# --------------------------------------------------------------------------
+# Authoritative-engine guard: the DRC leg must use --refill-zones
+# --------------------------------------------------------------------------
+class TestAuthoritativeEngine:
+    def test_drc_leg_invokes_refill_zones(self, monkeypatch, tmp_path):
+        """The gate's DRC leg must shell ``kicad-cli pcb drc --refill-zones``.
+
+        Regression guard against a slide back to ``kct check --drc-only``
+        (which trusts stale zone fills and misses copper shorts -- the
+        board-05 defect).  We drive a real ``run_geometric_drc`` call
+        through the gate with ``subprocess.run`` stubbed and assert the
+        argv carried ``--refill-zones``.
+        """
+        captured: dict[str, list[str]] = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = list(cmd)
+            out = cmd[cmd.index("--output") + 1]
+            Path(out).write_text(
+                '{"source": "", "date": "", "coordinate_units": "mm", "violations": []}'
+            )
+
+            class _Proc:
+                returncode = 0
+                stdout = b""
+                stderr = b""
+
+            return _Proc()
+
+        monkeypatch.setattr(
+            "kicad_tools.cli.runner.find_kicad_cli", lambda: Path("/usr/bin/kicad-cli")
+        )
+        monkeypatch.setattr("kicad_tools.drc.geometric.subprocess.run", fake_run)
+
+        pcb = tmp_path / "board_routed.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+
+        res = evaluate_pipeline_gate(pcb, route_ok=True)
+
+        assert "cmd" in captured, "run_geometric_drc did not shell kicad-cli"
+        assert "--refill-zones" in captured["cmd"]
+        assert "drc" in captured["cmd"]
+        assert res.drc_ran is True
+        assert res.drc_ok is True


### PR DESCRIPTION
## Summary

Every board recipe under `boards/` hand-rolled its own success gate: an ad-hoc `main()` that computed the process exit code from a *partial* AND of route/DRC/LVS booleans, plus a separately-printed `SUMMARY` block. Because the two were authored independently per board they drifted — and both drifted away from ground truth:

- **board-06** (`generate_design.py:3482`): `return 0 if route_success else 1` **dropped the DRC leg entirely** — 18 differential-pair errors printed `DRC: FAIL` while the process exited 0.
- **board-05** (`design.py:3576`): `return 0 if erc_success and drc_success else 1` **dropped route-completion** (81% routed still exited 0), and `drc_success` came from `kct check --drc-only`, which evaluates the **stale on-disk zone fills** and so missed the 2 real copper shorts `kicad-cli pcb drc --refill-zones` reports.
- **board-04** was the correct gate but copy-pasted.

This adds a **shared** `evaluate_pipeline_gate()` helper (new `src/kicad_tools/recipes/gate.py`) returning one `PipelineGateResult` from which BOTH the SUMMARY and the `main()` exit code derive, so they can no longer disagree.

## Changes

- **`src/kicad_tools/recipes/gate.py`** (new) — `PipelineGateResult` + `evaluate_pipeline_gate()`.
  - DRC leg's authoritative core is `run_geometric_drc(refill_zones=True)` (`kicad-cli pcb drc --refill-zones`, #3969) — **not** `kct check --drc-only`.
  - kicad-cli is structurally blind to the kct-internal diffpair/match-group length-skew rules, so the gate also accepts a caller-supplied `supplemental_drc_ok` (the board's existing `run_drc` verdict). The **union** of the two engines catches board-05's shorts AND board-06's diffpair errors.
  - Route completion is a **first-class leg** with an explicit per-board `route_allowance` (legitimately-PARTIAL boards pass a non-zero allowance rather than dropping the term).
  - Per-`type_str` `rule_allowances` reproduce the allowlist/tolerance semantics of `scripts/ci/check_routed_drc.py` (`unconnected_items` advisory; board-04's 2 legacy `hole_clearance` drills grandfathered).
  - `require_drc=True` fails closed when kicad-cli didn't run (won't certify a board it couldn't authoritatively check).
- **`boards/04-stm32-devboard/generate_design.py`** — behaviour-preserving reference migration: route/DRC/LVS legs now come from the shared gate; `run_drc` still runs to write the `drc_report.json` sidecar; the board-specific pipeline-step booleans stay ANDed in.
- **`boards/05-bldc-motor-controller/design.py`** — exit code no longer drops route-completion; DRC leg now sees copper shorts via `--refill-zones`.
- **`boards/06-diffpair-test/generate_design.py`** — exit code now incorporates the DRC leg; `MFG` line reworded to `WRITTEN`/`FAILED`.
- **`tests/test_recipes_gate.py`** (new) — 32 tests.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Shared helper exists; DRC leg uses `run_geometric_drc(refill_zones=True)`, not `kct check --drc-only` | ✅ | `gate.py`; `test_drc_leg_invokes_refill_zones` patches `subprocess.run` and asserts `--refill-zones` in argv |
| board-05 `main()` exits non-zero on PARTIAL-beyond-allowance OR error DRC (shorts) — 81% + 2 shorts → exit 1 | ✅ | Route leg + authoritative geometric leg; verified via gate on the routed artifact (clean committed → exit 0; injected 81%+2 shorts → exit 1) |
| board-06 `main()` incorporates the DRC leg — 18 diffpair errors → exit 1 | ✅ | `supplemental_drc_ok=drc_ok` threaded in; `test_supplemental_false_fails_even_when_geometric_clean` |
| SUMMARY lines and exit code both derived from the same `PipelineGateResult` | ✅ | `summary_lines()`/`exit_code()` both read `self.passed`; `TestDivergenceGuard` parametrized matrix |
| board-04 behaviour preserved (exits 0 on ≤2 drill allowance; exits 1 on new blocking/LVS short); e2e job stays green | ✅ | `rule_allowances={"hole_clearance": 2}`; existing `test_board_04_main_gate.py` + board-04 suite pass; board-04 e2e `\|\| true`s the recipe |
| Legitimate PARTIAL boards pass via an explicit `route_allowance` | ✅ | `test_declared_partial_within_allowance_passes` |
| bundle-written vs board-clean wording unambiguous | ✅ | board-05 `WRITTEN`/`FAILED` kept; board-06 `MFG bundle: WRITTEN/FAILED`; board-04 `Manufacturing bundle: WRITTEN/FAILED` |

## Test Plan

- `uv run pytest tests/test_recipes_gate.py` — 32 passed.
- `uv run pytest tests/test_check_routed_drc_advisory.py` — allowlist semantics preserved.
- `uv run pytest -k "board_04 or board_05"` — 141 passed, 1 skipped (includes `test_board_04_main_gate.py`).
- `uv run pytest tests/test_board_06_diffpair_test.py tests/test_fleet_status_drc.py` — 51 passed.
- ruff/format clean on changed files; mypy baseline gate green (no new type errors).
- Empirical: `run_geometric_drc` on the committed board-04/05/06 PCBs reports 0 errors (clean shipping artifacts); the gate returns exit 0 for a clean fully-routed board and exit 1 for a fresh 81%-route + 2-shorts scenario.

## Deferred (tracked, remains open)

Migrating boards **00/01/02/03/07** to the shared helper and cleaning up their residual `MFG bundle: PASS` wording is deferred to a follow-up (curator-sanctioned split). Hence `Part of #3912`, not `Closes`.

Part of #3912