### PR TITLE
fix(route): resolve --net-class-map keys against preserved nets on filtered passes

### DIFF
--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -803,6 +803,34 @@ Practical consequence: **carry the HV entries in every step's map**, not just
 the step that routes them. A preserved net with no entry in the current step's
 map resolves to the global clearance exactly as before.
 
+This works through **both** ways of supplying the map — the `net_class_map` in
+a design/config script and the `--net-class-map <sidecar.json>` CLI flag.
+Sidecar keys naming a preserved net used to be dropped on every filtered pass
+(`--nets` / `--skip-nets` / `--region` / `--complete`), because the loader
+rewrites a skipped net's pads to net 0 and the key was resolved only against
+the nets being routed. The symptom was a
+`Net-class map: merged 0/N sidecar entries` line and DRU-floor spacing on
+preserved copper; that is fixed
+([#4622](https://github.com/rjwalters/kicad-tools/issues/4622)) — the merge
+line now reports the true count, and the run prints the usual
+`WARNING: net-class-map: …` only for keys that match no net at all.
+
+Two details worth knowing when writing the sidecar:
+
+- **A preserved net must already carry copper on the input board.** The
+  preserved-name domain comes from the segments and vias actually present in
+  the file being routed. A net that has pads but no copper yet is not
+  "preserved" — there is no earlier-step geometry to space against — so an
+  entry naming it matches nothing and is reported as unmatched. Route it in an
+  earlier step (or write the entry in the step that routes it) rather than
+  expecting the current step to hold a gap around nothing.
+- **Bare keys resolve against the nets being routed first.** Keys are matched
+  on the sheet-local suffix after the last `/`, so a bare `LINE` key with a
+  routable `/HV/LINE` and a preserved `/LV/LINE` on the board resolves to the
+  **routable** net; the preserved net is left alone. Write the fully-qualified
+  name when you mean the preserved one. A key ambiguous *within* one of the two
+  groups is still applied to neither and warns, as before.
+
 Not covered — document, do not assume:
 
 - **`--engine grid`** blocks preserved routes at

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -74,6 +74,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
     from kicad_tools.router import Autorouter, LayerStack
+    from kicad_tools.router.net_names import NetClassMapResolution
     from kicad_tools.router.pairwise_clearance import AttachZone, PairwiseViolation
     from kicad_tools.router.primitives import Route
 
@@ -3756,6 +3757,81 @@ def _targeted_ripup_budget(args) -> int:
     return budget if budget is not None else 3
 
 
+def _preserved_net_names(router: "Autorouter", exclude: "set[str]") -> list[str]:
+    """Board net names that only exist as *preserved* copper (Issue #4622).
+
+    ``router.existing_routes`` is populated by
+    ``load_pcb_for_routing(load_existing_routes=True)`` with one
+    :class:`~kicad_tools.router.primitives.Route` per net that already has
+    segments/vias on the input board, each carrying the board's real
+    ``net_name``.  On a filtered pass those names are exactly the ones
+    missing from ``router.net_names``.
+
+    Names already present in ``exclude`` (the routable domain) are dropped so
+    the two domains are disjoint, and duplicates are collapsed while
+    preserving iteration order.
+
+    ``existing_routes`` may be absent entirely (the CLI unit tests drive this
+    helper with a ``SimpleNamespace`` stub router), so the attribute is read
+    defensively.
+    """
+    seen: list[str] = []
+    for route in getattr(router, "existing_routes", None) or []:
+        name = getattr(route, "net_name", None)
+        if not name or name in exclude or name in seen:
+            continue
+        seen.append(name)
+    return seen
+
+
+def _resolve_net_class_map_domains(
+    router: "Autorouter", user_keys
+) -> "tuple[NetClassMapResolution, list[str]]":
+    """Resolve sidecar keys against the routable *then* the preserved domain.
+
+    Returns the merged :class:`NetClassMapResolution` plus the union of both
+    name domains (for the nearest-name hints in the unresolved diagnostic).
+
+    **Two-phase and strictly additive** (Issue #4622).  Phase 1 resolves every
+    key against ``router.net_names`` exactly as before.  Phase 2 re-resolves
+    *only* the keys phase 1 left unmatched, against the preserved-only names.
+
+    A naive union of the two domains would be one line shorter and would also
+    make the reported repro pass, but it is wrong: :func:`resolve_net_key`
+    matches on the suffix after the last ``/``, so a union can make a
+    currently-**resolved** key **ambiguous** — routable ``/HV/LINE`` plus
+    preserved ``/LV/LINE`` turns a bare ``LINE`` key ambiguous, and ambiguous
+    keys are deliberately applied to *neither* candidate.  That would silently
+    drop the clearance of a net that *is* being routed this pass: a new
+    instance of the very bug class this fixes.  Two-phase cannot do that,
+    because a key that resolved in phase 1 never reaches phase 2.
+
+    A key matching no net in *either* domain still lands in ``unmatched``, so
+    genuine typos keep producing the (never ``--quiet``-suppressed) warning.
+    """
+    from kicad_tools.router.net_names import (
+        NetClassMapResolution,
+        resolve_net_class_map_keys,
+    )
+
+    routable_names = list(router.net_names.values())
+    primary = resolve_net_class_map_keys(user_keys, routable_names)
+
+    preserved_names = _preserved_net_names(router, set(routable_names))
+    if not preserved_names or not primary.unmatched:
+        return primary, routable_names
+
+    secondary = resolve_net_class_map_keys(primary.unmatched, preserved_names)
+    merged = NetClassMapResolution(
+        # Domains are disjoint by construction, so no resolved board net can
+        # be claimed by both phases.
+        resolved={**primary.resolved, **secondary.resolved},
+        unmatched=list(secondary.unmatched),
+        ambiguous={**primary.ambiguous, **secondary.ambiguous},
+    )
+    return merged, routable_names + preserved_names
+
+
 def _apply_net_class_map_sidecar(router: "Autorouter", args, quiet: bool = False) -> None:
     """Merge the pre-loaded --net-class-map sidecar into the router (Issue #2996).
 
@@ -3778,26 +3854,33 @@ def _apply_net_class_map_sidecar(router: "Autorouter", args, quiet: bool = False
     board net or matched ambiguously.  Ambiguous keys are applied to
     *neither* candidate — silently picking one would just relocate the bug.
 
+    Issue #4622: on a *filtered* pass (``--nets`` / ``--skip-nets`` /
+    ``--region`` / ``--complete``, i.e. every composition step) the loader
+    rewrites each skipped net's pads to ``net_num = 0``
+    (``router/io.py``), so preserved nets never enter ``router.net_names``.
+    Resolving only against ``router.net_names`` therefore dropped *every*
+    sidecar entry naming a preserved net — the ``merged 0/N sidecar
+    entries`` symptom — and preserved copper fell back to the DRU floor
+    instead of its requested class clearance.  The resolution domain is now
+    widened with the net names carried by ``router.existing_routes`` using a
+    **two-phase, additive** scheme (see :func:`_resolve_net_class_map_domains`).
+
     Idempotent and a no-op when the flag was not supplied.
     """
     loaded = getattr(args, "_loaded_net_class_map", None)
     if not loaded:
         return
 
-    from kicad_tools.router.net_names import (
-        nearest_net_names,
-        resolve_net_class_map_keys,
-    )
+    from kicad_tools.router.net_names import nearest_net_names
 
-    board_net_names = list(router.net_names.values())
-    resolution = resolve_net_class_map_keys(loaded.keys(), board_net_names)
+    resolution, diagnostic_net_names = _resolve_net_class_map_domains(router, loaded.keys())
 
     # Apply overrides rekeyed to the board's actual net names so
     # ``self.net_class_map.get(net_name)`` finds them at routing time.
     for board_net, user_key in resolution.resolved.items():
         router.net_class_map[board_net] = loaded[user_key]
 
-    _warn_unresolved_net_class_map(resolution, board_net_names, nearest_net_names)
+    _warn_unresolved_net_class_map(resolution, diagnostic_net_names, nearest_net_names)
 
     if not quiet:
         from kicad_tools.cli.progress import flush_print

--- a/tests/router/test_preserve_existing.py
+++ b/tests/router/test_preserve_existing.py
@@ -120,6 +120,7 @@ def _run_route(
     preserve: bool,
     skip_nets: str | None = None,
     net_class_map_path: str | None = None,
+    extra_argv: list[str] | None = None,
 ) -> str:
     """Write ``pcb_text`` to a temp file, run ``kct route``, return output text.
 
@@ -145,6 +146,8 @@ def _run_route(
         argv += ["--net-class-map", net_class_map_path]
     if preserve:
         argv.append("--preserve-existing")
+    if extra_argv:
+        argv += extra_argv
 
     route_main(argv)
     assert out_path.exists(), "route did not produce an output file"
@@ -699,3 +702,198 @@ class TestPreserveExistingHardAvoidLayers:
         # HV route neither consumes nor mutates it).
         assert len(preserved.segments) == 2
         assert {s.layer.kicad_name for s in preserved.segments} == {"F.Cu", "B.Cu"}
+
+
+# ---------------------------------------------------------------------------
+# Issue #4622: --net-class-map entries for PRESERVED nets must resolve on a
+# filtered (--nets / --skip-nets) composition step.
+# ---------------------------------------------------------------------------
+
+
+class TestPreservedNetClassMapResolution:
+    """The CLI sidecar path on a *filtered* pass (Issue #4622).
+
+    ``--skip-nets`` makes ``load_pcb_for_routing`` rewrite every skipped net's
+    pads to ``net_num = 0``, so those nets never enter ``router.net_names``.
+    ``_apply_net_class_map_sidecar`` used to resolve sidecar keys against
+    ``router.net_names`` alone, so every entry naming a preserved net was
+    dropped -- ``Net-class map: merged 0/N sidecar entries`` -- and preserved
+    copper fell back to the board-global DRU floor instead of the requested
+    per-net clearance.
+
+    These tests drive the real ``route_main(argv)`` CLI on the filtered path;
+    a unit test against ``net_class_map`` alone would not have caught the
+    defect, because the resolution domain is only wrong once the loader has
+    zeroed the skipped nets.
+    """
+
+    @staticmethod
+    def _spy_sidecar(monkeypatch) -> list[dict]:
+        """Record the router state each ``_apply_net_class_map_sidecar`` produced."""
+        from kicad_tools.cli import route_cmd
+
+        original = route_cmd._apply_net_class_map_sidecar
+        seen: list[dict] = []
+
+        def _wrapper(router, args, quiet=False):
+            original(router, args, quiet=quiet)
+            seen.append(
+                {
+                    "net_class_map": dict(router.net_class_map),
+                    "routable": dict(router.net_names),
+                    "preserved": {
+                        r.net: r.net_name for r in getattr(router, "existing_routes", [])
+                    },
+                }
+            )
+
+        monkeypatch.setattr(route_cmd, "_apply_net_class_map_sidecar", _wrapper)
+        return seen
+
+    def test_sidecar_entry_for_skipped_net_resolves(self, tmp_path, board_text, monkeypatch):
+        """The reported defect: a sidecar key naming a SKIPPED net now applies.
+
+        Pre-fix the three preserved keys landed in ``unmatched`` and
+        ``router.net_class_map`` never gained their 1.0 mm clearance.
+        """
+        import json
+
+        seen = self._spy_sidecar(monkeypatch)
+
+        map_path = tmp_path / "netclass.json"
+        map_path.write_text(
+            json.dumps(
+                {
+                    net: {"name": "HV", "trace_width": 0.25, "clearance": 1.0}
+                    for net in ("LINE_B", "LINE_C", "LINE_D")
+                }
+            )
+        )
+
+        _run_route(
+            tmp_path,
+            board_text,
+            preserve=True,
+            skip_nets=_SKIP_ALL_BUT_LINE_A,
+            net_class_map_path=str(map_path),
+        )
+
+        assert seen, "the sidecar merge helper never ran on this CLI path"
+        state = seen[0]
+        # Precondition the defect depends on: the skipped nets are NOT in the
+        # routable domain, but they ARE carried as preserved copper.
+        assert "LINE_B" not in state["routable"].values()
+        assert "LINE_B" in state["preserved"].values()
+        # ...and their sidecar clearance nonetheless reached the router's map.
+        for net in ("LINE_B", "LINE_C", "LINE_D"):
+            assert net in state["net_class_map"], (
+                f"{net} is preserved copper on this filtered pass and its "
+                "--net-class-map entry was dropped (issue #4622)"
+            )
+            assert state["net_class_map"][net].clearance == pytest.approx(1.0)
+
+    def test_lattice_driver_receives_preserved_clearance(self, tmp_path, board_text, monkeypatch):
+        """End to end: the resolved clearance reaches the lattice pathfinder.
+
+        ``_negotiate_lattice_netset`` (PR #4597) turns a resolved
+        ``net_class_map`` entry into the ``{net_id: mm}`` ``fixed_clearance``
+        map the pathfinder seeds preserved copper with.  Pre-fix that map was
+        empty on every composition step however large the sidecar clearance.
+        """
+        import json
+
+        from kicad_tools.router.lattice.pathfinder import LatticePathfinder
+
+        captured: list[dict] = []
+        original_route_netset = LatticePathfinder.route_netset
+
+        def _wrapper(self, connections, **kwargs):
+            captured.append(dict(kwargs.get("fixed_clearance") or {}))
+            return original_route_netset(self, connections, **kwargs)
+
+        monkeypatch.setattr(LatticePathfinder, "route_netset", _wrapper)
+
+        map_path = tmp_path / "netclass.json"
+        map_path.write_text(
+            json.dumps({"LINE_B": {"name": "HV", "trace_width": 0.25, "clearance": 1.0}})
+        )
+
+        _run_route(
+            tmp_path,
+            board_text,
+            preserve=True,
+            skip_nets=_SKIP_ALL_BUT_LINE_A,
+            net_class_map_path=str(map_path),
+            extra_argv=["--route-engine", "lattice", "--strategy", "basic"],
+        )
+
+        assert captured, "the lattice pathfinder was never driven"
+        assert any(captured), (
+            "fixed_clearance handed to the lattice pathfinder was empty -- the "
+            "preserved net's --net-class-map clearance never resolved (#4622)"
+        )
+        assert any(1.0 in clr.values() for clr in captured if clr), (
+            "preserved copper was not seeded at the sidecar's 1.0 mm clearance"
+        )
+
+    def test_unresolvable_key_still_warns_under_quiet(
+        self, tmp_path, board_text, capsys, monkeypatch
+    ):
+        """Widening the domain must not silence a key matching NO net at all.
+
+        The warning is deliberately not suppressed by ``--quiet`` (the
+        softstart-rev-B silent-inertness incident); ``_run_route`` always
+        passes ``--quiet``, so this pins both properties at once.
+        """
+        import json
+
+        seen = self._spy_sidecar(monkeypatch)
+
+        map_path = tmp_path / "netclass.json"
+        map_path.write_text(
+            json.dumps(
+                {
+                    "LINE_B": {"name": "HV", "clearance": 1.0},  # preserved -> resolves
+                    "LINE_A": {"name": "HV", "clearance": 1.0},  # routable  -> resolves
+                    "NOT_A_NET": {"name": "HV", "clearance": 1.0},  # typo -> warns
+                }
+            )
+        )
+
+        _run_route(
+            tmp_path,
+            board_text,
+            preserve=True,
+            skip_nets=_SKIP_ALL_BUT_LINE_A,
+            net_class_map_path=str(map_path),
+        )
+
+        err = capsys.readouterr().err
+        assert "WARNING: net-class-map:" in err
+        assert "2/3 entries matched" in err
+        assert "NOT_A_NET" in err
+        assert seen and "NOT_A_NET" not in seen[0]["net_class_map"]
+
+    def test_preserved_resolution_does_not_disturb_skipped_geometry(self, tmp_path, board_text):
+        """#4413 non-regression: skipped copper stays byte-identical."""
+        import json
+
+        orig = parse_segments(board_text)
+
+        map_path = tmp_path / "netclass.json"
+        map_path.write_text(
+            json.dumps({"LINE_B": {"name": "HV", "trace_width": 0.25, "clearance": 1.0}})
+        )
+
+        out_text = _run_route(
+            tmp_path,
+            board_text,
+            preserve=True,
+            skip_nets=_SKIP_ALL_BUT_LINE_A,
+            net_class_map_path=str(map_path),
+        )
+        out = parse_segments(out_text)
+
+        for net in ("LINE_B", "LINE_C", "LINE_D", "NODE_A", "NODE_B", "NODE_C", "NODE_D"):
+            assert net in out
+            assert _geom_set(out[net]) == _geom_set(orig[net])

--- a/tests/test_cli_route_net_class_map.py
+++ b/tests/test_cli_route_net_class_map.py
@@ -521,6 +521,256 @@ class TestHierarchicalPrefixNormalization:
 
 
 # =============================================================================
+# Issue #4622: preserved (non-routed) nets are resolvable on a filtered pass
+# =============================================================================
+
+
+def _preserved_route(net: int, net_name: str):
+    """A minimal preserved ``Route`` as ``load_pcb_for_routing`` builds them."""
+    from kicad_tools.router.layers import Layer
+    from kicad_tools.router.primitives import Route, Segment
+
+    return Route(
+        net=net,
+        net_name=net_name,
+        segments=[Segment(x1=0.0, y1=0.0, x2=1.0, y2=0.0, width=0.2, net=net, layer=Layer.F_CU)],
+    )
+
+
+def _stub_router_with_preserved(
+    net_names: dict[int, str], preserved: dict[int, str]
+) -> SimpleNamespace:
+    """``_stub_router`` plus the ``existing_routes`` a preserved pass carries.
+
+    ``net_names`` is the *routable* set (what survives ``--nets`` /
+    ``--skip-nets``); ``preserved`` is the ``{net_id: net_name}`` of copper
+    reloaded from the input board.
+    """
+    return SimpleNamespace(
+        net_names=dict(net_names),
+        net_class_map={},
+        existing_routes=[_preserved_route(n, name) for n, name in preserved.items()],
+    )
+
+
+class TestPreservedNetResolutionDomain:
+    """A filtered pass must still resolve sidecar keys for PRESERVED nets.
+
+    Under ``--nets`` / ``--skip-nets`` the loader rewrites every skipped net's
+    pads to ``net_num = 0``, so those nets never enter ``router.net_names``.
+    Resolving only against ``net_names`` therefore dropped every sidecar entry
+    naming a preserved net (``merged 0/N sidecar entries``) and preserved
+    copper fell back to the DRU floor.
+
+    The fix resolves in **two phases** -- routable first, then the still
+    unmatched keys against the preserved-only names -- which is strictly
+    additive and so cannot turn an already-resolved key ambiguous.
+    """
+
+    def test_preserved_only_key_resolves(self, capsys):
+        """The reported defect: a key naming a preserved net now applies."""
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        router = _stub_router_with_preserved({5: "NODE_A"}, {1: "LINE_A", 2: "LINE_B"})
+        loaded = {
+            "LINE_A": _sidecar_entry("HV", clearance=1.0),
+            "LINE_B": _sidecar_entry("HV", clearance=1.0),
+        }
+        args = SimpleNamespace(_loaded_net_class_map=loaded)
+
+        _apply_net_class_map_sidecar(router, args, quiet=True)
+
+        assert router.net_class_map["LINE_A"].clearance == pytest.approx(1.0)
+        assert router.net_class_map["LINE_B"].clearance == pytest.approx(1.0)
+        assert "WARNING" not in capsys.readouterr().err
+
+    def test_merged_count_reports_preserved_matches(self, capsys):
+        """The ``merged N/M`` line counts preserved matches (was ``0/4``)."""
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        router = _stub_router_with_preserved(
+            {5: "NODE_A"}, {1: "LINE_A", 2: "LINE_B", 3: "LINE_C", 4: "LINE_D"}
+        )
+        loaded = {
+            name: _sidecar_entry("HV", clearance=1.0)
+            for name in ("LINE_A", "LINE_B", "LINE_C", "LINE_D")
+        }
+        args = SimpleNamespace(_loaded_net_class_map=loaded)
+
+        _apply_net_class_map_sidecar(router, args, quiet=False)
+
+        out = capsys.readouterr()
+        assert "merged 4/4 sidecar entries" in out.out
+        assert "WARNING" not in out.err
+
+    def test_routable_key_still_resolves(self, capsys):
+        """A key that resolved before the change still resolves identically."""
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        router = _stub_router_with_preserved({5: "/NODE_A"}, {1: "LINE_A"})
+        loaded = {"NODE_A": _sidecar_entry("Sig", priority=3)}
+        args = SimpleNamespace(_loaded_net_class_map=loaded)
+
+        _apply_net_class_map_sidecar(router, args, quiet=True)
+
+        assert router.net_class_map["/NODE_A"].priority == 3
+        assert "WARNING" not in capsys.readouterr().err
+
+    def test_bare_key_matches_prefixed_preserved_net(self, capsys):
+        """Hierarchical preserved names ('/FUSED_LINE') take a bare key too."""
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        router = _stub_router_with_preserved({5: "NODE_A"}, {1: "/FUSED_LINE"})
+        loaded = {"FUSED_LINE": _sidecar_entry("Heavy", priority=5)}
+        args = SimpleNamespace(_loaded_net_class_map=loaded)
+
+        _apply_net_class_map_sidecar(router, args, quiet=True)
+
+        assert router.net_class_map["/FUSED_LINE"].priority == 5
+        assert "FUSED_LINE" not in router.net_class_map
+        assert "WARNING" not in capsys.readouterr().err
+
+    def test_key_matching_neither_domain_still_warns(self, capsys):
+        """Hazard 3: widening the domain must not silence genuine typos."""
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        router = _stub_router_with_preserved({5: "NODE_A"}, {1: "LINE_A"})
+        loaded = {
+            "LINE_A": _sidecar_entry("HV", clearance=1.0),
+            "LINE_TYPO": _sidecar_entry("HV", clearance=1.0),
+        }
+        args = SimpleNamespace(_loaded_net_class_map=loaded)
+
+        # quiet=True is the softstart-rev-B condition: the warning must
+        # still reach stderr even with --quiet.
+        _apply_net_class_map_sidecar(router, args, quiet=True)
+
+        assert router.net_class_map["LINE_A"].clearance == pytest.approx(1.0)
+        assert "LINE_TYPO" not in router.net_class_map
+        err = capsys.readouterr().err
+        assert "WARNING" in err
+        assert "1/2 entries matched" in err
+        assert "LINE_TYPO" in err
+
+    def test_unmatched_hint_can_name_a_preserved_net(self, capsys):
+        """Nearest-name hints draw on BOTH domains, so preserved nets show up."""
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        router = _stub_router_with_preserved({5: "NODE_A"}, {1: "/HV/FUSED_LINE"})
+        loaded = {"FUSED_LIN": _sidecar_entry("Heavy", priority=5)}  # typo
+        args = SimpleNamespace(_loaded_net_class_map=loaded)
+
+        _apply_net_class_map_sidecar(router, args, quiet=True)
+
+        err = capsys.readouterr().err
+        assert "0/1 entries matched" in err
+        assert "/HV/FUSED_LINE" in err
+
+    def test_suffix_collision_does_not_regress_routable_match(self, capsys):
+        """Hazard 2: a routable match must NOT become ambiguous.
+
+        ``resolve_net_key`` matches on the suffix after the last ``/``, so a
+        naive union of the routable and preserved domains would make the bare
+        key ``LINE`` ambiguous between routable ``/HV/LINE`` and preserved
+        ``/LV/LINE`` -- and ambiguous keys are applied to *neither* net.  That
+        would silently drop the clearance of a net that IS being routed this
+        pass.  Two-phase resolution keeps the phase-1 match.
+        """
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        router = _stub_router_with_preserved({5: "/HV/LINE"}, {1: "/LV/LINE"})
+        loaded = {"LINE": _sidecar_entry("HV", clearance=2.0)}
+        args = SimpleNamespace(_loaded_net_class_map=loaded)
+
+        _apply_net_class_map_sidecar(router, args, quiet=True)
+
+        # The routable net keeps its clearance; the preserved net is untouched.
+        assert router.net_class_map["/HV/LINE"].clearance == pytest.approx(2.0)
+        assert "/LV/LINE" not in router.net_class_map
+        err = capsys.readouterr().err
+        assert "AMBIGUOUS" not in err
+        assert "WARNING" not in err
+
+    def test_ambiguous_within_preserved_domain_applied_to_neither(self, capsys):
+        """A key ambiguous among PRESERVED nets is still applied to neither."""
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        router = _stub_router_with_preserved({5: "NODE_A"}, {1: "/HV/LINE", 2: "/LV/LINE"})
+        loaded = {"LINE": _sidecar_entry("HV", clearance=2.0)}
+        args = SimpleNamespace(_loaded_net_class_map=loaded)
+
+        _apply_net_class_map_sidecar(router, args, quiet=True)
+
+        assert "/HV/LINE" not in router.net_class_map
+        assert "/LV/LINE" not in router.net_class_map
+        err = capsys.readouterr().err
+        assert "AMBIGUOUS" in err
+        assert "0/1 entries matched" in err
+
+    def test_missing_existing_routes_attribute_tolerated(self, capsys):
+        """Hazard 1: a router with no ``existing_routes`` must not blow up."""
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        router = _stub_router({1: "/FUSED_LINE"})  # no existing_routes attribute
+        assert not hasattr(router, "existing_routes")
+        loaded = {"FUSED_LINE": _sidecar_entry("Heavy", priority=5)}
+        args = SimpleNamespace(_loaded_net_class_map=loaded)
+
+        _apply_net_class_map_sidecar(router, args, quiet=True)
+
+        assert router.net_class_map["/FUSED_LINE"].priority == 5
+        assert "WARNING" not in capsys.readouterr().err
+
+    def test_empty_existing_routes_is_a_no_op(self, capsys):
+        """An unfiltered pass (no preserved copper) behaves exactly as before."""
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        router = _stub_router_with_preserved({1: "/FUSED_LINE"}, {})
+        loaded = {
+            "FUSED_LINE": _sidecar_entry("Heavy", priority=5),
+            "TYPO": _sidecar_entry("Heavy", priority=5),
+        }
+        args = SimpleNamespace(_loaded_net_class_map=loaded)
+
+        _apply_net_class_map_sidecar(router, args, quiet=True)
+
+        assert router.net_class_map["/FUSED_LINE"].priority == 5
+        err = capsys.readouterr().err
+        assert "1/2 entries matched" in err
+
+    def test_preserved_net_also_routable_is_not_double_counted(self, capsys):
+        """A net that is BOTH routable and preserved resolves once, via phase 1."""
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        # ``--preserve-existing`` without a net filter loads every net's copper,
+        # so ``existing_routes`` and ``net_names`` overlap completely.
+        router = _stub_router_with_preserved({1: "LINE_A"}, {1: "LINE_A"})
+        loaded = {"LINE_A": _sidecar_entry("HV", clearance=1.0)}
+        args = SimpleNamespace(_loaded_net_class_map=loaded)
+
+        _apply_net_class_map_sidecar(router, args, quiet=False)
+
+        out = capsys.readouterr()
+        assert router.net_class_map["LINE_A"].clearance == pytest.approx(1.0)
+        assert "merged 1/1 sidecar entries" in out.out
+        assert "WARNING" not in out.err
+
+    def test_route_without_net_name_is_skipped(self, capsys):
+        """A preserved ``Route`` carrying no ``net_name`` never enters the domain."""
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        router = _stub_router_with_preserved({5: "NODE_A"}, {1: "LINE_A"})
+        router.existing_routes[0].net_name = None
+        loaded = {"LINE_A": _sidecar_entry("HV", clearance=1.0)}
+        args = SimpleNamespace(_loaded_net_class_map=loaded)
+
+        _apply_net_class_map_sidecar(router, args, quiet=True)
+
+        assert router.net_class_map == {}
+        assert "0/1 entries matched" in capsys.readouterr().err
+
+
+# =============================================================================
 # Issue #4587: KiCad layer NAMES in the sidecar resolve at preload
 # =============================================================================
 


### PR DESCRIPTION
## Summary

`--net-class-map` was silently inert on every composition step. On a filtered
pass (`--nets` / `--skip-nets` / `--region` / `--complete`) the loader rewrites
each skipped net's pads to `net_num = 0` (`router/io.py`), so preserved nets
never enter `router.net_names`. `_apply_net_class_map_sidecar` resolved sidecar
keys against `router.net_names` alone, so every entry naming a preserved net was
dropped with an easily-misread `Net-class map: merged 0/N sidecar entries` line,
and preserved copper was seeded at the board-global DRU floor instead of the
requested per-net clearance.

The fix widens the **resolution domain** in `route_cmd.py` only. `io.py`,
`core.py`, the pathfinder and the obstacle model are untouched — PR #4621
already shipped the consumer-side fallback
(`self.net_names.get(net) or route.net_name`) in `_negotiate_lattice_netset`.

### Two-phase, NOT a union

The naive one-line union of the routable + preserved name domains was
deliberately **not** implemented. `resolve_net_key` matches on the suffix after
the last `/`, so a union can turn a currently-**resolved** key **ambiguous**
(routable `/HV/LINE` + preserved `/LV/LINE` makes a bare `LINE` key ambiguous),
and ambiguous keys are applied to *neither* net — silently dropping the
clearance of a net that **is** being routed this pass. That would be a new
instance of the same bug class.

Instead: phase 1 resolves against the routable names exactly as before; phase 2
re-resolves **only** the still-unmatched keys against the preserved-only names.
A key that resolves in phase 1 never reaches phase 2, so the change is strictly
additive and cannot remove a clearance.

This is pinned by a test. Substituting the rejected union implementation makes
`test_suffix_collision_does_not_regress_routable_match` fail with
`KeyError: '/HV/LINE'` and
`'LINE' -> AMBIGUOUS, matches 2 board nets (/HV/LINE, /LV/LINE); skipped`, while
the shipped two-phase implementation passes.

## Changes

- `src/kicad_tools/cli/route_cmd.py` (+90 net)
  - New `_preserved_net_names(router, exclude)` — the preserved-only name
    domain from `router.existing_routes`, read with
    `getattr(router, "existing_routes", None) or []` so a `SimpleNamespace`
    stub router (which has no such attribute) is tolerated.
  - New `_resolve_net_class_map_domains(router, user_keys)` — the two-phase
    resolve; returns a merged `NetClassMapResolution` plus the union of both
    name lists so nearest-name hints can suggest preserved nets too.
  - `_apply_net_class_map_sidecar` now calls it. The rekey loop, the
    `merged N/M` line and `_warn_unresolved_net_class_map` keep their shapes.
    The helper was fixed, not any of its five callsites.
- `docs/guides/routing.md` — corrects the section PR #4621 added (see below).
- `tests/test_cli_route_net_class_map.py` — new
  `TestPreservedNetResolutionDomain` (12 tests, resolution level).
- `tests/router/test_preserve_existing.py` — new
  `TestPreservedNetClassMapResolution` (4 tests, **CLI** level via
  `route_main(argv)` on a filtered pass); `_run_route()` gained an additive
  `extra_argv` parameter.

## Acceptance Criteria Verification

**Measured reproduction** — two-step composition on `boards/02-charlieplex-led`
(step 1 routes `LINE_*`, step 2 routes `NODE_*` with `--preserve-existing` and a
4-entry sidecar mapping `LINE_*` to 1.0 mm), `--route-engine lattice`. The A/B
runs identical code apart from the one changed decision (the "before" arm
monkeypatches the resolver back to the pre-fix single domain). C++ backend
confirmed present first: `C++ backend: available (version 1.0.0)`.

```
===== BEFORE (pre-fix resolution) =====
--- step 2: route NODE_* group with LINE_* preserved (exit 0) ---
    Net-class map: merged 0/4 sidecar entries
    WARNING: net-class-map: 0/4 entries matched a board net after normalization.
requested preserved clearance: 1.0 mm
    gap 0.3657 mm  LINE_A vs NODE_B on F_CU
    gap 0.3657 mm  LINE_A vs NODE_B on F_CU
    gap 0.3657 mm  LINE_A vs NODE_B on F_CU
    gap 0.3657 mm  LINE_A vs NODE_B on F_CU
    gap 0.4000 mm  LINE_A vs NODE_A on F_CU
MIN preserved-to-routed edge-to-edge gap: 0.3657 mm  (LINE_A vs NODE_B on F_CU)

===== AFTER (two-phase) =====
--- step 2: route NODE_* group with LINE_* preserved ---
    Net-class map: merged 4/4 sidecar entries
requested preserved clearance: 1.0 mm
    gap 1.0000 mm  LINE_A vs NODE_A on F_CU
    gap 1.0000 mm  LINE_A vs NODE_A on F_CU
    gap 1.0728 mm  LINE_A vs NODE_A on F_CU
    gap 1.0728 mm  LINE_C vs NODE_C on F_CU
    gap 1.2142 mm  LINE_C vs NODE_C on F_CU
MIN preserved-to-routed edge-to-edge gap: 1.0000 mm  (LINE_A vs NODE_A on F_CU)
```

`merged 0/4` becomes `merged 4/4`; the min preserved-to-routed gap goes
0.3657 mm (the DRU floor) to exactly the requested 1.0000 mm.

**Mechanism probe** — the `{net_id: clearance}` map `_negotiate_lattice_netset`
hands the lattice pathfinder on the same step-2 pass:

```
mode=LEGACY (pre-fix)  exit=0
    Net-class map: merged 0/4 sidecar entries
    routable net_names        = {"7": "NODE_C", "6": "NODE_B", "5": "NODE_A", "8": "NODE_D"}
    preserved existing_routes = {"2": "LINE_B", "1": "LINE_A", "4": "LINE_D", "3": "LINE_C"}
    fixed_clearance -> pathfinder = {}

mode=FIXED (two-phase)  exit=0
    Net-class map: merged 4/4 sidecar entries
    routable net_names        = {"7": "NODE_C", "6": "NODE_B", "5": "NODE_A", "8": "NODE_D"}
    preserved existing_routes = {"1": "LINE_A", "3": "LINE_C", "4": "LINE_D", "2": "LINE_B"}
    fixed_clearance -> pathfinder = {"1": 1.0, "3": 1.0, "4": 1.0, "2": 1.0}
```

- [x] Sidecar entries for preserved nets resolve on a `--nets`/`--skip-nets`
      pass; `merged N/M` reports the true count (`0/4` becomes `4/4`).
- [x] The `boards/02-charlieplex-led` reproduction yields **1.0000 mm**, not
      0.3657 mm.
- [x] A regression test drives the **CLI** sidecar path (`route_main(argv)`) on
      a filtered pass with `--preserve-existing` + `--net-class-map` —
      `TestPreservedNetClassMapResolution` in
      `tests/router/test_preserve_existing.py`, built on the existing
      `_run_route()` helper. It asserts on the resolved `router.net_class_map`
      and, separately, on the `fixed_clearance` map actually handed to the
      lattice pathfinder.
- [x] Keys matching **no** net in either domain still warn, and still warn under
      `--quiet` — `test_unresolvable_key_still_warns_under_quiet` (CLI level,
      `--quiet` is always passed by `_run_route`) asserts
      `WARNING: net-class-map: 2/3 entries matched`, plus
      `test_key_matching_neither_domain_still_warns` at the unit level.
- [x] A key that resolves today against the routable set resolves identically
      after the change; it does **not** become ambiguous because a preserved net
      shares its suffix — `test_suffix_collision_does_not_regress_routable_match`
      (`/HV/LINE` routable, `/LV/LINE` preserved, bare `LINE` key). Verified to
      FAIL under the rejected union implementation.
- [x] No change to the config/design `net_class_map` path — that path never
      passes through `_apply_net_class_map_sidecar`; the diff touches only that
      helper.
- [x] Default path unchanged: with no sidecar the helper still returns
      immediately (`test_no_op_when_flag_absent`); with a sidecar whose keys all
      resolve against the routable set, phase 2 is skipped entirely
      (`if not preserved_names or not primary.unmatched: return primary, ...`)
      so the resolution is byte-identical to pre-fix.
      `test_preserved_resolution_does_not_disturb_skipped_geometry` additionally
      pins that skipped copper stays geometry-identical.
- [x] No `AttributeError` when `router` has no `existing_routes` — the existing
      `_stub_router()` tests pass **unmodified** (a separate
      `_stub_router_with_preserved()` was added for the new cases), and
      `test_missing_existing_routes_attribute_tolerated` asserts the stub really
      lacks the attribute.
- [x] `docs/guides/routing.md` updated (see below).

### Ambiguous keys still warn rather than silently mis-applying

Ambiguity **within** the preserved domain is still applied to neither net and
still warns — `test_ambiguous_within_preserved_domain_applied_to_neither`
asserts `AMBIGUOUS` and `0/1 entries matched` on stderr, with neither `/HV/LINE`
nor `/LV/LINE` gaining the override. Ambiguity within the routable domain is
unchanged (`test_ambiguous_key_applied_to_neither`, pre-existing, still passes).

### Docs correction

The section `Preserved copper keeps its --net-class-map clearance (lattice
engine)` told users to "carry the HV entries in every step's map", which was a
no-op on the CLI sidecar path. It now states that the recipe works through both
the design/config `net_class_map` and the `--net-class-map` sidecar, names the
old `merged 0/N` symptom and its fix, and adds the two caveats a sidecar author
needs:

- A preserved net must **already carry copper** on the input board — the
  preserved-name domain comes from `existing_routes`, so a net with pads but no
  copper yet matches nothing and is reported as unmatched (Hazard 4).
- Bare keys resolve against the nets **being routed** first, so a bare `LINE`
  with routable `/HV/LINE` and preserved `/LV/LINE` picks the routable net;
  write the fully-qualified name to mean the preserved one.

## Test Plan

```
tests/test_cli_route_net_class_map.py .....................................  37 passed
tests/router/test_preserve_existing.py .....................                 21 passed (258s)
tests/router/test_lattice_fixed_clearance_4597.py
tests/router/lattice/test_preserve_existing_obstacle.py
  + tests/test_cli_route_net_class_map.py                                    55 passed
tests/test_cli_route_nets_flag.py tests/test_cli_route_complete_4471.py
tests/test_route_cmd_input_preservation.py tests/test_net_class.py
tests/test_cli_check_net_class_map.py                                       152 passed
tests/test_net_names.py                                                      24 passed
```

Pre-fix failure proof (pytest plugin restoring the single-domain resolve):
**9 of the 16 new tests FAIL** without the fix —

```
FAILED tests/router/test_preserve_existing.py::TestPreservedNetClassMapResolution::test_sidecar_entry_for_skipped_net_resolves
FAILED tests/router/test_preserve_existing.py::TestPreservedNetClassMapResolution::test_lattice_driver_receives_preserved_clearance
FAILED tests/router/test_preserve_existing.py::TestPreservedNetClassMapResolution::test_unresolvable_key_still_warns_under_quiet
FAILED tests/test_cli_route_net_class_map.py::TestPreservedNetResolutionDomain::test_preserved_only_key_resolves
FAILED tests/test_cli_route_net_class_map.py::TestPreservedNetResolutionDomain::test_merged_count_reports_preserved_matches
FAILED tests/test_cli_route_net_class_map.py::TestPreservedNetResolutionDomain::test_bare_key_matches_prefixed_preserved_net
FAILED tests/test_cli_route_net_class_map.py::TestPreservedNetResolutionDomain::test_key_matching_neither_domain_still_warns
FAILED tests/test_cli_route_net_class_map.py::TestPreservedNetResolutionDomain::test_unmatched_hint_can_name_a_preserved_net
FAILED tests/test_cli_route_net_class_map.py::TestPreservedNetResolutionDomain::test_ambiguous_within_preserved_domain_applied_to_neither
9 failed, 7 passed, 42 deselected
```

Lint / format / types:

```
ruff format  -> clean
ruff check   -> All checks passed!
scripts/ci/check_mypy_baseline.py
  -> OK: mypy reports 1473 error(s), all within the baseline (1474 allowed).
     No new type errors.
```

(The baseline gate emits an advisory `1 baseline error(s) no longer occur`
notice — a net *improvement*, not a failure. The baseline file was deliberately
left untouched: regenerating it from a native-built worktree drops the
env-agnostic nanobind line and breaks CI.)

No `boards/**/output/` path was modified — the reproduction ran entirely in a
scratch directory; `check-main-clean.sh` reports the main worktree clean.

## Out of scope (deliberately not folded in)

Both were flagged by PR #4621's Judge and are pre-existing residuals:

1. `router/lattice/pathfinder.py:1902` — `committed.add_via(via_pt, start.net)`
   commits a newly-routed via with no clearance argument.
2. Lattice pad masks inflate at a single global `agent_radius`, so a preserved
   net's *pads* remain at the DRU floor.

Also untouched: `--engine grid` / `--engine mesh` preserved-copper clearance,
and the config/design `net_class_map` path.

Closes #4622
