### PR TITLE
fix(route): revive board-05 solo rescue loop (missing --allow-unsafe-grid)

### DIFF
--- a/boards/05-bldc-motor-controller/design.py
+++ b/boards/05-bldc-motor-controller/design.py
@@ -3127,6 +3127,15 @@ _RESCUE_EXCLUDED_NETS = frozenset(
 #     PR #3886).  Re-enable deterministic_budget here only together with the
 #     main pass, once a CI-terminating iteration ceiling is measured.
 #   * 4-layer, cpp backend, jlcpcb-tier1 -- same as the main pass.
+#   * ``allow_unsafe_grid=True`` (Issue #4528): the main pass opts into the
+#     memory-forced 0.1mm coarse grid via ``--allow-unsafe-grid`` (see the
+#     long #3911 comment on the main-pass ``cmd`` above, ~line 3053).  Every
+#     rescue knob is supposed to match the main pass, and this one was silently
+#     missing: without it ``kct route`` refuses the same grid at its #3911
+#     safety gate and every rescue subprocess exits 1 BEFORE routing anything,
+#     so the whole solo rescue loop reported bogus ``no_output`` failures for
+#     8/8 nets and had been dead since #3911 landed.  Board 05 knowingly
+#     accepts the coarse-grid DRC risk here exactly as it does on the main pass.
 _RESCUE_CONFIG = RescueConfig(
     manufacturer="jlcpcb-tier1",
     backend="cpp",
@@ -3137,6 +3146,7 @@ _RESCUE_CONFIG = RescueConfig(
     max_layers=4,
     excluded_nets=_RESCUE_EXCLUDED_NETS,
     micro_via_in_pad_fallback=True,
+    allow_unsafe_grid=True,
 )
 
 

--- a/src/kicad_tools/router/partial_rescue.py
+++ b/src/kicad_tools/router/partial_rescue.py
@@ -176,6 +176,16 @@ class RescueConfig:
     #: fill, which the trace-connectivity checker does not credit).
     excluded_nets: frozenset[str] = field(default_factory=frozenset)
     micro_via_in_pad_fallback: bool = False
+    #: Issue #4528: emit ``--allow-unsafe-grid`` on every rescue/completion
+    #: ``kct route`` subprocess.  A board whose MAIN pass opts into the
+    #: memory-forced coarse grid (grid > clearance/2, the #3911 auto-grid
+    #: safety gate) MUST set this so the rescue subprocess inherits the same
+    #: documented opt-in -- otherwise ``kct route`` refuses the grid and exits
+    #: 1 before routing anything, and the rescue loop reports bogus
+    #: ``no_output`` failures for every net.  Off by default: a board that
+    #: never opts into the unsafe grid on its main pass emits byte-identical
+    #: rescue argv (no flag).
+    allow_unsafe_grid: bool = False
     #: Extra args appended verbatim to each ``kct route`` invocation.
     extra_args: tuple[str, ...] = ()
 
@@ -350,6 +360,14 @@ def build_rescue_command(
     )
     if config.micro_via_in_pad_fallback:
         cmd.append("--micro-via-in-pad-fallback")
+    # Issue #4528: inherit the main pass's #3911 auto-grid opt-in.  The gate
+    # itself is grid-engine-only, but ``kct route`` accepts the flag regardless
+    # of engine, so it is safe to emit for both the rescue (grid A*) and the
+    # completion (lattice) shape.  Without it, a board whose main pass forced a
+    # coarse grid sees every rescue subprocess exit 1 at the CLI gate before
+    # routing anything (bogus ``no_output`` failures).
+    if config.allow_unsafe_grid:
+        cmd.append("--allow-unsafe-grid")
     cmd.extend(
         [
             "--backend",

--- a/src/kicad_tools/router/rescue_diagnostics.py
+++ b/src/kicad_tools/router/rescue_diagnostics.py
@@ -69,6 +69,7 @@ class RescueFailureCategory(Enum):
     BUDGET_EXHAUSTED = "budget_exhausted"
     CLEARANCE_INFIDELITY = "clearance_infidelity"
     CONGESTION = "congestion"
+    CLI_REFUSED = "cli_refused"
     NO_OUTPUT = "no_output"
     UNKNOWN = "unknown"
 
@@ -97,6 +98,13 @@ class RescueFailureCategory(Enum):
             "congestion": (
                 "congestion -- too many competing traces in the corridor for a "
                 "single-net solo pass to thread"
+            ),
+            "cli_refused": (
+                "CLI refused -- the rescue subprocess declined at a CLI "
+                "validation gate before routing anything (e.g. the #3911 "
+                "auto-grid safety gate rejecting a memory-forced coarse grid); "
+                "NOT a crash/OOM -- the recipe must forward the corresponding "
+                "opt-in flag (e.g. --allow-unsafe-grid) to the rescue stage"
             ),
             "no_output": (
                 "no output produced -- the rescue subprocess wrote no PCB file "
@@ -141,6 +149,38 @@ _ESCAPE_SIGNATURES = (
     "no open sector",
     "could not escape",
 )
+
+# Issue #4528: exit-1 CLI-validation-gate declines.  Each entry is a tuple of
+# substrings that MUST ALL be present in the captured stdout+stderr to match --
+# an AND-of-substrings signature keeps a match specific to the real refusal
+# message and avoids false positives from an unrelated stray token.  These gates
+# print a precise reason to stderr and return exit 1 BEFORE writing any PCB
+# file, so ``output_produced`` is False even though nothing crashed.  Open-ended
+# so other exit-1 CLI gates can be added without another restructure.
+#
+# The auto-grid refusal (route_cmd.py, #3911) is emitted verbatim as
+# ``Error: Auto-grid selected {N}mm, coarser than clearance/2 ({M}mm), ...``.
+_CLI_REFUSAL_SIGNATURES: tuple[tuple[str, ...], ...] = (
+    ("Error: Auto-grid selected", "clearance/2"),
+)
+
+
+def _match_cli_refusal(text: str) -> str:
+    """Return the matched CLI-refusal line, or ``""`` when no signature matches.
+
+    A signature matches when EVERY substring in one of its tuples is present in
+    *text*.  Returns the first line of *text* that contains the first substring
+    of the matched signature (the ``Error: ...`` line), so the reason table can
+    show the router's own words instead of a fabricated ``crash / OOM`` label.
+    """
+    for signature in _CLI_REFUSAL_SIGNATURES:
+        if all(sub in text for sub in signature):
+            anchor = signature[0]
+            for line in text.splitlines():
+                if anchor in line:
+                    return line.strip()
+            return anchor
+    return ""
 
 
 @dataclass
@@ -249,6 +289,21 @@ def classify_rescue_failure(
     )
 
     if not output_produced:
+        # Issue #4528: a missing PCB file is NOT necessarily a crash/OOM.  A CLI
+        # validation gate (e.g. the #3911 auto-grid safety gate) prints a
+        # precise reason to stderr and returns exit 1 BEFORE writing anything.
+        # Inspect the captured output for a known refusal signature before
+        # falling back to the generic (and here misleading) NO_OUTPUT label.
+        refusal_line = _match_cli_refusal(text)
+        if refusal_line:
+            return RescueFailureReason(
+                net=net,
+                category=RescueFailureCategory.CLI_REFUSED,
+                detail=f"{RescueFailureCategory.CLI_REFUSED.label} [{refusal_line}]",
+                pads_connected=pads_connected,
+                escape_note=escape_note,
+                grid_infidelity=grid_infidelity,
+            )
         return RescueFailureReason(
             net=net,
             category=RescueFailureCategory.NO_OUTPUT,

--- a/tests/router/test_partial_rescue.py
+++ b/tests/router/test_partial_rescue.py
@@ -257,6 +257,47 @@ def test_build_rescue_command_deterministic_budget_replaces_per_net_timeout(
     assert "--preserve-existing" in cmd
 
 
+def test_build_rescue_command_emits_allow_unsafe_grid_when_set(tmp_path: Path) -> None:
+    """Issue #4528: a board whose main pass opts into the coarse grid must
+    forward ``--allow-unsafe-grid`` to the rescue subprocess, or the #3911
+    auto-grid gate refuses the grid and exits 1 before routing anything."""
+    cmd = build_rescue_command(
+        tmp_path / "a.kicad_pcb",
+        tmp_path / "b.kicad_pcb",
+        ["SCL", "NRST"],
+        RescueConfig(allow_unsafe_grid=True),
+    )
+    assert "--allow-unsafe-grid" in cmd
+
+
+def test_build_rescue_command_emits_allow_unsafe_grid_in_complete_shape(
+    tmp_path: Path,
+) -> None:
+    """Issue #4528: the flag propagates to the completion (lattice) shape too --
+    ``_COMPLETION_CONFIG`` inherits it via ``dataclasses.replace(_RESCUE_CONFIG)``."""
+    cmd = build_rescue_command(
+        tmp_path / "a.kicad_pcb",
+        tmp_path / "b.kicad_pcb",
+        [],
+        RescueConfig(allow_unsafe_grid=True),
+        complete=True,
+    )
+    assert "--allow-unsafe-grid" in cmd
+    assert "--complete" in cmd
+
+
+def test_build_rescue_command_omits_allow_unsafe_grid_by_default(tmp_path: Path) -> None:
+    """Issue #4528: a board that does NOT opt into the unsafe grid emits
+    byte-identical rescue argv (no flag) -- the knob is off by default."""
+    cmd = build_rescue_command(
+        tmp_path / "a.kicad_pcb",
+        tmp_path / "b.kicad_pcb",
+        ["X"],
+        RescueConfig(),
+    )
+    assert "--allow-unsafe-grid" not in cmd
+
+
 # ---------------------------------------------------------------------------
 # build_rescue_command completion shape (issue #4478, epic #4465 Phase 5)
 # ---------------------------------------------------------------------------

--- a/tests/router/test_rescue_diagnostics.py
+++ b/tests/router/test_rescue_diagnostics.py
@@ -93,6 +93,65 @@ def test_no_output_produced() -> None:
     assert r.category is RescueFailureCategory.NO_OUTPUT
 
 
+# Real #3911 auto-grid refusal, printed to stderr with exit 1 BEFORE any PCB
+# file is written (so ``output_produced`` is False even though nothing crashed).
+_AUTO_GRID_REFUSAL_STDERR = (
+    "Error: Auto-grid selected 0.1mm, coarser than clearance/2 (0.075mm), "
+    "because the memory budget cap (max_cells=2,000,000) forced a coarser grid.\n"
+    "The router's own safety rule rejects this grid; routing WILL produce "
+    "clearance-violating vias/segments (DRC shorts).\n"
+)
+
+
+def test_cli_refusal_classified_distinct_from_no_output() -> None:
+    """Issue #4528: an auto-grid CLI refusal with no PCB output is CLI_REFUSED.
+
+    The subprocess declined at the #3911 validation gate and exited 1 before
+    routing anything -- it is NOT the crash/OOM ``no_output`` case, even though
+    ``output_produced`` is False.
+    """
+    r = classify_rescue_failure(
+        "ISENSE_A+", "", _AUTO_GRID_REFUSAL_STDERR, output_produced=False
+    )
+    assert r.category is RescueFailureCategory.CLI_REFUSED
+    assert r.category is not RescueFailureCategory.NO_OUTPUT
+    # The real router line is surfaced instead of a fabricated crash/OOM label.
+    assert "Auto-grid selected 0.1mm" in r.detail
+
+
+def test_cli_refusal_signature_on_stdout_also_matches() -> None:
+    """The signature is checked against combined stdout+stderr."""
+    r = classify_rescue_failure(
+        "PWM_CL", _AUTO_GRID_REFUSAL_STDERR, "", output_produced=False
+    )
+    assert r.category is RescueFailureCategory.CLI_REFUSED
+
+
+def test_genuine_no_output_still_classifies_as_no_output() -> None:
+    """Issue #4528 regression guard: empty output + no refusal signature is a
+    genuine crash/OOM-before-save and must keep the NO_OUTPUT label."""
+    r = classify_rescue_failure("ISENSE_C-", "", "", output_produced=False)
+    assert r.category is RescueFailureCategory.NO_OUTPUT
+    # A partial-but-unrelated log with no refusal signature is also NO_OUTPUT.
+    r2 = classify_rescue_failure(
+        "ISENSE_C-", "some unrelated crash traceback\n", "", output_produced=False
+    )
+    assert r2.category is RescueFailureCategory.NO_OUTPUT
+
+
+def test_format_rescue_reason_table_renders_cli_refused() -> None:
+    """Issue #4528: the new CLI_REFUSED category renders (label + detail)."""
+    reason = classify_rescue_failure(
+        "ISENSE_A+", "", _AUTO_GRID_REFUSAL_STDERR, output_produced=False
+    )
+    table = format_rescue_reason_table([reason])
+    assert "ISENSE_A+" in table
+    assert "cli_refused" in table
+    assert "CLI refused" in table
+    # Not mislabeled as a crash/OOM no-output case.
+    assert "no_output" not in table
+
+
 def test_unknown_when_no_signature() -> None:
     r = classify_rescue_failure("FOO", "some unrelated log line\n", "", output_produced=True)
     assert r.category is RescueFailureCategory.UNKNOWN

--- a/tests/router/test_rescue_diagnostics.py
+++ b/tests/router/test_rescue_diagnostics.py
@@ -110,9 +110,7 @@ def test_cli_refusal_classified_distinct_from_no_output() -> None:
     routing anything -- it is NOT the crash/OOM ``no_output`` case, even though
     ``output_produced`` is False.
     """
-    r = classify_rescue_failure(
-        "ISENSE_A+", "", _AUTO_GRID_REFUSAL_STDERR, output_produced=False
-    )
+    r = classify_rescue_failure("ISENSE_A+", "", _AUTO_GRID_REFUSAL_STDERR, output_produced=False)
     assert r.category is RescueFailureCategory.CLI_REFUSED
     assert r.category is not RescueFailureCategory.NO_OUTPUT
     # The real router line is surfaced instead of a fabricated crash/OOM label.
@@ -121,9 +119,7 @@ def test_cli_refusal_classified_distinct_from_no_output() -> None:
 
 def test_cli_refusal_signature_on_stdout_also_matches() -> None:
     """The signature is checked against combined stdout+stderr."""
-    r = classify_rescue_failure(
-        "PWM_CL", _AUTO_GRID_REFUSAL_STDERR, "", output_produced=False
-    )
+    r = classify_rescue_failure("PWM_CL", _AUTO_GRID_REFUSAL_STDERR, "", output_produced=False)
     assert r.category is RescueFailureCategory.CLI_REFUSED
 
 


### PR DESCRIPTION
## Summary

board-05's per-net **solo rescue loop has been dead since #3911** landed the auto-grid safety gate. The main route pass opts into the memory-forced 0.1mm coarse grid via `--allow-unsafe-grid` (with a long #3911 comment block), but `_RESCUE_CONFIG` never forwarded an equivalent flag -- so every rescue-stage `kct route` subprocess was refused at the #3911 gate and exited 1 *before routing anything*. A fresh regen reported `0/8 net(s) rescued`, every one mislabeled `no_output` ("crash / OOM before save") when in fact the CLI declined cleanly at a validation gate.

### Part 1 -- forward the opt-in to the rescue subprocess (Option A)
- Add `allow_unsafe_grid: bool = False` to `RescueConfig` (`partial_rescue.py`).
- Emit `--allow-unsafe-grid` from `build_rescue_command()` when set (applies to both the rescue and completion shapes; the flag is accepted by `kct route` regardless of engine).
- Set `allow_unsafe_grid=True` in board-05's `_RESCUE_CONFIG` with a comment cross-referencing #3911 and this issue.
- **Off by default**: boards that never opt into the unsafe grid emit byte-identical rescue argv (verified by the existing golden-argv test plus a new omit test).

### Part 2 -- stop the fabricated "crash / OOM" diagnosis
- Add `RescueFailureCategory.CLI_REFUSED`.
- Restructure `classify_rescue_failure()` so the `output_produced=False` branch inspects captured stdout/stderr for a CLI-refusal signature (open-ended tuple of AND-of-substrings, matching the existing `_ESCAPE_SIGNATURES` / `_BUDGET_SIGNATURES` pattern) **before** falling back to `NO_OUTPUT`. The auto-grid refusal now surfaces the router's own `Error: Auto-grid selected ...` line in the detail.
- A genuine crash/OOM (no signature present) still classifies as `NO_OUTPUT` -- regression-guarded.

## Test results
`uv run pytest tests/router/test_rescue_diagnostics.py tests/router/test_partial_rescue.py` -- **49 passed**. New cases: CLI_REFUSED classification (stdout + stderr), NO_OUTPUT regression guard, `format_rescue_reason_table` rendering of the new category, and `build_rescue_command` argv emit/omit (rescue + completion shapes).

## Notes
No overlap with open PR #4527 (issue #4476): that PR touches `design.py`'s step-6b batch-completion call and `build_rescue_command`'s `--complete-exclude-nets` forwarding only -- it does not touch `RescueConfig`'s fields, `_RESCUE_CONFIG`, or `rescue_diagnostics.py`. This change is additive regardless of merge order.

Closes #4528

🤖 Generated with [Claude Code](https://claude.com/claude-code)