### PR TITLE
fix(models3d): bake pad-field rotation into inserted 3D model refs

### DIFF
--- a/src/kicad_tools/pcb/models3d.py
+++ b/src/kicad_tools/pcb/models3d.py
@@ -32,11 +32,31 @@ no copper/pad/zone/net geometry changes.  Footprints that already share the
 library's origin convention (most SMD parts, e.g. ``R_0805_2012Metric``)
 compute a zero delta and are inserted verbatim.
 
+**Orientation-convention rotation.**  Some generators bake a footprint's
+rotation into the *pad coordinates* rather than expressing it as the
+placement angle ``(at x y angle)`` -- e.g. board-07's 0.1" header lays its
+pads along X (``(-10.16, 0)`` … ``(10.16, 0)``) while the canonical library
+footprint (and its ``.step`` body) lays them along Y.  The placement angle is
+``0`` and the copied model rotate is ``0``, so ``kicad-cli pcb render`` draws
+the body 90° off from the copper.  This is the rotation analog of the origin
+offset above: we derive the pad-field orientation of both the target block
+and the source library footprint from two anchor pads (the pad-1→pad-2
+vector), and bake ``theta = target - source`` into the inserted model's
+``(rotate (xyz 0 0 ...))``.  Because the model frame's Y is negated versus the
+footprint 2D frame, a footprint-2D rotation of ``theta`` maps to a model-frame
+Z rotation of ``-theta``.  The centroid offset is composed **in the rotated
+frame** (``offset_2d = target_centroid - R_theta * source_centroid``) so the
+body still lands on the target pads.  Co-oriented footprints (all SMD parts,
+headers already authored on the library convention, the origin-offset case
+above) compute ``theta ~= 0`` and keep ``(rotate (xyz 0 0 0))`` plus the
+existing offset verbatim.
+
 Used by ``kct pcb add-3d-models``.
 """
 
 from __future__ import annotations
 
+import math
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -299,6 +319,94 @@ def _find_first_at(text: str, start: int, end: int) -> tuple[float, float] | Non
     return None
 
 
+def _pad_number(text: str, start: int, end: int) -> str:
+    """Return the pad number (first quoted field) of a ``(pad ...)`` node.
+
+    ``text[start:end]`` spans the pad node's interior (just past ``(pad``).
+    Returns ``""`` when the pad carries no quoted number.
+    """
+    q = text.find('"', start, end)
+    if q == -1:
+        return ""
+    q_end = _skip_string(text, q)
+    return text[q + 1 : q_end - 1]
+
+
+def _pad_positions(block_text: str) -> list[tuple[str, tuple[float, float]]]:
+    """Return ``(pad_number, (x, y))`` for every positioned pad, in order.
+
+    Scans *block_text* (a full ``(footprint ...)`` or ``.kicad_mod`` body,
+    string-aware) for every copper ``(pad ...)`` node and records its number
+    and ``(at x y)`` position.  Pads without an ``(at ...)`` are skipped.
+    """
+    out: list[tuple[str, tuple[float, float]]] = []
+    i = 0
+    n = len(block_text)
+    needle = "(pad"
+    while i < n:
+        c = block_text[i]
+        if c == '"':
+            i = _skip_string(block_text, i)
+            continue
+        if c == "(" and block_text.startswith(needle, i):
+            after = i + len(needle)
+            if after < n and block_text[after] in " \t\n":
+                pad_end = _find_matching_paren(block_text, i)
+                number = _pad_number(block_text, after, pad_end)
+                at = _find_first_at(block_text, i, pad_end)
+                if at is not None:
+                    out.append((number, at))
+                i = pad_end + 1
+                continue
+        i += 1
+    return out
+
+
+def _pad_field_orientation(block_text: str) -> float | None:
+    """Return the pad-field orientation of a footprint block, in degrees.
+
+    The orientation is the angle (``atan2(dy, dx)``, degrees) of the vector
+    from pad ``"1"`` to pad ``"2"`` in the footprint-local 2D frame.  When the
+    numbered pads ``"1"`` / ``"2"`` are not both present, the first two
+    positioned pads (document order) are used as a fallback.
+
+    Returns ``None`` when fewer than two positioned pads exist, or when the two
+    anchor pads coincide (no derivable direction) -- callers then fall back to
+    zero rotation.  A footprint whose pad field is rotated by ``theta`` from
+    its library counterpart yields ``target - source == theta``.
+    """
+    pads = _pad_positions(block_text)
+    if len(pads) < 2:
+        return None
+    by_number = dict(pads)
+    if "1" in by_number and "2" in by_number:
+        p1, p2 = by_number["1"], by_number["2"]
+    else:
+        p1, p2 = pads[0][1], pads[1][1]
+    dx = p2[0] - p1[0]
+    dy = p2[1] - p1[1]
+    if abs(dx) < 1e-9 and abs(dy) < 1e-9:
+        return None
+    return math.degrees(math.atan2(dy, dx))
+
+
+def _normalize_angle(deg: float) -> float:
+    """Normalize an angle in degrees to the half-open range ``(-180, 180]``."""
+    a = deg % 360.0
+    if a > 180.0:
+        a -= 360.0
+    return a
+
+
+def _rotate_point(point: tuple[float, float], theta_deg: float) -> tuple[float, float]:
+    """Rotate *point* about the origin by *theta_deg* (footprint 2D frame, CCW)."""
+    rad = math.radians(theta_deg)
+    cos_t = math.cos(rad)
+    sin_t = math.sin(rad)
+    x, y = point
+    return (x * cos_t - y * sin_t, x * sin_t + y * cos_t)
+
+
 def _apply_offset_delta(model_block: str, dx: float, dy: float) -> str:
     """Return *model_block* with ``(dx, -dy)`` added into its ``(offset ...)``.
 
@@ -352,6 +460,43 @@ def _fmt_num(value: float) -> str:
     return f"{rounded:g}"
 
 
+def _apply_rotate_delta(model_block: str, theta_deg: float) -> str:
+    """Return *model_block* with a model-frame Z rotation of ``-theta_deg`` baked in.
+
+    *theta_deg* is the pad-field rotation of the target footprint relative to
+    its library source, measured in the footprint 2D frame.  The KiCad 3D-model
+    frame negates Y versus the footprint 2D frame, so a footprint-2D rotation of
+    ``theta`` maps to a model-frame Z rotation of ``-theta`` (pinned by the
+    regression tests).  The delta is added into the block's own ``(rotate (xyz
+    X Y Z))`` Z field; X and Y are preserved.
+
+    When *theta_deg* is (near) zero -- the co-oriented case (all SMD parts, the
+    origin-convention offset fixtures) -- the block is returned unchanged so
+    already-correct footprints get a verbatim insert.
+    """
+    if abs(_normalize_angle(theta_deg)) < 1e-6:
+        return model_block
+    rot_idx = model_block.find("(rotate")
+    if rot_idx == -1:
+        return model_block
+    rot_end = _find_matching_paren(model_block, rot_idx)
+    xyz_idx = model_block.find("(xyz", rot_idx, rot_end)
+    if xyz_idx == -1:
+        return model_block
+    xyz_end = _find_matching_paren(model_block, xyz_idx)
+    inner = model_block[xyz_idx + len("(xyz") : xyz_end]
+    fields = inner.split()
+    if len(fields) < 3:
+        return model_block
+    try:
+        rx, ry, rz = float(fields[0]), float(fields[1]), float(fields[2])
+    except ValueError:
+        return model_block
+    nz = _fmt_num(_normalize_angle(rz - theta_deg))  # footprint 2D theta -> model Z -theta
+    new_xyz = f"(xyz {_fmt_num(rx)} {_fmt_num(ry)} {nz})"
+    return model_block[:xyz_idx] + new_xyz + model_block[xyz_end + 1 :]
+
+
 # --------------------------------------------------------------------------
 # Resolvers: lib id -> dedented (model ...) block texts
 # --------------------------------------------------------------------------
@@ -359,17 +504,21 @@ def _fmt_num(value: float) -> str:
 
 @dataclass
 class ResolvedModels:
-    """A resolver hit: the model block texts plus the source pad-1 position.
+    """A resolver hit: the model block texts plus the source pad-field geometry.
 
     *models* are the dedented ``(model ...)`` node texts from the resolved
     library ``.kicad_mod``.  *source_anchor* is that footprint's own pad
     centroid (``None`` when it has no positioned pads), used to compute the
     origin-convention offset ``target_anchor - source_anchor`` at insertion
-    time.
+    time.  *source_orientation* is that footprint's pad-field orientation in
+    degrees (``None`` when fewer than two positioned pads exist), used to
+    compute the rotation ``theta = target_orientation - source_orientation``
+    that a pad-field-rotated target footprint needs baked into its model.
     """
 
     models: list[str]
     source_anchor: tuple[float, float] | None = None
+    source_orientation: float | None = None
 
 
 # A resolver maps a lib id to its resolved models.  For backward
@@ -535,6 +684,7 @@ def make_library_resolver(
                     result = ResolvedModels(
                         models=extract_model_blocks(mod_text),
                         source_anchor=_pad_anchor(mod_text),
+                        source_orientation=_pad_field_orientation(mod_text),
                     )
                     if sub_id is not None and substitution_log is not None:
                         substitution_log[lib_id] = sub_id
@@ -601,26 +751,42 @@ def add_model_refs_to_text(pcb_text: str, resolver: Resolver) -> tuple[str, Mode
         if isinstance(resolved, ResolvedModels):
             models = resolved.models
             source_anchor = resolved.source_anchor
+            source_orientation = resolved.source_orientation
         else:
             models = resolved
             source_anchor = None
+            source_orientation = None
         if not models:
             report.no_model_in_library.append(block.lib_id)
             continue
-        # Origin-convention offset: shift the body by target_anchor -
-        # source_anchor (pad centroids) so the model lands on the target
-        # footprint's pads even when it reuses a canonical name on a
-        # different origin convention.
+        # Orientation-convention rotation: a target footprint whose pad field
+        # is rotated relative to its library source (rotation baked into pad
+        # coordinates rather than the placement angle) needs the delta baked
+        # into the model's (rotate ...).  theta is measured in the footprint
+        # 2D frame; the model frame negates Y, so _apply_rotate_delta bakes a
+        # model-frame Z of -theta.  When either orientation is underivable
+        # (single-pad parts, LCSC-synthesized bodies) theta stays 0.
+        target_orientation = _pad_field_orientation(body)
+        theta = 0.0
+        if source_orientation is not None and target_orientation is not None:
+            theta = _normalize_angle(target_orientation - source_orientation)
+        # Origin-convention offset, composed in the rotated frame: shift the
+        # body by target_anchor - R_theta * source_anchor (pad centroids) so
+        # the model lands on the target footprint's pads after rotation.  With
+        # theta == 0 this reduces to the plain target - source centroid delta.
         target_anchor = _pad_anchor(body)
         dx = dy = 0.0
         if source_anchor is not None and target_anchor is not None:
-            dx = target_anchor[0] - source_anchor[0]
-            dy = target_anchor[1] - source_anchor[1]
+            rsx, rsy = _rotate_point(source_anchor, theta)
+            dx = target_anchor[0] - rsx
+            dy = target_anchor[1] - rsy
         # Insert before the line that holds the footprint's closing paren.
         close_line_start = pcb_text.rfind("\n", 0, block.end) + 1
         child_indent = block.indent + "\t"
         text = "".join(
-            _indent_block(_apply_offset_delta(m, dx, dy), child_indent) + "\n" for m in models
+            _indent_block(_apply_rotate_delta(_apply_offset_delta(m, dx, dy), theta), child_indent)
+            + "\n"
+            for m in models
         )
         insertions.append((close_line_start, text))
         report.patched.append(block.lib_id)

--- a/tests/test_pcb_add_3d_models.py
+++ b/tests/test_pcb_add_3d_models.py
@@ -15,7 +15,9 @@ from kicad_tools.footprints.library_path import LibraryPaths
 from kicad_tools.pcb.models3d import (
     ResolvedModels,
     _apply_offset_delta,
+    _apply_rotate_delta,
     _pad_anchor,
+    _pad_field_orientation,
     add_model_refs,
     add_model_refs_to_text,
     extract_model_blocks,
@@ -748,3 +750,308 @@ class TestResolvedModels:
         assert report.patched
         # No anchor available -> zero offset applied (verbatim).
         assert "(xyz 0 0 0)" in new_text
+
+
+# --------------------------------------------------------------------------
+# Orientation-convention rotation (issue #4448)
+# --------------------------------------------------------------------------
+#
+# Some generators bake a footprint's rotation into the *pad coordinates*
+# rather than the placement angle: board-07's 0.1" header lays its pads along
+# X while the canonical library footprint (and its STEP body) lays them along
+# Y.  Placement angle and model rotate are both 0 as written, so kicad-cli
+# renders the body 90° off from the copper.  The patcher must derive the
+# pad-field orientation from two anchor pads and bake theta = target - source
+# into the model (rotate (xyz 0 0 -theta)) -- model-frame Y is negated vs the
+# footprint 2D frame, so a footprint-2D rotation of theta maps to model-frame
+# Z of -theta -- while composing the centroid offset in the rotated frame.
+
+# Library footprint: 1x09 pins running along +Y (pad 1 at origin), matching
+# the canonical KiCad PinHeader_1x09_P2.54mm_Vertical .step authoring.
+# Centroid = (0, 10.16), orientation = +90° (pad-1 -> pad-2 is +Y).
+ROT_HEADER_LIB_MOD = (
+    '(footprint "PinHeader_1x09_P2.54mm_Vertical"\n'
+    '\t(layer "F.Cu")\n'
+    + "".join(
+        f'\t(pad "{i + 1}" thru_hole {"rect" if i == 0 else "oval"}\n'
+        f"\t\t(at 0 {i * 2.54:g})\n"
+        "\t\t(size 1.7 1.7)\n"
+        "\t\t(drill 1)\n"
+        '\t\t(layers "*.Cu" "*.Mask")\n'
+        "\t)\n"
+        for i in range(9)
+    )
+    + '\t(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/'
+    'PinHeader_1x09_P2.54mm_Vertical.step"\n'
+    "\t\t(offset\n\t\t\t(xyz 0 0 0)\n\t\t)\n"
+    "\t\t(scale\n\t\t\t(xyz 1 1 1)\n\t\t)\n"
+    "\t\t(rotate\n\t\t\t(xyz 0 0 0)\n\t\t)\n"
+    "\t)\n"
+    ")\n"
+)
+
+# Board footprint reusing that lib id but with the 90° baked into pad coords:
+# pads run along X from (-10.16, 0) to (10.16, 0) (board-07 generate_addr_header
+# geometry).  Centroid = (0, 0), orientation = 0° (pad-1 -> pad-2 is +X).
+ROT_HEADER_PCB_TEXT = (
+    "(kicad_pcb\n"
+    "\t(version 20240108)\n"
+    '\t(footprint "Connector_PinHeader_2.54mm:PinHeader_1x09_P2.54mm_Vertical"\n'
+    '\t\t(layer "F.Cu")\n'
+    "\t\t(at 113.5 120)\n"
+    + "".join(
+        f'\t\t(pad "{i + 1}" thru_hole {"rect" if i == 0 else "oval"}\n'
+        f"\t\t\t(at {(i - 4) * 2.54:g} 0)\n"
+        "\t\t\t(size 1.7 1.7)\n"
+        "\t\t\t(drill 1)\n"
+        '\t\t\t(layers "*.Cu" "*.Mask")\n'
+        "\t\t)\n"
+        for i in range(9)
+    )
+    + "\t)\n"
+    ")\n"
+)
+
+
+def _make_rot_header_library(tmp_path: Path) -> LibraryPaths:
+    root = tmp_path / "footprints"
+    lib = root / "Connector_PinHeader_2.54mm.pretty"
+    lib.mkdir(parents=True)
+    (lib / "PinHeader_1x09_P2.54mm_Vertical.kicad_mod").write_text(ROT_HEADER_LIB_MOD)
+    return LibraryPaths(footprints_path=root, source="config")
+
+
+class TestPadFieldOrientationHelper:
+    def _block(self, p2: tuple[float, float]) -> str:
+        return (
+            '(footprint "x"\n'
+            '\t(pad "1" thru_hole rect (at 0 0) (size 1 1))\n'
+            f'\t(pad "2" thru_hole oval (at {p2[0]:g} {p2[1]:g}) (size 1 1))\n'
+            ")\n"
+        )
+
+    def test_orientation_zero_pads_along_x(self):
+        assert _pad_field_orientation(self._block((1, 0))) == 0.0
+
+    def test_orientation_ninety_pads_along_y(self):
+        assert _pad_field_orientation(self._block((0, 1))) == 90.0
+
+    def test_orientation_one_eighty(self):
+        assert _pad_field_orientation(self._block((-1, 0))) == 180.0
+
+    def test_orientation_two_seventy_is_minus_ninety(self):
+        # atan2(-1, 0) = -90°; 270° is represented as -90 in the raw helper.
+        assert _pad_field_orientation(self._block((0, -1))) == -90.0
+
+    def test_orientation_uses_numbered_pads_not_document_order(self):
+        # Pad "2" appears before pad "1" in document order, but the pad-1 -> pad-2
+        # vector (+Y) must still drive the orientation.
+        block = (
+            '(footprint "x"\n'
+            '\t(pad "2" thru_hole oval (at 0 2.54) (size 1 1))\n'
+            '\t(pad "1" thru_hole rect (at 0 0) (size 1 1))\n'
+            ")\n"
+        )
+        assert _pad_field_orientation(block) == 90.0
+
+    def test_orientation_falls_back_to_first_two_pads_when_unnumbered(self):
+        block = (
+            '(footprint "x"\n'
+            '\t(pad "" thru_hole rect (at 0 0) (size 1 1))\n'
+            '\t(pad "" thru_hole oval (at 3 0) (size 1 1))\n'
+            ")\n"
+        )
+        assert _pad_field_orientation(block) == 0.0
+
+    def test_orientation_none_for_single_pad(self):
+        block = '(footprint "x"\n\t(pad "1" thru_hole rect (at 0 0) (size 1 1))\n)\n'
+        assert _pad_field_orientation(block) is None
+
+    def test_orientation_none_for_no_pads(self):
+        assert _pad_field_orientation('(footprint "x"\n\t(layer "F.Cu")\n)\n') is None
+
+    def test_orientation_none_for_coincident_anchor_pads(self):
+        block = (
+            '(footprint "x"\n'
+            '\t(pad "1" thru_hole rect (at 5 5) (size 1 1))\n'
+            '\t(pad "2" thru_hole oval (at 5 5) (size 1 1))\n'
+            ")\n"
+        )
+        assert _pad_field_orientation(block) is None
+
+
+class TestApplyRotateDelta:
+    MODEL = (
+        '(model "a.step"\n'
+        "\t(offset\n\t\t(xyz 0 0 0)\n\t)\n"
+        "\t(scale\n\t\t(xyz 1 1 1)\n\t)\n"
+        "\t(rotate\n\t\t(xyz 0 0 0)\n\t)\n)"
+    )
+
+    def test_footprint_theta_maps_to_model_z_negated(self):
+        # theta = -90 (target rotated -90 from source) -> model-frame Z = +90.
+        out = _apply_rotate_delta(self.MODEL, -90.0)
+        assert "(rotate\n\t\t(xyz 0 0 90)" in out
+        # Only the rotate xyz changed; offset/scale untouched.
+        assert "(offset\n\t\t(xyz 0 0 0)" in out
+        assert "(scale\n\t\t(xyz 1 1 1)" in out
+
+    def test_positive_theta_maps_to_negative_model_z(self):
+        out = _apply_rotate_delta(self.MODEL, 90.0)
+        assert "(rotate\n\t\t(xyz 0 0 -90)" in out
+
+    def test_zero_theta_is_verbatim(self):
+        assert _apply_rotate_delta(self.MODEL, 0.0) == self.MODEL
+
+    def test_full_turn_theta_is_verbatim(self):
+        # 360° normalizes to 0 -> no rotation baked in.
+        assert _apply_rotate_delta(self.MODEL, 360.0) == self.MODEL
+
+    def test_existing_nonzero_rotate_is_added_to(self):
+        model = '(model "a.step"\n\t(rotate\n\t\t(xyz 0 0 45)\n\t)\n)'
+        out = _apply_rotate_delta(model, -90.0)
+        # 45 - (-90) = 135
+        assert "(xyz 0 0 135)" in out
+
+
+class TestOrientationConventionRotation:
+    def test_pad_rotated_header_gets_ninety_degree_model_rotate(self, tmp_path):
+        """The board-07 case: library pads along Y, board pads along X.
+
+        theta = target(0°) - source(90°) = -90°; model-frame Z = -theta = +90°.
+        Offset is composed in the rotated frame:
+          R_{-90} * source_centroid(0, 10.16) = (10.16, 0)
+          offset_2d = target_centroid(0,0) - (10.16, 0) = (-10.16, 0)
+          model offset = (-10.16, -0, 0) = (-10.16, 0, 0)
+        """
+        lib = _make_rot_header_library(tmp_path)
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text(ROT_HEADER_PCB_TEXT)
+        report = add_model_refs(pcb, library_paths=lib)
+        assert report.patched == ["Connector_PinHeader_2.54mm:PinHeader_1x09_P2.54mm_Vertical"]
+        text = pcb.read_text()
+        import re
+
+        # Sign convention pinned: +90 model-frame Z for a -90 footprint rotation.
+        rotate_xyz = re.search(r"\(rotate\s*\(xyz ([^)]+)\)", text)
+        assert rotate_xyz is not None
+        assert rotate_xyz.group(1).strip() == "0 0 90"
+        # Centroid offset composed in the rotated frame.
+        offset_xyz = re.search(r"\(offset\s*\(xyz ([^)]+)\)", text)
+        assert offset_xyz is not None
+        assert offset_xyz.group(1).strip() == "-10.16 0 0"
+
+    def test_rotate_and_offset_are_pure_metadata(self, tmp_path):
+        """Only inserted model lines differ; no original copper line moves."""
+        lib = _make_rot_header_library(tmp_path)
+        new_text, _ = add_model_refs_to_text(ROT_HEADER_PCB_TEXT, make_library_resolver(lib))
+        original_lines = ROT_HEADER_PCB_TEXT.splitlines()
+        new_lines = new_text.splitlines()
+        it = iter(new_lines)
+        assert all(line in it for line in original_lines), "an original line moved/was dropped"
+        added = set(new_lines) - set(original_lines)
+        for line in added:
+            body = line.strip()
+            assert body.startswith(("(model", "(offset", "(scale", "(rotate", "(xyz", ")"))
+
+    def test_co_oriented_header_keeps_zero_rotate(self, tmp_path):
+        """The #4034 origin-convention header (pads along Y in BOTH the library
+        and the board) is co-oriented: theta ~= 0, so the inserted model keeps
+        (rotate (xyz 0 0 0)) verbatim -- no regression."""
+        import re
+
+        lib = _make_header_library(tmp_path)
+        new_text, _ = add_model_refs_to_text(HEADER_PCB_TEXT, make_library_resolver(lib))
+        rotate_xyz = re.search(r"\(rotate\s*\(xyz ([^)]+)\)", new_text)
+        assert rotate_xyz is not None
+        assert rotate_xyz.group(1).strip() == "0 0 0"
+        # And the origin offset is still the #4034 value (Y negated vs -1.27).
+        assert "(xyz 0 1.27 0)" in new_text
+
+    def test_co_oriented_smd_keeps_zero_rotate(self, tmp_path):
+        """An SMD 0805 part (co-oriented) keeps (rotate (xyz 0 0 0)) verbatim."""
+        import re
+
+        lib = _make_library(tmp_path)
+        new_text, _ = add_model_refs_to_text(PCB_TEXT, make_library_resolver(lib))
+        rotate_xyz = re.search(r"\(rotate\s*\(xyz ([^)]+)\)", new_text)
+        assert rotate_xyz is not None
+        assert rotate_xyz.group(1).strip() == "0 0 0"
+
+    def test_source_orientation_carried_on_resolved_models(self, tmp_path):
+        lib = _make_rot_header_library(tmp_path)
+        resolver = make_library_resolver(lib)
+        resolved = resolver("Connector_PinHeader_2.54mm:PinHeader_1x09_P2.54mm_Vertical")
+        assert isinstance(resolved, ResolvedModels)
+        assert resolved.source_orientation == 90.0
+
+    def test_one_eighty_rotation(self, tmp_path):
+        """A header whose pads run in -Y (180° from the library +Y) gets a
+        180° model rotate and the centroid offset composed in that frame."""
+        root = tmp_path / "footprints"
+        libdir = root / "Connector_PinHeader_2.54mm.pretty"
+        libdir.mkdir(parents=True)
+        (libdir / "PinHeader_1x09_P2.54mm_Vertical.kicad_mod").write_text(ROT_HEADER_LIB_MOD)
+        paths = LibraryPaths(footprints_path=root, source="config")
+        # Board pads run downward from (0, 20.32): pad 1 (0, 20.32) ... pad 9 (0, 0),
+        # i.e. the pad-1 -> pad-2 vector is -Y (180° from the library +Y).
+        # Centroid = (0, 10.16).
+        pcb_text = (
+            "(kicad_pcb\n"
+            '\t(footprint "Connector_PinHeader_2.54mm:PinHeader_1x09_P2.54mm_Vertical"\n'
+            '\t\t(layer "F.Cu")\n'
+            + "".join(
+                f'\t\t(pad "{i + 1}" thru_hole {"rect" if i == 0 else "oval"}\n'
+                f"\t\t\t(at 0 {20.32 - i * 2.54:g})\n"
+                "\t\t\t(size 1.7 1.7)\n"
+                "\t\t\t(drill 1)\n"
+                '\t\t\t(layers "*.Cu" "*.Mask")\n'
+                "\t\t)\n"
+                for i in range(9)
+            )
+            + "\t)\n"
+            ")\n"
+        )
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text(pcb_text)
+        add_model_refs(pcb, library_paths=paths)
+        text = pcb.read_text()
+        import re
+
+        # target orient = -90 (atan2(-2.54, 0)); source = 90; theta = -180 -> 180;
+        # model-frame Z = -theta = -180 -> normalize to 180.
+        rotate_xyz = re.search(r"\(rotate\s*\(xyz ([^)]+)\)", text)
+        assert rotate_xyz is not None
+        assert rotate_xyz.group(1).strip() == "0 0 180"
+        # R_{180} * source_centroid(0, 10.16) = (0, -10.16);
+        # offset_2d = target_centroid(0, 10.16) - (0, -10.16) = (0, 20.32);
+        # model offset Y negated -> (0, -20.32, 0).
+        offset_xyz = re.search(r"\(offset\s*\(xyz ([^)]+)\)", text)
+        assert offset_xyz is not None
+        assert offset_xyz.group(1).strip() == "0 -20.32 0"
+
+    def test_single_pad_target_falls_back_to_zero_rotation(self, tmp_path):
+        """A target footprint with only one positioned pad has no derivable
+        orientation -> zero rotation, no crash."""
+        lib = _make_rot_header_library(tmp_path)
+        pcb_text = (
+            "(kicad_pcb\n"
+            '\t(footprint "Connector_PinHeader_2.54mm:PinHeader_1x09_P2.54mm_Vertical"\n'
+            '\t\t(layer "F.Cu")\n'
+            '\t\t(pad "1" thru_hole rect\n'
+            "\t\t\t(at 0 0)\n"
+            "\t\t\t(size 1.7 1.7)\n"
+            '\t\t\t(layers "*.Cu" "*.Mask")\n'
+            "\t\t)\n"
+            "\t)\n"
+            ")\n"
+        )
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text(pcb_text)
+        report = add_model_refs(pcb, library_paths=lib)
+        assert report.patched
+        import re
+
+        rotate_xyz = re.search(r"\(rotate\s*\(xyz ([^)]+)\)", pcb.read_text())
+        assert rotate_xyz is not None
+        assert rotate_xyz.group(1).strip() == "0 0 0"


### PR DESCRIPTION
## Summary

Fixes the unwanted 90° rotation of the 0.1" pin header in board-07's 3D front
render (issue #4448). The root cause is the **rotation analog of #4034**: when
a generator bakes a footprint's rotation into its *pad coordinates* (board-07's
`generate_addr_header` lays the 1x09 header pads along X, while the canonical
library footprint `PinHeader_1x09_P2.54mm_Vertical` and its `.step` body lay
them along Y), the placement angle `(at x y)` and the copied model `(rotate)`
are **both 0** as written. The shared inserter (`add_model_refs`) compensated
only *translation* (the #4034 centroid offset) and always emitted
`(rotate (xyz 0 0 0))`, so `kicad-cli pcb render` drew the STEP body 90° off
from the copper.

The fix lives in the shared inserter `src/kicad_tools/pcb/models3d.py`, so
**any** rotated through-hole connector is covered — not a board-07 nudge.

## Changes

- `_pad_field_orientation(block)` — derives a footprint's pad-field orientation
  (degrees) from the pad-1 → pad-2 vector (falls back to the first two
  positioned pads; returns `None` for < 2 pads or coincident anchors).
- `_apply_rotate_delta(model_block, theta)` — bakes a model-frame Z rotation of
  `-theta` into the block's `(rotate (xyz ...))`. **Sign convention:** the model
  frame negates Y vs the footprint 2D frame, so a footprint-2D rotation of
  `theta` maps to a model-frame Z of `-theta`. Verbatim when `theta ≈ 0`.
- `ResolvedModels.source_orientation` — the library footprint's pad-field
  orientation, populated in `resolve()` alongside `source_anchor`.
- `add_model_refs_to_text` — computes `theta = target − source` and composes the
  centroid offset **in the rotated frame** (`target_centroid − R_theta ·
  source_centroid`) so the body still lands on the target pads. When either
  orientation is underivable (single-pad parts, LCSC-synthesized bodies) or the
  footprints are co-oriented, `theta = 0` and the offset/rotate are the existing
  #4034 behavior verbatim.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Root cause documented (pad-field orientation mismatch; placement angle + model rotate both 0) | ✅ | Summary above + module docstring |
| `add_model_refs` bakes pad-field rotation into `(rotate (xyz 0 0 θ))`, generic | ✅ | `_apply_rotate_delta` in the shared inserter; `TestOrientationConventionRotation` |
| Translation offset computed in the rotated frame | ✅ | `target − R_theta·source` in `add_model_refs_to_text`; asserted for 90°/180° |
| Co-oriented footprints keep `(rotate (xyz 0 0 0))` + existing offset (no #4034 regression) | ✅ | `test_co_oriented_header_keeps_zero_rotate`, `test_co_oriented_smd_keeps_zero_rotate`; all prior fixtures green |
| Board-07 J3 gets `(rotate (xyz 0 0 ±90))` aligned with copper | ✅ | End-to-end run vs the real installed KiCad library → `(rotate (xyz 0 0 90))`, `(offset (xyz -10.16 0 0))` |

## Test Plan

- `uv run pytest tests/test_pcb_add_3d_models.py` — **60 passed** (55 prior + new
  orientation-helper, `_apply_rotate_delta`, and rotation-integration tests).
- **Sign pinned:** the board-07 pad ordering (source +Y at 90°, target +X at 0°,
  `theta = 0 − 90 = −90`) yields a model-frame Z of `+90` — asserted in
  `test_pad_rotated_header_gets_ninety_degree_model_rotate`.
- Edge cases covered: 0/90/180/270° pad fields; 180° rotation with offset
  composed in-frame; co-oriented SMD + #4034 header stay zero-rotation; single-pad
  target falls back to zero rotation without crashing.
- End-to-end against the installed KiCad library on the real board-07 output:
  J3 header model gets `(rotate (xyz 0 0 90))` + `(offset (xyz -10.16 0 0))`.
- `ruff format --check`, `ruff check .`, and `mypy src/kicad_tools/pcb/models3d.py`
  all clean.

Closes #4448