### PR TITLE
feat(router): make escape-corridor reservation selective, bounded, inner-layer

### DIFF
--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -117,6 +117,42 @@ from .tuning import (
 from .via_conflict import ViaConflictManager
 from .zones import ZoneManager
 
+# ---------------------------------------------------------------------------
+# Escape-corridor reservation tuning (#4519)
+# ---------------------------------------------------------------------------
+# The congestion-aware escape-corridor planner (#4474) exposes two selectivity
+# knobs that PR #4509 left at their permissive library defaults, which reserved
+# every cluster over every layer and regressed board-05's blocking gate.  These
+# constants make a reservation a *selective, bounded* signal when a caller opts
+# into ``enable_escape_corridor_reservation``; they are internal tuning, not a
+# user-facing CLI surface (the only board-facing flag stays the boolean
+# ``--escape-corridor-reservation``).
+#
+# ``min_reserve_demand_frac`` is a fraction of the MOST-CONGESTED cluster's
+# demand in each package's plan: a cluster reserves a channel only when its
+# aggregated demand exceeds this fraction of the plan's peak cluster demand, so
+# only the genuinely congested clusters (e.g. board-05 U3's south sense band)
+# get a channel instead of every face of a dense part.  Self-calibrating per
+# package (no absolute magic number).  0.7 was calibrated against board-05's
+# measured per-cluster demands (U3 clusters ~52-142, U10 ~20-58): it trims U3
+# from 9/9 -> 2/9 and U10 from 11/11 -> 8/11 reserving clusters (#4519).  A
+# fraction of the estimator's *per-tile* peak was tried first and rejected --
+# ``cluster.demand`` aggregates several pin tiles and sums above the single-tile
+# peak on a dense part, so a per-tile fraction failed to trim anything.
+_ESCAPE_CORRIDOR_MIN_RESERVE_DEMAND_FRAC = 0.7
+# ``max_corridor_length_mm`` caps a corridor to a local escape channel a few mm
+# long instead of the board-spanning band a full destination-distance corridor
+# produced under PR #4509.  A few mm is enough to clear a dense part's immediate
+# escape congestion without reaching across the board.  This is the dominant
+# footprint lever: on board-05 it drops total reserved cells from ~25.9k (the
+# PR #4509 regression) toward ~5k even before the selectivity/inner-layer trims.
+_ESCAPE_CORRIDOR_MAX_LENGTH_MM = 5.0
+# Restrict escape corridors to the INNER routable layers (#4519, Scope item 3),
+# keeping the outer component layers free of escape attractors.  On board-05's
+# 4-layer stack this confines reservations to layers [1, 2] instead of spanning
+# all four; degrades gracefully to the outer layers on a 2-layer board.
+_ESCAPE_CORRIDOR_INNER_LAYERS_ONLY = True
+
 
 @dataclass
 class RoutingFailure:
@@ -2707,7 +2743,7 @@ class Autorouter:
             (ip_a, in_a), (ip_b, in_b) = chosen
             nc = self.net_class_map.get(p_name) or self.net_class_map.get(n_name)
             if nc is None:
-                nc = synth_routing.get(net_to_class.get(p_name, ""), None)
+                nc = synth_routing.get(net_to_class.get(p_name, ""))
             if nc is None:
                 self._lattice_pair_outcomes[pair_name] = "no-net-class"
                 continue
@@ -4277,6 +4313,23 @@ class Autorouter:
             estimator,
             net_pad_positions=net_pad_positions,
             kelvin_roots=kelvin_roots,
+            # Selectivity + length + layer tuning (#4519).  PR #4509 reserved
+            # every cluster over all four layers (U3 9/9, U10 11/11, ~25.9k
+            # SOFT cells) because these knobs sat at their permissive library
+            # defaults -- a SOFT attractor everywhere carries no discriminating
+            # signal and can pull unrelated nets into the congested band.  The
+            # three constants below make a reservation a *selective, bounded,
+            # inner-layer* signal (measured on board-05: ~25.9k cells over
+            # [0,1,2,3] -> ~2.9k cells over [1,2]):
+            #   * min_reserve_demand_frac: only clusters near the peak-congested
+            #     cluster reserve a channel (an uncongested face is a no-op).
+            #   * max_corridor_length_mm: caps a corridor to a local escape
+            #     channel a few mm long instead of a board-spanning band.
+            #   * inner_layers_only: keeps escape attractors off the outer
+            #     component layers.
+            min_reserve_demand_frac=_ESCAPE_CORRIDOR_MIN_RESERVE_DEMAND_FRAC,
+            max_corridor_length_mm=_ESCAPE_CORRIDOR_MAX_LENGTH_MM,
+            inner_layers_only=_ESCAPE_CORRIDOR_INNER_LAYERS_ONLY,
         )
 
         # Mutate the existing list in place (do NOT rebind) so a lazily-built

--- a/src/kicad_tools/router/escape_corridor.py
+++ b/src/kicad_tools/router/escape_corridor.py
@@ -170,6 +170,36 @@ class EscapeCorridorPlanner:
             (before the demand multiplier).
         max_corridor_length_mm: Optional cap on how far a corridor extends
             from the launch point (defaults to the destination distance).
+        min_reserve_demand: Absolute demand floor -- a cluster whose
+            aggregated ``CongestionEstimator`` demand is at or below this
+            value is skipped (no reservation).  The permissive ``0.0``
+            default only skips exactly-zero-demand clusters; a real board
+            wants a positive floor (or ``min_reserve_demand_frac``) so only
+            genuinely congested clusters reserve a channel (#4519).
+        min_reserve_demand_frac: Selectivity floor expressed as a fraction of
+            the *most-congested cluster's* demand in the plan (#4519).  A
+            cluster is skipped unless its demand exceeds
+            ``min_reserve_demand_frac * max(cluster.demand for the plan)`` --
+            i.e. only clusters near the peak-congested one reserve a channel,
+            which is the "only the congested cluster gets a channel" intent.
+            This is scale-free (self-calibrating per package) and, unlike a
+            fraction of the estimator's *per-tile* peak, actually discriminates
+            on a real board: ``cluster.demand`` aggregates several pin tiles,
+            so on a dense part every face's cluster typically sums above the
+            single-tile peak and a per-tile fraction fails to trim anything
+            (measured on board-05's U3/U10, #4519).  The effective threshold
+            is ``max(min_reserve_demand, min_reserve_demand_frac *
+            max_cluster_demand)``.  Defaults to ``0.0`` (no relative gating)
+            so the library default reserves every nonzero-demand cluster; a
+            production caller (``router/core.py``) supplies a positive
+            fraction to make the reservation selective.
+        inner_layers_only: When True, restrict corridor layer assignment to
+            the stack's INNER routable layers (#4519, Scope item 3), keeping
+            the outer component layers free of escape attractors.  Degrades
+            gracefully to all routable layers when the stack has no inner
+            layers (e.g. a 2-layer board).  Defaults to False (assign over
+            all routable layers, inner-preferred) so existing callers are
+            unchanged.
     """
 
     def __init__(
@@ -182,6 +212,8 @@ class EscapeCorridorPlanner:
         cells_per_pin: float = 1.0,
         max_corridor_length_mm: float | None = None,
         min_reserve_demand: float = 0.0,
+        min_reserve_demand_frac: float = 0.0,
+        inner_layers_only: bool = False,
     ) -> None:
         self.grid = grid
         self.congestion = congestion_estimator
@@ -190,6 +222,8 @@ class EscapeCorridorPlanner:
         self.cells_per_pin = float(cells_per_pin)
         self.max_corridor_length_mm = max_corridor_length_mm
         self.min_reserve_demand = float(min_reserve_demand)
+        self.min_reserve_demand_frac = float(min_reserve_demand_frac)
+        self.inner_layers_only = bool(inner_layers_only)
 
     # ------------------------------------------------------------------
     # Public API
@@ -216,6 +250,11 @@ class EscapeCorridorPlanner:
         unrelated nets (the #4087 hard-fence hazard).  Reservation is
         advisory: a cluster with no owner nets or no cells is skipped.
         """
+        # Selectivity threshold (#4519).  Combine the absolute floor with the
+        # relative floor (a fraction of the most-congested cluster's demand) so
+        # a reservation is a *selective* signal -- only genuinely congested
+        # clusters reserve a channel, not every face of a dense part.
+        threshold = self._reserve_threshold(plan.clusters)
         total = 0
         for cluster in plan.clusters:
             if cluster.layer_idx is None or not cluster.corridor_cells or not cluster.net_ids:
@@ -225,8 +264,9 @@ class EscapeCorridorPlanner:
             # reserved channel -- reserving one would only fence copper for
             # no benefit.  Skip it (no-op) when demand is at/under the
             # threshold.  When no estimator was supplied the planner runs in
-            # demand-agnostic mode and reserves every cluster.
-            if self.congestion is not None and cluster.demand <= self.min_reserve_demand:
+            # demand-agnostic mode and reserves every cluster (the threshold
+            # is only consulted when a congestion estimator is present).
+            if self.congestion is not None and cluster.demand <= threshold:
                 continue
             count = self.grid.reserve_corridor_cells(
                 layer_idx=cluster.layer_idx,
@@ -416,6 +456,29 @@ class EscapeCorridorPlanner:
             total += self.congestion.get_tile_demand(row, col)
         return total
 
+    def _reserve_threshold(self, clusters: list[EscapeCluster]) -> float:
+        """Effective per-cluster demand floor for the :meth:`reserve` gate.
+
+        Combines the absolute :attr:`min_reserve_demand` floor with the
+        relative :attr:`min_reserve_demand_frac` floor (a fraction of the
+        most-congested cluster's demand in this plan).  A cluster reserves a
+        channel only when its aggregated demand strictly exceeds this value
+        (#4519).
+
+        The relative term self-calibrates per package: it ranks each cluster
+        against the plan's peak cluster demand, so the gate keeps only the
+        clusters nearest the congestion peak regardless of the board's
+        absolute demand magnitude -- no global magic number.  A per-tile peak
+        does not work here because ``cluster.demand`` aggregates several tiles
+        and typically sums above the single-tile peak on a dense part (#4519).
+        """
+        threshold = self.min_reserve_demand
+        if self.min_reserve_demand_frac > 0.0 and clusters:
+            max_demand = max((c.demand for c in clusters), default=0.0)
+            if max_demand > 0.0:
+                threshold = max(threshold, self.min_reserve_demand_frac * max_demand)
+        return threshold
+
     def _peak_demand(self) -> float:
         """Peak per-tile demand across the estimator (0 when unavailable)."""
         if self.congestion is None:
@@ -458,6 +521,12 @@ class EscapeCorridorPlanner:
         layers where a dense part's in-pad vias drop to, keeping the outer
         (component) layers freer.  Falls back to whatever routable layers
         exist (2-layer boards have only outer layers).
+
+        When :attr:`inner_layers_only` is set (#4519, Scope item 3), the
+        outer layers are dropped entirely so escape attractors never land on
+        the component layers -- unless the stack has no inner layers (a
+        2-layer board), in which case the outer layers are retained so
+        assignment does not degrade to an empty set.
         """
         stack = getattr(self.grid, "layer_stack", None)
         get_routable = getattr(self.grid, "get_routable_indices", None)
@@ -472,5 +541,7 @@ class EscapeCorridorPlanner:
             outer = set(stack.get_outer_layer_indices())
             inner = [i for i in routable if i not in outer]
             outers = [i for i in routable if i in outer]
+            if self.inner_layers_only and inner:
+                return inner
             return inner + outers
         return routable

--- a/tests/router/test_escape_corridor.py
+++ b/tests/router/test_escape_corridor.py
@@ -236,6 +236,201 @@ def test_zero_demand_estimator_is_noop_reservation(grid_4layer: RoutingGrid) -> 
 
 
 # =============================================================================
+# 2b. Selectivity threshold (#4519): only genuinely congested clusters reserve
+# =============================================================================
+
+
+def _make_ns_pair() -> tuple[PackageInfo, dict[int, list[tuple[float, float]]]]:
+    """A minimal 2-pin part: one pin escaping N, one escaping S, far apart so
+    each lands in a distinct congestion tile (no face/tile overlap)."""
+    n_pad = Pad(x=CENTER, y=5.0, width=0.25, height=0.25, net=1, net_name="N_NET", ref="U9")
+    s_pad = Pad(x=CENTER, y=25.0, width=0.25, height=0.25, net=2, net_name="S_NET", ref="U9")
+    npp = {
+        1: [(CENTER, 5.0), (CENTER, 1.0)],  # off-package pad due north
+        2: [(CENTER, 25.0), (CENTER, 29.0)],  # off-package pad due south
+    }
+    pkg = make_package([n_pad, s_pad], ref="U9")
+    return pkg, npp
+
+
+def _south_hot_estimator(pkg: PackageInfo, s_pad_xy: tuple[float, float]) -> CongestionEstimator:
+    """Estimator with demand 100 in ONLY the tile holding ``s_pad_xy``."""
+    tgrid = TileGrid.from_board(0.0, 0.0, BOARD, BOARD, target_tiles=100)
+    demand = [[0.0] * tgrid.cols for _ in range(tgrid.rows)]
+    col, row = tgrid.tile_at(*s_pad_xy)
+    demand[row][col] = 100.0
+    est = CongestionEstimator(grid=tgrid)
+    est.demand = demand
+    return est
+
+
+def test_relative_threshold_reserves_only_congested_cluster(
+    grid_4layer: RoutingGrid,
+) -> None:
+    """#4519: with a relative-to-peak floor, only the congested (south) cluster
+    reserves a channel; the uncongested cluster is a no-op.
+
+    Without the floor (default 0.0) every nonzero-demand cluster reserves --
+    the PR #4509 over-reservation.  With ``min_reserve_demand_frac`` set, a
+    cluster reserves only when ``cluster.demand / peak_tile_demand`` exceeds
+    the fraction, so a diffuse low-demand face is skipped.
+    """
+    pkg, npp = _make_ns_pair()
+    est = _south_hot_estimator(pkg, (CENTER, 25.0))
+
+    # Baseline: no relative floor -> both clusters reserve (the over-reservation
+    # -- even the zero-demand north cluster is not skipped, only exactly-zero is,
+    # and the north tile IS exactly zero here so it is skipped; use a tiny base
+    # to demonstrate the permissive path reserves a diffuse cluster too).
+    est_base = _south_hot_estimator(pkg, (CENTER, 25.0))
+    n_col, n_row = est_base.grid.tile_at(CENTER, 5.0)
+    est_base.demand[n_row][n_col] = 1.0  # tiny nonzero north demand
+    permissive = EscapeCorridorPlanner(grid_4layer, est_base, net_pad_positions=npp)
+    permissive_plan = permissive.plan_and_reserve(pkg)
+    assert {c.face for c in permissive_plan.clusters if c.reserved_cell_count > 0} == {"N", "S"}
+
+    # Selective: a 0.5 * peak floor keeps only the south hotspot cluster.
+    grid_2 = RoutingGrid(
+        BOARD, BOARD, grid_4layer.rules, origin_x=0, origin_y=0, layer_stack=grid_4layer.layer_stack
+    )
+    selective = EscapeCorridorPlanner(
+        grid_2, est, net_pad_positions=npp, min_reserve_demand_frac=0.5
+    )
+    selective_plan = selective.plan_and_reserve(pkg)
+    reserved_faces = {c.face for c in selective_plan.clusters if c.reserved_cell_count > 0}
+    assert reserved_faces == {"S"}
+    assert selective_plan.total_reserved_cells > 0
+    assert selective_plan.total_reserved_cells < permissive_plan.total_reserved_cells
+
+
+def test_cluster_below_relative_threshold_is_skipped(grid_4layer: RoutingGrid) -> None:
+    """A nonzero-but-below-threshold cluster reserves zero cells; one above it
+    reserves a nonzero count (the selectivity contract, #4519)."""
+    pads, npp = make_dense_qfn()
+    pkg = make_package(pads)
+    est = uniform_estimator(peak_south=100.0, base=2.0)
+    planner = EscapeCorridorPlanner(
+        grid_4layer, est, net_pad_positions=npp, min_reserve_demand_frac=0.5
+    )
+    plan = planner.plan_and_reserve(pkg)
+    threshold = planner._reserve_threshold(plan.clusters)
+    south = next(c for c in plan.clusters if c.face == "S")
+    north = next(c for c in plan.clusters if c.face == "N")
+    # North sits in base-demand tiles (well under 0.5 * the peak cluster) -> skipped.
+    assert north.demand <= threshold
+    assert north.reserved_cell_count == 0
+    # South is the peak-congested cluster -> above threshold, reserves cells.
+    assert south.demand > threshold
+    assert south.reserved_cell_count > 0
+
+
+def test_relative_threshold_ignored_without_estimator(grid_4layer: RoutingGrid) -> None:
+    """Demand-agnostic mode (no estimator) reserves every cluster regardless of
+    the relative floor -- the gate is only consulted when an estimator exists."""
+    pads, npp = make_dense_qfn()
+    pkg = make_package(pads)
+    planner = EscapeCorridorPlanner(
+        grid_4layer, None, net_pad_positions=npp, min_reserve_demand_frac=0.9
+    )
+    plan = planner.plan_and_reserve(pkg)
+    assert plan.total_reserved_cells > 0
+    reserved_faces = {c.face for c in plan.clusters if c.reserved_cell_count > 0}
+    assert reserved_faces == {"N", "S", "E", "W"}
+
+
+# =============================================================================
+# 2c. Corridor-length cap (#4519): a corridor stays a local escape channel
+# =============================================================================
+
+
+def test_max_corridor_length_caps_reserved_extent(grid_4layer: RoutingGrid) -> None:
+    """A corridor with ``max_corridor_length_mm`` set never extends past the cap
+    from the cluster origin along the escape direction (#4519)."""
+    # A far destination (dest_dist large) would otherwise span most of the board.
+    pads, npp = make_dense_qfn(dest_dist=12.0)
+    pkg = make_package(pads)
+    est = uniform_estimator(base=5.0)
+
+    cap_mm = 2.0
+    capped = EscapeCorridorPlanner(
+        grid_4layer, est, net_pad_positions=npp, max_corridor_length_mm=cap_mm
+    )
+    capped_plan = capped.plan(pkg)
+
+    for cluster in capped_plan.clusters:
+        dx, dy = cluster.escape_dir
+        ox, oy = cluster.origin
+        for gx, gy in cluster.corridor_cells:
+            wx, wy = grid_4layer.grid_to_world(gx, gy)
+            # Longitudinal distance (projection onto the escape direction).
+            along = (wx - ox) * dx + (wy - oy) * dy
+            # Allow one grid resolution of slack for cell-center quantization.
+            assert along <= cap_mm + grid_4layer.resolution
+
+
+def test_uncapped_corridor_reaches_farther_than_capped(grid_4layer: RoutingGrid) -> None:
+    """The cap is load-bearing: an uncapped corridor reserves strictly more
+    cells than a short-capped one for the same far destination (#4519)."""
+    pads, npp = make_dense_qfn(dest_dist=12.0)
+    pkg = make_package(pads)
+    est = uniform_estimator(base=5.0)
+
+    capped = EscapeCorridorPlanner(
+        grid_4layer, est, net_pad_positions=npp, max_corridor_length_mm=2.0
+    )
+    capped_plan = capped.plan_and_reserve(pkg)
+
+    grid_b = RoutingGrid(
+        BOARD, BOARD, grid_4layer.rules, origin_x=0, origin_y=0, layer_stack=grid_4layer.layer_stack
+    )
+    uncapped = EscapeCorridorPlanner(grid_b, est, net_pad_positions=npp)
+    uncapped_plan = uncapped.plan_and_reserve(pkg)
+
+    assert capped_plan.total_reserved_cells < uncapped_plan.total_reserved_cells
+
+
+# =============================================================================
+# 3b. Inner-layer restriction (#4519, Scope item 3)
+# =============================================================================
+
+
+def test_inner_layers_only_confines_to_inner_layers(grid_4layer: RoutingGrid) -> None:
+    """With ``inner_layers_only`` set, no cluster is assigned an outer
+    (component) layer on a 4-layer stack (#4519)."""
+    pads, npp = make_dense_qfn()
+    pkg = make_package(pads)
+    est = uniform_estimator(base=5.0)  # all clusters congested
+    outer = set(grid_4layer.layer_stack.get_outer_layer_indices())
+
+    planner = EscapeCorridorPlanner(grid_4layer, est, net_pad_positions=npp, inner_layers_only=True)
+    plan = planner.plan_and_reserve(pkg)
+    used = plan.layers_used()
+    assert used  # something was assigned
+    assert used.isdisjoint(outer)  # never an outer/component layer
+
+    # Sanity: without the flag the same clusters DO spread onto outer layers.
+    grid_b = RoutingGrid(
+        BOARD, BOARD, grid_4layer.rules, origin_x=0, origin_y=0, layer_stack=grid_4layer.layer_stack
+    )
+    unrestricted = EscapeCorridorPlanner(grid_b, est, net_pad_positions=npp)
+    unrestricted_plan = unrestricted.plan_and_reserve(pkg)
+    assert unrestricted_plan.layers_used() & outer
+
+
+def test_inner_layers_only_degrades_on_2layer(grid_2layer: RoutingGrid) -> None:
+    """A 2-layer board has no inner layers; ``inner_layers_only`` must not
+    crash or reserve nothing -- it falls back to the outer routable layers."""
+    pads, npp = make_dense_qfn()
+    pkg = make_package(pads)
+    est = uniform_estimator(base=5.0)
+    planner = EscapeCorridorPlanner(grid_2layer, est, net_pad_positions=npp, inner_layers_only=True)
+    plan = planner.plan_and_reserve(pkg)  # must not raise
+    used = plan.layers_used()
+    assert used
+    assert used.issubset(set(grid_2layer.get_routable_indices()))
+
+
+# =============================================================================
 # 3. Layer assignment
 # =============================================================================
 


### PR DESCRIPTION
## Summary

The congestion-aware escape-corridor planner (#4474) exposes `min_reserve_demand` / `max_corridor_length_mm` kwargs, but the production call site `Autorouter._reserve_escape_corridors` (`router/core.py`) left both at their permissive library defaults. As the Judge diagnosed on PR #4509, that reserved **every** cluster over **all four** layers (board-05 U3 9/9, U10 11/11, ~25.9k SOFT cells) — a diffuse attractor field with no discriminating signal that can pull unrelated nets into the congested band, which regressed board-05's blocking gate (11 → 13) when the board was opted in.

This PR delivers the **selectivity + corridor-length tuning** the issue titles: a reservation becomes a *selective, bounded, inner-layer* signal. The board-05 opt-in is deliberately **not** re-added (see Acceptance below).

## Changes

- **`router/escape_corridor.py`**
  - Redefine `min_reserve_demand_frac` as a fraction of the **most-congested cluster's** demand in each plan (self-calibrating per package): only clusters near the congestion peak reserve a channel. A fraction of the estimator's *per-tile* peak was tried first and rejected — `cluster.demand` aggregates several pin tiles and typically **sums above** the single-tile peak on a dense part, so a per-tile fraction trims nothing (proven on board-05's U3/U10 below).
  - `_reserve_threshold` now takes the plan's clusters and combines the absolute floor with the relative (max-cluster) floor.
  - Add `inner_layers_only` option: restrict corridor layer assignment to inner routable layers; degrades gracefully to the outer layers on a 2-layer board.
- **`router/core.py`** — wire tuned constants at the `_reserve_escape_corridors` call site (internal tuning, not new CLI surface):
  - `_ESCAPE_CORRIDOR_MIN_RESERVE_DEMAND_FRAC = 0.7`
  - `_ESCAPE_CORRIDOR_MAX_LENGTH_MM = 5.0`
  - `_ESCAPE_CORRIDOR_INNER_LAYERS_ONLY = True`
  - Incidental: fix a pre-existing repo-wide **SIM910** lint error (introduced by #4288) that left main's `ruff check .` gate red — unrelated to this change but blocks every PR's CI.
- **`tests/router/test_escape_corridor.py`** — 7 new tests for the selectivity threshold, the corridor-length cap, and the inner-layer restriction (plus 2-layer degradation).

## Real-board evidence (reservation-only probe, board-05 unrouted PCB)

| config | U3 | U10 | total cells | layers |
|---|---|---|---|---|
| PR #4509 permissive | 9/9 | 11/11 | **25875** | [0,1,2,3] |
| this PR (0.7 + 5mm + inner-only) | **2/9** | **8/11** | **2886** | **[1,2]** |

The 25875 figure exactly matches the Judge's CI log (15734 + 10141). An 89% footprint reduction, a genuine small subset, confined to inner layers.

## Acceptance Criteria Verification

- [x] **Non-zero / core-supplied `min_reserve_demand`** — `min_reserve_demand_frac` (max-cluster basis) wired from core.py; reserves a small subset on board-05 (U3 2/9, U10 8/11), not 9/9 + 11/11.
- [x] **`max_corridor_length_mm` cap from core.py** — set to 5.0 mm; unit-tested that reserved cells never extend past the cap.
- [x] **Layer restriction (Scope item 3)** — `inner_layers_only` confines board-05 reservations to layers [1,2].
- [x] **Unit coverage** on the synthetic dense-QFN fixture for selectivity + length cap + inner-layer + edge cases (no-estimator, 2-layer).
- [x] **No `--max-blocking` threshold bump** — the gate is untouched.
- [ ] **Re-add board-05 opt-in** — **deliberately deferred.** Its acceptance gate is a CI-container `blocking_incomplete_count` measurement; per the board-05 CI job's own docs (#3822) a local macOS run is **not comparable** to the CI baseline, the CI re-route is nondeterministic, and PR #4509 was rejected for re-adding the opt-in speculatively. The reservation-footprint evidence above is strong but does not by itself prove the *blocking count* won't move. The guard test `test_design_does_not_enable_escape_corridor_reservation` is left intact (still passing). A follow-up issue tracks the CI-measured opt-in re-add.

## Test Plan

- [x] `uv run pytest tests/router/test_escape_corridor.py` — 19 passed (12 existing + 7 new).
- [x] `uv run pytest tests/test_board_05_batch_completion.py` — 6 passed (guard test still green).
- [x] `uv run ruff format <changed> --check` — clean; `uv run ruff check .` — clean (whole repo, after the SIM910 fix).
- [x] `uv run kct build-native` — C++ backend built; reservation probe run against the real board-05 PCB.

Closes #4519
