### PR TITLE
fix(diffpair): attribute follow-tail declines and reach the near-side run

### DIFF
--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -478,6 +478,20 @@ _TAIL_FOLLOW_MIN_FRACTION: float = 0.30
 # How much of the partner's landing run a following tail may give up (the last
 # stretch is the part most likely to be walled in by neighbour-pad halos).
 _TAIL_FOLLOW_KEEP_FRACTIONS: tuple[float, ...] = (1.0, 0.85, 0.7, 0.55, 0.4, 0.25)
+# ...and how much of its HEAD end (issue #4577).  ``_TAIL_FOLLOW_KEEP_FRACTIONS``
+# is applied by ``_truncate_spans``, a head-ANCHORED prefix, so ``run[0]`` is
+# identical at every rung -- and ``run[0]`` is the coordinate the lead-in fails
+# on in 22 of the 38 numeric board-06 declines.  These are that ladder's mirror
+# image: walk the entry point forward along the run, giving up a prefix of the
+# coupled copper to buy a bridge the axis-aligned synthesizer can actually draw.
+# The first rung is 0.0, so the pre-#4577 attempt is always tried first and a
+# tail that already bracketed is produced unchanged.
+_TAIL_FOLLOW_ENTRY_FRACTIONS: tuple[float, ...] = (0.0, 0.2, 0.4, 0.6)
+# How far OUTSIDE the coupling window the fallback A*'s soft cost fence sits
+# (issue #4577).  Big enough that the fence never penalises a cell the
+# continuity rule would score as coupled, small enough that the channel it
+# forms is still narrow enough to steer a shortest-path search.
+_TAIL_CHANNEL_WALL_MARGIN_MM: float = 0.15
 # Guardrails on the slice itself: too short to be worth following, or so many
 # partner segments that offsetting them would dominate construction time.
 _TAIL_FOLLOW_MIN_SLICE_MM: float = 0.3
@@ -5224,11 +5238,29 @@ class DiffPairRouter:
         So the coupled middle is new, while both hops keep every gate and
         detour the existing synthesizer has.
 
+        Issue #4577: that lead-in is the measured blocker, not the budget.
+        Instrumenting the candidate loop on board-06 shadow-ON seed 42 puts
+        ``lead`` -- ``_bridge_to`` found no route to ``run[0]`` at all -- as the
+        SOLE reason in 22 of the 38 numeric declines, and a participant in 27;
+        "the slice was mostly unoffsettable" accounts for 4.  Two changes
+        address it, both of which only ADD candidates:
+
+        * the expensive lead-in probe now also reaches the longest run on the
+          head's OWN side of the partner, because ordering purely by length
+          routinely aims it at a run across the guide, where no legal lead-in
+          can exist (a lead-in must keep ``partner_clearance``, so it cannot
+          cross the partner's copper); and
+        * the bridge point is negotiable -- :data:`_TAIL_FOLLOW_ENTRY_FRACTIONS`
+          walks the entry forward along the run, giving up a prefix.  This is
+          the mirror of the keep-fraction ladder, which is head-anchored and so
+          can never move ``run[0]``.
+
         Every span is held to exactly the gates ``_synthesize_tail`` applies
         (raster cells, ``partner_clearance`` centre-to-centre, and #4573's
         exact foreign-pad predicate).  Returns ``None`` when no side / run /
-        truncation produces a legal tail, and the caller's existing fallback
-        chain then runs unchanged.
+        entry / truncation produces a legal tail, and the caller's existing
+        fallback chain then runs unchanged; under ``KCT_SHADOW_DEBUG`` the
+        decline line names WHICH bracketing stage rejected each candidate.
         """
         grid = self.autorouter.grid
         if grid.layer_to_index(goal.layer.value) != layer_idx:
@@ -5249,6 +5281,7 @@ class DiffPairRouter:
         followed_best = 0.0
 
         candidates: list[list[tuple[float, float, float, float]]] = []
+        sides: list[float] = []
         for side in (1.0, -1.0):
             runs = self._follow_partner_runs(
                 pathfinder,
@@ -5267,95 +5300,162 @@ class DiffPairRouter:
                     followed_best,
                     sum(math.hypot(x2 - x1, y2 - y1) for x1, y1, x2, y2 in run),
                 )
-            candidates.extend(runs[:_TAIL_FOLLOW_MAX_RUNS_PER_SIDE])
-        candidates.sort(key=lambda r: -sum(math.hypot(x2 - x1, y2 - y1) for x1, y1, x2, y2 in r))
-
-        for rank, run in enumerate(candidates[: 2 * _TAIL_FOLLOW_MAX_RUNS_PER_SIDE]):
-            lead = self._bridge_to(
-                pathfinder,
-                head,
-                run[0][0],
-                run[0][1],
-                layer_idx,
-                partner_segments,
-                partner_clearance,
-                # The slice a landing tail gets is the stretch the body
-                # trimmed for being BLOCKED, so the usable offset run often
-                # starts past that blockage -- which the axis-aligned lead-in
-                # then cannot reach either.  Spend the expensive probes on the
-                # single longest run only, and only when the caller was
-                # already going to pay for them.
-                allow_expensive=allow_expensive_landing and rank == 0,
-            )
-            if lead is None:
-                continue
-            run_len = sum(math.hypot(x2 - x1, y2 - y1) for x1, y1, x2, y2 in run)
-            for keep_frac in _TAIL_FOLLOW_KEEP_FRACTIONS:
-                kept = self._truncate_spans(run, run_len * keep_frac)
-                if not kept:
-                    continue
-                kept_len = sum(math.hypot(x2 - x1, y2 - y1) for x1, y1, x2, y2 in kept)
-                anchor = self._virtual_pad_at(goal, kept[-1][2], kept[-1][3], layer_idx)
-                landing = self._synthesize_tail(
-                    pathfinder,
-                    anchor,
-                    goal,
-                    layer_idx,
-                    partner_segments=partner_segments,
-                    partner_clearance=partner_clearance,
+            for run in runs[:_TAIL_FOLLOW_MAX_RUNS_PER_SIDE]:
+                candidates.append(run)
+                sides.append(side)
+        order = sorted(
+            range(len(candidates)),
+            key=lambda i: -sum(math.hypot(x2 - x1, y2 - y1) for x1, y1, x2, y2 in candidates[i]),
+        )
+        candidates = [candidates[i] for i in order]
+        sides = [sides[i] for i in order]
+        # Issue #4577: which SIDE of the partner the tail's head already sits
+        # on.  ``_follow_partner_runs`` offsets the slice on both sides
+        # blindly, and the longest surviving run is routinely the one on the
+        # FAR side -- measured on board-06 seed 42, USB3_TX1: head
+        # (149.055, 63.490), partner (148.772, 63.772), winning run start
+        # (148.472, 64.073), i.e. the partner's own copper lies between the two.
+        # A lead-in to that run must cross the guide, which every gate in
+        # ``_synthesize_tail`` / ``_bridge_to`` forbids by construction, so the
+        # expensive probe is spent on a bridge that cannot exist (32 of the 50
+        # instrumented lead attempts returned no route at all, none of them a
+        # chain break).  Knowing the head's side lets the expensive probe also
+        # reach the best NEAR-side run.
+        head_side = self._head_partner_side(head, slice_)
+        near_rank = next(
+            (i for i, s in enumerate(sides) if head_side != 0.0 and s == head_side),
+            None,
+        )
+        # Issue #4577 (Gate 1): WHICH bracketing stage rejected each candidate.
+        # The pre-#4577 decline line reported only the slice/followed/budget
+        # arithmetic, which invited the wrong attribution -- the filed root
+        # cause blamed the budget, while the measured blocker on 22 of 38
+        # numeric board-06 declines is the LEAD-IN alone.  Counting the stages
+        # makes the next lever choice evidence-driven instead of narrative.
+        why: dict[str, int] = {}
+        for rank, full_run in enumerate(candidates[: 2 * _TAIL_FOLLOW_MAX_RUNS_PER_SIDE]):
+            full_len = sum(math.hypot(x2 - x1, y2 - y1) for x1, y1, x2, y2 in full_run)
+            # The slice a landing tail gets is the stretch the body trimmed for
+            # being BLOCKED, so the usable offset run often starts past that
+            # blockage -- which the axis-aligned lead-in then cannot reach
+            # either.  Spend the expensive probes on the single longest run
+            # only, and only when the caller was already going to pay for them
+            # -- plus (issue #4577) on the longest run that at least sits on
+            # the head's own side of the partner, since the longest run overall
+            # is frequently across the guide and so unreachable by any legal
+            # lead-in at all.
+            expensive = allow_expensive_landing and rank in (0, near_rank)
+            lead_found = False
+            for entry_frac in _TAIL_FOLLOW_ENTRY_FRACTIONS:
+                # Issue #4577: the bridge point is NEGOTIABLE.  ``_truncate_spans``
+                # is a head-anchored prefix, so every rung of
+                # ``_TAIL_FOLLOW_KEEP_FRACTIONS`` leaves ``run[0]`` exactly where
+                # it was -- and ``run[0]`` is the one coordinate the lead-in is
+                # failing on.  Walking the entry point forward along the run is
+                # that ladder's mirror image: it gives up a PREFIX of the coupled
+                # copper to buy a bridge the synthesizer can actually draw.
+                run = (
+                    full_run
+                    if entry_frac <= 0.0
+                    else self._suffix_spans(full_run, full_len * (1.0 - entry_frac))
                 )
-                if landing is None and allow_expensive_landing:
-                    landing = self._synthesize_crossing_tail(
-                        pathfinder, anchor, goal, layer_idx, partner_segments
-                    ) or self._fallback_tail_route(
+                run_len = sum(math.hypot(x2 - x1, y2 - y1) for x1, y1, x2, y2 in run)
+                if not run or run_len < _TAIL_FOLLOW_MIN_SLICE_MM:
+                    break  # every later entry point is shorter still
+                lead = self._bridge_to(
+                    pathfinder,
+                    head,
+                    run[0][0],
+                    run[0][1],
+                    layer_idx,
+                    partner_segments,
+                    partner_clearance,
+                    # Only the run's own start is worth an expensive probe: the
+                    # stepped-in entries exist to find a bridge the CHEAP
+                    # synthesizer can draw, so the worst-case probe count per
+                    # candidate is unchanged.
+                    allow_expensive=expensive and entry_frac <= 0.0,
+                )
+                if lead is None:
+                    continue
+                lead_found = True
+                for keep_frac in _TAIL_FOLLOW_KEEP_FRACTIONS:
+                    kept = self._truncate_spans(run, run_len * keep_frac)
+                    if not kept:
+                        why["truncate"] = why.get("truncate", 0) + 1
+                        continue
+                    kept_len = sum(math.hypot(x2 - x1, y2 - y1) for x1, y1, x2, y2 in kept)
+                    anchor = self._virtual_pad_at(goal, kept[-1][2], kept[-1][3], layer_idx)
+                    landing = self._synthesize_tail(
+                        pathfinder,
                         anchor,
                         goal,
-                        partner_segments,
-                        partner_clearance,
-                        # Issue #4570: the follow tail's own last-resort A*
-                        # lander is a second via-inventing source; bias it the
-                        # same way as the caller's.
-                        prefer_planar_layer=layer_idx if prefer_planar else None,
+                        layer_idx,
+                        partner_segments=partner_segments,
+                        partner_clearance=partner_clearance,
                     )
-                if landing is None:
-                    continue
-                total = _route_copper_length(lead) + kept_len + _route_copper_length(landing)
-                if total > budget:
-                    continue
-                route = Route(net=head.net, net_name=head.net_name)
-                route.segments.extend(lead.segments)
-                route.vias.extend(lead.vias)
-                for x1, y1, x2, y2 in kept:
-                    route.segments.append(
-                        Segment(
-                            x1=x1,
-                            y1=y1,
-                            x2=x2,
-                            y2=y2,
-                            width=width,
-                            layer=layer,
-                            net=head.net,
-                            net_name=head.net_name,
+                    if landing is None and allow_expensive_landing:
+                        landing = self._synthesize_crossing_tail(
+                            pathfinder, anchor, goal, layer_idx, partner_segments
+                        ) or self._fallback_tail_route(
+                            anchor,
+                            goal,
+                            partner_segments,
+                            partner_clearance,
+                            # Issue #4570: the follow tail's own last-resort A*
+                            # lander is a second via-inventing source; bias it
+                            # the same way as the caller's.
+                            prefer_planar_layer=layer_idx if prefer_planar else None,
                         )
-                    )
-                route.segments.extend(landing.segments)
-                route.vias.extend(landing.vias)
-                # Issue #4572 (and the #4462 lesson): a three-piece tail is
-                # only copper if the three pieces MEET.  ``_synthesize_tail``
-                # silently drops a sub-0.01 mm span, which is harmless at a
-                # pad landing but leaves a real break when the piece is spliced
-                # between a lead-in and a follow run -- and the #3540
-                # transactional strand guard then rips the whole pair
-                # (measured: PCIE_RX stranded at U3.32).  Verify the chain
-                # end-to-end and drop the candidate rather than emit a break.
-                if not route.segments or not self._route_is_chained(route, head, goal):
-                    continue
-                return route
+                    if landing is None:
+                        why["landing"] = why.get("landing", 0) + 1
+                        continue
+                    total = _route_copper_length(lead) + kept_len + _route_copper_length(landing)
+                    if total > budget:
+                        why["budget"] = why.get("budget", 0) + 1
+                        continue
+                    route = Route(net=head.net, net_name=head.net_name)
+                    route.segments.extend(lead.segments)
+                    route.vias.extend(lead.vias)
+                    for x1, y1, x2, y2 in kept:
+                        route.segments.append(
+                            Segment(
+                                x1=x1,
+                                y1=y1,
+                                x2=x2,
+                                y2=y2,
+                                width=width,
+                                layer=layer,
+                                net=head.net,
+                                net_name=head.net_name,
+                            )
+                        )
+                    route.segments.extend(landing.segments)
+                    route.vias.extend(landing.vias)
+                    # Issue #4572 (and the #4462 lesson): a three-piece tail is
+                    # only copper if the three pieces MEET.  ``_synthesize_tail``
+                    # silently drops a sub-0.01 mm span, which is harmless at a
+                    # pad landing but leaves a real break when the piece is
+                    # spliced between a lead-in and a follow run -- and the
+                    # #3540 transactional strand guard then rips the whole pair
+                    # (measured: PCIE_RX stranded at U3.32).  Verify the chain
+                    # end-to-end and drop the candidate rather than emit a break.
+                    if not route.segments or not self._route_is_chained(route, head, goal):
+                        why["chain"] = why.get("chain", 0) + 1
+                        continue
+                    return route
+            if not lead_found:
+                # Issue #4577: count the lead-in blocker ONCE per candidate run,
+                # not once per entry point, so the decline histogram stays
+                # comparable across the entry ladder's introduction.
+                why["lead"] = why.get("lead", 0) + 1
         if _SHADOW_DEBUG:
             slice_len = sum(math.hypot(x2 - x1, y2 - y1) for x1, y1, x2, y2, _w in slice_)
+            reasons = ",".join(f"{k}={why[k]}" for k in sorted(why)) or "no-surviving-run"
             print(
                 f"    [coupled-follow] declined: slice={slice_len:.3f} "
-                f"followed={followed_best:.3f} direct={direct:.3f} budget={budget:.3f}"
+                f"followed={followed_best:.3f} direct={direct:.3f} budget={budget:.3f} "
+                f"runs={len(candidates)} why={reasons}"
             )
         return None
 
@@ -5564,6 +5664,67 @@ class DiffPairRouter:
                 out.append((x1, y1, x1 + (x2 - x1) * t, y1 + (y2 - y1) * t))
             break
         return out
+
+    @staticmethod
+    def _suffix_spans(
+        spans: list[tuple[float, float, float, float]],
+        keep_len: float,
+    ) -> list[tuple[float, float, float, float]]:
+        """Tail-anchored suffix of a span chain, at most ``keep_len`` long.
+
+        Issue #4577.  The mirror of :meth:`_truncate_spans`: that one gives up
+        the run's LAST stretch (walled-in by neighbour-pad halos), this one
+        gives up its FIRST -- which is what a lead-in that cannot reach
+        ``run[0]`` needs, since the run a landing tail gets typically starts on
+        the far side of the very blockage that broke it.  The run's END is
+        preserved, so the landing hop the caller then synthesizes is
+        unaffected.
+        """
+        if keep_len <= 1e-9:
+            return []
+        out: list[tuple[float, float, float, float]] = []
+        used = 0.0
+        for x1, y1, x2, y2 in reversed(spans):
+            seg_len = math.hypot(x2 - x1, y2 - y1)
+            if seg_len < 1e-9:
+                continue
+            if used + seg_len <= keep_len + 1e-9:
+                out.append((x1, y1, x2, y2))
+                used += seg_len
+                continue
+            t = (keep_len - used) / seg_len
+            if t > 1e-6:
+                out.append((x2 - (x2 - x1) * t, y2 - (y2 - y1) * t, x2, y2))
+            break
+        out.reverse()
+        return out
+
+    @staticmethod
+    def _head_partner_side(
+        head: Pad,
+        slice_: list[tuple[float, float, float, float, float]],
+    ) -> float:
+        """Which offset side of the partner slice the tail's head sits on (#4577).
+
+        ``_guide_follow_slice`` cuts the slice AT the partner point closest to
+        ``head``, so ``slice_[0]``'s start is that point and the head->point
+        vector is (up to the cut's own error) the local normal.  Returns
+        ``+1.0`` / ``-1.0`` in ``_follow_partner_runs``' own side convention
+        (``n = (-uy, ux) / |u| * side``), or ``0.0`` when the head is on the
+        partner's centreline and neither side is nearer -- in which case the
+        caller must not express a preference.
+        """
+        if not slice_:
+            return 0.0
+        x1, y1, x2, y2, _w = slice_[0]
+        ux, uy = x2 - x1, y2 - y1
+        norm = math.hypot(ux, uy)
+        if norm < 1e-9:
+            return 0.0
+        proj = (head.x - x1) * (-uy / norm) + (head.y - y1) * (ux / norm)
+        if abs(proj) < 1e-9:
+            return 0.0
+        return 1.0 if proj > 0.0 else -1.0
 
     def _pair_seg_clearance(self, pathfinder: CoupledPathfinder, net_name: str) -> float:
         """Centerline distance bound between pair partners (issue #3508).
@@ -6013,6 +6174,68 @@ class DiffPairRouter:
                     return sites
         return sites
 
+    def _partner_channel_wall_sites(
+        self,
+        head: Pad,
+        goal: Pad,
+        partner_segments: list[Segment],
+        seg_clear: float,
+        max_sites: int = 40,
+    ) -> list[tuple[float, float]]:
+        """Cost walls just OUTSIDE the coupling window (issue #4577).
+
+        :meth:`_partner_boost_sites` samples the partner itself, so it only
+        ever pushes the fallback A* AWAY from the guide.  Nothing rewards the
+        band the continuity rule actually measures, and the probe -- which is a
+        shortest-path search over free cells -- has no reason to stay in it:
+        measured on board-06 seed 42, USB3_TX1's shipped landing tail is
+        4.865 mm over 84 grid steps at **0.000** coupled.
+
+        These sites are the missing other wall.  Offsetting each partner
+        segment by ``_COUPLING_WINDOW_MM + partner width + margin``
+        centre-to-centre on BOTH sides puts a soft cost fence at the far edge
+        of the coupled band, so the two cheapest lanes through the corridor are
+        the ones between the guide's own halo and that fence -- i.e. exactly
+        the offsets a coupled tail wants.  Combined with the repelling sites
+        the caller already has, the pair forms a channel rather than a
+        gradient.
+
+        ``avoid_locations`` only ADDS cost (``GridCell.avoidance_cost``), so
+        the fence is a preference, never a barrier: a tail whose only path
+        leaves the channel still routes, it just pays.  Nothing is written to
+        the grid's corridor reservations, which are global and shared with the
+        escape router (``grid.py`` ``clear_corridor_reservations`` / #4071).
+        """
+        if not partner_segments or seg_clear <= 0.0:
+            return []
+        reach = _COUPLING_WINDOW_MM + _TAIL_CHANNEL_WALL_MARGIN_MM
+        pad = 2.0 * seg_clear + reach + 0.5
+        lo_x, hi_x = min(head.x, goal.x) - pad, max(head.x, goal.x) + pad
+        lo_y, hi_y = min(head.y, goal.y) - pad, max(head.y, goal.y) + pad
+        step = max(self.autorouter.grid.resolution, seg_clear)
+        sites: list[tuple[float, float]] = []
+        for ps in partner_segments:
+            seg_len = math.hypot(ps.x2 - ps.x1, ps.y2 - ps.y1)
+            if seg_len < 1e-9:
+                continue
+            wall = reach + ps.width
+            nx, ny = -(ps.y2 - ps.y1) / seg_len, (ps.x2 - ps.x1) / seg_len
+            n_steps = max(1, int(math.ceil(seg_len / step)))
+            for i in range(n_steps + 1):
+                t = i / n_steps
+                px = ps.x1 + (ps.x2 - ps.x1) * t
+                py = ps.y1 + (ps.y2 - ps.y1) * t
+                for sign in (1.0, -1.0):
+                    wx, wy = px + wall * nx * sign, py + wall * ny * sign
+                    if not (lo_x <= wx <= hi_x and lo_y <= wy <= hi_y):
+                        continue
+                    if any(math.hypot(wx - sx, wy - sy) < step for sx, sy in sites):
+                        continue
+                    sites.append((wx, wy))
+                    if len(sites) >= max_sites:
+                        return sites
+        return sites
+
     @contextlib.contextmanager
     def _layer_locked_router(self, layer_idx: int) -> Iterator[bool]:
         """Narrow the shared pathfinder to one copper layer (issue #4570).
@@ -6357,6 +6580,138 @@ class DiffPairRouter:
         seg_clear: float,
         prefer_planar_layer: int | None = None,
     ) -> Route | None:
+        """Last-resort A* tail, with a coupling-aware retry (issues #4460/#4577).
+
+        The whole legacy chain is :meth:`_fallback_tail_route_body`, unchanged.
+        This wrapper adds ONE thing: when that chain's winner carries **zero**
+        coupled millimetres -- the 100%-uncoupled grid staircase issue #4577 is
+        about -- a single extra probe is spent with the guide's coupling band
+        fenced in on both sides (:meth:`_partner_channel_wall_sites`), and it is
+        preferred only when :meth:`_tail_is_better_coupled` says it beats the
+        incumbent on the same coupled-millimetres doctrine the follow tail is
+        judged by, at the same partner-clearance floor the incumbent met.
+
+        Restricting the retry to a zero-coupled incumbent is what keeps the
+        probe count bounded: every tail that already runs alongside its partner
+        (and every tail reached with no partner supplied) returns from the body
+        without the extra search.
+
+        **Measured outcome on board-06 shadow-ON seed 42: it fires 10 times and
+        upgrades 0 tails.**  It is kept because it is the only path that can
+        exploit a cheap coupled corridor, and because its instrumentation is
+        what PRICES the alternative: on USB3_TX1's landing it found a genuinely
+        coupled route (2.058 coupled mm against the incumbent's 0.000) that is
+        10.764 mm long against the incumbent's 4.865 -- 5.9 mm of extra copper
+        for 2.1 mm of coupling.  Swapping it in would have LOWERED that leg's
+        ``diffpair_routing_continuity`` (0.867 -> 0.815), which is exactly what
+        :meth:`_tail_is_better_coupled` exists to prevent.  The lever the issue
+        named is therefore not blocked by a missing attractor; it is blocked by
+        the price of the detour.
+        """
+        winner = self._fallback_tail_route_body(
+            head, goal, partner_segments, seg_clear, prefer_planar_layer
+        )
+        if winner is None or not partner_segments or seg_clear <= 0.0:
+            return winner
+        if self._tail_coupled_mm(winner, partner_segments)[0] > 0.0:
+            return winner
+        return self._channel_biased_tail(
+            head, goal, partner_segments, seg_clear, prefer_planar_layer, winner
+        )
+
+    def _channel_biased_tail(
+        self,
+        head: Pad,
+        goal: Pad,
+        partner_segments: list[Segment],
+        seg_clear: float,
+        prefer_planar_layer: int | None,
+        incumbent: Route,
+    ) -> Route:
+        """One channel-fenced A* retry for a 0%-coupled tail (issue #4577).
+
+        Returns ``incumbent`` unchanged unless the retry produces copper that
+
+        * passes the same exact foreign-pad / foreign-via gates
+          (:meth:`_route_pad_violation`, :meth:`_route_via_clear`),
+        * meets the SAME partner-clearance floor the incumbent met (the strict
+          intra-pair bound when the incumbent met it, the physical-overlap
+          floor otherwise -- so the retry can never smuggle copper past a check
+          the incumbent passed),
+        * does not invent a via when ``prefer_planar_layer`` says the partner
+          leg has none to match (#4570), and
+        * beats the incumbent under :meth:`_tail_is_better_coupled`: at least
+          ``_TAIL_FOLLOW_MIN_COUPLED_MM`` more coupled copper, and no more
+          extra length than the coupling it bought.
+        """
+        strict_ok = self._tail_partner_clear(incumbent, partner_segments, seg_clear)
+        floor = seg_clear if strict_ok else 0.0
+        sites = self._partner_boost_sites(head, goal, partner_segments, seg_clear)
+        sites = sites + self._partner_channel_wall_sites(head, goal, partner_segments, seg_clear)
+        if not sites:
+            return incumbent
+        radius_cells = max(
+            1, int(round(seg_clear / max(self.autorouter.grid.resolution, 1e-9) / 3.0))
+        )
+        if prefer_planar_layer is not None:
+            with self._layer_locked_router(prefer_planar_layer) as locked:
+                cand = (
+                    self._single_ended_guide_route(
+                        head,
+                        goal,
+                        per_net_timeout=10.0,
+                        avoid_locations=sites,
+                        avoid_radius_cells=radius_cells,
+                    )
+                    if locked
+                    else None
+                )
+            if cand is not None and cand.vias:
+                cand = None
+        else:
+            cand = self._single_ended_guide_route(
+                head,
+                goal,
+                per_net_timeout=10.0,
+                avoid_locations=sites,
+                avoid_radius_cells=radius_cells,
+            )
+        # Issue #4577 (Gate 1): report WHICH gate the channel-fenced retry lost
+        # to, on the same principle as the ``[coupled-follow] declined:``
+        # attribution -- a retry that silently does nothing is indistinguishable
+        # from one that is not wired up.
+        why: str | None = None
+        got = tot = 0.0
+        if cand is None or not cand.segments:
+            why = "no-path" if prefer_planar_layer is None else "no-planar-path"
+        elif self._route_pad_violation(cand)[0] > _SHADOW_PAD_DEFICIT_EPS:
+            why = "pad-deficit"
+        elif not self._route_via_clear(cand):
+            why = "via-deficit"
+        elif not self._tail_partner_clear(cand, partner_segments, floor):
+            why = "partner-clearance"
+        else:
+            got, tot = self._tail_coupled_mm(cand, partner_segments)
+            if not self._tail_is_better_coupled(cand, incumbent, partner_segments):
+                why = "not-better-coupled"
+        if _SHADOW_DEBUG:
+            print(
+                f"    [coupled-channel] {why or 'upgraded'}: sites={len(sites)} "
+                f"len={tot:.3f} coupled={got:.3f} "
+                f"segs={len(cand.segments) if cand is not None else 0} "
+                f"(was len={_route_copper_length(incumbent):.3f} "
+                f"segs={len(incumbent.segments)})"
+            )
+        return incumbent if (why is not None or cand is None) else cand
+
+    def _fallback_tail_route_body(
+        self,
+        head: Pad,
+        goal: Pad,
+        partner_segments: list[Segment] | None,
+        seg_clear: float,
+        prefer_planar_layer: int | None = None,
+    ) -> Route | None:
         """Partner-aware last-resort A* tail (issue #4460).
 
         Order is deliberately conservative: the UNBIASED probe runs first and
@@ -6522,6 +6877,10 @@ class DiffPairRouter:
         # winning wherever it was already good enough.
         source = "synth" if tail is not None else "none"
         following: Route | None = None
+        # Issue #4577: a follow candidate that lost only to the "no incumbent"
+        # stand-in bound, kept for a second, fair comparison once the tail that
+        # actually ships exists.
+        deferred_follow: Route | None = None
         if partner_segments:
             following = self._synthesize_following_tail(
                 pathfinder,
@@ -6537,15 +6896,29 @@ class DiffPairRouter:
                 allow_expensive_landing=tail is None,
                 prefer_planar=prefer_planar,
             )
-            if (
-                following is not None
+            if following is not None and not (
                 # Issue #4570: never let a via-carrying follow displace a
                 # PLANAR incumbent when the partner leg has no via to match.
-                and not (prefer_planar and following.vias and tail is not None and not tail.vias)
-                and self._tail_is_better_coupled(following, tail, partner_segments)
+                prefer_planar and following.vias and tail is not None and not tail.vias
             ):
-                tail = following
-                source = "follow"
+                if self._tail_is_better_coupled(following, tail, partner_segments):
+                    tail = following
+                    source = "follow"
+                elif tail is None:
+                    # Issue #4577: with no incumbent to measure the trade
+                    # against, ``_tail_is_better_coupled`` falls back to
+                    # ``_TAIL_FOLLOW_MIN_FRACTION`` -- but "no incumbent" is not
+                    # true here, it is merely not KNOWN YET.  When the cheap
+                    # synthesizer declined, what actually ships is the
+                    # partner-BLIND probe further down, and on board-06 seed 42
+                    # that is USB3_TX1's 4.865 mm / 84-segment / 0.000-coupled
+                    # A* staircase.  Judged against THAT, a 3.6 mm tail carrying
+                    # 0.85 coupled mm is both shorter and better coupled -- it
+                    # wins on exactly the coupled-millimetres doctrine this
+                    # method documents, and loses the fraction test only because
+                    # the comparison ran too early.  Hold the candidate and
+                    # re-judge it below, against the tail that will really ship.
+                    deferred_follow = following
         # Issue #4570: the LAYER-LOCKED A* runs before the crossing tail when
         # the partner leg has no via to match.  ``_synthesize_crossing_tail``
         # is a deliberate TWO-via construction (the polarity-swap crossover),
@@ -6581,6 +6954,36 @@ class DiffPairRouter:
             # Nothing else reached the pad: a weakly-coupled following tail is
             # still legal copper and still better than declining the side.
             tail, source = following, "follow-lastresort"
+        elif (
+            deferred_follow is not None
+            and tail is not None
+            and partner_segments
+            and source != "follow"
+        ):
+            # Issue #4577: the deferred re-judgement.  Exactly the same
+            # coupled-millimetres predicate, and the same #4570 via guard, now
+            # applied against the tail this call really produced instead of
+            # against ``None``.  It can only displace a tail the candidate beats
+            # on BOTH counts -- at least ``_TAIL_FOLLOW_MIN_COUPLED_MM`` more
+            # coupled copper, and no more extra length than the coupling bought
+            # -- so a follow that merely detours still loses.
+            if not (
+                prefer_planar and deferred_follow.vias and not tail.vias
+            ) and self._tail_is_better_coupled(deferred_follow, tail, partner_segments):
+                tail, source = deferred_follow, "follow-deferred"
+            elif _SHADOW_DEBUG:
+                # Gate 1 again: a deferred candidate that keeps losing is the
+                # single most useful number for the NEXT lever choice -- it says
+                # how much coupled copper the follow machinery could actually
+                # find, independent of why it declined.
+                got, tot = self._tail_coupled_mm(deferred_follow, partner_segments)
+                inc_got, inc_tot = self._tail_coupled_mm(tail, partner_segments)
+                print(
+                    f"    [coupled-follow] deferred candidate lost: "
+                    f"cand len={tot:.3f} coupled={got:.3f} vs "
+                    f"incumbent len={inc_tot:.3f} coupled={inc_got:.3f} "
+                    f"(floor={_TAIL_FOLLOW_MIN_COUPLED_MM:.3f})"
+                )
         if tail is None:
             print(
                 f"    [coupled-rescue] {label} tail unroutable for {pair_name} "

--- a/tests/test_diffpair_shadow.py
+++ b/tests/test_diffpair_shadow.py
@@ -2141,14 +2141,28 @@ def test_fallback_tail_route_without_partner_is_the_plain_probe():
 
 
 def test_fallback_tail_route_keeps_a_partner_clean_probe_unchanged():
-    """A tail that already holds the coupled clearance is returned as-is."""
+    """A tail that already holds the coupled clearance is returned as-is.
+
+    Issue #4577 split the method into a wrapper plus
+    ``_fallback_tail_route_body``.  The #4460 invariant this test was written
+    for is a statement about that BODY -- "a probe that already keeps the
+    intra-pair clearance must not trigger the guide-biased re-route" -- and it
+    is asserted on the body here, unchanged.  The wrapper's own extra probe is
+    a different condition (a winner carrying ZERO coupled millimetres) and is
+    covered by ``test_channel_retry_*`` below; what must still hold publicly is
+    that a clean probe comes back untouched, which is asserted first.
+    """
     dpr = _diffpair_router()
     probe_route = Route(net=2, net_name="USB3_TX1-")
     probe_route.segments.append(_gseg(5.0, 5.0, 8.0, 5.0))
-    calls = _stub_probe(dpr, probe_route)
+    _stub_probe(dpr, probe_route)
     head, goal = _tail_pads((5.0, 5.0), (8.0, 5.0))
     partner = [_gseg(4.0, 6.0, 9.0, 6.0)]
     assert dpr._fallback_tail_route(head, goal, partner, 0.4) is probe_route
+
+    dpr = _diffpair_router()
+    calls = _stub_probe(dpr, probe_route)
+    assert dpr._fallback_tail_route_body(head, goal, partner, 0.4) is probe_route
     assert len(calls) == 1, "a clean probe must not trigger the biased re-route"
 
 
@@ -3485,6 +3499,290 @@ def test_route_is_chained_rejects_a_subcell_hole():
     # Closing the 5 um hole makes it a chain again.
     route.segments[1].x1 = 1.0
     assert dpr._route_is_chained(route, head, goal) is True
+
+
+# --- Issue #4577: reaching the follow run, and attributing the declines ------
+#
+# Measured on board-06 shadow-ON seed 42 with the decline attribution added
+# below: `lead` -- ``_bridge_to`` could not reach the run's START from the tail
+# head -- is the SOLE reason in 22 of the 38 numeric declines and participates
+# in 27.  Two structural facts cause it: ``_follow_partner_runs`` breaks the run
+# AT the blockage (so the survivor begins past it, routinely on the far side of
+# the guide from the head), and ``_truncate_spans`` is a head-anchored prefix
+# (so ``run[0]`` is identical at every keep fraction).  Nothing before this
+# issue could move that one coordinate.
+
+
+def test_suffix_spans_is_the_mirror_of_truncate_spans():
+    """``_truncate_spans`` gives up the END; ``_suffix_spans`` the START."""
+    dpr = _diffpair_router()
+    spans = [(0.0, 0.0, 1.0, 0.0), (1.0, 0.0, 2.0, 0.0), (2.0, 0.0, 3.0, 0.0)]
+
+    kept = dpr._suffix_spans(spans, 1.5)
+    assert kept, "a 1.5mm suffix of a 3mm chain is not empty"
+    # The chain's END is preserved and its START has moved forward.
+    assert (kept[-1][2], kept[-1][3]) == (3.0, 0.0)
+    assert kept[0][0] == pytest.approx(1.5)
+    assert sum(math.hypot(x2 - x1, y2 - y1) for x1, y1, x2, y2 in kept) == pytest.approx(1.5)
+    # Degenerate rungs behave like the prefix helper's.
+    assert dpr._suffix_spans(spans, 0.0) == []
+    assert dpr._suffix_spans([], 1.0) == []
+
+
+def test_head_partner_side_matches_the_offset_side_convention():
+    """The head's side must be expressed in ``_follow_partner_runs``' units.
+
+    That method offsets by ``n = (-uy, ux) / |u| * side``, so a head sitting at
+    ``slice[0] + n`` for ``side=+1`` must report ``+1.0``.  Getting the sign
+    backwards would aim the expensive lead-in probe at the run that is
+    guaranteed to be across the guide -- the exact defect this is for.
+    """
+    dpr = _diffpair_router()
+    # Partner heading +x: n(+1) = (0, +1).
+    slice_ = [(4.0, 4.0, 6.0, 4.0, 0.2)]
+    assert dpr._head_partner_side(_tail_pads((4.0, 4.5), (9.0, 9.0))[0], slice_) == 1.0
+    assert dpr._head_partner_side(_tail_pads((4.0, 3.5), (9.0, 9.0))[0], slice_) == -1.0
+    # On the centreline, and with no slice at all, neither side is preferred.
+    assert dpr._head_partner_side(_tail_pads((5.0, 4.0), (9.0, 9.0))[0], slice_) == 0.0
+    assert dpr._head_partner_side(_tail_pads((4.0, 4.5), (9.0, 9.0))[0], []) == 0.0
+
+
+def _split_partner(x0=4.0, x1=9.0, y=4.0, step=0.25) -> list[Segment]:
+    """A horizontal guide as many short spans, so a blockage can BREAK a run.
+
+    ``_follow_partner_runs`` selects a spacing rung PER partner segment, so a
+    guide expressed as one long span is all-or-nothing.  Board-06's guides near
+    a landing are per-cell staircases (measured: a 2.634 mm slice over 40
+    spans), which is what makes partial runs possible at all.
+    """
+    n = int(round((x1 - x0) / step))
+    return [_gseg(x0 + step * i, y, x0 + step * (i + 1), y) for i in range(n)]
+
+
+def _follow_bridge_targets(dpr, head, goal, partner, clearance=0.4):
+    """Every ``(tx, ty, allow_expensive)`` the follow synthesizer asks for.
+
+    ``_bridge_to`` is stubbed to REFUSE, so the whole candidate ladder is
+    walked and recorded instead of short-circuiting on the first success.
+    """
+    seen: list[tuple[float, float, bool]] = []
+
+    def refuse(pathfinder, h, tx, ty, layer_idx, ps, pc, allow_expensive=False):
+        seen.append((round(tx, 3), round(ty, 3), allow_expensive))
+        return None
+
+    dpr._bridge_to = refuse  # type: ignore[method-assign]
+    assert (
+        dpr._synthesize_following_tail(
+            _AllClearPathfinder(),
+            head,
+            goal,
+            0,
+            partner,
+            clearance,
+            allow_expensive_landing=True,
+        )
+        is None
+    )
+    return seen
+
+
+def test_follow_entry_point_walks_forward_when_the_run_start_is_unreachable():
+    """The bridge point is NEGOTIABLE (issue #4577).
+
+    On ``main`` each candidate run gets exactly ONE ``_bridge_to`` attempt, at
+    ``run[0]`` -- and no keep fraction can move that coordinate, because
+    ``_truncate_spans`` is a head-anchored prefix.  A run whose start is
+    unreachable is therefore dead on arrival, which is the sole decline reason
+    in 22 of board-06's 38 numeric declines.  Each run must now be offered at
+    several entry points, walking FORWARD along it.
+    """
+    dpr = _pad_gate_router()
+    partner = _split_partner()
+    head, goal = _tail_pads((4.0, 4.45), (9.0, 4.45))
+
+    seen = _follow_bridge_targets(dpr, head, goal, partner)
+
+    by_run: dict[float, list[float]] = {}
+    for tx, ty, _exp in seen:
+        by_run.setdefault(ty, []).append(tx)
+    assert by_run, "the fixture must produce at least one offset run"
+    for ty, xs in by_run.items():
+        assert len(xs) > 1, f"run at y={ty} was offered only its own start (pre-#4577)"
+        assert xs == sorted(xs), "entry points must walk FORWARD along the run"
+        assert len(set(xs)) == len(xs), "each entry point must be a distinct target"
+
+
+def test_expensive_lead_probe_also_reaches_the_head_side_run():
+    """The far-side run is unreachable by construction (issue #4577).
+
+    ``_follow_partner_runs`` offsets the slice on both sides blindly and the
+    candidates are ordered by LENGTH, so the expensive lead-in probe is
+    routinely spent on a run that sits across the guide from the head -- where
+    any lead-in would have to cross the partner's own copper, which every gate
+    forbids.  Here foreign pads shorten the head-side run so the far-side one
+    ranks first; both must get the expensive probe.
+    """
+    dpr = _pad_gate_router()
+    partner = _split_partner()
+    head, goal = _tail_pads((4.0, 4.45), (9.0, 4.45))
+    # Wall off the first ~1.5mm of the +1 (head-side) offset run only.
+    for x in (4.3, 4.7, 5.1):
+        dpr.autorouter.grid.add_pad(_pad_at(x, 4.6, net=99, name="OTHER"))
+
+    seen = _follow_bridge_targets(dpr, head, goal, partner)
+
+    far = [(tx, exp) for tx, ty, exp in seen if ty < 4.0]
+    near = [(tx, exp) for tx, ty, exp in seen if ty > 4.0]
+    assert far and near, "the fixture must produce a run on each side"
+    assert min(tx for tx, _ in near) > 4.0, "the head-side run must start past the pads"
+    assert any(exp for _tx, exp in far), "the longest run keeps its expensive probe"
+    assert any(exp for _tx, exp in near), (
+        "the head-side run must also get one -- on main only rank 0 does, and "
+        "rank 0 here is the run across the guide"
+    )
+
+
+def test_follow_decline_names_the_stage_that_rejected_the_candidate(capsys, monkeypatch):
+    """Gate 1: the decline line must attribute, not just report arithmetic."""
+    import kicad_tools.router.diffpair_routing as dpr_mod
+
+    monkeypatch.setattr(dpr_mod, "_SHADOW_DEBUG", True)
+    dpr = _diffpair_router()
+    # The #4572 "detour far longer than the direct hop" fixture: a partner that
+    # loops away between the anchors, so every bracket blows the budget.
+    partner = [
+        _gseg(4.0, 4.0, 4.0, 1.0),
+        _gseg(4.0, 1.0, 9.0, 1.0),
+        _gseg(9.0, 1.0, 9.0, 4.0),
+    ]
+    head, goal = _tail_pads((4.4, 4.0), (9.4, 4.0))
+
+    assert (
+        dpr._synthesize_following_tail(_AllClearPathfinder(), head, goal, 0, partner, 0.4) is None
+    )
+
+    line = [ln for ln in capsys.readouterr().out.splitlines() if "[coupled-follow] declined:" in ln]
+    assert line, "a numeric decline must print its attribution"
+    assert "why=" in line[-1] and "runs=" in line[-1]
+    # The reason vocabulary is closed: no-surviving-run / lead / truncate /
+    # landing / budget / chain.
+    reasons = line[-1].split("why=")[-1].split()[0]
+    for token in reasons.split(","):
+        assert token.split("=")[0] in {
+            "no-surviving-run",
+            "lead",
+            "truncate",
+            "landing",
+            "budget",
+            "chain",
+        }
+
+
+def test_channel_wall_sites_sit_outside_the_coupling_window():
+    """The fence must never penalise a cell the continuity rule scores coupled.
+
+    Issue #4577's direction (b): ``_partner_boost_sites`` only REPELS, so the
+    fallback A* has no reason to stay in the band the rule measures.  The wall
+    sites are the missing outer edge -- and they are only useful if they are
+    strictly outside the window, or they would push the probe out of the very
+    band they exist to hold it in.
+    """
+    from kicad_tools.router.diffpair_routing import _COUPLING_WINDOW_MM
+
+    dpr = _diffpair_router()
+    head, goal = _tail_pads((5.0, 5.0), (8.0, 5.0))
+    partner = [_gseg(4.0, 5.0, 9.0, 5.0)]
+
+    sites = dpr._partner_channel_wall_sites(head, goal, partner, 0.4)
+
+    assert sites, "a partner in the corridor must produce a fence"
+    for _sx, sy in sites:
+        centre = abs(sy - 5.0)
+        # 0.2mm-wide guide: edge-to-edge = centre - 0.1 - 0.1 for a 0.2mm tail.
+        assert centre - 0.2 > _COUPLING_WINDOW_MM, "the fence is inside the coupled band"
+    # Both sides are fenced, so the result is a channel and not a gradient.
+    assert any(sy > 5.0 for _sx, sy in sites) and any(sy < 5.0 for _sx, sy in sites)
+    # No partner / no clearance floor => nothing to fence.
+    assert dpr._partner_channel_wall_sites(head, goal, [], 0.4) == []
+    assert dpr._partner_channel_wall_sites(head, goal, partner, 0.0) == []
+
+
+def test_channel_retry_is_not_vacuous_and_only_fires_on_a_zero_coupled_tail():
+    """Non-vacuity spy, mirroring ``test_shadow_entry_point_spy_is_not_vacuous``.
+
+    A refactor that silently stopped calling the retry would leave every other
+    assertion in this file green, so the call itself is asserted here -- both
+    that it HAPPENS for a 0%-coupled winner and that it does NOT for a winner
+    that already runs alongside its partner.
+    """
+    dpr = _diffpair_router()
+    head, goal = _tail_pads((5.0, 5.0), (8.0, 5.0))
+    seen: list[Route] = []
+
+    def spy(h, g, partner, clear, planar_layer, incumbent):
+        seen.append(incumbent)
+        return incumbent
+
+    dpr._channel_biased_tail = spy  # type: ignore[method-assign]
+
+    # (a) an uncoupled winner (partner 1.0mm away, outside the window).
+    uncoupled = Route(net=2, net_name="USB3_TX1-")
+    uncoupled.segments.append(_gseg(5.0, 5.0, 8.0, 5.0))
+    _stub_probe(dpr, uncoupled)
+    assert dpr._fallback_tail_route(head, goal, [_gseg(4.0, 6.0, 9.0, 6.0)], 0.4) is uncoupled
+    assert len(seen) == 1, "a 0.000-coupled winner MUST reach the channel retry"
+
+    # (b) a winner already inside the coupling window: no retry, no extra probe.
+    coupled = Route(net=2, net_name="USB3_TX1-")
+    coupled.segments.append(_gseg(5.0, 5.0, 8.0, 5.0))
+    _stub_probe(dpr, coupled)
+    assert dpr._fallback_tail_route(head, goal, [_gseg(4.0, 5.45, 9.0, 5.45)], 0.4) is coupled
+    assert len(seen) == 1, "an already-coupled winner must not pay for the retry"
+
+
+def test_channel_retry_is_inert_with_shadow_construction_off():
+    """Flag-OFF inertness, mirroring the #4574 crossing-tail guard.
+
+    ``partner_segments`` is supplied ONLY by the shadow constructor, so with
+    ``enable_shadow_construction`` off the wrapper must be a pass-through: one
+    probe, its result returned untouched, and the retry never entered.
+    """
+    dpr = _diffpair_router()
+    assert dpr.enable_shadow_construction is False
+    probe_route = Route(net=2, net_name="USB3_TX1-")
+    probe_route.segments.append(_gseg(5.0, 5.0, 8.0, 5.0))
+    calls = _stub_probe(dpr, probe_route)
+    entered: list[int] = []
+    dpr._channel_biased_tail = lambda *a, **k: entered.append(1)  # type: ignore[method-assign]
+    head, goal = _tail_pads((5.0, 5.0), (8.0, 5.0))
+
+    assert dpr._fallback_tail_route(head, goal, None, 0.0) is probe_route
+    assert calls == [(10.0, None, 1)]
+    assert entered == [], "the retry must not run without a partner"
+
+
+def test_channel_retry_declines_a_candidate_that_is_not_better_coupled():
+    """The retry can only displace a tail it beats on coupled millimetres.
+
+    Same predicate (``_tail_is_better_coupled``) the follow tail is judged by,
+    so a probe that merely wanders differently loses -- which is what keeps the
+    retry from trading DRC-clean copper for a cosmetic change.
+    """
+    dpr = _diffpair_router()
+    head, goal = _tail_pads((5.0, 5.0), (8.0, 5.0))
+    partner = [_gseg(4.0, 6.0, 9.0, 6.0)]
+    incumbent = Route(net=2, net_name="USB3_TX1-")
+    incumbent.segments.append(_gseg(5.0, 5.0, 8.0, 5.0))
+    # The stubbed probe returns another equally-uncoupled route.
+    other = Route(net=2, net_name="USB3_TX1-")
+    other.segments.append(_gseg(5.0, 5.0, 6.5, 4.5))
+    other.segments.append(_gseg(6.5, 4.5, 8.0, 5.0))
+    _stub_probe(dpr, other)
+
+    assert dpr._channel_biased_tail(head, goal, partner, 0.4, None, incumbent) is incumbent, (
+        "an equally-uncoupled candidate must not displace the incumbent"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Issue #4577 asked why `USB3_TX1`'s landing tail is still a 4.865 mm / 84-segment
/ 0.000-coupled A\* staircase, and offered four non-prescriptive candidate
directions. This PR ships **Gate 1's decline attribution** (mandatory
regardless of outcome), implements the two directions the attribution pointed
at, and reports a **measured negative result on Gate 2** with a quantitative
explanation.

**The headline finding: `USB3_TX1`'s residual is not a missing mechanism.** Both
levers now work — they produce coupled copper that `main` cannot produce — and
both lose the *length* trade, not a legality gate. On that landing, every route
carrying more coupling is longer by **more than the coupling it buys**, so
shipping one would **lower** the leg's `diffpair_routing_continuity`. The
constructor's existing coupled-millimetres doctrine correctly refuses.

Base commit: `092611b0`. Board output is unchanged mode-for-mode.

## Changes

`src/kicad_tools/router/diffpair_routing.py`

1. **Decline attribution (Gate 1).** `[coupled-follow] declined:` now carries
   `runs=N why=<stage>=<count>,…` over a closed vocabulary —
   `no-surviving-run` / `lead` / `truncate` / `landing` / `budget` / `chain`.
   Two more attribution lines were added for the paths introduced below:
   `[coupled-channel] <stage>` and `[coupled-follow] deferred candidate lost:`.
2. **`_head_partner_side`** + side-aware expensive probe. `_follow_partner_runs`
   offsets the slice on **both** sides blindly and the candidates are ordered by
   length, so the one expensive lead-in probe was routinely spent on a run
   sitting **across the guide** from the head — where no legal lead-in can
   exist, because a lead-in must keep `partner_clearance` and therefore cannot
   cross the partner's own copper. The probe is now also granted to the best run
   on the head's own side.
3. **`_suffix_spans`** + `_TAIL_FOLLOW_ENTRY_FRACTIONS` — a negotiable bridge
   point. `_truncate_spans` is a head-anchored prefix, so `run[0]` is identical
   at every keep fraction and nothing in the pre-#4577 code could move the one
   coordinate the lead-in was failing on. The new ladder is its mirror: walk the
   entry forward along the run, giving up a prefix to buy a bridge the
   axis-aligned synthesizer can actually draw.
4. **Deferred re-judgement.** A follow candidate that lost only to
   `_tail_is_better_coupled`'s "no incumbent" stand-in bound is kept and
   re-judged against the tail that *actually* ships. "No incumbent" was never
   true here — merely not known yet, because the A\* fallback runs later.
5. **`_partner_channel_wall_sites`** + `_channel_biased_tail` — issue #4577's
   direction (b). `_partner_boost_sites` only ever **repels** the fallback A\*
   from the guide; these sites add the missing **outer** wall just outside the
   coupling window, so the two cheapest lanes are the coupled offsets. Built
   from the transient `avoid_locations` primitive (already cleared in
   `_single_ended_guide_route`'s `finally`), so **no grid corridor reservation
   is written** and the escape router's global reservations are untouched —
   the hazard the issue flagged. `_fallback_tail_route` was split into a
   wrapper + `_fallback_tail_route_body` (the pattern #4582 established for
   `_shadow_route_pair`); the body is byte-unchanged.

Every new path only **adds** candidates. Each is held to the same raster /
foreign-pad (#4571) / foreign-via (#4575) / partner-clearance (#4460) gates and
the same `_tail_is_better_coupled` doctrine as before. No constant was retuned.

## Measurements

Base commit `092611b0`, `KCT_BOARD06_SHADOW=1 KCT_SHADOW_DEBUG=1
PYTHONHASHSEED=42 … --step route --seed 42`, C++ backend built. Both runs landed
in **Mode B** (#4536), so every board comparison below is paired mode-for-mode.

**Determinism confirmed as the issue requires**: two independent post-change
runs produced a byte-identical set of all 91 `[coupled-tail]` /
`[coupled-follow]` / `[coupled-channel]` lines (identical md5).

### Shadow phase — tail sources (33 tails)

| `src=` | before | after |
|---|---|---|
| `synth` | 14 | 14 |
| `crossing` | 9 | 9 |
| `follow` | 5 | 5 |
| `astar` | 5 | 5 |

### Shadow phase — decline reasons

Reproduces the Curator's baseline table exactly, which is how I validated the
instrumentation before trusting it.

| terminal reason | before | after |
|---|---|---|
| `no followable partner slice` | 9 | 9 |
| `no-surviving-run` (empty `why`) | 4 | 4 |
| `lead` only (`lead=1`×18, `lead=2`×4) | 22 | 22 |
| `budget` only | 6 | 6 |
| mixed containing `lead` | 5 | **4** |
| mixed `budget`+`landing` | 1 | 1 |
| **numeric declines** | **38** | **37** |
| total decline lines | 47 | 46 |

The one decline that left is `USB3_TX1`'s `shadow-end`
(`why=budget=6,lead=2` → bracketed successfully). Its candidate is now reported
by the new deferred line instead.

### Board (Mode B, paired)

| metric | before | after |
|---|---|---|
| DRC errors | 35 | 35 |
| `diffpair_clearance_intra` | 19 | 19 |
| `diffpair_routing_continuity` | 6 | 6 |
| `diffpair_length_skew` | 6 | 6 |
| `connectivity` | 3 | 3 |
| `impedance` | 1 | 1 |
| net reach | 18 of 21 | 18 of 21 |
| `class=coupled-ok` | 5 of 9 | 5 of 9 |
| `USB3_TX1` continuity | 84.7% | 84.7% |
| `USB3_TX2` continuity | 87.7% | 87.7% |
| `USB2_D` continuity | 62.6% | 62.6% |
| `PCIE_RX` continuity | passes (no error) | passes (no error) |
| foreign-via gate rejections | 323 | 470 |
| shadow-phase wall clock | 12.96 s | 17.84 s |

The foreign-via delta is the deliberate candidate-generation change Gate 3 asks
to have explained: more candidates are generated (entry ladder, near-side
expensive probe, channel retry), so more are screened. No candidate that passed
before is rejected now — the gate itself is untouched.

### Why `USB3_TX1` does not move (Gate 4 attribution)

The new instrumentation prints the two decisive numbers, both on the
`shadow-end` tail of the attempt that ships:

```
[coupled-follow] deferred candidate lost: cand len=6.447 coupled=1.042
                 vs incumbent len=4.884 coupled=0.000 (floor=0.500)
[coupled-channel] not-better-coupled: sites=22 len=10.764 coupled=2.058 segs=177
                 (was len=4.865 segs=84)
```

* The **follow** lever now works: fixing the lead-in turns a `lead`-blocked run
  into a bracketed 6.447 mm tail carrying **1.042 coupled mm** where `main`
  produced no candidate at all. It costs **1.563 mm** of extra copper for
  1.042 mm of coupling.
* The **channel-fenced A\*** (direction (b)) also works: it finds a genuinely
  coupled route — **2.058 coupled mm** against the shipped tail's 0.000. It
  costs **5.899 mm** of extra copper for 2.058 mm of coupling.

Both are rejected by `_tail_is_better_coupled`'s bound "the extra copper must
not exceed the coupled millimetres bought". That bound is not a stylistic
preference — running the arithmetic on the actual leg (52.976 mm, 0.8665
coupled) shows swapping either candidate in would make the metric **worse**:

| candidate | Δ coupled | Δ length | leg continuity |
|---|---|---|---|
| incumbent (shipped A\* staircase) | — | — | 0.8665 |
| follow (entry ladder) | +1.042 | +1.563 | 0.8607 |
| channel-fenced A\* | +2.058 | +5.899 | 0.8145 |

So the measurement **rules out constant-retuning as well as policy**: relaxing
`_TAIL_FOLLOW_MIN_COUPLED_MM` / `_TAIL_FOLLOW_MIN_FRACTION` /
`_TAIL_FOLLOW_LENGTH_*` would admit exactly these candidates and lower the
number the issue is trying to raise.

**What this rules in.** `USB3_TX1`'s landing corridor is congested enough that
coupled copper is only reachable via a detour. The issue's *title* ("the partner
slice is mostly unoffsettable") is right for **this pair** — its slice yields
0.851–1.042 mm of legal offset run out of 2.634 mm — even though the Curator's
board-wide correction (the lead-in dominates the *decline count*) is right for
the board. The remaining lever is not in the tail synthesizer: it is whatever
shortens the coupled path itself (placement / escape ordering / the guide's own
shape near the landing), which is out of scope here.

## Acceptance Criteria Verification

**Gate 1 — decline attribution ships regardless of outcome.** MET.
- [x] The decline line distinguishes the stage: `no-surviving-run` / `lead` /
      `truncate` / `landing` / `budget` / `chain`, plus `[coupled-channel]`
      (`no-path` / `pad-deficit` / `via-deficit` / `partner-clearance` /
      `not-better-coupled` / `upgraded`) and the deferred-candidate line.
- [x] The board-06 histogram is recorded above and matches the Curator's
      baseline table exactly.

**Gate 2 — the observable outcome.** NOT MET; Gate 4 applies.
- [ ] `USB3_TX1`'s `shadow-end` tail still ships as `src=astar`, 84 segments,
      `coupled=0.000`; continuity stays at 84.7%. Attribution above.

**Gate 3 — no regression, vacuity traps closed.** MET.
- [x] `class=coupled-ok` 5 of 9, unchanged (MIPI_CLK, PCIE_RX, USB2_D,
      USB3_TX1, USB3_TX2 — the same five pairs, verified per-pair, not by
      count).
- [x] `USB3_TX2` 87.7%, `USB2_D` 62.6%, `PCIE_RX` still passing — none regress.
- [x] `diffpair_clearance_intra` 19, at the Mode B baseline (not increased).
- [x] Net reach 18 of 21, at the Mode B baseline (not decreased).
- [x] Foreign-via gate 323 → 470: deliberate candidate-generation change,
      explained above.
- [x] Shadow construction remains OFF by default (`enable_shadow_construction`
      untouched, still `False`); every new path needs `partner_segments`, which
      only the shadow constructor supplies. Covered by
      `test_channel_retry_is_inert_with_shadow_construction_off`.
- [x] Lint / format / mypy baseline / pytest — see Test Plan.

**Gate 4 — a measured negative result is a legitimate outcome.** This is the
deliverable. Instrumentation shipped, attribution stated, no constant retuned,
no gate weakened, and no claim of a win from a rule that stopped firing (the
`coupled-ok` set is verified pair-by-pair precisely to rule that out).

**Out of scope, respected.** `_shadow_select_gap` is untouched — that is #4580.
`enable_shadow_construction` is not flipped (#4409 / #4463 Phase 5). The `+`
leg's length-matching meander (#4569's arithmetic cap) is untouched.

## Test Plan

- [x] `uv run pytest tests/test_diffpair_shadow.py` — 174 passed (was 165; 9 new).
- [x] **New tests fail on `main`.** Verified by checking out `092611b0`'s
      `diffpair_routing.py` under the new test file: 7 of the behavioural new
      tests fail (`AttributeError` / assertion), confirming non-vacuity.
- [x] Non-vacuity spy (`test_channel_retry_is_not_vacuous_and_only_fires_on_a_zero_coupled_tail`)
      asserts the retry both *does* run for a 0.000-coupled winner and does
      *not* run for an already-coupled one — mirroring
      `test_shadow_entry_point_spy_is_not_vacuous`.
- [x] Flag-OFF inertness (`test_channel_retry_is_inert_with_shadow_construction_off`)
      — one probe, result returned untouched, retry never entered.
- [x] Pure-Python-backend degradation: the channel retry reuses
      `_layer_locked_router`, which already yields `False` (no-op) when
      `set_routable_layers` is absent; the planar branch then produces no
      candidate and the incumbent is returned.
- [x] `_suffix_spans` edge cases (zero length, empty input) and the
      `_head_partner_side` sign convention are pinned directly.
- [x] `test_fallback_tail_route_keeps_a_partner_clean_probe_unchanged` — the
      #4460 invariant it was written for is a statement about the **body**, and
      is asserted on `_fallback_tail_route_body` unchanged; the public
      "clean probe comes back untouched" assertion is kept as well. Called out
      explicitly because it is the one pre-existing test this PR edits.
- [x] `uv run ruff check .` / `uv run ruff format . --check` — clean.
- [x] `uv run python scripts/ci/check_mypy_baseline.py` — the only finding is a
      pre-existing `src/kicad_tools/recovery/strategy.py` `[assignment]` error
      that reproduces identically on a clean `092611b0` checkout; nothing new
      from this PR.
- [x] `uv run pytest tests/test_board_06_diffpair_test.py` — 42 passed.
- [x] `uv run pytest tests/test_kct_check_parity.py` — 8 passed, the 3 known
      `TestBoard07KctCheckParity` failures unchanged (pre-existing local
      environment artifact, #4592; not touched).
- [x] `uv run pytest` (full suite) — **3 failed, 24070 passed, 96 skipped** in
      1:12:33. The 3 failures are exactly the pre-existing
      `TestBoard07KctCheckParity` ones (#4592), unchanged and untouched.
      *(An earlier `-x` run aborted on
      `TestBoard06StrictGateGuard::test_strict_gate_blocking_count_pinned`; that
      was traced to a regenerated `boards/06-diffpair-test/output/` artifact
      accidentally swept into an early WIP commit by a `git add -A` during
      measurement — not to a code change. The artifact was restored to
      `092611b0`, verified byte-identical to the main checkout's committed copy
      by md5, and those 42 tests pass again. The final commit does not touch
      `boards/` at all.)*
- [x] `boards/*/output/` restored to `092611b0` and verified byte-identical to
      the main checkout's committed artifact; the final commit touches only
      `src/kicad_tools/router/diffpair_routing.py` and
      `tests/test_diffpair_shadow.py`. `git status` is clean of board output and
      of `tests/benchmark_results.json` / `tests/fixtures/*`.

Closes #4577
