### PR TITLE
feat(router): congestion-aware escape-corridor reservation for dense parts

### DIFF
--- a/boards/05-bldc-motor-controller/design.py
+++ b/boards/05-bldc-motor-controller/design.py
@@ -3065,6 +3065,22 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
         # sanctioned "require explicit opt-in" remedy: the unsafe grid is now a
         # deliberate, documented choice instead of a silent default.
         "--allow-unsafe-grid",
+        # Issue #4474 (Phase 4, epic #4410): congestion-aware escape-corridor
+        # reservation.  Before the general negotiation, the escape pre-phase
+        # clusters U3 (DRV8301, HTSSOP-56) pins by face/destination -- with
+        # the post-Kelvin (#4499) topology so the five ISENSE sense taps aim
+        # at their R10-R12 shunt pads rather than the raw net centroid -- sizes
+        # a corridor per cluster from the CongestionEstimator demand, assigns
+        # clusters to distinct layers of the 4-layer stack, and SOFT-reserves
+        # the corridor cells.  The intent is to give U3's congested south
+        # sense band (ISENSE/PWM/SL_x) a reserved escape channel instead of
+        # letting it lose the negotiation greedily.  SOFT (attractor-only)
+        # reservation, so it biases the owning nets onto their channel without
+        # fencing any unrelated net out of the long span.  Opt-in per the
+        # #4051 rollout convention (default OFF elsewhere; byte-identical when
+        # absent).  Measurement (reach vs 29/36, rescue NO_LEGAL_ESCAPE +
+        # CONGESTION deltas for the sense band) is tracked on #4474.
+        "--escape-corridor-reservation",
         "--skip-nets",
         ",".join(skip_nets),
     ]

--- a/boards/05-bldc-motor-controller/design.py
+++ b/boards/05-bldc-motor-controller/design.py
@@ -3065,22 +3065,6 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
         # sanctioned "require explicit opt-in" remedy: the unsafe grid is now a
         # deliberate, documented choice instead of a silent default.
         "--allow-unsafe-grid",
-        # Issue #4474 (Phase 4, epic #4410): congestion-aware escape-corridor
-        # reservation.  Before the general negotiation, the escape pre-phase
-        # clusters U3 (DRV8301, HTSSOP-56) pins by face/destination -- with
-        # the post-Kelvin (#4499) topology so the five ISENSE sense taps aim
-        # at their R10-R12 shunt pads rather than the raw net centroid -- sizes
-        # a corridor per cluster from the CongestionEstimator demand, assigns
-        # clusters to distinct layers of the 4-layer stack, and SOFT-reserves
-        # the corridor cells.  The intent is to give U3's congested south
-        # sense band (ISENSE/PWM/SL_x) a reserved escape channel instead of
-        # letting it lose the negotiation greedily.  SOFT (attractor-only)
-        # reservation, so it biases the owning nets onto their channel without
-        # fencing any unrelated net out of the long span.  Opt-in per the
-        # #4051 rollout convention (default OFF elsewhere; byte-identical when
-        # absent).  Measurement (reach vs 29/36, rescue NO_LEGAL_ESCAPE +
-        # CONGESTION deltas for the sense band) is tracked on #4474.
-        "--escape-corridor-reservation",
         "--skip-nets",
         ",".join(skip_nets),
     ]

--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -462,6 +462,11 @@ def run_route_command(args) -> int:
         sub_argv.append("--cross-package-pair-corridor")
     if getattr(args, "slack_corridor_widening", False):
         sub_argv.append("--slack-corridor-widening")
+    # Issue #4474 (epic #4410): forward --escape-corridor-reservation.  Both
+    # parsers declare it as store_true defaulting to False, so only forward
+    # when the user set it (byte-identical when absent).
+    if getattr(args, "escape_corridor_reservation", False):
+        sub_argv.append("--escape-corridor-reservation")
     max_ripups_val = getattr(args, "max_ripups_per_net", None)
     if max_ripups_val is not None:
         sub_argv.extend(["--max-ripups-per-net", str(max_ripups_val)])

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -3314,6 +3314,23 @@ def _add_route_parser(subparsers) -> None:
             "(byte-identical when absent)."
         ),
     )
+    route_parser.add_argument(
+        "--escape-corridor-reservation",
+        action="store_true",
+        default=False,
+        help=(
+            "Enable congestion-aware escape-corridor reservation for dense "
+            "high-pin-count parts (Issue #4474, epic #4410).  Before the "
+            "general negotiation, clusters each dense part's pins by "
+            "face/destination (post-Kelvin, so ISENSE taps aim at their "
+            "shunt pad), sizes a corridor per cluster from the "
+            "CongestionEstimator demand, assigns clusters to distinct "
+            "layers, and SOFT-reserves the corridor cells so a congested "
+            "cluster (e.g. board-05's U3 south sense band) gets a reserved "
+            "channel instead of competing greedily.  Default OFF "
+            "(byte-identical when absent)."
+        ),
+    )
     # Issue #3054 (Phase 2 of #3045): wire region-based parallelism through to
     # ``route_all_negotiated``.  Opt-in (default off) so existing scripts and
     # CI runs see byte-identical routes; when set, the negotiated loop

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -3561,6 +3561,22 @@ def _apply_slack_corridor_widening(router: "Autorouter", args) -> None:
         router.enable_slack_corridor_widening = True
 
 
+def _apply_escape_corridor_reservation(router: "Autorouter", args) -> None:
+    """Enable congestion-aware escape-corridor reservation when requested (Issue #4474).
+
+    Off by default (mirrors ``enable_bundle_river_planner`` / the #4051
+    precedent).  When ``--escape-corridor-reservation`` is passed, set the
+    router's ``enable_escape_corridor_reservation`` flag so the escape
+    pre-phase plans and SOFT-reserves demand-sized per-cluster corridors for
+    dense high-pin-count parts BEFORE the general negotiation (via
+    ``EscapeCorridorPlanner``, driven by the ``CongestionEstimator``).  A
+    no-op when the flag is absent, so production routing is byte-identical to
+    pre-#4474 main.
+    """
+    if getattr(args, "escape_corridor_reservation", False):
+        router.enable_escape_corridor_reservation = True
+
+
 def _targeted_ripup_budget(args) -> int:
     """Resolve ``--max-ripups-per-net`` for the negotiated targeted path.
 
@@ -4565,6 +4581,7 @@ def route_with_layer_escalation(
         _apply_monotone_certificate_order(router, args)
         _apply_cross_package_pair_corridor(router, args)
         _apply_slack_corridor_widening(router, args)
+        _apply_escape_corridor_reservation(router, args)
 
         # Issue #3171: inject boosted analog routing class for --analog-nets /
         # --auto-analog selected nets (pour/ground nets are left untouched).
@@ -5506,6 +5523,7 @@ def route_with_rule_relaxation(
         _apply_monotone_certificate_order(router, args)
         _apply_cross_package_pair_corridor(router, args)
         _apply_slack_corridor_widening(router, args)
+        _apply_escape_corridor_reservation(router, args)
 
         # Issue #3171: inject boosted analog routing class for --analog-nets /
         # --auto-analog selected nets (pour/ground nets are left untouched).
@@ -7685,6 +7703,7 @@ def route_with_combined_escalation(
             _apply_monotone_certificate_order(router, args)
             _apply_cross_package_pair_corridor(router, args)
             _apply_slack_corridor_widening(router, args)
+            _apply_escape_corridor_reservation(router, args)
 
             # Issue #3171: inject boosted analog routing class for --analog-nets
             # / --auto-analog selected nets (pour/ground nets left untouched).
@@ -9815,6 +9834,22 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--escape-corridor-reservation",
+        action="store_true",
+        help=(
+            "Enable congestion-aware escape-corridor reservation for dense "
+            "high-pin-count parts (Issue #4474, epic #4410).  Before the "
+            "general negotiation, clusters each dense part's pins by "
+            "face/destination (post-Kelvin, so ISENSE taps aim at their "
+            "shunt pad), sizes a corridor per cluster from the "
+            "CongestionEstimator demand, assigns clusters to distinct "
+            "layers, and SOFT-reserves the corridor cells so a congested "
+            "cluster (e.g. board-05's U3 south sense band) gets a reserved "
+            "channel instead of competing greedily.  Default OFF "
+            "(byte-identical to prior behaviour when absent)."
+        ),
+    )
+    parser.add_argument(
         "--max-ripups-per-net",
         type=int,
         default=None,
@@ -11912,6 +11947,7 @@ def main(argv: list[str] | None = None) -> int:
     _apply_monotone_certificate_order(router, args)
     _apply_cross_package_pair_corridor(router, args)
     _apply_slack_corridor_widening(router, args)
+    _apply_escape_corridor_reservation(router, args)
 
     # Issue #3171: inject boosted analog routing class for --analog-nets /
     # --auto-analog selected nets (pour/ground nets are left untouched).

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -1058,6 +1058,23 @@ class Autorouter:
         # geometric-only segment heuristic.  Set True to opt in.
         self.enable_slack_corridor_widening = False
 
+        # Issue #4474 (Phase 4, epic #4410): congestion-aware escape-corridor
+        # reservation for dense high-pin-count parts.  When True, the escape
+        # pre-phase runs ``EscapeCorridorPlanner`` (``escape_corridor.py``)
+        # over each detected dense package BEFORE the general negotiation:
+        # it clusters the part's pins by face/destination (post-Kelvin, so
+        # ISENSE taps aim at their shunt pad), sizes a corridor per cluster
+        # from ``CongestionEstimator`` demand, assigns clusters to distinct
+        # layers, and SOFT-reserves the corridor cells so the congested
+        # cluster (e.g. U3's south sense band) gets a reserved channel
+        # instead of competing greedily.  Flag-off (default) is byte-identical
+        # to pre-#4474 main: the planner is never constructed and no cells are
+        # reserved.  Set True to opt in.
+        self.enable_escape_corridor_reservation = False
+        # Populated by ``_reserve_escape_corridors`` when the flag is on so
+        # tests / diagnostics can inspect the per-package plans after a run.
+        self._escape_corridor_plans: list[Any] = []
+
         # Issue #4084: records the most recent certificate classification
         # per qualifying byte-lane group (group name -> MonotoneCertificate)
         # so callers/tests can inspect the feasibility decision and failure
@@ -4142,6 +4159,90 @@ class Autorouter:
             pour_net_ids=pour_ids,
         )
         return self._congestion_estimator
+
+    def _reserve_escape_corridors(self, dense_packages: list[PackageInfo]) -> None:
+        """Plan + SOFT-reserve congestion-aware escape corridors (Issue #4474).
+
+        Runs ``EscapeCorridorPlanner`` over each detected dense package
+        BEFORE the escape main pass and the general negotiation, so the
+        congested clusters (e.g. board-05's U3 south sense band) get a
+        demand-sized reserved channel instead of competing greedily.  Only
+        invoked when ``enable_escape_corridor_reservation`` is set -- the
+        method is otherwise never called, keeping flag-off byte-identical to
+        pre-#4474 main.
+
+        Each package's reservation is advisory and wrapped so a failure
+        degrades to the pre-#4474 behaviour (no reservation) rather than
+        aborting routing.
+        """
+        from .escape_corridor import EscapeCorridorPlanner
+        from .kelvin import detect_kelvin_topology
+
+        if not dense_packages:
+            return
+
+        estimator = self._ensure_congestion_estimator()
+
+        # Board-wide net_id -> [(x, y), ...] map (ALL pads on each net) so the
+        # planner can resolve each net's off-package destination.  Iterate the
+        # sorted pad keys for determinism (required for --seed reproducibility).
+        net_pad_positions: dict[int, list[tuple[float, float]]] = {}
+        net_pad_objs: dict[int, list[Pad]] = {}
+        for key in sorted(self.pads):
+            pad = self.pads[key]
+            nid = int(pad.net)
+            if nid == 0:
+                continue
+            net_pad_positions.setdefault(nid, []).append((pad.x, pad.y))
+            net_pad_objs.setdefault(nid, []).append(pad)
+
+        # Post-Kelvin (#4499) destinations: an ISENSE sense tap terminates AT
+        # its shunt/sense-resistor pad, so resolve the Kelvin root per net and
+        # aim that net's cluster corridor at the shunt rather than the raw net
+        # centroid.  ``detect_kelvin_topology`` gates on the current-sense
+        # name pattern AND a shunt root pad, so ordinary nets that merely pass
+        # through a resistor are NOT redirected -- they stay absent here.
+        kelvin_roots: dict[int, tuple[float, float]] = {}
+        for nid, pad_objs in net_pad_objs.items():
+            if len(pad_objs) < 2:
+                continue
+            try:
+                topo = detect_kelvin_topology(pad_objs)
+            except Exception:
+                topo = None
+            if topo is not None:
+                root = pad_objs[topo.root_index]
+                kelvin_roots[nid] = (root.x, root.y)
+
+        planner = EscapeCorridorPlanner(
+            self.grid,
+            estimator,
+            net_pad_positions=net_pad_positions,
+            kelvin_roots=kelvin_roots,
+        )
+
+        # Mutate the existing list in place (do NOT rebind) so a lazily-built
+        # escape router that already captured this reference still sees the
+        # reserved plans regardless of build order.
+        self._escape_corridor_plans.clear()
+        for pkg in dense_packages:
+            try:
+                plan = planner.plan_and_reserve(pkg, soft=True)
+            except Exception:
+                logger.debug(
+                    "Escape-corridor reservation failed for package %s; "
+                    "continuing without it",
+                    getattr(pkg, "ref", "?"),
+                    exc_info=True,
+                )
+                continue
+            self._escape_corridor_plans.append(plan)
+            if plan.total_reserved_cells > 0:
+                print(
+                    f"  Escape corridors ({pkg.ref}): {plan.cluster_count} cluster(s), "
+                    f"{plan.total_reserved_cells} cells reserved across "
+                    f"layers {sorted(plan.layers_used())} (Issue #4474)"
+                )
 
     # ------------------------------------------------------------------
     # Impedance-driven sizing activation
@@ -15913,6 +16014,13 @@ class Autorouter:
                 # (default OFF).  When OFF the pair continuation corridor
                 # keeps its fixed padding, byte-identical to pre-#4085.
                 enable_slack_corridor_widening=self.enable_slack_corridor_widening,
+                # Issue #4474 (Phase 4): congestion-aware escape-corridor
+                # reservation gate (default OFF) + the per-package plans the
+                # escape pre-phase reserved on the grid.  When OFF the plan
+                # list is empty and the escape router honours no reserved
+                # channel, byte-identical to pre-#4474.
+                enable_escape_corridor_reservation=self.enable_escape_corridor_reservation,
+                escape_corridor_plans=self._escape_corridor_plans,
                 # Issue #3428: board-wide net-id -> pad-position map so the
                 # fine-pitch QFP in-pad rescue can aim its inner stub at
                 # the net's actual routing target instead of the parity-
@@ -16616,6 +16724,15 @@ class Autorouter:
 
         # Phase 1: Detect and route dense packages
         dense_packages = self.detect_dense_packages()
+
+        # Issue #4474 (Phase 4, epic #4410): congestion-aware escape-corridor
+        # reservation.  When opted in, reserve demand-sized per-cluster
+        # corridors on the grid BEFORE the escape main pass and the general
+        # negotiation, so the congested clusters get a reserved channel.
+        # Gated OFF by default; when off this block is skipped entirely and
+        # behaviour is byte-identical to pre-#4474 main.
+        if getattr(self, "enable_escape_corridor_reservation", False):
+            self._reserve_escape_corridors(dense_packages)
 
         already_escaped = self._escapes_generated_this_run
         if dense_packages and not already_escaped:

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -4230,8 +4230,7 @@ class Autorouter:
                 plan = planner.plan_and_reserve(pkg, soft=True)
             except Exception:
                 logger.debug(
-                    "Escape-corridor reservation failed for package %s; "
-                    "continuing without it",
+                    "Escape-corridor reservation failed for package %s; continuing without it",
                     getattr(pkg, "ref", "?"),
                     exc_info=True,
                 )

--- a/src/kicad_tools/router/escape.py
+++ b/src/kicad_tools/router/escape.py
@@ -1263,9 +1263,7 @@ class EscapeRouter:
         # explicit record that the escape router is consuming them, and lets
         # tests assert the reservation reached the escape phase without
         # monkey-patching.  Empty/absent (default) => no reserved channels.
-        self.enable_escape_corridor_reservation: bool = bool(
-            enable_escape_corridor_reservation
-        )
+        self.enable_escape_corridor_reservation: bool = bool(enable_escape_corridor_reservation)
         # ``is not None`` (not ``or``) so a live-but-currently-empty plan list
         # keeps its identity: the escape router may be built during the escape
         # pre-phase BEFORE ``_reserve_escape_corridors`` has populated it, and

--- a/src/kicad_tools/router/escape.py
+++ b/src/kicad_tools/router/escape.py
@@ -1099,6 +1099,8 @@ class EscapeRouter:
         enable_cross_package_pair_corridor: bool = False,
         net_name_to_id: dict[str, int] | None = None,
         enable_slack_corridor_widening: bool = False,
+        enable_escape_corridor_reservation: bool = False,
+        escape_corridor_plans: list | None = None,
     ):
         """Initialize the escape router.
 
@@ -1253,6 +1255,24 @@ class EscapeRouter:
         self.enable_slack_corridor_widening: bool = bool(enable_slack_corridor_widening)
         self.pair_corridor_slack_widened: int = 0
         self.pair_corridor_slack_budget_mm: float = 0.0
+        # Issue #4474 (Phase 4, epic #4410): congestion-aware escape-corridor
+        # reservation gate + the per-package plans reserved on the grid before
+        # the escape main pass.  The reservations live on ``self.grid`` (SOFT
+        # attractor cells), so the per-pin escape A* already honours them via
+        # the grid's corridor attractor -- this flag/plan reference is the
+        # explicit record that the escape router is consuming them, and lets
+        # tests assert the reservation reached the escape phase without
+        # monkey-patching.  Empty/absent (default) => no reserved channels.
+        self.enable_escape_corridor_reservation: bool = bool(
+            enable_escape_corridor_reservation
+        )
+        # ``is not None`` (not ``or``) so a live-but-currently-empty plan list
+        # keeps its identity: the escape router may be built during the escape
+        # pre-phase BEFORE ``_reserve_escape_corridors`` has populated it, and
+        # must observe the plans once they are appended in place.
+        self.escape_corridor_plans: list = (
+            escape_corridor_plans if escape_corridor_plans is not None else []
+        )
         # Issue #4086: board-wide net-name -> net-id map used ONLY to
         # resolve the off-package partner's net id for the cross-package
         # corridor owner set.  Empty map => owner set is this leg alone.

--- a/src/kicad_tools/router/escape_corridor.py
+++ b/src/kicad_tools/router/escape_corridor.py
@@ -1,0 +1,476 @@
+"""Congestion-aware escape-corridor reservation for dense high-pin-count parts.
+
+Issue #4474 (Phase 4 of epic #4410).  Dense high-pin-count parts (the
+DRV8301 HTSSOP-56 on board-05, any congested QFN/BGA/HTSSOP) escape their
+pins per-pin with no congestion-aware channel planning: the escape router
+places in-pad micro-vias greedily and the pins that share a congested face
+lose the general multi-net negotiation because *nothing reserves a channel
+for them*.  This module closes that gap by planning, sizing, and reserving
+escape corridors from :class:`~kicad_tools.router.congestion_estimator.CongestionEstimator`
+demand **before** the general negotiation runs.
+
+Pipeline (all driven by :class:`EscapeCorridorPlanner`):
+
+1. **Cluster** a dense part's routable pins by *face* (the bbox edge each
+   pin sits nearest) and by *destination* (the compass octant of the vector
+   from the pin to where its net has to go).  The destination geometry is
+   the *post-Kelvin* topology (#4499): an ISENSE sense tap terminates AT its
+   shunt/sense-resistor pad, not at the raw RSMT centroid, so ``kelvin_roots``
+   overrides the off-package centroid for those nets.
+2. **Size** each cluster's corridor to demand: the corridor's lateral
+   half-width grows with the pin count *and* with the local
+   ``CongestionEstimator`` demand, so a congested cluster (U3's south sense
+   band) gets a wider reserved channel than an uncongested one.
+3. **Assign layers** per cluster, distributing clusters across the routable
+   layers so different clusters escape on different layers where the stack
+   allows -- reducing same-layer contention.  Degrades gracefully on a
+   2-layer board (round-robins over whatever routable layers exist).
+4. **Reserve** the corridor cells on the routing grid via
+   :meth:`RoutingGrid.reserve_corridor_cells` (SOFT by default -- an
+   attractor bonus for the owning nets, not a hard fence, so unrelated nets
+   are never starved of the long channel).
+
+**Rollout convention (Issue #4051 precedent):** this planner is *never
+constructed* unless the caller opts in via the router's
+``enable_escape_corridor_reservation`` flag.  With the flag absent, routing
+output is byte-identical to pre-change main -- there is no import-time or
+run-time side effect.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .congestion_estimator import CongestionEstimator
+    from .escape import PackageInfo
+    from .grid import RoutingGrid
+    from .primitives import Pad
+
+
+# Compass octant names indexed by ``int((angle + 22.5) / 45) % 8`` where the
+# angle is measured with ``atan2(dy, dx)`` in degrees.  These are grid-space
+# directions (KiCad y grows downward), so "N" is decreasing y and "S" is
+# increasing y -- consistent bucketing is all that matters here.
+_OCTANTS = ("E", "SE", "S", "SW", "W", "NW", "N", "NE")
+
+
+def _octant_of(dx: float, dy: float) -> str:
+    """Return the compass octant name for a direction vector."""
+    if dx == 0.0 and dy == 0.0:
+        return "E"
+    angle = math.degrees(math.atan2(dy, dx))
+    idx = int((angle + 22.5) // 45) % 8
+    return _OCTANTS[idx]
+
+
+@dataclass
+class EscapeCluster:
+    """A group of a dense part's pins that escape toward a common neighbor.
+
+    A cluster is keyed by ``(face, dest_octant)`` -- the bbox edge the pins
+    sit nearest and the compass direction of their escape.  The reserved
+    corridor is a rectangle launched from :attr:`origin` (the cluster's pin
+    centroid) along :attr:`escape_dir` toward the cluster's shared
+    destination.
+
+    Attributes:
+        face: Nearest bbox edge for the cluster's pins (``"N"``/``"S"``/
+            ``"E"``/``"W"``).
+        dest_octant: Compass octant of the mean escape direction.
+        pads: The pins in this cluster.
+        net_ids: The distinct routable net ids the pins belong to (the
+            corridor owner set for :meth:`RoutingGrid.reserve_corridor_cells`).
+        escape_dir: Unit mean escape vector (grid space).
+        origin: Cluster pin centroid (mm), the corridor launch point.
+        destination: Mean destination point (mm) the corridor extends toward.
+        demand: ``CongestionEstimator`` demand aggregated over the cluster's
+            pin tiles.  Drives corridor sizing (higher demand -> wider).
+        layer_idx: Assigned escape layer (grid index), or ``None`` before
+            :meth:`EscapeCorridorPlanner._assign_layers` runs.
+        corridor_cells: Grid cells the reserved corridor covers.
+        reserved_cell_count: Cells actually reserved on the grid.
+    """
+
+    face: str
+    dest_octant: str
+    pads: list[Pad]
+    net_ids: frozenset[int]
+    escape_dir: tuple[float, float]
+    origin: tuple[float, float]
+    destination: tuple[float, float]
+    demand: float = 0.0
+    layer_idx: int | None = None
+    corridor_cells: frozenset[tuple[int, int]] = field(default_factory=frozenset)
+    reserved_cell_count: int = 0
+
+    @property
+    def key(self) -> tuple[str, str]:
+        """The clustering key ``(face, dest_octant)``."""
+        return (self.face, self.dest_octant)
+
+    @property
+    def pin_count(self) -> int:
+        """Number of pins in the cluster."""
+        return len(self.pads)
+
+
+@dataclass
+class EscapeCorridorPlan:
+    """The planned (and optionally reserved) corridors for one dense part.
+
+    Attributes:
+        ref: The dense part's component reference (e.g. ``"U3"``).
+        clusters: The per-``(face, dest_octant)`` clusters, deterministically
+            ordered by key.
+        total_reserved_cells: Sum of ``reserved_cell_count`` across clusters
+            after :meth:`EscapeCorridorPlanner.reserve` runs.
+    """
+
+    ref: str
+    clusters: list[EscapeCluster] = field(default_factory=list)
+    total_reserved_cells: int = 0
+
+    @property
+    def cluster_count(self) -> int:
+        """Number of clusters in the plan."""
+        return len(self.clusters)
+
+    def layers_used(self) -> set[int]:
+        """The set of distinct layer indices the plan assigned."""
+        return {c.layer_idx for c in self.clusters if c.layer_idx is not None}
+
+
+class EscapeCorridorPlanner:
+    """Plans and reserves demand-sized escape corridors for a dense part.
+
+    The planner is *generic*: it takes any :class:`PackageInfo`-shaped
+    object (only ``.ref``, ``.pads``, ``.center``, ``.bounding_box`` are
+    read) and a :class:`CongestionEstimator`, and produces an
+    :class:`EscapeCorridorPlan`.  It has no board-05-specific logic; the
+    board-05 sense band is simply the motivating congested cluster.
+
+    Args:
+        grid: The routing grid the corridors are reserved on.
+        congestion_estimator: RUDY demand source used to size corridors.
+            When ``None`` every cluster is treated as zero-demand (corridors
+            are sized by pin count alone).
+        net_pad_positions: Board-wide ``net_id -> [(x, y), ...]`` map of ALL
+            pad positions, used to resolve each net's off-package
+            destination.  When absent the package center is used as a
+            fallback destination.
+        kelvin_roots: ``net_id -> (x, y)`` map of Kelvin/sense-star root
+            (shunt-pad) positions (#4499).  For a net in this map the
+            destination is the root pad, so an ISENSE cluster's corridor
+            aims at the shunt where the star terminates rather than at the
+            raw net centroid.
+        cells_per_pin: Base corridor lateral cells contributed per pin
+            (before the demand multiplier).
+        max_corridor_length_mm: Optional cap on how far a corridor extends
+            from the launch point (defaults to the destination distance).
+    """
+
+    def __init__(
+        self,
+        grid: RoutingGrid,
+        congestion_estimator: CongestionEstimator | None = None,
+        *,
+        net_pad_positions: dict[int, list[tuple[float, float]]] | None = None,
+        kelvin_roots: dict[int, tuple[float, float]] | None = None,
+        cells_per_pin: float = 1.0,
+        max_corridor_length_mm: float | None = None,
+        min_reserve_demand: float = 0.0,
+    ) -> None:
+        self.grid = grid
+        self.congestion = congestion_estimator
+        self.net_pad_positions = net_pad_positions or {}
+        self.kelvin_roots = kelvin_roots or {}
+        self.cells_per_pin = float(cells_per_pin)
+        self.max_corridor_length_mm = max_corridor_length_mm
+        self.min_reserve_demand = float(min_reserve_demand)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def plan(self, package: PackageInfo) -> EscapeCorridorPlan:
+        """Cluster the part's pins, size corridors, and assign layers.
+
+        Does NOT touch the grid -- call :meth:`reserve` (or
+        :meth:`plan_and_reserve`) to commit the reservation.
+        """
+        clusters = self._cluster_pins(package)
+        for cluster in clusters:
+            self._size_corridor(package, cluster)
+        self._assign_layers(clusters)
+        return EscapeCorridorPlan(ref=package.ref, clusters=clusters)
+
+    def reserve(self, plan: EscapeCorridorPlan, *, soft: bool = True) -> int:
+        """Reserve every cluster's corridor cells on the grid.
+
+        Returns the total number of cells reserved.  A SOFT reservation
+        (default) applies only the A* attractor bonus for the owning nets
+        and fences nothing out -- so a long escape channel never starves
+        unrelated nets (the #4087 hard-fence hazard).  Reservation is
+        advisory: a cluster with no owner nets or no cells is skipped.
+        """
+        total = 0
+        for cluster in plan.clusters:
+            if cluster.layer_idx is None or not cluster.corridor_cells or not cluster.net_ids:
+                continue
+            # Edge case (#4474 test plan): a cluster on a face the
+            # CongestionEstimator reports as uncongested does not warrant a
+            # reserved channel -- reserving one would only fence copper for
+            # no benefit.  Skip it (no-op) when demand is at/under the
+            # threshold.  When no estimator was supplied the planner runs in
+            # demand-agnostic mode and reserves every cluster.
+            if self.congestion is not None and cluster.demand <= self.min_reserve_demand:
+                continue
+            count = self.grid.reserve_corridor_cells(
+                layer_idx=cluster.layer_idx,
+                cells=set(cluster.corridor_cells),
+                net_ids=cluster.net_ids,
+                soft=soft,
+            )
+            cluster.reserved_cell_count = count
+            total += count
+        plan.total_reserved_cells = total
+        return total
+
+    def plan_and_reserve(self, package: PackageInfo, *, soft: bool = True) -> EscapeCorridorPlan:
+        """Convenience: :meth:`plan` then :meth:`reserve`."""
+        plan = self.plan(package)
+        self.reserve(plan, soft=soft)
+        return plan
+
+    # ------------------------------------------------------------------
+    # Step 1: clustering
+    # ------------------------------------------------------------------
+
+    def _cluster_pins(self, package: PackageInfo) -> list[EscapeCluster]:
+        """Group routable pins by (nearest bbox face, escape octant)."""
+        min_x, min_y, max_x, max_y = package.bounding_box
+        pkg_pad_xy = {(round(p.x, 4), round(p.y, 4)) for p in package.pads}
+
+        buckets: dict[tuple[str, str], list[tuple[Pad, tuple[float, float]]]] = {}
+        for pad in package.pads:
+            net_id = int(pad.net)
+            if net_id == 0:
+                # Unassigned / plane pads escape via zone fill, not corridors.
+                continue
+            dest = self._destination_for(net_id, pad, package, pkg_pad_xy)
+            if dest is None:
+                continue
+            dx = dest[0] - pad.x
+            dy = dest[1] - pad.y
+            face = self._face_of(pad, min_x, min_y, max_x, max_y)
+            octant = _octant_of(dx, dy)
+            buckets.setdefault((face, octant), []).append((pad, dest))
+
+        clusters: list[EscapeCluster] = []
+        for (face, octant), members in sorted(buckets.items()):
+            pads = [m[0] for m in members]
+            dests = [m[1] for m in members]
+            n = len(pads)
+            ox = sum(p.x for p in pads) / n
+            oy = sum(p.y for p in pads) / n
+            dcx = sum(d[0] for d in dests) / n
+            dcy = sum(d[1] for d in dests) / n
+            ddx, ddy = dcx - ox, dcy - oy
+            norm = math.hypot(ddx, ddy)
+            if norm == 0.0:
+                edir = (1.0, 0.0)
+            else:
+                edir = (ddx / norm, ddy / norm)
+            net_ids = frozenset(int(p.net) for p in pads)
+            clusters.append(
+                EscapeCluster(
+                    face=face,
+                    dest_octant=octant,
+                    pads=pads,
+                    net_ids=net_ids,
+                    escape_dir=edir,
+                    origin=(ox, oy),
+                    destination=(dcx, dcy),
+                )
+            )
+        return clusters
+
+    def _destination_for(
+        self,
+        net_id: int,
+        pad: Pad,
+        package: PackageInfo,
+        pkg_pad_xy: set[tuple[float, float]],
+    ) -> tuple[float, float] | None:
+        """Resolve where ``net_id`` needs to escape toward from ``pad``.
+
+        Priority:
+          1. Kelvin/sense-star root (#4499) -- the shunt pad the sense tap
+             terminates at.
+          2. Centroid of the net's OFF-package pads (from
+             ``net_pad_positions``).
+          3. The package center (fallback), so a net that lives entirely on
+             this package still yields a well-defined outward direction.
+        """
+        root = self.kelvin_roots.get(net_id)
+        if root is not None:
+            return root
+
+        positions = self.net_pad_positions.get(net_id)
+        if positions:
+            off = [(x, y) for (x, y) in positions if (round(x, 4), round(y, 4)) not in pkg_pad_xy]
+            if off:
+                return (sum(p[0] for p in off) / len(off), sum(p[1] for p in off) / len(off))
+
+        # Fallback: aim away from the package center through the pad.
+        cx, cy = package.center
+        if pad.x == cx and pad.y == cy:
+            return None
+        return (cx + 2.0 * (pad.x - cx), cy + 2.0 * (pad.y - cy))
+
+    @staticmethod
+    def _face_of(pad: Pad, min_x: float, min_y: float, max_x: float, max_y: float) -> str:
+        """Return the bbox edge (``N``/``S``/``E``/``W``) the pad sits nearest."""
+        dist_w = abs(pad.x - min_x)
+        dist_e = abs(max_x - pad.x)
+        dist_n = abs(pad.y - min_y)
+        dist_s = abs(max_y - pad.y)
+        nearest = min(dist_w, dist_e, dist_n, dist_s)
+        if nearest == dist_n:
+            return "N"
+        if nearest == dist_s:
+            return "S"
+        if nearest == dist_w:
+            return "W"
+        return "E"
+
+    # ------------------------------------------------------------------
+    # Step 2: corridor sizing (demand-driven)
+    # ------------------------------------------------------------------
+
+    def _size_corridor(self, package: PackageInfo, cluster: EscapeCluster) -> None:
+        """Compute ``cluster.demand`` and the corridor cell footprint.
+
+        The lateral half-width scales with the pin count AND the local
+        congestion demand::
+
+            lat_half_cells = cells_per_pin * pin_count * (1 + demand_factor)
+
+        so a congested cluster reserves a strictly wider channel than an
+        equal-pin-count uncongested one -- the "size corridors to demand"
+        acceptance criterion.
+        """
+        res = self.grid.resolution
+        cluster.demand = self._cluster_demand(cluster)
+
+        # Normalise demand into a [0, 1] widening factor relative to the
+        # estimator's peak tile demand (so sizing is scale-free across boards).
+        demand_factor = 0.0
+        peak = self._peak_demand()
+        if peak > 0.0:
+            demand_factor = min(1.0, cluster.demand / peak)
+
+        lat_half_cells = self.cells_per_pin * cluster.pin_count * (1.0 + demand_factor)
+        lat_half = max(res, lat_half_cells * res * 0.5)
+
+        cx, cy = cluster.origin
+        dx, dy = cluster.escape_dir
+        # Lateral (perpendicular) unit vector.
+        lat_dx, lat_dy = -dy, dx
+
+        # Corridor length: reach toward the destination, capped.
+        dest_dist = math.hypot(cluster.destination[0] - cx, cluster.destination[1] - cy)
+        length = dest_dist if dest_dist > 0.0 else max(res * 4.0, lat_half * 2.0)
+        if self.max_corridor_length_mm is not None:
+            length = min(length, self.max_corridor_length_mm)
+        length = max(length, res * 2.0)
+
+        step = res * 0.5
+        cells: set[tuple[int, int]] = set()
+        t = 0.0
+        while t <= length:
+            u = -lat_half
+            while u <= lat_half:
+                wx = cx + dx * t + lat_dx * u
+                wy = cy + dy * t + lat_dy * u
+                cells.add(self.grid.world_to_grid(wx, wy))
+                u += step
+            t += step
+        cluster.corridor_cells = frozenset(cells)
+
+    def _cluster_demand(self, cluster: EscapeCluster) -> float:
+        """Aggregate ``CongestionEstimator`` demand over the cluster's tiles."""
+        if self.congestion is None:
+            return 0.0
+        tgrid = self.congestion.grid
+        seen: set[tuple[int, int]] = set()
+        total = 0.0
+        for pad in cluster.pads:
+            col, row = tgrid.tile_at(pad.x, pad.y)
+            if (row, col) in seen:
+                continue
+            seen.add((row, col))
+            total += self.congestion.get_tile_demand(row, col)
+        return total
+
+    def _peak_demand(self) -> float:
+        """Peak per-tile demand across the estimator (0 when unavailable)."""
+        if self.congestion is None:
+            return 0.0
+        peak = 0.0
+        for row in self.congestion.get_demand_grid():
+            for val in row:
+                if val > peak:
+                    peak = val
+        return peak
+
+    # ------------------------------------------------------------------
+    # Step 3: layer assignment
+    # ------------------------------------------------------------------
+
+    def _assign_layers(self, clusters: list[EscapeCluster]) -> None:
+        """Distribute clusters across routable layers to cut same-layer contention.
+
+        Highest-demand clusters are assigned first (they most need an
+        uncontested layer).  Assignment round-robins over the routable
+        layers, so on a 4-layer stack four clusters land on four distinct
+        layers; on a 2-layer board it degrades to round-robin over the two
+        outer layers.
+        """
+        routable = self._routable_layers()
+        if not routable:
+            return
+        order = sorted(
+            range(len(clusters)),
+            key=lambda i: (-clusters[i].demand, clusters[i].key),
+        )
+        for rank, idx in enumerate(order):
+            clusters[idx].layer_idx = routable[rank % len(routable)]
+
+    def _routable_layers(self) -> list[int]:
+        """Routable grid-layer indices, preferring inner layers first.
+
+        Inner (non-outer) signal layers are listed before outer layers so
+        that -- on a 4-layer stack -- clusters escape on the inner routing
+        layers where a dense part's in-pad vias drop to, keeping the outer
+        (component) layers freer.  Falls back to whatever routable layers
+        exist (2-layer boards have only outer layers).
+        """
+        stack = getattr(self.grid, "layer_stack", None)
+        get_routable = getattr(self.grid, "get_routable_indices", None)
+        if get_routable is not None:
+            routable = list(get_routable())
+        elif stack is not None:
+            routable = list(stack.get_routable_indices())
+        else:
+            return list(range(getattr(self.grid, "num_layers", 1)))
+
+        if stack is not None:
+            outer = set(stack.get_outer_layer_indices())
+            inner = [i for i in routable if i not in outer]
+            outers = [i for i in routable if i in outer]
+            return inner + outers
+        return routable

--- a/tests/router/test_escape_corridor.py
+++ b/tests/router/test_escape_corridor.py
@@ -1,0 +1,408 @@
+"""Tests for congestion-aware escape-corridor reservation (Issue #4474).
+
+Background
+----------
+Phase 4 of epic #4410.  ``EscapeCorridorPlanner``
+(``kicad_tools.router.escape_corridor``) clusters a dense high-pin-count
+part's pins by face/destination, sizes a corridor per cluster from
+``CongestionEstimator`` demand, assigns clusters to distinct layers, and
+SOFT-reserves the corridor cells on the routing grid BEFORE the general
+multi-net negotiation.
+
+Contract pinned here (all on a synthetic dense-QFN fixture, not board-05):
+
+1. Clustering: pins group by (nearest bbox face, escape octant).
+2. Sizing: a congested cluster reserves a strictly wider corridor than an
+   equal-pin-count uncongested one (sized to CongestionEstimator demand).
+3. Layer assignment: clusters spread across distinct routable layers on a
+   4-layer stack; degrades gracefully on a 2-layer board.
+4. Reservation happens as a standalone pre-pass -- cells owned by the
+   cluster's net ids appear on the grid before any routing.
+5. Post-Kelvin destinations (#4499): a sense net's cluster aims at its
+   shunt/root pad, not the raw net centroid.
+6. Default-OFF (the #4051 rollout convention): ``Autorouter`` defaults the
+   flag False, never constructs the planner, and reserves nothing -- so
+   routing output is byte-identical to pre-#4474 main.
+7. Edge cases: an uncongested face is a no-op; a 2-layer board does not
+   crash the layer-assignment step.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from kicad_tools.router.congestion_estimator import CongestionEstimator, TileGrid
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.escape import PackageInfo, PackageType
+from kicad_tools.router.escape_corridor import (
+    EscapeCorridorPlanner,
+    _octant_of,
+)
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import DesignRules
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+BOARD = 30.0
+CENTER = 15.0
+
+
+@pytest.fixture
+def rules() -> DesignRules:
+    return DesignRules(
+        trace_width=0.2,
+        trace_clearance=0.15,
+        via_drill=0.3,
+        via_diameter=0.6,
+        via_clearance=0.15,
+        grid_resolution=0.1,
+    )
+
+
+@pytest.fixture
+def grid_4layer(rules: DesignRules) -> RoutingGrid:
+    stack = LayerStack.four_layer_all_signal()
+    return RoutingGrid(BOARD, BOARD, rules, origin_x=0, origin_y=0, layer_stack=stack)
+
+
+@pytest.fixture
+def grid_2layer(rules: DesignRules) -> RoutingGrid:
+    return RoutingGrid(BOARD, BOARD, rules, origin_x=0, origin_y=0)
+
+
+def make_dense_qfn(
+    *,
+    pins_per_side: int = 4,
+    pitch: float = 0.5,
+    center: tuple[float, float] = (CENTER, CENTER),
+    dest_dist: float = 8.0,
+) -> tuple[list[Pad], dict[int, list[tuple[float, float]]]]:
+    """A dense 4-sided QFN whose every pin escapes straight out its own face.
+
+    Returns ``(pkg_pads, net_pad_positions)``.  Each pin gets a unique net
+    whose only OTHER pad sits ``dest_dist`` mm directly outward from the
+    package face, so the pin's escape octant is unambiguously N/S/E/W.
+    Net ids are laid out by side so tests can address a whole face's nets.
+    """
+    cx, cy = center
+    half = (pins_per_side - 1) * pitch / 2.0
+    pkg_pads: list[Pad] = []
+    net_pad_positions: dict[int, list[tuple[float, float]]] = {}
+
+    # side -> (face offset direction). KiCad y grows downward: N=min y.
+    sides = {
+        "N": (0.0, -1.0),
+        "S": (0.0, 1.0),
+        "W": (-1.0, 0.0),
+        "E": (1.0, 0.0),
+    }
+    nid = 1
+    edge = half + 1.0  # pad-row offset from center to the package edge
+    for side, (ox, oy) in sides.items():
+        for i in range(pins_per_side):
+            along = -half + i * pitch
+            if side in ("N", "S"):
+                px, py = cx + along, cy + oy * edge
+            else:
+                px, py = cx + ox * edge, cy + along
+            pad = Pad(
+                x=px,
+                y=py,
+                width=0.25,
+                height=0.25,
+                net=nid,
+                net_name=f"{side}_NET_{i}",
+                layer=Layer.F_CU,
+                ref="U3",
+            )
+            pkg_pads.append(pad)
+            # Destination pad: straight out the face.
+            dx, dy = px + ox * dest_dist, py + oy * dest_dist
+            net_pad_positions[nid] = [(px, py), (dx, dy)]
+            nid += 1
+    return pkg_pads, net_pad_positions
+
+
+def make_package(pads: list[Pad], ref: str = "U3") -> PackageInfo:
+    xs = [p.x for p in pads]
+    ys = [p.y for p in pads]
+    bbox = (min(xs), min(ys), max(xs), max(ys))
+    center = ((min(xs) + max(xs)) / 2.0, (min(ys) + max(ys)) / 2.0)
+    return PackageInfo(
+        ref=ref,
+        package_type=PackageType.QFN,
+        center=center,
+        pads=pads,
+        pin_count=len(pads),
+        pin_pitch=0.5,
+        bounding_box=bbox,
+        is_dense=True,
+    )
+
+
+def uniform_estimator(peak_south: float = 0.0, base: float = 0.0) -> CongestionEstimator:
+    """A hand-built estimator: ``base`` demand everywhere, ``peak_south`` in
+    the southern half of the board (rows below center)."""
+    tgrid = TileGrid.from_board(0.0, 0.0, BOARD, BOARD, target_tiles=100)
+    demand = [[base] * tgrid.cols for _ in range(tgrid.rows)]
+    if peak_south:
+        for r in range(tgrid.rows):
+            # tile row center y
+            y = tgrid.origin_y + (r + 0.5) * tgrid.tile_h
+            if y > CENTER:
+                for c in range(tgrid.cols):
+                    demand[r][c] = peak_south
+    est = CongestionEstimator(grid=tgrid)
+    est.demand = demand
+    return est
+
+
+# =============================================================================
+# 1. Clustering
+# =============================================================================
+
+
+def test_octant_helper_cardinal_directions() -> None:
+    assert _octant_of(1.0, 0.0) == "E"
+    assert _octant_of(0.0, 1.0) == "S"
+    assert _octant_of(0.0, -1.0) == "N"
+    assert _octant_of(-1.0, 0.0) == "W"
+
+
+def test_clusters_by_face_and_destination(grid_4layer: RoutingGrid) -> None:
+    pads, npp = make_dense_qfn()
+    pkg = make_package(pads)
+    planner = EscapeCorridorPlanner(grid_4layer, net_pad_positions=npp)
+    plan = planner.plan(pkg)
+
+    # Four faces -> four clusters, each pointing straight out its own octant.
+    assert plan.cluster_count == 4
+    by_key = {c.key: c for c in plan.clusters}
+    assert set(by_key) == {("N", "N"), ("S", "S"), ("E", "E"), ("W", "W")}
+    for cluster in plan.clusters:
+        assert cluster.pin_count == 4
+        # Every pin's net id is unique to the cluster.
+        assert len(cluster.net_ids) == 4
+
+
+def test_pin_assigned_to_nearest_face(grid_4layer: RoutingGrid) -> None:
+    pads, npp = make_dense_qfn(pins_per_side=3)
+    pkg = make_package(pads)
+    planner = EscapeCorridorPlanner(grid_4layer, net_pad_positions=npp)
+    plan = planner.plan(pkg)
+    south = next(c for c in plan.clusters if c.face == "S")
+    # All south-cluster pads sit on the max-y edge of the bbox.
+    max_y = pkg.bounding_box[3]
+    assert all(math.isclose(p.y, max_y) for p in south.pads)
+
+
+# =============================================================================
+# 2. Corridor sizing to CongestionEstimator demand
+# =============================================================================
+
+
+def test_corridor_sized_to_congestion_demand(grid_4layer: RoutingGrid) -> None:
+    """A congested (south) cluster reserves strictly more cells than an
+    equal-pin-count uncongested (north) cluster."""
+    pads, npp = make_dense_qfn()
+    pkg = make_package(pads)
+    est = uniform_estimator(peak_south=50.0, base=1.0)
+    planner = EscapeCorridorPlanner(grid_4layer, est, net_pad_positions=npp)
+    plan = planner.plan_and_reserve(pkg)
+
+    south = next(c for c in plan.clusters if c.face == "S")
+    north = next(c for c in plan.clusters if c.face == "N")
+    assert south.demand > north.demand
+    # Same pin count, same destination distance -> the wider (higher-demand)
+    # corridor is the only difference, so it reserves more cells.
+    assert south.reserved_cell_count > north.reserved_cell_count
+
+
+def test_zero_demand_estimator_is_noop_reservation(grid_4layer: RoutingGrid) -> None:
+    """Edge case: every face uncongested (demand 0) -> planner reserves nothing."""
+    pads, npp = make_dense_qfn()
+    pkg = make_package(pads)
+    est = uniform_estimator(peak_south=0.0, base=0.0)
+    planner = EscapeCorridorPlanner(grid_4layer, est, net_pad_positions=npp)
+    plan = planner.plan_and_reserve(pkg)
+    assert plan.total_reserved_cells == 0
+    assert not grid_4layer._reserved_for_nets
+
+
+# =============================================================================
+# 3. Layer assignment
+# =============================================================================
+
+
+def test_layer_assignment_distributes_across_layers_4layer(
+    grid_4layer: RoutingGrid,
+) -> None:
+    pads, npp = make_dense_qfn()
+    pkg = make_package(pads)
+    est = uniform_estimator(base=5.0)  # all clusters congested so all reserve
+    planner = EscapeCorridorPlanner(grid_4layer, est, net_pad_positions=npp)
+    plan = planner.plan_and_reserve(pkg)
+    # Four clusters over four routable layers -> four distinct layers.
+    assert len(plan.layers_used()) == 4
+
+
+def test_layer_assignment_degrades_on_2layer(grid_2layer: RoutingGrid) -> None:
+    pads, npp = make_dense_qfn()
+    pkg = make_package(pads)
+    est = uniform_estimator(base=5.0)
+    planner = EscapeCorridorPlanner(grid_2layer, est, net_pad_positions=npp)
+    plan = planner.plan_and_reserve(pkg)  # must not raise
+    routable = set(grid_2layer.get_routable_indices())
+    used = plan.layers_used()
+    assert used  # something was assigned
+    assert used.issubset(routable)
+
+
+# =============================================================================
+# 4. Reservation is a pre-pass (cells on grid, owned by cluster nets)
+# =============================================================================
+
+
+def test_reservation_populates_grid_before_negotiation(
+    grid_4layer: RoutingGrid,
+) -> None:
+    pads, npp = make_dense_qfn()
+    pkg = make_package(pads)
+    est = uniform_estimator(base=5.0)
+    planner = EscapeCorridorPlanner(grid_4layer, est, net_pad_positions=npp)
+
+    assert not grid_4layer._reserved_for_nets  # nothing reserved yet
+    plan = planner.plan_and_reserve(pkg)
+    assert plan.total_reserved_cells > 0
+    assert grid_4layer._reserved_for_nets  # reserved as a standalone pre-pass
+
+    # Every reserved cell is owned by the planning nets only (never a
+    # foreign net), matching the SOFT corridor owner-set contract.
+    all_cluster_nets: set[int] = set()
+    for c in plan.clusters:
+        all_cluster_nets |= set(c.net_ids)
+    for owners in grid_4layer._reserved_for_nets.values():
+        assert set(owners).issubset(all_cluster_nets)
+
+
+# =============================================================================
+# 5. Post-Kelvin destination (#4499)
+# =============================================================================
+
+
+def test_kelvin_root_overrides_destination(grid_4layer: RoutingGrid) -> None:
+    """A sense net whose Kelvin root is supplied aims its cluster at the
+    shunt pad, not the raw off-package centroid."""
+    # One south pin on a sense net; its net has an off-package pad to the
+    # EAST, but the Kelvin root (shunt) is to the SOUTH.
+    cx, cy = CENTER, CENTER
+    sense_pad = Pad(x=cx, y=cy + 2.0, width=0.25, height=0.25, net=1, net_name="ISENSE_A", ref="U3")
+    pkg = make_package([sense_pad])
+    # net_pad_positions would push the destination east...
+    npp = {1: [(cx, cy + 2.0), (cx + 15.0, cy + 2.0)]}
+    # ...but the Kelvin root is due south.
+    kelvin_roots = {1: (cx, cy + 15.0)}
+    planner = EscapeCorridorPlanner(grid_4layer, net_pad_positions=npp, kelvin_roots=kelvin_roots)
+    plan = planner.plan(pkg)
+    assert plan.cluster_count == 1
+    cluster = plan.clusters[0]
+    # Escape direction is southward (dy dominant, positive), not eastward.
+    assert cluster.escape_dir[1] > abs(cluster.escape_dir[0])
+    assert cluster.dest_octant == "S"
+
+
+# =============================================================================
+# 6. Default-OFF byte-identity guard (the #4051 rollout convention)
+# =============================================================================
+
+
+def _make_router_with_dense_qfn(*, enable: bool) -> Autorouter:
+    stack = LayerStack.four_layer_all_signal()
+    router = Autorouter(width=BOARD, height=BOARD, layer_stack=stack)
+    router.enable_escape_corridor_reservation = enable
+    pads, npp = make_dense_qfn()
+    comp_pins = [
+        {
+            "number": str(i + 1),
+            "x": p.x,
+            "y": p.y,
+            "net": int(p.net),
+            "net_name": p.net_name,
+        }
+        for i, p in enumerate(pads)
+    ]
+    router.add_component("U3", comp_pins)
+    # Each net's far destination pad on a separate footprint, so nets have
+    # real 2-pad geometry (nonzero RUDY demand at U3 -> the reservation
+    # gate opens) and an off-package destination for the planner to aim at.
+    dest_pins = []
+    for i, p in enumerate(pads):
+        far = npp[int(p.net)][1]
+        dest_pins.append(
+            {
+                "number": str(i + 1),
+                "x": far[0],
+                "y": far[1],
+                "net": int(p.net),
+                "net_name": p.net_name,
+            }
+        )
+    router.add_component("DST", dest_pins)
+    return router
+
+
+def test_autorouter_flag_defaults_off() -> None:
+    router = Autorouter(width=BOARD, height=BOARD)
+    assert router.enable_escape_corridor_reservation is False
+    assert router._escape_corridor_plans == []
+    # The lazily-built escape router mirrors the OFF state and carries no
+    # reserved plans -> nothing to consume.
+    assert router._escape.enable_escape_corridor_reservation is False
+    assert router._escape.escape_corridor_plans == []
+
+
+def _stub_heavy_escape(router: Autorouter, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub the escape pre-phase's A*-heavy sub-steps so a test can exercise
+    the (cheap) corridor-reservation gate without routing real escapes."""
+    monkeypatch.setattr(router, "_run_subgrid_prepass", lambda: [])
+    monkeypatch.setattr(router, "generate_escape_routes", lambda pkgs: [])
+    monkeypatch.setattr(router, "_build_pad_channel_budgets", lambda pkgs: [])
+
+
+def test_flag_off_reserves_nothing_flag_on_reserves(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default-OFF byte-identity: with the flag absent the escape pre-phase
+    reserves zero corridor cells; with it on, corridors are reserved."""
+    off = _make_router_with_dense_qfn(enable=False)
+    _stub_heavy_escape(off, monkeypatch)
+    off._run_escape_prephase()
+    assert off._escape_corridor_plans == []
+    assert not off.grid._reserved_for_nets
+
+    on = _make_router_with_dense_qfn(enable=True)
+    _stub_heavy_escape(on, monkeypatch)
+    on._run_escape_prephase()
+    # The planner ran and produced at least one plan; reservation is advisory
+    # so cells are reserved when the dense QFN clusters resolve.
+    assert on._escape_corridor_plans
+    total = sum(p.total_reserved_cells for p in on._escape_corridor_plans)
+    assert total > 0
+    assert on.grid._reserved_for_nets
+
+
+def test_escape_router_threads_flag_and_plans(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    on = _make_router_with_dense_qfn(enable=True)
+    _stub_heavy_escape(on, monkeypatch)
+    on._run_escape_prephase()
+    # The escape router built for the run sees the flag ON and the plans.
+    assert on._escape.enable_escape_corridor_reservation is True
+    assert on._escape.escape_corridor_plans is on._escape_corridor_plans


### PR DESCRIPTION
## Summary

Phase 4 of epic #4410. Adds a generic, congestion-aware escape-corridor reservation planner for dense high-pin-count parts (any congested QFN/BGA/HTSSOP). Before the general multi-net negotiation, the escape pre-phase can cluster a dense part's pins, size a reserved channel per cluster from `CongestionEstimator` demand, assign clusters to distinct layers, and SOFT-reserve the corridor cells — so a congested cluster gets a reserved escape channel instead of losing the negotiation greedily.

Shipped **default-OFF everywhere** behind `--escape-corridor-reservation`, per the #4051 rollout convention. **With the flag absent, routing output is byte-identical to pre-change main** (the planner is never constructed and no cells are reserved). **No board opts in** — see "Board-05 opt-in removed" below.

## Changes

- **`router/escape_corridor.py` (new)** — `EscapeCorridorPlanner` + `EscapeCluster` / `EscapeCorridorPlan`:
  1. *Cluster* pins by `(nearest bbox face, escape octant)`. Destination geometry is the **post-Kelvin** topology (#4499): an ISENSE tap's destination is its shunt/root pad (`kelvin_roots`), not the raw net centroid.
  2. *Size* each corridor to demand — lateral half-width grows with pin count **and** local `CongestionEstimator` demand (higher demand ⇒ strictly wider channel).
  3. *Assign layers* — highest-demand clusters first, round-robin over routable layers (inner-first); degrades gracefully on a 2-layer board.
  4. *Reserve* via `RoutingGrid.reserve_corridor_cells(..., soft=True)` — attractor-only, so a long channel never fences unrelated nets out (#4087 hazard).
- **`router/core.py`** — `Autorouter.enable_escape_corridor_reservation` flag (default False) + `_reserve_escape_corridors()`, invoked in `_run_escape_prephase` after dense-package detection and before escape generation, reusing `_ensure_congestion_estimator` (advisory: any failure degrades to no reservation). Builds the board-wide net→pad map and Kelvin roots (gated on `detect_kelvin_topology`).
- **`router/escape.py`** — `EscapeRouter` carries `enable_escape_corridor_reservation` + `escape_corridor_plans`, threaded from `_escape()`, so it consumes the reserved channels (which live on the shared grid).
- **`cli/parser.py`, `cli/route_cmd.py`, `cli/commands/routing.py`** — `--escape-corridor-reservation` in both route parsers + `_apply_escape_corridor_reservation` + forwarder, mirroring `--cross-package-pair-corridor` / `--slack-corridor-widening`.
- **`tests/router/test_escape_corridor.py` (new)** — 12 tests on a synthetic dense-QFN fixture.

## Board-05 opt-in removed (judge exit path (a))

An earlier revision of this PR opted `boards/05-bldc-motor-controller/design.py` into the flag. **That opt-in has been removed** (commit `revert(board-05): drop --escape-corridor-reservation opt-in`), and `design.py` is now byte-identical to main.

Reason: the Board 05 Routing Regression CI gate (`--max-blocking 11`) failed reproducibly with the opt-in — `blocking_incomplete_count = 13` on two runs across a rebase, versus **11 on main** measured on the same runner. The PR's blocking set was a strict superset of main's, plus `HALL_A` and `PWM_BL`.

Root cause (judge diagnosis): on board-05 the planner reserves far too broadly — `min_reserve_demand` defaults to `0.0` so the "uncongested face is a no-op" guard never engages (U3 9/9 and U10 11/11 clusters reserved), and `_size_corridor` falls back to the full destination distance because `max_corridor_length_mm` is never set. The result is ~25.9k near-uniform SOFT attractor cells across all four routable layers: no discriminating signal, and unrelated nets get pulled into the congested band.

**No `--max-blocking` threshold bump** is proposed here — the floor did not move, and raising the gate would encode a regression as the new baseline (undercutting #3775 / #3766 / #3829).

Planner selectivity (non-zero `min_reserve_demand`) + corridor-length capping (`max_corridor_length_mm`) + re-adding a board-05 opt-in **only** once measured blocking is `<=` main's baseline are tracked as a follow-up: **#4519**.

This PR therefore lands the generic default-OFF machinery only. The planner, CLI wiring, and 12 tests stand on their own merit.

## Scope note (deferred)

Scope item 4 (local grid refinement via `subgrid.py` inside a reserved corridor) is **deferred to a follow-up** — the issue text explicitly allows this ("may be deferred"). Corridor reservation + demand sizing + layer assignment + the default-OFF regression guard (the core ACs) are all implemented.

## Acceptance Criteria Verification

- [x] Generic escape planner reserves per-cluster corridors driven by `CongestionEstimator`, with unit coverage on a synthetic dense-QFN fixture (not board-05-specific).
- [x] **Default-OFF byte-identity** — flag absent ⇒ planner never constructed, zero cells reserved (`test_flag_off_reserves_nothing_flag_on_reserves`, `test_autorouter_flag_defaults_off`). No board recipe enables the flag, so every board's routing output is unchanged.
- [x] Corridor sized to `CongestionEstimator` demand (`test_corridor_sized_to_congestion_demand`).
- [x] Reservation happens as a pre-pass, before negotiation (`test_reservation_populates_grid_before_negotiation`).
- [x] Post-Kelvin destination override (`test_kelvin_root_overrides_destination`).
- [x] Layer distribution on 4-layer; graceful 2-layer degrade; uncongested-face no-op (edge-case tests).
- [ ] board-05 reach delta / rescue-category deltas — **deferred to #4519**. Measured on CI: the opt-in regressed blocking 11 → 13, so it was removed; the opt-in returns only with a measured improvement.

## Test Plan

- `tests/router/test_escape_corridor.py` — 12 passed.
- Regression: `test_cross_package_pair_corridor`, `test_byte_lane_corridor_reservation`, `test_congestion_estimator`, `test_congestion` (69 passed); `test_route_cmd_help_string`, `test_route_cmd_params`, `test_escape_diffpair` (118 passed); escape-router tests (41 passed).
- `ruff check` + `ruff format` clean on all changed files.
- Board 05 Routing Regression CI job expected green again with the opt-in removed (`design.py` identical to main).

Closes #4474
