### PR TITLE
fix(build-native): keep nanobind resolved in default uv sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,6 +712,21 @@ the worktree's `.venv/` does not inherit the C++ extension built in the
 main checkout. After `cd` into the worktree, run `uv run kct build-native`
 once before any routing benchmarks.
 
+The build's `nanobind` dependency is composed into the default dev
+dependency-group, so a plain `uv sync` keeps it resolved and a later
+`uv sync` (e.g. adding `--extra placement`) will not prune it. If you
+installed with only a subset of groups, add the `native` extra explicitly
+so nanobind stays lockfile-tracked:
+
+```bash
+uv sync --extra native            # repo/dev worktree
+pip install "kicad-tools[native]" # consumer / installed wheel
+```
+
+Avoid a bare `pip install nanobind` — it is not recorded in the resolved
+set and a subsequent `uv sync` will uninstall it, breaking the next
+`kct build-native` (issue #4412).
+
 ### Available Commands
 
 If you have `pnpm` installed, you can use these convenience scripts:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,6 +199,10 @@ all = [
     "jinja2>=3.1",
     "markdown>=3.5",
     "weasyprint>=60.0",
+    # nanobind is the build-time dependency for the C++ router extension
+    # (`kct build-native`). Included here so `pip install kicad-tools[all]`
+    # keeps it resolved; see the `native` extra and issue #4412.
+    "nanobind>=2.0",
     # shapely is a core dependency; listed here too for explicitness.
     "shapely>=2.0",
 ]
@@ -348,4 +352,14 @@ dev = [
     # cairosvg in the default sync, worktree exports silently shipped
     # bundles with no images/ (per-layer renders, assembly views).
     "cairosvg>=2.6",
+    # C++ router build tooling (mirrors the `native` extra). This group is
+    # installed by a default `uv sync`, so keeping the build deps here means
+    # nanobind stays resolved in the lockfile and a later `uv sync` won't
+    # prune it. Previously `kct build-native` ad-hoc-installed nanobind out
+    # of band, so an unrelated `uv sync` (e.g. adding `--extra placement`)
+    # silently removed it and the next rebuild failed (issue #4412).
+    "nanobind>=2.0",
+    "scikit-build-core>=0.8",
+    "cmake>=3.15",
+    "ninja>=1.10",
 ]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,7 +10,7 @@ Python helpers with `uv run python scripts/<name>.py`, from the repository root.
 
 | Script | Purpose |
 |--------|---------|
-| `build-cpp.sh` | Build/install the nanobind C++ router extension (`clean`, `check` subcommands). Wrapped by `kct build-native`. |
+| `build-cpp.sh` | Build/install the nanobind C++ router extension (`clean`, `check` subcommands). Wrapped by `kct build-native`. Requires the `native` extra (`uv sync --extra native` / `pip install "kicad-tools[native]"`) so nanobind stays lockfile-tracked; the default dev group already composes it in. |
 | `deploy-site.sh` | Manual one-command deploy of the kicad-tools.org demo gallery to Cloudflare Pages (via a locally authenticated `wrangler`). |
 | `install-kct.sh` | Install kicad-tools into a consumer PCB-design repo (uv dependency + vendored `.claude/commands/kct/` skills and `ci/` gate scripts). |
 | `calibrate_area_estimate.py` | Calibration helper for the sum-of-clearances board-area estimator (#3403). |

--- a/src/kicad_tools/cli/build_native_cmd.py
+++ b/src/kicad_tools/cli/build_native_cmd.py
@@ -175,9 +175,19 @@ def _install_nanobind(verbose: bool = False) -> tuple[bool, str | None]:
     except ImportError:
         pass
 
-    # Try to install nanobind
+    # Try to install nanobind ad hoc.
+    #
+    # NOTE (issue #4412): this fallback exists for pip-installed-wheel users
+    # who never ran `uv sync`. It installs nanobind directly into the active
+    # environment WITHOUT recording it in any lockfile/resolved set, so a
+    # later `uv sync` (e.g. adding an extra, or a fresh worktree) will prune
+    # it and the next `kct build-native` will fail on the missing import. The
+    # robust path is to keep nanobind resolved via the `native` extra
+    # (`uv sync --extra native` / `pip install "kicad-tools[native]"`), which
+    # the default dev dependency-group now composes in.
     if verbose:
-        print("  Installing nanobind...")
+        print("  Installing nanobind (ad hoc — not lockfile-tracked; prefer")
+        print("  `uv sync --extra native` so a later `uv sync` won't prune it)...")
 
     # Try different installation methods
     install_commands = [
@@ -218,7 +228,16 @@ def _install_nanobind(verbose: bool = False) -> tuple[bool, str | None]:
         except Exception as e:
             last_error = str(e)
 
-    return False, f"Failed to install nanobind. Last error: {last_error}"
+    return False, (
+        "Failed to install nanobind, the build-time dependency for the C++ "
+        "router extension. Install it via the `native` extra so it stays "
+        "resolved in your environment:\n"
+        "  - repo/dev worktree:  uv sync --extra native\n"
+        '  - consumer/wheel:     pip install "kicad-tools[native]"\n'
+        "(A bare `pip install nanobind` is not lockfile-tracked and can be "
+        "pruned by a later `uv sync`; see issue #4412.)\n"
+        f"Last error: {last_error}"
+    )
 
 
 def _get_nanobind_cmake_dir() -> Path | None:

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -7223,7 +7223,10 @@ def _add_build_native_parser(subparsers) -> None:
         description=(
             "Build and install the C++ router extension for significantly faster routing. "
             "This command handles all the build steps automatically: checking prerequisites, "
-            "installing nanobind, configuring cmake, and building the extension."
+            "ensuring nanobind is available, configuring cmake, and building the extension. "
+            "For a lockfile-tracked nanobind that survives a later `uv sync`, install the "
+            "build tooling via the `native` extra: `uv sync --extra native` (repo) or "
+            '`pip install "kicad-tools[native]"` (consumer).'
         ),
     )
     build_native_parser.add_argument(

--- a/tests/test_native_extra_composition.py
+++ b/tests/test_native_extra_composition.py
@@ -1,0 +1,96 @@
+"""Regression tests for nanobind dependency composition (Issue #4412).
+
+The C++ router extension is built by the opt-in ``kct build-native`` step,
+which requires an importable ``nanobind``. nanobind was declared only in the
+standalone ``native`` optional-dependency extra, which was orphaned from every
+set a default ``uv sync`` resolves. ``kct build-native`` then ad-hoc-installed
+nanobind out of band, so an unrelated later ``uv sync`` pruned it and the next
+rebuild failed on the missing import.
+
+These tests pin the fix so it cannot silently regress:
+
+* ``nanobind`` must appear in the default ``[dependency-groups] dev`` group
+  (the group a bare ``uv sync`` installs) and in the ``all`` extra.
+* ``_install_nanobind``'s failure message must name the ``native`` extra
+  install hint rather than a bare ``pip install nanobind``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest import mock
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - Python 3.10 fallback
+    import tomli as tomllib
+
+import kicad_tools.cli.build_native_cmd as bnc
+
+_PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+
+def _load_pyproject() -> dict:
+    with _PYPROJECT.open("rb") as fh:
+        return tomllib.load(fh)
+
+
+def _names(requirements: list[str]) -> set[str]:
+    """Extract distribution names from a list of PEP 508 requirement strings."""
+    names = set()
+    for req in requirements:
+        # Split off any version/marker specifiers; names are the leading token.
+        token = req.split(";")[0].strip()
+        for sep in ("[", ">", "<", "=", "!", "~", " ", "@"):
+            token = token.split(sep)[0]
+        names.add(token.strip().lower())
+    return names
+
+
+def test_nanobind_in_default_dev_dependency_group() -> None:
+    """A default ``uv sync`` installs [dependency-groups].dev — nanobind must
+    live there so it stays resolved and is not pruned by a later ``uv sync``."""
+    data = _load_pyproject()
+    dev_group = data["dependency-groups"]["dev"]
+    assert "nanobind" in _names(dev_group), (
+        "nanobind must be in [dependency-groups] dev so a default `uv sync` "
+        "keeps it resolved (issue #4412)"
+    )
+
+
+def test_nanobind_in_all_extra() -> None:
+    """The aggregate ``all`` extra must include nanobind for symmetry."""
+    data = _load_pyproject()
+    all_extra = data["project"]["optional-dependencies"]["all"]
+    assert "nanobind" in _names(all_extra), "nanobind must be in the `all` extra (issue #4412)"
+
+
+def test_native_extra_still_present() -> None:
+    """The standalone ``native`` extra remains the public consumer surface."""
+    data = _load_pyproject()
+    native = data["project"]["optional-dependencies"]["native"]
+    assert "nanobind" in _names(native)
+
+
+def test_install_nanobind_failure_names_native_extra() -> None:
+    """The failure hint must point at the `native` extra, not a bare install."""
+    # Force the import to fail so _install_nanobind takes the install path,
+    # and make every ad-hoc install command fail so it returns its error.
+    with (
+        mock.patch.dict(sys.modules, {"nanobind": None}),
+        mock.patch.object(bnc.shutil, "which", return_value=None),
+        mock.patch.object(
+            bnc.subprocess,
+            "run",
+            side_effect=FileNotFoundError,
+        ),
+    ):
+        ok, err = bnc._install_nanobind(verbose=False)
+
+    assert ok is False
+    assert err is not None
+    assert "uv sync --extra native" in err
+    assert "kicad-tools[native]" in err
+    # And it should warn that a bare install is not lockfile-tracked.
+    assert "pip install nanobind" in err

--- a/uv.lock
+++ b/uv.lock
@@ -1793,6 +1793,7 @@ all = [
     { name = "markitdown" },
     { name = "matplotlib" },
     { name = "mlx" },
+    { name = "nanobind" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pdfplumber" },
@@ -1893,8 +1894,12 @@ visualization = [
 [package.dev-dependencies]
 dev = [
     { name = "cairosvg" },
+    { name = "cmake" },
     { name = "jinja2" },
+    { name = "nanobind" },
+    { name = "ninja" },
     { name = "pytest-cov" },
+    { name = "scikit-build-core" },
 ]
 
 [package.metadata]
@@ -1930,6 +1935,7 @@ requires-dist = [
     { name = "mlx", marker = "extra == 'all'", specifier = ">=0.5" },
     { name = "mlx", marker = "extra == 'metal'", specifier = ">=0.5" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
+    { name = "nanobind", marker = "extra == 'all'", specifier = ">=2.0" },
     { name = "nanobind", marker = "extra == 'native'", specifier = ">=2.0" },
     { name = "ninja", marker = "extra == 'native'", specifier = ">=1.10" },
     { name = "numpy", specifier = ">=1.24" },
@@ -1979,8 +1985,12 @@ provides-extras = ["geometry", "drc", "parts", "datasheet", "placement", "resear
 [package.metadata.requires-dev]
 dev = [
     { name = "cairosvg", specifier = ">=2.6" },
+    { name = "cmake", specifier = ">=3.15" },
     { name = "jinja2", specifier = ">=3.1" },
+    { name = "nanobind", specifier = ">=2.0" },
+    { name = "ninja", specifier = ">=1.10" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "scikit-build-core", specifier = ">=0.8" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

nanobind — the build-time dependency for the C++ router extension
(`kct build-native`) — was declared only in the standalone `native`
optional-dependency extra, which was **orphaned** from every set a default
`uv sync` resolves (`all`, `dev`, `[dependency-groups] dev`). `kct build-native`
papered over the gap by ad-hoc-installing nanobind out of band, so an unrelated
later `uv sync` (adding an extra, a version bump, or a fresh worktree) pruned it
and the next rebuild failed on the missing import. The stale `.so` kept
`--check` green, so the breakage was deferred and non-obvious (issue #4412).

## Changes

- **pyproject.toml**: compose the `native` build tooling (`nanobind>=2.0` +
  `scikit-build-core`/`cmake`/`ninja`) into the default `[dependency-groups] dev`
  group — the group a bare `uv sync` installs — so nanobind stays resolved in the
  lockfile. Also add `nanobind>=2.0` to the `all` extra for symmetry. The
  standalone `native` extra is kept unchanged as the public consumer surface.
  Regenerated `uv.lock`. Did **not** touch `[build-system] requires` (the wheel
  build uses hatchling and does not compile the extension — wrong lever).
- **src/kicad_tools/cli/build_native_cmd.py**: `_install_nanobind`'s failure now
  names `uv sync --extra native` / `pip install "kicad-tools[native]"`, and the
  verbose ad-hoc path warns that a bare `pip install nanobind` is not
  lockfile-tracked and can be pruned by a later `uv sync`. The ad-hoc fallback is
  retained for pip-installed-wheel users.
- **Docs**: README "Fresh worktree checklist" (~708), `parser.py` build-native
  help text, and `scripts/README.md` `build-cpp.sh` row now name the `native`
  extra as the resolved-and-retained path instead of a bare nanobind install.
- **tests/test_native_extra_composition.py**: pins nanobind's presence in the dev
  group + `all` + `native` extras and asserts the extra-named failure hint, so the
  composition can't silently regress.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| nanobind declared in an extra and included in `dev`/`all` so consumers keep it resolved | ✅ | Added to `[dependency-groups] dev` and `all` extra; `uv lock` + default `uv sync` installs nanobind 2.10.2 |
| Default `uv sync` keeps nanobind resolved (not injected ad hoc) | ✅ | `uv sync` then `uv run python -c "import nanobind"` succeeds |
| A later `uv sync` (e.g. `--extra placement`) does not prune nanobind | ✅ | Ran `uv sync --extra placement` — no `- nanobind` line; import still succeeds |
| `kct build-native` error names the extra/install hint, not a bare `pip install nanobind` | ✅ | `_install_nanobind` failure string names `uv sync --extra native` / `kicad-tools[native]`; covered by new test |
| Ad-hoc fallback retained for pip-wheel users | ✅ | Install-command loop unchanged; only messaging updated |

## Test Plan

- `uv lock` → default `uv sync` resolves nanobind (2.10.2); `import nanobind` succeeds.
- `uv sync --extra placement` does not prune nanobind (verified no `- nanobind` line, import still works).
- New tests pass: `tests/test_native_extra_composition.py` (4 tests) + existing `tests/test_build_native_staleness.py` (11) — 15 passed.
- `ruff check` + `ruff format --check` clean on changed files.
- mypy baseline gate (`scripts/ci/check_mypy_baseline.py`): "No new type errors" — the baseline already carries both nanobind `import-not-found`/`import-untyped` signatures, so it stays green whether or not nanobind is installed in CI (left untightened per the known native-env baseline trap).

Closes #4412