### PR TITLE
feat(pcb): move-footprint --drag-endpoints carries trace ends with pads

### DIFF
--- a/src/kicad_tools/cli/commands/pcb.py
+++ b/src/kicad_tools/cli/commands/pcb.py
@@ -1007,6 +1007,8 @@ def _run_move_footprint_command(args, pcb_path: Path) -> int:
     dry_run = getattr(args, "dry_run", False)
     output_format = getattr(args, "format", "text")
     absolute = getattr(args, "absolute", False)
+    drag_endpoints = getattr(args, "drag_endpoints", False)
+    drag_tolerance = getattr(args, "drag_tolerance", 0.05)
 
     # Parse batch map JSON if provided
     batch_map = None
@@ -1041,6 +1043,8 @@ def _run_move_footprint_command(args, pcb_path: Path) -> int:
         output_path=output_path,
         output_format=output_format,
         absolute=absolute,
+        drag_endpoints=drag_endpoints,
+        drag_tolerance=drag_tolerance,
     )
 
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2141,6 +2141,22 @@ def _add_pcb_parser(subparsers) -> None:
         action="store_true",
         help="Preview moves without modifying the PCB file",
     )
+    pcb_move_fp.add_argument(
+        "--drag-endpoints",
+        action="store_true",
+        help="Translate trace-segment endpoints coincident with each moved pad "
+        "by that pad's delta, so routed copper follows the footprint instead "
+        "of being stranded. Translation-only; skipped (with a warning) for a "
+        "footprint whose --rotation also changes.",
+    )
+    pcb_move_fp.add_argument(
+        "--drag-tolerance",
+        type=float,
+        default=0.05,
+        metavar="MM",
+        help="Endpoint-coincidence match radius in mm for --drag-endpoints "
+        "(default: 0.05)",
+    )
 
     # pcb page-fit
     pcb_page_fit = pcb_subparsers.add_parser(

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2154,8 +2154,7 @@ def _add_pcb_parser(subparsers) -> None:
         type=float,
         default=0.05,
         metavar="MM",
-        help="Endpoint-coincidence match radius in mm for --drag-endpoints "
-        "(default: 0.05)",
+        help="Endpoint-coincidence match radius in mm for --drag-endpoints (default: 0.05)",
     )
 
     # pcb page-fit

--- a/src/kicad_tools/cli/pcb_move_footprint.py
+++ b/src/kicad_tools/cli/pcb_move_footprint.py
@@ -35,6 +35,8 @@ def run_move_footprint(
     output_path: Path | None = None,
     output_format: str = "text",
     absolute: bool = False,
+    drag_endpoints: bool = False,
+    drag_tolerance: float = 0.05,
 ) -> int:
     """Move one or more footprints in a PCB file.
 
@@ -51,6 +53,12 @@ def run_move_footprint(
         absolute: When True, interpret (x, y) as absolute KiCad page
             coordinates (subtract the board origin before assignment) rather
             than board-relative coordinates.
+        drag_endpoints: When True, translate trace-segment endpoints that were
+            coincident (within ``drag_tolerance``) with each moved pad by that
+            pad's delta, so routed copper follows the footprint instead of being
+            stranded.  First slice is translation-only: dragging is skipped (with
+            a warning) for any footprint whose ``rotation`` also changes.
+        drag_tolerance: Endpoint-coincidence match radius in mm (default 0.05).
 
     Returns:
         Exit code (0 for success, 1 for errors).
@@ -97,8 +105,12 @@ def run_move_footprint(
             return (x - ox, y - oy)
         return (x, y)
 
-    # Validate all references exist before making any changes
+    # Validate all references exist before making any changes.  When dragging
+    # endpoints, capture each pad's OLD board-relative position and its
+    # board-relative translation delta BEFORE any footprint moves -- the drag
+    # translates copper that terminated on the old pad position by that delta.
     move_details: list[dict] = []
+    drag_plans: list[dict] = []
     for ref, x, y, rot in moves:
         fp = pcb.get_footprint(ref)
         if not fp:
@@ -122,6 +134,35 @@ def run_move_footprint(
             }
         )
 
+        if drag_endpoints:
+            # Board-relative delta of a pure translation: the difference between
+            # the target board-relative footprint position and the current one.
+            # (_assign_coords maps the user's --to into board-relative space.)
+            assign_x, assign_y = _assign_coords(x, y)
+            fp_old_x, fp_old_y = fp.position
+            delta = (assign_x - fp_old_x, assign_y - fp_old_y)
+            rotation_changed = rot is not None and abs(rot - fp.rotation) > 1e-9
+            pads: list[dict] = []
+            for pad in fp.pads:
+                old_pos = pcb.get_pad_position(ref, pad.number)
+                if old_pos is None:
+                    continue
+                pads.append(
+                    {
+                        "number": pad.number,
+                        "net_number": pad.net_number,
+                        "net_name": pad.net_name,
+                        "old_pos": old_pos,
+                    }
+                )
+            drag_plans.append(
+                {
+                    "delta": delta,
+                    "rotation_changed": rotation_changed,
+                    "pads": pads,
+                }
+            )
+
     result = {
         "pcb": str(pcb_path),
         "dry_run": dry_run,
@@ -130,6 +171,57 @@ def run_move_footprint(
         "moves": move_details,
         "moved": False,
     }
+    if drag_endpoints:
+        result["drag_endpoints"] = True
+        result["drag_tolerance"] = drag_tolerance
+
+    # Drag coincident trace endpoints with each moved pad.  The drag mutates the
+    # in-memory PCB (and its S-expression tree) in place; it runs in dry-run too
+    # so per-pad counts can be reported, but the mutations are only persisted
+    # when save() is called below (skipped on dry-run).  Endpoints are matched
+    # against each pad's OLD position (captured pre-move) and translated by the
+    # footprint's board-relative delta.
+    if drag_endpoints:
+        total_dragged = 0
+        for md, plan in zip(move_details, drag_plans, strict=True):
+            if plan["rotation_changed"]:
+                md["drag_skipped_rotation"] = True
+                md["drag"] = []
+                continue
+            dx, dy = plan["delta"]
+            per_pad: list[dict] = []
+            for prec in plan["pads"]:
+                # A pad has attached copper only if it belongs to a real net.
+                # Skip unconnected pads so a passing-through trace on another
+                # net is never dragged by accident.
+                has_net = prec["net_number"] != 0 or bool(prec["net_name"])
+                if not has_net:
+                    continue
+                if dx == 0.0 and dy == 0.0:
+                    count = 0
+                else:
+                    # net_number 0 on a connected pad means a name-only board
+                    # (#4416): fall back to purely geometric matching.
+                    net_filter = prec["net_number"] or None
+                    count = pcb.drag_trace_endpoints(
+                        prec["old_pos"],
+                        (dx, dy),
+                        tolerance=drag_tolerance,
+                        net_number=net_filter,
+                    )
+                total_dragged += count
+                per_pad.append(
+                    {
+                        "pad": prec["number"],
+                        "net": prec["net_name"] or prec["net_number"],
+                        "endpoints_dragged": count,
+                        # The "subtly-broken board" signature: a pad with copper
+                        # expected but no endpoint moved with it.
+                        "zero_match_warning": count == 0,
+                    }
+                )
+            md["drag"] = per_pad
+        result["endpoints_dragged"] = total_dragged
 
     if not dry_run:
         for ref, x, y, rot in moves:
@@ -167,6 +259,20 @@ def run_move_footprint(
             )
             if md["old_rotation"] != md["new_rotation"]:
                 print(f"    Rotation: {md['old_rotation']} -> {md['new_rotation']}")
+            if md.get("drag_skipped_rotation"):
+                print(
+                    "    Drag endpoints: SKIPPED (rotation changed; "
+                    "rotation-aware dragging not supported in this slice)"
+                )
+            elif "drag" in md:
+                for dr in md["drag"]:
+                    line = (
+                        f"    Drag pad {dr['pad']} (net {dr['net']}): "
+                        f"{dr['endpoints_dragged']} endpoint(s)"
+                    )
+                    if dr["zero_match_warning"]:
+                        line += "  [WARNING: attached copper but no endpoint matched]"
+                    print(line)
         print()
         if dry_run:
             print("  Would move footprint(s)")

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -2960,6 +2960,132 @@ class PCB:
 
         return removed_count
 
+    def drag_trace_endpoints(
+        self,
+        point: tuple[float, float],
+        delta: tuple[float, float],
+        tolerance: float = 0.05,
+        net_number: int | None = None,
+    ) -> int:
+        """Translate trace-segment endpoints coincident with ``point`` by ``delta``.
+
+        Moves every segment endpoint (``start`` or ``end``) whose board-relative
+        position lies within ``tolerance`` mm of ``point`` by
+        ``delta = (dx, dy)``, updating BOTH the in-memory :class:`Segment`
+        dataclasses and the backing S-expression tree in place so the change
+        survives :meth:`save`.  Segment UUIDs are preserved (unlike a
+        remove + :meth:`add_trace`, which would mint fresh UUIDs).
+
+        This is the primitive behind ``move-footprint --drag-endpoints``: when a
+        footprint is nudged, the caller records each pad's OLD board-relative
+        position, moves the footprint, then calls this method once per pad with
+        that pad's translation so the copper that terminated on the pad follows
+        it and stays electrically attached.
+
+        Coordinate spaces: ``point``, ``delta`` and the stored
+        :attr:`Segment.start`/:attr:`Segment.end` values are all board-relative
+        (see :meth:`_detect_board_origin`).  The S-expression tree stores
+        sheet-absolute coordinates, so the board-origin offset is re-added when
+        the ``(start ...)``/``(end ...)`` atoms are rewritten -- this is what
+        makes the move persist correctly on a non-zero-origin board.
+
+        Args:
+            point: Board-relative (x, y) to match endpoints against.
+            delta: Board-relative (dx, dy) translation applied to each match.
+            tolerance: Match radius in mm (default 0.05).
+            net_number: When a positive net id is given, only segments in that
+                net are considered (fast path).  When ``None`` or ``0`` (e.g.
+                KiCad-10 name-only boards whose segments carry
+                ``net_number == 0``; see issue #4416), all segments are
+                considered and matching is purely geometric.
+
+        Returns:
+            The number of endpoints translated.
+        """
+        ox, oy = self._board_origin
+        px, py = point
+        dx, dy = delta
+        tol_sq = tolerance * tolerance
+
+        # Index the backing tree nodes so the matched atoms can be rewritten
+        # in place.  Segments loaded from disk carry UUIDs; fall back to a
+        # sheet-absolute coordinate key for any UUID-less node (mirrors the
+        # matching in remove_segments()).
+        node_by_uuid: dict[str, SExp] = {}
+        node_by_coord: dict[tuple[float, float, float, float, str], SExp] = {}
+        for child in self._sexp.children:
+            if child.is_atom or child.name != "segment":
+                continue
+            uuid_node = child.find("uuid")
+            uval = uuid_node.get_string(0) if uuid_node else None
+            if uval:
+                node_by_uuid[uval] = child
+                continue
+            start_node = child.find("start")
+            end_node = child.find("end")
+            layer_node = child.find("layer")
+            if start_node and end_node and layer_node:
+                key = (
+                    start_node.get_float(0) or 0.0,
+                    start_node.get_float(1) or 0.0,
+                    end_node.get_float(0) or 0.0,
+                    end_node.get_float(1) or 0.0,
+                    layer_node.get_string(0) or "",
+                )
+                node_by_coord[key] = child
+
+        def _matches(coord: tuple[float, float]) -> bool:
+            return (coord[0] - px) ** 2 + (coord[1] - py) ** 2 <= tol_sq
+
+        def _tree_node(seg: Segment) -> SExp | None:
+            if seg.uuid:
+                return node_by_uuid.get(seg.uuid)
+            key = (
+                seg.start[0] + ox,
+                seg.start[1] + oy,
+                seg.end[0] + ox,
+                seg.end[1] + oy,
+                seg.layer,
+            )
+            return node_by_coord.get(key)
+
+        moved = 0
+        for seg in self._segments:
+            if net_number is not None and net_number > 0 and seg.net_number != net_number:
+                continue
+            hit_start = _matches(seg.start)
+            hit_end = _matches(seg.end)
+            if not hit_start and not hit_end:
+                continue
+
+            # Resolve the tree node BEFORE mutating the coordinates so the
+            # coordinate-fallback key still reflects the on-disk position.
+            node = _tree_node(seg)
+
+            if hit_start:
+                new_start = (seg.start[0] + dx, seg.start[1] + dy)
+                seg.start = new_start
+                if node is not None:
+                    start_node = node.find("start")
+                    if start_node is not None:
+                        start_node.set_atom(0, new_start[0] + ox)
+                        start_node.set_atom(1, new_start[1] + oy)
+                moved += 1
+            if hit_end:
+                new_end = (seg.end[0] + dx, seg.end[1] + dy)
+                seg.end = new_end
+                if node is not None:
+                    end_node = node.find("end")
+                    if end_node is not None:
+                        end_node.set_atom(0, new_end[0] + ox)
+                        end_node.set_atom(1, new_end[1] + oy)
+                moved += 1
+
+        if moved:
+            self._invalidate_dedup_keys()
+
+        return moved
+
     def footprints_on_layer(self, layer: str) -> Iterator[Footprint]:
         """Get footprints on a specific layer."""
         for fp in self._footprints:

--- a/tests/test_pcb_move_footprint.py
+++ b/tests/test_pcb_move_footprint.py
@@ -306,6 +306,364 @@ class TestRunMoveFootprint:
         assert j3.rotation == pytest.approx(j3_rot_before, abs=0.01)
 
 
+# A routed board: two 2-pad passives with traces landing exactly on pads.
+#   R1 @ (100, 100): pad 1 -> (99, 100) net 1, pad 2 -> (101, 100) net 2
+#   R3 @ (100, 120): pad 1 -> (99, 120) net 3 -- copper is NOT coincident
+#     (seg-d starts at 95, 120), used to exercise the zero-match warning.
+# seg-c terminates on R2's pad (129, 100) and must never move when R1 moves.
+ROUTED_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (net 0 "")
+  (net 1 "N1")
+  (net 2 "N2")
+  (net 3 "N3")
+  (footprint "R"
+    (layer "F.Cu")
+    (uuid "fp-r1")
+    (at 100 100)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (pad "1" smd rect (at -1 0) (size 1 1) (layers "F.Cu") (net 1 "N1"))
+    (pad "2" smd rect (at 1 0) (size 1 1) (layers "F.Cu") (net 2 "N2"))
+  )
+  (footprint "R"
+    (layer "F.Cu")
+    (uuid "fp-r2")
+    (at 130 100)
+    (property "Reference" "R2" (at 0 -1.5 0) (layer "F.SilkS"))
+    (pad "1" smd rect (at -1 0) (size 1 1) (layers "F.Cu") (net 1 "N1"))
+    (pad "2" smd rect (at 1 0) (size 1 1) (layers "F.Cu") (net 0 ""))
+  )
+  (footprint "R"
+    (layer "F.Cu")
+    (uuid "fp-r3")
+    (at 100 120)
+    (property "Reference" "R3" (at 0 -1.5 0) (layer "F.SilkS"))
+    (pad "1" smd rect (at -1 0) (size 1 1) (layers "F.Cu") (net 3 "N3"))
+    (pad "2" smd rect (at 1 0) (size 1 1) (layers "F.Cu") (net 0 ""))
+  )
+  (segment (start 99 100) (end 90 100) (width 0.25) (layer "F.Cu") (net 1) (uuid "seg-a"))
+  (segment (start 101 100) (end 110 100) (width 0.25) (layer "F.Cu") (net 2) (uuid "seg-b"))
+  (segment (start 129 100) (end 120 100) (width 0.25) (layer "F.Cu") (net 1) (uuid "seg-c"))
+  (segment (start 95 120) (end 90 120) (width 0.25) (layer "F.Cu") (net 3) (uuid "seg-d"))
+)
+"""
+
+# Same routed board translated onto a non-zero board origin (116, 77).  In the
+# tree, copper is sheet-absolute; after load, board_origin is subtracted so the
+# in-memory view matches ROUTED_PCB.  R1's pad 1 is board-relative (99, 100).
+ROUTED_NONZERO_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (net 0 "")
+  (net 1 "N1")
+  (net 2 "N2")
+  (gr_rect
+    (start 116 77)
+    (end 300 260)
+    (layer "Edge.Cuts")
+    (width 0.1)
+    (uuid "edge-rect")
+  )
+  (footprint "R"
+    (layer "F.Cu")
+    (uuid "fp-r1")
+    (at 216 177)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (pad "1" smd rect (at -1 0) (size 1 1) (layers "F.Cu") (net 1 "N1"))
+    (pad "2" smd rect (at 1 0) (size 1 1) (layers "F.Cu") (net 2 "N2"))
+  )
+  (segment (start 215 177) (end 206 177) (width 0.25) (layer "F.Cu") (net 1) (uuid "seg-a"))
+  (segment (start 217 177) (end 226 177) (width 0.25) (layer "F.Cu") (net 2) (uuid "seg-b"))
+)
+"""
+
+# KiCad-10 name-only dialect (#4416): pads and segments carry (net "N1") with
+# no numeric id, so their net_number parses as 0.
+ROUTED_NAME_ONLY_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (net 0 "")
+  (net 1 "N1")
+  (net 2 "N2")
+  (footprint "R"
+    (layer "F.Cu")
+    (uuid "fp-r1")
+    (at 100 100)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (pad "1" smd rect (at -1 0) (size 1 1) (layers "F.Cu") (net "N1"))
+    (pad "2" smd rect (at 1 0) (size 1 1) (layers "F.Cu") (net "N2"))
+  )
+  (segment (start 99 100) (end 90 100) (width 0.25) (layer "F.Cu") (net "N1") (uuid "seg-a"))
+  (segment (start 101 100) (end 110 100) (width 0.25) (layer "F.Cu") (net "N2") (uuid "seg-b"))
+)
+"""
+
+
+def _seg(pcb, uuid):
+    """Return the Segment with the given uuid, or None."""
+    for s in pcb.segments:
+        if s.uuid == uuid:
+            return s
+    return None
+
+
+class TestDragEndpoints:
+    """Tests for move-footprint --drag-endpoints."""
+
+    def test_drag_persists_after_reload(self, tmp_path):
+        """Move + drag, save, RELOAD from disk: endpoints followed the pads.
+
+        Reloading is the critical assertion -- Segment has no __setattr__ ->
+        S-expression sync, so an in-memory-only check would pass even if the
+        tree was never updated.
+        """
+        from kicad_tools.cli.pcb_move_footprint import run_move_footprint
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(ROUTED_PCB)
+
+        rc = run_move_footprint(pcb, reference="R1", to=(105.0, 100.0), drag_endpoints=True)
+        assert rc == 0
+
+        board = PCB.load(pcb)
+        # R1 pad 1 was (99, 100) -> delta (5, 0): seg-a start follows.
+        seg_a = _seg(board, "seg-a")
+        assert seg_a is not None
+        assert seg_a.start == pytest.approx((104.0, 100.0))
+        # Far end of seg-a is untouched.
+        assert seg_a.end == pytest.approx((90.0, 100.0))
+        # R1 pad 2 was (101, 100): seg-b start follows.
+        seg_b = _seg(board, "seg-b")
+        assert seg_b is not None
+        assert seg_b.start == pytest.approx((106.0, 100.0))
+        assert seg_b.end == pytest.approx((110.0, 100.0))
+        # UUIDs preserved by the in-place tree-sync strategy.
+        assert {"seg-a", "seg-b", "seg-c", "seg-d"} <= {s.uuid for s in board.segments}
+
+    def test_drag_leaves_other_nets_and_footprints_untouched(self, tmp_path):
+        """seg-c (on R2's pad) is not moved when R1 moves."""
+        from kicad_tools.cli.pcb_move_footprint import run_move_footprint
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(ROUTED_PCB)
+
+        rc = run_move_footprint(pcb, reference="R1", to=(105.0, 100.0), drag_endpoints=True)
+        assert rc == 0
+
+        board = PCB.load(pcb)
+        seg_c = _seg(board, "seg-c")
+        assert seg_c is not None
+        assert seg_c.start == pytest.approx((129.0, 100.0))
+        assert seg_c.end == pytest.approx((120.0, 100.0))
+
+    def test_no_drag_flag_strands_traces(self, tmp_path):
+        """Without --drag-endpoints the traces stay put (regression guard)."""
+        from kicad_tools.cli.pcb_move_footprint import run_move_footprint
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(ROUTED_PCB)
+
+        rc = run_move_footprint(pcb, reference="R1", to=(105.0, 100.0))
+        assert rc == 0
+
+        board = PCB.load(pcb)
+        seg_a = _seg(board, "seg-a")
+        assert seg_a is not None
+        # Endpoint unchanged -> stranded (the gap this feature fills).
+        assert seg_a.start == pytest.approx((99.0, 100.0))
+
+    def test_zero_match_warning_json(self, tmp_path, capsys):
+        """Per-pad zero_match_warning surfaces in JSON output."""
+        from kicad_tools.cli.pcb_move_footprint import run_move_footprint
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(ROUTED_PCB)
+
+        rc = run_move_footprint(
+            pcb,
+            reference="R3",
+            to=(105.0, 120.0),
+            drag_endpoints=True,
+            output_format="json",
+        )
+        assert rc == 0
+
+        data = json.loads(capsys.readouterr().out)
+        drag = data["moves"][0]["drag"]
+        # Only pad 1 (net 3) is reported; pad 2 (net 0) is unconnected + skipped.
+        assert len(drag) == 1
+        assert drag[0]["pad"] == "1"
+        assert drag[0]["endpoints_dragged"] == 0
+        assert drag[0]["zero_match_warning"] is True
+
+    def test_zero_match_warning_text(self, tmp_path, capsys):
+        """Zero-match warning is printed in text mode."""
+        from kicad_tools.cli.pcb_move_footprint import run_move_footprint
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(ROUTED_PCB)
+
+        rc = run_move_footprint(pcb, reference="R3", to=(105.0, 120.0), drag_endpoints=True)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "WARNING" in out
+
+    def test_per_pad_counts_in_json(self, tmp_path, capsys):
+        """JSON reports per-pad drag counts and a total."""
+        from kicad_tools.cli.pcb_move_footprint import run_move_footprint
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(ROUTED_PCB)
+
+        rc = run_move_footprint(
+            pcb,
+            reference="R1",
+            to=(105.0, 100.0),
+            drag_endpoints=True,
+            output_format="json",
+        )
+        assert rc == 0
+
+        data = json.loads(capsys.readouterr().out)
+        assert data["drag_endpoints"] is True
+        assert data["drag_tolerance"] == 0.05
+        assert data["endpoints_dragged"] == 2
+        counts = {d["pad"]: d["endpoints_dragged"] for d in data["moves"][0]["drag"]}
+        assert counts == {"1": 1, "2": 1}
+
+    def test_nonzero_origin_drag_persists(self, tmp_path):
+        """Drag applies the board-origin offset when writing the tree."""
+        from kicad_tools.cli.pcb_move_footprint import run_move_footprint
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(ROUTED_NONZERO_PCB)
+
+        # R1 board-relative (100, 100) -> (105, 100): delta (5, 0).
+        rc = run_move_footprint(pcb, reference="R1", to=(105.0, 100.0), drag_endpoints=True)
+        assert rc == 0
+
+        board = PCB.load(pcb)
+        assert board.board_origin == pytest.approx((116.0, 77.0))
+        seg_a = _seg(board, "seg-a")
+        assert seg_a is not None
+        # Board-relative endpoint follows the pad.
+        assert seg_a.start == pytest.approx((104.0, 100.0))
+
+        # And the raw tree stores sheet-absolute (104 + 116, 100 + 77).
+        text = pcb.read_text()
+        assert "(start 220 177)" in text
+
+    def test_name_only_dialect_drag(self, tmp_path):
+        """Name-only nets (net_number 0) drag via geometric fallback (#4416)."""
+        from kicad_tools.cli.pcb_move_footprint import run_move_footprint
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(ROUTED_NAME_ONLY_PCB)
+
+        rc = run_move_footprint(pcb, reference="R1", to=(105.0, 100.0), drag_endpoints=True)
+        assert rc == 0
+
+        board = PCB.load(pcb)
+        seg_a = _seg(board, "seg-a")
+        seg_b = _seg(board, "seg-b")
+        assert seg_a is not None and seg_b is not None
+        assert seg_a.start == pytest.approx((104.0, 100.0))
+        assert seg_b.start == pytest.approx((106.0, 100.0))
+        # The name-only dialect is preserved on save.
+        assert '(net "N1")' in pcb.read_text()
+
+    def test_map_batch_composes_with_drag(self, tmp_path):
+        """--map batch mode applies the drag per moved footprint."""
+        from kicad_tools.cli.pcb_move_footprint import run_move_footprint
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(ROUTED_PCB)
+
+        batch = {
+            "R1": {"x": 105.0, "y": 100.0},
+            "R2": {"x": 135.0, "y": 100.0},
+        }
+        rc = run_move_footprint(pcb, batch_map=batch, drag_endpoints=True)
+        assert rc == 0
+
+        board = PCB.load(pcb)
+        # R1 pad 1 -> seg-a start moved by (5, 0).
+        assert _seg(board, "seg-a").start == pytest.approx((104.0, 100.0))
+        # R2 pad 1 (129, 100) -> seg-c start moved by (5, 0).
+        assert _seg(board, "seg-c").start == pytest.approx((134.0, 100.0))
+
+    def test_dry_run_reports_drag_without_writing(self, tmp_path, capsys):
+        """--dry-run reports intended drags but leaves the file untouched."""
+        from kicad_tools.cli.pcb_move_footprint import run_move_footprint
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(ROUTED_PCB)
+        original = pcb.read_text()
+
+        rc = run_move_footprint(
+            pcb,
+            reference="R1",
+            to=(105.0, 100.0),
+            drag_endpoints=True,
+            dry_run=True,
+            output_format="json",
+        )
+        assert rc == 0
+
+        data = json.loads(capsys.readouterr().out)
+        assert data["dry_run"] is True
+        assert data["endpoints_dragged"] == 2
+        # File must be byte-identical -- nothing was written.
+        assert pcb.read_text() == original
+
+    def test_rotation_skips_drag_with_warning(self, tmp_path, capsys):
+        """Combining --drag-endpoints with a rotation change skips the drag."""
+        from kicad_tools.cli.pcb_move_footprint import run_move_footprint
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = tmp_path / "test.kicad_pcb"
+        pcb.write_text(ROUTED_PCB)
+
+        rc = run_move_footprint(
+            pcb,
+            reference="R1",
+            to=(105.0, 100.0),
+            rotation=90.0,
+            drag_endpoints=True,
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "SKIPPED" in out
+
+        board = PCB.load(pcb)
+        # Footprint moved + rotated, but copper was NOT dragged.
+        fp = board.get_footprint("R1")
+        assert fp is not None
+        assert fp.rotation == pytest.approx(90.0)
+        seg_a = _seg(board, "seg-a")
+        assert seg_a is not None
+        assert seg_a.start == pytest.approx((99.0, 100.0))
+
+
 class TestMoveFootprintCLIParser:
     """Tests for the move-footprint CLI parser."""
 


### PR DESCRIPTION
## Summary

Extends the existing `kct pcb move-footprint` command with `--drag-endpoints` (and `--drag-tolerance MM`) so a sub-millimetre translation nudge of a routed footprint brings its connected copper along instead of stranding every trace end that terminated on its pads. This is the deliberately-narrow alternative to a full re-route for validated copper (see #4413/#4414 for why re-route is currently unusable for nudges).

## Changes

- **`src/kicad_tools/schema/pcb.py`** — new `PCB.drag_trace_endpoints(point, delta, tolerance, net_number)` primitive. It matches segment endpoints coincident (within tolerance) with a board-relative `point` and translates them by `delta`, rewriting the `(start ...)`/`(end ...)` atoms **in the S-expression tree in place** (re-adding the board-origin offset) and updating the in-memory `Segment` dataclass to match. **UUIDs are preserved.**
- **`src/kicad_tools/cli/pcb_move_footprint.py`** — captures each pad's OLD board-relative position (`get_pad_position`) before the move, then drags per pad by the pad's delta. Adds per-pad drag counts, a zero-match warning, and drag totals to both text and JSON output. New `drag_endpoints` / `drag_tolerance` params.
- **`src/kicad_tools/cli/parser.py`** — `--drag-endpoints` (store_true) and `--drag-tolerance` (float, default 0.05) on the `move-footprint` subparser.
- **`src/kicad_tools/cli/commands/pcb.py`** — threads the two flags through `_run_move_footprint_command`.
- **`tests/test_pcb_move_footprint.py`** — 13 new tests (routed fixtures on zero and non-zero board origin, plus a KiCad-10 name-only fixture).

### The persistence trap (addressed)

`Segment`/`Via` have **no** `__setattr__` → S-expression sync (the `segments`/`vias` setters even raise `AttributeError`). `save()` serializes the S-exp tree, so a naive `seg.start = ...` would be a silent no-op. The new helper edits the tree atoms directly; the mandatory test **saves AND reloads from disk** before asserting.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Move a routed 2-pad passive with `--drag-endpoints`; endpoints follow pads (persist through save+reload) | ✅ | `test_drag_persists_after_reload` reloads from disk; seg starts moved, far ends unchanged |
| Endpoints of other nets / non-coincident copper untouched | ✅ | `test_drag_leaves_other_nets_and_footprints_untouched` (seg-c on R2 stays put) |
| Works in both net dialects (numeric + KiCad-10 name-only, #4416) | ✅ | `test_name_only_dialect_drag` (net_number 0 → geometric fallback; `(net "N1")` dialect preserved) |
| Per-pad drag counts + zero-match warning | ✅ | `test_per_pad_counts_in_json`, `test_zero_match_warning_json`/`_text` |
| `--map` batch composition | ✅ | `test_map_batch_composes_with_drag` |
| Non-zero board origin (offset applied on write) | ✅ | `test_nonzero_origin_drag_persists` asserts raw `(start 220 177)` in tree |
| `--dry-run` reports intended drags without writing | ✅ | `test_dry_run_reports_drag_without_writing` (byte-identical file) |
| `--drag-endpoints` + `--rotation` → warn/skip (deferred rotation-aware drag) | ✅ | `test_rotation_skips_drag_with_warning` |
| UUIDs preserved | ✅ | asserted in `test_drag_persists_after_reload` |

**Deferred (out of scope, per the issue):** via-center dragging, rotation-aware dragging, diagonal/arc reflow, rip-up-reroute, mid-trace attachment.

## Test Plan

- `uv run pytest tests/test_pcb_move_footprint.py` — 38 passed.
- Related subsets (`-k "move_footprint or trace or segment"`) — 1182 passed, 51 skipped, 0 failed.
- `uv run ruff check` + `ruff format --check` on changed files — clean.
- `uv run python scripts/ci/check_mypy_baseline.py` — exit 0, no new type errors (all within baseline).

Closes #4418