### PR TITLE
feat(pcb): preserve name-only net-reference dialect on added copper

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -59,6 +59,7 @@ import logging
 import math
 import os
 import random
+import re
 import shutil
 import signal
 import sys
@@ -723,6 +724,27 @@ def _strip_route_blocks(pcb_content: str) -> tuple[str, int, int]:
     return "".join(out), segments_removed, vias_removed
 
 
+# Issue #4416: a KiCad-10 name-only inline net reference is ``(net "SDA")`` --
+# a ``(net`` token immediately followed by a quoted string.  Numeric boards
+# write ``(net 12)`` / ``(net 12 "SDA")`` inline and ``(net 12 "SDA")`` in the
+# header table (a digit always follows ``(net``), so the quoted-first form
+# appears only on name-based boards.  This lets us detect the input dialect
+# and re-emit route-added copper in the same dialect (see _finalize_routes).
+_NAME_ONLY_NET_RE = re.compile(r'\(net\s+"')
+
+
+def _board_uses_name_only_dialect(pcb_path: "Path | str") -> bool:
+    """Return True when *pcb_path* uses KiCad-10 name-only net refs (#4416).
+
+    Returns False on any read error (falls back to today's numeric emission).
+    """
+    try:
+        content = Path(pcb_path).read_text()
+    except OSError:
+        return False
+    return bool(_NAME_ONLY_NET_RE.search(content))
+
+
 def _insert_sexp_before_closing(pcb_content: str, sexp_fragments: str) -> str:
     """Insert S-expression fragments before the final closing parenthesis of a PCB file.
 
@@ -1105,6 +1127,10 @@ def _make_checkpoint_callback(
     if interval <= 0:
         return None
 
+    # Issue #4416: detect the source dialect once so every checkpoint write
+    # re-emits route copper in the board's own net-reference dialect.
+    name_only = _board_uses_name_only_dialect(pcb_path)
+
     # Mutable container so the closure can write back the timestamp.
     # ``[None]`` sentinel means "no checkpoint written yet"; the first
     # improvement event triggers an immediate write.
@@ -1120,7 +1146,7 @@ def _make_checkpoint_callback(
         # Materialize sexp from the snapshot (NOT self.routes).  Each
         # Route has its own to_sexp() so we can serialize directly without
         # touching the router's live state.
-        route_sexp = "\n\t".join(r.to_sexp() for r in best_routes)
+        route_sexp = "\n\t".join(r.to_sexp(name_only=name_only) for r in best_routes)
         # Issue #3155: carry preserved existing copper through every
         # checkpoint so the strip-then-rewrite (#2976) inside
         # _write_routed_pcb does not erase it from the staged input.
@@ -1184,19 +1210,25 @@ def _capture_preserved_routes(pcb_path: Path) -> list["Route"]:
 def _serialize_preserved_routes(
     preserved_routes: list["Route"],
     exclude_net_ids: set[int] | None = None,
+    *,
+    name_only: bool = False,
 ) -> str:
     """Serialize preserved routes, skipping any net in ``exclude_net_ids``.
 
     The exclusion set is the freshly-routed net ids: a net that was both
     pre-existing *and* re-routed must be emitted from the routed copy only,
     never twice (#3155 defensive dedupe).
+
+    Issue #4416: ``name_only`` re-emits preserved copper in the board's
+    ``(net "name")`` dialect so an incremental route pass does not flip the
+    preserved geometry to numeric.
     """
     exclude = exclude_net_ids or set()
     parts: list[str] = []
     for route in preserved_routes:
         if route.net in exclude:
             continue
-        sexp = route.to_sexp()
+        sexp = route.to_sexp(name_only=name_only)
         if sexp:
             parts.append(sexp)
     return "\n\t".join(parts)
@@ -1259,6 +1291,7 @@ def _finalize_routes(
     aggregate_segment_drop_threshold: float = 0.5,
     preserve_existing: bool = False,
     preserved_routes: list["Route"] | None = None,
+    pcb_path: "Path | str | None" = None,
 ) -> tuple[str, dict, dict]:
     """Run cleanup, compute statistics, and generate S-expressions.
 
@@ -1405,8 +1438,13 @@ def _finalize_routes(
             if not quiet:
                 flush_print(f"  {warning_msg}")
 
-    # Step 2: Generate S-expressions from the cleaned routes
-    route_sexp = router.to_sexp(skip_cleanup=True)
+    # Step 2: Generate S-expressions from the cleaned routes.
+    # Issue #4416: when the source board uses KiCad-10 name-only net refs,
+    # emit route-added copper in the same ``(net "name")`` dialect so the
+    # written file does not flip to numeric and ping-pong with kicad-cli's
+    # --save-board rewrite.  Defaults to numeric when pcb_path is unavailable.
+    name_only = _board_uses_name_only_dialect(pcb_path) if pcb_path is not None else False
+    route_sexp = router.to_sexp(skip_cleanup=True, name_only=name_only)
 
     # Issue #3155: re-emit preserved copper.  The preserved routes were
     # captured once from the freshly-staged input (``preserved_routes``),
@@ -1436,7 +1474,7 @@ def _finalize_routes(
             if stub_net_ids:
                 routed_net_ids = routed_net_ids - stub_net_ids
             preserved_sexp = _serialize_preserved_routes(
-                source_routes, exclude_net_ids=routed_net_ids
+                source_routes, exclude_net_ids=routed_net_ids, name_only=name_only
             )
             if preserved_sexp:
                 emitted = [r for r in source_routes if r.net not in routed_net_ids]
@@ -1531,8 +1569,11 @@ def _save_partial_results() -> bool:
         # Read original PCB content
         original_content = pcb_path.read_text()
 
-        # Get partial route S-expressions
-        route_sexp = router.to_sexp()
+        # Get partial route S-expressions.  Issue #4416: match the input
+        # dialect so the interrupted save does not flip name-based copper to
+        # numeric.  Detect from the content already in hand (avoid re-reading).
+        name_only = bool(_NAME_ONLY_NET_RE.search(original_content))
+        route_sexp = router.to_sexp(name_only=name_only)
 
         if route_sexp:
             # When the interrupt state holds a best *completed* attempt from
@@ -4878,6 +4919,7 @@ def route_with_layer_escalation(
         verbose=bool(getattr(args, "verbose", False)),
         preserve_existing=bool(getattr(args, "preserve_existing", False)),
         preserved_routes=_preserved_routes,
+        pcb_path=pcb_path,
     )
     # Update result with post-cleanup stats
     final_result.nets_routed = final_stats["nets_routed"]
@@ -5572,6 +5614,7 @@ def route_with_rule_relaxation(
         verbose=bool(getattr(args, "verbose", False)),
         preserve_existing=bool(getattr(args, "preserve_existing", False)),
         preserved_routes=_preserved_routes,
+        pcb_path=pcb_path,
     )
     # Update result with post-cleanup stats
     final_result.nets_routed = final_stats["nets_routed"]
@@ -7782,6 +7825,7 @@ def route_with_combined_escalation(
         verbose=bool(getattr(args, "verbose", False)),
         preserve_existing=bool(getattr(args, "preserve_existing", False)),
         preserved_routes=_preserved_routes,
+        pcb_path=pcb_path,
     )
     # Update result with post-cleanup stats
     final_result.nets_routed = final_stats["nets_routed"]
@@ -12071,6 +12115,7 @@ def main(argv: list[str] | None = None) -> int:
         verbose=bool(getattr(args, "verbose", False)),
         preserve_existing=bool(getattr(args, "preserve_existing", False)),
         preserved_routes=_preserved_routes,
+        pcb_path=pcb_path,
     )
 
     # Issue #4292: the committed copper is now serialised into ``route_sexp``;

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -14261,16 +14261,20 @@ class Autorouter:
         self._cleanup_stats = stats
         return stats
 
-    def to_sexp(self, *, skip_cleanup: bool = False) -> str:
+    def to_sexp(self, *, skip_cleanup: bool = False, name_only: bool = False) -> str:
         """Generate KiCad S-expressions for all routes.
 
         Automatically runs ``cleanup_artifacts()`` before emitting to
         remove net-0 orphans and out-of-bounds segments, unless
         *skip_cleanup* is True.
+
+        Issue #4416: ``name_only`` is threaded to every route so copper
+        appended to a KiCad-10 name-based board keeps its ``(net "name")``
+        dialect instead of flipping to numeric ``(net N)``.
         """
         if not skip_cleanup:
             self.cleanup_artifacts()
-        return "\n\t".join(route.to_sexp() for route in self.routes)
+        return "\n\t".join(route.to_sexp(name_only=name_only) for route in self.routes)
 
     def get_statistics(self, nets_to_route_ids: set[int] | None = None) -> dict:
         """Get routing statistics including congestion metrics.

--- a/src/kicad_tools/router/primitives.py
+++ b/src/kicad_tools/router/primitives.py
@@ -239,16 +239,22 @@ class Via:
     # producer of micro vias from inside the routing pipeline.
     is_micro: bool = False
 
-    def to_sexp(self) -> str:
+    def to_sexp(self, name_only: bool = False) -> str:
         """Generate KiCad S-expression.
 
         Emits ``(via micro ...)`` when :attr:`is_micro` is True so the
         micro-via token survives the route -> finalize -> file
         round-trip (issue #3124).  Otherwise emits a plain ``(via ...)``.
+
+        Issue #4416: when ``name_only`` is True and :attr:`net_name` is
+        known, the net reference is emitted as ``(net "name")`` to match a
+        KiCad-10 name-based board's dialect; otherwise the numeric
+        ``(net N)`` form is used (preserving behavior for numeric boards).
         """
         layer_start = self.layers[0].kicad_name
         layer_end = self.layers[1].kicad_name
         type_token = " micro" if self.is_micro else ""
+        net_ref = f'"{self.net_name}"' if name_only and self.net_name else str(self.net)
         # Issue #3925: field order matches KiCad's canonical writer
         # (uuid BEFORE net).  Emitting net before uuid caused every via to
         # churn on the first KiCad open/save round-trip, producing a diff
@@ -259,7 +265,7 @@ class Via:
 \t\t(drill {_fmt(self.drill)})
 \t\t(layers "{layer_start}" "{layer_end}")
 \t\t(uuid "{_make_uuid()}")
-\t\t(net {self.net})
+\t\t(net {net_ref})
 \t)"""
 
 
@@ -286,8 +292,13 @@ class Segment:
         """Return the end point as a tuple (x2, y2)."""
         return (self.x2, self.y2)
 
-    def to_sexp(self) -> str:
+    def to_sexp(self, name_only: bool = False) -> str:
         """Generate KiCad S-expression.
+
+        Issue #4416: when ``name_only`` is True and :attr:`net_name` is
+        known, the net reference is emitted as ``(net "name")`` to match a
+        KiCad-10 name-based board's dialect; otherwise the numeric
+        ``(net N)`` form is used.
 
         Issue #3925: field order matches KiCad's canonical writer (uuid
         BEFORE net).  Emitting net before uuid caused every segment to
@@ -324,13 +335,14 @@ class Segment:
                 self.y2,
                 context=f"net {self.net} on {self.layer.kicad_name}",
             )
+        net_ref = f'"{self.net_name}"' if name_only and self.net_name else str(self.net)
         return f"""(segment
 \t\t(start {self.x1:.4f} {self.y1:.4f})
 \t\t(end {self.x2:.4f} {self.y2:.4f})
 \t\t(width {_fmt(self.width)})
 \t\t(layer "{self.layer.kicad_name}")
 \t\t(uuid "{_make_uuid()}")
-\t\t(net {self.net})
+\t\t(net {net_ref})
 \t)"""
 
 
@@ -351,13 +363,18 @@ class Route:
     # re-enabled under the C++ backend).
     is_escape: bool = False
 
-    def to_sexp(self) -> str:
-        """Generate all S-expressions for this route."""
+    def to_sexp(self, name_only: bool = False) -> str:
+        """Generate all S-expressions for this route.
+
+        Issue #4416: ``name_only`` is threaded to every segment/via emitter
+        so a route appended to a KiCad-10 name-based board keeps that
+        board's ``(net "name")`` dialect.
+        """
         parts = []
         for seg in self.segments:
-            parts.append(seg.to_sexp())
+            parts.append(seg.to_sexp(name_only=name_only))
         for via in self.vias:
-            parts.append(via.to_sexp())
+            parts.append(via.to_sexp(name_only=name_only))
         return "\n\t".join(parts)
 
     def copy_geometry(self) -> "Route":

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -998,6 +998,14 @@ class Segment:
     net_number: int
     net_name: str = ""
     uuid: str = ""
+    # Issue #4416: parsed-dialect memory.  ``True`` when this segment's net
+    # reference was read in KiCad-10 name-only form ``(net "SDA")`` (no
+    # numeric id).  Serialization re-emits the same dialect so a name-based
+    # board stays name-based on save instead of flipping to ``(net 12)`` and
+    # ping-ponging with kicad-cli's ``--save-board`` name-only rewrite.
+    # Mirrors the parser's ``_originally_bare`` round-trip flag at the element
+    # level.  ``compare=False`` keeps dataclass equality identity-stable.
+    net_name_only: bool = field(default=False, compare=False)
 
     @classmethod
     def from_sexp(cls, sexp: SExp) -> Segment:
@@ -1030,22 +1038,48 @@ class Segment:
                 # KiCad 10 name-only format: (net "name")
                 seg.net_number = 0
                 seg.net_name = net.get_string(0) or ""
+                seg.net_name_only = True
         if uuid := sexp.find("uuid"):
             seg.uuid = uuid.get_string(0) or ""
 
         return seg
 
-    def to_sexp(self) -> SExp:
-        """Convert segment to S-expression for serialization."""
+    def _net_sexp(self) -> SExp:
+        """Build the ``(net ...)`` child in the segment's parsed dialect.
+
+        Issue #4416: emit ``(net "name")`` when the segment was read (or
+        constructed) in KiCad-10 name-only dialect and a net name is known;
+        otherwise fall back to the numeric ``(net N)`` form.  The empty-name
+        fallback keeps numeric boards and programmatic construction unchanged
+        and avoids emitting an invalid ``(net "")``.
+        """
+        if self.net_name_only and self.net_name:
+            return SExp.list("net", SExp.quoted_atom(self.net_name))
+        return SExp.list("net", self.net_number)
+
+    def to_sexp(self, offset: tuple[float, float] = (0.0, 0.0)) -> SExp:
+        """Convert segment to S-expression for serialization.
+
+        Issue #3925/#3907 parity: field order matches KiCad's canonical
+        writer (``uuid`` BEFORE ``net``), aligning the schema emitter with
+        ``router/primitives.py`` so a node flowing through either path does
+        not churn field order on the first KiCad open/save round-trip.
+
+        Issue #4416: ``offset`` adds a board-origin shift to the stored
+        coordinates (board-relative -> sheet-absolute) without mutating the
+        Python object, so ``add_trace`` can serialize through this single
+        dialect-aware path instead of hand-rolling a numeric ``(net ...)``.
+        """
+        ox, oy = offset
         seg_sexp = SExp.list("segment")
-        seg_sexp.append(SExp.list("start", self.start[0], self.start[1]))
-        seg_sexp.append(SExp.list("end", self.end[0], self.end[1]))
+        seg_sexp.append(SExp.list("start", self.start[0] + ox, self.start[1] + oy))
+        seg_sexp.append(SExp.list("end", self.end[0] + ox, self.end[1] + oy))
         seg_sexp.append(SExp.list("width", self.width))
         seg_sexp.append(SExp.list("layer", self.layer))
-        seg_sexp.append(SExp.list("net", self.net_number))
         if not self.uuid:
             self.uuid = str(uuid.uuid4())
         seg_sexp.append(SExp.list("uuid", self.uuid))
+        seg_sexp.append(self._net_sexp())
         return seg_sexp
 
 
@@ -1067,6 +1101,10 @@ class Via:
     # ``None`` => standard through-hole via.  The serializer mirrors
     # :func:`kicad_tools.sexp.builders.via_node` exactly.
     via_type: str | None = None
+    # Issue #4416: parsed-dialect memory (see :class:`Segment.net_name_only`).
+    # ``True`` when the via's net reference was read in name-only
+    # ``(net "SDA")`` form so serialization re-emits the same dialect.
+    net_name_only: bool = field(default=False, compare=False)
 
     @classmethod
     def from_sexp(cls, sexp: SExp) -> Via:
@@ -1116,32 +1154,51 @@ class Via:
                 # KiCad 10 name-only format: (net "name")
                 via.net_number = 0
                 via.net_name = net.get_string(0) or ""
+                via.net_name_only = True
         if uuid := sexp.find("uuid"):
             via.uuid = uuid.get_string(0) or ""
 
         return via
 
-    def to_sexp(self) -> SExp:
+    def _net_sexp(self) -> SExp:
+        """Build the ``(net ...)`` child in the via's parsed dialect (#4416).
+
+        See :meth:`Segment._net_sexp` -- emit ``(net "name")`` for name-only
+        boards with a known name, numeric ``(net N)`` otherwise.
+        """
+        if self.net_name_only and self.net_name:
+            return SExp.list("net", SExp.quoted_atom(self.net_name))
+        return SExp.list("net", self.net_number)
+
+    def to_sexp(self, offset: tuple[float, float] = (0.0, 0.0)) -> SExp:
         """Convert via to S-expression for serialization.
 
         When :attr:`via_type` is set (``"micro"`` / ``"blind"`` /
         ``"buried"``) the token is emitted immediately after ``via`` to
         match KiCad's format and survive a load + save round-trip
         (issue #3124).
+
+        Issue #3925/#3907 parity: ``uuid`` is emitted BEFORE ``net`` to
+        match KiCad's canonical writer and ``router/primitives.py``.
+
+        Issue #4416: ``offset`` adds a board-origin shift (board-relative ->
+        sheet-absolute) without mutating the Python object, and the net
+        reference is emitted in the via's parsed dialect.
         """
+        ox, oy = offset
         via_sexp = SExp.list("via")
         if self.via_type:
             via_sexp.append(SExp.atom(self.via_type))
-        via_sexp.append(SExp.list("at", self.position[0], self.position[1]))
+        via_sexp.append(SExp.list("at", self.position[0] + ox, self.position[1] + oy))
         via_sexp.append(SExp.list("size", self.size))
         via_sexp.append(SExp.list("drill", self.drill))
         # Build layers list
         layers_sexp = SExp.list("layers", *self.layers)
         via_sexp.append(layers_sexp)
-        via_sexp.append(SExp.list("net", self.net_number))
         if not self.uuid:
             self.uuid = str(uuid.uuid4())
         via_sexp.append(SExp.list("uuid", self.uuid))
+        via_sexp.append(self._net_sexp())
         return via_sexp
 
 
@@ -1506,6 +1563,13 @@ class PCB:
         self._setup: Setup | None = None
         self._title_block: dict[str, str] = {}
         self._board_origin: tuple[float, float] = (0.0, 0.0)
+        # Issue #4416: board-level net-reference dialect signal.  Set by
+        # _fixup_net_numbers() when the loaded board uses KiCad-10 name-only
+        # ``(net "SDA")`` inline references (or had its header net table
+        # stripped by kicad-cli --save-board).  Newly added copper
+        # (add_trace/add_via) emits name-based refs when this is True so a
+        # name-based board stays name-based on save.
+        self._net_name_only_dialect: bool = False
         self._parse()
         self._detect_board_origin()
         self._link_footprint_sexp_nodes()
@@ -1939,6 +2003,25 @@ class PCB:
            recovery loop, otherwise ``self._nets`` stays empty and every
            element silently collapses to ``net_number=0``.
         """
+        # Issue #4416: detect the board-level net-reference dialect BEFORE the
+        # recovery loop rewrites name-only elements' net_number.  The board is
+        # treated as name-only when any parsed segment/via was read in
+        # ``(net "name")`` form, or when any pad carries a name but no number
+        # (the pad-level name-only signal).  The kicad-cli --save-board case
+        # (stripped header table) is covered by these same element-level flags
+        # -- its inline copper/pad refs are all name-only.  We deliberately do
+        # NOT treat an empty ``self._nets`` alone as name-only, so a freshly
+        # constructed board with no header table keeps numeric emission.
+        self._net_name_only_dialect = (
+            any(seg.net_name_only for seg in self._segments)
+            or any(via.net_name_only for via in self._vias)
+            or any(
+                pad.net_number == 0 and bool(pad.net_name)
+                for fp in self._footprints
+                for pad in fp.pads
+            )
+        )
+
         # KiCad 10 --save-board: no header table survived. Synthesize one from
         # the inline name-only references so the recovery loop below has a map.
         if not self._nets:
@@ -4741,22 +4824,19 @@ class PCB:
                 width=width,
                 layer=layer,
                 net_number=net_number,
+                net_name=net or "",
+                # Issue #4416: match the board's net-reference dialect so
+                # copper added to a name-based board stays name-based on save.
+                net_name_only=self._net_name_only_dialect and bool(net),
                 uuid=str(uuid.uuid4()),
             )
             segments.append(seg)
             self._segments.append(seg)
-            if ox != 0.0 or oy != 0.0:
-                # Build sheet-absolute sexp without mutating the Python object.
-                seg_sexp = SExp.list("segment")
-                seg_sexp.append(SExp.list("start", seg.start[0] + ox, seg.start[1] + oy))
-                seg_sexp.append(SExp.list("end", seg.end[0] + ox, seg.end[1] + oy))
-                seg_sexp.append(SExp.list("width", seg.width))
-                seg_sexp.append(SExp.list("layer", seg.layer))
-                seg_sexp.append(SExp.list("net", seg.net_number))
-                seg_sexp.append(SExp.list("uuid", seg.uuid))
-                self._sexp.append(seg_sexp)
-            else:
-                self._sexp.append(seg.to_sexp())
+            # Serialize through the dialect-aware emitter; the board-origin
+            # offset converts board-relative coords to sheet-absolute without
+            # mutating the Python object (issue #4416 folds the former hand-
+            # rolled numeric branch into Segment.to_sexp).
+            self._sexp.append(seg.to_sexp(offset=(ox, oy)))
 
         return segments
 
@@ -4815,24 +4895,19 @@ class PCB:
             drill=drill,
             layers=list(layers),
             net_number=net_number,
+            net_name=net or "",
+            # Issue #4416: match the board's net-reference dialect (see add_trace).
+            net_name_only=self._net_name_only_dialect and bool(net),
             uuid=str(uuid.uuid4()),
         )
         self._vias.append(via)
 
         # Input position is board-relative (matches Footprint.position and
         # add_trace inputs); the S-expression form requires sheet-absolute.
+        # Serialize through the dialect-aware emitter with the board-origin
+        # offset (issue #4416 folds the former hand-rolled numeric branch in).
         ox, oy = self._board_origin
-        if ox != 0.0 or oy != 0.0:
-            via_sexp = SExp.list("via")
-            via_sexp.append(SExp.list("at", via.position[0] + ox, via.position[1] + oy))
-            via_sexp.append(SExp.list("size", via.size))
-            via_sexp.append(SExp.list("drill", via.drill))
-            via_sexp.append(SExp.list("layers", *via.layers))
-            via_sexp.append(SExp.list("net", via.net_number))
-            via_sexp.append(SExp.list("uuid", via.uuid))
-            self._sexp.append(via_sexp)
-        else:
-            self._sexp.append(via.to_sexp())
+        self._sexp.append(via.to_sexp(offset=(ox, oy)))
 
         return via
 

--- a/src/kicad_tools/sexp/builders.py
+++ b/src/kicad_tools/sexp/builders.py
@@ -331,6 +331,19 @@ def sheet_instances(sheet_path: str, page: str) -> SExp:
 # =============================================================================
 
 
+def _net_node(net: int, net_name: str | None) -> SExp:
+    """Build a ``(net ...)`` child in the requested dialect (issue #4416).
+
+    When *net_name* is a non-empty string the reference is emitted in
+    KiCad-10 name-only form ``(net "name")``; otherwise the numeric
+    ``(net <int>)`` form is used.  ``None``/empty *net_name* preserves the
+    historical numeric behavior for every existing caller.
+    """
+    if net_name:
+        return SExp.list("net", SExp.quoted_atom(net_name))
+    return SExp.list("net", net)
+
+
 def segment_node(
     start_x: float,
     start_y: float,
@@ -340,6 +353,7 @@ def segment_node(
     layer: str,
     net: int,
     uuid_str: str,
+    net_name: str | None = None,
 ) -> SExp:
     """Build a PCB track segment S-expression.
 
@@ -350,6 +364,10 @@ def segment_node(
         layer: Copper layer (e.g., "F.Cu", "B.Cu")
         net: Net number
         uuid_str: Unique identifier
+        net_name: Optional net name (issue #4416).  When supplied (and
+            non-empty) the net reference is emitted in KiCad-10 name-only
+            ``(net "name")`` dialect so copper appended to a name-based
+            board stays name-based.  Defaults to ``None`` (numeric).
 
     Example output:
         (segment
@@ -367,7 +385,7 @@ def segment_node(
         SExp.list("end", fmt(end_x), fmt(end_y)),
         SExp.list("width", fmt(width)),
         SExp.list("layer", layer),
-        SExp.list("net", net),
+        _net_node(net, net_name),
         uuid_node(uuid_str),
     )
 
@@ -381,6 +399,7 @@ def via_node(
     net: int,
     uuid_str: str,
     via_type: str | None = None,
+    net_name: str | None = None,
 ) -> SExp:
     """Build a PCB via S-expression.
 
@@ -394,6 +413,9 @@ def via_node(
         via_type: Optional via type. Use ``"micro"`` for micro-vias
             (KiCad emits ``(via micro ...)``). When *None* (the default),
             a standard through-hole via is produced.
+        net_name: Optional net name (issue #4416).  When supplied (and
+            non-empty) the net reference is emitted in name-only
+            ``(net "name")`` dialect.  Defaults to ``None`` (numeric).
 
     Example output (standard):
         (via
@@ -416,6 +438,7 @@ def via_node(
         )
     """
     layers_node = SExp.list("layers", *layers)
+    net_node = _net_node(net, net_name)
     if via_type == "micro":
         return SExp.list(
             "via",
@@ -424,7 +447,7 @@ def via_node(
             SExp.list("size", fmt(size)),
             SExp.list("drill", fmt(drill)),
             layers_node,
-            SExp.list("net", net),
+            net_node,
             uuid_node(uuid_str),
         )
     return SExp.list(
@@ -433,7 +456,7 @@ def via_node(
         SExp.list("size", fmt(size)),
         SExp.list("drill", fmt(drill)),
         layers_node,
-        SExp.list("net", net),
+        net_node,
         uuid_node(uuid_str),
     )
 

--- a/tests/test_pcb.py
+++ b/tests/test_pcb.py
@@ -1,5 +1,6 @@
 """Tests for PCB parsing and editing."""
 
+import re
 from pathlib import Path
 
 import pytest
@@ -3879,6 +3880,173 @@ class TestKiCad10NetNumberRecovery:
         assert pad1.net_name == "GND"
         assert pad2.net_number == 2
         assert pad2.net_name == "+3.3V"
+
+
+class TestNetDialectPreservation:
+    """Issue #4416: preserve the input board's net-reference dialect on save.
+
+    A KiCad-10 name-only board uses inline ``(net "SDA")`` references (no
+    numeric id).  Copper added by ``add_trace`` / ``add_via`` must re-emit
+    that same dialect so the file does not flip to numeric ``(net 12)`` and
+    ping-pong with kicad-cli's ``--save-board`` name-only rewrite.  Numeric
+    boards must stay numeric (no regression).
+    """
+
+    @staticmethod
+    def _child_names(sexp) -> list[str]:
+        return [c.name for c in sexp.children if c.name is not None]
+
+    def test_added_trace_stays_name_based_on_name_only_board(self, tmp_path):
+        """add_trace on a name-only board emits (net "GND"), not (net 1)."""
+        pcb_path = tmp_path / "kicad10.kicad_pcb"
+        pcb_path.write_text(KICAD10_NAMEONLY_PCB)
+        pcb = PCB.load(pcb_path)
+
+        # Board dialect is detected as name-only (seg-1 uses (net "GND")).
+        assert pcb._net_name_only_dialect is True
+
+        added = pcb.add_trace((99.0, 101.0), (101.0, 101.0), net="GND")
+        assert len(added) == 1
+        assert added[0].net_name_only is True
+        assert added[0].net_name == "GND"
+
+        out_path = tmp_path / "out.kicad_pcb"
+        pcb.save(out_path)
+        text = out_path.read_text()
+
+        # Both the original and the newly added segment are name-based.
+        # Every top-level (segment ...) net ref must be quoted, none numeric.
+        seg_net_refs = re.findall(r"\(segment.*?(\(net[^)]*\))", text, re.DOTALL)
+        assert len(seg_net_refs) == 2
+        for ref in seg_net_refs:
+            assert ref == '(net "GND")', ref
+
+        # Reloading round-trips the dialect (name-only preserved).
+        reloaded = PCB.load(out_path)
+        assert all(s.net_name_only for s in reloaded.segments)
+
+    def test_added_via_stays_name_based_on_name_only_board(self, tmp_path):
+        """add_via on a name-only board emits (net "VCC"), not (net 2)."""
+        pcb_path = tmp_path / "kicad10.kicad_pcb"
+        pcb_path.write_text(KICAD10_NAMEONLY_PCB)
+        pcb = PCB.load(pcb_path)
+
+        via = pcb.add_via(100.0, 100.0, net="VCC")
+        assert via is not None
+        assert via.net_name_only is True
+
+        out_path = tmp_path / "out.kicad_pcb"
+        pcb.save(out_path)
+        text = out_path.read_text()
+
+        via_net_refs = re.findall(r"\(via\b.*?(\(net[^)]*\))", text, re.DOTALL)
+        assert len(via_net_refs) == 1
+        assert via_net_refs[0] == '(net "VCC")'
+
+    def test_numeric_board_stays_numeric(self, minimal_pcb, tmp_path):
+        """add_trace on a traditional (net N "name") board stays numeric."""
+        pcb = PCB.load(minimal_pcb)
+        assert pcb._net_name_only_dialect is False
+
+        added = pcb.add_trace((10.0, 10.0), (20.0, 10.0), net="GND")
+        assert len(added) == 1
+        assert added[0].net_name_only is False
+
+        out_path = tmp_path / "out.kicad_pcb"
+        pcb.save(out_path)
+        text = out_path.read_text()
+
+        # No inline name-only segment refs appear on a numeric board.
+        seg_net_refs = re.findall(r"\(segment.*?(\(net[^)]*\))", text, re.DOTALL)
+        assert seg_net_refs, "expected at least one segment"
+        for ref in seg_net_refs:
+            assert re.match(r"\(net \d", ref), ref
+
+    def test_schema_segment_field_order_uuid_before_net(self):
+        """Segment.to_sexp emits uuid BEFORE net (KiCad canonical, #3925)."""
+        from kicad_tools.schema.pcb import Segment
+
+        seg = Segment(
+            start=(0.0, 0.0),
+            end=(1.0, 0.0),
+            width=0.25,
+            layer="F.Cu",
+            net_number=3,
+            net_name="SDA",
+            uuid="seg-uuid",
+        )
+        names = self._child_names(seg.to_sexp())
+        assert names.index("uuid") < names.index("net")
+
+    def test_schema_via_field_order_uuid_before_net(self):
+        """Via.to_sexp emits uuid BEFORE net (KiCad canonical, #3925)."""
+        from kicad_tools.schema.pcb import Via
+
+        via = Via(
+            position=(0.0, 0.0),
+            size=0.6,
+            drill=0.3,
+            layers=["F.Cu", "B.Cu"],
+            net_number=3,
+            net_name="SDA",
+            uuid="via-uuid",
+        )
+        names = self._child_names(via.to_sexp())
+        assert names.index("uuid") < names.index("net")
+
+    def test_name_only_segment_with_empty_name_falls_back_to_numeric(self):
+        """A name-only segment with a known number but empty name is safe.
+
+        Serializes to a valid ``(net N)`` -- never an invalid ``(net "")``.
+        """
+        from kicad_tools.schema.pcb import Segment
+
+        seg = Segment(
+            start=(0.0, 0.0),
+            end=(1.0, 0.0),
+            width=0.25,
+            layer="F.Cu",
+            net_number=7,
+            net_name="",
+            net_name_only=True,
+            uuid="seg-uuid",
+        )
+        net_child = seg.to_sexp().find("net")
+        assert net_child is not None
+        assert net_child.get_int(0) == 7
+        assert '(net "")' not in seg.to_sexp().to_string()
+
+    def test_router_primitive_segment_name_only_emission(self):
+        """router.primitives.Segment.to_sexp(name_only=True) emits the name."""
+        from kicad_tools.router.primitives import Layer, Segment
+
+        seg = Segment(
+            x1=0.0,
+            y1=0.0,
+            x2=1.0,
+            y2=0.0,
+            width=0.25,
+            layer=Layer.F_CU,
+            net=3,
+            net_name="SDA",
+        )
+        assert '(net "SDA")' in seg.to_sexp(name_only=True)
+        assert "(net 3)" in seg.to_sexp(name_only=False)
+        # Empty name falls back to numeric even when name_only is requested.
+        seg.net_name = ""
+        assert "(net 3)" in seg.to_sexp(name_only=True)
+
+    def test_builder_segment_node_name_only(self):
+        """builders.segment_node emits name-based ref when net_name is given."""
+        from kicad_tools.sexp.builders import segment_node
+
+        node = segment_node(0, 0, 1, 0, 0.25, "F.Cu", 3, "u", net_name="SDA")
+        net_child = node.find("net")
+        assert net_child is not None
+        assert net_child.get_string(0) == "SDA"
+        # Default (no net_name) stays numeric.
+        node2 = segment_node(0, 0, 1, 0, 0.25, "F.Cu", 3, "u")
+        assert node2.find("net").get_int(0) == 3
 
 
 class TestRemoveFootprint:

--- a/tests/test_route_cmd_net_dialect.py
+++ b/tests/test_route_cmd_net_dialect.py
@@ -1,0 +1,79 @@
+"""Tests for the net-reference dialect detector used by the route write path.
+
+Issue #4416: ``kct route`` (and its checkpoint / interrupt save paths) must
+re-emit route-added copper in the SAME net-reference dialect the input board
+used, so a KiCad-10 name-only board (``(net "SDA")``) does not flip to numeric
+``(net 12)`` and ping-pong with kicad-cli's ``--save-board`` name-only rewrite.
+
+The detector (:func:`_board_uses_name_only_dialect`) keys off inline name-only
+references and must NOT be fooled by the header ``(net N "name")`` table, which
+every board (numeric or name-only) carries.
+"""
+
+from __future__ import annotations
+
+from kicad_tools.cli.route_cmd import _board_uses_name_only_dialect
+
+_NAME_ONLY_BOARD = """\
+(kicad_pcb
+  (version 20260206)
+  (generator "pcbnew")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "VCC")
+  (segment (start 0 0) (end 1 0) (width 0.25) (layer "F.Cu") (net "GND") (uuid "s1"))
+)
+"""
+
+_NUMERIC_BOARD = """\
+(kicad_pcb
+  (version 20260206)
+  (generator "pcbnew")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "VCC")
+  (segment (start 0 0) (end 1 0) (width 0.25) (layer "F.Cu") (net 1) (uuid "s1"))
+)
+"""
+
+_NUMERIC_FULL_FORM_BOARD = """\
+(kicad_pcb
+  (version 20260206)
+  (generator "pcbnew")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+  (net 0 "")
+  (net 1 "GND")
+  (footprint "FP" (layer "F.Cu") (uuid "fp")
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 1 "GND"))
+  )
+)
+"""
+
+
+def test_name_only_board_detected(tmp_path):
+    p = tmp_path / "name.kicad_pcb"
+    p.write_text(_NAME_ONLY_BOARD)
+    assert _board_uses_name_only_dialect(p) is True
+
+
+def test_numeric_board_not_detected(tmp_path):
+    p = tmp_path / "numeric.kicad_pcb"
+    p.write_text(_NUMERIC_BOARD)
+    assert _board_uses_name_only_dialect(p) is False
+
+
+def test_numeric_full_form_board_not_detected(tmp_path):
+    """A (net N "name") full-form board -- and its header table -- is numeric.
+
+    The header ``(net 1 "GND")`` must not be mistaken for a name-only ref.
+    """
+    p = tmp_path / "full.kicad_pcb"
+    p.write_text(_NUMERIC_FULL_FORM_BOARD)
+    assert _board_uses_name_only_dialect(p) is False
+
+
+def test_missing_file_defaults_to_numeric(tmp_path):
+    """An unreadable path falls back to numeric (today's behavior)."""
+    assert _board_uses_name_only_dialect(tmp_path / "nope.kicad_pcb") is False


### PR DESCRIPTION
## Summary

KiCad-10 name-based boards use inline `(net "SDA")` net references. Every kct copper emitter previously hardcoded numeric `(net <N>)` with no per-element dialect memory, so any trace/via kct appended to a name-based board flipped to numeric. The next `kicad-cli pcb drc --refill-zones --save-board` then rewrote the whole file back to name-only — the dialect ping-pong the reporter observed (27k-line whole-file diffs).

Per the curator's root-cause analysis (the generic serializer round-trips faithfully; the flip is injected by the schema/router element emitters), this PR gives `Segment`/`Via` a parsed-dialect memory so kct emits the **same** dialect as the input, letting the two tools converge instead of ping-ponging.

## Changes

- **`schema/pcb.py`** — `Segment`/`Via` gain a `net_name_only` flag set in `from_sexp` (mirrors the parser's `_originally_bare` round-trip pattern; `compare=False` keeps dataclass identity stable). `to_sexp` emits `(net "name")` for name-only elements with a known name, numeric `(net N)` otherwise (empty-name fallback avoids invalid `(net "")`). Field order aligned to **uuid-before-net** (KiCad canonical, matching `router/primitives.py` per #3925/#3907). `_fixup_net_numbers` derives a board-level `_net_name_only_dialect` signal (from element-level name-only flags + pad name-only signal); `add_trace`/`add_via` tag newly added copper with it. `to_sexp` gained an `offset` arg, folding the former hand-rolled numeric board-origin branch into the single dialect-aware emitter.
- **`router/primitives.py`** + **`router/core.py`** — `Segment`/`Via`/`Route.to_sexp` and `Autorouter.to_sexp` gain a `name_only` param (uses the already-present `net_name` field).
- **`cli/route_cmd.py`** — `_board_uses_name_only_dialect()` detects the input dialect once; threaded through `_finalize_routes`, preserved-route serialization, the checkpoint callback, and the interrupt save.
- **`sexp/builders.py`** — `segment_node`/`via_node` gain an optional `net_name` arg (default `None` = numeric; backward compatible for all existing stitch/editor/rerouter callers).

## Deferred (out of scope — noted per curation)

- Global `--preserve-format` flag / documenting one canonical fleet-wide dialect (a design conversation).
- Pad net-ref dialect preservation — pads round-trip in place via their `_sexp_node` today and are not rebuilt by the copper path, so they do not exhibit the bug.
- Anything requiring kicad-cli to stop its `--save-board` whole-file rewrite (out of our control — the 27k-line diff is kicad-cli's, not kct's). Our fixable contribution is emitting the same dialect as the input so the two tools converge.

## Acceptance Criteria Verification

| Criterion (Test Plan) | Status | Verification |
|---|---|---|
| Dialect round-trip: name-only board + add_trace/add_via keeps `(net "X")` | ✅ | `test_added_trace_stays_name_based_on_name_only_board`, `test_added_via_stays_name_based_on_name_only_board` |
| Numeric board unchanged after add copper | ✅ | `test_numeric_board_stays_numeric` |
| Field order: schema Segment/Via place uuid before net | ✅ | `test_schema_segment_field_order_uuid_before_net`, `test_schema_via_field_order_uuid_before_net` |
| Fallback safety: known number + empty name → valid `(net N)`, no `(net "")` | ✅ | `test_name_only_segment_with_empty_name_falls_back_to_numeric`; router variant in `test_router_primitive_segment_name_only_emission` |
| Detector ignores header `(net N "name")` table | ✅ | `test_route_cmd_net_dialect.py` (4 cases: name-only, bare numeric, full-form, missing file) |

## Test Plan

- `tests/test_pcb.py::TestNetDialectPreservation` (8 tests) + `tests/test_route_cmd_net_dialect.py` (4 tests) — all pass.
- Regression: `test_pcb.py` (232), `test_router_primitives.py`, `test_sexp_builders.py`, `test_sexp_roundtrip.py`, `test_kicad10_roundtrip_new_tokens.py`, `test_stitch_cmd.py`, `test_route_auto_persistence.py`, `test_output_connectivity.py`, `test_route_cmd_zone_fill.py`, `test_runner_net_restore.py` — all green.
- `ruff check` + `ruff format --check` clean on changed files; baseline-gated mypy reports no new type errors.

Closes #4416