### PR TITLE
feat(creepage): export KiCad netclass-pair rules for referee-enforceable HV clearance

### DIFF
--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -58,6 +58,7 @@ from .commands import (
     run_constraints_command,
     run_create_pcb_command,
     run_creepage_command,
+    run_creepage_export_rules_command,
     run_datasheet_command,
     run_decisions_command,
     run_doctor_command,
@@ -290,6 +291,9 @@ def _dispatch_command(args) -> int:
 
     elif args.command == "creepage":
         return run_creepage_command(args)
+
+    elif args.command == "creepage-export-rules":
+        return run_creepage_export_rules_command(args)
 
     elif args.command == "sch":
         return run_sch_command(args)

--- a/src/kicad_tools/cli/commands/__init__.py
+++ b/src/kicad_tools/cli/commands/__init__.py
@@ -22,6 +22,7 @@ from .build import run_build_command
 from .config import run_config_command, run_interactive_command
 from .create_pcb import run_create_pcb_command
 from .creepage import run_creepage_command
+from .creepage_export_rules import run_creepage_export_rules_command
 from .datasheet import run_datasheet_command
 from .decisions import run_decisions_command
 from .doctor import run_doctor_command
@@ -88,6 +89,7 @@ __all__ = [
     # Validation
     "run_check_command",
     "run_creepage_command",
+    "run_creepage_export_rules_command",
     "run_validate_command",
     "run_validate_footprints_command",
     "run_fix_footprints_command",

--- a/src/kicad_tools/cli/commands/creepage_export_rules.py
+++ b/src/kicad_tools/cli/commands/creepage_export_rules.py
@@ -1,0 +1,173 @@
+"""``kct creepage-export-rules`` command handler (Issue #4508).
+
+Emits referee-enforceable KiCad artifacts from a ``--voltage-map`` +
+creepage-standard input:
+
+* voltage-domain **netclasses** + net-name patterns into ``<project>.kicad_pro``,
+  and
+* pairwise clearance **(rule ...)** clauses into a sentinel-delimited block in
+  ``<project>.kicad_dru``,
+
+so ``kicad-cli pcb drc`` independently confirms the pairwise HV<->LV creepage
+requirement kct's own router/placement/census already enforce (the project's
+two-engine 0-DRC manufacturability bar).
+
+This is a NEW SIBLING top-level command (``kct creepage-export-rules``), not a
+subcommand of the flat ``kct creepage <pcb>`` census -- restructuring ``creepage``
+into a group would break its documented flat invocation.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def run_creepage_export_rules_command(args) -> int:
+    """Handle ``creepage-export-rules``.  Returns the process exit code."""
+    from kicad_tools.core.project_file import load_project, save_project
+    from kicad_tools.creepage.engine import voltage_map_from_dict
+    from kicad_tools.creepage.export_rules import (
+        apply_netclass_assignments,
+        build_export,
+        merge_dru_block,
+        render_dru_block_body,
+    )
+    from kicad_tools.creepage.standards import StandardLookupError
+    from kicad_tools.schema.pcb import PCB
+
+    project_path = Path(args.project)
+    if not project_path.exists():
+        print(f"Error: project file not found: {project_path}", file=sys.stderr)
+        return 1
+    if project_path.suffix != ".kicad_pro":
+        print(
+            f"Error: expected a .kicad_pro project file, got {project_path.name}",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Resolve the sibling board (nets + footprints) and the .kicad_dru target.
+    pcb_arg = getattr(args, "pcb", None)
+    pcb_path = Path(pcb_arg) if pcb_arg else project_path.with_suffix(".kicad_pcb")
+    dru_path = project_path.with_suffix(".kicad_dru")
+
+    # No voltage map -> clean no-op (nothing to derive, nothing written).
+    vmap_arg = getattr(args, "voltage_map", None)
+    if not vmap_arg:
+        print(
+            "No --voltage-map supplied: nothing to export "
+            "(pairwise HV rules are derived from the voltage map).  No files written."
+        )
+        return 0
+
+    vmap_path = Path(vmap_arg)
+    if not vmap_path.exists():
+        print(f"Error: voltage-map file not found: {vmap_path}", file=sys.stderr)
+        return 1
+    try:
+        intervals, _edge_voltage = voltage_map_from_dict(json.loads(vmap_path.read_text()))
+    except json.JSONDecodeError as e:
+        print(f"Error: parsing voltage-map JSON: {e}", file=sys.stderr)
+        return 1
+    except (TypeError, ValueError) as e:
+        print(f"Error: invalid voltage-map structure: {e}", file=sys.stderr)
+        return 1
+
+    # Collapse each net's interval to its worst-case magnitude (the domain model
+    # is magnitude-only, matching placement's load_voltage_map).
+    voltage_map = {name: max(abs(iv.lo), abs(iv.hi)) for name, iv in intervals.items()}
+
+    if not pcb_path.exists():
+        print(f"Error: board file not found: {pcb_path}", file=sys.stderr)
+        print(
+            "  (netclass patterns + domain-bridging exemptions require the .kicad_pcb; "
+            "pass --pcb to point at it explicitly).",
+            file=sys.stderr,
+        )
+        return 1
+    pcb = PCB.load(pcb_path)
+    net_names = [n.name for n in pcb.nets.values() if n.number != 0 and n.name]
+
+    # Resolve the DRU clearance floor: explicit flag wins, else the project's
+    # own min_clearance, else a conservative default.
+    dru_floor = getattr(args, "dru_floor", None)
+    project_data = load_project(project_path)
+    if dru_floor is None:
+        dru_floor = _project_min_clearance(project_data)
+    dru_floor = float(dru_floor)
+
+    try:
+        plan = build_export(
+            voltage_map,
+            net_names,
+            pcb.footprints,
+            standard_id=getattr(args, "standard", "iec60664") or "iec60664",
+            pollution_degree=getattr(args, "pollution_degree", 2) or 2,
+            material_group=getattr(args, "material_group", "IIIa") or "IIIa",
+            hv_threshold=getattr(args, "hv_threshold", 30.0),
+            dru_floor_mm=dru_floor,
+        )
+    except StandardLookupError as e:
+        # Safety-critical: fail LOUD, never emit a guessed number.
+        print(f"Error: standard-table lookup failed: {e}", file=sys.stderr)
+        return 1
+
+    if plan.is_empty:
+        print("No mapped nets matched the board -- nothing to export.  No files written.")
+        return 0
+
+    dru_body = render_dru_block_body(plan)
+    dru_block = merge_dru_block(
+        dru_path.read_text() if dru_path.exists() else None,
+        dru_body,
+    )
+
+    _print_summary(plan, project_path, pcb_path, dru_path)
+
+    if getattr(args, "dry_run", False):
+        print("\n--- .kicad_dru block (dry run, not written) ---")
+        print(dru_body)
+        return 0
+
+    apply_netclass_assignments(project_data, plan)
+    save_project(project_data, project_path)
+    dru_path.write_text(dru_block)
+    print(f"\nWrote {len(plan.domain_voltages)} netclass(es) -> {project_path.name}")
+    print(f"Wrote {len(plan.rules)} pairwise rule(s) -> {dru_path.name}")
+    return 0
+
+
+def _project_min_clearance(project_data: dict) -> float:
+    """Best-effort read of the project's board-wide minimum clearance (mm)."""
+    try:
+        rules = project_data.get("board", {}).get("design_settings", {}).get("rules", {})
+        val = rules.get("min_clearance")
+        if isinstance(val, (int, float)) and val > 0:
+            return float(val)
+    except (AttributeError, TypeError):
+        pass
+    return 0.2
+
+
+def _print_summary(plan, project_path: Path, pcb_path: Path, dru_path: Path) -> None:
+    print("kct creepage-export-rules")
+    print(f"  Project: {project_path}")
+    print(f"  Board:   {pcb_path}")
+    print(f"  DRU:     {dru_path}")
+    print(f"  DRU clearance floor: {plan.dru_floor_mm:g} mm")
+    print(
+        f"  Voltage domains ({len(plan.domain_voltages)}): "
+        + ", ".join(f"{d}={plan.domain_voltages[d]:g}V" for d in sorted(plan.domain_voltages))
+    )
+    print(f"  Nets assigned: {len(plan.net_domains)}")
+    if plan.rules:
+        print(f"  Pairwise rules ({len(plan.rules)}):")
+        for rule in plan.rules:
+            print(f"    - {rule.name}: clearance >= {rule.min_mm:g} mm")
+    else:
+        print("  Pairwise rules: none (no domain pair exceeds the DRU floor)")
+    if plan.bridging_by_pair:
+        for (a, b), refs in sorted(plan.bridging_by_pair.items()):
+            print(f"  Attach-zone exemption {a}<->{b}: {', '.join(refs)}")

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -142,6 +142,7 @@ def create_parser() -> argparse.ArgumentParser:
     _add_bom_parser(subparsers)
     _add_check_parser(subparsers)
     _add_creepage_parser(subparsers)
+    _add_creepage_export_rules_parser(subparsers)
     _add_sch_parser(subparsers)
     _add_pcb_parser(subparsers)
     _add_lib_parser(subparsers)
@@ -565,6 +566,92 @@ def _add_creepage_parser(subparsers) -> None:
         choices=["table", "json"],
         default="table",
         help="Output format (default: table)",
+    )
+
+
+def _add_creepage_export_rules_parser(subparsers) -> None:
+    """Add creepage-export-rules parser (referee-enforceable HV rule export, #4508).
+
+    A NEW SIBLING top-level command (NOT a subcommand of the flat ``kct creepage
+    <pcb>`` census): emits voltage-domain netclasses into ``<project>.kicad_pro``
+    and pairwise clearance ``(rule ...)`` clauses into ``<project>.kicad_dru`` so
+    ``kicad-cli pcb drc`` can independently confirm the pairwise HV<->LV creepage
+    requirement.
+    """
+    p = subparsers.add_parser(
+        "creepage-export-rules",
+        help=(
+            "Export voltage-domain netclasses + pairwise HV clearance (rule) "
+            "clauses so kicad-cli DRC enforces creepage (Issue #4508)"
+        ),
+    )
+    p.add_argument("project", help="Path to the .kicad_pro project file")
+    p.add_argument(
+        "--pcb",
+        dest="pcb",
+        default=None,
+        help=(
+            "Path to the .kicad_pcb board (nets + footprints).  Defaults to the "
+            "project's sibling <project>.kicad_pcb."
+        ),
+    )
+    p.add_argument(
+        "--voltage-map",
+        dest="voltage_map",
+        default=None,
+        help=(
+            "Path to a JSON sidecar mapping net names to their RMS working "
+            "potential (volts), same format as `kct creepage --voltage-map`.  "
+            "Without it the command is a clean no-op (nothing written)."
+        ),
+    )
+    p.add_argument(
+        "--standard",
+        choices=["iec60664", "iec62368"],
+        default="iec60664",
+        help="Creepage standard for the derived per-pair minima (default: iec60664).",
+    )
+    p.add_argument(
+        "--pollution-degree",
+        dest="pollution_degree",
+        type=int,
+        choices=[1, 2, 3],
+        default=2,
+        help="IEC pollution degree (default: 2, typical indoor/office FR-4).",
+    )
+    p.add_argument(
+        "--material-group",
+        dest="material_group",
+        choices=["I", "II", "IIIa", "IIIb"],
+        default="IIIa",
+        help="Insulation material group by CTI (default: IIIa, conservative FR-4).",
+    )
+    p.add_argument(
+        "--hv-threshold",
+        dest="hv_threshold",
+        type=float,
+        default=30.0,
+        help=(
+            "Minimum |dV| (volts) for a domain pair to receive a pairwise rule "
+            "(default 30.0 -- aligned with the census/placement HV threshold)."
+        ),
+    )
+    p.add_argument(
+        "--dru-floor",
+        dest="dru_floor",
+        type=float,
+        default=None,
+        help=(
+            "Board-wide DRU clearance floor (mm).  Domain pairs at/below this "
+            "require nothing extra (no rule).  Defaults to the project's "
+            "min_clearance, else 0.2mm."
+        ),
+    )
+    p.add_argument(
+        "--dry-run",
+        dest="dry_run",
+        action="store_true",
+        help="Print the derived netclasses + rules without writing any files.",
     )
 
 

--- a/src/kicad_tools/creepage/export_rules.py
+++ b/src/kicad_tools/creepage/export_rules.py
@@ -1,0 +1,431 @@
+"""Referee-enforceable KiCad rule export from a voltage map (Issue #4508).
+
+Phase 3 of the pairwise HV-isolation clearance epic (#4431).  Phases 1-2 make
+the pairwise HV<->LV clearance requirement enforceable *inside* kct's own
+router/placement/census.  This module makes the SAME requirement enforceable by
+the **external referee** -- ``kicad-cli pcb drc`` -- so a routed HV board is
+independently confirmed against the voltage-map-derived pairwise creepage matrix
+(the project's two-engine manufacturability bar: 0 errors by BOTH kct AND
+kicad-cli).
+
+Two artifacts are emitted from the same ``--voltage-map`` + creepage-standard
+inputs the router/placement/census already consume:
+
+1. **Net -> netclass assignments** -- every mapped net is grouped into a
+   voltage-*domain* netclass (one class per distinct working-voltage magnitude),
+   written into the project's ``net_settings`` (``.kicad_pro``).
+
+2. **Custom ``(rule ...)`` clauses** -- one KiCad netclass-pair clause per domain
+   pair whose required creepage exceeds the board's DRU clearance floor, written
+   into a sentinel-delimited block in ``<project>.kicad_dru`` (which
+   ``kicad-cli pcb drc`` picks up automatically next to the project).
+
+Congruence with the router-side exemptions
+------------------------------------------
+The pairwise matrix reuses
+:func:`kicad_tools.placement.hv_domains.build_required_by_domain_pair`
+verbatim -- the same delta-V -> creepage lookup, the same ``hv_threshold`` floor
+and the same fail-loud out-of-table contract the router (#4511) and census use --
+so the referee and kct can never disagree about the matrix.
+
+The #4506 rated-footprint attach-zone exemption (a domain-bridging package whose
+own pins sit at pin-pitch, e.g. a sense resistor / optocoupler straddling two
+domains, which the board layout cannot pull apart) is expressed **directly in the
+pairwise rule's condition** as an ``insideCourtyard`` exclusion.  Inside such a
+footprint's courtyard the elevated pairwise clearance is *not* applied and the
+board's normal DRU clearance floor governs -- exactly the router-side relaxation
+from #4506 and the same-footprint census waiver from #4403.  Baking the exclusion
+into the condition (rather than a separate, later "relaxation" rule) makes the
+result **independent of KiCad's rule-precedence semantics**: whichever way KiCad
+resolves overlapping rules, a courtyard-internal pair is never subject to the
+elevated bound, and -- crucially -- the exclusion is scoped to a specific
+reference designator's courtyard, so it can never weaken the referee board-wide.
+
+Fallback / no-op
+----------------
+With no voltage map supplied there is nothing to derive; :func:`build_export`
+returns an empty plan and the CLI is a clean no-op (nothing written).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from itertools import combinations
+from typing import Iterable, Mapping, Sequence
+
+from kicad_tools.placement.hv_domains import build_required_by_domain_pair
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Netclass-name prefix that marks a kct-owned voltage-domain class.  Every class
+# / pattern re-emit is idempotent by this prefix: a re-run first drops all
+# ``kct_``-prefixed classes and patterns, then re-adds fresh -- so user-authored
+# classes are preserved and kct-owned ones never duplicate or go stale.
+NETCLASS_PREFIX = "kct_"
+
+# Sentinel markers delimiting the kct-owned block inside a ``.kicad_dru`` file.
+# On re-emit only the text BETWEEN these markers is replaced; any hand-written
+# rules outside the block are preserved.
+DRU_BLOCK_BEGIN = "# BEGIN kct creepage rules (Issue #4508) -- managed, do not edit"
+DRU_BLOCK_END = "# END kct creepage rules"
+
+# KiCad ``.kicad_dru`` files start with a version header.
+DRU_VERSION_HEADER = "(version 1)"
+
+# A required creepage within this tolerance (mm) of the DRU floor adds nothing
+# over the board-wide clearance rule, so no pairwise rule is emitted for it.
+_FLOOR_TOLERANCE = 1e-6
+
+
+def _norm_net_key(name: str) -> str:
+    """Normalise a net name for domain lookup (drop one leading ``/``).
+
+    Mirrors the census (:func:`kicad_tools.creepage.engine._norm_net_key`) and
+    the router (:func:`kicad_tools.router.pairwise_clearance._norm_net_key`) so
+    all three key the same nets regardless of the leading hierarchical slash.
+    """
+    return name[1:] if name.startswith("/") else name
+
+
+def domain_name(volts: float) -> str:
+    """Deterministic netclass name for a working-voltage *magnitude*.
+
+    ``150`` -> ``kct_150V``; ``3.3`` -> ``kct_3p3V``; ``0`` -> ``kct_0V``.  The
+    decimal point is rendered ``p`` so the name is a safe bare token in a KiCad
+    rule condition (``A.NetClass == 'kct_3p3V'``) and a valid netclass name.
+    """
+    token = f"{abs(float(volts)):g}".replace(".", "p").replace("-", "m")
+    return f"{NETCLASS_PREFIX}{token}V"
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RuleClause:
+    """One KiCad custom ``(rule ...)`` clause (clearance constraint)."""
+
+    name: str
+    condition: str
+    min_mm: float
+
+    def render(self) -> str:
+        """Render as ``.kicad_dru`` S-expression text."""
+        return (
+            f'(rule "{self.name}"\n'
+            f'  (condition "{self.condition}")\n'
+            f"  (constraint clearance (min {self.min_mm:g}mm)))"
+        )
+
+
+@dataclass
+class ExportPlan:
+    """The full set of derived artifacts for one board.
+
+    ``net_domains`` maps each *actual* net name to its domain netclass;
+    ``domain_voltages`` maps each domain netclass to its representative voltage
+    magnitude; ``rules`` are the pairwise clearance clauses; and
+    ``bridging_by_pair`` records, per domain pair, the reference designators of
+    domain-bridging footprints excluded from that pair's elevated bound.
+    """
+
+    net_domains: dict[str, str] = field(default_factory=dict)
+    domain_voltages: dict[str, float] = field(default_factory=dict)
+    rules: list[RuleClause] = field(default_factory=list)
+    bridging_by_pair: dict[tuple[str, str], list[str]] = field(default_factory=dict)
+    dru_floor_mm: float = 0.0
+
+    @property
+    def is_empty(self) -> bool:
+        """``True`` when there is nothing to emit (no voltage map / no domains)."""
+        return not self.net_domains and not self.rules
+
+
+# ---------------------------------------------------------------------------
+# Domain derivation
+# ---------------------------------------------------------------------------
+
+
+def build_domains(
+    voltage_map: Mapping[str, float],
+    net_names: Iterable[str],
+) -> tuple[dict[str, str], dict[str, float]]:
+    """Group nets into voltage-domain netclasses.
+
+    A net's domain is determined by the magnitude of its mapped potential; nets
+    sharing a magnitude share a domain.  ``net_names`` supplies the *authoritative*
+    net names (from the PCB) so the emitted netclass patterns match exactly what
+    KiCad sees, regardless of whether the voltage-map author wrote the leading
+    hierarchical ``/``.
+
+    Args:
+        voltage_map: ``{net_name: volts}`` (magnitudes taken with ``abs``).
+        net_names: All net names present on the board.
+
+    Returns:
+        ``(net_domains, domain_voltages)`` where *net_domains* maps each matched
+        actual net name to its domain netclass and *domain_voltages* maps each
+        domain netclass to its voltage magnitude.
+    """
+    norm_map = {_norm_net_key(k): abs(float(v)) for k, v in voltage_map.items()}
+
+    net_domains: dict[str, str] = {}
+    domain_voltages: dict[str, float] = {}
+    for name in net_names:
+        mag = norm_map.get(_norm_net_key(name))
+        if mag is None:
+            continue
+        dname = domain_name(mag)
+        net_domains[name] = dname
+        domain_voltages[dname] = mag
+    return net_domains, domain_voltages
+
+
+def detect_bridging_footprints(
+    footprints: Iterable,
+    net_domains: Mapping[str, str],
+) -> dict[tuple[str, str], list[str]]:
+    """Map each domain pair to the domain-bridging footprints straddling it.
+
+    A footprint *bridges* domains ``a`` and ``b`` when it holds pads on nets in
+    both.  Such a package's own pins sit at pin-pitch (the layout cannot pull
+    them to full creepage), so it is exempted from the elevated pairwise bound --
+    the #4506 rated-footprint attach-zone semantics, expressed here as a
+    per-footprint ``insideCourtyard`` exclusion on the pair's rule.
+
+    Keys are order-independent ``(a, b)`` tuples (sorted); values are sorted,
+    de-duplicated reference-designator lists.
+    """
+    out: dict[tuple[str, str], set[str]] = {}
+    for fp in footprints:
+        ref = getattr(fp, "reference", "") or ""
+        if not ref:
+            continue
+        domains: set[str] = set()
+        for pad in getattr(fp, "pads", []):
+            net_name = getattr(pad, "net_name", "") or ""
+            if not net_name:
+                continue
+            dom = net_domains.get(net_name) or net_domains.get(_norm_net_key(net_name))
+            if dom is not None:
+                domains.add(dom)
+        for a, b in combinations(sorted(domains), 2):
+            out.setdefault((a, b), set()).add(ref)
+    return {pair: sorted(refs) for pair, refs in out.items()}
+
+
+# ---------------------------------------------------------------------------
+# Rule clause construction
+# ---------------------------------------------------------------------------
+
+
+def build_rule_clauses(
+    domain_voltages: Mapping[str, float],
+    bridging_by_pair: Mapping[tuple[str, str], Sequence[str]],
+    *,
+    standard_id: str = "iec60664",
+    pollution_degree: int = 2,
+    material_group: str = "IIIa",
+    hv_threshold: float = 30.0,
+    dru_floor_mm: float = 0.0,
+) -> list[RuleClause]:
+    """Build the pairwise clearance rule clauses above the DRU floor.
+
+    Reuses :func:`kicad_tools.placement.hv_domains.build_required_by_domain_pair`
+    verbatim for the ``{(a, b): required_mm}`` matrix (same table lookup, same
+    ``hv_threshold`` gate, same fail-loud out-of-table contract).  Only pairs
+    whose required creepage is strictly above ``dru_floor_mm`` get a rule -- at
+    or below the floor the board-wide DRU clearance already covers them.
+
+    The referee constraint is ``clearance`` (through-air).  Because creepage is
+    always >= clearance, requiring ``clearance >= required_creepage`` is a
+    conservative (never-under-strict) enforcement of the creepage requirement.
+
+    Raises:
+        StandardLookupError: If any cross-domain ``|dV|`` exceeds the highest
+            tabulated row (propagated from ``build_required_by_domain_pair`` --
+            never silently extrapolated).
+    """
+    required = build_required_by_domain_pair(
+        domain_voltages,
+        standard_id=standard_id,
+        pollution_degree=pollution_degree,
+        material_group=material_group,
+        hv_threshold=hv_threshold,
+    )
+
+    clauses: list[RuleClause] = []
+    for (a, b), req in sorted(required.items()):
+        if req <= dru_floor_mm + _FLOOR_TOLERANCE:
+            continue
+        condition = f"A.NetClass == '{a}' && B.NetClass == '{b}'"
+        for ref in bridging_by_pair.get((a, b), ()):
+            # Exclude intra-footprint proximity for a domain-bridging package:
+            # inside its courtyard the normal DRU clearance floor governs (#4506).
+            condition += f" && !(A.insideCourtyard('{ref}') && B.insideCourtyard('{ref}'))"
+        clauses.append(RuleClause(name=f"kct_creepage_{a}_vs_{b}", condition=condition, min_mm=req))
+    return clauses
+
+
+# ---------------------------------------------------------------------------
+# Top-level plan assembly
+# ---------------------------------------------------------------------------
+
+
+def build_export(
+    voltage_map: Mapping[str, float] | None,
+    net_names: Iterable[str],
+    footprints: Iterable,
+    *,
+    standard_id: str = "iec60664",
+    pollution_degree: int = 2,
+    material_group: str = "IIIa",
+    hv_threshold: float = 30.0,
+    dru_floor_mm: float = 0.0,
+) -> ExportPlan:
+    """Derive the full :class:`ExportPlan` from a voltage map.
+
+    A ``None``/empty voltage map yields an empty plan (the no-op fallback).
+    """
+    if not voltage_map:
+        return ExportPlan(dru_floor_mm=dru_floor_mm)
+
+    net_names = list(net_names)
+    net_domains, domain_voltages = build_domains(voltage_map, net_names)
+    bridging_by_pair = detect_bridging_footprints(footprints, net_domains)
+    rules = build_rule_clauses(
+        domain_voltages,
+        bridging_by_pair,
+        standard_id=standard_id,
+        pollution_degree=pollution_degree,
+        material_group=material_group,
+        hv_threshold=hv_threshold,
+        dru_floor_mm=dru_floor_mm,
+    )
+    # Only report bridging footprints that actually gate an emitted rule (a pair
+    # below the DRU floor has no rule, so its "exemption" is meaningless noise).
+    relevant_bridging = {
+        pair: list(refs)
+        for pair, refs in bridging_by_pair.items()
+        if _pair_has_rule(pair[0], pair[1], rules)
+    }
+    return ExportPlan(
+        net_domains=net_domains,
+        domain_voltages=domain_voltages,
+        rules=rules,
+        bridging_by_pair=relevant_bridging,
+        dru_floor_mm=dru_floor_mm,
+    )
+
+
+def _pair_has_rule(a: str, b: str, rules: Sequence[RuleClause]) -> bool:
+    needle = f"kct_creepage_{a}_vs_{b}"
+    return any(r.name == needle for r in rules)
+
+
+# ---------------------------------------------------------------------------
+# .kicad_pro netclass assignment (idempotent, merge-preserving)
+# ---------------------------------------------------------------------------
+
+
+def apply_netclass_assignments(project_data: dict, plan: ExportPlan) -> None:
+    """Write the voltage-domain netclasses + net patterns into project data.
+
+    Idempotent and merge-preserving: all ``kct_``-prefixed classes/patterns are
+    dropped first (so a stale domain assignment from a prior run never lingers),
+    then the current domains re-added.  User-authored classes/patterns and the
+    project's ``rules``/``defaults`` are never touched.
+    """
+    from kicad_tools.core.project_file import (
+        add_netclass_definition,
+        add_netclass_pattern,
+        get_net_settings,
+    )
+
+    net_settings = get_net_settings(project_data)
+
+    # Drop kct-owned classes/patterns (idempotent re-emit).
+    net_settings["classes"] = [
+        c
+        for c in net_settings.get("classes", [])
+        if not str(c.get("name", "")).startswith(NETCLASS_PREFIX)
+    ]
+    net_settings["netclass_patterns"] = [
+        p
+        for p in net_settings.get("netclass_patterns", [])
+        if not str(p.get("netclass", "")).startswith(NETCLASS_PREFIX)
+    ]
+
+    # Re-add the current domains.  The class's own clearance is set to the DRU
+    # floor -- the elevated pairwise minima live in the .kicad_dru rules, not the
+    # class definition, so this never over-constrains a domain against itself.
+    for dname in sorted(plan.domain_voltages):
+        add_netclass_definition(project_data, dname, clearance=plan.dru_floor_mm or 0.2)
+
+    for net_name in sorted(plan.net_domains):
+        add_netclass_pattern(project_data, plan.net_domains[net_name], net_name)
+
+
+# ---------------------------------------------------------------------------
+# .kicad_dru rule block (idempotent sentinel-delimited merge -- NET-NEW logic)
+# ---------------------------------------------------------------------------
+
+
+def render_dru_block_body(plan: ExportPlan) -> str:
+    """Render the block body: a provenance header comment + the rule clauses."""
+    lines: list[str] = [
+        "# Generated by `kct creepage-export-rules` (Issue #4508).",
+        "# Pairwise HV creepage clearance, referee-enforceable by kicad-cli pcb drc.",
+    ]
+    if plan.domain_voltages:
+        domains = ", ".join(
+            f"{d}={plan.domain_voltages[d]:g}V" for d in sorted(plan.domain_voltages)
+        )
+        lines.append(f"# Voltage domains: {domains}")
+    if plan.bridging_by_pair:
+        for (a, b), refs in sorted(plan.bridging_by_pair.items()):
+            lines.append(
+                f"# Attach-zone exemption ({a}<->{b}): {', '.join(refs)} "
+                "(domain-bridging footprint(s); courtyard-internal pairs relax to the DRU floor)"
+            )
+    if not plan.rules:
+        lines.append("# (no domain pair exceeds the DRU clearance floor -- no rules emitted)")
+    body = "\n".join(lines)
+    if plan.rules:
+        body += "\n" + "\n".join(rule.render() for rule in plan.rules)
+    return body
+
+
+def merge_dru_block(existing: str | None, block_body: str) -> str:
+    """Merge the kct-owned rule block into existing ``.kicad_dru`` content.
+
+    * No existing content -> create ``(version 1)`` + the block.
+    * Existing block present -> replace only the text between the sentinels.
+    * Existing content, no block -> append the block, preserving everything
+      (and prepending a version header only if the file lacks one).
+
+    Idempotent: re-merging identical inputs yields byte-identical output.
+    """
+    block = f"{DRU_BLOCK_BEGIN}\n{block_body}\n{DRU_BLOCK_END}"
+
+    if existing is None or not existing.strip():
+        return f"{DRU_VERSION_HEADER}\n\n{block}\n"
+
+    pattern = re.compile(
+        re.escape(DRU_BLOCK_BEGIN) + r".*?" + re.escape(DRU_BLOCK_END),
+        re.DOTALL,
+    )
+    if pattern.search(existing):
+        merged = pattern.sub(lambda _m: block, existing)
+        return merged if merged.endswith("\n") else merged + "\n"
+
+    # Append; ensure a version header exists.
+    prefix = existing if existing.endswith("\n") else existing + "\n"
+    if not re.search(r"^\s*\(version\b", existing, re.MULTILINE):
+        prefix = f"{DRU_VERSION_HEADER}\n" + prefix
+    return f"{prefix}\n{block}\n"

--- a/tests/creepage/test_export_rules.py
+++ b/tests/creepage/test_export_rules.py
@@ -1,0 +1,496 @@
+"""Tests for referee-enforceable HV rule export (Issue #4508).
+
+Covers the emitter (``kicad_tools.creepage.export_rules``) and the
+``kct creepage-export-rules`` CLI:
+
+* domain derivation groups nets by voltage magnitude;
+* pairwise rules contain exactly the above-floor domain pairs with the
+  ``build_required_by_domain_pair`` minima; no rules without a voltage map;
+* domain-bridging footprints become ``insideCourtyard`` exclusions on their
+  pair's rule (the #4506 attach-zone congruence);
+* ``.kicad_pro`` netclass assignment is merge-preserving + idempotent;
+* the ``.kicad_dru`` sentinel block is created / replaced-in-place / append-only,
+  and re-emit is byte-idempotent;
+* emitted rules parse back via the DRU importer (``mfr_dru``);
+* the emitted board is clean under ``kicad-cli pcb drc`` when available
+  (skipped otherwise), and an intentionally-close pair is flagged.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from kicad_tools.cli.commands.creepage_export_rules import run_creepage_export_rules_command
+from kicad_tools.cli.mfr_dru import _extract_design_rules
+from kicad_tools.cli.parser import create_parser
+from kicad_tools.core.project_file import (
+    add_netclass_definition,
+    create_minimal_project,
+    save_project,
+)
+from kicad_tools.creepage.export_rules import (
+    DRU_BLOCK_BEGIN,
+    DRU_BLOCK_END,
+    NETCLASS_PREFIX,
+    build_domains,
+    build_export,
+    build_rule_clauses,
+    detect_bridging_footprints,
+    domain_name,
+    merge_dru_block,
+    render_dru_block_body,
+)
+from kicad_tools.placement.hv_domains import build_required_by_domain_pair
+
+# ---------------------------------------------------------------------------
+# Board fixtures (minimal-but-real KiCad S-expression boards)
+# ---------------------------------------------------------------------------
+
+_HEADER = """\
+(kicad_pcb
+  (version 20240108)
+  (generator "test_export_rules")
+  (general (thickness 1.6))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (37 "F.SilkS" user)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "AC_LINE")
+  (net 2 "GND")
+  (net 3 "3V3")
+"""
+
+_OUTLINE = """\
+  (gr_line (start 100 100) (end 160 100) (layer "Edge.Cuts") (width 0.1))
+  (gr_line (start 160 100) (end 160 130) (layer "Edge.Cuts") (width 0.1))
+  (gr_line (start 160 130) (end 100 130) (layer "Edge.Cuts") (width 0.1))
+  (gr_line (start 100 130) (end 100 100) (layer "Edge.Cuts") (width 0.1))
+"""
+
+
+def _footprint(ref: str, x: float, y: float, pads: list[tuple]) -> str:
+    """A multi-pad SMD footprint with a real F.CrtYd courtyard.
+
+    ``pads`` = (num, net_number, net_name, lx, ly); each pad is 1x1 mm.  A
+    courtyard rectangle enclosing all pads + 0.5 mm margin is emitted so KiCad's
+    ``insideCourtyard('<ref>')`` rule token resolves (the referee needs real
+    courtyard geometry for the #4506 attach-zone exemption).
+    """
+    pad_lines = "\n".join(
+        f'    (pad "{num}" smd rect (at {lx} {ly}) (size 1 1) (layers "F.Cu")\n'
+        f'      (net {nn} "{name}"))'
+        for num, nn, name, lx, ly in pads
+    )
+    xs = [lx for _n, _nn, _name, lx, _ly in pads]
+    ys = [ly for _n, _nn, _name, _lx, ly in pads]
+    cx0, cx1 = min(xs) - 1.0, max(xs) + 1.0
+    cy0, cy1 = min(ys) - 1.0, max(ys) + 1.0
+    crtyd = (
+        f"    (fp_rect (start {cx0} {cy0}) (end {cx1} {cy1})\n"
+        f'      (stroke (width 0.05) (type solid)) (fill none) (layer "F.CrtYd"))\n'
+    )
+    ref_prop = f'    (property "Reference" "{ref}" (at 0 0 0) (layer "F.SilkS"))\n'
+    return (
+        f'  (footprint "test:fp" (layer "F.Cu") (at {x} {y})\n{ref_prop}{crtyd}{pad_lines}\n  )\n'
+    )
+
+
+def _board_with_bridge() -> str:
+    """Board: AC_LINE (150 V), GND (0 V), 3V3 (3.3 V) + a bridging footprint.
+
+    ``R1`` holds an AC_LINE pad and a GND pad (a domain-bridging sense divider):
+    it straddles the 150 V<->0 V domain pair and must become an insideCourtyard
+    exclusion on that pair's rule.  ``P*`` place each net on its own footprint,
+    far apart, so the standalone board is compliant.
+    """
+    parts = [_HEADER, _OUTLINE]
+    parts.append(_footprint("P1", 110, 110, [("1", 1, "AC_LINE", 0, 0)]))
+    parts.append(_footprint("P2", 150, 125, [("1", 2, "GND", 0, 0)]))
+    parts.append(_footprint("P3", 110, 125, [("1", 3, "3V3", 0, 0)]))
+    # Bridging footprint: AC_LINE + GND pads at 1.5 mm centre pitch (0.5 mm
+    # copper gap) -- clears the 0.2 mm base floor but is far below the ~1.5 mm
+    # 150 V creepage requirement, so ONLY the courtyard exemption keeps it clean.
+    parts.append(_footprint("R1", 130, 115, [("1", 1, "AC_LINE", 0, 0), ("2", 2, "GND", 0, 1.5)]))
+    parts.append(")\n")
+    return "".join(parts)
+
+
+def _voltage_map() -> dict:
+    return {"AC_LINE": 150.0, "GND": 0.0, "3V3": 3.3}
+
+
+def _write_project(tmp_path, name="board"):
+    """Write a minimal .kicad_pro + sibling .kicad_pcb + voltage-map JSON."""
+    pro = tmp_path / f"{name}.kicad_pro"
+    save_project(create_minimal_project(f"{name}.kicad_pro"), pro)
+    pcb = tmp_path / f"{name}.kicad_pcb"
+    pcb.write_text(_board_with_bridge())
+    vmap = tmp_path / "voltages.json"
+    vmap.write_text(json.dumps(_voltage_map()))
+    return pro, pcb, vmap
+
+
+def _run(argv):
+    return run_creepage_export_rules_command(create_parser().parse_args(argv))
+
+
+# ---------------------------------------------------------------------------
+# Unit: domain derivation
+# ---------------------------------------------------------------------------
+
+
+def test_domain_name_sanitizes_decimal():
+    assert domain_name(150) == "kct_150V"
+    assert domain_name(3.3) == "kct_3p3V"
+    assert domain_name(0) == "kct_0V"
+    # Magnitude-only: a signed potential collapses to its magnitude domain.
+    assert domain_name(-170) == "kct_170V"
+
+
+def test_build_domains_groups_by_magnitude():
+    net_domains, domain_voltages = build_domains(
+        {"AC_LINE": 150, "GND": 0, "3V3": 3.3, "/AC_LINE2": 150},
+        ["AC_LINE", "GND", "3V3", "AC_LINE2", "UNMAPPED"],
+    )
+    # UNMAPPED gets no domain; the two 150 V nets share one domain.
+    assert net_domains == {
+        "AC_LINE": "kct_150V",
+        "GND": "kct_0V",
+        "3V3": "kct_3p3V",
+        "AC_LINE2": "kct_150V",
+    }
+    assert domain_voltages == {"kct_150V": 150.0, "kct_0V": 0.0, "kct_3p3V": 3.3}
+
+
+# ---------------------------------------------------------------------------
+# Unit: rule clause construction
+# ---------------------------------------------------------------------------
+
+
+def test_rules_only_above_floor_pairs_with_lookup_minima():
+    domain_voltages = {"kct_150V": 150.0, "kct_0V": 0.0, "kct_3p3V": 3.3}
+    expected = build_required_by_domain_pair(
+        domain_voltages, standard_id="iec60664", pollution_degree=2, material_group="IIIa"
+    )
+    # The 0V<->3.3V pair (|dV| 3.3 < 30) must not appear at all.
+    assert ("kct_0V", "kct_3p3V") not in expected
+
+    clauses = build_rule_clauses(
+        domain_voltages,
+        {},
+        standard_id="iec60664",
+        pollution_degree=2,
+        material_group="IIIa",
+        hv_threshold=30.0,
+        dru_floor_mm=0.2,
+    )
+    by_name = {c.name: c for c in clauses}
+    # Exactly the two above-threshold pairs, each above the DRU floor.
+    assert set(by_name) == {"kct_creepage_kct_0V_vs_kct_150V", "kct_creepage_kct_150V_vs_kct_3p3V"}
+    for (a, b), req in expected.items():
+        clause = by_name[f"kct_creepage_{a}_vs_{b}"]
+        assert clause.min_mm == req
+        assert req > 0.2
+
+
+def test_no_rules_without_voltage_map():
+    plan = build_export(None, ["AC_LINE", "GND"], [])
+    assert plan.is_empty
+    assert plan.rules == []
+    assert plan.net_domains == {}
+
+
+def test_high_dru_floor_suppresses_rules():
+    # A floor above the 150 V requirement leaves nothing to add over board-wide.
+    clauses = build_rule_clauses(
+        {"kct_150V": 150.0, "kct_0V": 0.0},
+        {},
+        dru_floor_mm=100.0,
+    )
+    assert clauses == []
+
+
+def test_out_of_table_voltage_fails_loud():
+    from kicad_tools.creepage.standards import StandardLookupError
+
+    with pytest.raises(StandardLookupError):
+        build_rule_clauses({"kct_big": 100000.0, "kct_0V": 0.0}, {}, dru_floor_mm=0.2)
+
+
+# ---------------------------------------------------------------------------
+# Unit: bridging-footprint detection -> insideCourtyard exclusion
+# ---------------------------------------------------------------------------
+
+
+def test_detect_bridging_footprints():
+    from kicad_tools.schema.pcb import PCB
+
+    net_domains = {"AC_LINE": "kct_150V", "GND": "kct_0V", "3V3": "kct_3p3V"}
+    pcb = _load_board(PCB, _board_with_bridge())
+    bridging = detect_bridging_footprints(pcb.footprints, net_domains)
+    # R1 bridges 150V<->0V (sorted: kct_0V, kct_150V).
+    assert bridging == {("kct_0V", "kct_150V"): ["R1"]}
+
+
+def test_bridging_footprint_becomes_condition_exclusion():
+    clauses = build_rule_clauses(
+        {"kct_150V": 150.0, "kct_0V": 0.0},
+        {("kct_0V", "kct_150V"): ["R1", "R2"]},
+        dru_floor_mm=0.2,
+    )
+    assert len(clauses) == 1
+    cond = clauses[0].condition
+    assert "A.NetClass == 'kct_0V' && B.NetClass == 'kct_150V'" in cond
+    assert "!(A.insideCourtyard('R1') && B.insideCourtyard('R1'))" in cond
+    assert "!(A.insideCourtyard('R2') && B.insideCourtyard('R2'))" in cond
+
+
+# ---------------------------------------------------------------------------
+# Unit: .kicad_pro netclass assignment (merge-preserving + idempotent)
+# ---------------------------------------------------------------------------
+
+
+def _sample_plan():
+    from kicad_tools.schema.pcb import PCB
+
+    pcb = _load_board(PCB, _board_with_bridge())
+    return build_export(
+        _voltage_map(),
+        [n.name for n in pcb.nets.values() if n.number != 0 and n.name],
+        pcb.footprints,
+        dru_floor_mm=0.2,
+    )
+
+
+def test_apply_netclass_preserves_user_classes_and_is_idempotent():
+    from kicad_tools.creepage.export_rules import apply_netclass_assignments
+
+    data = create_minimal_project("x.kicad_pro")
+    add_netclass_definition(data, "MyUserClass", clearance=0.3)
+
+    plan = _sample_plan()
+    apply_netclass_assignments(data, plan)
+    classes_1 = [c["name"] for c in data["net_settings"]["classes"]]
+    patterns_1 = list(data["net_settings"]["netclass_patterns"])
+
+    # User + Default classes preserved; kct domains added.
+    assert "MyUserClass" in classes_1
+    assert "Default" in classes_1
+    assert "kct_150V" in classes_1 and "kct_0V" in classes_1 and "kct_3p3V" in classes_1
+    # Patterns map each mapped net to its domain.
+    pat = {(p["netclass"], p["pattern"]) for p in patterns_1}
+    assert ("kct_150V", "AC_LINE") in pat
+    assert ("kct_0V", "GND") in pat
+    assert ("kct_3p3V", "3V3") in pat
+
+    # Idempotent: a second application yields identical classes/patterns (no dupes).
+    apply_netclass_assignments(data, plan)
+    assert [c["name"] for c in data["net_settings"]["classes"]] == classes_1
+    assert data["net_settings"]["netclass_patterns"] == patterns_1
+
+
+def test_apply_netclass_drops_stale_kct_domains():
+    from kicad_tools.creepage.export_rules import apply_netclass_assignments
+
+    data = create_minimal_project("x.kicad_pro")
+    # A stale kct domain from a prior run that no longer applies.
+    add_netclass_definition(data, f"{NETCLASS_PREFIX}999V", clearance=0.2)
+
+    apply_netclass_assignments(data, _sample_plan())
+    names = [c["name"] for c in data["net_settings"]["classes"]]
+    assert f"{NETCLASS_PREFIX}999V" not in names
+
+
+# ---------------------------------------------------------------------------
+# Unit: .kicad_dru sentinel-block merge
+# ---------------------------------------------------------------------------
+
+
+def test_merge_dru_block_creates_file_with_version_header():
+    out = merge_dru_block(None, '# body\n(rule "r" (constraint clearance (min 1mm)))')
+    assert out.startswith("(version 1)")
+    assert DRU_BLOCK_BEGIN in out and DRU_BLOCK_END in out
+
+
+def test_merge_dru_block_replaces_in_place_and_preserves_handwritten():
+    handwritten = (
+        "(version 1)\n\n"
+        '(rule "hand_rule" (constraint track_width (min 0.15mm)))\n\n'
+        f"{DRU_BLOCK_BEGIN}\nOLD\n{DRU_BLOCK_END}\n"
+    )
+    out = merge_dru_block(handwritten, "NEW_BODY")
+    assert "hand_rule" in out  # preserved
+    assert "OLD" not in out
+    assert "NEW_BODY" in out
+    # Only one block after replace.
+    assert out.count(DRU_BLOCK_BEGIN) == 1
+
+
+def test_merge_dru_block_appends_when_absent_and_is_idempotent():
+    handwritten = '(version 1)\n\n(rule "hand_rule" (constraint track_width (min 0.15mm)))\n'
+    once = merge_dru_block(handwritten, "BODY")
+    assert "hand_rule" in once
+    assert once.count(DRU_BLOCK_BEGIN) == 1
+    # Re-merging the produced content with the same body is byte-idempotent.
+    twice = merge_dru_block(once, "BODY")
+    assert twice == once
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: emitted rules parse back via the DRU importer
+# ---------------------------------------------------------------------------
+
+
+def test_emitted_rules_parse_back(tmp_path):
+    from kicad_tools.core.sexp_file import load_design_rules
+
+    plan = _sample_plan()
+    body = render_dru_block_body(plan)
+    dru_text = merge_dru_block(None, body)
+    dru_path = tmp_path / "parse.kicad_dru"
+    dru_path.write_text(dru_text)
+    sexp = load_design_rules(dru_path)
+    parsed = _extract_design_rules(sexp)
+    names = {r["name"] for r in parsed["rules"]}
+    assert "kct_creepage_kct_0V_vs_kct_150V" in names
+    assert "kct_creepage_kct_150V_vs_kct_3p3V" in names
+    for r in parsed["rules"]:
+        assert r["constraint"]["type"] == "clearance"
+        assert r["constraint"]["min"]["unit"] == "mm"
+        assert r["constraint"]["min"]["value"] > 0.2
+
+
+# ---------------------------------------------------------------------------
+# CLI end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_cli_writes_netclasses_and_rules(tmp_path, capsys):
+    pro, _pcb, vmap = _write_project(tmp_path)
+    rc = _run(["creepage-export-rules", str(pro), "--voltage-map", str(vmap)])
+    assert rc == 0
+
+    project = json.loads(pro.read_text())
+    class_names = {c["name"] for c in project["net_settings"]["classes"]}
+    assert {"kct_150V", "kct_0V", "kct_3p3V"} <= class_names
+
+    dru = (tmp_path / "board.kicad_dru").read_text()
+    assert DRU_BLOCK_BEGIN in dru
+    assert "kct_creepage_kct_0V_vs_kct_150V" in dru
+    # Bridging exemption for R1 present on the 150V<->0V rule.
+    assert "insideCourtyard('R1')" in dru
+
+
+def test_cli_no_voltage_map_is_noop(tmp_path, capsys):
+    pro, _pcb, _vmap = _write_project(tmp_path)
+    rc = _run(["creepage-export-rules", str(pro)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "no-op" in out.lower() or "nothing to export" in out.lower()
+    # Nothing written.
+    assert not (tmp_path / "board.kicad_dru").exists()
+
+
+def test_cli_dry_run_writes_nothing(tmp_path, capsys):
+    pro, _pcb, vmap = _write_project(tmp_path)
+    before = pro.read_text()
+    rc = _run(["creepage-export-rules", str(pro), "--voltage-map", str(vmap), "--dry-run"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "dry run" in out.lower()
+    assert not (tmp_path / "board.kicad_dru").exists()
+    assert pro.read_text() == before  # project untouched
+
+
+def test_cli_reemit_is_idempotent(tmp_path):
+    pro, _pcb, vmap = _write_project(tmp_path)
+    _run(["creepage-export-rules", str(pro), "--voltage-map", str(vmap)])
+    pro_1 = pro.read_text()
+    dru_1 = (tmp_path / "board.kicad_dru").read_text()
+    _run(["creepage-export-rules", str(pro), "--voltage-map", str(vmap)])
+    assert pro.read_text() == pro_1
+    assert (tmp_path / "board.kicad_dru").read_text() == dru_1
+
+
+def test_cli_missing_voltage_map_file_errors(tmp_path, capsys):
+    pro, _pcb, _vmap = _write_project(tmp_path)
+    rc = _run(["creepage-export-rules", str(pro), "--voltage-map", str(tmp_path / "nope.json")])
+    assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# kicad-cli referee integration (skipped when kicad-cli is unavailable)
+# ---------------------------------------------------------------------------
+
+
+def _find_kicad_cli():
+    try:
+        from kicad_tools.export import find_kicad_cli
+
+        return find_kicad_cli()
+    except Exception:
+        return shutil.which("kicad-cli")
+
+
+@pytest.mark.skipif(_find_kicad_cli() is None, reason="kicad-cli not available")
+def test_kicad_cli_drc_enforces_emitted_rules(tmp_path):
+    """The compliant board is clean; a too-close HV<->LV pair is flagged."""
+    kicad_cli = _find_kicad_cli()
+    pro, pcb, vmap = _write_project(tmp_path)
+    rc = _run(["creepage-export-rules", str(pro), "--voltage-map", str(vmap)])
+    assert rc == 0
+
+    def _drc_violation_count(pcb_path):
+        report = tmp_path / "drc.json"
+        subprocess.run(
+            [
+                str(kicad_cli),
+                "pcb",
+                "drc",
+                "--format",
+                "json",
+                "--severity-error",
+                "--exit-code-violations",
+                "-o",
+                str(report),
+                str(pcb_path),
+            ],
+            capture_output=True,
+        )
+        data = json.loads(report.read_text())
+        return len(data.get("violations", []))
+
+    # Compliant board: the P1/P2/P3 nets sit far apart -> no creepage violation.
+    assert _drc_violation_count(pcb) == 0
+
+    # Now pull GND right next to AC_LINE on distinct footprints (board-fixable
+    # approach, NOT inside R1's courtyard) -> the referee must flag it.
+    close = _board_with_bridge().replace(
+        '(footprint "test:fp" (layer "F.Cu") (at 150 125)',
+        '(footprint "test:fp" (layer "F.Cu") (at 111 110)',
+    )
+    pcb.write_text(close)
+    assert _drc_violation_count(pcb) >= 1
+
+
+def _load_board(PCB, source):
+    """Load a PCB from an in-memory S-expression source via a temp file."""
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.NamedTemporaryFile("w", suffix=".kicad_pcb", delete=False) as fh:
+        fh.write(source)
+        path = Path(fh.name)
+    try:
+        return PCB.load(path)
+    finally:
+        path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary

Implements Phase 3 of the pairwise HV-isolation clearance epic (#4431): make the voltage-map-derived pairwise HV↔LV creepage requirement enforceable by the **external referee**, `kicad-cli pcb drc`, not just kct's own validators. This closes the two-engine-honesty gap where an HV board kct signs off was never independently referee-checked for creepage.

New sibling top-level command `kct creepage-export-rules <project.kicad_pro> --voltage-map ...` (deliberately **not** a `kct creepage` subcommand — that would break the documented flat `kct creepage <pcb>` invocation).

## Changes

- **`src/kicad_tools/creepage/export_rules.py`** (new) — the emitter:
  - `build_domains` groups nets into voltage-domain netclasses by magnitude.
  - `build_rule_clauses` reuses `placement.hv_domains.build_required_by_domain_pair` **verbatim** for the `{(a,b): required_mm}` matrix (same table lookup, same `hv_threshold` floor, same fail-loud out-of-table contract), emitting one `clearance` rule per domain pair strictly above the DRU floor. Constraint is `clearance` (through-air); since creepage ≥ clearance, requiring `clearance ≥ required_creepage` is a conservative, never-under-strict enforcement.
  - `detect_bridging_footprints` + `insideCourtyard` exclusions express the #4506 rated-footprint attach-zone exemption **inside the pairwise rule condition** (`&& !(A.insideCourtyard('R1') && B.insideCourtyard('R1'))`). Baking the exclusion into the condition makes the result **independent of KiCad rule precedence** and scoped to a specific refdes courtyard, so it can never weaken the referee board-wide — directly addressing the curator's "expensive to be wrong" precedence concern.
  - `apply_netclass_assignments` — merge-preserving, idempotent `.kicad_pro` netclass writes (drops `kct_`-prefixed classes/patterns then re-adds; never touches user classes or `rules`/`defaults`).
  - `merge_dru_block` — **net-new** sentinel-delimited (`# BEGIN/END kct creepage rules`) `.kicad_dru` merge (create / replace-in-place / append; preserves hand-written rules; byte-idempotent). `dru_generator.py` does a full overwrite with no merge, so this logic is new (used it only as the S-expression formatting precedent).
- **`src/kicad_tools/cli/commands/creepage_export_rules.py`** (new) — CLI handler; resolves the sibling `.kicad_pcb`/`.kicad_dru`, no-ops cleanly without a voltage map, `--dry-run`, fails loud on out-of-table |ΔV|.
- **`parser.py` / `cli/__init__.py` / `cli/commands/__init__.py`** — wire the new command.

## Acceptance Criteria Verification

- [x] Given a two-domain voltage map, emitted rules contain exactly the above-floor domain pairs with the `build_required_by_domain_pair` minima — `test_rules_only_above_floor_pairs_with_lookup_minima`.
- [x] No rules emitted without a map (no-op fallback) — `test_no_rules_without_voltage_map`, `test_cli_no_voltage_map_is_noop`.
- [x] Round-trip: emit into a fixture project, run `kicad-cli pcb drc`, confirm an intentionally-close HV↔LV pair is flagged and a compliant board (incl. the exempted bridging footprint) is clean — `test_kicad_cli_drc_enforces_emitted_rules` (**ran, not skipped** — kicad-cli present in CI env).
- [x] Existing netclass definitions preserved; re-emit idempotent — `test_apply_netclass_preserves_user_classes_and_is_idempotent`, `test_apply_netclass_drops_stale_kct_domains`, `test_cli_reemit_is_idempotent`.
- [x] `.kicad_dru` block created / replaced-in-place / appended, hand-written rules preserved — three `test_merge_dru_block_*` tests.
- [x] Emitted rules parse back — `test_emitted_rules_parse_back` (via `mfr_dru._extract_design_rules`).
- [x] Attach-zone exemption congruent with #4506 — `test_detect_bridging_footprints`, `test_bridging_footprint_becomes_condition_exclusion`.
- [x] Out-of-table |ΔV| fails loud — `test_out_of_table_voltage_fails_loud`.
- [x] Flat `kct creepage <pcb>` invocation untouched.

## Test Plan

- `pytest tests/creepage/test_export_rules.py` — 20 passed (incl. the live kicad-cli DRC round-trip).
- `pytest tests/creepage/ tests/test_placement_hv_domains.py` — 250 passed (no regressions).
- `pytest tests/test_cli_parser_drift.py tests/test_build_parser_parity.py` — 28 passed.
- `ruff format` + `ruff check` on all changed files — clean.

Closes #4508

🤖 Generated with [Claude Code](https://claude.com/claude-code)