### PR TITLE
route/rescue: shell --complete (lattice) for batch completion instead of grid A*

### DIFF
--- a/src/kicad_tools/router/partial_rescue.py
+++ b/src/kicad_tools/router/partial_rescue.py
@@ -45,7 +45,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 __all__ = [
+    "CompletionResult",
     "RescueConfig",
+    "UnroutableLink",
     "all_net_names",
     "build_rescue_command",
     "complete_unfinished_nets",
@@ -53,6 +55,85 @@ __all__ = [
     "strip_net_copper",
     "rescue_partial_nets",
 ]
+
+
+@dataclass
+class UnroutableLink:
+    """One still-unroutable link parsed from a ``--complete-report`` (issue #4478).
+
+    Mirrors the per-link entries emitted by
+    :func:`kicad_tools.cli.route_cmd._build_complete_link_report` so a caller of
+    :func:`complete_unfinished_nets` can tell *why* a completion pass left a
+    link open (closed vs. unroutable-with-blockers) without re-parsing the raw
+    JSON.  ``blocking_copper`` non-empty is the "blocked by non-rippable copper"
+    signal the old grid-engine rescue could only report opaquely.
+    """
+
+    net: str
+    reason: str
+    start: str | None = None
+    end: str | None = None
+    deadline_hit: bool = False
+    blocking_copper: tuple[str, ...] = ()
+    nearest_blocker_mm: float | None = None
+    stuck_classification: str | None = None
+    tier_limit_note: str | None = None
+
+    @classmethod
+    def from_report_entry(cls, entry: dict) -> UnroutableLink:
+        link = entry.get("link") or {}
+        return cls(
+            net=entry.get("net", ""),
+            reason=entry.get("reason", ""),
+            start=link.get("start") if isinstance(link, dict) else None,
+            end=link.get("end") if isinstance(link, dict) else None,
+            deadline_hit=bool(entry.get("deadline_hit", False)),
+            blocking_copper=tuple(entry.get("blocking_copper") or ()),
+            nearest_blocker_mm=entry.get("nearest_blocker_mm"),
+            stuck_classification=entry.get("stuck_classification"),
+            tier_limit_note=entry.get("tier_limit_note"),
+        )
+
+
+@dataclass
+class CompletionResult:
+    """Structured outcome of a batch :func:`complete_unfinished_nets` run (#4478).
+
+    Extends the legacy ``list[(before, after)]`` progress history with the
+    Phase-4 per-link report so rescue outcomes (closed vs. unroutable-with-
+    blockers) propagate to callers instead of being discarded with the
+    subprocess output.  ``bool(result)`` and iteration/len forward to
+    :attr:`history` so existing call sites that treated the return as the
+    progress list keep working.
+    """
+
+    #: (unfinished_before, unfinished_after) per executed pass -- the legacy
+    #: history shape.
+    history: list[tuple[int, int]] = field(default_factory=list)
+    #: Links still unroutable after the final executed pass, parsed from that
+    #: pass's ``--complete-report``.  Empty when every link closed (or when no
+    #: report was produced -- a pass that closed everything writes none).
+    unroutable_links: list[UnroutableLink] = field(default_factory=list)
+
+    def __iter__(self):
+        return iter(self.history)
+
+    def __len__(self) -> int:
+        return len(self.history)
+
+    def __getitem__(self, index):
+        return self.history[index]
+
+    def __bool__(self) -> bool:
+        return bool(self.history)
+
+    def __eq__(self, other: object) -> bool:
+        # Backward-compat: allow ``result == [(2, 1), (1, 0)]`` comparisons.
+        if isinstance(other, list):
+            return self.history == other
+        if isinstance(other, CompletionResult):
+            return self.history == other.history and self.unroutable_links == other.unroutable_links
+        return NotImplemented
 
 
 @dataclass
@@ -210,8 +291,37 @@ def build_rescue_command(
     output_path: Path,
     skip_nets: list[str],
     config: RescueConfig,
+    *,
+    complete: bool = False,
+    complete_report: Path | None = None,
 ) -> list[str]:
-    """Build the ``kct route`` argv for one single-net rescue stage."""
+    """Build the ``kct route`` argv for one rescue/completion stage.
+
+    Two shapes, selected by *complete* (issue #4478, epic #4465 Phase 5):
+
+    * ``complete=False`` (default, single-net rescue path unchanged): route
+      one net against every OTHER net's preserved copper by naming the others
+      in ``--skip-nets``.  This shells the coarse uniform-grid A* via
+      ``--auto-layers`` -- the legacy rescue mechanism (#3471).
+
+    * ``complete=True`` (batch completion, walled-pocket case): shell
+      ``kct route --complete`` instead.  ``--complete`` auto-detects the
+      currently-unconnected signal nets (the SAME
+      :func:`partially_connected_signal_nets` detector the caller uses, so the
+      target sets agree by construction) and routes ONLY those links on the
+      lattice engine against all other copper held fixed -- the engine that can
+      thread a walled pocket / place a via-in-pad, which the grid A* cannot.
+
+    ``--complete`` is mutually exclusive with ``--skip-nets`` / ``--nets``
+    (``route_cmd._resolve_complete_nets`` hard-errors exit 2), so the
+    completion shape drops the skip-list entirely and relies on ``--complete``'s
+    auto-detection.  ``--complete`` also already implies ``--preserve-existing``
+    and disables ``--auto-layers`` unless explicitly passed, so the completion
+    shape omits ``--auto-layers`` (completion routes within the committed layer
+    stack -- issue #4477).  When *complete_report* is given, the structured
+    per-link JSON report (issue #4477 Phase 4) is written there for the caller
+    to consume.
+    """
     cmd = [
         sys.executable,
         "-m",
@@ -221,14 +331,23 @@ def build_rescue_command(
         "--output",
         str(output_path),
         "--preserve-existing",
-        "--auto-layers",
-        "--starting-layers",
-        str(config.starting_layers),
-        "--max-layers",
-        str(config.max_layers),
-        "--manufacturer",
-        config.manufacturer,
     ]
+    if not complete:
+        # Grid-engine rescue shape: whole-board layer escalation is fine here
+        # because a single net is being routed against everything else fixed.
+        # --complete deliberately OMITS --auto-layers (it disables it anyway)
+        # so completion stays within the committed layer stack (#4477).
+        cmd.append("--auto-layers")
+    cmd.extend(
+        [
+            "--starting-layers",
+            str(config.starting_layers),
+            "--max-layers",
+            str(config.max_layers),
+            "--manufacturer",
+            config.manufacturer,
+        ]
+    )
     if config.micro_via_in_pad_fallback:
         cmd.append("--micro-via-in-pad-fallback")
     cmd.extend(
@@ -249,14 +368,41 @@ def build_rescue_command(
         cmd.append("--deterministic-budget")
     else:
         cmd.extend(["--per-net-timeout", str(config.per_net_timeout_s)])
-    cmd.extend(
-        [
-            "--skip-nets",
-            ",".join(skip_nets),
-        ]
-    )
+    if complete:
+        # #4478: --complete self-selects the stranded nets; a skip/nets list
+        # would trip the mutual-exclusivity guard.  Never emit one here.
+        cmd.append("--complete")
+        if complete_report is not None:
+            cmd.extend(["--complete-report", str(complete_report)])
+    else:
+        cmd.extend(
+            [
+                "--skip-nets",
+                ",".join(skip_nets),
+            ]
+        )
     cmd.extend(config.extra_args)
     return cmd
+
+
+def _parse_complete_report(report_path: Path) -> list[UnroutableLink]:
+    """Parse a ``--complete-report`` JSON into :class:`UnroutableLink` records.
+
+    Returns an empty list when the file is absent (the CLI only writes it when
+    a link stays unroutable) or malformed -- a diagnostic report must never
+    break the completion loop it is reporting on.
+    """
+    if not report_path.exists():
+        return []
+    try:
+        data = json.loads(report_path.read_text())
+    except (json.JSONDecodeError, ValueError, OSError):
+        return []
+    return [
+        UnroutableLink.from_report_entry(entry)
+        for entry in data.get("unroutable_links", [])
+        if isinstance(entry, dict)
+    ]
 
 
 def complete_unfinished_nets(
@@ -266,7 +412,7 @@ def complete_unfinished_nets(
     max_passes: int = 3,
     pass_timeout_s: int = 600,
     quiet: bool = False,
-) -> list[tuple[int, int]]:
+) -> CompletionResult:
     """Batch completion passes: route ALL unfinished nets together.
 
     The single-net rescue loop (:func:`rescue_partial_nets`) fails on
@@ -278,6 +424,16 @@ def complete_unfinished_nets(
     ``--preserve-existing`` pass keeps negotiation alive among the
     unfinished cohort while still protecting the finished nets' copper.
 
+    Issue #4478 (epic #4465 Phase 5): each pass now shells
+    ``kct route --complete`` instead of the coarse grid-engine
+    ``--skip-nets`` shape.  ``--complete`` routes the stranded links on the
+    LATTICE engine -- the only engine that can thread a walled SMD pocket or
+    place a last-resort via-in-pad (Phase 3, #4475) -- so a completion pass can
+    finally close the walled pads the grid A* traded 1:1 forever (#4434).  The
+    per-link ``--complete-report`` (Phase 4, #4477) is captured and surfaced on
+    the returned :class:`CompletionResult` so callers see *why* a link stayed
+    open (closed vs. unroutable-with-blockers).
+
     This also fixes the budget shape of the escalation ladder: each
     ladder attempt re-routes the whole board from scratch and times out
     mid-queue, re-spending its stage budget on the same head-of-queue
@@ -288,9 +444,11 @@ def complete_unfinished_nets(
 
     1. Detects unfinished signal nets (checker-based, partial AND
        unrouted, pour nets excluded).
-    2. Strips their stranded copper (the #3470 overlap-stub lesson).
-    3. Routes them together against the preserved copper of everything
-       else (fresh ``kct route`` subprocess, same recipe knobs).
+    2. Strips their stranded copper (the #3470 overlap-stub lesson) -- which
+       also makes ``--complete``'s own auto-detection (the SAME detector) name
+       exactly this cohort.
+    3. Routes them together via ``kct route --complete`` against the preserved
+       copper of everything else (fresh subprocess, same recipe knobs).
     4. Keeps the result only if the unfinished count went DOWN;
        otherwise restores the pre-pass board byte-for-byte and stops.
 
@@ -304,8 +462,9 @@ def complete_unfinished_nets(
         quiet: Suppress progress prints.
 
     Returns:
-        List of ``(unfinished_before, unfinished_after)`` tuples, one
-        per executed pass.
+        A :class:`CompletionResult` carrying the ``(before, after)`` progress
+        history (list-compatible for legacy callers) and the per-link
+        unroutable-link report from the final executed pass.
     """
     import shutil
 
@@ -314,10 +473,10 @@ def complete_unfinished_nets(
             print(msg, flush=True)
 
     _log("\n" + "=" * 60)
-    _log("Completion passes for unfinished nets (Issue #3474 R2)...")
+    _log("Completion passes for unfinished nets (Issue #3474 R2 / #4478)...")
     _log("=" * 60)
 
-    history: list[tuple[int, int]] = []
+    result = CompletionResult()
     for pass_index in range(max_passes):
         targets = partially_connected_signal_nets(
             routed_path,
@@ -339,8 +498,9 @@ def complete_unfinished_nets(
         stripped = strip_net_copper(routed_path, targets)
         _log(f"   Stripped {stripped} stale copper block(s)")
 
-        skip = [n for n in all_net_names(routed_path) if n not in set(targets)]
         tmp_out = routed_path.with_name(routed_path.stem + "_completion.kicad_pcb")
+        report_path = routed_path.with_name(routed_path.stem + "_complete_report.json")
+        report_path.unlink(missing_ok=True)
         pass_config = RescueConfig(
             manufacturer=config.manufacturer,
             backend=config.backend,
@@ -354,8 +514,25 @@ def complete_unfinished_nets(
             micro_via_in_pad_fallback=config.micro_via_in_pad_fallback,
             extra_args=config.extra_args,
         )
-        cmd = build_rescue_command(routed_path, tmp_out, skip, pass_config)
+        # Issue #4478: shell ``kct route --complete`` (lattice engine) rather
+        # than the grid-engine ``--skip-nets`` shape.  --complete self-selects
+        # the stranded nets (same detector as ``targets`` above), so NO skip
+        # list is passed (it would trip the mutual-exclusivity guard).
+        cmd = build_rescue_command(
+            routed_path,
+            tmp_out,
+            [],
+            pass_config,
+            complete=True,
+            complete_report=report_path,
+        )
         subprocess.run(cmd, capture_output=True, text=True)
+
+        # Capture the per-link report BEFORE promoting/cleaning up.  A pass
+        # that closed every link writes no report (empty list); a pass that
+        # left a walled pad open writes one with blocking_copper populated.
+        pass_links = _parse_complete_report(report_path)
+        report_path.unlink(missing_ok=True)
 
         if not tmp_out.exists():
             _log("   Pass produced no output; restoring pre-pass board.")
@@ -376,11 +553,28 @@ def complete_unfinished_nets(
             excluded_nets=config.excluded_nets,
             include_unrouted=True,
         )
-        history.append((len(targets), len(remaining)))
+        result.history.append((len(targets), len(remaining)))
+        result.unroutable_links = pass_links
         _log(
             f"   Pass {pass_index + 1} result: {len(targets)} -> {len(remaining)} unfinished net(s)"
         )
+        if pass_links:
+            _log(
+                f"   {len(pass_links)} link(s) still unroutable: "
+                + ", ".join(
+                    f"{lk.net}"
+                    + (
+                        f" (blocked by {', '.join(lk.blocking_copper)})"
+                        if lk.blocking_copper
+                        else ""
+                    )
+                    for lk in pass_links
+                )
+            )
 
+        # Issue #4478 / AC item 4: a ``--complete`` pass that closed some but
+        # not all links still makes progress (count went down) and is kept;
+        # only a pass that did NOT reduce the unfinished count is discarded.
         if len(remaining) >= len(targets):
             _log("   No progress; restoring pre-pass board and stopping.")
             shutil.copyfile(backup, routed_path)
@@ -391,7 +585,7 @@ def complete_unfinished_nets(
         if not remaining:
             break
 
-    return history
+    return result
 
 
 def rescue_partial_nets(

--- a/tests/router/test_partial_rescue.py
+++ b/tests/router/test_partial_rescue.py
@@ -9,10 +9,13 @@ per-stage ``kct route`` command construction.
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 from kicad_tools.router.partial_rescue import (
+    CompletionResult,
     RescueConfig,
+    UnroutableLink,
     all_net_names,
     build_rescue_command,
     complete_unfinished_nets,
@@ -254,6 +257,143 @@ def test_build_rescue_command_deterministic_budget_replaces_per_net_timeout(
     assert "--preserve-existing" in cmd
 
 
+# ---------------------------------------------------------------------------
+# build_rescue_command completion shape (issue #4478, epic #4465 Phase 5)
+# ---------------------------------------------------------------------------
+
+
+def test_build_rescue_command_complete_shape(tmp_path: Path) -> None:
+    """complete=True shells ``kct route --complete`` -- NOT the grid-engine shape.
+
+    The completion shape must (a) emit ``--complete``, (b) NOT emit
+    ``--skip-nets``/``--nets`` (which trip the mutual-exclusivity guard,
+    route_cmd.py:8805), and (c) NOT emit ``--auto-layers`` (completion routes
+    within the committed layer stack -- issue #4477).
+    """
+    report = tmp_path / "report.json"
+    cmd = build_rescue_command(
+        tmp_path / "routed.kicad_pcb",
+        tmp_path / "out.kicad_pcb",
+        # A skip list is passed but MUST be ignored in complete mode.
+        ["SCL", "NRST"],
+        RescueConfig(manufacturer="jlcpcb-tier1", seed=7, stage_timeout_s=600),
+        complete=True,
+        complete_report=report,
+    )
+    assert "--complete" in cmd
+    # Mutual-exclusivity guard (route_cmd.py:8805): never combine --complete
+    # with a hand-enumerated net set.
+    assert "--skip-nets" not in cmd
+    assert "--nets" not in cmd
+    # Completion works within the committed layer stack (#4477): no whole-board
+    # layer escalation.
+    assert "--auto-layers" not in cmd
+    # --preserve-existing is still present (harmless: --complete implies it).
+    assert "--preserve-existing" in cmd
+    # The Phase 4 structured report is requested at the given path.
+    assert cmd[cmd.index("--complete-report") + 1] == str(report)
+    # Recipe knobs still flow through.
+    assert cmd[cmd.index("--manufacturer") + 1] == "jlcpcb-tier1"
+    assert cmd[cmd.index("--seed") + 1] == "7"
+    assert cmd[cmd.index("--timeout") + 1] == "600"
+
+
+def test_build_rescue_command_complete_omits_report_when_none(tmp_path: Path) -> None:
+    cmd = build_rescue_command(
+        tmp_path / "a.kicad_pcb",
+        tmp_path / "b.kicad_pcb",
+        [],
+        RescueConfig(),
+        complete=True,
+    )
+    assert "--complete" in cmd
+    assert "--complete-report" not in cmd
+
+
+def test_build_rescue_command_default_is_grid_rescue_shape(tmp_path: Path) -> None:
+    """complete defaults False: the single-net rescue shape is byte-unchanged."""
+    cmd = build_rescue_command(
+        tmp_path / "a.kicad_pcb",
+        tmp_path / "b.kicad_pcb",
+        ["X", "Y"],
+        RescueConfig(),
+    )
+    assert "--complete" not in cmd
+    assert "--complete-report" not in cmd
+    assert "--auto-layers" in cmd
+    assert cmd[cmd.index("--skip-nets") + 1] == "X,Y"
+
+
+def test_build_rescue_command_golden_argv_unchanged(tmp_path: Path) -> None:
+    """AC item 4: the default (single-net rescue) argv is byte-identical to the
+    pre-#4478 shape -- boards that never hit the completion path are unaffected."""
+    routed = tmp_path / "routed.kicad_pcb"
+    out = tmp_path / "routed_rescue.kicad_pcb"
+    cmd = build_rescue_command(
+        routed,
+        out,
+        ["SCL", "NRST"],
+        RescueConfig(
+            manufacturer="jlcpcb-tier1",
+            backend="cpp",
+            seed=42,
+            stage_timeout_s=300,
+            per_net_timeout_s=60,
+            starting_layers=4,
+            max_layers=4,
+            micro_via_in_pad_fallback=True,
+        ),
+    )
+    assert cmd == [
+        sys.executable,
+        "-m",
+        "kicad_tools.cli",
+        "route",
+        str(routed),
+        "--output",
+        str(out),
+        "--preserve-existing",
+        "--auto-layers",
+        "--starting-layers",
+        "4",
+        "--max-layers",
+        "4",
+        "--manufacturer",
+        "jlcpcb-tier1",
+        "--micro-via-in-pad-fallback",
+        "--backend",
+        "cpp",
+        "--seed",
+        "42",
+        "--timeout",
+        "300",
+        "--per-net-timeout",
+        "60",
+        "--skip-nets",
+        "SCL,NRST",
+    ]
+
+
+def test_unroutable_link_from_report_entry() -> None:
+    entry = {
+        "net": "/OC_TRIP_N",
+        "reason": "no-path",
+        "link": {"start": "U1-3", "end": "R4-1"},
+        "deadline_hit": False,
+        "blocking_copper": ["/V_BUS", "/GND"],
+        "nearest_blocker_mm": 0.1234,
+        "stuck_classification": "walled",
+        "tier_limit_note": "manufacturer 'x' does not support via-in-pad",
+    }
+    lk = UnroutableLink.from_report_entry(entry)
+    assert lk.net == "/OC_TRIP_N"
+    assert lk.reason == "no-path"
+    assert lk.start == "U1-3" and lk.end == "R4-1"
+    assert lk.blocking_copper == ("/V_BUS", "/GND")
+    assert lk.nearest_blocker_mm == 0.1234
+    assert lk.stuck_classification == "walled"
+
+
 def test_rescue_failed_stage_strips_stubs(tmp_path: Path, monkeypatch) -> None:
     """A failed rescue must leave the target net with NO copper (#3470)."""
     pcb = _write_pcb(tmp_path)
@@ -406,3 +546,128 @@ def test_completion_no_progress_restores_backup(tmp_path: Path, monkeypatch) -> 
     # copper back).
     assert pcb.read_text() == original
     assert not list(tmp_path.glob("*_prepass*"))
+
+
+# ---------------------------------------------------------------------------
+# complete_unfinished_nets: --complete rewiring + report propagation (#4478)
+# ---------------------------------------------------------------------------
+
+
+def test_completion_shells_complete_not_skip_nets(tmp_path: Path, monkeypatch) -> None:
+    """Every completion subprocess must use ``--complete`` and NO skip list (#4478).
+
+    This is the core of the rewiring: the completion driver no longer shells
+    the coarse grid engine via ``--skip-nets``; it shells ``kct route
+    --complete`` (lattice engine).  The mutual-exclusivity guard
+    (route_cmd.py:8805) means the argv must never combine ``--complete`` with
+    ``--skip-nets``/``--nets``.
+    """
+    pcb = _write_pcb(tmp_path)
+    captured: list[list[str]] = []
+
+    detections = iter([["SDA"], []])
+    monkeypatch.setattr(
+        "kicad_tools.router.partial_rescue.partially_connected_signal_nets",
+        lambda *a, **k: next(detections),
+    )
+
+    def _fake_run(cmd, **kwargs):
+        captured.append(list(cmd))
+
+        class _Result:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        out = Path(cmd[cmd.index("--output") + 1])
+        out.write_text(Path(cmd[4]).read_text())
+        return _Result()
+
+    monkeypatch.setattr("kicad_tools.router.partial_rescue.subprocess.run", _fake_run)
+
+    complete_unfinished_nets(pcb, RescueConfig(), max_passes=3, quiet=True)
+
+    assert captured, "a completion subprocess should have been launched"
+    for cmd in captured:
+        assert "--complete" in cmd
+        # The mutual-exclusivity guard must never be tripped from this path.
+        assert "--skip-nets" not in cmd
+        assert "--nets" not in cmd
+        assert "--complete-report" in cmd
+
+
+def test_completion_report_propagates_unroutable_links(tmp_path: Path, monkeypatch) -> None:
+    """A pass that leaves a link open surfaces the per-link report to the caller.
+
+    The fake ``kct route --complete`` writes a Phase-4 ``--complete-report``
+    naming one still-unroutable link with blocking copper.  The returned
+    :class:`CompletionResult` must expose it (closed vs. unroutable-with-
+    blockers propagation, AC item 3).
+    """
+    pcb = _write_pcb(tmp_path)
+
+    # Pass 1: two unfinished -> one remains (progress, kept).  Pass 2 detects
+    # the single remainder is unchanged from a prior detection so the loop
+    # would continue, but we stop it by reporting no further progress.
+    detections = iter([["SCL", "SDA"], ["SDA"], ["SDA"], ["SDA"]])
+    monkeypatch.setattr(
+        "kicad_tools.router.partial_rescue.partially_connected_signal_nets",
+        lambda *a, **k: next(detections),
+    )
+
+    def _fake_run(cmd, **kwargs):
+        class _Result:
+            returncode = 8  # --complete: one or more links remain unroutable
+            stdout = ""
+            stderr = ""
+
+        # Land SCL's copper (net 2) so the unfinished count drops 2 -> 1.
+        src = Path(cmd[4]).read_text()
+        out = Path(cmd[cmd.index("--output") + 1])
+        marker = "\t(segment\n\t\t(start 7 7)\n\t\t(net 2)\n\t)\n"
+        out.write_text(src.replace("(kicad_pcb\n", "(kicad_pcb\n" + marker, 1))
+        # Emit the structured Phase-4 report for the still-open SDA link.
+        report = Path(cmd[cmd.index("--complete-report") + 1])
+        report.write_text(
+            json.dumps(
+                {
+                    "unroutable_links": [
+                        {
+                            "net": "SDA",
+                            "reason": "no-path",
+                            "link": {"start": "U1-1", "end": "U2-1"},
+                            "deadline_hit": False,
+                            "blocking_copper": ["SCL"],
+                            "nearest_blocker_mm": 0.15,
+                            "stuck_classification": "walled",
+                        }
+                    ]
+                }
+            )
+        )
+        return _Result()
+
+    monkeypatch.setattr("kicad_tools.router.partial_rescue.subprocess.run", _fake_run)
+
+    result = complete_unfinished_nets(pcb, RescueConfig(), max_passes=1, quiet=True)
+
+    assert isinstance(result, CompletionResult)
+    assert result.history == [(2, 1)]
+    assert len(result.unroutable_links) == 1
+    link = result.unroutable_links[0]
+    assert link.net == "SDA"
+    assert link.blocking_copper == ("SCL",)  # non-empty -> "blocked by copper"
+    assert link.stuck_classification == "walled"
+    # No report side-file left behind.
+    assert not list(tmp_path.glob("*_complete_report*"))
+
+
+def test_completion_result_is_list_compatible() -> None:
+    """CompletionResult forwards list ops so legacy ``== [...]`` callers work."""
+    r = CompletionResult(history=[(2, 1), (1, 0)])
+    assert r == [(2, 1), (1, 0)]
+    assert len(r) == 2
+    assert list(r) == [(2, 1), (1, 0)]
+    assert r[0] == (2, 1)
+    assert bool(r) is True
+    assert bool(CompletionResult()) is False

--- a/tests/test_cli_route_complete_walled_4478.py
+++ b/tests/test_cli_route_complete_walled_4478.py
@@ -1,0 +1,215 @@
+"""Walled-SMD completion proof for the rescue rewiring (Issue #4478, epic #4465).
+
+Phase 5 points the completion/rescue driver at ``kct route --complete`` (the
+lattice engine) instead of the coarse uniform-grid A* it used to shell via
+``--skip-nets`` (gap G2).  The grid engine cannot thread a walled SMD pocket or
+place a via-in-pad, so ``#4434``'s batch route traded stranded walled pads 1:1
+forever.  This module is the end-to-end proof of the mechanism the rewiring
+unlocks (AC item 3):
+
+* a deliberately **walled** SMD pad the GRID engine cannot close,
+* the same pad closed by ``--complete`` (lattice) **only** on a fab tier that
+  supports via-in-pad (``jlcpcb-tier1``) -- a tier without it (plain ``jlcpcb``)
+  leaves the pad open rather than fabricating an unmanufacturable via,
+* and the ``#4413`` ``guard_copper_loss`` invariant: an unrelated net's
+  pre-existing copper is never deleted by the completion pass, even when the
+  walled link fails to close.
+
+Fixture geometry mirrors the Phase 3 pathfinder fixture
+(``tests/router/lattice/test_via_in_pad_last_resort.py``) lifted to a real
+``.kicad_pcb``: pad ``A`` (NET_A) on F.Cu is ringed by four single-pad wall
+nets on F.Cu with a 0.7 mm gap, leaving a via-in-pad straight down to pad ``B``
+(NET_A) on B.Cu as the only escape.  NET_KEEP is an unrelated,
+already-routed net whose segment must survive every pass untouched.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.route_cmd import main as route_main
+
+# Pad A center; the walls box it on F.Cu.
+_CX, _CY = 100.0, 100.0
+# Ring standoff / thickness / length -- the Phase 3 fixture's tuned geometry.
+_D, _WW, _WL = 0.7, 1.0, 3.0
+# NET_KEEP's pre-existing segment endpoints (unrelated to the walled pocket).
+# Written on one line on input; KiCad re-serializes it multi-line on output, so
+# tests probe for a surviving *net-6 segment* rather than this literal string.
+_KEEP_SEG = '(segment (start 106 105) (end 108 105) (width 0.2) (layer "F.Cu") (net 6))'
+
+
+def _net6_segment_preserved(text: str) -> bool:
+    """True iff exactly one NET_KEEP (net 6) segment survives the pass.
+
+    guard_copper_loss (#4413): the pre-existing unrelated segment must be
+    re-emitted (never deleted), and no new net-6 copper is fabricated.
+    """
+    return _seg_nets(text).count(6) == 1
+
+
+def _pad(ref: str, x: float, y: float, w: float, h: float, net: int, name: str, layer: str) -> str:
+    mask = "F.Paste F.Mask" if layer == "F.Cu" else "B.Paste B.Mask"
+    fp_layer = "F.Cu" if layer == "F.Cu" else "B.Cu"
+    return f"""  (footprint "test:P" (layer "{fp_layer}") (uuid "{ref}") (at {x} {y})
+    (property "Reference" "{ref}" (at 0 -2 0) (layer "F.SilkS"))
+    (property "Value" "v" (at 0 2 0) (layer "F.Fab"))
+    (pad "1" smd rect (at 0 0) (size {w} {h}) (layers "{layer}" "{mask}") (net {net} "{name}"))
+  )"""
+
+
+def _walled_board() -> str:
+    parts = [
+        _pad("U1", _CX, _CY, 0.3, 0.3, 1, "NET_A", "F.Cu"),
+        _pad("U2", _CX + 5, _CY, 0.3, 0.3, 1, "NET_A", "B.Cu"),
+        _pad("WR", _CX + _D + _WW / 2, _CY, _WW, _WL, 2, "WALL_R", "F.Cu"),
+        _pad("WL", _CX - _D - _WW / 2, _CY, _WW, _WL, 3, "WALL_L", "F.Cu"),
+        _pad("WT", _CX, _CY + _D + _WW / 2, _WL, _WW, 4, "WALL_T", "F.Cu"),
+        _pad("WB", _CX, _CY - _D - _WW / 2, _WL, _WW, 5, "WALL_B", "F.Cu"),
+        # NET_KEEP: an unrelated, already-routed net (guard_copper_loss probe).
+        _pad("K1", 106.0, 105.0, 0.3, 0.3, 6, "NET_KEEP", "F.Cu"),
+        _pad("K2", 108.0, 105.0, 0.3, 0.3, 6, "NET_KEEP", "F.Cu"),
+    ]
+    return f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "NET_A")
+  (net 2 "WALL_R")
+  (net 3 "WALL_L")
+  (net 4 "WALL_T")
+  (net 5 "WALL_B")
+  (net 6 "NET_KEEP")
+  (gr_rect (start 90 90) (end 115 110)
+    (stroke (width 0.1) (type default)) (fill none) (layer "Edge.Cuts"))
+{chr(10).join(parts)}
+  {_KEEP_SEG}
+)
+"""
+
+
+def _seg_nets(text: str) -> list[int]:
+    return [int(m.group(1)) for m in re.finditer(r"\(segment.*?\(net (\d+)\)", text, re.S)]
+
+
+def _via_nets(text: str) -> list[int]:
+    return [int(m.group(1)) for m in re.finditer(r"\(via.*?\(net (\d+)\)", text, re.S)]
+
+
+def _net1_via_in_pad(text: str) -> bool:
+    """True iff a NET_A (net 1) via sits inside pad A's footprint (a via-in-pad)."""
+    for m in re.finditer(r"\(via[^)]*?\(at ([-\d.]+) ([-\d.]+)\)(?:.*?)?\(net (\d+)\)", text, re.S):
+        vx, vy, net = float(m.group(1)), float(m.group(2)), int(m.group(3))
+        if net == 1 and abs(vx - _CX) <= 0.5 and abs(vy - _CY) <= 0.5:
+            return True
+    return False
+
+
+@pytest.fixture
+def walled_board(tmp_path: Path) -> Path:
+    board = tmp_path / "walled.kicad_pcb"
+    board.write_text(_walled_board())
+    return board
+
+
+def test_grid_engine_cannot_close_walled_pad(walled_board: Path, tmp_path: Path) -> None:
+    """Baseline: the coarse uniform-grid A* the old rescue shelled cannot close
+    the walled pad -- the exact failure mode #4478 fixes."""
+    out = tmp_path / "grid.kicad_pcb"
+    rc = route_main(
+        [
+            str(walled_board),
+            "-o",
+            str(out),
+            "--route-engine",
+            "grid",
+            "--nets",
+            "NET_A",
+            "--preserve-existing",
+            "--manufacturer",
+            "jlcpcb-tier1",
+            "--backend",
+            "cpp",
+        ]
+    )
+    assert out.exists()
+    # The grid engine lands NO copper for NET_A: the pad stays stranded.
+    assert 1 not in _seg_nets(out.read_text())
+    assert 1 not in _via_nets(out.read_text())
+    # And it did not return the clean-success code.
+    assert rc != 0
+
+
+def test_complete_closes_walled_pad_via_via_in_pad_on_supporting_tier(
+    walled_board: Path, tmp_path: Path
+) -> None:
+    """``--complete`` (lattice) closes the walled pad the grid engine could not,
+    using a via-in-pad, on a via-in-pad-capable tier -- AND preserves the
+    unrelated NET_KEEP copper (#4413 guard_copper_loss)."""
+    out = tmp_path / "complete_tier1.kicad_pcb"
+    rc = route_main(
+        [
+            str(walled_board),
+            "-o",
+            str(out),
+            "--complete",
+            "--via-in-pad-last-resort",
+            "--manufacturer",
+            "jlcpcb-tier1",
+            "--backend",
+            "cpp",
+        ]
+    )
+    # Routing succeeded even if the tiny synthetic fixture trips DRC (rc 3):
+    # the mechanism proof is that the previously-unroutable link now has copper.
+    assert rc in (0, 3), f"expected routing success (rc 0 or 3), got {rc}"
+    text = out.read_text()
+    # NET_A (the walled link) is now routed with a via-in-pad.
+    assert 1 in _via_nets(text), "NET_A must gain a via to escape the walled pocket"
+    assert _net1_via_in_pad(text), "the escape via must land inside pad A (a via-in-pad)"
+    # #4413 guard_copper_loss: NET_KEEP's pre-existing segment is untouched.
+    assert _net6_segment_preserved(text), "unrelated NET_KEEP copper must never be deleted"
+    # No other-net (wall) copper was fabricated.
+    assert set(_seg_nets(text)) | set(_via_nets(text)) <= {1, 6}
+
+
+def test_complete_does_not_fabricate_via_in_pad_on_unsupported_tier(
+    walled_board: Path, tmp_path: Path
+) -> None:
+    """On a tier WITHOUT via-in-pad support the walled pad is left open rather
+    than closed with an unmanufacturable via -- and NET_KEEP still survives."""
+    out = tmp_path / "complete_plain.kicad_pcb"
+    rc = route_main(
+        [
+            str(walled_board),
+            "-o",
+            str(out),
+            "--complete",
+            "--via-in-pad-last-resort",
+            "--manufacturer",
+            "jlcpcb",  # via_in_pad_supported=False
+            "--backend",
+            "cpp",
+        ]
+    )
+    text = out.read_text()
+    # The walled link is NOT closed: no via-in-pad was fabricated.
+    assert not _net1_via_in_pad(text), "no via-in-pad may appear on an unsupporting tier"
+    assert 1 not in _via_nets(text)
+    # --complete signals the unroutable link (exit 8) or a fatal no-route (1);
+    # either way it did NOT report clean success.
+    assert rc != 0
+    # #4413 guard_copper_loss holds even on the failed-completion path.
+    assert _net6_segment_preserved(text), "unrelated NET_KEEP copper must never be deleted"


### PR DESCRIPTION
## Summary

Phase 5 (exit phase) of epic #4465, parent defect #4434. The batch-completion driver `complete_unfinished_nets` shelled `kct route --preserve-existing --skip-nets …` with **no `--route-engine`**, so every completion pass ran the coarse uniform-grid A* that cannot thread a walled SMD pocket or place a via-in-pad (#4465 gap G2). The rescue loop never reached the engine that could close the pad — which is why #4434's batch route traded stranded walled pads 1:1 forever.

This PR points the completion case at the built-in `--complete` path (Phases 1–4, already merged via #4503/#4501) and consumes its structured per-link report. The single-net `rescue_partial_nets` path (and its `placement_nudge` caller) keep the grid `--skip-nets` shape unchanged.

## Changes

- **`src/kicad_tools/router/partial_rescue.py`**
  - `build_rescue_command(...)` gains keyword-only `complete=` / `complete_report=`. In completion mode it emits `kct route --complete [--complete-report PATH]` and drops the grid-engine shape: **no `--skip-nets`/`--nets`** (which would trip the mutual-exclusivity guard at `route_cmd.py:8805`) and **no `--auto-layers`** (completion routes within the committed layer stack — #4477). Default `complete=False` leaves the single-net rescue argv byte-identical.
  - `complete_unfinished_nets(...)` now shells `--complete` (lattice engine) per pass, passing `--complete-report` to a temp JSON. `--complete` self-selects the stranded nets via the **same** `partially_connected_signal_nets` detector the loop already calls, so the target sets agree by construction; the skip-list construction is dropped for this case.
  - New `CompletionResult` (list-compatible for legacy callers) + `UnroutableLink` dataclasses: the return type now carries the `(before, after)` progress history **plus** the parsed per-link report, so callers see closed vs. unroutable-with-blockers per link instead of the discarded subprocess output.
  - No-op tolerance: a `--complete` pass that closes some-but-not-all links still makes progress (count went down) and is kept; only a pass that does not reduce the unfinished count is rolled back byte-for-byte.
- **Tests** — `tests/router/test_partial_rescue.py`: completion-shape + golden-argv command construction, mutual-exclusivity guard never tripped from the rescue path, `CompletionResult`/`UnroutableLink` behavior, and report propagation (a pass leaving a link open surfaces `blocking_copper`). New `tests/test_cli_route_complete_walled_4478.py`: end-to-end walled-SMD fixture.

## Acceptance Criteria Verification

- [x] **Automated walled-fixture test (AC item 3)** — `tests/test_cli_route_complete_walled_4478.py`: a deliberately walled SMD pad the **grid engine cannot close** (`test_grid_engine_cannot_close_walled_pad`, rc≠0, zero net copper) but **`--complete` does** on a via-in-pad-capable tier (`jlcpcb-tier1`), landing a via **inside pad A** (a via-in-pad). On plain `jlcpcb` (no via-in-pad support) the pad is left open rather than fabricating an unmanufacturable via. Both paths assert the #4413 `guard_copper_loss` invariant: an unrelated net's pre-existing segment is never deleted.
- [x] **Golden-output regression (AC item 4)** — `test_build_rescue_command_golden_argv_unchanged` pins the full default argv byte-for-byte; boards that never hit the completion path are unaffected (the change is behind a default-`False` keyword). `placement_nudge` (the direct `build_rescue_command` caller) and all 26 nudge tests pass unchanged.
- [x] **Report propagation** — `test_completion_report_propagates_unroutable_links`: an unroutable link yields a structured `UnroutableLink` with non-empty `blocking_copper` visible on the returned `CompletionResult`.
- [x] **Mutual-exclusivity guard never trips from the rescue path** — `test_completion_shells_complete_not_skip_nets` asserts every completion argv carries `--complete` and never `--skip-nets`/`--nets`.
- [ ] **softstart rev-C final stranded pads (OC_TRIP_N, RF_EN, V_BUS_DVDT)** — **operator-only, cannot be run from this worktree** (softstart is a separate consumer repo). The mechanism is delivered here; the softstart run + `kicad-cli pcb drc --refill-zones` gate must be verified by an operator in the consumer repo before epic #4465 closes.
- [ ] **board-05 (#4410) walled-pocket links close via the same path** — **deferred** (heavy full-board integration run). Note: board-05's recipe currently uses the single-net `rescue_partial_nets` path (kept unchanged per the spec's constraint 1), so it does not automatically route through the new completion path; wiring board-05's recipe to `complete_unfinished_nets` + a full route is follow-up integration work. The underlying mechanism it needs is proven by the walled fixture above.

## Test Plan

- [x] `tests/router/test_partial_rescue.py` — 23 passed (unit, mocked)
- [x] `tests/test_cli_route_complete_walled_4478.py` — 3 passed (real routing, C++ backend)
- [x] `tests/test_cli_route_complete_4471.py`, `tests/test_cli_route_complete_report_4477.py`, `tests/test_cli_route_complete_localize_4472.py` — 32 passed (no regressions)
- [x] `tests/router/lattice/test_deadline_report_4477.py` — passed
- [x] `tests/router/test_placement_nudge.py`, `tests/test_placement_nudge.py` — 26 passed (direct `build_rescue_command` caller unchanged)
- [x] `ruff check` / `ruff format` clean on changed files

## Notes for reviewer

`scripts/route_chorus.py` calls `complete_unfinished_nets` and ignores its return value, so it picks up the `--complete` rewiring automatically with no code change. The new `CompletionResult` is list-compatible (`__eq__`/`__len__`/`__iter__`/`__getitem__`/`__bool__`) so no existing caller breaks.

Part of #4465
Closes #4478