### PR TITLE
fix(router/cpp): reinstall pairwise domain matrix after mid-session net-map/zone change

### DIFF
--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -982,6 +982,13 @@ class CppPathfinder:
         self._pairwise_cpp_payload: (
             tuple[list[int], list[list[float]], list] | Literal[False] | None
         ) = None
+        # Issue #4530: tracks whether the *currently cached* payload above has
+        # actually been pushed to the live ``Grid3D``.  ``Grid3D::pairwise_active_``
+        # only records "some matrix was ever installed on this grid", not "the
+        # current one is installed", so it cannot be used to gate the reinstall
+        # after a mid-session net-map / attach-zone change.  Cleared alongside
+        # ``_pairwise_cpp_payload`` in both invalidating setters.
+        self._pairwise_cpp_installed: bool = False
 
         # Issue #2929: Per-A*-call wall-clock instrumentation, mirroring the
         # Python pathfinder's instrumentation surface so callers can audit
@@ -1179,12 +1186,16 @@ class CppPathfinder:
         # Issue #4510: the C++ domain matrix / attach zones are keyed by net
         # ID, translated through this map -- rebuild them on the next validate.
         self._pairwise_cpp_payload = None
+        # Issue #4530: the rebuilt payload must be re-pushed to the C++ grid.
+        self._pairwise_cpp_installed = False
 
     def set_attach_zones(self, zones) -> None:
         """Install precomputed rated-footprint necking regions."""
         self._attach_zones = tuple(zones)
         # Issue #4510: invalidate the translated C++ zone payload.
         self._pairwise_cpp_payload = None
+        # Issue #4530: the rebuilt payload must be re-pushed to the C++ grid.
+        self._pairwise_cpp_installed = False
         if self._py_router is not None:
             self._py_router.set_attach_zones(self._attach_zones)
 
@@ -1201,9 +1212,11 @@ class CppPathfinder:
         means the setters are never called and the C++ validator behaves
         byte-identically to the pre-#4510 code path.  The translated payload is
         cached (it depends only on the table, the reverse net map and the
-        zones, all fixed for a routing session) and re-pushed whenever the grid
-        reports itself dormant -- which is exactly the case after the C++ grid
-        has been rebuilt underneath us.
+        zones) and re-pushed whenever either (a) the grid reports itself
+        dormant -- exactly the case after the C++ grid has been rebuilt
+        underneath us -- or (b) the cache was invalidated by a mid-session
+        net-map / attach-zone change (Issue #4530), tracked explicitly via
+        :attr:`_pairwise_cpp_installed`.
         """
         impl = getattr(self._grid, "_impl", None)
         if impl is None or not hasattr(impl, "set_pairwise_domains"):
@@ -1237,13 +1250,20 @@ class CppPathfinder:
             payload = (domains.net_to_domain, domains.matrix, cpp_zones)
             self._pairwise_cpp_payload = payload
 
-        # ``pairwise_active`` is False on a freshly-built grid, so this both
-        # installs on first use and reinstalls after a grid rebuild -- without
-        # re-pushing the matrix on every single validation call.
-        if not impl.pairwise_active:
+        # ``pairwise_active`` is False on a freshly-built grid, so it installs
+        # on first use and reinstalls after a grid rebuild.  But it latches
+        # True once any matrix is pushed and never resets on the same grid, so
+        # it cannot detect a payload rebuilt after a mid-session invalidation
+        # (Issue #4530).  ``_pairwise_cpp_installed`` closes that gap: it is
+        # cleared by both invalidating setters and set True only once the
+        # freshly-(re)built payload has been pushed -- so a rebuilt payload is
+        # re-pushed even while ``pairwise_active`` is already True, without
+        # re-pushing on every single validation call.
+        if not impl.pairwise_active or not self._pairwise_cpp_installed:
             net_to_domain, matrix, cpp_zones = payload
             impl.set_pairwise_domains(net_to_domain, matrix)
             impl.set_attach_zones(cpp_zones)
+            self._pairwise_cpp_installed = True
 
     def _resolve_partner_net_id(self, net_name: str) -> int | None:
         """Look up the integer net id of the diff-pair partner of *net_name*.

--- a/tests/router/test_pairwise_cpp_parity.py
+++ b/tests/router/test_pairwise_cpp_parity.py
@@ -510,6 +510,153 @@ def test_backend_sync_is_noop_without_voltage_map() -> None:
 
 
 @requires_cpp
+def test_backend_reinstalls_domains_after_net_id_remap() -> None:
+    """Issue #4530: a net-id remap mid-session must re-push the rebuilt payload.
+
+    ``Grid3D::pairwise_active_`` latches ``True`` after the first install and
+    never resets on the same grid, so before the fix the second (rebuilt)
+    payload was silently never pushed -- the new ids reported ``0.0`` and the
+    stale old ids kept their phantom widening.  This mirrors repro case 1 in the
+    issue body.
+    """
+    py_grid, rules = _backend_grid_and_rules()
+    rules.pairwise_clearance = _table()
+    cpp_grid = CppGrid.from_routing_grid(py_grid)
+    backend = CppPathfinder(cpp_grid, rules, diagonal_routing=True)
+
+    backend.set_net_name_to_id({"/AC_LINE": 1, "/GND": 2})
+    backend._sync_pairwise_domains_to_cpp()
+    assert cpp_grid._impl.pairwise_active is True
+    assert cpp_grid._impl.pairwise_required_clearance(1, 2) == pytest.approx(
+        IEC_150V_PD2_IIIA_MM
+    )
+
+    # Renumber the same nets: the rebuilt payload must reach the C++ grid even
+    # though ``pairwise_active`` is already ``True`` from the first push.
+    backend.set_net_name_to_id({"/AC_LINE": 7, "/GND": 8})
+    backend._sync_pairwise_domains_to_cpp()
+
+    # New ids now carry the widening (this is the assertion that fails today,
+    # returning 0.0 instead of 1.6).
+    assert cpp_grid._impl.pairwise_required_clearance(7, 8) == pytest.approx(
+        IEC_150V_PD2_IIIA_MM
+    )
+    # And the old ids no longer report phantom widening (the stale-values half).
+    assert cpp_grid._impl.pairwise_required_clearance(1, 2) == pytest.approx(0.0)
+
+
+@requires_cpp
+def test_backend_reinstalls_attach_zones_after_mid_session_change() -> None:
+    """Issue #4530: recomputing attach zones after a validate must re-push them.
+
+    ``set_attach_zones()`` has its own invalidation path independent of the
+    net-map setter; a zone recomputed mid-session (after the first sync has
+    already latched ``pairwise_active``) must still install on the live grid.
+    """
+    py_grid, rules = _backend_grid_and_rules()
+    rules.pairwise_clearance = _table()
+    cpp_grid = CppGrid.from_routing_grid(py_grid)
+    backend = CppPathfinder(cpp_grid, rules, diagonal_routing=True)
+    backend.set_net_name_to_id(dict(NET_NAMES))
+
+    backend.set_attach_zones((AttachZone(0.0, -1.0, 5.0, 1.0, frozenset({"AC_LINE", "GND"})),))
+    backend._sync_pairwise_domains_to_cpp()
+    assert cpp_grid._impl.pairwise_active is True
+    assert cpp_grid._impl.attach_zone_exempts(2.5, 0.0, HV_NET, LV_NET) is True
+    assert cpp_grid._impl.attach_zone_exempts(15.0, 15.0, HV_NET, LV_NET) is False
+
+    # Move the rated footprint's zone; the new zone must install even though
+    # ``pairwise_active`` latched ``True`` on the first sync.
+    backend.set_attach_zones((AttachZone(10.0, 10.0, 20.0, 20.0, frozenset({"AC_LINE", "GND"})),))
+    backend._sync_pairwise_domains_to_cpp()
+    assert cpp_grid._impl.attach_zone_count == 1
+    assert cpp_grid._impl.attach_zone_exempts(15.0, 15.0, HV_NET, LV_NET) is True
+    assert cpp_grid._impl.attach_zone_exempts(2.5, 0.0, HV_NET, LV_NET) is False
+
+
+class _CountingImpl:
+    """Wraps the real C++ grid impl to count pairwise/zone push calls."""
+
+    def __init__(self, real) -> None:
+        self._real = real
+        self.domain_pushes = 0
+        self.zone_pushes = 0
+
+    @property
+    def pairwise_active(self):
+        return self._real.pairwise_active
+
+    def set_pairwise_domains(self, net_to_domain, matrix):
+        self.domain_pushes += 1
+        return self._real.set_pairwise_domains(net_to_domain, matrix)
+
+    def set_attach_zones(self, zones):
+        self.zone_pushes += 1
+        return self._real.set_attach_zones(zones)
+
+
+@requires_cpp
+def test_backend_sync_pushes_once_per_distinct_payload() -> None:
+    """Issue #4530 steady state: repeated syncs push exactly once per payload.
+
+    Guards against a naive fix that unconditionally re-pushes on every
+    ``_sync_pairwise_domains_to_cpp()`` (i.e. every ``validate_route``), which
+    would regress the hot path ``Autorouter._prepare_routing()`` exercises with
+    an identical net map on every pass.
+    """
+    py_grid, rules = _backend_grid_and_rules()
+    rules.pairwise_clearance = _table()
+    cpp_grid = CppGrid.from_routing_grid(py_grid)
+    backend = CppPathfinder(cpp_grid, rules, diagonal_routing=True)
+    # Intercept the C++ push calls after construction so the counter sees only
+    # the syncs under test.
+    spy = _CountingImpl(cpp_grid._impl)
+    cpp_grid._impl = spy
+    backend.set_net_name_to_id(dict(NET_NAMES))
+
+    backend._sync_pairwise_domains_to_cpp()
+    backend._sync_pairwise_domains_to_cpp()
+    backend._sync_pairwise_domains_to_cpp()
+    assert spy.domain_pushes == 1
+    assert spy.zone_pushes == 1
+
+    # A materially different mapping triggers exactly one additional push, not
+    # one per subsequent sync.
+    backend.set_net_name_to_id({"/AC_LINE": 7, "/GND": 8})
+    backend._sync_pairwise_domains_to_cpp()
+    backend._sync_pairwise_domains_to_cpp()
+    assert spy.domain_pushes == 2
+    assert spy.zone_pushes == 2
+
+
+@requires_cpp
+def test_backend_sync_dormant_payload_never_touches_grid() -> None:
+    """Issue #4530: a rebuilt-but-``False`` payload must not flip the flag.
+
+    When there is no widening pair (all nets equal potential), the payload
+    resolves to ``False`` and the early-return must leave both the C++ grid and
+    ``_pairwise_cpp_installed`` untouched -- byte-identical pre-#4510 behaviour.
+    """
+    py_grid, rules = _backend_grid_and_rules()
+    # A flat voltage map -> build_cpp_domain_matrix returns None -> payload False.
+    rules.pairwise_clearance = build_pairwise_clearance_table(
+        {"/AC_LINE": 0.0, "/GND": 0.0}, dru=DRU
+    )
+    cpp_grid = CppGrid.from_routing_grid(py_grid)
+    backend = CppPathfinder(cpp_grid, rules, diagonal_routing=True)
+    spy = _CountingImpl(cpp_grid._impl)
+    cpp_grid._impl = spy
+    backend.set_net_name_to_id({"/AC_LINE": 1, "/GND": 2})
+
+    backend._sync_pairwise_domains_to_cpp()
+    assert backend._pairwise_cpp_payload is False
+    assert backend._pairwise_cpp_installed is False
+    assert spy.domain_pushes == 0
+    assert spy.zone_pushes == 0
+    assert spy.pairwise_active is False
+
+
+@requires_cpp
 def test_backend_validate_route_rejects_hv_trace_beside_lv_pad() -> None:
     """End-to-end: the C++ matrix catches a pad the Python post-check cannot.
 

--- a/tests/router/test_pairwise_cpp_parity.py
+++ b/tests/router/test_pairwise_cpp_parity.py
@@ -527,9 +527,7 @@ def test_backend_reinstalls_domains_after_net_id_remap() -> None:
     backend.set_net_name_to_id({"/AC_LINE": 1, "/GND": 2})
     backend._sync_pairwise_domains_to_cpp()
     assert cpp_grid._impl.pairwise_active is True
-    assert cpp_grid._impl.pairwise_required_clearance(1, 2) == pytest.approx(
-        IEC_150V_PD2_IIIA_MM
-    )
+    assert cpp_grid._impl.pairwise_required_clearance(1, 2) == pytest.approx(IEC_150V_PD2_IIIA_MM)
 
     # Renumber the same nets: the rebuilt payload must reach the C++ grid even
     # though ``pairwise_active`` is already ``True`` from the first push.
@@ -538,9 +536,7 @@ def test_backend_reinstalls_domains_after_net_id_remap() -> None:
 
     # New ids now carry the widening (this is the assertion that fails today,
     # returning 0.0 instead of 1.6).
-    assert cpp_grid._impl.pairwise_required_clearance(7, 8) == pytest.approx(
-        IEC_150V_PD2_IIIA_MM
-    )
+    assert cpp_grid._impl.pairwise_required_clearance(7, 8) == pytest.approx(IEC_150V_PD2_IIIA_MM)
     # And the old ids no longer report phantom widening (the stale-values half).
     assert cpp_grid._impl.pairwise_required_clearance(1, 2) == pytest.approx(0.0)
 


### PR DESCRIPTION
Closes #4530

## Problem

`CppPathfinder._sync_pairwise_domains_to_cpp()` gated the C++-side install of the (re)built pairwise domain matrix + attach zones on `impl.pairwise_active`. But `Grid3D::pairwise_active_` latches `True` after the first non-empty matrix install and never resets on the same `Grid3D` instance (short of a full grid rebuild). So a payload rebuilt after a net-map or attach-zone invalidation was silently never pushed: remapped net ids reported `0.0` clearance while the stale old ids kept phantom widening. The Python side over-interpreted `pairwise_active` as "the *current* matrix is installed" when it only means "some matrix was ever installed".

## Fix (Python only, no C++ changes)

- Add `self._pairwise_cpp_installed = False` in `__init__`.
- Clear it alongside the existing `_pairwise_cpp_payload = None` reset in both `set_net_name_to_id()` and `set_attach_zones()`.
- Change the guard to `if not impl.pairwise_active or not self._pairwise_cpp_installed:` and set the flag `True` after pushing.

The guard now fires on either a dormant grid (rebuild) or a not-yet-installed rebuilt payload (mid-session change), while still pushing only once per distinct payload. The dormant path (payload resolves to `False`, no voltage map) returns early before touching `impl` and leaves the flag `False`, matching byte-identical pre-#4510 behaviour.

## Tests

Four new regression tests in `tests/router/test_pairwise_cpp_parity.py`:
1. `test_backend_reinstalls_domains_after_net_id_remap` — mirrors the issue repro: after remapping `{/AC_LINE: 1, /GND: 2}` -> `{7, 8}`, the new pair reports `1.6` and the old pair reports `0.0`.
2. `test_backend_reinstalls_attach_zones_after_mid_session_change` — the independent `set_attach_zones()` invalidation path.
3. `test_backend_sync_pushes_once_per_distinct_payload` — steady-state: repeated syncs push exactly once per payload (guards against a naive always-repush fix).
4. `test_backend_sync_dormant_payload_never_touches_grid` — the `False`-payload path leaves grid and flag untouched.

Tests 1-3 fail against the old guard and pass after the fix; test 4 passes both ways (verifying unchanged dormant behaviour). Full file: `31 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)