### PR TITLE
feat(optimize-placement): add --seed current to warm-start CMA-ES from the current layout

### DIFF
--- a/src/kicad_tools/cli/optimize_placement_cmd.py
+++ b/src/kicad_tools/cli/optimize_placement_cmd.py
@@ -914,8 +914,14 @@ def run_optimize_placement(
         if not quiet:
             print(f"\nGenerating seed placement ({seed_method})...")
 
-        # Generate initial seed
-        seed_vector = _generate_seed(seed_method, components, nets, board_outline)
+        # Generate initial seed. The "current" method warm-starts from the
+        # on-disk footprint positions (via _read_current_vector, the same
+        # encoder used by --dry-run) so the optimizer refines the existing
+        # layout; other methods synthesise a fresh seed.
+        if seed_method == "current":
+            seed_vector = _read_current_vector(pcb_path, components)
+        else:
+            seed_vector = _generate_seed(seed_method, components, nets, board_outline)
 
         # Apply slide-off pre-processing
         if not no_slide_off:
@@ -932,6 +938,16 @@ def run_optimize_placement(
                     f"({slide_result.overlaps_remaining} remaining, "
                     f"{slide_result.iterations_run} iterations)"
                 )
+
+        # Warm-start CMA-ES from the (slid-off) current layout so the
+        # optimizer refines it rather than re-imagining from the bounds
+        # center. CMAESStrategy.initialize honours config.extra["mean"]
+        # (shape-validated + bounds-clamped) and defaults to a tight sigma
+        # when a mean override is present. Other seed methods keep their
+        # historical center-mean behaviour -- their generated seed is only
+        # scored for the "Seed" line below, never fed to the optimizer.
+        if seed_method == "current":
+            config.extra["mean"] = seed_vector.data
 
         # Evaluate seed
         seed_score = _evaluate(

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -5202,10 +5202,16 @@ def _add_optimize_placement_parser(subparsers) -> None:
     )
     op_parser.add_argument(
         "--seed",
-        choices=["force-directed", "random"],
+        choices=["force-directed", "random", "current"],
         default="force-directed",
         dest="seed_method",
-        help="Seed placement method (default: force-directed)",
+        help=(
+            "Seed placement method (default: force-directed). "
+            "'current' warm-starts CMA-ES from the board's existing footprint "
+            "positions with a tight step size, refining the current layout "
+            "instead of re-imagining it -- use it to resolve a few local "
+            "violations without discarding a ratified hand floorplan."
+        ),
     )
     op_parser.add_argument(
         "--weights",

--- a/src/kicad_tools/placement/cmaes_strategy.py
+++ b/src/kicad_tools/placement/cmaes_strategy.py
@@ -124,8 +124,11 @@ class CMAESStrategy(PlacementStrategy):
         """Initialize the CMA-ES optimizer and produce initial population.
 
         Sets up the CMAwM optimizer with:
-        - Mean at the center of the bounded region
-        - Sigma as 1/4 of the average range (covers ~95% of the space)
+        - Mean at the center of the bounded region, or a caller-supplied
+          warm-start mean (``config.extra["mean"]``) for refining an existing
+          layout instead of re-imagining from the center.
+        - Sigma as 1/4 of the average range (covers ~95% of the space), or a
+          much tighter step when warm-starting so refinement stays local.
         - Discrete steps for rotation and side variables
         - Auto-scaled or user-specified population size
 
@@ -134,9 +137,18 @@ class CMAESStrategy(PlacementStrategy):
             config: Strategy configuration. Supports extra keys:
                 - ``population_size`` (int): Override auto-scaled pop size.
                 - ``sigma`` (float): Override initial step size.
+                - ``mean`` (array-like): Warm-start initial mean, shape
+                  ``(ndim,)``. Validated against ``bounds`` and clamped into
+                  ``[lower, upper]`` (CMAwM requires the mean inside bounds).
+                  When supplied, the default sigma is tightened so the run
+                  refines the seed layout rather than re-imagining it.
 
         Returns:
             Initial population of placement vectors for external evaluation.
+
+        Raises:
+            ValueError: If ``config.extra["mean"]`` has a shape that does not
+                match ``bounds``.
         """
         self._config = config
         self._bounds = bounds
@@ -148,14 +160,32 @@ class CMAESStrategy(PlacementStrategy):
             _auto_population_size(ndim),
         )
 
-        # Initial mean: center of the bounded region
-        mean = (bounds.lower + bounds.upper) / 2.0
+        # Initial mean: caller-supplied warm-start, else center of the region.
+        mean_override = config.extra.get("mean")
+        warm_start = mean_override is not None
+        if not warm_start:
+            mean = (bounds.lower + bounds.upper) / 2.0
+        else:
+            mean = np.asarray(mean_override, dtype=np.float64)
+            if mean.shape != bounds.lower.shape:
+                raise ValueError(
+                    "config.extra['mean'] has shape "
+                    f"{mean.shape}, expected {bounds.lower.shape} to match bounds"
+                )
+            # CMAwM raises if the mean falls outside bounds; clamp to stay in.
+            # Discrete dims (rotation index, side) are already integer-valued
+            # from encode() and lie within [lower, upper], so clipping is a
+            # no-op for them.
+            mean = np.clip(mean, bounds.lower, bounds.upper)
 
-        # Initial sigma: 1/4 of the average range
+        # Initial sigma: 1/4 of the average range (fresh seed), or a much
+        # tighter step when warm-starting so CMA-ES refines the seed layout
+        # rather than re-imagining it.
         ranges = bounds.upper - bounds.lower
         # Avoid zero range (can happen for single-value discrete dims)
         safe_ranges = np.where(ranges > 0, ranges, 1.0)
-        sigma = float(config.extra.get("sigma", np.mean(safe_ranges) / 4.0))
+        default_sigma = np.mean(safe_ranges) / (20.0 if warm_start else 4.0)
+        sigma = float(config.extra.get("sigma", default_sigma))
 
         # Build CMAwM bounds array: shape (ndim, 2)
         cma_bounds = np.column_stack([bounds.lower, bounds.upper])

--- a/tests/test_optimize_placement_cmd.py
+++ b/tests/test_optimize_placement_cmd.py
@@ -19,6 +19,8 @@ from kicad_tools.cli.optimize_placement_cmd import (  # noqa: E402
     _generate_seed,
     _parse_weights,
     _print_score,
+    _read_board_data,
+    _read_current_vector,
     _vector_to_placements,
     _write_placements_to_pcb_atomic,
     run_optimize_placement,
@@ -263,6 +265,137 @@ class TestGenerateSeed:
     def test_unknown_seed_raises(self, simple_components, simple_nets, board):
         with pytest.raises(ValueError, match="Unknown seed method"):
             _generate_seed("nonexistent", simple_components, simple_nets, board)
+
+
+class TestSeedCurrentWiring:
+    """`--seed current` warm-starts CMA-ES from the on-disk placement."""
+
+    def test_read_current_vector_encodes_on_disk_positions(self, tmp_pcb):
+        """_read_current_vector reflects the actual footprint positions."""
+        components, _nets, _board, _rules, _origin = _read_board_data(str(tmp_pcb))
+        vec = _read_current_vector(str(tmp_pcb), components)
+        assert isinstance(vec, PlacementVector)
+        assert vec.num_components == len(components)
+        # The mean is the current layout, NOT the geometric center of the
+        # board bounds -- so at least one component's x/y differs from center.
+        placement_bounds = bounds(_board, components)
+        center = (placement_bounds.lower + placement_bounds.upper) / 2.0
+        assert not np.allclose(vec.data, center)
+
+    def test_seed_current_sets_cmaes_mean_to_current_positions(
+        self, tmp_pcb, tmp_path, monkeypatch
+    ):
+        """--seed current injects config.extra['mean'] = current placement."""
+        from kicad_tools.cli import optimize_placement_cmd as mod
+
+        captured: dict[str, object] = {}
+        original_initialize = CMAESStrategy.initialize
+
+        def spy_initialize(self, placement_bounds, config):
+            captured["mean"] = config.extra.get("mean")
+            return original_initialize(self, placement_bounds, config)
+
+        monkeypatch.setattr(CMAESStrategy, "initialize", spy_initialize)
+
+        # Expected mean = the encoded current placement (slide-off disabled so
+        # the comparison is exact; the sample board has no overlaps anyway).
+        components, _nets, _board, _rules, _origin = _read_board_data(str(tmp_pcb))
+        expected = _read_current_vector(str(tmp_pcb), components).data
+
+        out = tmp_path / "out.kicad_pcb"
+        rc = mod.run_optimize_placement(
+            str(tmp_pcb),
+            seed_method="current",
+            max_iterations=1,
+            output_path=str(out),
+            no_slide_off=True,
+            quiet=True,
+        )
+        assert rc in (0, 1)  # optimization ran; feasibility is not asserted here
+        assert captured["mean"] is not None, "mean was not injected for --seed current"
+        assert np.allclose(np.asarray(captured["mean"], dtype=float), expected)
+        # And it must NOT be the bounds-center default.
+        placement_bounds = bounds(_board, components)
+        center = (placement_bounds.lower + placement_bounds.upper) / 2.0
+        assert not np.allclose(np.asarray(captured["mean"], dtype=float), center)
+
+    def test_default_seed_does_not_inject_mean(self, tmp_pcb, tmp_path, monkeypatch):
+        """force-directed keeps the historical center-mean (mean unset)."""
+        from kicad_tools.cli import optimize_placement_cmd as mod
+
+        captured: dict[str, object] = {"seen": False, "mean": "sentinel"}
+        original_initialize = CMAESStrategy.initialize
+
+        def spy_initialize(self, placement_bounds, config):
+            captured["seen"] = True
+            captured["mean"] = config.extra.get("mean")
+            return original_initialize(self, placement_bounds, config)
+
+        monkeypatch.setattr(CMAESStrategy, "initialize", spy_initialize)
+
+        out = tmp_path / "out.kicad_pcb"
+        mod.run_optimize_placement(
+            str(tmp_pcb),
+            seed_method="force-directed",
+            max_iterations=1,
+            output_path=str(out),
+            quiet=True,
+        )
+        assert captured["seen"] is True
+        assert captured["mean"] is None
+
+
+class TestInitializeMeanOverride:
+    """CMAESStrategy.initialize honours config.extra['mean']."""
+
+    def test_mean_override_used_as_initial_mean(self, simple_components, board):
+        """With a tiny sigma, the first population sits at the supplied mean."""
+        placement_bounds = bounds(board, simple_components)
+        # A distinct in-bounds mean (shifted off the center).
+        target = (placement_bounds.lower + placement_bounds.upper) / 2.0
+        # Nudge continuous x/y dims for each component toward the lower bound.
+        for i in range(len(simple_components)):
+            base = i * 4
+            target[base] = placement_bounds.lower[base] + 0.1
+            target[base + 1] = placement_bounds.lower[base + 1] + 0.1
+
+        strategy = CMAESStrategy()
+        config = StrategyConfig(
+            max_iterations=1,
+            seed=7,
+            extra={"mean": target, "sigma": 1e-9},
+        )
+        pop = strategy.initialize(placement_bounds, config)
+        # Continuous dims of every candidate should hug the injected mean.
+        cont = ~placement_bounds.discrete_mask
+        for cand in pop:
+            assert np.allclose(cand.data[cont], target[cont], atol=1e-3)
+
+    def test_wrong_length_mean_raises(self, simple_components, board):
+        placement_bounds = bounds(board, simple_components)
+        bad = np.zeros(len(placement_bounds.lower) + 1, dtype=float)
+        strategy = CMAESStrategy()
+        config = StrategyConfig(max_iterations=1, seed=1, extra={"mean": bad})
+        with pytest.raises(ValueError, match="mean"):
+            strategy.initialize(placement_bounds, config)
+
+    def test_out_of_bounds_mean_is_clamped_not_rejected(self, simple_components, board):
+        """An out-of-bounds mean is clipped into [lower, upper], not rejected."""
+        placement_bounds = bounds(board, simple_components)
+        # Far above the upper bound on every dimension.
+        over = placement_bounds.upper + 1000.0
+        strategy = CMAESStrategy()
+        config = StrategyConfig(
+            max_iterations=1,
+            seed=3,
+            extra={"mean": over, "sigma": 1e-9},
+        )
+        pop = strategy.initialize(placement_bounds, config)  # must not raise
+        cont = ~placement_bounds.discrete_mask
+        for cand in pop:
+            # Clamped to the upper bound (within CMAwM's discretization slack).
+            assert np.all(cand.data[cont] <= placement_bounds.upper[cont] + 1e-6)
+            assert np.all(cand.data[cont] >= placement_bounds.lower[cont] - 1e-6)
 
 
 class TestPrintScore:
@@ -598,6 +731,22 @@ class TestCLIHelp:
         assert args.verbose is True
         assert args.quiet is True
 
+    def test_parser_accepts_seed_current(self):
+        """--seed current is a valid choice."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(["optimize-placement", "board.kicad_pcb", "--seed", "current"])
+        assert args.seed_method == "current"
+
+    def test_parser_rejects_unknown_seed(self):
+        """An unknown --seed value is rejected by argparse."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["optimize-placement", "board.kicad_pcb", "--seed", "bogus"])
+
 
 # ---------------------------------------------------------------------------
 # Optimization convergence test (sanity check, not performance benchmark)
@@ -758,7 +907,6 @@ class TestInterruptHandling:
 # Import helpers needed by the new tests
 from kicad_tools.cli.optimize_placement_cmd import (
     _extract_board_outline,
-    _read_board_data,
     _write_placements_to_pcb,
 )
 


### PR DESCRIPTION
## Summary

`kct optimize-placement --seed` offered only `force-directed` and `random`, both of which synthesise a fresh seed — the optimizer re-imagines the whole board and discards a ratified hand floorplan. Worse, the generated seed was **cosmetic**: it was scored for the "Seed" comparison line but never fed to CMA-ES, which always started its mean at the geometric center of the bounds.

This PR adds `--seed current`, which warm-starts CMA-ES from the board's on-disk footprint positions so the optimizer *refines* the current layout (with a tight step size) instead of re-imagining it — the common last-mile task of resolving a few local violations while keeping the floorplan.

Ask #2 (`--only-refs` / `--freeze-others` frozen-dimension mode) is deferred to a follow-up per the issue's Scope Guard.

## Changes

- **`cli/parser.py`** — add `"current"` to `--seed` choices with refinement-oriented help text.
- **`cli/optimize_placement_cmd.py`** — for `seed_method == "current"`, build the seed via the existing `_read_current_vector(pcb_path, components)` (the same on-disk encoder used by `--dry-run`, #3940); after slide-off, inject it as the CMA-ES initial mean via `config.extra["mean"]`. Other seed methods are untouched (their generated seed is still only scored, never fed to the optimizer).
- **`placement/cmaes_strategy.py`** — `initialize()` now honours `config.extra["mean"]`: shape-validated against `bounds` (`ValueError` on mismatch), clamped into `[lower, upper]` (CMAwM requires the mean inside bounds), with a much tighter default sigma when warm-starting so refinement stays local. Absent a mean override, behaviour is unchanged (center mean, 1/4-range sigma).
- **`tests/test_optimize_placement_cmd.py`** — new coverage (see below).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `--seed current` starts CMA-ES from the current positions (mean = `_read_current_vector`, not bounds center) | ✅ | `test_seed_current_sets_cmaes_mean_to_current_positions` asserts injected mean == encoded current placement and != bounds center |
| `--seed {force-directed,random}` unchanged by default | ✅ | Mean is injected **only** for `current`; `test_default_seed_does_not_inject_mean` asserts `config.extra["mean"]` stays `None` for force-directed |
| `initialize` honours `config.extra["mean"]`, validates shape, clamps to bounds; wrong-length raises `ValueError` | ✅ | `TestInitializeMeanOverride`: used-as-mean (tiny sigma), wrong-length raises, out-of-bounds clamped not rejected |
| Tight default sigma for the current-seed path, documented in `--help` | ✅ | `initialize()` uses `mean(range)/20` when warm-starting (vs `/4`); parser help documents the "tight step size" behaviour |
| Ask #2 filed as a separate follow-up / out of scope | ✅ | Deferred per Scope Guard; noted here and in the commit body |

## Test Plan

- New tests in `tests/test_optimize_placement_cmd.py` (all passing):
  - `TestSeedCurrentWiring` — `_read_current_vector` reflects on-disk positions; `--seed current` injects the current-placement mean; force-directed leaves the mean unset.
  - `TestInitializeMeanOverride` — mean override is used as the initial mean, wrong-length raises `ValueError`, out-of-bounds is clamped.
  - `TestCLIHelp` — parser accepts `--seed current` and rejects unknown values.
- Full file: `84 passed` (was 84 pre-change count of green + new; no regressions). Strategy + MCP placement suites green.
- Lint/format clean on all four files; mypy baseline gate green (no new type errors).

Closes #4405