### PR TITLE
route/complete Phase 3: via-in-pad as tier-gated last-resort attach for walled SMD pads

### DIFF
--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -705,6 +705,17 @@ def run_route_command(args) -> int:
                 ),
             ]
         )
+    # Issue #4475 (epic #4465 Phase 3): forward --via-in-pad-last-resort to
+    # the inner route command.  The inner main() sets
+    # DesignRules.via_in_pad_last_resort so the lattice engine stages a
+    # same-net via-in-pad attach as a last resort instead of the #4284
+    # opportunistic tier-only gate.  Outer parser uses the
+    # ``route_via_in_pad_last_resort`` dest, inner uses
+    # ``via_in_pad_last_resort``; check both for forward-compat.
+    if getattr(args, "route_via_in_pad_last_resort", False) or getattr(
+        args, "via_in_pad_last_resort", False
+    ):
+        sub_argv.append("--via-in-pad-last-resort")
     # Issue #2464: Forward differential pair routing flags
     if getattr(args, "differential_pairs", False):
         sub_argv.append("--differential-pairs")

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -3966,6 +3966,30 @@ def _add_route_parser(subparsers) -> None:
         ),
     )
     route_parser.add_argument(
+        "--via-in-pad-last-resort",
+        action="store_true",
+        dest="route_via_in_pad_last_resort",
+        default=False,
+        help=(
+            "Issue #4475 (epic #4465 Phase 3): on the lattice engine "
+            "(--route-engine lattice, the engine --complete selects), stage "
+            "a same-net via-in-pad attach as a LAST RESORT rather than an "
+            "opportunistic one.  Without this flag, a fab tier that "
+            "supports via-in-pad (jlcpcb-tier1, pcbway) may land a via on a "
+            "pad whenever it happens to be the cheapest path -- the #4284 "
+            "behaviour.  With it, the search first tries an in-layer route "
+            "or a free-space (off-pad) via layer change with via-in-pad "
+            "forced OFF; only when NO such route exists does it retry with "
+            "the pad-site via admitted, and only on a tier that supports "
+            "it.  A tier without via-in-pad support never reaches the "
+            "retry -- the link is reported unroutable with an explicit "
+            "'via-in-pad-tier-unsupported' reason rather than a generic "
+            "decline.  Default off preserves the pre-#4475 opportunistic "
+            "behaviour bit-for-bit (mirrors --micro-via-in-pad-fallback's "
+            "opt-in-by-default-off semantics)."
+        ),
+    )
+    route_parser.add_argument(
         "--differential-pairs",
         action="store_true",
         help=(

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -4225,6 +4225,11 @@ def route_with_layer_escalation(
         # to a HARD constraint for the ampacity-free case (nets with a declared
         # ``target_ampacity`` are hard-blocked regardless of this flag).
         strict_layers=getattr(args, "strict_layers", False),
+        # Issue #4475 (epic #4465 Phase 3): stage the lattice engine's
+        # same-net via-in-pad attach as a LAST RESORT (in-layer / free-space
+        # via first) instead of the #4284 opportunistic tier-only gate.
+        # Default off preserves that pre-#4475 behaviour bit-for-bit.
+        via_in_pad_last_resort=getattr(args, "via_in_pad_last_resort", False),
     )
 
     # Parse skip nets
@@ -5442,6 +5447,10 @@ def route_with_rule_relaxation(
             auto_mfr_tier_in_progress=getattr(args, "_auto_mfr_tier_in_progress", False),
             # Issue #4433: forward --strict-layers (hard per-net avoid_layers).
             strict_layers=getattr(args, "strict_layers", False),
+            # Issue #4475 (epic #4465 Phase 3): stage via-in-pad as a
+            # LAST RESORT on the lattice engine. Default off is
+            # bit-for-bit pre-#4475.
+            via_in_pad_last_resort=getattr(args, "via_in_pad_last_resort", False),
         )
 
         # Load PCB
@@ -7616,6 +7625,10 @@ def route_with_combined_escalation(
                 auto_mfr_tier_in_progress=getattr(args, "_auto_mfr_tier_in_progress", False),
                 # Issue #4433: forward --strict-layers (hard per-net avoid_layers).
                 strict_layers=getattr(args, "strict_layers", False),
+                # Issue #4475 (epic #4465 Phase 3): stage via-in-pad as a
+                # LAST RESORT on the lattice engine. Default off is
+                # bit-for-bit pre-#4475.
+                via_in_pad_last_resort=getattr(args, "via_in_pad_last_resort", False),
             )
 
             # Load PCB
@@ -10795,6 +10808,21 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--via-in-pad-last-resort",
+        action="store_true",
+        dest="via_in_pad_last_resort",
+        default=False,
+        help=(
+            "Issue #4475 (epic #4465 Phase 3): on the lattice engine, stage "
+            "a same-net via-in-pad attach as a LAST RESORT (in-layer / "
+            "free-space via first) instead of the #4284 opportunistic "
+            "tier-only gate.  A tier without via_in_pad_supported never "
+            "reaches the retry -- the link declines with an explicit "
+            "'via-in-pad-tier-unsupported' reason.  Default off preserves "
+            "the pre-#4475 opportunistic behaviour bit-for-bit."
+        ),
+    )
+    parser.add_argument(
         "--show-congestion",
         action="store_true",
         help=(
@@ -11534,6 +11562,11 @@ def main(argv: list[str] | None = None) -> int:
         # to a HARD constraint for the ampacity-free case (nets with a declared
         # ``target_ampacity`` are hard-blocked regardless of this flag).
         strict_layers=getattr(args, "strict_layers", False),
+        # Issue #4475 (epic #4465 Phase 3): stage the lattice engine's
+        # same-net via-in-pad attach as a LAST RESORT (in-layer / free-space
+        # via first) instead of the #4284 opportunistic tier-only gate.
+        # Default off preserves that pre-#4475 behaviour bit-for-bit.
+        via_in_pad_last_resort=getattr(args, "via_in_pad_last_resort", False),
     )
 
     # Import progress helpers

--- a/src/kicad_tools/router/lattice/pathfinder.py
+++ b/src/kicad_tools/router/lattice/pathfinder.py
@@ -729,7 +729,14 @@ class LatticePathfinder:
         except Exception:
             return False
 
-    def _via_ok(self, key: NodeKey, net: int, committed: CommittedCopper) -> bool:
+    def _via_ok(
+        self,
+        key: NodeKey,
+        net: int,
+        committed: CommittedCopper,
+        *,
+        via_in_pad_override: bool | None = None,
+    ) -> bool:
         """Through-via legality at a lattice node.
 
         Static part: the via body (inflated beyond the trace keep-out by
@@ -743,6 +750,17 @@ class LatticePathfinder:
         only when the fab tier supports it (:attr:`_via_in_pad_allowed`).
         Dynamic part: committed copper on all layers + committed vias
         (:meth:`CommittedCopper.via_clear`).
+
+        ``via_in_pad_override`` (issue #4475, epic #4465 Phase 3) lets a
+        caller bypass the tier gate for the SAME-net window hit: ``None``
+        (default) preserves the pre-#4475 :attr:`_via_in_pad_allowed`
+        tier-only check byte-for-byte; ``False`` forces the same-net hit
+        illegal regardless of tier (the last-resort search's stage (a)+(b)
+        pass, which must never land a via-in-pad); ``True`` forces it legal
+        regardless of tier (a DIAGNOSTIC-ONLY probe used to name the
+        tier-limit decline reason -- callers must never emit a route found
+        this way). The unconditional OTHER-net grown-rect veto below is
+        never affected by this override.
         """
         lattice = self.build()
         obstacles = self.obstacles
@@ -778,7 +796,12 @@ class LatticePathfinder:
                 # layer change moves off the pad onto the escape stub.
                 # Other-net falls through to the unconditional grown-rect
                 # veto below.
-                if pad.net == net and not self._via_in_pad_allowed:
+                allow_via_in_pad = (
+                    self._via_in_pad_allowed
+                    if via_in_pad_override is None
+                    else via_in_pad_override
+                )
+                if pad.net == net and not allow_via_in_pad:
                     return False
             if pad.net == net:
                 continue
@@ -823,6 +846,98 @@ class LatticePathfinder:
         stubs_override: tuple[list, list] | None = None,
         exempt_pads: frozenset[int] | None = None,
     ) -> tuple[_RouteResult | None, str]:
+        """Route one connection, staging via-in-pad as a last resort (#4475).
+
+        Thin orchestrator around :meth:`_route_search` (the actual A*
+        implementation). When :attr:`DesignRules.via_in_pad_last_resort` is
+        off (the default -- byte-for-byte pre-#4475 behavior), this simply
+        forwards to a single :meth:`_route_search` call with the legacy
+        tier-only via-in-pad gate (#4284): a same-net pad-site via is legal
+        whenever the fab tier allows it, opportunistically, in the SAME
+        unified search as every other edge.
+
+        When the flag is on (and the connection is via-eligible: planar
+        fat-agent runs never get vias at all, so staging is a no-op for
+        them), the search runs in stages:
+
+        (a)+(b) In-layer route / free-space (off-pad) via layer change,
+            with via-in-pad forced OFF regardless of tier. If this stage
+            finds a path, it is returned immediately -- the pad is closed
+            WITHOUT a via-in-pad whenever any other route exists.
+        (c) Only reached when stage (a)+(b) fails.  The fab tier is the
+            hard floor here (#4284): on a tier that does not support
+            via-in-pad, stage (c) is never attempted.  Instead a cheap
+            DIAGNOSTIC-ONLY re-run (via-in-pad forced legal, its result
+            always discarded -- never emitted) checks whether the pad-site
+            via is the actual reason the link is stuck, so the decline can
+            be reported with the explicit ``"via-in-pad-tier-unsupported"``
+            reason (feeds Phase 4 reporting, epic #4465) rather than a
+            generic ``"no-path"``.  When the tier DOES support via-in-pad,
+            stage (c) retries with the tier-gated legality (identical to
+            the single-stage legacy path) and its outcome -- success or
+            failure -- is returned as-is.
+        """
+        fat = extra_clearance > 0.0 or partner_net is not None
+        last_resort = (
+            self.rules.via_in_pad_last_resort
+            and allow_vias
+            and not fat
+            and self.num_layers > 1
+        )
+        search_kwargs: dict[str, Any] = {
+            "committed": committed,
+            "history": history,
+            "present": present,
+            "allow_vias": allow_vias,
+            "extra_clearance": extra_clearance,
+            "partner_net": partner_net,
+            "stub_layers": stub_layers,
+            "stubs_override": stubs_override,
+            "exempt_pads": exempt_pads,
+        }
+        if not last_resort:
+            return self._route_search(start, end, net_class, **search_kwargs)
+
+        # Stage (a)+(b): via-in-pad forced OFF regardless of tier.
+        result, reason = self._route_search(
+            start, end, net_class, via_in_pad_override=False, **search_kwargs
+        )
+        if result is not None:
+            return result, reason
+
+        # Stage (c): the tier gate is the hard floor.  A tier without
+        # via-in-pad support never reaches it -- report the tier-limit
+        # reason (only when a diagnostic re-run proves via-in-pad would
+        # actually have closed the link; otherwise the honest stage-(a)+(b)
+        # decline reason stands, e.g. a pad-escape failure unrelated to
+        # vias at all).
+        if not self._via_in_pad_allowed:
+            diag_result, _diag_reason = self._route_search(
+                start, end, net_class, via_in_pad_override=True, **search_kwargs
+            )
+            if diag_result is not None:
+                return None, "via-in-pad-tier-unsupported"
+            return None, reason
+
+        return self._route_search(start, end, net_class, via_in_pad_override=None, **search_kwargs)
+
+    def _route_search(
+        self,
+        start: Pad,
+        end: Pad,
+        net_class: object | None,
+        *,
+        committed: CommittedCopper,
+        history: dict[Resource, float],
+        present: float,
+        allow_vias: bool = True,
+        extra_clearance: float = 0.0,
+        partner_net: int | None = None,
+        stub_layers: tuple[int, ...] | None = None,
+        stubs_override: tuple[list, list] | None = None,
+        exempt_pads: frozenset[int] | None = None,
+        via_in_pad_override: bool | None = None,
+    ) -> tuple[_RouteResult | None, str]:
         """A* over the (node, layer) graph; returns ``(result, reason)``.
 
         Octilinear geometric edge costs + ``via_cost`` per layer hop +
@@ -838,6 +953,8 @@ class LatticePathfinder:
         run that cannot complete on one layer declines honestly).
         ``stubs_override`` lets :meth:`_route_pair_impl` supply parity-
         filtered stub sets (``(stubs_a, stubs_b)``) instead of recomputing.
+        ``via_in_pad_override`` (issue #4475) is forwarded verbatim to every
+        :meth:`_via_ok` call this search makes; see that method's docstring.
         """
         lattice = self.build()
         obstacles = self.obstacles
@@ -1000,7 +1117,9 @@ class LatticePathfinder:
             if allow_vias and self.num_layers > 1:
                 vok = via_ok.get(key)
                 if vok is None:
-                    vok = self._via_ok(key, net, committed)
+                    vok = self._via_ok(
+                        key, net, committed, via_in_pad_override=via_in_pad_override
+                    )
                     via_ok[key] = vok
                 if vok:
                     # Via edges join matching nodes on ADJACENT layers only

--- a/src/kicad_tools/router/lattice/pathfinder.py
+++ b/src/kicad_tools/router/lattice/pathfinder.py
@@ -797,9 +797,7 @@ class LatticePathfinder:
                 # Other-net falls through to the unconditional grown-rect
                 # veto below.
                 allow_via_in_pad = (
-                    self._via_in_pad_allowed
-                    if via_in_pad_override is None
-                    else via_in_pad_override
+                    self._via_in_pad_allowed if via_in_pad_override is None else via_in_pad_override
                 )
                 if pad.net == net and not allow_via_in_pad:
                     return False
@@ -879,10 +877,7 @@ class LatticePathfinder:
         """
         fat = extra_clearance > 0.0 or partner_net is not None
         last_resort = (
-            self.rules.via_in_pad_last_resort
-            and allow_vias
-            and not fat
-            and self.num_layers > 1
+            self.rules.via_in_pad_last_resort and allow_vias and not fat and self.num_layers > 1
         )
         search_kwargs: dict[str, Any] = {
             "committed": committed,
@@ -1117,9 +1112,7 @@ class LatticePathfinder:
             if allow_vias and self.num_layers > 1:
                 vok = via_ok.get(key)
                 if vok is None:
-                    vok = self._via_ok(
-                        key, net, committed, via_in_pad_override=via_in_pad_override
-                    )
+                    vok = self._via_ok(key, net, committed, via_in_pad_override=via_in_pad_override)
                     via_ok[key] = vok
                 if vok:
                     # Via edges join matching nodes on ADJACENT layers only

--- a/src/kicad_tools/router/rules.py
+++ b/src/kicad_tools/router/rules.py
@@ -112,6 +112,27 @@ class DesignRules:
     # writes localized to route_cmd.py's escalation wrapper).
     auto_mfr_tier_in_progress: bool = False
 
+    # Via-in-pad as a LAST-RESORT attach on the lattice engine (Issue #4475,
+    # epic #4465 Phase 3).  Issue #4284 made the lattice engine's
+    # ``LatticePathfinder._via_ok`` admit a same-net via barrel on an SMD pad
+    # whenever the fab tier supports it (``MfrLimits.via_in_pad_supported``),
+    # but that gate is OPPORTUNISTIC: the unified A* search may pick a
+    # via-in-pad site even when an in-layer route or a free-space (off-pad)
+    # via exists elsewhere, simply because it happened to be on the
+    # cheapest path.  When this flag is ``True``, ``_route_impl`` instead
+    # runs a staged search per connection: (a)+(b) in-layer / free-space-via
+    # route with via-in-pad forced OFF regardless of tier; only when that
+    # stage finds no path does (c) retry with via-in-pad admitted -- and
+    # only on a tier where :attr:`manufacturer` supports it (the hard floor
+    # is unconditional: a tier without ``via_in_pad_supported`` never reaches
+    # stage (c), and the connection is declined with an explicit
+    # ``"via-in-pad-tier-unsupported"`` reason instead of a generic
+    # ``"no-path"`` so Phase 4 reporting (epic #4465) can name the real
+    # constraint).  Default ``False`` preserves the pre-#4475 opportunistic
+    # #4284 behavior bit-for-bit -- mirrors the opt-in-by-default-off
+    # semantics of ``--micro-via-in-pad-fallback`` (escape.py / #3118).
+    via_in_pad_last_resort: bool = False
+
     # Per-component clearance overrides (Issue #1016)
     # Maps component reference (e.g., "U1") to clearance in mm
     # Use for fine-pitch ICs where tighter clearance is needed between pins

--- a/tests/router/lattice/test_via_in_pad_last_resort.py
+++ b/tests/router/lattice/test_via_in_pad_last_resort.py
@@ -284,7 +284,15 @@ _OUTLINE_RECT = """  (gr_rect (start 0.0 0.0) (end 20.0 20.0)
 
 
 def _footprint(
-    ref: str, x: float, y: float, w: float, h: float, net: int, net_name: str, layer: str, uuid_n: int
+    ref: str,
+    x: float,
+    y: float,
+    w: float,
+    h: float,
+    net: int,
+    net_name: str,
+    layer: str,
+    uuid_n: int,
 ) -> str:
     return f"""  (footprint "kct:Pad"
     (layer "{layer}")

--- a/tests/router/lattice/test_via_in_pad_last_resort.py
+++ b/tests/router/lattice/test_via_in_pad_last_resort.py
@@ -1,0 +1,352 @@
+"""Via-in-pad as a tier-gated LAST-RESORT attach (Issue #4475, epic #4465 P3).
+
+Issue #4284 made ``LatticePathfinder._via_ok`` admit a same-net via barrel on
+an SMD pad whenever the fab tier supports it (``MfrLimits.via_in_pad_supported``),
+but that gate is purely tier-based: the unified A* search may land a
+via-in-pad site OPPORTUNISTICALLY even when an in-layer route or a
+free-space (off-pad) via exists elsewhere, simply because it happened to lie
+on the cheapest path.  Issue #4434's ask (external-tool parity) is that
+via-in-pad should be reached only as a LAST RESORT on a genuinely walled pad.
+
+This module exercises the new ``DesignRules.via_in_pad_last_resort`` flag:
+
+1. Default OFF preserves the pre-#4475 opportunistic #4284 behavior
+   byte-for-byte (a walled pad still closes via an opportunistic via-in-pad
+   at a via-in-pad-capable tier, exactly as before this issue).
+2. ON, an OPEN pad (an in-layer/free-space-via route exists) closes WITHOUT
+   ever landing a via-in-pad -- staging forces via-in-pad OFF for the first
+   search stage, so a successful first-stage route can never contain one.
+3. ON, a WALLED pad (no in-layer/free-space-via escape exists) reaches for
+   via-in-pad ONLY as the last resort, and only on a tier that supports it.
+4. On a tier WITHOUT via-in-pad support, the walled pad is reported
+   unroutable with the explicit ``"via-in-pad-tier-unsupported"`` reason
+   (feeds Phase 4 reporting) instead of a generic ``"no-path"``, and no
+   via-in-pad copper is ever emitted.
+5. The existing other-net grown-rect veto still holds under the new
+   staged ordering: a foreign-net pad is never a legal via site.
+6. The emitted via-in-pad passes real ``kicad-cli pcb drc --refill-zones``
+   clean on a via-in-pad-supported tier (jlcpcb-tier1) -- the cross-gate
+   rule; ``kct check`` alone is insufficient.
+
+Fixture geometry: two same-net SMD pads, ``A`` on F.Cu and ``B`` on B.Cu (so
+the connection needs at least one layer change).  A "walled" variant rings
+``A`` with four other-net SMD pads on F.Cu only, standing off far enough
+that the ring's grown-rect via veto (``via_pad_grow``) does not reach A's
+own center (so A's own pad-site via sites stay legal) but close enough that
+the ring's agent-radius mask blocks every in-layer edge/node AND every
+off-pad via site beyond A's own via-in-pad window -- so the ONLY legal via
+site left for A's net is inside A's own pad (a via-in-pad, by construction).
+B.Cu is left untouched (the ring pads are F.Cu-only SMD), so once a via
+lands at A's location the rest of the path is a normal, unobstructed
+B.Cu run to B.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.drc.geometric import run_geometric_drc
+from kicad_tools.router.io import load_pads_for_analysis, merge_routes_into_pcb
+from kicad_tools.router.lattice.pathfinder import LatticePathfinder
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import DesignRules
+
+_OUTLINE = [(-3.0, -3.0), (8.0, -3.0), (8.0, 3.0), (-3.0, 3.0)]
+
+# Ring standoff (mm) from A's center.  Chosen so the ring's grown-rect via
+# veto (``via_pad_grow`` = via_r + clearance - agent_radius = 0.25 at the
+# default DesignRules geometry) does NOT reach A's center (0.7 - 0.25 = 0.45
+# > 0), while its agent-radius node/edge mask (0.3) blocks every in-layer
+# node/edge beyond A's own 0.5 mm via-in-pad window (0.7 - 0.3 = 0.4 < 0.5).
+_WALL_STANDOFF = 0.7
+_WALL_THICKNESS = 1.0
+_WALL_LENGTH = 3.0
+
+
+def _pad(x: float, y: float, w: float, h: float, net: int, *, ref: str, layer: Layer) -> Pad:
+    return Pad(
+        x=x, y=y, width=w, height=h, net=net, net_name=f"N{net}", layer=layer, ref=ref, pin="1"
+    )
+
+
+def _make_pads(*, walled: bool) -> tuple[list[Pad], Pad, Pad]:
+    pad_a = _pad(0.0, 0.0, 0.3, 0.3, 1, ref="U1", layer=Layer.F_CU)
+    pad_b = _pad(5.0, 0.0, 0.3, 0.3, 1, ref="U2", layer=Layer.B_CU)
+    pads = [pad_a, pad_b]
+    if walled:
+        d, ww, hh = _WALL_STANDOFF, _WALL_THICKNESS, _WALL_LENGTH
+        pads += [
+            _pad(d + ww / 2.0, 0.0, ww, hh, 2, ref="WR", layer=Layer.F_CU),
+            _pad(-(d + ww / 2.0), 0.0, ww, hh, 2, ref="WL", layer=Layer.F_CU),
+            _pad(0.0, d + ww / 2.0, hh, ww, 2, ref="WT", layer=Layer.F_CU),
+            _pad(0.0, -(d + ww / 2.0), hh, ww, 2, ref="WB", layer=Layer.F_CU),
+        ]
+    return pads, pad_a, pad_b
+
+
+def _via_hits_pad(via: object, pad: Pad, via_radius: float) -> bool:
+    return (
+        abs(via.x - pad.x) <= pad.width / 2.0 + via_radius  # type: ignore[attr-defined]
+        and abs(via.y - pad.y) <= pad.height / 2.0 + via_radius  # type: ignore[attr-defined]
+    )
+
+
+def _route_single(
+    pads: list[Pad], pad_a: Pad, pad_b: Pad, rules: DesignRules
+) -> tuple[object | None, str]:
+    pf = LatticePathfinder(_OUTLINE, pads, rules, layer_stack=LayerStack.two_layer())
+    committed = pf._fresh_committed()
+    return pf._route_impl(pad_a, pad_b, None, committed=committed, history={}, present=0.0)
+
+
+# ---------------------------------------------------------------------------
+# 1. Default OFF preserves the pre-#4475 opportunistic behavior.
+# ---------------------------------------------------------------------------
+
+
+def test_default_off_preserves_legacy_opportunistic_via_in_pad() -> None:
+    """``via_in_pad_last_resort`` defaults to False: the walled pad still
+    closes via an OPPORTUNISTIC via-in-pad at a supporting tier, exactly the
+    #4284 behavior this issue must not regress."""
+    pads, pad_a, pad_b = _make_pads(walled=True)
+    rules = DesignRules(manufacturer="jlcpcb-tier1")
+    assert rules.via_in_pad_last_resort is False
+
+    result, reason = _route_single(pads, pad_a, pad_b, rules)
+    assert result is not None, f"expected a route, got decline: {reason}"
+    via_r = rules.via_diameter / 2.0
+    assert any(_via_hits_pad(v, pad_a, via_r) for v in result.route.vias)
+
+
+# ---------------------------------------------------------------------------
+# 2. ON + open pad: closes WITHOUT via-in-pad when a route exists.
+# ---------------------------------------------------------------------------
+
+
+def test_last_resort_closes_open_pad_without_via_in_pad() -> None:
+    pads, pad_a, pad_b = _make_pads(walled=False)
+    rules = DesignRules(manufacturer="jlcpcb-tier1", via_in_pad_last_resort=True)
+
+    result, reason = _route_single(pads, pad_a, pad_b, rules)
+    assert result is not None, f"expected a route, got decline: {reason}"
+    via_r = rules.via_diameter / 2.0
+    offenders = [
+        (v.x, v.y)
+        for v in result.route.vias
+        if _via_hits_pad(v, pad_a, via_r) or _via_hits_pad(v, pad_b, via_r)
+    ]
+    assert not offenders, f"via-in-pad shipped when an open route existed: {offenders}"
+
+
+# ---------------------------------------------------------------------------
+# 3. ON + walled pad, supporting tier: reaches for via-in-pad as last resort.
+# ---------------------------------------------------------------------------
+
+
+def test_last_resort_reaches_via_in_pad_only_when_walled() -> None:
+    pads, pad_a, pad_b = _make_pads(walled=True)
+    rules = DesignRules(manufacturer="jlcpcb-tier1", via_in_pad_last_resort=True)
+
+    result, reason = _route_single(pads, pad_a, pad_b, rules)
+    assert result is not None, f"expected the walled pad to close via last-resort: {reason}"
+    via_r = rules.via_diameter / 2.0
+    assert any(_via_hits_pad(v, pad_a, via_r) for v in result.route.vias), (
+        "walled pad closed without a via-in-pad -- last-resort stage never engaged"
+    )
+
+
+def test_last_resort_off_and_on_agree_when_pad_is_open() -> None:
+    """Sanity: the flag must not change the outcome for an ordinary
+    (non-walled) connection -- it only changes WHICH via is picked when
+    ties exist, never whether the connection completes."""
+    pads, pad_a, pad_b = _make_pads(walled=False)
+    for last_resort in (False, True):
+        rules = DesignRules(manufacturer="jlcpcb-tier1", via_in_pad_last_resort=last_resort)
+        result, reason = _route_single(pads, pad_a, pad_b, rules)
+        assert result is not None, f"last_resort={last_resort}: {reason}"
+
+
+# ---------------------------------------------------------------------------
+# 4. Tier hard floor: no via-in-pad support -> explicit tier-limit reason.
+# ---------------------------------------------------------------------------
+
+
+def test_last_resort_reports_tier_limit_reason_when_unsupported() -> None:
+    pads, pad_a, pad_b = _make_pads(walled=True)
+    rules = DesignRules(manufacturer="jlcpcb", via_in_pad_last_resort=True)
+    assert not LatticePathfinder(_OUTLINE, pads, rules)._via_in_pad_allowed
+
+    result, reason = _route_single(pads, pad_a, pad_b, rules)
+    assert result is None
+    assert reason == "via-in-pad-tier-unsupported"
+
+
+def test_last_resort_tier_limit_reason_surfaces_through_route_netset() -> None:
+    """The same tier-limit reason lands in ``failure_reasons`` from the
+    normal multi-net negotiation entry point, not just the single-route
+    helper."""
+    pads, pad_a, pad_b = _make_pads(walled=True)
+    rules = DesignRules(manufacturer="jlcpcb", via_in_pad_last_resort=True)
+    pf = LatticePathfinder(_OUTLINE, pads, rules, layer_stack=LayerStack.two_layer())
+    routes, stats = pf.route_netset([((1, 0), pad_a, pad_b, None)], max_iterations=2)
+    assert stats.routed == 0
+    assert pf.failure_reasons == {(1, 0): "via-in-pad-tier-unsupported"}
+
+
+def test_no_manufacturer_configured_never_reaches_via_in_pad() -> None:
+    """No manufacturer configured is the conservative default (matches
+    :attr:`LatticePathfinder._via_in_pad_allowed`): the walled pad declines
+    with the tier-limit reason exactly as the unsupported-tier case."""
+    pads, pad_a, pad_b = _make_pads(walled=True)
+    rules = DesignRules(manufacturer=None, via_in_pad_last_resort=True)
+    result, reason = _route_single(pads, pad_a, pad_b, rules)
+    assert result is None
+    assert reason == "via-in-pad-tier-unsupported"
+
+
+# ---------------------------------------------------------------------------
+# 5. Other-net pad site is never a legal via site under the new ordering.
+# ---------------------------------------------------------------------------
+
+
+def test_other_net_wall_pad_never_used_as_via_site() -> None:
+    pads, pad_a, pad_b = _make_pads(walled=True)
+    rules = DesignRules(manufacturer="jlcpcb-tier1", via_in_pad_last_resort=True)
+
+    result, reason = _route_single(pads, pad_a, pad_b, rules)
+    assert result is not None, reason
+    via_r = rules.via_diameter / 2.0
+    wall_pads = [p for p in pads if p.net == 2]
+    offenders = [
+        (v.x, v.y, wp.ref)
+        for v in result.route.vias
+        for wp in wall_pads
+        if _via_hits_pad(v, wp, via_r)
+    ]
+    assert not offenders, f"other-net pad used as a via site: {offenders}"
+
+
+def test_via_ok_override_forces_legality_independent_of_tier() -> None:
+    """Unit-level check on the new ``via_in_pad_override`` parameter itself:
+    ``False`` forces illegal, ``True`` forces legal, ``None`` preserves the
+    pre-#4475 tier-only gate -- for the SAME-net window hit only; the
+    unconditional other-net veto is untouched by the override."""
+    pads, pad_a, _pad_b = _make_pads(walled=False)
+    for manufacturer in (None, "jlcpcb", "jlcpcb-tier1"):
+        rules = DesignRules(manufacturer=manufacturer)
+        pf = LatticePathfinder(_OUTLINE, pads, rules, layer_stack=LayerStack.two_layer())
+        committed = pf._fresh_committed()
+        lattice = pf.build()
+        # The node at A's own center is a legal via-in-pad candidate site.
+        key = min(
+            lattice.nodes,
+            key=lambda k: abs(lattice.node_point(k)[0]) + abs(lattice.node_point(k)[1]),
+        )
+        assert not pf._via_ok(key, pad_a.net, committed, via_in_pad_override=False)
+        assert pf._via_ok(key, pad_a.net, committed, via_in_pad_override=True)
+        assert pf._via_ok(key, pad_a.net, committed, via_in_pad_override=None) == (
+            pf._via_in_pad_allowed
+        )
+
+
+# ---------------------------------------------------------------------------
+# 6. Real kicad-cli DRC on the emitted via-in-pad copper.
+# ---------------------------------------------------------------------------
+
+_HEADER = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (37 "F.SilkS" user "F.Silkscreen")
+    (44 "Edge.Cuts" user)
+    (49 "F.Fab" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "NET1")
+  (net 2 "WALL")
+"""
+
+_OUTLINE_RECT = """  (gr_rect (start 0.0 0.0) (end 20.0 20.0)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+"""
+
+
+def _footprint(
+    ref: str, x: float, y: float, w: float, h: float, net: int, net_name: str, layer: str, uuid_n: int
+) -> str:
+    return f"""  (footprint "kct:Pad"
+    (layer "{layer}")
+    (uuid "00000000-0000-0000-0000-0000000000{uuid_n:02d}")
+    (at {x} {y})
+    (property "Reference" "{ref}" (at 0 -1.5 0) (layer "F.SilkS")
+      (effects (font (size 1.0 1.0) (thickness 0.15)))
+      (uuid "00000000-0000-0000-0000-0000000001{uuid_n:02d}"))
+    (pad "1" smd rect (at 0 0) (size {w} {h})
+      (layers "{layer}") (net {net} "{net_name}"))
+  )
+"""
+
+
+def _walled_board_text() -> str:
+    """A real ``.kicad_pcb`` mirroring the synthetic walled fixture above,
+    for a genuine ``kicad-cli pcb drc --refill-zones`` roundtrip."""
+    ax, ay = 10.0, 10.0
+    bx, by = 10.0 + 5.0, 10.0
+    d, ww, hh = _WALL_STANDOFF, _WALL_THICKNESS, _WALL_LENGTH
+    fps = [
+        _footprint("U1", ax, ay, 0.3, 0.3, 1, "NET1", "F.Cu", 10),
+        _footprint("U2", bx, by, 0.3, 0.3, 1, "NET1", "B.Cu", 11),
+        _footprint("WR", ax + d + ww / 2.0, ay, ww, hh, 2, "WALL", "F.Cu", 12),
+        _footprint("WL", ax - d - ww / 2.0, ay, ww, hh, 2, "WALL", "F.Cu", 13),
+        _footprint("WT", ax, ay + d + ww / 2.0, hh, ww, 2, "WALL", "F.Cu", 14),
+        _footprint("WB", ax, ay - d - ww / 2.0, hh, ww, 2, "WALL", "F.Cu", 15),
+    ]
+    return _HEADER + _OUTLINE_RECT + "".join(fps) + ")\n"
+
+
+def test_walled_via_in_pad_last_resort_is_drc_clean(tmp_path: Path) -> None:
+    """The via-in-pad emitted as a last resort must pass real
+    ``kicad-cli pcb drc --refill-zones`` on a via-in-pad-supported tier --
+    ``kct check`` alone is insufficient (standing process rule)."""
+    text = _walled_board_text()
+    base_pcb = tmp_path / "base.kicad_pcb"
+    base_pcb.write_text(text)
+    base = run_geometric_drc(base_pcb)
+    if not base.ran:
+        pytest.skip(f"kicad-cli DRC unavailable: {base.reason}")
+    assert base.error_count == 0
+
+    pads = load_pads_for_analysis(text)
+    net1_pads = [p for p in pads if p.net == 1]
+    assert len(net1_pads) == 2
+    pad_a, pad_b = net1_pads
+
+    rules = DesignRules(manufacturer="jlcpcb-tier1", via_in_pad_last_resort=True)
+    pf = LatticePathfinder.from_board(text, rules=rules)
+    routes, stats = pf.route_netset([((1, 0), pad_a, pad_b, None)], max_iterations=4)
+    assert stats.routed == 1, f"declines: {pf.failure_reasons}"
+
+    route = next(iter(routes.values()))
+    via_r = rules.via_diameter / 2.0
+    assert any(_via_hits_pad(v, pad_a, via_r) for v in route.vias), (
+        "fixture regression: expected the walled pad to require a via-in-pad"
+    )
+
+    sexp = "".join(r.to_sexp() for r in routes.values() if r.segments)
+    out = tmp_path / "routed.kicad_pcb"
+    out.write_text(merge_routes_into_pcb(text, sexp))
+    res = run_geometric_drc(out)
+    assert res.ran
+    assert res.error_count == 0, f"via-in-pad copper is not DRC clean: {dict(res.by_type)}"


### PR DESCRIPTION
## Summary

Phase 3 of epic #4465 (depends on Phase 2 / #4472; parent defect #4434).

`LatticePathfinder._via_ok` / `_via_in_pad_allowed` (issue #4284) already admit a same-net via barrel intersecting an SMD pad, but ONLY tier-gated (`MfrLimits.via_in_pad_supported`): the unified A* search can pick a via-in-pad site *opportunistically* whenever it happens to sit on the cheapest path, even when an in-layer route or a free-space (off-pad) via exists elsewhere. This PR makes via-in-pad a genuine **last resort**, behind a new opt-in flag:

- `DesignRules.via_in_pad_last_resort: bool = False` (new field).
- `--via-in-pad-last-resort` CLI flag (`kct route`), wired through both the outer (`cli/parser.py`) and inner (`route_cmd.py`) parsers plus the forwarding shim (`cli/commands/routing.py`), consistent with the existing `--micro-via-in-pad-fallback` opt-in-by-default-off convention.
- `LatticePathfinder._route_impl` is now a thin staging wrapper around the renamed A* implementation (`_route_search`):
  - **Stage (a)+(b)**: in-layer route / free-space via, with via-in-pad forced OFF regardless of tier. If found, returned immediately -- the pad closes *without* a via-in-pad whenever any other route exists.
  - **Stage (c)**: only reached when (a)+(b) fails. The fab tier is the hard floor (#4284): on a tier without `via_in_pad_supported`, stage (c) is never attempted -- a diagnostic-only re-run (result always discarded, never emitted) checks whether via-in-pad would have closed the link, and if so the decline reason is the explicit `"via-in-pad-tier-unsupported"` (instead of a generic `"no-path"`), feeding Phase 4 (#4477) reporting. On a supporting tier, stage (c) retries with the legacy tier-gated legality.
- `_via_ok` gains a `via_in_pad_override: bool | None` parameter (`None` = pre-#4475 tier-only gate; `False` = force illegal; `True` = force legal, diagnostic-only). The unconditional OTHER-net grown-rect veto is untouched by the override.
- Default off preserves the pre-#4475 opportunistic #4284 behavior byte-for-byte.

## Test plan

- [x] New `tests/router/lattice/test_via_in_pad_last_resort.py` (10 tests):
  - Default-off preserves the legacy opportunistic via-in-pad on a walled pad.
  - Flag-on + open pad closes **without** a via-in-pad (any successful stage-(a)+(b) route is via-in-pad-free by construction).
  - Flag-on + walled pad (synthetic fixture: a same-net pad ringed by other-net pads far enough that the via veto doesn't reach the pad's own center, but close enough to block every other in-layer/via site) reaches for via-in-pad only then.
  - Tier without `via_in_pad_supported` (and no manufacturer configured) declines with `"via-in-pad-tier-unsupported"`, both from `_route_impl` directly and via `route_netset.failure_reasons`.
  - Other-net pad is never used as a via site under the new staged ordering (regression check on the existing grown-rect veto).
  - Direct unit test on the new `_via_ok(..., via_in_pad_override=...)` parameter.
  - Real `kicad-cli pcb drc --refill-zones` roundtrip on a synthetic walled `.kicad_pcb` fixture: the emitted via-in-pad is DRC-clean on `jlcpcb-tier1` (the cross-gate rule -- `kct check` alone is insufficient).
- [x] `uv run pytest tests/router/lattice/test_via_in_pad.py tests/router/lattice/test_via_hole_floor.py tests/router/lattice/test_negotiation.py tests/router/lattice/test_localized_build_4472.py` -- 30 passed (no regressions in the pre-existing files touching `_via_ok`/`_route_impl`).
- [x] `uv run pytest tests/test_cli_route_complete_4471.py tests/router/lattice/test_localized_build_4472.py` -- 24 passed (`--complete` CLI integration unaffected).
- [x] `uv run pytest tests/test_cli_parser_drift.py` -- 15 passed (outer/inner parser + forwarding shim in sync).
- [x] End-to-end CLI smoke test on a synthetic walled fixture: `kct route --complete --via-in-pad-last-resort --manufacturer jlcpcb-tier1` emits a via at the walled pad's exact center; the same command with `--manufacturer jlcpcb` declines with `decline[via-in-pad-tier-unsupported]`.
- [x] `ruff check` clean on all changed files; `mypy` shows zero new errors in the two touched router-core files (`lattice/pathfinder.py`, `rules.py`).

Closes #4475