### PR TITLE
feat(drc): grid-independent different-net short verifier + repair post-pass

### DIFF
--- a/boards/05-bldc-motor-controller/design.py
+++ b/boards/05-bldc-motor-controller/design.py
@@ -3229,6 +3229,84 @@ def stitch_pcb(routed_path: Path) -> bool:
     return True
 
 
+def repair_shorts_in_routed_pcb(routed_path: Path) -> int:
+    """Verify + repair grid-independent different-net copper shorts (Issue #4470).
+
+    board-05 routes on ``--allow-unsafe-grid`` (a 0.1mm grid coarser than
+    ``clearance/2`` = 0.075mm) because the memory-safe 0.05mm grid reaches
+    fewer nets.  At that resolution the C++ A* occupancy model cannot
+    represent sub-cell clearance, so two different-net vias/segments can
+    quantize into geometrically-overlapping world positions that pass
+    grid-occupancy yet fail geometric DRC.  A fresh regen therefore emitted
+    real ``shorting_items`` under ``kicad-cli pcb drc --refill-zones`` (a via
+    shorting NRST/OSC_IN on In2.Cu and a via shorting PWM_CH/OSC_OUT on
+    B.Cu) that the router's coarse occupancy model was structurally blind
+    to.
+
+    This step runs the grid-independent geometric verifier
+    (:func:`kicad_tools.drc.different_net_short.find_different_net_shorts`)
+    over the emitted copper and then relocates each offending via with the
+    clearance-safe candidate-ladder engine
+    (:func:`kicad_tools.drc.different_net_short.repair_different_net_shorts`,
+    built on the #4408 hole-to-hole relocation template).  A relocation
+    target is accepted only when it clears every foreign via/segment/pad by
+    the manufacturer clearance, so the move eliminates the short without
+    introducing a new one; a boxed-in via is left in place and reported.
+
+    Ordering (critical): this must run **after** routing / rescue / stitch
+    (so it sees all placed copper -- signal traces, escape/rescue vias, and
+    the pour stitch vias) and **before** :func:`fill_zones_in_routed_pcb`
+    (so the subsequent zone re-fill and the final DRC measure the repaired
+    geometry).
+
+    This step never changes the script's exit code directly (a residual
+    short surfaces through the authoritative ``kicad-cli pcb drc
+    --refill-zones`` gate in :func:`main`).  Returns the number of vias
+    relocated.
+    """
+    from kicad_tools.drc.different_net_short import (
+        find_different_net_shorts,
+        repair_different_net_shorts,
+    )
+    from kicad_tools.manufacturers import get_profile
+    from kicad_tools.schema.pcb import PCB
+
+    print("\n" + "=" * 60)
+    print("Repairing different-net copper shorts (Issue #4470)...")
+    print("=" * 60)
+
+    pcb = PCB.load(routed_path)
+    before = find_different_net_shorts(pcb)
+    if not before:
+        print("\n   No different-net copper shorts detected (grid-independent verifier).")
+        return 0
+
+    print(f"\n1. Detected {len(before)} different-net short(s):")
+    for s in before:
+        print(f"   {s.describe()}")
+
+    rules = get_profile("jlcpcb-tier1").get_design_rules()
+    result = repair_different_net_shorts(pcb, rules)
+
+    print("\n2. Repair:")
+    for line in result.summary().split("\n"):
+        print(f"   {line}")
+
+    if result.changed:
+        pcb.save(routed_path)
+
+    remaining = find_different_net_shorts(pcb)
+    if remaining:
+        print(
+            f"\n   WARNING: {len(remaining)} different-net short(s) remain after repair "
+            "(boxed-in or segment-only) -- see the kicad-cli DRC gate below."
+        )
+    else:
+        print("\n   SUCCESS: no different-net shorts remain.")
+
+    return len(result.moved)
+
+
 def fill_zones_in_routed_pcb(routed_path: Path) -> int:
     """Fill copper zones in the routed PCB via ``kicad-cli``.
 
@@ -3508,6 +3586,18 @@ def main() -> int:
         # vias into the plane).  See stitch_pcb() for the full rationale.
         if routed_path.exists():
             stitch_pcb(routed_path)
+
+        # Step 7a: Verify + repair grid-independent different-net copper
+        # shorts (Issue #4470).  The --allow-unsafe-grid route can quantize
+        # two different-net vias/segments into geometrically-overlapping
+        # positions that pass grid-occupancy but fail geometric DRC (real
+        # shorting_items).  This grid-independent post-pass geometrically
+        # detects those overlaps and relocates the offending via
+        # clearance-safely.  Must run AFTER routing/rescue/stitch (all copper
+        # placed) and BEFORE fill_zones_in_routed_pcb (so the re-fill + DRC
+        # measure the repaired geometry).
+        if routed_path.exists():
+            repair_shorts_in_routed_pcb(routed_path)
 
         # Step 7: Repair DRC clearance violations introduced by routing.
         # Issue #3096: tried calling fix-drc as a separate subprocess

--- a/src/kicad_tools/drc/different_net_short.py
+++ b/src/kicad_tools/drc/different_net_short.py
@@ -1,0 +1,580 @@
+"""Grid-independent different-net copper-short verifier + repair post-pass.
+
+Issue #4470 (board-05 Phase 2) -- a *grid-independent* guarantee that the
+copper the router emitted is free of different-net shorts.
+
+Motivation
+----------
+board-05 (a dense fine-pitch BLDC controller) routes on
+``--allow-unsafe-grid``: its auto-selected 0.1 mm grid is coarser than
+``clearance / 2`` (0.075 mm) because the memory-safe 0.05 mm grid reaches
+fewer nets.  At that resolution the C++ A* **occupancy** model cannot
+represent sub-cell clearance, so two different-net vias/segments can
+quantize into geometrically-overlapping world positions that pass the
+grid-occupancy check yet fail geometric DRC.  A fresh regen therefore
+emits real ``shorting_items`` (``kicad-cli pcb drc --refill-zones``): a via
+shorting ``NRST``/``OSC_IN`` on ``In2.Cu`` and a via shorting
+``PWM_CH``/``OSC_OUT`` on ``B.Cu``.
+
+The router's world-coordinate clearance predicates
+(:mod:`kicad_tools.router.via_clearance`) already know how to measure
+edge-to-edge copper distance, but the router only ever consults them
+*within the coarse grid*.  This module **lifts that geometry into a
+post-route pass**: after all copper is placed it geometrically checks
+every emitted via + segment for different-net overlaps the grid missed,
+and relocates the offending via with the clearance-safe candidate-ladder
+engine shared with the #4408 hole-to-hole relocation pass.
+
+Two public entry points
+-----------------------
+* :func:`find_different_net_shorts` -- the grid-independent **verifier**.
+  Pure geometry over the placed copper; layer-aware (a via only conflicts
+  with copper on a layer its plated barrel actually spans).  Returns a
+  :class:`ShortItem` per different-net overlap.  With the default
+  ``clearance=0.0`` it flags only *actual* copper overlaps (the
+  ``shorting_items`` DRC class); a positive ``clearance`` additionally
+  flags sub-clearance near-misses.
+* :func:`repair_different_net_shorts` -- the **repair** post-pass.  For
+  every short that involves a via it relocates the via to a
+  clearance-safe location using the shared
+  :func:`kicad_tools.drc.relocate_drill_clearance._try_relocate` engine
+  (candidate ladder + connectivity stubs + a boxed-in "leave in place and
+  report" fallback).  Because the relocation target is accepted only when
+  it clears *all* foreign copper by the manufacturer clearance, moving the
+  via there necessarily eliminates the short without introducing a new one
+  -- an already-short-free board is never regressed.
+
+Scope note: the repair moves *vias* (a point object with an escape node to
+slide along).  A pure segment-vs-segment overlap has no via to relocate;
+it is detected and surfaced as ``unresolved`` rather than silently
+dropped.  On board-05 both shorts are via shorts, so via relocation covers
+them.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from kicad_tools.core.geometry import (
+    point_to_segment_distance,
+    segment_to_segment_distance,
+)
+
+if TYPE_CHECKING:
+    from kicad_tools.manufacturers.base import DesignRules
+    from kicad_tools.schema.pcb import PCB, Segment, Via
+
+# Only overlaps deeper than this (mm) count as a short.  Grid-quantization
+# overlaps on a coarse grid are ~0.025 mm+ (grid 0.1 vs clearance/2 0.075),
+# so a sub-micron floor rejects floating-point noise without missing a real
+# short.  Mirrors the epsilon convention in :mod:`router.via_clearance`.
+_EPS = 1e-4
+
+
+# ---------------------------------------------------------------------------
+# Copper-layer ordering (physical stack, NOT KiCad's internal layer numbers)
+# ---------------------------------------------------------------------------
+#
+# KiCad renumbers copper layers so ``layer.number`` is NOT the physical
+# stack order (a 4-layer board can carry In2.Cu=6, B.Cu=2).  The layer NAME
+# encodes the true order: ``F.Cu`` is the top, ``In{k}.Cu`` are the inner
+# layers in ascending ``k``, and ``B.Cu`` is the bottom.  We map a name to a
+# monotonic ordinal so a via's plated barrel span [start..end] can be tested
+# for overlap with a segment's single layer.
+_BOTTOM_ORDINAL = 10_000
+
+
+def _copper_ordinal(layer_name: str) -> int | None:
+    """Return a monotonic top->bottom ordinal for a copper layer name.
+
+    ``F.Cu`` -> 0, ``In{k}.Cu`` -> k, ``B.Cu`` -> a large sentinel so it
+    always sorts last.  Returns ``None`` for a non-copper layer name.
+    """
+    if layer_name == "F.Cu":
+        return 0
+    if layer_name == "B.Cu":
+        return _BOTTOM_ORDINAL
+    if layer_name.startswith("In") and layer_name.endswith(".Cu"):
+        try:
+            return int(layer_name[2:-3])
+        except ValueError:
+            return None
+    return None
+
+
+def _via_layer_span(via: Via) -> tuple[int, int]:
+    """Return the (top, bottom) copper ordinals a via's barrel spans.
+
+    A standard through-hole via lists ``("F.Cu", "B.Cu")`` and therefore
+    spans the whole stack; a blind/buried/micro via lists its true
+    endpoints.  A via with no parseable copper layers is treated as
+    spanning the full stack (conservative -- never misses a conflict).
+    """
+    ordinals = [o for name in via.layers if (o := _copper_ordinal(name)) is not None]
+    if not ordinals:
+        return (0, _BOTTOM_ORDINAL)
+    return (min(ordinals), max(ordinals))
+
+
+def _via_spans_layer(via: Via, layer_name: str) -> bool:
+    """True iff the via's plated barrel reaches ``layer_name``."""
+    ord_ = _copper_ordinal(layer_name)
+    if ord_ is None:
+        return False
+    lo, hi = _via_layer_span(via)
+    return lo <= ord_ <= hi
+
+
+def _via_spans_overlap(a: Via, b: Via) -> bool:
+    """True iff two vias share at least one copper layer."""
+    a_lo, a_hi = _via_layer_span(a)
+    b_lo, b_hi = _via_layer_span(b)
+    return max(a_lo, b_lo) <= min(a_hi, b_hi)
+
+
+# ---------------------------------------------------------------------------
+# Net identity (dialect-robust)
+# ---------------------------------------------------------------------------
+
+
+def _net_identity(pcb: PCB, net_number: int, net_name: str) -> tuple[object, str] | None:
+    """Return a ``(key, display_name)`` net identity, or ``None`` if unnetted.
+
+    Prefers the numeric net id (what routed copper always carries); falls
+    back to the name for KiCad-10 name-only ``(net "SDA")`` copper whose
+    numeric id parses as 0.  Returns ``None`` for genuinely unnetted copper
+    (net 0 with no name) so free-floating graphic copper never registers as
+    a short participant.
+    """
+    if net_number != 0:
+        name = net_name
+        if not name:
+            net = pcb._nets.get(net_number)
+            name = net.name if net is not None else str(net_number)
+        return (net_number, name)
+    if net_name:
+        return (net_name, net_name)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Verifier
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ShortItem:
+    """A geometric different-net copper overlap the grid model missed.
+
+    Attributes:
+        kind: ``"via-via"``, ``"via-segment"`` or ``"segment-segment"``.
+        net_a_name / net_b_name: The two shorted net names.
+        layer: The copper layer the conflict occurs on (``"?"`` when a via
+            barrel spans multiple candidate layers with a segment on a
+            single one it is the segment's layer; for via-via it is the
+            top shared layer).
+        x / y: Approximate world location of the overlap (mm).
+        gap: Edge-to-edge copper gap in mm (negative = overlap depth).
+    """
+
+    kind: str
+    net_a_name: str
+    net_b_name: str
+    layer: str
+    x: float
+    y: float
+    gap: float
+    # Movable via handles for the repair pass (not part of equality/repr).
+    via_a: Via | None = field(default=None, compare=False, repr=False)
+    via_b: Via | None = field(default=None, compare=False, repr=False)
+
+    @property
+    def net_pair(self) -> frozenset[str]:
+        """Order-independent {net_a, net_b} name pair."""
+        return frozenset({self.net_a_name, self.net_b_name})
+
+    def describe(self) -> str:
+        """Human-readable one-line description."""
+        return (
+            f"{self.kind} short {self.net_a_name}/{self.net_b_name} on {self.layer} "
+            f"at ({self.x:.3f}, {self.y:.3f}); gap {self.gap:.3f}mm"
+        )
+
+
+def _seg_bbox(seg: Segment) -> tuple[float, float, float, float]:
+    """Axis-aligned bounding box (minx, miny, maxx, maxy) of a segment core."""
+    (x1, y1), (x2, y2) = seg.start, seg.end
+    return (min(x1, x2), min(y1, y2), max(x1, x2), max(y1, y2))
+
+
+def find_different_net_shorts(
+    pcb: PCB,
+    *,
+    clearance: float = 0.0,
+) -> list[ShortItem]:
+    """Geometrically flag different-net copper overlaps the grid missed.
+
+    Checks every pair among the board's emitted vias + routed segments for
+    a different-net edge-to-edge gap below ``clearance`` (with the default
+    ``clearance=0.0`` this flags only *actual* copper overlaps -- the
+    ``shorting_items`` DRC class).  The check is layer-aware: a via
+    conflicts with a segment (or another via) only on a copper layer its
+    plated barrel actually spans, so a through-hole via on ``F.Cu`` copper
+    does not spuriously "short" an inner-layer trace of another net.
+
+    This is the grid-independent guarantee: unlike the router's coarse
+    grid-occupancy model, it operates on raw world coordinates, so it
+    catches sub-cell overlaps the occupancy model cannot represent.
+
+    Args:
+        pcb: The routed board to inspect (not mutated).
+        clearance: Minimum required edge-to-edge gap (mm).  ``0.0`` = flag
+            overlaps only; a positive value additionally flags sub-clearance
+            near-misses.
+
+    Returns:
+        One :class:`ShortItem` per different-net violation, deterministically
+        ordered.
+    """
+    threshold = clearance - _EPS
+    shorts: list[ShortItem] = []
+
+    vias = list(pcb.vias)
+    segments = list(pcb.segments)
+
+    # Precompute net identities once.
+    via_ident: list[tuple[object, str] | None] = [
+        _net_identity(pcb, v.net_number, v.net_name) for v in vias
+    ]
+    seg_ident: list[tuple[object, str] | None] = [
+        _net_identity(pcb, s.net_number, s.net_name) for s in segments
+    ]
+
+    # --- via vs via -------------------------------------------------------
+    for i in range(len(vias)):
+        vi = vias[i]
+        idi = via_ident[i]
+        if idi is None:
+            continue
+        for j in range(i + 1, len(vias)):
+            vj = vias[j]
+            idj = via_ident[j]
+            if idj is None or idi[0] == idj[0]:
+                continue
+            if not _via_spans_overlap(vi, vj):
+                continue
+            d = math.hypot(vi.position[0] - vj.position[0], vi.position[1] - vj.position[1])
+            gap = d - vi.size / 2.0 - vj.size / 2.0
+            if gap < threshold:
+                lo = max(_via_layer_span(vi)[0], _via_layer_span(vj)[0])
+                layer = _ordinal_layer_name(pcb, lo)
+                shorts.append(
+                    ShortItem(
+                        kind="via-via",
+                        net_a_name=idi[1],
+                        net_b_name=idj[1],
+                        layer=layer,
+                        x=(vi.position[0] + vj.position[0]) / 2.0,
+                        y=(vi.position[1] + vj.position[1]) / 2.0,
+                        gap=gap,
+                        via_a=vi,
+                        via_b=vj,
+                    )
+                )
+
+    # --- via vs segment ---------------------------------------------------
+    for i, vi in enumerate(vias):
+        idi = via_ident[i]
+        if idi is None:
+            continue
+        vr = vi.size / 2.0
+        for k, seg in enumerate(segments):
+            idk = seg_ident[k]
+            if idk is None or idi[0] == idk[0]:
+                continue
+            if not _via_spans_layer(vi, seg.layer):
+                continue
+            d = point_to_segment_distance(
+                vi.position[0], vi.position[1], seg.start[0], seg.start[1], seg.end[0], seg.end[1]
+            )
+            gap = d - vr - seg.width / 2.0
+            if gap < threshold:
+                shorts.append(
+                    ShortItem(
+                        kind="via-segment",
+                        net_a_name=idi[1],
+                        net_b_name=idk[1],
+                        layer=seg.layer,
+                        x=vi.position[0],
+                        y=vi.position[1],
+                        gap=gap,
+                        via_a=vi,
+                        via_b=None,
+                    )
+                )
+
+    # --- segment vs segment (same layer) ----------------------------------
+    for a in range(len(segments)):
+        sa = segments[a]
+        ida = seg_ident[a]
+        if ida is None:
+            continue
+        ax0, ay0, ax1, ay1 = _seg_bbox(sa)
+        pad_a = sa.width / 2.0 + clearance
+        for b in range(a + 1, len(segments)):
+            sb = segments[b]
+            idb = seg_ident[b]
+            if idb is None or ida[0] == idb[0] or sa.layer != sb.layer:
+                continue
+            bx0, by0, bx1, by1 = _seg_bbox(sb)
+            pad = pad_a + sb.width / 2.0
+            # Cheap AABB reject before the exact segment-segment distance.
+            if ax1 + pad < bx0 or bx1 + pad < ax0 or ay1 + pad < by0 or by1 + pad < ay0:
+                continue
+            d = segment_to_segment_distance(
+                sa.start[0],
+                sa.start[1],
+                sa.end[0],
+                sa.end[1],
+                sb.start[0],
+                sb.start[1],
+                sb.end[0],
+                sb.end[1],
+            )
+            gap = d - sa.width / 2.0 - sb.width / 2.0
+            if gap < threshold:
+                shorts.append(
+                    ShortItem(
+                        kind="segment-segment",
+                        net_a_name=ida[1],
+                        net_b_name=idb[1],
+                        layer=sa.layer,
+                        x=(sa.start[0] + sa.end[0] + sb.start[0] + sb.end[0]) / 4.0,
+                        y=(sa.start[1] + sa.end[1] + sb.start[1] + sb.end[1]) / 4.0,
+                        gap=gap,
+                        via_a=None,
+                        via_b=None,
+                    )
+                )
+
+    shorts.sort(key=lambda s: (s.kind, s.net_a_name, s.net_b_name, round(s.x, 3), round(s.y, 3)))
+    return shorts
+
+
+def _ordinal_layer_name(pcb: PCB, ordinal: int) -> str:
+    """Best-effort reverse map from a copper ordinal to a layer name."""
+    for layer in pcb.copper_layers:
+        if _copper_ordinal(layer.name) == ordinal:
+            return layer.name
+    if ordinal == 0:
+        return "F.Cu"
+    if ordinal >= _BOTTOM_ORDINAL:
+        return "B.Cu"
+    return f"In{ordinal}.Cu"
+
+
+# ---------------------------------------------------------------------------
+# Repair
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ShortRepairMove:
+    """Record of a via relocated to clear a different-net short."""
+
+    old_x: float
+    old_y: float
+    new_x: float
+    new_y: float
+    net_name: str
+    uuid: str
+    stub_layers: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ShortRepairUnresolved:
+    """Record of a short left in place (boxed-in via, or segment-only)."""
+
+    kind: str
+    net_a_name: str
+    net_b_name: str
+    layer: str
+    x: float
+    y: float
+    reason: str
+
+
+@dataclass
+class ShortRepairResult:
+    """Aggregate outcome of a different-net short repair pass."""
+
+    moved: list[ShortRepairMove] = field(default_factory=list)
+    unresolved: list[ShortRepairUnresolved] = field(default_factory=list)
+
+    @property
+    def changed(self) -> bool:
+        """True when at least one via was moved."""
+        return bool(self.moved)
+
+    def summary(self) -> str:
+        """Human-readable multi-line summary."""
+        lines = [
+            f"Different-net short repair: moved {len(self.moved)} via(s), "
+            f"{len(self.unresolved)} unresolved"
+        ]
+        for m in self.moved:
+            lines.append(
+                f"  Via {m.uuid[:8] or '?'} (net '{m.net_name}'): "
+                f"({m.old_x:.3f}, {m.old_y:.3f}) -> ({m.new_x:.3f}, {m.new_y:.3f}); "
+                f"stubs on {', '.join(m.stub_layers) or '(none)'}"
+            )
+        for u in self.unresolved:
+            lines.append(
+                f"  UNRESOLVED {u.kind} {u.net_a_name}/{u.net_b_name} on {u.layer} "
+                f"at ({u.x:.3f}, {u.y:.3f}): {u.reason}"
+            )
+        return "\n".join(lines)
+
+
+def repair_different_net_shorts(
+    pcb: PCB,
+    design_rules: DesignRules,
+    *,
+    detect_clearance: float = 0.0,
+    dry_run: bool = False,
+) -> ShortRepairResult:
+    """Relocate offending vias to eliminate different-net copper shorts.
+
+    For each short that involves a via, a new location is found with the
+    shared clearance-safe candidate-ladder engine
+    (:func:`kicad_tools.drc.relocate_drill_clearance._try_relocate`): it
+    prefers a slide onto the via's own routed escape node, else an
+    8-direction ladder, and accepts a target only when
+    :func:`kicad_tools.cli.relocate_in_pad_vias._check_clearance` passes at
+    it -- i.e. the target clears *every* foreign via/segment/pad by
+    ``design_rules.min_clearance_mm`` and every drill by
+    ``min_hole_to_hole_mm``.  Because that guarantee subsumes "not shorting
+    the offended net", moving the via there both eliminates the short and
+    introduces no new violation (safety invariant).  A via with no
+    clearance-legal location (boxed in) is left in place and reported.  A
+    pure segment-vs-segment short (no via to move) is reported as
+    unresolved.
+
+    Greedy ordering: the via participating in the most shorts is moved
+    first, so one relocation can clear several overlaps.
+
+    Args:
+        pcb: The routed board to repair (mutated in place unless ``dry_run``).
+        design_rules: Active manufacturer rules driving the clearance-safe
+            relocation.
+        detect_clearance: Gap threshold (mm) passed to
+            :func:`find_different_net_shorts`.  Defaults to ``0.0`` (repair
+            actual overlaps only).
+        dry_run: When True, compute the report without mutating the board.
+
+    Returns:
+        A :class:`ShortRepairResult` listing every moved via and every
+        short left in place.
+    """
+    from kicad_tools.cli.relocate_in_pad_vias import (
+        _collect_smd_pads_by_net,
+        _collect_tht_pads,
+    )
+    from kicad_tools.drc.relocate_drill_clearance import _try_relocate
+
+    result = ShortRepairResult()
+
+    min_clearance = design_rules.min_clearance_mm
+    min_hole_to_hole = design_rules.min_hole_to_hole_mm
+
+    pads_by_net = _collect_smd_pads_by_net(pcb)
+    tht_pads = _collect_tht_pads(pcb)
+
+    # Vias whose relocation was attempted and failed (boxed in): do not retry.
+    failed: set[int] = set()
+
+    max_iterations = 4 * max(1, len(pcb.vias))
+    for _ in range(max_iterations):
+        shorts = find_different_net_shorts(pcb, clearance=detect_clearance)
+        via_shorts = [s for s in shorts if s.via_a is not None or s.via_b is not None]
+        if not via_shorts:
+            break
+
+        # Count via participation (by object identity) and remember handles.
+        counts: Counter[int] = Counter()
+        via_by_id: dict[int, Via] = {}
+        for s in via_shorts:
+            for via in (s.via_a, s.via_b):
+                if via is None:
+                    continue
+                counts[id(via)] += 1
+                via_by_id[id(via)] = via
+
+        ordered = sorted(
+            via_by_id.values(),
+            key=lambda v: (-counts[id(v)], round(v.position[0], 4), round(v.position[1], 4)),
+        )
+
+        moved_this_pass = False
+        for via in ordered:
+            if id(via) in failed or via.net_number == 0:
+                continue
+            outcome = _try_relocate(
+                pcb, via, pads_by_net, tht_pads, min_clearance, min_hole_to_hole, dry_run
+            )
+            if outcome is None:
+                failed.add(id(via))
+                continue
+            result.moved.append(
+                ShortRepairMove(
+                    old_x=outcome.old_x,
+                    old_y=outcome.old_y,
+                    new_x=outcome.new_x,
+                    new_y=outcome.new_y,
+                    net_name=outcome.net_name,
+                    uuid=outcome.uuid,
+                    stub_layers=list(outcome.stub_layers),
+                )
+            )
+            moved_this_pass = True
+            if dry_run:
+                # The board is not mutated in dry_run, so the same short
+                # would be re-selected forever; report one move and stop.
+                failed.add(id(via))
+            break
+
+        if not moved_this_pass:
+            break
+
+    # Surface any short still present after the greedy loop.
+    for s in find_different_net_shorts(pcb, clearance=detect_clearance):
+        if s.via_a is None and s.via_b is None:
+            reason = "segment-vs-segment overlap (no via to relocate)"
+        else:
+            reason = "no clearance-legal location for the offending via (boxed in)"
+        result.unresolved.append(
+            ShortRepairUnresolved(
+                kind=s.kind,
+                net_a_name=s.net_a_name,
+                net_b_name=s.net_b_name,
+                layer=s.layer,
+                x=s.x,
+                y=s.y,
+                reason=reason,
+            )
+        )
+
+    return result
+
+
+__all__ = [
+    "ShortItem",
+    "ShortRepairMove",
+    "ShortRepairResult",
+    "ShortRepairUnresolved",
+    "find_different_net_shorts",
+    "repair_different_net_shorts",
+]

--- a/tests/test_different_net_short.py
+++ b/tests/test_different_net_short.py
@@ -1,0 +1,288 @@
+"""Unit tests for the grid-independent different-net short verifier + repair.
+
+Issue #4470 (board-05 Phase 2).  These tests exercise
+:mod:`kicad_tools.drc.different_net_short` on synthetic boards -- no routing,
+no board recipe -- so they run in milliseconds and pin the correctness-critical
+behaviour:
+
+* the verifier flags a different-net via/via and via/segment copper overlap
+  that a coarse grid-occupancy model would miss (the board-05 failure mode:
+  two different-net vias quantized into overlapping world positions);
+* the verifier is layer-aware -- a via only conflicts with copper on a layer
+  its plated barrel actually spans, and same-net copper is never a short;
+* the repair relocates the offending via to a clearance-safe location so the
+  short is gone, and a boxed-in via is left in place and reported;
+* the committed board-05 artifact (kicad-cli-clean) registers zero shorts, so
+  an already-short-free board is never regressed.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.drc.different_net_short import (
+    find_different_net_shorts,
+    repair_different_net_shorts,
+)
+from kicad_tools.manufacturers import get_profile
+from kicad_tools.schema.pcb import PCB
+
+_SIZE = 0.6
+_DRILL = 0.3
+
+
+def _tier1_rules():
+    """board-05's active profile (jlcpcb-tier1, 4-layer)."""
+    return get_profile("jlcpcb-tier1").get_design_rules()
+
+
+# ---------------------------------------------------------------------------
+# Verifier
+# ---------------------------------------------------------------------------
+
+
+def test_flags_via_via_different_net_overlap() -> None:
+    """Two different-net through-hole vias overlapping in copper are a short."""
+    pcb = PCB.create(width=40.0, height=40.0)
+    # Centers 0.3 mm apart, radii 0.3 + 0.3 -> 0.3 mm copper overlap.
+    pcb.add_via(20.0, 20.0, size=_SIZE, drill=_DRILL, net="NRST")
+    pcb.add_via(20.3, 20.0, size=_SIZE, drill=_DRILL, net="OSC_IN")
+
+    shorts = find_different_net_shorts(pcb)
+    via_via = [s for s in shorts if s.kind == "via-via"]
+    assert len(via_via) == 1
+    assert via_via[0].net_pair == frozenset({"NRST", "OSC_IN"})
+    assert via_via[0].gap < 0  # genuine copper overlap
+
+
+def test_flags_via_segment_different_net_overlap() -> None:
+    """A via landing on a foreign-net trace on a spanned layer is a short."""
+    pcb = PCB.create(width=40.0, height=40.0)
+    pcb.add_trace((10.0, 10.0), (15.0, 10.0), width=0.2, layer="In2.Cu", net="PWM_CH")
+    # Through-hole via barrel spans In2.Cu; its center sits on the trace.
+    pcb.add_via(12.5, 10.0, size=_SIZE, drill=_DRILL, net="OSC_OUT")
+
+    shorts = find_different_net_shorts(pcb)
+    via_seg = [s for s in shorts if s.kind == "via-segment"]
+    assert len(via_seg) == 1
+    assert via_seg[0].net_pair == frozenset({"PWM_CH", "OSC_OUT"})
+    assert via_seg[0].layer == "In2.Cu"
+    assert via_seg[0].gap < 0
+
+
+def test_same_net_overlap_is_not_a_short() -> None:
+    """Same-net copper may touch freely -- never flagged."""
+    pcb = PCB.create(width=40.0, height=40.0)
+    pcb.add_via(20.0, 20.0, size=_SIZE, drill=_DRILL, net="GND")
+    pcb.add_via(20.2, 20.0, size=_SIZE, drill=_DRILL, net="GND")
+    pcb.add_trace((10.0, 10.0), (15.0, 10.0), width=0.2, layer="B.Cu", net="GND")
+    pcb.add_via(12.5, 10.0, size=_SIZE, drill=_DRILL, net="GND")
+
+    assert find_different_net_shorts(pcb) == []
+
+
+def test_layer_awareness_blind_via_does_not_short_unspanned_layer() -> None:
+    """A blind via that does not reach a layer cannot short copper on it."""
+    pcb = PCB.create(width=40.0, height=40.0)
+    pcb.add_trace((10.0, 10.0), (15.0, 10.0), width=0.2, layer="In2.Cu", net="PWM_CH")
+    # A via whose barrel spans only F.Cu..In1.Cu -- it never reaches In2.Cu.
+    pcb.add_via(12.5, 10.0, size=_SIZE, drill=_DRILL, layers=("F.Cu", "In1.Cu"), net="OSC_OUT")
+    assert find_different_net_shorts(pcb) == []
+
+    # A through-hole via on the trace (clear of the blind via) DOES reach
+    # In2.Cu -> short.
+    pcb.add_via(13.5, 10.0, size=_SIZE, drill=_DRILL, net="SWDIO")
+    shorts = find_different_net_shorts(pcb)
+    assert len(shorts) == 1
+    assert shorts[0].net_pair == frozenset({"PWM_CH", "SWDIO"})
+
+
+def test_clearance_threshold_flags_near_miss() -> None:
+    """A positive clearance flags sub-clearance near-misses, not just overlaps."""
+    pcb = PCB.create(width=40.0, height=40.0)
+    # Gap = 0.6 - 0.3 - 0.3 = 0.0 edge-to-edge (tangent) -> not an overlap,
+    # but a sub-clearance near-miss at any positive clearance.
+    pcb.add_via(20.0, 20.0, size=_SIZE, drill=_DRILL, net="NRST")
+    pcb.add_via(20.6, 20.0, size=_SIZE, drill=_DRILL, net="OSC_IN")
+
+    assert find_different_net_shorts(pcb, clearance=0.0) == []
+    near = find_different_net_shorts(pcb, clearance=0.15)
+    assert len(near) == 1
+
+
+def test_flags_segment_segment_overlap_same_layer() -> None:
+    """Two different-net traces overlapping on the same layer are a short."""
+    pcb = PCB.create(width=40.0, height=40.0)
+    pcb.add_trace((10.0, 10.0), (20.0, 10.0), width=0.25, layer="B.Cu", net="A")
+    pcb.add_trace((15.0, 10.05), (25.0, 10.05), width=0.25, layer="B.Cu", net="B")
+    shorts = find_different_net_shorts(pcb)
+    seg_seg = [s for s in shorts if s.kind == "segment-segment"]
+    assert len(seg_seg) == 1
+    assert seg_seg[0].net_pair == frozenset({"A", "B"})
+
+
+def test_segment_segment_different_layer_not_short() -> None:
+    """Overlapping traces on different layers do not short."""
+    pcb = PCB.create(width=40.0, height=40.0)
+    pcb.add_trace((10.0, 10.0), (20.0, 10.0), width=0.25, layer="F.Cu", net="A")
+    pcb.add_trace((15.0, 10.0), (25.0, 10.0), width=0.25, layer="B.Cu", net="B")
+    assert find_different_net_shorts(pcb) == []
+
+
+# ---------------------------------------------------------------------------
+# Repair
+# ---------------------------------------------------------------------------
+
+
+def _board05_style_shorts() -> PCB:
+    """A synthetic coarse-grid board reproducing the board-05 short signature.
+
+    A different-net via/via overlap (NRST/OSC_IN) and a via-on-trace overlap
+    (PWM_CH/OSC_OUT) -- the two shorts named in issue #4470 -- each with a
+    routed escape node so the repair has a slide direction.
+    """
+    pcb = PCB.create(width=60.0, height=60.0)
+    # NRST/OSC_IN via overlap, each with a B.Cu escape leg heading OUTWARD
+    # (away from each other) so the vias can slide apart onto their own nodes.
+    pcb.add_via(20.0, 20.0, size=_SIZE, drill=_DRILL, net="NRST")
+    pcb.add_via(20.3, 20.0, size=_SIZE, drill=_DRILL, net="OSC_IN")
+    pcb.add_trace((20.0, 20.0), (17.0, 20.0), width=0.2, layer="B.Cu", net="NRST")
+    pcb.add_trace((20.3, 20.0), (23.0, 20.0), width=0.2, layer="B.Cu", net="OSC_IN")
+    # PWM_CH/OSC_OUT via-on-trace overlap.  The foreign PWM_CH trace is on
+    # In2.Cu; OSC_OUT's own escape leg is on F.Cu (a different layer), so
+    # relocating the through-hole via off the trace resolves the In2.Cu short
+    # without the escape leg itself crossing PWM_CH.
+    pcb.add_trace((40.0, 40.0), (46.0, 40.0), width=0.2, layer="In2.Cu", net="PWM_CH")
+    pcb.add_via(43.0, 40.0, size=_SIZE, drill=_DRILL, net="OSC_OUT")
+    pcb.add_trace((43.0, 40.0), (43.0, 45.0), width=0.2, layer="F.Cu", net="OSC_OUT")
+    return pcb
+
+
+def test_repair_eliminates_shorts() -> None:
+    """The repair relocates offending vias so no different-net short remains."""
+    pcb = _board05_style_shorts()
+    rules = _tier1_rules()
+
+    before = find_different_net_shorts(pcb)
+    assert before, "fixture should start with different-net shorts"
+
+    result = repair_different_net_shorts(pcb, rules)
+    assert result.changed
+    assert not result.unresolved
+
+    after = find_different_net_shorts(pcb)
+    assert after == [], f"repair left {len(after)} short(s): {[s.describe() for s in after]}"
+
+    # Every moved via genuinely cleared foreign copper by the clearance floor.
+    for m in result.moved:
+        for other in pcb.vias:
+            if other.uuid == m.uuid or other.net_number == 0:
+                continue
+            gap = (
+                math.hypot(other.position[0] - m.new_x, other.position[1] - m.new_y)
+                - _SIZE / 2.0
+                - other.size / 2.0
+            )
+            # Different-net vias must now clear (same-net stacking is allowed).
+            if other.net_name != m.net_name:
+                assert gap >= -1e-6
+
+
+def test_repair_preserves_connectivity_with_stub() -> None:
+    """A relocated via re-bonds to its old location via same-net copper."""
+    pcb = _board05_style_shorts()
+    result = repair_different_net_shorts(pcb, _tier1_rules())
+
+    for m in result.moved:
+        old, new = (m.old_x, m.old_y), (m.new_x, m.new_y)
+        if math.hypot(new[0] - old[0], new[1] - old[1]) < 1e-6:
+            continue  # no actual move
+        bonded = False
+        # Net number for the moved via.
+        net_no = pcb.get_net_by_name(m.net_name)
+        net_number = net_no.number if net_no else None
+        if net_number is None:
+            continue
+        for seg in pcb.segments_in_net(net_number):
+            eps = {seg.start, seg.end}
+            if any(math.hypot(p[0] - old[0], p[1] - old[1]) < 1e-3 for p in eps) and any(
+                math.hypot(p[0] - new[0], p[1] - new[1]) < 1e-3 for p in eps
+            ):
+                bonded = True
+                break
+        assert bonded, f"moved via on {m.net_name} not bonded old->new"
+
+
+def test_repair_dry_run_does_not_mutate() -> None:
+    """``dry_run`` reports moves without touching the board."""
+    pcb = _board05_style_shorts()
+    positions_before = [(v.position[0], v.position[1]) for v in pcb.vias]
+    seg_count = len(pcb.segments)
+
+    result = repair_different_net_shorts(pcb, _tier1_rules(), dry_run=True)
+    assert result.moved  # it reports what it WOULD do
+
+    positions_after = [(v.position[0], v.position[1]) for v in pcb.vias]
+    assert positions_before == positions_after
+    assert len(pcb.segments) == seg_count
+    # Shorts are still present because nothing was actually moved.
+    assert find_different_net_shorts(pcb)
+
+
+def test_boxed_in_via_left_in_place_and_reported() -> None:
+    """A via with no clearance-legal escape is left in place and reported."""
+    rules = _tier1_rules()
+    pcb = PCB.create(width=6.0, height=6.0)
+    # Center via boxed by a tight ring of foreign-net vias on every side, so no
+    # 8-direction candidate clears the clearance floor.
+    pcb.add_via(3.0, 3.0, size=_SIZE, drill=_DRILL, net="VICTIM")
+    ring = 0.62  # just inside overlap with the center via
+    for k in range(16):
+        ang = 2 * math.pi * k / 16
+        pcb.add_via(
+            3.0 + ring * math.cos(ang),
+            3.0 + ring * math.sin(ang),
+            size=_SIZE,
+            drill=_DRILL,
+            net=f"BLOCK{k}",
+        )
+
+    before = find_different_net_shorts(pcb)
+    assert before, "center via should short its ring neighbours"
+
+    result = repair_different_net_shorts(pcb, rules)
+    # Nothing can be safely relocated -> shorts persist and are reported.
+    assert result.unresolved
+    assert find_different_net_shorts(pcb)
+
+
+# ---------------------------------------------------------------------------
+# Regression: an already-short-free board is never flagged
+# ---------------------------------------------------------------------------
+
+
+def test_committed_board05_is_short_free() -> None:
+    """The committed (kicad-cli-clean) board-05 artifact has zero shorts.
+
+    This is the "no regression on already-short-free boards" acceptance
+    criterion: the geometric verifier must agree with kicad-cli that the
+    shipped board has no different-net copper overlap.
+    """
+    artifact = (
+        Path(__file__).resolve().parents[1]
+        / "boards"
+        / "05-bldc-motor-controller"
+        / "output"
+        / "bldc_controller_routed.kicad_pcb"
+    )
+    if not artifact.exists():
+        pytest.skip("committed board-05 artifact not present")
+
+    pcb = PCB.load(artifact)
+    shorts = find_different_net_shorts(pcb)
+    assert shorts == [], (
+        f"unexpected shorts on committed board-05: {[s.describe() for s in shorts]}"
+    )


### PR DESCRIPTION
## Summary

board-05 routes on `--allow-unsafe-grid` (a 0.1mm grid coarser than
`clearance/2` = 0.075mm) because the memory-safe 0.05mm grid reaches fewer
nets. At that resolution the C++ A* **occupancy** model cannot represent
sub-cell clearance, so two different-net vias/segments can quantize into
geometrically-overlapping world positions that pass grid-occupancy yet fail
geometric DRC — real `shorting_items`. A fresh regen emitted 2 such shorts
(a via shorting `NRST`/`OSC_IN` on In2.Cu and a via shorting `PWM_CH`/`OSC_OUT`
on B.Cu). There was no grid-independent guarantee that emitted copper is
short-free.

This PR adds that guarantee as a **generic library capability**: a
post-route geometric verifier + a clearance-safe repair post-pass, wired
into board-05's recipe.

## Changes

- **New `kicad_tools.drc.different_net_short`**:
  - `find_different_net_shorts()` — the grid-independent **verifier**. Pure
    world-coordinate geometry over the emitted vias + segments, **layer-aware**
    (a via only conflicts with copper on a layer its plated barrel actually
    spans). Detects via-via, via-segment and segment-segment different-net
    overlaps. Default `clearance=0.0` targets the `shorting_items` class; a
    positive `clearance` also flags sub-clearance near-misses. Lifts the
    `router/via_clearance.py` copper-distance predicates out of the coarse
    grid into a post-route pass.
  - `repair_different_net_shorts()` — the **repair**. Relocates each offending
    via with the shared #4408 candidate-ladder engine (escape-node slide → 8-
    direction ladder, connectivity stubs, boxed-in → leave-in-place + report).
    A target is accepted only when `_check_clearance` passes at it (clears all
    foreign copper by the manufacturer clearance), so the move eliminates the
    short **without** introducing a new one.
- **`boards/05-bldc-motor-controller/design.py`**: new Step 7a runs
  verify+repair after routing/rescue/stitch and before zone fill (so the
  re-fill + final DRC measure the repaired geometry).
- **`tests/test_different_net_short.py`**: 12 unit tests (synthetic fixtures).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Verifier flags the 2 board-05 shorts on a fresh regen | ✅ | Full regen: `Detected 2 different-net short(s): OSC_IN/NRST on In2.Cu; OSC_OUT/PWM_CH on B.Cu` — exactly the two named in the issue |
| Repair eliminates them; `kicad-cli pcb drc --refill-zones` → 0 `shorting_items` | ✅ | Regen: `moved 2 via(s), 0 unresolved` → authoritative `kicad-cli pcb drc --refill-zones` reports **0 error-severity violations, 0 shorting_items** |
| Generic: catches an injected overlap on a synthetic coarse-grid fixture | ✅ | `test_flags_via_via/via_segment/segment_segment_*` inject different-net overlaps on synthetic boards and assert the flag |
| No regression on already-short-free boards | ✅ | `test_committed_board05_is_short_free`: the committed (kicad-cli-clean) board-05 artifact registers **0** shorts (verifier agrees with kicad-cli) |

## Test Plan

- `uv run pytest tests/test_different_net_short.py tests/test_relocate_drill_clearance.py` → 19 passed
- `ruff check` + `ruff format --check` clean on changed files
- mypy baseline-gated check: no new type errors
- **Full board-05 regen** (`design.py`): verifier flagged the 2 real shorts,
  repair moved 2 vias / 0 unresolved, and `kicad-cli pcb drc --refill-zones`
  → 0 shorting_items. (The pipeline's overall PARTIAL/FAIL is the pre-existing
  partial-route WIP tracked in #3766/#3775 — 10 connectivity residuals, 0
  blocking manufacturing DRC — unrelated to shorts.)

Note: the nondeterministic board-05 regen artifacts (routed PCB, mfg bundle)
are intentionally **not** committed — the committed artifact remains the
curated shipping truth. This PR ships only the generic capability + recipe
wiring.

Closes #4470
Part of #4410