### PR TITLE
board-05 Phase 6 closeout (rescoped): pin exit-code gate + tighten CI blocking bound

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1643,35 +1643,32 @@ jobs:
   board-05-routing-regression:
     # Issue #3822: blocking-net baseline gate for board 05 ("bldc-motor-
     # controller").  Board 05 is the only demo board whose routing changes
-    # CANNOT be validated on the local macOS host: the committed CI-generated
-    # artifact reaches 7 blocking signal nets, but an unmodified host regen of
-    # the same recipe/seed/backend reaches ~11 (the macOS host router reaches
-    # fewer nets than the Linux CI router).  Because of that divergence there
-    # was no validation path for board-05 routing work (#3775, #3766) -- this
-    # job provides one by regenerating + re-routing board 05 INSIDE the CI
-    # container and hard-asserting blocking_incomplete_count <= 11.
+    # CANNOT be validated on the local macOS host: an unmodified host regen of
+    # the recipe/seed/backend reaches fewer nets than the Linux CI router.
+    # Because of that divergence there was no validation path for board-05
+    # routing work (#3775, #3766) -- this job provides one by regenerating +
+    # re-routing board 05 INSIDE the CI container and hard-asserting
+    # blocking_incomplete_count <= 7.
     #
-    # CI RE-ROUTE IS NONDETERMINISTIC (9-10); THRESHOLD IS A TEMPORARY LOOSE
-    # BOUND OF 11 (issue #3836).  The committed on-disk artifact is 7 blocking,
-    # but that 7-blocking board is NOT reproducible from the current recipe AND
-    # a fresh full re-route inside CI (timeout raised to 90 min so it runs to
-    # completion) is itself nondeterministic at its floor: it MEASURES
-    # blocking_incomplete_count = 9 OR 10 depending on the run (observed:
-    # main=9, PR #3835 branch=10 on two consecutive runs with IDENTICAL router
-    # code; blocking nets hover around ISENSE_A+/-, ISENSE_B+/-, ISENSE_C-,
-    # PHASE_A/B/C, PWM_BH, +HALL_A intermittently).  The 7 -> 9/10 gap between
-    # the committed artifact and a fresh CI re-route is the board-05 routing
-    # reproducibility regression tracked in #3775 / #3766 / #3829.  The
-    # previous default of 9 sat EXACTLY on the nondeterministic 9-vs-10 floor,
-    # so a coin-flip re-route intermittently red-lighted PRs that never touched
-    # the router (#3836, observed on PR #3835).  --max-blocking is therefore
-    # set to 11, a safe margin above the observed CI ceiling of 10, so the gate
-    # stops flaking.  This is a TEMPORARY loose bound, not the end state: the
-    # gate stays a hard assertion (no continue-on-error) and still catches
-    # GROSS regressions (> 11).  The proper fix is a DETERMINISTIC re-route
-    # (pin seed / iteration order), after which --max-blocking should be
-    # tightened back toward 7 (the committed artifact) then 0 -- tracked in
-    # #3775 / #3766 / #3829.
+    # PHASE 5 LOWERED THE FRESH-REGEN FLOOR FROM 9-10 TO 6; THRESHOLD IS NOW 7
+    # (issue #4479).  The committed on-disk artifact is hand-verified at 0
+    # blocking (PR #4003, DRC-clean + LVS-clean), but that gold board is NOT
+    # reproducible from a fully-unattended regen yet.  A fresh full re-route
+    # inside CI (timeout raised to 90 min so it runs to completion) MEASURED
+    # blocking_incomplete_count = 6 on commit 2de4089a, with Phase 5's
+    # Kelvin-star rooting + batch-completion + rescue-revival wiring active
+    # (PR #4527 / #4532; CI run 30666373355).  The residual cohort is
+    # ISENSE_A-, ISENSE_B-, ISENSE_C-, PHASE_A, PHASE_B, PHASE_C.  That is a
+    # large win over the pre-Phase-5 floor of 9-10 (nondeterministic run-to-run
+    # per #3836), though still short of the committed artifact's 0.
+    # --max-blocking is therefore set to 7 -- one net of safety margin above the
+    # measured CI ceiling of 6, the same "+1 above the observed ceiling"
+    # methodology the previous loose bound of 11 (10 + 1) used -- so the gate
+    # locks in Phase 5's gain (11 -> 7) while tolerating the historical
+    # run-to-run nondeterminism.  The gate stays a hard assertion (no
+    # continue-on-error) and still catches GROSS regressions (> 7).  Tighten
+    # further toward 0 as #4548 (escape-corridor reservation, targeting the
+    # PHASE_A/B/C south-escape congestion) and the ISENSE -leg follow-up land.
     #
     # Unlike boards 00-03/06/07, board 05 has NO committed output/lvs.json on
     # origin/main, so the --lvs-only e2e asserter is not reusable.  The
@@ -1680,27 +1677,24 @@ jobs:
     # NetStatusAnalyzer.blocking_incomplete_count (which mirrors the
     # check_routed_drc advisory/plane-residual filtering).
     #
-    # The --max-blocking threshold defaults to 11 (a TEMPORARY loose bound
-    # above the observed nondeterministic CI ceiling of 10) and is a CLI arg so
-    # #3775/#3766/#3829 can tighten it back toward 7/0 once the re-route is
-    # deterministic.  <= 11 catches GROSS regressions without flaking on the
-    # 9-vs-10 nondeterminism.
+    # The --max-blocking threshold defaults to 7 (one net above the
+    # Phase-5-measured CI ceiling of 6) and is a CLI arg so #4548 / the ISENSE
+    # -leg follow-up can tighten it toward 0 as they land.  <= 7 catches GROSS
+    # regressions without flaking on board-05's historical nondeterminism.
     #
-    # Issue #3887 (SUPERSEDED by #3894): #3887 migrated board 05's main pass +
-    # rescue loop from the --per-net-timeout wall-clock cutoff to a fixed per-net
+    # Pre-Phase-5 history (why the bound was 11 before):
+    # Issue #3836: the wall-clock re-route was nondeterministic at 9-10 blocking
+    # (observed main=9, PR #3835 branch=10 twice, identical router code); a
+    # default of 9 sat exactly on the boundary and red-lighted unrelated PRs, so
+    # it was loosened to 11 (10 + 1).
+    # Issue #3887 (SUPERSEDED by #3894): migrated board 05's main pass + rescue
+    # loop from the --per-net-timeout wall-clock cutoff to a fixed per-net
     # ITERATION budget, claiming determinism; that claim did not hold up on CI.
-    #
-    # Issue #3894: REVERTED #3887's deterministic per-net ITERATION budget on
-    # board 05 back to the pre-#3887 wall-clock recipe (--per-net-timeout 60 /
-    # --timeout 900).  #3887's iteration budget did LESS total routing work than
-    # the wall-clock outer rip-up/reroute loop, so it completed FEWER nets and
-    # REGRESSED this job's blocking count to 12-15 (vs the historical wall-clock
-    # 9-10); the byte-determinism it promised was never actually achieved on CI.
-    # The wall-clock recipe is board 05's known-GREEN state (<=11).  It is
-    # admittedly nondeterministic run-to-run (~9-10), so --max-blocking STAYS at
-    # 11 (the loose bound above the observed CI ceiling of 10); genuine board-05
-    # routing determinism -- and any tightening toward 7/0 -- is deferred to
-    # #3775 / #3766 / #3829.
+    # Issue #3894: REVERTED #3887's iteration budget back to the wall-clock
+    # recipe (--per-net-timeout 60 / --timeout 900); #3887's budget did LESS
+    # total routing work and REGRESSED the count to 12-15.  Per #3822 the
+    # CI-measured blocking_incomplete_count is authoritative, so the threshold
+    # is only tightened on CI-measured evidence (as here for Phase 5).
     #
     # The ``Build C++ router backend`` step is REQUIRED: the recipe re-routes
     # during regen, and per CLAUDE.md a missing native extension makes routing
@@ -1724,12 +1718,12 @@ jobs:
     # verdict.  The run was on track for ~45-55 min wall-clock, so the budget
     # is set generously to 90 min to let the full route + rescue loop + gate
     # run to completion and emit a REAL blocking-net count.  With the timeout
-    # raised, the run completed and MEASURED 9-10 blocking nets (nondeter-
-    # ministic), so the gate is set to <= 11 to clear the ceiling without
-    # flaking (#3836) -- see the floor note above.  This is
+    # raised, the run completed and MEASURED 6 blocking nets with Phase 5 active
+    # (down from the pre-Phase-5 9-10), so the gate is set to <= 7 to clear the
+    # measured ceiling without flaking -- see the floor note above.  This is
     # intentionally higher than every other job (next-highest is the 45-min
     # Test job) because no other job runs the board-05 rescue loop from clean.
-    name: Board 05 Routing Regression (blocking <= 11)
+    name: Board 05 Routing Regression (blocking <= 7)
     runs-on: ubuntu-latest
     timeout-minutes: 90
     container:
@@ -1777,24 +1771,23 @@ jobs:
             /tmp/board05-ci || true
           test -f /tmp/board05-ci/bldc_controller_routed.kicad_pcb
 
-      - name: Assert blocking-net baseline (<= 11, a temporary loose bound)
-        # Hard gate: fails the job (exit 2) if blocking_incomplete_count > 11.
-        # 11 is a TEMPORARY loose bound (issue #3836): board-05's CI re-route is
-        # NONDETERMINISTIC (9-10 blocking; observed main=9, PR #3835 branch=10
-        # twice with identical router code) and diverges from the committed
-        # artifact (7 blocking).  The previous default of 9 sat exactly on the
-        # 9-vs-10 boundary and intermittently red-lighted unrelated PRs, so the
-        # threshold is set a safe margin above the observed ceiling of 10.  The
-        # gate still catches GROSS regressions (> 11).  The 7 -> 9/10 gap is the
-        # board-05 reproducibility regression tracked in #3775/#3766/#3829; the
-        # proper fix is a DETERMINISTIC re-route, then tightening --max-blocking
-        # back toward 7/0.  A LOCAL macOS run would report ~11 -- the documented
-        # host-vs-CI divergence (#3822), not a job defect.  No
-        # continue-on-error: this stays a hard gate and now reliably goes GREEN.
+      - name: Assert blocking-net baseline (<= 7, Phase-5 measured + 1 margin)
+        # Hard gate: fails the job (exit 2) if blocking_incomplete_count > 7.
+        # 7 is one net above the Phase-5-measured CI ceiling of 6 (issue #4479):
+        # board-05's CI re-route reaches 6 blocking (ISENSE_A-/B-/C-, PHASE_A/B/C)
+        # with Phase 5 active and diverges from the committed 0-blocking artifact
+        # (PR #4003).  The threshold uses the same "+1 above the observed
+        # ceiling" methodology the pre-Phase-5 bound of 11 (10 + 1) used, so it
+        # locks in Phase 5's gain while tolerating board-05's historical
+        # run-to-run nondeterminism.  The gate still catches GROSS regressions
+        # (> 7).  Tighten toward 0 as #4548 (escape-corridor reservation) and the
+        # ISENSE -leg follow-up land.  A LOCAL macOS run would report more
+        # blocking nets -- the documented host-vs-CI divergence (#3822), not a
+        # job defect.  No continue-on-error: this stays a hard gate.
         run: |
           set -euo pipefail
           uv run python scripts/ci/check_board_05_blocking.py \
-            --max-blocking 11 \
+            --max-blocking 7 \
             /tmp/board05-ci/bldc_controller_routed.kicad_pcb
 
   board-04-end-to-end:

--- a/boards/05-bldc-motor-controller/design.py
+++ b/boards/05-bldc-motor-controller/design.py
@@ -2963,8 +2963,11 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
     # FET->motor PHASE pads are scattered across the whole board, so a
     # bounding-box pour island shorts against the rail pours.  Net: PHASE
     # connectivity is placement-bound on this board and needs a targeted
-    # U3-south relayout (tracked as a follow-up).  Left skipped here until
-    # that placement work lands so the committed routing does not regress.
+    # U3-south relayout / escape-channel relief -- now tracked concretely as
+    # #4548 (re-add board-05's escape-corridor reservation opt-in after CI
+    # blocking-count validation), which targets exactly this PHASE_A/B/C
+    # south-escape-channel congestion.  Left skipped here until #4548 lands so
+    # the committed routing does not regress.
     skip_nets = ["+24V", "+5V", "+3V3", "GND", "PHASE_A", "PHASE_B", "PHASE_C"]
 
     cmd = [

--- a/scripts/ci/check_board_05_blocking.py
+++ b/scripts/ci/check_board_05_blocking.py
@@ -2,63 +2,62 @@
 """Board-05 blocking-net baseline gate for CI (issue #3822).
 
 Board-05 (BLDC motor controller) is the only demo board whose routing
-changes cannot be validated on the local macOS development host: the
-committed CI-generated artifact reaches **7 blocking signal nets**, but an
-unmodified local regen of the same recipe/seed/backend reaches ~11 (the
-macOS host router reaches fewer nets than the Linux CI router on the
-identical recipe). See the recipe note in
+changes cannot be validated on the local macOS development host: an
+unmodified local regen of the recipe reaches fewer nets than the Linux CI
+router on the identical recipe/seed/backend (host-vs-CI reach divergence,
+#3822). See the recipe note in
 ``boards/05-bldc-motor-controller/design.py`` (~lines 2870-2871).
 
-CI re-route is NONDETERMINISTIC (9-10 blocking); threshold is a TEMPORARY loose bound of 11
--------------------------------------------------------------------------------------------
-The committed on-disk artifact is 7 blocking, but that 7-blocking board is
-NOT reproducible from the current recipe -- a fresh full re-route INSIDE
-CI (kicad/kicad:10.0, timeout raised to 90 min so it runs to completion)
-is ALSO nondeterministic at its floor: it measures
-**blocking_incomplete_count = 9 OR 10 depending on the run** (observed:
-main re-routes to 9, the PR #3835 branch -- whose router code is identical
-to main -- re-routed to 10 on two consecutive CI runs). The blocking nets
-hover around: ISENSE_A+, ISENSE_A-, ISENSE_B+, ISENSE_B-, ISENSE_C-,
-PHASE_A, PHASE_B, PHASE_C, PWM_BH (+ HALL_A intermittently). The 7 -> 9/10
-gap between the committed artifact and a fresh CI re-route is the board-05
-routing reproducibility regression tracked in **#3775 / #3766 / #3829**.
+Phase 5 lowered the fresh-regen floor from 9-10 to 6; threshold is now 7
+----------------------------------------------------------------------
+The **committed** on-disk artifact
+(``boards/05-bldc-motor-controller/output/bldc_controller_routed.kicad_pcb``)
+is hand-verified at **0 blocking** signal nets (PR #4003, DRC-clean and
+LVS-clean). That gold artifact is NOT reproducible from a fully-unattended
+regen yet. A fresh full re-route INSIDE CI (kicad/kicad:10.0, timeout
+raised to 90 min so it runs to completion) measured
+**blocking_incomplete_count = 6** on commit 2de4089a -- with the Phase-5
+Kelvin-star rooting + batch-completion + rescue-revival wiring active
+(PR #4527 / #4532; CI run 30666373355). The residual blocking cohort is
+``ISENSE_A-, ISENSE_B-, ISENSE_C-, PHASE_A, PHASE_B, PHASE_C``. That is a
+large win over the pre-Phase-5 floor of 9-10 (historically nondeterministic
+run-to-run), but still short of the committed artifact's 0.
 
-``--max-blocking`` therefore defaults to **11** -- a TEMPORARY loose bound
-chosen to stop CI flakiness. The previous default of 9 sat EXACTLY on the
-nondeterministic 9-vs-10 boundary, so a coin-flip re-route red-lighted PRs
-that never touched the router (issue #3836, observed on PR #3835). 11 is a
-safe margin above the observed CI ceiling of 10, so the gate stops flaking
-while remaining a hard assertion (no ``continue-on-error``) that still
-catches GROSS regressions (anything > 11 blocking).
+``--max-blocking`` therefore defaults to **7** -- one net of safety margin
+above the Phase-5-measured CI ceiling of 6, the same "+1 above the observed
+ceiling" methodology the previous loose bound of 11 (10 + 1) used. This
+locks in Phase 5's gain (11 -> 7) while tolerating board-05's historical
+run-to-run nondeterminism, so the gate stops flaking while remaining a hard
+assertion (no ``continue-on-error``) that still catches GROSS regressions
+(anything > 7 blocking).
 
-This is a deliberately LOOSE, temporary bound -- not the end state. The
-proper fix is to make the board-05 re-route DETERMINISTIC (pin seed /
-iteration order) and then tighten ``--max-blocking`` back toward 7 (the
-committed artifact) and ultimately 0, locking in each gain. That work is
-tracked in **#3775 / #3766 / #3829**.
+This bound is still not the end state. As #4548 (re-add
+``--escape-corridor-reservation`` after CI blocking-count validation, which
+targets the PHASE_A/B/C south-escape congestion) and a dedicated follow-up
+for the ISENSE ``-``-leg residuals land, tighten ``--max-blocking`` further
+toward 0, locking in each gain.
 
 Validation path for board-05 routing changes
 ---------------------------------------------
 Regenerate board-05 **in the CI environment** (the ``kicad/kicad:10.0``
 container) and let the board-05 CI job assert
-``blocking_incomplete_count <= 11`` via this gate. A LOCAL run of this gate
-after a full host regen reports ~11 -- that is the documented host-vs-CI
-reach divergence (#3822), NOT a defect in this script or the job. The
-authoritative verdict is the PR's own CI run.
+``blocking_incomplete_count <= 7`` via this gate. A LOCAL run of this gate
+after a full host regen reports more blocking nets -- that is the documented
+host-vs-CI reach divergence (#3822), NOT a defect in this script or the job.
+The authoritative verdict is the PR's own CI run.
 
 This gate loads the routed board-05 PCB and asserts that the number of
-blocking incomplete nets does not exceed ``--max-blocking`` (default 11).
+blocking incomplete nets does not exceed ``--max-blocking`` (default 7).
 It reuses :class:`kicad_tools.analysis.net_status.NetStatusAnalyzer` --
 whose ``blocking_incomplete_count`` "Mirrors
 ``scripts/ci/check_routed_drc.py:_count_blocking_errors``", i.e. it applies
 the same advisory/plane-residual filtering the DRC gate uses -- rather than
 re-deriving the metric.
 
-The ``--max-blocking`` threshold is a CLI argument (default 11, a temporary
-loose bound above the observed nondeterministic CI ceiling of 10) so future
-PRs (#3775 PHASE relayout, #3766 complete the blocking nets, #3829 make the
-re-route deterministic) can tighten it to 7, ... 0 as they land routing
-improvements, locking in each gain.
+The ``--max-blocking`` threshold is a CLI argument (default 7, one net above
+the Phase-5-measured CI ceiling of 6) so future PRs (#4548 escape-corridor
+reservation, the ISENSE ``-``-leg follow-up) can tighten it toward 0 as
+they land routing improvements, locking in each gain.
 
 Exit codes (mirrors ``scripts/ci/check_routed_drc.py``):
     0 -- Blocking count within threshold (job passes).
@@ -75,35 +74,35 @@ import argparse
 import sys
 from pathlib import Path
 
-# TEMPORARY loose bound (issue #3836). A fresh full re-route of board-05
-# (kicad/kicad:10.0, 90-min timeout) is NONDETERMINISTIC at its floor: it
-# reaches 9 OR 10 blocking nets depending on the run (observed: main=9,
-# PR #3835 branch=10 twice, with identical router code). The committed
-# on-disk artifact is 7, which is itself not reproducible from the current
-# recipe. The previous default of 9 sat exactly on the 9-vs-10 boundary and
-# intermittently red-lighted unrelated PRs. 11 is a safe margin above the
-# observed CI ceiling of 10, so the gate stops flaking while still catching
-# gross regressions (> 11). The proper fix is a DETERMINISTIC re-route, after
-# which this should be tightened back toward 7 then 0 -- tracked in
-# #3775 / #3766 / #3829.
+# Phase-5 bound (issue #4479). A fresh full re-route of board-05
+# (kicad/kicad:10.0, 90-min timeout) measured blocking_incomplete_count = 6
+# on commit 2de4089a, with Phase 5's Kelvin-star rooting + batch-completion +
+# rescue-revival wiring active (PR #4527 / #4532; CI run 30666373355). The
+# residual cohort is ISENSE_A-, ISENSE_B-, ISENSE_C-, PHASE_A, PHASE_B,
+# PHASE_C. That is a large win over the pre-Phase-5 floor of 9-10 (which was
+# nondeterministic run-to-run), though still short of the committed artifact's
+# 0 blocking (hand-verified, PR #4003). 7 is one net of safety margin above
+# the measured CI ceiling of 6 -- the same "+1 above the observed ceiling"
+# methodology the previous loose bound of 11 (10 + 1) used -- so the gate
+# stops flaking while still catching gross regressions (> 7). Tighten further
+# toward 0 as #4548 (escape-corridor reservation) and the ISENSE -leg
+# follow-up land.
 #
-# Issue #3887 (SUPERSEDED by #3894): #3887 moved board-05's main pass + rescue
-# loop from the wall-clock --per-net-timeout cutoff to a fixed per-net
-# ITERATION budget, claiming determinism. That claim did not hold up on CI.
-#
-# Issue #3894: REVERTED #3887's deterministic per-net ITERATION budget on
-# board 05 back to the pre-#3887 wall-clock recipe (--per-net-timeout 60 /
-# --timeout 900). #3887's budget did LESS total routing work than the
-# wall-clock outer rip-up/reroute loop, so it completed FEWER nets and
-# REGRESSED this count to 12-15 (vs the historical wall-clock 9-10); the
-# byte-determinism it promised was also never actually achieved on CI.
-# Restoring the wall-clock recipe returns board 05 to its known-GREEN state
-# (<=11). The threshold STAYS at 11: the wall-clock re-route is nondeterministic
-# run-to-run (~9-10), and per #3822 the CI-measured blocking_incomplete_count is
-# authoritative, so any tightening toward the documented target of 7 is a
-# deliberate follow-up gated on a genuine board-05 determinism fix
-# (#3775 / #3766 / #3829), NOT a locally-guessed number.
-DEFAULT_MAX_BLOCKING = 11
+# History (why the bound was 11 before Phase 5):
+# Issue #3836: the pre-Phase-5 wall-clock re-route was NONDETERMINISTIC at 9-10
+# blocking (observed main=9, PR #3835 branch=10 twice, identical router code);
+# a default of 9 sat exactly on the 9-vs-10 boundary and intermittently
+# red-lighted unrelated PRs, so it was loosened to 11 (10 + 1).
+# Issue #3887 (SUPERSEDED by #3894): moved board-05's main pass + rescue loop
+# from the wall-clock --per-net-timeout cutoff to a fixed per-net ITERATION
+# budget, claiming determinism. That claim did not hold up on CI.
+# Issue #3894: REVERTED #3887's per-net ITERATION budget back to the wall-clock
+# recipe (--per-net-timeout 60 / --timeout 900); #3887's budget did LESS total
+# routing work and REGRESSED the count to 12-15. Per #3822 the CI-measured
+# blocking_incomplete_count is authoritative, so this bound is only tightened
+# on CI-measured evidence (as it is here for Phase 5), NOT a locally-guessed
+# number.
+DEFAULT_MAX_BLOCKING = 7
 
 
 def annotate_error(file: str, message: str) -> None:
@@ -185,16 +184,15 @@ def check_pcb(pcb_path: Path, max_blocking: int) -> tuple[int, str]:
     return (
         2,
         f"Board-05 blocking-net regression: {count} blocking incomplete net(s) "
-        f"exceeds --max-blocking={max_blocking}. This threshold is a TEMPORARY "
-        f"loose bound (issue #3836): board-05's CI re-route is NONDETERMINISTIC "
-        f"(9-10 blocking) and diverges from the committed artifact (7), so the "
-        f"default of 11 sits a safe margin above the observed CI ceiling of 10 "
-        f"to stop flakiness. The gate still catches GROSS regressions (> 11). "
-        f"The proper fix is a DETERMINISTIC re-route, then tightening this back "
-        f"toward 7 then 0 -- tracked in #3775/#3766/#3829. Either fix the "
-        f"routing or, if the floor truly moved, adjust --max-blocking in the CI "
-        f"job with reviewer sign-off. NOTE: a LOCAL macOS run routes board-05 to "
-        f"~11 blocking nets; this gate is CI-validated only (#3822)."
+        f"exceeds --max-blocking={max_blocking}. The default of 7 is one net "
+        f"above the Phase-5-measured CI ceiling of 6 (issue #4479): board-05's "
+        f"CI re-route reaches 6 blocking with Phase 5 active, while the committed "
+        f"artifact is 0 blocking (PR #4003). The gate still catches GROSS "
+        f"regressions (> 7). Tighten this further toward 0 as #4548 (escape- "
+        f"corridor reservation) and the ISENSE -leg follow-up land. Either fix "
+        f"the routing or, if the floor truly moved, adjust --max-blocking in the "
+        f"CI job with reviewer sign-off. NOTE: a LOCAL macOS run routes board-05 "
+        f"to more blocking nets; this gate is CI-validated only (#3822)."
         f"{names_suffix}",
     )
 
@@ -215,11 +213,11 @@ def main(argv: list[str] | None = None) -> int:
         default=DEFAULT_MAX_BLOCKING,
         help=(
             "Maximum allowed blocking_incomplete_count before the gate fails "
-            f"(default: {DEFAULT_MAX_BLOCKING}, a TEMPORARY loose bound above "
-            "the observed nondeterministic CI ceiling of 10; board-05's CI "
-            "re-route is nondeterministic at 9-10 and diverges from the "
-            "committed artifact of 7 -- issue #3836). Tighten this back toward "
-            "7/0 once the re-route is made deterministic (#3775/#3766/#3829)."
+            f"(default: {DEFAULT_MAX_BLOCKING}, one net above the Phase-5- "
+            "measured CI ceiling of 6; board-05's CI re-route reaches 6 blocking "
+            "with Phase 5 active and diverges from the committed 0-blocking "
+            "artifact -- issue #4479). Tighten this further toward 0 as #4548 "
+            "and the ISENSE -leg follow-up land."
         ),
     )
     args = parser.parse_args(argv)

--- a/tests/test_board_05_batch_completion.py
+++ b/tests/test_board_05_batch_completion.py
@@ -17,7 +17,12 @@ finished nets stay protected.
 These are cheap static (AST) guards -- KiCad-independent, no routing -- that
 pin the wiring and its ordering.  The routing outcome itself is asserted by
 the ``board-05-routing-regression`` CI job
-(``scripts/ci/check_board_05_blocking.py --max-blocking 11``).
+(``scripts/ci/check_board_05_blocking.py --max-blocking 7``).
+
+This module also guards the #3912 exit-code gate: ``main()`` must call
+``evaluate_pipeline_gate(...)`` with ``route_allowance=0`` (a literal ``0``)
+so a PARTIAL route makes ``design.py`` exit non-zero instead of silently
+shipping a worse board (Issue #4479).
 """
 
 from __future__ import annotations
@@ -148,6 +153,46 @@ def test_completion_config_keeps_the_board_rescue_knobs() -> None:
         assert f"{knob}=" not in source, (
             f"_COMPLETION_CONFIG must not override {knob} (Issue #4476 keeps "
             "board-05's rescue knobs unchanged)."
+        )
+
+
+def test_main_pipeline_gate_pins_route_allowance_zero() -> None:
+    """The #3912 exit-code gate must keep ``route_allowance=0`` (a literal 0).
+
+    ``main()`` calls ``evaluate_pipeline_gate(...)`` (design.py ~line 3832)
+    with ``route_allowance=0`` so a PARTIAL route makes ``design.py`` exit
+    non-zero rather than silently shipping a board worse than the committed
+    0-blocking artifact.  Pinning the *literal* ``0`` -- not a variable that
+    could be reassigned elsewhere -- turns "verify the gate holds" into a
+    durable regression guard: any future edit that loosens the allowance to
+    tolerate PARTIAL (a non-zero literal, or a mutable name) fails CI
+    immediately (Issue #4479, #3912).
+    """
+    fn = _main_fn(_design_tree())
+    gate_calls = [
+        node
+        for node in ast.walk(fn)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "evaluate_pipeline_gate"
+    ]
+    assert gate_calls, (
+        "main() must call evaluate_pipeline_gate() -- the #3912 exit-code gate "
+        "that fails design.py on a PARTIAL route (Issue #4479/#3912)."
+    )
+    for call in gate_calls:
+        allowance = next(
+            (kw.value for kw in call.keywords if kw.arg == "route_allowance"),
+            None,
+        )
+        assert allowance is not None, (
+            "evaluate_pipeline_gate(...) must pass route_allowance explicitly (Issue #4479/#3912)."
+        )
+        assert isinstance(allowance, ast.Constant) and allowance.value == 0, (
+            "evaluate_pipeline_gate(...) must pass route_allowance=0 as a "
+            "literal 0 (not a variable that could be silently loosened) so a "
+            "PARTIAL route always fails the gate (Issue #4479/#3912). Got: "
+            f"{ast.unparse(allowance)}"
         )
 
 

--- a/tests/test_check_board_05_blocking.py
+++ b/tests/test_check_board_05_blocking.py
@@ -1,19 +1,18 @@
 """Tests for the board-05 blocking-net CI gate (issue #3822).
 
 ``scripts/ci/check_board_05_blocking.py`` regenerates + routes board 05 in
-CI and asserts ``blocking_incomplete_count <= --max-blocking`` (default 11,
-a TEMPORARY loose bound above the observed nondeterministic CI ceiling of
-10; board-05's CI re-route is nondeterministic at 9-10 and diverges from the
-committed artifact of 7 -- the gap is tracked in #3775/#3766/#3829, and the
-flaky-gate consequence in #3836).
+CI and asserts ``blocking_incomplete_count <= --max-blocking`` (default 7,
+one net above the Phase-5-measured CI ceiling of 6; board-05's CI re-route
+reaches 6 blocking with Phase 5 active and diverges from the committed
+0-blocking artifact -- issue #4479).
 
 The pass/fail VERDICT against a real route is CI-only (the macOS host routes
-board 05 to ~11 blocking nets, not 7 -- the documented host-vs-CI reach
-divergence). These tests therefore exercise the script's *threshold logic*
-against a synthetic blocking count (``count_blocking`` is monkeypatched) so
-the comparison / exit-code behaviour is verified without needing a real
-7-blocking route. They also cover argument parsing and the missing-file
-tool-error path.
+board 05 to more blocking nets than the Linux CI router -- the documented
+host-vs-CI reach divergence, #3822). These tests therefore exercise the
+script's *threshold logic* against a synthetic blocking count
+(``count_blocking`` is monkeypatched) so the comparison / exit-code
+behaviour is verified without needing a real route. They also cover argument
+parsing and the missing-file tool-error path.
 
 The script is loaded via importlib (it lives under ``scripts/ci/`` outside
 the installed package), mirroring ``tests/test_check_board_e2e.py``.
@@ -40,19 +39,19 @@ def _load_helper():
     return module
 
 
-def test_default_threshold_is_temporary_loose_bound() -> None:
+def test_default_threshold_locks_in_phase5_gain() -> None:
     helper = _load_helper()
-    assert helper.DEFAULT_MAX_BLOCKING == 11
+    assert helper.DEFAULT_MAX_BLOCKING == 7
 
 
-def test_default_clears_nondeterministic_ci_floor(tmp_path, monkeypatch) -> None:
-    """Rationale for the default of 11 (issue #3836): board-05's CI re-route is
-    nondeterministic at 9-10 blocking, so the gate must pass at BOTH 9 and 10
-    and only fail above the observed ceiling.
+def test_default_clears_phase5_ci_floor(tmp_path, monkeypatch) -> None:
+    """Rationale for the default of 7 (issue #4479): Phase 5 lowered board-05's
+    fresh-regen CI floor to 6 blocking, so the gate must pass at the measured
+    ceiling of 6 (and at the exact bound of 7) and only fail above it.
 
-    This documents WHY 11 was chosen: 9 (main) and 10 (PR #3835 branch, twice,
-    identical router code) must both be green so the gate stops flaking, while
-    12 (a gross regression beyond the ceiling) must still red.
+    This documents WHY 7 was chosen: 6 (the Phase-5 CI measurement) must be
+    green with one net of margin, while 8 (a gross regression beyond the
+    bound) must still red.
     """
     helper = _load_helper()
     pcb = tmp_path / "bldc_controller_routed.kicad_pcb"
@@ -65,23 +64,21 @@ def test_default_clears_nondeterministic_ci_floor(tmp_path, monkeypatch) -> None
             lambda _p: (count, [f"NET{i}" for i in range(count)]),
         )
 
-    # 9 and 10 -- the observed nondeterministic CI floor/ceiling -- both pass.
-    route_to(9)
-    assert helper.check_pcb(pcb, max_blocking=helper.DEFAULT_MAX_BLOCKING)[0] == 0
-    route_to(10)
+    # 6 -- the Phase-5-measured CI ceiling -- passes with one net of margin.
+    route_to(6)
     assert helper.check_pcb(pcb, max_blocking=helper.DEFAULT_MAX_BLOCKING)[0] == 0
 
-    # 11 (the exact bound) still passes; 12 (gross regression) fails.
-    route_to(11)
+    # 7 (the exact bound) still passes; 8 (gross regression) fails.
+    route_to(7)
     assert helper.check_pcb(pcb, max_blocking=helper.DEFAULT_MAX_BLOCKING)[0] == 0
-    route_to(12)
+    route_to(8)
     exit_code, message = helper.check_pcb(pcb, max_blocking=helper.DEFAULT_MAX_BLOCKING)
     assert exit_code == 2
     assert "regression" in message.lower()
 
 
 def test_check_pcb_passes_at_ci_ceiling(tmp_path, monkeypatch) -> None:
-    """10 blocking nets (observed CI ceiling) with --max-blocking 11 -> exit 0."""
+    """6 blocking nets (Phase-5 CI ceiling) with --max-blocking 7 -> exit 0."""
     helper = _load_helper()
     pcb = tmp_path / "bldc_controller_routed.kicad_pcb"
     pcb.write_text("(kicad_pcb)")
@@ -89,28 +86,28 @@ def test_check_pcb_passes_at_ci_ceiling(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(
         helper,
         "count_blocking",
-        lambda _p: (10, [f"NET{i}" for i in range(10)]),
+        lambda _p: (6, [f"NET{i}" for i in range(6)]),
     )
 
-    exit_code, message = helper.check_pcb(pcb, max_blocking=11)
+    exit_code, message = helper.check_pcb(pcb, max_blocking=7)
     assert exit_code == 0
-    assert "10 blocking incomplete net(s)" in message
+    assert "6 blocking incomplete net(s)" in message
 
 
 def test_check_pcb_passes_when_below_threshold(tmp_path, monkeypatch) -> None:
-    """A future improvement (5 blocking) still passes the <= 11 gate."""
+    """A future improvement (5 blocking) still passes the <= 7 gate."""
     helper = _load_helper()
     pcb = tmp_path / "bldc_controller_routed.kicad_pcb"
     pcb.write_text("(kicad_pcb)")
 
     monkeypatch.setattr(helper, "count_blocking", lambda _p: (5, ["A", "B", "C", "D", "E"]))
 
-    exit_code, _ = helper.check_pcb(pcb, max_blocking=11)
+    exit_code, _ = helper.check_pcb(pcb, max_blocking=7)
     assert exit_code == 0
 
 
 def test_check_pcb_fails_on_gross_regression(tmp_path, monkeypatch) -> None:
-    """12 blocking nets (beyond the observed ceiling) with default -> exit 2."""
+    """12 blocking nets (well beyond the bound) with default -> exit 2."""
     helper = _load_helper()
     pcb = tmp_path / "bldc_controller_routed.kicad_pcb"
     pcb.write_text("(kicad_pcb)")
@@ -121,36 +118,36 @@ def test_check_pcb_fails_on_gross_regression(tmp_path, monkeypatch) -> None:
         lambda _p: (12, [f"NET{i}" for i in range(12)]),
     )
 
-    exit_code, message = helper.check_pcb(pcb, max_blocking=11)
+    exit_code, message = helper.check_pcb(pcb, max_blocking=7)
     assert exit_code == 2
     assert "regression" in message.lower()
     assert "12 blocking incomplete net(s)" in message
 
 
 def test_check_pcb_fails_when_threshold_below_actual(tmp_path, monkeypatch) -> None:
-    """--max-blocking 0 against the measured 10 -> exit 2 (test-plan check)."""
+    """--max-blocking 0 against the measured 6 -> exit 2 (test-plan check)."""
     helper = _load_helper()
     pcb = tmp_path / "bldc_controller_routed.kicad_pcb"
     pcb.write_text("(kicad_pcb)")
 
-    monkeypatch.setattr(helper, "count_blocking", lambda _p: (10, [f"NET{i}" for i in range(10)]))
+    monkeypatch.setattr(helper, "count_blocking", lambda _p: (6, [f"NET{i}" for i in range(6)]))
 
     exit_code, _ = helper.check_pcb(pcb, max_blocking=0)
     assert exit_code == 2
 
 
 def test_check_pcb_fails_when_tightened_toward_committed(tmp_path, monkeypatch) -> None:
-    """Tightening --max-blocking to 7 (the committed artifact) fails at the
-    current nondeterministic floor of 9-10 -- this is the lever
-    #3775/#3766/#3829 will pull once the re-route is deterministic and the
-    floor drops back to 7."""
+    """Tightening --max-blocking to 0 (the committed artifact) fails at the
+    current fresh-regen floor of 6 -- this is the lever #4548 (escape-corridor
+    reservation) and the ISENSE -leg follow-up will pull as they close the
+    remaining blocking cohort toward 0."""
     helper = _load_helper()
     pcb = tmp_path / "bldc_controller_routed.kicad_pcb"
     pcb.write_text("(kicad_pcb)")
 
-    monkeypatch.setattr(helper, "count_blocking", lambda _p: (9, [f"NET{i}" for i in range(9)]))
+    monkeypatch.setattr(helper, "count_blocking", lambda _p: (6, [f"NET{i}" for i in range(6)]))
 
-    exit_code, _ = helper.check_pcb(pcb, max_blocking=7)
+    exit_code, _ = helper.check_pcb(pcb, max_blocking=0)
     assert exit_code == 2
 
 
@@ -169,11 +166,11 @@ def test_main_prints_measured_count_on_pass(tmp_path, monkeypatch, capsys) -> No
     pcb = tmp_path / "bldc_controller_routed.kicad_pcb"
     pcb.write_text("(kicad_pcb)")
 
-    monkeypatch.setattr(helper, "count_blocking", lambda _p: (7, [f"NET{i}" for i in range(7)]))
+    monkeypatch.setattr(helper, "count_blocking", lambda _p: (6, [f"NET{i}" for i in range(6)]))
 
     assert helper.main([str(pcb)]) == 0
     out = capsys.readouterr().out
-    assert "MEASURED blocking_incomplete_count = 7" in out
+    assert "MEASURED blocking_incomplete_count = 6" in out
 
 
 def test_main_prints_measured_count_on_regression(tmp_path, monkeypatch, capsys) -> None:
@@ -204,12 +201,12 @@ def test_main_parses_max_blocking_arg(tmp_path, monkeypatch) -> None:
     pcb = tmp_path / "bldc_controller_routed.kicad_pcb"
     pcb.write_text("(kicad_pcb)")
 
-    monkeypatch.setattr(helper, "count_blocking", lambda _p: (10, ["A", "B"]))
+    monkeypatch.setattr(helper, "count_blocking", lambda _p: (6, ["A", "B"]))
 
-    # default 11 -> 10 passes
+    # default 7 -> 6 passes
     assert helper.main([str(pcb)]) == 0
-    # tightened to 7 -> 10 fails
-    assert helper.main([str(pcb), "--max-blocking", "7"]) == 2
+    # tightened to 5 -> 6 fails
+    assert helper.main([str(pcb), "--max-blocking", "5"]) == 2
 
 
 def test_main_rejects_negative_threshold(tmp_path) -> None:


### PR DESCRIPTION
## Summary

Rescoped closeout for #4479 (Phase 6 of the board-05 epic #4410). Per the Curator's 2026-07-31 rewrite, the original "enable by default + regen + 100% route" scope is no longer achievable/desirable: a fresh unattended regen today measures 6 blocking nets, strictly worse than the committed 0-blocking artifact (PR #4003), so regenerating would regress the shipped board. This PR implements the three dependency-free items that remain, and deliberately does **not** regen/commit the routed artifact or flip `--escape-corridor-reservation` (owned by open issue #4548).

## Changes

1. **AST guard test** (`tests/test_board_05_batch_completion.py`): new `test_main_pipeline_gate_pins_route_allowance_zero` asserts `main()`'s `evaluate_pipeline_gate(...)` call passes `route_allowance=0` as a **literal 0** (not a mutable variable). This turns the #3912 exit-code gate from a one-time manual read into a durable regression guard -- any future edit that loosens the allowance to tolerate PARTIAL fails CI immediately. Reuses the existing `_design_tree()`/`_main_fn()` helpers. Verified it fails when the literal is mutated to a non-zero value.
2. **Tighten `DEFAULT_MAX_BLOCKING` 11 -> 7** (`scripts/ci/check_board_05_blocking.py` + the matching `--max-blocking` arg, job `name:`, and comments in `.github/workflows/ci.yml`). Phase 5 measured `blocking_incomplete_count=6` on a fresh unattended CI regen (commit 2de4089a, run 30666373355). 7 applies the same "+1 above the observed ceiling" methodology the old bound of 11 (10+1) used, locking in the 9-10 -> 6 gain. Stale pre-Phase-5 docstrings/comments (the "committed artifact is 7 blocking" / "9-10 baseline" narrative) are updated to the Phase-5 state, and the coupled assertions in `tests/test_check_board_05_blocking.py` are updated to match the new threshold/floor.
3. **Docstring-only** (`boards/05-bldc-motor-controller/design.py`): the PHASE_A/B/C skip-list note now cites **#4548** by number instead of a vague "tracked as a follow-up" placeholder. No flag/functional change; the committed PCB artifact is untouched.

## Acceptance Criteria (revised scope)

- [x] AST guard pins `route_allowance=0` (literal) in the #3912 gate; fails if loosened.
- [x] `DEFAULT_MAX_BLOCKING` tightened to 7 (CI-measured 6 + 1 margin) in both the script and ci.yml; stale docstrings updated.
- [x] PHASE_A/B/C skip-list note cites #4548 by number (comment-only).
- [x] Committed `bldc_controller_routed.kicad_pcb` / `.kicad_pro`/`.kicad_prl`/`.kicad_dru` untouched; `kct route` flag list untouched.

## Test Plan

- `uv run pytest tests/test_board_05_batch_completion.py tests/test_board_05_drc_hotspot_regression.py tests/test_board_05_drc_allowlist.py tests/test_check_board_05_blocking.py` -- all green (25 passed, 1 pre-fix failure resolved; see below).
- `uv run ruff format` + `uv run ruff check` on all changed Python files -- clean.
- Negative check: mutating `route_allowance=0` -> `=1` in a copy of design.py makes the new guard detect the failure (confirmed).
- CI verification: the `board-05-routing-regression` job (`kicad/kicad:10.0`) will re-measure `blocking_incomplete_count` against the new `--max-blocking 7`. If a legitimately-nondeterministic run exceeds 7, the +1 margin should be revisited per the same methodology.

## Notes for reviewer

- `tests/test_check_board_05_blocking.py` was not in the Curator's Affected-Files list, but it directly pins `DEFAULT_MAX_BLOCKING == 11` and the 9-10 pass/fail narrative, so it had to be updated in lockstep with the threshold change (otherwise it would fail CI). The updates are mechanical (11 -> 7, 9-10 floor -> 6).
- Threshold value (7) chosen from the single CI-measured sample of 6 in the issue body + the documented "+1 safety margin" methodology; I do not have a local `kicad-cli`/CI container to run additional samples. If CI shows the floor is a range (e.g. 6-7), the bound may need +1 more.

Closes #4479

🤖 Generated with [Claude Code](https://claude.com/claude-code)