### PR TITLE
fix(sexp): emit keepout disposition tokens as bare symbols

### DIFF
--- a/src/kicad_tools/sexp/builders.py
+++ b/src/kicad_tools/sexp/builders.py
@@ -704,7 +704,6 @@ def keepout_node(
             (connect_pads (clearance 0))
             (min_thickness 0.25)
             (keepout (tracks not_allowed) (vias not_allowed) (pads allowed) (copperpour not_allowed))
-            (fill yes)
             (polygon (pts (xy X Y) ...))
         )
     """
@@ -734,10 +733,15 @@ def keepout_node(
     )
     zone.append(keepout)
 
-    # Add minimal zone properties
+    # Add minimal zone properties.
+    #
+    # Note: a rule-area (keepout) zone must NOT carry a bare ``(fill yes)`` node.
+    # KiCad 10 writes the fill state for rule areas as ``(fill (thermal_gap ...)
+    # (thermal_bridge_width ...))`` with no ``yes`` token, and regenerates the
+    # node on save, so we omit it here entirely (Issue #4430). Emitting
+    # ``(fill yes)`` is non-canonical for rule areas.
     zone.append(SExp.list("connect_pads", SExp.list("clearance", 0)))
     zone.append(SExp.list("min_thickness", 0.25))
-    zone.append(SExp.list("fill", "yes"))
     zone.append(polygon)
 
     return zone

--- a/src/kicad_tools/sexp/parser.py
+++ b/src/kicad_tools/sexp/parser.py
@@ -710,6 +710,11 @@ class SExp:
             "x",
             "y",
             "xy",
+            # Keepout / rule-area disposition enums (Issue #4430, #4185)
+            # KiCad 10 requires these as bare symbols, e.g. (tracks allowed),
+            # (copperpour not_allowed). Quoting them is a hard parse error.
+            "allowed",
+            "not_allowed",
             # Other
             "allow_missing_courtyard",
             "allow_soldermask_bridges",

--- a/tests/test_zone_api.py
+++ b/tests/test_zone_api.py
@@ -131,10 +131,13 @@ class TestKeeoutDataclass:
 
         assert "(zone" in sexp_str
         assert "(keepout" in sexp_str
-        # S-expression uses quoted strings for keyword values
-        assert 'tracks "not_allowed"' in sexp_str or "(tracks not_allowed)" in sexp_str
-        assert 'vias "allowed"' in sexp_str or "(vias allowed)" in sexp_str
-        assert 'copperpour "not_allowed"' in sexp_str or "(copperpour not_allowed)" in sexp_str
+        # Disposition tokens MUST be bare symbols -- KiCad 10 rejects the quoted
+        # form as a hard parse error (Issue #4430).
+        assert "(tracks not_allowed)" in sexp_str
+        assert "(vias allowed)" in sexp_str
+        assert "(copperpour not_allowed)" in sexp_str
+        assert '"not_allowed"' not in sexp_str
+        assert '"allowed"' not in sexp_str
 
 
 class TestZoneNodeBuilder:
@@ -202,6 +205,9 @@ class TestKeepoutNodeBuilder:
         assert "(zone" in sexp_str
         assert "(keepout" in sexp_str
         assert '(layers "F.Cu" "B.Cu")' in sexp_str
+        # A rule-area keepout must NOT carry a bare (fill yes) node -- KiCad 10
+        # regenerates the rule-area fill on save (Issue #4430).
+        assert "(fill yes)" not in sexp_str
 
     def test_keepout_node_restrictions(self):
         """keepout_node respects restriction settings."""
@@ -215,10 +221,13 @@ class TestKeepoutNodeBuilder:
         )
         sexp_str = sexp.to_string()
 
-        # S-expression uses quoted strings for keyword values
-        assert 'tracks "not_allowed"' in sexp_str or "(tracks not_allowed)" in sexp_str
-        assert 'vias "allowed"' in sexp_str or "(vias allowed)" in sexp_str
-        assert 'copperpour "not_allowed"' in sexp_str or "(copperpour not_allowed)" in sexp_str
+        # Disposition tokens MUST be bare symbols -- KiCad 10 rejects the quoted
+        # form as a hard parse error (Issue #4430).
+        assert "(tracks not_allowed)" in sexp_str
+        assert "(vias allowed)" in sexp_str
+        assert "(copperpour not_allowed)" in sexp_str
+        assert '"not_allowed"' not in sexp_str
+        assert '"allowed"' not in sexp_str
 
 
 class TestPCBEditorZoneAPI:

--- a/tests/test_zones_hv_keepout.py
+++ b/tests/test_zones_hv_keepout.py
@@ -8,6 +8,8 @@ pure geometry (no ``kicad-cli`` needed), the shared HV-net classification with
 
 from __future__ import annotations
 
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -18,6 +20,9 @@ from kicad_tools.schema.pcb import PCB
 from kicad_tools.zones.hv_keepout import build_hv_keepout_plan
 
 pytest.importorskip("shapely")
+
+# kicad-cli is used for the end-to-end load test below; skip when absent.
+KICAD_CLI = shutil.which("kicad-cli")
 
 
 # A minimal-but-real board:
@@ -235,6 +240,72 @@ def test_cli_writes_keepout_zone(tmp_path: Path) -> None:
     pcb = PCB.load(str(board))
     keepouts = [z for z in pcb.zones if z.net_number == 0]
     assert len(keepouts) == 1
+
+
+@pytest.mark.skipif(KICAD_CLI is None, reason="kicad-cli not installed")
+def test_emitted_keepout_loads_in_kicad(tmp_path: Path) -> None:
+    """Regression (Issue #4430): the emitted keepout must load in kicad-cli.
+
+    v0.19.0 wrote quoted disposition tokens (``(tracks "allowed")``) plus a bare
+    ``(fill yes)`` node, which KiCad 10 rejects as a hard parse error ->
+    ``Failed to load board``.  This is the construction-path twin of #4185.
+
+    We inject an actual ``keepout_node()`` (the exact builder used by
+    ``kct zones hv-keepout``) into a real, loadable demo board and assert
+    ``kicad-cli pcb drc`` still loads it.  The minimal in-module ``_BOARD``
+    fixtures are intentionally partial and do not load in kicad-cli on their
+    own, so a full real board is required for a meaningful load test (mirrors
+    ``tests/test_sexp_roundtrip.py::test_keepout_board_loads_in_kicad``).
+    """
+    from kicad_tools.sexp.builders import keepout_node
+    from kicad_tools.sexp.parser import parse_file
+
+    demo = (
+        Path(__file__).parent.parent
+        / "boards"
+        / "00-simple-led"
+        / "output"
+        / "simple_led.kicad_pcb"
+    )
+    if not demo.exists():
+        pytest.skip(f"Demo board not found: {demo}")
+
+    doc = parse_file(demo)
+    keepout = keepout_node(
+        points=[(50, 50), (70, 50), (70, 70), (50, 70)],
+        layers=["F.Cu", "B.Cu"],
+        no_tracks=False,
+        no_vias=False,
+        no_pour=True,
+        uuid_str="hv-keepout-4430-test",
+    )
+    doc.children.append(keepout)
+
+    output = doc.to_string()
+    # Disposition tokens must be BARE, and no bare (fill yes) on a rule area.
+    assert '"not_allowed"' not in output
+    assert '"allowed"' not in output
+    assert "(copperpour not_allowed)" in output
+    assert "(fill yes)" not in output
+
+    out_path = tmp_path / "keepout_board.kicad_pcb"
+    out_path.write_text(output)
+
+    # kicad-cli returns 0 on a clean load (or if DRC violations are found); a
+    # load failure prints "Failed to load board" and returns non-zero.
+    result = subprocess.run(
+        [KICAD_CLI, "pcb", "drc", str(out_path), "-o", str(tmp_path / "drc.json")],
+        capture_output=True,
+        text=True,
+    )
+    assert "Failed to load board" not in result.stderr, (
+        f"kicad-cli failed to load a board carrying the emitted keepout.\n"
+        f"rc={result.returncode}\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert result.returncode == 0, (
+        f"kicad-cli pcb drc returned {result.returncode} on the keepout board.\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
 
 
 def test_cli_dry_run_writes_nothing(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

`kct zones hv-keepout` (shipped v0.19.0, PR #4382) wrote copperpour-keepout
zones whose disposition tokens serialized as **quoted strings**
(`(tracks "allowed")`, `(copperpour "not_allowed")`). KiCad 10 / kicad-cli
10.0.4 rejects the quoted form as a **hard parse error** — `Failed to load
board` (rc=3) — so the written board is unloadable and `--refill` cannot run.

This is the construction-path twin of #4185. That fix kept KiCad-*parsed*
keepouts bare (via `_originally_bare`), but `keepout_node()` *constructs* fresh
atoms (`_originally_bare=False`), which the serializer quoted because
`allowed`/`not_allowed` were absent from `_needs_quoting()`'s allowlist.

The curator empirically verified against kicad-cli 10.0.4 that the **quoted
tokens are the sole load-breaker** (`(fill yes)` is tolerated on load but
non-canonical for rule areas).

## Changes

- **`src/kicad_tools/sexp/parser.py`** (primary, load-blocking): add `"allowed"`
  and `"not_allowed"` to the `unquoted_keywords` allowlist in `_needs_quoting()`,
  so every freshly-constructed keepout atom serializes **bare** (same mechanism
  as #4393's chamfer symbols).
- **`src/kicad_tools/sexp/builders.py`** (canonical): drop the non-canonical bare
  `(fill yes)` node from `keepout_node()` — KiCad regenerates the rule-area fill
  on save; docstring example updated.
- **`tests/test_zone_api.py`**: tighten the two permissive
  quoted-*or*-bare assertions (lines 135-137, 219-221) to **bare-only** — the
  permissive `or` form is what let the regression ship. Also assert no
  `(fill yes)`.
- **`tests/test_zones_hv_keepout.py`**: add a kicad-cli-gated load test that
  injects an emitted `keepout_node()` into a real demo board and asserts
  `kicad-cli pcb drc` does **not** emit `Failed to load board` (rc=0).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Disposition tokens emit as bare symbols | ✅ | Output contains `(tracks allowed)` / `(copperpour not_allowed)`; no `"allowed"`/`"not_allowed"` |
| `(fill yes)` removed from keepout zone | ✅ | `keepout_node()` no longer appends the fill node; `assert "(fill yes)" not in sexp_str` |
| Permissive test assertions tightened to bare-only | ✅ | `test_zone_api.py` now requires bare form and rejects the quoted form |
| kicad-cli load test added | ✅ | `test_emitted_keepout_loads_in_kicad` runs `kicad-cli pcb drc`, asserts no `Failed to load board`, rc==0 |
| Emitted keepout loads in kicad-cli 10.0.4 | ✅ | New test PASSES locally against kicad-cli 10.0.4 (was rc=3 before) |
| No regression to #4185 round-trip | ✅ | `test_keepout_footprint_roundtrips_bare` + `test_keepout_board_loads_in_kicad` still pass |

## Test Plan

- `uv run pytest tests/test_zone_api.py tests/test_zones_hv_keepout.py tests/test_sexp_roundtrip.py` — 44 passed, kicad-cli load test PASSES (not skipped; kicad-cli 10.0.4 present locally).
- Broader `-k "sexp or keepout or zone"` — 1384 passed, 29 skipped.
- `ruff check` / `ruff format --check` — clean.
- mypy baseline gate (`scripts/ci/check_mypy_baseline.py`) — passes; no new type errors (line-shift is baseline-agnostic).

Closes #4430