### PR TITLE
fix(sch): dedup cross-sheet duplicate power refs in fix-annotation

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 4314
-# Branch: feature/issue-4314
+# Issue: 4415
+# Branch: feature/issue-4415
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/src/kicad_tools/cli/sch_fix_annotation.py
+++ b/src/kicad_tools/cli/sch_fix_annotation.py
@@ -119,18 +119,32 @@ def _needs_reassignment(sym: dict) -> bool:
 
 
 def _existing_canonical_numbers(power_symbols: list[dict]) -> dict[str, set[int]]:
-    """Collect canonical numbers already in use, keyed by prefix.
+    """Collect the canonical numbers *kept* under first-occurrence-wins dedup.
 
-    Only references that are *already canonical and correctly-familied*
-    (i.e. would not be reassigned) reserve their number.  This lets the
-    assignment phase skip over numbers that established, correct symbols hold.
+    A reference reserves its number only when it is *already canonical and
+    correctly-familied* AND it is the **first** symbol across the flattened
+    hierarchy to hold that ``(prefix, number)`` pair.  Later symbols carrying
+    the same canonical designator are cross-sheet duplicates that will be
+    reassigned by ``build_rename_plan`` — so they do **not** reserve.
+
+    Reserving via a plain set would collapse two ``#PWR40`` symbols into the
+    single entry ``{40}`` and silently discard the collision, leaving both
+    duplicates untouched.  Seeding from first-occurrence canonicals only keeps
+    the reserved set consistent with the keep/reassign decision made in
+    ``build_rename_plan`` (the first holder keeps ``40``; the ``_next()``
+    machinery then hands the duplicate a fresh, non-reserved number).
     """
     reserved: dict[str, set[int]] = {_POWER_PREFIX: set(), _FLAG_PREFIX: set()}
     for sym in power_symbols:
         number = _canonical_number(sym)
         if number is None:
             continue
-        reserved[_power_prefix_for(sym)].add(number)
+        prefix = _power_prefix_for(sym)
+        if number in reserved[prefix]:
+            # Duplicate canonical ref (cross-sheet collision): the first holder
+            # already reserved this number; this one will be reassigned.
+            continue
+        reserved[prefix].add(number)
     return reserved
 
 
@@ -143,6 +157,15 @@ def build_rename_plan(ordered_power_symbols: list[dict]) -> dict[str, dict]:
     unique ``#PWR<dd>`` / ``#FLG<dd>`` designators are assigned to every
     symbol whose reference is not already canonical, skipping numbers held by
     canonical symbols so no collision is introduced.
+
+    Uniqueness is enforced **project-wide across the flattened hierarchy**
+    using first-occurrence-wins: the first symbol to hold a canonical
+    ``(prefix, number)`` keeps it, and any *later* symbol carrying the same
+    canonical designator is treated as a cross-sheet duplicate and reassigned
+    via ``_next()``.  This catches the case the old per-symbol canonicality
+    check missed — two individually-canonical ``#PWR40`` symbols on different
+    sheets are a real annotation error even though each looks fine in
+    isolation.
 
     Returns a dict mapping symbol UUID -> ``{"old": str, "new": str}`` for
     every symbol that actually changes reference (identity renames are
@@ -159,11 +182,20 @@ def build_rename_plan(ordered_power_symbols: list[dict]) -> dict[str, dict]:
         counters[prefix] = n + 1
         return n
 
+    # Canonical (prefix, number) pairs already kept, so a later symbol holding
+    # the same canonical designator is recognised as a cross-sheet duplicate.
+    kept_canonical: dict[str, set[int]] = {_POWER_PREFIX: set(), _FLAG_PREFIX: set()}
+
     plan: dict[str, dict] = {}
     for sym in ordered_power_symbols:
-        if not _needs_reassignment(sym):
-            continue
         prefix = _power_prefix_for(sym)
+        number = _canonical_number(sym)
+        if number is not None and number not in kept_canonical[prefix]:
+            # First canonical holder of this (prefix, number): keep it as-is.
+            kept_canonical[prefix].add(number)
+            continue
+        # Non-canonical ref, OR a later duplicate of an already-kept canonical:
+        # assign a fresh, project-globally-unique number.
         new_ref = _format_reference(prefix, _next(prefix))
         old_ref = str(sym["reference"])
         if old_ref == new_ref:
@@ -180,11 +212,22 @@ def _net_membership(netlist: Netlist) -> dict[frozenset[tuple[str, str]], int]:
     net's display name/code, since renumbering can legitimately change a net's
     name while leaving the electrical grouping intact.
 
+    ``#``-prefixed nodes (power/flag symbols) are **excluded** from the
+    membership: power symbols connect by *value*, so their designators are
+    electrically meaningless — the very thing this command renumbers.  Keeping
+    them would break the gate on cross-sheet duplicates: ``ref_rename`` is keyed
+    by the old reference *string*, so renaming one of two same-named ``#PWR40``
+    nodes translates **both** before-snapshot nodes, producing a spurious diff
+    that aborts an otherwise net-neutral repair.  Dropping power nodes compares
+    only the real-component connectivity that must stay invariant.
+
     Returns a multiset ``{membership_frozenset: count}``.
     """
     snapshot: dict[frozenset[tuple[str, str]], int] = {}
     for net in netlist.nets:
-        membership = frozenset((node.reference, node.pin) for node in net.nodes)
+        membership = frozenset(
+            (node.reference, node.pin) for node in net.nodes if not node.reference.startswith("#")
+        )
         snapshot[membership] = snapshot.get(membership, 0) + 1
     return snapshot
 

--- a/tests/test_sch_fix_annotation.py
+++ b/tests/test_sch_fix_annotation.py
@@ -290,6 +290,37 @@ class TestBuildRenamePlan:
         assert "u1" not in plan  # #PWR40 is canonical, unchanged
         assert plan["u2"]["new"] == "#PWR01"  # #PWR040 normalized, 40 reserved
 
+    def test_cross_sheet_canonical_duplicate_reassigned(self):
+        # Two *individually-canonical* #PWR40 symbols on different sheets are a
+        # real cross-sheet annotation collision even though each looks fine in
+        # isolation.  First-occurrence-wins: the first holder keeps #PWR40; the
+        # later duplicate is reassigned to a fresh, non-reserved number.
+        plan = build_rename_plan(
+            [
+                self._power("power:+3V3", "#PWR40", "u1"),
+                self._power("power:+5V", "#PWR40", "u2"),
+            ],
+        )
+        assert "u1" not in plan  # first holder keeps #PWR40
+        assert plan["u2"]["old"] == "#PWR40"
+        assert plan["u2"]["new"] == "#PWR01"  # reassigned, 40 reserved
+        assert len(plan) == 1  # exactly one of the duplicates renamed
+
+    def test_three_way_canonical_duplicate_reassigned(self):
+        # Three colliding #PWR40: only the first survives; the other two get
+        # distinct fresh numbers (no collision among the reassignments).
+        plan = build_rename_plan(
+            [
+                self._power("power:GND", "#PWR40", "u1"),
+                self._power("power:GND", "#PWR40", "u2"),
+                self._power("power:GND", "#PWR40", "u3"),
+            ],
+        )
+        assert "u1" not in plan
+        assert plan["u2"]["new"] == "#PWR01"
+        assert plan["u3"]["new"] == "#PWR02"
+        assert plan["u2"]["new"] != plan["u3"]["new"]
+
     def test_real_components_absent(self):
         # Only power symbols are passed to build_rename_plan by the caller;
         # a symbol that is already canonical is omitted from the plan.
@@ -335,16 +366,40 @@ class TestDiffNetMembership:
         diffs = diff_net_membership(before, after, ref_rename)
         assert diffs
 
-    def test_naive_comparison_would_falsely_diff(self):
-        # Without translation, the rename alone changes (ref, pin) identity;
-        # confirm the translation path (empty rename) *does* diff, proving the
-        # translation is what makes the neutral case pass.
+    def test_power_only_rename_neutral_even_without_translation(self):
+        # Power/flag nodes (#-prefixed) are dropped from the membership snapshot
+        # entirely: they connect by *value*, so their designators are
+        # electrically meaningless.  A pure power rename is therefore net-neutral
+        # even with an EMPTY rename map — the drop, not the translation, is what
+        # makes it neutral now.  A power-only net collapses to the empty
+        # membership on both sides.
         before = Netlist(nets=[_net("GND", ("#GNDD", "1"))])
         after = Netlist(nets=[_net("GND", ("#PWR01", "1"))])
-        diffs_no_translation = diff_net_membership(before, after, {})
-        assert diffs_no_translation  # naive: would (correctly) look changed
-        diffs_translated = diff_net_membership(before, after, {"#GNDD": "#PWR01"})
-        assert diffs_translated == []
+        assert diff_net_membership(before, after, {}) == []
+        assert diff_net_membership(before, after, {"#GNDD": "#PWR01"}) == []
+
+    def test_cross_sheet_duplicate_power_rename_is_neutral(self):
+        # Regression for the net-neutrality gate abort on cross-sheet duplicates.
+        # Two #PWR40 symbols on DIFFERENT rails (+3.3V vs +5V); the repair
+        # renames exactly one to #PWR41.  ref_rename is keyed by the shared old
+        # string "#PWR40", so the old membership (which included power nodes)
+        # would translate BOTH #PWR40 nodes to #PWR41 -> a spurious diff that
+        # aborts the whole repair.  With power nodes dropped, the gate compares
+        # only the real-component connectivity (U1.3 / U1.5), which is invariant.
+        before = Netlist(
+            nets=[
+                _net("+3V3", ("#PWR40", "1"), ("U1", "3")),
+                _net("+5V", ("#PWR40", "1"), ("U1", "5")),
+            ]
+        )
+        after = Netlist(
+            nets=[
+                _net("+3V3", ("#PWR40", "1"), ("U1", "3")),
+                _net("+5V", ("#PWR41", "1"), ("U1", "5")),
+            ]
+        )
+        ref_rename = {"#PWR40": "#PWR41"}
+        assert diff_net_membership(before, after, ref_rename) == []
 
 
 # ---------------------------------------------------------------------------
@@ -423,6 +478,47 @@ class TestRunFixAnnotationSkipNetCheck:
 
         # Real component reference untouched.
         assert '(property "Reference" "R1"' in root_after
+
+    def test_cross_sheet_canonical_duplicate_renames_exactly_one(self, tmp_path):
+        # Two individually-canonical #PWR40 power symbols on different rails,
+        # one per sheet.  The old per-symbol canonicality check skipped BOTH
+        # (each looked fine in isolation), so the annotation error survived the
+        # repair.  Project-wide uniqueness must reassign exactly one: the first
+        # holder (root, processed first) keeps #PWR40; the sub-sheet duplicate
+        # gets a fresh number.
+        root_text = _root_schematic(
+            _power_symbol_with_instance(
+                "power:+3V3", "#PWR40", "u-root-40", "root", f"/{ROOT_UUID}"
+            ),
+        )
+        sub_text = _sub_schematic(
+            _power_symbol_with_instance(
+                "power:+5V",
+                "#PWR40",
+                "u-sub-40",
+                "root",
+                f"/{ROOT_UUID}/{SUB_SHEET_UUID}",
+            ),
+        )
+        root = _write_hierarchy(tmp_path, root_text, sub_text)
+
+        rc = run_fix_annotation(root, backup=False, skip_net_check=True)
+        assert rc == 0
+
+        root_after = root.read_text()
+        sub_after = (tmp_path / "sub.kicad_sch").read_text()
+        combined = root_after + sub_after
+
+        # Exactly one symbol keeps #PWR40; the duplicate is reassigned to #PWR01.
+        assert combined.count('(property "Reference" "#PWR40"') == 1
+        assert combined.count('(property "Reference" "#PWR01"') == 1
+        # The first holder (root) keeps #PWR40; the sub-sheet duplicate renamed.
+        assert '(property "Reference" "#PWR40"' in root_after
+        assert '(property "Reference" "#PWR01"' in sub_after
+        # The renamed symbol's (instances) block is updated in step — no stale
+        # #PWR40 designator left behind for kicad-cli to keep flagging.
+        assert '(reference "#PWR01")' in sub_after
+        assert '(reference "#PWR40")' not in sub_after
 
     def test_backup_creates_bak_file(self, tmp_path):
         root_text = _root_schematic(


### PR DESCRIPTION
## Summary
`sch fix-annotation` missed pre-existing **cross-sheet duplicate** power references, so the `kicad-cli` annotation warning persisted after a repair. Two symbols on different sheets each holding a canonical `#PWR40` were both skipped because canonicality was judged one symbol at a time, with no project-global uniqueness check across the flattened hierarchy.

## Changes
- `build_rename_plan`: enforce **project-wide uniqueness** with first-occurrence-wins. The first holder of a `(prefix, number)` keeps it; any *later* symbol carrying the same canonical designator is treated as a cross-sheet duplicate and reassigned via the existing `_next()` machinery.
- `_existing_canonical_numbers`: seed the reserved set from **kept (first-occurrence)** canonicals only. A plain set previously collapsed two `#PWR40`s to `{40}`, discarding the collision multiplicity.
- `_net_membership`: drop `#`-prefixed (power) nodes from the net-neutrality gate snapshot. `ref_rename` is keyed by the old reference *string*, so renaming one of two same-named `#PWR40` nodes translated **both** before-snapshot nodes → spurious diff → aborted an otherwise net-neutral repair at the gate. Power connects by value, so its designators are electrically meaningless; the gate now compares only real-component connectivity.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Two identically-canonical `#PWR40` → exactly one renamed | ✅ | `test_cross_sheet_canonical_duplicate_reassigned` (first keeps `#PWR40`, second → `#PWR01`, `len(plan)==1`) |
| Project-global uniqueness across the flattened hierarchy | ✅ | `test_three_way_canonical_duplicate_reassigned` (two distinct reassignments) + end-to-end two-sheet fixture |
| Cross-sheet-duplicate rename is net-neutral at the gate | ✅ | `test_cross_sheet_duplicate_power_rename_is_neutral` (`#PWR40` on +3.3V/+5V, one renamed, `diff==[]`) |
| No regression to existing dedup/reservation/padding behavior | ✅ | Existing `TestBuildRenamePlan` / `TestDiffNetMembership` / e2e suites pass (33 passed) |

## Test Plan
- `uv run pytest tests/test_sch_fix_annotation.py` → **33 passed**.
- `uv run ruff check` + `ruff format --check` on both files → clean.
- `uv run mypy src/kicad_tools/cli/sch_fix_annotation.py` → no issues.
- Updated the now-obsolete `test_naive_comparison_would_falsely_diff` (its premise — that ref translation is what neutralizes a power rename — no longer holds now that power nodes are dropped) into `test_power_only_rename_neutral_even_without_translation`.

Closes #4415