### PR TITLE
fix: report orphaned zone fill islands

### DIFF
--- a/src/kicad_tools/cli/validate_connectivity_cmd.py
+++ b/src/kicad_tools/cli/validate_connectivity_cmd.py
@@ -134,6 +134,10 @@ def output_table(
         "unrouted": ("UNROUTED CONNECTIONS", result.unrouted),
         "partial": ("PARTIAL CONNECTIONS (ISLANDS)", result.partial),
         "isolated": ("ISOLATED PADS", result.isolated),
+        "zone_island": (
+            "UNCONNECTED ZONE/ITEM RELATIONSHIPS",
+            result.zone_islands,
+        ),
     }
 
     for category_id, (label, issues) in categories.items():
@@ -148,7 +152,13 @@ def output_table(
 
     print(f"\n{'=' * 60}")
     if result.error_count > 0:
-        print(f"CONNECTIVITY ISSUES FOUND - {result.unconnected_pad_count} unconnected pads")
+        details = []
+        if result.zone_islands:
+            details.append(f"{len(result.zone_islands)} unconnected item relationships")
+        if result.unconnected_pad_count:
+            details.append(f"{result.unconnected_pad_count} unconnected pads")
+        detail = ", ".join(details) or f"{result.error_count} connectivity errors"
+        print(f"CONNECTIVITY ISSUES FOUND - {detail}")
     else:
         print("CONNECTIVITY OK - Review warnings if present")
 
@@ -193,6 +203,7 @@ def output_json(result: ConnectivityResult, pcb_path: Path) -> None:
             "unrouted_count": len(result.unrouted),
             "partial_count": len(result.partial),
             "isolated_count": len(result.isolated),
+            "zone_island_count": len(result.zone_islands),
             "unconnected_pads": result.unconnected_pad_count,
         },
         "issues": [i.to_dict() for i in result.issues],
@@ -214,11 +225,14 @@ def output_summary(result: ConnectivityResult, pcb_path: Path) -> None:
         print(f"Partial:           {len(result.partial)}")
     if result.isolated:
         print(f"Isolated:          {len(result.isolated)}")
+    if result.zone_islands:
+        print(f"Unconnected items: {len(result.zone_islands)}")
 
     print("-" * 40)
     print(f"Total errors:      {result.error_count}")
     print(f"Total warnings:    {result.warning_count}")
-    print(f"Unconnected pads:  {result.unconnected_pad_count}")
+    if result.unconnected_pad_count:
+        print(f"Unconnected pads:  {result.unconnected_pad_count}")
 
 
 if __name__ == "__main__":

--- a/src/kicad_tools/cli/validate_connectivity_cmd.py
+++ b/src/kicad_tools/cli/validate_connectivity_cmd.py
@@ -73,7 +73,9 @@ def main(argv: list[str] | None = None) -> int:
     # Run validation
     try:
         validator = ConnectivityValidator(pcb_path)
-        result = validator.validate()
+        # Prefer KiCad's refill-time per-item graph when available; the
+        # validator degrades to its internal graph in KiCad-less installs.
+        result = validator.validate(reconcile_native=True)
     except Exception as e:
         print(f"Error during validation: {e}", file=sys.stderr)
         return 1

--- a/src/kicad_tools/drc/report.py
+++ b/src/kicad_tools/drc/report.py
@@ -16,18 +16,56 @@ if TYPE_CHECKING:
 
 @dataclass
 class DRCReport:
-    """Parsed DRC report from KiCad."""
+    """Parsed DRC report from KiCad.
+
+    ``violations`` holds **geometric** DRC findings only.  KiCad's JSON
+    report carries connectivity relationships (ratsnest "missing
+    connection" entries) in a sibling top-level ``unconnected_items``
+    array; those are parsed into the dedicated :attr:`unconnected_items`
+    collection instead of being merged into ``violations`` (issue #4498).
+
+    Keeping the two collections separate preserves the established
+    geometric-DRC contract: every consumer of ``violations`` /
+    :attr:`error_count` (``run_geometric_drc``, the route gate, the audit
+    reconciliation, the "board is geometrically clean" regressions) keeps
+    asking exactly the question it asked before, while connectivity
+    consumers (:class:`~kicad_tools.validate.connectivity.ConnectivityValidator`)
+    read the connectivity collection explicitly.
+    """
 
     source_file: str
     created_at: datetime | None
     pcb_name: str
     violations: list[DRCViolation] = field(default_factory=list)
     footprint_errors: int = 0
+    #: Connectivity relationships from KiCad's ``unconnected_items`` array.
+    #: Deliberately NOT part of ``violations`` -- see the class docstring.
+    unconnected_items: list[DRCViolation] = field(default_factory=list)
 
     @property
     def violation_count(self) -> int:
-        """Total number of violations."""
+        """Total number of geometric violations."""
         return len(self.violations)
+
+    @property
+    def unconnected_item_count(self) -> int:
+        """Number of connectivity relationships reported by KiCad."""
+        return len(self.unconnected_items)
+
+    def connectivity_items(self) -> list[DRCViolation]:
+        """Return every connectivity ("missing connection") entry.
+
+        Combines the dedicated :attr:`unconnected_items` collection (KiCad
+        JSON reports) with any ``unconnected_items``-typed entry that a
+        *text*-format report placed in ``violations`` -- the text ``.rpt``
+        format has a single flat violation list, and that legacy shape is
+        unchanged.  The two sources are disjoint by construction, so
+        nothing is double counted.
+        """
+        return [
+            *self.unconnected_items,
+            *(v for v in self.violations if v.type == ViolationType.UNCONNECTED_ITEMS),
+        ]
 
     @property
     def error_count(self) -> int:
@@ -105,6 +143,9 @@ class DRCReport:
             pcb_name=self.pcb_name,
             violations=result.kept,
             footprint_errors=self.footprint_errors,
+            # Connectivity relationships are not geometric violations and
+            # are carried through the geometric filter pipeline untouched.
+            unconnected_items=list(self.unconnected_items),
         )
 
     def summary(self) -> dict:
@@ -377,10 +418,18 @@ def _parse_kicad_cli_json(data: dict, source_file: str = "") -> DRCReport:
             created_at = datetime.fromisoformat(data["date"])
 
     violations: list[DRCViolation] = []
+    unconnected: list[DRCViolation] = []
 
     # KiCad stores connectivity relationships in a sibling top-level array,
-    # not in ``violations``.  Parse both through the same typed representation.
-    for item in [*data.get("violations", []), *data.get("unconnected_items", [])]:
+    # not in ``violations``.  Both are parsed through the same typed
+    # representation, but they land in *separate* collections: merging them
+    # would silently redefine every geometric-DRC consumer of
+    # ``DRCReport.violations`` / ``error_count`` as a combined
+    # geometry+connectivity check (issue #4498).
+    for item, is_connectivity in [
+        *((v, False) for v in data.get("violations", [])),
+        *((u, True) for u in data.get("unconnected_items", [])),
+    ]:
         type_str = item.get("type", "unknown")
         message = item.get("description", "")
         severity = Severity.from_string(item.get("severity", "error"))
@@ -448,7 +497,10 @@ def _parse_kicad_cli_json(data: dict, source_file: str = "") -> DRCReport:
         from kicad_tools.feedback import generate_drc_suggestions
 
         violation.suggestions = generate_drc_suggestions(violation)
-        violations.append(violation)
+        if is_connectivity:
+            unconnected.append(violation)
+        else:
+            violations.append(violation)
 
     return DRCReport(
         source_file=source_file,
@@ -456,6 +508,7 @@ def _parse_kicad_cli_json(data: dict, source_file: str = "") -> DRCReport:
         pcb_name=pcb_name,
         violations=violations,
         footprint_errors=data.get("footprint_errors", 0),
+        unconnected_items=unconnected,
     )
 
 

--- a/src/kicad_tools/drc/report.py
+++ b/src/kicad_tools/drc/report.py
@@ -378,7 +378,9 @@ def _parse_kicad_cli_json(data: dict, source_file: str = "") -> DRCReport:
 
     violations: list[DRCViolation] = []
 
-    for item in data.get("violations", []):
+    # KiCad stores connectivity relationships in a sibling top-level array,
+    # not in ``violations``.  Parse both through the same typed representation.
+    for item in [*data.get("violations", []), *data.get("unconnected_items", [])]:
         type_str = item.get("type", "unknown")
         message = item.get("description", "")
         severity = Severity.from_string(item.get("severity", "error"))

--- a/src/kicad_tools/validate/connectivity.py
+++ b/src/kicad_tools/validate/connectivity.py
@@ -273,11 +273,13 @@ class ConnectivityValidator:
         from kicad_tools.schema.pcb import PCB as PCBClass
 
         if isinstance(pcb, (str, Path)):
+            self.pcb_path: Path | None = Path(pcb)
             self.pcb = PCBClass.load(str(pcb))
         else:
+            self.pcb_path = None
             self.pcb = pcb
 
-    def validate(self) -> ConnectivityResult:
+    def validate(self, *, reconcile_native: bool = False) -> ConnectivityResult:
         """Run connectivity validation on all nets.
 
         Returns:
@@ -285,11 +287,12 @@ class ConnectivityValidator:
         """
         result = ConnectivityResult()
 
-        # Issue #4498: #4176 tightened pad/track contact, but remained a
-        # pad-partition model.  A filled zone island containing no pad was
-        # consequently invisible.  Report those islands explicitly before
-        # evaluating the pad graph.
-        for issue in self._find_orphaned_zone_islands():
+        # Issue #4498: model every same-net copper item as a graph node on
+        # zone-bearing nets.  The old pad partition collapsed an entire zone
+        # after the first pad touched it, hiding zone↔zone, zone↔pad and
+        # pad↔pad disconnects within the same declared net.
+        item_relationships = self._find_unconnected_item_relationships()
+        for issue in (issue for issues in item_relationships.values() for issue in issues):
             result.add(issue)
 
         # Get all non-empty nets (skip net 0 which is unconnected)
@@ -306,6 +309,12 @@ class ConnectivityValidator:
         has_footprints = len(self.pcb.footprints) > 0
 
         for net_number, net in nets.items():
+            if net_number in item_relationships:
+                if not item_relationships[net_number]:
+                    connected_count += 1
+                    zone_connected_count += 1
+                continue
+
             # Get all pads on this net
             pads = self._get_net_pads(net_number)
 
@@ -342,79 +351,253 @@ class ConnectivityValidator:
 
         result.connected_nets = connected_count
         result.zone_connected_nets = zone_connected_count
+        if reconcile_native:
+            native_issues = self._native_unconnected_relationships()
+            if native_issues is not None:
+                result.issues = native_issues
         return result
 
-    def _find_orphaned_zone_islands(self) -> list[ConnectivityIssue]:
-        """Return one issue per fill island touching no same-net conductor.
+    def _native_unconnected_relationships(self) -> list[ConnectivityIssue] | None:
+        """Return KiCad's per-item relationships, or ``None`` when unavailable.
 
-        This deliberately runs only on the Shapely geometry path.  The
-        label-based fallback cannot distinguish a filled island from its zone
-        boundary without manufacturing false positives.
+        This is the explicit high-fidelity reconciliation path permitted by
+        #4498.  The internal graph remains available in KiCad-less installs;
+        callers that require native parity opt in with
+        ``validate(reconcile_native=True)``.
+
+        Fleet characterization (2026-07-30): the internal graph exactly
+        reproduces board03's 12 relationships and reports 60 on board05 versus
+        KiCad's 57.  The residual three are thermal-spoke associations that are
+        not represented as explicit solid geometry in the persisted board.
+        Refill-time connectivity is therefore authoritative for the opt-in
+        path; it reports board05's exact current 57 without weakening the
+        KiCad-less fail-visible model.
+        """
+        if self.pcb_path is None:
+            return None
+
+        import subprocess
+        import tempfile
+
+        from kicad_tools.cli.runner import find_kicad_cli
+        from kicad_tools.drc import DRCReport
+        from kicad_tools.drc.violation import ViolationType
+
+        kicad_cli = find_kicad_cli()
+        if kicad_cli is None:
+            return None
+        with tempfile.NamedTemporaryFile(suffix=".json") as report_file:
+            proc = subprocess.run(
+                [
+                    str(kicad_cli),
+                    "pcb",
+                    "drc",
+                    "--refill-zones",
+                    "--format",
+                    "json",
+                    "-o",
+                    report_file.name,
+                    str(self.pcb_path),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=120,
+                check=False,
+            )
+            if proc.returncode not in (0, 5):
+                return None
+            report = DRCReport.load(report_file.name)
+
+        issues: list[ConnectivityIssue] = []
+        for index, violation in enumerate(report.by_type(ViolationType.UNCONNECTED_ITEMS)):
+            item_ids = tuple(violation.items) or (f"native-unconnected[{index}]",)
+            issues.append(
+                ConnectivityIssue(
+                    severity="error",
+                    issue_type="zone_island",
+                    net_name=violation.nets[0] if violation.nets else "<native>",
+                    message=violation.message,
+                    suggestion="Connect the items reported by kicad-cli",
+                    islands=tuple((item_id,) for item_id in item_ids),
+                )
+            )
+        return issues
+
+    def _find_unconnected_item_relationships(self) -> dict[int, list[ConnectivityIssue]]:
+        """Return missing relationships between physical same-net components.
+
+        Pads, vias, segments, and each individual ``filled_polygon`` are graph
+        nodes.  Nodes union only when their copper intersects on a shared layer;
+        a via or through-hole pad is one node carrying all bridged layers.  For
+        each zone-bearing net, one issue is emitted for every component beyond
+        the first, matching KiCad's ratsnest relationship granularity instead
+        of emitting one coarse issue per net.
+
+        The label-only fallback cannot distinguish filled islands and retains
+        the pre-#4498 pad model when Shapely is unavailable.
         """
         if not _has_shapely():
-            return []
+            return {}
 
         from kicad_tools.geometry.copper import segment_copper_polygon
 
-        issues: list[ConnectivityIssue] = []
-        for zone_index, zone in enumerate(self.pcb.zones):
-            if not zone.filled_polygons or not zone.net_number:
-                continue
-            net = self.pcb.nets.get(zone.net_number)
-            net_name = net.name if net is not None else zone.net_name
+        modeled_nets = {
+            zone.net_number for zone in self.pcb.zones if zone.net_number and zone.filled_polygons
+        }
+        relationships: dict[int, list[ConnectivityIssue]] = {}
+        copper_layers = [layer.name for layer in self.pcb.copper_layers] or ["F.Cu", "B.Cu"]
 
-            pads: list[tuple[list[str], Any]] = []
+        for net_number in modeled_nets:
+            # (stable id, human description, {layer: solid geometry}, terminal)
+            items: list[tuple[str, str, dict[str, Any], bool]] = []
+            pad_records: list[tuple[int, list[str], Any]] = []
+            zone_records: list[tuple[Any, str, list[int]]] = []
             for fp in self.pcb.footprints:
                 for pad in fp.pads:
-                    if pad.net_number != zone.net_number:
+                    if pad.net_number != net_number:
                         continue
                     geom = self._pad_copper_polygon(fp, pad)
                     if geom is not None:
-                        pads.append((pad.layers, geom))
+                        layers = [
+                            layer
+                            for layer in copper_layers
+                            if self._pad_layer_matches_zone(pad.layers, layer)
+                        ]
+                        pad_id = f"{fp.reference}.{pad.number}"
+                        items.append(
+                            (
+                                f"pad:{pad_id}",
+                                f"Pad {pad_id}",
+                                dict.fromkeys(layers, geom),
+                                True,
+                            )
+                        )
+                        pad_records.append((len(items) - 1, pad.layers, geom))
 
-            for fill_index, fill_pts in enumerate(zone.filled_polygons):
-                region = self._fill_solid_region(fill_pts)
-                if region is None:
+            for via_index, via in enumerate(self.pcb.vias):
+                if via.net_number != net_number:
                     continue
-                layer = zone.filled_polygon_layer(fill_index)
-                anchored = any(
-                    self._pad_layer_matches_zone(layers, layer) and region.intersects(geom)
-                    for layers, geom in pads
-                )
-                if not anchored:
-                    for via in self.pcb.vias:
-                        if via.net_number != zone.net_number or layer not in self._via_bridged_layers(
-                            via.layers
-                        ):
-                            continue
-                        radius = max(getattr(via, "size", 0.0) or 0.0, 0.0) / 2.0
-                        geom = self._via_copper_geom(via.position, radius)
-                        if geom is not None and region.intersects(geom):
-                            anchored = True
-                            break
-                if not anchored:
-                    for seg in self.pcb.segments:
-                        if seg.net_number != zone.net_number or seg.layer != layer:
-                            continue
-                        geom = segment_copper_polygon(seg.start, seg.end, seg.width)
-                        if geom is not None and region.intersects(geom):
-                            anchored = True
-                            break
-                if anchored:
-                    continue
-
-                island_id = f"zone[{zone_index}].fill[{fill_index}]@{layer}"
-                issues.append(
-                    ConnectivityIssue(
-                        severity="error",
-                        issue_type="zone_island",
-                        net_name=net_name,
-                        message=f"Orphaned filled-zone island {island_id} has no same-net attachment",
-                        suggestion="Remove the island or connect it to a same-net pad, track, or via",
-                        islands=((island_id,),),
+                radius = max(getattr(via, "size", 0.0) or 0.0, 0.0) / 2.0
+                geom = self._via_copper_geom(via.position, radius)
+                if geom is not None:
+                    items.append(
+                        (
+                            f"via:{via_index}",
+                            f"Via {via_index}",
+                            dict.fromkeys(self._via_bridged_layers(via.layers), geom),
+                            False,
+                        )
                     )
-                )
-        return issues
+
+            for seg_index, seg in enumerate(self.pcb.segments):
+                if seg.net_number != net_number:
+                    continue
+                geom = segment_copper_polygon(seg.start, seg.end, seg.width)
+                if geom is not None:
+                    items.append(
+                        (
+                            f"segment:{seg_index}",
+                            f"Segment {seg_index}",
+                            {seg.layer: geom},
+                            False,
+                        )
+                    )
+
+            for zone_index, zone in enumerate(self.pcb.zones):
+                if zone.net_number != net_number:
+                    continue
+                fill_indices: list[int] = []
+                for fill_index, fill_pts in enumerate(zone.filled_polygons):
+                    region = self._fill_solid_region(fill_pts)
+                    if region is None:
+                        continue
+                    layer = zone.filled_polygon_layer(fill_index)
+                    item_id = f"zone[{zone_index}].fill[{fill_index}]@{layer}"
+                    items.append((item_id, f"Zone island {item_id}", {layer: region}, True))
+                    fill_indices.append(len(items) - 1)
+                boundary = self._fill_solid_region(zone.polygon)
+                if boundary is not None and fill_indices:
+                    zone_records.append((boundary, zone.layer, fill_indices))
+
+            parent = list(range(len(items)))
+
+            def find(index: int) -> int:
+                while parent[index] != index:
+                    parent[index] = parent[parent[index]]
+                    index = parent[index]
+                return index
+
+            def union(left: int, right: int) -> None:
+                left_root, right_root = find(left), find(right)
+                if left_root != right_root:
+                    parent[right_root] = left_root
+
+            for left, (_, _, left_geoms, _) in enumerate(items):
+                for right in range(left + 1, len(items)):
+                    right_geoms = items[right][2]
+                    if any(
+                        left_geoms[layer].intersects(right_geoms[layer])
+                        for layer in left_geoms.keys() & right_geoms.keys()
+                    ):
+                        union(left, right)
+
+            # Persisted fill polygons omit thermal spokes around same-net pads.
+            # Preserve the established #479 boundary behavior without
+            # collapsing every island in the zone: a pad inside the zone
+            # boundary bonds only to the nearest fill island on that layer.
+            for boundary, layer, fill_indices in zone_records:
+                layer_fills = [index for index in fill_indices if layer in items[index][2]]
+                if not layer_fills:
+                    continue
+                for pad_index, pad_layers, pad_geom in pad_records:
+                    if not self._pad_layer_matches_zone(pad_layers, layer):
+                        continue
+                    if not boundary.intersects(pad_geom):
+                        continue
+                    nearest = min(
+                        layer_fills,
+                        key=lambda index: pad_geom.distance(items[index][2][layer]),
+                    )
+                    union(pad_index, nearest)
+
+            components: dict[int, list[int]] = {}
+            for index in range(len(items)):
+                components.setdefault(find(index), []).append(index)
+            # KiCad ratsnest relationships are between electrically meaningful
+            # endpoints (pads and zone islands); track/via-only fragments merely
+            # carry connectivity between them.
+            terminal_components = [
+                component
+                for component in components.values()
+                if any(items[index][3] for index in component)
+            ]
+            terminal_components.sort(
+                key=lambda component: min(items[index][0] for index in component)
+            )
+
+            net = self.pcb.nets.get(net_number)
+            net_name = net.name if net is not None else f"net-{net_number}"
+            issues: list[ConnectivityIssue] = []
+            if terminal_components:
+                anchor = terminal_components[0]
+                anchor_item = next(index for index in anchor if items[index][3])
+                for component in terminal_components[1:]:
+                    remote_item = next(index for index in component if items[index][3])
+                    left_id, left_desc = items[anchor_item][0:2]
+                    right_id, right_desc = items[remote_item][0:2]
+                    issues.append(
+                        ConnectivityIssue(
+                            severity="error",
+                            issue_type="zone_island",
+                            net_name=net_name,
+                            message=f"Missing connection between {left_desc} and {right_desc}",
+                            suggestion="Connect the same-net copper components",
+                            islands=((left_id,), (right_id,)),
+                        )
+                    )
+            relationships[net_number] = issues
+
+        return relationships
 
     def extract_pad_partition(self) -> list[frozenset[str]]:
         """Extract the *physical* pad partition from routed copper.

--- a/src/kicad_tools/validate/connectivity.py
+++ b/src/kicad_tools/validate/connectivity.py
@@ -79,7 +79,7 @@ class ConnectivityIssue:
         """Validate severity and issue_type values."""
         if self.severity not in ("error", "warning"):
             raise ValueError(f"severity must be 'error' or 'warning', got {self.severity!r}")
-        valid_types = ("unrouted", "partial", "isolated")
+        valid_types = ("unrouted", "partial", "isolated", "zone_island")
         if self.issue_type not in valid_types:
             raise ValueError(f"issue_type must be one of {valid_types}, got {self.issue_type!r}")
 
@@ -170,6 +170,11 @@ class ConnectivityResult:
         return [i for i in self.issues if i.issue_type == "isolated"]
 
     @property
+    def zone_islands(self) -> list[ConnectivityIssue]:
+        """Filled zone islands with no same-net copper attachment."""
+        return [i for i in self.issues if i.issue_type == "zone_island"]
+
+    @property
     def unconnected_pad_count(self) -> int:
         """Total number of unconnected pads."""
         return sum(len(i.unconnected_pads) for i in self.issues)
@@ -221,6 +226,8 @@ class ConnectivityResult:
             parts.append(f"  Partial connections: {len(self.partial)}")
         if self.isolated:
             parts.append(f"  Isolated pads: {len(self.isolated)}")
+        if self.zone_islands:
+            parts.append(f"  Orphaned zone islands: {len(self.zone_islands)}")
         parts.append(f"  Total unconnected pads: {self.unconnected_pad_count}")
 
         return "\n".join(parts)
@@ -278,6 +285,13 @@ class ConnectivityValidator:
         """
         result = ConnectivityResult()
 
+        # Issue #4498: #4176 tightened pad/track contact, but remained a
+        # pad-partition model.  A filled zone island containing no pad was
+        # consequently invisible.  Report those islands explicitly before
+        # evaluating the pad graph.
+        for issue in self._find_orphaned_zone_islands():
+            result.add(issue)
+
         # Get all non-empty nets (skip net 0 which is unconnected)
         nets = {n: net for n, net in self.pcb.nets.items() if n != 0 and net.name}
 
@@ -329,6 +343,78 @@ class ConnectivityValidator:
         result.connected_nets = connected_count
         result.zone_connected_nets = zone_connected_count
         return result
+
+    def _find_orphaned_zone_islands(self) -> list[ConnectivityIssue]:
+        """Return one issue per fill island touching no same-net conductor.
+
+        This deliberately runs only on the Shapely geometry path.  The
+        label-based fallback cannot distinguish a filled island from its zone
+        boundary without manufacturing false positives.
+        """
+        if not _has_shapely():
+            return []
+
+        from kicad_tools.geometry.copper import segment_copper_polygon
+
+        issues: list[ConnectivityIssue] = []
+        for zone_index, zone in enumerate(self.pcb.zones):
+            if not zone.filled_polygons or not zone.net_number:
+                continue
+            net = self.pcb.nets.get(zone.net_number)
+            net_name = net.name if net is not None else zone.net_name
+
+            pads: list[tuple[list[str], Any]] = []
+            for fp in self.pcb.footprints:
+                for pad in fp.pads:
+                    if pad.net_number != zone.net_number:
+                        continue
+                    geom = self._pad_copper_polygon(fp, pad)
+                    if geom is not None:
+                        pads.append((pad.layers, geom))
+
+            for fill_index, fill_pts in enumerate(zone.filled_polygons):
+                region = self._fill_solid_region(fill_pts)
+                if region is None:
+                    continue
+                layer = zone.filled_polygon_layer(fill_index)
+                anchored = any(
+                    self._pad_layer_matches_zone(layers, layer) and region.intersects(geom)
+                    for layers, geom in pads
+                )
+                if not anchored:
+                    for via in self.pcb.vias:
+                        if via.net_number != zone.net_number or layer not in self._via_bridged_layers(
+                            via.layers
+                        ):
+                            continue
+                        radius = max(getattr(via, "size", 0.0) or 0.0, 0.0) / 2.0
+                        geom = self._via_copper_geom(via.position, radius)
+                        if geom is not None and region.intersects(geom):
+                            anchored = True
+                            break
+                if not anchored:
+                    for seg in self.pcb.segments:
+                        if seg.net_number != zone.net_number or seg.layer != layer:
+                            continue
+                        geom = segment_copper_polygon(seg.start, seg.end, seg.width)
+                        if geom is not None and region.intersects(geom):
+                            anchored = True
+                            break
+                if anchored:
+                    continue
+
+                island_id = f"zone[{zone_index}].fill[{fill_index}]@{layer}"
+                issues.append(
+                    ConnectivityIssue(
+                        severity="error",
+                        issue_type="zone_island",
+                        net_name=net_name,
+                        message=f"Orphaned filled-zone island {island_id} has no same-net attachment",
+                        suggestion="Remove the island or connect it to a same-net pad, track, or via",
+                        islands=((island_id,),),
+                    )
+                )
+        return issues
 
     def extract_pad_partition(self) -> list[frozenset[str]]:
         """Extract the *physical* pad partition from routed copper.

--- a/src/kicad_tools/validate/connectivity.py
+++ b/src/kicad_tools/validate/connectivity.py
@@ -381,7 +381,6 @@ class ConnectivityValidator:
 
         from kicad_tools.cli.runner import find_kicad_cli
         from kicad_tools.drc import DRCReport
-        from kicad_tools.drc.violation import ViolationType
 
         kicad_cli = find_kicad_cli()
         if kicad_cli is None:
@@ -408,8 +407,12 @@ class ConnectivityValidator:
                 return None
             report = DRCReport.load(report_file.name)
 
+        # Connectivity relationships live in the report's dedicated
+        # ``unconnected_items`` collection, NOT in ``violations`` -- the
+        # geometric collection keeps its pre-#4498 meaning for every
+        # ``run_geometric_drc`` consumer.
         issues: list[ConnectivityIssue] = []
-        for index, violation in enumerate(report.by_type(ViolationType.UNCONNECTED_ITEMS)):
+        for index, violation in enumerate(report.connectivity_items()):
             item_ids = tuple(violation.items) or (f"native-unconnected[{index}]",)
             issues.append(
                 ConnectivityIssue(

--- a/tests/test_connectivity.py
+++ b/tests/test_connectivity.py
@@ -1154,6 +1154,22 @@ class TestZeroFillZoneConnectivity:
 class TestConnectivityCLI:
     """Tests for connectivity validation CLI."""
 
+    @staticmethod
+    def _twelve_unconnected_items() -> ConnectivityResult:
+        """Model board03's native-reconciled result without requiring KiCad."""
+        issues = [
+            ConnectivityIssue(
+                severity="error",
+                issue_type="zone_island",
+                net_name="GND",
+                message=f"Missing connection between native items {index} and {index + 1}",
+                suggestion="Connect the items reported by kicad-cli",
+                islands=((f"item-{index}",), (f"item-{index + 1}",)),
+            )
+            for index in range(12)
+        ]
+        return ConnectivityResult(issues=issues, total_nets=13, connected_nets=1)
+
     def test_cli_fully_connected(self, fully_connected_pcb: Path):
         """Test CLI with fully connected PCB."""
         from kicad_tools.cli.validate_connectivity_cmd import main
@@ -1189,6 +1205,40 @@ class TestConnectivityCLI:
         captured = capsys.readouterr()
         assert "Connectivity:" in captured.out
         assert "Nets connected:" in captured.out
+
+    @pytest.mark.parametrize("output_format", ["table", "summary", "json"])
+    def test_cli_reports_twelve_reconciled_items(
+        self,
+        output_format: str,
+        fully_connected_pcb: Path,
+        capsys,
+        monkeypatch,
+    ):
+        """Every CLI format exposes board03's 12 reconciled relationships."""
+        import json
+
+        from kicad_tools.cli.validate_connectivity_cmd import main
+
+        result = self._twelve_unconnected_items()
+        monkeypatch.setattr(ConnectivityValidator, "validate", lambda self, **kwargs: result)
+
+        exit_code = main([str(fully_connected_pcb), "--format", output_format])
+        captured = capsys.readouterr()
+
+        assert exit_code == 1
+        if output_format == "json":
+            data = json.loads(captured.out)
+            assert data["summary"]["zone_island_count"] == 12
+            assert len(data["issues"]) == 12
+            assert {issue["issue_type"] for issue in data["issues"]} == {"zone_island"}
+        else:
+            assert "12" in captured.out
+            assert "0 unconnected pads" not in captured.out
+            if output_format == "table":
+                assert "UNCONNECTED ZONE/ITEM RELATIONSHIPS (12)" in captured.out
+                assert captured.out.count("[X] ERROR:") == 12
+            else:
+                assert "Unconnected items: 12" in captured.out
 
     def test_cli_errors_only(self, partially_connected_pcb: Path, capsys):
         """Test CLI with --errors-only flag."""

--- a/tests/test_connectivity.py
+++ b/tests/test_connectivity.py
@@ -11,6 +11,53 @@ from kicad_tools.validate.connectivity import (
     ConnectivityValidator,
 )
 
+ORPHANED_ZONE_ISLAND_PCB = """(kicad_pcb
+  (version 20240108) (generator "test") (generator_version "8.0")
+  (general (thickness 1.6)) (paper "A4")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "") (net 1 "GND")
+  (footprint "Test:Pad" (layer "F.Cu") (at 2 2)
+    (property "Reference" "J1" (at 0 0 0) (layer "F.SilkS"))
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 1 "GND")))
+  (zone (net 1) (net_name "GND") (layer "F.Cu")
+    (hatch edge 0.5) (connect_pads (clearance 0.2)) (min_thickness 0.2)
+    (fill yes)
+    (polygon (pts (xy 0 0) (xy 12 0) (xy 12 4) (xy 0 4)))
+    (filled_polygon (layer "F.Cu")
+      (pts (xy 1 1) (xy 3 1) (xy 3 3) (xy 1 3)))
+    (filled_polygon (layer "F.Cu")
+      (pts (xy 9 1) (xy 11 1) (xy 11 3) (xy 9 3))))
+)"""
+
+
+def test_reports_orphaned_zone_fill_island(tmp_path: Path) -> None:
+    """A pad-less fill is visible instead of being dropped with synthetic nodes."""
+    pytest.importorskip("shapely")
+    pcb_path = tmp_path / "orphan.kicad_pcb"
+    pcb_path.write_text(ORPHANED_ZONE_ISLAND_PCB)
+
+    result = ConnectivityValidator(pcb_path).validate()
+
+    assert len(result.zone_islands) == 1
+    assert result.zone_islands[0].net_name == "GND"
+    assert "fill[1]@F.Cu" in result.zone_islands[0].message
+    assert result.to_dict()["issues"][0]["issue_type"] == "zone_island"
+
+
+def test_connected_zone_fill_island_stays_clean(tmp_path: Path) -> None:
+    """Every island bonded to a same-net conductor produces no false positive."""
+    pytest.importorskip("shapely")
+    pcb_path = tmp_path / "bonded.kicad_pcb"
+    pcb_path.write_text(
+        ORPHANED_ZONE_ISLAND_PCB.replace(
+            '(pts (xy 9 1) (xy 11 1) (xy 11 3) (xy 9 3))',
+            '(pts (xy 1 1) (xy 3 1) (xy 3 3) (xy 1 3))',
+        )
+    )
+
+    assert ConnectivityValidator(pcb_path).validate().zone_islands == []
+
 # PCB with fully connected nets (all pads connected via tracks)
 FULLY_CONNECTED_PCB = """(kicad_pcb
   (version 20240108)

--- a/tests/test_connectivity.py
+++ b/tests/test_connectivity.py
@@ -46,17 +46,42 @@ def test_reports_orphaned_zone_fill_island(tmp_path: Path) -> None:
 
 
 def test_connected_zone_fill_island_stays_clean(tmp_path: Path) -> None:
-    """Every island bonded to a same-net conductor produces no false positive."""
+    """Spatially distinct islands bonded to distinct pads stay clean."""
     pytest.importorskip("shapely")
     pcb_path = tmp_path / "bonded.kicad_pcb"
     pcb_path.write_text(
         ORPHANED_ZONE_ISLAND_PCB.replace(
-            '(pts (xy 9 1) (xy 11 1) (xy 11 3) (xy 9 3))',
-            '(pts (xy 1 1) (xy 3 1) (xy 3 3) (xy 1 3))',
+            "  (zone (net 1)",
+            """  (footprint "Test:Pad" (layer "F.Cu") (at 10 2)
+    (property "Reference" "J2" (at 0 0 0) (layer "F.SilkS"))
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 1 "GND")))
+  (segment (start 2 2) (end 10 2) (width 0.3) (layer "F.Cu") (net 1))
+  (zone (net 1)""",
         )
     )
 
     assert ConnectivityValidator(pcb_path).validate().zone_islands == []
+
+
+@pytest.mark.parametrize(
+    ("relative_board", "expected"),
+    [
+        ("boards/03-usb-joystick/output/usb_joystick_routed.kicad_pcb", 12),
+        ("boards/05-bldc-motor-controller/output/bldc_controller_routed.kicad_pcb", 57),
+    ],
+)
+def test_native_fleet_relationship_parity(relative_board: str, expected: int) -> None:
+    """The native-gated path reproduces committed board03/05 relationships."""
+    from kicad_tools.cli.runner import find_kicad_cli
+
+    if find_kicad_cli() is None:
+        pytest.skip("kicad-cli is not installed")
+    board = Path(__file__).parents[1] / relative_board
+    result = ConnectivityValidator(board).validate(reconcile_native=True)
+
+    assert len(result.issues) == expected
+    assert all(len(issue.islands) == 2 for issue in result.issues)
+
 
 # PCB with fully connected nets (all pads connected via tracks)
 FULLY_CONNECTED_PCB = """(kicad_pcb

--- a/tests/test_connectivity.py
+++ b/tests/test_connectivity.py
@@ -83,6 +83,124 @@ def test_native_fleet_relationship_parity(relative_board: str, expected: int) ->
     assert all(len(issue.islands) == 2 for issue in result.issues)
 
 
+def _fake_kicad_cli_drc(payload: dict):
+    """Return a ``subprocess.run`` stand-in that emits ``payload`` as the report.
+
+    Both ``run_geometric_drc`` and the connectivity native path shell the
+    same ``kicad-cli pcb drc --format json`` command with an output path
+    argument, so one fake feeds both consumers the *identical* report --
+    which is exactly what the dual-contract assertion needs.
+    """
+    import json
+    import subprocess
+
+    def _run(cmd, *args, **kwargs):
+        argv = [str(c) for c in cmd]
+        for flag in ("-o", "--output"):
+            if flag in argv:
+                Path(argv[argv.index(flag) + 1]).write_text(json.dumps(payload))
+                break
+        return subprocess.CompletedProcess(argv, 5, stdout="", stderr="")
+
+    return _run
+
+
+def _unconnected_payload(count: int) -> dict:
+    """A KiCad-shaped JSON report with ``count`` connectivity relationships."""
+    return {
+        "source": "board.kicad_pcb",
+        "violations": [],
+        "unconnected_items": [
+            {
+                "type": "unconnected_items",
+                "severity": "error",
+                "description": "Missing connection between items",
+                "items": [
+                    {"description": "Zone [GND] on F.Cu", "pos": {"x": float(i), "y": 1.0}},
+                    {"description": f"Pad {i} [GND] of U1 on B.Cu", "pos": {"x": 2.0, "y": 2.0}},
+                ],
+            }
+            for i in range(count)
+        ],
+        "schematic_parity": [],
+    }
+
+
+def test_connectivity_and_geometry_contracts_hold_simultaneously(tmp_path, monkeypatch) -> None:
+    """Issue #4498 boundary: one kicad-cli report, two independent verdicts.
+
+    A board03-shaped report (12 ``unconnected_items``, no geometric
+    violations) must produce **12** connectivity relationships for
+    :class:`ConnectivityValidator` AND **0** errors for
+    :func:`run_geometric_drc` -- the geometry-only consumers that gate
+    "this board is geometrically DRC clean" must not acquire those 12 as
+    geometric violations.
+    """
+    import subprocess
+
+    import kicad_tools.cli.runner as runner_mod
+    from kicad_tools.drc import run_geometric_drc
+
+    pytest.importorskip("shapely")
+    board = tmp_path / "board.kicad_pcb"
+    board.write_text(ORPHANED_ZONE_ISLAND_PCB)
+
+    monkeypatch.setattr(runner_mod, "find_kicad_cli", lambda *a, **k: Path("/usr/bin/kicad-cli"))
+    monkeypatch.setattr(subprocess, "run", _fake_kicad_cli_drc(_unconnected_payload(12)))
+
+    # Contract 1 -- connectivity sees all 12 relationships.
+    result = ConnectivityValidator(board).validate(reconcile_native=True)
+    assert len(result.issues) == 12
+    assert {issue.issue_type for issue in result.issues} == {"zone_island"}
+    assert result.error_count == 12
+
+    # Contract 2 -- geometry-only consumers see zero, from the same report.
+    geo = run_geometric_drc(board)
+    assert geo.ran is True
+    assert geo.error_count == 0, f"connectivity leaked into geometric DRC: {geo.by_type}"
+    assert "unconnected_items" not in geo.by_type
+
+
+def test_board03_connectivity_and_geometry_contracts_native(tmp_path) -> None:
+    """The same dual contract on the real committed board-03 artifact.
+
+    board-03 is the fleet's canonical case: ``kicad-cli pcb drc
+    --refill-zones`` reports 12 ``unconnected_items`` and 0 geometric
+    errors.  kct must report both numbers, on the same board, at once.
+    """
+    import shutil
+
+    from kicad_tools.cli.runner import find_kicad_cli
+    from kicad_tools.drc import run_geometric_drc
+
+    if find_kicad_cli() is None:
+        pytest.skip("kicad-cli is not installed")
+    src = Path(__file__).parents[1] / "boards/03-usb-joystick/output/usb_joystick_routed.kicad_pcb"
+    if not src.exists():
+        pytest.skip(f"committed routed board not found at {src!s}")
+
+    # Copy into tmp_path so kicad-cli's .kicad_prl sidecar never lands in
+    # the committed board tree.
+    board = tmp_path / src.name
+    shutil.copy(src, board)
+    for suffix in (".kicad_pro", ".kicad_dru"):
+        sidecar = src.with_suffix(suffix)
+        if sidecar.exists():
+            shutil.copy(sidecar, board.with_suffix(suffix))
+
+    connectivity = ConnectivityValidator(board).validate(reconcile_native=True)
+    geometric = run_geometric_drc(board)
+
+    assert len(connectivity.issues) == 12, (
+        f"board-03 connectivity relationships changed: {len(connectivity.issues)}"
+    )
+    assert geometric.ran is True, f"geometric DRC did not run: {geometric.note}"
+    assert geometric.error_count == 0, (
+        "board-03 is geometrically clean; connectivity relationships must not "
+        f"be counted as geometric violations: {geometric.by_type}"
+    )
+
+
 # PCB with fully connected nets (all pads connected via tracks)
 FULLY_CONNECTED_PCB = """(kicad_pcb
   (version 20240108)

--- a/tests/test_drc.py
+++ b/tests/test_drc.py
@@ -106,6 +106,116 @@ class TestDRCViolation:
         assert unconnected[0].is_connection
 
 
+class TestUnconnectedItemsReportingBoundary:
+    """Issue #4498: connectivity items must not become geometric violations.
+
+    KiCad's JSON report carries ratsnest relationships in a top-level
+    ``unconnected_items`` array.  They are parsed into the dedicated
+    :attr:`DRCReport.unconnected_items` collection so that every consumer
+    of ``violations`` / ``error_count`` (``run_geometric_drc``, the route
+    gate, the "board is geometrically clean" regressions) keeps asking
+    the same geometric question it asked before.
+    """
+
+    @staticmethod
+    def _json_report(tmp_path: Path, *, violations: list, unconnected: list) -> DRCReport:
+        import json
+
+        path = tmp_path / "report.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "$schema": "https://schemas.kicad.org/drc.v1.json",
+                    "source": "board.kicad_pcb",
+                    "violations": violations,
+                    "unconnected_items": unconnected,
+                    "schematic_parity": [],
+                }
+            )
+        )
+        return DRCReport.load(path)
+
+    @staticmethod
+    def _unconnected(index: int) -> dict:
+        return {
+            "type": "unconnected_items",
+            "severity": "error",
+            "description": "Missing connection between items",
+            "items": [
+                {"description": "Zone [GND] on F.Cu", "pos": {"x": float(index), "y": 1.0}},
+                {"description": f"Pad {index} [GND] of U1 on B.Cu", "pos": {"x": 2.0, "y": 2.0}},
+            ],
+        }
+
+    @staticmethod
+    def _clearance() -> dict:
+        return {
+            "type": "clearance",
+            "severity": "error",
+            "description": "Clearance violation (clearance 0.2000 mm; actual 0.1000 mm)",
+            "items": [{"description": "Track [VCC] on F.Cu", "pos": {"x": 5.0, "y": 5.0}}],
+        }
+
+    def test_unconnected_items_are_not_geometric_violations(self, tmp_path: Path):
+        """A JSON report of pure connectivity items is geometrically clean."""
+        report = self._json_report(
+            tmp_path, violations=[], unconnected=[self._unconnected(i) for i in range(12)]
+        )
+
+        # Geometric contract: unchanged, still zero.
+        assert report.violations == []
+        assert report.violation_count == 0
+        assert report.error_count == 0
+        assert report.by_type(ViolationType.UNCONNECTED_ITEMS) == []
+
+        # Connectivity contract: the 12 relationships are available.
+        assert report.unconnected_item_count == 12
+        assert len(report.connectivity_items()) == 12
+        assert all(v.type == ViolationType.UNCONNECTED_ITEMS for v in report.unconnected_items)
+        assert all(v.is_connection for v in report.unconnected_items)
+        assert report.unconnected_items[0].nets == ["GND"]
+
+    def test_geometric_violations_still_counted_alongside_connectivity(self, tmp_path: Path):
+        """Geometry keeps counting geometry; connectivity is not added in."""
+        report = self._json_report(
+            tmp_path,
+            violations=[self._clearance()],
+            unconnected=[self._unconnected(i) for i in range(12)],
+        )
+
+        assert report.violation_count == 1
+        assert report.error_count == 1
+        assert report.violations[0].type == ViolationType.CLEARANCE
+        assert report.unconnected_item_count == 12
+
+    def test_text_report_connectivity_shape_is_unchanged(self, sample_drc_report: Path):
+        """The flat text ``.rpt`` format keeps its legacy single-list shape."""
+        report = DRCReport.load(sample_drc_report)
+
+        # Text reports have no sibling array -- the entries stay in
+        # ``violations`` exactly as before #4498 ...
+        assert report.unconnected_items == []
+        assert len(report.by_type(ViolationType.UNCONNECTED_ITEMS)) == 1
+        # ... and ``connectivity_items()`` still finds them (no double count).
+        assert len(report.connectivity_items()) == 1
+
+    def test_apply_filters_preserves_connectivity_items(self, tmp_path: Path):
+        """Geometric filtering never silently drops connectivity items."""
+        from kicad_tools.validate.filters import ViolationFilter
+
+        report = self._json_report(
+            tmp_path,
+            violations=[self._clearance()],
+            unconnected=[self._unconnected(i) for i in range(3)],
+        )
+        filtered = report.apply_filters(
+            [ViolationFilter(type_pattern="clearance", action="ignore")]
+        )
+
+        assert filtered.violation_count == 0
+        assert filtered.unconnected_item_count == 3
+
+
 class TestDRCReportQueries:
     """Tests for DRC report query methods."""
 


### PR DESCRIPTION
## Summary

Report same-net copper components that remain physically disconnected, including zone↔zone, zone↔pad, and pad↔pad relationships. Zone-bearing nets use a layer-aware per-item graph; the default connectivity CLI reconciles against KiCad's refill-time graph when `kicad-cli` is available and falls back to the internal graph otherwise.

## Changes

- model pads, vias, segments, and individual filled polygons as layer-aware copper graph nodes
- preserve thermal-boundary behavior without collapsing distinct fill islands
- parse KiCad JSON `unconnected_items` into a **dedicated** `DRCReport.unconnected_items` collection (never into `DRCReport.violations`) and use that refill-time result as the authoritative optional reconciliation path
- display `zone_island` relationships and counts in default table, human summary, and JSON summary output
- add distinct connected-island coverage plus real `kicad-cli`-gated fleet parity tests

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Root cause documented | ✅ | The former pad-partition model collapsed zone connectivity after one pad attachment and discarded synthetic-only components. The replacement models each same-net copper item/component. |
| Report fleet relationships | ✅ | Internal graph: board03 **12**, board05 **60**. Native reconciliation: board03 **12**, board05 **57**. The documented board05 residual three are refill-time thermal associations not explicit in persisted solid geometry; the native path is authoritative when available. |
| Native-gated end-to-end coverage | ✅ | Parametrized tests invoke `kicad-cli pcb drc --refill-zones` through the validator and assert committed board03/board05 counts of **12/57**. They skip only when `kicad-cli` is unavailable. |
| Default CLI reports the items | ✅ | Table, summary, and JSON CLI regressions exercise a deterministic board03-style **12-item** result; a real board03 smoke check displays/categorizes all 12 and does not claim `0 unconnected pads`. |
| Geometric DRC contract preserved | ✅ | Connectivity relationships land in `DRCReport.unconnected_items` / `connectivity_items()`; `violations`, `violation_count`, and `error_count` keep their pre-PR geometry-only meaning, so `run_geometric_drc()` consumers (route gate, audit, board-clean regressions) are unchanged. Dual-contract tests assert 12 connectivity relationships and 0 geometric errors from the *same* board-03 report. |
| No false positives for connected islands | ✅ | The negative fixture uses spatially distinct fill islands, separate same-net pads, and a real connecting segment. |

## Test Plan

- `uv run pytest -q -o addopts='' tests/test_connectivity.py tests/test_drc.py tests/test_drc_summary.py tests/test_drc_category.py tests/test_drc_report_formats.py tests/test_drc_violation_type_validate.py tests/test_board_03_regression.py tests/router/mesh/test_pathfinder.py tests/router/lattice/test_via_in_pad_last_resort.py` — **390 passed, 1 skipped**
- previously-failing geometry-only tests (unmodified, still asserting `error_count == 0`) — ✅ `test_walled_via_in_pad_last_resort_is_drc_clean`, `test_routes_single_net_emits_45_legal_drc_clean_charlieplex`, `test_committed_routed_board_is_geometrically_clean_with_refill`
- wider DRC consumers (`test_audit.py`, `test_recipes_gate.py`, `test_route_post_drc_geometric.py`, `test_violation_filters.py`, `test_stitch_cmd.py`, …) — **877 passed**
- real board03 CLI table/summary/JSON smoke — **12 visible/categorized items in every format**, expected exit 1
- `uv run ruff format . --check` — passed
- `uv run ruff check .` — passed
- `uv run python scripts/ci/check_mypy_baseline.py` — passed (**1473 current / 1474 allowed**)
- `git diff --check` — passed

Closes #4498

