### PR TITLE
chore: update Repo Skills 0.4.3 -> 0.7.0

### DIFF
--- a/.claude/commands/repo/audit.md
+++ b/.claude/commands/repo/audit.md
@@ -48,6 +48,14 @@ Run each of the following checks and compile results into a single report:
 - Local branches whose PRs are merged
 - Orphaned or stale worktrees
 
+### Out of scope: host posture (see [[host-optimize]])
+
+This is a repo-scoped audit. The **host** a machine presents to heavy build
+workloads — Gatekeeper scan churn, backup-agent interference, build-tree bloat,
+sudo/concurrency posture — is not checked here. For a build host, run
+[[host-optimize]] instead; unlike this read-only audit, that command applies its
+safe-tier fixes by default.
+
 ## Output Format
 
 Present findings as a table grouped by category:

--- a/.claude/commands/repo/branches.md
+++ b/.claude/commands/repo/branches.md
@@ -120,21 +120,77 @@ STALE WORKTREES (0):
 worktree is removed until it passes — irreversible removal of work that exists
 nowhere else is never acceptable, `--prune` or not.
 
+The check runs in two stages, plus one fixed rule about which way it fails.
+
+#### 5a. Ancestry — does the branch carry commits that exist nowhere else?
+
 For every branch about to be deleted, list commits that live *only* on that
 branch — not reachable from the default branch and not present on any remote:
 
 ```bash
-git log --oneline <branch> --not --remotes --not <default>
+git log --oneline <branch> --not <default> --remotes
 ```
 
-- **Empty** → the work is preserved elsewhere (merged or pushed); safe to delete.
-- **Non-empty** → those commits would be **permanently lost**. Do NOT auto-delete
-  even under `--prune`. Reclassify the branch as UNKNOWN, show the count and the
-  commit subjects, and require an explicit per-branch confirmation.
+- **Empty** → the branch carries no commits of its own; safe to delete.
+- **Non-empty** → this proves nothing yet. Go to 5b before concluding.
 
-(A merged PR whose remote branch was already deleted may show commits here after
-a squash-merge — that's the safe direction to err: surface it and let the user
-confirm the work is truly in the PR.)
+`--not` is a **toggle**, not a per-argument negation: it flips the sense of every
+ref that follows it, up to the next `--not`. Both exclusions must therefore sit
+after a **single** `--not`. Writing it as
+`<branch> --not --remotes --not <default>` flips the sense back to positive and
+folds all of `<default>`'s own commits into the output, so the exclusion silently
+stops working — the check then reports commits the branch never had, and returns
+empty only when unrelated refs happen to cover the tip. **Never add a second
+`--not`.** If `--remotes` is too broad for the repo, spell the exclusions out
+instead: `git log --oneline <branch> --not <default> origin/<default>`.
+
+#### 5b. Content — does `<default>` already contain this work?
+
+A non-empty 5a result does **not** mean the work would be lost. A squash-merge
+replays the branch's changes as one brand-new commit whose parent is
+`<default>`'s prior tip, so the branch's original commits never become ancestors
+of `<default>` and *always* appear in 5a — even when every line of the work is
+already merged. Decide with **content containment**, not SHA ancestry:
+
+```bash
+# Would merging the branch into <default> change anything at all?
+# `--write-tree` requires git >= 2.38; on older git this errors and you take the fallback below.
+[ "$(git merge-tree --write-tree <default> <branch>)" = "$(git rev-parse '<default>^{tree}')" ]
+```
+
+Equal trees → `<default>` already holds the branch's content → safe to delete.
+If `git merge-tree` is unsupported (git < 2.38) or reports a conflict, fall back
+to the exact-match form `git diff --quiet <default> <branch>`: exit 0 (identical
+trees) is also proof of containment, while a non-zero exit proves nothing either
+way. Failing both, ask the forge whether the branch's PR was merged:
+
+```bash
+gh pr list --head <branch> --state merged --json number --jq length
+```
+
+A count `>= 1` means the work landed through that PR; safe to delete.
+
+If none of these establish containment, the 5a commits would be **permanently
+lost**. Do NOT auto-delete even under `--prune`. Reclassify the branch as
+UNKNOWN, show the count and the commit subjects, and require an explicit
+per-branch confirmation.
+
+**Do NOT "simplify" 5b to `git branch --merged <default>`.** That lists only
+branches whose commits are literal ancestors of `<default>`, which is never true
+after a squash-merge — every squash-merged branch would be classified unsafe and
+`--prune` would silently stop pruning anything, defeating the feature with no
+error to notice. `--merged` answers "are these exact commits on `<default>`";
+pruning needs "does `<default>` already have this work". Different questions.
+
+#### 5c. Failure direction — ambiguity and errors always mean KEEP
+
+If any command in 5a or 5b exits non-zero unexpectedly, emits output that cannot
+be parsed, or cannot run at all — `gh` missing, unauthenticated, or rate-limited;
+no network; an unknown or ambiguous ref; `git merge-tree` unsupported — the
+branch is classified **UNKNOWN / KEEP**. **Never SAFE.** Ambiguity is never
+resolved in favour of deletion, and this holds under `--prune` exactly as it does
+without it. A branch wrongly kept costs one line of report noise; a branch
+wrongly deleted costs the work.
 
 For each worktree about to be removed, refuse if it has uncommitted changes —
 that work exists nowhere else:
@@ -151,7 +207,9 @@ Then delete the branches that passed the loss check:
 
 ```bash
 git branch -d <branch_name>           # -d (safe): refuses if not merged
-# escalate to -D only for a branch the loss check proved is pushed/merged
+# escalate to -D only for a branch the loss check proved is pushed, or whose
+# content 5b proved is already contained in <default> (the squash-merge case,
+# where -d refuses because the original SHAs are not ancestors of <default>)
 ```
 
 Report what was deleted, what was skipped for potential data loss, and what

--- a/.claude/commands/repo/handoff.md
+++ b/.claude/commands/repo/handoff.md
@@ -1,0 +1,149 @@
+---
+name: "handoff"
+description: "Roll the Claude session safely — file follow-ups, reset to baseline, check for a CLI update, and write a handoff note the next session reads first"
+domain: repo
+type: command
+user-invocable: true
+---
+
+# /repo:handoff — Roll the Session Safely
+
+Rolling a Claude Code session — quitting the CLI and starting fresh — is the
+moment a session's most valuable output is most likely to be lost, because what
+is worth carrying forward is exactly what exists *only* in the session's
+context: in-flight state, settled decisions, and empirically-discovered traps.
+This command makes the roll a repeatable ritual instead of an ad-hoc scramble.
+
+It **composes** the existing commands rather than reimplementing them —
+[[followups]] to capture deferred work, [[reset]] to reach a clean git baseline
+— and adds only what does not exist yet: the CLI version check, the handoff
+note, and exact restart instructions.
+
+**Relationship to `/compact`:** compaction handles the *soft* boundary —
+context pressure within a continuous session. `/repo:handoff` handles the
+*hard* boundary: process restart, CLI upgrade, or a deliberate fresh start. If
+the version check below finds no update and the only pressure is context size,
+say so — a `/compact` may be all that's needed.
+
+## Usage
+
+```
+/repo:handoff                  # Run the ritual end-to-end, confirmations as usual
+/repo:handoff --dry-run        # Preview the note and proposed actions; file, prune, and write nothing
+/repo:handoff --prune          # Pass --prune through to the reset stage
+```
+
+## Steps — ordering is load-bearing
+
+Run the stages in exactly this order. Each later stage depends on the earlier
+ones having actually happened.
+
+### 1. File follow-ups first (see [[followups]])
+
+Run the full [[followups]] flow — mine the session, propose, confirm, file.
+This must precede reset because [[reset]] prunes branches, worktrees, and
+stashes that a follow-up may need to reference, and filing wants the git state
+reset is about to remove. Record the issue URLs actually filed (and anything
+proposed-but-declined) — the note needs them.
+
+Under `--dry-run`, run followups in its own `--dry-run` mode: propose, file
+nothing.
+
+### 2. Reset to baseline (see [[reset]])
+
+Run the full [[reset]] ritual: working-tree safety check, stash review, branch
+& worktree review, remote sync, land on the default branch. Pass `--prune`
+through if given. All of reset's gates apply unchanged — nothing irreversible
+happens without explicit approval, and a dirty working tree stops the ritual
+until the user decides (commit / stash / abort). Record what reset actually
+did and what it intentionally left behind.
+
+Under `--dry-run`, report what reset *would* do without acting.
+
+### 3. Check the CLI version — before recommending a restart
+
+Best-effort, never blocking:
+
+```bash
+claude --version                 # what this session is running
+npm view @anthropic-ai/claude-code version 2>/dev/null   # latest, if npm is available
+```
+
+Report one of: **update available** (restart is worth it — note both versions),
+**current** (a restart gains nothing; if the motive was context pressure,
+suggest `/compact` instead), or **unknown** (say so plainly — do not guess).
+
+### 4. Write the handoff note last
+
+Written last because it must record what followups actually filed and what
+reset actually did — any earlier and it is speculative.
+
+**Where it lives (both halves required):**
+
+1. `.claude/handoff.md` in this repo — repo-scoped and discoverable. Ensure it
+   is gitignored (add a `.claude/handoff.md` entry if not already covered);
+   the note is session state, never a commit.
+2. A pointer in the agent's auto-memory index (`MEMORY.md` in the memory
+   directory, when one exists): a single line —
+   `- Handoff note at .claude/handoff.md — READ FIRST, then delete note + this line.`
+   The memory index is read automatically at session start, but it arrives as
+   passive background context, not an instruction — so the pointer is a
+   *best-effort backup*, not a guarantee the note is read (a live handoff has
+   been observed to slip past it). The mechanism that actively announces the
+   note is the `session-start-handoff.sh` **SessionStart hook** (installed by
+   Repo Skills), which surfaces the note as session context on startup and
+   resume — the full body inlined when the note is small, a header outline plus
+   an oversize warning when it is large.
+
+**What goes in — only what is not recoverable from the repo:**
+
+- **In-flight state** — open PRs and what they await, running background work,
+  anything mid-flight.
+- **Decisions and their rationale** — settled questions the next session must
+  not relitigate.
+- **Empirically-discovered traps** — "this command hangs", "this flag silently
+  no-ops": findings that cost real time and are invisible in the code.
+- **The precise next action** — one concrete step, not a roadmap.
+
+Deliberately **exclude** anything readable from git history, the issue
+tracker, or `CLAUDE.md` — the exclusion discipline is what keeps the note
+short enough to be read.
+
+**Honesty constraint:** every item carries a verification status —
+`[verified]` (done and checked), `[believed-done]` (done, not re-checked), or
+`[attempted]` (tried, outcome uncertain). A handoff that overstates completion
+is worse than none, because the next session builds on it.
+
+**One-shot contract:** the note describes a single moment. The next session
+reads it, absorbs it, then deletes both the note and the memory pointer —
+promoting anything durable into real memory files or issues. A stale handoff
+lying around is a trap of its own.
+
+Under `--dry-run`, print the note to the conversation instead of writing it.
+
+### 5. Emit the restart block — and stop
+
+The agent cannot quit, upgrade, or relaunch its own process. Do not pretend
+to. End by printing an exact, copy-pasteable block for the human, e.g.:
+
+```
+# In this terminal:
+#   1. Quit this session (Ctrl+C or /exit)
+#   2. If an update was available:
+claude update
+#   3. Relaunch in this repo:
+cd <repo-root> && claude
+# The SessionStart hook announces the handoff note to the new session
+# (the memory-index pointer is a best-effort backup).
+```
+
+Then stop. The ritual is complete when the note is durable and the
+instructions are on screen — the restart itself belongs to the human.
+
+## Principles
+
+Same as every hygiene command: **apply safe fixes, gate destructive ones** —
+this command adds no gates of its own but inherits every gate of the commands
+it composes ([[followups]] always confirms before filing; [[reset]] never
+destroys without opt-in). **Don't be noisy**: the note's value comes from what
+it excludes.

--- a/.claude/commands/repo/help.md
+++ b/.claude/commands/repo/help.md
@@ -57,12 +57,15 @@ stashes, untracked files) always need an explicit opt-in.
 | Command | When to reach for it |
 |---------|----------------------|
 | /repo:reset | Done with a task — get back on main, synced, stale state reviewed |
+| /repo:handoff | Rolling the session (context full, CLI update) — preserve what only the session knows, then restart |
 | /repo:tidy  | Working tree cluttered with build artifacts and temp files |
 | /repo:remote | Need a cloud dev box (GCP/AWS) with this repo ready to go |
-| /repo:release | Cut a release — pre-flight, semver, CHANGELOG, version bump, tag, GitHub Release |
+| /repo:sudo | One-time machine setup — grant passwordless sudo (validated drop-in) so an agent over SSH isn't blocked on password prompts |
+| /repo:release | Cut a release — pre-flight, semver, CHANGELOG, version bump, tag, GitHub Release. Supports per-project release policy via named phase-boundary seams in `.repo/release-policy.md` |
 
 ### Periodic maintenance
 | /repo:audit | Monthly sweep, or after a big refactor/import |
+| /repo:host-optimize | Prep/re-check a Mac (or Linux box) for heavy Loom/agent build use — Gatekeeper churn, backup-agent interference, build-tree bloat |
 | /repo:update-tools | Keep Loom/Anvil/Repo Skills installs current |
 
 ### Focused checks

--- a/.claude/commands/repo/host-optimize.md
+++ b/.claude/commands/repo/host-optimize.md
@@ -1,0 +1,370 @@
+---
+name: "host-optimize"
+description: "Audit and prepare a Mac (or Linux box) for heavy Loom/agent build use — Gatekeeper churn, backup-agent interference, build-tree bloat"
+domain: repo
+type: command
+user-invocable: true
+---
+
+# /repo:host-optimize — Prepare a Build Host
+
+Audit the **host** a machine presents to heavy Loom/agent build workloads, then
+apply the safe fixes and gate the consequential ones. This is host preparation,
+not repo hygiene: nothing here is discoverable from inside a repo, and none of it
+is fixed by [[tidy]] or [[audit]]. It exists because a Mac Studio running six
+concurrent release-build worktrees melted down — load average 118, VNC unusable,
+a multi-hour remediation — and **every root cause was host configuration**:
+`syspolicyd` burning 14+ CPU-hours a day re-scanning `target/` trees on every
+Gatekeeper cache miss, a backup agent churning build dirs at 98% CPU, no
+passwordless sudo, an empty Developer Tools exemption list, and ~10 GB of dead
+worktree `target/` dirs the scanner kept re-walking.
+
+Follows the pack's **inventory → categorize by consequence → report → apply**
+shape (the same shape as [[tidy]] and [[branches]]). Audit checks are always
+report-only and safe. Fixes are split into three consequence tiers: **safe /
+default-on**, **confirm-first**, and **documented-but-manual** (printed only,
+never executed).
+
+**macOS-first, Linux-aware.** The Gatekeeper / SIP / Spotlight / Time Machine
+material is macOS-only and is gated behind a `uname` check. The portable subset
+— build-tree bloat, Loom concurrency vs core count, sudo posture, cache infra,
+remote access — still runs and reports on Linux.
+
+## Usage
+
+```
+/repo:host-optimize            # Audit, apply safe fixes, report; confirm-first items prompt
+/repo:host-optimize --ask      # Review every finding and confirm before applying anything
+/repo:host-optimize --audit    # Audit and report only — apply nothing (like /repo:audit)
+```
+
+(`--apply` is accepted as a synonym for the default, for muscle memory. On a
+non-macOS host the macOS-only checks are skipped with a one-line note and the
+portable subset runs unchanged.)
+
+## Hard constraints (read before implementing)
+
+1. **The two SIP-gated / global items — the ExecPolicy DB trim and
+   `spctl --global-disable` — are PRINT-ONLY. Never shell out to perform
+   either.** The ExecPolicy trim is SIP-gated (Recovery-mode only) and
+   `spctl --global-disable` disables Gatekeeper machine-wide; both are printed
+   as a recipe for a human to run deliberately. This is a hard constraint, not a
+   nice-to-have — it is the highest-consequence part of the command.
+2. **Never write to `/etc/sudoers.d/`.** The sudo-posture check only *detects*
+   whether a passwordless drop-in exists and *delegates* to `/repo:sudo` (issue #49)
+   or prints the manual `visudo`-validated recipe. It does not itself install a
+   sudoers drop-in.
+3. **Everything applied must have appeared in the report first**, and re-running
+   after a clean pass must report a no-op (idempotency) rather than re-applying
+   or erroring.
+
+## Steps
+
+### 1. Detect platform
+
+```bash
+OS="$(uname -s)"   # Darwin = macOS, Linux = Linux
+CORES="$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || nproc)"
+```
+
+Gate every macOS-only probe below behind `[ "$OS" = Darwin ]`. On Linux, print
+`Skipping macOS-only checks (syspolicyd, Gatekeeper, Time Machine, Spotlight) on
+$OS` and run only the portable subset (checks 4–8).
+
+### 2. Audit checks (report-only, always safe)
+
+Run each check and assign a severity consistent with [[audit]]'s scheme —
+**critical** (actively causing or about to cause harm), **warn** (should fix,
+not yet harmful), **info** (nice to fix). Report all findings in one table;
+never mutate anything in this phase.
+
+#### 2.1 syspolicyd health — macOS only
+
+The feedback loop that caused the incident. Each freshly built, ad-hoc-signed
+binary is a Gatekeeper cache miss (`errSecCSUnsigned`) that triggers a malware
+scan re-walking enormous `target/` trees, and the ExecPolicy DB bloats over time
+so every lookup gets slower.
+
+```bash
+# CPU time syspolicyd has burned vs system uptime (a high ratio = the loop is hot)
+ps -axo pid,comm,time | grep -E 'syspolicyd$'
+uptime
+# ExecPolicy DB size — 53 MB in the incident; anything into the tens of MB is a warn
+ls -lh /var/db/SystemPolicyConfiguration/ExecPolicy 2>/dev/null
+# Recent malware-scan churn in the log (bounded window so this stays cheap)
+log show --predicate 'process == "syspolicyd"' --last 30m --style compact 2>/dev/null \
+  | grep -ci 'malware' || true
+```
+
+- **critical**: syspolicyd CPU-time / uptime ratio is high **and** malware-scan
+  log churn is active — the loop is live.
+- **warn**: ExecPolicy DB in the tens of MB (lookups are slowing) with no active
+  churn yet.
+- **info**: DB small, ratio low.
+
+The remediation for a bloated DB is the SIP-gated trim — **printed only** in
+step 4, never run here.
+
+#### 2.2 Gatekeeper posture — macOS only
+
+```bash
+spctl --status                                   # assessments enabled/disabled
+spctl developer-mode --status 2>/dev/null || true
+# Developer Tools exemption list — empty list = every built binary is re-scanned
+sqlite3 /var/db/SystemPolicyConfiguration/ExecPolicy \
+  'select count(*) from developer_tools;' 2>/dev/null || echo 'unreadable'
+```
+
+- **warn**: Developer Tools list empty on a heavy build host (the exact
+  incident condition — every ad-hoc-signed binary is a fresh scan).
+- **info**: assessments enabled with a populated exemption list (normal, healthy).
+
+#### 2.3 Backup / indexing agents — macOS only
+
+Backup and indexing agents love churning build dirs (Backblaze ran a
+`-completesync` at ~98% CPU mid-build-storm during the incident).
+
+```bash
+# Backblaze present?
+ls /Library/Backblaze.bzpkg 2>/dev/null && echo 'backblaze present'
+pgrep -l bztransmit 2>/dev/null || true
+# Time Machine exclusions already covering build dirs?
+tmutil isexcluded ./target 2>/dev/null || true
+# Spotlight indexing status for this volume
+mdutil -s . 2>/dev/null || true
+```
+
+- **warn**: a backup/indexing agent is present and the repo's `target/` /
+  `.loom/worktrees/` dirs are **not** excluded — they will be re-walked.
+- **info**: agents present but build dirs already excluded.
+
+#### 2.4 sudo posture — portable
+
+Detect only; **never** write to `/etc/sudoers.d/`.
+
+```bash
+USER_NAME="$(id -un)"
+ls "/etc/sudoers.d/${USER_NAME}-nopasswd" 2>/dev/null && echo 'nopasswd drop-in present'
+sudo -n true 2>/dev/null && echo 'passwordless sudo works' || echo 'sudo requires a password'
+```
+
+- **warn**: no passwordless drop-in on an unattended agent build host — a remote
+  agent is blocked on every root-level fix.
+- **info**: drop-in present and `sudo -n` succeeds.
+
+Remediation is **delegated to `/repo:sudo` (#49)**, or the printed manual recipe —
+see step 5. Never installed here.
+
+#### 2.5 Build-tree bloat — portable
+
+The directory trees the scanner keeps re-walking. Dead worktree `target/` dirs
+are the safe-to-reclaim ones.
+
+```bash
+# target/ sizes across the repo and every loom worktree
+du -sh target 2>/dev/null || true
+for wt in .loom/worktrees/*/; do du -sh "$wt/target" 2>/dev/null || true; done
+# Dead worktrees whose branch/issue is gone but whose target/ lingers
+git worktree list --porcelain
+```
+
+- **warn**: multi-GB of `target/` under `.loom/worktrees/` belonging to worktrees
+  git no longer lists (dead artifacts), or a very large main `target/`.
+- **info**: only live-worktree build trees present.
+
+Cross-reference [[tidy]] for the in-repo clutter half; this check is specifically
+about the dead-worktree build artifacts the host scanner re-walks.
+
+#### 2.6 Cache infra — portable
+
+```bash
+command -v sccache >/dev/null && sccache --show-stats 2>/dev/null || echo 'sccache not installed'
+df -h . | tail -1     # disk headroom on the build volume
+```
+
+- **warn**: sccache absent (or installed but not wired into the build) on a
+  repeat-build host, or disk headroom under ~10%.
+- **info**: sccache working, ample headroom.
+
+#### 2.7 Concurrency sanity — portable
+
+```bash
+# Loom's configured worktree concurrency vs core count
+jq -r '.concurrency // .maxWorkers // "unset"' .loom/config.json 2>/dev/null || echo 'no .loom/config.json'
+echo "cores: $CORES"
+```
+
+- **critical**: configured concurrency far exceeds cores (the incident: six
+  concurrent release builds of a large Rust workspace drove load average to 118).
+- **info**: concurrency at or below a sane multiple of the core count.
+
+This check only *reports* the mismatch and suggests a value; it never edits
+`.loom/config.json` (that is a deliberate operator call).
+
+#### 2.8 Remote access — portable (with macOS specifics)
+
+A headless build box that sleeps mid-build, or has no remote path in, is a
+support problem waiting to happen.
+
+```bash
+# SSH reachable?
+[ "$OS" = Darwin ] && sudo systemsetup -getremotelogin 2>/dev/null || systemctl is-active ssh sshd 2>/dev/null || true
+if [ "$OS" = Darwin ]; then
+  # Screen Sharing enabled?
+  launchctl list 2>/dev/null | grep -qi screensharing && echo 'screen sharing on'
+  # Will it sleep a headless box mid-build?
+  pmset -g | grep -E 'sleep|disksleep'
+fi
+```
+
+- **warn**: no remote-access path enabled, or power settings will sleep the
+  machine (or its disk) during a long unattended build.
+- **info**: reachable and configured to stay awake.
+
+### 3. Report
+
+Group findings by check and severity, in one table (mirrors [[audit]]'s format),
+then list what the apply phase *will* do per tier before doing it.
+
+```
+## Host Optimize — <hostname> (Darwin, 20 cores)
+
+### Findings
+| Severity | Check            | Finding |
+|----------|------------------|---------|
+| critical | syspolicyd       | 14.2 CPU-hrs vs 26h uptime; malware-scan churn active |
+| critical | concurrency      | .loom concurrency 6 vs 20 cores of a large Rust WS — load 118 risk |
+| warn     | gatekeeper       | Developer Tools exemption list empty |
+| warn     | backup agents    | Backblaze present; target/ not excluded |
+| warn     | sudo posture     | no /etc/sudoers.d/<user>-nopasswd drop-in |
+| warn     | build-tree bloat | 9.7 GB target/ across 4 dead worktrees; 77 GB main target/ |
+| info     | cache infra      | sccache working; 41% disk free |
+| info     | remote access    | SSH on, Screen Sharing on, sleep disabled |
+
+### Will apply now (safe / default-on)
+- Remove target/ of 4 dead loom worktrees (frees ~9.7 GB)
+- tmutil addexclusion ./target and .loom/worktrees/*/target
+- Spotlight: drop .metadata_never_index into those dirs
+- Print Backblaze exclusion instructions (manual — GUI-gated)
+
+### Will prompt (confirm-first)
+- spctl developer-mode enable-terminal (+ GUI toggle you must flip)
+- sudo drop-in via /repo:sudo (delegated; not yet installed)
+
+### Printed only — never executed (documented-but-manual)
+- ExecPolicy DB trim (SIP-gated, Recovery-mode recipe)
+- spctl --global-disable trade-offs
+```
+
+Under `--audit`, stop here.
+
+### 4. Documented-but-manual — PRINT ONLY, NEVER EXECUTE
+
+These two items are printed as recipes for a human to run deliberately. The
+implementation **must not** contain a code path that executes either — verify by
+inspection.
+
+**ExecPolicy DB trim (SIP-gated, Recovery mode).** When the DB has bloated (2.1),
+print:
+
+```
+The ExecPolicy DB (/var/db/SystemPolicyConfiguration/ExecPolicy) is <size>.
+Trimming it is SIP-gated and cannot be done from a normal session. To reset it:
+  1. Reboot into Recovery (hold power on Apple silicon; Cmd-R on Intel).
+  2. From Recovery Terminal, disable SIP:  csrutil disable
+  3. Reboot, then from a normal session remove and let macOS rebuild the DB.
+  4. Reboot into Recovery again and re-enable SIP:  csrutil enable
+This is a deliberate, high-consequence procedure — do it during a maintenance
+window, not mid-build.
+```
+
+**`spctl --global-disable` (disables Gatekeeper machine-wide).** Print the
+trade-offs and the exact command, and require explicit human action:
+
+```
+spctl --global-disable turns off Gatekeeper assessment for the WHOLE machine.
+It eliminates the ad-hoc-signing scan storm but removes malware screening for
+every app on the host — a real security downgrade. If you accept that trade-off
+on a dedicated, physically-secured build box, run it yourself:
+  sudo spctl --global-disable
+Prefer the Developer Tools exemption (step 5) first — it fixes the build-scan
+churn without disabling Gatekeeper globally.
+```
+
+Never run either command from this skill.
+
+### 5. Apply — safe / default-on (no confirmation)
+
+Apply immediately (unless `--ask` or `--audit`), each reported as applied. All
+must be idempotent — re-running skips anything already done.
+
+- **Dead loom-worktree `target/` cleanup.** For each `target/` under
+  `.loom/worktrees/` whose worktree git no longer lists, `rm -rf` it (these are
+  regenerable build artifacts of a gone worktree; the [[tidy]] safety posture
+  applies — never touch a live worktree's tree). Re-report bytes freed.
+- **Time Machine exclusion** (macOS): `tmutil addexclusion` for `./target` and
+  each `.loom/worktrees/*/target`. `tmutil isexcluded` first so a second run is a
+  no-op.
+- **Spotlight exclusion** (macOS): drop a `.metadata_never_index` marker into
+  `target/` and the worktree build dirs (idempotent — skip if present); mention
+  `mdutil -i off <volume>` as the volume-wide alternative for a dedicated box.
+- **Backblaze exclusion instructions** (macOS): Backblaze's exclusions are
+  GUI-gated, so **print** the steps (Backblaze Settings → Exclusions → add the
+  repo `target/` and `.loom/worktrees/` paths) rather than editing its config.
+
+### 6. Apply — confirm-first (explicit prompt before acting)
+
+Each of these prompts for confirmation before doing anything (and under `--ask`
+so does everything in step 5):
+
+- **`spctl developer-mode enable-terminal`** (macOS): after confirmation, run it
+  to add the terminal's toolchain to the Developer Tools exemption — then **tell
+  the human** which GUI toggle to flip (System Settings → Privacy & Security →
+  Developer Tools → enable your terminal), because the pane is GUI-gated and the
+  CLI half alone is not always sufficient.
+- **sudo drop-in** (portable): **delegated to `/repo:sudo` (#49)** — never
+  reimplemented here. If `/repo:sudo` is installed, point the user at it (or its
+  `--sudo` flag). Until #49 ships, print the manual recipe and stop:
+
+  ```
+  To grant passwordless sudo for unattended agent work, run visudo and add a
+  validated drop-in (do NOT edit /etc/sudoers.d/ by hand without visudo -c):
+    sudo visudo -f /etc/sudoers.d/<user>-nopasswd
+    <user> ALL=(ALL) NOPASSWD: ALL
+  visudo validates syntax before saving — a malformed sudoers file can lock you
+  out. This skill will not write that file for you.
+  ```
+
+- **Pause / resume backup agents around a build storm** (macOS): after
+  confirmation, offer to pause Backblaze (`bztransmit` / the menu-bar control)
+  for the duration of a build and resume after — never silently, and always
+  reversible.
+
+### 7. Idempotency
+
+After applying, re-run the relevant probes so the report reflects the new state.
+A second back-to-back invocation must report a clean/no-op state (exclusions
+already present, dead targets already gone, drop-in already detected) and must
+not re-apply or error.
+
+## Safety Rules
+
+1. **PRINT-ONLY, NEVER EXECUTE** the ExecPolicy DB trim and
+   `spctl --global-disable`. No code path may run either — this is the load-bearing
+   constraint of the command.
+2. **Never write to `/etc/sudoers.d/`.** Detect and delegate to `/repo:sudo` (#49)
+   or print the `visudo` recipe; never install the drop-in from here.
+3. **Everything applied must appear in the report first** (step 3), and safe-tier
+   fixes are the only ones applied without confirmation.
+4. **Never delete a live worktree's `target/`** — only `target/` belonging to
+   worktrees git no longer lists. Regenerable build output only; never tracked
+   files, never `.git/`.
+5. **Confirm-first means confirm.** `spctl developer-mode enable-terminal`, the
+   sudo delegation, and backup-agent pause/resume all require an explicit prompt;
+   `--ask` extends confirmation to the safe tier too.
+6. **macOS-only checks skip cleanly on non-macOS** with a one-line note; the
+   portable subset (checks 4–8) still runs and reports.
+7. **Idempotent** — a second run on a prepared host reports a no-op, never
+   re-applies or errors.
+8. **Never edit `.loom/config.json`** — the concurrency check reports a mismatch
+   and suggests a value; changing it is a deliberate operator call.

--- a/.claude/commands/repo/release.md
+++ b/.claude/commands/repo/release.md
@@ -19,10 +19,66 @@ at release time, never hardcoded, so this works in any repo.
 /repo:release                  # Interactive release from the default branch
 ```
 
+## Phase 0 — Load project release policy
+
+Before Phase 1, load the repo's **release policy** if it has one. This is the
+single supported way for a project to inject its own procedural steps (gates,
+extra manifest edits, post-release deploys) at named phase boundaries without
+forking this command — see **Extension points — per-project release policy**
+below for the full seam contract and semantics. Projects migrating off Loom's
+removed `/loom:release` skill re-home their policy here.
+
+The policy lives in **one** file at the repo root: **`.repo/release-policy.md`**.
+Each seam is an H2 section headed `## seam: <name>`. Read it, then **validate the
+declared seam names and surface any that don't bind**, so a typo'd or orphaned
+seam fails loudly instead of silently doing nothing:
+
+```bash
+POLICY_FILE=".repo/release-policy.md"
+KNOWN_SEAMS="pre-flight pre-changelog-style pre-apply pre-push post-push pre-github-release post-summary"
+AUGMENT_ONLY="post-push post-summary"   # no default action → '(replace)' is meaningless
+if [ ! -f "$POLICY_FILE" ]; then
+  echo "(no $POLICY_FILE — running with the built-in phases only, no behavior change)"
+else
+  echo "Project release policy: $POLICY_FILE"
+  # Enumerate declared seams from '## seam: <name>' headers (dropping an optional
+  # '(replace)' suffix) and check each against the known set.
+  grep -E '^##[[:space:]]+seam:[[:space:]]*' "$POLICY_FILE" | while IFS= read -r header; do
+    name="$(printf '%s' "$header" | sed -E 's/^##[[:space:]]+seam:[[:space:]]*//; s/[[:space:]]*\(replace\)[[:space:]]*$//; s/[[:space:]]+$//')"
+    mode="augment"
+    printf '%s' "$header" | grep -Eq '\(replace\)[[:space:]]*$' && mode="replace"
+    case " $KNOWN_SEAMS " in
+      *" $name "*)
+        case " $AUGMENT_ONLY " in
+          *" $name "*)
+            if [ "$mode" = replace ]; then
+              echo "  WARNING: seam '$name' is augment-only — '(replace)' is meaningless here and will be ignored"
+            else
+              echo "  bound: $name (augment)"
+            fi ;;
+          *) echo "  bound: $name ($mode)" ;;
+        esac ;;
+      *)
+        echo "  WARNING: unknown seam '$name' — it matches no phase boundary and will NOT run. Fix the name (see the seam table) or remove the section." ;;
+    esac
+  done
+fi
+```
+
+If any `WARNING:` line prints, **stop and show it to the operator before Phase 1
+proceeds.** An unknown or misused seam is almost always a typo, or policy written
+against a seam this command doesn't expose — silently ignoring it is the exact
+failure this mechanism exists to prevent. Offer **[c]** continue anyway (the
+offending section simply won't run) or **[a]** abort to fix the policy. When the
+policy is clean, note which seams are bound and carry that into the phases below.
+
 ## Phase 1 — Pre-flight
 
 Confirm the repo is safe to cut from. The CI gate degrades gracefully when no
 workflows exist.
+
+> Seam `pre-flight` fires at the start of this phase — run any bound policy steps
+> before (augment) or in place of (replace) the checks below.
 
 ```bash
 # CI status, if CI exists at all
@@ -193,16 +249,65 @@ level and **ask the user to confirm or override.**
 
 ## Phase 4 — Draft the CHANGELOG
 
+> Seam `pre-changelog-style` fires before drafting — run any bound policy steps
+> to enforce a house changelog style (augment) or produce the entry itself
+> (replace).
+
 If `CHANGELOG.md` exists, study its format and draft a new entry matching it
 (header with today's date, a summary line, grouped changes, issue refs). If it's
 **absent**, offer to bootstrap a "Keep a Changelog" template. Present the draft
 and iterate until approved. Omit empty sections.
 
+### Fold an existing `## Unreleased` section into the draft
+
+A CHANGELOG may already carry a `## Unreleased` section — a convention where
+merged-but-unshipped changes accumulate under a placeholder heading at the top of
+the file (directly under the `# Changelog` title, above the newest version entry)
+until the next release names them. If one exists, this release **is** that
+version, so its entries must be folded into the new entry rather than left
+stranded below the freshly-inserted version heading. Do this **at draft time**,
+as part of matching the file's format above — not as a separate Phase 5 step:
+
+1. Check for an existing `^## Unreleased` heading in `CHANGELOG.md`. If none
+   exists, skip the rest of this sub-section entirely and behave exactly as
+   before — the fold path is strictly opt-in on the heading's presence and makes
+   **no** change to the draft-from-git-log path when absent.
+2. If present, capture its body — every line between that heading and the next
+   `^## ` heading (the newest existing version entry).
+3. Merge those captured items into the git-log-derived draft, **de-duplicating**
+   against items this release already derived from its git-log range. Entries in
+   this repo cite issue/PR numbers in their lead-ins (e.g. `(#38, PR #42)`,
+   `(#43)`), so a simple `grep -oE '#[0-9]+'` per bullet and a set-intersection
+   against the range's issue/PR references is a sufficient dedup key for v1 (fall
+   back to a fuzzy text match only for bullets that cite no number). Keep a
+   captured `## Unreleased` bullet only if none of its numbers already appear in
+   the git-log-derived draft.
+4. Produce **one** combined entry headed with the new version + today's date,
+   positioned **where `## Unreleased` was** — since that heading conventionally
+   sits at the very top, this is a rename-in-place (`## Unreleased` →
+   `## X.Y.Z (date)`), not an append elsewhere and no reordering. The
+   `## Unreleased` heading itself is removed as part of drafting.
+
+> Seam interaction: under a `pre-changelog-style (replace)` policy the default
+> draft heuristic — including this fold — is skipped per the seam's
+> "policy steps produce the entry; skip the default draft heuristic" semantics
+> (see the seam table below), so folding any `## Unreleased` section becomes the
+> policy's responsibility. Under `augment` (the default), the seam's steps run
+> first and then this fold runs, so there is no conflict.
+
 ## Phase 5 — Apply
+
+> Seam `pre-apply` fires before this phase — run any bound policy steps (e.g.
+> edit extra manifests) before (augment) or in place of (replace) the bump.
 
 Once approved:
 
-1. Insert the new entry into `CHANGELOG.md`.
+1. Insert the new entry into `CHANGELOG.md`. Phase 4 has already produced the
+   fully-merged entry (folding any `## Unreleased` section into it at draft
+   time), so this is a straight "write this string" — no fold/merge happens here.
+   The `pre-apply` seam therefore needs **no** change for the fold: it fires
+   before this insert, after drafting is complete, so it never observes an
+   un-folded entry regardless of how the string was assembled.
 2. **Show the version-bearing files** the tool will touch, then bump. Dispatch on
    the detected tool; each branch must produce a version commit **and** tag:
 
@@ -226,10 +331,27 @@ Once approved:
    commit/tag convention (check `git log` and `git tag`).
 3. **Verify**: re-read the version and confirm the tag exists
    (`git tag --sort=-v:refname | head -1`). For cargo, `cargo check --workspace`.
+   Also confirm the `## Unreleased` fold (Phase 4) actually landed: grep the
+   freshly-written `CHANGELOG.md` for any surviving `## Unreleased` heading and
+   **fail loudly** if one remains — a stray heading means the fold silently
+   didn't happen (e.g. both headings were left in place, or dedup dropped the
+   merge), which would strand this release's entries below the new version.
+
+   ```bash
+   if grep -Eq '^##[[:space:]]+Unreleased([[:space:]]|$)' CHANGELOG.md; then
+     echo "ERROR: a '## Unreleased' heading survived — Phase 4 fold did not complete" >&2
+     exit 1
+   fi
+   ```
 
 Show the result and get final confirmation.
 
 ## Phase 6 — Push & release
+
+Three seams fire in this phase: `pre-push` (before the push), `post-push`
+(immediately after it succeeds), and `pre-github-release` (before
+`gh release create`). Run any bound policy steps at each boundary — e.g. a
+`pre-github-release` gate that holds the Release until publish workflows finish.
 
 After an explicit yes:
 
@@ -259,11 +381,103 @@ CHANGELOG: 1 entry added
 Release:   GitHub Release created  (or: tag push only — no release workflow)
 ```
 
+> Seam `post-summary` fires after the summary — run any bound policy steps (e.g.
+> deploy a docs site, notify a channel).
+
+## Extension points — per-project release policy
+
+The phases above are fixed, but a project can inject its own procedural steps at
+**named phase boundaries** ("seams") without forking this command. This is what
+projects migrating off Loom's removed `/loom:release` skill use to re-home
+release policy — gates, extra manifest edits, post-release deploys.
+
+### Where policy lives
+
+**One** file, at the repo root: **`.repo/release-policy.md`**. There is a single
+supported lookup path by design — no per-user, per-branch, or fallback locations.
+Advisory *reminders* (e.g. "bump the protocol version when the API changes") still
+belong in the repo's CLAUDE.md, which this command already reads as context; the
+policy file is specifically for **procedural steps bound to a seam**.
+
+### Policy file format
+
+Each seam is an H2 section whose header is `## seam: <name>`, optionally suffixed
+with `(replace)`. The section body is the prose/steps the command runs at that
+boundary. Non-seam prose (a title, notes) is ignored — only `## seam:` headers
+bind.
+
+```markdown
+# Release policy — my-project
+
+## seam: pre-github-release
+
+Hold the GitHub Release until both publish workflows finish:
+- `gh run watch <npm-publish-run>` and `<crates-publish-run>` must both be green.
+
+## seam: post-summary
+
+Deploy the docs site: `gh workflow run deploy-site.yml`.
+
+## seam: pre-push (replace)
+
+Push via the release-bot identity instead of the default push:
+`git -c user.name="release-bot" push origin "$(git symbolic-ref --short HEAD)" --follow-tags`
+```
+
+### Seams and semantics
+
+Steps **augment** by default — they run *in addition to* the phase's built-in
+action, at the boundary. Appending `(replace)` to the header makes the policy
+steps stand in for the phase's default action instead. `(replace)` is only
+meaningful where the boundary has a default action to replace:
+
+| Seam | Fires | Augment (default) | `(replace)` |
+|------|-------|-------------------|-------------|
+| `pre-flight` | start of Phase 1 | run policy steps, then the standard pre-flight checks | policy steps become the pre-flight gate; skip the built-in CI/clean-tree checks |
+| `pre-changelog-style` | before Phase 4 drafts the entry | run policy steps (e.g. enforce a house changelog style), then draft — the default draft still folds any existing `## Unreleased` section into the new entry | policy steps produce the entry; skip the default draft heuristic — **including** the `## Unreleased` fold, so a `(replace)` policy owns folding any `## Unreleased` section itself or it will be left stranded |
+| `pre-apply` | before Phase 5 applies | run policy steps (e.g. edit extra manifests), then bump + commit + tag | policy steps perform the bump/commit/tag; skip the default apply dispatch |
+| `pre-push` | before the `git push` in Phase 6 | run policy steps (a final gate), then push | policy steps perform the push; skip the default `git push` |
+| `post-push` | immediately after the push succeeds | run policy steps | **augment-only** — no default action; a `(replace)` marker is ignored with a warning |
+| `pre-github-release` | before `gh release create` | run policy steps (e.g. wait for publish workflows), then create the Release | policy steps create the Release (or intentionally skip it); skip the default `gh release create` |
+| `post-summary` | after the Phase 7 summary | run policy steps (e.g. deploy a site) | **augment-only** — no default action; a `(replace)` marker is ignored with a warning |
+
+### Unknown seams are surfaced, never silently ignored
+
+Phase 0 enumerates every `## seam: <name>` in the policy file and checks each name
+against the table above. A header naming no known seam — a typo like
+`pre-changelog-styl`, or policy written against a seam this command doesn't expose
+— prints a `WARNING` shown to the operator **before Phase 1 proceeds**, rather
+than binding to nothing. Likewise, `(replace)` on an augment-only seam
+(`post-push`, `post-summary`) warns. This is the guarantee that migrated policy
+cannot silently stop firing.
+
+### Migrating from `/loom:release`
+
+Loom's removed `/loom:release` skill exposed five seams. **All five carry over
+under the same names**, so policy targeting them binds unchanged:
+
+| `/loom:release` seam | `/repo:release` seam | Change |
+|----------------------|----------------------|--------|
+| `pre-changelog-style` | `pre-changelog-style` | none (identity) |
+| `pre-push` | `pre-push` | none (identity) |
+| `post-push` | `post-push` | none (identity) |
+| `pre-github-release` | `pre-github-release` | none (identity) |
+| `post-summary` | `post-summary` | none (identity) |
+
+`/repo:release` adds two boundaries Loom didn't have — `pre-flight` and
+`pre-apply` — for gates that must run before the pre-flight checks or before the
+version bump. To migrate, move the policy text into `.repo/release-policy.md`
+under a `## seam: <name>` header for each old seam name. Nothing is dropped in the
+rename.
+
 ## Principles
 
 Cutting a release is irreversible and outward-facing, so unlike the safe-fix
 hygiene commands it stays **report first, act second** — nothing is committed,
 tagged, or pushed without a yes. **General by design** — the tool and the file
-set are discovered, never assumed. If the repo needs a release-time reminder
+set are discovered, never assumed. If the repo needs a release-time *reminder*
 (e.g. "bump the protocol version when the API changes"), keep it in the repo's
-own CLAUDE.md; this command reads that context at runtime.
+own CLAUDE.md; this command reads that context at runtime. Procedural policy that
+must *run* at a specific point — a gate, an extra manifest edit, a post-release
+deploy — goes in `.repo/release-policy.md` bound to a named seam instead (see
+**Extension points — per-project release policy** above).

--- a/.claude/commands/repo/remote.md
+++ b/.claude/commands/repo/remote.md
@@ -33,6 +33,29 @@ locally to drive the cloud CLI; they are **never** copied to the VM.
 First time in a repo? Run `/repo:remote --configure` to build the `.env` below,
 then `/repo:remote` to launch.
 
+The provisioning contract below is implemented **once**, as an executable
+script — `scripts/repo/repo-remote.sh`, installed to
+`.claude/skills/repo/scripts/repo-remote.sh`. The interactive flow here is a
+thin wrapper: it runs the wizard/cost-confirmation UX, and once you say yes it
+calls that script rather than re-issuing `aws`/`gcloud` calls from prose. The
+same script is the **headless entry point** a non-interactive caller (e.g.
+loom's `fleet add-worker`) invokes directly:
+
+```
+repo-remote up [aws|gcp]              # DRY RUN: print the resolved plan + estimated cost as JSON, create NOTHING
+repo-remote up --yes [--json]        # provision (or reuse) with no prompts; requires pre-supplied cost-relevant config
+repo-remote status [--json]          # list instances tagged repo-remote=<name>
+repo-remote down [--yes] [--delete]  # dry-run listing without --yes; stop (or --delete to terminate) with --yes
+```
+
+`--yes` **removes the prompt, not the consent.** A cost-relevant field missing
+from config — the provider, its credentials, or `REPO_REMOTE_INSTANCE_TYPE` —
+is a loud, non-zero-exit failure, never a silent default that could pick a
+billable size on its own. Plain `repo-remote up` (no `--yes`) is a dry run that
+prints the plan and estimated hourly cost and spends nothing, so a caller can
+implement a "plan shown before money is spent" check against the `--json`
+output (instance id, public IP, SSH alias, estimated hourly cost).
+
 ## Configuration — two layers
 
 Settings come from two files, loaded in order so the repo can override the
@@ -104,7 +127,8 @@ REPO_REMOTE_DOCKERFILE=./Dockerfile       # optional: build & run this checked-i
 REPO_REMOTE_SETUP="make setup"            # optional first-boot command; fallback when no Dockerfile
 
 # --- session ---
-REPO_REMOTE_IDLE_SHUTDOWN_MIN=120
+REPO_REMOTE_IDLE_SHUTDOWN_MIN=120         # interactive-host default; use ~20 for daemon-managed/worker hosts (see below)
+REPO_REMOTE_IDLE_MARKER=                   # optional idle-exit marker path (default: /var/run/repo-remote-daemon-idle.marker)
 ```
 
 Only `REPO_REMOTE_PROVIDER` (or a provider argument) and that provider's
@@ -189,6 +213,15 @@ wants a repo-specific account/region.
 
 ## Steps
 
+Steps 1–4, plus `--status`/`--down`, describe the provisioning contract that
+`scripts/repo/repo-remote.sh` implements. The interactive flow **delegates** to
+that script: it performs the credential-hygiene checks and the wizard/cost
+confirmation here, then hands the resolved plan to `repo-remote up --yes`
+(passing the confirmed provider/instance-type through config) rather than
+issuing the `aws`/`gcloud` calls itself. This keeps a single implementation, so
+the headless path and the interactive path cannot drift. The cloud-CLI
+specifics below document *what the script does* and remain the reference for it.
+
 ### 1. Load and validate config
 
 Load both layers and resolve the effective settings (a provider argument
@@ -253,12 +286,75 @@ Requirements for the created instance:
   on AWS, quota-aware handling.
 - Install an idle-shutdown guard (cron checking SSH sessions + CPU, running
   `shutdown -h` after `REPO_REMOTE_IDLE_SHUTDOWN_MIN`) so a forgotten VM — GPU
-  ones especially — doesn't burn money
+  ones especially — doesn't burn money. See **The idle-shutdown guard** below for
+  its exact activity model, the daemon-host short-window recommendation, and the
+  idle-exit marker contract.
 - AWS: security group allowing SSH from the user's IP only, using
   `REPO_REMOTE_SSH_KEY`'s public key. GCP: prefer OS Login / IAP.
 
 If the zone/region is stocked out (common for GPU types), offer the nearest
 alternative zone or the next type down rather than failing.
+
+#### The idle-shutdown guard
+
+The guard is a cron watchdog (`/usr/local/bin/repo-remote-idle-check`, run every
+minute) installed via cloud-init user-data. It powers the host off with
+`shutdown -h` once it has been idle for `REPO_REMOTE_IDLE_SHUTDOWN_MIN` minutes.
+
+**Activity model (what keeps the host alive).** "Activity" is exactly two local
+signals: an **open SSH session** (`who`) **or** a **CPU load average > 0.2**.
+There is deliberately **no process-name veto** — a running background process
+(including `loom-daemon`) does **not**, on its own, keep the host alive. If a
+future daemon-presence veto is ever wanted, it must be added as a deliberate,
+documented change to `idle_guard_userdata()`; it is not implied by the current
+text. (This corrects an earlier problem statement that assumed a
+`pgrep -f loom-daemon` veto existed — it never did in this repo.)
+
+**Idle window — pick per host role:**
+
+- **Interactive hosts** (a human SSHes in to work): keep the default
+  `REPO_REMOTE_IDLE_SHUTDOWN_MIN=120`. The generous 2-hour margin is sized for
+  "operator stepped away from a session" so the box isn't yanked out from under
+  someone mid-task.
+- **Daemon-managed / worker hosts** (e.g. a box running `loom-daemon` for a
+  fleet, with no interactive operator): use a **short window such as
+  `REPO_REMOTE_IDLE_SHUTDOWN_MIN=20`**. These hosts have no human session to
+  protect, so the "operator forgot a session" margin is pure wasted spend — on a
+  c7i.2xlarge-class worker (~$8.60/day) the difference between a 120- and a
+  20-minute window is real money once the fleet goes quiet.
+
+**Idle-exit marker contract (`REPO_REMOTE_IDLE_MARKER`).** For daemon-managed
+hosts, the guard also honors an **idle-exit marker file** so a daemon can hand
+the guard a precise "idle since" time instead of waiting for the guard's own
+once-a-minute load sampling to first read idle. This is a self-contained
+contract published by `repo:remote` — the guard works standalone whether or not
+anything ever writes the file:
+
+- **Path.** `REPO_REMOTE_IDLE_MARKER` sets the file path the guard watches;
+  unset, it defaults to **`/var/run/repo-remote-daemon-idle.marker`**. The path
+  is always embedded in the generated guard, so the branch is present-but-inert
+  until the file exists on-host.
+- **Semantics.** When the marker file **exists**, the guard treats its **mtime**
+  as an authoritative "idle since" timestamp and powers off once that mtime is
+  older than `REPO_REMOTE_IDLE_SHUTDOWN_MIN` minutes — **replacing** (not
+  supplementing) its own internal stamp countdown for that pass. In other words:
+  shutdown fires `IDLE_MIN` minutes after the marker's mtime, independent of when
+  the guard's SSH/load sampling happened to first observe idleness.
+- **Safety precedence.** An active SSH session or CPU load > 0.2 still vetoes
+  shutdown *before* the marker is consulted — the guard never powers off a host
+  someone is actively using, even if a stale marker is present. A marker with a
+  **future** mtime (clock skew) yields a negative age and simply never triggers,
+  so it can't cause a spurious power-off.
+- **Producer contract (for a daemon side, e.g. loom's idle-exit).** On a clean
+  idle-exit, `touch` the marker path (creating/updating its mtime). To reset the
+  clock when work resumes, remove the file (or `touch` it again). The on-host
+  image is Ubuntu (GNU coreutils), so the guard reads the mtime with
+  `stat -c %Y`. This repo neither writes nor depends on any daemon writing the
+  file — the convention stands alone and a daemon may adopt it whenever it ships.
+
+On a daemon-managed host the two stages compose: the daemon's own idle-exit
+(writing the marker) is the first stage; this guard, `IDLE_MIN` minutes later, is
+the second and final stage that actually powers the box off.
 
 #### GPU hosts
 
@@ -436,6 +532,10 @@ Claude Code cannot host an interactive SSH session itself, so hand it to the OS
   terminal
 
 Tell the user they can start `claude` in that session to continue on the remote.
+On a freshly provisioned box, `/repo:sudo` is the companion step that unblocks
+root-level remediation over SSH — a non-interactive SSH session can't answer a
+`sudo` password prompt, so an agent stalls on it until a validated
+passwordless-sudo drop-in is installed.
 
 ### 8. Report
 
@@ -444,6 +544,12 @@ hourly cost estimate, idle-shutdown window, the SSH alias, whether the ID was
 written back to `.env`, and the teardown command (`/repo:remote --down`).
 
 ## `--status` and `--down`
+
+Both delegate to the shared script (`repo-remote status` / `repo-remote down`),
+which resolves the same two config layers and only ever touches instances
+carrying this repo's `repo-remote` tag. `repo-remote down` without `--yes` is a
+dry run that lists exactly what would stop; `--yes` acts, and `--delete`
+terminates.
 
 - `--status`: list all instances labeled `repo-remote=<repo-name>` with state
   and uptime; estimate accumulated cost. Uses the resolved credentials (shared

--- a/.claude/commands/repo/sudo.md
+++ b/.claude/commands/repo/sudo.md
@@ -1,0 +1,275 @@
+---
+name: "sudo"
+description: "Opt-in passwordless sudo for a dev machine — install a visudo-validated /etc/sudoers.d drop-in (ALL or a scoped command list) so an agent over SSH isn't blocked on password prompts, always confirmed first"
+domain: repo
+type: command
+user-invocable: true
+---
+
+# /repo:sudo — Passwordless-sudo setup for dev machines
+
+Install (or inspect, or remove) a `NOPASSWD:` **sudoers drop-in** for the
+current user on **this machine**, so an agent driving the box over SSH isn't
+stopped dead by a `sudo` password prompt it can't answer. A non-interactive SSH
+session has no TTY to type a password into, so every root-level remediation —
+`launchctl bootout`, killing a runaway root process, `spctl`, `renice` — stalls
+until a human runs the command by hand. This command installs the standard fix
+once, safely, so agent-driven remote sessions can finish end-to-end.
+
+This is **machine-global, consequential setup**: the drop-in grants anyone
+holding the user's SSH key effective root on this box. It is therefore in the
+same **always-confirm-first** class as `/repo:remote`, `/repo:followups`, and
+`/repo:update-tools` — it shows the **exact file contents** it will write and
+**never applies silently**, even without `--ask`. There is nothing to opt into;
+confirmation is the only mode. The reasonable trade this makes — passwordless
+root for personal dev machines on a private tailnet — is a deliberate operator
+choice, so the operator makes it explicitly every time a scope changes.
+
+> **Touch ID is the better answer for *local, interactive* use** — enabling
+> `pam_tid.so` in `/etc/pam.d/sudo` lets a Mac authorize `sudo` with a
+> fingerprint. But Touch ID does **not** work over SSH (there is no local
+> fingerprint reader on the remote end), which is exactly why a `NOPASSWD:`
+> drop-in is the right tool for **agent sessions** and this command exists.
+
+The **destructive-command guard still applies on top.** Passwordless sudo
+removes the *password* gate, not the guard's `ask`/`block` gates on risky
+commands (`rm -rf /`, force-push to `main`, cloud destruction, …). Granting
+passwordless root does not weaken any of those checks.
+
+## Usage
+
+```
+/repo:sudo                 # Guided: explain the grant, confirm, install an ALL-scoped drop-in
+/repo:sudo --scoped        # Confirm, then install a command-list-scoped drop-in
+                            #   (launchctl, pkill, spctl, renice, …) instead of ALL
+/repo:sudo --status        # Report whether a drop-in exists, its scope, and validity — writes nothing
+/repo:sudo --remove        # Confirm, then remove this command's drop-in file
+```
+
+## How it works
+
+The drop-in lives at a well-known, per-user path — **the file itself is the
+marker**:
+
+```
+/etc/sudoers.d/<user>-nopasswd
+```
+
+Both macOS and Linux read this directory automatically, so **no OS branching is
+needed**:
+
+- **macOS** — `/etc/sudoers` (a symlink target of `/private/etc/sudoers`)
+  ships `@includedir /private/etc/sudoers.d` by default, and `/etc/sudoers.d`
+  is `/private/etc/sudoers.d`.
+- **Linux** — nearly every distro ships `#includedir /etc/sudoers.d` in
+  `/etc/sudoers`.
+
+The candidate file is always syntax-checked **in isolation** with
+`sudo visudo -cf "$TMP"` *before* it is copied into `/etc/sudoers.d/` — a
+malformed drop-in never becomes live policy. After the validated file is
+installed, a full-chain `sudo visudo -c` (it validates `/etc/sudoers` **and**
+every file it includes) implicitly proves the include chain is active on either
+platform, so there is no need to detect the OS or hand-verify the directive.
+
+The written file always carries a **discoverability header** on its first line
+so `--status`, `--remove`, and any later host-posture audit (e.g.
+`/repo:host-optimize`) can find and attribute it without guessing from the
+filename:
+
+```
+# Installed by /repo:sudo (rjwalters/repo) — see .claude/commands/repo/sudo.md
+```
+
+Two scopes are supported:
+
+- **ALL** (default) — blanket passwordless root:
+
+  ```
+  <user> ALL=(ALL) NOPASSWD: ALL
+  ```
+
+- **Scoped** (`--scoped`) — passwordless only for a small allowlist of
+  service-management commands, so agents are unblocked on the operations that
+  actually stall over SSH without granting blanket root:
+
+  ```
+  <user> ALL=(ALL) NOPASSWD: /bin/launchctl, /usr/bin/pkill, /usr/sbin/spctl, /usr/bin/renice
+  ```
+
+  Anything outside that list still prompts for a password. Adjust the allowlist
+  to what the machine actually needs before confirming.
+
+## Steps
+
+### 1. Resolve the target and read current state
+
+Resolve the drop-in path and read what's already installed — every mode below
+starts here, and it is the whole of `--status`.
+
+```bash
+USER_NAME="$(id -un)"
+DROPIN="/etc/sudoers.d/${USER_NAME}-nopasswd"
+
+if [ -f "$DROPIN" ] || sudo test -f "$DROPIN" 2>/dev/null; then
+  CURRENT="$(sudo cat "$DROPIN" 2>/dev/null)"        # readable only as root (0440)
+else
+  CURRENT=""
+fi
+```
+
+Classify the installed scope from `$CURRENT`, ignoring the header/comment lines:
+
+- **absent** — no file.
+- **ALL** — the effective grant is `NOPASSWD: ALL`.
+- **scoped** — the effective grant is a `NOPASSWD:` command list.
+
+Determine the **requested** scope from the flags: `--scoped` → scoped list;
+otherwise → ALL. (`--status` and `--remove` don't request a scope.)
+
+### 2. `--status` — report only, write nothing
+
+Report and **stop** — this mode never writes, never prompts, and must not
+change the file's mtime:
+
+- Whether `$DROPIN` exists, and its scope (ALL vs. the scoped command list).
+- Whether it currently passes validation — run `sudo visudo -c` and report
+  pass/fail (this reads the config; it does not modify it).
+- Whether passwordless sudo is actually in effect right now:
+  `sudo -n true 2>/dev/null && echo 'passwordless sudo works' || echo 'sudo still requires a password'`.
+
+Then exit. Do not fall through to any write path.
+
+### 3. `--remove` — delete this command's drop-in (confirm first)
+
+Only ever remove **this command's own** file at `$DROPIN` (identified by the
+header from step 1) — never touch other files in `/etc/sudoers.d/`.
+
+1. If the file is absent, say so and stop (nothing to remove — idempotent).
+2. Show the file that will be deleted and its current contents, and get an
+   explicit **yes**.
+3. Remove it, then re-validate so the removal didn't break anything:
+
+   ```bash
+   sudo rm -f "$DROPIN"
+   sudo visudo -c
+   ```
+
+4. Confirm the effect: a subsequent `sudo` now prompts for a password again
+   (`sudo -n true` should fail). Report done.
+
+### 4. Idempotency check (install modes)
+
+Before writing anything, compare the **installed** scope (step 1) against the
+**requested** scope (step 2):
+
+- **Same scope already installed** → **no-op.** Report "already configured
+  (`<scope>`) at `$DROPIN`" and stop. Do not re-prompt and do not re-write —
+  re-running with the same scope must make no changes.
+- **Different scope installed** (e.g. `--scoped` requested but `ALL` is
+  installed, or vice-versa) → this is a real change of the grant. Say so
+  explicitly ("currently `ALL`; you asked for `scoped`"), and require
+  confirmation in step 5 before overwriting.
+- **Nothing installed** → proceed to step 5 as a fresh install.
+
+### 5. Confirm, then write / validate / roll back
+
+Always show the **exact file contents** (including the header line) that will be
+written, name the target path, and get an explicit **yes** before touching
+anything — even without `--ask`. Never write silently.
+
+Build the file in a temp location and **validate the candidate in isolation
+before it can go live** — only a syntactically valid file is ever copied into
+`/etc/sudoers.d/`. There is no separate "enable" step for a sudoers.d file: the
+`@includedir` / `#includedir` directive picks it up on the very next `sudo`
+parse, so a broken file that reaches the directory is *already* live policy —
+and because sudo fails closed on a syntax error, the rollback `sudo rm` could be
+denied by the very file it is trying to remove. Validating `$TMP` first makes
+that failure mode impossible; the post-install full-chain check is then only a
+belt-and-suspenders proof that the include wiring is sound:
+
+```bash
+USER_NAME="$(id -un)"
+DROPIN="/etc/sudoers.d/${USER_NAME}-nopasswd"
+TMP="$(mktemp)"
+
+# Header first (discoverability), then the grant line for the chosen scope:
+{
+  echo "# Installed by /repo:sudo (rjwalters/repo) — see .claude/commands/repo/sudo.md"
+  # Default (ALL):
+  echo "${USER_NAME} ALL=(ALL) NOPASSWD: ALL"
+  # --scoped instead:
+  # echo "${USER_NAME} ALL=(ALL) NOPASSWD: /bin/launchctl, /usr/bin/pkill, /usr/sbin/spctl, /usr/bin/renice"
+} > "$TMP"
+chmod 440 "$TMP"
+
+# Validate the candidate BEFORE it can affect live policy. visudo -cf checks a
+# single file's syntax without installing it, so a malformed drop-in never
+# becomes active and we never depend on a possibly-broken sudo to undo it.
+if ! sudo visudo -cf "$TMP"; then
+  rm -f "$TMP"
+  echo "candidate sudoers failed validation — nothing installed" >&2
+  exit 1
+fi
+
+# Only a validated file reaches /etc/sudoers.d/:
+sudo cp "$TMP" "$DROPIN"
+sudo chmod 440 "$DROPIN"
+rm -f "$TMP"
+
+# Belt-and-suspenders: full-chain re-check proves the include wiring too. If it
+# somehow fails, remove the drop-in and exit non-zero — never leave an
+# unvalidated or broken file in place. (This rollback is now reliable because
+# the file was already known-valid before it landed.)
+if ! sudo visudo -c; then
+  sudo rm -f "$DROPIN"
+  echo "post-install validation failed — removed ${DROPIN}, no change made" >&2
+  exit 1
+fi
+```
+
+The order is load-bearing: the candidate is syntax-checked with
+`visudo -cf "$TMP"` **before** the `cp`, so a malformed drop-in never becomes
+live policy and the rollback never has to fight a broken sudo. The post-install
+`visudo -c` is the final full-chain gate; if it fails for **any** reason the
+drop-in is deleted and the command exits non-zero — there is no path in which a
+failed-validation file survives, and no path in which an unvalidated file goes
+live even momentarily.
+
+### 6. Verify and report
+
+On success, prove the grant actually took and report a compact block:
+
+```bash
+sudo -n true 2>/dev/null && echo 'passwordless sudo now works' \
+                         || echo 'WARNING: drop-in written and validated but sudo -n still prompts'
+```
+
+Report: the path written, the scope (ALL vs. the scoped list, with the exact
+command list for the scoped case), that permissions are `0440`, that
+`visudo -c` passed, and the removal command (`/repo:sudo --remove`) for undoing
+it later.
+
+## Safety Rules
+
+1. **Always confirm before writing** — show the exact file contents (header +
+   grant line) and the target path, and act only on an explicit yes. There is
+   no silent/auto-apply mode; confirmation is the only mode.
+2. **Validate the candidate before it goes live, then roll back on failure** —
+   the candidate is built at `0440` in a temp file and syntax-checked in
+   isolation with `sudo visudo -cf "$TMP"` **before** it is copied into
+   `/etc/sudoers.d/`, so a malformed drop-in never becomes active policy (a
+   sudoers.d file is live the instant it lands, and sudo fails closed on a
+   syntax error — validating pre-install is what keeps the rollback reliable). A
+   post-install full-chain `sudo visudo -c` then re-checks the include wiring;
+   on any failure the file is removed and the command exits non-zero. A broken
+   sudoers file can lock the user out of root, so an unvalidated file is never
+   installed or left behind.
+3. **Idempotent** — re-running with the same scope detects the existing drop-in
+   and no-ops; only a scope *change* prompts to overwrite.
+4. **Only ever touch this command's own drop-in** at
+   `/etc/sudoers.d/<user>-nopasswd` (identified by its `Installed by /repo:sudo`
+   header) — never other files in `/etc/sudoers.d/`.
+5. **The destructive-command guard still applies** — passwordless sudo removes
+   the password gate, not the guard's `ask`/`block` gates on risky commands.
+6. **Prefer the smallest grant that unblocks the work** — offer `--scoped`
+   (launchctl / pkill / spctl / renice) when blanket `ALL` root isn't needed.

--- a/.claude/commands/repo/update-tools.md
+++ b/.claude/commands/repo/update-tools.md
@@ -15,15 +15,22 @@ to update the stale ones.
 ## Usage
 
 ```
-/repo:update-tools             # Report, then offer updates
-/repo:update-tools --check     # Report only
-/repo:update-tools loom        # Only check/update one tool
+/repo:update-tools               # Report, then offer updates (commit + land on the default branch)
+/repo:update-tools --check       # Report only, never writes
+/repo:update-tools loom          # Only check/update one tool
+/repo:update-tools --no-commit   # Update the working tree but leave it uncommitted for review
 ```
 
 An update runs the tool's own installer (executing code from its source repo
 and rewriting `.claude/`), so unlike the safe-fix hygiene commands this one is
 **not** auto-applied — it reports and confirms before updating. `--check` is
 the report-only form.
+
+Once an update is confirmed, it is committed and landed on the default branch
+(`main`) by default — it does **not** push, and it never folds a pre-existing
+dirty working tree into the update commit. Pass `--no-commit` (alias
+`--stage-only`) to restore the old behavior of leaving the changes uncommitted
+for manual review. See step 5 and the Safety Rules for details.
 
 ## Steps
 
@@ -114,9 +121,66 @@ git -C <source> pull --ff-only
 If the source clone has local modifications or `--ff-only` fails, report it
 and skip that tool rather than resolving on your own.
 
-After updating, re-read each metadata file to confirm the new version, and
-show a summary of what changed in the repo (`git status --short`) so the user
-can review and commit the update.
+After updating, re-read each metadata file to confirm the new version and show
+a summary of what changed (`git status --short`).
+
+### 5. Land the update (default)
+
+A confirmed tool bump is a safe, reversible, version-controlled change (the
+installer is idempotent and re-runnable), so by default `update-tools` **commits
+it and lands it on the default branch** rather than stopping at an uncommitted
+diff. It **never** pushes — pushing is outward-facing and stays a separate,
+explicit action (Safety Rule 5). Pass `--no-commit` (alias `--stage-only`) to
+skip this step and leave the working-tree changes uncommitted for manual review
+instead (the old behavior).
+
+Land each tool's bump as its own commit:
+
+1. **Isolate the installer's footprint.** Snapshot the working tree *before*
+   running the installer so a pre-existing dirty tree is never folded into the
+   update commit:
+
+   ```bash
+   pre=$(mktemp); post=$(mktemp)
+   git -C <this-repo> status --porcelain | sed 's/^...//' | sort > "$pre"
+   # ... run the tool's installer (step 4, above) ...
+   git -C <this-repo> status --porcelain | sed 's/^...//' | sort > "$post"
+   # Paths the installer actually changed = post minus pre:
+   comm -13 "$pre" "$post" > changed.txt
+   ```
+
+   Stage **only** those paths (`git -C <this-repo> add -- $(cat changed.txt)`),
+   never `git add -A`. If `changed.txt` is empty the installer was a no-op —
+   report "already current" and skip the commit for that tool.
+
+2. **Commit + land on the default branch, without committing straight to it:**
+
+   ```bash
+   DEFAULT=$(git -C <this-repo> symbolic-ref --quiet --short refs/remotes/origin/HEAD | sed 's#^origin/##')
+   DEFAULT=${DEFAULT:-main}
+   CUR=$(git -C <this-repo> symbolic-ref --short HEAD)
+   MSG="chore(tooling): update <tool> <old>→<new>"
+
+   if [ "$CUR" = "$DEFAULT" ]; then
+     # On the default branch: commit on a short-lived branch, then fast-forward
+     # merge it in — lands on the default branch without a straight-to-main commit.
+     tmp="tooling/update-<tool>-<new>"
+     git -C <this-repo> checkout -b "$tmp"
+     git -C <this-repo> commit -m "$MSG"
+     git -C <this-repo> checkout "$DEFAULT"
+     git -C <this-repo> merge --ff-only "$tmp"
+     git -C <this-repo> branch -d "$tmp"
+   else
+     # Already on a feature branch: commit here and report where it landed —
+     # do NOT switch branches mid-session and disturb the user's working state.
+     git -C <this-repo> commit -m "$MSG"
+     echo "Landed the update on '$CUR' (not '$DEFAULT') — you are on a feature branch."
+   fi
+   ```
+
+3. **Report** the resulting commit (`git -C <this-repo> log --oneline -1`) and
+   remind the user it has **not** been pushed (run `git push` explicitly to
+   share it).
 
 ## Safety Rules
 
@@ -125,5 +189,11 @@ can review and commit the update.
    marker blocks; hand-copying breaks reinstall idempotency
 3. **Never resolve source-repo git problems silently** (diverged clone, dirty
    tree) — report and skip
-4. **The update touches the working tree** — leave the changes uncommitted for
-   the user to review
+4. **Land the update, don't just stage it** — by default commit the installer's
+   changes and land them on the default branch with a per-tool
+   `chore(tooling): update <tool> <old>→<new>` message. Stage **only** the paths
+   the installer actually changed — never fold a pre-existing dirty working tree
+   into the update commit. `--no-commit` / `--stage-only` restores the old
+   leave-it-uncommitted-for-review behavior.
+5. **Never push** — landing on the local default branch is reversible; pushing is
+   outward-facing and stays a separate, explicit action the user runs themselves.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,6 +29,26 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/skills/repo/hooks/session-start-handoff.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/skills/repo/hooks/session-start-handoff.sh"
+          }
+        ]
+      }
     ]
   },
   "permissions": {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,10 @@
           },
           {
             "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.loom/hooks/guard-destructive-generic.sh"
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PROJECT_DIR}/.loom/hooks/guard-loom-workflow.sh"
           }
         ]

--- a/.claude/skills/repo/SKILL.md
+++ b/.claude/skills/repo/SKILL.md
@@ -14,7 +14,7 @@ each change; add `--ask` to review findings and confirm first. Anything
 irreversible — deleting a branch, worktree, stash, or untracked file — is never
 automatic: it takes an explicit opt-in and passes a permanent-loss check.
 Commands whose only action is consequential (`orphans`, `update-tools`,
-`followups`, `release`, `remote`) always confirm first by nature. The environment commands (`remote`) stand up
+`followups`, `release`, `remote`, `sudo`) always confirm first by nature. The environment commands (`remote`) stand up
 infrastructure only after showing exactly what they will create and what it
 costs.
 
@@ -26,9 +26,12 @@ costs.
 | [[all]] | The whole hygiene pass in order — audit, docs, tidy, update-tools, reset — safe fixes by default, destructive steps gated |
 | [[audit]] | Full sweep — runs all hygiene checks, produces a summary report |
 | [[reset]] | Back to baseline — review stale worktrees/branches/stashes, sync with remote, return to the default branch |
+| [[handoff]] | Roll the session safely — file follow-ups, reset, check for a CLI update, write a handoff note the next session reads first |
 | [[tidy]] | Tidy up — build artifacts, caches, temp files, empty dirs |
-| [[release]] | Cut a release — pre-flight, semver decision, CHANGELOG, version bump, tag, GitHub Release |
-| [[remote]] | Launch a cloud dev session (GCP or AWS) with this repo ready to go, then open SSH |
+| [[release]] | Cut a release — pre-flight, semver decision, CHANGELOG, version bump, tag, GitHub Release. Supports per-project release policy via named phase-boundary seams in `.repo/release-policy.md` |
+| [[host-optimize]] | Prepare a Mac (or Linux box) for heavy Loom/agent build use — audit Gatekeeper churn, backup-agent interference, build-tree bloat; apply safe fixes, gate consequential ones |
+| [[remote]] | Launch a cloud dev session (GCP or AWS) with this repo ready to go, then open SSH. Its provisioning contract is implemented once in `scripts/repo/repo-remote.sh` (installed to `.claude/skills/repo/scripts/`); the interactive flow delegates to that script, which also serves as a headless `repo-remote up --yes --json` entry point for non-interactive callers (e.g. loom's `fleet add-worker`) |
+| [[sudo]] | Opt-in passwordless-sudo setup for a dev machine — install a `visudo`-validated `/etc/sudoers.d` drop-in (blanket `ALL` or a scoped command list) so an agent over SSH isn't blocked on password prompts; always confirmed first, validated with rollback on failure |
 | [[update-tools]] | Check installed tool packages (Loom, Anvil, …) against their sources and offer updates |
 | [[followups]] | Capture follow-on work from this session and file it as issues — here or in upstream tool repos, always confirmed first |
 | [[branches]] | Branch & worktree hygiene — merged PRs, orphaned branches, stale worktrees |
@@ -45,6 +48,8 @@ costs.
 - When the working tree feels messy (`tidy`, `orphans`)
 - When `git branch` output has grown unmanageable (`branches`)
 - When local hardware isn't enough or you need a clean Linux box (`remote`)
+- Before turning a Mac into a heavy Loom/agent build host (`host-optimize`)
+- To unblock an agent driving a dev box over SSH from `sudo` password prompts (`sudo`)
 - Periodically, to keep installed tool packages current (`update-tools`)
 - Periodically (monthly) as general hygiene (`audit`)
 - Before a demo, handoff, or onboarding (clean up before they arrive)
@@ -70,41 +75,93 @@ costs.
 
 Installing Repo Skills also wires a **PreToolUse safety hook** —
 `.claude/skills/repo/hooks/guard-destructive.sh` — into the consumer repo's
-`.claude/settings.json`. It runs before every agent `Bash` command and:
+`.claude/settings.json`. This is the **canonical generic destructive-command
+guard** (rjwalters/repo#30): Loom and other tooling defer to this copy instead
+of shipping their own. It runs before every agent `Bash` command and:
 
 - **Blocks** catastrophic operations outright: `rm -rf` of root / `$HOME` / a
-  top-level system dir, force-push to `main`/`master`, fork bombs,
-  `curl … | sh`, `gh repo delete`/`archive`, `docker system prune`, cloud
-  destruction (`aws iam delete`, `aws s3 rb`, `aws cloudformation delete-stack`,
-  `az … delete`, `gcloud … delete`, `aws ec2 terminate`), system-lifecycle
-  commands (`halt`/`reboot`/`poweroff`/`shutdown`/`init 0|6`), and SQL DDL/DML
-  (`DROP TABLE`, `TRUNCATE TABLE`, `DELETE FROM …` without a `WHERE`).
-- **Asks** for confirmation on reversible-but-risky ones: `git reset --hard`,
-  `git clean -fd`, `git push --force` (non-main), `kubectl delete`, `docker rm`,
-  `gh pr/issue close`, credential reads (`cat ~/.ssh/…`), etc.
-- **Allows** everything else — including scoped deletes like `rm -rf /tmp/foo`
-  and `rm -rf node_modules`.
+  top-level system dir (with lexical `..`/`//` normalization so traversal
+  can't smuggle one past), `rm` targets outside the repo/temp scope (see
+  `rmScope` below), force-push to `main`/`master`, fork bombs, piping a
+  download to a shell (`curl … | sh` — only when the pipe target *is* a
+  shell), `gh repo delete`/`archive`, `docker system prune`, cloud destruction
+  (`aws iam delete`, `aws s3 rb`, `aws cloudformation delete-stack`,
+  `az … delete`, `gcloud … delete`), system-lifecycle commands
+  (`halt`/`reboot`/`poweroff`/`shutdown`/`init 0|6`, command-word matched so
+  prose never trips), and SQL DDL/DML (`DROP TABLE`, `TRUNCATE TABLE`,
+  `DELETE FROM …` without a `WHERE`).
+- **Asks** for confirmation on risky-but-legitimate ones: force ops
+  (`git push --force` / `git reset --hard`, branch-aware via `forceScope`),
+  `git clean -fd`, un-isolated `git read-tree`, mutating cloud verbs
+  (`aws ec2 run|terminate|stop-…`, `aws s3 cp|rm|sync`, `docker rm|stop|…` —
+  read-only `describe*`/`ls`/`get*` never prompt), `kubectl delete`,
+  `gh release delete`, credential reads (`cat ~/.ssh/…`), etc.
+- **Allows** everything else — scoped deletes like `rm -rf node_modules` or
+  `/tmp` subpaths, and obviously read-only commands (`git status`, `ls`,
+  `grep`, …) via a structural fast path that skips the pattern gauntlet.
+
+Precision features ported from Loom's guard: quote-aware command segmentation
+(a `|` inside quotes is not a pipe), literal-text redaction (a dangerous phrase
+quoted in `--body`/`-m`/`--title`/`--notes`/`--comment` values doesn't trip the
+scan — command substitution inside such a value still does), comment stripping,
+and an opt-in JSONL decision-telemetry log for measuring guard friction.
 
 The hook only fires when Claude Code runs with `--dangerously-skip-permissions`
 (it is skipped entirely under `--permission-mode bypassPermissions`).
 
-### Opting out per repo
+### Configuring per repo
 
-Two guard categories can be turned off for repos where they are a category
-error (a database engine, or a repo whose job is managing cloud/containers).
-Resolution order, highest precedence first:
+All toggles resolve: `REPO_*` env var (wins) → legacy `LOOM_*` env var →
+`guards.<key>` in `.claude/skills/repo/config.json` (wins) → legacy
+`.loom/config.json` → default. On/off values: `0`/`false`/`no` and
+`1`/`true`/`yes`.
 
-| Category | Env var (wins) | Legacy env var | Config key |
-|----------|----------------|----------------|------------|
-| SQL DDL/DML | `REPO_GUARD_SQL` | `LOOM_GUARD_SQL` | `guards.sqlDdl` |
-| Cloud CLI | `REPO_GUARD_CLOUD` | `LOOM_GUARD_CLOUD` | `guards.cloudCli` |
+| Toggle | Env var (wins) | Legacy env var | Config key | Default |
+|--------|----------------|----------------|------------|---------|
+| Read-only fast path | `REPO_GUARD_READONLY_FASTPATH` | `LOOM_GUARD_READONLY_FASTPATH` | `guards.readOnlyFastPath` (+ extend-only `guards.readOnlyFastPathExtra`) | on |
+| SQL DDL/DML | `REPO_GUARD_SQL` | `LOOM_GUARD_SQL` | `guards.sqlDdl` | on |
+| Cloud CLI (mutating-verb asks + `az`/`gcloud` delete denies) | `REPO_GUARD_CLOUD` | `LOOM_GUARD_CLOUD` | `guards.cloudCli` | on |
+| Reversible-GitHub asks (`gh pr/issue close`, `gh label delete`) | `REPO_GUARD_REVERSIBLE_GH` | `LOOM_GUARD_REVERSIBLE_GH` | `guards.reversibleGh` | **off** (opt-in) |
+| rm scope (`repo` denies outside-repo/temp targets; `off`/`permissive` restores legacy) | `REPO_RM_SCOPE` | `LOOM_RM_SCOPE` | `guards.rmScope` | `repo` |
+| Force-op branch scope (`all` / `protected` / `off`) | `REPO_FORCE_SCOPE` | `LOOM_FORCE_SCOPE` | `guards.forceScope` | `all` |
+| Decision telemetry log | `REPO_GUARD_DECISION_LOG` (path: `REPO_GUARD_DECISION_LOG_FILE`) | `LOOM_GUARD_DECISION_LOG` (`…_FILE`) | `guards.decisionLog` | **off** (opt-in) |
 
-Env values `0`/`false`/`no` disable; `1`/`true`/`yes` force on. The config key
-is read from `.claude/skills/repo/config.json` (Repo Skills' own location),
-falling back to the legacy `.loom/config.json` for repos migrating off Loom's
-guard. Only an explicit `false` disables — a missing key keeps the guard on.
+For the on-by-default guards only an explicit `false` disables — a missing key
+or malformed config keeps the guard on; the opt-in toggles are the inverse.
 
 ```json
 // .claude/skills/repo/config.json
-{ "guards": { "sqlDdl": false, "cloudCli": true } }
+{ "guards": { "sqlDdl": false, "cloudCli": true, "forceScope": "protected" } }
 ```
+
+The full stable interface (input/output contract, exit semantics, every env
+name) is documented in the hook's own header — downstream tools (e.g. Loom's
+installer) gate on it via this repo's release version.
+
+## Handoff-note hook (SessionStart)
+
+The installer wires a second hook, `session-start-handoff.sh`, as two
+`SessionStart` entries — one matching `startup`, one matching `resume`. When
+[[handoff]] has left a note at `.claude/handoff.md`, the hook emits it as
+session context via `hookSpecificOutput.additionalContext`: the note's path,
+its age, a staleness warning once the note passes seven days, and the note
+itself. When the note is at or under a size cap (`MAX_BODY_BYTES`, 10 KB) the
+**full body is inlined**; above the cap it falls back to an outline built from
+the note's `#`/`##` headers plus an explicit oversize warning. Inlining the body
+is deliberate (issue #33): the load-bearing content lives in the body, and a
+headers-only summary conveys shape but nothing actionable.
+
+Behavioral contract:
+
+- **Read-only.** It never writes, deletes, or modifies the note. Absorbing the
+  note and deleting it is [[handoff]]'s own one-shot contract.
+- **Silent when there is nothing to say.** No note, or an unreadable one, means
+  no output and exit 0.
+- **Fails open.** Malformed stdin, a missing `cwd`, or any internal error exits
+  0 with no output. A hook fault must never block session start.
+- **Skips `/clear`.** `clear` is not a process relaunch, so re-emitting the
+  banner there would be noise.
+
+There are no configuration toggles — the hook's behavior is fixed. To disable
+it, remove its `SessionStart` entries from `.claude/settings.json` (or run
+`uninstall.sh`, which removes only the entries it owns).

--- a/.claude/skills/repo/hooks/guard-destructive.sh
+++ b/.claude/skills/repo/hooks/guard-destructive.sh
@@ -1,13 +1,60 @@
 #!/usr/bin/env bash
 # guard-destructive.sh - PreToolUse hook to block destructive agent commands
 #
-# Part of Repo Skills (https://github.com/rjwalters/repo). Generic repository
-# hygiene: this hook is a Claude Code PreToolUse hook that intercepts Bash
-# commands before execution and blocks / asks on catastrophic operations. It is
-# installed by install.sh into .claude/skills/repo/hooks/ and wired into the
-# consumer repo's .claude/settings.json PreToolUse -> Bash matcher.
+# Part of Repo Skills (https://github.com/rjwalters/repo), and the CANONICAL
+# generic destructive-command guard (rjwalters/repo#30): Loom and other tooling
+# defer to this copy rather than shipping their own. It is installed by
+# install.sh into .claude/skills/repo/hooks/ and wired into the consumer repo's
+# .claude/settings.json PreToolUse -> Bash matcher.
 #
-# Receives JSON on stdin with tool_input.command and cwd fields.
+# Provenance: the precision work in this file (segment parsing, quote-aware
+# splitting, literal-text redaction, the read-only fast path, toggles, decision
+# telemetry) was developed in rjwalters/loom and consolidated here. Bare issue
+# refs like (#3553)/(#3771) refer to rjwalters/loom issues; refs written
+# repo#NN refer to rjwalters/repo.
+#
+# =============================================================================
+# STABLE INTERFACE (the contract downstream tools — e.g. Loom — rely on)
+# =============================================================================
+#
+# Input:  JSON on stdin with .tool_input.command and .cwd (Claude Code
+#         PreToolUse hook payload). An empty/absent command allows.
+# Output: silence + exit 0  => allow;  otherwise a single JSON object:
+#   { "hookSpecificOutput": { "hookEventName": "PreToolUse",
+#       "permissionDecision": "deny|ask", "permissionDecisionReason": "..." } }
+# Exit:   ALWAYS 0, even on deny/ask/internal error. The "hookEventName" field
+#         is REQUIRED by Claude Code's schema — without it the decision is
+#         silently discarded and the guard becomes inert.
+# Errors: this script MUST never exit non-zero or emit invalid output. Any
+#         internal error is caught by the ERR trap, logged to
+#         <script-dir>/../logs/hook-errors.log, and resolves to allow (fail
+#         open) to prevent infinite retry loops in Claude Code.
+#
+# Config: guards.* keys are read from BOTH config locations —
+#           .claude/skills/repo/config.json   (Repo Skills' own; WINS)
+#           .loom/config.json                 (legacy/Loom; fallback)
+#         Env vars override config; the REPO_* name wins over the legacy
+#         LOOM_* name. Both names are a stable part of this interface.
+#
+#   Toggle (config key)          REPO_* env                     legacy LOOM_* env              default
+#   guards.readOnlyFastPath      REPO_GUARD_READONLY_FASTPATH   LOOM_GUARD_READONLY_FASTPATH   on
+#   guards.readOnlyFastPathExtra (config-only extend list)      —                              []
+#   guards.sqlDdl                REPO_GUARD_SQL                 LOOM_GUARD_SQL                 on
+#   guards.cloudCli              REPO_GUARD_CLOUD               LOOM_GUARD_CLOUD               on
+#   guards.reversibleGh          REPO_GUARD_REVERSIBLE_GH       LOOM_GUARD_REVERSIBLE_GH       off (opt-in)
+#   guards.decisionLog           REPO_GUARD_DECISION_LOG        LOOM_GUARD_DECISION_LOG        off (opt-in)
+#   (decision log path)          REPO_GUARD_DECISION_LOG_FILE   LOOM_GUARD_DECISION_LOG_FILE   <script-dir>/../logs/guard-decisions.log
+#   guards.rmScope               REPO_RM_SCOPE                  LOOM_RM_SCOPE                  repo
+#   guards.forceScope            REPO_FORCE_SCOPE               LOOM_FORCE_SCOPE               all
+#   (default-branch seam)        REPO_DEFAULT_BRANCH            LOOM_DEFAULT_BRANCH            resolved from git
+#   worktree.root (config key)   —                              LOOM_WORKTREE_ROOT             <repo>/.loom/worktrees
+#
+# On/off toggles accept 0/false/no and 1/true/yes. rmScope accepts
+# repo|off|permissive; forceScope accepts all|protected|off. Loom-compat
+# surfaces (the .loom/config.json fallback, LOOM_* env names, and the
+# .loom/worktrees rm allowlist) are permanent parts of this contract, not
+# transitional shims — Loom installs no generic guard of its own.
+# =============================================================================
 #
 # IMPORTANT: This hook only fires when Claude Code is invoked with:
 #   --dangerously-skip-permissions  <- hooks FIRE
@@ -23,30 +70,19 @@
 #   - Block (deny): Dangerous commands that should never run
 #   - Ask: Commands that need human confirmation
 #   - Allow: Everything else (exit 0, no output)
-#
-# Output format (Claude Code hooks spec):
-#   { "hookSpecificOutput": { "hookEventName": "PreToolUse", "permissionDecision": "deny|ask", "permissionDecisionReason": "..." } }
-#
-# NOTE: The "hookEventName": "PreToolUse" field is REQUIRED by Claude Code's
-# PreToolUse hook schema. Without it, Claude Code silently discards the
-# decision and the guard becomes inert.
-#
-# Toggles (see the SQL / cloud guard sections below):
-#   - SQL DDL/DML guard:  REPO_GUARD_SQL   env, or guards.sqlDdl   config key
-#   - Cloud-CLI guard:    REPO_GUARD_CLOUD env, or guards.cloudCli config key
-#   Config is read from .claude/skills/repo/config.json (Repo Skills' own
-#   location). For back-compat with repos that previously ran Loom's guard, the
-#   legacy LOOM_GUARD_SQL / LOOM_GUARD_CLOUD env vars and .loom/config.json are
-#   accepted as lower-precedence fallbacks.
-#
-# Error handling: This script MUST never exit with a non-zero code or produce
-# invalid output. Any internal error is caught by the trap, logged for
-# diagnostics, and results in an "allow" decision to prevent infinite retry
-# loops in Claude Code.
 
 # Determine log directory relative to this script's location
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null || echo ".")"
 HOOK_ERROR_LOG="${SCRIPT_DIR}/../logs/hook-errors.log"
+
+# Decision telemetry log (issue #3771) — a SEPARATE JSONL file from
+# HOOK_ERROR_LOG. At runtime SCRIPT_DIR is the installed hook's own directory
+# (.claude/skills/repo/hooks/), so this resolves to
+# .claude/skills/repo/logs/guard-decisions.log in a real install.
+# REPO_GUARD_DECISION_LOG_FILE (or the legacy LOOM_ name) overrides the path (a
+# test seam; also lets an operator point the log elsewhere). Off by default —
+# see decision_log_enabled() below.
+DECISION_LOG="${REPO_GUARD_DECISION_LOG_FILE:-${LOOM_GUARD_DECISION_LOG_FILE:-${SCRIPT_DIR}/../logs/guard-decisions.log}}"
 
 # Log a diagnostic error message (best-effort, never fails the script)
 log_hook_error() {
@@ -54,6 +90,71 @@ log_hook_error() {
     # Ensure log directory exists
     mkdir -p "$(dirname "$HOOK_ERROR_LOG")" 2>/dev/null || true
     echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] [guard-destructive] $msg" >> "$HOOK_ERROR_LOG" 2>/dev/null || true
+}
+
+# =============================================================================
+# DECISION TELEMETRY (issue #3771) — one JSONL record per deny/ask decision.
+#
+# Append a machine-readable record to DECISION_LOG each time the guard denies or
+# asks, so false-positive friction becomes measurable (which patterns fire, how
+# often, before/after a precision fix). Deliberately does NOT log `allow`: the
+# #3687 read-only fast path's zero-overhead silent-allow must stay silent, and
+# allow-logging would swamp the log with the ~99% common case.
+#
+# STABLE SCHEMA (the contract #3772's reader/aggregation tooling stacks on — do
+# NOT rename fields without considering that dependency), one JSON object per
+# line:
+#   {"ts":"<UTC>","decision":"deny"|"ask","pattern":"<tag>",
+#    "tier":"catastrophic"|"ask","command":"<redacted>"}
+#     ts       — UTC timestamp, same format as log_hook_error's date -u call.
+#     decision — "deny" or "ask".
+#     pattern  — a short, stable rule tag (NOT the full free-text reason). For
+#                the pattern-array loops it is the matched pattern; the non-loop
+#                sites pass a static tag (e.g. "sql-ddl", "rm-protected-path").
+#     tier     — "catastrophic" for deny, "ask" for ask.
+#     command  — the command string, REDACTED via strip_literal_text() so no raw
+#                --body/-m/--title/--notes/--comment secret value is persisted.
+#
+# Best-effort like log_hook_error: gated by the lazy decision_log_enabled()
+# toggle, and a log-write failure (permission denied, disk full, missing dir)
+# NEVER changes the deny/ask decision and NEVER causes a non-zero exit. Callers
+# invoke it as `log_guard_decision ... || true` so it can never trip the ERR
+# trap.
+#
+# One-liner to summarize fires by pattern (AC — full tooling is #3772):
+#   jq -r '.pattern' .claude/skills/repo/logs/guard-decisions.log | sort | uniq -c | sort -rn
+# =============================================================================
+log_guard_decision() {
+    # Args: <decision> <tier> <pattern-tag>. The command is read from the global
+    # $COMMAND and redacted here. Returns 0 unconditionally.
+    decision_log_enabled || return 0
+    local decision="$1" tier="$2" tag="${3:-$1}"
+    local ts redacted line
+    ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null) || ts=""
+    # Redact quoted --body/-m/--title/--notes/--comment values (same redactor the
+    # pattern-matching tiers use) so no raw secret text is persisted to a log that
+    # aggregates across sessions. Fall back to raw only if redaction produced
+    # nothing (awk unavailable) — impossible in practice since jq is required and
+    # awk is used throughout.
+    redacted=$(strip_literal_text "$COMMAND" 2>/dev/null) || redacted=""
+    [[ -n "$redacted" ]] || redacted="$COMMAND"
+    # Build the JSONL record with jq so all escaping is correct. If jq fails,
+    # skip the write entirely rather than hand-roll a line that might mis-escape.
+    line=$(jq -cn \
+        --arg ts "$ts" \
+        --arg decision "$decision" \
+        --arg pattern "$tag" \
+        --arg tier "$tier" \
+        --arg command "$redacted" \
+        '{ts:$ts, decision:$decision, pattern:$pattern, tier:$tier, command:$command}' \
+        2>/dev/null) || return 0
+    [[ -n "$line" ]] || return 0
+    mkdir -p "$(dirname "$DECISION_LOG")" 2>/dev/null || true
+    # Group the append so a FAILED >> redirection (unwritable/nonexistent dir)
+    # has its bash-level error caught by the group's stderr redirect too — a bare
+    # `>> "$f" 2>/dev/null` does not suppress the redirection-open error itself.
+    { printf '%s\n' "$line" >> "$DECISION_LOG"; } 2>/dev/null || true
+    return 0
 }
 
 # Top-level error trap: on ANY unexpected error, output valid JSON "allow"
@@ -78,6 +179,245 @@ if [[ -z "$COMMAND" ]]; then
     exit 0
 fi
 
+# =============================================================================
+# READ-ONLY FAST PATH (issue #3687) — default ON.
+#
+# guard-destructive.sh is a PreToolUse/Bash hook, so it fires before EVERY Bash
+# tool call. In Bash-dense sessions (remote ops, benchmark drivers) the vast
+# majority of those calls are obviously read-only — `git status`, `ls`, `grep`,
+# `aws … describe*`, `gh … list` — yet each one still runs the full deny/ask
+# gauntlet (~37 grep/awk/sed forks + a git rev-parse, ~179ms measured). This
+# block short-circuits that overwhelmingly-common case to a silent `allow` with
+# a single bash-builtin structural test (zero forks) plus, only when that test
+# passes, one lazy `jq` config read.
+#
+# SECURITY: a fast path is a guard bypass by construction, so admission is
+# purely STRUCTURAL and conservative — never content-sensitive:
+#   1. Reject fast-path eligibility if the raw command contains ANY of
+#      ;  &  |  <  >  backtick  $(  or a newline. This kills chaining, piping,
+#      redirection, and command substitution (so `git status && <force-push>`,
+#      `git status; rm -rf /`, `git status $(rm -rf /)`, `git status > /etc/x`
+#      all fall through to the full path unchanged).
+#   2. Exact first-token (command-word) allowlist — never a wrapper. Because the
+#      allowlist is keyed on the literal first token, wrapper forms (`bash -c`,
+#      `sh -c`, `eval`, `xargs`, `env … git status`, `sudo git status`) are
+#      excluded automatically: their first token isn't allowlisted.
+#   3. Verb/subcommand exactness for multi-word tools, chosen to be provably
+#      disjoint from every existing deny/ask pattern:
+#        git status|log|diff|show  (bare — `git -C /p status` is NOT admitted)
+#        ls  grep  rg
+#        jq  wc  head  tail        (pure read-only text/JSON filters — none has
+#          an in-place-mutation flag, so any args are admitted, #3772)
+#        test  [  [[               (boolean file/string test builtins — no
+#          mutation surface at all, #3772)
+#        find                      (admitted for any args EXCEPT when a dangerous
+#          action-primary is present: -delete, -exec, -execdir, -ok, -okdir,
+#          -fls, -fprint, -fprint0, -fprintf. Any of those disqualifies eligibility
+#          and falls through to the full path — structural, not content-scanned,
+#          so a future `find -delete` deny rule is never silently bypassed, #3772)
+#        gh <noun> view|list       (never delete/close/archive/…)
+#        aws <service> describe*|get*|list*  and  aws s3 ls   (mirrors the
+#          verb-anchoring already in CLOUD_ASK_PATTERNS: those verbs are never
+#          mutating, so this only skips greps that were going to allow anyway)
+#   cat and ssh are DELIBERATELY EXCLUDED from the built-in list:
+#     - cat has a narrow existing ASK carve-out (cat …/.ssh/, cat …/.aws/
+#       credentials); a blanket cat fast-path would silently skip it.
+#     - ssh wraps an OPAQUE remote command string that the raw ALWAYS_BLOCK scan
+#       still covers today; fast-pathing any `ssh …` would drop that coverage.
+#
+# False NEGATIVES (declining eligibility) are always safe — they just fall
+# through to the correct, slower existing behavior. False POSITIVES are the only
+# danger, so the eligibility test stays maximally conservative.
+#
+# CONFIG-ORDERING CHOICE: this block runs BEFORE REPO_ROOT is resolved (the git
+# rev-parse subprocess below), on purpose — the structural test never needs the
+# repo root. Only the toggle/extra-list config read needs a config file, and it
+# is resolved LAZILY (only after structural admission already passed) by walking
+# up from CWD to the nearest guard config (.claude/skills/repo/config.json or
+# legacy .loom/config.json) WITHOUT forking git
+# (fastpath_config_file). So a fast-pathed command pays: 1 bash-builtin test +
+# (only if eligible) 1 stat-walk + 1 jq read — never the git rev-parse, never a
+# deny/ask array, never a log write.
+#
+# Toggle: guards.readOnlyFastPath (default true) / LOOM_GUARD_READONLY_FASTPATH
+# env (0/false/no disables, 1/true/yes forces on; env wins). Optional
+# guards.readOnlyFastPathExtra is an EXTEND-ONLY array of literal first-word
+# commands (each entry is a full-generality bypass for that command word).
+# =============================================================================
+
+# Locate the nearest guard config by walking up from CWD, fork-free (no git
+# rev-parse). At each level Repo Skills' own config
+# (.claude/skills/repo/config.json) wins over the legacy .loom/config.json.
+# Cached. Best-effort: empty when none is found.
+_FASTPATH_CFG_FILE=""
+_FASTPATH_CFG_FILE_DONE=""
+fastpath_config_file() {
+    if [[ -z "$_FASTPATH_CFG_FILE_DONE" ]]; then
+        _FASTPATH_CFG_FILE_DONE=1
+        local d="$CWD"
+        if [[ -n "$d" && "$d" == /* ]]; then
+            while :; do
+                if [[ -f "$d/.claude/skills/repo/config.json" ]]; then
+                    _FASTPATH_CFG_FILE="$d/.claude/skills/repo/config.json"
+                    break
+                fi
+                if [[ -f "$d/.loom/config.json" ]]; then
+                    _FASTPATH_CFG_FILE="$d/.loom/config.json"
+                    break
+                fi
+                [[ "$d" == "/" ]] && break
+                local parent="${d%/*}"
+                [[ -z "$parent" ]] && parent="/"
+                d="$parent"
+            done
+        fi
+    fi
+    printf '%s' "$_FASTPATH_CFG_FILE"
+}
+
+# Resolve the fast-path toggle (config + env), cached. Default true. Only ever
+# called after structural admission has already passed, so the jq read stays off
+# the hot path for commands that don't structurally qualify.
+_FASTPATH_ENABLED_CACHE=""
+fastpath_enabled() {
+    if [[ -z "$_FASTPATH_ENABLED_CACHE" ]]; then
+        local enabled=true cfg
+        cfg=$(fastpath_config_file)
+        if [[ -n "$cfg" ]]; then
+            # Only an explicit `false` disables; a missing key or malformed JSON
+            # (jq non-zero, caught by ||) stays ON — mirrors sql_guard_enabled().
+            enabled=$(jq -r 'if .guards.readOnlyFastPath == false then "false" else "true" end' "$cfg" 2>/dev/null) || enabled=true
+            [[ -n "$enabled" ]] || enabled=true
+        fi
+        # Env override wins over config; REPO_* wins over the legacy LOOM_* name.
+        case "${LOOM_GUARD_READONLY_FASTPATH:-}" in
+            0|false|no)  enabled=false ;;
+            1|true|yes)  enabled=true ;;
+        esac
+        case "${REPO_GUARD_READONLY_FASTPATH:-}" in
+            0|false|no)  enabled=false ;;
+            1|true|yes)  enabled=true ;;
+        esac
+        _FASTPATH_ENABLED_CACHE="$enabled"
+    fi
+    [[ "$_FASTPATH_ENABLED_CACHE" == "true" ]]
+}
+
+# Shared structural pre-check: reject any chaining/piping/redirection/
+# substitution/newline. Pure bash builtins, zero forks.
+fastpath_structural_ok() {
+    case "$1" in
+        *';'*|*'&'*|*'|'*|*'<'*|*'>'*|*'`'*|*'$('*) return 1 ;;
+    esac
+    [[ "$1" == *$'\n'* ]] && return 1
+    return 0
+}
+
+# Built-in allowlist admission — bash-builtin regex/case only, zero forks.
+fastpath_builtin_admits() {
+    local cmd="$1"
+    fastpath_structural_ok "$cmd" || return 1
+    local -a t
+    read -ra t <<< "$cmd"
+    local n=${#t[@]}
+    (( n >= 1 )) || return 1
+    case "${t[0]}" in
+        ls|grep|rg)
+            return 0
+            ;;
+        jq|wc|head|tail)
+            # Pure read-only text/JSON filters. None writes files or takes an
+            # in-place-mutation flag (jq has no `-i`; wc/head/tail never mutate),
+            # so any arguments are admitted with no sub-form check.
+            return 0
+            ;;
+        test|'['|'[[')
+            # Boolean file/string test builtins — no mutation surface at all.
+            return 0
+            ;;
+        find)
+            # find is read-only UNLESS a dangerous action-primary is present.
+            # Structurally exclude the write/delete/exec primaries: if ANY token
+            # exactly matches one, decline eligibility (fall through to the full
+            # path). Pure bash-builtin string compares, zero forks.
+            local i
+            for (( i = 1; i < n; i++ )); do
+                case "${t[i]}" in
+                    -delete|-exec|-execdir|-ok|-okdir|-fls|-fprint|-fprint0|-fprintf)
+                        return 1
+                        ;;
+                esac
+            done
+            return 0
+            ;;
+        git)
+            (( n >= 2 )) || return 1
+            case "${t[1]}" in
+                status|log|diff|show) return 0 ;;
+            esac
+            return 1
+            ;;
+        gh)
+            (( n >= 3 )) || return 1
+            case "${t[2]}" in
+                view|list) return 0 ;;
+            esac
+            return 1
+            ;;
+        aws)
+            (( n >= 3 )) || return 1
+            [[ "${t[1]}" == "s3" && "${t[2]}" == "ls" ]] && return 0
+            case "${t[2]}" in
+                describe*|get*|list*) return 0 ;;
+            esac
+            return 1
+            ;;
+    esac
+    return 1
+}
+
+# Optional extend-only escape hatch: guards.readOnlyFastPathExtra is an array of
+# literal first-word commands. Read lazily (only when the built-in list did not
+# admit) and cached. Each entry is a full-generality bypass for that word.
+_FASTPATH_EXTRA_CACHE=""
+_FASTPATH_EXTRA_DONE=""
+fastpath_extra_admits() {
+    local cmd="$1"
+    fastpath_structural_ok "$cmd" || return 1
+    local -a t
+    read -ra t <<< "$cmd"
+    (( ${#t[@]} >= 1 )) || return 1
+    local first="${t[0]}"
+    if [[ -z "$_FASTPATH_EXTRA_DONE" ]]; then
+        _FASTPATH_EXTRA_DONE=1
+        local cfg
+        cfg=$(fastpath_config_file)
+        if [[ -n "$cfg" ]]; then
+            _FASTPATH_EXTRA_CACHE=$(jq -r '(.guards.readOnlyFastPathExtra // []) | .[]' "$cfg" 2>/dev/null) || _FASTPATH_EXTRA_CACHE=""
+        fi
+    fi
+    [[ -n "$_FASTPATH_EXTRA_CACHE" ]] || return 1
+    local w
+    while IFS= read -r w; do
+        [[ -n "$w" && "$first" == "$w" ]] && return 0
+    done <<< "$_FASTPATH_EXTRA_CACHE"
+    return 1
+}
+
+# Fast-path dispatch. The env fast-disable check is first so a fully-disabled
+# feature stays entirely off the hot path (no structural test, no config read).
+# REPO_* wins over the legacy LOOM_* name (fastpath_enabled applies the same
+# precedence for the enable direction).
+_fastpath_env="${REPO_GUARD_READONLY_FASTPATH:-${LOOM_GUARD_READONLY_FASTPATH:-}}"
+if [[ "$_fastpath_env" != "0" && "$_fastpath_env" != "false" && "$_fastpath_env" != "no" ]]; then
+    if fastpath_builtin_admits "$COMMAND"; then
+        # Silent allow: no stdout/stderr, no log_hook_error, before REPO_ROOT.
+        fastpath_enabled && exit 0
+    elif fastpath_extra_admits "$COMMAND"; then
+        fastpath_enabled && exit 0
+    fi
+fi
+
 # Resolve repo root from cwd (handles worktree paths safely)
 REPO_ROOT=""
 if [[ -n "$CWD" ]] && [[ -d "$CWD" ]]; then
@@ -88,52 +428,28 @@ elif [[ -n "$CWD" ]]; then
 fi
 
 # =============================================================================
-# Config toggle resolution helper.
+# Shared config reader for the guards.* toggles below.
 #
-# read_guard_toggle <config-key> <REPO_env_value> <LOOM_env_value>
-#   Echoes "true" or "false". Resolution order (highest precedence first):
-#     1. REPO_GUARD_* env var  (Repo Skills' own name)
-#     2. LOOM_GUARD_*  env var  (legacy back-compat)
-#     3. .claude/skills/repo/config.json  -> guards.<key>  (Repo Skills' location)
-#     4. .loom/config.json                -> guards.<key>  (legacy back-compat)
-#     5. Default: true (guard on)
-#
-# Env values 0/false/no disable; 1/true/yes force on. Only an explicit `false`
-# in a config file disables (a missing key stays on). Every read is best-effort:
-# any parse failure falls through to guard-ON and never trips the ERR trap.
+# guard_cfg <key> — echo the raw value of .guards.<key> (via jq tostring, so
+# booleans arrive as "true"/"false" and strings as their bare text), or "unset"
+# when the key is absent, the file is missing/malformed, or there is no repo
+# root. Repo Skills' own config (.claude/skills/repo/config.json) WINS over the
+# legacy Loom location (.loom/config.json). Best-effort: any jq failure reads
+# as unset and never trips the ERR trap; each caller applies its own default
+# and polarity, so a malformed config always falls through to that caller's
+# safe default.
 # =============================================================================
-read_guard_toggle() {
-    local key="$1" repo_env="$2" loom_env="$3"
-    local enabled=true
-    local cfg
-
-    # Config files (lowest precedence first, so later reads override earlier).
-    for cfg in "$REPO_ROOT/.loom/config.json" "$REPO_ROOT/.claude/skills/repo/config.json"; do
-        if [[ -n "$REPO_ROOT" && -f "$cfg" ]]; then
-            # jq // is alternative-on-null, not default-on-missing, so use
-            # if/then/else to treat only an explicit `false` as disabled (a
-            # missing key stays on). On malformed JSON jq exits non-zero and the
-            # `||` fallback preserves the current value.
-            local val
-            val=$(jq -r --arg k "$key" 'if .guards[$k] == false then "false" elif .guards[$k] == true then "true" else "unset" end' "$cfg" 2>/dev/null) || val="unset"
-            case "$val" in
-                false) enabled=false ;;
-                true)  enabled=true ;;
-            esac
+guard_cfg() {
+    local key="$1" cfg val
+    for cfg in "$REPO_ROOT/.claude/skills/repo/config.json" "$REPO_ROOT/.loom/config.json"; do
+        [[ -n "$REPO_ROOT" && -f "$cfg" ]] || continue
+        val=$(jq -r --arg k "$key" '((.guards? // {}) | if has($k) then (.[$k] | tostring) else "unset" end)' "$cfg" 2>/dev/null) || val="unset"
+        if [[ -n "$val" && "$val" != "unset" ]]; then
+            printf '%s' "$val"
+            return 0
         fi
     done
-
-    # Env overrides win over config; REPO name wins over the legacy LOOM name.
-    case "$loom_env" in
-        0|false|no)  enabled=false ;;
-        1|true|yes)  enabled=true ;;
-    esac
-    case "$repo_env" in
-        0|false|no)  enabled=false ;;
-        1|true|yes)  enabled=true ;;
-    esac
-
-    echo "$enabled"
+    printf 'unset'
 }
 
 # =============================================================================
@@ -144,40 +460,875 @@ read_guard_toggle() {
 # database engines, where those statements are the product's own dev/test
 # vocabulary. Such repos opt out; everyone else keeps the guard on.
 #
-# Resolution runs LAZILY — sql_guard_enabled() is only invoked once a command
-# has already matched a SQL DDL/DML pattern, so the config read never touches
-# the hot path for the ~99% of commands that are not SQL. The result is cached
-# so a command matching multiple SQL patterns pays for at most one read.
+# Resolution order (highest precedence first):
+#   1. REPO_GUARD_SQL env var, then legacy LOOM_GUARD_SQL
+#      (0/false/no disables, 1/true/yes forces on)
+#   2. guards.sqlDdl via guard_cfg() — repo config wins over legacy .loom
+#      (default true when absent)
+#   3. Default: true (guard on)
+#
+# The resolution runs LAZILY — sql_guard_enabled() is only invoked once a
+# command has already matched a SQL DDL/DML pattern, so the jq config read never
+# touches the hot path for the ~99% of commands that are not SQL. The result is
+# cached so a command matching multiple SQL patterns pays for at most one read.
+#
+# The config read is best-effort: any parse failure falls through to guard-ON
+# and never trips the ERR trap or produces a non-zero exit.
 # =============================================================================
 _SQL_GUARD_CACHE=""
 sql_guard_enabled() {
     if [[ -z "$_SQL_GUARD_CACHE" ]]; then
-        _SQL_GUARD_CACHE=$(read_guard_toggle sqlDdl "${REPO_GUARD_SQL:-}" "${LOOM_GUARD_SQL:-}")
+        local enabled=true
+        # Only an explicit `false` disables (a missing guards.sqlDdl key or a
+        # malformed config reads as unset and stays on).
+        case "$(guard_cfg sqlDdl)" in
+            false) enabled=false ;;
+            true)  enabled=true ;;
+        esac
+        # Env override wins over config; REPO_* wins over the legacy LOOM_* name.
+        case "${LOOM_GUARD_SQL:-}" in
+            0|false|no)  enabled=false ;;
+            1|true|yes)  enabled=true ;;
+        esac
+        case "${REPO_GUARD_SQL:-}" in
+            0|false|no)  enabled=false ;;
+            1|true|yes)  enabled=true ;;
+        esac
+        _SQL_GUARD_CACHE="$enabled"
     fi
     [[ "$_SQL_GUARD_CACHE" == "true" ]]
 }
 
 # =============================================================================
-# Cloud-CLI guard toggle — default ON. Same mechanism as the SQL guard.
+# Cloud CLI guard toggle — default ON.
 #
-# Lets a repo whose job IS managing cloud/containers (e.g. a remote-dev
-# command that launches/stops/terminates EC2) opt down the broad aws/docker
-# ASK patterns and the `aws ec2 terminate` deny, which otherwise fire on every
-# read-only describe and make legitimate teardown unrunnable.
+# The cloud/docker ASK patterns (mutating aws ec2/lambda/s3/... subcommands and
+# docker rm/rmi/stop/kill/restart) prompt for confirmation on every match. For a
+# repo whose *purpose* is managing cloud infrastructure (launch/stop/terminate
+# dev VMs, build/tear-down containers), that friction is a category error — the
+# mutating calls are the product's own dev/test vocabulary. Such repos opt out;
+# everyone else keeps the guard on. The genuinely catastrophic aws/docker denies
+# in ALWAYS_BLOCK_PATTERNS are NOT gated by this toggle and stay active.
 #
-# Lazy + cached, mirroring sql_guard_enabled().
+# Resolution order (highest precedence first):
+#   1. REPO_GUARD_CLOUD env var, then legacy LOOM_GUARD_CLOUD
+#      (0/false/no disables, 1/true/yes forces on)
+#   2. guards.cloudCli via guard_cfg() — repo config wins over legacy .loom
+#      (default true when absent)
+#   3. Default: true (guard on)
+#
+# Mirrors sql_guard_enabled() exactly: cached in _CLOUD_GUARD_CACHE, invoked
+# LAZILY only after a cloud pattern has already matched so the jq config read
+# never touches the hot path for non-cloud commands. The config read is
+# best-effort: any parse failure falls through to guard-ON.
 # =============================================================================
 _CLOUD_GUARD_CACHE=""
 cloud_guard_enabled() {
     if [[ -z "$_CLOUD_GUARD_CACHE" ]]; then
-        _CLOUD_GUARD_CACHE=$(read_guard_toggle cloudCli "${REPO_GUARD_CLOUD:-}" "${LOOM_GUARD_CLOUD:-}")
+        local enabled=true
+        # Only an explicit `false` disables (a missing key or malformed config
+        # reads as unset and stays on).
+        case "$(guard_cfg cloudCli)" in
+            false) enabled=false ;;
+            true)  enabled=true ;;
+        esac
+        # Env override wins over config; REPO_* wins over the legacy LOOM_* name.
+        case "${LOOM_GUARD_CLOUD:-}" in
+            0|false|no)  enabled=false ;;
+            1|true|yes)  enabled=true ;;
+        esac
+        case "${REPO_GUARD_CLOUD:-}" in
+            0|false|no)  enabled=false ;;
+            1|true|yes)  enabled=true ;;
+        esac
+        _CLOUD_GUARD_CACHE="$enabled"
     fi
     [[ "$_CLOUD_GUARD_CACHE" == "true" ]]
 }
 
+# =============================================================================
+# Reversible-GitHub ask toggle — default OFF (opt-IN; inverse polarity, #3757).
+#
+# `gh pr close`, `gh issue close`, and `gh label delete` change shared state but
+# are trivially reversible — `gh pr reopen`, `gh issue reopen`, and recreating a
+# label (a repo with labels.yml restores in one `gh label sync`). A guard whose
+# purpose is preventing irreversible loss should not add confirmation friction to
+# these: an autonomous agent that closes its own issue/PR as part of a normal
+# lifecycle would otherwise stall on a prompt (or, headless, block entirely). So
+# they are NO LONGER in the ungated ASK_PATTERNS array; a repo that still wants
+# the confirmation can opt IN here. The genuinely hard-to-reverse ops
+# (`gh release delete` — published artifacts/tags; `git clean -fd` / `git
+# checkout .` / `git restore .` — untracked/uncommitted loss) STAY in the ungated
+# ask tier and are unaffected by this toggle.
+#
+# This is the INVERSE polarity of sql_guard_enabled()/cloud_guard_enabled():
+# those default ON (guard active) and are opted OUT; this one defaults OFF (no
+# ask) and is opted IN — because enabling it ADDS friction rather than removing
+# it. So the default and the absent-key resolution are `false`, not `true`.
+#
+# Resolution order (highest precedence first):
+#   1. REPO_GUARD_REVERSIBLE_GH env var, then legacy LOOM_GUARD_REVERSIBLE_GH
+#      (1/true/yes enables the ask, 0/false/no forces it off)
+#   2. guards.reversibleGh via guard_cfg() — repo config wins over legacy .loom
+#      (default false when absent)
+#   3. Default: false (no ask)
+#
+# Mirrors cloud_guard_enabled()'s lazy/cached shape: cached in
+# _REVERSIBLE_GH_GUARD_CACHE, invoked LAZILY only after a reversible-gh pattern
+# has already matched so the jq config read never touches the hot path for the
+# common (non-matching) case. The config read is best-effort: any parse failure
+# falls through to guard-OFF (the default), never blocking.
+# =============================================================================
+_REVERSIBLE_GH_GUARD_CACHE=""
+reversible_gh_guard_enabled() {
+    if [[ -z "$_REVERSIBLE_GH_GUARD_CACHE" ]]; then
+        local enabled=false
+        # Only an explicit `true` enables (a missing guards.reversibleGh key or
+        # a malformed config reads as unset and stays off — inverse polarity).
+        case "$(guard_cfg reversibleGh)" in
+            true)  enabled=true ;;
+            false) enabled=false ;;
+        esac
+        # Env override wins over config; REPO_* wins over the legacy LOOM_* name.
+        case "${LOOM_GUARD_REVERSIBLE_GH:-}" in
+            0|false|no)  enabled=false ;;
+            1|true|yes)  enabled=true ;;
+        esac
+        case "${REPO_GUARD_REVERSIBLE_GH:-}" in
+            0|false|no)  enabled=false ;;
+            1|true|yes)  enabled=true ;;
+        esac
+        _REVERSIBLE_GH_GUARD_CACHE="$enabled"
+    fi
+    [[ "$_REVERSIBLE_GH_GUARD_CACHE" == "true" ]]
+}
+
+# =============================================================================
+# Decision-telemetry toggle — default OFF (opt-IN; inverse polarity, #3771).
+#
+# The deny/ask decision log (log_guard_decision() near the top of this file) is
+# OFF by default: it writes a new persistent, cross-session artifact of redacted
+# commands, so — mirroring the other opt-in data-collection features in Loom
+# (transcript archival #3726, the model-cost experiment #3725) — a zero-config
+# install sees NO new file and NO behaviour change. An operator enables it to
+# measure guard-hook friction.
+#
+# Same INVERSE polarity as reversible_gh_guard_enabled(): defaults false, the
+# absent-key resolution is false, and only an explicit `true` (config) or a
+# truthy env value enables it.
+#
+# Resolution order (highest precedence first):
+#   1. REPO_GUARD_DECISION_LOG env var, then legacy LOOM_GUARD_DECISION_LOG
+#      (1/true/yes/on enables; 0/false/no/off disables). Overrides config.
+#   2. guards.decisionLog via guard_cfg() — repo config wins over legacy .loom
+#      (default false when absent).
+#   3. Default: false (no decision log written).
+#
+# Resolved LAZILY and cached in _DECISION_LOG_CACHE, invoked only from inside
+# log_guard_decision() (i.e. only once a deny/ask is about to fire), exactly like
+# the other toggles — so the config read NEVER touches the hot path for the ~99%
+# of commands that neither deny nor ask, and in particular never runs on the
+# #3687 read-only fast path (which exits before any deny/ask). The config read is
+# best-effort: any parse failure falls through to guard-OFF (the default).
+# =============================================================================
+_DECISION_LOG_CACHE=""
+decision_log_enabled() {
+    if [[ -z "$_DECISION_LOG_CACHE" ]]; then
+        local enabled=false
+        # Only an explicit `true` enables; a missing key or malformed config
+        # reads as unset and stays OFF — inverse of sql_guard_enabled().
+        case "$(guard_cfg decisionLog)" in
+            true)  enabled=true ;;
+            false) enabled=false ;;
+        esac
+        # Env override wins over config; REPO_* wins over the legacy LOOM_* name.
+        case "${LOOM_GUARD_DECISION_LOG:-}" in
+            0|false|no|off)   enabled=false ;;
+            1|true|yes|on)    enabled=true ;;
+        esac
+        case "${REPO_GUARD_DECISION_LOG:-}" in
+            0|false|no|off)   enabled=false ;;
+            1|true|yes|on)    enabled=true ;;
+        esac
+        _DECISION_LOG_CACHE="$enabled"
+    fi
+    [[ "$_DECISION_LOG_CACHE" == "true" ]]
+}
+
+# =============================================================================
+# rm-scope repo mode toggle — default REPO (safe-by-default; opt out to off).
+#
+# As of issue #3628 (ADR Option B) this guard defaults to `repo` mode: it
+# DENIES any rm target that is neither under the repo / worktree areas nor on a
+# built-in ephemeral allowlist (system temp dirs + the Claude scratchpad), in
+# addition to the catastrophic top-level deny. A zero-config install therefore
+# gets outside-repo rm protection out of the box (e.g. `rm -rf
+# /Users/someone/important` is DENIED).
+#
+# The legacy permissive behaviour — block only catastrophic rm targets (root,
+# $HOME, bare top-level dirs) and ALLOW every deeper subpath including subpaths
+# OUTSIDE the repo — is now an explicit opt-out: guards.rmScope:"off" (or the
+# synonym "permissive") / LOOM_RM_SCOPE=off. Consumers who relied on the old
+# permissive default must set one of those to restore it.
+#
+# The catastrophic top-level deny stays unconditional in BOTH modes, so bare
+# /tmp and / are still blocked regardless of rmScope.
+#
+# Resolution order (highest precedence first):
+#   1. REPO_RM_SCOPE env var, then legacy LOOM_RM_SCOPE (repo enables;
+#      off/0/no/permissive disables). Overrides config. Absent → falls through
+#      to config/default.
+#   2. guards.rmScope via guard_cfg() — repo config wins over legacy .loom:
+#      "off"/"permissive" => off; absent key / any other value / malformed
+#      JSON => repo (the default).
+#   3. Default: repo (safe-by-default, current behaviour after #3628)
+#
+# Mirrors sql_guard_enabled() / cloud_guard_enabled(): cached in
+# _RM_SCOPE_CACHE, invoked LAZILY only after a candidate rm target survives the
+# catastrophic check, so the jq config read never touches the hot path for
+# non-rm commands. The config read is best-effort: any parse failure falls
+# through to REPO (the safe default) and never trips the ERR trap.
+# =============================================================================
+_RM_SCOPE_CACHE=""
+rm_scope_repo_enabled() {
+    if [[ -z "$_RM_SCOPE_CACHE" ]]; then
+        local mode=repo
+        # Only an explicit guards.rmScope of "off" or "permissive" opts out to
+        # the legacy permissive behaviour; any other value, a missing key, or a
+        # malformed config (reads as unset) resolves to "repo" (the safe
+        # default).
+        case "$(guard_cfg rmScope)" in
+            off|permissive) mode=off ;;
+        esac
+        # Env override wins over config; REPO_* wins over the legacy LOOM_* name.
+        case "${LOOM_RM_SCOPE:-}" in
+            repo)                  mode=repo ;;
+            off|0|no|permissive)   mode=off ;;
+        esac
+        case "${REPO_RM_SCOPE:-}" in
+            repo)                  mode=repo ;;
+            off|0|no|permissive)   mode=off ;;
+        esac
+        _RM_SCOPE_CACHE="$mode"
+    fi
+    [[ "$_RM_SCOPE_CACHE" == "repo" ]]
+}
+
+# Resolve the Loom worktree base dir for repo-scope checks. Mirrors the
+# precedence of loom_worktree_root() in defaults/scripts/lib/worktree-root.sh
+# (env -> config -> default), replicated inline so the hook stays
+# self-contained and best-effort: any failure falls back to the default in-repo
+# path and never fails the hook. Only called in repo mode, once per rm scan.
+resolve_worktree_root() {
+    local repo_root="$1"
+    [[ -z "$repo_root" ]] && return 0
+    # 1. Env override (highest priority); must be absolute. LOOM_WORKTREE_ROOT
+    #    is kept as the only env name — it is a Loom concept and part of the
+    #    Loom-compat contract.
+    if [[ -n "${LOOM_WORKTREE_ROOT:-}" && "$LOOM_WORKTREE_ROOT" == /* ]]; then
+        printf '%s/%s' "${LOOM_WORKTREE_ROOT%/}" "$(basename "$repo_root")"
+        return 0
+    fi
+    # 2. Config key worktree.root (absolute only), read from both config
+    #    locations — repo config wins over legacy .loom.
+    local config_file
+    for config_file in "$repo_root/.claude/skills/repo/config.json" "$repo_root/.loom/config.json"; do
+        [[ -f "$config_file" ]] || continue
+        local cfg_root
+        cfg_root=$(jq -r '.worktree.root? // empty' "$config_file" 2>/dev/null) || cfg_root=""
+        if [[ -n "$cfg_root" && "$cfg_root" == /* ]]; then
+            printf '%s/%s' "${cfg_root%/}" "$(basename "$repo_root")"
+            return 0
+        fi
+    done
+    # 3. Default — in-repo worktrees dir.
+    printf '%s/.loom/worktrees' "$repo_root"
+}
+
+# =============================================================================
+# force-op branch-scope toggle — default ALL (preserve current behaviour).
+#
+# The three generic force-op ASK patterns (git push --force / -f /
+# --force-with-lease and git reset --hard) prompt on EVERY match regardless of
+# which branch is targeted. For an autonomous/background agent that cannot answer
+# an interactive prompt, that stalls the agent on routine own-branch rebase /
+# amend / reset work. The genuinely dangerous case is a force op against a
+# PROTECTED branch (the repo default plus main/master), which stays a hard deny
+# via ALWAYS_BLOCK_PATTERNS for the explicit main/master forms.
+#
+# guards.forceScope selects the behaviour:
+#   "all"       (default) — ask on every force op, exactly as before (#3674).
+#   "protected"           — ask only when the resolved target is a protected
+#                           branch (repo default / main / master) or the branch
+#                           identity is ambiguous (detached HEAD); allow force
+#                           ops on the agent's own working branches.
+#   "off"                 — never ask/deny on force ops. The unconditional
+#                           main/master hard-denies in ALWAYS_BLOCK_PATTERNS
+#                           STILL apply in every mode, including "off".
+#
+# Resolution order (highest precedence first):
+#   1. REPO_FORCE_SCOPE env var, then legacy LOOM_FORCE_SCOPE
+#      (all/protected/off). Overrides config.
+#   2. guards.forceScope via guard_cfg() — repo config wins over legacy .loom:
+#      "protected"/"off"; absent key / any other value / malformed JSON =>
+#      "all" (the current-behaviour default).
+#   3. Default: all (preserve current behaviour byte-for-byte)
+#
+# Mirrors sql_guard_enabled() / rm_scope_repo_enabled(): cached in
+# _FORCE_SCOPE_CACHE, invoked LAZILY only after a command plausibly carries a
+# force op, so the jq config read never touches the hot path for the ~99% of
+# commands that are not force ops. The config read is best-effort: any parse
+# failure falls through to "all" (the safe default) and never trips the ERR trap.
+# =============================================================================
+_FORCE_SCOPE_CACHE=""
+force_scope_mode() {
+    if [[ -z "$_FORCE_SCOPE_CACHE" ]]; then
+        local mode=all
+        # Only "protected"/"off" opt away from the default; a missing key, any
+        # other value, or a malformed config (reads as unset) resolves to "all".
+        case "$(guard_cfg forceScope)" in
+            protected) mode=protected ;;
+            off)       mode=off ;;
+        esac
+        # Env override wins over config; REPO_* wins over the legacy LOOM_* name.
+        case "${LOOM_FORCE_SCOPE:-}" in
+            all)         mode=all ;;
+            protected)   mode=protected ;;
+            off)         mode=off ;;
+        esac
+        case "${REPO_FORCE_SCOPE:-}" in
+            all)         mode=all ;;
+            protected)   mode=protected ;;
+            off)         mode=off ;;
+        esac
+        _FORCE_SCOPE_CACHE="$mode"
+    fi
+    printf '%s' "$_FORCE_SCOPE_CACHE"
+}
+
+# Resolve the repository's default branch name for the protected-branch set.
+# Inlined, offline-first detection mirroring loom_default_branch() in
+# defaults/scripts/lib/default-branch.sh, replicated here so the hook stays
+# self-contained (same rationale as resolve_worktree_root() mirroring
+# loom_worktree_root() rather than sourcing it). Deliberately OMITS the network
+# `git ls-remote` fallback — a PreToolUse hook must never touch the network — so
+# resolution is env-var / local-ref only; the main/master literals in the
+# protected set below cover the common case when local detection yields nothing.
+# Best-effort: echoes the branch name or nothing on failure. Only invoked in
+# "protected" mode after a force op has already matched.
+resolve_default_branch() {
+    local dir="$1"
+    # 1. Env var override — highest priority (escape hatch + test seam).
+    #    REPO_* wins over the legacy LOOM_* name.
+    if [[ -n "${REPO_DEFAULT_BRANCH:-}" ]]; then
+        printf '%s' "$REPO_DEFAULT_BRANCH"
+        return 0
+    fi
+    if [[ -n "${LOOM_DEFAULT_BRANCH:-}" ]]; then
+        printf '%s' "$LOOM_DEFAULT_BRANCH"
+        return 0
+    fi
+    [[ -z "$dir" ]] && return 0
+    # 2. Local symbolic ref for origin/HEAD — offline, no network.
+    local sref
+    sref=$(git -C "$dir" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)
+    if [[ -n "$sref" ]]; then
+        printf '%s' "${sref#origin/}"
+        return 0
+    fi
+    # 3. Local probe: prefer main, then master, whichever remote ref exists.
+    local candidate
+    for candidate in main master; do
+        if git -C "$dir" show-ref --verify --quiet "refs/remotes/origin/$candidate" 2>/dev/null; then
+            printf '%s' "$candidate"
+            return 0
+        fi
+    done
+    # 4. No local answer — echo nothing (caller's main/master literals cover it).
+    return 0
+}
+
+# =============================================================================
+# QUOTE-AWARE COMMAND SEGMENTATION (#3755)
+#
+# The three segment parsers below (parse_force_ops, lifecycle_or_cloud_reason,
+# extract_rm_targets) split a command string on the shell separators ; | & && ||
+# to find each simple command's command word. The historical split was a naive
+#   gsub(/&&|\|\||[;|&]/, "\n")
+# over the raw string, which has NO lexer — so a `|`-alternation INSIDE a quoted
+# argument (e.g. `grep -E "lifecycle|halt|poweroff"`) was split as if it were a
+# real pipe, manufacturing a phantom segment whose command word is the bare word
+# `halt` and hard-denying a completely read-only command.
+#
+# `qsplit()` replaces that gsub: it walks the string tracking single-/double-quote
+# state and emits a newline for a separator ONLY when it is OUTSIDE a quoted span.
+# A quoted span is treated as inert (its separators are preserved as literal
+# text) ONLY when it carries no command substitution — no `$(` and no backtick —
+# mirroring strip_literal_text()'s #3679 safety floor: a smuggled
+# `"$(a|halt)"` keeps its separators ACTIVE so the genuine protection is intact.
+# The token VALUES are preserved verbatim (unlike a redaction approach), so
+# extract_rm_targets still sees the real `rm` targets. Best-effort like
+# strip_literal_text(): backslash-escaped quotes and an unterminated quote fall
+# back to the old separator-active behaviour, never widening a deny into an allow.
+#
+# Shared as a single awk source string so the three parsers cannot drift.
+# =============================================================================
+_QSPLIT_AWK='
+function qsplit(s,   out, n, i, c, j, qc, ci, inner, SQ, DQ) {
+    SQ = sprintf("%c", 39)   # single quote
+    DQ = sprintf("%c", 34)   # double quote
+    out = ""
+    n = length(s)
+    i = 1
+    while (i <= n) {
+        c = substr(s, i, 1)
+        if (c == DQ || c == SQ) {
+            qc = c
+            ci = 0
+            for (j = i + 1; j <= n; j++) {
+                if (substr(s, j, 1) == qc) { ci = j; break }
+            }
+            if (ci == 0) {
+                # Unterminated quote: fall back to separator-active processing so
+                # a stray quote never suppresses a real split (never widen a deny).
+                out = out c
+                i++
+                continue
+            }
+            inner = substr(s, i + 1, ci - i - 1)
+            if (index(inner, "$(") == 0 && index(inner, "`") == 0) {
+                # Inert quoted span: copy verbatim, separators inside are literal.
+                out = out substr(s, i, ci - i + 1)
+                i = ci + 1
+                continue
+            }
+            # Span carries command substitution: keep separators ACTIVE (copy the
+            # opening quote and keep walking char-by-char so a `|` inside splits).
+            out = out c
+            i++
+            continue
+        }
+        if (c == ";") { out = out "\n"; i++; continue }
+        if (c == "&") {
+            if (i < n && substr(s, i + 1, 1) == "&") { out = out "\n"; i += 2; continue }
+            out = out "\n"; i++; continue
+        }
+        if (c == "|") {
+            if (i < n && substr(s, i + 1, 1) == "|") { out = out "\n"; i += 2; continue }
+            out = out "\n"; i++; continue
+        }
+        out = out c
+        i++
+    }
+    return out
+}
+'
+
+# =============================================================================
+# MULTI-LINE QUOTE-AWARE SEGMENTATION (#71)
+#
+# The three segment parsers (parse_force_ops, lifecycle_or_cloud_reason,
+# extract_rm_targets) originally segmented per awk INPUT RECORD with
+# `$0 = qsplit($0); split($0, segs, "\n")`. Because awk's default RS="\n" splits
+# a multi-line command into separate records BEFORE the pattern block runs,
+# qsplit()'s quote-tracking state — scoped to a single call — reset at every
+# embedded newline. An interior line of an otherwise-inert multi-line quoted
+# DATA literal (echo/printf/--body) was therefore lexed as its own top-level
+# segment with no memory that it is still inside an open quote from a prior line,
+# so a quoted `git push --force origin main` false-`ask`ed (parse_force_ops) and
+# a quoted `halt` false-`deny`ed (lifecycle_or_cloud_reason). PR #69 fixed the
+# identical defect in extract_rm_targets() with a whole-buffer slurp-then-segment
+# lexer; this shared helper generalizes that lexer so all three parsers segment
+# ONCE over the full command and cannot drift (the same rationale the _QSPLIT_AWK
+# header gives for sharing qsplit()).
+#
+# `ml_segment(buf, segs)` fills the caller's `segs[]` out-array (AWK passes arrays
+# by reference) with one entry per top-level segment and returns the count. It
+# deliberately does NOT reuse qsplit()+split("\n"): qsplit() emits a `\n` for each
+# REAL separator while ALSO leaving a literal newline that lived inside an inert
+# quoted span untouched, so the two become indistinguishable to a downstream
+# `split(s, segs, "\n")`. Segmentation is therefore done inline here, so an inert
+# quoted span's embedded newlines never become segment boundaries.
+#
+# Segmentation contract (identical to qsplit()'s single-line behaviour, now
+# correctly carried ACROSS embedded newlines):
+#   - Separators `;` `&` (`&&`) `|` (`||`) OUTSIDE any quote split segments.
+#   - A raw newline OUTSIDE any quote ALSO splits — so a GENUINE multi-line
+#     command still yields a real later-line segment and still denies (safety
+#     floor preserved; matches the old per-record behaviour where each input line
+#     was its own record).
+#   - An INERT quoted span (no `$(` and no backtick) is copied VERBATIM, so its
+#     embedded newlines/separators stay literal and never manufacture a phantom
+#     segment out of quoted documentation prose (the false positive).
+#   - A quoted span carrying command substitution (`$(` or a backtick) keeps its
+#     separators ACTIVE (walked char-by-char, exactly like qsplit()), so a
+#     smuggled payload is never hidden behind an opening quote.
+#   - An unterminated quote copies the remainder verbatim (best-effort; never
+#     widens a deny into an allow).
+# =============================================================================
+_ML_QSPLIT_AWK='
+function ml_segment(buf, segs,   SQ, DQ, s, n, seg, segc, i, c, qc, ci, j, inner) {
+    SQ = sprintf("%c", 39)   # single quote
+    DQ = sprintf("%c", 34)   # double quote
+    split("", segs)          # clear the caller-supplied out-array
+    s = buf
+    n = length(s)
+    seg = ""
+    segc = 0
+    i = 1
+    while (i <= n) {
+        c = substr(s, i, 1)
+        if (c == DQ || c == SQ) {
+            qc = c
+            ci = 0
+            for (j = i + 1; j <= n; j++) if (substr(s, j, 1) == qc) { ci = j; break }
+            if (ci == 0) {
+                seg = seg substr(s, i)   # unterminated quote: copy rest verbatim
+                i = n + 1
+                continue
+            }
+            inner = substr(s, i + 1, ci - i - 1)
+            if (index(inner, "$(") == 0 && index(inner, "`") == 0) {
+                seg = seg substr(s, i, ci - i + 1)   # inert span: verbatim (newlines stay literal)
+                i = ci + 1
+                continue
+            }
+            seg = seg c   # command substitution present: keep separators ACTIVE
+            i++
+            continue
+        }
+        if (c == ";" || c == "&" || c == "|" || c == "\n") {
+            segs[++segc] = seg; seg = ""; i++; continue
+        }
+        seg = seg c
+        i++
+    }
+    segs[++segc] = seg
+    return segc
+}
+'
+
+# Parse force-op segments out of a command, emitting one TAB-separated
+# "<cpath>\t<target>" line per genuine git force-push / hard-reset. Portable awk
+# only (mirrors extract_rm_targets / lifecycle_or_cloud_reason segment parsing):
+#   - split on ; | & && || and newline, strip a leading sudo wrapper.
+#   - only a segment whose command word is `git` is considered.
+#   - `git -C <path> ...` sets <cpath>; other pre-subcommand global options are
+#     skipped (`-c <k=v>` consumes its argument).
+#   - push: emitted only when a --force/-f/--force-with-lease flag is present.
+#     ONE line is emitted per positional refspec (pos[2], pos[3], …) after the
+#     remote — a multi-refspec push like `git push --force origin a b` emits a
+#     line for `a` AND `b`, so a protected branch in any refspec position (not
+#     just the first) reaches the caller's per-line check (#3674 follow-up).
+#     <target> is the destination branch parsed from each refspec —
+#       * `<src>:<dst>` form => <dst>
+#       * a bare ref        => the ref with a leading `+` stripped
+#       * `HEAD`, or no ref => the literal "@HEAD@" (resolve checked-out branch)
+#   - reset --hard: always emitted with <target> = "@HEAD@".
+# The caller resolves "@HEAD@" to the checked-out branch and applies the mode.
+parse_force_ops() {
+    printf '%s' "$1" | awk "$_ML_QSPLIT_AWK"'
+    BEGIN {
+        SEP = sprintf("%c", 31)  # US (unit separator) — non-whitespace so bash
+                                 # read does not trim an empty cpath.
+        buf = ""
+    }
+    # Slurp the whole (possibly multi-line) command, then segment ONCE with the
+    # shared quote-aware lexer (#71) so a multi-line quoted DATA literal whose
+    # interior line is a force-push phrase is no longer mis-read as a real
+    # segment (the pre-#71 per-record `qsplit()` reset quote state at each
+    # embedded newline).
+    { buf = buf (NR > 1 ? "\n" : "") $0 }
+    END {
+        n = ml_segment(buf, segs)
+        for (i = 1; i <= n; i++) {
+            seg = segs[i]
+            sub(/^[ \t]+/, "", seg)
+            sub(/^sudo[ \t]+/, "", seg)
+            sub(/^[ \t]+/, "", seg)
+            m = split(seg, toks, /[ \t]+/)
+            if (m == 0) continue
+            if (toks[1] != "git") continue
+            # Walk global options between `git` and the subcommand.
+            cpath = ""
+            k = 2
+            while (k <= m) {
+                t = toks[k]
+                if (t == "-C") { cpath = toks[k+1]; k += 2; continue }
+                if (t == "-c") { k += 2; continue }
+                if (t ~ /^-/)  { k += 1; continue }
+                break
+            }
+            if (k > m) continue
+            subcmd = toks[k]
+            if (subcmd == "push") {
+                force = 0
+                np = 0
+                # pos is a file-global awk array; clear it per segment
+                # (portable — split with an empty string empties the array) so
+                # refspecs from a prior segment cannot leak into this one now
+                # that we read every positional slot, not just pos[2].
+                split("", pos)
+                for (j = k+1; j <= m; j++) {
+                    t = toks[j]
+                    if (t == "--force" || t == "-f" || t == "--force-with-lease" || t ~ /^--force-with-lease=/) { force = 1; continue }
+                    if (t ~ /^-/) continue
+                    np++
+                    pos[np] = t
+                }
+                if (!force) continue
+                # pos[1] is the remote; pos[2..np] are refspecs. Emit ONE line per
+                # positional refspec so a protected branch in ANY refspec position
+                # (not just the first) reaches the per-line check in the caller. A
+                # bare push with no refspec (np < 2) resolves the checked-out branch.
+                if (np < 2) {
+                    print cpath SEP "@HEAD@"
+                } else {
+                    for (p = 2; p <= np; p++) {
+                        rs = pos[p]
+                        sub(/^\+/, "", rs)
+                        ci = index(rs, ":")
+                        if (ci > 0) rs = substr(rs, ci + 1)
+                        target = "@HEAD@"
+                        if (rs != "HEAD" && rs != "") target = rs
+                        print cpath SEP target
+                    }
+                }
+            } else if (subcmd == "reset") {
+                hard = 0
+                for (j = k+1; j <= m; j++) if (toks[j] == "--hard") hard = 1
+                if (hard) print cpath SEP "@HEAD@"
+            }
+        }
+    }'
+}
+
+# Redact the quoted VALUES of known text-carrying flags (--body, -m/--message,
+# --title, --notes, --comment) so a dangerous-looking phrase quoted INSIDE such a
+# value no longer trips the raw ALWAYS_BLOCK_PATTERNS substring scan (catastrophic
+# tier) or the ASK_PATTERNS scan (ask tier, #3756). Used ONLY to build the
+# literal-redacted working copies for those two loops (mirrors the
+# COMMAND_NO_COMMENT precedent); every other scan keeps reading the raw command.
+# This kills the #3679 false positive where `gh pr comment --body "…git push
+# --force origin main…"` / `git commit -m "…"` hard-denied even though nothing
+# executes, and (#3756) the analogous ask-tier false ask where an ask-phrase like
+# `gh issue close` quoted inside a `--comment`/`--body` value prompted for
+# confirmation despite no such command actually being run.
+#
+# Safety floor preserved two ways:
+#   - `-c` is deliberately NOT a text-carrying flag, so `bash -c '<payload>'`
+#     is never redacted and its payload stays caught by the raw scan.
+#   - a quoted span is redacted ONLY when it carries no command-substitution or
+#     backtick opener (`$(` — which also subsumes the arithmetic `$((` — or a
+#     backtick). So a smuggling attempt like `git commit -m "$(git push --force
+#     origin main)"` is left intact and still hard-denies.
+# Each redacted span is replaced by a SAME-LENGTH placeholder so byte offsets of
+# the surrounding command are unchanged. Best-effort like COMMAND_NO_COMMENT:
+# it does not model backslash-escaped quotes, but since the result feeds only
+# the narrowing (never widening) catastrophic scan, the worst case is a raw
+# substring surviving — never a catastrophic block being skipped incorrectly.
+strip_literal_text() {
+    printf '%s' "$1" | awk '
+    BEGIN {
+        SQ = sprintf("%c", 39)   # single quote
+        DQ = sprintf("%c", 34)   # double quote
+        # boundary + text-carrying flag + optional (ws / = / ws) + quoted span.
+        # The leading boundary class includes a newline so a `--body` that begins
+        # a continuation line is still recognized; the quoted-span classes
+        # ([^"]* / [^'"'"']*) already match a newline, so a MULTI-LINE quoted
+        # value is captured as one span once the whole command is slurped below.
+        re = "(^|[ \t\n])(--message|--body|--notes|--title|--comment|-m)[ \t]*=?[ \t]*(" \
+             DQ "[^" DQ "]*" DQ "|" SQ "[^" SQ "]*" SQ ")"
+        buf = ""
+    }
+    # MULTI-LINE REDACTION (#3898): slurp the whole (possibly multi-line) command
+    # into one buffer, preserving embedded newlines, then redact ONCE in END so a
+    # quoted flag value that spans several lines is treated as a single inert
+    # span. The old per-line ($0) processing split a multi-line `gh issue create
+    # --body "…"` body at each newline, leaving a dangerous phrase quoted on an
+    # interior line un-redacted — which then tripped the catastrophic scan on
+    # documentation text that merely MENTIONS a dangerous command (the meta
+    # false-positive that blocked filing #3898). Single-line input is
+    # byte-for-byte identical to the previous behaviour.
+    { buf = buf (NR > 1 ? "\n" : "") $0 }
+    END {
+        s = buf
+        out = ""
+        while (match(s, re)) {
+            pre     = substr(s, 1, RSTART - 1)
+            matched = substr(s, RSTART, RLENGTH)
+            s       = substr(s, RSTART + RLENGTH)
+            # Locate the opening quote inside the matched span.
+            qpos = 0
+            for (i = 1; i <= length(matched); i++) {
+                c = substr(matched, i, 1)
+                if (c == DQ || c == SQ) { qpos = i; break }
+            }
+            head  = substr(matched, 1, qpos)                              # up to & incl. opening quote
+            qchar = substr(matched, qpos, 1)
+            inner = substr(matched, qpos + 1, length(matched) - qpos - 1) # between the quotes
+            # Redact ONLY provably inert text (no command substitution / backtick).
+            # gsub(/./) leaves embedded newlines untouched (awk `.` never matches a
+            # newline), so a multi-line span stays SAME-LENGTH and byte offsets of
+            # the surrounding command are preserved.
+            if (index(inner, "$(") == 0 && index(inner, "`") == 0) {
+                gsub(/./, "X", inner)
+            }
+            out = out pre head inner qchar
+        }
+        out = out s
+        printf "%s", out
+    }'
+}
+
+# Redact the quoted argument(s) of a non-executing "data sink" command word
+# (echo, printf) so a dangerous-looking string that appears ONLY as quoted DATA
+# handed to echo/printf no longer trips the raw ALWAYS_BLOCK_PATTERNS scan
+# (catastrophic tier) or the ASK_PATTERNS scan (ask tier) (#53). echo/printf
+# print their arguments verbatim; they never EXECUTE them, so a quoted argument
+# is inert text — exactly like a --body/-m value — yet strip_literal_text()'s
+# flag allowlist never covered it. This is the meta false-positive that blocked
+# a guard self-test (`echo '{"…":"<dangerous cmd>"}' | guard-destructive.sh`)
+# and blocked filing this very issue's heredoc body.
+#
+# Command-word anchored (mirrors fastpath_builtin_admits() and the segment
+# parsers): the quoted args are redacted ONLY for a simple command whose FIRST
+# token is exactly `echo` or `printf` (optionally behind a bare `sudo`/`env`
+# wrapper). A wrapper that actually EXECUTES its argument — `bash -c '<payload>'`,
+# `sh -c`, `eval`, `xargs` — is never a data sink and is never redacted here.
+#
+# Safety floor, identical to strip_literal_text()/qsplit():
+#   - A quoted span is redacted ONLY when it carries no command substitution /
+#     backtick opener (`$(` or a backtick), so a smuggled `echo "$(<payload>)"`
+#     keeps its payload intact and still hard-denies.
+#   - The `echo '<payload>' | sh` shape (data PIPED into a shell that WOULD
+#     execute it) is handled by the command_has_shell_segment() gate at the call
+#     site, which skips this redaction entirely whenever any pipeline segment's
+#     command word is a shell — so the raw scan still sees and blocks the payload.
+#
+# Single-pass quote-aware lexer. It deliberately does NOT reuse qsplit(), whose
+# `\n`-per-separator contract would conflate a real newline inside a multi-line
+# quoted span with a shell separator; here a multi-line span is redacted as one
+# inert unit (`.` never matches a newline, so each line stays SAME-LENGTH and the
+# surrounding byte offsets are preserved). Best-effort like strip_literal_text():
+# an unterminated quote copies the remainder verbatim (never redacts), and the
+# result feeds only the NARROWING scans, so the worst case is a raw substring
+# surviving (a false block) — never a catastrophic block being skipped.
+strip_datasink_literals() {
+    printf '%s' "$1" | awk '
+    BEGIN {
+        SQ = sprintf("%c", 39)   # single quote
+        DQ = sprintf("%c", 34)   # double quote
+        buf = ""
+    }
+    { buf = buf (NR > 1 ? "\n" : "") $0 }
+    END {
+        s = buf
+        n = length(s)
+        out = ""
+        i = 1
+        atcmd = 1     # at the start of a simple command (command-word position)
+        sink = 0      # inside an echo/printf data-sink command
+        while (i <= n) {
+            c = substr(s, i, 1)
+            # A shell separator resets to command-word position.
+            if (c == ";" || c == "&" || c == "|" || c == "\n") {
+                out = out c; i++; atcmd = 1; sink = 0; continue
+            }
+            # Leading whitespace is copied without leaving command-word position.
+            if (c == " " || c == "\t") { out = out c; i++; continue }
+            # Command-word position: read the first token and classify it.
+            if (atcmd) {
+                atcmd = 0
+                tok = ""
+                j = i
+                while (j <= n) {
+                    cc = substr(s, j, 1)
+                    if (cc == " " || cc == "\t" || cc == ";" || cc == "&" || cc == "|" || cc == "\n") break
+                    tok = tok cc
+                    j++
+                }
+                # A bare sudo/env wrapper: emit it and stay in command-word
+                # position so the NEXT token is classified as the command word.
+                if (tok == "sudo" || tok == "env") {
+                    out = out tok; i = j; atcmd = 1; continue
+                }
+                if (tok == "echo" || tok == "printf") { sink = 1 }
+                out = out tok; i = j; continue
+            }
+            # Mid-command: a quoted span is redacted only inside a data sink.
+            if (c == DQ || c == SQ) {
+                qc = c
+                ci = 0
+                for (j = i + 1; j <= n; j++) {
+                    if (substr(s, j, 1) == qc) { ci = j; break }
+                }
+                if (ci == 0) {
+                    # Unterminated quote: copy the rest verbatim, never redact.
+                    out = out substr(s, i); i = n + 1; continue
+                }
+                inner = substr(s, i + 1, ci - i - 1)
+                if (sink && index(inner, "$(") == 0 && index(inner, "`") == 0) {
+                    gsub(/./, "X", inner)   # . never matches \n: multi-line stays same-length
+                }
+                out = out qc inner qc; i = ci + 1; continue
+            }
+            out = out c; i++
+        }
+        printf "%s", out
+    }'
+}
+
+# Return 0 (success) if ANY quote-aware segment's command word is a shell binary
+# (sh/bash/dash/zsh/ksh/csh/tcsh/fish/pwsh, with or without a leading path).
+# GATES strip_datasink_literals(): when a shell could consume the command's data
+# (e.g. `echo '<payload>' | sh`), the data-sink redaction is skipped so the raw
+# catastrophic scan still sees — and blocks — the payload. Conservative by
+# construction: a shell ANYWHERE in the command disables the (narrowing)
+# redaction, so the worst case is a preserved false BLOCK, never a skipped one.
+# `guard-destructive.sh` (basename is not a bare shell word) is deliberately NOT
+# matched, so the guard's own `echo '<json>' | guard-destructive.sh` self-test
+# still redacts and no longer false-blocks (#53). Emits "yes"/"no".
+command_has_shell_segment() {
+    printf '%s' "$1" | awk "$_QSPLIT_AWK"'
+    { buf = buf (NR > 1 ? "\n" : "") $0 }
+    END {
+        found = 0
+        s = qsplit(buf)   # quote-aware segmentation (#3755); separators -> \n
+        n = split(s, segs, "\n")
+        for (i = 1; i <= n; i++) {
+            seg = segs[i]
+            sub(/^[ \t]+/, "", seg)
+            # Strip any run of leading VAR=val assignments, then a sudo/env wrapper,
+            # so the REAL command word is classified. The required trailing [ \t]+
+            # in the assignment pattern guarantees the loop makes progress.
+            while (match(seg, /^[A-Za-z_][A-Za-z0-9_]*=[^ \t]*[ \t]+/)) { seg = substr(seg, RLENGTH + 1) }
+            sub(/^sudo[ \t]+/, "", seg)
+            sub(/^env[ \t]+/, "", seg)
+            sub(/^[ \t]+/, "", seg)
+            m = split(seg, toks, /[ \t]+/)
+            if (m == 0) continue
+            w = toks[1]
+            sub(/.*\//, "", w)   # basename only
+            if (w == "sh" || w == "bash" || w == "dash" || w == "zsh" || \
+                w == "ksh" || w == "csh" || w == "tcsh" || w == "fish" || w == "pwsh") { found = 1 }
+        }
+        print (found ? "yes" : "no")
+    }'
+}
+
 # Helper: output a deny decision and exit
+#
+# Optional second arg is a short, STABLE rule tag (issue #3771) recorded as the
+# decision log's `pattern` field; it defaults to "deny" (a function-name-derived
+# fallback) so this stays backward-compatible with call sites that don't pass
+# one. Telemetry is emitted BEFORE the JSON decision so a logging hiccup can
+# never suppress the deny, and the `|| true` guarantees it never trips the ERR
+# trap. Deny is always the "catastrophic" tier.
 deny() {
     local reason="$1"
+    local tag="${2:-deny}"
+    log_guard_decision "deny" "catastrophic" "$tag" || true
     if jq -n --arg reason "$reason" '{
         hookSpecificOutput: {
             hookEventName: "PreToolUse",
@@ -195,8 +1346,14 @@ deny() {
 }
 
 # Helper: output an ask decision and exit
+#
+# Same optional rule-tag convention as deny() (issue #3771); defaults to "ask".
+# Ask is always the "ask" tier. Telemetry is best-effort and emitted before the
+# JSON decision.
 ask() {
     local reason="$1"
+    local tag="${2:-ask}"
+    log_guard_decision "ask" "ask" "$tag" || true
     if jq -n --arg reason "$reason" '{
         hookSpecificOutput: {
             hookEventName: "PreToolUse",
@@ -220,10 +1377,10 @@ ask() {
 ALWAYS_BLOCK_PATTERNS=(
     # GitHub destructive operations — command-position anchored (start-of-line
     # or a shell separator must precede the verb) so the phrase inside a flag
-    # value no longer trips. The catastrophic scan still runs over the full raw
-    # command, including quoted/heredoc text, so a `gh repo delete` that a shell
-    # would actually execute (leading, sudo-prefixed, or after a separator)
-    # still denies.
+    # value no longer trips. NOTE: the catastrophic scan still runs over the
+    # full raw command, including quoted/heredoc text, so a `gh repo delete`
+    # that a shell would actually execute (leading, sudo-prefixed, or after a
+    # separator) still denies (#3553).
     '(^|[;&|[:space:]])gh repo delete'
     '(^|[;&|[:space:]])gh repo archive'
 
@@ -239,9 +1396,21 @@ ALWAYS_BLOCK_PATTERNS=(
     # scoped path like `rm -rf /tmp/x` no longer trips the catastrophic rule,
     # while root / home obliteration still denies. The left side of `rm` is
     # deliberately NOT anchored, so a quoted payload such as `bash -c 'rm -rf /'`
-    # (root followed by a closing quote) still matches. The trailing class
-    # matches anything that is not a path-continuation character (so `/`, `/ `,
-    # `/*`, `/;`, `/'` all count as "root itself" but `/tmp` does not).
+    # (root followed by a closing quote) still matches (#3553). The trailing
+    # class matches anything that is not a path-continuation character (so `/`,
+    # `/ `, `/*`, `/;`, `/'` all count as "root itself" but `/tmp` does not).
+    # NOTE (#72): these three patterns require `rm` to be immediately followed by
+    # whitespace, so a command-word substitution like `$(which rm) -rf /` (where
+    # `rm` is followed by `)`) does NOT match here. That shape is instead caught
+    # by the extract_rm_targets() -> rm-protected-path path below, whose deny
+    # covers root, $HOME, AND every top-level dir — a superset of these three.
+    # For that superset claim to actually hold for the substitution shape, the
+    # extract path must recognize the SAME home/root targets these literal
+    # patterns do: extract_rm_targets() strips a leading `env` (and VAR=val
+    # assignments) as well as `sudo`, and the protected-path loop expands a bare
+    # `~`/`$HOME` target before the check — so `env $(which rm) -rf /`,
+    # `$(which rm) -rf ~`, and `$(which rm) -rf $HOME` all deny just like their
+    # literal counterparts. No parallel regex is needed for the substitution case.
     'rm[[:space:]]+-[a-zA-Z]*[rf][a-zA-Z]*[[:space:]]+/([^[:alnum:]._~/-]|$)'
     'rm[[:space:]]+-[a-zA-Z]*[rf][a-zA-Z]*[[:space:]]+~([^[:alnum:]._~/-]|$)'
     'rm[[:space:]]+-[a-zA-Z]*[rf][a-zA-Z]*[[:space:]]+\$HOME([^[:alnum:]._~/-]|$)'
@@ -249,20 +1418,37 @@ ALWAYS_BLOCK_PATTERNS=(
     # Fork bombs
     ':\(\)\{ :\|:& \};:'
 
-    # Pipe to shell (supply chain risk)
-    'curl .* \| .*sh'
-    'curl .* \| bash'
-    'wget .* \| .*sh'
-    'wget .* -O- \| sh'
+    # Pipe to shell (supply chain risk) — the piped-to COMMAND must itself be
+    # a shell (repo#29). The old shapes ('curl .* \| .*sh', 'curl .* \| bash',
+    # 'wget .* \| .*sh', 'wget .* -O- \| sh') matched "sh" anywhere after the
+    # pipe, so piping a download to `tee /usr/share/...`, `shasum`, or any
+    # path containing "sh" false-positived (and quoting such a pipeline in an
+    # issue body blocked the bug report about it). The single fixed pattern
+    # anchors on the command position immediately after a pipe: optional
+    # sudo (with flags), an optional path prefix, then a shell word
+    # (sh/bash/dash/zsh/ksh/csh/tcsh/fish/pwsh) followed by a non-word
+    # character. `[^;&]*` spans pipes but not command separators, so a
+    # multi-stage pipeline (`curl … | gunzip | sh`) still denies while a
+    # neighbouring command after `&&`/`;` is never mis-joined. Known accepted
+    # misses: a wrapper consuming the command position (`| sudo -u user sh`,
+    # `| env sh`); `bash -c 'curl … | sh'` still denies (raw scan, `-c` is
+    # never redacted).
+    '(^|[;&|[:space:](])(curl|wget)[^;&]*\|[[:space:]]*(sudo[[:space:]]+(-[^[:space:]]+[[:space:]]+)*)?([^[:space:]|;&]*/)?(ba|da|z|k|c|tc|fi|pw)?sh([[:space:]]|$|[;&|)])'
 
     # Cloud infrastructure destruction. The aws forms below are specific
     # multi-token phrases, so they stay in this raw substring scan. The az/gcloud
     # CLIs, by contrast, need command-word anchoring — an unanchored `az.*delete`
-    # matches "h·az·ard … delete" across unrelated prose tokens — so they are
-    # handled by the segment-parsed lifecycle/cloud check further below, NOT here.
+    # matches "h·az·ard … delete" across unrelated prose tokens (#3584) — so they
+    # are handled by the segment-parsed lifecycle/cloud check further below, NOT
+    # here.
+    # NOTE: `aws ec2 terminate` is deliberately NOT in this raw catastrophic
+    # scan. For a repo whose job is standing up and tearing down dev VMs the
+    # teardown path (`terminate-instances`) is a first-class workflow, so it is
+    # downgraded to an ask via the toggle-gated CLOUD_ASK_PATTERNS below (and
+    # fully bypassed when LOOM_GUARD_CLOUD=0 / guards.cloudCli:false). The other
+    # aws forms here stay ungated — they remain a hard safety floor (#3593).
     'aws s3 rm.*--recursive'
     'aws s3 rb'
-    'aws ec2 terminate'
     'aws iam delete'
     'aws cloudformation delete-stack'
 
@@ -270,24 +1456,46 @@ ALWAYS_BLOCK_PATTERNS=(
     'docker system prune'
 
     # NOTE: system-lifecycle commands (halt/reboot/poweroff/shutdown/init 0/
-    # init 6) are deliberately NOT in this raw substring scan. Even a
-    # whitespace-inclusive boundary anchor still fired inside ordinary prose
-    # ("...the box will halt", "...after a reboot event"), and a pure regex tweak
-    # can't separate `sudo halt` from `will halt` (both are "<word> halt"). They
-    # are handled by the segment-parsed check below, which denies only when a
-    # segment's *command word* is exactly the lifecycle word.
+    # init 6) are deliberately NOT in this raw substring scan. Even the
+    # whitespace-inclusive boundary anchor they used to carry still fired inside
+    # ordinary prose ("...the box will halt", "...after a reboot event"), and a
+    # pure regex tweak can't separate `sudo halt` from `will halt` (both are
+    # "<word> halt"). They are handled by the segment-parsed check below, which
+    # denies only when a segment's *command word* is exactly the lifecycle word
+    # (#3584).
 )
 
+# Build a literal-text-redacted working copy ONLY for the catastrophic scan
+# below, so a force-push-to-main phrase quoted inside a
+# --body/-m/--title/--notes/--comment value no longer false-positives (#3679,
+# --comment added #3756). The awk only runs when one of those flags is actually
+# present, keeping it off the hot path (mirrors the COMMAND_NO_COMMENT
+# `#`-present guard). `-c` is intentionally excluded so `bash -c '<payload>'`
+# payloads still reach the raw scan; spans carrying `$(` / backtick are left
+# intact so command-substitution smuggling still hard-denies.
+COMMAND_NO_LITERAL_TEXT="$COMMAND"
+if [[ "$COMMAND" == *"--body"* || "$COMMAND" == *"--message"* || \
+      "$COMMAND" == *"--title"* || "$COMMAND" == *"--notes"* || \
+      "$COMMAND" == *"--comment"* || "$COMMAND" == *"-m"* ]]; then
+    COMMAND_NO_LITERAL_TEXT=$(strip_literal_text "$COMMAND")
+fi
+# ALSO redact the quoted args of a data-sink command word (echo/printf), so a
+# dangerous string handed to echo/printf as inert DATA no longer trips the raw
+# scan (#53) — the meta false-positive that blocked guard self-tests and filing
+# this issue's heredoc body. Gated on echo/printf being present (off the hot
+# path otherwise) AND on NO shell segment existing: when data is piped into a
+# shell that would execute it (`echo '<payload>' | sh`), the redaction is skipped
+# so the raw scan still blocks the payload. `-c` wrappers (bash -c/sh -c) are
+# never data sinks, and `$(`/backtick spans are never redacted, so smuggling
+# still hard-denies.
+if [[ "$COMMAND" == *"echo"* || "$COMMAND" == *"printf"* ]] && \
+   [[ "$(command_has_shell_segment "$COMMAND")" == "no" ]]; then
+    COMMAND_NO_LITERAL_TEXT=$(strip_datasink_literals "$COMMAND_NO_LITERAL_TEXT")
+fi
+
 for pattern in "${ALWAYS_BLOCK_PATTERNS[@]}"; do
-    # EC2 terminate is a first-class teardown verb for cloud-management repos;
-    # let the cloud-CLI toggle downgrade it (deny -> pass to normal flow). The
-    # other catastrophic aws/docker patterns (iam delete, s3 rb, s3 recursive
-    # delete, cloudformation delete-stack, docker system prune) stay always-on.
-    if [[ "$pattern" == 'aws ec2 terminate' ]] && ! cloud_guard_enabled; then
-        continue
-    fi
-    if echo "$COMMAND" | grep -qiE "$pattern"; then
-        deny "BLOCKED: Command matches dangerous pattern: $pattern"
+    if echo "$COMMAND_NO_LITERAL_TEXT" | grep -qiE "$pattern"; then
+        deny "BLOCKED: Command matches dangerous pattern: $pattern" "catastrophic:$pattern"
     fi
 done
 
@@ -303,12 +1511,42 @@ done
 # stripped copy is used only for the *narrowing* ASK/DDL matches (never the
 # catastrophic scan) the worst case is a missed ask on quoted data, never a
 # missed catastrophic block. The sed only runs when a `#` is actually present,
-# keeping it off the hot path.
+# keeping it off the hot path (#3553).
 # =============================================================================
 if [[ "$COMMAND" == *"#"* ]]; then
     COMMAND_NO_COMMENT=$(printf '%s\n' "$COMMAND" | sed -E 's/(^|[[:space:]])#.*$//')
 else
     COMMAND_NO_COMMENT="$COMMAND"
+fi
+
+# =============================================================================
+# ASK-TIER WORKING COPY (#3756) — comment-stripped AND literal-text redacted.
+#
+# The ASK_PATTERNS loop below needs BOTH narrowings the catastrophic tier's two
+# copies provide separately: COMMAND_NO_COMMENT's `#`-comment stripping AND
+# strip_literal_text()'s quoted-flag-value redaction (the #3679 fix the ask tier
+# never received). Building the ask copy from COMMAND_NO_COMMENT (not raw
+# $COMMAND) preserves the comment-stripping the ask tier already relied on, then
+# redacts --body/-m/--title/--notes/--comment values so an ask-phrase quoted
+# inside such a value (e.g. `gh pr comment --body "…gh issue close…"`) no longer
+# false-asks. The strip only runs when a text-carrying flag is present, keeping
+# it off the hot path. Never feeds the catastrophic scan (that keeps reading the
+# raw command), so this can only NARROW an ask, never miss a hard deny.
+# =============================================================================
+COMMAND_ASK_SCAN="$COMMAND_NO_COMMENT"
+if [[ "$COMMAND_NO_COMMENT" == *"--body"* || "$COMMAND_NO_COMMENT" == *"--message"* || \
+      "$COMMAND_NO_COMMENT" == *"--title"* || "$COMMAND_NO_COMMENT" == *"--notes"* || \
+      "$COMMAND_NO_COMMENT" == *"--comment"* || "$COMMAND_NO_COMMENT" == *"-m"* ]]; then
+    COMMAND_ASK_SCAN=$(strip_literal_text "$COMMAND_NO_COMMENT")
+fi
+# Mirror the catastrophic tier's data-sink redaction (#53): an ask-phrase quoted
+# as inert echo/printf data (e.g. `echo 'run gh issue close 5 to clean up'`)
+# should not false-ask. Same shell-segment gate keeps `echo '<phrase>' | sh`
+# reaching the raw ask scan. Never feeds the catastrophic scan, so it can only
+# NARROW an ask, never miss a hard deny.
+if [[ "$COMMAND_NO_COMMENT" == *"echo"* || "$COMMAND_NO_COMMENT" == *"printf"* ]] && \
+   [[ "$(command_has_shell_segment "$COMMAND_NO_COMMENT")" == "no" ]]; then
+    COMMAND_ASK_SCAN=$(strip_datasink_literals "$COMMAND_ASK_SCAN")
 fi
 
 # =============================================================================
@@ -318,8 +1556,9 @@ fi
 # and the az/gcloud cloud-delete CLIs are far too common as ordinary prose,
 # identifiers, and flag names to scan as unanchored substrings — and even a
 # whitespace-inclusive boundary anchor still fired inside comments and commit
-# messages. A pure regex tweak cannot separate `sudo halt` (a real command)
-# from `will halt` (prose) because both are "<word> halt".
+# messages ("...the box will halt", "...after a reboot event"). A pure regex
+# tweak cannot separate `sudo halt` (a real command) from `will halt` (prose)
+# because both are "<word> halt".
 #
 # So we segment-parse instead, mirroring extract_rm_targets(): split the command
 # on ; | & && || and newline, strip a leading sudo/env wrapper from each segment,
@@ -328,15 +1567,23 @@ fi
 # distinguishes `sudo halt` (command word = halt) from `will halt` (command word
 # = echo/other) and from `--instance-initiated-shutdown-behavior` (not a command
 # word at all). The scan runs against COMMAND_NO_COMMENT so a lifecycle/cloud
-# word sitting in a trailing comment is already gone.
+# word sitting in a trailing comment is already gone. The catastrophic
+# ALWAYS_BLOCK scan above still reads the raw string for the symbolic patterns
+# (rm -rf /, the fork bomb, curl|sh) that are not prose-prone (#3584).
 # =============================================================================
 lifecycle_or_cloud_reason() {
     # Emit a deny reason (one per line) for every segment whose command word is a
     # system-lifecycle command or an az/gcloud delete. Portable awk only.
-    printf '%s' "$1" | awk '
-    {
-        gsub(/&&|\|\||[;|&]/, "\n")
-        n = split($0, segs, "\n")
+    printf '%s' "$1" | awk "$_ML_QSPLIT_AWK"'
+    BEGIN { buf = "" }
+    # Slurp the whole (possibly multi-line) command, then segment ONCE with the
+    # shared quote-aware lexer (#71) so a multi-line quoted DATA literal whose
+    # interior line is a lifecycle/cloud word (e.g. `halt`) is no longer mis-read
+    # as a real segment (the pre-#71 per-record `qsplit()` reset quote state at
+    # each embedded newline, hard-denying inert quoted prose).
+    { buf = buf (NR > 1 ? "\n" : "") $0 }
+    END {
+        n = ml_segment(buf, segs)
         for (i = 1; i <= n; i++) {
             seg = segs[i]
             sub(/^[ \t]+/, "", seg)
@@ -348,7 +1595,7 @@ lifecycle_or_cloud_reason() {
             # NAME halt` likewise resolve to `halt`. A bare `env halt` (no
             # assignment) is unaffected — the loop matches nothing and leaves
             # `halt` as the command word. Portable awk only (no GNU/BSD-specific
-            # escapes), consistent with extract_rm_targets().
+            # escapes), consistent with extract_rm_targets(). (#3586)
             if (sub(/^env([ \t]+|$)/, "", seg)) {
                 sub(/^[ \t]+/, "", seg)
                 stripped = 1
@@ -384,22 +1631,26 @@ lifecycle_or_cloud_reason() {
     }'
 }
 
-_LIFECYCLE_REASON=$(lifecycle_or_cloud_reason "$COMMAND_NO_COMMENT" | head -1)
-if [[ -n "$_LIFECYCLE_REASON" ]]; then
-    # Gate the cloud-delete portion behind the cloud toggle; lifecycle commands
-    # stay always-on.
-    if [[ "$_LIFECYCLE_REASON" == "cloud resource deletion:"* ]]; then
-        cloud_guard_enabled && deny "BLOCKED: $_LIFECYCLE_REASON"
+# Lifecycle denies are unconditional. The az/gcloud delete denies are gated by
+# the cloud-CLI toggle (Repo Skills refinement): for a repo whose job IS
+# managing cloud infra, `az`/`gcloud … delete` is first-class teardown, so
+# guards.cloudCli:false / REPO_GUARD_CLOUD=0 downgrades those denies to allow.
+# Every emitted reason is inspected (not just the first) so a skipped cloud
+# reason can never mask a lifecycle deny later in the same command.
+while IFS= read -r _lifecycle_reason; do
+    [[ -z "$_lifecycle_reason" ]] && continue
+    if [[ "$_lifecycle_reason" == "cloud resource deletion:"* ]]; then
+        cloud_guard_enabled && deny "BLOCKED: $_lifecycle_reason" "lifecycle-or-cloud-delete"
     else
-        deny "BLOCKED: $_LIFECYCLE_REASON"
+        deny "BLOCKED: $_lifecycle_reason" "lifecycle-or-cloud-delete"
     fi
-fi
+done < <(lifecycle_or_cloud_reason "$COMMAND_NO_COMMENT")
 
 # =============================================================================
 # DATABASE DESTRUCTION - Gated by the SQL DDL/DML guard toggle
 #
 # Kept separate from ALWAYS_BLOCK_PATTERNS so DB-engine repos can opt out
-# (guards.sqlDdl:false / REPO_GUARD_SQL=0). A single alternation grep matches
+# (guards.sqlDdl:false / LOOM_GUARD_SQL=0). A single alternation grep matches
 # all four DDL statements in one pass (cheaper than a per-pattern loop), and
 # sql_guard_enabled() is consulted only after a match, so the config read stays
 # off the hot path.
@@ -407,7 +1658,7 @@ fi
 SQL_DDL_PATTERN='DROP DATABASE|DROP TABLE|DROP SCHEMA|TRUNCATE TABLE'
 if echo "$COMMAND_NO_COMMENT" | grep -qiE "$SQL_DDL_PATTERN" && sql_guard_enabled; then
     matched=$(echo "$COMMAND_NO_COMMENT" | grep -oiE "$SQL_DDL_PATTERN" | head -1)
-    deny "BLOCKED: Command matches dangerous pattern: ${matched:-SQL DDL statement}"
+    deny "BLOCKED: Command matches dangerous pattern: ${matched:-SQL DDL statement}" "sql-ddl"
 fi
 
 # =============================================================================
@@ -415,14 +1666,18 @@ fi
 #
 # Only *actual local* `rm` command words are inspected. `extract_rm_targets`
 # splits the command on ; | & && || and, for each simple-command segment whose
-# command word is `rm` (optionally sudo-prefixed) AND which carries a
-# recursive/force flag, emits the non-flag argument tokens. Consequences:
-#   - A token from an earlier command in the same line is never mis-read as an
+# command word is `rm` (optionally sudo-prefixed) — OR a command-word
+# *substitution* `$(...)`/backtick in executable position (#72) — AND which
+# carries a recursive/force flag, emits the non-flag argument tokens.
+# Consequences (#3553):
+#   - A token from an earlier command in the same line (e.g. the `host-ip.txt`
+#     in `HOST=$(cat host-ip.txt); ssh $HOST rm -rf …`) is never mis-read as an
 #     rm target — only tokens of a real `rm` segment are considered.
 #   - An `rm` inside a remote payload (`ssh host 'rm -rf /home/ubuntu/foo'`) is
 #     NOT treated as a local rm: the wrapper's command word is `ssh`/`scp`, not
-#     `rm`. The ALWAYS_BLOCK catastrophic patterns above still scan the whole
-#     string, so a remote or quoted `rm -rf /` still denies.
+#     `rm`, so no local target is emitted and the local scope check is skipped.
+#     The ALWAYS_BLOCK catastrophic patterns above still scan the whole string,
+#     so a remote or quoted `rm -rf /` still denies.
 #   - Only root, the user's $HOME, and *top-level* directories (/tmp, /var, /etc,
 #     /usr, /home, /opt, /bin, …) are blocked. A scoped subpath such as
 #     `rm -rf /tmp/whatever` or `rm -rf /var/foo` is allowed — the guard stops
@@ -431,24 +1686,107 @@ fi
 
 extract_rm_targets() {
     # Emit one rm-target token per line for every local `rm -r/-f` invocation.
-    # Portable awk only (no GNU/BSD-specific escapes); replaces the shell
-    # separators with newlines, then inspects each simple command.
-    printf '%s' "$1" | awk '
-    {
-        gsub(/&&|\|\||[;|&]/, "\n")
-        n = split($0, segs, "\n")
-        for (i = 1; i <= n; i++) {
-            seg = segs[i]
+    # Portable awk only (no GNU/BSD-specific escapes).
+    #
+    # MULTI-LINE QUOTE AWARENESS (#60): slurp the whole (possibly multi-line)
+    # command into ONE buffer, then segment ONCE with a quote-aware walk — instead
+    # of the old per-awk-record `$0 = qsplit($0)`, whose quote-tracking reset at
+    # every input newline because awk's default RS split the command into separate
+    # records. That per-record form false-blocked a multi-line quoted DATA literal
+    # (echo/printf/--body) whose interior line merely BEGINS with `rm -rf /`: the
+    # interior line was scanned as its own top-level segment with no memory that it
+    # is still inside an open quote from a prior line, so its command word resolved
+    # to a real `rm` and its lone `/` token hit the protected-root deny. Mirrors
+    # the buffer-slurp the catastrophic/ask redactors (strip_datasink_literals /
+    # strip_literal_text) and command_has_shell_segment() already use.
+    #
+    # Segmentation is delegated to the shared ml_segment() lexer (#71,
+    # _ML_QSPLIT_AWK) rather than reusing qsplit()+split("\n"), because qsplit()
+    # emits a `\n` for each real separator while ALSO leaving a literal newline
+    # that lived inside an inert quoted span untouched — the two are then
+    # indistinguishable to a downstream `split(s, segs, "\n")`, which is exactly
+    # why the naive slurp-then-qsplit would still re-split the quoted `rm -rf /`
+    # line into its own segment. ml_segment() walks the buffer once so an inert
+    # quoted span's embedded newlines never become segment boundaries. PR #69
+    # introduced this lexer inline here; #71 extracted it into the shared helper
+    # so parse_force_ops()/lifecycle_or_cloud_reason() reuse the SAME algorithm
+    # instead of duplicating it (see the _ML_QSPLIT_AWK header for the full
+    # segmentation contract).
+    printf '%s' "$1" | awk "$_ML_QSPLIT_AWK"'
+    BEGIN { buf = "" }
+    { buf = buf (NR > 1 ? "\n" : "") $0 }
+    END {
+        segc = ml_segment(buf, segs)
+        for (si = 1; si <= segc; si++) {
+            seg = segs[si]
             sub(/^[ \t]+/, "", seg)
-            sub(/^sudo[ \t]+/, "", seg)
+            # Strip a leading run of VAR=val assignments and sudo/env wrappers
+            # (in any order/repetition) so the REAL command word — a literal `rm`
+            # OR a command-word substitution — is what we classify. `env` is
+            # stripped alongside `sudo` (#72): `env $(which rm) -rf /` and
+            # `env rm -rf /` must be seen as an rm command word, not shielded
+            # behind the wrapper. The required trailing [ \t]+ in each sub()
+            # guarantees the while loop makes progress and terminates.
+            while (sub(/^[A-Za-z_][A-Za-z0-9_]*=[^ \t]*[ \t]+/, "", seg) || \
+                   sub(/^sudo[ \t]+/, "", seg) || \
+                   sub(/^env[ \t]+/, "", seg)) { }
             sub(/^[ \t]+/, "", seg)
-            if (seg !~ /^rm([ \t]|$)/) continue
-            m = split(seg, toks, /[ \t]+/)
+            # Determine the argument tail and the token index to start scanning
+            # from. Two command-word shapes emit targets:
+            #   (a) a literal `rm` command word — scan from toks[2] (skip "rm").
+            #   (b) a command-word *substitution* — `$(...)` or a backtick pair —
+            #       in executable position (#72). The substitution result becomes
+            #       the command word at run time, so `$(which rm) -rf /` never
+            #       presents a literal `rm` token yet is exactly as dangerous. We
+            #       deliberately do NOT try to resolve what the substitution names
+            #       (`which rm`, `command -v rm`, an alias, a PATH-relative rm, … —
+            #       unbounded and trivially bypassable); we key on the SHAPE
+            #       (substitution in command-word position + a recursive/force
+            #       flag + a protected-path target) and let the downstream
+            #       protected-path check decide. A benign `$(which ls) -la /tmp`
+            #       carries no recursive/force flag, so it emits no target and
+            #       stays allowed — no blanket deny on command-word substitutions.
+            tail = ""
+            start = 0
+            if (seg ~ /^rm([ \t]|$)/) {
+                tail = seg
+                start = 2
+            } else if (substr(seg, 1, 2) == "$(") {
+                # Balanced-paren skip past the substitution so an internal space
+                # (e.g. `$(command -v rm)`) is NOT mis-split into a bogus
+                # flag/target token. Start depth at 1 for the opening `(`.
+                depth = 1
+                p = 3
+                L = length(seg)
+                while (p <= L && depth > 0) {
+                    ch = substr(seg, p, 1)
+                    if (ch == "(") depth++
+                    else if (ch == ")") depth--
+                    p++
+                }
+                if (depth != 0) continue   # unterminated: emit nothing (conservative)
+                tail = substr(seg, p)
+                sub(/^[ \t]+/, "", tail)
+                start = 1
+            } else if (substr(seg, 1, 1) == "`") {
+                # Backtick command word: skip to the closing backtick.
+                p = 2
+                L = length(seg)
+                while (p <= L && substr(seg, p, 1) != "`") p++
+                if (p > L) continue        # unterminated: emit nothing
+                p++                         # step past the closing backtick
+                tail = substr(seg, p)
+                sub(/^[ \t]+/, "", tail)
+                start = 1
+            } else {
+                continue
+            }
+            m = split(tail, toks, /[ \t]+/)
             has_rf = 0
-            for (j = 2; j <= m; j++)
+            for (j = start; j <= m; j++)
                 if (toks[j] ~ /^-/ && toks[j] ~ /[rRfF]/) has_rf = 1
             if (!has_rf) continue
-            for (j = 2; j <= m; j++) {
+            for (j = start; j <= m; j++) {
                 if (toks[j] == "") continue
                 if (toks[j] ~ /^-/) continue
                 print toks[j]
@@ -496,8 +1834,14 @@ normalize_abs_path() {
 }
 
 # Cheap pre-check keeps awk off the hot path for the ~99% of commands that have
-# no recursive/force rm at all.
-if echo "$COMMAND" | grep -qE 'rm[[:space:]]+-[a-zA-Z]*[rf]'; then
+# no recursive/force rm at all. The first alternative matches a literal `rm`
+# command word; the second admits a command-word *substitution* (#72) — a
+# closing `)` or backtick immediately followed by a recursive/force flag, as in
+# `$(which rm) -rf /` or `` `which rm` -rf / `` — so extract_rm_targets() is
+# invoked for that shape too. This gate is only an optimization: a false match
+# here is harmless because extract_rm_targets() emits a target only for a real
+# rm-flavored (substitution/rm command word + recursive-force flag) segment.
+if echo "$COMMAND" | grep -qE 'rm[[:space:]]+-[a-zA-Z]*[rf]|[)`][[:space:]]+-[a-zA-Z]*[rf]'; then
     RM_TARGETS=$(extract_rm_targets "$COMMAND" | head -20)
 
     for target in $RM_TARGETS; do
@@ -514,6 +1858,8 @@ if echo "$COMMAND" | grep -qE 'rm[[:space:]]+-[a-zA-Z]*[rf]'; then
                 continue ;;
             build|./build|*/build)
                 continue ;;
+            .loom/worktrees/*|*/.loom/worktrees/*)
+                continue ;;
             .next|./.next|*/.next)
                 continue ;;
             __pycache__|./__pycache__|*/__pycache__)
@@ -523,6 +1869,31 @@ if echo "$COMMAND" | grep -qE 'rm[[:space:]]+-[a-zA-Z]*[rf]'; then
             *.pyc)
                 continue ;;
         esac
+
+        # Expand a leading `~` or `$HOME` token so home-directory targets are
+        # recognized the same way the literal-rm ALWAYS_BLOCK `$HOME`/`~`
+        # patterns handle them (#72). extract_rm_targets() emits the raw token,
+        # so a substitution-path target of `~` or `$HOME` (as in
+        # `$(which rm) -rf ~`) would otherwise be treated as a CWD-relative path
+        # and never flagged, an asymmetry vs. literal `rm -rf ~`/`rm -rf $HOME`.
+        # Only bare-home and home-subpath forms are expanded — this mirrors the
+        # literal floor exactly: bare `$HOME`/`~` deny (whole-home wipe) while a
+        # home *subpath* expands to a deeper path and stays allowed.
+        if [[ -n "$HOME" ]]; then
+            # The `~` in the case globs below is a LITERAL match against the
+            # emitted target token, not a path we want the shell to expand —
+            # SC2088 (tilde-does-not-expand-in-quotes) is exactly the intended
+            # behaviour here, so it is suppressed.
+            # shellcheck disable=SC2088
+            case "$target" in
+                '~')          target="$HOME" ;;
+                '~/'*)        target="$HOME/${target#\~/}" ;;
+                '$HOME')      target="$HOME" ;;
+                '$HOME/'*)    target="$HOME/${target#\$HOME/}" ;;
+                '${HOME}')    target="$HOME" ;;
+                '${HOME}/'*)  target="$HOME/${target#\$\{HOME\}/}" ;;
+            esac
+        fi
 
         # Resolve path to absolute (raw — normalization happens next).
         ABS_PATH=""
@@ -550,7 +1921,64 @@ if echo "$COMMAND" | grep -qE 'rm[[:space:]]+-[a-zA-Z]*[rf]'; then
             if [[ "$ABS_PATH" == "/" ]] || \
                [[ -n "$HOME" && "$ABS_PATH" == "$HOME" ]] || \
                [[ "$ABS_PATH" =~ ^/[^/]+$ ]]; then
-                deny "BLOCKED: rm on protected system path: $ABS_PATH"
+                deny "BLOCKED: rm on protected system path: $ABS_PATH" "rm-protected-path"
+            fi
+
+            # Opt-in repo-scoped strict mode (guards.rmScope:"repo" /
+            # LOOM_RM_SCOPE=repo). The catastrophic top-level deny above stays
+            # unconditional; here we additionally DENY any target that is
+            # neither under the repo / worktree areas nor on the built-in
+            # ephemeral allowlist. Default OFF preserves the permissive
+            # behaviour byte-for-byte (rm_scope_repo_enabled() returns false).
+            if rm_scope_repo_enabled; then
+                IN_SCOPE=false
+
+                # Repo + worktree areas. Prefix matches carry a trailing slash
+                # (or match the dir itself) so a sibling dir sharing a name
+                # prefix — e.g. "<repo>-sibling" vs "<repo>" — is NOT admitted.
+                if [[ -n "$REPO_ROOT" ]]; then
+                    if [[ "$ABS_PATH" == "$REPO_ROOT" || "$ABS_PATH" == "$REPO_ROOT"/* ]]; then
+                        IN_SCOPE=true
+                    fi
+                    # The default in-repo worktrees dir is always in scope, even
+                    # when an external worktree.root / LOOM_WORKTREE_ROOT is set.
+                    if [[ "$IN_SCOPE" == false ]] && \
+                       { [[ "$ABS_PATH" == "$REPO_ROOT/.loom/worktrees" || "$ABS_PATH" == "$REPO_ROOT/.loom/worktrees"/* ]]; }; then
+                        IN_SCOPE=true
+                    fi
+                    # Configured/overridden worktree root (external volumes).
+                    if [[ "$IN_SCOPE" == false ]]; then
+                        if [[ -z "${_WT_ROOT+x}" ]]; then
+                            _WT_ROOT=$(resolve_worktree_root "$REPO_ROOT")
+                        fi
+                        if [[ -n "$_WT_ROOT" ]] && \
+                           { [[ "$ABS_PATH" == "$_WT_ROOT" || "$ABS_PATH" == "$_WT_ROOT"/* ]]; }; then
+                            IN_SCOPE=true
+                        fi
+                    fi
+                fi
+
+                # Built-in ephemeral allowlist: system temp roots + the Claude
+                # scratchpad. normalize_abs_path() is LEXICAL — it does NOT
+                # resolve symlinks — so on macOS both the symlink form (/tmp,
+                # /var/tmp, /var/folders) AND its /private target must be listed.
+                # A bare temp root (/tmp, /private/tmp, …) is NOT matched here:
+                # those have no trailing component, so the catastrophic
+                # top-level deny above already handled bare /tmp, and a bare
+                # /private/tmp falls through to the out-of-scope deny.
+                if [[ "$IN_SCOPE" == false ]]; then
+                    case "$ABS_PATH" in
+                        /tmp/*|/private/tmp/*|\
+                        /var/tmp/*|/private/var/tmp/*|\
+                        /var/folders/*|/private/var/folders/*|\
+                        */claude-*/*/scratchpad/*)
+                            IN_SCOPE=true ;;
+                    esac
+                fi
+
+                if [[ "$IN_SCOPE" == false ]]; then
+                    deny "BLOCKED: rm target outside repo scope (guards.rmScope=repo; set guards.rmScope:\"off\" in .claude/skills/repo/config.json to opt out): $ABS_PATH" "rm-scope-outside-repo"
+                fi
             fi
         fi
     done
@@ -561,12 +1989,71 @@ fi
 # =============================================================================
 
 # Gated by the SQL DDL/DML guard toggle. DB-engine repos opt out via
-# guards.sqlDdl:false or REPO_GUARD_SQL=0. sql_guard_enabled() is consulted only
+# guards.sqlDdl:false or LOOM_GUARD_SQL=0. sql_guard_enabled() is consulted only
 # after the DELETE-FROM-without-WHERE match, keeping the config read off the hot
 # path for non-SQL commands.
 if echo "$COMMAND_NO_COMMENT" | grep -qiE 'DELETE[[:space:]]+FROM[[:space:]]+' && \
    ! echo "$COMMAND_NO_COMMENT" | grep -qiE 'WHERE[[:space:]]+'; then
-    sql_guard_enabled && deny "BLOCKED: DELETE FROM without WHERE clause"
+    sql_guard_enabled && deny "BLOCKED: DELETE FROM without WHERE clause" "sql-delete-no-where"
+fi
+
+# =============================================================================
+# FORCE-OP BRANCH SCOPE - branch-aware git push --force / git reset --hard
+#
+# Gated by guards.forceScope / LOOM_FORCE_SCOPE (see force_scope_mode() above).
+#   - "all"       (default): every force op asks — byte-for-byte the pre-#3674
+#                            behaviour, so existing tests still see an ask.
+#   - "protected"          : ask only when the resolved target is a protected
+#                            branch (repo default / main / master) or the branch
+#                            identity is ambiguous (detached HEAD / unresolved);
+#                            own working branches pass straight through.
+#   - "off"                : never ask/deny here.
+#
+# The explicit main/master force-push hard-denies in ALWAYS_BLOCK_PATTERNS above
+# already fired for those forms and are NOT reachable here in ANY mode — this
+# block only ever downgrades to ask/allow, never weakens a hard deny.
+#
+# A cheap pre-check keeps the config read + segment parser off the hot path for
+# the ~99% of commands with no force flag at all.
+# =============================================================================
+if [[ "$COMMAND_NO_COMMENT" == *git* ]] && \
+   echo "$COMMAND_NO_COMMENT" | grep -qE '(--force|--force-with-lease|(^|[[:space:]])-f([[:space:]]|$)|--hard)'; then
+    _FORCE_MODE=$(force_scope_mode)
+    if [[ "$_FORCE_MODE" != "off" ]]; then
+        _FORCE_OPS=$(parse_force_ops "$COMMAND_NO_COMMENT")
+        if [[ -n "$_FORCE_OPS" ]]; then
+            if [[ "$_FORCE_MODE" == "all" ]]; then
+                # Preserve pre-#3674 behaviour byte-for-byte: any force op asks.
+                ask "Command requires confirmation: $COMMAND" "force-op:all"
+            fi
+            # "protected" mode: ask only for protected-branch or ambiguous
+            # targets; allow own working branches. resolve_default_branch() plus
+            # the main/master literals form the protected set.
+            while IFS=$'\037' read -r _fcpath _ftarget; do
+                [[ -z "$_ftarget" ]] && _ftarget="@HEAD@"
+                _fcwd="$_fcpath"
+                [[ -z "$_fcwd" ]] && _fcwd="$CWD"
+                if [[ "$_ftarget" == "@HEAD@" ]]; then
+                    _fbranch=""
+                    if [[ -n "$_fcwd" ]]; then
+                        _fbranch=$(git -C "$_fcwd" symbolic-ref --short HEAD 2>/dev/null || true)
+                    fi
+                    if [[ -z "$_fbranch" ]]; then
+                        # Detached HEAD / unresolved identity is ambiguous — ask,
+                        # never silently allow (fail toward asking).
+                        ask "Command requires confirmation: $COMMAND (force operation on a detached or unresolved branch)" "force-op:detached"
+                    fi
+                    _ftarget="$_fbranch"
+                fi
+                _fdefault=$(resolve_default_branch "$_fcwd")
+                if [[ "$_ftarget" == "main" || "$_ftarget" == "master" ]] || \
+                   { [[ -n "$_fdefault" && "$_ftarget" == "$_fdefault" ]]; }; then
+                    ask "Command requires confirmation: $COMMAND (force operation targets protected branch '$_ftarget')" "force-op:protected"
+                fi
+            done <<< "$_FORCE_OPS"
+            # No protected/ambiguous target matched — fall through to allow.
+        fi
+    fi
 fi
 
 # =============================================================================
@@ -574,66 +2061,184 @@ fi
 # =============================================================================
 
 ASK_PATTERNS=(
-    # Git destructive operations (not on main/master - those are blocked above)
-    'git push --force'
-    'git push -f '
-    'git reset --hard'
-    'git clean -fd'
-    'git checkout \.'
-    'git restore \.'
+    # NOTE: the force-op patterns (git push --force / -f / --force-with-lease and
+    # git reset --hard) are NOT in this ungated array. They are handled by the
+    # branch-aware FORCE-OP BRANCH SCOPE block above, gated by
+    # force_scope_mode() (guards.forceScope / LOOM_FORCE_SCOPE, #3674), so an
+    # autonomous agent can force-push / hard-reset its own working branch without
+    # a stall while protected-branch force ops still ask. git clean / checkout .
+    # / restore . stay here — they are not force ops and have no branch scope.
+    #
+    # COMMAND-POSITION ANCHORING (#3756): every entry is prefixed with
+    # `(^|[;&|[:space:]])`, mirroring ALWAYS_BLOCK_PATTERNS's `gh repo delete`
+    # anchor (#3553), so the phrase only fires at start-of-command or after a
+    # shell separator — an ask-phrase that merely appears inside another
+    # command's quoted argument (e.g. `jq -n '{cmd:"gh issue close 123"}'`, the
+    # phrase preceded by `"`) no longer false-asks. Entries whose command is a
+    # multi-word phrase (`kubectl rollout restart`, `git checkout \.`) are
+    # anchored at the FIRST token only — the phrase's leading command word — per
+    # the `gh repo delete` precedent. (Like the catastrophic tier, this anchor
+    # cannot distinguish a real separator from a whitespace INSIDE a quoted
+    # string, so a mid-quote prose mention such as `echo "… gh pr close …"` still
+    # matches on its leading space — an accepted limitation shared with the
+    # ALWAYS_BLOCK tier; command-word segment classification is #3757's scope.)
+    '(^|[;&|[:space:]])git clean -fd'
+    '(^|[;&|[:space:]])git checkout \.'
+    '(^|[;&|[:space:]])git restore \.'
 
-    # GitHub operations that modify shared state
-    'gh pr close'
-    'gh issue close'
-    'gh release delete'
-    'gh label delete'
+    # GitHub operations that are genuinely hard to reverse. `gh release delete`
+    # removes published artifacts/tags — it STAYS an ungated ask. The reversible
+    # GitHub state changes (`gh pr close`, `gh issue close`, `gh label delete`)
+    # were REMOVED from this array (#3757): they are trivially undone (gh pr
+    # reopen / gh issue reopen / recreate the label) and are only asked for when
+    # a repo opts IN via guards.reversibleGh (REVERSIBLE_GH_ASK_PATTERNS below).
+    '(^|[;&|[:space:]])gh release delete'
 
-    # Cloud CLI operations
-    'aws s3'
-    'aws ec2'
-    'aws lambda'
+    # NOTE: cloud CLI (aws) + docker ASK patterns are NOT in this ungated array.
+    # They live in CLOUD_ASK_PATTERNS below, gated by cloud_guard_enabled() so
+    # cloud-dev repos can opt down (LOOM_GUARD_CLOUD=0 / guards.cloudCli:false).
 
-    # Docker operations
+    # Service management
+    '(^|[;&|[:space:]])systemctl restart'
+    '(^|[;&|[:space:]])systemctl stop'
+    '(^|[;&|[:space:]])systemctl disable'
+
+    # Kubernetes operations
+    '(^|[;&|[:space:]])kubectl delete'
+    '(^|[;&|[:space:]])kubectl rollout restart'
+    '(^|[;&|[:space:]])kubectl drain'
+
+    # SkyPilot infrastructure
+    '(^|[;&|[:space:]])sky down'
+    '(^|[;&|[:space:]])sky stop'
+
+    # Credential exposure
+    '(^|[;&|[:space:]])printenv.*SECRET'
+    '(^|[;&|[:space:]])printenv.*TOKEN'
+    '(^|[;&|[:space:]])printenv.*KEY'
+    '(^|[;&|[:space:]])cat.*/\.ssh/'
+    '(^|[;&|[:space:]])cat.*/\.aws/credentials'
+)
+
+for pattern in "${ASK_PATTERNS[@]}"; do
+    if echo "$COMMAND_ASK_SCAN" | grep -qE "$pattern"; then
+        ask "Command requires confirmation: $COMMAND" "ask:$pattern"
+    fi
+done
+
+# =============================================================================
+# REVERSIBLE-GITHUB ASK patterns — gated by the reversible-gh guard toggle (#3757)
+#
+# Kept OUT of the ungated ASK_PATTERNS array (mirroring the CLOUD_ASK_PATTERNS
+# split) because these GitHub state changes are trivially reversible and should
+# NOT prompt by default — an autonomous agent closing its own issue/PR as part of
+# a normal lifecycle would otherwise stall. reversible_gh_guard_enabled() defaults
+# OFF and is consulted only AFTER a pattern matches, so the config read stays off
+# the hot path for non-matching commands (mirrors the SQL DDL / cloud blocks).
+#
+# These entries are anchored (#3756) and scanned against COMMAND_ASK_SCAN — the
+# comment-stripped, literal-text-redacted ask working copy — exactly as they were
+# while living in ASK_PATTERNS, so #3756's redaction still applies when the toggle
+# is opted IN (an ask-phrase quoted inside a --body/--comment value does not
+# false-ask). `gh release delete` deliberately stays in the ungated ASK_PATTERNS
+# above (hard to reverse) and is NOT gated here.
+# =============================================================================
+REVERSIBLE_GH_ASK_PATTERNS=(
+    '(^|[;&|[:space:]])gh pr close'
+    '(^|[;&|[:space:]])gh issue close'
+    '(^|[;&|[:space:]])gh label delete'
+)
+
+for pattern in "${REVERSIBLE_GH_ASK_PATTERNS[@]}"; do
+    if echo "$COMMAND_ASK_SCAN" | grep -qE "$pattern" && reversible_gh_guard_enabled; then
+        ask "Command requires confirmation: $COMMAND (set guards.reversibleGh:true in .claude/skills/repo/config.json to keep this ask; it is off by default because the op is trivially reversible)" "reversible-gh:$pattern"
+    fi
+done
+
+# =============================================================================
+# git read-tree WITHOUT an isolating GIT_INDEX_FILE assignment
+#
+# A bare `git read-tree` (no tree-ish, no isolated index) is equivalent to
+# `git read-tree --empty`: it clobbers the repository's REAL staging index,
+# turning every tracked file into a phantom staged deletion. The working tree
+# and HEAD are left untouched and NO reflog entry is written, so the corruption
+# is silent and near-invisible (issue #3637 — a judge ran one against the main
+# checkout during a merge simulation and emptied the live index).
+#
+# This is an ASK (not a deny) because it is generic git hygiene, not a Loom
+# workflow rule, and an isolated form is legitimate. It is kept narrow: the
+# safe, index-free path is `git merge-tree --write-tree <base> <branch>` for a
+# merge preview, or `GIT_INDEX_FILE=$(mktemp) git read-tree <tree>` when a
+# temporary index really is needed. Any command that carries a `GIT_INDEX_FILE=`
+# assignment is treated as isolated and passes through untouched.
+#
+# `git commit-tree` is intentionally NOT guarded here — it writes a commit
+# object from an existing tree and does not mutate the index.
+# =============================================================================
+if echo "$COMMAND_NO_COMMENT" | grep -qE '(^|[;&|(]|[[:space:]])git[[:space:]]+read-tree'; then
+    # Isolated form (GIT_INDEX_FILE=... git read-tree ...) is allowed.
+    if ! echo "$COMMAND_NO_COMMENT" | grep -qE 'GIT_INDEX_FILE='; then
+        ask "Command requires confirmation: $COMMAND (a bare 'git read-tree' empties the real staging index with no reflog trace; use 'git merge-tree --write-tree <base> <branch>' for a merge preview, or isolate with GIT_INDEX_FILE=\$(mktemp))" "git-read-tree"
+    fi
+fi
+
+# =============================================================================
+# CLOUD CLI ASK patterns — gated by the cloud CLI guard toggle
+#
+# Kept separate from ASK_PATTERNS so cloud-dev repos can opt out
+# (guards.cloudCli:false / LOOM_GUARD_CLOUD=0). cloud_guard_enabled() is
+# consulted only AFTER a cloud pattern matches, so the config read stays off the
+# hot path for non-cloud commands (mirrors the SQL DDL block above).
+#
+# The aws entries are VERB-ANCHORED (case-sensitive ERE against the
+# comment-stripped command): only mutating subcommands match, never read-only
+# describe*/get*/list*/ls. So `aws ec2 describe-instances`, `aws s3 ls`, and
+# `aws lambda list-functions` no longer prompt, while `run-instances`,
+# `create-*`, `terminate-instances`, `stop-instances`, `lambda invoke`,
+# `lambda publish*`, `sns publish`, etc. still ask.
+#
+# The docker entries already name only mutating verbs (rm/rmi/stop/kill/restart)
+# and never match read-only `docker ps`/`docker logs`, so they are unchanged —
+# they only move under this toggle.
+# =============================================================================
+CLOUD_ASK_PATTERNS=(
+    # aws mutating subcommands (verb-anchored). The service list covers the
+    # common infra-mutating namespaces; the verb list is the mutating vocabulary
+    # (never describe*/get*/list*/ls). terminate lands here — an ask, not a deny.
+    # invoke/publish are mutating (lambda invoke runs arbitrary code with side
+    # effects; lambda publish-version / publish-layer-version and sns publish
+    # mutate state) — there is no read-only `aws <svc> invoke|publish`, so they
+    # cannot introduce describe/get/list false-positives. copy (ec2
+    # copy-image/copy-snapshot) and assign (ec2 assign-*-addresses) are likewise
+    # mutating-only. All were caught by the pre-#3593 bare `aws ec2|lambda`
+    # prefixes and must stay asks (#3595).
+    'aws (ec2|lambda|s3api|rds|iam|autoscaling|cloudformation|eks|ecs|elb|elbv2|route53|dynamodb|sns|sqs) (run|create|delete|terminate|stop|start|modify|update|put|reboot|authorize|revoke|attach|detach|associate|disassociate|register|deregister|enable|disable|add|remove|set|import|restore|reset|cancel|scale|invoke|publish|copy|assign)'
+    # aws s3 (high-level) mutating verbs. `ls` is intentionally excluded. `mb`
+    # (make-bucket) is mutating and was caught by the old bare `aws s3` prefix.
+    'aws s3 (rm|rb|cp|mv|sync|mb)'
+
+    # Docker operations (already mutating-verb only; does not match docker ps/logs)
     'docker rm'
     'docker rmi'
     'docker stop'
     'docker kill'
     'docker restart'
-
-    # Service management
-    'systemctl restart'
-    'systemctl stop'
-    'systemctl disable'
-
-    # Kubernetes operations
-    'kubectl delete'
-    'kubectl rollout restart'
-    'kubectl drain'
-
-    # SkyPilot infrastructure
-    'sky down'
-    'sky stop'
-
-    # Credential exposure
-    'printenv.*SECRET'
-    'printenv.*TOKEN'
-    'printenv.*KEY'
-    'cat.*/\.ssh/'
-    'cat.*/\.aws/credentials'
 )
 
-for pattern in "${ASK_PATTERNS[@]}"; do
-    # When the cloud-CLI guard is toggled off, skip the broad aws/docker
-    # namespace asks (they fire on read-only describe/ls too). The credential-
-    # exposure and non-cloud asks below still apply.
-    case "$pattern" in
-        'aws s3'|'aws ec2'|'aws lambda'|'docker rm'|'docker rmi'|'docker stop'|'docker kill'|'docker restart')
-            cloud_guard_enabled || continue ;;
-    esac
-    if echo "$COMMAND_NO_COMMENT" | grep -qE "$pattern"; then
-        ask "Command requires confirmation: $COMMAND"
+for pattern in "${CLOUD_ASK_PATTERNS[@]}"; do
+    if echo "$COMMAND_NO_COMMENT" | grep -qE "$pattern" && cloud_guard_enabled; then
+        ask "Command requires confirmation: $COMMAND (set guards.cloudCli:false in .claude/skills/repo/config.json if this repo manages cloud infra as a first-class workflow)" "cloud-cli:$pattern"
     fi
 done
+
+# =============================================================================
+# NOTE: This file is the CANONICAL generic repository-hygiene guard
+# (rjwalters/repo#30). Loom-workflow-specific guards (the 'gh pr merge' →
+# merge-pr.sh redirect, the 'pip install -e' worktree block) live in Loom's
+# guard-loom-workflow.sh, registered as a separate PreToolUse/Bash hook that
+# fires independently of this one — orchestration concerns stay with the
+# orchestrator, generic protection lives here.
+# =============================================================================
 
 # =============================================================================
 # ALLOW - Everything else passes through

--- a/.claude/skills/repo/hooks/session-start-handoff.sh
+++ b/.claude/skills/repo/hooks/session-start-handoff.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# session-start-handoff.sh - SessionStart hook that surfaces a pending
+# /repo:handoff note at the start of a Claude Code session.
+#
+# Part of Repo Skills (https://github.com/rjwalters/repo), installed by
+# install.sh into .claude/skills/repo/hooks/ and wired into the consumer repo's
+# .claude/settings.json under hooks.SessionStart (matchers "startup" and
+# "resume").
+#
+# WHY: /repo:handoff writes .claude/handoff.md and adds a pointer line to the
+# agent's memory index. That makes the note findable, but nothing announces it,
+# and the command's one-shot contract ("read it, then delete it") means a note
+# that never gets absorbed lingers silently. handoff.md calls a stale note "a
+# trap of its own". This hook makes both facts visible at session start.
+#
+# =============================================================================
+# STABLE INTERFACE (the contract install.sh/uninstall.sh and the tests rely on)
+# =============================================================================
+#
+# Input:  JSON on stdin (Claude Code SessionStart payload). Fields consumed:
+#           .cwd    - the session's working directory
+#           .source - "startup" | "resume" | "clear" | "compact" | "fork"
+#         Anything else in the payload is ignored.
+#
+# Output: silence + exit 0  => nothing to surface;  otherwise EXACTLY one JSON
+#         object on stdout:
+#           { "hookSpecificOutput": { "hookEventName": "SessionStart",
+#               "additionalContext": "..." } }
+#         The "hookEventName" field is REQUIRED by Claude Code's schema -
+#         without it the additionalContext is silently discarded.
+#
+# Exit:   ALWAYS 0, on every path including internal error. SessionStart has no
+#         decision control (a hook cannot block session start), so the only
+#         thing a failure here can accomplish is noise in the transcript.
+#
+# Errors: this script MUST never exit non-zero and never emit invalid output.
+#         Any internal error is caught by the ERR trap, logged to
+#         <script-dir>/../logs/hook-errors.log, and resolves to silence (fail
+#         open) - mirroring guard-destructive.sh's convention.
+#
+# READ-ONLY: this hook never writes, deletes, or modifies .claude/handoff.md or
+#         any other file in the repo. Deleting the note after it is absorbed is
+#         the /repo:handoff one-shot contract's job, not this hook's. The only
+#         file it may ever write is its own diagnostic error log.
+#
+# SOURCE GATING: only "startup" and "resume" are acted on. install.sh wires
+#         exactly those two matchers, and this script re-checks .source anyway
+#         so a hand-edited settings.json that routes "clear"/"compact"/"fork"
+#         here still no-ops. A /clear is not a process relaunch and the note has
+#         not been touched, so repeating the banner there is pure noise.
+# =============================================================================
+
+# Age thresholds (hours). STALE_HOURS is the ">7d" line handoff.md warns about.
+RECENT_HOURS=48
+STALE_HOURS=168
+
+# Payload sizing (issue #33). When the note is small enough (<= MAX_BODY_BYTES)
+# it is cheap to inline verbatim on every launch, and the full body is what
+# carries the actionable content - a headers-only outline conveys shape but
+# nothing to act on. Above that cap we fall back to a headers-only outline
+# (capped at MAX_HEADERS) plus a loud oversize warning, bounding the pathological
+# case. The 10 KB cap comfortably covers the ~9 KB real-world note that motivated
+# the hook, and /repo:handoff's exclusion discipline is designed to keep notes
+# short, so the common case inlines.
+MAX_BODY_BYTES=10240
+MAX_HEADERS=9
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null || echo ".")"
+HOOK_ERROR_LOG="${SCRIPT_DIR}/../logs/hook-errors.log"
+
+# Log a diagnostic error message (best-effort, never fails the script).
+log_hook_error() {
+    local msg="$1"
+    mkdir -p "$(dirname "$HOOK_ERROR_LOG")" 2>/dev/null || true
+    echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] [session-start-handoff] $msg" >> "$HOOK_ERROR_LOG" 2>/dev/null || true
+}
+
+# Top-level error trap: on ANY unexpected error, emit nothing and exit 0. Note
+# this exits BEFORE any stdout is produced (the single printf below is the last
+# statement in the script), so the trap can never truncate a half-written JSON
+# object into malformed output.
+trap 'log_hook_error "Unexpected error on line ${LINENO}: ${BASH_COMMAND:-unknown} (exit=$?)"; exit 0' ERR
+
+# Read stdin safely - if cat fails, the ERR trap fires and we stay silent.
+INPUT=$(cat 2>/dev/null) || INPUT=""
+
+# jq is how we both parse the payload and build well-formed output. Without it
+# we cannot guarantee valid JSON, so stay silent rather than hand-roll one.
+if ! command -v jq &>/dev/null; then
+    log_hook_error "jq not found in PATH - emitting no context"
+    exit 0
+fi
+
+SOURCE=$(printf '%s' "$INPUT" | jq -r '.source // empty' 2>/dev/null) || SOURCE=""
+CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || CWD=""
+
+# Source gating. An absent/unparseable source means malformed input, which
+# fails open to silence rather than guessing.
+case "$SOURCE" in
+    startup|resume) ;;
+    *) exit 0 ;;
+esac
+
+# Resolve the repo root from cwd (handles worktrees). Fall back to cwd itself
+# when it is not a git repo, mirroring the original proposal's
+# `root=$(git rev-parse --show-toplevel) || root=$PWD`.
+[[ -n "$CWD" && -d "$CWD" ]] || exit 0
+REPO_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null) || REPO_ROOT=""
+[[ -n "$REPO_ROOT" ]] || REPO_ROOT="$CWD"
+
+NOTE="$REPO_ROOT/.claude/handoff.md"
+[[ -f "$NOTE" && -r "$NOTE" ]] || exit 0
+
+# Portable mtime: BSD/macOS `stat -f %m` vs GNU `stat -c %Y`. If neither works
+# we cannot compute age, so skip the banner entirely rather than emit a partial
+# one or error out.
+MTIME=$(stat -f %m "$NOTE" 2>/dev/null) || MTIME=""
+[[ -n "$MTIME" ]] || MTIME=$(stat -c %Y "$NOTE" 2>/dev/null) || MTIME=""
+[[ "$MTIME" =~ ^[0-9]+$ ]] || { log_hook_error "could not stat mtime of $NOTE - emitting no context"; exit 0; }
+
+NOW=$(date +%s 2>/dev/null) || NOW=""
+[[ "$NOW" =~ ^[0-9]+$ ]] || exit 0
+
+AGE_H=$(( (NOW - MTIME) / 3600 ))
+# Clock skew / a future mtime would otherwise produce a negative age. Written as
+# an `if` rather than `(( )) &&` so the arithmetic test's non-zero status in the
+# common case can never reach the ERR trap.
+if (( AGE_H < 0 )); then AGE_H=0; fi
+
+if   (( AGE_H < 1 ));             then AGE_LABEL="just now"
+elif (( AGE_H < RECENT_HOURS ));  then AGE_LABEL="${AGE_H}h old"
+else                                   AGE_LABEL="$(( AGE_H / 24 ))d old"
+fi
+
+CONTEXT="A /repo:handoff note is pending in this repository.
+
+  Path: $NOTE
+  Age:  $AGE_LABEL"
+
+if (( AGE_H >= STALE_HOURS )); then
+    CONTEXT="$CONTEXT
+  STALE: this note is older than 7 days. A handoff describes one moment; verify
+         every claim in it against the repo before acting on it."
+fi
+
+# Payload policy (issue #33). Under the size cap, inline the full note body -
+# that is where the load-bearing, actionable content lives; a headers-only
+# outline conveys shape but nothing to act on, which was the observed failure.
+# Above the cap, fall back to that outline plus an explicit oversize warning so a
+# pathological note cannot bloat every launch. The read-in-full / one-shot
+# directive below is appended in BOTH branches.
+NOTE_BYTES=$(wc -c < "$NOTE" 2>/dev/null | tr -d '[:space:]') || NOTE_BYTES=""
+[[ "$NOTE_BYTES" =~ ^[0-9]+$ ]] || NOTE_BYTES=0
+
+if (( NOTE_BYTES <= MAX_BODY_BYTES )); then
+    # Full body inline. `|| BODY=""` keeps a read failure on the fail-open path.
+    BODY=$(cat "$NOTE" 2>/dev/null) || BODY=""
+    CONTEXT="$CONTEXT
+
+The full note follows between the markers - read it now:
+
+----- BEGIN HANDOFF NOTE -----
+$BODY
+----- END HANDOFF NOTE -----"
+else
+    # Oversize fallback: headers only. `|| true` because grep exits 1 when the
+    # note has no headers at all (a valid, non-error state) and head closing the
+    # pipe early can surface as a non-zero status.
+    HEADERS=$(grep -E '^#{1,2} ' "$NOTE" 2>/dev/null | head -n "$MAX_HEADERS" | sed 's/^#* *//' || true)
+    CONTEXT="$CONTEXT
+  OVERSIZE: this note is ${NOTE_BYTES} bytes, above the ${MAX_BODY_BYTES}-byte
+            inline cap, so only its section headers are shown below. Open the
+            note and read it in full now - the actionable detail is in the body,
+            not these headers."
+    if [[ -n "$HEADERS" ]]; then
+        CONTEXT="$CONTEXT
+
+Sections:
+$(printf '%s\n' "$HEADERS" | sed 's/^/  - /')"
+    fi
+fi
+
+CONTEXT="$CONTEXT
+
+Read the note in full before doing anything else. Per the /repo:handoff one-shot
+contract, once you have absorbed it, delete both the note and its pointer line
+in the memory index - promote anything durable into real memory files or issues."
+
+OUTPUT=$(jq -cn --arg ctx "$CONTEXT" \
+    '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $ctx}}' 2>/dev/null) || OUTPUT=""
+
+# Never emit anything if jq could not build well-formed JSON.
+[[ -n "$OUTPUT" ]] || { log_hook_error "jq failed to build output JSON - emitting no context"; exit 0; }
+
+printf '%s\n' "$OUTPUT"
+exit 0

--- a/.claude/skills/repo/install-metadata.json
+++ b/.claude/skills/repo/install-metadata.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.4.3",
-  "commit": "a4962b3",
+  "version": "0.7.0",
+  "commit": "1f338f3",
   "dev": false,
-  "commands": ["all","audit","branches","docs","followups","gitignore","help","links","orphans","readme","release","remote","reset","tidy","update-tools"]
+  "commands": ["all","audit","branches","docs","followups","gitignore","handoff","help","host-optimize","links","orphans","readme","release","remote","reset","sudo","tidy","update-tools"]
 }

--- a/.claude/skills/repo/scripts/repo-remote.sh
+++ b/.claude/skills/repo/scripts/repo-remote.sh
@@ -1,0 +1,790 @@
+#!/usr/bin/env bash
+# repo-remote.sh — headless, scriptable entry point for /repo:remote provisioning.
+#
+# This is the non-interactive implementation of the provisioning contract
+# documented (as prose) in commands/repo/remote.md. The interactive skill wraps
+# this script with its wizard / cost-confirmation UX and, once the human has
+# confirmed, calls `repo-remote up --yes`; a caller such as loom's
+# `fleet add-worker` invokes the same `up --yes --json` path directly. There is
+# ONE implementation of the contract so the two paths cannot drift (repo#52).
+#
+# The seam this produces, consumed by loom fleet orchestration: "a reachable
+# Ubuntu box, this repo's SSH alias written, instance id recorded" — emitted as
+# machine-readable JSON (instance id, public IP, SSH alias, estimated hourly
+# cost) so a caller can implement loom's "plan shown before money is spent" rule.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# STABLE INTERFACE (downstream tooling gates on this via the package version)
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Subcommands (both the `up`/`down`/`status` verbs and the remote.md-style
+# `--status`/`--down` flags are accepted, for parity with the prose command):
+#
+#   repo-remote up [--yes] [--json] [aws|gcp]     Provision (or reuse) an instance.
+#       Without --yes: a DRY-RUN plan (resolved spec + estimated cost) is emitted
+#       and NOTHING is created — this is the "plan shown before money spent" path.
+#       With --yes: the plan is executed. --yes removes the *prompt*, never the
+#       *consent requirement*: a cost-relevant field missing from config is a
+#       loud, non-zero-exit failure, never a silent default (repo#52 cost gate).
+#
+#   repo-remote status|--status [--json] [aws|gcp]   List instances this command
+#       created (tagged repo-remote=<name>) with state; no mutation.
+#
+#   repo-remote down|--down [--yes] [--delete] [--json] [aws|gcp]   Teardown.
+#       Without --yes: a DRY-RUN listing of exactly what would stop/terminate.
+#       With --yes: stop them; add --delete to terminate (disk goes with it).
+#
+# Config: two layers, shared first then repo (repo overrides), matching the
+# skill exactly:
+#   1. ${XDG_CONFIG_HOME:-$HOME/.config}/repo/remote.env   (shared cloud creds)
+#   2. <git-root>/.env                                     (per-repo machine)
+#
+# Cost gate (repo#52 — the highest-cost-of-being-wrong element): `up` (with or
+# without --yes) REQUIRES the provider, that provider's credentials, and
+# REPO_REMOTE_INSTANCE_TYPE to be present in config. Instance type is the
+# cost-relevant field and is NEVER defaulted here — that removes interactivity,
+# not consent. Non-cost-relevant fields (disk, idle window, image) do fall back
+# to built-in defaults, matching the prose command.
+#
+# Exit codes:
+#   0  success (including a dry-run plan)
+#   2  missing / invalid required config (the cost gate; loud failure)
+#   3  provider authentication failed
+#   4  cloud operation failed
+#   64 usage error
+#
+# Testability hooks (honored so the suite can exercise the full contract against
+# mocked cloud CLIs without touching real infrastructure or a real ~/.ssh):
+#   XDG_CONFIG_HOME            locates the shared remote.env (already standard)
+#   REPO_REMOTE_SSH_CONFIG     SSH config file to write the alias into
+#                              (default: ~/.ssh/config)
+#   PATH                       mock `aws`/`gcloud` are picked up from PATH
+#
+set -uo pipefail
+
+# ── output helpers ──────────────────────────────────────────────────────────
+_is_tty() { [[ -t 2 ]]; }
+log()  { printf '%s\n' "repo-remote: $*" >&2; }
+die()  { local code="$1"; shift; printf '%s\n' "repo-remote: ERROR: $*" >&2; exit "$code"; }
+
+JSON_OUT=false   # --json
+YES=false        # --yes
+DELETE=false     # --down --delete
+ACTION=""        # up | down | status
+PROVIDER_ARG=""  # aws | gcp (positional override)
+
+# ── JSON emission (no jq dependency for output; values are controlled) ──────
+# json_escape <string> -> a JSON string body (without surrounding quotes)
+json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\t'/\\t}"
+  s="${s//$'\r'/}"
+  printf '%s' "$s"
+}
+
+# ── config loading ──────────────────────────────────────────────────────────
+# Load the two env layers into the environment, shared first then repo (repo
+# wins because it is sourced last). Mirrors commands/repo/remote.md step 2.
+SHARED_ENV=""
+REPO_ENV=""
+GIT_ROOT=""
+
+resolve_paths() {
+  SHARED_ENV="${XDG_CONFIG_HOME:-$HOME/.config}/repo/remote.env"
+  GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  [[ -n "$GIT_ROOT" ]] && REPO_ENV="$GIT_ROOT/.env"
+}
+
+load_config() {
+  set -a
+  # shellcheck disable=SC1090
+  [[ -f "$SHARED_ENV" ]] && . "$SHARED_ENV"
+  # shellcheck disable=SC1090
+  [[ -n "$REPO_ENV" && -f "$REPO_ENV" ]] && . "$REPO_ENV"
+  set +a
+}
+
+# ── effective settings ──────────────────────────────────────────────────────
+PROVIDER=""
+NAME=""
+INSTANCE_TYPE=""
+INSTANCE_ID=""
+DISK_GB=""
+IMAGE=""
+GPU_ACCEL=""       # GCP accelerator string, e.g. nvidia-l4:1
+IDLE_MIN=""
+IS_GPU=false
+REGION=""
+COST_HOURLY=""
+COST_APPROX=false
+
+# GPU-family detection: infer a GPU host from the instance family so the caller
+# needn't set a separate flag (remote.md "GPU hosts").
+is_gpu_family() {  # <provider> <instance-type>
+  local p="$1" t="$2"
+  [[ -n "${GPU_ACCEL:-}" ]] && return 0
+  case "$p" in
+    aws) [[ "$t" =~ ^(g3|g4|g4dn|g5|g5g|g6|g6e|p2|p3|p4|p4d|p5)\. ]] && return 0 ;;
+    gcp) [[ "$t" =~ ^(g2|a2|a3)- ]] && return 0 ;;
+  esac
+  return 1
+}
+
+# Approximate on-demand USD/hour by instance type. Unknown types fall back to a
+# GPU/non-GPU heuristic flagged approximate — the JSON always carries a number
+# so a caller can implement a budget check, and never silently claims precision.
+estimate_cost() {  # sets COST_HOURLY, COST_APPROX
+  local t="$1"
+  COST_APPROX=false
+  case "$t" in
+    # AWS general purpose / compute
+    t3.medium)   COST_HOURLY=0.0416 ;;
+    t3.large)    COST_HOURLY=0.0832 ;;
+    t3.xlarge)   COST_HOURLY=0.1664 ;;
+    t3.2xlarge)  COST_HOURLY=0.3328 ;;
+    m5.large)    COST_HOURLY=0.096  ;;
+    m5.xlarge)   COST_HOURLY=0.192  ;;
+    m5.2xlarge)  COST_HOURLY=0.384  ;;
+    m5.4xlarge)  COST_HOURLY=0.768  ;;
+    m6i.xlarge)  COST_HOURLY=0.192  ;;
+    m6i.2xlarge) COST_HOURLY=0.384  ;;
+    c5.xlarge)   COST_HOURLY=0.17   ;;
+    c5.2xlarge)  COST_HOURLY=0.34   ;;
+    c5.4xlarge)  COST_HOURLY=0.68   ;;
+    # AWS GPU
+    g4dn.xlarge) COST_HOURLY=0.526  ;;
+    g5.xlarge)   COST_HOURLY=1.006  ;;
+    g5.2xlarge)  COST_HOURLY=1.212  ;;
+    g6.xlarge)   COST_HOURLY=0.8048 ;;
+    g6e.xlarge)  COST_HOURLY=1.861  ;;
+    g6e.2xlarge) COST_HOURLY=2.242  ;;
+    p4d.24xlarge) COST_HOURLY=32.77 ;;
+    # GCP predefined
+    e2-standard-2)  COST_HOURLY=0.067 ;;
+    e2-standard-4)  COST_HOURLY=0.134 ;;
+    e2-standard-8)  COST_HOURLY=0.268 ;;
+    n1-standard-4)  COST_HOURLY=0.19  ;;
+    n1-standard-8)  COST_HOURLY=0.38  ;;
+    g2-standard-4)  COST_HOURLY=0.71  ;;
+    g2-standard-8)  COST_HOURLY=0.85  ;;
+    a2-highgpu-1g)  COST_HOURLY=3.67  ;;
+    *)
+      COST_APPROX=true
+      if [[ "$IS_GPU" == true ]]; then COST_HOURLY=1.50; else COST_HOURLY=0.20; fi
+      ;;
+  esac
+  # A GCP accelerator adds to the machine price; fold in a rough per-card cost so
+  # the estimate for GPU-on-GCP is not silently the bare-machine price.
+  if [[ -n "${GPU_ACCEL:-}" && "$PROVIDER" == gcp ]]; then
+    COST_APPROX=true
+    COST_HOURLY="$(awk -v c="$COST_HOURLY" 'BEGIN{printf "%.4f", c + 0.70}')"
+  fi
+}
+
+resolve_settings() {
+  PROVIDER="${PROVIDER_ARG:-${REPO_REMOTE_PROVIDER:-}}"
+  # lower-case the provider
+  PROVIDER="$(printf '%s' "$PROVIDER" | tr '[:upper:]' '[:lower:]')"
+
+  NAME="$(basename "${GIT_ROOT:-$PWD}")"
+
+  INSTANCE_TYPE="${REPO_REMOTE_INSTANCE_TYPE:-}"
+  INSTANCE_ID="${REPO_REMOTE_INSTANCE_ID:-}"
+  GPU_ACCEL="${REPO_REMOTE_GPU:-}"
+  IMAGE="${REPO_REMOTE_IMAGE:-}"
+
+  # Non-cost-relevant fields DO fall back to defaults (matches the prose command).
+  DISK_GB="${REPO_REMOTE_DISK_GB:-50}"
+  IDLE_MIN="${REPO_REMOTE_IDLE_SHUTDOWN_MIN:-120}"
+  # Idle-exit marker contract (see commands/repo/remote.md). A daemon-managed
+  # host (e.g. one running loom-daemon) may write this file on clean idle-exit;
+  # the guard treats its mtime as an authoritative "idle since" timestamp. The
+  # path is always embedded in the guard so the contract is self-contained and
+  # works standalone — it stays inert until the file actually exists on-host.
+  IDLE_MARKER="${REPO_REMOTE_IDLE_MARKER:-/var/run/repo-remote-daemon-idle.marker}"
+
+  case "$PROVIDER" in
+    aws) REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}" ;;
+    gcp) REGION="${GCP_ZONE:-}" ;;
+  esac
+
+  if [[ -n "$INSTANCE_TYPE" ]] && is_gpu_family "$PROVIDER" "$INSTANCE_TYPE"; then
+    IS_GPU=true
+  fi
+  [[ -n "$INSTANCE_TYPE" ]] && estimate_cost "$INSTANCE_TYPE"
+}
+
+# ── the cost gate ───────────────────────────────────────────────────────────
+# Enforce that every field whose absence could cause an *unexpected* bill is
+# present in config. This is what makes `--yes` safe: it removes the interactive
+# prompt but not the requirement that the human pre-supplied the budget-relevant
+# choices. Missing config fails loudly (exit 2), never a silent default.
+require_cost_config() {
+  local missing=()
+
+  [[ -n "$PROVIDER" ]] || missing+=("REPO_REMOTE_PROVIDER (or an aws|gcp argument)")
+  case "$PROVIDER" in
+    aws)
+      [[ -n "${AWS_ACCESS_KEY_ID:-}" ]]     || missing+=("AWS_ACCESS_KEY_ID")
+      [[ -n "${AWS_SECRET_ACCESS_KEY:-}" ]] || missing+=("AWS_SECRET_ACCESS_KEY")
+      [[ -n "$REGION" ]]                    || missing+=("AWS_REGION")
+      ;;
+    gcp)
+      [[ -n "${GCP_PROJECT:-}" ]]                     || missing+=("GCP_PROJECT")
+      [[ -n "$REGION" ]]                              || missing+=("GCP_ZONE")
+      [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]  || missing+=("GOOGLE_APPLICATION_CREDENTIALS")
+      ;;
+    "") : ;;  # provider itself already reported above
+    *)  die 2 "unknown provider '$PROVIDER' (expected aws or gcp)" ;;
+  esac
+
+  # THE cost-relevant field. Never defaulted — an unpinned instance type is
+  # exactly how an unexpected bill happens.
+  [[ -n "$INSTANCE_TYPE" ]] || missing+=("REPO_REMOTE_INSTANCE_TYPE (required — no default, so a run never silently picks a billable size)")
+
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    local m
+    log "cannot proceed — required config is missing (no silent defaults for cost-relevant fields):"
+    for m in "${missing[@]}"; do log "  - $m"; done
+    log "set them in ${SHARED_ENV} (shared) or ${REPO_ENV:-<git-root>/.env} (per-repo), or run /repo:remote --configure."
+    exit 2
+  fi
+}
+
+# ── the idle-shutdown guard (cloud-init user-data) ──────────────────────────
+# A forgotten VM — GPU ones especially — must turn itself off. Emitted as a
+# cloud-init script that installs a cron watchdog running `shutdown -h` after
+# IDLE_MIN minutes with no active SSH session and low CPU.
+#
+# "Activity" is defined by exactly two local signals: an open SSH session (`who`)
+# OR CPU load average > 0.2. There is NO process-name veto — a running daemon
+# (loom-daemon or otherwise) does NOT, by itself, keep this host alive. If a
+# future daemon-presence veto is ever wanted it must be added deliberately here
+# and documented; it is not implied by the current logic.
+#
+# Idle-exit marker contract (published by this repo so a daemon side can conform
+# without this repo depending on it): when $IDLE_MARKER exists on-host, the guard
+# treats its mtime as an authoritative "idle since" timestamp and shuts down
+# IDLE_MIN minutes after that mtime — REPLACING (not supplementing) its own
+# $STAMP-based countdown start for that pass. A daemon that idle-exits cleanly can
+# `touch` this file to hand the guard a precise idle-start instead of waiting for
+# the guard's own load-average sampling to first read idle. The guard works
+# standalone: with no marker file present it falls back to the unchanged
+# who/load/$STAMP behavior. The marker path is always embedded (default below,
+# overridable via REPO_REMOTE_IDLE_MARKER) so the branch is inert-but-ready.
+idle_guard_userdata() {
+  cat <<EOF
+#!/bin/bash
+# repo-remote idle-shutdown guard (idle window: ${IDLE_MIN} min)
+cat >/usr/local/bin/repo-remote-idle-check <<'GUARD'
+#!/bin/bash
+IDLE_MIN=${IDLE_MIN}
+STAMP=/var/run/repo-remote-idle.stamp
+# Idle-exit marker: mtime = authoritative "idle since" (e.g. written by
+# loom-daemon on clean idle-exit). Overridable via REPO_REMOTE_IDLE_MARKER.
+MARKER=${IDLE_MARKER}
+# An active SSH session or non-trivial CPU load is real activity: reset the
+# idle timer and veto shutdown regardless of any marker (never power off a box
+# someone is actively using). No process-name check — see the note in the
+# generating script.
+if who | grep -q . || [ "\$(awk '{print (\$1 > 0.2)}' /proc/loadavg)" = "1" ]; then
+  date +%s > "\$STAMP"; exit 0
+fi
+# Marker present ⇒ its mtime REPLACES the local \$STAMP countdown start. The
+# on-host image is Ubuntu (GNU coreutils), so \`stat -c %Y\` is authoritative;
+# the \`|| echo 0\` guards a vanished/unreadable file. A future mtime (clock
+# skew) yields a negative age, which is never >= IDLE_MIN, so it can't trigger a
+# spurious shutdown.
+if [ -f "\$MARKER" ]; then
+  MARKER_AGE_MIN=\$(( ( \$(date +%s) - \$(stat -c %Y "\$MARKER" 2>/dev/null || echo 0) ) / 60 ))
+  if [ "\$MARKER_AGE_MIN" -ge "\$IDLE_MIN" ]; then
+    /sbin/shutdown -h now "repo-remote: daemon idle-exit marker aged \${MARKER_AGE_MIN}m"
+  fi
+  exit 0
+fi
+# No marker ⇒ unchanged local stamp-based countdown.
+[ -f "\$STAMP" ] || { date +%s > "\$STAMP"; exit 0; }
+NOW=\$(date +%s); LAST=\$(cat "\$STAMP")
+if [ \$(( (NOW - LAST) / 60 )) -ge "\$IDLE_MIN" ]; then
+  /sbin/shutdown -h now "repo-remote: idle for \${IDLE_MIN}m"
+fi
+GUARD
+chmod +x /usr/local/bin/repo-remote-idle-check
+echo "* * * * * root /usr/local/bin/repo-remote-idle-check" >/etc/cron.d/repo-remote-idle
+EOF
+}
+
+# ── AWS provider ────────────────────────────────────────────────────────────
+aws_authenticate() {
+  aws sts get-caller-identity >/dev/null 2>&1 \
+    || die 3 "AWS authentication failed with the resolved credentials (aws sts get-caller-identity). Not falling back to ambient/other credentials."
+}
+
+# Resolve the AMI into RESOLVED_AMI: an explicit override wins; a GPU host
+# defaults to the AWS Deep Learning Base OSS Nvidia Driver GPU AMI (Ubuntu
+# 22.04); otherwise the latest Ubuntu 22.04 LTS. (remote.md "GPU hosts".)
+# Sets a global (rather than echoing) so a `die` here propagates to the whole
+# process instead of being swallowed by a `$(...)` subshell.
+RESOLVED_AMI=""
+aws_resolve_image() {
+  if [[ -n "$IMAGE" ]]; then RESOLVED_AMI="$IMAGE"; return 0; fi
+  local q name
+  if [[ "$IS_GPU" == true ]]; then
+    name='Deep Learning Base OSS Nvidia Driver GPU AMI (Ubuntu 22.04)*'
+    q="$(aws ec2 describe-images --owners amazon \
+      --filters "Name=name,Values=$name" \
+      --query 'sort_by(Images,&CreationDate)[-1].ImageId' --output text 2>/dev/null)"
+  else
+    name='ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*'
+    q="$(aws ec2 describe-images --owners 099720109477 \
+      --filters "Name=name,Values=$name" \
+      --query 'sort_by(Images,&CreationDate)[-1].ImageId' --output text 2>/dev/null)"
+  fi
+  [[ -n "$q" && "$q" != "None" ]] || die 4 "could not resolve an AMI for ${INSTANCE_TYPE} (GPU=${IS_GPU}). Set REPO_REMOTE_IMAGE to override."
+  RESOLVED_AMI="$q"
+}
+
+# Describe a single instance's state; echoes state name or "missing".
+aws_instance_state() {  # <instance-id>
+  local out
+  out="$(aws ec2 describe-instances --instance-ids "$1" \
+        --query 'Reservations[0].Instances[0].State.Name' --output text 2>/dev/null)" || { echo missing; return; }
+  [[ -n "$out" && "$out" != "None" ]] && echo "$out" || echo missing
+}
+
+# Find a running|stopped instance previously created for this repo (by tag).
+aws_find_tagged() {  # echoes "<id> <state>" or empty
+  aws ec2 describe-instances \
+    --filters "Name=tag:repo-remote,Values=${NAME}" \
+              "Name=instance-state-name,Values=running,stopped,stopping,pending" \
+    --query 'Reservations[].Instances[].[InstanceId,State.Name]' --output text 2>/dev/null \
+    | grep -v '^None' | head -n1
+}
+
+aws_public_ip() {  # <instance-id>
+  aws ec2 describe-instances --instance-ids "$1" \
+    --query 'Reservations[0].Instances[0].PublicIpAddress' --output text 2>/dev/null
+}
+
+# Create a fresh instance into CREATED_ID (global, so a `die` propagates rather
+# than being swallowed by a command-substitution subshell). run-instances is
+# invoked EXACTLY ONCE — capturing stdout and stderr in one call — because a
+# retry-to-read-the-error would risk launching a second billable instance.
+CREATED_ID=""
+aws_create() {
+  local ami sg key udfile errfile iid rc err
+  aws_resolve_image; ami="$RESOLVED_AMI"
+  key="${REPO_REMOTE_SSH_KEY_NAME:-}"
+  sg="${REPO_REMOTE_SECURITY_GROUP:-}"
+
+  udfile="$(mktemp)"; idle_guard_userdata >"$udfile"
+  errfile="$(mktemp)"
+
+  local -a args=(ec2 run-instances
+    --image-id "$ami"
+    --instance-type "$INSTANCE_TYPE"
+    --block-device-mappings "DeviceName=/dev/sda1,Ebs={VolumeSize=${DISK_GB}}"
+    --tag-specifications "ResourceType=instance,Tags=[{Key=repo-remote,Value=${NAME}}]"
+    --user-data "file://${udfile}"
+    --query 'Instances[0].InstanceId' --output text)
+  [[ -n "$key" ]] && args+=(--key-name "$key")
+  [[ -n "$sg" ]]  && args+=(--security-group-ids "$sg")
+
+  iid="$(aws "${args[@]}" 2>"$errfile")"; rc=$?
+  err="$(cat "$errfile" 2>/dev/null)"
+  rm -f "$udfile" "$errfile"
+
+  if [[ $rc -ne 0 || -z "$iid" || "$iid" == "None" ]]; then
+    # Surface the quota-exceeded case with the exact remediation (remote.md).
+    if printf '%s' "$err" | grep -q 'VcpuLimitExceeded'; then
+      die 4 "AWS GPU vCPU quota is 0 by default (VcpuLimitExceeded). Request a limit >= this type's vCPUs at Service Quotas -> EC2 -> quota code L-DB2E81BA, then retry."
+    fi
+    die 4 "aws ec2 run-instances failed: ${err:-unknown error}"
+  fi
+  CREATED_ID="$iid"
+}
+
+aws_up() {
+  aws_authenticate
+  local iid="" state="" reused=false
+
+  if [[ -n "$INSTANCE_ID" ]]; then
+    state="$(aws_instance_state "$INSTANCE_ID")"
+    case "$state" in
+      running)          iid="$INSTANCE_ID"; reused=true ;;
+      stopped|stopping) aws ec2 start-instances --instance-ids "$INSTANCE_ID" >/dev/null 2>&1 \
+                          || die 4 "failed to start stopped instance $INSTANCE_ID"
+                        iid="$INSTANCE_ID"; reused=true ;;
+      missing)          log "pinned REPO_REMOTE_INSTANCE_ID=$INSTANCE_ID no longer exists; creating a fresh instance."
+                        INSTANCE_ID="" ;;
+      *)                iid="$INSTANCE_ID"; reused=true ;;
+    esac
+  fi
+
+  if [[ -z "$iid" ]]; then
+    local found; found="$(aws_find_tagged)"
+    if [[ -n "$found" ]]; then
+      iid="$(printf '%s' "$found" | awk '{print $1}')"
+      state="$(printf '%s' "$found" | awk '{print $2}')"
+      reused=true
+      if [[ "$state" == stopped || "$state" == stopping ]]; then
+        aws ec2 start-instances --instance-ids "$iid" >/dev/null 2>&1 \
+          || die 4 "failed to start reused instance $iid"
+      fi
+    fi
+  fi
+
+  if [[ -z "$iid" ]]; then
+    aws_create           # sets CREATED_ID or dies (main-shell context)
+    iid="$CREATED_ID"
+    reused=false
+  fi
+
+  aws ec2 wait instance-running --instance-ids "$iid" >/dev/null 2>&1 || true
+  local ip; ip="$(aws_public_ip "$iid")"
+  [[ "$ip" == "None" ]] && ip=""
+
+  writeback_instance_id "$iid"
+  local alias; alias="$(write_ssh_alias "$ip")"
+
+  emit_up_result "$iid" "$ip" "$alias" "$reused"
+}
+
+aws_status() {
+  aws_authenticate
+  local rows
+  rows="$(aws ec2 describe-instances \
+    --filters "Name=tag:repo-remote,Values=${NAME}" \
+    --query 'Reservations[].Instances[].[InstanceId,State.Name,InstanceType,PublicIpAddress,LaunchTime]' \
+    --output text 2>/dev/null | grep -v '^None' || true)"
+  emit_status_result "$rows"
+}
+
+aws_down() {
+  aws_authenticate
+  local ids
+  if [[ -n "$INSTANCE_ID" ]]; then
+    ids="$INSTANCE_ID"
+  else
+    ids="$(aws ec2 describe-instances \
+      --filters "Name=tag:repo-remote,Values=${NAME}" \
+                "Name=instance-state-name,Values=running,stopped,stopping,pending" \
+      --query 'Reservations[].Instances[].InstanceId' --output text 2>/dev/null | grep -v '^None' || true)"
+  fi
+  ids="$(printf '%s' "$ids" | tr '\t' ' ' | xargs 2>/dev/null || true)"
+
+  if [[ -z "$ids" ]]; then
+    emit_down_result "" "noop"
+    return 0
+  fi
+
+  if [[ "$YES" != true ]]; then
+    emit_down_result "$ids" "dry-run"
+    return 0
+  fi
+
+  if [[ "$DELETE" == true ]]; then
+    # shellcheck disable=SC2086
+    aws ec2 terminate-instances --instance-ids $ids >/dev/null 2>&1 \
+      || die 4 "aws ec2 terminate-instances failed for: $ids"
+    emit_down_result "$ids" "terminated"
+  else
+    # shellcheck disable=SC2086
+    aws ec2 stop-instances --instance-ids $ids >/dev/null 2>&1 \
+      || die 4 "aws ec2 stop-instances failed for: $ids"
+    emit_down_result "$ids" "stopped"
+  fi
+}
+
+# ── GCP provider ────────────────────────────────────────────────────────────
+gcp_authenticate() {
+  gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}" >/dev/null 2>&1 \
+    || die 3 "GCP authentication failed (gcloud auth activate-service-account)."
+  gcloud config set project "${GCP_PROJECT}" >/dev/null 2>&1 || true
+}
+
+gcp_up() {
+  gcp_authenticate
+  local vm="repo-remote-${NAME}" ip="" reused=false state
+  state="$(gcloud compute instances describe "$vm" --zone "$REGION" \
+    --format='value(status)' 2>/dev/null || true)"
+  if [[ -n "$state" ]]; then
+    reused=true
+    if [[ "$state" != "RUNNING" ]]; then
+      gcloud compute instances start "$vm" --zone "$REGION" >/dev/null 2>&1 \
+        || die 4 "failed to start existing instance $vm"
+    fi
+  else
+    local -a args=(compute instances create "$vm"
+      --zone "$REGION"
+      --machine-type "$INSTANCE_TYPE"
+      --boot-disk-size "${DISK_GB}GB"
+      --labels "repo-remote=${NAME}"
+      --image-family "${IMAGE:-ubuntu-2204-lts}" --image-project "${REPO_REMOTE_IMAGE_PROJECT:-ubuntu-os-cloud}")
+    [[ -n "$GPU_ACCEL" ]] && args+=(--accelerator "type=${GPU_ACCEL%%:*},count=${GPU_ACCEL##*:}" --maintenance-policy TERMINATE)
+    local ud; ud="$(mktemp)"; idle_guard_userdata >"$ud"
+    args+=(--metadata-from-file "startup-script=${ud}")
+    gcloud "${args[@]}" >/dev/null 2>&1 || { rm -f "$ud"; die 4 "gcloud compute instances create failed for $vm"; }
+    rm -f "$ud"
+  fi
+  ip="$(gcloud compute instances describe "$vm" --zone "$REGION" \
+    --format='value(networkInterfaces[0].accessConfigs[0].natIP)' 2>/dev/null || true)"
+
+  writeback_instance_id "$vm"
+  local alias; alias="$(write_ssh_alias "$ip")"
+  emit_up_result "$vm" "$ip" "$alias" "$reused"
+}
+
+gcp_status() {
+  gcp_authenticate
+  local rows
+  rows="$(gcloud compute instances list \
+    --filter="labels.repo-remote=${NAME}" \
+    --format='value(name,status,machineType.basename(),networkInterfaces[0].accessConfigs[0].natIP,creationTimestamp)' 2>/dev/null || true)"
+  emit_status_result "$rows"
+}
+
+gcp_down() {
+  gcp_authenticate
+  local vm="repo-remote-${NAME}"
+  [[ -n "$INSTANCE_ID" ]] && vm="$INSTANCE_ID"
+  local exists
+  exists="$(gcloud compute instances describe "$vm" --zone "$REGION" --format='value(name)' 2>/dev/null || true)"
+  if [[ -z "$exists" ]]; then emit_down_result "" "noop"; return 0; fi
+  if [[ "$YES" != true ]]; then emit_down_result "$vm" "dry-run"; return 0; fi
+  if [[ "$DELETE" == true ]]; then
+    gcloud compute instances delete "$vm" --zone "$REGION" --quiet >/dev/null 2>&1 \
+      || die 4 "gcloud compute instances delete failed for $vm"
+    emit_down_result "$vm" "terminated"
+  else
+    gcloud compute instances stop "$vm" --zone "$REGION" --quiet >/dev/null 2>&1 \
+      || die 4 "gcloud compute instances stop failed for $vm"
+    emit_down_result "$vm" "stopped"
+  fi
+}
+
+# ── write-back + SSH alias ──────────────────────────────────────────────────
+# Write the new instance id back to the repo's .env (git root, never the shared
+# file — the handle is per-repo), updating in place or appending. remote.md §4.
+writeback_instance_id() {  # <instance-id>
+  local id="$1"
+  [[ -n "$REPO_ENV" ]] || return 0
+  if [[ -f "$REPO_ENV" ]] && grep -q '^REPO_REMOTE_INSTANCE_ID=' "$REPO_ENV"; then
+    local tmp; tmp="$(mktemp)"
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      if [[ "$line" == REPO_REMOTE_INSTANCE_ID=* ]]; then
+        printf 'REPO_REMOTE_INSTANCE_ID=%s\n' "$id"
+      else
+        printf '%s\n' "$line"
+      fi
+    done <"$REPO_ENV" >"$tmp"
+    mv "$tmp" "$REPO_ENV"
+  else
+    printf 'REPO_REMOTE_INSTANCE_ID=%s\n' "$id" >>"$REPO_ENV"
+  fi
+}
+
+# Write/refresh the one-word SSH alias so the connection is `ssh repo-remote-<name>`.
+# Honors REPO_REMOTE_SSH_CONFIG (default ~/.ssh/config) so tests never touch a
+# real config. Echoes the alias name.
+write_ssh_alias() {  # <ip>
+  local ip="$1" alias="repo-remote-${NAME}"
+  local cfg="${REPO_REMOTE_SSH_CONFIG:-$HOME/.ssh/config}"
+  local key="${REPO_REMOTE_SSH_KEY:-~/.ssh/id_ed25519}"
+  local user="${REPO_REMOTE_SSH_USER:-ubuntu}"
+  [[ -z "$ip" ]] && { printf '%s' "$alias"; return 0; }
+
+  mkdir -p "$(dirname "$cfg")" 2>/dev/null || true
+  local tmp; tmp="$(mktemp)"
+  # Strip any prior block for this alias, then append a fresh one.
+  if [[ -f "$cfg" ]]; then
+    awk -v a="Host $alias" '
+      $0 == a {skip=1; next}
+      skip && /^Host / {skip=0}
+      skip {next}
+      {print}
+    ' "$cfg" >"$tmp"
+  fi
+  {
+    [[ -s "$tmp" ]] && printf '\n'
+    printf 'Host %s\n' "$alias"
+    printf '    HostName %s\n' "$ip"
+    printf '    User %s\n' "$user"
+    printf '    IdentityFile %s\n' "$key"
+  } >>"$tmp"
+  mv "$tmp" "$cfg"
+  chmod 600 "$cfg" 2>/dev/null || true
+  printf '%s' "$alias"
+}
+
+# ── result emitters ─────────────────────────────────────────────────────────
+emit_plan() {  # dry-run plan (no cloud mutation)
+  if [[ "$JSON_OUT" == true ]]; then
+    printf '{'
+    printf '"action":"plan",'
+    printf '"dry_run":true,'
+    printf '"provider":"%s",' "$(json_escape "$PROVIDER")"
+    printf '"name":"%s",' "$(json_escape "$NAME")"
+    printf '"instance_type":"%s",' "$(json_escape "$INSTANCE_TYPE")"
+    printf '"region":"%s",' "$(json_escape "$REGION")"
+    printf '"disk_gb":%s,' "$DISK_GB"
+    printf '"gpu":%s,' "$IS_GPU"
+    printf '"idle_shutdown_min":%s,' "$IDLE_MIN"
+    printf '"ssh_alias":"repo-remote-%s",' "$(json_escape "$NAME")"
+    printf '"estimated_hourly_cost_usd":%s,' "$COST_HOURLY"
+    printf '"estimated_cost_approximate":%s' "$COST_APPROX"
+    printf '}\n'
+  else
+    log "PLAN (dry run — nothing created; pass --yes to provision):"
+    log "  provider:            $PROVIDER"
+    log "  instance type:       $INSTANCE_TYPE${IS_GPU:+ (GPU)}"
+    log "  region/zone:         $REGION"
+    log "  disk:                ${DISK_GB} GB"
+    log "  idle shutdown:       ${IDLE_MIN} min"
+    log "  est. hourly cost:    \$${COST_HOURLY}/hr$([[ "$COST_APPROX" == true ]] && echo ' (approximate)')"
+    log "  ssh alias:           repo-remote-${NAME}"
+  fi
+}
+
+emit_up_result() {  # <id> <ip> <alias> <reused>
+  local id="$1" ip="$2" alias="$3" reused="$4"
+  if [[ "$JSON_OUT" == true ]]; then
+    printf '{'
+    printf '"action":"up",'
+    printf '"provider":"%s",' "$(json_escape "$PROVIDER")"
+    printf '"name":"%s",' "$(json_escape "$NAME")"
+    printf '"instance_id":"%s",' "$(json_escape "$id")"
+    printf '"public_ip":"%s",' "$(json_escape "$ip")"
+    printf '"ssh_alias":"%s",' "$(json_escape "$alias")"
+    printf '"instance_type":"%s",' "$(json_escape "$INSTANCE_TYPE")"
+    printf '"region":"%s",' "$(json_escape "$REGION")"
+    printf '"gpu":%s,' "$IS_GPU"
+    printf '"idle_shutdown_min":%s,' "$IDLE_MIN"
+    printf '"reused":%s,' "$reused"
+    printf '"estimated_hourly_cost_usd":%s,' "$COST_HOURLY"
+    printf '"estimated_cost_approximate":%s' "$COST_APPROX"
+    printf '}\n'
+  else
+    log "$([[ "$reused" == true ]] && echo reused || echo created) instance $id (${INSTANCE_TYPE}) @ ${ip:-<no public ip>}"
+    log "  ssh alias:        $alias"
+    log "  est. hourly cost: \$${COST_HOURLY}/hr$([[ "$COST_APPROX" == true ]] && echo ' (approximate)')"
+    log "  teardown:         repo-remote down --yes   (or /repo:remote --down)"
+  fi
+}
+
+emit_status_result() {  # <rows: id state type ip launch, tab/space separated per line>
+  local rows="$1"
+  if [[ "$JSON_OUT" == true ]]; then
+    printf '{"action":"status","provider":"%s","name":"%s","instances":[' \
+      "$(json_escape "$PROVIDER")" "$(json_escape "$NAME")"
+    local first=true line id state type ip launch
+    while IFS= read -r line; do
+      [[ -z "$line" ]] && continue
+      id="$(printf '%s' "$line" | awk '{print $1}')"
+      state="$(printf '%s' "$line" | awk '{print $2}')"
+      type="$(printf '%s' "$line" | awk '{print $3}')"
+      ip="$(printf '%s' "$line" | awk '{print $4}')"
+      launch="$(printf '%s' "$line" | awk '{print $5}')"
+      [[ "$ip" == "None" ]] && ip=""
+      [[ "$first" == true ]] && first=false || printf ','
+      printf '{"instance_id":"%s","state":"%s","instance_type":"%s","public_ip":"%s","launch_time":"%s"}' \
+        "$(json_escape "$id")" "$(json_escape "$state")" "$(json_escape "$type")" "$(json_escape "$ip")" "$(json_escape "$launch")"
+    done <<<"$rows"
+    printf ']}\n'
+  else
+    if [[ -z "$rows" ]]; then
+      log "no instances tagged repo-remote=${NAME}"
+    else
+      log "instances tagged repo-remote=${NAME}:"
+      printf '%s\n' "$rows" >&2
+    fi
+  fi
+}
+
+emit_down_result() {  # <ids> <disposition: noop|dry-run|stopped|terminated>
+  local ids="$1" disp="$2"
+  if [[ "$JSON_OUT" == true ]]; then
+    printf '{"action":"down","provider":"%s","name":"%s","disposition":"%s","instances":[' \
+      "$(json_escape "$PROVIDER")" "$(json_escape "$NAME")" "$(json_escape "$disp")"
+    local first=true id
+    for id in $ids; do
+      [[ "$first" == true ]] && first=false || printf ','
+      printf '"%s"' "$(json_escape "$id")"
+    done
+    printf ']}\n'
+  else
+    case "$disp" in
+      noop)     log "no instances tagged repo-remote=${NAME} to stop" ;;
+      dry-run)  log "DRY RUN — would stop$([[ "$DELETE" == true ]] && echo /terminate): $ids (pass --yes to act)" ;;
+      stopped)  log "stopped: $ids" ;;
+      terminated) log "terminated (disks removed): $ids" ;;
+    esac
+  fi
+}
+
+# ── argument parsing ────────────────────────────────────────────────────────
+usage() {
+  sed -n '4,60p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      up|status|down) [[ -z "$ACTION" ]] && ACTION="$1" || die 64 "multiple actions given ($ACTION, $1)" ;;
+      --status)       ACTION="status" ;;
+      --down)         ACTION="down" ;;
+      --yes|-y)       YES=true ;;
+      --json)         JSON_OUT=true ;;
+      --delete)       DELETE=true ;;
+      aws|gcp)        PROVIDER_ARG="$1" ;;
+      -h|--help)      usage; exit 0 ;;
+      *)              die 64 "unknown argument: $1 (see --help)" ;;
+    esac
+    shift
+  done
+  [[ -n "$ACTION" ]] || die 64 "no action given (expected: up | status | down; see --help)"
+}
+
+# ── main ────────────────────────────────────────────────────────────────────
+main() {
+  parse_args "$@"
+  resolve_paths
+  load_config
+  resolve_settings
+
+  case "$ACTION" in
+    up)
+      require_cost_config
+      if [[ "$YES" != true ]]; then
+        emit_plan          # dry-run: the plan (with cost) is shown, nothing spent
+        exit 0
+      fi
+      case "$PROVIDER" in
+        aws) aws_up ;;
+        gcp) gcp_up ;;
+        *)   die 2 "unknown provider '$PROVIDER'" ;;
+      esac
+      ;;
+    status)
+      [[ -n "$PROVIDER" ]] || die 2 "REPO_REMOTE_PROVIDER (or an aws|gcp argument) is required for status"
+      case "$PROVIDER" in
+        aws) aws_status ;;
+        gcp) gcp_status ;;
+        *)   die 2 "unknown provider '$PROVIDER'" ;;
+      esac
+      ;;
+    down)
+      [[ -n "$PROVIDER" ]] || die 2 "REPO_REMOTE_PROVIDER (or an aws|gcp argument) is required for down"
+      case "$PROVIDER" in
+        aws) aws_down ;;
+        gcp) gcp_down ;;
+        *)   die 2 "unknown provider '$PROVIDER'" ;;
+      esac
+      ;;
+  esac
+}
+
+main "$@"

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,13 @@ boards/*/*/output/board.json
 # Repo Skills machine-local install metadata (absolute source path + timestamp)
 .claude/skills/repo/.install-local.json
 
+# Repo Skills runtime artifacts (transient by design -- never commit)
+# handoff.md is a one-shot session baton written by /repo:handoff and deleted
+# after the next session absorbs it; logs/ holds hook-errors.log and the
+# opt-in guard-decisions.log telemetry.
+.claude/handoff.md
+.claude/skills/repo/logs/
+
 # Loom model-cost experiment (canary A/B, #3725/#3731)
 # The CANARY confirmation MUST stay uncommitted by design -- a copied/committed
 # config can never confirm canary status. Local outcome-chain stats too.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ suspect the auto-detection missed something (e.g. a touched build flag).
 See `README.md` "Fresh worktree checklist" for the full setup sequence.
 
 <!-- BEGIN REPO-SKILLS -->
-This repository has [Repo Skills](https://github.com/rjwalters/repo) v0.4.3 installed —
+This repository has [Repo Skills](https://github.com/rjwalters/repo) v0.7.0 installed —
 general repository hygiene and environment commands invoked as `/repo:<command>`. Run
 `/repo:help` for the command list, or see `.claude/skills/repo/SKILL.md` for the full
 guide. Hygiene commands apply safe, reversible fixes by default and report each


### PR DESCRIPTION
Routine tool update via the /repo:all hygiene pass. The Repo Skills payload is a vendored-file refresh only — installed by rjwalters/repo's install.sh (source v0.7.0-4-g1f338f3) from the local clone; no hand edits. New commands: /repo:handoff, /repo:host-optimize, /repo:sudo; new SessionStart handoff hook wired into .claude/settings.json; repo-remote.sh helper; marker-bounded CLAUDE.md block re-stamped.

**Not vendored-bytes-only, though** — see the next section. The bump has a behavioral side effect on Loom's guard posture that is addressed here rather than absorbed silently.

## Guard-posture interaction (judge finding)

### The dispatcher flip

`.loom/hooks/guard-destructive.sh` is a runtime *dispatcher*. It `exec`s the canonical Repo Skills guard whenever that guard carries the `repo#29` marker, and otherwise falls back to Loom's vendored `guard-destructive-generic.sh`:

```bash
if [[ -r "$CANONICAL_GUARD" ]] && grep -q 'repo#29' "$CANONICAL_GUARD" 2>/dev/null; then
    exec bash "$CANONICAL_GUARD"
fi
```

Repo Skills 0.7.0 **adds** that marker. So merging this bump changes which destructive-command guard actually runs for every agent in this repo:

| | `repo#29` in canonical guard | Guard that actually runs |
|---|---|---|
| `main` today (0.4.3) | absent (0 hits) | `.loom/hooks/guard-destructive-generic.sh` (vendored) |
| this PR (0.7.0) | present (1 hit) | `.claude/skills/repo/hooks/guard-destructive.sh` (canonical) |

That matters because of a Loom-owned exception documented at `.loom/docs/guard-hooks.md:64`: the vendored copy — and only the vendored copy — carries the Bash-tool **write-confinement** category (`guards.worktreeIsolation`, loom#4178: denies `>`/`>>`, `tee`, `sed -i`, `cp`/`mv` writes into the main checkout while a Loom-managed worktree exists).

```
worktreeIsolation|write-confinement|WORKTREE_ISOLATION
  .loom/hooks/guard-destructive-generic.sh          -> 11 hits (deny at line 2100)
  repo-skills 0.7.0 guard-destructive.sh           ->  0 hits
```

The regression is **latent** — with no worktrees present both guards no-op identically, so no check would ever flag it — and there is no toggle-level workaround, since the dispatcher exposes no env/config override to keep preferring the vendored copy. This repo runs autonomous sweeps with builders in worktrees, i.e. the exact #4178 exposure window (that incident was an agent using a Bash-tool write to edit live guard hooks in the main checkout after the `Edit|Write` matcher denied it).

### The fix in this PR: belt-and-suspenders hook entry

`.claude/settings.json` now wires the vendored guard as an **additional** `PreToolUse`/`Bash` entry, so the write-confinement category runs regardless of which guard the dispatcher picks:

```json
{ "type": "command", "command": "${CLAUDE_PROJECT_DIR}/.loom/hooks/guard-destructive.sh" },
{ "type": "command", "command": "${CLAUDE_PROJECT_DIR}/.loom/hooks/guard-destructive-generic.sh" },
{ "type": "command", "command": "${CLAUDE_PROJECT_DIR}/.loom/hooks/guard-loom-workflow.sh" }
```

Verified locally by feeding simulated `PreToolUse` payloads to each guard from inside a Loom-managed worktree:

| Probe | Dispatcher (→ canonical 0.7.0) | Added direct entry |
|---|---|---|
| benign `git status --short` | exit 0, no output (allow) | exit 0, no output (allow) |
| shared destructive pattern | `deny` | `deny` (idempotent, no double-deny breakage) |
| Bash write into main checkout w/ worktree present | **exit 0 — ALLOWED** | **`deny` — the #4178 block restored** |

Row 3 is the regression and its mitigation in one line. JSON validated with `python3 -m json.tool`; the script path exists and is executable.

**Latency cost** (the judge asked for this before choosing option 2): measured **~25 ms per Bash tool call** over 10 benign invocations. The shared generic pattern set does get evaluated twice; at 25 ms that is well inside the noise of a tool round-trip, and it buys back a safety category in a repo doing unattended sweeps.

### Upstream filing

Filed against Loom: **rjwalters/loom#4894** — the dispatcher probes for a *version* marker but never for *capability*, so it hands off to a guard missing a category it is documented to own. Suggested ACs there: honor an override (e.g. `LOOM_GUARD_PREFER_VENDORED`) **or** stop `exec`ing and always chain the write-confinement category (ideally extracted into its own hook, which would also remove the double-run tax), plus a regression test asserting the category still fires with a canonical-marker guard installed, plus a correction to `guard-hooks.md:64`, which currently states the exception as if it always holds.

Once that lands, the extra settings.json entry here becomes redundant and can be dropped.

## Also folded in (judge's non-blocking nit)

`.gitignore` now covers the two runtime artifacts the 0.7.0 surface can create, so `git add -A` cannot commit them:

- `.claude/handoff.md` — one-shot session baton written by `/repo:handoff`, transient by design
- `.claude/skills/repo/logs/` — `hook-errors.log` plus the opt-in `guard-decisions.log` telemetry

Both were added outside any tool-managed marker block, next to the existing `.claude/skills/repo/.install-local.json` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
