### PR TITLE
fix(pcb): resolve name-based net refs in strip_traces net filter

### DIFF
--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -5482,6 +5482,16 @@ class PCB:
                         net_numbers_to_strip.add(net_num)
                         break
 
+        # Reverse map (net name -> number) so we can resolve name-based inline
+        # net references — ``(net "GND")``, the dialect KiCad 10 writes — back to
+        # the numeric id carried in the header net table.  Mirrors the map built
+        # by ``_fixup_net_numbers`` (see the ``name_to_number`` construction
+        # above).  Without this, ``get_int(0)`` returns None for a name token and
+        # every copper item resolves to net 0, so the net filter matches nothing.
+        name_to_number: dict[str, int] = {
+            net.name: net_num for net_num, net in self._nets.items() if net.name and net_num != 0
+        }
+
         # Build layer set for fast membership tests
         layer_set: set[str] | None = None
         if layers is not None:
@@ -5545,8 +5555,18 @@ class PCB:
 
         def _net_num_from_child(child: SExp) -> int:
             net_node = child.find("net")
-            if net_node:
-                return net_node.get_int(0) or 0
+            if not net_node:
+                return 0
+            # Numeric dialect: ``(net 5)`` — read the id directly.
+            num = net_node.get_int(0)
+            if num is not None:
+                return num
+            # Name-based dialect: ``(net "GND")`` — resolve via the header table.
+            # Read-only resolution for the filter decision; the on-disk token is
+            # left untouched, so kept items retain their original name form.
+            name = net_node.get_string(0)
+            if name is not None:
+                return name_to_number.get(name, 0)
             return 0
 
         def _should_strip_net(net_num: int) -> bool:

--- a/tests/test_pcb.py
+++ b/tests/test_pcb.py
@@ -3027,6 +3027,58 @@ class TestStripTraces:
                 break
         assert gnd_net_num not in remaining_net_nums
 
+    def test_strip_specific_nets_name_based_dialect(self, tmp_path: Path):
+        """Strip name-based inline net refs — ``(net "GND")`` — via the header table.
+
+        Regression for #4414: KiCad 10 writes copper items with name-based net
+        references (``(net "GND")``) while the header net table still carries
+        numeric ids (``(net 1 "GND")``).  ``strip_traces`` walks the raw
+        S-expression and read each item's net token with ``get_int(0)``, which
+        returns None for a name atom → net 0 → the net filter matched nothing and
+        removed 0 segments/vias for every net name.  The fix resolves name-based
+        refs through the header net table.
+        """
+        board_text = """\
+(kicad_pcb
+  (version 20260306)
+  (generator "pcbnew")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "VCC")
+  (segment (start 10 10) (end 50 10) (width 0.25) (layer "F.Cu") (net "GND") (uuid "s1"))
+  (segment (start 10 12) (end 50 12) (width 0.25) (layer "F.Cu") (net "GND") (uuid "s2"))
+  (segment (start 10 20) (end 50 20) (width 0.25) (layer "F.Cu") (net "VCC") (uuid "s3"))
+  (via (at 30 10) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net "GND") (uuid "v1"))
+  (via (at 30 20) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net "VCC") (uuid "v2"))
+)
+"""
+        board_path = tmp_path / "name_based.kicad_pcb"
+        board_path.write_text(board_text)
+        pcb = PCB.load(str(board_path))
+
+        assert len(pcb.segments) == 3
+        assert len(pcb.vias) == 2
+
+        # Strip only GND — must resolve the name-based inline refs.
+        stats = pcb.strip_traces(nets=["GND"])
+
+        # Only GND copper removed: 2 GND segments + 1 GND via.
+        assert stats["segments"] == 2
+        assert stats["vias"] == 1
+
+        # VCC copper survives untouched.
+        assert len(pcb.segments) == 1
+        assert len(pcb.vias) == 1
+        vcc_net_num = None
+        for net_num, net in pcb.nets.items():
+            if net.name == "VCC":
+                vcc_net_num = net_num
+                break
+        assert vcc_net_num is not None
+        assert {seg.net_number for seg in pcb.segments} == {vcc_net_num}
+        assert {via.net_number for via in pcb.vias} == {vcc_net_num}
+
     def test_strip_traces_updates_sexp(self, minimal_pcb: Path, tmp_path: Path):
         """Test that stripping traces updates the underlying S-expression."""
         pcb = PCB.load(minimal_pcb)


### PR DESCRIPTION
## Summary
`kct pcb strip --nets <name>` removed 0 segments/vias for every net on boards using the name-based net-reference dialect that KiCad 10 writes (`(net "GND")`), while the header net table still carries numeric ids (`(net 1 "GND")`). Region-only strip worked because it skips the net gate. This is a regression that surfaced once boards began carrying name-based net refs in copper items (chorus PR #47).

Root cause: `strip_traces` (`schema/pcb.py:5381`) walks the raw S-expression and reads each item's net token via the nested `_net_num_from_child`, which did `net_node.get_int(0) or 0`. `get_int("GND")` returns `None`, so every segment/via/zone resolved to net 0 and the filter set never matched.

## Changes
- `src/kicad_tools/schema/pcb.py` — in `strip_traces`, build a `name_to_number` reverse map from `self._nets` (mirroring the pattern in `_fixup_net_numbers`), and make `_net_num_from_child` fall back to `get_string(0)` → map lookup when `get_int(0)` is `None`. Read-only resolution — the on-disk net token is left untouched (no dialect flip). Single-site fix covers segments, vias, and zones.
- `tests/test_pcb.py` — add `test_strip_specific_nets_name_based_dialect`: name-based inline fixture (header `(net N "name")` + inline `(net "NAME")` on segments and vias), asserts `strip_traces(nets=["GND"])` removes only GND copper and VCC survives. Confirmed the test fails without the fix.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Name-based board `--nets 'GND'` removes exactly that net's copper (non-zero) | ✅ | New test: 2 GND segments + 1 GND via removed |
| Name-based inline refs resolve via header table; numeric dialect unchanged | ✅ | Numeric `test_strip_specific_nets` stays green |
| Numeric `(net 5)` and empty `(net "")` refs unaffected | ✅ | Numeric branch returns early; empty name → `.get(name, 0)` |
| Vias and zones resolve too (all three call sites) | ✅ | Shared `_net_num_from_child` fixes segments/vias/zones; test covers vias |
| Region-only strip unaffected | ✅ | Net gate untouched when `nets is None` |

## Test Plan
- New regression test fails without the src fix, passes with it.
- All 8 strip tests pass: `uv run pytest tests/test_pcb.py -k "test_strip_specific_nets or test_strip_traces"` → 8 passed.
- `uv run ruff check .` and `uv run ruff format . --check` clean. mypy on `pcb.py` shows only pre-existing errors (none in the edited region; mypy is not in the `check:ci` gate).

Closes #4414