### PR TITLE
test: re-baseline board-07 match-group family delta from 1 to 0

### DIFF
--- a/tests/test_kct_check_parity.py
+++ b/tests/test_kct_check_parity.py
@@ -121,9 +121,27 @@ BOARD_07_EXPECTED_FAMILY_DELTA: dict[str, int] = {
     # the via-inclusive 1.069mm residual (route-side tuner converges the
     # via-BLIND skew to 0.000 -- see the #3928/#3931 note in
     # scripts/ci/check_matchgroup_coverage.py).
+    #
+    # Re-baselined 2026-08-04 (Issue #4592): match_group_length_skew 1 -> 0.
+    # PR #4030 (commit de0d91ec, closes #4007, "measure standard vias as
+    # through-vias in match-group skew") made the route-side tuner and the
+    # file-based checker measure via length the same way, collapsing the
+    # spurious via-inclusive ADDR_BUS 1.069mm residual described above to
+    # ~0.0015mm -- well inside the 0.500mm tolerance.  The rule still RUNS on
+    # the committed artifact (summary.rules_checked_by_rule.match_group_length_skew
+    # = 1); it simply finds nothing, i.e. gated-but-clean.  #4030 updated
+    # .github/routed-drc-tolerance.yml, tests/test_board_07_matchgroup_test.py
+    # and tests/test_match_group_length.py; PR #4211 (commit 2985cd4e, Issue
+    # #4207) then re-baselined the sibling `blocking == 8` assertion in THIS
+    # file (see TestCiGateCountsGatedFamilies below) -- but both missed this
+    # dict, leaving the file self-contradictory (9 here vs 8 there) until
+    # #4592.  KEEP THE TWO IN SYNC: the sum of the values in this dict MUST
+    # equal the `blocking ==` pin in
+    # TestCiGateCountsGatedFamilies.test_board_07_gate_counts_diffpair_and_matchgroup
+    # (currently 4 + 4 + 0 = 8).
     "diffpair_length_skew": 4,
     "diffpair_routing_continuity": 4,
-    "match_group_length_skew": 1,
+    "match_group_length_skew": 0,
 }
 
 
@@ -472,6 +490,11 @@ class TestCiGateCountsGatedFamilies:
         # before/after #4030, so no clearance/short violation vanished.
         # Advisory connectivity is unchanged at 5 (the DQ3/DQ4/MIPI_DAT0_N/
         # TMDS_D0_N/TMDS_D1_N #3438 negotiated-reach residual).
+        #
+        # KEEP IN SYNC with BOARD_07_EXPECTED_FAMILY_DELTA at the top of this
+        # file: this pin must equal sum(BOARD_07_EXPECTED_FAMILY_DELTA.values()).
+        # #4211 updated only this assertion and left that dict stale, which is
+        # what Issue #4592 had to clean up -- re-baseline BOTH together.
         assert blocking == 8, (
             f"expected 8 blocking errors (4 diffpair_length_skew + "
             f"4 diffpair_routing_continuity + 0 match_group_length_skew) on "


### PR DESCRIPTION
## Summary

`tests/test_kct_check_parity.py` contained two pins of the same board-07 fact
that contradicted each other. The module-level dict
`BOARD_07_EXPECTED_FAMILY_DELTA` still claimed `match_group_length_skew: 1`
(summing to 9), while the sibling assertion in
`TestCiGateCountsGatedFamilies` asserted `blocking == 8`. This makes three
`TestBoard07KctCheckParity` tests fail deterministically on every clean
checkout.

**Corrected root cause (this is NOT environment-dependent — the original issue
premise was wrong).**

* PR #4030 (`de0d91ec`, closes #4007, "measure standard vias as through-vias in
  match-group skew") made the route-side tuner and the file-based checker
  measure via length the same way. The spurious via-inclusive ADDR_BUS
  1.069 mm skew collapsed to ~0.0015 mm — well inside the 0.500 mm
  tolerance — so the lone `match_group_length_skew` violation was legitimately
  eliminated. The rule still **runs** on the committed artifact
  (`summary.rules_checked_by_rule.match_group_length_skew == 1`); it just finds
  nothing (gated-but-clean).
* PR #4211 (`2985cd4e`, #4207) re-baselined the sibling `blocking` assertion
  from 9 to 8 with a long forensic comment, but **did not touch this dict**.
* "Passes in CI" is a misreading: the PR-blocking `Test` job deselects these
  tests via `-m "not slow"` (`.github/workflows/ci.yml:142`), so the PR gate
  never ran them. The nightly `.github/workflows/slow-tests.yml` *does* run
  them and has been red every night. There is no KiCad version, locale, or
  fixture-state divergence — and therefore no `skipif` to add and no CI-only
  environment requirement to document. The pin was simply stale.

## Changes

`tests/test_kct_check_parity.py` (the only file changed):

* `BOARD_07_EXPECTED_FAMILY_DELTA["match_group_length_skew"]`: `1` -> `0`.
* Dated re-baseline comment (2026-08-04, Issue #4592) in the file's existing
  comment style, citing #4030 / `de0d91ec` / #4007 / #4211 / #4207.
* Reciprocal "KEEP IN SYNC" notes on both pins: the dict comment points at the
  `blocking ==` assertion, and the assertion's comment points back at the dict.
  Two constants in one file encoding the same 8-vs-9 fact is exactly what
  produced this bug twice (#4207, then #4592).

No test logic changed. `test_sidecar_adds_exactly_the_three_families` already
filters `expected_added` on `expected > 0` (line 379) and its docstring already
describes the gated-but-clean case, so a `0` correctly drops the family from the
expected added-set.

## Acceptance Criteria Verification

- [x] `BOARD_07_EXPECTED_FAMILY_DELTA["match_group_length_skew"]` is `0`, with a
      dated re-baseline comment citing #4030 / `de0d91ec` / #4007 / #4211 / #4592.
- [x] `uv run pytest tests/test_kct_check_parity.py` passes fully — **11 passed,
      0 failed** (see below).
- [x] The two board-07 pins agree: `4 + 4 + 0 = 8` equals the `blocking == 8`
      assertion, and both now carry a cross-reference.
- [x] `NET_CLASS_GATED_FAMILIES` is unchanged;
      `test_bare_check_noop_contract_preserved` still passes and still asserts
      zero for all three families.
- [x] No board artifact, no `.github/routed-drc-tolerance.yml`, no `src/` file
      touched — `git diff --stat` is a single test file, 24 insertions /
      1 deletion.
- [x] PR body states the corrected root cause (above), not the
      "environment-dependent" hypothesis.

## Test Plan

### Before (clean checkout of `main` @ `092611b0`, in the issue worktree)

```
$ uv run pytest tests/test_kct_check_parity.py -p no:randomly -q -o addopts=
...
E  AssertionError: 'match_group_length_skew' delta was 0, expected 1
E  assert 0 == 1
...
E  AssertionError: assert (13 - 5) == 9
E   +  where 9 = sum(dict_values([4, 4, 1]))
...
FAILED tests/test_kct_check_parity.py::TestBoard07KctCheckParity::test_sidecar_adds_exactly_the_three_families
FAILED tests/test_kct_check_parity.py::TestBoard07KctCheckParity::test_family_delta_counts_pinned
FAILED tests/test_kct_check_parity.py::TestBoard07KctCheckParity::test_total_error_count_delta
3 failed, 8 passed in 278.65s (0:04:38)
```

### After (this branch)

```
$ uv run pytest tests/test_kct_check_parity.py -p no:randomly -q -o addopts=
...........                                                              [100%]
11 passed in 62.27s (0:01:02)
```

### Independent verification (no pytest) — `kct check` on the committed artifact

With the sidecar:

```
$ uv run kct check boards/07-matchgroup-test/output/matchgroup_test_routed.kicad_pcb \
    --mfr jlcpcb --errors-only --format json \
    --net-class-map boards/07-matchgroup-test/output/net_class_map.json
errors: 13
by rule: {'connectivity': 5, 'diffpair_length_skew': 4, 'diffpair_routing_continuity': 4}
summary.rules_checked_by_rule.match_group_length_skew: 1
```

`match_group_length_skew` contributes **0** errors while its
`rules_checked_by_rule` entry is **1** — the rule is engaged and clean, exactly
as the re-baseline claims.

Isolated bare run (PCB copied away from its adjacent `net_class_map.json`,
mirroring the test's `bare` fixture):

```
isolated bare errors: 5
by rule: {'connectivity': 5}
```

So the delta is `13 - 5 = 8 = 4 + 4 + 0`. (Note: running `kct check` *in place*
without `--net-class-map` still reports 13, because the sidecar sitting next to
the PCB is auto-discovered — the isolation is what produces the documented 5.)

### Regression suites (re-baselined by #4030; must not drift)

```
$ uv run pytest tests/test_board_07_matchgroup_test.py tests/test_match_group_length.py \
    tests/test_check_matchgroup_coverage.py -q -o addopts=
110 passed, 5 warnings in 3.04s
```

### Lint / format

```
$ uv run ruff check tests/test_kct_check_parity.py     -> All checks passed!
$ uv run ruff format --check tests/test_kct_check_parity.py -> 1 file already formatted
```

Environment: `uv sync` in a fresh worktree, then `uv run kct build-native`
(`C++ backend installed successfully! router_cpp.cpython-312-darwin.so`). The
parity tests do not re-route — they run `kct check` over the committed
artifact — so the result is deterministic either way.

## Coverage note

Zeroing the pin does not lose rule-engagement coverage. Engagement is enforced
independently by `scripts/ci/check_matchgroup_coverage.py:630`, which fails when
a rule's `rules_checked_by_rule` entry drops below 1, and by
`test_bare_check_noop_contract_preserved` in the other direction.

## Out of scope (unchanged, per the issue's scope guard)

The nightly `Slow Tests` workflow reports `11 failed, 27 passed, 13 skipped,
4 errors`. This PR fixes 3 of those 11; the workflow will still be red for
unrelated reasons. Not chased here. Also untouched by design: the board-07
routed artifact, `.github/routed-drc-tolerance.yml`, `NET_CLASS_GATED_FAMILIES`,
any `src/` file, and `.github/workflows/ci.yml`'s `-m "not slow"` selection.

Closes #4592
