### PR TITLE
fix(route): stop net-class-map sidecar from overwriting the user's input file

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -1985,10 +1985,39 @@ def show_preview(
         return "n"
 
 
+def _sidecar_collides_with_input(input_path: Path, sidecar_path: Path) -> bool:
+    """True when the derived sidecar would overwrite the user's input file.
+
+    Issue #4428: the derived sidecar basename (``net_class_map.json``) is
+    identical to the natural name of a hand-authored ``--net-class-map``
+    file, so when the routed board is written into the directory that holds
+    the user's input, the two paths are the *same file* and the route step
+    silently clobbers the authored constraints.  This detects that
+    collision so the caller can divert the write.
+
+    Uses :func:`os.path.samefile` (inode identity — handles symlinks and
+    ``./`` / ``../`` path noise) when both paths exist; falls back to
+    resolved-path equality when the sidecar target does not yet exist.
+    """
+    import os
+
+    try:
+        if input_path.exists() and sidecar_path.exists():
+            return os.path.samefile(str(input_path), str(sidecar_path))
+    except OSError:
+        pass
+    try:
+        return input_path.resolve() == sidecar_path.resolve()
+    except OSError:
+        return False
+
+
 def _write_net_class_map_sidecar(
     output_path: Path,
     net_class_map: dict | None,
     quiet: bool = False,
+    input_path: Path | None = None,
+    loaded_net_class_map: dict | None = None,
 ) -> None:
     """Serialize the router's net-class map to a sidecar next to the PCB.
 
@@ -2002,24 +2031,61 @@ def _write_net_class_map_sidecar(
     continuity rules.  A blocked write (read-only output dir) is a
     non-fatal warning, never a route failure.
 
+    Issue #4428 — never overwrite the user's input file: when the routed
+    board is written into the same directory that holds the user's
+    hand-authored ``--net-class-map`` file, the derived sidecar path
+    resolves to the *exact same file* the user passed in.  When
+    ``input_path`` collides with the derived ``net_class_map.json``, the
+    write is diverted to a sibling ``net_class_map.effective.json`` so the
+    authored input is left untouched.  In the common (no-collision) case the
+    plain ``net_class_map.json`` name is kept so ``kct check`` auto-discovery
+    is unaffected.
+
+    Issue #4428 — round-trip fidelity: when a user map was loaded, its
+    authored entries are merged *over* the classifier output before
+    serialization so resolved HV nets keep their authored ``name`` /
+    ``target_ampacity`` / ``avoid_layers`` instead of the name-pattern
+    classifier's guess (e.g. ``AC_LINE`` would otherwise re-serialize as the
+    classifier's ``'Audio'``).
+
     Args:
         output_path: Path to the routed PCB file.  The sidecar is written
             to the same directory.
         net_class_map: The autorouter's ``{net_name: NetClassRouting}``
-            map.  Skipped when ``None`` or empty (an empty map would write
-            a misleading sidecar that the check-side probe would treat as
-            present).
+            map.  Skipped when empty *and* no ``loaded_net_class_map`` is
+            supplied (an empty map would write a misleading sidecar that the
+            check-side probe would treat as present).
         quiet: If True, suppress the confirmation line.
+        input_path: The resolved ``--net-class-map`` INPUT path (or
+            ``None``).  Used only to detect — and avoid — a self-overwrite
+            of the user's authored file.
+        loaded_net_class_map: The user's loaded ``{net_name: NetClassRouting}``
+            map (``args._loaded_net_class_map``), merged over
+            ``net_class_map`` for round-trip fidelity.
     """
-    if not net_class_map:
-        return
     import json
 
     from kicad_tools.router.rules import net_class_map_to_dict
 
+    # Round-trip fidelity (Issue #4428): overlay the user's authored entries
+    # on the classifier output so resolved HV nets keep their authored
+    # name / target_ampacity / avoid_layers rather than the name-pattern guess.
+    effective_map = dict(net_class_map or {})
+    if loaded_net_class_map:
+        effective_map.update(loaded_net_class_map)
+    if not effective_map:
+        return
+
     sidecar_path = output_path.parent / "net_class_map.json"
+
+    # Never clobber the user's --net-class-map input file (Issue #4428).
+    diverted = False
+    if input_path is not None and _sidecar_collides_with_input(input_path, sidecar_path):
+        sidecar_path = output_path.parent / "net_class_map.effective.json"
+        diverted = True
+
     try:
-        payload = net_class_map_to_dict(net_class_map)
+        payload = net_class_map_to_dict(effective_map)
         sidecar_path.write_text(json.dumps(payload, indent=2))
     except (OSError, TypeError, ValueError) as e:
         # Non-fatal: a blocked / read-only output directory (or an
@@ -2028,7 +2094,10 @@ def _write_net_class_map_sidecar(
             print(f"  Warning: could not write net-class-map sidecar: {e}")
         return
     if not quiet:
-        print(f"  Net-class-map sidecar: {sidecar_path}")
+        if diverted:
+            print(f"  Net-class-map sidecar: {sidecar_path} (input --net-class-map left unchanged)")
+        else:
+            print(f"  Net-class-map sidecar: {sidecar_path}")
 
 
 def _write_fab_profile_sidecar(
@@ -2144,6 +2213,8 @@ def run_post_route_drc(
     net_class_map: dict | None = None,
     copper_oz: float = 1.0,
     strict_drc: bool = False,
+    net_class_map_input_path: Path | None = None,
+    loaded_net_class_map: dict | None = None,
 ) -> tuple[int, int]:
     """Run DRC validation on the routed PCB.
 
@@ -2171,6 +2242,14 @@ def run_post_route_drc(
             that the PASS is not authoritative.  Default ``False``
             preserves the graceful-degradation soft NOTE for KiCad-less
             environments (Issue #4178).
+        net_class_map_input_path: The resolved ``--net-class-map`` INPUT
+            path (Issue #4428).  Threaded to the sidecar writer so it never
+            overwrites the user's authored file when the routed board is
+            written into the same directory.
+        loaded_net_class_map: The user's loaded net-class map
+            (``args._loaded_net_class_map``), merged over the classifier
+            output for round-trip fidelity in the derived sidecar (Issue
+            #4428).
 
     Returns:
         Tuple of (error_count, warning_count)
@@ -2184,7 +2263,13 @@ def run_post_route_drc(
     # This is the shared post-route DRC entry for all three route flows
     # (default multi-layer, rule-relaxation, and single-layer), so writing
     # here covers every callsite in one place.
-    _write_net_class_map_sidecar(output_path, net_class_map, quiet=quiet)
+    _write_net_class_map_sidecar(
+        output_path,
+        net_class_map,
+        quiet=quiet,
+        input_path=net_class_map_input_path,
+        loaded_net_class_map=loaded_net_class_map,
+    )
 
     # Issue #3920: persist the resolved fab profile as a ``fab_profile.json``
     # sidecar next to the routed PCB so bare ``kct check`` auto-discovers the
@@ -5048,6 +5133,13 @@ def route_with_layer_escalation(
             # Issue #4178: forward --strict-drc so a native DRC that did
             # not run becomes a hard failure instead of a soft NOTE.
             strict_drc=getattr(args, "strict_drc", False),
+            # Issue #4428: thread the resolved --net-class-map INPUT path +
+            # loaded map so the derived sidecar never overwrites the user's
+            # authored file and preserves authored HV/ampacity fields.
+            net_class_map_input_path=(
+                Path(args.net_class_map).resolve() if getattr(args, "net_class_map", None) else None
+            ),
+            loaded_net_class_map=getattr(args, "_loaded_net_class_map", None),
         )
 
         # Auto-fix DRC violations if requested
@@ -5745,6 +5837,13 @@ def route_with_rule_relaxation(
             # Issue #4178: forward --strict-drc so a native DRC that did
             # not run becomes a hard failure instead of a soft NOTE.
             strict_drc=getattr(args, "strict_drc", False),
+            # Issue #4428: thread the resolved --net-class-map INPUT path +
+            # loaded map so the derived sidecar never overwrites the user's
+            # authored file and preserves authored HV/ampacity fields.
+            net_class_map_input_path=(
+                Path(args.net_class_map).resolve() if getattr(args, "net_class_map", None) else None
+            ),
+            loaded_net_class_map=getattr(args, "_loaded_net_class_map", None),
         )
 
         # Auto-fix DRC violations if requested
@@ -7959,6 +8058,13 @@ def route_with_combined_escalation(
             # Issue #4178: forward --strict-drc so a native DRC that did
             # not run becomes a hard failure instead of a soft NOTE.
             strict_drc=getattr(args, "strict_drc", False),
+            # Issue #4428: thread the resolved --net-class-map INPUT path +
+            # loaded map so the derived sidecar never overwrites the user's
+            # authored file and preserves authored HV/ampacity fields.
+            net_class_map_input_path=(
+                Path(args.net_class_map).resolve() if getattr(args, "net_class_map", None) else None
+            ),
+            loaded_net_class_map=getattr(args, "_loaded_net_class_map", None),
         )
 
         # Auto-fix DRC violations if requested
@@ -9372,7 +9478,12 @@ def main(argv: list[str] | None = None) -> int:
             "matches KiCad's '/'-prefixed label net /FUSED_LINE while "
             "global power nets (GND, +3.3V) stay bare; keys that match no "
             "board net or match ambiguously are reported on stderr and "
-            "skipped (Issue #4149)."
+            "skipped (Issue #4149).  This INPUT file is never overwritten: "
+            "the route writes a derived sidecar (net_class_map.json) next to "
+            "the routed PCB for kct check auto-discovery, and when that would "
+            "collide with this input file (board written into the same "
+            "directory) the derived map is diverted to "
+            "net_class_map.effective.json instead (Issue #4428)."
         ),
     )
     parser.add_argument(
@@ -12482,6 +12593,12 @@ def main(argv: list[str] | None = None) -> int:
             net_class_map=getattr(router, "net_class_map", None),
             # Issue #4178: forward --strict-drc (see other call sites).
             strict_drc=getattr(args, "strict_drc", False),
+            # Issue #4428: never overwrite the user's --net-class-map input
+            # (see other call sites); preserve authored fields round-trip.
+            net_class_map_input_path=(
+                Path(args.net_class_map).resolve() if getattr(args, "net_class_map", None) else None
+            ),
+            loaded_net_class_map=getattr(args, "_loaded_net_class_map", None),
         )
 
         # Auto-fix DRC violations if requested

--- a/tests/test_cli_check_net_class_map.py
+++ b/tests/test_cli_check_net_class_map.py
@@ -559,6 +559,144 @@ class TestSidecarWrittenByRoute:
             or (ro_dir / "net_class_map.json").exists()
         )
 
+    def test_input_file_not_overwritten_on_collision(self, tmp_path: Path):
+        """Issue #4428: when the routed board lives in the same directory as
+        the user's hand-authored ``net_class_map.json``, the route step must
+        NOT clobber it -- the derived map is diverted to
+        ``net_class_map.effective.json`` instead."""
+        from kicad_tools.cli.route_cmd import _write_net_class_map_sidecar
+        from kicad_tools.router.rules import (
+            NetClassRouting,
+            net_class_map_from_dict,
+            net_class_map_to_dict,
+        )
+
+        # Hand-authored HV input sidecar, sitting next to where the board
+        # will be written.
+        input_path = tmp_path / "net_class_map.json"
+        authored = {
+            "AC_LINE": NetClassRouting(
+                name="HV",
+                target_ampacity=15.0,
+                avoid_layers=[1, 2],
+            )
+        }
+        input_path.write_text(json.dumps(net_class_map_to_dict(authored), indent=2))
+        original_bytes = input_path.read_bytes()
+
+        pcb_out = tmp_path / "board_routed.kicad_pcb"
+        pcb_out.write_text("(kicad_pcb)")
+
+        # The classifier's guess for AC_LINE ("Audio") is what the router map
+        # would carry; the loaded authored map must win in the derived sidecar.
+        classifier = {"AC_LINE": NetClassRouting(name="Audio")}
+
+        _write_net_class_map_sidecar(
+            pcb_out,
+            classifier,
+            quiet=True,
+            input_path=input_path,
+            loaded_net_class_map=authored,
+        )
+
+        # The authored input file is byte-for-byte untouched.
+        assert input_path.read_bytes() == original_bytes
+
+        # The derived map landed in the effective sidecar, not the input file.
+        effective = tmp_path / "net_class_map.effective.json"
+        assert effective.is_file()
+        loaded = net_class_map_from_dict(json.loads(effective.read_text()))
+        # Round-trip fidelity: authored HV fields survive, not "Audio".
+        assert loaded["AC_LINE"].name == "HV"
+        assert loaded["AC_LINE"].target_ampacity == 15.0
+        assert loaded["AC_LINE"].avoid_layers == [1, 2]
+
+    def test_no_collision_writes_plain_sidecar(self, tmp_path: Path):
+        """Issue #4428: when the input path differs from the derived sidecar
+        path (input lives in a different directory), the plain
+        ``net_class_map.json`` is still written so ``kct check`` auto-discovery
+        is unaffected."""
+        from kicad_tools.cli.route_cmd import _write_net_class_map_sidecar
+        from kicad_tools.router.rules import NetClassRouting, net_class_map_to_dict
+
+        # Input in a separate directory -> no collision with the output dir.
+        input_dir = tmp_path / "authored"
+        input_dir.mkdir()
+        input_path = input_dir / "net_class_map.json"
+        input_path.write_text(
+            json.dumps(net_class_map_to_dict({"AC_LINE": NetClassRouting(name="HV")}))
+        )
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        pcb_out = out_dir / "board_routed.kicad_pcb"
+        pcb_out.write_text("(kicad_pcb)")
+
+        _write_net_class_map_sidecar(
+            pcb_out,
+            {"AC_LINE": NetClassRouting(name="HV")},
+            quiet=True,
+            input_path=input_path,
+            loaded_net_class_map={"AC_LINE": NetClassRouting(name="HV")},
+        )
+
+        # Plain sidecar written; no diverted effective sidecar.
+        assert (out_dir / "net_class_map.json").is_file()
+        assert not (out_dir / "net_class_map.effective.json").exists()
+
+    def test_round_trip_fidelity_merges_loaded_over_classifier(self, tmp_path: Path):
+        """Issue #4428: the loaded user map is merged OVER the classifier
+        output before serialization so resolved nets keep authored fields
+        (``name``/``target_ampacity``/``avoid_layers``) rather than the
+        name-pattern guess."""
+        from kicad_tools.cli.route_cmd import _write_net_class_map_sidecar
+        from kicad_tools.router.rules import NetClassRouting, net_class_map_from_dict
+
+        pcb_out = tmp_path / "board_routed.kicad_pcb"
+        pcb_out.write_text("(kicad_pcb)")
+
+        classifier = {"AC_LINE": NetClassRouting(name="Audio")}
+        authored = {"AC_LINE": NetClassRouting(name="HV", target_ampacity=20.0, avoid_layers=[1])}
+
+        # No input collision here (no input_path) -> plain sidecar, but the
+        # authored map must still override the classifier's "Audio".
+        _write_net_class_map_sidecar(pcb_out, classifier, quiet=True, loaded_net_class_map=authored)
+
+        sidecar = tmp_path / "net_class_map.json"
+        loaded = net_class_map_from_dict(json.loads(sidecar.read_text()))
+        assert loaded["AC_LINE"].name == "HV"
+        assert loaded["AC_LINE"].target_ampacity == 20.0
+        assert loaded["AC_LINE"].avoid_layers == [1]
+
+    def test_symlinked_input_resolves_to_same_inode(self, tmp_path: Path):
+        """Issue #4428: a symlinked input path resolving to the same file as
+        the derived sidecar is detected as a collision (samefile inode
+        identity), so the input target is not overwritten."""
+        from kicad_tools.cli.route_cmd import _write_net_class_map_sidecar
+        from kicad_tools.router.rules import NetClassRouting, net_class_map_to_dict
+
+        real = tmp_path / "net_class_map.json"
+        real.write_text(json.dumps(net_class_map_to_dict({"AC_LINE": NetClassRouting(name="HV")})))
+        original_bytes = real.read_bytes()
+
+        link = tmp_path / "authored_link.json"
+        link.symlink_to(real)
+
+        pcb_out = tmp_path / "board_routed.kicad_pcb"
+        pcb_out.write_text("(kicad_pcb)")
+
+        _write_net_class_map_sidecar(
+            pcb_out,
+            {"AC_LINE": NetClassRouting(name="Audio")},
+            quiet=True,
+            input_path=link,
+            loaded_net_class_map={"AC_LINE": NetClassRouting(name="HV")},
+        )
+
+        # The real file (target of the symlink) is untouched.
+        assert real.read_bytes() == original_bytes
+        assert (tmp_path / "net_class_map.effective.json").is_file()
+
 
 class TestInactiveSkewRuleWarningNonCLI:
     """Issue #3917 Defect 3 / AC4: the INACTIVE warning fires from a *direct*


### PR DESCRIPTION
## Summary

`kct route` silently overwrote the user's `--net-class-map` input file whenever the routed board was written into the same directory as that file. The post-route sidecar writer (`_write_net_class_map_sidecar`) hard-coded its target to `<output_dir>/net_class_map.json` and wrote unconditionally — the natural name of a hand-authored input sidecar — so `output_path.parent / "net_class_map.json"` resolved to the exact same file the user passed in. The re-serialized map came from the router's name-pattern classifier, so authored HV constraints were also corrupted (e.g. `AC_LINE` → `'Audio'`, losing `target_ampacity`/`avoid_layers`).

## Changes

- **Never overwrite the input (Ask #1):** thread the resolved `--net-class-map` INPUT path into `_write_net_class_map_sidecar` via `run_post_route_drc` (all four callsites). Guard the write with `os.path.samefile` (inode identity, handles symlinks) with a resolved-path-equality fallback when the target does not yet exist. On collision, divert the derived map to `net_class_map.effective.json` instead of overwriting; keep the plain `net_class_map.json` name in the no-collision case so `kct check` auto-discovery is unaffected.
- **Round-trip fidelity (Ask #2):** merge the loaded user map over the classifier output before serialization so resolved HV nets retain authored `name`/`target_ampacity`/`avoid_layers`.
- **Help text (Ask #3):** `--net-class-map` help now names the derived sidecar and states the input file is never overwritten.
- **Tests:** extended `TestSidecarWrittenByRoute` with collision, non-collision, round-trip-fidelity, and symlinked-input regression tests.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Input file not overwritten on collision; derived map lands in `net_class_map.effective.json` | ✅ | `test_input_file_not_overwritten_on_collision` (byte-for-byte input unchanged; effective sidecar present) |
| Non-collision still writes plain `net_class_map.json` (check auto-discovery unaffected) | ✅ | `test_no_collision_writes_plain_sidecar` + existing `test_sidecar_written_and_round_trips` |
| Round-trip fidelity: loaded map preserves `name`/`target_ampacity`/`avoid_layers` (not `'Audio'`) | ✅ | `test_round_trip_fidelity_merges_loaded_over_classifier` |
| Symlinked input resolving to same inode detected as collision | ✅ | `test_symlinked_input_resolves_to_same_inode` |
| Read-only output dir remains non-fatal | ✅ | existing `test_readonly_output_dir_is_non_fatal` still passes |

## Test Plan

- `uv run pytest tests/test_cli_check_net_class_map.py` — 30 passed
- `uv run pytest tests/test_route_post_drc_geometric.py tests/test_route_auto_fix.py tests/test_drc_constraints_export.py` — 74 passed
- `uv run ruff check` + `ruff format --check` — clean on changed files
- `uv run python scripts/ci/check_mypy_baseline.py` — no new type errors (within baseline)

Closes #4428