### PR TITLE
fix(cli): make outer --auto-layers tri-state so explicit overrides reach route_cmd

### DIFF
--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -524,9 +524,17 @@ def run_route_command(args) -> int:
     # Issue #2388: --auto-layers is now enabled by default.  Forward only
     # the user's explicit choice (so the default takes effect when neither
     # is passed and --no-auto-layers is honored when disabled).
-    auto_layers_attr = getattr(args, "auto_layers", True)
+    # Issue #4502: the outer parser is tri-state (default=None), so an
+    # explicit ``--auto-layers`` is now distinguishable from "unset" and
+    # must be forwarded literally -- the inner argv-sniffing sites
+    # (_apply_complete_mode_defaults, and the --auto-layers/--layers
+    # conflict check) key off the token being present in this sub_argv.
+    auto_layers_attr = getattr(args, "auto_layers", None)
     if auto_layers_attr is False:
         sub_argv.append("--no-auto-layers")
+    elif auto_layers_attr is True:
+        sub_argv.append("--auto-layers")
+    # None (unset): forward nothing; the inner parser's own default=True applies.
     if getattr(args, "max_layers", 6) != 6:
         sub_argv.extend(["--max-layers", str(args.max_layers)])
     # Issue #3400: forward --starting-layers when explicitly supplied.

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -3513,10 +3513,19 @@ def _add_route_parser(subparsers) -> None:
         dest="no_optimize",
         help="Alias for --no-optimize (keep raw grid-step segments for debugging)",
     )
+    # Issue #4502: tri-state default.  ``BooleanOptionalAction`` with
+    # ``default=True`` collapses "user typed --auto-layers" and "user typed
+    # nothing" into the same ``True``, so ``run_route_command`` could never
+    # forward an explicit ``--auto-layers`` to the inner parser -- and the
+    # inner argv-sniffing sites (``_apply_complete_mode_defaults`` and the
+    # ``--auto-layers``/``--layers`` conflict check) were blind to it.  With
+    # ``default=None`` the value is True only when explicitly enabled, False
+    # only when explicitly disabled, and None when unset; the inner
+    # route_cmd parser remains the canonical owner of the ``True`` default.
     route_parser.add_argument(
         "--auto-layers",
         action=argparse.BooleanOptionalAction,
-        default=True,
+        default=None,
         help=(
             "Automatically escalate layer count on routing failure "
             "(default: enabled). Tries 2 -> 4 -> 6 layers until routing "

--- a/tests/test_cli_route_auto_layers_explicit_forwarding.py
+++ b/tests/test_cli_route_auto_layers_explicit_forwarding.py
@@ -1,0 +1,159 @@
+"""Explicit ``--auto-layers`` must survive the outer ``kct route`` dispatcher.
+
+Regression tests for issue #4502.  The outer parser (``cli/parser.py``)
+previously declared ``--auto-layers`` as a ``BooleanOptionalAction`` with
+``default=True``, which collapsed "user explicitly typed ``--auto-layers``"
+and "user typed nothing" into the same ``args.auto_layers is True``.
+``run_route_command`` therefore forwarded only ``--no-auto-layers``, so the
+inner ``route_cmd`` argv-sniffing sites --
+``_apply_complete_mode_defaults`` (which disables auto-layers under
+``--complete`` "unless you pass ``--auto-layers``") and the
+``--auto-layers``/``--layers`` conflict check -- could never observe the
+user's explicit override.
+
+These tests drive the **real** dispatcher (``create_parser()`` ->
+``run_route_command()`` -> mocked ``route_cmd.main``) rather than a
+hand-built ``SimpleNamespace``, which is precisely why the existing unit
+tests in ``tests/test_layer_escalation.py`` did not catch the bug.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def pcb_file(tmp_path):
+    """A placeholder board path -- ``route_cmd.main`` is mocked in most tests."""
+    pcb = tmp_path / "board.kicad_pcb"
+    pcb.write_text("(kicad_pcb (version 20221018) (generator pcbnew))")
+    return pcb
+
+
+def _dispatch(argv):
+    """Parse ``argv`` with the real outer parser and capture the inner argv."""
+    from kicad_tools.cli.commands.routing import run_route_command
+    from kicad_tools.cli.parser import create_parser
+
+    parser = create_parser()
+    args = parser.parse_args(argv)
+    with patch("kicad_tools.cli.route_cmd.main") as mock_main:
+        mock_main.return_value = 0
+        run_route_command(args)
+        return args, mock_main.call_args[0][0]
+
+
+class TestExplicitAutoLayersForwarding:
+    """The outer parser's tri-state value reaches the inner argv intact."""
+
+    def test_explicit_auto_layers_survives_outer_dispatcher(self, pcb_file):
+        """Issue #4502: an explicit --auto-layers on the outer ``kct route``
+        parser must reach the inner route_cmd.main() argv, not collapse into
+        the default and get silently dropped."""
+        args, sub_argv = _dispatch(
+            ["route", str(pcb_file), "--complete", "--auto-layers", "--dry-run", "--quiet"]
+        )
+
+        assert args.auto_layers is True
+        assert "--auto-layers" in sub_argv
+        assert "--no-auto-layers" not in sub_argv
+
+    def test_unset_auto_layers_is_none_and_forwards_nothing(self, pcb_file):
+        """No flag => tri-state ``None`` and nothing forwarded, so the inner
+        parser's own ``default=True`` still supplies the effective default."""
+        args, sub_argv = _dispatch(["route", str(pcb_file), "--dry-run", "--quiet"])
+
+        assert args.auto_layers is None
+        assert "--auto-layers" not in sub_argv
+        assert "--no-auto-layers" not in sub_argv
+
+    def test_explicit_no_auto_layers_still_forwarded(self, pcb_file):
+        """``--no-auto-layers`` keeps working exactly as before."""
+        args, sub_argv = _dispatch(
+            ["route", str(pcb_file), "--no-auto-layers", "--dry-run", "--quiet"]
+        )
+
+        assert args.auto_layers is False
+        assert "--no-auto-layers" in sub_argv
+        assert "--auto-layers" not in sub_argv
+
+
+class TestCompleteModeRespectsExplicitOverride:
+    """``_apply_complete_mode_defaults`` sees the forwarded token (#4502/#4477)."""
+
+    @staticmethod
+    def _apply(sub_argv, auto_layers):
+        """Run the inner ``--complete`` defaults against a forwarded argv."""
+        from kicad_tools.cli.route_cmd import _apply_complete_mode_defaults
+
+        args = SimpleNamespace(
+            complete=True,
+            preserve_existing=False,
+            route_engine="grid",
+            auto_layers=auto_layers,
+            quiet=False,
+        )
+        # Stand-in for the inner parser: only ``get_default`` is consulted.
+        parser = SimpleNamespace(get_default=lambda name: {"route_engine": "grid"}[name])
+        _apply_complete_mode_defaults(args, parser, sub_argv)
+        return args
+
+    def test_complete_keeps_explicit_auto_layers(self, pcb_file, capsys):
+        """``--complete --auto-layers`` no longer prints the misleading
+        'disabling --auto-layers ... pass --auto-layers to override' notice."""
+        _args, sub_argv = _dispatch(
+            ["route", str(pcb_file), "--complete", "--auto-layers", "--dry-run"]
+        )
+        capsys.readouterr()  # discard dispatcher output
+
+        inner = self._apply(sub_argv, auto_layers=True)
+
+        assert inner.auto_layers is True
+        assert "disabling --auto-layers" not in capsys.readouterr().out
+
+    def test_complete_without_flag_still_disables_auto_layers(self, pcb_file, capsys):
+        """No explicit flag => ``--complete`` still disables auto-layers (#4477)."""
+        _args, sub_argv = _dispatch(["route", str(pcb_file), "--complete", "--dry-run"])
+        capsys.readouterr()  # discard dispatcher output
+
+        # The inner parser's own default=True is what --complete overrides.
+        inner = self._apply(sub_argv, auto_layers=True)
+
+        assert inner.auto_layers is False
+        assert "disabling --auto-layers" in capsys.readouterr().out
+
+    def test_complete_with_no_auto_layers_still_disabled(self, pcb_file, capsys):
+        """``--complete --no-auto-layers`` stays disabled, silently."""
+        _args, sub_argv = _dispatch(
+            ["route", str(pcb_file), "--complete", "--no-auto-layers", "--dry-run"]
+        )
+        capsys.readouterr()  # discard dispatcher output
+
+        inner = self._apply(sub_argv, auto_layers=False)
+
+        assert inner.auto_layers is False
+        assert "disabling --auto-layers" not in capsys.readouterr().out
+
+
+class TestAutoLayersLayersConflictThroughDispatcher:
+    """The ``--auto-layers`` + ``--layers`` conflict check now fires (#4502)."""
+
+    def test_conflict_tokens_reach_inner_argv(self, pcb_file):
+        _args, sub_argv = _dispatch(
+            ["route", str(pcb_file), "--auto-layers", "--layers", "4", "--dry-run", "--quiet"]
+        )
+
+        assert "--auto-layers" in sub_argv
+        assert "--layers" in sub_argv
+
+    def test_conflict_error_fires_in_route_main(self, pcb_file, capsys):
+        """End-to-end: the forwarded argv makes ``route_cmd.main`` reject the
+        explicit ``--auto-layers`` + ``--layers`` combination instead of
+        silently letting ``--layers`` win."""
+        from kicad_tools.cli import route_cmd
+
+        rc = route_cmd.main([str(pcb_file), "--auto-layers", "--layers", "4", "--dry-run"])
+
+        assert rc == 1
+        assert "--auto-layers cannot be used with --layers" in capsys.readouterr().err

--- a/tests/test_layer_escalation.py
+++ b/tests/test_layer_escalation.py
@@ -15,9 +15,9 @@ class TestLayerEscalationCLIParameters:
     """Tests for --auto-layers parameter handling in route command."""
 
     def test_auto_layers_default_not_forwarded(self):
-        """auto-layers is the default (Issue #2388) so it is NOT forwarded
-        to the underlying CLI when set to True; --no-auto-layers IS
-        forwarded when explicitly disabled."""
+        """auto-layers unset (Issue #4502 tri-state ``None``) is NOT forwarded
+        to the underlying CLI; the inner parser's own ``default=True`` applies.
+        --no-auto-layers IS forwarded when explicitly disabled."""
         from kicad_tools.cli.commands.routing import run_route_command
 
         args = SimpleNamespace(
@@ -39,7 +39,7 @@ class TestLayerEscalationCLIParameters:
             layers="auto",
             force=False,
             no_optimize=False,
-            auto_layers=True,  # default value
+            auto_layers=None,  # unset (outer parser default, Issue #4502)
             max_layers=6,
             min_completion=0.95,
         )
@@ -49,8 +49,49 @@ class TestLayerEscalationCLIParameters:
             run_route_command(args)
 
             call_args = mock_main.call_args[0][0]
-            # Default value: do not forward (the underlying CLI also defaults to True).
+            # Unset: do not forward (the underlying CLI also defaults to True).
             assert "--auto-layers" not in call_args
+            assert "--no-auto-layers" not in call_args
+
+    def test_explicit_auto_layers_forwarded_when_enabled(self):
+        """--auto-layers is forwarded when auto_layers=True (Issue #4502).
+
+        With the outer parser's tri-state default, ``True`` means the user
+        explicitly typed ``--auto-layers``; the token must reach the inner
+        argv so route_cmd's argv-sniffing sites can observe the override.
+        """
+        from kicad_tools.cli.commands.routing import run_route_command
+
+        args = SimpleNamespace(
+            pcb="test.kicad_pcb",
+            output=None,
+            strategy="negotiated",
+            skip_nets=None,
+            grid=0.25,
+            trace_width=0.2,
+            clearance=0.15,
+            via_drill=0.3,
+            via_diameter=0.6,
+            mc_trials=10,
+            iterations=15,
+            verbose=False,
+            dry_run=True,
+            quiet=True,
+            power_nets=None,
+            layers="auto",
+            force=False,
+            no_optimize=False,
+            auto_layers=True,  # user explicitly enabled
+            max_layers=6,
+            min_completion=0.95,
+        )
+
+        with patch("kicad_tools.cli.route_cmd.main") as mock_main:
+            mock_main.return_value = 0
+            run_route_command(args)
+
+            call_args = mock_main.call_args[0][0]
+            assert "--auto-layers" in call_args
             assert "--no-auto-layers" not in call_args
 
     def test_no_auto_layers_forwarded_when_disabled(self):


### PR DESCRIPTION
## Summary

`kct route board.kicad_pcb --complete --auto-layers` silently dropped the user's explicit override and printed *"--complete: disabling --auto-layers (… pass --auto-layers to override)"* — advising the user to do exactly what they had just done.

Root cause: the outer parser (`cli/parser.py::_add_route_parser`) declared `--auto-layers` as `argparse.BooleanOptionalAction` with `default=True`, which collapses "user typed `--auto-layers`" and "user typed nothing" into the same `args.auto_layers is True`. `run_route_command` could therefore only forward the `False` branch (`--no-auto-layers`), so the literal `--auto-layers` token never reached `route_cmd.main()`'s argv — and **both** of route_cmd's argv-sniffing sites were blind to it:

- `_apply_complete_mode_defaults` (`route_cmd.py:8794-8806`) disabled auto-layers under `--complete` even for an explicit `--auto-layers`.
- the `--auto-layers` / `--layers` conflict check (`route_cmd.py:11368-11381`) silently let `--layers` win instead of reporting the real conflict in intent.

This implements the issue's recommended **Option 2**: tri-state `default=None` on the outer flag + a three-way forward branch in the dispatcher. No change to `route_cmd.py` — its inner parser stays the canonical owner of the `default=True`, and its sniffing sites are already correct given a correctly-forwarded `sub_argv`.

## Changes

- **`src/kicad_tools/cli/parser.py`** — outer `--auto-layers` is now `default=None` (tri-state), with a comment recording why the boolean default cannot live here.
- **`src/kicad_tools/cli/commands/routing.py`** — `run_route_command` forwarding becomes three-way: `True` → append `--auto-layers`, `False` → append `--no-auto-layers`, `None` → forward nothing (the inner parser's own `default=True` supplies the effective default). The `getattr` fallback also moves `True` → `None` so programmatic callers that omit the attribute keep the previous "forward nothing" behaviour.
- **`tests/test_cli_route_auto_layers_explicit_forwarding.py`** (new) — regression coverage driving the **real** dispatcher chain: `create_parser()` → `run_route_command()` → mocked `route_cmd.main`. 4 of its 8 tests fail on `main` today.
- **`tests/test_layer_escalation.py`** — `test_auto_layers_default_not_forwarded` now uses `auto_layers=None` for the "unset" case (it previously encoded the ambiguous semantics), plus a new sibling `test_explicit_auto_layers_forwarded_when_enabled` for the explicit-`True` case.

### Why the bug survived the existing tests

Every pre-existing `run_route_command` test hand-builds a `SimpleNamespace`, so `cli/parser.py`'s `BooleanOptionalAction` — where the explicitness signal was destroyed — was never exercised. The new file goes through `create_parser()`.

## Acceptance Criteria Verification

- [x] **Outer `--auto-layers` has `default=None`** — `parser.py:3516-3535`.
- [x] **Three-way forwarding; flagless `kct route` is byte-identical** — `test_unset_auto_layers_is_none_and_forwards_nothing` asserts `args.auto_layers is None` and that neither token is forwarded; `test_auto_layers_default_not_forwarded` (updated) asserts the same at the `SimpleNamespace` level.
- [x] **`--complete --auto-layers` no longer prints "disabling --auto-layers"** — verified manually (see Test Plan) and by `test_complete_keeps_explicit_auto_layers`, which feeds the *real* forwarded `sub_argv` into `_apply_complete_mode_defaults` and asserts `auto_layers` stays `True` with no notice printed.
- [x] **`--complete` alone still disables auto-layers (#4477 unchanged)** — `test_complete_without_flag_still_disables_auto_layers`; manual run still prints the notice.
- [x] **`--complete --no-auto-layers` still disabled** — `test_complete_with_no_auto_layers_still_disabled`.
- [x] **`explicit_auto_layers` conflict check now fires through the real dispatcher** — `test_conflict_error_fires_in_route_main`; manual run of `kct route <board> --auto-layers --layers 4 --allow-offboard --dry-run` exits `1` with `Error: --auto-layers cannot be used with --layers 4.` (previously it silently let `--layers` win). `--layers 4` alone still exits `0`.
- [x] **`test_auto_layers_default_not_forwarded` updated + new explicit-`True` test added.**
- [x] **No other outer-dispatch consumer regresses** — re-verified at implementation time: `grep -rn "auto_layers" src/` shows the only consumer of the outer parser's value outside `route_cmd.py` is `routing.py:527`. The other hits are `router/output.py`'s unrelated `auto_layers_attempted` parameter.

## Test Plan

- [x] `uv run pytest tests/test_cli_route_auto_layers_explicit_forwarding.py` — **8 passed**. Verified this file **fails on pre-fix code** (stashed the two `src/` edits: **4 failed, 4 passed**), i.e. it genuinely catches the reported bug.
- [x] `uv run pytest tests/test_layer_escalation.py tests/test_route_cmd_params.py tests/test_cli_parser_drift.py tests/test_auto_mfr_tier_log_suppression.py tests/test_route_auto_mfr_tier.py` — **213 passed**.
- [x] `uv run pytest tests/test_auto_pcb_size_integration.py tests/test_auto_pcb_size_doomed_fixture.py tests/test_cli_route_match_groups.py tests/test_route_max_cells_flag.py` — **67 passed, 1 skipped** (the other `SimpleNamespace` callers that set `auto_layers=True` incidentally; none assert on auto-layers forwarding, no changes needed).
- [x] `uv run pytest` over the four `--complete` suites + `test_build_parser_parity.py` + `test_cli_commands.py` + `test_cli.py` + `test_route_engine_strategy_gate.py` + `test_pipeline_cli_args.py` — **198 passed**.
- [x] Every remaining `create_parser()`-using test file (15 suites, incl. `test_partial_routing_features.py`, `test_mcp_routing.py`, `router/lattice/test_engine_dispatch.py`) — **385 passed**.
- [x] Manual verification on `tests/fixtures/routing-diagnostic.kicad_pcb`:
  - `--complete --auto-layers --dry-run` → no "disabling --auto-layers" line.
  - `--complete --dry-run` → still prints "  --complete: disabling --auto-layers …".
  - `--auto-layers --layers 4 --allow-offboard --dry-run` → rc `1` + conflict error.
- [x] `uv run ruff format . --check` (1714 files already formatted) and `uv run ruff check .` — clean.
- [x] `uv run --extra dev mypy src/kicad_tools/cli/parser.py src/kicad_tools/cli/commands/routing.py` — no issues (no baseline update performed).
- [ ] Full `uv run pytest` sweep running locally at time of PR creation; result posted as a PR comment.

Closes #4502

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqrwHsMchwVCgHXWLey3C6