### PR TITLE
fix(creepage): union voltage-mapped HV nets into census membership

### DIFF
--- a/src/kicad_tools/cli/commands/creepage.py
+++ b/src/kicad_tools/cli/commands/creepage.py
@@ -183,7 +183,20 @@ def run_creepage_command(args) -> int:
     pcb = PCB.load(pcb_path)
     net_class = getattr(args, "net_class", "HV") or "HV"
 
-    hv_nets = resolve_hv_nets(pcb, net_class, net_class_map)
+    # Voltage-derived census membership (issue #4401): when a voltage map is
+    # supplied, a high-|V| net whose routing class is not HV must still enter
+    # the census.  Gate the union on the map's presence so the no-map path is
+    # byte-identical to before.
+    hv_nets = resolve_hv_nets(
+        pcb,
+        net_class,
+        net_class_map,
+        voltage_map=voltage_map,
+        edge_voltage=edge_voltage,
+        census_threshold=(
+            getattr(args, "census_threshold", 30.0) if voltage_map is not None else None
+        ),
+    )
     try:
         report = compute_creepage_census(
             pcb,

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -513,6 +513,24 @@ def _add_creepage_parser(subparsers) -> None:
             "Requires --standard (and --pollution-degree)."
         ),
     )
+    # Voltage-derived census membership (issue #4401): a high-|V| net whose
+    # routing class is not HV must still enter the census.
+    creepage_parser.add_argument(
+        "--census-threshold",
+        dest="census_threshold",
+        type=float,
+        default=30.0,
+        help=(
+            "Voltage threshold (volts) for voltage-derived HV census membership. "
+            "Only takes effect with --voltage-map: any net whose mapped potential "
+            "differs from the board-edge reference (_edge_voltage) by at least "
+            "this many volts is added to the HV census, in UNION with the "
+            "class-based/name-pattern selection.  This pulls a high-|V| net "
+            "carrying a non-HV routing class (e.g. a 150 V gate-drive net classed "
+            "Digital) into the audit instead of silently excluding it.  Default "
+            "30.0 -- aligned with optimize-placement --hv-threshold."
+        ),
+    )
     creepage_parser.add_argument(
         "--material-group",
         dest="material_group",

--- a/src/kicad_tools/creepage/engine.py
+++ b/src/kicad_tools/creepage/engine.py
@@ -400,6 +400,10 @@ def resolve_hv_nets(
     pcb: PCB,
     net_class: str,
     net_class_map: dict[str, NetClassRouting] | None = None,
+    *,
+    voltage_map: dict[str, float] | None = None,
+    edge_voltage: float = 0.0,
+    census_threshold: float | None = None,
 ) -> dict[int, str]:
     """Return ``{net_number: net_name}`` for nets belonging to ``net_class``.
 
@@ -422,6 +426,20 @@ def resolve_hv_nets(
        ``NEUTRAL`` ...) is therefore selected here.  An explicit map entry
        always wins (step 1), so operator-supplied classification is never
        overridden by this fallback.
+    4. **Voltage-derived union** (issue #4401) -- when both ``voltage_map`` and
+       ``census_threshold`` are supplied, every net whose mapped potential
+       differs from ``edge_voltage`` by at least ``census_threshold`` volts is
+       added, **in union** with the class/name selection above.  This closes the
+       false-pass where a high-|V| net carrying a non-HV routing class (e.g. a
+       ``±150 V`` gate-drive net classed ``Digital``) was silently excluded from
+       the census.  Keys are normalised with :func:`_norm_net_key`, matching the
+       census's own leading-``/`` convention.  The union never *removes* a
+       class-selected net, so a class-``HV`` net at low/unmapped voltage is
+       still audited.
+
+    ``voltage_map``/``edge_voltage``/``census_threshold`` all default to the
+    no-op path: with no map (or ``census_threshold=None``) the output is
+    byte-identical to the class/name selection alone.
     """
     from kicad_tools.router.net_class import classify_from_name
 
@@ -446,6 +464,19 @@ def resolve_hv_nets(
         # no NetClass.HV, so classify_from_name never yields "hv" above.
         if target == "hv" and MAINS_NAME_RE.search(net.name):
             selected[net.number] = net.name
+
+    # Voltage-derived union (issue #4401): pull in any mapped net whose
+    # potential differs from the board-edge reference by >= the threshold,
+    # regardless of its routing class.  Union, not replace.
+    if voltage_map is not None and census_threshold is not None:
+        norm_vmap = {_norm_net_key(k): float(v) for k, v in voltage_map.items()}
+        for net in pcb.nets.values():
+            if net.number == 0 or not net.name:
+                continue
+            v = norm_vmap.get(_norm_net_key(net.name))
+            if v is not None and abs(v - edge_voltage) >= census_threshold:
+                selected[net.number] = net.name
+
     return selected
 
 

--- a/tests/creepage/test_creepage_cli.py
+++ b/tests/creepage/test_creepage_cli.py
@@ -284,3 +284,132 @@ def test_missing_net_class_map_errors(tmp_path, capsys):
     err = capsys.readouterr().err
     assert rc == 1
     assert "net-class-map file not found" in err
+
+
+# ---------------------------------------------------------------------------
+# #4401 voltage-derived census membership: a high-|V| net whose routing class
+# is not HV must still enter the census when a --voltage-map is supplied.
+# ---------------------------------------------------------------------------
+
+
+def _vmap_file(tmp_path, mapping, name="vmap.json"):
+    p = tmp_path / name
+    p.write_text(json.dumps(mapping))
+    return p
+
+
+def test_census_threshold_pulls_high_v_non_hv_net_into_census(tmp_path, capsys):
+    # board_no_hv_source ships SIG + GND -- neither is mains-named nor class-HV,
+    # so without a voltage map the census is empty (see
+    # test_high_working_voltage_without_mains_names_fires_guard).  Mapping SIG at
+    # 150 V with the default 30 V --census-threshold pulls it into hv_nets and
+    # produces audited pair rows (against GND and the board edge).
+    pcb = _write(tmp_path, board_no_hv_source())
+    vmap = _vmap_file(tmp_path, {"SIG": 150.0})
+    rc = _run(
+        [
+            "creepage",
+            str(pcb),
+            "--standard",
+            "iec60664",
+            "--voltage-map",
+            str(vmap),
+            "--pollution-degree",
+            "2",
+            "--format",
+            "json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0  # 18 mm gap clears the 150 V requirement
+    assert "SIG" in payload["hv_nets"]
+    assert payload["pair_count"] >= 2  # SIG-vs-GND and SIG-vs-edge
+    kinds = {p["kind"] for p in payload["pairs"]}
+    assert {"conductor", "edge"} <= kinds
+
+
+def test_census_threshold_above_voltage_excludes_net(tmp_path, capsys):
+    # A --census-threshold above the mapped potential leaves the net out: SIG at
+    # 150 V with a 200 V threshold resolves an empty census (no mains names, no
+    # working voltage -> no vacuity guard) -> inert exit 0.
+    pcb = _write(tmp_path, board_no_hv_source())
+    vmap = _vmap_file(tmp_path, {"SIG": 150.0})
+    rc = _run(
+        [
+            "creepage",
+            str(pcb),
+            "--standard",
+            "iec60664",
+            "--voltage-map",
+            str(vmap),
+            "--pollution-degree",
+            "2",
+            "--census-threshold",
+            "200",
+            "--format",
+            "json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["hv_nets"] == []
+    assert payload["pairs"] == []
+
+
+def test_census_edge_voltage_reference_honored_via_cli(tmp_path, capsys):
+    # The reserved _edge_voltage key shifts the reference: with _edge_voltage=140
+    # a 150 V net is only 10 V above it -> below the default 30 V threshold ->
+    # not a census member.
+    pcb = _write(tmp_path, board_no_hv_source())
+    vmap = _vmap_file(tmp_path, {"SIG": 150.0, "_edge_voltage": 140.0})
+    rc = _run(
+        [
+            "creepage",
+            str(pcb),
+            "--standard",
+            "iec60664",
+            "--voltage-map",
+            str(vmap),
+            "--pollution-degree",
+            "2",
+            "--format",
+            "json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["hv_nets"] == []
+
+
+def test_census_threshold_inert_without_voltage_map(tmp_path, capsys):
+    # Without --voltage-map the flag has no effect: the class/name selection
+    # alone governs.  A mains-named board still resolves its HV nets exactly as
+    # before, regardless of --census-threshold.
+    pcb = _write(tmp_path, board_mains_named_source())
+    rc = _run(
+        [
+            "creepage",
+            str(pcb),
+            "--standard",
+            "iec60664",
+            "--working-voltage",
+            "250",
+            "--pollution-degree",
+            "2",
+            "--census-threshold",
+            "5",
+            "--format",
+            "json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    # Mains nets still classified via the #4354 name fallback (not the voltage
+    # union), the ~1 mm AC_LINE<->GND gap fails -> exit 1.
+    assert rc == 1
+    assert "AC_LINE" in payload["hv_nets"]
+
+
+def test_census_threshold_defaults_to_thirty(tmp_path):
+    # The flag default matches optimize-placement --hv-threshold (30.0).
+    args = create_parser().parse_args(["creepage", "board.kicad_pcb", "--min", "1.5"])
+    assert args.census_threshold == 30.0

--- a/tests/creepage/test_creepage_engine.py
+++ b/tests/creepage/test_creepage_engine.py
@@ -467,3 +467,135 @@ def test_no_voltage_map_leaves_report_in_single_voltage_mode(tmp_path):
     report = compute_creepage_census(pcb, hv, min_mm=1.5)
     assert report.voltage_map is None
     assert report.uses_voltage_map is False
+
+
+# ---------------------------------------------------------------------------
+# Voltage-derived census membership union (issue #4401)
+# ---------------------------------------------------------------------------
+
+
+def test_voltage_union_selects_high_v_non_hv_class_net(tmp_path):
+    # The repro: a high-|V| net (SIG at 150 V) that is NEITHER mains-named NOR
+    # class-HV. Without a voltage map it is invisible to the census; with the
+    # map + threshold it is pulled in by the voltage-derived union.
+    pcb = _load(tmp_path, board_no_hv_source())  # nets: SIG, GND
+    base = resolve_hv_nets(pcb, "HV", net_class_map=None)
+    assert base == {}  # neither SIG nor GND is HV by class/name
+
+    hv = resolve_hv_nets(
+        pcb,
+        "HV",
+        net_class_map=None,
+        voltage_map={"SIG": 150.0},
+        census_threshold=30.0,
+    )
+    assert set(hv.values()) == {"SIG"}
+
+
+def test_voltage_union_is_union_not_replace(tmp_path):
+    # A class-HV net at a LOW/unmapped voltage must remain selected even though
+    # the voltage-derived pass would not add it (union, not replace); a separate
+    # high-|V| non-HV net is added on top.
+    pcb = _load(tmp_path, board_source(with_slot=False))  # L_MAINS (HV via map), GND
+    hv = resolve_hv_nets(
+        pcb,
+        "HV",
+        _hv_map(),  # classifies L_MAINS as HV
+        voltage_map={"L_MAINS": 5.0, "GND": 150.0},  # L_MAINS below threshold
+        census_threshold=30.0,
+    )
+    # L_MAINS kept via class selection despite 5 V; GND added via voltage union.
+    assert set(hv.values()) == {"L_MAINS", "GND"}
+
+
+def test_voltage_union_edge_voltage_shifts_reference(tmp_path):
+    # Membership keys on |V - edge_voltage|, not raw |V|.  With edge_voltage=140
+    # a 150 V net is only 10 V above the reference -> below the 30 V threshold.
+    pcb = _load(tmp_path, board_no_hv_source())
+    hv = resolve_hv_nets(
+        pcb,
+        "HV",
+        net_class_map=None,
+        voltage_map={"SIG": 150.0},
+        edge_voltage=140.0,
+        census_threshold=30.0,
+    )
+    assert hv == {}
+
+    # Same net, edge_voltage=0 -> 150 V >= 30 V -> selected.
+    hv2 = resolve_hv_nets(
+        pcb,
+        "HV",
+        net_class_map=None,
+        voltage_map={"SIG": 150.0},
+        edge_voltage=0.0,
+        census_threshold=30.0,
+    )
+    assert set(hv2.values()) == {"SIG"}
+
+
+def test_voltage_union_threshold_boundary_is_inclusive(tmp_path):
+    # A net exactly AT the threshold is selected (>= boundary).
+    pcb = _load(tmp_path, board_no_hv_source())
+    hv = resolve_hv_nets(
+        pcb,
+        "HV",
+        net_class_map=None,
+        voltage_map={"SIG": 30.0},
+        census_threshold=30.0,
+    )
+    assert set(hv.values()) == {"SIG"}
+
+    # Just below the threshold -> excluded.
+    hv2 = resolve_hv_nets(
+        pcb,
+        "HV",
+        net_class_map=None,
+        voltage_map={"SIG": 29.999},
+        census_threshold=30.0,
+    )
+    assert hv2 == {}
+
+
+def test_voltage_union_key_normalization_matches_census(tmp_path):
+    # A leading-'/' voltage-map key resolves the same net as the bare name
+    # (reuses _norm_net_key, matching the census's own lookup convention).
+    pcb = _load(tmp_path, board_no_hv_source())
+    hv = resolve_hv_nets(
+        pcb,
+        "HV",
+        net_class_map=None,
+        voltage_map={"/SIG": 150.0},  # hierarchical leading slash
+        census_threshold=30.0,
+    )
+    assert set(hv.values()) == {"SIG"}
+
+
+def test_voltage_union_negative_potential_uses_magnitude(tmp_path):
+    # A -150 V net is |−150 − 0| = 150 V from the edge reference -> selected.
+    pcb = _load(tmp_path, board_no_hv_source())
+    hv = resolve_hv_nets(
+        pcb,
+        "HV",
+        net_class_map=None,
+        voltage_map={"SIG": -150.0},
+        census_threshold=30.0,
+    )
+    assert set(hv.values()) == {"SIG"}
+
+
+def test_no_map_output_byte_identical_to_baseline(tmp_path):
+    # The no-op path: passing voltage_map=None (or census_threshold=None) must
+    # yield exactly the class/name selection with no voltage influence.
+    pcb = _load(tmp_path, board_source(with_slot=False))
+    baseline = resolve_hv_nets(pcb, "HV", _hv_map())
+
+    # census_threshold=None disables the union even when a map is present.
+    same_no_threshold = resolve_hv_nets(
+        pcb, "HV", _hv_map(), voltage_map={"GND": 150.0}, census_threshold=None
+    )
+    assert same_no_threshold == baseline
+
+    # voltage_map=None disables the union even when a threshold is present.
+    same_no_map = resolve_hv_nets(pcb, "HV", _hv_map(), voltage_map=None, census_threshold=30.0)
+    assert same_no_map == baseline


### PR DESCRIPTION
## Summary

The HV creepage census resolves membership entirely through `resolve_hv_nets` (class map -> `classify_from_name` -> `MAINS_NAME_RE`), which never consulted the per-net `--voltage-map`. A net the map declares at ±150 V but whose routing class is non-HV (e.g. a gate-drive net classed `Digital`) was silently excluded, producing zero pair rows -- a safety-gate **false pass** (the softstart rev-C scenario in the issue). This PR closes the missing link: membership.

## Changes

- **`src/kicad_tools/creepage/engine.py`** -- extend `resolve_hv_nets` with optional keyword params `voltage_map` / `edge_voltage` / `census_threshold`. After the existing class/name selection, a voltage-derived **union** loop adds every net whose `|V - edge_voltage| >= census_threshold`, reusing `_norm_net_key` for leading-`/` key parity with the census. Union (not replace): a class-HV net at low/unmapped voltage is still selected. New params default `None`/`0.0` -> the no-map path is byte-identical.
- **`src/kicad_tools/cli/parser.py`** -- add `--census-threshold` (default `30.0`, aligned with `optimize-placement --hv-threshold`); help notes it only takes effect with `--voltage-map`.
- **`src/kicad_tools/cli/commands/creepage.py`** -- thread the parsed `voltage_map` / `edge_voltage` / `census_threshold` into the `resolve_hv_nets` call, gated on `voltage_map is not None` so the no-map path is unchanged.
- Tests in `tests/creepage/test_creepage_engine.py` and `tests/creepage/test_creepage_cli.py`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `resolve_hv_nets` gains optional `voltage_map`/`edge_voltage`/`census_threshold`; no-map output byte-identical | ✅ | `test_no_map_output_byte_identical_to_baseline` (both `census_threshold=None` and `voltage_map=None` disable the union) |
| High-\|V\| net enters census in union with class/name selection | ✅ | `test_voltage_union_selects_high_v_non_hv_class_net`, `test_census_threshold_pulls_high_v_non_hv_net_into_census` (JSON `hv_nets` + conductor/edge pairs) |
| Union, not replace (low-V class-HV net still selected) | ✅ | `test_voltage_union_is_union_not_replace` |
| `--census-threshold` documented, only affects membership with `--voltage-map` | ✅ | help text; `test_census_threshold_inert_without_voltage_map` |
| Key normalization matches census (`/SIG` == `SIG`) | ✅ | `test_voltage_union_key_normalization_matches_census` |
| `edge_voltage` honored (keys on `\|V - edge_voltage\|`) | ✅ | `test_voltage_union_edge_voltage_shifts_reference`, `test_census_edge_voltage_reference_honored_via_cli` (`_edge_voltage` key) |
| `>=` boundary inclusive | ✅ | `test_voltage_union_threshold_boundary_is_inclusive` |
| Auditor path + no-map CLI path unchanged | ✅ | `auditor.py:1248` calls positionally; new params default off; full `tests/creepage/` suite green (174 passed) |

## Scope note / follow-up

The auditor path (`auditor.py`) has no voltage map and is intentionally left byte-identical (new params default `None`). Threading a voltage map through the audit path is a separate follow-up, not implemented here.

## Test Plan

- `uv run pytest tests/creepage/` -> 174 passed.
- `uv run ruff check` / `ruff format --check` on all changed files -> clean.
- `uv run mypy src/kicad_tools/creepage/engine.py src/kicad_tools/cli/commands/creepage.py` -> no issues.

Closes #4401