### PR TITLE
feat(diffpair): instrument coupled router with rejection histogram + failure taxonomy

### DIFF
--- a/src/kicad_tools/router/cpp/include/coupled_pathfinder.hpp
+++ b/src/kicad_tools/router/cpp/include/coupled_pathfinder.hpp
@@ -12,10 +12,12 @@
  * #2473/#3508 approach/departure tolerance relaxation, the #3078/#3508
  * path-history / trail-proximity guard, the #3439 corridor bitset, the
  * ``partner_aware`` heuristic (#3115), weighted A* (#3508) and the #3508
- * LIFO-seq tie-break.  The ``allow_swap_via`` polarity-swap move (#2473),
- * the ``manhattan_sum`` legacy heuristic and exact ``last_rejections``
- * string-keyed parity are intentionally DEFERRED to the pure-Python
- * fallback; the Python wrapper routes those cases to Python.
+ * LIFO-seq tie-break.  The ``allow_swap_via`` polarity-swap move (#2473)
+ * and the ``manhattan_sum`` legacy heuristic are intentionally DEFERRED to
+ * the pure-Python fallback; the Python wrapper routes those cases to Python.
+ * Issue #4459 wired the ``last_rejections`` string-keyed histogram out of
+ * the C++ search (surfaced on ``CoupledRouteResult::rejections``) so a
+ * C++-path budget-exit reports which guard pruned the frontier.
  *
  * The search consumes the SAME ``Grid3D`` the single-ended ``Pathfinder``
  * uses (marshalled once via ``CppGrid.from_routing_grid``); it is a new

--- a/src/kicad_tools/router/cpp/include/types.hpp
+++ b/src/kicad_tools/router/cpp/include/types.hpp
@@ -10,6 +10,8 @@
 #include <vector>
 #include <tuple>
 #include <optional>
+#include <string>
+#include <unordered_map>
 
 namespace router {
 
@@ -377,6 +379,15 @@ struct CoupledPathNode {
 //   iteration_limited    -- when ``timeout_exceeded``, TRUE iff the ITERATION
 //                           budget was the binding constraint (else the
 //                           wall-clock budget); mirrors ``last_iteration_limited``.
+//   rejections           -- Issue #4459: per-reason move-rejection histogram
+//                           (which guard pruned the frontier), keyed by the
+//                           SAME reason vocabulary the pure-Python coupled
+//                           loop uses (``last_rejections``): sym/asym x
+//                           blocked/spacing/floor/trail, the via guards, and
+//                           corridor pruning.  Lets a 0/9 budget-exit be
+//                           triaged (plateau vs no-progress vs off-angle vs
+//                           infeasible-gap) instead of reading the old
+//                           categorically-empty dict on the C++ path.
 struct CoupledRouteResult {
     std::vector<CoupledPathNode> path;  // root->goal; empty when !success.
     bool success = false;
@@ -385,6 +396,9 @@ struct CoupledRouteResult {
     double best_progress = -1.0;
     bool timeout_exceeded = false;
     bool iteration_limited = false;
+    // Issue #4459: rejection histogram (reason -> count).  Empty only when the
+    // search popped no neighbours at all (e.g. the start state is the goal).
+    std::unordered_map<std::string, int64_t> rejections;
 };
 
 // Neighbor direction: dx, dy, dlayer, cost_multiplier

--- a/src/kicad_tools/router/cpp/src/bindings.cpp
+++ b/src/kicad_tools/router/cpp/src/bindings.cpp
@@ -14,6 +14,7 @@
 #include <nanobind/stl/tuple.h>
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/string.h>
+#include <nanobind/stl/unordered_map.h>
 
 namespace nb = nanobind;
 using namespace nb::literals;
@@ -479,13 +480,16 @@ NB_MODULE(router_cpp, m) {
         .def_ro("iterations", &CoupledRouteResult::iterations)
         .def_ro("best_progress", &CoupledRouteResult::best_progress)
         .def_ro("timeout_exceeded", &CoupledRouteResult::timeout_exceeded)
-        .def_ro("iteration_limited", &CoupledRouteResult::iteration_limited);
+        .def_ro("iteration_limited", &CoupledRouteResult::iteration_limited)
+        // Issue #4459: per-reason move-rejection histogram (reason -> count).
+        .def_ro("rejections", &CoupledRouteResult::rejections);
 
     // CoupledPathfinder class (Issue #4065): C++ port of the joint-state
     // diff-pair A* loop.  Consumes the SAME Grid3D as the single-ended
     // Pathfinder.  See coupled_pathfinder.hpp for the v1 scope / deferred
-    // features (allow_swap_via, manhattan_sum heuristic, string-keyed
-    // rejection counters remain Python-only).
+    // features (allow_swap_via, manhattan_sum heuristic).  Issue #4459 wired
+    // the string-keyed rejection histogram out of the C++ search (previously
+    // Python-only), surfaced on ``CoupledRouteResult::rejections``.
     nb::class_<CoupledPathfinder>(m, "CoupledPathfinder")
         .def(nb::init<Grid3D&, const DesignRules&, int, int, int, int, int,
                       double, double>(),

--- a/src/kicad_tools/router/cpp/src/coupled_pathfinder.cpp
+++ b/src/kicad_tools/router/cpp/src/coupled_pathfinder.cpp
@@ -214,6 +214,15 @@ CoupledRouteResult CoupledPathfinder::route(
 
     double best_progress = -1.0;  // -1 sentinel = "nothing popped yet".
 
+    // Issue #4459: per-reason move-rejection histogram.  Counts which guard
+    // pruned each candidate so a 0/9 budget-exit can be triaged (which
+    // constraint dominates the frontier).  Keys mirror the pure-Python
+    // ``last_rejections`` vocabulary (diffpair_routing.py) so the two backends
+    // report the same taxonomy; the via-guard keys are the C++ path's superset
+    // (the Python via move does not currently count rejections).
+    std::unordered_map<std::string, int64_t> rejections;
+    auto rej = [&rejections](const char* reason) { ++rejections[reason]; };
+
     // Endpoint (x,y,layer) cells stripped from the trail sets, mirroring the
     // Python discard at diffpair_routing.py:1829-1838.
     const uint64_t p_start_cell = xyl_key(p_start_x, p_start_y, start_layer);
@@ -245,6 +254,7 @@ CoupledRouteResult CoupledPathfinder::route(
             result.best_progress = best_progress;
             result.timeout_exceeded = true;
             result.iteration_limited = true;  // #3921: iteration budget bound.
+            result.rejections = std::move(rejections);  // #4459
             return result;
         }
         // Wall-clock check every 64 iters (diffpair_routing.py:1728-1743).
@@ -254,6 +264,7 @@ CoupledRouteResult CoupledPathfinder::route(
             result.best_progress = best_progress;
             result.timeout_exceeded = true;
             result.iteration_limited = false;  // wall-clock bound.
+            result.rejections = std::move(rejections);  // #4459
             return result;
         }
 
@@ -290,6 +301,7 @@ CoupledRouteResult CoupledPathfinder::route(
             result.success = true;
             result.iterations = static_cast<int>(iterations);
             result.best_progress = best_progress;
+            result.rejections = std::move(rejections);  // #4459
             return result;
         }
 
@@ -438,19 +450,19 @@ CoupledRouteResult CoupledPathfinder::route(
                         at_goal(np_x, np_y, p_start_x, p_start_y);
             bool n_ep = at_goal(nn_x, nn_y, n_goal_x, n_goal_y) ||
                         at_goal(nn_x, nn_y, n_start_x, n_start_y);
-            if (!p_ep && is_trace_blocked(np_x, np_y, np_l, p_net)) continue;
-            if (!n_ep && is_trace_blocked(nn_x, nn_y, nn_l, n_net)) continue;
+            if (!p_ep && is_trace_blocked(np_x, np_y, np_l, p_net)) { rej("sym_blocked_p"); continue; }
+            if (!n_ep && is_trace_blocked(nn_x, nn_y, nn_l, n_net)) { rej("sym_blocked_n"); continue; }
 
             double sdx = np_x - nn_x, sdy = np_y - nn_y;
             double new_spacing = std::sqrt(sdx * sdx + sdy * sdy);
             int tolerance = spacing_relaxed ? relaxed_tolerance : 1;
-            if (std::abs(new_spacing - target_spacing) > tolerance) continue;
+            if (std::abs(new_spacing - target_spacing) > tolerance) { rej("sym_spacing"); continue; }
 
             if (min_spacing_cells_ > 0 && !(p_ep && n_ep)) {
-                if (new_spacing + 1e-9 < min_spacing_cells_) continue;
+                if (new_spacing + 1e-9 < min_spacing_cells_) { rej("sym_floor"); continue; }
             }
             if (self_intersects(np_x, np_y, np_l, nn_x, nn_y, nn_l,
-                                true, true, p_ep, n_ep)) continue;
+                                true, true, p_ep, n_ep)) { rej("sym_trail"); continue; }
 
             double cost = rules_.cost_straight;
             bool dir_changed = !(current.dir_dx == 0 && current.dir_dy == 0) &&
@@ -483,19 +495,25 @@ CoupledRouteResult CoupledPathfinder::route(
                     bool p_ep = at_goal(cp_x, cp_y, p_goal_x, p_goal_y) ||
                                 at_goal(cp_x, cp_y, p_start_x, p_start_y);
                     bool blocked = !(p_ep || !is_trace_blocked(cp_x, cp_y, cp_l, p_net));
+                    if (blocked) rej("asym_blocked_p");  // #4459
                     if (!blocked) {
                         double sdx = cp_x - cn_x, sdy = cp_y - cn_y;
                         double new_spacing = std::sqrt(sdx * sdx + sdy * sdy);
-                        if (std::abs(new_spacing - target_spacing) <= asym_tolerance) {
+                        if (std::abs(new_spacing - target_spacing) > asym_tolerance) {
+                            rej("asym_spacing_p");  // #4459
+                        } else {
                             bool n_ep = at_goal(cn_x, cn_y, n_goal_x, n_goal_y) ||
                                         at_goal(cn_x, cn_y, n_start_x, n_start_y);
                             bool bypass_floor = p_ep && n_ep;
                             bool floor_ok =
                                 !(min_spacing_cells_ > 0 && !bypass_floor &&
                                   new_spacing + 1e-9 < min_spacing_cells_);
-                            if (floor_ok &&
-                                !self_intersects(cp_x, cp_y, cp_l, cn_x, cn_y, cn_l,
-                                                 true, false, p_ep, n_ep)) {
+                            if (!floor_ok) {
+                                rej("asym_floor_p");  // #4459
+                            } else if (self_intersects(cp_x, cp_y, cp_l, cn_x, cn_y, cn_l,
+                                                       true, false, p_ep, n_ep)) {
+                                rej("asym_trail_p");  // #4459
+                            } else {
                                 double cost = rules_.cost_straight;
                                 bool dir_changed =
                                     !(current.dir_dx == 0 && current.dir_dy == 0) &&
@@ -526,19 +544,26 @@ CoupledRouteResult CoupledPathfinder::route(
                     int cn_x = current.n_x + dx, cn_y = current.n_y + dy, cn_l = current.n_layer;
                     bool n_ep = at_goal(cn_x, cn_y, n_goal_x, n_goal_y) ||
                                 at_goal(cn_x, cn_y, n_start_x, n_start_y);
-                    if (n_ep || !is_trace_blocked(cn_x, cn_y, cn_l, n_net)) {
+                    if (!(n_ep || !is_trace_blocked(cn_x, cn_y, cn_l, n_net))) {
+                        rej("asym_blocked_n");  // #4459
+                    } else {
                         double sdx = cp_x - cn_x, sdy = cp_y - cn_y;
                         double new_spacing = std::sqrt(sdx * sdx + sdy * sdy);
-                        if (std::abs(new_spacing - target_spacing) <= asym_tolerance) {
+                        if (std::abs(new_spacing - target_spacing) > asym_tolerance) {
+                            rej("asym_spacing_n");  // #4459
+                        } else {
                             bool p_ep = at_goal(cp_x, cp_y, p_goal_x, p_goal_y) ||
                                         at_goal(cp_x, cp_y, p_start_x, p_start_y);
                             bool bypass_floor = p_ep && n_ep;
                             bool floor_ok =
                                 !(min_spacing_cells_ > 0 && !bypass_floor &&
                                   new_spacing + 1e-9 < min_spacing_cells_);
-                            if (floor_ok &&
-                                !self_intersects(cp_x, cp_y, cp_l, cn_x, cn_y, cn_l,
-                                                 false, true, p_ep, n_ep)) {
+                            if (!floor_ok) {
+                                rej("asym_floor_n");  // #4459
+                            } else if (self_intersects(cp_x, cp_y, cp_l, cn_x, cn_y, cn_l,
+                                                       false, true, p_ep, n_ep)) {
+                                rej("asym_trail_n");  // #4459
+                            } else {
                                 double cost = rules_.cost_straight;
                                 bool dir_changed =
                                     !(current.dir_dx == 0 && current.dir_dy == 0) &&
@@ -573,10 +598,10 @@ CoupledRouteResult CoupledPathfinder::route(
                            at_goal(current.n_x, current.n_y, n_start_x, n_start_y);
             for (int new_layer : routable_layers) {
                 if (new_layer == current.p_layer) continue;
-                if (!p_at_ep && is_via_blocked(current.p_x, current.p_y, p_net)) continue;
-                if (!n_at_ep && is_via_blocked(current.n_x, current.n_y, n_net)) continue;
-                if (!p_at_ep && is_trace_blocked(current.p_x, current.p_y, new_layer, p_net)) continue;
-                if (!n_at_ep && is_trace_blocked(current.n_x, current.n_y, new_layer, n_net)) continue;
+                if (!p_at_ep && is_via_blocked(current.p_x, current.p_y, p_net)) { rej("via_blocked_p"); continue; }
+                if (!n_at_ep && is_via_blocked(current.n_x, current.n_y, n_net)) { rej("via_blocked_n"); continue; }
+                if (!p_at_ep && is_trace_blocked(current.p_x, current.p_y, new_layer, p_net)) { rej("via_trace_blocked_p"); continue; }
+                if (!n_at_ep && is_trace_blocked(current.n_x, current.n_y, new_layer, n_net)) { rej("via_trace_blocked_n"); continue; }
                 double cost = rules_.cost_via * 2.0;
                 // Issue #4080: corridor attractor on the via-drop
                 // destination cells -- the reservation is what makes the
@@ -600,7 +625,10 @@ CoupledRouteResult CoupledPathfinder::route(
         for (const Cand& c : neighbors) {
             // Corridor pruning (diffpair_routing.py:1864-1871).
             if (have_corridor) {
-                if (!in_corridor(c.px, c.py) || !in_corridor(c.nx, c.ny)) continue;
+                if (!in_corridor(c.px, c.py) || !in_corridor(c.nx, c.ny)) {
+                    rej("corridor");  // #4459
+                    continue;
+                }
             }
             JointKey nkey = joint_key(c.px, c.py, c.pl, c.nx, c.ny, c.nl);
             if (closed_set.count(nkey)) continue;
@@ -631,6 +659,7 @@ CoupledRouteResult CoupledPathfinder::route(
     result.success = false;
     result.iterations = static_cast<int>(iterations);
     result.best_progress = best_progress;
+    result.rejections = std::move(rejections);  // #4459
     return result;
 }
 

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -3123,8 +3123,9 @@ class CppCoupledPathfinder:
         ``(p_x, p_y, p_layer, n_x, n_y, n_layer, via_from_parent)`` tuples in
         root->goal order (or ``None`` when the search failed), and
         ``diagnostics`` carries ``iterations`` / ``best_progress`` /
-        ``timeout_exceeded`` / ``iteration_limited`` for the caller's
-        ``last_*`` bookkeeping.
+        ``timeout_exceeded`` / ``iteration_limited`` and (Issue #4459) the
+        per-reason ``rejections`` histogram for the caller's ``last_*``
+        bookkeeping.
         """
         res = self._impl.route(
             int(p_start_xy[0]),
@@ -3152,6 +3153,12 @@ class CppCoupledPathfinder:
             "best_progress": float(res.best_progress),
             "timeout_exceeded": bool(res.timeout_exceeded),
             "iteration_limited": bool(res.iteration_limited),
+            # Issue #4459: per-reason move-rejection histogram (reason -> count).
+            # Surfaces WHICH guard pruned the frontier on the C++ path so a
+            # budget-exit is triageable (was hard-emptied on the C++ path,
+            # forcing the caller's ``last_rejections`` to a categorically-empty
+            # dict).  ``res.rejections`` is a ``dict[str, int]`` from nanobind.
+            "rejections": {str(k): int(v) for k, v in dict(res.rejections).items()},
         }
         if not res.success:
             return None, diagnostics

--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -23,6 +23,8 @@ from enum import Enum
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from .core import Autorouter
     from .cpp_backend import CppCoupledPathfinder
     from .grid import RoutingGrid
@@ -173,6 +175,156 @@ _SHADOW_GAP_MAX_TOL_FRAC: float = float(os.environ.get("KCT_SHADOW_GAP_MAX_TOL_F
 #   1. compute per-segment-pair clearance,
 #   2. report violations,
 #   3. expose a public accessor for Phase B to consume.
+
+
+# Issue #4459: diff-pair Phase 1 ground-truth taxonomy.  Every coupled pair
+# that fails to couple falls into exactly one of these classes; Phases 2-5 of
+# the #4409 epic each target a specific class, so this per-pair classification
+# is the measurement harness that lets a later phase verify it fixed the class
+# it claims to.  Diagnostic-only -- classifying a pair changes no geometry.
+COUPLED_OUTCOME_GUIDE_MISSING = "guide-missing"
+COUPLED_OUTCOME_SHADOW_OVERLAP = "shadow-declined-overlap"
+COUPLED_OUTCOME_SHADOW_BLOCKAGE = "shadow-declined-blockage"
+COUPLED_OUTCOME_JOINT_PLATEAU = "joint-A*-plateau"
+COUPLED_OUTCOME_LANDING_STALL = "landing-stall"
+
+
+def dominant_rejection(rejections: Mapping[str, int] | None) -> str | None:
+    """Return the single most-frequent rejection reason, or ``None``.
+
+    Issue #4459: the coupled search's per-reason rejection histogram
+    (``CoupledPathfinder.last_rejections``) tells us WHICH guard pruned the
+    frontier most often on a budget-exit.  Ties break alphabetically for a
+    deterministic diagnostic.  An empty / ``None`` histogram returns ``None``
+    (the search popped no neighbours -- e.g. the start state was the goal).
+    """
+    if not rejections:
+        return None
+    # max by (count, then reverse-alpha) so the highest count wins and ties
+    # resolve to the alphabetically-first key deterministically.
+    return max(sorted(rejections), key=lambda k: rejections[k])
+
+
+@dataclass
+class CoupledPairReport:
+    """Structured per-pair ground-truth for one coupled diff-pair attempt.
+
+    Issue #4459 (Phase 1 of #4409): emitted for every pair the coupled router
+    attempts so Phases 2-5 have a per-pair failure classification to verify
+    against.  Diagnostic-only -- constructing this record changes no routing
+    behaviour or geometry.
+
+    Attributes:
+        pair_name: Base name of the diff pair (e.g. ``"MIPI_CLK"``).
+        classification: One of the ``COUPLED_OUTCOME_*`` taxonomy strings, or
+            ``"coupled-ok"`` when the pair actually coupled.
+        coupled: Whether the pair coupled (a route was produced).
+        backend: Which search served the attempt (``"cpp"`` / ``"python"``).
+        coupled_phase: The phase label the attempt reached (``open`` /
+            ``corridor`` / ``shadow`` / ``shadow-swapped`` / ...).
+        guide_ok: Whether the single-ended guide probe produced segments.
+        best_progress: Smallest joint remaining Manhattan distance any popped
+            joint state reached (``inf`` when nothing popped / not applicable).
+        dominant_rejection: The most-frequent frontier-pruning reason, or
+            ``None``.
+        start_pitch_cells: P/N start-pad pitch in grid cells.
+        end_pitch_cells: P/N end-pad pitch in grid cells.
+        target_spacing_cells: The coupled search's target center spacing.
+        off_angle_segments: Count of guide segments that are neither
+            axis-aligned nor exactly 45 degrees (an off-angle proxy Phase 4
+            targets).
+        shadow_enabled: Whether shadow construction was active for this pair.
+    """
+
+    pair_name: str
+    classification: str
+    coupled: bool
+    backend: str
+    coupled_phase: str
+    guide_ok: bool
+    best_progress: float
+    dominant_rejection: str | None
+    start_pitch_cells: float
+    end_pitch_cells: float
+    target_spacing_cells: int
+    off_angle_segments: int
+    shadow_enabled: bool
+
+    def format_line(self) -> str:
+        """One-line ``[coupled-pair-report]`` rendering for stdout logs."""
+        bp = "inf" if self.best_progress == float("inf") else f"{self.best_progress:.0f}"
+        return (
+            f"    [coupled-pair-report] pair={self.pair_name} "
+            f"class={self.classification} coupled={self.coupled} "
+            f"backend={self.backend} phase={self.coupled_phase} "
+            f"guide_ok={self.guide_ok} best_progress={bp} "
+            f"dominant_rejection={self.dominant_rejection} "
+            f"start_pitch={self.start_pitch_cells:.1f} "
+            f"end_pitch={self.end_pitch_cells:.1f} "
+            f"target_spacing={self.target_spacing_cells} "
+            f"off_angle_segs={self.off_angle_segments} "
+            f"shadow={self.shadow_enabled}"
+        )
+
+
+def _count_off_angle_segments(route: Route | None) -> int:
+    """Count guide segments that are neither axis-aligned nor exactly 45 deg.
+
+    Issue #4459: an off-angle proxy for the Phase-4 failure class.  A segment
+    is on-angle when it is horizontal (``dy == 0``), vertical (``dx == 0``) or
+    a true 45 (``|dx| == |dy|``); anything else is off-angle.  ``None`` / empty
+    routes contribute zero.
+    """
+    if route is None:
+        return 0
+    off = 0
+    for seg in route.segments:
+        dx = abs(seg.x2 - seg.x1)
+        dy = abs(seg.y2 - seg.y1)
+        if dx < 1e-9 or dy < 1e-9:
+            continue  # axis-aligned
+        if abs(dx - dy) < 1e-6:
+            continue  # exact 45
+        off += 1
+    return off
+
+
+def classify_coupled_pair_outcome(
+    *,
+    coupled: bool,
+    coupled_phase: str,
+    guide_ok: bool,
+    best_progress: float,
+    shadow_enabled: bool,
+    shadow_decline_reason: str | None,
+    near_miss_cells: int = NEAR_MISS_RESCUE_CELLS,
+) -> str:
+    """Classify a coupled-pair attempt into the #4459 failure taxonomy.
+
+    Diagnostic-only.  Returns ``"coupled-ok"`` when the pair coupled, else one
+    of the ``COUPLED_OUTCOME_*`` classes:
+
+    * ``guide-missing`` -- the single-ended guide probe produced no path, so
+      neither the shadow constructor nor the corridor search had a seed.
+    * ``shadow-declined-overlap`` / ``shadow-declined-blockage`` -- shadow
+      construction was active and declined (only reachable with shadow ON);
+      the sub-reason is the shadow's last decline cause.
+    * ``landing-stall`` -- the joint A* got within ``near_miss_cells`` of the
+      goal (the pad-landing needle-eye stall, Phase 5's class).
+    * ``joint-A*-plateau`` -- the joint A* stalled far from the goal (overlap /
+      blockage / off-angle body failures, Phases 2-4's classes).
+    """
+    if coupled:
+        return "coupled-ok"
+    if not guide_ok:
+        return COUPLED_OUTCOME_GUIDE_MISSING
+    if shadow_enabled and shadow_decline_reason is not None:
+        if shadow_decline_reason == "overlap":
+            return COUPLED_OUTCOME_SHADOW_OVERLAP
+        return COUPLED_OUTCOME_SHADOW_BLOCKAGE
+    if best_progress != float("inf") and best_progress <= near_miss_cells:
+        return COUPLED_OUTCOME_LANDING_STALL
+    return COUPLED_OUTCOME_JOINT_PLATEAU
 
 
 @dataclass
@@ -691,6 +843,11 @@ class CoupledPathfinder:
         self.last_best_progress: float = float("inf")
         self.last_best_state: CoupledState | None = None
         self.last_best_node: CoupledNode | None = None
+        # Issue #4459: backend that served the most-recent coupled search
+        # ("python" or "cpp").  Lets the ``[coupled-timing]`` diagnostic report
+        # ``best_state=n/a (cpp)`` instead of a misleading ``best_state=None``
+        # for the C++ path, which carries no Python ``CoupledState`` object.
+        self.last_coupled_backend: str = "python"
 
         # Issue #3508: per-search move-rejection counters keyed by
         # rejection reason (sym/asym x blocked/spacing/floor/trail,
@@ -1698,11 +1855,24 @@ class CoupledPathfinder:
         self.last_iterations = int(diagnostics["iterations"])
         bp = diagnostics["best_progress"]
         self.last_best_progress = float("inf") if bp < 0 else float(bp)
+        # Issue #4459: the C++ joint-state search carries no Python
+        # ``CoupledState`` object, so ``last_best_state`` / ``last_best_node``
+        # are genuinely unavailable on this path -- but ``last_best_progress``
+        # above IS the real progress signal.  The old ``[coupled-timing]``
+        # print read ``last_best_state`` (hard-set to ``None`` here) and
+        # printed ``best_state=None`` for EVERY C++ pair, implying "never
+        # moved" even when the joint A* made progress.  Record the backend so
+        # the diagnostic can print ``best_state=n/a (cpp)`` and lean on
+        # ``best_progress`` / ``rejections`` instead of the None red herring.
         self.last_best_state = None
         self.last_best_node = None
+        self.last_coupled_backend = "cpp"
         self.last_timeout_exceeded = bool(diagnostics["timeout_exceeded"])
         self.last_iteration_limited = bool(diagnostics["iteration_limited"])
-        self.last_rejections = collections.defaultdict(int)
+        # Issue #4459: populate the rejection histogram from the C++ search
+        # (was hard-emptied here, so ``last_rejections`` was categorically
+        # empty on the C++ path and no guard-pruning signal survived).
+        self.last_rejections = collections.defaultdict(int, diagnostics.get("rejections", {}) or {})
 
         if path is None:
             return True, None
@@ -1827,6 +1997,12 @@ class CoupledPathfinder:
         self.last_best_progress: float = float("inf")
         self.last_best_state: CoupledState | None = None
         self.last_best_node: CoupledNode | None = None
+        # Issue #4459: which backend served the most-recent search.  Defaults
+        # to ``"python"`` here; ``_try_cpp_route_coupled`` overrides it to
+        # ``"cpp"`` when the C++ joint-state search handles the pair.  The
+        # ``[coupled-timing]`` diagnostic uses this to avoid reading the
+        # C++-path ``last_best_state=None`` as "never moved".
+        self.last_coupled_backend = "python"
         # Issue #3508: reset the per-search rejection counters.
         self.last_rejections = collections.defaultdict(int)
 
@@ -2721,6 +2897,17 @@ class DiffPairRouter:
         # observability-only; Phase B (separate PR) will consume this
         # list to drive a fine-grid repair sub-pass.
         self._intra_clearance_violations: list[IntraPairClearanceViolation] = []
+        # Issue #4459 (Phase 1 of #4409): ground-truth instrumentation for the
+        # coupled diff-pair search.  ``_last_shadow_decline_reason`` records the
+        # LAST reason the geometric shadow constructor declined a side
+        # ("overlap" -- self-check / physical P/N overlap, or "blockage" --
+        # no legal via site / mid-route obstacle / unreachable pad tail);
+        # reset per spec, set inside ``_shadow_route_pair``.
+        # ``_last_coupled_pair_report`` holds the most-recent per-pair
+        # taxonomy classification (a :class:`CoupledPairReport`).  Both are
+        # diagnostic-only and never influence routing decisions.
+        self._last_shadow_decline_reason: str | None = None
+        self._last_coupled_pair_report: CoupledPairReport | None = None
         # Issue #3089: True iff the most-recent call to
         # ``route_differential_pair_coupled`` returned because the
         # inner ``CoupledPathfinder.route_coupled`` exceeded its
@@ -4330,6 +4517,7 @@ class DiffPairRouter:
                     f"    [coupled-shadow] side={side:+.0f} no legal shadow-via "
                     f"site for {pair.name}"
                 )
+                self._last_shadow_decline_reason = "blockage"  # #4459
                 continue
 
             # ------------------------------------------------------------
@@ -4375,6 +4563,7 @@ class DiffPairRouter:
                     )
                     break
             if interior_block:
+                self._last_shadow_decline_reason = "blockage"  # #4459
                 continue
             a0 = trim_start + 2 * step if trim_start > 0 else 0.0
             a1 = arc_total - trim_end - (2 * step if trim_end > 0 else 0.0)
@@ -4383,6 +4572,7 @@ class DiffPairRouter:
                     f"    [coupled-shadow] side={side:+.0f} clear run too "
                     f"short for {pair.name} ({a1 - a0:.2f}mm)"
                 )
+                self._last_shadow_decline_reason = "blockage"  # #4459
                 continue
 
             # Slice elements to [lo, hi] by arc length.  Vias are kept
@@ -4449,6 +4639,7 @@ class DiffPairRouter:
                     a0_eff = a0 + extra0
                     break
             if start_tail is None:
+                self._last_shadow_decline_reason = "blockage"  # #4459
                 continue
             end_tail = None
             a1_eff = a1
@@ -4474,10 +4665,12 @@ class DiffPairRouter:
                     a1_eff = a1 - extra1
                     break
             if end_tail is None:
+                self._last_shadow_decline_reason = "blockage"  # #4459
                 continue
             kept = _slice_kept(a0_eff, a1_eff)
             seg_elements = [e for e in kept if e[0] == "seg"]
             if not seg_elements:
+                self._last_shadow_decline_reason = "blockage"  # #4459
                 continue
 
             shadow_route = Route(net=s_net, net_name=s_net_name)
@@ -4576,6 +4769,7 @@ class DiffPairRouter:
                     f"(worst={violation.actual_clearance_mm:+.3f}mm); trying "
                     f"other side"
                 )
+                self._last_shadow_decline_reason = "overlap"  # #4459
                 continue
             # Issue #3508 (second pass): full physical-overlap check
             # (via-vs-seg / via-vs-via / seg-vs-seg) mirroring the
@@ -4587,6 +4781,7 @@ class DiffPairRouter:
                     f"P/N overlap (via-aware) for {pair.name}; trying "
                     f"other side"
                 )
+                self._last_shadow_decline_reason = "overlap"  # #4459
                 continue
             return p_route, n_route
 
@@ -5010,6 +5205,10 @@ class DiffPairRouter:
             spec_t0 = time.monotonic()
             result: tuple[Route, Route] | None = None
             coupled_phase = "open"
+            # Issue #4459: reset the shadow-decline reason for this spec so a
+            # prior pair's decline cannot leak into this pair's per-pair
+            # classification.  ``_shadow_route_pair`` sets it at each decline.
+            self._last_shadow_decline_reason = None
             # Issue #3473: iterations the corridor attempt consumed,
             # charged against the shared per-pair iteration budget so
             # the open fallback gets the REMAINDER (not a fresh full
@@ -5252,17 +5451,82 @@ class DiffPairRouter:
             # for a failing pair is the budget-exceeded warning -- the
             # corridor/open phase split and the iteration cost (the two
             # knobs recipe authors tune) were invisible in CI logs.
+            # Issue #4459: kill the ``best_state=None`` red herring.  The C++
+            # joint-state search (``_try_cpp_route_coupled``) carries no Python
+            # ``CoupledState`` object, so ``last_best_state`` is genuinely
+            # ``None`` on that path -- but the OLD line printed ``best_state=
+            # None`` for EVERY C++ pair, implying "never moved" even when the
+            # joint A* made real progress.  The true signal is
+            # ``last_best_progress`` (the smallest joint remaining distance any
+            # popped state reached) plus the dominant frontier-pruning reason.
+            # Report ``n/a (cpp)`` on the C++ path so the line stops implying a
+            # stall; keep the real state repr on the Python path.
+            backend = getattr(pathfinder, "last_coupled_backend", "python")
             best_state = pathfinder.last_best_state
+            if best_state is None and backend == "cpp":
+                best_state_repr = "n/a (cpp)"
+            else:
+                best_state_repr = str(best_state)
+            dominant = dominant_rejection(pathfinder.last_rejections)
             print(
                 f"    [coupled-timing] phase={coupled_phase} "
+                f"backend={backend} "
                 f"elapsed={spec_elapsed:.2f}s "
                 f"corridor_iters={corridor_iterations_used} "
                 f"last_iters={pathfinder.last_iterations} "
                 f"best_progress={pathfinder.last_best_progress} "
-                f"best_state={best_state} "
+                f"best_state={best_state_repr} "
+                f"dominant_rejection={dominant} "
                 f"rejections={dict(pathfinder.last_rejections)} "
                 f"success={result is not None}"
             )
+
+            # Issue #4459: structured per-pair ground-truth report.  Classify
+            # this attempt into the #4409 failure taxonomy so Phases 2-5 can
+            # verify a fix targeted the class it claims.  Emitted for EVERY
+            # pair (coupled or not) under both shadow-OFF (default) and
+            # shadow-ON (``KCT_BOARD06_SHADOW=1``) so board-06's 9 pairs each
+            # get a classification.  Diagnostic-only: building/printing this
+            # record changes no routing behaviour or geometry.
+            resolution = self.autorouter.grid.resolution
+            start_pitch_cells = (
+                math.dist((spec.p_start.x, spec.p_start.y), (spec.n_start.x, spec.n_start.y))
+                / resolution
+            )
+            end_pitch_cells = (
+                math.dist((spec.p_end.x, spec.p_end.y), (spec.n_end.x, spec.n_end.y)) / resolution
+            )
+            guide_ok = guide_route is not None and bool(guide_route.segments)
+            shadow_decline_reason = (
+                getattr(self, "_last_shadow_decline_reason", None)
+                if self.enable_shadow_construction
+                else None
+            )
+            classification = classify_coupled_pair_outcome(
+                coupled=result is not None,
+                coupled_phase=coupled_phase,
+                guide_ok=guide_ok,
+                best_progress=pathfinder.last_best_progress,
+                shadow_enabled=self.enable_shadow_construction,
+                shadow_decline_reason=shadow_decline_reason,
+            )
+            report = CoupledPairReport(
+                pair_name=pair.name,
+                classification=classification,
+                coupled=result is not None,
+                backend=backend,
+                coupled_phase=coupled_phase,
+                guide_ok=guide_ok,
+                best_progress=pathfinder.last_best_progress,
+                dominant_rejection=dominant,
+                start_pitch_cells=start_pitch_cells,
+                end_pitch_cells=end_pitch_cells,
+                target_spacing_cells=spacing_cells,
+                off_angle_segments=_count_off_angle_segments(guide_route),
+                shadow_enabled=self.enable_shadow_construction,
+            )
+            self._last_coupled_pair_report = report
+            print(report.format_line())
 
             # Issue #3508: near-miss rescue.  The weighted corridor-
             # bounded coupled search reliably traverses the route body

--- a/tests/test_diffpair_coupled_instrumentation_4459.py
+++ b/tests/test_diffpair_coupled_instrumentation_4459.py
@@ -1,0 +1,518 @@
+"""Instrumentation / ground-truth tests for the coupled diff-pair router.
+
+Issue #4459 (Phase 1 of the #4409 epic): diagnostic-only wiring that makes the
+0/9 coupled-routing failure triageable.  Three things are asserted here:
+
+1. The ``[coupled-timing]`` diagnostic no longer prints a categorically-``None``
+   ``best_state`` on the C++ path (the "best_state=None red herring") -- it
+   reports ``backend=cpp`` and ``best_state=n/a (cpp)`` and leans on the real
+   ``best_progress`` / dominant-rejection signal instead.
+2. ``CoupledPathfinder.last_rejections`` is NON-EMPTY on the C++ path -- the
+   per-reason rejection histogram is wired out of the C++ joint search (it was
+   previously hard-emptied, so no frontier-pruning signal survived).
+3. Every attempted pair is classified into the failure taxonomy and a
+   structured ``[coupled-pair-report]`` line is emitted.
+
+None of this changes routing behaviour or geometry -- these tests only assert
+the diagnostics, never a different route.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.router.cpp_backend import is_cpp_available
+from kicad_tools.router.diffpair_routing import (
+    COUPLED_OUTCOME_GUIDE_MISSING,
+    COUPLED_OUTCOME_JOINT_PLATEAU,
+    COUPLED_OUTCOME_LANDING_STALL,
+    COUPLED_OUTCOME_SHADOW_BLOCKAGE,
+    COUPLED_OUTCOME_SHADOW_OVERLAP,
+    CoupledPairReport,
+    CoupledPathfinder,
+    _count_off_angle_segments,
+    build_corridor_mask,
+    classify_coupled_pair_outcome,
+    dominant_rejection,
+)
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.primitives import Pad, Route, Segment
+from kicad_tools.router.rules import DesignRules
+
+# The pure-Python coupled loop's rejection vocabulary (diffpair_routing.py); the
+# C++ histogram must key on the SAME reasons (plus the via-guard superset).
+_KNOWN_REJECTION_KEYS = {
+    "sym_blocked_p",
+    "sym_blocked_n",
+    "sym_spacing",
+    "sym_floor",
+    "sym_trail",
+    "asym_blocked_p",
+    "asym_spacing_p",
+    "asym_floor_p",
+    "asym_trail_p",
+    "asym_blocked_n",
+    "asym_spacing_n",
+    "asym_floor_n",
+    "asym_trail_n",
+    "via_blocked_p",
+    "via_blocked_n",
+    "via_trace_blocked_p",
+    "via_trace_blocked_n",
+    "corridor",
+}
+
+
+# ---------------------------------------------------------------------------
+# Pure-unit taxonomy / helper tests (no backend required)
+# ---------------------------------------------------------------------------
+
+
+def test_dominant_rejection_picks_highest_count():
+    assert dominant_rejection({"sym_floor": 3, "corridor": 9, "sym_spacing": 5}) == "corridor"
+
+
+def test_dominant_rejection_ties_break_alphabetically():
+    # corridor and sym_spacing both 5 -> alphabetically-first ("corridor").
+    assert dominant_rejection({"sym_spacing": 5, "corridor": 5}) == "corridor"
+
+
+def test_dominant_rejection_empty_is_none():
+    assert dominant_rejection({}) is None
+    assert dominant_rejection(None) is None
+
+
+def test_classify_coupled_ok_when_coupled():
+    assert (
+        classify_coupled_pair_outcome(
+            coupled=True,
+            coupled_phase="corridor",
+            guide_ok=True,
+            best_progress=0.0,
+            shadow_enabled=False,
+            shadow_decline_reason=None,
+        )
+        == "coupled-ok"
+    )
+
+
+def test_classify_guide_missing():
+    assert (
+        classify_coupled_pair_outcome(
+            coupled=False,
+            coupled_phase="open",
+            guide_ok=False,
+            best_progress=float("inf"),
+            shadow_enabled=False,
+            shadow_decline_reason=None,
+        )
+        == COUPLED_OUTCOME_GUIDE_MISSING
+    )
+
+
+def test_classify_joint_plateau_far_from_goal():
+    # Far-from-goal stall (best_progress well above the near-miss threshold).
+    assert (
+        classify_coupled_pair_outcome(
+            coupled=False,
+            coupled_phase="open",
+            guide_ok=True,
+            best_progress=398.0,
+            shadow_enabled=False,
+            shadow_decline_reason=None,
+            near_miss_cells=60,
+        )
+        == COUPLED_OUTCOME_JOINT_PLATEAU
+    )
+
+
+def test_classify_landing_stall_near_goal():
+    assert (
+        classify_coupled_pair_outcome(
+            coupled=False,
+            coupled_phase="open",
+            guide_ok=True,
+            best_progress=12.0,
+            shadow_enabled=False,
+            shadow_decline_reason=None,
+            near_miss_cells=60,
+        )
+        == COUPLED_OUTCOME_LANDING_STALL
+    )
+
+
+def test_classify_shadow_decline_overlap_and_blockage():
+    assert (
+        classify_coupled_pair_outcome(
+            coupled=False,
+            coupled_phase="open",
+            guide_ok=True,
+            best_progress=float("inf"),
+            shadow_enabled=True,
+            shadow_decline_reason="overlap",
+        )
+        == COUPLED_OUTCOME_SHADOW_OVERLAP
+    )
+    assert (
+        classify_coupled_pair_outcome(
+            coupled=False,
+            coupled_phase="open",
+            guide_ok=True,
+            best_progress=float("inf"),
+            shadow_enabled=True,
+            shadow_decline_reason="blockage",
+        )
+        == COUPLED_OUTCOME_SHADOW_BLOCKAGE
+    )
+
+
+def test_shadow_decline_reason_ignored_when_shadow_off():
+    # A decline reason set from a prior pair must not leak into a flag-off
+    # classification (shadow is not even attempted with the flag off).
+    assert (
+        classify_coupled_pair_outcome(
+            coupled=False,
+            coupled_phase="open",
+            guide_ok=True,
+            best_progress=400.0,
+            shadow_enabled=False,
+            shadow_decline_reason="overlap",
+        )
+        == COUPLED_OUTCOME_JOINT_PLATEAU
+    )
+
+
+def test_count_off_angle_segments():
+    route = Route(net=1, net_name="G")
+    # horizontal (on), vertical (on), 45 (on), off-angle (off).
+    route.segments.append(Segment(x1=0, y1=0, x2=5, y2=0, width=0.2, layer=Layer.F_CU, net=1))
+    route.segments.append(Segment(x1=5, y1=0, x2=5, y2=5, width=0.2, layer=Layer.F_CU, net=1))
+    route.segments.append(Segment(x1=5, y1=5, x2=8, y2=8, width=0.2, layer=Layer.F_CU, net=1))
+    route.segments.append(Segment(x1=8, y1=8, x2=12, y2=9, width=0.2, layer=Layer.F_CU, net=1))
+    assert _count_off_angle_segments(route) == 1
+    assert _count_off_angle_segments(None) == 0
+
+
+def test_pair_report_format_line_has_all_fields():
+    report = CoupledPairReport(
+        pair_name="MIPI_CLK",
+        classification=COUPLED_OUTCOME_JOINT_PLATEAU,
+        coupled=False,
+        backend="cpp",
+        coupled_phase="open",
+        guide_ok=True,
+        best_progress=398.0,
+        dominant_rejection="corridor",
+        start_pitch_cells=10.0,
+        end_pitch_cells=8.0,
+        target_spacing_cells=5,
+        off_angle_segments=0,
+        shadow_enabled=False,
+    )
+    line = report.format_line()
+    assert "[coupled-pair-report]" in line
+    assert "pair=MIPI_CLK" in line
+    assert f"class={COUPLED_OUTCOME_JOINT_PLATEAU}" in line
+    assert "backend=cpp" in line
+    assert "best_progress=398" in line
+    assert "dominant_rejection=corridor" in line
+    # inf renders as a stable token, never a Python float repr.
+    inf_report = CoupledPairReport(
+        pair_name="X",
+        classification=COUPLED_OUTCOME_GUIDE_MISSING,
+        coupled=False,
+        backend="cpp",
+        coupled_phase="open",
+        guide_ok=False,
+        best_progress=float("inf"),
+        dominant_rejection=None,
+        start_pitch_cells=1.0,
+        end_pitch_cells=1.0,
+        target_spacing_cells=2,
+        off_angle_segments=0,
+        shadow_enabled=False,
+    )
+    assert "best_progress=inf" in inf_report.format_line()
+
+
+# ---------------------------------------------------------------------------
+# C++ rejection-histogram wiring (acceptance criterion 2)
+# ---------------------------------------------------------------------------
+
+
+def _make_grid(width: float = 12.7, height: float = 12.7) -> RoutingGrid:
+    return RoutingGrid(width=width, height=height, rules=DesignRules())
+
+
+def _simple_pair_pads() -> tuple[Pad, Pad, Pad, Pad]:
+    p_start = Pad(x=2.0, y=4.0, width=0.4, height=0.4, net=1, net_name="D+", layer=Layer.F_CU)
+    p_end = Pad(x=10.0, y=4.0, width=0.4, height=0.4, net=1, net_name="D+", layer=Layer.F_CU)
+    n_start = Pad(x=2.0, y=6.0, width=0.4, height=0.4, net=2, net_name="D-", layer=Layer.F_CU)
+    n_end = Pad(x=10.0, y=6.0, width=0.4, height=0.4, net=2, net_name="D-", layer=Layer.F_CU)
+    return p_start, p_end, n_start, n_end
+
+
+def _make_pf(grid: RoutingGrid, use_cpp: bool) -> CoupledPathfinder:
+    pf = CoupledPathfinder(
+        grid=grid, rules=DesignRules(), target_spacing_cells=2, min_spacing_cells=2
+    )
+    pf._use_cpp_coupled = use_cpp
+    return pf
+
+
+@pytest.mark.skipif(
+    not is_cpp_available(),
+    reason="rejection-histogram wiring requires the router_cpp backend (kct build-native)",
+)
+def test_cpp_path_populates_rejection_histogram_on_budget_exit():
+    """On a budget-exited C++ joint search ``last_rejections`` is non-empty.
+
+    Previously ``_try_cpp_route_coupled`` hard-set ``last_rejections`` to an
+    empty defaultdict on EVERY C++ return, so no signal survived about which
+    guard pruned the frontier.  The histogram is now wired out of the C++
+    search; a small joint search that exhausts its iteration budget must
+    surface at least one rejection reason, all drawn from the known
+    vocabulary.
+    """
+    pads = _simple_pair_pads()
+    pf = _make_pf(_make_grid(), use_cpp=True)
+    # A tiny iteration budget forces a budget-exit while the spacing/floor
+    # guards are actively pruning off-target neighbours.
+    res = pf.route_coupled(*pads, max_iterations_budget=16)
+    assert res is None, "tiny budget must not converge (setup guard)"
+    assert pf.last_coupled_backend == "cpp"
+    assert len(pf.last_rejections) > 0, "C++ path must surface a rejection histogram"
+    assert all(v > 0 for v in pf.last_rejections.values())
+    unknown = set(pf.last_rejections) - _KNOWN_REJECTION_KEYS
+    assert not unknown, f"unexpected rejection keys: {unknown}"
+    # The dominant reason is a real, non-None signal now.
+    assert dominant_rejection(pf.last_rejections) in _KNOWN_REJECTION_KEYS
+
+
+@pytest.mark.skipif(
+    not is_cpp_available(),
+    reason="corridor rejection test requires the router_cpp backend (kct build-native)",
+)
+def test_cpp_path_reports_corridor_rejections_inside_tight_corridor():
+    """A corridor-bounded C++ search records ``corridor`` frontier pruning."""
+    grid = _make_grid()
+    pads = _simple_pair_pads()
+    p_start, p_end, n_start, n_end = pads
+    guide = Route(net=1, net_name="GUIDE")
+    guide.segments.append(
+        Segment(x1=2.0, y1=5.0, x2=10.0, y2=5.0, width=0.2, layer=Layer.F_CU, net=1)
+    )
+    # A DELIBERATELY tight corridor (radius 3) so many neighbours land outside
+    # it and are pruned as ``corridor`` rejections; a tiny budget forces exit.
+    corridor = build_corridor_mask(
+        grid,
+        guide,
+        radius_cells=3,
+        extra_cells=(
+            grid.world_to_grid(p_start.x, p_start.y),
+            grid.world_to_grid(p_end.x, p_end.y),
+            grid.world_to_grid(n_start.x, n_start.y),
+            grid.world_to_grid(n_end.x, n_end.y),
+        ),
+    )
+    pf = _make_pf(grid, use_cpp=True)
+    pf.route_coupled(*pads, max_iterations_budget=32, corridor=corridor)
+    assert pf.last_rejections.get("corridor", 0) > 0, (
+        f"tight corridor must prune neighbours; got {dict(pf.last_rejections)}"
+    )
+
+
+@pytest.mark.skipif(
+    not is_cpp_available(),
+    reason="backend-marker test requires the router_cpp backend (kct build-native)",
+)
+def test_last_coupled_backend_marker_tracks_backend():
+    """``last_coupled_backend`` distinguishes the C++ vs pure-Python search."""
+    pads = _simple_pair_pads()
+
+    cpp_pf = _make_pf(_make_grid(), use_cpp=True)
+    cpp_pf.route_coupled(*pads, max_iterations_budget=16)
+    assert cpp_pf.last_coupled_backend == "cpp"
+
+    py_pf = _make_pf(_make_grid(), use_cpp=False)
+    py_pf.route_coupled(*pads, max_iterations_budget=16)
+    assert py_pf.last_coupled_backend == "python"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end diagnostic emission (acceptance criteria 1 & 3) via a stub
+# pathfinder -- no backend required, and no real routing performed.
+# ---------------------------------------------------------------------------
+
+
+def _two_pad_router_and_pair():
+    """A 2-pad diff pair + its router, ready for the coupled pre-phase."""
+    from kicad_tools.router.core import Autorouter
+    from kicad_tools.router.diffpair import (
+        DifferentialPair,
+        DifferentialPairType,
+        DifferentialSignal,
+    )
+
+    router = Autorouter(width=30.0, height=10.0, rules=DesignRules())
+    p_y, n_y = 4.8, 5.2
+    router.add_component(
+        "U1",
+        [
+            {
+                "number": "1",
+                "x": 5.0,
+                "y": p_y,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 1,
+                "net_name": "USB_D+",
+            },
+            {
+                "number": "2",
+                "x": 5.0,
+                "y": n_y,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 2,
+                "net_name": "USB_D-",
+            },
+        ],
+    )
+    router.add_component(
+        "J1",
+        [
+            {
+                "number": "1",
+                "x": 25.0,
+                "y": p_y,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 1,
+                "net_name": "USB_D+",
+            },
+            {
+                "number": "2",
+                "x": 25.0,
+                "y": n_y,
+                "width": 0.4,
+                "height": 0.4,
+                "net": 2,
+                "net_name": "USB_D-",
+            },
+        ],
+    )
+    pair = DifferentialPair(
+        name="USB_D",
+        positive=DifferentialSignal(
+            net_name="USB_D+", net_id=1, base_name="USB_D", polarity="P", notation="plus_minus"
+        ),
+        negative=DifferentialSignal(
+            net_name="USB_D-", net_id=2, base_name="USB_D", polarity="N", notation="plus_minus"
+        ),
+        pair_type=DifferentialPairType.USB2,
+    )
+    return router, pair
+
+
+class _CppLikeStubPathfinder:
+    """Stub emulating a C++ joint search that made progress but did not couple.
+
+    Mirrors the ``_try_cpp_route_coupled`` state: ``last_best_state`` is ``None``
+    (the C++ path carries no Python ``CoupledState``) but ``last_best_progress``
+    and ``last_rejections`` hold the REAL signal, and ``last_coupled_backend``
+    is ``"cpp"``.
+    """
+
+    def __init__(self):
+        self.last_timeout_exceeded = False
+        self.last_iteration_limited = False
+        self.last_iterations = 1000
+        self.last_best_progress = 398.0
+        self.last_best_state = None  # the historic red herring
+        self.last_best_node = None
+        self.last_coupled_backend = "cpp"
+        self.last_rejections = {"corridor": 120, "sym_spacing": 40}
+
+    def route_coupled(self, *_a, **_k):
+        return None  # deferred (did not couple)
+
+
+def _install_stub(monkeypatch):
+    import kicad_tools.router.diffpair_routing as dpr_mod
+
+    monkeypatch.setattr(dpr_mod, "CoupledPathfinder", lambda *a, **k: _CppLikeStubPathfinder())
+
+
+def test_coupled_timing_kills_best_state_none_red_herring(monkeypatch, capsys):
+    """The ``[coupled-timing]`` line must NOT print ``best_state=None`` on the
+    C++ path -- it reports ``backend=cpp`` / ``best_state=n/a (cpp)`` and the
+    real ``best_progress`` + dominant-rejection instead."""
+    router, pair = _two_pad_router_and_pair()
+    dpr = router._diffpair
+    dpr.enable_shadow_construction = False
+    # A guide route exists so the pair is classified as a joint-A* stall, not
+    # guide-missing.
+    guide = Route(net=1, net_name="USB_D+")
+    guide.segments.append(
+        Segment(x1=5.0, y1=5.0, x2=25.0, y2=5.0, width=0.2, layer=Layer.F_CU, net=1)
+    )
+    monkeypatch.setattr(dpr, "_single_ended_guide_route", lambda *a, **k: guide)
+    _install_stub(monkeypatch)
+
+    dpr.route_differential_pair_coupled(pair, coupled_only=True)
+    out = capsys.readouterr().out
+
+    assert "[coupled-timing]" in out
+    assert "backend=cpp" in out
+    assert "best_state=n/a (cpp)" in out
+    assert "best_state=None" not in out, (
+        f"the best_state=None red herring must be gone; got: {out!r}"
+    )
+    assert "best_progress=398.0" in out
+    assert "dominant_rejection=corridor" in out
+
+
+def test_coupled_pair_report_emitted_with_classification(monkeypatch, capsys):
+    """A structured ``[coupled-pair-report]`` line is emitted, classifying the
+    pair into the failure taxonomy (here a far-from-goal joint-A* plateau)."""
+    router, pair = _two_pad_router_and_pair()
+    dpr = router._diffpair
+    dpr.enable_shadow_construction = False
+    guide = Route(net=1, net_name="USB_D+")
+    guide.segments.append(
+        Segment(x1=5.0, y1=5.0, x2=25.0, y2=5.0, width=0.2, layer=Layer.F_CU, net=1)
+    )
+    monkeypatch.setattr(dpr, "_single_ended_guide_route", lambda *a, **k: guide)
+    _install_stub(monkeypatch)
+
+    dpr.route_differential_pair_coupled(pair, coupled_only=True)
+    out = capsys.readouterr().out
+
+    assert "[coupled-pair-report]" in out
+    assert "pair=USB_D" in out
+    assert f"class={COUPLED_OUTCOME_JOINT_PLATEAU}" in out
+    assert "coupled=False" in out
+    assert "guide_ok=True" in out
+    # The report is retained on the router for programmatic consumption.
+    report = dpr._last_coupled_pair_report
+    assert report is not None
+    assert report.classification == COUPLED_OUTCOME_JOINT_PLATEAU
+    assert report.dominant_rejection == "corridor"
+
+
+def test_coupled_pair_report_classifies_guide_missing(monkeypatch, capsys):
+    """With no single-ended guide the pair is classified ``guide-missing``."""
+    router, pair = _two_pad_router_and_pair()
+    dpr = router._diffpair
+    dpr.enable_shadow_construction = False
+    monkeypatch.setattr(dpr, "_single_ended_guide_route", lambda *a, **k: None)
+    _install_stub(monkeypatch)
+
+    dpr.route_differential_pair_coupled(pair, coupled_only=True)
+    out = capsys.readouterr().out
+
+    assert f"class={COUPLED_OUTCOME_GUIDE_MISSING}" in out
+    assert dpr._last_coupled_pair_report is not None
+    assert dpr._last_coupled_pair_report.classification == COUPLED_OUTCOME_GUIDE_MISSING


### PR DESCRIPTION
## Summary

Phase 1 of the #4409 diff-pair epic: **diagnostic-only** instrumentation that makes the board-06 0/9 coupled-routing failure triageable. No coupling algorithm change — routing outcomes and geometry are byte-for-byte unchanged (0/9 stays 0/9); this is the measurement harness for Phases 2–5.

Three problems fixed:

1. **Kill the `best_state=None` red herring.** `_try_cpp_route_coupled` hard-set `self.last_best_state = None` on every return from the C++ coupled path, so the `[coupled-timing]` line printed `best_state=None` for *every* pair regardless of progress — falsely implying "never moved." The C++ joint search carries no Python `CoupledState`, so the line now reports `backend=cpp` / `best_state=n/a (cpp)` and leans on the real `last_best_progress` and the dominant-rejection reason.
2. **Wire the C++ rejection histogram.** The C++ coupled search now counts per-reason move rejections (sym/asym × blocked/spacing/floor/trail, the via guards, and corridor pruning), surfaces them on `CoupledRouteResult::rejections` (nanobind), threads them through `CppCoupledPathfinder.route` diagnostics, and populates `pathfinder.last_rejections` on the C++ path (previously hard-emptied at the C++ return).
3. **Per-pair failure taxonomy.** A structured `[coupled-pair-report]` line is emitted for every attempted pair, classifying it into `guide-missing` / `shadow-declined-overlap` / `shadow-declined-blockage` / `joint-A*-plateau` / `landing-stall`, with guide-route success, start/end pad pitch vs target spacing, off-angle segment count, and the dominant rejection. Emitted under both shadow-OFF (default) and shadow-ON (`KCT_BOARD06_SHADOW=1`).

## Changes

- `cpp/src/coupled_pathfinder.cpp`: local rejection histogram, incremented at every pruning site; returned on all four exit paths.
- `cpp/include/types.hpp`: `CoupledRouteResult::rejections` (`unordered_map<string,int64_t>`).
- `cpp/src/bindings.cpp`: bind `rejections` (added `nanobind/stl/unordered_map.h`).
- `cpp/include/coupled_pathfinder.hpp`: doc update (histogram no longer Python-only).
- `cpp_backend.py`: surface `rejections` in the diagnostics dict.
- `diffpair_routing.py`: populate `last_rejections` + `last_coupled_backend` on the C++ path; `dominant_rejection`, `classify_coupled_pair_outcome`, `_count_off_angle_segments`, `CoupledPairReport`; fix the `[coupled-timing]` print; emit `[coupled-pair-report]`; capture the shadow decline sub-reason in `_shadow_route_pair` (no control-flow change).
- `tests/test_diffpair_coupled_instrumentation_4459.py`: 17 new tests.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `[coupled-timing]` no longer prints categorically-`None` `best_state`; C++ path reports true `best_progress` + dominant reason | ✅ | `test_coupled_timing_kills_best_state_none_red_herring` asserts `best_state=None` absent, `backend=cpp`, `best_state=n/a (cpp)`, `dominant_rejection=…` present |
| `last_rejections` non-empty on the C++ path (histogram wired), verified by a unit test on a small joint search | ✅ | `test_cpp_path_populates_rejection_histogram_on_budget_exit` + `…reports_corridor_rejections_inside_tight_corridor` |
| Per-pair report for all pairs classifying into the taxonomy, shadow-OFF and shadow-ON | ✅ | `[coupled-pair-report]` emitted per spec; `classify_coupled_pair_outcome` covers all 5 classes incl. shadow overlap/blockage; report tests + board-06 suite |
| No change to routed geometry or pass/fail; existing router tests green | ✅ | C++/Python parity suite, shadow, corridor, npad, phase-b, budget-exit, board-06 all pass |

## Test Plan

- `uv run kct build-native` (C++ backend rebuilt after `.cpp`/`.hpp` edits).
- New file: 17 passed. Coupled/diffpair regression suites (parity, shadow, corridor, floor, per-pair-timeout, backref-restore, integration, npad, phase-b, budget-exit, swap-via-reject, board-06): all green.
- `ruff check .` + `ruff format . --check` clean; mypy baseline gate reports **0 new errors** (net −1).

Closes #4459
Part of #4409