### PR TITLE
fix(creepage): add sub-50V rows to IEC 60664-1 Table F.4 transcription

### DIFF
--- a/src/kicad_tools/creepage/standards.py
+++ b/src/kicad_tools/creepage/standards.py
@@ -34,7 +34,11 @@ Table provenance (transcribed values -- spot-check before certifying)
 ---------------------------------------------------------------------
 
 * **Creepage** -- IEC 60664-1:2020 Table F.4 (the "Table 4" of older
-  editions) and the harmonised IEC 62368-1:2018 (3rd ed.) Table 17.  Keyed on
+  editions; renumbered Table F.5 in the 2020 Ed. 3.1) and the harmonised
+  IEC 62368-1:2018 (3rd ed.) Table 17.  The full 10 V-1000 V voltage axis
+  transcribed here (including the sub-50 V head) is cross-checked against the
+  controlled copy of **EN 60664-1:2007 Table F.4 (p. 67)**, "Creepage
+  distances to avoid failure due to tracking".  Keyed on
   **RMS working voltage**, pollution degree, and material group
   (I: CTI >= 600, II: 400 <= CTI < 600, IIIa: 175 <= CTI < 400,
   IIIb: 100 <= CTI < 175).  For pollution degree 1 the standard does not
@@ -114,7 +118,18 @@ def normalize_material_group(group: str) -> str:
 
 # Ascending RMS working-voltage rows shared by every creepage column below.
 # IEC 60664-1:2020 Table F.4 / IEC 62368-1:2018 Table 17 (voltage axis).
+# The sub-50 V head (10-40 V) is the low end of EN 60664-1:2007 Table F.4
+# (p. 67); without it every working voltage <= 50 V spuriously stepped up to
+# the 50 V row (1.2 mm @ PD2/IIIa), which no dense-board pad gap can meet and
+# which kept the creepage gate from ever passing (issue #4402).
 _CREEPAGE_VOLTAGE_ROWS: tuple[float, ...] = (
+    10.0,
+    12.5,
+    16.0,
+    20.0,
+    25.0,
+    32.0,
+    40.0,
     50.0,
     63.0,
     80.0,
@@ -133,13 +148,23 @@ _CREEPAGE_VOLTAGE_ROWS: tuple[float, ...] = (
 
 # Creepage distances in mm, aligned index-for-index with _CREEPAGE_VOLTAGE_ROWS.
 # Source: IEC 60664-1:2020 Table F.4 (== IEC 62368-1:2018 Table 17, harmonised).
+# The sub-50 V rows (10-40 V) are the general-material columns of
+# EN 60664-1:2007 Table F.4 (p. 67); material groups I/II/III are identical
+# through 32 V and first diverge at 40 V (PD2: 0.56/0.80/1.10) per the standard.
 # PD1 is material-group independent (single column); PD2/PD3 subdivide by group.
-# Rows read left-to-right at: 50, 63, 80, 100, 125, 160, 200, 250, 320, 400,
-# 500, 630, 800, 1000 V.
+# Rows read left-to-right at: 10, 12.5, 16, 20, 25, 32, 40, 50, 63, 80, 100,
+# 125, 160, 200, 250, 320, 400, 500, 630, 800, 1000 V.
 _CREEPAGE_MM: dict[int, dict[str, tuple[float, ...]]] = {
     # Pollution degree 1 -- Table F.4, PD1 column (no material-group split).
     1: {
         _PD1_ANY: (
+            0.080,  # 10 V
+            0.090,  # 12.5 V
+            0.100,  # 16 V
+            0.110,  # 20 V
+            0.125,  # 25 V
+            0.14,  # 32 V
+            0.16,  # 40 V
             0.18,  # 50 V
             0.20,  # 63 V
             0.22,  # 80 V
@@ -159,6 +184,13 @@ _CREEPAGE_MM: dict[int, dict[str, tuple[float, ...]]] = {
     # Pollution degree 2 -- Table F.4, PD2 columns.
     2: {
         "I": (
+            0.40,  # 10 V
+            0.42,  # 12.5 V
+            0.45,  # 16 V
+            0.48,  # 20 V
+            0.50,  # 25 V
+            0.53,  # 32 V
+            0.56,  # 40 V
             0.6,  # 50 V
             0.63,  # 63 V
             0.67,  # 80 V
@@ -175,6 +207,13 @@ _CREEPAGE_MM: dict[int, dict[str, tuple[float, ...]]] = {
             5.0,  # 1000 V
         ),
         "II": (
+            0.40,  # 10 V
+            0.42,  # 12.5 V
+            0.45,  # 16 V
+            0.48,  # 20 V
+            0.50,  # 25 V
+            0.53,  # 32 V
+            0.80,  # 40 V
             0.85,  # 50 V
             0.9,  # 63 V
             0.9,  # 80 V
@@ -191,6 +230,13 @@ _CREEPAGE_MM: dict[int, dict[str, tuple[float, ...]]] = {
             7.1,  # 1000 V
         ),
         "IIIa": (
+            0.40,  # 10 V
+            0.42,  # 12.5 V
+            0.45,  # 16 V
+            0.48,  # 20 V
+            0.50,  # 25 V
+            0.53,  # 32 V
+            1.10,  # 40 V
             1.2,  # 50 V
             1.25,  # 63 V
             1.3,  # 80 V
@@ -212,6 +258,13 @@ _CREEPAGE_MM: dict[int, dict[str, tuple[float, ...]]] = {
     # lookup fails loud rather than aliasing to IIIa.
     3: {
         "I": (
+            1.00,  # 10 V
+            1.05,  # 12.5 V
+            1.10,  # 16 V
+            1.20,  # 20 V
+            1.25,  # 25 V
+            1.30,  # 32 V
+            1.40,  # 40 V
             1.5,  # 50 V
             1.6,  # 63 V
             1.7,  # 80 V
@@ -228,6 +281,13 @@ _CREEPAGE_MM: dict[int, dict[str, tuple[float, ...]]] = {
             12.5,  # 1000 V
         ),
         "II": (
+            1.00,  # 10 V
+            1.05,  # 12.5 V
+            1.10,  # 16 V
+            1.20,  # 20 V
+            1.25,  # 25 V
+            1.30,  # 32 V
+            1.60,  # 40 V
             1.7,  # 50 V
             1.8,  # 63 V
             1.9,  # 80 V
@@ -244,6 +304,13 @@ _CREEPAGE_MM: dict[int, dict[str, tuple[float, ...]]] = {
             14.0,  # 1000 V
         ),
         "IIIa": (
+            1.00,  # 10 V
+            1.05,  # 12.5 V
+            1.10,  # 16 V
+            1.20,  # 20 V
+            1.25,  # 25 V
+            1.30,  # 32 V
+            1.80,  # 40 V
             1.9,  # 50 V
             2.0,  # 63 V
             2.1,  # 80 V

--- a/tests/creepage/test_creepage_engine.py
+++ b/tests/creepage/test_creepage_engine.py
@@ -395,15 +395,16 @@ def test_cross_domain_pair_matches_flat_voltage_lookup(tmp_path):
     assert pair.provenance["voltage"]["delta_v_v"] == 150.0
 
 
-def test_sub_table_floor_steps_up_to_fifty_volt_row(tmp_path):
-    # dv=30 V (< the 50 V lowest row) conservatively uses the 50 V row.
+def test_sub_50v_steps_up_to_nearest_tabulated_row(tmp_path):
+    # dv=30 V steps up to the 32 V row of Table F.4 (issue #4402: the sub-50 V
+    # rows are now tabulated, so a 30 V pair no longer jumps to the 50 V row).
     pcb = _load(tmp_path, board_source(with_slot=False))
     hv = resolve_hv_nets(pcb, "HV", _hv_map())
     report = _census_map(pcb, hv, {"L_MAINS": 30.0})
     pair = _conductor_pair(report, "GND")
-    expected, _ = _std().required_creepage(50.0, 2, "IIIa")
+    expected, _ = _std().required_creepage(32.0, 2, "IIIa")
     assert pair.required_creepage_mm == pytest.approx(expected)
-    assert pair.provenance["creepage"]["voltage_row_used_v"] == 50.0
+    assert pair.provenance["creepage"]["voltage_row_used_v"] == 32.0
 
 
 def test_board_edge_uses_edge_voltage_default_zero(tmp_path):

--- a/tests/creepage/test_standards.py
+++ b/tests/creepage/test_standards.py
@@ -119,9 +119,52 @@ def test_between_rows_steps_up_not_interpolated():
 
 def test_below_lowest_row_steps_up_to_lowest():
     std = get_standard("iec60664")
+    # 12 V sits between the 10 and 12.5 V rows -> steps UP to the 12.5 V row.
     value, prov = std.required_creepage(12, 2, "IIIa")
-    assert prov["voltage_row_used_v"] == 50.0  # lowest tabulated row
-    assert value == pytest.approx(1.2)
+    assert prov["voltage_row_used_v"] == 12.5
+    assert value == pytest.approx(0.42)
+
+
+def test_below_lowest_tabulated_row_steps_up_to_10v():
+    """Working voltages below the F.4 floor (10 V) step up to the 10 V row.
+
+    The reported ΔV = 1.65 V regression (issue #4402): before the sub-50 V
+    rows were added this stepped up to the 50 V row (1.2 mm) and no dense-board
+    pad gap could satisfy it.  It now resolves to the 10 V row -> 0.40 mm.
+    """
+    std = get_standard("iec60664")
+    for v in (1.65, 5.0, 9.9):
+        value, prov = std.required_creepage(v, 2, "IIIa")
+        assert prov["voltage_row_used_v"] == 10.0, f"{v} V did not step up to 10 V row"
+        assert value == pytest.approx(0.40)
+
+
+def test_sub_50v_rows_exact_boundaries():
+    """Exact-row and just-above-boundary step-up across the new sub-50 V rows."""
+    std = get_standard("iec60664")
+    # Exact-row hits.
+    assert std.required_creepage(10, 2, "IIIa")[0] == pytest.approx(0.40)
+    assert std.required_creepage(12.5, 2, "IIIa")[0] == pytest.approx(0.42)
+    assert std.required_creepage(16, 2, "IIIa")[0] == pytest.approx(0.45)
+    assert std.required_creepage(20, 2, "IIIa")[0] == pytest.approx(0.48)
+    assert std.required_creepage(25, 2, "IIIa")[0] == pytest.approx(0.50)
+    assert std.required_creepage(32, 2, "IIIa")[0] == pytest.approx(0.53)
+    # 40 V is where the material groups first diverge.
+    assert std.required_creepage(40, 2, "I")[0] == pytest.approx(0.56)
+    assert std.required_creepage(40, 2, "II")[0] == pytest.approx(0.80)
+    assert std.required_creepage(40, 2, "IIIa")[0] == pytest.approx(1.10)
+    assert std.required_creepage(40, 3, "IIIa")[0] == pytest.approx(1.80)
+    # Just above the 10 V row -> steps up to the 12.5 V row (no interpolation).
+    value, prov = std.required_creepage(10.1, 2, "IIIa")
+    assert prov["voltage_row_used_v"] == 12.5
+    assert value == pytest.approx(0.42)
+
+
+def test_sub_50v_pd1_column():
+    """PD1 sub-50 V values are material-group independent."""
+    std = get_standard("iec60664")
+    assert std.required_creepage(10, 1, "II")[0] == pytest.approx(0.080)
+    assert std.required_creepage(40, 1, "II")[0] == pytest.approx(0.16)
 
 
 def test_above_highest_row_fails_loud():


### PR DESCRIPTION
## Summary

The Table F.4 creepage transcription in `standards.py` started at the **50 V** row, so the (correct) step-up rule mapped *every* working voltage ≤ 50 V to the 50 V row — 1.2 mm at PD2/IIIa. No dense-board adjacent-pad gap (0805 ≈ 0.8 mm, SOT-23/DPAK ≈ 0.635–0.95 mm) can satisfy 1.2 mm, so the `creepage` exit-code gate could never go green on a real board (issue #4402). A reported ΔV = 1.65 V pair was being assigned the full 50 V / 1.2 mm requirement.

This prepends the seven missing sub-50 V rows so low-ΔV pairs resolve against the standard's actual requirement (floor drops to 0.40 mm), unblocking the gate.

## Changes

- `src/kicad_tools/creepage/standards.py`
  - Prepend `10, 12.5, 16, 20, 25, 32, 40 V` to `_CREEPAGE_VOLTAGE_ROWS`.
  - Index-align the seven new values to every `_CREEPAGE_MM` column: PD1 (`_PD1_ANY`), PD2 I/II/IIIa, PD3 I/II/IIIa. The `_CREEPAGE_MM[2]["IIIb"] = ...IIIa` alias carries IIIb automatically.
  - General-material values from EN 60664-1:2007 Table F.4 (p. 67). Groups I/II/III are identical through 32 V and first diverge at 40 V (PD2: 0.56/0.80/1.10).
  - Refresh the row-enumeration comments and add the EN 60664-1:2007 Table F.4 (p. 67) citation to the module provenance block.
- `tests/creepage/test_standards.py` — update `test_below_lowest_row_steps_up_to_lowest` (12 V now → 12.5 V row / 0.42 mm) and add coverage for the new rows, PD1 sub-50 V, exact-boundary/just-above step-up, and `< 10 V` → 10 V row / 0.40 mm.
- `tests/creepage/test_creepage_engine.py` — update the census test that encoded the 50 V floor (30 V now steps up to the 32 V row / 0.53 mm).

## Scope pins (per curator)

- Floor drops to **0.40 mm** for any nonzero ΔV; 10 V is F.4's lowest row — **no sub-10 V rows added** (`< 10 V` correctly steps up to 10 V).
- Clearance Table F.2 is **NOT** truncated (lowest row already 330 V) — creepage-only fix.
- IEC 62368-1 Table 17 shares `_CREEPAGE_MM` and is fixed by the same change.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| ΔV = 1.65 V / 5 V → 10 V row, 0.40 mm | ✅ | `test_below_lowest_tabulated_row_steps_up_to_10v` |
| Exact-boundary step-up at each new row (40 V group divergence 0.56/0.80/1.10, PD3 1.80) | ✅ | `test_sub_50v_rows_exact_boundaries` |
| Just-above boundary (10.1 V → 12.5 V row, no interpolation) | ✅ | `test_sub_50v_rows_exact_boundaries` |
| PD1 sub-50 V (10 V → 0.080, 40 V → 0.16) | ✅ | `test_sub_50v_pd1_column` |
| Existing 50 V-floor test updated (12 V → 12.5 V / 0.42 mm) | ✅ | `test_below_lowest_row_steps_up_to_lowest` |
| Monotonic-in-voltage + I ≤ II ≤ IIIa ordering over extended range | ✅ | existing consistency tests pass |
| 62368 parity (shared `_CREEPAGE_MM`) | ✅ | `test_two_standards_are_harmonised` |
| `> 1000 V` and IIIb/PD3 still fail loud | ✅ | existing fail-loud tests pass |

## Test Plan

- `uv run pytest tests/creepage/ -q` → **165 passed**
- `uv run ruff check src/kicad_tools/creepage/standards.py tests/creepage/` → clean
- `uv run ruff format --check` → formatted
- `uv run mypy src/kicad_tools/creepage/standards.py` → no issues

Closes #4402