### PR TITLE
fix(diffpair): validate shadow-constructed copper against foreign pad clearance

### DIFF
--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -227,6 +227,41 @@ _SHADOW_MEANDER_MAX_FRAC: float = float(os.environ.get("KCT_SHADOW_MEANDER_MAX_F
 _SHADOW_MEANDER_MAX_CELLS: int = int(os.environ.get("KCT_SHADOW_MEANDER_MAX_CELLS", "12"))
 _SHADOW_MEANDER_MIN_CELLS: int = int(os.environ.get("KCT_SHADOW_MEANDER_MIN_CELLS", "3"))
 
+# Issue #4571: exact foreign-pad clearance gate for constructed copper.
+#
+# Every shadow validation gate rasterises against ``_is_cell_blocked``, whose
+# pad halo is INTENTIONALLY shrunk in fine-pitch corridors (``RoutingGrid.
+# _clearance_for_pin_pitch``, "full manufacturer clearance is validated in
+# post-routing DRC").  For single-ended nets that promise is kept by
+# ``Autorouter._demote_pad_clearance_violation_nets`` (exact, but only demotes
+# above one grid resolution) plus ``drc_verify_and_nudge`` (the sub-resolution
+# remainder) -- and ``drc_verify_and_nudge`` unconditionally SKIPS diff-pair
+# nets (#3508: the nudge helpers are not partner-aware).  So constructed
+# coupled copper had no stage, coarse or exact, that agreed with the
+# ``clearance_pad_segment`` DRC predicate, and shipped sub-resolution pad
+# grazes and outright pad overlaps (measured on board-06 shadow-ON, seed 42:
+# MIPI_CLK- over MIPI_D0+/MIPI_D0- pads at 0.037 mm and over its own partner's
+# MIPI_CLK+ pads at 0.015 mm).
+#
+# The gate below re-uses the exact-geometry primitives the single-ended
+# backstop uses (``RoutingGrid.worst_segment_pad_deficit`` /
+# ``worst_via_pad_deficit``) at construction time, with ``exclude_net`` ONLY --
+# no ``exclude_refs``.  Passing the net's own component refs (the way the
+# single-ended backstop does) would hand the pads of a P/N pair that shares one
+# connector ref straight to the #3545 same-component carve-out and silently
+# re-exempt the partner's pad on exactly the fine-pitch connectors this gate
+# exists for.
+#
+# ``_SHADOW_PAD_DEFICIT_EPS`` is a geometric noise floor (a serialization
+# quantum), NOT a clearance relaxation: it must stay far below the grid
+# resolution, because unlike the single-ended path there is no downstream
+# repair pass to absorb whatever this gate lets through.
+_SHADOW_PAD_DEFICIT_EPS: float = 1e-4
+# Chunk length used to localise WHERE along a body segment a pad deficit sits,
+# so the existing end-trim machinery can shave a grazing landing instead of
+# declining the whole side.
+_SHADOW_PAD_PROBE_STEP_MM: float = 0.2
+
 
 # ---------------------------------------------------------------------------
 # Issue #3023 Phase A: intra-pair clearance violation detection
@@ -3205,8 +3240,10 @@ class DiffPairRouter:
         # Issue #4459 (Phase 1 of #4409): ground-truth instrumentation for the
         # coupled diff-pair search.  ``_last_shadow_decline_reason`` records the
         # LAST reason the geometric shadow constructor declined a side
-        # ("overlap" -- self-check / physical P/N overlap, or "blockage" --
-        # no legal via site / mid-route obstacle / unreachable pad tail);
+        # ("overlap" -- self-check / physical P/N overlap, "blockage" --
+        # no legal via site / mid-route obstacle / unreachable pad tail, or
+        # "pad-clearance" -- constructed copper inside a foreign pad's
+        # clearance halo, #4571);
         # reset per spec, set inside ``_shadow_route_pair``.
         # ``_last_coupled_pair_report`` holds the most-recent per-pair
         # taxonomy classification (a :class:`CoupledPairReport`).  Both are
@@ -3833,6 +3870,173 @@ class DiffPairRouter:
                 return False
         return True
 
+    # ------------------------------------------------------------------
+    # Issue #4571: exact foreign-pad clearance gate for constructed copper
+    # ------------------------------------------------------------------
+
+    def _pad_component_pitches(self) -> dict[str, float] | None:
+        """Ref -> min pin pitch map for the exact pad-clearance primitives.
+
+        Mirrors what ``Autorouter._demote_pad_clearance_violation_nets``
+        feeds ``worst_segment_pad_deficit`` so the constructor's gate and
+        the single-ended finalization backstop agree on the REQUIRED
+        clearance for every component (fine-pitch relaxations included).
+        """
+        try:
+            return self.autorouter.component_pitches
+        except Exception:  # pragma: no cover - defensive (test doubles)
+            return None
+
+    def _span_pad_deficit(
+        self,
+        x1: float,
+        y1: float,
+        x2: float,
+        y2: float,
+        layer_idx: int,
+        net: int,
+        width: float,
+    ) -> float:
+        """Worst exact clearance deficit of a candidate span vs FOREIGN pads.
+
+        Issue #4571.  ``> 0`` means the span would violate the
+        ``clearance_pad_segment`` predicate against some pad that is not on
+        ``net`` -- including the diff-pair PARTNER's pads, which are a
+        foreign net and therefore fully checked.
+
+        Deliberately called with ``exclude_net`` only and NO
+        ``exclude_refs``: the #3545 same-component carve-out would otherwise
+        exempt the partner's pad whenever P and N share a fine-pitch
+        connector ref (the board-06 FFC case this gate exists for).
+        """
+        grid = self.autorouter.grid
+        probe = Segment(
+            x1=x1,
+            y1=y1,
+            x2=x2,
+            y2=y2,
+            width=width,
+            layer=Layer(grid.index_to_layer(layer_idx)),
+            net=net,
+            net_name="",
+        )
+        deficit, _loc = grid.worst_segment_pad_deficit(
+            probe,
+            exclude_net=net,
+            component_pitches=self._pad_component_pitches(),
+        )
+        return deficit
+
+    def _span_pad_clear(
+        self,
+        x1: float,
+        y1: float,
+        x2: float,
+        y2: float,
+        layer_idx: int,
+        net: int,
+        width: float,
+    ) -> bool:
+        """True when a candidate span keeps foreign-pad clearance (#4571)."""
+        return (
+            self._span_pad_deficit(x1, y1, x2, y2, layer_idx, net, width) <= _SHADOW_PAD_DEFICIT_EPS
+        )
+
+    def _segment_pad_clear(self, seg: Segment) -> bool:
+        """True when an assembled segment keeps foreign-pad clearance (#4571)."""
+        grid = self.autorouter.grid
+        return self._span_pad_clear(
+            seg.x1,
+            seg.y1,
+            seg.x2,
+            seg.y2,
+            grid.layer_to_index(seg.layer.value),
+            seg.net,
+            seg.width,
+        )
+
+    def _via_pad_deficit(self, via: Via) -> float:
+        """Worst exact clearance deficit of a via vs FOREIGN pads (#4571)."""
+        deficit, _loc = self.autorouter.grid.worst_via_pad_deficit(
+            via,
+            exclude_net=via.net,
+            component_pitches=self._pad_component_pitches(),
+        )
+        return deficit
+
+    def _route_pad_violation(
+        self,
+        route: Route,
+    ) -> tuple[float, tuple[float, float] | None]:
+        """Worst foreign-pad clearance deficit over an assembled route (#4571).
+
+        Returns ``(worst_deficit, worst_pad_location)``; ``worst_deficit <=
+        _SHADOW_PAD_DEFICIT_EPS`` means the route is clean.
+        """
+        grid = self.autorouter.grid
+        pitches = self._pad_component_pitches()
+        worst = 0.0
+        worst_loc: tuple[float, float] | None = None
+        for seg in route.segments:
+            deficit, loc = grid.worst_segment_pad_deficit(
+                seg,
+                exclude_net=seg.net,
+                component_pitches=pitches,
+            )
+            if deficit > worst:
+                worst, worst_loc = deficit, loc
+        for via in route.vias:
+            deficit, loc = grid.worst_via_pad_deficit(
+                via,
+                exclude_net=via.net,
+                component_pitches=pitches,
+            )
+            if deficit > worst:
+                worst, worst_loc = deficit, loc
+        return worst, worst_loc
+
+    def _pad_deficit_arcs(
+        self,
+        x1: float,
+        y1: float,
+        x2: float,
+        y2: float,
+        layer_idx: int,
+        net: int,
+        width: float,
+        arc0: float,
+    ) -> list[float]:
+        """Arc positions along a span whose copper violates a foreign pad.
+
+        Issue #4571.  The blockage scan in :meth:`_shadow_route_pair`
+        localises RASTER blockages by arc length so the existing end-trim
+        machinery can shave a grazing landing (and only an INTERIOR blockage
+        fails the side).  This is the exact-pad-clearance sibling: the whole
+        span is probed first (one pass over the pad list) and only a span
+        that actually violates is subdivided, so the common clean case costs
+        a single call.
+        """
+        if self._span_pad_clear(x1, y1, x2, y2, layer_idx, net, width):
+            return []
+        span_len = math.hypot(x2 - x1, y2 - y1)
+        n_chunks = max(1, int(math.ceil(span_len / _SHADOW_PAD_PROBE_STEP_MM)))
+        arcs: list[float] = []
+        for i in range(n_chunks):
+            t0 = i / n_chunks
+            t1 = (i + 1) / n_chunks
+            cx1 = x1 + (x2 - x1) * t0
+            cy1 = y1 + (y2 - y1) * t0
+            cx2 = x1 + (x2 - x1) * t1
+            cy2 = y1 + (y2 - y1) * t1
+            if not self._span_pad_clear(cx1, cy1, cx2, cy2, layer_idx, net, width):
+                arcs.append(arc0 + span_len * (t0 + t1) / 2.0)
+        # A violation the chunking could not localise (e.g. a span shorter
+        # than one chunk) still has to be reported, or the caller would treat
+        # the span as clean.
+        if not arcs:
+            arcs.append(arc0 + span_len / 2.0)
+        return arcs
+
     def _synthesize_tail(
         self,
         pathfinder: CoupledPathfinder,
@@ -3937,6 +4141,19 @@ class DiffPairRouter:
                 if near_partner and any(
                     self._min_distance_to_partner(x1, y1, x2, y2, near_partner, layer)
                     < partner_clearance
+                    for x1, y1, x2, y2 in segs
+                ):
+                    continue
+                # Issue #4571: the grid raster's pad halo is shrunk in
+                # fine-pitch corridors, so a cell-clear landing tail can still
+                # sit inside (or on top of) a foreign pad -- and a diff-pair
+                # net gets no downstream nudge repair.  Screen every candidate
+                # with the exact DRC-equivalent predicate here, INSIDE the
+                # loop, so the remaining detours stay reachable instead of the
+                # constructor accepting the first raster-clear candidate and
+                # shipping a short.
+                if any(
+                    not self._span_pad_clear(x1, y1, x2, y2, layer_idx, head.net, width)
                     for x1, y1, x2, y2 in segs
                 ):
                     continue
@@ -4268,6 +4485,14 @@ class DiffPairRouter:
                                 net_name=head.net_name,
                             )
                         )
+                    # Issue #4571: the crossover's stubs, its alt-layer
+                    # crossing and BOTH via barrels are only raster-validated
+                    # above, and the raster's pad halo is shrunk in fine-pitch
+                    # corridors.  Screen the assembled candidate with the exact
+                    # DRC-equivalent pad predicate so a violating crossover
+                    # loses to a later via-site candidate instead of shipping.
+                    if self._route_pad_violation(route)[0] > _SHADOW_PAD_DEFICIT_EPS:
+                        continue
                     return route
         return None
 
@@ -4388,7 +4613,20 @@ class DiffPairRouter:
             )
             return r if (r is not None and r.segments) else None
 
+        # Issue #4571: the A* probe validates against the grid raster, whose
+        # pad halo is shrunk in fine-pitch corridors, and a diff-pair net is
+        # excluded from ``drc_verify_and_nudge`` -- so a raster-clear fallback
+        # tail is the constructor's most direct route to a pad short.  Discard
+        # any probe result whose copper violates the exact pad predicate; the
+        # caller's anchor-stepping retry then gets the attempt instead.
+        def _pad_ok(cand: Route | None) -> bool:
+            return cand is not None and self._route_pad_violation(cand)[0] <= (
+                _SHADOW_PAD_DEFICIT_EPS
+            )
+
         plain = _probe(None, 1)
+        if not _pad_ok(plain):
+            plain = None
         if not partner_segments:
             return plain
         if plain is not None and self._tail_partner_clear(plain, partner_segments, seg_clear):
@@ -4400,6 +4638,8 @@ class DiffPairRouter:
                 1, int(round(seg_clear / max(self.autorouter.grid.resolution, 1e-9) / 3.0))
             )
             biased = _probe(sites, radius_cells)
+            if not _pad_ok(biased):
+                biased = None
             if biased is not None and self._tail_partner_clear(biased, partner_segments, seg_clear):
                 return biased
         # Neither reaches the coupled clearance: settle for any tail that at
@@ -4720,6 +4960,12 @@ class DiffPairRouter:
                 for s in probe:
                     if not self._segment_cells_clear(pathfinder, s.x1, s.y1, s.x2, s.y2, _li, _net):
                         return False
+                    # Issue #4571: a meander tooth is constructed copper on a
+                    # net the downstream nudge repair skips -- validate it
+                    # against the exact foreign-pad predicate, not only the
+                    # (fine-pitch-shrunk) raster halo.
+                    if not self._span_pad_clear(s.x1, s.y1, s.x2, s.y2, _li, _net, _w):
+                        return False
                     if (
                         self._min_distance_to_partner(
                             s.x1, s.y1, s.x2, s.y2, partner_segments, _t.layer
@@ -4872,8 +5118,12 @@ class DiffPairRouter:
                 continue
             if cur.layer == prev.layer and gap <= res:
                 li = self.autorouter.grid.layer_to_index(cur.layer.value)
+                # Issue #4571: the inserted connector is real copper -- hold it
+                # to the exact foreign-pad predicate too, not just the raster.
                 if self._segment_cells_clear(
                     pathfinder, prev.x2, prev.y2, cur.x1, cur.y1, li, cur.net
+                ) and self._span_pad_clear(
+                    prev.x2, prev.y2, cur.x1, cur.y1, li, cur.net, cur.width
                 ):
                     out.append(
                         Segment(
@@ -4977,6 +5227,14 @@ class DiffPairRouter:
                         gx, gy = grid.world_to_grid(x1 + (x2 - x1) * t, y1 + (y2 - y1) * t)
                         if pathfinder._is_cell_blocked(gx, gy, _li, _seg.net):
                             return False
+                    # Issue #4571: the dogleg's perpendicular bulge is NEW
+                    # copper on a net the downstream nudge repair skips, and
+                    # the raster it was just checked against carries the
+                    # shrunk fine-pitch pad halo.  A variant that swings a leg
+                    # into a foreign pad's clearance halo loses to the other
+                    # variant (or the segment is kept as-is, unchanged).
+                    if not self._span_pad_clear(x1, y1, x2, y2, _li, _seg.net, _seg.width):
+                        return False
                 return True
 
             chosen_mid: tuple[float, float] | None = None
@@ -5855,6 +6113,27 @@ class DiffPairRouter:
             blocked_arcs: list[float] = []
             for e in elements:
                 if e[0] == "via":
+                    # Issue #4571: a shadow via is exempt from the raster scan
+                    # (its site was chosen with the via predicate), but that
+                    # predicate reads the same shrunk pad halo.  Report a via
+                    # whose barrel violates the exact pad predicate at ITS arc
+                    # position, so the trim/interior logic below treats it like
+                    # any other blockage.
+                    _, vx0, vy0, vl0, vl1 = e
+                    probe_via = Via(
+                        x=vx0,
+                        y=vy0,
+                        drill=rules.via_drill,
+                        diameter=rules.via_diameter,
+                        layers=(
+                            Layer(grid.index_to_layer(vl0)),
+                            Layer(grid.index_to_layer(vl1)),
+                        ),
+                        net=s_net,
+                        net_name=s_net_name,
+                    )
+                    if self._via_pad_deficit(probe_via) > _SHADOW_PAD_DEFICIT_EPS:
+                        blocked_arcs.append(arc)
                     continue
                 _, x1, y1, x2, y2, li = e
                 seg_len = math.hypot(x2 - x1, y2 - y1)
@@ -5866,6 +6145,12 @@ class DiffPairRouter:
                     gx, gy = grid.world_to_grid(x1 + (x2 - x1) * t, y1 + (y2 - y1) * t)
                     if pathfinder._is_cell_blocked(gx, gy, li, s_net):
                         blocked_arcs.append(arc + seg_len * t)
+                # Issue #4571: exact pad-clearance sibling of the raster scan.
+                # Reported as ARCS (not as an outright rejection) so a body
+                # end grazing a connector pad field is TRIMMED into the landing
+                # tail -- the same graceful path the raster blockages take --
+                # and only an interior pad violation fails the side.
+                blocked_arcs.extend(self._pad_deficit_arcs(x1, y1, x2, y2, li, s_net, s_width, arc))
                 arc += seg_len
             trim_start = 0.0
             trim_end = 0.0
@@ -6170,6 +6455,32 @@ class DiffPairRouter:
                     f"other side"
                 )
                 self._last_shadow_decline_reason = "overlap"  # #4459
+                continue
+            # Issue #4571 (third pass): FOREIGN-PAD clearance self-check.  The
+            # two gates above compare copper to copper only -- segment to
+            # segment and via to segment/via -- so neither can see a landing
+            # tail drawn across the sibling pin's PAD (the board-06 FFC case:
+            # MIPI_CLK- copper over MIPI_D0+/MIPI_D0- pads at 0.037 mm and over
+            # its own partner MIPI_CLK+'s pads at 0.015 mm).  The exact
+            # ``clearance_pad_segment``-equivalent primitives close that
+            # quadrant here, at the same "fail this side over to the other"
+            # point, using ``exclude_net`` only so the partner's pads on a
+            # shared fine-pitch connector ref are never carve-out-exempted.
+            #
+            # Only the CONSTRUCTED leg is gated: the guide is ordinary
+            # single-ended copper produced (and validated) by the per-net
+            # router, and it keeps the single-ended finalization backstops.
+            # Declining a side over a pre-existing guide graze would cost
+            # coupling without fixing anything the constructor introduced.
+            pad_deficit, pad_loc = self._route_pad_violation(shadow_route)
+            if pad_deficit > _SHADOW_PAD_DEFICIT_EPS:
+                loc_str = f" near ({pad_loc[0]:.3f}, {pad_loc[1]:.3f})" if pad_loc else ""
+                print(
+                    f"    [coupled-shadow] side={side:+.0f} foreign-pad "
+                    f"clearance deficit {pad_deficit:.3f}mm{loc_str} for "
+                    f"{pair.name}; trying other side"
+                )
+                self._last_shadow_decline_reason = "pad-clearance"  # #4571
                 continue
             return p_route, n_route
 

--- a/tests/test_diffpair_shadow.py
+++ b/tests/test_diffpair_shadow.py
@@ -2393,3 +2393,278 @@ def test_meander_is_a_no_op_when_nothing_is_owed():
     short.segments.append(_gseg(2.0, 5.0, 12.0, 5.0))
     assert dpr._meander_route_to_length(short, [_gseg(2.0, 5.3, 12.0, 5.3)], pf, 0.0, 0.3) == 0.0
     assert len(short.segments) == 1
+
+
+# ---------------------------------------------------------------------------
+# 13. exact foreign-pad clearance gate for constructed copper (issue #4571)
+# ---------------------------------------------------------------------------
+#
+# Every shadow validation gate rasterises against ``_is_cell_blocked``, whose
+# pad halo is deliberately SHRUNK in fine-pitch corridors on the documented
+# promise that "full manufacturer clearance is validated in post-routing DRC".
+# For a diff-pair net that promise is never kept: the single-ended finalization
+# backstop only demotes deficits larger than one grid resolution, and
+# ``drc_verify_and_nudge`` (which would mop up the sub-resolution remainder)
+# unconditionally SKIPS coupled nets (#3508 -- the nudge helpers are not
+# partner-aware).  The constructor's own self-checks compare copper to copper
+# only, never copper to PAD.  Measured consequence on board-06 shadow-ON:
+# MIPI_CLK- copper over the MIPI_D0+/MIPI_D0- pads (0.037 mm) and over its own
+# partner MIPI_CLK+'s pads (0.015 mm) -- real shorts, all BELOW the 0.05 mm
+# floor the single-ended backstop would have caught.
+#
+# These tests pin the gate at the primitive level: sub-resolution grazes are
+# rejected, own-net pads stay legal (a tail must be able to land), and the
+# #3545 same-component carve-out can never re-exempt the PARTNER's pad on a
+# shared fine-pitch connector ref.
+
+
+def _pad_gate_router(resolution: float = 0.05):
+    from kicad_tools.router.core import Autorouter
+
+    rules = DesignRules()
+    rules.grid_resolution = resolution
+    router = Autorouter(width=20.0, height=10.0, rules=rules)
+    return router._diffpair
+
+
+def _pad_at(x, y, net, name, ref="J1", pin="1", size=0.3):
+    from kicad_tools.router.primitives import Pad
+
+    return Pad(
+        x=x,
+        y=y,
+        width=size,
+        height=size,
+        layer=Layer.F_CU,
+        net=net,
+        net_name=name,
+        ref=ref,
+        pin=pin,
+    )
+
+
+# Geometry used throughout: a 0.3 x 0.3 pad reads as a 0.15 mm radius disc, a
+# 0.2 mm trace contributes 0.1 mm of half-width, and the default manufacturer
+# clearance is 0.2 mm.  A centreline 0.42 mm from the pad centre therefore has
+# 0.17 mm of edge clearance -- a 0.03 mm deficit, i.e. BELOW the 0.05 mm grid
+# resolution the single-ended backstop uses as its floor.
+_GRAZE_DY = 0.42
+_GRAZE_DEFICIT = 0.03
+
+
+def test_span_pad_clear_rejects_a_subresolution_foreign_pad_graze():
+    dpr = _pad_gate_router()
+    dpr.autorouter.grid.add_pad(_pad_at(5.0, 5.0, net=99, name="MIPI_D0+"))
+
+    deficit = dpr._span_pad_deficit(3.0, 5.0 + _GRAZE_DY, 7.0, 5.0 + _GRAZE_DY, 0, 7, 0.2)
+    assert deficit == pytest.approx(_GRAZE_DEFICIT, abs=1e-9)
+    # The whole point of the gate: this is smaller than one grid cell, so the
+    # single-ended finalization backstop's ``nudge_reach`` floor would let it
+    # ship, and ``drc_verify_and_nudge`` never runs on a coupled net.
+    assert deficit < dpr.autorouter.grid.resolution
+    assert dpr._span_pad_clear(3.0, 5.0 + _GRAZE_DY, 7.0, 5.0 + _GRAZE_DY, 0, 7, 0.2) is False
+
+
+def test_span_pad_clear_accepts_copper_outside_the_halo():
+    dpr = _pad_gate_router()
+    dpr.autorouter.grid.add_pad(_pad_at(5.0, 5.0, net=99, name="MIPI_D0+"))
+
+    assert dpr._span_pad_clear(3.0, 6.5, 7.0, 6.5, 0, 7, 0.2) is True
+
+
+def test_span_pad_clear_ignores_the_segments_own_net_pad():
+    """A landing tail MUST be able to reach (and sit on) its own pad."""
+    dpr = _pad_gate_router()
+    dpr.autorouter.grid.add_pad(_pad_at(5.0, 5.0, net=7, name="MIPI_CLK-"))
+
+    # Straight through the middle of its own pad: legal, by definition.
+    assert dpr._span_pad_clear(3.0, 5.0, 7.0, 5.0, 0, 7, 0.2) is True
+
+
+def test_span_pad_clear_flags_a_pad_on_a_different_layer_only_when_shared():
+    dpr = _pad_gate_router()
+    dpr.autorouter.grid.add_pad(_pad_at(5.0, 5.0, net=99, name="MIPI_D0+"))
+
+    b_cu = dpr.autorouter.grid.layer_to_index(Layer.B_CU.value)
+    # Same geometry on the opposite layer: an SMD pad cannot be violated.
+    assert dpr._span_pad_clear(3.0, 5.0, 7.0, 5.0, b_cu, 7, 0.2) is True
+
+
+def test_partner_pad_on_a_shared_connector_ref_is_not_carveout_exempt():
+    """The #3545 same-component carve-out must never hide a PARTNER pad.
+
+    Diff-pair P and N legs routinely land on the same fine-pitch connector
+    ``ref`` (board-06's FFC carries both MIPI_CLK+ and MIPI_CLK-).  Reusing
+    ``worst_segment_pad_deficit`` the way the single-ended backstop does --
+    with ``exclude_refs`` set to the net's own component refs -- hands the
+    partner's pad straight to the carve-out and silences exactly the
+    intra-pair overlap this gate exists to catch.
+    """
+    dpr = _pad_gate_router()
+    grid = dpr.autorouter.grid
+    # Both pair legs on one fine-pitch (0.4 mm pitch) connector ref.
+    grid.add_pad(_pad_at(5.0, 5.0, net=8, name="MIPI_CLK+", ref="J1", pin="1"))
+    grid.add_pad(_pad_at(5.4, 5.0, net=7, name="MIPI_CLK-", ref="J1", pin="2"))
+    assert grid._component_is_fine_pitch("J1") is True
+
+    seg = Segment(
+        x1=3.0,
+        y1=5.0 + _GRAZE_DY,
+        x2=7.0,
+        y2=5.0 + _GRAZE_DY,
+        width=0.2,
+        layer=Layer.F_CU,
+        net=7,
+        net_name="MIPI_CLK-",
+    )
+    # The single-ended backstop's call shape: the carve-out silences it.
+    exempted, _ = grid.worst_segment_pad_deficit(seg, exclude_net=7, exclude_refs={"J1"})
+    assert exempted == 0.0
+    # The constructor's gate passes ``exclude_net`` ONLY -- the partner's pad
+    # (and MIPI_CLK-'s own pad, which is same-net and correctly skipped) is
+    # measured exactly.
+    assert dpr._span_pad_deficit(seg.x1, seg.y1, seg.x2, seg.y2, 0, 7, 0.2) == pytest.approx(
+        _GRAZE_DEFICIT, abs=1e-9
+    )
+    assert dpr._segment_pad_clear(seg) is False
+
+
+def test_route_pad_violation_reports_the_worst_segment_deficit():
+    dpr = _pad_gate_router()
+    dpr.autorouter.grid.add_pad(_pad_at(5.0, 5.0, net=99, name="MIPI_D0+"))
+
+    route = Route(net=7, net_name="MIPI_CLK-")
+    route.segments.append(
+        Segment(
+            x1=3.0,
+            y1=5.0 + _GRAZE_DY,
+            x2=7.0,
+            y2=5.0 + _GRAZE_DY,
+            width=0.2,
+            layer=Layer.F_CU,
+            net=7,
+            net_name="MIPI_CLK-",
+        )
+    )
+    deficit, loc = dpr._route_pad_violation(route)
+    assert deficit == pytest.approx(_GRAZE_DEFICIT, abs=1e-9)
+    assert loc == (5.0, 5.0)
+
+
+def test_route_pad_violation_covers_the_via_quadrant():
+    """A shadow via barrel inside a foreign pad halo is a violation too."""
+    dpr = _pad_gate_router()
+    rules = dpr.autorouter.rules
+    dpr.autorouter.grid.add_pad(_pad_at(5.0, 5.0, net=99, name="MIPI_D0+"))
+
+    clean = Route(net=7, net_name="MIPI_CLK-")
+    clean.vias.append(
+        Via(
+            x=8.0,
+            y=5.0,
+            drill=rules.via_drill,
+            diameter=rules.via_diameter,
+            layers=(Layer.F_CU, Layer.B_CU),
+            net=7,
+            net_name="MIPI_CLK-",
+        )
+    )
+    assert dpr._route_pad_violation(clean)[0] == 0.0
+
+    grazing = Route(net=7, net_name="MIPI_CLK-")
+    grazing.vias.append(
+        Via(
+            x=5.0,
+            y=5.0 + 0.15 + rules.via_diameter / 2 + 0.15,
+            drill=rules.via_drill,
+            diameter=rules.via_diameter,
+            layers=(Layer.F_CU, Layer.B_CU),
+            net=7,
+            net_name="MIPI_CLK-",
+        )
+    )
+    deficit, loc = dpr._route_pad_violation(grazing)
+    assert deficit == pytest.approx(0.05, abs=1e-9)
+    assert loc == (5.0, 5.0)
+
+
+def test_pad_deficit_arcs_localise_the_violating_end_of_a_span():
+    """Violations are reported as ARCS so the end-trim can shave them.
+
+    A body segment that only grazes a connector pad at one END must not fail
+    the whole side -- the existing trim machinery consumes the offending arc
+    into the landing tail, exactly as it does for raster blockages.
+    """
+    dpr = _pad_gate_router()
+    dpr.autorouter.grid.add_pad(_pad_at(2.5, 5.0, net=99, name="MIPI_D0+"))
+
+    arcs = dpr._pad_deficit_arcs(2.0, 5.0 + _GRAZE_DY, 12.0, 5.0 + _GRAZE_DY, 0, 7, 0.2, 0.0)
+    assert arcs, "the span grazes the pad; the scan must report it"
+    # 10 mm span, pad at its head: every offending arc sits in the first 20%.
+    assert max(arcs) < 2.0
+
+
+def test_pad_deficit_arcs_is_empty_for_a_clean_span():
+    dpr = _pad_gate_router()
+    dpr.autorouter.grid.add_pad(_pad_at(2.5, 5.0, net=99, name="MIPI_D0+"))
+
+    assert dpr._pad_deficit_arcs(2.0, 7.0, 12.0, 7.0, 0, 7, 0.2, 0.0) == []
+
+
+def test_synthesize_tail_detours_around_a_foreign_pad_the_raster_cannot_see():
+    """The board-06 shape: a raster-clear landing tail drawn over a pad.
+
+    ``_AllClearPathfinder`` never blocks a cell, standing in for the
+    fine-pitch corridor where the grid halo is shrunk to ``min_trace_width /
+    2``.  Before #4571 the direct candidate won and shipped a pad short; now
+    the pad screen runs INSIDE the candidate loop, so a later detour wins.
+    """
+    dpr = _pad_gate_router()
+    dpr.autorouter.grid.add_pad(_pad_at(6.5, 5.0, net=99, name="MIPI_D0+"))
+    head, goal = _tail_pads((5.0, 5.0), (8.0, 5.0))
+
+    tail = dpr._synthesize_tail(_AllClearPathfinder(), head, goal, 0)
+
+    assert tail is not None, "a legal detour exists; the synthesizer must find it"
+    assert len(tail.segments) > 1, "the direct candidate runs straight over the pad"
+    for seg in tail.segments:
+        assert dpr._segment_pad_clear(seg)
+    # Still lands exactly on the pads it was asked to connect.
+    assert (tail.segments[0].x1, tail.segments[0].y1) == (5.0, 5.0)
+    assert (tail.segments[-1].x2, tail.segments[-1].y2) == (8.0, 5.0)
+
+
+def test_synthesize_tail_is_unchanged_when_no_pad_is_near():
+    """No pad in reach -> the direct candidate still wins (byte-identical)."""
+    dpr = _pad_gate_router()
+    dpr.autorouter.grid.add_pad(_pad_at(6.5, 9.0, net=99, name="MIPI_D0+"))
+    head, goal = _tail_pads((5.0, 5.0), (8.0, 5.0))
+
+    tail = dpr._synthesize_tail(_AllClearPathfinder(), head, goal, 0)
+
+    assert tail is not None
+    assert len(tail.segments) == 1
+    seg = tail.segments[0]
+    assert (seg.x1, seg.y1, seg.x2, seg.y2) == (5.0, 5.0, 8.0, 5.0)
+
+
+def test_close_shadow_chain_refuses_a_connector_through_a_pad_halo():
+    """Even a sub-cell repair connector is real copper and must clear pads."""
+    dpr, pf = _chain_router_and_pathfinder()
+    dpr.autorouter.grid.add_pad(_pad_at(4.02, 2.0, net=99, name="MIPI_D0+"))
+    route = _chain_route([(2.0, 2.0), (4.0, 2.0)])
+    route.segments.append(
+        Segment(
+            x1=4.0,
+            y1=2.024,
+            x2=6.0,
+            y2=2.024,
+            width=0.1,
+            layer=Layer.F_CU,
+            net=7,
+            net_name="MIPI_CLK-",
+        )
+    )
+
+    assert dpr._close_shadow_chain(route, pf) == 0
+    assert len(route.segments) == 2


### PR DESCRIPTION
## Summary

The geometric shadow constructor validated its parallel offset, its via sites
and its landing tails against the routing grid raster (`_is_cell_blocked`)
only. That raster's pad halo is **intentionally shrunk** in fine-pitch
corridors (`RoutingGrid._clearance_for_pin_pitch`, "full manufacturer
clearance is validated in post-routing DRC"). For single-ended nets that
promise is kept by `Autorouter._demote_pad_clearance_violation_nets` (exact
geometry, but only demotes deficits **above one grid resolution**) plus
`drc_verify_and_nudge` (the sub-resolution remainder) — and
`drc_verify_and_nudge` **unconditionally skips diff-pair nets** (#3508: "the
nudge helpers are not partner-aware"). The constructor's own two self-checks
(`find_intra_pair_clearance_violations`, `_pair_has_physical_overlap`) compare
copper to copper — segment-vs-segment and via-vs-segment/via — and **never**
copper to a PAD.

Net effect: shadow-constructed copper had no stage, coarse or exact, that
agreed with the `clearance_pad_segment` DRC predicate. All four measured
board-06 violations (0.037 mm foreign-net and 0.015 mm intra-pair, both real
shorts) sat **below** the 0.05 mm floor the single-ended backstop would have
caught.

This PR adds the exact, DRC-equivalent predicate at construction time,
re-using the same primitives the single-ended backstop uses.

## Changes

`src/kicad_tools/router/diffpair_routing.py`

- New helpers on `DiffPairRouter`: `_span_pad_deficit` / `_span_pad_clear`
  (candidate spans), `_segment_pad_clear`, `_via_pad_deficit`,
  `_route_pad_violation` (assembled route, segments **and** vias) and
  `_pad_deficit_arcs` (arc-localised body probe).
  All of them call `RoutingGrid.worst_segment_pad_deficit` /
  `worst_via_pad_deficit` with **`exclude_net` only and no `exclude_refs`** —
  the curator-flagged trap: passing the net's own component refs (the way
  `_demote_pad_clearance_violation_nets` does) hands a P/N pair that shares
  one connector `ref` straight to the #3545 same-component carve-out and
  silently re-exempts the **partner's** pad on exactly the fine-pitch
  connectors this gate exists for.
- The predicate is applied everywhere the constructor accepts copper:
  - `_synthesize_tail` — **inside** the candidate loop (so the remaining
    detours stay reachable), alongside the #4460 partner screen;
  - `_synthesize_crossing_tail` — on the assembled two-via crossover
    (stubs + alt-layer crossing + both barrels) before it is returned;
  - `_fallback_tail_route` — both A* probes are discarded when they violate,
    handing the attempt back to the caller's anchor-stepping retry;
  - `_close_shadow_chain` — the inserted repair connector is real copper;
  - `_meander_route_to_length` (`_tooth_ok`) — meander teeth;
  - `_quantize_shadow_segments` (`_legs_clear`) — the 45-dogleg bulge is new
    copper the raster check alone cleared;
  - the body blockage scan in `_shadow_route_pair` — reported as **arcs**, so
    a body end grazing a connector pad field is TRIMMED into the landing tail
    (the same graceful path raster blockages take) and only an *interior*
    violation fails the side; vias are probed at their own arc position;
  - a final self-check on the assembled shadow leg at the existing "fail this
    side over to the other" point, with a new `pad-clearance` decline reason.
- Only the **constructed** leg is gated. The guide is ordinary single-ended
  copper produced and validated by the per-net router and keeps the
  single-ended finalization backstops; declining a side over a pre-existing
  guide graze would cost coupling without fixing anything the constructor
  introduced.
- `_shadow_select_gap` was deliberately **not** changed (see "Notes").

`tests/test_diffpair_shadow.py` — 12 new unit tests (section 13).

## Acceptance Criteria Verification

Repro: `KCT_BOARD06_SHADOW=1 PYTHONHASHSEED=42 uv run python
boards/06-diffpair-test/generate_design.py --step route --seed 42`, then
`kct check --mfr jlcpcb` (net-class-map sidecar auto-loaded).

| rule | before (main `3de50783`) | after |
|---|---|---|
| `clearance_pad_segment` | **27** | **0** |
| `diffpair_clearance_intra` | 19 | 19 |
| `diffpair_length_skew` | 7 | 6 |
| `diffpair_routing_continuity` | 7 | 6 |
| `connectivity` | 1 | 3 |
| `clearance_segment_via` | 0 | 1 |
| `impedance` | 1 | 1 |
| **total errors** | **62** | **36** |

- [x] **The 4 identified pad-halo violations are gone.** Per-violation
  attribution from the before-run JSON report:
  - `MIPI_CLK-` vs `MIPI_D0+` pad `J4-3`, clearance **-0.0365 mm**
    (`Trace-c241330b`) — gone
  - `MIPI_CLK-` vs `MIPI_D0-` pad `J4-4`, clearance **-0.0365 mm**
    (same trace) — gone
  - `MIPI_CLK-` vs `MIPI_CLK+` pad `U4-1`, clearance **-0.015 mm**
    (`Trace-759cde66`) — gone
  - `MIPI_CLK-` vs `MIPI_CLK+` pad `U4-1`, clearance **-0.015 mm**
    (`Trace-ec1b8ca1`) — gone

  The offending copper was a straight `MIPI_CLK-` run at y=117.024 from
  x=106.30 to 109.30 passing directly over the J4 pad row at y=117.5; the
  gated constructor replaces it with a layer-diving crossing tail.
- [x] **`clearance_pad_segment` <= 14** — it is **0**. Every other
  pad-clearance survivor in the before-run (the `USB3_TX1`/`USB3_TX2`
  intra-pair overlaps at `J1-A2`/`A3`/`B2`, the `PCIE_RX` grazes at `U3-31`,
  the `USB2_D` grazes at `U1-11`, the `MIPI_D0` grazes at `U4-4`/`J4-M2`)
  also cleared, because those pairs' constructed legs are re-validated by the
  same gate.
- [x] **Total DRC error count not worse than 62** — **36**.
- [ ] **Construction rate >= 6/9 — NOT met: 5/9.** See "Known trade-off".
- [x] **Shadow-OFF behaviour unchanged / flag default unchanged.** Every
  method touched here is reachable only through `_shadow_route_pair` or
  `_rescue_near_miss_coupled`, and both are gated on
  `enable_shadow_construction` (which stays default `False`). The committed
  board-06 artifact is untouched by this PR and
  `tests/test_board_06_diffpair_test.py` (the strict-gate / allowlist /
  advisory-connectivity pins) is green.
- [x] **New primitive-level tests** covering a foreign-pad graze below
  `grid.resolution`, an own-net pad (must stay legal), and the
  shared-connector-ref partner-pad case.

### Known trade-off (construction rate 6/9 -> 5/9)

`MIPI_D0` drops from `coupled-ok` to `guide-missing`, and `MIPI_D0+/-` end
unrouted (18/21 signal nets vs 20/21). Taxonomy after:

```
MIPI_CLK  coupled-ok (shadow)          PCIE_TX   shadow-declined-overlap
MIPI_D0   guide-missing                USB3_RX1  shadow-declined-blockage
PCIE_RX   coupled-ok (shadow)          USB3_RX2  shadow-declined-blockage
USB2_D    coupled-ok (shadow-swapped)  USB3_TX1  coupled-ok (shadow)
                                       USB3_TX2  coupled-ok (shadow)
```

(baseline was identical except `MIPI_D0 = coupled-ok (shadow-swapped)`.)

This is a congestion consequence the fix **exposes** rather than causes:
before this PR, `MIPI_D0`'s escape from `J4-3`/`J4-4` coexisted with
`MIPI_CLK-` copper lying **on those very pads** (the -0.0365 mm overlaps
above) — i.e. `MIPI_D0+`/`MIPI_D0-` were electrically shorted to `MIPI_CLK-`,
so their "routed" status was not real. With that copper legalised,
`MIPI_CLK-`'s only legal landing at J4's 0.8 mm pad row is a two-via
layer-diving crossing tail, and its barrels (at 106.24,118.08 and
108.24,117.61) occupy the channel `MIPI_D0+` needed, so its guide probe now
fails outright. Trading 3 shorted nets for 2 honestly-unrouted nets is the
better artifact (62 -> 36 errors), but it does miss the letter of the
construction-rate criterion, so flagging it explicitly for the reviewer
rather than tuning the gate down to keep the short.

Follow-up worth filing (out of scope here): the crossing-tail via lattice is
blind to *other* nets' pad-escape channels — it should prefer sites that do
not seal a neighbouring fine-pitch pad's only exit.

## Test Plan

- [x] `uv run pytest tests/test_diffpair_shadow.py` — **93 passed**
  (81 pre-existing + 12 new).
- [x] `uv run pytest tests/test_board_06_diffpair_test.py` — 42 passed
  (strict-gate blocking count, allowlist and advisory-connectivity pins all
  green against the untouched committed artifact).
- [x] `uv run pytest tests/ -k diffpair` — 797 passed (the 4 board-06 guard
  failures seen mid-work were a local artifact-overwrite from the shadow-ON
  repro runs; the committed artifact is restored and they pass).
- [x] `uv run ruff format --check src/ tests/` and `uv run ruff check
  src/ tests/` — clean.
- [x] Board-06 shadow-ON repro measured before and after (table above).

Closes #4571