### PR TITLE
feat(drc): mfr-driven hole-to-hole via relocation post-pass (board-04 tier1-clean regen)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1832,38 +1832,34 @@ jobs:
           test -f /tmp/board04-ci/lvs.json
           test -f /tmp/board04-ci/stm32_devboard_routed.kicad_pcb
 
-      - name: Assert fresh DRC within recipe tolerance (--allow 2, recipe-vs-artifact)
-        # This step gates the FRESH regen (the recipe's output), which is a
-        # DIFFERENT artifact from the committed board-04 PCB.  Since #4017 the
-        # two diverge by design:
+      - name: Assert fresh DRC strict-0 (recipe-vs-artifact now converged)
+        # This step gates the FRESH regen (the recipe's output).  Since #4408
+        # the recipe reproduces a strict-0 board, so the fresh regen and the
+        # committed artifact have CONVERGED:
         #
-        #   * The COMMITTED artifact is strict-0 -- its 0.350mm drill pair was
-        #     re-spaced artifact-only (the NRST in-pad via nudged 0.5mm east +
-        #     re-bonded to pad U2.7 with an F.Cu stub), with NO change to
-        #     generate_design.py's router/placement.  It carries NO entry in
-        #     .github/routed-drc-tolerance.yml, so the committed-artifact
-        #     "Routed PCB DRC Check" job ratchets it at strict-0.
-        #   * The FRESH regen still routes the LEGACY 0.350mm pair (2
-        #     hole_to_hole_clearance errors), because the recipe geometry
-        #     was intentionally untouched (curation constraint).
+        #   * The COMMITTED artifact is strict-0.  Its 0.350mm drill pair was
+        #     originally re-spaced artifact-only in #4017 (the NRST in-pad via
+        #     nudged 0.5mm east + re-bonded to pad U2.7 with an F.Cu stub).
+        #   * The FRESH regen is NOW strict-0 too: #4408 back-ported that fix
+        #     into the recipe as a generic, mfr-floor-driven hole-to-hole
+        #     relocation post-pass (``relocate_drill_clearance_step``), so the
+        #     router-stacked 0.350mm pair is relocated by construction every
+        #     regen -- no artifact patching.
         #
-        # A single YAML value can't satisfy both (both resolve to the same
-        # repo-relative path).  So this fresh-regen gate uses ``--allow 2`` to
-        # tolerate the 2 grandfathered recipe drills + the advisory
-        # connectivity finding, while the YAML stays entry-free (strict-0) for
-        # the committed artifact.  A 3rd blocking error or any new rule still
-        # fails this gate (exit 2).  When #3847's exit clause is finally closed
-        # in the RECIPE (router re-spaces the pair), drop this to strict-0 by
-        # removing ``--allow 2``.
+        # Both artifacts resolve to the same repo-relative path and now both
+        # measure strict-0, so this gate drops ``--allow`` entirely (default
+        # tolerance 0).  ANY blocking error -- a re-introduced hole-to-hole
+        # pair or a new rule -- fails this gate (exit 2), which is exactly the
+        # regression guard #4408 asked for.
         run: |
           set -euo pipefail
           # Stage the fresh routed PCB over the repo-relative committed path:
           # check_routed_drc.py keys the jlcpcb-tier1 mfr override off the
           # path's repo-relative form (relative_to(cwd)), so the fresh artifact
           # MUST live at the committed path for the jlcpcb-tier1 override to
-          # resolve.  The blocking-error tolerance for THIS invocation comes
-          # from ``--allow 2`` (recipe-vs-artifact divergence, see above), not
-          # the YAML.  No cleanup is needed afterwards: the CI checkout is a
+          # resolve.  The blocking-error tolerance for THIS invocation is now
+          # strict-0 (default), matching the committed artifact.  No cleanup is
+          # needed afterwards: the CI checkout is a
           # throwaway workspace discarded when the job ends, nothing downstream
           # reads the committed PCB, and (per #3854 review) the previous
           # ``git checkout -- ...`` restore aborted the step with exit 128
@@ -1875,7 +1871,6 @@ jobs:
           cp /tmp/board04-ci/stm32_devboard_routed.kicad_pcb \
             boards/04-stm32-devboard/output/stm32_devboard_routed.kicad_pcb
           uv run python scripts/ci/check_routed_drc.py \
-            --allow 2 \
             boards/04-stm32-devboard/output/stm32_devboard_routed.kicad_pcb
 
       - name: Emit board.json via kct board-metrics

--- a/boards/04-stm32-devboard/generate_design.py
+++ b/boards/04-stm32-devboard/generate_design.py
@@ -1676,6 +1676,61 @@ def tie_power_pads(routed_path: Path) -> bool:
     return True
 
 
+def relocate_drill_clearance_step(routed_path: Path) -> bool:
+    """Relieve fine-pitch hole-to-hole via crowding (issue #4408).
+
+    The fresh deterministic route escapes three adjacent LQFP-48 west pins
+    (OSC_OUT / NRST / GND) through in-pad micro-vias stacked at the 0.5 mm pin
+    pitch.  Two of the resulting drill pairs measure 0.350 mm edge-to-edge --
+    below the ``jlcpcb-tier1`` 0.500 mm ``min_hole_to_hole_mm`` floor -- so a
+    fresh regen previously FAILED ``kct check --mfr jlcpcb-tier1`` with 2
+    ``hole_to_hole_clearance`` errors.  #4017 fixed this artifact-only (a hand
+    nudge of the middle NRST via that was deliberately NOT back-ported), so the
+    committed board diverged from the recipe and every regen reintroduced the
+    violation.
+
+    This step back-ports that fix as a **generic, ``--mfr``-driven** post-route
+    pass (:func:`kicad_tools.drc.relocate_drill_clearance.relocate_drill_clearance`):
+    it reads the active manufacturer profile's hole-to-hole floor, relocates the
+    offending via onto a clearance-safe location (preferring its own routed
+    escape node -- the #4017 pattern) validated against the shared clearance
+    engine, and re-bonds it with short connectivity stubs on every connected
+    layer.  It never mis-places a via into a fresh violation; a boxed-in via is
+    left in place and reported.
+
+    Because the pass is purely floor-driven, any fine-pitch QFP/QFN board routed
+    at a via-in-pad tier benefits -- board 04 passing is the evidence.  Runs
+    AFTER the via-adding steps (``stitch_pcb`` / ``tie_power_pads``) so it sees
+    the full via set, and BEFORE ``quantize_escapes`` / ``fill_zones`` so any
+    stub is 45-quantized and the re-pour backs off the relocated via.
+
+    Returns True on success (including a no-op when the route is already clear).
+    """
+    from kicad_tools.drc.relocate_drill_clearance import relocate_drill_clearance
+    from kicad_tools.manufacturers import get_profile
+    from kicad_tools.schema.pcb import PCB
+
+    print("\n" + "=" * 60)
+    print("Relocating fine-pitch hole-to-hole vias (issue #4408)...")
+    print("=" * 60)
+
+    design_rules = get_profile("jlcpcb-tier1").get_design_rules()
+    pcb = PCB.load(str(routed_path))
+    result = relocate_drill_clearance(pcb, design_rules)
+
+    if result.changed:
+        pcb.save(str(routed_path))
+
+    print("   " + result.summary().replace("\n", "\n   "))
+    if result.unresolved:
+        print(
+            f"\n   WARNING: {len(result.unresolved)} via(s) left in place (boxed in) -- "
+            "the fresh regen may still carry a hole-to-hole error."
+        )
+    print("\n   SUCCESS: relocate_drill_clearance_step completed")
+    return True
+
+
 def fill_zones(routed_path: Path) -> bool:
     """
     Re-pour the copper zones (GND B.Cu plane) after stitching.
@@ -2011,6 +2066,19 @@ def main() -> int:
         # re-pours so the new ties take effect).
         tie_success = tie_power_pads(routed_path)
 
+        # Step 6.3: Relieve fine-pitch hole-to-hole via crowding (#4408) -- the
+        # fresh route stacks the OSC_OUT/NRST/GND LQFP-48 west escapes as in-pad
+        # micro-vias at the 0.5mm pin pitch, leaving two 0.350mm drill pairs
+        # below the jlcpcb-tier1 0.500mm hole-to-hole floor.  This generic,
+        # mfr-floor-driven pass relocates the offending (middle NRST) via onto a
+        # clearance-safe escape node and re-bonds it with connectivity stubs,
+        # back-porting the artifact-only #4017 nudge into the recipe so a fresh
+        # regen is tier1-clean by construction.  Must run AFTER stitch_pcb +
+        # tie_power_pads (so it sees every via) and BEFORE quantize_escapes (so
+        # any stub is 45-quantized) / fill_zones (so the re-pour backs off the
+        # relocated via).
+        drill_clearance_success = relocate_drill_clearance_step(routed_path)
+
         # Step 6.4: 45-degree quantize the escape copper (#3797 / #3532) -- the
         # fresh deterministic route + the fix_osc_escape re-aim + the kct stitch
         # GND pad-tails ship a few arbitrary-angle hops (the OSC_OUT re-aim
@@ -2126,6 +2194,7 @@ def main() -> int:
         print(f"  45-quantize: {'SUCCESS' if quantize_success else 'FAIL'}")
         print(f"  Stitch: {'SUCCESS' if stitch_success else 'FAIL'}")
         print(f"  Power-pad tie: {'SUCCESS' if tie_success else 'FAIL'}")
+        print(f"  Hole-to-hole relocate: {'SUCCESS' if drill_clearance_success else 'FAIL'}")
         print(f"  Zone fill: {'SUCCESS' if fill_success else 'FAIL'}")
         print(f"  Manufacturing bundle: {'WRITTEN' if mfr_success else 'FAILED'}")
         print("\nBoard description:")
@@ -2228,6 +2297,7 @@ def main() -> int:
                 and quantize_success
                 and stitch_success
                 and tie_success
+                and drill_clearance_success
                 and fill_success
                 and mfr_success
                 and gate.passed

--- a/src/kicad_tools/cli/fix_drc_cmd.py
+++ b/src/kicad_tools/cli/fix_drc_cmd.py
@@ -27,7 +27,8 @@ from kicad_tools.drc.repair_clearance import ClearanceRepairer, RepairResult
 from kicad_tools.drc.repair_drill_clearance import DrillClearanceRepairer, DrillRepairResult
 from kicad_tools.drc.report import DRCReport
 from kicad_tools.drc.violation import ViolationType
-from kicad_tools.manufacturers import get_all_manufacturer_names
+from kicad_tools.manufacturers import get_all_manufacturer_names, get_profile
+from kicad_tools.manufacturers.base import DesignRules
 
 
 @dataclass
@@ -236,6 +237,16 @@ Examples:
     do_connectivity_check = not args.dry_run and not args.no_connectivity_check
     connectivity_rollback_occurred = False
 
+    # Active manufacturer design rules -- forwarded to the drill-clearance
+    # repairer so every via slide is re-validated against the shared clearance
+    # engine before it is applied (issue #4408).  Best-effort: if the profile
+    # cannot be resolved we fall back to the legacy unchecked-slide behaviour.
+    drill_design_rules: DesignRules | None = None
+    try:
+        drill_design_rules = get_profile(args.mfr).get_design_rules(args.layers)
+    except Exception:
+        drill_design_rules = None
+
     for pass_num in range(1, effective_max_passes + 1):
         # Classify violations from current report
         do_clearance = args.only is None or args.only == "clearance"
@@ -328,6 +339,7 @@ Examples:
             dry_run=args.dry_run,
             pass_number=pass_num,
             local_reroute=args.local_reroute,
+            design_rules=drill_design_rules,
         )
 
         repaired_this_pass = clearance_result.repaired + drill_result.repaired
@@ -490,8 +502,15 @@ def _run_single_pass(
     dry_run: bool,
     pass_number: int = 1,
     local_reroute: bool = False,
+    design_rules: DesignRules | None = None,
 ) -> tuple[RepairResult, DrillRepairResult]:
-    """Execute a single repair pass (clearance + drill) and return results."""
+    """Execute a single repair pass (clearance + drill) and return results.
+
+    When ``design_rules`` is provided it is forwarded to the drill-clearance
+    repairer so every via slide is re-validated against the shared clearance
+    engine before it is applied (issue #4408) -- a slide that would introduce a
+    new violation is declined rather than mis-placing the via.
+    """
     clearance_result = RepairResult()
     drill_result = DrillRepairResult()
 
@@ -526,6 +545,7 @@ def _run_single_pass(
                 max_displacement=max_displacement,
                 margin=margin,
                 dry_run=dry_run,
+                design_rules=design_rules,
             )
             if drill_result.repaired > 0 and not dry_run:
                 drill_repairer.save(output_path)

--- a/src/kicad_tools/drc/relocate_drill_clearance.py
+++ b/src/kicad_tools/drc/relocate_drill_clearance.py
@@ -1,0 +1,449 @@
+"""Generic, manufacturer-floor-driven hole-to-hole via relocation post-pass.
+
+Issue #4408 -- back-port the artifact-only #4017 hole-to-hole fix into a
+library-level, ``--mfr``-driven pass so *any* fine-pitch QFP/QFN board routed
+at a tier that supports via-in-pad is drill-clearance-clean unattended.
+
+Motivation
+----------
+When a fine-pitch part (e.g. an LQFP-48 at 0.5 mm pin pitch) is routed with
+in-pad micro-vias, adjacent pins' in-pad vias can sit closer than the fab's
+hole-to-hole (drill-to-drill) floor even though each via is individually a
+legal via-in-pad.  On board-04 three in-pad micro-vias (OSC_OUT / NRST / GND)
+stack at the 0.5 mm pitch, so the middle via's drill is only 0.350 mm
+edge-to-edge from each neighbour -- below the ``jlcpcb-tier1`` 0.500 mm
+``min_hole_to_hole_mm`` floor.  This is **not** a via-in-pad violation
+(tier1 supports via-in-pad); it is a hole-to-hole spacing violation between two
+otherwise-legal vias.
+
+The existing :mod:`kicad_tools.cli.relocate_in_pad_vias` pass owns the
+clearance-safe geometry engine (:func:`_check_clearance` -- hole-to-hole /
+THT / copper aware -- plus the 8-direction candidate ladder and the
+connectivity-stub logic) but is a **no-op** on profiles that support via-in-pad
+and only ever targets a via *inside a same-net pad*.  It never fires on a
+hole-to-hole pair of two legal in-pad vias.  This module **bridges that gap**:
+it is *driven by* hole-to-hole violations (like
+:mod:`kicad_tools.drc.repair_drill_clearance`) but *validated by* the
+clearance-safe engine (like :mod:`kicad_tools.cli.relocate_in_pad_vias`) -- one
+engine, no second copy of the geometry checks.
+
+Mechanism
+---------
+For a board and the active manufacturer's :class:`DesignRules`:
+
+1. Read the profile's ``min_hole_to_hole_mm`` (and ``min_clearance_mm``) -- the
+   pass is purely floor-driven, so a wider-floor profile relocates more
+   aggressively and a via-in-pad-supporting tier still gets hole-to-hole
+   relief.
+2. Enumerate via/via drill pairs closer than the floor.  Greedily pick the via
+   participating in the **most** violations (the "middle" of a stack), so a
+   single move can clear multiple pairs.
+3. Find a new location for that via using the candidate ladder -- preferring a
+   slide onto its own routed escape node (the #4017 pattern, minimal move,
+   keeps the via in-pad) then an 8-direction ladder from the via centre -- that
+   satisfies the hole-to-hole floor **and** passes
+   :func:`_check_clearance` (no new copper / hole-to-hole / THT violation).
+4. Preserve connectivity by appending a short stub from the old to the new
+   location on every connected copper layer (the pad's copper layer plus each
+   connected segment's layer), exactly as the Phase-1 signal-slide does.
+5. When no clearance-legal location exists (boxed in), **leave the via in place
+   and report it** -- the pass never mis-places a via into a fresh violation
+   (safety invariant, mirroring the relocate_in_pad_vias contract).
+
+The pass mutates the board in place (unless ``dry_run``).  It adds only same-net
+stub copper and moves via positions -- no existing routed copper on any other
+net is touched, so an already-routed board is never regressed.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from kicad_tools.cli.relocate_in_pad_vias import (
+    _PLANE_DIRECTIONS,
+    _check_clearance,
+    _collect_smd_pads_by_net,
+    _collect_tht_pads,
+    _endpoint_at,
+    _pad_copper_layer,
+)
+from kicad_tools.validate.rules.via_pad_geometry import via_inside_pad
+
+if TYPE_CHECKING:
+    from kicad_tools.manufacturers.base import DesignRules
+    from kicad_tools.schema.pcb import PCB, Segment, Via
+
+# Coincidence tolerance (mm) for "a stub already runs old->new on this layer".
+_SEG_COINCIDENT_TOL = 1e-3
+# Floating-point slack for the hole-to-hole comparison (mm).
+_EPS = 1e-6
+
+
+@dataclass
+class DrillClearanceRelocation:
+    """Record of a via moved to satisfy the hole-to-hole floor."""
+
+    old_x: float
+    old_y: float
+    new_x: float
+    new_y: float
+    net: int
+    net_name: str
+    uuid: str
+    stub_layers: list[str] = field(default_factory=list)
+
+
+@dataclass
+class DrillClearanceUnresolved:
+    """Record of a hole-to-hole violation left in place (boxed in)."""
+
+    x: float
+    y: float
+    net: int
+    net_name: str
+    uuid: str
+    reason: str
+
+
+@dataclass
+class DrillClearanceRelocationResult:
+    """Aggregate outcome of a hole-to-hole relocation pass."""
+
+    moved: list[DrillClearanceRelocation] = field(default_factory=list)
+    unresolved: list[DrillClearanceUnresolved] = field(default_factory=list)
+
+    @property
+    def changed(self) -> bool:
+        """True when at least one via was moved."""
+        return bool(self.moved)
+
+    def summary(self) -> str:
+        """Human-readable one-line-per-section summary."""
+        lines = [f"Hole-to-hole relocation: moved {len(self.moved)} via(s)"]
+        for m in self.moved:
+            lines.append(
+                f"  Via {m.uuid[:8] or '?'} (net '{m.net_name}'): "
+                f"({m.old_x:.3f}, {m.old_y:.3f}) -> ({m.new_x:.3f}, {m.new_y:.3f}); "
+                f"stubs on {', '.join(m.stub_layers) or '(none)'}"
+            )
+        if self.unresolved:
+            lines.append(f"  {len(self.unresolved)} unresolved (boxed in, left in place):")
+            for u in self.unresolved:
+                lines.append(f"    Via at ({u.x:.3f}, {u.y:.3f}) net '{u.net_name}': {u.reason}")
+        return "\n".join(lines)
+
+
+def _resolve_net_name(pcb: PCB, via: Via) -> str:
+    """Return the via's net name, resolving from the board net table if needed.
+
+    :class:`Via` objects created programmatically (``PCB.add_via``) carry only a
+    net *number*; the name lives in ``pcb._nets``.  Loaded boards populate
+    ``via.net_name`` directly.  This resolves both.
+    """
+    if via.net_name:
+        return via.net_name
+    net = pcb._nets.get(via.net_number)
+    return net.name if net is not None else ""
+
+
+def _hole_gap(a: Via, b: Via) -> float:
+    """Edge-to-edge drill gap (mm) between two vias."""
+    d = math.hypot(a.position[0] - b.position[0], a.position[1] - b.position[1])
+    return d - a.drill / 2.0 - b.drill / 2.0
+
+
+def _violating_pairs(vias: list[Via], min_hole_to_hole: float) -> list[tuple[Via, Via]]:
+    """Return all via/via pairs whose drill gap is below the floor."""
+    pairs: list[tuple[Via, Via]] = []
+    for i in range(len(vias)):
+        for j in range(i + 1, len(vias)):
+            if _hole_gap(vias[i], vias[j]) < min_hole_to_hole - _EPS:
+                pairs.append((vias[i], vias[j]))
+    return pairs
+
+
+def _segment_exists(
+    pcb: PCB, net_number: int, layer: str, a: tuple[float, float], b: tuple[float, float]
+) -> bool:
+    """True when a same-net segment already runs ``a``->``b`` on ``layer``.
+
+    Used to avoid appending a stub that would exactly duplicate an existing
+    routed escape leg (which happens when a via is slid onto its own escape
+    node).
+    """
+    for seg in pcb.segments_in_net(net_number):
+        if seg.layer != layer:
+            continue
+        s, e = seg.start, seg.end
+        fwd = (
+            abs(s[0] - a[0]) < _SEG_COINCIDENT_TOL
+            and abs(s[1] - a[1]) < _SEG_COINCIDENT_TOL
+            and abs(e[0] - b[0]) < _SEG_COINCIDENT_TOL
+            and abs(e[1] - b[1]) < _SEG_COINCIDENT_TOL
+        )
+        rev = (
+            abs(s[0] - b[0]) < _SEG_COINCIDENT_TOL
+            and abs(s[1] - b[1]) < _SEG_COINCIDENT_TOL
+            and abs(e[0] - a[0]) < _SEG_COINCIDENT_TOL
+            and abs(e[1] - a[1]) < _SEG_COINCIDENT_TOL
+        )
+        if fwd or rev:
+            return True
+    return False
+
+
+def _find_target(
+    pcb: PCB,
+    via: Via,
+    escape_far: tuple[float, float] | None,
+    pads_by_net: dict,
+    tht_pads: list,
+    min_clearance: float,
+    min_hole_to_hole: float,
+) -> tuple[float, float] | None:
+    """Find the first clearance-safe location that clears the hole-to-hole floor.
+
+    Preference order:
+
+    1. The via's routed escape node (``escape_far``) -- a minimal move that
+       keeps the via in-pad and lands on existing copper (the #4017 pattern),
+       plus a few multiples of the floor along the same direction.
+    2. An 8-direction ladder at increasing multiples of the floor from the via
+       centre.
+
+    A candidate is accepted only when :func:`_check_clearance` passes at it
+    (which enforces the hole-to-hole floor to every other via/THT drill and the
+    copper clearance to every other-net pad / track / via).  Returns ``None``
+    when every candidate is boxed in.
+    """
+    vx, vy = via.position
+    candidates: list[tuple[float, float]] = []
+
+    if escape_far is not None:
+        ex, ey = escape_far
+        dist = math.hypot(ex - vx, ey - vy)
+        if dist > _EPS:
+            candidates.append((ex, ey))
+            ux, uy = (ex - vx) / dist, (ey - vy) / dist
+            for mult in (1.0, 1.25, 1.5, 2.0):
+                candidates.append(
+                    (vx + ux * min_hole_to_hole * mult, vy + uy * min_hole_to_hole * mult)
+                )
+
+    for mult in (1.0, 1.25, 1.5, 2.0):
+        reach = min_hole_to_hole * mult
+        for dx, dy in _PLANE_DIRECTIONS:
+            candidates.append((vx + dx * reach, vy + dy * reach))
+
+    for nx, ny in candidates:
+        if (
+            _check_clearance(
+                pcb, via, nx, ny, pads_by_net, tht_pads, min_clearance, min_hole_to_hole
+            )
+            is None
+        ):
+            return (nx, ny)
+    return None
+
+
+def _try_relocate(
+    pcb: PCB,
+    via: Via,
+    pads_by_net: dict,
+    tht_pads: list,
+    min_clearance: float,
+    min_hole_to_hole: float,
+    dry_run: bool,
+) -> DrillClearanceRelocation | None:
+    """Attempt one clearance-safe relocation of ``via``.
+
+    Returns the :class:`DrillClearanceRelocation` record on success, or ``None``
+    when the via is boxed in (no clearance-legal off-position) or the move could
+    not be persisted -- in which case the via is left untouched.
+    """
+    vx, vy = via.position
+    net_name = _resolve_net_name(pcb, via)
+
+    # Same-net pad containing the via (for the pad-copper stub bond).
+    containing_pad = None
+    for _fp, pad, bbox in pads_by_net.get(via.net_number, []):
+        if via_inside_pad(via, bbox):
+            containing_pad = pad
+            break
+
+    # Same-net routed segments whose endpoint lands on the via.
+    connected: list[tuple[Segment, tuple[float, float]]] = []
+    for seg in pcb.segments_in_net(via.net_number):
+        far = _endpoint_at(seg, vx, vy)
+        if far is not None:
+            connected.append((seg, far))
+
+    escape_far: tuple[float, float] | None = None
+    if connected:
+        _seg, escape_far = max(
+            connected,
+            key=lambda item: math.hypot(item[1][0] - vx, item[1][1] - vy),
+        )
+
+    target = _find_target(
+        pcb, via, escape_far, pads_by_net, tht_pads, min_clearance, min_hole_to_hole
+    )
+    if target is None:
+        return None
+    new_x, new_y = target
+
+    # Connectivity stub layers: the pad's copper layer plus every connected
+    # segment's layer (deduplicated, order-preserving).
+    stub_layers: list[str] = []
+    seen: set[str] = set()
+    layer_sources: list[str] = []
+    if containing_pad is not None:
+        layer_sources.append(_pad_copper_layer(containing_pad))
+    layer_sources.extend(seg.layer for seg, _ in connected)
+    for layer in layer_sources:
+        if layer and layer not in seen:
+            seen.add(layer)
+            stub_layers.append(layer)
+
+    widths = [seg.width for seg, _ in connected if seg.width > 0]
+    stub_width = min(widths) if widths else 0.2
+
+    if not dry_run:
+        # Append connectivity stubs BEFORE moving the via so the old location
+        # stays bonded to the new one on every connected layer.  Skip a layer
+        # whose old->new leg already exists (avoids duplicating an escape leg
+        # when the via slides onto its own escape node).
+        for layer in stub_layers:
+            if _segment_exists(pcb, via.net_number, layer, (vx, vy), (new_x, new_y)):
+                continue
+            pcb.add_trace(
+                (vx, vy),
+                (new_x, new_y),
+                width=stub_width,
+                layer=layer,
+                net=net_name or None,
+            )
+        if not pcb.relocate_via(via, (new_x, new_y)):
+            return None
+
+    return DrillClearanceRelocation(
+        old_x=vx,
+        old_y=vy,
+        new_x=new_x,
+        new_y=new_y,
+        net=via.net_number,
+        net_name=net_name,
+        uuid=via.uuid,
+        stub_layers=stub_layers,
+    )
+
+
+def relocate_drill_clearance(
+    pcb: PCB,
+    design_rules: DesignRules,
+    *,
+    nets: set[str] | None = None,
+    dry_run: bool = False,
+) -> DrillClearanceRelocationResult:
+    """Relocate vias to satisfy the manufacturer's hole-to-hole floor.
+
+    Args:
+        pcb: The board to operate on (mutated in place unless ``dry_run``).
+        design_rules: Active manufacturer rules.  ``min_hole_to_hole_mm`` is the
+            floor the pass enforces and ``min_clearance_mm`` gates the
+            relocated copper.  Unlike :func:`relocate_in_pad_vias`, this pass is
+            **not** gated on ``via_in_pad_supported`` -- a hole-to-hole
+            violation between two legal in-pad vias must be relieved even on a
+            profile that supports via-in-pad.
+        nets: Optional set of net *names* to restrict the pass to (``None`` =
+            all nets).
+        dry_run: When True, compute the report without mutating the board.
+
+    Returns:
+        A :class:`DrillClearanceRelocationResult` listing every moved via and
+        every violation left in place (boxed in).  Relocation is always
+        clearance-safe: a via is moved only to a location that passes
+        :func:`_check_clearance`, so the pass never introduces a new violation.
+    """
+    result = DrillClearanceRelocationResult()
+
+    min_clearance = design_rules.min_clearance_mm
+    min_hole_to_hole = design_rules.min_hole_to_hole_mm
+
+    pads_by_net = _collect_smd_pads_by_net(pcb)
+    tht_pads = _collect_tht_pads(pcb)
+
+    # Vias whose relocation was attempted and failed (boxed in): do not retry,
+    # so the greedy loop falls through to the partner via in the pair.
+    failed: set[str] = set()
+
+    # Bound the greedy loop: at most one move per via.
+    max_iterations = 4 * max(1, len(pcb.vias))
+    for _ in range(max_iterations):
+        pairs = _violating_pairs(list(pcb.vias), min_hole_to_hole)
+        if not pairs:
+            break
+
+        counts: dict[int, int] = {}
+        vias_in_pairs: dict[int, Via] = {}
+        for a, b in pairs:
+            counts[id(a)] = counts.get(id(a), 0) + 1
+            counts[id(b)] = counts.get(id(b), 0) + 1
+            vias_in_pairs[id(a)] = a
+            vias_in_pairs[id(b)] = b
+
+        # Deterministic: most-violating first, then by position.
+        ordered = sorted(
+            vias_in_pairs.values(),
+            key=lambda v: (-counts[id(v)], round(v.position[0], 4), round(v.position[1], 4)),
+        )
+
+        moved_this_pass = False
+        for via in ordered:
+            if via.uuid in failed:
+                continue
+            if via.net_number == 0:
+                continue
+            net_name = _resolve_net_name(pcb, via)
+            if nets is not None and net_name not in nets:
+                continue
+
+            outcome = _try_relocate(
+                pcb, via, pads_by_net, tht_pads, min_clearance, min_hole_to_hole, dry_run
+            )
+            if outcome is None:
+                failed.add(via.uuid)
+                continue
+            result.moved.append(outcome)
+            moved_this_pass = True
+            # In dry_run mode the board is not mutated, so the same pair would
+            # be re-selected forever -- stop after reporting one representative
+            # move per violating via.
+            if dry_run:
+                failed.add(via.uuid)
+            break
+
+        if not moved_this_pass:
+            break
+
+    # Surface any violation still present after the greedy loop.
+    seen_uuids: set[str] = set()
+    for a, b in _violating_pairs(list(pcb.vias), min_hole_to_hole):
+        for via in (a, b):
+            if via.uuid in seen_uuids:
+                continue
+            seen_uuids.add(via.uuid)
+            result.unresolved.append(
+                DrillClearanceUnresolved(
+                    x=via.position[0],
+                    y=via.position[1],
+                    net=via.net_number,
+                    net_name=_resolve_net_name(pcb, via),
+                    uuid=via.uuid,
+                    reason="no clearance-legal location satisfies the hole-to-hole floor (boxed in)",
+                )
+            )
+
+    return result

--- a/src/kicad_tools/drc/repair_drill_clearance.py
+++ b/src/kicad_tools/drc/repair_drill_clearance.py
@@ -18,10 +18,14 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from ..sexp import SExp, parse_file
 from .net_compat import resolve_net_atom
 from .violation import DRCViolation, ViolationType
+
+if TYPE_CHECKING:
+    from kicad_tools.manufacturers.base import DesignRules
 
 
 @dataclass
@@ -62,6 +66,7 @@ class DrillRepairResult:
     skipped_no_delta: int = 0
     skipped_exceeds_max: int = 0
     skipped_infeasible: int = 0
+    skipped_unsafe: int = 0
     actions: list[DrillRepairAction] = field(default_factory=list)
 
     @property
@@ -84,6 +89,10 @@ class DrillRepairResult:
             lines.append(f"  Skipped (exceeds max displacement): {self.skipped_exceeds_max}")
         if self.skipped_infeasible > 0:
             lines.append(f"  Skipped (infeasible): {self.skipped_infeasible}")
+        if self.skipped_unsafe > 0:
+            lines.append(
+                f"  Skipped (slide would introduce a new violation): {self.skipped_unsafe}"
+            )
         if self.skipped_no_location > 0:
             lines.append(f"  Skipped (no location): {self.skipped_no_location}")
         if self.skipped_no_delta > 0:
@@ -144,6 +153,7 @@ class DrillClearanceRepairer:
         max_displacement: float = 0.5,
         margin: float = 0.01,
         dry_run: bool = False,
+        design_rules: DesignRules | None = None,
     ) -> DrillRepairResult:
         """Repair drill clearance violations.
 
@@ -152,6 +162,20 @@ class DrillClearanceRepairer:
             max_displacement: Maximum allowed slide distance in mm
             margin: Extra clearance margin beyond minimum in mm
             dry_run: If True, compute repairs but don't modify PCB
+            design_rules: Active manufacturer rules.  When provided, every
+                computed slide is **re-validated** against the shared
+                clearance engine
+                (:func:`kicad_tools.cli.relocate_in_pad_vias._check_clearance`)
+                before it is applied: a slide that would introduce a new
+                hole-to-hole / copper-clearance violation (crowding another
+                neighbour, shorting a foreign net) is **declined** -- the via
+                is left in place and counted in
+                :attr:`DrillRepairResult.skipped_unsafe`.  This is the
+                clearance-safety gap #4017 hit: the previous ``_slide_via``
+                moved a via without checking that its new position was itself
+                legal, so the fix had to be done by hand.  When ``None``
+                (default) the legacy unchecked-slide behaviour is preserved
+                for backward compatibility.
 
         Returns:
             DrillRepairResult with details of all repairs
@@ -167,7 +191,7 @@ class DrillClearanceRepairer:
         result.total_violations = len(drill_violations)
 
         for violation in drill_violations:
-            self._repair_single(violation, result, max_displacement, margin, dry_run)
+            self._repair_single(violation, result, max_displacement, margin, dry_run, design_rules)
 
         return result
 
@@ -178,6 +202,7 @@ class DrillClearanceRepairer:
         max_displacement: float,
         margin: float,
         dry_run: bool,
+        design_rules: DesignRules | None = None,
     ) -> None:
         """Attempt to repair a single drill clearance violation."""
         if not violation.locations or len(violation.locations) < 1:
@@ -242,6 +267,7 @@ class DrillClearanceRepairer:
             required_displacement,
             result,
             dry_run,
+            design_rules,
         )
 
     def _find_vias_near(
@@ -330,11 +356,17 @@ class DrillClearanceRepairer:
         required_displacement: float,
         result: DrillRepairResult,
         dry_run: bool,
+        design_rules: DesignRules | None = None,
     ) -> None:
         """Slide a via away from another object to achieve clearance.
 
         Finds a connected trace segment and slides the via along it.
         Falls back to pushing via directly away if no connected trace exists.
+
+        When ``design_rules`` is provided the computed target is re-validated
+        against the shared clearance engine before it is applied; a slide that
+        would introduce a new violation is declined (the via is left in place
+        and counted in :attr:`DrillRepairResult.skipped_unsafe`).
         """
         # Find connected segment to determine slide direction
         connected_seg = self._find_connected_segment(via_x, via_y, via_net)
@@ -389,6 +421,21 @@ class DrillClearanceRepairer:
                 via_x, via_y, other_x, other_y, required_displacement
             )
 
+        # Clearance-safety gate (#4408): re-validate the computed target before
+        # applying it.  The legacy path slid ``dist`` and updated the segment
+        # endpoint WITHOUT checking that the new position was itself legal, so a
+        # slide could crowd the OTHER neighbour or short a foreign net -- which
+        # is why #4017 had to be relocated by hand.  When ``design_rules`` is
+        # provided we reject a target that introduces a new violation and leave
+        # the via untouched (safety invariant: never make the board worse).
+        if design_rules is not None:
+            reason = self._target_clearance_reason(
+                via_x, via_y, via_x + dx, via_y + dy, design_rules
+            )
+            if reason is not None:
+                result.skipped_unsafe += 1
+                return
+
         uuid_node = via_node.find("uuid")
         uuid_str = uuid_node.get_first_atom() if uuid_node else ""
         action = DrillRepairAction(
@@ -413,6 +460,66 @@ class DrillClearanceRepairer:
 
         result.repaired += 1
         result.slid += 1
+
+    def _target_clearance_reason(
+        self,
+        via_x: float,
+        via_y: float,
+        new_x: float,
+        new_y: float,
+        design_rules: DesignRules,
+    ) -> str | None:
+        """Return a reason string if moving the via at ``(via_x, via_y)`` to
+        ``(new_x, new_y)`` would violate clearance; ``None`` when the target is
+        clearance-safe.
+
+        Bridges the SExp repair model to the shared PCB-schema clearance engine
+        (:func:`kicad_tools.cli.relocate_in_pad_vias._check_clearance`) by
+        building a lightweight :class:`PCB` view over the current document.
+        Rebuilt per call because a prior repair may have mutated the document;
+        drill-clearance violation clusters are small so this stays cheap.
+        """
+        from kicad_tools.cli.relocate_in_pad_vias import (
+            _check_clearance,
+            _collect_smd_pads_by_net,
+            _collect_tht_pads,
+        )
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB(self.doc)
+        # The repairer works in ABSOLUTE file coordinates, but a PCB view is
+        # board-relative (``_detect_board_origin``).  Convert the pre- and
+        # post-move points into the view's frame before matching / checking.
+        ox, oy = pcb._board_origin
+        rel_via_x, rel_via_y = via_x - ox, via_y - oy
+        rel_new_x, rel_new_y = new_x - ox, new_y - oy
+
+        # Locate the schema Via matching the pre-move position so
+        # ``_check_clearance`` exempts it (and reads its drill/size/net).
+        target_via = None
+        best = 1e-3
+        for v in pcb.vias:
+            d = math.hypot(v.position[0] - rel_via_x, v.position[1] - rel_via_y)
+            if d < best:
+                best = d
+                target_via = v
+        if target_via is None:
+            # Could not map the via into the schema view; do not block the
+            # legacy behaviour on a lookup miss.
+            return None
+
+        pads_by_net = _collect_smd_pads_by_net(pcb)
+        tht_pads = _collect_tht_pads(pcb)
+        return _check_clearance(
+            pcb,
+            target_via,
+            rel_new_x,
+            rel_new_y,
+            pads_by_net,
+            tht_pads,
+            design_rules.min_clearance_mm,
+            design_rules.min_hole_to_hole_mm,
+        )
 
     def undo_action(self, action: DrillRepairAction) -> bool:
         """Reverse a previously-applied drill-clearance repair action.

--- a/tests/test_board_04_drill_clearance_regen.py
+++ b/tests/test_board_04_drill_clearance_regen.py
@@ -1,0 +1,131 @@
+"""Regression guard: board-04 fresh regen is jlcpcb-tier1 hole-to-hole clean.
+
+Issue #4408.  Board-04's LQFP-48 west escape routes three in-pad micro-vias
+(OSC_OUT / NRST / GND) stacked at the 0.5 mm pin pitch, leaving two 0.350 mm
+drill pairs below the jlcpcb-tier1 0.500 mm ``min_hole_to_hole_mm`` floor.  #4017
+fixed this ARTIFACT-ONLY (a hand nudge that was deliberately not back-ported),
+so every fresh regen reintroduced 2 ``hole_to_hole_clearance`` errors and the
+committed board diverged from the recipe.
+
+#4408 back-ports the fix as a generic, ``--mfr``-driven post-route pass
+(``relocate_drill_clearance_step`` in the recipe, wired between
+``tie_power_pads`` and ``quantize_escapes``).  Two guards:
+
+1. A fast source-pin (no routing) that the recipe still wires the step -- so a
+   future recipe cleanup that drops it fails at PR time rather than silently
+   regressing to artifact-only.
+2. A ``@slow`` end-to-end regen that runs ``generate_design.py`` and asserts the
+   FRESH routed board is tier1-clean (0 blocking DRC errors), which is the real
+   acceptance criterion the CI fresh-regen gate now enforces at strict-0.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BOARD_04_RECIPE = REPO_ROOT / "boards" / "04-stm32-devboard" / "generate_design.py"
+
+
+def test_recipe_wires_hole_to_hole_relocation_step() -> None:
+    """Fast source-pin: the recipe must invoke the hole-to-hole relocation pass.
+
+    Pins both the step function and its call site so a future edit that removes
+    either (silently reverting to the artifact-only #4017 state) trips here.
+    """
+    source = BOARD_04_RECIPE.read_text()
+
+    assert "def relocate_drill_clearance_step(" in source, (
+        "board-04 recipe no longer defines relocate_drill_clearance_step -- the "
+        "generic #4408 hole-to-hole relocation pass.  Without it the fresh regen "
+        "reintroduces the 2 grandfathered 0.350mm drill pairs and diverges from "
+        "the committed artifact (the #4017 artifact-only state)."
+    )
+    assert "relocate_drill_clearance_step(routed_path)" in source, (
+        "board-04 recipe defines relocate_drill_clearance_step but no longer "
+        "CALLS it in the post-route pipeline.  Re-wire it between tie_power_pads "
+        "and quantize_escapes (issue #4408)."
+    )
+    # It must import the library engine (the shared clearance-safe pass), not a
+    # board-specific hack.
+    assert (
+        "from kicad_tools.drc.relocate_drill_clearance import relocate_drill_clearance" in source
+    ), (
+        "board-04 recipe no longer imports the library relocate_drill_clearance "
+        "engine -- the fix must live in the library, not a board-local hack "
+        "(issue #4408)."
+    )
+
+
+@pytest.mark.slow
+def test_fresh_regen_is_tier1_hole_to_hole_clean(tmp_path: Path) -> None:
+    """End-to-end: a fresh ``generate_design.py`` run is jlcpcb-tier1-clean.
+
+    This is the #4408 acceptance criterion: the GENERATOR (not a committed
+    artifact) produces a tier1-clean board unattended.  Mirrors the CI
+    fresh-regen strict-0 gate.
+    """
+    out_dir = tmp_path / "board04"
+    out_dir.mkdir()
+
+    # Regen may exit non-zero on a partial route under load (documented
+    # host-vs-CI router divergence, #3822); the DRC assertion below is the real
+    # gate, so tolerate a non-zero recipe exit as long as the routed PCB exists.
+    proc = subprocess.run(
+        [sys.executable, str(BOARD_04_RECIPE), str(out_dir)],
+        capture_output=True,
+        text=True,
+        timeout=1200,
+        check=False,
+    )
+
+    routed = out_dir / "stm32_devboard_routed.kicad_pcb"
+    if not routed.exists():
+        pytest.fail(
+            "board-04 regen did not produce a routed PCB.\n"
+            f"stdout tail:\n{proc.stdout[-2000:]}\n"
+            f"stderr tail:\n{proc.stderr[-2000:]}"
+        )
+
+    check = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "kicad_tools.cli",
+            "check",
+            str(routed),
+            "--mfr",
+            "jlcpcb-tier1",
+            "--errors-only",
+            "--format",
+            "json",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+        check=False,
+    )
+    brace = check.stdout.find("{")
+    assert brace >= 0, f"kct check produced no JSON payload:\n{check.stdout}"
+    payload = json.loads(check.stdout[brace:])
+
+    violations = payload.get("violations", [])
+    # Blocking (non-advisory) errors, counted the way the CI gate counts them.
+    blocking = [
+        v for v in violations if v.get("severity") == "error" and v.get("rule_id") != "connectivity"
+    ]
+    hole_to_hole = [v for v in blocking if v.get("rule_id") == "hole_to_hole_clearance"]
+
+    assert not hole_to_hole, (
+        "Fresh board-04 regen still has hole_to_hole_clearance errors -- the "
+        "relocation pass did not relieve the LQFP-48 west escape stack:\n"
+        + "\n".join(f"  - {v.get('message')} at {v.get('location')}" for v in hole_to_hole)
+    )
+    assert not blocking, "Fresh board-04 regen has blocking jlcpcb-tier1 DRC errors:\n" + "\n".join(
+        f"  - {v.get('rule_id')}: {v.get('message')}" for v in blocking
+    )

--- a/tests/test_board_04_partial_route_fastfail.py
+++ b/tests/test_board_04_partial_route_fastfail.py
@@ -67,6 +67,9 @@ class TestBoard04PartialRouteFastFail:
         monkeypatch.setattr(module, "fix_osc_escape", _boom("fix_osc_escape"))
         monkeypatch.setattr(module, "stitch_pcb", _boom("stitch_pcb"))
         monkeypatch.setattr(module, "tie_power_pads", _boom("tie_power_pads"))
+        monkeypatch.setattr(
+            module, "relocate_drill_clearance_step", _boom("relocate_drill_clearance_step")
+        )
         monkeypatch.setattr(module, "quantize_escapes", _boom("quantize_escapes"))
         monkeypatch.setattr(module, "fill_zones", _boom("fill_zones"))
         monkeypatch.setattr(module, "run_drc", _boom("run_drc"))
@@ -102,6 +105,7 @@ class TestBoard04PartialRouteFastFail:
         monkeypatch.setattr(module, "fix_osc_escape", lambda *a, **k: True)
         monkeypatch.setattr(module, "stitch_pcb", lambda *a, **k: True)
         monkeypatch.setattr(module, "tie_power_pads", lambda *a, **k: True)
+        monkeypatch.setattr(module, "relocate_drill_clearance_step", lambda *a, **k: True)
         monkeypatch.setattr(module, "quantize_escapes", lambda *a, **k: True)
         monkeypatch.setattr(module, "fill_zones", lambda *a, **k: True)
         monkeypatch.setattr(module, "run_drc", lambda *a, **k: True)

--- a/tests/test_relocate_drill_clearance.py
+++ b/tests/test_relocate_drill_clearance.py
@@ -1,0 +1,259 @@
+"""Unit tests for the generic hole-to-hole via relocation pass (issue #4408).
+
+These tests exercise
+:func:`kicad_tools.drc.relocate_drill_clearance.relocate_drill_clearance` on
+synthetic boards -- no routing, no board recipe -- so they run in milliseconds
+and pin the safety-critical behaviour:
+
+* the middle via of a 0.5 mm-pitch in-pad stack (the board-04 LQFP-48 west
+  escape geometry) is relocated onto a clearance-safe location so both drill
+  pairs clear the floor;
+* the pass reads the **active** manufacturer floor (a wider floor relocates a
+  pair a narrower floor tolerates -- it is not hardcoded to 0.5, and it is not
+  gated on ``via_in_pad_supported``);
+* a boxed-in via is left in place and reported (the safety invariant: the pass
+  never mis-places a via into a fresh violation).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+
+from kicad_tools.drc.relocate_drill_clearance import (
+    _find_target,
+    _violating_pairs,
+    relocate_drill_clearance,
+)
+from kicad_tools.manufacturers import get_profile
+from kicad_tools.schema.pcb import PCB
+
+# The board-04 geometry: 0.3 mm micro-via pad / 0.15 mm drill.
+_SIZE = 0.3
+_DRILL = 0.15
+
+
+def _tier1_rules():
+    """jlcpcb-tier1 design rules (min_hole_to_hole 0.5 mm, via-in-pad supported)."""
+    return get_profile("jlcpcb-tier1").get_design_rules()
+
+
+def _stack_board() -> PCB:
+    """Three in-pad micro-vias stacked at the 0.5 mm pin pitch.
+
+    Mirrors the board-04 OSC_OUT / NRST / GND west-escape cluster: the middle
+    via's drill is 0.350 mm edge-to-edge from each neighbour (< 0.5 mm floor).
+    The middle via carries an east-going escape track, so it can slide onto its
+    own escape node exactly as #4017 did by hand.
+    """
+    pcb = PCB.create(width=40.0, height=40.0)
+    pcb.add_via(20.0, 20.0, size=_SIZE, drill=_DRILL, net="OSC_OUT")
+    pcb.add_via(20.0, 20.5, size=_SIZE, drill=_DRILL, net="NRST")
+    pcb.add_via(20.0, 21.0, size=_SIZE, drill=_DRILL, net="GND")
+    # East escape for the middle (NRST) via -> gives it a slide direction/node.
+    pcb.add_trace((20.0, 20.5), (20.5, 20.5), width=0.127, layer="B.Cu", net="NRST")
+    return pcb
+
+
+def test_relocates_middle_via_of_pitch_stack() -> None:
+    """The middle via of a 0.5 mm stack is relocated; both pairs clear the floor."""
+    pcb = _stack_board()
+    rules = _tier1_rules()
+
+    before = _violating_pairs(list(pcb.vias), rules.min_hole_to_hole_mm)
+    assert len(before) == 2, "expected the two 0.350 mm pairs to violate the 0.5 mm floor"
+
+    result = relocate_drill_clearance(pcb, rules)
+
+    assert result.changed
+    assert len(result.moved) == 1
+    assert result.moved[0].net_name == "NRST"
+    assert not result.unresolved
+
+    # Post-move: no via/via pair is below the floor.
+    after = _violating_pairs(list(pcb.vias), rules.min_hole_to_hole_mm)
+    assert after == [], f"relocation left {len(after)} hole-to-hole pair(s) unresolved"
+
+    # And the relocated via genuinely cleared both neighbours by >= the floor.
+    moved = result.moved[0]
+    for via in pcb.vias:
+        if via.uuid == moved.uuid:
+            continue
+        gap = (
+            math.hypot(via.position[0] - moved.new_x, via.position[1] - moved.new_y)
+            - _DRILL / 2.0
+            - via.drill / 2.0
+        )
+        assert gap >= rules.min_hole_to_hole_mm - 1e-6
+
+
+def test_relocated_via_stays_connected_via_stub() -> None:
+    """The relocated via re-bonds to its old location with connectivity stubs."""
+    pcb = _stack_board()
+    result = relocate_drill_clearance(pcb, _tier1_rules())
+
+    moved = result.moved[0]
+    # A signal via that slides off its pad must stub on every connected layer so
+    # the pad / route stays electrically bonded to the new via location.
+    assert moved.stub_layers, "expected connectivity stub layer(s) for the moved signal via"
+
+    # There is now same-net copper running old -> new (either the pre-existing
+    # escape leg or an appended stub) so the move preserved connectivity.
+    old = (moved.old_x, moved.old_y)
+    new = (moved.new_x, moved.new_y)
+    bonded = False
+    for seg in pcb.segments_in_net(moved.net):
+        endpoints = {seg.start, seg.end}
+        if any(math.hypot(p[0] - old[0], p[1] - old[1]) < 1e-3 for p in endpoints) and any(
+            math.hypot(p[0] - new[0], p[1] - new[1]) < 1e-3 for p in endpoints
+        ):
+            bonded = True
+            break
+    assert bonded, "no same-net segment bonds the old via location to the new one"
+
+
+def test_pass_reads_active_floor_not_hardcoded() -> None:
+    """The relocation is driven by the active ``min_hole_to_hole_mm`` floor.
+
+    The same 0.350 mm-gap stack is a violation at a 0.5 mm floor but legal at a
+    0.3 mm floor -- so a narrow-floor run must be a no-op and a wide-floor run
+    must relocate.  This proves the pass reads the profile's floor rather than a
+    hardcoded 0.5 (and is not gated on ``via_in_pad_supported``).
+    """
+    tier1 = _tier1_rules()
+
+    narrow = dataclasses.replace(tier1, min_hole_to_hole_mm=0.30)
+    pcb_narrow = _stack_board()
+    result_narrow = relocate_drill_clearance(pcb_narrow, narrow)
+    assert not result_narrow.changed, "0.350 mm gap is legal at a 0.30 mm floor -- must not move"
+
+    wide = dataclasses.replace(tier1, min_hole_to_hole_mm=0.50)
+    pcb_wide = _stack_board()
+    result_wide = relocate_drill_clearance(pcb_wide, wide)
+    assert result_wide.changed, "0.350 mm gap violates a 0.50 mm floor -- must relocate"
+
+
+def test_dry_run_reports_without_mutating() -> None:
+    """``dry_run`` reports the move without touching the board."""
+    pcb = _stack_board()
+    original = [(v.position[0], v.position[1]) for v in pcb.vias]
+
+    result = relocate_drill_clearance(pcb, _tier1_rules(), dry_run=True)
+
+    assert result.changed  # it WOULD move a via
+    assert [(v.position[0], v.position[1]) for v in pcb.vias] == original
+
+
+def test_net_scoping_restricts_moves() -> None:
+    """A ``nets`` filter restricts which vias the pass may relocate."""
+    pcb = _stack_board()
+    # NRST (the only via with an escape) is excluded, so no move is possible
+    # without introducing a violation elsewhere -> the pass leaves it and reports.
+    result = relocate_drill_clearance(pcb, _tier1_rules(), nets={"GND", "OSC_OUT"})
+
+    assert all(m.net_name in {"GND", "OSC_OUT"} for m in result.moved)
+
+
+def _boxed_target_board() -> PCB:
+    """A via surrounded by other-net vias in all 8 ladder directions.
+
+    Every candidate location the ladder proposes lands on top of a blocking
+    drill, so no clearance-legal off-position exists.
+    """
+    from kicad_tools.drc.relocate_drill_clearance import _PLANE_DIRECTIONS
+
+    pcb = PCB.create(width=40.0, height=40.0)
+    cx, cy = 20.0, 20.0
+    pcb.add_via(cx, cy, size=_SIZE, drill=_DRILL, net="TARGET")
+    # Ring radius chosen so blockers do not violate each other (0.65 mm chord ->
+    # 0.5 mm gap, exactly the floor) but block every candidate direction.
+    ring_r = 0.85
+    for i, (dx, dy) in enumerate(_PLANE_DIRECTIONS):
+        pcb.add_via(cx + dx * ring_r, cy + dy * ring_r, size=_SIZE, drill=_DRILL, net=f"BLK{i}")
+    return pcb
+
+
+def test_boxed_in_target_has_no_clearance_legal_location() -> None:
+    """``_find_target`` returns None when every ladder candidate is blocked."""
+    from kicad_tools.cli.relocate_in_pad_vias import _collect_smd_pads_by_net, _collect_tht_pads
+
+    pcb = _boxed_target_board()
+    rules = _tier1_rules()
+    # The target is the centre via (programmatic Via objects carry only a net
+    # number, so select by position rather than name).
+    target = min(pcb.vias, key=lambda v: math.hypot(v.position[0] - 20.0, v.position[1] - 20.0))
+
+    pads_by_net = _collect_smd_pads_by_net(pcb)
+    tht_pads = _collect_tht_pads(pcb)
+
+    result = _find_target(
+        pcb,
+        target,
+        None,  # no escape node
+        pads_by_net,
+        tht_pads,
+        rules.min_clearance_mm,
+        rules.min_hole_to_hole_mm,
+    )
+    assert result is None
+
+
+def test_dense_field_never_introduces_a_new_violation() -> None:
+    """The pass is clearance-safe on a crowded field (safety invariant).
+
+    A dense via grid has interior vias that are genuinely boxed in (reported
+    unresolved) and edge vias that can escape to clear spots (relocated).  The
+    invariant under test: whatever the pass does, it must NEVER increase the
+    violation count -- every move is validated against ``_check_clearance`` and
+    a via with no clearance-legal location is left in place and reported.
+    """
+    from kicad_tools.cli.relocate_in_pad_vias import (
+        _check_clearance,
+        _collect_smd_pads_by_net,
+        _collect_tht_pads,
+    )
+
+    pcb = PCB.create(width=40.0, height=40.0)
+    # 5x5 grid at 0.35 mm spacing (0.20 mm drill gap << 0.5 mm floor).
+    n = 0
+    for gx in range(5):
+        for gy in range(5):
+            pcb.add_via(
+                18.0 + gx * 0.35,
+                18.0 + gy * 0.35,
+                size=_SIZE,
+                drill=_DRILL,
+                net=f"N{n}",
+            )
+            n += 1
+
+    rules = _tier1_rules()
+    before = _violating_pairs(list(pcb.vias), rules.min_hole_to_hole_mm)
+    assert before, "sanity: the dense grid must start with violations"
+
+    result = relocate_drill_clearance(pcb, rules)
+
+    # Safety invariant: the pass never makes the board worse.
+    after = _violating_pairs(list(pcb.vias), rules.min_hole_to_hole_mm)
+    assert len(after) <= len(before)
+
+    # Interior vias are boxed in -> reported, never mis-placed.
+    assert result.unresolved
+
+    # Every via the pass moved is itself clearance-safe at its new location.
+    pads_by_net = _collect_smd_pads_by_net(pcb)
+    tht_pads = _collect_tht_pads(pcb)
+    by_uuid = {v.uuid: v for v in pcb.vias}
+    for m in result.moved:
+        via = by_uuid[m.uuid]
+        reason = _check_clearance(
+            pcb,
+            via,
+            via.position[0],
+            via.position[1],
+            pads_by_net,
+            tht_pads,
+            rules.min_clearance_mm,
+            rules.min_hole_to_hole_mm,
+        )
+        assert reason is None, f"moved via {m.uuid[:8]} is not clearance-safe: {reason}"

--- a/tests/test_repair_drill_clearance_safe.py
+++ b/tests/test_repair_drill_clearance_safe.py
@@ -1,0 +1,123 @@
+"""Clearance-safety gate for the drill-clearance repairer (issue #4408).
+
+Before #4408 ``DrillClearanceRepairer._slide_via`` slid a via by the shortfall
+without checking that the *new* position was itself legal -- so a slide could
+resolve one hole-to-hole pair while crowding the neighbour on the other side (or
+shorting a foreign net).  That is exactly why #4017 had to be relocated by hand.
+
+These tests pin the new behaviour: when the active manufacturer's
+:class:`DesignRules` are supplied, a slide that would introduce a NEW violation
+is **declined** (the via is left in place and counted in ``skipped_unsafe``),
+while the legacy unchecked-slide behaviour is preserved when no rules are given.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from kicad_tools.core.types import Severity
+from kicad_tools.drc.repair_drill_clearance import DrillClearanceRepairer
+from kicad_tools.drc.violation import DRCViolation, Location, ViolationType
+from kicad_tools.manufacturers import get_profile
+from kicad_tools.schema.pcb import PCB
+
+_SIZE = 0.3
+_DRILL = 0.15
+
+
+def _crowded_board(path: Path) -> None:
+    """Three vias where sliding the middle one away from its neighbour crowds a
+    third via on the far side.
+
+    * via A (net A) at (5.0, 5.00)  -- the violation partner
+    * via B (net B) at (5.0, 5.35)  -- the via that would be slid (gap 0.20 < 0.5)
+    * via C (net C) at (5.0, 5.85)  -- sliding B north to clear A lands ~0.19 mm
+                                       from C (a fresh hole-to-hole violation)
+
+    Board is created un-centred so board-relative == file-absolute coordinates,
+    keeping the DRC location arithmetic simple.
+    """
+    pcb = PCB.create(width=40.0, height=40.0, center=False)
+    pcb.add_via(5.0, 5.00, size=_SIZE, drill=_DRILL, net="A")
+    pcb.add_via(5.0, 5.35, size=_SIZE, drill=_DRILL, net="B")
+    pcb.add_via(5.0, 5.85, size=_SIZE, drill=_DRILL, net="C")
+    # A north-going escape on B's net gives the slide a direction toward C.
+    pcb.add_trace((5.0, 5.35), (5.0, 6.0), width=0.15, layer="B.Cu", net="B")
+    pcb.save(str(path))
+
+
+def _hole_to_hole_violation() -> DRCViolation:
+    """A hole-to-hole violation between via A and via B (0.20 mm < 0.50 mm).
+
+    Location is nudged toward via A so the repairer's two-nearest selection
+    picks (A, B) and slides B (the second-nearest), which owns the escape.
+    """
+    return DRCViolation(
+        type=ViolationType.DRILL_CLEARANCE,
+        type_str="drill_clearance",
+        severity=Severity.ERROR,
+        message="Hole-to-hole clearance 0.200mm < minimum 0.500mm",
+        locations=[Location(x_mm=5.0, y_mm=5.05)],
+        required_value_mm=0.5,
+        actual_value_mm=0.2,
+    )
+
+
+def _via_b_position(pcb_path: Path) -> tuple[float, float]:
+    pcb = PCB.load(str(pcb_path))
+    via = min(pcb.vias, key=lambda v: abs(v.position[1] - 5.35))
+    return via.position
+
+
+def test_unsafe_slide_declined_with_design_rules(tmp_path: Path) -> None:
+    """With design rules, a slide that would crowd via C is declined."""
+    pcb_path = tmp_path / "crowded.kicad_pcb"
+    _crowded_board(pcb_path)
+    before = _via_b_position(pcb_path)
+
+    rules = get_profile("jlcpcb-tier1").get_design_rules()
+    repairer = DrillClearanceRepairer(pcb_path)
+    result = repairer.repair([_hole_to_hole_violation()], design_rules=rules)
+
+    assert result.repaired == 0, "the unsafe slide must NOT be applied"
+    assert result.skipped_unsafe == 1
+    # Nothing was written / moved.
+    assert _via_b_position(pcb_path) == before
+
+
+def test_legacy_slide_applied_without_design_rules(tmp_path: Path) -> None:
+    """Backward compat: with no design rules the via is still slid (unchecked)."""
+    pcb_path = tmp_path / "crowded.kicad_pcb"
+    _crowded_board(pcb_path)
+    before = _via_b_position(pcb_path)
+
+    repairer = DrillClearanceRepairer(pcb_path)
+    result = repairer.repair([_hole_to_hole_violation()])  # no design_rules
+
+    assert result.repaired == 1
+    assert result.skipped_unsafe == 0
+    repairer.save(str(pcb_path))
+    # The via moved (north, toward C) -- the legacy unchecked behaviour.
+    assert _via_b_position(pcb_path) != before
+
+
+def test_safe_slide_still_applied_with_design_rules(tmp_path: Path) -> None:
+    """A slide into open space is applied even when design rules are supplied."""
+    pcb_path = tmp_path / "open.kicad_pcb"
+    # via A + via B violate; there is NO third via to crowd, so sliding B north
+    # to clear A is clearance-safe and must be applied.
+    pcb = PCB.create(width=40.0, height=40.0, center=False)
+    pcb.add_via(5.0, 5.00, size=_SIZE, drill=_DRILL, net="A")
+    pcb.add_via(5.0, 5.35, size=_SIZE, drill=_DRILL, net="B")
+    pcb.add_trace((5.0, 5.35), (5.0, 7.0), width=0.15, layer="B.Cu", net="B")
+    pcb.save(str(pcb_path))
+    before = _via_b_position(pcb_path)
+
+    rules = get_profile("jlcpcb-tier1").get_design_rules()
+    repairer = DrillClearanceRepairer(pcb_path)
+    result = repairer.repair([_hole_to_hole_violation()], design_rules=rules)
+
+    assert result.repaired == 1
+    assert result.skipped_unsafe == 0
+    repairer.save(str(pcb_path))
+    assert _via_b_position(pcb_path) != before


### PR DESCRIPTION
## Summary

Back-ports the artifact-only #4017 hole-to-hole fix into a **library-level, `--mfr`-driven** relocation pass so *any* fine-pitch QFP/QFN board routed at a via-in-pad tier is drill-clearance clean unattended. Board-04's LQFP-48 west escape stacks OSC_OUT/NRST/GND in-pad micro-vias at the 0.5 mm pin pitch, leaving two **0.350 mm** drill pairs below the jlcpcb-tier1 **0.500 mm** hole-to-hole floor. #4017 patched this only on the committed artifact, so every fresh `generate_design.py` regen reintroduced 2 `hole_to_hole_clearance` errors and the committed board diverged from the recipe.

The fix bridges the two existing modules the curator identified: the **clearance-safe engine** (`relocate_in_pad_vias._check_clearance` + candidate ladder + stub logic) is now *driven by* hole-to-hole violations. One engine, no second copy of the geometry checks.

## Changes

- **New `src/kicad_tools/drc/relocate_drill_clearance.py`** — greedy, floor-driven pass: picks the via participating in the most violations (the middle of a stack), relocates it onto a location validated by the shared `_check_clearance` (preferring its own routed escape node — the #4017 pattern, minimal move, keeps it in-pad), re-bonds with connectivity stubs on every connected layer, and **leaves boxed-in vias in place + reports them** (safety invariant: never introduces a new violation). Not gated on `via_in_pad_supported`.
- **`repair_drill_clearance.py` made clearance-safe** — optional `design_rules` re-validates every computed slide against `_check_clearance` and **declines** a slide that would crowd a neighbour / short a foreign net (`skipped_unsafe`) — the exact gap #4017 hit (`_slide_via` moved without re-validating). `fix-drc` threads the active `--mfr` rules in. Legacy unchecked behaviour preserved when no rules are supplied.
- **`boards/04-stm32-devboard/generate_design.py`** — wires `relocate_drill_clearance_step` between `tie_power_pads` and `quantize_escapes` (after all via-adding steps, before quantize/fill), replacing the artifact-only #4017 dependency.
- **`.github/workflows/ci.yml`** — flips the board-04 fresh-regen gate from `--allow 2` to **strict-0** (recipe and committed artifact have converged).
- **Tests** — relocation-engine unit tests, the repair clearance-safety gate, and a board-04 fresh-regen regression guard (fast source-pin + `@slow` end-to-end tier1-clean assertion). Updated the partial-route fast-fail test's pipeline-step enumeration to include the new step.

## Acceptance Criteria Verification

| Criterion (from issue) | Status | Verification |
|---|---|---|
| Fresh `generate_design.py` run yields `kct check --mfr jlcpcb-tier1` = PASSED (0 errors), no artifact patching | ✅ | Fresh regen to a clean tmpdir: **0 errors**; step log shows `moved 1 via (NRST): (26.838,22.250) -> (27.338,22.250)` |
| Fix lives in the generator/router (a hole-to-hole-aware planner), not a committed artifact | ✅ | New library pass + generator wiring; committed PCB untouched |
| Regression guard asserts the regenerated board is tier1-clean | ✅ | `@slow` `test_fresh_regen_is_tier1_hole_to_hole_clean` (passed, 100s) + fast source-pin; CI gate now strict-0 |
| Boxed-in via left in place, never mis-placed | ✅ | `test_boxed_in_target_has_no_clearance_legal_location`, `test_dense_field_never_introduces_a_new_violation` |
| Active `--mfr` floor honoured (not hardcoded 0.5) | ✅ | `test_pass_reads_active_floor_not_hardcoded` (0.3 floor = no-op; 0.5 floor = relocates) |

## Test Plan

Verified on a **fresh regen** (not the committed artifact):
- `kct check --mfr jlcpcb-tier1` → **0 errors** (was 2 `hole_to_hole_clearance`)
- copper-LVS `compare_copper_netlist` → **0 shorts / 0 opens**
- `kicad-cli pcb drc --refill-zones` → **0 violations / 0 unconnected** (repo cross-gate)
- CI strict-0 gate script staged over the committed path → exit 0
- Touched-area suite: 317 passed (fast) + 13 new tests + `@slow` regen; mypy baseline gate exit 0; ruff clean.

## Deferred (out of scope, noted per curation)

- Option (a) escape-planner-by-construction (research-heavy inter-net constraint).
- Auto-wiring the pass into `kct route` so all boards get it without a per-board post-step.
- Rotated / dense `pad_absolute_bbox` over-approximation edge cases.

The escalation trigger (a via simultaneously in-pad **and** plane-stitched needing a zone re-flood) did **not** fire: the relocated via is the signal NRST via (stub-rebondable), not the plane-stitched GND via.

Closes #4408