### PR TITLE
fix(diffpair): mitre inside-bend corners in the shadow parallel-offset

### DIFF
--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -4213,6 +4213,85 @@ class DiffPairRouter:
         # No feasible rung: keep nominal (ladder head), degrade gracefully.
         return gap_ladder[0]
 
+    @staticmethod
+    def _offset_corner_join(
+        pseg_start: tuple[float, float],
+        pseg_end: tuple[float, float],
+        a: tuple[float, float],
+        b: tuple[float, float],
+        side: float,
+        d: float,
+        resolution: float,
+    ) -> tuple[str, tuple[float, float] | None]:
+        """Decide how two consecutive parallel-offset segments join at a corner.
+
+        Issue #4460 (Phase 2 of #4409): a fixed-side parallel offset of a
+        bending guide self-overlaps on the INSIDE of every bend.  ``pseg_*``
+        are the endpoints of the previously emitted offset segment (its end
+        ``pseg_end`` is the running ``prev_pt``); ``a``/``b`` are the current
+        offset segment's endpoints.  ``side`` is the lateral offset sign and
+        ``d`` the nominal center spacing (used only to bound convex spikes).
+
+        Returns ``(mode, point)``:
+
+        * ``("none", None)`` -- the offset endpoints already meet (gap below
+          half a grid cell); the caller just appends the current segment.
+        * ``("miter", mx)`` -- clip/extend the previous segment's END to
+          ``mx`` and start the current segment at ``mx``.  This is the correct
+          join for a CONCAVE (inside) corner: the offset lines cross and the
+          intersection de-folds the overlap.  The concave miter apex always
+          lies on the offset side of the guide, so it can never dive across
+          the guide centerline the way a straight bevel chord does at a sharp
+          inside bend (the pre-fix bevel fallback dropped a fold segment clear
+          across the guide, a full-trace-width local self-cross).  For CONVEX
+          (outside) corners the miter is still used, but only when its spike
+          stays within ``2*d + gap`` (a sharp outside turn otherwise grows an
+          unbounded spike).
+        * ``("bevel", None)`` -- insert a straight chord ``pseg_end -> a``.
+          Reached only for convex corners whose miter spike is out of bounds
+          (the chord stays on the offset side there) or degenerate geometry.
+
+        Pure geometry -- no grid / obstacle state -- so it is unit-testable in
+        isolation (see ``tests/test_diffpair_shadow.py``).
+        """
+        gap = math.hypot(a[0] - pseg_end[0], a[1] - pseg_end[1])
+        if gap <= resolution / 2:
+            return ("none", None)
+
+        d1x, d1y = pseg_end[0] - pseg_start[0], pseg_end[1] - pseg_start[1]
+        d2x, d2y = b[0] - a[0], b[1] - a[1]
+        # Turn handedness: cross(prev_dir, cur_dir).  The offset lies on the
+        # INSIDE of the turn (segments fold/overlap) when the guide bends
+        # toward the offset side, i.e. ``cross * side > 0``.
+        cross = d1x * d2y - d1y * d2x
+        concave = cross * side > 1e-12
+
+        denom = d1x * d2y - d1y * d2x
+        if abs(denom) <= 1e-9:
+            # Parallel offset lines: no intersection to miter to.
+            return ("bevel", None)
+        t = ((a[0] - pseg_end[0]) * d2y - (a[1] - pseg_end[1]) * d2x) / denom
+        cand = (pseg_end[0] + d1x * t, pseg_end[1] + d1y * t)
+
+        if concave:
+            # De-fold unconditionally (no spike bound): the concave miter
+            # apex stays on the offset side and clipping to it removes the
+            # self-crossing fold.  Guard only against the pathological
+            # near-reversal where the intersection would push BEHIND the
+            # previous segment's start (which would flip its direction);
+            # there, fall back to the bevel rather than emit a reversed spur.
+            plen2 = d1x * d1x + d1y * d1y
+            if plen2 > 1e-18:
+                tp = ((cand[0] - pseg_start[0]) * d1x + (cand[1] - pseg_start[1]) * d1y) / plen2
+                if tp > 1e-6:
+                    return ("miter", cand)
+            return ("bevel", None)
+
+        # Convex corner: bound the miter spike (sharp outside turns).
+        if math.hypot(cand[0] - pseg_end[0], cand[1] - pseg_end[1]) <= 2.0 * d + gap:
+            return ("miter", cand)
+        return ("bevel", None)
+
     def _shadow_route_pair(
         self,
         pair: DifferentialPair,
@@ -4461,50 +4540,44 @@ class DiffPairRouter:
                                 ok = False
                                 break
                         else:
-                            gap = math.hypot(a[0] - prev_pt[0], a[1] - prev_pt[1])
-                            if gap > grid.resolution / 2:
-                                # Issue #3508: MITER the corner join.  A
-                                # straight bevel chord between the two
-                                # offset endpoints passes INSIDE the
-                                # corner (d*cos(45deg) ~ 0.75*d at a 90
-                                # degree turn), shaving the coupled gap
-                                # below the intra-pair clearance -- the
-                                # measured one-mild-violation-per-pair
-                                # Phase B churn.  Extending both offset
-                                # segments to their line intersection
-                                # keeps the full offset everywhere.
-                                mx = None
-                                if elements and elements[-1][0] == "seg":
-                                    pseg = elements[-1]
-                                    d1x, d1y = pseg[3] - pseg[1], pseg[4] - pseg[2]
-                                    d2x, d2y = b[0] - a[0], b[1] - a[1]
-                                    denom = d1x * d2y - d1y * d2x
-                                    if abs(denom) > 1e-9:
-                                        t = (
-                                            (a[0] - pseg[3]) * d2y - (a[1] - pseg[4]) * d2x
-                                        ) / denom
-                                        cand = (
-                                            pseg[3] + d1x * t,
-                                            pseg[4] + d1y * t,
-                                        )
-                                        # Bound the miter spike (sharp
-                                        # angles) to ~2 gaps.
-                                        if (
-                                            math.hypot(
-                                                cand[0] - prev_pt[0],
-                                                cand[1] - prev_pt[1],
-                                            )
-                                            <= 2.0 * d + gap
-                                        ):
-                                            mx = cand
-                                if mx is not None:
-                                    pseg = elements[-1]
+                            # Issue #3508 / #4460: join the corner between the
+                            # previous offset segment and this one.  A straight
+                            # bevel chord between the two offset endpoints cuts
+                            # INSIDE the corner (d*cos(45deg) ~ 0.75*d at a 90
+                            # degree turn), shaving the coupled gap below the
+                            # intra-pair clearance; worse, at a SHARP inside
+                            # (concave) bend the offset polyline folds over
+                            # itself and the bevel dives a fold segment clear
+                            # across the guide centerline (a full-trace-width
+                            # local self-cross).  ``_offset_corner_join`` mitres
+                            # inside corners to the offset-line intersection
+                            # (de-folding without ever crossing the guide) and
+                            # keeps the spike bound only for convex corners.
+                            if elements and elements[-1][0] == "seg":
+                                pseg = elements[-1]
+                                mode, mx = self._offset_corner_join(
+                                    (pseg[1], pseg[2]),
+                                    (pseg[3], pseg[4]),
+                                    a,
+                                    b,
+                                    side,
+                                    d,
+                                    grid.resolution,
+                                )
+                                if mode == "miter" and mx is not None:
                                     elements[-1] = ("seg", pseg[1], pseg[2], mx[0], mx[1], pseg[5])
                                     a = mx
-                                else:
+                                elif mode == "bevel":
                                     elements.append(
                                         ("seg", prev_pt[0], prev_pt[1], a[0], a[1], sec_layer)
                                     )
+                            elif (
+                                math.hypot(a[0] - prev_pt[0], a[1] - prev_pt[1])
+                                > grid.resolution / 2
+                            ):
+                                elements.append(
+                                    ("seg", prev_pt[0], prev_pt[1], a[0], a[1], sec_layer)
+                                )
                     elements.append(("seg", a[0], a[1], b[0], b[1], sec_layer))
                     prev_pt = b
                     prev_layer = sec_layer

--- a/tests/test_diffpair_shadow.py
+++ b/tests/test_diffpair_shadow.py
@@ -217,6 +217,122 @@ def test_point_segment_distance_beyond_endpoint():
 
 
 # ---------------------------------------------------------------------------
+# 4b. inside-bend self-overlap mitigation (#4460)
+# ---------------------------------------------------------------------------
+#
+# ``_offset_corner_join`` decides how two consecutive fixed-side parallel
+# offset segments meet.  At a sharp INSIDE (concave) bend the offset polyline
+# folds over itself; the old straight-bevel fallback then dove a fold segment
+# clear across the guide centerline (a full-trace-width local self-cross).
+# These tests pin the corrected behaviour: concave corners mitre to the
+# offset-line intersection (staying on the offset side, never crossing the
+# guide) while convex spikes stay bounded.
+
+
+def _offset_endpoints(p0, p1, side, d):
+    """Offset a guide segment ``p0->p1`` by ``d`` on the given lateral side.
+
+    Mirrors the offset formula in ``_shadow_route_pair`` (normal is
+    ``(-u_y, u_x) * side``), so the corner-join inputs match what the
+    constructor actually feeds the helper.
+    """
+    ux, uy = p1[0] - p0[0], p1[1] - p0[1]
+    length = math.hypot(ux, uy)
+    ux, uy = ux / length, uy / length
+    nx, ny = -uy * side, ux * side
+    return (p0[0] + d * nx, p0[1] + d * ny), (p1[0] + d * nx, p1[1] + d * ny)
+
+
+def test_offset_corner_join_sharp_concave_mitres_without_crossing_guide():
+    """A sharp inside bend mitres to the intersection, staying off the guide.
+
+    Guide reverses direction near 180 deg (V0->V East, then V->V2 back to the
+    upper-left).  With the old ``2*d + gap`` spike bound this concave corner
+    exceeded the bound and fell back to a straight bevel from ``prev_pt`` to
+    ``a`` -- a chord that crosses the guide centerline (y == 0).  The fix
+    mitres instead; the apex must stay strictly on the offset side (y > 0).
+    """
+    from kicad_tools.router.diffpair_routing import DiffPairRouter
+
+    d = 0.25
+    v0, v, v2 = (-10.0, 0.0), (0.0, 0.0), (-8.0, 1.0)
+    pseg_start, pseg_end = _offset_endpoints(v0, v, +1.0, d)
+    a, b = _offset_endpoints(v, v2, +1.0, d)
+
+    mode, mx = DiffPairRouter._offset_corner_join(
+        pseg_start, pseg_end, a, b, side=+1.0, d=d, resolution=0.05
+    )
+
+    assert mode == "miter"
+    assert mx is not None
+    # The offset side is +y here; a correct de-fold apex never crosses to the
+    # far (guide/partner) side.
+    assert mx[1] > 0.0
+    # The straight bevel the fix REPLACES would have crossed the guide: the
+    # chord prev_pt -> a spans from +y to -y.
+    assert pseg_end[1] > 0.0 > a[1]
+
+
+def test_offset_corner_join_sharp_convex_stays_bounded_as_bevel():
+    """A sharp OUTSIDE bend keeps the spike bound and falls back to a bevel.
+
+    Same near-reversal geometry on the opposite lateral side is convex; its
+    miter spike is unbounded, so the helper must NOT emit it (that would be a
+    long copper spur).  It degrades to the bevel, which stays on the offset
+    side for a convex corner.
+    """
+    from kicad_tools.router.diffpair_routing import DiffPairRouter
+
+    d = 0.25
+    v0, v, v2 = (-10.0, 0.0), (0.0, 0.0), (-8.0, 1.0)
+    pseg_start, pseg_end = _offset_endpoints(v0, v, -1.0, d)
+    a, b = _offset_endpoints(v, v2, -1.0, d)
+
+    mode, mx = DiffPairRouter._offset_corner_join(
+        pseg_start, pseg_end, a, b, side=-1.0, d=d, resolution=0.05
+    )
+
+    assert mode == "bevel"
+    assert mx is None
+
+
+def test_offset_corner_join_gentle_convex_mitres():
+    """A 90 deg outside corner is within the spike bound -> mitre (unchanged)."""
+    from kicad_tools.router.diffpair_routing import DiffPairRouter
+
+    d = 0.25
+    # East then North: a right-angle turn.  Offset side +1 (left of travel)
+    # is the OUTSIDE of this left turn's partner... pick the convex side.
+    v0, v, v2 = (-10.0, 0.0), (0.0, 0.0), (0.0, 10.0)
+    pseg_start, pseg_end = _offset_endpoints(v0, v, -1.0, d)
+    a, b = _offset_endpoints(v, v2, -1.0, d)
+
+    mode, mx = DiffPairRouter._offset_corner_join(
+        pseg_start, pseg_end, a, b, side=-1.0, d=d, resolution=0.05
+    )
+
+    assert mode == "miter"
+    assert mx is not None
+
+
+def test_offset_corner_join_collinear_needs_no_join():
+    """Collinear continuation (endpoints already meet) returns ``none``."""
+    from kicad_tools.router.diffpair_routing import DiffPairRouter
+
+    d = 0.25
+    v0, v, v2 = (-10.0, 0.0), (0.0, 0.0), (10.0, 0.0)
+    pseg_start, pseg_end = _offset_endpoints(v0, v, +1.0, d)
+    a, b = _offset_endpoints(v, v2, +1.0, d)
+
+    mode, mx = DiffPairRouter._offset_corner_join(
+        pseg_start, pseg_end, a, b, side=+1.0, d=d, resolution=0.05
+    )
+
+    assert mode == "none"
+    assert mx is None
+
+
+# ---------------------------------------------------------------------------
 # 5. mid-route asymmetric moves
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Phase-2 increment of the diffpair coupled-router epic (#4409 / #4460). The
geometric shadow constructor (`_shadow_route_pair`, opt-in
`enable_shadow_construction`) offsets the single-ended guide polyline to a
fixed lateral side. At a **sharp inside (concave) bend** the offset segments
fold over each other; the old corner join computed the miter intersection but
rejected it whenever the spike exceeded a `2*d + gap` bound and fell back to a
**straight bevel chord** `prev_pt -> a`. On the concave side that chord dives a
fold segment clear across the guide centerline — a full-trace-width local
self-cross that the intra-pair self-check rejects.

This PR mitigates that inside-bend self-overlap generically: it distinguishes
**concave** (inside, segments fold) from **convex** (outside, gap) corners by
the turn handedness relative to the offset side, and clips concave corners to
the offset-line intersection unconditionally (the concave miter apex always
stays on the offset side, so it de-folds without ever crossing the guide),
while keeping the spike bound for convex corners.

## Changes

- New pure static helper `DiffPairRouter._offset_corner_join(...)` that returns
  `("miter", mx)` / `("bevel", None)` / `("none", None)` for a corner join,
  with concave corners de-folded to the line intersection (no spike bound) and
  convex spikes still bounded.
- Rewrote the inline corner-join block in `_shadow_route_pair` to call it
  (replacing the concave self-crossing bevel).
- 4 unit tests (`tests/test_diffpair_shadow.py`): sharp-concave mitres without
  crossing the guide, sharp-convex stays bounded (bevel), gentle-convex mitres,
  collinear is a no-op.

## Scope guards honoured

- `enable_shadow_construction` **default stays OFF** — committed board
  artifacts and CI routing behaviour are byte-unchanged. This only affects the
  opt-in shadow constructor's geometry when enabled.
- No Phase-3 (45-census/off-angle), Phase-4 (skew/tail-connect) or Phase-5
  (enable-by-default) work. The 2 MIPI tail-connect strandings are noted, not
  touched.

## Acceptance-criteria status (honest)

| Criterion | Status | Notes |
|-----------|--------|-------|
| Board-06 shadow-ON construction 4/9 -> >=6/9 | ❌ not reached | Stays **4/9** (MIPI_CLK, MIPI_D0, PCIE_RX, USB2_D). See measurement below. |
| Technique is generic (any diff pair with sharp inside bends) | ✅ | Per-vertex concave/convex classification; not board-06-specific; unit-tested in isolation. |
| `enable_shadow_construction` default stays OFF; routing unchanged when off | ✅ | Constructor is fully gated; helper only runs under shadow construction. |

## Why 4/9 does not move — measured, not assumed

I reproduced the shadow-ON run (`KCT_BOARD06_SHADOW=1 ... --step route --seed 42`)
before and after, and instrumented the worst-violation geometry of the declining
pairs (temporary dump, removed before commit). The 5 declines are **not**
dominated by the adjacent-corner fold this PR fixes:

- **PCIE_TX** — the segment self-check actually **passes** on the non-swapped
  side (worst `+0.022mm`); it is declined by the **via-aware physical-overlap**
  gate (`_pair_has_physical_overlap`), i.e. a shadow/guide **via** clearance, a
  different subsystem (#3541 territory).
- **USB3_RX1 / USB3_TX1 / USB3_TX2** — the `-0.275mm` (full-trace-width)
  self-check overlap is a **non-adjacent local self-approach collision**: for
  USB3_RX1 the offending shadow segment sits at guide-arc ~3.0mm and collides
  (centres 0.025mm apart) with the guide at arc ~2.1mm — ~20 segments apart, in
  the congested BGA-escape fan (918 guide segments over 49mm). A per-vertex
  miter (adjacent segments only) provably cannot fix a collision between
  non-adjacent parts of the polyline. Both global offset sides fail, exactly as
  the issue's own note predicts ("an S-curve bends both ways").
- **USB3_RX2** — `mid-route blockage` (obstacle), not overlap.

The miter fix does measurably reduce overlap magnitude where the fold *was*
adjacent (e.g. USB2_D worst improved `-0.186 -> -0.003mm` on one side) and
introduces **no new declines/regressions** (same 4/9, USB2_D still constructs).

## Deferral / recommendation for reaching >=6/9

Per the scope guidance ("if it exceeds one clean PR, ship a coherent slice +
note deferrals"), this ships the tractable, generic correctness slice
(approach 1). Reaching >=6/9 on board-06 requires the **non-adjacent** escape-
region collisions to be resolved, which a single global-offset-side constructor
cannot do. The tractable follow-up is **approach 2** from the issue —
shadow-aware guide biasing toward gentler bends (a guide-side bend penalty) — or
per-section side switching with a legal crossing. I recommend a fresh
epic-phase issue scoped to that; it is a router change larger than one clean PR
and out of this phase's construction-feasibility scope.

## Test Plan

- `uv run kct build-native` (C++ backend available).
- `uv run pytest tests/test_diffpair_shadow.py` — 39 passed (incl. 4 new corner-join tests).
- `uv run pytest tests/test_diffpair_self_intersection.py tests/test_diffpair_corridor.py tests/test_diffpair_coupled_instrumentation_4459.py tests/test_diffpair_phase_b.py tests/test_diffpair_partner_wiring.py tests/test_diffpair_swap_via_reject.py` — all pass.
- `ruff format --check` + `ruff check` clean on changed files.
- Board-06 shadow-ON reproduced pre/post: 4/9 construct, no regressions.

Part of #4460
Part of #4409
