### PR TITLE
Root lattice/mesh stars at the Kelvin shunt pad and wire board-05 to batch completion

### DIFF
--- a/boards/05-bldc-motor-controller/design.py
+++ b/boards/05-bldc-motor-controller/design.py
@@ -27,6 +27,7 @@ If no output directory is specified, files are written to ./output/
 import subprocess
 import sys
 import uuid
+from dataclasses import replace
 from pathlib import Path
 
 from kicad_tools.core.project_file import create_minimal_project, save_project
@@ -3182,20 +3183,37 @@ def rescue_partial_nets(routed_path: Path) -> dict[str, bool]:
     return shared_rescue_partial_nets(routed_path, _RESCUE_CONFIG)
 
 
-# Wall budget for ONE batch-completion pass (Issue #4476).  The board-05 CI
-# job (``board-05-routing-regression``) has a 90-minute ceiling and a fresh
-# regen already spends ~45-55 min on the main pass + the per-net rescue loop,
-# so the completion phase is capped at ``_COMPLETION_MAX_PASSES *
-# _COMPLETION_PASS_TIMEOUT_S`` (2 x 360 s = 12 min) of routing plus its
-# checker overhead.  Two passes are enough to see whether the batch is
-# productive at all: ``complete_unfinished_nets`` stops early on convergence
-# AND on the first no-progress pass (restoring the pre-pass board
-# byte-for-byte), so the worst case is only paid when passes keep closing
-# nets.  Per #3880/#3894 this phase, like the rest of board 05, deliberately
-# stays on the wall-clock cutoff -- ``_RESCUE_CONFIG`` sets no
-# ``deterministic_budget``.
-_COMPLETION_MAX_PASSES = 2
-_COMPLETION_PASS_TIMEOUT_S = 360
+# Batch-completion budget (Issue #4476).  The board-05 CI job
+# (``board-05-routing-regression``) has a 90-minute ceiling and a fresh regen
+# already spends ~30-40 min on the main pass, so the completion phase runs
+# exactly ONE pass.
+#
+# What actually bounds a ``--complete`` pass is NOT ``--timeout`` (the grid
+# engine's whole-route wall budget, kept below only as a backstop): it is the
+# lattice engine's per-link deadline, which ``route_cmd._resolve_complete_
+# link_budget`` derives from ``--per-net-timeout`` as
+# ``per_net_timeout * link_count`` (issues #4472/#4501).  Board-05's stranded
+# cohort is ~8 nets / ~18 links, so at ``_RESCUE_CONFIG.per_net_timeout_s``
+# (60 s) the negotiation aborts after at most ~18 min, plus a few minutes of
+# board load / emit / zone fill.  ONE pass therefore costs <= ~25 min, which
+# fits the job's remaining headroom; a second pass would not.  Measured
+# 2026-07-31 on a fresh host regen: one pass took the board from 11 -> 6
+# blocking nets, closing ISENSE_A+, ISENSE_B+, PWM_BH, PWM_CH and PWM_CL.
+#
+# Per #3880/#3894 this phase, like the rest of board 05, deliberately stays on
+# the wall-clock cutoff -- ``_RESCUE_CONFIG`` sets no ``deterministic_budget``.
+# Do NOT raise the pass count without a CI-measured wall-clock.
+_COMPLETION_MAX_PASSES = 1
+_COMPLETION_PASS_TIMEOUT_S = 900
+
+# Completion-pass knobs: board-05's rescue config verbatim (manufacturer, seed,
+# per-net cutoff, layer stack, micro-via-in-pad fallback -- all unchanged) plus
+# ``--skip-drc``.  The completion subprocess's own post-route DRC is pure
+# overhead here: it re-validates a board that design.py goes on to repair
+# (step 7a, #4470) and re-check (step 9) anyway, and on this board that
+# validation costs minutes of the CI budget.  Skipping it changes no emitted
+# copper -- ``kct route`` writes the routed PCB before the DRC step.
+_COMPLETION_CONFIG = replace(_RESCUE_CONFIG, extra_args=("--skip-drc",))
 
 
 def complete_unfinished_nets(routed_path: Path) -> CompletionResult:
@@ -3203,7 +3221,8 @@ def complete_unfinished_nets(routed_path: Path) -> CompletionResult:
 
     Thin wrapper over the shared
     :func:`kicad_tools.router.partial_rescue.complete_unfinished_nets`,
-    invoked with this board's knobs (:data:`_RESCUE_CONFIG`, unchanged).
+    invoked with this board's knobs (:data:`_COMPLETION_CONFIG` -- the rescue
+    config verbatim plus ``--skip-drc``).
 
     Why this runs AFTER :func:`rescue_partial_nets` (issue #4476):
 
@@ -3236,7 +3255,7 @@ def complete_unfinished_nets(routed_path: Path) -> CompletionResult:
     """
     return shared_complete_unfinished_nets(
         routed_path,
-        _RESCUE_CONFIG,
+        _COMPLETION_CONFIG,
         max_passes=_COMPLETION_MAX_PASSES,
         pass_timeout_s=_COMPLETION_PASS_TIMEOUT_S,
     )

--- a/boards/05-bldc-motor-controller/design.py
+++ b/boards/05-bldc-motor-controller/design.py
@@ -33,7 +33,10 @@ from kicad_tools.core.project_file import create_minimal_project, save_project
 from kicad_tools.dev import warn_if_stale
 from kicad_tools.pcb.center_sheet import centered_origin
 from kicad_tools.recipes.gate import evaluate_pipeline_gate
-from kicad_tools.router.partial_rescue import RescueConfig
+from kicad_tools.router.partial_rescue import CompletionResult, RescueConfig
+from kicad_tools.router.partial_rescue import (
+    complete_unfinished_nets as shared_complete_unfinished_nets,
+)
 from kicad_tools.router.partial_rescue import rescue_partial_nets as shared_rescue_partial_nets
 from kicad_tools.schematic.blocks import (
     CurrentSenseShunt,
@@ -3179,6 +3182,66 @@ def rescue_partial_nets(routed_path: Path) -> dict[str, bool]:
     return shared_rescue_partial_nets(routed_path, _RESCUE_CONFIG)
 
 
+# Wall budget for ONE batch-completion pass (Issue #4476).  The board-05 CI
+# job (``board-05-routing-regression``) has a 90-minute ceiling and a fresh
+# regen already spends ~45-55 min on the main pass + the per-net rescue loop,
+# so the completion phase is capped at ``_COMPLETION_MAX_PASSES *
+# _COMPLETION_PASS_TIMEOUT_S`` (2 x 360 s = 12 min) of routing plus its
+# checker overhead.  Two passes are enough to see whether the batch is
+# productive at all: ``complete_unfinished_nets`` stops early on convergence
+# AND on the first no-progress pass (restoring the pre-pass board
+# byte-for-byte), so the worst case is only paid when passes keep closing
+# nets.  Per #3880/#3894 this phase, like the rest of board 05, deliberately
+# stays on the wall-clock cutoff -- ``_RESCUE_CONFIG`` sets no
+# ``deterministic_budget``.
+_COMPLETION_MAX_PASSES = 2
+_COMPLETION_PASS_TIMEOUT_S = 360
+
+
+def complete_unfinished_nets(routed_path: Path) -> CompletionResult:
+    """Batch-complete the nets the solo rescue loop could not close (#4476).
+
+    Thin wrapper over the shared
+    :func:`kicad_tools.router.partial_rescue.complete_unfinished_nets`,
+    invoked with this board's knobs (:data:`_RESCUE_CONFIG`, unchanged).
+
+    Why this runs AFTER :func:`rescue_partial_nets` (issue #4476):
+
+    The solo rescue reroutes each residual net ALONE against every other
+    net's PRESERVED (immutable) copper.  In board-05's saturated U3 south
+    sense band that is exactly the wrong shape -- the relief machinery
+    correctly reports "blocked only by non-rippable copper" and rolls back,
+    so a fresh regen logs ``Rescue ISENSE_A+: FAILED (no output produced)``
+    for the whole stranded cohort (ISENSE_A+/A-/B+/B-/C-, PWM_BH, PWM_CH).
+    The batch pass instead routes the WHOLE unfinished cohort together via
+    ``kct route --complete``, so those nets can still negotiate with each
+    other while the finished nets stay protected -- and ``--complete`` drives
+    the LATTICE engine, which (unlike the grid A*) can thread a walled SMD
+    pocket and place a last-resort via-in-pad.  Since #4476 that engine also
+    roots a Kelvin sense net's star at the shunt pad
+    (:func:`kicad_tools.router.core._star_topology_pads`), so the five ISENSE
+    nets keep the Kelvin topology through completion instead of getting an
+    arbitrary ``pads[0]`` hub.
+
+    Safety is inherited from the shared function, not re-implemented here: a
+    byte-for-byte pre-pass backup is restored whenever a pass fails to reduce
+    the unfinished-net count (so a failed completion never leaves stranded
+    stub copper and never makes the board worse), and each pass strips the
+    target nets' stale copper before routing.
+
+    Returns the :class:`~kicad_tools.router.partial_rescue.CompletionResult`:
+    ``.history`` is the ``(before, after)`` unfinished-count progression and
+    ``.unroutable_links`` names the still-open links with a concrete reason
+    (``blocking_copper``) instead of the solo loop's opaque "no output".
+    """
+    return shared_complete_unfinished_nets(
+        routed_path,
+        _RESCUE_CONFIG,
+        max_passes=_COMPLETION_MAX_PASSES,
+        pass_timeout_s=_COMPLETION_PASS_TIMEOUT_S,
+    )
+
+
 def emit_phase1_diagnostics(routed_path: Path) -> None:
     """Print the board-05 Phase-1 ground-truth diagnostics (issue #4469).
 
@@ -3644,6 +3707,31 @@ def main() -> int:
                 # Every residual net rescued -- the board is fully routed
                 # even though step 6's exit code reported partial.
                 route_success = True
+
+            # Step 6b-batch: whatever the SOLO rescue could not close is
+            # handed to the batch completion pass (Issue #4476).  A net
+            # rerouted alone against the U3 south band's immutable copper is
+            # "blocked only by non-rippable copper" and rolls back; routing
+            # the whole unfinished cohort together via ``kct route --complete``
+            # (lattice engine, Kelvin-rooted since #4476) keeps negotiation
+            # alive among exactly those nets.  Safe to layer on top of the
+            # solo loop: a pass that does not reduce the unfinished count
+            # restores the pre-pass board byte-for-byte, so this can only
+            # improve reach -- never strand copper.  See
+            # complete_unfinished_nets().
+            completion = complete_unfinished_nets(routed_path)
+            if completion.history and completion.history[-1][1] == 0:
+                # The batch pass closed every remaining unfinished net.
+                route_success = True
+            if completion.unroutable_links:
+                print("\n   Links still unroutable after batch completion:")
+                for link in completion.unroutable_links:
+                    detail = f" [{link.reason}]" if link.reason else ""
+                    if link.blocking_copper:
+                        detail += f" blocked by {', '.join(link.blocking_copper)}"
+                    if link.nearest_blocker_mm is not None:
+                        detail += f" (nearest {link.nearest_blocker_mm:.3f} mm)"
+                    print(f"     {link.net}: {link.start} -> {link.end}{detail}")
 
             # Step 6b-diagnostics: board-05 Phase-1 ground-truth instrumentation
             # (Issue #4469).  Prints the grid-fidelity report + per-net stranding

--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -404,6 +404,13 @@ def run_route_command(args) -> int:
     # and tests/test_cli_parser_drift.py stays green.
     if getattr(args, "complete", False):
         sub_argv.append("--complete")
+    # Issue #4476: forward --complete-exclude-nets (pour/plane nets --complete
+    # must not route -- their connectivity comes from a filled zone the trace
+    # checker cannot credit).  Declared on BOTH parsers with an empty-string
+    # default, so an unset flag forwards nothing and the argv stays
+    # byte-identical (tests/test_cli_parser_drift.py).
+    if getattr(args, "complete_exclude_nets", ""):
+        sub_argv.extend(["--complete-exclude-nets", args.complete_exclude_nets])
     # Issue #4477 (epic #4465, Phase 4): forward --complete-report (the
     # structured unroutable-link report path).  Both parsers declare it; see
     # tests/test_cli_parser_drift.py.

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -3127,6 +3127,21 @@ def _add_route_parser(subparsers) -> None:
         ),
     )
     route_parser.add_argument(
+        "--complete-exclude-nets",
+        metavar="NAMES",
+        default="",
+        help=(
+            "Issue #4476: comma-separated net names --complete must NOT "
+            "route, even when the connectivity checker reports them "
+            "unconnected. Intended for pour/plane-carried nets (GND, +3V3, "
+            "board-05's PHASE_A/B/C): their connectivity comes from a filled "
+            "zone, which trace connectivity does not credit, so without this "
+            "--complete would lay traces on nets the recipe deliberately "
+            "skips. Empty (the default) preserves the auto-detected set "
+            "exactly. Ignored without --complete."
+        ),
+    )
+    route_parser.add_argument(
         "--complete-report",
         metavar="PATH",
         help=(

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -8841,10 +8841,21 @@ def _resolve_complete_nets(args, pcb_path: Path) -> int:
     from kicad_tools.router.partial_rescue import partially_connected_signal_nets
 
     manufacturer = getattr(args, "manufacturer", "jlcpcb") or "jlcpcb"
+    # Issue #4476: pour/plane-carried nets are "unconnected" to a TRACE
+    # connectivity checker by construction (their continuity comes from a
+    # filled zone), so without an exclusion list --complete lays traces on
+    # exactly the nets a recipe deliberately routes as copper pours.  Empty by
+    # default -- the auto-detected set is unchanged for every existing caller.
+    excluded = frozenset(
+        n.strip()
+        for n in (getattr(args, "complete_exclude_nets", "") or "").split(",")
+        if n.strip()
+    )
     try:
         stranded = partially_connected_signal_nets(
             pcb_path,
             manufacturer=manufacturer,
+            excluded_nets=excluded,
             include_unrouted=True,
         )
     except Exception as e:  # pragma: no cover - detection should not raise
@@ -8864,6 +8875,10 @@ def _resolve_complete_nets(args, pcb_path: Path) -> int:
     if not getattr(args, "quiet", False):
         preview = ", ".join(stranded)
         print(f"--complete: routing {len(stranded)} unconnected signal net(s): {preview}")
+        if excluded:
+            print(
+                f"--complete: excluding {len(excluded)} pour/plane net(s): {', '.join(sorted(excluded))}"
+            )
     return 0
 
 
@@ -9622,6 +9637,21 @@ def main(argv: list[str] | None = None) -> int:
             "#4413 copper-loss guard is active). Mutually exclusive with "
             "--nets / --skip-nets. A board with nothing left to connect is a "
             "safe no-op."
+        ),
+    )
+    parser.add_argument(
+        "--complete-exclude-nets",
+        metavar="NAMES",
+        default="",
+        help=(
+            "Issue #4476: comma-separated net names --complete must NOT "
+            "route, even when the connectivity checker reports them "
+            "unconnected. Intended for pour/plane-carried nets (GND, +3V3, "
+            "board-05's PHASE_A/B/C): their connectivity comes from a filled "
+            "zone, which trace connectivity does not credit, so without this "
+            "--complete would lay traces on nets the recipe deliberately "
+            "skips. Empty (the default) preserves the auto-detected set "
+            "exactly. Ignored without --complete."
         ),
     )
     parser.add_argument(

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -77,6 +77,7 @@ from .failure_analysis import (
     RootCauseAnalyzer,
 )
 from .grid import RoutingGrid
+from .kelvin import detect_kelvin_topology
 from .layers import Layer, LayerStack
 from .length import LengthTracker, LengthViolation
 from .match_group_length import MatchGroup, MatchGroupTracker
@@ -362,6 +363,41 @@ def _format_pad_ref(pad: Pad) -> str:
         return pad.ref
     # Steiner point or other synthetic pad — identify by position
     return f"steiner@({pad.x:.3f},{pad.y:.3f})"
+
+
+def _star_topology_pads(pads: list[Pad]) -> tuple[Pad, list[Pad]]:
+    """Pick the star hub + terminal order for a net's lattice/mesh connections.
+
+    Issue #4476: the lattice (:meth:`Autorouter._negotiate_lattice_netset`) and
+    mesh (:meth:`Autorouter._negotiate_mesh_netset`) drivers historically built
+    each multi-pad net's connection set as a naive star rooted at ``pads[0]``
+    -- the first pad in dict-insertion order.  For a **Kelvin** current-sense
+    net that is wrong for exactly the reason
+    :mod:`kicad_tools.router.kelvin` documents: the sense tap must connect *at*
+    the shunt pad, so an arbitrary hub re-introduces the load-current IR drop
+    into the measurement.  Phase 3 (#4473/#4499) fixed this for the negotiated
+    grid path (``build_rsmt`` -> ``MSTRouter``) but not for these two engines --
+    and ``kct route --complete`` (and therefore
+    :func:`kicad_tools.router.partial_rescue.complete_unfinished_nets`) drives
+    the **lattice** engine.
+
+    Returns ``(anchor, terminals)``:
+
+    * Recognised Kelvin sense net (``detect_kelvin_topology`` gates on BOTH the
+      current-sense name pattern AND a resolvable shunt/sense-resistor pad) ->
+      the shunt pad as anchor, with the remaining terminals in the Kelvin
+      star's shortest-first order.
+    * Anything else -> ``(pads[0], pads[1:])``, byte-identical to the
+      pre-#4476 behaviour, so ordinary nets are untouched.
+    """
+    if len(pads) >= 3:
+        try:
+            topo = detect_kelvin_topology(pads)
+        except Exception:  # pragma: no cover - detection must never break routing
+            topo = None
+        if topo is not None:
+            return pads[topo.root_index], [pads[t] for _root, t in topo.edges]
+    return pads[0], list(pads[1:])
 
 
 # Issue #3433: greedy vertex-cover selection for the demote-to-partial
@@ -2439,6 +2475,10 @@ class Autorouter:
         per-net topology), runs the PathFinder/VPR portal negotiation once, and
         buckets the winning routes by net id.  Mesh triangulation happens once
         for the whole board inside :meth:`MeshPathfinder.route_netset`.
+
+        Issue #4476: the star's hub comes from :func:`_star_topology_pads`, so
+        a recognised Kelvin current-sense net is rooted at its shunt pad rather
+        than at the arbitrary first pad; every other net is unchanged.
         """
         pf = self._ensure_mesh_pathfinder()
 
@@ -2449,8 +2489,11 @@ class Autorouter:
             pads = [self.pads[k] for k in pad_keys if k in self.pads]
             if len(pads) < 2:
                 continue
-            anchor = pads[0]
-            for seq, other in enumerate(pads[1:]):
+            # Issue #4476: a recognised Kelvin sense net roots its star at the
+            # shunt pad, not the arbitrary first pad (see
+            # ``_star_topology_pads``); ordinary nets keep ``pads[0]``.
+            anchor, terminals = _star_topology_pads(pads)
+            for seq, other in enumerate(terminals):
                 if anchor.layer != other.layer:
                     continue  # single-layer: skip cross-layer connections
                 connections.append(((net, seq), anchor, other, None))
@@ -2718,6 +2761,16 @@ class Autorouter:
         DECLINES with a reason (reported below and in
         :attr:`_lattice_pair_outcomes`) -- it is never split into uncoupled
         legs.
+
+        Kelvin sense nets (issue #4476): the non-coupled star's hub comes from
+        :func:`_star_topology_pads`, so a recognised current-sense net is
+        rooted at its shunt pad.  This is the engine ``kct route --complete``
+        (and therefore
+        :func:`kicad_tools.router.partial_rescue.complete_unfinished_nets`)
+        drives, so a batch completion pass now preserves the same Kelvin
+        guarantee ``build_rsmt``/:class:`MSTRouter` give the negotiated grid
+        pass.  The coupled ``reserved`` branch keeps its nearest-endpoint
+        anchor selection untouched.
         """
         pf = self._ensure_lattice_pathfinder()
 
@@ -2754,8 +2807,13 @@ class Autorouter:
                     connections.append(((net, seq), anchor, other, net_class))
                 continue
             pads = [p for _k, p in keyed]
-            anchor = pads[0]
-            for seq, other in enumerate(pads[1:]):
+            # Issue #4476: Kelvin sense nets root the star at the shunt pad so
+            # ``--complete`` (which drives THIS engine) preserves the Phase-3
+            # (#4473/#4499) guarantee the negotiated grid pass already has.
+            # Only the non-coupled branch: the diff-pair ``reserved`` branch
+            # above keeps its nearest-endpoint anchor selection untouched.
+            anchor, terminals = _star_topology_pads(pads)
+            for seq, other in enumerate(terminals):
                 connections.append(((net, seq), anchor, other, net_class))
 
         # Issue #4477: remember each connection's pad endpoints keyed exactly

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -4312,44 +4312,68 @@ def verify_output_connectivity(
     """
     from .observability import _pt, _UnionFind
 
-    # Parse segments from PCB content: (segment (start X Y) (end X Y) ... (net N) ...)
-    seg_pattern = re.compile(
-        r"\(segment\s+"
-        r".*?\(start\s+([\d.+-]+)\s+([\d.+-]+)\)"
-        r".*?\(end\s+([\d.+-]+)\s+([\d.+-]+)\)"
-        r".*?\(net\s+(\d+)\)"
-        r".*?\)",
-        re.DOTALL,
-    )
+    # Issue #4476: scan each ``(segment ...)`` / ``(via ...)`` block FIRST and
+    # read its fields inside that block, instead of one mega-pattern whose
+    # lazy ``.*?`` gaps span the whole file.
+    #
+    # The old ordered pattern (``\(segment\s+.*?\(start...\).*?\(net\s+(\d+)\)``
+    # under DOTALL) required a NUMERIC net ref.  On a KiCad-10 name-only board
+    # -- the ``(net "GND")`` dialect ``route_cmd._board_uses_name_only_dialect``
+    # detects and re-emits (#4416); board-05 is one, because its zones are
+    # written in that dialect -- no segment ever matches, so each ``(segment``
+    # start makes the lazy gap scan to the end of the file looking for a
+    # numeric ``(net N)``.  Measured on board-05's 510 KB / 699-segment
+    # completion output: >4 minutes for this one call (the router's post-save
+    # tail appeared to hang), and the verification silently saw ZERO copper.
+    #
+    # ``[^()]*\([^()]*\)`` matches a segment/via body exactly (these blocks
+    # nest at most one level deep), so the scan is linear and cannot backtrack
+    # across the file.
+    seg_block_re = re.compile(r"\(segment\b(?:[^()]*\([^()]*\))*[^()]*\)")
+    via_block_re = re.compile(r"\(via\b(?:[^()]*\([^()]*\))*[^()]*\)")
+    start_re = re.compile(r"\(start\s+([\d.+-]+)\s+([\d.+-]+)\)")
+    end_re = re.compile(r"\(end\s+([\d.+-]+)\s+([\d.+-]+)\)")
+    at_re = re.compile(r"\(at\s+([\d.+-]+)\s+([\d.+-]+)\)")
+    # Both dialects: ``(net 12)`` and the name-only ``(net "GND")``.
+    net_ref_re = re.compile(r'\(net\s+(?:(\d+)|"((?:[^"\\]|\\.)*)")\s*\)')
+    # Header net table, used to resolve a name-only reference back to its id
+    # so both dialects key ``segments_by_net`` identically.
+    name_to_id = {
+        m.group(2): int(m.group(1)) for m in re.finditer(r'\(net\s+(\d+)\s+"([^"]*)"\)', pcb_content)
+    }
 
-    # Parse vias: (via (at X Y) ... (net N) ...)
-    # NOTE (#3447 sweep): unlike the ordered regexes fixed in #3446
-    # (parse_vias) and #3447 (_remove_conflicting_vias), this pattern
-    # uses lazy ``.*?`` wildcards between fields, so it tolerates
-    # KiCad-8 field order (uuid before net) and via type tokens
-    # (micro/blind/buried).  Checked and intentionally left as-is.
-    via_pattern = re.compile(
-        r"\(via\s+"
-        r".*?\(at\s+([\d.+-]+)\s+([\d.+-]+)\)"
-        r".*?\(net\s+(\d+)\)"
-        r".*?\)",
-        re.DOTALL,
-    )
+    def _block_net_id(block: str) -> int | None:
+        m = net_ref_re.search(block)
+        if m is None:
+            return None
+        if m.group(1) is not None:
+            return int(m.group(1))
+        return name_to_id.get(m.group(2).replace('\\"', '"'))
 
     # Group parsed segments by net
     segments_by_net: dict[int, list[tuple[tuple[float, float], tuple[float, float]]]] = {}
-    for m in seg_pattern.finditer(pcb_content):
-        x1, y1, x2, y2 = float(m.group(1)), float(m.group(2)), float(m.group(3)), float(m.group(4))
-        net_id = int(m.group(5))
+    for block_match in seg_block_re.finditer(pcb_content):
+        block = block_match.group(0)
+        s_m = start_re.search(block)
+        e_m = end_re.search(block)
+        net_id = _block_net_id(block)
+        if s_m is None or e_m is None or net_id is None:
+            continue
+        x1, y1 = float(s_m.group(1)), float(s_m.group(2))
+        x2, y2 = float(e_m.group(1)), float(e_m.group(2))
         segments_by_net.setdefault(net_id, []).append(
             (_pt(x1, y1, tolerance), _pt(x2, y2, tolerance))
         )
 
     # Group parsed vias by net
     vias_by_net: dict[int, list[tuple[float, float]]] = {}
-    for m in via_pattern.finditer(pcb_content):
-        x, y = float(m.group(1)), float(m.group(2))
-        net_id = int(m.group(3))
+    for block_match in via_block_re.finditer(pcb_content):
+        block = block_match.group(0)
+        at_m = at_re.search(block)
+        net_id = _block_net_id(block)
+        if at_m is None or net_id is None:
+            continue
+        x, y = float(at_m.group(1)), float(at_m.group(2))
         vias_by_net.setdefault(net_id, []).append(_pt(x, y, tolerance))
 
     result: dict[int, dict] = {}

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -4339,7 +4339,8 @@ def verify_output_connectivity(
     # Header net table, used to resolve a name-only reference back to its id
     # so both dialects key ``segments_by_net`` identically.
     name_to_id = {
-        m.group(2): int(m.group(1)) for m in re.finditer(r'\(net\s+(\d+)\s+"([^"]*)"\)', pcb_content)
+        m.group(2): int(m.group(1))
+        for m in re.finditer(r'\(net\s+(\d+)\s+"([^"]*)"\)', pcb_content)
     }
 
     def _block_net_id(block: str) -> int | None:

--- a/src/kicad_tools/router/partial_rescue.py
+++ b/src/kicad_tools/router/partial_rescue.py
@@ -331,6 +331,14 @@ def build_rescue_command(
     stack -- issue #4477).  When *complete_report* is given, the structured
     per-link JSON report (issue #4477 Phase 4) is written there for the caller
     to consume.
+
+    Issue #4476: ``--complete``'s auto-detection re-runs the same TRACE
+    connectivity checker, which knows nothing about ``config.excluded_nets`` --
+    so a pour/plane-carried net (board-05's ``PHASE_A/B/C``, ``GND``) looks
+    "unconnected" and the completion pass would lay traces on nets the recipe
+    routes as copper zones.  The completion shape therefore forwards the
+    exclusions as ``--complete-exclude-nets``.  A config with no exclusions
+    emits no flag, so its argv is byte-identical to pre-#4476.
     """
     cmd = [
         sys.executable,
@@ -390,6 +398,14 @@ def build_rescue_command(
         # #4478: --complete self-selects the stranded nets; a skip/nets list
         # would trip the mutual-exclusivity guard.  Never emit one here.
         cmd.append("--complete")
+        # Issue #4476: --complete's own auto-detection uses the same trace
+        # connectivity checker but knows nothing about ``excluded_nets``, so
+        # without this the completion pass lays traces on the pour/plane nets
+        # the caller deliberately excluded (board-05's PHASE_A/B/C, GND, ...).
+        # Emitted only when the caller HAS exclusions, so the argv of a
+        # config without them is byte-identical to pre-#4476.
+        if config.excluded_nets:
+            cmd.extend(["--complete-exclude-nets", ",".join(sorted(config.excluded_nets))])
         if complete_report is not None:
             cmd.extend(["--complete-report", str(complete_report)])
     else:

--- a/tests/router/test_lattice_kelvin_anchor.py
+++ b/tests/router/test_lattice_kelvin_anchor.py
@@ -1,0 +1,273 @@
+"""Kelvin-rooted star topology in the lattice/mesh drivers (issue #4476).
+
+``kct route --complete`` -- and therefore
+:func:`kicad_tools.router.partial_rescue.complete_unfinished_nets`, the batch
+rescue path board-05 uses -- drives the **lattice** engine, not the negotiated
+grid ``MSTRouter``.  Phase 3 (#4473/#4499) taught ``build_rsmt``/``MSTRouter``
+to route a Kelvin current-sense net as a star rooted at the shunt pad, but
+:meth:`Autorouter._negotiate_lattice_netset` and
+:meth:`Autorouter._negotiate_mesh_netset` still built a naive
+``anchor = pads[0]`` star, so a completion pass silently re-introduced the
+exact defect Phase 3 fixed.
+
+These tests pin the fix:
+
+1. :func:`_star_topology_pads` roots a recognised Kelvin net at the shunt pad
+   and orders the terminals shortest-first.
+2. Ordinary nets keep ``(pads[0], pads[1:])`` byte-identically.
+3. The lattice driver's per-connection endpoints all anchor at the shunt.
+4. The mesh driver does the same.
+5. The diff-pair ``reserved`` (coupled) branch is untouched.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from kicad_tools.router.core import Autorouter, _star_topology_pads
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.primitives import Pad
+
+
+def _pad(
+    x: float,
+    y: float,
+    net: int,
+    *,
+    ref: str,
+    pin: str = "1",
+    net_name: str = "N1",
+    layer: Layer = Layer.F_CU,
+) -> Pad:
+    return Pad(
+        x=x,
+        y=y,
+        width=1.0,
+        height=1.0,
+        net=net,
+        net_name=net_name,
+        layer=layer,
+        ref=ref,
+        pin=pin,
+    )
+
+
+def _kelvin_pads(net: int = 1, net_name: str = "ISENSE_A+") -> list[Pad]:
+    """A 4-terminal ISENSE net whose shunt (R10.1) is NOT first in pad order.
+
+    Distances from the shunt at (20, 20): U1.5 -> 5 mm, Q1.2 -> 10 mm,
+    J1.3 -> 20 mm, so the Kelvin star's shortest-first order is
+    ``[U1.5, Q1.2, J1.3]``.
+    """
+    return [
+        _pad(25.0, 20.0, net, ref="U1", pin="5", net_name=net_name),
+        _pad(20.0, 20.0, net, ref="R10", pin="1", net_name=net_name),
+        _pad(20.0, 30.0, net, ref="Q1", pin="2", net_name=net_name),
+        _pad(40.0, 20.0, net, ref="J1", pin="3", net_name=net_name),
+    ]
+
+
+def _add_pad(router: Autorouter, pad: Pad) -> None:
+    key = (pad.ref, pad.pin)
+    router.pads[key] = pad
+    router.nets.setdefault(pad.net, []).append(key)
+    if pad.net_name:
+        router.net_names[pad.net] = pad.net_name
+
+
+class _StubPathfinder:
+    """Records the connections handed to ``route_netset`` and routes nothing."""
+
+    def __init__(self) -> None:
+        self.connections: list[tuple[object, Pad, Pad, object]] = []
+        self.failure_reasons: dict[object, str] = {}
+
+    def route_netset(self, connections: list[Any], **_kwargs: Any) -> tuple[dict, Any]:
+        self.connections = list(connections)
+        return {}, SimpleNamespace(
+            routed=0,
+            total=len(connections),
+            iterations=0,
+            converged=True,
+            lattice_builds=1,
+        )
+
+
+# ---------------------------------------------------------------------------
+# 1-2. The shared star-topology helper.
+# ---------------------------------------------------------------------------
+
+
+def test_star_topology_roots_kelvin_net_at_shunt_pad() -> None:
+    pads = _kelvin_pads()
+    anchor, terminals = _star_topology_pads(pads)
+
+    assert (anchor.ref, anchor.pin) == ("R10", "1")
+    # Shortest-first ordering, matching build_kelvin_star_edges.
+    assert [(p.ref, p.pin) for p in terminals] == [("U1", "5"), ("Q1", "2"), ("J1", "3")]
+    # Every non-root terminal appears exactly once (a star, not a chain).
+    assert len(terminals) == len(pads) - 1
+    assert anchor not in terminals
+
+
+def test_star_topology_leaves_ordinary_net_unchanged() -> None:
+    """A non-sense net keeps the pre-#4476 ``(pads[0], pads[1:])`` shape."""
+    pads = [
+        _pad(25.0, 20.0, 2, ref="U1", pin="5", net_name="PWM_AH"),
+        _pad(20.0, 20.0, 2, ref="R20", pin="1", net_name="PWM_AH"),
+        _pad(20.0, 30.0, 2, ref="Q2", pin="2", net_name="PWM_AH"),
+    ]
+    anchor, terminals = _star_topology_pads(pads)
+
+    assert anchor is pads[0]
+    assert terminals == pads[1:]
+
+
+def test_star_topology_sense_net_without_shunt_is_unchanged() -> None:
+    """Name gate alone is not enough -- no resistor pad means no Kelvin root."""
+    pads = [
+        _pad(25.0, 20.0, 3, ref="U1", pin="5", net_name="ISENSE_B+"),
+        _pad(20.0, 20.0, 3, ref="U2", pin="1", net_name="ISENSE_B+"),
+        _pad(20.0, 30.0, 3, ref="Q3", pin="2", net_name="ISENSE_B+"),
+    ]
+    anchor, terminals = _star_topology_pads(pads)
+
+    assert anchor is pads[0]
+    assert terminals == pads[1:]
+
+
+def test_star_topology_two_pad_net_is_unchanged() -> None:
+    """A 2-pin net has no topology choice; detection is skipped entirely."""
+    pads = [
+        _pad(25.0, 20.0, 4, ref="U1", pin="5", net_name="ISENSE_C-"),
+        _pad(20.0, 20.0, 4, ref="R12", pin="1", net_name="ISENSE_C-"),
+    ]
+    anchor, terminals = _star_topology_pads(pads)
+
+    assert anchor is pads[0]
+    assert terminals == pads[1:]
+
+
+# ---------------------------------------------------------------------------
+# 3. The lattice driver.
+# ---------------------------------------------------------------------------
+
+
+def _lattice_connections(pads: list[Pad]) -> list[tuple[object, Pad, Pad, object]]:
+    router = Autorouter(60, 50, strategy="lattice")
+    for pad in pads:
+        _add_pad(router, pad)
+    stub = _StubPathfinder()
+    router._lattice_pathfinder = stub
+    router._negotiate_lattice_netset()
+    return stub.connections
+
+
+def test_lattice_netset_anchors_kelvin_net_at_shunt() -> None:
+    connections = _lattice_connections(_kelvin_pads())
+
+    assert len(connections) == 3
+    assert all((anchor.ref, anchor.pin) == ("R10", "1") for _k, anchor, _o, _c in connections)
+    assert [(other.ref, other.pin) for _k, _a, other, _c in connections] == [
+        ("U1", "5"),
+        ("Q1", "2"),
+        ("J1", "3"),
+    ]
+
+
+def test_lattice_connection_endpoints_report_the_kelvin_root() -> None:
+    """The #4477 unroutable-link report names the shunt as every link's start."""
+    router = Autorouter(60, 50, strategy="lattice")
+    for pad in _kelvin_pads():
+        _add_pad(router, pad)
+    router._lattice_pathfinder = _StubPathfinder()
+    router._negotiate_lattice_netset()
+
+    endpoints = router._lattice_connection_endpoints
+    assert endpoints
+    assert all(start == "R10.1" for start, _end in endpoints.values())
+
+
+def test_lattice_netset_ordinary_net_keeps_first_pad_anchor() -> None:
+    pads = [
+        _pad(25.0, 20.0, 2, ref="U1", pin="5", net_name="PWM_AH"),
+        _pad(20.0, 20.0, 2, ref="R20", pin="1", net_name="PWM_AH"),
+        _pad(20.0, 30.0, 2, ref="Q2", pin="2", net_name="PWM_AH"),
+    ]
+    connections = _lattice_connections(pads)
+
+    assert len(connections) == 2
+    assert all((anchor.ref, anchor.pin) == ("U1", "5") for _k, anchor, _o, _c in connections)
+    assert [(other.ref, other.pin) for _k, _a, other, _c in connections] == [
+        ("R20", "1"),
+        ("Q2", "2"),
+    ]
+
+
+def test_lattice_netset_leaves_coupled_reserved_branch_alone() -> None:
+    """The diff-pair ``reserved`` branch keeps its nearest-endpoint anchor.
+
+    A coupled pair's extra pads attach to whichever RESERVED endpoint is
+    nearest -- Kelvin root selection must not leak into that branch even when
+    the pair net's name would trip the sense-name pattern.
+    """
+    router = Autorouter(60, 50, strategy="lattice")
+    pads = [
+        _pad(10.0, 10.0, 5, ref="U9", pin="1", net_name="ISENSE_D+"),
+        _pad(50.0, 10.0, 5, ref="J9", pin="1", net_name="ISENSE_D+"),
+        _pad(48.0, 12.0, 5, ref="R99", pin="1", net_name="ISENSE_D+"),
+    ]
+    for pad in pads:
+        _add_pad(router, pad)
+    stub = _StubPathfinder()
+    router._lattice_pathfinder = stub
+    # Reserve the two main-run endpoints exactly as an engaged pair would.
+    reserved = {5: [("U9", "1"), ("J9", "1")]}
+    router._lattice_coupled_connections = lambda: ([], reserved)  # type: ignore[method-assign]
+    router._negotiate_lattice_netset()
+
+    assert len(stub.connections) == 1
+    _key, anchor, other, _cls = stub.connections[0]
+    # Nearest reserved endpoint to R99 is J9 -- NOT the Kelvin root (R99).
+    assert (anchor.ref, anchor.pin) == ("J9", "1")
+    assert (other.ref, other.pin) == ("R99", "1")
+
+
+# ---------------------------------------------------------------------------
+# 4. The mesh driver.
+# ---------------------------------------------------------------------------
+
+
+def _mesh_connections(pads: list[Pad]) -> list[tuple[object, Pad, Pad, object]]:
+    router = Autorouter(60, 50, strategy="mesh")
+    for pad in pads:
+        _add_pad(router, pad)
+    stub = _StubPathfinder()
+    router._mesh_pathfinder = stub
+    router._negotiate_mesh_netset()
+    return stub.connections
+
+
+def test_mesh_netset_anchors_kelvin_net_at_shunt() -> None:
+    connections = _mesh_connections(_kelvin_pads())
+
+    assert len(connections) == 3
+    assert all((anchor.ref, anchor.pin) == ("R10", "1") for _k, anchor, _o, _c in connections)
+    assert [(other.ref, other.pin) for _k, _a, other, _c in connections] == [
+        ("U1", "5"),
+        ("Q1", "2"),
+        ("J1", "3"),
+    ]
+
+
+def test_mesh_netset_ordinary_net_keeps_first_pad_anchor() -> None:
+    pads = [
+        _pad(25.0, 20.0, 2, ref="U1", pin="5", net_name="PWM_AH"),
+        _pad(20.0, 20.0, 2, ref="R20", pin="1", net_name="PWM_AH"),
+        _pad(20.0, 30.0, 2, ref="Q2", pin="2", net_name="PWM_AH"),
+    ]
+    connections = _mesh_connections(pads)
+
+    assert len(connections) == 2
+    assert all((anchor.ref, anchor.pin) == ("U1", "5") for _k, anchor, _o, _c in connections)

--- a/tests/router/test_partial_rescue.py
+++ b/tests/router/test_partial_rescue.py
@@ -351,6 +351,52 @@ def test_build_rescue_command_complete_omits_report_when_none(tmp_path: Path) ->
     assert "--complete-report" not in cmd
 
 
+def test_build_rescue_command_complete_forwards_excluded_pour_nets(tmp_path: Path) -> None:
+    """Issue #4476: ``--complete`` must not route the caller's pour/plane nets.
+
+    ``--complete`` re-detects the stranded set with the same TRACE connectivity
+    checker, which credits nothing to a filled zone -- so board-05's
+    PHASE_A/B/C (routed as copper pours, deliberately in ``--skip-nets`` on the
+    main pass) look unconnected and would get traces.  The exclusions ride
+    along as ``--complete-exclude-nets``.
+    """
+    cmd = build_rescue_command(
+        tmp_path / "a.kicad_pcb",
+        tmp_path / "b.kicad_pcb",
+        [],
+        RescueConfig(excluded_nets=frozenset({"GND", "PHASE_B", "PHASE_A"})),
+        complete=True,
+    )
+    # Sorted for determinism across runs (frozenset iteration order is not).
+    assert cmd[cmd.index("--complete-exclude-nets") + 1] == "GND,PHASE_A,PHASE_B"
+    # Still not a hand-enumerated routable set -- the guard stays satisfied.
+    assert "--skip-nets" not in cmd
+    assert "--nets" not in cmd
+
+
+def test_build_rescue_command_complete_omits_exclusions_when_empty(tmp_path: Path) -> None:
+    """No exclusions -> no flag, so the pre-#4476 completion argv is unchanged."""
+    cmd = build_rescue_command(
+        tmp_path / "a.kicad_pcb",
+        tmp_path / "b.kicad_pcb",
+        [],
+        RescueConfig(),
+        complete=True,
+    )
+    assert "--complete-exclude-nets" not in cmd
+
+
+def test_build_rescue_command_grid_shape_ignores_exclusions(tmp_path: Path) -> None:
+    """The single-net rescue shape never emits the completion-only flag."""
+    cmd = build_rescue_command(
+        tmp_path / "a.kicad_pcb",
+        tmp_path / "b.kicad_pcb",
+        ["X"],
+        RescueConfig(excluded_nets=frozenset({"GND"})),
+    )
+    assert "--complete-exclude-nets" not in cmd
+
+
 def test_build_rescue_command_default_is_grid_rescue_shape(tmp_path: Path) -> None:
     """complete defaults False: the single-net rescue shape is byte-unchanged."""
     cmd = build_rescue_command(

--- a/tests/test_board_05_batch_completion.py
+++ b/tests/test_board_05_batch_completion.py
@@ -97,14 +97,15 @@ def test_main_runs_batch_completion_after_solo_rescue_and_before_stitch() -> Non
     )
 
 
-def test_completion_budget_fits_the_ci_wall_clock_envelope() -> None:
-    """The completion phase must stay well inside the 90-min CI job budget.
+def test_completion_runs_exactly_one_pass() -> None:
+    """The completion phase must stay inside the 90-min CI job budget.
 
-    A fresh board-05 regen already spends ~45-55 min on the main pass plus
-    the solo rescue loop, so the batch phase's worst case
-    (``_COMPLETION_MAX_PASSES * _COMPLETION_PASS_TIMEOUT_S``) is capped at 15
-    minutes of routing.  Raising it needs a CI-measured wall-clock, not a
-    guess (#3880/#3894 history).
+    What bounds a ``--complete`` pass is the lattice per-link deadline
+    (``--per-net-timeout`` x link count, issues #4472/#4501), not
+    ``--timeout``: board-05's ~18 stranded links at 60 s each cap ONE pass at
+    ~18 min of negotiation.  A fresh regen already spends ~30-40 min before
+    this phase, so a second pass would not fit.  Raising the pass count needs
+    a CI-measured wall-clock, not a guess (the #3880/#3894 history).
     """
     tree = _design_tree()
     consts: dict[str, int] = {}
@@ -114,14 +115,40 @@ def test_completion_budget_fits_the_ci_wall_clock_envelope() -> None:
                 if isinstance(target, ast.Name) and isinstance(node.value.value, int):
                     consts[target.id] = node.value.value
 
-    assert "_COMPLETION_MAX_PASSES" in consts
-    assert "_COMPLETION_PASS_TIMEOUT_S" in consts
-    worst_case_s = consts["_COMPLETION_MAX_PASSES"] * consts["_COMPLETION_PASS_TIMEOUT_S"]
-    assert 0 < worst_case_s <= 900, (
-        f"Batch completion worst case is {worst_case_s}s; the board-05 CI job "
-        "budget (90 min total, ~45-55 min already spent) does not have room "
-        "for more than ~15 min of completion routing."
+    assert consts.get("_COMPLETION_MAX_PASSES") == 1, (
+        "board-05 runs exactly one batch-completion pass; more does not fit "
+        "the 90-minute board-05-routing-regression budget (Issue #4476)."
     )
+    assert 0 < consts.get("_COMPLETION_PASS_TIMEOUT_S", 0) <= 900
+
+
+def test_completion_config_keeps_the_board_rescue_knobs() -> None:
+    """The completion pass must reuse ``_RESCUE_CONFIG``, not re-declare knobs.
+
+    manufacturer / seed / per-net cutoff / layer stack / micro-via-in-pad are
+    load-bearing board-05 history (#3425/#3118/#3880/#3894); the completion
+    config is that config plus ``--skip-drc`` (design.py runs its own DRC at
+    step 9, so the subprocess's is pure CI-budget overhead).
+    """
+    tree = _design_tree()
+    assign = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        and any(isinstance(t, ast.Name) and t.id == "_COMPLETION_CONFIG" for t in node.targets)
+    )
+    source = ast.unparse(assign.value)
+    assert source.startswith("replace(_RESCUE_CONFIG"), (
+        "_COMPLETION_CONFIG must be derived from _RESCUE_CONFIG via "
+        f"dataclasses.replace so the board's knobs cannot drift; got: {source}"
+    )
+    assert "--skip-drc" in source
+    # No re-declaration of the load-bearing knobs.
+    for knob in ("manufacturer", "seed", "per_net_timeout_s", "deterministic_budget"):
+        assert f"{knob}=" not in source, (
+            f"_COMPLETION_CONFIG must not override {knob} (Issue #4476 keeps "
+            "board-05's rescue knobs unchanged)."
+        )
 
 
 def test_design_does_not_enable_escape_corridor_reservation() -> None:

--- a/tests/test_board_05_batch_completion.py
+++ b/tests/test_board_05_batch_completion.py
@@ -1,0 +1,136 @@
+"""Regression guard: board-05 design.py runs a BATCH completion pass (#4476).
+
+Issue #4476: board-05's step 6b only ran the **solo** rescue loop
+(:func:`kicad_tools.router.partial_rescue.rescue_partial_nets`), which
+reroutes each residual net ALONE against every other net's preserved,
+immutable copper.  In the saturated U3 south sense band that is blocked by
+non-rippable copper by construction, so a fresh regen logged
+``Rescue ISENSE_A+: FAILED (no output produced)`` for the whole stranded
+cohort (ISENSE_A+/A-/B+/B-/C-, PWM_BH, PWM_CH).
+
+The recipe now layers the shared BATCH pass
+(:func:`kicad_tools.router.partial_rescue.complete_unfinished_nets`, which
+shells ``kct route --complete`` on the lattice engine) on top of the solo
+loop, so the unfinished cohort can still negotiate with itself while the
+finished nets stay protected.
+
+These are cheap static (AST) guards -- KiCad-independent, no routing -- that
+pin the wiring and its ordering.  The routing outcome itself is asserted by
+the ``board-05-routing-regression`` CI job
+(``scripts/ci/check_board_05_blocking.py --max-blocking 11``).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DESIGN_PY = REPO_ROOT / "boards" / "05-bldc-motor-controller" / "design.py"
+
+
+def _design_tree() -> ast.Module:
+    return ast.parse(DESIGN_PY.read_text())
+
+
+def _main_fn(tree: ast.Module) -> ast.FunctionDef:
+    return next(
+        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "main"
+    )
+
+
+def _first_call_lines(fn: ast.FunctionDef) -> dict[str, int]:
+    lines: dict[str, int] = {}
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            lines.setdefault(node.func.id, node.lineno)
+    return lines
+
+
+def test_design_imports_the_shared_batch_completion() -> None:
+    """The batch pass must come from the shared library, not a recipe copy."""
+    tree = _design_tree()
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == (
+            "kicad_tools.router.partial_rescue"
+        ):
+            imported.update(alias.name for alias in node.names)
+
+    assert "complete_unfinished_nets" in imported, (
+        "design.py must import complete_unfinished_nets from "
+        "kicad_tools.router.partial_rescue (Issue #4476) -- the no-stub / "
+        "no-short rollback guarantee lives in the shared function and must "
+        "not be re-implemented in the recipe."
+    )
+
+
+def test_design_defines_completion_wrapper() -> None:
+    tree = _design_tree()
+    funcs = {node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)}
+    assert "complete_unfinished_nets" in funcs, (
+        "design.py must define a complete_unfinished_nets() wrapper carrying "
+        "this board's rescue knobs (Issue #4476)."
+    )
+
+
+def test_main_runs_batch_completion_after_solo_rescue_and_before_stitch() -> None:
+    """Ordering is load-bearing.
+
+    The batch pass must see whatever the solo loop could close (so it runs
+    after ``rescue_partial_nets``) and its copper must be present before the
+    pour stitching / zone fill / DRC tail (so it runs before ``stitch_pcb``).
+    """
+    lines = _first_call_lines(_main_fn(_design_tree()))
+
+    assert "complete_unfinished_nets" in lines, (
+        "main() must call complete_unfinished_nets() as part of step 6b (Issue #4476)."
+    )
+    assert "rescue_partial_nets" in lines
+    assert "stitch_pcb" in lines
+    assert lines["rescue_partial_nets"] < lines["complete_unfinished_nets"] < lines["stitch_pcb"], (
+        "complete_unfinished_nets() must run AFTER rescue_partial_nets() and "
+        "BEFORE stitch_pcb(). Current order:\n"
+        f"  rescue_partial_nets      @ line {lines['rescue_partial_nets']}\n"
+        f"  complete_unfinished_nets @ line {lines['complete_unfinished_nets']}\n"
+        f"  stitch_pcb               @ line {lines['stitch_pcb']}"
+    )
+
+
+def test_completion_budget_fits_the_ci_wall_clock_envelope() -> None:
+    """The completion phase must stay well inside the 90-min CI job budget.
+
+    A fresh board-05 regen already spends ~45-55 min on the main pass plus
+    the solo rescue loop, so the batch phase's worst case
+    (``_COMPLETION_MAX_PASSES * _COMPLETION_PASS_TIMEOUT_S``) is capped at 15
+    minutes of routing.  Raising it needs a CI-measured wall-clock, not a
+    guess (#3880/#3894 history).
+    """
+    tree = _design_tree()
+    consts: dict[str, int] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and isinstance(node.value.value, int):
+                    consts[target.id] = node.value.value
+
+    assert "_COMPLETION_MAX_PASSES" in consts
+    assert "_COMPLETION_PASS_TIMEOUT_S" in consts
+    worst_case_s = consts["_COMPLETION_MAX_PASSES"] * consts["_COMPLETION_PASS_TIMEOUT_S"]
+    assert 0 < worst_case_s <= 900, (
+        f"Batch completion worst case is {worst_case_s}s; the board-05 CI job "
+        "budget (90 min total, ~45-55 min already spent) does not have room "
+        "for more than ~15 min of completion routing."
+    )
+
+
+def test_design_does_not_enable_escape_corridor_reservation() -> None:
+    """#4519 gates the corridor-reservation opt-in; #4476 must not sneak it in.
+
+    ``--escape-corridor-reservation`` regressed this board's blocking gate
+    (11 -> 13) when it was opted in during PR #4509, so it stays OFF until
+    #4519 lands measured-safe selectivity.
+    """
+    text = DESIGN_PY.read_text()
+    assert "--escape-corridor-reservation" not in text
+    assert "escape_corridor_reservation" not in text

--- a/tests/test_cli_route_complete_4471.py
+++ b/tests/test_cli_route_complete_4471.py
@@ -131,6 +131,48 @@ class TestResolveCompleteNets:
         assert rc == 2
         assert "mutually exclusive" in capsys.readouterr().err
 
+    def test_exclude_nets_are_passed_to_the_detector(self, monkeypatch, capsys):
+        """Issue #4476: pour/plane nets named by --complete-exclude-nets are
+        withheld from the auto-detected routable set.
+
+        A filled zone carries their connectivity, which the TRACE checker does
+        not credit -- so without this they look stranded and --complete lays
+        traces on nets the recipe routes as copper pours.
+        """
+        import kicad_tools.router.partial_rescue as pr
+
+        seen: dict = {}
+
+        def _spy(_path, *, manufacturer, excluded_nets, include_unrouted):
+            seen["excluded"] = excluded_nets
+            return [n for n in ("/NET_A", "GND", "PHASE_A") if n not in excluded_nets]
+
+        monkeypatch.setattr(pr, "partially_connected_signal_nets", _spy)
+        args = _complete_args(complete_exclude_nets="GND, PHASE_A ,")
+        rc = _resolve_complete_nets(args, Path("dummy.kicad_pcb"))
+
+        assert rc == 0
+        # Whitespace trimmed, empty entries dropped.
+        assert seen["excluded"] == frozenset({"GND", "PHASE_A"})
+        assert args.nets == "/NET_A"
+        assert "excluding 2 pour/plane net(s)" in capsys.readouterr().out
+
+    def test_exclude_nets_defaults_to_no_exclusions(self, monkeypatch):
+        """Absent/empty flag keeps the pre-#4476 auto-detected set exactly."""
+        import kicad_tools.router.partial_rescue as pr
+
+        seen: dict = {}
+
+        def _spy(_path, *, manufacturer, excluded_nets, include_unrouted):
+            seen["excluded"] = excluded_nets
+            return ["/NET_A"]
+
+        monkeypatch.setattr(pr, "partially_connected_signal_nets", _spy)
+        # No ``complete_exclude_nets`` attribute at all (older namespaces).
+        rc = _resolve_complete_nets(_complete_args(), Path("dummy.kicad_pcb"))
+        assert rc == 0
+        assert seen["excluded"] == frozenset()
+
     def test_noop_when_complete_absent(self, monkeypatch):
         import kicad_tools.router.partial_rescue as pr
 

--- a/tests/test_output_connectivity.py
+++ b/tests/test_output_connectivity.py
@@ -210,3 +210,110 @@ class TestVerifyOutputConnectivity:
 
         assert result[1]["connected"] is False
         assert result[1]["connected_pads"] == 0
+
+
+# ---------------------------------------------------------------------------
+# KiCad-10 name-only net dialect + linear-time scan (Issue #4476)
+# ---------------------------------------------------------------------------
+
+
+def _named_seg_sexp(x1: float, y1: float, x2: float, y2: float, net_name: str) -> str:
+    """A segment in the KiCad-10 name-only dialect: ``(net "NAME")``."""
+    return (
+        f"(segment\n\t\t(start {x1:.4f} {y1:.4f})\n\t\t(end {x2:.4f} {y2:.4f})\n"
+        f'\t\t(width 0.2)\n\t\t(layer "F.Cu")\n\t\t(uuid "u")\n\t\t(net "{net_name}")\n\t)'
+    )
+
+
+def _named_via_sexp(x: float, y: float, net_name: str) -> str:
+    return (
+        f"(via\n\t\t(at {x:.4f} {y:.4f})\n\t\t(size 0.6)\n\t\t(drill 0.3)\n"
+        f'\t\t(layers "F.Cu" "B.Cu")\n\t\t(uuid "u")\n\t\t(net "{net_name}")\n\t)'
+    )
+
+
+def _wrap_named_pcb(fragments: str, *, net_table: dict[int, str]) -> str:
+    """Wrap fragments in a PCB whose header declares the numeric net table."""
+    table = "\n  ".join(f'(net {nid} "{name}")' for nid, name in sorted(net_table.items()))
+    return f"(kicad_pcb (version 20241229)\n  {table}\n  {fragments}\n)"
+
+
+class TestNameOnlyNetDialect:
+    """Issue #4476: verification must read the ``(net "NAME")`` dialect.
+
+    ``route_cmd._board_uses_name_only_dialect`` (#4416) re-emits route copper
+    in whatever dialect the input board uses, and board-05 IS a name-only
+    board (its zones are written that way).  The pre-#4476 numeric-only
+    pattern matched nothing on such a board, so the post-save verification
+    silently saw zero copper -- and, because its lazy gaps then scanned to
+    end-of-file per ``(segment`` token, took minutes to say so.
+    """
+
+    def test_named_segment_connects_a_net(self):
+        pcb = _wrap_named_pcb(_named_seg_sexp(0.0, 0.0, 5.0, 0.0, "NET1"), net_table={1: "NET1"})
+        pads = [_pad(0.0, 0.0, 1, "U1", "1"), _pad(5.0, 0.0, 1, "U1", "2")]
+
+        result = verify_output_connectivity(pcb, {1: pads})
+
+        assert result[1]["connected"] is True
+        assert result[1]["connected_pads"] == 2
+
+    def test_named_via_bridges_two_segments(self):
+        frags = "\n  ".join(
+            [
+                _named_seg_sexp(0.0, 0.0, 5.0, 0.0, "NET1"),
+                _named_via_sexp(5.0, 0.0, "NET1"),
+                _named_seg_sexp(5.0, 0.0, 10.0, 0.0, "NET1"),
+            ]
+        )
+        pcb = _wrap_named_pcb(frags, net_table={1: "NET1"})
+        pads = [_pad(0.0, 0.0, 1, "U1", "1"), _pad(10.0, 0.0, 1, "U2", "1")]
+
+        result = verify_output_connectivity(pcb, {1: pads})
+
+        assert result[1]["connected"] is True
+
+    def test_named_segment_on_wrong_net_does_not_help(self):
+        pcb = _wrap_named_pcb(
+            _named_seg_sexp(0.0, 0.0, 5.0, 0.0, "NET2"), net_table={1: "NET1", 2: "NET2"}
+        )
+        pads = [_pad(0.0, 0.0, 1, "U1", "1"), _pad(5.0, 0.0, 1, "U1", "2")]
+
+        result = verify_output_connectivity(pcb, {1: pads})
+
+        assert result[1]["connected"] is False
+        assert result[1]["connected_pads"] == 0
+
+    def test_unknown_net_name_is_ignored_not_crashed(self):
+        """A name absent from the header table is skipped, never an exception."""
+        pcb = _wrap_named_pcb(_named_seg_sexp(0.0, 0.0, 5.0, 0.0, "GHOST"), net_table={1: "NET1"})
+        pads = [_pad(0.0, 0.0, 1, "U1", "1"), _pad(5.0, 0.0, 1, "U1", "2")]
+
+        result = verify_output_connectivity(pcb, {1: pads})
+
+        assert result[1]["connected"] is False
+
+    def test_scan_is_linear_on_a_large_unmatched_board(self):
+        """Regression guard for the >4-minute board-05 stall.
+
+        700 name-only segments in a 500 KB board: the pre-#4476 pattern made
+        each ``(segment`` token scan to end-of-file hunting for a numeric
+        ``(net N)``.  The block-scoped scan is linear, so this completes in
+        well under a second.
+        """
+        import time
+
+        frags = "\n  ".join(
+            _named_seg_sexp(float(i), 0.0, float(i) + 1.0, 0.0, "NET1") for i in range(700)
+        )
+        # Pad the board out with unrelated text so a runaway scan is expensive.
+        filler = "\n".join(
+            f'  (gr_line (start {i} 0) (end {i} 1) (layer "Edge.Cuts"))' for i in range(3000)
+        )
+        pcb = _wrap_named_pcb(frags + "\n" + filler, net_table={1: "NET1"})
+        assert len(pcb) > 200_000
+
+        pads = [_pad(0.0, 0.0, 1, "U1", "1"), _pad(700.0, 0.0, 1, "U2", "1")]
+        started = time.monotonic()
+        verify_output_connectivity(pcb, {1: pads})
+        assert time.monotonic() - started < 5.0


### PR DESCRIPTION
## Summary

`kct route --complete` — the engine `partial_rescue.complete_unfinished_nets` shells since #4514 — built every multi-pad net's connection set as a naive star anchored at `pads[0]`. Phase 3 (#4473/#4499) taught `build_rsmt`/`MSTRouter` to root a Kelvin current-sense net at its shunt pad, but the lattice and mesh netset drivers never learned it, so a completion pass silently re-introduced the exact defect Phase 3 fixed. This PR closes that gap and wires board-05's step 6b to the batch completion path.

Along the way the wiring exposed three real blockers that had to be fixed for the path to work at all on board-05; each is a small, separately-committed change with its own tests.

**Measured on a fresh host regen (board-05, seed 7):**

| | blocking nets | `unconnected_items` | new shorts | completion wall-clock |
|---|---|---|---|---|
| Post-solo-rescue baseline (pre-#4476 pipeline state) | **11** | 97 | — | — |
| After the batch completion pass | **6** | 85 | **0** | **4 min 39 s** |

Closed by the batch pass: `ISENSE_A+`, `ISENSE_B+`, `PWM_BH`, `PWM_CH`, `PWM_CL`. Still open: `ISENSE_A-/B-/C-` — now with a concrete per-link reason instead of the old opaque "no output produced" (see below). The three residual `PHASE_*` nets are pour-carried and were never rescue targets.

## Changes

**1. Kelvin-rooted lattice/mesh stars (the generic library fix)** — `src/kicad_tools/router/core.py`
- New `_star_topology_pads(pads) -> (anchor, terminals)`: for a net `detect_kelvin_topology` recognises (both gates: current-sense name **and** a resolvable shunt pad) it returns the shunt pad plus the star's shortest-first terminals; for anything else it returns `(pads[0], pads[1:])` — byte-identical to pre-#4476.
- Used by `_negotiate_lattice_netset()` (non-coupled branch only — the diff-pair `reserved` nearest-endpoint anchor is untouched) and `_negotiate_mesh_netset()`.

**2. board-05 recipe wiring** — `boards/05-bldc-motor-controller/design.py`
- Step 6b now runs the solo rescue first (unchanged), then the shared `complete_unfinished_nets()` on whatever remains, and prints each still-unroutable link's `blocking_copper` reason.
- Bounded at **one** pass. What actually bounds a `--complete` pass is the lattice per-link deadline (`--per-net-timeout` × link count, #4472/#4501), not `--timeout`: board-05's cohort is 17 links, so the negotiation ceiling is ~17 min (measured: 265 s used of a 1020 s budget). `_COMPLETION_CONFIG` is `_RESCUE_CONFIG` via `dataclasses.replace` plus `--skip-drc`, so the board's load-bearing knobs (#3425/#3118/#3880/#3894) cannot drift.
- `--escape-corridor-reservation` is **not** enabled (deferred to #4519); a test asserts the string never appears in the recipe.

**3. `--complete` must not route pour/plane-carried nets** — `route_cmd.py`, `parser.py`, `commands/routing.py`, `partial_rescue.py`
- `--complete` re-detects its routable set with the TRACE connectivity checker, which credits nothing to a filled zone, so board-05's `PHASE_A/B/C` read as stranded and got traces — nets the recipe deliberately routes as copper pours. `--skip-nets` cannot express this (mutually exclusive with `--complete`).
- New `--complete-exclude-nets`; `build_rescue_command` forwards `RescueConfig.excluded_nets` when non-empty. Cohort drops 11 → 8 and the localized lattice box narrows from 66 mm to 38 mm wide. No flag emitted when there are no exclusions, so existing argv is byte-identical.

**4. Output-connectivity verification: linear and dialect-aware** — `src/kicad_tools/router/io.py`
- `verify_output_connectivity` matched segments with one ordered pattern whose lazy DOTALL gaps required a **numeric** `(net N)`. Board-05 is a KiCad-10 name-only board (`(net "GND")`, the dialect #4416 detects and re-emits, because its zones are written that way), so nothing matched and every `(segment` token scanned to end-of-file. **Measured: >45 minutes in this one call** on the 510 KB completion output, with the verification silently seeing zero copper. This is what made the completion pass look non-terminating.
- Now scans each `(segment ...)`/`(via ...)` block first (they nest one level deep, so the block pattern is linear), then reads its fields, resolving a name-only ref through the header net table. Same result on numeric boards; the completion pass went from >45 min to 4 min 39 s.

## Acceptance Criteria Verification

- [x] **Lattice roots a Kelvin net's star at the shunt pad; ordinary nets unchanged; mesh gets the same fix** — `tests/router/test_lattice_kelvin_anchor.py` (10 tests): synthetic 4-pad ISENSE net anchors every connection at `R10.1` (not the first-inserted `U1.5`), ordinary/sense-without-shunt/2-pad nets keep `(pads[0], pads[1:])`, and the coupled `reserved` branch still picks the nearest reserved endpoint. Confirmed live on board-05: **every** unroutable link in the completion report starts at a shunt pad (`R12.2`, `R11.2`, `R10.2`).
- [x] **design.py calls `complete_unfinished_nets()` in step 6b** — `tests/test_board_05_batch_completion.py` (6 AST guards: shared import, wrapper defined, ordering after solo rescue and before `stitch_pcb`, one pass, knobs derived from `_RESCUE_CONFIG`, no corridor reservation).
- [x] **The 7 stranded nets route, or get a concrete `blocking_copper` reason** — 5 of 7 routed (`ISENSE_A+`, `PWM_BH`, `PWM_CH`, plus `PWM_CL` and `ISENSE_B+`). The rest are named per link, e.g. `ISENSE_A- | no-path | R12.2 -> U3.33 | blocking: ISENSE_B+, GATE_AL, ISENSE_A+ | nearest 0.05 mm | placement_bound`.
- [x] **`blocking_incomplete_count` does not regress** — 11 → **6** on the host regen (gate is `<= 11`). CI is authoritative per #3775/#3766/#3829; the threshold is untouched.
- [x] **Zero new `shorting_items`** — `kicad-cli pcb drc --refill-zones`: 1 short before, 1 after — the same pre-existing `NRST`/`OSC_IN` pair the pipeline's #4470 repair step handles downstream. Zero new shorts.
- [x] **No stranded stubs on a failed net** — `track_dangling` is 2 before and 2 after. The shared function's byte-for-byte pre-pass backup + rollback is inherited, not re-implemented.
- [x] **`--escape-corridor-reservation` NOT enabled on board-05** — asserted by test.
- [x] **Existing suites pass** — `test_partial_rescue.py` (26), `test_escape_corridor.py` (12), `test_cli_route_complete_4471.py` (17), lattice + mesh suites: **354 passed, 2 skipped**.
- [x] **Within the CI wall-clock envelope** — the completion phase is 4 min 39 s end-to-end on the host (negotiation used 265 s of its 1020 s budget). Comfortably inside the 90-minute `board-05-routing-regression` job.

## Test Plan

- `uv run pytest tests/test_output_connectivity.py tests/router/test_partial_rescue.py tests/test_cli_route_complete_4471.py tests/router/lattice tests/router/mesh tests/router/test_lattice_kelvin_anchor.py tests/test_kelvin_topology.py tests/router/test_escape_corridor.py tests/test_board_05_batch_completion.py tests/test_board_05_stitch_pipeline.py tests/test_cli_parser_drift.py tests/router/test_preserve_existing.py` → **354 passed, 2 skipped**
- `uv run ruff format --check .` / `uv run ruff check .` → clean
- `uv run python scripts/ci/check_mypy_baseline.py` (clean cache) → 1473 errors, all within the 1474 baseline, no new type errors
- Board-05: fresh regen to the post-solo-rescue state, then the exact recipe completion command; blocking count via `scripts/ci/check_board_05_blocking.py`, shorts via `kicad-cli pcb drc --refill-zones`
- **Not** included, per the issue's out-of-scope list: no regenerated `bldc_controller_routed.kicad_pcb` and no re-baselined `test_board_05_drc_hotspot_regression.py` — that is Phase 6 (#4479).

## Notes for the reviewer

Two out-of-scope findings surfaced during verification and are **not** fixed here (follow-up issues filed):

1. **board-05's solo rescue loop has been dead since #3911.** `_RESCUE_CONFIG` does not pass `--allow-unsafe-grid` while the main pass does, so every rescue subprocess exits 1 at the auto-grid safety gate. Reproduced directly: `Error: Auto-grid selected 0.1mm > clearance/2 (0.075mm)...`. The loop's "no output produced — crash / OOM before save" diagnosis is misleading. The batch path is unaffected (the gate is grid-engine-only), which is why this PR works regardless.
2. **Other numeric-only `(net N)` consumers on name-only boards** — e.g. `partial_rescue.strip_net_copper`'s `\(net (\d+)\)` match. Same #4416 dialect mismatch this PR fixed in the verifier.

Closes #4476