### PR TITLE
feat(route): --complete pass — auto-detect + route only unconnected links on lattice fixed-obstacle path

### DIFF
--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -397,6 +397,13 @@ def run_route_command(args) -> int:
     # store_true defaulting to False, so only forward when the user set it.
     if getattr(args, "preserve_existing", False):
         sub_argv.append("--preserve-existing")
+    # Issue #4471 (epic #4465): forward --complete (auto-detect + route only
+    # the currently-unconnected signal links on the lattice fixed-obstacle
+    # path).  Declared on BOTH parsers as store_true defaulting to False, so
+    # only forward when the user set it -- flag-off argv stays byte-identical
+    # and tests/test_cli_parser_drift.py stays green.
+    if getattr(args, "complete", False):
+        sub_argv.append("--complete")
     grid_val = str(args.grid)
     if grid_val.lower() != "auto":
         sub_argv.extend(["--grid", grid_val])

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -3109,6 +3109,24 @@ def _add_route_parser(subparsers) -> None:
         ),
     )
     route_parser.add_argument(
+        "--complete",
+        action="store_true",
+        default=False,
+        help=(
+            "Completion pass (Issue #4471, epic #4465): auto-detect the "
+            "currently-unconnected signal nets and route ONLY those links, "
+            "treating every other net's copper as a fixed obstacle. Implies "
+            "--preserve-existing and, unless you override --route-engine, "
+            "selects the lattice engine with --strategy basic (the "
+            "route-only-listed-links path the #4280 gate permits; a "
+            "negotiated strategy is coerced to basic with a printed notice "
+            "rather than rejected). Existing copper is never deleted (the "
+            "#4413 copper-loss guard is active). Mutually exclusive with "
+            "--nets / --skip-nets (--complete chooses the net set itself). A "
+            "board with nothing left to connect is a safe no-op."
+        ),
+    )
+    route_parser.add_argument(
         "--region",
         metavar="X1,Y1,X2,Y2",
         help=(

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -8234,10 +8234,32 @@ def _validate_route_engine_strategy(args) -> int:
     if engine == "grid":
         return 0
 
+    # Issue #4471 (epic #4465): --complete carve-out.  --complete is a
+    # route-only-the-currently-unconnected-links contract -- it dispatches
+    # through the SAME basic/lattice-netset path the #4280 gate protects (route
+    # only ``self.nets`` against fixed foreign copper), NOT the whole-netset
+    # negotiation the gate exists to guard.  So rather than REJECT a non-basic
+    # (typically the default ``negotiated``) strategy under --complete, coerce
+    # it to basic with a printed notice.  The other modifiers (--two-phase /
+    # --multi-resolution / --escape-routing) genuinely bypass the netset path
+    # and remain hard conflicts even under --complete.
+    complete_mode = bool(getattr(args, "complete", False))
+
     conflicts: list[str] = []
     if args.strategy != "basic":
-        default_note = " (the default)" if args.strategy == "negotiated" else ""
-        conflicts.append(f"--strategy {args.strategy}{default_note}")
+        if complete_mode:
+            coerced_from = args.strategy
+            args.strategy = "basic"
+            if not getattr(args, "quiet", False):
+                default_note = " (the default)" if coerced_from == "negotiated" else ""
+                print(
+                    f"  --complete: coercing --strategy {coerced_from}{default_note} to "
+                    "basic (completion runs the lattice netset driver on the "
+                    "listed links, not whole-netset negotiation)"
+                )
+        else:
+            default_note = " (the default)" if args.strategy == "negotiated" else ""
+            conflicts.append(f"--strategy {args.strategy}{default_note}")
     if getattr(args, "two_phase", False):
         conflicts.append("--two-phase")
     if getattr(args, "multi_resolution", False):
@@ -8662,6 +8684,111 @@ def _offboard_preflight(pcb_path: Path) -> int:
     return 2
 
 
+def _apply_complete_mode_defaults(args, parser) -> None:
+    """Apply the ``--complete`` mode implications (Issue #4471, epic #4465).
+
+    ``--complete`` is a *route-only-the-currently-unconnected-links* contract:
+    it auto-detects the stranded signal nets (later, in
+    :func:`_resolve_complete_nets`, which needs the validated board path) and
+    routes ONLY those against all other copper held as fixed obstacles.  Two
+    implications must be stamped BEFORE the #4280 engine/strategy gate runs so
+    the gate sees the coherent combination:
+
+    * ``--preserve-existing`` -- every other net's copper is loaded as an
+      immovable obstacle and re-emitted verbatim.  This also arms the #4413
+      copper-loss guard on the terminal write (``guard_copper_loss`` is keyed
+      off ``args.preserve_existing`` at every save site).
+    * the lattice engine -- unless the user explicitly overrode
+      ``--route-engine`` (a non-default value), completion dispatches through
+      the lattice netset driver (``core.py:_negotiate_lattice_netset``), which
+      already routes ONLY ``self.nets`` against
+      ``fixed_copper = existing_routes not in self.nets`` (#4355).
+
+    ``--strategy`` is intentionally NOT coerced here: the gate
+    (:func:`_validate_route_engine_strategy`) owns the coercion so the printed
+    notice lives beside the rule it relaxes.  No-op when ``--complete`` is
+    absent -- a plain ``kct route`` is byte-identical.
+    """
+    if not getattr(args, "complete", False):
+        return
+    # --complete implies --preserve-existing (idempotent; an explicit
+    # --preserve-existing is a harmless no-op).
+    args.preserve_existing = True
+    # Select the lattice engine unless the user explicitly picked an engine.
+    # argparse cannot distinguish an explicit ``--route-engine grid`` from the
+    # default, so "still at the default" is treated as "not overridden" and
+    # flipped to lattice; any explicit mesh/lattice choice is respected as-is.
+    engine_default = parser.get_default("route_engine")
+    if getattr(args, "route_engine", engine_default) == engine_default:
+        args.route_engine = "lattice"
+        if not getattr(args, "quiet", False):
+            print(
+                "  --complete: routing unconnected links on the lattice engine "
+                "(override with --route-engine)"
+            )
+
+
+def _resolve_complete_nets(args, pcb_path: Path) -> int:
+    """Auto-detect the unconnected signal nets for ``--complete`` (Issue #4471).
+
+    Runs the existing detection helper
+    (:func:`~kicad_tools.router.partial_rescue.partially_connected_signal_nets`
+    with ``include_unrouted=True``) to find every signal net whose pads are not
+    all trace-connected, then stamps ``args.nets`` with exactly those net names
+    so the established #4322 route-only machinery (:func:`_resolve_route_only_nets`)
+    inverts them into the ``--skip-nets`` + ``--preserve-existing`` fixed-obstacle
+    path.  The lattice netset driver then routes ONLY those nets against all
+    other copper.
+
+    Mutually exclusive with ``--nets`` / ``--skip-nets``: ``--complete`` chooses
+    the routable set itself, so a hand-enumerated set would contradict it.
+
+    Returns 0 on success (or when ``--complete`` is absent).  When the board has
+    no unconnected signal nets, sets ``args._complete_noop`` and returns 0 so
+    the caller can short-circuit to a safe no-op write (never a full re-route).
+    A non-zero return (with a printed error) signals a usage/validation error.
+    """
+    if not getattr(args, "complete", False):
+        return 0
+
+    if getattr(args, "nets", None) or getattr(args, "skip_nets", None):
+        print(
+            "Error: --complete auto-detects the nets to route and is mutually "
+            "exclusive with --nets / --skip-nets (--complete chooses the "
+            "routable set itself).",
+            file=sys.stderr,
+        )
+        return 2
+
+    from kicad_tools.router.partial_rescue import partially_connected_signal_nets
+
+    manufacturer = getattr(args, "manufacturer", "jlcpcb") or "jlcpcb"
+    try:
+        stranded = partially_connected_signal_nets(
+            pcb_path,
+            manufacturer=manufacturer,
+            include_unrouted=True,
+        )
+    except Exception as e:  # pragma: no cover - detection should not raise
+        print(f"Error detecting unconnected nets for --complete: {e}", file=sys.stderr)
+        return 1
+
+    if not stranded:
+        args._complete_noop = True
+        if not getattr(args, "quiet", False):
+            print(
+                "--complete: no unconnected signal nets detected; the board is "
+                "already fully connected (nothing to route)."
+            )
+        return 0
+
+    args.nets = ",".join(stranded)
+    if not getattr(args, "quiet", False):
+        preview = ", ".join(stranded)
+        print(f"--complete: routing {len(stranded)} unconnected signal net(s): {preview}")
+    return 0
+
+
 def _resolve_route_only_nets(args, pcb_path: Path) -> int:
     """Resolve ``--nets`` (route ONLY the listed nets) -- Issue #4322.
 
@@ -9068,6 +9195,24 @@ def main(argv: list[str] | None = None) -> int:
             "Preserves manually-routed nets, skipped nets' geometry, and "
             "standalone stitch vias across a route pass. Default off (full "
             "re-route, existing copper is replaced by freshly routed nets)."
+        ),
+    )
+    parser.add_argument(
+        "--complete",
+        action="store_true",
+        default=False,
+        help=(
+            "Completion pass (Issue #4471, epic #4465): auto-detect the "
+            "currently-unconnected signal nets and route ONLY those links, "
+            "treating every other net's copper as a fixed obstacle. Implies "
+            "--preserve-existing and, unless you override --route-engine, "
+            "selects the lattice engine with --strategy basic (the "
+            "route-only-listed-links path the #4280 gate permits; a "
+            "negotiated strategy is coerced to basic with a printed notice "
+            "rather than rejected). Existing copper is never deleted (the "
+            "#4413 copper-loss guard is active). Mutually exclusive with "
+            "--nets / --skip-nets. A board with nothing left to connect is a "
+            "safe no-op."
         ),
     )
     parser.add_argument(
@@ -10487,6 +10632,12 @@ def main(argv: list[str] | None = None) -> int:
 
     args = parser.parse_args(argv)
 
+    # Issue #4471 (epic #4465): stamp the --complete mode implications
+    # (--preserve-existing + the lattice engine, unless the user overrode
+    # --route-engine) BEFORE the #4280 gate so the gate sees the coherent
+    # route-only-listed-links combination.  No-op when --complete is absent.
+    _apply_complete_mode_defaults(args, parser)
+
     # Issue #4280: hard compatibility gate for --route-engine mesh|lattice.
     # Runs before ANY other work (env stamping, board loading, escalation
     # dispatch) so an inert engine flag can never silently ship grid copper.
@@ -10555,6 +10706,30 @@ def main(argv: list[str] | None = None) -> int:
 
     if pcb_path.suffix != ".kicad_pcb":
         print(f"Warning: Expected .kicad_pcb file, got {pcb_path.suffix}")
+
+    # Issue #4471 (epic #4465): resolve --complete BEFORE --nets.  Auto-detects
+    # the currently-unconnected signal nets and stamps ``args.nets`` with
+    # exactly those, so the #4322 route-only machinery below inverts them into
+    # the --skip-nets + --preserve-existing fixed-obstacle path (the lattice
+    # netset driver then routes ONLY those links).  A board with nothing left
+    # to connect sets ``args._complete_noop`` and is written back unchanged --
+    # never a full re-route.
+    args._complete_noop = False
+    _complete_rc = _resolve_complete_nets(args, pcb_path)
+    if _complete_rc != 0:
+        return _complete_rc
+    if getattr(args, "_complete_noop", False):
+        # Nothing stranded: preserve the board exactly.  Reuse the atomic
+        # writer with an empty route fragment (writes original content back)
+        # and the #4413 copper-loss guard armed -- a trivially-passing check
+        # that keeps the no-op path on the same guarded write as a real pass.
+        output_path = (
+            Path(args.output) if args.output else pcb_path.with_stem(pcb_path.stem + "_routed")
+        )
+        _write_routed_pcb(pcb_path, output_path, "", guard_copper_loss=True)
+        if not getattr(args, "quiet", False):
+            print(f"  Wrote {output_path} (unchanged)")
+        return 0
 
     # Issue #4322: resolve --nets (route ONLY the listed nets) by inverting it
     # into the --skip-nets machinery.  Validates mutual exclusion with

--- a/tests/test_cli_route_complete_4471.py
+++ b/tests/test_cli_route_complete_4471.py
@@ -1,0 +1,313 @@
+"""Tests for the ``--complete`` completion pass (Issue #4471, epic #4465).
+
+``kct route <board> --complete`` auto-detects the currently-unconnected signal
+nets and routes ONLY those links, treating every other net's copper as a fixed
+obstacle.  It is the first-class composition of pieces that already existed but
+were unwired:
+
+* detection -- ``partial_rescue.partially_connected_signal_nets`` (include_unrouted),
+* net selection -- the #4322 ``--nets`` route-only machinery (invert into
+  ``--skip-nets`` + imply ``--preserve-existing``),
+* fixed-obstacle routing -- the lattice netset driver
+  (``core.py:_negotiate_lattice_netset`` routes ONLY ``self.nets`` against
+  ``fixed_copper = existing_routes not in self.nets``, #4355),
+* the #4280 engine/strategy gate, which now carves out ``--complete`` (a
+  route-only-listed-links contract, not the whole-netset negotiation the gate
+  protects).
+
+The unit tests exercise the three CLI-layer helpers in isolation; the
+end-to-end test routes a deliberately-stranded link on a real board through the
+lattice engine and asserts the other net's copper is preserved.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.route_cmd import (
+    _apply_complete_mode_defaults,
+    _resolve_complete_nets,
+    _validate_route_engine_strategy,
+)
+from kicad_tools.cli.route_cmd import (
+    main as route_main,
+)
+
+
+# ---------------------------------------------------------------------------
+# Argparse defaults the helpers read off the namespace.
+# ---------------------------------------------------------------------------
+def _complete_args(**overrides) -> argparse.Namespace:
+    base = {
+        "complete": True,
+        "route_engine": "grid",
+        "strategy": "negotiated",
+        "preserve_existing": False,
+        "nets": None,
+        "skip_nets": None,
+        "manufacturer": "jlcpcb",
+        "quiet": False,
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+class _FakeParser:
+    """Minimal stand-in for ``parser.get_default`` used by the defaults helper."""
+
+    @staticmethod
+    def get_default(name: str):
+        return {"route_engine": "grid", "strategy": "negotiated"}.get(name)
+
+
+# ---------------------------------------------------------------------------
+# _apply_complete_mode_defaults -- implications stamped BEFORE the #4280 gate
+# ---------------------------------------------------------------------------
+class TestApplyCompleteModeDefaults:
+    def test_implies_preserve_existing_and_lattice(self, capsys):
+        args = _complete_args()
+        _apply_complete_mode_defaults(args, _FakeParser())
+        assert args.preserve_existing is True
+        assert args.route_engine == "lattice"
+        assert "lattice engine" in capsys.readouterr().out
+
+    def test_respects_explicit_engine_override(self, capsys):
+        args = _complete_args(route_engine="mesh")
+        _apply_complete_mode_defaults(args, _FakeParser())
+        # An explicit non-default engine is respected -- not flipped to lattice.
+        assert args.route_engine == "mesh"
+        assert args.preserve_existing is True
+
+    def test_noop_when_complete_absent(self):
+        args = _complete_args(complete=False)
+        _apply_complete_mode_defaults(args, _FakeParser())
+        # No implication stamped -- plain ``kct route`` is byte-identical.
+        assert args.preserve_existing is False
+        assert args.route_engine == "grid"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_complete_nets -- auto-detection + mutual exclusion + no-op
+# ---------------------------------------------------------------------------
+class TestResolveCompleteNets:
+    def test_populates_nets_from_detection(self, monkeypatch, capsys):
+        import kicad_tools.router.partial_rescue as pr
+
+        monkeypatch.setattr(
+            pr, "partially_connected_signal_nets", lambda *a, **k: ["/NET_A", "/NET_B"]
+        )
+        args = _complete_args()
+        rc = _resolve_complete_nets(args, Path("dummy.kicad_pcb"))
+        assert rc == 0
+        assert args.nets == "/NET_A,/NET_B"
+        assert getattr(args, "_complete_noop", False) is False
+        out = capsys.readouterr().out
+        assert "/NET_A" in out and "/NET_B" in out
+
+    def test_empty_detection_is_noop(self, monkeypatch, capsys):
+        import kicad_tools.router.partial_rescue as pr
+
+        monkeypatch.setattr(pr, "partially_connected_signal_nets", lambda *a, **k: [])
+        args = _complete_args()
+        rc = _resolve_complete_nets(args, Path("dummy.kicad_pcb"))
+        assert rc == 0
+        assert args._complete_noop is True
+        # No net set is fabricated -- a full re-route must NOT be triggered.
+        assert args.nets is None
+        assert "already fully connected" in capsys.readouterr().out
+
+    def test_mutually_exclusive_with_nets(self, capsys):
+        args = _complete_args(nets="/NET_A")
+        rc = _resolve_complete_nets(args, Path("dummy.kicad_pcb"))
+        assert rc == 2
+        assert "mutually exclusive" in capsys.readouterr().err
+
+    def test_mutually_exclusive_with_skip_nets(self, capsys):
+        args = _complete_args(skip_nets="GND")
+        rc = _resolve_complete_nets(args, Path("dummy.kicad_pcb"))
+        assert rc == 2
+        assert "mutually exclusive" in capsys.readouterr().err
+
+    def test_noop_when_complete_absent(self, monkeypatch):
+        import kicad_tools.router.partial_rescue as pr
+
+        called = {"n": 0}
+
+        def _spy(*a, **k):
+            called["n"] += 1
+            return []
+
+        monkeypatch.setattr(pr, "partially_connected_signal_nets", _spy)
+        args = _complete_args(complete=False)
+        rc = _resolve_complete_nets(args, Path("dummy.kicad_pcb"))
+        assert rc == 0
+        # Detection is not even attempted without --complete.
+        assert called["n"] == 0
+        assert args.nets is None
+
+
+# ---------------------------------------------------------------------------
+# #4280 gate carve-out -- --complete permits lattice + coerces strategy
+# ---------------------------------------------------------------------------
+def _gate_args(**overrides) -> argparse.Namespace:
+    base = {
+        "route_engine": "grid",
+        "strategy": "negotiated",
+        "two_phase": False,
+        "multi_resolution": False,
+        "escape_routing": None,
+        "no_escape_routing": False,
+        "complete": False,
+        "quiet": False,
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+class TestGateCompleteCarveOut:
+    def test_complete_lattice_coerces_negotiated_to_basic(self, capsys):
+        args = _gate_args(route_engine="lattice", strategy="negotiated", complete=True)
+        rc = _validate_route_engine_strategy(args)
+        assert rc == 0  # NOT rejected
+        assert args.strategy == "basic"  # coerced
+        assert "coercing --strategy negotiated" in capsys.readouterr().out
+
+    def test_complete_lattice_basic_is_clean(self, capsys):
+        args = _gate_args(route_engine="lattice", strategy="basic", complete=True)
+        rc = _validate_route_engine_strategy(args)
+        assert rc == 0
+        assert args.strategy == "basic"
+
+    def test_without_complete_negotiated_still_rejected(self, capsys):
+        # The gate is unchanged for non-complete runs (#4280 still protects).
+        args = _gate_args(route_engine="lattice", strategy="negotiated", complete=False)
+        rc = _validate_route_engine_strategy(args)
+        assert rc == 2
+        assert "#4280" in capsys.readouterr().err
+
+    def test_complete_does_not_relax_two_phase(self, capsys):
+        # --two-phase genuinely bypasses the netset path -- still a hard
+        # conflict even under --complete.
+        args = _gate_args(route_engine="lattice", strategy="basic", complete=True, two_phase=True)
+        rc = _validate_route_engine_strategy(args)
+        assert rc == 2
+        assert "--two-phase" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: one deliberately-stranded link on an otherwise-routed board.
+# NET1 is fully connected (a pre-existing segment between its two pads); NET2
+# is unrouted.  ``--complete`` must close NET2 on the lattice engine and leave
+# NET1's copper untouched.
+# ---------------------------------------------------------------------------
+STRANDED_BOARD = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general
+    (thickness 1.6)
+  )
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup
+    (pad_to_mask_clearance 0)
+  )
+  (net 0 "")
+  (net 1 "NET1")
+  (net 2 "NET2")
+  (gr_rect (start 100 100) (end 130 120)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000010")
+    (at 108 105)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "NET1"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "NET1"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000020")
+    (at 120 105)
+    (property "Reference" "R2" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (net 2 "NET2"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (net 2 "NET2"))
+  )
+  (segment (start 107.49 105) (end 108.51 105) (width 0.2) (layer "F.Cu") (net 1))
+)
+"""
+
+
+def _segment_nets(pcb_text: str) -> list[int]:
+    import re
+
+    return [int(m.group(1)) for m in re.finditer(r"\(segment.*?\(net (\d+)\)", pcb_text, re.S)]
+
+
+@pytest.fixture
+def stranded_board(tmp_path: Path) -> Path:
+    board = tmp_path / "stranded.kicad_pcb"
+    board.write_text(STRANDED_BOARD)
+    return board
+
+
+class TestCompleteEndToEnd:
+    def test_closes_stranded_link_on_lattice_preserving_other_copper(
+        self, stranded_board: Path, tmp_path: Path
+    ):
+        out = tmp_path / "stranded_out.kicad_pcb"
+        rc = route_main([str(stranded_board), "-o", str(out), "--complete", "--backend", "cpp"])
+        assert rc == 0, "completion pass should succeed"
+        assert out.exists()
+
+        seg_nets = _segment_nets(out.read_text())
+        # NET1's pre-existing copper is preserved (fixed obstacle, not deleted).
+        assert 1 in seg_nets, "NET1 copper must be preserved"
+        # NET2 (the stranded link) is now routed -- new copper appeared.
+        assert 2 in seg_nets, "NET2 (stranded) must be routed by --complete"
+
+    def test_fully_connected_board_is_safe_noop(self, stranded_board: Path, tmp_path: Path):
+        # First close NET2, producing a fully-connected board.
+        routed = tmp_path / "routed.kicad_pcb"
+        assert (
+            route_main([str(stranded_board), "-o", str(routed), "--complete", "--backend", "cpp"])
+            == 0
+        )
+        # A second --complete pass has nothing to route: byte-identical output.
+        noop = tmp_path / "noop.kicad_pcb"
+        rc = route_main([str(routed), "-o", str(noop), "--complete", "--backend", "cpp"])
+        assert rc == 0
+        assert noop.read_bytes() == routed.read_bytes(), "no-op must not mutate the board"
+
+    def test_composes_with_explicit_route_engine_lattice(
+        self, stranded_board: Path, tmp_path: Path, capsys
+    ):
+        # --complete + explicit --route-engine lattice must NOT trip the #4280
+        # gate; the coerced strategy prints a notice rather than erroring.
+        out = tmp_path / "compose_out.kicad_pcb"
+        rc = route_main(
+            [
+                str(stranded_board),
+                "-o",
+                str(out),
+                "--complete",
+                "--route-engine",
+                "lattice",
+                "--backend",
+                "cpp",
+            ]
+        )
+        assert rc == 0
+        assert 2 in _segment_nets(out.read_text())


### PR DESCRIPTION
## Summary

Phase 1 of the route/complete epic (**Part of #4465**; parent defect #4434). Adds a first-class `kct route --complete` mode that routes ONLY the currently-unconnected signal links against all existing copper held as fixed obstacles.

The pieces existed but were unwired for this use case:
- lattice netset driver ingests fixed copper (`core.py:_negotiate_lattice_netset` routes only `self.nets` against `fixed_copper = existing_routes not in self.nets`, #4355),
- detection (`partial_rescue.partially_connected_signal_nets`, include_unrouted),
- the #4322 `--nets` route-only machinery (invert into `--skip-nets` + imply `--preserve-existing`).

`--complete` composes them.

## What it does

`kct route <board> --complete`:
1. auto-detects the currently-unconnected signal nets via `partially_connected_signal_nets(include_unrouted=True)`,
2. sets the routable net set to exactly those links, loading all other copper as fixed obstacles,
3. implies `--preserve-existing` (which arms the #4413 copper-loss guard at every save site) and selects the **lattice** engine + `--strategy basic` unless the user overrides `--route-engine`,
4. is a **byte-identical no-op** on an already-connected board (written back through the atomic writer, never a full re-route).

## #4280 gate carve-out

`_validate_route_engine_strategy` now recognizes `--complete` as a route-only-listed-links contract (NOT the whole-netset negotiation the gate protects): `--route-engine lattice --complete` is permitted, and a negotiated `--strategy` is **coerced to basic with a printed notice** rather than rejected. The genuinely-incompatible modifiers (`--two-phase` / `--multi-resolution` / `--escape-routing`) remain hard conflicts even under `--complete`.

## Scope discipline

- `--complete` declared on **both** route parsers (`parser.py` outer + `route_cmd.py` inner) and the `commands/routing.py` forwarding shim, so `tests/test_cli_parser_drift.py` stays green.
- Plain `kct route` without `--complete` is unchanged (flag-off argv byte-identical).
- Mutually exclusive with `--nets` / `--skip-nets` (—complete chooses the net set itself).

## Non-goals (later phases)
Localized per-link bbox build (Phase 2 #4472 — whole-board build is used here), via-in-pad last-resort (Phase 3), reporting (Phase 4), rewiring `partial_rescue` (Phase 5).

## Acceptance criteria
- [x] `--complete` routes only the unconnected links, all other copper fixed, never deletes copper (#4413 guard active via preserve-existing).
- [x] On a fixture with one deliberately-stranded link (NET2) on an otherwise-routed board (NET1), `--complete` closes it on lattice; NET1's copper is preserved (segment net-1 retained, 4 new net-2 segments; post-route connectivity clean).
- [x] `--complete` composes with `--route-engine lattice` without tripping #4280; coerced strategy prints a notice.
- [x] `kct route` WITHOUT `--complete` is byte-identical (parser-drift golden + route-output goldens pass).

## Testing
- New `tests/test_cli_route_complete_4471.py`: 15 tests (defaults helper, detection/mutual-exclusion/no-op, gate carve-out, end-to-end stranded-link routing + no-op + lattice compose). All pass.
- Regression: `test_route_engine_strategy_gate`, `test_cli_route_nets_flag`, `test_route_cmd_input_preservation`, `test_cli_parser_drift`, `test_route_grid_safety_gate` — 82 pass.
- Lint (`ruff check` + `ruff format`) clean; mypy baseline gate exit 0 (no new type errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)