### PR TITLE
ci: gate board end-to-end jobs on plane-net completion (#4531)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -995,6 +995,20 @@ jobs:
           cp -r /tmp/board00-ci/. /tmp/board00-staging/00-simple-led/output/
           uv run kct board-metrics /tmp/board00-staging/00-simple-led
 
+      - name: Assert plane-net completion (no floating pads, #4531)
+        # Gate on the RAW total_unconnected_pads of the freshly-routed PCB.
+        # A floating power/plane pad (e.g. a VCC pin with no track and no
+        # reachable pour) passes DRC/LVS/router "N/N nets" but is
+        # electrically broken -- and blocking_incomplete_count would
+        # name-exclude it (power/plane nets), so this gate uses the raw
+        # count instead (see scripts/ci/check_net_status.py). Board 05 is
+        # intentionally NOT gated here; it keeps its own dedicated
+        # check_board_05_blocking.py gate (#3775/#3766/#3829).
+        run: |
+          set -euo pipefail
+          uv run python scripts/ci/check_net_status.py \
+            /tmp/board00-ci/simple_led_routed.kicad_pcb
+
       - name: Assert artifacts + lvs.json + board.json fields
         # The gate-side asserter: presence of every required artifact,
         # lvs.json clean=true, and board.json status=ok / drc_violations=0
@@ -1074,6 +1088,15 @@ jobs:
           mkdir -p /tmp/board01-staging/01-voltage-divider/output
           cp -r /tmp/board01-ci/. /tmp/board01-staging/01-voltage-divider/output/
           uv run kct board-metrics /tmp/board01-staging/01-voltage-divider
+
+      - name: Assert plane-net completion (no floating pads, #4531)
+        # See board-00's step: raw total_unconnected_pads gate; catches a
+        # floating power/plane pad that blocking_incomplete_count would
+        # name-exclude (scripts/ci/check_net_status.py).
+        run: |
+          set -euo pipefail
+          uv run python scripts/ci/check_net_status.py \
+            /tmp/board01-ci/voltage_divider_routed.kicad_pcb
 
       - name: Assert artifacts + lvs.json + board.json fields
         # Reuse the generalized board-00 asserter with --stem so it derives
@@ -1161,6 +1184,15 @@ jobs:
           mkdir -p /tmp/board02-staging/02-charlieplex-led/output
           cp -r /tmp/board02-ci/. /tmp/board02-staging/02-charlieplex-led/output/
           uv run kct board-metrics /tmp/board02-staging/02-charlieplex-led
+
+      - name: Assert plane-net completion (no floating pads, #4531)
+        # See board-00's step: raw total_unconnected_pads gate; catches a
+        # floating power/plane pad that blocking_incomplete_count would
+        # name-exclude (scripts/ci/check_net_status.py).
+        run: |
+          set -euo pipefail
+          uv run python scripts/ci/check_net_status.py \
+            /tmp/board02-ci/charlieplex_3x3_routed.kicad_pcb
 
       - name: Assert artifacts + lvs.json + board.json fields
         # Reuse the generalized board-00 asserter with --stem so it derives
@@ -1288,6 +1320,17 @@ jobs:
           mkdir -p /tmp/board03-staging/03-usb-joystick/output
           cp -r /tmp/board03-ci/. /tmp/board03-staging/03-usb-joystick/output/
           uv run kct board-metrics /tmp/board03-staging/03-usb-joystick
+
+      - name: Assert plane-net completion (no floating pads, #4531)
+        # THIS is the board from the #4531 repro: PR #4525 committed a
+        # board-03 artifact with J2.1 (VCC) floating -- no track, no
+        # reachable pour -- and all 16 CI checks passed. This raw
+        # total_unconnected_pads gate is the assertion that would have
+        # red-lighted that break (scripts/ci/check_net_status.py).
+        run: |
+          set -euo pipefail
+          uv run python scripts/ci/check_net_status.py \
+            /tmp/board03-ci/usb_joystick_routed.kicad_pcb
 
       - name: Assert artifacts + lvs.json clean (LVS-only)
         # --lvs-only: assert artifact presence + lvs.json clean=true +
@@ -1425,6 +1468,15 @@ jobs:
           cp -r /tmp/board06-ci/. /tmp/board06-staging/06-diffpair-test/output/
           uv run kct board-metrics /tmp/board06-staging/06-diffpair-test
 
+      - name: Assert plane-net completion (no floating pads, #4531)
+        # See board-00's step: raw total_unconnected_pads gate; catches a
+        # floating power/plane pad that blocking_incomplete_count would
+        # name-exclude (scripts/ci/check_net_status.py).
+        run: |
+          set -euo pipefail
+          uv run python scripts/ci/check_net_status.py \
+            /tmp/board06-ci/diffpair_test_routed.kicad_pcb
+
       - name: Assert artifacts + LVS clean (#4012)
         # --lvs-only: assert lvs.json clean=true + board.json lvs_clean=true,
         # but NOT status:ok / drc_violations:0 (board 06 carries allowlisted
@@ -1558,6 +1610,20 @@ jobs:
           mkdir -p /tmp/board07-staging/07-matchgroup-test/output
           cp -r /tmp/board07-ci/. /tmp/board07-staging/07-matchgroup-test/output/
           uv run kct board-metrics /tmp/board07-staging/07-matchgroup-test
+
+      - name: Assert plane-net completion (known opens tolerated, #4531)
+        # Raw total_unconnected_pads gate (scripts/ci/check_net_status.py).
+        # Board 07 routes PARTIAL by design: 5 seed-invariant unroutable
+        # nets (#3438/#4012). --known-open-nets excludes THOSE nets' pads
+        # from the gated count while still failing on an unconnected pad on
+        # any OTHER net -- so a DIFFERENT net silently going open is still
+        # caught (tighter than raising --max-unconnected to their pad
+        # count). The set mirrors the --lvs-known-opens above.
+        run: |
+          set -euo pipefail
+          uv run python scripts/ci/check_net_status.py \
+            --known-open-nets "DQ3,DQ4,MIPI_DAT0_N,TMDS_D0_N,TMDS_D1_N" \
+            /tmp/board07-ci/matchgroup_test_routed.kicad_pcb
 
       - name: Assert artifacts + honest known-opens LVS state (#4012)
         # --lvs-known-opens: lvs.json must be present, clean=false, NOT
@@ -1880,6 +1946,15 @@ jobs:
           mkdir -p /tmp/board04-staging/04-stm32-devboard/output
           cp -r /tmp/board04-ci/. /tmp/board04-staging/04-stm32-devboard/output/
           uv run kct board-metrics /tmp/board04-staging/04-stm32-devboard
+
+      - name: Assert plane-net completion (no floating pads, #4531)
+        # See board-00's step: raw total_unconnected_pads gate; catches a
+        # floating power/plane pad that blocking_incomplete_count would
+        # name-exclude (scripts/ci/check_net_status.py).
+        run: |
+          set -euo pipefail
+          uv run python scripts/ci/check_net_status.py \
+            /tmp/board04-ci/stm32_devboard_routed.kicad_pcb
 
       - name: Assert artifacts + lvs.json clean (LVS-only)
         # --lvs-only: assert artifact presence + lvs.json clean=true +

--- a/scripts/ci/check_net_status.py
+++ b/scripts/ci/check_net_status.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Plane-net / floating-pad completion gate for CI (issue #4531).
+
+A floating power pad -- e.g. board-03's ``J2.1`` (VCC) with no track and no
+reachable pour -- silently passed ALL 16 CI checks (PR #4525): the router's
+"13/13 signal nets" excludes plane nets, geometric DRC excludes connectivity
+by design, copper LVS's ``bound_pad_count`` is unmoved by a zone-bonded pad
+going floating, and ``test_connectivity.py``'s single scalar re-baselined the
+break as three more fill islands.  The information was there --
+``kct net-status`` names the pad exactly -- but nothing asserted on it.  This
+gate wires that assertion into every board's end-to-end job.
+
+CRITICAL: this gate uses the RAW, UNFILTERED connectivity counts
+-------------------------------------------------------------------
+``NetStatusResult.blocking_incomplete_count`` (and ``blocking_incomplete``)
+deliberately drop any net whose ``is_advisory_incomplete`` is ``True``
+(:mod:`kicad_tools.analysis.net_status`, ~lines 136-163).  That property
+returns ``True`` when ``net_type`` is ``"plane"`` or ``"power"`` -- and
+``net_type`` is derived PURELY FROM THE NET NAME (any name starting with
+``+``/``-``/``V`` or exactly ``GND``/``AGND``/``DGND``/``VCC``/``VDD``/``VSS``),
+NOT from whether the net actually has a zone or filled copper.  So the exact
+bug #4531 reports -- a net literally named ``VCC`` with ZERO connected pads
+and no reachable pour -- is classified advisory and would be SILENTLY EXCLUDED
+from ``blocking_incomplete_count``.  A gate built on that metric (the way
+``scripts/ci/check_board_05_blocking.py`` is) would NOT catch this regression.
+
+This gate therefore asserts on ``NetStatusResult.total_unconnected_pads`` --
+the raw pad-centric count, exactly the signal ``kct net-status``'s own CLI
+exit code already uses (``src/kicad_tools/cli/net_status_cmd.py``: nonzero exit
+whenever ``incomplete_count`` or ``unrouted_count`` is nonzero).  That exit
+code was simply never wired into CI, which is why the reporter's ``kct
+net-status`` repro surfaced the break immediately while every other signal
+missed it.
+
+Connectivity model: STRICT (real copper geometry, matches KiCad)
+----------------------------------------------------------------
+This gate runs ``NetStatusAnalyzer(..., strict=True)`` so connectivity is
+decided by real geometric copper contact (shapely polygon intersection),
+matching KiCad's connectivity engine / ``kicad-cli pcb drc`` (Issue #4176).
+The DEFAULT 0.01mm endpoint-proximity model UNDER-detects pad<->pour bonds and
+would report FALSE opens on genuinely poured-connected pads (board 06's
+GND/+1V2/VBUS_USB: 16 false opens under the default model, 0 under strict /
+kicad-cli).  strict mode is both sound (no false positives on pour-connected
+boards) and complete (a genuine float -- a pad with no copper reaching it --
+is unconnected under either model, so the #4531 J2.1-VCC break still fails).
+shapely is a CORE dependency (Issue #3824), so strict mode is always available.
+
+Note on board 05: the ``check_board_05_blocking.py`` gate has the SAME
+``blocking_incomplete_count`` blind spot described above (a floating pad on a
+net named e.g. ``PHASE_A``/``ISENSE_A+`` would not trip the "power" name
+pattern, so the gap is narrower there -- but a net renamed to start with
+``V``/``+``/``-`` or matching the power-name list would reproduce it).  Fixing
+that gate is OUT OF SCOPE for #4531 (its ``<= 11`` threshold is load-bearing
+for #3775/#3766/#3829); board 05 keeps its own dedicated gate and is NOT gated
+by this script.
+
+``--known-open-nets NET[,NET...]``
+----------------------------------
+Board 07 ("matchgroup-test") routes PARTIAL by design: 5 seed-invariant
+unroutable nets (#3438/#4012: ``DQ3,DQ4,MIPI_DAT0_N,TMDS_D0_N,TMDS_D1_N``).
+Passing those via ``--known-open-nets`` excludes THEIR unconnected pads from
+the gated count while still failing on an unconnected pad appearing on ANY
+OTHER net -- so a *different* net silently going open is still caught (tighter
+than merely raising ``--max-unconnected`` to their pad count, which would let
+a substituted open slip through).  Mirrors
+``check_board_00_e2e.py``'s ``assert_lvs_known_opens`` intent.
+
+Exit codes (mirrors ``scripts/ci/check_board_05_blocking.py`` /
+``check_routed_drc.py``):
+    0 -- Unconnected-pad count within threshold (job passes).
+    1 -- Tool failure (file missing, PCB parse error, etc.).
+    2 -- Unconnected pads exceed threshold (regression -- job fails).
+
+GitHub-Actions annotations (``::error file=...::``) are emitted to stdout so
+the PR Files-changed view surfaces a regression inline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+DEFAULT_MAX_UNCONNECTED = 0
+
+
+def annotate_error(file: str, message: str) -> None:
+    """Emit a GitHub-Actions ``::error file=...::`` annotation."""
+    print(f"::error file={file}::{message}", flush=True)
+
+
+def annotate_warning(file: str, message: str) -> None:
+    """Emit a GitHub-Actions ``::warning file=...::`` annotation."""
+    print(f"::warning file={file}::{message}", flush=True)
+
+
+def analyze_unconnected(pcb_path: Path) -> tuple[int, list[tuple[str, list[str]]]]:
+    """Load the routed PCB and return its raw unconnected-pad status.
+
+    Uses the RAW, unfiltered :class:`NetStatusResult` view -- explicitly NOT
+    ``blocking_incomplete_count`` (see the module docstring's pitfall note).
+
+    Args:
+        pcb_path: Path to a routed ``.kicad_pcb`` file.
+
+    Returns:
+        Tuple ``(total_unconnected_pads, per_net)`` where
+        ``total_unconnected_pads`` is
+        ``NetStatusResult.total_unconnected_pads`` (the raw pad-centric count)
+        and ``per_net`` is a sorted list of ``(net_name, [REF.PAD @ (x, y),
+        ...])`` for every net carrying at least one unconnected pad, for
+        diagnostic output.
+
+    Raises:
+        RuntimeError: If the PCB cannot be loaded or analyzed.
+    """
+    # Imported lazily so ``--help`` works even outside the ``uv run``
+    # environment where ``kicad_tools`` is importable.
+    from kicad_tools.analysis.net_status import NetStatusAnalyzer
+
+    # ``strict=True`` decides connectivity by REAL geometric copper contact
+    # (shapely polygon intersection), which matches KiCad's connectivity engine
+    # / ``kicad-cli pcb drc`` (Issue #4176).  This is deliberate and load-
+    # bearing for THIS gate: the DEFAULT 0.01mm endpoint-proximity model
+    # UNDER-detects pad<->pour bonds -- a pad whose real copper overlaps a pour
+    # but whose reference point is not within 0.01mm of a trace endpoint is
+    # reported as a FALSE open.  Board 06 ("diffpair-test") is the concrete
+    # case: its GND/+1V2/VBUS_USB pads are genuinely poured-connected
+    # (kicad-cli DRC: 0 unconnected), yet the default model reports 16 false
+    # opens.  strict mode reports 0 there while STILL catching a genuine float
+    # (a pad with no copper reaching it is unconnected under either model), so
+    # it is both sound (no false positives on pour-connected boards) and
+    # complete (the #4531 J2.1-VCC break still fails).  shapely is a CORE
+    # dependency (Issue #3824), so strict mode is always available in CI.
+    try:
+        result = NetStatusAnalyzer(str(pcb_path), strict=True).analyze()
+    except Exception as e:  # noqa: BLE001 -- surface any load/parse failure as a tool error
+        raise RuntimeError(f"failed to analyze {pcb_path}: {e}") from e
+
+    per_net: list[tuple[str, list[str]]] = []
+    for net in result.nets:
+        if net.unconnected_count <= 0:
+            continue
+        pads = [
+            f"{p.full_name} @ ({p.position[0]:.2f}, {p.position[1]:.2f})"
+            for p in net.unconnected_pads
+        ]
+        per_net.append((net.net_name, pads))
+    per_net.sort(key=lambda item: item[0])
+
+    return result.total_unconnected_pads, per_net
+
+
+def check_pcb(
+    pcb_path: Path,
+    max_unconnected: int,
+    known_open_nets: set[str] | None = None,
+) -> tuple[int, str]:
+    """Compare a routed PCB's unconnected-pad count to the threshold.
+
+    Args:
+        pcb_path: Path to the routed ``.kicad_pcb`` file.
+        max_unconnected: Maximum allowed unconnected pads on nets NOT in
+            ``known_open_nets``.
+        known_open_nets: Nets permitted to carry unconnected pads (board 07's
+            documented #3438 opens).  Their pads are excluded from the gated
+            count, but an unconnected pad on any OTHER net still fails.
+
+    Returns:
+        ``(exit_code, message)``.  ``exit_code`` is 0 (pass), 1 (tool
+        failure), or 2 (regression).  ``message`` is a human-readable summary
+        suitable for stdout and GitHub annotations.
+    """
+    known_open_nets = known_open_nets or set()
+
+    if not pcb_path.is_file():
+        return 1, f"routed PCB not found: {pcb_path}"
+
+    try:
+        total_unconnected, per_net = analyze_unconnected(pcb_path)
+    except RuntimeError as e:
+        return 1, str(e)
+
+    # Split offending nets into gated (must be zero) vs tolerated (known open).
+    gated: list[tuple[str, list[str]]] = [
+        (name, pads) for name, pads in per_net if name not in known_open_nets
+    ]
+    tolerated: list[tuple[str, list[str]]] = [
+        (name, pads) for name, pads in per_net if name in known_open_nets
+    ]
+    gated_pad_count = sum(len(pads) for _name, pads in gated)
+
+    # Always surface the measured numbers on plain stdout, BEFORE the verdict,
+    # so CI logs record the real figures on every path (pass, or regression
+    # with exit 2) -- matching check_board_05_blocking.py's convention.
+    known_suffix = (
+        f" (known-open nets excluded: {', '.join(sorted(known_open_nets))})"
+        if known_open_nets
+        else ""
+    )
+    lines = [
+        f"MEASURED total_unconnected_pads = {total_unconnected} "
+        f"(threshold <= {max_unconnected} on non-known-open nets){known_suffix}"
+    ]
+    if per_net:
+        lines.append("  unconnected pads by net:")
+        for name, pads in per_net:
+            tag = " [known-open, tolerated]" if name in known_open_nets else ""
+            lines.append(f"    {name}{tag}: {len(pads)} unconnected")
+            for pad in pads:
+                lines.append(f"      - {pad}")
+    else:
+        lines.append("  (no unconnected pads)")
+    print("\n".join(lines), flush=True)
+
+    # A known-open net that is no longer open is an IMPROVEMENT, not a failure
+    # -- surface it as a warning so reviewers can tighten --known-open-nets
+    # (mirrors check_board_00_e2e's "graduate this job" note).
+    open_net_names = {name for name, _pads in per_net}
+    no_longer_open = sorted(known_open_nets - open_net_names)
+
+    if gated_pad_count <= max_unconnected:
+        offenders = (
+            f" [tolerated known-open nets: {', '.join(name for name, _ in tolerated)}]"
+            if tolerated
+            else ""
+        )
+        graduate = (
+            f" NOTE: known-open net(s) {', '.join(no_longer_open)} are no longer "
+            f"open -- consider tightening --known-open-nets."
+            if no_longer_open
+            else ""
+        )
+        return (
+            0,
+            f"OK: {pcb_path} -- {gated_pad_count} unconnected pad(s) on gated nets "
+            f"(threshold <= {max_unconnected}).{offenders}{graduate}",
+        )
+
+    offending_names = ", ".join(name for name, _ in gated)
+    return (
+        2,
+        f"Floating-pad regression: {gated_pad_count} unconnected pad(s) on "
+        f"{len(gated)} net(s) ({offending_names}) exceeds --max-unconnected="
+        f"{max_unconnected}. This is the exact class of break #4531 gates: a pad "
+        f"with no track and no reachable pour that passes DRC/LVS/router "
+        f"'N/N nets' but is electrically floating. NOTE: this gate uses the RAW "
+        f"total_unconnected_pads (NOT blocking_incomplete_count, which "
+        f"name-excludes power/plane nets -- the very bug class here). Either fix "
+        f"the routing (kct net-status names the pad) or, if a NEW net is a "
+        f"legitimate designed open, add it to --known-open-nets with reviewer "
+        f"sign-off.",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="check_net_status",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "pcb",
+        help="Path to the routed .kicad_pcb file to check.",
+    )
+    parser.add_argument(
+        "--max-unconnected",
+        type=int,
+        default=DEFAULT_MAX_UNCONNECTED,
+        help=(
+            "Maximum allowed unconnected pads on nets NOT in --known-open-nets "
+            f"before the gate fails (default: {DEFAULT_MAX_UNCONNECTED}). Uses "
+            "the RAW NetStatusResult.total_unconnected_pads, NOT "
+            "blocking_incomplete_count (which name-excludes power/plane nets -- "
+            "the #4531 bug class)."
+        ),
+    )
+    parser.add_argument(
+        "--known-open-nets",
+        default=None,
+        metavar="NET[,NET...]",
+        help=(
+            "Comma-separated net names permitted to carry unconnected pads "
+            "(e.g. board 07's 5 seed-invariant #3438 opens). Their pads are "
+            "excluded from the gated count, but an unconnected pad on any OTHER "
+            "net still fails -- so a different net silently going open is still "
+            "caught."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    if args.max_unconnected < 0:
+        print("::error::--max-unconnected must be a non-negative integer", flush=True)
+        return 1
+
+    known_open_nets: set[str] = set()
+    if args.known_open_nets:
+        known_open_nets = {n.strip() for n in args.known_open_nets.split(",") if n.strip()}
+        if not known_open_nets:
+            print("::error::--known-open-nets was given an empty net list", flush=True)
+            return 1
+
+    pcb_path = Path(args.pcb)
+    exit_code, message = check_pcb(pcb_path, args.max_unconnected, known_open_nets)
+
+    if exit_code == 0:
+        print(message, flush=True)
+    else:
+        annotate_error(str(pcb_path), message)
+        print(
+            f"\nGate failed (exit {exit_code}). See ::error:: annotation above.",
+            flush=True,
+        )
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_net_status.py
+++ b/tests/test_check_net_status.py
@@ -163,9 +163,7 @@ def test_known_open_no_longer_open_passes_with_note(tmp_path, monkeypatch, capsy
     helper = _load_helper()
     pcb = _write_pcb(tmp_path)
     monkeypatch.setattr(helper, "analyze_unconnected", lambda _p: (0, []))
-    exit_code, message = helper.check_pcb(
-        pcb, max_unconnected=0, known_open_nets={"DQ3"}
-    )
+    exit_code, message = helper.check_pcb(pcb, max_unconnected=0, known_open_nets={"DQ3"})
     assert exit_code == 0
     assert "no longer" in message.lower()
 
@@ -209,12 +207,8 @@ def _floating_power_net_result():
         net_number=1,
         net_name="VCC",
         total_pads=2,
-        connected_pads=[
-            PadInfo("U1", "1", (10.0, 10.0), is_connected=True, layers=["F.Cu"])
-        ],
-        unconnected_pads=[
-            PadInfo("J2", "1", (2.5, 35.0), is_connected=False, layers=["F.Cu"])
-        ],
+        connected_pads=[PadInfo("U1", "1", (10.0, 10.0), is_connected=True, layers=["F.Cu"])],
+        unconnected_pads=[PadInfo("J2", "1", (2.5, 35.0), is_connected=False, layers=["F.Cu"])],
     )
     result = NetStatusResult(nets=[vcc], total_nets=1)
     return result

--- a/tests/test_check_net_status.py
+++ b/tests/test_check_net_status.py
@@ -1,0 +1,312 @@
+"""Tests for the plane-net / floating-pad completion CI gate (issue #4531).
+
+``scripts/ci/check_net_status.py`` loads a freshly-routed PCB and asserts its
+RAW ``NetStatusResult.total_unconnected_pads`` is within ``--max-unconnected``
+(default 0), tolerating an explicit ``--known-open-nets`` list (board 07's 5
+seed-invariant #3438 opens).
+
+The critical property under test is the ``is_advisory_incomplete``
+NAME-PATTERN pitfall documented in the script: a net literally named ``VCC``
+(or ``GND``/``+3V3``/...) with a floating pad is classified
+``is_advisory_incomplete=True`` and DROPPED from
+``blocking_incomplete_count`` -- the exact silent-pass the #4531 repro hit.
+``test_gate_fails_on_floating_power_named_pad`` builds a real
+``NetStatusResult`` for such a net and proves this gate (which uses the raw
+count) fails on it even while ``blocking_incomplete_count`` is 0, so this bug
+class cannot silently regress through the new gate itself.
+
+Threshold/exit-code logic is exercised against a synthetic ``per_net``
+(``analyze_unconnected`` monkeypatched) so the comparison / exit-code
+behaviour is verified without needing a real broken route.
+
+The script is loaded via importlib (it lives under ``scripts/ci/`` outside the
+installed package), mirroring ``tests/test_check_board_05_blocking.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HELPER_SCRIPT_PATH = REPO_ROOT / "scripts" / "ci" / "check_net_status.py"
+
+
+def _load_helper():
+    spec = importlib.util.spec_from_file_location("check_net_status", HELPER_SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_net_status"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_pcb(tmp_path: Path) -> Path:
+    pcb = tmp_path / "board_routed.kicad_pcb"
+    pcb.write_text("(kicad_pcb)")
+    return pcb
+
+
+# ---------------------------------------------------------------------------
+# Threshold / exit-code logic (analyze_unconnected monkeypatched)
+# ---------------------------------------------------------------------------
+
+
+def test_default_threshold_is_zero() -> None:
+    helper = _load_helper()
+    assert helper.DEFAULT_MAX_UNCONNECTED == 0
+
+
+def test_passes_on_fully_connected_board(tmp_path, monkeypatch) -> None:
+    helper = _load_helper()
+    pcb = _write_pcb(tmp_path)
+    monkeypatch.setattr(helper, "analyze_unconnected", lambda _p: (0, []))
+    exit_code, message = helper.check_pcb(pcb, max_unconnected=0)
+    assert exit_code == 0
+    assert "0 unconnected pad(s)" in message
+
+
+def test_fails_on_single_floating_pad(tmp_path, monkeypatch) -> None:
+    helper = _load_helper()
+    pcb = _write_pcb(tmp_path)
+    monkeypatch.setattr(
+        helper,
+        "analyze_unconnected",
+        lambda _p: (1, [("VCC", ["J2.1 @ (2.50, 35.00)"])]),
+    )
+    exit_code, message = helper.check_pcb(pcb, max_unconnected=0)
+    assert exit_code == 2
+    assert "regression" in message.lower()
+    assert "VCC" in message
+
+
+def test_max_unconnected_tolerance_allows_up_to_bound(tmp_path, monkeypatch) -> None:
+    helper = _load_helper()
+    pcb = _write_pcb(tmp_path)
+    monkeypatch.setattr(
+        helper,
+        "analyze_unconnected",
+        lambda _p: (2, [("NETA", ["U1.1 @ (0.00, 0.00)", "U2.1 @ (1.00, 1.00)"])]),
+    )
+    # exactly at the bound -> pass
+    assert helper.check_pcb(pcb, max_unconnected=2)[0] == 0
+    # one below the bound -> fail
+    assert helper.check_pcb(pcb, max_unconnected=1)[0] == 2
+
+
+def test_missing_file_is_tool_error(tmp_path) -> None:
+    helper = _load_helper()
+    missing = tmp_path / "does_not_exist.kicad_pcb"
+    exit_code, message = helper.check_pcb(missing, max_unconnected=0)
+    assert exit_code == 1
+    assert "not found" in message.lower()
+
+
+# ---------------------------------------------------------------------------
+# --known-open-nets (board 07)
+# ---------------------------------------------------------------------------
+
+
+def test_known_open_nets_are_tolerated(tmp_path, monkeypatch) -> None:
+    helper = _load_helper()
+    pcb = _write_pcb(tmp_path)
+    monkeypatch.setattr(
+        helper,
+        "analyze_unconnected",
+        lambda _p: (
+            2,
+            [
+                ("DQ3", ["U1.5 @ (0.00, 0.00)"]),
+                ("TMDS_D0_N", ["U2.9 @ (1.00, 1.00)"]),
+            ],
+        ),
+    )
+    exit_code, message = helper.check_pcb(
+        pcb,
+        max_unconnected=0,
+        known_open_nets={"DQ3", "DQ4", "MIPI_DAT0_N", "TMDS_D0_N", "TMDS_D1_N"},
+    )
+    assert exit_code == 0
+    assert "0 unconnected pad(s) on gated nets" in message
+
+
+def test_new_open_on_different_net_still_fails_with_known_opens(tmp_path, monkeypatch) -> None:
+    """A *different* net going open is caught even when known-opens are set."""
+    helper = _load_helper()
+    pcb = _write_pcb(tmp_path)
+    monkeypatch.setattr(
+        helper,
+        "analyze_unconnected",
+        lambda _p: (
+            2,
+            [
+                ("DQ3", ["U1.5 @ (0.00, 0.00)"]),  # tolerated
+                ("SOME_SIGNAL", ["U3.2 @ (5.00, 5.00)"]),  # NEW open -> must fail
+            ],
+        ),
+    )
+    exit_code, message = helper.check_pcb(
+        pcb,
+        max_unconnected=0,
+        known_open_nets={"DQ3", "DQ4", "MIPI_DAT0_N", "TMDS_D0_N", "TMDS_D1_N"},
+    )
+    assert exit_code == 2
+    assert "SOME_SIGNAL" in message
+    assert "DQ3" not in message.split("exceeds")[0]  # tolerated net not blamed
+
+
+def test_known_open_no_longer_open_passes_with_note(tmp_path, monkeypatch, capsys) -> None:
+    """A known-open net that routed clean is an improvement -> pass with a note."""
+    helper = _load_helper()
+    pcb = _write_pcb(tmp_path)
+    monkeypatch.setattr(helper, "analyze_unconnected", lambda _p: (0, []))
+    exit_code, message = helper.check_pcb(
+        pcb, max_unconnected=0, known_open_nets={"DQ3"}
+    )
+    assert exit_code == 0
+    assert "no longer" in message.lower()
+
+
+# ---------------------------------------------------------------------------
+# Regression: the is_advisory_incomplete name-pattern pitfall (#4531 core)
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_analyzer(monkeypatch, result) -> None:
+    """Replace ``NetStatusAnalyzer`` so ``analyze()`` returns ``result``.
+
+    The gate imports the class lazily from ``kicad_tools.analysis.net_status``
+    inside ``analyze_unconnected``, so patching the module attribute reaches
+    the real ``analyze_unconnected`` + ``check_pcb`` code path over a
+    synthetic ``NetStatusResult``.
+    """
+    from kicad_tools.analysis import net_status as ns
+
+    class _FakeAnalyzer:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def analyze(self):
+            return result
+
+    monkeypatch.setattr(ns, "NetStatusAnalyzer", _FakeAnalyzer)
+
+
+def _floating_power_net_result():
+    """Build a ``NetStatusResult`` with a ``VCC`` net that has a floating pad.
+
+    Mirrors the #4531 repro: J2.1 (VCC) unconnected, one other VCC pad
+    connected -> status 'incomplete', net_type 'power', hence
+    ``is_advisory_incomplete=True`` and dropped from
+    ``blocking_incomplete_count``.
+    """
+    from kicad_tools.analysis.net_status import NetStatus, NetStatusResult, PadInfo
+
+    vcc = NetStatus(
+        net_number=1,
+        net_name="VCC",
+        total_pads=2,
+        connected_pads=[
+            PadInfo("U1", "1", (10.0, 10.0), is_connected=True, layers=["F.Cu"])
+        ],
+        unconnected_pads=[
+            PadInfo("J2", "1", (2.5, 35.0), is_connected=False, layers=["F.Cu"])
+        ],
+    )
+    result = NetStatusResult(nets=[vcc], total_nets=1)
+    return result
+
+
+def test_advisory_classifier_confirms_the_pitfall() -> None:
+    """Sanity-check the pitfall exists: VCC floating pad is advisory-filtered."""
+    result = _floating_power_net_result()
+    vcc = result.nets[0]
+    assert vcc.status == "incomplete"
+    assert vcc.net_type == "power"
+    assert vcc.is_advisory_incomplete is True
+    # The trap: the "blocking" count the naive gate would use is ZERO ...
+    assert result.blocking_incomplete_count == 0
+    # ... while the RAW pad-centric count this gate uses is 1.
+    assert result.total_unconnected_pads == 1
+
+
+def test_gate_fails_on_floating_power_named_pad(tmp_path, monkeypatch) -> None:
+    """The core #4531 regression: a floating VCC pad MUST fail this gate.
+
+    Uses the real ``analyze_unconnected`` + ``NetStatusResult`` (only the
+    analyzer's PCB load is faked), so this proves the gate reads the raw
+    ``total_unconnected_pads`` and does NOT fall into the
+    ``blocking_incomplete_count`` name-exclusion trap.
+    """
+    helper = _load_helper()
+    pcb = _write_pcb(tmp_path)
+    _install_fake_analyzer(monkeypatch, _floating_power_net_result())
+
+    exit_code, message = helper.check_pcb(pcb, max_unconnected=0)
+    assert exit_code == 2
+    assert "VCC" in message
+
+
+# ---------------------------------------------------------------------------
+# CLI / main() wiring
+# ---------------------------------------------------------------------------
+
+
+def test_main_prints_measured_count_on_pass(tmp_path, monkeypatch, capsys) -> None:
+    helper = _load_helper()
+    pcb = _write_pcb(tmp_path)
+    monkeypatch.setattr(helper, "analyze_unconnected", lambda _p: (0, []))
+    assert helper.main([str(pcb)]) == 0
+    out = capsys.readouterr().out
+    assert "MEASURED total_unconnected_pads = 0" in out
+
+
+def test_main_prints_measured_count_on_regression(tmp_path, monkeypatch, capsys) -> None:
+    helper = _load_helper()
+    pcb = _write_pcb(tmp_path)
+    monkeypatch.setattr(
+        helper,
+        "analyze_unconnected",
+        lambda _p: (1, [("VCC", ["J2.1 @ (2.50, 35.00)"])]),
+    )
+    assert helper.main([str(pcb)]) == 2
+    out = capsys.readouterr().out
+    assert "MEASURED total_unconnected_pads = 1" in out
+    assert "J2.1" in out
+
+
+def test_main_parses_known_open_nets_arg(tmp_path, monkeypatch) -> None:
+    helper = _load_helper()
+    pcb = _write_pcb(tmp_path)
+    monkeypatch.setattr(
+        helper,
+        "analyze_unconnected",
+        lambda _p: (1, [("DQ3", ["U1.5 @ (0.00, 0.00)"])]),
+    )
+    # without known-opens -> the DQ3 open fails
+    assert helper.main([str(pcb)]) == 2
+    # with DQ3 tolerated -> passes
+    assert helper.main([str(pcb), "--known-open-nets", "DQ3,DQ4"]) == 0
+
+
+def test_main_rejects_negative_threshold(tmp_path) -> None:
+    helper = _load_helper()
+    pcb = _write_pcb(tmp_path)
+    assert helper.main([str(pcb), "--max-unconnected", "-1"]) == 1
+
+
+def test_main_rejects_empty_known_open_nets(tmp_path, monkeypatch) -> None:
+    helper = _load_helper()
+    pcb = _write_pcb(tmp_path)
+    monkeypatch.setattr(helper, "analyze_unconnected", lambda _p: (0, []))
+    assert helper.main([str(pcb), "--known-open-nets", " , "]) == 1
+
+
+def test_help_exits_zero() -> None:
+    helper = _load_helper()
+    with pytest.raises(SystemExit) as excinfo:
+        helper.main(["--help"])
+    assert excinfo.value.code == 0


### PR DESCRIPTION
## Summary

A floating power pad (board-03's `J2.1`/VCC with no track and no reachable pour) passed **all 16 CI checks** (PR #4525). Every existing gate was blind to it: the router's "N/N nets" excludes plane nets, geometric DRC excludes connectivity by design, and copper LVS's `bound_pad_count` is unmoved by a zone-bonded pad going floating. `kct net-status` named the pad exactly, but nothing asserted on it.

This wires that assertion into every board's end-to-end job (capability 1 from the issue -- the reporter's "cheap, high-value" recommendation).

## Changes

- **`scripts/ci/check_net_status.py`** (new): loads the freshly-routed PCB and asserts its **raw** `NetStatusResult.total_unconnected_pads` is within `--max-unconnected` (default 0). Exit codes `0`/`1`/`2` with `::error file=...::` annotations, matching the sibling gates.
  - Explicitly does **NOT** use `blocking_incomplete_count` -- that metric drops any net whose `is_advisory_incomplete` is `True`, a **name-only** classifier (`net_type` derived purely from the net name: `+`/`-`/`V`/`GND`/`VCC`/...). It would silently exclude the exact `VCC`-named floating pad this gate exists to catch -- the pitfall the curation flagged.
  - Runs the analyzer in **strict mode** (real copper geometry, matching `kicad-cli pcb drc` / #4176). The default 0.01mm endpoint-proximity model under-detects pad↔pour bonds and reported **16 false opens** on board 06's genuinely poured-connected `GND`/`+1V2`/`VBUS_USB` pads; strict reports 0 there while a genuine float still fails.
  - `--known-open-nets NET[,NET...]`: tolerates a designed-open set while still failing on a *different* net going open (tighter than raising `--max-unconnected`).
- **`.github/workflows/ci.yml`**: adds the gate step to `board-00/01/02/03/04/06/07-end-to-end`, right after each job's `board-metrics` step. Board 07 passes `--known-open-nets "DQ3,DQ4,MIPI_DAT0_N,TMDS_D0_N,TMDS_D1_N"` (its 5 seed-invariant #3438 opens). **Board 05 is untouched** -- it keeps its own dedicated `check_board_05_blocking.py` gate (#3775/#3766/#3829).
- **`tests/test_check_net_status.py`** (new): threshold/exit-code logic, `--known-open-nets` behaviour, and a **regression test** proving a `VCC`-named net with a floating pad (`blocking_incomplete_count == 0`, `total_unconnected_pads == 1`) fails the gate -- so the advisory-classifier pitfall cannot silently regress through the gate itself.

## Verification

- 16/16 new tests pass; `ruff check` and `mypy` clean on both new files.
- Gate run locally against every committed routed artifact: boards 00-04 and 06 exit 0; board 07 exits 0 with `--known-open-nets` (tolerating exactly its 5 documented opens, which strict mode confirms are exactly `DQ3,DQ4,MIPI_DAT0_N,TMDS_D0_N,TMDS_D1_N`).
- Confirmed the healthy board-03 artifact (the repro board) passes exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)