### PR TITLE
fix(explain): resolve spec reference deterministically by manufacturer

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 4473
-# Branch: feature/issue-4473
+# Issue: 4491
+# Branch: feature/issue-4491
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/src/kicad_tools/explain/__init__.py
+++ b/src/kicad_tools/explain/__init__.py
@@ -65,7 +65,7 @@ from .rationale import (
     record_decision,
     save_decisions,
 )
-from .registry import ExplanationRegistry
+from .registry import DEFAULT_MANUFACTURER, ExplanationRegistry, normalize_manufacturer
 
 if TYPE_CHECKING:
     pass
@@ -165,8 +165,13 @@ def explain(
         explanation, context, current_value, required_value, unit
     )
 
-    # Get primary spec reference
-    spec_ref = explanation.spec_references[0] if explanation.spec_references else None
+    # Resolve the spec reference deterministically. A rule (e.g.
+    # "trace_clearance") can have references from multiple manufacturers
+    # (JLCPCB, OSH Park, ...); pick the one matching context["manufacturer"]
+    # when given, otherwise fall back to the registry's default manufacturer,
+    # and only fall back to positional [0] if neither is present. This must
+    # not depend on registry/YAML load order.
+    spec_ref = _resolve_spec_reference(explanation.spec_references, context.get("manufacturer"))
 
     return ExplanationResult(
         rule=explanation.rule_id,
@@ -382,6 +387,38 @@ def _generate_fix_suggestions(
             )
 
     return suggestions
+
+
+def _resolve_spec_reference(
+    spec_references: list[SpecReference],
+    manufacturer: str | None,
+) -> SpecReference | None:
+    """Deterministically pick the spec reference for a rule.
+
+    Args:
+        spec_references: All spec references registered for the rule (may
+            include one entry per manufacturer, e.g. JLCPCB and OSH Park).
+        manufacturer: Explicit manufacturer requested via context, if any.
+
+    Returns:
+        The matching SpecReference, the registry's default-manufacturer
+        reference, the first reference, or None if the list is empty. The
+        result never depends on registry/YAML load order.
+    """
+    if not spec_references:
+        return None
+
+    if manufacturer:
+        key = normalize_manufacturer(manufacturer)
+        for ref in spec_references:
+            if ref.manufacturer == key:
+                return ref
+
+    for ref in spec_references:
+        if ref.manufacturer == DEFAULT_MANUFACTURER:
+            return ref
+
+    return spec_references[0]
 
 
 def _get_rule_id_from_violation(violation: Any) -> str:

--- a/src/kicad_tools/explain/models.py
+++ b/src/kicad_tools/explain/models.py
@@ -17,12 +17,16 @@ class SpecReference:
         section: Section within the spec (e.g., "PCB Specifications > Minimum Clearance")
         url: URL to the specification document
         version: Version or date of the specification
+        manufacturer: Normalized manufacturer key this reference belongs to
+            (e.g. "jlcpcb", "oshpark"), empty for non-manufacturer references
+            such as interface specs.
     """
 
     name: str
     section: str = ""
     url: str = ""
     version: str = ""
+    manufacturer: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
@@ -31,6 +35,7 @@ class SpecReference:
             "section": self.section,
             "url": self.url,
             "version": self.version,
+            "manufacturer": self.manufacturer,
         }
 
 

--- a/src/kicad_tools/explain/registry.py
+++ b/src/kicad_tools/explain/registry.py
@@ -21,6 +21,23 @@ logger = logging.getLogger(__name__)
 # Default specs directory
 SPECS_DIR = Path(__file__).parent / "specs"
 
+# Default manufacturer used to resolve a rule's *primary* spec reference when
+# the caller doesn't specify one (matches the "jlcpcb" default used
+# throughout the rest of the CLI, e.g. --manufacturer help text).
+DEFAULT_MANUFACTURER = "jlcpcb"
+
+
+def normalize_manufacturer(name: str) -> str:
+    """Normalize a manufacturer name/id to a stable lookup key.
+
+    Args:
+        name: Manufacturer name or id (e.g. "JLCPCB", "OSH Park", "jlcpcb")
+
+    Returns:
+        Lowercase key with whitespace stripped (e.g. "jlcpcb", "oshpark")
+    """
+    return name.lower().replace(" ", "").replace("-", "").replace("_", "")
+
 
 class ExplanationRegistry:
     """Registry of rule explanations.
@@ -152,7 +169,11 @@ class ExplanationRegistry:
             logger.warning("PyYAML not installed, skipping YAML spec loading")
             return
 
-        for yaml_file in specs_dir.glob("*.yaml"):
+        # Sort so load order (and therefore which manufacturer's rule text
+        # "wins" on merge below) is deterministic across OSes/filesystems.
+        # ``Path.glob`` order depends on directory-entry order, which is not
+        # guaranteed and can differ between local runs and CI.
+        for yaml_file in sorted(specs_dir.glob("*.yaml")):
             try:
                 cls._load_yaml_file(yaml_file)
             except Exception as e:
@@ -187,6 +208,7 @@ class ExplanationRegistry:
             data: Parsed YAML data
         """
         manufacturer = data.get("manufacturer", "")
+        manufacturer_key = normalize_manufacturer(manufacturer)
         base_url = data.get("url", "")
         version = data.get("last_updated", "")
 
@@ -197,6 +219,7 @@ class ExplanationRegistry:
                 section=rule_data.get("spec_section", ""),
                 url=base_url,
                 version=version,
+                manufacturer=manufacturer_key,
             )
 
             # Build fix templates from values if available
@@ -208,6 +231,37 @@ class ExplanationRegistry:
                         fix_templates.append(
                             f"For {layer_type.replace('_', ' ')} boards: adjust to {value}"
                         )
+
+            existing = cls._explanations.get(rule_id)
+            if existing is not None:
+                # Multiple manufacturer YAML files may define the same
+                # rule_id (e.g. "trace_clearance" in both jlcpcb.yaml and
+                # oshpark.yaml). Rather than letting the last-loaded file
+                # silently clobber the previous one -- which made
+                # explain()'s choice of "the" spec reference depend on
+                # filesystem iteration order -- merge this manufacturer's
+                # reference into the existing rule's spec_references list so
+                # callers can select deterministically by manufacturer.
+                if any(ref.manufacturer == manufacturer_key for ref in existing.spec_references):
+                    continue
+
+                is_default = manufacturer_key == DEFAULT_MANUFACTURER
+                primary_is_default = bool(existing.spec_references) and (
+                    existing.spec_references[0].manufacturer == DEFAULT_MANUFACTURER
+                )
+                if is_default and not primary_is_default:
+                    # Promote this manufacturer's rule text to primary so the
+                    # "canonical" wording for a rule is always the default
+                    # manufacturer's, regardless of file load order.
+                    existing.title = rule_data.get("title", rule_id)
+                    existing.explanation = rule_data.get("explanation", "").strip()
+                    existing.fix_templates = fix_templates
+                    existing.related_rules = rule_data.get("related_rules", [])
+                    existing.severity = rule_data.get("severity", "error")
+                    existing.spec_references.insert(0, spec_ref)
+                else:
+                    existing.spec_references.append(spec_ref)
+                continue
 
             explanation = RuleExplanation(
                 rule_id=rule_id,

--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -222,10 +222,30 @@ class TestExplainFunction:
             explain("completely_unknown_rule_xyz123")
 
     def test_explain_with_spec_reference(self):
-        """Test that explain results include spec references."""
+        """Test that explain results include spec references.
+
+        "trace_clearance" is defined by multiple manufacturer spec files
+        (JLCPCB, OSH Park), so pin the manufacturer explicitly rather than
+        assuming spec_references[0] happens to be JLCPCB -- that ordering
+        depends on registry load order, not on this test's intent.
+        """
+        result = explain("trace_clearance", context={"manufacturer": "jlcpcb"})
+        assert result.spec_reference is not None
+        assert "JLCPCB" in result.spec_reference.name
+
+    def test_explain_with_spec_reference_default_manufacturer(self):
+        """explain() with no manufacturer in context should resolve
+        deterministically to the registry's default manufacturer (JLCPCB),
+        independent of registry iteration/load order."""
         result = explain("trace_clearance")
         assert result.spec_reference is not None
         assert "JLCPCB" in result.spec_reference.name
+
+    def test_explain_with_spec_reference_other_manufacturer(self):
+        """explain() should honor an explicit non-default manufacturer."""
+        result = explain("trace_clearance", context={"manufacturer": "oshpark"})
+        assert result.spec_reference is not None
+        assert "OSH Park" in result.spec_reference.name
 
 
 class TestExplainNetConstraints:


### PR DESCRIPTION
## Summary

`explain("trace_clearance")` picked `explanation.spec_references[0]`, but the
registry silently let the *last-loaded* manufacturer YAML file
(`jlcpcb.yaml` / `oshpark.yaml`) overwrite an earlier one for the same
`rule_id`, since `ExplanationRegistry._load_manufacturer_spec` did a plain
`cls.register(rule_id, explanation)` with no merge. Which manufacturer
"won" therefore depended on `Path.glob("*.yaml")` filesystem iteration
order, which is not guaranteed to be stable across OSes/filesystems (or
even across repeated `reload()` calls within one process) -- hence
`tests/test_explain.py::TestExplainFunction::test_explain_with_spec_reference`
passing locally (JLCPCB) but failing in CI's full suite (OSH Park).

## Fix

- `registry.py`: when a `rule_id` is defined by more than one manufacturer
  YAML file, **merge** the new manufacturer's `SpecReference` into the
  existing rule's `spec_references` list instead of overwriting the whole
  `RuleExplanation`. The registry's default manufacturer (`jlcpcb`, matching
  the `--manufacturer jlcpcb` default used throughout the CLI) is always
  promoted to the *primary* rule text/spec-reference, regardless of which
  file happened to load first. `specs_dir.glob("*.yaml")` results are also
  sorted for deterministic load order.
- `models.py`: `SpecReference` gains a `manufacturer` key (normalized, e.g.
  `"jlcpcb"`, `"oshpark"`) so references can be looked up by manufacturer.
- `explain/__init__.py`: `explain()` now resolves the spec reference via a
  new `_resolve_spec_reference()` helper -- honors
  `context["manufacturer"]` when given, else falls back to the registry's
  default manufacturer, else falls back to `spec_references[0]` only if
  neither manufacturer key is present (e.g. interface specs that have a
  single reference).
- `tests/test_explain.py`: `test_explain_with_spec_reference` now pins
  `context={"manufacturer": "jlcpcb"}` instead of assuming
  `spec_references[0]` is JLCPCB. Added two more tests: one asserting the
  no-context default resolves to JLCPCB, and one exercising an explicit
  `oshpark` manufacturer to prove the resolution is genuinely
  manufacturer-aware, not just hardcoded.

## Verification

- `uv run pytest tests/test_explain.py -q` -- 41 passed (was previously
  passing in isolation anyway; now also robust).
- `uv run pytest tests/test_router_core.py tests/test_decisions.py tests/test_explain.py tests/test_erc_explain.py -q` --
  268 passed, 4 skipped (the other modules that import `kicad_tools.explain`
  and could leak shared registry state).
- Directly proved order-independence by monkeypatching
  `ExplanationRegistry._load_yaml_specs` to load `oshpark.yaml` before
  `jlcpcb.yaml` (reversed glob order) and confirming `explain("trace_clearance")`
  still resolves to JLCPCB by default, `context={"manufacturer": "oshpark"}`
  resolves to OSH Park, and `context={"manufacturer": "jlcpcb"}` resolves to
  JLCPCB -- regardless of load order.
- `uv run ruff check` / `uv run ruff format --check` on changed files: clean.
- Did not run the full 23k+ test repo suite locally (no C++ router backend
  built in this worktree makes router-heavy tests impractically slow for
  this session); the targeted verification above directly exercises the
  registry-sharing scenario the issue describes.

Closes #4491