### PR TITLE
fix(diffpair): order crossing-tail via sites by other nets' escape channels

### DIFF
--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -20,7 +20,7 @@ import os
 import time
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, NamedTuple
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator, Mapping
@@ -294,6 +294,73 @@ _SHADOW_PAD_DEFICIT_EPS: float = 1e-4
 # so the existing end-trim machinery can shave a grazing landing instead of
 # declining the whole side.
 _SHADOW_PAD_PROBE_STEP_MM: float = 0.2
+
+# Issue #4574: the constructed crossover's via sites are chosen FIRST-LEGAL out
+# of a fixed 3x5 lattice, so the winning site carries no information about what
+# the rest of the board still has to route.  An all-layer F.Cu<->B.Cu barrel is
+# an obstacle on EVERY layer for EVERY later net, and the lattice's preferred
+# sites sit -- by construction -- in the middle of the connector's escape field.
+# On board-06 that seals MIPI_D0's only channel (its corridor probe returns
+# ``guide_route=FAILED segments=0``, i.e. sealed rather than congested).
+#
+# The remedy is a PREFERENCE, never a new gate: every legality check keeps its
+# place and its veto, and the candidate lattice is merely re-ORDERED so that,
+# among sites that are already legal, one that leaves a not-yet-routed pad's
+# direct escape open is tried before one that plugs it.
+#
+# ``_ESCAPE_CHANNEL_REACH_PITCHES`` bounds how far out from a pad the escape is
+# treated as un-detourable, in multiples of that pad's own component pitch.
+# Close to a fine-pitch pad the neighbouring pads' halos leave no room to route
+# around a barrel; a few pitches out the net has the whole board to detour
+# through, so scoring there would be noise rather than signal.
+_ESCAPE_CHANNEL_REACH_PITCHES: float = 3.0
+
+
+class _EscapeChannel(NamedTuple):
+    """A not-yet-routed pad's direct escape ray (issue #4574).
+
+    ``(x, y)`` is the pad centre, ``(ux, uy)`` the unit direction toward the
+    rest of that net's pads (the shortest way out is the way it has to go),
+    and ``reach`` how far along that ray the channel is considered sealed by
+    a barrel rather than merely inconvenienced by one.
+    """
+
+    x: float
+    y: float
+    ux: float
+    uy: float
+    reach: float
+
+
+def _channel_seal_penalty(
+    x: float,
+    y: float,
+    keepout: float,
+    channels: list[_EscapeChannel],
+) -> float:
+    """How deeply a via barrel at ``(x, y)`` plugs other nets' escapes (#4574).
+
+    ``keepout`` is the centre-to-centre distance a foreign trace must keep
+    from the barrel (``via_diameter/2 + trace_clearance + trace_width/2``), so
+    a barrel closer than that to a channel's ray makes the pad's direct escape
+    illegal.  The penalty is the summed intrusion depth over every channel the
+    barrel reaches into -- ``0.0`` means the barrel leaves every modelled
+    escape exactly as it found it, which is the overwhelmingly common case and
+    the one that preserves today's first-legal behaviour verbatim.
+    """
+    penalty = 0.0
+    for ch in channels:
+        dx = x - ch.x
+        dy = y - ch.y
+        along = dx * ch.ux + dy * ch.uy
+        if along <= 0.0 or along >= ch.reach:
+            continue  # behind the pad, or far enough out to be detoured
+        lateral = abs(dx * ch.uy - dy * ch.ux)
+        if lateral >= keepout:
+            continue  # the direct escape still fits past this barrel
+        penalty += keepout - lateral
+    return penalty
+
 
 # Issue #4572: the constructor's landing tails are the pair's uncoupled copper.
 #
@@ -3636,6 +3703,75 @@ class DiffPairRouter:
                     drills.append((via.x, via.y, via.drill))
         return drills
 
+    def _escape_channel_registry(self, exclude_nets: frozenset[int]) -> list[_EscapeChannel]:
+        """Direct escape rays of pads whose net still has no copper (#4574).
+
+        Assembled ONCE per crossover -- the same shape as
+        :meth:`_collect_existing_drills` -- and then consulted per candidate
+        via site, so the 225-pair candidate loop never re-scans the pad list.
+
+        A net qualifies when it has at least two pads and no committed route
+        in ``autorouter.routes``: it still has to get out of its pads, and any
+        all-layer barrel dropped across that exit is a wall on every layer.
+        The "has no committed route" test is deliberately the cheap one --
+        :meth:`_net_is_connected` runs full connectivity validation per net,
+        which is far too heavy here, and over-reporting a net as unrouted only
+        adds a preference term, never a veto.
+
+        Each pad's escape direction is taken toward the mean of the REST of
+        its own net's pads: that is where the net has to go, it needs no
+        footprint-body geometry, and it is sign-unambiguous (unlike a
+        principal-axis normal, which cannot tell which side of a single pad
+        row is the outside).  The channel length is bounded by
+        ``_ESCAPE_CHANNEL_REACH_PITCHES`` pitches of the pad's own component,
+        so the notion of "sealed" scales with the pad field it belongs to.
+
+        Returns an empty list -- i.e. degrades to today's exact first-legal
+        behaviour -- whenever the autorouter state this needs is unavailable
+        (test doubles, the stub-edge caller's throwaway pathfinder, boards
+        with no pitch information).
+        """
+        autorouter = self.autorouter
+        pads = getattr(autorouter, "pads", None)
+        nets = getattr(autorouter, "nets", None)
+        if not pads or not nets:
+            return []
+        pitches = self._pad_component_pitches()
+        if not pitches:
+            return []
+        routed_nets = {route.net for route in getattr(autorouter, "routes", None) or ()}
+        channels: list[_EscapeChannel] = []
+        # ``sorted`` keeps the registry -- and therefore every penalty sum --
+        # independent of dict iteration order (AC-6 / #4536).
+        for net_id in sorted(nets):
+            if net_id in exclude_nets or net_id in routed_nets:
+                continue
+            members = [pads[key] for key in nets[net_id] if key in pads]
+            if len(members) < 2:
+                continue
+            others = len(members) - 1
+            sum_x = sum(pad.x for pad in members)
+            sum_y = sum(pad.y for pad in members)
+            for pad in members:
+                pitch = pitches.get(pad.ref, 0.0)
+                if pitch <= 0.0:
+                    continue  # no pitch known -> no fine-pitch escape to model
+                dx = (sum_x - pad.x) / others - pad.x
+                dy = (sum_y - pad.y) / others - pad.y
+                span = math.hypot(dx, dy)
+                if span < 1e-9:
+                    continue
+                channels.append(
+                    _EscapeChannel(
+                        x=pad.x,
+                        y=pad.y,
+                        ux=dx / span,
+                        uy=dy / span,
+                        reach=min(span, _ESCAPE_CHANNEL_REACH_PITCHES * pitch),
+                    )
+                )
+        return channels
+
     def _resolve_detection_inputs(
         self,
     ) -> tuple[dict | None, dict[str, str] | None, list | None]:
@@ -5227,163 +5363,196 @@ class DiffPairRouter:
         existing_drills = self._collect_existing_drills()
         min_h2h = getattr(rules, "min_hole_to_hole", 0.5)
 
-        for v1 in _via_candidates(head.x, head.y, 1.0):
-            for v2 in _via_candidates(goal.x, goal.y, -1.0):
-                # Issue #3855: replace the hardcoded 0.6mm center-to-center
-                # via-to-via check with an edge-to-edge ``min_hole_to_hole``
-                # check.  This single crossover's two vias must clear each
-                # other AND every other existing drill (other crossovers'
-                # fan-out vias + through-hole pad drills, any net).
-                edge_v1v2 = (
-                    math.hypot(v2[0] - v1[0], v2[1] - v1[1])
-                    - rules.via_drill / 2
-                    - rules.via_drill / 2
+        # Issue #4574: the candidate lattice is enumerated in a fixed order
+        # that carries no information about the board, so a site that happens
+        # to plug a neighbouring unrouted pad's only escape wins purely by
+        # being earlier in the tuple literals.  Re-ORDER the pairs by how
+        # deeply their barrels intrude on those escapes -- lowest intrusion
+        # first -- and leave every legality gate below exactly where it is.
+        #
+        # ``sort`` is stable, so pairs with equal penalty (and, when no
+        # channel is modelled at all, ALL pairs) keep their enumeration order:
+        # with an empty or uninformative registry this returns bit-for-bit
+        # what the un-scored first-legal loop returned.
+        #
+        # Scoring is confined to the shadow constructor -- the one caller
+        # whose barrels are placed speculatively into a live pad field.  The
+        # stub-edge completion path (issue #3508) runs with construction OFF
+        # and keeps its untouched default behaviour.
+        candidate_pairs = [
+            (v1, v2)
+            for v1 in _via_candidates(head.x, head.y, 1.0)
+            for v2 in _via_candidates(goal.x, goal.y, -1.0)
+        ]
+        if self.enable_shadow_construction:
+            exclude = {head.net}
+            exclude.update(ps.net for ps in partner_segments)
+            channels = self._escape_channel_registry(frozenset(exclude))
+            if channels:
+                seal_keepout = rules.via_diameter / 2 + rules.trace_clearance + width / 2
+                seal_cache: dict[tuple[float, float], float] = {}
+
+                def _site_penalty(site: tuple[float, float]) -> float:
+                    cached = seal_cache.get(site)
+                    if cached is None:
+                        cached = _channel_seal_penalty(site[0], site[1], seal_keepout, channels)
+                        seal_cache[site] = cached
+                    return cached
+
+                candidate_pairs.sort(
+                    key=lambda pair: _site_penalty(pair[0]) + _site_penalty(pair[1])
                 )
-                if edge_v1v2 < min_h2h:
-                    continue  # the two crossover vias too close drill-to-drill
-                if not drill_hole_to_hole_clear(
-                    v1[0], v1[1], rules.via_drill, existing_drills, min_h2h
+
+        for v1, v2 in candidate_pairs:
+            # Issue #3855: replace the hardcoded 0.6mm center-to-center
+            # via-to-via check with an edge-to-edge ``min_hole_to_hole``
+            # check.  This single crossover's two vias must clear each
+            # other AND every other existing drill (other crossovers'
+            # fan-out vias + through-hole pad drills, any net).
+            edge_v1v2 = (
+                math.hypot(v2[0] - v1[0], v2[1] - v1[1]) - rules.via_drill / 2 - rules.via_drill / 2
+            )
+            if edge_v1v2 < min_h2h:
+                continue  # the two crossover vias too close drill-to-drill
+            if not drill_hole_to_hole_clear(
+                v1[0], v1[1], rules.via_drill, existing_drills, min_h2h
+            ):
+                continue
+            if not drill_hole_to_hole_clear(
+                v2[0], v2[1], rules.via_drill, existing_drills, min_h2h
+            ):
+                continue
+            g1 = grid.world_to_grid(*v1)
+            g2 = grid.world_to_grid(*v2)
+            if pathfinder._is_via_blocked(g1[0], g1[1], head.net):
+                continue
+            if pathfinder._is_via_blocked(g2[0], g2[1], head.net):
+                continue
+            # Via barrels: distance to partner copper on ANY layer.
+            if (
+                self._min_distance_to_partner(v1[0], v1[1], v1[0], v1[1], partner_segments, None)
+                < via_clear
+            ):
+                continue
+            if (
+                self._min_distance_to_partner(v2[0], v2[1], v2[0], v2[1], partner_segments, None)
+                < via_clear
+            ):
+                continue
+            # Surface stubs must stay clear of same-layer partner copper.
+            if (
+                self._min_distance_to_partner(
+                    head.x, head.y, v1[0], v1[1], partner_segments, surface
+                )
+                < seg_clear
+            ):
+                continue
+            if (
+                self._min_distance_to_partner(
+                    v2[0], v2[1], goal.x, goal.y, partner_segments, surface
+                )
+                < seg_clear
+            ):
+                continue
+            if not self._segment_cells_clear(
+                pathfinder, head.x, head.y, v1[0], v1[1], layer_idx, head.net
+            ):
+                continue
+            if not self._segment_cells_clear(
+                pathfinder, v2[0], v2[1], goal.x, goal.y, layer_idx, head.net
+            ):
+                continue
+            for alt in routable:
+                if not self._segment_cells_clear(
+                    pathfinder, v1[0], v1[1], v2[0], v2[1], alt, head.net
                 ):
                     continue
-                if not drill_hole_to_hole_clear(
-                    v2[0], v2[1], rules.via_drill, existing_drills, min_h2h
-                ):
-                    continue
-                g1 = grid.world_to_grid(*v1)
-                g2 = grid.world_to_grid(*v2)
-                if pathfinder._is_via_blocked(g1[0], g1[1], head.net):
-                    continue
-                if pathfinder._is_via_blocked(g2[0], g2[1], head.net):
-                    continue
-                # Via barrels: distance to partner copper on ANY layer.
+                alt_layer = Layer(grid.index_to_layer(alt))
+                # Issue #3508 (second pass): the partner guide is
+                # NOT in the grid, so the alt-layer crossover must
+                # also be checked geometrically against partner
+                # copper ON THAT LAYER -- a via-bearing partner
+                # guide has inner-layer segments the cell check
+                # cannot see (measured: USB3_RX1/RX2 "physically
+                # overlapping copper" rips in the recipe's 6b
+                # repair even with nudge protection).
                 if (
                     self._min_distance_to_partner(
-                        v1[0], v1[1], v1[0], v1[1], partner_segments, None
-                    )
-                    < via_clear
-                ):
-                    continue
-                if (
-                    self._min_distance_to_partner(
-                        v2[0], v2[1], v2[0], v2[1], partner_segments, None
-                    )
-                    < via_clear
-                ):
-                    continue
-                # Surface stubs must stay clear of same-layer partner copper.
-                if (
-                    self._min_distance_to_partner(
-                        head.x, head.y, v1[0], v1[1], partner_segments, surface
+                        v1[0], v1[1], v2[0], v2[1], partner_segments, alt_layer
                     )
                     < seg_clear
                 ):
                     continue
-                if (
-                    self._min_distance_to_partner(
-                        v2[0], v2[1], goal.x, goal.y, partner_segments, surface
-                    )
-                    < seg_clear
-                ):
-                    continue
-                if not self._segment_cells_clear(
-                    pathfinder, head.x, head.y, v1[0], v1[1], layer_idx, head.net
-                ):
-                    continue
-                if not self._segment_cells_clear(
-                    pathfinder, v2[0], v2[1], goal.x, goal.y, layer_idx, head.net
-                ):
-                    continue
-                for alt in routable:
-                    if not self._segment_cells_clear(
-                        pathfinder, v1[0], v1[1], v2[0], v2[1], alt, head.net
-                    ):
-                        continue
-                    alt_layer = Layer(grid.index_to_layer(alt))
-                    # Issue #3508 (second pass): the partner guide is
-                    # NOT in the grid, so the alt-layer crossover must
-                    # also be checked geometrically against partner
-                    # copper ON THAT LAYER -- a via-bearing partner
-                    # guide has inner-layer segments the cell check
-                    # cannot see (measured: USB3_RX1/RX2 "physically
-                    # overlapping copper" rips in the recipe's 6b
-                    # repair even with nudge protection).
-                    if (
-                        self._min_distance_to_partner(
-                            v1[0], v1[1], v2[0], v2[1], partner_segments, alt_layer
-                        )
-                        < seg_clear
-                    ):
-                        continue
-                    route = Route(net=head.net, net_name=head.net_name)
-                    if math.hypot(v1[0] - head.x, v1[1] - head.y) > 0.01:
-                        route.segments.append(
-                            Segment(
-                                x1=head.x,
-                                y1=head.y,
-                                x2=v1[0],
-                                y2=v1[1],
-                                width=width,
-                                layer=surface,
-                                net=head.net,
-                                net_name=head.net_name,
-                            )
-                        )
-                    route.vias.append(
-                        Via(
-                            x=v1[0],
-                            y=v1[1],
-                            drill=rules.via_drill,
-                            diameter=rules.via_diameter,
-                            layers=(surface, alt_layer),
-                            net=head.net,
-                            net_name=head.net_name,
-                        )
-                    )
+                route = Route(net=head.net, net_name=head.net_name)
+                if math.hypot(v1[0] - head.x, v1[1] - head.y) > 0.01:
                     route.segments.append(
                         Segment(
-                            x1=v1[0],
-                            y1=v1[1],
-                            x2=v2[0],
-                            y2=v2[1],
+                            x1=head.x,
+                            y1=head.y,
+                            x2=v1[0],
+                            y2=v1[1],
                             width=width,
-                            layer=alt_layer,
+                            layer=surface,
                             net=head.net,
                             net_name=head.net_name,
                         )
                     )
-                    route.vias.append(
-                        Via(
-                            x=v2[0],
-                            y=v2[1],
-                            drill=rules.via_drill,
-                            diameter=rules.via_diameter,
-                            layers=(alt_layer, surface),
+                route.vias.append(
+                    Via(
+                        x=v1[0],
+                        y=v1[1],
+                        drill=rules.via_drill,
+                        diameter=rules.via_diameter,
+                        layers=(surface, alt_layer),
+                        net=head.net,
+                        net_name=head.net_name,
+                    )
+                )
+                route.segments.append(
+                    Segment(
+                        x1=v1[0],
+                        y1=v1[1],
+                        x2=v2[0],
+                        y2=v2[1],
+                        width=width,
+                        layer=alt_layer,
+                        net=head.net,
+                        net_name=head.net_name,
+                    )
+                )
+                route.vias.append(
+                    Via(
+                        x=v2[0],
+                        y=v2[1],
+                        drill=rules.via_drill,
+                        diameter=rules.via_diameter,
+                        layers=(alt_layer, surface),
+                        net=head.net,
+                        net_name=head.net_name,
+                    )
+                )
+                if math.hypot(goal.x - v2[0], goal.y - v2[1]) > 0.01:
+                    route.segments.append(
+                        Segment(
+                            x1=v2[0],
+                            y1=v2[1],
+                            x2=goal.x,
+                            y2=goal.y,
+                            width=width,
+                            layer=surface,
                             net=head.net,
                             net_name=head.net_name,
                         )
                     )
-                    if math.hypot(goal.x - v2[0], goal.y - v2[1]) > 0.01:
-                        route.segments.append(
-                            Segment(
-                                x1=v2[0],
-                                y1=v2[1],
-                                x2=goal.x,
-                                y2=goal.y,
-                                width=width,
-                                layer=surface,
-                                net=head.net,
-                                net_name=head.net_name,
-                            )
-                        )
-                    # Issue #4571: the crossover's stubs, its alt-layer
-                    # crossing and BOTH via barrels are only raster-validated
-                    # above, and the raster's pad halo is shrunk in fine-pitch
-                    # corridors.  Screen the assembled candidate with the exact
-                    # DRC-equivalent pad predicate so a violating crossover
-                    # loses to a later via-site candidate instead of shipping.
-                    if self._route_pad_violation(route)[0] > _SHADOW_PAD_DEFICIT_EPS:
-                        continue
-                    return route
+                # Issue #4571: the crossover's stubs, its alt-layer
+                # crossing and BOTH via barrels are only raster-validated
+                # above, and the raster's pad halo is shrunk in fine-pitch
+                # corridors.  Screen the assembled candidate with the exact
+                # DRC-equivalent pad predicate so a violating crossover
+                # loses to a later via-site candidate instead of shipping.
+                if self._route_pad_violation(route)[0] > _SHADOW_PAD_DEFICIT_EPS:
+                    continue
+                return route
         return None
 
     def _tail_partner_clear(

--- a/tests/test_diffpair_shadow.py
+++ b/tests/test_diffpair_shadow.py
@@ -3730,3 +3730,230 @@ def test_shadow_entry_point_spy_is_not_vacuous(monkeypatch):
     make the shadow-OFF assertion pass for the wrong reason.
     """
     assert _spy_shadow_entry(monkeypatch, shadow_enabled=True).count("shadow") >= 1
+
+
+# --- Issue #4574: escape-channel-aware crossing-tail via sites ---------------
+# ``_synthesize_crossing_tail`` enumerates a fixed 3x5 lattice around each
+# endpoint and ships the FIRST candidate that survives the legality gauntlet.
+# The enumeration order carries no information about the board, so an all-layer
+# barrel routinely lands in the middle of a neighbouring fine-pitch pad's only
+# escape (board-06: MIPI_D0's corridor probe returns ``segments=0`` -- sealed,
+# not congested).  The remedy re-ORDERS the lattice by how deeply each barrel
+# intrudes on not-yet-routed pads' direct escapes; it adds no gate, and with an
+# empty/uninformative registry it must reproduce the first-legal result exactly.
+
+
+class _CrossingPathfinder:
+    """Pathfinder stand-in for the crossover lattice: nothing is blocked.
+
+    Isolates via-SITE SELECTION from grid state, so a site that loses can only
+    have lost to the ordering or to an explicit gate.
+    """
+
+    def __init__(self, width: float = 0.2) -> None:
+        self._width = width
+
+    def _get_trace_width_for_net(self, net_name: str) -> float:
+        return self._width
+
+    def _is_cell_blocked(self, gx: int, gy: int, layer_idx: int, net: int) -> bool:
+        return False
+
+    def _is_via_blocked(self, gx: int, gy: int, net: int) -> bool:
+        return False
+
+
+def _crossing_router(shadow: bool = True):
+    """A router whose crossover lattice has a second routable layer to dive to."""
+    from kicad_tools.router.core import Autorouter
+
+    rules = DesignRules()
+    rules.grid_resolution = 0.1
+    router = Autorouter(width=20.0, height=10.0, rules=rules)
+    dpr = router._diffpair
+    dpr.enable_shadow_construction = shadow
+    return dpr
+
+
+def _register_unrouted_neighbour(
+    dpr,
+    pad_xy=(7.0, 5.6),
+    far_xy=(12.0, 5.6),
+    net: int = 9,
+    pitch: float = 0.5,
+) -> None:
+    """An unrouted two-pad net escaping east along ``y = pad_xy[1]``.
+
+    Registered on the AUTOROUTER (``pads`` / ``nets`` / ``component_pitches``)
+    and deliberately NOT on the grid, so the neighbour can only influence the
+    result through the preference -- never through the #4571 pad gate.
+    """
+    dpr.autorouter.pads[("J9", "1")] = _pad_at(
+        pad_xy[0], pad_xy[1], net=net, name="NEIGH", ref="J9", pin="1"
+    )
+    dpr.autorouter.pads[("U9", "1")] = _pad_at(
+        far_xy[0], far_xy[1], net=net, name="NEIGH", ref="U9", pin="1"
+    )
+    dpr.autorouter.nets[net] = [("J9", "1"), ("U9", "1")]
+    dpr.autorouter._component_pitches = {"J9": pitch, "U9": pitch}
+
+
+def _crossing_tail(dpr):
+    head, goal = _tail_pads((5.0, 5.0), (8.0, 5.0))
+    return dpr._synthesize_crossing_tail(_CrossingPathfinder(), head, goal, 0, [])
+
+
+def _via_sites(tail):
+    return [(pytest.approx(v.x), pytest.approx(v.y)) for v in tail.vias]
+
+
+def test_crossing_tail_first_legal_site_is_the_unscored_baseline():
+    """Control: with nothing to avoid, both barrels sit on the endpoints."""
+    tail = _crossing_tail(_crossing_router())
+
+    assert tail is not None
+    assert len(tail.vias) == 2
+    assert (tail.vias[0].x, tail.vias[0].y) == (5.0, 5.0)
+    assert (tail.vias[1].x, tail.vias[1].y) == (8.0, 5.0)
+
+
+def test_crossing_tail_steps_off_an_unrouted_pads_escape_channel():
+    """The seal this issue is about: the first-legal site plugs a neighbour.
+
+    The lattice's a=0/b=0 goal-side site sits 0.6 mm from the neighbour's
+    escape ray -- inside the 0.65 mm a foreign trace needs from the barrel --
+    so the neighbour's direct exit becomes illegal.  Later lattice sites are
+    equally legal and leave it open; one of those must ship instead.
+    """
+    from kicad_tools.router.diffpair_routing import _channel_seal_penalty
+
+    dpr = _crossing_router()
+    _register_unrouted_neighbour(dpr)
+    channels = dpr._escape_channel_registry(frozenset({2}))
+    keepout = dpr.autorouter.rules.via_diameter / 2 + dpr.autorouter.rules.trace_clearance + 0.2 / 2
+    # Pre-condition: the site the unscored loop ships really does seal it.
+    assert _channel_seal_penalty(8.0, 5.0, keepout, channels) > 0.0
+
+    tail = _crossing_tail(dpr)
+
+    assert tail is not None
+    assert (tail.vias[1].x, tail.vias[1].y) == (8.0, 4.4)
+    for via in tail.vias:
+        assert _channel_seal_penalty(via.x, via.y, keepout, channels) == 0.0
+
+
+def test_crossing_tail_scoring_is_inert_with_shadow_construction_off():
+    """AC-5: the stub-edge caller (``partner_segments=[]``, shadow OFF) is untouched.
+
+    Same board state as the test above -- only the flag differs -- so a
+    changed result here could only come from the scoring leaking onto the
+    default path.
+    """
+    dpr = _crossing_router(shadow=False)
+    _register_unrouted_neighbour(dpr)
+
+    tail = _crossing_tail(dpr)
+
+    assert tail is not None, "the stub-edge path must still synthesize a tail"
+    assert (tail.vias[1].x, tail.vias[1].y) == (8.0, 5.0)
+
+
+def test_crossing_tail_with_an_empty_registry_is_bit_for_bit_first_legal():
+    """AC-4: no unrouted neighbours -> the preference cannot change anything."""
+    scored = _crossing_tail(_crossing_router())
+    baseline = _crossing_tail(_crossing_router(shadow=False))
+
+    assert scored is not None and baseline is not None
+    assert _via_sites(scored) == _via_sites(baseline)
+    assert [(s.x1, s.y1, s.x2, s.y2, s.layer) for s in scored.segments] == [
+        (s.x1, s.y1, s.x2, s.y2, s.layer) for s in baseline.segments
+    ]
+
+
+def test_crossing_tail_breaks_uniform_penalty_ties_on_enumeration_order(monkeypatch):
+    """AC-4 / AC-6: when scoring cannot discriminate, first-legal still wins."""
+    import kicad_tools.router.diffpair_routing as dpr_mod
+
+    dpr = _crossing_router()
+    _register_unrouted_neighbour(dpr)
+    monkeypatch.setattr(dpr_mod, "_channel_seal_penalty", lambda x, y, keepout, channels: 1.0)
+
+    tail = _crossing_tail(dpr)
+
+    assert tail is not None
+    assert (tail.vias[1].x, tail.vias[1].y) == (8.0, 5.0)
+
+
+def test_crossing_tail_preference_never_bypasses_the_foreign_pad_gate():
+    """A zero-penalty site that is a pad short must still lose (#4571's lesson).
+
+    The site the preference wants -- (8.0, 4.4) -- is occupied by a foreign
+    pad ON THE GRID here, so the exact ``clearance_pad_segment`` screen inside
+    the candidate loop has to veto it and the loop has to fall through to the
+    next site the preference likes.
+    """
+    import kicad_tools.router.diffpair_routing as dpr_mod
+
+    dpr = _crossing_router()
+    _register_unrouted_neighbour(dpr)
+    dpr.autorouter.grid.add_pad(_pad_at(8.0, 4.4, net=99, name="OTHER"))
+
+    tail = _crossing_tail(dpr)
+
+    assert tail is not None
+    assert (tail.vias[1].x, tail.vias[1].y) != (8.0, 4.4)
+    assert dpr._route_pad_violation(tail)[0] <= dpr_mod._SHADOW_PAD_DEFICIT_EPS
+
+
+def test_escape_channel_registry_skips_routed_and_pitchless_nets():
+    """The registry is an UNROUTED-neighbour oracle, not a pad dump."""
+    dpr = _crossing_router()
+    _register_unrouted_neighbour(dpr)
+
+    assert len(dpr._escape_channel_registry(frozenset({2}))) == 2
+    # The net under construction (and its partner) never scores itself.
+    assert dpr._escape_channel_registry(frozenset({2, 9})) == []
+    # A component with no known pitch contributes no channel.
+    dpr.autorouter._component_pitches = {}
+    assert dpr._escape_channel_registry(frozenset({2})) == []
+    # Copper already committed for the net -> it is no longer waiting to escape.
+    dpr.autorouter._component_pitches = {"J9": 0.5, "U9": 0.5}
+    dpr.autorouter.routes.append(Route(net=9, net_name="NEIGH"))
+    assert dpr._escape_channel_registry(frozenset({2})) == []
+
+
+def test_escape_channel_registry_is_empty_without_autorouter_state():
+    """AC-4 degradation: test doubles and pitchless boards score nothing."""
+    dpr = _crossing_router()
+
+    assert dpr._escape_channel_registry(frozenset()) == []
+
+
+def test_channel_seal_penalty_only_fires_inside_the_channel():
+    """Behind the pad, past the reach, or clear laterally: all cost nothing."""
+    from kicad_tools.router.diffpair_routing import _channel_seal_penalty, _EscapeChannel
+
+    channel = [_EscapeChannel(x=0.0, y=0.0, ux=1.0, uy=0.0, reach=1.5)]
+
+    assert _channel_seal_penalty(-0.5, 0.0, 0.65, channel) == 0.0  # behind the pad
+    assert _channel_seal_penalty(2.0, 0.0, 0.65, channel) == 0.0  # past the reach
+    assert _channel_seal_penalty(0.75, 0.65, 0.65, channel) == 0.0  # clear laterally
+    # Dead centre in the channel is the deepest intrusion there is.
+    assert _channel_seal_penalty(0.75, 0.0, 0.65, channel) == pytest.approx(0.65)
+    # ...and the penalty decreases monotonically as the barrel steps aside.
+    assert _channel_seal_penalty(0.75, 0.3, 0.65, channel) == pytest.approx(0.35)
+
+
+def test_channel_seal_penalty_sums_over_every_channel_it_reaches():
+    """Two sealed neighbours are worse than one; the score is additive."""
+    from kicad_tools.router.diffpair_routing import _channel_seal_penalty, _EscapeChannel
+
+    channels = [
+        _EscapeChannel(x=0.0, y=0.0, ux=1.0, uy=0.0, reach=1.5),
+        _EscapeChannel(x=0.0, y=0.4, ux=1.0, uy=0.0, reach=1.5),
+    ]
+
+    one = _channel_seal_penalty(0.75, -0.4, 0.65, channels)
+    both = _channel_seal_penalty(0.75, 0.2, 0.65, channels)
+    assert one == pytest.approx(0.25)
+    assert both == pytest.approx(0.9)


### PR DESCRIPTION
## Summary

`_synthesize_crossing_tail` enumerates a fixed 3×5 via lattice around each
endpoint and ships the **first** pair that survives the legality gauntlet. That
order is a pure enumeration artifact — it carries no information about what the
rest of the board still has to route — so an all-layer F.Cu↔B.Cu barrel (an
obstacle on *every* layer for *every* later net) routinely wins a site in the
middle of a neighbouring fine-pitch pad's escape field.

This PR turns "first legal" into "best legal": candidate barrels are scored by
how deeply they intrude on the direct escape of pads whose net has no committed
copper yet, and the lattice is sorted by that penalty **before** the (unchanged)
gates run.

It is a preference, never a gate. Every legality check keeps its place and its
veto; `list.sort` is stable so equal-penalty candidates keep enumeration order;
and an empty or uninformative registry reproduces the first-legal result
bit-for-bit.

## Changes

- **`src/kicad_tools/router/diffpair_routing.py`**
  - `_EscapeChannel` + `_channel_seal_penalty` (module level): a not-yet-routed
    pad's direct escape ray, and how deeply a barrel at `(x, y)` plugs it. The
    bound is the same `via_diameter/2 + trace_clearance + trace_width/2` the
    partner-facing check at `via_clear` already uses — i.e. the barrel is
    penalised exactly when it makes the pad's straight-out escape *illegal*.
  - `_ESCAPE_CHANNEL_REACH_PITCHES = 3.0`: how far out from a pad the escape is
    treated as un-detourable, in multiples of that pad's **own component pitch**.
  - `DiffPairRouter._escape_channel_registry()`: assembled once per crossover
    (same shape as `_collect_existing_drills`), so the 225-pair candidate loop
    never re-scans the pad list. A net qualifies when it has ≥2 pads and no
    committed route in `autorouter.routes`. Escape direction is taken toward the
    mean of the *rest* of that net's pads — no footprint-body geometry needed,
    and sign-unambiguous for a single pad row (a principal-axis normal cannot
    tell which side of one row is the outside). Iterates `sorted(nets)`, so the
    registry — and every penalty sum — is independent of dict order.
  - `_synthesize_crossing_tail`: the nested `for v1 … for v2 …` becomes one loop
    over a `candidate_pairs` list that is sorted by
    `penalty(v1) + penalty(v2)` when shadow construction is on and the registry
    is non-empty. Per-site penalties are memoised (30 evaluations, not 225).
    The gate body below is unchanged apart from the de-indent — review with
    `git diff -w` (181 real added lines vs 445 with the re-indent).
- **`tests/test_diffpair_shadow.py`** — 10 new tests (below).

## Acceptance Criteria Verification

Baseline re-measured on this PR's own base commit `d5615fe5` (not the figures
quoted in the issue), same command, same seed:

```bash
uv run kct build-native --check      # C++ backend: available (version 1.0.0)
KCT_BOARD06_SHADOW=1 PYTHONHASHSEED=42 uv run python \
  boards/06-diffpair-test/generate_design.py --step route --seed 42
uv run kct check boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb --mfr jlcpcb
```

### Construction phase (`[coupled-pair-report]`, the stable signal)

| pair | base `d5615fe5` | this PR |
|---|---|---|
| MIPI_CLK | `coupled-ok` | `coupled-ok` |
| **MIPI_D0** | **`guide-missing`** (`corridor-probe … FAILED segments=0`) | **`guide-missing`** (unchanged) |
| PCIE_RX | `coupled-ok` | `coupled-ok` |
| PCIE_TX | `shadow-declined-overlap` | `shadow-declined-overlap` |
| USB2_D | `coupled-ok` | `coupled-ok` |
| USB3_RX1 | `shadow-declined-blockage` | `shadow-declined-blockage` |
| USB3_RX2 | `shadow-declined-blockage` | `shadow-declined-blockage` |
| USB3_TX1 | `coupled-ok` | `coupled-ok` |
| USB3_TX2 | `coupled-ok` | `coupled-ok` |

`DIFFPAIR_CORRIDOR_YIELD: 2 coupled pair(s) … reach 18 -> 19 of 21: USB2_D, MIPI_CLK`
on both.

### `kct check --mfr jlcpcb`

| rule | base `d5615fe5` | this PR |
|---|---|---|
| `diffpair_clearance_intra` | 7 | 7 |
| `diffpair_length_skew` | 7 | 7 |
| `diffpair_routing_continuity` | 7 | 7 |
| `clearance_pad_segment` | 5 | 5 |
| `connectivity` | 3 | 3 |
| `impedance` | 2 | 2 |
| `clearance_segment_via` | 1 | 1 |
| `via_in_pad` | 1 | 1 |
| **total errors** | **33** | **33** |
| LVS | 3 opens (J1.A6/B6, J4.3/U4.3, J4.4/U4.4) | 3 opens (identical) |

- [x] **AC-2 (no construction regression)** — the base `coupled-ok` set
      {MIPI_CLK, PCIE_RX, USB2_D, USB3_TX1, USB3_TX2} is unchanged; no pair
      moved to `guide-missing` or `shadow-declined-*`.
- [x] **AC-3 (no DRC regression)** — every listed rule count and the total are
      identical to the re-measured base. No byte-identity is asserted (#4536).
- [x] **AC-4 (preference, never a veto)** — demonstrated by three unit tests:
      empty registry ⇒ route identical (vias *and* segments) to the shadow-OFF
      first-legal route; uniform penalty (monkeypatched) ⇒ first-legal wins; a
      zero-penalty site that fails `_route_pad_violation` is still rejected.
- [x] **AC-5 (default path untouched)** — `enable_shadow_construction` still
      defaults to `False` (unchanged), and the scoring sits *inside* that guard,
      so the `:4083` stub-edge caller (`partner_segments=[]`, shadow OFF) takes
      the identical code path. Covered by
      `test_crossing_tail_scoring_is_inert_with_shadow_construction_off`, which
      builds the *same* board state and asserts the un-scored site still ships.
- [x] **AC-6 (deterministic)** — registry iterates `sorted(nets)`; the sort is
      stable so ties resolve on enumeration index. Verified by running the unit
      fixture under `PYTHONHASHSEED` 0/1/42/12345: identical registry and
      identical via sites. Board-level `[coupled-pair-report]` classes are
      identical across the two full runs.
- [x] **AC-7 (generic)** — no net-name, ref-name or board branch anywhere; the
      mechanism reads pad coordinates, component pitch, and whether the net has
      committed copper.
- [x] **AC-8** — `uv run pytest tests/test_diffpair_shadow.py` → 151 passed
      (141 before + 10 new); `ruff format --check` and `ruff check .` clean;
      mypy baseline check: *"1473 error(s), all within the baseline (1474
      allowed). No new type errors."*
- [ ] **AC-1 (primary observable) — NOT met, and measurement says it is not
      reachable from via-site selection.** See below.

### AC-1: why MIPI_D0's corridor stays sealed

AC-1 rested on the premise that the lattice "already prove[s] it has freedom to
choose". Instrumented with the new ordering, it does not — not for this tail:

```
CHOSE MIPI_CLK- rank=208/225 penalty=0.7429
      v1=(108.24091, 117.60773)   <- the exact barrel the issue indicts
      v2=(106.23878, 118.08373)
```

208 candidate pairs score strictly better (many at penalty `0.0`) and **all 208
are rejected by an existing legality gate**. The preference is working; the
lattice is saturated.

The pinch, from the constructed copper dumped at seal time (MIPI_D0's pads are
J4.3 `(106.9,117.5)` / J4.4 `(107.7,117.5)`, escaping east to U4 at `x=125.5`):

```
MIPI_CLK+ F.Cu  (106.150,116.650) -> (124.350,116.650)  w=0.1016   guide
MIPI_CLK- F.Cu  (108.102,117.024) -> (113.300,117.000)  w=0.225    shadow body
MIPI_CLK- F.Cu  (108.241,117.608) -> (108.241,117.163)             tail stub
MIPI_CLK- VIA   (108.241,117.608) d=0.45                           all-layer barrel
```

* clear of the body centreline `y=117.024`: `0.1125 + 0.1016` ⇒ `y >= 117.238`
* clear of the barrel centre `y=117.608`: `0.225+0.1016+0.1125 = 0.4391` ⇒ `y <= 117.169`

`117.238 > 117.169` ⇒ no lane ⇒ `guide_route=FAILED segments=0`. Note the tail
STUB shares `v1`'s x, so moving only the barrel cannot help: any `v1` off the
head drags a surface stub across the same lane.

The one site that *would* have left the lane open is lattice index 0,
`v1 = (108.102,117.024)` (the tail head itself, penalty `0.0`) — the crossover
then runs on In1 *under* the row and re-surfaces west of MIPI_D0. It misses the
via-vs-partner clearance by **0.0034 mm**: the barrel would sit `0.3740 mm`
from the MIPI_CLK+ guide centreline where `via_diameter/2 + trace_clearance +
partner_width/2 = 0.3774 mm`. The shadow BODY was offset to `0.374 mm` from the
guide by `_shadow_select_gap`, which judges the gap against the intra-pair
clearance floor and the raster and has no term for "a via barrel will later have
to sit on this centreline".

So the residual blocker is one layer up the stack from via-site selection.
Filed as **#4580** with the full derivation and three suggested directions.

This PR delivers the issue's stated scope verbatim — *"make the shadow
constructor's via-site selection prefer, among sites that are already legal, the
ones that do not seal a not-yet-routed net's only escape channel"* — as a
generic, zero-regression capability, and converts AC-1 from a hypothesis into a
measured negative result that redirects the epic's next step. Judge: if you would
rather this stay open until #4580 lands, say so and I will switch the reference
to `Part of #4574`.

Per the sequencing note, only lattice (1) was touched. Lattice (2)
(`_shadow_route_pair`'s shadow-via lattice) fires **only at a guide layer
change**, and MIPI_CLK's guide has `(0, 0)` vias on both sides, so it cannot be
the source of this seal; extending it was left out to keep the diff bounded for
#4575 / #4577 queued behind it on this file.

## Test Plan

New tests in `tests/test_diffpair_shadow.py` (all passing):

- `test_crossing_tail_first_legal_site_is_the_unscored_baseline` — control.
- `test_crossing_tail_steps_off_an_unrouted_pads_escape_channel` — two legal
  sites, exactly one on an unrouted pad's escape ray; the other must ship, and
  every shipped barrel scores `0.0`.
- `test_crossing_tail_scoring_is_inert_with_shadow_construction_off` — AC-5,
  the `partner_segments=[]` stub-edge path still synthesizes the unscored tail.
- `test_crossing_tail_with_an_empty_registry_is_bit_for_bit_first_legal` — AC-4.
- `test_crossing_tail_breaks_uniform_penalty_ties_on_enumeration_order` — AC-4/6.
- `test_crossing_tail_preference_never_bypasses_the_foreign_pad_gate` — mirrors
  the `#4571` pattern: a zero-penalty site that is a pad short still loses.
- `test_escape_channel_registry_skips_routed_and_pitchless_nets` — the oracle.
- `test_escape_channel_registry_is_empty_without_autorouter_state` — degradation.
- `test_channel_seal_penalty_only_fires_inside_the_channel` — behind the pad,
  past the reach, clear laterally ⇒ all `0.0`; monotone as the barrel steps aside.
- `test_channel_seal_penalty_sums_over_every_channel_it_reaches` — additivity.

Edge cases covered by construction: pure-Python backend (the pathfinder stand-in
has no `set_routable_layers`); no fine-pitch neighbour ⇒ empty registry, zero
overhead; nothing left unrouted ⇒ empty registry; shadow OFF ⇒ no code path
change at all.

Board artifacts under `boards/*/output/` were regenerated for the measurements
and restored (`git checkout -- boards/`); the diff is source + tests only.

Closes #4574
