### PR TITLE
refactor(boards): migrate remaining 5 recipes to the shared pipeline success gate

### DIFF
--- a/boards/00-simple-led/generate_design.py
+++ b/boards/00-simple-led/generate_design.py
@@ -26,6 +26,7 @@ from kicad_tools.core.project_file import create_minimal_project, save_project
 from kicad_tools.dev import warn_if_stale
 from kicad_tools.lvs import write_lvs_report
 from kicad_tools.pcb.center_sheet import centered_origin
+from kicad_tools.recipes.gate import evaluate_pipeline_gate
 from kicad_tools.schematic.models.schematic import Schematic
 
 # Warn if running source scripts with stale pipx install
@@ -1003,6 +1004,29 @@ def main() -> int:
         # stale"`` ship-ready blocker in ``kct fleet status``.
         mfg_success = export_manufacturing_bundle(routed_path, output_dir)
 
+        # Issue #3912: derive BOTH the SUMMARY and the exit code from ONE
+        # shared PipelineGateResult so they can never diverge.  The gate's
+        # DRC leg is AUTHORITATIVE -- it runs ``kicad-cli pcb drc
+        # --refill-zones`` (run_geometric_drc) from scratch, catching
+        # copper shorts that the stale-zone-fill ``kct check`` engine is
+        # blind to -- and the recipe's own ``run_drc`` verdict
+        # (``drc_success``) is threaded in as ``supplemental_drc_ok`` so it
+        # can only TIGHTEN the DRC verdict, never loosen it.  Board 00
+        # routes fully (the fast-fail above already raised on a partial
+        # route, so ``route_success`` is True here) with no allowance, and
+        # its copper-LVS verdict (``lvs_success``) is the LVS leg.  Board 00
+        # is manufacturable-clean, so the gate passes and the recipe exits 0.
+        gate = evaluate_pipeline_gate(
+            routed_path,
+            route_ok=route_success,
+            route_allowance=0,
+            lvs_ok=lvs_success,
+            supplemental_drc_ok=drc_success,
+            supplemental_reason=(
+                "kct check reported error-level DRC findings (see DRC output above)"
+            ),
+        )
+
         # Summary
         print("\n" + "=" * 60)
         print("SUMMARY")
@@ -1015,20 +1039,25 @@ def main() -> int:
         print(f"  4. PCB (routed): {routed_path.name}")
         print("\nResults:")
         print(f"  ERC: {'PASS' if erc_success else 'FAIL'}")
-        print(f"  Routing: {'SUCCESS' if route_success else 'PARTIAL'}")
-        print(f"  DRC: {'PASS' if drc_success else 'FAIL'}")
-        print(f"  LVS: {'PASS' if lvs_success else 'FAIL'}")
-        print(f"  MFG bundle: {'PASS' if mfg_success else 'FAIL'}")
+        for line in gate.summary_lines():
+            print(line)
+        # #3912: mfg_success means ``kct export`` WROTE a bundle (exit 0),
+        # NOT that the board is DRC-clean -- board cleanliness is the
+        # ``DRC``/``Overall`` verdict above.  Label "WRITTEN" so PASS is
+        # never mistaken for a DRC pass.
+        print(f"  MFG bundle: {'WRITTEN' if mfg_success else 'FAILED'}")
         print("\nCircuit description:")
         print("  - J1: 2-pin power input (VCC, GND)")
         print("  - R1: 330 ohm current limiter")
         print("  - D1: LED indicator")
         print("  - 5V input -> ~10mA LED current")
 
-        # Partial routing is acceptable; success if ERC, DRC, and LVS pass.
-        # (``run_lvs`` raises on a dirty LVS so a False ``lvs_success`` here
-        # would mean LVS itself short-circuited -- belt-and-braces guard.)
-        return 0 if erc_success and drc_success and lvs_success else 1
+        # #3912: the exit code derives from the SAME PipelineGateResult that
+        # drove the SUMMARY above (route / DRC / LVS legs).  ERC remains an
+        # independent gating leg not modelled by the shared gate.  (``run_lvs``
+        # already raises on a dirty LVS so a False ``lvs_ok`` here would mean
+        # LVS itself short-circuited -- belt-and-braces guard.)
+        return 0 if erc_success and gate.passed else 1
 
     except Exception as e:
         print(f"\nError: {e}", file=sys.stderr)

--- a/boards/01-voltage-divider/generate_design.py
+++ b/boards/01-voltage-divider/generate_design.py
@@ -25,6 +25,7 @@ from kicad_tools.core.project_file import create_minimal_project, save_project
 from kicad_tools.dev import warn_if_stale
 from kicad_tools.lvs import write_lvs_report
 from kicad_tools.pcb.center_sheet import centered_origin
+from kicad_tools.recipes.gate import evaluate_pipeline_gate
 from kicad_tools.schematic.models.schematic import Schematic
 
 # Warn if running source scripts with stale pipx install
@@ -842,6 +843,28 @@ def main() -> int:
         # mtime must be newer than the freshly routed PCB).
         mfg_success = export_manufacturing_bundle(routed_path, output_dir)
 
+        # Issue #3912: derive BOTH the SUMMARY and the exit code from ONE
+        # shared PipelineGateResult so they can never diverge.  The gate's
+        # DRC leg is AUTHORITATIVE -- it runs ``kicad-cli pcb drc
+        # --refill-zones`` (run_geometric_drc) from scratch, catching copper
+        # shorts the stale-zone-fill ``kct check`` engine misses -- and the
+        # recipe's own ``run_drc`` verdict (``drc_success``) is threaded in
+        # as ``supplemental_drc_ok`` so it can only TIGHTEN the DRC verdict.
+        # Board 01 routes fully (the fast-fail above already raised on a
+        # partial route) with no allowance; its copper-LVS verdict
+        # (``lvs_success``) is the LVS leg.  Board 01 is manufacturable-clean,
+        # so the gate passes and the recipe exits 0.
+        gate = evaluate_pipeline_gate(
+            routed_path,
+            route_ok=route_success,
+            route_allowance=0,
+            lvs_ok=lvs_success,
+            supplemental_drc_ok=drc_success,
+            supplemental_reason=(
+                "kct check reported error-level DRC findings (see DRC output above)"
+            ),
+        )
+
         # Summary
         print("\n" + "=" * 60)
         print("SUMMARY")
@@ -854,20 +877,24 @@ def main() -> int:
         print(f"  4. PCB (routed): {routed_path.name}")
         print("\nResults:")
         print(f"  ERC: {'PASS' if erc_success else 'FAIL'}")
-        print(f"  Routing: {'SUCCESS' if route_success else 'PARTIAL'}")
-        print(f"  DRC: {'PASS' if drc_success else 'FAIL'}")
-        print(f"  LVS: {'PASS' if lvs_success else 'FAIL'}")
-        print(f"  MFG bundle: {'PASS' if mfg_success else 'FAIL'}")
+        for line in gate.summary_lines():
+            print(line)
+        # #3912: mfg_success means ``kct export`` WROTE a bundle (exit 0),
+        # NOT that the board is DRC-clean -- cleanliness is the ``DRC``/
+        # ``Overall`` verdict above.  Label "WRITTEN" so PASS is never
+        # mistaken for a DRC pass.
+        print(f"  MFG bundle: {'WRITTEN' if mfg_success else 'FAILED'}")
         print("\nDesign summary:")
         print("  - J1: 2-pin input connector (VIN, GND)")
         print("  - R1, R2: 10k voltage divider")
         print("  - J2: 2-pin output connector (VOUT, GND)")
         print("  - 5V input -> 2.5V output")
 
-        # Partial routing is acceptable; success if ERC, DRC, and LVS pass.
-        # (``write_lvs_report`` raises on a dirty LVS so a False
-        # ``lvs_success`` here would mean LVS short-circuited.)
-        return 0 if erc_success and drc_success and lvs_success else 1
+        # #3912: the exit code derives from the SAME PipelineGateResult that
+        # drove the SUMMARY above (route / DRC / LVS legs).  ERC remains an
+        # independent gating leg.  (``write_lvs_report`` already raises on a
+        # dirty LVS so a False ``lvs_ok`` here would mean LVS short-circuited.)
+        return 0 if erc_success and gate.passed else 1
 
     except Exception as e:
         print(f"\nError: {e}", file=sys.stderr)

--- a/boards/02-charlieplex-led/generate_design.py
+++ b/boards/02-charlieplex-led/generate_design.py
@@ -37,6 +37,7 @@ from kicad_tools.core.project_file import create_minimal_project, save_project
 from kicad_tools.dev import warn_if_stale
 from kicad_tools.lvs import write_lvs_report
 from kicad_tools.pcb.center_sheet import centered_origin
+from kicad_tools.recipes.gate import evaluate_pipeline_gate
 from kicad_tools.schematic.grid import GridSize
 from kicad_tools.schematic.models.schematic import Schematic, SnapMode
 
@@ -837,6 +838,28 @@ def main() -> int:
         # mtime must be newer than the freshly routed PCB).
         mfg_success = export_manufacturing_bundle(routed_path, output_dir)
 
+        # Issue #3912: derive BOTH the SUMMARY and the exit code from ONE
+        # shared PipelineGateResult so they can never diverge.  The gate's
+        # DRC leg is AUTHORITATIVE -- it runs ``kicad-cli pcb drc
+        # --refill-zones`` (run_geometric_drc) from scratch, catching copper
+        # shorts the stale-zone-fill ``kct check`` engine misses -- and the
+        # recipe's own ``run_drc`` verdict (``drc_success``) is threaded in
+        # as ``supplemental_drc_ok`` so it can only TIGHTEN the DRC verdict.
+        # Board 02 routes fully (the fast-fail above already raised on a
+        # partial route) with no allowance; its copper-LVS verdict
+        # (``lvs_success``) is the LVS leg.  Board 02 is manufacturable-clean,
+        # so the gate passes and the recipe exits 0.
+        gate = evaluate_pipeline_gate(
+            routed_path,
+            route_ok=route_success,
+            route_allowance=0,
+            lvs_ok=lvs_success,
+            supplemental_drc_ok=drc_success,
+            supplemental_reason=(
+                "kct check reported error-level DRC findings (see DRC output above)"
+            ),
+        )
+
         # Summary
         print("\n" + "=" * 60)
         print("SUMMARY")
@@ -849,19 +872,23 @@ def main() -> int:
         print(f"  4. PCB (routed): {routed_path.name}")
         print("\nResults:")
         print(f"  ERC: {'PASS' if erc_success else 'FAIL'}")
-        print(f"  Routing: {'SUCCESS' if route_success else 'PARTIAL'}")
-        print(f"  DRC: {'PASS' if drc_success else 'FAIL'}")
-        print(f"  LVS: {'PASS' if lvs_success else 'FAIL'}")
-        print(f"  MFG bundle: {'PASS' if mfg_success else 'FAIL'}")
+        for line in gate.summary_lines():
+            print(line)
+        # #3912: mfg_success means ``kct export`` WROTE a bundle (exit 0),
+        # NOT that the board is DRC-clean -- cleanliness is the ``DRC``/
+        # ``Overall`` verdict above.  Label "WRITTEN" so PASS is never
+        # mistaken for a DRC pass.
+        print(f"  MFG bundle: {'WRITTEN' if mfg_success else 'FAILED'}")
         print("\nCharlieplex LED mapping:")
         print("  LED   Anode    Cathode")
         for led_conn in LED_CONNECTIONS:
             print(f"  {led_conn.ref}    {led_conn.anode_node}  {led_conn.cathode_node}")
 
-        # Partial routing is acceptable; success if ERC, DRC, and LVS pass.
-        # (``write_lvs_report`` raises on a dirty LVS so a False
-        # ``lvs_success`` here would mean LVS short-circuited.)
-        return 0 if erc_success and drc_success and lvs_success else 1
+        # #3912: the exit code derives from the SAME PipelineGateResult that
+        # drove the SUMMARY above (route / DRC / LVS legs).  ERC remains an
+        # independent gating leg.  (``write_lvs_report`` already raises on a
+        # dirty LVS so a False ``lvs_ok`` here would mean LVS short-circuited.)
+        return 0 if erc_success and gate.passed else 1
 
     except Exception as e:
         print(f"\nError: {e}", file=sys.stderr)

--- a/boards/03-usb-joystick/generate_design.py
+++ b/boards/03-usb-joystick/generate_design.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from kicad_tools.core.project_file import create_minimal_project, save_project
 from kicad_tools.dev import warn_if_stale
 from kicad_tools.lvs import write_lvs_report
+from kicad_tools.recipes.gate import evaluate_pipeline_gate
 
 # Warn if running source scripts with stale pipx install
 warn_if_stale()
@@ -878,7 +879,13 @@ def main() -> int:
         # surface the green status.  ``run_label`` stays ``False``: the
         # copper comparator is the meaningful leg, and the USB-C fixture's
         # ``schematic_net=None`` label noise keeps the label leg advisory.
-        write_lvs_report(
+        # Issue #3912: capture the copper-LVS verdict so it can be ANDed
+        # into the shared gate below.  ``require_clean=True`` already RAISES
+        # on a dirty copper comparator (so a short/open can't reach the
+        # gate at all), but threading ``copper_clean`` makes the gate's LVS
+        # leg self-documenting and defends against a future
+        # ``require_clean=False``.
+        copper_clean, _label_clean = write_lvs_report(
             sch_path,
             routed_path,
             output_dir,
@@ -892,6 +899,30 @@ def main() -> int:
         # reports ``ship_ready=true``.
         mfg_success = export_manufacturing_bundle(routed_path, output_dir)
 
+        # Issue #3912: derive BOTH the SUMMARY and the exit code from ONE
+        # shared PipelineGateResult so they can never diverge.  The previous
+        # exit gate (``erc_success and drc_success``) dropped route
+        # completion and LVS from the exit expression entirely.  The gate's
+        # DRC leg is AUTHORITATIVE -- it runs ``kicad-cli pcb drc
+        # --refill-zones`` (run_geometric_drc) from scratch -- and the
+        # recipe's own ``run_drc`` verdict (``drc_success``,
+        # ``--mfr jlcpcb-tier1``) is threaded in as ``supplemental_drc_ok``
+        # so it can only TIGHTEN the DRC verdict.  Board 03 routes fully
+        # (the fast-fail above already raised on a partial route) with no
+        # allowance; ``copper_clean`` is the LVS leg.  Board 03 passes at
+        # its jlcpcb-tier1 tier, so the gate passes and the recipe exits 0.
+        gate = evaluate_pipeline_gate(
+            routed_path,
+            route_ok=route_success,
+            route_allowance=0,
+            lvs_ok=copper_clean,
+            supplemental_drc_ok=drc_success,
+            supplemental_reason=(
+                "kct check --mfr jlcpcb-tier1 reported error-level DRC findings "
+                "(see DRC output above)"
+            ),
+        )
+
         # Summary
         print("\n" + "=" * 60)
         print("SUMMARY")
@@ -904,18 +935,24 @@ def main() -> int:
         print(f"  4. PCB (routed): {routed_path.name}")
         print("\nResults:")
         print(f"  ERC: {'PASS' if erc_success else 'FAIL'}")
-        print(f"  Routing: {'SUCCESS' if route_success else 'PARTIAL'}")
-        print(f"  DRC: {'PASS' if drc_success else 'FAIL'}")
-        print(f"  MFG bundle: {'PASS' if mfg_success else 'FAIL'}")
+        for line in gate.summary_lines():
+            print(line)
+        # #3912: mfg_success means ``kct export`` WROTE a bundle (exit 0),
+        # NOT that the board is DRC-clean -- cleanliness is the ``DRC``/
+        # ``Overall`` verdict above.  Label "WRITTEN" so PASS is never
+        # mistaken for a DRC pass.
+        print(f"  MFG bundle: {'WRITTEN' if mfg_success else 'FAILED'}")
         print("\nBoard description:")
         print("  - USB game controller with analog joystick")
         print("  - 32-pin QFP MCU")
         print("  - USB Type-C connector")
         print("  - 4 tactile buttons")
 
-        # For this complex demo board, partial routing is acceptable
-        # Success if ERC passes and DRC has no errors (warnings OK)
-        return 0 if erc_success and drc_success else 1
+        # #3912: the exit code derives from the SAME PipelineGateResult that
+        # drove the SUMMARY above (route / DRC / LVS legs).  ERC remains an
+        # independent gating leg.  For this complex demo board partial routing
+        # would trip the route leg (the fast-fail above handles that path).
+        return 0 if erc_success and gate.passed else 1
 
     except Exception as e:
         print(f"\nError: {e}", file=sys.stderr)

--- a/boards/07-matchgroup-test/generate_design.py
+++ b/boards/07-matchgroup-test/generate_design.py
@@ -62,6 +62,7 @@ from kicad_tools.pcb.center_sheet import (
     edge_cuts_bbox,
     translate_pcb_text,
 )
+from kicad_tools.recipes.gate import evaluate_pipeline_gate
 from kicad_tools.router.rules import (
     NET_CLASS_POWER,
     NetClassRouting,
@@ -2145,6 +2146,53 @@ def main() -> int:
             # bundle still clears the ``"artifacts stale"`` blocker.
             mfg_ok = export_manufacturing_bundle(routed_path, output_dir)
 
+            # Issue #3912: derive BOTH the SUMMARY and the exit code from ONE
+            # shared PipelineGateResult so they can never diverge.  The
+            # previous ``return 0 if route_success else 1`` gated ONLY on
+            # route completion while the SUMMARY printed an independent
+            # ``DRC:`` line -- exactly the exit-code-vs-SUMMARY drift this
+            # issue eliminates.
+            #
+            # Board 07 is PARTIAL BY DESIGN: 5 seed-invariant unroutable nets
+            # (#3438: DQ3, DQ4, MIPI_DAT0_N, TMDS_D0_N, TMDS_D1_N).  The gate
+            # reflects that PARTIAL state HONESTLY rather than papering over
+            # it:
+            #   * ``route_ok=route_success`` -- ``kct route`` exits non-zero
+            #     on a partial route, so ``route_success`` is False and the
+            #     ``Routing:`` line honestly reads PARTIAL.  ``route_allowance``
+            #     is left at 0 ON PURPOSE: inflating it to swallow the known
+            #     opens would flip the ``Routing:`` line to a FALSE "SUCCESS"
+            #     (route_status() reads SUCCESS whenever route_ok is True),
+            #     which is the opposite of reflecting PARTIAL honestly.
+            #   * ``lvs_ok=None`` -- the 5 copper-LVS opens ARE the documented
+            #     #3438 plateau (``write_lvs_report(require_clean=False)``
+            #     above keeps them advisory); making them a gating leg would
+            #     FALSELY FAIL the board for being exactly at its plateau.
+            #   * ``supplemental_drc_ok=drc_ok`` -- ``run_drc``
+            #     (``kct check --mfr jlcpcb``) is the only engine that sees
+            #     the match-group / diffpair length-skew rule families
+            #     kicad-cli cannot express, so its verdict tightens the DRC
+            #     leg (the authoritative geometric ``kicad-cli --refill-zones``
+            #     leg runs inside the gate).
+            # Net effect: the board honestly ends FAIL (route PARTIAL + real
+            # kct-check DRC residuals) and exits non-zero -- NOT a false exit 0
+            # for a board that is not fully routed and not DRC-clean.  The
+            # board-07-end-to-end CI job tolerates this non-zero recipe exit
+            # (`|| true`) and gates on the explicit known-opens + allowlist
+            # asserters instead.
+            gate = evaluate_pipeline_gate(
+                routed_path,
+                route_ok=route_success,
+                route_allowance=0,
+                lvs_ok=None,
+                supplemental_drc_ok=drc_ok,
+                supplemental_reason=(
+                    "kct check --mfr jlcpcb reported error-level DRC findings "
+                    "(match-group / diffpair skew + allowlisted residuals; see "
+                    "DRC output above)"
+                ),
+            )
+
             print("\n" + "=" * 60)
             print("SUMMARY")
             print("=" * 60)
@@ -2154,15 +2202,15 @@ def main() -> int:
             print(f"  PCB:       {pcb_path.name}")
             print(f"  Routed:    {routed_path.name}")
             print("\nResults:")
-            print(f"  Routing: {'SUCCESS' if route_success else 'PARTIAL'}")
-            print(f"  DRC:     {'PASS' if drc_ok else 'FAIL (see above)'}")
+            for line in gate.summary_lines():
+                print(line)
             # #3912: mfg_ok means `kct export` wrote a bundle (exit 0), not
             # that the board is DRC-clean.  Board DRC status is the "DRC:"
             # line above.  Label "WRITTEN" so PASS is never mistaken for a
             # DRC pass.
             print(f"  MFG:     {'WRITTEN' if mfg_ok else 'FAILED (see above)'}")
 
-            return 0 if route_success else 1
+            return gate.exit_code()
 
         if args.step == "schematic":
             create_schematic(output_dir)

--- a/tests/test_board_03_copper_lvs.py
+++ b/tests/test_board_03_copper_lvs.py
@@ -29,6 +29,7 @@ from pathlib import Path
 import pytest
 
 from kicad_tools.cli.runner import find_kicad_cli
+from kicad_tools.drc.geometric import GeometricDRCResult
 from kicad_tools.lvs import compare_copper_netlist
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -307,9 +308,34 @@ class TestBoard03PartialRouteFastFail:
 
         def _fake_lvs(*a, **k):
             lvs_called.append(True)
+            # #3912: the migrated main() unpacks ``copper_clean, _label_clean =
+            # write_lvs_report(...)`` and ANDs ``copper_clean`` into the shared
+            # gate's LVS leg.  Return a clean 2-tuple so the happy path reaches
+            # a PASSING gate (the whole point of this test).
+            return (True, True)
 
         monkeypatch.setattr(module, "write_lvs_report", _fake_lvs)
         monkeypatch.setattr(module, "export_manufacturing_bundle", lambda *a, **k: True)
+
+        # #3912: neutralise the gate's AUTHORITATIVE geometric-DRC leg.  The
+        # migrated main() calls ``evaluate_pipeline_gate(routed_path, ...)``,
+        # which shells ``run_geometric_drc`` (kicad-cli pcb drc) on the routed
+        # PCB.  This unit test stubs the entire pipeline prefix, so no real
+        # routed board exists for kicad-cli to check -- the DRC run would report
+        # ``ran=False`` and (with the default ``require_drc=True``) fail the gate
+        # for a reason this test is NOT trying to exercise.  Wrap the recipe's
+        # ``evaluate_pipeline_gate`` reference to inject a clean, "did-run"
+        # ``GeometricDRCResult`` via the gate's documented ``_drc_result`` test
+        # seam.  The gate's route/LVS legs (the ones this test asserts on) still
+        # run for real, so a PASSING verdict genuinely proves the full-route
+        # path reaches and clears the LVS gate.
+        real_gate = module.evaluate_pipeline_gate
+
+        def _gate_with_clean_drc(*a, **k):
+            k.setdefault("_drc_result", GeometricDRCResult(ran=True, by_type={}))
+            return real_gate(*a, **k)
+
+        monkeypatch.setattr(module, "evaluate_pipeline_gate", _gate_with_clean_drc)
         monkeypatch.setattr(module.sys, "argv", ["generate_design.py", str(tmp_path / "out")])
 
         rc = module.main()

--- a/tests/test_migrated_boards_gate_3912.py
+++ b/tests/test_migrated_boards_gate_3912.py
@@ -1,0 +1,195 @@
+"""Divergence guard for the boards migrated to the shared success gate (#3912).
+
+Issue #3912 finishes migrating every board recipe's ``main()`` onto the shared
+:func:`kicad_tools.recipes.gate.evaluate_pipeline_gate` helper so that a
+board's printed ``SUMMARY`` block and its process exit code are BOTH derived
+from ONE :class:`~kicad_tools.recipes.gate.PipelineGateResult` and can never
+diverge (the exact defect the issue names: board-06 printed ``DRC: FAIL`` while
+exiting 0; board-05 dropped route-completion from its exit expression).
+
+Boards 04/05/06 landed in earlier increments; this file locks in the final
+five:
+
+* ``boards/00-simple-led``
+* ``boards/01-voltage-divider``
+* ``boards/02-charlieplex-led``
+* ``boards/03-usb-joystick``
+* ``boards/07-matchgroup-test`` (PARTIAL by design -- #3438 known opens)
+
+Two layers of guard:
+
+1. **Structural** -- assert each migrated recipe drives BOTH the SUMMARY and
+   the exit code from the shared gate (``gate.summary_lines()`` +
+   ``gate.passed`` / ``gate.exit_code()``) and no longer hand-rolls the
+   per-leg ``Routing:``/``DRC:``/``LVS:`` result f-strings or the misleading
+   ``MFG bundle: PASS`` wording that used to conflate "bundle written" with
+   "board DRC-clean".
+2. **Behavioral** -- exercise :func:`evaluate_pipeline_gate` on the two
+   representative recipe verdicts (a manufacturable-clean board like 00, and
+   the PARTIAL-plus-residual-DRC board 07) and assert the SUMMARY's
+   ``Overall:`` line agrees with :meth:`~PipelineGateResult.exit_code` -- the
+   invariant that makes divergence impossible.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.drc.geometric import GeometricDRCResult
+from kicad_tools.recipes.gate import evaluate_pipeline_gate
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# (board dir, generate_design.py relative to the board dir).  All five use
+# ``generate_design.py`` (board-05's recipe is ``design.py`` and landed in an
+# earlier increment, so it is intentionally not in this list).
+MIGRATED_BOARDS = [
+    "boards/00-simple-led/generate_design.py",
+    "boards/01-voltage-divider/generate_design.py",
+    "boards/02-charlieplex-led/generate_design.py",
+    "boards/03-usb-joystick/generate_design.py",
+    "boards/07-matchgroup-test/generate_design.py",
+]
+
+# Hand-rolled per-leg result f-strings the migration REMOVES.  Their presence
+# would mean a SUMMARY line is authored independently of the gate again -- the
+# precise way exit-code and SUMMARY drift apart (#3912).
+FORBIDDEN_HANDROLLED_SNIPPETS = [
+    "if route_success else 'PARTIAL'",
+    "if drc_success else 'FAIL'",
+    "if drc_ok else 'FAIL",
+    "if lvs_success else 'FAIL'",
+    "bundle: {'PASS'",  # the "bundle written == board clean" conflation
+]
+
+
+def _clean_drc() -> GeometricDRCResult:
+    return GeometricDRCResult(ran=True, error_count=0, by_type={})
+
+
+@pytest.fixture(params=MIGRATED_BOARDS)
+def board_source(request: pytest.FixtureRequest) -> str:
+    path = REPO_ROOT / request.param
+    assert path.is_file(), f"migrated recipe not found: {path}"
+    return path.read_text()
+
+
+# --------------------------------------------------------------------------
+# Structural guard: the gate is the single source of truth
+# --------------------------------------------------------------------------
+class TestGateWiring:
+    def test_imports_and_calls_shared_gate(self, board_source: str) -> None:
+        assert "from kicad_tools.recipes.gate import evaluate_pipeline_gate" in board_source
+        # Exactly one gate evaluation per recipe -- a second would reintroduce
+        # the multi-verdict drift this issue removes.
+        assert board_source.count("evaluate_pipeline_gate(") == 1
+
+    def test_summary_derived_from_gate(self, board_source: str) -> None:
+        assert "for line in gate.summary_lines():" in board_source
+
+    def test_exit_code_derived_from_gate(self, board_source: str) -> None:
+        assert ("gate.passed" in board_source) or ("gate.exit_code()" in board_source)
+
+    def test_no_handrolled_result_lines(self, board_source: str) -> None:
+        for snippet in FORBIDDEN_HANDROLLED_SNIPPETS:
+            assert snippet not in board_source, (
+                f"migrated recipe still hand-rolls a SUMMARY line ({snippet!r}); "
+                "it must derive from gate.summary_lines() so the SUMMARY and the "
+                "exit code cannot diverge (#3912)."
+            )
+
+    def test_bundle_wording_is_written_not_pass(self, board_source: str) -> None:
+        # The manufacturing-bundle line must say WRITTEN/FAILED (bundle was
+        # produced), never PASS -- "bundle written" is not "board DRC-clean".
+        if "MFG bundle:" in board_source or "MFG:" in board_source:
+            assert "'WRITTEN'" in board_source
+
+
+# --------------------------------------------------------------------------
+# Behavioral guard: SUMMARY Overall line agrees with the exit code
+# --------------------------------------------------------------------------
+class TestSummaryExitAgreement:
+    def _overall_from_summary(self, result) -> str:  # noqa: ANN001
+        overall = [ln for ln in result.summary_lines() if ln.strip().startswith("Overall:")]
+        assert len(overall) == 1, result.summary_lines()
+        return overall[0].split(":", 1)[1].strip()
+
+    def test_clean_board_like_00_passes(self) -> None:
+        """A manufacturable-clean board (route+DRC+LVS all clean) -> PASS/exit 0.
+
+        Mirrors boards 00/01/02: ``route_ok`` True, geometric DRC clean, the
+        recipe ``run_drc`` verdict (supplemental) clean, copper-LVS clean.
+        """
+        res = evaluate_pipeline_gate(
+            Path("board00_routed.kicad_pcb"),
+            route_ok=True,
+            route_allowance=0,
+            lvs_ok=True,
+            supplemental_drc_ok=True,
+            _drc_result=_clean_drc(),
+        )
+        assert res.passed is True
+        assert res.exit_code() == 0
+        assert self._overall_from_summary(res) == "PASS"
+
+    def test_partial_board_like_07_fails_honestly(self) -> None:
+        """Board 07 is PARTIAL by design + carries kct-check DRC residuals.
+
+        The honest verdict is FAIL/exit 1: ``route_ok`` False (the ``Routing:``
+        line must read PARTIAL, not a falsely-inflated SUCCESS), ``lvs_ok`` None
+        (the 5 #3438 opens are advisory, so LVS must NOT gate -- otherwise the
+        board is falsely failed for being exactly at its documented plateau),
+        and the supplemental ``kct check`` verdict False.  Even though the
+        authoritative geometric DRC leg is clean, the supplemental verdict
+        tightens ``drc_ok`` to False.
+        """
+        res = evaluate_pipeline_gate(
+            Path("matchgroup_test_routed.kicad_pcb"),
+            route_ok=False,
+            route_allowance=0,
+            lvs_ok=None,
+            supplemental_drc_ok=False,
+            _drc_result=_clean_drc(),
+        )
+        assert res.route_ok is False
+        assert res.drc_ok is False  # supplemental tightened it
+        assert res.passed is False
+        assert res.exit_code() == 1
+        assert res.route_status() == "PARTIAL"
+        assert res.drc_status() == "FAIL"
+        assert res.lvs_status() == "n/a"  # advisory, not a gating leg
+        assert self._overall_from_summary(res) == "FAIL"
+
+    @pytest.mark.parametrize(
+        ("route_ok", "supplemental_drc_ok", "lvs_ok"),
+        [
+            (True, True, True),
+            (True, True, None),
+            (True, False, True),
+            (False, True, True),
+            (True, True, False),
+            (False, False, None),
+        ],
+    )
+    def test_overall_line_always_matches_exit_code(
+        self, route_ok: bool, supplemental_drc_ok: bool, lvs_ok: bool | None
+    ) -> None:
+        """The SUMMARY ``Overall:`` line can NEVER disagree with the exit code.
+
+        This is the divergence-guard invariant #3912 requires of every migrated
+        recipe: since both are derived from one ``PipelineGateResult``,
+        ``Overall: PASS`` <=> ``exit_code() == 0`` for every leg combination.
+        """
+        res = evaluate_pipeline_gate(
+            Path("dummy_routed.kicad_pcb"),
+            route_ok=route_ok,
+            route_allowance=0,
+            lvs_ok=lvs_ok,
+            supplemental_drc_ok=supplemental_drc_ok,
+            _drc_result=_clean_drc(),
+        )
+        overall = self._overall_from_summary(res)
+        assert (overall == "PASS") == (res.exit_code() == 0)
+        assert (overall == "PASS") == res.passed


### PR DESCRIPTION
## Summary

Finishes the deferred #3912 migration. The shared success-gate helper
`src/kicad_tools/recipes/gate.py` (`evaluate_pipeline_gate` →
`PipelineGateResult`, PR #4424) and boards 04/05/06 already landed. This PR
migrates the **remaining five** board recipes so their `SUMMARY` block and
their `main()` exit code are BOTH derived from ONE `PipelineGateResult` and
can no longer diverge — the exact defect this issue names (board-06 printed
`DRC: FAIL` while exiting 0; board-05 dropped route-completion from its exit
expression).

Migrated: `boards/00-simple-led`, `boards/01-voltage-divider`,
`boards/02-charlieplex-led`, `boards/03-usb-joystick`,
`boards/07-matchgroup-test`.

## Changes

- **Boards 00/01/02** (manufacturable-clean): route leg (`route_ok`), the
  authoritative geometric DRC leg (`kicad-cli pcb drc --refill-zones` via
  `run_geometric_drc`), the recipe's own `run_drc` verdict threaded as
  `supplemental_drc_ok` (tightens, never loosens), and the copper-LVS leg
  (`lvs_ok`). Still exit 0.
- **Board 03**: same, capturing the copper-LVS verdict from
  `write_lvs_report` for the LVS leg. Passes at its `jlcpcb-tier1` tier.
- **Board 07** (PARTIAL by design — #3438 five known opens): `route_ok`
  reflects the partial route honestly (`route_allowance=0`, so `Routing`
  reads PARTIAL rather than a falsely-inflated SUCCESS); `lvs_ok=None` keeps
  the known opens advisory so the board is **not** falsely failed at its
  documented plateau; the `kct check --mfr jlcpcb` residuals tighten
  `drc_ok`. Honest end state: **FAIL / exit 1**, matching prior behavior
  (`return 0 if route_success else 1`) but now derived from the same gate as
  the SUMMARY. CI tolerates the non-zero recipe exit (`|| true`) and gates on
  the explicit known-opens + allowlist asserters.
- Replace the misleading `MFG bundle: PASS` wording with `WRITTEN` on every
  migrated board (bundle written ≠ board DRC-clean).
- New `tests/test_migrated_boards_gate_3912.py`: structural guard that each
  recipe drives SUMMARY + exit from the shared gate (no hand-rolled result
  lines, WRITTEN wording), plus a behavioral guard that the SUMMARY
  `Overall:` line always agrees with the exit code (the divergence guard).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| All 5 remaining boards on the shared gate | ✅ | Each `generate_design.py` has exactly one `evaluate_pipeline_gate(` call; SUMMARY via `gate.summary_lines()`, exit via `gate.passed`/`gate.exit_code()` |
| SUMMARY and exit code cannot diverge | ✅ | Both derived from one `PipelineGateResult`; behavioral test asserts `Overall:` ⇔ `exit_code()` across leg combinations |
| Boards 00/01/02 still exit 0 (no regression) | ✅ | Board 00 run end-to-end: exit 0, `Overall: PASS`. Boards 01/02 geometric DRC clean; identical structure |
| Board 03 passes at its tier | ✅ | Geometric DRC clean; `run_drc --mfr jlcpcb-tier1` gate preserved |
| Board 07 reflects PARTIAL honestly (no false 0, no false fail at plateau) | ✅ | `route_ok=route_success` (PARTIAL), `lvs_ok=None` (opens advisory), residual DRC tightens → honest FAIL/exit 1 |
| "MFG bundle: PASS" divergent wording cleaned up | ✅ | All migrated boards now print `WRITTEN`/`FAILED` |
| Test asserting SUMMARY ⇔ exit code | ✅ | `tests/test_migrated_boards_gate_3912.py` |

## Test Plan

- `uv run pytest tests/test_migrated_boards_gate_3912.py tests/test_recipes_gate.py` → 65 passed.
- `uv run ruff check` + `ruff format --check` on all five recipes → clean.
- Board 00 regenerated end-to-end → exit 0, `Overall: PASS`, `MFG bundle: WRITTEN`.
- Board 07 regenerated end-to-end → PARTIAL route (seed-invariant #3438 opens) → honest FAIL/exit 1 (empirically: geometric DRC clean but `kct check --mfr jlcpcb` reports 13 errors → supplemental tightens `drc_ok`).

Closes #3912