### PR TITLE
feat(route): gate every engine on a post-route board-level HV pairwise audit

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1171,17 +1171,24 @@ kct symbols project.kicad_sch --format json
 ### `kct route` ladder
 
 The router exposes a finer-grained ladder so CI can tell partial routing
-apart from clean routing with DRC issues. Source of truth: the epilog at
-[`src/kicad_tools/cli/route_cmd.py:4051-4059`](../../src/kicad_tools/cli/route_cmd.py).
+apart from clean routing with DRC issues. Source of truth: the `exit codes:`
+epilog in [`src/kicad_tools/cli/route_cmd.py`](../../src/kicad_tools/cli/route_cmd.py)
+(`build_parser`), expanded by the `# Exit codes:` comment block in `main()`.
 
 | Code | Meaning |
 |------|---------|
 | 0 | All nets routed (or meets `--min-completion`), DRC clean |
 | 1 | Fatal failure — no nets routed |
 | 2 | Partial routing — below `--min-completion` threshold |
-| 3 | Routing meets threshold **but** DRC violations remain — **also** returned when `--auto-fix` rollback fires (issue #2852). Both meanings share this code by design (see `route_cmd.py:2576-2580`). |
-| 4 | Partial routing **and** segment-segment clearance violations |
+| 3 | Routing meets threshold **but** the copper is clearance-dirty. Three meanings share this code by design: DRC violations remain; `--auto-fix` rolled back on a connectivity regression (issue #2852); or the post-route board-level HV pairwise-clearance audit under `--voltage-map` found violations the engine's search let through (issue #4588). In every case "routing succeeded, but the resulting copper cannot be trusted". |
+| 4 | Partial routing **and** clearance violations remain — segment-segment (issue #1666) or HV pairwise (issue #4588) |
 | 5 | Interrupted by SIGINT with partial results saved (file on disk is valid) |
+| 8 | `--complete`: one or more previously-unconnected links remain unroutable (issue #4477) |
+
+> **Consumer note (issue #4588).** `kct build` and `kct pipeline` treat exit 3
+> as a non-fatal warning. Neither forwards `--voltage-map` today, so the HV
+> meaning of 3 cannot reach them; threading the flag through and making the
+> pairwise-dirty result fatal there is tracked as issue #4607.
 
 ### `kct optimize-placement`
 

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -70,9 +70,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
 
     from kicad_tools.router import Autorouter, LayerStack
+    from kicad_tools.router.pairwise_clearance import AttachZone, PairwiseViolation
     from kicad_tools.router.primitives import Route
 
 # Issue #3035: ``_auto_skip_pour_nets`` was promoted to a public helper at
@@ -3849,10 +3850,224 @@ def _apply_pairwise_clearance(router: "Autorouter", args, quiet: bool = False) -
     if not quiet:
         from kicad_tools.cli.progress import flush_print
 
+        # Issue #4588: name the enforcement that will ACTUALLY run.  Only the
+        # grid engines consult ``rules.pairwise_clearance`` during search
+        # (``router/pathfinder.py``, ``router/cpp_backend.py``, the C++ halo);
+        # lattice/mesh resolve clearance as a pure scalar, so claiming
+        # "route-time creepage rejection active" there was the reassuring line
+        # that made the false pass silent.  Both engines are now covered by the
+        # post-route board audit (``_audit_pairwise_clearance``).
+        engine = getattr(args, "route_engine", "grid") or "grid"
+        enforcement = (
+            "route-time rejection + post-route audit"
+            if engine == "grid"
+            else f"post-route audit only -- the {engine} search is pairwise-blind"
+        )
         flush_print(
             f"  HV pairwise clearance: {len(voltages)} mapped nets, "
-            f"{len(required)} cross-pairs (route-time creepage rejection active)"
+            f"{len(required)} cross-pairs ({enforcement})"
         )
+
+
+def _pairwise_attach_zones(router: "Autorouter") -> "tuple[AttachZone, ...]":
+    """Resolve (and memoise) the #4506 rated-footprint attach zones for *router*.
+
+    ``_apply_pairwise_clearance`` builds these only when the active pathfinder
+    exposes ``set_attach_zones`` (the grid engines).  The post-route audit gate
+    (#4588) needs them on **every** engine, so this helper resolves them
+    independently from ``router._pairwise_attach_zone_pcb_path`` and caches the
+    result on the router -- loading the PCB twice per run would be pure waste.
+
+    Returns an empty tuple when no source board path was recorded (attach-zone
+    exemption then simply does not apply, which is the pre-#4506 behaviour).
+    """
+    cached: tuple[AttachZone, ...] | None = getattr(router, "_pairwise_attach_zones_cache", None)
+    if cached is not None:
+        return cached
+
+    pcb_path = getattr(router, "_pairwise_attach_zone_pcb_path", None)
+    zones: tuple[AttachZone, ...] = ()
+    if pcb_path is not None:
+        from kicad_tools.router.pairwise_clearance import build_attach_zones
+        from kicad_tools.schema.pcb import PCB
+
+        try:
+            zones = tuple(build_attach_zones(PCB.load(pcb_path).footprints))
+        except Exception:  # pragma: no cover - defensive: never fail the audit
+            zones = ()
+    with contextlib.suppress(AttributeError):  # exotic router stand-ins
+        router._pairwise_attach_zones_cache = zones  # type: ignore[attr-defined]
+    return zones
+
+
+def _audit_pairwise_clearance(
+    router: "Autorouter", args, *, id_to_name=None
+) -> "list[PairwiseViolation]":
+    """Board-level post-route pairwise (HV creepage) audit -- issue #4588.
+
+    ``rules.pairwise_clearance`` is consumed **only** by the grid engines'
+    route-acceptance predicates (``router/pathfinder.py``, ``router/cpp_backend.py``
+    and the C++ ``Grid3D`` halo).  The lattice and mesh engines resolve clearance
+    as a pure scalar, so a ``--voltage-map`` run on those engines committed HV
+    copper at DRU spacing while still printing the reassuring ``HV pairwise
+    clearance: N mapped nets`` line -- a silent false pass of a safety feature.
+
+    This audit closes that hole engine-agnostically: every engine commits copper
+    by appending to ``router.routes``, so a whole-board scan of that list catches
+    what the search let through, regardless of which search produced it.
+
+    Returns a list of :class:`~kicad_tools.router.pairwise_clearance.PairwiseViolation`
+    sorted worst-shortfall-first.  A strict no-op (empty list, no board load, no
+    scan) when ``--voltage-map`` was not supplied, so every pre-existing run is
+    byte-identical.
+
+    Scope: **trace-to-trace, same layer only** (the limit of
+    ``find_pairwise_violations``).  Pad/via geometry is the ``kct creepage``
+    census' remit; the failure banner says so.
+    """
+    if getattr(args, "_pairwise_required", None) is None:
+        return []
+    rules = getattr(router, "rules", None)
+    table = getattr(rules, "pairwise_clearance", None) if rules is not None else None
+    if table is None:
+        return []
+    routes = list(getattr(router, "routes", None) or [])
+    if not routes:
+        return []
+
+    from kicad_tools.router.pairwise_clearance import find_pairwise_violations
+
+    violations = find_pairwise_violations(
+        routes,
+        table,
+        id_to_name=id_to_name,
+        dru=table.dru,
+        attach_zones=_pairwise_attach_zones(router),
+    )
+    # A single conflicting corridor is decomposed into many collinear segment
+    # pairs that all report the SAME net pair, gap and location.  Collapse the
+    # exact duplicates so the count reflects distinct defects rather than
+    # segment granularity (this can only shrink the list, never empty a
+    # non-empty one, so the gate's fire/no-fire decision is unaffected).
+    unique: dict[tuple, PairwiseViolation] = {}
+    for v in violations:
+        key = (
+            v.net_a,
+            v.net_b,
+            round(v.x, 3),
+            round(v.y, 3),
+            round(v.actual_mm, 4),
+            round(v.required_mm, 4),
+        )
+        unique.setdefault(key, v)
+    deduped = list(unique.values())
+    # Worst shortfall first; net names/coords break ties so the ordering is
+    # fully deterministic (CI diffs the banner text).
+    deduped.sort(key=lambda v: (-(v.required_mm - v.actual_mm), v.net_a, v.net_b, v.x, v.y))
+    return deduped
+
+
+def _format_pairwise_violations(violations: "Sequence[PairwiseViolation]", limit: int = 10) -> str:
+    """Render pairwise violations in the ``router/io.py`` clearance-report shape.
+
+    ``[trace] /NET_A vs /NET_B: X.XXXmm (required Y.YYYmm) at (x, y)`` with an
+    ``... and K more`` tail, so the output is diffable against ``kct creepage``.
+    """
+    lines = [
+        f"  [trace] {v.net_a} vs {v.net_b}: {v.actual_mm:.3f}mm "
+        f"(required {v.required_mm:.3f}mm) at ({v.x:.3f}, {v.y:.3f})"
+        for v in violations[:limit]
+    ]
+    remaining = len(violations) - limit
+    if remaining > 0:
+        lines.append(f"  ... and {remaining} more")
+    return "\n".join(lines)
+
+
+def _print_pairwise_addendum(violations: "Sequence[PairwiseViolation]") -> None:
+    """Fold pairwise findings into an already-failing summary (issue #4588).
+
+    Used by the ``PARTIAL`` / ``ROUTING FAILED: DRC`` branches so a run that is
+    dirty for several reasons still prints exactly one coherent report.
+    """
+    print(f"  Additionally, {len(violations)} HV pairwise clearance violation(s) detected:")
+    print(_format_pairwise_violations(violations, limit=5))
+    print("  (trace-to-trace only; run 'kct creepage' for the full census)")
+
+
+def _pairwise_escalation_exit(rc: int, violations: "Sequence[PairwiseViolation]") -> int:
+    """Map an escalation wrapper's exit code through the #4588 gate.
+
+    ``0`` (met the completion threshold) becomes ``3`` -- the established
+    "routing succeeded but the copper is clearance-dirty" contract -- and ``2``
+    (below threshold) becomes ``4``, mirroring ``main()``'s seg-seg handling.
+    Any other code (fatal, deadline, rollback) already carries a more specific
+    diagnosis and is passed through untouched.
+    """
+    if not violations:
+        return rc
+    if rc == 0:
+        return 3
+    if rc == 2:
+        return 4
+    return rc
+
+
+def _audit_pairwise_for_escalation(final_result, args) -> "list[PairwiseViolation]":
+    """Run the #4588 HV pairwise gate for the escalation wrapper flows.
+
+    ``route_with_layer_escalation`` / ``route_with_rule_relaxation`` /
+    ``route_with_combined_escalation`` are *terminal* paths: each owns its own
+    summary banner and exit-code block, and ``main()``'s post-DRC gate never
+    runs for them.  Because ``--auto-layers`` defaults to **True**, the
+    layer-escalation wrapper is the DEFAULT ``kct route`` path -- and the one
+    the issue-#4588 report actually exercised -- so gating only ``main()``'s
+    inline block would have left the audit dead where it matters most.
+
+    Safe to call after ``_release_routing_engine_state``: that helper
+    explicitly preserves ``router.routes``, which is all this audit reads.
+    """
+    return _audit_pairwise_clearance(
+        final_result.router,
+        args,
+        id_to_name={v: k for k, v in (getattr(final_result, "net_map", None) or {}).items()},
+    )
+
+
+def _print_pairwise_failure_banner(
+    violations: "Sequence[PairwiseViolation]", args, output_path
+) -> None:
+    """Print the #4588 ``ROUTING FAILED`` banner for board-level HV violations."""
+    print("ROUTING FAILED: pairwise HV clearance violations")
+    print("=" * 60)
+    print()
+    print(f"HV Pairwise Clearance ({len(violations)} violation(s)):")
+    print(_format_pairwise_violations(violations))
+    print()
+    print("Routed copper is closer than the --voltage-map derived creepage")
+    print("requirement for these net pairs. This board is NOT safe to manufacture.")
+    print()
+    print("Scope of this gate: trace-to-trace, same layer only. Pad and via")
+    print("geometry are not scanned here -- 'kct creepage' is the authoritative")
+    print("full census:")
+    vm = getattr(args, "voltage_map", None)
+    print(
+        f"  kct creepage {output_path} --voltage-map {vm} --standard "
+        f"{getattr(args, 'creepage_standard', 'iec60664')} --pollution-degree "
+        f"{getattr(args, 'pollution_degree', 2)} --material-group "
+        f"{getattr(args, 'material_group', 'IIIa')}"
+    )
+    engine = getattr(args, "route_engine", "grid") or "grid"
+    if engine != "grid":
+        # Issue #4588 gates; issue #4602 will teach the non-grid searches to
+        # AVOID the proximity instead of only reporting it.  Until then the
+        # only in-tool remedy is the engine that already enforces pairwise
+        # clearance during search (#4454 / #4511).
+        print()
+        print(f"  The {engine} search resolves clearance as a per-net scalar and cannot")
+        print("  avoid HV<->LV proximity (issue #4602). Remedies: re-route with")
+        print("  --route-engine grid (route-time creepage rejection), widen the HV")
+        print("  corridor in placement, or add rated attach zones (#4506).")
 
 
 def _warn_unresolved_net_class_map(resolution, board_net_names, nearest_fn) -> None:
@@ -5397,10 +5612,18 @@ def route_with_layer_escalation(
                 args=args,  # Issue #2802: honor total wall-clock deadline
             )
 
+    # Issue #4588: board-level HV pairwise clearance gate.  A no-op without
+    # --voltage-map; otherwise it audits the copper this engine committed.
+    _pairwise = _audit_pairwise_for_escalation(final_result, args)
+
     # Final summary
     if not quiet:
         print("\n" + "=" * 60)
-        if final_result.success:
+        if final_result.success and _pairwise:
+            # Issue #4588: this run would have printed a SUCCESS banner while
+            # its own copper violates the --voltage-map creepage requirement.
+            _print_pairwise_failure_banner(_pairwise, args, output_path)
+        elif final_result.success:
             print(f"SUCCESS: Design requires minimum {final_result.layer_count} layers")
         else:
             print(
@@ -5423,6 +5646,8 @@ def route_with_layer_escalation(
                 # path; suppress the redundant "Try --auto-layers" recommendation.
                 auto_layers_attempted=True,
             )
+            if _pairwise:
+                _print_pairwise_addendum(_pairwise)
 
     # Issue #2881: Stash the final router on args so an outer
     # ``route_with_mfr_tier_escalation`` wrapper can inspect
@@ -5448,10 +5673,10 @@ def route_with_layer_escalation(
         # detected") already covers this case semantically.
         if fix_result == 3:
             return 3
-        return 0
+        return _pairwise_escalation_exit(0, _pairwise)
     # Partial routing: some nets were routed but not all — pipeline should continue
     if final_result.nets_routed > 0:
-        return 2
+        return _pairwise_escalation_exit(2, _pairwise)
     # Nothing was routed — treat as fatal failure
     return 1
 
@@ -6115,10 +6340,16 @@ def route_with_rule_relaxation(
                 args=args,  # Issue #2802: honor total wall-clock deadline
             )
 
+    # Issue #4588: board-level HV pairwise clearance gate (see the
+    # layer-escalation wrapper above for why each terminal path needs it).
+    _pairwise = _audit_pairwise_for_escalation(final_result, args)
+
     # Final summary
     if not quiet:
         print("\n" + "=" * 60)
-        if final_result.success:
+        if final_result.success and _pairwise:
+            _print_pairwise_failure_banner(_pairwise, args, output_path)
+        elif final_result.success:
             print("SUCCESS: Routing complete with adaptive rules")
             if final_result.tier > 0:
                 print(
@@ -6143,6 +6374,8 @@ def route_with_rule_relaxation(
                 nets_to_route_ids=_multi_pad_ids,
                 single_pad_count=getattr(final_result, "single_pad_count", 0),
             )
+            if _pairwise:
+                _print_pairwise_addendum(_pairwise)
 
     if final_result.success:
         # Issue #3238: propagate auto-fix-skipped-by-deadline.
@@ -6152,10 +6385,10 @@ def route_with_rule_relaxation(
         # detect a silent rollback on an otherwise-clean routing run.
         if fix_result == 3:
             return 3
-        return 0
+        return _pairwise_escalation_exit(0, _pairwise)
     # Partial routing: some nets were routed but not all — pipeline should continue
     if final_result.nets_routed > 0:
-        return 2
+        return _pairwise_escalation_exit(2, _pairwise)
     # Nothing was routed — treat as fatal failure
     return 1
 
@@ -8350,10 +8583,16 @@ def route_with_combined_escalation(
                 args=args,  # Issue #2802: honor total wall-clock deadline
             )
 
+    # Issue #4588: board-level HV pairwise clearance gate (see the
+    # layer-escalation wrapper above for why each terminal path needs it).
+    _pairwise = _audit_pairwise_for_escalation(final_result, args)
+
     # Final summary
     if not quiet:
         print("\n" + "=" * 60)
-        if final_result.success:
+        if final_result.success and _pairwise:
+            _print_pairwise_failure_banner(_pairwise, args, output_path)
+        elif final_result.success:
             print(
                 f"SUCCESS: Minimum viable config = {final_result.layer_count} layers + "
                 f"tier {final_result.tier} rules"
@@ -8380,6 +8619,8 @@ def route_with_combined_escalation(
                 # recommendation.
                 auto_layers_attempted=True,
             )
+            if _pairwise:
+                _print_pairwise_addendum(_pairwise)
 
     if final_result.success:
         # Issue #3238: propagate auto-fix-skipped-by-deadline.
@@ -8389,10 +8630,10 @@ def route_with_combined_escalation(
         # detect a silent rollback on an otherwise-clean routing run.
         if fix_result == 3:
             return 3
-        return 0
+        return _pairwise_escalation_exit(0, _pairwise)
     # Partial routing: some nets were routed but not all — pipeline should continue
     if final_result.nets_routed > 0:
-        return 2
+        return _pairwise_escalation_exit(2, _pairwise)
     # Nothing was routed — treat as fatal failure
     return 1
 
@@ -13739,6 +13980,23 @@ def main(argv: list[str] | None = None) -> int:
 
     _rss.mark("post-drc")
 
+    # Issue #4588: board-level pairwise (HV creepage) gate.
+    #
+    # ``rules.pairwise_clearance`` is only consulted by the *grid* engines'
+    # route-acceptance predicates, so a ``--voltage-map`` run on ``--route-engine
+    # lattice``/``mesh`` previously committed HV copper at scalar-DRU spacing and
+    # still exited 0 with a SUCCESS banner.  Auditing the committed copper
+    # (``router.routes``) here catches that on every engine.  Runs *after* DRC
+    # and *before* the summary predicate; a strict no-op without ``--voltage-map``
+    # (and never on ``--dry-run``, where nothing was committed to disk).
+    # Deliberately NOT gated on ``--skip-drc``: this is not a DRC sub-step.
+    pairwise_violations: list = []
+    if not args.dry_run:
+        pairwise_violations = _audit_pairwise_clearance(
+            router, args, id_to_name={v: k for k, v in net_map.items()}
+        )
+    pairwise_violation_count = len(pairwise_violations)
+
     # Summary
     all_nets_routed = stats["nets_routed"] == nets_to_route
     drc_passed = drc_errors <= 0  # -1 means DRC failed to run, treat as passed
@@ -13755,7 +14013,13 @@ def main(argv: list[str] | None = None) -> int:
 
     if not quiet:
         print("\n" + "=" * 60)
-        if all_nets_routed and drc_passed:
+        if pairwise_violation_count > 0 and drc_passed and (all_nets_routed or meets_threshold):
+            # Issue #4588: this run would otherwise have printed a SUCCESS
+            # banner.  Board-level HV creepage violations make that a false
+            # pass, so the pairwise failure banner replaces it outright --
+            # SUCCESS must be unreachable while non-exempt violations exist.
+            _print_pairwise_failure_banner(pairwise_violations, args, output_path)
+        elif all_nets_routed and drc_passed:
             if drc_ran and drc_errors == 0:
                 print(f"SUCCESS: All signal nets routed, DRC passed!{summary_suffix}")
             else:
@@ -13798,12 +14062,22 @@ def main(argv: list[str] | None = None) -> int:
             print(f"  - Or re-route with auto-fix: kct route {args.pcb} --auto-fix")
             print()
             print(f"  Run 'kct check {output_path} --mfr {args.manufacturer}' for full details")
+            if pairwise_violation_count > 0:
+                # Issue #4588: one coherent failure report -- HV creepage is
+                # folded into the DRC banner rather than printing a second one.
+                print()
+                print(f"HV Pairwise Clearance ({pairwise_violation_count} violation(s)):")
+                print(_format_pairwise_violations(pairwise_violations))
+                print("  (trace-to-trace only; run 'kct creepage' for the full census)")
         else:
             print(
                 f"PARTIAL: Routed {stats['nets_routed']}/{nets_to_route} signal nets{summary_suffix}"
             )
             if drc_ran and drc_errors > 0:
                 print(f"  Additionally, {drc_errors} DRC violation(s) detected.")
+            if pairwise_violation_count > 0:
+                # Issue #4588: see the DRC branch above.
+                _print_pairwise_addendum(pairwise_violations)
 
             # Issue #2388: When the negotiated loop bailed out due to a
             # power-net stall, surface actionable suggestions naming the
@@ -13889,7 +14163,12 @@ def main(argv: list[str] | None = None) -> int:
     #     connectivity regression (fix-drc exit 3) — semantically the same
     #     contract ("routing succeeded but DRC is dirty"); callers cannot
     #     trust the post-route DRC state.
-    # 4 = Seg-seg clearance violations remain AND routing is below threshold (Issue #1666)
+    #     Issue #4588: also returned when the post-route board-level HV
+    #     pairwise-clearance audit (--voltage-map) finds violations the
+    #     engine's search let through — semantically a clearance failure, so
+    #     it shares the "routing succeeded but the copper is dirty" contract.
+    # 4 = Seg-seg or HV pairwise clearance violations remain AND routing is
+    #     below threshold (Issue #1666, extended by #4588)
     # 5 = Interrupted by SIGINT with partial results saved (handled in _handle_interrupt)
     # 6 = Connectivity regression detected (--strict mode only): either
     #     the optimize / DRC nudge phases reduced the number of fully-
@@ -13951,13 +14230,21 @@ def main(argv: list[str] | None = None) -> int:
     # but before every generic threshold-based code below.
     if getattr(args, "complete", False) and not all_nets_routed:
         return 8
-    elif meets_threshold and drc_passed and seg_seg_violation_count == 0:
+    elif (
+        meets_threshold
+        and drc_passed
+        and seg_seg_violation_count == 0
+        and pairwise_violation_count == 0
+    ):
         return 0
-    elif meets_threshold and (not drc_passed or seg_seg_violation_count > 0):
+    elif meets_threshold and (
+        not drc_passed or seg_seg_violation_count > 0 or pairwise_violation_count > 0
+    ):
         # Meets completion threshold but has DRC or clearance violations
+        # (including issue #4588 board-level HV pairwise creepage violations)
         return 3
-    elif not meets_threshold and seg_seg_violation_count > 0:
-        # Below threshold AND has seg-seg clearance violations
+    elif not meets_threshold and (seg_seg_violation_count > 0 or pairwise_violation_count > 0):
+        # Below threshold AND has seg-seg or HV pairwise clearance violations
         return 4
     else:
         # Partial routing: some nets routed but below threshold

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -66,6 +66,7 @@ import sys
 import textwrap
 import time
 from dataclasses import dataclass
+from dataclasses import replace as dataclass_replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -3828,11 +3829,7 @@ def _apply_pairwise_clearance(router: "Autorouter", args, quiet: bool = False) -
     if required is None or voltages is None:
         return
 
-    from kicad_tools.router.pairwise_clearance import (
-        PairwiseClearanceTable,
-        build_attach_zones,
-    )
-    from kicad_tools.schema.pcb import PCB
+    from kicad_tools.router.pairwise_clearance import PairwiseClearanceTable
 
     rules = getattr(router, "rules", None)
     if rules is None:
@@ -3845,7 +3842,11 @@ def _apply_pairwise_clearance(router: "Autorouter", args, quiet: bool = False) -
     pcb_path = getattr(router, "_pairwise_attach_zone_pcb_path", None)
     pathfinder = getattr(router, "router", None)
     if pathfinder is not None and pcb_path is not None and hasattr(pathfinder, "set_attach_zones"):
-        pathfinder.set_attach_zones(build_attach_zones(PCB.load(pcb_path).footprints))
+        # Issue #4588: route through the shared resolver so the grid search sees
+        # the same sheet-absolute zones the post-route audit does.  Building them
+        # inline here (pre-#4588) leaked board-relative footprint coordinates
+        # into a sheet-absolute pathfinder.
+        pathfinder.set_attach_zones(_pairwise_attach_zones(router))
 
     if not quiet:
         from kicad_tools.cli.progress import flush_print
@@ -3872,11 +3873,19 @@ def _apply_pairwise_clearance(router: "Autorouter", args, quiet: bool = False) -
 def _pairwise_attach_zones(router: "Autorouter") -> "tuple[AttachZone, ...]":
     """Resolve (and memoise) the #4506 rated-footprint attach zones for *router*.
 
-    ``_apply_pairwise_clearance`` builds these only when the active pathfinder
-    exposes ``set_attach_zones`` (the grid engines).  The post-route audit gate
-    (#4588) needs them on **every** engine, so this helper resolves them
-    independently from ``router._pairwise_attach_zone_pcb_path`` and caches the
-    result on the router -- loading the PCB twice per run would be pure waste.
+    This is the single resolver for both consumers: ``_apply_pairwise_clearance``
+    hands the result to the grid pathfinder's ``set_attach_zones``, and the
+    post-route audit gate (#4588) uses it on **every** engine.  The result is
+    cached on the router -- loading the PCB twice per run would be pure waste.
+
+    **Coordinate space.**  ``PCB.load`` detects the Edge.Cuts origin and exposes
+    footprint positions *board-relative* (``schema/pcb.py::_detect_board_origin``),
+    while both the routed segments (``router/io.py``) and the grid pathfinder work
+    in *sheet-absolute* millimetres.  The zones are therefore shifted by
+    ``pcb.board_origin`` -- the same board-relative -> sheet-absolute offset
+    ``Segment.to_sexp``/``Via.to_sexp`` apply when writing copper (#4416).
+    Without the shift the #4506 exemption silently misses on every board that
+    does not sit at sheet origin (0, 0) -- i.e. on every real board.
 
     Returns an empty tuple when no source board path was recorded (attach-zone
     exemption then simply does not apply, which is the pre-#4506 behaviour).
@@ -3892,8 +3901,27 @@ def _pairwise_attach_zones(router: "Autorouter") -> "tuple[AttachZone, ...]":
         from kicad_tools.schema.pcb import PCB
 
         try:
-            zones = tuple(build_attach_zones(PCB.load(pcb_path).footprints))
-        except Exception:  # pragma: no cover - defensive: never fail the audit
+            pcb = PCB.load(pcb_path)
+            ox, oy = pcb.board_origin
+            zones = tuple(
+                dataclass_replace(
+                    zone,
+                    min_x=zone.min_x + ox,
+                    min_y=zone.min_y + oy,
+                    max_x=zone.max_x + ox,
+                    max_y=zone.max_y + oy,
+                )
+                for zone in build_attach_zones(pcb.footprints)
+            )
+        except Exception as exc:  # defensive: never fail the audit on a bad board
+            # Issue #4588: an empty tuple is indistinguishable from "no rated
+            # footprints on this board", so a silent swallow degrades straight
+            # into a false HARD fail.  Say so on stderr.
+            print(
+                f"Warning: could not build #4506 rated attach zones from {pcb_path} "
+                f"({type(exc).__name__}: {exc}); HV pairwise exemptions will not apply.",
+                file=sys.stderr,
+            )
             zones = ()
     with contextlib.suppress(AttributeError):  # exotic router stand-ins
         router._pairwise_attach_zones_cache = zones  # type: ignore[attr-defined]
@@ -9978,8 +10006,11 @@ def main(argv: list[str] | None = None) -> int:
               0  all nets routed (or meets --min-completion), DRC clean
               1  fatal failure -- no nets routed
               2  partial routing -- below --min-completion threshold
-              3  routing meets threshold but DRC violations remain
-              4  partial routing AND segment-segment clearance violations
+              3  routing meets threshold but the copper is clearance-dirty:
+                 DRC violations remain, --auto-fix rolled back (issue #2852),
+                 or the --voltage-map HV pairwise audit failed (issue #4588)
+              4  partial routing AND segment-segment or HV pairwise
+                 clearance violations (issues #1666, #4588)
               5  interrupted by SIGINT with partial results saved
               8  --complete: one or more unroutable links remain (issue #4477)
         """),
@@ -14167,6 +14198,10 @@ def main(argv: list[str] | None = None) -> int:
     #     pairwise-clearance audit (--voltage-map) finds violations the
     #     engine's search let through — semantically a clearance failure, so
     #     it shares the "routing succeeded but the copper is dirty" contract.
+    #     KNOWN GAP (issue #4607): build_cmd.py / pipeline_cmd.py treat exit 3
+    #     as a non-fatal warning (and label it a DRC failure).  Neither
+    #     forwards --voltage-map today, so the HV meaning cannot reach them;
+    #     #4607 threads the flag through and makes it fatal there.
     # 4 = Seg-seg or HV pairwise clearance violations remain AND routing is
     #     below threshold (Issue #1666, extended by #4588)
     # 5 = Interrupted by SIGINT with partial results saved (handled in _handle_interrupt)

--- a/src/kicad_tools/router/pairwise_clearance.py
+++ b/src/kicad_tools/router/pairwise_clearance.py
@@ -591,6 +591,7 @@ def find_pairwise_violations(
     *,
     id_to_name: Mapping[int, str] | None = None,
     dru: float | None = None,
+    attach_zones: Sequence[AttachZone] = (),
     tolerance: float = _PASS_TOLERANCE,
 ) -> list[PairwiseViolation]:
     """Scan a whole routed board for pairwise-clearance shortfalls (board-level).
@@ -600,6 +601,13 @@ def find_pairwise_violations(
     found (empty when the board satisfies all pairwise requirements).  Intended
     for a post-route board audit / tests; the in-loop validators use
     :func:`route_pairwise_violation` for early-exit.
+
+    ``attach_zones`` (issue #4588) carries the #4506 rated-footprint necking
+    regions through to :func:`segment_pair_violation`, exactly as
+    :func:`route_pairwise_violation` already does.  Omitting them would make
+    this scan report every deliberately-exempted domain-bridging footprint
+    (tap resistors, TO-220 packages, optocouplers) as a violation -- a false
+    *fail* that renders every HV board unroutable by construction.
     """
     materialised = list(routes)
     floor = table.dru if dru is None else dru
@@ -624,6 +632,7 @@ def find_pairwise_violations(
                         net_a_name=a_name,
                         net_b_name=b_name,
                         dru=floor,
+                        attach_zones=attach_zones,
                         tolerance=tolerance,
                     )
                     if violation is not None:

--- a/tests/router/test_pairwise_clearance.py
+++ b/tests/router/test_pairwise_clearance.py
@@ -371,6 +371,67 @@ def test_find_pairwise_violations_board_scan() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Issue #4588: the board scan must honour #4506 attach zones
+# ---------------------------------------------------------------------------
+
+
+def _hv_lv_board_routes() -> list[Route]:
+    """Two parallel HV/LV segments 0.3 mm apart -- above DRU, below creepage."""
+    return [
+        Route(net=1, net_name="/AC_LINE", segments=[_seg(0, 0, 5, 0, 1, "/AC_LINE")]),
+        Route(net=2, net_name="/GND", segments=[_seg(0, 0.5, 5, 0.5, 2, "/GND")]),
+    ]
+
+
+def test_find_pairwise_violations_without_attach_zone_reports() -> None:
+    """Baseline for the exemption test: the pair IS a violation unexempted."""
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    violations = find_pairwise_violations(_hv_lv_board_routes(), table)
+    assert len(violations) == 1
+    # Edge-to-edge gap is 0.3 mm (0.5 centre - two 0.1 half-widths), which is
+    # comfortably above the 0.2 mm DRU floor -- so an attach zone can waive it.
+    assert violations[0].actual_mm == pytest.approx(0.3)
+
+
+def test_find_pairwise_violations_honours_attach_zone_exemption() -> None:
+    """A rated-footprint attach zone covering the span suppresses the finding.
+
+    Without this (issue #4588), the post-route gate would fire on every
+    deliberately-exempted domain-bridging footprint and make HV boards
+    unroutable by construction -- a false fail as bad as the false pass.
+    """
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    zone = AttachZone(-1.0, -1.0, 6.0, 1.5, frozenset({"AC_LINE", "GND"}))
+    assert find_pairwise_violations(_hv_lv_board_routes(), table, attach_zones=(zone,)) == []
+
+
+def test_find_pairwise_violations_attach_zone_outside_span_still_reports() -> None:
+    """An attach zone that does not cover the gap point exempts nothing."""
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    far = AttachZone(50.0, 50.0, 60.0, 60.0, frozenset({"AC_LINE", "GND"}))
+    assert len(find_pairwise_violations(_hv_lv_board_routes(), table, attach_zones=(far,))) == 1
+
+
+def test_find_pairwise_violations_attach_zone_needs_both_nets() -> None:
+    """A zone listing only one of the two nets cannot waive the pair."""
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    partial = AttachZone(-1.0, -1.0, 6.0, 1.5, frozenset({"AC_LINE"}))
+    assert len(find_pairwise_violations(_hv_lv_board_routes(), table, attach_zones=(partial,))) == 1
+
+
+def test_find_pairwise_violations_attach_zone_never_waives_below_dru() -> None:
+    """Attach zones waive the HV *widening* only, never the scalar DRU floor."""
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    routes = [
+        Route(net=1, net_name="/AC_LINE", segments=[_seg(0, 0, 5, 0, 1, "/AC_LINE")]),
+        # 0.25 mm centre-to-centre -> 0.05 mm edge gap, below the 0.2 mm DRU.
+        Route(net=2, net_name="/GND", segments=[_seg(0, 0.25, 5, 0.25, 2, "/GND")]),
+    ]
+    zone = AttachZone(-1.0, -1.0, 6.0, 1.5, frozenset({"AC_LINE", "GND"}))
+    assert len(find_pairwise_violations(routes, table, attach_zones=(zone,))) == 1
+
+
+# ---------------------------------------------------------------------------
 # Backward compatibility
 # ---------------------------------------------------------------------------
 

--- a/tests/test_route_pairwise_gate_4588.py
+++ b/tests/test_route_pairwise_gate_4588.py
@@ -18,7 +18,13 @@ committed (``router.routes``), so it is engine-agnostic.  These tests pin:
 2. the identical board **without** ``--voltage-map`` -> gate is a strict no-op
    (exit 0, ``SUCCESS``, byte-identical copper);
 3. grid + ``--voltage-map`` on a board with no HV/LV proximity -> still exit 0
-   (the gate is not a false-positive source on the production default).
+   (the gate is not a false-positive source on the production default);
+4. a board whose only HV/LV proximity is inside a **rated domain-bridging
+   footprint** (#4506) -> exit 0 at *any* board origin.  ``PCB.load`` reports
+   footprint positions board-relative while ``router.routes`` are
+   sheet-absolute, so an unshifted attach zone silently misses on every board
+   that does not sit at sheet origin -- i.e. on every real board -- turning
+   this gate into a hard false fail.
 
 Boards are fully synthetic S-expression strings (same approach as
 ``test_route_offboard_gate.py``) -- the softstart rev-C board from the original
@@ -96,6 +102,55 @@ def _two_domain_board(lv_offset_mm: float) -> str:
   (net 1 "/HV_LINE")
   (net 2 "/LV_SENSE")
   (gr_rect (start 100 100) (end 130 116)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+{"".join(parts)})
+"""
+
+
+def _bridging_board(origin_x: float, origin_y: float) -> str:
+    """Board whose only HV/LV proximity lives inside a rated bridging footprint.
+
+    ``R5`` is the canonical #4506 domain-bridging part: pad 1 on ``/HV_LINE``,
+    pad 2 on ``/LV_SENSE``, 2 mm apart.  Each net's other terminal sits 9 mm
+    away, so the two nets come within the creepage requirement *only* across
+    R5's own body -- exactly what the attach-zone exemption exists to waive.
+    The board rectangle starts at ``(origin_x, origin_y)``, which is what
+    ``PCB._detect_board_origin`` picks up as the board origin.
+    """
+    ox, oy = origin_x, origin_y
+    bridge_pads = "\n    ".join(
+        [
+            _pad("1", -1.0, 0, 1, "/HV_LINE"),
+            _pad("2", 1.0, 0, 2, "/LV_SENSE"),
+        ]
+    )
+    parts = [
+        _fp("R1", 10, ox + 5.0, oy + 5.0, _pad("1", 0, 0, 1, "/HV_LINE")),
+        _fp("R5", 11, ox + 15.0, oy + 5.0, bridge_pads),
+        _fp("R3", 12, ox + 25.0, oy + 5.0, _pad("1", 0, 0, 2, "/LV_SENSE")),
+    ]
+    return f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general
+    (thickness 1.6)
+  )
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup
+    (pad_to_mask_clearance 0)
+  )
+  (net 0 "")
+  (net 1 "/HV_LINE")
+  (net 2 "/LV_SENSE")
+  (gr_rect (start {ox} {oy}) (end {ox + 30.0} {oy + 16.0})
     (stroke (width 0.1) (type default))
     (fill none)
     (layer "Edge.Cuts")
@@ -294,6 +349,101 @@ class TestGridUnaffected:
         assert rc == 0, captured
         assert "SUCCESS:" in captured
         assert "pairwise HV clearance violations" not in captured
+
+
+class TestAttachZoneExemptionCoordinateSpace:
+    """The #4506 exemption must survive a non-zero board origin (PR #4603).
+
+    Every pre-existing attach-zone test builds ``AttachZone`` literals in the
+    same space as its synthetic ``Route``s, so none of them *can* observe a
+    coordinate-space mismatch.  These tests vary only where the board sits on
+    the sheet: ``(0, 0)`` used to pass and every real origin used to fail with
+    a hard ``ROUTING FAILED``, because ``PCB.load`` hands back board-relative
+    footprint positions while ``router.routes`` are sheet-absolute.
+    """
+
+    # (0, 0) is the only origin the pre-fix code handled; 100/100 is the
+    # Judge's reproduction; 136/77.5 is boards/00-simple-led's real origin.
+    ORIGINS = [(0.0, 0.0), (100.0, 100.0), (136.0, 77.5)]
+
+    @pytest.mark.parametrize("origin", ORIGINS)
+    def test_rated_bridging_footprint_is_exempt_at_any_board_origin(
+        self, origin: tuple[float, float], tmp_path: Path, capsys
+    ) -> None:
+        ox, oy = origin
+        pcb = tmp_path / f"bridge_{ox}_{oy}.kicad_pcb"
+        pcb.write_text(_bridging_board(ox, oy))
+        vmap = _write_voltage_map(tmp_path)
+        out = tmp_path / f"bridge_{ox}_{oy}_routed.kicad_pcb"
+
+        rc = route_main(_route_args(pcb, out, "lattice", vmap))
+        captured = capsys.readouterr().out
+
+        assert rc == 0, f"origin {origin} exited {rc}\n{captured}"
+        assert "SUCCESS:" in captured
+        assert "ROUTING FAILED" not in captured
+        assert "pairwise HV clearance violations" not in captured
+
+    @pytest.mark.parametrize("origin", ORIGINS)
+    def test_grid_engine_shares_the_corrected_zones(
+        self, origin: tuple[float, float], tmp_path: Path, capsys
+    ) -> None:
+        """``_apply_pairwise_clearance`` feeds the pathfinder the same resolver.
+
+        The mis-spaced zones also blinded the grid engine's *route-time*
+        rejection, which walled the bridging footprint off and dropped the
+        board to 1/2 nets.  One shared helper repairs both paths.
+        """
+        ox, oy = origin
+        pcb = tmp_path / f"bridge_grid_{ox}_{oy}.kicad_pcb"
+        pcb.write_text(_bridging_board(ox, oy))
+        vmap = _write_voltage_map(tmp_path)
+        out = tmp_path / f"bridge_grid_{ox}_{oy}_routed.kicad_pcb"
+
+        rc = route_main(_route_args(pcb, out, "grid", vmap))
+        captured = capsys.readouterr().out
+
+        assert rc == 0, f"origin {origin} exited {rc}\n{captured}"
+        assert "Routed: 2/2 nets" in captured
+
+    def test_zones_are_returned_in_sheet_absolute_millimetres(self, tmp_path: Path) -> None:
+        """Pin the space directly: zones must be offset by ``pcb.board_origin``."""
+        from types import SimpleNamespace
+
+        from kicad_tools.cli.route_cmd import _pairwise_attach_zones
+
+        origin = (100.0, 100.0)
+        pcb = tmp_path / "space.kicad_pcb"
+        pcb.write_text(_bridging_board(*origin))
+
+        zones = _pairwise_attach_zones(SimpleNamespace(_pairwise_attach_zone_pcb_path=str(pcb)))
+
+        assert len(zones) == 1, f"expected only the 2-net bridging footprint, got {zones}"
+        zone = zones[0]
+        assert zone.net_names == frozenset({"HV_LINE", "LV_SENSE"})
+        # R5 sits 15 mm / 5 mm into a board whose origin is (100, 100), so the
+        # zone must straddle the sheet-absolute point (115, 105).
+        assert zone.min_x < 115.0 < zone.max_x, zone
+        assert zone.min_y < 105.0 < zone.max_y, zone
+        assert zone.exempts(115.0, 105.0, "/HV_LINE", "/LV_SENSE")
+
+    def test_unreadable_board_warns_on_stderr_instead_of_failing_silently(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """An empty tuple must never be mistaken for "no exemptions apply"."""
+        from types import SimpleNamespace
+
+        from kicad_tools.cli.route_cmd import _pairwise_attach_zones
+
+        broken = tmp_path / "broken.kicad_pcb"
+        broken.write_text("(kicad_pcb (this is not a board")
+
+        zones = _pairwise_attach_zones(SimpleNamespace(_pairwise_attach_zone_pcb_path=str(broken)))
+
+        assert zones == ()
+        err = capsys.readouterr().err
+        assert "rated attach zones" in err
+        assert "broken.kicad_pcb" in err
 
 
 class TestAuditHelper:

--- a/tests/test_route_pairwise_gate_4588.py
+++ b/tests/test_route_pairwise_gate_4588.py
@@ -1,0 +1,415 @@
+"""CLI-level tests for the post-route pairwise HV clearance gate (issue #4588).
+
+Before this gate, ``rules.pairwise_clearance`` was consumed **only** by the
+grid engines' route-acceptance predicates (``router/pathfinder.py``,
+``router/cpp_backend.py``, and the C++ ``Grid3D`` halo).  ``--route-engine
+lattice`` resolves clearance as a pure scalar
+(``router/lattice/pathfinder.py``: ``max(net_class.clearance,
+rules.trace_clearance)``), so a ``--voltage-map`` run on lattice committed HV
+copper at DRU spacing, printed a reassuring ``HV pairwise clearance: N mapped
+nets`` line, and exited 0 with ``SUCCESS`` -- a silent false pass of a safety
+feature on a mains board.
+
+The gate is a post-route, board-level audit of the copper the engine actually
+committed (``router.routes``), so it is engine-agnostic.  These tests pin:
+
+1. lattice + ``--voltage-map`` + planted HV/LV proximity -> non-zero exit,
+   ``ROUTING FAILED`` banner, no ``SUCCESS`` banner;
+2. the identical board **without** ``--voltage-map`` -> gate is a strict no-op
+   (exit 0, ``SUCCESS``, byte-identical copper);
+3. grid + ``--voltage-map`` on a board with no HV/LV proximity -> still exit 0
+   (the gate is not a false-positive source on the production default).
+
+Boards are fully synthetic S-expression strings (same approach as
+``test_route_offboard_gate.py``) -- the softstart rev-C board from the original
+report is local-only and must never be a CI dependency.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.route_cmd import main as route_main
+
+# 300 V vs 0 V under IEC 60664-1 / PD2 / material group IIIa needs millimetres
+# of creepage; the planted traces sit a few tenths of a mm apart, so the gate
+# has an unambiguous finding while the scalar DRU (0.2 mm) is satisfied.
+HV_VOLTS = 300.0
+
+
+def _pad(number: str, x: float, y: float, net: int, net_name: str) -> str:
+    return (
+        f'(pad "{number}" smd rect (at {x} {y}) (size 0.4 0.4) '
+        f'(layers "F.Cu" "F.Paste" "F.Mask") (net {net} "{net_name}"))'
+    )
+
+
+def _fp(ref: str, uid: int, x: float, y: float, pads: str) -> str:
+    return f"""  (footprint "Resistor_SMD:R_0603_1608Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000{uid:02d}")
+    (at {x} {y})
+    (property "Reference" "{ref}" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    {pads}
+  )
+"""
+
+
+def _two_domain_board(lv_offset_mm: float) -> str:
+    """Synthetic two-domain board: an HV pair and an LV pair running parallel.
+
+    Both nets are simple two-pad point-to-point links spanning the board
+    west-to-east.  ``lv_offset_mm`` is the north/south separation between the
+    two corridors: a small value forces the routed copper into HV/LV proximity
+    that satisfies the scalar DRU but violates the creepage requirement, while
+    a large value keeps the corridors far apart (the clean control board).
+    """
+    hv_y = 105.0
+    lv_y = hv_y + lv_offset_mm
+    parts = [
+        _fp("R1", 10, 103.0, hv_y, _pad("1", 0, 0, 1, "/HV_LINE")),
+        _fp("R2", 11, 127.0, hv_y, _pad("1", 0, 0, 1, "/HV_LINE")),
+        _fp("R3", 12, 103.0, lv_y, _pad("1", 0, 0, 2, "/LV_SENSE")),
+        _fp("R4", 13, 127.0, lv_y, _pad("1", 0, 0, 2, "/LV_SENSE")),
+    ]
+    return f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general
+    (thickness 1.6)
+  )
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup
+    (pad_to_mask_clearance 0)
+  )
+  (net 0 "")
+  (net 1 "/HV_LINE")
+  (net 2 "/LV_SENSE")
+  (gr_rect (start 100 100) (end 130 116)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+{"".join(parts)})
+"""
+
+
+def _strip_uuids(text: str) -> str:
+    """Drop the freshly-generated per-element ``uuid`` lines from a board."""
+    return re.sub(r'\(uuid "[^"]*"\)', "(uuid)", text)
+
+
+def _write_voltage_map(tmp_path: Path) -> Path:
+    vmap = tmp_path / "vmap.json"
+    vmap.write_text(json.dumps({"/HV_LINE": HV_VOLTS, "/LV_SENSE": 0.0}))
+    return vmap
+
+
+def _route_args(pcb: Path, out: Path, engine: str, vmap: Path | None) -> list[str]:
+    args = [
+        str(pcb),
+        "-o",
+        str(out),
+        "--route-engine",
+        engine,
+        "--strategy",
+        "basic",
+        # The gate is deliberately NOT a DRC sub-step: --skip-drc must not
+        # disable it (and keeps these tests free of a kicad-cli dependency).
+        "--skip-drc",
+    ]
+    if vmap is not None:
+        args += [
+            "--voltage-map",
+            str(vmap),
+            "--creepage-standard",
+            "iec60664",
+            "--pollution-degree",
+            "2",
+            "--material-group",
+            "IIIa",
+        ]
+    return args
+
+
+@pytest.fixture
+def tight_board(tmp_path: Path) -> Path:
+    """HV and LV corridors 0.6 mm apart -- DRU-legal, creepage-illegal."""
+    pcb = tmp_path / "tight.kicad_pcb"
+    pcb.write_text(_two_domain_board(0.6))
+    return pcb
+
+
+@pytest.fixture
+def wide_board(tmp_path: Path) -> Path:
+    """HV and LV corridors 10 mm apart -- clears creepage by a wide margin."""
+    pcb = tmp_path / "wide.kicad_pcb"
+    pcb.write_text(_two_domain_board(10.0))
+    return pcb
+
+
+class TestLatticeGate:
+    """The engine that had zero pairwise awareness must no longer false-pass."""
+
+    def test_lattice_with_voltage_map_fails_on_hv_proximity(
+        self, tight_board: Path, tmp_path: Path, capsys
+    ) -> None:
+        vmap = _write_voltage_map(tmp_path)
+        out = tmp_path / "tight_routed.kicad_pcb"
+        rc = route_main(_route_args(tight_board, out, "lattice", vmap))
+        captured = capsys.readouterr().out
+
+        assert rc != 0, f"expected a non-zero exit, got {rc}\n{captured}"
+        assert "ROUTING FAILED" in captured
+        assert "pairwise HV clearance violations" in captured
+        # The SUCCESS banner must be unreachable in this state.
+        assert "SUCCESS:" not in captured
+        # Violation lines carry the census-diffable shape and name the census.
+        assert "/HV_LINE vs /LV_SENSE:" in captured or "/LV_SENSE vs /HV_LINE:" in captured
+        assert "(required " in captured
+        assert "kct creepage" in captured
+        # The failure must name the actual cause and an in-tool remedy rather
+        # than leaving the operator with a dead end (follow-up #4602).
+        assert "issue #4602" in captured
+        assert "--route-engine grid" in captured
+
+    def test_engagement_line_does_not_claim_route_time_enforcement_on_lattice(
+        self, tight_board: Path, tmp_path: Path, capsys
+    ) -> None:
+        """The pre-route ``HV pairwise clearance:`` line must be engine-honest.
+
+        The original defect was *silence*: the run printed ``(route-time
+        creepage rejection active)`` on an engine whose search never reads
+        ``rules.pairwise_clearance``.  That reassurance is what made the false
+        pass invisible, so it must not survive on the non-grid engines.
+        """
+        vmap = _write_voltage_map(tmp_path)
+        out = tmp_path / "engagement.kicad_pcb"
+        route_main(_route_args(tight_board, out, "lattice", vmap))
+        captured = capsys.readouterr().out
+
+        assert "HV pairwise clearance:" in captured
+        assert "post-route audit only" in captured
+        assert "route-time creepage rejection active" not in captured
+
+    def test_engagement_line_still_reports_route_time_rejection_on_grid(
+        self, wide_board: Path, tmp_path: Path, capsys
+    ) -> None:
+        """Grid genuinely rejects during search, so it must still say so."""
+        vmap = _write_voltage_map(tmp_path)
+        out = tmp_path / "engagement_grid.kicad_pcb"
+        route_main(_route_args(wide_board, out, "grid", vmap))
+        captured = capsys.readouterr().out
+
+        assert "HV pairwise clearance:" in captured
+        assert "route-time rejection + post-route audit" in captured
+
+    def test_lattice_without_voltage_map_is_a_strict_noop(
+        self, tight_board: Path, tmp_path: Path, capsys
+    ) -> None:
+        """Backward compatibility: no ``--voltage-map`` -> no gate, exit unchanged."""
+        out = tmp_path / "tight_noflag.kicad_pcb"
+        rc = route_main(_route_args(tight_board, out, "lattice", None))
+        captured = capsys.readouterr().out
+
+        assert rc == 0, captured
+        assert "SUCCESS:" in captured
+        assert "pairwise HV clearance violations" not in captured
+
+    def test_gate_is_copper_identical_to_the_ungated_run(
+        self, tight_board: Path, tmp_path: Path
+    ) -> None:
+        """The gate audits, it never edits: same copper with and without the flag.
+
+        The exit code differs -- that is the whole point -- but the copper
+        written to disk must be identical, proving the gate is a pure read-only
+        audit rather than a router behaviour change.  Per-element ``uuid``
+        values are freshly generated on every write and are compared out.
+        """
+        vmap = _write_voltage_map(tmp_path)
+        gated = tmp_path / "gated.kicad_pcb"
+        ungated = tmp_path / "ungated.kicad_pcb"
+        route_main(_route_args(tight_board, gated, "lattice", vmap))
+        route_main(_route_args(tight_board, ungated, "lattice", None))
+        assert _strip_uuids(gated.read_text()) == _strip_uuids(ungated.read_text())
+
+
+class TestNonEscalationPath:
+    """``--no-auto-layers`` takes ``main()``'s own post-DRC block, not a wrapper.
+
+    ``--auto-layers`` defaults to True, so the escalation wrappers own the
+    default flow; ``main()``'s inline summary/exit-code block is only reached
+    with ``--no-auto-layers``.  Both terminal paths must gate.
+    """
+
+    def test_inline_path_gates_on_hv_proximity(
+        self, tight_board: Path, tmp_path: Path, capsys
+    ) -> None:
+        vmap = _write_voltage_map(tmp_path)
+        out = tmp_path / "inline_routed.kicad_pcb"
+        rc = route_main(
+            _route_args(tight_board, out, "lattice", vmap) + ["--no-auto-layers", "--layers", "2"]
+        )
+        captured = capsys.readouterr().out
+
+        assert rc != 0, f"expected a non-zero exit, got {rc}\n{captured}"
+        assert "ROUTING FAILED: pairwise HV clearance violations" in captured
+        assert "SUCCESS:" not in captured
+
+    def test_inline_path_without_voltage_map_is_a_strict_noop(
+        self, tight_board: Path, tmp_path: Path, capsys
+    ) -> None:
+        out = tmp_path / "inline_noflag.kicad_pcb"
+        rc = route_main(
+            _route_args(tight_board, out, "lattice", None) + ["--no-auto-layers", "--layers", "2"]
+        )
+        captured = capsys.readouterr().out
+
+        assert rc == 0, captured
+        assert "SUCCESS:" in captured
+        assert "pairwise HV clearance violations" not in captured
+
+
+class TestGridUnaffected:
+    """The production default must not acquire a new false-positive source."""
+
+    def test_grid_with_voltage_map_on_a_clean_board_still_exits_zero(
+        self, wide_board: Path, tmp_path: Path, capsys
+    ) -> None:
+        vmap = _write_voltage_map(tmp_path)
+        out = tmp_path / "wide_routed.kicad_pcb"
+        rc = route_main(_route_args(wide_board, out, "grid", vmap))
+        captured = capsys.readouterr().out
+
+        assert rc == 0, captured
+        assert "SUCCESS:" in captured
+        assert "pairwise HV clearance violations" not in captured
+
+
+class TestAuditHelper:
+    """Unit-level coverage of the gate helper's edge cases (no routing)."""
+
+    def test_no_voltage_map_short_circuits_before_touching_the_router(self) -> None:
+        from types import SimpleNamespace
+
+        from kicad_tools.cli.route_cmd import _audit_pairwise_clearance
+
+        args = SimpleNamespace(_pairwise_required=None)
+
+        class _Exploding:
+            """Any attribute access would mean the no-op path did real work."""
+
+            def __getattr__(self, name):  # pragma: no cover - must never run
+                raise AssertionError(f"gate touched router.{name} without --voltage-map")
+
+        assert _audit_pairwise_clearance(_Exploding(), args) == []
+
+    def test_absent_table_is_a_noop(self) -> None:
+        from types import SimpleNamespace
+
+        from kicad_tools.cli.route_cmd import _audit_pairwise_clearance
+
+        args = SimpleNamespace(_pairwise_required={})
+        router = SimpleNamespace(rules=SimpleNamespace(pairwise_clearance=None), routes=[])
+        assert _audit_pairwise_clearance(router, args) == []
+
+    def test_empty_routes_are_a_noop(self) -> None:
+        from types import SimpleNamespace
+
+        from kicad_tools.cli.route_cmd import _audit_pairwise_clearance
+        from kicad_tools.router.pairwise_clearance import build_pairwise_clearance_table
+
+        table = build_pairwise_clearance_table({"/HV": HV_VOLTS, "/LV": 0.0}, dru=0.2)
+        args = SimpleNamespace(_pairwise_required={})
+        router = SimpleNamespace(rules=SimpleNamespace(pairwise_clearance=table), routes=[])
+        assert _audit_pairwise_clearance(router, args) == []
+
+    def test_net_absent_from_the_voltage_map_resolves_to_the_dru_floor(self) -> None:
+        """An unmapped net must not crash the scan.
+
+        ``PairwiseClearanceTable.required_clearance`` returns the DRU floor for
+        any pair absent from ``required_by_pair`` (the documented contract the
+        route-acceptance validators already rely on), so an unmapped net yields
+        no HV widening and therefore no finding.  The gate inherits that
+        semantics verbatim rather than inventing its own.
+        """
+        from types import SimpleNamespace
+
+        from kicad_tools.cli.route_cmd import _audit_pairwise_clearance
+        from kicad_tools.router.layers import Layer
+        from kicad_tools.router.pairwise_clearance import build_pairwise_clearance_table
+        from kicad_tools.router.primitives import Route, Segment
+
+        table = build_pairwise_clearance_table({"/HV": HV_VOLTS}, dru=0.2)
+        routes = [
+            Route(
+                net=1,
+                net_name="/HV",
+                segments=[Segment(0, 0, 5, 0, 0.2, Layer.F_CU, net=1, net_name="/HV")],
+            ),
+            Route(
+                net=2,
+                net_name="/UNMAPPED",
+                segments=[Segment(0, 0.4, 5, 0.4, 0.2, Layer.F_CU, net=2, net_name="/UNMAPPED")],
+            ),
+        ]
+        args = SimpleNamespace(_pairwise_required={})
+        router = SimpleNamespace(
+            rules=SimpleNamespace(pairwise_clearance=table),
+            routes=routes,
+            _pairwise_attach_zone_pcb_path=None,
+        )
+        assert _audit_pairwise_clearance(router, args) == []
+
+    def test_zero_hv_classified_nets_is_a_noop(self) -> None:
+        """A voltage map with no net above the HV threshold produces no findings."""
+        from types import SimpleNamespace
+
+        from kicad_tools.cli.route_cmd import _audit_pairwise_clearance
+        from kicad_tools.router.layers import Layer
+        from kicad_tools.router.pairwise_clearance import build_pairwise_clearance_table
+        from kicad_tools.router.primitives import Route, Segment
+
+        table = build_pairwise_clearance_table({"/A": 3.3, "/B": 0.0}, dru=0.2)
+        routes = [
+            Route(
+                net=1,
+                net_name="/A",
+                segments=[Segment(0, 0, 5, 0, 0.2, Layer.F_CU, net=1, net_name="/A")],
+            ),
+            Route(
+                net=2,
+                net_name="/B",
+                segments=[Segment(0, 0.4, 5, 0.4, 0.2, Layer.F_CU, net=2, net_name="/B")],
+            ),
+        ]
+        args = SimpleNamespace(_pairwise_required={})
+        router = SimpleNamespace(
+            rules=SimpleNamespace(pairwise_clearance=table),
+            routes=routes,
+            _pairwise_attach_zone_pcb_path=None,
+        )
+        assert _audit_pairwise_clearance(router, args) == []
+
+    def test_formatter_shape_and_more_tail(self) -> None:
+        from kicad_tools.cli.route_cmd import _format_pairwise_violations
+        from kicad_tools.router.pairwise_clearance import PairwiseViolation
+
+        violations = [
+            PairwiseViolation(net_a="/A", net_b="/B", actual_mm=0.4, required_mm=3.2, x=1.0, y=2.0)
+            for _ in range(12)
+        ]
+        text = _format_pairwise_violations(violations, limit=10)
+        assert "/A vs /B: 0.400mm (required 3.200mm)" in text
+        assert "... and 2 more" in text
+        assert len(text.splitlines()) == 11


### PR DESCRIPTION
## Summary

`--voltage-map` was accepted on every routing engine, but pairwise (HV creepage) clearance was only ever enforced as a **route-acceptance predicate inside the grid pathfinders** (`router/pathfinder.py:3787`, `router/cpp_backend.py:2388`, and the C++ `Grid3D` halo). `src/kicad_tools/router/lattice/**` contains **zero** occurrences of `pairwise`, `voltage`, or `domain` — it resolves clearance as a pure per-net scalar (`router/lattice/pathfinder.py:448-458`). So a `--voltage-map` run on `--route-engine lattice` committed HV copper at DRU spacing, printed a reassuring `(route-time creepage rejection active)` line, and exited **0** with `SUCCESS`, while `kct creepage` on the same output failed the board.

Nothing downstream could catch it either: the route CLI's success predicate is a function of `nets_routed` and scalar-DRU `drc_errors` only — pairwise clearance was not a term in it on **any** engine.

This PR adds a post-route, board-level pairwise audit of the copper the engine actually committed (`router.routes` — populated identically by grid, lattice and mesh) and folds it into the exit-code predicate and summary banner. **No clearance intelligence is added to the lattice search itself**; that remains unbuilt and is tracked in the newly-filed #4602 (cross-linked on epic #4431).

## Changes

**`src/kicad_tools/router/pairwise_clearance.py`**
- `find_pairwise_violations()` now forwards `attach_zones` to `segment_pair_violation()`, as the acceptance-time `route_pairwise_violation()` already did. Without this the gate would fire on every #4506-exempt rated domain-bridging footprint (tap resistors, TO-220, optos) and make HV boards unroutable by construction — a false *fail* as bad as the false pass. No change to `route_pairwise_violation`.

**`src/kicad_tools/cli/route_cmd.py`**
- `_pairwise_attach_zones()` — resolves + memoises the #4506 attach zones from `router._pairwise_attach_zone_pcb_path` on **every** engine (`_apply_pairwise_clearance` only builds them when the pathfinder exposes `set_attach_zones`, i.e. grid).
- `_audit_pairwise_clearance()` — reuses the already-shipped `find_pairwise_violations()` board scan, collapses duplicate collinear segment-pair findings, and sorts worst-shortfall-first for deterministic output. **Strict no-op** when `args._pairwise_required is None` (no `--voltage-map`), when the table is absent, when `router.routes` is empty, and on `--dry-run`. Deliberately **not** gated on `--skip-drc` — it is not a DRC sub-step.
- `_format_pairwise_violations()` / `_print_pairwise_failure_banner()` / `_print_pairwise_addendum()` — output in the existing `router/io.py` clearance-report shape with an `... and K more` tail; names `kct creepage` as the authoritative full census.
- Gate wired into `main()`'s post-DRC block **and** the three `route_with_*` escalation wrappers. `--auto-layers` defaults to **True**, so `route_with_layer_escalation` is the default `kct route` path and the one the report exercised — gating only `main()`'s inline block would have left the audit dead where it matters most. Exit `3` (met threshold, copper dirty) / `4` (below threshold), matching the established seg-seg clearance contract. `SUCCESS:` is unreachable while non-exempt violations exist; when DRC also fails, the pairwise findings are folded into the single existing failure banner rather than printing a second one.
- The pre-route engagement line is now **engine-honest** — that reassurance is exactly what made the false pass silent:
  - grid: `... (route-time rejection + post-route audit)`
  - lattice/mesh: `... (post-route audit only -- the lattice search is pairwise-blind)`
- On a non-grid engine the failure banner names the cause, the remedies, and follow-up #4602.

**Scope guard honoured:** the `--net-class-map` / `--voltage-map` preload block at `route_cmd.py:11490-11567` (reserved for #4587) is untouched. Nearest hunks are at old-file lines 8395 and 13741 — verified with `git diff -U0 | grep '^@@'`.

**Known limitation (stated, not papered over):** this gate is **trace-to-trace, same-layer only** — the limit of `find_pairwise_violations`. Pad↔trace and via↔copper pairs are not scanned, so the gate is a strict subset of the `kct creepage` census, not a parity match. The banner says so and points at `kct creepage`. Visible in the repro below: the gate's worst finding is 0.247 mm while the census (which walks pads) reports 0.200 mm.

## Acceptance Criteria Verification

| Criterion | Status |
|---|---|
| Board-level pairwise audit of `router.routes` after DRC, before the summary banner, on every engine | Done — `main()` + all three `route_with_*` wrappers |
| Non-exempt violations → `ROUTING FAILED` banner + non-zero exit; `SUCCESS` unreachable | Done — verified live (exit 3) and asserted in tests |
| `find_pairwise_violations` forwards `attach_zones` | Done — 5 new tests in `tests/router/test_pairwise_clearance.py` |
| Failure output uses `/NET_A vs /NET_B: X.XXXmm (required Y.YYYmm)` + `... and K more`, names `kct creepage`, states traces-only scope | Done — see live output below |
| Backward compat: no `--voltage-map` → strict no-op, byte-identical copper | Done — verified live (copper IDENTICAL modulo regenerated `uuid`s) and asserted by `test_gate_is_copper_identical_to_the_ungated_run` |
| lattice + `--voltage-map` + sub-creepage HV↔LV proximity → non-zero exit | Done — live exit 3 |
| grid + `--voltage-map` on a clean board → still exit 0 | Done — `TestGridUnaffected` |
| No change to `router/io.py::format_clearance_violations` or the attach-zone builder chasing "suppressed findings" | Done — neither file's reporter is touched (the report's mis-diagnosis is not carried into the code) |
| Follow-up for lattice search-time avoidance filed + cross-linked | Done — **#4602**, cross-linked with a scope note on epic **#4431** |

## Test Plan

### Live repro — lattice + `--voltage-map` on a synthetic two-domain board

`/HV_LINE` at 300 V vs `/LV_SENSE` at 0 V, IEC 60664-1 / PD2 / material group IIIa; corridors 0.6 mm apart (DRU-legal at 0.2 mm, creepage-illegal at 3.2 mm).

```
$ kct route tight.kicad_pcb -o tight_routed.kicad_pcb --route-engine lattice \
    --strategy basic --skip-drc --voltage-map vmap.json \
    --creepage-standard iec60664 --pollution-degree 2 --material-group IIIa

  HV pairwise clearance: 2 mapped nets, 1 cross-pairs (post-route audit only -- the lattice search is pairwise-blind)
  ...
  Routed: 2/2 nets (100%)
  Status: SUCCESS
  Result: Design routed successfully on 2 layers (100% completion)

============================================================
ROUTING FAILED: pairwise HV clearance violations
============================================================

HV Pairwise Clearance (43 violation(s)):
  [trace] /HV_LINE vs /LV_SENSE: 0.247mm (required 3.200mm) at (126.300, 105.600)
  [trace] /HV_LINE vs /LV_SENSE: 0.366mm (required 3.200mm) at (104.200, 105.400)
  [trace] /HV_LINE vs /LV_SENSE: 0.366mm (required 3.200mm) at (104.600, 105.800)
  [trace] /HV_LINE vs /LV_SENSE: 0.366mm (required 3.200mm) at (125.800, 105.800)
  [trace] /HV_LINE vs /LV_SENSE: 0.400mm (required 3.200mm) at (103.000, 105.300)
  [trace] /HV_LINE vs /LV_SENSE: 0.400mm (required 3.200mm) at (104.000, 105.300)
  [trace] /HV_LINE vs /LV_SENSE: 0.400mm (required 3.200mm) at (126.000, 105.700)
  [trace] /HV_LINE vs /LV_SENSE: 0.400mm (required 3.200mm) at (126.200, 105.700)
  [trace] /HV_LINE vs /LV_SENSE: 0.400mm (required 3.200mm) at (127.000, 105.300)
  [trace] /HV_LINE vs /LV_SENSE: 0.432mm (required 3.200mm) at (126.100, 105.700)
  ... and 33 more

Routed copper is closer than the --voltage-map derived creepage
requirement for these net pairs. This board is NOT safe to manufacture.

Scope of this gate: trace-to-trace, same layer only. Pad and via
geometry are not scanned here -- 'kct creepage' is the authoritative
full census:
  kct creepage tight_routed.kicad_pcb --voltage-map vmap.json --standard iec60664 --pollution-degree 2 --material-group IIIa

  The lattice search resolves clearance as a per-net scalar and cannot
  avoid HV<->LV proximity (issue #4602). Remedies: re-route with
  --route-engine grid (route-time creepage rejection), widen the HV
  corridor in placement, or add rated attach zones (#4506).

EXIT=3
```

Before this PR the same command ended `SUCCESS: Design requires minimum 2 layers`, exit **0**.

### Independent cross-check — `kct creepage` agrees

```
$ kct creepage tight_routed.kicad_pcb --voltage-map vmap.json --standard iec60664 \
    --pollution-degree 2 --material-group IIIa

HV net         Against        Layer     Clnce    ReqCl    Creep    ReqCr   Margin   Govern        Rel  Result
-------------------------------------------------------------------------------------------------------------
/HV_LINE       /LV_SENSE      F.Cu      0.200    0.200    0.200    3.200   -3.000  derived      board    FAIL
/HV_LINE       <board edge>   *         2.800    0.200    2.800    3.200   -0.400  derived      board    FAIL

FAIL: 2/2 pair(s) fail the derived creepage/clearance requirement.
```

(The census reports 0.200 mm where the gate reports 0.247 mm — the census walks pads, the gate does not. That is the documented traces-only scope, not a disagreement.)

### Live negative control — no `--voltage-map`

```
$ kct route tight.kicad_pcb -o ungated.kicad_pcb --route-engine lattice --strategy basic --skip-drc
...
============================================================
SUCCESS: Design requires minimum 2 layers

NO-VMAP EXIT=0

=== copper identical? ===
IDENTICAL
```

Copper written with and without the flag is byte-identical modulo the per-element `uuid`s that are regenerated on every write — the gate audits, it never edits.

### Automated

```
$ .venv/bin/python -m pytest tests/test_route_pairwise_gate_4588.py -q -p no:randomly --no-cov
14 passed, 12 warnings in 5.74s
```

```
$ .venv/bin/python -m pytest tests/router/test_pairwise_clearance.py -q -p no:randomly
34 passed in 20.74s
```

```
$ .venv/bin/python -m pytest tests/test_route_exit_codes.py tests/test_route_cmd_success_output.py \
    tests/test_route_offboard_gate.py tests/test_route_engine_strategy_gate.py \
    tests/test_route_auto_partial_cli_4165.py tests/router/test_pairwise_clearance.py \
    tests/router/test_pairwise_cpp_parity.py tests/test_route_pairwise_gate_4588.py \
    -q -p no:randomly --no-cov
200 passed, 9 warnings in 36.15s
```

Full router suite (regression check for false-fails on the production default), exit code 0, no failures:

```
$ .venv/bin/python -m pytest tests/router/ -q -p no:randomly --no-cov -x -q
............s..s........................................................ [ 26%]
..............................................s......................... [ 32%]
........................................................................ [ 39%]
   ... (all dots) ...
.............                                                            [100%]
exit 0
```

(The doubled `-q` suppresses the trailing count line; `-x` plus exit 0 is the pass signal. The `tests/router/lattice` subtree — the CLI-invoking part — was re-run after the final string edits: `149 passed, 2 skipped in 183.61s`.)

New coverage:
- `tests/test_route_pairwise_gate_4588.py` (new, 14 tests) — lattice+vmap → non-zero exit + banner + no `SUCCESS`; the `--no-auto-layers` inline path (`main()`'s own block) gated separately from the escalation wrappers; no-vmap strict no-op on both paths; copper-identity; grid+vmap on a clean board still exit 0; engine-honest engagement line on both engines; and unit coverage of the helper's edge cases (no vmap short-circuits before touching the router at all, absent table, empty routes, net absent from the voltage map, zero HV-classified nets, formatter shape + `... and K more` tail).
- `tests/router/test_pairwise_clearance.py` (+5) — `find_pairwise_violations` with an `AttachZone` covering the violating span returns `[]`; without it returns the violation; a zone outside the span or listing only one of the two nets exempts nothing; and a zone never waives the scalar DRU floor.

### Lint / type

```
$ .venv/bin/ruff check src/ tests/          -> All checks passed!
$ .venv/bin/ruff format --check <changed>   -> 4 files already formatted
$ scripts/ci/check_mypy_baseline.py         -> OK: mypy reports 1473 error(s), all within the baseline (1474 allowed). No new type errors.
```

(The baseline check emits an advisory `1 baseline error no longer occurs` warning. Not tightened here: `--update` in a native-built worktree drops the env-agnostic nanobind `import-not-found` line and breaks CI's Type Check job.)

Closes #4588
