### PR TITLE
feat(creepage): per-net voltage RANGES {min,max} with worst-case ΔV

### DIFF
--- a/src/kicad_tools/creepage/__init__.py
+++ b/src/kicad_tools/creepage/__init__.py
@@ -19,9 +19,11 @@ from __future__ import annotations
 from .engine import (
     CreepagePair,
     CreepageReport,
+    VoltageInterval,
     compute_creepage_census,
     resolve_hv_nets,
     surface_path_length,
+    voltage_map_from_dict,
 )
 from .standards import (
     DISCLAIMER,
@@ -38,8 +40,10 @@ __all__ = [
     "CreepageReport",
     "CreepageStandard",
     "StandardLookupError",
+    "VoltageInterval",
     "compute_creepage_census",
     "get_standard",
     "resolve_hv_nets",
     "surface_path_length",
+    "voltage_map_from_dict",
 ]

--- a/src/kicad_tools/creepage/engine.py
+++ b/src/kicad_tools/creepage/engine.py
@@ -36,7 +36,7 @@ import heapq
 import math
 import re
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from kicad_tools._shapely import has_shapely, require_shapely
 
@@ -78,36 +78,110 @@ def _norm_net_key(name: str) -> str:
 # Reserved voltage-map key (#4371): the board-edge / earth reference potential.
 _EDGE_VOLTAGE_KEY = "_edge_voltage"
 
+# Range-object keys for a swinging-node interval entry (#4411).
+_RANGE_MIN_KEY = "min"
+_RANGE_MAX_KEY = "max"
 
-def voltage_map_from_dict(data: Any) -> tuple[dict[str, float], float]:
-    """Parse a per-net voltage map sidecar (#4371).
 
-    ``data`` maps net names to their **RMS working potential relative to a
-    common reference** (volts), e.g.
-    ``{"/AC_LINE": 150, "/AC_NEUTRAL": 0, "/SCAP_POS": 90}``.  Keys starting
-    with ``_`` are reserved for in-band metadata and are NOT treated as nets
-    (mirrors :func:`kicad_tools.router.rules.net_class_map_from_dict`).  The one
+class VoltageInterval(NamedTuple):
+    """A net's mapped potential as a closed interval ``[lo, hi]`` (volts) (#4411).
+
+    A single static value ``v`` cannot represent a switching node that *swings*
+    over a range (a common-source net that rides ``-170..+90 V`` every mains
+    cycle in normal operation).  Each mapped net therefore becomes a closed
+    interval:
+
+    * a scalar ``v`` -> the degenerate interval ``(v, v)`` (byte-identical to the
+      pre-#4411 scalar model);
+    * a ``{"min": v0, "max": v1}`` object -> ``(min(v0, v1), max(v0, v1))``.
+
+    Endpoints are worst-case DC-equivalent magnitudes about a common reference
+    (see the census docstring); AC phase relationships are NOT modelled.
+    """
+
+    lo: float
+    hi: float
+
+    @property
+    def is_degenerate(self) -> bool:
+        """``True`` when ``lo == hi`` (equivalent to a scalar voltage)."""
+        return self.lo == self.hi
+
+
+def _as_interval(value: Any) -> VoltageInterval:
+    """Normalise a voltage-map value to a :class:`VoltageInterval`.
+
+    Accepts an already-parsed interval (pass-through) or a bare scalar (a
+    degenerate ``(v, v)`` interval).  This lets the census / HV-union consumers
+    be called with either the interval-typed map from
+    :func:`voltage_map_from_dict` or a plain ``{net: volts}`` scalar map without
+    a separate parse step -- a scalar is exactly its degenerate interval.
+    """
+    if isinstance(value, VoltageInterval):
+        return value
+    return VoltageInterval(float(value), float(value))
+
+
+def voltage_map_from_dict(data: Any) -> tuple[dict[str, VoltageInterval], float]:
+    """Parse a per-net voltage map sidecar (#4371, ranges added #4411).
+
+    ``data`` maps net names to their **working potential relative to a common
+    reference** (volts).  Each entry is EITHER a scalar (a single static
+    potential) OR a ``{"min": v0, "max": v1}`` object describing a swinging
+    node's excursion, e.g.
+    ``{"/AC_LINE": 150, "/AC_NEUTRAL": 0, "/SRC_NEG": {"min": -170, "max": 90}}``.
+    Every net becomes a closed :class:`VoltageInterval`; a scalar is the
+    degenerate interval ``(v, v)`` and a range is normalised to
+    ``(min, max)`` (author order is irrelevant).
+
+    Keys starting with ``_`` are reserved for in-band metadata and are NOT
+    treated as nets (mirrors
+    :func:`kicad_tools.router.rules.net_class_map_from_dict`).  The one
     recognised reserved key is ``_edge_voltage`` -- the board-edge / earth
-    reference potential (default ``0.0`` V).
+    reference potential (default ``0.0`` V).  ``_edge_voltage`` stays a *scalar*
+    (earth is a fixed reference, not a swing); a range object there is rejected.
 
     Returns ``(voltages, edge_voltage)``.
 
     Raises:
         TypeError: if ``data`` is not a dict.
-        ValueError: if any net voltage (or ``_edge_voltage``) is not a finite
-            real number.
+        ValueError: if any net voltage endpoint (or ``_edge_voltage``) is not a
+            finite real number, or a range object is malformed.
     """
     if not isinstance(data, dict):
         raise TypeError(f"voltage_map_from_dict expects a dict, got {type(data).__name__}")
-    voltages: dict[str, float] = {}
+    voltages: dict[str, VoltageInterval] = {}
     edge_voltage = 0.0
     for key, value in data.items():
         if isinstance(key, str) and key.startswith("_"):
             if key == _EDGE_VOLTAGE_KEY:
-                edge_voltage = _coerce_voltage(key, value)
+                edge_voltage = _coerce_voltage(key, value)  # scalar-only reference
             continue  # other _-prefixed keys are documentation (_comment, ...)
-        voltages[str(key)] = _coerce_voltage(key, value)
+        voltages[str(key)] = _coerce_interval(key, value)
     return voltages, edge_voltage
+
+
+def _coerce_interval(key: Any, value: Any) -> VoltageInterval:
+    """Coerce a voltage-map value to a :class:`VoltageInterval` or raise.
+
+    A scalar becomes the degenerate interval ``(v, v)``; a
+    ``{"min": v0, "max": v1}`` object is normalised to ``(min, max)``.  Both
+    endpoints go through the existing :func:`_coerce_voltage` finite/real/no-bool
+    checks.  A malformed range object (missing a key, carrying extra keys, or a
+    non-numeric endpoint) raises ``ValueError`` in the same style as the scalar
+    message.
+    """
+    if isinstance(value, dict):
+        if set(value) != {_RANGE_MIN_KEY, _RANGE_MAX_KEY}:
+            raise ValueError(
+                f"voltage-map range entry for {key!r} must be an object with exactly "
+                f"'min' and 'max' keys, got keys {sorted(value)!r}"
+            )
+        lo = _coerce_voltage(f"{key}.min", value[_RANGE_MIN_KEY])
+        hi = _coerce_voltage(f"{key}.max", value[_RANGE_MAX_KEY])
+        return VoltageInterval(min(lo, hi), max(lo, hi))
+    v = _coerce_voltage(key, value)
+    return VoltageInterval(v, v)
 
 
 def _coerce_voltage(key: Any, value: Any) -> float:
@@ -340,7 +414,7 @@ class CreepageReport:
     # a ``{net_name: volts}`` map when the requirement is derived per pair from
     # ``|ΔV|`` instead of one global working voltage.  When set, the report-level
     # ``required_creepage_mm`` / ``working_voltage`` are ``None`` (per-pair).
-    voltage_map: dict[str, float] | None = None
+    voltage_map: dict[str, VoltageInterval] | None = None
     edge_voltage: float = 0.0
 
     @property
@@ -425,7 +499,13 @@ class CreepageReport:
         # keys are added ONLY in map mode, so single-voltage output is unchanged.
         if self.voltage_map is not None:
             d["voltage_source"] = "per-pair |dV| (voltage-map)"
-            d["voltage_map"] = dict(self.voltage_map)
+            # Backward-compat (#4411): echo a degenerate interval (lo == hi) as a
+            # bare scalar so an all-scalar map serialises byte-identically to the
+            # pre-range schema; a genuine swing surfaces as ``{"min", "max"}``.
+            d["voltage_map"] = {
+                name: (iv.lo if iv.is_degenerate else {"min": iv.lo, "max": iv.hi})
+                for name, iv in self.voltage_map.items()
+            }
             d["edge_voltage_v"] = self.edge_voltage
         return d
 
@@ -440,7 +520,7 @@ def resolve_hv_nets(
     net_class: str,
     net_class_map: dict[str, NetClassRouting] | None = None,
     *,
-    voltage_map: dict[str, float] | None = None,
+    voltage_map: dict[str, VoltageInterval] | None = None,
     edge_voltage: float = 0.0,
     census_threshold: float | None = None,
 ) -> dict[int, str]:
@@ -466,8 +546,9 @@ def resolve_hv_nets(
        always wins (step 1), so operator-supplied classification is never
        overridden by this fallback.
     4. **Voltage-derived union** (issue #4401) -- when both ``voltage_map`` and
-       ``census_threshold`` are supplied, every net whose mapped potential
-       differs from ``edge_voltage`` by at least ``census_threshold`` volts is
+       ``census_threshold`` are supplied, every net whose worst-case magnitude
+       relative to ``edge_voltage`` -- ``max(|lo - edge|, |hi - edge|)`` over its
+       mapped interval (#4411) -- is at least ``census_threshold`` volts is
        added, **in union** with the class/name selection above.  This closes the
        false-pass where a high-|V| net carrying a non-HV routing class (e.g. a
        ``±150 V`` gate-drive net classed ``Digital``) was silently excluded from
@@ -508,13 +589,17 @@ def resolve_hv_nets(
     # potential differs from the board-edge reference by >= the threshold,
     # regardless of its routing class.  Union, not replace.
     if voltage_map is not None and census_threshold is not None:
-        norm_vmap = {_norm_net_key(k): float(v) for k, v in voltage_map.items()}
+        norm_vmap = {_norm_net_key(k): _as_interval(v) for k, v in voltage_map.items()}
         for net in pcb.nets.values():
             if net.number == 0 or not net.name:
                 continue
-            v = norm_vmap.get(_norm_net_key(net.name))
-            if v is not None and abs(v - edge_voltage) >= census_threshold:
-                selected[net.number] = net.name
+            iv = norm_vmap.get(_norm_net_key(net.name))
+            if iv is not None:
+                # Worst-case magnitude relative to the edge (#4411): a net that
+                # swings across the threshold in EITHER extreme is pulled in.
+                worst = max(abs(iv.lo - edge_voltage), abs(iv.hi - edge_voltage))
+                if worst >= census_threshold:
+                    selected[net.number] = net.name
 
     return selected
 
@@ -876,7 +961,7 @@ def compute_creepage_census(
     material_group: str | None = None,
     creepage_provenance: dict[str, Any] | None = None,
     clearance_provenance: dict[str, Any] | None = None,
-    voltage_map: dict[str, float] | None = None,
+    voltage_map: dict[str, VoltageInterval] | None = None,
     standard_obj: CreepageStandard | None = None,
     edge_voltage: float = 0.0,
 ) -> CreepageReport:
@@ -892,11 +977,14 @@ def compute_creepage_census(
 
     Per-net voltage model (#4371)
     -----------------------------
-    When ``voltage_map`` (``{net_name: volts}``) **and** ``standard_obj`` are
-    supplied, the requirement is derived **per pair** from the pairwise voltage
-    difference ``dv = |V(a) - V(b)|`` (unmapped nets default to ``0 V``; the
-    board edge uses ``edge_voltage``, default ``0 V`` == earth), instead of one
-    global working voltage.  Same-potential pairs (``dv <= _ZERO_DV_EPS``) get a
+    When ``voltage_map`` (``{net_name: VoltageInterval}``) **and** ``standard_obj``
+    are supplied, the requirement is derived **per pair** from the worst-case
+    pairwise voltage difference ``dv = max(|a.hi - b.lo|, |b.hi - a.lo|)`` over
+    the two nets' closed intervals (#4411) -- a swinging node's excursion can no
+    longer hide behind its dominant static value (unmapped nets default to the
+    degenerate ``0 V`` interval; the board edge uses the degenerate
+    ``edge_voltage`` interval, default ``0 V`` == earth), instead of one global
+    working voltage.  Same-potential pairs (``dv <= _ZERO_DV_EPS``) get a
     required creepage/clearance of ``0.0`` and are a trivial PASS -- this
     short-circuits the standard-table lookup (which starts at 50 V and raises
     for ``V <= 0``).  In map mode the HV-vs-HV pairing skip is relaxed so that
@@ -930,7 +1018,11 @@ def compute_creepage_census(
         required_clearance_mm=required_clearance_mm,
         creepage_provenance=creepage_provenance or {},
         clearance_provenance=clearance_provenance or {},
-        voltage_map=dict(voltage_map) if (map_mode and voltage_map is not None) else None,
+        voltage_map=(
+            {k: _as_interval(v) for k, v in voltage_map.items()}
+            if (map_mode and voltage_map is not None)
+            else None
+        ),
         edge_voltage=edge_voltage,
     )
 
@@ -957,14 +1049,15 @@ def compute_creepage_census(
         )
 
     # --- Per-pair |dV| requirement machinery (map mode only, #4371) ---------
-    norm_vmap: dict[str, float] = {}
+    norm_vmap: dict[str, VoltageInterval] = {}
     if map_mode:
         assert voltage_map is not None
-        norm_vmap = {_norm_net_key(k): float(v) for k, v in voltage_map.items()}
+        norm_vmap = {_norm_net_key(k): _as_interval(v) for k, v in voltage_map.items()}
     _req_cache: dict[float, tuple[float, float, dict[str, Any], dict[str, Any]]] = {}
 
-    def _voltage(name: str) -> float:
-        return norm_vmap.get(_norm_net_key(name), 0.0)
+    def _voltage(name: str) -> VoltageInterval:
+        # Unmapped nets default to the degenerate 0 V interval.
+        return norm_vmap.get(_norm_net_key(name), VoltageInterval(0.0, 0.0))
 
     def _required_for_dv(
         dv: float,
@@ -997,19 +1090,39 @@ def compute_creepage_census(
     def _pair_requirement(
         name_a: str, name_b: str | None, *, edge: bool = False
     ) -> tuple[float, float, dict[str, Any]]:
-        """Per-pair ``(req_creepage, req_clearance, provenance)`` from ``|dV|``."""
-        va = _voltage(name_a)
-        vb = edge_voltage if edge else _voltage(name_b or "")
-        dv = abs(va - vb)
+        """Per-pair ``(req_creepage, req_clearance, provenance)`` from worst-case ``|dV|``.
+
+        Each net is a closed interval (#4411).  The binding stress is the
+        worst-case endpoint combination
+        ``dv = max(|a.hi - b.lo|, |b.hi - a.lo|)`` -- a swinging node's excursion
+        can no longer hide behind its dominant static value.  For two degenerate
+        intervals ``(v, v)``/``(w, w)`` this collapses to ``|v - w|``, so scalar
+        maps reproduce the pre-range behaviour byte-for-byte.  The board edge is
+        the degenerate interval ``(edge_voltage, edge_voltage)``.
+        """
+        a = _voltage(name_a)
+        b = VoltageInterval(edge_voltage, edge_voltage) if edge else _voltage(name_b or "")
+        # Worst-case ΔV over interval endpoints, tracking which endpoints governed.
+        dv_hi_lo = abs(a.hi - b.lo)
+        dv_lo_hi = abs(b.hi - a.lo)
+        if dv_hi_lo >= dv_lo_hi:
+            dv, a_ep, b_ep, va, vb = dv_hi_lo, "hi", "lo", a.hi, b.lo
+        else:
+            dv, a_ep, b_ep, va, vb = dv_lo_hi, "lo", "hi", a.lo, b.hi
         req_creep, req_clear, cprov, clprov = _required_for_dv(dv)
-        prov: dict[str, Any] = {
-            "voltage": {
-                "net_a_v": va,
-                "net_b_v": vb,
-                "delta_v_v": round(dv, 4),
-                "same_potential": dv <= _ZERO_DV_EPS,
-            }
+        voltage_prov: dict[str, Any] = {
+            "net_a_v": va,
+            "net_b_v": vb,
+            "delta_v_v": round(dv, 4),
+            "same_potential": dv <= _ZERO_DV_EPS,
         }
+        # Record the governing endpoints only when a genuine swing was involved,
+        # so an all-scalar (degenerate) map serialises byte-identically to the
+        # pre-#4411 provenance (the endpoint choice is arbitrary when lo == hi).
+        if not (a.is_degenerate and b.is_degenerate):
+            voltage_prov["net_a_endpoint"] = a_ep
+            voltage_prov["net_b_endpoint"] = b_ep
+        prov: dict[str, Any] = {"voltage": voltage_prov}
         if cprov:
             prov["creepage"] = cprov
         if clprov:

--- a/src/kicad_tools/placement/hv_domains.py
+++ b/src/kicad_tools/placement/hv_domains.py
@@ -61,6 +61,16 @@ def load_voltage_map(path: str | Path) -> dict[str, float]:
     net magnitudes and has no concept of an edge/earth reference, so the
     ``edge_voltage`` half of the returned pair is discarded here.
 
+    Range support (#4411): the shared parser now models each net as a closed
+    ``[lo, hi]`` interval so the creepage census can reason about swinging nodes.
+    Placement's cross-domain model is *magnitude-only* (``derive_ref_domains_*``
+    and ``detect_derived_tap_exempt_pairs`` operate on ``abs(...)``), so each
+    interval is collapsed here to its worst-case magnitude ``max(|lo|, |hi|)``,
+    keeping this loader's ``dict[str, float]`` return and confining the range
+    blast radius to the loader.  A scalar entry ``v`` collapses to ``|v|`` --
+    identical to the pre-range behaviour, since the downstream consumers already
+    took ``abs`` of the signed value.
+
     Raises:
         ValueError: If the file is not a JSON object, or if any net voltage is
             not a finite real number.
@@ -70,7 +80,8 @@ def load_voltage_map(path: str | Path) -> dict[str, float]:
         # ``voltage_map_from_dict`` raises ``TypeError`` for a non-dict; keep the
         # historical ``ValueError`` contract for the placement loader's callers.
         raise ValueError(f"voltage map must be a JSON object, got {type(raw).__name__}")
-    return voltage_map_from_dict(raw)[0]
+    intervals = voltage_map_from_dict(raw)[0]
+    return {name: max(abs(iv.lo), abs(iv.hi)) for name, iv in intervals.items()}
 
 
 def load_hv_domains(path: str | Path) -> dict[str, dict]:

--- a/tests/creepage/test_creepage_engine.py
+++ b/tests/creepage/test_creepage_engine.py
@@ -314,7 +314,12 @@ def _std():
 
 
 def _census_map(pcb, hv, vmap, *, edge=0.0, pd=2, mg="IIIa"):
+    from kicad_tools.creepage.engine import voltage_map_from_dict
+
     std = _std()
+    # Route through the shared parser so the census receives the interval-typed
+    # map exactly as the CLI does (scalars -> degenerate intervals, #4411).
+    parsed, _edge = voltage_map_from_dict(vmap)
     return compute_creepage_census(
         pcb,
         hv,
@@ -323,7 +328,7 @@ def _census_map(pcb, hv, vmap, *, edge=0.0, pd=2, mg="IIIa"):
         standard_edition=std.edition,
         pollution_degree=pd,
         material_group=mg,
-        voltage_map=vmap,
+        voltage_map=parsed,
         standard_obj=std,
         edge_voltage=edge,
     )
@@ -336,7 +341,7 @@ def _both_hv_map():
 
 
 def test_voltage_map_from_dict_parses_nets_reserved_keys_and_edge():
-    from kicad_tools.creepage.engine import voltage_map_from_dict
+    from kicad_tools.creepage.engine import VoltageInterval, voltage_map_from_dict
 
     voltages, edge = voltage_map_from_dict(
         {
@@ -346,8 +351,50 @@ def test_voltage_map_from_dict_parses_nets_reserved_keys_and_edge():
             "_comment": "ignored documentation",
         }
     )
-    assert voltages == {"/AC_LINE": 150.0, "/AC_NEUTRAL": 0.0}
+    # Each scalar entry becomes a degenerate interval (v, v) (#4411).
+    assert voltages == {
+        "/AC_LINE": VoltageInterval(150.0, 150.0),
+        "/AC_NEUTRAL": VoltageInterval(0.0, 0.0),
+    }
+    assert all(iv.is_degenerate for iv in voltages.values())
     assert edge == 12.0
+
+
+def test_voltage_map_from_dict_accepts_range_and_normalises_order():
+    # A {min,max} entry becomes a closed interval; author order is irrelevant
+    # (both {min,max} and {max,min} normalise to (min, max)) (#4411).
+    from kicad_tools.creepage.engine import VoltageInterval, voltage_map_from_dict
+
+    voltages, _edge = voltage_map_from_dict(
+        {
+            "/SRC_NEG": {"min": -170, "max": 90},
+            "/SRC_NEG_REV": {"min": 90, "max": -170},  # inverted author order
+            "/STATIC": 42,
+        }
+    )
+    assert voltages["/SRC_NEG"] == VoltageInterval(-170.0, 90.0)
+    assert voltages["/SRC_NEG_REV"] == VoltageInterval(-170.0, 90.0)
+    # A scalar alongside ranges stays degenerate.
+    assert voltages["/STATIC"] == VoltageInterval(42.0, 42.0)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        {"NET": {"min": 0}},  # missing 'max'
+        {"NET": {"max": 0}},  # missing 'min'
+        {"NET": {"min": 0, "max": 1, "typ": 0.5}},  # extra key
+        {"NET": {"min": "x", "max": 1}},  # non-numeric endpoint
+        {"NET": {"min": 0, "max": True}},  # bool endpoint
+        {"NET": {"min": 0, "max": float("nan")}},  # NaN endpoint
+        {"_edge_voltage": {"min": 0, "max": 1}},  # edge stays scalar-only
+    ],
+)
+def test_voltage_map_from_dict_rejects_malformed_range(bad):
+    from kicad_tools.creepage.engine import voltage_map_from_dict
+
+    with pytest.raises(ValueError):
+        voltage_map_from_dict(bad)
 
 
 @pytest.mark.parametrize(
@@ -474,6 +521,118 @@ def test_no_voltage_map_leaves_report_in_single_voltage_mode(tmp_path):
     report = compute_creepage_census(pcb, hv, min_mm=1.5)
     assert report.voltage_map is None
     assert report.uses_voltage_map is False
+
+
+# ---------------------------------------------------------------------------
+# Worst-case interval ΔV (Issue #4411): swinging nodes can no longer hide the
+# real pairwise stress behind a single dominant static value.
+# ---------------------------------------------------------------------------
+
+
+def test_swinging_node_not_reported_same_potential(tmp_path):
+    # SCAP_POS(+90) vs TRK_POS[-146..+90]: the two nets share their DOMINANT
+    # state (+90) so a scalar model would derive dv == 0 (a same-potential false
+    # PASS).  The interval model derives the worst-case excursion:
+    #   dv = max(|90 - 90|, |90 - (-146)|) = 236 V  -> a mains-class requirement.
+    pcb = _load(tmp_path, board_source(with_slot=False))
+    hv = resolve_hv_nets(pcb, "HV", _both_hv_map())
+    report = _census_map(
+        pcb,
+        hv,
+        {"L_MAINS": {"min": -146.0, "max": 90.0}, "GND": 90.0},
+    )
+    conductor = [p for p in report.pairs if p.kind == "conductor"]
+    assert len(conductor) == 1
+    pair = conductor[0]
+    v = pair.provenance["voltage"]
+    assert v["same_potential"] is False
+    assert v["delta_v_v"] == pytest.approx(236.0)
+    # A real, non-trivial creepage requirement is derived (NOT the 0.0 of a
+    # same-potential pair).
+    assert pair.required_creepage_mm is not None and pair.required_creepage_mm > 0.0
+    expected, _ = _std().required_creepage(236.0, 2, "IIIa")
+    assert pair.required_creepage_mm == pytest.approx(expected)
+
+
+def test_worst_case_provenance_records_governing_endpoints(tmp_path):
+    # The binding ΔV came from L_MAINS's low endpoint against GND's high endpoint
+    # (or the symmetric assignment) -- provenance must name which endpoints won.
+    pcb = _load(tmp_path, board_source(with_slot=False))
+    hv = resolve_hv_nets(pcb, "HV", _both_hv_map())
+    report = _census_map(
+        pcb,
+        hv,
+        {"L_MAINS": {"min": -146.0, "max": 90.0}, "GND": 90.0},
+    )
+    pair = next(p for p in report.pairs if p.kind == "conductor")
+    v = pair.provenance["voltage"]
+    assert {"net_a_endpoint", "net_b_endpoint"} <= set(v)
+    # The governing endpoints are the two that are 236 V apart: one net's -146
+    # extreme and the other's +90.  net_a_v / net_b_v echo those governing values.
+    assert {v["net_a_v"], v["net_b_v"]} == {-146.0, 90.0}
+
+
+def test_edge_pair_uses_worst_case_swing_vs_edge(tmp_path):
+    # A net swinging about earth: TRK[-146..+90] vs the board edge (0 V) must use
+    # the worst-case magnitude 146 V, not the +90 dominant value.
+    pcb = _load(tmp_path, board_source(with_slot=False))
+    hv = resolve_hv_nets(pcb, "HV", _hv_map())
+    report = _census_map(pcb, hv, {"L_MAINS": {"min": -146.0, "max": 90.0}})
+    edge = next(p for p in report.pairs if p.kind == "edge")
+    assert edge.provenance["voltage"]["delta_v_v"] == pytest.approx(146.0)
+
+
+def test_degenerate_range_equals_scalar_and_stays_byte_identical(tmp_path):
+    # {min:v, max:v} is exactly the scalar v: same requirement, same provenance
+    # (including NO endpoint keys, so scalar-map JSON is unchanged).
+    pcb = _load(tmp_path, board_source(with_slot=False))
+    hv = resolve_hv_nets(pcb, "HV", _hv_map())
+    scalar = _census_map(pcb, hv, {"L_MAINS": 150.0})
+    ranged = _census_map(pcb, hv, {"L_MAINS": {"min": 150.0, "max": 150.0}})
+    ps = _conductor_pair(scalar, "GND")
+    pr = _conductor_pair(ranged, "GND")
+    assert ps.required_creepage_mm == pr.required_creepage_mm
+    assert ps.provenance == pr.provenance
+    # Degenerate pairs carry NO endpoint provenance (arbitrary when lo == hi).
+    assert "net_a_endpoint" not in ps.provenance["voltage"]
+
+
+def test_scalar_map_report_echo_serialises_as_scalar(tmp_path):
+    # Backward-compat: an all-scalar map echoes bare scalars in to_dict (no
+    # {min,max} wrapping), while a genuine range surfaces as {min,max}.
+    pcb = _load(tmp_path, board_source(with_slot=False))
+    hv = resolve_hv_nets(pcb, "HV", _both_hv_map())
+    scalar = _census_map(pcb, hv, {"L_MAINS": 150.0, "GND": 0.0}).to_dict()
+    assert scalar["voltage_map"] == {"L_MAINS": 150.0, "GND": 0.0}
+    ranged = _census_map(pcb, hv, {"L_MAINS": {"min": -146.0, "max": 90.0}, "GND": 0.0}).to_dict()
+    assert ranged["voltage_map"] == {"L_MAINS": {"min": -146.0, "max": 90.0}, "GND": 0.0}
+
+
+def test_resolve_hv_union_pulls_in_net_swinging_across_threshold(tmp_path):
+    # A net whose DOMINANT state is below threshold but whose swing crosses it
+    # must still be pulled into the census by worst-case magnitude (#4411).
+    from kicad_tools.creepage.engine import VoltageInterval
+
+    pcb = _load(tmp_path, board_no_hv_source())  # nets: SIG, GND
+    # SIG dominant +5 V (below 30 V), but swings to -150 V -> worst-case 150 V.
+    hv = resolve_hv_nets(
+        pcb,
+        "HV",
+        net_class_map=None,
+        voltage_map={"SIG": VoltageInterval(-150.0, 5.0)},
+        census_threshold=30.0,
+    )
+    assert set(hv.values()) == {"SIG"}
+
+    # Dominant +5 V AND a shallow -5 V swing: worst-case 5 V stays below 30 V.
+    hv2 = resolve_hv_nets(
+        pcb,
+        "HV",
+        net_class_map=None,
+        voltage_map={"SIG": VoltageInterval(-5.0, 5.0)},
+        census_threshold=30.0,
+    )
+    assert hv2 == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_placement_hv_domains.py
+++ b/tests/test_placement_hv_domains.py
@@ -109,6 +109,36 @@ class TestLoaders:
         p.write_text(json.dumps({"/AC_LINE": 150, "/REF": 1.65}))
         assert load_voltage_map(p) == {"/AC_LINE": 150.0, "/REF": 1.65}
 
+    def test_load_voltage_map_collapses_range_to_worst_case_magnitude(self, tmp_path) -> None:
+        """A ``{min,max}`` entry collapses to ``max(|lo|, |hi|)`` (#4411).
+
+        Placement's cross-domain model is magnitude-only, so a swinging node is
+        segregated on its worst-case magnitude while the loader keeps returning
+        ``dict[str, float]``.
+        """
+        p = tmp_path / "v.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "/SRC_NEG": {"min": -170, "max": 90},  # worst-case magnitude 170
+                    "/TRK_POS": {"min": -146, "max": 90},  # worst-case magnitude 146
+                    "/REF": 1.65,  # scalar collapses to |1.65| = 1.65
+                }
+            )
+        )
+        assert load_voltage_map(p) == {
+            "/SRC_NEG": 170.0,
+            "/TRK_POS": 146.0,
+            "/REF": 1.65,
+        }
+
+    def test_load_voltage_map_rejects_malformed_range(self, tmp_path) -> None:
+        """A malformed range object propagates the shared parser's ``ValueError``."""
+        p = tmp_path / "v.json"
+        p.write_text(json.dumps({"/AC_LINE": {"min": 0}}))  # missing 'max'
+        with pytest.raises(ValueError):
+            load_voltage_map(p)
+
     def test_load_voltage_map_rejects_non_numeric(self, tmp_path) -> None:
         p = tmp_path / "v.json"
         p.write_text(json.dumps({"/AC_LINE": "high"}))


### PR DESCRIPTION
Closes #4411

## Summary
Extends the shared voltage-map parser to accept a per-net **range** `{"min": ..., "max": ...}` in addition to a scalar, and has the creepage census reason over the **worst-case |ΔV|** using the interval extremes. Scalar entries remain byte-identical (degenerate interval collapses to `|v−w|`).

## Changes
- `src/kicad_tools/creepage/engine.py` — `voltage_map_from_dict` now yields `VoltageInterval(lo, hi)` per net (scalar → degenerate `(v,v)`); endpoints reuse the existing `_coerce_voltage` finite/real/no-bool checks; `_edge_voltage` stays scalar. `_pair_requirement` uses `dv = max(|a.hi − b.lo|, |b.hi − a.lo|)` with governing-endpoint provenance. `resolve_hv_nets` union membership uses worst-case magnitude vs `edge_voltage`. `CreepageReport.voltage_map` `to_dict` echo serializes a **scalar** when `lo == hi` (scalar-map JSON unchanged).
- `src/kicad_tools/creepage/__init__.py` — export `VoltageInterval`.
- `src/kicad_tools/placement/hv_domains.py` — `load_voltage_map` collapses each interval to `max(|lo|,|hi|)`, keeping its `dict[str,float]` return, so placement's magnitude-only cross-domain model is unchanged (blast radius confined to the loader).

## Backward-compat
- Scalar map entries produce byte-identical census output and JSON.
- The same-potential false-PASS case (e.g. `SCAP_POS(+90) ↔ TRK_POS[−146…+90]` ≈ 236 V real stress) now flags.
- RMS-vs-peak interpretation unchanged; AC phase modelling out of scope.

## Gates
- `tests/creepage/ tests/test_placement_hv_domains.py` → 230 passed.
- ruff check + format: clean on all 5 files.
- Local mypy note: the baseline gate flags pre-existing entries in `recovery/strategy.py` / `mcp/server.py` (files this PR does not touch) under the local **python3.14** venv; CI's Type Check runs **python3.12** where the baseline matches. #4411's own 3 source files are mypy-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)