### PR TITLE
fix(export): key preflight THT policy on fab family, reconcile LCSC post-enrichment

### DIFF
--- a/src/kicad_tools/export/manufacturing.py
+++ b/src/kicad_tools/export/manufacturing.py
@@ -434,6 +434,13 @@ class ManufacturingPackage:
         if not assembly_ok:
             return result
 
+        # Step 1.5: Reconcile the recorded ``bom_fields`` preflight result
+        # against the LCSC enrichment that only just ran (Step 1).  Preflight
+        # inspects a raw BOM before any network/cache lookup, so its
+        # "missing LCSC part number" clause is a prediction that
+        # ``--auto-lcsc`` may have already invalidated (issue #4591).
+        self._reconcile_preflight_lcsc(result)
+
         # Step 2: Report (optional)
         if self.config.include_report:
             self._generate_report(out_dir, result)
@@ -459,6 +466,91 @@ class ManufacturingPackage:
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    # Substring that identifies the LCSC clause emitted by
+    # ``PreflightChecker._check_bom_fields``.
+    _LCSC_CLAUSE_MARKER = "missing LCSC part number"
+
+    # Substrings that identify the non-LCSC problem clauses.  Anything in
+    # ``details`` that matches neither these nor the LCSC marker is an
+    # informational note and is preserved verbatim.
+    _BOM_FIELD_ISSUE_MARKERS = ("missing footprint", "missing value")
+
+    def _reconcile_preflight_lcsc(self, result: ManufacturingResult) -> None:
+        """Update the recorded ``bom_fields`` result with post-enrichment LCSC state.
+
+        ``PreflightChecker`` runs before any file is written (Step 0), which
+        is deliberate: ``strict_preflight`` and ``block_on_unbuildable_bom``
+        must be able to abort with nothing on disk.  The consequence is that
+        ``_check_bom_fields`` sees a *raw* BOM: for the ``--auto-lcsc`` path
+        it cannot know which items :func:`enrich_bom_lcsc` will resolve,
+        because that requires parts-API / cache I/O which preflight must not
+        perform.  (The spec-overlay path is predicted statically by
+        ``PreflightChecker._spec_lcsc_refs`` -- issues #3926 / #3932.)
+
+        So the LCSC clause is reconciled here, after Step 1 has actually run
+        the enrichment, and before the manifest is serialized.  Both the
+        manifest (``_build_manifest`` reads ``result.preflight_results``) and
+        the CLI summary render the updated entry with no changes at either
+        consumer.
+
+        Safety rules:
+
+        * A ``FAIL`` is **never** downgraded -- a ``bom_fields`` FAIL comes
+          from missing footprints, which enrichment cannot fix.
+        * Non-LCSC clauses (missing footprint / missing value) and
+          informational notes are preserved verbatim.
+        * No enrichment report (``--no-auto-lcsc``, non-JLCPCB family,
+          enrichment error) or no preflight results (``--skip-preflight``)
+          makes this a no-op.
+        """
+        if not result.preflight_results:
+            return
+        if result.assembly_result is None:
+            return
+
+        report = result.assembly_result.lcsc_enrichment
+        if report is None:
+            return
+
+        entry = next((pr for pr in result.preflight_results if pr.name == "bom_fields"), None)
+        if entry is None or entry.status == "FAIL":
+            return
+
+        clauses = [c.strip() for c in entry.details.split(";")] if entry.details else []
+        lcsc_clauses = [c for c in clauses if self._LCSC_CLAUSE_MARKER in c]
+        if not lcsc_clauses:
+            # Nothing predicted about LCSC -- leave the entry untouched.
+            return
+
+        other_clauses = [c for c in clauses if self._LCSC_CLAUSE_MARKER not in c]
+        remaining_issues = [
+            c for c in other_clauses if any(marker in c for marker in self._BOM_FIELD_ISSUE_MARKERS)
+        ]
+        notes = [c for c in other_clauses if c not in remaining_issues]
+
+        unmatched_entries = report.unmatched_entries
+        if unmatched_entries:
+            refs = [ref for e in unmatched_entries for ref in e.references]
+            shown = ", ".join(sorted(refs)[:10])
+            suffix = f" (and {len(refs) - 10} more)" if len(refs) > 10 else ""
+            remaining_issues.append(
+                f"{len(unmatched_entries)} component group(s) still missing LCSC "
+                f"part number after enrichment: {shown}{suffix}"
+            )
+        else:
+            resolved = report.auto_matched + report.cache_matched
+            if resolved:
+                notes.append(f"{resolved} group(s) received LCSC from enrichment")
+
+        if remaining_issues:
+            entry.status = "WARN"
+            entry.message = f"BOM field issues: {len(remaining_issues)} problem(s)"
+        else:
+            entry.status = "OK"
+            entry.message = "All BOM items have required fields (LCSC resolved by enrichment)"
+
+        entry.details = "; ".join(remaining_issues + notes)
 
     def _check_drc_safety_floor(self, result: ManufacturingResult) -> None:
         """Hard-abort export on net shorts / connectivity errors.

--- a/src/kicad_tools/export/preflight.py
+++ b/src/kicad_tools/export/preflight.py
@@ -91,7 +91,12 @@ class PreflightChecker:
             print("Cannot proceed with export")
     """
 
-    # Manufacturers whose standard assembly service is SMT-only
+    # Fab *families* whose standard assembly service is SMT-only.
+    #
+    # Compared against ``self._fab_family`` (NOT the raw ``--mfr`` value):
+    # capability tiers such as ``jlcpcb-tier1`` share the parent fab's
+    # assembly service and CPL format, so they must inherit the parent's
+    # THT policy.  See ``get_fab_family()`` and issue #3497.
     _SMT_ONLY_MANUFACTURERS = {"jlcpcb"}
 
     def __init__(
@@ -115,11 +120,25 @@ class PreflightChecker:
         # (default: lazily constructed in _check_bom_lcsc_values).
         self._parts_cache = parts_cache
 
-        # Determine THT exclusion: explicit override, or default per manufacturer
+        # Resolve the fab *family* once.  Export-format concerns (BOM/CPL
+        # formatters, THT policy) are properties of the physical fab, not of
+        # a capability tier: ``jlcpcb-tier1`` -> ``jlcpcb``.  The CPL writer
+        # already resolves the family (``assembly.py`` -> ``get_fab_family``),
+        # so preflight must use the same key or its THT predictions desync
+        # from the file that actually ships (issue #4591).  DRC limits keep
+        # using the *full* manufacturer ID -- see ``_get_manufacturer_limits``.
+        try:
+            from ..manufacturers import get_fab_family
+
+            self._fab_family = get_fab_family(self.manufacturer)
+        except Exception:  # pragma: no cover - defensive; resolver is pure
+            self._fab_family = self.manufacturer
+
+        # Determine THT exclusion: explicit override, or default per fab family
         if exclude_tht is not None:
             self._exclude_tht = exclude_tht
         else:
-            self._exclude_tht = self.manufacturer in self._SMT_ONLY_MANUFACTURERS
+            self._exclude_tht = self._fab_family in self._SMT_ONLY_MANUFACTURERS
 
         # Lazy-loaded objects
         self._pcb = None
@@ -620,7 +639,7 @@ class PreflightChecker:
                 details=f"THT references: {refs}{suffix}",
             )
 
-        if self.manufacturer in self._SMT_ONLY_MANUFACTURERS:
+        if self._fab_family in self._SMT_ONLY_MANUFACTURERS:
             return PreflightResult(
                 name="tht_in_cpl",
                 status="WARN",

--- a/tests/test_manufacturing_package.py
+++ b/tests/test_manufacturing_package.py
@@ -1611,3 +1611,201 @@ class TestManufacturingPreflightSpecOverlay:
 
         assert result.status == "WARN"
         assert "2/2 active item(s) missing LCSC part number" in result.details
+
+
+class TestPreflightLCSCReconciliation:
+    """``bom_fields`` must reflect post-``--auto-lcsc`` state (issue #4591).
+
+    Preflight (Step 0) runs before any file is written -- deliberately, so
+    ``--strict-preflight`` can abort with nothing on disk.  It therefore
+    cannot know what ``enrich_bom_lcsc`` (Step 1) will resolve, since that
+    needs parts-API / cache I/O.  ``_reconcile_preflight_lcsc`` updates the
+    recorded result after enrichment and before the manifest is serialized.
+    """
+
+    def _write_project(self, tmp_path):
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        pcb = project_dir / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+        (project_dir / "board.kicad_sch").write_text("(kicad_sch)")
+        return pcb
+
+    def _enrichment(self, *, auto=0, unmatched_refs=()):
+        from kicad_tools.export.bom_enrich import EnrichmentEntry, EnrichmentReport
+
+        entries = [
+            EnrichmentEntry(
+                value="100nF",
+                footprint="C_0402",
+                references=[f"C{i}"],
+                lcsc_part=f"C{1000 + i}",
+                source="auto",
+            )
+            for i in range(auto)
+        ]
+        entries += [
+            EnrichmentEntry(
+                value="X",
+                footprint="F",
+                references=[ref],
+                lcsc_part="",
+                source="unmatched",
+            )
+            for ref in unmatched_refs
+        ]
+        return EnrichmentReport(entries=entries)
+
+    def _run_export(self, tmp_path, monkeypatch, preflight_results, enrichment):
+        """Run a full export with assembly mocked to report ``enrichment``."""
+        pcb = self._write_project(tmp_path)
+
+        from kicad_tools.export import assembly
+
+        def fake_assembly_export(self, output_dir=None):
+            od = Path(output_dir) if output_dir else self.config.output_dir
+            od.mkdir(parents=True, exist_ok=True)
+            res = assembly.AssemblyPackageResult(output_dir=od)
+            res.lcsc_enrichment = enrichment
+            return res
+
+        monkeypatch.setattr(assembly.AssemblyPackage, "export", fake_assembly_export)
+        monkeypatch.setattr(PreflightChecker, "run_all", lambda self: preflight_results)
+
+        config = ManufacturingConfig(include_report=False, include_project_zip=False)
+        pkg = ManufacturingPackage(pcb_path=pcb, manufacturer="jlcpcb", config=config)
+        out_dir = tmp_path / "out"
+        result = pkg.export(out_dir)
+        manifest = json.loads((out_dir / "manifest.json").read_text())
+        entry = next(e for e in manifest["preflight"] if e["name"] == "bom_fields")
+        return result, entry
+
+    def test_fully_enriched_warn_becomes_ok(self, tmp_path, monkeypatch):
+        """Enrichment resolved everything => manifest records OK, not the WARN."""
+        preflight = [
+            PreflightResult(
+                name="bom_fields",
+                status="WARN",
+                message="BOM field issues: 1 problem(s)",
+                details="88/88 active item(s) missing LCSC part number",
+            )
+        ]
+        _, entry = self._run_export(tmp_path, monkeypatch, preflight, self._enrichment(auto=88))
+        assert entry["status"] == "OK"
+        assert "missing LCSC part number" not in entry["message"]
+        assert "missing LCSC part number" not in entry.get("details", "")
+        assert "88 group(s) received LCSC from enrichment" in entry["details"]
+
+    def test_partial_enrichment_names_only_unmatched(self, tmp_path, monkeypatch):
+        preflight = [
+            PreflightResult(
+                name="bom_fields",
+                status="WARN",
+                message="BOM field issues: 1 problem(s)",
+                details="10/10 active item(s) missing LCSC part number",
+            )
+        ]
+        _, entry = self._run_export(
+            tmp_path,
+            monkeypatch,
+            preflight,
+            self._enrichment(auto=8, unmatched_refs=("U7", "U9")),
+        )
+        assert entry["status"] == "WARN"
+        assert "2 component group(s) still missing LCSC" in entry["details"]
+        assert "U7" in entry["details"]
+        assert "U9" in entry["details"]
+        assert "10/10" not in entry["details"]
+
+    def test_fail_is_never_downgraded(self, tmp_path, monkeypatch):
+        """A FAIL (missing footprint) survives reconciliation verbatim."""
+        preflight = [
+            PreflightResult(
+                name="bom_fields",
+                status="FAIL",
+                message="BOM field issues: 2 problem(s)",
+                details=(
+                    "1 item(s) missing footprint: U1; 5/5 active item(s) missing LCSC part number"
+                ),
+            )
+        ]
+        _, entry = self._run_export(tmp_path, monkeypatch, preflight, self._enrichment(auto=5))
+        assert entry["status"] == "FAIL"
+        assert entry["details"] == (
+            "1 item(s) missing footprint: U1; 5/5 active item(s) missing LCSC part number"
+        )
+
+    def test_non_lcsc_warn_clause_is_preserved(self, tmp_path, monkeypatch):
+        """A missing-value WARN keeps the entry at WARN after LCSC resolves."""
+        preflight = [
+            PreflightResult(
+                name="bom_fields",
+                status="WARN",
+                message="BOM field issues: 2 problem(s)",
+                details=(
+                    "1 item(s) missing value: R9; 4/4 active item(s) missing LCSC part number"
+                ),
+            )
+        ]
+        _, entry = self._run_export(tmp_path, monkeypatch, preflight, self._enrichment(auto=4))
+        assert entry["status"] == "WARN"
+        assert "1 item(s) missing value: R9" in entry["details"]
+        assert "missing LCSC part number" not in entry["details"]
+
+    def test_no_enrichment_report_is_noop(self, tmp_path, monkeypatch):
+        """``--no-auto-lcsc`` (no report) must leave the entry untouched."""
+        preflight = [
+            PreflightResult(
+                name="bom_fields",
+                status="WARN",
+                message="BOM field issues: 1 problem(s)",
+                details="3/3 active item(s) missing LCSC part number",
+            )
+        ]
+        _, entry = self._run_export(tmp_path, monkeypatch, preflight, None)
+        assert entry["status"] == "WARN"
+        assert entry["details"] == "3/3 active item(s) missing LCSC part number"
+
+    def test_ok_entry_without_lcsc_clause_untouched(self, tmp_path, monkeypatch):
+        """The #3926 spec-overlay note must not be rewritten."""
+        preflight = [
+            PreflightResult(
+                name="bom_fields",
+                status="OK",
+                message="All 4 BOM items have required fields",
+                details="4 active item(s) will receive LCSC from spec overlay",
+            )
+        ]
+        _, entry = self._run_export(tmp_path, monkeypatch, preflight, self._enrichment(auto=0))
+        assert entry["status"] == "OK"
+        assert entry["message"] == "All 4 BOM items have required fields"
+        assert entry["details"] == "4 active item(s) will receive LCSC from spec overlay"
+
+    def test_skip_preflight_reconciliation_noop(self, tmp_path, monkeypatch):
+        """No preflight results => reconciliation is a no-op, not a crash."""
+        pcb = self._write_project(tmp_path)
+
+        from kicad_tools.export import assembly
+
+        def fake_assembly_export(self, output_dir=None):
+            od = Path(output_dir) if output_dir else self.config.output_dir
+            od.mkdir(parents=True, exist_ok=True)
+            res = assembly.AssemblyPackageResult(output_dir=od)
+            res.lcsc_enrichment = self_enrichment
+            return res
+
+        self_enrichment = self._enrichment(auto=2)
+        monkeypatch.setattr(assembly.AssemblyPackage, "export", fake_assembly_export)
+
+        config = ManufacturingConfig(
+            include_report=False,
+            include_project_zip=False,
+            preflight=PreflightConfig(skip_all=True),
+        )
+        pkg = ManufacturingPackage(pcb_path=pcb, manufacturer="jlcpcb", config=config)
+        out_dir = tmp_path / "out"
+        result = pkg.export(out_dir)
+
+        assert result.preflight_results == []
+        manifest = json.loads((out_dir / "manifest.json").read_text())
+        assert "preflight" not in manifest

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1692,3 +1692,134 @@ class TestPreflightBomCplMatchTHT:
         result = checker._check_bom_cpl_match()
         assert result.status == "OK"
         assert "DNP excluded" in result.message
+
+
+# ---------------------------------------------------------------------------
+# Capability-tier manufacturers resolve THT policy via the fab family (#4591)
+# ---------------------------------------------------------------------------
+
+
+class TestPreflightFabFamilyTHT:
+    """``jlcpcb-tier1`` must inherit the ``jlcpcb`` SMT-only THT policy.
+
+    The CPL writer resolves the fab *family* (``get_fab_family()``) before
+    picking a formatter, so a preflight that keyed off the raw ``--mfr``
+    string predicted "THT included" for a CPL that in fact excluded THT --
+    producing a false ``tht_in_cpl`` OK and a spurious ``bom_cpl_match``
+    FAIL (issue #4591).
+    """
+
+    def test_tier_id_resolves_exclude_tht(self, tmp_path):
+        pcb = _create_pcb_with_mixed_footprints(tmp_path, ["R1"], ["J1"])
+        base = PreflightChecker(
+            pcb_path=pcb,
+            manufacturer="jlcpcb",
+            config=PreflightConfig(skip_drc=True, skip_erc=True),
+        )
+        tier = PreflightChecker(
+            pcb_path=pcb,
+            manufacturer="jlcpcb-tier1",
+            config=PreflightConfig(skip_drc=True, skip_erc=True),
+        )
+        assert base._exclude_tht is True
+        assert tier._exclude_tht is True
+        assert tier._fab_family == "jlcpcb"
+
+    def test_tier_id_tht_in_cpl_reports_excluded(self, tmp_path):
+        pcb = _create_pcb_with_mixed_footprints(tmp_path, ["R1"], ["J1", "J2"])
+        checker = PreflightChecker(
+            pcb_path=pcb,
+            manufacturer="jlcpcb-tier1",
+            config=PreflightConfig(skip_drc=True, skip_erc=True),
+        )
+        checker.run_all()
+        result = checker._check_tht_in_cpl()
+        assert result.status == "OK"
+        assert "excluded from CPL" in result.message
+        assert "included in CPL" not in result.message
+        # Details still enumerate the THT references.
+        assert "J1" in result.details
+        assert "J2" in result.details
+
+    def test_tier_id_bom_cpl_match_no_false_fail(self, tmp_path, monkeypatch):
+        """A BOM/CPL delta that is purely THT exclusion must report OK."""
+        pcb = _create_pcb_with_mixed_footprints(tmp_path, ["R1", "C1"], ["J1"])
+        sch = tmp_path / "board.kicad_sch"
+        sch.write_text('(kicad_sch (version 20231120) (generator "eeschema"))')
+
+        checker = PreflightChecker(
+            pcb_path=pcb,
+            schematic_path=sch,
+            manufacturer="jlcpcb-tier1",
+            config=PreflightConfig(skip_drc=True, skip_erc=True),
+        )
+        checker.run_all()
+
+        from kicad_tools.schema.bom import BOM, BOMItem
+
+        # J1 is on the PCB but absent from the BOM -- exactly the shape that
+        # produced "1 in CPL but not in BOM" FAIL before the fix.
+        bom = BOM(
+            items=[
+                BOMItem(reference="R1", value="10k", footprint="R_0402", lib_id="Device:R"),
+                BOMItem(reference="C1", value="100nF", footprint="C_0402", lib_id="Device:C"),
+            ]
+        )
+        monkeypatch.setattr(checker, "_load_bom", lambda: bom)
+
+        result = checker._check_bom_cpl_match()
+        assert result.status == "OK"
+        assert "THT excluded" in result.message
+
+    def test_include_tht_override_wins_for_both_ids(self, tmp_path):
+        """Explicit ``exclude_tht=False`` (--include-tht) keeps precedence."""
+        pcb = _create_pcb_with_mixed_footprints(tmp_path, ["R1"], ["J1"])
+        for mfr in ("jlcpcb", "jlcpcb-tier1"):
+            checker = PreflightChecker(
+                pcb_path=pcb,
+                manufacturer=mfr,
+                exclude_tht=False,
+                config=PreflightConfig(skip_drc=True, skip_erc=True),
+            )
+            assert checker._exclude_tht is False, mfr
+            checker.run_all()
+            result = checker._check_tht_in_cpl()
+            assert result.status == "WARN", mfr
+            assert "SMT-only" in result.message
+            # The user-facing message names the ID the user actually passed.
+            assert mfr in result.message
+
+    def test_non_jlc_family_still_includes_tht(self, tmp_path):
+        pcb = _create_pcb_with_mixed_footprints(tmp_path, ["R1"], ["J1"])
+        checker = PreflightChecker(
+            pcb_path=pcb,
+            manufacturer="generic",
+            config=PreflightConfig(skip_drc=True, skip_erc=True),
+        )
+        assert checker._exclude_tht is False
+        checker.run_all()
+        result = checker._check_tht_in_cpl()
+        assert result.status == "OK"
+        assert "included in CPL" in result.message
+
+    def test_drc_limits_still_use_full_manufacturer_id(self, tmp_path, monkeypatch):
+        """Tier DRC limits must NOT be resolved through the fab family."""
+        import kicad_tools.manufacturers as mfr_mod
+
+        seen: list[str] = []
+        real_get_profile = mfr_mod.get_profile
+
+        def _spy(manufacturer_id: str):
+            seen.append(manufacturer_id)
+            return real_get_profile(manufacturer_id)
+
+        monkeypatch.setattr(mfr_mod, "get_profile", _spy)
+
+        pcb = _create_pcb_with_footprints(tmp_path, ["R1"])
+        checker = PreflightChecker(
+            pcb_path=pcb,
+            manufacturer="jlcpcb-tier1",
+            config=PreflightConfig(skip_drc=True, skip_erc=True),
+        )
+        checker._get_manufacturer_limits()
+        assert seen == ["jlcpcb-tier1"]


### PR DESCRIPTION
## Summary

`kct export --mfr jlcpcb-tier1` embedded a false `bom_cpl_match` **FAIL** and a stale
`bom_fields` LCSC **WARN** into `manifest.json`. Per the Curator's verified root-cause
analysis these are **two independent defects**, and only one of them is an ordering
problem — so the originally-suggested "move preflight after enrichment" fix is *not*
what this PR does (it would regress the deliberate pre-write invariant at
`manufacturing.py:355-424` that lets `--strict-preflight` abort with nothing on disk).

**Bug A (the FAIL) — fixed at source, not post-hoc.** `PreflightChecker._SMT_ONLY_MANUFACTURERS`
is an exact-match set `{"jlcpcb"}` that was compared against the *raw* `--mfr` value, so
`jlcpcb-tier1` yielded `_exclude_tht = False`. The CPL writer resolves the fab **family**
first (`assembly.py` → `get_fab_family()` → `JLCPCBPnPFormatter`, `exclude_tht=True`) and
does omit THT. That desync produced both the false `tht_in_cpl` "included in CPL" and the
`bom_cpl_match` FAIL (BOM-absent THT connectors counted as "in CPL but not in BOM").

**Bug B (the LCSC WARN) — the genuine ordering issue.** `_check_bom_fields()` predicts the
spec-overlay path via `_spec_lcsc_refs()` (#3926/#3932) but has no `--auto-lcsc` equivalent,
and cannot have one: `enrich_bom_lcsc()` does parts-API / cache I/O that preflight must not
perform. Reconciled post-assembly instead.

## Changes

- `src/kicad_tools/export/preflight.py`
  - `PreflightChecker.__init__` resolves `self._fab_family = get_fab_family(self.manufacturer)`
    once (lazy import, matching the file's existing style) and the `_exclude_tht` default now
    tests the **family** against `_SMT_ONLY_MANUFACTURERS`.
  - `_check_tht_in_cpl()`'s SMT-only comparison keys off `self._fab_family`; the user-facing
    message still prints the original `self.manufacturer` so `jlcpcb-tier1` appears in the text.
  - `_check_bom_cpl_match()` is fixed **transitively** (its body is unchanged — it reads
    `self._exclude_tht`).
  - `_get_manufacturer_limits()` still calls `get_profile(self.manufacturer)` with the **full**
    tier ID — deliberately unchanged, now guarded by a regression test.
- `src/kicad_tools/export/manufacturing.py`
  - New private `ManufacturingPackage._reconcile_preflight_lcsc()` plus one call site in
    `export()` between the `assembly_ok` guard and Step 2. It rewrites the recorded
    `bom_fields` entry from `result.assembly_result.lcsc_enrichment`:
    - `unmatched == 0` → `OK` with a `N group(s) received LCSC from enrichment` note;
    - otherwise `WARN` naming only the genuinely-unmatched references;
    - **never** downgrades a `FAIL`; preserves missing-footprint / missing-value clauses and
      informational notes verbatim; no-ops with no enrichment report (`--no-auto-lcsc`,
      non-JLCPCB family) or no preflight results (`--skip-preflight`).
- Tests: 6 new cases in `tests/test_preflight.py`, 7 new cases in `tests/test_manufacturing_package.py`.

**`_build_manifest()` is NOT touched** (reserved for sibling #4590). It already serializes
`result.preflight_results`, so reconciling that list upstream fixes both the manifest and the
CLI summary with zero consumer changes.

## Acceptance Criteria Verification

- [x] `PreflightChecker(manufacturer="jlcpcb-tier1")` with no explicit `exclude_tht` resolves
      `_exclude_tht is True` — `test_tier_id_resolves_exclude_tht`.
- [x] `tht_in_cpl` reports `OK ... excluded from CPL` with THT refs still in `details` —
      `test_tier_id_tht_in_cpl_reports_excluded`.
- [x] `bom_cpl_match` no longer counts THT-only refs under "in CPL but not in BOM"; reports
      `OK` with a `N THT excluded` info part — `test_tier_id_bom_cpl_match_no_false_fail`.
- [x] `--include-tht` still forces `_exclude_tht = False` for **both** `jlcpcb` and
      `jlcpcb-tier1` — `test_include_tht_override_wins_for_both_ids`.
- [x] `preflight.py` `_get_manufacturer_limits()` still calls `get_profile()` with the full ID
      — `test_drc_limits_still_use_full_manufacturer_id` (spies on the resolver, asserts
      `seen == ["jlcpcb-tier1"]`).
- [x] After `--auto-lcsc` resolves every active item, the `bom_fields` entry in `manifest.json`
      is `OK` — `test_fully_enriched_warn_becomes_ok` (reads the written manifest).
- [x] A `bom_fields` `FAIL` is never downgraded — `test_fail_is_never_downgraded`.
- [x] `--skip-preflight` / `--strict-preflight` unchanged; strict still aborts pre-write —
      `test_skip_preflight_reconciliation_noop` plus the pre-existing
      `test_strict_preflight_blocks_export` (asserts `not out_dir.exists()`), still green.
- [x] The #3926/#3932 spec-overlay tests pass **unchanged** — `TestManufacturingPreflightSpecOverlay`
      untouched; `test_ok_entry_without_lcsc_clause_untouched` additionally pins that the
      spec-overlay note is not rewritten.
- [x] No change to `_build_manifest()`'s `files_info` loop (reserved for #4590) — the diff
      touches no line inside `_build_manifest()`.

## Test Plan

**Manual before/after** (synthetic 3×SMD + 2×THT board, `export_cmd.main` with
`--bom-source pcb --skip-drc --skip-erc --no-auto-lcsc`; note the top-level `kct export`
shim does not forward `--bom-source`, so the module entry point was used):

BEFORE (`origin/main` @ 092611b0):

```
===== --mfr jlcpcb =====
  [OK]   tht_in_cpl: 2 through-hole component(s) excluded from CPL
  [OK]   bom_cpl_match: BOM and CPL references match (3 components, 2 THT excluded)
CPL cpl_jlcpcb.csv: THT (J1/J2) rows = 0

===== --mfr jlcpcb-tier1 =====
  [OK]   tht_in_cpl: 2 through-hole component(s) included in CPL     <-- FALSE
  [OK]   bom_cpl_match: BOM and CPL references match (5 components)  <-- counts THT
CPL cpl_jlcpcb.csv: THT (J1/J2) rows = 0
```

AFTER (this branch) — tier1 now matches the parent fab exactly:

```
===== --mfr jlcpcb =====
  [OK]   tht_in_cpl: 2 through-hole component(s) excluded from CPL
  [OK]   bom_cpl_match: BOM and CPL references match (3 components, 2 THT excluded)
CPL cpl_jlcpcb.csv: THT (J1/J2) rows = 0

===== --mfr jlcpcb-tier1 =====
  [OK]   tht_in_cpl: 2 through-hole component(s) excluded from CPL
  [OK]   bom_cpl_match: BOM and CPL references match (3 components, 2 THT excluded)
CPL cpl_jlcpcb.csv: THT (J1/J2) rows = 0
```

**Automated:**

```
$ uv run pytest tests/test_preflight.py tests/test_manufacturing_package.py tests/test_export.py --no-cov -q
........................................................................ [ 32%]
........................................................................ [ 65%]
........................................................................ [ 98%]
....                                                                     [100%]
220 passed in 1.12s
```

Related suites that reference `PreflightChecker` or the THT filter:

```
$ uv run pytest tests/test_board_05_export.py tests/test_bom_pcb_source.py \
    tests/test_lcsc_value_guard.py tests/test_lcsc_package_guard.py \
    tests/test_pipeline_cmd.py tests/test_bom_enrich.py tests/test_export_cmd.py \
    tests/test_assembly_validation.py --no-cov -q
478 passed in 31.13s
```

(`tests/test_bom_enrich.py::TestEnrichBomLcsc::test_null_list_yields_clean_unmatched_reason`
failed on the first pass purely because the fresh worktree venv lacked the optional `parts`
extra — `LCSCDependencyMissingError: requests ...`. After `uv sync --extra dev --extra parts`
it passes; `uv.lock` is unchanged.)

Full-coverage runs (the repo default `addopts`) also pass:
`tests/test_preflight.py` → `76 passed in 1162.79s`.

**Lint / type:**

```
$ uv run ruff check .        -> All checks passed!
$ uv run ruff format . --check -> 1725 files already formatted
$ uv run python scripts/ci/check_mypy_baseline.py
OK: mypy reports 1473 error(s), all within the baseline (1474 allowed). No new type errors.
```

(The baseline gate emits its usual "1 baseline error no longer occurs" nag — environment
dependent, unrelated to this diff; the per-file error counts for `preflight.py` and
`manufacturing.py` are identical to the baseline's 14. Baseline left untouched per the
known native-env `--update` trap.)

Closes #4591
