### PR TITLE
fix(diffpair): gate shadow-constructed copper on exact via clearance

### DIFF
--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -56,6 +56,7 @@ from .quantize import (
     dogleg_points,
     verify_segment_45,
 )
+from .via_clearance import segment_via_deficit
 
 logger = logging.getLogger(__name__)
 
@@ -295,6 +296,36 @@ _SHADOW_PAD_DEFICIT_EPS: float = 1e-4
 # declining the whole side.
 _SHADOW_PAD_PROBE_STEP_MM: float = 0.2
 
+# Issue #4575: the segment-vs-VIA quadrant of the same validation gap.  The
+# constructor's only via-aware self-check is ``_pair_has_physical_overlap``,
+# which is an OVERLAP detector (``via_r + seg_w/2``, no clearance term), and the
+# partner universe handed to every tail screen is ``list(guide.segments)`` -- it
+# contains no vias at all.  So a constructed leg passing 0.090 mm from the
+# partner leg's barrel is accepted by every construction-time gate and then
+# reported by ``clearance_segment_via`` at 0.102 mm (measured on board-06
+# shadow-ON seed 42: USB3_TX1+ copper vs a USB3_TX1- barrel).  A diff-pair net
+# is excluded from ``drc_verify_and_nudge`` (#3508), so nothing downstream
+# repairs it.
+#
+# THRESHOLD (load-bearing): ``ClearanceRule`` exempts a declared diff pair from
+# the generic clearance check ONLY when both elements are SEGMENTS
+# (``validate/rules/clearance.py`` -- the #2560 scoping).  A segment-vs-via or
+# via-vs-via pair between P and N is therefore checked at the full board
+# minimum.  This gate must use ``rules.trace_clearance`` /
+# ``rules.via_clearance``, NOT ``_pair_seg_clearance``'s intra-pair relaxation:
+# the relaxed bound is deliberately tighter than the manufacturer clearance, so
+# a gate built on it could never fire on the very finding it exists to close.
+#
+# Same noise floor as the pad quadrant (one serialization quantum, and the same
+# value as ``DRC_TOLERANCE``) so the gate and the checker agree at the boundary.
+_SHADOW_VIA_DEFICIT_EPS: float = _SHADOW_PAD_DEFICIT_EPS
+# Mirrors ``validate.rules.clearance._COLOCATION_EPSILON_MM`` (#2706): the
+# in-pad-escape router places segment endpoints EXACTLY at via centres, and the
+# DRC skips such pairs.  A gate without the same carve-out would be stricter
+# than the checker and decline sides over geometry that is never reported --
+# pure reach loss for zero DRC gain.
+_SHADOW_VIA_COLOCATION_EPS: float = 1e-4
+
 # Issue #4574: the constructed crossover's via sites are chosen FIRST-LEGAL out
 # of a fixed 3x5 lattice, so the winning site carries no information about what
 # the rest of the board still has to route.  An all-layer F.Cu<->B.Cu barrel is
@@ -360,6 +391,30 @@ def _channel_seal_penalty(
             continue  # the direct escape still fits past this barrel
         penalty += keepout - lateral
     return penalty
+
+
+class _ShadowForeignCopper(NamedTuple):
+    """Copper the constructed leg must keep VIA clearance from (issue #4575).
+
+    ``vias`` and ``segments`` are flat snapshots unioning the board's
+    committed routes with the pair's own SIBLING legs -- the guide, and
+    (during the late one-leg-at-a-time mutations of #4553's length matcher
+    and #4570's via mirror) the other constructed leg.  The sibling legs are
+    never in the routing grid during shadow construction, which is exactly
+    why no raster check can see them.
+
+    Elements carry their own ``net``, so same-net filtering is a per-element
+    comparison at query time -- ``exclude_net`` semantics with no
+    ``exclude_refs`` anywhere (the #3545 same-component carve-out would
+    exempt the partner's barrel whenever P and N share a fine-pitch
+    connector ref, which is exactly the board-06 case this gate exists for).
+
+    See :meth:`DiffPairRouter._shadow_foreign_copper` for how the snapshot is
+    built and why ``autorouter.routes`` (not ``grid.routes``) is the source.
+    """
+
+    vias: tuple[Via, ...]
+    segments: tuple[Segment, ...]
 
 
 # Issue #4572: the constructor's landing tails are the pair's uncoupled copper.
@@ -3624,7 +3679,8 @@ class DiffPairRouter:
         # ("overlap" -- self-check / physical P/N overlap, "blockage" --
         # no legal via site / mid-route obstacle / unreachable pad tail, or
         # "pad-clearance" -- constructed copper inside a foreign pad's
-        # clearance halo, #4571);
+        # clearance halo, #4571, or "via-clearance" -- constructed copper
+        # inside a foreign VIA BARREL's clearance halo, #4575);
         # reset per spec, set inside ``_shadow_route_pair``.
         # ``_last_coupled_pair_report`` holds the most-recent per-pair
         # taxonomy classification (a :class:`CoupledPairReport`).  Both are
@@ -3636,6 +3692,21 @@ class DiffPairRouter:
         # boosts the guide A*'s cost at these sites to steer the re-route away.
         self._last_shadow_overlap_locations: list[tuple[float, float]] = []
         self._last_coupled_pair_report: CoupledPairReport | None = None
+        # Issue #4575: foreign-copper universe for the exact segment-vs-via /
+        # via-vs-via clearance gate, armed for the duration of ONE
+        # ``_shadow_route_pair`` call by ``_shadow_foreign_copper``.  ``None``
+        # means the gate is DISARMED and every one of its screens is a no-op --
+        # which is precisely the state on the shadow-construction-OFF path and
+        # for the ordinary (non-shadow) ``_tail_route`` calls, so this change
+        # cannot alter either.
+        self._shadow_foreign_universe: _ShadowForeignCopper | None = None
+        # Issue #4575 (observability, in the spirit of #4459): how many
+        # CANDIDATES the foreign-via gate rejected during the most recent
+        # ``_shadow_route_pair`` call.  A gate that only ever declines whole
+        # sides trades DRC errors for coupling; this counter is the evidence
+        # that the per-candidate screens are doing the repair instead.
+        # Diagnostic only -- never read by a routing decision.
+        self._shadow_via_gate_rejections: int = 0
         # Issue #3089: True iff the most-recent call to
         # ``route_differential_pair_coupled`` returned because the
         # inner ``CoupledPathfinder.route_coupled`` exceeded its
@@ -4445,6 +4516,282 @@ class DiffPairRouter:
                 worst, worst_loc = deficit, loc
         return worst, worst_loc
 
+    # ------------------------------------------------------------------
+    # Issue #4575: exact foreign-VIA clearance gate for constructed copper
+    # ------------------------------------------------------------------
+
+    @contextlib.contextmanager
+    def _shadow_foreign_copper(self, *partners: Route) -> Iterator[None]:
+        """Arm the segment-vs-via clearance gate for one pair attempt (#4575).
+
+        The gate is deliberately AMBIENT rather than threaded through the
+        eight-deep tail-synthesis call chain (``_tail_route`` ->
+        ``_synthesize_following_tail`` -> ``_bridge_to`` /
+        ``_follow_partner_runs`` -> ``_synthesize_tail`` /
+        ``_synthesize_crossing_tail`` -> ``_fallback_tail_route`` ->
+        ``_planar_tail_probe``).  Two properties follow from that and both
+        are load-bearing:
+
+        * **No screen can be missed.**  Every candidate produced anywhere in
+          that chain is measured, including the last-resort A* tail whose
+          partner screen (``_tail_partner_clear`` with ``clearance=0.0``)
+          checks barrels for physical OVERLAP only.
+        * **It is inert everywhere else.**  Outside this context manager
+          ``_shadow_foreign_universe`` is ``None`` and every screen below
+          returns ``0.0``, so the ordinary (non-shadow) ``_tail_route``
+          calls and the whole shadow-construction-OFF path are unchanged.
+
+        The universe unions two sources:
+
+        * every route already committed to ``autorouter.routes`` -- the
+          AUTHORITATIVE list, deliberately NOT ``grid.routes``, which can
+          hold a stale best-iteration geometry after a restore (see the #3486
+          warning on ``RoutingGrid.worst_via_segment_deficit``); and
+        * ``partners`` -- the pair's own sibling legs, which are never in the
+          grid during shadow construction and are therefore invisible to
+          every raster check.  The guide is registered here for the whole
+          construction, and the post-assembly gate re-registers the FINAL
+          guide geometry (the #4553 length matcher and the #4570 via mirror
+          both mutate a leg after the first snapshot was taken).
+
+        NOTHING is filtered out by net at snapshot time.  The
+        ``exclude_net`` discipline is applied per ELEMENT at query time
+        (``via.net == seg.net`` -> skip), which is the same
+        ``exclude_net``-only rule #4571 uses and which
+        :meth:`_collect_existing_drills` already applies to the drill
+        registry -- and never ``exclude_refs``, whose #3545 same-component
+        carve-out would exempt the partner's barrel on exactly the fine-pitch
+        connectors this gate exists for.
+
+        Measured scope note (board-06 shadow-ON seed 42): every candidate
+        rejection this gate makes traces to the PARTNER leg -- a run with the
+        committed half of the universe removed produces the identical
+        per-pair rejection counts.  That is consistent with the board having
+        no constructed-copper-vs-third-party-barrel finding at baseline, so
+        the committed half is defence-in-depth for other boards rather than
+        the thing that closes #4575.
+
+        Nesting is supported (``_shadow_route_pair`` re-enters itself for the
+        uncompressed-guide retry, and the post-assembly gate re-arms with the
+        FINAL guide geometry) by save/restore.
+        """
+        prev = self._shadow_foreign_universe
+        vias: list[Via] = []
+        segments: list[Segment] = []
+        for route in list(getattr(self.autorouter, "routes", None) or []):
+            vias.extend(route.vias)
+            segments.extend(route.segments)
+        for partner in partners:
+            vias.extend(partner.vias)
+            segments.extend(partner.segments)
+        self._shadow_foreign_universe = _ShadowForeignCopper(tuple(vias), tuple(segments))
+        try:
+            yield
+        finally:
+            self._shadow_foreign_universe = prev
+
+    @contextlib.contextmanager
+    def _shadow_foreign_copper_extended(self, *extra: Route) -> Iterator[None]:
+        """Temporarily widen the armed universe with more copper (#4575).
+
+        Used where the constructor mutates ONE leg while the OTHER leg has
+        already been built -- the length matcher's meander teeth and the
+        #4570 via-signature mirror.  At that point the sibling leg is
+        constructed copper that exists nowhere in the ambient universe (it is
+        neither committed nor the pre-assembly guide), so without this the
+        tooth screens would be blind to the very barrels the pair just gained
+        (measured on board-06 seed 42: a guide-leg meander tooth dipped to
+        0.090 mm from the shadow leg's own landing via).
+
+        A no-op when the gate is disarmed, so the shadow-OFF path is unchanged.
+        """
+        prev = self._shadow_foreign_universe
+        if prev is None:
+            yield
+            return
+        vias = list(prev.vias)
+        segments = list(prev.segments)
+        for route in extra:
+            vias.extend(route.vias)
+            segments.extend(route.segments)
+        self._shadow_foreign_universe = _ShadowForeignCopper(tuple(vias), tuple(segments))
+        try:
+            yield
+        finally:
+            self._shadow_foreign_universe = prev
+
+    @staticmethod
+    def _seg_via_colocated(seg: Segment, via: Via) -> bool:
+        """#2706 co-location carve-out, matching ``ClearanceRule`` (#4575).
+
+        The in-pad-escape router places segment endpoints EXACTLY at via
+        centres, and the DRC skips any segment/via pair whose segment
+        endpoint is within ``_COLOCATION_EPSILON_MM`` of the via centre.
+        Without the same carve-out this gate would be STRICTER than the
+        checker and decline sides over geometry the checker never reports.
+        """
+        return (
+            math.hypot(seg.x1 - via.x, seg.y1 - via.y) < _SHADOW_VIA_COLOCATION_EPS
+            or math.hypot(seg.x2 - via.x, seg.y2 - via.y) < _SHADOW_VIA_COLOCATION_EPS
+        )
+
+    def _segment_via_deficit(self, seg: Segment) -> tuple[float, tuple[float, float] | None]:
+        """Worst exact clearance deficit of a segment vs FOREIGN vias (#4575).
+
+        ``> _SHADOW_VIA_DEFICIT_EPS`` means the segment would violate the
+        ``clearance_segment_via`` predicate against some via that is not on
+        ``seg.net`` -- INCLUDING the diff-pair partner's barrels, which the
+        DRC checks at the full board minimum because its diff-pair exemption
+        covers segment-to-SEGMENT edges only.
+
+        Returns ``(0.0, None)`` when the gate is disarmed.
+        """
+        universe = self._shadow_foreign_universe
+        if universe is None:
+            return 0.0, None
+        clearance = self.autorouter.rules.trace_clearance
+        worst = 0.0
+        worst_loc: tuple[float, float] | None = None
+        for via in universe.vias:
+            if via.net == seg.net:
+                continue  # own-net copper may touch (a tail lands on it)
+            if self._seg_via_colocated(seg, via):
+                continue
+            deficit = segment_via_deficit(seg, via, clearance)
+            if deficit > worst:
+                worst, worst_loc = deficit, (via.x, via.y)
+        return worst, worst_loc
+
+    def _span_via_deficit(
+        self,
+        x1: float,
+        y1: float,
+        x2: float,
+        y2: float,
+        layer_idx: int,
+        net: int,
+        width: float,
+    ) -> float:
+        """Worst foreign-via clearance deficit of a candidate span (#4575)."""
+        if self._shadow_foreign_universe is None:
+            return 0.0
+        grid = self.autorouter.grid
+        probe = Segment(
+            x1=x1,
+            y1=y1,
+            x2=x2,
+            y2=y2,
+            width=width,
+            layer=Layer(grid.index_to_layer(layer_idx)),
+            net=net,
+            net_name="",
+        )
+        return self._segment_via_deficit(probe)[0]
+
+    def _span_via_clear(
+        self,
+        x1: float,
+        y1: float,
+        x2: float,
+        y2: float,
+        layer_idx: int,
+        net: int,
+        width: float,
+    ) -> bool:
+        """True when a candidate span keeps foreign-via clearance (#4575)."""
+        ok = (
+            self._span_via_deficit(x1, y1, x2, y2, layer_idx, net, width) <= _SHADOW_VIA_DEFICIT_EPS
+        )
+        if not ok:
+            self._shadow_via_gate_rejections += 1
+        return ok
+
+    def _via_copper_deficit(self, via: Via) -> tuple[float, tuple[float, float] | None]:
+        """Worst deficit of a via vs FOREIGN segments and vias (#4575).
+
+        The mirror direction of :meth:`_segment_via_deficit`: a constructed
+        barrel is copper on every layer it spans, so it must keep
+        ``rules.via_clearance`` from foreign trace centrelines (the exact
+        threshold ``RoutingGrid.worst_via_segment_deficit`` and
+        ``via_clears_foreign_segment`` use) and from foreign barrels.
+        """
+        universe = self._shadow_foreign_universe
+        if universe is None:
+            return 0.0, None
+        clearance = self.autorouter.rules.via_clearance
+        worst = 0.0
+        worst_loc: tuple[float, float] | None = None
+        for seg in universe.segments:
+            if seg.net == via.net:
+                continue
+            if self._seg_via_colocated(seg, via):
+                continue
+            deficit = segment_via_deficit(seg, via, clearance)
+            if deficit > worst:
+                worst, worst_loc = deficit, (via.x, via.y)
+        v_lo = min(via.layers[0].value, via.layers[1].value)
+        v_hi = max(via.layers[0].value, via.layers[1].value)
+        for other in universe.vias:
+            if other.net == via.net:
+                continue
+            o_lo = min(other.layers[0].value, other.layers[1].value)
+            o_hi = max(other.layers[0].value, other.layers[1].value)
+            if o_hi < v_lo or o_lo > v_hi:
+                continue  # barrels never share a layer
+            dist = math.hypot(via.x - other.x, via.y - other.y)
+            deficit = via.diameter / 2 + other.diameter / 2 + clearance - dist
+            if deficit > worst:
+                worst, worst_loc = deficit, (other.x, other.y)
+        return worst, worst_loc
+
+    def _route_via_violation(
+        self,
+        route: Route,
+    ) -> tuple[float, tuple[float, float] | None]:
+        """Worst foreign-via clearance deficit over an assembled route (#4575).
+
+        Sibling of :meth:`_route_pad_violation` for the via quadrant.  Both
+        directions of the P/N interaction are covered by measuring the
+        CONSTRUCTED leg only, because the partner is registered as foreign
+        copper: the leg's segments are checked against the partner's barrels
+        AND the leg's barrels against the partner's segments and barrels.
+
+        Only the CONSTRUCTED leg is ever passed in.  The guide leg is not
+        measured against third-party copper: it is ordinary single-ended
+        router output that keeps the single-ended finalization backstops, so
+        declining a side over a pre-existing guide graze would cost coupling
+        without fixing anything the constructor introduced (the #4571
+        rationale, one quadrant over).  Guide copper the CONSTRUCTOR added --
+        the length matcher's meander teeth, the via mirror's z-jog -- is
+        still covered, because it is screened as it is built (against a
+        universe widened with the sibling leg) and because the post-assembly
+        call re-registers the final guide as foreign copper.
+
+        Returns ``(worst_deficit, worst_location)``; ``worst_deficit <=
+        _SHADOW_VIA_DEFICIT_EPS`` means the route is clean.  Always
+        ``(0.0, None)`` when the gate is disarmed.
+        """
+        if self._shadow_foreign_universe is None:
+            return 0.0, None
+        worst = 0.0
+        worst_loc: tuple[float, float] | None = None
+        for seg in route.segments:
+            deficit, loc = self._segment_via_deficit(seg)
+            if deficit > worst:
+                worst, worst_loc = deficit, loc
+        for via in route.vias:
+            deficit, loc = self._via_copper_deficit(via)
+            if deficit > worst:
+                worst, worst_loc = deficit, loc
+        return worst, worst_loc
+
+    def _route_via_clear(self, route: Route | None) -> bool:
+        """True when an assembled candidate keeps foreign-via clearance (#4575)."""
+        ok = route is not None and self._route_via_violation(route)[0] <= _SHADOW_VIA_DEFICIT_EPS
+        if not ok and route is not None:
+            self._shadow_via_gate_rejections += 1
+        return ok
+
     def _pad_deficit_arcs(
         self,
         x1: float,
@@ -4636,6 +4983,17 @@ class DiffPairRouter:
                 # shipping a short.
                 if any(
                     not self._span_pad_clear(x1, y1, x2, y2, layer_idx, head.net, width)
+                    for x1, y1, x2, y2 in segs
+                ):
+                    continue
+                # Issue #4575: the partner universe this method screens against
+                # is ``partner_segments`` -- SEGMENTS.  A landing tail drawn
+                # 0.090 mm from the partner leg's via BARREL therefore passes
+                # every check above and ships (board-06 seed 42, USB3_TX1).
+                # Screen it here, inside the loop, so a grazing candidate loses
+                # to a later detour instead of declining the side.
+                if any(
+                    not self._span_via_clear(x1, y1, x2, y2, layer_idx, head.net, width)
                     for x1, y1, x2, y2 in segs
                 ):
                     continue
@@ -5159,11 +5517,12 @@ class DiffPairRouter:
         partner_segments: list[Segment],
         partner_clearance: float,
     ) -> bool:
-        """The three gates every synthesized tail span must pass (#4572).
+        """The four gates every synthesized tail span must pass (#4572).
 
-        Deliberately the SAME three, in the same order, as
+        Deliberately the SAME four, in the same order, as
         :meth:`_synthesize_tail`'s candidate loop: grid raster, partner
-        clearance floor (#4460), exact foreign-pad clearance (#4571/PR #4573).
+        clearance floor (#4460), exact foreign-pad clearance (#4571/PR #4573)
+        and exact foreign-via clearance (#4575).
         """
         for x1, y1, x2, y2 in spans:
             if not self._segment_cells_clear(pathfinder, x1, y1, x2, y2, layer_idx, net):
@@ -5176,6 +5535,9 @@ class DiffPairRouter:
                 return False
         for x1, y1, x2, y2 in spans:
             if not self._span_pad_clear(x1, y1, x2, y2, layer_idx, net, width):
+                return False
+        for x1, y1, x2, y2 in spans:
+            if not self._span_via_clear(x1, y1, x2, y2, layer_idx, net, width):
                 return False
         return True
 
@@ -5552,6 +5914,14 @@ class DiffPairRouter:
                 # loses to a later via-site candidate instead of shipping.
                 if self._route_pad_violation(route)[0] > _SHADOW_PAD_DEFICIT_EPS:
                     continue
+                # Issue #4575: the barrel screens above measure this crossover
+                # against the partner's SEGMENTS only, and the raster cannot
+                # see the partner at all.  Hold the assembled crossover to the
+                # exact ``clearance_segment_via`` / via-vs-via predicates too,
+                # so a via site that grazes the partner's barrel loses to the
+                # next candidate pair rather than shipping.
+                if not self._route_via_clear(route):
+                    continue
                 return route
         return None
 
@@ -5725,6 +6095,8 @@ class DiffPairRouter:
             why = "lock-leaked-a-via"
         elif self._route_pad_violation(cand)[0] > _SHADOW_PAD_DEFICIT_EPS:
             why = "pad-deficit"
+        elif not self._route_via_clear(cand):
+            why = "via-deficit"  # issue #4575
         elif partner_segments and not self._tail_partner_clear(cand, partner_segments, seg_clear):
             why = "partner-clearance"
         if _SHADOW_DEBUG:
@@ -5858,6 +6230,14 @@ class DiffPairRouter:
             ]
             if any(self._via_pad_deficit(v) > _SHADOW_PAD_DEFICIT_EPS for v in vias):
                 continue
+            # Issue #4575: the mirrored jog drills TWO new barrels into copper
+            # the raster does not fully model (the partner is not in the grid
+            # at all).  Hold them to the exact via-vs-foreign-segment /
+            # via-vs-via predicates before anything is mutated, exactly as the
+            # pad predicate above -- otherwise the symmetry repair itself
+            # becomes a new source of ``clearance_segment_via`` findings.
+            if any(self._via_copper_deficit(v)[0] > _SHADOW_VIA_DEFICIT_EPS for v in vias):
+                continue
             if not self._segment_cells_clear(pathfinder, ax, ay, bx, by, jog_idx, net):
                 continue
             jog_seg = Segment(
@@ -5872,6 +6252,8 @@ class DiffPairRouter:
             )
             if not self._segment_pad_clear(jog_seg):
                 continue
+            if self._segment_via_deficit(jog_seg)[0] > _SHADOW_VIA_DEFICIT_EPS:
+                continue  # issue #4575: relocated copper vs foreign barrels
             if partner_segments and any(
                 self._min_distance_to_partner(v.x, v.y, v.x, v.y, partner_segments, None)
                 < via_clear
@@ -5947,14 +6329,21 @@ class DiffPairRouter:
                 if count % 2:
                     return False
                 for _ in range(count // 2):
-                    if not self._mirror_z_jog(
-                        deficient,
-                        layer_pair,
-                        pathfinder,
-                        list(partner.segments),
-                        deficient.net,
-                        deficient.net_name,
-                    ):
+                    # Issue #4575: the mirror drills into the pair's OTHER
+                    # constructed leg's neighbourhood, and that leg is in
+                    # neither the committed routes nor the pre-assembly guide.
+                    # Widen the armed universe so ``_mirror_z_jog``'s barrel
+                    # screens can see the partner's own barrels and traces.
+                    with self._shadow_foreign_copper_extended(partner):
+                        mirrored = self._mirror_z_jog(
+                            deficient,
+                            layer_pair,
+                            pathfinder,
+                            list(partner.segments),
+                            deficient.net,
+                            deficient.net_name,
+                        )
+                    if not mirrored:
                         return False
         return self._via_layer_multiset(guide_route, num_copper_layers) == (
             self._via_layer_multiset(shadow_route, num_copper_layers)
@@ -5986,7 +6375,7 @@ class DiffPairRouter:
         PCIE_RX / USB3_TX1).  When ``prefer_planar_layer`` names the layer the
         partner's corresponding copper occupies, ONE extra probe is spent with
         the router locked to that layer, and its result is preferred whenever
-        it passes the same ``_pad_ok`` / ``_tail_partner_clear`` gates as the
+        it passes the same ``_copper_ok`` / ``_tail_partner_clear`` gates as the
         unbiased probe.  ``None`` (the default, and the only value reachable
         with shadow construction off) skips the extra probe entirely, so the
         legacy chain below is untouched.
@@ -6008,13 +6397,25 @@ class DiffPairRouter:
         # tail is the constructor's most direct route to a pad short.  Discard
         # any probe result whose copper violates the exact pad predicate; the
         # caller's anchor-stepping retry then gets the attempt instead.
-        def _pad_ok(cand: Route | None) -> bool:
-            return cand is not None and self._route_pad_violation(cand)[0] <= (
-                _SHADOW_PAD_DEFICIT_EPS
+        # Issue #4575: the same argument one quadrant over, and it is the
+        # sharper one HERE.  The last-resort acceptance below settles for
+        # ``_tail_partner_clear(..., 0.0)``, whose barrel bound drops the
+        # clearance term entirely -- copper is only required not to physically
+        # intersect the partner.  Rejecting a via-violating probe up front (so
+        # both ``plain`` and ``biased`` are already ``None`` by the time that
+        # loop runs) keeps the last-resort path consistent with the
+        # post-assembly gate: the caller's anchor-stepping retry gets the
+        # attempt instead of the constructor emitting copper the gate is
+        # guaranteed to reject.
+        def _copper_ok(cand: Route | None) -> bool:
+            return (
+                cand is not None
+                and self._route_pad_violation(cand)[0] <= _SHADOW_PAD_DEFICIT_EPS
+                and self._route_via_clear(cand)
             )
 
         plain = _probe(None, 1)
-        if not _pad_ok(plain):
+        if not _copper_ok(plain):
             plain = None
 
         # Issue #4570: the unbiased probe stays FIRST CHOICE whenever it is
@@ -6050,7 +6451,7 @@ class DiffPairRouter:
                     biased = None
             else:
                 biased = _probe(sites, radius_cells)
-            if not _pad_ok(biased):
+            if not _copper_ok(biased):
                 biased = None
             if biased is not None and self._tail_partner_clear(biased, partner_segments, seg_clear):
                 return biased
@@ -6418,13 +6819,23 @@ class DiffPairRouter:
         )
         if need <= 1e-6:
             return 0.0
-        added = self._meander_route_to_length(
-            shorter,
-            list(partner.segments),
-            pathfinder,
-            need,
-            min_partner_center,
-        )
+        # Issue #4575: ``partner`` here is the pair's OTHER constructed leg --
+        # copper that exists in neither the committed route list nor the
+        # pre-assembly guide, so the foreign-via gate armed for this
+        # construction cannot see its barrels.  A tooth is displaced AWAY from
+        # the partner's traces, which says nothing about the partner's VIAS
+        # (board-06 seed 42: a guide-leg tooth landed 0.090 mm from the shadow
+        # leg's own landing via).  Widen the universe for the duration so each
+        # candidate tooth is screened against them and a violating tooth simply
+        # loses to the next window.
+        with self._shadow_foreign_copper_extended(partner):
+            added = self._meander_route_to_length(
+                shorter,
+                list(partner.segments),
+                pathfinder,
+                need,
+                min_partner_center,
+            )
         if _SHADOW_DEBUG:
             print(
                 f"    [coupled-shadow-match] {pair.name} delta={delta:+.3f} "
@@ -6518,6 +6929,11 @@ class DiffPairRouter:
                     # against the exact foreign-pad predicate, not only the
                     # (fine-pitch-shrunk) raster halo.
                     if not self._span_pad_clear(s.x1, s.y1, s.x2, s.y2, _li, _net, _w):
+                        return False
+                    # Issue #4575: and against the exact foreign-VIA predicate.
+                    # A tooth is pushed AWAY from the partner, straight into
+                    # whatever barrels sit on the far side.
+                    if not self._span_via_clear(s.x1, s.y1, s.x2, s.y2, _li, _net, _w):
                         return False
                     if (
                         self._min_distance_to_partner(
@@ -6671,12 +7087,19 @@ class DiffPairRouter:
                 continue
             if cur.layer == prev.layer and gap <= res:
                 li = self.autorouter.grid.layer_to_index(cur.layer.value)
-                # Issue #4571: the inserted connector is real copper -- hold it
-                # to the exact foreign-pad predicate too, not just the raster.
-                if self._segment_cells_clear(
-                    pathfinder, prev.x2, prev.y2, cur.x1, cur.y1, li, cur.net
-                ) and self._span_pad_clear(
-                    prev.x2, prev.y2, cur.x1, cur.y1, li, cur.net, cur.width
+                # Issue #4571 / #4575: the inserted connector is real copper --
+                # hold it to the exact foreign-pad AND foreign-via predicates
+                # too, not just the raster.
+                if (
+                    self._segment_cells_clear(
+                        pathfinder, prev.x2, prev.y2, cur.x1, cur.y1, li, cur.net
+                    )
+                    and self._span_pad_clear(
+                        prev.x2, prev.y2, cur.x1, cur.y1, li, cur.net, cur.width
+                    )
+                    and self._span_via_clear(
+                        prev.x2, prev.y2, cur.x1, cur.y1, li, cur.net, cur.width
+                    )
                 ):
                     out.append(
                         Segment(
@@ -6787,6 +7210,11 @@ class DiffPairRouter:
                     # into a foreign pad's clearance halo loses to the other
                     # variant (or the segment is kept as-is, unchanged).
                     if not self._span_pad_clear(x1, y1, x2, y2, _li, _seg.net, _seg.width):
+                        return False
+                    # Issue #4575: same argument for a foreign VIA barrel --
+                    # the bulge is new copper the raster's via halo does not
+                    # measure at the exact ``clearance_segment_via`` threshold.
+                    if not self._span_via_clear(x1, y1, x2, y2, _li, _seg.net, _seg.width):
                         return False
                 return True
 
@@ -7366,8 +7794,6 @@ class DiffPairRouter:
         self._last_shadow_overlap_locations = []
         if not guide.segments:
             return None
-        grid = self.autorouter.grid
-        rules = self.autorouter.rules
         # Issue #4553: compress the guide's per-cell staircase FIRST, so the
         # parallel offset is taken from a polyline with long straight runs.
         # The caller's ``guide`` object is left untouched (it is reused by the
@@ -7382,6 +7808,59 @@ class DiffPairRouter:
         guide_was_simplified = guide is not raw_guide
         if not guide.segments:
             return None
+        # Issue #4575: register the guide (the PARTNER leg) plus every
+        # committed route as foreign copper for the whole construction, so the
+        # exact segment-vs-via / via-vs-via predicates are reachable from every
+        # tail-synthesis screen below and from the post-assembly gate.  Armed
+        # here -- after simplification -- so the registered partner segments are
+        # exactly the ones the tail screens receive as ``partner_segs``.  The
+        # gate is a no-op outside this block, which is what keeps the
+        # shadow-construction-OFF path unchanged.
+        outermost = self._shadow_foreign_universe is None
+        if outermost:
+            self._shadow_via_gate_rejections = 0
+        with self._shadow_foreign_copper(guide):
+            result = self._shadow_route_pair_body(
+                pair,
+                spec,
+                pathfinder,
+                guide,
+                raw_guide,
+                guide_was_simplified,
+                spacing_cells,
+                swap_roles,
+            )
+        if outermost and self._shadow_via_gate_rejections:
+            # One line, only when the gate actually did something: N candidates
+            # were rejected for grazing a foreign barrel and lost to a LATER
+            # candidate (a repair), which is the outcome that does not cost
+            # reach.  A side that could not be repaired says so separately, via
+            # the ``via-clearance`` decline line inside the body.
+            print(
+                f"    [coupled-shadow] {pair.name} foreign-via gate rejected "
+                f"{self._shadow_via_gate_rejections} candidate(s) (issue #4575)"
+            )
+        return result
+
+    def _shadow_route_pair_body(
+        self,
+        pair: DifferentialPair,
+        spec: CoupledSegmentSpec,
+        pathfinder: CoupledPathfinder,
+        guide: Route,
+        raw_guide: Route,
+        guide_was_simplified: bool,
+        spacing_cells: int,
+        swap_roles: bool,
+    ) -> tuple[Route, Route] | None:
+        """Body of :meth:`_shadow_route_pair` (split out for issue #4575).
+
+        Separated ONLY so the caller can arm ``_shadow_foreign_copper``
+        around the whole construction without re-indenting it; the guide has
+        already been simplified (or not) by the caller.
+        """
+        grid = self.autorouter.grid
+        rules = self.autorouter.rules
         if swap_roles:
             shadow_start, shadow_end = spec.p_start, spec.p_end
         else:
@@ -8106,6 +8585,38 @@ class DiffPairRouter:
                     f"{pair.name}; trying other side"
                 )
                 self._last_shadow_decline_reason = "pad-clearance"  # #4571
+                continue
+            # Issue #4575 (fourth pass): FOREIGN-VIA clearance self-check, the
+            # quadrant adjacent to #4571's.  ``_pair_has_physical_overlap``
+            # above does look at barrels, but only at the bodies-intersect
+            # threshold (``via_r + seg_w/2``, no clearance term) -- so a
+            # constructed leg passing 0.090 mm from the partner's barrel is
+            # "clean" to it and is then reported by ``clearance_segment_via``
+            # at 0.102 mm (board-06 seed 42, USB3_TX1+ vs USB3_TX1-).  The
+            # exact predicates close it here, at the same failover point.
+            #
+            # Both directions of the P/N interaction are covered by measuring
+            # the CONSTRUCTED leg alone, because the guide is registered as
+            # foreign copper: shadow segments vs guide barrels, and shadow
+            # barrels vs guide segments/barrels.  The guide leg is never gated
+            # against THIRD-PARTY copper (the #4571 rationale above).
+            #
+            # The universe is re-armed on ``guide_route_obj`` -- the FINAL
+            # guide geometry -- rather than reusing the ambient snapshot: the
+            # #4570 via mirror and the #4553 length matcher both mutate the
+            # guide leg after that snapshot was taken, and it was exactly one
+            # of those late guide-leg meander teeth that grazed the shadow's
+            # landing barrel at 0.090 mm on board-06 seed 42.
+            with self._shadow_foreign_copper(guide_route_obj):
+                via_deficit, via_loc = self._route_via_violation(shadow_route)
+            if via_deficit > _SHADOW_VIA_DEFICIT_EPS:
+                loc_str = f" near ({via_loc[0]:.3f}, {via_loc[1]:.3f})" if via_loc else ""
+                print(
+                    f"    [coupled-shadow] side={side:+.0f} foreign-via "
+                    f"clearance deficit {via_deficit:.3f}mm{loc_str} for "
+                    f"{pair.name}; trying other side"
+                )
+                self._last_shadow_decline_reason = "via-clearance"  # #4575
                 continue
             if not via_symmetric:
                 # Issue #4570: this side is otherwise legal but its two legs

--- a/src/kicad_tools/router/via_clearance.py
+++ b/src/kicad_tools/router/via_clearance.py
@@ -451,6 +451,61 @@ class _ViaLike(Protocol):
     # ``layers`` is a 2-tuple whose elements expose ``.value``.
 
 
+def segment_via_deficit(
+    seg: _SegmentLike,
+    via: _ViaLike,
+    trace_clearance: float,
+    hard_intersection_only: bool = False,
+) -> float:
+    """Signed clearance deficit of a segment against a foreign-net via.
+
+    Issue #4575.  The DEFICIT form of :func:`segment_clears_foreign_via`:
+    returns ``required - actual`` in mm, so ``> 0`` is a violation whose
+    magnitude is exactly how much clearance is missing and ``<= 0`` is
+    clean.  This is the same sign convention
+    :meth:`kicad_tools.router.grid.RoutingGrid.worst_via_segment_deficit`
+    and :meth:`~kicad_tools.router.grid.RoutingGrid.worst_segment_pad_deficit`
+    use, so a gate built on it can report "0.012 mm short" the way the DRC
+    finding does rather than only "bad".
+
+    Split out of the boolean predicate (which now delegates here) so a
+    caller that needs the magnitude -- the diff-pair shadow constructor's
+    segment-vs-via gate -- cannot drift from the predicate's threshold
+    arithmetic.  This is the #4571 ``_span_pad_deficit`` /
+    ``worst_segment_pad_deficit`` split applied to the via quadrant.
+
+    Layer-awareness is inherited: a via that does not span the segment's
+    layer returns ``-inf`` (infinitely clear), never a small negative that
+    a ``max()`` accumulation could mistake for a near-miss.
+
+    Same-net filtering remains the CALLER's responsibility, as it is for
+    :func:`segment_clears_foreign_via`.
+
+    Args:
+        seg: The candidate segment.  Reads ``x1/y1/x2/y2/width/layer``.
+        via: A foreign-net via to measure against.  Reads
+            ``x/y/diameter/layers``.
+        trace_clearance: Manufacturer minimum copper-to-copper clearance
+            in mm (use ``via_clearance`` for the via-vs-via-barrel
+            direction, matching ``worst_via_segment_deficit``).
+        hard_intersection_only: When True, drop ``trace_clearance`` from
+            the threshold -- the physical-overlap-only bound.
+
+    Returns:
+        ``required - dist`` where ``required = via.diameter/2 +
+        seg.width/2 (+ trace_clearance)``.
+    """
+    v_lo = min(via.layers[0].value, via.layers[1].value)
+    v_hi = max(via.layers[0].value, via.layers[1].value)
+    if not (v_lo <= seg.layer.value <= v_hi):
+        return -math.inf  # Via doesn't reach the segment's layer.
+    dist = point_to_segment_distance(via.x, via.y, seg.x1, seg.y1, seg.x2, seg.y2)
+    required = via.diameter / 2 + seg.width / 2
+    if not hard_intersection_only:
+        required += trace_clearance
+    return required - dist
+
+
 def segment_clears_foreign_via(
     seg: _SegmentLike,
     via: _ViaLike,
@@ -517,19 +572,20 @@ def segment_clears_foreign_via(
     Returns:
         True if the segment clears the via, False on violation.
     """
-    # Layer overlap check: vias span layers[0]..layers[1] inclusive.
-    v_lo = min(via.layers[0].value, via.layers[1].value)
-    v_hi = max(via.layers[0].value, via.layers[1].value)
-    if not (v_lo <= seg.layer.value <= v_hi):
-        return True  # Via doesn't reach the segment's layer.
-
-    dist = point_to_segment_distance(via.x, via.y, seg.x1, seg.y1, seg.x2, seg.y2)
-    required = via.diameter / 2 + seg.width / 2
-    if not hard_intersection_only:
-        required += trace_clearance
+    # Layer overlap, distance and threshold all live in
+    # ``segment_via_deficit`` (issue #4575) so the boolean predicate and
+    # the magnitude-reporting gate can never disagree.  A via that does
+    # not span the segment's layer yields ``-inf`` there, which satisfies
+    # the comparison below exactly as the old early ``return True`` did.
+    #
     # 1e-9 epsilon mirrors ``point_clear_of_copper``'s convention so a
     # segment exactly at the clearance threshold is admitted.
-    return dist >= required - 1e-9
+    return (
+        segment_via_deficit(
+            seg, via, trace_clearance, hard_intersection_only=hard_intersection_only
+        )
+        <= 1e-9
+    )
 
 
 def via_clears_foreign_segment(

--- a/tests/test_diffpair_shadow.py
+++ b/tests/test_diffpair_shadow.py
@@ -1446,6 +1446,30 @@ def _shadow_setup(spacing_cells: int, bend_end: tuple[float, float]):
     return dpr, pair, spec, pathfinder, guide
 
 
+def _defeat_pair_self_check_gates(mp) -> None:
+    """Stub off BOTH constructed-pair copper self-checks (issue #4575).
+
+    The fixtures below deliberately drive the constructor with DEGENERATE
+    geometry -- a 0.4 mm coupled gap alongside a 0.7 mm-diameter guide via,
+    or a stub tail that drops a 0.6 mm via straight onto the body anchor --
+    so that the single property under test is observable in what the
+    constructor COMMITS rather than being masked by a blanket decline.  That
+    geometry PHYSICALLY overlaps the partner (0.40 mm centre-to-centre
+    against a 0.45 mm overlap threshold), which is why
+    ``_pair_has_physical_overlap`` has always been stubbed off here.
+
+    ``_route_via_violation`` is the CLEARANCE sibling of that same overlap
+    check -- it fires on exactly the same geometry, one quadrant over -- so
+    it is stubbed off alongside it.  Leaving it armed would turn every one of
+    these fixtures into a test of the #4575 gate instead of the property it
+    was written for.
+    """
+    from kicad_tools.router.diffpair_routing import DiffPairRouter
+
+    mp.setattr(DiffPairRouter, "_pair_has_physical_overlap", lambda self, p, n: False, raising=True)
+    mp.setattr(DiffPairRouter, "_route_via_violation", lambda self, r: (0.0, None), raising=True)
+
+
 def _stub_tail_route(
     self, _pf, head, goal, _layer, _label, _name, partner_segments=None, prefer_planar=False
 ):
@@ -1508,12 +1532,10 @@ def test_shadow_via_clears_partner_at_tight_gap(monkeypatch):
     )
 
     monkeypatch.setattr(DiffPairRouter, "_tail_route", _stub_tail_route, raising=True)
-    # Defeat the belt-and-braces overlap gate so we observe the via the
+    # Defeat the belt-and-braces copper self-checks so we observe the via the
     # constructor PRODUCES (the fix must clear the guide by construction,
     # not merely fail the side over to a reject-everything None).
-    monkeypatch.setattr(
-        DiffPairRouter, "_pair_has_physical_overlap", lambda self, p, n: False, raising=True
-    )
+    _defeat_pair_self_check_gates(monkeypatch)
 
     result = dpr._shadow_route_pair(pair, spec, pathfinder, guide, spacing_cells)
     assert result is not None, "shadow constructor should place a clearing via, not give up"
@@ -1567,13 +1589,11 @@ def test_shadow_via_guard_is_load_bearing(monkeypatch):
                 spacing_cells, bend_end=_SHADOW_VIA_GUARD_BEND_END
             )
             mp.setattr(DiffPairRouter, "_tail_route", _stub_tail_route, raising=True)
-            # Stub OFF the belt-and-braces overlap gate in both runs: it is the
-            # production backstop, but here we are isolating the GUARD's effect,
-            # so what the constructor COMMITS (clean vs short) must be the
-            # guard's doing, not the gate's.
-            mp.setattr(
-                DiffPairRouter, "_pair_has_physical_overlap", lambda self, p, n: False, raising=True
-            )
+            # Stub OFF the belt-and-braces copper self-checks in both runs:
+            # they are the production backstop, but here we are isolating the
+            # GUARD's effect, so what the constructor COMMITS (clean vs short)
+            # must be the guard's doing, not the gates'.
+            _defeat_pair_self_check_gates(mp)
             if disable_guard:
                 # ``_min_distance_to_partner`` is called in exactly one place
                 # inside ``_shadow_route_pair`` -- the #3541 via-vs-guide guard.
@@ -2676,6 +2696,386 @@ def test_close_shadow_chain_refuses_a_connector_through_a_pad_halo():
 
 
 # ---------------------------------------------------------------------------
+# 14. exact foreign-VIA clearance gate for constructed copper (issue #4575)
+# ---------------------------------------------------------------------------
+#
+# The quadrant adjacent to #4571's.  The constructor's only via-aware copper
+# self-check is ``_pair_has_physical_overlap``, and it is an OVERLAP detector:
+# ``via.diameter/2 + seg.width/2``, no clearance term.  Worse, the partner
+# universe every tail screen receives is ``list(guide.segments)`` -- the
+# guide's VIAS are not in it at all.  So a constructed leg passing 0.090 mm
+# from the partner leg's barrel is accepted by every construction-time gate and
+# then reported by ``clearance_segment_via`` at the 0.102 mm board minimum
+# (measured on board-06 shadow-ON seed 42: USB3_TX1+ copper vs a USB3_TX1-
+# barrel).  A diff-pair net is excluded from ``drc_verify_and_nudge`` (#3508),
+# so nothing downstream repairs it.
+#
+# THE VACUITY TRAP these tests pin: ``ClearanceRule`` exempts a declared diff
+# pair from the generic clearance check ONLY when both elements are SEGMENTS,
+# so a segment-vs-via pair between P and N is checked at the FULL board
+# minimum.  A gate built on the intra-pair relaxation would be strictly looser
+# than the checker and could never fire on the finding it exists to close.
+
+
+def _via_gate_via(x, y, net, name, diameter=0.7, layers=(Layer.F_CU, Layer.B_CU)):
+    from kicad_tools.router.primitives import Via
+
+    return Via(
+        x=x,
+        y=y,
+        drill=0.35,
+        diameter=diameter,
+        layers=layers,
+        net=net,
+        net_name=name,
+    )
+
+
+def _via_gate_seg(x1, y1, x2, y2, net=7, name="USB3_TX1+", width=0.2, layer=Layer.F_CU):
+    return Segment(x1=x1, y1=y1, x2=x2, y2=y2, width=width, layer=layer, net=net, net_name=name)
+
+
+# Geometry used throughout this section.  A 0.7 mm via reads as a 0.35 mm
+# barrel radius, a 0.2 mm trace contributes 0.1 mm of half-width, and the
+# default manufacturer clearance is 0.2 mm.  So:
+#   * copper physically INTERSECTS below 0.45 mm centre-to-centre, and
+#   * the DRC requires 0.65 mm.
+# A centreline 0.55 mm away is therefore NON-overlapping (the overlap gate
+# accepts it) yet 0.10 mm short of clearance -- the exact regime the board-06
+# 0.090 mm finding lives in.
+_BARREL_GAP = 0.55
+_BARREL_DEFICIT = 0.10
+_BARREL_OVERLAP_BOUND = 0.45
+
+
+def test_segment_via_gate_rejects_a_subclearance_nonoverlapping_barrel_gap():
+    """AC-5: the gate fires exactly where the overlap detector cannot.
+
+    The two legs are a declared diff pair, the barrel belongs to the PARTNER,
+    and the copper does not intersect -- so ``_pair_has_physical_overlap``
+    (the only pre-#4575 via-aware self-check) accepts it.  The exact
+    ``clearance_segment_via`` predicate does not.
+    """
+    from kicad_tools.router.via_clearance import segment_clears_foreign_via
+
+    dpr = _pad_gate_router()
+    rules = dpr.autorouter.rules
+
+    partner = Route(net=8, net_name="USB3_TX1-")
+    partner.vias.append(_via_gate_via(5.0, 5.0, net=8, name="USB3_TX1-"))
+    shadow = Route(net=7, net_name="USB3_TX1+")
+    seg = _via_gate_seg(3.0, 5.0 + _BARREL_GAP, 7.0, 5.0 + _BARREL_GAP)
+    shadow.segments.append(seg)
+
+    # Sanity: this is the non-overlapping-but-sub-clearance regime.
+    assert _BARREL_OVERLAP_BOUND < _BARREL_GAP < _BARREL_OVERLAP_BOUND + rules.trace_clearance
+    assert dpr._pair_has_physical_overlap(partner, shadow) is False
+    assert segment_clears_foreign_via(seg, partner.vias[0], rules.trace_clearance) is False
+
+    with dpr._shadow_foreign_copper(partner):
+        deficit, loc = dpr._route_via_violation(shadow)
+    assert deficit == pytest.approx(_BARREL_DEFICIT, abs=1e-9)
+    assert loc == (5.0, 5.0)
+
+
+def test_via_gate_threshold_is_the_inter_net_clearance_not_the_intra_pair_one():
+    """AC-5 (the vacuity trap), stated as arithmetic.
+
+    ``DiffPairClearanceIntraRule``'s per-class threshold is deliberately
+    TIGHTER than the manufacturer clearance, and ``ClearanceRule``'s diff-pair
+    exemption covers segment-to-SEGMENT edges only.  Measuring this quadrant
+    against the intra-pair bound would therefore produce a gate that passes
+    the very geometry the DRC reports.
+    """
+    from kicad_tools.router.via_clearance import segment_via_deficit
+
+    dpr = _pad_gate_router()
+    rules = dpr.autorouter.rules
+    via = _via_gate_via(5.0, 5.0, net=8, name="USB3_TX1-")
+    seg = _via_gate_seg(3.0, 5.0 + _BARREL_GAP, 7.0, 5.0 + _BARREL_GAP)
+
+    intra_pair = 0.08  # a representative per-class intra-pair clearance
+    assert intra_pair < rules.trace_clearance
+    # The trap: at the relaxed bound this geometry reads CLEAN ...
+    assert segment_via_deficit(seg, via, intra_pair) < 0.0
+    # ... while the threshold the checker actually applies reports the deficit.
+    assert segment_via_deficit(seg, via, rules.trace_clearance) == pytest.approx(
+        _BARREL_DEFICIT, abs=1e-9
+    )
+
+
+def test_segment_via_deficit_agrees_with_the_boolean_predicate():
+    """Drift guard: the gate and ``segment_clears_foreign_via`` are one formula."""
+    from kicad_tools.router.via_clearance import segment_clears_foreign_via, segment_via_deficit
+
+    via = _via_gate_via(5.0, 5.0, net=8, name="USB3_TX1-")
+    for dy in (0.30, 0.44, 0.45, 0.55, 0.6499, 0.65, 0.80):
+        seg = _via_gate_seg(3.0, 5.0 + dy, 7.0, 5.0 + dy)
+        clear = segment_clears_foreign_via(seg, via, 0.2)
+        assert clear == (segment_via_deficit(seg, via, 0.2) <= 1e-9), dy
+
+
+def test_via_gate_ignores_the_segments_own_net_via():
+    """A tail MUST still be able to land on (and run into) its own net's via."""
+    dpr = _pad_gate_router()
+
+    own = Route(net=7, net_name="USB3_TX1+")
+    own.vias.append(_via_gate_via(5.0, 5.0, net=7, name="USB3_TX1+"))
+    shadow = Route(net=7, net_name="USB3_TX1+")
+    shadow.segments.append(_via_gate_seg(3.0, 5.0, 7.0, 5.0))  # straight through it
+
+    with dpr._shadow_foreign_copper(own):
+        assert dpr._route_via_violation(shadow)[0] == 0.0
+
+
+def test_partner_via_on_a_shared_connector_ref_is_still_measured():
+    """AC-6: ``exclude_net`` only -- no ``exclude_refs`` carve-out (#3545).
+
+    Diff-pair P and N legs routinely land on the same fine-pitch connector
+    ``ref`` (board-06's FFC carries both MIPI_CLK+ and MIPI_CLK-).  The #3545
+    same-component carve-out that the single-ended backstop applies would
+    exempt the partner's copper on exactly the connectors this gate exists
+    for, so the gate must never consult a ref at all.
+    """
+    dpr = _pad_gate_router()
+    grid = dpr.autorouter.grid
+    grid.add_pad(_pad_at(5.0, 5.0, net=8, name="MIPI_CLK+", ref="J1", pin="1"))
+    grid.add_pad(_pad_at(5.4, 5.0, net=7, name="MIPI_CLK-", ref="J1", pin="2"))
+    assert grid._component_is_fine_pitch("J1") is True
+
+    partner = Route(net=8, net_name="MIPI_CLK+")
+    partner.vias.append(_via_gate_via(5.0, 5.0, net=8, name="MIPI_CLK+"))
+    shadow = Route(net=7, net_name="MIPI_CLK-")
+    shadow.segments.append(
+        _via_gate_seg(3.0, 5.0 + _BARREL_GAP, 7.0, 5.0 + _BARREL_GAP, net=7, name="MIPI_CLK-")
+    )
+
+    with dpr._shadow_foreign_copper(partner):
+        assert dpr._route_via_violation(shadow)[0] == pytest.approx(_BARREL_DEFICIT, abs=1e-9)
+
+
+def test_segment_endpoint_colocated_with_a_foreign_via_is_not_flagged():
+    """AC-7: mirror ``ClearanceRule``'s #2706 in-pad-escape carve-out.
+
+    The router's in-pad escape places segment endpoints EXACTLY at via
+    centres, and the DRC skips such pairs.  A gate without the carve-out
+    would be STRICTER than the checker and decline sides over geometry that
+    is never reported -- pure reach loss for zero DRC gain.
+    """
+    dpr = _pad_gate_router()
+
+    foreign = Route(net=99, net_name="OTHER")
+    foreign.vias.append(_via_gate_via(5.0, 5.0, net=99, name="OTHER"))
+    shadow = Route(net=7, net_name="USB3_TX1+")
+    shadow.segments.append(_via_gate_seg(5.0, 5.0, 8.0, 5.0))  # endpoint ON the via centre
+
+    with dpr._shadow_foreign_copper(foreign):
+        assert dpr._route_via_violation(shadow)[0] == 0.0
+
+    # One quantum away from the carve-out epsilon the copper IS measured.
+    moved = Route(net=7, net_name="USB3_TX1+")
+    moved.segments.append(_via_gate_seg(5.01, 5.0, 8.0, 5.0))
+    with dpr._shadow_foreign_copper(foreign):
+        assert dpr._route_via_violation(moved)[0] > 0.0
+
+
+def test_blind_via_that_does_not_span_the_segments_layer_is_not_flagged():
+    """Layer-span awareness: a barrel is only copper where it actually runs."""
+    dpr = _pad_gate_router()
+
+    shadow = Route(net=7, net_name="USB3_TX1+")
+    shadow.segments.append(
+        _via_gate_seg(3.0, 5.0 + _BARREL_GAP, 7.0, 5.0 + _BARREL_GAP, layer=Layer.F_CU)
+    )
+
+    blind = Route(net=99, net_name="OTHER")
+    blind.vias.append(
+        _via_gate_via(5.0, 5.0, net=99, name="OTHER", layers=(Layer.B_CU, Layer.B_CU))
+    )
+    with dpr._shadow_foreign_copper(blind):
+        assert dpr._route_via_violation(shadow)[0] == 0.0
+
+    # Positive control: the SAME site as a through via does span F.Cu.
+    through = Route(net=99, net_name="OTHER")
+    through.vias.append(_via_gate_via(5.0, 5.0, net=99, name="OTHER"))
+    with dpr._shadow_foreign_copper(through):
+        assert dpr._route_via_violation(shadow)[0] == pytest.approx(_BARREL_DEFICIT, abs=1e-9)
+
+
+def test_via_gate_measures_the_via_vs_via_quadrant_too():
+    """A constructed BARREL must clear a foreign barrel at ``via_clearance``."""
+    dpr = _pad_gate_router()
+    rules = dpr.autorouter.rules
+    bound = rules.via_diameter + rules.via_clearance  # centre-to-centre
+
+    foreign = Route(net=99, net_name="OTHER")
+    foreign.vias.append(_via_gate_via(5.0, 5.0, net=99, name="OTHER"))
+
+    clean = Route(net=7, net_name="USB3_TX1+")
+    clean.vias.append(_via_gate_via(5.0 + bound, 5.0, net=7, name="USB3_TX1+"))
+    grazing = Route(net=7, net_name="USB3_TX1+")
+    grazing.vias.append(_via_gate_via(5.0 + bound - 0.05, 5.0, net=7, name="USB3_TX1+"))
+
+    with dpr._shadow_foreign_copper(foreign):
+        assert dpr._route_via_violation(clean)[0] == pytest.approx(0.0, abs=1e-9)
+        deficit, loc = dpr._route_via_violation(grazing)
+    assert deficit == pytest.approx(0.05, abs=1e-9)
+    assert loc == (5.0, 5.0)
+
+
+def test_via_gate_measures_a_constructed_barrel_against_foreign_segments():
+    """The mirror direction: shadow BARREL vs the partner's trace."""
+    dpr = _pad_gate_router()
+    rules = dpr.autorouter.rules
+    bound = rules.via_diameter / 2 + 0.1 + rules.via_clearance
+
+    partner = Route(net=8, net_name="USB3_TX1-")
+    partner.segments.append(_via_gate_seg(0.0, 5.0, 10.0, 5.0, net=8, name="USB3_TX1-"))
+    shadow = Route(net=7, net_name="USB3_TX1+")
+    shadow.vias.append(_via_gate_via(5.0, 5.0 + bound - 0.05, net=7, name="USB3_TX1+"))
+
+    with dpr._shadow_foreign_copper(partner):
+        assert dpr._route_via_violation(shadow)[0] == pytest.approx(0.05, abs=1e-9)
+
+
+def test_via_gate_is_a_no_op_when_disarmed():
+    """AC-8: outside a ``_shadow_route_pair`` call the gate does not exist.
+
+    This is what keeps the shadow-construction-OFF path (and every ordinary,
+    non-shadow ``_tail_route`` call) byte-identical.
+    """
+    dpr = _pad_gate_router()
+    shadow = Route(net=7, net_name="USB3_TX1+")
+    shadow.segments.append(_via_gate_seg(3.0, 5.0, 7.0, 5.0))
+    shadow.vias.append(_via_gate_via(5.0, 5.0, net=7, name="USB3_TX1+"))
+
+    partner = Route(net=8, net_name="USB3_TX1-")
+    partner.vias.append(_via_gate_via(5.0, 5.0 + _BARREL_GAP, net=8, name="USB3_TX1-"))
+
+    assert dpr._shadow_foreign_universe is None
+    assert dpr._route_via_violation(shadow) == (0.0, None)
+    assert dpr._span_via_clear(3.0, 5.0, 7.0, 5.0, 0, 7, 0.2) is True
+    # ... and it is restored to inert after an armed block, including nesting.
+    with dpr._shadow_foreign_copper(partner):
+        assert dpr._route_via_violation(shadow)[0] > 0.0
+        with dpr._shadow_foreign_copper(Route(net=8, net_name="P")):
+            assert dpr._route_via_violation(shadow) == (0.0, None)
+        assert dpr._route_via_violation(shadow)[0] > 0.0
+    assert dpr._shadow_foreign_universe is None
+    assert dpr._route_via_violation(shadow) == (0.0, None)
+
+
+def test_sibling_leg_copper_is_only_visible_inside_the_extended_universe():
+    """The board-06 residual's actual shape: LATE guide-leg copper.
+
+    The #4553 length matcher and the #4570 via mirror both mutate ONE leg
+    after the other leg is already built, and that sibling leg is in neither
+    the committed route list nor the pre-assembly guide.  So the ambient
+    universe cannot see its barrels; ``_shadow_foreign_copper_extended`` is
+    what makes the meander-tooth / z-jog screens see them.
+    """
+    dpr = _pad_gate_router()
+
+    guide = Route(net=8, net_name="USB3_TX1-")
+    guide.segments.append(_via_gate_seg(0.0, 5.0, 10.0, 5.0, net=8, name="USB3_TX1-"))
+    sibling = Route(net=8, net_name="USB3_TX1-")
+    sibling.vias.append(_via_gate_via(5.0, 5.0 + _BARREL_GAP, net=8, name="USB3_TX1-"))
+    tooth = Route(net=7, net_name="USB3_TX1+")
+    tooth.segments.append(_via_gate_seg(3.0, 5.0 + 2 * _BARREL_GAP, 7.0, 5.0 + 2 * _BARREL_GAP))
+
+    with dpr._shadow_foreign_copper(guide):
+        # Blind: the sibling leg's barrel is nowhere in the universe.
+        assert dpr._route_via_violation(tooth)[0] == 0.0
+        with dpr._shadow_foreign_copper_extended(sibling):
+            assert dpr._route_via_violation(tooth)[0] == pytest.approx(_BARREL_DEFICIT, abs=1e-9)
+        # ... and the widening is scoped.
+        assert dpr._route_via_violation(tooth)[0] == 0.0
+    # Disarmed, the extension is a no-op rather than an implicit arming.
+    with dpr._shadow_foreign_copper_extended(sibling):
+        assert dpr._shadow_foreign_universe is None
+        assert dpr._route_via_violation(tooth)[0] == 0.0
+
+
+def test_pair_with_no_vias_anywhere_is_completely_unaffected():
+    """The gate is a no-op for a via-free pair -- no cost, no behaviour change."""
+    dpr = _pad_gate_router()
+    partner = Route(net=8, net_name="USB3_TX1-")
+    partner.segments.append(_via_gate_seg(0.0, 5.0, 10.0, 5.0, net=8, name="USB3_TX1-"))
+    shadow = Route(net=7, net_name="USB3_TX1+")
+    shadow.segments.append(_via_gate_seg(0.0, 5.2, 10.0, 5.2))
+
+    with dpr._shadow_foreign_copper(partner):
+        assert dpr._route_via_violation(shadow) == (0.0, None)
+
+
+def test_synthesize_tail_detours_around_a_partner_via_the_raster_cannot_see():
+    """The REPAIR half of the fix: a grazing candidate loses to a later one.
+
+    The partner guide is never in the routing grid, so ``_AllClearPathfinder``
+    (which blocks nothing) is a faithful stand-in.  With the gate disarmed the
+    direct candidate wins and ships copper straight through the partner's
+    barrel; with it armed the synthesizer detours instead of declining.
+    """
+    dpr = _pad_gate_router()
+    head, goal = _tail_pads((5.0, 5.0), (8.0, 5.0))
+    partner = Route(net=99, net_name="OTHER")
+    partner.vias.append(_via_gate_via(6.5, 5.0, net=99, name="OTHER"))
+
+    # Disarmed: unchanged pre-#4575 behaviour -- the direct candidate wins.
+    plain = dpr._synthesize_tail(_AllClearPathfinder(), head, goal, 0)
+    assert plain is not None and len(plain.segments) == 1
+
+    with dpr._shadow_foreign_copper(partner):
+        tail = dpr._synthesize_tail(_AllClearPathfinder(), head, goal, 0)
+        assert tail is not None, "a legal detour exists; the synthesizer must find it"
+        assert len(tail.segments) > 1, "the direct candidate runs through the barrel"
+        assert dpr._route_via_violation(tail)[0] == 0.0
+    # Still lands exactly on the pads it was asked to connect.
+    assert (tail.segments[0].x1, tail.segments[0].y1) == (5.0, 5.0)
+    assert (tail.segments[-1].x2, tail.segments[-1].y2) == (8.0, 5.0)
+
+
+def test_shadow_pair_declines_a_side_on_foreign_via_clearance(monkeypatch):
+    """The FAILOVER half: a violating side loses to the other offset side.
+
+    The guide (partner) carries a barrel 0.55 mm off the ``side=+1`` offset
+    line.  It is not in the routing grid (the guide never is, so the
+    constructor's raster cannot see it), it is not a pad (#4571's gate cannot
+    see it), and at 0.55 mm the copper does not intersect
+    (``_pair_has_physical_overlap``'s bound is 0.45 mm, so it cannot see it
+    either) -- only the exact ``clearance_segment_via`` predicate can.  The
+    side is declined with a distinct reason and ``side=-1`` ships instead.
+
+    The #4570 via-signature gate is switched off for the duration: a
+    single-via guide is deliberately asymmetric, and its ``via-skew`` decline
+    reason would otherwise mask the one under test.
+    """
+    import kicad_tools.router.diffpair_routing as dpr_mod
+    from kicad_tools.router.diffpair_routing import DiffPairRouter
+
+    monkeypatch.setattr(dpr_mod, "_SHADOW_VIA_SYMMETRY", False, raising=True)
+
+    spacing_cells = 4
+    dpr, pair, spec, pathfinder, _ = _shadow_setup(spacing_cells, bend_end=(11.0, 7.7))
+    guide = _planar_guide(spec.p_start)  # straight F.Cu run at y = 4.8
+    # side=+1 offsets the shadow to y = 5.2; put the partner's barrel in the
+    # sub-clearance-but-non-overlapping band above it.
+    guide.vias.append(
+        _via_gate_via(15.0, 5.2 + _BARREL_GAP, net=spec.p_start.net, name=spec.p_start.net_name)
+    )
+    monkeypatch.setattr(DiffPairRouter, "_tail_route", _stub_tail_route_planar, raising=True)
+
+    result = dpr._shadow_route_pair(pair, spec, pathfinder, guide, spacing_cells)
+
+    assert result is not None, "the other offset side is legal; the pair must still ship"
+    assert dpr._last_shadow_decline_reason == "via-clearance"
+    _p_route, n_route = result
+    assert n_route.segments, "the shadow leg must carry copper"
+    for seg in n_route.segments:
+        assert seg.y1 < 4.8 and seg.y2 < 4.8, "the surviving side is the one away from the barrel"
+
+
+# ---------------------------------------------------------------------------
 # Issue #4572: coupling-aware landing-tail synthesis
 # ---------------------------------------------------------------------------
 # The shadow constructor trims the coupled body at both ends and reconnects to
@@ -3418,9 +3818,7 @@ def _run_shadow_with_tails(monkeypatch, tail_stub):
     dpr, pair, spec, pathfinder, _ = _shadow_setup(spacing_cells, bend_end=(11.0, 7.7))
     guide = _planar_guide(spec.p_start)
     monkeypatch.setattr(DiffPairRouter, "_tail_route", tail_stub, raising=True)
-    monkeypatch.setattr(
-        DiffPairRouter, "_pair_has_physical_overlap", lambda self, p, n: False, raising=True
-    )
+    _defeat_pair_self_check_gates(monkeypatch)
     result = dpr._shadow_route_pair(pair, spec, pathfinder, guide, spacing_cells)
     return dpr, result
 
@@ -3489,9 +3887,7 @@ def test_symmetric_side_beats_an_asymmetric_one(monkeypatch):
         return stub(self, _pf, head, goal, _layer, _label, _name, partner_segments)
 
     monkeypatch.setattr(DiffPairRouter, "_tail_route", _tail, raising=True)
-    monkeypatch.setattr(
-        DiffPairRouter, "_pair_has_physical_overlap", lambda self, p, n: False, raising=True
-    )
+    _defeat_pair_self_check_gates(monkeypatch)
     spacing_cells = 4
     dpr, pair, spec, pathfinder, _ = _shadow_setup(spacing_cells, bend_end=(11.0, 7.7))
     guide = _planar_guide(spec.p_start)


### PR DESCRIPTION
## Summary

The shadow constructor had no clearance-aware gate for the **segment-vs-via**
quadrant. Its only via-aware copper self-check, `_pair_has_physical_overlap`,
measures at the *bodies-intersect* threshold (`via_r + seg_w/2`, no clearance
term), and the partner universe handed to every tail screen is
`partner_segs = list(guide.segments)` — **containing no vias at all**. So a
constructed leg passing 0.090 mm from the partner leg's barrel cleared every
construction-time gate and was then reported by `clearance_segment_via` at the
0.102 mm board minimum. A diff-pair net is excluded from `drc_verify_and_nudge`
(#3508), so nothing downstream repaired it.

This adds the exact `clearance_segment_via` / via-vs-via predicate at both
levels #4571 used for the pad quadrant — a **per-candidate screen** inside tail
synthesis (a repair: the grazing candidate loses to a later one) and a
**post-assembly failover gate** with a new `"via-clearance"` decline reason.
Measured on board-06 shadow-ON seed 42: `clearance_segment_via` **1 → 0**, with
reach, `coupled-ok` and every other rule count unchanged.

## Root cause (sharper than the issue's original text)

The board-06 residual is **intra-pair**, and the offending copper is created
*late*, by the constructor itself:

* `USB3_TX1-` is the shadow leg and carries 2 vias; `USB3_TX1+` is the guide and
  carries 0 (the `[coupled-shadow] via-signature mismatch … guide=(0, 0)
  shadow=(2, 2)` line), so the pair ships through #4570's `asym_fallback`.
* The offending segment is a **guide-leg meander tooth** added by #4553's
  `_length_match_constructed_pair` *after* the shadow's landing via already
  exists. The tooth screen (`_tooth_ok`) is displaced "away from the partner's
  *segments*" and says nothing about the partner's **barrels**.
* `ClearanceRule` exempts a declared diff pair only when **both** elements are
  segments (`validate/rules/clearance.py:994-1005`), so a P/N segment-vs-via
  pair is checked at the full board minimum — which is why 0.090 mm against
  0.102 mm is reported for two nets of the same pair.

Four leak paths, all closed by one mechanism:

1. `diffpair_routing.py:7781` `partner_segs = list(guide.segments)` — no vias in
   the tail-screen partner universe.
2. `_tail_partner_clear`'s non-strict barrel bound drops the clearance term, and
   the last-resort caller passes `clearance=0.0`.
3. The length matcher's teeth and #4570's z-jog mirror run *outside* the tail
   screens, against a leg the ambient universe does not contain.
4. Third-party barrels are raster-only, and the raster halo is shrunk in
   fine-pitch corridors.

## Changes

**`src/kicad_tools/router/via_clearance.py`**
* New pure-geometry `segment_via_deficit(seg, via, clearance,
  hard_intersection_only=False) -> float` returning `required - actual`
  (`> 0` = violation), next to the existing predicates.
* `segment_clears_foreign_via` now **delegates** to it, so the gate and the
  predicate can never drift (the #4571 `_span_pad_deficit` /
  `worst_segment_pad_deficit` split, applied to the via quadrant). Behaviour is
  bit-identical: layer mismatch yields `-inf`, which satisfies the same `<= 1e-9`
  comparison the old early `return True` did.

**`src/kicad_tools/router/diffpair_routing.py`**
* `_shadow_foreign_copper(*partners)` — a context manager that arms an **ambient**
  foreign-copper universe for exactly one `_shadow_route_pair` call: the board's
  committed `autorouter.routes` (the authoritative list, *not* `grid.routes` —
  the #3486 stale-universe warning) **plus** the partner leg, which is never in
  the grid. `_shadow_foreign_copper_extended(*extra)` widens it scoped-ly with the
  pair's *other constructed leg* for the late one-leg-at-a-time mutations.
* Deficit primitives: `_segment_via_deficit` (seg vs foreign barrels, at
  `rules.trace_clearance`), `_via_copper_deficit` (barrel vs foreign
  segments/barrels, at `rules.via_clearance`), `_span_via_deficit` /
  `_span_via_clear`, `_route_via_violation` / `_route_via_clear`.
* Per-candidate **screens** (repairs) at every site that already carries the
  #4571 pad screen: `_synthesize_tail`'s candidate loop, `_spans_are_legal`
  (the follow-tail chokepoint), `_synthesize_crossing_tail`'s assembled
  crossover, `_planar_tail_probe` (`why="via-deficit"`), `_fallback_tail_route`'s
  `_pad_ok` → `_copper_ok`, `_mirror_z_jog`'s jog vias + relocated stretch,
  `_meander_route_to_length`'s `_tooth_ok`, `_close_shadow_chain`'s repair
  connector, and `_quantize_shadow_segments`' dogleg legs.
* Post-assembly **gate** in `_shadow_route_pair`, immediately after the #4571 pad
  gate and before the `via_symmetric` / `asym_fallback` branch, with decline
  reason `"via-clearance"`. It re-arms the universe on the **final**
  `guide_route_obj` so late guide-leg copper is measured.
* `_shadow_route_pair` split into a thin arming wrapper + `_shadow_route_pair_body`
  purely so the `with` block wraps the construction without re-indenting 800 lines.
* Observability (#4459 style): `_shadow_via_gate_rejections` counts per-candidate
  rejections and prints one line per pair when non-zero.

**Conventions carried over unchanged**
* `_SHADOW_VIA_DEFICIT_EPS = _SHADOW_PAD_DEFICIT_EPS` (`1e-4`, `DRC_TOLERANCE`).
* **`exclude_net` only**, applied per element at query time. No `exclude_refs`
  anywhere — the #3545 same-component carve-out would exempt the partner's barrel
  on exactly the fine-pitch connectors this gate exists for.
* `_SHADOW_VIA_COLOCATION_EPS = 1e-4` mirrors `ClearanceRule`'s #2706
  in-pad-escape carve-out, so the gate is never *stricter* than the checker.
* `_shadow_select_gap` is **untouched** — that is #4580's scope.
* `enable_shadow_construction` stays **OFF** by default.

## Measurement (board-06 shadow-ON, seed 42, C++ backend built)

`KCT_BOARD06_SHADOW=1 PYTHONHASHSEED=42 uv run python
boards/06-diffpair-test/generate_design.py --step route --seed 42`, then
`uv run kct check … --mfr jlcpcb`. Base commit `45744d0a`, isolated worktree.

Board-06's **downstream** phases are wall-clock nondeterministic (#4536): the
full regeneration lands in one of two attractor modes. Both base *and* change
were sampled and both reach both modes, so the table is paired **mode for mode**
(3 base runs, 3 change runs).

### Mode A (base ×1, change ×2)

| Signal | base `45744d0a` | this PR | Δ |
|---|---|---|---|
| **`clearance_segment_via`** | **1** | **0** | **−1** |
| Total DRC errors | 33 | **32** | −1 |
| `diffpair_clearance_intra` | 7 | 7 | 0 |
| `diffpair_length_skew` | 7 | 7 | 0 |
| `diffpair_routing_continuity` | 7 | 7 | 0 |
| `clearance_pad_segment` | 5 | 5 | 0 |
| `connectivity` | 3 | 3 | 0 |
| `impedance` | 2 | 2 | 0 |
| `via_in_pad` | 1 | 1 | 0 |
| Warnings | 7 | 7 | 0 |
| **Signal nets routed** | **19 / 21** | **19 / 21** | 0 |
| **Pairs `class=coupled-ok`** | **5 / 9** | **5 / 9** | 0 |

### Mode B (base ×2, change ×1) — the mode the Curator's baseline measured

| Signal | base `45744d0a` | this PR | Δ |
|---|---|---|---|
| **`clearance_segment_via`** | **1** | **0** | **−1** |
| Total DRC errors | 36 | **35** | −1 |
| `diffpair_clearance_intra` | 19 | 19 | 0 |
| `diffpair_length_skew` | 6 | 6 | 0 |
| `diffpair_routing_continuity` | 6 | 6 | 0 |
| `connectivity` | 3 | 3 | 0 |
| `impedance` | 1 | 1 | 0 |
| Warnings | 7 | 7 | 0 |
| **Signal nets routed** | **18 / 21** | **18 / 21** | 0 |
| **Pairs `class=coupled-ok`** | **5 / 9** | **5 / 9** | 0 |

In **both** modes the change is exactly `−1` total error, and that error is the
`clearance_segment_via` finding. Nothing else moves.

### `[coupled-pair-report]` class census (identical base vs change, both modes)

| pair | class |
|---|---|
| MIPI_CLK | `coupled-ok` |
| MIPI_D0 | `guide-missing` |
| PCIE_RX | `coupled-ok` |
| PCIE_TX | `shadow-declined-blockage` |
| USB2_D | `coupled-ok` |
| USB3_RX1 | `shadow-declined-blockage` |
| USB3_RX2 | `shadow-declined-blockage` |
| **USB3_TX1** | **`coupled-ok`** |
| USB3_TX2 | `coupled-ok` |

`USB3_TX1` — the pair that owned the finding — is still **`coupled-ok`**. The
rule did not stop firing because the constructed copper went away.

### The finding itself

```
base:   [X] clearance_segment_via (different-net)
            Segment to via clearance 0.090mm < minimum 0.102mm
            Nets: USB3_TX1+ / USB3_TX1-
this PR: (rule not reported)
```

Geometry from the base artifact (board coords = file coords + (98.5, 47.5)):
segment `USB3_TX1+ (10.5000, 8.4500) -> (10.9508, 7.9992)` w=0.275 on F.Cu,
against via `USB3_TX1- (11.1234, 8.4671)` ⌀0.45 — i.e. DRC location
`(109.623, 55.967)`, exactly the pair the issue quotes.

## Acceptance Criteria Verification

* **AC-1 (the finding).** ✅ `clearance_segment_via` **1 → 0**; the
  `USB3_TX1+` / `USB3_TX1-` 0.090 mm pair is gone from `kct check --mfr jlcpcb`
  in both modes.
* **AC-2 (no reach purchase).** ✅ Nets routed and `coupled-ok` are **identical**
  mode-for-mode (19/21 & 5/9 in Mode A, 18/21 & 5/9 in Mode B) — both ≥ the
  18/21 and 5/9 floors. No trade was made.
* **AC-3 (no quadrant swap).** ✅ Total DRC errors go **down** by 1 in both
  modes (33→32, 36→35); `diffpair_clearance_intra` is unchanged (7→7, 19→19).
  No rule count increases.
* **AC-4 (non-vacuity).** ✅ The gate fires, with a measured deficit, at the
  exact DRC location:
  ```
  [coupled-shadow] side=-1 foreign-via clearance deficit 0.039mm near (109.623, 55.967) for USB3_TX1; trying other side
  [coupled-shadow] USB3_TX1 foreign-via gate rejected 7 candidate(s) (issue #4575)
  ```
  **Named mechanism:** for `USB3_TX1` it is the **post-assembly failover** —
  `side=-1` is declined with reason `"via-clearance"` and the pair is
  re-constructed on `side=+1`, which is why it stays `coupled-ok`. Across the
  board the **repair** half does the bulk of the work: 246 candidates were
  screened out and lost to a later candidate (MIPI_CLK 3, PCIE_RX 15,
  PCIE_TX 68+107, USB2_D 82+7, USB3_RX1 34, USB3_TX1 7) with **no** side lost
  to it.
* **AC-5 (exact predicate).** ✅ The gate uses `rules.trace_clearance`
  (segment-vs-via) and `rules.via_clearance` (via-vs-via / via-vs-segment),
  never `_pair_seg_clearance`'s intra-pair relaxation.
  `test_segment_via_gate_rejects_a_subclearance_nonoverlapping_barrel_gap`
  constructs a **non-overlapping** 0.55 mm barrel gap (overlap bound 0.45 mm,
  clearance bound 0.65 mm), asserts `_pair_has_physical_overlap` **accepts** it
  and the gate reports 0.10 mm;
  `test_via_gate_threshold_is_the_inter_net_clearance_not_the_intra_pair_one`
  pins the vacuity trap directly (the same geometry reads *clean* at an
  intra-pair bound); `test_segment_via_deficit_agrees_with_the_boolean_predicate`
  is the drift guard against `segment_clears_foreign_via`.
* **AC-6 (`exclude_net` only).** ✅ No `exclude_refs` / same-component carve-out
  is consulted anywhere. `test_partner_via_on_a_shared_connector_ref_is_still_measured`
  puts P and N on one fine-pitch `J1` (asserting `_component_is_fine_pitch`) and
  the partner's barrel is still measured.
* **AC-7 (co-location parity).** ✅
  `test_segment_endpoint_colocated_with_a_foreign_via_is_not_flagged` — an
  endpoint on the via centre is not flagged, one 0.01 mm step away it is.
* **AC-8 (default unchanged).** ✅ `enable_shadow_construction` untouched. The
  gate is **ambient**: outside `_shadow_route_pair` the universe is `None` and
  every screen returns `0.0` / `True`, so the shadow-OFF path and the ordinary
  (non-shadow) `_tail_route` calls are unreachable by it. Pinned by
  `test_via_gate_is_a_no_op_when_disarmed`, and by the existing shadow-off tests
  passing unmodified.
* **AC-9 (suite green).** ✅ See Test Plan.

## Scope notes

* **#4580 (cited, not absorbed).** `_shadow_select_gap` is untouched. As the
  issue asked, the count of crossover/candidate sites the new gate rejects is
  recorded above (246 across 6 pairs). None of them cost a side — every pair that
  constructed before still constructs — so no #4580 saturation was observed, but
  the interaction is real and the counts are the number to watch there.
* **Third-party quadrant.** The committed-routes half of the universe is
  included (defence-in-depth for other boards), but on board-06 it contributes
  **zero** candidate rejections: a control run with that half removed produces
  the identical per-pair rejection counts. That is consistent with the baseline
  having no constructed-copper-vs-third-party-barrel finding at all. Recorded in
  `_shadow_foreign_copper`'s docstring.
* **#4577 not touched** (same file, same net, different defect). Whoever lands
  second re-measures.

## Test Plan

* `uv run pytest tests/test_diffpair_shadow.py` — **165 passed** (14 new tests in
  a new section *"14. exact foreign-VIA clearance gate for constructed copper"*).
* `uv run pytest tests/test_diffpair_routing_integration.py
  tests/test_board_06_diffpair_test.py tests/test_escape_segment_via_clearance.py
  tests/test_main_router_segment_via_clearance.py
  tests/test_main_router_via_segment_clearance.py tests/test_via_segment_short_3486.py
  tests/test_pathfinder_via_foreign_clearance.py
  tests/test_clearance_in_pad_via_colocation.py tests/test_clearance_via_barrel_layers.py`
  — green.
* `uv run pytest` — full suite: **24061 passed, 96 skipped, 3 failed** in 65m25s;
  the 3 failures are the pre-existing ones noted below.
* `uv run ruff check .` / `uv run ruff format . --check` — clean.
* `uv run python scripts/ci/check_mypy_baseline.py` — `OK: mypy reports 1473
  error(s), all within the baseline (1474 allowed)`. (The baseline file is
  deliberately **not** regenerated — `--update` in a native-built worktree drops
  the env-agnostic nanobind line.)
* Manual board-06 verification: the tables above (6 runs total).
* `boards/*/output/` artifacts were regenerated during measurement and
  **restored**; `git status` is clean of board output and
  `./.loom/scripts/check-main-clean.sh` exits 0.

### Pre-existing failures (unchanged, not introduced here)

`tests/test_kct_check_parity.py::TestBoard07KctCheckParity` — 3 failures, a known
local-environment artifact (CI is green on main). Confirmed present at
`45744d0a` and unchanged by this PR.

Closes #4575
