### PR TITLE
fix(stitch): validate via candidates against zone fill, not the outline

### DIFF
--- a/src/kicad_tools/cli/stitch_cmd.py
+++ b/src/kicad_tools/cli/stitch_cmd.py
@@ -283,6 +283,14 @@ class StitchResult:
     # corresponding pads are also recorded in ``pads_skipped`` with a
     # ``hole_to_hole:`` reason.
     hole_to_hole_rejected: int = 0
+    # Issue #4432: pads whose only reachable via site lands OFF the same-net
+    # refilled fill (inside a keepout void / clearance pullback where the
+    # pour has retreated).  A local via there would dangle (``via_dangling``)
+    # once zones refill, so instead of placing it we record the pad here --
+    # it needs a routed fanout trace out to the fill edge, not a stitch via.
+    # Each entry is (pad, reason).  These pads are ALSO recorded in
+    # ``pads_skipped`` so existing summaries still count them.
+    needs_routed_fanout: list[tuple[PadInfo, str]] = field(default_factory=list)
 
 
 @dataclass
@@ -1641,6 +1649,72 @@ def identify_nearest_obstacle(
     return best
 
 
+def _same_net_fill_on_layer(
+    same_net_filled_polygons: list[FilledPolygon] | None,
+    layer: str | None,
+) -> list[FilledPolygon]:
+    """Return the same-net fill polygons that lie on ``layer``.
+
+    Issue #4432: the same-net fill *gate* is active only when actual pour
+    geometry exists on the via's target layer.  When ``layer`` is ``None``
+    (no resolved terminus) every same-net fill polygon qualifies.  An empty
+    result means the gate is a **no-op** (unfilled board / no fill on the
+    target layer) and the caller must fall back to outline behaviour.
+    """
+    if not same_net_filled_polygons:
+        return []
+    if layer is None:
+        return list(same_net_filled_polygons)
+    return [fp for fp in same_net_filled_polygons if fp.layer == layer]
+
+
+def _point_on_same_net_fill(
+    px: float,
+    py: float,
+    radius: float,
+    same_net_filled_polygons: list[FilledPolygon],
+    layer: str | None,
+) -> bool:
+    """Return True if a via pad at ``(px, py)`` sits on same-net zone fill.
+
+    Issue #4432: a stitching via only bonds to the plane when its pad lands
+    on the refilled copper (``filled_polygon``), not merely inside the zone
+    OUTLINE.  The pour retreats from the outline wherever a copper keepout,
+    thermal relief, clearance pullback, or island split removes fill, and a
+    via dropped in one of those retreated regions dangles.
+
+    Margin-aware: the point must be inside a same-net ``FilledPolygon`` AND
+    at least ``radius`` from every edge, so the via *pad* (not just its
+    centre) sits on copper rather than overhanging a void or the fill
+    boundary.  The even-odd :func:`point_in_polygon` already treats keepout
+    voids (holed fill rings KiCad emits as keyholed ``pts`` lists) as
+    outside, so a candidate inside a void hole is correctly rejected.
+
+    Layer filtering: only polygons whose ``.layer`` matches ``layer`` are
+    considered (``layer=None`` skips the filter).
+
+    Returns ``False`` when ``same_net_filled_polygons`` is empty -- callers
+    must gate on the presence of fill (see :func:`_same_net_fill_on_layer`)
+    so the check stays a no-op on unfilled boards.
+    """
+    for fp in same_net_filled_polygons:
+        if layer is not None and fp.layer != layer:
+            continue
+        # Fast bounding-box pre-filter (with the pad radius as a margin).
+        if (
+            px < fp.min_x - radius
+            or px > fp.max_x + radius
+            or py < fp.min_y - radius
+            or py > fp.max_y + radius
+        ):
+            continue
+        if point_in_polygon(px, py, fp.points) and _point_has_edge_margin(
+            px, py, fp.points, radius
+        ):
+            return True
+    return False
+
+
 def calculate_via_position(
     pad: PadInfo,
     offset: float,
@@ -1656,6 +1730,8 @@ def calculate_via_position(
     other_net_drills: list[tuple[float, float, float, int]] | None = None,
     via_drill: float = 0.0,
     min_hole_to_hole: float = 0.5,
+    same_net_filled_polygons: list[FilledPolygon] | None = None,
+    same_net_fill_layer: str | None = None,
 ) -> tuple[float, float] | None:
     """Calculate a valid via placement position near the pad.
 
@@ -1694,6 +1770,15 @@ def calculate_via_position(
             used only for the ``other_net_drills`` hole-to-hole check.
         min_hole_to_hole: Minimum drill edge-to-edge spacing (mm,
             default 0.5) for the ``other_net_drills`` check.
+        same_net_filled_polygons: Issue #4432 -- same-net zone fill
+            (``filled_polygon``) geometry.  When non-empty AND fill exists on
+            ``same_net_fill_layer``, a candidate whose via pad does not land
+            on same-net fill is rejected (it would dangle where the pour has
+            retreated for a keepout / clearance pullback).  Empty (or no fill
+            on the layer) makes the gate a no-op, so unfilled boards stitch
+            exactly as before.
+        same_net_fill_layer: Target layer the via bonds to.  Only same-net
+            fill on this layer counts toward the containment gate.
     """
     if other_net_tracks is None:
         other_net_tracks = []
@@ -1708,6 +1793,10 @@ def calculate_via_position(
 
     via_radius = via_size / 2
     trace_half_width = trace_width / 2
+
+    # Issue #4432: same-net fill containment gate, active only when pour
+    # geometry exists on the target layer (empty -> no-op / outline fallback).
+    same_net_fill_gate = _same_net_fill_on_layer(same_net_filled_polygons, same_net_fill_layer)
 
     # Try different offsets from pad center
     # Start with the direction away from pad center, try 8 directions
@@ -1826,6 +1915,16 @@ def calculate_via_position(
                     conflict = True
 
             if conflict:
+                continue
+
+            # Issue #4432: same-net FILL containment gate.  After clearance
+            # passes, reject a candidate that lands where the same-net pour
+            # cannot exist (keepout void / clearance pullback) -- such a via
+            # dangles once zones refill.  No-op when no same-net fill exists
+            # on the target layer (``same_net_fill_gate`` empty).
+            if same_net_fill_gate and not _point_on_same_net_fill(
+                via_x, via_y, via_radius, same_net_fill_gate, same_net_fill_layer
+            ):
                 continue
 
             # Check connecting trace path (pad center -> via center) for clearance
@@ -2030,6 +2129,8 @@ def calculate_dogleg_via_position(
     via_drill: float = 0.0,
     other_net_drills: list[tuple[float, float, float, int]] | None = None,
     min_hole_to_hole: float = MIN_HOLE_TO_HOLE_CLEARANCE,
+    same_net_filled_polygons: list[FilledPolygon] | None = None,
+    same_net_fill_layer: str | None = None,
 ) -> tuple[float, float, float, float] | None:
     """Calculate a dog-leg (L-shaped) via placement for fine-pitch components.
 
@@ -2086,6 +2187,9 @@ def calculate_dogleg_via_position(
     trace_half_width = trace_width / 2
 
     pad_radius = max(pad.width, pad.height) / 2
+
+    # Issue #4432: same-net fill containment gate (see calculate_via_position).
+    same_net_fill_gate = _same_net_fill_on_layer(same_net_filled_polygons, same_net_fill_layer)
 
     # Determine the dominant alignment direction based on nearby other-net pads
     # This helps us route along the pad row first, then escape perpendicular
@@ -2232,6 +2336,15 @@ def calculate_dogleg_via_position(
                     if conflict:
                         continue
 
+                    # Issue #4432: same-net FILL containment gate.  Reject a
+                    # dog-leg via landing where the same-net pour has retreated
+                    # (keepout void / clearance pullback).  No-op when no
+                    # same-net fill exists on the target layer.
+                    if same_net_fill_gate and not _point_on_same_net_fill(
+                        via_x, via_y, via_radius, same_net_fill_gate, same_net_fill_layer
+                    ):
+                        continue
+
                     # Issue #4177: drill hole-to-hole guard.  The checks
                     # above use COPPER geometry; they do not enforce the
                     # fab's drill-to-drill minimum.  A dog-leg stitch via
@@ -2339,6 +2452,8 @@ def calculate_extended_escape_position(
     via_drill: float = 0.0,
     other_net_drills: list[tuple[float, float, float, int]] | None = None,
     min_hole_to_hole: float = MIN_HOLE_TO_HOLE_CLEARANCE,
+    same_net_filled_polygons: list[FilledPolygon] | None = None,
+    same_net_fill_layer: str | None = None,
 ) -> tuple[float, float, list[tuple[float, float]]] | None:
     """Calculate an extended escape route for pads in dense IC pin fields.
 
@@ -2397,6 +2512,9 @@ def calculate_extended_escape_position(
     via_radius = via_size / 2
     trace_half_width = trace_width / 2
     pad_radius = max(pad.width, pad.height) / 2
+
+    # Issue #4432: same-net fill containment gate (see calculate_via_position).
+    same_net_fill_gate = _same_net_fill_on_layer(same_net_filled_polygons, same_net_fill_layer)
 
     # Analyze nearby other-net pads to find escape channels
     nearby_pads = [
@@ -2498,6 +2616,14 @@ def calculate_extended_escape_position(
                 min_hole_to_hole=min_hole_to_hole,
             ):
                 return False
+
+        # Issue #4432: same-net FILL containment gate.  Reject an escape via
+        # landing where the same-net pour has retreated (keepout void /
+        # clearance pullback).  No-op when no same-net fill on the layer.
+        if same_net_fill_gate and not _point_on_same_net_fill(
+            vx, vy, via_radius, same_net_fill_gate, same_net_fill_layer
+        ):
+            return False
 
         return True
 
@@ -3873,6 +3999,8 @@ def run_thermal_stitch(
     other_net_vias = find_all_board_vias(sexp, exclude_nets=target_net_nums)
     other_net_pads = find_all_pads(sexp, exclude_nets=target_net_nums)
     other_net_filled_polys = find_all_filled_polygons(sexp, exclude_nets=target_net_nums)
+    # Issue #4432: same-net zone FILL geometry for the fill-containment gate.
+    same_net_filled_polys = find_same_net_filled_polygons(sexp, target_net_nums)
     # Issue #3855: foreign-net DRILL registry for the hole-to-hole guard.
     # Issue #4010: exclude target-net PAD drills from the base pool too --
     # a thermal via halo rings a TO-220 pad at ~0.55mm from its center,
@@ -4034,12 +4162,23 @@ def run_thermal_stitch(
             ):
                 continue
 
-            # Must fall inside a same-net zone polygon with proper margin.
-            # (When no zones are defined for the net, fall back to placing
-            # the via anyway -- this lets the stitcher be useful on boards
-            # whose zone step has not yet run, at the cost of a possible
-            # DRC warning until zones are added.)
-            if same_net_zones:
+            # Must land on same-net copper with proper margin.
+            #
+            # Issue #4432: prefer the refilled FILL geometry over the zone
+            # OUTLINE.  A via inside the outline but inside a keepout void /
+            # clearance pullback lands where no copper exists and would dangle
+            # once zones refill.  ``_point_on_same_net_fill`` is margin- and
+            # keepout-void-aware (even-odd ray cast excludes holed fill rings).
+            #
+            # Empty-fill no-op: when no same-net fill exists on the target
+            # layer (zones unfilled), fall back to the zone OUTLINE gate so
+            # the stitcher stays usable pre-refill.
+            _, thermal_terminus = get_via_layers(surface_layer, target_layer_by_net.get(net_name))
+            fill_gate = _same_net_fill_on_layer(same_net_filled_polys, thermal_terminus)
+            if fill_gate:
+                if not _point_on_same_net_fill(vx, vy, zone_margin, fill_gate, thermal_terminus):
+                    continue
+            elif same_net_zones:
                 in_zone = False
                 for zp in same_net_zones:
                     if point_in_polygon(vx, vy, zp.points) and _point_has_edge_margin(
@@ -4131,6 +4270,10 @@ def run_blanket_stitch(
     other_net_vias = find_all_board_vias(sexp, exclude_nets=target_net_nums)
     other_net_pads = find_all_pads(sexp, exclude_nets=target_net_nums)
     other_net_filled_polys = find_all_filled_polygons(sexp, exclude_nets=target_net_nums)
+    # Issue #4432: same-net zone FILL geometry.  Blanket vias are seeded from
+    # the fill (not the zone outline) so grid points never land in a keepout
+    # void / clearance pullback where the pour has retreated.
+    same_net_filled_polys = find_same_net_filled_polygons(sexp, target_net_nums)
     # Issue #3855: foreign-net DRILL registry for the hole-to-hole guard.
     # Issue #4010: exclude target-net PAD drills from the base pool too (see
     # the matching note in run_thermal_stitch).  A blanket via ringing a
@@ -4210,9 +4353,31 @@ def run_blanket_stitch(
                     net_target_layer = None
                     result.fallback_nets.append(net_name)
 
-        for zone_poly in zone_polygons:
-            # Generate grid positions inside this zone polygon
-            grid_positions = generate_grid_positions(zone_poly.points, spacing, margin)
+        # Issue #4432: seed the grid from the refilled FILL polygons on the
+        # target layer, not the zone OUTLINE.  ``generate_grid_positions``
+        # keeps only points inside the seed polygon with edge margin, so
+        # seeding from the fill automatically excludes keepout voids /
+        # clearance pullbacks (KiCad keyholes voids into the fill ring, and
+        # both the even-odd containment and the edge-margin check reject them).
+        # Empty-fill no-op: when no same-net fill exists on the target layer
+        # (zones unfilled), fall back to seeding from the zone outline.
+        net_fill_polys = _same_net_fill_on_layer(
+            [fp for fp in same_net_filled_polys if fp.net_number == net_number],
+            net_target_layer,
+        )
+        if net_fill_polys:
+            seed_polygons = [fp.points for fp in net_fill_polys]
+        else:
+            seed_polygons = [zp.points for zp in zone_polygons]
+
+        # Zone layer drives the via's surface terminus (unchanged semantics);
+        # zone polygons for a net share a layer, so read it once here since the
+        # seed loop no longer iterates ``ZonePolygon`` objects (issue #4432).
+        zone_layer_str = zone_polygons[0].layer
+
+        for seed_points in seed_polygons:
+            # Generate grid positions inside this seed polygon
+            grid_positions = generate_grid_positions(seed_points, spacing, margin)
 
             for gx, gy in grid_positions:
                 # Check clearance against all existing copper, including
@@ -4248,7 +4413,7 @@ def run_blanket_stitch(
                 # Determine via layers
                 # For blanket vias, use F.Cu -> target or F.Cu -> B.Cu
                 surface_layer = "F.Cu"
-                if zone_poly.layer.startswith("B."):
+                if zone_layer_str.startswith("B."):
                     surface_layer = "B.Cu"
                 layers = get_via_layers(surface_layer, net_target_layer)
 
@@ -4485,6 +4650,7 @@ def run_stitch(
         pad: PadInfo,
         eff_other_net_tracks: list[TrackSegment],
         eff_other_net_vias: list[tuple[float, float, float, int]],
+        enforce_fill_gate: bool = True,
     ) -> (
         tuple[
             tuple[float, float] | None,
@@ -4497,6 +4663,16 @@ def run_stitch(
         # Per-pad obstacle pools including SIBLING stitch-net pads (see
         # ``_sibling_pools`` above -- board 07 +1V2 via on +1V8 pad short).
         eff_pads, eff_pad_bboxes, eff_drills = _sibling_pools(pad)
+
+        # Issue #4432: resolve the via's deep terminus layer -- the plane fill
+        # the via must bond to lives there.  The same-net FILL gate rejects a
+        # candidate landing where the pour has retreated (keepout void /
+        # clearance pullback).  ``enforce_fill_gate=False`` disables it so the
+        # caller can reclassify a fully-failed pad as needs-routed-fanout vs a
+        # genuine clearance obstruction.  Empty ``same_net_filled_polys``
+        # (unfilled board) makes the gate a no-op regardless.
+        _, terminus_layer = get_via_layers(pad.layer, net_target_layers.get(pad.net_name))
+        fill_gate = same_net_filled_polys if enforce_fill_gate else []
 
         # Calculate via position with clearance checking against all copper,
         # including the connecting trace path from pad to via
@@ -4514,6 +4690,8 @@ def run_stitch(
             other_net_pad_bboxes=eff_pad_bboxes,
             other_net_drills=eff_drills,
             via_drill=drill,
+            same_net_filled_polygons=fill_gate,
+            same_net_fill_layer=terminus_layer,
         )
 
         # Track if we're using dog-leg or extended escape routing
@@ -4538,6 +4716,8 @@ def run_stitch(
                 via_drill=drill,
                 other_net_drills=eff_drills,
                 min_hole_to_hole=MIN_HOLE_TO_HOLE_CLEARANCE,
+                same_net_filled_polygons=fill_gate,
+                same_net_fill_layer=terminus_layer,
             )
 
             if dogleg_pos is None:
@@ -4558,6 +4738,8 @@ def run_stitch(
                     via_drill=drill,
                     other_net_drills=eff_drills,
                     min_hole_to_hole=MIN_HOLE_TO_HOLE_CLEARANCE,
+                    same_net_filled_polygons=fill_gate,
+                    same_net_fill_layer=terminus_layer,
                 )
 
                 if extended_pos is None:
@@ -4578,6 +4760,8 @@ def run_stitch(
                             other_net_pad_bboxes=eff_pad_bboxes,
                             other_net_drills=eff_drills,
                             via_drill=micro_via_drill,
+                            same_net_filled_polygons=fill_gate,
+                            same_net_fill_layer=terminus_layer,
                         )
                         if micro_pos is None:
                             # Also try dogleg with micro-via size
@@ -4595,6 +4779,8 @@ def run_stitch(
                                 via_drill=micro_via_drill,
                                 other_net_drills=eff_drills,
                                 min_hole_to_hole=MIN_HOLE_TO_HOLE_CLEARANCE,
+                                same_net_filled_polygons=fill_gate,
+                                same_net_fill_layer=terminus_layer,
                             )
                             if micro_dogleg is not None:
                                 # Use micro dogleg
@@ -4614,6 +4800,8 @@ def run_stitch(
                                 via_drill=micro_via_drill,
                                 other_net_drills=eff_drills,
                                 min_hole_to_hole=MIN_HOLE_TO_HOLE_CLEARANCE,
+                                same_net_filled_polygons=fill_gate,
+                                same_net_fill_layer=terminus_layer,
                             )
                             if micro_extended is not None:
                                 return (None, None, micro_extended, True)
@@ -4673,6 +4861,33 @@ def run_stitch(
             # band intrusion rather than leaving the pad disconnected.
             fallback_result = _attempt_placement(pad, other_net_tracks, other_net_vias)
             if fallback_result is None:
+                # Issue #4432: distinguish an OFF-FILL failure from a genuine
+                # clearance obstruction.  Re-run placement against the same
+                # pre-existing copper but with the same-net FILL gate DISABLED.
+                # If a candidate now appears, the ONLY blocker was the fill
+                # gate -- the pad sits in a void band / clearance pullback
+                # where a local via would dangle (``via_dangling``).  Report it
+                # as needing a routed fanout to the fill edge instead of
+                # placing (or reporting a bogus clearance conflict for) it.
+                if same_net_filled_polys and (
+                    _attempt_placement(
+                        pad,
+                        other_net_tracks,
+                        other_net_vias,
+                        enforce_fill_gate=False,
+                    )
+                    is not None
+                ):
+                    reason = (
+                        "no same-net fill at candidate site -- pad sits in a "
+                        "keepout void / clearance pullback where the pour has "
+                        "retreated; needs routed fanout to the fill edge (a "
+                        "local via would dangle once zones refill)"
+                    )
+                    result.needs_routed_fanout.append((pad, reason))
+                    result.pads_skipped.append((pad, reason))
+                    continue
+
                 # Genuinely no placement even against pre-existing copper --
                 # this is a real obstruction, not a self-inflicted cross-net
                 # rejection.  Record the skip diagnostic as before.
@@ -5358,6 +5573,19 @@ def output_result(
             "clearance graze to avoid stranding the pad)"
         )
         for pad, _reason in result.connectivity_fallback[:5]:
+            print(f"      - {pad.net_name}: {pad.reference}.{pad.pad_number}")
+    if result.needs_routed_fanout:
+        # Issue #4432: pads whose only reachable via site is OFF the same-net
+        # fill (keepout void / clearance pullback).  A local via would dangle,
+        # so it was NOT placed -- the pad needs a routed fanout to the fill
+        # edge.  Surfaced distinctly so the operator does not read a bogus
+        # "Added via near X" success for a pad that stayed unconnected.
+        print(
+            f"  ~ {len(result.needs_routed_fanout)} pad(s) need routed fanout "
+            "(only reachable via site is off same-net fill -- inside a keepout "
+            "void / clearance pullback; a local via would dangle)"
+        )
+        for pad, _reason in result.needs_routed_fanout[:5]:
             print(f"      - {pad.net_name}: {pad.reference}.{pad.pad_number}")
     if result.pads_skipped:
         print(f"  ! Skipped {len(result.pads_skipped)} pads (manual placement needed)")

--- a/tests/test_stitch_cmd.py
+++ b/tests/test_stitch_cmd.py
@@ -21,6 +21,8 @@ from kicad_tools.cli.stitch_cmd import (
     _fallback_grazes_foreign_pour,
     _fallback_overlaps_sibling_stitch,
     _is_ground_net,
+    _point_on_same_net_fill,
+    _same_net_fill_on_layer,
     _should_use_stackup_fallback,
     calculate_dogleg_via_position,
     calculate_extended_escape_position,
@@ -7873,3 +7875,388 @@ class TestMultiNetPreexistingHoleGuard:
                 - j1_drill / 2
             )
             assert edge + 1e-3 >= MIN_HOLE_TO_HOLE_CLEARANCE
+
+
+# ---------------------------------------------------------------------------
+# Issue #4432: stitch must validate via candidates against the refilled FILL
+# (filled_polygon), not the zone OUTLINE.  Vias that land where the pour has
+# retreated (keepout void / clearance pullback) dangle once zones refill.
+# ---------------------------------------------------------------------------
+
+# Pad-based board: GND plane on In1.Cu whose refilled copper has RETREATED to
+# the right half (x >= 125).  The left half (x < 125) is inside the zone
+# OUTLINE but has NO fill -- a via there would dangle.  One GND SMD pad sits
+# in the void band, one sits over solid fill.
+FILL_RETREAT_TEST_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (zone (net 1) (net_name "GND") (layer "In1.Cu") (uuid "zone-retreat-gnd")
+    (name "GND_plane")
+    (connect_pads (clearance 0.2))
+    (min_thickness 0.2)
+    (fill yes)
+    (polygon (pts (xy 100 100) (xy 140 100) (xy 140 140) (xy 100 140)))
+    (filled_polygon (layer "In1.Cu") (pts (xy 125 100) (xy 140 100) (xy 140 140) (xy 125 140)))
+  )
+  (footprint "Capacitor_SMD:C_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-00000000off1")
+    (at 105 120)
+    (property "Reference" "OFFPAD" (at 0 -1.5 0) (layer "F.SilkS") (uuid "ref-off"))
+    (pad "1" smd roundrect (at 0 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+  )
+  (footprint "Capacitor_SMD:C_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000on1")
+    (at 132 120)
+    (property "Reference" "ONPAD" (at 0 -1.5 0) (layer "F.SilkS") (uuid "ref-on"))
+    (pad "1" smd roundrect (at 0 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+  )
+)
+"""
+
+
+# Same board WITHOUT any filled_polygon nodes -- zone OUTLINE only (unfilled
+# board).  The fill gate must be a no-op here so both pads still stitch.
+EMPTY_FILL_TEST_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (zone (net 1) (net_name "GND") (layer "In1.Cu") (uuid "zone-nofill-gnd")
+    (name "GND_plane")
+    (connect_pads (clearance 0.2))
+    (min_thickness 0.2)
+    (fill yes)
+    (polygon (pts (xy 100 100) (xy 140 100) (xy 140 140) (xy 100 140)))
+  )
+  (footprint "Capacitor_SMD:C_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-00000000off2")
+    (at 105 120)
+    (property "Reference" "OFFPAD" (at 0 -1.5 0) (layer "F.SilkS") (uuid "ref-off2"))
+    (pad "1" smd roundrect (at 0 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+  )
+  (footprint "Capacitor_SMD:C_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000on2")
+    (at 132 120)
+    (property "Reference" "ONPAD" (at 0 -1.5 0) (layer "F.SilkS") (uuid "ref-on2"))
+    (pad "1" smd roundrect (at 0 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+  )
+)
+"""
+
+
+def _fill_layer_pcb(filled_polygon_line: str) -> str:
+    """Build a thermal-pad board with a configurable GND fill on In1.Cu.
+
+    A single 5x5mm exposed GND pad (Q1) sits centred at (110, 110).  The
+    caller supplies the ``(filled_polygon ...)`` s-expression line (or an
+    empty string for an unfilled board) to control where the pour actually
+    exists relative to the pad.
+    """
+    return f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (zone (net 1) (net_name "GND") (layer "In1.Cu") (uuid "zone-thermal-gnd")
+    (name "GND_plane")
+    (connect_pads (clearance 0.2))
+    (min_thickness 0.2)
+    (fill yes)
+    (polygon (pts (xy 100 100) (xy 140 100) (xy 140 140) (xy 100 140)))
+    {filled_polygon_line}
+  )
+  (footprint "Package_DFN_QFN:QFN-EP"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000q1000")
+    (at 110 110)
+    (property "Reference" "Q1" (at 0 -3 0) (layer "F.SilkS") (uuid "ref-q1"))
+    (pad "1" smd roundrect (at 0 0) (size 5 5) (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.1) (net 1 "GND"))
+  )
+)
+"""
+
+
+# Blanket board: GND plane on In1.Cu whose refilled copper covers only the
+# LEFT half (x <= 114).  The right half (x > 114) is inside the zone OUTLINE
+# but has no fill -- blanket vias must not be seeded there.
+BLANKET_VOID_TEST_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (31 "B.Cu" signal)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (zone (net 1) (net_name "GND") (layer "In1.Cu") (uuid "zone-blanket-void")
+    (name "GND_plane")
+    (connect_pads (clearance 0.2))
+    (min_thickness 0.2)
+    (fill yes)
+    (polygon (pts (xy 100 100) (xy 130 100) (xy 130 130) (xy 100 130)))
+    (filled_polygon (layer "In1.Cu") (pts (xy 100 100) (xy 114 100) (xy 114 130) (xy 100 130)))
+  )
+)
+"""
+
+
+class TestPointOnSameNetFillHelper:
+    """Unit tests for the ``_point_on_same_net_fill`` / gate helpers (#4432)."""
+
+    # A holed fill ring: outer 20x20 square with a 4x4 keepout void centred at
+    # (10, 10), keyholed via a zero-width seam on the left edge (y=10).  The
+    # even-odd ray cast treats the void interior as OUTSIDE.
+    HOLED_RING = [
+        (0, 0),
+        (20, 0),
+        (20, 20),
+        (0, 20),
+        (0, 10),
+        (8, 10),
+        (8, 8),
+        (12, 8),
+        (12, 12),
+        (8, 12),
+        (8, 10),
+        (0, 10),
+    ]
+
+    def _fp(self, points, layer="In1.Cu", net_number=1, net_name="GND"):
+        return FilledPolygon(net_number=net_number, net_name=net_name, layer=layer, points=points)
+
+    def test_true_on_solid_fill(self):
+        """A point well inside solid fill returns True."""
+        fp = self._fp([(40, 40), (60, 40), (60, 60), (40, 60)])
+        assert _point_on_same_net_fill(50, 50, 0.225, [fp], "In1.Cu") is True
+
+    def test_false_inside_keepout_void(self):
+        """A point inside a holed ring's keepout void returns False."""
+        fp = self._fp(self.HOLED_RING)
+        # (10, 10) is the centre of the 4x4 void -> off fill.
+        assert _point_on_same_net_fill(10, 10, 0.225, [fp], "In1.Cu") is False
+        # A point in the solid part of the same ring -> on fill.
+        assert _point_on_same_net_fill(3, 3, 0.225, [fp], "In1.Cu") is True
+
+    def test_margin_aware_rejects_pad_overhang(self):
+        """A centre on fill but whose pad radius overhangs the edge is False."""
+        fp = self._fp([(40, 40), (60, 40), (60, 60), (40, 60)])
+        # Centre 0.1mm inside the x=60 edge; a 0.225 radius pad overhangs it.
+        assert _point_on_same_net_fill(59.9, 50, 0.225, [fp], "In1.Cu") is False
+
+    def test_filters_by_layer(self):
+        """Only fill on the requested layer counts."""
+        fp = self._fp([(40, 40), (60, 40), (60, 60), (40, 60)], layer="In1.Cu")
+        assert _point_on_same_net_fill(50, 50, 0.225, [fp], "B.Cu") is False
+        assert _point_on_same_net_fill(50, 50, 0.225, [fp], "In1.Cu") is True
+
+    def test_gate_helper_empty_when_no_fill_on_layer(self):
+        """``_same_net_fill_on_layer`` returns [] (gate off) when no fill matches."""
+        fp = self._fp([(40, 40), (60, 40), (60, 60), (40, 60)], layer="In1.Cu")
+        assert _same_net_fill_on_layer([fp], "B.Cu") == []
+        assert _same_net_fill_on_layer([], "In1.Cu") == []
+        assert _same_net_fill_on_layer([fp], "In1.Cu") == [fp]
+        # layer=None -> no filter (all fills qualify).
+        assert _same_net_fill_on_layer([fp], None) == [fp]
+
+
+class TestStitchFillContainmentGate:
+    """Issue #4432: pad-based stitch rejects off-fill via sites."""
+
+    def test_off_fill_pad_reported_not_stitched(self, tmp_path: Path):
+        """A GND pad in the void band is reported needs-routed-fanout, no via."""
+        pcb_file = tmp_path / "retreat.kicad_pcb"
+        pcb_file.write_text(FILL_RETREAT_TEST_PCB)
+
+        result = run_stitch(
+            pcb_path=pcb_file,
+            net_names=["GND"],
+            via_size=0.45,
+            drill=0.2,
+            clearance=0.2,
+            offset=0.5,
+            trace_width=0.2,
+            dry_run=True,
+        )
+
+        # The off-fill pad must NOT receive a via and must be flagged.
+        fanout_refs = {pad.reference for pad, _ in result.needs_routed_fanout}
+        assert "OFFPAD" in fanout_refs
+        placed_refs = {v.pad.reference for v in result.vias_added}
+        assert "OFFPAD" not in placed_refs
+
+    def test_on_fill_pad_still_stitched(self, tmp_path: Path):
+        """A GND pad over solid fill still gets a via (no over-rejection)."""
+        pcb_file = tmp_path / "retreat.kicad_pcb"
+        pcb_file.write_text(FILL_RETREAT_TEST_PCB)
+
+        result = run_stitch(
+            pcb_path=pcb_file,
+            net_names=["GND"],
+            via_size=0.45,
+            drill=0.2,
+            clearance=0.2,
+            offset=0.5,
+            trace_width=0.2,
+            dry_run=True,
+        )
+
+        placed_refs = {v.pad.reference for v in result.vias_added}
+        assert "ONPAD" in placed_refs
+        # The placed via lands on the fill (x >= 125 solid boundary).
+        on_via = next(v for v in result.vias_added if v.pad.reference == "ONPAD")
+        assert on_via.via_x >= 125.0
+
+    def test_empty_fill_is_noop(self, tmp_path: Path):
+        """With no filled_polygon nodes the gate is inactive: both pads stitch."""
+        pcb_file = tmp_path / "nofill.kicad_pcb"
+        pcb_file.write_text(EMPTY_FILL_TEST_PCB)
+
+        result = run_stitch(
+            pcb_path=pcb_file,
+            net_names=["GND"],
+            via_size=0.45,
+            drill=0.2,
+            clearance=0.2,
+            offset=0.5,
+            trace_width=0.2,
+            dry_run=True,
+        )
+
+        assert result.needs_routed_fanout == []
+        placed_refs = {v.pad.reference for v in result.vias_added}
+        assert {"OFFPAD", "ONPAD"} <= placed_refs
+
+
+class TestThermalFillContainmentGate:
+    """Issue #4432: thermal stitch gates candidates on fill, not outline."""
+
+    def test_thermal_pad_over_fill_places_vias(self, tmp_path: Path):
+        """Thermal vias are placed when the fill covers the pad."""
+        pcb_file = tmp_path / "thermal_fill.kicad_pcb"
+        pcb_file.write_text(
+            _fill_layer_pcb(
+                '(filled_polygon (layer "In1.Cu") '
+                "(pts (xy 100 100) (xy 140 100) (xy 140 140) (xy 100 140)))"
+            )
+        )
+
+        result = run_thermal_stitch(
+            pcb_path=pcb_file,
+            net_names=["GND"],
+            vias_per_pad=4,
+            dry_run=True,
+        )
+        assert len(result.vias_added) > 0
+
+    def test_thermal_pad_in_void_rejected(self, tmp_path: Path):
+        """No thermal via lands where the fill has retreated from the pad."""
+        pcb_file = tmp_path / "thermal_void.kicad_pcb"
+        # Fill retreated to x >= 130; the pad (bbox 107.5-112.5) is fully void.
+        pcb_file.write_text(
+            _fill_layer_pcb(
+                '(filled_polygon (layer "In1.Cu") '
+                "(pts (xy 130 100) (xy 140 100) (xy 140 140) (xy 130 140)))"
+            )
+        )
+
+        result = run_thermal_stitch(
+            pcb_path=pcb_file,
+            net_names=["GND"],
+            vias_per_pad=4,
+            dry_run=True,
+        )
+        assert len(result.vias_added) == 0
+        assert any("thermal" in reason for _pad, reason in result.pads_skipped)
+
+    def test_thermal_empty_fill_is_noop(self, tmp_path: Path):
+        """With no fill geometry the outline gate still places thermal vias."""
+        pcb_file = tmp_path / "thermal_nofill.kicad_pcb"
+        pcb_file.write_text(_fill_layer_pcb(""))
+
+        result = run_thermal_stitch(
+            pcb_path=pcb_file,
+            net_names=["GND"],
+            vias_per_pad=4,
+            dry_run=True,
+        )
+        assert len(result.vias_added) > 0
+
+
+class TestBlanketFillContainmentGate:
+    """Issue #4432: blanket stitch seeds the grid from fill, not outline."""
+
+    def test_blanket_grid_confined_to_fill(self, tmp_path: Path):
+        """No blanket via lands in the void band beyond the fill boundary."""
+        pcb_file = tmp_path / "blanket_void.kicad_pcb"
+        pcb_file.write_text(BLANKET_VOID_TEST_PCB)
+
+        result = run_blanket_stitch(
+            pcb_path=pcb_file,
+            net_names=["GND"],
+            via_size=0.45,
+            drill=0.2,
+            clearance=0.2,
+            spacing=3.0,
+            dry_run=True,
+        )
+
+        assert len(result.vias_added) > 0
+        # Fill covers x <= 114; every seeded via must stay on it (with margin).
+        assert all(v.via_x <= 114.5 for v in result.vias_added)
+
+    def test_blanket_empty_fill_spans_outline(self, tmp_path: Path):
+        """With no fill the grid still spans the full zone outline (no-op)."""
+        pcb_file = tmp_path / "blanket_nofill.kicad_pcb"
+        pcb_file.write_text(BLANKET_TEST_PCB)
+
+        result = run_blanket_stitch(
+            pcb_path=pcb_file,
+            net_names=["GND"],
+            via_size=0.45,
+            drill=0.2,
+            clearance=0.2,
+            spacing=3.0,
+            dry_run=True,
+        )
+        # Outline spans x 100-130; grid should reach beyond x=115 (no fill gate).
+        assert any(v.via_x > 115 for v in result.vias_added)


### PR DESCRIPTION
## Summary

`kct stitch` decided where a stitching via could land by testing the
candidate against the zone **OUTLINE**, never the refilled copper
(`filled_polygon`). The pour retreats from the outline wherever a copper
keepout, thermal relief, clearance pullback, or island split removes fill, so
a via dropped in a retreated region has no same-net copper to bond to and
`kicad-cli pcb drc --refill-zones` reports it as `via_dangling` once zones
refill (softstart rev-C: 27 hits). Each dangling via also strands its
pad-to-via escape trace, and the "Added via near X" line read as success.

This adds a same-net **fill containment gate** to candidate acceptance across
all three stitch modes, keyed off `find_same_net_filled_polygons`.

## Changes

- **Helpers** (`stitch_cmd.py`): `_point_on_same_net_fill` (margin- and
  layer-aware, reuses the even-odd `point_in_polygon`, which already excludes
  keepout voids KiCad keyholes into the fill ring) and `_same_net_fill_on_layer`
  (drives the empty-fill no-op).
- **Pad-based path**: thread `same_net_filled_polygons` + the resolved via
  terminus layer into `calculate_via_position` and its dog-leg /
  extended-escape / micro-via siblings; reject candidates landing off same-net
  fill **after** the existing clearance checks pass.
- **Thermal path** (`run_thermal_stitch`): replace the outline gate
  (`point_in_polygon(vx, vy, zp.points)` + edge margin) with the fill gate.
- **Blanket path** (`run_blanket_stitch`): seed the grid from the
  `filled_polygon`, not `zone_poly.points` (outline).
- **Reporting**: off-fill pads recorded in a new
  `StitchResult.needs_routed_fanout` bucket + a distinct CLI summary line,
  instead of a bogus "Added via near X".
- **Empty-fill guard**: the gate is a no-op when no same-net fill exists on
  the target layer (unfilled board), falling back to today's outline behaviour
  so stitch stays usable pre-refill.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Validate candidates against the refilled fill, not the outline | ✅ | Fill gate threaded into pad/thermal/blanket paths; helper reuses void-aware `point_in_polygon` |
| Sites with no fill reported as "needs routed fanout" not a dangling via | ✅ | `needs_routed_fanout` bucket + CLI line; `test_off_fill_pad_reported_not_stitched` |
| `_point_on_same_net_fill` helper (margin + layer filtered) | ✅ | `TestPointOnSameNetFillHelper` (solid True, keepout-void False, overhang False, layer filter) |
| On-fill happy path still stitches | ✅ | `test_on_fill_pad_still_stitched` |
| Empty-fill no-op (pre-refill boards) | ✅ | `test_empty_fill_is_noop`, `test_thermal_empty_fill_is_noop`, `test_blanket_empty_fill_spans_outline` |
| Thermal / blanket keepout-void rejection | ✅ | `test_thermal_pad_in_void_rejected`, `test_blanket_grid_confined_to_fill` |

## Test Plan

- 13 new regression tests in `tests/test_stitch_cmd.py` (off-fill rejection,
  on-fill success, empty-fill no-op x3, thermal void rejection, blanket void
  confinement, helper unit tests) — all pass.
- Full `tests/test_stitch_cmd.py`: 296 passed.
- `ruff format --check` + `ruff check .`: clean.
- mypy: 17 pre-existing errors in untouched code, **0 new** (verified
  before/after).

Closes #4432