### PR TITLE
feat(router): enforce pairwise HV domain clearance in C++ validate_route

### DIFF
--- a/src/kicad_tools/router/cpp/include/grid.hpp
+++ b/src/kicad_tools/router/cpp/include/grid.hpp
@@ -280,6 +280,15 @@ public:
     //              partner_net use intra_pair_clearance instead of
     //              trace_clearance.  Defaults preserve pre-#2559 behavior.
     // intra_pair_clearance: tighter clearance applied only to the partner.
+    //
+    // Issue #4510 / Epic #4431 Phase 2a: when ``set_pairwise_domains`` has
+    // installed a domain matrix, the required clearance for a pair whose
+    // BOTH nets have a known domain becomes
+    // ``max(effective_scalar, matrix[dom_a][dom_b])``.  The diff-pair
+    // partner relaxation keeps precedence (it *tightens within* a pair; the
+    // matrix *widens across* domains), and an installed attach zone
+    // (``set_attach_zones``) covering the gap point waives the widening --
+    // never the scalar floor.
     ValidationResult validate_route(
         const std::vector<Segment>& segments,
         const std::vector<Via>& vias,
@@ -290,6 +299,48 @@ public:
         float min_drill_clearance,
         int partner_net = -1,
         float intra_pair_clearance = 0.0f) const;
+
+    // -----------------------------------------------------------------------
+    // Pairwise (HV-isolation) domain clearance -- Issue #4510, Phase 2a of
+    // epic #4431.  Both setters are DORMANT by default: until one is called
+    // the validator behaves byte-identically to the pre-#4510 code path.
+    // -----------------------------------------------------------------------
+
+    // Install the per-net domain-id array plus the dense domain-pair
+    // clearance matrix (mm).
+    //
+    // net_to_domain: indexed by net id; entry is the net's domain index, or
+    //                -1 for "no domain" (the overwhelming majority of nets on
+    //                a board with a partial voltage map).  Net ids beyond the
+    //                array's length are treated as domain-less.
+    // matrix:        ``matrix[dom_a][dom_b]`` is the REQUIRED clearance (mm)
+    //                between the two domains -- a pure *widening* value, i.e.
+    //                0.0 for pairs that need no HV widening beyond the scalar
+    //                floor.  Must be square and symmetric; Python builds it
+    //                from ``PairwiseClearanceTable.required_by_pair``.
+    //
+    // Passing empty containers returns the grid to the dormant state.
+    void set_pairwise_domains(const std::vector<int>& net_to_domain,
+                              const std::vector<std::vector<float>>& matrix);
+
+    // Install the rated-footprint attach zones (Issue #4506) used to waive
+    // the pairwise widening (never the scalar floor) inside a domain-bridging
+    // footprint's necking region.  Zones are computed once per routing
+    // session on the Python side; passing an empty vector clears them.
+    void set_attach_zones(const std::vector<AttachZone>& zones);
+
+    // True once a non-empty domain matrix has been installed.
+    bool pairwise_active() const { return pairwise_active_; }
+    size_t attach_zone_count() const { return attach_zones_.size(); }
+
+    // Required pairwise clearance (mm) between two net ids.  Returns 0.0 when
+    // the matrix is dormant, when either net id is out of range, or when
+    // either net has no domain -- so ``max(scalar, this)`` is the scalar.
+    float pairwise_required_clearance(int net_a, int net_b) const;
+
+    // True when an installed attach zone contains ``(x, y)`` AND has BOTH
+    // ``net_a`` and ``net_b`` among its member net ids.
+    bool attach_zone_exempts(float x, float y, int net_a, int net_b) const;
 
     // Accessors for validation data sizes (for testing/debugging)
     size_t pad_count() const { return pads_.size(); }
@@ -328,6 +379,16 @@ private:
     std::vector<PadInfo> pads_;
     std::vector<StoredSegment> stored_segments_;
     std::vector<StoredVia> stored_vias_;
+
+    // Pairwise (HV-isolation) domain clearance storage (Issue #4510).
+    // ``pairwise_active_`` is the grid-wide fast-path flag: when false the
+    // widening branch in validate_route() is skipped entirely, so boards
+    // without a voltage map keep byte-identical behaviour and cost.
+    bool pairwise_active_ = false;
+    int domain_count_ = 0;
+    std::vector<int> net_domain_;        // net id -> domain index (-1 = none)
+    std::vector<float> domain_matrix_;   // row-major domain_count_ x domain_count_
+    std::vector<AttachZone> attach_zones_;
 };
 
 }  // namespace router

--- a/src/kicad_tools/router/cpp/include/types.hpp
+++ b/src/kicad_tools/router/cpp/include/types.hpp
@@ -179,7 +179,17 @@ namespace router {
 // crossing net onto its inner-layer channel while leaving the mandatory
 // crossings legal.  Old .so files lack ``reserved_soft`` and the new
 // ``reserve_cell`` signature; the version bump forces a rebuild.
-constexpr int ROUTER_CPP_BUILD_VERSION = 17;
+// Version 18 (Issue #4510, Phase 2a of epic #4431): pairwise (HV-isolation)
+// domain clearance in ``Grid3D::validate_route``.  ``Grid3D`` gains two
+// dormant-by-default setters -- ``set_pairwise_domains(net_to_domain, matrix)``
+// (a per-net domain-id array plus a dense domain-pair -> required-clearance
+// matrix in mm) and ``set_attach_zones(zones)`` (the net-id-translated
+// rated-footprint necking regions from #4506) -- plus the new ``AttachZone``
+// struct below.  When the setters are never called the validator behaves
+// byte-identically to version 17.  Old .so files lack both bindings, so the
+// Python plumbing in ``cpp_backend.py`` would silently no-op against a stale
+// build; the version bump forces a rebuild via ``kct build-native``.
+constexpr int ROUTER_CPP_BUILD_VERSION = 18;
 
 // Issue #4071: fixed-capacity owner-set size for per-cell corridor
 // reservations.  Observed owner sets in practice are tiny: 1 for the
@@ -545,6 +555,24 @@ struct StoredVia {
     float drill;
     float diameter;
     int net;
+};
+
+// Rated-footprint attach zone for pairwise clearance (Issue #4510 / #4506).
+//
+// Layer-agnostic axis-aligned bounding box plus the set of net ids that
+// terminate on the rated footprint.  Mirrors the frozen ``AttachZone``
+// dataclass in ``src/kicad_tools/router/pairwise_clearance.py``, except the
+// net *names* of the Python shape are translated to integer net ids by
+// ``cpp_backend.py`` before crossing the boundary (``Grid3D`` has no string
+// table).  A zone may legitimately span more than two nets (a 3-pad rated
+// connector), so membership is tested per-candidate-pair: BOTH nets of the
+// pair must be members for the widening to be waived.
+struct AttachZone {
+    float min_x = 0.0f;
+    float min_y = 0.0f;
+    float max_x = 0.0f;
+    float max_y = 0.0f;
+    std::vector<int> net_ids;
 };
 
 // Validation result (Issue #2439)

--- a/src/kicad_tools/router/cpp/src/bindings.cpp
+++ b/src/kicad_tools/router/cpp/src/bindings.cpp
@@ -77,6 +77,20 @@ NB_MODULE(router_cpp, m) {
         .def_rw("violation_y", &ValidationResult::violation_y)
         .def_rw("violation_type", &ValidationResult::violation_type);
 
+    // AttachZone struct (Issue #4510 / #4506)
+    //
+    // Net-id-translated mirror of the ``AttachZone`` frozen dataclass in
+    // ``router/pairwise_clearance.py``.  Python constructs these once per
+    // routing session (``cpp_backend.py::_sync_pairwise_domains_to_cpp``) and
+    // installs them via ``Grid3D.set_attach_zones``.
+    nb::class_<AttachZone>(m, "AttachZone")
+        .def(nb::init<>())
+        .def_rw("min_x", &AttachZone::min_x)
+        .def_rw("min_y", &AttachZone::min_y)
+        .def_rw("max_x", &AttachZone::max_x)
+        .def_rw("max_y", &AttachZone::max_y)
+        .def_rw("net_ids", &AttachZone::net_ids);
+
     // PadBounds struct
     nb::class_<PadBounds>(m, "PadBounds")
         .def(nb::init<>())
@@ -267,6 +281,30 @@ NB_MODULE(router_cpp, m) {
              "/ Phase 1C: when partner_net >= 0 and intra_pair_clearance >= 0, "
              "comparisons against partner_net use intra_pair_clearance instead "
              "of trace_clearance (defaults preserve pre-#2559 behavior).")
+        // Pairwise (HV-isolation) domain clearance -- Issue #4510 / #4431 Phase 2a
+        .def("set_pairwise_domains", &Grid3D::set_pairwise_domains,
+             "net_to_domain"_a, "matrix"_a,
+             "Install the per-net domain-id array (indexed by net id, -1 = no "
+             "domain) plus the dense symmetric domain-pair required-clearance "
+             "matrix in mm.  Dormant by default: until this is called (or when "
+             "called with empty containers) validate_route() behaves exactly as "
+             "before.  Matrix entries are pure WIDENING values -- the validator "
+             "applies max(effective_scalar, matrix[dom_a][dom_b]).")
+        .def("set_attach_zones", &Grid3D::set_attach_zones, "zones"_a,
+             "Install rated-footprint attach zones (Issue #4506) whose bbox + "
+             "net-id membership waives the pairwise WIDENING (never the scalar "
+             "floor) for a pair terminating on the same domain-bridging "
+             "footprint.  Empty vector (the default) clears them.")
+        .def_prop_ro("pairwise_active", &Grid3D::pairwise_active)
+        .def_prop_ro("attach_zone_count", &Grid3D::attach_zone_count)
+        .def("pairwise_required_clearance", &Grid3D::pairwise_required_clearance,
+             "net_a"_a, "net_b"_a,
+             "Required pairwise clearance (mm) between two net ids; 0.0 when "
+             "dormant or when either net has no domain.")
+        .def("attach_zone_exempts", &Grid3D::attach_zone_exempts,
+             "x"_a, "y"_a, "net_a"_a, "net_b"_a,
+             "True when an installed attach zone contains (x, y) and lists BOTH "
+             "net ids among its members.")
         .def_prop_ro("pad_count", &Grid3D::pad_count)
         .def_prop_ro("stored_segment_count", &Grid3D::stored_segment_count)
         .def_prop_ro("stored_via_count", &Grid3D::stored_via_count);

--- a/src/kicad_tools/router/cpp/src/grid.cpp
+++ b/src/kicad_tools/router/cpp/src/grid.cpp
@@ -463,6 +463,164 @@ void Grid3D::clear_stored_routes() {
     stored_vias_.clear();
 }
 
+// ---------------------------------------------------------------------------
+// Pairwise (HV-isolation) domain clearance -- Issue #4510 / Epic #4431 Phase 2a
+// ---------------------------------------------------------------------------
+
+void Grid3D::set_pairwise_domains(const std::vector<int>& net_to_domain,
+                                  const std::vector<std::vector<float>>& matrix) {
+    domain_count_ = static_cast<int>(matrix.size());
+    net_domain_ = net_to_domain;
+    domain_matrix_.clear();
+
+    if (domain_count_ <= 0 || net_domain_.empty()) {
+        // Dormant: restore the pre-#4510 behaviour exactly.
+        pairwise_active_ = false;
+        domain_count_ = 0;
+        net_domain_.clear();
+        return;
+    }
+
+    domain_matrix_.reserve(static_cast<size_t>(domain_count_) * domain_count_);
+    for (const auto& row : matrix) {
+        for (int j = 0; j < domain_count_; ++j) {
+            domain_matrix_.push_back(
+                j < static_cast<int>(row.size()) ? row[static_cast<size_t>(j)] : 0.0f);
+        }
+    }
+    pairwise_active_ = true;
+}
+
+void Grid3D::set_attach_zones(const std::vector<AttachZone>& zones) {
+    attach_zones_ = zones;
+}
+
+float Grid3D::pairwise_required_clearance(int net_a, int net_b) const {
+    if (!pairwise_active_) return 0.0f;
+    if (net_a < 0 || net_b < 0) return 0.0f;
+    const size_t n = net_domain_.size();
+    if (static_cast<size_t>(net_a) >= n || static_cast<size_t>(net_b) >= n) return 0.0f;
+    const int da = net_domain_[static_cast<size_t>(net_a)];
+    const int db = net_domain_[static_cast<size_t>(net_b)];
+    if (da < 0 || db < 0 || da >= domain_count_ || db >= domain_count_) return 0.0f;
+    return domain_matrix_[static_cast<size_t>(da) * static_cast<size_t>(domain_count_) +
+                          static_cast<size_t>(db)];
+}
+
+bool Grid3D::attach_zone_exempts(float x, float y, int net_a, int net_b) const {
+    for (const auto& zone : attach_zones_) {
+        if (x < zone.min_x || x > zone.max_x || y < zone.min_y || y > zone.max_y) continue;
+        bool has_a = false;
+        bool has_b = false;
+        for (int nid : zone.net_ids) {
+            if (nid == net_a) has_a = true;
+            if (nid == net_b) has_b = true;
+        }
+        if (has_a && has_b) return true;
+    }
+    return false;
+}
+
+namespace {
+
+// Closest point on segment (x1,y1)-(x2,y2) to the point (px, py).
+// Mirrors the projection/clamp used by ``point_to_segment_distance``.
+inline std::pair<float, float> closest_point_on_segment(
+    float px, float py, float x1, float y1, float x2, float y2) {
+    const float dx = x2 - x1;
+    const float dy = y2 - y1;
+    const float len_sq = dx * dx + dy * dy;
+    if (len_sq <= 1e-15f) return {x1, y1};
+    float t = ((px - x1) * dx + (py - y1) * dy) / len_sq;
+    t = std::max(0.0f, std::min(1.0f, t));
+    return {x1 + t * dx, y1 + t * dy};
+}
+
+// Midpoint between the closest points of two line segments.  Port of
+// ``_closest_gap_midpoint`` in ``router/pairwise_clearance.py`` so the C++
+// attach-zone consult keys off the SAME gap point as the Python validator
+// (a long segment's own midpoint is not the gap point -- see
+// ``test_attach_zone_uses_closest_gap_not_long_segment_midpoint``).
+inline std::pair<float, float> closest_gap_midpoint(
+    float ax1, float ay1, float ax2, float ay2,
+    float bx1, float by1, float bx2, float by2) {
+    const float ux = ax2 - ax1, uy = ay2 - ay1;
+    const float vx = bx2 - bx1, vy = by2 - by1;
+    const float wx = ax1 - bx1, wy = ay1 - by1;
+    const float a = ux * ux + uy * uy;
+    const float b = ux * vx + uy * vy;
+    const float c = vx * vx + vy * vy;
+    const float d = ux * wx + uy * wy;
+    const float e = vx * wx + vy * wy;
+
+    if (a <= 1e-15f && c <= 1e-15f) {
+        return {(ax1 + bx1) / 2.0f, (ay1 + by1) / 2.0f};
+    }
+    if (a <= 1e-15f) {
+        const float t = std::max(0.0f, std::min(1.0f, e / c));
+        return {(ax1 + bx1 + t * vx) / 2.0f, (ay1 + by1 + t * vy) / 2.0f};
+    }
+    if (c <= 1e-15f) {
+        const float s = std::max(0.0f, std::min(1.0f, -d / a));
+        return {(ax1 + s * ux + bx1) / 2.0f, (ay1 + s * uy + by1) / 2.0f};
+    }
+
+    const float denominator = a * c - b * b;
+    float s_num = denominator, s_den = denominator;
+    float t_num = denominator, t_den = denominator;
+
+    if (denominator <= 1e-15f) {
+        s_num = 0.0f;
+        s_den = 1.0f;
+        t_num = e;
+        t_den = c;
+    } else {
+        s_num = b * e - c * d;
+        t_num = a * e - b * d;
+        if (s_num < 0.0f) {
+            s_num = 0.0f;
+            t_num = e;
+            t_den = c;
+        } else if (s_num > s_den) {
+            s_num = s_den;
+            t_num = e + b;
+            t_den = c;
+        }
+    }
+
+    if (t_num < 0.0f) {
+        t_num = 0.0f;
+        if (-d < 0.0f) {
+            s_num = 0.0f;
+            s_den = 1.0f;
+        } else if (-d > a) {
+            s_num = 1.0f;
+            s_den = 1.0f;
+        } else {
+            s_num = -d;
+            s_den = a;
+        }
+    } else if (t_num > t_den) {
+        t_num = t_den;
+        if (-d + b < 0.0f) {
+            s_num = 0.0f;
+            s_den = 1.0f;
+        } else if (-d + b > a) {
+            s_num = 1.0f;
+            s_den = 1.0f;
+        } else {
+            s_num = -d + b;
+            s_den = a;
+        }
+    }
+
+    const float s = std::abs(s_num) <= 1e-15f ? 0.0f : s_num / s_den;
+    const float t = std::abs(t_num) <= 1e-15f ? 0.0f : t_num / t_den;
+    return {(ax1 + s * ux + bx1 + t * vx) / 2.0f, (ay1 + s * uy + by1 + t * vy) / 2.0f};
+}
+
+}  // namespace
+
 ValidationResult Grid3D::validate_route(
     const std::vector<Segment>& segments,
     const std::vector<Via>& vias,
@@ -484,6 +642,28 @@ ValidationResult Grid3D::validate_route(
     // the branch is dormant (default), validation behaves exactly as before.
     bool partner_active =
         (partner_net >= 0) && (partner_net != exclude_net) && (intra_pair_clearance >= 0.0f);
+
+    // Issue #4510 / Epic #4431 Phase 2a: pairwise (HV-isolation) widening.
+    // Dormant unless ``set_pairwise_domains`` installed a matrix, in which
+    // case the required clearance for a domain-known pair becomes
+    // ``max(effective_scalar, matrix[dom_a][dom_b])``.  The gap point is
+    // computed LAZILY (only when a widening actually applies) so the common
+    // no-voltage-map board pays a single bool test per comparison.
+    //
+    // ``gap_point`` is a nullary callable returning the (x, y) mid-gap
+    // coordinate consulted by the attach-zone exemption (#4506): a rated
+    // domain-bridging footprint may neck the pair down to the scalar floor
+    // inside its courtyard, but never below it -- the exemption skips only
+    // the widening, never ``base``.
+    const bool pairwise_on = pairwise_active_;
+    auto widen = [&](float base, int foreign_net, auto&& gap_point) -> float {
+        if (!pairwise_on) return base;
+        const float required = pairwise_required_clearance(exclude_net, foreign_net);
+        if (required <= base) return base;
+        const std::pair<float, float> p = gap_point();
+        if (attach_zone_exempts(p.first, p.second, exclude_net, foreign_net)) return base;
+        return required;
+    };
 
     // Helper: check if a ref_hash is in the exclusion set
     auto is_excluded_ref = [&](uint32_t ref_hash) -> bool {
@@ -601,6 +781,17 @@ ValidationResult Grid3D::validate_route(
                 result.min_clearance = clearance;
             }
 
+            // Issue #4510: widen for a cross-domain (HV) pair.  The gap point
+            // is the midpoint between the pad centre and the closest point on
+            // the candidate segment's centreline -- the pad analogue of the
+            // Python validator's closest-approach midpoint.
+            required_clearance = widen(required_clearance, pad.net, [&]() {
+                const auto cp = closest_point_on_segment(
+                    pad.x, pad.y, seg.x1, seg.y1, seg.x2, seg.y2);
+                return std::pair<float, float>((pad.x + cp.first) / 2.0f,
+                                               (pad.y + cp.second) / 2.0f);
+            });
+
             if (clearance < required_clearance - CLEARANCE_EPSILON_MM) {
                 result.valid = false;
                 result.violation_x = pad.x;
@@ -630,10 +821,19 @@ ValidationResult Grid3D::validate_route(
 
             // Issue #2559 / Phase 1C: tighter clearance for the diff-pair
             // partner only.  All other foreign nets keep the wider rule.
-            float effective_clearance =
-                (partner_active && other.net == partner_net)
-                ? intra_pair_clearance
-                : trace_clearance;
+            const bool is_partner = partner_active && other.net == partner_net;
+            float effective_clearance = is_partner ? intra_pair_clearance : trace_clearance;
+
+            // Issue #4510: the partner branch keeps PRECEDENCE -- it tightens
+            // *within* a declared pair, whereas the matrix widens *across*
+            // domains; a net that is both the diff-pair partner and formally
+            // cross-domain stays at ``intra_pair_clearance``.
+            if (!is_partner) {
+                effective_clearance = widen(effective_clearance, other.net, [&]() {
+                    return closest_gap_midpoint(seg.x1, seg.y1, seg.x2, seg.y2,
+                                                other.x1, other.y1, other.x2, other.y2);
+                });
+            }
 
             if (clearance < effective_clearance - CLEARANCE_EPSILON_MM) {
                 result.valid = false;
@@ -659,10 +859,18 @@ ValidationResult Grid3D::validate_route(
             }
 
             // Issue #2559 / Phase 1C: tighter clearance for the partner.
-            float effective_clearance =
-                (partner_active && sv.net == partner_net)
-                ? intra_pair_clearance
-                : trace_clearance;
+            const bool is_partner = partner_active && sv.net == partner_net;
+            float effective_clearance = is_partner ? intra_pair_clearance : trace_clearance;
+
+            // Issue #4510: cross-domain widening (partner branch wins).
+            if (!is_partner) {
+                effective_clearance = widen(effective_clearance, sv.net, [&]() {
+                    const auto cp = closest_point_on_segment(
+                        sv.x, sv.y, seg.x1, seg.y1, seg.x2, seg.y2);
+                    return std::pair<float, float>((sv.x + cp.first) / 2.0f,
+                                                   (sv.y + cp.second) / 2.0f);
+                });
+            }
 
             if (clearance < effective_clearance - CLEARANCE_EPSILON_MM) {
                 result.valid = false;
@@ -701,7 +909,16 @@ ValidationResult Grid3D::validate_route(
                 result.min_clearance = clearance;
             }
 
-            if (clearance < via_clearance - CLEARANCE_EPSILON_MM) {
+            // Issue #4510: cross-domain widening for the candidate via vs a
+            // stored foreign segment (no diff-pair partner branch here).
+            const float effective_clearance = widen(via_clearance, seg.net, [&]() {
+                const auto cp = closest_point_on_segment(
+                    via.x, via.y, seg.x1, seg.y1, seg.x2, seg.y2);
+                return std::pair<float, float>((via.x + cp.first) / 2.0f,
+                                               (via.y + cp.second) / 2.0f);
+            });
+
+            if (clearance < effective_clearance - CLEARANCE_EPSILON_MM) {
                 result.valid = false;
                 result.violation_x = via.x;
                 result.violation_y = via.y;
@@ -727,7 +944,13 @@ ValidationResult Grid3D::validate_route(
                 result.min_clearance = clearance;
             }
 
-            if (clearance < via_clearance - CLEARANCE_EPSILON_MM) {
+            // Issue #4510: cross-domain widening for via-vs-via.  The gap
+            // point is the midpoint of the two via centres.
+            const float effective_clearance = widen(via_clearance, sv.net, [&]() {
+                return std::pair<float, float>((via.x + sv.x) / 2.0f, (via.y + sv.y) / 2.0f);
+            });
+
+            if (clearance < effective_clearance - CLEARANCE_EPSILON_MM) {
                 result.valid = false;
                 result.violation_x = via.x;
                 result.violation_y = via.y;

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -23,7 +23,7 @@ import logging
 import math
 import os
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     import numpy as np
@@ -47,7 +47,7 @@ logger = logging.getLogger(__name__)
 # ``AttributeError`` deep in the routing code (e.g. ``router_cpp.PadBounds``
 # missing).  The guard below catches that at import time and falls back to the
 # pure-Python router with an actionable ``kct build-native`` hint.
-_REQUIRED_CPP_BUILD_VERSION = 17
+_REQUIRED_CPP_BUILD_VERSION = 18
 
 # Try to import C++ module with detailed error tracking
 _CPP_IMPORT_ERROR: str | None = None
@@ -973,6 +973,16 @@ class CppPathfinder:
         self._net_name_to_id: dict[str, int] = {}
         self._attach_zones = ()
 
+        # Issue #4510 / Epic #4431 Phase 2a: lazily-built C++ payload for the
+        # pairwise (HV-isolation) domain matrix + net-id-translated attach
+        # zones.  ``None`` = not built yet; ``False`` = built and found empty
+        # (nothing to install -- the C++ validator stays dormant).  Invalidated
+        # whenever the reverse net map or the attach zones change, since both
+        # feed the translation.
+        self._pairwise_cpp_payload: (
+            tuple[list[int], list[list[float]], list] | Literal[False] | None
+        ) = None
+
         # Issue #2929: Per-A*-call wall-clock instrumentation, mirroring the
         # Python pathfinder's instrumentation surface so callers can audit
         # deadline behavior regardless of which backend handles the call.
@@ -1166,12 +1176,74 @@ class CppPathfinder:
         ``clearance`` for every other net).
         """
         self._net_name_to_id = dict(mapping)
+        # Issue #4510: the C++ domain matrix / attach zones are keyed by net
+        # ID, translated through this map -- rebuild them on the next validate.
+        self._pairwise_cpp_payload = None
 
     def set_attach_zones(self, zones) -> None:
         """Install precomputed rated-footprint necking regions."""
         self._attach_zones = tuple(zones)
+        # Issue #4510: invalidate the translated C++ zone payload.
+        self._pairwise_cpp_payload = None
         if self._py_router is not None:
             self._py_router.set_attach_zones(self._attach_zones)
+
+    def _sync_pairwise_domains_to_cpp(self) -> None:
+        """Install the pairwise domain matrix + attach zones on the C++ grid.
+
+        Issue #4510 / Epic #4431 Phase 2a.  ``Grid3D::validate_route`` gains
+        cross-domain (HV-isolation) widening only when a domain matrix has been
+        installed; this is where :attr:`DesignRules.pairwise_clearance` and
+        :attr:`_attach_zones` cross the Python/C++ boundary, translated from
+        net *names* to the integer net ids the grid speaks.
+
+        Fully dormant without a voltage map: no ``pairwise_clearance`` table
+        means the setters are never called and the C++ validator behaves
+        byte-identically to the pre-#4510 code path.  The translated payload is
+        cached (it depends only on the table, the reverse net map and the
+        zones, all fixed for a routing session) and re-pushed whenever the grid
+        reports itself dormant -- which is exactly the case after the C++ grid
+        has been rebuilt underneath us.
+        """
+        impl = getattr(self._grid, "_impl", None)
+        if impl is None or not hasattr(impl, "set_pairwise_domains"):
+            return  # Stale .so without the #4510 surface -- stay dormant.
+
+        payload = self._pairwise_cpp_payload
+        if payload is False:
+            return  # Already determined: nothing to install.
+
+        if payload is None:
+            table = getattr(self._rules, "pairwise_clearance", None)
+            if table is None:
+                return  # No voltage map -- leave the cache unset (may arrive later).
+            from .pairwise_clearance import attach_zones_to_net_ids, build_cpp_domain_matrix
+
+            domains = build_cpp_domain_matrix(table, self._net_name_to_id)
+            if domains is None:
+                self._pairwise_cpp_payload = False
+                return
+            cpp_zones = []
+            for min_x, min_y, max_x, max_y, net_ids in attach_zones_to_net_ids(
+                self._attach_zones, self._net_name_to_id
+            ):
+                zone = router_cpp.AttachZone()
+                zone.min_x = min_x
+                zone.min_y = min_y
+                zone.max_x = max_x
+                zone.max_y = max_y
+                zone.net_ids = net_ids
+                cpp_zones.append(zone)
+            payload = (domains.net_to_domain, domains.matrix, cpp_zones)
+            self._pairwise_cpp_payload = payload
+
+        # ``pairwise_active`` is False on a freshly-built grid, so this both
+        # installs on first use and reinstalls after a grid rebuild -- without
+        # re-pushing the matrix on every single validation call.
+        if not impl.pairwise_active:
+            net_to_domain, matrix, cpp_zones = payload
+            impl.set_pairwise_domains(net_to_domain, matrix)
+            impl.set_attach_zones(cpp_zones)
 
     def _resolve_partner_net_id(self, net_name: str) -> int | None:
         """Look up the integer net id of the diff-pair partner of *net_name*.
@@ -2218,6 +2290,15 @@ class CppPathfinder:
             if partner_id is not None:
                 partner_net_id = int(partner_id)
                 intra_pair_clearance = float(net_class.effective_intra_pair_clearance())
+
+        # Issue #4510 / Epic #4431 Phase 2a: install the pairwise (HV) domain
+        # matrix and the net-id-translated rated-footprint attach zones on the
+        # C++ grid alongside the partner plumbing above, so ``validate_route``
+        # enforces max(effective_scalar, matrix[dom_a][dom_b]) itself instead
+        # of relying solely on the Python post-check below (which sees only
+        # trace-vs-trace copper, not pads and vias).  No-op without a voltage
+        # map.
+        self._sync_pairwise_domains_to_cpp()
 
         vresult = self._grid._impl.validate_route(
             cpp_segs,

--- a/src/kicad_tools/router/pairwise_clearance.py
+++ b/src/kicad_tools/router/pairwise_clearance.py
@@ -261,6 +261,114 @@ def build_pairwise_clearance_table(
     )
 
 
+class CppDomainMatrix(NamedTuple):
+    """C++-consumable form of a :class:`PairwiseClearanceTable` (Issue #4510).
+
+    Attributes:
+        net_to_domain: Indexed by net id; entry is the net's domain index or
+            ``-1`` when the net participates in no widening pair.  Net ids
+            beyond the list's length are domain-less by construction.
+        matrix: Dense symmetric ``matrix[dom_a][dom_b]`` of *widening* values
+            (mm).  Entries are the raw creepage requirement WITHOUT the DRU
+            floor, so the C++ validator's ``max(effective_scalar, matrix[a][b])``
+            never raises a pair above its scalar rule unless HV widening
+            genuinely applies -- matching
+            :func:`segment_pair_violation`'s ``required <= floor`` skip.
+    """
+
+    net_to_domain: list[int]
+    matrix: list[list[float]]
+
+
+def build_cpp_domain_matrix(
+    table: PairwiseClearanceTable | None,
+    net_name_to_id: Mapping[str, int],
+) -> CppDomainMatrix | None:
+    """Project a pairwise table onto integer net ids for ``Grid3D`` (Issue #4510).
+
+    ``Grid3D`` has no string table, so the net-name-keyed
+    :attr:`PairwiseClearanceTable.required_by_pair` must be re-expressed as a
+    per-net domain-id array plus a dense domain-pair matrix.  Phase 1 treats
+    each net as its own domain, so the "domains" here are exactly the nets that
+    participate in at least one widening pair AND resolve to a board net id.
+
+    Returns ``None`` when nothing needs widening (no table, an empty matrix, or
+    fewer than two resolvable participating nets) -- the dormant signal that
+    keeps the C++ setter uncalled and ``validate_route`` byte-identical.
+    """
+    if table is None:
+        return None
+    pairs = table.required_by_pair
+    if not pairs:
+        return None
+
+    participating: set[str] = set()
+    for (net_a, net_b), required in pairs.items():
+        if required > 0.0:
+            participating.add(net_a)
+            participating.add(net_b)
+    if not participating:
+        return None
+
+    # A board net name may carry a leading ``/``; the table keys never do.  Two
+    # distinct board nets can in principle normalise to the same key, so every
+    # matching id joins the same domain.
+    ids_by_key: dict[str, list[int]] = {}
+    for name, net_id in net_name_to_id.items():
+        key = _norm_net_key(name)
+        if key in participating and int(net_id) >= 0:
+            ids_by_key.setdefault(key, []).append(int(net_id))
+    if len(ids_by_key) < 2:
+        return None
+
+    domain_keys = sorted(ids_by_key)  # deterministic domain indices
+    domain_index = {key: i for i, key in enumerate(domain_keys)}
+
+    max_id = max(net_id for ids in ids_by_key.values() for net_id in ids)
+    net_to_domain = [-1] * (max_id + 1)
+    for key, ids in ids_by_key.items():
+        for net_id in ids:
+            net_to_domain[net_id] = domain_index[key]
+
+    size = len(domain_keys)
+    matrix = [[0.0] * size for _ in range(size)]
+    for (net_a, net_b), required in pairs.items():
+        i = domain_index.get(net_a)
+        j = domain_index.get(net_b)
+        if i is None or j is None:
+            continue
+        value = float(required)
+        matrix[i][j] = value
+        matrix[j][i] = value
+
+    return CppDomainMatrix(net_to_domain=net_to_domain, matrix=matrix)
+
+
+def attach_zones_to_net_ids(
+    zones: Sequence[AttachZone],
+    net_name_to_id: Mapping[str, int],
+) -> list[tuple[float, float, float, float, list[int]]]:
+    """Translate net-name-keyed attach zones to net-id tuples (Issue #4510).
+
+    ``Grid3D`` works in integer net ids, so :attr:`AttachZone.net_names` must be
+    resolved through the router's reverse map before crossing into C++.  A zone
+    may legitimately span more than two nets (a 3-pad rated connector); zones
+    that resolve to fewer than two ids cannot exempt any pair and are dropped.
+    """
+    ids_by_key: dict[str, list[int]] = {}
+    for name, net_id in net_name_to_id.items():
+        if int(net_id) >= 0:
+            ids_by_key.setdefault(_norm_net_key(name), []).append(int(net_id))
+
+    out: list[tuple[float, float, float, float, list[int]]] = []
+    for zone in zones:
+        net_ids = sorted({nid for key in zone.net_names for nid in ids_by_key.get(key, ())})
+        if len(net_ids) < 2:
+            continue
+        out.append((zone.min_x, zone.min_y, zone.max_x, zone.max_y, net_ids))
+    return out
+
+
 class PairwiseViolation(NamedTuple):
     """A single post-route pairwise-clearance shortfall (Issue #4431).
 

--- a/tests/router/test_pairwise_cpp_parity.py
+++ b/tests/router/test_pairwise_cpp_parity.py
@@ -1,0 +1,544 @@
+"""C++ ``validate_route`` pairwise (HV-isolation) clearance parity (Issue #4510).
+
+Phase 2a of epic #4431 -- the *validation-layer* half.  Phase 1 (#4454) taught
+only the Python validator about net-pair creepage requirements, so with the C++
+backend active the authoritative geometric validator could not see them at all.
+This module covers:
+
+* the dormant-by-default ``Grid3D.set_pairwise_domains`` /
+  ``Grid3D.set_attach_zones`` setters (never called -> pre-#4510 behaviour);
+* ``max(effective_scalar, matrix[dom_a][dom_b])`` across every copper pair
+  ``validate_route`` walks -- segment-vs-pad, segment-vs-segment,
+  segment-vs-via, via-vs-segment and via-vs-via;
+* attach-zone exemption parity with the Python fixtures from #4506, including
+  the floor guarantee (an exemption waives the *widening*, never the DRU);
+* diff-pair partner precedence over the matrix widening (#2559 / #2556); and
+* the ``cpp_backend.py`` plumbing that translates net *names* to the net *ids*
+  ``Grid3D`` speaks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kicad_tools.router.cpp_backend import CppGrid, CppPathfinder, is_cpp_available
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.pairwise_clearance import (
+    AttachZone,
+    attach_zones_to_net_ids,
+    build_cpp_domain_matrix,
+    build_pairwise_clearance_table,
+    find_pairwise_violations,
+)
+from kicad_tools.router.primitives import Pad, Route, Segment
+from kicad_tools.router.rules import DesignRules
+
+requires_cpp = pytest.mark.skipif(
+    not is_cpp_available(),
+    reason="C++ router backend not available",
+)
+
+# IEC 60664-1, PD2, material group IIIa @ 150 V -> 1.6 mm (same constant the
+# Python-side suite pins in ``test_pairwise_clearance.py``).
+IEC_150V_PD2_IIIA_MM = 1.6
+DRU = 0.2
+TRACE_WIDTH = 0.2
+
+HV_NET = 1  # /AC_LINE
+LV_NET = 2  # /GND
+HV_TAP_NET = 3  # /AC_LINE_TAP -- same domain as HV_NET
+NET_NAMES = {"/AC_LINE": HV_NET, "/GND": LV_NET, "/AC_LINE_TAP": HV_TAP_NET}
+VOLTAGES = {"/AC_LINE": 150.0, "/GND": 0.0, "/AC_LINE_TAP": 150.0}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _table(dru: float = DRU):
+    return build_pairwise_clearance_table(VOLTAGES, dru=dru)
+
+
+def _cpp_grid():
+    from kicad_tools.router import router_cpp
+
+    # 20 x 20 mm at 0.1 mm resolution; validate_route only consults the
+    # explicitly registered pads / stored segments / stored vias.
+    return router_cpp.Grid3D(200, 200, 2, 0.1, 0.0, 0.0)
+
+
+def _cpp_segment(x1, y1, x2, y2, net, layer=0, width=TRACE_WIDTH):
+    from kicad_tools.router import router_cpp
+
+    seg = router_cpp.Segment()
+    seg.x1, seg.y1, seg.x2, seg.y2 = x1, y1, x2, y2
+    seg.width = width
+    seg.layer = layer
+    seg.net = net
+    return seg
+
+
+def _cpp_via(x, y, net, layer_from=0, layer_to=1, drill=0.3, diameter=0.6):
+    from kicad_tools.router import router_cpp
+
+    via = router_cpp.Via()
+    via.x, via.y = x, y
+    via.drill = drill
+    via.diameter = diameter
+    via.layer_from = layer_from
+    via.layer_to = layer_to
+    via.net = net
+    return via
+
+
+def _cpp_zone(min_x, min_y, max_x, max_y, net_ids):
+    from kicad_tools.router import router_cpp
+
+    zone = router_cpp.AttachZone()
+    zone.min_x, zone.min_y, zone.max_x, zone.max_y = min_x, min_y, max_x, max_y
+    zone.net_ids = list(net_ids)
+    return zone
+
+
+def _install_domains(grid, dru: float = DRU) -> None:
+    domains = build_cpp_domain_matrix(_table(dru), NET_NAMES)
+    assert domains is not None
+    grid.set_pairwise_domains(domains.net_to_domain, domains.matrix)
+
+
+def _validate(grid, segments, vias=(), exclude_net=HV_NET, trace_clearance=DRU, **kwargs):
+    return grid.validate_route(
+        list(segments),
+        list(vias),
+        exclude_net,
+        [],
+        trace_clearance,
+        kwargs.get("via_clearance", DRU),
+        kwargs.get("min_drill_clearance", 0.102),
+        kwargs.get("partner_net", -1),
+        kwargs.get("intra_pair_clearance", 0.0),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dormancy / backward compatibility
+# ---------------------------------------------------------------------------
+
+
+@requires_cpp
+def test_setters_dormant_by_default() -> None:
+    grid = _cpp_grid()
+    assert grid.pairwise_active is False
+    assert grid.attach_zone_count == 0
+    # Every net is domain-less, so the matrix lookup can never widen anything.
+    assert grid.pairwise_required_clearance(HV_NET, LV_NET) == pytest.approx(0.0)
+    assert grid.attach_zone_exempts(0.0, 0.0, HV_NET, LV_NET) is False
+
+
+@requires_cpp
+def test_uninstalled_matrix_leaves_hv_lv_pair_valid() -> None:
+    """Without the setter, a 0.2 mm HV<->LV gap passes at the scalar floor."""
+    grid = _cpp_grid()
+    grid.add_stored_segment(0.0, 0.4, 5.0, 0.4, TRACE_WIDTH, 0, LV_NET)
+    result = _validate(grid, [_cpp_segment(0.0, 0.0, 5.0, 0.0, HV_NET)])
+    assert result.valid
+
+
+@requires_cpp
+def test_empty_matrix_returns_grid_to_dormant_state() -> None:
+    grid = _cpp_grid()
+    _install_domains(grid)
+    assert grid.pairwise_active is True
+
+    grid.set_pairwise_domains([], [])
+    assert grid.pairwise_active is False
+    grid.add_stored_segment(0.0, 0.4, 5.0, 0.4, TRACE_WIDTH, 0, LV_NET)
+    assert _validate(grid, [_cpp_segment(0.0, 0.0, 5.0, 0.0, HV_NET)]).valid
+
+
+# ---------------------------------------------------------------------------
+# Matrix widening -- parity with the Python validator
+# ---------------------------------------------------------------------------
+
+
+@requires_cpp
+def test_seg_seg_parity_with_python_find_pairwise_violations() -> None:
+    """C++ and Python agree: HV<->LV below requirement fails, HV<->HV at DRU passes."""
+    table = _table()
+    py_hv = Segment(0.0, 0.0, 5.0, 0.0, TRACE_WIDTH, Layer.F_CU, net=HV_NET, net_name="/AC_LINE")
+    py_lv = Segment(0.0, 0.4, 5.0, 0.4, TRACE_WIDTH, Layer.F_CU, net=LV_NET, net_name="/GND")
+    py_tap = Segment(
+        0.0, -0.4, 5.0, -0.4, TRACE_WIDTH, Layer.F_CU, net=HV_TAP_NET, net_name="/AC_LINE_TAP"
+    )
+
+    python_violations = find_pairwise_violations(
+        [
+            Route(net=HV_NET, net_name="/AC_LINE", segments=[py_hv]),
+            Route(net=LV_NET, net_name="/GND", segments=[py_lv]),
+            Route(net=HV_TAP_NET, net_name="/AC_LINE_TAP", segments=[py_tap]),
+        ],
+        table,
+    )
+    flagged = {tuple(sorted((v.net_a, v.net_b))) for v in python_violations}
+    # Both HV nets are too close to LV; the two equal-potential HV nets are not.
+    assert flagged == {("/AC_LINE", "/GND"), ("/AC_LINE_TAP", "/GND")}
+
+    grid = _cpp_grid()
+    _install_domains(grid)
+    candidate = [_cpp_segment(0.0, 0.0, 5.0, 0.0, HV_NET)]
+
+    # Cross-domain foreign copper at the same 0.2 mm gap -> rejected.
+    grid.add_stored_segment(0.0, 0.4, 5.0, 0.4, TRACE_WIDTH, 0, LV_NET)
+    cross = _validate(grid, candidate)
+    assert not cross.valid
+    assert cross.violation_type == 2  # seg-seg
+
+    # Same-domain foreign copper at the same gap -> accepted (DRU governs).
+    same_domain = _cpp_grid()
+    _install_domains(same_domain)
+    same_domain.add_stored_segment(0.0, -0.4, 5.0, -0.4, TRACE_WIDTH, 0, HV_TAP_NET)
+    assert _validate(same_domain, candidate).valid
+
+
+@requires_cpp
+def test_matrix_accepts_pair_meeting_requirement() -> None:
+    grid = _cpp_grid()
+    _install_domains(grid)
+    # 2.0 mm centre gap -> 1.8 mm edge gap >= 1.6 mm requirement.
+    grid.add_stored_segment(0.0, 2.0, 5.0, 2.0, TRACE_WIDTH, 0, LV_NET)
+    assert _validate(grid, [_cpp_segment(0.0, 0.0, 5.0, 0.0, HV_NET)]).valid
+
+
+@requires_cpp
+def test_matrix_widens_segment_vs_pad() -> None:
+    """The Python post-check is trace-vs-trace only; C++ also walks pads."""
+    grid = _cpp_grid()
+    _install_domains(grid)
+    # Circular 0.2 mm pad on the LV net, 0.4 mm off the candidate centreline:
+    # edge gap = 0.4 - 0.1 (trace) - 0.1 (pad) = 0.2 mm -> at the DRU floor.
+    grid.add_pad(2.5, 0.4, 0.2, 0.2, LV_NET, 0, 0, DRU, False)
+    result = _validate(grid, [_cpp_segment(0.0, 0.0, 5.0, 0.0, HV_NET)])
+    assert not result.valid
+    assert result.violation_type == 1  # seg-pad
+
+
+@requires_cpp
+def test_matrix_widens_segment_vs_stored_via() -> None:
+    grid = _cpp_grid()
+    _install_domains(grid)
+    # Via radius 0.3 + trace radius 0.1 -> 0.8 mm centre distance = 0.4 mm gap.
+    grid.add_stored_via(2.5, 0.8, 0.3, 0.6, LV_NET)
+    result = _validate(grid, [_cpp_segment(0.0, 0.0, 5.0, 0.0, HV_NET)])
+    assert not result.valid
+    assert result.violation_type == 3  # seg-via
+
+
+@requires_cpp
+def test_matrix_widens_candidate_via_vs_stored_segment() -> None:
+    grid = _cpp_grid()
+    _install_domains(grid)
+    grid.add_stored_segment(0.0, 1.0, 5.0, 1.0, TRACE_WIDTH, 0, LV_NET)
+    result = _validate(grid, [], [_cpp_via(2.5, 0.0, HV_NET)])
+    assert not result.valid
+    assert result.violation_type == 4  # via-seg
+
+
+@requires_cpp
+def test_matrix_widens_candidate_via_vs_stored_via() -> None:
+    grid = _cpp_grid()
+    _install_domains(grid)
+    grid.add_stored_via(2.5, 1.0, 0.3, 0.6, LV_NET)
+    result = _validate(grid, [], [_cpp_via(2.5, 0.0, HV_NET)])
+    assert not result.valid
+    assert result.violation_type == 5  # via-via
+
+
+@requires_cpp
+def test_same_net_drill_spacing_unaffected_by_matrix() -> None:
+    """Same-net drill spacing is a same-net rule -- the matrix never applies."""
+    grid = _cpp_grid()
+    _install_domains(grid)
+    grid.add_stored_via(2.5, 1.0, 0.3, 0.6, HV_NET)
+    assert _validate(grid, [], [_cpp_via(2.5, 0.0, HV_NET)]).valid
+
+
+# ---------------------------------------------------------------------------
+# Attach-zone exemption parity (#4506 fixtures, mirrored against C++)
+# ---------------------------------------------------------------------------
+
+
+@requires_cpp
+def test_attach_zone_exempts_only_terminating_pair_inside_zone() -> None:
+    """Mirror of the Python fixture of the same name against the C++ path."""
+    grid = _cpp_grid()
+    _install_domains(grid)
+    grid.set_attach_zones([_cpp_zone(0.0, -1.0, 5.0, 1.0, [HV_NET, LV_NET])])
+    candidate = [_cpp_segment(0.0, 0.0, 5.0, 0.0, HV_NET)]
+
+    # Rated package owns both nets -> the pair may neck down to the DRU floor.
+    grid.add_stored_segment(0.0, 0.4, 5.0, 0.4, TRACE_WIDTH, 0, LV_NET)
+    assert _validate(grid, candidate).valid
+
+    # A net merely crossing the courtyard -- not a member of the rated
+    # footprint's zone -- receives no waiver.
+    outside_membership = _cpp_grid()
+    _install_domains(outside_membership)
+    outside_membership.set_attach_zones([_cpp_zone(0.0, -1.0, 5.0, 1.0, [HV_NET, HV_TAP_NET])])
+    outside_membership.add_stored_segment(0.0, 0.4, 5.0, 0.4, TRACE_WIDTH, 0, LV_NET)
+    assert not _validate(outside_membership, candidate).valid
+
+
+@requires_cpp
+def test_attach_zone_does_not_exempt_same_pair_outside_zone() -> None:
+    grid = _cpp_grid()
+    _install_domains(grid)
+    grid.set_attach_zones([_cpp_zone(0.0, -1.0, 5.0, 1.0, [HV_NET, LV_NET])])
+    # Both segments run well east of the zone.
+    grid.add_stored_segment(10.0, 0.4, 15.0, 0.4, TRACE_WIDTH, 0, LV_NET)
+    assert not _validate(grid, [_cpp_segment(10.0, 0.0, 15.0, 0.0, HV_NET)]).valid
+
+
+@requires_cpp
+def test_attach_zone_uses_closest_gap_not_long_segment_midpoint() -> None:
+    """The gap point is the closest approach, not either segment's midpoint."""
+    grid = _cpp_grid()
+    _install_domains(grid)
+    grid.set_attach_zones([_cpp_zone(4.0, 4.0, 6.0, 6.0, [HV_NET, LV_NET])])
+    # A long foreign segment whose own midpoint is inside the zone, but whose
+    # closest approach to the short candidate is far outside it.
+    grid.add_stored_segment(0.0, 5.4, 10.0, 5.4, TRACE_WIDTH, 0, LV_NET)
+    assert not _validate(grid, [_cpp_segment(9.0, 5.0, 9.5, 5.0, HV_NET)]).valid
+
+    # The mirrored geometry -- a short in-zone foreign neck -- IS waived even
+    # though the candidate extends far outside the zone.
+    waived = _cpp_grid()
+    _install_domains(waived)
+    waived.set_attach_zones([_cpp_zone(4.0, 4.0, 6.0, 6.0, [HV_NET, LV_NET])])
+    waived.add_stored_segment(4.8, 5.4, 5.2, 5.4, TRACE_WIDTH, 0, LV_NET)
+    assert _validate(waived, [_cpp_segment(0.0, 5.0, 10.0, 5.0, HV_NET)]).valid
+
+
+@requires_cpp
+def test_attach_zone_never_waives_below_dru_floor() -> None:
+    """The rated-package neck may reach, but never cross, the scalar floor."""
+    grid = _cpp_grid()
+    _install_domains(grid)
+    grid.set_attach_zones([_cpp_zone(0.0, -1.0, 5.0, 1.0, [HV_NET, LV_NET])])
+    # 0.25 mm centre distance minus two 0.1 mm radii = 0.05 mm edge gap.
+    grid.add_stored_segment(0.0, 0.25, 5.0, 0.25, TRACE_WIDTH, 0, LV_NET)
+    result = _validate(grid, [_cpp_segment(0.0, 0.0, 5.0, 0.0, HV_NET)])
+    assert not result.valid
+    assert result.min_clearance == pytest.approx(0.05, abs=1e-5)
+
+
+@requires_cpp
+def test_attach_zone_exempts_pad_walking_false_positive() -> None:
+    """A domain-bridging rated footprint's own pads must not fail validation."""
+    grid = _cpp_grid()
+    _install_domains(grid)
+    grid.add_pad(2.5, 0.4, 0.2, 0.2, LV_NET, 0, 0, DRU, False)
+    assert not _validate(grid, [_cpp_segment(0.0, 0.0, 5.0, 0.0, HV_NET)]).valid
+
+    exempt = _cpp_grid()
+    _install_domains(exempt)
+    exempt.add_pad(2.5, 0.4, 0.2, 0.2, LV_NET, 0, 0, DRU, False)
+    exempt.set_attach_zones([_cpp_zone(0.0, -1.0, 5.0, 1.0, [HV_NET, LV_NET])])
+    assert _validate(exempt, [_cpp_segment(0.0, 0.0, 5.0, 0.0, HV_NET)]).valid
+
+
+@requires_cpp
+def test_attach_zone_with_more_than_two_nets_requires_both_members() -> None:
+    """A 3-pad rated connector's zone exempts any *member* pair, not just two."""
+    grid = _cpp_grid()
+    _install_domains(grid)
+    grid.set_attach_zones([_cpp_zone(0.0, -1.0, 5.0, 1.0, [HV_NET, LV_NET, HV_TAP_NET])])
+    grid.add_stored_segment(0.0, 0.4, 5.0, 0.4, TRACE_WIDTH, 0, LV_NET)
+    assert _validate(grid, [_cpp_segment(0.0, 0.0, 5.0, 0.0, HV_NET)]).valid
+    assert grid.attach_zone_exempts(2.5, 0.2, HV_TAP_NET, LV_NET) is True
+    assert grid.attach_zone_exempts(2.5, 0.2, HV_NET, 99) is False
+
+
+# ---------------------------------------------------------------------------
+# Diff-pair partner precedence (#2559 / Epic #2556)
+# ---------------------------------------------------------------------------
+
+
+@requires_cpp
+def test_partner_relaxation_takes_precedence_over_matrix_widening() -> None:
+    """A net that is both diff-pair partner and cross-domain stays tight."""
+    grid = _cpp_grid()
+    _install_domains(grid)
+    grid.add_stored_segment(0.0, 0.4, 5.0, 0.4, TRACE_WIDTH, 0, LV_NET)
+    candidate = [_cpp_segment(0.0, 0.0, 5.0, 0.0, HV_NET)]
+
+    # Without the partner declaration the matrix rejects the 0.2 mm gap.
+    assert not _validate(grid, candidate).valid
+
+    # With LV_NET declared as the partner, the within-pair clearance wins.
+    assert _validate(grid, candidate, partner_net=LV_NET, intra_pair_clearance=0.1).valid
+
+
+@requires_cpp
+def test_partner_precedence_does_not_leak_to_other_nets() -> None:
+    grid = _cpp_grid()
+    _install_domains(grid)
+    grid.add_stored_segment(0.0, 0.4, 5.0, 0.4, TRACE_WIDTH, 0, LV_NET)
+    # A partner declaration for a DIFFERENT net leaves the LV pair widened.
+    assert not _validate(
+        grid,
+        [_cpp_segment(0.0, 0.0, 5.0, 0.0, HV_NET)],
+        partner_net=HV_TAP_NET,
+        intra_pair_clearance=0.1,
+    ).valid
+
+
+# ---------------------------------------------------------------------------
+# Python -> C++ translation helpers
+# ---------------------------------------------------------------------------
+
+
+def test_build_cpp_domain_matrix_projects_nets_onto_domains() -> None:
+    domains = build_cpp_domain_matrix(_table(), NET_NAMES)
+    assert domains is not None
+    net_to_domain, matrix = domains
+    # HV and HV_TAP share no domain (Phase 1: one domain per net), but their
+    # matrix entry is 0 -- no widening between equal potentials.
+    hv, lv, tap = (net_to_domain[n] for n in (HV_NET, LV_NET, HV_TAP_NET))
+    assert -1 not in (hv, lv, tap)
+    assert matrix[hv][lv] == pytest.approx(IEC_150V_PD2_IIIA_MM)
+    assert matrix[lv][hv] == pytest.approx(IEC_150V_PD2_IIIA_MM)
+    assert matrix[hv][tap] == pytest.approx(0.0)
+    assert matrix[hv][hv] == pytest.approx(0.0)
+    # Net 0 (the unconnected/pour convention) never carries a domain.
+    assert net_to_domain[0] == -1
+
+
+def test_build_cpp_domain_matrix_matches_python_resolver() -> None:
+    """The exported matrix reproduces ``required_clearance`` above the floor."""
+    table = _table()
+    domains = build_cpp_domain_matrix(table, NET_NAMES)
+    assert domains is not None
+    net_to_domain, matrix = domains
+    for name_a, id_a in NET_NAMES.items():
+        for name_b, id_b in NET_NAMES.items():
+            expected = table.required_clearance(name_a, name_b)
+            exported = matrix[net_to_domain[id_a]][net_to_domain[id_b]]
+            assert max(table.dru, exported) == pytest.approx(expected)
+
+
+def test_build_cpp_domain_matrix_normalises_leading_slash() -> None:
+    # Voltage map without slashes, board net names with them.
+    table = build_pairwise_clearance_table({"AC_LINE": 150.0, "GND": 0.0}, dru=DRU)
+    domains = build_cpp_domain_matrix(table, {"/AC_LINE": 1, "/GND": 2})
+    assert domains is not None
+    net_to_domain, matrix = domains
+    assert matrix[net_to_domain[1]][net_to_domain[2]] == pytest.approx(IEC_150V_PD2_IIIA_MM)
+
+
+def test_build_cpp_domain_matrix_dormant_without_widening_pairs() -> None:
+    assert build_cpp_domain_matrix(None, NET_NAMES) is None
+    # All nets at the same potential -> no pair needs widening.
+    flat = build_pairwise_clearance_table({"/A": 0.0, "/B": 0.0}, dru=DRU)
+    assert build_cpp_domain_matrix(flat, {"/A": 1, "/B": 2}) is None
+    # Participating nets unresolvable to board ids.
+    assert build_cpp_domain_matrix(_table(), {}) is None
+
+
+def test_attach_zones_to_net_ids_translates_and_drops_unresolvable() -> None:
+    zones = (
+        AttachZone(0.0, -1.0, 5.0, 1.0, frozenset({"AC_LINE", "GND"})),
+        AttachZone(9.0, 9.0, 10.0, 10.0, frozenset({"AC_LINE", "NOT_ON_BOARD"})),
+    )
+    translated = attach_zones_to_net_ids(zones, NET_NAMES)
+    assert translated == [(0.0, -1.0, 5.0, 1.0, [HV_NET, LV_NET])]
+
+
+def test_attach_zones_to_net_ids_preserves_multi_net_zones() -> None:
+    zone = AttachZone(0.0, 0.0, 1.0, 1.0, frozenset({"AC_LINE", "GND", "AC_LINE_TAP"}))
+    (translated,) = attach_zones_to_net_ids((zone,), NET_NAMES)
+    assert translated[4] == [HV_NET, LV_NET, HV_TAP_NET]
+
+
+# ---------------------------------------------------------------------------
+# cpp_backend plumbing
+# ---------------------------------------------------------------------------
+
+
+def _backend_grid_and_rules():
+    rules = DesignRules(
+        trace_width=TRACE_WIDTH,
+        trace_clearance=DRU,
+        via_clearance=DRU,
+        grid_resolution=0.1,
+    )
+    grid = RoutingGrid(width=20.0, height=20.0, rules=rules, layer_stack=LayerStack.two_layer())
+    return grid, rules
+
+
+@requires_cpp
+def test_backend_threads_domain_matrix_and_zones_into_cpp_grid() -> None:
+    py_grid, rules = _backend_grid_and_rules()
+    rules.pairwise_clearance = _table()
+    cpp_grid = CppGrid.from_routing_grid(py_grid)
+    backend = CppPathfinder(cpp_grid, rules, diagonal_routing=True)
+    backend.set_net_name_to_id(dict(NET_NAMES))
+    backend.set_attach_zones((AttachZone(0.0, -1.0, 5.0, 1.0, frozenset({"AC_LINE", "GND"})),))
+
+    assert cpp_grid._impl.pairwise_active is False
+    backend._sync_pairwise_domains_to_cpp()
+
+    assert cpp_grid._impl.pairwise_active is True
+    assert cpp_grid._impl.attach_zone_count == 1
+    assert cpp_grid._impl.pairwise_required_clearance(HV_NET, LV_NET) == pytest.approx(
+        IEC_150V_PD2_IIIA_MM
+    )
+    assert cpp_grid._impl.attach_zone_exempts(2.5, 0.2, HV_NET, LV_NET) is True
+
+
+@requires_cpp
+def test_backend_sync_is_noop_without_voltage_map() -> None:
+    py_grid, rules = _backend_grid_and_rules()
+    cpp_grid = CppGrid.from_routing_grid(py_grid)
+    backend = CppPathfinder(cpp_grid, rules, diagonal_routing=True)
+    backend.set_net_name_to_id(dict(NET_NAMES))
+
+    backend._sync_pairwise_domains_to_cpp()
+    assert cpp_grid._impl.pairwise_active is False
+    assert cpp_grid._impl.attach_zone_count == 0
+
+
+@requires_cpp
+def test_backend_validate_route_rejects_hv_trace_beside_lv_pad() -> None:
+    """End-to-end: the C++ matrix catches a pad the Python post-check cannot.
+
+    ``route_pairwise_violation`` (the Phase 1 Python post-check) walks only
+    trace-vs-trace copper, so an HV trace hugging a foreign LV *pad* is
+    invisible to it.  This is the gap Phase 2a closes.
+    """
+    py_grid, rules = _backend_grid_and_rules()
+    rules.pairwise_clearance = _table()
+    cpp_grid = CppGrid.from_routing_grid(py_grid)
+    backend = CppPathfinder(cpp_grid, rules, diagonal_routing=True)
+    backend.set_net_name_to_id(dict(NET_NAMES))
+
+    # LV pad 0.4 mm off the HV candidate's centreline -> 0.2 mm edge gap.
+    cpp_grid._impl.add_pad(2.5, 0.4, 0.2, 0.2, LV_NET, 0, 0, DRU, False)
+
+    route = Route(
+        net=HV_NET,
+        net_name="/AC_LINE",
+        segments=[
+            Segment(0.0, 0.0, 5.0, 0.0, TRACE_WIDTH, Layer.F_CU, net=HV_NET, net_name="/AC_LINE")
+        ],
+    )
+    start = Pad(0.0, 0.0, 0.2, 0.2, HV_NET, "/AC_LINE")
+    end = Pad(5.0, 0.0, 0.2, 0.2, HV_NET, "/AC_LINE")
+
+    assert backend._validate_route_clearance(route, start, end, 1) is not None
+
+    # The same geometry inside a rated footprint's attach zone validates clean.
+    backend.set_attach_zones((AttachZone(0.0, -1.0, 5.0, 1.0, frozenset({"AC_LINE", "GND"})),))
+    cpp_grid._impl.set_pairwise_domains([], [])  # force a fresh install
+    assert backend._validate_route_clearance(route, start, end, 1) is None


### PR DESCRIPTION
## Summary

Phase 2a of epic #4431 (split of #4507) — the **validation-layer** half.

`Grid3D::validate_route` knew exactly one pairwise special case (the #2559 diff-pair partner relaxation), so with the C++ backend active the authoritative geometric validator could not see HV-isolation requirements at all — only the Phase 1 Python trace-vs-trace post-check could. This teaches the C++ validator the domain matrix, threads in the #4506 rated-footprint attach-zone exemption, and plumbs both from Python.

Search-time avoidance/pricing (`pathfinder.cpp`) is explicitly **out of scope** and stays with #4511. Interim behaviour is identical to today's Phase-1 post-check rejection, so convergence is unchanged.

## Changes

**C++ (`cpp/include/types.hpp`, `cpp/include/grid.hpp`, `cpp/src/grid.cpp`, `cpp/src/bindings.cpp`)**

- New `AttachZone` struct (bbox + `vector<int> net_ids`) — the net-id-translated mirror of the Python frozen dataclass.
- `Grid3D` gains a per-net domain-id array, a dense row-major domain-pair clearance matrix (mm), the attach-zone vector, and a grid-wide `pairwise_active_` fast-path flag.
- Two dormant-by-default setters bound through nanobind: `set_pairwise_domains(net_to_domain, matrix)` and `set_attach_zones(zones)`; plus read-only `pairwise_active` / `attach_zone_count` and the query helpers `pairwise_required_clearance()` / `attach_zone_exempts()` (used by the parity tests).
- `validate_route` applies `max(effective_scalar, matrix[dom_a][dom_b])` at **every** copper pair it walks: segment-vs-pad, segment-vs-segment, segment-vs-via, via-vs-segment, via-vs-via. Same-net drill spacing is untouched (same-net rule).
- **Precedence**: the diff-pair partner branch wins — it tightens *within* a declared pair, the matrix widens *across* domains. A net that is both partner and cross-domain stays at `intra_pair_clearance`.
- **Attach-zone exemption** skips only the widening, never the scalar floor. The gap point is a faithful C++ port of the Python validator's `_closest_gap_midpoint` (so a long segment's own midpoint is never mistaken for the gap point), computed **lazily** — a board with no voltage map pays one bool test per comparison.
- `ROUTER_CPP_BUILD_VERSION` 17 -> 18 (new binding surface) with the matching `_REQUIRED_CPP_BUILD_VERSION` bump.

**Python (`router/pairwise_clearance.py`, `router/cpp_backend.py`)**

- `build_cpp_domain_matrix(table, net_name_to_id) -> CppDomainMatrix | None` projects a `PairwiseClearanceTable` onto integer net ids (Phase 1: one domain per participating net). Matrix entries are **pure widening values** — the raw creepage requirement without the DRU floor — so `max(scalar, matrix)` can never raise a pair above its scalar rule, exactly mirroring `segment_pair_violation`'s `required <= floor` skip. Returns `None` (dormant) when nothing needs widening.
- `attach_zones_to_net_ids(zones, net_name_to_id)` resolves `AttachZone.net_names` through the reverse net map, normalising the leading `/`, preserving multi-net (>2) rated connectors, and dropping zones that resolve to fewer than two ids.
- `CppPathfinder._sync_pairwise_domains_to_cpp()` installs both on the C++ grid, called next to the existing `partner_net_id` resolution immediately before `validate_route`. The translated payload is cached (invalidated by `set_net_name_to_id` / `set_attach_zones`) and reinstalled whenever the grid reports itself dormant — which covers a rebuilt C++ grid.

## Acceptance Criteria Verification

- [x] **Dormant-by-default `set_pairwise_domains`** — `test_setters_dormant_by_default`, `test_uninstalled_matrix_leaves_hv_lv_pair_valid`, `test_empty_matrix_returns_grid_to_dormant_state`.
- [x] **Dormant-by-default attach-zone setter consuming the net-id-translated shape** — `attach_zone_count == 0` by default; `router_cpp.AttachZone` is the net-id mirror; `test_backend_sync_is_noop_without_voltage_map`.
- [x] **`max(effective_scalar, matrix[dom_a][dom_b])` honouring exemption + partner precedence** — `test_matrix_widens_segment_vs_pad` / `_vs_stored_via` / `_candidate_via_vs_stored_segment` / `_vs_stored_via`, `test_attach_zone_*`, `test_partner_relaxation_takes_precedence_over_matrix_widening`, `test_partner_precedence_does_not_leak_to_other_nets`.
- [x] **`cpp_backend.py` threads both matrix and `_attach_zones` (net-id translated)** — `test_backend_threads_domain_matrix_and_zones_into_cpp_grid`, `test_backend_validate_route_rejects_hv_trace_beside_lv_pad`.
- [x] **`uv run kct build-native` succeeds** — `C++ backend: available (version 1.0.0)`, `BUILD_VERSION == 18`.

## Test Plan

New: `tests/router/test_pairwise_cpp_parity.py` (27 tests).

- [x] **Parity** — `test_seg_seg_parity_with_python_find_pairwise_violations`: the same fixture is scanned by Python `find_pairwise_violations` and by C++ `validate_route`; both flag the HV<->LV pair below requirement and both accept the same-domain pair at the DRU floor.
- [x] **Exemption parity** — mirrors of `test_attach_zone_exempts_only_terminating_pair_inside_zone`, `test_attach_zone_does_not_exempt_same_pair_outside_zone` and `test_attach_zone_uses_closest_gap_not_long_segment_midpoint` against the C++ path, plus `test_attach_zone_exempts_pad_walking_false_positive` (the pad-walking false positive #4506 exists to prevent) and `test_attach_zone_with_more_than_two_nets_requires_both_members`.
- [x] **Exemption floor** — `test_attach_zone_never_waives_below_dru_floor`: a 0.05 mm gap inside the zone still fails at the 0.2 mm scalar floor.
- [x] **Backward compat** — dormancy tests above; existing suites green **unmodified**: `tests/router/` (1005 passed, 5 skipped), `tests/ -k diffpair` (753 passed), `tests/test_router_core.py` + `test_router_grid.py` + `test_router_integration.py` + `test_router_io.py` + `test_board_04_routing_regression.py` + segment/via-clearance suites (591 passed), `tests/test_cpp_validation_parity.py` / `test_router_cpp_via_clearance.py` / `test_router_cpp_foreign_pad_metal_rejection.py` / `test_validate_clearance_rect_pad.py` (all green).
- [x] **Diff-pair regression** — the two precedence tests above, plus the full 753-test diffpair suite unchanged.
- [x] `uv run ruff format . --check` (1714 files already formatted) and `uv run ruff check .` clean; `scripts/ci/check_mypy_baseline.py` reports no new type errors (1473 within the 1474 baseline).

### Note on a pre-existing failure

`tests/router/lattice/test_post_pass_gating.py::test_cli_grid_still_runs_both_passes` fails when run **after** `tests/test_router_determinism.py` in the same process. Verified **pre-existing**: it reproduces identically on the unmodified base commit with a base-version `.so` (this branch's changes stashed). It passes in isolation and in a standalone `tests/router/` run. Not addressed here — out of scope.

Closes #4510