### PR TITLE
fix(lattice): honor the net-class clearance of --preserve-existing copper

### DIFF
--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -777,6 +777,46 @@ so it does, then re-run the tile.
 > the board, plants the cross-region boundary stubs, and routes the tiles in
 > sequence automatically, making this recipe a single command.
 
+### Preserved copper keeps its `--net-class-map` clearance (lattice engine)
+
+Any multi-step composition (`--region`, `--nets`, or an explicit
+`--preserve-existing`) routes one group of nets per step and treats the copper
+from earlier steps as a fixed obstacle. On the **lattice** engine
+(`--engine lattice`) that preserved copper is spaced at the
+`--net-class-map` clearance **of the preserved net**, not merely at the
+board-global DRU clearance
+([#4597](https://github.com/rjwalters/kicad-tools/issues/4597)). The required
+edge-to-edge gap between new copper and preserved copper is
+
+```
+max(new_net_class_clearance, preserved_net_class_clearance)
+```
+
+floored at `DesignRules.trace_clearance` — the same rule that applies to two
+nets routed in a single pass, so a step boundary no longer changes the answer.
+This is what makes the HV-outer recipe (route the mains group first, then the
+low-voltage group with a map that puts 2.0–3.2 mm on the HV nets) actually
+enforce those isolation gaps; before this the cross-step pairs collapsed to
+the DRU floor (~0.2 mm) and passed DRC silently.
+
+Practical consequence: **carry the HV entries in every step's map**, not just
+the step that routes them. A preserved net with no entry in the current step's
+map resolves to the global clearance exactly as before.
+
+Not covered — document, do not assume:
+
+- **`--engine grid`** blocks preserved routes at
+  `segment_width / 2 + DesignRules.trace_clearance` for all routes, preserved
+  or fresh; per-net class clearance is not applied to preserved copper there.
+- **`--engine mesh`** inflates its preserved-copper obstacles at the global
+  `trace_width + trace_clearance` and its committed model is net-agnostic, so
+  it cannot express a per-net clearance at all.
+- **Class-pair (pairwise) clearance** — the voltage-matrix mechanism is a
+  separate feature and is not applied to preserved copper by this rule.
+- **Via-to-via**: a *new* via applies its own class clearance to preserved
+  copper traces, and honors a preserved via's class clearance, but a new via
+  does not yet apply *its own* class clearance against other vias.
+
 ---
 
 ## See Also

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -2897,6 +2897,28 @@ class Autorouter:
         # this the lattice sees the non-listed pads but not the traces between
         # them and legally crosses foreign copper -> segment-segment shorts.
         fixed_copper = [r for r in self.existing_routes if r.net not in self.nets]
+        # Issue #4597: preserved copper keeps its NET-CLASS clearance across the
+        # pass boundary.  ``--preserve-existing`` composition (the documented
+        # 2-step HV-outer recipe, generalized to voltage-binned groups) routes
+        # one group per step with a per-step --net-class-map whose entries carry
+        # large HV clearances; without this resolution every preserved segment
+        # seeded at the board-global DRU floor, so ``max(own_clr, stored_clr)``
+        # in ``CommittedCopper`` collapsed to the ROUTING net's own clearance
+        # and cross-step pairs landed at 0.166-0.2 mm instead of the mapped
+        # 2.0-3.2 mm.  Resolve exactly as the listed-net branch above does
+        # (``self.net_class_map[net_name]``, floor at ``rules.trace_clearance``)
+        # so a preserved net is spaced identically to the same net routed
+        # in-pass.  The pathfinder stays geometry-only: it receives a plain
+        # ``{net_id: clearance}`` map, never the name-keyed class table.
+        fixed_clearance: dict[int, float] = {}
+        for route in fixed_copper:
+            if route.net in fixed_clearance:
+                continue
+            name = self.net_names.get(route.net) or getattr(route, "net_name", None)
+            nc = self.net_class_map.get(name) if name else None
+            clr = getattr(nc, "clearance", None) or 0.0
+            if clr > self.rules.trace_clearance:
+                fixed_clearance[route.net] = clr
         # Issue #4472: per-link wall-clock deadline.  ``--complete`` stamps a
         # per-link budget so each completion search aborts within a bounded
         # budget instead of grinding (issue #4434's >10-minute non-termination)
@@ -2911,6 +2933,7 @@ class Autorouter:
             connections,
             coupled=coupled,
             fixed_copper=fixed_copper,
+            fixed_clearance=fixed_clearance,
             max_iterations=max_iterations,
             deadline=deadline,
         )

--- a/src/kicad_tools/router/grid.py
+++ b/src/kicad_tools/router/grid.py
@@ -4247,6 +4247,13 @@ class RoutingGrid:
         positions inward.  The extra cell ensures the blocked envelope is
         always at least as large as the geometric clearance requirement.
 
+        Issue #4597 (scope note): the blocking radius uses the board-global
+        ``rules.trace_clearance`` for EVERY route, preserved or fresh -- this
+        engine does not apply a preserved net's ``--net-class-map`` clearance,
+        so multi-step ``--preserve-existing`` composition still spaces
+        cross-step pairs at the DRU floor here.  Only ``--engine lattice``
+        carries the per-net clearance across the pass boundary.
+
         Args:
             route: The route to mark on the grid.
             max_trace_width: Maximum trace width across all net classes.

--- a/src/kicad_tools/router/lattice/coupled.py
+++ b/src/kicad_tools/router/lattice/coupled.py
@@ -186,8 +186,11 @@ def committed_seg_clear_grown(
         gap = committed.trace_half + hw + max(committed.clearance, iclr) + extra
         if cnet not in nets and seg_seg_dist(a, b, c, d) < gap - _EPS:
             return False
-    vgap = committed.via_radius + committed.clearance + committed.trace_half + extra
-    for point, vnet in committed.vias:
+    # Issue #4597: honor the stored via's class clearance, mirroring the
+    # ``max(clearance, iclr)`` the copper loop above already applies.
+    base_vgap = committed.via_radius + committed.trace_half + committed.clearance + extra
+    for point, vnet, vclr in committed.vias:
+        vgap = base_vgap if vclr <= committed.clearance else base_vgap - committed.clearance + vclr
         if vnet not in nets and seg_pt_dist(a, b, point) < vgap - _EPS:
             return False
     return True
@@ -206,8 +209,11 @@ def committed_point_clear_grown(
         gap = committed.trace_half + hw + max(committed.clearance, iclr) + extra
         if cnet not in nets and seg_pt_dist(c, d, point) < gap - _EPS:
             return False
-    vgap = committed.via_radius + committed.clearance + committed.trace_half + extra
-    for vpt, vnet in committed.vias:
+    # Issue #4597: honor the stored via's class clearance (see
+    # ``committed_seg_clear_grown``).
+    base_vgap = committed.via_radius + committed.trace_half + committed.clearance + extra
+    for vpt, vnet, vclr in committed.vias:
+        vgap = base_vgap if vclr <= committed.clearance else base_vgap - committed.clearance + vclr
         if vnet not in nets and dist(point, vpt) < vgap - _EPS:
             return False
     return True

--- a/src/kicad_tools/router/lattice/obstacles.py
+++ b/src/kicad_tools/router/lattice/obstacles.py
@@ -187,6 +187,13 @@ class CommittedCopper:
     KiCad's conditional-rule semantics, where the wider constraint governs
     when either net is in the class).  ``None`` arguments fall back to the
     board-global trace geometry -- the pre-#4271 behavior, byte-for-byte.
+
+    Issue #4597 (preserved copper): committed VIAS carry a stored clearance
+    too, so ``seg_clear`` / ``node_clear`` space a trace from a via at
+    ``via_radius + own_half + max(own_clearance, stored_via_clearance)``.
+    That is what lets ``--preserve-existing`` copper seeded from an earlier
+    routing step keep its net-class-map clearance across the pass boundary
+    instead of collapsing to the board-global floor.
     """
 
     def __init__(
@@ -206,7 +213,12 @@ class CommittedCopper:
         self.via_via_gap = via_via_gap  # via centre to via centre (cross-net)
         self.same_net_via_gap = same_net_via_gap  # hole-to-hole floor
         self.copper: list[SegHash] = [SegHash() for _ in range(num_layers)]
-        self.vias: list[tuple[Pt, int]] = []
+        # ``(point, net, clearance)`` -- the stored clearance is the via's own
+        # net-class clearance (issue #4597), defaulting to the board-global
+        # floor.  It participates in ``max(own_clr, stored_clr)`` exactly the
+        # way a stored SEGMENT's clearance does, so a preserved HV via keeps
+        # its class gap instead of collapsing to the global via gap.
+        self.vias: list[tuple[Pt, int, float]] = []
 
     # -- mutation --------------------------------------------------------
 
@@ -247,9 +259,14 @@ class CommittedCopper:
             if dist(a, b) > 1e-9:
                 self.copper[layer].add(a, b, net, hw, clr)
 
-    def add_via(self, point: Pt, net: int) -> None:
-        """Commit a through-via (blocks the site on ALL layers)."""
-        self.vias.append((point, net))
+    def add_via(self, point: Pt, net: int, clearance: float | None = None) -> None:
+        """Commit a through-via (blocks the site on ALL layers).
+
+        ``clearance`` is the via's own net-class clearance (issue #4597);
+        ``None`` -> the board-global clearance, which is exactly the pre-#4597
+        behavior for every caller that does not pass one.
+        """
+        self.vias.append((point, net, self.clearance if clearance is None else clearance))
 
     # -- predicates --------------------------------------------------------
 
@@ -275,9 +292,15 @@ class CommittedCopper:
             gap = own_half + hw + max(own_clr, iclr)
             if cnet != net and seg_seg_dist(a, b, c, d) < gap - 1e-9:
                 return False
-        via_gap = self.via_radius + own_clr + own_half
-        for point, vnet in self.vias:
+        # Issue #4597: honor the STORED via's class clearance the same way the
+        # copper loop above honors a stored segment's -- a preserved HV via must
+        # be cleared at its own class gap, not merely at the querying net's.
+        # ``max`` can only grow the gap, so a via stored at the global floor
+        # takes the precomputed ``own_via_gap`` and is byte-identical.
+        own_via_gap = self.via_radius + own_half + own_clr
+        for point, vnet, vclr in self.vias:
             if vnet != net:
+                via_gap = own_via_gap if vclr <= own_clr else self.via_radius + own_half + vclr
                 if seg_pt_dist(a, b, point) < via_gap - 1e-9:
                     return False
             elif seg_body_crosses_pt(a, b, point):
@@ -306,8 +329,10 @@ class CommittedCopper:
             gap = own_half + hw + max(own_clr, iclr)
             if cnet != net and seg_pt_dist(c, d, point) < gap - 1e-9:
                 return False
-        via_gap = self.via_radius + own_clr + own_half
-        for vpt, vnet in self.vias:
+        # Issue #4597: ``max(own_clr, stored_via_clr)`` -- see ``seg_clear``.
+        own_via_gap = self.via_radius + own_half + own_clr
+        for vpt, vnet, vclr in self.vias:
+            via_gap = own_via_gap if vclr <= own_clr else self.via_radius + own_half + vclr
             if vnet != net and dist(point, vpt) < via_gap - 1e-9:
                 return False
         return True
@@ -319,6 +344,12 @@ class CommittedCopper:
         The via-to-trace gap honors each stored segment's TRUE half-width
         and class clearance (#4271): ``via_radius + stored_half +
         max(global_clearance, stored_clearance)``.
+
+        Issue #4597 (one-sided): the cross-net via-to-via gap also grows to the
+        STORED via's class clearance.  This method takes no querying-net
+        clearance argument at all, so the querying via's own class clearance is
+        still not applied to via-to-via pairs -- a pre-existing #4271 residual
+        that is deliberately NOT widened here.
         """
         pad = self.via_radius + self.clearance + self.trace_half + 2.0
         for layer in range(self.num_layers):
@@ -326,7 +357,7 @@ class CommittedCopper:
                 gap = self.via_radius + hw + max(self.clearance, iclr)
                 if cnet != net and seg_pt_dist(c, d, point) < gap - 1e-9:
                     return False
-        for vpt, vnet in self.vias:
+        for vpt, vnet, vclr in self.vias:
             # Cross-net vias must honor BOTH the copper gap (via_via_gap =
             # via diameter + clearance, centre-to-centre) AND the drill
             # hole-to-hole floor (same_net_via_gap = via_drill +
@@ -335,7 +366,12 @@ class CommittedCopper:
             # 0.5mm floor (issue #4291: 16 hole_to_hole DRC warnings on the
             # softstart P4 run of record).
             if vnet != net:
-                gap = max(self.via_via_gap, self.same_net_via_gap)
+                # ``2 * via_radius + vclr`` re-derives the copper gap at the
+                # STORED via's class clearance (``via_via_gap`` itself is
+                # ``via_diameter + global_clearance``), so a preserved HV via
+                # keeps its class gap.  ``max`` never shrinks the gap: a via
+                # stored at the global floor is byte-identical (#4597).
+                gap = max(self.via_via_gap, 2.0 * self.via_radius + vclr, self.same_net_via_gap)
             else:
                 gap = self.same_net_via_gap
             if dist(point, vpt) < gap - 1e-9:

--- a/src/kicad_tools/router/lattice/pathfinder.py
+++ b/src/kicad_tools/router/lattice/pathfinder.py
@@ -266,14 +266,22 @@ class LatticePathfinder:
         self.pair_outcomes: dict[object, str] = {}
         # Issue #4355: immovable copper from NON-listed nets (the preserved
         # ``router.existing_routes``), pre-processed into per-segment seed
-        # tuples ``(layer_idx, a, b, net, half_width)`` plus via sites
-        # ``(point, net)``.  Every fresh CommittedCopper model is pre-seeded
-        # with these so a negotiated net spaces against the fixed copper as a
-        # HARD geometric block -- routes around it or is honestly reported
-        # unroutable, never shipped as a short.  Empty (the default) preserves
-        # the pre-#4355 behavior byte-for-byte.
-        self._fixed_runs: list[tuple[int, Pt, Pt, int, float]] = []
-        self._fixed_vias: list[tuple[Pt, int]] = []
+        # tuples ``(layer_idx, a, b, net, half_width, clearance)`` plus via
+        # sites ``(point, net, clearance)``.  Every fresh CommittedCopper model
+        # is pre-seeded with these so a negotiated net spaces against the fixed
+        # copper as a HARD geometric block -- routes around it or is honestly
+        # reported unroutable, never shipped as a short.  Empty (the default)
+        # preserves the pre-#4355 behavior byte-for-byte.
+        #
+        # Issue #4597: the per-seed CLEARANCE is the preserved net's own
+        # net-class clearance (resolved by the caller and handed to
+        # :meth:`route_netset` as ``fixed_clearance``), floored at
+        # ``rules.trace_clearance``.  Before this the seed hardcoded the
+        # board-global floor, so a multi-step ``--preserve-existing``
+        # composition silently spaced new copper at the DRU floor from an HV
+        # net the net-class map put at 2.0-3.2 mm.
+        self._fixed_runs: list[tuple[int, Pt, Pt, int, float, float]] = []
+        self._fixed_vias: list[tuple[Pt, int, float]] = []
 
     # -- construction from a board ----------------------------------------
 
@@ -400,29 +408,52 @@ class LatticePathfinder:
         """Commit the preserved non-listed copper into ``committed`` (#4355).
 
         Each preserved segment is committed under its OWN net id at its emitted
-        half-width and the board-global clearance floor -- a hard geometric
-        block that ``route_netset`` declines to cross (never shipped as a
-        short).  Same-net exemption in :meth:`CommittedCopper.seg_clear` means
-        seeding a listed net's own stale copper (if any slipped into the fixed
-        set) cannot block that net's fresh route.  Each preserved via seeds
-        ``committed.vias`` (a through-via blocks every layer).
-        """
-        clr = self.rules.trace_clearance
-        for layer_idx, a, b, net, half in self._fixed_runs:
-            committed.add_run(layer_idx, [a, b], net, half, clr)
-        for point, net in self._fixed_vias:
-            committed.add_via(point, net)
+        half-width and its OWN net-class clearance (issue #4597) -- a hard
+        geometric block that ``route_netset`` declines to cross (never shipped
+        as a short).  Same-net exemption in :meth:`CommittedCopper.seg_clear`
+        means seeding a listed net's own stale copper (if any slipped into the
+        fixed set) cannot block that net's fresh route.  Each preserved via
+        seeds ``committed.vias`` at that same clearance (a through-via blocks
+        every layer).
 
-    def _set_fixed_copper(self, routes: list[Route] | None) -> None:
+        Nets with no resolved class clearance seed at ``rules.trace_clearance``
+        exactly as before #4597.
+        """
+        for layer_idx, a, b, net, half, clr in self._fixed_runs:
+            committed.add_run(layer_idx, [a, b], net, half, clr)
+        for point, net, clr in self._fixed_vias:
+            committed.add_via(point, net, clr)
+
+    def _fixed_clearance_for(self, net: int, clearances: dict[int, float] | None) -> float:
+        """Seed clearance for preserved net ``net`` (issue #4597).
+
+        Same floor semantics as :meth:`_conn_geometry`: a class may only GROW
+        the gap, never shrink it below ``rules.trace_clearance``.  An unmapped
+        net (or ``clearances is None``) resolves to the board-global floor --
+        the pre-#4597 behavior, byte-for-byte.
+        """
+        if not clearances:
+            return self.rules.trace_clearance
+        return max(clearances.get(net) or 0.0, self.rules.trace_clearance)
+
+    def _set_fixed_copper(
+        self,
+        routes: list[Route] | None,
+        clearances: dict[int, float] | None = None,
+    ) -> None:
         """Pre-process preserved ``Route``s into flat seed tuples (#4355).
 
         Called once by :meth:`route_netset`; maps each segment's layer enum to
         a lattice layer index (dropping copper on non-routing layers) and each
         via to a site.  ``None``/empty resets the seed set so a reused
         pathfinder does not carry stale fixed copper.
+
+        ``clearances`` (issue #4597) is a plain ``{net_id: clearance}`` map the
+        CALLER resolved from its net-class map -- the pathfinder stays
+        geometry-only and never sees net names or net classes.
         """
-        runs: list[tuple[int, Pt, Pt, int, float]] = []
-        vias: list[tuple[Pt, int]] = []
+        runs: list[tuple[int, Pt, Pt, int, float, float]] = []
+        vias: list[tuple[Pt, int, float]] = []
         for route in routes or []:
             for seg in getattr(route, "segments", []):
                 try:
@@ -438,9 +469,13 @@ class LatticePathfinder:
                 if dist(a, b) <= 1e-9:
                     continue
                 half = (getattr(seg, "width", None) or self.rules.trace_width) / 2.0
-                runs.append((layer_idx, a, b, seg.net, half))
+                runs.append(
+                    (layer_idx, a, b, seg.net, half, self._fixed_clearance_for(seg.net, clearances))
+                )
             for via in getattr(route, "vias", []):
-                vias.append(((via.x, via.y), via.net))
+                vias.append(
+                    ((via.x, via.y), via.net, self._fixed_clearance_for(via.net, clearances))
+                )
         self._fixed_runs = runs
         self._fixed_vias = vias
 
@@ -1680,6 +1715,7 @@ class LatticePathfinder:
         *,
         coupled: list[CoupledConnection] | None = None,
         fixed_copper: list[Route] | None = None,
+        fixed_clearance: dict[int, float] | None = None,
         max_iterations: int = 8,
         present_cost_initial: float = 1.0,
         present_cost_growth: float = 1.6,
@@ -1722,6 +1758,16 @@ class LatticePathfinder:
         immovable hard obstacle, so a negotiated net routes AROUND it or is
         honestly declined -- it is never emitted overlapping foreign copper.
 
+        Issue #4597: ``fixed_clearance`` is a plain ``{net_id: clearance}`` map
+        giving each preserved net its net-class clearance, floored at
+        ``rules.trace_clearance`` (a class may only GROW the gap).  Without it
+        every preserved segment/via seeds at the board-global floor, so a
+        multi-step ``--preserve-existing`` composition spaced new copper at the
+        DRU floor from an HV net the map put at 2.0-3.2 mm -- the
+        ``max(own_clr, stored_clr)`` term in :class:`CommittedCopper` collapsed
+        to the routing net's own clearance.  ``None`` / ``{}`` / unmapped nets
+        preserve the pre-#4597 behavior byte-for-byte.
+
         Issue #4472: ``deadline`` is an optional absolute
         :func:`time.monotonic` timestamp.  When set, the negotiation aborts as
         soon as it is reached -- checked before each iteration and before each
@@ -1734,7 +1780,7 @@ class LatticePathfinder:
         # deadline check) so a report can honestly say "elapsed Xs of a Ys
         # budget" even on a run that never hits the deadline.
         start_time = time.monotonic()
-        self._set_fixed_copper(fixed_copper)
+        self._set_fixed_copper(fixed_copper, fixed_clearance)
         self.build()
         pairs = list(coupled or [])
 

--- a/src/kicad_tools/router/mesh/pathfinder.py
+++ b/src/kicad_tools/router/mesh/pathfinder.py
@@ -901,6 +901,14 @@ class MeshPathfinder:
         Called at the top of every negotiation pass (the dict is reset each
         pass), so the seed is re-applied per pass.  A ``None`` / empty seed adds
         nothing and is a byte-identical no-op.
+
+        Issue #4597 (scope note): unlike the lattice engine, this seed does NOT
+        carry the preserved net's ``--net-class-map`` clearance -- the capsules
+        are inflated at the board-global ``trace_width + trace_clearance`` and
+        the mesh committed model is net-AGNOSTIC (plain polygons with no per-net
+        field), so it cannot express a per-net clearance without a model change.
+        Multi-step ``--preserve-existing`` composition therefore still spaces
+        cross-step pairs at the DRU floor on ``--engine mesh``.
         """
         for route in fixed_copper or []:
             for lidx, polys in self._route_obstacles_by_layer(route).items():

--- a/tests/router/lattice/test_preserve_existing_obstacle.py
+++ b/tests/router/lattice/test_preserve_existing_obstacle.py
@@ -10,6 +10,13 @@ shipped a ``clearance_segment_segment`` SHORT.
 hard block, and therefore either routes AROUND the fixed copper or declines the
 connection as unroutable -- it never emits copper overlapping the fixed net.
 
+Issue #4597 extends that seed contract with the preserved net's CLASS
+clearance.  ``route_netset(..., fixed_clearance={net: clr})`` seeds each
+preserved segment/via at its own ``--net-class-map`` clearance instead of the
+board-global DRU floor, so a multi-step ``--preserve-existing`` composition
+(the documented HV-outer recipe) spaces cross-step pairs at the mapped gap --
+the same result the map produces when both nets are routed in one pass.
+
 These are fast unit-level checks (a handful of pads, no full board or
 ``kicad-cli``): they pin the seed contract that the CLI ``--nets`` /
 ``--preserve-existing`` paths depend on.
@@ -18,10 +25,11 @@ These are fast unit-level checks (a handful of pads, no full board or
 from __future__ import annotations
 
 from kicad_tools.router.lattice.geometry import seg_seg_dist
+from kicad_tools.router.lattice.obstacles import CommittedCopper
 from kicad_tools.router.lattice.pathfinder import LatticePathfinder
 from kicad_tools.router.layers import Layer, LayerStack
-from kicad_tools.router.primitives import Pad, Route, Segment
-from kicad_tools.router.rules import DesignRules
+from kicad_tools.router.primitives import Pad, Route, Segment, Via
+from kicad_tools.router.rules import DesignRules, NetClassRouting
 
 _OUTLINE = [(0.0, 0.0), (20.0, 0.0), (20.0, 20.0), (0.0, 20.0)]
 
@@ -163,3 +171,255 @@ def test_fixed_copper_empty_is_byte_identical_noop() -> None:
         segs_a = [(s.x1, s.y1, s.x2, s.y2, s.layer) for s in routes_none[key].segments]
         segs_b = [(s.x1, s.y1, s.x2, s.y2, s.layer) for s in routes_empty[key].segments]
         assert segs_a == segs_b
+
+
+# ---------------------------------------------------------------------------
+# Issue #4597: preserved copper keeps its NET-CLASS clearance across the pass
+# boundary (``--preserve-existing`` multi-step composition).
+# ---------------------------------------------------------------------------
+
+_HV_CLEARANCE = 2.0  # what a per-step --net-class-map puts on the HV net
+
+
+def _short_walls() -> list[Segment]:
+    """A stub wall on BOTH routing layers, short enough to route around.
+
+    The full-height wall of the #4355 fixtures forces a decline once the gap
+    grows to HV size; this one leaves a legal detour at either end on both
+    layers, so the test measures the SPACING the map produced rather than
+    merely "declined".
+    """
+    return [
+        _wall_segment(Layer.F_CU, y1=8.0, y2=12.0),
+        _wall_segment(Layer.B_CU, y1=8.0, y2=12.0),
+    ]
+
+
+def _min_gap_to_walls(routes: dict[object, Route], walls: list[Segment]) -> float:
+    """Smallest EDGE-to-EDGE copper gap between routed copper and ``walls``.
+
+    Centreline distance minus both half-widths, so the value is directly
+    comparable with a required clearance (what a DRC report measures).
+    """
+    best = float("inf")
+    for route in routes.values():
+        for seg in route.segments:
+            for wall in walls:
+                if seg.layer != wall.layer or seg.net == wall.net:
+                    continue
+                d = seg_seg_dist(
+                    (seg.x1, seg.y1),
+                    (seg.x2, seg.y2),
+                    (wall.x1, wall.y1),
+                    (wall.x2, wall.y2),
+                )
+                best = min(best, d - seg.width / 2.0 - wall.width / 2.0)
+    return best
+
+
+def _route_against_walls(
+    *,
+    fixed_clearance: dict[int, float] | None,
+    net_class: object | None = None,
+) -> tuple[dict[object, Route], object, list[Segment]]:
+    rules, stack, pads, _conns = _fixture()
+    walls = _short_walls()
+    conns = [((1, 0), pads[0], pads[1], net_class)]
+    pf = LatticePathfinder(_OUTLINE, pads, rules, layer_stack=stack)
+    routes, stats = pf.route_netset(
+        conns,
+        fixed_copper=[Route(net=2, net_name="N2", segments=walls)],
+        fixed_clearance=fixed_clearance,
+        max_iterations=6,
+    )
+    return routes, stats, walls
+
+
+def test_preserved_net_class_clearance_spaces_cross_step_pair() -> None:
+    """Cross-step spacing: a preserved net mapped at 2.0mm gets 2.0mm (#4597).
+
+    This is the reported defect: step 1 routes the HV net, step 2 routes an LV
+    net with ``--preserve-existing`` and a map putting 2.0mm on the HV net.
+    Pre-#4597 the preserved copper seeded at the board-global DRU floor, so the
+    LV copper landed at ~0.2mm from it.
+    """
+    baseline, base_stats, walls = _route_against_walls(fixed_clearance=None)
+    mapped, mapped_stats, _walls = _route_against_walls(fixed_clearance={2: _HV_CLEARANCE})
+
+    # Both actually route (the wall is short enough to detour around on either
+    # layer) -- the mapped run is spaced, not declined.
+    assert base_stats.routed == 1
+    assert mapped_stats.routed == 1
+
+    base_gap = _min_gap_to_walls(baseline, walls)
+    mapped_gap = _min_gap_to_walls(mapped, walls)
+
+    # Pre-fix behavior, pinned: without the map the gap collapses to the DRU
+    # floor and is nowhere near the 2.0mm the map asked for.
+    assert base_gap < _HV_CLEARANCE
+    # Post-fix: the preserved net's class clearance governs, exactly as it
+    # would if both nets had been routed in one pass.
+    assert mapped_gap >= _HV_CLEARANCE - 1e-6, f"mapped gap {mapped_gap:.4f} < {_HV_CLEARANCE}"
+
+
+def test_new_net_class_clearance_still_governs_reverse_pairing() -> None:
+    """Symmetry: preserved LV at the floor + new HV net mapped at 2.0mm (#4597).
+
+    ``max(own_clr, stored_clr)`` already gave this direction; the test pins
+    that the #4597 seed change does not regress it.
+    """
+    hv = NetClassRouting(name="HV", trace_width=0.2, clearance=_HV_CLEARANCE)
+    routes, stats, walls = _route_against_walls(fixed_clearance=None, net_class=hv)
+
+    assert stats.routed == 1
+    gap = _min_gap_to_walls(routes, walls)
+    assert gap >= _HV_CLEARANCE - 1e-6, f"reverse gap {gap:.4f} < {_HV_CLEARANCE}"
+
+
+def _geometry(routes: dict[object, Route]) -> list[tuple]:
+    return sorted(
+        (key[0], key[1], s.x1, s.y1, s.x2, s.y2, s.layer)
+        for key, route in routes.items()
+        for s in route.segments
+        if isinstance(key, tuple)
+    )
+
+
+def test_uniform_map_and_unmapped_nets_are_byte_identical_noops() -> None:
+    """A map that adds nothing above the DRU floor changes nothing (#4597).
+
+    Three no-op forms, all byte-identical to ``fixed_clearance=None``:
+    a uniform map at ``rules.trace_clearance``, a map naming only nets that are
+    not in the fixed set, and a map whose clearance is BELOW the floor (clamped
+    up by ``max``, never shrinking the gap).
+    """
+    rules, _stack, _pads, _conns = _fixture()
+    reference, _stats, _walls = _route_against_walls(fixed_clearance=None)
+
+    for label, clearances in (
+        ("uniform", {2: rules.trace_clearance}),
+        ("unmapped", {99: 3.0}),
+        ("below-floor", {2: 0.05}),
+        ("empty", {}),
+    ):
+        routes, stats, _w = _route_against_walls(fixed_clearance=clearances)
+        assert stats.routed == 1, label
+        assert _geometry(routes) == _geometry(reference), label
+
+
+def test_seed_tuples_carry_the_resolved_clearance() -> None:
+    """``_set_fixed_copper`` stamps the resolved clearance onto every seed."""
+    rules, stack, pads, _conns = _fixture()
+    walls = _short_walls()
+    via = Via(x=10.0, y=14.0, drill=0.3, diameter=0.6, layers=(Layer.F_CU, Layer.B_CU), net=2)
+    fixed = [Route(net=2, net_name="N2", segments=walls, vias=[via])]
+
+    pf = LatticePathfinder(_OUTLINE, pads, rules, layer_stack=stack)
+    pf._set_fixed_copper(fixed, {2: _HV_CLEARANCE})
+    assert [r[-1] for r in pf._fixed_runs] == [_HV_CLEARANCE, _HV_CLEARANCE]
+    assert pf._fixed_vias == [((10.0, 14.0), 2, _HV_CLEARANCE)]
+
+    # Unmapped / below-floor / absent all resolve to the DRU floor.
+    for clearances in (None, {}, {2: 0.05}, {7: 3.0}):
+        pf._set_fixed_copper(fixed, clearances)
+        assert [r[-1] for r in pf._fixed_runs] == [rules.trace_clearance] * 2
+        assert pf._fixed_vias == [((10.0, 14.0), 2, rules.trace_clearance)]
+
+    # ``None`` routes still reset the seed set (no stale fixed copper).
+    pf._set_fixed_copper(None, {2: _HV_CLEARANCE})
+    assert pf._fixed_runs == [] and pf._fixed_vias == []
+
+
+def test_preserved_copper_off_the_routing_stack_is_still_skipped() -> None:
+    """Copper on a non-routing layer is dropped, mapped clearance or not."""
+    rules, stack, pads, _conns = _fixture()
+    off_stack = Segment(
+        x1=10.0, y1=8.0, x2=10.0, y2=12.0, width=0.5, layer=Layer.IN1_CU, net=2, net_name="N2"
+    )
+    pf = LatticePathfinder(_OUTLINE, pads, rules, layer_stack=stack)  # two-layer stack
+    pf._set_fixed_copper([Route(net=2, net_name="N2", segments=[off_stack])], {2: _HV_CLEARANCE})
+    assert pf._fixed_runs == []
+
+
+def test_same_net_preserved_copper_never_blocks_its_own_net() -> None:
+    """A listed net's own stale copper in the fixed set cannot block it (#4355).
+
+    The same-net exemption must survive the #4597 clearance seeding -- a large
+    mapped clearance on the net's own copper must not make it unroutable.
+    """
+    rules, stack, pads, conns = _fixture()
+    # Net 1's own stale copper, straight through the corridor it needs.
+    stale = Segment(
+        x1=10.0, y1=8.0, x2=10.0, y2=12.0, width=0.5, layer=Layer.F_CU, net=1, net_name="N1"
+    )
+    pf = LatticePathfinder(_OUTLINE, pads, rules, layer_stack=stack)
+    routes, stats = pf.route_netset(
+        conns,
+        fixed_copper=[Route(net=1, net_name="N1", segments=[stale])],
+        fixed_clearance={1: 3.0},
+        max_iterations=6,
+    )
+    assert stats.routed == 1
+    assert routes
+
+
+def _committed(rules: DesignRules) -> CommittedCopper:
+    return CommittedCopper(
+        2,
+        trace_half=rules.trace_width / 2.0,
+        clearance=rules.trace_clearance,
+        via_radius=rules.via_diameter / 2.0,
+        via_via_gap=rules.via_diameter + rules.trace_clearance,
+        same_net_via_gap=rules.via_drill + rules.min_hole_to_hole,
+    )
+
+
+def test_committed_via_carries_its_class_clearance() -> None:
+    """A preserved HV via blocks a new LV trace at the HV class gap (#4597).
+
+    ``CommittedCopper.add_via`` used to take no clearance at all, so the via
+    term in ``seg_clear`` / ``node_clear`` was ``via_radius + own_clr +
+    own_half`` -- the global via gap, whatever the map said.
+    """
+    rules = DesignRules()
+    own_half = rules.trace_width / 2.0
+    via_r = rules.via_diameter / 2.0
+    # A probe trace just outside the GLOBAL via gap but well inside the 2.0mm
+    # HV gap.
+    probe_y = via_r + rules.trace_clearance + own_half + 0.05
+
+    floor = _committed(rules)
+    floor.add_via((0.0, 0.0), 2)  # pre-#4597 form: no clearance argument
+    assert floor.seg_clear((-1.0, probe_y), (1.0, probe_y), 0, net=1)
+    assert floor.node_clear((0.0, probe_y), 0, net=1)
+
+    hv = _committed(rules)
+    hv.add_via((0.0, 0.0), 2, _HV_CLEARANCE)
+    assert not hv.seg_clear((-1.0, probe_y), (1.0, probe_y), 0, net=1)
+    assert not hv.node_clear((0.0, probe_y), 0, net=1)
+
+    # Same net is still exempt, and copper beyond the HV gap is still legal.
+    assert hv.seg_clear((-1.0, probe_y), (1.0, probe_y), 0, net=2)
+    clear_y = via_r + _HV_CLEARANCE + own_half + 1e-6
+    assert hv.seg_clear((-1.0, clear_y), (1.0, clear_y), 0, net=1)
+
+
+def test_committed_via_to_via_gap_grows_to_the_stored_class_clearance() -> None:
+    """Cross-net via-to-via also honors the STORED via's clearance (#4597).
+
+    One-sided by design: ``via_clear`` takes no querying-net clearance, so a
+    NEWLY routed HV via still does not apply its own class clearance to other
+    vias (pre-existing #4271 residual, deliberately not widened here).
+    """
+    rules = DesignRules()
+    via_r = rules.via_diameter / 2.0
+    probe = rules.via_diameter + rules.trace_clearance + 0.05  # just past the global gap
+
+    floor = _committed(rules)
+    floor.add_via((0.0, 0.0), 2)
+    assert floor.via_clear((probe, 0.0), net=1)
+
+    hv = _committed(rules)
+    hv.add_via((0.0, 0.0), 2, _HV_CLEARANCE)
+    assert not hv.via_clear((probe, 0.0), net=1)
+    assert hv.via_clear((2.0 * via_r + _HV_CLEARANCE + 1e-6, 0.0), net=1)

--- a/tests/router/test_lattice_fixed_clearance_4597.py
+++ b/tests/router/test_lattice_fixed_clearance_4597.py
@@ -1,0 +1,204 @@
+"""The lattice driver resolves preserved copper's net-class clearance (#4597).
+
+``--preserve-existing`` composition (the documented HV-outer recipe, generalized
+to voltage-binned groups) routes one net group per step and hands the earlier
+steps' copper to the next step as ``router.existing_routes``.
+:meth:`Autorouter._negotiate_lattice_netset` used to pass that copper to
+``LatticePathfinder.route_netset`` with no clearance information at all, so the
+pathfinder seeded every preserved segment/via at the board-global DRU floor and
+``CommittedCopper``'s ``max(own_clr, stored_clr)`` collapsed to the ROUTING
+net's own clearance -- cross-step pairs landed at ~0.2mm however large the
+``--net-class-map`` clearance on the preserved net was.
+
+These tests pin the DRIVER half of the fix: that the ``{net_id: clearance}``
+map handed to the pathfinder is resolved with exactly the same lookup and the
+same ``max(class, rules)`` floor the listed-net branch already uses, and that
+it stays EMPTY (a byte-identical no-op) whenever no class asks for more than the
+board-global clearance.  The geometry half lives in
+``tests/router/lattice/test_preserve_existing_obstacle.py``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.primitives import Pad, Route, Segment, Via
+from kicad_tools.router.rules import NetClassRouting
+
+_HV_CLEARANCE = 2.0
+
+
+class _CapturingPathfinder:
+    """Captures ``route_netset``'s kwargs and routes nothing."""
+
+    def __init__(self) -> None:
+        self.kwargs: dict[str, Any] = {}
+        self.failure_reasons: dict[object, str] = {}
+
+    def route_netset(self, connections: list[Any], **kwargs: Any) -> tuple[dict, Any]:
+        self.kwargs = kwargs
+        return {}, SimpleNamespace(
+            routed=0,
+            total=len(connections),
+            iterations=0,
+            converged=True,
+            lattice_builds=1,
+        )
+
+
+def _pad(x: float, y: float, net: int, *, ref: str, net_name: str) -> Pad:
+    return Pad(
+        x=x,
+        y=y,
+        width=1.0,
+        height=1.0,
+        net=net,
+        net_name=net_name,
+        layer=Layer.F_CU,
+        ref=ref,
+        pin="1",
+    )
+
+
+def _preserved_route(net: int, net_name: str) -> Route:
+    """One preserved segment + one preserved via on ``net``."""
+    return Route(
+        net=net,
+        net_name=net_name,
+        segments=[
+            Segment(
+                x1=10.0,
+                y1=5.0,
+                x2=10.0,
+                y2=25.0,
+                width=0.5,
+                layer=Layer.F_CU,
+                net=net,
+                net_name=net_name,
+            )
+        ],
+        vias=[
+            Via(
+                x=10.0,
+                y=25.0,
+                drill=0.3,
+                diameter=0.6,
+                layers=(Layer.F_CU, Layer.B_CU),
+                net=net,
+                net_name=net_name,
+            )
+        ],
+    )
+
+
+def _driver(
+    *,
+    net_class_map: dict[str, NetClassRouting] | None = None,
+    preserved: list[Route] | None = None,
+    register_net_name: bool = True,
+) -> _CapturingPathfinder:
+    """Run ``_negotiate_lattice_netset`` against a capturing pathfinder."""
+    router = Autorouter(60, 50, strategy="lattice")
+    # Listed net 1 (two pads -> one connection).
+    for pad in (
+        _pad(5.0, 15.0, 1, ref="U1", net_name="/LV_SIG"),
+        _pad(50.0, 15.0, 1, ref="U2", net_name="/LV_SIG"),
+    ):
+        router.pads[(pad.ref, pad.pin)] = pad
+        router.nets.setdefault(pad.net, []).append((pad.ref, pad.pin))
+        router.net_names[pad.net] = pad.net_name
+
+    router.existing_routes = list(preserved or [])
+    if register_net_name:
+        for route in router.existing_routes:
+            router.net_names[route.net] = route.net_name
+    if net_class_map is not None:
+        router.net_class_map.update(net_class_map)
+
+    stub = _CapturingPathfinder()
+    router._lattice_pathfinder = stub  # type: ignore[assignment]
+    router._negotiate_lattice_netset()
+    return stub
+
+
+def test_preserved_hv_net_clearance_reaches_the_pathfinder() -> None:
+    """The mapped 2.0mm HV clearance is handed down keyed by NET ID."""
+    stub = _driver(
+        net_class_map={"/FUSED_LINE": NetClassRouting(name="HV", clearance=_HV_CLEARANCE)},
+        preserved=[_preserved_route(2, "/FUSED_LINE")],
+    )
+
+    assert [r.net for r in stub.kwargs["fixed_copper"]] == [2]
+    assert stub.kwargs["fixed_clearance"] == {2: _HV_CLEARANCE}
+
+
+def test_route_net_name_resolves_when_net_names_has_no_entry() -> None:
+    """A preserved net absent from ``net_names`` falls back to ``route.net_name``."""
+    stub = _driver(
+        net_class_map={"/FUSED_LINE": NetClassRouting(name="HV", clearance=_HV_CLEARANCE)},
+        preserved=[_preserved_route(2, "/FUSED_LINE")],
+        register_net_name=False,
+    )
+
+    assert stub.kwargs["fixed_clearance"] == {2: _HV_CLEARANCE}
+
+
+def test_unmapped_preserved_net_yields_an_empty_map() -> None:
+    """No map entry -> no clearance override; the pre-#4597 seed path exactly."""
+    stub = _driver(preserved=[_preserved_route(2, "/FUSED_LINE")])
+
+    assert stub.kwargs["fixed_copper"]
+    assert stub.kwargs["fixed_clearance"] == {}
+
+
+def test_class_clearance_at_or_below_the_dru_floor_is_omitted() -> None:
+    """A class may only GROW the gap -- at/below the floor it is a no-op.
+
+    Omitting the entry (rather than storing the floor) keeps the map empty on
+    every default-map board, so the pathfinder's seed path is byte-identical.
+    """
+    router_floor = Autorouter(60, 50, strategy="lattice").rules.trace_clearance
+    for clearance in (router_floor, router_floor / 2.0):
+        stub = _driver(
+            net_class_map={"/FUSED_LINE": NetClassRouting(name="X", clearance=clearance)},
+            preserved=[_preserved_route(2, "/FUSED_LINE")],
+        )
+        assert stub.kwargs["fixed_clearance"] == {}, clearance
+
+
+def test_listed_nets_are_not_given_a_preserved_clearance() -> None:
+    """A LISTED net's own stale copper is filtered out of ``fixed_copper``.
+
+    It must therefore never appear in the clearance map either -- a net may not
+    fix itself in place, whatever its class says.
+    """
+    stub = _driver(
+        net_class_map={"/LV_SIG": NetClassRouting(name="HV", clearance=_HV_CLEARANCE)},
+        preserved=[_preserved_route(1, "/LV_SIG")],
+    )
+
+    assert stub.kwargs["fixed_copper"] == []
+    assert stub.kwargs["fixed_clearance"] == {}
+
+
+def test_multiple_preserved_nets_each_resolve_independently() -> None:
+    """Voltage-binned composition: several preserved nets, several clearances."""
+    stub = _driver(
+        net_class_map={
+            "/FUSED_LINE": NetClassRouting(name="HV", clearance=3.2),
+            "/SRC_NEG": NetClassRouting(name="HV", clearance=_HV_CLEARANCE),
+            # Below the floor -> omitted, not stored at the floor.
+            "/CHASSIS": NetClassRouting(name="LV", clearance=0.05),
+        },
+        preserved=[
+            _preserved_route(2, "/FUSED_LINE"),
+            _preserved_route(3, "/SRC_NEG"),
+            _preserved_route(4, "/CHASSIS"),
+            _preserved_route(5, "/UNMAPPED"),
+        ],
+    )
+
+    assert stub.kwargs["fixed_clearance"] == {2: 3.2, 3: _HV_CLEARANCE}


### PR DESCRIPTION
## Summary

`--preserve-existing` copper was seeded into the lattice obstacle model **without its net-class clearance**, so a multi-step composition spaced new copper at the board-global DRU floor from a net the `--net-class-map` had put at 2.0–3.2 mm. On a mains board that gap passes DRC at the global floor and ships silently.

The defect was literal and localized. `LatticePathfinder._seed_fixed_copper` hardcoded `clr = self.rules.trace_clearance` for every preserved segment and called `committed.add_via(point, net)` with no clearance at all, and the seed tuples had no clearance slot to carry one. `CommittedCopper` already computes `own_half + stored_half + max(own_clr, stored_clr)`, so seeding at the DRU floor collapsed that `max()` to the routing net's own clearance. The **half-width** was already preserved from `seg.width`, which is exactly why the reported measurements landed at 0.166–0.2 mm (global/via floor) rather than 0.000 mm — #4355's hard block worked, the #4271 class-clearance semantics did not survive the pass boundary.

This threads a plain `{net_id: clearance}` map from `AutoRouter` to the pathfinder. The name-to-class resolution stays in `core.py` where it already lives for listed nets; the pathfinder stays geometry-only.

## Changes

- **`src/kicad_tools/router/lattice/pathfinder.py`** — `_fixed_runs` becomes `(layer_idx, a, b, net, half, clr)` and `_fixed_vias` becomes `(point, net, clr)`. `_set_fixed_copper(routes, clearances=None)` stamps each seed via a new `_fixed_clearance_for`, which applies the same `max(class, rules.trace_clearance)` floor as `_conn_geometry` (a class may only GROW the gap). `route_netset` gains a keyword-only `fixed_clearance` argument defaulting to `None`. `_seed_fixed_copper` uses the per-tuple clearance instead of the hardcoded floor.
- **`src/kicad_tools/router/lattice/obstacles.py`** — `CommittedCopper.add_via(point, net, clearance=None)` stores `(point, net, clr)`; `None` → the board-global clearance, so every existing 2-arg callsite is unchanged. The via terms in `seg_clear` / `node_clear` become `via_radius + own_half + max(own_clr, stored_clr)`. `via_clear`'s cross-net via-to-via gap grows to `max(via_via_gap, 2*via_radius + stored_clr, same_net_via_gap)` — the **one-sided** improvement the issue sanctions.
- **`src/kicad_tools/router/lattice/coupled.py`** — the two grown-envelope predicates unpack the widened via tuple and honor the stored clearance, mirroring the `max(clearance, iclr)` their copper loops already apply.
- **`src/kicad_tools/router/core.py`** — `_negotiate_lattice_netset` builds the `{net_id: clearance}` map beside the existing `fixed_copper` filter, resolving the net name as `self.net_names.get(net) or route.net_name` (the fallback matters: a preserved net's pads load with `net=0`, so it is often absent from `net_names`). Entries at or below the DRU floor are **omitted**, so the map is empty on default-map boards and the seed path is byte-identical there.
- Hot-path shape preserved: `seg_clear` / `node_clear` / the coupled predicates precompute the querying net's own via gap and only recompute when a stored clearance actually exceeds it.

Out-of-scope engines are now **documented as unchanged**, not silently assumed fixed: `grid.py:mark_route` (blocks at `seg.width/2 + rules.trace_clearance` for all routes), `mesh/pathfinder.py:_seed_fixed_copper` (net-agnostic polygons cannot express per-net clearance), plus a user-facing section in `docs/guides/routing.md`.

## Acceptance Criteria Verification

- [x] **Per-net clearance resolution for preserved copper; `None`/unmapped → `rules.trace_clearance` exactly as today.** `_fixed_clearance_for` returns the floor for `None` / `{}` / unmapped / below-floor. Pinned by `test_seed_tuples_carry_the_resolved_clearance`.
- [x] **`core.py` supplies the resolution with `_conn_geometry`'s floor semantics.** Pinned by the six tests in `tests/router/test_lattice_fixed_clearance_4597.py`.
- [x] **Preserved vias covered; `seg_clear` / `node_clear` use `via_radius + own_half + max(own_clr, stored_via_clr)`.** Pinned by `test_committed_via_carries_its_class_clearance`.
- [x] **Cross-step spacing test.** `test_preserved_net_class_clearance_spaces_cross_step_pair`. Measured: **0.4500 mm → 2.1956 mm** for a preserved net mapped at 2.0 mm.
- [x] **Symmetry test.** `test_new_net_class_clearance_still_governs_reverse_pairing` — reverse pairing yields **2.1956 mm**, byte-identical to the forward case (the fix makes preserved spacing match within-pass spacing exactly).
- [x] **Byte-identical no-op regression.** `test_uniform_map_and_unmapped_nets_are_byte_identical_noops` compares emitted geometry for uniform / unmapped / below-floor / empty maps against `fixed_clearance=None`. The **four existing tests pass unchanged**, including `test_fixed_copper_empty_is_byte_identical_noop`.
- [x] **Scope reservation honored.** The diff contains **zero** changes to `src/kicad_tools/cli/route_cmd.py` and **zero** changes to `src/kicad_tools/router/rules.py`. Verified: `git diff --name-only origin/main...HEAD | grep -E 'cli/route_cmd\.py|router/rules\.py'` → no match.
- [x] **Mesh and grid documented as unchanged.** See above.

Edge cases from the test plan, all covered: unmapped net → floor; below-floor map → clamped up, never shrinks; same-net preserved copper → still exempt (`test_same_net_preserved_copper_never_blocks_its_own_net`, with a 3.0 mm map on the net's own stale copper); `fixed_copper` non-empty with `fixed_clearance=None`/`{}` → identical output; copper off the routing stack → still skipped (`test_preserved_copper_off_the_routing_stack_is_still_skipped`); preserved via on a mapped HV net → cleared at the HV class clearance.

## Measurements

Unit fixture (a foreign-net wall on both routing layers, one net routed across it):

| Case | Min edge-to-edge gap to preserved copper |
|---|---|
| `fixed_clearance=None` (pre-fix behavior) | **0.4500 mm** |
| `fixed_clearance={2: 2.0}` (preserved net mapped at 2.0 mm) | **2.1956 mm** |
| Reverse: new net's class at 2.0 mm, preserved at the floor | **2.1956 mm** |

Board-level A/B on `boards/02-charlieplex-led` — step 1 routes `LINE_*` on the lattice engine, step 2 routes `NODE_*` with `--preserve-existing` while `LINE_*` is preserved:

| Case | Min edge-to-edge gap to preserved `LINE_*` | Connections |
|---|---|---|
| No class map on the preserved nets (pre-fix equivalent) | **0.3657 mm** | 18/18 |
| `LINE_*` mapped at 1.0 mm | **1.0000 mm** | 17/18 |

The mapped clearance is enforced to the millimetre. The one lost connection (`decline[pad-escape-end]` on `NODE_B`) is the expected trade-off of a much larger keep-out on a dense 2-layer board, and it is the correct failure mode: an honest decline rather than a silently under-spaced trace.

## Residual (measured, belongs elsewhere)

The evidence board's 129/81 census was not re-measured — softstart rev-C is local-only and its symlink dangles in a fresh worktree, and the issue explicitly does not gate on it. But the board-level A/B above surfaced a **second, independent defect upstream of this fix**, which anyone chasing the residual census will hit:

`_apply_net_class_map_sidecar` resolves `--net-class-map` keys against `list(router.net_names.values())`, and `router/io.py` assigns `net=0` to the pads of every skipped net — so under `--nets` / `--skip-nets` (i.e. **every** composition step) the preserved nets are absent from `net_names` and their sidecar entries are dropped at merge time. Reproduced on the charlieplex board: a 4-entry HV sidecar reports `Net-class map: merged 0/4 sidecar entries`, and the two step-2 outputs (with and without the sidecar) are identical at 0.3657 mm.

Consequence: on the **CLI sidecar path** the HV clearance never reaches `net_class_map`, so this fix cannot act. It works today via the **config/design `net_class_map`** path (an `Autorouter(..., net_class_map=...)` map is not filtered by board nets) — that is the 1.0000 mm result above. The fix is a one-line widening of `board_net_names` to include `router.existing_routes` net names, but it lives in `src/kicad_tools/cli/route_cmd.py`, which is hard-reserved for this issue, so it is **deliberately not touched here**. Reported rather than silently worked around; no follow-up issue was filed per instruction.

Also deliberately not addressed (pre-existing, documented in code): `via_clear` takes no querying-net clearance, so a *newly routed* HV via still does not apply its own class clearance to other vias — a #4271 residual, not a `--preserve-existing` regression.

## Test Plan

```
$ .venv/bin/kct build-native --check
C++ backend: available (version 1.0.0)
  build version: 18 (required: 18)
  extension: router_cpp.cpython-312-darwin.so

$ .venv/bin/pytest tests/router/lattice/test_preserve_existing_obstacle.py -q
12 passed in 0.89s

$ .venv/bin/pytest tests/router/lattice/ tests/router/test_lattice_fixed_clearance_4597.py \
                   tests/router/test_preserve_existing.py -q
180 passed, 2 skipped, 4 warnings in 231.78s (0:03:51)

$ .venv/bin/pytest tests/router/lattice/test_net_class_widths.py tests/router/lattice/test_self_drc.py \
                   tests/router/lattice/test_via_hole_floor.py tests/router/lattice/test_coupled_pairs.py \
                   tests/router/lattice/test_coupled_board06.py -q
59 passed in 137.13s (0:02:17)

$ .venv/bin/pytest tests/router/test_preserve_existing.py tests/test_route_zones_preserved.py -q
34 passed in 44.19s

$ .venv/bin/ruff format . --check
1727 files already formatted

$ .venv/bin/ruff check .
All checks passed!

$ .venv/bin/python scripts/ci/check_mypy_baseline.py
OK: mypy reports 1473 error(s), all within the baseline (1474 allowed). No new type errors.
```

Note on the mypy gate: it must be run against a **clean** `.mypy_cache`. A stale incremental cache in this worktree reported one phantom error in `src/kicad_tools/recovery/strategy.py`, a file this PR does not touch; it disappears after `rm -rf .mypy_cache`. The "1 baseline error no longer occurs" warning is the known native-env nanobind `import-not-found` line — `--update` was deliberately **not** run, since doing so from a worktree with the extension built drops an env-agnostic baseline line and breaks CI.

Closes #4597
