### PR TITLE
feat(diffpair): add an opt-in crossover legality census (#4580)

### DIFF
--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -219,6 +219,19 @@ _GUIDE_BIAS_BOOST_REPEATS: int = int(os.environ.get("KCT_GUIDE_BIAS_BOOST_REPEAT
 # it sits relative to the guide.  Diagnostic-only; off by default.
 _SHADOW_DEBUG: bool = os.environ.get("KCT_SHADOW_DEBUG", "0") == "1"
 
+# A bare (x, y) via site in the crossover candidate lattice (issue #4580).
+_XY = tuple[float, float]
+
+# Issue #4580: opt-in crossover LEGALITY census.  See
+# ``DiffPairRouter._synthesize_crossing_tail`` for what it measures and why the
+# first-legal loop cannot answer the question on its own.  Diagnostic-only, off
+# by default, and observation-only when on -- it never changes which route
+# ships.  Costs a full 225-candidate sweep per crossover.
+_CROSSTAIL_CENSUS: bool = os.environ.get("KCT_CROSSTAIL_CENSUS", "0") == "1"
+# How many legal candidates the census lists per crossover before truncating.
+# The count in the header line is always the true total, never the listed one.
+_CROSSTAIL_CENSUS_LIST: int = 12
+
 # Issue #4553: guide pre-simplification.  The C++ per-net A* emits one segment
 # per grid cell, so a board-06 guide is a ~400-segment staircase whose longest
 # contiguous collinear run is ~0.3 mm.  Every micro-corner costs the parallel
@@ -5911,6 +5924,27 @@ class DiffPairRouter:
             for v1 in _via_candidates(head.x, head.y, 1.0)
             for v2 in _via_candidates(goal.x, goal.y, -1.0)
         ]
+        # Issue #4580: the crossover LEGALITY census.  ``_synthesize_crossing_tail``
+        # returns the first legal candidate and says nothing about the rest, so
+        # "the site that ships seals a neighbour" is indistinguishable from two
+        # very different worlds: an ORDERING problem (many sites are legal, a
+        # better key would pick a kinder one) or a SATURATION one (almost
+        # nothing is legal, and no key can help).  #4574 and #4580 were both
+        # filed as the former; measuring board-06 showed the latter.  Telling
+        # them apart needs the size and membership of the legal set, which no
+        # amount of ``KCT_SHADOW_DEBUG`` output can supply.
+        #
+        # ``KCT_CROSSTAIL_CENSUS=1`` scans the WHOLE lattice instead of
+        # stopping at the first legal candidate and reports what it found.  It
+        # is observation only -- the route returned is still the first legal
+        # one in sorted order, i.e. exactly what the un-instrumented loop
+        # returns -- and it costs a full 225-candidate sweep per crossover, so
+        # it is opt-in and off in every normal run.
+        census_on = _CROSSTAIL_CENSUS
+        census_enum = {id(pair): i for i, pair in enumerate(candidate_pairs)}
+        census_legal: list[tuple[int, int, float, _XY, _XY]] = []
+        census_key: Callable[[tuple[_XY, _XY]], float] | None = None
+        census_first: Route | None = None
         if self.enable_shadow_construction:
             exclude = {head.net}
             exclude.update(ps.net for ps in partner_segments)
@@ -5926,11 +5960,13 @@ class DiffPairRouter:
                         seal_cache[site] = cached
                     return cached
 
-                candidate_pairs.sort(
-                    key=lambda pair: _site_penalty(pair[0]) + _site_penalty(pair[1])
-                )
+                def _pair_penalty(pair: tuple[_XY, _XY]) -> float:
+                    return _site_penalty(pair[0]) + _site_penalty(pair[1])
 
-        for v1, v2 in candidate_pairs:
+                candidate_pairs.sort(key=_pair_penalty)
+                census_key = _pair_penalty
+
+        for rank, (v1, v2) in enumerate(candidate_pairs):
             # Issue #3855: replace the hardcoded 0.6mm center-to-center
             # via-to-via check with an edge-to-edge ``min_hole_to_hole``
             # check.  This single crossover's two vias must clear each
@@ -6087,8 +6123,62 @@ class DiffPairRouter:
                 # next candidate pair rather than shipping.
                 if not self._route_via_clear(route):
                     continue
+                if census_on:
+                    census_legal.append(
+                        (
+                            census_enum.get(id(candidate_pairs[rank]), -1),
+                            rank,
+                            census_key((v1, v2)) if census_key is not None else 0.0,
+                            v1,
+                            v2,
+                        )
+                    )
+                    if census_first is None:
+                        census_first = route  # what the un-instrumented loop returns
+                    break  # legal -- record it and keep scanning the lattice
                 return route
+        if census_on:
+            self._report_crossing_tail_census(head, goal, census_legal, len(candidate_pairs))
+            return census_first  # observation only: the first legal candidate
         return None
+
+    @staticmethod
+    def _report_crossing_tail_census(
+        head: Pad,
+        goal: Pad,
+        legal: list[tuple[int, int, float, _XY, _XY]],
+        total: int,
+    ) -> None:
+        """Print one crossover's legality census (issue #4580).
+
+        The header's ``legal=`` count is the true size of the legal set; only
+        the per-candidate listing truncates, and it says so when it does.  The
+        distinction that matters when reading this is whether the legal
+        candidates share a via SITE: distinct sites mean the ordering has a
+        real choice to make, while a legal set that is a singleton in ``v1``
+        (board-06's MIPI_CLK- landing) means no ordering key can move the
+        result and the constraint lives upstream in placement / escape
+        planning.
+        """
+        print(
+            f"    [crosstail-census] net={head.net_name} "
+            f"head=({head.x:.5f},{head.y:.5f}) goal=({goal.x:.5f},{goal.y:.5f}) "
+            f"legal={len(legal)}/{total} "
+            f"distinct_v1={len({site[3] for site in legal})}",
+            flush=True,
+        )
+        for enum_i, rank, penalty, v1, v2 in legal[:_CROSSTAIL_CENSUS_LIST]:
+            print(
+                f"    [crosstail-census]   rank={rank} enum={enum_i} pen={penalty:.4f} "
+                f"v1=({v1[0]:.5f},{v1[1]:.5f}) v2=({v2[0]:.5f},{v2[1]:.5f})",
+                flush=True,
+            )
+        if len(legal) > _CROSSTAIL_CENSUS_LIST:
+            print(
+                f"    [crosstail-census]   ... {len(legal) - _CROSSTAIL_CENSUS_LIST} "
+                f"further legal candidate(s) not listed",
+                flush=True,
+            )
 
     def _tail_partner_clear(
         self,

--- a/tests/test_diffpair_shadow.py
+++ b/tests/test_diffpair_shadow.py
@@ -4651,3 +4651,144 @@ def test_channel_seal_penalty_sums_over_every_channel_it_reaches():
     both = _channel_seal_penalty(0.75, 0.2, 0.65, channels)
     assert one == pytest.approx(0.25)
     assert both == pytest.approx(0.9)
+
+
+# --- Issue #4580: crossover legality census ---------------------------------
+# ``_synthesize_crossing_tail`` ships the FIRST legal candidate and reports
+# nothing about the rest, which makes an ORDERING problem (many legal sites, a
+# better key would pick a kinder one) look exactly like a SATURATION one
+# (almost nothing is legal, so no key can help).  #4574 and #4580 were both
+# filed as the former; the census showed board-06's MIPI_CLK- landing is the
+# latter -- 2 legal candidates out of 225, both on the SAME sealing ``v1``.
+# The census is opt-in, and when on it must remain observation-only.
+
+
+def _census_on(monkeypatch) -> None:
+    import kicad_tools.router.diffpair_routing as dpr_mod
+
+    monkeypatch.setattr(dpr_mod, "_CROSSTAIL_CENSUS", True)
+
+
+def _census_lines(capsys) -> list[str]:
+    return [
+        line.strip()
+        for line in capsys.readouterr().out.splitlines()
+        if "[crosstail-census]" in line
+    ]
+
+
+def test_crossing_tail_census_is_off_by_default(capsys):
+    """The sweep is expensive: a normal run must not pay for it or print it."""
+    tail = _crossing_tail(_crossing_router())
+
+    assert tail is not None
+    assert _census_lines(capsys) == []
+
+
+def test_crossing_tail_census_ships_the_route_it_would_have_shipped(monkeypatch, capsys):
+    """The load-bearing safety property: the census OBSERVES, it never steers.
+
+    Scanning the whole lattice must not change which candidate wins, so the
+    censused route has to be bit-for-bit the un-instrumented one.  The
+    ``capsys`` assertion keeps this non-vacuous -- without it the test would
+    still pass if the census silently never ran.
+    """
+    dpr = _crossing_router()
+    _register_unrouted_neighbour(dpr)
+    baseline = _crossing_tail(dpr)
+    capsys.readouterr()
+
+    _census_on(monkeypatch)
+    censused_router = _crossing_router()
+    _register_unrouted_neighbour(censused_router)
+    censused = _crossing_tail(censused_router)
+
+    assert _census_lines(capsys), "the census must actually have run"
+    assert baseline is not None and censused is not None
+    assert _via_sites(censused) == _via_sites(baseline)
+    assert [(s.x1, s.y1, s.x2, s.y2, s.layer) for s in censused.segments] == [
+        (s.x1, s.y1, s.x2, s.y2, s.layer) for s in baseline.segments
+    ]
+
+
+def test_crossing_tail_census_counts_the_whole_legal_set(monkeypatch, capsys):
+    """First-legal stops at one; the census has to keep going.
+
+    An open lattice has many legal candidates, so a census that reported only
+    the shipped one -- the number the old loop could produce -- would be the
+    exact failure this instrumentation exists to rule out.
+    """
+    _census_on(monkeypatch)
+
+    assert _crossing_tail(_crossing_router()) is not None
+
+    header = [line for line in _census_lines(capsys) if "legal=" in line]
+    assert len(header) == 1
+    legal, total = header[0].split("legal=")[1].split()[0].split("/")
+    assert int(total) == 225
+    assert int(legal) > 1, "an unobstructed lattice has many legal candidates"
+
+
+def test_crossing_tail_census_never_lists_a_candidate_a_gate_rejected(monkeypatch, capsys):
+    """The census reports legality, so it must apply every gate, not skip them.
+
+    The site at ``(8.0, 4.4)`` is covered by a foreign pad ON THE GRID, so the
+    #4571 pad screen vetoes it; a census that enumerated candidates instead of
+    validating them would happily list it.
+    """
+    _census_on(monkeypatch)
+    dpr = _crossing_router()
+    _register_unrouted_neighbour(dpr)
+    dpr.autorouter.grid.add_pad(_pad_at(8.0, 4.4, net=99, name="OTHER"))
+
+    assert _crossing_tail(dpr) is not None
+
+    listed = [line for line in _census_lines(capsys) if "v2=" in line]
+    assert listed, "the census must list the legal candidates it found"
+    assert not any("v2=(8.00000,4.40000)" in line for line in listed)
+
+
+def test_crossing_tail_census_reports_a_singleton_via_site_lattice(capsys):
+    """``distinct_v1`` is what separates 'reorder it' from 'placement's problem'.
+
+    Board-06's MIPI_CLK- landing has two legal candidates that share one
+    ``v1`` -- the sealing barrel -- so every legal route carries the same wall
+    and no ordering key can help.  A census that reported only ``legal=2``
+    would leave that indistinguishable from two genuinely different choices.
+    """
+    from kicad_tools.router.diffpair_routing import DiffPairRouter
+
+    head, goal = _tail_pads((108.10213, 117.02400), (106.10000, 117.50000))
+    shared_v1 = (108.24091, 117.60773)
+    DiffPairRouter._report_crossing_tail_census(
+        head,
+        goal,
+        [
+            (32, 204, 0.7429, shared_v1, (106.23878, 118.08373)),
+            (34, 206, 0.7429, shared_v1, (106.37756, 118.66746)),
+        ],
+        225,
+    )
+
+    header = _census_lines(capsys)[0]
+    assert "legal=2/225" in header
+    assert "distinct_v1=1" in header
+
+
+def test_crossing_tail_census_announces_truncation_instead_of_hiding_it(capsys):
+    """A silent cap reads as 'that was all of them' -- it must say what it dropped."""
+    from kicad_tools.router.diffpair_routing import (
+        _CROSSTAIL_CENSUS_LIST,
+        DiffPairRouter,
+    )
+
+    head, goal = _tail_pads((0.0, 0.0), (3.0, 0.0))
+    many = [
+        (i, i, 0.0, (float(i), 1.0), (float(i), 2.0)) for i in range(_CROSSTAIL_CENSUS_LIST + 5)
+    ]
+    DiffPairRouter._report_crossing_tail_census(head, goal, many, 225)
+
+    lines = _census_lines(capsys)
+    assert f"legal={_CROSSTAIL_CENSUS_LIST + 5}/225" in lines[0]
+    assert sum(1 for line in lines if "rank=" in line) == _CROSSTAIL_CENSUS_LIST
+    assert any("5 further legal candidate(s) not listed" in line for line in lines)


### PR DESCRIPTION
## Summary

**This is AC-B: a measured negative result.** The seal #4580 describes is real
and still reproduces, but it is **not reachable from `_synthesize_crossing_tail`**
— by any ordering key, including the one the issue proposes. What ships here is
the instrumentation that proves it, which AC-B explicitly permits ("changed only
by instrumentation that is itself guarded and tested").

The curator's redirect (Option A — generalise `_channel_seal_penalty` from
points to segments) **was implemented and measured**, then dropped. Details below.

## The decisive measurement

`_synthesize_crossing_tail` returns the *first legal* candidate from its
225-pair lattice and reports nothing about the rest. That makes an **ordering**
problem (many legal sites; a better key picks a kinder one) look identical from
the outside to a **saturation** problem (almost nothing is legal; no key can
help). #4574 and #4580 were both filed as the former.

`KCT_CROSSTAIL_CENSUS=1` scans the whole lattice. For `MIPI_CLK-`'s landing at
J4.2 — the crossover this issue is about:

```
[crosstail-census] net=MIPI_CLK- head=(108.10213,117.02400) goal=(106.10000,117.50000) legal=2/225 distinct_v1=1
[crosstail-census]   rank=208 enum=32 pen=0.7429 v1=(108.24091,117.60773) v2=(106.23878,118.08373)
[crosstail-census]   rank=210 enum=34 pen=0.7429 v1=(108.24091,117.60773) v2=(106.37756,118.66746)
```

`rank=208 enum=32 pen=0.7429` reproduces the curator's R4/R5 figures **exactly**
on post-#4604 `main`, which validates the baseline. The new facts are the last
two fields:

- **`legal=2/225`** — 223 of 225 candidates are rejected by a legality gate.
- **`distinct_v1=1`** — and the two survivors carry the **same `v1`**,
  `(108.24091, 117.60773)`: the sealing barrel, its F.Cu stub, and the `In1.Cu`
  run. They differ only in `v2`.

**Every legal crossover ships the same wall.** Re-ordering chooses between two
routes that are identical in the copper that does the sealing, so no scoring
function can unseal `MIPI_D0` from here. This is a lattice with one legal
anchor, not a scoring blind spot.

### The saturation is board-wide, not local to this site

Across all 123 crossover attempts in the run:

| legal set size | crossover attempts |
|---|---|
| `0/225` | 117 (95%) |
| `2/225` | 3 |
| `4/225` | 1 |
| `6/225` | 2 |

95% of crossover attempts have **no legal candidate at all**, so ordering is
inert for them by definition. Only 6 attempts board-wide offer any choice. This
generalises the finding well past #4580: the via-site *ordering* lever that
#4574 introduced and #4580 proposed to sharpen is nearly vacuous on board-06,
because the lattice almost never presents a choice to order.

## What was tried and dropped: the segment-aware seal penalty (Option A)

Implemented in full, per the curator's redirect, and measured:

- `_channel_seal_penalty` generalised from a point to a segment
  (segment-to-ray closest approach, clipped to the channel's `(0, reach)` band).
- `_EscapeChannel` given `layer` / `through_hole`, because J4 is an FFC
  connector whose MIPI pads are **SMD, F.Cu only** — an inner-layer run under
  the pad row cannot wall in an F.Cu-only pad's *direct* escape, but an F.Cu
  stub across the ray can.
- The whole assembled footprint scored (both stubs + the alt-layer run + both
  barrels) rather than the two barrel centres.

It **worked** and it **fired on exactly the right copper**: the shipped
crossover's penalty rose `0.7429 → 1.4929`, the added ~0.75 being the vertical
F.Cu stub at `x = 108.2409` crossing `MIPI_D0`'s escape ray at `y = 117.5` —
copper #4574's point model scores as `0.0` at both endpoints. (The geometry is
exact: a degenerate segment reproduces the point form bit-for-bit.)

And it changed **nothing**, because of `distinct_v1=1`. Compared on the
deterministic shadow surface (#4593) — the only valid single-run signal:

| signal | baseline (`main`) | with segment-aware penalty |
|---|---|---|
| `coupled-ok` **by name** | `MIPI_CLK, PCIE_RX, USB2_D, USB3_TX1, USB3_TX2` | **identical** |
| `MIPI_D0` class | `guide-missing` | `guide-missing` |
| `PCIE_TX` / `USB3_RX1` / `USB3_RX2` | `shadow-declined-blockage` | identical |
| `[coupled-pair-report]` lines | 11 | 11 |
| `[coupled-tail]` lines | 33 | 33 |
| `[coupled-follow] declined` | 46 | 46 |
| `[corridor-probe] FAILED` | 1 | 1 |

Per-pair identical, **by name, not by count** (G2). *Scope note:* the
segment-penalty run was stopped after its shadow phase completed, so this
comparison is on the deterministic shadow/pair surface rather than a full board
diff — which is the surface #4593 says to use anyway, since the downstream
error/reach counts are bimodal.

It was dropped rather than shipped: a preference that re-orders nothing
measurable, while carrying real re-ordering risk on the 6 crossovers that *do*
have a choice, is speculative generality. The implementation is fully described
above if a future board ever presents an unsaturated lattice.

## What ships

Only the census. It is:

- **off by default** (`KCT_CROSSTAIL_CENSUS=0`) — it costs a full 225-candidate
  sweep per crossover;
- **observation-only when on** — the route returned is still the first legal
  candidate in sorted order, i.e. exactly what the un-instrumented loop returns.
  There is a test pinning this bit-for-bit;
- **honest about truncation** — the header count is always the true legal-set
  size; the listing caps at 12 and says how many it dropped.

The curator's note said "a builder should re-create that same instrumentation…
it is not obtainable from `KCT_SHADOW_DEBUG` alone". This makes it permanent, so
the next investigation — which is now a placement/escape-planning one — gets it
for free.

## Baseline, re-measured on post-#4604 `main`

Measured at `7a1cdc66` in an isolated worktree, C++ backend built, seed 42.
The run landed in **Mode A** of the #4536 bimodality and reproduces the
curator's recorded Mode A exactly:

| signal | measured | curator's Mode A |
|---|---|---|
| `kct check --mfr jlcpcb` | **32 errors**, 7 warnings | 32 |
| `diffpair_clearance_intra` | **7** | 7 |
| `diffpair_length_skew` | 7 | — |
| `diffpair_routing_continuity` | 7 | — |
| `connectivity` / `impedance` | 3 / 2 | — |
| reach | **`PARTIAL: 19/21`** (corridor-yield 18 → 19) | 19-of-21 |
| `coupled-ok` | **5/9** — `MIPI_CLK, PCIE_RX, USB2_D, USB3_TX1, USB3_TX2` | 5/9 |

Stranded: `MIPI_D0+`, `MIPI_D0-`, `USB_CC1`. LVS still reports the two
`MIPI_D0` opens at J4 — the symptom this issue is about, unchanged.

### Both #4536 modes were observed, and that is not a regression signal

The three full runs did not all land in the same downstream mode:

| run | mode | errors | `clearance_intra` | reach |
|---|---|---|---|---|
| baseline, census **off**, `main` | **A** | 32 | 7 | 19/21 |
| PR head, census **on** | **B** | 35 | 19 | 18/21 |

Both are the curator's recorded modes, reproduced exactly. Per #4593 these
counts are **bimodal and are not a valid single-run pass/fail signal** — which
is precisely why the deterministic shadow surface is the one used above, and
there it is identical across all three runs. Reading the A→B difference as a
regression would be the exact error #4593 exists to prevent; the census cannot
cause it, because it is observation-only by construction and pinned bit-for-bit
by `test_crossing_tail_census_ships_the_route_it_would_have_shipped`.

## Guards

- **G1 (reach)** — `PARTIAL: 19/21`, unchanged. The shipped change cannot alter
  routing: inert when the env var is unset, observation-only when set.
- **G2 (vacuity)** — `coupled-ok` reported **by name**, 5/9, with the full
  per-pair `class=` list. No pair was traded for another.
- **G3 (intra-clearance)** — `diffpair_clearance_intra` = 7, unchanged; no rung
  selection is touched.
- **G4 (determinism)** — **three** independent full runs in this investigation
  (baseline census-off, segment-penalty variant, PR-head census-on) produced an
  identical shadow triple — `[coupled-tail]` **33**, `[coupled-follow] declined`
  **46**, `[corridor-probe] FAILED` **1** — and identical per-pair classes
  across all 11 `[coupled-pair-report]` lines. Note the decline count is **46**
  on post-#4604 `main`, not the 47 recorded at `092611b0`: #4604 changed the
  follow-tail path, exactly as the issue warned.

## Where the problem actually lives

`MIPI_D0`'s seal is set by the J4 pad field, not by the diffpair constructor:
223/225 rejections, 95% of crossovers with an empty legal set, and a legal set
that is a singleton in the sealing via site. The remaining lever is upstream —
placement, escape ordering, or guide shape near the landing (**#3438**,
**#4408**), which is also where #4577 landed. Epic **#4409** is updated
accordingly.

## Test plan

- `tests/test_diffpair_shadow.py` — 6 new tests: off-by-default; ships the same
  route it would have shipped (bit-for-bit, with a `capsys` assertion keeping it
  non-vacuous); counts the whole legal set rather than stopping at one; never
  lists a candidate a gate rejected; reports `distinct_v1` for a singleton
  lattice; announces truncation instead of hiding it.
- Full file: **180 passed**.
- `ruff check` / `ruff format` clean; `check_mypy_baseline.py` reports no new
  type errors.

---

Closes #4580
