### PR TITLE
feat(router): classifier-driven placement-delta feedback loop (apply + keep-if-reach-improves)

### DIFF
--- a/src/kicad_tools/recovery/applicator.py
+++ b/src/kicad_tools/recovery/applicator.py
@@ -82,6 +82,8 @@ class StrategyApplicator:
             return self._apply_move_component(pcb, strategy)
         elif strategy.type == StrategyType.MOVE_MULTIPLE:
             return self._apply_move_multiple(pcb, strategy)
+        elif strategy.type == StrategyType.ROTATE_COMPONENT:
+            return self._apply_rotate_component(pcb, strategy)
         else:
             return ApplicationResult(
                 success=False,
@@ -177,6 +179,67 @@ class StrategyApplicator:
             message=f"Moved {len(moved)} components: " + "; ".join(messages),
         )
 
+    def _apply_rotate_component(self, pcb: PCB, strategy: ResolutionStrategy) -> ApplicationResult:
+        """Apply a single-component in-place rotation strategy (issue #4467).
+
+        Rotates the footprint about its own origin (``fp.position`` is
+        unchanged) by ``rotation_delta`` degrees.  This is the geometric
+        realization of the classifier's ``DE_REVERSE_BUNDLE`` verdict --
+        flipping a reversed facing pad column (``rotation_delta == 180``) so a
+        self-crossing bundle stops crossing.
+
+        Only the footprint-level orientation is written here.  The board-frame
+        pad positions the classifier reads are derived from ``fp.position`` +
+        ``fp.rotation`` applied to each pad's local offset (see
+        ``stuck_classifier._iter_board_pads``), so bumping ``fp.rotation`` is
+        sufficient for the PCB view.  The Phase-2 driver separately re-syncs the
+        router's flat pad coordinates before re-routing.
+        """
+        if not strategy.actions:
+            return ApplicationResult(
+                success=False,
+                components_moved=[],
+                message="No actions in strategy",
+            )
+
+        action = strategy.actions[0]
+        if action.type != "rotate":
+            return ApplicationResult(
+                success=False,
+                components_moved=[],
+                message=f"Expected rotate action, got {action.type}",
+            )
+
+        ref = action.target
+        rotation_delta = action.params.get("rotation_delta")
+        if rotation_delta is None:
+            return ApplicationResult(
+                success=False,
+                components_moved=[],
+                message="Missing rotation_delta in rotate action params",
+            )
+
+        fp = self._find_footprint(pcb, ref)
+        if fp is None:
+            return ApplicationResult(
+                success=False,
+                components_moved=[],
+                message=f"Component {ref} not found",
+            )
+
+        old_rotation = float(getattr(fp, "rotation", 0.0))
+        new_rotation = (old_rotation + float(rotation_delta)) % 360.0
+        fp.rotation = new_rotation
+
+        return ApplicationResult(
+            success=True,
+            components_moved=[ref],
+            message=(
+                f"Rotated {ref} by {float(rotation_delta):.1f} deg "
+                f"({old_rotation:.1f} -> {new_rotation:.1f})"
+            ),
+        )
+
     def is_safe_to_apply(self, strategy: ResolutionStrategy, pcb: PCB) -> bool:
         """Check if applying a strategy is safe.
 
@@ -193,6 +256,17 @@ class StrategyApplicator:
         Returns:
             True if the strategy is safe to apply.
         """
+        # ROTATE_COMPONENT keeps the footprint centre fixed (rotation about the
+        # origin), so board-bounds / move-distance checks do not apply -- only
+        # the target's existence matters (issue #4467).
+        if strategy.type == StrategyType.ROTATE_COMPONENT:
+            for action in strategy.actions:
+                if action.type != "rotate":
+                    continue
+                if self._find_footprint(pcb, action.target) is None:
+                    return False
+            return True
+
         if strategy.type not in [StrategyType.MOVE_COMPONENT, StrategyType.MOVE_MULTIPLE]:
             return False
 

--- a/src/kicad_tools/recovery/types.py
+++ b/src/kicad_tools/recovery/types.py
@@ -38,6 +38,7 @@ class StrategyType(Enum):
 
     MOVE_COMPONENT = "move_component"  # Move a single component
     MOVE_MULTIPLE = "move_multiple"  # Move multiple components
+    ROTATE_COMPONENT = "rotate_component"  # Rotate a single component in place
     ADD_VIA = "add_via"  # Add via to change layers
     CHANGE_LAYER = "change_layer"  # Route on different layer
     REROUTE_NET = "reroute_net"  # Reroute a single net

--- a/src/kicad_tools/router/__init__.py
+++ b/src/kicad_tools/router/__init__.py
@@ -226,12 +226,20 @@ from .parallel import (
     resolve_parallel_conflicts,
 )
 from .pathfinder import AStarNode, Router
+from .placement_delta import (
+    PlacementDelta,
+    delta_from_diagnosis,
+    deltas_from_result,
+)
 from .placement_feedback import (
     PlacementAdjustment,
+    PlacementDeltaFeedbackLoop,
+    PlacementDeltaFeedbackResult,
     PlacementDiffEntry,
     PlacementFeedbackLoop,
     PlacementFeedbackResult,
     detect_pf_stagnation,
+    write_placement_delta_json,
 )
 from .preflight import (
     OffGridReport,
@@ -496,6 +504,13 @@ __all__ = [
     "PlacementAdjustment",
     "PlacementDiffEntry",
     "detect_pf_stagnation",
+    # Classifier-driven placement-delta feedback (#4467)
+    "PlacementDeltaFeedbackLoop",
+    "PlacementDeltaFeedbackResult",
+    "PlacementDelta",
+    "delta_from_diagnosis",
+    "deltas_from_result",
+    "write_placement_delta_json",
     # Escape Routing (dense packages)
     "EscapeRouter",
     "EscapeRoute",

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -88,7 +88,13 @@ from .parallel import (
     find_independent_groups,
 )
 from .path import create_intra_ic_routes, reduce_pads_after_intra_ic
-from .placement_feedback import PlacementFeedbackLoop, PlacementFeedbackResult
+from .placement_feedback import (
+    PlacementDeltaFeedbackLoop,
+    PlacementDeltaFeedbackResult,
+    PlacementFeedbackLoop,
+    PlacementFeedbackResult,
+    write_placement_delta_json,
+)
 from .primitives import Obstacle, Pad, Route, Via
 from .rules import (
     DEFAULT_NET_CLASS_MAP,
@@ -15757,6 +15763,99 @@ class Autorouter:
             timeout=timeout,
             per_net_timeout=per_net_timeout,
         )
+
+    def route_with_placement_delta_feedback(
+        self,
+        pcb: any = None,
+        max_adjustments: int = 3,
+        use_negotiated: bool = True,
+        verbose: bool = True,
+        fixed_refs: set[str] | list[str] | None = None,
+        max_movement: float | None = 5.0,
+        timeout: float | None = None,
+        per_net_timeout: float | None = None,
+        enable_placement_delta_feedback: bool = True,
+        delta_output_path: str | None = None,
+        delta_proposer: Any = None,
+        min_confidence: float = 0.5,
+        stagnation_patience: int = 3,
+        outer_timeout: float | None = None,
+    ) -> PlacementDeltaFeedbackResult | PlacementFeedbackResult:
+        """Close the router<->placement loop with classifier-driven deltas (#4467).
+
+        Phase 2 of the board-07 feedback epic (#3438).  Runs the
+        :class:`~kicad_tools.router.placement_feedback.PlacementDeltaFeedbackLoop`:
+        each iteration classifies the current placement, translates every
+        PLACEMENT_BOUND / CONGESTION_SATURATED diagnosis into a
+        :class:`~kicad_tools.router.placement_delta.PlacementDelta` (Phase 1,
+        #4466), applies the top applyable delta (including ``rotate_180`` to
+        de-reverse a facing part), re-routes, and keeps the change only on a
+        strict routed-net increase -- otherwise reverts placement + routes
+        atomically.
+
+        Args:
+            pcb: The PCB whose placement the loop may mutate.  Required for
+                placement deltas; when ``None`` the loop only routes.
+            max_adjustments: Maximum delta apply/keep-or-revert iterations.
+            use_negotiated: Use negotiated-congestion routing for each pass.
+            verbose: Print per-iteration progress.
+            fixed_refs: Component refs that must never move (anchors); a delta
+                targeting one is skipped with a logged reason.
+            max_movement: Hard cap on per-component translate distance (mm); a
+                delta exceeding it is skipped.  Rotations keep the centre fixed
+                and are never budget-limited.
+            timeout / per_net_timeout: Forwarded to the negotiated router.
+            enable_placement_delta_feedback: Default-on toggle (A/B + bisection
+                guard).  When ``False`` this delegates to
+                :meth:`route_with_placement_feedback` for byte-identical prior
+                behavior and writes no delta artifact.
+            delta_output_path: When set, write ``<path>`` as the
+                ``_placement_delta.json`` artifact (applied + proposed deltas,
+                round-trippable via :meth:`PlacementDelta.from_dict`).
+            delta_proposer: Optional ``Callable[[PCB], list[PlacementDelta]]``
+                override for the classifier pipeline (used by tests).
+            min_confidence / stagnation_patience / outer_timeout: Forwarded to
+                the legacy loop only when the toggle is off.
+
+        Returns:
+            A :class:`PlacementDeltaFeedbackResult` when the delta loop runs, or
+            a :class:`PlacementFeedbackResult` when the toggle is off.
+        """
+        if not enable_placement_delta_feedback:
+            # Bisection guard: exact prior behavior, no delta artifact written.
+            return self.route_with_placement_feedback(
+                pcb=pcb,
+                max_adjustments=max_adjustments,
+                use_negotiated=use_negotiated,
+                min_confidence=min_confidence,
+                verbose=verbose,
+                fixed_refs=fixed_refs,
+                max_movement=max_movement,
+                timeout=timeout,
+                per_net_timeout=per_net_timeout,
+                stagnation_patience=stagnation_patience,
+                outer_timeout=outer_timeout,
+            )
+
+        loop = PlacementDeltaFeedbackLoop(
+            router=self,
+            pcb=pcb,
+            verbose=verbose,
+            fixed_refs=fixed_refs,
+            max_movement=max_movement,
+            delta_proposer=delta_proposer,
+        )
+        result = loop.run_delta(
+            max_adjustments=max_adjustments,
+            use_negotiated=use_negotiated,
+            timeout=timeout,
+            per_net_timeout=per_net_timeout,
+        )
+        if delta_output_path is not None:
+            write_placement_delta_json(
+                delta_output_path, result.applied_deltas, result.proposed_deltas
+            )
+        return result
 
     # =========================================================================
     # Escape Routing API (Dense Packages)

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -15766,7 +15766,7 @@ class Autorouter:
 
     def route_with_placement_delta_feedback(
         self,
-        pcb: any = None,
+        pcb: Any = None,
         max_adjustments: int = 3,
         use_negotiated: bool = True,
         verbose: bool = True,

--- a/src/kicad_tools/router/placement_delta.py
+++ b/src/kicad_tools/router/placement_delta.py
@@ -108,6 +108,29 @@ class PlacementDelta:
             "confidence": self.confidence,
         }
 
+    @classmethod
+    def from_dict(cls, data: dict) -> PlacementDelta:
+        """Reconstruct a :class:`PlacementDelta` from :meth:`to_dict` output.
+
+        The round-trip counterpart required by Phase 2 (#4467): the
+        ``<output>_placement_delta.json`` artifact stores each delta via
+        :meth:`to_dict`, and a propose-only recipe reloads them via this
+        classmethod to apply them deterministically without re-running the
+        classifier.  Missing optional keys fall back to the dataclass
+        defaults so a hand-written or older artifact still loads.
+        """
+        return cls(
+            net_name=data["net_name"],
+            target_ref=data["target_ref"],
+            kind=data["kind"],
+            dx=float(data.get("dx", 0.0)),
+            dy=float(data.get("dy", 0.0)),
+            rotation_delta=float(data.get("rotation_delta", 0.0)),
+            source_action=data.get("source_action", ""),
+            rationale=data.get("rationale", ""),
+            confidence=data.get("confidence", ""),
+        )
+
 
 def delta_from_diagnosis(pcb: PCB, diag: StuckNetDiagnosis) -> PlacementDelta | None:
     """Translate one classifier diagnosis into a concrete placement delta.

--- a/src/kicad_tools/router/placement_feedback.py
+++ b/src/kicad_tools/router/placement_feedback.py
@@ -9,18 +9,23 @@ routing failures.
 from __future__ import annotations
 
 import copy
+import json
 import math
 import time
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
     from kicad_tools.router.core import Autorouter
+    from kicad_tools.router.placement_delta import PlacementDelta
     from kicad_tools.router.primitives import Route
     from kicad_tools.schema.pcb import PCB
 
 from kicad_tools.recovery import (
+    Action,
     ApplicationResult,
+    Difficulty,
     ResolutionStrategy,
     StrategyApplicator,
     StrategyGenerator,
@@ -1031,3 +1036,462 @@ class PlacementFeedbackLoop:
             "difficulty": strategy.difficulty.value,
             "risks": risks,
         }
+
+
+@dataclass
+class PlacementDeltaFeedbackResult:
+    """Result of the classifier-driven placement-delta feedback loop (#4467).
+
+    Distinct from :class:`PlacementFeedbackResult` (the blocker-geometry loop):
+    this records the concrete :class:`~kicad_tools.router.placement_delta.PlacementDelta`
+    objects the classifier proposed and which of them the driver *kept* (a delta
+    is kept only when applying it + re-routing strictly increased the routed-net
+    count; otherwise it is reverted atomically and never appears in
+    ``applied_deltas``).
+
+    Attributes:
+        success: Whether all nets are routed in the returned state.
+        routes: Final list of routes (the best state observed).
+        iterations: Number of routing passes performed.
+        applied_deltas: Deltas that were applied AND kept (strict improvement).
+        proposed_deltas: Every delta the classifier proposed across iterations,
+            whether or not it was applied (superset of ``applied_deltas``).
+        skipped_deltas / skip_reasons: Parallel lists recording deltas the
+            selector declined (anchored ref, over ``max_movement``, unsafe, or a
+            non-applyable ``reorder_pins`` kind) and the one-line reason, so the
+            "skipped with a logged reason" contract is observable in tests.
+        failed_nets: Net IDs still unrouted in the returned state.
+        placement_diff: Per-component before/after positions for kept moves.
+        exit_reason: ``pd_converged`` | ``pd_reverted`` | ``pd_no_delta`` |
+            ``pd_no_pcb`` | ``pd_apply_failed`` | ``pd_max_iter``.
+    """
+
+    success: bool
+    routes: list[Route]
+    iterations: int
+    applied_deltas: list[PlacementDelta] = field(default_factory=list)
+    proposed_deltas: list[PlacementDelta] = field(default_factory=list)
+    skipped_deltas: list[PlacementDelta] = field(default_factory=list)
+    skip_reasons: list[str] = field(default_factory=list)
+    failed_nets: list[int] = field(default_factory=list)
+    placement_diff: list[PlacementDiffEntry] = field(default_factory=list)
+    exit_reason: str = "pd_max_iter"
+
+    def summary(self) -> str:
+        lines = [
+            "Placement-Delta Feedback Result:",
+            f"  Success: {self.success}",
+            f"  Iterations: {self.iterations}",
+            f"  Exit reason: {self.exit_reason}",
+            f"  Routes: {len(self.routes)}",
+            f"  Deltas proposed: {len(self.proposed_deltas)}",
+            f"  Deltas kept:     {len(self.applied_deltas)}",
+            f"  Deltas skipped:  {len(self.skipped_deltas)}",
+            f"  Failed nets: {len(self.failed_nets)}",
+        ]
+        for delta in self.applied_deltas:
+            lines.append(f"    kept: {delta.target_ref} {delta.kind} ({delta.net_name})")
+        for delta, reason in zip(self.skipped_deltas, self.skip_reasons, strict=False):
+            lines.append(f"    skipped: {delta.target_ref} {delta.kind} -- {reason}")
+        return "\n".join(lines)
+
+
+def write_placement_delta_json(
+    path: str | Path,
+    applied: list[PlacementDelta],
+    proposed: list[PlacementDelta],
+) -> dict[str, Any]:
+    """Write the ``<output>_placement_delta.json`` artifact (issue #4467).
+
+    Serializes the applied (kept) and proposed deltas via
+    :meth:`PlacementDelta.to_dict` so a propose-only recipe can reload them with
+    :meth:`PlacementDelta.from_dict` and apply them deterministically without
+    re-running the loop.  Returns the serialized dict for convenience/testing.
+    """
+    data = {
+        "applied": [d.to_dict() for d in applied],
+        "proposed": [d.to_dict() for d in proposed],
+    }
+    Path(path).write_text(json.dumps(data, indent=2))
+    return data
+
+
+class PlacementDeltaFeedbackLoop(PlacementFeedbackLoop):
+    """Classifier-driven placement-delta feedback loop (issue #4467).
+
+    Phase 2 of the board-07 router<->placement epic (#3438).  Where the base
+    :class:`PlacementFeedbackLoop` is driven by ``analyze_routing_failure`` ->
+    ``recovery.StrategyGenerator`` (blocker geometry, translation-only), this
+    subclass is driven by the stuck-net *classifier*
+    (:func:`~kicad_tools.router.stuck_classifier.classify_stuck_nets_from_pcb`)
+    and Phase-1's translator
+    (:func:`~kicad_tools.router.placement_delta.deltas_from_result`).  That lets
+    it execute the ``rotate_180`` (de-reverse a reversed facing QFN) move the
+    classifier recommends -- a move the blocker-geometry loop cannot express.
+
+    Relationship to the file-based, subprocess-driven
+    :mod:`kicad_tools.router.placement_nudge` (#3865): both classify stuck nets
+    and gate a placement change on re-routed reach, but ``placement_nudge``
+    operates on a routed ``.kicad_pcb`` file via a chorus-runner subprocess and
+    is translation-only.  This loop runs *in process* on the live
+    :class:`~kicad_tools.router.core.Autorouter`, consumes typed
+    :class:`~kicad_tools.router.placement_delta.PlacementDelta` objects
+    (including ``rotate_180``), and reuses the base loop's monotone best-snapshot
+    machinery for atomic keep/revert.
+
+    Each outer iteration:
+
+    1. classify the current PCB placement, translate every PLACEMENT_BOUND /
+       CONGESTION_SATURATED diagnosis into a :class:`PlacementDelta`;
+    2. select the top applyable delta (skip ``reorder_pins`` -- no pad-remap
+       applicator exists yet -- and any delta whose target is anchored, exceeds
+       ``max_movement``, or is unsafe, each with a logged reason);
+    3. apply it to BOTH the PCB footprint (via
+       :class:`~kicad_tools.recovery.StrategyApplicator`) and the router's flat
+       pad coordinates, then clear routes and re-route;
+    4. keep the change only on a **strict** routed-net increase; otherwise revert
+       placement + router pads + routes atomically.
+    """
+
+    def __init__(
+        self,
+        router: Autorouter,
+        pcb: PCB | None = None,
+        verbose: bool = True,
+        fixed_refs: set[str] | list[str] | None = None,
+        max_movement: float | None = 5.0,
+        delta_proposer: Callable[[PCB], list[PlacementDelta]] | None = None,
+    ):
+        super().__init__(
+            router=router,
+            pcb=pcb,
+            verbose=verbose,
+            fixed_refs=fixed_refs,
+            max_movement=max_movement,
+        )
+        # Injectable so tests can drive the keep/revert logic with a known delta
+        # without constructing a full classifier fixture.  Defaults to the real
+        # classifier -> translator pipeline.
+        self._delta_proposer = delta_proposer
+
+    # --- delta proposal / selection ----------------------------------------
+
+    def _propose_deltas(self) -> list[PlacementDelta]:
+        """Classify the current PCB and translate diagnoses into deltas."""
+        if self.pcb is None:
+            return []
+        if self._delta_proposer is not None:
+            return list(self._delta_proposer(self.pcb))
+        from kicad_tools.router.placement_delta import deltas_from_result
+        from kicad_tools.router.stuck_classifier import classify_stuck_nets_from_pcb
+
+        result = classify_stuck_nets_from_pcb(self.pcb)
+        return deltas_from_result(self.pcb, result)
+
+    def _strategy_from_delta(self, delta: PlacementDelta) -> ResolutionStrategy | None:
+        """Build a recovery ``ResolutionStrategy`` for an applyable delta.
+
+        Returns ``None`` for kinds with no Phase-2 applicator (``reorder_pins``)
+        or when the target footprint is missing.
+        """
+        fp = self._find_footprint(delta.target_ref)
+        if fp is None:
+            return None
+        if delta.kind == "translate":
+            old_x, old_y = fp.position[0], fp.position[1]
+            return ResolutionStrategy(
+                type=StrategyType.MOVE_COMPONENT,
+                difficulty=Difficulty.MEDIUM,
+                confidence=1.0,
+                actions=[
+                    Action(
+                        type="move",
+                        target=delta.target_ref,
+                        params={"x": old_x + delta.dx, "y": old_y + delta.dy},
+                    )
+                ],
+                affected_components=[delta.target_ref],
+                affected_nets=[delta.net_name],
+            )
+        if delta.kind == "rotate_180":
+            return ResolutionStrategy(
+                type=StrategyType.ROTATE_COMPONENT,
+                difficulty=Difficulty.MEDIUM,
+                confidence=1.0,
+                actions=[
+                    Action(
+                        type="rotate",
+                        target=delta.target_ref,
+                        params={"rotation_delta": delta.rotation_delta},
+                    )
+                ],
+                affected_components=[delta.target_ref],
+                affected_nets=[delta.net_name],
+            )
+        # reorder_pins (rationale-only in Phase 1) and any unknown kind.
+        return None
+
+    def _select_delta(
+        self,
+        deltas: list[PlacementDelta],
+        skipped: list[PlacementDelta],
+        skip_reasons: list[str],
+    ) -> tuple[PlacementDelta, ResolutionStrategy] | None:
+        """Return the first applyable ``(delta, strategy)``, logging skips.
+
+        Honors the ladder's omissions by construction: ``deltas`` only ever
+        contains moves the classifier's translator emitted, so a suppressed
+        action (e.g. ``WIDEN_CHANNEL`` for a reversed bus) is never present to
+        select.  Records every declined delta + reason on the parallel
+        ``skipped`` / ``skip_reasons`` lists so the skip is observable.
+        """
+
+        def _skip(delta: PlacementDelta, reason: str) -> None:
+            skipped.append(delta)
+            skip_reasons.append(reason)
+            if self.verbose:
+                print(f"  Skipping delta {delta.target_ref} ({delta.kind}): {reason}")
+
+        for delta in deltas:
+            if delta.kind == "reorder_pins":
+                _skip(delta, "reorder_pins has no Phase-2 applicator (pad-remap not implemented)")
+                continue
+            if delta.target_ref in self.fixed_refs:
+                _skip(delta, f"target {delta.target_ref} is anchored (fixed_refs)")
+                continue
+            strategy = self._strategy_from_delta(delta)
+            if strategy is None:
+                _skip(delta, f"no applyable strategy for kind={delta.kind!r}")
+                continue
+            if self._strategy_touches_fixed_refs(strategy):
+                _skip(delta, "strategy touches an anchored ref")
+                continue
+            if not self._strategy_within_movement_budget(strategy):
+                cap = f"{self.max_movement:.2f}mm" if self.max_movement is not None else "n/a"
+                _skip(delta, f"move exceeds max_movement cap ({cap})")
+                continue
+            if self.pcb is not None and not self._strategy_applicator.is_safe_to_apply(
+                strategy, self.pcb
+            ):
+                _skip(delta, "unsafe to apply (board bounds)")
+                continue
+            return delta, strategy
+        return None
+
+    # --- router-pad synchronization ----------------------------------------
+
+    def _router_pads(self) -> list[Any]:
+        """Flat list of the router's Pad objects (``all_pads`` if present)."""
+        pads = getattr(self.router, "all_pads", None)
+        if pads:
+            return list(pads)
+        return list(getattr(self.router, "pads", {}).values())
+
+    def _snapshot_router_pads(self) -> list[tuple[Any, float, float]]:
+        """Capture each router Pad object's ``(x, y)`` for atomic restore."""
+        return [(pad, pad.x, pad.y) for pad in self._router_pads()]
+
+    def _restore_router_pads(self, snapshot: list[tuple[Any, float, float]]) -> None:
+        """Restore router Pad coordinates captured by :meth:`_snapshot_router_pads`.
+
+        Only pad coordinates are restored -- the routing grid is rebuilt from
+        these coordinates by ``_clear_routes`` at the top of the next routing
+        pass, so no explicit grid reset is needed here (and the final best-state
+        restore does not re-route).
+        """
+        for pad, x, y in snapshot:
+            pad.x = x
+            pad.y = y
+
+    def _apply_delta_to_router_pads(self, delta: PlacementDelta) -> None:
+        """Mutate the router's flat pad coordinates to match an applied delta.
+
+        The router routes against its own ``Pad`` objects (board-frame ``x``/
+        ``y``), NOT the PCB footprints, so a PCB-only mutation would leave the
+        re-route geometrically unchanged.  This mirrors the pad transform
+        ``optim.router_factory`` applies for candidate placements:
+
+        * ``translate`` -> shift every pad of the target ref by ``(dx, dy)``;
+        * ``rotate_180`` -> point-reflect every pad of the target ref through the
+          footprint origin (a 180-degree rotation about the origin is exactly a
+          reflection through it), matching what the PCB-frame classifier sees
+          after ``fp.rotation += 180``.
+        """
+        pads = self._router_pads()
+        if delta.kind == "translate":
+            for pad in pads:
+                if getattr(pad, "ref", "") == delta.target_ref:
+                    pad.x += delta.dx
+                    pad.y += delta.dy
+        elif delta.kind == "rotate_180":
+            fp = self._find_footprint(delta.target_ref)
+            if fp is None:
+                return
+            cx, cy = fp.position[0], fp.position[1]
+            for pad in pads:
+                if getattr(pad, "ref", "") == delta.target_ref:
+                    pad.x = 2.0 * cx - pad.x
+                    pad.y = 2.0 * cy - pad.y
+
+    # --- driver ------------------------------------------------------------
+
+    def run_delta(
+        self,
+        max_adjustments: int = 3,
+        use_negotiated: bool = True,
+        timeout: float | None = None,
+        per_net_timeout: float | None = None,
+    ) -> PlacementDeltaFeedbackResult:
+        """Run the classifier-driven placement-delta feedback loop.
+
+        Args:
+            max_adjustments: Maximum number of delta apply/keep-or-revert
+                iterations to attempt after the initial routing pass.
+            use_negotiated: Use negotiated-congestion routing (vs plain
+                ``route_all``) for every routing pass.
+            timeout / per_net_timeout: Forwarded to the negotiated router so each
+                re-route respects the caller's wall-clock budget.
+
+        Returns:
+            A :class:`PlacementDeltaFeedbackResult`.  The returned routes/placement
+            are always the best (highest routed-net) state observed -- a
+            non-improving delta is reverted atomically (placement, router pads,
+            and routes all restored).
+        """
+        negotiated_kwargs: dict[str, Any] = {}
+        if timeout is not None:
+            negotiated_kwargs["timeout"] = timeout
+        if per_net_timeout is not None:
+            negotiated_kwargs["per_net_timeout"] = per_net_timeout
+
+        def _route() -> list[Route]:
+            self._clear_routes()
+            if use_negotiated:
+                return self.router.route_all_negotiated(**negotiated_kwargs)
+            return self.router.route_all()
+
+        def _routed_count() -> int:
+            total = len(self.router.nets) - 1  # -1 for net 0
+            return total - len(self.router.get_failed_nets())
+
+        applied: list[PlacementDelta] = []
+        proposed: list[PlacementDelta] = []
+        skipped: list[PlacementDelta] = []
+        skip_reasons: list[str] = []
+
+        if self.verbose:
+            print("\n=== Placement-Delta Feedback Loop (classifier-driven) ===")
+            print(f"  Max adjustments: {max_adjustments}")
+            if self.fixed_refs:
+                print(f"  Anchored refs:   {', '.join(sorted(self.fixed_refs))}")
+            if self.max_movement is not None:
+                print(f"  Max movement:    {self.max_movement:.2f}mm")
+
+        # Initial routing pass establishes the baseline / best state.
+        _route()
+        total_nets = len(self.router.nets) - 1
+        best_count = _routed_count()
+        best_routes = copy.deepcopy(list(self.router.routes))
+        best_placement = self._snapshot_placement()
+        best_pads = self._snapshot_router_pads()
+
+        if self.verbose:
+            print(f"  Baseline: routed {best_count}/{total_nets} nets")
+
+        exit_reason = "pd_max_iter"
+        iteration = 0
+        for iteration in range(max_adjustments):
+            if not self.router.get_failed_nets():
+                exit_reason = "pd_converged"
+                break
+            if self.pcb is None:
+                exit_reason = "pd_no_pcb"
+                break
+
+            deltas = self._propose_deltas()
+            proposed.extend(deltas)
+            selection = self._select_delta(deltas, skipped, skip_reasons)
+            if selection is None:
+                exit_reason = "pd_no_delta"
+                if self.verbose:
+                    print("  No applyable placement delta; stopping.")
+                break
+            delta, strategy = selection
+
+            # Snapshot the pre-apply state so a non-improving delta reverts
+            # atomically (placement + router pads + routes together).
+            pre_placement = self._snapshot_placement()
+            pre_pads = self._snapshot_router_pads()
+            pre_routes = copy.deepcopy(list(self.router.routes))
+            pre_count = _routed_count()
+
+            # Record the pre-move position (once) for the placement diff.
+            self._snapshot_positions([delta.target_ref])
+
+            if self.verbose:
+                print(
+                    f"\n--- Iteration {iteration} --- applying {delta.kind} "
+                    f"to {delta.target_ref} (net {delta.net_name})"
+                )
+
+            result = self._strategy_applicator.apply_strategy(self.pcb, strategy)
+            if not result.success:
+                exit_reason = "pd_apply_failed"
+                if self.verbose:
+                    print(f"  Delta application failed: {result.message}")
+                break
+            # Keep the router's flat pad geometry in lockstep with the PCB.
+            self._apply_delta_to_router_pads(delta)
+
+            _route()
+            new_count = _routed_count()
+
+            if new_count > pre_count:
+                applied.append(delta)
+                if self.verbose:
+                    print(f"  Kept: routed {pre_count} -> {new_count} (strict improvement)")
+                if new_count > best_count:
+                    best_count = new_count
+                    best_routes = copy.deepcopy(list(self.router.routes))
+                    best_placement = self._snapshot_placement()
+                    best_pads = self._snapshot_router_pads()
+            else:
+                # Revert atomically: placement, router pads, and routes.
+                self._restore_placement(pre_placement)
+                self._restore_router_pads(pre_pads)
+                self.router.routes = pre_routes
+                exit_reason = "pd_reverted"
+                if self.verbose:
+                    print(
+                        f"  Reverted: routed {pre_count} -> {new_count} "
+                        f"(no strict improvement); placement + routes restored"
+                    )
+                break
+
+        # Restore the best observed state (routes + placement + router pads
+        # together) so the returned result is monotone in routed-net count.
+        current_count = _routed_count()
+        if best_count > current_count:
+            self.router.routes = copy.deepcopy(best_routes)
+            self._restore_placement(best_placement)
+            self._restore_router_pads(best_pads)
+
+        failed_nets = self.router.get_failed_nets()
+        if self.verbose:
+            print("\n=== Placement-Delta Feedback Complete ===")
+            print(f"  Deltas kept: {len(applied)}  proposed: {len(proposed)}")
+            print(f"  Final failed nets: {len(failed_nets)}")
+            print(f"  Exit reason: {exit_reason}")
+
+        return PlacementDeltaFeedbackResult(
+            success=len(failed_nets) == 0,
+            routes=list(self.router.routes),
+            iterations=iteration + 1,
+            applied_deltas=applied,
+            proposed_deltas=proposed,
+            skipped_deltas=skipped,
+            skip_reasons=skip_reasons,
+            failed_nets=failed_nets,
+            placement_diff=self._build_placement_diff(),
+            exit_reason=exit_reason,
+        )

--- a/tests/router/test_placement_delta_feedback.py
+++ b/tests/router/test_placement_delta_feedback.py
@@ -1,0 +1,428 @@
+"""Tests for the classifier-driven placement-delta feedback loop (issue #4467).
+
+Phase 2 of the board-07 router<->placement epic (#3438): apply a Phase-1
+:class:`~kicad_tools.router.placement_delta.PlacementDelta`, re-route, and keep
+the change only on a strict routed-net improvement (else revert atomically).
+
+The driver's keep/revert/skip logic is exercised with a lightweight
+:class:`FakeRouter` whose routing outcome is a deterministic function of the
+current pad geometry, plus an injected ``delta_proposer`` -- this isolates the
+loop's transaction semantics from real routing physics.  A separate test drives
+the *real* classifier -> translator pipeline on the reversed-bundle fixture to
+confirm the driver's default proposer emits the expected ``rotate_180`` delta.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.recovery import (
+    Action,
+    Difficulty,
+    ResolutionStrategy,
+    StrategyApplicator,
+    StrategyType,
+)
+from kicad_tools.router import (
+    PlacementDelta,
+    PlacementDeltaFeedbackLoop,
+    PlacementDeltaFeedbackResult,
+    write_placement_delta_json,
+)
+
+# Reuse the Phase-1 reversed-bundle fixture verbatim so the classifier emits a
+# genuine DE_REVERSE_BUNDLE -> rotate_180 delta on UB.
+from tests.router.test_placement_delta import _facing_rows_bundle_board, _load
+
+# --------------------------------------------------------------------------- #
+# Lightweight test doubles                                                     #
+# --------------------------------------------------------------------------- #
+
+
+class MockFootprint:
+    def __init__(self, reference: str, x: float, y: float, rotation: float = 0.0):
+        self.reference = reference
+        self.position = (x, y)
+        self.rotation = rotation
+        self.pads: list = []
+
+
+class MockPCB:
+    def __init__(self, footprints):
+        self.footprints = list(footprints)
+        self.graphic_items = []
+        self.segments = []
+        self.vias = []
+        self.zones = []
+        self.nets = {}
+
+
+class FakePad:
+    def __init__(self, x: float, y: float, ref: str, pin: str = "1"):
+        self.x = x
+        self.y = y
+        self.ref = ref
+        self.pin = pin
+
+
+class FakeRouter:
+    """Minimal Autorouter stand-in for the delta-feedback loop.
+
+    ``failed_predicate(router) -> list[int]`` computes the currently-failing net
+    ids from the live pad geometry, so a pad move applied by the loop changes the
+    routed count exactly the way a real re-route would.  ``nets`` has ``n + 1``
+    entries (net 0 is the no-net sentinel) so ``total_nets == n``.
+    """
+
+    def __init__(self, pads, total_nets, failed_predicate):
+        self.all_pads = list(pads)
+        self.pads = {(p.ref, p.pin): p for p in pads}
+        self.nets = {i: [] for i in range(total_nets + 1)}
+        self.routes: list = []
+        self._failed_predicate = failed_predicate
+        self.route_calls = 0
+
+    def _reset_for_new_trial(self):
+        self.routes = []
+
+    def route_all_negotiated(self, **kwargs):
+        self.route_calls += 1
+        # A dummy route object per routed net keeps deep-copy/restore honest.
+        self.routes = [object() for _ in range(len(self.nets) - 1 - len(self.get_failed_nets()))]
+        return self.routes
+
+    def route_all(self):
+        return self.route_all_negotiated()
+
+    def get_failed_nets(self):
+        return list(self._failed_predicate(self))
+
+
+def _ub_pad(router: FakeRouter) -> FakePad:
+    return router.pads[("UB", "2")]
+
+
+def _rotate_fixes_net2(router: FakeRouter) -> list[int]:
+    """Net 2 fails while UB's pad "2" sits at its original x (12.0)."""
+    return [2] if abs(_ub_pad(router).x - 12.0) < 1e-6 else []
+
+
+def _rotate_never_helps(_router: FakeRouter) -> list[int]:
+    return [2]
+
+
+def _make_loop(footprint_refs, pads, total_nets, failed_predicate, proposer, **kw):
+    fps = [MockFootprint(ref, x, y) for ref, x, y in footprint_refs]
+    pcb = MockPCB(fps)
+    router = FakeRouter(pads, total_nets, failed_predicate)
+    loop = PlacementDeltaFeedbackLoop(
+        router=router,
+        pcb=pcb,
+        verbose=False,
+        delta_proposer=proposer,
+        **kw,
+    )
+    return loop, router, pcb
+
+
+def _rotate_delta(ref: str = "UB", net: str = "DQ2") -> PlacementDelta:
+    return PlacementDelta(
+        net_name=net,
+        target_ref=ref,
+        kind="rotate_180",
+        rotation_delta=180.0,
+        source_action="de_reverse_bundle",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Applicator: rotate_180 support (#4467)                                       #
+# --------------------------------------------------------------------------- #
+
+
+class TestApplicatorRotate:
+    def test_rotate_component_flips_footprint_rotation(self):
+        applicator = StrategyApplicator()
+        pcb = MockPCB([MockFootprint("U5", 10.0, 20.0, rotation=0.0)])
+        strategy = ResolutionStrategy(
+            type=StrategyType.ROTATE_COMPONENT,
+            difficulty=Difficulty.MEDIUM,
+            confidence=1.0,
+            actions=[Action(type="rotate", target="U5", params={"rotation_delta": 180.0})],
+        )
+        result = applicator.apply_strategy(pcb, strategy)
+        assert result.success is True
+        assert result.components_moved == ["U5"]
+        assert pcb.footprints[0].rotation == 180.0
+        # Rotation keeps the centre fixed.
+        assert pcb.footprints[0].position == (10.0, 20.0)
+
+    def test_rotate_wraps_modulo_360(self):
+        applicator = StrategyApplicator()
+        pcb = MockPCB([MockFootprint("U5", 0.0, 0.0, rotation=270.0)])
+        strategy = ResolutionStrategy(
+            type=StrategyType.ROTATE_COMPONENT,
+            difficulty=Difficulty.MEDIUM,
+            confidence=1.0,
+            actions=[Action(type="rotate", target="U5", params={"rotation_delta": 180.0})],
+        )
+        applicator.apply_strategy(pcb, strategy)
+        assert pcb.footprints[0].rotation == 90.0  # (270 + 180) % 360
+
+    def test_rotate_missing_component_fails(self):
+        applicator = StrategyApplicator()
+        pcb = MockPCB([])
+        strategy = ResolutionStrategy(
+            type=StrategyType.ROTATE_COMPONENT,
+            difficulty=Difficulty.MEDIUM,
+            confidence=1.0,
+            actions=[Action(type="rotate", target="U5", params={"rotation_delta": 180.0})],
+        )
+        result = applicator.apply_strategy(pcb, strategy)
+        assert result.success is False
+
+    def test_rotate_is_safe_to_apply(self):
+        applicator = StrategyApplicator()
+        pcb = MockPCB([MockFootprint("U5", 10.0, 20.0)])
+        strategy = ResolutionStrategy(
+            type=StrategyType.ROTATE_COMPONENT,
+            difficulty=Difficulty.MEDIUM,
+            confidence=1.0,
+            actions=[Action(type="rotate", target="U5", params={"rotation_delta": 180.0})],
+        )
+        assert applicator.is_safe_to_apply(strategy, pcb) is True
+        # A rotation targeting a missing ref is not safe.
+        assert applicator.is_safe_to_apply(strategy, MockPCB([])) is False
+
+
+# --------------------------------------------------------------------------- #
+# PlacementDelta.from_dict round-trip (#4467)                                  #
+# --------------------------------------------------------------------------- #
+
+
+class TestPlacementDeltaRoundTrip:
+    def test_rotate_delta_round_trips(self):
+        d = _rotate_delta()
+        assert PlacementDelta.from_dict(d.to_dict()) == d
+
+    def test_translate_delta_round_trips(self):
+        d = PlacementDelta(
+            net_name="SDA",
+            target_ref="U3",
+            kind="translate",
+            dx=1.25,
+            dy=-0.5,
+            source_action="move_part",
+            rationale="crowded",
+            confidence="medium",
+        )
+        assert PlacementDelta.from_dict(d.to_dict()) == d
+
+    def test_from_dict_tolerates_missing_optional_keys(self):
+        d = PlacementDelta.from_dict({"net_name": "N", "target_ref": "U1", "kind": "rotate_180"})
+        assert d.rotation_delta == 0.0
+        assert d.confidence == ""
+
+
+# --------------------------------------------------------------------------- #
+# Driver: keep / revert semantics                                             #
+# --------------------------------------------------------------------------- #
+
+
+class TestDeltaFeedbackKeepRevert:
+    def test_applied_rotate_that_improves_reach_is_kept(self):
+        # UB pad "2" starts at x=12; rotating UB 180 about its centre (10,10)
+        # point-reflects it to x=8, which the predicate reads as "net 2 routed".
+        loop, router, pcb = _make_loop(
+            footprint_refs=[("UB", 10.0, 10.0)],
+            pads=[FakePad(12.0, 10.0, "UB", "2")],
+            total_nets=2,
+            failed_predicate=_rotate_fixes_net2,
+            proposer=lambda _pcb: [_rotate_delta()],
+        )
+        result = loop.run_delta(max_adjustments=3)
+        assert isinstance(result, PlacementDeltaFeedbackResult)
+        assert result.success is True
+        assert [d.target_ref for d in result.applied_deltas] == ["UB"]
+        # Placement change kept: footprint rotated and pad reflected.
+        assert pcb.footprints[0].rotation == 180.0
+        assert _ub_pad(router).x == pytest.approx(8.0)
+        # Diff records the kept rotation.
+        assert any(e.ref == "UB" and abs(e.rotation_delta) == 180.0 for e in result.placement_diff)
+
+    def test_non_improving_delta_is_reverted_atomically(self):
+        loop, router, pcb = _make_loop(
+            footprint_refs=[("UB", 10.0, 10.0)],
+            pads=[FakePad(12.0, 10.0, "UB", "2")],
+            total_nets=2,
+            failed_predicate=_rotate_never_helps,
+            proposer=lambda _pcb: [_rotate_delta()],
+        )
+        result = loop.run_delta(max_adjustments=3)
+        assert result.applied_deltas == []
+        assert result.exit_reason == "pd_reverted"
+        # Placement fully restored: rotation back to 0, pad back to x=12.
+        assert pcb.footprints[0].rotation == 0.0
+        assert _ub_pad(router).x == pytest.approx(12.0)
+        # Routed count unchanged (net 2 still failing).
+        assert result.failed_nets == [2]
+        # No spurious diff entry for a reverted move.
+        assert result.placement_diff == []
+
+
+# --------------------------------------------------------------------------- #
+# Driver: anchor / budget / kind skips (with logged reason)                    #
+# --------------------------------------------------------------------------- #
+
+
+class TestDeltaFeedbackSkips:
+    def test_anchored_target_is_skipped_with_reason(self):
+        loop, router, pcb = _make_loop(
+            footprint_refs=[("UB", 10.0, 10.0)],
+            pads=[FakePad(12.0, 10.0, "UB", "2")],
+            total_nets=2,
+            failed_predicate=_rotate_fixes_net2,
+            proposer=lambda _pcb: [_rotate_delta()],
+            fixed_refs={"UB"},
+        )
+        result = loop.run_delta(max_adjustments=3)
+        assert result.applied_deltas == []
+        assert result.exit_reason == "pd_no_delta"
+        assert result.skipped_deltas and result.skipped_deltas[0].target_ref == "UB"
+        assert any("anchored" in r for r in result.skip_reasons)
+        # Anchored footprint never rotated.
+        assert pcb.footprints[0].rotation == 0.0
+
+    def test_translate_over_max_movement_is_skipped(self):
+        far = PlacementDelta(net_name="DQ2", target_ref="UB", kind="translate", dx=10.0, dy=0.0)
+        loop, router, pcb = _make_loop(
+            footprint_refs=[("UB", 10.0, 10.0)],
+            pads=[FakePad(12.0, 10.0, "UB", "2")],
+            total_nets=2,
+            failed_predicate=_rotate_fixes_net2,
+            proposer=lambda _pcb: [far],
+            max_movement=5.0,
+        )
+        result = loop.run_delta(max_adjustments=3)
+        assert result.applied_deltas == []
+        assert result.exit_reason == "pd_no_delta"
+        assert any("max_movement" in r for r in result.skip_reasons)
+        # Pad untouched.
+        assert _ub_pad(router).x == pytest.approx(12.0)
+
+    def test_reorder_pins_delta_is_skipped(self):
+        reorder = PlacementDelta(net_name="DQ2", target_ref="UB", kind="reorder_pins")
+        loop, router, pcb = _make_loop(
+            footprint_refs=[("UB", 10.0, 10.0)],
+            pads=[FakePad(12.0, 10.0, "UB", "2")],
+            total_nets=2,
+            failed_predicate=_rotate_fixes_net2,
+            proposer=lambda _pcb: [reorder],
+        )
+        result = loop.run_delta(max_adjustments=3)
+        assert result.applied_deltas == []
+        assert any("reorder_pins" in r for r in result.skip_reasons)
+
+    def test_ladder_omission_no_delta_applies_nothing(self):
+        # Classifier suppressed every move (empty proposal) -> driver is a no-op.
+        loop, router, pcb = _make_loop(
+            footprint_refs=[("UB", 10.0, 10.0)],
+            pads=[FakePad(12.0, 10.0, "UB", "2")],
+            total_nets=2,
+            failed_predicate=_rotate_fixes_net2,
+            proposer=lambda _pcb: [],
+        )
+        result = loop.run_delta(max_adjustments=3)
+        assert result.applied_deltas == []
+        assert result.exit_reason == "pd_no_delta"
+        assert pcb.footprints[0].rotation == 0.0
+        assert _ub_pad(router).x == pytest.approx(12.0)
+
+
+# --------------------------------------------------------------------------- #
+# Real classifier -> translator emits the rotate_180 delta the driver consumes #
+# --------------------------------------------------------------------------- #
+
+
+class TestClassifierEmitsDelta:
+    def test_reversed_bundle_default_proposer_emits_rotate_180(self, tmp_path: Path):
+        pcb = _load(tmp_path, _facing_rows_bundle_board(reversed_rows=True))
+        # A loop with the DEFAULT proposer (classifier -> translator); no router
+        # call needed -- we only exercise proposal.
+        loop = PlacementDeltaFeedbackLoop(
+            router=FakeRouter([], 0, lambda _r: []), pcb=pcb, verbose=False
+        )
+        deltas = loop._propose_deltas()
+        rotate = [d for d in deltas if d.kind == "rotate_180"]
+        assert rotate, f"expected a rotate_180 delta, got {[d.kind for d in deltas]}"
+        assert rotate[0].target_ref == "UB"
+        assert rotate[0].rotation_delta == 180.0
+
+
+# --------------------------------------------------------------------------- #
+# JSON artifact round-trip (#4467)                                             #
+# --------------------------------------------------------------------------- #
+
+
+class TestPlacementDeltaJson:
+    def test_written_artifact_round_trips(self, tmp_path: Path):
+        loop, router, pcb = _make_loop(
+            footprint_refs=[("UB", 10.0, 10.0)],
+            pads=[FakePad(12.0, 10.0, "UB", "2")],
+            total_nets=2,
+            failed_predicate=_rotate_fixes_net2,
+            proposer=lambda _pcb: [_rotate_delta()],
+        )
+        result = loop.run_delta(max_adjustments=3)
+        out = tmp_path / "board_routed_placement_delta.json"
+        write_placement_delta_json(out, result.applied_deltas, result.proposed_deltas)
+
+        data = json.loads(out.read_text())
+        assert [PlacementDelta.from_dict(d) for d in data["applied"]] == result.applied_deltas
+        assert [PlacementDelta.from_dict(d) for d in data["proposed"]] == result.proposed_deltas
+        # The kept rotate_180 is present in the applied artifact.
+        assert data["applied"][0]["kind"] == "rotate_180"
+        assert data["applied"][0]["target_ref"] == "UB"
+
+
+# --------------------------------------------------------------------------- #
+# Autorouter entry point: default-on toggle + bisection guard                  #
+# --------------------------------------------------------------------------- #
+
+
+class TestAutorouterEntryPoint:
+    def test_toggle_on_runs_delta_loop_and_writes_json(self, tmp_path: Path):
+        from kicad_tools.router.core import Autorouter
+
+        router = Autorouter(50, 50)  # no components -> trivially converged
+        out = tmp_path / "delta.json"
+        result = router.route_with_placement_delta_feedback(
+            pcb=None,
+            max_adjustments=1,
+            verbose=False,
+            delta_output_path=str(out),
+        )
+        assert isinstance(result, PlacementDeltaFeedbackResult)
+        assert out.exists()
+        payload = json.loads(out.read_text())
+        assert payload == {"applied": [], "proposed": []}
+
+    def test_toggle_off_delegates_to_legacy_loop(self, tmp_path: Path):
+        from kicad_tools.router.core import Autorouter
+        from kicad_tools.router.placement_feedback import PlacementFeedbackResult
+
+        router = Autorouter(50, 50)
+        out = tmp_path / "delta.json"
+        result = router.route_with_placement_delta_feedback(
+            pcb=None,
+            max_adjustments=1,
+            verbose=False,
+            enable_placement_delta_feedback=False,
+            delta_output_path=str(out),
+        )
+        # Bisection guard: legacy result type, no delta artifact written.
+        assert isinstance(result, PlacementFeedbackResult)
+        assert not out.exists()


### PR DESCRIPTION
## Summary

Phase 2 of the board-07 router↔placement feedback epic (#3438). Phase 1
(#4466) shipped the classifier→delta translator (`placement_delta.py`); this
PR closes the loop: **apply** a `PlacementDelta`, **re-route**, and **keep the
change only if reach strictly improves** — otherwise revert placement, router
pads, and routes atomically.

The new `PlacementDeltaFeedbackLoop` is the generic, classifier-driven
counterpart to the blocker-geometry `PlacementFeedbackLoop`: it consumes the
Phase-1 translator's typed deltas (including `rotate_180`, which the legacy
translation-only loop cannot express) and reuses that loop's monotone
best-snapshot restore machinery (#2840/#3504) for the keep/revert transaction.

## Changes

- **`recovery/types.py`**: add `StrategyType.ROTATE_COMPONENT`.
- **`recovery/applicator.py`**: execute an in-place footprint rotation
  (`rotate` action) — flips `fp.rotation` mod 360, centre fixed; the board-frame
  pad geometry the classifier reads follows automatically. `is_safe_to_apply`
  accepts rotations (no bounds/distance check needed).
- **`router/placement_delta.py`**: add `PlacementDelta.from_dict()` so the
  artifact round-trips (propose-only recipe can reload + apply deterministically).
- **`router/placement_feedback.py`**: new `PlacementDeltaFeedbackLoop` (+
  `PlacementDeltaFeedbackResult`, `write_placement_delta_json`). Per iteration:
  classify the current PCB → translate PLACEMENT_BOUND/CONGESTION_SATURATED
  diagnoses → select the top **applyable** delta (skipping `reorder_pins`,
  anchored refs, over-`max_movement`, and unsafe deltas each with a logged
  reason) → apply to both the PCB footprint and the router's flat pad
  coordinates → re-route → keep on strict improvement else revert atomically.
- **`router/core.py`**: `Autorouter.route_with_placement_delta_feedback(...)`
  with a default-on `enable_placement_delta_feedback` toggle (off delegates to
  the legacy `route_with_placement_feedback` for byte-identical behavior — the
  bisection guard) and optional `<output>_placement_delta.json` emission.
- **`router/__init__.py`**: export the new symbols.

## Acceptance Criteria Verification

- [x] Reversed-bundle fixture whose opens are `PLACEMENT_BOUND` → applying the
  emitted `rotate_180` + re-routing strictly increases routed count; driver
  keeps it. (`test_applied_rotate_that_improves_reach_is_kept`;
  `test_reversed_bundle_default_proposer_emits_rotate_180` confirms the real
  classifier→translator emits the `rotate_180` on `UB`.)
- [x] Non-improving delta reverted (routed count **and** placement restored,
  atomic). (`test_non_improving_delta_is_reverted_atomically`.)
- [x] `fixed_refs`/anchors and `max_movement` honored — skipped with a logged
  reason. (`test_anchored_target_is_skipped_with_reason`,
  `test_translate_over_max_movement_is_skipped`.)
- [x] Ladder omissions honored — driver never applies a move the classifier
  suppressed. (`test_ladder_omission_no_delta_applies_nothing`; `reorder_pins`
  is skipped, `test_reorder_pins_delta_is_skipped`.)
- [x] `<output>_placement_delta.json` written and round-trips
  `PlacementDelta.to_dict()`. (`test_written_artifact_round_trips`,
  `test_toggle_on_runs_delta_loop_and_writes_json`.)
- [x] Toggle off restores exact prior behavior. (`test_toggle_off_delegates_to_legacy_loop`.)

## Test Plan

- `pytest tests/router/test_placement_delta_feedback.py` — 17 passed.
- `pytest tests/test_recovery.py tests/test_placement_strategy.py tests/test_placement_feedback.py` — 106 passed, 1 skipped.
- `pytest tests/router/test_placement_delta.py tests/router/test_stuck_classifier.py` — no regressions.
- `ruff check` + `ruff format` clean on all changed files.

## Notes for reviewer

- **Router-pad sync is load-bearing.** The router routes against its own flat
  `Pad` objects, so a PCB-only mutation would leave the re-route unchanged. The
  driver mirrors `optim.router_factory`'s pad transform (translate the pad; for
  `rotate_180`, point-reflect through the footprint origin) so the re-route
  reflects the change; the PCB footprint is mutated in lockstep for
  classification, emission, and the placement diff.
- **Scope: Autorouter path only** (`kct route`). The separate
  `RoutingOrchestrator` (`kct route-auto`) will not pick this up automatically —
  acceptable for this phase, noted per Curator guidance rather than expanding
  scope. Wiring the default `kct route` CLI to this loop is intentionally left
  as a follow-up to avoid destabilizing default routing; the API toggle is
  default-on so the bisection-guard AC holds.
- Cross-references the file-based `placement_nudge.py` (#3865) in the new
  driver's docstring; `reorder_pins` deltas are skipped (no pad-remap applicator
  exists yet, per Phase-1 design).

Closes #4467