### PR TITLE
docs: refresh What's New to v0.19.0 + close CLI reference gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,12 @@ Notes and caveats:
 
 ### Unified CLI (`kct` or `kicad-tools`)
 
+The commands below are the ones most workflows reach for. The authoritative
+full list (every command and subcommand) lives in
+[CLI Reference → Commands Overview](docs/reference/cli.md#commands-overview).
+
+**Inspection and validation**
+
 | Command | Description |
 |---------|-------------|
 | `kct symbols <schematic>` | List symbols with filtering |
@@ -539,18 +545,50 @@ Notes and caveats:
 | `kct drc <pcb>` | Run design rules check (requires kicad-cli) |
 | `kct check <pcb>` | Pure Python DRC (no kicad-cli needed) |
 | `kct creepage <pcb>` | HV surface-path (creepage) audit vs IEC 60664-1 / 62368-1 |
-| `kct analyze <pcb>` | Signal-integrity + current-sense analog layout lint |
-| `kct route <pcb>` | Autoroute a PCB (`--nets`/`--skip-nets` to select nets) |
-| `kct reason <pcb>` | LLM-driven PCB layout reasoning |
-| `kct placement <pcb>` | Detect and optimize component placement |
-| `kct optimize-placement <pcb>` | CMA-ES/Bayesian global placement optimization |
+| `kct creepage-export-rules <project>` | Export voltage-domain netclasses + pairwise HV clearance rules so kicad-cli DRC enforces creepage |
+| `kct analyze <pcb>` | Signal-integrity, current-sense, and electrical-rating layout lint |
+| `kct audit <project>` | Manufacturing readiness audit (ERC, DRC, connectivity, compatibility) |
+| `kct impedance <subcommand>` | Transmission line impedance calculations |
+
+**Layout and routing**
+
+| Command | Description |
+|---------|-------------|
+| `kct route <pcb>` | Autoroute a PCB (`--nets`/`--skip-nets` to select nets, `--complete` to finish one) |
 | `kct route-auto <pcb>` | Orchestrator-based multi-strategy autorouting |
 | `kct optimize-traces <pcb>` | Optimize routed traces |
+| `kct placement <pcb>` | Detect and optimize component placement |
+| `kct optimize-placement <pcb>` | CMA-ES/Bayesian global placement optimization |
+| `kct zones <subcommand>` | Add copper pour zones (and `hv-keepout` plane voids) |
+| `kct stitch <pcb>` | Auto-add stitching vias for plane connections |
+| `kct reason <pcb>` | LLM-driven PCB layout reasoning |
+
+**Repair**
+
+| Command | Description |
+|---------|-------------|
+| `kct fix-drc <pcb>` | Automated DRC violation repair (clearance + drill) |
+| `kct fix-erc <schematic>` | Automated ERC violation repair (PWR_FLAG + no-connect) |
+| `kct fix-vias <pcb>` | Fix vias to meet manufacturer specifications (incl. off-pad relocation) |
+| `kct pipeline <input>` | End-to-end repair pipeline for existing PCBs |
+
+**Parts and manufacturing**
+
+| Command | Description |
+|---------|-------------|
 | `kct datasheet <subcommand>` | Search, download, parse datasheets |
 | `kct parts <subcommand>` | LCSC/JLCPCB part lookup, cache, offline catalog sync |
 | `kct export <pcb>` | Manufacturing bundle export (gerbers, BOM, CPL) |
 | `kct mfr <subcommand>` | Manufacturer rule profiles (apply-rules, validate) |
+| `kct spec <subcommand>` | Project specification (`.kct`) management |
 | `kct fleet status` | Routing + manufacturing readiness across all boards |
+
+**Environment**
+
+| Command | Description |
+|---------|-------------|
+| `kct doctor` | Diagnose kicad-tools installation health (version-record drift) |
+| `kct build-native` | Build the C++ router backend for 10-100x faster routing |
 | `kct mcp serve` | Start MCP server for AI agent integration |
 
 All commands support `--format json` for machine-readable output.
@@ -594,50 +632,54 @@ All commands support `--format json` for machine-readable output.
 | `mcp` | MCP server for AI agent integration |
 | `layout` | Layout preservation for PCB regeneration |
 
-## What's New (v0.16.0, July 2026)
+## What's New (v0.19.0, July 2026)
 
-Recent additions an agent reading these docs cold should know about:
+Recent additions an agent reading these docs cold should know about. Older
+entries live in [CHANGELOG.md](CHANGELOG.md).
 
-- **Router feasibility & coupling flags on `kct route`** — `--monotone-certificate-order`
-  (certify a bundle's escape feasibility and derive a constructive net order),
-  `--cross-package-pair-corridor`, and `--slack-corridor-widening` (all default
-  off). Coupled diff-pair attempts that all budget-exit now early-abort to a
-  plain single-ended route instead of degrading the result.
-- **JLCPCB parts stack** — `kct parts sync-catalog` mirrors the full jlcparts
-  dataset for offline lookups; set `JLCPCB_ACCESS_KEY`/`JLCPCB_SECRET_KEY` to
-  use the official open-platform API (see Parts Lookup below).
-- **`kct check --refill-zones`** — refill zone fills via kicad-cli before the
-  pure-Python checks, killing stale-fill clearance false positives; a loud
-  advisory now fires when copper is measured against possibly-stale fills.
-- **Hierarchical-schematic LVS** — multi-sheet designs are no longer vacuous.
-- **`/kct:tapeout` skill** — one command that produces a complete, fab-ready
-  export bundle or refuses loudly.
-- **`kct fleet status`** — survey routing + manufacturing readiness across every
-  board in `boards/`. The "are we ship-ready?" entry point. See
-  [Manufacturing Export → ship-ready check](docs/guides/manufacturing-export.md#are-we-ship-ready-kct-fleet-status).
-- **`kct route --auto-layers` / `--auto-mfr-tier`** — automatic layer-count
-  and manufacturer-tier escalation when routing hits a wall. `--auto-layers`
-  defaults to **enabled**; opt out with `--no-auto-layers`. See
-  [Routing → Strategy Escalation](docs/guides/routing.md#strategy-escalation).
-- **`kct route --checkpoint-interval`** — atomic best-so-far writes every N
-  seconds; SIGINT leaves a valid PCB on disk. See
-  [Routing → Long-Running Routes](docs/guides/routing.md#long-running-routes-checkpointing).
-- **`kct optimize-placement --anchor-weight`** — CMA-ES placement optimizer
-  biased toward locked footprints. The validated recipe (lock perimeter
-  parts only, weight `1.0`, `--allow-infeasible`) lifted board-05 BLDC from
-  40% → 60% routing completion. See
-  [Placement Optimization → Anchoring Perimeter Footprints](docs/guides/placement-optimization.md#anchoring-perimeter-footprints).
-- **`kct stitch --mfr` / `--copper`** — stackup-aware via dimensions; the
-  manufacturer YAML drives via geometry. See
-  [CLI Reference → stitch](docs/reference/cli.md#stitch).
-- **`kct build --step preflight-routing`** — routing-completeness gate that
-  blocks manufacturing artefacts when nets are unrouted. Override with
-  `--allow-incomplete`. See
-  [Manufacturing Export → Routing Completeness Preflight](docs/guides/manufacturing-export.md#routing-completeness-preflight).
-- **`Footprint.locked` + siblings round-trip** through `PCB.save` (locked,
-  dnp, exclude_from_pos_files, exclude_from_bom, plus preserved unknown
-  `(attr ...)` tokens). See
-  [API → Footprint attributes](docs/reference/api.md#footprint-attributes-locked-dnp-exclude_from).
+- **HV-isolation design loop** (v0.19.0) — `kct creepage --voltage-map` derives
+  each conductor pair's required creepage from its own `|ΔV|` instead of one
+  group working voltage; `kct zones hv-keepout` generates plane voids so inner
+  pours clear HV nets; `kct optimize-placement --voltage-map` / `--hv-domains`
+  place HV parts with a hard creepage-keepout feasibility term. The
+  `/kct:hv-isolation-loop` skill sequences the whole loop.
+- **`kct creepage-export-rules`** (since v0.19.0) — export voltage-domain
+  netclasses plus pairwise HV clearance `(rule ...)` clauses into the project so
+  `kicad-cli pcb drc` enforces creepage too, not just `kct creepage`.
+- **`kct check --emit-dru` / `--emit-drc-constraints`** (v0.19.0) — emit
+  `.kicad_dru` / `.kicad_pro` sidecars from the checker's already-resolved
+  `--mfr` floors, so `kicad-cli pcb drc` and `kct check` reason over identical
+  rules by construction.
+- **`kct analyze electrical-rating`** (v0.19.0) — deterministic, advisory
+  LED-overcurrent and capacitor voltage-derating checks sourced from schematic
+  fields; parts missing ratings are skipped, never failed.
+- **`kct fix-vias` off-pad relocation** (v0.19.0) — relocate via-in-pad and
+  plane-stitch vias off-pad while preserving connectivity, with THT
+  hole-to-hole clearance checking and multi-branch relocation.
+- **`kct doctor`** (v0.19.0) — diagnose an installation's version-record drift
+  (dependency pin, `.kct/install-metadata.json`, CLAUDE.md marker block).
+  Advisory by default; `--strict` exits non-zero so it can gate CI.
+- **`kct route --complete`** (since v0.19.0) — targeted completion pass: detect
+  the still-unconnected links and route only those, treating every other net's
+  copper as a fixed obstacle. Implies `--preserve-existing` and never deletes
+  copper; skip pour-carried nets with `--complete-exclude-nets`. See
+  [CLI Reference → route](docs/reference/cli.md#route).
+- **`kct creepage` HV audit + `kct analyze current-sense`** (v0.18.0) — per-pair
+  creepage census against IEC 60664-1 / 62368-1 tables (slot-aware, clearance
+  and creepage reported as distinct values), and an analog lint for
+  sense↔high-current parallel runs, sense-loop area, and Kelvin-tap integrity.
+  A below-standard HV pair fails the `kct audit` gate.
+- **Real `--nets NET[,NET...]` on `route` / `route-auto`** (v0.18.0) — route
+  only the listed nets (inverse of `--skip-nets`); non-listed copper is treated
+  as a fixed obstacle.
+- **Experimental routing substrates** (v0.17.0) — `--route-engine lattice`
+  (adaptive octilinear; 45°-legal copper by construction) and `--route-engine
+  mesh` (constrained-Delaunay navmesh), both default **off**. `--route-engine
+  grid` remains the default and is unchanged. See
+  [Routing Guide](docs/guides/routing.md).
+- **`kct net-status --why`** (v0.17.0) — ranked fix recommendations explaining
+  why each incomplete net is stuck, with pin-order-verified reversed-bundle
+  detection.
 
 ## Features
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -29,6 +29,8 @@ kct [--help] [--version] <command> [options]
 | **Validation** | `erc` | ERC validation and analysis |
 | | `drc` | Parse DRC reports with manufacturer rules |
 | | `check` | Pure Python DRC (no kicad-cli) |
+| | `creepage` | HV creepage/clearance census (surface-path distance) |
+| | `creepage-export-rules` | Export voltage-domain netclasses + pairwise HV clearance rules so kicad-cli DRC enforces creepage |
 | | `validate` | Validation tools (schematic-to-PCB sync) |
 | | `validate-footprints` | Validate footprints for pad spacing issues |
 | | `net-status` | Report net connectivity status for a PCB |
@@ -84,6 +86,7 @@ kct [--help] [--version] <command> [options]
 | | `interactive` | Launch interactive REPL mode |
 | | `run` | Run a Python script with the kicad-tools interpreter |
 | | `build-native` | Build the C++ router backend (10-100x faster routing) |
+| | `doctor` | Diagnose kicad-tools installation health (version-record drift) |
 
 ---
 
@@ -627,6 +630,53 @@ Common flags (the full surface lives in `kct route --help`):
 | `--seed N` | Seed Python `random` for reproducible routing (#2589) |
 | `--auto-fix` / `--auto-fix-passes N` | Run `kct fix-drc` after routing on DRC failure |
 | `--skip-drc` | Skip post-route DRC validation |
+
+#### Targeted completion mode (`--complete`)
+
+`--complete` is a completion pass rather than a full route (epic #4465): it
+auto-detects the currently-unconnected signal nets and routes **only** those
+links, treating every other net's copper as a fixed obstacle. It implies
+`--preserve-existing`, never deletes existing copper, and is a safe no-op on a
+board with nothing left to connect. Unless you override `--route-engine`, it
+selects the lattice engine with `--strategy basic` (a negotiated strategy is
+coerced to `basic` with a printed notice). It is mutually exclusive with
+`--nets` / `--skip-nets` — `--complete` chooses the net set itself.
+
+| Option | Description |
+|--------|-------------|
+| `--complete` | Route only the unconnected links; all other copper is a fixed obstacle |
+| `--complete-exclude-nets NAMES` | Comma-separated nets `--complete` must not route even when reported unconnected — for pour/plane-carried nets (`GND`, `+3V3`, phase nets) whose connectivity comes from a filled zone. Ignored without `--complete`. |
+| `--complete-report PATH` | Write the structured unroutable-link report (net, link pad endpoints, elapsed vs the per-link deadline, blocking copper) as JSON. Only written when links remain unroutable; a human-readable summary always prints. Ignored without `--complete`. |
+| `--via-in-pad-last-resort` | On the lattice engine, stage a same-net via-in-pad attach as a last resort instead of an opportunistic one: the search first tries an in-layer route or an off-pad via layer change, and only retries with the pad-site via admitted when no such route exists (and only on a fab tier that supports via-in-pad). |
+
+Each link gets a bounded per-link deadline, so a single pathological net cannot
+consume the whole `--timeout`; links that exhaust it are reported as unroutable
+with their blocking copper rather than silently dropped.
+
+```bash
+# Finish a partially routed board without touching existing copper
+kct route board.kicad_pcb --complete \
+  --complete-exclude-nets 'GND,+3V3' \
+  --complete-report unroutable.json \
+  -o board_complete.kicad_pcb
+```
+
+#### Placement-delta feedback
+
+`--placement-delta-feedback` (default **off**) closes the loop between routing
+and placement. After the initial routing pass, if any nets remain unrouted, it
+classifies the routed board, translates each `PLACEMENT_BOUND` /
+`CONGESTION_SATURATED` diagnosis into a concrete placement delta (a translate or
+a 180° rotation), applies the top applyable one, re-routes, and keeps the change
+**only** on a strict routed-net increase. Connectors (`J*`, `P*`) and locked
+footprints are auto-anchored, and the applied deltas are written to
+`<output>_placement_delta.json`.
+
+| Option | Description |
+|--------|-------------|
+| `--placement-delta-feedback` / `--no-placement-delta-feedback` | Enable / explicitly disable the loop (default: disabled) |
+| `--placement-delta-feedback-budget N` | Maximum apply/keep-or-revert iterations (default: 3) |
+| `--placement-delta-feedback-timeout SECONDS` | Per-iteration wall-clock budget for the loop's re-routes; survives an already-exhausted `--timeout`. Default: share whatever remains of `--timeout`. |
 
 #### Feasibility / coupling flags (v0.15.0, all default off)
 


### PR DESCRIPTION
Documentation hygiene pass. No issue reference — this closes gaps found in a
verified docs audit at `4b38bc3f`. Docs-only diff; no behaviour change.

## Audit findings fixed

**1. `README.md` "What's New" was stale by three minor versions.** The section
was titled *"What's New (v0.16.0, July 2026)"* while `pyproject.toml` is at
`0.19.0`, so an agent reading the README cold would miss the entire
HV-isolation family. Retitled to v0.19.0 and re-cut from the v0.17.0 /
v0.18.0 / v0.19.0 CHANGELOG entries, keeping the section's existing length
discipline (11 bullets, was 13) and adding a pointer to `CHANGELOG.md` for
older entries. Headline items now covered:

- `kct creepage --voltage-map`, `kct zones hv-keepout`,
  `kct optimize-placement --voltage-map` / `--hv-domains` (the HV-isolation loop)
- `kct check --emit-dru` / `--emit-drc-constraints`
- `kct analyze electrical-rating`
- `kct fix-vias` off-pad relocation
- `kct doctor` version-record drift check
- `kct route --complete` and `kct creepage-export-rules`, both marked
  **since v0.19.0** (they landed after the 0.19.0 tag)
- carried forward: v0.18.0 `kct creepage` / `analyze current-sense` / real
  `--nets`, and v0.17.0 `--route-engine lattice|mesh` / `net-status --why`

**2. `README.md` unified CLI table was missing 13 command families.** Rather
than grow one 34-row table, it is now grouped into five short tables —
inspection and validation, layout and routing, repair, parts and
manufacturing, environment — with a lead-in line naming
`docs/reference/cli.md#commands-overview` as the authoritative full list. Added
rows for `creepage-export-rules`, `zones`, `stitch`, `fix-vias`, `fix-drc`,
`fix-erc`, `audit`, `doctor`, `build-native`, `spec`, `pipeline`, and
`impedance`.

**3. `docs/reference/cli.md` Commands Overview was missing three commands.**
Added `creepage` and `creepage-export-rules` under **Validation**, and `doctor`
under **Utilities**.

**4. `docs/reference/cli.md` `route` section did not document `--complete`.**
Added two subsections:

- **Targeted completion mode** — what `--complete` does (auto-detect
  unconnected links, route only those, all other copper a fixed obstacle,
  implies `--preserve-existing`, lattice + `--strategy basic` by default,
  mutually exclusive with `--nets` / `--skip-nets`), a flag table covering
  `--complete-exclude-nets`, `--complete-report`, and
  `--via-in-pad-last-resort`, a note on the bounded per-link deadline, and a
  worked example.
- **Placement-delta feedback** — the classifier-driven loop and its three
  flags (`--placement-delta-feedback` / `--no-…`, `-budget`, `-timeout`),
  including the strict routed-net-increase keep rule and the
  `<output>_placement_delta.json` artifact.

The long tail of `route` tuning flags is deliberately left to `kct route --help`.

## Verification

- Every command and flag name written was read out of
  `src/kicad_tools/cli/parser.py` first — no invented flags.
- `uv run pytest tests/test_diffpair_docs.py tests/test_match_group_docs.py
  tests/test_kct_skills_consumer_generic.py` — 41 passed.
- No markdown linter is configured in `package.json`; style follows the
  surrounding tables.

## Deliberately not done

`docs/guides/hv-isolation.md` was flagged by the audit as missing but is
explicitly deferred out of this pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
