### PR TITLE
fix(build-native): verify the installed extension in a fresh interpreter

### DIFF
--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -163,6 +163,51 @@ job rebuilds from a clean checkout and asserts the guard reports the
 backend as available, so a forgotten version bump or stale `.so` will fail
 CI rather than silently regress production.
 
+### How the build verifies itself (Issue #4589)
+
+`kct build-native` verifies the extension it just installed by running
+`get_backend_info()` in a **freshly spawned interpreter**
+(`cpp_backend.probe_backend_info()`), not by reloading the module in the
+process that did the build. This matters because a C extension cannot be
+re-imported from a replaced file in the same process: once
+`router_cpp.*.so` has been `dlopen`'d, CPython keeps the initialised module
+in a runtime extension cache that neither `sys.modules.pop()` nor
+`importlib.invalidate_caches()` clears, so the re-import returns the
+*identical* module object — describing the **pre-build** extension.
+
+`kct build-native --check` resolves availability through the same
+`probe_backend_info()` helper, so the two commands cannot report different
+answers for the same on-disk state. They previously could, in both
+directions:
+
+| Rebuild trigger | Old in-process probe | Reality |
+|---|---|---|
+| `BUILD_VERSION` mismatch | `Extension installed but not loading correctly` | fine — `--check` reported *available* seconds later |
+| source newer than `.so` (mtime) | `installed successfully!` | unverified — success was asserted against code the process never loaded |
+
+Practical consequences for contributors:
+
+- **A build failure warning now names the cause**: the
+  `unavailable_reason` (ImportError text / ABI mismatch / `BUILD_VERSION`
+  mismatch), the `.so` path probed, and the interpreter used.
+- **`--check` still compiles nothing** and stays sub-second in a warm venv;
+  it returns before `build_native()` is ever called. A multi-minute
+  `uv run kct build-native --check` in a fresh worktree is `uv sync`
+  creating the venv, not this command building.
+- **`--check` also prints `BUILD_VERSION`**, which is the number the
+  staleness guard actually checks — the `version 1.0.0` string is the
+  extension's own version and never changes on a bindings bump.
+- **`kct route`'s silent auto-build** goes through the same probe. When a
+  rebuild succeeds but the running process cannot hot-swap the replaced
+  extension, it now says exactly that ("re-run the command") instead of
+  announcing a 10-100x-slower Python fallback as if the build had failed.
+- The `.so` is installed with a temp file + `os.replace()`, so a
+  concurrently running process never reads a half-written image, and
+  `_find_installed_so()` resolves the extension suffix of the **running**
+  interpreter (`importlib.machinery.EXTENSION_SUFFIXES`) instead of the
+  first `glob` hit — a checkout carrying 312/313/314 builds side by side no
+  longer makes rebuild decisions against a `.so` it never loads.
+
 ---
 
 ## Running Tests

--- a/src/kicad_tools/cli/build_native_cmd.py
+++ b/src/kicad_tools/cli/build_native_cmd.py
@@ -31,6 +31,10 @@ class BuildResult:
     steps_completed: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
     skipped: bool = False
+    # Issue #4589: the fresh-interpreter probe result that decided
+    # ``backend_installed`` (``cpp_backend.probe_backend_info()`` output).
+    # ``None`` when no build was performed (short-circuit / early failure).
+    verification: dict | None = None
 
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON output."""
@@ -42,6 +46,7 @@ class BuildResult:
             "steps_completed": self.steps_completed,
             "warnings": self.warnings,
             "skipped": self.skipped,
+            "verification": self.verification,
         }
 
 
@@ -96,12 +101,67 @@ def _get_cpp_source_dir() -> Path | None:
     return None
 
 
-def _find_installed_so(router_dir: Path) -> Path | None:
-    """Return the installed router_cpp extension (.so/.pyd), if any."""
-    for pattern in ("router_cpp.*.so", "router_cpp.*.pyd"):
-        for so_file in router_dir.glob(pattern):
-            return so_file
-    return None
+def _extension_candidates(router_dir: Path) -> list[Path]:
+    """Return every installed ``router_cpp`` extension file, sorted by name.
+
+    Sorted so the result never depends on filesystem (``Path.glob``) order --
+    a multi-ABI directory (``router_cpp.cpython-312-darwin.so`` alongside
+    ``...-313-...`` / ``...-314-...``) is normal in a shared checkout.
+    """
+    seen: set[Path] = set()
+    for pattern in (
+        "router_cpp.*.so",
+        "router_cpp.*.pyd",
+        "router_cpp.so",
+        "router_cpp.pyd",
+    ):
+        seen.update(router_dir.glob(pattern))
+    return sorted(seen, key=lambda p: p.name)
+
+
+def _find_installed_so(router_dir: Path, *, abi_only: bool = False) -> Path | None:
+    """Return the installed router_cpp extension for the RUNNING interpreter.
+
+    Issue #4589: this used to return the first ``Path.glob`` hit, which is
+    filesystem order, not interpreter order.  Measured on a checkout carrying
+    312/313/314 builds side by side, it returned
+    ``router_cpp.cpython-313-darwin.so`` while the interpreter actually
+    imported ``router_cpp.cpython-312-darwin.so``.  Two things then went
+    wrong: :func:`_is_so_stale` made the rebuild decision against a file this
+    interpreter never loads, and the ``Extension: <name>`` success line named
+    the wrong file.
+
+    Selection order:
+
+    1. The first match against :data:`importlib.machinery.EXTENSION_SUFFIXES`
+       (e.g. ``.cpython-312-darwin.so``, then ``.abi3.so``, then ``.so``; on
+       Windows ``.cp312-win_amd64.pyd`` then ``.pyd``) -- i.e. exactly what
+       this interpreter's import machinery would pick.
+    2. Otherwise the alphabetically-first candidate, so the answer is
+       deterministic even for a foreign-ABI-only directory.
+
+    Args:
+        router_dir: Directory to search (the installed ``router/`` package).
+        abi_only: When ``True``, return ``None`` instead of falling back to
+            step 2 -- i.e. "is there an extension THIS interpreter could
+            load?".  A foreign-ABI-only directory then reads as "not
+            installed", which is what it actually is for this interpreter.
+    """
+    import importlib.machinery
+
+    candidates = _extension_candidates(router_dir)
+    if not candidates:
+        return None
+
+    by_name = {path.name: path for path in candidates}
+    for suffix in importlib.machinery.EXTENSION_SUFFIXES:
+        match = by_name.get(f"router_cpp{suffix}")
+        if match is not None:
+            return match
+
+    if abi_only:
+        return None
+    return candidates[0]
 
 
 def _newest_cpp_source_mtime(cpp_dir: Path) -> float | None:
@@ -152,6 +212,38 @@ def _is_so_stale(router_dir: Path) -> bool:
         return False
 
     return newest_source > so_mtime
+
+
+def _install_extension_atomically(source: Path, target: Path) -> None:
+    """Install ``source`` at ``target`` via a temp file + :func:`os.replace`.
+
+    Issue #4589: ``shutil.copy2(source, target)`` truncates and rewrites the
+    destination **in place** -- the same inode a concurrently running process
+    (or this one) may already have ``dlopen``'d.  That process can then read a
+    half-written image.  Writing into a sibling temp file in the destination
+    directory and renaming over the target makes the swap atomic: readers keep
+    the old inode until they re-open, and no one ever observes a partial file.
+
+    The temp file is created in ``target.parent`` so the rename stays within a
+    single filesystem (``os.replace`` across devices raises ``OSError``).
+    """
+    import os
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(target.parent), prefix=f".{target.name}.", suffix=".tmp"
+    )
+    os.close(fd)
+    tmp_path = Path(tmp_name)
+    try:
+        # copy2 preserves mode/mtime from the freshly built artifact,
+        # overriding mkstemp's restrictive 0600.
+        shutil.copy2(source, tmp_path)
+        os.replace(tmp_path, target)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            tmp_path.unlink()
+        raise
 
 
 def _get_project_root() -> Path | None:
@@ -420,11 +512,12 @@ def build_native(
         if verbose:
             print("  Build: OK")
 
-        # Step 6: Find and copy the .so file
-        so_files = list(build_dir.glob("**/router_cpp.*.so"))
+        # Step 6: Find and copy the .so file (sorted: never depend on
+        # filesystem glob order -- Issue #4589)
+        so_files = sorted(build_dir.glob("**/router_cpp.*.so"))
         if not so_files:
             # Try .pyd for Windows
-            so_files = list(build_dir.glob("**/router_cpp.*.pyd"))
+            so_files = sorted(build_dir.glob("**/router_cpp.*.pyd"))
         if not so_files:
             result.error_message = "Build succeeded but router_cpp extension not found"
             return result
@@ -435,44 +528,70 @@ def build_native(
         if verbose:
             print(f"Installing to {target_path}...")
 
-        shutil.copy2(so_file, target_path)
+        _install_extension_atomically(so_file, target_path)
         result.so_path = target_path
         result.steps_completed.append(f"Installed: {target_path}")
 
-        # Verify the installation
+        # Verify the installation in a FRESH INTERPRETER (Issue #4589).
+        #
+        # The old code verified in-process with ``sys.modules.pop`` +
+        # ``importlib.invalidate_caches`` + ``importlib.reload``.  That cannot
+        # observe the file we just wrote: an already-``dlopen``'d C extension
+        # is held in CPython's runtime extension cache (keyed by filename +
+        # module name) which none of those calls clear, so the re-import
+        # returns the IDENTICAL module object -- the pre-build extension.
+        # Consequences, both measured:
+        #
+        #   * version-stale rebuild -> false NEGATIVE: "Extension installed
+        #     but not loading correctly", contradicted by ``--check`` seconds
+        #     later in a fresh interpreter;
+        #   * mtime-stale rebuild   -> false POSITIVE: reported success while
+        #     the freshly built .so is one a fresh interpreter REJECTS.
+        #
+        # ``probe_backend_info`` runs ``get_backend_info()`` under
+        # ``sys.executable`` -- literally the code path ``--check`` uses -- so
+        # the two commands cannot disagree about the same on-disk state.
         try:
-            # Clear any cached imports
-            #
-            # Issue #2594: ``importlib.reload(cpp_module)`` alone is not
-            # enough when the original ``from . import router_cpp`` failed
-            # at startup (fresh checkout with no .so on disk).  Python
-            # caches the negative result on the parent package's
-            # ``FileFinder`` and may leave a partial / ``None`` entry in
-            # ``sys.modules`` for ``kicad_tools.router.router_cpp``.  We
-            # must drop that stale entry and invalidate the path-based
-            # caches so the reloaded ``cpp_backend`` actually picks up
-            # the freshly-written ``.so``.  ``sys`` is already imported
-            # at module scope -- do NOT shadow it with a local import
-            # here (would trigger ``UnboundLocalError`` on the earlier
-            # ``sys.executable`` reference at the cmake configure step).
-            import importlib
+            from kicad_tools.router import cpp_backend as cpp_module
 
-            sys.modules.pop("kicad_tools.router.router_cpp", None)
-            importlib.invalidate_caches()
+            # This process has replaced the extension on disk, so its own
+            # in-memory view is stale by construction from here on.
+            cpp_module.note_extension_replaced()
 
-            import kicad_tools.router.cpp_backend as cpp_module
+            info = cpp_module.probe_backend_info(allow_in_process=False)
+            probe = info.get("probe", {})
+            result.verification = info
 
-            importlib.reload(cpp_module)
-            if cpp_module.is_cpp_available():
+            if info.get("available"):
                 result.backend_installed = True
                 result.success = True
                 if verbose:
-                    print("  Verification: OK")
+                    print(f"  Verification: OK (fresh interpreter: {probe.get('interpreter')})")
+            elif probe.get("failed"):
+                # The probe itself could not run (timeout, spawn error, bad
+                # output).  Do NOT claim the extension is broken.
+                result.warnings.append(
+                    "Could not verify the installed extension -- the verification "
+                    "probe did not run.\n"
+                    f"Reason: {probe.get('error')}\n"
+                    f"Extension: {target_path}\n"
+                    f"Interpreter: {probe.get('interpreter')}"
+                )
+                result.success = True  # Build succeeded
             else:
-                result.warnings.append("Extension installed but not loading correctly")
+                result.warnings.append(
+                    "Extension installed but a fresh interpreter cannot load it.\n"
+                    f"Reason: {info.get('unavailable_reason') or 'unknown'}\n"
+                    f"Extension: {target_path}\n"
+                    f"Interpreter: {probe.get('interpreter')}"
+                )
                 result.success = True  # Build succeeded, just verification failed
         except Exception as e:
-            result.warnings.append(f"Could not verify installation: {e}")
+            result.warnings.append(
+                f"Could not verify installation: {type(e).__name__}: {e}\n"
+                f"Extension: {target_path}\n"
+                f"Interpreter: {sys.executable}"
+            )
             result.success = True  # Build succeeded
 
     finally:
@@ -508,7 +627,13 @@ def format_result_text(result: BuildResult) -> str:
             lines.append("Build completed with warnings.")
             lines.append("")
             for warning in result.warnings:
-                lines.append(f"  Warning: {warning}")
+                # Issue #4589: warnings are now multi-line (reason / probed
+                # .so path / interpreter).  Indent continuation lines so the
+                # detail stays attached to its "Warning:" header.
+                first, *rest = warning.split("\n")
+                lines.append(f"  Warning: {first}")
+                for extra in rest:
+                    lines.append(f"    {extra}")
     else:
         lines.append("Build failed.")
         lines.append("")
@@ -566,21 +691,48 @@ def main(argv: list[str] | None = None) -> int:
     parser = create_parser()
     args = parser.parse_args(argv)
 
-    # Check mode - just report status
+    # Check mode - just report status.
+    #
+    # NOTE (Issue #4589): this branch performs NO compilation and must stay
+    # that way -- it returns before ``build_native()`` is ever called.  A
+    # multi-minute ``uv run kct build-native --check`` in a fresh worktree is
+    # ``uv sync`` creating the venv, not this command building anything.
+    #
+    # It resolves availability through the SAME ``probe_backend_info`` helper
+    # the post-build verification uses, so the two commands cannot report
+    # different answers for the same on-disk state.  Nothing has replaced the
+    # extension under this short-lived process, so the probe answers
+    # in-process (no subprocess spawn) and stays sub-second.
     if args.check:
         try:
-            from kicad_tools.router.cpp_backend import get_backend_info, is_cpp_available
+            from kicad_tools.router.cpp_backend import probe_backend_info
 
-            info = get_backend_info()
+            info = probe_backend_info()
+            available = bool(info.get("available"))
             if args.format == "json":
                 print(json.dumps(info, indent=2))
             else:
-                if is_cpp_available():
-                    print(f"C++ backend: available (version {info['version']})")
+                if available:
+                    print(f"C++ backend: available (version {info.get('version')})")
+                    # Issue #4589: ``version()`` ("1.0.0") is NOT the number
+                    # the staleness guard checks -- surface BUILD_VERSION and
+                    # the resolved extension so a rebuild prompt is legible.
+                    build_version = info.get("build_version")
+                    if build_version is not None:
+                        print(
+                            f"  build version: {build_version} "
+                            f"(required: {info.get('required_build_version')})"
+                        )
+                    extension_path = info.get("extension_path")
+                    if extension_path:
+                        print(f"  extension: {Path(extension_path).name}")
                 else:
                     print("C++ backend: not installed")
+                    reason = info.get("unavailable_reason")
+                    if reason:
+                        print(f"  reason: {reason}")
                     print("Run `kct build-native` to install.")
-            return 0 if is_cpp_available() else 1
+            return 0 if available else 1
         except ImportError:
             if args.format == "json":
                 print(json.dumps({"available": False, "error": "Module not found"}))

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -23,6 +23,7 @@ import logging
 import math
 import os
 import time
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
@@ -51,10 +52,17 @@ _REQUIRED_CPP_BUILD_VERSION = 18
 
 # Try to import C++ module with detailed error tracking
 _CPP_IMPORT_ERROR: str | None = None
+# Issue #4589: diagnostics captured at import time so ``get_backend_info()``
+# can report the numbers the staleness guard actually cares about, even after
+# the version guard below nulls out ``router_cpp``.
+_CPP_BUILD_VERSION: int | None = None
+_CPP_EXTENSION_PATH: str | None = None
 try:
     from . import router_cpp
 
     _CPP_AVAILABLE = True
+    _CPP_BUILD_VERSION = getattr(router_cpp, "BUILD_VERSION", None)
+    _CPP_EXTENSION_PATH = getattr(router_cpp, "__file__", None)
 except ImportError as e:
     _CPP_AVAILABLE = False
     _CPP_IMPORT_ERROR = str(e)
@@ -114,6 +122,184 @@ def is_cpp_available() -> bool:
     return _CPP_AVAILABLE
 
 
+# ---------------------------------------------------------------------------
+# Fresh-interpreter availability probe (Issue #4589)
+# ---------------------------------------------------------------------------
+#
+# ``kct build-native`` used to verify its own work with an in-process
+# ``sys.modules.pop`` + ``importlib.reload`` dance.  That cannot work for a C
+# extension: once ``router_cpp.*.so`` has been ``dlopen``'d, CPython keeps the
+# initialised module in a runtime-level extension cache keyed by
+# ``(filename, module name)`` which neither ``sys.modules.pop`` nor
+# ``importlib.invalidate_caches`` clears, and the loader will not re-read the
+# file.  The re-import therefore returns the *identical* module object, so the
+# probe reports on the PRE-build extension:
+#
+#   * version-stale rebuild  -> false NEGATIVE ("installed but not loading
+#     correctly") even though every later process loads it fine;
+#   * mtime-stale rebuild    -> false POSITIVE (the build is "verified"
+#     against code that was never loaded).
+#
+# The only reliable way to answer "what will the next process see?" is to ask
+# a *fresh* interpreter -- which is exactly what ``build-native --check``
+# already did implicitly by being a new process.  ``probe_backend_info()``
+# below is that single shared probe: ``--check`` and the post-build
+# verification both go through it, so they cannot disagree for the same
+# on-disk state.
+_PROBE_SOURCE = (
+    "import json, sys\n"
+    "from kicad_tools.router.cpp_backend import get_backend_info\n"
+    "sys.stdout.write(json.dumps(get_backend_info()))\n"
+)
+
+# Set once this process has replaced the on-disk extension (i.e. after
+# ``build_native()`` installs a new ``.so``).  From that moment the in-process
+# view is stale BY CONSTRUCTION and ``probe_backend_info()`` must spawn a
+# subprocess instead of trusting it.
+_EXTENSION_REPLACED = False
+
+
+def note_extension_replaced() -> None:
+    """Record that this process overwrote the on-disk ``router_cpp`` extension.
+
+    Called by ``build_native()`` right after installing a freshly compiled
+    ``.so``.  It permanently poisons the in-process fast path of
+    :func:`probe_backend_info` for this interpreter, because the already
+    ``dlopen``'d extension can no longer describe what is on disk.
+    """
+    global _EXTENSION_REPLACED
+    _EXTENSION_REPLACED = True
+
+
+def extension_replaced_in_process() -> bool:
+    """Whether this process has replaced the on-disk extension (see above)."""
+    return _EXTENSION_REPLACED
+
+
+def probe_backend_info(
+    *,
+    executable: str | None = None,
+    timeout: float = 60.0,
+    allow_in_process: bool = True,
+) -> dict:
+    """Return the backend info a *freshly started* interpreter would report.
+
+    This is the single availability probe shared by ``kct build-native``'s
+    post-build verification and ``kct build-native --check`` (Issue #4589).
+
+    The returned dict is exactly what :func:`get_backend_info` produces, plus a
+    ``"probe"`` sub-dict describing how the answer was obtained::
+
+        {"mode": "in-process" | "subprocess",
+         "interpreter": "/path/to/python",
+         "failed": bool,          # True only when the probe could not run
+         "error": str | None}     # populated when ``failed`` is True
+
+    Args:
+        executable: Interpreter to probe with (defaults to ``sys.executable``).
+        timeout: Seconds to wait for the subprocess probe.
+        allow_in_process: Permit the in-process fast path when it is provably
+            equivalent to a fresh interpreter -- that is, when this process has
+            not replaced the extension on disk (see
+            :func:`extension_replaced_in_process`).  Pass ``False`` to force a
+            subprocess (what the post-build verification does).
+
+    Never raises: a probe that cannot run reports ``probe.failed`` with the
+    real error text rather than claiming the extension is broken.
+    """
+    import json
+    import os
+    import pathlib
+    import subprocess
+    import sys
+
+    interpreter = executable or sys.executable
+
+    # Fast path: nothing has replaced the extension under this process, so the
+    # module state we already hold IS what a fresh interpreter would compute
+    # from the same files.  This keeps ``--check`` a sub-second, no-subprocess,
+    # no-compilation status query.
+    info: dict
+    if allow_in_process and not _EXTENSION_REPLACED:
+        info = get_backend_info()
+        info["probe"] = {
+            "mode": "in-process",
+            "interpreter": interpreter,
+            "failed": False,
+            "error": None,
+        }
+        return info
+
+    env = os.environ.copy()
+    # Make sure the child can import ``kicad_tools`` even when this process
+    # found it via a cwd-relative entry on ``sys.path``.
+    try:
+        import kicad_tools
+
+        pkg_parent = str(pathlib.Path(kicad_tools.__file__).resolve().parent.parent)
+        existing = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = pkg_parent + (os.pathsep + existing if existing else "")
+    except Exception:  # pragma: no cover - defensive
+        pass
+
+    probe_meta = {
+        "mode": "subprocess",
+        "interpreter": interpreter,
+        "failed": False,
+        "error": None,
+    }
+
+    try:
+        completed = subprocess.run(
+            [interpreter, "-c", _PROBE_SOURCE],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+        )
+    except Exception as exc:
+        probe_meta["failed"] = True
+        probe_meta["error"] = f"{type(exc).__name__}: {exc}"
+        return _probe_failure_info(probe_meta)
+
+    if completed.returncode != 0:
+        probe_meta["failed"] = True
+        probe_meta["error"] = (
+            f"probe interpreter exited {completed.returncode}: "
+            f"{(completed.stderr or '').strip() or '<no stderr>'}"
+        )
+        return _probe_failure_info(probe_meta)
+
+    try:
+        info = json.loads(completed.stdout)
+    except Exception as exc:
+        probe_meta["failed"] = True
+        probe_meta["error"] = (
+            f"could not parse probe output ({type(exc).__name__}: {exc}): "
+            f"{(completed.stdout or '').strip()[:200]!r}"
+        )
+        return _probe_failure_info(probe_meta)
+
+    info["probe"] = probe_meta
+    return info
+
+
+def _probe_failure_info(probe_meta: dict) -> dict:
+    """Build the info dict returned when the probe itself could not run.
+
+    ``available`` is ``False`` (we genuinely do not know), but the reason
+    names the probe failure so callers never report a working extension as
+    broken on the strength of a subprocess that never ran.
+    """
+    return {
+        "backend": "unknown",
+        "version": "unknown",
+        "available": False,
+        "unavailable_reason": f"backend probe did not run: {probe_meta['error']}",
+        "probe": probe_meta,
+    }
+
+
 def get_cpp_unavailable_reason() -> str | None:
     """Get the reason why C++ backend is unavailable.
 
@@ -153,13 +339,29 @@ def _reload_cpp_backend() -> bool:
     safe case: the previous attempt never succeeded, so there is no
     initialised native module to clash with.
 
+    .. important:: **This only works when the extension was never
+       successfully imported in this process.**  Once ``router_cpp.*.so``
+       has been ``dlopen``'d, CPython's runtime extension cache returns the
+       *identical* module object on re-import, so a replaced ``.so`` (e.g. a
+       ``BUILD_VERSION``-mismatch rebuild) is invisible here -- the reload
+       re-reports the pre-build extension.  Never use the result of this
+       function to decide whether a *build* succeeded; use
+       :func:`probe_backend_info` (a fresh interpreter) for that.  This
+       function answers only the narrower question "can THIS process use the
+       backend now?" (Issue #4589).
+
     Returns:
-        ``True`` if the backend is available after reload, ``False`` otherwise.
+        ``True`` if the backend is available in *this process* after the
+        reload, ``False`` otherwise.
     """
-    global _CPP_AVAILABLE, _CPP_IMPORT_ERROR, router_cpp
+    global _CPP_AVAILABLE, _CPP_IMPORT_ERROR, router_cpp, _EXTENSION_REPLACED
 
     import importlib
     import sys as _sys
+
+    # ``importlib.reload`` re-executes this module's top level, which would
+    # reset the sticky "we replaced the .so" flag back to its initial False.
+    was_replaced = _EXTENSION_REPLACED
 
     # 1. Drop any stale negative/partial entry for the C++ extension itself.
     #    A failed ``from . import router_cpp`` at startup leaves a None or
@@ -182,6 +384,7 @@ def _reload_cpp_backend() -> bool:
         importlib.reload(module)
     except Exception as exc:  # pragma: no cover - defensive
         logger.warning("Failed to reload cpp_backend after build: %s", exc)
+        _EXTENSION_REPLACED = _EXTENSION_REPLACED or was_replaced
         return _CPP_AVAILABLE
 
     # Mirror the freshly-imported globals into this module's namespace so
@@ -190,6 +393,7 @@ def _reload_cpp_backend() -> bool:
     _CPP_AVAILABLE = getattr(module, "_CPP_AVAILABLE", False)
     _CPP_IMPORT_ERROR = getattr(module, "_CPP_IMPORT_ERROR", None)
     router_cpp = getattr(module, "router_cpp", None)
+    _EXTENSION_REPLACED = _EXTENSION_REPLACED or was_replaced
     return _CPP_AVAILABLE
 
 
@@ -258,19 +462,30 @@ def ensure_cpp_backend_available(
     if backend == "cpp":
         if is_cpp_available():
             return True, False, None
+        outcome: AutoBuildOutcome | None = None
         if allow_auto_build and _auto_build_allowed_by_env():
-            built = _attempt_auto_build(quiet=quiet)
-            if built:
+            outcome = _attempt_auto_build(quiet=quiet)
+            if outcome.available_in_process:
                 return True, False, None
         # Build either disallowed or failed -- preserve the original
         # hard-error behavior so ``--backend cpp`` never silently falls
-        # back to Python.
-        _emit(
-            "Error: C++ backend requested but not available.\n"
-            "Build the C++ extension or use --backend auto/python.\n"
-            "See README for build instructions.",
-            file=sys.stderr,
-        )
+        # back to Python.  Issue #4589: when the build DID succeed and only
+        # the in-process hot-swap was impossible, say so instead of the
+        # misleading "not available".
+        if outcome is not None and outcome.available_on_disk:
+            _emit(
+                "Error: the C++ backend was just built and a fresh interpreter loads it,\n"
+                "but this already-running process cannot swap in the replaced extension.\n"
+                "Re-run this command to use the C++ backend.",
+                file=sys.stderr,
+            )
+        else:
+            _emit(
+                "Error: C++ backend requested but not available.\n"
+                "Build the C++ extension or use --backend auto/python.\n"
+                "See README for build instructions.",
+                file=sys.stderr,
+            )
         return False, False, 1
 
     # --backend auto (default): try to auto-build if not available.
@@ -278,8 +493,14 @@ def ensure_cpp_backend_available(
         return True, False, None
 
     if allow_auto_build and _auto_build_allowed_by_env():
-        built = _attempt_auto_build(quiet=quiet)
-        if built:
+        outcome = _attempt_auto_build(quiet=quiet)
+        if outcome.available_in_process:
+            return True, False, None
+        if outcome.available_on_disk:
+            # Issue #4589: the extension IS installed -- _attempt_auto_build
+            # already explained why this process cannot use it.  Emitting
+            # "C++ router backend not installed" here would contradict
+            # ``kct build-native --check`` seconds later.
             return True, False, None
 
     # Backend still unavailable: emit the existing warning and continue
@@ -319,17 +540,44 @@ def _toolchain_available() -> bool:
     return any(shutil.which(compiler) is not None for compiler in ("clang++", "g++"))
 
 
-def _attempt_auto_build(*, quiet: bool) -> bool:
+@dataclass(frozen=True)
+class AutoBuildOutcome:
+    """Result of the silent ``kct route`` auto-build (Issue #4589).
+
+    Two *different* questions have to be answered separately, because a C
+    extension that was already ``dlopen``'d in this process cannot be swapped
+    out for a rebuilt file:
+
+    Attributes:
+        available_in_process: The running process can use the C++ backend now
+            (``is_cpp_available()`` is True after the reload).
+        available_on_disk: A *fresh interpreter* reports the backend as
+            available -- i.e. the build genuinely succeeded, even if this
+            process cannot hot-swap it.
+        reason: Human-readable explanation when ``available_on_disk`` is False.
+    """
+
+    available_in_process: bool
+    available_on_disk: bool
+    reason: str | None = None
+
+    def __bool__(self) -> bool:  # pragma: no cover - convenience
+        return self.available_in_process
+
+
+def _attempt_auto_build(*, quiet: bool) -> AutoBuildOutcome:
     """Run ``build_native(force=False)`` and reload this module on success.
 
-    Returns ``True`` if the C++ backend is available after the attempt
-    (either it was already built and the call short-circuited, or it
-    built successfully).  Returns ``False`` on any failure -- never
-    raises.
+    Never raises.  The ``build_native`` call short-circuits in milliseconds
+    when the backend is already loaded and up to date, so repeat invocations
+    are effectively free once the ``.so`` exists.
 
-    The ``build_native`` call short-circuits in milliseconds when the
-    backend is already loaded (see ``build_native_cmd.py:193-208``), so
-    repeat invocations are effectively free once the ``.so`` exists.
+    Issue #4589: the return value distinguishes "this process can use the
+    backend" from "the build succeeded".  Previously both collapsed into a
+    single ``False``, so a successful build that merely could not be
+    hot-swapped into the running interpreter was announced as a build failure
+    followed by ``C++ router backend not installed`` -- the same false
+    negative ``kct build-native`` printed.
     """
     if not _toolchain_available():
         if not quiet:
@@ -337,7 +585,11 @@ def _attempt_auto_build(*, quiet: bool) -> bool:
                 "Note: C++ router toolchain (cmake + clang++/g++) not found; skipping auto-build.",
                 flush=True,
             )
-        return False
+        return AutoBuildOutcome(
+            available_in_process=False,
+            available_on_disk=False,
+            reason="C++ toolchain (cmake + clang++/g++) not found",
+        )
 
     if not quiet:
         print(
@@ -355,16 +607,24 @@ def _attempt_auto_build(*, quiet: bool) -> bool:
                 f"Note: auto-build raised {type(exc).__name__}: {exc}; falling back to Python.",
                 flush=True,
             )
-        return False
+        return AutoBuildOutcome(
+            available_in_process=False,
+            available_on_disk=False,
+            reason=f"auto-build raised {type(exc).__name__}: {exc}",
+        )
 
     if not getattr(result, "success", False):
+        err = getattr(result, "error_message", None) or "unknown error"
         if not quiet:
-            err = getattr(result, "error_message", None) or "unknown error"
             print(
                 f"Note: C++ auto-build failed: {err}; falling back to Python.",
                 flush=True,
             )
-        return False
+        return AutoBuildOutcome(
+            available_in_process=False,
+            available_on_disk=False,
+            reason=f"auto-build failed: {err}",
+        )
 
     # Build succeeded -- reload this module so module-level globals
     # (``_CPP_AVAILABLE``, ``router_cpp``) reflect the freshly written
@@ -379,13 +639,34 @@ def _attempt_auto_build(*, quiet: bool) -> bool:
     # platform where dlopen of the new .so itself fails after the build
     # wrote it to disk).
     available = _reload_cpp_backend()
-    if not available and not quiet:
+    if available:
+        return AutoBuildOutcome(available_in_process=True, available_on_disk=True)
+
+    # The in-process reload could not pick it up.  Before blaming the build,
+    # ask the SAME fresh-interpreter probe ``kct build-native --check`` uses
+    # what is actually on disk (Issue #4589) -- an already-``dlopen``'d
+    # extension can never be replaced in-process, so this is the expected
+    # outcome of a version-guard rebuild, not a failure.
+    probe = probe_backend_info(allow_in_process=False)
+    if probe.get("available"):
+        if not quiet:
+            print(
+                "Note: the C++ backend was built successfully and verified in a fresh "
+                "interpreter, but this already-running process cannot load the replaced "
+                "extension (CPython keeps the original dlopen handle). Using Python for "
+                "THIS run only -- re-run the command to get the C++ backend.",
+                flush=True,
+            )
+        return AutoBuildOutcome(available_in_process=False, available_on_disk=True)
+
+    reason = probe.get("unavailable_reason") or "unknown reason"
+    if not quiet:
         print(
-            "Note: C++ build succeeded but module reload did not pick it up; "
-            "falling back to Python.",
+            f"Note: C++ build reported success but a fresh interpreter still cannot "
+            f"load the extension ({reason}); falling back to Python.",
             flush=True,
         )
-    return available
+    return AutoBuildOutcome(available_in_process=False, available_on_disk=False, reason=reason)
 
 
 def get_backend_info() -> dict:
@@ -393,10 +674,22 @@ def get_backend_info() -> dict:
 
     Returns a dictionary with:
         - backend: "cpp" or "python"
-        - version: version string
+        - version: version string (the extension's ``version()`` string, e.g.
+          ``"1.0.0"`` -- NOT the number the staleness guard checks)
+        - build_version: the compiled ``router_cpp.BUILD_VERSION`` integer, or
+          ``None`` when the extension could not be imported at all
+        - required_build_version: ``_REQUIRED_CPP_BUILD_VERSION`` -- the value
+          ``build_version`` must equal for the backend to be enabled
+        - extension_path: the ``.so``/``.pyd`` this interpreter actually
+          imported, or ``None``
         - available: True if C++ backend is available
         - unavailable_reason: Error message if C++ unavailable (only if available=False)
         - platform: Current platform info (for diagnostics)
+
+    Issue #4589: ``build_version`` / ``required_build_version`` /
+    ``extension_path`` are reported in BOTH the available and unavailable
+    branches, because "version 1.0.0" alone could not explain a
+    ``BUILD_VERSION``-mismatch disable.
     """
     import platform
     import sys
@@ -411,6 +704,9 @@ def get_backend_info() -> dict:
         return {
             "backend": "cpp",
             "version": router_cpp.version(),
+            "build_version": _CPP_BUILD_VERSION,
+            "required_build_version": _REQUIRED_CPP_BUILD_VERSION,
+            "extension_path": _CPP_EXTENSION_PATH,
             "available": True,
             "platform": platform_info,
         }
@@ -443,6 +739,9 @@ def get_backend_info() -> dict:
     result = {
         "backend": "python",
         "version": "pure-python",
+        "build_version": _CPP_BUILD_VERSION,
+        "required_build_version": _REQUIRED_CPP_BUILD_VERSION,
+        "extension_path": _CPP_EXTENSION_PATH,
         "available": False,
         "unavailable_reason": reason,
         "build_hint": build_hint,

--- a/tests/test_build_native_staleness.py
+++ b/tests/test_build_native_staleness.py
@@ -18,11 +18,23 @@ They exercise the pure decision helpers and the short-circuit branch of
 
 from __future__ import annotations
 
+import importlib.machinery
 import os
 from pathlib import Path
 from unittest import mock
 
+import pytest
+
 import kicad_tools.cli.build_native_cmd as bnc
+
+# The extension suffix this interpreter's import machinery would pick, e.g.
+# ``.cpython-312-darwin.so`` (POSIX) or ``.cp312-win_amd64.pyd`` (Windows).
+RUNNING_ABI_SUFFIX = importlib.machinery.EXTENSION_SUFFIXES[0]
+
+# Two suffixes this interpreter can never load, used to build multi-ABI
+# fixtures.  Chosen to sort BOTH before and after the running suffix so the
+# tests cannot pass by accident on glob/sort order.
+FOREIGN_SUFFIXES = (".cpython-000-foreign.so", ".cpython-999-foreign.so")
 
 
 def _make_so(router_dir: Path, mtime: float) -> Path:
@@ -173,3 +185,415 @@ class TestFormatResultText:
 def test_build_result_to_dict_includes_skipped() -> None:
     result = bnc.BuildResult(success=True, skipped=True)
     assert result.to_dict()["skipped"] is True
+
+
+# ---------------------------------------------------------------------------
+# Issue #4589
+# ---------------------------------------------------------------------------
+
+
+def _touch_extension(router_dir: Path, suffix: str, mtime: float) -> Path:
+    """Create ``router_cpp<suffix>`` with a fixed mtime."""
+    router_dir.mkdir(parents=True, exist_ok=True)
+    path = router_dir / f"router_cpp{suffix}"
+    path.write_bytes(b"\x00")
+    os.utime(path, (mtime, mtime))
+    return path
+
+
+class TestFindInstalledSoAbiAwareness:
+    """``_find_installed_so`` must resolve the RUNNING interpreter's ABI.
+
+    Before Issue #4589 it returned the first ``Path.glob`` hit -- filesystem
+    order.  Measured on a checkout carrying 312/313/314 builds it returned
+    ``router_cpp.cpython-313-darwin.so`` while the interpreter imported
+    ``router_cpp.cpython-312-darwin.so``.
+    """
+
+    def test_prefers_running_interpreter_suffix(self, tmp_path: Path) -> None:
+        router_dir = tmp_path / "router"
+        for suffix in FOREIGN_SUFFIXES:
+            _touch_extension(router_dir, suffix, 100.0)
+        expected = _touch_extension(router_dir, RUNNING_ABI_SUFFIX, 100.0)
+
+        assert bnc._find_installed_so(router_dir) == expected
+
+    def test_prefers_running_suffix_regardless_of_creation_order(self, tmp_path: Path) -> None:
+        """Create the ABI match FIRST so a first-glob-hit impl would pass."""
+        router_dir = tmp_path / "router"
+        expected = _touch_extension(router_dir, RUNNING_ABI_SUFFIX, 100.0)
+        for suffix in FOREIGN_SUFFIXES:
+            _touch_extension(router_dir, suffix, 100.0)
+
+        assert bnc._find_installed_so(router_dir) == expected
+
+    def test_deterministic_when_no_abi_match(self, tmp_path: Path) -> None:
+        router_dir = tmp_path / "router"
+        for suffix in FOREIGN_SUFFIXES:
+            _touch_extension(router_dir, suffix, 100.0)
+
+        found = bnc._find_installed_so(router_dir)
+        # Alphabetically first by name -- deterministic, not glob order.
+        assert found is not None
+        assert found.name == sorted(f"router_cpp{s}" for s in FOREIGN_SUFFIXES)[0]
+        # And repeated calls agree.
+        assert bnc._find_installed_so(router_dir) == found
+
+    def test_abi_only_treats_foreign_abi_as_not_installed(self, tmp_path: Path) -> None:
+        router_dir = tmp_path / "router"
+        for suffix in FOREIGN_SUFFIXES:
+            _touch_extension(router_dir, suffix, 100.0)
+
+        assert bnc._find_installed_so(router_dir, abi_only=True) is None
+
+    def test_abi_only_returns_the_match_when_present(self, tmp_path: Path) -> None:
+        router_dir = tmp_path / "router"
+        _touch_extension(router_dir, FOREIGN_SUFFIXES[0], 100.0)
+        expected = _touch_extension(router_dir, RUNNING_ABI_SUFFIX, 100.0)
+
+        assert bnc._find_installed_so(router_dir, abi_only=True) == expected
+
+    def test_returns_none_for_empty_dir(self, tmp_path: Path) -> None:
+        assert bnc._find_installed_so(tmp_path) is None
+        assert bnc._find_installed_so(tmp_path, abi_only=True) is None
+
+    def test_matches_bare_suffix_extension(self, tmp_path: Path) -> None:
+        """``router_cpp.so`` / ``router_cpp.pyd`` are legal names too.
+
+        The old ``router_cpp.*.so`` glob could not match them at all.
+        """
+        router_dir = tmp_path / "router"
+        bare = importlib.machinery.EXTENSION_SUFFIXES[-1]  # ".so" / ".pyd"
+        expected = _touch_extension(router_dir, bare, 100.0)
+
+        assert bnc._find_installed_so(router_dir) == expected
+
+
+class TestIsSoStaleUsesAbiMatch:
+    """``_is_so_stale`` must compare against the .so this interpreter loads."""
+
+    def test_stale_when_abi_match_is_old_but_foreign_abi_is_new(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        router_dir = tmp_path / "router"
+        cpp_dir = router_dir / "cpp"
+        _touch_extension(router_dir, RUNNING_ABI_SUFFIX, 100.0)  # ours: OLD
+        for suffix in FOREIGN_SUFFIXES:
+            _touch_extension(router_dir, suffix, 900.0)  # foreign: NEW
+        _make_cpp_source(cpp_dir, "pathfinder.cpp", 500.0)
+        monkeypatch.setattr(bnc, "_get_cpp_source_dir", lambda: cpp_dir)
+
+        # A foreign-ABI-blind implementation sees a 900.0 .so and reports
+        # "up to date", skipping a rebuild this interpreter genuinely needs.
+        assert bnc._is_so_stale(router_dir) is True
+
+    def test_not_stale_when_abi_match_is_new_but_foreign_abi_is_old(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        router_dir = tmp_path / "router"
+        cpp_dir = router_dir / "cpp"
+        _touch_extension(router_dir, RUNNING_ABI_SUFFIX, 900.0)  # ours: NEW
+        for suffix in FOREIGN_SUFFIXES:
+            _touch_extension(router_dir, suffix, 100.0)  # foreign: OLD
+        _make_cpp_source(cpp_dir, "pathfinder.cpp", 500.0)
+        monkeypatch.setattr(bnc, "_get_cpp_source_dir", lambda: cpp_dir)
+
+        # A foreign-ABI-blind implementation sees a 100.0 .so and forces a
+        # needless multi-minute rebuild.
+        assert bnc._is_so_stale(router_dir) is False
+
+
+class TestAtomicInstall:
+    """The .so must be renamed into place, never rewritten in place."""
+
+    def test_replaces_inode_instead_of_truncating(self, tmp_path: Path) -> None:
+        target = tmp_path / "router" / f"router_cpp{RUNNING_ABI_SUFFIX}"
+        target.parent.mkdir(parents=True)
+        target.write_bytes(b"OLD-CONTENT-THAT-IS-DLOPENED")
+        old_inode = target.stat().st_ino
+
+        source = tmp_path / "build" / f"router_cpp{RUNNING_ABI_SUFFIX}"
+        source.parent.mkdir(parents=True)
+        source.write_bytes(b"NEW")
+
+        bnc._install_extension_atomically(source, target)
+
+        assert target.read_bytes() == b"NEW"
+        # A new inode proves os.replace() was used: an in-place copy2 would
+        # have truncated the file a running process still has mapped.
+        assert target.stat().st_ino != old_inode
+
+    def test_creates_target_when_absent(self, tmp_path: Path) -> None:
+        target = tmp_path / "router" / f"router_cpp{RUNNING_ABI_SUFFIX}"
+        source = tmp_path / "build" / f"router_cpp{RUNNING_ABI_SUFFIX}"
+        source.parent.mkdir(parents=True)
+        source.write_bytes(b"NEW")
+
+        bnc._install_extension_atomically(source, target)
+
+        assert target.read_bytes() == b"NEW"
+
+    def test_leaves_no_temp_file_on_failure(self, tmp_path: Path) -> None:
+        target = tmp_path / "router" / f"router_cpp{RUNNING_ABI_SUFFIX}"
+        target.parent.mkdir(parents=True)
+        missing_source = tmp_path / "build" / "does-not-exist.so"
+
+        with pytest.raises(OSError):
+            bnc._install_extension_atomically(missing_source, target)
+
+        assert list(target.parent.iterdir()) == []
+
+
+def _stub_build_pipeline(monkeypatch, tmp_path: Path) -> Path:
+    """Stub every heavy step of ``build_native`` so only the tail runs.
+
+    Returns the fake package root; the installed extension lands in
+    ``<root>/router/``.
+    """
+    package_root = tmp_path / "pkg"
+    (package_root / "router").mkdir(parents=True)
+
+    source_dir = tmp_path / "src"
+    source_dir.mkdir()
+    (source_dir / "CMakeLists.txt").write_text("cmake\n")
+
+    build_dir = tmp_path / "build"
+    build_dir.mkdir()
+    (build_dir / f"router_cpp{RUNNING_ABI_SUFFIX}").write_bytes(b"FRESHLY-BUILT")
+
+    monkeypatch.setattr(bnc, "_get_package_root", lambda: package_root)
+    monkeypatch.setattr(bnc, "_check_cmake", lambda: (True, "/usr/bin/cmake"))
+    monkeypatch.setattr(bnc, "_check_compiler", lambda: (True, "/usr/bin/clang++"))
+    monkeypatch.setattr(bnc, "_install_nanobind", lambda verbose=False: (True, None))
+    monkeypatch.setattr(bnc, "_get_nanobind_cmake_dir", lambda: tmp_path / "nanobind")
+    monkeypatch.setattr(bnc, "_get_project_root", lambda: source_dir)
+    monkeypatch.setattr(bnc.tempfile, "mkdtemp", lambda **_: str(build_dir))
+    monkeypatch.setattr(bnc.shutil, "rmtree", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        bnc.subprocess, "run", lambda *_a, **_k: mock.MagicMock(returncode=0, stderr="")
+    )
+    return package_root
+
+
+@pytest.fixture
+def isolated_replace_flag(monkeypatch):
+    """Keep ``note_extension_replaced()`` from leaking into other tests."""
+    from kicad_tools.router import cpp_backend
+
+    monkeypatch.setattr(cpp_backend, "_EXTENSION_REPLACED", False)
+    return cpp_backend
+
+
+class TestPostBuildVerificationUsesFreshInterpreter:
+    """Issue #4589: verification must ask a fresh interpreter, not reload.
+
+    An already-``dlopen``'d C extension cannot be re-imported from a replaced
+    file in the same process, so the old in-process reload probe reported on
+    the PRE-build extension: a false negative on a version-stale rebuild
+    ("Extension installed but not loading correctly", contradicted by
+    ``--check``) and a false positive on an mtime-stale rebuild (success
+    reported against code that was never loaded).
+    """
+
+    def test_reports_success_when_fresh_interpreter_sees_backend(
+        self, tmp_path: Path, monkeypatch, isolated_replace_flag
+    ) -> None:
+        cpp_backend = isolated_replace_flag
+        _stub_build_pipeline(monkeypatch, tmp_path)
+
+        calls: list[dict] = []
+
+        def _probe(**kwargs):
+            calls.append(kwargs)
+            return {
+                "available": True,
+                "version": "1.0.0",
+                "probe": {"mode": "subprocess", "interpreter": "/py", "failed": False},
+            }
+
+        monkeypatch.setattr(cpp_backend, "probe_backend_info", _probe)
+
+        result = bnc.build_native(force=True)
+
+        assert result.success is True
+        assert result.backend_installed is True
+        assert result.warnings == []
+        # The probe must be forced into a subprocess: the in-process view is
+        # stale by construction once we have overwritten the .so.
+        assert calls == [{"allow_in_process": False}]
+        assert "installed successfully" in bnc.format_result_text(result)
+
+    def test_marks_extension_replaced_so_later_probes_do_not_trust_memory(
+        self, tmp_path: Path, monkeypatch, isolated_replace_flag
+    ) -> None:
+        cpp_backend = isolated_replace_flag
+        _stub_build_pipeline(monkeypatch, tmp_path)
+        monkeypatch.setattr(
+            cpp_backend,
+            "probe_backend_info",
+            lambda **_: {"available": True, "probe": {"interpreter": "/py"}},
+        )
+
+        assert cpp_backend.extension_replaced_in_process() is False
+        bnc.build_native(force=True)
+        assert cpp_backend.extension_replaced_in_process() is True
+
+    def test_failure_warning_names_reason_path_and_interpreter(
+        self, tmp_path: Path, monkeypatch, isolated_replace_flag
+    ) -> None:
+        cpp_backend = isolated_replace_flag
+        package_root = _stub_build_pipeline(monkeypatch, tmp_path)
+        monkeypatch.setattr(
+            cpp_backend,
+            "probe_backend_info",
+            lambda **_: {
+                "available": False,
+                "unavailable_reason": "router_cpp build version 20 does not match required 19",
+                "probe": {
+                    "mode": "subprocess",
+                    "interpreter": "/opt/py/bin/python",
+                    "failed": False,
+                },
+            },
+        )
+
+        result = bnc.build_native(force=True)
+
+        assert result.success is True  # the build itself succeeded
+        assert result.backend_installed is False
+        assert len(result.warnings) == 1
+        warning = result.warnings[0]
+        assert "build version 20 does not match required 19" in warning
+        assert str(package_root / "router" / f"router_cpp{RUNNING_ABI_SUFFIX}") in warning
+        assert "/opt/py/bin/python" in warning
+        # Generic, uninformative wording must be gone.
+        assert "not loading correctly" not in warning
+
+        text = bnc.format_result_text(result)
+        assert "Reason:" in text
+        assert "Extension:" in text
+        assert "Interpreter:" in text
+
+    def test_probe_that_cannot_run_does_not_claim_extension_is_broken(
+        self, tmp_path: Path, monkeypatch, isolated_replace_flag
+    ) -> None:
+        cpp_backend = isolated_replace_flag
+        _stub_build_pipeline(monkeypatch, tmp_path)
+        monkeypatch.setattr(
+            cpp_backend,
+            "probe_backend_info",
+            lambda **_: {
+                "available": False,
+                "unavailable_reason": "backend probe did not run: TimeoutExpired: 60s",
+                "probe": {
+                    "mode": "subprocess",
+                    "interpreter": "/opt/py/bin/python",
+                    "failed": True,
+                    "error": "TimeoutExpired: 60s",
+                },
+            },
+        )
+
+        result = bnc.build_native(force=True)
+
+        assert result.success is True
+        warning = result.warnings[0]
+        assert "probe did not run" in warning
+        assert "TimeoutExpired" in warning
+        # Must NOT assert the extension is broken -- we do not know.
+        assert "cannot load it" not in warning
+
+    def test_verification_payload_is_exposed_in_json(
+        self, tmp_path: Path, monkeypatch, isolated_replace_flag
+    ) -> None:
+        cpp_backend = isolated_replace_flag
+        _stub_build_pipeline(monkeypatch, tmp_path)
+        payload = {
+            "available": True,
+            "build_version": 18,
+            "probe": {"mode": "subprocess", "interpreter": "/py", "failed": False},
+        }
+        monkeypatch.setattr(cpp_backend, "probe_backend_info", lambda **_: payload)
+
+        result = bnc.build_native(force=True)
+
+        assert result.to_dict()["verification"] == payload
+
+
+class TestCheckModeSharesTheProbeAndNeverBuilds:
+    """``--check`` must use the same probe and compile nothing."""
+
+    def test_check_uses_shared_probe(self, monkeypatch, capsys) -> None:
+        from kicad_tools.router import cpp_backend
+
+        monkeypatch.setattr(
+            cpp_backend,
+            "probe_backend_info",
+            lambda **_: {
+                "available": True,
+                "version": "1.0.0",
+                "build_version": 18,
+                "required_build_version": 18,
+                "extension_path": f"/pkg/router/router_cpp{RUNNING_ABI_SUFFIX}",
+                "probe": {"mode": "in-process", "interpreter": "/py", "failed": False},
+            },
+        )
+
+        assert bnc.main(["--check"]) == 0
+        out = capsys.readouterr().out
+        assert "C++ backend: available (version 1.0.0)" in out
+        # Issue #4589: version() is not the number the staleness guard checks.
+        assert "build version: 18 (required: 18)" in out
+        assert f"router_cpp{RUNNING_ABI_SUFFIX}" in out
+
+    def test_check_reports_the_probe_reason_when_unavailable(self, monkeypatch, capsys) -> None:
+        from kicad_tools.router import cpp_backend
+
+        monkeypatch.setattr(
+            cpp_backend,
+            "probe_backend_info",
+            lambda **_: {
+                "available": False,
+                "unavailable_reason": "router_cpp build version 20 does not match required 19",
+                "probe": {"mode": "in-process", "interpreter": "/py", "failed": False},
+            },
+        )
+
+        assert bnc.main(["--check"]) == 1
+        out = capsys.readouterr().out
+        assert "C++ backend: not installed" in out
+        assert "build version 20 does not match required 19" in out
+
+    def test_check_never_calls_build_native(self, monkeypatch) -> None:
+        """Regression guard: do not "fix" --check by making it compile."""
+        from kicad_tools.router import cpp_backend
+
+        monkeypatch.setattr(
+            cpp_backend,
+            "probe_backend_info",
+            lambda **_: {"available": True, "version": "1.0.0"},
+        )
+        boom = mock.MagicMock(side_effect=AssertionError("--check must not build"))
+        monkeypatch.setattr(bnc, "build_native", boom)
+        # Any compiler/cmake invocation would also be a build.
+        monkeypatch.setattr(
+            bnc.subprocess,
+            "run",
+            mock.MagicMock(side_effect=AssertionError("--check must not run subprocesses")),
+        )
+
+        assert bnc.main(["--check"]) == 0
+        assert boom.call_count == 0
+
+    def test_check_and_post_build_verification_call_the_same_helper(self) -> None:
+        """Static guard: both paths resolve through ``probe_backend_info``."""
+        source = Path(bnc.__file__).read_text()
+        # Post-build verification (forced fresh interpreter) ...
+        assert "cpp_module.probe_backend_info(allow_in_process=False)" in source
+        # ... and --check, through the same helper.
+        assert "info = probe_backend_info()" in source
+        # The in-process reload probe must be gone from the build path: it is
+        # what let the two commands disagree (Issue #4589).
+        code = "\n".join(line for line in source.splitlines() if not line.lstrip().startswith("#"))
+        assert "importlib.reload(" not in code
+        assert 'sys.modules.pop("kicad_tools.router.router_cpp"' not in code

--- a/tests/test_router_cpp_auto_build.py
+++ b/tests/test_router_cpp_auto_build.py
@@ -8,6 +8,7 @@ handling -- not on actually invoking cmake.
 
 from __future__ import annotations
 
+import json
 import subprocess
 from unittest import mock
 
@@ -336,6 +337,265 @@ class TestRouteCmdCallsHelper:
         assert "WARNING: C++ router backend not installed" not in text, (
             "Old inline Python-fallback warning still present in route_cmd.py"
         )
+
+
+class TestProbeBackendInfo:
+    """Issue #4589: the shared fresh-interpreter availability probe.
+
+    ``kct build-native`` used to verify its own work in the process that just
+    did the build.  For an already-``dlopen``'d C extension that is impossible:
+    ``sys.modules.pop`` + ``importlib.invalidate_caches`` + ``reload`` return
+    the *identical* module object, so the probe describes the PRE-build
+    extension.  ``probe_backend_info`` answers the only question that matters
+    -- "what will the next process see?" -- by asking a fresh interpreter.
+    """
+
+    def test_in_process_fast_path_when_nothing_was_replaced(self, monkeypatch):
+        """``--check`` must stay sub-second: no subprocess when it is safe."""
+        monkeypatch.setattr(cpp_backend, "_EXTENSION_REPLACED", False)
+        spawned = mock.MagicMock(side_effect=AssertionError("must not spawn"))
+        monkeypatch.setattr(subprocess, "run", spawned)
+
+        info = cpp_backend.probe_backend_info()
+
+        assert info["probe"]["mode"] == "in-process"
+        assert info["probe"]["failed"] is False
+        assert info["available"] is cpp_backend.is_cpp_available()
+        assert spawned.call_count == 0
+
+    def test_forced_subprocess_reports_child_answer(self, monkeypatch):
+        monkeypatch.setattr(cpp_backend, "_EXTENSION_REPLACED", False)
+        payload = {"available": True, "version": "1.0.0", "build_version": 18}
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *_a, **_k: mock.MagicMock(returncode=0, stdout=json.dumps(payload), stderr=""),
+        )
+
+        info = cpp_backend.probe_backend_info(allow_in_process=False)
+
+        assert info["available"] is True
+        assert info["build_version"] == 18
+        assert info["probe"]["mode"] == "subprocess"
+        assert info["probe"]["failed"] is False
+
+    def test_subprocess_used_automatically_after_extension_replaced(self, monkeypatch):
+        """Once this process overwrote the .so, memory is stale by construction."""
+        monkeypatch.setattr(cpp_backend, "_EXTENSION_REPLACED", False)
+        cpp_backend.note_extension_replaced()
+        assert cpp_backend.extension_replaced_in_process() is True
+
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *_a, **_k: mock.MagicMock(
+                returncode=0, stdout=json.dumps({"available": True}), stderr=""
+            ),
+        )
+
+        # Note: allow_in_process defaults to True and is still overridden.
+        info = cpp_backend.probe_backend_info()
+        assert info["probe"]["mode"] == "subprocess"
+
+    def test_unavailable_child_carries_the_reason_through(self, monkeypatch):
+        monkeypatch.setattr(cpp_backend, "_EXTENSION_REPLACED", False)
+        payload = {
+            "available": False,
+            "unavailable_reason": "router_cpp build version 20 does not match required 19",
+        }
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *_a, **_k: mock.MagicMock(returncode=0, stdout=json.dumps(payload), stderr=""),
+        )
+
+        info = cpp_backend.probe_backend_info(allow_in_process=False)
+
+        assert info["available"] is False
+        assert "build version 20 does not match required 19" in info["unavailable_reason"]
+        assert info["probe"]["failed"] is False
+
+    def test_probe_crash_is_reported_as_probe_failure_not_broken_extension(self, monkeypatch):
+        monkeypatch.setattr(cpp_backend, "_EXTENSION_REPLACED", False)
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *_a, **_k: mock.MagicMock(returncode=1, stdout="", stderr="Traceback: boom"),
+        )
+
+        info = cpp_backend.probe_backend_info(allow_in_process=False)
+
+        assert info["available"] is False
+        assert info["probe"]["failed"] is True
+        assert "exited 1" in info["probe"]["error"]
+        assert "boom" in info["probe"]["error"]
+        assert "probe did not run" in info["unavailable_reason"]
+
+    def test_probe_timeout_never_raises(self, monkeypatch):
+        monkeypatch.setattr(cpp_backend, "_EXTENSION_REPLACED", False)
+
+        def _timeout(*_a, **_k):
+            raise subprocess.TimeoutExpired(cmd="python", timeout=60)
+
+        monkeypatch.setattr(subprocess, "run", _timeout)
+
+        info = cpp_backend.probe_backend_info(allow_in_process=False, timeout=60)
+
+        assert info["available"] is False
+        assert info["probe"]["failed"] is True
+        assert "TimeoutExpired" in info["probe"]["error"]
+
+    def test_unparseable_output_is_a_probe_failure(self, monkeypatch):
+        monkeypatch.setattr(cpp_backend, "_EXTENSION_REPLACED", False)
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *_a, **_k: mock.MagicMock(returncode=0, stdout="not json", stderr=""),
+        )
+
+        info = cpp_backend.probe_backend_info(allow_in_process=False)
+
+        assert info["probe"]["failed"] is True
+        assert "could not parse probe output" in info["probe"]["error"]
+
+    def test_probe_reports_the_interpreter_it_used(self, monkeypatch):
+        monkeypatch.setattr(cpp_backend, "_EXTENSION_REPLACED", False)
+        seen: dict = {}
+
+        def _run(cmd, **kwargs):
+            seen["cmd"] = cmd
+            return mock.MagicMock(returncode=0, stdout=json.dumps({"available": True}), stderr="")
+
+        monkeypatch.setattr(subprocess, "run", _run)
+
+        info = cpp_backend.probe_backend_info(
+            executable="/opt/py/bin/python", allow_in_process=False
+        )
+
+        assert info["probe"]["interpreter"] == "/opt/py/bin/python"
+        assert seen["cmd"][0] == "/opt/py/bin/python"
+
+    def test_probe_really_runs_a_fresh_interpreter(self):
+        """End-to-end: no mocks, a genuine subprocess must agree with us."""
+        info = cpp_backend.probe_backend_info(allow_in_process=False, timeout=120)
+
+        assert info["probe"]["mode"] == "subprocess"
+        assert info["probe"]["failed"] is False, info["probe"]["error"]
+        assert info["available"] is cpp_backend.is_cpp_available()
+
+
+class TestGetBackendInfoBuildVersion:
+    """Issue #4589: ``version()`` ("1.0.0") is not the staleness number."""
+
+    def test_reports_build_version_and_requirement(self):
+        info = cpp_backend.get_backend_info()
+
+        assert "build_version" in info
+        assert "required_build_version" in info
+        assert "extension_path" in info
+        assert info["required_build_version"] == cpp_backend._REQUIRED_CPP_BUILD_VERSION
+
+    def test_build_version_matches_requirement_when_available(self):
+        if not cpp_backend.is_cpp_available():
+            pytest.skip("C++ backend not available on this environment")
+        info = cpp_backend.get_backend_info()
+        assert info["build_version"] == info["required_build_version"]
+        assert info["extension_path"] is not None
+
+
+class TestAutoBuildUsesSharedProbe:
+    """Issue #4589: ``kct route``'s silent auto-build shared the same flaw.
+
+    ``_attempt_auto_build`` used to collapse "this process cannot hot-swap the
+    rebuilt extension" into "the build failed", printing a Python-fallback
+    announcement that ``kct build-native --check`` would contradict a second
+    later.
+    """
+
+    def _patch_reload_to_fail(self, monkeypatch):
+        monkeypatch.setattr(cpp_backend, "_reload_cpp_backend", lambda: False)
+
+    def test_successful_build_that_cannot_hot_swap_is_not_reported_as_failure(
+        self, force_cpp_unavailable, toolchain_present, no_env_optout, monkeypatch, capsys
+    ):
+        self._patch_reload_to_fail(monkeypatch)
+        _patch_build_native(monkeypatch, lambda **_: _FakeBuildResult(success=True))
+        probe_calls: list[dict] = []
+
+        def _probe(**kwargs):
+            probe_calls.append(kwargs)
+            return {"available": True}
+
+        monkeypatch.setattr(cpp_backend, "probe_backend_info", _probe)
+
+        outcome = cpp_backend._attempt_auto_build(quiet=False)
+
+        assert outcome.available_in_process is False
+        assert outcome.available_on_disk is True
+        # The shared probe must be forced into a fresh interpreter.
+        assert probe_calls == [{"allow_in_process": False}]
+
+        out = capsys.readouterr().out
+        assert "built successfully" in out
+        assert "re-run the command" in out.lower()
+
+    def test_no_not_installed_warning_when_the_build_actually_succeeded(
+        self, force_cpp_unavailable, toolchain_present, no_env_optout, monkeypatch, capsys
+    ):
+        self._patch_reload_to_fail(monkeypatch)
+        _patch_build_native(monkeypatch, lambda **_: _FakeBuildResult(success=True))
+        monkeypatch.setattr(cpp_backend, "probe_backend_info", lambda **_: {"available": True})
+
+        ok, force_python, exit_code = cpp_backend.ensure_cpp_backend_available(
+            backend="auto", quiet=False
+        )
+
+        assert ok is True
+        assert exit_code is None
+        out = capsys.readouterr().out
+        # This is the line that used to contradict `kct build-native --check`.
+        assert "C++ router backend not installed" not in out
+
+    def test_genuine_failure_still_warns_with_the_probe_reason(
+        self, force_cpp_unavailable, toolchain_present, no_env_optout, monkeypatch, capsys
+    ):
+        self._patch_reload_to_fail(monkeypatch)
+        _patch_build_native(monkeypatch, lambda **_: _FakeBuildResult(success=True))
+        monkeypatch.setattr(
+            cpp_backend,
+            "probe_backend_info",
+            lambda **_: {"available": False, "unavailable_reason": "ABI mismatch: cpython-313"},
+        )
+
+        ok, force_python, exit_code = cpp_backend.ensure_cpp_backend_available(
+            backend="auto", quiet=False
+        )
+
+        assert ok is True
+        outcome_out = capsys.readouterr().out
+        assert "ABI mismatch: cpython-313" in outcome_out
+        assert "C++ router backend not installed" in outcome_out
+
+    def test_backend_cpp_error_distinguishes_built_but_not_hot_swappable(
+        self, force_cpp_unavailable, toolchain_present, no_env_optout, monkeypatch, capsys
+    ):
+        self._patch_reload_to_fail(monkeypatch)
+        _patch_build_native(monkeypatch, lambda **_: _FakeBuildResult(success=True))
+        monkeypatch.setattr(cpp_backend, "probe_backend_info", lambda **_: {"available": True})
+
+        ok, force_python, exit_code = cpp_backend.ensure_cpp_backend_available(
+            backend="cpp", quiet=False
+        )
+
+        assert ok is False
+        assert exit_code == 1
+        err = capsys.readouterr().err
+        assert "Re-run this command" in err
+        assert "not available" not in err
+
+    def test_outcome_is_truthy_only_when_usable_in_process(self):
+        assert bool(cpp_backend.AutoBuildOutcome(True, True)) is True
+        assert bool(cpp_backend.AutoBuildOutcome(False, True)) is False
 
 
 class TestReloadCppBackend:


### PR DESCRIPTION
## Summary

`kct build-native` verified its own work **in the process that just did the build**, while `kct build-native --check` verified in a **fresh interpreter**. Those probes are not equivalent: once `router_cpp.*.so` has been `dlopen`'d, CPython keeps the initialised module in a runtime extension cache that neither `sys.modules.pop()` nor `importlib.invalidate_caches()` clears, so `importlib.reload()` returns the *identical* module object — the probe reports on the **pre-build** extension.

This PR replaces that in-process probe with a **fresh-interpreter subprocess probe** shared with `--check`, so the two commands cannot disagree about the same on-disk state, and fixes the same-family defects the curated issue identified (ABI-blind `.so` selection, in-place install, `kct route`'s auto-build path).

Both failure directions were reproduced on this checkout before the fix, and re-run after — real terminal output below.

## Changes

- **`src/kicad_tools/router/cpp_backend.py`**
  - New `probe_backend_info(*, executable, timeout, allow_in_process)` — runs `get_backend_info()` under `sys.executable` and returns its dict plus a `probe` sub-dict (`mode` / `interpreter` / `failed` / `error`). Never raises; a probe that cannot run reports the probe failure rather than claiming the extension is broken.
  - New `note_extension_replaced()` / `extension_replaced_in_process()` — once this process has overwritten the `.so`, the in-process fast path is poisoned by construction and the probe always spawns a subprocess.
  - `get_backend_info()` now reports `build_version`, `required_build_version` and `extension_path` in **both** branches (the `version 1.0.0` string is not the number the staleness guard checks).
  - `_attempt_auto_build()` returns a new `AutoBuildOutcome` separating *usable in this process* from *the build succeeded*, resolved through the same probe. `ensure_cpp_backend_available()` no longer prints "C++ router backend not installed" after a build that actually succeeded.
  - `_reload_cpp_backend()` kept (it is the correct primitive for the fresh-checkout case) but documented as unable to observe a replaced extension, and it no longer resets the replaced-flag on reload.
- **`src/kicad_tools/cli/build_native_cmd.py`**
  - Post-build verification uses `probe_backend_info(allow_in_process=False)`; failure warnings carry the concrete reason, the `.so` path probed and the interpreter used.
  - `_find_installed_so()` is ABI-aware (`importlib.machinery.EXTENSION_SUFFIXES`, deterministic `sorted()` fallback, `abi_only=` mode, matches bare `router_cpp.so`/`.pyd` too). `_is_so_stale()` and the `Extension:` line follow it.
  - `_install_extension_atomically()` — temp file in the destination dir + `os.replace()` instead of `shutil.copy2()` truncating the live inode.
  - `--check` resolves through the same probe and additionally prints `build version` and the resolved extension. It still returns before `build_native()` is ever called.
  - `BuildResult.verification` carries the probe payload into `--format json`.
- **`docs/contributing/development.md`** — new "How the build verifies itself" section with the two-direction table and the "`--check` compiles nothing" note.
- **Tests** — 37 new tests across `tests/test_build_native_staleness.py` and `tests/test_router_cpp_auto_build.py`.

## Acceptance Criteria Verification

Every criterion was checked by running the command, not by reading the code.

### AC1 — version-stale rebuild no longer prints "not loading correctly"

Setup: working `.so` on disk at `BUILD_VERSION` 18, then both constants bumped to 19 (simulating a bindings bump), exactly the issue's Test Plan recipe.

**BEFORE the fix:**

```
=== BEFORE-FIX / FALSE NEGATIVE: kct build-native (version-stale .so on disk) ===
Building C++ router backend...

Build completed with warnings.

  Warning: Extension installed but not loading correctly

=== immediately after: kct build-native --check (fresh interpreter) ===
C++ backend: available (version 1.0.0)
exit=0
```

**AFTER the fix (same recipe):**

```
=== AFTER-FIX / FALSE NEGATIVE CASE: kct build-native ===
Building C++ router backend...

C++ backend installed successfully!

  Extension: router_cpp.cpython-312-darwin.so

Run `kct route --backend cpp` to use the C++ backend.
exit=0

=== kct build-native --check ===
C++ backend: available (version 1.0.0)
  build version: 19 (required: 19)
  extension: router_cpp.cpython-312-darwin.so
exit=0
```

### AC2 — one shared probe; the two commands cannot disagree

The mirror-image defect proves this is not just a one-sided patch. Setup: `types.hpp` bumped to 20 while `_REQUIRED_CPP_BUILD_VERSION` stays 19 — an mtime-stale rebuild producing a `.so` this venv must reject.

**BEFORE the fix (false POSITIVE — "verified" against code never loaded):**

```
=== BEFORE-FIX / FALSE POSITIVE: kct build-native (mtime-stale rebuild) ===
Building C++ router backend...

C++ backend installed successfully!

  Extension: router_cpp.cpython-312-darwin.so

Run `kct route --backend cpp` to use the C++ backend.

=== immediately after: kct build-native --check (fresh interpreter) ===
C++ backend: not installed
Run `kct build-native` to install.
exit=1
```

**AFTER the fix — both commands now agree, and both name the same reason:**

```
=== AFTER-FIX / FALSE POSITIVE CASE: kct build-native ===
Building C++ router backend...

Build completed with warnings.

  Warning: Extension installed but a fresh interpreter cannot load it.
    Reason: router_cpp build version 20 does not match required 19. The compiled .so is stale relative to the C++ source tree. Rebuild with: kct build-native
    Extension: /.../src/kicad_tools/router/router_cpp.cpython-312-darwin.so
    Interpreter: /.../.venv/bin/python
exit=0

=== kct build-native --check ===
C++ backend: not installed
  reason: router_cpp build version 20 does not match required 19. The compiled .so is stale relative to the C++ source tree. Rebuild with: kct build-native
Run `kct build-native` to install.
exit=1
```

Structurally: `build_native()` calls `cpp_module.probe_backend_info(allow_in_process=False)`; the `--check` branch calls `probe_backend_info()`. Both execute the same `get_backend_info()` body. Pinned by `test_check_and_post_build_verification_call_the_same_helper`, which also asserts `importlib.reload(` and the `sys.modules.pop("kicad_tools.router.router_cpp"` idiom are gone from the build path.

### AC3 — failure warning names reason, path and interpreter

See the AFTER block for the false-positive case above: `Reason:` / `Extension:` / `Interpreter:` are all present. Pinned by `test_failure_warning_names_reason_path_and_interpreter`.

### AC4 — `_find_installed_so()` is ABI-aware and deterministic

**BEFORE** (multi-ABI directory, this venv is CPython 3.12):

```
glob order:            ['router_cpp.cpython-313-darwin.so', 'router_cpp.cpython-312-darwin.so', 'router_cpp.cpython-314-darwin.so']
_find_installed_so -> router_cpp.cpython-313-darwin.so
actually imported  -> router_cpp.cpython-312-darwin.so
running ABI suffix -> .cpython-312-darwin.so
```

**AFTER** (same directory contents):

```
glob order:        ['router_cpp.cpython-313-darwin.so', 'router_cpp.cpython-312-darwin.so', 'router_cpp.cpython-314-darwin.so']
_find_installed_so -> router_cpp.cpython-312-darwin.so
actually imported  -> router_cpp.cpython-312-darwin.so
```

and the reported extension line follows it:

```
C++ backend already installed -- SKIPPED rebuild (use --force to recompile)

  Extension: router_cpp.cpython-312-darwin.so
```

`_is_so_stale()` is pinned against the ABI-matched file in both directions (foreign-ABI newer than source + ABI match older must report stale, and vice versa).

### AC5 — atomic install

`_install_extension_atomically()` writes a sibling temp file in the destination directory and `os.replace()`s it. `test_replaces_inode_instead_of_truncating` asserts the target's **inode changes**, which an in-place `copy2` cannot do, plus a no-temp-file-left-behind test on failure.

### AC6 — `kct route`'s auto-build stops falsely announcing a Python fallback

**BEFORE** (version-stale `.so`, auto-build succeeds):

```
is_cpp_available() at start: False
C++ router extension missing -- building (~30s, one-time)...
Note: C++ build succeeded but module reload did not pick it up; falling back to Python.
WARNING: C++ router backend not installed -- using Python (10-100x slower).
  Build it now:  kct build-native
  Check status:  kct build-native --check

=== what a fresh interpreter says right after ===
C++ backend: available (version 1.0.0)
```

**AFTER** (same scenario):

```
is_cpp_available() at start: False
C++ router extension missing -- building (~30s, one-time)...
Note: the C++ backend was built successfully and verified in a fresh interpreter, but this already-running process cannot load the replaced extension (CPython keeps the original dlopen handle). Using Python for THIS run only -- re-run the command to get the C++ backend.
result: (True, False, None)

=== what a fresh interpreter says right after ===
C++ backend: available (version 1.0.0)
  build version: 20 (required: 20)
  extension: router_cpp.cpython-312-darwin.so
```

The false "C++ router backend not installed" line is gone; the run still uses Python for **that process** (an already-`dlopen`'d extension genuinely cannot be swapped), which is now stated accurately instead of being blamed on the build. A genuine failure still warns, with the probe's real reason:

```
Note: C++ build reported success but a fresh interpreter still cannot load the extension (router_cpp build version 19 does not match required 20. ...); falling back to Python.
WARNING: C++ router backend not installed -- using Python (10-100x slower).
```

### AC7 — `--check` performs NO compilation and stays sub-second

Explicitly **not** "fixed" by making it build, per the issue's out-of-scope guard.

```
=== --check timing (warm venv, no compilation) ===
C++ backend: available (version 1.0.0)
real 0.35
C++ backend: available (version 1.0.0)
real 1.23
C++ backend: available (version 1.0.0)
real 0.43

=== proof --check compiles nothing: mtime of the .so before/after ===
1785858664 src/kicad_tools/router/router_cpp.cpython-312-darwin.so
1785858664 src/kicad_tools/router/router_cpp.cpython-312-darwin.so
```

(The 1.23 s sample is machine load; the baseline the Curator measured on the pre-fix code was 0.368 s, so there is no regression.) Regression-guarded by `test_check_never_calls_build_native`, which fails the test if `--check` calls `build_native` **or** spawns any subprocess.

### AC8 — no behavior change for the fresh-checkout case

`.so` removed entirely, then:

```
=== FRESH-CHECKOUT CASE (no .so at all): kct build-native ===
Building C++ router backend...

C++ backend installed successfully!

  Extension: router_cpp.cpython-312-darwin.so

Run `kct route --backend cpp` to use the C++ backend.
exit=0
```

## Test Plan

```
$ .venv/bin/python -m pytest tests/test_build_native_staleness.py \
      tests/test_router_cpp_auto_build.py tests/test_native_extra_composition.py -q
77 passed in 0.92s
```

Broader regression sweep over everything touching the backend/CLI:

```
$ .venv/bin/python -m pytest tests/ -q -k "cpp or backend or build_native or route_cmd or native"
860 passed, 51 skipped, 23299 deselected in 117.89s
```

Lint / format:

```
$ .venv/bin/ruff check .
All checks passed!
$ .venv/bin/ruff format --check src tests
1661 files already formatted
```

New test coverage (37 tests):

- `_find_installed_so`: prefers the running ABI regardless of creation order; deterministic sorted fallback; `abi_only` treats a foreign-ABI-only directory as not installed; bare `.so`/`.pyd` suffix; empty directory.
- `_is_so_stale`: computed against the ABI-matched `.so` in both directions.
- `_install_extension_atomically`: inode replacement, target creation, no temp file left on failure.
- `probe_backend_info`: in-process fast path spawns nothing; forced subprocess; automatic subprocess after `note_extension_replaced()`; unavailable-with-reason passthrough; child crash / timeout / unparseable output all reported as *probe failures*, never as a broken extension; reports the interpreter used; one un-mocked end-to-end subprocess probe that must agree with `is_cpp_available()`.
- `build_native` post-build verification: success path forces `allow_in_process=False`; sets the replaced flag; failure warning content; probe-failure wording; `verification` payload in `to_dict()`.
- `--check`: shared probe, reason surfaced, build-version line, never builds, static guard that both paths share the helper.
- Auto-build: `AutoBuildOutcome` semantics, no "not installed" line after a successful build, genuine failure still warns with the probe reason, `--backend cpp` hard error distinguishes "built but not hot-swappable".

## Notes for the reviewer

- **`--check` deliberately keeps an in-process fast path.** It is gated on `extension_replaced_in_process()`: a short-lived `--check` process has not replaced anything, so its in-memory state *is* what a fresh interpreter would compute from the same files. This is what keeps `--check` sub-second (no extra interpreter spawn) while still routing through the single shared helper. The moment `build_native()` writes a `.so`, the flag flips and the probe always spawns.
- **Pre-existing Type Check state**: `scripts/ci/check_mypy_baseline.py` reports one NEW error in `src/kicad_tools/recovery/strategy.py` (a mypy message-format drift against the recorded baseline). Verified pre-existing — reverting both of my source files reproduces the identical failure. This PR contributes zero new mypy findings; the baseline was not touched.

Closes #4589
