### PR TITLE
feat(placement): flag off-board connectors marooned in the board interior

### DIFF
--- a/src/kicad_tools/placement/analyzer.py
+++ b/src/kicad_tools/placement/analyzer.py
@@ -38,6 +38,10 @@ class DesignRules:
     min_hole_to_hole: float = 0.5  # mm
     min_edge_clearance: float = 0.3  # mm
     courtyard_margin: float = 0.25  # mm - margin around pads for courtyard
+    # Maximum gap an off-board connector's courtyard may stand off from the
+    # nearest board edge before it is flagged as marooned in the interior
+    # (issue #4450). Board-03's USB-C J1 sits 8 mm inside the north edge.
+    edge_connector_max_inset: float = 2.0  # mm
 
 
 class PlacementAnalyzer:
@@ -130,6 +134,7 @@ class PlacementAnalyzer:
         if self._board_edge:
             conflicts.extend(self._check_off_board())
             conflicts.extend(self._check_edge_clearance(rules.min_edge_clearance))
+            conflicts.extend(self._check_edge_connectors(rules.edge_connector_max_inset))
 
         # Sort by severity then location
         conflicts.sort(key=lambda c: (c.severity.value, c.location.x, c.location.y))
@@ -264,6 +269,7 @@ class PlacementAnalyzer:
         if self._board_edge:
             conflicts.extend(self._check_off_board())
             conflicts.extend(self._check_edge_clearance(rules.min_edge_clearance))
+            conflicts.extend(self._check_edge_connectors(rules.edge_connector_max_inset))
 
         # Sort by severity then location
         conflicts.sort(key=lambda c: (c.severity.value, c.location.x, c.location.y))
@@ -815,6 +821,97 @@ class PlacementAnalyzer:
                     actual_clearance=dist,
                     required_clearance=min_clearance,
                 )
+
+    def _check_edge_connectors(self, max_inset: float) -> Iterator[Conflict]:
+        """Flag off-board connectors marooned in the board interior.
+
+        An "edge connector" — USB, barrel jack, RJ45, card-edge finger, or a
+        cable header — must sit at the board **perimeter** so its mating face
+        is accessible off the board.  A connector whose courtyard is *fully
+        inside* the outline yet stands off from the nearest edge by more than
+        ``max_inset`` mm is almost certainly mis-placed: no cable can physically
+        reach it.  This is the motivating case for issue #4450 — board-03's
+        USB-C ``J1`` sits 8 mm inside the north edge with its mouth facing the
+        board interior, so a USB cable cannot plug in.
+
+        Connector classification reuses the shared detector in
+        :mod:`kicad_tools.optim.edge_placement` (``_is_connector``, keyed on
+        reference designator and footprint-name keywords) rather than a private
+        keyword list, so the placement checker and the placement optimizer never
+        drift apart on what counts as a connector.
+
+        Only components whose courtyard is fully inside the outline are
+        considered.  A connector whose courtyard overhangs or falls outside the
+        edge is either an intentional edge overhang or a shifted-off-board part
+        already reported by :meth:`_check_off_board`; skipping those avoids
+        double-reporting and means a correctly *edge-placed* connector (its
+        courtyard touching the edge) never trips this check.
+
+        This is a heuristic surfaced at ``WARNING`` severity: some connectors
+        (board-to-board mezzanine, internal jumpers) are legitimately interior,
+        so the finding invites review rather than invalidating the placement.
+        """
+        if not self._board_edge:
+            return
+
+        from kicad_tools.optim.edge_placement import _is_connector
+
+        edge = self._board_edge
+        # Float-noise tolerance for the fully-inside containment test (the
+        # board-relative frame is produced by subtraction).
+        eps = 1e-6
+
+        for comp in self._components:
+            if not comp.courtyard:
+                continue
+            if not _is_connector(comp.reference, comp.footprint):
+                continue
+
+            cy = comp.courtyard
+
+            # Skip parts not fully inside the outline — those are handled by
+            # _check_off_board (overhang / shifted-off-board).  A connector
+            # placed flush at the edge has its courtyard touching (or slightly
+            # past) the outline, so it is excluded here by design.
+            outside = (
+                cy.min_x < edge.min_x - eps
+                or cy.max_x > edge.max_x + eps
+                or cy.min_y < edge.min_y - eps
+                or cy.max_y > edge.max_y + eps
+            )
+            if outside:
+                continue
+
+            # Distance from the courtyard to each of the four board edges; the
+            # smallest is how far the connector stands off the perimeter.
+            gaps = {
+                "left": cy.min_x - edge.min_x,
+                "right": edge.max_x - cy.max_x,
+                "top": cy.min_y - edge.min_y,
+                "bottom": edge.max_y - cy.max_y,
+            }
+            nearest_edge = min(gaps, key=lambda k: gaps[k])
+            inset = gaps[nearest_edge]
+
+            if inset <= max_inset:
+                # Adjacent to an edge — correctly perimeter-placed.
+                continue
+
+            yield Conflict(
+                type=ConflictType.EDGE_CONNECTOR_PLACEMENT,
+                severity=ConflictSeverity.WARNING,
+                component1=comp.reference,
+                component2=f"{nearest_edge}_edge",
+                message=(
+                    f"off-board connector {comp.reference} is {inset:.1f}mm inside "
+                    f"the board interior (nearest edge: {nearest_edge}); off-board "
+                    "connectors must sit at the perimeter with the mating face "
+                    "accessible off-board"
+                ),
+                location=cy.center,
+                actual_clearance=inset,
+                required_clearance=max_inset,
+            )
 
     def _extract_board_edge(self, pcb) -> Rectangle | None:
         """Extract board outline bounding box from the Edge.Cuts layer.

--- a/src/kicad_tools/placement/conflict.py
+++ b/src/kicad_tools/placement/conflict.py
@@ -15,6 +15,9 @@ class ConflictType(Enum):
     SILKSCREEN_PAD = "silkscreen_pad"  # Silkscreen over copper pads
     EDGE_CLEARANCE = "edge_clearance"  # Components too close to board edge
     OFF_BOARD = "off_board"  # Component courtyard/pads outside the board outline
+    EDGE_CONNECTOR_PLACEMENT = (
+        "edge_connector_placement"  # Off-board connector marooned in the board interior
+    )
 
     @classmethod
     def from_string(cls, s: str) -> "ConflictType":
@@ -34,6 +37,8 @@ class ConflictType(Enum):
             return cls.PAD_CLEARANCE
         if "silk" in s_lower:
             return cls.SILKSCREEN_PAD
+        if "connector" in s_lower:
+            return cls.EDGE_CONNECTOR_PLACEMENT
         if "off" in s_lower and "board" in s_lower:
             return cls.OFF_BOARD
         if "edge" in s_lower:

--- a/tests/test_edge_connector_placement.py
+++ b/tests/test_edge_connector_placement.py
@@ -1,0 +1,170 @@
+"""Tests for the interior-marooned edge-connector placement check (issue #4450).
+
+``PlacementAnalyzer`` (the ``kct placement check`` path) flags off-board
+connectors — USB, barrel jack, RJ45, card-edge, cable headers — whose courtyard
+is fully inside the board outline but stands off from the nearest edge by more
+than ``DesignRules.edge_connector_max_inset`` mm.  Such a connector cannot be
+reached by a cable: the motivating case is board-03's USB-C ``J1``, placed 8 mm
+inside the north edge with its mouth facing the board interior.
+
+The board outline is drawn as a graphics ``gr_rect`` only (no copper Edge.Cuts
+segments), matching what ``kct create-pcb`` and KiCad itself emit, and the
+detected board origin at (100, 100) puts the outline at board-relative
+(0, 0)-(80, 60).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.placement import PlacementAnalyzer
+from kicad_tools.placement.analyzer import DesignRules
+from kicad_tools.placement.conflict import ConflictType
+
+# Board outline: sheet (100,100)-(180,160) -> board-relative (0,0)-(80,60).
+_OUTLINE = """  (gr_rect (start 100 100) (end 180 160)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+"""
+
+
+def _connector_fp(
+    ref: str,
+    x: float,
+    y: float,
+    uuid_n: int,
+    fp_name: str = "Connector_USB:USB_C_Receptacle_GCT_USB4105",
+) -> str:
+    """A small USB-C-like connector footprint (~9mm-wide pad span) at sheet (x, y)."""
+    return f"""  (footprint "{fp_name}"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000{uuid_n:02d}")
+    (at {x} {y})
+    (property "Reference" "{ref}" (at 0 -3 0) (layer "F.SilkS"))
+    (property "Value" "USB-C" (at 0 3 0) (layer "F.Fab"))
+    (pad "A1" smd rect (at -4 0) (size 1.0 2.0) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "VBUS"))
+    (pad "A12" smd rect (at 4 0) (size 1.0 2.0) (layers "F.Cu" "F.Paste" "F.Mask") (net 0 ""))
+  )
+"""
+
+
+def _resistor_fp(ref: str, x: float, y: float, uuid_n: int) -> str:
+    """A small SMD resistor (non-connector) at sheet (x, y)."""
+    return f"""  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000{uuid_n:02d}")
+    (at {x} {y})
+    (property "Reference" "{ref}" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "VBUS"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (net 0 ""))
+  )
+"""
+
+
+def _board(*footprints: str) -> str:
+    body = "".join(footprints)
+    return f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general
+    (thickness 1.6)
+  )
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup
+    (pad_to_mask_clearance 0)
+  )
+  (net 0 "")
+  (net 1 "VBUS")
+{_OUTLINE}{body})
+"""
+
+
+def _write(tmp_path: Path, name: str, content: str) -> Path:
+    pcb_file = tmp_path / name
+    pcb_file.write_text(content)
+    return pcb_file
+
+
+def _edge_connector_conflicts(conflicts):
+    return [c for c in conflicts if c.type == ConflictType.EDGE_CONNECTOR_PLACEMENT]
+
+
+class TestEdgeConnectorPlacement:
+    """Interior-marooned edge-connector detection in PlacementAnalyzer."""
+
+    def test_interior_marooned_connector_flagged(self, tmp_path: Path):
+        """A USB-C connector 8mm inside the north edge is flagged."""
+        # J1 at sheet (140, 108) -> board-relative (40, 8); courtyard top edge
+        # ~6.75mm inside the outline (well past the 2mm default threshold).
+        pcb = _write(tmp_path, "marooned.kicad_pcb", _board(_connector_fp("J1", 140, 108, 1)))
+
+        conflicts = PlacementAnalyzer().find_conflicts(pcb)
+        flagged = _edge_connector_conflicts(conflicts)
+
+        assert len(flagged) == 1
+        c = flagged[0]
+        assert c.component1 == "J1"
+        assert c.component2 == "top_edge"
+        assert c.actual_clearance is not None and c.actual_clearance > 2.0
+        assert "interior" in c.message.lower()
+
+    def test_edge_placed_connector_not_flagged(self, tmp_path: Path):
+        """A connector flush against the north edge is not flagged."""
+        # J1 at sheet (140, 101.5) -> board-relative (40, 1.5); courtyard top
+        # edge only 0.25mm from the outline.
+        pcb = _write(tmp_path, "edge.kicad_pcb", _board(_connector_fp("J1", 140, 101.5, 1)))
+
+        conflicts = PlacementAnalyzer().find_conflicts(pcb)
+
+        assert _edge_connector_conflicts(conflicts) == []
+
+    def test_non_connector_interior_part_not_flagged(self, tmp_path: Path):
+        """A resistor sitting in the board interior is not an edge connector."""
+        pcb = _write(tmp_path, "resistor.kicad_pcb", _board(_resistor_fp("R1", 140, 130, 1)))
+
+        conflicts = PlacementAnalyzer().find_conflicts(pcb)
+
+        assert _edge_connector_conflicts(conflicts) == []
+
+    def test_marooned_connector_not_double_reported_as_off_board(self, tmp_path: Path):
+        """The interior connector is fully on-board, so OFF_BOARD must not fire."""
+        pcb = _write(tmp_path, "marooned2.kicad_pcb", _board(_connector_fp("J1", 140, 108, 1)))
+
+        conflicts = PlacementAnalyzer().find_conflicts(pcb)
+
+        assert len(_edge_connector_conflicts(conflicts)) == 1
+        assert [c for c in conflicts if c.type == ConflictType.OFF_BOARD] == []
+
+    def test_edge_overhang_connector_not_flagged_by_this_check(self, tmp_path: Path):
+        """A connector whose courtyard overhangs the edge is an OFF_BOARD case, not this one."""
+        # J1 at sheet (140, 100) -> board-relative (40, 0); courtyard extends
+        # above the north edge (min_y ~ -1.25), so it is "outside" and handled
+        # by _check_off_board rather than the interior-marooned check.
+        pcb = _write(tmp_path, "overhang.kicad_pcb", _board(_connector_fp("J1", 140, 100, 1)))
+
+        conflicts = PlacementAnalyzer().find_conflicts(pcb)
+
+        assert _edge_connector_conflicts(conflicts) == []
+
+    def test_threshold_is_configurable(self, tmp_path: Path):
+        """Raising edge_connector_max_inset above the actual inset suppresses the flag."""
+        pcb = _write(tmp_path, "config.kicad_pcb", _board(_connector_fp("J1", 140, 108, 1)))
+
+        # Default rules flag it; a 10mm tolerance (> the ~6.75mm inset) does not.
+        assert len(_edge_connector_conflicts(PlacementAnalyzer().find_conflicts(pcb))) == 1
+        loose = DesignRules(edge_connector_max_inset=10.0)
+        assert _edge_connector_conflicts(PlacementAnalyzer().find_conflicts(pcb, loose)) == []
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Adds an edge-connector **placement-validation check** to `PlacementAnalyzer`
(the `kct placement check` path). It flags off-board connectors (USB, barrel
jack, RJ45, card-edge, cable headers) whose courtyard is **fully inside** the
board outline yet stands off from the nearest edge by more than a threshold —
i.e. marooned in the interior where no cable can reach them.

Motivating case (issue #4450): board-03's USB-C `J1` sits ~7.6mm inside the
north edge with its mouth facing the board interior, so a USB cable physically
cannot plug in. Confirmed a **real placement defect** in the board data, not a
3D-render-rotation artifact (that is #4448, a distinct issue).

This is the **detection/validation first slice**. The solver-side
outward-orientation force and the board-03 J1 relocation are deferred (see
below), so this PR uses `Part of #4450` rather than closing it.

## Changes

- `placement/conflict.py`: add `ConflictType.EDGE_CONNECTOR_PLACEMENT` (+ a
  `from_string` mapping).
- `placement/analyzer.py`:
  - new `DesignRules.edge_connector_max_inset` (default 2.0mm).
  - new `_check_edge_connectors()` — mirrors `_check_off_board` structurally,
    uses only already-loaded component/edge data, and **reuses** the existing
    `optim.edge_placement._is_connector` classifier so the connector
    reference/keyword list never drifts from the placement optimizer's.
  - wired into both `find_conflicts` and `_find_conflicts_internal` alongside
    the other edge checks.
- `tests/test_edge_connector_placement.py`: new regression suite.

## Design notes

- Only connectors whose courtyard is **fully inside** the outline are
  considered. A connector that overhangs or falls outside the edge is an
  intentional edge overhang or a shifted-off-board part already reported by
  `_check_off_board`; skipping those avoids double-reporting and means a
  correctly **edge-placed** connector never trips this check.
- `WARNING` severity (heuristic): some connectors (board-to-board mezzanine,
  internal jumpers) are legitimately interior, so the finding invites review
  rather than invalidating the placement.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| New `ConflictType.EDGE_CONNECTOR_PLACEMENT` emitted for an interior-marooned off-board connector | ✅ | `_check_edge_connectors` in `analyzer.py`; unit test `test_interior_marooned_connector_flagged` |
| Classification reuses the existing `optim.edge_placement` detector (no keyword drift) | ✅ | imports `_is_connector` from `optim.edge_placement` |
| `kct placement check` on board-03's routed PCB surfaces J1 as interior-placed | ✅ | Ran `PlacementAnalyzer` on `boards/03-usb-joystick/output/usb_joystick_routed.kicad_pcb` → flags `J1` (7.6mm inside, top edge) and `J2` (7.9mm, left edge) |
| Regression test: interior USB-C flags, edge-placed USB-C passes | ✅ | `test_interior_marooned_connector_flagged` / `test_edge_placed_connector_not_flagged` |
| Non-connector interior part not flagged | ✅ | `test_non_connector_interior_part_not_flagged` |
| No double-report with `_check_off_board` (overhang / on-board) | ✅ | `test_marooned_connector_not_double_reported_as_off_board`, `test_edge_overhang_connector_not_flagged_by_this_check` |
| Deferred items captured, not attempted here | ✅ | See Deferred below |

## Deferred (follow-up work, not in this PR)

- **Outward-orientation force** — extend `EdgeConstraint`/`compute_edge_force`
  to rotate connectors so the mating face aligns with `Edge.normal()`. Needs
  per-footprint mating-face metadata; warrants its own design pass.
- **board-03 J1 relocation + re-route** — move J1 to the north edge and re-tune
  the escape routing (coupled to the #3410 diff-pair re-route). This validation
  check will then *verify* that fix.

## Test Plan

- `pytest tests/test_edge_connector_placement.py` — 6 passed.
- `pytest tests/test_placement.py tests/test_edge_placement.py` — 101 passed, 1
  skipped (no regressions in the existing analyzer/edge suites).
- `ruff check` / `ruff format --check` clean; `mypy` clean on changed sources.
- Manual: analyzer on board-03 routed PCB surfaces J1 (and J2).

Part of #4450