### PR TITLE
feat(check): split kct check report into manufacturing vs advisory buckets

### DIFF
--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -26,7 +26,7 @@ import argparse
 import json
 import sys
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
@@ -2063,6 +2063,81 @@ def _print_measurement_summary(violations: list[DRCViolation]) -> None:
         )
 
 
+@dataclass
+class _CategoryTally:
+    """Per-severity counts + rule_id set for one reporting category (Issue #3803)."""
+
+    errors: int = 0
+    warnings: int = 0
+    infos: int = 0
+    waived: int = 0
+    rules: set[str] = field(default_factory=set)
+
+    def add(self, v: DRCViolation) -> None:
+        self.rules.add(v.rule_id)
+        if v.is_waived:
+            self.waived += 1
+        elif v.is_error:
+            self.errors += 1
+        elif v.is_info:
+            self.infos += 1
+        else:
+            self.warnings += 1
+
+    @property
+    def total(self) -> int:
+        """Active (non-waived) finding count for the bucket headline."""
+        return self.errors + self.warnings + self.infos
+
+    def detail(self) -> str:
+        parts = [f"{self.errors} errors", f"{self.warnings} warnings", f"{self.infos} infos"]
+        if self.waived:
+            parts.append(f"{self.waived} waived")
+        return ", ".join(parts)
+
+    def rule_list(self) -> str:
+        return ", ".join(sorted(self.rules)) if self.rules else "none"
+
+
+def _print_category_summary(violations: list[DRCViolation]) -> None:
+    """Print the manufacturing-vs-advisory reporting buckets (Issue #3803).
+
+    Splits the finding set into two clearly-labelled categories using the
+    single-source-of-truth :meth:`DRCChecker.category_for_rule` classifier
+    so a reader can trust the manufacturing headline to mean
+    fabrication-blocking copper defects, and not confuse it with
+    routing-intent / quality findings (connectivity completion, diff-pair
+    skew/continuity, copper slivers, ampacity, silk).
+
+    Presentation-only: this reads the same ``violations`` list already
+    counted by :func:`output_table` and does not alter the verdict, exit
+    code, or any per-severity count.
+    """
+    mfg = _CategoryTally()
+    adv = _CategoryTally()
+    for v in violations:
+        bucket = (
+            adv if DRCChecker.category_for_rule(v.rule_id) == DRCChecker.CATEGORY_ADVISORY else mfg
+        )
+        bucket.add(v)
+
+    print(f"\n{'-' * 60}")
+    print("CATEGORY SUMMARY (fabrication-blocking vs advisory -- Issue #3803):")
+    # The manufacturing headline is ALWAYS shown -- its value is precisely
+    # that a reader can trust "Manufacturing DRC: 0 blocking" on a board
+    # whose only findings are advisory-quality (the headline complaint).
+    print(f"  Manufacturing DRC: {mfg.errors} blocking  (copper/clearance/hole/edge/mask/drill)")
+    print(f"      {mfg.detail()}  [{mfg.rule_list()}]")
+    # The advisory block is shown only when there ARE advisory findings, so
+    # a manufacturing-only board does not render an empty advisory header.
+    if adv.total:
+        print(
+            f"  Advisory/quality:  {adv.total} advisory"
+            "  (connectivity, diff-pair, copper_sliver, ampacity, silk)"
+        )
+        print(f"      {adv.detail()}  [{adv.rule_list()}]")
+
+
 def output_table(
     violations: list[DRCViolation],
     results: DRCResults,
@@ -2099,6 +2174,13 @@ def output_table(
         print(f"\n{'=' * 60}")
         print("DRC PASSED - No violations found")
         return
+
+    # Issue #3803: render the manufacturing-vs-advisory category buckets so
+    # the headline distinguishes fabrication-blocking copper defects from
+    # routing-intent / quality findings.  Presentation-only -- the
+    # per-severity counts above and the PASS/FAIL verdict below are
+    # unchanged.
+    _print_category_summary(violations)
 
     # Issue #3924 AC1: render the length-match / continuity measurement
     # table before the violation listing so the measured values are visible

--- a/src/kicad_tools/validate/checker.py
+++ b/src/kicad_tools/validate/checker.py
@@ -276,6 +276,133 @@ class DRCChecker:
         """
         return rule_id in cls.ADVISORY_RULE_IDS
 
+    # Reporting-category taxonomy (Issue #3803).
+    #
+    # ``kct check`` historically folded routing-intent / quality findings
+    # (``connectivity``, diff-pair skew/continuity, ``copper_sliver``,
+    # ``ampacity``, silk) into the same undifferentiated "DRC violations"
+    # count as fabrication-blocking copper/clearance defects.  Because
+    # ``connectivity`` and the diff-pair rules emit ``severity="error"``,
+    # they inflate the headline exactly like a real short -- so
+    # "N DRC violations" could not be trusted to mean "N fab-blocking
+    # copper defects".
+    #
+    # This map classifies every rule_id into one of two *reporting*
+    # buckets so the CLI can render a per-bucket headline.  The category
+    # names mirror the wording of the native ``ViolationCategory``
+    # taxonomy (``drc/violation.py``) for cross-report consistency.
+    #
+    # IMPORTANT: this is a PRESENTATION-ONLY axis and is deliberately
+    # ORTHOGONAL to :attr:`ADVISORY_RULE_IDS` (the *gating* advisory set,
+    # which stays ``{"connectivity"}``).  Classifying a rule as
+    # ``advisory-quality`` here does NOT change any gate verdict, exit
+    # code, or severity -- only how the finding is grouped in the human
+    # report.  Do not derive :meth:`is_advisory_rule` from this map.
+    CATEGORY_MANUFACTURING: str = "manufacturing"
+    CATEGORY_ADVISORY: str = "advisory-quality"
+
+    # Single source of truth: rule_id -> reporting category.  Adding a
+    # rule requires exactly one edit here.  Dynamically-suffixed subtypes
+    # (e.g. ``clearance_pad_segment``, built via ``f"clearance_{suffix}"``
+    # in ``rules/clearance.py``) are covered by the prefix fallback in
+    # :meth:`category_for_rule`, so this map need only list canonical ids.
+    RULE_CATEGORY: dict[str, str] = {
+        # ---- Advisory / quality: routing-intent & non-fab-blocking. ----
+        "connectivity": CATEGORY_ADVISORY,
+        "ampacity": CATEGORY_ADVISORY,
+        "copper_sliver": CATEGORY_ADVISORY,
+        "impedance": CATEGORY_ADVISORY,
+        "diffpair_clearance_intra": CATEGORY_ADVISORY,
+        "diffpair_length_skew": CATEGORY_ADVISORY,
+        "diffpair_routing_continuity": CATEGORY_ADVISORY,
+        "match_group_length_skew": CATEGORY_ADVISORY,
+        "silk_over_copper": CATEGORY_ADVISORY,
+        "silk_edge_clearance": CATEGORY_ADVISORY,
+        "silkscreen_line_width": CATEGORY_ADVISORY,
+        "silkscreen_over_pad": CATEGORY_ADVISORY,
+        "silkscreen_text_height": CATEGORY_ADVISORY,
+        # ---- Manufacturing DRC: fab-blocking copper/clearance/hole/
+        #      edge/mask/drill/geometry. -----------------------------
+        "clearance": CATEGORY_MANUFACTURING,
+        "clearance_net0_bridge": CATEGORY_MANUFACTURING,
+        "clearance_pad_zone": CATEGORY_MANUFACTURING,
+        "clearance_segment_zone": CATEGORY_MANUFACTURING,
+        "clearance_via_zone": CATEGORY_MANUFACTURING,
+        "edge_clearance": CATEGORY_MANUFACTURING,
+        "edge_clearance_pad": CATEGORY_MANUFACTURING,
+        "edge_clearance_pad_hole": CATEGORY_MANUFACTURING,
+        "edge_clearance_trace": CATEGORY_MANUFACTURING,
+        "edge_clearance_via": CATEGORY_MANUFACTURING,
+        "edge_clearance_zone": CATEGORY_MANUFACTURING,
+        "hole_to_hole_clearance": CATEGORY_MANUFACTURING,
+        "solder_mask_clearance": CATEGORY_MANUFACTURING,
+        "solder_mask_pad": CATEGORY_MANUFACTURING,
+        "via_in_pad": CATEGORY_MANUFACTURING,
+        "min_pad_size": CATEGORY_MANUFACTURING,
+        "pth_annular_ring": CATEGORY_MANUFACTURING,
+        "pad_grid": CATEGORY_MANUFACTURING,
+        "dimensions": CATEGORY_MANUFACTURING,
+        "dimension_trace_width": CATEGORY_MANUFACTURING,
+        "dimension_via_diameter": CATEGORY_MANUFACTURING,
+        "dimension_via_drill": CATEGORY_MANUFACTURING,
+        "dimension_annular_ring": CATEGORY_MANUFACTURING,
+        "footprint_outside_board": CATEGORY_MANUFACTURING,
+        "single_pad_net": CATEGORY_MANUFACTURING,
+        "net_undeclared": CATEGORY_MANUFACTURING,
+        "zone_fill": CATEGORY_MANUFACTURING,
+        "zone_fill_disabled": CATEGORY_MANUFACTURING,
+        "zone_no_net": CATEGORY_MANUFACTURING,
+        "zone_unfilled": CATEGORY_MANUFACTURING,
+    }
+
+    # Prefix fallbacks for dynamically-suffixed rule_id families so a new
+    # subtype is categorized without a map edit.  The first matching
+    # prefix wins, so the advisory prefixes (which are more specific
+    # netlist/quality families) are checked before the broad
+    # ``clearance`` manufacturing prefix.
+    _CATEGORY_PREFIXES: tuple[tuple[str, str], ...] = (
+        ("diffpair", CATEGORY_ADVISORY),
+        ("match_group", CATEGORY_ADVISORY),
+        ("silk", CATEGORY_ADVISORY),
+        ("edge_clearance", CATEGORY_MANUFACTURING),
+        ("clearance", CATEGORY_MANUFACTURING),
+        ("dimension", CATEGORY_MANUFACTURING),
+        ("zone", CATEGORY_MANUFACTURING),
+        ("via", CATEGORY_MANUFACTURING),
+        ("hole", CATEGORY_MANUFACTURING),
+        ("drill", CATEGORY_MANUFACTURING),
+        ("solder_mask", CATEGORY_MANUFACTURING),
+        ("pth_", CATEGORY_MANUFACTURING),
+    )
+
+    @classmethod
+    def category_for_rule(cls, rule_id: str) -> str:
+        """Return the reporting category for ``rule_id``.
+
+        One of :attr:`CATEGORY_MANUFACTURING` (fabrication-blocking
+        copper / clearance / hole / edge / mask / drill defects) or
+        :attr:`CATEGORY_ADVISORY` (routing-intent & quality findings such
+        as connectivity completion, diff-pair skew, copper slivers,
+        ampacity, silk).
+
+        Classification is resolved from the explicit :attr:`RULE_CATEGORY`
+        map first, then a prefix fallback for dynamically-suffixed
+        subtypes, and finally defaults to
+        :attr:`CATEGORY_MANUFACTURING`.  The manufacturing default is
+        deliberate: an unrecognized rule surfaces in the fab-blocking
+        bucket rather than being silently hidden among advisory findings.
+
+        This is a presentation-only classifier; see :attr:`RULE_CATEGORY`
+        for why it must not alter any gate verdict.
+        """
+        category = cls.RULE_CATEGORY.get(rule_id)
+        if category is not None:
+            return category
+        for prefix, prefix_category in cls._CATEGORY_PREFIXES:
+            if rule_id.startswith(prefix):
+                return prefix_category
+        return cls.CATEGORY_MANUFACTURING
+
     def _absolutize(self, results: DRCResults) -> DRCResults:
         """Rewrite violation locations from board-relative to sheet-absolute.
 

--- a/tests/test_check_category_buckets.py
+++ b/tests/test_check_category_buckets.py
@@ -1,0 +1,163 @@
+"""Two-bucket manufacturing-vs-advisory rendering in ``kct check`` (Issue #3803).
+
+``output_table`` (the ``kct check`` table reporter) historically folded
+routing-intent / quality findings (``connectivity``, diff-pair
+skew/continuity, ``copper_sliver``, ``ampacity``) into the same
+undifferentiated "DRC violations" count as fabrication-blocking
+copper/clearance defects.  Because ``connectivity`` and the diff-pair
+rules emit ``severity="error"``, "N DRC violations" could read as N
+fab-blocking copper defects even when native ``kicad-cli`` reports 0.
+
+This slice adds a CATEGORY SUMMARY block that splits the findings into two
+labelled buckets with a per-bucket headline count.  It is
+PRESENTATION-ONLY: the per-severity ``Results:`` counts and the
+PASS/FAIL/WARNING verdict line are unchanged.
+
+These tests capture the reporter output (``capsys``) and assert the
+bucket rendering, and separately assert the verdict line is byte-identical
+to what the severity counts alone dictate (no gate/exit-code drift).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.check_cmd import output_table
+from kicad_tools.validate import DRCResults, DRCViolation
+
+_PCB = Path("board.kicad_pcb")
+
+
+def _render(violations: list[DRCViolation]) -> str:
+    results = DRCResults()
+    for v in violations:
+        results.add(v)
+    results.rules_checked = max(1, len({v.rule_id for v in violations}))
+    output_table(violations, results, _PCB, "jlcpcb", 4, False)
+    return ""
+
+
+def _render_capsys(violations: list[DRCViolation], capsys) -> str:
+    _render(violations)
+    return capsys.readouterr().out
+
+
+def test_two_labeled_buckets_present(capsys) -> None:
+    """A mixed board renders both the manufacturing and advisory headers."""
+    violations = [
+        DRCViolation(rule_id="clearance", severity="error", message="copper short"),
+        DRCViolation(rule_id="connectivity", severity="error", message="GND incomplete"),
+    ]
+    out = _render_capsys(violations, capsys)
+    assert "CATEGORY SUMMARY" in out
+    assert "Manufacturing DRC:" in out
+    assert "Advisory/quality:" in out
+
+
+def test_all_advisory_board_reads_zero_blocking(capsys) -> None:
+    """On a board whose only findings are connectivity / diff-pair /
+    copper_sliver, the manufacturing headline reads 0 blocking while the
+    advisory bucket lists them (the exact headline complaint)."""
+    violations = [
+        DRCViolation(rule_id="connectivity", severity="error", message="GND incomplete"),
+        DRCViolation(rule_id="diffpair_length_skew", severity="error", message="skew"),
+        DRCViolation(rule_id="copper_sliver", severity="warning", message="sliver"),
+    ]
+    out = _render_capsys(violations, capsys)
+    assert "Manufacturing DRC: 0 blocking" in out
+    # The advisory bucket surfaces the three findings and names the rules.
+    assert "Advisory/quality:  3 advisory" in out
+    assert "connectivity" in out
+    assert "copper_sliver" in out
+    assert "diffpair_length_skew" in out
+
+
+def test_manufacturing_violation_counted_in_manufacturing_bucket(capsys) -> None:
+    """A real clearance/edge violation lands in the manufacturing bucket
+    and the blocking headline reflects it."""
+    violations = [
+        DRCViolation(rule_id="clearance", severity="error", message="copper short"),
+        DRCViolation(rule_id="edge_clearance", severity="error", message="near edge"),
+    ]
+    out = _render_capsys(violations, capsys)
+    assert "Manufacturing DRC: 2 blocking" in out
+
+
+def test_manufacturing_only_board_omits_empty_advisory_header(capsys) -> None:
+    """Edge case: a manufacturing-only board renders no empty advisory
+    header (but still shows the manufacturing headline)."""
+    violations = [
+        DRCViolation(rule_id="clearance", severity="error", message="copper short"),
+    ]
+    out = _render_capsys(violations, capsys)
+    assert "Manufacturing DRC: 1 blocking" in out
+    assert "Advisory/quality:" not in out
+
+
+def test_dynamic_clearance_subtype_is_manufacturing(capsys) -> None:
+    """A dynamically-suffixed ``clearance_segment_via`` subtype (not a
+    literal in the category map) is bucketed as manufacturing via the
+    prefix fallback."""
+    violations = [
+        DRCViolation(
+            rule_id="clearance_segment_via",
+            severity="error",
+            message="trace/via short",
+            nets=("NET_A", "NET_B"),
+        ),
+    ]
+    out = _render_capsys(violations, capsys)
+    assert "Manufacturing DRC: 1 blocking" in out
+    assert "Advisory/quality:" not in out
+
+
+@pytest.mark.parametrize(
+    ("violations", "expected_verdict"),
+    [
+        # Advisory-only ERROR must still drive DRC FAILED (unchanged gate).
+        (
+            [DRCViolation(rule_id="connectivity", severity="error", message="x")],
+            "DRC FAILED - Fix errors before manufacturing",
+        ),
+        # Advisory-only WARNING -> DRC WARNING (unchanged).
+        (
+            [DRCViolation(rule_id="copper_sliver", severity="warning", message="x")],
+            "DRC WARNING - Review warnings",
+        ),
+        # Manufacturing error -> DRC FAILED (unchanged).
+        (
+            [DRCViolation(rule_id="clearance", severity="error", message="x")],
+            "DRC FAILED - Fix errors before manufacturing",
+        ),
+    ],
+)
+def test_verdict_line_unchanged_by_category_split(
+    violations: list[DRCViolation], expected_verdict: str, capsys
+) -> None:
+    """Presentation-only guarantee: the PASS/FAIL/WARNING verdict line is
+    determined solely by severity counts and is NOT altered by re-bucketing
+    findings into manufacturing vs advisory.
+
+    In particular an advisory-only *error* still prints DRC FAILED -- the
+    reporting-category split does NOT demote connectivity/diff-pair errors
+    off the blocking verdict (that would be a gate-semantics change, which
+    is explicitly out of scope for this slice).
+    """
+    out = _render_capsys(violations, capsys)
+    assert expected_verdict in out
+
+
+def test_category_summary_does_not_alter_results_counts(capsys) -> None:
+    """The per-severity ``Results:`` block is unchanged -- the CATEGORY
+    SUMMARY is purely additive output."""
+    violations = [
+        DRCViolation(rule_id="clearance", severity="error", message="x"),
+        DRCViolation(rule_id="connectivity", severity="error", message="y"),
+        DRCViolation(rule_id="copper_sliver", severity="warning", message="z"),
+    ]
+    out = _render_capsys(violations, capsys)
+    # Two errors + one warning, exactly as before this slice.
+    assert "Errors:     2" in out
+    assert "Warnings:   1" in out

--- a/tests/test_check_cmd_coverage.py
+++ b/tests/test_check_cmd_coverage.py
@@ -348,3 +348,126 @@ class TestEntryPointRegistryParity:
             f"check_all-only={check_all_methods - dispatcher_methods}.  "
             "See Issue #3044."
         )
+
+
+class TestRuleCategoryTaxonomy:
+    """Issue #3803: the manufacturing-vs-advisory *reporting* taxonomy.
+
+    ``DRCChecker.category_for_rule`` classifies every rule_id into one of
+    two presentation buckets so ``kct check`` can render a per-bucket
+    headline.  These tests pin:
+
+    * the classifier is total (no rule_id resolves to an unexpected
+      category) and covers every rule_id registered in the validate rules;
+    * the load-bearing advisory rules (the ones that inflated the headline)
+      land in ``advisory-quality`` and the fab-blocking rules land in
+      ``manufacturing``;
+    * the taxonomy is ORTHOGONAL to the gating ``ADVISORY_RULE_IDS`` set --
+      classifying ``copper_sliver`` as advisory-quality for reporting must
+      NOT change what :meth:`DRCChecker.is_advisory_rule` returns (that
+      drives gate verdicts and must stay ``{"connectivity"}``).
+    """
+
+    import re
+    from pathlib import Path as _Path
+
+    _RULES_DIR = _Path(__file__).resolve().parent.parent / "src" / "kicad_tools" / "validate"
+    _RULE_ID_RE = re.compile(r'rule_id\s*=\s*"([a-z0-9_]+)"')
+
+    @classmethod
+    def _registered_rule_ids(cls) -> set[str]:
+        """Scrape every literal ``rule_id="..."`` from the validate engine."""
+        found: set[str] = set()
+        for path in cls._RULES_DIR.rglob("*.py"):
+            found.update(cls._RULE_ID_RE.findall(path.read_text()))
+        return found
+
+    def test_every_registered_rule_id_is_categorized(self) -> None:
+        """No uncategorized leak: each registered rule_id maps to exactly
+        one of the two known categories."""
+        valid = {DRCChecker.CATEGORY_MANUFACTURING, DRCChecker.CATEGORY_ADVISORY}
+        rule_ids = self._registered_rule_ids()
+        assert rule_ids, "expected to scrape at least one rule_id from validate/"
+        for rule_id in rule_ids:
+            category = DRCChecker.category_for_rule(rule_id)
+            assert category in valid, f"{rule_id} -> {category!r} is not a valid category"
+
+    def test_advisory_quality_rules_classified(self) -> None:
+        """The routing-intent / quality rules that inflated the headline
+        must land in the advisory bucket."""
+        for rule_id in (
+            "connectivity",
+            "ampacity",
+            "copper_sliver",
+            "impedance",
+            "diffpair_length_skew",
+            "diffpair_routing_continuity",
+            "diffpair_clearance_intra",
+            "match_group_length_skew",
+            "silk_over_copper",
+        ):
+            assert DRCChecker.category_for_rule(rule_id) == DRCChecker.CATEGORY_ADVISORY, (
+                f"{rule_id} must be advisory-quality"
+            )
+
+    def test_manufacturing_rules_classified(self) -> None:
+        """Fab-blocking copper / clearance / hole / edge / mask / drill
+        rules must land in the manufacturing bucket."""
+        for rule_id in (
+            "clearance",
+            "clearance_segment_zone",
+            "clearance_via_zone",
+            "edge_clearance",
+            "edge_clearance_via",
+            "hole_to_hole_clearance",
+            "via_in_pad",
+            "solder_mask_pad",
+            "dimension_via_drill",
+            "single_pad_net",
+            "footprint_outside_board",
+            "zone_fill",
+        ):
+            assert DRCChecker.category_for_rule(rule_id) == DRCChecker.CATEGORY_MANUFACTURING, (
+                f"{rule_id} must be manufacturing"
+            )
+
+    def test_dynamic_clearance_subtypes_classified(self) -> None:
+        """Dynamically-suffixed ``clearance_*`` subtypes (built via
+        ``f"clearance_{suffix}"`` in rules/clearance.py, so not literal in
+        the map) fall through to the manufacturing prefix rule."""
+        for rule_id in (
+            "clearance_pad_segment",
+            "clearance_segment_via",
+            "clearance_pad_via",
+            "clearance_via_via",
+            "clearance_segment_segment",
+        ):
+            assert DRCChecker.category_for_rule(rule_id) == DRCChecker.CATEGORY_MANUFACTURING, (
+                f"{rule_id} must be manufacturing"
+            )
+
+    def test_unknown_rule_defaults_to_manufacturing(self) -> None:
+        """An unrecognized rule surfaces in the fab-blocking bucket rather
+        than being silently hidden among advisory findings."""
+        assert (
+            DRCChecker.category_for_rule("some_brand_new_rule") == DRCChecker.CATEGORY_MANUFACTURING
+        )
+
+    def test_reporting_taxonomy_is_orthogonal_to_gating(self) -> None:
+        """Reporting-category classification must NOT change the gating
+        advisory set: ``is_advisory_rule`` stays ``{"connectivity"}`` even
+        though copper_sliver/diffpair/ampacity are advisory *for reporting*.
+        """
+        assert frozenset({"connectivity"}) == DRCChecker.ADVISORY_RULE_IDS
+        assert DRCChecker.is_advisory_rule("connectivity") is True
+        for rule_id in (
+            "copper_sliver",
+            "diffpair_length_skew",
+            "ampacity",
+            "impedance",
+            "silk_over_copper",
+        ):
+            # advisory-quality for REPORTING ...
+            assert DRCChecker.category_for_rule(rule_id) == DRCChecker.CATEGORY_ADVISORY
+            # ... but NOT advisory for GATING (unchanged behavior).
+            assert DRCChecker.is_advisory_rule(rule_id) is False


### PR DESCRIPTION
## Summary

`kct check`'s table reporter folded routing-intent / quality findings
(`connectivity`, diff-pair skew/continuity, `copper_sliver`, `ampacity`, silk)
into the same undifferentiated "DRC violations" count as fabrication-blocking
copper/clearance defects. Because `connectivity` and the diff-pair rules emit
`severity="error"`, "N DRC violations" could read as N fab-blocking copper
defects even when native `kicad-cli --refill-zones` reports 0.

This is facet (a) of #3803 (reporting-category separation) — the novel,
bounded slice unique to this issue. **Presentation-only**: no gate semantics,
exit codes, or rule severities change. The verdict/PASS-FAIL is byte-identical;
only the human-readable grouping changes.

## Changes

- **`validate/checker.py`** — promote the single-`connectivity` `ADVISORY_RULE_IDS`
  seed into a full rule→category taxonomy as the single source of truth:
  `RULE_CATEGORY` map + `CATEGORY_MANUFACTURING` / `CATEGORY_ADVISORY` constants +
  `category_for_rule()` classifier. A prefix fallback covers dynamically-suffixed
  `clearance_*` subtypes; unknown rules default to the **manufacturing** bucket
  so nothing is silently hidden among advisory findings. `ADVISORY_RULE_IDS` and
  `is_advisory_rule()` are left **untouched** (still `{"connectivity"}`) — the
  reporting taxonomy is deliberately orthogonal to the gating advisory set.
- **`cli/check_cmd.py`** — `output_table` now emits a `CATEGORY SUMMARY` block
  with two labeled buckets and a per-bucket headline: `Manufacturing DRC: N
  blocking` (always shown) and `Advisory/quality: M advisory` (shown only when
  advisory findings exist, so a manufacturing-only board renders no empty
  advisory header). `BY RULE` and all existing sections are unchanged.
- **Tests** — `tests/test_check_category_buckets.py` (two-bucket rendering +
  verdict/exit-code invariance) and a `TestRuleCategoryTaxonomy` class in
  `tests/test_check_cmd_coverage.py` (full rule_id coverage, classification,
  and gating-orthogonality).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Two labeled buckets with per-bucket headline | ✅ | `test_two_labeled_buckets_present`, manual `kct check` run |
| All-advisory board reads "0 blocking" while advisory lists findings | ✅ | `test_all_advisory_board_reads_zero_blocking` |
| Rule→category in a single source of truth; `is_advisory_rule` unchanged for gating | ✅ | `RULE_CATEGORY` map; `test_reporting_taxonomy_is_orthogonal_to_gating`; existing `test_is_advisory_rule_classifier` still green |
| No gate/severity/exit-code regression (presentation-only) | ✅ | `test_verdict_line_unchanged_by_category_split`, `test_category_summary_does_not_alter_results_counts` |
| Every rule_id categorized, no uncategorized leak | ✅ | `test_every_registered_rule_id_is_categorized` scrapes all validate/ rule_ids |
| Manufacturing-only board renders no empty advisory header | ✅ | `test_manufacturing_only_board_omits_empty_advisory_header` |

## Test Plan

- `tests/test_check_category_buckets.py` + `tests/test_check_cmd_coverage.py` +
  `tests/test_check_routed_drc_advisory.py` + `tests/test_cli_check.py`: **121 passed**.
- New taxonomy + bucket tests: **15 passed**.
- `ruff check` / `ruff format --check`: clean on changed files.
- mypy baseline gate (`scripts/ci/check_mypy_baseline.py`): no new type errors.
- board03 routing baseline (`test_reach_meets_floor`, `test_per_net_reach_usb_signals`):
  **pass** with the C++ router backend built (initial fresh-worktree failures were
  environmental — missing native extension — and unrelated to this DRC-report change).

## Deferred (out of scope for this slice)

- **copper_sliver ↔ kicad-cli reconciliation (facet b1)** — follow-up to #3830 (closed).
- **zone-island unconnected items (facet b2)** — follow-up to #4176 (closed).

Because those two facets remain, this references the issue without auto-closing it.

Part of #3803