### PR TITLE
feat(route/complete): localize the lattice build to a per-link bbox + per-link deadline

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -4511,6 +4511,11 @@ def route_with_layer_escalation(
                     # Issue #4148: region-bounded routing.  When set, cells
                     # outside the board-relative box are marked as obstacles.
                     region=getattr(args, "_region_box", None),
+                    # Issue #4472 (epic #4465, Phase 2): --complete localizes the
+                    # lattice build + static masks to the region box, and bounds
+                    # each link's search with a per-link wall-clock budget.
+                    localize_lattice_to_region=getattr(args, "_complete_localized", False),
+                    lattice_link_budget_s=getattr(args, "_complete_link_budget_s", None),
                     # Issue #4170 (Phase 2b-1): board-relative boundary stub
                     # terminals whose tip cells are carved open as same-net
                     # reconnection targets (None when no --region / no stubs).
@@ -5457,6 +5462,11 @@ def route_with_rule_relaxation(
                     load_existing_routes=getattr(args, "preserve_existing", False),
                     # Issue #4148: region-bounded routing (see main()).
                     region=getattr(args, "_region_box", None),
+                    # Issue #4472 (epic #4465, Phase 2): --complete localizes the
+                    # lattice build + static masks to the region box, and bounds
+                    # each link's search with a per-link wall-clock budget.
+                    localize_lattice_to_region=getattr(args, "_complete_localized", False),
+                    lattice_link_budget_s=getattr(args, "_complete_link_budget_s", None),
                     # Issue #4170 (Phase 2b-1): board-relative boundary stub
                     # terminals whose tip cells are carved open as same-net
                     # reconnection targets (None when no --region / no stubs).
@@ -7626,6 +7636,11 @@ def route_with_combined_escalation(
                         load_existing_routes=getattr(args, "preserve_existing", False),
                         # Issue #4148: region-bounded routing (see main()).
                         region=getattr(args, "_region_box", None),
+                        # Issue #4472 (epic #4465, Phase 2): --complete localizes the
+                        # lattice build + static masks to the region box, and bounds
+                        # each link's search with a per-link wall-clock budget.
+                        localize_lattice_to_region=getattr(args, "_complete_localized", False),
+                        lattice_link_budget_s=getattr(args, "_complete_link_budget_s", None),
                         # Issue #4170 (Phase 2b-1): board-relative boundary stub
                         # terminals whose tip cells are carved open as same-net
                         # reconnection targets (None when no --region / no stubs).
@@ -8786,6 +8801,165 @@ def _resolve_complete_nets(args, pcb_path: Path) -> int:
     if not getattr(args, "quiet", False):
         preview = ", ".join(stranded)
         print(f"--complete: routing {len(stranded)} unconnected signal net(s): {preview}")
+    return 0
+
+
+# Issue #4472 (epic #4465, Phase 2): --complete localization tunables.
+#
+# The per-link escape margin grows each stranded net's pad-to-pad bbox by
+# enough room for a legal escape stub + a via site + clearance on every side,
+# so the localized lattice still contains the route the un-localized build
+# would find.  3.0 mm comfortably covers a jlcpcb via land (~0.6 mm) plus a
+# short escape neck and clearance; the box is additionally snapped OUTWARD to
+# the whole-board coarse grid inside the router, adding up to one coarse cell
+# of headroom per side.
+_COMPLETE_BBOX_MARGIN_MM = 3.0
+# A stranded net whose own pad span exceeds this fraction of the board's
+# corresponding dimension defeats localization (its box is ~the whole board);
+# it is REPORTED (expand-and-continue) rather than silently mis-bounded.
+_COMPLETE_OVERSIZE_FRACTION = 0.9
+# Default per-link wall-clock budget (seconds) when --per-net-timeout is
+# disabled (0) -- e.g. under --deterministic-budget.  Kept as a safety
+# backstop so a completion search still aborts within a bounded budget.
+_COMPLETE_LINK_BUDGET_DEFAULT_S = 60.0
+
+
+def _resolve_complete_link_budget(args) -> float:
+    """Per-link wall-clock budget (seconds) for a ``--complete`` pass.
+
+    Issue #4472.  Reuses the existing wall-clock plumbing: an explicit
+    ``--per-net-timeout`` (the per-net A* cutoff) doubles as the per-link
+    completion budget; when it is disabled (``0``, e.g. under
+    ``--deterministic-budget``) a bounded default backstop is used so the
+    search still aborts within a budget rather than grinding (issue #4434).
+    """
+    t = getattr(args, "per_net_timeout", None)
+    if t and t > 0:
+        return float(t)
+    return _COMPLETE_LINK_BUDGET_DEFAULT_S
+
+
+def _apply_complete_localization(args, pcb_path: Path) -> int:
+    """Localize a ``--complete`` pass to a per-link bounding box (Issue #4472).
+
+    Computes the union of the stranded nets' pad bounding boxes (board-relative,
+    matching ``--region``), grows it by an escape margin, and stamps it on
+    ``args._region_box`` so the EXISTING ``--region`` plumbing carries it into
+    ``load_pcb_for_routing`` -- there ``localize_lattice_to_region`` confines the
+    octilinear lattice build + static masks to that pocket instead of the whole
+    board.  Also stamps the per-link wall-clock budget.  A user-supplied
+    ``--region`` is respected verbatim (the lattice localizes to it instead).
+
+    Per-net reasonableness (expand-or-decline AC): a stranded net whose pads
+    span more than :data:`_COMPLETE_OVERSIZE_FRACTION` of a board dimension
+    cannot benefit from localization; it is REPORTED and the union box is
+    expanded to include it (correctness preserved) rather than silently
+    mis-bounded.  No-op when ``--complete`` is absent or found nothing stranded.
+    """
+    if not getattr(args, "complete", False):
+        return 0
+    if getattr(args, "_complete_noop", False):
+        return 0
+
+    # Arm the localization flag + per-link budget regardless of how the box is
+    # sourced (auto-computed here, or a user-supplied --region parsed later).
+    args._complete_localized = True
+    args._complete_link_budget_s = _resolve_complete_link_budget(args)
+
+    # A user-supplied --region wins: honor their explicit spatial bound and let
+    # the lattice localize to it (the box is stamped later by
+    # _parse_and_apply_region).  Do not compute an auto box on top of it.
+    if getattr(args, "region", None):
+        return 0
+
+    quiet = getattr(args, "quiet", False)
+    try:
+        from kicad_tools.schema.pcb import PCB as _SchemaPCB
+
+        pcb = _SchemaPCB.load(str(pcb_path))
+    except Exception as e:  # pragma: no cover - load errors surface later too
+        # Non-fatal: fall back to the whole-board build (still correct, slower).
+        if not quiet:
+            print(f"--complete: could not localize the lattice build ({e}); using whole board.")
+        return 0
+
+    stranded = {n for n in (args.nets.split(",") if getattr(args, "nets", None) else []) if n}
+    if not stranded:
+        return 0
+
+    # Board outline bbox (board-relative, matching the --region convention).
+    outline = pcb.get_board_outline()
+    board_box = None
+    if outline:
+        board_box = (
+            min(p[0] for p in outline),
+            min(p[1] for p in outline),
+            max(p[0] for p in outline),
+            max(p[1] for p in outline),
+        )
+
+    # Collect each stranded net's pad positions (board-relative).
+    pads_by_net: dict[str, list[tuple[float, float]]] = {}
+    for fp in pcb.footprints:
+        for pad in fp.pads:
+            net_name = getattr(pad, "net_name", "") or ""
+            if net_name not in stranded:
+                continue
+            pos = pcb.get_pad_position(fp.reference, pad.number)
+            if pos is None:
+                continue
+            pads_by_net.setdefault(net_name, []).append((pos[0], pos[1]))
+
+    if not pads_by_net:
+        if not quiet:
+            print("--complete: no pad geometry found for the stranded nets; using whole board.")
+        return 0
+
+    board_w = (board_box[2] - board_box[0]) if board_box else float("inf")
+    board_h = (board_box[3] - board_box[1]) if board_box else float("inf")
+
+    oversized: list[str] = []
+    ux0 = uy0 = float("inf")
+    ux1 = uy1 = float("-inf")
+    for net_name, pts in pads_by_net.items():
+        nx0 = min(p[0] for p in pts)
+        ny0 = min(p[1] for p in pts)
+        nx1 = max(p[0] for p in pts)
+        ny1 = max(p[1] for p in pts)
+        if (nx1 - nx0) > _COMPLETE_OVERSIZE_FRACTION * board_w or (
+            ny1 - ny0
+        ) > _COMPLETE_OVERSIZE_FRACTION * board_h:
+            oversized.append(net_name)
+        ux0, uy0 = min(ux0, nx0), min(uy0, ny0)
+        ux1, uy1 = max(ux1, nx1), max(uy1, ny1)
+
+    m = _COMPLETE_BBOX_MARGIN_MM
+    box = (ux0 - m, uy0 - m, ux1 + m, uy1 + m)
+    if board_box:
+        box = (
+            max(box[0], board_box[0]),
+            max(box[1], board_box[1]),
+            min(box[2], board_box[2]),
+            min(box[3], board_box[3]),
+        )
+    args._region_box = box
+    # A localized build re-routes only the stranded pocket against fixed copper;
+    # a whole-board cached result must not be reused (mirrors --region).
+    args.no_cache = True
+
+    if not quiet:
+        print(
+            "--complete: localized lattice build to "
+            f"({box[0]:.2f}, {box[1]:.2f})-({box[2]:.2f}, {box[3]:.2f}) mm "
+            f"(+{m:.1f} mm escape margin); per-link budget "
+            f"{args._complete_link_budget_s:.0f}s."
+        )
+        if oversized:
+            print(
+                "--complete: WARNING: net(s) span most of the board and cannot "
+                f"benefit from localization (box expanded to include them): "
+                f"{', '.join(sorted(oversized))}"
+            )
     return 0
 
 
@@ -10760,6 +10934,17 @@ def main(argv: list[str] | None = None) -> int:
         if rc != 0:
             return rc
 
+    # Issue #4472 (epic #4465, Phase 2): localize a --complete pass to a
+    # per-link bounding box.  Runs AFTER --region so a user-supplied box wins
+    # (the lattice localizes to it); otherwise the union of the stranded nets'
+    # pad bboxes + escape margin is stamped on ``args._region_box`` and the
+    # per-link wall-clock budget is armed.  No-op unless --complete is active.
+    args._complete_localized = False
+    args._complete_link_budget_s = None
+    _loc_rc = _apply_complete_localization(args, pcb_path)
+    if _loc_rc != 0:
+        return _loc_rc
+
     # Issue #3154: advisory schematic/PCB drift banner.  Non-blocking -- the
     # hard gate lives behind 'kct check --netlist-sync'.  Skips silently when
     # no schematic is discovered, when in sync, or when --no-sync-check / --quiet.
@@ -11440,6 +11625,11 @@ def main(argv: list[str] | None = None) -> int:
                 load_existing_routes=getattr(args, "preserve_existing", False),
                 # Issue #4148: region-bounded routing (see main()).
                 region=getattr(args, "_region_box", None),
+                # Issue #4472 (epic #4465, Phase 2): --complete localizes the
+                # lattice build + static masks to the region box, and bounds
+                # each link's search with a per-link wall-clock budget.
+                localize_lattice_to_region=getattr(args, "_complete_localized", False),
+                lattice_link_budget_s=getattr(args, "_complete_link_budget_s", None),
                 # Issue #4170 (Phase 2b-1): board-relative boundary stub
                 # terminals whose tip cells are carved open as same-net
                 # reconnection targets (None when no --region / no stubs).
@@ -11503,6 +11693,11 @@ def main(argv: list[str] | None = None) -> int:
                 load_existing_routes=getattr(args, "preserve_existing", False),
                 # Issue #4148: region-bounded routing (see main()).
                 region=getattr(args, "_region_box", None),
+                # Issue #4472 (epic #4465, Phase 2): --complete localizes the
+                # lattice build + static masks to the region box, and bounds
+                # each link's search with a per-link wall-clock budget.
+                localize_lattice_to_region=getattr(args, "_complete_localized", False),
+                lattice_link_budget_s=getattr(args, "_complete_link_budget_s", None),
                 # Issue #4170 (Phase 2b-1): board-relative boundary stub
                 # terminals whose tip cells are carved open as same-net
                 # reconnection targets (None when no --region / no stubs).

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -1085,6 +1085,24 @@ class Autorouter:
         # Issue #4270: per-diff-pair coupled-routing outcomes for the lattice
         # engine ("coupled" or a decline reason), keyed by pair base name.
         self._lattice_pair_outcomes: dict[str, str] = {}
+        # Issue #4472 (epic #4465, Phase 2): localized per-link lattice build.
+        # When set to a WORLD-coordinate ``(x1, y1, x2, y2)`` box,
+        # :meth:`_ensure_lattice_pathfinder` builds the octilinear lattice +
+        # per-layer static pad masks over ONLY this box (snapped to the
+        # whole-board coarse grid so in-box nodes stay a subset of the
+        # whole-board lattice) instead of the entire board outline.  This is
+        # the ``--complete`` perf enabler: a completion pass re-routing one
+        # walled link pays a per-link build + A* rather than a whole-board one
+        # (issue #4434's ">10-minute" non-termination).  ``None`` preserves
+        # the whole-board build byte-for-byte.
+        self._lattice_region_world: tuple[float, float, float, float] | None = None
+        # Issue #4472: per-link wall-clock budget (seconds) for the lattice
+        # netset negotiation.  When set, :meth:`_negotiate_lattice_netset`
+        # stamps an absolute monotonic deadline (budget x link-count) and
+        # ``route_netset`` aborts the negotiation once it passes, returning the
+        # best routes found so far.  ``None`` preserves the unbudgeted
+        # (iteration-capped only) behaviour.
+        self._lattice_link_budget_s: float | None = None
 
         # Initialize grid and routers using shared helper
         # Issue #972: Helper includes adaptive grid resolution for large boards
@@ -2451,6 +2469,8 @@ class Autorouter:
         :meth:`_ensure_mesh_pathfinder`: the Edge.Cuts bbox when the board has
         an outline, else the grid origin/dimensions fallback.
         """
+        import inspect
+
         from .lattice.pathfinder import LatticePathfinder
 
         if self._lattice_pathfinder is None:
@@ -2461,6 +2481,20 @@ class Autorouter:
                 by0 = self.grid.origin_y
                 bx1 = self.grid.origin_x + self.grid.width
                 by1 = self.grid.origin_y + self.grid.height
+            # Issue #4472: localized per-link build.  When a completion pass
+            # has stamped a per-link region box, snap it to the whole-board
+            # lattice coarse grid and build the lattice over ONLY that box.
+            # Snapping to the same coarse origin the whole-board build would
+            # use keeps the localized lattice's in-box nodes an exact subset of
+            # the whole-board lattice (the pad set -- and thus the refine
+            # max-level and node ``unit`` -- is unchanged), so a route that
+            # stays inside the box is identical to the un-localized build; this
+            # is a pure perf optimization, not a routing-behaviour change.
+            if self._lattice_region_world is not None:
+                coarse = inspect.signature(LatticePathfinder).parameters["coarse"].default
+                bx0, by0, bx1, by1 = self._snap_lattice_region(
+                    self._lattice_region_world, (bx0, by0, bx1, by1), float(coarse)
+                )
             outline = [(bx0, by0), (bx1, by0), (bx1, by1), (bx0, by1)]
             # The lattice is replicated across the board's REAL copper stack
             # (issue #4278 acceptance 6) -- never hardcoded to 2 layers.
@@ -2476,6 +2510,51 @@ class Autorouter:
                 layer_stack=self.layer_stack,
             )
         return self._lattice_pathfinder
+
+    @staticmethod
+    def _snap_lattice_region(
+        box: tuple[float, float, float, float],
+        board_bbox: tuple[float, float, float, float],
+        coarse: float,
+    ) -> tuple[float, float, float, float]:
+        """Snap a per-link region box to the whole-board lattice coarse grid.
+
+        Issue #4472.  The octilinear lattice anchors its node grid at the
+        outline's min corner (``OctilinearLattice.origin == bbox[:2]``) and
+        places nodes at integer multiples of its cell unit from there.  A
+        localized build over an arbitrary sub-box would therefore shift every
+        node, changing routes.  Snapping the box OUTWARD to the whole-board
+        coarse grid (origin == ``board_bbox`` min, cell == ``coarse``) makes
+        the localized coarse cells -- and hence the derived fine nodes -- align
+        exactly with the whole-board lattice, so a route that stays inside the
+        box is identical to the un-localized build.  The result is clamped to
+        the board bbox and kept non-degenerate (at least one coarse cell).
+        """
+        rx0, ry0, rx1, ry1 = box
+        lo_x, hi_x = min(rx0, rx1), max(rx0, rx1)
+        lo_y, hi_y = min(ry0, ry1), max(ry0, ry1)
+        bx0, by0, bx1, by1 = board_bbox
+        # Clamp the requested box into the board before snapping.
+        lo_x = min(max(lo_x, bx0), bx1)
+        lo_y = min(max(lo_y, by0), by1)
+        hi_x = min(max(hi_x, bx0), bx1)
+        hi_y = min(max(hi_y, by0), by1)
+        if coarse <= 0:
+            return (bx0, by0, bx1, by1)
+        # Snap outward to the whole-board coarse grid (origin at the board min).
+        lo_x = bx0 + math.floor((lo_x - bx0) / coarse) * coarse
+        lo_y = by0 + math.floor((lo_y - by0) / coarse) * coarse
+        hi_x = bx0 + math.ceil((hi_x - bx0) / coarse) * coarse
+        hi_y = by0 + math.ceil((hi_y - by0) / coarse) * coarse
+        # Clamp back to the board (snapping out can only overshoot the board
+        # edge, never the interior origin) and guarantee a non-empty extent.
+        lo_x, lo_y = max(lo_x, bx0), max(lo_y, by0)
+        hi_x, hi_y = min(hi_x, bx1), min(hi_y, by1)
+        if hi_x <= lo_x:
+            hi_x = min(bx1, lo_x + coarse)
+        if hi_y <= lo_y:
+            hi_y = min(by1, lo_y + coarse)
+        return (lo_x, lo_y, hi_x, hi_y)
 
     def _lattice_coupled_connections(
         self,
@@ -2661,11 +2740,22 @@ class Autorouter:
         # this the lattice sees the non-listed pads but not the traces between
         # them and legally crosses foreign copper -> segment-segment shorts.
         fixed_copper = [r for r in self.existing_routes if r.net not in self.nets]
+        # Issue #4472: per-link wall-clock deadline.  ``--complete`` stamps a
+        # per-link budget so each completion search aborts within a bounded
+        # budget instead of grinding (issue #4434's >10-minute non-termination)
+        # -- the deadline scales with the number of links being closed so a
+        # small cohort stays bounded while a larger set is still given
+        # proportional headroom.  ``None`` preserves the unbudgeted behaviour.
+        deadline: float | None = None
+        if self._lattice_link_budget_s and self._lattice_link_budget_s > 0:
+            link_count = max(1, len(connections) + len(coupled))
+            deadline = time.monotonic() + self._lattice_link_budget_s * link_count
         routes_by_key, stats = pf.route_netset(
             connections,
             coupled=coupled,
             fixed_copper=fixed_copper,
             max_iterations=max_iterations,
+            deadline=deadline,
         )
         self._lattice_negotiation_stats = stats
 

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -3387,6 +3387,8 @@ def load_pcb_for_routing(
     region: tuple[float, float, float, float] | None = None,
     stub_terminals: dict[int, list[StubTerminal]] | None = None,
     strategy: str = "grid",
+    localize_lattice_to_region: bool = False,
+    lattice_link_budget_s: float | None = None,
 ) -> tuple[Autorouter, dict[str, int]]:
     """
     Load a KiCad PCB file and create an Autorouter with all components.
@@ -3460,6 +3462,19 @@ def load_pcb_for_routing(
                 :class:`Pad` and are never inserted into ``router.pads`` /
                 ``router.nets``.  Requires ``load_existing_routes=True`` (the
                 stub copper must be loaded first).
+        localize_lattice_to_region: Issue #4472 (epic #4465, Phase 2).  When
+                True AND ``region`` is set, the WORLD-coordinate region box is
+                stamped on ``router._lattice_region_world`` so the octilinear
+                lattice build + per-layer static masks are confined to that box
+                (snapped to the whole-board coarse grid) instead of the entire
+                board outline.  This is the ``--complete`` perf enabler that
+                bounds a per-link completion build + A* to the walled pocket.
+                Default False keeps a plain ``--region`` run whole-board.
+        lattice_link_budget_s: Issue #4472.  Optional per-link wall-clock
+                budget (seconds) stamped on ``router._lattice_link_budget_s``;
+                the lattice netset negotiation aborts within
+                ``budget x link-count`` seconds and returns the best routes so
+                far.  ``None`` preserves the unbudgeted negotiation.
 
     Returns:
         Tuple of (Autorouter instance, net_map dict)
@@ -3906,6 +3921,20 @@ def load_pcb_for_routing(
             max(ry1, ry2),
             blocked,
         )
+        # Issue #4472 (epic #4465, Phase 2): under ``--complete`` the same
+        # region box also LOCALIZES the octilinear lattice build -- the
+        # per-link perf enabler.  Stamp the WORLD-coordinate box on the router
+        # so ``_ensure_lattice_pathfinder`` builds + masks only that pocket
+        # (snapped to the whole-board coarse grid) instead of the entire board
+        # outline.  Gated on ``localize_lattice_to_region`` so a plain
+        # ``--region`` grid/lattice run is byte-identical.
+        if localize_lattice_to_region:
+            router._lattice_region_world = (wx1, wy1, wx2, wy2)
+
+    # Issue #4472: per-link wall-clock budget for the lattice netset
+    # negotiation (``--complete``); ``None`` preserves the unbudgeted loop.
+    if lattice_link_budget_s is not None:
+        router._lattice_link_budget_s = lattice_link_budget_s
 
     # Issue #4170 (Phase 2b-1): carve bare boundary stub endpoints open as
     # same-net A* targets and store them for the Autorouter target-merge shim.

--- a/src/kicad_tools/router/lattice/pathfinder.py
+++ b/src/kicad_tools/router/lattice/pathfinder.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import heapq
 import math
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -1562,6 +1563,7 @@ class LatticePathfinder:
         present_cost_initial: float = 1.0,
         present_cost_growth: float = 1.6,
         history_increment_factor: float = 1.0,
+        deadline: float | None = None,
     ) -> tuple[dict[object, Route], LatticeNegotiationStats]:
         """PathFinder/VPR-style negotiation over capacity-1 lattice resources.
 
@@ -1598,6 +1600,14 @@ class LatticePathfinder:
         pre-seeded into every per-pass :class:`CommittedCopper` model as an
         immovable hard obstacle, so a negotiated net routes AROUND it or is
         honestly declined -- it is never emitted overlapping foreign copper.
+
+        Issue #4472: ``deadline`` is an optional absolute
+        :func:`time.monotonic` timestamp.  When set, the negotiation aborts as
+        soon as it is reached -- checked before each iteration and before each
+        per-connection search -- and returns the best routes found so far.
+        This bounds a ``--complete`` completion pass so a pathological search
+        aborts within a per-link budget instead of grinding (issue #4434).
+        ``None`` preserves the pre-#4472 unbudgeted (iteration-capped) loop.
         """
         self._set_fixed_copper(fixed_copper)
         self.build()
@@ -1625,7 +1635,13 @@ class LatticePathfinder:
         iterations_run = 0
         present = present_cost_initial
 
+        deadline_hit = False
         for it in range(max_iterations):
+            # Issue #4472: abort before starting a fresh pass once the per-link
+            # budget is spent; the best pass seen so far is returned below.
+            if deadline is not None and time.monotonic() >= deadline:
+                deadline_hit = True
+                break
             iterations_run = it + 1
             committed = self._fresh_committed()
             routes: dict[object, Route] = {}
@@ -1634,6 +1650,11 @@ class LatticePathfinder:
             routed_items = 0
             failed: list[tuple[int, Any]] = []
             for _length, kind, item in items:
+                # Issue #4472: abort mid-pass on the deadline too, so a single
+                # slow search inside one pass cannot overrun the budget.
+                if deadline is not None and time.monotonic() >= deadline:
+                    deadline_hit = True
+                    break
                 if kind == 1:
                     pres, preason = self._route_pair_impl(
                         item, committed=committed, history=history, present=present
@@ -1691,6 +1712,12 @@ class LatticePathfinder:
                 best_routes = routes
                 best_reasons = reasons
                 best_pair_outcomes = pair_outcomes
+
+            # Issue #4472: a deadline-truncated pass is NOT convergence -- some
+            # items were never attempted, so ``failed`` is incomplete.  Record
+            # the best-so-far above, then stop without claiming convergence.
+            if deadline_hit:
+                break
 
             if not failed:
                 converged = True

--- a/tests/router/lattice/test_localized_build_4472.py
+++ b/tests/router/lattice/test_localized_build_4472.py
@@ -1,0 +1,222 @@
+"""Localized per-link lattice build + per-link deadline (Issue #4472, epic #4465).
+
+Phase 2 of ``kct route --complete``.  A completion pass that re-routes one
+walled link used to pay a WHOLE-BOARD lattice build + a whole-board A* every
+time (issue #4434's ">10 minutes without terminating").  Phase 2 restricts the
+octilinear lattice build + per-layer static masks to a per-link bounding box
+and bounds each link's search with a wall-clock budget.
+
+These tests pin the four load-bearing properties:
+
+1. ``Autorouter._snap_lattice_region`` snaps a requested box OUTWARD to the
+   whole-board coarse grid, clamps to the board, and never degenerates.
+2. ``_ensure_lattice_pathfinder`` builds over the localized box when one is
+   stamped (and over the whole board otherwise).
+3. The localized build is genuinely smaller (fewer lattice nodes) yet produces
+   the IDENTICAL route to the un-localized build for an in-box connection --
+   localization is a perf optimization, not a correctness change.
+4. ``LatticePathfinder.route_netset(deadline=...)`` aborts on the deadline and
+   returns the best routes so far (not falsely "converged").
+"""
+
+from __future__ import annotations
+
+import time
+
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.lattice.pathfinder import LatticePathfinder
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import DesignRules
+
+_COARSE = 3.2  # LatticePathfinder default coarse cell (kept in sync via the signature)
+
+
+def _pad(x: float, y: float, net: int, *, ref: str) -> Pad:
+    return Pad(
+        x=x,
+        y=y,
+        width=1.0,
+        height=1.0,
+        net=net,
+        net_name=f"N{net}",
+        layer=Layer.F_CU,
+        ref=ref,
+        pin="1",
+    )
+
+
+def _route_signature(route) -> list[tuple]:
+    """A comparable, order-stable geometry signature for a route."""
+    segs = sorted(
+        (
+            round(s.x1, 6),
+            round(s.y1, 6),
+            round(s.x2, 6),
+            round(s.y2, 6),
+            round(s.width, 6),
+            s.layer,
+        )
+        for s in route.segments
+    )
+    vias = sorted((round(v.x, 6), round(v.y, 6)) for v in route.vias)
+    return [("seg", *t) for t in segs] + [("via", *t) for t in vias]
+
+
+# ---------------------------------------------------------------------------
+# 1. _snap_lattice_region: grid alignment, clamping, non-degeneracy.
+# ---------------------------------------------------------------------------
+class TestSnapLatticeRegion:
+    def test_snaps_outward_to_coarse_grid(self):
+        board = (0.0, 0.0, 100.0, 60.0)
+        # Pad bbox (40,30)-(60,30) grown by 3 mm -> (37,27)-(63,33).
+        box = (37.0, 27.0, 63.0, 33.0)
+        lo_x, lo_y, hi_x, hi_y = Autorouter._snap_lattice_region(box, board, _COARSE)
+        # Every edge lands on a multiple of coarse from the board origin (0,0).
+        for v in (lo_x, lo_y, hi_x, hi_y):
+            assert abs((v / _COARSE) - round(v / _COARSE)) < 1e-9
+        # Outward snap: the snapped box CONTAINS the requested box.
+        assert lo_x <= 37.0 and lo_y <= 27.0 and hi_x >= 63.0 and hi_y >= 33.0
+
+    def test_clamped_to_board(self):
+        board = (0.0, 0.0, 20.0, 20.0)
+        # A box overflowing the board must clamp to the board extent.
+        box = (-5.0, -5.0, 40.0, 40.0)
+        lo_x, lo_y, hi_x, hi_y = Autorouter._snap_lattice_region(box, board, _COARSE)
+        assert lo_x >= 0.0 and lo_y >= 0.0
+        assert hi_x <= 20.0 and hi_y <= 20.0
+
+    def test_never_degenerate(self):
+        board = (0.0, 0.0, 20.0, 20.0)
+        # A zero-area box still yields at least one coarse cell of extent.
+        box = (10.0, 10.0, 10.0, 10.0)
+        lo_x, lo_y, hi_x, hi_y = Autorouter._snap_lattice_region(box, board, _COARSE)
+        assert hi_x > lo_x and hi_y > lo_y
+
+
+# ---------------------------------------------------------------------------
+# 2. _ensure_lattice_pathfinder honors the localized box.
+# ---------------------------------------------------------------------------
+def _lattice_router(region_world=None) -> Autorouter:
+    r = Autorouter(100.0, 60.0, 0.0, 0.0, layer_stack=LayerStack.two_layer(), strategy="lattice")
+    r._board_bbox = (0.0, 0.0, 100.0, 60.0)
+    a1, a2 = _pad(40.0, 30.0, 1, ref="A1"), _pad(60.0, 30.0, 1, ref="A2")
+    r.all_pads = [a1, a2]
+    r.pads = {("A1", "1"): a1, ("A2", "1"): a2}
+    r.nets = {1: [("A1", "1"), ("A2", "1")]}
+    r.net_names = {1: "N1"}
+    r._lattice_region_world = region_world
+    return r
+
+
+class TestEnsureLatticePathfinderLocalization:
+    def test_whole_board_outline_by_default(self):
+        pf = _lattice_router()._ensure_lattice_pathfinder()
+        xs = [p[0] for p in pf.outline]
+        ys = [p[1] for p in pf.outline]
+        assert (min(xs), min(ys), max(xs), max(ys)) == (0.0, 0.0, 100.0, 60.0)
+
+    def test_localized_outline_when_box_set(self):
+        # Pad bbox + 3 mm margin, un-snapped, handed to the router.
+        pf = _lattice_router((37.0, 27.0, 63.0, 33.0))._ensure_lattice_pathfinder()
+        xs = [p[0] for p in pf.outline]
+        ys = [p[1] for p in pf.outline]
+        bx0, by0, bx1, by1 = min(xs), min(ys), max(xs), max(ys)
+        # Snapped to the coarse grid, strictly inside the whole board.
+        assert bx0 > 0.0 and by0 > 0.0 and bx1 < 100.0 and by1 < 60.0
+        # Contains the pads with margin.
+        assert bx0 <= 40.0 and bx1 >= 60.0 and by0 <= 30.0 and by1 >= 30.0
+
+
+# ---------------------------------------------------------------------------
+# 3. Localized build == smaller lattice, IDENTICAL in-box route.
+# ---------------------------------------------------------------------------
+class TestLocalizationPreservesRoute:
+    def _pads_and_conn(self):
+        a1, a2 = _pad(40.0, 30.0, 1, ref="A1"), _pad(60.0, 30.0, 1, ref="A2")
+        return [a1, a2], ((1, 0), a1, a2, None)
+
+    def test_localized_lattice_has_fewer_nodes(self):
+        pads, _conn = self._pads_and_conn()
+        rules = DesignRules()
+        full = LatticePathfinder(
+            [(0.0, 0.0), (100.0, 0.0), (100.0, 60.0), (0.0, 60.0)],
+            pads,
+            rules,
+            LayerStack.two_layer(),
+        )
+        box = Autorouter._snap_lattice_region(
+            (37.0, 27.0, 63.0, 33.0), (0.0, 0.0, 100.0, 60.0), _COARSE
+        )
+        local = LatticePathfinder(
+            [(box[0], box[1]), (box[2], box[1]), (box[2], box[3]), (box[0], box[3])],
+            pads,
+            rules,
+            LayerStack.two_layer(),
+        )
+        assert len(local.build().nodes) < len(full.build().nodes)
+
+    def test_localized_route_identical_to_whole_board(self):
+        pads, conn = self._pads_and_conn()
+        rules = DesignRules()
+        full = LatticePathfinder(
+            [(0.0, 0.0), (100.0, 0.0), (100.0, 60.0), (0.0, 60.0)],
+            pads,
+            rules,
+            LayerStack.two_layer(),
+        )
+        full_routes, full_stats = full.route_netset([conn], max_iterations=4)
+        assert (1, 0) in full_routes, f"whole-board declined: {full.failure_reasons}"
+
+        box = Autorouter._snap_lattice_region(
+            (37.0, 27.0, 63.0, 33.0), (0.0, 0.0, 100.0, 60.0), _COARSE
+        )
+        local = LatticePathfinder(
+            [(box[0], box[1]), (box[2], box[1]), (box[2], box[3]), (box[0], box[3])],
+            pads,
+            rules,
+            LayerStack.two_layer(),
+        )
+        local_routes, _ = local.route_netset([conn], max_iterations=4)
+        assert (1, 0) in local_routes, f"localized declined: {local.failure_reasons}"
+
+        # The snapped localized build shares the whole-board lattice's node
+        # grid, so an in-box connection routes to the SAME geometry.
+        assert _route_signature(local_routes[(1, 0)]) == _route_signature(full_routes[(1, 0)])
+        assert full_stats.lattice_builds == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. route_netset(deadline=...) aborts and returns best-so-far.
+# ---------------------------------------------------------------------------
+class TestRouteNetsetDeadline:
+    def _pf(self):
+        a1, a2 = _pad(40.0, 30.0, 1, ref="A1"), _pad(60.0, 30.0, 1, ref="A2")
+        return LatticePathfinder(
+            [(0.0, 0.0), (100.0, 0.0), (100.0, 60.0), (0.0, 60.0)],
+            [a1, a2],
+            DesignRules(),
+            LayerStack.two_layer(),
+        ), ((1, 0), a1, a2, None)
+
+    def test_past_deadline_aborts_immediately(self):
+        pf, conn = self._pf()
+        started = time.monotonic()
+        routes, stats = pf.route_netset([conn], max_iterations=8, deadline=time.monotonic() - 1.0)
+        elapsed = time.monotonic() - started
+        # No pass ran to completion; nothing routed; NOT falsely converged.
+        assert routes == {}
+        assert stats.routed == 0
+        assert stats.converged is False
+        assert elapsed < 1.0
+
+    def test_generous_deadline_matches_unbudgeted(self):
+        pf, conn = self._pf()
+        budgeted, s_budget = pf.route_netset(
+            [conn], max_iterations=4, deadline=time.monotonic() + 3600.0
+        )
+        pf2, conn2 = self._pf()
+        unbudgeted, s_plain = pf2.route_netset([conn2], max_iterations=4)
+        assert (1, 0) in budgeted and (1, 0) in unbudgeted
+        assert s_budget.converged == s_plain.converged
+        assert _route_signature(budgeted[(1, 0)]) == _route_signature(unbudgeted[(1, 0)])

--- a/tests/test_cli_route_complete_localize_4472.py
+++ b/tests/test_cli_route_complete_localize_4472.py
@@ -1,0 +1,152 @@
+"""``--complete`` localized per-link build wiring (Issue #4472, epic #4465).
+
+Phase 2 restricts the lattice build to a per-link bounding box and bounds each
+link's search with a wall-clock budget.  These tests exercise the CLI-layer
+helpers that compute the localized region box + budget, and an end-to-end
+completion pass that closes a stranded link through the localized build and
+terminates within a bounded budget.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.route_cmd import (
+    _COMPLETE_LINK_BUDGET_DEFAULT_S,
+    _apply_complete_localization,
+    _resolve_complete_link_budget,
+)
+from kicad_tools.cli.route_cmd import (
+    main as route_main,
+)
+
+# Reuse the Phase 1 stranded-board fixture text (NET1 pre-routed, NET2 stranded).
+from tests.test_cli_route_complete_4471 import STRANDED_BOARD, _segment_nets
+
+
+@pytest.fixture
+def stranded_board(tmp_path: Path) -> Path:
+    board = tmp_path / "stranded.kicad_pcb"
+    board.write_text(STRANDED_BOARD)
+    return board
+
+
+def _loc_args(pcb: Path, **overrides) -> argparse.Namespace:
+    base = {
+        "complete": True,
+        "_complete_noop": False,
+        "nets": "NET2",
+        "region": None,
+        "quiet": False,
+        "per_net_timeout": 30.0,
+        "_region_box": None,
+        "no_cache": False,
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_complete_link_budget: reuse the wall-clock plumbing.
+# ---------------------------------------------------------------------------
+class TestResolveLinkBudget:
+    def test_honors_explicit_per_net_timeout(self):
+        args = argparse.Namespace(per_net_timeout=12.5)
+        assert _resolve_complete_link_budget(args) == 12.5
+
+    def test_falls_back_to_default_when_disabled(self):
+        # --per-net-timeout 0 (e.g. under --deterministic-budget) -> backstop.
+        args = argparse.Namespace(per_net_timeout=0.0)
+        assert _resolve_complete_link_budget(args) == _COMPLETE_LINK_BUDGET_DEFAULT_S
+
+    def test_falls_back_when_missing(self):
+        args = argparse.Namespace()
+        assert _resolve_complete_link_budget(args) == _COMPLETE_LINK_BUDGET_DEFAULT_S
+
+
+# ---------------------------------------------------------------------------
+# _apply_complete_localization: stamps _region_box + budget from the pad bbox.
+# ---------------------------------------------------------------------------
+class TestApplyCompleteLocalization:
+    def _net2_pads(self, pcb_path: Path) -> list[tuple[float, float]]:
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.load(str(pcb_path))
+        pts = []
+        for fp in pcb.footprints:
+            for pad in fp.pads:
+                if (getattr(pad, "net_name", "") or "") == "NET2":
+                    pos = pcb.get_pad_position(fp.reference, pad.number)
+                    if pos is not None:
+                        pts.append((pos[0], pos[1]))
+        return pts
+
+    def test_stamps_localized_box_and_budget(self, stranded_board: Path, capsys):
+        args = _loc_args(stranded_board)
+        rc = _apply_complete_localization(args, stranded_board)
+        assert rc == 0
+        assert args._complete_localized is True
+        assert args._complete_link_budget_s == 30.0
+        assert args._region_box is not None
+        assert args.no_cache is True
+
+        # The box contains every NET2 pad (in the same board-relative frame).
+        x0, y0, x1, y1 = args._region_box
+        for px, py in self._net2_pads(stranded_board):
+            assert x0 <= px <= x1 and y0 <= py <= y1
+        # ...and is a genuine localization: smaller than the 30x20 board.
+        assert (x1 - x0) < 30.0 and (y1 - y0) < 20.0
+        assert "localized lattice build" in capsys.readouterr().out
+
+    def test_respects_user_region(self, stranded_board: Path):
+        # A user-supplied --region wins: no auto box is computed, but the
+        # localization flag + budget are still armed (the lattice localizes to
+        # the user's box, stamped later by _parse_and_apply_region).
+        args = _loc_args(stranded_board, region="105,102,112,108")
+        rc = _apply_complete_localization(args, stranded_board)
+        assert rc == 0
+        assert args._complete_localized is True
+        assert args._complete_link_budget_s == 30.0
+        assert args._region_box is None  # not overwritten by the auto path
+
+    def test_noop_when_not_complete(self, stranded_board: Path):
+        args = _loc_args(stranded_board, complete=False)
+        rc = _apply_complete_localization(args, stranded_board)
+        assert rc == 0
+        assert getattr(args, "_region_box", None) is None
+
+    def test_noop_when_complete_noop(self, stranded_board: Path):
+        args = _loc_args(stranded_board, _complete_noop=True)
+        rc = _apply_complete_localization(args, stranded_board)
+        assert rc == 0
+        assert args._region_box is None
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: localized --complete closes the stranded link, and terminates
+# within a bounded budget (the #4434 ">10 minutes" is now a per-link deadline).
+# ---------------------------------------------------------------------------
+class TestLocalizedCompleteEndToEnd:
+    def test_closes_link_and_terminates_bounded(self, stranded_board: Path, tmp_path: Path):
+        out = tmp_path / "out.kicad_pcb"
+        started = time.monotonic()
+        rc = route_main([str(stranded_board), "-o", str(out), "--complete", "--backend", "cpp"])
+        elapsed = time.monotonic() - started
+        assert rc == 0
+        # The stranded link is closed by the localized build.
+        assert 2 in _segment_nets(out.read_text())
+        # NET1's pre-existing copper is preserved (fixed obstacle).
+        assert 1 in _segment_nets(out.read_text())
+        # Bounded: the localized build + per-link deadline terminate quickly --
+        # generous ceiling for CI, but far below the #4434 >10-minute grind.
+        assert elapsed < 120.0
+
+    def test_localization_banner_printed(self, stranded_board: Path, tmp_path: Path, capsys):
+        out = tmp_path / "out.kicad_pcb"
+        rc = route_main([str(stranded_board), "-o", str(out), "--complete", "--backend", "cpp"])
+        assert rc == 0
+        assert "localized lattice build" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
Phase 2 of the `kct route --complete` epic (#4465): the perf enabler that ends the #4434 ">10-minute walled-pocket grind". A `--complete` pass that re-routes one walled link used to build the octilinear lattice + per-layer static masks over the **entire board** and run a whole-board A* every time. This restricts the build + search to a **per-link bounding box** and bounds each link with a wall-clock deadline. Grid and non-complete lattice routing are byte-identical (the new paths only fire when a completion pass stamps the box/budget).

## Changes
- **`router/core.py`** — `Autorouter` gains `_lattice_region_world` (WORLD-coord box) and `_lattice_link_budget_s`. `_ensure_lattice_pathfinder` builds over the box when set, snapping it OUTWARD to the whole-board coarse grid via the new `_snap_lattice_region` helper so the localized lattice's in-box nodes stay an exact subset of the whole-board lattice (same pads → same refine max-level → same node `unit`). `_negotiate_lattice_netset` stamps `deadline = now + budget × link-count` and passes it through.
- **`router/lattice/pathfinder.py`** — `route_netset` takes an optional `deadline` (absolute `time.monotonic`); the negotiation aborts before each iteration and each per-connection search once it passes, returning the best routes so far and **not** falsely `converged`.
- **`router/io.py`** — `load_pcb_for_routing` gains `localize_lattice_to_region` / `lattice_link_budget_s`, reusing the existing `--region` box plumbing to stamp the world-coord box + budget onto the router.
- **`cli/route_cmd.py`** — `_apply_complete_localization` computes the union of the stranded nets' pad bboxes + a 3 mm escape margin (board-relative, matching `--region`), stamps it on `args._region_box` (a user-supplied `--region` wins), and arms the per-link budget from `--per-net-timeout` (bounded 60 s backstop when disabled, e.g. under `--deterministic-budget`). Oversized nets (spanning most of the board) are **reported and the box expands** to include them rather than being silently mis-bounded. Threaded into all five `load_pcb_for_routing` call sites.

## Acceptance Criteria Verification

| Criterion (issue #4472) | Status | Verification |
|-------------------------|--------|--------------|
| A `--complete` attempt the whole-board build couldn't terminate now completes within the per-link deadline (assert wall-clock bound) | ✅ | `route_netset(deadline=...)` aborts before each iteration/search; `test_past_deadline_aborts_immediately` asserts a past deadline returns in <1 s not converged; end-to-end `test_closes_link_and_terminates_bounded` asserts wall-clock bound; localized lattice is provably smaller (`test_localized_lattice_has_fewer_nodes`). |
| Localized build gives the SAME closing route as un-localized where both terminate | ✅ | `_snap_lattice_region` aligns the box to the whole-board coarse grid; `test_localized_route_identical_to_whole_board` asserts byte-identical route geometry, `test_generous_deadline_matches_unbudgeted` asserts the deadline param is inert when not hit. |
| Preserved copper crossing the bbox boundary is honored as a fixed obstacle | ✅ | Reuses the #4355 `fixed_copper` seam unchanged (preserved copper of non-listed nets is a hard obstacle in the netset); end-to-end asserts NET1's pre-existing copper is preserved while NET2 closes. |
| Links whose pads don't fit a reasonable bbox are reported (expand-or-decline) | ✅ | `_apply_complete_localization` flags nets spanning > 90% of a board dimension and expands the union to include them with a printed WARNING (`_COMPLETE_OVERSIZE_FRACTION`). |

## Test Plan
- New: `tests/router/lattice/test_localized_build_4472.py` (snap alignment/clamp/degeneracy, `_ensure_lattice_pathfinder` localization, fewer-nodes + identical-route proof, deadline abort + best-so-far).
- New: `tests/test_cli_route_complete_localize_4472.py` (budget resolution, `_apply_complete_localization` box/budget stamping + user-`--region` respect + no-op guards, end-to-end localized completion closing the stranded link within a bounded budget).
- Regression: Phase 1 + full `tests/router/lattice/` + region suites — **168 passed, 2 skipped**.
- `ruff check .` / `ruff format . --check` clean; mypy baseline gate: **no new type errors**.

Part of #4465
Closes #4472

🤖 Generated with [Claude Code](https://claude.com/claude-code)