### PR TITLE
fix(router): preserve name-based-dialect copper on --preserve-existing save

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -785,6 +785,28 @@ def _validate_sexp_parentheses(content: str) -> bool:
     return depth == 0
 
 
+class CatastrophicCopperLossError(RuntimeError):
+    """Raised when a save would drop almost all of a board's existing copper.
+
+    Issue #4413 defense-in-depth: a ``--preserve-existing`` / ``--nets`` /
+    ``--region`` save must round-trip the board's pre-existing segments and
+    vias.  If a parser dialect regression (or any future bug) ever empties
+    the preserved set again, the terminal write would otherwise silently
+    overwrite a fully-routed board with only the freshly-routed net.  This
+    guard turns that silent data loss into a loud, safe abort that leaves
+    the output file untouched.
+    """
+
+
+# Below this fraction of the input's copper surviving a preserve/nets/region
+# save, the write is treated as catastrophic loss and aborted (#4413).
+_COPPER_LOSS_ABORT_FRACTION = 0.10
+# Inputs with at most this many routed elements are "trivial" -- the guard
+# does not fire (a near-empty board legitimately routes to a handful of
+# elements, so the ratio test would be meaningless / falsely tripped).
+_COPPER_LOSS_TRIVIAL_INPUT = 100
+
+
 def _write_routed_pcb(
     pcb_path: Path,
     output_path: Path,
@@ -792,6 +814,7 @@ def _write_routed_pcb(
     *,
     layer_count: int = 2,
     is_checkpoint: bool = False,
+    guard_copper_loss: bool = False,
 ) -> Path:
     """Atomically write a routed PCB file.
 
@@ -826,6 +849,13 @@ def _write_routed_pcb(
             Checkpoints serialize the in-progress best snapshot; they
             should match whatever stackup is currently in use and not
             attempt to escalate.  Defaults to False.
+        guard_copper_loss: Issue #4413 defense-in-depth.  When True (the
+            terminal ``--preserve-existing`` / ``--nets`` / ``--region``
+            save), the write aborts with
+            :class:`CatastrophicCopperLossError` -- leaving the output file
+            untouched -- if a non-trivial input's routed copper would drop
+            below :data:`_COPPER_LOSS_ABORT_FRACTION`.  Checkpoint writes
+            leave this False so a mid-route snapshot is never blocked.
 
     Returns:
         The ``output_path`` that was written to (returned unchanged so
@@ -836,6 +866,9 @@ def _write_routed_pcb(
         ValueError: If the generated PCB has unbalanced S-expression
             parentheses (indicates a bug in route generation -- caller
             is responsible for surfacing this).
+        CatastrophicCopperLossError: If ``guard_copper_loss`` is True and
+            the save would drop >90% of a non-trivial input's copper
+            (issue #4413).  The output file is left untouched.
     """
     original_content = pcb_path.read_text()
 
@@ -857,6 +890,33 @@ def _write_routed_pcb(
             "(unbalanced parentheses). This is a bug in kicad-tools. "
             "Please report it."
         )
+
+    # Issue #4413 defense-in-depth: on a preserve/nets/region save, refuse
+    # to overwrite a fully-routed board with only a sliver of copper.  Count
+    # the routed elements the input carried vs what the output would carry;
+    # if a non-trivial input drops below the abort fraction, raise BEFORE
+    # touching the output file so silent data loss becomes a loud, safe
+    # failure independent of any future parser dialect regression.
+    if guard_copper_loss:
+        _, in_segs, in_vias = _strip_route_blocks(original_content)
+        _, out_segs, out_vias = _strip_route_blocks(output_content)
+        in_total = in_segs + in_vias
+        out_total = out_segs + out_vias
+        if (
+            in_total > _COPPER_LOSS_TRIVIAL_INPUT
+            and out_total < _COPPER_LOSS_ABORT_FRACTION * in_total
+        ):
+            raise CatastrophicCopperLossError(
+                "Refusing to save: the routed output would retain only "
+                f"{out_total} of {in_total} existing copper elements "
+                f"(<{_COPPER_LOSS_ABORT_FRACTION:.0%}) under "
+                "--preserve-existing/--nets/--region. This indicates the "
+                "board's existing copper was NOT preserved (e.g. a net-"
+                "reference dialect the parser could not resolve). The output "
+                f"file {output_path} was left UNCHANGED to prevent data "
+                "loss. Please report this at "
+                "https://github.com/rjwalters/kicad-tools/issues (ref #4413)."
+            )
 
     # Atomic write: tmp file -> fsync -> rename.  Sibling-in-same-dir
     # ensures os.replace is a same-filesystem rename (atomic on POSIX).
@@ -4914,6 +4974,10 @@ def route_with_layer_escalation(
             output_path,
             route_sexp,
             layer_count=final_result.layer_count,
+            # Issue #4413: guard the terminal preserve/nets/region save so a
+            # dropped preserved set aborts loudly instead of overwriting the
+            # board with only the freshly-routed net.
+            guard_copper_loss=bool(getattr(args, "preserve_existing", False)),
         )
 
     if not quiet:
@@ -5608,6 +5672,10 @@ def route_with_rule_relaxation(
             output_path,
             route_sexp,
             layer_count=final_result.layer_count,
+            # Issue #4413: guard the terminal preserve/nets/region save so a
+            # dropped preserved set aborts loudly instead of overwriting the
+            # board with only the freshly-routed net.
+            guard_copper_loss=bool(getattr(args, "preserve_existing", False)),
         )
 
     if not quiet:
@@ -7816,6 +7884,10 @@ def route_with_combined_escalation(
             output_path,
             route_sexp,
             layer_count=final_result.layer_count,
+            # Issue #4413: guard the terminal preserve/nets/region save so a
+            # dropped preserved set aborts loudly instead of overwriting the
+            # board with only the freshly-routed net.
+            guard_copper_loss=bool(getattr(args, "preserve_existing", False)),
         )
 
     if not quiet:
@@ -12236,6 +12308,9 @@ def main(argv: list[str] | None = None) -> int:
                 pcb_path,
                 output_path,
                 combined_sexp,
+                # Issue #4413: abort rather than overwrite when a
+                # preserve/nets/region save would drop nearly all copper.
+                guard_copper_loss=bool(getattr(args, "preserve_existing", False)),
             )
 
             # We need output_content for the connectivity verification below;

--- a/src/kicad_tools/router/optimizer/pcb.py
+++ b/src/kicad_tools/router/optimizer/pcb.py
@@ -80,6 +80,51 @@ _RE_END = re.compile(r"\(end\s+([\d.eE+-]+)\s+([\d.eE+-]+)\)")
 _RE_WIDTH = re.compile(r"\(width\s+([\d.eE+-]+)\)")
 _RE_LAYER = re.compile(r'\(layer\s+"([^"]+)"\)')
 _RE_NET = re.compile(r"\(net\s+(\d+)\)")
+# Issue #4413: KiCad-10 name-based net dialect -- segments/vias reference
+# their net by quoted name instead of a numeric id, e.g.
+# ``(net "Net-(C11-Pad2)")``.  The numeric ``_RE_NET`` above matches
+# nothing on such blocks, so before this pattern existed the parser
+# skipped EVERY segment/via on a name-based board.  When those parsers
+# feed ``--preserve-existing`` / ``--nets``, an empty preserved set let
+# the dialect-blind strip pass delete all existing copper on save
+# (silent, catastrophic data loss).
+_RE_NET_NAME = re.compile(r'\(net\s+"([^"]*)"\)')
+
+
+def _resolve_block_net(
+    block: str,
+    net_names: dict[int, str],
+    name_to_id: dict[str, int],
+) -> tuple[int, str] | None:
+    """Resolve the net id + name referenced inside a segment/via *block*.
+
+    Handles both KiCad net-reference dialects (issue #4413):
+
+    * numeric  ``(net N)``        -> id ``N``, name from the header table.
+    * name     ``(net "NAME")``   -> id from the ``name_to_id`` reverse map,
+      name ``NAME``.
+
+    Returns ``None`` only when the block carries no ``(net ...)`` field at
+    all (a genuinely malformed block).  A name-only reference whose name is
+    absent from the header table is deliberately **not** dropped: it is
+    kept with a best-effort net id of ``0`` so pre-existing copper is never
+    silently discarded -- dropping copper is exactly the failure mode this
+    resolver fixes.
+    """
+    m_net = _RE_NET.search(block)
+    if m_net:
+        net = int(m_net.group(1))
+        return net, net_names.get(net, f"Net{net}")
+
+    m_name = _RE_NET_NAME.search(block)
+    if m_name:
+        net_name = m_name.group(1)
+        # An empty inline name is the KiCad no-net (net 0) reference.
+        if not net_name:
+            return 0, "Net0"
+        return name_to_id.get(net_name, 0), net_name
+
+    return None
 
 
 def parse_segments(pcb_text: str) -> dict[str, list[Segment]]:
@@ -91,18 +136,23 @@ def parse_segments(pcb_text: str) -> dict[str, list[Segment]]:
     """
     segments_by_net: dict[str, list[Segment]] = {}
 
-    # First, build net ID to name mapping
+    # First, build net ID to name mapping (and its reverse, so name-based
+    # ``(net "NAME")`` references resolve to numeric ids -- issue #4413).
     net_names = parse_net_names(pcb_text)
+    name_to_id = {name: nid for nid, name in net_names.items()}
 
     for _start, _end, block in _extract_balanced_blocks(pcb_text, "segment"):
         m_start = _RE_START.search(block)
         m_end = _RE_END.search(block)
         m_width = _RE_WIDTH.search(block)
         m_layer = _RE_LAYER.search(block)
-        m_net = _RE_NET.search(block)
+        resolved_net = _resolve_block_net(block, net_names, name_to_id)
 
-        # All five core fields are required; skip malformed blocks.
-        if not (m_start and m_end and m_width and m_layer and m_net):
+        # All five core fields are required; skip malformed blocks.  The
+        # net resolver handles both the numeric ``(net N)`` and name-based
+        # ``(net "NAME")`` dialects, so a name-only board no longer drops
+        # every segment here (#4413).
+        if not (m_start and m_end and m_width and m_layer and resolved_net):
             continue
 
         x1 = float(m_start.group(1))
@@ -111,8 +161,7 @@ def parse_segments(pcb_text: str) -> dict[str, list[Segment]]:
         y2 = float(m_end.group(2))
         width = float(m_width.group(1))
         layer_name = m_layer.group(1)
-        net = int(m_net.group(1))
-        net_name = net_names.get(net, f"Net{net}")
+        net, net_name = resolved_net
 
         # Convert layer name to Layer enum
         try:
@@ -152,8 +201,10 @@ def parse_vias(pcb_text: str) -> dict[str, list[Via]]:
     """
     vias_by_net: dict[str, list[Via]] = {}
 
-    # Reuse existing net-name mapping
+    # Reuse existing net-name mapping (plus its reverse for the name-based
+    # ``(net "NAME")`` dialect -- issue #4413).
     net_names = parse_net_names(pcb_text)
+    name_to_id = {name: nid for nid, name in net_names.items()}
 
     # Issue #3414 / #3155: use the same balanced-parentheses walker as
     # ``parse_segments`` so that fields may appear in any order and extra
@@ -187,10 +238,13 @@ def parse_vias(pcb_text: str) -> dict[str, list[Via]]:
         m_size = _re_size.search(block)
         m_drill = _re_drill.search(block)
         m_layers = _re_layers.search(block)
-        m_net = _RE_NET.search(block)
+        resolved_net = _resolve_block_net(block, net_names, name_to_id)
 
-        # All five core fields are required; skip malformed blocks.
-        if not (m_at and m_size and m_drill and m_layers and m_net):
+        # All five core fields are required; skip malformed blocks.  The
+        # net resolver handles both the numeric ``(net N)`` and name-based
+        # ``(net "NAME")`` dialects, so a name-only board no longer drops
+        # every via here (#4413).
+        if not (m_at and m_size and m_drill and m_layers and resolved_net):
             continue
 
         m_type = _re_via_type.match(block)
@@ -201,8 +255,7 @@ def parse_vias(pcb_text: str) -> dict[str, list[Via]]:
         drill = float(m_drill.group(1))
         layer_start_name = m_layers.group(1)
         layer_end_name = m_layers.group(2)
-        net = int(m_net.group(1))
-        net_name = net_names.get(net, f"Net{net}")
+        net, net_name = resolved_net
 
         # Convert layer names to Layer enum
         try:

--- a/tests/router/test_preserve_existing.py
+++ b/tests/router/test_preserve_existing.py
@@ -40,18 +40,21 @@ These tests verify:
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
 
 from kicad_tools.cli.route_cmd import (
+    CatastrophicCopperLossError,
     _capture_preserved_routes,
     _finalize_routes,
     _serialize_preserved_routes,
+    _write_routed_pcb,
 )
 from kicad_tools.cli.route_cmd import main as route_main
 from kicad_tools.router.io import load_pcb_for_routing
-from kicad_tools.router.optimizer.pcb import parse_net_names, parse_segments
+from kicad_tools.router.optimizer.pcb import parse_net_names, parse_segments, parse_vias
 
 # A real routed board with eight 2-pad signal nets (LINE_*/NODE_*) and full
 # segment geometry.  Reused as the fixture so the tests exercise real KiCad
@@ -324,3 +327,176 @@ class TestPreserveExistingFinalize:
             preserved_routes=preserved,
         )
         assert route_sexp_off.count("(segment") == 0
+
+
+# ---------------------------------------------------------------------------
+# Issue #4413: name-based net dialect + catastrophic-copper-loss guard.
+# ---------------------------------------------------------------------------
+
+
+def _to_name_based_dialect(pcb_text: str) -> str:
+    """Rewrite inline numeric ``(net N)`` refs to the name-based dialect.
+
+    KiCad-10 hand-evolved boards reference a segment/via's net by quoted
+    name -- ``(net "Net-(C11-Pad2)")`` -- instead of the numeric
+    ``(net 5)``.  This helper converts a numeric-dialect fixture into that
+    dialect so the preservation path can be exercised against it.
+
+    Only the *inline* number-only form is rewritten: the header
+    declarations ``(net N "name")`` carry a trailing string and never match
+    ``\\(net (\\d+)\\)``, so they are left untouched (and remain the source
+    of truth for the name->id reverse map).  ``(net 0)`` / unnamed nets stay
+    numeric because they have no name to key on.
+    """
+    net_names = parse_net_names(pcb_text)
+
+    def repl(m: re.Match) -> str:
+        nid = int(m.group(1))
+        name = net_names.get(nid)
+        if not name:
+            return m.group(0)
+        return f'(net "{name}")'
+
+    return re.sub(r"\(net (\d+)\)", repl, pcb_text)
+
+
+class TestNameBasedDialectParsing:
+    """Issue #4413: the preserve-path parser must resolve ``(net "NAME")``."""
+
+    def test_parse_segments_resolves_name_based_refs(self, board_text):
+        """AC: parse_segments returns resolved segments on a name-based board."""
+        name_based = _to_name_based_dialect(board_text)
+        # Sanity: the conversion actually produced name-based inline refs and
+        # removed the numeric-only inline form for a real net.
+        assert '(net "LINE_A")' in name_based
+
+        numeric = parse_segments(board_text)
+        namebased = parse_segments(name_based)
+
+        # Before the fix, ``namebased`` was empty (every block dropped).
+        assert namebased, "name-based board parsed to ZERO segments (data-loss bug)"
+        assert set(namebased) == set(numeric)
+        for net in _ALL_SIGNAL_NETS:
+            # Same geometry AND same resolved numeric net id (connectivity).
+            assert _geom_set(namebased[net]) == _geom_set(numeric[net])
+
+    def test_parse_vias_resolves_name_based_refs(self, tmp_path, board_text):
+        """AC: parse_vias resolves name-based via refs (incl. a stitch via)."""
+        net_names = parse_net_names(board_text)
+        gnd_net = next(nid for nid, name in net_names.items() if name == "GND")
+        stitched = _inject_stitch_via(board_text, net=gnd_net, x=12.3456, y=23.4567)
+        name_based = _to_name_based_dialect(stitched)
+
+        v_numeric = parse_vias(stitched)
+        v_namebased = parse_vias(name_based)
+
+        assert v_namebased, "name-based board parsed to ZERO vias (data-loss bug)"
+        assert set(v_namebased) == set(v_numeric)
+        # The GND stitch via survived with its resolved numeric net id.
+        assert any(abs(v.x - 12.3456) < 1e-4 and v.net == gnd_net for v in v_namebased["GND"])
+
+    def test_name_absent_from_header_is_not_dropped(self):
+        """Edge case (a): a name-only ref with no header entry keeps the block."""
+        pcb_text = (
+            "(kicad_pcb\n"
+            '  (net 0 "")\n'
+            "  (segment (start 0 0) (end 1 1) (width 0.2) "
+            '(layer "F.Cu") (net "MYSTERY_NET"))\n'
+            ")\n"
+        )
+        segs = parse_segments(pcb_text)
+        # The block is preserved (keyed by its name) rather than silently
+        # discarded -- dropping copper is the exact failure mode being fixed.
+        assert "MYSTERY_NET" in segs
+        assert len(segs["MYSTERY_NET"]) == 1
+
+
+class TestPreserveExistingNameBasedCLI:
+    """End-to-end: --preserve-existing must round-trip a name-based board."""
+
+    def test_preserve_keeps_other_nets_on_name_based_board(self, tmp_path, board_text):
+        """AC #1: every OTHER net's copper survives a single-net re-route."""
+        name_based = _to_name_based_dialect(board_text)
+        orig = parse_segments(name_based)
+        assert set(orig) == set(_ALL_SIGNAL_NETS)
+
+        out_text = _run_route(tmp_path, name_based, preserve=True, skip_nets=_SKIP_ALL_BUT_LINE_A)
+        out = parse_segments(out_text)
+
+        # All pre-existing copper on the skipped nets survives byte-identical.
+        for net in ("LINE_B", "LINE_C", "LINE_D", "NODE_A", "NODE_B", "NODE_C", "NODE_D"):
+            assert net in out, (
+                f"{net} copper was destroyed on a NAME-BASED board under "
+                "--preserve-existing (the #4413 data-loss regression)"
+            )
+            assert _geom_set(out[net]) == _geom_set(orig[net])
+
+        # The one routable net is present (re-routed in place).
+        assert "LINE_A" in out
+        assert len(out["LINE_A"]) > 0
+
+
+class TestCatastrophicCopperLossGuard:
+    """Issue #4413 defense-in-depth: refuse to overwrite on catastrophic loss."""
+
+    @staticmethod
+    def _board_with_segments(count: int) -> str:
+        seg = '(segment (start 0 0) (end 1 1) (width 0.2) (layer "F.Cu") (net 1))'
+        body = "\n  ".join(seg for _ in range(count))
+        return f'(kicad_pcb\n  (net 0 "")\n  (net 1 "GND")\n  {body}\n)\n'
+
+    def test_guard_aborts_and_leaves_output_untouched(self, tmp_path):
+        """A >90% copper drop under the guard raises and does NOT write."""
+        in_path = tmp_path / "in.kicad_pcb"
+        in_path.write_text(self._board_with_segments(150))
+
+        out_path = tmp_path / "out.kicad_pcb"
+        sentinel = "SENTINEL-UNTOUCHED"
+        out_path.write_text(sentinel)
+
+        # Only a single segment re-emitted -> 1/150 survives (<10%).
+        route_sexp = '(segment (start 0 0) (end 2 2) (width 0.2) (layer "F.Cu") (net 1))'
+        with pytest.raises(CatastrophicCopperLossError):
+            _write_routed_pcb(in_path, out_path, route_sexp, guard_copper_loss=True)
+
+        # The output file on disk is unchanged (no partial/torn overwrite).
+        assert out_path.read_text() == sentinel
+
+    def test_guard_off_permits_the_same_write(self, tmp_path):
+        """Without the guard flag (default) the same write proceeds."""
+        in_path = tmp_path / "in.kicad_pcb"
+        in_path.write_text(self._board_with_segments(150))
+        out_path = tmp_path / "out.kicad_pcb"
+
+        route_sexp = '(segment (start 0 0) (end 2 2) (width 0.2) (layer "F.Cu") (net 1))'
+        _write_routed_pcb(in_path, out_path, route_sexp)  # guard_copper_loss defaults False
+        assert out_path.exists()
+        assert out_path.read_text().count("(segment") == 1
+
+    def test_guard_no_false_positive_when_copper_preserved(self, tmp_path):
+        """The guard does not fire when the preserved copper is re-emitted."""
+        in_path = tmp_path / "in.kicad_pcb"
+        in_path.write_text(self._board_with_segments(150))
+        out_path = tmp_path / "out.kicad_pcb"
+
+        # Re-emit all 150 preserved segments plus one freshly-routed one.
+        seg = '(segment (start 0 0) (end 1 1) (width 0.2) (layer "F.Cu") (net 1))'
+        preserved = "\n  ".join(seg for _ in range(150))
+        route_sexp = (
+            '(segment (start 0 0) (end 2 2) (width 0.2) (layer "F.Cu") (net 1))\n  ' + preserved
+        )
+        _write_routed_pcb(in_path, out_path, route_sexp, guard_copper_loss=True)
+        assert out_path.read_text().count("(segment") == 151
+
+    def test_guard_ignores_trivial_input(self, tmp_path):
+        """A trivial input (<=100 segments) never trips the guard."""
+        in_path = tmp_path / "in.kicad_pcb"
+        in_path.write_text(self._board_with_segments(10))
+        out_path = tmp_path / "out.kicad_pcb"
+
+        route_sexp = '(segment (start 0 0) (end 2 2) (width 0.2) (layer "F.Cu") (net 1))'
+        # 1/10 survives -- below the fraction, but the input is trivial so the
+        # guard stays silent (a near-empty board legitimately routes to a few
+        # elements).
+        _write_routed_pcb(in_path, out_path, route_sexp, guard_copper_loss=True)
+        assert out_path.exists()


### PR DESCRIPTION
## Summary

`kct route <board> --nets '<one-net>' --preserve-existing` on a fully-routed
KiCad-10 **name-based-dialect** board (segments/vias reference their net by
quoted name, e.g. `(net "Net-(C11-Pad2)")`) silently deleted ALL other nets'
copper on save — 6037 segments -> 6 in the field report. This PR fixes the
root cause and adds a defense-in-depth guard so the failure can never again
be silent.

**Root cause:** the preserve-path parser (`parse_segments`/`parse_vias` in
`router/optimizer/pcb.py`) extracted a block's net id with a numeric-only
regex `\(net\s+(\d+)\)`. On a name-based board it matched nothing, so every
segment/via was skipped, `_capture_preserved_routes` returned `[]`,
`_finalize_routes` re-emitted no preserved copper, and the dialect-blind
`_strip_route_blocks` then removed all existing copper — leaving only the
freshly-routed net.

## Changes

- **`router/optimizer/pcb.py` (Fix 1, correctness):** new `_resolve_block_net`
  helper resolves BOTH dialects — numeric `(net N)` and name-based
  `(net "NAME")` — via a `name -> id` reverse map built from the header net
  table (`parse_net_names`), mirroring `runner.py:_resolve_name_only_nets`.
  `parse_segments`/`parse_vias` use it instead of the numeric-only regex. A
  name absent from the header is **kept** (best-effort id 0), never dropped —
  dropping copper is the exact failure mode being fixed. Re-emitted copper is
  the KiCad-canonical numeric form with header-matched ids, so connectivity is
  preserved.
- **`cli/route_cmd.py` (Fix 2, defense-in-depth):** `_write_routed_pcb` gains a
  `guard_copper_loss` flag (set at the four terminal preserve/nets/region
  saves via `getattr(args, "preserve_existing", False)` — `--nets` and
  `--region` both imply `preserve_existing`). When a non-trivial input (>100
  routed elements) would retain <10% of its copper, the write raises
  `CatastrophicCopperLossError` **before** touching the output file. Checkpoint
  writes leave the flag off so mid-route snapshots are never blocked.
- **`tests/router/test_preserve_existing.py`:** name-based parser unit tests,
  an end-to-end `--preserve-existing` regression on a name-based board, and
  the catastrophic-loss guard tests (abort + file-untouched, guard-off,
  no-false-positive, trivial-input).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Preserve round-trips ALL copper on a name-based board | ✅ | `TestPreserveExistingNameBasedCLI` — every skipped net byte-identical |
| No regression on the numeric `(net N)` dialect (#3155) | ✅ | Existing `TestPreserveExistingCLI` + `test_optimizer_pcb_segments` still pass |
| `parse_segments`/`parse_vias` non-empty on `(net "NAME")` | ✅ | `TestNameBasedDialectParsing` — resolved to correct numeric ids |
| Guard: >90% drop aborts, output untouched | ✅ | `test_guard_aborts_and_leaves_output_untouched` |
| Re-emitted copper references correct net ids | ✅ | `_geom_set` identity includes `seg.net`; ids resolved via header reverse map |
| Name absent from header not dropped | ✅ | `test_name_absent_from_header_is_not_dropped` |
| Zone drop deferred to #4416 | ✅ | Out of scope; segment/via + guard only |

## Test Plan

- `pytest tests/router/test_preserve_existing.py` — 20 passed.
- `pytest tests/test_optimizer_pcb_segments.py` — 34 passed (numeric dialect unchanged).
- **Confirmed the regression fails without the fix:** reverting only
  `pcb.py`, the 4 name-based tests fail (`parse_segments` -> empty set, the
  data-loss bug); they pass with the fix.
- `ruff format . --check` and `ruff check .` clean; `mypy` introduces no new
  errors (the 30 in `route_cmd.py` are pre-existing, none at changed lines).

## Notes

- Sibling **#4414** (`pcb strip --nets`) shares this numeric-only root cause;
  the shared parser fix should cover it but keeps its own verification.
- **#4416** (zone re-serialization dialect flip) is the distinct mechanism
  behind the `zones 6->5` / `filled_polygons 329->40` half of the report — not
  touched here.

Closes #4413