### PR TITLE
fix(net-status): fuse pads across through-vias joining inner-layer segments

### DIFF
--- a/src/kicad_tools/analysis/net_status.py
+++ b/src/kicad_tools/analysis/net_status.py
@@ -719,61 +719,71 @@ class NetStatusAnalyzer:
                         graph[pad].add(other)
                         graph[other].add(pad)
 
-        # Connect segment chains to vias (Issue #1991 fix).
-        # If a segment endpoint coincides with a via position, all pads in
-        # that segment chain are electrically connected through the via.
-        # Without this link the pad->trace->via chain breaks whenever the
-        # zone-connection check fails (e.g. zone on inner layer, through-via
-        # not recognized, or via near zone boundary edge).
-        for component in segment_components:
-            component_endpoints: list[tuple[float, float]] = []
-            for seg_idx in component:
+        # Connect segment chains to vias, fusing chains that share a via
+        # (Issue #4429 — the pad-to-pad analogue of the #4229 zone/pour fix,
+        # originally the Issue #1991 pad->trace->via link).
+        #
+        # ``_build_segment_components`` only chains segments whose own copper
+        # touches, so a cross-layer path
+        #   pad -> F.Cu trace -> through-via -> In2.Cu trace -> through-via ->
+        #   F.Cu trace -> pad
+        # splits into three per-layer components that a shared through-via never
+        # fuses.  The old per-component loop bridged pads only *within* one
+        # component, so the far pad landed in its own island -> false
+        # ``incomplete`` even though kicad-cli DRC reports the copper continuous.
+        #
+        # We now merge components that share a via into extended chains
+        # (``_merge_chains_via_vias``) and, for each extended chain, fully
+        # connect every pad reachable through it: pads on the chain's segments
+        # plus pads sitting on any via the chain electrically touches.  A trace
+        # landing on the via *annular ring* (offset from centre, as a real
+        # router/hand-stitch does) is recognised by ``_segment_touches_via``'s
+        # copper-geometry fallback.
+        #
+        # The via<->segment bond is gated on ``_via_spans_layer`` so a
+        # blind/buried via does not fuse an inner-layer segment it does not
+        # electrically reach; through-vias span every layer and are unaffected.
+        #
+        # Shapely-absent (core-only) installs degrade gracefully:
+        # ``_segment_touches_via`` and ``_find_pads_touching_geom`` fall back to
+        # endpoint/centre proximity when the copper geometry is ``None``, so
+        # cross-component bridging via coincident via-centre endpoints still
+        # works without shapely (only ring landings need the geometry path).
+        extended_chains = self._merge_chains_via_vias(
+            segments, segment_components, vias, require_layer_span=True
+        )
+        for chain in extended_chains:
+            chain_pads: set[str] = set()
+            for seg_idx in chain:
                 seg = segments[seg_idx]
-                component_endpoints.append(seg.start)
-                component_endpoints.append(seg.end)
-
-            # Check if this segment chain's copper touches a via.
-            # Default: an endpoint within POSITION_TOLERANCE of the via center.
-            # Strict (Issue #4176): a segment copper polygon in the chain
-            # intersects the via copper geometry.
-            for via in vias:
                 if self.strict:
-                    via_geom = self._via_geom(via)
-                    touches_via = any(
-                        self._geoms_touch(self._segment_poly(segments[seg_idx]), via_geom)
-                        for seg_idx in component
+                    chain_pads.update(
+                        self._find_pads_touching_geom(self._segment_poly(seg), pad_positions)
                     )
                 else:
-                    touches_via = any(
-                        self._points_close(ep, via.position) for ep in component_endpoints
-                    )
-                if touches_via:
-                    # Collect all pads in this segment chain
-                    chain_pads: set[str] = set()
-                    for seg_idx in component:
-                        seg = segments[seg_idx]
-                        if self.strict:
-                            chain_pads.update(
-                                self._find_pads_touching_geom(
-                                    self._segment_poly(seg), pad_positions
-                                )
-                            )
-                        else:
-                            chain_pads.update(self._find_pads_at_point(seg.start, pad_positions))
-                            chain_pads.update(self._find_pads_at_point(seg.end, pad_positions))
-                    # Also include any pads at the via position itself
+                    chain_pads.update(self._find_pads_at_point(seg.start, pad_positions))
+                    chain_pads.update(self._find_pads_at_point(seg.end, pad_positions))
+
+            # Include pads sitting on any via this chain electrically touches
+            # (the via must span the touching segment's layer).
+            for via in vias:
+                via_geom = self._via_geom(via)
+                if any(
+                    self._segment_touches_via(segments[seg_idx], via, via_geom)
+                    and self._via_spans_layer(via.layers, segments[seg_idx].layer)
+                    for seg_idx in chain
+                ):
                     if self.strict:
-                        chain_pads.update(
-                            self._find_pads_touching_geom(self._via_geom(via), pad_positions)
-                        )
+                        chain_pads.update(self._find_pads_touching_geom(via_geom, pad_positions))
                     else:
                         chain_pads.update(self._find_pads_at_point(via.position, pad_positions))
-                    # Connect all pads in this chain through the via
-                    chain_list = list(chain_pads)
-                    for i, pad in enumerate(chain_list):
-                        for other in chain_list[i + 1 :]:
-                            graph[pad].add(other)
-                            graph[other].add(pad)
+
+            # Fully connect every pad reachable through this extended chain.
+            chain_list = list(chain_pads)
+            for i, pad in enumerate(chain_list):
+                for other in chain_list[i + 1 :]:
+                    graph[pad].add(other)
+                    graph[other].add(pad)
 
         # --- Zone / pour connectivity via per-fill-island grouping (#3914) ---
         # The previous model added every pad inside a zone *boundary* polygon
@@ -1083,6 +1093,7 @@ class NetStatusAnalyzer:
         segments: list,
         segment_components: list[set[int]],
         vias: list,
+        require_layer_span: bool = False,
     ) -> list[set[int]]:
         """Merge segment components that share a via into extended chains.
 
@@ -1096,6 +1107,12 @@ class NetStatusAnalyzer:
         The merge is purely additive connectivity: it never fuses two chains
         that don't share a via, so genuinely separate copper stays separate and
         the #3914 "don't union disjoint fills" guarantee is unaffected.
+
+        When ``require_layer_span`` is ``True`` a via only bonds a segment whose
+        layer the via electrically spans (``_via_spans_layer``), so a
+        blind/buried via does not fuse an inner-layer segment it cannot reach
+        (Issue #4429).  The default (``False``) preserves the layer-agnostic
+        behaviour the zone/pour path (#4229) relies on.
         """
         n = len(segment_components)
         parent = list(range(n))
@@ -1115,7 +1132,14 @@ class NetStatusAnalyzer:
             via_geom = self._via_geom(via)
             touching: list[int] = []
             for ci, component in enumerate(segment_components):
-                if any(self._segment_touches_via(segments[s], via, via_geom) for s in component):
+                if any(
+                    self._segment_touches_via(segments[s], via, via_geom)
+                    and (
+                        not require_layer_span
+                        or self._via_spans_layer(via.layers, segments[s].layer)
+                    )
+                    for s in component
+                ):
                     touching.append(ci)
             for other in touching[1:]:
                 union(touching[0], other)

--- a/tests/test_analysis_net_status.py
+++ b/tests/test_analysis_net_status.py
@@ -1865,3 +1865,166 @@ class TestZeroFillZoneConnectivity:
         assert gnd.status == "complete", (
             f"Fully filled zone should connect both pads; got {gnd.status}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Issue #4429 — through-via + inner-layer segment connectivity (no zone)
+# ---------------------------------------------------------------------------
+
+# Pad-to-pad cross-layer path with NO zone:
+#   U1.12 (F.Cu) -> through-via -> In2.Cu segment (landed on the via rings) ->
+#   through-via -> F.Cu segment -> U2.3 (F.Cu)
+# The inner-layer trace endpoints sit 0.15 mm off the via centres (on the via
+# annular ring), so default endpoint-proximity (POSITION_TOLERANCE = 0.01 mm)
+# cannot chain across layers -- the fix must recognise the through-via as
+# fusing the two different-layer segment components (Issue #4429).
+THROUGH_VIA_INNER_SEGMENT_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (2 "In2.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "OC_TRIP_N")
+
+  (footprint "R_0402"
+    (layer "F.Cu")
+    (at 20 15)
+    (property "Reference" "U1")
+    (pad "12" smd rect (at 0 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "OC_TRIP_N"))
+  )
+
+  (footprint "R_0402"
+    (layer "F.Cu")
+    (at 35 15)
+    (property "Reference" "U2")
+    (pad "3" smd rect (at 0 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "OC_TRIP_N"))
+  )
+
+  (via (at 20 15) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 1))
+  (via (at 30 15) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 1))
+
+  (segment (start 20.15 15) (end 29.85 15) (width 0.25) (layer "In2.Cu") (net 1))
+  (segment (start 30 15) (end 35 15) (width 0.25) (layer "F.Cu") (net 1))
+)
+"""
+
+
+# Edge case: a blind F.Cu/In1.Cu via must NOT bridge an In2.Cu segment it does
+# not electrically span.  Same shape as above but every via is blind
+# F.Cu/In1.Cu, so the inner In2.Cu run is electrically isolated from the F.Cu
+# pads and the far pad stays unconnected (guards against over-connecting).
+BLIND_VIA_INNER_SEGMENT_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (2 "In2.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "OC_TRIP_N")
+
+  (footprint "R_0402"
+    (layer "F.Cu")
+    (at 20 15)
+    (property "Reference" "U1")
+    (pad "12" smd rect (at 0 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "OC_TRIP_N"))
+  )
+
+  (footprint "R_0402"
+    (layer "F.Cu")
+    (at 35 15)
+    (property "Reference" "U2")
+    (pad "3" smd rect (at 0 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "OC_TRIP_N"))
+  )
+
+  (via (at 20 15) (size 0.6) (drill 0.3) (layers "F.Cu" "In1.Cu") (net 1))
+  (via (at 30 15) (size 0.6) (drill 0.3) (layers "F.Cu" "In1.Cu") (net 1))
+
+  (segment (start 20.15 15) (end 29.85 15) (width 0.25) (layer "In2.Cu") (net 1))
+  (segment (start 30 15) (end 35 15) (width 0.25) (layer "F.Cu") (net 1))
+)
+"""
+
+
+@pytest.fixture
+def through_via_inner_segment_pcb(tmp_path: Path) -> Path:
+    """PCB: F.Cu pad -> through-via -> In2.Cu segment -> through-via -> F.Cu pad."""
+    pcb_file = tmp_path / "through_via_inner_segment.kicad_pcb"
+    pcb_file.write_text(THROUGH_VIA_INNER_SEGMENT_PCB)
+    return pcb_file
+
+
+@pytest.fixture
+def blind_via_inner_segment_pcb(tmp_path: Path) -> Path:
+    """PCB: same topology but blind F.Cu/In1.Cu vias that cannot reach In2.Cu."""
+    pcb_file = tmp_path / "blind_via_inner_segment.kicad_pcb"
+    pcb_file.write_text(BLIND_VIA_INNER_SEGMENT_PCB)
+    return pcb_file
+
+
+class TestThroughViaInnerSegmentConnectivity:
+    """Issue #4429: through-vias joining inner-layer segment runs.
+
+    A through-via joining two different-layer segment components must fuse the
+    pads they carry, so a ``pad -> trace -> via -> inner-trace -> via -> trace
+    -> pad`` path reports ``complete`` (matching kicad-cli DRC) instead of a
+    false open.  This is the pad-to-pad analogue of the #4229 zone/pour fix.
+    """
+
+    def test_default_mode_complete(self, through_via_inner_segment_pcb: Path):
+        """Default (non-strict) mode reports the cross-layer path complete."""
+        analyzer = NetStatusAnalyzer(through_via_inner_segment_pcb)
+        result = analyzer.analyze()
+
+        net = result.get_net("OC_TRIP_N")
+        assert net is not None
+        assert net.total_pads == 2
+        assert net.unconnected_count == 0, (
+            "through-via -> In2.Cu segment -> through-via must connect both pads; "
+            f"unconnected: {[p.full_name for p in net.unconnected_pads]}"
+        )
+        assert net.status == "complete", f"expected complete, got {net.status}"
+
+    def test_strict_mode_complete(self, through_via_inner_segment_pcb: Path):
+        """Strict (real-geometry) mode also reports the path complete."""
+        analyzer = NetStatusAnalyzer(through_via_inner_segment_pcb, strict=True)
+        result = analyzer.analyze()
+
+        net = result.get_net("OC_TRIP_N")
+        assert net is not None
+        assert net.total_pads == 2
+        assert net.unconnected_count == 0, (
+            "strict mode must also fuse the through-via inner-segment path; "
+            f"unconnected: {[p.full_name for p in net.unconnected_pads]}"
+        )
+        assert net.status == "complete", f"expected complete, got {net.status}"
+
+    def test_blind_via_does_not_bridge_unspanned_inner_segment(
+        self, blind_via_inner_segment_pcb: Path
+    ):
+        """A blind F.Cu/In1.Cu via must NOT bridge an In2.Cu segment.
+
+        The layer-span gate keeps a via from fusing an inner-layer segment it
+        does not electrically reach, so the far pad honestly stays unconnected.
+        """
+        analyzer = NetStatusAnalyzer(blind_via_inner_segment_pcb)
+        result = analyzer.analyze()
+
+        net = result.get_net("OC_TRIP_N")
+        assert net is not None
+        assert net.total_pads == 2
+        assert net.status != "complete", (
+            "blind F.Cu/In1.Cu via must not over-connect an In2.Cu segment; "
+            f"got status={net.status}"
+        )
+        assert net.unconnected_count == 1

--- a/tests/test_connectivity_reachability_4165.py
+++ b/tests/test_connectivity_reachability_4165.py
@@ -106,3 +106,26 @@ def test_pcb_schema_segment_shape_via_start_end():
     pads = [(0.0, 0.0), (10.0, 0.0)]
     segs = [_PcbSeg((0.0, 0.0), (10.0, 0.0))]
     assert check_net_pad_connectivity(pads, segments=segs) == (2, 2)
+
+
+def test_through_via_inner_layer_chain_complete():
+    """Issue #4429 (confirming): the router oracle already handles this.
+
+    ``pad -> In2.Cu trace -> through-via -> F.Cu trace -> pad`` with the vias
+    at the segment endpoints: the layer-agnostic via union joins the two
+    different-layer segments into one component, so both pads are connected.
+    This confirms the router accounting is NOT affected by the per-component
+    layer bug that #4429 fixes in ``NetStatusAnalyzer``.
+    """
+    pads = [(20.0, 15.0), (35.0, 15.0)]
+    segs = [
+        _seg(20.0, 15.0, 30.0, 15.0, layer=Layer.IN2_CU),
+        _seg(30.0, 15.0, 35.0, 15.0, layer=Layer.F_CU),
+    ]
+    # Without vias the two segments are on different layers -> disjoint.
+    assert check_net_pad_connectivity(pads, segments=segs) == (1, 2)
+    vias = [
+        Via(x=20.0, y=15.0, drill=0.3, diameter=0.6, layers=(Layer.F_CU, Layer.B_CU)),
+        Via(x=30.0, y=15.0, drill=0.3, diameter=0.6, layers=(Layer.F_CU, Layer.B_CU)),
+    ]
+    assert check_net_pad_connectivity(pads, segments=segs, vias=vias) == (2, 2)


### PR DESCRIPTION
## Summary

`kct net-status` false-reported a pad unconnected on a net that is
electrically continuous through a `through-via → inner-layer segment →
through-via` chain, while `kicad-cli pcb drc --refill-zones` reports 0
unconnected items. The false open blocked ship-ready gating on 4-layer
boards that reach an inner-layer signal segment through a through-via.

**Root cause:** `NetStatusAnalyzer._build_connectivity_graph`'s "Connect
segment chains to vias" block bridged a via only *within a single segment
component*. A cross-layer path
`pad → F.Cu trace → through-via → In2.Cu trace → through-via → F.Cu trace → pad`
splits into three per-layer segment components, and the shared through-vias
never fused them, so the far pad landed in its own island. This is the
pad-to-pad analogue of #4229 (which fixed `pad→trace→via→pour` for the
zone path).

## Changes

- `src/kicad_tools/analysis/net_status.py`:
  - Replaced the per-component "Connect segment chains to vias" block with a
    **per-extended-chain** bridge that reuses the zone-path primitives
    `_merge_chains_via_vias` (union-find over components that share a via)
    and `_segment_touches_via` (recognises trace endpoints landing on the via
    annular ring, not just dead-centre). These helpers were previously wired
    only into the zone/pour path.
  - Added an optional `require_layer_span` flag to `_merge_chains_via_vias`
    (default `False`, so the existing zone caller is byte-for-byte unchanged).
    The pad-to-pad path passes `True` so the via↔segment bond is gated on
    `_via_spans_layer` — a blind/buried via does not fuse an inner-layer
    segment it cannot electrically reach. Through-vias span all layers and
    are unaffected.
  - Applies to **both** default and strict modes. Degrades gracefully when
    shapely is absent (endpoint/centre-proximity fallback; only ring landings
    need geometry).
- `tests/test_analysis_net_status.py`: added `TestThroughViaInnerSegmentConnectivity`
  (through-via + In2.Cu-segment fixtures, no zone).
- `tests/test_connectivity_reachability_4165.py`: added a confirming test that
  the router union-find oracle (`check_net_pad_connectivity`) already reports
  the same topology complete — **no router code change** (secondary ask verified).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Through-via inner-segment net reports `complete`, 0 unconnected (default) | ✅ | `test_default_mode_complete`; fails pre-fix (reproduces `incomplete`) |
| Same in strict mode | ✅ | `test_strict_mode_complete` |
| Blind/buried via must NOT bridge a non-spanned inner segment | ✅ | `test_blind_via_does_not_bridge_unspanned_inner_segment` (stays incomplete via `_via_spans_layer` gate) |
| No new false `complete`; #3914 / #4229 cases unaffected | ✅ | full `test_analysis_net_status.py`, `test_net_status_strict.py`, `test_net_status.py` suites pass (135 tests) |
| Router accounting confirmed unaffected | ✅ | `test_through_via_inner_layer_chain_complete` (router oracle already complete) |

## Test Plan

- New default-mode test **fails before** the source fix (`incomplete`, 1 pad
  unconnected) and **passes after** — confirmed by stashing the source change.
- `uv run pytest tests/test_analysis_net_status.py tests/test_net_status_strict.py tests/test_net_status.py tests/test_connectivity_reachability_4165.py` → 135 passed.
- `uv run ruff check` / `ruff format --check` clean on all changed files.
- `uv run mypy` clean on `net_status.py` and `router/connectivity.py`.

Closes #4429