### PR TITLE
fix(diffpair): recover reach from corridors sealed by coupled bodies

### DIFF
--- a/boards/06-diffpair-test/generate_design.py
+++ b/boards/06-diffpair-test/generate_design.py
@@ -2608,22 +2608,35 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
     # original artifact-quality defects are now FIXED on main -- stranded
     # shadow tails (#3665 transactional connectivity rollback) and shadow
     # vias intersecting the partner (#3667 full-polyline via validation).
-    # The re-scoped corridor-competition defect did NOT reproduce on the
-    # current (#3413-phase-6, tightened-width) geometry: the shadow-ON
-    # seed-42 re-run reached 15/15 single-ended nets at its best
-    # negotiated snapshot (MIPI_D0-/USB_CC1 not stranded).  But shadow-ON
-    # is still not shippable here for two deeper reasons:
-    #   * Convergence collapsed 6-7/9 -> 3/9.  The 0.225-0.275 mm coupled
-    #     widths make the geometric parallel offset infeasible for 6/9
-    #     pairs (self-check overlap -0.165..-0.275 mm; mid-route blockage).
-    #   * The surviving shadow segments are 3.7-11.9 deg off-angle
-    #     (#3975 OffAngleSegmentWarning -> would fail the 45-census if
-    #     committed) and the 6 fallbacks blow the wall-clock (>1200 s vs
-    #     ~150 s / 21-21 shadow-OFF; the negotiated 360 s backstop fires).
-    # Enabling by default needs a shadow-aware by-construction dogleg
-    # (#3907/#3975) plus a parallel-offset feasibility fix at the tight
-    # widths.  When BOTH land, flip the env default and the optimizer/nudge
-    # diff-pair protections below together.  See #3921 for the full data.
+    # Issue #4463 (2026-08-02 re-measure) CORRECTS the #3921-era claim that
+    # used to sit here -- "the corridor-competition defect did NOT reproduce
+    # ... 15/15 single-ended nets at its best negotiated snapshot".  It DOES
+    # reproduce on the post-#4576 geometry: the shadow-ON seed-42 run strands
+    # MIPI_D0+, MIPI_D0- AND USB_CC1 (18/21), because the coupled pre-phase's
+    # copper is non-rippable inside ``route_all_negotiated`` -- every rip-up
+    # round and relief rescue rolls back with "blocked only by non-rippable
+    # copper of <pair nets>" and the loop burns its full 10-iteration ceiling
+    # (362.3 s, stranded set unchanged from iteration 1).  #4463 added a
+    # zero-overflow fixed-point exit for that loop plus a corridor-yield
+    # recovery (rip the pairs sitting on a stranded net's path, re-run this
+    # strategy once, keep the trade only if reach improved), which takes the
+    # shadow-ON run to 19/21 with this negotiated phase down to 148.1 s
+    # (shadow-OFF measures 361.5 s / 21/21 / 587.9 s total on the same
+    # machine; shadow-ON totals 1351.2 s post-fix, so the total job -- not
+    # the negotiated phase -- is now the wall-clock problem).
+    # Shadow-ON is still not shippable here:
+    #   * Convergence is 5/9 (post-#4576).  The 0.225-0.275 mm coupled widths
+    #     make the geometric parallel offset infeasible for the rest
+    #     (self-check overlap; mid-route blockage; #4574 guide-missing).
+    #   * USB_CC1 still strands -- its corridor is contested even with the
+    #     coupled bodies gone.
+    #   * The surviving shadow segments are off-angle (#3975
+    #     OffAngleSegmentWarning; the post-route quantization pass repairs
+    #     them, #3907 is the by-construction fix) and skew/continuity
+    #     residuals (#4570/#4575/#4577) are still open.
+    # Enabling by default needs those to close.  When they do, flip the env
+    # default and the optimizer/nudge diff-pair protections below together.
+    # See #4409 (epic) and #4463 for the current data.
     import os as _os
 
     ENABLE_COUPLED_SHADOW = _os.environ.get("KCT_BOARD06_SHADOW", "0") == "1"

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -1411,6 +1411,18 @@ class Autorouter:
         # and cleared at the end of the main strategy.
         self._budget_exit_diff_nets: set[int] = set()
 
+        # Issue #4463: set by ``route_all_with_diffpairs`` for the duration of
+        # a shadow-ON main strategy.  Tells ``route_all_negotiated`` that the
+        # coupled pre-phase committed copper it cannot rip, so a stranded set
+        # that does not change across zero-overflow iterations is a fixed
+        # point the loop should stop grinding on (the caller's corridor-yield
+        # recovery is what can actually free those corridors).
+        self._coupled_prephase_stall_exit: bool = False
+        # Issue #4463: wall-clock cap applied to ``route_all_negotiated``'s
+        # ``timeout`` for the ONE strategy re-run the corridor-yield recovery
+        # performs.  ``None`` (normal) leaves the caller's timeout alone.
+        self._negotiated_timeout_cap: float | None = None
+
         # Routing failure tracking (Issue #688)
         self.routing_failures: list[RoutingFailure] = []
 
@@ -8595,6 +8607,17 @@ class Autorouter:
 
         start_time = time.time()
 
+        # Issue #4463: the corridor-yield recovery re-runs the caller's
+        # strategy a SECOND time after ripping the coupled bodies that sealed
+        # a net in.  That second pass must not be allowed to spend the
+        # recipe's full backstop again -- measured on board 06 shadow-ON, an
+        # uncapped re-run burned its whole 360s budget and took the job from
+        # 770s to 1376s for one recovered net.  The cap is set only for the
+        # duration of that re-run; a normal call never sees it.
+        _yield_cap = getattr(self, "_negotiated_timeout_cap", None)
+        if _yield_cap is not None:
+            timeout = min(timeout, float(_yield_cap)) if timeout else float(_yield_cap)
+
         # If hierarchical mode is requested, delegate to two-phase routing
         if hierarchical:
             return self.route_all_two_phase(
@@ -9008,6 +9031,12 @@ class Autorouter:
         # Issue #2274: Track consecutive stalls for neighborhood rip-up escalation
         neighborhood_stall_count = 0
         prev_routed_count = 0
+        # Issue #4463: consecutive zero-overflow iterations that ended with the
+        # SAME stranded-net set.  Only consulted when the coupled diff-pair
+        # pre-phase committed non-rippable copper ahead of this loop
+        # (``_coupled_prephase_stall_exit``); see the break site below.
+        prephase_stall_count = 0
+        prev_stranded_set: frozenset[int] | None = None
         full_reorder_used_this_iter = False
         # Issue #2514: Identify single-pad nets up front so the recovery
         # loop can distinguish "structurally unroutable" from "failed but
@@ -9489,6 +9518,49 @@ class Autorouter:
         # analysis: full state snapshots remain singleton, only the metric
         # tuple history is kept.
         iteration_trajectory: list[IterationMetrics] = [best_metrics]
+
+        def _prephase_corridor_fixed_point(stranded: list[int]) -> bool:
+            """Issue #4463: is the loop stuck on non-rippable pre-phase copper?
+
+            Called from BOTH branches (targeted and standard rip-up) at the
+            zero-overflow-but-stranded decision point.  When a coupled
+            diff-pair pre-phase committed copper ahead of this loop, that
+            copper is NON-RIPPABLE here -- it is not in ``net_routes``, so no
+            rip-up round, no neighborhood-radius escalation and no relief
+            rescue can free a corridor it sealed (every rescue rolls back with
+            "blocked only by non-rippable copper of ...").  With overflow
+            already at zero there is nothing left to negotiate either, so an
+            UNCHANGED stranded set across consecutive iterations is a fixed
+            point: further iterations can only re-derive the same failure at
+            escalating cost.  Board 06 shadow-ON seed 42 measured exactly
+            that -- the same 3 stranded nets for all 10 iterations, 362.3s,
+            final reach unchanged from iteration 1.
+
+            Returns True (caller breaks) only on the third consecutive
+            iteration with an identical stranded set, and only when the
+            caller set ``_coupled_prephase_stall_exit``.  Shadow-OFF runs --
+            i.e. every board in CI today -- never set it and keep the #3448
+            continue-to-the-ceiling behaviour byte-for-byte.
+            """
+            nonlocal prephase_stall_count, prev_stranded_set
+            if not getattr(self, "_coupled_prephase_stall_exit", False):
+                return False
+            current = frozenset(stranded)
+            if prev_stranded_set == current:
+                prephase_stall_count += 1
+            else:
+                prephase_stall_count = 0
+            prev_stranded_set = current
+            if prephase_stall_count < 2:
+                return False
+            flush_print(
+                f"  Coupled pre-phase corridor stall: the same {len(stranded)} "
+                f"net(s) have been stranded with zero overflow for "
+                f"{prephase_stall_count + 1} consecutive iterations and the "
+                f"blocking copper is non-rippable here -- ending the loop for "
+                f"corridor-yield recovery (issue #4463) ({elapsed_str()})"
+            )
+            return True
 
         def _capture_iteration_end(iter_index: int, overflow_val: int) -> None:
             """Issue #2803: end-of-iteration capture point.
@@ -10697,6 +10769,8 @@ class Autorouter:
                                 f"net(s) still stranded -- continuing "
                                 f"(Issue #3448): {', '.join(stranded_names)}"
                             )
+                            if _prephase_corridor_fixed_point(stranded_targeted):
+                                break
 
                         # Issue #2274: Neighborhood rip-up when stalled with 0
                         # overflow but unrouted nets remain.
@@ -11460,6 +11534,8 @@ class Autorouter:
                             f"still stranded -- continuing (Issue #3448): "
                             f"{', '.join(stranded_names_std)}"
                         )
+                        if _prephase_corridor_fixed_point(stranded_std):
+                            break
 
                     # Issue #2518: short-circuit out of the iteration loop if a
                     # nested per-net loop already tripped the wall-clock budget.

--- a/src/kicad_tools/router/diffpair.py
+++ b/src/kicad_tools/router/diffpair.py
@@ -636,10 +636,32 @@ class DifferentialPairConfig:
     #      guide polyline with the crossing-tail via-clear bound
     #      (``_shadow_route_pair`` ~3448-3465).
     #   3. Corridor competition stranding later single-ended nets.  This
-    #      one did NOT reproduce on the current (post-#3413-phase-6)
-    #      board-06 geometry: the 2026-07-08 seed-42 shadow-ON re-run
-    #      reached 15/15 single-ended nets at its best negotiated
-    #      snapshot -- MIPI_D0-/USB_CC1 were not stranded.
+    #      DOES reproduce on the current geometry -- the #3921-era note
+    #      this comment used to carry ("did NOT reproduce ... 15/15 at
+    #      its best negotiated snapshot") is WRONG as of the post-#4576
+    #      geometry and was corrected in #4463.  Measured 2026-08-02,
+    #      seed 42, main @ 0a8d724e: MIPI_D0+, MIPI_D0- AND USB_CC1 all
+    #      strand (18/21 reach).  The pre-phase's copper is NON-RIPPABLE
+    #      in the negotiated loop (it is not in that loop's
+    #      ``net_routes``), so every rip-up round, neighbourhood-radius
+    #      escalation and relief rescue rolled back with "blocked only by
+    #      non-rippable copper of <pair nets>" and the loop burned its
+    #      whole 10-iteration ceiling -- 362.3 s with the stranded set
+    #      unchanged from iteration 1.
+    #      PARTLY MITIGATED (#4463) by two mechanisms, both gated on this
+    #      flag so shadow-OFF runs are byte-identical:
+    #        * ``route_all_negotiated`` now ends the loop once its
+    #          stranded set is a zero-overflow fixed point (362.3 s ->
+    #          147.5 s on that run) instead of re-deriving the same
+    #          failure ten times; and
+    #        * ``DiffPairRouter._plan_corridor_yields`` /
+    #          ``_apply_corridor_yields`` rip the pairs whose copper sits
+    #          on a stranded net's path and re-run the main strategy once
+    #          with those nets freed, keeping the trade only when reach
+    #          improves.  On board 06 that recovers MIPI_D0 (18/21 ->
+    #          19/21 by yielding USB2_D + MIPI_CLK).  USB_CC1 remains
+    #          stranded: its corridor is contested even with the coupled
+    #          bodies gone.
     #
     # Issue #3921 (2026-07-08) re-measured shadow-ON end-to-end and found
     # TWO NEW blockers that keep the flag OFF on the current geometry:
@@ -650,19 +672,44 @@ class DifferentialPairConfig:
     #      partner (10 "self-check overlap" events, worst -0.165..-0.275 mm)
     #      or cannot clear an obstacle the guide threaded (12 "mid-route
     #      blockage" events).  Only MIPI_CLK/MIPI_D0/PCIE_RX construct.
-    #   B. Off-angle geometry + wall-time blowup.  The surviving shadow
-    #      segments serialize at 3.7-11.9 deg off the 0/45/90/135 set
-    #      (``OffAngleSegmentWarning`` from the #3975 emission guard), so a
-    #      committed shadow-ON artifact would fail the fleet 45-census; and
-    #      the 6 failed-shadow pairs fall back to a ~350 s coupled pre-phase
-    #      plus a negotiated phase that hits its 360 s backstop, blowing the
-    #      CI wall-clock (>1200 s vs ~150 s shadow-OFF, which reaches 21/21).
+    #   B. Off-angle geometry.  The surviving shadow segments serialize
+    #      off the 0/45/90/135 set (``OffAngleSegmentWarning`` from the
+    #      #3975 emission guard); the recipe's post-route quantization
+    #      pass repairs them, but a by-construction dogleg (#3907) is the
+    #      real fix.
     #
-    # Enabling this by default is therefore blocked on (i) a shadow-aware
-    # by-construction dogleg at the emission site (migrating
-    # ``_shadow_route_pair`` per #3907/#3975) and (ii) restoring the
-    # parallel-offset feasibility at the tightened widths -- both deeper
-    # than the corridor-competition rip-up this field was re-scoped for.
+    # WALL-CLOCK (re-measured 2026-08-02 under #4463; the old "~150 s
+    # shadow-OFF vs >1200 s shadow-ON" figures in this comment were stale
+    # and framed against the wrong budget).  The real envelope is the
+    # ``diffpair-routing-regression`` CI job's 30-minute ``timeout-minutes``
+    # ceiling, against which a GREEN shadow-OFF run historically lands at
+    # 14m22s-20m42s TOTAL job wall-clock -- roughly half of that budget is
+    # the post-route pipeline (pour fill/stitch/repair/re-fill, copper-union
+    # audit, DRC, mfg export), not diff-pair routing.  On this machine,
+    # ``generate_design.py --step route --seed 42`` measures (one machine,
+    # one build; ``KCT_CORRIDOR_YIELD=0`` reproduces the "before" row):
+    #
+    #     shadow OFF          : 587.9 s total, negotiated 361.5 s, 21/21
+    #     shadow ON, pre-#4463: 770.4 s total, negotiated 362.3 s, 18/21
+    #     shadow ON, post     : 1351.2 s total, negotiated 148.1 s +
+    #                           50.6 s planning + 300.5 s capped re-run,
+    #                           19/21
+    #
+    # So the negotiated phase itself is now WELL inside the 2x-of-shadow-OFF
+    # target (148.1 s vs 361.5 s; 448.6 s counting the recovery re-run), but
+    # the TOTAL shadow-ON job grew: the two pairs that yield stop being
+    # diff-pair nets, so they re-enter the optimizer / nudge / repair passes
+    # the shadow path excludes them from.  22.5 min of local wall-clock has
+    # no headroom against the job's 30-minute ceiling on a slower CI runner
+    # -- which is itself a reason the default stays OFF.  CI never runs this
+    # path today (the board-06 recipe gates it behind ``KCT_BOARD06_SHADOW``
+    # and CI does not set it).
+    #
+    # Enabling this by default is therefore still blocked on: the
+    # remaining corridor contention (USB_CC1 is not recoverable by
+    # yielding), the total shadow-ON wall-clock above, the open
+    # skew/continuity residuals (#4570, #4574, #4575, #4577), and a
+    # shadow-aware by-construction dogleg (#3907/#3975).
     # Set ``KCT_BOARD06_SHADOW=1`` on the board-06 recipe to reproduce the
     # shadow-ON run.  Default False keeps recipes on their pre-#3508
     # budget-exit behaviour (0/9 coupled, 21/21 single-ended reach).

--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -143,6 +143,34 @@ _OFFSET_JOIN_COINCIDENT_MM: float = 1e-4
 # experimentation (KCT_SHADOW_PER_PAIR_BUDGET_S).
 _SHADOW_PER_PAIR_BUDGET_S: float = float(os.environ.get("KCT_SHADOW_PER_PAIR_BUDGET_S", "30.0"))
 
+# Issue #4463: budgets for the corridor-yield recovery
+# (``DiffPairRouter._plan_corridor_yields`` / ``_apply_corridor_yields``),
+# which runs after the main strategy when shadow construction is ON.  On
+# board 06 shadow-ON (seed 42) three nets sealed in by committed coupled
+# bodies cost the negotiated loop its full 10-iteration ceiling -- 362.3s to
+# arrive at the same 18/21 it had after iteration 1 -- because that copper is
+# non-rippable there.
+#
+#   * ``_CORRIDOR_GUARD_PROBE_S`` bounds one routability probe.  A probe that
+#     succeeds does so in well under a second; only the hopeless ones need
+#     bounding.
+#   * ``_CORRIDOR_GUARD_BUDGET_S`` bounds the whole planning pass -- past it
+#     the plan is truncated and the board keeps what the strategy produced.
+#   * ``_CORRIDOR_YIELD_RERUN_S`` caps the ONE strategy re-run performed after
+#     the yield.  Without a cap the re-run spends the recipe's full negotiated
+#     backstop a second time (measured: 363s, taking the job from 770s to
+#     1376s).  Applied via ``Autorouter._negotiated_timeout_cap`` and removed
+#     as soon as the re-run returns.
+#   * ``KCT_CORRIDOR_YIELD=0`` is the kill-switch for the whole #4463
+#     behaviour (both the negotiated loop's fixed-point exit and the
+#     plan/yield/re-run recovery); it restores the pre-#4463 shadow-ON
+#     pipeline exactly, which is how the before/after numbers above were
+#     measured on one build.  Shadow-OFF runs never reach either mechanism.
+_CORRIDOR_GUARD_PROBE_S: float = float(os.environ.get("KCT_CORRIDOR_GUARD_PROBE_S", "8.0"))
+_CORRIDOR_GUARD_BUDGET_S: float = float(os.environ.get("KCT_CORRIDOR_GUARD_BUDGET_S", "120.0"))
+_CORRIDOR_YIELD_RERUN_S: float = float(os.environ.get("KCT_CORRIDOR_YIELD_RERUN_S", "300.0"))
+_CORRIDOR_YIELD_ENABLED: bool = os.environ.get("KCT_CORRIDOR_YIELD", "1").strip() != "0"
+
 # Issue #3990 (unit 2b of #3921): variable-gap parallel offset.  The
 # geometric shadow constructor historically offset the WHOLE guide by a
 # single constant center-to-center gap ``d = spacing_cells * resolution``.
@@ -9500,6 +9528,399 @@ class DiffPairRouter:
 
         return all_routes, warnings, routed_net_ids
 
+    # ------------------------------------------------------------------
+    # Issue #4463: corridor-competition recovery
+    # ------------------------------------------------------------------
+
+    def _probe_net_routable(
+        self,
+        net_id: int,
+        per_net_timeout: float,
+    ) -> list[Route] | None:
+        """Probe whether ``net_id`` can be routed on the CURRENT grid.
+
+        Issue #4463.  Routes the net with the ordinary single-ended
+        router, checks that every pad of the net ended up in one
+        connected component, then **rolls the copper back off the grid**
+        so the probe leaves no trace.  Returns the (already-unmarked)
+        routes on success and ``None`` when the net could not be routed
+        or the produced copper left a pad stranded.
+
+        This is deliberately the same oracle the main strategy uses --
+        a real A* through the real obstacle field -- rather than a
+        cheaper reachability approximation, because the thing we need to
+        know is exactly "would the main strategy strand this net".
+
+        "Leaves no trace" covers ROUTER state as well as copper.  The
+        C++ backend memoizes per-net clearance-resume exhaustions and
+        skips the Python fallback on the SECOND one (#3923), so a probe
+        that legitimately fails against a sealed corridor would silently
+        make every later probe of the same net pessimistic -- the net
+        would look unrecoverable purely because we asked twice.  The
+        memo (and the failure log) is therefore snapshotted and restored
+        around every probe, which is what makes repeated probes of one
+        net answer the same question the main strategy would.
+        """
+        autorouter = self.autorouter
+        before = len(autorouter.routes)
+        failures_before = len(getattr(autorouter, "routing_failures", []))
+        backend = getattr(autorouter, "router", None)
+        resume_memo = getattr(backend, "_resume_clearance_exhaustions", None)
+        saved_memo = dict(resume_memo) if isinstance(resume_memo, dict) else None
+        routes: list[Route] = []
+        try:
+            routes = autorouter.route_net(net_id, per_net_timeout=per_net_timeout)
+        except Exception:  # pragma: no cover - defensive: a probe must never raise
+            logger.debug("[corridor-yield] probe raised for net %s", net_id, exc_info=True)
+            routes = []
+        finally:
+            if saved_memo is not None and isinstance(resume_memo, dict):
+                resume_memo.clear()
+                resume_memo.update(saved_memo)
+            failures = getattr(autorouter, "routing_failures", None)
+            if isinstance(failures, list) and len(failures) > failures_before:
+                del failures[failures_before:]
+
+        # Roll back every route the probe committed (both the ones it
+        # returned and anything else it appended -- e.g. MST sub-edges).
+        committed = list(autorouter.routes[before:])
+        del autorouter.routes[before:]
+        seen_ids = {id(r) for r in committed}
+        for route in routes:
+            if id(route) not in seen_ids:
+                committed.append(route)
+                seen_ids.add(id(route))
+        for route in committed:
+            with contextlib.suppress(Exception):
+                autorouter.grid.unmark_route(route)
+
+        if not routes:
+            return None
+
+        pad_keys = autorouter.nets.get(net_id, [])
+        net_pads = [autorouter.pads[k] for k in pad_keys if k in autorouter.pads]
+        if len(net_pads) >= 2:
+            conn = validate_net_connectivity(routes, {net_id: net_pads})
+            info = conn.get(net_id, {})
+            if not info.get("connected", False):
+                return None
+        return routes
+
+    @staticmethod
+    def _copper_conflicts(
+        routes_a: list[Route],
+        routes_b: list[Route],
+        clearance: float,
+    ) -> bool:
+        """Return True when two route sets have copper within ``clearance``.
+
+        Issue #4463.  Used to decide which committed coupled bodies stand
+        in the way of a stranded net's desired path: to run that path, any
+        copper closer to it than the clearance rule has to go, and copper
+        that is further away does not.  Vias count on every layer (a
+        through via is an obstacle on layers its owner never traced on).
+        """
+
+        def _segments(
+            routes: list[Route],
+        ) -> list[tuple[object | None, float, float, float, float, float]]:
+            out: list[tuple[object | None, float, float, float, float, float]] = []
+            for route in routes:
+                for seg in route.segments:
+                    layer = getattr(seg.layer, "value", seg.layer)
+                    out.append((layer, seg.x1, seg.y1, seg.x2, seg.y2, seg.width / 2.0))
+                for via in route.vias:
+                    # layer=None -> "every layer" (through-hole annulus)
+                    out.append((None, via.x, via.y, via.x, via.y, via.diameter / 2.0))
+            return out
+
+        segs_a = _segments(routes_a)
+        segs_b = _segments(routes_b)
+        for la, ax1, ay1, ax2, ay2, ra in segs_a:
+            for lb, bx1, by1, bx2, by2, rb in segs_b:
+                if la is not None and lb is not None and la != lb:
+                    continue
+                gap = _segment_to_segment_distance(ax1, ay1, ax2, ay2, bx1, by1, bx2, by2)
+                if gap - ra - rb < clearance:
+                    return True
+        return False
+
+    def _net_is_connected(self, net_id: int) -> bool:
+        """Whether the copper committed so far connects every pad of a net.
+
+        Issue #4463.  Ground truth for the corridor-yield recovery: a net
+        with fewer than two routable pads is trivially "connected"; any
+        other net must have copper on the board that unions all of its
+        pads into one component (the same
+        :func:`validate_net_connectivity` oracle the #3540 transactional
+        shadow claim uses).
+        """
+        autorouter = self.autorouter
+        pad_keys = autorouter.nets.get(net_id, [])
+        net_pads = [autorouter.pads[k] for k in pad_keys if k in autorouter.pads]
+        if len(net_pads) < 2:
+            return True
+        routes = [r for r in autorouter.routes if r.net == net_id]
+        if not routes:
+            return False
+        conn = validate_net_connectivity(routes, {net_id: net_pads})
+        return bool(conn.get(net_id, {}).get("connected", False))
+
+    def _plan_corridor_yields(
+        self,
+        candidate_nets: list[int],
+        committed_pairs: list[tuple[DifferentialPair, list[Route]]],
+    ) -> tuple[list[tuple[DifferentialPair, list[Route]]], list[int]]:
+        """Which committed coupled bodies seal a still-unconnected net in?
+
+        Issue #4463 (corridor competition).  The coupled pre-phase claims
+        its corridors first and its copper is **non-rippable** for the
+        rest of the pipeline: the negotiated loop's ``net_routes`` holds
+        only the nets it routes itself, so a net whose only corridor a
+        committed coupled body sealed can never be recovered there.  Every
+        rip-up round, every neighbourhood-radius escalation and every
+        relief rescue rolls back with ``blocked only by non-rippable
+        copper of <pair nets>`` -- measured on board 06 shadow-ON (seed
+        42, main @ 0a8d724e): ``MIPI_D0+``, ``MIPI_D0-`` and ``USB_CC1``
+        stranded for all 10 iterations, 362.3 s spent in the negotiated
+        loop, final reach 18/21.
+
+        This planner answers the question the loop could not: for each net
+        the main strategy actually failed to connect, is there a path once
+        the coupled copper is out of the way, and if so which pairs sit on
+        it?  It works on GROUND TRUTH (what the strategy produced), it
+        commits nothing, and it leaves the board exactly as it found it --
+        the caller decides whether to act on the plan.
+
+        Per stranded net it probes at most twice: once with the coupled
+        copper lifted, and (only if that fails) once with the other
+        candidate nets' rippable copper lifted as well -- the relief
+        rescue's "rip the victims" step, except it may also cross the
+        coupled boundary the rescue cannot.  The fixed, small probe count
+        is deliberate: ``mark_route`` / ``unmark_route`` round-trips are
+        not perfectly symmetric in the router's auxiliary state, so a
+        design that probed once per (net, pair) combination would slowly
+        poison its own oracle.
+
+        Args:
+            candidate_nets: Every signal net that may be examined -- the
+                main strategy's nets plus the diff-pair nets (a pair the
+                pre-phase CLAIMED but left unconnected is itself a
+                corridor-competition victim, and it is not in the main
+                strategy's net list precisely because the claim removed
+                it).
+            committed_pairs: ``(pair, routes)`` for every pair whose
+                copper the coupled pre-phase committed.
+
+        Returns:
+            ``(pairs_to_yield, stranded_nets)`` -- the pairs whose copper
+            stands on some stranded net's path, and the stranded nets that
+            were examined.
+        """
+        autorouter = self.autorouter
+        grid = autorouter.grid
+        if not candidate_nets or not committed_pairs:
+            return [], []
+
+        stranded = [n for n in candidate_nets if not self._net_is_connected(n)]
+        if not stranded:
+            return [], []
+
+        names = getattr(autorouter, "net_names", {}) or {}
+
+        def _name(net_id: int) -> str:
+            return str(names.get(net_id, f"Net_{net_id}"))
+
+        def _unmark(routes: list[Route]) -> None:
+            for route in routes:
+                with contextlib.suppress(Exception):
+                    grid.unmark_route(route)
+
+        def _remark(routes: list[Route]) -> None:
+            for route in routes:
+                autorouter._mark_route(route)
+
+        def _restore(routes: list[Route]) -> None:
+            _remark(routes)
+            for route in routes:
+                if route not in autorouter.routes:
+                    autorouter.routes.append(route)
+
+        # The clearance a foreign trace must keep from the desired path,
+        # plus one grid cell of slack for the grid's own marking margin.
+        clearance = float(getattr(autorouter.rules, "trace_clearance", 0.2)) + float(
+            getattr(grid, "resolution", 0.1)
+        )
+        deadline = time.monotonic() + _CORRIDOR_GUARD_BUDGET_S
+        probe_timeout = _CORRIDOR_GUARD_PROBE_S
+        t0 = time.monotonic()
+        print(
+            f"\n  [corridor-yield] {len(stranded)} net(s) left unconnected by the "
+            f"main strategy: {', '.join(_name(n) for n in stranded)}"
+        )
+
+        planned: dict[int, tuple[DifferentialPair, list[Route]]] = {}
+        for net_id in stranded:
+            if time.monotonic() > deadline:
+                logger.warning(
+                    "DIFFPAIR_CORRIDOR_GUARD_BUDGET: corridor-yield planning hit "
+                    "its %.0fs budget with %d stranded net(s) unexamined "
+                    "(issue #4463)",
+                    _CORRIDOR_GUARD_BUDGET_S,
+                    len(stranded) - len(planned),
+                )
+                break
+
+            for _pair, routes in committed_pairs:
+                _unmark(routes)
+            desired = self._probe_net_routable(net_id, probe_timeout)
+
+            neighbour_routes: dict[int, list[Route]] = {}
+            if desired is None:
+                coupled_ids = {id(r) for _p, rts in committed_pairs for r in rts}
+                for other in candidate_nets:
+                    if other == net_id:
+                        continue
+                    owned = [
+                        r for r in autorouter.routes if r.net == other and id(r) not in coupled_ids
+                    ]
+                    if owned:
+                        neighbour_routes[other] = owned
+                        _unmark(owned)
+                        for route in owned:
+                            if route in autorouter.routes:
+                                autorouter.routes.remove(route)
+                desired = self._probe_net_routable(net_id, probe_timeout)
+
+            # Put the board back exactly as it was -- this is a plan, not a
+            # commitment.
+            for owned in neighbour_routes.values():
+                _restore(owned)
+            for _pair, routes in committed_pairs:
+                _remark(routes)
+
+            if desired is None:
+                print(
+                    f"    [corridor-yield] {_name(net_id)} stays unroutable with "
+                    f"every coupled corridor lifted -- not a corridor-competition "
+                    f"failure"
+                )
+                continue
+
+            blocking = [
+                (pair, routes)
+                for pair, routes in committed_pairs
+                if self._copper_conflicts(routes, desired, clearance)
+            ]
+            if not blocking:
+                print(
+                    f"    [corridor-yield] no coupled copper sits on "
+                    f"{_name(net_id)}'s path; nothing to yield for it"
+                )
+                continue
+            for pair, routes in blocking:
+                planned[id(pair)] = (pair, routes)
+            print(
+                f"    [corridor-yield] {_name(net_id)} is sealed in by "
+                f"{', '.join(p.name for p, _r in blocking)}"
+            )
+
+        print(
+            f"  [corridor-yield] planning took {time.monotonic() - t0:.1f}s; "
+            f"{len(planned)} pair(s) to yield"
+        )
+        return list(planned.values()), stranded
+
+    def _apply_corridor_yields(
+        self,
+        to_yield: list[tuple[DifferentialPair, list[Route]]],
+        candidate_nets: list[int],
+        non_diffpair_strategy: object,
+    ) -> tuple[bool, set[int], list[Route], list[Route]]:
+        """Rip the planned pairs, re-run the main strategy, keep only if it paid.
+
+        Issue #4463.  Landing the freed nets one at a time here does NOT
+        work: the corridor a coupled body was sealing is contested, so the
+        stranded net and the freed pair legs have to be arranged TOGETHER
+        -- which is precisely what the negotiated strategy does on a
+        shadow-OFF run (it reaches 21/21 on board 06 with these nets routed
+        single-ended).  So the pass rips the planned pairs, hands the board
+        back to the caller's strategy for one more pass, and scores the
+        result.
+
+        The trade is transactional on REACH: if the second pass does not
+        connect MORE of ``candidate_nets`` than the first left connected,
+        every route it produced is unmarked and the yielded coupled copper
+        is put back exactly as it was.  A pair that claims-but-strands
+        costs reach, a pair that yields costs only quality, and a yield
+        that buys neither is simply undone.
+
+        Returns:
+            ``(kept, released_net_ids, removed_routes, added_routes)``.
+        """
+        autorouter = self.autorouter
+        if not to_yield:
+            return False, set(), [], []
+
+        reach_before = sum(1 for n in candidate_nets if self._net_is_connected(n))
+        snapshot_ids = {id(r) for r in autorouter.routes}
+        yielded_routes = [r for _p, routes in to_yield for r in routes]
+        released_nets: set[int] = set()
+        for pair, routes in to_yield:
+            released_nets.update(pair.get_net_ids())
+            for route in routes:
+                with contextlib.suppress(Exception):
+                    autorouter.grid.unmark_route(route)
+                if route in autorouter.routes:
+                    autorouter.routes.remove(route)
+
+        print(
+            f"  [corridor-yield] {len(to_yield)} pair(s) yielded their corridor: "
+            f"{', '.join(p.name for p, _r in to_yield)}; re-running the main "
+            f"strategy for the freed nets"
+        )
+        autorouter._negotiated_timeout_cap = _CORRIDOR_YIELD_RERUN_S
+        try:
+            non_diffpair_strategy()  # type: ignore[operator]
+        finally:
+            autorouter._negotiated_timeout_cap = None
+            autorouter._budget_exit_diff_nets = set()
+
+        added_routes = [r for r in autorouter.routes if id(r) not in snapshot_ids]
+        reach_after = sum(1 for n in candidate_nets if self._net_is_connected(n))
+
+        if reach_after > reach_before:
+            logger.warning(
+                "DIFFPAIR_CORRIDOR_YIELD: %d coupled pair(s) yielded a sealed "
+                "corridor; reach %d -> %d of %d net(s): %s (issue #4463)",
+                len(to_yield),
+                reach_before,
+                reach_after,
+                len(candidate_nets),
+                ", ".join(p.name for p, _r in to_yield),
+            )
+            print(
+                f"  [corridor-yield] reach {reach_before} -> {reach_after} of "
+                f"{len(candidate_nets)} net(s); keeping the yield"
+            )
+            return True, released_nets, yielded_routes, added_routes
+
+        # The trade did not pay -- put the board back as the first pass left it.
+        for route in added_routes:
+            with contextlib.suppress(Exception):
+                autorouter.grid.unmark_route(route)
+            if route in autorouter.routes:
+                autorouter.routes.remove(route)
+        for route in yielded_routes:
+            autorouter._mark_route(route)
+            if route not in autorouter.routes:
+                autorouter.routes.append(route)
+        print(
+            f"  [corridor-yield] reach {reach_before} -> {reach_after} of "
+            f"{len(candidate_nets)} net(s); yield reverted"
+        )
+        return False, set(), [], []
+
     def route_all_with_diffpairs(
         self,
         diffpair_config: DifferentialPairConfig | None = None,
@@ -9589,6 +10010,9 @@ class DiffPairRouter:
         self._last_budget_exit_pair_names = []
         self._last_coupled_attempted_count = 0
         self._last_budget_exit_count = 0
+        # Issue #4463: pairs that yielded their corridor to unblock a
+        # single-ended net (empty unless the corridor guard fired).
+        self._last_corridor_yield_pair_names: list[str] = []
 
         if diffpair_config is None or not diffpair_config.enabled:
             return self.autorouter.route_all(net_order), []
@@ -9627,6 +10051,10 @@ class DiffPairRouter:
         # Track diff-pair nets that we successfully routed so the
         # caller can decide which nets to leave for the main strategy.
         coupled_routed_nets: set[int] = set()
+        # Issue #4463: (pair, routes) for every pair whose copper this
+        # pre-phase committed -- the yield candidates for the
+        # corridor-yield recovery that runs after the main strategy.
+        committed_pair_routes: list[tuple[DifferentialPair, list[Route]]] = []
 
         refused_diff_nets: set[int] = set()
         # Issue #3089: track diff-pair nets whose coupled search hit the
@@ -9743,6 +10171,10 @@ class DiffPairRouter:
                             f"unrouted stub edge; returning it to the main "
                             f"strategy (issue #3508)"
                         )
+                # Issue #4463: remember what this pair committed so the
+                # corridor-competition guard below can make it yield if its
+                # copper seals a corridor a later single-ended net needs.
+                committed_pair_routes.append((pair, list(pair_routes)))
             all_routes.extend(pair_routes)
             if warning:
                 warnings.append(warning)
@@ -9850,6 +10282,17 @@ class DiffPairRouter:
         # assigns an empty set (no promotion).
         self.autorouter._budget_exit_diff_nets = set(budget_exit_diff_nets)
 
+        # Issue #4463: tell the negotiated loop that this run carries coupled
+        # pre-phase copper it cannot rip.  With that flag set the loop stops
+        # once its stranded set is a zero-overflow fixed point instead of
+        # re-deriving the same failure for its whole iteration ceiling
+        # (board 06 shadow-ON seed 42: 10 iterations, 362.3s, no change) --
+        # the corridor-yield recovery below is what can actually free those
+        # nets.  Shadow-OFF runs never set it, so CI is untouched.
+        self.autorouter._coupled_prephase_stall_exit = bool(
+            _CORRIDOR_YIELD_ENABLED and self.enable_shadow_construction and committed_pair_routes
+        )
+
         non_diff_nets = [n for n in self.autorouter.nets if n not in diff_net_ids and n != 0]
         if non_diff_nets:
             print(f"\n--- Routing {len(non_diff_nets)} non-differential nets ---")
@@ -9895,6 +10338,45 @@ class DiffPairRouter:
                     # legacy per-net path too -- the priority lift
                     # is meaningful only for this strategy invocation.
                     self.autorouter._budget_exit_diff_nets = set()
+
+        # Issue #4463: corridor-yield recovery.  The main strategy has now
+        # told us -- on ground truth, not prediction -- which nets it could
+        # not connect.  Any of those that becomes routable once the coupled
+        # copper is lifted was stranded by corridor competition, so the pairs
+        # standing on its path yield their corridor and the strategy is run
+        # ONE more time with those nets back in the routable set.  Re-running
+        # the strategy (rather than landing the nets one by one here) is what
+        # makes the trade pay: the freed corridor is contested, and only the
+        # negotiated loop can arrange the freed pair legs and the stranded net
+        # together -- exactly what it does on a shadow-OFF run, which reaches
+        # 21/21 with those nets routed single-ended.  The whole trade is
+        # transactional on REACH: if the second pass does not connect more
+        # nets than the first, every route is restored.  Shadow-OFF runs skip
+        # this entirely, so CI and the committed artifacts are untouched.
+        if (
+            _CORRIDOR_YIELD_ENABLED
+            and self.enable_shadow_construction
+            and committed_pair_routes
+            and non_diffpair_strategy is not None
+        ):
+            # Candidates are the main strategy's nets PLUS the diff-pair nets:
+            # a pair the pre-phase claimed but left unconnected (board 06's
+            # MIPI_D0, whose shadow declined and whose legs the negotiated loop
+            # then failed) is itself a corridor-competition victim, and it is
+            # not in ``non_diff_nets`` precisely because the claim removed it.
+            candidate_nets = list(dict.fromkeys([*non_diff_nets, *sorted(diff_net_ids)]))
+            to_yield, _stranded = self._plan_corridor_yields(candidate_nets, committed_pair_routes)
+            kept, released_nets, removed_routes, added_routes = self._apply_corridor_yields(
+                to_yield, candidate_nets, non_diffpair_strategy
+            )
+            if kept:
+                diff_net_ids = diff_net_ids - released_nets
+                coupled_routed_nets -= released_nets
+                removed_ids = {id(r) for r in removed_routes}
+                all_routes = [r for r in all_routes if id(r) not in removed_ids]
+                all_routes.extend(added_routes)
+                self._last_corridor_yield_pair_names = [p.name for p, _r in to_yield]
+        self.autorouter._coupled_prephase_stall_exit = False
 
         # Issue #4095: surface the budget-exit pair set to the instance so
         # the CLI can warn that ``--differential-pairs`` fell back to

--- a/tests/test_diffpair_corridor_guard.py
+++ b/tests/test_diffpair_corridor_guard.py
@@ -1,0 +1,376 @@
+"""Tests for the corridor-yield recovery (Issue #4463).
+
+The coupled diff-pair pre-phase claims its corridors before the main
+strategy runs, and its committed copper is **non-rippable** afterwards:
+the negotiated loop's rip-up machinery only knows about the nets it
+routes itself, so a single-ended net whose only corridor was sealed by a
+committed coupled body can never be recovered.  Measured on board 06
+shadow-ON (seed 42, main @ 0a8d724e): ``MIPI_D0+``, ``MIPI_D0-`` and
+``USB_CC1`` all strand, every rip-up round rolls back with
+``blocked only by non-rippable copper of <pair nets>``, and the loop
+burns its entire 10-iteration ceiling (362.3 s) before giving up at
+18/21 reach.
+
+``DiffPairRouter._plan_corridor_yields`` closes that hole after the main
+strategy, on ground truth: for every net the strategy actually failed to
+connect it asks whether lifting the coupled copper makes the net routable,
+and names the pairs standing on the resulting path.  ``route_all_with_
+diffpairs`` then rips exactly those, re-runs the strategy once so the
+negotiated loop can arrange the freed corridor globally, and keeps the
+trade only when reach improved.
+
+These tests cover the four units that make that safe:
+
+1. ``_copper_conflicts`` -- which committed copper stands on the path a
+   stranded net wants, and therefore has to yield.
+2. ``_net_is_connected`` -- the reach oracle the trade is scored with.
+3. ``_probe_net_routable`` -- the probe must leave NO trace on the grid
+   or in ``autorouter.routes`` (it is a question, not a commitment).
+4. ``_plan_corridor_yields`` + the orchestration around it -- a sealing
+   pair is named, a distant pair is not, the plan commits nothing, an
+   unrecoverable net costs no pair, a yield that gains no reach is
+   reverted, and none of it runs with shadow construction off.
+"""
+
+from __future__ import annotations
+
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.diffpair import (
+    DifferentialPair,
+    DifferentialPairConfig,
+    DifferentialSignal,
+)
+from kicad_tools.router.diffpair_routing import DiffPairRouter
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.primitives import Route, Segment, Via
+from kicad_tools.router.rules import DesignRules
+
+
+def _seg(x1: float, y1: float, x2: float, y2: float, layer: Layer, net: int = 1) -> Segment:
+    return Segment(x1=x1, y1=y1, x2=x2, y2=y2, width=0.2, layer=layer, net=net)
+
+
+# ---------------------------------------------------------------------------
+# Fixture: a board whose single-ended net must cross the pair's corridor
+# ---------------------------------------------------------------------------
+
+
+def _channel_router() -> Autorouter:
+    """``SIG`` (net 3) has one pad on each side of a horizontal channel.
+
+    Copper across the whole channel on every layer therefore strands
+    ``SIG`` exactly the way a committed coupled body strands ``MIPI_D0``
+    on board 06.
+    """
+    rules = DesignRules(trace_width=0.2, trace_clearance=0.2, grid_resolution=0.1)
+    router = Autorouter(width=20.0, height=8.0, rules=rules)
+    router.add_component(
+        "U1",
+        [
+            {
+                "number": "1",
+                "x": 2.0,
+                "y": 1.0,
+                "width": 0.6,
+                "height": 0.6,
+                "net": 3,
+                "net_name": "SIG",
+            },
+        ],
+    )
+    router.add_component(
+        "U2",
+        [
+            {
+                "number": "1",
+                "x": 18.0,
+                "y": 7.0,
+                "width": 0.6,
+                "height": 0.6,
+                "net": 3,
+                "net_name": "SIG",
+            },
+        ],
+    )
+    return router
+
+
+def _wall_routes(router: Autorouter) -> list[Route]:
+    """Copper across the FULL width of the board on every routable layer."""
+    routes: list[Route] = []
+    for idx in router.grid.get_routable_indices():
+        layer = Layer(router.grid.index_to_layer(idx))
+        routes.append(
+            Route(
+                net=1,
+                net_name="PAIR+",
+                segments=[_seg(0.0, 4.0, 20.0, 4.0, layer, net=1)],
+            )
+        )
+    return routes
+
+
+def _pair() -> DifferentialPair:
+    return DifferentialPair(
+        name="PAIR",
+        positive=DifferentialSignal("PAIR+", 1, "PAIR", "P", "plus_minus"),
+        negative=DifferentialSignal("PAIR-", 2, "PAIR", "N", "plus_minus"),
+    )
+
+
+def _other_pair() -> DifferentialPair:
+    return DifferentialPair(
+        name="OTHER",
+        positive=DifferentialSignal("OTHER+", 4, "OTHER", "P", "plus_minus"),
+        negative=DifferentialSignal("OTHER-", 5, "OTHER", "N", "plus_minus"),
+    )
+
+
+def _bystander() -> list[Route]:
+    return [
+        Route(
+            net=4,
+            net_name="OTHER+",
+            segments=[_seg(0.5, 0.4, 3.0, 0.4, Layer.F_CU, net=4)],
+        )
+    ]
+
+
+def _commit(router: Autorouter, routes: list[Route]) -> None:
+    for route in routes:
+        router._mark_route(route)
+        router.routes.append(route)
+
+
+# ---------------------------------------------------------------------------
+# 1. _copper_conflicts -- what stands on the desired path
+# ---------------------------------------------------------------------------
+
+
+def test_copper_conflicts_same_layer_touching_copper():
+    a = [Route(net=1, net_name="A", segments=[_seg(0.0, 0.0, 10.0, 0.0, Layer.F_CU)])]
+    b = [Route(net=2, net_name="B", segments=[_seg(0.0, 0.25, 10.0, 0.25, Layer.F_CU, net=2)])]
+    # Centreline gap 0.25 mm minus two 0.1 mm half-widths = 0.05 mm of air,
+    # which is under the 0.2 mm clearance -> a genuine conflict.
+    assert DiffPairRouter._copper_conflicts(a, b, clearance=0.2) is True
+
+
+def test_copper_conflicts_same_layer_far_apart():
+    a = [Route(net=1, net_name="A", segments=[_seg(0.0, 0.0, 10.0, 0.0, Layer.F_CU)])]
+    b = [Route(net=2, net_name="B", segments=[_seg(0.0, 5.0, 10.0, 5.0, Layer.F_CU, net=2)])]
+    assert DiffPairRouter._copper_conflicts(a, b, clearance=0.2) is False
+
+
+def test_copper_conflicts_ignores_other_layers():
+    a = [Route(net=1, net_name="A", segments=[_seg(0.0, 0.0, 10.0, 0.0, Layer.F_CU)])]
+    b = [Route(net=2, net_name="B", segments=[_seg(0.0, 0.0, 10.0, 0.0, Layer.B_CU, net=2)])]
+    assert DiffPairRouter._copper_conflicts(a, b, clearance=0.2) is False
+
+
+def test_copper_conflicts_via_blocks_every_layer():
+    """A through via is an obstacle on layers its owner never traced on."""
+    via = Via(x=5.0, y=0.0, drill=0.3, diameter=0.6, layers=(Layer.F_CU, Layer.B_CU), net=1)
+    a = [Route(net=1, net_name="A", segments=[], vias=[via])]
+    b = [Route(net=2, net_name="B", segments=[_seg(0.0, 0.3, 10.0, 0.3, Layer.B_CU, net=2)])]
+    assert DiffPairRouter._copper_conflicts(a, b, clearance=0.2) is True
+
+
+# ---------------------------------------------------------------------------
+# 2. _net_is_connected -- the reach oracle
+# ---------------------------------------------------------------------------
+
+
+def test_net_is_connected_is_false_without_copper():
+    router = _channel_router()
+    assert router._diffpair._net_is_connected(3) is False
+
+
+def test_net_is_connected_is_true_for_a_single_pad_net():
+    router = _channel_router()
+    # Net 99 has no pads at all -- nothing to connect, nothing to strand.
+    assert router._diffpair._net_is_connected(99) is True
+
+
+# ---------------------------------------------------------------------------
+# 3. _probe_net_routable -- a probe must leave no trace
+# ---------------------------------------------------------------------------
+
+
+def test_probe_leaves_no_copper_behind():
+    router = _channel_router()
+    dp = router._diffpair
+    routes_before = len(router.routes)
+
+    probe = dp._probe_net_routable(3, per_net_timeout=10.0)
+
+    assert probe, "expected the unobstructed single-ended net to be routable"
+    assert len(router.routes) == routes_before, (
+        "the probe committed copper to autorouter.routes instead of rolling it back"
+    )
+    claimed = sum(
+        1
+        for idx in router.grid.get_routable_indices()
+        for y in range(router.grid.rows)
+        for x in range(router.grid.cols)
+        if router.grid.grid[idx][y][x].net == 3 and not router.grid.grid[idx][y][x].is_obstacle
+    )
+    assert claimed == 0, f"{claimed} grid cell(s) still claimed by the probed net"
+
+
+def test_probe_reports_a_sealed_net_as_unroutable():
+    router = _channel_router()
+    _commit(router, _wall_routes(router))
+    assert router._diffpair._probe_net_routable(3, per_net_timeout=10.0) is None
+
+
+# ---------------------------------------------------------------------------
+# 4. _plan_corridor_yields
+# ---------------------------------------------------------------------------
+
+
+def test_plan_names_the_pair_that_seals_the_corridor():
+    router = _channel_router()
+    dp = router._diffpair
+    wall = _wall_routes(router)
+    _commit(router, wall)
+    assert dp._net_is_connected(3) is False
+
+    to_yield, stranded = dp._plan_corridor_yields([3], [(_pair(), wall)])
+
+    assert [p.name for p, _r in to_yield] == ["PAIR"]
+    assert stranded == [3]
+    # Planning commits nothing: the board is exactly as it was found.
+    for route in wall:
+        assert route in router.routes
+    assert dp._net_is_connected(3) is False
+
+
+def test_plan_skips_a_pair_that_is_not_the_blocker():
+    """A pair that does not sit on the stranded net's path is not planned."""
+    router = _channel_router()
+    dp = router._diffpair
+    wall = _wall_routes(router)
+    bystander = _bystander()
+    _commit(router, [*wall, *bystander])
+
+    to_yield, _stranded = dp._plan_corridor_yields(
+        [3], [(_other_pair(), bystander), (_pair(), wall)]
+    )
+
+    assert [p.name for p, _r in to_yield] == ["PAIR"], (
+        "only the sealing pair may be asked to yield its corridor"
+    )
+    for route in bystander:
+        assert route in router.routes
+
+
+def test_plan_is_empty_when_nothing_is_stranded():
+    router = _channel_router()
+    dp = router._diffpair
+    bystander = _bystander()
+    _commit(router, bystander)
+    # Route SIG normally so it is connected before the pass runs.
+    for route in router.route_net(3):
+        assert route.net == 3
+    assert dp._net_is_connected(3) is True
+
+    assert dp._plan_corridor_yields([3], [(_other_pair(), bystander)]) == ([], [])
+    for route in bystander:
+        assert route in router.routes
+
+
+def test_plan_leaves_an_unrecoverable_net_alone():
+    """A net that stays unroutable with the coupled copper lifted is left be.
+
+    ``SIG`` here is walled off by a foreign-net obstacle the pre-phase did
+    not create, so yielding coupled corridors cannot help and no pair may
+    be sacrificed for it.
+    """
+    router = _channel_router()
+    dp = router._diffpair
+    bystander = _bystander()
+    _commit(router, bystander)
+    # A wall owned by a net that is NOT a yield candidate.
+    foreign = [
+        Route(
+            net=7,
+            net_name="WALL",
+            segments=[_seg(0.0, 4.0, 20.0, 4.0, Layer(router.grid.index_to_layer(idx)), net=7)],
+        )
+        for idx in router.grid.get_routable_indices()
+    ]
+    _commit(router, foreign)
+
+    to_yield, stranded = dp._plan_corridor_yields([3], [(_other_pair(), bystander)])
+
+    assert to_yield == []
+    assert stranded == [3]
+    for route in bystander:
+        assert route in router.routes
+
+
+def test_yield_is_reverted_when_it_does_not_gain_reach():
+    """The trade is transactional on REACH.
+
+    A yield that frees a corridor the strategy cannot use must put the
+    coupled copper back -- the board 06 shadow-ON measurement that took
+    reach from 18/21 to 15/21 was exactly this case scored dishonestly.
+    """
+    router = _channel_router()
+    dp = router._diffpair
+    wall = _wall_routes(router)
+    _commit(router, wall)
+
+    to_yield, _stranded = dp._plan_corridor_yields([3], [(_pair(), wall)])
+    assert [p.name for p, _r in to_yield] == ["PAIR"]
+
+    # A strategy that routes nothing: the freed corridor buys no reach.
+    kept, released, removed, added = dp._apply_corridor_yields(to_yield, [3], lambda: [])
+
+    assert (kept, released, removed, added) == (False, set(), [], [])
+    assert dp._net_is_connected(3) is False
+    for route in wall:
+        assert route in router.routes, "a reverted yield must restore the pair's copper"
+
+
+def test_yield_is_kept_when_the_re_run_lands_the_stranded_net():
+    """A yield that lets the strategy connect the stranded net is kept."""
+    router = _channel_router()
+    dp = router._diffpair
+    wall = _wall_routes(router)
+    _commit(router, wall)
+
+    to_yield, _stranded = dp._plan_corridor_yields([3], [(_pair(), wall)])
+
+    def _strategy() -> list[Route]:
+        return router.route_net(3)
+
+    kept, released, removed, added = dp._apply_corridor_yields(to_yield, [3], _strategy)
+
+    assert kept is True
+    assert released == {1, 2}
+    assert len(removed) == len(wall)
+    assert added, "the re-run's copper must be returned to the caller"
+    assert dp._net_is_connected(3) is True
+    for route in wall:
+        assert route not in router.routes
+
+
+def test_recovery_does_not_run_with_shadow_construction_off():
+    """Shadow-OFF runs (every board in CI today) never enter the recovery."""
+    router = _channel_router()
+    dp = router._diffpair
+    calls: list[object] = []
+
+    def _boom(*args: object, **kwargs: object) -> None:
+        calls.append(args)
+        raise AssertionError("the corridor-yield planner must not run with shadow OFF")
+
+    dp._plan_corridor_yields = _boom  # type: ignore[method-assign]
+    dp._apply_corridor_yields = _boom  # type: ignore[method-assign]
+    config = DifferentialPairConfig(enabled=True, enable_shadow_construction=False)
+
+    router.route_all_with_diffpairs(config, non_diffpair_strategy=lambda: [])
+
+    assert calls == []
+    assert getattr(router, "_coupled_prephase_stall_exit", False) is False


### PR DESCRIPTION
## Summary

The coupled diff-pair pre-phase commits its copper **before** the main
strategy runs, and that copper is **non-rippable** inside
`route_all_negotiated` — it never enters that loop's `net_routes`, so no
rip-up round, no neighbourhood-radius escalation and no relief rescue can free
a corridor it sealed. Reproduced on board 06 shadow-ON (seed 42, `main` @
`0a8d724e`): `MIPI_D0+`, `MIPI_D0-` and `USB_CC1` strand, every rescue rolls
back with `blocked only by non-rippable copper of <pair nets>`, and the loop
burns its whole 10-iteration ceiling — **362.3 s** to arrive at the same 18/21
it already had after iteration 1.

This also **corrects the stale `#3921`-era claim** (in `diffpair.py:638-643`
and the board-06 recipe) that corridor competition "did NOT reproduce": it
does, on current geometry, and worse than previously recorded.

Two mechanisms, both gated on `enable_shadow_construction` **and** killable via
`KCT_CORRIDOR_YIELD=0`, so shadow-OFF runs — every board in CI — are
behaviourally untouched:

1. **Fixed-point exit** (`core.py`): the negotiated loop stops once its
   stranded set is a zero-overflow fixed point (same nets, three consecutive
   iterations, nothing left to negotiate) instead of re-deriving the same
   failure at escalating cost.
2. **Corridor yield** (`diffpair_routing.py`): `_plan_corridor_yields` probes —
   on ground truth, after the strategy has reported what it could not connect —
   which stranded nets become routable once the coupled copper is lifted, and
   which pairs sit on the resulting path. `_apply_corridor_yields` rips exactly
   those, re-runs the main strategy **once** (capped) so the negotiated loop
   can arrange the freed corridor globally, and keeps the trade **only if reach
   improved** — otherwise every route is restored.

The "re-run the strategy" shape is load-bearing: the freed corridor is
contested, so the stranded net and the freed pair legs have to be arranged
together — which is exactly what a shadow-OFF run does when it reaches 21/21
with those nets single-ended. Landing them one-by-one here was measured and
rejected (it never gained reach).

## Changes

- `src/kicad_tools/router/core.py` — `_prephase_corridor_fixed_point` closure
  called from both rip-up branches; two new `Autorouter` fields
  (`_coupled_prephase_stall_exit`, `_negotiated_timeout_cap`) and the timeout
  cap application in `route_all_negotiated`.
- `src/kicad_tools/router/diffpair_routing.py` — `_probe_net_routable` (a probe
  that leaves no trace, including restoring the C++ backend's per-net
  clearance-resume memo, #3923, which otherwise makes repeated probes of one
  net silently pessimistic), `_copper_conflicts`, `_net_is_connected`,
  `_plan_corridor_yields`, `_apply_corridor_yields`, orchestration in
  `route_all_with_diffpairs`, and four env-tunable budgets incl. the
  `KCT_CORRIDOR_YIELD=0` kill-switch.
- `src/kicad_tools/router/diffpair.py` — the `enable_shadow_construction`
  comment: the corridor-competition claim corrected, the stale
  `~150 s` / `>1200 s` wall-clock figures replaced with measured numbers and
  the real CI envelope (the job's 30-minute `timeout-minutes`).
- `boards/06-diffpair-test/generate_design.py` — same correction at the
  `KCT_BOARD06_SHADOW` toggle.
- `tests/test_diffpair_corridor_guard.py` — 15 new tests.

## Measurements (one machine, one build; `KCT_CORRIDOR_YIELD=0` = "before")

`KCT_BOARD06_SHADOW=1 PYTHONHASHSEED=42 uv run python boards/06-diffpair-test/generate_design.py --step route --seed 42`

| | shadow-OFF | shadow-ON before | shadow-ON after |
|---|---|---|---|
| signal reach | **21/21** | 18/21 | **19/21** |
| stranded | — | MIPI_D0+, MIPI_D0-, USB_CC1 | USB_CC1 (+1 leg) |
| negotiated loop | 361.5 s | 362.3 / 362.8 s | **148.1 s** + 50.6 s planning + 300.5 s capped re-run |
| total `--step route` | 587.9 s | 754.9–770.4 s | 1351.2 s |
| DRC errors | (committed baseline 18) | 36 | 33 |

Per-rule, shadow-ON before → after: `diffpair_clearance_intra` 19 → **7**,
`diffpair_length_skew` 6 → 7, `diffpair_routing_continuity` 6 → 7,
`clearance_pad_segment` 0 → **5**, `connectivity` 3 → 3, `impedance` 1 → 2.

**Honest caveats** (the two yielded pairs stop being diff-pair nets, so they
re-enter the single-ended optimizer/nudge/repair passes the shadow path
excludes them from):

- Skew/continuity each tick up by 1 (14 vs the 12 the issue's AC asked not to
  exceed), and `clearance_pad_segment` goes 0 → 5, against an AC that wanted it
  to stay 0. Total error count still *improves* (36 → 33).
- Total shadow-ON job wall-clock grows 754.9 s → 1351.2 s (22.5 min) even
  though the negotiated phase itself is far cheaper. That has no headroom
  against the 30-minute CI ceiling on a slower runner — documented at the flag
  as one more reason the default stays OFF. **CI never runs this path** (it is
  behind `KCT_BOARD06_SHADOW`, which CI does not set).
- `USB_CC1` is still stranded: its corridor is contested even with every
  coupled body gone, so no yield can pay for it.

## Acceptance Criteria Verification

- [x] Corridor competition reproduced, root-caused (non-rippable pre-phase
      copper) and mitigated; reach 18/21 → 19/21. **Not 21/21** — `USB_CC1`
      is not recoverable by yielding (measured, not assumed).
- [x] Negotiated-loop wall-clock reduced from 361.8 s → **148.1 s**; the
      shadow-OFF baseline for the same phase is 361.5 s, so this is inside the
      "within 2× of shadow-OFF" target (0.41×; 1.24× counting the recovery
      re-run). Both numbers published above.
- [x] Full shadow-ON job wall-clock measured end-to-end (1351.2 s) and
      documented against the job's 30-minute `timeout-minutes` ceiling.
- [x] `.github/routed-drc-tolerance.yml` (18), `check_diffpair_coverage.py`
      `DIFFPAIR_VIOLATION_BASELINE` (18) and `EXPECTED_STRICT_GATE_ERRORS` (18)
      **unchanged**; no committed artifact touched (`git status` clean under
      `boards/`).
- [x] `diffpair.py`'s `enable_shadow_construction` comment corrected (the
      "#3921 corridor competition did NOT reproduce" claim and the
      `~150 s`/`>1200 s` figures).
- [x] `enable_shadow_construction` remains `False` by default in
      `DifferentialPairConfig` and board-06's recipe stays env-gated — the flip
      is **not** attempted here.
- [ ] Follow-up phase for the deferred flip: to be recorded on the epic
      thread (#4409) by the reviewer/owner — this PR does not file issues.

## Test Plan

- [x] `tests/test_diffpair_corridor_guard.py` — 15 new tests (probe leaves no
      trace; conflict geometry incl. via-blocks-every-layer; plan names only
      the sealing pair; plan commits nothing; unrecoverable net costs no pair;
      yield reverted when it gains no reach; yield kept when it does; nothing
      runs with shadow OFF).
- [x] `uv run pytest -k "diffpair or negotiated or router_core or route_all"` —
      **1372 passed**, 1 skipped.
- [x] `uv run python scripts/ci/check_diffpair_coverage.py boards/06-diffpair-test --seed 42`
      — **PASS**: reach 21/21, 18 errors (allowlist 18), all 3 diff-pair rules
      exercised.
- [x] Shadow-OFF end-to-end re-route: 21/21, `check_routed_drc.py` strict gate
      clean; committed artifacts restored/untouched.
- [x] `ruff format --check` (1725 files) + `ruff check .` clean.
- [ ] `kicad-cli pcb drc --refill-zones` on the shadow-ON artifact — not run
      (each shadow-ON reproduction is ~13–22 min and the run budget went to the
      before/after matrix above); the shadow-OFF path, which is what ships, is
      gated by `check_diffpair_coverage.py` above.

**Pre-existing, unrelated**: `scripts/ci/check_mypy_baseline.py` reports one
"new" error in `src/kicad_tools/recovery/strategy.py` (a file this PR does not
touch) — the local mypy renders the message without the method name while the
baseline records it with, so it fails to match. The baseline was **not**
edited. Also note the *main* checkout has pre-existing uncommitted board-06
output drift (from an earlier reproduction run, mtime predates this branch);
untouched here.

Closes #4463