### PR TITLE
board-05 Phase 3: Kelvin/current-sense topology model + constrained routing

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 4415
-# Branch: feature/issue-4415
+# Issue: 4473
+# Branch: feature/issue-4473
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/boards/05-bldc-motor-controller/design.py
+++ b/boards/05-bldc-motor-controller/design.py
@@ -2921,6 +2921,19 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
     but re-routing each residual net ALONE against the committed copper
     of everything else lands a subset.  See that function's docstring
     for the mechanism and bounds.
+
+    Issue #4473 (2026-07) -- Kelvin / current-sense topology model.  The
+    five ISENSE nets are 4-pad Kelvin structures (shunt R10-R12, op-amp
+    SP/SN input, low-side FET-source tap, ADC PA0-2).  ``build_rsmt``
+    previously synthesised arbitrary Steiner branch points on them
+    (undifferentiated equipotentials), so the sense tap could merge into
+    the shunt->load high-current segment.  The router now recognises
+    current-sense nets by convention (net-name pattern + a shunt-resistor
+    root pad) and routes them as a *star rooted at the shunt pad* (the
+    Kelvin point): every sense terminal connects AT the shunt pad and no
+    sense edge shares the high-current segment.  This is a GENERIC
+    capability -- see ``kicad_tools.router.kelvin`` -- not a board-05
+    special case; board-05's R10-R12 shunts resolve as the Kelvin roots.
     """
     print("\n" + "=" * 60)
     print(

--- a/src/kicad_tools/router/algorithms/steiner.py
+++ b/src/kicad_tools/router/algorithms/steiner.py
@@ -350,6 +350,8 @@ def build_rsmt(
     pad_objs: list[Pad],
     congestion_fn: Callable[[float, float, float, float], float] | None = None,
     snap_fn: Callable[[float, float], tuple[float, float]] | None = None,
+    *,
+    allow_kelvin: bool = True,
 ) -> tuple[list[Pad], list[tuple[int, int]]]:
     """Build Rectilinear Steiner Minimum Tree.
 
@@ -378,6 +380,17 @@ def build_rsmt(
             with ``PADS_OFF_GRID: steiner@(...)`` — the softstart
             SRC_POS / BUS_LINE / SCAP_POS+ / VRECT signature.  Terminal
             pads are never snapped, only synthetic points.
+        allow_kelvin: When True (default), recognise current-sense /
+            Kelvin sense nets (Issue #4473) and route them as a *star
+            rooted at the shunt/sense-resistor pad* instead of an
+            arbitrary RSMT.  A Kelvin sense tap must connect AT the shunt
+            pad (the Kelvin point) and must not share the high-current
+            segment; the generic RSMT's arbitrary Steiner branch points
+            violate that.  Detection is conservative (net-name pattern
+            AND a resolvable shunt resistor pad) so ordinary nets are
+            untouched -- see :mod:`kicad_tools.router.kelvin`.  Set False
+            to force the plain RSMT (used by tests exercising the RSMT
+            path directly).
 
     Returns:
         (extended_pads, edges) where extended_pads includes original
@@ -392,6 +405,17 @@ def build_rsmt(
 
     if n == 2:
         return list(pad_objs), [(0, 1)]
+
+    # Issue #4473: Kelvin / current-sense nets get a constrained star
+    # topology (sense trace connects AT the Kelvin point, no shared
+    # high-current segment) instead of an arbitrary RSMT.  Returns None
+    # for every non-sense net, so this is a no-op for ordinary nets.
+    if allow_kelvin:
+        from ..kelvin import build_kelvin_topology
+
+        kelvin = build_kelvin_topology(pad_objs)
+        if kelvin is not None:
+            return kelvin
 
     # Extract coordinates
     terminals = [(p.x, p.y) for p in pad_objs]

--- a/src/kicad_tools/router/kelvin.py
+++ b/src/kicad_tools/router/kelvin.py
@@ -227,9 +227,7 @@ def build_kelvin_star_edges(pad_objs: list[Pad], root_index: int) -> list[tuple[
     """
     rx, ry = pad_objs[root_index].x, pad_objs[root_index].y
     edges = [(root_index, k) for k in range(len(pad_objs)) if k != root_index]
-    edges.sort(
-        key=lambda e: abs(rx - pad_objs[e[1]].x) + abs(ry - pad_objs[e[1]].y)
-    )
+    edges.sort(key=lambda e: abs(rx - pad_objs[e[1]].x) + abs(ry - pad_objs[e[1]].y))
     return edges
 
 

--- a/src/kicad_tools/router/kelvin.py
+++ b/src/kicad_tools/router/kelvin.py
@@ -1,0 +1,267 @@
+"""Kelvin / current-sense topology model and constrained routing (Issue #4473).
+
+A **Kelvin** (4-wire / current-sense) connection taps the sense voltage
+*at* a shunt/sense-resistor pad -- the *Kelvin point* -- so a
+high-impedance measurement (op-amp input, ADC) reads the true shunt
+voltage and is not corrupted by the IR drop along the high-current path
+that flows through the same net.
+
+Why the generic RSMT is wrong for these nets
+--------------------------------------------
+The autorouter's Rectilinear Steiner Minimum Tree
+(:func:`kicad_tools.router.algorithms.steiner.build_rsmt`) treats every
+terminal of a multi-pad net as an interchangeable equipotential and
+inserts Steiner branch points wherever total wirelength is minimised.
+For an ordinary signal that is fine.  For a Kelvin sense net it is
+*incorrect*: an arbitrary Steiner branch can merge the sense tap into the
+shunt -> load high-current segment, so the op-amp reads the voltage at the
+branch point rather than at the shunt pad, injecting the load-current IR
+drop straight into the measurement.
+
+On board-05 the five ISENSE nets are 4-pad Kelvin structures (shunt
+R10-R12, op-amp SP/SN input, low-side FET-source tap, ADC PA0-2).  The
+generic RSMT synthesises arbitrary Steiner points on them (design.py
+:func:`route_pcb` docstring, the ``2888-2907`` region) and they lose the
+multi-net negotiation in the congested U3 south sense band.
+
+The topology model
+------------------
+This module recognises Kelvin sense nets by convention (net-name pattern
++ presence of a shunt/sense-resistor pad) and replaces the RSMT with a
+**star topology rooted at the Kelvin point**: every other terminal
+connects directly to the shunt pad, so
+
+  * the sense trace physically connects **at** the Kelvin point, and
+  * no sense edge shares copper with the high-current edge except at the
+    Kelvin point itself (the star has exactly one shared node -- the
+    root -- and no synthesised Steiner branch points).
+
+The result is a drop-in replacement for :func:`build_rsmt`'s return shape
+``(extended_pads, edges)``: ``extended_pads`` is the original pad list
+unchanged (a star introduces **no** virtual Steiner pads) and ``edges``
+are ``(root_index, terminal_index)`` pairs sorted shortest-first for
+routing order.
+
+Detection is deliberately conservative so ordinary analog nets are not
+disturbed: a net is only treated as Kelvin when BOTH its name matches a
+current-sense pattern AND a shunt/sense-resistor root pad can be
+identified.  Any net that fails either gate falls back to the generic
+RSMT unchanged.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from .net_names import net_name_suffix
+
+if TYPE_CHECKING:
+    from .primitives import Pad
+
+
+# ---------------------------------------------------------------------------
+# Detection conventions
+# ---------------------------------------------------------------------------
+
+# Net-name substrings that denote a current-sense / Kelvin net.  Kept
+# intentionally broad (matches ``ISENSE_A+``, ``I_SENSE_P``, ``VSNS``,
+# ``CURRENT_SENSE``, ``SHUNT``, ``IMON``, ``KELVIN``) because the second
+# gate -- the presence of a shunt/sense-resistor root pad -- is what
+# actually protects ordinary analog nets from being reshaped.  The suffix
+# after the last ``/`` is matched so hierarchical names (``/PWR/ISENSE_A``)
+# resolve the same as bare ones.
+_SENSE_NAME_RE = re.compile(
+    r"(I_?SENSE|V_?SENSE|C_?SENSE|CURR(ENT)?_?SENSE|SENSE|SHUNT|"
+    r"ISNS|VSNS|CSNS|IMON|VMON|KELVIN)",
+    re.IGNORECASE,
+)
+
+# Reference-designator pattern for a discrete resistor (the shunt).  A
+# current-sense Kelvin tap is taken at a shunt resistor's pad, so the pad
+# whose footprint is a resistor is the Kelvin point.
+_RESISTOR_REF_RE = re.compile(r"^R\d", re.IGNORECASE)
+
+# Library-footprint substrings that identify a resistor / shunt package,
+# used as a fallback when the pad's ``ref`` is unavailable (e.g. a pad
+# harvested without its designator).
+_RESISTOR_FP_RE = re.compile(r"(resistor|_shunt|shunt_|current[_-]?sense)", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class KelvinTopology:
+    """A recognised Kelvin sense net and its constrained star topology.
+
+    Attributes:
+        root_index: Index into the net's pad list of the Kelvin-point pad
+            (the shunt/sense-resistor pad every sense trace must tap).
+        edges: ``(root_index, terminal_index)`` pairs forming the star,
+            sorted shortest-first for routing order.  Every non-root
+            terminal appears exactly once, so the sense taps connect at
+            the Kelvin point and never through the high-current terminal.
+    """
+
+    root_index: int
+    edges: list[tuple[int, int]]
+
+
+def _is_shunt_pad(pad: Pad) -> bool:
+    """Return True when ``pad`` belongs to a shunt / sense resistor.
+
+    A pad is a Kelvin-point candidate when its component reference is a
+    resistor designator (``R10``, ``R3``) or, lacking a usable ref, its
+    library footprint name reads as a resistor/shunt package.  Virtual
+    Steiner pads (``steiner_point``) never qualify.
+    """
+    if getattr(pad, "steiner_point", False):
+        return False
+    ref = (pad.ref or "").strip()
+    if ref and _RESISTOR_REF_RE.match(ref):
+        return True
+    fp = getattr(pad, "footprint_name", "") or ""
+    if fp and _RESISTOR_FP_RE.search(fp):
+        return True
+    return False
+
+
+def is_sense_net_name(net_name: str) -> bool:
+    """Return True when ``net_name`` reads as a current-sense / Kelvin net.
+
+    Matches the dedicated sense-name pattern (``ISENSE``, ``VSNS``,
+    ``SHUNT`` ...) against the sheet-local suffix so hierarchical names
+    (``/PWR/ISENSE_A``) resolve the same as bare ones.  Deliberately
+    narrower than the router's ANALOG classification: ``ADC0`` classifies
+    ANALOG but is not a sense tap and is excluded here, so ordinary analog
+    nets keep the generic RSMT.
+    """
+    if not net_name:
+        return False
+    suffix = net_name_suffix(net_name)
+    return bool(_SENSE_NAME_RE.search(suffix))
+
+
+def find_kelvin_root(pad_objs: list[Pad]) -> int | None:
+    """Identify the Kelvin-point pad index among a net's pads.
+
+    The Kelvin point is the shunt/sense-resistor pad every sense trace
+    must tap.  Selection:
+
+    * Gather the pads that sit on a resistor/shunt footprint
+      (:func:`_is_shunt_pad`).
+    * Zero candidates -> ``None`` (not a resolvable Kelvin net; the caller
+      falls back to the generic RSMT).
+    * One candidate -> that pad.
+    * Several candidates (e.g. both pads of the shunt are on the net, or a
+      filter resistor shares it) -> the candidate minimising total
+      Manhattan distance to every other pad, a deterministic "most
+      central" tie-break that keeps the star's total wirelength low.
+
+    Returns:
+        Index into ``pad_objs`` of the Kelvin-point pad, or ``None``.
+    """
+    candidates = [i for i, p in enumerate(pad_objs) if _is_shunt_pad(p)]
+    if not candidates:
+        return None
+    if len(candidates) == 1:
+        return candidates[0]
+
+    def _total_manhattan(idx: int) -> float:
+        px, py = pad_objs[idx].x, pad_objs[idx].y
+        return sum(
+            abs(px - pad_objs[k].x) + abs(py - pad_objs[k].y)
+            for k in range(len(pad_objs))
+            if k != idx
+        )
+
+    # Deterministic: minimise total distance, break exact ties by lowest
+    # index so repeated runs pick the same root.
+    return min(candidates, key=lambda i: (_total_manhattan(i), i))
+
+
+def detect_kelvin_topology(pad_objs: list[Pad]) -> KelvinTopology | None:
+    """Recognise a Kelvin sense net and return its star topology.
+
+    A net qualifies only when ALL hold:
+
+    1. It has at least 3 terminals (a 2-pin net has no topology choice and
+       is already Kelvin-correct as a single edge).
+    2. Its net name reads as a current-sense / Kelvin net
+       (:func:`is_sense_net_name`).
+    3. A shunt/sense-resistor root pad is resolvable
+       (:func:`find_kelvin_root`).
+
+    Returns:
+        A :class:`KelvinTopology` (root index + star edges) when all gates
+        pass, else ``None`` so the caller falls back to the generic RSMT.
+    """
+    if len(pad_objs) < 3:
+        return None
+
+    # All pads of a net share one net name; read it from the first real
+    # (non-Steiner) pad.
+    net_name = ""
+    for p in pad_objs:
+        if not getattr(p, "steiner_point", False):
+            net_name = p.net_name or ""
+            if net_name:
+                break
+    if not is_sense_net_name(net_name):
+        return None
+
+    root = find_kelvin_root(pad_objs)
+    if root is None:
+        return None
+
+    edges = build_kelvin_star_edges(pad_objs, root)
+    return KelvinTopology(root_index=root, edges=edges)
+
+
+def build_kelvin_star_edges(pad_objs: list[Pad], root_index: int) -> list[tuple[int, int]]:
+    """Build the star edge list rooted at ``root_index``.
+
+    Every non-root terminal connects directly to the root (the Kelvin
+    point).  Edges are sorted shortest-first (Manhattan) so the router
+    lays the tightest, most-constrained sense taps before the longer runs
+    -- matching :func:`build_rsmt`'s routing-order convention.
+    """
+    rx, ry = pad_objs[root_index].x, pad_objs[root_index].y
+    edges = [(root_index, k) for k in range(len(pad_objs)) if k != root_index]
+    edges.sort(
+        key=lambda e: abs(rx - pad_objs[e[1]].x) + abs(ry - pad_objs[e[1]].y)
+    )
+    return edges
+
+
+def build_kelvin_topology(
+    pad_objs: list[Pad],
+) -> tuple[list[Pad], list[tuple[int, int]]] | None:
+    """Constrained Kelvin topology as a drop-in for :func:`build_rsmt`.
+
+    Returns ``(extended_pads, edges)`` with the SAME shape
+    :func:`build_rsmt` returns, so a caller can substitute it directly:
+
+    * ``extended_pads`` is ``list(pad_objs)`` unchanged -- a star
+      introduces **no** synthetic Steiner branch points, which is exactly
+      what makes the topology Kelvin-correct (no arbitrary branch can
+      merge the sense tap into the high-current segment).
+    * ``edges`` are ``(root, terminal)`` index pairs into ``extended_pads``
+      sorted shortest-first.
+
+    Returns ``None`` when the net is not a recognised Kelvin sense net, so
+    the caller falls through to the generic RSMT.
+    """
+    topo = detect_kelvin_topology(pad_objs)
+    if topo is None:
+        return None
+    return list(pad_objs), topo.edges
+
+
+def is_kelvin_net(pad_objs: list[Pad]) -> bool:
+    """Return True when this net's pads form a recognised Kelvin sense net.
+
+    Convenience predicate for callers that want to *prioritise* Kelvin
+    nets (route them before ordinary equipotentials so their constrained
+    star wins the corridor negotiation) without building the topology.
+    """
+    return detect_kelvin_topology(pad_objs) is not None

--- a/tests/test_kelvin_topology.py
+++ b/tests/test_kelvin_topology.py
@@ -340,9 +340,7 @@ class TestBoard05ISenseNets:
     def test_multi_pad_isense_nets_route_kelvin(self):
         pads_by_net = self._sense_pads_by_net()
         multi = {
-            n: pads
-            for n, pads in pads_by_net.items()
-            if n.startswith("ISENSE_") and len(pads) >= 3
+            n: pads for n, pads in pads_by_net.items() if n.startswith("ISENSE_") and len(pads) >= 3
         }
         assert multi, "expected at least one multi-pad ISENSE net"
         for name, pads in multi.items():

--- a/tests/test_kelvin_topology.py
+++ b/tests/test_kelvin_topology.py
@@ -1,0 +1,360 @@
+"""Tests for the Kelvin / current-sense routing topology model (Issue #4473).
+
+A Kelvin sense net must route as a *star rooted at the shunt pad* (the
+Kelvin point): every sense terminal connects directly to the shunt pad so
+the sense trace taps AT the Kelvin point and never shares the
+high-current segment.  This module covers:
+
+- detection (net-name + shunt-pad gates, conservative fall-through),
+- root selection (single / multiple shunt pads, deterministic tie-break),
+- star topology shape (no Steiner points, all edges rooted, ordering),
+- ``build_rsmt`` integration (Kelvin -> star, ordinary net -> RSMT),
+- a synthetic 4-pad Kelvin fixture proving the sense taps land at the
+  Kelvin point and no edge joins two non-root (high-current) terminals.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.router.algorithms.steiner import build_rsmt
+from kicad_tools.router.kelvin import (
+    KelvinTopology,
+    build_kelvin_star_edges,
+    build_kelvin_topology,
+    detect_kelvin_topology,
+    find_kelvin_root,
+    is_kelvin_net,
+    is_sense_net_name,
+)
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.primitives import Pad
+
+
+def _pad(
+    x: float,
+    y: float,
+    ref: str = "",
+    net_name: str = "ISENSE_A+",
+    footprint_name: str = "",
+    net: int = 1,
+) -> Pad:
+    return Pad(
+        x=x,
+        y=y,
+        width=0.5,
+        height=0.5,
+        net=net,
+        net_name=net_name,
+        layer=Layer.F_CU,
+        ref=ref,
+        footprint_name=footprint_name,
+    )
+
+
+class TestSenseNameDetection:
+    """``is_sense_net_name`` -- current-sense name recognition."""
+
+    def test_isense_matches(self):
+        assert is_sense_net_name("ISENSE_A+")
+        assert is_sense_net_name("ISENSE_B-")
+
+    def test_underscore_and_abbrev_variants(self):
+        assert is_sense_net_name("I_SENSE_P")
+        assert is_sense_net_name("VSNS")
+        assert is_sense_net_name("CSNS_1")
+        assert is_sense_net_name("SHUNT_A")
+        assert is_sense_net_name("IMON")
+        assert is_sense_net_name("CURRENT_SENSE")
+
+    def test_hierarchical_suffix_matches(self):
+        assert is_sense_net_name("/PWR/ISENSE_A")
+        assert is_sense_net_name("/A/B/VSNS")
+
+    def test_ordinary_analog_not_matched(self):
+        # ADC0 classifies ANALOG but is not a sense tap.
+        assert not is_sense_net_name("ADC0")
+        assert not is_sense_net_name("VREF")
+        assert not is_sense_net_name("GND")
+        assert not is_sense_net_name("+3.3V")
+
+    def test_empty_name(self):
+        assert not is_sense_net_name("")
+
+
+class TestFindKelvinRoot:
+    """``find_kelvin_root`` -- shunt-pad identification."""
+
+    def test_single_resistor_pad(self):
+        pads = [_pad(0, 0, "U3"), _pad(10, 10, "R10"), _pad(20, 0, "Q1")]
+        assert find_kelvin_root(pads) == 1
+
+    def test_footprint_fallback_when_ref_missing(self):
+        pads = [
+            _pad(0, 0, "", footprint_name="Package_SO:SOIC-8"),
+            _pad(10, 10, "", footprint_name="Resistor_SMD:R_2512_6332Metric"),
+        ]
+        assert find_kelvin_root(pads) == 1
+
+    def test_no_resistor_pad_returns_none(self):
+        pads = [_pad(0, 0, "U3"), _pad(10, 10, "Q1"), _pad(20, 0, "U2")]
+        assert find_kelvin_root(pads) is None
+
+    def test_multiple_resistor_pads_pick_most_central(self):
+        # Two shunt-side pads on the net; the central one minimises total
+        # Manhattan distance and is chosen deterministically.
+        pads = [
+            _pad(0, 0, "U3"),  # sense sink
+            _pad(0, 100, "R10"),  # far shunt pad
+            _pad(5, 5, "R10"),  # central shunt pad
+            _pad(10, 0, "Q1"),  # high-current
+        ]
+        assert find_kelvin_root(pads) == 2
+
+    def test_steiner_pad_never_root(self):
+        p = _pad(5, 5, "R10")
+        p.steiner_point = True
+        pads = [_pad(0, 0, "R11"), p, _pad(20, 0, "U3")]
+        # Only the non-Steiner resistor pad qualifies.
+        assert find_kelvin_root(pads) == 0
+
+
+class TestDetectKelvinTopology:
+    """``detect_kelvin_topology`` -- full gating."""
+
+    def test_detects_four_pad_kelvin(self):
+        pads = [
+            _pad(10, 10, "R10"),  # shunt / Kelvin point
+            _pad(0, 0, "U3"),  # op-amp sense input
+            _pad(20, 0, "Q1"),  # low-side FET source tap (high current)
+            _pad(0, 20, "U2"),  # ADC
+        ]
+        topo = detect_kelvin_topology(pads)
+        assert isinstance(topo, KelvinTopology)
+        assert topo.root_index == 0
+
+    def test_two_pin_net_not_kelvin(self):
+        pads = [_pad(0, 0, "R10"), _pad(10, 0, "U3")]
+        assert detect_kelvin_topology(pads) is None
+
+    def test_sense_name_without_shunt_falls_through(self):
+        pads = [_pad(0, 0, "U3"), _pad(10, 0, "U2"), _pad(20, 0, "Q1")]
+        assert detect_kelvin_topology(pads) is None
+
+    def test_shunt_without_sense_name_falls_through(self):
+        pads = [
+            _pad(10, 10, "R10", net_name="NET_FOO"),
+            _pad(0, 0, "U3", net_name="NET_FOO"),
+            _pad(20, 0, "Q1", net_name="NET_FOO"),
+        ]
+        assert detect_kelvin_topology(pads) is None
+
+    def test_net_name_read_from_first_real_pad(self):
+        steiner = _pad(5, 5, "", net_name="")
+        steiner.steiner_point = True
+        pads = [steiner, _pad(10, 10, "R10"), _pad(0, 0, "U3"), _pad(20, 0, "Q1")]
+        topo = detect_kelvin_topology(pads)
+        assert topo is not None
+
+
+class TestStarEdges:
+    """``build_kelvin_star_edges`` -- star shape + ordering."""
+
+    def test_all_edges_rooted(self):
+        pads = [_pad(10, 10, "R10"), _pad(0, 0, "U3"), _pad(20, 0, "Q1"), _pad(0, 20, "U2")]
+        edges = build_kelvin_star_edges(pads, 0)
+        assert len(edges) == 3
+        assert all(e[0] == 0 for e in edges)
+        # Every non-root terminal appears exactly once.
+        assert sorted(e[1] for e in edges) == [1, 2, 3]
+
+    def test_shortest_first_ordering(self):
+        # Root at origin; terminals at distances 5, 10, 20.
+        pads = [_pad(0, 0, "R10"), _pad(20, 0, "U3"), _pad(5, 0, "U2"), _pad(10, 0, "Q1")]
+        edges = build_kelvin_star_edges(pads, 0)
+        dists = [abs(pads[e[1]].x) for e in edges]
+        assert dists == sorted(dists)
+        assert dists == [5, 10, 20]
+
+    def test_no_edge_between_two_non_root_terminals(self):
+        # The Kelvin guarantee: no edge joins two non-root (high-current /
+        # sense) terminals, so no sense tap shares the high-current segment.
+        pads = [_pad(10, 10, "R10"), _pad(0, 0, "U3"), _pad(20, 0, "Q1"), _pad(0, 20, "U2")]
+        edges = build_kelvin_star_edges(pads, 0)
+        for a, b in edges:
+            assert 0 in (a, b)
+
+
+class TestBuildRsmtIntegration:
+    """``build_rsmt`` routes Kelvin nets as stars, others as RSMT."""
+
+    def test_kelvin_net_routes_as_star_no_steiner_points(self):
+        pads = [_pad(10, 10, "R10"), _pad(0, 0, "U3"), _pad(20, 0, "Q1"), _pad(0, 20, "U2")]
+        ext, edges = build_rsmt(pads)
+        # A star adds no virtual Steiner pads.
+        assert len(ext) == len(pads)
+        assert not any(p.steiner_point for p in ext)
+        # All edges emanate from the shunt pad (index 0).
+        assert all(0 in e for e in edges)
+
+    def test_allow_kelvin_false_forces_rsmt(self):
+        pads = [_pad(0, 0, "R10"), _pad(10, 0, "U3"), _pad(0, 10, "Q1"), _pad(10, 10, "U2")]
+        ext_star, edges_star = build_rsmt(pads, allow_kelvin=True)
+        ext_rsmt, edges_rsmt = build_rsmt(pads, allow_kelvin=False)
+        # The RSMT path may introduce Steiner points; the star never does.
+        assert not any(p.steiner_point for p in ext_star)
+        # The two paths need not agree on edge count, but the star is a
+        # pure 3-edge star for 4 terminals.
+        assert len(edges_star) == 3
+        assert all(0 in e for e in edges_star)
+
+    def test_ordinary_net_unchanged_by_kelvin_gate(self):
+        # A non-sense multi-terminal net still gets the generic RSMT and
+        # may synthesise Steiner points -- the Kelvin gate is a no-op.
+        pads = [
+            _pad(0, 0, "U1", net_name="DATA0"),
+            _pad(10, 0, "U2", net_name="DATA0"),
+            _pad(0, 10, "U3", net_name="DATA0"),
+            _pad(10, 10, "U4", net_name="DATA0"),
+        ]
+        ext_default, edges_default = build_rsmt(pads)
+        ext_forced, edges_forced = build_rsmt(pads, allow_kelvin=False)
+        assert len(ext_default) == len(ext_forced)
+        assert edges_default == edges_forced
+
+    def test_is_kelvin_net_predicate(self):
+        kelvin = [_pad(10, 10, "R10"), _pad(0, 0, "U3"), _pad(20, 0, "Q1")]
+        ordinary = [
+            _pad(0, 0, "U1", net_name="DATA0"),
+            _pad(10, 0, "U2", net_name="DATA0"),
+            _pad(0, 10, "U3", net_name="DATA0"),
+        ]
+        assert is_kelvin_net(kelvin)
+        assert not is_kelvin_net(ordinary)
+
+
+class TestSyntheticKelvinFixture:
+    """End-to-end synthetic Kelvin fixture (acceptance criterion #3).
+
+    Models a real 4-wire current-sense structure: a shunt resistor whose
+    two pads carry the high current (shunt+ / shunt-), an op-amp sense
+    input, and an ADC.  The sense net (shunt+ side) must connect the sense
+    terminals AT the shunt+ pad, never routing them through the FET-source
+    high-current terminal.
+    """
+
+    def _fixture_pads(self) -> list[Pad]:
+        # ISENSE_A+ : shunt R10 pin-1 (Kelvin point), op-amp U3 SP input,
+        # low-side FET Q1 source tap (carries load current), ADC U2 PA0.
+        return [
+            _pad(50.0, 20.0, "U3"),  # op-amp sense input (hi-Z)
+            _pad(30.0, 10.0, "R10"),  # shunt pad == Kelvin point
+            _pad(30.0, 40.0, "Q1"),  # FET source tap (high current)
+            _pad(60.0, 45.0, "U2"),  # ADC input (hi-Z)
+        ]
+
+    def test_fixture_routes_with_kelvin_topology(self):
+        pads = self._fixture_pads()
+        ext, edges = build_rsmt(pads)
+
+        # No synthetic Steiner branch points -- a branch point could merge
+        # the sense tap into the high-current segment.
+        assert not any(p.steiner_point for p in ext)
+
+        # Every edge is incident to the shunt pad (the Kelvin point).
+        root = next(i for i, p in enumerate(ext) if p.ref == "R10")
+        assert all(root in e for e in edges)
+
+        # The op-amp and ADC (sense sinks) connect DIRECTLY to the shunt,
+        # not via the FET-source high-current terminal.
+        fet = next(i for i, p in enumerate(ext) if p.ref == "Q1")
+        opamp = next(i for i, p in enumerate(ext) if p.ref == "U3")
+        adc = next(i for i, p in enumerate(ext) if p.ref == "U2")
+        neighbours = {a if b == opamp else b for a, b in edges if opamp in (a, b)}
+        assert neighbours == {root}
+        neighbours_adc = {a if b == adc else b for a, b in edges if adc in (a, b)}
+        assert neighbours_adc == {root}
+        # No direct sense-to-FET edge exists.
+        assert (opamp, fet) not in edges and (fet, opamp) not in edges
+        assert (adc, fet) not in edges and (fet, adc) not in edges
+
+    def test_topology_via_build_kelvin_topology_matches(self):
+        pads = self._fixture_pads()
+        via_helper = build_kelvin_topology(pads)
+        assert via_helper is not None
+        ext, edges = via_helper
+        assert len(ext) == len(pads)
+        root = next(i for i, p in enumerate(ext) if p.ref == "R10")
+        assert all(root in e for e in edges)
+
+
+# ---------------------------------------------------------------------------
+# Board-05 acceptance (criterion #2): the real ISENSE nets are recognised
+# and carry the Kelvin topology rooted at their shunt resistor.
+# ---------------------------------------------------------------------------
+
+_BOARD05_PCB = (
+    Path(__file__).resolve().parents[1]
+    / "boards"
+    / "05-bldc-motor-controller"
+    / "output"
+    / "bldc_controller.kicad_pcb"
+)
+
+
+@pytest.mark.skipif(not _BOARD05_PCB.exists(), reason="board-05 PCB not generated")
+class TestBoard05ISenseNets:
+    """board-05's ISENSE nets carry the Kelvin topology (shunt-rooted)."""
+
+    def _sense_pads_by_net(self):
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = PCB.load(str(_BOARD05_PCB))
+        num_to_name = {num: n.name for num, n in pcb.nets.items()}
+        pads_by_net: dict[str, list[Pad]] = defaultdict(list)
+        for fp in pcb.footprints:
+            for pad in fp.pads:
+                name = pad.net_name or num_to_name.get(pad.net_number, "")
+                if not name or not is_sense_net_name(name):
+                    continue
+                try:
+                    pos = pcb.get_pad_position(fp.reference, pad.number)
+                except Exception:
+                    pos = (0.0, 0.0)
+                if not pos or len(pos) < 2:
+                    pos = (0.0, 0.0)
+                pads_by_net[name].append(
+                    _pad(float(pos[0]), float(pos[1]), fp.reference, net_name=name)
+                )
+        return pads_by_net
+
+    def test_isense_nets_present(self):
+        pads_by_net = self._sense_pads_by_net()
+        # The board exposes the ISENSE_{A,B,C}{+,-} sense-net family.
+        isense = {n for n in pads_by_net if n.startswith("ISENSE_")}
+        assert len(isense) >= 5, f"expected >=5 ISENSE nets, got {sorted(isense)}"
+
+    def test_multi_pad_isense_nets_route_kelvin(self):
+        pads_by_net = self._sense_pads_by_net()
+        multi = {
+            n: pads
+            for n, pads in pads_by_net.items()
+            if n.startswith("ISENSE_") and len(pads) >= 3
+        }
+        assert multi, "expected at least one multi-pad ISENSE net"
+        for name, pads in multi.items():
+            topo = detect_kelvin_topology(pads)
+            assert topo is not None, f"{name} not recognised as Kelvin"
+            # The Kelvin point is a shunt resistor pad.
+            root_ref = pads[topo.root_index].ref
+            assert root_ref.upper().startswith("R"), (
+                f"{name} Kelvin root {root_ref} is not a shunt resistor"
+            )
+            # Star topology: no synthesised Steiner points, every edge
+            # rooted at the shunt pad (sense taps land at the Kelvin point).
+            ext, edges = build_rsmt(pads)
+            assert not any(p.steiner_point for p in ext)
+            assert all(topo.root_index in e for e in edges)


### PR DESCRIPTION
## Summary

Phase 3 of Epic #4410. Adds a **generic** Kelvin / current-sense routing topology model so 4-wire sense taps route correctly instead of as undifferentiated equipotentials.

### Problem
The autorouter's RSMT (`algorithms/steiner.py:build_rsmt`) treats every terminal of a multi-pad net as interchangeable and inserts Steiner branch points wherever total wirelength is minimised. For a Kelvin current-sense net that is *incorrect*: an arbitrary Steiner branch can merge the sense tap into the shunt→load high-current segment, so the op-amp/ADC reads the load-current IR drop instead of the true shunt voltage. On board-05 the five ISENSE nets (shunt R10-R12, op-amp SP/SN input, low-side FET-source tap, ADC PA0-2) route this way.

### Approach (generic capability)
New module `kicad_tools.router.kelvin`:
- **Detection** — `is_sense_net_name` (net-name pattern: `ISENSE`, `VSNS`, `SHUNT`, `IMON`, …) + `find_kelvin_root` (the shunt/sense-resistor pad is the Kelvin point). A net is only reshaped when **both** gates pass, so ordinary analog nets (`ADC0`, `VREF`) keep the generic RSMT.
- **Constrained topology** — `build_kelvin_topology` returns a **star rooted at the shunt pad**: every sense terminal connects directly to the Kelvin point, introducing **no** synthetic Steiner branch points, so no sense edge shares the high-current segment except at the Kelvin point itself. Drop-in for `build_rsmt`'s `(extended_pads, edges)` shape.
- `build_rsmt` gains `allow_kelvin=True` and applies the star for recognised sense nets (a no-op for every other net). Wired into both RSMT call sites (`MSTRouter`, `NegotiatedRouter`) via that shared function.

### Acceptance criteria
- [x] Sense-tap nets are recognised and carry the Kelvin topology constraint.
- [x] board-05's ISENSE nets route with correct Kelvin topology — verified against the real `bldc_controller.kicad_pcb`: `ISENSE_A±`/`B±`/`C-` resolve their R10-R12 shunts as the Kelvin roots and route as shunt-rooted stars (no Steiner points).
- [x] Generic synthetic 4-pad Kelvin fixture routes correctly under the constraint.

### Tests
`tests/test_kelvin_topology.py` (26 tests): name/root/topology detection, `build_rsmt` integration (Kelvin→star, ordinary net unchanged), synthetic 4-pad Kelvin fixture proving sense taps land at the Kelvin point with no sense↔FET edge, and a board-05 acceptance class loading the real PCB. Existing `test_steiner.py` (54) and negotiated/MST router suites pass unchanged.

Closes #4473

🤖 Generated with [Claude Code](https://claude.com/claude-code)