### PR TITLE
fix(models3d): bake model rotate as rz + theta, not rz - theta

### DIFF
--- a/src/kicad_tools/pcb/models3d.py
+++ b/src/kicad_tools/pcb/models3d.py
@@ -42,14 +42,17 @@ the body 90° off from the copper.  This is the rotation analog of the origin
 offset above: we derive the pad-field orientation of both the target block
 and the source library footprint from two anchor pads (the pad-1→pad-2
 vector), and bake ``theta = target - source`` into the inserted model's
-``(rotate (xyz 0 0 ...))``.  Because the model frame's Y is negated versus the
-footprint 2D frame, a footprint-2D rotation of ``theta`` maps to a model-frame
-Z rotation of ``-theta``.  The centroid offset is composed **in the rotated
-frame** (``offset_2d = target_centroid - R_theta * source_centroid``) so the
-body still lands on the target pads.  Co-oriented footprints (all SMD parts,
-headers already authored on the library convention, the origin-offset case
-above) compute ``theta ~= 0`` and keep ``(rotate (xyz 0 0 0))`` plus the
-existing offset verbatim.
+``(rotate (xyz 0 0 ...))``.  **Two negations cancel here**: the model frame
+negates Y versus the footprint 2D frame, *and* KiCad negates the written
+``(rotate ...)`` components when it applies them at render time.  Their
+composition is the identity, so a written ``rz`` **is** the footprint-2D
+rotation it produces -- to realize ``theta`` we write ``rz + theta``, never
+``rz - theta`` (that inverted sign was the #4583 defect).  The centroid offset
+is composed **in the rotated frame** (``offset_2d = target_centroid - R_theta *
+source_centroid``) so the body still lands on the target pads.  Co-oriented
+footprints (all SMD parts, headers already authored on the library convention,
+the origin-offset case above) compute ``theta ~= 0`` and keep ``(rotate (xyz 0 0
+0))`` plus the existing offset verbatim.
 
 Used by ``kct pcb add-3d-models``.
 """
@@ -461,14 +464,22 @@ def _fmt_num(value: float) -> str:
 
 
 def _apply_rotate_delta(model_block: str, theta_deg: float) -> str:
-    """Return *model_block* with a model-frame Z rotation of ``-theta_deg`` baked in.
+    """Return *model_block* with a model-frame Z rotation of ``+theta_deg`` baked in.
 
     *theta_deg* is the pad-field rotation of the target footprint relative to
-    its library source, measured in the footprint 2D frame.  The KiCad 3D-model
-    frame negates Y versus the footprint 2D frame, so a footprint-2D rotation of
-    ``theta`` maps to a model-frame Z rotation of ``-theta`` (pinned by the
-    regression tests).  The delta is added into the block's own ``(rotate (xyz
-    X Y Z))`` Z field; X and Y are preserved.
+    its library source, measured in the footprint 2D frame.  Two negations
+    cancel in the model rotation path: the KiCad 3D-model frame negates Y
+    versus the footprint 2D frame, **and** KiCad negates the written ``(rotate
+    ...)`` components when it applies them at render time (the renderer rotates
+    by ``-m_Rotation.z`` in a right-handed Y-up model frame).  Conjugating the
+    applied rotation ``-rz`` by the Y flip yields ``+rz``, so a written ``rz``
+    **is** the footprint-2D rotation it produces.  Realizing ``theta`` therefore
+    means writing ``rz + theta``; the pre-#4583 ``rz - theta`` rotated bodies the
+    wrong way and (once composed with the rotated-frame centroid offset) threw
+    them ``2 * |R_theta * source_centroid|`` off their pads.  The delta is added
+    into the block's own ``(rotate (xyz X Y Z))`` Z field; X and Y are preserved.
+    A library model that already carries a nonzero ``rz`` composes by plain
+    addition, because ``rz`` and ``theta`` are then in the same sense.
 
     When *theta_deg* is (near) zero -- the co-oriented case (all SMD parts, the
     origin-convention offset fixtures) -- the block is returned unchanged so
@@ -492,7 +503,10 @@ def _apply_rotate_delta(model_block: str, theta_deg: float) -> str:
         rx, ry, rz = float(fields[0]), float(fields[1]), float(fields[2])
     except ValueError:
         return model_block
-    nz = _fmt_num(_normalize_angle(rz - theta_deg))  # footprint 2D theta -> model Z -theta
+    # A written rz IS the footprint-2D rotation it produces: KiCad negates the
+    # written (rotate ...) at render time and the model frame negates Y, and the
+    # two negations cancel.  So realize theta by writing rz + theta (#4583).
+    nz = _fmt_num(_normalize_angle(rz + theta_deg))
     new_xyz = f"(xyz {_fmt_num(rx)} {_fmt_num(ry)} {nz})"
     return model_block[:xyz_idx] + new_xyz + model_block[xyz_end + 1 :]
 
@@ -763,8 +777,9 @@ def add_model_refs_to_text(pcb_text: str, resolver: Resolver) -> tuple[str, Mode
         # is rotated relative to its library source (rotation baked into pad
         # coordinates rather than the placement angle) needs the delta baked
         # into the model's (rotate ...).  theta is measured in the footprint
-        # 2D frame; the model frame negates Y, so _apply_rotate_delta bakes a
-        # model-frame Z of -theta.  When either orientation is underivable
+        # 2D frame; the model frame's Y negation and KiCad's render-time
+        # negation of the written (rotate ...) cancel, so _apply_rotate_delta
+        # bakes a model-frame Z of +theta.  When either orientation is underivable
         # (single-pad parts, LCSC-synthesized bodies) theta stays 0.
         target_orientation = _pad_field_orientation(body)
         theta = 0.0

--- a/tests/test_pcb_add_3d_models.py
+++ b/tests/test_pcb_add_3d_models.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import difflib
 from pathlib import Path
 
+import pytest
+
 from kicad_tools.footprints.library_path import LibraryPaths
 from kicad_tools.pcb.models3d import (
     ResolvedModels,
@@ -762,9 +764,17 @@ class TestResolvedModels:
 # Y.  Placement angle and model rotate are both 0 as written, so kicad-cli
 # renders the body 90° off from the copper.  The patcher must derive the
 # pad-field orientation from two anchor pads and bake theta = target - source
-# into the model (rotate (xyz 0 0 -theta)) -- model-frame Y is negated vs the
-# footprint 2D frame, so a footprint-2D rotation of theta maps to model-frame
-# Z of -theta -- while composing the centroid offset in the rotated frame.
+# into the model (rotate (xyz 0 0 +theta)) -- TWO negations cancel here: the
+# model frame negates Y vs the footprint 2D frame, AND KiCad negates the
+# written (rotate ...) when it applies it at render time, so a written rz IS
+# the footprint-2D rotation it produces -- while composing the centroid offset
+# in the rotated frame.
+#
+# Issue #4583: the original #4448/#4457 implementation baked -theta.  The four
+# assertions below pinning +90-for-theta=-90 were themselves wrong and have been
+# flipped; test_one_eighty_rotation passed under BOTH signs (180 == -180 after
+# normalization), which is exactly how the defect shipped green.  See
+# `_assert_model_lands_on_target_pads` for the non-sign-invariant guard.
 
 # Library footprint: 1x09 pins running along +Y (pad 1 at origin), matching
 # the canonical KiCad PinHeader_1x09_P2.54mm_Vertical .step authoring.
@@ -888,17 +898,20 @@ class TestApplyRotateDelta:
         "\t(rotate\n\t\t(xyz 0 0 0)\n\t)\n)"
     )
 
-    def test_footprint_theta_maps_to_model_z_negated(self):
-        # theta = -90 (target rotated -90 from source) -> model-frame Z = +90.
+    def test_footprint_theta_maps_to_model_z_directly(self):
+        # #4583 sign pin: theta = -90 -> model-frame Z = -90 (NOT +90).  A
+        # written rz is the footprint-2D rotation it produces, because KiCad's
+        # render-time negation of (rotate ...) cancels the model frame's Y flip.
         out = _apply_rotate_delta(self.MODEL, -90.0)
-        assert "(rotate\n\t\t(xyz 0 0 90)" in out
+        assert "(rotate\n\t\t(xyz 0 0 -90)" in out
         # Only the rotate xyz changed; offset/scale untouched.
         assert "(offset\n\t\t(xyz 0 0 0)" in out
         assert "(scale\n\t\t(xyz 1 1 1)" in out
 
-    def test_positive_theta_maps_to_negative_model_z(self):
+    def test_positive_theta_maps_to_positive_model_z(self):
+        # #4583 sign pin, the other direction: theta = +90 -> model Z = +90.
         out = _apply_rotate_delta(self.MODEL, 90.0)
-        assert "(rotate\n\t\t(xyz 0 0 -90)" in out
+        assert "(rotate\n\t\t(xyz 0 0 90)" in out
 
     def test_zero_theta_is_verbatim(self):
         assert _apply_rotate_delta(self.MODEL, 0.0) == self.MODEL
@@ -910,15 +923,68 @@ class TestApplyRotateDelta:
     def test_existing_nonzero_rotate_is_added_to(self):
         model = '(model "a.step"\n\t(rotate\n\t\t(xyz 0 0 45)\n\t)\n)'
         out = _apply_rotate_delta(model, -90.0)
-        # 45 - (-90) = 135
-        assert "(xyz 0 0 135)" in out
+        # #4583: plain addition -- rz and theta are in the same sense, so
+        # 45 + (-90) = -45 (NOT 45 - (-90) = 135).
+        assert "(xyz 0 0 -45)" in out
+
+
+def _assert_model_lands_on_target_pads(
+    patched_text: str,
+    source_centroid: tuple[float, float],
+    target_centroid: tuple[float, float],
+) -> None:
+    """Geometric end-to-end guard for the #4583 rotation sign.
+
+    Parses the inserted ``(offset ...)`` / ``(rotate ...)`` back out of the
+    patched board text, reconstructs the transform KiCad will actually apply to
+    the STEP body, and asserts it maps the *source* (library) pad centroid onto
+    the *target* (board) pad centroid to within 1 nm.
+
+    Reconstruction, in footprint-2D coordinates:
+
+    * the model frame negates Y, so a model offset ``(ox, oy, oz)`` is a
+      footprint-2D translation of ``(ox, -oy)``;
+    * a written ``rz`` **is** the footprint-2D rotation it produces (KiCad's
+      render-time negation of ``(rotate ...)`` cancels the model frame's Y
+      flip), so the applied rotation is ``R_{+rz}``.
+
+    So the body's source centroid lands at ``(ox, -oy) + R_{rz}(source)``.
+
+    This is deliberately **not** sign-invariant at +/-90 degrees: flipping the
+    sign in ``_apply_rotate_delta`` moves the reconstructed point by
+    ``2 * |R_theta * source_centroid|`` and the assertion fails.  A
+    literal-string assertion alone would not have caught #4457, and
+    ``test_one_eighty_rotation`` cannot (180 == -180 after normalization).
+    """
+    import math
+    import re
+
+    offset_xyz = re.search(r"\(offset\s*\(xyz ([^)]+)\)", patched_text)
+    rotate_xyz = re.search(r"\(rotate\s*\(xyz ([^)]+)\)", patched_text)
+    assert offset_xyz is not None, "no (offset (xyz ...)) in patched text"
+    assert rotate_xyz is not None, "no (rotate (xyz ...)) in patched text"
+    ox, oy, _oz = (float(v) for v in offset_xyz.group(1).split())
+    _rx, _ry, rz = (float(v) for v in rotate_xyz.group(1).split())
+
+    rad = math.radians(rz)
+    sx, sy = source_centroid
+    landed = (
+        ox + (sx * math.cos(rad) - sy * math.sin(rad)),
+        -oy + (sx * math.sin(rad) + sy * math.cos(rad)),
+    )
+    assert landed == pytest.approx(target_centroid, abs=1e-6), (
+        f"model body lands at {landed}, expected the target pad centroid "
+        f"{target_centroid} (offset={ox},{oy} rotate_z={rz})"
+    )
 
 
 class TestOrientationConventionRotation:
     def test_pad_rotated_header_gets_ninety_degree_model_rotate(self, tmp_path):
         """The board-07 case: library pads along Y, board pads along X.
 
-        theta = target(0°) - source(90°) = -90°; model-frame Z = -theta = +90°.
+        theta = target(0°) - source(90°) = -90°; model-frame Z = +theta = -90°
+        (#4583 -- KiCad's render-time negation of (rotate ...) cancels the model
+        frame's Y flip, so a written rz *is* the footprint-2D rotation).
         Offset is composed in the rotated frame:
           R_{-90} * source_centroid(0, 10.16) = (10.16, 0)
           offset_2d = target_centroid(0,0) - (10.16, 0) = (-10.16, 0)
@@ -932,14 +998,67 @@ class TestOrientationConventionRotation:
         text = pcb.read_text()
         import re
 
-        # Sign convention pinned: +90 model-frame Z for a -90 footprint rotation.
+        # Sign convention pinned (#4583): -90 model-frame Z for a -90 footprint
+        # rotation.  Pre-#4583 this asserted "0 0 90" and rendered off-board.
         rotate_xyz = re.search(r"\(rotate\s*\(xyz ([^)]+)\)", text)
         assert rotate_xyz is not None
-        assert rotate_xyz.group(1).strip() == "0 0 90"
-        # Centroid offset composed in the rotated frame.
+        assert rotate_xyz.group(1).strip() == "0 0 -90"
+        # Centroid offset composed in the rotated frame (unchanged by #4583).
         offset_xyz = re.search(r"\(offset\s*\(xyz ([^)]+)\)", text)
         assert offset_xyz is not None
         assert offset_xyz.group(1).strip() == "-10.16 0 0"
+        # ...and the reconstructed transform actually seats the body on the pads.
+        _assert_model_lands_on_target_pads(text, (0.0, 10.16), (0.0, 0.0))
+
+    def test_minus_ninety_body_lands_on_target_pads(self, tmp_path):
+        """#4583 geometric regression, theta = -90 (== 270).
+
+        Not sign-invariant: under the pre-#4583 ``rz - theta`` the body lands at
+        (-20.32, 0) instead of the target centroid (0, 0) -- exactly the 20.32 mm
+        = 2 x 10.16 mm displacement observed on board-07's J3.
+        """
+        lib = _make_rot_header_library(tmp_path)
+        new_text, report = add_model_refs_to_text(ROT_HEADER_PCB_TEXT, make_library_resolver(lib))
+        assert report.patched
+        _assert_model_lands_on_target_pads(new_text, (0.0, 10.16), (0.0, 0.0))
+
+    def test_plus_ninety_body_lands_on_target_pads(self, tmp_path):
+        """#4583 geometric regression, theta = +90 (the mirror of the above).
+
+        Board pads run along -X (pad 1 at (10.16, 0) down to pad 9 at
+        (-10.16, 0)), so target orientation = 180°, source = 90°, theta = +90°.
+        Expect (rotate (xyz 0 0 90)) and (offset (xyz 10.16 0 0)).  Asserting
+        both directions blocks a future ``abs()``-style regression that would
+        satisfy only one of them.
+        """
+        import re
+
+        lib = _make_rot_header_library(tmp_path)
+        pcb_text = (
+            "(kicad_pcb\n"
+            '\t(footprint "Connector_PinHeader_2.54mm:PinHeader_1x09_P2.54mm_Vertical"\n'
+            '\t\t(layer "F.Cu")\n'
+            + "".join(
+                f'\t\t(pad "{i + 1}" thru_hole {"rect" if i == 0 else "oval"}\n'
+                f"\t\t\t(at {10.16 - i * 2.54:g} 0)\n"
+                "\t\t\t(size 1.7 1.7)\n"
+                "\t\t\t(drill 1)\n"
+                '\t\t\t(layers "*.Cu" "*.Mask")\n'
+                "\t\t)\n"
+                for i in range(9)
+            )
+            + "\t)\n"
+            ")\n"
+        )
+        new_text, report = add_model_refs_to_text(pcb_text, make_library_resolver(lib))
+        assert report.patched
+        rotate_xyz = re.search(r"\(rotate\s*\(xyz ([^)]+)\)", new_text)
+        assert rotate_xyz is not None
+        assert rotate_xyz.group(1).strip() == "0 0 90"
+        offset_xyz = re.search(r"\(offset\s*\(xyz ([^)]+)\)", new_text)
+        assert offset_xyz is not None
+        assert offset_xyz.group(1).strip() == "10.16 0 0"
+        _assert_model_lands_on_target_pads(new_text, (0.0, 10.16), (0.0, 0.0))
 
     def test_rotate_and_offset_are_pure_metadata(self, tmp_path):
         """Only inserted model lines differ; no original copper line moves."""


### PR DESCRIPTION
## Summary

`_apply_rotate_delta` baked the **inverted** sign of the pad-field orientation delta into an inserted `(model ... (rotate (xyz 0 0 Z)))`. Footprints whose rotation is baked into pad *coordinates* rather than the placement angle therefore rendered their 3D body rotated the wrong way; composed with the centroid offset (which is correctly computed in the rotated frame) the body landed `2 * |R_theta * source_centroid|` away from its pads — 20.32 mm for board-07's 9-pin J3, entirely off the west board edge.

One-operator change:

```python
nz = _fmt_num(_normalize_angle(rz - theta_deg))   # before
nz = _fmt_num(_normalize_angle(rz + theta_deg))   # after
```

### Mechanism (the docstrings were half-right)

The old comments justified `-theta` from the model frame's Y negation alone. That is only half the derivation: KiCad **also** negates the written `(rotate ...)` components when it applies them at render time (the renderer rotates by `-m_Rotation.z` in a right-handed Y-up model frame). Conjugating the applied `-rz` by the Y flip yields `+rz`, so the two negations cancel and a written `rz` **is** the footprint-2D rotation it produces. Realizing `theta` means writing `rz + theta`.

All three doc sites now state the cancellation explicitly, so the next reader cannot re-derive the old answer from the Y flip alone.

### I flipped the wrong assertions rather than matching them

Four existing assertions encoded the inverted convention. Treating them as ground truth would have produced a fully green PR with a still-broken render — CI cannot catch it, because KiCad is not on the runners. That is how #4457 shipped this bug.

| Test | Was | Now |
|---|---|---|
| `test_footprint_theta_maps_to_model_z_negated` → `..._directly` | `0 0 90` for `theta = -90` | `0 0 -90` |
| `test_positive_theta_maps_to_negative_model_z` → `test_positive_theta_maps_to_positive_model_z` | `0 0 -90` for `theta = +90` | `0 0 90` |
| `test_existing_nonzero_rotate_is_added_to` | `0 0 135` | `0 0 -45` |
| `test_pad_rotated_header_gets_ninety_degree_model_rotate` | `0 0 90` | `0 0 -90` (offset unchanged at `-10.16 0 0`) |

The curator suggested renaming the second test to `test_negative_theta_maps_to_negative_model_z`, but its body exercises `theta = +90`; I used `test_positive_theta_maps_to_positive_model_z` so the name matches the assertion.

`test_one_eighty_rotation` is deliberately **untouched** — `_normalize_angle(0 + 180) == _normalize_angle(0 - 180) == 180.0`, so it passes under both signs. Every theta-zero / co-oriented / `_pad_field_orientation` / offset test is likewise unmodified.

## Changes

- `src/kicad_tools/pcb/models3d.py` — the sign in `_apply_rotate_delta`; corrected module docstring "Orientation-convention rotation" paragraph, `_apply_rotate_delta` docstring (the "pinned by the regression tests" phrasing is gone — those tests pinned the wrong sign), and the inline comment in `add_model_refs_to_text`.
- `tests/test_pcb_add_3d_models.py` — four flipped assertions, two renamed tests, corrected fixture comment block, and new non-sign-invariant regression coverage.

`_pad_field_orientation`, `_normalize_angle`, `_rotate_point`, `_apply_offset_delta`, `synthesize_model_block`, the resolver tiers and the `theta = target - source` / rotated-frame offset composition are all unchanged.

## New regression coverage

`_assert_model_lands_on_target_pads` is a geometric end-to-end guard: it parses the inserted `(offset ...)` / `(rotate ...)` back out, reconstructs the transform KiCad will actually apply (undoing the model-frame Y negation, rotating by `+rz`), and asserts it maps the **source** pad centroid onto the **target** pad centroid within 1 nm. Applied at `theta = -90` (== 270) and `theta = +90`, so a future `abs()`-style regression satisfying only one direction is blocked.

**Negative control (required by the issue).** With the sign temporarily reverted to `rz - theta_deg`:

```
FAILED test_minus_ninety_body_lands_on_target_pads
E  AssertionError: model body lands at (-20.32, 6.22e-16), expected the target pad
   centroid (0.0, 0.0) (offset=-10.16,0.0 rotate_z=90.0)
FAILED test_plus_ninety_body_lands_on_target_pads
E  AssertionError: assert '0 0 -90' == '0 0 90'
2 failed, 2 passed
```

The two that still passed are `test_one_eighty_rotation` and `test_orientation_one_eighty` — confirming the new tests are genuinely sign-sensitive and the 180 case is not.

## Acceptance Criteria Verification

- [x] `_apply_rotate_delta` bakes `_normalize_angle(rz + theta_deg)`; the inline comment states the double-negation cancellation
- [x] Module docstring paragraph corrected; the `-theta` claim removed
- [x] `_apply_rotate_delta` docstring corrected; "(pinned by the regression tests)" removed
- [x] Four wrong-sign assertions flipped to the tabulated values; two misleading test names renamed
- [x] `test_one_eighty_rotation` and every theta-zero / co-oriented / `_pad_field_orientation` / offset test passes **unmodified**
- [x] New non-sign-invariant coverage at +/-90, including the source-centroid-onto-target-centroid reconstruction
- [x] Model-stripped board-07 scratch copy emits `(offset (xyz -10.16 0 0))` **and** `(rotate (xyz 0 0 -90))` for J3 — output below
- [x] No file under `boards/`, no `docs/guides/lcsc-3d-models.md`, no LCSC-tier code changed (`git status` shows exactly the two in-scope files)
- [x] `ruff check .`, `ruff format . --check`, mypy baseline gate clean; `tests/test_pcb_add_3d_models.py` green

## Test Plan

**Automated** — `tests/test_pcb_add_3d_models.py` 62 passed; with `tests/test_lcsc_models.py` 114 passed. `ruff check .` → `All checks passed!`; `ruff format . --check` → `1726 files already formatted`; `scripts/ci/check_mypy_baseline.py` → `OK: mypy reports 1473 error(s), all within the baseline (1474 allowed). No new type errors.` (no errors in `models3d.py`).

**Manual ground truth** (KiCad 10 / `kicad-cli`, not runnable in CI). Stripped all 8 `(model ...)` blocks from a scratch copy of `boards/07-matchgroup-test/output/matchgroup_test_routed.kicad_pcb` (paren-matched, written outside the repo), then re-patched with this branch:

```
(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x09_P2.54mm_Vertical.step"
        (offset
                (xyz -10.16 0 0)
        )
        (scale
                (xyz 1 1 1)
        )
        (rotate
                (xyz 0 0 -90)
        )
)
```

Re-patching the same stripped board with `main`'s code emits `(xyz 0 0 90)`. The complete before/after board diff is that one line:

```
687c687
<                               (xyz 0 0 90)
---
>                               (xyz 0 0 -90)
```

Rendered both with `kicad-cli pcb render --side top`: **before**, J3's 9-pin body hangs entirely off the west board edge with its 9 gold pads bare; **after**, the body seats exactly on its pad row, on-board, no bare pads. Every other component renders identically.

**Independent reproduction** (before touching any code, without board 07): a scratch two-instance board, both 1x09 headers with the pad row along +X and the same `(offset (xyz -10.16 0 0))`, differing only in the baked rotate. `-90` seated the body on its pads; `+90` displaced it in -X leaving the pads bare. Measured displacement ~179 px against a 100 mm / 868 px board scale = **20.6 mm ≈ 20.32 mm = 2 × 10.16 mm** — the arithmetic signature of applying an offset composed for `theta` while rotating by `-theta`, which confirms the offset composition was already correct and the rotate sign was the sole defect.

**Edge cases** — `theta = 0` (SMD) still inserts verbatim; `theta = 180` unchanged at `0 0 180`; single-pad / unresolvable-orientation footprints still fall back to `0 0 0`; a library model with pre-existing nonzero `rz` composes additively (now `45 + (-90) = -45`). `test_rotate_and_offset_are_pure_metadata` / `test_offset_is_pure_metadata_no_copper_delta` confirm the patch remains pure metadata insertion.

**Cleanliness** — every scratch and render artifact written outside the repo; `check-main-clean.sh` exit 0; `git status --porcelain` shows only the two in-scope files.

## Note for #4585 (carried forward from the Curator)

`boards/03-usb-joystick/output/usb_joystick.kicad_pcb` and `usb_joystick_routed.kicad_pcb` each carry 4 `Button_Switch_SMD:SW_SPST_TL3342` refs with the wrong-sign `(rotate (xyz 0 0 90))` (board pads along X, library along Y, so `theta = -90`). It went unnoticed because the TL3342 body is near-symmetric under a 180-degree flip and the centroids coincide. Deliberately **not** fixed here — regenerating board artifacts is #4585's scope, which should widen from "boards 06/07" to include board 03.

Closes #4583
