### PR TITLE
fix(drc): drop copper_sliver union-seam and keyhole-pinch false positives on board 06

### DIFF
--- a/src/kicad_tools/validate/rules/copper_sliver.py
+++ b/src/kicad_tools/validate/rules/copper_sliver.py
@@ -316,6 +316,24 @@ class CopperSliverRule(DRCRule):
         angle_limit = KICAD_SLIVER_ANGLE_TOLERANCE_DEG
         resolve = CopperSliverRule._resolve_arm_index
         rings = [component.exterior, *component.interiors]
+
+        # Keyhole/pinch guard (issue #4521): ``make_valid()`` /
+        # ``unary_union`` can leave a hole ring touching the exterior ring
+        # (or another hole) at exactly one shared coordinate -- a
+        # topologically degenerate "keyhole" pinch.  ``_iter_sliver_tips``
+        # walks ``[exterior, *interiors]`` independently, so it evaluates
+        # the interior ring's local neighbourhood on its own and finds a
+        # spurious acute tip from the hole's own shape rather than from real
+        # copper thinness at that location.  Native KiCad's outline set does
+        # not walk such a pinch as a tip.  Any coordinate shared by two
+        # rings of this component is a topological join, not a copper tip --
+        # collect those coordinates so the walk below can skip them.
+        ring_membership: dict[tuple[float, float], int] = {}
+        for ring in rings:
+            for pt in set(list(ring.coords)[:-1]):
+                ring_membership[pt] = ring_membership.get(pt, 0) + 1
+        pinch_coords = {pt for pt, count in ring_membership.items() if count > 1}
+
         for ring in rings:
             coords = list(ring.coords)[:-1]
             if len(coords) < KICAD_SLIVER_MINIMUM_VERTEX_COUNT:
@@ -334,6 +352,10 @@ class CopperSliverRule(DRCRule):
                     continue
                 if (prior_index, next_index) in seen_arms:
                     continue
+                if current in pinch_coords:
+                    # Keyhole/pinch join shared with another ring -- not a
+                    # real copper tip (see ``pinch_coords`` above, #4521).
+                    continue
                 previous = coords[prior_index]
                 following = coords[next_index]
                 if not CopperSliverRule._chord_is_locally_inside(
@@ -351,6 +373,24 @@ class CopperSliverRule(DRCRule):
                 angle = math.degrees(math.acos(cosine))
                 opposite_width = math.hypot(following[0] - previous[0], following[1] - previous[1])
                 if angle < angle_limit and opposite_width > sliver_width_tolerance:
+                    # Union-seam guard (issue #4521): a genuine acute sliver
+                    # protrudes above its opposite chord by at least the
+                    # sliver width tolerance.  Where a same-net track buffer
+                    # fuses into a zone fill, ``unary_union`` leaves an acute
+                    # seam whose two arms are wildly mismatched in length and
+                    # nearly collinear with the chord -- its perpendicular
+                    # height above the chord is ~0, so it is not real copper
+                    # thinness.  Symmetric acute tips that pass the width test
+                    # always have height >> tolerance (height >= chord /
+                    # (2*tan(angle/2)) > 2.8*chord for angle < 20 deg), so
+                    # this drops the seam without hiding a real sliver.
+                    cross = abs(
+                        (following[0] - previous[0]) * (current[1] - previous[1])
+                        - (following[1] - previous[1]) * (current[0] - previous[0])
+                    )
+                    tip_height = cross / opposite_width
+                    if tip_height <= sliver_width_tolerance:
+                        continue
                     seen_arms.add((prior_index, next_index))
                     yield (current, angle, opposite_width)
 

--- a/tests/test_validate_copper_sliver.py
+++ b/tests/test_validate_copper_sliver.py
@@ -402,6 +402,127 @@ class TestViolationTypeWiring:
         assert _TYPE_CATEGORY_MAP[ViolationType.COPPER_SLIVER] is ViolationCategory.MANUFACTURING
 
 
+# ---------------------------------------------------------------------------
+# Scenario: board-06 false-positive guards (issue #4521)
+#
+# kicad-cli reports 0 copper_sliver on board 06 while the internal rule
+# over-reported 2, from two geometrically distinct artifacts of the shapely
+# copper union that native KiCad's integer-nm poly-set union does not create:
+#
+#   1. Union seam -- a same-net track buffer fuses into a zone fill and leaves
+#      an acute tip whose arms are wildly mismatched and nearly collinear with
+#      the chord (tiny perpendicular height above the opposite chord).
+#   2. Keyhole pinch -- make_valid()/unary_union leaves a hole ring touching
+#      the exterior ring at exactly one shared coordinate, and the independent
+#      per-ring tip walk finds a spurious acute tip on the hole's own shape.
+#
+# These tests exercise the guards directly and, crucially, assert that the
+# guards do NOT suppress genuine slivers (no false negatives traded).
+# ---------------------------------------------------------------------------
+
+
+def _component(exterior, interiors=None):
+    """Build a minimal polygon-like object for ``_iter_sliver_tips``."""
+    return SimpleNamespace(
+        exterior=SimpleNamespace(coords=[*exterior, exterior[0]]),
+        interiors=[SimpleNamespace(coords=[*ring, ring[0]]) for ring in (interiors or [])],
+    )
+
+
+class TestUnionSeamGuard:
+    def test_near_collinear_asymmetric_seam_is_not_flagged(self, monkeypatch):
+        """A near-collinear seam (tip height ~0) is not a real sliver.
+
+        The tip is acute (arms nearly parallel) and its opposite chord is
+        wide (> 0.08 mm), so it clears the angle and width tests, but the
+        tip lies almost on the line joining its two resolved arms -- its
+        perpendicular height above that chord is ~0.  This is the In1.Cu
+        union-seam false positive on board 06.
+        """
+        monkeypatch.setattr(CopperSliverRule, "_chord_is_locally_inside", lambda *_: True)
+        # tip (1,1) is collinear with resolved arms (0,0) and (0.96,0.96).
+        seam = [(0.0, 0.0), (1.0, 1.0), (0.96, 0.96), (2.0, 0.0), (1.5, -0.5), (0.5, -0.5)]
+        assert list(CopperSliverRule._iter_sliver_tips(_component(seam), 0.08)) == []
+
+    def test_genuine_acute_wedge_with_real_height_is_still_flagged(self, monkeypatch):
+        """A symmetric acute wedge protrudes far above its chord -> sliver.
+
+        Same angle/width regime as the seam above, but the tip apex is 10 mm
+        from the opposite chord, so the height guard keeps it.  This proves
+        the seam guard is not blanket suppression.
+        """
+        monkeypatch.setattr(CopperSliverRule, "_chord_is_locally_inside", lambda *_: True)
+        wedge = [
+            (10.0, 0.05),
+            (0.0, 0.0),  # apex tip, 10 mm from the (x=10) chord
+            (10.0, -0.05),
+            (11.0, -0.05),
+            (11.0, 0.05),
+            (10.5, 0.05),
+        ]
+        tips = list(CopperSliverRule._iter_sliver_tips(_component(wedge), 0.08))
+        assert len(tips) == 1
+        assert tips[0][0] == pytest.approx((0.0, 0.0))
+
+
+class TestKeyholePinchGuard:
+    def test_hole_touching_exterior_at_shared_vertex_is_not_flagged(self, monkeypatch):
+        """A coordinate shared by two rings is a pinch join, not a tip."""
+        monkeypatch.setattr(CopperSliverRule, "_chord_is_locally_inside", lambda *_: True)
+        exterior = [(0, 0), (5.0, 0.0), (10, 0), (10, 10), (5, 10), (0, 10)]
+        # Interior hole whose acute tip sits at (5, 0) -- exactly on the
+        # exterior ring (the keyhole pinch).
+        interior = [(4.9, 1.0), (5.0, 0.0), (5.1, 1.0), (6.0, 1.0), (6.0, 2.0), (4.0, 2.0)]
+        assert (
+            list(CopperSliverRule._iter_sliver_tips(_component(exterior, [interior]), 0.08)) == []
+        )
+
+    def test_genuine_interior_tip_not_shared_with_exterior_is_flagged(self, monkeypatch):
+        """An interior-ring acute tip NOT shared with the exterior survives.
+
+        Guards against the pinch fix silently dropping real interior-ring
+        slivers -- only exact cross-ring coordinate sharing is suppressed.
+        """
+        monkeypatch.setattr(CopperSliverRule, "_chord_is_locally_inside", lambda *_: True)
+        # Exterior no longer contains (5, 0), so the tip is not a pinch join.
+        exterior = [(0, 0), (4.0, 0.0), (10, 0), (10, 10), (5, 10), (0, 10)]
+        interior = [(4.9, 1.0), (5.0, 0.0), (5.1, 1.0), (6.0, 1.0), (6.0, 2.0), (4.0, 2.0)]
+        tips = list(CopperSliverRule._iter_sliver_tips(_component(exterior, [interior]), 0.08))
+        assert len(tips) == 1
+        assert tips[0][0] == pytest.approx((5.0, 0.0))
+
+
+class TestTwoTipCaseStillDetected:
+    def test_two_genuine_acute_tips_both_survive(self):
+        """A shape with two genuine acute tips still reports 2 (2/2).
+
+        Guards the fix against over-correcting the union/tip-walk into
+        blanket suppression -- both distinct tips must remain detected
+        through the full union + simplify + walk pipeline.
+        """
+        # A central rectangle with a symmetric acute spike on the left and
+        # the right (mirror of the single-tip ``_acute_tip`` fixture).
+        two_spike = [
+            (20, 10),
+            (30, 10),
+            (30, 14.95),
+            (40, 15),  # right spike tip
+            (30, 15.05),
+            (30, 20),
+            (20, 20),
+            (20, 15.05),
+            (10, 15),  # left spike tip
+            (20, 14.95),
+        ]
+        zone = _zone_with_fill(two_spike)
+        results = _run(min_trace_width=0.127, zones=[zone])
+        slivers = [v for v in results.violations if v.rule_id == "copper_sliver"]
+        assert len(slivers) == 2
+        located = {v.location for v in slivers}
+        assert (40.0, 15.0) in located
+        assert (10.0, 15.0) in located
+
+
 POSITIVE_FIXTURE = Path(__file__).parent / "fixtures" / "copper_sliver_positive.kicad_pcb"
 REPO_ROOT = Path(__file__).parent.parent
 
@@ -499,6 +620,10 @@ def test_micro_vertex_beside_tip_matches_native_count(kink: str, label: str, tmp
         "boards/00-simple-led/output/simple_led_routed.kicad_pcb",
         "boards/02-charlieplex-led/output/charlieplex_3x3_routed.kicad_pcb",
         "boards/04-stm32-devboard/output/stm32_devboard_routed.kicad_pcb",
+        # Board 06 previously over-reported two false positives vs kicad-cli's
+        # zero (issue #4521): a union-seam acute tip on In1.Cu and a keyhole
+        # pinch on B.Cu.  Both must now agree at 0/0.
+        "boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb",
         "boards/07-matchgroup-test/output/matchgroup_test_routed.kicad_pcb",
     ],
 )


### PR DESCRIPTION
## Summary

Board 06 (`06-diffpair-test`) over-reported **2** `copper_sliver` markers while `kicad-cli` reports **0**. Both are artifacts of the shapely copper union that native KiCad's integer-nm poly-set union does not create. This PR adds two independent, geometrically-grounded guards in `_iter_sliver_tips()` so the internal count matches native (0/0) without trading any false negatives.

## Changes

- `src/kicad_tools/validate/rules/copper_sliver.py`
  - **Union-seam guard (In1.Cu, `56.607, 22.623`):** a same-net track buffer fuses into a zone fill and leaves an acute tip whose arms are mismatched ~27:1 and nearly collinear with the opposite chord (perpendicular height ≈ 0.005 mm). Require the tip to protrude above its opposite chord by more than the sliver width tolerance. Symmetric acute tips that pass the width test always have height ≫ tolerance (`height ≥ chord / (2·tan(angle/2)) > 2.8·chord` for angle < 20°), so genuine slivers are untouched.
  - **Keyhole-pinch guard (B.Cu, `95.151, 41.079`):** `make_valid()`/`unary_union` leaves a hole ring touching the exterior ring at exactly one shared coordinate; the per-ring tip walk then finds a spurious acute tip on the hole's own shape. Skip any tip whose coordinate is shared between two rings of the same component.
- `tests/test_validate_copper_sliver.py`
  - Added board 06 to the `test_repository_board_count_matches_native` parametrize list.
  - New unit tests for both guards, each paired with a genuine-sliver counterpart proving the guard is not blanket suppression, plus a two-tip case confirming genuine multi-tip detection survives (2/2).

## Acceptance Criteria Verification

- [x] Board 06 reports internal `0` for `copper_sliver` (verified locally; native side asserted via the parametrized integration test, which skips cleanly when `kicad-cli` is absent).
- [x] Boards 00-05 and 07 stay at `0` internally (verified: only board 06 had any internal detections before this change).
- [x] Existing positive fixtures stay detected (positive control tip height ≈ 10 mm, kept by the height guard); micro-vertex and threshold tests unchanged.
- [x] No false negatives traded: genuine acute wedge, genuine (non-shared) interior-ring tip, and a genuine two-tip shape all still detected.
- [x] Board 06 added to the parametrized native-comparison matrix.

## Test Plan

- `uv run pytest tests/test_validate_copper_sliver.py` — 38 passed (32 prior + 6 new); `kicad-cli`-gated integration tests skip cleanly (no `kicad-cli` in sandbox).
- `uv run ruff format` / `uv run ruff check` on both changed files — clean.
- Manual: internal `CopperSliverRule` run over all 8 boards — board 06 now 0, all others 0.

> Note: `kicad-cli` is not available in this environment, so the native `0` for board 06 is asserted by the (skipping) integration test and needs a run on a host with `kicad-cli` on PATH to close the native side of the AC.

Closes #4521

🤖 Generated with [Claude Code](https://claude.com/claude-code)