### PR TITLE
fix(recovery): sync absolute pad angles on ROTATE_COMPONENT + wire Pad rotation to sexp (#4518)

### DIFF
--- a/src/kicad_tools/recovery/applicator.py
+++ b/src/kicad_tools/recovery/applicator.py
@@ -188,12 +188,18 @@ class StrategyApplicator:
         flipping a reversed facing pad column (``rotation_delta == 180``) so a
         self-crossing bundle stops crossing.
 
-        Only the footprint-level orientation is written here.  The board-frame
-        pad positions the classifier reads are derived from ``fp.position`` +
-        ``fp.rotation`` applied to each pad's local offset (see
-        ``stuck_classifier._iter_board_pads``), so bumping ``fp.rotation`` is
-        sufficient for the PCB view.  The Phase-2 driver separately re-syncs the
-        router's flat pad coordinates before re-routing.
+        Both the footprint-level orientation AND every pad's absolute angle are
+        updated here.  The board-frame pad *positions* the classifier reads are
+        derived from ``fp.position`` + ``fp.rotation`` applied to each pad's
+        local offset (see ``stuck_classifier._iter_board_pads``), so bumping
+        ``fp.rotation`` is sufficient for that view.  But each pad's ``(at x y
+        ANGLE)`` third token is the pad's ABSOLUTE board-frame orientation (see
+        ``schema/pcb.py`` ``Pad.rotation`` and the #3902 fix), so it must be
+        bumped by the same ``rotation_delta`` or serializing the mutated PCB
+        leaves every pad angle stale -- reintroducing the #3902 defect class for
+        non-180-symmetric pad shapes (chamfered roundrect, trapezoid, custom).
+        The Phase-2 driver separately re-syncs the router's flat pad coordinates
+        (which carry no rotation of their own) before re-routing.
         """
         if not strategy.actions:
             return ApplicationResult(
@@ -230,6 +236,18 @@ class StrategyApplicator:
         old_rotation = float(getattr(fp, "rotation", 0.0))
         new_rotation = (old_rotation + float(rotation_delta)) % 360.0
         fp.rotation = new_rotation
+
+        # A pad's ``(at x y ANGLE)`` third token is the pad's ABSOLUTE board-frame
+        # orientation and already includes the parent footprint's rotation, so it
+        # must be advanced by the same delta.  ``Footprint.__setattr__`` for
+        # ``rotation`` only rewrites the footprint's own ``(at ...)`` token and is
+        # unaware of pads (schema/pcb.py), so without this loop the pad angles go
+        # stale on serialization (the #3902 defect class).  Guard with getattr/
+        # hasattr since test doubles (MockFootprint) may carry pads without a
+        # ``.rotation`` attribute.
+        for pad in getattr(fp, "pads", []):
+            if hasattr(pad, "rotation"):
+                pad.rotation = (float(pad.rotation) + float(rotation_delta)) % 360.0
 
         return ApplicationResult(
             success=True,

--- a/src/kicad_tools/router/placement_feedback.py
+++ b/src/kicad_tools/router/placement_feedback.py
@@ -356,7 +356,7 @@ class PlacementFeedbackLoop:
         # placement -- the saved artifact can contain opens/DRC at the new
         # pad positions.  Snapshot the placement ALONGSIDE the routes and
         # restore them together so the best snapshot is atomic.
-        best_placement_snapshot: dict[str, tuple[tuple[float, float], float]] = (
+        best_placement_snapshot: dict[str, tuple[tuple[float, float], float, list[float]]] = (
             self._snapshot_placement()
         )
 
@@ -919,16 +919,27 @@ class PlacementFeedbackLoop:
             rotation = float(getattr(fp, "rotation", 0.0))
             self._original_positions[ref] = ((pos[0], pos[1]), rotation)
 
-    def _snapshot_placement(self) -> dict[str, tuple[tuple[float, float], float]]:
-        """Capture every footprint's (x, y) position and rotation.
+    def _snapshot_placement(
+        self,
+    ) -> dict[str, tuple[tuple[float, float], float, list[float]]]:
+        """Capture every footprint's (x, y) position, rotation, and pad angles.
 
         Issue #3504: used to take an atomic best snapshot of the
         component placement alongside the best routes.  Returns a mapping
-        ``ref -> ((x, y), rotation)``.  When no PCB is attached (routing-
-        strategies-only mode) this returns an empty dict, which makes
-        ``_restore_placement`` a no-op.
+        ``ref -> ((x, y), rotation, [pad_rotation, ...])``.  When no PCB is
+        attached (routing-strategies-only mode) this returns an empty dict,
+        which makes ``_restore_placement`` a no-op.
+
+        Issue #4518: the per-pad rotations are captured alongside the
+        footprint-level rotation so that a reverted (non-improving) delta
+        restores each pad's ABSOLUTE ``(at x y ANGLE)`` orientation too.  The
+        applicator's ``rotate_180`` bumps every pad's ``.rotation`` in lockstep
+        with ``fp.rotation`` (see ``StrategyApplicator._apply_rotate_component``),
+        so restoring only the footprint angle would leave pad angles stale in the
+        other direction on revert.  Pads are captured in ``fp.pads`` list order,
+        which is stable, so restore round-trips by index.
         """
-        snapshot: dict[str, tuple[tuple[float, float], float]] = {}
+        snapshot: dict[str, tuple[tuple[float, float], float, list[float]]] = {}
         if self.pcb is None:
             return snapshot
         for fp in getattr(self.pcb, "footprints", []):
@@ -937,14 +948,17 @@ class PlacementFeedbackLoop:
                 continue
             pos = fp.position
             rotation = float(getattr(fp, "rotation", 0.0))
-            snapshot[ref] = ((pos[0], pos[1]), rotation)
+            pad_rotations = [
+                float(pad.rotation) for pad in getattr(fp, "pads", []) if hasattr(pad, "rotation")
+            ]
+            snapshot[ref] = ((pos[0], pos[1]), rotation, pad_rotations)
         return snapshot
 
     def _restore_placement(
         self,
-        snapshot: dict[str, tuple[tuple[float, float], float]],
+        snapshot: dict[str, tuple[tuple[float, float], float, list[float]]],
     ) -> None:
-        """Restore footprint positions/rotations from a placement snapshot.
+        """Restore footprint positions/rotations/pad angles from a snapshot.
 
         Issue #3504: counterpart to :meth:`_snapshot_placement`.  Writes
         the captured ``(x, y)`` and rotation back onto each footprint so
@@ -952,6 +966,11 @@ class PlacementFeedbackLoop:
         were computed against.  Refs present in the PCB but absent from the
         snapshot are left untouched (defensive against footprints added
         mid-loop, which does not happen in practice).
+
+        Issue #4518: also restores each pad's absolute ``.rotation`` from the
+        captured list (matched by ``fp.pads`` list order) so a reverted delta
+        leaves pad angles exactly as they were pre-delta, not just the
+        footprint-level rotation.
         """
         if self.pcb is None or not snapshot:
             return
@@ -959,10 +978,17 @@ class PlacementFeedbackLoop:
             ref = getattr(fp, "reference", None)
             if ref is None or ref not in snapshot:
                 continue
-            (x, y), rotation = snapshot[ref]
+            (x, y), rotation, pad_rotations = snapshot[ref]
             fp.position = (x, y)
             if hasattr(fp, "rotation"):
                 fp.rotation = rotation
+            pads = [pad for pad in getattr(fp, "pads", []) if hasattr(pad, "rotation")]
+            # strict=False: capture and restore both filter on the same
+            # ``hasattr(pad, "rotation")`` predicate over the same stable
+            # ``fp.pads`` list, so lengths match in practice; tolerate a
+            # mismatch defensively rather than raising mid-revert.
+            for pad, pad_rotation in zip(pads, pad_rotations, strict=False):
+                pad.rotation = pad_rotation
 
     def _build_placement_diff(self) -> list[PlacementDiffEntry]:
         """Build the placement diff from snapshotted original positions.

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -295,10 +295,15 @@ class Pad:
             return
         at_node = sexp_node.find_child("at")
         if at_node is not None:
+            # ``rotation`` is always numeric; narrow to ``float`` so the SExp
+            # mutators receive their declared ``float`` type rather than the
+            # ``object`` of ``__setattr__``'s signature (keeps mypy at baseline,
+            # matching ``Footprint.__setattr__``'s already-baselined pattern).
+            angle = float(value)  # type: ignore[arg-type]
             if len(at_node.children) >= 3:
-                at_node.set_value(2, value)
-            elif value != 0.0:
-                at_node.add(value)
+                at_node.set_value(2, angle)
+            elif angle != 0.0:
+                at_node.add(angle)
 
     @property
     def net(self) -> int:

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -269,6 +269,36 @@ class Pad:
     # Corner-radius ratio for ``roundrect`` pads: radius = rratio * min(w, h).
     # KiCad's default is 0.25 when ``(roundrect_rratio ...)`` is absent.
     roundrect_rratio: float = 0.25
+    # Back-reference to the ``(pad ...)`` S-expression node, linked by
+    # :meth:`PCB._link_footprint_sexp_nodes` after parsing so that assigning
+    # ``pad.rotation`` keeps the ``(at x y ANGLE)`` third token in sync with the
+    # Python value (issue #4518).  Without this a mutation like
+    # ``StrategyApplicator._apply_rotate_component`` bumping ``pad.rotation``
+    # would update the dataclass field but never reach ``PCB.save`` (which
+    # serialises the raw S-expression tree), leaving stale absolute pad angles
+    # -- the #3902 defect class.  ``compare=False`` keeps dataclass equality
+    # value-based (as the existing pad round-trip tests expect).
+    _sexp_node: SExp | None = field(default=None, repr=False, compare=False)
+
+    def __setattr__(self, name: str, value: object) -> None:
+        # Store the Python value first via the default mechanism.
+        super().__setattr__(name, value)
+
+        # Only ``rotation`` mirrors into the S-expression tree.  During
+        # ``__init__`` (and for pads never linked to a node, e.g. freshly
+        # instantiated library pads or test doubles) ``_sexp_node`` is None and
+        # this is a no-op -- matching ``Footprint.__setattr__``'s guard.
+        if name != "rotation":
+            return
+        sexp_node: SExp | None = self.__dict__.get("_sexp_node")
+        if sexp_node is None:
+            return
+        at_node = sexp_node.find_child("at")
+        if at_node is not None:
+            if len(at_node.children) >= 3:
+                at_node.set_value(2, value)
+            elif value != 0.0:
+                at_node.add(value)
 
     @property
     def net(self) -> int:
@@ -2364,6 +2394,19 @@ class PCB:
                 # both _sexp_node and _board_origin are in place.
                 object.__setattr__(fp, "_board_origin", self._board_origin)
                 object.__setattr__(fp, "_sexp_node", child)
+
+                # Issue #4518: link each Pad to its own ``(pad ...)`` node so
+                # that assigning ``pad.rotation`` syncs the absolute ``(at x y
+                # ANGLE)`` third token into the S-expression tree ``save()``
+                # serialises.  ``Footprint.from_sexp`` appends pads in
+                # ``find_all("pad")`` order, so matching that same traversal
+                # here keeps the Python list and the node list index-aligned.
+                pad_nodes = child.find_all("pad")
+                # strict=False: ``fp.pads`` and the ``(pad ...)`` node list are
+                # both built from the same ``find_all("pad")`` traversal, so
+                # they align; tolerate a rare mismatch rather than raising.
+                for pad_obj, pad_node in zip(fp.pads, pad_nodes, strict=False):
+                    object.__setattr__(pad_obj, "_sexp_node", pad_node)
 
                 # Migrate the legacy KiCad-6 in-attr 'locked' token to
                 # the modern top-level ``(locked yes)`` form. KiCad 10's

--- a/tests/router/test_placement_delta_feedback.py
+++ b/tests/router/test_placement_delta_feedback.py
@@ -631,7 +631,18 @@ class TestComposedDeltaFeedbackIntegration:
         from kicad_tools.router.core import Autorouter
         from kicad_tools.router.layers import Layer
 
-        router = Autorouter(width=20, height=20)
+        # Bound each per-net A* to a fixed node-expansion budget (issue #3881).
+        # The BOX net is deliberately unroutable (boxed in by its own copper);
+        # without a cap the C++ pathfinder gives up and falls back to pure-Python
+        # A*, which exhaustively scans the grid and blows past CI's 60s per-test
+        # timeout (10-100x slower -- the fallback path from the #3438 loop).  A
+        # positive ``per_net_iterations`` makes the C++ search give up
+        # DETERMINISTICALLY at the cap (returning FAILURE_ITERATION_LIMIT) and
+        # tells the loop to SKIP the Python fallback for the capped net -- so BOX
+        # still fails (the loop reaches the apply/keep-or-revert branch as
+        # intended) but does so in milliseconds, machine-independently.  20k is
+        # far more than the short straight N1 net needs to route.
+        router = Autorouter(width=20, height=20, per_net_iterations=20_000)
         for fp in pcb.footprints:
             # KiCad applies footprint orientation as a negated angle vs standard
             # CCW math (see router/io.py::route_pcb); mirror that so the router's

--- a/tests/router/test_placement_delta_feedback.py
+++ b/tests/router/test_placement_delta_feedback.py
@@ -38,16 +38,80 @@ from kicad_tools.router import (
 from tests.router.test_placement_delta import _facing_rows_bundle_board, _load
 
 # --------------------------------------------------------------------------- #
+# Real-PCB fixture with a non-180-symmetric rotated-pad footprint (#4518)      #
+# --------------------------------------------------------------------------- #
+
+# A footprint (UB) whose pads carry a nonzero ABSOLUTE ``(at x y ANGLE)`` third
+# token (45 deg) on an oval/roundrect shape -- so a stale pad angle after a
+# footprint rotation is a real geometry error, not a 180-symmetric no-op.  A
+# routable net (N1: A<->B) plus a persistently-unroutable net (BOX, boxed in by
+# its own copper) let the composed delta loop reach the apply/keep-or-revert
+# branch on a REAL ``Autorouter`` instead of short-circuiting on convergence.
+_ROTATED_PAD_BOARD = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (layers (0 "F.Cu" signal) (44 "Edge.Cuts" user))
+  (net 0 "")
+  (net 1 "N1")
+  (net 2 "BOX")
+  (footprint "R" (layer "F.Cu") (at 2 10)
+    (property "Reference" "A")
+    (pad "1" smd rect (at 0 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "N1"))
+  )
+  (footprint "R" (layer "F.Cu") (at 10 10)
+    (property "Reference" "B")
+    (pad "1" smd rect (at 0 0) (size 0.5 0.5) (layers "F.Cu") (net 1 "N1"))
+  )
+  (footprint "BOX" (layer "F.Cu") (at 10 10)
+    (property "Reference" "BX")
+    (pad "1" smd rect (at 0 -1.5) (size 1.4 1.4) (layers "F.Cu") (net 2 "BOX"))
+    (pad "2" smd rect (at 0 1.5) (size 1.4 1.4) (layers "F.Cu") (net 2 "BOX"))
+    (pad "3" smd rect (at -1.5 0) (size 1.4 1.4) (layers "F.Cu") (net 2 "BOX"))
+    (pad "4" smd rect (at 1.5 0) (size 1.4 1.4) (layers "F.Cu") (net 2 "BOX"))
+  )
+  (footprint "chamf" (layer "F.Cu") (at 16 16)
+    (property "Reference" "UB")
+    (pad "1" smd roundrect (at 0 -0.6 45) (size 0.6 0.3) (layers "F.Cu") (net 0 ""))
+    (pad "2" smd roundrect (at 0 0.6 45) (size 0.6 0.3) (layers "F.Cu") (net 0 ""))
+  )
+)
+"""
+
+
+def _rotated_pad_board(tmp_path: Path):
+    """Load ``_ROTATED_PAD_BOARD`` as a real :class:`PCB`."""
+    return _load(tmp_path, _ROTATED_PAD_BOARD)
+
+
+# --------------------------------------------------------------------------- #
 # Lightweight test doubles                                                     #
 # --------------------------------------------------------------------------- #
 
 
+class MockPad:
+    """Minimal pad stub carrying only the ``.rotation`` the applicator and the
+    snapshot/restore path read (issue #4518)."""
+
+    def __init__(self, rotation: float = 0.0):
+        self.rotation = rotation
+
+
 class MockFootprint:
-    def __init__(self, reference: str, x: float, y: float, rotation: float = 0.0):
+    def __init__(
+        self,
+        reference: str,
+        x: float,
+        y: float,
+        rotation: float = 0.0,
+        pad_rotations: list[float] | None = None,
+    ):
         self.reference = reference
         self.position = (x, y)
         self.rotation = rotation
-        self.pads: list = []
+        # Default empty (existing tests): the applicator/snapshot pad loops are
+        # no-ops.  Pass ``pad_rotations`` to exercise the #4518 pad-angle sync.
+        self.pads: list = [MockPad(r) for r in (pad_rotations or [])]
 
 
 class MockPCB:
@@ -197,6 +261,83 @@ class TestApplicatorRotate:
         # A rotation targeting a missing ref is not safe.
         assert applicator.is_safe_to_apply(strategy, MockPCB([])) is False
 
+    # ----- #4518: absolute pad-angle sync ---------------------------------- #
+
+    @staticmethod
+    def _rotate_strategy(ref: str, delta: float) -> ResolutionStrategy:
+        return ResolutionStrategy(
+            type=StrategyType.ROTATE_COMPONENT,
+            difficulty=Difficulty.MEDIUM,
+            confidence=1.0,
+            actions=[Action(type="rotate", target=ref, params={"rotation_delta": delta})],
+        )
+
+    def test_rotate_bumps_mock_pad_rotations(self):
+        """#4518: every pad's ``.rotation`` advances by the same delta as the
+        footprint's, in lockstep."""
+        applicator = StrategyApplicator()
+        fp = MockFootprint("U5", 10.0, 20.0, rotation=0.0, pad_rotations=[45.0, 90.0])
+        pcb = MockPCB([fp])
+        applicator.apply_strategy(pcb, self._rotate_strategy("U5", 180.0))
+        assert fp.rotation == 180.0
+        assert [pad.rotation for pad in fp.pads] == [225.0, 270.0]
+
+    def test_rotate_pad_rotation_wraps_modulo_360(self):
+        """A pad starting at a nonzero angle wraps past 360 like the footprint."""
+        applicator = StrategyApplicator()
+        fp = MockFootprint("U5", 0.0, 0.0, rotation=270.0, pad_rotations=[200.0])
+        pcb = MockPCB([fp])
+        applicator.apply_strategy(pcb, self._rotate_strategy("U5", 180.0))
+        assert fp.rotation == 90.0  # (270 + 180) % 360
+        assert fp.pads[0].rotation == 20.0  # (200 + 180) % 360
+
+    def test_rotate_tolerates_pad_without_rotation_attr(self):
+        """A pad stub lacking ``.rotation`` (older schema / test double) must not
+        raise via the ``hasattr`` guard, and a zero-pad footprint is fine too."""
+        applicator = StrategyApplicator()
+
+        class _BarePad:  # no ``.rotation`` attribute
+            pass
+
+        fp = MockFootprint("U5", 0.0, 0.0, rotation=0.0)
+        fp.pads = [_BarePad()]
+        pcb = MockPCB([fp])
+        result = applicator.apply_strategy(pcb, self._rotate_strategy("U5", 180.0))
+        assert result.success is True
+        assert fp.rotation == 180.0
+        assert not hasattr(fp.pads[0], "rotation")
+
+        empty = MockFootprint("U6", 0.0, 0.0)
+        result2 = applicator.apply_strategy(MockPCB([empty]), self._rotate_strategy("U6", 90.0))
+        assert result2.success is True
+        assert empty.rotation == 90.0
+
+    def test_rotate_syncs_absolute_pad_angles_on_real_pcb(self, tmp_path: Path):
+        """#4518 core: on a REAL ``PCB``/``Pad``, rotating UB 180 deg advances
+        every pad's absolute ``(at x y ANGLE)`` third token, and the change
+        survives a save + reload round-trip (the serialization path #3902 warned
+        about).  UB's pads start at 45 deg on a non-180-symmetric roundrect."""
+        applicator = StrategyApplicator()
+        pcb = _rotated_pad_board(tmp_path)
+        ub = next(fp for fp in pcb.footprints if fp.reference == "UB")
+        assert [pad.rotation for pad in ub.pads] == [45.0, 45.0]
+
+        result = applicator.apply_strategy(pcb, self._rotate_strategy("UB", 180.0))
+        assert result.success is True
+        assert ub.rotation == 180.0
+        assert [pad.rotation for pad in ub.pads] == [225.0, 225.0]
+
+        # Serialize + reparse: the absolute pad angles must persist (proving the
+        # dataclass write reached the S-expression tree, not just memory).
+        out = tmp_path / "rotated_out.kicad_pcb"
+        pcb.save(str(out))
+        from kicad_tools.schema.pcb import PCB
+
+        reloaded = PCB.load(str(out))
+        ub2 = next(fp for fp in reloaded.footprints if fp.reference == "UB")
+        assert ub2.rotation == 180.0
+        assert [pad.rotation for pad in ub2.pads] == [225.0, 225.0]
+
 
 # --------------------------------------------------------------------------- #
 # PlacementDelta.from_dict round-trip (#4467)                                  #
@@ -271,6 +412,46 @@ class TestDeltaFeedbackKeepRevert:
         assert result.failed_nets == [2]
         # No spurious diff entry for a reverted move.
         assert result.placement_diff == []
+
+    def test_reverted_delta_restores_pad_rotations(self):
+        """#4518 coupled defect: a reverted (non-improving) delta must restore
+        each pad's absolute ``.rotation`` -- not only ``fp.rotation``.  Without
+        the snapshot/restore fix the pad angles would stay bumped (225) while the
+        footprint reverts to 0, leaving the board stale in the *other* direction.
+        """
+        fps = [MockFootprint("UB", 10.0, 10.0, rotation=0.0, pad_rotations=[45.0, 45.0])]
+        pcb = MockPCB(fps)
+        router = FakeRouter([FakePad(12.0, 10.0, "UB", "2")], 2, _rotate_never_helps)
+        loop = PlacementDeltaFeedbackLoop(
+            router=router,
+            pcb=pcb,
+            verbose=False,
+            delta_proposer=lambda _pcb: [_rotate_delta()],
+        )
+        result = loop.run_delta(max_adjustments=3)
+        assert result.applied_deltas == []
+        assert result.exit_reason == "pd_reverted"
+        # Both the footprint AND every pad angle are back to pre-delta values.
+        assert pcb.footprints[0].rotation == 0.0
+        assert [pad.rotation for pad in pcb.footprints[0].pads] == [45.0, 45.0]
+
+    def test_kept_delta_bumps_pad_rotations(self):
+        """#4518: when a rotate delta is KEPT, the applicator's pad-angle bump
+        survives through the loop (footprint 180 -> pads +180)."""
+        fps = [MockFootprint("UB", 10.0, 10.0, rotation=0.0, pad_rotations=[45.0, 90.0])]
+        pcb = MockPCB(fps)
+        router = FakeRouter([FakePad(12.0, 10.0, "UB", "2")], 2, _rotate_fixes_net2)
+        loop = PlacementDeltaFeedbackLoop(
+            router=router,
+            pcb=pcb,
+            verbose=False,
+            delta_proposer=lambda _pcb: [_rotate_delta()],
+        )
+        result = loop.run_delta(max_adjustments=3)
+        assert result.success is True
+        assert [d.target_ref for d in result.applied_deltas] == ["UB"]
+        assert pcb.footprints[0].rotation == 180.0
+        assert [pad.rotation for pad in pcb.footprints[0].pads] == [225.0, 270.0]
 
 
 # --------------------------------------------------------------------------- #
@@ -426,3 +607,101 @@ class TestAutorouterEntryPoint:
         # Bisection guard: legacy result type, no delta artifact written.
         assert isinstance(result, PlacementFeedbackResult)
         assert not out.exists()
+
+
+# --------------------------------------------------------------------------- #
+# Composed path: real Autorouter + real PCB (#4518 AC integration)             #
+# --------------------------------------------------------------------------- #
+
+
+class TestComposedDeltaFeedbackIntegration:
+    """End-to-end: drive ``route_with_placement_delta_feedback`` with a REAL
+    ``Autorouter`` and a REAL parsed ``PCB`` (not ``FakeRouter``/``MockPCB``),
+    apply a ``rotate_180`` to UB, and confirm the composed apply ->
+    ``_apply_delta_to_router_pads`` -> ``_reset_for_new_trial`` grid rebuild ->
+    keep-or-revert cycle leaves UB's pad angles consistent with ``fp.rotation``
+    -- and that the board round-trips through serialization.  This closes the
+    "composed path is never exercised end to end" gap from the issue body.
+    """
+
+    @staticmethod
+    def _build_router(pcb):
+        import math
+
+        from kicad_tools.router.core import Autorouter
+        from kicad_tools.router.layers import Layer
+
+        router = Autorouter(width=20, height=20)
+        for fp in pcb.footprints:
+            # KiCad applies footprint orientation as a negated angle vs standard
+            # CCW math (see router/io.py::route_pcb); mirror that so the router's
+            # flat board-frame pads match what the classifier/PCB view expects.
+            rot_rad = math.radians(-fp.rotation)
+            cos_r, sin_r = math.cos(rot_rad), math.sin(rot_rad)
+            pads = []
+            for pad in fp.pads:
+                px, py = pad.position
+                rx = px * cos_r - py * sin_r
+                ry = px * sin_r + py * cos_r
+                pads.append(
+                    {
+                        "number": pad.number,
+                        "x": fp.position[0] + rx,
+                        "y": fp.position[1] + ry,
+                        "width": pad.size[0],
+                        "height": pad.size[1],
+                        "net": pad.net_number,
+                        "net_name": pad.net_name,
+                        "layer": Layer.F_CU,
+                    }
+                )
+            router.add_component(fp.reference, pads)
+        return router
+
+    def test_composed_rotate_preserves_pad_angle_consistency(self, tmp_path: Path):
+        from kicad_tools.schema.pcb import PCB
+
+        pcb = _rotated_pad_board(tmp_path)
+        router = self._build_router(pcb)
+
+        ub = next(fp for fp in pcb.footprints if fp.reference == "UB")
+        fp_before = ub.rotation
+        pad_before = [pad.rotation for pad in ub.pads]
+        assert pad_before == [45.0, 45.0]
+
+        # The BOX net is boxed in by its own copper and never routes, so the loop
+        # does not short-circuit on convergence -- it reaches the apply branch,
+        # rotates UB, re-routes, and (since UB is off-net) reverts.
+        result = router.route_with_placement_delta_feedback(
+            pcb=pcb,
+            max_adjustments=2,
+            verbose=False,
+            delta_proposer=lambda _pcb: [
+                PlacementDelta(
+                    net_name="BOX",
+                    target_ref="UB",
+                    kind="rotate_180",
+                    rotation_delta=180.0,
+                    source_action="de_reverse_bundle",
+                )
+            ],
+        )
+        assert isinstance(result, PlacementDeltaFeedbackResult)
+        # AC(a): the delta was actually proposed/considered (composed path ran),
+        # and the outcome is either a strict improvement or an atomic revert.
+        assert len(result.proposed_deltas) >= 1
+        assert result.applied_deltas or result.exit_reason == "pd_reverted"
+
+        # AC(b): for EVERY pad, the applied absolute-angle delta equals the
+        # applied footprint-rotation delta -- consistent whether kept or reverted.
+        fp_delta = (ub.rotation - fp_before) % 360.0
+        for pad, before in zip(ub.pads, pad_before, strict=True):
+            assert (pad.rotation - before) % 360.0 == fp_delta
+
+        # And the consistency survives serialize + reparse (the KiCad view).
+        out = tmp_path / "composed_out.kicad_pcb"
+        pcb.save(str(out))
+        reloaded = PCB.load(str(out))
+        ub2 = next(fp for fp in reloaded.footprints if fp.reference == "UB")
+        assert ub2.rotation == ub.rotation
+        assert [pad.rotation for pad in ub2.pads] == [pad.rotation for pad in ub.pads]


### PR DESCRIPTION
## Summary

`StrategyApplicator._apply_rotate_component` rotated a footprint by writing only `fp.rotation`, leaving every pad's absolute `(at x y ANGLE)` third token stale by the rotation delta on serialization — reintroducing the (closed, CRITICAL) #3902 absolute-pad-angle defect class for non-180-symmetric pad shapes (chamfered roundrect, trapezoid, custom): phantom shorting / solder-mask-bridge DRC and wrong gerber apertures once a mutated `PCB` is written out. Dormant today (no production caller of `route_with_placement_delta_feedback`), but activates the moment Phase 3 of epic #3438 wires the delta loop into `kct route`.

## Root cause ran deeper than the suggested one-liner

The issue suggested `pad.rotation = (pad.rotation + delta) % 360`. That alone does **not** fix serialization: schema `Pad` objects were never linked to their `(pad ...)` S-expression nodes, and `PCB.save` serialises the raw S-expression tree — so assigning `pad.rotation` updated the dataclass field but never reached the saved file. Verified empirically (load → `fp.rotation += 180` + `pad.rotation += 180` → save → reload left pad angles at `45` while the footprint went to `180`).

## Changes (three coupled fixes)

1. **`schema/pcb.py`** — wire `Pad.rotation` to its S-expression node, mirroring `Footprint`: a `_sexp_node` back-reference (`compare=False`, so pad equality stays value-based), a `__setattr__` that syncs the `(at ...)` third token, and per-pad node linking in `_link_footprint_sexp_nodes`. Now `pad.rotation = X` round-trips through `save()`/`load()`.
2. **`recovery/applicator.py`** — `_apply_rotate_component` advances every pad's `.rotation` by the same delta as `fp.rotation` (`hasattr`-guarded for test doubles / zero-pad footprints).
3. **`router/placement_feedback.py`** — `_snapshot_placement` / `_restore_placement` capture and restore per-pad rotations alongside `(x, y)` and `fp.rotation`, so a reverted (non-improving) delta restores pad angles too rather than leaving them stale in the *other* direction (the coupled defect the curator flagged).

## Tests (all 7 AC items)

- Real-`Pad`/`PCB` applicator pad-angle sync + **save → reload round-trip** (AC4, AC(b)).
- MockFootprint pad-bump, modulo-360 wrap, and `hasattr`/zero-pad guard cases.
- `test_reverted_delta_restores_pad_rotations` and `test_kept_delta_bumps_pad_rotations` loop regressions (AC5).
- `TestComposedDeltaFeedbackIntegration`: composed **real `Autorouter` + real `PCB`** path through `route_with_placement_delta_feedback`, asserting pad-angle consistency (kept or reverted) and serialization round-trip (AC6).

`uv run pytest tests/router/test_placement_delta_feedback.py tests/router/test_placement_delta.py` → 39 passed. Broad schema/recovery/round-trip sweep → 569 passed. `ruff format` + `ruff check` clean on all changed files.

Closes #4518

🤖 Generated with [Claude Code](https://claude.com/claude-code)