### PR TITLE
feat(route): bounded per-link deadline + blocking-copper report for --complete

### DIFF
--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -404,6 +404,11 @@ def run_route_command(args) -> int:
     # and tests/test_cli_parser_drift.py stays green.
     if getattr(args, "complete", False):
         sub_argv.append("--complete")
+    # Issue #4477 (epic #4465, Phase 4): forward --complete-report (the
+    # structured unroutable-link report path).  Both parsers declare it; see
+    # tests/test_cli_parser_drift.py.
+    if getattr(args, "complete_report", None):
+        sub_argv.extend(["--complete-report", args.complete_report])
     grid_val = str(args.grid)
     if grid_val.lower() != "auto":
         sub_argv.extend(["--grid", grid_val])

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -3127,6 +3127,20 @@ def _add_route_parser(subparsers) -> None:
         ),
     )
     route_parser.add_argument(
+        "--complete-report",
+        metavar="PATH",
+        help=(
+            "Issue #4477 (epic #4465, Phase 4): write the structured, "
+            "machine-readable --complete unroutable-link report to PATH as "
+            "JSON (net, link pad endpoints, elapsed vs the per-link "
+            "deadline, and blocking copper reusing the 'kct net-status "
+            "--why' obstruction enumeration). Only written when --complete "
+            "left one or more links unroutable; a human-readable summary is "
+            "always printed regardless of this flag. Ignored without "
+            "--complete."
+        ),
+    )
+    route_parser.add_argument(
         "--region",
         metavar="X1,Y1,X2,Y2",
         help=(

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -8699,13 +8699,13 @@ def _offboard_preflight(pcb_path: Path) -> int:
     return 2
 
 
-def _apply_complete_mode_defaults(args, parser) -> None:
+def _apply_complete_mode_defaults(args, parser, argv: list[str] | None = None) -> None:
     """Apply the ``--complete`` mode implications (Issue #4471, epic #4465).
 
     ``--complete`` is a *route-only-the-currently-unconnected-links* contract:
     it auto-detects the stranded signal nets (later, in
     :func:`_resolve_complete_nets`, which needs the validated board path) and
-    routes ONLY those against all other copper held as fixed obstacles.  Two
+    routes ONLY those against all other copper held as fixed obstacles.  Three
     implications must be stamped BEFORE the #4280 engine/strategy gate runs so
     the gate sees the coherent combination:
 
@@ -8718,6 +8718,16 @@ def _apply_complete_mode_defaults(args, parser) -> None:
       the lattice netset driver (``core.py:_negotiate_lattice_netset``), which
       already routes ONLY ``self.nets`` against
       ``fixed_copper = existing_routes not in self.nets`` (#4355).
+    * ``--auto-layers`` OFF (issue #4477) -- ``--auto-layers`` defaults to
+      True and, left alone, silently routes a completion pass through
+      :func:`route_with_layer_escalation` -- a WHOLE-BOARD reimplementation
+      of the routing loop with its own exit-code tail that never runs the
+      per-link deadline + blocking-copper report this phase adds, and that
+      re-attempts the ENTIRE board at 2/4/6 layers on failure, contradicting
+      "route ONLY these already-placed links against the board's existing
+      layer stack".  Disabled under ``--complete`` unless the user passed
+      ``--auto-layers``/``--no-auto-layers`` explicitly (mirrors the
+      ``--auto-pcb-size`` implies ``--auto-layers`` precedent below).
 
     ``--strategy`` is intentionally NOT coerced here: the gate
     (:func:`_validate_route_engine_strategy`) owns the coercion so the printed
@@ -8740,6 +8750,19 @@ def _apply_complete_mode_defaults(args, parser) -> None:
             print(
                 "  --complete: routing unconnected links on the lattice engine "
                 "(override with --route-engine)"
+            )
+    _argv = argv if argv is not None else sys.argv
+    if (
+        "--auto-layers" not in _argv
+        and "--no-auto-layers" not in _argv
+        and getattr(args, "auto_layers", False)
+    ):
+        args.auto_layers = False
+        if not getattr(args, "quiet", False):
+            print(
+                "  --complete: disabling --auto-layers (completion routes "
+                "against the board's existing layer stack; pass --auto-layers "
+                "to override)"
             )
 
 
@@ -8961,6 +8984,177 @@ def _apply_complete_localization(args, pcb_path: Path) -> int:
                 f"{', '.join(sorted(oversized))}"
             )
     return 0
+
+
+def _net_name_for_lattice_key(router: "Autorouter", key: object) -> str:
+    """Resolve a lattice ``failure_reasons``/endpoints key to a net name.
+
+    Issue #4477.  Singles are keyed ``(net_id, seq)`` (issue #4278); coupled
+    diff pairs are keyed ``("pair", p_net_id, n_net_id)`` (issue #4270).  Any
+    other shape (defensive) falls back to ``str(key)`` rather than raising --
+    a reporting helper must never break the completion pass it is reporting
+    on.
+    """
+    if isinstance(key, tuple) and len(key) == 3 and key[0] == "pair":
+        _tag, p_id, n_id = key
+        p_name = router.net_names.get(p_id, str(p_id))
+        n_name = router.net_names.get(n_id, str(n_id))
+        return f"{p_name}/{n_name}"
+    if isinstance(key, tuple) and len(key) == 2:
+        net_id, _seq = key
+        return router.net_names.get(net_id, str(net_id))
+    return str(key)
+
+
+def _build_complete_link_report(router: "Autorouter", pcb_path: Path) -> dict | None:
+    """Structured, machine-readable unroutable-link report for ``--complete``.
+
+    Issue #4477 (epic #4465, Phase 4).  Combines two pieces of diagnosis that
+    already exist independently:
+
+    * **Timing** -- the lattice netset negotiation's per-connection decline
+      reason (``LatticePathfinder.failure_reasons``, issue #4278) plus the
+      per-link wall-clock budget stats (``LatticeNegotiationStats``,
+      issue #4472): elapsed time, the granted budget, and whether the
+      deadline was hit.  A connection never reached before the deadline is
+      declined with the honest reason ``"deadline-exceeded"`` (see
+      :meth:`~kicad_tools.router.lattice.pathfinder.LatticePathfinder.route_netset`).
+    * **Blocking copper** -- the SAME obstruction enumeration
+      ``kct net-status --why`` prints
+      (:func:`~kicad_tools.router.stuck_classifier.classify_stuck_nets`),
+      run read-only against *pcb_path* (the resolved working board at this
+      point in the pipeline -- by the time this is called it may be the
+      ``-o``/auto-pour staged copy rather than the literal ``args.pcb`` file,
+      but a link that failed to route received no new copper, so its
+      immediate surroundings are geometrically identical to the original
+      input -- the ``--preserve-existing`` + #4413 copper-loss guard
+      invariant this whole feature depends on).
+
+    Returns ``None`` when there is nothing to report: either every
+    ``--complete`` link routed cleanly, or the completion pass did not run
+    the lattice engine (e.g. an explicit ``--route-engine`` override), which
+    is the only engine this per-link diagnosis is wired to (issue #4465's
+    staged design backs completion with the lattice engine).
+
+    Reads ``router._lattice_failure_reasons`` -- a plain dict copied off the
+    pathfinder at negotiation time -- rather than
+    ``router._lattice_pathfinder.failure_reasons`` directly, because
+    ``_release_routing_engine_state`` (#4292) nulls ``_lattice_pathfinder``
+    before the CLI's post-route tail (where this function is called) runs.
+    """
+    stats = getattr(router, "_lattice_negotiation_stats", None)
+    if stats is None:
+        return None
+    reasons: dict[object, str] = dict(getattr(router, "_lattice_failure_reasons", {}) or {})
+    if not reasons:
+        return None
+
+    endpoints: dict[object, tuple[str, str]] = (
+        getattr(router, "_lattice_connection_endpoints", {}) or {}
+    )
+
+    # Tier-limit context (Phase 3, issue #4475, not yet built): surface
+    # whether the configured manufacturer supports via-in-pad at all, so a
+    # consumer can flag "this link may need a capability this fab tier
+    # lacks" even before Phase 3's last-resort ordering lands a precise
+    # per-link tier-limit reason.  Informational only -- never asserted as
+    # the definitive cause of a specific decline.
+    mfr = getattr(getattr(router, "rules", None), "manufacturer", None)
+    via_in_pad_supported: bool | None = None
+    if mfr:
+        try:
+            from kicad_tools.router.mfr_limits import get_mfr_limits
+
+            via_in_pad_supported = bool(get_mfr_limits(mfr).via_in_pad_supported)
+        except Exception:
+            via_in_pad_supported = None
+    tier_limit_note: str | None = None
+    if via_in_pad_supported is False:
+        tier_limit_note = (
+            f"manufacturer '{mfr}' does not support via-in-pad; a walled SMD "
+            "pad may require it to close (Phase 3, issue #4475's last-resort "
+            "via-in-pad ordering, is not applied by this build)"
+        )
+
+    try:
+        from kicad_tools.router.stuck_classifier import classify_stuck_nets
+
+        diag_by_net = {d.net_name: d for d in classify_stuck_nets(pcb_path).diagnoses}
+    except Exception:
+        diag_by_net = {}
+
+    links: list[dict] = []
+    for key in sorted(reasons, key=lambda k: _net_name_for_lattice_key(router, k)):
+        reason = reasons[key]
+        net_name = _net_name_for_lattice_key(router, key)
+        ep = endpoints.get(key)
+        diag = diag_by_net.get(net_name)
+        entry: dict = {
+            "net": net_name,
+            "reason": reason,
+            "link": {"start": ep[0], "end": ep[1]} if ep else None,
+            "deadline_hit": bool(reason == "deadline-exceeded" or stats.deadline_hit),
+            "elapsed_s": round(stats.elapsed_s, 3),
+            "budget_s": round(stats.budget_s, 3) if stats.budget_s is not None else None,
+            "blocking_copper": list(diag.blocking_nets) if diag else [],
+            "nearest_blocker_mm": (
+                round(diag.nearest_blocker_mm, 4)
+                if diag and diag.nearest_blocker_mm is not None
+                else None
+            ),
+            "stuck_classification": diag.classification.value if diag else None,
+            "stuck_evidence": diag.evidence if diag else "",
+        }
+        if tier_limit_note is not None:
+            entry["tier_limit_note"] = tier_limit_note
+        links.append(entry)
+
+    return {
+        "pcb": str(pcb_path),
+        "manufacturer": mfr,
+        "via_in_pad_supported": via_in_pad_supported,
+        "deadline_hit": stats.deadline_hit,
+        "elapsed_s": round(stats.elapsed_s, 3),
+        "budget_s": round(stats.budget_s, 3) if stats.budget_s is not None else None,
+        "unroutable_links": links,
+    }
+
+
+def _print_complete_link_report(report: dict) -> None:
+    """Human-readable rendering of :func:`_build_complete_link_report`."""
+    links = report["unroutable_links"]
+    budget_note = (
+        f" of a {report['budget_s']:.1f}s budget" if report["budget_s"] is not None else ""
+    )
+    deadline_note = " -- deadline exceeded" if report["deadline_hit"] else ""
+    print()
+    print(
+        f"--complete: {len(links)} unroutable link(s) "
+        f"(elapsed {report['elapsed_s']:.1f}s{budget_note}{deadline_note}):"
+    )
+    for entry in links:
+        link = entry["link"]
+        ep = f"{link['start']} <-> {link['end']}" if link else "(pads unknown)"
+        print(f"  [{entry['net']}] {ep} -- {entry['reason']}")
+        if entry["blocking_copper"]:
+            nearest = entry["nearest_blocker_mm"]
+            nearest_note = f" (nearest {nearest:.3f}mm)" if nearest is not None else ""
+            print(f"      blocking copper: {', '.join(entry['blocking_copper'])}{nearest_note}")
+        if entry["stuck_classification"]:
+            print(
+                f"      classification: {entry['stuck_classification'].upper()} "
+                f"-- {entry['stuck_evidence']}"
+            )
+        if entry.get("tier_limit_note"):
+            print(f"      tier limit: {entry['tier_limit_note']}")
+    print()
+
+
+def _write_complete_report(report: dict, path: str) -> None:
+    """Persist :func:`_build_complete_link_report` as JSON at *path*."""
+    import json
+
+    Path(path).write_text(json.dumps(report, indent=2) + "\n")
 
 
 def _resolve_route_only_nets(args, pcb_path: Path) -> int:
@@ -9328,6 +9522,7 @@ def main(argv: list[str] | None = None) -> int:
               3  routing meets threshold but DRC violations remain
               4  partial routing AND segment-segment clearance violations
               5  interrupted by SIGINT with partial results saved
+              8  --complete: one or more unroutable links remain (issue #4477)
         """),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -9387,6 +9582,20 @@ def main(argv: list[str] | None = None) -> int:
             "#4413 copper-loss guard is active). Mutually exclusive with "
             "--nets / --skip-nets. A board with nothing left to connect is a "
             "safe no-op."
+        ),
+    )
+    parser.add_argument(
+        "--complete-report",
+        metavar="PATH",
+        help=(
+            "Issue #4477 (epic #4465, Phase 4): write the structured, "
+            "machine-readable --complete unroutable-link report to PATH as "
+            "JSON (net, link pad endpoints, elapsed vs the per-link "
+            "deadline, and blocking copper reusing the 'kct net-status "
+            "--why' obstruction enumeration). Only written when --complete "
+            "left one or more links unroutable; a human-readable summary is "
+            "always printed regardless of this flag. Ignored without "
+            "--complete."
         ),
     )
     parser.add_argument(
@@ -10810,7 +11019,7 @@ def main(argv: list[str] | None = None) -> int:
     # (--preserve-existing + the lattice engine, unless the user overrode
     # --route-engine) BEFORE the #4280 gate so the gate sees the coherent
     # route-only-listed-links combination.  No-op when --complete is absent.
-    _apply_complete_mode_defaults(args, parser)
+    _apply_complete_mode_defaults(args, parser, argv)
 
     # Issue #4280: hard compatibility gate for --route-engine mesh|lattice.
     # Runs before ANY other work (env stamping, board loading, escalation
@@ -13296,6 +13505,24 @@ def main(argv: list[str] | None = None) -> int:
             nets_to_route_ids=multi_pad_net_ids,
         )
 
+    # Issue #4477 (epic #4465, Phase 4): ``--complete`` blocking-copper
+    # reporting.  Built from *pcb_path* -- the resolved working board -- so
+    # the blocking-copper enumeration matches ``kct net-status --why``
+    # exactly (a link that failed to route left no new copper behind, so its
+    # surroundings are unchanged from the original input).  ``None`` when
+    # every link routed cleanly or the completion pass did not run the
+    # lattice engine (no per-link diagnosis is wired up elsewhere).
+    _complete_report = None
+    if getattr(args, "complete", False) and not all_nets_routed:
+        _complete_report = _build_complete_link_report(router, pcb_path)
+        if _complete_report is not None:
+            if not quiet:
+                _print_complete_link_report(_complete_report)
+            if getattr(args, "complete_report", None):
+                _write_complete_report(_complete_report, args.complete_report)
+                if not quiet:
+                    print(f"  --complete: unroutable-link report written to {args.complete_report}")
+
     # Exit codes:
     # 0 = Routing meets --min-completion threshold AND (DRC passed OR DRC not run)
     # 1 = Fatal failure — no nets routed, no useful output
@@ -13318,6 +13545,14 @@ def main(argv: list[str] | None = None) -> int:
     #     regressions without parsing the full route log.  The
     #     AUTOFIX_SKIPPED_BUDGET_EXHAUSTED stderr token is emitted on
     #     this path.
+    # 8 = ``--complete`` left one or more previously-unconnected links
+    #     unroutable (issue #4477).  Distinct from -- and checked BEFORE --
+    #     the generic --min-completion threshold codes below: --complete
+    #     routes ONLY a small, explicitly-identified set of stranded links,
+    #     so a lenient --min-completion must never mask "the link this run
+    #     was specifically asked to close never closed".  See the per-link
+    #     report printed above (and optionally written via
+    #     --complete-report) for WHY and what copper is blocking.
     #
     # The --min-completion flag (default 0.95) controls the success threshold.
     # With --min-completion 0.80, routing 85% of nets returns exit code 0.
@@ -13350,6 +13585,15 @@ def main(argv: list[str] | None = None) -> int:
     if stats["nets_routed"] == 0 and nets_to_route > 0:
         # Nothing was routed — treat as fatal failure
         return 1
+
+    # Issue #4477: --complete exits nonzero whenever a link it was asked to
+    # close remains unroutable, independent of --min-completion (a whole-
+    # board convenience threshold that must not paper over a completion
+    # pass that failed at the ONE thing it was asked to do).  Checked after
+    # the "nothing routed at all" fatal path (which keeps its own exit 1)
+    # but before every generic threshold-based code below.
+    if getattr(args, "complete", False) and not all_nets_routed:
+        return 8
     elif meets_threshold and drc_passed and seg_seg_violation_count == 0:
         return 0
     elif meets_threshold and (not drc_passed or seg_seg_violation_count > 0):

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -1103,6 +1103,16 @@ class Autorouter:
         # best routes found so far.  ``None`` preserves the unbudgeted
         # (iteration-capped only) behaviour.
         self._lattice_link_budget_s: float | None = None
+        # Issue #4477 (epic #4465, Phase 4): pad endpoints (``"REF.PIN"``) for
+        # every connection dispatched into the lattice negotiation, keyed by
+        # the SAME key ``pf.failure_reasons`` uses.  Lets a ``--complete``
+        # unroutable-link report name exactly which two pads a failed
+        # connection joins.  Populated by :meth:`_negotiate_lattice_netset`.
+        self._lattice_connection_endpoints: dict[object, tuple[str, str]] = {}
+        # Issue #4477: per-connection decline reasons, copied off the
+        # pathfinder (see :meth:`_negotiate_lattice_netset`) so they survive
+        # ``_release_routing_engine_state`` nulling ``_lattice_pathfinder``.
+        self._lattice_failure_reasons: dict[object, str] = {}
 
         # Initialize grid and routers using shared helper
         # Issue #972: Helper includes adaptive grid resolution for large boards
@@ -2722,6 +2732,21 @@ class Autorouter:
             for seq, other in enumerate(pads[1:]):
                 connections.append(((net, seq), anchor, other, net_class))
 
+        # Issue #4477: remember each connection's pad endpoints keyed exactly
+        # as ``pf.failure_reasons`` keys them, so an unroutable-link report
+        # can name the pads a failed connection joins without re-deriving pad
+        # topology from the bare key.
+        endpoints: dict[object, tuple[str, str]] = {
+            key: (f"{anchor.ref}.{anchor.pin}", f"{other.ref}.{other.pin}")
+            for key, anchor, other, _net_class in connections
+        }
+        for pc in coupled:
+            endpoints[pc.key] = (
+                f"{pc.pad_p_a.ref}.{pc.pad_p_a.pin}",
+                f"{pc.pad_p_b.ref}.{pc.pad_p_b.pin}",
+            )
+        self._lattice_connection_endpoints = endpoints
+
         if not connections and not coupled:
             return {}
 
@@ -2758,6 +2783,14 @@ class Autorouter:
             deadline=deadline,
         )
         self._lattice_negotiation_stats = stats
+        # Issue #4477 (epic #4465, Phase 4): copy the per-connection decline
+        # diagnosis onto the ROUTER (not just the pathfinder) because
+        # ``_release_routing_engine_state`` (#4292) nulls
+        # ``router._lattice_pathfinder`` before the CLI's post-route tail runs
+        # (a memory-pressure optimization) -- a ``--complete`` unroutable-link
+        # report built after that point would otherwise see ``None`` and lose
+        # every decline reason.  This plain dict is cheap to retain.
+        self._lattice_failure_reasons: dict[object, str] = dict(pf.failure_reasons)
 
         # Issue #4271: the shortfall must be DIAGNOSABLE from the run output
         # (honest decline census), not buried on the pathfinder object.

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -2790,7 +2790,7 @@ class Autorouter:
         # (a memory-pressure optimization) -- a ``--complete`` unroutable-link
         # report built after that point would otherwise see ``None`` and lose
         # every decline reason.  This plain dict is cheap to retain.
-        self._lattice_failure_reasons: dict[object, str] = dict(pf.failure_reasons)
+        self._lattice_failure_reasons = dict(pf.failure_reasons)
 
         # Issue #4271: the shortfall must be DIAGNOSABLE from the run output
         # (honest decline census), not buried on the pathfinder object.

--- a/src/kicad_tools/router/lattice/pathfinder.py
+++ b/src/kicad_tools/router/lattice/pathfinder.py
@@ -87,6 +87,15 @@ class LatticeNegotiationStats:
     routed: int
     total: int
     lattice_builds: int
+    # Issue #4477 (epic #4465, Phase 4): bounded per-link termination
+    # reporting.  ``deadline_hit`` is True when ``deadline`` (issue #4472) cut
+    # the negotiation short before every connection was attempted;
+    # ``elapsed_s`` is the wall-clock the WHOLE negotiation took;
+    # ``budget_s`` is the budget the caller granted (``None`` when the
+    # negotiation ran unbudgeted, preserving the pre-#4472 behaviour).
+    deadline_hit: bool = False
+    elapsed_s: float = 0.0
+    budget_s: float | None = None
 
     @property
     def completion(self) -> float:
@@ -1609,6 +1618,10 @@ class LatticePathfinder:
         aborts within a per-link budget instead of grinding (issue #4434).
         ``None`` preserves the pre-#4472 unbudgeted (iteration-capped) loop.
         """
+        # Issue #4477: wall-clock the WHOLE negotiation (not just the
+        # deadline check) so a report can honestly say "elapsed Xs of a Ys
+        # budget" even on a run that never hits the deadline.
+        start_time = time.monotonic()
         self._set_fixed_copper(fixed_copper)
         self.build()
         pairs = list(coupled or [])
@@ -1641,6 +1654,19 @@ class LatticePathfinder:
             # budget is spent; the best pass seen so far is returned below.
             if deadline is not None and time.monotonic() >= deadline:
                 deadline_hit = True
+                # Issue #4477: if NO pass ever ran (the budget was already
+                # spent before the first attempt -- e.g. an extremely tight
+                # budget on a large cohort), ``best_reasons`` would otherwise
+                # stay empty and the caller could not report WHY every link
+                # is unroutable.  Synthesize an honest "never attempted"
+                # decline for each connection so the report is never blank.
+                if best_count < 0:
+                    best_count = 0
+                    for _length, kind, item in items:
+                        key = item.key if kind == 1 else item[0]
+                        best_reasons[key] = "deadline-exceeded"
+                        if kind == 1:
+                            best_pair_outcomes[key] = "deadline-exceeded"
                 break
             iterations_run = it + 1
             committed = self._fresh_committed()
@@ -1649,11 +1675,21 @@ class LatticePathfinder:
             pair_outcomes: dict[object, str] = {}
             routed_items = 0
             failed: list[tuple[int, Any]] = []
-            for _length, kind, item in items:
+            for _idx, (_length, kind, item) in enumerate(items):
                 # Issue #4472: abort mid-pass on the deadline too, so a single
                 # slow search inside one pass cannot overrun the budget.
                 if deadline is not None and time.monotonic() >= deadline:
                     deadline_hit = True
+                    # Issue #4477: every connection from here to the end of
+                    # this pass was never attempted -- stamp them honestly as
+                    # "deadline-exceeded" rather than silently omitting them
+                    # from ``reasons`` (which would make an unroutable link
+                    # undiagnosable in the completion report).
+                    for _length2, kind2, item2 in items[_idx:]:
+                        key2 = item2.key if kind2 == 1 else item2[0]
+                        reasons[key2] = "deadline-exceeded"
+                        if kind2 == 1:
+                            pair_outcomes[key2] = "deadline-exceeded"
                     break
                 if kind == 1:
                     pres, preason = self._route_pair_impl(
@@ -1754,12 +1790,20 @@ class LatticePathfinder:
 
         self.failure_reasons = best_reasons
         self.pair_outcomes = best_pair_outcomes
+        # Issue #4477: the budget the CALLER granted for this call is the
+        # remaining time between the deadline and this call's start -- an
+        # honest "elapsed of a Ys budget" figure even when the deadline was
+        # never reached.  ``None`` when the negotiation ran unbudgeted.
+        budget_s = max(0.0, deadline - start_time) if deadline is not None else None
         stats = LatticeNegotiationStats(
             iterations=iterations_run,
             converged=converged,
             routed=best_count if best_count >= 0 else 0,
             total=len(connections) + len(pairs),
             lattice_builds=self.lattice_builds,
+            deadline_hit=deadline_hit,
+            elapsed_s=time.monotonic() - start_time,
+            budget_s=budget_s,
         )
         return best_routes, stats
 

--- a/tests/router/lattice/test_deadline_report_4477.py
+++ b/tests/router/lattice/test_deadline_report_4477.py
@@ -1,0 +1,123 @@
+"""Bounded per-link termination + reporting stats (Issue #4477, epic #4465).
+
+Phase 4 of ``kct route --complete``.  Phase 2 (#4472) added a per-link
+wall-clock ``deadline`` to :meth:`LatticePathfinder.route_netset`; this phase
+adds two properties on top of it that a completion report can consume:
+
+1. A connection that is never reached before the deadline is declined with
+   the honest reason ``"deadline-exceeded"`` in :attr:`failure_reasons` --
+   never silently omitted (which would make an unroutable link
+   undiagnosable).  This covers BOTH corners: the deadline expiring mid-pass
+   (some connections attempted, the rest stamped) and expiring before the
+   very first pass ever runs (every connection stamped).
+2. :class:`LatticeNegotiationStats` carries ``deadline_hit`` / ``elapsed_s`` /
+   ``budget_s`` so a caller can report "elapsed Xs of a Ys budget" without
+   re-deriving timing from scratch.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+from kicad_tools.router.lattice.pathfinder import LatticePathfinder
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import DesignRules
+
+
+def _pad(x: float, y: float, net: int, *, ref: str, pin: str = "1") -> Pad:
+    return Pad(
+        x=x,
+        y=y,
+        width=0.5,
+        height=0.5,
+        net=net,
+        net_name=f"N{net}",
+        layer=Layer.F_CU,
+        ref=ref,
+        pin=pin,
+    )
+
+
+def _pf(*pads: Pad) -> LatticePathfinder:
+    return LatticePathfinder(
+        [(0.0, 0.0), (100.0, 0.0), (100.0, 60.0), (0.0, 60.0)],
+        list(pads),
+        DesignRules(),
+        LayerStack.two_layer(),
+    )
+
+
+class TestStatsCarryTiming:
+    """LatticeNegotiationStats.deadline_hit / elapsed_s / budget_s."""
+
+    def test_unbudgeted_run_has_no_budget(self):
+        a1, a2 = _pad(10, 10, 1, ref="A1"), _pad(20, 10, 1, ref="A2")
+        pf = _pf(a1, a2)
+        _routes, stats = pf.route_netset([((1, 0), a1, a2, None)], max_iterations=4)
+        assert stats.deadline_hit is False
+        assert stats.budget_s is None
+        assert stats.elapsed_s >= 0.0
+
+    def test_budgeted_run_reports_budget_and_elapsed(self):
+        a1, a2 = _pad(10, 10, 1, ref="A1"), _pad(20, 10, 1, ref="A2")
+        pf = _pf(a1, a2)
+        deadline = time.monotonic() + 3600.0
+        _routes, stats = pf.route_netset(
+            [((1, 0), a1, a2, None)], max_iterations=4, deadline=deadline
+        )
+        assert stats.deadline_hit is False
+        assert stats.budget_s is not None and stats.budget_s > 3000.0
+        assert stats.elapsed_s >= 0.0
+
+
+class TestDeadlineExceededNeverSilent:
+    """Every connection the deadline cut off gets an honest reason."""
+
+    def test_already_expired_stamps_every_connection(self):
+        # Case 1: the budget is spent before the FIRST pass ever runs -- no
+        # pass computed a single ``reasons`` entry, so the (pre-#4477)
+        # behaviour would silently return an empty ``failure_reasons``.
+        a1, a2 = _pad(10, 10, 1, ref="A1"), _pad(20, 10, 1, ref="A2")
+        b1, b2 = _pad(50, 10, 2, ref="B1"), _pad(60, 10, 2, ref="B2")
+        pf = _pf(a1, a2, b1, b2)
+        connections = [((1, 0), a1, a2, None), ((2, 0), b1, b2, None)]
+        routes, stats = pf.route_netset(
+            connections, max_iterations=8, deadline=time.monotonic() - 1.0
+        )
+        assert routes == {}
+        assert stats.routed == 0
+        assert stats.converged is False
+        assert stats.deadline_hit is True
+        # BOTH connections are diagnosable -- neither is silently omitted.
+        assert pf.failure_reasons == {(1, 0): "deadline-exceeded", (2, 0): "deadline-exceeded"}
+
+    def test_mid_pass_expiry_stamps_only_the_unattempted_tail(self):
+        # Case 2: the deadline is hit PARTWAY through the first pass.  Item 0
+        # is attempted (real decline/success reason); every later item is
+        # stamped "deadline-exceeded" rather than silently dropped.
+        a1, a2 = _pad(10, 10, 1, ref="A1"), _pad(20, 10, 1, ref="A2")
+        b1, b2 = _pad(50, 10, 2, ref="B1"), _pad(60, 10, 2, ref="B2")
+        pf = _pf(a1, a2, b1, b2)
+        connections = [((1, 0), a1, a2, None), ((2, 0), b1, b2, None)]
+
+        # Deterministic clock: call #1 is ``start_time``; call #2 is the
+        # top-of-loop deadline check (before pass 0 -- not yet expired);
+        # call #3 is the mid-pass check before item 0 (not yet expired, so
+        # item 0 is attempted for real); call #4 is the mid-pass check
+        # before item 1 (now past the deadline); call #5 is the trailing
+        # ``elapsed_s`` computation.  ``_route_impl`` makes no ``monotonic``
+        # calls of its own (grep-verified), so this sequence is exact.
+        clock = iter([0.0, 1.0, 2.0, 100.0, 150.0])
+        with patch("kicad_tools.router.lattice.pathfinder.time.monotonic", lambda: next(clock)):
+            routes, stats = pf.route_netset(connections, max_iterations=1, deadline=50.0)
+
+        assert stats.deadline_hit is True
+        assert stats.converged is False
+        # Item 0 got a REAL attempt (present in either routes or with a
+        # genuine decline reason -- either way, NOT "deadline-exceeded").
+        assert pf.failure_reasons.get((1, 0)) != "deadline-exceeded" or (1, 0) in routes
+        # Item 1 was never reached: honestly stamped, not silently dropped.
+        assert pf.failure_reasons[(2, 0)] == "deadline-exceeded"
+        assert (2, 0) not in routes

--- a/tests/test_cli_route_complete_report_4477.py
+++ b/tests/test_cli_route_complete_report_4477.py
@@ -1,0 +1,282 @@
+"""``--complete`` bounded termination + blocking-copper report (Issue #4477).
+
+Phase 4 of ``kct route --complete`` (epic #4465).  Scope:
+
+1. A per-link deadline bounds a completion pass instead of grinding (the
+   #4434 ">10 minutes" failure mode) -- Phase 2 (#4472) already wires the
+   deadline into the lattice negotiation; this phase asserts the CLI-level
+   completion attempt actually returns within it on a link that is
+   deliberately, topologically unroutable.
+2. An unroutable link is reported with the blocking copper enumerated,
+   reusing the SAME ``classify_stuck_nets`` machinery ``kct net-status --why``
+   prints -- both as a human-readable summary and as a structured
+   ``--complete-report PATH`` JSON artifact.
+3. ``--complete`` exits nonzero when a link it was asked to close remains
+   unroutable, independent of the (irrelevant here) ``--min-completion``
+   threshold.
+
+Fixture: NET2's second pad (``U1.1``) sits inside a fully-closed rectangular
+copper picture-frame (net ``WALL``, four segments whose corners share exact
+endpoints so the loop is closed under BOTH the default 0.01mm-proximity
+connectivity model used by ``classify_stuck_nets`` AND real router geometry).
+A pad strictly inside a closed loop of another net's copper cannot be routed
+out without crossing that copper on a single-layer board -- this is
+topologically unroutable, not merely "hard", so the test never depends on
+router heuristics or resolution to hold.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.route_cmd import main as route_main
+
+# ---------------------------------------------------------------------------
+# Walled-pocket fixture: NET1 fully routed (preserved-copper control), NET2's
+# second pad walled in by the closed WALL picture-frame (genuinely
+# unroutable), NET4 freely routable (so a multi-link run has a MIX of
+# success/failure and exercises the nonzero-exit path distinct from the
+# "nothing routed at all" fatal code).
+# ---------------------------------------------------------------------------
+WALLED_POCKET_BOARD = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general
+    (thickness 1.6)
+  )
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup
+    (pad_to_mask_clearance 0)
+  )
+  (net 0 "")
+  (net 1 "NET1")
+  (net 2 "NET2")
+  (net 3 "WALL")
+  (net 4 "NET4")
+  (gr_rect (start 0 0) (end 60 40)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000010")
+    (at 10 10)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "NET1"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (net 1 "NET1"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000020")
+    (at 10 30)
+    (property "Reference" "R2" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.3 0.3) (layers "F.Cu" "F.Paste" "F.Mask") (net 2 "NET2"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000030")
+    (at 40 20)
+    (property "Reference" "U1" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "target" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at 0 0) (size 0.3 0.3) (layers "F.Cu" "F.Paste" "F.Mask") (net 2 "NET2"))
+  )
+  (footprint "wall_pad" (layer "F.Cu") (at 39 19)
+    (property "Reference" "W1")
+    (pad "1" smd rect (at 0 0) (size 0.5 0.5) (layers "F.Cu") (net 3 "WALL"))
+  )
+  (footprint "wall_pad" (layer "F.Cu") (at 41 21)
+    (property "Reference" "W2")
+    (pad "1" smd rect (at 0 0) (size 0.5 0.5) (layers "F.Cu") (net 3 "WALL"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000040")
+    (at 20 5)
+    (property "Reference" "R4" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (net 4 "NET4"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64) (layers "F.Cu" "F.Paste" "F.Mask") (net 4 "NET4"))
+  )
+  (segment (start 9.5 10) (end 10.5 10) (width 0.2) (layer "F.Cu") (net 1))
+  (segment (start 39 19) (end 41 19) (width 0.6) (layer "F.Cu") (net 3))
+  (segment (start 41 19) (end 41 21) (width 0.6) (layer "F.Cu") (net 3))
+  (segment (start 41 21) (end 39 21) (width 0.6) (layer "F.Cu") (net 3))
+  (segment (start 39 21) (end 39 19) (width 0.6) (layer "F.Cu") (net 3))
+)
+"""
+
+
+@pytest.fixture
+def walled_board(tmp_path: Path) -> Path:
+    board = tmp_path / "walled.kicad_pcb"
+    board.write_text(WALLED_POCKET_BOARD)
+    return board
+
+
+def _segment_nets(pcb_text: str) -> list[int]:
+    import re
+
+    return [int(m.group(1)) for m in re.finditer(r"\(segment.*?\(net (\d+)\)", pcb_text, re.S)]
+
+
+class TestBoundedTermination:
+    """AC1: the completion attempt returns within the configured deadline."""
+
+    def test_walled_link_terminates_bounded(self, walled_board: Path, tmp_path: Path):
+        out = tmp_path / "out.kicad_pcb"
+        # --skip-drc: isolate the router's own bounded-search guarantee from
+        # the (unrelated, pre-existing) kicad-cli DRC subprocess wall-clock.
+        rc = route_main(
+            [str(walled_board), "-o", str(out), "--complete", "--backend", "cpp", "--skip-drc"]
+        )
+        # NET2 cannot close (topologically walled); NET4 can -- exit 8, not
+        # the "nothing routed" fatal code 1 (see TestExitSemantics below).
+        assert rc == 8
+        # NET1 (control) and WALL (fixed obstacle) are preserved; NET4 closed;
+        # NET2 never received new copper (it was declined, not shipped).
+        seg_nets = _segment_nets(out.read_text())
+        assert 1 in seg_nets and 3 in seg_nets and 4 in seg_nets
+
+    def test_completes_well_under_the_ten_minute_failure_mode(
+        self, walled_board: Path, tmp_path: Path
+    ):
+        import time
+
+        out = tmp_path / "out.kicad_pcb"
+        started = time.monotonic()
+        route_main(
+            [str(walled_board), "-o", str(out), "--complete", "--backend", "cpp", "--skip-drc"]
+        )
+        elapsed = time.monotonic() - started
+        # The #4434 failure mode was >10 minutes (600s) non-termination on a
+        # single walled link.  A generous CI ceiling that is still a small
+        # fraction of that -- the per-link deadline default is 60s/link.
+        assert elapsed < 90.0
+
+
+class TestBlockingCopperReport:
+    """AC2: an unroutable link names the blocking copper + reason."""
+
+    def test_human_readable_report_printed(self, walled_board: Path, tmp_path: Path, capsys):
+        out = tmp_path / "out.kicad_pcb"
+        route_main(
+            [str(walled_board), "-o", str(out), "--complete", "--backend", "cpp", "--skip-drc"]
+        )
+        text = capsys.readouterr().out
+        assert "unroutable link" in text
+        assert "NET2" in text
+        assert "WALL" in text  # the blocking copper is named
+
+    def test_json_report_schema(self, walled_board: Path, tmp_path: Path):
+        out = tmp_path / "out.kicad_pcb"
+        report_path = tmp_path / "report.json"
+        route_main(
+            [
+                str(walled_board),
+                "-o",
+                str(out),
+                "--complete",
+                "--backend",
+                "cpp",
+                "--skip-drc",
+                "--complete-report",
+                str(report_path),
+            ]
+        )
+        assert report_path.exists()
+        report = json.loads(report_path.read_text())
+        assert report["deadline_hit"] is False
+        assert isinstance(report["elapsed_s"], int | float)
+        assert report["budget_s"] is not None
+
+        links = report["unroutable_links"]
+        assert len(links) == 1
+        entry = links[0]
+        assert entry["net"] == "NET2"
+        assert entry["link"] == {"start": "R2.1", "end": "U1.1"}
+        assert entry["reason"]  # a decline reason is always present
+        assert "WALL" in entry["blocking_copper"]
+        # Elapsed/deadline bookkeeping is per-link too (issue #4477 scope).
+        assert entry["elapsed_s"] >= 0.0
+        assert entry["budget_s"] > 0.0
+
+    def test_no_report_file_when_nothing_unroutable(self, tmp_path: Path):
+        # A fully-solvable board (no walled pocket) must not fabricate a
+        # report: --complete-report is only written when links remain
+        # unroutable.
+        from tests.test_cli_route_complete_4471 import STRANDED_BOARD
+
+        board = tmp_path / "solvable.kicad_pcb"
+        board.write_text(STRANDED_BOARD)
+        out = tmp_path / "out.kicad_pcb"
+        report_path = tmp_path / "report.json"
+        rc = route_main(
+            [
+                str(board),
+                "-o",
+                str(out),
+                "--complete",
+                "--backend",
+                "cpp",
+                "--skip-drc",
+                "--complete-report",
+                str(report_path),
+            ]
+        )
+        assert rc == 0
+        assert not report_path.exists()
+
+
+class TestExitSemantics:
+    """AC3: --complete exits nonzero when links remain unroutable."""
+
+    def test_mixed_success_and_failure_exits_8(self, walled_board: Path, tmp_path: Path):
+        # NET4 routes cleanly, NET2 does not: distinct from the "nothing
+        # routed at all" fatal code (1) -- exit 8 says "not everything asked
+        # for was closed", which --min-completion must never mask.
+        out = tmp_path / "out.kicad_pcb"
+        rc = route_main(
+            [str(walled_board), "-o", str(out), "--complete", "--backend", "cpp", "--skip-drc"]
+        )
+        assert rc == 8
+
+    def test_lenient_min_completion_does_not_mask_failure(self, walled_board: Path, tmp_path: Path):
+        # A lenient --min-completion (1 of 2 links = 50% >= 0.1 threshold)
+        # would ordinarily report SUCCESS; --complete must still fail hard.
+        out = tmp_path / "out.kicad_pcb"
+        rc = route_main(
+            [
+                str(walled_board),
+                "-o",
+                str(out),
+                "--complete",
+                "--backend",
+                "cpp",
+                "--skip-drc",
+                "--min-completion",
+                "0.1",
+            ]
+        )
+        assert rc == 8
+
+    def test_fully_solvable_board_exits_0(self, tmp_path: Path):
+        from tests.test_cli_route_complete_4471 import STRANDED_BOARD
+
+        board = tmp_path / "solvable.kicad_pcb"
+        board.write_text(STRANDED_BOARD)
+        out = tmp_path / "out.kicad_pcb"
+        rc = route_main(
+            [str(board), "-o", str(out), "--complete", "--backend", "cpp", "--skip-drc"]
+        )
+        assert rc == 0


### PR DESCRIPTION
## Summary

Epic #4465 Phase 4 (gap G5). Adds bounded per-link termination and blocking-copper reporting to `kct route --complete`, so a completion attempt on an unroutable link terminates within its configured budget (instead of the >10-minute non-termination in #4434) and reports *why* the link failed.

## Changes

- `router/lattice/pathfinder.py`: `LatticeNegotiationStats` gains `deadline_hit` / `elapsed_s` / `budget_s`. A connection cut off by the per-link deadline (issue #4472 plumbing) is now stamped with an honest `"deadline-exceeded"` decline reason in `failure_reasons` instead of being silently omitted — covers both "deadline expires mid-pass" and "deadline already spent before the first pass ever runs".
- `router/core.py` (`Autorouter`): records each connection's pad endpoints (`_lattice_connection_endpoints`) and copies the pathfinder's per-connection decline reasons onto the router (`_lattice_failure_reasons`) so they survive `_release_routing_engine_state` nulling `_lattice_pathfinder` before the CLI's post-route report is built.
- `cli/route_cmd.py`:
  - `--complete` now also disables `--auto-layers` by default (unless the user passes `--auto-layers`/`--no-auto-layers` explicitly), since the layer-escalation path re-implements the whole routing loop without this phase's per-link deadline/report wiring.
  - New `_build_complete_link_report` / `_print_complete_link_report` / `_write_complete_report`: combine the timing diagnosis above with the SAME blocking-copper obstruction enumeration `kct net-status --why` uses (`classify_stuck_nets`), plus an informational via-in-pad tier-limit note (Phase 3, #4475) when the configured manufacturer doesn't support via-in-pad.
  - New `--complete-report PATH` flag writes the structured report as JSON; a human-readable summary is always printed when links remain unroutable.
  - `--complete` now exits **8** when one or more links it was asked to close remain unroutable, independent of `--min-completion` (checked before the generic threshold-based codes, after the "nothing routed at all" fatal code 1).
- `cli/parser.py` / `cli/commands/routing.py`: declare/forward `--complete-report` on both parsers (keeps `tests/test_cli_parser_drift.py` green).
- New tests: `tests/router/lattice/test_deadline_report_4477.py` (deadline/stats unit tests) and `tests/test_cli_route_complete_report_4477.py` (CLI end-to-end tests on a deliberately-unroutable walled-pocket fixture).

Plain `kct route` (no `--complete`) is unaffected — every new code path is gated behind `getattr(args, "complete", False)` or only activates when `deadline is not None` (which was already `None` outside `--complete`).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Completion attempt on the walled-pocket fixture returns within the configured per-link deadline (was >10 min) | ✅ | `TestBoundedTermination` — asserts wall-clock elapsed < 90s (default 60s/link budget), vs. the #4434 >600s failure mode |
| Unroutable links reported with blocking copper listed, including tier-limit reasons from the Phase 3 via-in-pad gate | ✅ | `TestBlockingCopperReport` — human-readable + JSON report name the blocking `WALL` net; `tier_limit_note` surfaces manufacturer via-in-pad support informationally (Phase 3 #4475's precise per-link reason isn't merged yet, so this is a best-effort placeholder that Phase 3 will populate more precisely once it lands) |
| Deadline + report behavior covered by automated tests on a fixture link made deliberately unroutable | ✅ | New walled-pocket fixture: a pad topologically enclosed by a closed copper picture-frame of a foreign net — genuinely unroutable on a single layer, not merely "hard" |
| `kct route` without `--complete` is byte-identical (grid production default unchanged) | ✅ | All new behavior gated behind `args.complete` / `deadline is not None`; existing Phase 2/3 test suite (`tests/test_cli_route_complete_4471.py`, `tests/router/lattice/`) and `tests/test_cli_parser_drift.py` all still pass |

## Test Plan

- `uv run python -m pytest tests/router/lattice/test_deadline_report_4477.py tests/test_cli_route_complete_report_4477.py -q` — 12 passed
- `uv run python -m pytest tests/test_cli_route_complete_4471.py -q` — 15 passed (Phase 2/3 regression check)
- `uv run python -m pytest tests/router/lattice/ -q` — 139 passed, 2 skipped
- `uv run python -m pytest tests/test_cli_parser_drift.py -q` — 15 passed
- `uv run ruff format . --check` / `uv run ruff check <touched files>` — clean

Closes #4477