### PR TITLE
fix(diffpair): make shadow rescue tails partner-aware (4/9 -> 6/9 board-06 construction)

### DIFF
--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -170,6 +170,11 @@ _GUIDE_SELF_APPROACH_DETOUR_RATIO: float = float(
 # fixed cost over the boosted neighbourhood; one pass is too weak to divert the
 # A* out of a dense escape fan, so accumulate several.
 _GUIDE_BIAS_BOOST_REPEATS: int = int(os.environ.get("KCT_GUIDE_BIAS_BOOST_REPEATS", "6"))
+# Issue #4460: opt-in verbose provenance for shadow self-check declines.  When
+# set, every ``self-check overlap`` decline prints WHICH part of the assembled
+# shadow (start tail / body / end tail) produced the offending segment and where
+# it sits relative to the guide.  Diagnostic-only; off by default.
+_SHADOW_DEBUG: bool = os.environ.get("KCT_SHADOW_DEBUG", "0") == "1"
 
 
 # ---------------------------------------------------------------------------
@@ -305,6 +310,25 @@ def _count_off_angle_segments(route: Route | None) -> int:
             continue  # exact 45
         off += 1
     return off
+
+
+def _segments_within(a: Segment, b: Segment, margin: float) -> bool:
+    """Cheap axis-aligned-bounding-box overlap test with ``margin`` (issue #4460).
+
+    A conservative pre-filter for the sampled centreline-distance checks: when
+    the two segments' AABBs do not come within ``margin``, no point of ``a`` can
+    be within ``margin`` of ``b``, so the expensive sampling is skipped.  Never
+    rejects a genuinely-close pair (the AABB is a superset of the segment).
+    """
+    if min(a.x1, a.x2) - margin > max(b.x1, b.x2):
+        return False
+    if max(a.x1, a.x2) + margin < min(b.x1, b.x2):
+        return False
+    if min(a.y1, a.y2) - margin > max(b.y1, b.y2):
+        return False
+    if max(a.y1, a.y2) + margin < min(b.y1, b.y2):
+        return False
+    return True
 
 
 def classify_coupled_pair_outcome(
@@ -3547,7 +3571,13 @@ class DiffPairRouter:
         return True
 
     def _synthesize_tail(
-        self, pathfinder: CoupledPathfinder, head: Pad, goal: Pad, layer_idx: int
+        self,
+        pathfinder: CoupledPathfinder,
+        head: Pad,
+        goal: Pad,
+        layer_idx: int,
+        partner_segments: list[Segment] | None = None,
+        partner_clearance: float = 0.0,
     ) -> Route | None:
         """Geometric head->pad tail on the head's layer (issue #3508).
 
@@ -3557,6 +3587,19 @@ class DiffPairRouter:
         directly -- a straight segment, or an axis-aligned dogleg --
         and validate every covered grid cell with
         :meth:`_segment_cells_clear`.
+
+        Issue #4460: when ``partner_segments`` is supplied the partner
+        (diff-pair guide) copper is part of the CANDIDATE FILTER, not a
+        post-hoc veto on the single winner.  The partner is not in the grid,
+        so ``_segment_cells_clear`` cannot see it; screening only the first
+        obstacle-clear candidate threw away the 20+ remaining U-detours
+        whenever that one candidate happened to hug the guide, and the caller
+        fell through to a partner-BLIND A* tail that ran on top of the guide
+        (measured on board 06: every shadow ``self-check overlap`` decline
+        traced to such a tail, centre-to-centre 0.018-0.035 mm).  Requiring
+        ``partner_clearance`` centre-to-centre inside the loop makes the
+        detour repertoire actually reachable.  With no partner supplied
+        (``partner_clearance`` 0) the selection is unchanged.
         """
         grid = self.autorouter.grid
         goal_layer_idx = grid.layer_to_index(goal.layer.value)
@@ -3564,6 +3607,25 @@ class DiffPairRouter:
             return None  # layer mismatch: leave to the A* fallback
         width = pathfinder._get_trace_width_for_net(head.net_name)
         layer = Layer(grid.index_to_layer(layer_idx))
+
+        # Issue #4460: narrow the partner list ONCE to same-layer copper inside
+        # the candidate envelope (the widest U-detour is +/-3.2 mm).  Guides
+        # reach ~900 segments; screening 27 candidates against all of them
+        # would dominate the constructor's runtime.
+        near_partner: list[Segment] = []
+        if partner_segments and partner_clearance > 0.0:
+            reach = 3.2 + partner_clearance + grid.resolution
+            lo_x, hi_x = min(head.x, goal.x) - reach, max(head.x, goal.x) + reach
+            lo_y, hi_y = min(head.y, goal.y) - reach, max(head.y, goal.y) + reach
+            near_partner = [
+                ps
+                for ps in partner_segments
+                if ps.layer == layer
+                and min(ps.x1, ps.x2) <= hi_x
+                and max(ps.x1, ps.x2) >= lo_x
+                and min(ps.y1, ps.y2) <= hi_y
+                and max(ps.y1, ps.y2) >= lo_y
+            ]
 
         candidates: list[list[tuple[float, float, float, float]]] = [
             [(head.x, head.y, goal.x, goal.y)],  # direct
@@ -3607,6 +3669,14 @@ class DiffPairRouter:
                 self._segment_cells_clear(pathfinder, x1, y1, x2, y2, layer_idx, head.net)
                 for x1, y1, x2, y2 in segs
             ):
+                # Issue #4460: the partner (guide) is not in the grid -- screen
+                # it here so a candidate that hugs it loses to a later detour.
+                if near_partner and any(
+                    self._min_distance_to_partner(x1, y1, x2, y2, near_partner, layer)
+                    < partner_clearance
+                    for x1, y1, x2, y2 in segs
+                ):
+                    continue
                 route = Route(net=head.net, net_name=head.net_name)
                 for x1, y1, x2, y2 in segs:
                     if abs(x2 - x1) < 0.01 and abs(y2 - y1) < 0.01:
@@ -3938,6 +4008,144 @@ class DiffPairRouter:
                     return route
         return None
 
+    def _tail_partner_clear(
+        self,
+        tail: Route,
+        partner_segments: list[Segment],
+        clearance: float,
+    ) -> bool:
+        """Does ``tail`` keep clear of the partner (guide) copper? (issue #4460)
+
+        Two bounds, selected by ``clearance``:
+
+        * ``clearance > 0`` -- the intra-pair CLEARANCE bound (centre-to-centre
+          ``trace_width + intra_pair_clearance``), i.e. a properly-coupled
+          tail.  Via barrels additionally keep the manufacturer trace
+          clearance to partner copper on any layer.
+        * ``clearance <= 0`` -- the PHYSICAL-overlap bound only (copper edges
+          must not intersect).  This is exactly what the constructor's
+          self-check gate (``find_intra_pair_clearance_violations`` /
+          ``_pair_has_physical_overlap``) demands, so a tail passing it can
+          never be the reason a side is declined.
+
+        The partner is never in the routing grid during shadow construction,
+        so this geometric screen is the only thing standing between a
+        partner-blind A* tail and copper drawn on top of the guide.
+        """
+        rules = self.autorouter.rules
+        strict = clearance > 0.0
+        for seg in tail.segments:
+            for ps in partner_segments:
+                if ps.layer != seg.layer:
+                    continue
+                need = clearance if strict else (seg.width + ps.width) / 2.0
+                # Cheap AABB reject first: guides run to 900 segments and the
+                # sampled distance below is the hot loop of every tail screen.
+                if not _segments_within(seg, ps, need):
+                    continue
+                if (
+                    self._min_distance_to_partner(seg.x1, seg.y1, seg.x2, seg.y2, [ps], seg.layer)
+                    < need
+                ):
+                    return False
+        for via in tail.vias:
+            bound = via.diameter / 2.0 + (rules.trace_clearance if strict else 0.0)
+            for ps in partner_segments:
+                if self._point_segment_distance(via.x, via.y, ps) < bound + ps.width / 2.0:
+                    return False
+        return True
+
+    def _partner_boost_sites(
+        self,
+        head: Pad,
+        goal: Pad,
+        partner_segments: list[Segment],
+        seg_clear: float,
+        max_sites: int = 40,
+    ) -> list[tuple[float, float]]:
+        """Sample partner copper inside the tail's neighbourhood (issue #4460).
+
+        Returned world points feed ``_single_ended_guide_route``'s
+        ``avoid_locations`` so the fallback tail's A* pays to run along the
+        guide instead of treating it as free space.  Only partner copper near
+        the head->goal corridor is sampled (a whole 900-segment escape guide
+        would boost the entire board), points are spaced by ``seg_clear`` so
+        the boosted neighbourhoods tile rather than stack, and the count is
+        capped so the boost pass stays cheap.
+        """
+        if not partner_segments or seg_clear <= 0.0:
+            return []
+        pad = 2.0 * seg_clear + 0.5
+        lo_x, hi_x = min(head.x, goal.x) - pad, max(head.x, goal.x) + pad
+        lo_y, hi_y = min(head.y, goal.y) - pad, max(head.y, goal.y) + pad
+        step = max(self.autorouter.grid.resolution, seg_clear)
+        sites: list[tuple[float, float]] = []
+        for ps in partner_segments:
+            seg_len = math.hypot(ps.x2 - ps.x1, ps.y2 - ps.y1)
+            n_steps = max(1, int(math.ceil(seg_len / step)))
+            for i in range(n_steps + 1):
+                t = i / n_steps
+                px = ps.x1 + (ps.x2 - ps.x1) * t
+                py = ps.y1 + (ps.y2 - ps.y1) * t
+                if not (lo_x <= px <= hi_x and lo_y <= py <= hi_y):
+                    continue
+                if any(math.hypot(px - sx, py - sy) < step for sx, sy in sites):
+                    continue
+                sites.append((px, py))
+                if len(sites) >= max_sites:
+                    return sites
+        return sites
+
+    def _fallback_tail_route(
+        self,
+        head: Pad,
+        goal: Pad,
+        partner_segments: list[Segment] | None,
+        seg_clear: float,
+    ) -> Route | None:
+        """Partner-aware last-resort A* tail (issue #4460).
+
+        Order is deliberately conservative: the UNBIASED probe runs first and
+        is returned unchanged whenever it already keeps the intra-pair
+        clearance, so every tail that was acceptable before this change is
+        byte-identical.  Only a tail that fails that bound triggers the
+        guide-biased re-route, and only a tail that additionally fails the
+        PHYSICAL-overlap bound is discarded outright -- handing the decision
+        back to the caller's anchor-stepping retry instead of emitting copper
+        the self-check gate is guaranteed to reject.
+        """
+
+        def _probe(avoid: list[tuple[float, float]] | None, radius: int) -> Route | None:
+            r = self._single_ended_guide_route(
+                head,
+                goal,
+                per_net_timeout=10.0,
+                avoid_locations=avoid,
+                avoid_radius_cells=radius,
+            )
+            return r if (r is not None and r.segments) else None
+
+        plain = _probe(None, 1)
+        if not partner_segments:
+            return plain
+        if plain is not None and self._tail_partner_clear(plain, partner_segments, seg_clear):
+            return plain
+        biased: Route | None = None
+        sites = self._partner_boost_sites(head, goal, partner_segments, seg_clear)
+        if sites:
+            radius_cells = max(
+                1, int(round(seg_clear / max(self.autorouter.grid.resolution, 1e-9) / 3.0))
+            )
+            biased = _probe(sites, radius_cells)
+            if biased is not None and self._tail_partner_clear(biased, partner_segments, seg_clear):
+                return biased
+        # Neither reaches the coupled clearance: settle for any tail that at
+        # least does not physically overlap the guide (the self-check bound).
+        for cand in (plain, biased):
+            if cand is not None and self._tail_partner_clear(cand, partner_segments, 0.0):
+                return cand
+        return None
+
     def _tail_route(
         self,
         pathfinder: CoupledPathfinder,
@@ -3955,27 +4163,32 @@ class DiffPairRouter:
         in the grid) are rejected geometrically, and a two-via crossing
         tail is attempted before giving up -- the polarity-swap pairs'
         terminal crossover.
+
+        Issue #4460: the last-resort per-net A* fallback is now partner-AWARE
+        too.  The guide is not grid copper, so an unbiased A* tail routes
+        straight along (and through) it; every board-06 shadow ``self-check
+        overlap`` decline was such a tail.  The fallback is therefore
+        re-routed with the guide's neighbourhood cost-boosted and the result
+        is VALIDATED against the partner: a tail that physically overlaps the
+        guide is discarded rather than emitted, which lets the caller's
+        anchor-stepping loop retry from a deeper body anchor instead of
+        spending the attempt on copper the self-check will reject anyway.
         """
-        tail = self._synthesize_tail(pathfinder, head, goal, layer_idx)
-        if tail is not None and partner_segments:
-            seg_clear = self._pair_seg_clearance(pathfinder, head.net_name)
-            for seg in tail.segments:
-                if (
-                    self._min_distance_to_partner(
-                        seg.x1, seg.y1, seg.x2, seg.y2, partner_segments, seg.layer
-                    )
-                    < seg_clear
-                ):
-                    tail = None
-                    break
+        seg_clear = self._pair_seg_clearance(pathfinder, head.net_name) if partner_segments else 0.0
+        tail = self._synthesize_tail(
+            pathfinder,
+            head,
+            goal,
+            layer_idx,
+            partner_segments=partner_segments,
+            partner_clearance=seg_clear,
+        )
         if tail is None and partner_segments:
             tail = self._synthesize_crossing_tail(
                 pathfinder, head, goal, layer_idx, partner_segments
             )
         if tail is None:
-            tail = self._single_ended_guide_route(head, goal, per_net_timeout=10.0)
-            if tail is not None and not tail.segments:
-                tail = None
+            tail = self._fallback_tail_route(head, goal, partner_segments, seg_clear)
         if tail is None:
             print(
                 f"    [coupled-rescue] {label} tail unroutable for {pair_name} "
@@ -4464,6 +4677,68 @@ class DiffPairRouter:
                     continue
                 approaches.append(loc)
         return approaches
+
+    def _debug_shadow_overlap(
+        self,
+        pair_name: str,
+        side: float,
+        violation: IntraPairClearanceViolation,
+        shadow_route: Route,
+        guide: Route,
+        n_start_tail: int,
+        n_body: int,
+        n_end_tail: int,
+        swap_roles: bool,
+    ) -> None:
+        """Print provenance for a shadow self-check overlap (``KCT_SHADOW_DEBUG``)."""
+        shadow_seg = violation.p_segment if swap_roles else violation.n_segment
+        guide_seg = violation.n_segment if swap_roles else violation.p_segment
+
+        def _key(s):
+            return (round(s.x1, 6), round(s.y1, 6), round(s.x2, 6), round(s.y2, 6))
+
+        idx = -1
+        for k, s in enumerate(shadow_route.segments):
+            if _key(s) == _key(shadow_seg):
+                idx = k
+                break
+        if idx < 0:
+            part = "post-quantize(unmatched)"
+        elif idx < n_start_tail:
+            part = f"start-tail[{idx}/{n_start_tail}]"
+        elif idx < n_start_tail + n_body:
+            part = f"body[{idx - n_start_tail}/{n_body}]"
+        else:
+            part = f"end-tail[{idx - n_start_tail - n_body}/{n_end_tail}]"
+        gidx = -1
+        garc = 0.0
+        arc = 0.0
+        for k, s in enumerate(guide.segments):
+            if _key(s) == _key(guide_seg):
+                gidx = k
+                garc = arc
+            arc += math.hypot(s.x2 - s.x1, s.y2 - s.y1)
+        smid = ((shadow_seg.x1 + shadow_seg.x2) / 2, (shadow_seg.y1 + shadow_seg.y2) / 2)
+        # Nearest guide segment (by arc) to the shadow midpoint, to tell an
+        # ADJACENT pinch (the offset's own guide segment) from a NON-ADJACENT
+        # collision (a distant leg of the same guide).
+        best = (float("inf"), -1, 0.0)
+        arc = 0.0
+        for k, s in enumerate(guide.segments):
+            if s.layer == shadow_seg.layer:
+                dd = self._point_segment_distance(smid[0], smid[1], s)
+                if dd < best[0]:
+                    best = (dd, k, arc)
+            arc += math.hypot(s.x2 - s.x1, s.y2 - s.y1)
+        print(
+            f"    [shadow-debug] {pair_name} side={side:+.0f} "
+            f"worst={violation.actual_clearance_mm:+.3f}mm part={part} "
+            f"shadow_seg=({shadow_seg.x1:.3f},{shadow_seg.y1:.3f})->"
+            f"({shadow_seg.x2:.3f},{shadow_seg.y2:.3f}) L={shadow_seg.layer.value} "
+            f"w={shadow_seg.width:.3f} | guide_seg_idx={gidx}/{len(guide.segments)} "
+            f"arc={garc:.2f} | nearest_guide_idx={best[1]} nearest_arc={best[2]:.2f} "
+            f"nearest_d={best[0]:.3f}"
+        )
 
     def _shadow_route_pair(
         self,
@@ -5018,6 +5293,18 @@ class DiffPairRouter:
                     f"other side"
                 )
                 self._last_shadow_decline_reason = "overlap"  # #4459
+                if _SHADOW_DEBUG:
+                    self._debug_shadow_overlap(
+                        pair.name,
+                        side,
+                        violation,
+                        shadow_route,
+                        guide,
+                        len(start_tail.segments),
+                        len([e for e in kept if e[0] == "seg"]),
+                        len(end_tail.segments),
+                        swap_roles,
+                    )
                 # Issue #4460 (approach 2): record WHERE the offset overlapped
                 # the guide so a guide re-route can be biased away from it.  The
                 # midpoint of the two offending segments localises the pinch;

--- a/tests/test_diffpair_shadow.py
+++ b/tests/test_diffpair_shadow.py
@@ -1701,3 +1701,250 @@ def test_shadow_select_gap_degrades_to_nominal_when_no_rung_feasible():
         "no feasible rung must degrade to the nominal gap (ladder head), not "
         "silently ship a blocked offset -- the downstream self-check gates apply"
     )
+
+
+# ---------------------------------------------------------------------------
+# 10. partner-aware rescue tails (issue #4460, approach 2)
+# ---------------------------------------------------------------------------
+#
+# The shadow constructor's rescue tails connect the trimmed offset body to the
+# real pads.  The partner (guide) is NOT in the routing grid during shadow
+# construction, so an obstacle-only screen cannot see it.  Measured on board 06
+# BEFORE this change: every shadow ``self-check overlap`` decline traced to a
+# tail drawn on top of the guide (centre-to-centre 0.018-0.035 mm).  These
+# tests pin the two mechanisms that fixed it -- partner clearance as a
+# CANDIDATE FILTER inside ``_synthesize_tail`` (rather than a post-hoc veto on
+# the single winner) and the ``_tail_partner_clear`` two-tier screen the A*
+# fallback is validated against.
+
+
+class _AllClearPathfinder:
+    """Pathfinder stand-in: fixed trace width, nothing obstacle-blocked.
+
+    Isolates the tail synthesizer's CANDIDATE SELECTION from grid state, so a
+    rejected candidate can only have been rejected by the partner screen.
+    """
+
+    def __init__(self, width: float = 0.2) -> None:
+        self._width = width
+
+    def _get_trace_width_for_net(self, net_name: str) -> float:
+        return self._width
+
+    def _is_cell_blocked(self, gx: int, gy: int, layer_idx: int, net: int) -> bool:
+        return False
+
+
+def _tail_pads(head_xy, goal_xy):
+    from kicad_tools.router.primitives import Pad
+
+    head = Pad(
+        x=head_xy[0],
+        y=head_xy[1],
+        width=0.3,
+        height=0.3,
+        net=2,
+        net_name="USB3_TX1-",
+        layer=Layer.F_CU,
+    )
+    goal = Pad(
+        x=goal_xy[0],
+        y=goal_xy[1],
+        width=0.3,
+        height=0.3,
+        net=2,
+        net_name="USB3_TX1-",
+        layer=Layer.F_CU,
+    )
+    return head, goal
+
+
+def _crossing_partner() -> list[Segment]:
+    """A guide leg that crosses the straight head->goal corridor mid-way."""
+    return [_gseg(6.5, 4.5, 6.5, 5.5)]
+
+
+def test_synthesize_tail_without_partner_takes_the_direct_candidate():
+    """Baseline: with no partner supplied the first clear candidate wins."""
+    dpr = _diffpair_router()
+    head, goal = _tail_pads((5.0, 5.0), (8.0, 5.0))
+    tail = dpr._synthesize_tail(_AllClearPathfinder(), head, goal, 0)
+    assert tail is not None
+    assert len(tail.segments) == 1
+    seg = tail.segments[0]
+    assert (seg.x1, seg.y1, seg.x2, seg.y2) == (5.0, 5.0, 8.0, 5.0)
+
+
+def test_synthesize_tail_detours_around_partner_instead_of_giving_up():
+    """A partner across the direct corridor selects a later detour candidate.
+
+    Before #4460 the partner screen ran only on the winning candidate, so this
+    geometry produced ``None`` and the caller fell through to a partner-blind
+    A* tail.  The 20+ U-detour candidates were never consulted.
+    """
+    dpr = _diffpair_router()
+    head, goal = _tail_pads((5.0, 5.0), (8.0, 5.0))
+    partner = _crossing_partner()
+    clearance = 0.5
+    tail = dpr._synthesize_tail(
+        _AllClearPathfinder(),
+        head,
+        goal,
+        0,
+        partner_segments=partner,
+        partner_clearance=clearance,
+    )
+    assert tail is not None, "a legal detour exists; the synthesizer must find it"
+    assert len(tail.segments) > 1, "the direct candidate crosses the partner"
+    for seg in tail.segments:
+        assert (
+            dpr._min_distance_to_partner(seg.x1, seg.y1, seg.x2, seg.y2, partner, seg.layer)
+            >= clearance - 1e-9
+        )
+    # Endpoints are still exactly head -> goal (the tail must land on the pad).
+    assert (tail.segments[0].x1, tail.segments[0].y1) == (5.0, 5.0)
+    assert (tail.segments[-1].x2, tail.segments[-1].y2) == (8.0, 5.0)
+
+
+def test_synthesize_tail_returns_none_when_no_candidate_clears_partner():
+    """An unreachable clearance still declines -- the caller then re-anchors."""
+    dpr = _diffpair_router()
+    head, goal = _tail_pads((5.0, 5.0), (8.0, 5.0))
+    partner = _crossing_partner()
+    tail = dpr._synthesize_tail(
+        _AllClearPathfinder(),
+        head,
+        goal,
+        0,
+        partner_segments=partner,
+        partner_clearance=50.0,
+    )
+    assert tail is None
+
+
+def _tail_with(y: float, width: float = 0.2) -> Route:
+    route = Route(net=2, net_name="USB3_TX1-")
+    route.segments.append(
+        Segment(x1=5.0, y1=y, x2=8.0, y2=y, width=width, layer=Layer.F_CU, net=2, net_name="N")
+    )
+    return route
+
+
+def test_tail_partner_clear_physical_tier_rejects_touching_copper():
+    """Tier B (``clearance <= 0``) is the copper-edge bound the gates enforce."""
+    dpr = _diffpair_router()
+    partner = [_gseg(4.0, 5.15, 9.0, 5.15)]  # both widths 0.2 -> edges meet at 0.2
+    assert dpr._tail_partner_clear(_tail_with(5.0), partner, 0.0) is False
+    assert dpr._tail_partner_clear(_tail_with(5.4), partner, 0.0) is True
+
+
+def test_tail_partner_clear_strict_tier_demands_intra_pair_clearance():
+    """Tier A additionally demands the coupled centre-to-centre spacing."""
+    dpr = _diffpair_router()
+    partner = [_gseg(4.0, 5.25, 9.0, 5.25)]
+    assert dpr._tail_partner_clear(_tail_with(5.0), partner, 0.0) is True
+    assert dpr._tail_partner_clear(_tail_with(5.0), partner, 0.4) is False
+    assert dpr._tail_partner_clear(_tail_with(5.0), partner, 0.2) is True
+
+
+def test_tail_partner_clear_ignores_partner_on_another_layer():
+    """Segments on different layers cannot short -- not a tail violation."""
+    dpr = _diffpair_router()
+    partner = [_gseg(4.0, 5.0, 9.0, 5.0, layer=Layer.B_CU)]
+    assert dpr._tail_partner_clear(_tail_with(5.0), partner, 0.4) is True
+
+
+def test_tail_partner_clear_catches_via_barrel_over_partner():
+    """A tail VIA spans every layer, so it must clear partner copper anywhere."""
+    dpr = _diffpair_router()
+    tail = Route(net=2, net_name="USB3_TX1-")
+    tail.vias.append(
+        Via(x=6.0, y=5.0, drill=0.3, diameter=0.6, layers=(Layer.F_CU, Layer.B_CU), net=2)
+    )
+    partner = [_gseg(4.0, 5.0, 9.0, 5.0, layer=Layer.B_CU)]
+    assert dpr._tail_partner_clear(tail, partner, 0.0) is False
+    far = [_gseg(4.0, 7.0, 9.0, 7.0, layer=Layer.B_CU)]
+    assert dpr._tail_partner_clear(tail, far, 0.0) is True
+
+
+def test_partner_boost_sites_are_local_spaced_and_bounded():
+    """Boost sites cover only the tail corridor, tiled at the clearance pitch."""
+    dpr = _diffpair_router()
+    head, goal = _tail_pads((5.0, 5.0), (8.0, 5.0))
+    partner = [_gseg(0.0, 5.3, 20.0, 5.3)]
+    seg_clear = 0.4
+    sites = dpr._partner_boost_sites(head, goal, partner, seg_clear)
+    assert sites, "partner copper runs through the corridor -> sites expected"
+    pad = 2.0 * seg_clear + 0.5
+    for sx, sy in sites:
+        assert 5.0 - pad <= sx <= 8.0 + pad
+        assert 5.0 - pad <= sy <= 8.0 + pad
+    for i, (ax, ay) in enumerate(sites):
+        for bx, by in sites[i + 1 :]:
+            assert math.hypot(ax - bx, ay - by) >= seg_clear - 1e-9
+    assert len(sites) <= 40
+
+
+def test_partner_boost_sites_empty_without_partner():
+    dpr = _diffpair_router()
+    head, goal = _tail_pads((5.0, 5.0), (8.0, 5.0))
+    assert dpr._partner_boost_sites(head, goal, [], 0.4) == []
+    assert dpr._partner_boost_sites(head, goal, [_gseg(0.0, 5.3, 20.0, 5.3)], 0.0) == []
+
+
+def _stub_probe(dpr, result):
+    """Replace the per-net guide probe, recording how it was called."""
+    calls: list[tuple] = []
+
+    def fake(start, end, per_net_timeout=None, avoid_locations=None, avoid_radius_cells=1):
+        calls.append((per_net_timeout, avoid_locations, avoid_radius_cells))
+        return result
+
+    dpr._single_ended_guide_route = fake  # type: ignore[method-assign]
+    return calls
+
+
+def test_fallback_tail_route_without_partner_is_the_plain_probe():
+    """Flag-OFF inertness guard: no partner -> the pre-#4460 call, verbatim.
+
+    ``partner_segments`` is supplied ONLY by the shadow constructor, so with
+    ``enable_shadow_construction`` off this is the whole of the fallback path.
+    It must issue exactly one unbiased probe and return its result untouched.
+    """
+    dpr = _diffpair_router()
+    probe_route = Route(net=2, net_name="USB3_TX1-")
+    probe_route.segments.append(_gseg(5.0, 5.0, 8.0, 5.0))
+    calls = _stub_probe(dpr, probe_route)
+    head, goal = _tail_pads((5.0, 5.0), (8.0, 5.0))
+    assert dpr._fallback_tail_route(head, goal, None, 0.0) is probe_route
+    assert calls == [(10.0, None, 1)]
+
+
+def test_fallback_tail_route_keeps_a_partner_clean_probe_unchanged():
+    """A tail that already holds the coupled clearance is returned as-is."""
+    dpr = _diffpair_router()
+    probe_route = Route(net=2, net_name="USB3_TX1-")
+    probe_route.segments.append(_gseg(5.0, 5.0, 8.0, 5.0))
+    calls = _stub_probe(dpr, probe_route)
+    head, goal = _tail_pads((5.0, 5.0), (8.0, 5.0))
+    partner = [_gseg(4.0, 6.0, 9.0, 6.0)]
+    assert dpr._fallback_tail_route(head, goal, partner, 0.4) is probe_route
+    assert len(calls) == 1, "a clean probe must not trigger the biased re-route"
+
+
+def test_fallback_tail_route_discards_a_tail_drawn_on_the_partner():
+    """The measured board-06 failure: an A* tail on top of the guide.
+
+    Before #4460 this copper was emitted and the whole shadow side was then
+    declined by the self-check.  Now it is discarded, so the constructor's
+    anchor-stepping loop gets to retry from a deeper body anchor.
+    """
+    dpr = _diffpair_router()
+    probe_route = Route(net=2, net_name="USB3_TX1-")
+    probe_route.segments.append(_gseg(5.0, 5.0, 8.0, 5.0))
+    calls = _stub_probe(dpr, probe_route)
+    head, goal = _tail_pads((5.0, 5.0), (8.0, 5.0))
+    partner = [_gseg(4.0, 5.02, 9.0, 5.02)]  # centre-to-centre 0.02mm
+    assert dpr._fallback_tail_route(head, goal, partner, 0.4) is None
+    assert len(calls) == 2, "an overlapping probe must trigger the biased re-route"
+    assert calls[1][1], "the retry must carry partner boost sites"


### PR DESCRIPTION
## Summary

Phase 2 of the diffpair coupled-router epic (#4409), continuing from PR #4512.

The issue asked for **approach 2 (shadow-aware guide re-routing)** and expected the blocker to be non-adjacent guide self-approaches. Instrumenting the actual declines (`KCT_SHADOW_DEBUG=1`, added here) showed the blocker was somewhere else entirely: **every one of board 06's 13 shadow `self-check overlap` declines came from a RESCUE TAIL, not from the parallel-offset body.**

The partner (guide) side is not in the routing grid during shadow construction, so nothing stopped a tail from being drawn straight along — or through — the guide. Measured centre-to-centre distances of the offending tails: **0.018–0.035 mm**, i.e. copper on copper. That copper then failed the constructor's own self-check and cost the whole offset side.

Making the tails partner-aware takes board-06 shadow construction from **4/9 to 6/9**, converting exactly the pairs the issue named as the target population (USB3_TX1, USB3_TX2).

## Changes

`src/kicad_tools/router/diffpair_routing.py`

- **`_synthesize_tail` takes the partner clearance as a CANDIDATE FILTER** instead of the caller vetoing the single winner after the fact. The synthesizer offers 27 candidates (direct, two doglegs, 24 U-detours); screening only the first obstacle-clear one threw away the entire detour repertoire whenever that one candidate happened to hug the guide — and the caller then fell through to the partner-blind A* fallback. A one-shot AABB/layer prefilter keeps this cheap against 900-segment guides.
- **`_fallback_tail_route`** — the last-resort per-net A* tail is now validated against the partner and, on failure, retried with the guide's neighbourhood cost-boosted (reusing #4512's `avoid_locations` machinery via the new `_partner_boost_sites`). Ordering is deliberately conservative: the **unbiased probe runs first and is returned untouched whenever it already holds the clearance**, so any tail that was acceptable before is unchanged.
- **`_tail_partner_clear`** — two-tier screen: the intra-pair clearance bound (properly-coupled tail), then the physical-overlap bound the self-check actually enforces. A tail failing *both* is discarded, so the constructor's existing anchor-stepping loop retries from a deeper body anchor instead of spending the attempt on copper that is certain to be rejected. (That retry loop already existed; it was dead code because the partner-blind fallback always "succeeded".)
- **`_segments_within`** — module-level AABB pre-filter for the sampled distance checks.
- **`KCT_SHADOW_DEBUG=1`** — opt-in per-decline provenance line (which part of the assembled shadow produced the offending segment, and where it sits relative to the guide). This is the instrumentation the diagnosis above rests on; it is how a Phase-3/4 builder can re-derive the taxonomy.

`tests/test_diffpair_shadow.py` — 12 new unit tests (see Test Plan).

## Acceptance Criteria Verification

- [x] **Board-06 shadow-ON construction rises from 4/9 to ≥6/9.** Measured **6/9** (see table below), reproduced on two independent runs of the final code. USB3_TX1 and USB3_TX2 crossed over — the pairs the issue named as the target population.
- [x] **The technique is generic.** Nothing is keyed to board 06, a net name, or a pair count: the mechanism is "the partner is not in the grid, therefore screen it geometrically and let the existing detour/anchor-stepping repertoire do its job." Any pair whose rescue tail would otherwise be drawn on its partner benefits.
- [x] **`enable_shadow_construction` default stays OFF; routing unchanged when off.** Every new code path is reached only when `partner_segments` is supplied, and the only caller that supplies it is `_shadow_route_pair`. With the flag off, `_tail_route` computes `seg_clear = 0.0`, `_synthesize_tail`'s partner filter is inert, and `_fallback_tail_route` reduces to the exact pre-existing `_single_ended_guide_route(head, goal, per_net_timeout=10.0)` call. Pinned by `test_fallback_tail_route_without_partner_is_the_plain_probe`.
- [x] **No regression in the 4 currently-constructing pairs.** MIPI_CLK, MIPI_D0, PCIE_RX, USB2_D all still construct. (PCIE_RX now constructs on the un-swapped side rather than the swapped one — still `coupled-ok`.)

### Board-06 measurement

`KCT_BOARD06_SHADOW=1 uv run python boards/06-diffpair-test/generate_design.py --step route --seed 42`

| Pair | before (main @ `ca83bab`) | after | note |
|---|---|---|---|
| MIPI_CLK | coupled-ok (shadow) | coupled-ok (shadow) | strands on commit (#3540, Phase 4) |
| MIPI_D0 | coupled-ok (shadow-swapped) | coupled-ok (shadow-swapped) | |
| PCIE_RX | coupled-ok (shadow-swapped) | coupled-ok (shadow) | |
| PCIE_TX | shadow-declined-overlap | shadow-declined-overlap | now a BODY overlap + via gate, not a tail |
| USB2_D | coupled-ok (shadow-swapped) | coupled-ok (shadow-swapped) | |
| USB3_RX1 | shadow-declined-blockage | shadow-declined-overlap | via-aware overlap (#3541 territory) |
| USB3_RX2 | shadow-declined-blockage | shadow-declined-blockage | mid-route blockage, deferred by the issue |
| **USB3_TX1** | shadow-declined-overlap | **coupled-ok (shadow)** | **target** |
| **USB3_TX2** | shadow-declined-overlap | **coupled-ok (shadow)** | **target** |
| | **4/9** | **6/9** | |

The remaining `self-check overlap` declines are now **body**-offset segments (PCIE_TX −0.200/−0.139 mm, USB2_D −0.003 mm), not tails — the tail class is eliminated.

## Notes on the "byte-identical committed artifact" check

The scope guard asked for the committed board artifact to be byte-identical with the flag off. **That check is not decidable on board 06 as it stands** — the flag-OFF `--step route --seed 42` pipeline is not run-to-run reproducible on *unmodified* `main`. Measured on this worktree at `ca83bab` with no source changes:

- run A: 1862 segments · run B: 1854 segments · **9525 differing lines** between two identical-code runs
- my change vs. run A: 8160 differing lines — *fewer* than main differs from itself
- both differ from the committed artifact (which predates today's router merges)

So byte comparison cannot discriminate this change; the artifact is wall-clock-budget dependent (negotiated routing, stall detection, rip-up timers) and every `(uuid …)` is regenerated per run. The flag-OFF inertness claim is therefore established **structurally** (single gated entry point, argued above) and **by unit test**, not by artifact diff. Worth a follow-up issue if deterministic board artifacts are wanted as a gate.

## Test Plan

- [x] 12 new unit tests in `tests/test_diffpair_shadow.py`:
  - `_synthesize_tail`: direct candidate without a partner; detour selected when the direct corridor is crossed; `None` when no candidate clears.
  - `_tail_partner_clear`: physical tier, strict tier, cross-layer exemption, via-barrel-over-partner.
  - `_partner_boost_sites`: locality, spacing, bound, empty cases.
  - `_fallback_tail_route`: flag-OFF inertness (exactly one unbiased probe, result verbatim), clean probe kept unchanged, partner-overlapping probe discarded after a biased retry.
- [x] `tests/test_diffpair_shadow.py` + `test_diffpair_self_intersection.py` + `test_diffpair_corridor.py` + `test_diffpair_coupled_instrumentation_4459.py`: **102 passed** (was 90 on main).
- [x] Wider blast-radius subset `-k "diffpair or coupled or shadow or tail"`: **884 passed, 6 skipped**.
- [x] Router-wide subset `-k "router or route"`: **4170 passed, 37 skipped** (35m35s).
- [x] Board-06 shadow-ON run reproduced twice on the final code: 6/9 both times, identical per-pair taxonomy.
- [x] `uv run kct build-native` before every measurement (C++ backend active).
- [x] `uv run ruff format . --check` and `uv run ruff check .` clean.

## Scope guards honored

- Does **not** flip `enable_shadow_construction` (Phase 5, #4463).
- Does **not** touch the 45-census / off-angle cleanup (Phase 3, #4461) or skew closure (Phase 4, #4462).
- Does **not** re-implement approach 1 (per-vertex miter, #4490).
- MIPI_CLK / USB3_TX1 strand-on-commit (`connected_pads=1/2`, #3540 rollback) is observed and left alone — that is the Phase-4 `_tail_route` landing-connectivity item the issue explicitly says to note but not fix.

## Deferred (honest)

`#4460` stays open only if the epic wants more than 6/9. The three still-declining pairs are each blocked by a subsystem the issue itself deferred:

- **PCIE_TX**, **USB3_RX1** — the via-aware physical-overlap gate / "no legal shadow-via site" (#3541 territory).
- **USB3_RX2** — mid-route obstacle blockage of the offset body.

Neither is a tail problem, and neither is reachable from approach 2.

Part of #4460

🤖 Generated with [Claude Code](https://claude.com/claude-code)
