### PR TITLE
chore: untrack .loom-managed worktree marker from git

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,0 @@
-# Loom-managed worktree marker
-# Created by .loom/scripts/worktree.sh
-# Issue: 4491
-# Branch: feature/issue-4491
-# Removing this file makes Loom treat the worktree as user-owned and refuse
-# to clean it up automatically.


### PR DESCRIPTION
## Summary

`.loom-managed` is a per-worktree runtime marker written by `.loom/scripts/worktree.sh`. It is listed in `.gitignore` (line 51, inside the `>>> loom-managed <<<` block), but it was accidentally committed to `main` in the #4443 merge (content: `Issue: 4415`). Because gitignore only suppresses *untracked* files, the tracked copy made every builder worktree see a locally-modified tracked file, so `git add -A` swept a spurious `.loom-managed` diff into feature commits (observed in PR #4499: 4415 -> 4473).

This PR untracks the file with `git rm --cached`, which removes it from the index only. Working copies in all active loom worktrees are left on disk untouched, and the existing `.gitignore` entry takes effect immediately.

## Changes

- `git rm --cached .loom-managed` — single-file, single-commit removal from git tracking. No file contents were edited and no file was deleted from disk.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `.loom-managed` no longer tracked (`git ls-files .loom-managed` empty) | ✅ | `git ls-files .loom-managed` returns no output post-commit |
| Existing `.gitignore` entry now takes effect | ✅ | `git status --ignored --short` lists `!! .loom-managed`; `git status --short` is clean (the marker is no longer picked up by `git add -A`) |
| No working-copy `.loom-managed` deleted or modified | ✅ | `--cached` only; this worktree's own marker is still on disk and still reads `# Issue: 4500` |
| No other tracked files touched (single-file, single-commit) | ✅ | `git diff --stat origin/main..HEAD` -> `.loom-managed \| 6 ------`, 1 file changed, 6 deletions |

## Test Plan

- `git ls-files .loom-managed` -> empty (file untracked)
- `git status --ignored --short` -> `!! .loom-managed` (gitignore rule active)
- `head -3 .loom-managed` -> still present on disk with this worktree's own issue number (4500)
- `git status --short` -> clean, marker no longer appears as a modification
- `./.loom/scripts/check-main-clean.sh` -> main checkout untouched (exit 0)

No code paths change; no build or test impact.

Closes #4500