### PR TITLE
docs(diffpair): document board-06's deterministic shadow-phase measurement surface

### DIFF
--- a/boards/06-diffpair-test/README.md
+++ b/boards/06-diffpair-test/README.md
@@ -151,18 +151,35 @@ KCT_BOARD06_SHADOW=1 PYTHONHASHSEED=42 uv run python \
 
 ### The two downstream modes
 
-Once shadow output feeds the negotiated `route_all_negotiated` pass, the
-board settles into one of two stable modes rather than a continuum:
+**All figures in this subsection are from the shadow-ON configuration
+(`KCT_BOARD06_SHADOW=1`, the repro block above).  The default recipe
+runs shadow-OFF** --- `ENABLE_COUPLED_SHADOW` reads `KCT_BOARD06_SHADOW`
+with default `"0"` (`generate_design.py`, the #3508 block), which is what
+the committed artifact and CI use.
 
-| | DRC errors | `diffpair_clearance_intra` | reach |
+Once shadow output feeds the negotiated `route_all_negotiated` pass, the
+shadow-ON board settles into one of two stable modes rather than a
+continuum:
+
+| (shadow-ON) | DRC errors | `diffpair_clearance_intra` | reach |
 |---|---|---|---|
 | Mode A | 32 | 7 | 19 of 21 |
 | Mode B | 35 | 19 | 18 of 21 |
 
-`coupled-ok` is 5/9 in both modes. A run's mode is identifiable from
-three mutually consistent signals --- total DRC error count, the
-`diffpair_clearance_intra` count, and reach --- which is what makes
-paired mode-for-mode comparison possible instead of guesswork.
+`coupled-ok` is 5/9 in both modes --- the shadow-ON convergence figure
+recorded in the recipe comments ("Convergence is 5/9 (post-#4576)").  A
+run's mode is identifiable from three mutually consistent signals ---
+total DRC error count, the `diffpair_clearance_intra` count, and reach
+--- which is what makes paired mode-for-mode comparison possible instead
+of guesswork.
+
+**If you ran with the default (shadow-OFF), you are not in either
+mode.** Expect the committed / CI floor instead: **18 DRC errors**
+(9 `diffpair_length_skew` + 9 `diffpair_routing_continuity`, the value
+pinned for this board in `.github/routed-drc-tolerance.yml`) at **21 of
+21** reach --- the shadow-OFF reach recorded in the same recipe
+comments.  A default-config run landing on those numbers is the expected
+result, not an unrecognized third mode.
 
 ### Measurement convention
 
@@ -190,7 +207,11 @@ Two traps this has already cost people:
 ### Standing invariants and the vacuity trap
 
 A change should not drop `coupled-ok` below 5/9, and should not drop
-reach when compared mode-for-mode.  Watch for the **vacuity trap**:
+reach when compared mode-for-mode.  **The 5/9 figure is the shadow-ON
+convergence number** recorded in the recipe comments next to
+`ENABLE_COUPLED_SHADOW`; like the mode table, it is an invariant for
+shadow-ON runs, so evaluate it against a shadow-ON baseline rather than
+a default (shadow-OFF) one.  Watch for the **vacuity trap**:
 `diffpair_length_skew` only fires on an *engaged* (coupled) pair, so a
 change that knocks a pair from coupled to declined removes it from
 skew-checking entirely --- the error count can drop while the change is

--- a/boards/06-diffpair-test/README.md
+++ b/boards/06-diffpair-test/README.md
@@ -121,6 +121,91 @@ Per the Epic #2556 Phase 4L mitigation strategy, this board is scaffolded
 now with PCIe / MIPI pairs declared but DRC tolerated at "non-strict" if
 #2648 hasn't landed yet.  Re-route and tighten when #2648 merges.
 
+## Measuring Changes: the Shadow Phase Is Deterministic, Full Regen Is Not (#4536)
+
+Full board-06 regeneration (`generate_design.py --step route`) is
+run-to-run nondeterministic downstream of the coupled diff-pair
+pre-phase --- two same-seed runs of unmodified `main` can differ by
+thousands of lines ([#4536], open).  Every agent that measures a board-06
+change by diffing two full regens rediscovers this the hard way; this
+section exists so that discovery is a paragraph instead of a multi-hour
+detour.
+
+**The shadow-construction phase itself is fully deterministic.** This was
+established independently more than once during a 5-issue diffpair sweep
+(2026-08-03/04, [#4570]/[#4574]/[#4575]/[#4577]/[#4579]/[#4581]/[#4582]):
+two full runs at the same commit produce byte-identical sets of all 33
+`[coupled-tail]` lines, all 47 `[coupled-follow] declined` lines, and 323
+gate rejections from the #4575 via-clearance gate (split 3+15+68+107+82+7+34+7
+across the 9 pairs). The #4582 Judge independently reproduced the same
+323 figure across four separate runs spanning both downstream modes
+below. The nondeterminism is entirely downstream of this phase.
+
+Reproduce the shadow phase and its debug trace:
+
+```bash
+KCT_BOARD06_SHADOW=1 PYTHONHASHSEED=42 uv run python \
+  boards/06-diffpair-test/generate_design.py --step route --seed 42
+# KCT_SHADOW_DEBUG=1 adds the [coupled-tail] / [coupled-follow] instrumentation
+```
+
+### The two downstream modes
+
+Once shadow output feeds the negotiated `route_all_negotiated` pass, the
+board settles into one of two stable modes rather than a continuum:
+
+| | DRC errors | `diffpair_clearance_intra` | reach |
+|---|---|---|---|
+| Mode A | 32 | 7 | 19 of 21 |
+| Mode B | 35 | 19 | 18 of 21 |
+
+`coupled-ok` is 5/9 in both modes. A run's mode is identifiable from
+three mutually consistent signals --- total DRC error count, the
+`diffpair_clearance_intra` count, and reach --- which is what makes
+paired mode-for-mode comparison possible instead of guesswork.
+
+### Measurement convention
+
+- **Compare shadow-phase counters directly.** The `[coupled-tail]` /
+  `[coupled-follow] declined` line counts and the per-pair gate-rejection
+  split are deterministic; a difference there is a real signal.
+- **Compare full-regen (board-level) results paired mode-for-mode.**
+  Identify each side's mode from the three signals above before
+  comparing error counts, `diffpair_clearance_intra`, or reach across a
+  change.
+- **Never assert a delta from a single run of each side.** A lone
+  before/after pair can silently compare Mode A against Mode B and
+  report a mode flip as a regression or a win. Run enough repeats to
+  identify the mode on both sides first.
+
+Two traps this has already cost people:
+
+1. A Builder's first baseline landed in Mode A while the Curator's had
+   landed in Mode B, so the two disagreed on the "current" numbers and
+   neither was wrong.
+2. A Builder ran a narrow-vs-broad comparison that looked decisive and
+   was pure mode noise --- only paired sampling separated signal from
+   [#4536].
+
+### Standing invariants and the vacuity trap
+
+A change should not drop `coupled-ok` below 5/9, and should not drop
+reach when compared mode-for-mode.  Watch for the **vacuity trap**:
+`diffpair_length_skew` only fires on an *engaged* (coupled) pair, so a
+change that knocks a pair from coupled to declined removes it from
+skew-checking entirely --- the error count can drop while the change is
+a regression, not a win.  Always read `coupled-ok` and reach alongside
+the raw error count, never the error count alone.
+
+[#4536]: https://github.com/rjwalters/kicad-tools/issues/4536
+[#4570]: https://github.com/rjwalters/kicad-tools/issues/4570
+[#4574]: https://github.com/rjwalters/kicad-tools/issues/4574
+[#4575]: https://github.com/rjwalters/kicad-tools/issues/4575
+[#4577]: https://github.com/rjwalters/kicad-tools/issues/4577
+[#4579]: https://github.com/rjwalters/kicad-tools/issues/4579
+[#4581]: https://github.com/rjwalters/kicad-tools/issues/4581
+[#4582]: https://github.com/rjwalters/kicad-tools/issues/4582
+
 ## CI Gate (Phase 4N, #2660)
 
 This board is **re-routed from scratch on every pull request** by the

--- a/boards/README.md
+++ b/boards/README.md
@@ -162,6 +162,15 @@ Two caveats:
   round-trip, drowning real changes in reformat noise. If you regenerate a
   board and see a large diff with no geometric change, confirm you are
   comparing same-version fresh-vs-fresh before assuming a router bug.
+- **Board 06 is a known exception downstream of its coupled diff-pair
+  pre-phase**: full-regen output is run-to-run nondeterministic even at a
+  fixed version and seed (issue #4536, open). The pre-phase itself
+  (shadow construction) *is* deterministic and is the correct surface to
+  measure a change against --- see [`boards/06-diffpair-test/README.md`
+  "Measuring Changes"](06-diffpair-test/README.md#measuring-changes-the-shadow-phase-is-deterministic-full-regen-is-not-4536)
+  for the two stable downstream modes and the paired-comparison
+  convention. Do not assume the smoke test above proves full-board
+  byte-identity on this one board.
 
 ### Subprocess (`kct route`) vs. in-process (`router.route_all_*`)
 

--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -3813,7 +3813,11 @@ class DiffPairRouter:
         routed_nets = {route.net for route in getattr(autorouter, "routes", None) or ()}
         channels: list[_EscapeChannel] = []
         # ``sorted`` keeps the registry -- and therefore every penalty sum --
-        # independent of dict iteration order (AC-6 / #4536).
+        # independent of dict iteration order (AC-6 / #4536). This fixed one
+        # source of board-06 full-regen nondeterminism, not all of it -- see
+        # boards/06-diffpair-test/README.md "Measuring Changes" for the
+        # deterministic shadow-phase measurement surface and the two
+        # remaining stable downstream modes.
         for net_id in sorted(nets):
             if net_id in exclude_nets or net_id in routed_nets:
                 continue


### PR DESCRIPTION
## Summary

- Documents that board-06's coupled shadow-construction phase is fully deterministic while full-board regen is not (#4536, open), sited in `boards/06-diffpair-test/README.md` and cross-linked from `boards/README.md`'s determinism section.
- Records the two stable downstream modes (Mode A / Mode B) and the three signals that identify a run's mode (total DRC errors, `diffpair_clearance_intra` count, reach).
- States the paired-comparison measurement convention (compare shadow counters directly; compare board-level results mode-for-mode; never assert a delta from a single run of each side) and the two concrete traps it has already cost people.
- Notes the standing invariants (`coupled-ok` >= 5/9, reach not dropping mode-for-mode) and the `diffpair_length_skew` vacuity trap.
- Adds a one-line pointer comment near the #4536 AC-6 fix in `diffpair_routing.py`.

Closes #4593

## Test plan

- [x] `uv run ruff check` on the touched Python file — clean
- [x] Docs-only change (plus one code comment) — no functional behavior change, no tests required
- [x] Verified all new markdown reference-style links (`[#4536]` etc.) have matching definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)