### PR TITLE
feat(router): emit an applyable placement delta from a stuck-net diagnosis

### DIFF
--- a/src/kicad_tools/router/placement_delta.py
+++ b/src/kicad_tools/router/placement_delta.py
@@ -1,0 +1,334 @@
+"""Classifier -> concrete placement-delta translator (issue #4466).
+
+Phase 1 of the board-07 router<->placement feedback epic (#3438).
+
+The stuck-net classifier (:mod:`kicad_tools.router.stuck_classifier`) already
+PROVES the fix for a placement-bound net: :func:`_build_recommendation` ranks a
+fix ladder (``DE_REVERSE_BUNDLE`` / ``REORDER_PINS`` / ``MOVE_PART`` / ...) and
+:func:`_resolve_bundle_orientation` measures which facing part is reversed.  But
+the ladder terminates at an *English sentence* -- nothing turns it into an
+applyable ``(ref, dx, dy, rotation)``.  This module is the missing translator.
+
+It is the "propose" half only: a **pure, read-only** function that maps one
+:class:`~kicad_tools.router.stuck_classifier.StuckNetDiagnosis` onto a single
+:class:`PlacementDelta` (JSON-serializable data).  It performs NO ``PCB``
+mutation and attempts NO re-route -- applying the delta and re-routing is
+Phase 2 (#4467).
+
+Mapping rules (driven off the *top-ranked* action, honoring the ladder's
+deliberate omissions -- e.g. a reversed bus never gets ``WIDEN_CHANNEL``):
+
+* ``DE_REVERSE_BUNDLE`` -> ``kind="rotate_180"`` on the reversed facing part
+  (:attr:`BundleOrientation.secondary_ref`), ``rotation_delta = 180.0``.  This
+  is the geometric realization of "flip the facing pad column so the bundle
+  stops self-crossing".
+* ``MOVE_PART`` -> ``kind="translate"``: ``target_ref`` is the crowded foreign
+  component nearest the stranded pad; ``(dx, dy)`` is a minimal bounded step
+  toward the widest open escape arc.
+* ``REORDER_PINS`` -> ``kind="reorder_pins"`` with rationale only (no geometry
+  in P1; an applicator needs a pad-remap that does not yet exist).
+* ``WIDEN_CHANNEL`` / ``ACCEPT_PLATEAU`` / no recommendation -> ``None`` (there
+  is no placement move to emit -- never synthesize one the ladder dropped).
+
+Generic: works for any board's ``PLACEMENT_BOUND`` / ``CONGESTION_SATURATED``
+diagnosis, not just board-07.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from kicad_tools.router.stuck_classifier import (
+    DEFAULT_CONGESTION_RADIUS_MM,
+    ESCAPE_SECTORS,
+    RecommendedAction,
+    StuckNetDiagnosis,
+    _foreign_obstructions,
+    _iter_board_pads,
+)
+
+if TYPE_CHECKING:
+    from kicad_tools.router.stuck_classifier import StuckClassifierResult
+    from kicad_tools.schema.pcb import PCB
+
+
+__all__ = [
+    "PlacementDelta",
+    "MAX_TRANSLATE_MM",
+    "delta_from_diagnosis",
+    "deltas_from_result",
+]
+
+
+# Bound on a single ``translate`` proposal.  The move is deliberately minimal --
+# a small nudge to open a lane, not a wholesale relocation -- so a Phase-2
+# applicator can probe cheaply and a human can eyeball it.  "A few mm" per the
+# #4466 design; the step magnitude equals this bound (minimal-first).
+MAX_TRANSLATE_MM = 2.0
+
+# Radius scanned around the stranded pad for the foreign obstructions that seed
+# the translate direction.  Reuses the classifier's congestion ring so the
+# delta agrees with the geometry that produced the MOVE_PART verdict.
+_TRANSLATE_RADIUS_MM = DEFAULT_CONGESTION_RADIUS_MM
+
+
+@dataclass
+class PlacementDelta:
+    """A concrete, applyable placement change proposed for one stuck net.
+
+    Data only -- emitting a ``PlacementDelta`` mutates nothing.  ``kind`` is one
+    of ``"translate"`` | ``"rotate_180"`` | ``"reorder_pins"``; the geometric
+    fields carry the move for the kinds that have one (``translate`` uses
+    ``dx``/``dy``; ``rotate_180`` uses ``rotation_delta``; ``reorder_pins``
+    carries rationale only).
+    """
+
+    net_name: str
+    target_ref: str
+    kind: str
+    dx: float = 0.0
+    dy: float = 0.0
+    rotation_delta: float = 0.0
+    source_action: str = ""
+    rationale: str = ""
+    confidence: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "net_name": self.net_name,
+            "target_ref": self.target_ref,
+            "kind": self.kind,
+            "dx": round(self.dx, 4),
+            "dy": round(self.dy, 4),
+            "rotation_delta": round(self.rotation_delta, 4),
+            "source_action": self.source_action,
+            "rationale": self.rationale,
+            "confidence": self.confidence,
+        }
+
+
+def delta_from_diagnosis(pcb: PCB, diag: StuckNetDiagnosis) -> PlacementDelta | None:
+    """Translate one classifier diagnosis into a concrete placement delta.
+
+    Returns ``None`` when the top-ranked action is not an applyable placement
+    move (``WIDEN_CHANNEL`` / ``ACCEPT_PLATEAU`` / empty ladder), or when the
+    geometry needed to realize the move is unavailable (e.g. a reversed-bundle
+    verdict whose facing part could not be resolved).  Pure/read-only: ``pcb``
+    is never mutated.
+    """
+    if not diag.recommendation:
+        return None
+
+    top = diag.recommendation[0]
+    action = top.action
+    confidence = top.confidence.value
+    rationale = top.rationale
+
+    if action is RecommendedAction.DE_REVERSE_BUNDLE:
+        return _rotate_180_delta(diag, confidence, rationale)
+    if action is RecommendedAction.MOVE_PART:
+        return _translate_delta(pcb, diag, confidence, rationale)
+    if action is RecommendedAction.REORDER_PINS:
+        return _reorder_pins_delta(diag, confidence, rationale)
+
+    # WIDEN_CHANNEL / ACCEPT_PLATEAU (or anything else): no placement move.
+    return None
+
+
+def deltas_from_result(pcb: PCB, result: StuckClassifierResult) -> list[PlacementDelta]:
+    """Emit a ``PlacementDelta`` for every diagnosis that yields one.
+
+    Convenience wrapper over :func:`delta_from_diagnosis`; diagnoses that map to
+    ``None`` (non-placement top action) are simply skipped.
+    """
+    out: list[PlacementDelta] = []
+    for diag in result.diagnoses:
+        delta = delta_from_diagnosis(pcb, diag)
+        if delta is not None:
+            out.append(delta)
+    return out
+
+
+# --- per-kind builders ------------------------------------------------------
+
+
+def _rotate_180_delta(
+    diag: StuckNetDiagnosis, confidence: str, rationale: str
+) -> PlacementDelta | None:
+    """DE_REVERSE_BUNDLE -> flip the reversed facing part 180 degrees.
+
+    The reversed part is the bundle's ``secondary_ref`` (the classifier resolves
+    the two facing rows and reports ``primary_ref`` / ``secondary_ref`` with the
+    ``secondary`` being the one whose pad column runs opposite the primary).  A
+    180-degree rotation is the geometric realization of "flip the facing pad
+    column" so the bundle stops self-crossing.  Returns ``None`` when the facing
+    part could not be resolved (no applyable target).
+    """
+    orientation = diag.bundle_orientation
+    if orientation is None or not orientation.secondary_ref:
+        return None
+    return PlacementDelta(
+        net_name=diag.net_name,
+        target_ref=orientation.secondary_ref,
+        kind="rotate_180",
+        rotation_delta=180.0,
+        source_action=RecommendedAction.DE_REVERSE_BUNDLE.value,
+        rationale=rationale,
+        confidence=confidence,
+    )
+
+
+def _reorder_pins_delta(
+    diag: StuckNetDiagnosis, confidence: str, rationale: str
+) -> PlacementDelta | None:
+    """REORDER_PINS -> a rationale-only delta (no geometry in Phase 1).
+
+    A pad-level re-map applicator does not exist yet, so this carries no
+    ``(dx, dy, rotation)`` -- it names the part whose pin order should change
+    (the reversed facing part when known) and defers the mechanics to a future
+    phase.
+    """
+    orientation = diag.bundle_orientation
+    target_ref = orientation.secondary_ref if orientation else ""
+    return PlacementDelta(
+        net_name=diag.net_name,
+        target_ref=target_ref,
+        kind="reorder_pins",
+        source_action=RecommendedAction.REORDER_PINS.value,
+        rationale=rationale,
+        confidence=confidence,
+    )
+
+
+def _translate_delta(
+    pcb: PCB, diag: StuckNetDiagnosis, confidence: str, rationale: str
+) -> PlacementDelta | None:
+    """MOVE_PART -> a minimal bounded translate of the crowding foreign part.
+
+    ``target_ref`` is the foreign component whose pad sits nearest the stranded
+    pad (the part physically walling the escape); ``(dx, dy)`` is a step of at
+    most :data:`MAX_TRANSLATE_MM` from the foreign-congestion centroid toward
+    the widest open escape arc.  Returns ``None`` when there is no foreign
+    obstruction to move away from, or no resolvable direction / target.
+    """
+    positions = _stranded_pad_positions(pcb, diag.net_name)
+    if not positions:
+        return None
+
+    # The densest stranded pad drives the move (it is the most walled-in).
+    best_point: tuple[float, float] | None = None
+    best_obstr: list[tuple[float, float, float, int]] = []
+    best_count = -1
+    for pt in positions:
+        obstr = _foreign_obstructions(pcb, diag.net_number, pt, _TRANSLATE_RADIUS_MM)
+        if len(obstr) > best_count:
+            best_count = len(obstr)
+            best_point = pt
+            best_obstr = obstr
+    if best_point is None or not best_obstr:
+        return None
+
+    direction = _widest_open_arc_direction(best_obstr, best_point, ESCAPE_SECTORS)
+    if direction is None:
+        return None
+
+    target_ref = _nearest_foreign_component(pcb, diag.net_number, best_point)
+    if not target_ref:
+        return None
+
+    dx = MAX_TRANSLATE_MM * math.cos(direction)
+    dy = MAX_TRANSLATE_MM * math.sin(direction)
+    return PlacementDelta(
+        net_name=diag.net_name,
+        target_ref=target_ref,
+        kind="translate",
+        dx=dx,
+        dy=dy,
+        source_action=RecommendedAction.MOVE_PART.value,
+        rationale=rationale,
+        confidence=confidence,
+    )
+
+
+# --- geometry helpers -------------------------------------------------------
+
+
+def _stranded_pad_positions(pcb: PCB, net_name: str) -> list[tuple[float, float]]:
+    """Board-frame positions of ``net_name``'s unconnected pads (read-only)."""
+    from kicad_tools.analysis.net_status import NetStatusAnalyzer
+
+    analysis = NetStatusAnalyzer(pcb).analyze()
+    status = analysis.get_net(net_name)
+    if status is None:
+        return []
+    return [p.position for p in status.unconnected_pads]
+
+
+def _nearest_foreign_component(pcb: PCB, target_net: int, point: tuple[float, float]) -> str:
+    """Reference of the foreign component whose pad is nearest ``point``.
+
+    "Foreign" == any net other than ``target_net``.  Ties break on the smaller
+    distance; the scan is deterministic in footprint order.  Returns ``""`` when
+    the board has no foreign pad at all.
+    """
+    px, py = point
+    best_ref = ""
+    best_dist = math.inf
+    for ref, net_number, (bx, by), _size in _iter_board_pads(pcb):
+        if net_number == target_net:
+            continue
+        d = math.hypot(bx - px, by - py)
+        if d < best_dist:
+            best_dist = d
+            best_ref = ref
+    return best_ref
+
+
+def _widest_open_arc_direction(
+    obstructions: list[tuple[float, float, float, int]],
+    point: tuple[float, float],
+    sectors: int,
+) -> float | None:
+    """Center angle (radians) of the widest open escape arc around ``point``.
+
+    Mirrors :func:`~kicad_tools.router.stuck_classifier._widest_open_arc` but
+    returns the *direction* of the widest open run rather than its width.  Every
+    obstruction blocks its angular sector; the widest contiguous run of open
+    sectors (wrapping around the circle) yields the escape direction.  Returns
+    ``0.0`` when nothing blocks (pick +x) and ``None`` when every sector is
+    blocked (no lane -> caller declines to emit a move).
+    """
+    px, py = point
+    blocked = [False] * sectors
+    for ox, oy, _d, _net in obstructions:
+        ang = math.atan2(oy - py, ox - px)
+        idx = int((ang + math.pi) / (2 * math.pi) * sectors) % sectors
+        blocked[idx] = True
+
+    if not any(blocked):
+        return 0.0
+    if all(blocked):
+        return None
+
+    # Widest run of open (False) sectors over the doubled circular array.
+    best_len = 0
+    best_start = 0
+    run = 0
+    run_start = 0
+    for i in range(2 * sectors):
+        if blocked[i % sectors]:
+            run = 0
+            run_start = i + 1
+        else:
+            if run == 0:
+                run_start = i
+            run += 1
+            if run > best_len:
+                best_len = run
+                best_start = run_start
+
+    center_idx = best_start + best_len / 2.0
+    # Invert the sector bucketing: idx = (ang + pi) / (2pi) * sectors.
+    return (center_idx / sectors) * 2 * math.pi - math.pi

--- a/src/kicad_tools/router/stuck_classifier.py
+++ b/src/kicad_tools/router/stuck_classifier.py
@@ -345,6 +345,13 @@ class StuckNetDiagnosis:
     # is warranted (PLACEMENT_BOUND / CONGESTION_SATURATED).
     topology: str = ""
     recommendation: list[RankedAction] = field(default_factory=list)
+    # Issue #4466 (Phase 1 of #3438): the measured facing-row orientation that
+    # fed the ladder, surfaced so the classifier->delta translator
+    # (:mod:`kicad_tools.router.placement_delta`) can name the reversed part
+    # (``secondary_ref``) without recomputing it.  Populated only for the two
+    # bundle topologies (SELF_CROSSING / CO_ORIENTED); ``None`` otherwise.  Kept
+    # OUT of :meth:`to_dict` so existing JSON output paths are byte-unchanged.
+    bundle_orientation: BundleOrientation | None = None
 
     @property
     def classification_value(self) -> str:
@@ -944,6 +951,9 @@ def classify_stuck_nets_from_pcb(
                     )
                 if orientation.verdict == ORIENT_CO_ORIENTED:
                     diag.topology = TOPOLOGY_CO_ORIENTED
+            # Surface the measured orientation (issue #4466) so the delta
+            # translator need not recompute it.  ``None`` for foreign-cluster.
+            diag.bundle_orientation = orientation
             confidence = _grade_confidence(target_group)
             diag.recommendation = _build_recommendation(
                 classification=diag.classification,

--- a/tests/router/test_placement_delta.py
+++ b/tests/router/test_placement_delta.py
@@ -1,0 +1,402 @@
+"""Unit tests for the classifier -> placement-delta translator (issue #4466).
+
+Phase 1 of the board-07 router<->placement feedback epic (#3438).  The
+translator is a pure, read-only function: it maps one classifier
+``StuckNetDiagnosis`` onto a single applyable ``PlacementDelta`` (or ``None``),
+driven off the top-ranked action and honoring the ladder's deliberate
+omissions.  These tests exercise:
+
+* the mapping table directly (constructed diagnoses -- no PCB), and
+* the end-to-end path on synthetic boards and the committed board-07 artifact.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.router.placement_delta import (
+    MAX_TRANSLATE_MM,
+    PlacementDelta,
+    delta_from_diagnosis,
+    deltas_from_result,
+)
+from kicad_tools.router.stuck_classifier import (
+    BundleOrientation,
+    Confidence,
+    RankedAction,
+    RecommendedAction,
+    StuckClass,
+    StuckNetDiagnosis,
+    classify_stuck_nets_from_pcb,
+)
+from kicad_tools.schema.pcb import PCB
+
+# ---------------------------------------------------------------------------
+# Synthetic boards (self-contained; mirror the stuck-classifier fixtures)
+# ---------------------------------------------------------------------------
+
+_HEADER = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+"""
+
+
+def _same_group_ring(cx: float, cy: float, radius: float, count: int, gap: int) -> str:
+    """`count` DQ0 pads ringing (cx, cy) -- same-match-group siblings of DQ2."""
+    import math
+
+    out = []
+    slots = count + gap
+    for i in range(count):
+        ang = 2 * math.pi * i / slots
+        px = cx + radius * math.cos(ang)
+        py = cy + radius * math.sin(ang)
+        out.append(
+            f'  (footprint "dq0_{i}" (layer "F.Cu") (at {px:.4f} {py:.4f})\n'
+            f'    (property "Reference" "S{i}")\n'
+            f'    (pad "1" smd circle (at 0 0) (size 0.2 0.2) '
+            f'(layers "F.Cu") (net 2 "DQ0"))\n'
+            f"  )\n"
+        )
+    return "".join(out)
+
+
+def _facing_rows_bundle_board(*, reversed_rows: bool) -> str:
+    """A DDR_DATA bundle whose facing columns UA/UB are co-oriented or reversed.
+
+    The stranded DQ2 pad is crowded by a dense ring of its own DDR siblings, so
+    the net classifies PLACEMENT_BOUND with a self-crossing topology; the two
+    multi-net columns UA/UB are read as the facing rows by the orientation
+    resolver (co-oriented when ``reversed_rows`` is False, fully reversed when
+    True).  ``secondary_ref`` resolves to UB (count tie broken on reference asc).
+    """
+    ua_order = ["DQ0", "DQ1", "DQ2"]
+    ub_order = list(reversed(ua_order)) if reversed_rows else ua_order
+    net_num = {"DQ2": 1, "DQ0": 2, "DQ1": 3}
+
+    def _column(ref: str, cx: float, order: list[str]) -> str:
+        pads = "".join(
+            f'    (pad "{i + 1}" smd circle (at 0 {float(i - 1):.1f}) (size 0.2 0.2) '
+            f'(layers "F.Cu") (net {net_num[name]} "{name}"))\n'
+            for i, name in enumerate(order)
+        )
+        return (
+            f'  (footprint "col_{ref}" (layer "F.Cu") (at {cx:.1f} 50)\n'
+            f'    (property "Reference" "{ref}")\n' + pads + "  )\n"
+        )
+
+    return _HEADER + (
+        '  (net 0 "")\n'
+        '  (net 1 "DQ2")\n'
+        '  (net 2 "DQ0")\n'
+        '  (net 3 "DQ1")\n'
+        '  (footprint "R_0402" (layer "F.Cu") (at 10 10)\n'
+        '    (property "Reference" "R1")\n'
+        '    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "DQ2"))\n'
+        '    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "DQ2"))\n'
+        "  )\n"
+        '  (footprint "U_SOT" (layer "F.Cu") (at 80 80)\n'
+        '    (property "Reference" "U1")\n'
+        '    (pad "1" smd circle (at 0 0) (size 0.2 0.2) (layers "F.Cu") (net 1 "DQ2"))\n'
+        "  )\n"
+        + _same_group_ring(80, 80, 1.5, count=22, gap=2)
+        + _column("UA", 30.0, ua_order)
+        + _column("UB", 50.0, ub_order)
+        + '  (segment (start 9.5 10) (end 10.5 10) (width 0.25) (layer "F.Cu") (net 1))\n'
+        ")\n"
+    )
+
+
+def _foreign_ring(cx: float, cy: float, radius: float, count: int, gap: int) -> str:
+    """`count` distinct single-pad FOREIGN nets ringing (cx, cy) with an open arc."""
+    import math
+
+    out = []
+    slots = count + gap
+    for i in range(count):
+        ang = 2 * math.pi * i / slots
+        px = cx + radius * math.cos(ang)
+        py = cy + radius * math.sin(ang)
+        net = 100 + i
+        out.append(
+            f'  (net {net} "OBS{i}")\n'
+            f'  (footprint "obs{i}" (layer "F.Cu") (at {px:.4f} {py:.4f})\n'
+            f'    (property "Reference" "O{i}")\n'
+            f'    (pad "1" smd circle (at 0 0) (size 0.2 0.2) '
+            f'(layers "F.Cu") (net {net} "OBS{i}"))\n'
+            f"  )\n"
+        )
+    return "".join(out)
+
+
+def _foreign_cluster_board() -> str:
+    """A stranded TGT pad walled by genuinely foreign copper -> MOVE_PART."""
+    return _HEADER + (
+        '  (net 0 "")\n'
+        '  (net 1 "TGT")\n'
+        '  (footprint "R_0402" (layer "F.Cu") (at 10 10)\n'
+        '    (property "Reference" "R1")\n'
+        '    (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "TGT"))\n'
+        '    (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "TGT"))\n'
+        "  )\n"
+        '  (footprint "U_SOT" (layer "F.Cu") (at 80 80)\n'
+        '    (property "Reference" "U1")\n'
+        '    (pad "1" smd circle (at 0 0) (size 0.2 0.2) (layers "F.Cu") (net 1 "TGT"))\n'
+        "  )\n"
+        + _foreign_ring(80, 80, 1.5, count=10, gap=4)
+        + '  (segment (start 9.5 10) (end 10.5 10) (width 0.25) (layer "F.Cu") (net 1))\n'
+        ")\n"
+    )
+
+
+def _load(tmp_path: Path, text: str) -> PCB:
+    p = tmp_path / "board.kicad_pcb"
+    p.write_text(text)
+    return PCB.load(str(p))
+
+
+def _diag(pcb: PCB, net_name: str) -> StuckNetDiagnosis:
+    result = classify_stuck_nets_from_pcb(pcb)
+    return next(d for d in result.diagnoses if d.net_name == net_name)
+
+
+# ---------------------------------------------------------------------------
+# Mapping-table unit tests (constructed diagnoses; PCB unused on these paths)
+# ---------------------------------------------------------------------------
+
+
+def _make_diag(net_name: str, actions, **kw) -> StuckNetDiagnosis:
+    return StuckNetDiagnosis(
+        net_name=net_name,
+        net_number=1,
+        classification=StuckClass.PLACEMENT_BOUND,
+        unconnected_pads=["U1-1"],
+        recommendation=[
+            RankedAction(a, f"rationale for {a.value}", Confidence.MEDIUM) for a in actions
+        ],
+        **kw,
+    )
+
+
+class TestMappingTable:
+    def test_de_reverse_maps_to_rotate_180_on_secondary_ref(self):
+        diag = _make_diag(
+            "DQ2",
+            [RecommendedAction.DE_REVERSE_BUNDLE, RecommendedAction.ACCEPT_PLATEAU],
+            bundle_orientation=BundleOrientation(
+                verdict="reversed",
+                inverted_pairs=3,
+                total_pairs=3,
+                inversion_fraction=1.0,
+                primary_ref="UA",
+                secondary_ref="UB",
+            ),
+        )
+        delta = delta_from_diagnosis(None, diag)  # pcb unused for rotate_180
+        assert delta is not None
+        assert delta.kind == "rotate_180"
+        assert delta.target_ref == "UB"
+        assert delta.rotation_delta == 180.0
+        assert delta.dx == 0.0 and delta.dy == 0.0
+        assert delta.source_action == "de_reverse_bundle"
+        assert delta.confidence == "medium"
+
+    def test_de_reverse_without_orientation_returns_none(self):
+        diag = _make_diag("DQ2", [RecommendedAction.DE_REVERSE_BUNDLE])
+        assert delta_from_diagnosis(None, diag) is None
+
+    def test_reorder_pins_maps_to_reorder_kind_rationale_only(self):
+        diag = _make_diag(
+            "DQ2",
+            [RecommendedAction.REORDER_PINS],
+            bundle_orientation=BundleOrientation(
+                verdict="reversed", primary_ref="UA", secondary_ref="UB"
+            ),
+        )
+        delta = delta_from_diagnosis(None, diag)
+        assert delta is not None
+        assert delta.kind == "reorder_pins"
+        assert delta.target_ref == "UB"
+        assert delta.dx == 0.0 and delta.dy == 0.0 and delta.rotation_delta == 0.0
+        assert delta.source_action == "reorder_pins"
+
+    def test_accept_plateau_top_returns_none(self):
+        diag = _make_diag("N", [RecommendedAction.ACCEPT_PLATEAU])
+        assert delta_from_diagnosis(None, diag) is None
+
+    def test_widen_channel_top_returns_none(self):
+        diag = _make_diag("N", [RecommendedAction.WIDEN_CHANNEL])
+        assert delta_from_diagnosis(None, diag) is None
+
+    def test_empty_recommendation_returns_none(self):
+        diag = _make_diag("N", [])
+        assert delta_from_diagnosis(None, diag) is None
+
+
+# ---------------------------------------------------------------------------
+# End-to-end tests on synthetic boards
+# ---------------------------------------------------------------------------
+
+
+class TestSyntheticBoards:
+    def test_reversed_bundle_emits_rotate_180_on_secondary(self, tmp_path: Path):
+        """AC (a): a reversed 3+ member facing-row bundle -> rotate_180 on the
+        secondary (reversed) facing part."""
+        pcb = _load(tmp_path, _facing_rows_bundle_board(reversed_rows=True))
+        diag = _diag(pcb, "DQ2")
+        assert diag.classification is StuckClass.PLACEMENT_BOUND
+        assert diag.topology == "self_crossing_bundle"
+        assert diag.bundle_orientation is not None
+        assert diag.bundle_orientation.verdict == "reversed"
+
+        delta = delta_from_diagnosis(pcb, diag)
+        assert delta is not None
+        assert delta.kind == "rotate_180"
+        assert delta.target_ref == diag.bundle_orientation.secondary_ref == "UB"
+        assert delta.rotation_delta == 180.0
+
+    def test_co_oriented_bundle_emits_translate_not_rotate(self, tmp_path: Path):
+        """AC (b): a co-oriented saturated bundle -> translate (NOT rotate --
+        de-reversing a co-oriented bundle would create crossings)."""
+        pcb = _load(tmp_path, _facing_rows_bundle_board(reversed_rows=False))
+        diag = _diag(pcb, "DQ2")
+        assert diag.topology == "co_oriented_bundle"
+        assert diag.recommendation[0].action is RecommendedAction.MOVE_PART
+
+        delta = delta_from_diagnosis(pcb, diag)
+        assert delta is not None
+        assert delta.kind == "translate"
+        assert delta.rotation_delta == 0.0
+        assert (delta.dx, delta.dy) != (0.0, 0.0)
+
+    def test_foreign_cluster_emits_translate(self, tmp_path: Path):
+        """AC (c): a foreign-cluster PLACEMENT_BOUND -> translate."""
+        pcb = _load(tmp_path, _foreign_cluster_board())
+        diag = _diag(pcb, "TGT")
+        assert diag.classification is StuckClass.PLACEMENT_BOUND
+        assert diag.topology == "foreign_cluster"
+
+        delta = delta_from_diagnosis(pcb, diag)
+        assert delta is not None
+        assert delta.kind == "translate"
+        assert delta.target_ref  # a concrete crowding component was named
+        assert (delta.dx, delta.dy) != (0.0, 0.0)
+
+    def test_translate_step_is_bounded(self, tmp_path: Path):
+        """The translate magnitude never exceeds the minimal bound."""
+        import math
+
+        pcb = _load(tmp_path, _foreign_cluster_board())
+        delta = delta_from_diagnosis(pcb, _diag(pcb, "TGT"))
+        assert delta is not None
+        assert math.hypot(delta.dx, delta.dy) <= MAX_TRANSLATE_MM + 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Serialization + purity
+# ---------------------------------------------------------------------------
+
+
+class TestSerializationAndPurity:
+    def test_to_dict_is_json_serializable(self, tmp_path: Path):
+        pcb = _load(tmp_path, _facing_rows_bundle_board(reversed_rows=True))
+        delta = delta_from_diagnosis(pcb, _diag(pcb, "DQ2"))
+        assert delta is not None
+        blob = json.dumps(delta.to_dict())  # must not raise
+        loaded = json.loads(blob)
+        assert loaded["kind"] == "rotate_180"
+        assert loaded["target_ref"] == "UB"
+        assert set(loaded.keys()) == {
+            "net_name",
+            "target_ref",
+            "kind",
+            "dx",
+            "dy",
+            "rotation_delta",
+            "source_action",
+            "rationale",
+            "confidence",
+        }
+
+    def test_delta_from_diagnosis_does_not_mutate_pcb(self, tmp_path: Path):
+        pcb = _load(tmp_path, _foreign_cluster_board())
+        before = (len(pcb.footprints), len(pcb.segments), len(pcb.vias))
+        fp_positions_before = [fp.position for fp in pcb.footprints]
+        delta_from_diagnosis(pcb, _diag(pcb, "TGT"))
+        after = (len(pcb.footprints), len(pcb.segments), len(pcb.vias))
+        assert before == after
+        assert [fp.position for fp in pcb.footprints] == fp_positions_before
+
+
+# ---------------------------------------------------------------------------
+# Committed board-07 acceptance evidence (issue #4466 primary AC)
+# ---------------------------------------------------------------------------
+
+_BOARD07_ARTIFACT = (
+    Path(__file__).resolve().parents[2]
+    / "boards"
+    / "07-matchgroup-test"
+    / "output"
+    / "matchgroup_test_routed.kicad_pcb"
+)
+
+
+@pytest.mark.skipif(
+    not _BOARD07_ARTIFACT.exists(), reason="board-07 committed artifact not present"
+)
+class TestBoard07:
+    @pytest.fixture(scope="class")
+    def pcb(self) -> PCB:
+        return PCB.load(str(_BOARD07_ARTIFACT))
+
+    def test_ddr_self_crossing_nets_emit_rotate_180(self, pcb: PCB):
+        """The reversed DDR byte (DQ3/DQ4, inversion_fraction ~= 1.0) each emit a
+        rotate_180 targeting the reversed facing QFN."""
+        result = classify_stuck_nets_from_pcb(pcb)
+        ddr = [
+            d
+            for d in result.diagnoses
+            if d.match_group == "DDR_DATA" and d.topology == "self_crossing_bundle"
+        ]
+        assert ddr, "expected reversed DDR nets on the board-07 artifact"
+        for diag in ddr:
+            assert diag.bundle_orientation is not None
+            assert diag.bundle_orientation.verdict == "reversed"
+            assert diag.bundle_orientation.inversion_fraction == pytest.approx(1.0)
+            delta = delta_from_diagnosis(pcb, diag)
+            assert delta is not None
+            assert delta.kind == "rotate_180"
+            assert delta.rotation_delta == 180.0
+            assert delta.target_ref == diag.bundle_orientation.secondary_ref
+
+    def test_tmds_co_oriented_lanes_emit_translate(self, pcb: PCB):
+        """The co-oriented TMDS lanes emit translate, never rotate_180."""
+        result = classify_stuck_nets_from_pcb(pcb)
+        tmds = [d for d in result.diagnoses if d.net_name.startswith("TMDS_")]
+        assert tmds, "expected stuck TMDS nets on the board-07 artifact"
+        for diag in tmds:
+            assert diag.topology == "co_oriented_bundle"
+            delta = delta_from_diagnosis(pcb, diag)
+            assert delta is not None
+            assert delta.kind == "translate"
+            assert delta.rotation_delta == 0.0
+
+    def test_deltas_from_result_covers_all_placement_actions(self, pcb: PCB):
+        """Every diagnosis whose top action is MOVE_PART/DE_REVERSE_BUNDLE yields
+        a delta; the aggregate emits both kinds and nothing else non-null."""
+        result = classify_stuck_nets_from_pcb(pcb)
+        deltas = deltas_from_result(pcb, result)
+        kinds = {d.kind for d in deltas}
+        assert "rotate_180" in kinds
+        assert "translate" in kinds
+        assert all(isinstance(d, PlacementDelta) for d in deltas)
+        # JSON round-trips for the whole batch.
+        json.dumps([d.to_dict() for d in deltas])


### PR DESCRIPTION
## Summary

The stuck-net classifier already PROVES a placement fix (`_build_recommendation` ranks a `DE_REVERSE_BUNDLE` / `REORDER_PINS` / `MOVE_PART` ladder, `_resolve_bundle_orientation` measures which facing part is reversed) — but the ladder terminated at an English sentence. Nothing turned it into an applyable `(ref, dx, dy, rotation)`.

This adds the missing translator: a **pure, read-only** function mapping one `StuckNetDiagnosis` to a single JSON-serializable `PlacementDelta`. This is Phase 1 (**EMIT only**) of the router↔placement feedback epic (#3438); apply + re-route is Phase 2 (#4467).

## Changes

- **NEW `src/kicad_tools/router/placement_delta.py`** — `PlacementDelta` dataclass + `delta_from_diagnosis(pcb, diag)` (and a `deltas_from_result` convenience wrapper). Mapping, driven off the **top-ranked** action and honoring the ladder's deliberate omissions:
  - `DE_REVERSE_BUNDLE` → `rotate_180` on the reversed facing part (`BundleOrientation.secondary_ref`), `rotation_delta=180`
  - `MOVE_PART` → `translate`: `target_ref` = nearest crowding foreign component, `(dx,dy)` = minimal bounded step (≤ `MAX_TRANSLATE_MM`) toward the widest open escape arc
  - `REORDER_PINS` → `reorder_pins` (rationale only; no geometry in Phase 1)
  - `WIDEN_CHANNEL` / `ACCEPT_PLATEAU` / empty ladder → `None`
- **`src/kicad_tools/router/stuck_classifier.py`** — surface the measured `BundleOrientation` on `StuckNetDiagnosis.bundle_orientation` so the translator names the reversed part without recomputing it. Kept **out of `to_dict()`** so existing JSON/CLI (`net-status --why`) output is byte-unchanged.
- **NEW `tests/router/test_placement_delta.py`** — mapping-table unit tests, synthetic-board integration tests, serialization/purity tests, and board-07 artifact acceptance.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Delta for every PLACEMENT_BOUND/CONGESTION_SATURATED whose top action is MOVE_PART/DE_REVERSE_BUNDLE; None for ACCEPT_PLATEAU/empty | ✅ | `TestMappingTable` + `deltas_from_result` |
| Board-07: 3 self-crossing DDR nets (verdict=reversed, inversion_fraction≈1.0) emit `rotate_180` on the reversed QFN | ✅ | `TestBoard07::test_ddr_self_crossing_nets_emit_rotate_180` — DQ3/DQ4 emit rotate_180 targeting `U2` (secondary_ref, 28/28 inversions) |
| Board-07: co-oriented TMDS lanes emit `translate` (NOT rotate) | ✅ | `TestBoard07::test_tmds_co_oriented_lanes_emit_translate` — TMDS_D0_N/TMDS_D1_N → translate |
| Pure/read-only, no PCB mutation; `to_dict()` JSON-serializable | ✅ | `TestSerializationAndPurity` |
| Unit tests: reversed bundle→rotate_180; co-oriented→translate; foreign-cluster→translate; ACCEPT_PLATEAU→None | ✅ | `TestSyntheticBoards` + `TestMappingTable` |
| No behavior change to existing classifier output paths | ✅ | `to_dict()` untouched; `test_stuck_classifier.py` (21) and `test_net_status_cmd.py` (18) pass |

## Test Plan

- `uv run pytest tests/router/test_placement_delta.py` → 15 passed
- `uv run pytest tests/router/test_stuck_classifier.py` → 21 passed (no regression)
- `uv run pytest tests/test_net_status_cmd.py` → 18 passed (`--why` path unchanged)
- `uv run ruff check` / `ruff format --check` → clean
- mypy baseline gate (`scripts/ci/check_mypy_baseline.py`) → OK, no new type errors

Note on the classifier vs. issue AC: on the *current* committed board-07 artifact the reversed DDR set is DQ3/DQ4 (2, plus a foreign-cluster MIPI net → translate) rather than the 3 quoted in the issue body; the artifact evolved since the issue was filed. The GENERIC distinction the issue targets — reversed→`rotate_180`, co-oriented→`translate` — is honored for every net.

Closes #4466
Part of #3438