### PR TITLE
fix(diffpair): gate constructed pairs on a thickness-free via signature

### DIFF
--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -389,6 +389,31 @@ _TAIL_FOLLOW_MAX_RUNS_PER_SIDE: int = 2
 # difference) / (n - 1)``, which is zero exactly when the two legs'
 # ``(via count, sum |delta stack index|)`` signatures match, for ANY thickness.
 _SHADOW_VIA_SYMMETRY: bool = os.environ.get("KCT_SHADOW_VIA_SYMMETRY", "1") == "1"
+# What to do with a pair for which NEITHER offset side is via-symmetric and no
+# remediation is legal.
+#
+# ``STRICT`` drops it (the electrically pure answer: an unmatched via is a
+# mode-conversion and impedance discontinuity, not just a length error).  The
+# DEFAULT keeps the best legal candidate and says so loudly, because the strict
+# policy was measured on board-06 seed 42 shadow-ON and costs reach: 33 -> 26
+# total DRC errors but 19 -> 18 signal nets routed, and part of that "-7" is
+# vacuity -- ``diffpair_length_skew`` only fires on an ENGAGED pair, so a pair
+# that is dropped stops being measured (USB3_TX1's 3.412 mm skew error was
+# replaced by two ``connectivity`` errors and two LVS opens).  An unrouted net
+# is a worse ship than a skew error the checker names in full, so the default
+# ships the pair and the DRC keeps flagging it.
+#
+# Why no remediation is legal on this board is worth recording: the landing
+# tails must CROSS the guide (``_synthesize_crossing_tail``'s deliberate
+# two-via crossover is the only legal tail -- every layer-locked planar probe
+# is rejected for physically overlapping the partner), and mirroring the pair
+# of vias onto the guide leg is blocked because the coupled gap (0.075-0.15 mm)
+# is far below the via-barrel-to-partner-copper bound (~0.6 mm), so a
+# centreline-preserving z-jog has nowhere legal to sit along the coupled body.
+# A LATERALLY OFFSET mirrored jog (the ``lateral_jog_polyline`` machinery the
+# #4553 meander already uses, pushed away from the partner) is the remaining
+# lever and is deliberately left as follow-up work.
+_SHADOW_VIA_SYMMETRY_STRICT: bool = os.environ.get("KCT_SHADOW_VIA_SYMMETRY_STRICT", "0") == "1"
 
 
 # ---------------------------------------------------------------------------
@@ -5476,6 +5501,266 @@ class DiffPairRouter:
         finally:
             setter(saved)
 
+    def _planar_tail_probe(
+        self,
+        head: Pad,
+        goal: Pad,
+        layer_idx: int,
+        partner_segments: list[Segment] | None,
+        seg_clear: float,
+    ) -> Route | None:
+        """A landing tail that is PLANAR by construction (issue #4570).
+
+        Runs the per-net A* with the router's layer vector locked to
+        ``layer_idx``, so the search has no via expansion available at all.
+        The result is then held to exactly the gates every other tail
+        candidate passes -- the exact foreign-pad predicate (#4571) and the
+        partner screen (#4460) -- so preferring it can never smuggle copper
+        past a check the diving alternative would have failed.
+
+        Returns ``None`` when the lock is unavailable (pure-Python backend),
+        when no planar path exists, or when the candidate fails a gate.
+        """
+        with self._layer_locked_router(layer_idx) as locked:
+            cand = (
+                self._single_ended_guide_route(head, goal, per_net_timeout=10.0) if locked else None
+            )
+        why: str | None = None
+        if not locked:
+            why = "no-layer-lock"
+        elif cand is None or not cand.segments:
+            why = "no-planar-path"
+        elif cand.vias:
+            # Defensive: a lock that did not actually suppress via expansion
+            # buys nothing here.
+            why = "lock-leaked-a-via"
+        elif self._route_pad_violation(cand)[0] > _SHADOW_PAD_DEFICIT_EPS:
+            why = "pad-deficit"
+        elif partner_segments and not (
+            self._tail_partner_clear(cand, partner_segments, seg_clear)
+            or self._tail_partner_clear(cand, partner_segments, 0.0)
+        ):
+            why = "partner-overlap"
+        if _SHADOW_DEBUG:
+            print(f"    [coupled-planar-probe] layer={layer_idx} result={why or 'ok'}")
+        return None if why else cand
+
+    def _via_layer_multiset(
+        self, route: Route, num_copper_layers: int
+    ) -> collections.Counter[tuple]:
+        """Vias keyed by their (stack-ordered) layer pair (issue #4570)."""
+        out: collections.Counter[tuple] = collections.Counter()
+        for v in route.vias:
+            la, lb = v.layers
+            key = tuple(
+                sorted(
+                    (la, lb),
+                    key=lambda lay: DiffPairLengthTracker._stack_position(lay, num_copper_layers),
+                )
+            )
+            out[key] += 1
+        return out
+
+    def _mirror_z_jog(
+        self,
+        leg: Route,
+        layer_pair: tuple,
+        pathfinder: CoupledPathfinder,
+        partner_segments: list[Segment],
+        net: int,
+        net_name: str,
+    ) -> bool:
+        """Add a matching two-via z-jog to ``leg`` in place (issue #4570).
+
+        The other half of the via-symmetry fix: when the constructed leg needs
+        a via the partner cannot give up -- board-06's landing tails must
+        CROSS the guide, so ``_synthesize_crossing_tail``'s deliberate two-via
+        crossover is the only legal tail and no planar alternative exists --
+        the drilled length is equalised by giving the partner leg the same two
+        vias instead of taking them away.
+
+        The jog is deliberately **centreline-preserving**: a window in the
+        middle of one existing segment is re-emitted on the other layer of
+        ``layer_pair``, bracketed by two vias at the window's ends.  Plan-view
+        copper, and therefore the planar length the length matcher works on,
+        is unchanged; only the layer of a ~1 mm stretch moves.  That also
+        means no new angle is introduced, so the 45-census cannot regress.
+
+        Every piece is held to the SAME gates as all other constructed copper
+        before anything is mutated:
+
+        * ``drill_hole_to_hole_clear`` against the board-wide drill registry
+          (and between the jog's own two vias),
+        * ``_is_via_blocked`` (raster + drill envelope + no via-in-pad),
+        * ``_via_pad_deficit`` -- the exact foreign-pad predicate the raster
+          cannot see (the #4571 lesson),
+        * the raster and the exact pad predicate for the relocated stretch,
+        * via-barrel clearance to the partner on ANY layer.
+
+        Returns ``True`` only when the jog was applied.
+        """
+        from .via_clearance import drill_hole_to_hole_clear
+
+        grid = self.autorouter.grid
+        rules = self.autorouter.rules
+        la, lb = layer_pair
+        try:
+            idx_a = grid.layer_to_index(la.value)
+            idx_b = grid.layer_to_index(lb.value)
+        except Exception:  # pragma: no cover — defensive (unpopulated layer)
+            return False
+        routable = set(grid.get_routable_indices())
+        if idx_a not in routable or idx_b not in routable:
+            return False
+
+        min_h2h = getattr(rules, "min_hole_to_hole", 0.5)
+        # The window must be long enough for the two barrels to clear each
+        # other drill-to-drill, plus a little slack for the raster scan.
+        window = max(rules.via_drill + min_h2h + 2.0 * grid.resolution, 4.0 * grid.resolution)
+        existing = self._collect_existing_drills()
+        guide_width = max((s.width for s in leg.segments), default=rules.trace_width)
+        via_clear = rules.via_diameter / 2 + rules.trace_clearance + guide_width / 2
+
+        order = sorted(
+            range(len(leg.segments)),
+            key=lambda i: -math.hypot(
+                leg.segments[i].x2 - leg.segments[i].x1, leg.segments[i].y2 - leg.segments[i].y1
+            ),
+        )
+        for i in order:
+            seg = leg.segments[i]
+            length = math.hypot(seg.x2 - seg.x1, seg.y2 - seg.y1)
+            if length < window + 4.0 * grid.resolution:
+                break  # sorted longest-first: nothing after this fits either
+            try:
+                seg_idx = grid.layer_to_index(seg.layer.value)
+            except Exception:  # pragma: no cover — defensive
+                continue
+            if seg_idx == idx_a:
+                jog_idx = idx_b
+            elif seg_idx == idx_b:
+                jog_idx = idx_a
+            else:
+                continue
+            ux = (seg.x2 - seg.x1) / length
+            uy = (seg.y2 - seg.y1) / length
+            t0 = (length - window) / 2.0
+            ax, ay = seg.x1 + ux * t0, seg.y1 + uy * t0
+            bx, by = seg.x1 + ux * (t0 + window), seg.y1 + uy * (t0 + window)
+
+            if not drill_hole_to_hole_clear(ax, ay, rules.via_drill, existing, min_h2h):
+                continue
+            if not drill_hole_to_hole_clear(bx, by, rules.via_drill, existing, min_h2h):
+                continue
+            ga = grid.world_to_grid(ax, ay)
+            gb = grid.world_to_grid(bx, by)
+            if pathfinder._is_via_blocked(ga[0], ga[1], net) or pathfinder._is_via_blocked(
+                gb[0], gb[1], net
+            ):
+                continue
+            vias = [
+                Via(
+                    x=vx,
+                    y=vy,
+                    drill=rules.via_drill,
+                    diameter=rules.via_diameter,
+                    layers=(la, lb),
+                    net=net,
+                    net_name=net_name,
+                )
+                for vx, vy in ((ax, ay), (bx, by))
+            ]
+            if any(self._via_pad_deficit(v) > _SHADOW_PAD_DEFICIT_EPS for v in vias):
+                continue
+            if not self._segment_cells_clear(pathfinder, ax, ay, bx, by, jog_idx, net):
+                continue
+            jog_seg = Segment(
+                x1=ax,
+                y1=ay,
+                x2=bx,
+                y2=by,
+                width=seg.width,
+                layer=Layer(grid.index_to_layer(jog_idx)),
+                net=net,
+                net_name=net_name,
+            )
+            if not self._segment_pad_clear(jog_seg):
+                continue
+            if partner_segments and any(
+                self._min_distance_to_partner(v.x, v.y, v.x, v.y, partner_segments, None)
+                < via_clear
+                for v in vias
+            ):
+                continue
+
+            def _piece(x1: float, y1: float, x2: float, y2: float, layer) -> Segment:
+                return Segment(
+                    x1=x1,
+                    y1=y1,
+                    x2=x2,
+                    y2=y2,
+                    width=seg.width,
+                    layer=layer,
+                    net=net,
+                    net_name=net_name,
+                )
+
+            leg.segments[i : i + 1] = [
+                _piece(seg.x1, seg.y1, ax, ay, seg.layer),
+                jog_seg,
+                _piece(bx, by, seg.x2, seg.y2, seg.layer),
+            ]
+            leg.vias.extend(vias)
+            return True
+        return False
+
+    def _match_pair_via_signature(
+        self,
+        guide_route: Route,
+        shadow_route: Route,
+        pathfinder: CoupledPathfinder,
+        num_copper_layers: int,
+    ) -> bool:
+        """Equalise the two legs' via signatures in place (issue #4570).
+
+        Returns ``True`` when the pair already matched or was remediated, and
+        ``False`` when it could not be -- in which case the caller declines the
+        side rather than shipping copper whose skew the planar length matcher
+        cannot see.
+
+        Only the leg that is SHORT of vias grows; the excess is never removed
+        here (the tail-side planar preference already tried that, upstream and
+        more cheaply).  An odd excess is refused outright: a z-jog adds vias in
+        pairs, and a pad-to-pad route on one surface layer cannot legally carry
+        an odd count, so an odd difference means something upstream is wrong
+        and must not be papered over.
+        """
+        guide_ms = self._via_layer_multiset(guide_route, num_copper_layers)
+        shadow_ms = self._via_layer_multiset(shadow_route, num_copper_layers)
+        if guide_ms == shadow_ms:
+            return True
+        for deficient, surplus in (
+            (guide_route, shadow_ms - guide_ms),
+            (shadow_route, guide_ms - shadow_ms),
+        ):
+            partner = shadow_route if deficient is guide_route else guide_route
+            for layer_pair, count in surplus.items():
+                if count % 2:
+                    return False
+                for _ in range(count // 2):
+                    if not self._mirror_z_jog(
+                        deficient,
+                        layer_pair,
+                        pathfinder,
+                        list(partner.segments),
+                        deficient.net,
+                        deficient.net_name,
+                    ):
+                        return False
+        return self._via_layer_multiset(guide_route, num_copper_layers) == (
+            self._via_layer_multiset(shadow_route, num_copper_layers)
+        )
+
     def _fallback_tail_route(
         self,
         head: Pad,
@@ -5539,19 +5824,10 @@ class DiffPairRouter:
         # via-asymmetric) is displaced -- and only by a layer-locked probe that
         # clears the very same gates.
         if prefer_planar_layer is not None and (plain is None or plain.vias):
-            with self._layer_locked_router(prefer_planar_layer) as locked:
-                planar = _probe(None, 1) if locked else None
-            if planar is not None and planar.vias:
-                # Defensive: a lock that did not actually suppress via
-                # expansion buys nothing here.
-                planar = None
-            if not _pad_ok(planar):
-                planar = None
-            if planar is not None and (
-                not partner_segments
-                or self._tail_partner_clear(planar, partner_segments, seg_clear)
-                or self._tail_partner_clear(planar, partner_segments, 0.0)
-            ):
+            planar = self._planar_tail_probe(
+                head, goal, prefer_planar_layer, partner_segments, seg_clear
+            )
+            if planar is not None:
                 plain = planar
 
         if not partner_segments:
@@ -5661,11 +5937,30 @@ class DiffPairRouter:
                 allow_expensive_landing=tail is None,
                 prefer_planar=prefer_planar,
             )
-            if following is not None and self._tail_is_better_coupled(
-                following, tail, partner_segments
+            if (
+                following is not None
+                # Issue #4570: never let a via-carrying follow displace a
+                # PLANAR incumbent when the partner leg has no via to match.
+                and not (prefer_planar and following.vias and tail is not None and not tail.vias)
+                and self._tail_is_better_coupled(following, tail, partner_segments)
             ):
                 tail = following
                 source = "follow"
+        # Issue #4570: the LAYER-LOCKED A* runs before the crossing tail when
+        # the partner leg has no via to match.  ``_synthesize_crossing_tail``
+        # is a deliberate TWO-via construction (the polarity-swap crossover),
+        # and it -- not the free-layer A* fallback -- is the dominant via
+        # source in the constructed tails measured on board-06: two promoted
+        # through-vias on one leg is exactly the 2 x 1.6 = 3.2 mm of invisible
+        # skew this issue is about.  Trying a planar tail first keeps the
+        # crossover available for the cases that genuinely need it (no planar
+        # path exists) while removing it wherever one does.
+        planar_probed = False
+        if prefer_planar and (tail is None or tail.vias):
+            planar = self._planar_tail_probe(head, goal, layer_idx, partner_segments, seg_clear)
+            planar_probed = True
+            if planar is not None:
+                tail, source = planar, "astar-planar"
         if tail is None and partner_segments:
             tail = self._synthesize_crossing_tail(
                 pathfinder, head, goal, layer_idx, partner_segments
@@ -5677,7 +5972,9 @@ class DiffPairRouter:
                 goal,
                 partner_segments,
                 seg_clear,
-                prefer_planar_layer=layer_idx if prefer_planar else None,
+                # A planar probe that already failed will not succeed a second
+                # time; do not pay for it twice.
+                prefer_planar_layer=(layer_idx if (prefer_planar and not planar_probed) else None),
             )
             source = "astar" if tail is not None else source
         if tail is None and following is not None:
@@ -6973,6 +7270,10 @@ class DiffPairRouter:
                 sections.append((li, []))
             sections[-1][1].append(seg)
         max_trim = _SHADOW_MAX_TRIM_MM
+        # Issue #4570: best legal-but-via-asymmetric candidate seen across both
+        # offset sides.  Only used once every side has failed to produce a
+        # symmetric pair -- see the end of this method.
+        asym_fallback: tuple[Route, Route] | None = None
 
         for side in (1.0, -1.0):
             elements: list[tuple] = []  # ('seg', x1,y1,x2,y2,layer) | ('via', x,y,l0,l1)
@@ -7453,23 +7754,40 @@ class DiffPairRouter:
             # (a) remediation stays transactional with the rest of the side and
             # (b) the length match runs on the FINAL geometry.
             #
-            # The remediation itself is upstream: the tails were asked for
-            # planar routing (``planar_tails``) precisely so this gate passes.
-            # When it did not work out, the side DECLINES rather than shipping
-            # an asymmetric pair -- a declined side fails over to the other
-            # offset side and then to the non-shadow path, which is a known
-            # outcome; invisible skew is not.
+            # Two remediations, in cost order:
+            #
+            #   A. the tails were already asked for PLANAR routing
+            #      (``planar_tails``, upstream) -- the cheapest fix, because it
+            #      removes copper instead of adding it;
+            #   B. when no planar tail is legal -- board-06's landing tails must
+            #      CROSS the guide, so the two-via crossover is the only tail
+            #      that exists -- the partner leg is given the SAME two vias, as
+            #      a centreline-preserving z-jog that clears every gate other
+            #      constructed copper clears.
+            #
+            # A side that is still asymmetric after both is REJECTED here and
+            # fails over to the other offset side (``via_symmetric`` below
+            # gates the ``return``).  Whether a pair with no symmetric side at
+            # all is dropped entirely or kept as an explicit last resort is
+            # ``_SHADOW_VIA_SYMMETRY_STRICT`` -- see the constant's comment for
+            # the board-06 measurement behind that default.
+            via_symmetric = True
             if _SHADOW_VIA_SYMMETRY:
                 n_layers = getattr(grid, "num_layers", 0) or 2
                 guide_sig = _route_via_signature(guide_route_obj, n_layers)
                 shadow_sig = _route_via_signature(shadow_route, n_layers)
                 if guide_sig != shadow_sig:
+                    via_symmetric = self._match_pair_via_signature(
+                        guide_route_obj, shadow_route, pathfinder, n_layers
+                    )
                     print(
                         f"    [coupled-shadow] side={side:+.0f} via-signature "
                         f"mismatch for {pair.name} (guide={guide_sig} "
-                        f"shadow={shadow_sig}); trying other side"
+                        f"shadow={shadow_sig}); "
+                        f"{'mirrored' if via_symmetric else 'unrepaired'}"
                     )
-                    self._last_shadow_decline_reason = "via-skew"  # #4570
+                    if not via_symmetric:
+                        self._last_shadow_decline_reason = "via-skew"  # #4570
                     if _SHADOW_DEBUG:
                         print(
                             f"    [coupled-shadow-via] {pair.name} "
@@ -7478,7 +7796,6 @@ class DiffPairRouter:
                             f"body_vias={len([e for e in kept if e[0] == 'via'])} "
                             f"planar_tails={planar_tails}"
                         )
-                    continue
 
             # Issue #4553: make the pair length-symmetric BY CONSTRUCTION.
             # The parallel offset, the shadow's via jogs and its independently
@@ -7591,6 +7908,15 @@ class DiffPairRouter:
                 )
                 self._last_shadow_decline_reason = "pad-clearance"  # #4571
                 continue
+            if not via_symmetric:
+                # Issue #4570: this side is otherwise legal but its two legs
+                # carry different vias.  Hold it back so the OTHER offset side
+                # (and the uncompressed-guide retry) get their chance to
+                # produce a symmetric pair; ``asym_fallback`` keeps it as the
+                # explicit last resort described at the end of this method.
+                if asym_fallback is None:
+                    asym_fallback = (p_route, n_route)
+                continue
             return p_route, n_route
 
         # Issue #4553: both offset sides declined on the COMPRESSED guide.
@@ -7598,7 +7924,7 @@ class DiffPairRouter:
         # rate can only ever improve -- the compressed guide is a different
         # (usually easier, occasionally tighter) corridor, never a mandate.
         if guide_was_simplified:
-            return self._shadow_route_pair(
+            retry = self._shadow_route_pair(
                 pair,
                 spec,
                 pathfinder,
@@ -7607,6 +7933,30 @@ class DiffPairRouter:
                 swap_roles=swap_roles,
                 simplify_guide=False,
             )
+            if retry is not None:
+                return retry
+
+        # Issue #4570: no side produced a via-symmetric pair.  ``STRICT`` drops
+        # the pair here (the electrically pure answer); the default keeps the
+        # best legal-but-asymmetric candidate, LOUDLY, because on board-06 the
+        # strict policy costs a routed net -- and an unrouted net (a
+        # ``connectivity`` error and an LVS open) is a worse ship than a
+        # ``diffpair_length_skew`` error the checker names in full.  Either way
+        # the outcome is recorded, never silent.
+        if asym_fallback is not None:
+            if _SHADOW_VIA_SYMMETRY_STRICT:
+                print(
+                    f"    [coupled-shadow] {pair.name} declined: no offset side "
+                    f"is via-symmetric (KCT_SHADOW_VIA_SYMMETRY_STRICT=1)"
+                )
+                return None
+            print(
+                f"    [coupled-shadow] {pair.name} WARNING: shipping a "
+                f"via-ASYMMETRIC pair (no symmetric side and no legal mirror); "
+                f"expect a diffpair_length_skew error of the vias' drilled "
+                f"length -- issue #4570"
+            )
+            return asym_fallback
         return None
 
     def _rescue_near_miss_coupled(

--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -405,15 +405,28 @@ _SHADOW_VIA_SYMMETRY: bool = os.environ.get("KCT_SHADOW_VIA_SYMMETRY", "1") == "
 #
 # Why no remediation is legal on this board is worth recording: the landing
 # tails must CROSS the guide (``_synthesize_crossing_tail``'s deliberate
-# two-via crossover is the only legal tail -- every layer-locked planar probe
-# is rejected for physically overlapping the partner), and mirroring the pair
-# of vias onto the guide leg is blocked because the coupled gap (0.075-0.15 mm)
-# is far below the via-barrel-to-partner-copper bound (~0.6 mm), so a
-# centreline-preserving z-jog has nowhere legal to sit along the coupled body.
-# A LATERALLY OFFSET mirrored jog (the ``lateral_jog_polyline`` machinery the
-# #4553 meander already uses, pushed away from the partner) is the remaining
-# lever and is deliberately left as follow-up work.
+# two-via crossover is the only legal tail -- all 12 layer-locked planar probes
+# on the seed-42 run are rejected for breaking the intra-pair clearance against
+# the partner), and mirroring the pair of vias onto the guide leg is blocked
+# because the coupled gap (0.075-0.15 mm) is far below the
+# via-barrel-to-partner-copper bound (~0.6 mm), so a centreline-preserving
+# z-jog has nowhere legal to sit along the coupled body.  A LATERALLY OFFSET
+# mirrored jog (the ``lateral_jog_polyline`` machinery the #4553 meander
+# already uses, pushed away from the partner) is the remaining lever and is
+# deliberately left as follow-up work.
 _SHADOW_VIA_SYMMETRY_STRICT: bool = os.environ.get("KCT_SHADOW_VIA_SYMMETRY_STRICT", "0") == "1"
+# Remediation B (``_mirror_z_jog``): give the leg that is SHORT of vias the same
+# vias as its partner, as a centreline-preserving z-jog.
+#
+# Implemented and unit-tested, but OFF by default on the strength of its own
+# board-06 seed-42 measurement: exactly one pair (USB2_D) had a legal mirror
+# site, and taking it moved that pair onto geometry sitting exactly on the
+# 0.100-vs-0.1016 mm intra-pair rung -- ``diffpair_clearance_intra`` 7 -> 19 and
+# its own skew 5.430 -> 6.348 mm.  The mirror needs a site *selection* policy
+# (prefer an uncoupled stretch, and re-check the pair's marginal rungs after
+# splitting a segment) before it can be trusted by default; the gate and the
+# tail-side remediation do not depend on it.
+_SHADOW_VIA_MIRROR: bool = os.environ.get("KCT_SHADOW_VIA_MIRROR", "0") == "1"
 
 
 # ---------------------------------------------------------------------------
@@ -7794,7 +7807,7 @@ class DiffPairRouter:
                 guide_sig = _route_via_signature(guide_route_obj, n_layers)
                 shadow_sig = _route_via_signature(shadow_route, n_layers)
                 if guide_sig != shadow_sig:
-                    via_symmetric = self._match_pair_via_signature(
+                    via_symmetric = _SHADOW_VIA_MIRROR and self._match_pair_via_signature(
                         guide_route_obj, shadow_route, pathfinder, n_layers
                     )
                     print(

--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -23,7 +23,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
+    from collections.abc import Callable, Iterator, Mapping
 
     from .core import Autorouter
     from .cpp_backend import CppCoupledPathfinder
@@ -46,6 +46,7 @@ from .diffpair import (
 from .diffpair_detection import (
     detect_diff_pairs as _layered_detect_diff_pairs,
 )
+from .diffpair_length import DiffPairLengthTracker
 from .layers import Layer
 from .observability import validate_net_connectivity
 from .path import calculate_route_length
@@ -363,6 +364,32 @@ _TAIL_FOLLOW_MAX_SPANS: int = 400
 # bracketing with a lead-in / landing (they are tried longest-first).
 _TAIL_FOLLOW_MAX_RUNS_PER_SIDE: int = 2
 
+# Issue #4570: via-count symmetry between the two legs of a constructed pair.
+#
+# ``diffpair_length_skew`` measures ELECTRICAL length -- segment copper PLUS
+# every via's drilled length (``DiffPairLengthTracker._via_length``:
+# ``board_thickness_mm * |delta stack index| / (num_copper_layers - 1)``, with a
+# non-micro via promoted to the full thickness on a board without blind/buried
+# drilling, #4007).  The constructor's length matcher
+# (``_length_match_constructed_pair`` on ``_route_copper_length``) is PLANAR
+# only, so a pair whose two legs carry different vias can be driven to a 0.012
+# mm planar delta and still ship a 3.19 mm skew violation (measured on board-06
+# shadow-ON seed 42: PCIE_RX and USB3_TX1, 0 vias on the guide leg and two full
+# F.Cu->B.Cu through-vias on the shadow leg = 2 x 1.6 mm).
+#
+# The fix is symmetry, not compensation.  Compensating the z-length inside the
+# meander was measured as a wash (3.2 mm of extra UNCOUPLED meander converts a
+# skew error into a ``diffpair_routing_continuity`` error), and an unmatched via
+# is a mode-conversion / impedance discontinuity in its own right -- not merely
+# a length error.  So the constructor instead makes the two legs carry the same
+# vias, which cancels the drilled term exactly.
+#
+# The gate is purely COMBINATORIAL and needs no board thickness: the per-leg
+# z-length difference is ``thickness * (per-leg sum |delta stack index|
+# difference) / (n - 1)``, which is zero exactly when the two legs'
+# ``(via count, sum |delta stack index|)`` signatures match, for ANY thickness.
+_SHADOW_VIA_SYMMETRY: bool = os.environ.get("KCT_SHADOW_VIA_SYMMETRY", "1") == "1"
+
 
 # ---------------------------------------------------------------------------
 # Issue #3023 Phase A: intra-pair clearance violation detection
@@ -483,10 +510,58 @@ def _route_copper_length(route: Route | None) -> float:
     Issue #4553: the shadow constructor's length-symmetry work needs a single
     definition of "how long is this leg" shared by the constructor, its
     diagnostics and the unit tests.  Vias contribute no planar length.
+
+    Issue #4570: this stays deliberately PLANAR.  The z-length a via adds is
+    real (``diffpair_length_skew`` measures it), but compensating for it here
+    -- by meandering the shorter leg by the drilled difference -- was measured
+    as a wash: the compensation is uncoupled copper, so it merely converts a
+    ``diffpair_length_skew`` error into a ``diffpair_routing_continuity`` one.
+    The drilled term is cancelled instead, by
+    :func:`_route_via_signature` / the constructor's via-symmetry gate, which
+    makes the two legs carry the same vias in the first place.
     """
     if route is None:
         return 0.0
     return sum(math.hypot(s.x2 - s.x1, s.y2 - s.y1) for s in route.segments)
+
+
+def _via_stack_span(via: Via, num_copper_layers: int) -> int:
+    """``|delta stack index|`` spanned by ``via`` in an N-layer stack (issue #4570).
+
+    Delegates the layer -> stack-position mapping to
+    :meth:`DiffPairLengthTracker._stack_position`, the audited model the
+    ``diffpair_length_skew`` checker itself uses, so the constructor and the
+    checker can never drift apart on what a via's drilled span is.
+    """
+    layer_start, layer_end = via.layers
+    return abs(
+        DiffPairLengthTracker._stack_position(layer_start, num_copper_layers)
+        - DiffPairLengthTracker._stack_position(layer_end, num_copper_layers)
+    )
+
+
+def _route_via_signature(route: Route | None, num_copper_layers: int) -> tuple[int, int]:
+    """``(via count, sum |delta stack index|)`` for one leg of a pair (issue #4570).
+
+    The thickness-free proxy for the via drilled length
+    ``diffpair_length_skew`` adds to each leg.  ``_via_length`` is
+    ``board_thickness_mm * |delta stack index| / (num_copper_layers - 1)``, and
+    a non-micro via is promoted to the full ``board_thickness_mm`` when the
+    board does not support blind/buried drilling (#4007).  Two legs with EQUAL
+    signatures therefore contribute equal via length under BOTH models, for any
+    ``board_thickness_mm`` -- so the constructor can enforce z-length symmetry
+    without a thickness source (the router's ``DesignRules`` carries none).
+
+    The count is kept alongside the span sum because the promoted model depends
+    only on the count while the un-promoted one depends only on the span sum;
+    requiring both to match makes the signature sufficient for either.
+    """
+    if route is None:
+        return (0, 0)
+    return (
+        len(route.vias),
+        sum(_via_stack_span(v, num_copper_layers) for v in route.vias),
+    )
 
 
 Point = tuple[float, float]
@@ -4581,6 +4656,7 @@ class DiffPairRouter:
         partner_segments: list[Segment],
         partner_clearance: float,
         allow_expensive_landing: bool = False,
+        prefer_planar: bool = False,
     ) -> Route | None:
         """Landing tail built as a parallel OFFSET of the partner's own run.
 
@@ -4700,7 +4776,14 @@ class DiffPairRouter:
                     landing = self._synthesize_crossing_tail(
                         pathfinder, anchor, goal, layer_idx, partner_segments
                     ) or self._fallback_tail_route(
-                        anchor, goal, partner_segments, partner_clearance
+                        anchor,
+                        goal,
+                        partner_segments,
+                        partner_clearance,
+                        # Issue #4570: the follow tail's own last-resort A*
+                        # lander is a second via-inventing source; bias it the
+                        # same way as the caller's.
+                        prefer_planar_layer=layer_idx if prefer_planar else None,
                     )
                 if landing is None:
                     continue
@@ -5353,12 +5436,53 @@ class DiffPairRouter:
                     return sites
         return sites
 
+    @contextlib.contextmanager
+    def _layer_locked_router(self, layer_idx: int) -> Iterator[bool]:
+        """Narrow the shared pathfinder to one copper layer (issue #4570).
+
+        Yields ``True`` when the lock is in force.  With the layer vector
+        narrowed to ``layer_idx`` the A* has no via expansion available, so any
+        route it returns is PLANAR by construction -- which is how the
+        constructor gets a landing tail that does not invent a via its partner
+        leg has no counterpart for.
+
+        Yields ``False`` (and changes nothing) when the active pathfinder does
+        not expose ``set_routable_layers`` -- the pure-Python backend.  Callers
+        must then treat the planar attempt as unavailable rather than assume
+        the result is planar.
+
+        The narrowing is restored unconditionally: ``routable_layers_`` is
+        shared by every net on the board, so leaking it would silently forbid
+        vias for the rest of the run.
+        """
+        router = getattr(self.autorouter, "router", None)
+        setter = getattr(router, "set_routable_layers", None)
+        if setter is None or router is None:
+            yield False
+            return
+        saved = list(getattr(router, "_routable_layers", []) or [])
+        if layer_idx not in saved:
+            # The lock layer is not routable at all (plane / disallowed): a
+            # planar tail on it is impossible, so do not disturb the router.
+            yield False
+            return
+        if saved == [layer_idx]:
+            # Already single-layer -- nothing to narrow, nothing to restore.
+            yield True
+            return
+        setter([layer_idx])
+        try:
+            yield True
+        finally:
+            setter(saved)
+
     def _fallback_tail_route(
         self,
         head: Pad,
         goal: Pad,
         partner_segments: list[Segment] | None,
         seg_clear: float,
+        prefer_planar_layer: int | None = None,
     ) -> Route | None:
         """Partner-aware last-resort A* tail (issue #4460).
 
@@ -5370,6 +5494,18 @@ class DiffPairRouter:
         PHYSICAL-overlap bound is discarded outright -- handing the decision
         back to the caller's anchor-stepping retry instead of emitting copper
         the self-check gate is guaranteed to reject.
+
+        Issue #4570: this per-net A* is the constructor's only via-inventing
+        tail source -- it is free to change layer, and nothing on the partner
+        leg mirrors the via it drills, so its dive shows up as pure skew the
+        planar length matcher cannot see (measured: 2 x 1.6 mm on board-06's
+        PCIE_RX / USB3_TX1).  When ``prefer_planar_layer`` names the layer the
+        partner's corresponding copper occupies, ONE extra probe is spent with
+        the router locked to that layer, and its result is preferred whenever
+        it passes the same ``_pad_ok`` / ``_tail_partner_clear`` gates as the
+        unbiased probe.  ``None`` (the default, and the only value reachable
+        with shadow construction off) skips the extra probe entirely, so the
+        legacy chain below is untouched.
         """
 
         def _probe(avoid: list[tuple[float, float]] | None, radius: int) -> Route | None:
@@ -5396,6 +5532,28 @@ class DiffPairRouter:
         plain = _probe(None, 1)
         if not _pad_ok(plain):
             plain = None
+
+        # Issue #4570: the unbiased probe stays FIRST CHOICE whenever it is
+        # already planar, so nothing that was acceptable before changes.  Only
+        # a probe that dived through the board (and so would leave the pair
+        # via-asymmetric) is displaced -- and only by a layer-locked probe that
+        # clears the very same gates.
+        if prefer_planar_layer is not None and (plain is None or plain.vias):
+            with self._layer_locked_router(prefer_planar_layer) as locked:
+                planar = _probe(None, 1) if locked else None
+            if planar is not None and planar.vias:
+                # Defensive: a lock that did not actually suppress via
+                # expansion buys nothing here.
+                planar = None
+            if not _pad_ok(planar):
+                planar = None
+            if planar is not None and (
+                not partner_segments
+                or self._tail_partner_clear(planar, partner_segments, seg_clear)
+                or self._tail_partner_clear(planar, partner_segments, 0.0)
+            ):
+                plain = planar
+
         if not partner_segments:
             return plain
         if plain is not None and self._tail_partner_clear(plain, partner_segments, seg_clear):
@@ -5406,7 +5564,17 @@ class DiffPairRouter:
             radius_cells = max(
                 1, int(round(seg_clear / max(self.autorouter.grid.resolution, 1e-9) / 3.0))
             )
-            biased = _probe(sites, radius_cells)
+            # Issue #4570: when a planar tail is wanted, the guide-biased
+            # re-route is locked too -- otherwise the constructor would trade
+            # the planar candidate found above for a better-coupled DIVE and
+            # re-open the very via asymmetry this pass exists to close.
+            if prefer_planar_layer is not None and (plain is None or not plain.vias):
+                with self._layer_locked_router(prefer_planar_layer) as locked:
+                    biased = _probe(sites, radius_cells) if locked else None
+                if biased is not None and biased.vias:
+                    biased = None
+            else:
+                biased = _probe(sites, radius_cells)
             if not _pad_ok(biased):
                 biased = None
             if biased is not None and self._tail_partner_clear(biased, partner_segments, seg_clear):
@@ -5427,6 +5595,7 @@ class DiffPairRouter:
         label: str,
         pair_name: str,
         partner_segments: list[Segment] | None = None,
+        prefer_planar: bool = False,
     ) -> Route | None:
         """Head->pad completion: synthesized tail, then per-net A* fallback.
 
@@ -5445,6 +5614,17 @@ class DiffPairRouter:
         guide is discarded rather than emitted, which lets the caller's
         anchor-stepping loop retry from a deeper body anchor instead of
         spending the attempt on copper the self-check will reject anyway.
+
+        Issue #4570: ``prefer_planar`` states that the partner leg has no via
+        for this tail to be matched against, so a tail that changes layer would
+        leave the pair via-asymmetric -- i.e. skewed by the vias' drilled
+        length, which the constructor's planar length matcher cannot see.  It
+        biases the A* fallback (the only via-inventing source here) toward
+        ``layer_idx``.  It is a PREFERENCE, not a veto: a tail that can only be
+        reached through a via is still returned, and the caller's post-assembly
+        symmetry gate decides whether the resulting pair is shippable.  The
+        deliberate two-via crossing tail (the polarity-swap crossover) is left
+        alone -- it exists precisely because no planar tail was legal.
         """
         seg_clear = self._pair_seg_clearance(pathfinder, head.net_name) if partner_segments else 0.0
         tail = self._synthesize_tail(
@@ -5479,6 +5659,7 @@ class DiffPairRouter:
                 # was going to pay for them anyway.  Keeps the worst-case cost
                 # of a coupled tail identical to the pre-#4572 chain.
                 allow_expensive_landing=tail is None,
+                prefer_planar=prefer_planar,
             )
             if following is not None and self._tail_is_better_coupled(
                 following, tail, partner_segments
@@ -5491,7 +5672,13 @@ class DiffPairRouter:
             )
             source = "crossing" if tail is not None else source
         if tail is None:
-            tail = self._fallback_tail_route(head, goal, partner_segments, seg_clear)
+            tail = self._fallback_tail_route(
+                head,
+                goal,
+                partner_segments,
+                seg_clear,
+                prefer_planar_layer=layer_idx if prefer_planar else None,
+            )
             source = "astar" if tail is not None else source
         if tail is None and following is not None:
             # Nothing else reached the pad: a weakly-coupled following tail is
@@ -7092,6 +7279,18 @@ class DiffPairRouter:
             # legal first step), consume more of the body into the
             # tail and retry from a deeper anchor.
             partner_segs = list(guide.segments)
+            # Issue #4570: the shadow BODY mirrors the guide's vias one-for-one
+            # (the ``"via"`` branch below re-emits each kept guide via at the
+            # offset position), but the landing TAILS are synthesized
+            # independently -- so a tail that dives through the board has no
+            # counterpart on the guide leg and shows up as pure electrical
+            # skew.  When the guide carries no via at all, every via the tails
+            # invent is therefore unmatched by construction; ask for planar
+            # tails in that case.  (A guide WITH vias may legitimately want a
+            # tail via -- e.g. one the body trim dropped -- so the preference is
+            # not applied there; the post-assembly symmetry gate below is what
+            # actually decides either way.)
+            planar_tails = _SHADOW_VIA_SYMMETRY and not guide.vias
             start_tail = None
             a0_eff = a0
             for extra0 in (0.0, 0.7, 1.5, 3.0):
@@ -7111,6 +7310,7 @@ class DiffPairRouter:
                     "shadow-start",
                     pair.name,
                     partner_segments=partner_segs,
+                    prefer_planar=planar_tails,
                 )
                 if start_tail is not None:
                     a0_eff = a0 + extra0
@@ -7137,6 +7337,7 @@ class DiffPairRouter:
                     "shadow-end",
                     pair.name,
                     partner_segments=partner_segs,
+                    prefer_planar=planar_tails,
                 )
                 if end_tail is not None:
                     a1_eff = a1 - extra1
@@ -7240,6 +7441,44 @@ class DiffPairRouter:
             guide_route_obj = Route(net=guide_net_pad.net, net_name=guide_net_pad.net_name)
             guide_route_obj.segments.extend(guide.segments)
             guide_route_obj.vias.extend(guide.vias)
+
+            # Issue #4570: VIA-SYMMETRY gate.  ``diffpair_length_skew`` measures
+            # electrical length -- planar copper PLUS each via's drilled length
+            # -- while ``_length_match_constructed_pair`` below is planar-only.
+            # A pair whose legs carry different vias can therefore be driven to
+            # a ~0.01 mm planar delta and still ship a multi-millimetre skew
+            # violation (board-06 seed 42: 2 x 1.6 mm on PCIE_RX / USB3_TX1).
+            # Gate here -- after assembly and chain repair, before the
+            # clearance gates and before the planar length match -- so that
+            # (a) remediation stays transactional with the rest of the side and
+            # (b) the length match runs on the FINAL geometry.
+            #
+            # The remediation itself is upstream: the tails were asked for
+            # planar routing (``planar_tails``) precisely so this gate passes.
+            # When it did not work out, the side DECLINES rather than shipping
+            # an asymmetric pair -- a declined side fails over to the other
+            # offset side and then to the non-shadow path, which is a known
+            # outcome; invisible skew is not.
+            if _SHADOW_VIA_SYMMETRY:
+                n_layers = getattr(grid, "num_layers", 0) or 2
+                guide_sig = _route_via_signature(guide_route_obj, n_layers)
+                shadow_sig = _route_via_signature(shadow_route, n_layers)
+                if guide_sig != shadow_sig:
+                    print(
+                        f"    [coupled-shadow] side={side:+.0f} via-signature "
+                        f"mismatch for {pair.name} (guide={guide_sig} "
+                        f"shadow={shadow_sig}); trying other side"
+                    )
+                    self._last_shadow_decline_reason = "via-skew"  # #4570
+                    if _SHADOW_DEBUG:
+                        print(
+                            f"    [coupled-shadow-via] {pair.name} "
+                            f"tail0_vias={len(start_tail.vias)} "
+                            f"tail1_vias={len(end_tail.vias)} "
+                            f"body_vias={len([e for e in kept if e[0] == 'via'])} "
+                            f"planar_tails={planar_tails}"
+                        )
+                    continue
 
             # Issue #4553: make the pair length-symmetric BY CONSTRUCTION.
             # The parallel offset, the shadow's via jogs and its independently

--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -5692,6 +5692,19 @@ class DiffPairRouter:
                 for v in vias
             ):
                 continue
+            # The relocated stretch is copper on a layer this leg was not on.
+            # It must keep the manufacturer clearance from the PARTNER's copper
+            # THERE -- the partner's own crossing tail dives to exactly these
+            # inner/bottom layers, and skipping this screen was measured as 12
+            # extra ``diffpair_clearance_intra`` errors on board-06 seed 42.
+            if partner_segments:
+                partner_w = max((p.width for p in partner_segments), default=rules.trace_width)
+                jog_bound = (seg.width + partner_w) / 2.0 + rules.trace_clearance
+                if (
+                    self._min_distance_to_partner(ax, ay, bx, by, partner_segments, jog_seg.layer)
+                    < jog_bound
+                ):
+                    continue
 
             def _piece(x1: float, y1: float, x2: float, y2: float, layer) -> Segment:
                 return Segment(
@@ -7911,13 +7924,30 @@ class DiffPairRouter:
             if not via_symmetric:
                 # Issue #4570: this side is otherwise legal but its two legs
                 # carry different vias.  Hold it back so the OTHER offset side
-                # (and the uncompressed-guide retry) get their chance to
-                # produce a symmetric pair; ``asym_fallback`` keeps it as the
-                # explicit last resort described at the end of this method.
+                # gets its chance to produce a symmetric pair;
+                # ``asym_fallback`` keeps it as the explicit last resort
+                # described just below the loop.
                 if asym_fallback is None:
                     asym_fallback = (p_route, n_route)
                 continue
             return p_route, n_route
+
+        # Issue #4570: no side of THIS guide is via-symmetric.  Take the
+        # asymmetric candidate here rather than after the uncompressed-guide
+        # retry below: the retry re-derives the whole body from a different
+        # corridor, and on board-06 letting it displace an already-legal
+        # candidate moved PCIE_RX onto geometry with 7 extra
+        # ``clearance_segment_via`` violations and a hole-to-hole failure.
+        # Symmetry is worth preferring a SIDE for; it is not worth trading a
+        # different pair's clearance for.
+        if asym_fallback is not None and not _SHADOW_VIA_SYMMETRY_STRICT:
+            print(
+                f"    [coupled-shadow] {pair.name} WARNING: shipping a "
+                f"via-ASYMMETRIC pair (no symmetric side and no legal mirror); "
+                f"expect a diffpair_length_skew error of the vias' drilled "
+                f"length -- issue #4570"
+            )
+            return asym_fallback
 
         # Issue #4553: both offset sides declined on the COMPRESSED guide.
         # Retry once on the original per-cell polyline so the construction
@@ -7936,27 +7966,16 @@ class DiffPairRouter:
             if retry is not None:
                 return retry
 
-        # Issue #4570: no side produced a via-symmetric pair.  ``STRICT`` drops
-        # the pair here (the electrically pure answer); the default keeps the
-        # best legal-but-asymmetric candidate, LOUDLY, because on board-06 the
-        # strict policy costs a routed net -- and an unrouted net (a
-        # ``connectivity`` error and an LVS open) is a worse ship than a
-        # ``diffpair_length_skew`` error the checker names in full.  Either way
-        # the outcome is recorded, never silent.
-        if asym_fallback is not None:
-            if _SHADOW_VIA_SYMMETRY_STRICT:
-                print(
-                    f"    [coupled-shadow] {pair.name} declined: no offset side "
-                    f"is via-symmetric (KCT_SHADOW_VIA_SYMMETRY_STRICT=1)"
-                )
-                return None
+        # Issue #4570: ``STRICT`` reaches here with an asymmetric candidate in
+        # hand and DROPS it (the electrically pure answer: an unmatched via is
+        # a mode-conversion and impedance discontinuity, not merely a length
+        # error).  See ``_SHADOW_VIA_SYMMETRY_STRICT`` for why that is not the
+        # default.
+        if asym_fallback is not None and _SHADOW_VIA_SYMMETRY_STRICT:
             print(
-                f"    [coupled-shadow] {pair.name} WARNING: shipping a "
-                f"via-ASYMMETRIC pair (no symmetric side and no legal mirror); "
-                f"expect a diffpair_length_skew error of the vias' drilled "
-                f"length -- issue #4570"
+                f"    [coupled-shadow] {pair.name} declined: no offset side "
+                f"is via-symmetric (KCT_SHADOW_VIA_SYMMETRY_STRICT=1)"
             )
-            return asym_fallback
         return None
 
     def _rescue_near_miss_coupled(

--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -5518,6 +5518,13 @@ class DiffPairRouter:
         partner screen (#4460) -- so preferring it can never smuggle copper
         past a check the diving alternative would have failed.
 
+        The partner screen is the STRICT intra-pair bound, not the
+        physical-overlap floor the legacy fallback settles for: this probe runs
+        ahead of ``_synthesize_crossing_tail``, whose stubs already honour the
+        strict bound, so accepting a merely-non-overlapping planar tail here
+        would buy via symmetry with intra-pair clearance (measured on board-06
+        seed 42: ``diffpair_clearance_intra`` 7 -> 19).
+
         Returns ``None`` when the lock is unavailable (pure-Python backend),
         when no planar path exists, or when the candidate fails a gate.
         """
@@ -5536,11 +5543,8 @@ class DiffPairRouter:
             why = "lock-leaked-a-via"
         elif self._route_pad_violation(cand)[0] > _SHADOW_PAD_DEFICIT_EPS:
             why = "pad-deficit"
-        elif partner_segments and not (
-            self._tail_partner_clear(cand, partner_segments, seg_clear)
-            or self._tail_partner_clear(cand, partner_segments, 0.0)
-        ):
-            why = "partner-overlap"
+        elif partner_segments and not self._tail_partner_clear(cand, partner_segments, seg_clear):
+            why = "partner-clearance"
         if _SHADOW_DEBUG:
             print(f"    [coupled-planar-probe] layer={layer_idx} result={why or 'ok'}")
         return None if why else cand

--- a/tests/test_diffpair_shadow.py
+++ b/tests/test_diffpair_shadow.py
@@ -3650,6 +3650,31 @@ def test_mirrored_z_jog_is_refused_when_the_partner_occupies_the_jog_layer():
     assert deficient.vias == []
 
 
+def test_mirror_is_opt_in_and_the_gate_does_not_depend_on_it(monkeypatch):
+    """Remediation B ships OFF; the gate still detects and records without it.
+
+    ``_mirror_z_jog``'s own board-06 measurement (one legal site, and taking it
+    landed that pair on the 0.100-vs-0.1016 mm intra-pair rung) says it needs a
+    site-selection policy first, so the default path never calls it.
+    """
+    import kicad_tools.router.diffpair_routing as dpr_mod
+
+    assert dpr_mod._SHADOW_VIA_MIRROR is False
+
+    called: list[int] = []
+    monkeypatch.setattr(
+        dpr_mod.DiffPairRouter,
+        "_match_pair_via_signature",
+        lambda self, *a, **k: called.append(1) or True,
+        raising=True,
+    )
+    dpr, result = _run_shadow_with_tails(monkeypatch, _stub_tail_route_diving)
+
+    assert called == [], "the mirror must not run with KCT_SHADOW_VIA_MIRROR unset"
+    assert result is not None
+    assert dpr._last_shadow_decline_reason == "via-skew", "detection is independent of the mirror"
+
+
 def test_mirror_refuses_an_odd_via_excess():
     """A z-jog adds vias in PAIRS; an odd difference is refused, not papered over."""
     dpr = _diffpair_router()

--- a/tests/test_diffpair_shadow.py
+++ b/tests/test_diffpair_shadow.py
@@ -1931,6 +1931,9 @@ class _AllClearPathfinder:
     def _is_cell_blocked(self, gx: int, gy: int, layer_idx: int, net: int) -> bool:
         return False
 
+    def _is_via_blocked(self, gx: int, gy: int, net: int) -> bool:
+        return False
+
 
 def _tail_pads(head_xy, goal_xy):
     from kicad_tools.router.primitives import Pad
@@ -3433,17 +3436,71 @@ def test_shadow_pair_with_symmetric_planar_legs_is_accepted(monkeypatch):
 
 
 def test_shadow_pair_declines_when_only_one_leg_carries_a_via(monkeypatch):
-    """The #4570 defect: 0 vias on the guide, 2 through-vias on the shadow.
+    """The #4570 defect under STRICT: 0 vias on the guide, 2 on the shadow.
 
     Before the gate this pair SHIPPED -- the planar length matcher drove it to
     a sub-hundredth-mm planar delta and reported success while
-    ``diffpair_length_skew`` measured 3.19 mm.  It must now decline instead,
-    with a reason distinct from ``overlap`` / ``blockage``.
+    ``diffpair_length_skew`` measured 3.19 mm.  Under
+    ``KCT_SHADOW_VIA_SYMMETRY_STRICT`` the pair is dropped instead, with a
+    reason distinct from ``overlap`` / ``blockage``.
+    """
+    import kicad_tools.router.diffpair_routing as dpr_mod
+
+    monkeypatch.setattr(dpr_mod, "_SHADOW_VIA_SYMMETRY_STRICT", True, raising=True)
+    dpr, result = _run_shadow_with_tails(monkeypatch, _stub_tail_route_diving)
+
+    assert result is None, "strict mode must not ship an asymmetric pair"
+    assert dpr._last_shadow_decline_reason == "via-skew"
+
+
+def test_shadow_pair_records_the_asymmetry_it_ships_by_default(monkeypatch):
+    """Default policy: the pair still ships, but never SILENTLY.
+
+    Dropping the pair costs a routed net on board-06 (measured: reach 19 -> 18,
+    and the "improved" DRC count is partly vacuity because
+    ``diffpair_length_skew`` only fires on an ENGAGED pair).  So the default
+    keeps the pair -- and records ``via-skew`` so the outcome is visible to the
+    #4459 taxonomy and to ``KCT_SHADOW_DEBUG``.
     """
     dpr, result = _run_shadow_with_tails(monkeypatch, _stub_tail_route_diving)
 
-    assert result is None, "an asymmetric pair must never be silently accepted"
-    assert dpr._last_shadow_decline_reason == "via-skew"
+    assert result is not None
+    assert dpr._last_shadow_decline_reason == "via-skew", (
+        "an asymmetric ship must still be recorded, not silent"
+    )
+
+
+def test_symmetric_side_beats_an_asymmetric_one(monkeypatch):
+    """The gate's cheapest win: prefer the offset side whose legs match.
+
+    ``asym_fallback`` is only consulted after BOTH sides have been tried, so a
+    side-``+1`` pair that dives can never displace a symmetric side-``-1`` one.
+    """
+    from kicad_tools.router.diffpair_routing import DiffPairRouter
+
+    seen: list[float] = []
+
+    def _tail(self, _pf, head, goal, _layer, _label, _name, partner_segments=None, **kw):
+        # Dive on the first side attempted, stay planar on the second.
+        first = not seen
+        if _label == "shadow-start":
+            seen.append(1.0)
+        stub = _stub_tail_route_diving if first else _stub_tail_route_planar
+        return stub(self, _pf, head, goal, _layer, _label, _name, partner_segments)
+
+    monkeypatch.setattr(DiffPairRouter, "_tail_route", _tail, raising=True)
+    monkeypatch.setattr(
+        DiffPairRouter, "_pair_has_physical_overlap", lambda self, p, n: False, raising=True
+    )
+    spacing_cells = 4
+    dpr, pair, spec, pathfinder, _ = _shadow_setup(spacing_cells, bend_end=(11.0, 7.7))
+    guide = _planar_guide(spec.p_start)
+
+    result = dpr._shadow_route_pair(pair, spec, pathfinder, guide, spacing_cells)
+
+    assert result is not None
+    p_route, n_route = result
+    assert p_route.vias == [] and n_route.vias == [], "the symmetric side must win"
 
 
 def test_shadow_via_symmetry_gate_honours_its_kill_switch(monkeypatch):
@@ -3474,6 +3531,104 @@ def test_symmetric_two_via_legs_are_not_misdiagnosed(monkeypatch):
     shadow_leg.vias.append(_via((Layer.F_CU, Layer.B_CU), x=6.2, net=2))
 
     assert _route_via_signature(guide_leg, 4) == _route_via_signature(shadow_leg, 4)
+
+
+# ---------------------------------------------------------------------------
+# Remediation B: the mirrored, centreline-preserving z-jog.
+# ---------------------------------------------------------------------------
+
+
+def _mirror_legs(dpr, partner_x_offset: float = 20.0):
+    """A long straight leg plus a partner far enough away to allow a mirror."""
+    net = 1
+    deficient = Route(net=net, net_name="USB_D+")
+    deficient.segments.append(
+        Segment(
+            x1=2.0, y1=2.0, x2=16.0, y2=2.0, width=0.2, layer=Layer.F_CU, net=net, net_name="USB_D+"
+        )
+    )
+    partner = Route(net=2, net_name="USB_D-")
+    partner.segments.append(
+        Segment(
+            x1=2.0,
+            y1=2.0 + partner_x_offset,
+            x2=16.0,
+            y2=2.0 + partner_x_offset,
+            width=0.2,
+            layer=Layer.F_CU,
+            net=2,
+            net_name="USB_D-",
+        )
+    )
+    partner.vias.append(_via((Layer.F_CU, Layer.B_CU), x=6.0, y=2.0 + partner_x_offset, net=2))
+    partner.vias.append(_via((Layer.F_CU, Layer.B_CU), x=9.0, y=2.0 + partner_x_offset, net=2))
+    return deficient, partner
+
+
+def test_mirrored_z_jog_matches_the_signature_without_moving_copper():
+    """The mirror equalises the drilled length without changing plan view.
+
+    The window is re-emitted on the other layer, so the leg's PLANAR length --
+    what ``_length_match_constructed_pair`` works on -- is untouched, and no
+    new angle is introduced (so the 45-census cannot regress).
+    """
+    from kicad_tools.router.diffpair_routing import _route_copper_length, _route_via_signature
+
+    dpr = _diffpair_router()
+    deficient, partner = _mirror_legs(dpr)
+    before_len = _route_copper_length(deficient)
+
+    ok = dpr._match_pair_via_signature(deficient, partner, _AllClearPathfinder(), 2)
+
+    assert ok is True
+    assert _route_via_signature(deficient, 2) == _route_via_signature(partner, 2)
+    assert abs(_route_copper_length(deficient) - before_len) < 1e-9
+    # Exactly one stretch changed layer, bracketed by the two new vias.
+    assert [s.layer for s in deficient.segments] == [Layer.F_CU, Layer.B_CU, Layer.F_CU]
+    assert len(deficient.vias) == 2
+    for v in deficient.vias:
+        assert v.layers == (Layer.F_CU, Layer.B_CU)
+
+
+def test_mirrored_z_jog_is_refused_when_the_barrel_would_graze_the_partner():
+    """A coupled body has no legal mirror site -- the barrel bound is ~0.6 mm.
+
+    This is why board-06's crossing-tail pairs cannot be repaired by mirroring:
+    the intra-pair gap is a tenth of the via-barrel-to-partner-copper bound, so
+    a centreline-preserving jog has nowhere to sit.
+    """
+    dpr = _diffpair_router()
+    deficient, partner = _mirror_legs(dpr, partner_x_offset=0.3)
+
+    assert dpr._match_pair_via_signature(deficient, partner, _AllClearPathfinder(), 2) is False
+    assert deficient.vias == [], "a refused mirror must not leave copper behind"
+
+
+def test_mirrored_z_jog_is_refused_over_a_foreign_pad():
+    """The mirror passes the exact foreign-pad predicate, not just the raster."""
+    dpr = _pad_gate_router()
+    deficient, partner = _mirror_legs(dpr)
+    # Drop a foreign pad on the middle of the leg, where the jog window sits.
+    dpr.autorouter.grid.add_pad(_pad_at(9.0, 2.0, net=99, name="OTHER"))
+
+    ok = dpr._match_pair_via_signature(deficient, partner, _AllClearPathfinder(), 2)
+
+    if ok:
+        # A legal window elsewhere on the leg is fine; what must never happen
+        # is a via inside the foreign pad's halo.
+        for v in deficient.vias:
+            assert dpr._via_pad_deficit(v) <= 1e-4
+    else:
+        assert deficient.vias == []
+
+
+def test_mirror_refuses_an_odd_via_excess():
+    """A z-jog adds vias in PAIRS; an odd difference is refused, not papered over."""
+    dpr = _diffpair_router()
+    deficient, partner = _mirror_legs(dpr)
+    partner.vias.pop()  # leaves a single unmatched via
+
+    assert dpr._match_pair_via_signature(deficient, partner, _AllClearPathfinder(), 2) is False
 
 
 def _spy_shadow_entry(monkeypatch, shadow_enabled: bool) -> list[str]:

--- a/tests/test_diffpair_shadow.py
+++ b/tests/test_diffpair_shadow.py
@@ -3476,19 +3476,14 @@ def test_symmetric_two_via_legs_are_not_misdiagnosed(monkeypatch):
     assert _route_via_signature(guide_leg, 4) == _route_via_signature(shadow_leg, 4)
 
 
-def test_via_symmetry_path_is_unreachable_with_shadow_construction_off(monkeypatch):
-    """Shadow-OFF inertness, asserted structurally (#4536: no byte-identity).
-
-    Every #4570 behaviour hangs off ONE gated entry point -- the
-    ``enable_shadow_construction`` guard in front of ``_shadow_route_pair``.
-    With the flag off that method is never called, so neither the symmetry
-    gate nor the planar-tail preference can run.
-    """
+def _spy_shadow_entry(monkeypatch, shadow_enabled: bool) -> list[str]:
+    """Drive the coupled pre-phase once and record whether #4570 code ran."""
     from kicad_tools.router.diffpair_routing import DiffPairRouter
 
     router, pair = _two_pad_coupled_router_and_pair()
     dpr = router._diffpair
     assert dpr.enable_shadow_construction is False, "the default must stay OFF"
+    dpr.enable_shadow_construction = shadow_enabled
 
     calls: list[str] = []
     monkeypatch.setattr(
@@ -3503,7 +3498,27 @@ def test_via_symmetry_path_is_unreachable_with_shadow_construction_off(monkeypat
         lambda self, layer_idx: calls.append("lock"),
         raising=True,
     )
-
     dpr.route_differential_pair_coupled(pair, per_pair_timeout=2.0, coupled_only=True)
+    return calls
 
-    assert calls == [], "shadow-OFF must reach neither the gate nor the layer lock"
+
+def test_via_symmetry_path_is_unreachable_with_shadow_construction_off(monkeypatch):
+    """Shadow-OFF inertness, asserted structurally (#4536: no byte-identity).
+
+    Every #4570 behaviour hangs off ONE gated entry point -- the
+    ``enable_shadow_construction`` guard in front of ``_shadow_route_pair``.
+    With the flag off that method is never called, so neither the symmetry
+    gate nor the planar-tail preference can run.
+    """
+    assert _spy_shadow_entry(monkeypatch, shadow_enabled=False) == [], (
+        "shadow-OFF must reach neither the gate nor the layer lock"
+    )
+
+
+def test_shadow_entry_point_spy_is_not_vacuous(monkeypatch):
+    """Positive control for the inertness test above.
+
+    Without this, a fixture that never reached the shadow branch at all would
+    make the shadow-OFF assertion pass for the wrong reason.
+    """
+    assert _spy_shadow_entry(monkeypatch, shadow_enabled=True).count("shadow") >= 1

--- a/tests/test_diffpair_shadow.py
+++ b/tests/test_diffpair_shadow.py
@@ -3622,6 +3622,34 @@ def test_mirrored_z_jog_is_refused_over_a_foreign_pad():
         assert deficient.vias == []
 
 
+def test_mirrored_z_jog_is_refused_when_the_partner_occupies_the_jog_layer():
+    """The relocated stretch is screened on the layer it MOVES TO.
+
+    The partner's own crossing tail dives to exactly the layer the jog lands
+    on, so a mirror that only checks the barrels leaves same-layer P/N copper
+    at a fraction of the clearance (measured: 12 extra
+    ``diffpair_clearance_intra`` errors on board-06 seed 42).
+    """
+    dpr = _diffpair_router()
+    deficient, partner = _mirror_legs(dpr)
+    # Partner copper laid directly over the jog window, on the jog's layer.
+    partner.segments.append(
+        Segment(
+            x1=2.0,
+            y1=2.05,
+            x2=16.0,
+            y2=2.05,
+            width=0.2,
+            layer=Layer.B_CU,
+            net=2,
+            net_name="USB_D-",
+        )
+    )
+
+    assert dpr._match_pair_via_signature(deficient, partner, _AllClearPathfinder(), 2) is False
+    assert deficient.vias == []
+
+
 def test_mirror_refuses_an_odd_via_excess():
     """A z-jog adds vias in PAIRS; an odd difference is refused, not papered over."""
     dpr = _diffpair_router()

--- a/tests/test_diffpair_shadow.py
+++ b/tests/test_diffpair_shadow.py
@@ -1446,7 +1446,9 @@ def _shadow_setup(spacing_cells: int, bend_end: tuple[float, float]):
     return dpr, pair, spec, pathfinder, guide
 
 
-def _stub_tail_route(self, _pf, head, goal, _layer, _label, _name, partner_segments=None):
+def _stub_tail_route(
+    self, _pf, head, goal, _layer, _label, _name, partner_segments=None, prefer_planar=False
+):
     """Degenerate body-anchor tail (isolates the via geometry under test).
 
     Routing the real pad-reaching tail would have a straight fake tail
@@ -3080,3 +3082,428 @@ def test_route_is_chained_rejects_a_subcell_hole():
     # Closing the 5 um hole makes it a chain again.
     route.segments[1].x1 = 1.0
     assert dpr._route_is_chained(route, head, goal) is True
+
+
+# ---------------------------------------------------------------------------
+# Issue #4570: via-count symmetry between the two legs of a constructed pair.
+#
+# ``diffpair_length_skew`` measures ELECTRICAL length -- planar copper plus
+# each via's drilled length -- while the constructor's length matcher is planar
+# only.  A pair whose two legs carry different vias can therefore be driven to
+# a ~0.01 mm planar delta and still ship a multi-millimetre skew violation
+# (board-06 seed 42: 2 x 1.6 mm of unmatched through-via on PCIE_RX /
+# USB3_TX1).  The constructor now measures a thickness-free per-leg via
+# signature, asks the landing tails to stay planar when the partner leg has no
+# via to match, and DECLINES the side rather than shipping the asymmetry.
+# ---------------------------------------------------------------------------
+
+
+def _via(layers, x=1.0, y=1.0, net=1, is_micro=False) -> Via:
+    return Via(
+        x=x,
+        y=y,
+        drill=0.3,
+        diameter=0.6,
+        layers=layers,
+        net=net,
+        net_name="P",
+        is_micro=is_micro,
+    )
+
+
+def _planar_leg(length: float = 10.0, net: int = 1) -> Route:
+    r = Route(net=net, net_name="P")
+    r.segments.append(
+        Segment(
+            x1=0.0, y1=0.0, x2=length, y2=0.0, width=0.2, layer=Layer.F_CU, net=net, net_name="P"
+        )
+    )
+    return r
+
+
+def test_via_signature_is_zero_for_a_planar_route():
+    from kicad_tools.router.diffpair_routing import _route_via_signature
+
+    assert _route_via_signature(_planar_leg(), 4) == (0, 0)
+    assert _route_via_signature(None, 4) == (0, 0)
+
+
+def test_via_signature_counts_both_vias_and_their_stack_spans():
+    """The measured board-06 tail case: two full F.Cu->B.Cu through-vias."""
+    from kicad_tools.router.diffpair_routing import _route_via_signature
+
+    leg = _planar_leg()
+    leg.vias.append(_via((Layer.F_CU, Layer.B_CU)))
+    leg.vias.append(_via((Layer.F_CU, Layer.B_CU), x=5.0))
+
+    # 4-layer stack: F.Cu -> B.Cu spans 3 stack positions.
+    assert _route_via_signature(leg, 4) == (2, 6)
+    # ...and 1 on a 2-layer stack: the signature follows the STACK, not the
+    # KiCad layer enum (which would call F.Cu->B.Cu a 5-layer span either way).
+    assert _route_via_signature(leg, 2) == (2, 2)
+
+
+def test_via_signature_separates_a_blind_via_from_a_through_via():
+    """The span sum -- not just the count -- is what has to match (#4570 AC)."""
+    from kicad_tools.router.diffpair_routing import _route_via_signature
+
+    blind = _planar_leg()
+    blind.vias.append(_via((Layer.F_CU, Layer.IN1_CU), is_micro=True))
+    through = _planar_leg()
+    through.vias.append(_via((Layer.F_CU, Layer.B_CU)))
+
+    assert _route_via_signature(blind, 4) == (1, 1)
+    assert _route_via_signature(through, 4) == (1, 3)
+    assert _route_via_signature(blind, 4) != _route_via_signature(through, 4)
+
+
+@pytest.mark.parametrize("thickness", [0.6, 1.0, 1.6, 2.4])
+@pytest.mark.parametrize("blind_buried", [True, False])
+def test_equal_via_signatures_cancel_the_skew_rule_via_term(thickness, blind_buried):
+    """The thickness-free claim, asserted against the checker's own model.
+
+    Two legs whose ``(via count, sum |delta stack index|)`` signatures agree
+    contribute EQUAL via length under ``DiffPairLengthTracker._measure_route``
+    -- the exact measurement ``diffpair_length_skew`` performs -- for any
+    ``board_thickness_mm`` and with or without through-via promotion (#4007).
+    That is why the constructor can enforce z-length symmetry without a
+    thickness source (the router's ``DesignRules`` carries none).
+    """
+    from kicad_tools.router.diffpair_length import DiffPairLengthTracker
+    from kicad_tools.router.diffpair_routing import _route_via_signature
+
+    leg_a = _planar_leg()
+    leg_a.vias.append(_via((Layer.F_CU, Layer.B_CU)))
+    leg_a.vias.append(_via((Layer.IN1_CU, Layer.IN2_CU), x=4.0))
+    # Same signature, different placement/order.
+    leg_b = _planar_leg()
+    leg_b.vias.append(_via((Layer.IN2_CU, Layer.IN1_CU), x=7.0))
+    leg_b.vias.append(_via((Layer.B_CU, Layer.F_CU), x=2.0))
+
+    assert _route_via_signature(leg_a, 4) == _route_via_signature(leg_b, 4)
+
+    len_a = DiffPairLengthTracker._measure_route(
+        leg_a, thickness, 4, blind_buried_supported=blind_buried
+    )
+    len_b = DiffPairLengthTracker._measure_route(
+        leg_b, thickness, 4, blind_buried_supported=blind_buried
+    )
+    assert abs(len_a - len_b) < 1e-9
+
+
+def test_unequal_via_signatures_are_exactly_the_measured_board06_skew():
+    """0 vias vs 2 through-vias on a 1.6 mm 4-layer board = 3.2 mm of skew."""
+    from kicad_tools.router.diffpair_length import DiffPairLengthTracker
+    from kicad_tools.router.diffpair_routing import _route_via_signature
+
+    guide_leg = _planar_leg()
+    shadow_leg = _planar_leg()
+    shadow_leg.vias.append(_via((Layer.F_CU, Layer.B_CU)))
+    shadow_leg.vias.append(_via((Layer.F_CU, Layer.B_CU), x=5.0))
+
+    assert _route_via_signature(guide_leg, 4) != _route_via_signature(shadow_leg, 4)
+    skew = DiffPairLengthTracker._measure_route(
+        shadow_leg, 1.6, 4, blind_buried_supported=False
+    ) - DiffPairLengthTracker._measure_route(guide_leg, 1.6, 4, blind_buried_supported=False)
+    assert abs(skew - 3.2) < 1e-9
+
+
+def test_via_signature_tolerates_an_odd_via_count_without_crashing():
+    """A single-via leg is physically odd but must not break the gate."""
+    from kicad_tools.router.diffpair_routing import _route_via_signature
+
+    leg = _planar_leg()
+    leg.vias.append(_via((Layer.F_CU, Layer.B_CU)))
+    assert _route_via_signature(leg, 4) == (1, 3)
+
+
+# ---------------------------------------------------------------------------
+# Remediation A: the planar-preferred landing tail.
+# ---------------------------------------------------------------------------
+
+
+class _FakeRouterLayerLock:
+    """Records ``set_routable_layers`` calls so the lock can be asserted."""
+
+    def __init__(self, layers):
+        self._routable_layers = list(layers)
+        self.calls: list[list[int]] = []
+
+    def set_routable_layers(self, layers):
+        self.calls.append(list(layers))
+        self._routable_layers = list(layers)
+
+
+def _diving_route(net=2) -> Route:
+    r = Route(net=net, net_name="USB3_TX1-")
+    r.segments.append(
+        Segment(x1=0.0, y1=0.0, x2=2.0, y2=0.0, width=0.2, layer=Layer.F_CU, net=net, net_name="N")
+    )
+    r.segments.append(
+        Segment(x1=2.0, y1=0.0, x2=4.0, y2=0.0, width=0.2, layer=Layer.B_CU, net=net, net_name="N")
+    )
+    r.vias.append(_via((Layer.F_CU, Layer.B_CU), x=2.0, y=0.0, net=net))
+    return r
+
+
+def _planar_route(net=2) -> Route:
+    r = Route(net=net, net_name="USB3_TX1-")
+    r.segments.append(
+        Segment(x1=0.0, y1=0.0, x2=4.0, y2=0.5, width=0.2, layer=Layer.F_CU, net=net, net_name="N")
+    )
+    return r
+
+
+def _fallback_tail_probe_spy(dpr, monkeypatch, fake_router):
+    """Wire a scripted ``_single_ended_guide_route`` onto ``dpr``.
+
+    Returns the diving route while the router is unlocked and a planar one
+    while it is locked -- i.e. exactly the board-06 situation the planar
+    preference exists for.
+    """
+    monkeypatch.setattr(dpr.autorouter, "router", fake_router, raising=False)
+    monkeypatch.setattr(dpr, "_route_pad_violation", lambda route: (0.0, None), raising=False)
+
+    def _probe(head, goal, per_net_timeout=None, avoid_locations=None, avoid_radius_cells=1):
+        locked = fake_router._routable_layers == [0]
+        return _planar_route() if locked else _diving_route()
+
+    monkeypatch.setattr(dpr, "_single_ended_guide_route", _probe, raising=False)
+
+
+def test_planar_preference_displaces_a_diving_astar_tail(monkeypatch):
+    """The via-inventing A* tail is replaced by a layer-locked planar one."""
+    dpr = _diffpair_router()
+    fake_router = _FakeRouterLayerLock([0, 1])
+    _fallback_tail_probe_spy(dpr, monkeypatch, fake_router)
+    head, goal = _tail_pads((0.0, 0.0), (4.0, 0.5))
+
+    tail = dpr._fallback_tail_route(head, goal, None, 0.0, prefer_planar_layer=0)
+
+    assert tail is not None
+    assert tail.vias == [], "a planar tail was available; the dive must not ship"
+    # The lock was applied and then RESTORED (a leaked narrowing would forbid
+    # vias for every remaining net on the board).
+    assert fake_router.calls == [[0], [0, 1]]
+    assert fake_router._routable_layers == [0, 1]
+
+
+def test_planar_preference_is_not_attempted_without_the_flag(monkeypatch):
+    """Default (and the only shadow-OFF-reachable) path: no extra probe."""
+    dpr = _diffpair_router()
+    fake_router = _FakeRouterLayerLock([0, 1])
+    _fallback_tail_probe_spy(dpr, monkeypatch, fake_router)
+    head, goal = _tail_pads((0.0, 0.0), (4.0, 0.5))
+
+    tail = dpr._fallback_tail_route(head, goal, None, 0.0)
+
+    assert tail is not None
+    assert tail.vias, "the legacy chain returns the unbiased (diving) probe"
+    assert fake_router.calls == [], "the router must not be touched at all"
+
+
+def test_planar_preference_keeps_the_dive_when_no_planar_tail_is_legal(monkeypatch):
+    """A planar candidate that fails the exact pad predicate is REJECTED.
+
+    The remediation may never bypass the gates the rest of the constructed
+    copper passes (#4571's lesson).  When the planar probe's copper violates
+    them the diving tail is kept and the caller's symmetry gate -- not this
+    function -- decides the side's fate.
+    """
+    dpr = _diffpair_router()
+    fake_router = _FakeRouterLayerLock([0, 1])
+    _fallback_tail_probe_spy(dpr, monkeypatch, fake_router)
+    # Every PLANAR candidate violates the exact foreign-pad predicate.
+    monkeypatch.setattr(
+        dpr,
+        "_route_pad_violation",
+        lambda route: ((0.5, (1.0, 1.0)) if not route.vias else (0.0, None)),
+        raising=False,
+    )
+    head, goal = _tail_pads((0.0, 0.0), (4.0, 0.5))
+
+    tail = dpr._fallback_tail_route(head, goal, None, 0.0, prefer_planar_layer=0)
+
+    assert tail is not None
+    assert tail.vias, "the rejected planar candidate must not displace the dive"
+    assert fake_router.calls == [[0], [0, 1]], "lock applied then restored"
+
+
+def test_layer_lock_is_a_noop_without_a_set_routable_layers_backend():
+    """The pure-Python backend has no layer vector: report the lock unavailable."""
+    dpr = _diffpair_router()
+
+    class _NoLockRouter:
+        pass
+
+    dpr.autorouter.router = _NoLockRouter()
+    with dpr._layer_locked_router(0) as locked:
+        assert locked is False
+
+
+def test_layer_lock_declines_a_layer_that_is_not_routable():
+    dpr = _diffpair_router()
+    fake_router = _FakeRouterLayerLock([0, 1])
+    dpr.autorouter.router = fake_router
+    with dpr._layer_locked_router(5) as locked:
+        assert locked is False
+    assert fake_router.calls == []
+
+
+# ---------------------------------------------------------------------------
+# The gate itself, driven through ``_shadow_route_pair``.
+# ---------------------------------------------------------------------------
+
+
+def _planar_guide(p_start_pad) -> Route:
+    """A straight, VIA-FREE F.Cu guide -- board-06's PCIE_RX / USB3_TX1 case."""
+    net, name = p_start_pad.net, p_start_pad.net_name
+    guide = Route(net=net, net_name=name)
+    guide.segments.append(
+        Segment(
+            x1=5.0, y1=4.8, x2=25.0, y2=4.8, width=0.2, layer=Layer.F_CU, net=net, net_name=name
+        )
+    )
+    return guide
+
+
+def _stub_tail_route_planar(
+    self, _pf, head, goal, _layer, _label, _name, partner_segments=None, prefer_planar=False
+):
+    """Degenerate planar body-anchor tail (see ``_stub_tail_route``)."""
+    r = Route(net=goal.net, net_name=goal.net_name)
+    r.segments.append(
+        Segment(
+            x1=head.x,
+            y1=head.y,
+            x2=head.x + 0.001,
+            y2=head.y,
+            width=0.2,
+            layer=head.layer,
+            net=goal.net,
+            net_name=goal.net_name,
+        )
+    )
+    return r
+
+
+def _stub_tail_route_diving(
+    self, _pf, head, goal, _layer, _label, _name, partner_segments=None, prefer_planar=False
+):
+    """A stub tail that dives -- the unmatched via #4570 is about."""
+    r = _stub_tail_route_planar(
+        self, _pf, head, goal, _layer, _label, _name, partner_segments, prefer_planar
+    )
+    r.vias.append(
+        Via(
+            x=head.x,
+            y=head.y,
+            drill=0.3,
+            diameter=0.6,
+            layers=(Layer.F_CU, Layer.B_CU),
+            net=goal.net,
+            net_name=goal.net_name,
+        )
+    )
+    return r
+
+
+def _run_shadow_with_tails(monkeypatch, tail_stub):
+    from kicad_tools.router.diffpair_routing import DiffPairRouter
+
+    spacing_cells = 4
+    dpr, pair, spec, pathfinder, _ = _shadow_setup(spacing_cells, bend_end=(11.0, 7.7))
+    guide = _planar_guide(spec.p_start)
+    monkeypatch.setattr(DiffPairRouter, "_tail_route", tail_stub, raising=True)
+    monkeypatch.setattr(
+        DiffPairRouter, "_pair_has_physical_overlap", lambda self, p, n: False, raising=True
+    )
+    result = dpr._shadow_route_pair(pair, spec, pathfinder, guide, spacing_cells)
+    return dpr, result
+
+
+def test_shadow_pair_with_symmetric_planar_legs_is_accepted(monkeypatch):
+    """Control: a via-free guide plus via-free tails passes the gate."""
+    dpr, result = _run_shadow_with_tails(monkeypatch, _stub_tail_route_planar)
+
+    assert result is not None
+    p_route, n_route = result
+    assert p_route.vias == [] and n_route.vias == []
+    assert dpr._last_shadow_decline_reason != "via-skew"
+
+
+def test_shadow_pair_declines_when_only_one_leg_carries_a_via(monkeypatch):
+    """The #4570 defect: 0 vias on the guide, 2 through-vias on the shadow.
+
+    Before the gate this pair SHIPPED -- the planar length matcher drove it to
+    a sub-hundredth-mm planar delta and reported success while
+    ``diffpair_length_skew`` measured 3.19 mm.  It must now decline instead,
+    with a reason distinct from ``overlap`` / ``blockage``.
+    """
+    dpr, result = _run_shadow_with_tails(monkeypatch, _stub_tail_route_diving)
+
+    assert result is None, "an asymmetric pair must never be silently accepted"
+    assert dpr._last_shadow_decline_reason == "via-skew"
+
+
+def test_shadow_via_symmetry_gate_honours_its_kill_switch(monkeypatch):
+    """``KCT_SHADOW_VIA_SYMMETRY=0`` restores the pre-#4570 behaviour exactly."""
+    import kicad_tools.router.diffpair_routing as dpr_mod
+
+    monkeypatch.setattr(dpr_mod, "_SHADOW_VIA_SYMMETRY", False, raising=True)
+    dpr, result = _run_shadow_with_tails(monkeypatch, _stub_tail_route_diving)
+
+    assert result is not None, "with the gate off the asymmetric pair ships as before"
+    assert dpr._last_shadow_decline_reason != "via-skew"
+
+
+def test_symmetric_two_via_legs_are_not_misdiagnosed(monkeypatch):
+    """Both legs dive (the deliberate polarity-swap crossover): leave it alone.
+
+    A crossing tail is a two-via construction BY DESIGN.  It is only a defect
+    when the partner leg has no counterpart, so a guide that carries the same
+    via signature must still be accepted.
+    """
+    from kicad_tools.router.diffpair_routing import _route_via_signature
+
+    guide_leg = _planar_leg()
+    guide_leg.vias.append(_via((Layer.F_CU, Layer.B_CU)))
+    guide_leg.vias.append(_via((Layer.B_CU, Layer.F_CU), x=6.0))
+    shadow_leg = _planar_leg(net=2)
+    shadow_leg.vias.append(_via((Layer.F_CU, Layer.B_CU), x=1.2, net=2))
+    shadow_leg.vias.append(_via((Layer.F_CU, Layer.B_CU), x=6.2, net=2))
+
+    assert _route_via_signature(guide_leg, 4) == _route_via_signature(shadow_leg, 4)
+
+
+def test_via_symmetry_path_is_unreachable_with_shadow_construction_off(monkeypatch):
+    """Shadow-OFF inertness, asserted structurally (#4536: no byte-identity).
+
+    Every #4570 behaviour hangs off ONE gated entry point -- the
+    ``enable_shadow_construction`` guard in front of ``_shadow_route_pair``.
+    With the flag off that method is never called, so neither the symmetry
+    gate nor the planar-tail preference can run.
+    """
+    from kicad_tools.router.diffpair_routing import DiffPairRouter
+
+    router, pair = _two_pad_coupled_router_and_pair()
+    dpr = router._diffpair
+    assert dpr.enable_shadow_construction is False, "the default must stay OFF"
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        DiffPairRouter,
+        "_shadow_route_pair",
+        lambda self, *a, **k: calls.append("shadow") or None,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        DiffPairRouter,
+        "_layer_locked_router",
+        lambda self, layer_idx: calls.append("lock"),
+        raising=True,
+    )
+
+    dpr.route_differential_pair_coupled(pair, per_pair_timeout=2.0, coupled_only=True)
+
+    assert calls == [], "shadow-OFF must reach neither the gate nor the layer lock"


### PR DESCRIPTION
## Summary

`diffpair_length_skew` measures **electrical** length — planar copper **plus** every
via's drilled length — while the shadow constructor's length matcher
(`_length_match_constructed_pair` over `_route_copper_length`) sums **planar segment
copper only**. A constructed pair could therefore be driven to a 0.012 mm planar delta
and still ship a 3.19 mm skew violation, with the constructor reporting success.

This PR closes the *measurement* gap the constructor had: it gives the constructor a
**thickness-free per-leg via signature**, gates every constructed pair on leg symmetry
before the clearance gates and the planar length match, implements **both** remediations
the issue names, and — when neither is legal — records the outcome instead of letting it
pass unnoticed.

Per the issue, option (1) (compensating z-length inside the meander) is **not** taken;
`_route_copper_length`'s docstring now records why.

## Changes

`src/kicad_tools/router/diffpair_routing.py` (the only source file touched):

- **`_route_via_signature` / `_via_stack_span`** — `(via count, Σ|Δ stack index|)` per leg,
  with the layer → stack-position mapping delegated to
  `DiffPairLengthTracker._stack_position` so the constructor and the checker cannot drift.
  Equal signatures ⇒ equal via length under **both** the plain and the through-via-promoted
  (#4007) models, for **any** `board_thickness_mm` — which is why no thickness is plumbed
  into `router.rules.DesignRules`.
- **Symmetry gate in `_shadow_route_pair`** — runs after assembly/chain-repair and **before**
  the clearance gates and `_length_match_constructed_pair`, so remediation is transactional
  and the planar match runs on final geometry. An asymmetric side is held back so the other
  offset side gets its chance; the outcome is always recorded
  (`_last_shadow_decline_reason = "via-skew"`, printed, and visible under `KCT_SHADOW_DEBUG`).
- **Remediation A — planar-preferred tail.** `_layer_locked_router` narrows the shared
  pathfinder's routable-layer vector to one layer (always restored), and `_planar_tail_probe`
  runs a per-net A* that has no via expansion available. It is tried **before**
  `_synthesize_crossing_tail` (the measurement below shows the crossover — not the free-layer
  A* — is the dominant unmatched-via source) and is held to the **strict** intra-pair bound,
  plus the same exact foreign-pad predicate every other tail passes.
- **Remediation B — mirrored z-jog** (`_mirror_z_jog` / `_match_pair_via_signature`). Gives the
  leg that is *short* of vias the same vias, as a **centreline-preserving** jog: a window of one
  existing segment re-emitted on the other layer, bracketed by two vias. Plan-view copper — and
  therefore planar length — is unchanged, and no new angle is introduced. Every piece clears
  drill hole-to-hole, `_is_via_blocked`, the exact `worst_via_pad_deficit` foreign-pad
  predicate, the raster + pad predicate for the relocated stretch, via-barrel clearance to the
  partner on any layer, and the partner clearance **on the layer the jog moves to**.
  **Opt-in** (`KCT_SHADOW_VIA_MIRROR=1`) — see "Why B is opt-in" below.
- **Policy knobs.** `KCT_SHADOW_VIA_SYMMETRY=0` restores pre-#4570 behaviour exactly;
  `KCT_SHADOW_VIA_SYMMETRY_STRICT=1` drops a pair for which no side is symmetric (the
  electrically pure answer) instead of shipping it with the recorded reason.

## Board-06 measurement (seed 42, shadow-ON, same machine, same build)

```
uv run kct build-native --check                      # C++ backend: available (1.0.0)
KCT_BOARD06_SHADOW=1 PYTHONHASHSEED=42 \
  uv run python boards/06-diffpair-test/generate_design.py --step route --seed 42
uv run kct check boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb --mfr jlcpcb
```

`before` is this same build with `KCT_SHADOW_VIA_SYMMETRY=0` (the change is fully inert),
and it reproduces the post-#4578 baseline exactly.

| metric | before (gate off) | **after (shipped default)** | after, `STRICT=1` | after, `MIRROR=1` |
|---|---|---|---|---|
| signal nets routed | 19 / 21 | **19 / 21** | 18 / 21 | 19 / 21 |
| coupled-ok pairs | 5 | **5** | 3 | 5 |
| DRC errors (total) | 33 | **33** | 26 | 36 |
| `diffpair_length_skew` | 7 | **7** | 6 | 7 |
| `diffpair_routing_continuity` | 7 | **7** | 7 | 6 |
| `diffpair_clearance_intra` | 7 | **7** | 7 | 19 |
| `clearance_pad_segment` | 5 | **5** | 0 | 0 |
| `connectivity` | 3 | **3** | 3 | 2 |
| `impedance` | 2 | **2** | 1 | 1 |
| `via_in_pad` | 1 | **1** | 1 | 0 |
| `clearance_segment_via` | 1 | **1** | 1 | 1 |
| LVS copper opens | 3 | **3** | 3 | 2 |
| raw routes / segments / vias | 20 / 6678 / 27 | **20 / 6678 / 27** | — | 21 / 5377 / 26 |

The shipped default is **metric-for-metric identical to the baseline** (including the raw
route/segment/via counts), so this PR carries **no regression** — while the constructor now
*detects* 10 via-signature mismatches per run and records 4 asymmetric ships that were
previously invisible.

### The two named pairs

Neither `PCIE_RX` nor `USB3_TX1` ends with equal signatures under the shipped default; both
are **recorded** with the new `via-skew` reason (the issue's acceptance option (b)):

```
[coupled-shadow] side=+1 via-signature mismatch for PCIE_RX (guide=(0, 0) shadow=(2, 2)); unrepaired
[coupled-shadow-via] PCIE_RX tail0_vias=2 tail1_vias=0 body_vias=0 planar_tails=True
[coupled-shadow] PCIE_RX WARNING: shipping a via-ASYMMETRIC pair (no symmetric side and
                 no legal mirror); expect a diffpair_length_skew error of the vias'
                 drilled length -- issue #4570
```

Their per-pair skew is unchanged (`PCIE_RX` 3.676 mm, `USB3_TX1` 3.412 mm) — the numbers the
issue predicts, now attributed at construction time.

### Why the asymmetry survives on this board (the finding)

The issue's root-cause hypothesis was that `_fallback_tail_route`'s free-layer A* dives.
Measured, the dominant source is **`_synthesize_crossing_tail`** — a deliberate *two*-via
crossover, which is exactly the `2 × 1.6 = 3.200 mm` in the issue's evidence table.

- **Remediation A cannot fire here**: all 12 layer-locked planar probes in the seed-42 run are
  rejected — the shadow's landing tail must *cross* the guide, so a planar tail breaks the
  intra-pair clearance. The crossover is not a defect on this board, it is the only legal tail.
- **Remediation B is blocked along the coupled body**: the intra-pair gap is 0.075–0.15 mm and
  the via-barrel-to-partner-copper bound is ~0.6 mm, so a centreline-preserving jog has nowhere
  legal to sit.

### Why B is opt-in

With `KCT_SHADOW_VIA_MIRROR=1`, exactly **one** pair (`USB2_D`) had a legal mirror site, and
taking it moved that pair onto geometry sitting on the 0.100-vs-0.1016 mm intra-pair rung:
`diffpair_clearance_intra` 7 → 19 and its own skew 5.430 → 6.348 mm. The mirror needs a site
**selection** policy (prefer an uncoupled stretch; re-check the marginal rungs after splitting
a segment) before it can be trusted by default. The gate and remediation A do not depend on it.

### Why `STRICT` is not the default

Dropping the pair improves the headline DRC count (33 → 26) but costs a routed net (19 → 18),
and part of that −7 is **vacuity**: `diffpair_length_skew` only fires on an *engaged* pair, so
`USB3_TX1`'s 3.412 mm skew error is simply replaced by two `connectivity` errors and two LVS
opens. An unrouted net is a worse ship than a skew error the checker names in full. The knob is
there for whoever wants the pure policy.

### Remaining lever (follow-up)

A **laterally offset** mirrored jog — reusing the `lateral_jog_polyline` machinery the #4553
meander already has, pushed away from the partner so the barrel bound is satisfied — is the way
to make remediation B viable along a coupled body. Deliberately out of scope here.

## Acceptance Criteria Verification

- [x] **Thickness-free per-leg via signature helper** — `_route_via_signature` (count +
      Σ|Δ stack index|), stack indices from `DiffPairLengthTracker._stack_position`.
      Asserted equivalent to `_measure_route`'s via term for thickness ∈ {0.6, 1.0, 1.6, 2.4}
      × blind/buried ∈ {on, off}.
- [x] **`_shadow_route_pair` gates on leg symmetry** after assembly, before the clearance gates
      and `_length_match_constructed_pair`. An asymmetric pair triggers remediation and is never
      *silently* accepted — the shipped default records `via-skew` and prints a warning; `STRICT`
      declines.
- [x] **At least one remediation implemented, covering the TAIL** — both A (planar-preferred
      tail, on `_tail_route` / `_fallback_tail_route` / `_synthesize_following_tail`'s lander)
      and B (partner via mirror).
- [x] **Newly emitted via passes the same gates as all other constructed copper** —
      `_is_via_blocked`, `worst_via_pad_deficit`, drill hole-to-hole, intra-pair/partner
      clearance (barrels on any layer *and* the relocated stretch on its own layer). No jog is
      needed for the mirror (centreline-preserving), so the 45-census cannot regress.
      Unit tests cover the foreign-pad and partner rejections.
- [x] **Degrades with a recorded reason** distinct from `overlap` / `blockage` / `pad-clearance`
      (`via-skew`), visible under `_SHADOW_DEBUG`.
- [x] **PCIE_RX and USB3_TX1 reported** — both recorded as via-asymmetric with the new reason
      (option (b)); per-rule `kct check` counts published before → after above.
- [x] **No regression at seed 42** — reach 19/21 unchanged, total DRC 33 unchanged,
      `diffpair_length_skew` 7 unchanged (does not increase), every other rule count unchanged.
- [x] **Shadow-OFF inertness demonstrated structurally** — single gated entry point
      (`enable_shadow_construction` → `_shadow_route_pair`) plus
      `test_via_symmetry_path_is_unreachable_with_shadow_construction_off`, with a positive
      control (`test_shadow_entry_point_spy_is_not_vacuous`) so the assertion cannot pass for the
      wrong reason. **No** byte-identical-artifact scope guard (#4536).
- [x] **No committed artifact or baseline touched** — `.github/routed-drc-tolerance.yml`,
      `DIFFPAIR_VIOLATION_BASELINE`, `EXPECTED_STRICT_GATE_ERRORS` unchanged; `git status` clean
      under `boards/`. Diff is 2 files: the router module and its test file.
- [x] **`enable_shadow_construction` remains `False`** and board-06's recipe stays behind
      `KCT_BOARD06_SHADOW`.

## Test Plan

- [x] `uv run pytest` — **24037 passed**, 96 skipped, 3 failed. The 3 failures
      (`tests/test_kct_check_parity.py::TestBoard07KctCheckParity`) are **pre-existing on
      `main`** — verified by running that file on a clean `main` checkout, same 3 failures.
- [x] `uv run ruff check .` — clean. `uv run ruff format . --check` — clean.
- [x] `uv run python scripts/ci/check_mypy_baseline.py` — `OK: 1473 error(s), all within the
      baseline (1474 allowed)`, identical to `main`. Baseline file untouched.
- [x] 21 new unit tests in `tests/test_diffpair_shadow.py`: signature semantics (planar, two
      through-vias, blind-vs-through span, odd count), the thickness-free claim against
      `_measure_route`, the exact 3.2 mm board-06 arithmetic, planar-probe preference /
      non-preference / rejection, layer-lock save-restore and no-op paths, gate accept /
      record / strict-decline / kill-switch, symmetric-side preference, the deliberate
      two-via crossover not being misdiagnosed, mirror success (signature matched, planar
      length unchanged, exactly one relocated stretch), mirror refusals (partner barrel graze,
      foreign pad, partner on the jog layer, odd excess), mirror opt-in, shadow-OFF inertness
      + its positive control.
- [x] Manual board-06 measurement of record, run four ways on the same machine and build
      (table above), with `boards/` restored after each run.

Closes #4570
