### PR TITLE
fix(diffpair): join sub-grid-cell offset steps instead of leaving polyline breaks

### DIFF
--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -117,6 +117,15 @@ NEAR_MISS_RESCUE_CELLS: int = int(os.environ.get("KCT_COUPLED_RESCUE_CELLS", "60
 # continuity thresholds.
 _SHADOW_MAX_TRIM_MM: float = float(os.environ.get("KCT_SHADOW_MAX_TRIM_MM", "5.0"))
 
+# Issue #4462: the largest separation between two consecutive parallel-offset
+# endpoints that may be treated as "already coincident" and joined by snapping
+# rather than by emitting a connector.  One 0.1 um serialization quantum: below
+# it the two endpoints round to the same 4-dp coordinate in the .kicad_pcb, so
+# snapping is exact and free.  ANY larger separation must be joined with real
+# copper -- an unjoined sub-grid-cell step is a break in the polyline, which
+# costs the whole coupled pair via the #3540 transactional strand guard.
+_OFFSET_JOIN_COINCIDENT_MM: float = 1e-4
+
 # Issue #3987 (unit 2a of #3921): hard per-pair wall-clock budget for the
 # shadow-construction coupled attempt.  When ``enable_shadow_construction``
 # is on, a pair is routed either as a validated parallel shadow (ms) or it
@@ -4815,6 +4824,75 @@ class DiffPairRouter:
             route.segments[:] = rebuilt
         return added_total
 
+    def _close_shadow_chain(
+        self,
+        route: Route,
+        pathfinder: CoupledPathfinder,
+    ) -> int:
+        """Enforce chain-connectivity on an assembled shadow polyline (#4462).
+
+        The constructed shadow is ``start tail + trimmed body + end tail``, and
+        every one of those pieces is built independently.  A gap of even a few
+        microns between two consecutive segments is invisible to the clearance
+        and census gates but fatal downstream: the #3540 transactional strand
+        guard runs :func:`validate_net_connectivity`, which unions segment
+        endpoints snapped onto a 0.01 mm lattice, so a broken chain reads as
+        "1/2 pads reached" and the ENTIRE coupled pair is ripped and re-routed
+        single-ended -- losing a pair whose copper was otherwise good (measured
+        on board-06: MIPI_CLK, MIPI_D0 and PCIE_RX, all three already
+        length-matched to under 0.45 mm by #4553's constructor).
+
+        Two repairs, both conservative:
+
+        * a gap within one serialization quantum is closed by SNAPPING the
+          following segment's start onto the previous segment's end, so the two
+          coordinates are bit-identical and no rounding boundary can separate
+          them; and
+        * a larger gap, up to one grid cell, is closed by inserting a real
+          connector segment -- but only when that connector is obstacle-clear
+          and planar (same layer).
+
+        Anything else is left exactly as it is today (the strand guard remains
+        the backstop).  Returns the number of repairs made.
+        """
+        segs = route.segments
+        if len(segs) < 2:
+            return 0
+        res = self.autorouter.grid.resolution
+        out: list[Segment] = [segs[0]]
+        repairs = 0
+        for cur in segs[1:]:
+            prev = out[-1]
+            gap = math.hypot(cur.x1 - prev.x2, cur.y1 - prev.y2)
+            if gap <= _OFFSET_JOIN_COINCIDENT_MM:
+                if gap > 0.0:
+                    cur.x1, cur.y1 = prev.x2, prev.y2
+                    repairs += 1
+                out.append(cur)
+                continue
+            if cur.layer == prev.layer and gap <= res:
+                li = self.autorouter.grid.layer_to_index(cur.layer.value)
+                if self._segment_cells_clear(
+                    pathfinder, prev.x2, prev.y2, cur.x1, cur.y1, li, cur.net
+                ):
+                    out.append(
+                        Segment(
+                            x1=prev.x2,
+                            y1=prev.y2,
+                            x2=cur.x1,
+                            y2=cur.y1,
+                            width=cur.width,
+                            layer=cur.layer,
+                            net=cur.net,
+                            net_name=cur.net_name,
+                        )
+                    )
+                    repairs += 1
+            out.append(cur)
+        if repairs:
+            route.segments[:] = out
+        return repairs
+
     def _quantize_shadow_segments(
         self,
         route: Route,
@@ -5089,8 +5167,9 @@ class DiffPairRouter:
 
         Returns ``(mode, point)``:
 
-        * ``("none", None)`` -- the offset endpoints already meet (gap below
-          half a grid cell); the caller just appends the current segment.
+        * ``("none", None)`` -- the offset endpoints already meet to within one
+          serialization quantum; the caller snaps the current segment's start
+          onto ``pseg_end`` (an exact-coordinate no-op join) and appends it.
         * ``("miter", mx)`` -- clip/extend the previous segment's END to
           ``mx`` and start the current segment at ``mx``.  This is the correct
           join for a CONCAVE (inside) corner: the offset lines cross and the
@@ -5103,15 +5182,37 @@ class DiffPairRouter:
           stays within ``2*d + gap`` (a sharp outside turn otherwise grows an
           unbounded spike).
         * ``("bevel", None)`` -- insert a straight chord ``pseg_end -> a``.
-          Reached only for convex corners whose miter spike is out of bounds
-          (the chord stays on the offset side there) or degenerate geometry.
+          Reached for convex corners whose miter spike is out of bounds (the
+          chord stays on the offset side there), for degenerate geometry, and
+          for SUB-CELL steps (below).
 
         Pure geometry -- no grid / obstacle state -- so it is unit-testable in
         isolation (see ``tests/test_diffpair_shadow.py``).
         """
         gap = math.hypot(a[0] - pseg_end[0], a[1] - pseg_end[1])
-        if gap <= resolution / 2:
+        if gap <= _OFFSET_JOIN_COINCIDENT_MM:
             return ("none", None)
+        if gap <= resolution / 2:
+            # Issue #4462: a SUB-CELL step, not a coincidence.  Consecutive
+            # collinear guide segments that select different rungs of the
+            # variable-gap ladder (``_shadow_select_gap``, #3990) offset to
+            # endpoints separated by the rung difference -- perpendicular to
+            # travel and, on board-06's 0.05 mm grid, 0.024 mm.  This used to
+            # return ``"none"``, and the caller then appended the current
+            # segment starting at ``a`` while the previous one ended at
+            # ``pseg_end``: a literal 0.024 mm BREAK in the emitted polyline.
+            # The pair still constructed (both landing tails reached their
+            # pads), but ``validate_net_connectivity`` snaps endpoints onto a
+            # 0.01 mm lattice, so the net split into two components and the
+            # #3540 transactional strand guard ripped the whole coupled pair
+            # (measured: MIPI_CLK, MIPI_D0 and PCIE_RX, all three with
+            # construction-time skew already under 0.45 mm).
+            #
+            # Join it with a chord rather than a miter: at this scale the two
+            # offset lines are near-parallel, so the miter apex is numerically
+            # unbounded, while the chord is exactly the (typically axis-
+            # aligned) step itself.
+            return ("bevel", None)
 
         d1x, d1y = pseg_end[0] - pseg_start[0], pseg_end[1] - pseg_start[1]
         d2x, d2y = b[0] - a[0], b[1] - a[1]
@@ -5296,6 +5397,55 @@ class DiffPairRouter:
                     continue
                 approaches.append(loc)
         return approaches
+
+    def _debug_strand(
+        self,
+        pair_name: str,
+        net_id: int,
+        info: dict,
+        routes: list[Route],
+        net_pads: dict[int, list[Pad]],
+    ) -> None:
+        """Print why a committed pair net failed the #3540 connectivity claim."""
+        net_routes = [r for r in routes if r.net == net_id]
+        print(
+            f"    [coupled-strand] {pair_name} net={net_id} "
+            f"stranded={info.get('stranded_pads', [])} routes={len(net_routes)}"
+        )
+        for pad in net_pads.get(net_id, []):
+            best = float("inf")
+            for r in net_routes:
+                for s in r.segments:
+                    for px, py in ((s.x1, s.y1), (s.x2, s.y2)):
+                        best = min(best, math.hypot(px - pad.x, py - pad.y))
+            print(
+                f"      pad {getattr(pad, 'ref', '?')}.{getattr(pad, 'pin', '?')} "
+                f"@({pad.x:.3f},{pad.y:.3f}) nearest_endpoint={best:.4f}mm"
+            )
+        for ri, r in enumerate(net_routes):
+            if not r.segments:
+                continue
+            first, last = r.segments[0], r.segments[-1]
+            print(
+                f"      route[{ri}] segs={len(r.segments)} vias={len(r.vias)} "
+                f"start=({first.x1:.3f},{first.y1:.3f}) end=({last.x2:.3f},{last.y2:.3f})"
+            )
+            # Report every chain break inside the route (the union-find only
+            # links endpoints that snap to the same 0.01 mm bucket).
+            for k in range(len(r.segments) - 1):
+                a, b = r.segments[k], r.segments[k + 1]
+                gap = math.hypot(b.x1 - a.x2, b.y1 - a.y2)
+                if gap > 0.005:
+                    on_via = any(
+                        math.hypot(v.x - a.x2, v.y - a.y2) < 0.005
+                        and math.hypot(v.x - b.x1, v.y - b.y1) < 0.005
+                        for v in r.vias
+                    )
+                    print(
+                        f"        break@seg{k} gap={gap:.4f}mm "
+                        f"({a.x2:.3f},{a.y2:.3f})->({b.x1:.3f},{b.y1:.3f}) "
+                        f"layers={a.layer.value}/{b.layer.value} via_bridged={on_via}"
+                    )
 
     def _debug_shadow_overlap(
         self,
@@ -5655,13 +5805,28 @@ class DiffPairRouter:
                                     elements.append(
                                         ("seg", prev_pt[0], prev_pt[1], a[0], a[1], sec_layer)
                                     )
+                                else:
+                                    # Issue #4462: ``"none"`` means the two
+                                    # endpoints agree to within a serialization
+                                    # quantum -- make them agree EXACTLY, so the
+                                    # polyline is chain-connected bit-for-bit
+                                    # and no endpoint-snapping connectivity
+                                    # check can split the net at a rounding
+                                    # boundary.
+                                    a = prev_pt
                             elif (
                                 math.hypot(a[0] - prev_pt[0], a[1] - prev_pt[1])
-                                > grid.resolution / 2
+                                > _OFFSET_JOIN_COINCIDENT_MM
                             ):
+                                # Issue #4462: the post-via re-entry join had the
+                                # same sub-cell hole as the corner join above --
+                                # a step under half a grid cell was silently left
+                                # unjoined.  Emit the connector for any real gap.
                                 elements.append(
                                     ("seg", prev_pt[0], prev_pt[1], a[0], a[1], sec_layer)
                                 )
+                            else:
+                                a = prev_pt
                     elements.append(("seg", a[0], a[1], b[0], b[1], sec_layer))
                     prev_pt = b
                     prev_layer = sec_layer
@@ -5892,8 +6057,17 @@ class DiffPairRouter:
             # (#3975) -- validate.  A residual off-angle segment (no clear
             # dogleg variant) degrades gracefully; it is not silently
             # shipped as a short.
+            # Issue #4462: close any residual break BEFORE the dogleg pass, so
+            # the quantizer (which preserves each segment's own endpoints) is
+            # working on an already-connected chain.
+            chain_repairs = self._close_shadow_chain(shadow_route, pathfinder)
             pre_quant_len = _route_copper_length(shadow_route)
             self._quantize_shadow_segments(shadow_route, pathfinder)
+            if _SHADOW_DEBUG and chain_repairs:
+                print(
+                    f"    [coupled-shadow-chain] {pair.name} side={side:+.0f} "
+                    f"closed {chain_repairs} polyline break(s)"
+                )
             if _SHADOW_DEBUG:
                 guide_len = sum(math.hypot(g.x2 - g.x1, g.y2 - g.y1) for g in guide.segments)
                 print(
@@ -7221,6 +7395,8 @@ class DiffPairRouter:
                         info.get("connected_pads", 0),
                         info.get("total_pads", 0),
                     )
+                    if _SHADOW_DEBUG:
+                        self._debug_strand(pair.name, net_id, info, routes, net_pads_for_check)
                 # Roll back: unmark every committed route for this pair and
                 # drop it from the autorouter's route list, leaving a clean
                 # grid for whichever fallback handles the pair next.  No

--- a/tests/test_diffpair_shadow.py
+++ b/tests/test_diffpair_shadow.py
@@ -333,6 +333,201 @@ def test_offset_corner_join_collinear_needs_no_join():
 
 
 # ---------------------------------------------------------------------------
+# 4b-bis. sub-cell offset steps must be JOINED, not dropped (#4462)
+# ---------------------------------------------------------------------------
+#
+# ``_shadow_select_gap`` (#3990) picks the parallel-offset gap PER SEGMENT from
+# an impedance-band ladder.  Two consecutive COLLINEAR guide segments that pick
+# different rungs offset to endpoints separated perpendicular to travel by the
+# rung difference -- on board-06's 0.05 mm grid, 0.024 mm.  ``_offset_corner_join``
+# used to answer ``"none"`` ("the endpoints already meet") for any gap under half
+# a grid cell, and the caller then started the next segment 0.024 mm away from
+# where the previous one ended: a literal break in the emitted polyline.
+#
+# The break is invisible to the clearance/census gates but fatal downstream --
+# ``validate_net_connectivity`` unions endpoints snapped to a 0.01 mm lattice,
+# so the net reads "1/2 pads reached" and the #3540 transactional strand guard
+# rips the WHOLE coupled pair.  Measured on board-06: MIPI_CLK, MIPI_D0 and
+# PCIE_RX, all three already length-matched to under 0.45 mm by #4553.
+
+
+def test_offset_corner_join_subcell_step_is_bevelled_not_dropped():
+    """A sub-half-cell perpendicular step is real copper, not a coincidence."""
+    from kicad_tools.router.diffpair_routing import DiffPairRouter
+
+    # Collinear eastward guide; the second segment offsets 0.024 mm further out
+    # (a different rung of the variable-gap ladder).
+    pseg_start, pseg_end = (0.0, 0.250), (5.0, 0.250)
+    a, b = (5.0, 0.274), (10.0, 0.274)
+
+    mode, mx = DiffPairRouter._offset_corner_join(
+        pseg_start, pseg_end, a, b, side=+1.0, d=0.25, resolution=0.05
+    )
+
+    # 0.024 < resolution/2 == 0.025 -- the exact board-06 signature.
+    assert math.hypot(a[0] - pseg_end[0], a[1] - pseg_end[1]) < 0.05 / 2
+    assert mode == "bevel"
+    assert mx is None
+
+
+def test_offset_corner_join_none_only_within_a_serialization_quantum():
+    """``none`` is reserved for endpoints that serialize to the same coordinate."""
+    from kicad_tools.router.diffpair_routing import (
+        _OFFSET_JOIN_COINCIDENT_MM,
+        DiffPairRouter,
+    )
+
+    pseg_start, pseg_end = (0.0, 0.25), (5.0, 0.25)
+
+    def _mode(dy: float) -> str:
+        a = (5.0, 0.25 + dy)
+        b = (10.0, 0.25 + dy)
+        return DiffPairRouter._offset_corner_join(
+            pseg_start, pseg_end, a, b, side=+1.0, d=0.25, resolution=0.05
+        )[0]
+
+    assert _mode(0.0) == "none"
+    assert _mode(_OFFSET_JOIN_COINCIDENT_MM / 2.0) == "none"
+    # One order of magnitude above the quantum is already real copper.
+    assert _mode(_OFFSET_JOIN_COINCIDENT_MM * 10.0) == "bevel"
+
+
+def _chain_router_and_pathfinder(resolution: float = 0.05):
+    from kicad_tools.router.core import Autorouter
+
+    rules = DesignRules()
+    rules.grid_resolution = resolution
+    router = Autorouter(width=20.0, height=20.0, rules=rules)
+    pf = CoupledPathfinder(grid=router.grid, rules=rules, target_spacing_cells=4)
+    return router._diffpair, pf
+
+
+def _chain_route(points, net: int = 7) -> Route:
+    route = Route(net=net, net_name="MIPI_CLK-")
+    for k in range(len(points) - 1):
+        (x1, y1), (x2, y2) = points[k], points[k + 1]
+        route.segments.append(
+            Segment(
+                x1=x1,
+                y1=y1,
+                x2=x2,
+                y2=y2,
+                width=0.1,
+                layer=Layer.F_CU,
+                net=net,
+                net_name="MIPI_CLK-",
+            )
+        )
+    return route
+
+
+def test_close_shadow_chain_is_a_noop_on_a_connected_polyline():
+    dpr, pf = _chain_router_and_pathfinder()
+    route = _chain_route([(2.0, 2.0), (4.0, 2.0), (6.0, 4.0), (8.0, 4.0)])
+    before = [(s.x1, s.y1, s.x2, s.y2) for s in route.segments]
+
+    assert dpr._close_shadow_chain(route, pf) == 0
+    assert [(s.x1, s.y1, s.x2, s.y2) for s in route.segments] == before
+
+
+def test_close_shadow_chain_inserts_a_connector_for_a_subcell_break():
+    """The board-06 signature: a 0.024 mm break is closed with real copper."""
+    dpr, pf = _chain_router_and_pathfinder()
+    route = _chain_route([(2.0, 2.0), (4.0, 2.0)])
+    route.segments.append(
+        Segment(
+            x1=4.0,
+            y1=2.024,
+            x2=6.0,
+            y2=2.024,
+            width=0.1,
+            layer=Layer.F_CU,
+            net=7,
+            net_name="MIPI_CLK-",
+        )
+    )
+
+    assert dpr._close_shadow_chain(route, pf) == 1
+    pts = [(s.x1, s.y1) for s in route.segments] + [(route.segments[-1].x2, route.segments[-1].y2)]
+    for k in range(len(route.segments) - 1):
+        a, b = route.segments[k], route.segments[k + 1]
+        assert math.hypot(b.x1 - a.x2, b.y1 - a.y2) == 0.0
+    assert pts[0] == (2.0, 2.0)
+    assert pts[-1] == (6.0, 2.024)
+
+
+def test_close_shadow_chain_snaps_a_sub_quantum_gap_to_bit_equality():
+    dpr, pf = _chain_router_and_pathfinder()
+    route = _chain_route([(2.0, 2.0), (4.0, 2.0)])
+    route.segments.append(
+        Segment(
+            x1=4.0,
+            y1=2.00002,
+            x2=6.0,
+            y2=2.0,
+            width=0.1,
+            layer=Layer.F_CU,
+            net=7,
+            net_name="MIPI_CLK-",
+        )
+    )
+
+    assert dpr._close_shadow_chain(route, pf) == 1
+    # Snapped, not connector-ed: still two segments, endpoints bit-identical.
+    assert len(route.segments) == 2
+    assert route.segments[1].y1 == route.segments[0].y2
+
+
+def test_close_shadow_chain_leaves_a_large_gap_alone():
+    """Beyond one grid cell the strand guard, not a blind connector, decides."""
+    dpr, pf = _chain_router_and_pathfinder()
+    route = _chain_route([(2.0, 2.0), (4.0, 2.0)])
+    route.segments.append(
+        Segment(
+            x1=4.0, y1=3.0, x2=6.0, y2=3.0, width=0.1, layer=Layer.F_CU, net=7, net_name="MIPI_CLK-"
+        )
+    )
+
+    assert dpr._close_shadow_chain(route, pf) == 0
+    assert len(route.segments) == 2
+
+
+def test_subcell_break_strands_a_net_and_closing_it_restores_connectivity():
+    """Pins the whole bug->symptom chain the #3540 rollback reacted to."""
+    from kicad_tools.router.observability import validate_net_connectivity
+    from kicad_tools.router.primitives import Pad
+
+    dpr, pf = _chain_router_and_pathfinder()
+    route = _chain_route([(2.0, 2.0), (4.0, 2.0)])
+    route.segments.append(
+        Segment(
+            x1=4.0,
+            y1=2.024,
+            x2=6.0,
+            y2=2.024,
+            width=0.1,
+            layer=Layer.F_CU,
+            net=7,
+            net_name="MIPI_CLK-",
+        )
+    )
+    pads = [
+        Pad(x=2.0, y=2.0, width=0.3, height=0.3, layer=Layer.F_CU, net=7, net_name="MIPI_CLK-"),
+        Pad(x=6.0, y=2.024, width=0.3, height=0.3, layer=Layer.F_CU, net=7, net_name="MIPI_CLK-"),
+    ]
+
+    broken = validate_net_connectivity([route], {7: pads})[7]
+    assert broken["connected"] is False
+    assert broken["connected_pads"] == 1
+
+    dpr._close_shadow_chain(route, pf)
+
+    fixed = validate_net_connectivity([route], {7: pads})[7]
+    assert fixed["connected"] is True
+    assert fixed["connected_pads"] == 2
+
+
+# ---------------------------------------------------------------------------
 # 4c. shadow-aware guide re-routing: non-adjacent self-approach detection (#4460)
 # ---------------------------------------------------------------------------
 #


### PR DESCRIPTION
## Summary

Three board-06 diff pairs constructed *successfully* — length-matched to under
0.45 mm by #4553 — and were then **thrown away**. The #3540 transactional strand
guard reported `1/2 pads reached` and ripped all of their coupled copper.

Measuring it rather than assuming it found the cause, and it is one line of
geometry: **a 0.024 mm break in the emitted shadow polyline.**

`_offset_corner_join` answered `("none", None)` — documented as *"the offset
endpoints already meet"* — for any gap under **half a grid cell**. The caller
then appended the next segment starting at `a` while the previous one ended
0.024 mm away at `pseg_end`. Nothing was emitted to bridge them.

They do not "already meet". `_shadow_select_gap` (#3990) picks the
parallel-offset gap **per segment** from an impedance-band ladder; two
consecutive *collinear* guide segments that pick different rungs offset to
endpoints separated perpendicular to travel by the rung difference — on
board-06's 0.05 mm grid, exactly 0.024 mm, just under the 0.025 mm threshold.

The break is invisible to every gate the constructor runs (clearance, census,
overlap — all per-segment). It is fatal one layer down:
`validate_net_connectivity` unions segment endpoints snapped onto a 0.01 mm
lattice, so the net splits into two components, reads as `1/2 pads reached`, and
the pair is rolled back to fully-independent routing — 0% coupling and full
single-ended skew.

Instrumented run on `971fff5d`, all three breaks identical in kind:

```
[coupled-strand] MIPI_CLK net=21 stranded=['U4.2'] routes=1
  pad J4.2 @(106.100,117.500) nearest_endpoint=0.0000mm
  pad U4.2 @(125.500,116.300) nearest_endpoint=0.0000mm     <- both pads landed!
  route[0] segs=11 vias=0 start=(106.100,117.500) end=(125.500,116.300)
    break@seg3 gap=0.0240mm (109.300,117.024)->(109.300,117.000)
[coupled-strand] MIPI_D0 net=23 stranded=['U4.4']  break@seg3 gap=0.0240mm, break@seg5 gap=0.0240mm
[coupled-strand] PCIE_RX net=19 stranded=['U3.32'] break@seg9 gap=0.0240mm
```

Both landing tails reached their pads exactly (`nearest_endpoint=0.0000`). The
tails were never the problem; the body was broken in the middle.

## Changes

`src/kicad_tools/router/diffpair_routing.py` — all of it reached only via
`_shadow_route_pair`, i.e. only when `enable_shadow_construction=True`.

1. **`_offset_corner_join`: sub-cell steps are joined, not dropped.** `"none"`
   now means "coincident to within one 0.1 µm serialization quantum"
   (`_OFFSET_JOIN_COINCIDENT_MM`), and the caller snaps the following segment's
   start onto the previous end so the two coordinates are *bit-identical* — no
   rounding boundary can separate them. A gap between that quantum and half a
   grid cell returns `"bevel"`, emitting the connector chord. Deliberately a
   chord and not a miter: at this scale the two offset lines are near-parallel,
   so the miter apex is numerically unbounded, while the chord is exactly the
   (in every measured case, axis-aligned) step itself.

2. **Same hole in the post-via re-entry join** (the `elif` branch taken when the
   previous element is a via) — also thresholded at half a cell, also now
   thresholded at the serialization quantum.

3. **`_close_shadow_chain`: the invariant, enforced.** The shadow is assembled
   from three independently-built pieces (start tail + trimmed body + end tail),
   so "the polyline is connected" was an assumption, not a checked property. This
   walks the assembled route before the dogleg pass and closes any residual
   break — snapping within a serialization quantum, inserting a real
   obstacle-validated planar connector up to one grid cell. Anything larger is
   left exactly as today and the strand guard remains the backstop. It found
   *additional* breaks the corner-join fix does not cover (MIPI_D0, PCIE_TX,
   USB3_TX1, USB3_TX2 — at the tail/body junctions), so the class of defect was
   broader than the one instance.

4. **`_debug_strand`** — `KCT_SHADOW_DEBUG` provenance for a #3540 rollback:
   stranded pad ids, per-pad nearest-endpoint distance, and every chain break
   with its gap, layers and via-bridging status. This is what turned "landing
   tail exhausted its candidates" (the curated hypothesis, and the previous
   builder's) into a two-minute diagnosis.

`tests/test_diffpair_shadow.py`: +8 tests — the board-06 sub-cell signature is
bevelled not dropped; `"none"` is bounded by the serialization quantum;
`_close_shadow_chain` is a no-op on a connected polyline, inserts a connector for
a sub-cell break, snaps a sub-quantum gap to bit-equality, and leaves a large gap
alone; and an end-to-end test that pins the whole bug→symptom chain — a 0.024 mm
break makes `validate_net_connectivity` report `connected_pads == 1`, and closing
it restores `connected == True`.

**No thresholds were weakened.** No change to any skew, clearance, continuity or
impedance tolerance, to `min_segment_length`, or to
`.github/routed-drc-tolerance.yml`. `enable_shadow_construction` stays off by
default (Phase 5's job).

## Acceptance Criteria Verification

Measured with
`KCT_BOARD06_SHADOW=1 KCT_SHADOW_DEBUG=1 PYTHONHASHSEED=42 uv run python boards/06-diffpair-test/generate_design.py --step route --seed 42`
then `kct check --mfr jlcpcb`, before (`971fff5d`, reproducing PR #4567's table
exactly) and after.

### `kct check` — board-06 shadow-ON

| | before | after |
|---|---|---|
| **total errors** | **143** | **62** |
| `edge_clearance_trace` | 90 | **0** |
| `clearance_pad_segment` | 14 | 27 ⚠️ |
| `diffpair_clearance_intra` | 19 | 19 |
| `diffpair_routing_continuity` | 9 | **7** |
| `diffpair_length_skew` | 7 | 7 |
| `via_in_pad` | 1 | **0** |
| `clearance_pad_via` | 1 | **0** |
| `OffAngleSegmentWarning` | 2 | **0** |
| pairs rolled back by the strand guard | **3** | **0** |
| construction rate | 6/9 | 6/9 (identical pair set) |
| signal nets routed | 20/21 | 20/21 |

**AC: the strand-rollback path is closed — MET.** Zero
`[coupled-shadow] ... stranded` warnings. MIPI_CLK, MIPI_D0 and PCIE_RX all keep
their coupled copper.

**AC: continuity errors at or below the pre-#4567 count of 6 — NOT MET (7).**
Two of the three rolled-back pairs now pass outright:

| pair | before | after | threshold |
|---|---|---|---|
| MIPI_CLK | 0.0% | **passes** | 85% |
| PCIE_RX | 0.0% | **passes** | 85% |
| MIPI_D0 | 3.9% | 78.5% | 85% |

The remaining four in-scope failures are characterised, not hand-waved:

- **USB3_TX1 83.5% and USB3_TX2 84.0% are arithmetically unreachable.** Adding
  differential length necessarily uncouples it: 6.3 mm on a 53.0 mm leg caps
  coupling at 89.4%, and 4.9 mm on 38.7 mm caps it at 88.8% — both under the 90%
  threshold *at zero window consumption*. This is the trade #4567's judge review
  explicitly ruled non-blocking and left here; it cannot be closed without either
  weakening the threshold (forbidden) or giving back the skew win.
- **MIPI_D0 78.5% and USB2_D 62.9% are landing-tail/trim dominated, not meander
  dominated.** MIPI_D0's accepted construction carries `tail0=4.804 tail1=2.750`
  on a 24.4 mm leg; USB2_D's carries `trim0=4.144 tail0=4.116` on 12.1 mm. That
  is a genuinely separate lever (shorter tails, not better meanders) and is
  filed rather than rushed.

**AC: #4567's skew wins preserved, per-pair delta within 2× tolerance — MET at
construction for 5 of 6.** Constructed deltas after: MIPI_CLK 0.456 (2×tol 0.600),
PCIE_RX 0.467 (1.000), USB2_D 0.921 (6.000), USB3_TX1 0.012 (1.000), USB3_TX2
0.162 (1.000). MIPI_D0 is the exception at 1.944 (2×tol 0.600) — it is now routed
via the swapped-role path because MIPI_CLK's *surviving* coupled copper occupies
space the old attempt used. Even so it is a 6.569 → 1.944 mm improvement at
artifact level.

**AC: construction rate not below 6/9 — MET.** 6/9, identical pair set.

**AC: no off-angle regression from constructed copper — MET, improved.** 2 → 0
`OffAngleSegmentWarning` (both prior warnings were on PCIE_TX-, emitted by the
step-13 via-legalization pass, not by the constructor).

**AC: check total never worse than 143 — MET.** 143 → 62.

**AC: shadow-OFF unaffected — MET.** Every changed code path is inside
`_shadow_route_pair`. `PYTHONHASHSEED=42 uv run python scripts/ci/check_diffpair_coverage.py boards/06-diffpair-test --seed 42`
→ **exit 0**, 18 errors (allowed 18), signal reach **21/21**, pour connectivity OK,
all 3 diff-pair rules exercised — byte-identical to the documented baseline.

### Two residuals, both measured — reviewer attention requested

**1. `clearance_pad_segment` 14 → 27.** Not new copper *behaviour*; newly
*surviving* copper. All 13 additions are on MIPI_CLK's coupled copper in the FFC
connector's pad field — copper that in the previous run was ripped by the strand
guard and never reached the artifact. Four are foreign-net (`MIPI_CLK-` vs
`MIPI_D0±` pads, 0.037 mm) and are real: the shadow constructor validates its
offset against the grid raster, which is not encoding those pad halos the way the
DRC rule measures them. Same shape as the `edge_clearance_trace` finding the
judge ruled on in #4567 — a pre-existing gap in a different subsystem, exposed by
changing which pairs survive. Filed as **#4571** rather than fixed here.
Net effect on the same surface is −81 errors.

**2. `diffpair_length_skew` count unchanged at 7, and PCIE_RX reads 2.153 →
3.667 — which is not a regression, it is a *unit* mismatch I can now name
exactly.** The rule's length model (`DiffPairLengthTracker._measure_route`)
includes **via drilled length**; the constructor's `_length_match_constructed_pair`
sums **planar copper only**. Measured from the artifact:

| pair | planar Δ | vias P / N | via z-length Δ | rule skew |
|---|---|---|---|---|
| PCIE_RX | 0.467 | 0 / 2 (F.Cu→B.Cu) | 2 × 1.6 = 3.200 | 3.667 ✔ |
| USB3_TX1 | 0.012 | 0 / 2 (F.Cu→B.Cu) | 3.200 | 3.188 ✔ |

Both reconcile to the millimetre. PCIE_RX's *planar* copper actually improved
2.153 → 0.467. The residual is entirely **via-count asymmetry between the P and N
legs**, introduced by a landing tail that dives through the board while its
partner stays on F.Cu. Closing it means either compensating the z-length in the
meander (which buys skew at the cost of coupled fraction — a net-zero trade on
this board, I checked the arithmetic) or matching via counts across the legs
(the electrically correct answer, and a real piece of work). Filed as **#4570**,
with the full reconciliation table and both candidate fixes written up.

## Test Plan

- `uv run pytest tests/ -k "diffpair or shadow or serpentine or quantize or board_06 or fleet_45 or observability or length"` — **1210 passed, 6 skipped, 0 failed**.
- `uv run pytest tests/test_diffpair_shadow.py tests/test_diffpair.py tests/test_diffpair_self_intersection.py tests/test_diffpair_corridor.py tests/test_diffpair_coupled_instrumentation_4459.py tests/test_diffpair_length_tuning.py tests/test_diffpair_serpentine_clearance.py` — 218 passed.
- Shadow-OFF CI gate `scripts/ci/check_diffpair_coverage.py` — exit 0, 21/21 reach, 18/18 errors.
- `uv run ruff format . --check` → 1724 files already formatted; `uv run ruff check .` → All checks passed.
- Regenerated board artifacts restored with `git checkout --`; the diff is source + tests only.

### Pre-existing failure (NOT introduced by this PR)

`scripts/ci/check_mypy_baseline.py` fails locally with one error in
`src/kicad_tools/recovery/strategy.py`, a file this PR does not touch — the known
local mypy-version drift against `.github/mypy-baseline.txt` documented on #4567.
CI is authoritative.

## CI

**16/16 checks pass** on `0bd9c2b8` — including `Test` (19m39s), `Type Check`
(settling the local mypy drift above as environmental), the shadow-OFF
`Diff-Pair Routing Regression (boards/06-diffpair-test)`, and all eight board
end-to-end jobs.

## Follow-ups filed

- **#4570** — construction-time length matching is blind to via drilled length
  (explains the two residual skew errors to the millimetre).
- **#4571** — shadow constructor emits copper inside foreign pad clearance halos
  (explains the `clearance_pad_segment` 14 → 27 movement).

Closes #4462

