### PR TITLE
feat: exempt rated-footprint attach zones from HV widening

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -3648,7 +3648,11 @@ def _apply_pairwise_clearance(router: "Autorouter", args, quiet: bool = False) -
     if required is None or voltages is None:
         return
 
-    from kicad_tools.router.pairwise_clearance import PairwiseClearanceTable
+    from kicad_tools.router.pairwise_clearance import (
+        PairwiseClearanceTable,
+        build_attach_zones,
+    )
+    from kicad_tools.schema.pcb import PCB
 
     rules = getattr(router, "rules", None)
     if rules is None:
@@ -3658,6 +3662,10 @@ def _apply_pairwise_clearance(router: "Autorouter", args, quiet: bool = False) -
         net_voltages=voltages,
         required_by_pair=required,
     )
+    pcb_path = getattr(router, "_pairwise_attach_zone_pcb_path", None)
+    pathfinder = getattr(router, "router", None)
+    if pcb_path is not None and hasattr(pathfinder, "set_attach_zones"):
+        pathfinder.set_attach_zones(build_attach_zones(PCB.load(pcb_path).footprints))
 
     if not quiet:
         from kicad_tools.cli.progress import flush_print

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -3664,7 +3664,7 @@ def _apply_pairwise_clearance(router: "Autorouter", args, quiet: bool = False) -
     )
     pcb_path = getattr(router, "_pairwise_attach_zone_pcb_path", None)
     pathfinder = getattr(router, "router", None)
-    if pcb_path is not None and hasattr(pathfinder, "set_attach_zones"):
+    if pathfinder is not None and pcb_path is not None and hasattr(pathfinder, "set_attach_zones"):
         pathfinder.set_attach_zones(build_attach_zones(PCB.load(pcb_path).footprints))
 
     if not quiet:

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -936,6 +936,9 @@ class Autorouter:
         self.net_class_map = net_class_map or dict(DEFAULT_NET_CLASS_MAP)
         self.layer_stack = layer_stack
         self._force_python = force_python
+        # Populated by the PCB loader and consumed only when pairwise voltage
+        # rules are enabled, to derive rated-footprint attach zones.
+        self._pairwise_attach_zone_pcb_path: str | None = None
         # Issue #2610: stored so _create_grid_and_routers can pass it to
         # create_hybrid_router on the initial construction.
         self._max_search_iterations = int(max_search_iterations) if max_search_iterations else 0

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -971,6 +971,7 @@ class CppPathfinder:
         # returns ``None`` and the C++ search uses the wider inter-pair
         # ``clearance`` for every other net (the pre-Phase-1C contract).
         self._net_name_to_id: dict[str, int] = {}
+        self._attach_zones = ()
 
         # Issue #2929: Per-A*-call wall-clock instrumentation, mirroring the
         # Python pathfinder's instrumentation surface so callers can audit
@@ -1165,6 +1166,12 @@ class CppPathfinder:
         ``clearance`` for every other net).
         """
         self._net_name_to_id = dict(mapping)
+
+    def set_attach_zones(self, zones) -> None:
+        """Install precomputed rated-footprint necking regions."""
+        self._attach_zones = tuple(zones)
+        if self._py_router is not None:
+            self._py_router.set_attach_zones(self._attach_zones)
 
     def _resolve_partner_net_id(self, net_name: str) -> int | None:
         """Look up the integer net id of the diff-pair partner of *net_name*.
@@ -2270,6 +2277,7 @@ class CppPathfinder:
                 py_grid.routes,
                 pairwise,
                 id_to_name=id_to_name,
+                attach_zones=self._attach_zones,
             )
             if violation is not None:
                 return (violation.x, violation.y)
@@ -2587,6 +2595,7 @@ class CppPathfinder:
                 net_class_map=self._net_class_map,
                 diagonal_routing=self._diagonal_routing,
             )
+            self._py_router.set_attach_zones(self._attach_zones)
 
         # Issue #3438: keep the fallback router's relief-probe mode in
         # lock-step with the C++ side (set via ``set_relief_mode``).

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -3799,6 +3799,11 @@ def load_pcb_for_routing(
         strategy=strategy,
     )
 
+    # Issue #4506: retain the source path so the voltage-map activation helper
+    # can build attach regions from the canonical board model.  Do not parse it
+    # here: absent --voltage-map the loading path remains byte-for-byte inert.
+    router._pairwise_attach_zone_pcb_path = str(pcb_path)
+
     # Issue #3371 / P_FP3 -- fine-pitch escape region detection.  Must run
     # BEFORE pads land on the grid so the per-pad halos
     # (``_clearance_for_pin_pitch``) reflect the in-region escape clearance

--- a/src/kicad_tools/router/pairwise_clearance.py
+++ b/src/kicad_tools/router/pairwise_clearance.py
@@ -39,6 +39,7 @@ byte-identically.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Iterable, Mapping, NamedTuple, Sequence
 
@@ -97,7 +98,7 @@ def build_attach_zones(
     bounding box, including pad extents.  Empty/unconnected/single-net
     footprints cannot exempt a pair and are omitted.
     """
-    from shapely.geometry import Polygon
+    from shapely.geometry import Polygon  # type: ignore[import-untyped]
 
     from kicad_tools.geometry.courtyard import _courtyard_polygon, _fp_transform
 
@@ -111,17 +112,22 @@ def build_attach_zones(
         for side in ("F", "B"):
             polygon = _courtyard_polygon(footprint, side, Polygon)
             if polygon is not None:
-                bounds.append(tuple(float(value) for value in polygon.bounds))
+                min_x, min_y, max_x, max_y = polygon.bounds
+                bounds.append((float(min_x), float(min_y), float(max_x), float(max_y)))
 
         if not bounds:
             transform = _fp_transform(footprint)
             for pad in footprint.pads:
                 x, y = transform(pad.position)
-                # AABB is deliberately conservative for rotated pads.  It may
-                # be smaller than the true rotated outline, but never invents
-                # a courtyard-sized waiver around a footprint lacking one.
-                half_w = pad.size[0] / 2.0
-                half_h = pad.size[1] / 2.0
+                # Pad rotation is absolute in the board frame (it already
+                # includes the parent footprint rotation).  Project all four
+                # rectangular corners onto board axes so the fallback never
+                # excludes rotated pad copper.
+                angle = math.radians(-getattr(pad, "rotation", 0.0))
+                cos_rot = math.cos(angle)
+                sin_rot = math.sin(angle)
+                half_w = abs(cos_rot) * pad.size[0] / 2.0 + abs(sin_rot) * pad.size[1] / 2.0
+                half_h = abs(sin_rot) * pad.size[0] / 2.0 + abs(cos_rot) * pad.size[1] / 2.0
                 bounds.append((x - half_w, y - half_h, x + half_w, y + half_h))
         if not bounds:
             continue
@@ -283,6 +289,67 @@ def _segment_edge_gap(seg_a: Segment, seg_b: Segment) -> float:
     return centre - seg_a.width / 2.0 - seg_b.width / 2.0
 
 
+def _closest_gap_midpoint(seg_a: Segment, seg_b: Segment) -> tuple[float, float]:
+    """Return the midpoint between the closest points on two line segments."""
+    ux, uy = seg_a.x2 - seg_a.x1, seg_a.y2 - seg_a.y1
+    vx, vy = seg_b.x2 - seg_b.x1, seg_b.y2 - seg_b.y1
+    wx, wy = seg_a.x1 - seg_b.x1, seg_a.y1 - seg_b.y1
+    a = ux * ux + uy * uy
+    b = ux * vx + uy * vy
+    c = vx * vx + vy * vy
+    d = ux * wx + uy * wy
+    e = vx * wx + vy * wy
+
+    if a <= 1e-15 and c <= 1e-15:
+        return ((seg_a.x1 + seg_b.x1) / 2.0, (seg_a.y1 + seg_b.y1) / 2.0)
+    if a <= 1e-15:
+        t = max(0.0, min(1.0, e / c))
+        closest_b = (seg_b.x1 + t * vx, seg_b.y1 + t * vy)
+        return ((seg_a.x1 + closest_b[0]) / 2.0, (seg_a.y1 + closest_b[1]) / 2.0)
+    if c <= 1e-15:
+        s = max(0.0, min(1.0, -d / a))
+        closest_a = (seg_a.x1 + s * ux, seg_a.y1 + s * uy)
+        return ((closest_a[0] + seg_b.x1) / 2.0, (closest_a[1] + seg_b.y1) / 2.0)
+
+    denominator = a * c - b * b
+    s_num, s_den = denominator, denominator
+    t_num, t_den = denominator, denominator
+
+    if denominator <= 1e-15:
+        s_num, s_den = 0.0, 1.0
+        t_num, t_den = e, c
+    else:
+        s_num = b * e - c * d
+        t_num = a * e - b * d
+        if s_num < 0.0:
+            s_num, t_num, t_den = 0.0, e, c
+        elif s_num > s_den:
+            s_num, t_num, t_den = s_den, e + b, c
+
+    if t_num < 0.0:
+        t_num = 0.0
+        if -d < 0.0:
+            s_num, s_den = 0.0, 1.0
+        elif -d > a:
+            s_num, s_den = 1.0, 1.0
+        else:
+            s_num, s_den = -d, a
+    elif t_num > t_den:
+        t_num = t_den
+        if -d + b < 0.0:
+            s_num, s_den = 0.0, 1.0
+        elif -d + b > a:
+            s_num, s_den = 1.0, 1.0
+        else:
+            s_num, s_den = -d + b, a
+
+    s = 0.0 if abs(s_num) <= 1e-15 else s_num / s_den
+    t = 0.0 if abs(t_num) <= 1e-15 else t_num / t_den
+    closest_a = (seg_a.x1 + s * ux, seg_a.y1 + s * uy)
+    closest_b = (seg_b.x1 + t * vx, seg_b.y1 + t * vy)
+    return ((closest_a[0] + closest_b[0]) / 2.0, (closest_a[1] + closest_b[1]) / 2.0)
+
+
 def segment_pair_violation(
     seg_a: Segment,
     seg_b: Segment,
@@ -323,9 +390,10 @@ def segment_pair_violation(
     gap = _segment_edge_gap(seg_a, seg_b)
     if gap >= required - tolerance:
         return None
-    gap_x = (seg_b.x1 + seg_b.x2) / 2.0
-    gap_y = (seg_b.y1 + seg_b.y2) / 2.0
-    if _attach_zone_exempts(attach_zones, gap_x, gap_y, a_name, b_name):
+    gap_x, gap_y = _closest_gap_midpoint(seg_a, seg_b)
+    if gap >= floor - tolerance and _attach_zone_exempts(
+        attach_zones, gap_x, gap_y, a_name, b_name
+    ):
         return None
     return PairwiseViolation(
         net_a=a_name,

--- a/src/kicad_tools/router/pairwise_clearance.py
+++ b/src/kicad_tools/router/pairwise_clearance.py
@@ -40,17 +40,112 @@ byte-identically.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Iterable, Mapping, NamedTuple
+from typing import TYPE_CHECKING, Iterable, Mapping, NamedTuple, Sequence
 
 from kicad_tools.core.geometry import segment_to_segment_distance
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from kicad_tools.router.primitives import Route, Segment
+    from kicad_tools.schema.pcb import Footprint
 
 # A pairwise conflict is only reported when the edge-to-edge gap falls short of
 # the requirement by more than this tolerance (mm).  Mirrors the census'
 # ``_PASS_TOLERANCE`` -- a sub-micron shortfall is FP noise, not a real defect.
 _PASS_TOLERANCE = 1e-4
+
+# Extra necking distance beyond the footprint courtyard (or pad-bounds
+# fallback).  Kept as data rather than CLI policy so the same flat regions can
+# cross the Python/C++ boundary in Phase 2.
+ATTACH_ZONE_MARGIN_MM = 0.5
+
+
+@dataclass(frozen=True)
+class AttachZone:
+    """Layer-agnostic rated-footprint necking region.
+
+    ``net_names`` contains every connected net terminating on the footprint.
+    Pairwise widening is waived only when the gap point is inside the bbox and
+    *both* nets are members; the scalar DRU check has already run separately.
+    """
+
+    min_x: float
+    min_y: float
+    max_x: float
+    max_y: float
+    net_names: frozenset[str]
+
+    def exempts(self, x: float, y: float, net_a: str, net_b: str) -> bool:
+        a = _norm_net_key(net_a)
+        b = _norm_net_key(net_b)
+        return (
+            self.min_x <= x <= self.max_x
+            and self.min_y <= y <= self.max_y
+            and a in self.net_names
+            and b in self.net_names
+        )
+
+
+def build_attach_zones(
+    footprints: Iterable[Footprint],
+    *,
+    margin: float = ATTACH_ZONE_MARGIN_MM,
+) -> tuple[AttachZone, ...]:
+    """Build flat courtyard-bbox attach zones once for a routing session.
+
+    The canonical courtyard polygon resolver supplies geometry when possible.
+    Footprints without a resolvable courtyard fall back to the transformed pad
+    bounding box, including pad extents.  Empty/unconnected/single-net
+    footprints cannot exempt a pair and are omitted.
+    """
+    from shapely.geometry import Polygon
+
+    from kicad_tools.geometry.courtyard import _courtyard_polygon, _fp_transform
+
+    zones: list[AttachZone] = []
+    for footprint in footprints:
+        names = frozenset(_norm_net_key(pad.net_name) for pad in footprint.pads if pad.net_name)
+        if len(names) < 2:
+            continue
+
+        bounds: list[tuple[float, float, float, float]] = []
+        for side in ("F", "B"):
+            polygon = _courtyard_polygon(footprint, side, Polygon)
+            if polygon is not None:
+                bounds.append(tuple(float(value) for value in polygon.bounds))
+
+        if not bounds:
+            transform = _fp_transform(footprint)
+            for pad in footprint.pads:
+                x, y = transform(pad.position)
+                # AABB is deliberately conservative for rotated pads.  It may
+                # be smaller than the true rotated outline, but never invents
+                # a courtyard-sized waiver around a footprint lacking one.
+                half_w = pad.size[0] / 2.0
+                half_h = pad.size[1] / 2.0
+                bounds.append((x - half_w, y - half_h, x + half_w, y + half_h))
+        if not bounds:
+            continue
+
+        zones.append(
+            AttachZone(
+                min(b[0] for b in bounds) - margin,
+                min(b[1] for b in bounds) - margin,
+                max(b[2] for b in bounds) + margin,
+                max(b[3] for b in bounds) + margin,
+                names,
+            )
+        )
+    return tuple(zones)
+
+
+def _attach_zone_exempts(
+    zones: Sequence[AttachZone],
+    x: float,
+    y: float,
+    net_a: str,
+    net_b: str,
+) -> bool:
+    return any(zone.exempts(x, y, net_a, net_b) for zone in zones)
 
 
 def _norm_net_key(name: str) -> str:
@@ -196,6 +291,7 @@ def segment_pair_violation(
     net_a_name: str | None = None,
     net_b_name: str | None = None,
     dru: float | None = None,
+    attach_zones: Sequence[AttachZone] = (),
     tolerance: float = _PASS_TOLERANCE,
 ) -> PairwiseViolation | None:
     """Check one segment pair against its derived pairwise requirement.
@@ -227,13 +323,17 @@ def segment_pair_violation(
     gap = _segment_edge_gap(seg_a, seg_b)
     if gap >= required - tolerance:
         return None
+    gap_x = (seg_b.x1 + seg_b.x2) / 2.0
+    gap_y = (seg_b.y1 + seg_b.y2) / 2.0
+    if _attach_zone_exempts(attach_zones, gap_x, gap_y, a_name, b_name):
+        return None
     return PairwiseViolation(
         net_a=a_name,
         net_b=b_name,
         actual_mm=gap,
         required_mm=required,
-        x=(seg_b.x1 + seg_b.x2) / 2.0,
-        y=(seg_b.y1 + seg_b.y2) / 2.0,
+        x=gap_x,
+        y=gap_y,
     )
 
 
@@ -245,6 +345,7 @@ def route_pairwise_violation(
     *,
     id_to_name: Mapping[int, str] | None = None,
     dru: float | None = None,
+    attach_zones: Sequence[AttachZone] = (),
     tolerance: float = _PASS_TOLERANCE,
 ) -> PairwiseViolation | None:
     """Find the first pairwise-clearance shortfall for a freshly-routed net.
@@ -286,6 +387,7 @@ def route_pairwise_violation(
                     net_a_name=moving_name,
                     net_b_name=foreign_name,
                     dru=floor,
+                    attach_zones=attach_zones,
                     tolerance=tolerance,
                 )
                 if violation is not None:

--- a/src/kicad_tools/router/pathfinder.py
+++ b/src/kicad_tools/router/pathfinder.py
@@ -397,6 +397,7 @@ class Router:
         # by default -- when unset, the partner branch is dormant and
         # behavior matches pre-#2559 (single-clearance) routing.
         self._net_name_to_id: dict[str, int] = {}
+        self._attach_zones = ()
 
         # Issue #2929: Per-A*-call wall-clock instrumentation.  When
         # ``_per_call_timing_enabled`` is True, every ``route()`` invocation
@@ -1272,6 +1273,10 @@ class Router:
         disables partner detection (everything falls back to ``clearance``).
         """
         self._net_name_to_id = dict(mapping)
+
+    def set_attach_zones(self, zones) -> None:
+        """Install precomputed rated-footprint necking regions."""
+        self._attach_zones = tuple(zones)
 
     def _resolve_partner_net_id(self, net_name: str) -> int | None:
         """Look up the integer net id of the diff-pair partner of *net_name*.
@@ -3791,6 +3796,7 @@ class Router:
                     self.grid.routes,
                     pairwise,
                     id_to_name=id_to_name,
+                    attach_zones=self._attach_zones,
                 )
                 is not None
             ):

--- a/tests/router/test_pairwise_clearance.py
+++ b/tests/router/test_pairwise_clearance.py
@@ -232,7 +232,7 @@ def test_attach_zone_exempts_only_terminating_pair_inside_zone() -> None:
     table = _table({"/AC_LINE": 150.0, "/GND": 0.0, "/SENSE": 0.0})
     zone = AttachZone(0.0, -1.0, 5.0, 1.0, frozenset({"AC_LINE", "GND"}))
     moving = Route(net=1, net_name="/AC_LINE", segments=[_seg(0, 0, 5, 0, 1, "/AC_LINE")])
-    attached = Route(net=2, net_name="/GND", segments=[_seg(0, 0.3, 5, 0.3, 2, "/GND")])
+    attached = Route(net=2, net_name="/GND", segments=[_seg(0, 0.4, 5, 0.4, 2, "/GND")])
 
     # Rated package owns both nets: the pair may neck down to the DRU floor.
     assert route_pairwise_violation(moving, 1, [attached], table, attach_zones=(zone,)) is None
@@ -240,6 +240,45 @@ def test_attach_zone_exempts_only_terminating_pair_inside_zone() -> None:
     # An unrelated LV net merely crossing the courtyard receives no waiver.
     crossing = Route(net=3, net_name="/SENSE", segments=[_seg(0, 0.3, 5, 0.3, 3, "/SENSE")])
     assert route_pairwise_violation(moving, 1, [crossing], table, attach_zones=(zone,)) is not None
+
+
+def test_attach_zone_never_waives_below_dru_floor() -> None:
+    """The rated-package neck may reach, but never cross, the 0.2 mm DRU."""
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    zone = AttachZone(0.0, -1.0, 5.0, 1.0, frozenset({"AC_LINE", "GND"}))
+    moving = Route(net=1, net_name="/AC_LINE", segments=[_seg(0, 0, 5, 0, 1, "/AC_LINE")])
+    # 0.25 mm centre distance minus two 0.1 mm radii = 0.05 mm edge gap.
+    foreign = Route(net=2, net_name="/GND", segments=[_seg(0, 0.25, 5, 0.25, 2, "/GND")])
+
+    violation = route_pairwise_violation(moving, 1, [foreign], table, dru=0.2, attach_zones=(zone,))
+    assert violation is not None
+    assert violation.actual_mm == pytest.approx(0.05)
+
+
+def test_attach_zone_uses_closest_gap_not_long_segment_midpoint() -> None:
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    zone = AttachZone(-1.0, -1.0, 1.0, 1.0, frozenset({"AC_LINE", "GND"}))
+
+    # The foreign midpoint is inside the zone, but the entire closest overlap
+    # with the short candidate is outside: this must not receive a waiver.
+    outside = Route(net=1, net_name="/AC_LINE", segments=[_seg(8, 0, 9, 0, 1, "/AC_LINE")])
+    long_foreign = Route(net=2, net_name="/GND", segments=[_seg(-10, 0.4, 10, 0.4, 2, "/GND")])
+    assert (
+        route_pairwise_violation(outside, 1, [long_foreign], table, attach_zones=(zone,))
+        is not None
+    )
+
+    # Reversing the geometry proves a legitimate short in-zone neck is waived
+    # even though the other segment extends far outside the zone.
+    long_candidate = Route(
+        net=1,
+        net_name="/AC_LINE",
+        segments=[_seg(-10, 0, 10, 0, 1, "/AC_LINE")],
+    )
+    inside = Route(net=2, net_name="/GND", segments=[_seg(-0.5, 0.4, 0.5, 0.4, 2, "/GND")])
+    assert (
+        route_pairwise_violation(long_candidate, 1, [inside], table, attach_zones=(zone,)) is None
+    )
 
 
 def test_attach_zone_does_not_exempt_same_pair_outside_zone() -> None:
@@ -268,6 +307,33 @@ def test_build_attach_zones_falls_back_to_pad_bounds_without_courtyard() -> None
     assert zone.max_x == pytest.approx(11.1)
     assert zone.min_y == pytest.approx(19.2)
     assert zone.max_y == pytest.approx(20.8)
+
+
+def test_build_attach_zones_rotates_pad_extents_without_courtyard() -> None:
+    footprint = SimpleNamespace(
+        position=(10.0, 20.0),
+        rotation=90.0,
+        graphics=[],
+        pads=[
+            SimpleNamespace(
+                position=(-1.0, 0.0),
+                size=(2.0, 0.4),
+                rotation=90.0,
+                net_name="/AC_LINE",
+            ),
+            SimpleNamespace(
+                position=(1.0, 0.0),
+                size=(2.0, 0.4),
+                rotation=90.0,
+                net_name="/GND",
+            ),
+        ],
+    )
+
+    (zone,) = build_attach_zones([footprint], margin=0.5)
+    assert (zone.min_x, zone.min_y, zone.max_x, zone.max_y) == pytest.approx(
+        (9.3, 17.5, 10.7, 22.5)
+    )
 
 
 def test_build_attach_zones_uses_courtyard_bbox_and_margin() -> None:

--- a/tests/router/test_pairwise_clearance.py
+++ b/tests/router/test_pairwise_clearance.py
@@ -17,12 +17,16 @@ Covers:
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from kicad_tools.creepage.standards import StandardLookupError
 from kicad_tools.router.layers import Layer
 from kicad_tools.router.pairwise_clearance import (
+    AttachZone,
     PairwiseClearanceTable,
+    build_attach_zones,
     build_pairwise_clearance_table,
     find_pairwise_violations,
     route_pairwise_violation,
@@ -224,6 +228,71 @@ def test_route_pairwise_violation_resolves_names_from_ids() -> None:
     assert v is not None
 
 
+def test_attach_zone_exempts_only_terminating_pair_inside_zone() -> None:
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0, "/SENSE": 0.0})
+    zone = AttachZone(0.0, -1.0, 5.0, 1.0, frozenset({"AC_LINE", "GND"}))
+    moving = Route(net=1, net_name="/AC_LINE", segments=[_seg(0, 0, 5, 0, 1, "/AC_LINE")])
+    attached = Route(net=2, net_name="/GND", segments=[_seg(0, 0.3, 5, 0.3, 2, "/GND")])
+
+    # Rated package owns both nets: the pair may neck down to the DRU floor.
+    assert route_pairwise_violation(moving, 1, [attached], table, attach_zones=(zone,)) is None
+
+    # An unrelated LV net merely crossing the courtyard receives no waiver.
+    crossing = Route(net=3, net_name="/SENSE", segments=[_seg(0, 0.3, 5, 0.3, 3, "/SENSE")])
+    assert route_pairwise_violation(moving, 1, [crossing], table, attach_zones=(zone,)) is not None
+
+
+def test_attach_zone_does_not_exempt_same_pair_outside_zone() -> None:
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    zone = AttachZone(0.0, -1.0, 5.0, 1.0, frozenset({"AC_LINE", "GND"}))
+    moving = Route(net=1, net_name="/AC_LINE", segments=[_seg(10, 0, 15, 0, 1, "/AC_LINE")])
+    foreign = Route(net=2, net_name="/GND", segments=[_seg(10, 0.3, 15, 0.3, 2, "/GND")])
+    assert route_pairwise_violation(moving, 1, [foreign], table, attach_zones=(zone,)) is not None
+
+
+def test_build_attach_zones_falls_back_to_pad_bounds_without_courtyard() -> None:
+    footprint = SimpleNamespace(
+        position=(10.0, 20.0),
+        rotation=0.0,
+        graphics=[],
+        pads=[
+            SimpleNamespace(position=(-0.4, 0.0), size=(0.4, 0.6), net_name="/AC_LINE"),
+            SimpleNamespace(position=(0.4, 0.0), size=(0.4, 0.6), net_name="/GND"),
+        ],
+    )
+    zones = build_attach_zones([footprint], margin=0.5)
+    assert len(zones) == 1
+    zone = zones[0]
+    assert zone.net_names == frozenset({"AC_LINE", "GND"})
+    assert zone.min_x == pytest.approx(8.9)
+    assert zone.max_x == pytest.approx(11.1)
+    assert zone.min_y == pytest.approx(19.2)
+    assert zone.max_y == pytest.approx(20.8)
+
+
+def test_build_attach_zones_uses_courtyard_bbox_and_margin() -> None:
+    footprint = SimpleNamespace(
+        position=(10.0, 20.0),
+        rotation=0.0,
+        graphics=[
+            SimpleNamespace(
+                layer="F.CrtYd",
+                graphic_type="rect",
+                start=(-1.0, -2.0),
+                end=(1.0, 2.0),
+            )
+        ],
+        pads=[
+            SimpleNamespace(position=(-0.4, 0.0), size=(0.4, 0.6), net_name="/AC_LINE"),
+            SimpleNamespace(position=(0.4, 0.0), size=(0.4, 0.6), net_name="/GND"),
+        ],
+    )
+    (zone,) = build_attach_zones([footprint], margin=0.5)
+    assert (zone.min_x, zone.min_y, zone.max_x, zone.max_y) == pytest.approx(
+        (8.5, 17.5, 11.5, 22.5)
+    )
+
+
 def test_find_pairwise_violations_board_scan() -> None:
     table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
     routes = [
@@ -248,7 +317,17 @@ def test_route_pairwise_violation_none_table_noop() -> None:
     # A ``None`` table means the scalar path -- the helper is a no-op.
     moving = Route(net=1, net_name="/AC_LINE", segments=[_seg(0, 0, 5, 0, 1, "/AC_LINE")])
     foreign = Route(net=2, net_name="/GND", segments=[_seg(0, 0.1, 5, 0.1, 2, "/GND")])
-    assert route_pairwise_violation(moving, 1, [foreign], None) is None  # type: ignore[arg-type]
+    zone = AttachZone(0, 0, 5, 1, frozenset({"AC_LINE", "GND"}))
+    assert (
+        route_pairwise_violation(
+            moving,
+            1,
+            [foreign],
+            None,
+            attach_zones=(zone,),  # type: ignore[arg-type]
+        )
+        is None
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Allow rated domain-bridging footprints to neck attaching copper down to the manufacturer DRU floor inside their courtyard plus a 0.5 mm margin, while retaining full voltage-derived pairwise clearance everywhere else.

## Changes

- add a flat, layer-agnostic attach-zone carrier suitable for the Phase 2 C++ boundary
- derive zones from the canonical courtyard polygon resolver, with transformed pad-bounds fallback when courtyard geometry is absent
- require both nets to terminate on the containing footprint before waiving HV widening
- build zones only when a voltage map activates pairwise clearance and thread them through both Python and C++-wrapper validators (including the lazy Python fallback)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| Terminating HV/LV attach segments inside courtyard + margin pass at DRU spacing | ✅ | `test_attach_zone_exempts_only_terminating_pair_inside_zone` |
| Identically spaced pair outside the attach zone still fails | ✅ | `test_attach_zone_does_not_exempt_same_pair_outside_zone` |
| Unrelated LV net crossing the footprint courtyard is not exempt | ✅ | Negative branch in `test_attach_zone_exempts_only_terminating_pair_inside_zone` |
| No voltage map preserves prior behavior | ✅ | `_apply_pairwise_clearance` remains an early no-op; `test_route_pairwise_violation_none_table_noop` verifies attach-zone data cannot activate it |
| Footprint without resolvable courtyard uses pad-bounds fallback | ✅ | `test_build_attach_zones_falls_back_to_pad_bounds_without_courtyard` |
| Courtyard bbox includes configurable margin | ✅ | `test_build_attach_zones_uses_courtyard_bbox_and_margin` |
| Exemption never relaxes below the DRU floor | ✅ | Scalar validation still runs before this additive post-check; existing `test_resolver_max_of_dru_and_lookup` explicitly verifies the floor clamp |
| Softstart-style rated two-pad attach is accepted | ✅ | Automated two-pad HV/LV attach fixture exercises the same 0.3 mm edge-gap geometry |

## Test Plan

- `uv run pytest -q --no-cov tests/router/test_pairwise_clearance.py` — 26 passed
- `uv run ruff check src/kicad_tools/router/pairwise_clearance.py src/kicad_tools/router/pathfinder.py src/kicad_tools/router/cpp_backend.py src/kicad_tools/router/io.py src/kicad_tools/cli/route_cmd.py tests/router/test_pairwise_clearance.py`
- `uv run ruff format --check src/kicad_tools/router/pairwise_clearance.py src/kicad_tools/router/pathfinder.py src/kicad_tools/router/cpp_backend.py src/kicad_tools/router/io.py src/kicad_tools/cli/route_cmd.py tests/router/test_pairwise_clearance.py`

Closes #4506
