### PR TITLE
fix(router/cpp): keep Grid3D alive for the lifetime of the pathfinder

### DIFF
--- a/src/kicad_tools/router/cpp/src/bindings.cpp
+++ b/src/kicad_tools/router/cpp/src/bindings.cpp
@@ -273,8 +273,22 @@ NB_MODULE(router_cpp, m) {
 
     // Pathfinder class
     nb::class_<Pathfinder>(m, "Pathfinder")
+        // Issue #4485: ``Pathfinder`` stores ``Grid3D& grid_`` -- a bare C++
+        // reference to the ``Grid3D`` argument.  Without a keep-alive policy
+        // nanobind is free to garbage-collect the Python ``Grid3D`` wrapper as
+        // soon as the caller drops its last reference (e.g. the common
+        // ``Pathfinder(Grid3D(...), rules).route(...)`` idiom, where the grid
+        // is an unnamed temporary).  That frees the underlying ``cells_``
+        // storage and leaves ``grid_`` dangling; the next ``route()`` reads
+        // freed heap, producing the nondeterministic segment-count instability
+        // reported in #4485 (confirmed as a heap-use-after-free by
+        // AddressSanitizer at ``pathfinder.cpp`` ``grid_.at(...)``).
+        // ``keep_alive<1, 2>`` ties the grid's lifetime (patient, arg index 2)
+        // to the newly-constructed Pathfinder (nurse, index 1 = the implicit
+        // ``self``/instance slot of the ``__init__`` binding).
         .def(nb::init<Grid3D&, const DesignRules&, bool>(),
-             "grid"_a, "rules"_a, "diagonal_routing"_a = true)
+             "grid"_a, "rules"_a, "diagonal_routing"_a = true,
+             nb::keep_alive<1, 2>())
         // Issue #4346: ``start_pad_bounds`` / ``end_pad_bounds`` are bound via a
         // thin lambda taking ``std::optional<PadBounds>`` defaulting to
         // ``nb::none()`` instead of a materialized ``PadBounds{}`` default arg.
@@ -491,11 +505,17 @@ NB_MODULE(router_cpp, m) {
     // the string-keyed rejection histogram out of the C++ search (previously
     // Python-only), surfaced on ``CoupledRouteResult::rejections``.
     nb::class_<CoupledPathfinder>(m, "CoupledPathfinder")
+        // Issue #4485: like ``Pathfinder``, ``CoupledPathfinder`` holds a bare
+        // ``Grid3D& grid_`` reference, so the grid argument must outlive the
+        // pathfinder.  ``keep_alive<1, 2>`` ties the grid (patient, arg index
+        // 2) to the constructed CoupledPathfinder (nurse, index 1) to prevent
+        // the same dangling-reference use-after-free.
         .def(nb::init<Grid3D&, const DesignRules&, int, int, int, int, int,
                       double, double>(),
              "grid"_a, "rules"_a, "target_spacing_cells"_a, "min_spacing_cells"_a,
              "trace_half_width_cells"_a, "via_extra_cells"_a, "via_drill_cells"_a,
-             "spacing_penalty_factor"_a, "heuristic_weight"_a)
+             "spacing_penalty_factor"_a, "heuristic_weight"_a,
+             nb::keep_alive<1, 2>())
         .def("route", &CoupledPathfinder::route,
              "p_start_x"_a, "p_start_y"_a, "n_start_x"_a, "n_start_y"_a,
              "start_layer"_a,

--- a/tests/test_router_cpp_grid_keepalive_4485.py
+++ b/tests/test_router_cpp_grid_keepalive_4485.py
@@ -1,0 +1,160 @@
+"""Regression tests for issue #4485.
+
+``tests/test_router_cpp_padbounds_leak_4346.py::
+test_omitted_pad_bounds_matches_explicit_all_zero`` failed intermittently in
+CI with nondeterministic segment counts (``assert 2 == 0``, ``assert 98 ==
+90``, ...).  AddressSanitizer traced this to a **heap-use-after-free** inside
+``Pathfinder::route`` at ``grid_.at(...)``: the C++ ``Pathfinder`` stores a
+bare ``Grid3D& grid_`` reference, but the nanobind constructor binding lacked a
+``keep_alive`` policy.  In the common ``_make_pathfinder().route(...)`` idiom
+the ``Grid3D`` Python wrapper is an unnamed temporary whose last reference is
+dropped as soon as the factory returns, so nanobind garbage-collects it and
+frees the underlying ``cells_`` storage -- leaving ``grid_`` dangling.  The
+next ``route()`` then reads freed heap, and whatever happens to occupy that
+memory (allocator- and load-dependent) steers the A* search down different
+paths, hence the run-to-run instability.
+
+The fix adds ``nb::keep_alive<1, 2>()`` to the ``Pathfinder`` and
+``CoupledPathfinder`` constructor bindings, tying the grid argument's lifetime
+to the constructed pathfinder.  These tests assert that policy directly (the
+grid's Python reference count is elevated by the pathfinder holding a strong
+reference) and behaviourally (routing remains valid and deterministic after
+every external reference to the grid has been dropped and collected).
+"""
+
+import gc
+import sys
+
+import pytest
+
+from kicad_tools.router.cpp_backend import is_cpp_available
+
+pytestmark = pytest.mark.skipif(
+    not is_cpp_available(),
+    reason="C++ router backend not built (run `kct build-native`)",
+)
+
+
+def _make_rules():
+    from kicad_tools.router import router_cpp
+
+    rules = router_cpp.DesignRules()
+    rules.trace_width = 0.2
+    rules.trace_clearance = 0.2
+    rules.via_diameter = 0.6
+    rules.via_drill = 0.3
+    rules.via_clearance = 0.2
+    rules.grid_resolution = 0.5
+    return rules
+
+
+_ROUTE_KWARGS = {
+    "start_x": 5.0 * 0.5,
+    "start_y": 50.0 * 0.5,
+    "start_layer": 0,
+    "end_x": 95.0 * 0.5,
+    "end_y": 50.0 * 0.5,
+    "end_layer": 0,
+    "net": 1,
+}
+
+
+def test_pathfinder_keeps_grid_alive() -> None:
+    """Constructing a ``Pathfinder`` must hold a strong reference to its grid.
+
+    Without ``nb::keep_alive<1, 2>()`` the pathfinder stores only a bare C++
+    ``Grid3D&`` and does NOT bump the Python refcount, so the grid can be
+    freed out from under the still-live pathfinder (issue #4485).  A refcount
+    delta of at least one proves the keep-alive edge exists.
+    """
+    from kicad_tools.router import router_cpp
+
+    grid = router_cpp.Grid3D(100, 100, 2, 0.5, 0.0, 0.0)
+    before = sys.getrefcount(grid)
+    pathfinder = router_cpp.Pathfinder(grid, _make_rules(), True)
+    after = sys.getrefcount(grid)
+
+    assert after > before, (
+        "Pathfinder did not take a strong reference to its Grid3D -- the "
+        "nb::keep_alive<1, 2> policy on the constructor binding has regressed "
+        f"(refcount {before} -> {after}, issue #4485)."
+    )
+    # Keep ``pathfinder`` live until after the assertion.
+    assert pathfinder is not None
+
+
+def test_coupled_pathfinder_keeps_grid_alive() -> None:
+    """``CoupledPathfinder`` has the same bare ``Grid3D&`` member and must
+    likewise keep its grid alive (issue #4485)."""
+    from kicad_tools.router import router_cpp
+
+    grid = router_cpp.Grid3D(100, 100, 2, 0.5, 0.0, 0.0)
+    before = sys.getrefcount(grid)
+    coupled = router_cpp.CoupledPathfinder(grid, _make_rules(), 4, 2, 1, 0, 1, 1.0, 1.0)
+    after = sys.getrefcount(grid)
+
+    assert after > before, (
+        "CoupledPathfinder did not take a strong reference to its Grid3D -- "
+        "the nb::keep_alive<1, 2> policy has regressed (refcount "
+        f"{before} -> {after}, issue #4485)."
+    )
+    assert coupled is not None
+
+
+def test_route_survives_dropped_grid_reference() -> None:
+    """Routing must stay valid after every external grid reference is dropped.
+
+    This reproduces the exact ``_make_pathfinder().route(...)`` shape from the
+    #4485 failure: the ``Grid3D`` is an unnamed temporary owned only by the
+    pathfinder.  We force a collection between construction and routing (and
+    churn the allocator) so that, absent the keep-alive fix, the freed grid
+    storage would very likely be reused -- corrupting the A* search.  With the
+    fix the grid stays alive and the route is well-formed.
+    """
+    from kicad_tools.router import router_cpp
+
+    def make_pathfinder():
+        # The Grid3D temporary has NO surviving Python name once this
+        # function returns -- only the Pathfinder's keep-alive edge holds it.
+        return router_cpp.Pathfinder(
+            router_cpp.Grid3D(100, 100, 2, 0.5, 0.0, 0.0), _make_rules(), True
+        )
+
+    pathfinder = make_pathfinder()
+
+    # Aggressively encourage reuse of any freed grid storage.
+    gc.collect()
+    _churn = [bytearray(4096) for _ in range(256)]
+    del _churn
+    gc.collect()
+
+    result = pathfinder.route(**_ROUTE_KWARGS)
+    assert result.success, "route on a pathfinder whose grid temporary was dropped failed"
+    assert len(result.segments) > 0
+
+
+def test_dropped_grid_route_matches_retained_grid_route() -> None:
+    """A route whose grid was dropped must match one whose grid is retained.
+
+    Establishes the equivalence the original #4485 test asserted, but framed as
+    the actual invariant at stake: dropping the caller's grid reference must
+    NOT change routing.  Run repeatedly to catch any residual nondeterminism.
+    """
+    from kicad_tools.router import router_cpp
+
+    # Reference: keep an explicit local name on the grid for its whole life.
+    retained_grid = router_cpp.Grid3D(100, 100, 2, 0.5, 0.0, 0.0)
+    retained_pf = router_cpp.Pathfinder(retained_grid, _make_rules(), True)
+    reference = retained_pf.route(**_ROUTE_KWARGS)
+    assert reference.success
+
+    for _ in range(25):
+        # Grid is a pure temporary held only by the pathfinder.
+        pf = router_cpp.Pathfinder(
+            router_cpp.Grid3D(100, 100, 2, 0.5, 0.0, 0.0), _make_rules(), True
+        )
+        gc.collect()
+        result = pf.route(**_ROUTE_KWARGS)
+        assert result.success
+        assert len(result.segments) == len(reference.segments)
+        assert len(result.vias) == len(reference.vias)


### PR DESCRIPTION
## Summary

Root-causes and fixes the flaky/nondeterministic CI failure in
`tests/test_router_cpp_padbounds_leak_4346.py::test_omitted_pad_bounds_matches_explicit_all_zero`
(issue #4485). The test asserted that routing with omitted pad-bounds args
produces the same segment count as passing explicit all-zero `PadBounds()`,
but the counts diverged nondeterministically across CI runs (`assert 2 == 0`,
`assert 98 == 90`, `assert 123 == 122`), turning the blocking **Test** gate
red on unrelated Python-only PRs.

**This was not a real omitted-vs-explicit-PadBounds behavior difference** —
both `route()` calls in the test pass an all-zero `PadBounds{}` and route the
same input. The divergence was **memory corruption**.

## Root cause (confirmed with AddressSanitizer)

The nanobind `Pathfinder` (and `CoupledPathfinder`) constructor bindings stored
the incoming grid only as a bare C++ `Grid3D& grid_` reference, with **no
keep-alive call policy**. In the `_make_pathfinder().route(...)` idiom the
`Grid3D` is an unnamed Python temporary whose last reference is dropped when the
factory returns, so nanobind garbage-collects the wrapper and frees its
`cells_` storage — leaving `grid_` **dangling**. The next `route()` reads freed
heap at `grid_.at(...)`, and whatever allocator/load-dependent bytes occupy that
memory steer the A* search down different paths.

ASan pins it exactly:

```
ERROR: AddressSanitizer: heap-use-after-free ... in router::Pathfinder::route ... pathfinder.cpp:1081
  freed by: nanobind::detail::wrap_destruct<router::Grid3D> ... inst_dealloc  (grid GC'd)
  allocated by: router::Grid3D::Grid3D ... cells_ vector
```

Diagnosis path: the flake reproduces locally **only under `MallocScribble=1`**
(freed-memory poisoning), not `MallocPreScribble` — the signature of reading
freed-then-reused memory. An ASan build then named the exact use-after-free.

## Changes

- `src/kicad_tools/router/cpp/src/bindings.cpp`: add `nb::keep_alive<1, 2>()`
  to the `Pathfinder` and `CoupledPathfinder` constructor bindings, tying the
  grid argument's lifetime (patient) to the constructed pathfinder (nurse).
  `CoupledPathfinder` carries the identical latent bug and is fixed in the same
  pass.
- `tests/test_router_cpp_grid_keepalive_4485.py` (new): guards the policy
  directly (the grid's Python refcount is elevated by the pathfinder holding a
  strong reference) and behaviourally (routing stays valid + deterministic
  after the caller's grid reference is dropped and GC'd).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Root-cause the nondeterminism (not re-run/skip) | ✅ | ASan: heap-use-after-free from GC'd `Grid3D`; dangling `grid_` reference |
| Prefer a determinism fix over weakening the test | ✅ | Fixed the lifetime bug in C++ bindings; original test unchanged and now stable |
| Router produces identical output for identical input | ✅ | 300+ scribbled iterations and 40/40 pytest runs all stable at 90/90 segments |
| No retry/skip band-aid | ✅ | No skip/retry added; structural keep-alive fix |
| Confirm determinism over many repeat runs | ✅ | 40/40 flaky-test runs pass under `MallocScribble`+`MallocPreScribble`; ASan build clean post-fix |

## Test Plan

- Reproduced the flake locally: under `MallocScribble=1`, single and paired
  routes returned wildly varying segment counts (90/126/148/171/272…).
- Built the extension with `-fsanitize=address`; the unmodified code fails with
  a heap-use-after-free at `pathfinder.cpp` `grid_.at()`; **after the fix the
  ASan build is clean** across 80 paired iterations.
- Production (non-ASan) build via `kct build-native --force`:
  - 300 iterations under `MallocScribble`+`MallocPreScribble` → single distinct
    result `(90, 90, 0, 0)`.
  - 40/40 runs of the previously-flaky test pass under scribbling.
  - New regression file + original `test_router_cpp_padbounds_leak_4346.py`:
    7 passed.
  - Broader router C++ suite (`test_router_cpp_backend`, `test_grid_cpp_parity`,
    `test_route_deterministic_budget_load_independence`, and others):
    112 passed, 6 skipped.
- `ruff check` / `ruff format` clean on the new test file.

Closes #4485

🤖 Generated with [Claude Code](https://claude.com/claude-code)