### PR TITLE
feat(creepage): classify same-footprint pad pairs and add opt-in gate waiver

### DIFF
--- a/src/kicad_tools/cli/commands/creepage.py
+++ b/src/kicad_tools/cli/commands/creepage.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
-    from kicad_tools.creepage.engine import CreepageReport
+    from kicad_tools.creepage.engine import CreepagePair, CreepageReport
 
 # Distinct exit code for "could not classify any HV net on a board that looks
 # like mains" (issue #4354).  Kept separate from 1 ("a measured pair failed its
@@ -225,6 +225,16 @@ def run_creepage_command(args) -> int:
         print(f"Error: standard-table lookup failed: {e}", file=sys.stderr)
         return 1
 
+    # Same-footprint waiver (#4403): mark component-internal pairs as waived so
+    # they drop out of the exit-code gate (report.gate_passed) while remaining
+    # listed (annotated WAIVED).  This is a STANDALONE-CLI opt-in only -- it
+    # never touches report.passed, so the kct audit manufacturing-readiness gate
+    # (which keys off the raw, un-waived result) is unaffected.
+    if getattr(args, "waive_same_footprint", False):
+        for pair in report.pairs:
+            if pair.relationship == "same_footprint":
+                pair.waived = True
+
     # Vacuity guard (issue #4354): a census that resolves ZERO HV nets is only
     # legitimately "nothing to audit" on a genuinely low-voltage board.  When
     # the board carries mains-named copper OR a mains-level working voltage was
@@ -251,10 +261,11 @@ def run_creepage_command(args) -> int:
         _warn_hv_unclassified(report, mains_suspects, working_voltage)
         return EXIT_HV_UNCLASSIFIED
 
-    # Non-zero exit iff any pair fails its governing bound(s).  An empty census
-    # on a genuinely low-voltage board (no mains names, no HV working voltage)
-    # is a clean exit 0.
-    return 0 if report.passed else 1
+    # Non-zero exit iff any NON-waived pair fails its governing bound(s) (#4403).
+    # ``gate_passed`` == ``passed`` unless --waive-same-footprint was supplied, so
+    # the default exit behavior is unchanged.  An empty census on a genuinely
+    # low-voltage board (no mains names, no HV working voltage) is a clean exit 0.
+    return 0 if report.gate_passed else 1
 
 
 def _warn_hv_unclassified(
@@ -293,6 +304,59 @@ def _warn_hv_unclassified(
     )
 
 
+def _result_token(p: CreepagePair) -> str:
+    """Per-row result token: WAIVED for a waived failing pair, else PASS/FAIL."""
+    if p.waived and not p.passed:
+        return "WAIVED"
+    return "PASS" if p.passed else "FAIL"
+
+
+def _rel_token(p: CreepagePair) -> str:
+    """Compact footprint-relationship token for the census tables (#4403)."""
+    return "same-ftpt" if p.relationship == "same_footprint" else "board"
+
+
+def _print_gate_summary(report: CreepageReport, unit_desc: str) -> None:
+    """Print the pass/fail summary, honoring same-footprint waivers (#4403).
+
+    Silence is a false-pass, so the waived list is always surfaced.  When a
+    waiver is active the GATE result (``report.gate_passed``) is reported; the
+    raw ``report.passed`` still counts every pair (and still drives ``kct
+    audit``).
+    """
+    total = len(report.pairs)
+    waived = [p for p in report.pairs if p.waived]
+    gate_failures = [p for p in report.pairs if not p.passed and not p.waived]
+    same_fp = [p for p in report.pairs if p.relationship == "same_footprint"]
+
+    if waived:
+        if gate_failures:
+            print(
+                f"FAIL (gate): {len(gate_failures)}/{total} board pair(s) fail "
+                f"{unit_desc}; {len(waived)} same-footprint pair(s) WAIVED "
+                "(component-rating residuals -- qualify at the component, not the layout)."
+            )
+        else:
+            print(
+                f"PASS (gate): {total - len(waived)}/{total} pair(s) clear "
+                f"{unit_desc}; {len(waived)} same-footprint pair(s) WAIVED "
+                "(component-rating residuals -- qualify at the component, not the layout)."
+            )
+        return
+
+    failures = [p for p in report.pairs if not p.passed]
+    if failures:
+        line = f"FAIL: {len(failures)}/{total} pair(s) fail {unit_desc}."
+    else:
+        line = f"PASS: all {total} pair(s) clear {unit_desc}."
+    if same_fp:
+        line += (
+            f"  ({len(same_fp)} same-footprint pair(s) present -- re-run with "
+            "--waive-same-footprint to exclude component-internal spacing from the gate.)"
+        )
+    print(line)
+
+
 def _render_table(report: CreepageReport, *, guard_triggered: bool = False) -> None:
     """Print the human-readable census table (phase-1 / manual --min mode)."""
     if not report.has_hv_nets:
@@ -324,25 +388,20 @@ def _render_table(report: CreepageReport, *, guard_triggered: bool = False) -> N
 
     header = (
         f"{'HV net':<16} {'Against':<16} {'Layer':<7} "
-        f"{'Clearance':>10} {'Creepage':>10} {'Margin':>10} {'Result':>7}"
+        f"{'Clearance':>10} {'Creepage':>10} {'Margin':>10} {'Rel':>10} {'Result':>7}"
     )
     print(header)
     print("-" * len(header))
     for p in report.pairs:
-        result = "PASS" if p.passed else "FAIL"
+        result = _result_token(p)
         print(
             f"{p.net_a:<16} {p.net_b:<16} {p.layer:<7} "
             f"{p.clearance_mm:>9.3f}  {p.creepage_mm:>9.3f}  "
-            f"{p.margin_mm:>9.3f}  {result:>7}"
+            f"{p.margin_mm:>9.3f}  {_rel_token(p):>10}  {result:>7}"
         )
 
     print()
-    failures = [p for p in report.pairs if not p.passed]
-    total = len(report.pairs)
-    if failures:
-        print(f"FAIL: {len(failures)}/{total} pair(s) below {report.min_mm:.3f} mm creepage.")
-    else:
-        print(f"PASS: all {total} pair(s) clear {report.min_mm:.3f} mm creepage.")
+    _print_gate_summary(report, f"{report.min_mm:.3f} mm creepage")
 
 
 def _render_table_standard(report: CreepageReport, *, guard_triggered: bool = False) -> None:
@@ -418,28 +477,20 @@ def _render_table_standard(report: CreepageReport, *, guard_triggered: bool = Fa
     header = (
         f"{'HV net':<14} {'Against':<14} {'Layer':<6} "
         f"{'Clnce':>8} {'ReqCl':>8} {'Creep':>8} {'ReqCr':>8} "
-        f"{'Margin':>8} {'Govern':>8} {'Result':>7}"
+        f"{'Margin':>8} {'Govern':>8} {'Rel':>10} {'Result':>7}"
     )
     print(header)
     print("-" * len(header))
     for p in report.pairs:
-        result = "PASS" if p.passed else "FAIL"
+        result = _result_token(p)
         req_cl = p.required_clearance_mm if p.required_clearance_mm is not None else 0.0
         req_cr = p.required_creepage_mm if p.required_creepage_mm is not None else 0.0
         print(
             f"{p.net_a:<14} {p.net_b:<14} {p.layer:<6} "
             f"{p.clearance_mm:>8.3f} {req_cl:>8.3f} "
             f"{p.creepage_mm:>8.3f} {req_cr:>8.3f} "
-            f"{p.margin_mm:>8.3f} {p.governing_bound:>8} {result:>7}"
+            f"{p.margin_mm:>8.3f} {p.governing_bound:>8} {_rel_token(p):>10} {result:>7}"
         )
 
     print()
-    failures = [p for p in report.pairs if not p.passed]
-    total = len(report.pairs)
-    if failures:
-        print(
-            f"FAIL: {len(failures)}/{total} pair(s) fail the derived creepage/clearance "
-            "requirement."
-        )
-    else:
-        print(f"PASS: all {total} pair(s) clear the derived creepage/clearance requirement.")
+    _print_gate_summary(report, "the derived creepage/clearance requirement")

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -542,6 +542,24 @@ def _add_creepage_parser(subparsers) -> None:
             "conservative assumption for common FR-4."
         ),
     )
+    # Same-footprint waiver (#4403): pairs whose binding gap is between two pads
+    # of ONE footprint are component pin-pitch (functional insulation governed
+    # by the component's own rating, not board creepage tables).  Off by default
+    # -- when set, such pairs stay listed (annotated WAIVED) but drop out of the
+    # exit-code gate so board-level defects are no longer buried.  This is a
+    # STANDALONE-CLI opt-in only: it never relaxes the ``kct audit``
+    # manufacturing-readiness gate (which keys off the raw, un-waived result).
+    creepage_parser.add_argument(
+        "--waive-same-footprint",
+        dest="waive_same_footprint",
+        action="store_true",
+        help=(
+            "Exclude same-footprint pad pairs (component-internal spacing) from "
+            "the exit-code gate.  They remain listed (annotated WAIVED) as "
+            "component-rating residuals -- qualify them at the component, not the "
+            "layout.  Does NOT affect the kct audit manufacturing-readiness gate."
+        ),
+    )
     creepage_parser.add_argument(
         "--format",
         choices=["table", "json"],

--- a/src/kicad_tools/creepage/engine.py
+++ b/src/kicad_tools/creepage/engine.py
@@ -203,6 +203,18 @@ class CreepagePair:
     required_creepage_mm: float | None = None
     required_clearance_mm: float | None = None
     provenance: dict[str, Any] = field(default_factory=dict)
+    # Footprint relationship of the binding measurement (#4403).  ``"board"``
+    # is a layout-fixable net-to-net (or net-to-edge) approach; ``"same_footprint"``
+    # means the binding gap is between two pads of a SINGLE footprint (component
+    # pin pitch), which the board layout cannot change -- per IEC 60664-1 that is
+    # functional insulation governed by the component's own rating, not the
+    # board's creepage tables.
+    relationship: str = "board"  # "board" | "same_footprint"
+    # Set True only when the operator passes ``--waive-same-footprint`` AND this
+    # pair is ``relationship == "same_footprint"``.  A waived pair is still listed
+    # (annotated WAIVED) but is excluded from :attr:`CreepageReport.gate_passed`.
+    # It NEVER affects the raw :attr:`CreepageReport.passed` (the safety gate).
+    waived: bool = False
 
     @property
     def governing_creepage_mm(self) -> float:
@@ -265,7 +277,11 @@ class CreepagePair:
 
     def to_dict(self) -> dict[str, Any]:
         # Phase-1 backward compatibility: with no derived requirement (manual
-        # --min only) the JSON schema is byte-for-byte identical to phase 1.
+        # --min only) the JSON schema matched phase 1 byte-for-byte.  The
+        # additive ``relationship`` key (#4403) intentionally changes that
+        # schema in BOTH phase-1 and phase-2 rows -- the serialization
+        # drift-guard tests were updated to include it.  ``waived`` is emitted
+        # only on the rows the operator actually waived.
         base = {
             "net_a": self.net_a,
             "net_b": self.net_b,
@@ -274,8 +290,11 @@ class CreepagePair:
             "clearance_mm": round(self.clearance_mm, 4),
             "creepage_mm": round(self.creepage_mm, 4),
             "margin_mm": round(self.margin_mm, 4),
+            "relationship": self.relationship,
             "pass": self.passed,
         }
+        if self.waived:
+            base["waived"] = True
         if self.required_creepage_mm is None:
             return base
         # Phase-2 (standard) mode: attach the derived requirements + provenance.
@@ -326,8 +345,28 @@ class CreepageReport:
 
     @property
     def passed(self) -> bool:
-        """``True`` when every pair clears its bounds (vacuously true if empty)."""
+        """``True`` when every pair clears its bounds (vacuously true if empty).
+
+        This is the RAW, un-waived result.  The manufacturing-readiness gate
+        (``kct audit`` -> :class:`IsolationStatus`) keys off THIS property, so a
+        same-footprint waiver must NEVER flow into it -- an unqualified
+        component-internal shortfall still blocks manufacturing by default
+        (#4403 safety guard).  Only :attr:`gate_passed` honors waivers, and only
+        the standalone ``kct creepage`` CLI opts into it.
+        """
         return all(p.passed for p in self.pairs)
+
+    @property
+    def gate_passed(self) -> bool:
+        """``True`` when every NON-waived pair clears its bounds (#4403).
+
+        Identical to :attr:`passed` unless the operator waived same-footprint
+        pairs via ``kct creepage --waive-same-footprint``.  Waived pairs remain
+        listed (annotated WAIVED) but drop out of this exit-code gate so the
+        actionable board-level defects are no longer buried under
+        component-rating residuals.
+        """
+        return all(p.passed for p in self.pairs if not p.waived)
 
     @property
     def has_hv_nets(self) -> bool:
@@ -547,6 +586,80 @@ def _net_union_on_layer(pcb: PCB, layer_name: str) -> dict[int, Any]:
         for net_number, parts in _net_geoms_on_layer(pcb, layer_name).items()
         if parts
     }
+
+
+# ---------------------------------------------------------------------------
+# Footprint-membership index for same-footprint classification (#4403)
+# ---------------------------------------------------------------------------
+
+
+class _FootprintPadIndex:
+    """Per-layer footprint -> net -> pad-polygon index (#4403).
+
+    The census unions each net's copper per layer (:func:`_net_union_on_layer`)
+    before pairing, which erases which *pad* -- and therefore which *footprint*
+    -- produced a binding measurement.  This index recovers that identity so a
+    component-internal pad gap (two pads of one package) can be told apart from
+    a board-fixable net-to-net approach.
+
+    It attributes the *binding* measurement: a binding pair ``(net_a, net_b)``
+    with binding straight-line ``clearance`` on ``layer`` is ``same_footprint``
+    iff a **single footprint** holds pads on BOTH nets whose minimum
+    pad-to-pad distance on that layer equals the binding ``clearance`` within a
+    geometric epsilon.  The equality check matters: two nets can share a
+    footprint *and* also approach at a board-level site elsewhere that is the
+    true binding minimum -- when the intra-footprint gap is larger than the
+    binding clearance, something else (a trace, another package) bound it, so
+    the pair is correctly ``board``.
+
+    Reuses the same pad geometry (:func:`_pad_polygon`) and layer-membership
+    test as :func:`_net_geoms_on_layer`, and ``fp.reference`` as the footprint
+    identity -- the same refdes source the hole-to-hole same-footprint downgrade
+    uses (``validate/rules/dimensions.py``).
+    """
+
+    def __init__(self, pcb: PCB) -> None:
+        from kicad_tools.validate.rules.clearance import _pad_polygon
+
+        # layer -> net_number -> set(fp_ref) that has a pad on that net/layer.
+        self._by_net: dict[str, dict[int, set[str]]] = {}
+        # layer -> (fp_ref, net_number) -> [pad polygons].
+        self._pads: dict[str, dict[tuple[str, int], list[Any]]] = {}
+
+        copper_layer_names = [layer.name for layer in pcb.copper_layers]
+        for fp in pcb.footprints:
+            ref = fp.reference
+            if not ref:
+                continue
+            for pad in fp.pads:
+                poly = _pad_polygon(pad, fp)
+                if poly is None or getattr(poly, "is_empty", False):
+                    continue
+                for layer_name in copper_layer_names:
+                    if layer_name in pad.layers or "*.Cu" in pad.layers:
+                        self._by_net.setdefault(layer_name, {}).setdefault(
+                            pad.net_number, set()
+                        ).add(ref)
+                        self._pads.setdefault(layer_name, {}).setdefault(
+                            (ref, pad.net_number), []
+                        ).append(poly)
+
+    def relationship(self, layer_name: str, net_a: int, net_b: int, clearance_mm: float) -> str:
+        """Classify a binding pair as ``"same_footprint"`` or ``"board"``."""
+        by_net = self._by_net.get(layer_name)
+        pads = self._pads.get(layer_name)
+        if not by_net or pads is None:
+            return "board"
+        shared = by_net.get(net_a, set()) & by_net.get(net_b, set())
+        for ref in shared:
+            a_polys = pads.get((ref, net_a), [])
+            b_polys = pads.get((ref, net_b), [])
+            if not a_polys or not b_polys:
+                continue
+            min_dist = min(pa.distance(pb) for pa in a_polys for pb in b_polys)
+            if abs(min_dist - clearance_mm) <= _PASS_TOLERANCE:
+                return "same_footprint"
+        return "board"
 
 
 # ---------------------------------------------------------------------------
@@ -914,6 +1027,11 @@ def compute_creepage_census(
     for layer in pcb.copper_layers:
         layer_unions[layer.name] = _net_union_on_layer(pcb, layer.name)
 
+    # Footprint-membership index (#4403): recovers the pad->footprint identity
+    # the per-net union erases, so each binding pair can be classified as a
+    # board-fixable approach or a component-internal (same-footprint) gap.
+    fp_index = _FootprintPadIndex(pcb)
+
     # --- HV-vs-other-conductor pairs (binding layer = smallest creepage) ---
     # (hv_number, other_number) -> (clearance, creepage, layer)
     #
@@ -946,6 +1064,7 @@ def compute_creepage_census(
     for (hv_num, other_num), (clearance, creepage, layer_name) in best.items():
         net_a_name = hv_nets[hv_num]
         net_b_name = number_to_name.get(other_num, f"net{other_num}")
+        relationship = fp_index.relationship(layer_name, hv_num, other_num, clearance)
         if map_mode:
             req_creep, req_clear, prov = _pair_requirement(net_a_name, net_b_name)
             report.pairs.append(
@@ -959,6 +1078,7 @@ def compute_creepage_census(
                     layer=layer_name,
                     clearance_mm=clearance,
                     creepage_mm=creepage,
+                    relationship=relationship,
                 )
             )
         else:
@@ -970,6 +1090,7 @@ def compute_creepage_census(
                     layer=layer_name,
                     clearance_mm=clearance,
                     creepage_mm=creepage,
+                    relationship=relationship,
                 )
             )
 

--- a/tests/creepage/fixtures.py
+++ b/tests/creepage/fixtures.py
@@ -180,3 +180,105 @@ def board_mains_named_source() -> str:
     parts.append(_footprint("U4", 105, 110, 4, "FUSED_LINE"))
     parts.append(")\n")
     return "".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Same-footprint classification fixtures (Issue #4403)
+# ---------------------------------------------------------------------------
+
+# Header for the same-footprint fixtures.  Nets: L_MAINS (HV via the standard
+# net-class map), plus GND / SRC_NEG / DIV_MID as ordinary conductors.
+_SAMEFP_HEADER = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test_creepage")
+  (general (thickness 1.6))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "L_MAINS")
+  (net 2 "GND")
+  (net 3 "SRC_NEG")
+  (net 4 "DIV_MID")
+"""
+
+
+def _footprint2(ref: str, x: float, y: float, pads: list[tuple]) -> str:
+    """A multi-pad SMD footprint at (x, y).
+
+    ``pads`` is a list of ``(number, net_number, net_name, local_x, local_y)``;
+    each pad is a 0.6 x 0.6 mm rect so a 1.0 mm pad-centre pitch leaves a 0.4 mm
+    copper-edge gap (below any realistic mains creepage requirement).
+    """
+    pad_lines = "\n".join(
+        f'    (pad "{num}" smd rect (at {lx} {ly}) (size 0.6 0.6) (layers "F.Cu")\n'
+        f'      (net {nn} "{name}"))'
+        for num, nn, name, lx, ly in pads
+    )
+    # A Reference property is required so ``fp.reference`` is populated -- the
+    # same-footprint classification (#4403) keys the binding measurement on it.
+    ref_prop = f'    (property "Reference" "{ref}" (at 0 0 0) (layer "F.SilkS"))\n'
+    return f'  (footprint "test:pad2" (layer "F.Cu") (at {x} {y})\n{ref_prop}{pad_lines}\n  )\n'
+
+
+def board_same_footprint_fail_source() -> str:
+    """Board exercising all three binding relationships (#4403).
+
+    * **same_footprint** -- ``FET1`` carries an ``L_MAINS`` pad and an
+      ``SRC_NEG`` pad 1.0 mm apart (0.4 mm copper gap).  ``SRC_NEG`` exists on
+      no other footprint, so the only ``L_MAINS <-> SRC_NEG`` approach is this
+      component-internal gap.
+    * **board** -- ``P1`` (``L_MAINS``) and ``P2`` (``GND``) sit 1.0 mm apart
+      on distinct footprints, so the binding ``L_MAINS <-> GND`` gap is
+      board-fixable.
+    * **shared-footprint but board-binds** -- ``FET2`` holds ``L_MAINS`` and
+      ``DIV_MID`` pads 2.0 mm apart (1.7 mm gap), but ``P3`` (``L_MAINS``) and
+      ``P4`` (``DIV_MID``) approach to 0.4 mm elsewhere.  Because the binding
+      minimum (0.4 mm) is NOT the intra-footprint gap (1.7 mm), the pair is
+      correctly ``board`` -- this is the equality-check guard.
+
+    All three binding gaps are 0.4 mm, so every conductor pair FAILs a
+    >=1 mm requirement -- used for the "board fail remains after waiver" path.
+    """
+    parts = [_SAMEFP_HEADER, _OUTLINE]
+    # same_footprint: L_MAINS + SRC_NEG in one package, 0.4 mm gap.
+    parts.append(
+        _footprint2("FET1", 110, 110, [("1", 1, "L_MAINS", 0, 0), ("2", 3, "SRC_NEG", 0, 1.0)])
+    )
+    # board: L_MAINS + GND on distinct footprints, 0.4 mm gap.
+    parts.append(_footprint2("P1", 120, 110, [("1", 1, "L_MAINS", 0, 0)]))
+    parts.append(_footprint2("P2", 120, 111, [("1", 2, "GND", 0, 0)]))
+    # shared-footprint but board-binds: FET2 holds both nets 1.7 mm apart, but
+    # P3/P4 approach to 0.4 mm, so DIV_MID binds board-level, not intra-FET2.
+    parts.append(
+        _footprint2("FET2", 110, 115, [("1", 1, "L_MAINS", 0, 0), ("2", 4, "DIV_MID", 0, 2.0)])
+    )
+    parts.append(_footprint2("P3", 130, 110, [("1", 1, "L_MAINS", 0, 0)]))
+    parts.append(_footprint2("P4", 130, 111, [("1", 4, "DIV_MID", 0, 0)]))
+    parts.append(")\n")
+    return "".join(parts)
+
+
+def board_same_footprint_only_source() -> str:
+    """Board whose ONLY sub-requirement gap is a same-footprint pair (#4403).
+
+    ``FET1`` carries an ``L_MAINS`` pad and an ``SRC_NEG`` pad 0.4 mm apart (the
+    same_footprint fail).  ``P1`` (``L_MAINS``) and ``P2`` (``GND``) sit ~7 mm
+    apart, so the board-level ``L_MAINS <-> GND`` pair and the board-edge pairs
+    all clear a ~1 mm requirement.  With ``--waive-same-footprint`` the gate then
+    passes (exit 0); without it, the same-footprint fail exits 1.
+    """
+    parts = [_SAMEFP_HEADER, _OUTLINE]
+    parts.append(
+        _footprint2("FET1", 110, 110, [("1", 1, "L_MAINS", 0, 0), ("2", 3, "SRC_NEG", 0, 1.0)])
+    )
+    # Board-level L_MAINS <-> GND ~7 mm apart -> clears a ~1 mm requirement.
+    parts.append(_footprint2("P1", 118, 110, [("1", 1, "L_MAINS", 0, 0)]))
+    parts.append(_footprint2("P2", 118, 118, [("1", 2, "GND", 0, 0)]))
+    parts.append(")\n")
+    return "".join(parts)

--- a/tests/creepage/test_creepage_cli.py
+++ b/tests/creepage/test_creepage_cli.py
@@ -20,6 +20,8 @@ from .fixtures import (
     board_benign_suspect_names_source,
     board_mains_named_source,
     board_no_hv_source,
+    board_same_footprint_fail_source,
+    board_same_footprint_only_source,
     board_source,
 )
 
@@ -267,6 +269,107 @@ def test_benign_suspect_named_board_exits_zero(tmp_path, capsys):
     assert rc == 0
     assert "Nothing to audit -- exit 0" in captured.out
     assert "WARNING" not in captured.err
+
+
+# ---------------------------------------------------------------------------
+# #4403 same-footprint waiver: classify + gate on --waive-same-footprint.
+# ---------------------------------------------------------------------------
+
+
+def test_same_footprint_tagged_in_json(tmp_path, capsys):
+    pcb = _write(tmp_path, board_same_footprint_only_source())
+    ncm = _hv_map_file(tmp_path)
+    _run(["creepage", str(pcb), "--net-class-map", str(ncm), "--min", "1.0", "--format", "json"])
+    payload = json.loads(capsys.readouterr().out)
+    src = next(p for p in payload["pairs"] if p["net_b"] == "SRC_NEG")
+    gnd = next(p for p in payload["pairs"] if p["net_b"] == "GND")
+    assert src["relationship"] == "same_footprint"
+    assert gnd["relationship"] == "board"
+    # Without the waiver flag nothing is marked waived.
+    assert "waived" not in src
+
+
+def test_waiver_off_same_footprint_fail_exits_nonzero(tmp_path, capsys):
+    # Default (flag absent): a same-footprint fail still fails the gate (exit 1),
+    # exactly as before -- the waiver is opt-in.
+    pcb = _write(tmp_path, board_same_footprint_only_source())
+    ncm = _hv_map_file(tmp_path)
+    rc = _run(["creepage", str(pcb), "--net-class-map", str(ncm), "--min", "1.0"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "FAIL" in out
+    # The relationship split is surfaced to prompt the operator toward the flag.
+    assert "same-footprint" in out
+
+
+def test_waiver_on_only_same_footprint_fail_exits_zero(tmp_path, capsys):
+    # With --waive-same-footprint and the ONLY fail being same-footprint, the
+    # gate passes (exit 0) but the pair is still listed (annotated WAIVED).
+    pcb = _write(tmp_path, board_same_footprint_only_source())
+    ncm = _hv_map_file(tmp_path)
+    rc = _run(
+        [
+            "creepage",
+            str(pcb),
+            "--net-class-map",
+            str(ncm),
+            "--min",
+            "1.0",
+            "--waive-same-footprint",
+        ]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "WAIVED" in out
+    assert "SRC_NEG" in out  # still listed, never dropped
+    assert "PASS (gate)" in out
+
+
+def test_waiver_on_board_fail_still_exits_nonzero(tmp_path, capsys):
+    # A board-level fail must still fail the gate even when same-footprint pairs
+    # are waived.
+    pcb = _write(tmp_path, board_same_footprint_fail_source())
+    ncm = _hv_map_file(tmp_path)
+    rc = _run(
+        [
+            "creepage",
+            str(pcb),
+            "--net-class-map",
+            str(ncm),
+            "--min",
+            "1.0",
+            "--waive-same-footprint",
+        ]
+    )
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "FAIL (gate)" in out
+    assert "WAIVED" in out  # the same-footprint pair is annotated but excluded
+
+
+def test_waiver_on_json_marks_waived_true(tmp_path, capsys):
+    pcb = _write(tmp_path, board_same_footprint_only_source())
+    ncm = _hv_map_file(tmp_path)
+    _run(
+        [
+            "creepage",
+            str(pcb),
+            "--net-class-map",
+            str(ncm),
+            "--min",
+            "1.0",
+            "--waive-same-footprint",
+            "--format",
+            "json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    src = next(p for p in payload["pairs"] if p["net_b"] == "SRC_NEG")
+    gnd = next(p for p in payload["pairs"] if p["net_b"] == "GND")
+    assert src["waived"] is True
+    assert "waived" not in gnd  # board pairs are never waived
+    # The report-level passed stays False (raw) -- only the exit code (gate) flips.
+    assert payload["passed"] is False
 
 
 def test_missing_pcb_file_errors(tmp_path, capsys):

--- a/tests/creepage/test_creepage_engine.py
+++ b/tests/creepage/test_creepage_engine.py
@@ -30,7 +30,13 @@ from kicad_tools.creepage.engine import (
     surface_path_length,
 )
 
-from .fixtures import board_mains_named_source, board_no_hv_source, board_source
+from .fixtures import (
+    board_mains_named_source,
+    board_no_hv_source,
+    board_same_footprint_fail_source,
+    board_same_footprint_only_source,
+    board_source,
+)
 
 pytestmark = pytest.mark.skipif(not has_shapely(), reason="creepage requires shapely")
 
@@ -599,3 +605,87 @@ def test_no_map_output_byte_identical_to_baseline(tmp_path):
     # voltage_map=None disables the union even when a threshold is present.
     same_no_map = resolve_hv_nets(pcb, "HV", _hv_map(), voltage_map=None, census_threshold=30.0)
     assert same_no_map == baseline
+
+
+# ---------------------------------------------------------------------------
+# Same-footprint classification + gate_passed (Issue #4403)
+# ---------------------------------------------------------------------------
+
+
+def _census_samefp(pcb, min_mm=1.0):
+    hv = resolve_hv_nets(pcb, "HV", _hv_map())
+    return compute_creepage_census(pcb, hv, min_mm=min_mm)
+
+
+def test_intra_footprint_pad_gap_classifies_same_footprint(tmp_path):
+    # FET1 holds L_MAINS + SRC_NEG pads 0.4 mm apart; SRC_NEG exists on no other
+    # footprint, so the binding L_MAINS<->SRC_NEG gap is component-internal.
+    report = _census_samefp(_load(tmp_path, board_same_footprint_fail_source()))
+    assert _conductor_pair(report, "SRC_NEG").relationship == "same_footprint"
+
+
+def test_net_to_net_board_approach_classifies_board(tmp_path):
+    # P1(L_MAINS) and P2(GND) are distinct footprints 0.4 mm apart -> board.
+    report = _census_samefp(_load(tmp_path, board_same_footprint_fail_source()))
+    assert _conductor_pair(report, "GND").relationship == "board"
+
+
+def test_shared_footprint_but_board_binds_classifies_board(tmp_path):
+    # FET2 holds L_MAINS + DIV_MID 1.7 mm apart, but P3/P4 approach to 0.4 mm.
+    # Because the binding minimum (0.4) is NOT the intra-footprint gap (1.7),
+    # the pair is board-level -- the equality-check guard.
+    report = _census_samefp(_load(tmp_path, board_same_footprint_fail_source()))
+    div = _conductor_pair(report, "DIV_MID")
+    assert div.clearance_mm == pytest.approx(0.4, abs=1e-3)
+    assert div.relationship == "board"
+
+
+def test_edge_pair_is_always_board(tmp_path):
+    report = _census_samefp(_load(tmp_path, board_same_footprint_fail_source()))
+    edge = next(p for p in report.pairs if p.kind == "edge")
+    assert edge.relationship == "board"
+
+
+def test_relationship_defaults_board_for_plain_board(tmp_path):
+    # The single-pad-per-footprint board has no same-footprint pairs at all.
+    pcb = _load(tmp_path, board_source(with_slot=False))
+    report = compute_creepage_census(pcb, resolve_hv_nets(pcb, "HV", _hv_map()), min_mm=1.5)
+    assert all(p.relationship == "board" for p in report.pairs)
+
+
+def test_gate_passed_excludes_waived_pairs_but_passed_does_not(tmp_path):
+    # A board whose ONLY sub-requirement fail is a same-footprint pair: once that
+    # pair is waived, gate_passed is True while the raw passed stays False.
+    report = _census_samefp(_load(tmp_path, board_same_footprint_only_source()))
+    assert report.passed is False  # SRC_NEG (same_footprint) fails
+    assert report.gate_passed is False  # nothing waived yet
+
+    for p in report.pairs:
+        if p.relationship == "same_footprint":
+            p.waived = True
+    assert report.gate_passed is True  # waived pair drops out of the gate
+    assert report.passed is False  # raw result still counts it (safety gate)
+
+
+def test_gate_passed_still_fails_on_a_board_pair_after_waiver(tmp_path):
+    # With a board-level fail present, waiving same-footprint pairs must NOT
+    # rescue the gate.
+    report = _census_samefp(_load(tmp_path, board_same_footprint_fail_source()))
+    for p in report.pairs:
+        if p.relationship == "same_footprint":
+            p.waived = True
+    assert report.gate_passed is False  # GND / DIV_MID board fails remain
+    assert report.passed is False
+
+
+def test_relationship_serialized_always_and_waived_only_when_true(tmp_path):
+    report = _census_samefp(_load(tmp_path, board_same_footprint_only_source()))
+    same_fp = _conductor_pair(report, "SRC_NEG")
+    board = _conductor_pair(report, "GND")
+    # relationship is always present; waived only appears once set True.
+    assert same_fp.to_dict()["relationship"] == "same_footprint"
+    assert "waived" not in same_fp.to_dict()
+    same_fp.waived = True
+    assert same_fp.to_dict()["waived"] is True
+    assert board.to_dict()["relationship"] == "board"
+    assert "waived" not in board.to_dict()

--- a/tests/creepage/test_creepage_standards_cli.py
+++ b/tests/creepage/test_creepage_standards_cli.py
@@ -108,6 +108,10 @@ def test_standard_json_carries_provenance(tmp_path, capsys):
         assert pair["required_clearance_mm"] == 0.2
         assert "clearance_pass" in pair
         assert "provenance" in pair
+        # Phase-2 drift-guard (#4403): ``relationship`` is always emitted; the
+        # single-pad fixture has no same-footprint pairs, and none are waived.
+        assert pair["relationship"] == "board"
+        assert "waived" not in pair
 
 
 def test_standard_fail_when_requirement_not_met(tmp_path, capsys):
@@ -284,6 +288,8 @@ def test_min_only_json_schema_unchanged(tmp_path, capsys):
         "passed",
     }
     for pair in payload["pairs"]:
+        # Drift-guard: ``relationship`` is now an always-on additive key (#4403);
+        # ``waived`` appears only on waived rows (none here).
         assert set(pair.keys()) == {
             "net_a",
             "net_b",
@@ -292,8 +298,10 @@ def test_min_only_json_schema_unchanged(tmp_path, capsys):
             "clearance_mm",
             "creepage_mm",
             "margin_mm",
+            "relationship",
             "pass",
         }
+        assert pair["relationship"] == "board"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

On dense HV boards, most `kct creepage` FAILs are between two pads of a **single footprint** (a FET's D/S pads, an opto's adjacent pins, a divider resistor's own pads). Board layout cannot change a package's pin pitch; per IEC 60664-1 that spacing is functional insulation governed by the component's own rating, not the board's creepage tables. The census unions each net's copper per layer before pairing (`_net_union_on_layer`), which erased the pad→footprint identity, so these component-internal residuals were reported byte-for-byte identically to board-fixable gaps — burying the handful of genuinely layout-actionable defects.

This classifies each binding pair as `board` or `same_footprint` and lets the operator waive same-footprint pairs from the exit-code gate (opt-in) while keeping them listed (annotated WAIVED).

## Changes

- **`creepage/engine.py`**: `CreepagePair` gains `relationship` ("board" | "same_footprint") and `waived` fields; `to_dict()` emits `relationship` always and `waived` only when True. New `_FootprintPadIndex` does an up-front per-layer footprint-membership scan (reusing `_pad_polygon` + `fp.reference`, the same identity source as the `dimensions.py:263` hole-to-hole downgrade) and attributes the **binding** measurement: `same_footprint` iff a single footprint holds pads on both nets whose min pad-to-pad distance equals the binding clearance within `_PASS_TOLERANCE`. The equality check keeps a shared-footprint pair that actually binds board-level classified as `board`. Added `CreepageReport.gate_passed` = `all(p.passed for p in pairs if not p.waived)`.
- **`cli/parser.py`**: registered `--waive-same-footprint` (`store_true`, default OFF).
- **`cli/commands/creepage.py`**: when the flag is set, mark `same_footprint` pairs `waived`; the exit code now uses `gate_passed`. Both render paths annotate WAIVED rows, show a `Rel` column, and print a gate-result summary that always surfaces the waived count (silence would be a false-pass).

## Safety guard (load-bearing)

The manufacturing-readiness gate (`auditor.py:405`) blocks on `isolation.passed`, sourced from the engine's raw `CreepageReport.passed`. **The waiver never flows into `passed`** — only the new `gate_passed` and the standalone `kct creepage` CLI opt into it. Threading the waiver into `kct audit` is out of scope, so an unqualified component-internal shortfall still blocks manufacturing readiness by default. Verified: audit/isolation suite (354 passed) unchanged.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `relationship` tag added + classified via footprint-membership scan | ✅ | `_FootprintPadIndex`; engine tests for same_footprint / board / shared-fp-but-board-binds / edge |
| `--waive-same-footprint` (default off) excludes waived pairs from gate, keeps them listed | ✅ | CLI tests: exit 0 when only same-fp fails + WAIVED annotation; exit 1 when a board fail remains |
| `gate_passed` honors waivers; `passed` does not | ✅ | `test_gate_passed_excludes_waived_pairs_but_passed_does_not` |
| Waiver does NOT flow into `passed` / `kct audit` | ✅ | JSON `passed` stays False under waiver; audit suite green; no auditor changes |
| Serialization drift-guards updated for additive `relationship` key | ✅ | phase-1 exact-key guard + phase-2 assertions updated |
| Default behavior unchanged (flag absent) | ✅ | exit codes/tables unchanged; only additive `relationship` key in JSON |

## Test Plan

- `uv run pytest tests/creepage/` — **175 passed** (28 new: engine classification + gate_passed, CLI waiver exit codes + WAIVED annotation + JSON keys, drift-guards).
- Audit/isolation regression: `-k "isolation or auditor or audit"` — **354 passed, 17 skipped**.
- `ruff check` / `ruff format --check` / `mypy` on all changed source — clean.
- Manual: rendered census shows `same-ftpt` / WAIVED rows and the `PASS (gate)` / `FAIL (gate)` summary; exit flips 1→0 only when the sole fails are same-footprint.

**Full Test job must run (do NOT waive it):** serialization drift-guards live in the full Test job.

Closes #4403