### PR TITLE
feat(check): general .kct_waivers.json waiver mechanism for any rule

### DIFF
--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -1282,6 +1282,20 @@ def main(argv: list[str] | None = None) -> int:
             "omitted (Issue #4137)."
         ),
     )
+    parser.add_argument(
+        "--waivers",
+        dest="waivers",
+        default=None,
+        help=(
+            "Path to a general .kct_waivers.json sidecar (schema version 2) "
+            "waiving findings for ANY rule by matching the violation's items "
+            "(and optional nets) set (see kicad_tools.validate.rules.waivers). "
+            "Matched findings report as WAIVED instead of failing the gate. "
+            "Auto-discovered next to the board when this flag is omitted "
+            "(Issue #4417). Waived findings keep severity 'error' in JSON so "
+            "the kct audit manufacturing gate stays blocking by default."
+        ),
+    )
     # Issue #3061: auto-derive the pad_grid tolerance from each board's
     # pad-offset histogram by default for the CLI.  Users can opt back into
     # the fixed-0.05mm behaviour with --pad-grid-strict, or pin a custom
@@ -1531,6 +1545,46 @@ def main(argv: list[str] | None = None) -> int:
                     file=sys.stderr,
                 )
 
+    # Load optional general waivers sidecar (Issue #4417).  Same load/degrade
+    # contract as --courtyard-waivers above: an explicit --waivers path always
+    # wins and a malformed explicit file is a hard error; an auto-discovered
+    # .kct_waivers.json that fails to parse degrades gracefully (warn + zero
+    # waivers).  Applied centrally after check_all() (below), so it covers any
+    # rule id -- not just courtyards_overlap.
+    from kicad_tools.validate.rules.waivers import (
+        discover_waivers_sidecar,
+        load_waivers,
+    )
+
+    general_waivers = None
+    gw_explicit = args.waivers is not None
+    if gw_explicit:
+        gw_path: Path | None = Path(args.waivers).resolve()
+    else:
+        gw_path = discover_waivers_sidecar(pcb_path)
+
+    if gw_path is not None:
+        if not gw_path.exists():
+            print(f"Error: waivers file not found: {gw_path}", file=sys.stderr)
+            return 1
+        try:
+            general_waivers = load_waivers(gw_path)
+        except ValueError as e:
+            if gw_explicit:
+                print(f"Error: {e}", file=sys.stderr)
+                return 1
+            print(
+                f"WARNING: ignoring malformed waivers sidecar {gw_path}: {e}",
+                file=sys.stderr,
+            )
+            general_waivers = None
+        else:
+            if not gw_explicit:
+                print(
+                    f"[INFO] auto-loaded waivers sidecar: {gw_path}",
+                    file=sys.stderr,
+                )
+
     # Issue #4321 (Tier 1/2): resolve the loaded net-class-map's user keys
     # onto the board's actual net names *before* handing the map to
     # DRCChecker, mirroring ``route_cmd._apply_net_class_map_sidecar``.
@@ -1690,6 +1744,18 @@ def main(argv: list[str] | None = None) -> int:
         pad_grid_threshold=pad_grid_threshold,
         pad_grid_auto_derive=pad_grid_auto_derive,
     )
+
+    # Issue #4417: apply general waivers centrally, once, AFTER all checks run.
+    # This marks matching findings waived (visible, counted separately, excluded
+    # from error_count) and appends a waiver_unused info advisory for any stale
+    # entry.  It intentionally runs on the raw results before the errors-only
+    # filter and exit-code computation below.  The courtyard rule keeps its own
+    # per-rule waiver path (Issue #4137); apply_waivers skips already-waived
+    # findings, so the two paths compose without double-waiving.
+    if general_waivers is not None:
+        from kicad_tools.validate.rules.waivers import apply_waivers
+
+        apply_waivers(results, general_waivers)
 
     # Issue #4321 (Tier 3): fail loud when an ampacity target was declared
     # but never evaluated.  A declared ``target_ampacity`` that matched zero

--- a/src/kicad_tools/validate/rules/waivers.py
+++ b/src/kicad_tools/validate/rules/waivers.py
@@ -1,0 +1,305 @@
+"""General ``.kct_waivers.json`` waiver mechanism for ``kct check`` (Issue #4417).
+
+This generalizes the pair-level courtyard waiver infrastructure that shipped as
+Issue #4137 (``.courtyard_waivers.json``, see
+:mod:`kicad_tools.validate.rules.courtyard_waivers`) to a *central*,
+rule-agnostic waiver step: any ``rule_id`` emitted by the checker can be waived
+by matching the violation's ``items`` (and, optionally, ``nets``) *set* against
+a committed, human-editable sidecar.
+
+Unlike the courtyard loader -- which is bound to the single ``courtyards_overlap``
+rule, matches a fixed unordered *ref pair*, and applies waivers *inside* the
+rule while it runs -- this module:
+
+* accepts **any** ``rule`` id (no hard-coded rule allow-list),
+* matches on the violation's ``items`` set (exact set, order-insensitive) and an
+  optional ``nets`` set (for net-scoped findings such as clearance shorts), and
+* applies waivers as a **post-check** step (:func:`apply_waivers`) that runs once
+  after ``DRCChecker.check_all()``, replacing each matched finding with a
+  ``waived=True`` copy.
+
+Schema (``version == 2``)::
+
+    {
+      "version": 2,
+      "waivers": [
+        {
+          "rule": "courtyards_overlap",
+          "items": ["C52", "U10"],
+          "reason": "EE-mandated tight decoupling, <=2mm from U10 VCC",
+          "issue": "chorus#18"
+        },
+        {
+          "rule": "clearance_pad_pad",
+          "nets": ["GND", "VBUS"],
+          "reason": "documented star-ground tie",
+          "issue": "chorus#20"
+        }
+      ]
+    }
+
+Matching semantics (exact-set, order-insensitive):
+
+* A waiver matches a violation when ``violation.rule_id == waiver.rule`` **and**,
+  when the waiver names ``items``, ``set(violation.items) == set(waiver.items)``
+  **and**, when the waiver names ``nets``, ``set(violation.nets) == set(waiver.nets)``.
+* Exact-set (not subset): a 2-item entry does **NOT** waive a 3-item finding.
+* At least one of ``items`` / ``nets`` must be present so a waiver cannot match
+  every finding for a rule blindly.
+
+Manufacturing-gate safety (mirrors the #4403 ``gate_passed`` precedent): a
+waived finding keeps its underlying ``severity`` (typically ``"error"``) in the
+JSON output while reporting ``status: "waived"``.  ``kct check``'s own exit gate
+keys off ``is_error`` (waived excluded -> intended relief), but ``kct audit``
+re-parses the JSON ``severity`` field and ignores ``waived``, so a waived
+finding **stays blocking in the manufacturing gate by default**.
+
+Discovery / loading contract mirrors ``courtyard_waivers`` exactly:
+
+* An explicit ``--waivers <path>`` always wins and a malformed explicit file is a
+  hard error.
+* An auto-discovered ``.kct_waivers.json`` sidecar that fails to parse degrades
+  gracefully (the caller warns and continues with zero waivers).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any
+
+from kicad_tools.validate.violations import DRCResults, DRCViolation
+
+# The only schema version understood by this loader.  Reject other values with
+# a clear error rather than silently misinterpreting a future schema.
+SUPPORTED_VERSION = 2
+
+# Rule id for the advisory "unused waiver" info finding emitted when a loaded
+# waiver entry matches no violation on the board (generalization of the
+# courtyard-specific ``courtyard_waiver_unused``).
+WAIVER_UNUSED_RULE_ID = "waiver_unused"
+
+
+@dataclass(frozen=True)
+class Waiver:
+    """A single general waiver entry.
+
+    Attributes:
+        rule: The ``rule_id`` this waiver applies to (any checker rule).
+        items: Unordered set of item references (e.g. ``{"C52", "U10"}``).
+            Empty when the waiver is matched purely by ``nets``.
+        nets: Unordered set of net names.  Empty when the waiver is matched
+            purely by ``items``.
+        reason: Human-readable justification (non-empty).
+        issue: Tracking reference, e.g. ``"chorus#18"`` (non-empty).
+    """
+
+    rule: str
+    items: frozenset[str]
+    nets: frozenset[str]
+    reason: str
+    issue: str
+
+    def matches(self, violation: DRCViolation) -> bool:
+        """Return True when this waiver applies to ``violation``.
+
+        Exact-set, order-insensitive match on ``items`` and (optionally)
+        ``nets``.  An empty ``items`` / ``nets`` on the waiver means "do not
+        constrain on that axis"; at least one axis is always populated (the
+        loader enforces it).
+        """
+        if violation.rule_id != self.rule:
+            return False
+        if self.items and frozenset(violation.items) != self.items:
+            return False
+        if self.nets and frozenset(violation.nets) != self.nets:
+            return False
+        return True
+
+
+@dataclass
+class Waivers:
+    """A loaded, validated collection of general waiver entries."""
+
+    entries: list[Waiver] = field(default_factory=list)
+
+    def match(self, violation: DRCViolation) -> Waiver | None:
+        """Return the first waiver matching ``violation``, or ``None``."""
+        for entry in self.entries:
+            if entry.matches(violation):
+                return entry
+        return None
+
+    def __len__(self) -> int:
+        return len(self.entries)
+
+
+def waivers_from_dict(data: Any) -> Waivers:
+    """Build :class:`Waivers` from parsed JSON data.
+
+    Raises:
+        ValueError: if the top-level structure, ``version``, or any waiver
+            entry is malformed.  The message identifies the offending entry's
+            index so a human can fix the file quickly.
+    """
+    if not isinstance(data, dict):
+        raise ValueError(f"waivers file must be a JSON object, got {type(data).__name__}")
+
+    if "version" not in data:
+        raise ValueError("waivers file is missing the required 'version' key")
+    version = data["version"]
+    if version != SUPPORTED_VERSION:
+        raise ValueError(
+            f"unsupported waivers version {version!r} "
+            f"(this build understands version {SUPPORTED_VERSION})"
+        )
+
+    raw_waivers = data.get("waivers", [])
+    if not isinstance(raw_waivers, list):
+        raise ValueError("waivers 'waivers' must be a list")
+
+    entries: list[Waiver] = []
+    for idx, raw in enumerate(raw_waivers):
+        entries.append(_parse_entry(idx, raw))
+
+    return Waivers(entries=entries)
+
+
+def _parse_str_set(where: str, key: str, raw: Any) -> frozenset[str]:
+    """Validate an optional list-of-non-empty-strings field into a frozenset."""
+    if raw is None:
+        return frozenset()
+    if not isinstance(raw, list):
+        raise ValueError(f"{where} '{key}' must be a list of strings")
+    if not all(isinstance(x, str) and x for x in raw):
+        raise ValueError(f"{where} '{key}' entries must be non-empty strings")
+    return frozenset(raw)
+
+
+def _parse_entry(idx: int, raw: Any) -> Waiver:
+    """Validate and build one waiver entry, raising on any defect."""
+    where = f"waiver #{idx}"
+    if not isinstance(raw, dict):
+        raise ValueError(f"{where} must be an object, got {type(raw).__name__}")
+
+    rule = raw.get("rule")
+    if not isinstance(rule, str) or not rule:
+        raise ValueError(f"{where} is missing a non-empty string 'rule'")
+
+    items = _parse_str_set(where, "items", raw.get("items"))
+    nets = _parse_str_set(where, "nets", raw.get("nets"))
+    if not items and not nets:
+        raise ValueError(f"{where} must name at least one 'items' or 'nets' entry")
+
+    reason = raw.get("reason")
+    if not isinstance(reason, str) or not reason.strip():
+        raise ValueError(f"{where} is missing a non-empty 'reason'")
+
+    issue = raw.get("issue")
+    if not isinstance(issue, str) or not issue.strip():
+        raise ValueError(f"{where} is missing a non-empty 'issue'")
+
+    return Waiver(rule=rule, items=items, nets=nets, reason=reason, issue=issue)
+
+
+def load_waivers(path: Path) -> Waivers:
+    """Load and validate a ``.kct_waivers.json`` file.
+
+    Raises:
+        ValueError: if the file is not valid JSON or fails schema validation.
+    """
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        raise ValueError(f"parsing waivers JSON: {e}") from e
+    return waivers_from_dict(data)
+
+
+def discover_waivers_sidecar(pcb_path: Path) -> Path | None:
+    """Probe conventional locations for a ``.kct_waivers.json`` sidecar.
+
+    Mirrors :func:`courtyard_waivers.discover_courtyard_waivers_sidecar`: probe
+    the PCB directory, then a sibling ``output/`` subdir, then ``../output/``.
+
+    Returns:
+        The first existing candidate path, or ``None`` when no sidecar found.
+    """
+    pcb_dir = pcb_path.parent
+    filename = ".kct_waivers.json"
+    candidates = [
+        pcb_dir / filename,
+        pcb_dir / "output" / filename,
+        pcb_dir.parent / "output" / filename,
+    ]
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def apply_waivers(results: DRCResults, waivers: Waivers) -> None:
+    """Apply general waivers to ``results`` in place (post-check step).
+
+    For each non-waived violation that matches a waiver entry, replace it with a
+    ``waived=True`` copy carrying the entry's ``reason`` / ``issue``.  Because
+    :class:`DRCViolation` is frozen, a new instance is built via
+    :func:`dataclasses.replace`.  Findings already waived (e.g. by the
+    per-rule courtyard path) are left untouched.
+
+    Any waiver entry that matched no finding gets a :data:`WAIVER_UNUSED_RULE_ID`
+    ``info`` advisory appended so stale entries stay visible without failing the
+    gate.
+    """
+    if not waivers.entries:
+        return
+
+    used: set[int] = set()
+    rebuilt: list[DRCViolation] = []
+    for v in results.violations:
+        if v.waived:
+            rebuilt.append(v)
+            continue
+        matched_idx: int | None = None
+        for idx, entry in enumerate(waivers.entries):
+            if entry.matches(v):
+                matched_idx = idx
+                break
+        if matched_idx is None:
+            rebuilt.append(v)
+            continue
+        entry = waivers.entries[matched_idx]
+        used.add(matched_idx)
+        rebuilt.append(
+            replace(
+                v,
+                waived=True,
+                waiver_reason=entry.reason,
+                waiver_issue=entry.issue,
+            )
+        )
+
+    for idx, entry in enumerate(waivers.entries):
+        if idx in used:
+            continue
+        scope_parts = []
+        if entry.items:
+            scope_parts.append(f"items={sorted(entry.items)}")
+        if entry.nets:
+            scope_parts.append(f"nets={sorted(entry.nets)}")
+        scope = ", ".join(scope_parts)
+        rebuilt.append(
+            DRCViolation(
+                rule_id=WAIVER_UNUSED_RULE_ID,
+                severity="info",
+                message=(
+                    f"Waiver for rule {entry.rule!r} ({scope}) matched no finding "
+                    f"(tracking {entry.issue}); the underlying defect may already "
+                    "be resolved, or the rule/refs may have changed."
+                ),
+                items=tuple(sorted(entry.items)),
+                nets=tuple(sorted(entry.nets)),
+            )
+        )
+
+    results.violations = rebuilt

--- a/tests/test_cli_check_waivers.py
+++ b/tests/test_cli_check_waivers.py
@@ -1,0 +1,203 @@
+"""End-to-end CLI tests for ``kct check --waivers`` (Issue #4417).
+
+Exercises the general ``.kct_waivers.json`` sidecar against a real board with an
+overlapping-courtyard finding: a matching waiver flips the exit code, the
+finding is reported WAIVED (non-blocking) yet keeps ``severity: error`` in the
+JSON -- so the ``kct audit`` manufacturing gate (which re-parses that JSON and
+ignores ``waived``) stays blocking by default.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from kicad_tools.cli import check_cmd
+from kicad_tools.drc.report import parse_json_report
+
+pytest.importorskip("shapely")
+
+
+def _board_file(tmp_path, *, refs_positions):
+    """Write a minimal .kicad_pcb with overlapping F.CrtYd footprints."""
+    fps = []
+    for ref, (x, y) in refs_positions:
+        fps.append(
+            f"""  (footprint "TestFP" (layer "F.Cu")
+    (at {x} {y})
+    (property "Reference" "{ref}" (at 0 0) (layer "F.SilkS"))
+    (fp_rect (start -1 -1) (end 1 1) (stroke (width 0.05) (type solid)) (layer "F.CrtYd"))
+  )"""
+        )
+    content = (
+        "(kicad_pcb (version 20240108) (generator test)\n"
+        '  (layers (0 "F.Cu" signal) (31 "B.Cu" signal))\n' + "\n".join(fps) + "\n)\n"
+    )
+    path = tmp_path / "board.kicad_pcb"
+    path.write_text(content)
+    return path
+
+
+def _write_waiver(path, waivers):
+    path.write_text(json.dumps({"version": 2, "waivers": waivers}))
+
+
+class TestCliWaivers:
+    def test_matching_waiver_flips_exit_and_json_status(self, tmp_path, capsys):
+        board = _board_file(tmp_path, refs_positions=[("U1", (10.0, 10.0)), ("C1", (11.0, 10.0))])
+        waiver = tmp_path / "w.json"
+        _write_waiver(
+            waiver,
+            [
+                {
+                    "rule": "courtyards_overlap",
+                    "items": ["U1", "C1"],
+                    "reason": "EE-mandated tight decoupling",
+                    "issue": "chorus#18",
+                }
+            ],
+        )
+        rc = check_cmd.main(
+            [
+                str(board),
+                "--only",
+                "courtyard_overlap",
+                "--waivers",
+                str(waiver),
+                "--format",
+                "json",
+                "--drc-only",
+            ]
+        )
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert rc == 0
+        assert data["summary"]["errors"] == 0
+        assert data["summary"]["waived"] == 1
+        assert data["summary"]["passed"] is True
+        waived_v = [v for v in data["violations"] if v.get("waived")]
+        assert len(waived_v) == 1
+        # Load-bearing manufacturing-gate safety: status flips to "waived" but
+        # the underlying severity stays "error".
+        assert waived_v[0]["status"] == "waived"
+        assert waived_v[0]["severity"] == "error"
+        assert waived_v[0]["waiver_reason"] == "EE-mandated tight decoupling"
+        assert waived_v[0]["waiver_issue"] == "chorus#18"
+
+    def test_manufacturing_gate_still_blocks_on_waived(self, tmp_path):
+        """The audit re-parser reads severity and ignores waived -> stays blocking."""
+        board = _board_file(tmp_path, refs_positions=[("U1", (10.0, 10.0)), ("C1", (11.0, 10.0))])
+        waiver = tmp_path / "w.json"
+        _write_waiver(
+            waiver,
+            [
+                {
+                    "rule": "courtyards_overlap",
+                    "items": ["U1", "C1"],
+                    "reason": "intentional",
+                    "issue": "x#1",
+                }
+            ],
+        )
+        out_json = tmp_path / "out.json"
+        check_cmd.main(
+            [
+                str(board),
+                "--only",
+                "courtyard_overlap",
+                "--waivers",
+                str(waiver),
+                "--output",
+                str(out_json),
+                "--drc-only",
+            ]
+        )
+        report = parse_json_report(out_json.read_text())
+        # Waiver relieved the kct-check gate, but the audit-facing report still
+        # counts the finding as an error (severity-keyed).
+        assert report.error_count == 1
+
+    def test_no_waiver_still_fails(self, tmp_path, capsys):
+        board = _board_file(tmp_path, refs_positions=[("U1", (10.0, 10.0)), ("C1", (11.0, 10.0))])
+        rc = check_cmd.main(
+            [str(board), "--only", "courtyard_overlap", "--format", "json", "--drc-only"]
+        )
+        data = json.loads(capsys.readouterr().out)
+        assert rc == 2
+        assert data["summary"]["errors"] == 1
+        assert data["summary"]["passed"] is False
+
+    def test_explicit_malformed_waiver_hard_error(self, tmp_path):
+        board = _board_file(tmp_path, refs_positions=[("U1", (10.0, 10.0)), ("C1", (11.0, 10.0))])
+        bad = tmp_path / "bad.json"
+        bad.write_text("{not json")
+        rc = check_cmd.main([str(board), "--only", "courtyard_overlap", "--waivers", str(bad)])
+        assert rc == 1
+
+    def test_explicit_missing_waiver_hard_error(self, tmp_path):
+        board = _board_file(tmp_path, refs_positions=[("U1", (10.0, 10.0)), ("C1", (11.0, 10.0))])
+        rc = check_cmd.main(
+            [
+                str(board),
+                "--only",
+                "courtyard_overlap",
+                "--waivers",
+                str(tmp_path / "does-not-exist.json"),
+            ]
+        )
+        assert rc == 1
+
+    def test_auto_discovered_malformed_degrades(self, tmp_path, capsys):
+        board = _board_file(tmp_path, refs_positions=[("U1", (10.0, 10.0)), ("C1", (11.0, 10.0))])
+        # Auto-discovered sidecar next to the board is malformed -> warn + continue.
+        (tmp_path / ".kct_waivers.json").write_text("{not json")
+        rc = check_cmd.main(
+            [str(board), "--only", "courtyard_overlap", "--format", "json", "--drc-only"]
+        )
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        # Degraded to zero waivers: the overlap still fails.
+        assert rc == 2
+        assert data["summary"]["errors"] == 1
+        assert "ignoring malformed waivers sidecar" in captured.err
+
+    def test_unused_waiver_advisory(self, tmp_path, capsys):
+        board = _board_file(tmp_path, refs_positions=[("U1", (10.0, 10.0)), ("C1", (11.0, 10.0))])
+        waiver = tmp_path / "w.json"
+        _write_waiver(
+            waiver,
+            [
+                {
+                    "rule": "courtyards_overlap",
+                    "items": ["U1", "C1"],
+                    "reason": "matches",
+                    "issue": "x#1",
+                },
+                {
+                    "rule": "courtyards_overlap",
+                    "items": ["X9", "Y9"],
+                    "reason": "stale",
+                    "issue": "x#2",
+                },
+            ],
+        )
+        rc = check_cmd.main(
+            [
+                str(board),
+                "--only",
+                "courtyard_overlap",
+                "--waivers",
+                str(waiver),
+                "--format",
+                "json",
+                "--drc-only",
+            ]
+        )
+        data = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert data["summary"]["waived"] == 1
+        unused = [v for v in data["violations"] if v["rule_id"] == "waiver_unused"]
+        assert len(unused) == 1
+        assert unused[0]["severity"] == "info"
+        assert "x#2" in unused[0]["message"]

--- a/tests/test_validate_waivers.py
+++ b/tests/test_validate_waivers.py
@@ -1,0 +1,309 @@
+"""Tests for the general ``.kct_waivers.json`` waiver mechanism (Issue #4417).
+
+Covers the v2 loader, exact-set/order-insensitive matching (items + optional
+nets), the central :func:`apply_waivers` post-check step, and the
+``waiver_unused`` advisory for stale entries.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.validate.rules.waivers import (
+    WAIVER_UNUSED_RULE_ID,
+    Waivers,
+    apply_waivers,
+    discover_waivers_sidecar,
+    load_waivers,
+    waivers_from_dict,
+)
+from kicad_tools.validate.violations import DRCResults, DRCViolation
+
+
+def _v(rule_id="clearance_pad_pad", items=(), nets=(), severity="error"):
+    return DRCViolation(
+        rule_id=rule_id,
+        severity=severity,
+        message="x",
+        items=tuple(items),
+        nets=tuple(nets),
+    )
+
+
+class TestLoader:
+    def test_v2_happy_path(self):
+        w = waivers_from_dict(
+            {
+                "version": 2,
+                "waivers": [
+                    {
+                        "rule": "courtyards_overlap",
+                        "items": ["C52", "U10"],
+                        "reason": "EE-mandated tight decoupling",
+                        "issue": "chorus#18",
+                    }
+                ],
+            }
+        )
+        assert len(w) == 1
+        entry = w.entries[0]
+        assert entry.rule == "courtyards_overlap"
+        assert entry.items == frozenset({"C52", "U10"})
+        assert entry.nets == frozenset()
+        assert entry.reason == "EE-mandated tight decoupling"
+        assert entry.issue == "chorus#18"
+
+    def test_nets_only_entry(self):
+        w = waivers_from_dict(
+            {
+                "version": 2,
+                "waivers": [
+                    {
+                        "rule": "clearance_pad_pad",
+                        "nets": ["GND", "VBUS"],
+                        "reason": "documented star-ground tie",
+                        "issue": "x#1",
+                    }
+                ],
+            }
+        )
+        assert w.entries[0].items == frozenset()
+        assert w.entries[0].nets == frozenset({"GND", "VBUS"})
+
+    def test_missing_version_rejected(self):
+        with pytest.raises(ValueError, match="missing the required 'version'"):
+            waivers_from_dict({"waivers": []})
+
+    def test_unsupported_version_rejected(self):
+        with pytest.raises(ValueError, match="unsupported waivers version"):
+            waivers_from_dict({"version": 1, "waivers": []})
+
+    def test_non_object_rejected(self):
+        with pytest.raises(ValueError, match="must be a JSON object"):
+            waivers_from_dict([1, 2, 3])
+
+    def test_missing_reason_rejected(self):
+        with pytest.raises(ValueError, match="non-empty 'reason'"):
+            waivers_from_dict(
+                {
+                    "version": 2,
+                    "waivers": [{"rule": "r", "items": ["A", "B"], "issue": "x#1"}],
+                }
+            )
+
+    def test_missing_issue_rejected(self):
+        with pytest.raises(ValueError, match="non-empty 'issue'"):
+            waivers_from_dict(
+                {
+                    "version": 2,
+                    "waivers": [{"rule": "r", "items": ["A", "B"], "reason": "ok"}],
+                }
+            )
+
+    def test_empty_rule_rejected(self):
+        with pytest.raises(ValueError, match="non-empty string 'rule'"):
+            waivers_from_dict(
+                {
+                    "version": 2,
+                    "waivers": [{"rule": "", "items": ["A"], "reason": "r", "issue": "i"}],
+                }
+            )
+
+    def test_no_items_or_nets_rejected(self):
+        with pytest.raises(ValueError, match="at least one 'items' or 'nets'"):
+            waivers_from_dict(
+                {
+                    "version": 2,
+                    "waivers": [{"rule": "r", "reason": "r", "issue": "i"}],
+                }
+            )
+
+    def test_items_non_string_rejected(self):
+        with pytest.raises(ValueError, match="'items' entries must be non-empty"):
+            waivers_from_dict(
+                {
+                    "version": 2,
+                    "waivers": [{"rule": "r", "items": ["A", 3], "reason": "r", "issue": "i"}],
+                }
+            )
+
+
+class TestLoadFromFile:
+    def test_load_and_discover(self, tmp_path):
+        pcb_path = tmp_path / "board.kicad_pcb"
+        pcb_path.write_text("(kicad_pcb)")
+        sidecar = tmp_path / ".kct_waivers.json"
+        sidecar.write_text(
+            '{"version": 2, "waivers": [{"rule": "r", "items": ["A", "B"], '
+            '"reason": "ok", "issue": "x#1"}]}'
+        )
+        found = discover_waivers_sidecar(pcb_path)
+        assert found == sidecar
+        w = load_waivers(found)
+        assert len(w) == 1
+
+    def test_discover_returns_none_when_absent(self, tmp_path):
+        pcb_path = tmp_path / "board.kicad_pcb"
+        pcb_path.write_text("(kicad_pcb)")
+        assert discover_waivers_sidecar(pcb_path) is None
+
+    def test_load_malformed_json_raises(self, tmp_path):
+        bad = tmp_path / ".kct_waivers.json"
+        bad.write_text("{not json")
+        with pytest.raises(ValueError, match="parsing waivers JSON"):
+            load_waivers(bad)
+
+
+class TestMatching:
+    def test_items_order_insensitive(self):
+        w = waivers_from_dict(
+            {
+                "version": 2,
+                "waivers": [{"rule": "r", "items": ["A", "B"], "reason": "ok", "issue": "x#1"}],
+            }
+        )
+        assert w.match(_v(rule_id="r", items=("B", "A"))) is not None
+        assert w.match(_v(rule_id="r", items=("A", "B"))) is not None
+
+    def test_exact_set_rejects_subset(self):
+        w = waivers_from_dict(
+            {
+                "version": 2,
+                "waivers": [{"rule": "r", "items": ["A", "B"], "reason": "ok", "issue": "x#1"}],
+            }
+        )
+        # A 3-item finding must NOT be waived by a 2-item entry.
+        assert w.match(_v(rule_id="r", items=("A", "B", "C"))) is None
+
+    def test_rule_id_must_match(self):
+        w = waivers_from_dict(
+            {
+                "version": 2,
+                "waivers": [{"rule": "r", "items": ["A", "B"], "reason": "ok", "issue": "x#1"}],
+            }
+        )
+        assert w.match(_v(rule_id="other", items=("A", "B"))) is None
+
+    def test_nets_match(self):
+        w = waivers_from_dict(
+            {
+                "version": 2,
+                "waivers": [
+                    {
+                        "rule": "clearance_pad_pad",
+                        "nets": ["GND", "VBUS"],
+                        "reason": "ok",
+                        "issue": "x#1",
+                    }
+                ],
+            }
+        )
+        assert w.match(_v(nets=("VBUS", "GND"))) is not None
+        assert w.match(_v(nets=("GND",))) is None
+
+    def test_items_and_nets_both_constrained(self):
+        w = waivers_from_dict(
+            {
+                "version": 2,
+                "waivers": [
+                    {
+                        "rule": "r",
+                        "items": ["A", "B"],
+                        "nets": ["N1"],
+                        "reason": "ok",
+                        "issue": "x#1",
+                    }
+                ],
+            }
+        )
+        assert w.match(_v(rule_id="r", items=("A", "B"), nets=("N1",))) is not None
+        # items match but nets do not
+        assert w.match(_v(rule_id="r", items=("A", "B"), nets=("N2",))) is None
+
+
+class TestApplyWaivers:
+    def _waivers(self, *entries):
+        return waivers_from_dict({"version": 2, "waivers": list(entries)})
+
+    def test_marks_only_matching_waived(self):
+        results = DRCResults(
+            violations=[
+                _v(rule_id="r", items=("A", "B")),
+                _v(rule_id="r", items=("C", "D")),
+            ]
+        )
+        waivers = self._waivers({"rule": "r", "items": ["A", "B"], "reason": "ok", "issue": "x#1"})
+        apply_waivers(results, waivers)
+        # A/B waived, C/D untouched, no unused advisory.
+        assert results.waived_count == 1
+        assert results.error_count == 1
+        waived = results.waived[0]
+        assert set(waived.items) == {"A", "B"}
+        assert waived.waiver_reason == "ok"
+        assert waived.waiver_issue == "x#1"
+        assert waived.severity == "error"  # underlying severity preserved
+
+    def test_unused_waiver_emits_info(self):
+        results = DRCResults(violations=[_v(rule_id="r", items=("A", "B"))])
+        waivers = self._waivers({"rule": "r", "items": ["X", "Y"], "reason": "ok", "issue": "x#9"})
+        apply_waivers(results, waivers)
+        assert results.waived_count == 0
+        assert results.error_count == 1
+        unused = [v for v in results.violations if v.rule_id == WAIVER_UNUSED_RULE_ID]
+        assert len(unused) == 1
+        assert unused[0].severity == "info"
+        assert "x#9" in unused[0].message
+
+    def test_already_waived_untouched(self):
+        pre_waived = DRCViolation(
+            rule_id="courtyards_overlap",
+            severity="error",
+            message="waived by per-rule path",
+            items=("A", "B"),
+            waived=True,
+            waiver_reason="courtyard",
+            waiver_issue="c#1",
+        )
+        results = DRCResults(violations=[pre_waived])
+        # A general waiver targeting the same pair must NOT re-waive / clobber.
+        waivers = self._waivers(
+            {
+                "rule": "courtyards_overlap",
+                "items": ["A", "B"],
+                "reason": "general",
+                "issue": "g#1",
+            }
+        )
+        apply_waivers(results, waivers)
+        assert results.waived_count == 1
+        # Original reason preserved; general entry counts as unused.
+        assert results.waived[0].waiver_reason == "courtyard"
+        unused = [v for v in results.violations if v.rule_id == WAIVER_UNUSED_RULE_ID]
+        assert len(unused) == 1
+
+    def test_empty_waivers_noop(self):
+        results = DRCResults(violations=[_v(rule_id="r", items=("A", "B"))])
+        apply_waivers(results, Waivers())
+        assert results.error_count == 1
+        assert results.waived_count == 0
+        assert all(v.rule_id != WAIVER_UNUSED_RULE_ID for v in results.violations)
+
+    def test_one_entry_waives_multiple_findings(self):
+        # Same ref-set on front and back -> two findings, one entry waives both.
+        results = DRCResults(
+            violations=[
+                _v(rule_id="courtyards_overlap", items=("A", "B")),
+                _v(rule_id="courtyards_overlap", items=("A", "B")),
+            ]
+        )
+        waivers = self._waivers(
+            {
+                "rule": "courtyards_overlap",
+                "items": ["A", "B"],
+                "reason": "ok",
+                "issue": "x#1",
+            }
+        )
+        apply_waivers(results, waivers)
+        assert results.waived_count == 2
+        assert all(v.rule_id != WAIVER_UNUSED_RULE_ID for v in results.violations)


### PR DESCRIPTION
## Summary

Generalizes the courtyard-only waiver infrastructure (Issue #4137) into a
rule-agnostic, post-check waiver step so an intentional, EE-mandated violation
can be documented and dropped from `kct check`'s 0-error sign-off gate while
staying fully visible and auditable. A new **version-2 `.kct_waivers.json`**
sidecar waives findings for **any** `rule_id` by matching the violation's
`items` (and optional `nets`) as an exact, order-insensitive set.

This is the **first slice** the curator scoped on #4417; the "bonus" and
gate-opt-in items are explicitly deferred to separate follow-up issues (below).

## Changes

- **New `src/kicad_tools/validate/rules/waivers.py`**
  - `Waiver` / `Waivers` models; exact-set, order-insensitive matching on
    `items` and optional `nets`.
  - `waivers_from_dict` (v2 schema: any `rule`, required non-empty
    `reason`/`issue`, at least one of `items`/`nets`; rejects other versions,
    non-object roots, malformed entries).
  - `load_waivers`, `discover_waivers_sidecar` (probes `.kct_waivers.json` in
    the pcb dir, `output/`, `../output/`).
  - `apply_waivers(results, waivers)` — central post-check step: replaces each
    matched finding with a `waived=True` copy (frozen dataclass → `replace`),
    skips already-waived findings, and appends a `waiver_unused` **info**
    advisory for stale entries.
- **`src/kicad_tools/cli/check_cmd.py`**
  - New `--waivers <path>` flag + auto-discovery, mirroring the
    `--courtyard-waivers` load/degrade contract exactly (explicit malformed =
    hard error; auto-discovered malformed = warn + continue with zero waivers).
  - `apply_waivers()` invoked once after `run_selected_checks()`, before the
    errors-only filter / exit-code computation.
- No change to `violations.py` (fields + `error_count`-excludes-waived already
  exist) or `drc/report.py` (audit parser stays severity-keyed — see safety).

## Manufacturing-gate safety (preserved by construction)

Mirrors the #4403 `gate_passed` precedent:

- `kct check`'s own exit gate keys off `is_error` (waived excluded) → a matched
  waiver flips the exit code and reaches 0 errors. **Intended relief.**
- The JSON keeps `severity: "error"` while reporting `status: "waived"`. `kct
  audit` re-parses via `drc/report.py::_parse_kct_check_json`, which reads
  `severity` and **ignores `waived`** → a waived finding **stays blocking in
  the manufacturing gate by default.** The audit parser is untouched in this
  slice. Covered by `test_manufacturing_gate_still_blocks_on_waived`.

## Deferred (explicit follow-ups, NOT built here)

- `.kicad_pro` `drc_exclusions` honoring (the ask's "bonus" — hash/UUID match).
- `kct audit --honor-check-waivers` opt-in (default must stay blocking).
- Geometric/location-based matching.
- Inline (in-`.kicad_pcb`) annotations.
- Deprecating/auto-migrating `.courtyard_waivers.json`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| v2 waiver applies to a non-courtyard rule | ✅ | `test_marks_only_matching_waived`, `test_nets_match` (clearance_pad_pad) |
| Waived excluded from check exit gate | ✅ | CLI e2e `test_matching_waiver_flips_exit_and_json_status` (rc 2→0, errors 0) |
| Audit JSON still `severity: error` | ✅ | `test_manufacturing_gate_still_blocks_on_waived` (report.error_count == 1) |
| `waiver_unused` advisory for stale entries | ✅ | `test_unused_waiver_emits_info`, CLI `test_unused_waiver_advisory` |
| Exact-set rejects subset | ✅ | `test_exact_set_rejects_subset` |
| v1 courtyard back-compat unchanged | ✅ | `tests/test_validate_courtyard_overlap.py` green (28 tests) |
| `--waivers` load/degrade contract | ✅ | explicit-malformed / missing → rc 1; auto-malformed → warn + continue |

## Test Plan

- `tests/test_validate_waivers.py` (new, 20 tests): loader validation, matching
  semantics, `apply_waivers` behavior incl. compose-with-courtyard, one-entry-
  waives-multiple, empty no-op.
- `tests/test_cli_check_waivers.py` (new, 7 tests): end-to-end gate flip, JSON
  status/severity, manufacturing-gate safety re-parse, malformed/missing
  handling, unused advisory.
- Back-compat: `tests/test_validate_courtyard_overlap.py`, `tests/test_cli_check.py`,
  `tests/test_cli_parser_drift.py` all green.
- `ruff check` / `ruff format --check` clean; `mypy` clean on the new module and
  `check_cmd.py`.

Closes #4417