### PR TITLE
feat(router): pairwise HV-isolation clearance resolver + post-route validator (Phase 1)

### DIFF
--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -723,6 +723,21 @@ def run_route_command(args) -> int:
         sub_argv.extend(["--analog-nets", args.analog_nets])
     if getattr(args, "auto_analog", False):
         sub_argv.append("--auto-analog")
+    # Issue #4431 (Phase 1): forward --voltage-map + the creepage lookup knobs
+    # so the inner route_cmd builds the HV pairwise-clearance table.  Both
+    # parsers declare each; the creepage knobs share the inner defaults
+    # (iec60664 / 2 / IIIa / 30.0), so only forward non-defaults to keep
+    # flag-off argv byte-identical (enforced by tests/test_cli_parser_drift.py).
+    if getattr(args, "voltage_map", None) is not None:
+        sub_argv.extend(["--voltage-map", args.voltage_map])
+        if getattr(args, "creepage_standard", "iec60664") != "iec60664":
+            sub_argv.extend(["--creepage-standard", args.creepage_standard])
+        if getattr(args, "pollution_degree", 2) != 2:
+            sub_argv.extend(["--pollution-degree", str(args.pollution_degree)])
+        if getattr(args, "material_group", "IIIa") != "IIIa":
+            sub_argv.extend(["--material-group", args.material_group])
+        if getattr(args, "hv_threshold", 30.0) != 30.0:
+            sub_argv.extend(["--hv-threshold", str(args.hv_threshold)])
     return route_main(sub_argv)
 
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -4041,6 +4041,73 @@ def _add_route_parser(subparsers) -> None:
             "two sets are unioned)."
         ),
     )
+    # Issue #4431 (Phase 1): --voltage-map HV pairwise clearance.  Declared on
+    # BOTH parsers + forwarded by commands/routing.py (enforced by
+    # tests/test_cli_parser_drift.py).
+    route_parser.add_argument(
+        "--voltage-map",
+        dest="voltage_map",
+        default=None,
+        metavar="FILE",
+        help=(
+            "Path to a JSON per-net voltage map {net_name: volts} (reuses the "
+            "#4371 format; ranges {min,max} per #4411 collapse to worst-case "
+            "magnitude). Enables HV-isolation pairwise clearance (Issue #4431 "
+            "Phase 1): the router derives a net-pair required-clearance matrix "
+            "max(dru, IEC creepage @ |ΔV|) using the SAME lookup as HV-aware "
+            "placement (--voltage-map on optimize-placement) and the creepage "
+            "census, then the Python post-route validator flags an HV net that "
+            "runs closer than its pairwise requirement to non-HV copper. Absent, "
+            "routing is byte-identical to the scalar-clearance default. NOTE: "
+            "Phase 1 is a diagnostic/foundation -- it does NOT by itself make an "
+            "HV board route cleanly (search-time avoidance is deferred to a "
+            "follow-up architect epic, Phase 2)."
+        ),
+    )
+    route_parser.add_argument(
+        "--creepage-standard",
+        dest="creepage_standard",
+        choices=["iec60664", "iec62368"],
+        default="iec60664",
+        help=(
+            "Creepage standard for the --voltage-map pairwise-clearance lookup "
+            "(default: iec60664). Mirrors optimize-placement / kct creepage."
+        ),
+    )
+    route_parser.add_argument(
+        "--pollution-degree",
+        dest="pollution_degree",
+        type=int,
+        choices=[1, 2, 3],
+        default=2,
+        help=(
+            "IEC pollution degree for the --voltage-map pairwise-clearance "
+            "lookup (default: 2). Mirrors optimize-placement / kct creepage."
+        ),
+    )
+    route_parser.add_argument(
+        "--material-group",
+        dest="material_group",
+        default="IIIa",
+        help=(
+            "Insulation material group I/II/IIIa/IIIb for the --voltage-map "
+            "pairwise-clearance lookup (default: IIIa). Mirrors "
+            "optimize-placement / kct creepage."
+        ),
+    )
+    route_parser.add_argument(
+        "--hv-threshold",
+        dest="hv_threshold",
+        type=float,
+        default=30.0,
+        metavar="VOLTS",
+        help=(
+            "Minimum net-pair |ΔV| (volts) that triggers a creepage widening "
+            "for --voltage-map pairwise clearance; lower-difference pairs keep "
+            "the scalar DRU floor to avoid over-segregating low-voltage nets "
+            "(default: 30.0). Mirrors optimize-placement / kct creepage."
+        ),
+    )
 
 
 def _add_route_auto_parser(subparsers) -> None:

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -3541,6 +3541,48 @@ def _apply_net_class_map_sidecar(router: "Autorouter", args, quiet: bool = False
         )
 
 
+def _apply_pairwise_clearance(router: "Autorouter", args, quiet: bool = False) -> None:
+    """Attach the preloaded HV pairwise-clearance table to the router (#4431).
+
+    ``main()`` validates and derives the ``--voltage-map`` pairwise matrix early
+    (so error paths short-circuit before routing) and stashes the per-net
+    voltages + ``{(net_a, net_b): required_mm}`` matrix on
+    ``args._pairwise_voltages`` / ``args._pairwise_required``.  Each
+    router-creation site calls this helper (alongside
+    :func:`_apply_net_class_map_sidecar`) to build a
+    :class:`~kicad_tools.router.pairwise_clearance.PairwiseClearanceTable` with
+    the router's actual DRU floor (``rules.trace_clearance``) and set it on the
+    shared :class:`DesignRules` instance the pathfinder/backend read at
+    post-route validation time.
+
+    Idempotent and a no-op when ``--voltage-map`` was not supplied (the scalar
+    clearance path is then byte-identical to pre-#4431).
+    """
+    required = getattr(args, "_pairwise_required", None)
+    voltages = getattr(args, "_pairwise_voltages", None)
+    if required is None or voltages is None:
+        return
+
+    from kicad_tools.router.pairwise_clearance import PairwiseClearanceTable
+
+    rules = getattr(router, "rules", None)
+    if rules is None:
+        return
+    rules.pairwise_clearance = PairwiseClearanceTable(
+        dru=float(rules.trace_clearance),
+        net_voltages=voltages,
+        required_by_pair=required,
+    )
+
+    if not quiet:
+        from kicad_tools.cli.progress import flush_print
+
+        flush_print(
+            f"  HV pairwise clearance: {len(voltages)} mapped nets, "
+            f"{len(required)} cross-pairs (route-time creepage rejection active)"
+        )
+
+
 def _warn_unresolved_net_class_map(resolution, board_net_names, nearest_fn) -> None:
     """Emit the Issue #4149 misconfiguration diagnostic to stderr.
 
@@ -4406,6 +4448,8 @@ def route_with_layer_escalation(
 
         # Issue #2996: merge --net-class-map sidecar onto router's map.
         _apply_net_class_map_sidecar(router, args, quiet=quiet)
+        # Issue #4431: attach the --voltage-map HV pairwise-clearance table.
+        _apply_pairwise_clearance(router, args, quiet=quiet)
         # Issue #3470: thread --max-ripups-per-net into the destructive
         # rip-up budgets (route_all + two-phase stall recovery).
         _apply_ripup_budget_override(router, args)
@@ -5327,6 +5371,8 @@ def route_with_rule_relaxation(
 
         # Issue #2996: merge --net-class-map sidecar onto router's map.
         _apply_net_class_map_sidecar(router, args, quiet=quiet)
+        # Issue #4431: attach the --voltage-map HV pairwise-clearance table.
+        _apply_pairwise_clearance(router, args, quiet=quiet)
         # Issue #3470: thread --max-ripups-per-net into the destructive
         # rip-up budgets (route_all + two-phase stall recovery).
         _apply_ripup_budget_override(router, args)
@@ -7486,6 +7532,8 @@ def route_with_combined_escalation(
 
             # Issue #2996: merge --net-class-map sidecar onto router's map.
             _apply_net_class_map_sidecar(router, args, quiet=quiet)
+            # Issue #4431: attach the --voltage-map HV pairwise-clearance table.
+            _apply_pairwise_clearance(router, args, quiet=quiet)
             # Issue #3470: thread --max-ripups-per-net into the destructive
             # rip-up budgets (route_all + two-phase stall recovery).
             _apply_ripup_budget_override(router, args)
@@ -9376,6 +9424,70 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--voltage-map",
+        dest="voltage_map",
+        default=None,
+        metavar="FILE",
+        help=(
+            "Path to a JSON per-net voltage map {net_name: volts} (reuses the "
+            "#4371 format; ranges {min,max} per #4411 collapse to worst-case "
+            "magnitude). Enables HV-isolation pairwise clearance (Issue #4431 "
+            "Phase 1): the router derives a net-pair required-clearance matrix "
+            "max(dru, IEC creepage @ |ΔV|) using the SAME lookup as HV-aware "
+            "placement (--voltage-map on optimize-placement) and the creepage "
+            "census, then the Python post-route validator flags an HV net that "
+            "runs closer than its pairwise requirement to non-HV copper. Absent, "
+            "routing is byte-identical to the scalar-clearance default. NOTE: "
+            "Phase 1 is a diagnostic/foundation -- it does NOT by itself make an "
+            "HV board route cleanly (search-time avoidance is deferred to a "
+            "follow-up architect epic, Phase 2)."
+        ),
+    )
+    parser.add_argument(
+        "--creepage-standard",
+        dest="creepage_standard",
+        choices=["iec60664", "iec62368"],
+        default="iec60664",
+        help=(
+            "Creepage standard for the --voltage-map pairwise-clearance lookup "
+            "(default: iec60664). Mirrors optimize-placement / kct creepage."
+        ),
+    )
+    parser.add_argument(
+        "--pollution-degree",
+        dest="pollution_degree",
+        type=int,
+        choices=[1, 2, 3],
+        default=2,
+        help=(
+            "IEC pollution degree for the --voltage-map pairwise-clearance "
+            "lookup (default: 2). Mirrors optimize-placement / kct creepage."
+        ),
+    )
+    parser.add_argument(
+        "--material-group",
+        dest="material_group",
+        default="IIIa",
+        help=(
+            "Insulation material group I/II/IIIa/IIIb for the --voltage-map "
+            "pairwise-clearance lookup (default: IIIa). Mirrors "
+            "optimize-placement / kct creepage."
+        ),
+    )
+    parser.add_argument(
+        "--hv-threshold",
+        dest="hv_threshold",
+        type=float,
+        default=30.0,
+        metavar="VOLTS",
+        help=(
+            "Minimum net-pair |ΔV| (volts) that triggers a creepage widening "
+            "for --voltage-map pairwise clearance; lower-difference pairs keep "
+            "the scalar DRU floor to avoid over-segregating low-voltage nets "
+            "(default: 30.0). Mirrors optimize-placement / kct creepage."
+        ),
+    )
+    parser.add_argument(
         "--analog-nets",
         dest="analog_nets",
         default=None,
@@ -10393,6 +10505,49 @@ def main(argv: list[str] | None = None) -> int:
             print(f"Error: invalid net-class-map structure: {e}", file=sys.stderr)
             return 1
 
+    # Issue #4431 (Phase 1): validate and load the optional --voltage-map early
+    # (mirrors the --net-class-map preload above) so a missing file / malformed
+    # JSON / out-of-table |ΔV| short-circuits with exit 1 before any routing
+    # work runs.  The derived per-net voltages + pairwise required-clearance
+    # matrix are stashed on ``args._pairwise_voltages`` / ``_pairwise_required``;
+    # each router-creation site attaches a ``PairwiseClearanceTable`` (built with
+    # the router's actual DRU floor) via ``_apply_pairwise_clearance``.  Absent
+    # the flag this is a no-op and routing stays byte-identical to the scalar
+    # path.
+    args._pairwise_voltages = None
+    args._pairwise_required = None
+    if getattr(args, "voltage_map", None) is not None:
+        from kicad_tools.creepage.standards import StandardLookupError
+        from kicad_tools.placement.hv_domains import (
+            build_required_by_domain_pair,
+            load_voltage_map,
+        )
+        from kicad_tools.router.pairwise_clearance import _norm_net_key
+
+        vm_path = Path(args.voltage_map).resolve()
+        if not vm_path.exists():
+            print(f"Error: voltage-map file not found: {vm_path}", file=sys.stderr)
+            return 1
+        try:
+            _raw_voltages = load_voltage_map(vm_path)
+        except (ValueError, OSError) as e:
+            print(f"Error: invalid voltage-map: {e}", file=sys.stderr)
+            return 1
+        _voltages = {_norm_net_key(n): abs(float(v)) for n, v in _raw_voltages.items()}
+        try:
+            _required = build_required_by_domain_pair(
+                _voltages,
+                standard_id=getattr(args, "creepage_standard", "iec60664"),
+                pollution_degree=getattr(args, "pollution_degree", 2),
+                material_group=getattr(args, "material_group", "IIIa"),
+                hv_threshold=getattr(args, "hv_threshold", 30.0),
+            )
+        except StandardLookupError as e:
+            print(f"Error: voltage-map creepage lookup failed: {e}", file=sys.stderr)
+            return 1
+        args._pairwise_voltages = _voltages
+        args._pairwise_required = _required
+
     # Normalize --auto-fix-passes: explicit value implies --auto-fix
     if args.auto_fix_passes is not None:
         if args.auto_fix_passes < 1:
@@ -10991,6 +11146,8 @@ def main(argv: list[str] | None = None) -> int:
 
     # Issue #2996: merge --net-class-map sidecar onto router's map.
     _apply_net_class_map_sidecar(router, args, quiet=quiet)
+    # Issue #4431: attach the --voltage-map HV pairwise-clearance table.
+    _apply_pairwise_clearance(router, args, quiet=quiet)
     # Issue #3470: thread --max-ripups-per-net into the destructive
     # rip-up budgets (route_all + two-phase stall recovery).
     _apply_ripup_budget_override(router, args)
@@ -11038,6 +11195,8 @@ def main(argv: list[str] | None = None) -> int:
                 per_net_iterations=getattr(args, "per_net_iterations", 0) or 0,
             )
             _apply_net_class_map_sidecar(fresh, args, quiet=True)
+            # Issue #4431: attach the --voltage-map HV pairwise-clearance table.
+            _apply_pairwise_clearance(fresh, args, quiet=True)
             _apply_analog_net_class(fresh, args, quiet=True)
             return fresh
 

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -2188,6 +2188,29 @@ class CppPathfinder:
                     ):
                         return (via.x, via.y)
 
+        # Issue #4431 (Phase 1): additive pairwise HV-isolation post-check on the
+        # Python validation path (no C++ change in this slice).  When a
+        # voltage-map-derived pairwise table is attached, reject a route segment
+        # that runs closer than max(dru, IEC creepage @ |ΔV|) to foreign copper.
+        # The C++ ``validate_route`` above already enforced the scalar clearance
+        # against ``py_grid.routes``; this layer adds only the HV widening for
+        # net pairs whose requirement exceeds the scalar floor.  Absent the
+        # table (``None``) this is a no-op -- the scalar path is byte-identical.
+        pairwise = getattr(self._rules, "pairwise_clearance", None)
+        if pairwise is not None:
+            from .pairwise_clearance import route_pairwise_violation
+
+            id_to_name = {nid: name for name, nid in self._net_name_to_id.items()}
+            violation = route_pairwise_violation(
+                route,
+                start.net,
+                py_grid.routes,
+                pairwise,
+                id_to_name=id_to_name,
+            )
+            if violation is not None:
+                return (violation.x, violation.y)
+
         return None
 
     def _boost_avoidance_at(

--- a/src/kicad_tools/router/pairwise_clearance.py
+++ b/src/kicad_tools/router/pairwise_clearance.py
@@ -1,0 +1,348 @@
+"""Pairwise (net-pair) clearance resolver for HV isolation routing (Issue #4431).
+
+Phase 1 of the "scalar clearance -> pairwise clearance" epic (mirrors the
+diff-pair clearance epic #2556). The router's clearance model is
+*scalar-per-net* (:attr:`kicad_tools.router.rules.DesignRules.trace_clearance`
+and :attr:`~kicad_tools.router.rules.NetClassRouting.clearance`), which cannot
+express the HV-isolation requirement: a mains/bank net needs IEC-creepage
+spacing (1.3-1.6 mm @150 V PD2) from *low-voltage* copper but only DRU-functional
+spacing (0.3-0.4 mm) from its *own cluster's* nets. A single scalar forces the
+false choice between "unroutable TO-220 field" (blanket-wide) and "111 board
+creepage fails" (cluster-relaxed).
+
+This module adds the shared **data carrier + resolver** and a **Python
+post-route validator** primitive. It is a *consumption* problem, not a new
+algorithm: the delta-V -> creepage lookup, the HV threshold gating and the
+fail-loud out-of-table contract are all reused verbatim from the already-merged
+placement derivation
+(:func:`kicad_tools.placement.hv_domains.build_required_by_domain_pair`, itself
+backed by :meth:`kicad_tools.creepage.standards.CreepageStandard.required_creepage`).
+Feeding that builder a per-net ``{net_name: |V|}`` map -- each net treated as its
+own "domain" -- yields the order-independent ``{(net_a, net_b): required_mm}``
+matrix the router resolves against, so the router, placement and the post-route
+creepage census all agree by construction.
+
+Explicitly OUT OF SCOPE here (deferred to follow-up architect phases):
+
+* **Phase 2** -- search-time avoidance (widening the A* grid-reservation halo
+  around HV copper) plus the C++ ``validate_route`` extension. That is what
+  actually lets an HV board *converge* instead of thrashing the negotiator;
+  Phase 1 is a diagnostic/foundation only and does NOT by itself make an HV
+  board route cleanly.
+* **Phase 3** -- KiCad netclass-pair custom ``(rule ...)`` export for
+  ``kicad-cli pcb drc`` referee-enforceability.
+
+Backward compatibility: absent a voltage map, :attr:`DesignRules.pairwise_clearance`
+is ``None`` and every consumer falls through to the pre-existing scalar path
+byte-identically.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Iterable, Mapping, NamedTuple
+
+from kicad_tools.core.geometry import segment_to_segment_distance
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from kicad_tools.router.primitives import Route, Segment
+
+# A pairwise conflict is only reported when the edge-to-edge gap falls short of
+# the requirement by more than this tolerance (mm).  Mirrors the census'
+# ``_PASS_TOLERANCE`` -- a sub-micron shortfall is FP noise, not a real defect.
+_PASS_TOLERANCE = 1e-4
+
+
+def _norm_net_key(name: str) -> str:
+    """Normalise a net name for pairwise lookup (drop one leading ``/``).
+
+    KiCad emits hierarchical net names with a leading ``/`` (``/AC_LINE``);
+    hand-authored voltage maps may or may not include it.  Stripping a single
+    leading slash on both sides makes the lookup robust to either convention --
+    identical to the creepage census' ``_norm_net_key`` (#4371) so the router
+    and the census key the same nets.
+    """
+    return name[1:] if name.startswith("/") else name
+
+
+@dataclass(frozen=True)
+class PairwiseClearanceTable:
+    """Order-independent net-pair -> required-clearance carrier (Issue #4431).
+
+    Attributes:
+        dru: The scalar manufacturer/DRU clearance floor (mm).  Every resolved
+            requirement is at least this value -- a pairwise widening never
+            *tightens* below the fab's functional spacing.
+        net_voltages: ``{net_name: |V|}`` worst-case voltage magnitude per net,
+            keyed by the ``/``-stripped net name.  Retained for provenance /
+            diagnostics; the resolver reads :attr:`required_by_pair`.
+        required_by_pair: ``{(net_a, net_b): required_mm}`` with order-independent
+            (sorted, ``/``-stripped) keys, as produced by
+            :func:`kicad_tools.placement.hv_domains.build_required_by_domain_pair`
+            over :attr:`net_voltages`.  Pairs below the HV threshold are absent
+            (they need no widening beyond ``dru``).
+    """
+
+    dru: float
+    net_voltages: Mapping[str, float]
+    required_by_pair: Mapping[tuple[str, str], float]
+
+    def required_clearance(self, net_a: str, net_b: str) -> float:
+        """Return ``max(dru, creepage_lookup(|Va - Vb|))`` for a net pair.
+
+        Same-net queries and pairs below the HV threshold (absent from
+        :attr:`required_by_pair`) return :attr:`dru` -- i.e. the scalar path is
+        preserved for everything that does not require HV widening.
+        """
+        a = _norm_net_key(net_a)
+        b = _norm_net_key(net_b)
+        if a == b:
+            return self.dru
+        key = (a, b) if a <= b else (b, a)
+        return max(self.dru, self.required_by_pair.get(key, 0.0))
+
+
+def build_pairwise_clearance_table(
+    net_voltages: Mapping[str, float],
+    *,
+    dru: float,
+    standard_id: str = "iec60664",
+    pollution_degree: int = 2,
+    material_group: str = "IIIa",
+    hv_threshold: float = 30.0,
+) -> PairwiseClearanceTable:
+    """Build a :class:`PairwiseClearanceTable` from a per-net voltage map.
+
+    Reuses :func:`kicad_tools.placement.hv_domains.build_required_by_domain_pair`
+    -- the SAME builder placement (#4373) and the creepage census consume --
+    treating each net as its own single-net "domain".  Given identical inputs
+    the router and placement therefore produce byte-identical matrices (there is
+    no forked lookup).  The delta-V -> creepage step is fail-loud: an out-of-table
+    ``|Delta V|`` raises
+    :class:`~kicad_tools.creepage.standards.StandardLookupError` rather than
+    silently extrapolating.
+
+    Args:
+        net_voltages: ``{net_name: volts}`` -- signed or magnitude; magnitudes
+            are taken internally.  Reserved ``_``-prefixed metadata keys should
+            already be stripped by the loader
+            (:func:`kicad_tools.placement.hv_domains.load_voltage_map`).
+        dru: Scalar clearance floor (mm), typically ``DesignRules.trace_clearance``.
+        standard_id: Creepage standard id (``iec60664`` / ``iec62368``).
+        pollution_degree: IEC pollution degree (1, 2 or 3).
+        material_group: Insulation material group (``I``/``II``/``IIIa``/``IIIb``).
+        hv_threshold: Minimum ``|Delta V|`` (volts) for a pair to receive a
+            creepage widening; pairs below it keep only the ``dru`` floor.
+
+    Returns:
+        A frozen :class:`PairwiseClearanceTable`.
+
+    Raises:
+        StandardLookupError: If a cross-pair ``|Delta V|`` exceeds the highest
+            tabulated row (no silent extrapolation).
+    """
+    # Lazy import keeps the router<->placement dependency off module-import time
+    # (placement.__init__ pulls router.rules), avoiding any import-order cycle.
+    from kicad_tools.placement.hv_domains import build_required_by_domain_pair
+
+    normalised = {_norm_net_key(name): abs(float(v)) for name, v in net_voltages.items()}
+    required = build_required_by_domain_pair(
+        normalised,
+        standard_id=standard_id,
+        pollution_degree=pollution_degree,
+        material_group=material_group,
+        hv_threshold=hv_threshold,
+    )
+    return PairwiseClearanceTable(
+        dru=float(dru),
+        net_voltages=normalised,
+        required_by_pair=required,
+    )
+
+
+class PairwiseViolation(NamedTuple):
+    """A single post-route pairwise-clearance shortfall (Issue #4431).
+
+    Attributes:
+        net_a: The moving/route net name.
+        net_b: The foreign net name it is too close to.
+        actual_mm: Measured edge-to-edge gap (mm).
+        required_mm: The derived pairwise requirement (mm).
+        x: Violation x-coordinate (mm) -- midpoint of the foreign segment.
+        y: Violation y-coordinate (mm).
+    """
+
+    net_a: str
+    net_b: str
+    actual_mm: float
+    required_mm: float
+    x: float
+    y: float
+
+
+def _segment_edge_gap(seg_a: Segment, seg_b: Segment) -> float:
+    """Edge-to-edge gap (mm) between two trace segments' copper on one layer."""
+    centre = segment_to_segment_distance(
+        seg_a.x1, seg_a.y1, seg_a.x2, seg_a.y2, seg_b.x1, seg_b.y1, seg_b.x2, seg_b.y2
+    )
+    return centre - seg_a.width / 2.0 - seg_b.width / 2.0
+
+
+def segment_pair_violation(
+    seg_a: Segment,
+    seg_b: Segment,
+    table: PairwiseClearanceTable,
+    *,
+    net_a_name: str | None = None,
+    net_b_name: str | None = None,
+    dru: float | None = None,
+    tolerance: float = _PASS_TOLERANCE,
+) -> PairwiseViolation | None:
+    """Check one segment pair against its derived pairwise requirement.
+
+    Returns a :class:`PairwiseViolation` when the two segments share a layer and
+    their edge-to-edge gap falls short of ``required_clearance(a, b)`` by more
+    than ``tolerance``; otherwise ``None``.  Pairs whose requirement does not
+    exceed the scalar DRU floor are skipped -- the ordinary scalar clearance
+    check already governs them, so this validator only adds the *HV widening*.
+
+    Net names default to the segments' own :attr:`Segment.net_name`; the live
+    in-loop validators pass ``net_a_name``/``net_b_name`` explicitly because a
+    mid-route segment may not yet carry a populated net-name string (the net id
+    is authoritative there and is resolved by the caller).
+
+    Different-layer pairs return ``None`` in Phase 1 (surface creepage is a
+    same-layer phenomenon here; cross-layer/through-hole geometry is the census'
+    and Phase 2's remit).
+    """
+    if seg_a.layer != seg_b.layer:
+        return None
+    a_name = seg_a.net_name if net_a_name is None else net_a_name
+    b_name = seg_b.net_name if net_b_name is None else net_b_name
+    floor = table.dru if dru is None else dru
+    required = table.required_clearance(a_name, b_name)
+    if required <= floor + tolerance:
+        # No HV widening for this pair -- the scalar path already covers it.
+        return None
+    gap = _segment_edge_gap(seg_a, seg_b)
+    if gap >= required - tolerance:
+        return None
+    return PairwiseViolation(
+        net_a=a_name,
+        net_b=b_name,
+        actual_mm=gap,
+        required_mm=required,
+        x=(seg_b.x1 + seg_b.x2) / 2.0,
+        y=(seg_b.y1 + seg_b.y2) / 2.0,
+    )
+
+
+def route_pairwise_violation(
+    route: Route,
+    exclude_net: int,
+    foreign_routes: Iterable[Route],
+    table: PairwiseClearanceTable,
+    *,
+    id_to_name: Mapping[int, str] | None = None,
+    dru: float | None = None,
+    tolerance: float = _PASS_TOLERANCE,
+) -> PairwiseViolation | None:
+    """Find the first pairwise-clearance shortfall for a freshly-routed net.
+
+    Walks every segment of ``route`` against every segment of the already-routed
+    ``foreign_routes`` (skipping the route's own net), returning the first
+    :class:`PairwiseViolation` or ``None`` when the route clears all pairwise
+    requirements.  This is the additive HV check threaded into the Python
+    post-route validators (``pathfinder`` and ``cpp_backend``); the scalar
+    segment/pad/via checks run first and unchanged.
+
+    ``exclude_net`` is the route's own net id (same-net copper never conflicts).
+    ``id_to_name`` resolves a net id to its board net name; when omitted the
+    routes' own :attr:`Route.net_name` strings are used.  Ids are authoritative
+    mid-route (segment/route name strings may be unset), so the live validators
+    pass an inverted ``net_name_to_id`` map here.
+    """
+    if table is None:
+        return None
+    floor = table.dru if dru is None else dru
+    # ``exclude_net`` is the route's own net id and is authoritative mid-route
+    # (``route.net``/``route.net_name`` may be unset before finalisation).
+    moving_name = _resolve_net_name(id_to_name, exclude_net, route.net_name)
+    for other in foreign_routes:
+        if other.net == exclude_net:
+            continue
+        # Cheap prune: skip the whole foreign route when this net pair needs no
+        # HV widening beyond the scalar floor.
+        foreign_name = _resolve_net_name(id_to_name, other.net, other.net_name)
+        required = table.required_clearance(moving_name, foreign_name)
+        if required <= floor + tolerance:
+            continue
+        for seg in route.segments:
+            for oseg in other.segments:
+                violation = segment_pair_violation(
+                    seg,
+                    oseg,
+                    table,
+                    net_a_name=moving_name,
+                    net_b_name=foreign_name,
+                    dru=floor,
+                    tolerance=tolerance,
+                )
+                if violation is not None:
+                    return violation
+    return None
+
+
+def find_pairwise_violations(
+    routes: Iterable[Route],
+    table: PairwiseClearanceTable,
+    *,
+    id_to_name: Mapping[int, str] | None = None,
+    dru: float | None = None,
+    tolerance: float = _PASS_TOLERANCE,
+) -> list[PairwiseViolation]:
+    """Scan a whole routed board for pairwise-clearance shortfalls (board-level).
+
+    Every unordered pair of distinct-net routes is checked segment-vs-segment.
+    Returns a deterministically-ordered list of every :class:`PairwiseViolation`
+    found (empty when the board satisfies all pairwise requirements).  Intended
+    for a post-route board audit / tests; the in-loop validators use
+    :func:`route_pairwise_violation` for early-exit.
+    """
+    materialised = list(routes)
+    floor = table.dru if dru is None else dru
+    out: list[PairwiseViolation] = []
+    for i in range(len(materialised)):
+        ra = materialised[i]
+        a_name = _resolve_net_name(id_to_name, ra.net, ra.net_name)
+        for j in range(i + 1, len(materialised)):
+            rb = materialised[j]
+            if ra.net == rb.net:
+                continue
+            b_name = _resolve_net_name(id_to_name, rb.net, rb.net_name)
+            required = table.required_clearance(a_name, b_name)
+            if required <= floor + tolerance:
+                continue
+            for seg in ra.segments:
+                for oseg in rb.segments:
+                    violation = segment_pair_violation(
+                        seg,
+                        oseg,
+                        table,
+                        net_a_name=a_name,
+                        net_b_name=b_name,
+                        dru=floor,
+                        tolerance=tolerance,
+                    )
+                    if violation is not None:
+                        out.append(violation)
+    return out
+
+
+def _resolve_net_name(id_to_name: Mapping[int, str] | None, net_id: int, fallback: str) -> str:
+    """Resolve a net id to its board net name, falling back to a known string."""
+    if id_to_name is not None:
+        name = id_to_name.get(net_id)
+        if name:
+            return name
+    return fallback

--- a/src/kicad_tools/router/pathfinder.py
+++ b/src/kicad_tools/router/pathfinder.py
@@ -3731,6 +3731,29 @@ class Router:
             if not is_valid:
                 return False
 
+        # Issue #4431 (Phase 1): additive pairwise HV-isolation check.  When a
+        # voltage-map-derived pairwise clearance table is present, reject a route
+        # segment that runs closer than max(dru, IEC creepage @ |ΔV|) to foreign
+        # copper.  Absent the table (``None``) this is a no-op, preserving the
+        # scalar path byte-for-byte.  Foreign copper is the already-routed
+        # ``self.grid.routes``; the scalar seg/pad/via checks above still run.
+        pairwise = getattr(self.rules, "pairwise_clearance", None)
+        if pairwise is not None:
+            from .pairwise_clearance import route_pairwise_violation
+
+            id_to_name = {nid: name for name, nid in self._net_name_to_id.items()}
+            if (
+                route_pairwise_violation(
+                    route,
+                    exclude_net,
+                    self.grid.routes,
+                    pairwise,
+                    id_to_name=id_to_name,
+                )
+                is not None
+            ):
+                return False
+
         return True
 
     def _merge_same_net_vias(self, route: Route) -> None:

--- a/src/kicad_tools/router/rules.py
+++ b/src/kicad_tools/router/rules.py
@@ -10,9 +10,12 @@ This module provides:
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from .layers import Layer
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .pairwise_clearance import PairwiseClearanceTable
 
 # Allowed values for :attr:`NetClassRouting.route_via`.
 # - ``"pathfinder"`` (default) -- ordinary trace, standard pathfinder routing.
@@ -113,6 +116,18 @@ class DesignRules:
     # Maps component reference (e.g., "U1") to clearance in mm
     # Use for fine-pitch ICs where tighter clearance is needed between pins
     component_clearances: dict[str, float] = field(default_factory=dict)
+
+    # Pairwise (net-pair) HV-isolation clearance table (Issue #4431, Phase 1).
+    # Scalar clearance cannot express "far from LV copper, near from own
+    # cluster".  When a ``--voltage-map`` is supplied, the route CLI builds a
+    # :class:`~kicad_tools.router.pairwise_clearance.PairwiseClearanceTable`
+    # (net-pair -> max(dru, IEC creepage @ |ΔV|)) and attaches it here; the
+    # Python post-route validators then reject an HV net that runs too close to
+    # non-HV copper.  ``None`` (default) preserves the scalar path byte-for-byte
+    # -- absent a voltage map NOTHING consults this field.  The search-time halo
+    # widening + C++ validator extension (what actually makes an HV board
+    # converge) are deferred to Phase 2; KiCad netclass-pair export to Phase 3.
+    pairwise_clearance: "PairwiseClearanceTable | None" = None
 
     # Fine-pitch automatic clearance (Issue #1016)
     # When set, components with pin pitch below fine_pitch_threshold automatically

--- a/tests/router/test_pairwise_clearance.py
+++ b/tests/router/test_pairwise_clearance.py
@@ -1,0 +1,287 @@
+"""Tests for the HV-isolation pairwise clearance resolver + validator (#4431).
+
+Phase 1 of the "scalar clearance -> pairwise clearance" epic (mirrors #2556).
+Covers:
+
+* the :class:`PairwiseClearanceTable` resolver (``max(dru, creepage@|ΔV|)``,
+  same-domain -> DRU, cross-domain -> IEC, absent-net -> DRU floor);
+* cross-consumer agreement -- the router and placement produce byte-identical
+  matrices from the same voltage map (both go through
+  ``build_required_by_domain_pair``);
+* the Python post-route validator (segment-pair + route-level) flagging an
+  HV↔LV pair below its pairwise requirement and accepting an HV↔HV pair at DRU;
+* backward compatibility (``DesignRules.pairwise_clearance`` defaults to
+  ``None`` and the scalar path is untouched);
+* the fail-loud out-of-table contract and the DRU floor clamp.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.creepage.standards import StandardLookupError
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.pairwise_clearance import (
+    PairwiseClearanceTable,
+    build_pairwise_clearance_table,
+    find_pairwise_violations,
+    route_pairwise_violation,
+    segment_pair_violation,
+)
+from kicad_tools.router.primitives import Route, Segment
+from kicad_tools.router.rules import DesignRules
+
+# A 150 V mains net vs ground: IEC 60664-1, PD2, material group IIIa -> 1.6 mm.
+IEC_150V_PD2_IIIA_MM = 1.6
+DRU = 0.2
+
+
+def _table(voltages: dict[str, float], dru: float = DRU) -> PairwiseClearanceTable:
+    return build_pairwise_clearance_table(voltages, dru=dru)
+
+
+# ---------------------------------------------------------------------------
+# Resolver
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_cross_domain_returns_iec_creepage() -> None:
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    assert table.required_clearance("/AC_LINE", "/GND") == pytest.approx(IEC_150V_PD2_IIIA_MM)
+
+
+def test_resolver_is_order_independent() -> None:
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    assert table.required_clearance("/GND", "/AC_LINE") == table.required_clearance(
+        "/AC_LINE", "/GND"
+    )
+
+
+def test_resolver_same_domain_returns_dru() -> None:
+    # Two nets at the same potential (same cluster) get only the DRU floor.
+    table = _table({"/AC_LINE": 150.0, "/AC_LINE_TAP": 150.0})
+    assert table.required_clearance("/AC_LINE", "/AC_LINE_TAP") == pytest.approx(DRU)
+
+
+def test_resolver_same_net_returns_dru() -> None:
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    assert table.required_clearance("/AC_LINE", "/AC_LINE") == pytest.approx(DRU)
+
+
+def test_resolver_absent_net_treated_as_dru_floor() -> None:
+    # A net not in the voltage map is LV (no widening) -> DRU floor.
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    assert table.required_clearance("/AC_LINE", "/UNMAPPED_SIG") == pytest.approx(DRU)
+
+
+def test_resolver_normalises_leading_slash() -> None:
+    # Map keyed with a leading slash; query without one (and vice versa).
+    table = _table({"/AC_LINE": 150.0, "GND": 0.0})
+    assert table.required_clearance("AC_LINE", "/GND") == pytest.approx(IEC_150V_PD2_IIIA_MM)
+
+
+def test_resolver_max_of_dru_and_lookup() -> None:
+    # A tiny sub-DRU |ΔV| lookup would still be floored at DRU; and a real HV
+    # pair exceeds DRU.  Verify the ``max`` explicitly with a large DRU.
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0}, dru=2.0)
+    # required creepage (1.6) < dru (2.0) -> floored up to dru.
+    assert table.required_clearance("/AC_LINE", "/GND") == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# Cross-consumer agreement with placement (#4373)
+# ---------------------------------------------------------------------------
+
+
+def test_router_and_placement_produce_identical_matrices() -> None:
+    """The router and placement derive the SAME domain-pair matrix (#4431 AC).
+
+    Both consumers go through ``build_required_by_domain_pair`` -- there is no
+    forked lookup.  With disjoint refs per mapped net, placement's derived
+    ``domain_voltages`` coincide with the router's per-net voltage map, so the
+    full pipelines produce byte-identical matrices.
+    """
+    from kicad_tools.placement.cost import Net
+    from kicad_tools.placement.hv_domains import (
+        build_required_by_domain_pair,
+        derive_ref_domains_from_voltage_map,
+    )
+
+    voltage_map = {"AC_LINE": 150.0, "GND": 0.0, "V12": 12.0}
+    # Disjoint refs: each ref touches exactly one mapped net, so its domain is
+    # that net and placement's domain_voltages == the router's per-net map.
+    nets = [
+        Net(name="AC_LINE", pins=[("R1", "1"), ("R1", "2")]),
+        Net(name="GND", pins=[("R2", "1"), ("R2", "2")]),
+        Net(name="V12", pins=[("R3", "1"), ("R3", "2")]),
+    ]
+
+    _ref_domains, domain_voltages = derive_ref_domains_from_voltage_map(nets, voltage_map)
+    placement_matrix = build_required_by_domain_pair(domain_voltages)
+
+    router_table = build_pairwise_clearance_table(voltage_map, dru=DRU)
+
+    assert dict(router_table.required_by_pair) == dict(placement_matrix)
+    # And the router's builder is literally the placement builder over the same
+    # domain_voltages input (no fork).
+    assert dict(router_table.required_by_pair) == build_required_by_domain_pair(domain_voltages)
+
+
+# ---------------------------------------------------------------------------
+# Fail-loud + edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_out_of_table_delta_v_raises() -> None:
+    # A |ΔV| above the highest tabulated IEC row must raise, never extrapolate.
+    with pytest.raises(StandardLookupError):
+        build_pairwise_clearance_table({"/HVDC": 100_000.0, "/GND": 0.0}, dru=DRU)
+
+
+def test_below_hv_threshold_pair_absent_from_matrix() -> None:
+    # A 12 V vs 0 V pair is below the 30 V default threshold -> no widening.
+    table = _table({"/V12": 12.0, "/GND": 0.0})
+    assert ("GND", "V12") not in table.required_by_pair
+    assert table.required_clearance("/V12", "/GND") == pytest.approx(DRU)
+
+
+# ---------------------------------------------------------------------------
+# Segment-pair validator
+# ---------------------------------------------------------------------------
+
+
+def _seg(x1, y1, x2, y2, net, name, layer=Layer.F_CU, width=0.2) -> Segment:
+    return Segment(x1, y1, x2, y2, width, layer, net=net, net_name=name)
+
+
+def test_segment_pair_flags_hv_lv_below_requirement() -> None:
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    # Two parallel same-layer segments 0.4 mm centre-to-centre -> 0.2 mm edge
+    # gap, far below the 1.6 mm requirement.
+    hv = _seg(0.0, 0.0, 5.0, 0.0, net=1, name="/AC_LINE")
+    lv = _seg(0.0, 0.4, 5.0, 0.4, net=2, name="/GND")
+    v = segment_pair_violation(hv, lv, table)
+    assert v is not None
+    assert v.required_mm == pytest.approx(IEC_150V_PD2_IIIA_MM)
+    assert v.actual_mm == pytest.approx(0.2, abs=1e-6)
+
+
+def test_segment_pair_accepts_hv_lv_meeting_requirement() -> None:
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    # 2.0 mm centre gap -> 1.8 mm edge gap >= 1.6 mm requirement -> OK.
+    hv = _seg(0.0, 0.0, 5.0, 0.0, net=1, name="/AC_LINE")
+    lv = _seg(0.0, 2.0, 5.0, 2.0, net=2, name="/GND")
+    assert segment_pair_violation(hv, lv, table) is None
+
+
+def test_segment_pair_accepts_same_domain_at_dru() -> None:
+    table = _table({"/AC_LINE": 150.0, "/AC_LINE_TAP": 150.0})
+    # Same potential (own cluster): 0.4 mm centre / 0.2 mm edge is fine at DRU.
+    a = _seg(0.0, 0.0, 5.0, 0.0, net=1, name="/AC_LINE")
+    b = _seg(0.0, 0.4, 5.0, 0.4, net=2, name="/AC_LINE_TAP")
+    assert segment_pair_violation(a, b, table) is None
+
+
+def test_segment_pair_ignores_different_layers() -> None:
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    hv = _seg(0.0, 0.0, 5.0, 0.0, net=1, name="/AC_LINE", layer=Layer.F_CU)
+    lv = _seg(0.0, 0.4, 5.0, 0.4, net=2, name="/GND", layer=Layer.B_CU)
+    assert segment_pair_violation(hv, lv, table) is None
+
+
+# ---------------------------------------------------------------------------
+# Route-level validator (the in-loop hook shape)
+# ---------------------------------------------------------------------------
+
+
+def test_route_pairwise_violation_flags_foreign_hv_proximity() -> None:
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    moving = Route(net=1, net_name="/AC_LINE", segments=[_seg(0, 0, 5, 0, 1, "/AC_LINE")])
+    foreign = Route(net=2, net_name="/GND", segments=[_seg(0, 0.3, 5, 0.3, 2, "/GND")])
+    id_to_name = {1: "/AC_LINE", 2: "/GND"}
+    v = route_pairwise_violation(moving, 1, [foreign], table, id_to_name=id_to_name)
+    assert v is not None
+    assert v.net_b == "/GND"
+
+
+def test_route_pairwise_violation_skips_same_net() -> None:
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    moving = Route(net=1, net_name="/AC_LINE", segments=[_seg(0, 0, 5, 0, 1, "/AC_LINE")])
+    # A foreign route on the SAME net id must be skipped (same-net copper).
+    same = Route(net=1, net_name="/AC_LINE", segments=[_seg(0, 0.3, 5, 0.3, 1, "/AC_LINE")])
+    id_to_name = {1: "/AC_LINE"}
+    assert route_pairwise_violation(moving, 1, [same], table, id_to_name=id_to_name) is None
+
+
+def test_route_pairwise_violation_resolves_names_from_ids() -> None:
+    # Segment/route name strings unset; names come from the id map (the live
+    # in-loop condition where mid-route net-name strings are not yet populated).
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    moving = Route(net=1, net_name="", segments=[_seg(0, 0, 5, 0, 1, "")])
+    foreign = Route(net=2, net_name="", segments=[_seg(0, 0.3, 5, 0.3, 2, "")])
+    id_to_name = {1: "/AC_LINE", 2: "/GND"}
+    v = route_pairwise_violation(moving, 1, [foreign], table, id_to_name=id_to_name)
+    assert v is not None
+
+
+def test_find_pairwise_violations_board_scan() -> None:
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    routes = [
+        Route(net=1, net_name="/AC_LINE", segments=[_seg(0, 0, 5, 0, 1, "/AC_LINE")]),
+        Route(net=2, net_name="/GND", segments=[_seg(0, 0.3, 5, 0.3, 2, "/GND")]),
+    ]
+    violations = find_pairwise_violations(routes, table)
+    assert len(violations) == 1
+    assert {violations[0].net_a, violations[0].net_b} == {"/AC_LINE", "/GND"}
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility
+# ---------------------------------------------------------------------------
+
+
+def test_design_rules_pairwise_clearance_defaults_none() -> None:
+    assert DesignRules().pairwise_clearance is None
+
+
+def test_route_pairwise_violation_none_table_noop() -> None:
+    # A ``None`` table means the scalar path -- the helper is a no-op.
+    moving = Route(net=1, net_name="/AC_LINE", segments=[_seg(0, 0, 5, 0, 1, "/AC_LINE")])
+    foreign = Route(net=2, net_name="/GND", segments=[_seg(0, 0.1, 5, 0.1, 2, "/GND")])
+    assert route_pairwise_violation(moving, 1, [foreign], None) is None  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# CLI attach wiring (_apply_pairwise_clearance)
+# ---------------------------------------------------------------------------
+
+
+def test_apply_pairwise_clearance_attaches_table_with_router_dru() -> None:
+    from types import SimpleNamespace
+
+    from kicad_tools.cli.route_cmd import _apply_pairwise_clearance
+
+    rules = DesignRules(trace_clearance=0.25)
+    router = SimpleNamespace(rules=rules)
+    args = SimpleNamespace(
+        _pairwise_voltages={"AC_LINE": 150.0, "GND": 0.0},
+        _pairwise_required={("AC_LINE", "GND"): 1.6},
+    )
+    _apply_pairwise_clearance(router, args, quiet=True)
+    table = rules.pairwise_clearance
+    assert isinstance(table, PairwiseClearanceTable)
+    # DRU floor is the router's actual trace_clearance, not a hardcoded default.
+    assert table.dru == pytest.approx(0.25)
+    assert table.required_clearance("AC_LINE", "GND") == pytest.approx(IEC_150V_PD2_IIIA_MM)
+
+
+def test_apply_pairwise_clearance_noop_without_voltage_map() -> None:
+    from types import SimpleNamespace
+
+    from kicad_tools.cli.route_cmd import _apply_pairwise_clearance
+
+    rules = DesignRules()
+    router = SimpleNamespace(rules=rules)
+    args = SimpleNamespace(_pairwise_voltages=None, _pairwise_required=None)
+    _apply_pairwise_clearance(router, args, quiet=True)
+    assert rules.pairwise_clearance is None


### PR DESCRIPTION
## Summary

Phase 1 of the "scalar clearance → pairwise clearance" epic for HV-isolation
routing (mirrors the diff-pair clearance epic #2556). The router's clearance
model is **scalar-per-net**, which cannot express the pairwise/asymmetric HV
requirement: a mains/bank net needs IEC-creepage spacing (1.3–1.6 mm @150 V PD2)
from *LV* copper but only DRU-functional spacing from its *own cluster's* nets.
A single scalar forces the false choice between "unroutable TO-220 field"
(blanket-wide) and "111 board creepage fails" (cluster-relaxed).

This is a **consumption** problem, not a new algorithm: the ΔV→creepage lookup,
HV-threshold gating and fail-loud out-of-table contract are **reused verbatim**
from the already-merged placement derivation
(`placement.hv_domains.build_required_by_domain_pair`), so the router, HV-aware
placement (#4373) and the post-route creepage census all agree by construction.

Phase 1 delivers (a) the shared data carrier every later phase builds on and
(b) a route-time creepage rejection that replaces the post-hoc census as the
guardrail — the **data-carrier → Python validator** slice of the template.

## Changes

- **New `router/pairwise_clearance.py`** — `PairwiseClearanceTable` resolver:
  `required_clearance(net_a, net_b) → max(dru, creepage_lookup(|ΔV|))`, keyed
  order-independently, `/`-normalised like the census. Same-domain / absent /
  below-threshold pairs return the DRU floor. Plus segment-pair, route-level
  (in-loop) and board-level validator helpers.
- **`DesignRules.pairwise_clearance`** field, default `None` → scalar path is
  byte-for-byte unchanged.
- **route CLI `--voltage-map`** (+ `--creepage-standard` / `--pollution-degree`
  / `--material-group` / `--hv-threshold`) — declared on both parsers,
  forwarded by `commands/routing.py`, preloaded & validated early (missing
  file / malformed JSON / out-of-table |ΔV| → exit 1), attached to the router's
  shared `DesignRules` at each router-creation site with the router's actual DRU.
- **Validator threading** — `pathfinder._validate_route_clearance` and
  `cpp_backend._validate_route_clearance` gain an **additive** pairwise
  post-check on the **Python validation path only** (no `cpp/` change in this
  slice), rejecting an HV net that runs closer than its pairwise requirement to
  non-HV copper. Net names are resolved from authoritative net ids.

## Explicitly deferred (follow-up architect epic — NOT in this PR)

- **Phase 2** — search-time avoidance (widen the A* grid-reservation halo around
  HV copper) + the C++ `validate_route` extension. *This is what actually makes
  an HV board converge instead of thrashing the negotiator.*
- **Phase 3** — KiCad netclass-pair custom `(rule …)` export for
  `kicad-cli pcb drc` referee-enforceability.

⚠️ **Phase 1 is a diagnostic/foundation. It does NOT by itself make the softstart
rev-C (or any HV) board route cleanly** — that requires Phase 2's search-time
avoidance. Approve to de-risk the shared data model and gain route-time
rejection; the architect should file Phases 2–3 as an epic.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `PairwiseClearanceTable.required_clearance` = `max(dru, creepage@|ΔV|)`, scalar fallback | ✅ | `test_resolver_*` |
| Derived via the SAME `build_required_by_domain_pair` path as placement; identical matrices | ✅ | `test_router_and_placement_produce_identical_matrices` |
| route CLI accepts `--voltage-map` (documented in `--help`) | ✅ | `kct route --help`; `test_cli_parser_drift` |
| Python post-route validator rejects HV↔LV below requirement; accepts HV↔HV at DRU | ✅ | `test_segment_pair_*`, `test_route_pairwise_violation_*` |
| Backward-compat: no `--voltage-map` → byte-identical (scalar path) | ✅ | `None`-gated; 108 validate/clearance/determinism tests pass unchanged |
| Out-of-table |ΔV| raises `StandardLookupError` (no silent clamp) | ✅ | `test_out_of_table_delta_v_raises`; CLI exit 1 verified |
| Phase 2 / Phase 3 deferred + cross-linked | ✅ | This PR body + module/flag docstrings |

## Test Plan

- `tests/router/test_pairwise_clearance.py` — 22 tests: resolver, cross-consumer
  matrix agreement with placement, segment/route/board validators, fail-loud
  edge cases, DRU-floor clamp, backward-compat no-op, and the `_apply_pairwise_clearance`
  CLI attach wiring (DRU floor taken from the router's real `trace_clearance`).
- Regression: `pytest tests/router -k "validate or clearance or determinism"` →
  108 passed (scalar path unaffected); CLI parser/route suites → 45 passed.
- Gates: ruff check + format clean; mypy baseline-gated (no new errors).
- CLI error paths verified manually (missing file, out-of-table |ΔV| → exit 1).

Part of #4431