### PR TITLE
fix(silkscreen): count silk_over_copper per pad pair, add silk_overlap rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`silk_overlap` DRC rule** — `kct check --only silkscreen` now detects
+  silkscreen printed on top of other silkscreen, closing a gap where an entire
+  `kicad-cli pcb drc` rule class was invisible to a kct-only workflow. Emitted
+  at `warning` severity (advisory, non-blocking), one violation per unordered
+  (silk item, silk item) pair. Same-footprint pairs count — a reference
+  designator over its own courtyard art is a real finding, confirmed against
+  `kicad-cli` on a synthetic fixture. Detection is bare geometric intersection
+  rather than KiCad's configurable silk clearance, so it under-reports rather
+  than over-reports (#4612).
+
+### Changed
+
+- **`silk_over_copper` now counts one violation per (silk item, mask aperture)
+  pair**, matching `kicad-cli pcb drc`. Previously it de-duplicated to one
+  violation per silk element. **User-visible: reported `silk_over_copper`
+  counts roughly double** (measured on the in-repo fleet: 2→4, 6→12, 4→7, 3→5),
+  with no change to which silk elements are detected. This makes kct and
+  kicad-cli counts directly comparable — the cross-gate convention that has the
+  two engines referee each other at manufacturing sign-off previously compared
+  numbers that could not agree by construction. It also fixes a second defect:
+  the rule stopped at the first R-tree hit, so a refdes straddling four pads
+  named one *arbitrary* member of the collision set (board 05 reported `U10
+  pad 28`; the real set is pads 27, 28, 29, 30) (#4612).
+
+### Known limitations
+
+- `silk_over_copper`'s aperture set is **pad-only**: untented via mask openings
+  are not indexed, so a silk stroke crossing an untented via is reported by
+  `kicad-cli` but not by kct. Measured on a synthetic probe board; the in-repo
+  fleet tents all vias, so the gap is invisible there (#4612).
+
 ## [0.19.0] - 2026-07-20
 
 ### Summary

--- a/src/kicad_tools/validate/checker.py
+++ b/src/kicad_tools/validate/checker.py
@@ -987,8 +987,14 @@ class DRCChecker:
           (``silkscreen_over_pad``)
         - Silkscreen text/graphics over pad mask apertures -- geometric shapely
           check (``silk_over_copper``)
+        - Silkscreen text/graphics over other silkscreen -- geometric shapely
+          check (``silk_overlap``)
         - Silkscreen text/graphics too close to the board edge -- geometric
           shapely check (``silk_edge_clearance``)
+
+        The three geometric checks count **one violation per colliding pair**,
+        matching ``kicad-cli pcb drc`` so the two engines can referee each other
+        (#4612).
 
         Returns:
             DRCResults containing silkscreen violations

--- a/src/kicad_tools/validate/rules/silkscreen.py
+++ b/src/kicad_tools/validate/rules/silkscreen.py
@@ -5,7 +5,17 @@ This module implements DRC checks for silkscreen elements:
 - Minimum text height
 - Silkscreen-over-pad detection (legacy centroid heuristic)
 - Silkscreen-over-copper detection (geometric, vs pad mask apertures)
+- Silkscreen-over-silkscreen detection (geometric, silk vs silk)
 - Silkscreen-to-edge clearance (geometric, vs Edge.Cuts outline)
+
+**Cross-gate counting model.**  The three geometric checks are designed to be
+count-comparable with ``kicad-cli pcb drc``, which is used as kct's referee at
+manufacturing sign-off.  Each emits **one violation per colliding pair**:
+``silk_over_copper`` per (silk item, mask aperture), ``silk_overlap`` per
+unordered (silk item, silk item), ``silk_edge_clearance`` per (silk item,
+outline) -- the outline being a single object, so that one is per silk item.
+A count mismatch against kicad-cli is therefore a bug to investigate, not a
+convention difference to explain away.  See #4612 for the measured parity table.
 """
 
 from __future__ import annotations
@@ -69,6 +79,18 @@ _CLEARANCE_EPSILON_MM = 1e-4
 # overlaps by exactly 0.01 mm^2; a 0.05 mm^2 gate separates them with wide
 # margin and drops no real finding.
 _MIN_OVERLAP_AREA_MM2 = 0.05
+
+# Minimum silk/silk overlap area (mm^2) before ``silk_overlap`` fires.
+# A SIBLING of ``_MIN_OVERLAP_AREA_MM2`` rather than a reuse of it, because the
+# calibration genuinely differs: silk-over-copper always pairs a silk element
+# with a comparatively large pad aperture, whereas silk-over-silk routinely
+# pairs two thin strokes.  Two minimum-width (0.15 mm) silk lines crossing at
+# right angles overlap by only 0.0225 mm^2 -- well under the 0.05 mm^2 copper
+# gate -- so reusing that constant would silently drop the single most obvious
+# silk_overlap case.  0.005 mm^2 keeps right-angle stroke crossings (4.5x
+# margin) while still rejecting numerically-degenerate hairline touches between
+# two axis-aligned text bounding boxes.
+_MIN_SILK_OVERLAP_AREA_MM2 = 0.005
 
 
 def is_silkscreen_layer(layer: str) -> bool:
@@ -527,6 +549,28 @@ def _iter_pad_apertures(
     SMD pads expose copper on their own side; thru_hole pads expose copper on
     BOTH sides (so they are yielded for both ``"F"`` and ``"B"``).  ``side`` is
     the silk side the aperture must be checked against.
+
+    **Aperture-set scope: pads only (known, deliberate gap -- see #4612).**
+    The aperture index is built from ``footprint.pads`` exclusively;
+    ``pcb.vias`` is never consulted, so an *untented* via's mask opening is not
+    an aperture as far as this module is concerned.  KiCad's silk-clearance
+    provider indexes mask-layer items generally, and this divergence is
+    **measured, not assumed**: on a synthetic probe board carrying
+    ``(tenting (front no) (back no))`` plus one silk segment across a via,
+    ``kicad-cli pcb drc --severity-all`` (KiCad 10.0.5, 2026-08-04) reports::
+
+        silk_over_copper | warning | Segment on F.Silkscreen <-> Via [GND] on F.Cu - B.Cu
+
+    while this rule reports 0.  That is the only known residue after #4612
+    brought pad-pair counting into exact parity with kicad-cli.
+
+    The gap is unexercised by the in-repo fleet: every committed board sets
+    ``(tenting (front yes) (back yes))`` in its ``setup`` block, so no fleet via
+    has a mask opening at all, and kicad-cli names a *pad* in every one of its
+    ``silk_over_copper`` findings on boards 03/05/06/07.  Modelling via
+    apertures needs per-via tenting resolution (board default + per-via
+    override) that this module does not currently parse, so it is deferred to a
+    follow-up rather than guessed at.
     """
     for footprint in pcb.footprints:
         transform = _fp_transform(footprint)
@@ -556,13 +600,30 @@ def check_silk_over_copper(
     Builds a shapely geometry per silk element (text bbox or buffered graphic
     stroke) and tests it against the solder-mask apertures of all pads on the
     matching silk side.  Emits a ``silk_over_copper`` **warning** (matching
-    kicad-cli severity) for any silk element that intersects an aperture.
+    kicad-cli severity) for any silk/aperture intersection.
+
+    **Counting model: one violation per (silk item, mask aperture) pair,
+    matching ``kicad-cli pcb drc``.**  A refdes straddling four pads yields four
+    violations, not one -- so a kct count and a kicad-cli count are directly
+    comparable, and every colliding pad is named rather than an arbitrary
+    representative.  Before #4612 this de-duplicated to one violation per silk
+    element, which under-reported by ~2x and named an R-tree-ordered arbitrary
+    member of the collision set; a count mismatch against kicad-cli is now a
+    bug, not a convention difference.  Violations are sorted by
+    ``(silk label, pad label)`` because ``STRtree.query`` order is unspecified.
+
+    The ``_MIN_OVERLAP_AREA_MM2`` gate is applied **per pair** (each silk/pad
+    intersection must clear it independently), which is the reading the per-pair
+    counting model implies.
 
     This supersedes the crude centroid heuristic in
     :func:`check_silkscreen_over_pads` (which is retained for backward
     compatibility with the ``silkscreen_over_pad`` rule_id), and unlike that
     heuristic it accounts for real text bounding boxes, graphic strokes,
     board-level silk, thru-hole apertures, and silk-over-other-footprint pads.
+
+    The aperture set is **pad-only**; see :func:`_iter_pad_apertures` for the
+    untented-via scope note.
 
     Args:
         pcb: The PCB to check.
@@ -588,6 +649,7 @@ def check_silk_over_copper(
         if entries:
             trees[side] = STRtree([g for g, _ in entries])
 
+    found: list[DRCViolation] = []
     for side, geom, silk_label, location, layer in _iter_silk_geometries(pcb):
         side_entries = apertures.get(side)
         if not side_entries:
@@ -599,10 +661,14 @@ def check_silk_over_copper(
             if not geom.intersects(ap_geom):
                 continue
             # Require a non-trivial overlap area to reject hairline corner
-            # touches that the AABB text approximation can manufacture.
+            # touches that the AABB text approximation can manufacture.  Applied
+            # per (silk, aperture) pair -- see the counting model above.
             if geom.intersection(ap_geom).area < _MIN_OVERLAP_AREA_MM2:
                 continue
-            results.add(
+            # One violation per (silk item, mask aperture) PAIR, matching
+            # kicad-cli.  Do NOT re-introduce a break here: it collapses a
+            # multi-pad collision to a single arbitrary representative (#4612).
+            found.append(
                 DRCViolation(
                     rule_id="silk_over_copper",
                     severity="warning",
@@ -612,7 +678,106 @@ def check_silk_over_copper(
                     items=(silk_label, pad_label),
                 )
             )
-            break  # one violation per silk element
+
+    # STRtree.query order is unspecified; sort for deterministic reporting.
+    for violation in sorted(found, key=lambda v: (v.items[0], v.items[1])):
+        results.add(violation)
+
+    return results
+
+
+def check_silk_overlap(
+    pcb: PCB,
+    design_rules: DesignRules,
+) -> DRCResults:
+    """Geometric check: silkscreen printed on top of other silkscreen.
+
+    Silk-over-silk renders both elements illegible (the refdes you need at
+    assembly and rework time is the usual casualty).  kicad-cli reports this as
+    ``silk_overlap``; before #4612 kct had no producer for it at all, so an
+    entire kicad-cli rule class was invisible to a kct-only workflow even though
+    :data:`~kicad_tools.drc.violation.ViolationType.SILK_OVERLAP` and its fix
+    suggestions were already wired up downstream.
+
+    **Counting model: one violation per unordered (silk item, silk item) pair,
+    matching ``kicad-cli pcb drc``.**  A silk element never pairs with itself,
+    and each colliding pair is emitted exactly once (never as both ``(A, B)``
+    and ``(B, A)``).  Front and back silk are indexed separately, so F-side silk
+    can never pair with B-side silk.
+
+    **Same-footprint pairs DO count.**  A reference designator overlapping its
+    own footprint's courtyard/outline art is a real, reportable finding, not a
+    self-collision to filter out.  kicad-cli is the tiebreaker here and it was
+    measured directly (2026-08-04, KiCad 10.0.5) on the synthetic probe fixture
+    that mirrors ``tests/test_validate_silkscreen.py``'s
+    ``test_same_footprint_refdes_over_own_graphic_flags``::
+
+        silk_overlap | warning | Reference field of A1 <-> Segment of A1 on F.Silkscreen
+        silk_overlap | warning | Reference field of B1 <-> Reference field of C1
+
+    Both the same-footprint pair and the cross-footprint pair fire, so this
+    function excludes neither.
+
+    **Detection is bare intersection, not clearance.**  KiCad's silk-to-silk
+    test enforces a configurable *clearance* (silk must be some distance apart);
+    this check requires the geometries to actually overlap.  That is the
+    deliberately conservative choice for an advisory rule -- it under-reports
+    rather than over-reports relative to kicad-cli on boards that configure a
+    non-zero silk clearance, and it needs no new profile field.
+
+    Args:
+        pcb: The PCB to check.
+        design_rules: Design rules (unused; detection is bare geometric
+            intersection, gated by :data:`_MIN_SILK_OVERLAP_AREA_MM2`).
+
+    Returns:
+        DRCResults containing any ``silk_overlap`` warnings.
+    """
+    del design_rules  # bare intersection; no profile field participates
+    require_shapely("silk-overlap geometry")
+    from shapely import STRtree
+
+    results = DRCResults(rules_checked=1)
+
+    # Reuse the single silk traversal shared with silk_over_copper /
+    # silk_edge_clearance; partition by side so F silk never pairs with B silk.
+    by_side: dict[str, list[tuple[_Geometry, str, tuple[float, float], str]]] = {"F": [], "B": []}
+    for side, geom, label, location, layer in _iter_silk_geometries(pcb):
+        by_side[side].append((geom, label, location, layer))
+
+    found: list[DRCViolation] = []
+    for entries in by_side.values():
+        if len(entries) < 2:
+            continue
+        tree = STRtree([g for g, _, _, _ in entries])
+        for i, (geom, label_a, location, layer) in enumerate(entries):
+            for raw_idx in tree.query(geom):
+                j = int(raw_idx)
+                # Skip self-pairing, and emit each unordered pair once by
+                # keeping only j > i.  Compared by INDEX, not geometry: two
+                # identical refdes boxes on different parts are distinct
+                # elements and must still pair with each other.
+                if j <= i:
+                    continue
+                other_geom, label_b, _, _ = entries[j]
+                if not geom.intersects(other_geom):
+                    continue
+                if geom.intersection(other_geom).area < _MIN_SILK_OVERLAP_AREA_MM2:
+                    continue
+                found.append(
+                    DRCViolation(
+                        rule_id="silk_overlap",
+                        severity="warning",
+                        message=(f"Silkscreen {label_a} overlaps silkscreen {label_b}"),
+                        location=location,
+                        layer=layer,
+                        items=(label_a, label_b),
+                    )
+                )
+
+    # STRtree.query order is unspecified; sort for deterministic reporting.
+    for violation in sorted(found, key=lambda v: (v.items[0], v.items[1])):
+        results.add(violation)
 
     return results
 
@@ -628,6 +793,11 @@ def check_silk_edge_clearance(
     the silk crosses the outline or sits within :data:`SILK_EDGE_CLEARANCE_MM`
     of it.  No-op when the board has no outline (mirrors
     ``EdgeClearanceRule.check``).
+
+    **Counting model: one violation per (silk item, outline) pair, matching
+    ``kicad-cli pcb drc``.**  The outline is treated as a single object, so this
+    is one violation per offending silk item -- unlike ``silk_over_copper``,
+    where each colliding aperture counts separately.
 
     Args:
         pcb: The PCB to check.
@@ -695,6 +865,7 @@ def check_all_silkscreen(
     )
     results.merge(check_silkscreen_over_pads(pcb, design_rules))
     results.merge(check_silk_over_copper(pcb, design_rules))
+    results.merge(check_silk_overlap(pcb, design_rules))
     results.merge(check_silk_edge_clearance(pcb, design_rules))
 
     return results

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1842,11 +1842,13 @@ class TestSilkscreenRules:
 
         # Should have 2 violations (text + line); this fixture has no pads or
         # board outline so the geometric silk_over_copper / silk_edge_clearance
-        # checks contribute no violations.
+        # checks contribute no violations, and its refdes sits clear of its
+        # silk line so silk_overlap contributes none either.
         assert len(results) == 2
-        # 5 rule types checked: line width, text height, legacy over-pad,
-        # geometric silk_over_copper, silk_edge_clearance.
-        assert results.rules_checked == 5
+        # 6 rule types checked: line width, text height, legacy over-pad,
+        # geometric silk_over_copper, silk_overlap (added by #4612),
+        # silk_edge_clearance.
+        assert results.rules_checked == 6
 
         # Check that both rule types are represented
         rule_ids = {v.rule_id for v in results.violations}

--- a/tests/test_validate_silkscreen.py
+++ b/tests/test_validate_silkscreen.py
@@ -1,13 +1,22 @@
 """Tests for the geometric silkscreen DRC rules.
 
-Covers the two checks added in issue #3844:
+Covers the checks added in issue #3844:
 
 - ``check_silk_over_copper`` -- silk text/graphics over exposed pad mask
   apertures (supersedes the crude ``silkscreen_over_pad`` centroid heuristic).
 - ``check_silk_edge_clearance`` -- silk text/graphics too close to / crossing
   the ``Edge.Cuts`` board outline.
 
-Both emit ``severity="warning"`` so they do not block the manufacturing gate.
+plus the check and counting-model change from issue #4612:
+
+- ``check_silk_over_copper`` now emits one violation per **(silk item, mask
+  aperture) pair**, matching ``kicad-cli pcb drc``, instead of de-duplicating
+  to one violation per silk element (which under-reported ~2x and named an
+  arbitrary member of the collision set).
+- ``check_silk_overlap`` -- silk over other silk, the previously-missing
+  producer for the already-wired ``silk_overlap`` violation type.
+
+All emit ``severity="warning"`` so they do not block the manufacturing gate.
 """
 
 from __future__ import annotations
@@ -17,6 +26,7 @@ import pytest
 from kicad_tools.manufacturers import get_profile
 from kicad_tools.schema.pcb import (
     PCB,
+    BoardGraphic,
     Footprint,
     FootprintGraphic,
     FootprintText,
@@ -27,8 +37,10 @@ from kicad_tools.schema.pcb import (
 from kicad_tools.sexp import SExp
 from kicad_tools.validate.rules.silkscreen import (
     SILK_EDGE_CLEARANCE_MM,
+    check_all_silkscreen,
     check_silk_edge_clearance,
     check_silk_over_copper,
+    check_silk_overlap,
 )
 
 
@@ -290,8 +302,14 @@ class TestSilkOverCopper:
         assert results.violations[0].items[0].startswith("Q1")
         assert "R20" in results.violations[0].items[1]
 
-    def test_one_violation_per_silk_element(self):
-        """A silk element overlapping two pads still fires only once."""
+    def test_one_violation_per_silk_aperture_pair(self):
+        """A silk element overlapping two pads fires TWICE, once per pair.
+
+        AC1 of #4612.  This test previously asserted the opposite (one
+        violation per silk element); the de-dup was removed because it made
+        kct's count incomparable with ``kicad-cli pcb drc``, which reports one
+        violation per (silk item, mask aperture) pair.
+        """
         pcb = _empty_pcb()
         fp = _make_footprint(
             pads=[
@@ -303,7 +321,352 @@ class TestSilkOverCopper:
         pcb._footprints.append(fp)
 
         results = check_silk_over_copper(pcb, _rules())
+        assert len(results) == 2
+        assert [v.items[1] for v in results.violations] == ["U1 pad 1", "U1 pad 2"]
+
+    def test_multi_pad_straddle_names_every_pad(self):
+        """A refdes straddling 4 pads yields 4 violations naming all 4.
+
+        AC3/AC9 of #4612 -- the board-05 ``U10`` pattern (a TSSOP reference
+        field over pads 27/28/29/30).  Before the fix the loop broke at the
+        first STRtree hit, so kct emitted a single violation naming an
+        arbitrary member of the collision set.  This is the regression guard
+        against a future "de-dup for readability" change silently
+        reintroducing the under-count.
+        """
+        pcb = _empty_pcb()
+        fp = _make_footprint(
+            reference="U10",
+            pads=[
+                _smd_pad(number="27", position=(-1.8, 0.0), size=(1.0, 2.0)),
+                _smd_pad(number="28", position=(-0.6, 0.0), size=(1.0, 2.0)),
+                _smd_pad(number="29", position=(0.6, 0.0), size=(1.0, 2.0)),
+                _smd_pad(number="30", position=(1.8, 0.0), size=(1.0, 2.0)),
+            ],
+            texts=[_ref_text(text="U10", position=(0.0, 0.0), font_size=(2.0, 2.0))],
+        )
+        pcb._footprints.append(fp)
+
+        results = check_silk_over_copper(pcb, _rules())
+        assert len(results) >= 3  # AC9: >= 3 apertures -> >= 3 violations
+        assert [v.items[1] for v in results.violations] == [
+            "U10 pad 27",
+            "U10 pad 28",
+            "U10 pad 29",
+            "U10 pad 30",
+        ]
+
+    def test_violations_are_sorted_deterministically(self):
+        """Emitted pairs are sorted by (silk label, pad label).
+
+        ``STRtree.query`` order is unspecified, so the rule sorts before
+        emitting; downstream reporting and any pair-set diff against kicad-cli
+        depend on that being stable.
+        """
+        pcb = _empty_pcb()
+        fp = _make_footprint(
+            reference="U1",
+            pads=[
+                _smd_pad(number="3", position=(1.2, 0.0), size=(1.0, 2.0)),
+                _smd_pad(number="1", position=(-1.2, 0.0), size=(1.0, 2.0)),
+                _smd_pad(number="2", position=(0.0, 0.0), size=(1.0, 2.0)),
+            ],
+            texts=[_ref_text(position=(0.0, 0.0), font_size=(2.0, 2.0))],
+        )
+        pcb._footprints.append(fp)
+
+        pairs = [(v.items[0], v.items[1]) for v in check_silk_over_copper(pcb, _rules()).violations]
+        assert pairs == sorted(pairs)
+
+
+# ---------------------------------------------------------------------------
+# silk_overlap (#4612)
+# ---------------------------------------------------------------------------
+#
+# No committed board can serve as a fixture here: ``kicad-cli pcb drc
+# --severity-all`` reports ZERO ``silk_overlap`` on every board under
+# ``boards/`` (and ``silk_overlap`` is not in the report's ``ignored_checks``,
+# so the test genuinely ran), because the fleet's silkscreen is reference
+# designator text only -- no footprint silk graphics at all.  These synthetic
+# fixtures were cross-checked against a hand-authored probe ``.kicad_pcb`` fed
+# to ``kicad-cli pcb drc`` (KiCad 10.0.5, 2026-08-04), which returned exactly
+# the two pairs modelled below:
+#
+#   silk_overlap | warning | Reference field of A1 <-> Segment of A1 on F.Silkscreen
+#   silk_overlap | warning | Reference field of B1 <-> Reference field of C1
+#
+# i.e. kicad-cli counts BOTH same-footprint and cross-footprint pairs, which is
+# the AC6 tiebreaker.
+
+
+def _silk_line(
+    *,
+    start: tuple[float, float],
+    end: tuple[float, float],
+    layer: str = "F.SilkS",
+    stroke_width: float = 0.15,
+) -> FootprintGraphic:
+    return FootprintGraphic(
+        graphic_type="line",
+        layer=layer,
+        stroke_width=stroke_width,
+        start=start,
+        end=end,
+    )
+
+
+class TestSilkOverlap:
+    def test_two_footprints_refdes_overlap_flags(self):
+        """Two footprints whose reference fields overlap yield one pair.
+
+        Mirrors the probe fixture's ``B1 <-> C1`` finding.
+        """
+        pcb = _empty_pcb()
+        pcb._footprints.extend(
+            [
+                _make_footprint(
+                    reference="B1",
+                    position=(10.0, 10.0),
+                    texts=[_ref_text(text="B1", position=(0.0, 0.0))],
+                ),
+                _make_footprint(
+                    reference="C1",
+                    position=(10.4, 10.0),
+                    texts=[_ref_text(text="C1", position=(0.0, 0.0))],
+                ),
+            ]
+        )
+
+        results = check_silk_overlap(pcb, _rules())
+
         assert len(results) == 1
+        v = results.violations[0]
+        assert v.rule_id == "silk_overlap"
+        assert v.severity == "warning"
+        assert {v.items[0], v.items[1]} == {"B1 (reference)", "C1 (reference)"}
+
+    def test_negative_control_clear_silk_passes(self):
+        """The same two footprints, moved apart, produce no violation."""
+        pcb = _empty_pcb()
+        pcb._footprints.extend(
+            [
+                _make_footprint(
+                    reference="B1",
+                    position=(10.0, 10.0),
+                    texts=[_ref_text(text="B1", position=(0.0, 0.0))],
+                ),
+                _make_footprint(
+                    reference="C1",
+                    position=(10.0, 20.0),
+                    texts=[_ref_text(text="C1", position=(0.0, 0.0))],
+                ),
+            ]
+        )
+
+        results = check_silk_overlap(pcb, _rules())
+        assert len(results) == 0
+        assert results.passed is True
+
+    def test_same_footprint_refdes_over_own_graphic_flags(self):
+        """A refdes overlapping its OWN footprint's silk art counts (AC6).
+
+        kicad-cli is the tiebreaker and it reports this pair
+        (``Reference field of A1 <-> Segment of A1 on F.Silkscreen``), so the
+        rule deliberately does not filter same-footprint pairs.
+        """
+        pcb = _empty_pcb()
+        fp = _make_footprint(
+            reference="A1",
+            texts=[_ref_text(text="A1", position=(0.0, 0.0))],
+            graphics=[
+                # Crosses the refdes bbox.
+                _silk_line(start=(-2.0, 0.0), end=(2.0, 0.0)),
+                # Well clear of it (negative control within the same footprint).
+                _silk_line(start=(-2.0, -2.0), end=(2.0, -2.0)),
+            ],
+        )
+        pcb._footprints.append(fp)
+
+        results = check_silk_overlap(pcb, _rules())
+        assert len(results) == 1
+        assert {results.violations[0].items[0], results.violations[0].items[1]} == {
+            "A1 (reference)",
+            "A1 (fp_line)",
+        }
+
+    def test_element_never_pairs_with_itself(self):
+        """A lone silk element cannot collide with itself."""
+        pcb = _empty_pcb()
+        pcb._footprints.append(_make_footprint(texts=[_ref_text(position=(0.0, 0.0))]))
+
+        assert len(check_silk_overlap(pcb, _rules())) == 0
+
+    def test_pair_emitted_only_once(self):
+        """``(A, B)`` and ``(B, A)`` collapse to a single violation."""
+        pcb = _empty_pcb()
+        pcb._footprints.extend(
+            [
+                _make_footprint(
+                    reference="B1",
+                    position=(10.0, 10.0),
+                    texts=[_ref_text(text="XXXX", position=(0.0, 0.0))],
+                ),
+                _make_footprint(
+                    reference="C1",
+                    position=(10.0, 10.0),
+                    texts=[_ref_text(text="XXXX", position=(0.0, 0.0))],
+                ),
+            ]
+        )
+
+        # Two *identical* geometries on different parts: still distinct
+        # elements (compared by index, not geometry), so they pair -- once.
+        assert len(check_silk_overlap(pcb, _rules())) == 1
+
+    def test_front_silk_never_pairs_with_back_silk(self):
+        """Coincident F.SilkS and B.SilkS elements do not collide."""
+        pcb = _empty_pcb()
+        pcb._footprints.extend(
+            [
+                _make_footprint(
+                    reference="B1",
+                    position=(10.0, 10.0),
+                    texts=[_ref_text(text="B1", position=(0.0, 0.0), layer="F.SilkS")],
+                ),
+                _make_footprint(
+                    reference="C1",
+                    position=(10.0, 10.0),
+                    texts=[_ref_text(text="C1", position=(0.0, 0.0), layer="B.SilkS")],
+                ),
+            ]
+        )
+
+        assert len(check_silk_overlap(pcb, _rules())) == 0
+
+    def test_board_level_text_participates(self):
+        """A board-level gr_text overlapping a footprint refdes is flagged."""
+        pcb = _empty_pcb()
+        pcb._footprints.append(
+            _make_footprint(
+                reference="B1",
+                position=(10.0, 10.0),
+                texts=[_ref_text(text="B1", position=(0.0, 0.0))],
+            )
+        )
+        pcb._texts.append(
+            GraphicText(
+                text="LOGO",
+                position=(10.0, 10.0),
+                layer="F.SilkS",
+                font_size=(1.0, 1.0),
+                font_thickness=0.15,
+            )
+        )
+
+        results = check_silk_overlap(pcb, _rules())
+        assert len(results) == 1
+        assert "LOGO" in results.violations[0].items
+
+    def test_board_level_graphic_participates(self):
+        """A board-level gr_line crossing a footprint refdes is flagged."""
+        pcb = _empty_pcb()
+        pcb._footprints.append(
+            _make_footprint(
+                reference="B1",
+                position=(10.0, 10.0),
+                texts=[_ref_text(text="B1", position=(0.0, 0.0))],
+            )
+        )
+        pcb._graphics.append(
+            BoardGraphic(
+                graphic_type="line",
+                layer="F.SilkS",
+                stroke_width=0.3,
+                start=(8.0, 10.0),
+                end=(12.0, 10.0),
+            )
+        )
+
+        results = check_silk_overlap(pcb, _rules())
+        assert len(results) == 1
+        assert "gr_line" in results.violations[0].items
+
+    def test_crossing_min_width_strokes_flag(self):
+        """Two 0.15mm strokes crossing at right angles are NOT gated out.
+
+        Their intersection area is only 0.0225 mm^2 -- below
+        ``_MIN_OVERLAP_AREA_MM2`` (0.05), which is why ``silk_overlap`` uses
+        its own, smaller ``_MIN_SILK_OVERLAP_AREA_MM2`` gate.
+        """
+        pcb = _empty_pcb()
+        pcb._footprints.append(
+            _make_footprint(
+                graphics=[
+                    _silk_line(start=(-2.0, 0.0), end=(2.0, 0.0)),
+                    _silk_line(start=(0.0, -2.0), end=(0.0, 2.0)),
+                ],
+            )
+        )
+
+        assert len(check_silk_overlap(pcb, _rules())) == 1
+
+    def test_hidden_and_empty_text_skipped(self):
+        """Hidden and zero-length silk text never participate."""
+        pcb = _empty_pcb()
+        pcb._footprints.extend(
+            [
+                _make_footprint(
+                    reference="B1",
+                    position=(10.0, 10.0),
+                    texts=[_ref_text(text="B1", position=(0.0, 0.0), hidden=True)],
+                ),
+                _make_footprint(
+                    reference="C1",
+                    position=(10.0, 10.0),
+                    texts=[_ref_text(text="", position=(0.0, 0.0))],
+                ),
+                _make_footprint(
+                    reference="D1",
+                    position=(10.0, 10.0),
+                    texts=[_ref_text(text="D1", position=(0.0, 0.0))],
+                ),
+            ]
+        )
+
+        assert len(check_silk_overlap(pcb, _rules())) == 0
+
+    def test_board_with_no_silk_is_noop(self):
+        """A board with zero silk yields zero violations, not an exception."""
+        assert len(check_silk_overlap(_empty_pcb(), _rules())) == 0
+
+    def test_reachable_through_check_all_silkscreen(self):
+        """``silk_overlap`` is merged into the silkscreen check group (AC5).
+
+        ``kct check --only silkscreen`` dispatches to
+        ``DesignRuleChecker.check_silkscreen`` -> ``check_all_silkscreen``, so
+        merging the producer there is what makes the rule reachable with no
+        ``cli/check_cmd.py`` change.
+        """
+        pcb = _empty_pcb()
+        pcb._footprints.extend(
+            [
+                _make_footprint(
+                    reference="B1",
+                    position=(10.0, 10.0),
+                    texts=[_ref_text(text="B1", position=(0.0, 0.0))],
+                ),
+                _make_footprint(
+                    reference="C1",
+                    position=(10.4, 10.0),
+                    texts=[_ref_text(text="C1", position=(0.0, 0.0))],
+                ),
+            ]
+        )
+
+        results = check_all_silkscreen(pcb, _rules())
+        overlaps = [v for v in results.violations if v.rule_id == "silk_overlap"]
+        assert len(overlaps) == 1
+        assert overlaps[0].severity == "warning"
 
 
 # ---------------------------------------------------------------------------
@@ -505,6 +868,131 @@ def test_real_board_regression(rel_path, rule_id):
     assert len(by_rule[rule_id]) >= 1
     for v in (*over.violations, *edge.violations):
         assert v.severity == "warning"
+
+
+# --- Cross-gate parity with ``kicad-cli pcb drc`` (AC2/AC3 of #4612) --------
+#
+# These pair sets were captured from
+#   kicad-cli pcb drc --refill-zones --severity-all --format json
+# run on COPIES of the committed boards (KiCad 10.0.5, 2026-08-04), reducing
+# each violation's two items to (silk owner refdes, "<footprint>:<pad>").
+# Before #4612 kct emitted 2/6/4/3 against kicad-cli's 4/12/7/5.
+_KICAD_CLI_SILK_OVER_COPPER_PAIRS: dict[str, set[tuple[str, str]]] = {
+    "03-usb-joystick/output/usb_joystick_routed.kicad_pcb": {
+        ("C11", "C10:1"),
+        ("C11", "C10:2"),
+        ("R11", "R10:1"),
+        ("R11", "R10:2"),
+    },
+    "05-bldc-motor-controller/output/bldc_controller_routed.kicad_pcb": {
+        ("C7", "C4:2"),
+        ("C8", "C5:1"),
+        ("Q1", "R20:1"),
+        ("Q1", "R20:2"),
+        ("Q3", "R21:1"),
+        ("Q3", "R21:2"),
+        ("Q5", "R22:1"),
+        ("Q5", "R22:2"),
+        ("U10", "U10:27"),
+        ("U10", "U10:28"),
+        ("U10", "U10:29"),
+        ("U10", "U10:30"),
+    },
+    "06-diffpair-test/output/diffpair_test_routed.kicad_pcb": {
+        ("U1", "U1:12"),
+        ("U1", "U1:13"),
+        ("U2", "U2:A4"),
+        ("U3", "U3:18"),
+        ("U3", "U3:19"),
+        ("U4", "U4:9"),
+        ("U4", "U4:10"),
+    },
+    "07-matchgroup-test/output/matchgroup_test_routed.kicad_pcb": {
+        ("U3", "U3:9"),
+        ("U3", "U3:10"),
+        ("U4", "U4:A4"),
+        ("U5", "U5:18"),
+        ("U5", "U5:19"),
+    },
+}
+
+
+def _kct_pair_set(pcb: PCB) -> set[tuple[str, str]]:
+    """Reduce kct ``silk_over_copper`` violations to comparable pair keys."""
+    import re
+
+    pairs = set()
+    for v in check_silk_over_copper(pcb, _rules()).violations:
+        silk = re.sub(r" \(\w+\)$", "", v.items[0])
+        pad = re.sub(r" pad ", ":", v.items[1])
+        pairs.add((silk, pad))
+    return pairs
+
+
+@pytest.mark.parametrize("rel_path", sorted(_KICAD_CLI_SILK_OVER_COPPER_PAIRS))
+def test_silk_over_copper_pair_parity_with_kicad_cli(rel_path):
+    """kct's (silk, pad) pair SET equals kicad-cli's, not just the count.
+
+    AC2 (exact count parity: 4 / 12 / 7 / 5) and AC3 (pair identity, so a
+    multi-pad straddle names every pad rather than an arbitrary representative)
+    of #4612.
+    """
+    import os
+
+    path = os.path.join(_BOARD_ROOT, rel_path)
+    if not os.path.exists(path):
+        pytest.skip(f"board fixture not present: {path}")
+
+    expected = _KICAD_CLI_SILK_OVER_COPPER_PAIRS[rel_path]
+    actual = _kct_pair_set(PCB.load(path))
+    assert actual == expected
+    assert len(actual) == len(expected)
+
+
+def test_board_05_u10_names_all_four_straddled_pads():
+    """The board-05 ``U10`` refdes names pads 27, 28, 29 AND 30.
+
+    The concrete AC3 case: before #4612 kct reported only ``U10 pad 28``, an
+    arbitrary R-tree-ordered member of the real collision set.
+    """
+    import os
+
+    path = os.path.join(
+        _BOARD_ROOT, "05-bldc-motor-controller/output/bldc_controller_routed.kicad_pcb"
+    )
+    if not os.path.exists(path):
+        pytest.skip(f"board fixture not present: {path}")
+
+    pairs = _kct_pair_set(PCB.load(path))
+    u10_pads = sorted(pad.split(":")[1] for silk, pad in pairs if silk == "U10")
+    assert u10_pads == ["27", "28", "29", "30"]
+
+
+@pytest.mark.parametrize(
+    "rel_path",
+    sorted(_KICAD_CLI_SILK_OVER_COPPER_PAIRS)
+    + [
+        "01-voltage-divider/output/voltage_divider_routed.kicad_pcb",
+        "02-charlieplex-led/output/charlieplex_3x3_routed.kicad_pcb",
+        "04-stm32-devboard/output/stm32_devboard_routed.kicad_pcb",
+    ],
+)
+def test_silk_overlap_zero_on_all_committed_boards(rel_path):
+    """kicad-cli reports zero ``silk_overlap`` on every committed board.
+
+    ``silk_overlap`` is NOT in the DRC report's ``ignored_checks``, so the test
+    genuinely ran and genuinely found nothing (the fleet's silkscreen is refdes
+    text only).  kct must agree -- this is the no-false-positive guard for the
+    new rule, the analogue of ``test_clean_boards_no_false_positives``.
+    """
+    import os
+
+    path = os.path.join(_BOARD_ROOT, rel_path)
+    if not os.path.exists(path):
+        pytest.skip(f"board fixture not present: {path}")
+
+    results = check_silk_overlap(PCB.load(path), _rules())
+    assert len(results) == 0, [tuple(v.items) for v in results.violations]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

`kct check` and `kicad-cli pcb drc` are used as referees for each other at manufacturing sign-off, but they reported `silk_over_copper` counts that differed by ~2x, and `kct` had no `silk_overlap` producer at all — so an entire kicad-cli rule class was invisible to a kct-only workflow.

The curator's triage is confirmed and reproduced: **kct's geometry was never wrong.** The whole gap was one line — `break  # one violation per silk element` at `silkscreen.py:615`. kicad-cli emits one violation per **(silk item, mask aperture) pair**; kct de-duplicated to one per silk element. A second defect fell out of the same `break`: because it stopped at the first STRtree hit, the pad kct named was an **arbitrary R-tree-ordered member** of the collision set (board 05 said `U10 pad 28`; the real set is pads 27, 28, 29, 30), so findings were not actionable.

This PR makes kct's counting model match kicad-cli's, and adds the missing `silk_overlap` producer.

## Changes

- **`src/kicad_tools/validate/rules/silkscreen.py`** (primary)
  - Removed the per-element `break` in `check_silk_over_copper`; every colliding pair is now emitted. Violations are sorted by `(silk label, pad label)` because `STRtree.query` order is unspecified.
  - The `_MIN_OVERLAP_AREA_MM2` gate stays **per-pair** (its current placement) — that is the reading the per-pair counting model implies, and it is called out in the docstring.
  - Added `check_silk_overlap`, reusing `_iter_silk_geometries` (no second traversal). Partitions by side, builds one `STRtree` per side, skips `j <= i` so self-pairs are excluded and each unordered pair is emitted once. Comparison is **by index**, not geometry, so two identical refdes boxes on different parts still pair with each other.
  - Merged it into `check_all_silkscreen`.
  - Documented the counting model on all three geometric checks and in the module docstring (AC8).
  - Documented the pad-only aperture scope on `_iter_pad_apertures`, with the measured untented-via divergence (AC7).
- **`src/kicad_tools/validate/checker.py`** — docstring only (verified: `git diff` touches nothing but the docstring).
- **`tests/test_validate_silkscreen.py`** — per-pair granularity, multi-pad straddle, determinism, the synthetic `silk_overlap` fixture + negative controls, and cross-gate pair-set parity tests.
- **`tests/test_validate.py`** — one mechanical count update: `check_all_silkscreen` now runs 6 rules, not 5.
- **`CHANGELOG.md`** — `Unreleased` entry covering the user-visible count change, the new rule, and the known limitation.

**`src/kicad_tools/cli/check_cmd.py` is NOT modified** — the silkscreen group at `check_cmd.py:2045` picks the new rule up automatically, exactly as #3849 established. `drc/violation.py`, `validate/filters.py`, and `feedback/suggestions.py` are also untouched (all three already carried the `silk_overlap` plumbing).

## Acceptance Criteria Verification

### AC1 — Per-pair granularity ✅
The `break` is gone. Verified by `test_one_violation_per_silk_aperture_pair` (a refdes over 2 pads now yields 2 violations, naming `U1 pad 1` and `U1 pad 2`).

### AC2 / AC3 — Exact fleet parity, on the **pair set**, not just the count ✅

Re-measured today against `kicad-cli` 10.0.5 (`pcb drc --refill-zones --severity-all --format json`) on **copies** of the committed boards in a scratch directory. The curator's 4/12/7/5 literals reproduce exactly.

**Before** (the `break` still present):

```
=== b03  kct=2  kicad-cli=4  match=False
    ONLY-CLI : [('C11', 'C10:1'), ('R11', 'R10:1')]
=== b05  kct=6  kicad-cli=12  match=False
    ONLY-CLI : [('Q1', 'R20:1'), ('Q3', 'R21:2'), ('Q5', 'R22:2'), ('U10', 'U10:27'), ('U10', 'U10:29'), ('U10', 'U10:30')]
=== b06  kct=4  kicad-cli=7  match=False
    ONLY-CLI : [('U1', 'U1:12'), ('U3', 'U3:18'), ('U4', 'U4:10')]
=== b07  kct=3  kicad-cli=5  match=False
    ONLY-CLI : [('U3', 'U3:10'), ('U5', 'U5:18')]
TOTAL kct=15 kicad-cli=28
```

**After:**

```
=== b03  kct=4  kicad-cli=4  match=True
    kct : C11      <-> C10:1
    kct : C11      <-> C10:2
    kct : R11      <-> R10:1
    kct : R11      <-> R10:2
=== b05  kct=12  kicad-cli=12  match=True
    kct : C7       <-> C4:2
    kct : C8       <-> C5:1
    kct : Q1       <-> R20:1
    kct : Q1       <-> R20:2
    kct : Q3       <-> R21:1
    kct : Q3       <-> R21:2
    kct : Q5       <-> R22:1
    kct : Q5       <-> R22:2
    kct : U10      <-> U10:27
    kct : U10      <-> U10:28
    kct : U10      <-> U10:29
    kct : U10      <-> U10:30
=== b06  kct=7  kicad-cli=7  match=True
    kct : U1       <-> U1:12
    kct : U1       <-> U1:13
    kct : U2       <-> U2:A4
    kct : U3       <-> U3:18
    kct : U3       <-> U3:19
    kct : U4       <-> U4:10
    kct : U4       <-> U4:9
=== b07  kct=5  kicad-cli=5  match=True
    kct : U3       <-> U3:10
    kct : U3       <-> U3:9
    kct : U4       <-> U4:A4
    kct : U5       <-> U5:18
    kct : U5       <-> U5:19
TOTAL kct=28 kicad-cli=28
```

**Exact pair-set equality on all four boards. Zero residue** — not one pair differs in either direction. Board 03 yields both `R11 <-> R10 pad 1` and `pad 2`; board 05 yields `U10 <-> U10 pads 27, 28, 29, 30`.

Locked in by `test_silk_over_copper_pair_parity_with_kicad_cli` (asserts the full pair **set**) and `test_board_05_u10_names_all_four_straddled_pads`.

End-to-end through the CLI, unchanged code path:

```
$ kct check <scratch>/b05.kicad_pcb --mfr jlcpcb-tier1 --only silkscreen
  [!] silk_over_copper
      Silkscreen U10 (reference) overlaps exposed copper of U10 pad 27
  [!] silk_over_copper
      Silkscreen U10 (reference) overlaps exposed copper of U10 pad 28
  ...
DRC:       PASSED   (6 rules checked, 0 error(s), 14 warning(s))
```

14 = 12 `silk_over_copper` + 2 `silk_edge_clearance`, matching kicad-cli's 12 + 2 on the same board.

### AC4 — No new false positives ✅
`test_clean_boards_no_false_positives` is **untouched** and green: boards 01/02/04 still yield zero `silk_over_copper` and zero `silk_edge_clearance`.

### AC5 — `silk_overlap` producer exists ✅
`check_silk_overlap` emits `rule_id="silk_overlap"` at `severity="warning"`, merged into `check_all_silkscreen`, reachable with **no** `cli/check_cmd.py` change:

```
$ kct check <scratch>/probe.kicad_pcb --mfr jlcpcb-tier1 --only silkscreen --verbose
      0 errors, 2 warnings, 0 infos  [silk_overlap]
  [!] silk_overlap
      Silkscreen A1 (reference) overlaps silkscreen A1 (fp_line)
  [!] silk_overlap
      Silkscreen B1 (reference) overlaps silkscreen C1 (reference)
```

### AC6 — Self-pairing excluded; same-footprint policy decided by measurement ✅

An element never pairs with itself (`test_element_never_pairs_with_itself`), and each unordered pair is emitted once (`test_pair_emitted_only_once`).

For the same-footprint question the issue nominates kicad-cli as the tiebreaker, so I measured it. As the curator established, **no committed board can serve as a fixture** — kicad-cli reports 0 `silk_overlap` on all of them, `silk_overlap` is *not* in the report's `ignored_checks` (verified: the only ignored key is `missing_courtyard`), and the fleet's silk is refdes text only with zero footprint graphics. I hand-authored a probe `.kicad_pcb` with A1 (refdes over its own `fp_line`), B1/C1 (overlapping refdes on different footprints), D1 (clear, negative control):

```
$ kicad-cli pcb drc --severity-all --format json -o probe.drc.json probe.kicad_pcb
silk_overlap | warning | Reference field of A1  <->  Segment of A1 on F.Silkscreen
silk_overlap | warning | Reference field of B1  <->  Reference field of C1
silk_over_copper | warning | Segment on F.Silkscreen  <->  Via [GND] on F.Cu - B.Cu
```

**Verdict: same-footprint pairs DO count** — a refdes over its own courtyard art is a real finding, so the rule filters neither case. Stated in the `check_silk_overlap` docstring with the measurement quoted verbatim.

kct against the same fixture:

```
probe.kicad_pcb        kct=2   kicad-cli=2
      kct : A1 (reference)  <->  A1 (fp_line)
      kct : B1 (reference)  <->  C1 (reference)
      cli : Reference field of A1  <->  Segment of A1 on F.Silkscreen
      cli : Reference field of B1  <->  Reference field of C1
```

Exact pair-set match. And on all 7 committed boards, kct agrees with kicad-cli's zero:

```
b01.kicad_pcb          kct=0   kicad-cli=0
b02.kicad_pcb          kct=0   kicad-cli=0
b03.kicad_pcb          kct=0   kicad-cli=0
b04.kicad_pcb          kct=0   kicad-cli=0
b05.kicad_pcb          kct=0   kicad-cli=0
b06.kicad_pcb          kct=0   kicad-cli=0
b07.kicad_pcb          kct=0   kicad-cli=0
```

That is the no-false-positive guard for the new rule, locked in by `test_silk_overlap_zero_on_all_committed_boards`.

### AC7 — Aperture-set scope stated, **and measured** ✅

Documented on `_iter_pad_apertures` as pad-only. The probe run above also settles the untented-via question empirically rather than by assertion: with `(tenting (front no) (back no))` and one silk segment across a via, **kicad-cli reports the finding and kct reports 0**.

```
kct silk_over_copper on probe: 0 []
kicad-cli silk_over_copper on probe: 1
    Segment on F.Silkscreen  <->  Via [GND] on F.Cu - B.Cu
```

**This is the one measured residue** after pair parity — see "Residue" below. The committed fleet all set `(tenting (front yes) (back yes))`, so no fleet via has a mask opening and the gap is invisible there; kicad-cli names a *pad* in every one of its fleet `silk_over_copper` findings.

### AC8 — Cross-gate documentation ✅
The module docstring plus all three of `check_silk_over_copper` / `check_silk_overlap` / `check_silk_edge_clearance` state their counting model, so a future reader can tell whether a count mismatch is a bug or a convention. `silk_edge_clearance` is documented as per-(silk item, outline) — i.e. per silk item, since the outline is one object — precisely because it differs from `silk_over_copper`.

### AC9 — Regression guard against silent re-collapse ✅
`test_multi_pad_straddle_names_every_pad` asserts `len(results) >= 3` for a refdes over 4 apertures **and** the exact pad list `["U10 pad 27", "U10 pad 28", "U10 pad 29", "U10 pad 30"]`. A future "de-dup for readability" change cannot pass it. The `break`'s absence also carries an inline comment naming the issue.

### AC10 — Board baselines reconciled ✅
`tests/router/test_board03_routing_baseline.py::test_committed_pcb_drc_state` (which holds `EXPECTED_COMMITTED_DRC_RULES`) and `tests/test_board_01_ship_ready.py` both pass unmodified — they assert rule-**id** sets, and `silk_over_copper` was already in the set, so doubling its count changes nothing.

```
$ pytest tests/test_board_01_ship_ready.py tests/router/test_board03_routing_baseline.py::test_committed_pcb_drc_state -q
5 passed in 6.38s
```

## Test Plan

```
$ pytest tests/test_validate_silkscreen.py -q
48 passed in 51.74s

$ pytest tests/test_drc.py tests/test_drc_category.py tests/test_drc_summary.py \
         tests/test_violation_filters.py tests/test_suggestions.py \
         tests/test_check_cmd_coverage.py tests/test_audit.py -q
444 passed in 66.31s

$ pytest tests/test_validate.py -q
87 passed, 5 skipped in 0.46s

$ pytest -n auto --benchmark-disable -m "not slow" -q
1 failed, 24141 passed, 92 skipped in 466.90s
```

The single full-suite failure is `test_placement_seed.py::TestForceDirectedPlacement::test_performance_20_components`, a wall-clock timing test unrelated to silkscreen; it passes standalone (`1 passed in 0.52s`) and only trips under `-n auto` parallel load.

Lint / format / types:

```
$ ruff check .        -> All checks passed!
$ ruff format --check . -> 1726 files already formatted
$ python scripts/ci/check_mypy_baseline.py
OK: mypy reports 1473 error(s), all within the baseline (1474 allowed). No new type errors.
```

(The "1 baseline error no longer occurs" warning is the known native-worktree nanobind artifact — `.github/mypy-baseline.txt:59-60` keeps both signatures deliberately. The baseline is **not** updated here.)

Edge cases covered by new tests: hidden text skipped, empty-string text skipped, back-side silk never pairs with front-side silk, board-level `gr_text` **and** `gr_line` participate in `silk_overlap`, a board with zero silk returns cleanly rather than raising, and minimum-width strokes crossing at right angles survive the area gate.

All `kicad-cli` and `kct` runs used **copies** of the boards in a scratch directory outside the repository; `check-main-clean.sh` reports the main worktree clean.

## Notes for review

**Deliberate scope omission.** `src/kicad_tools/validate/rules/__init__.py` re-exports `check_silk_over_copper` / `check_silk_edge_clearance` / `check_all_silkscreen`, and symmetry would add `check_silk_overlap` there. I left it out to honour the issue's explicit scope reservation (`silkscreen.py` plus a docstring-only `checker.py` touch). Nothing depends on the barrel — every caller and test imports from `validate.rules.silkscreen` directly, and the rule is fully reachable via `check_all_silkscreen`. Happy to add the two lines if a reviewer prefers the symmetry.

**Residue for a follow-up (not filed — reporting to the operator per instruction).** Pair parity on the committed fleet is exact with zero residue, so the only measured gap is the untented-via aperture from AC7: kicad-cli 1, kct 0 on the probe board. Closing it needs per-via tenting resolution (board `setup` default plus per-via override), which this module does not currently parse — a genuinely separate change with its own false-positive profile. The other suspected blind spots the curator listed (arc/circle strokes dropped by `_stroke_geometry`, non-rotating pad-aperture AABB, glyph metrics, the `0.05 mm²` gate) remain **unexercised and unrefuted** — the fleet has 0 rotated footprints and 0 silk graphics, so nothing here proves or disproves them, and they stay explicitly out of scope.

Closes #4612
