### PR TITLE
feat(recipes): gate mutating board recipes on a parseable project.kct

### DIFF
--- a/boards/00-simple-led/generate_design.py
+++ b/boards/00-simple-led/generate_design.py
@@ -27,6 +27,7 @@ from kicad_tools.dev import warn_if_stale
 from kicad_tools.lvs import write_lvs_report
 from kicad_tools.pcb.center_sheet import centered_origin
 from kicad_tools.recipes.gate import evaluate_pipeline_gate
+from kicad_tools.recipes.precondition import require_spec
 from kicad_tools.schematic.models.schematic import Schematic
 
 # Warn if running source scripts with stale pipx install
@@ -937,6 +938,15 @@ def run_lvs(sch_path: Path, routed_pcb_path: Path, output_dir: Path) -> bool:
 
 def main() -> int:
     """Main entry point."""
+    # Precondition (#4539): refuse to mutate a board that carries no captured
+    # intent.  Anchored on ``__file__`` -- NOT ``Path.cwd()`` and NOT the
+    # output dir -- because CI invokes this recipe from the repo root with an
+    # out-of-tree output dir, so a cwd-anchored search would find nothing and
+    # fire spuriously.  Advisory by default (L1: project.kct exists, is
+    # non-empty, and parses); ``KCT_REQUIRE_SPEC=1`` upgrades it to a hard L2
+    # gate that exits non-zero BEFORE any file is written.
+    require_spec(__file__)
+
     if len(sys.argv) > 1:
         output_dir = Path(sys.argv[1])
     else:

--- a/boards/01-voltage-divider/generate_design.py
+++ b/boards/01-voltage-divider/generate_design.py
@@ -26,6 +26,7 @@ from kicad_tools.dev import warn_if_stale
 from kicad_tools.lvs import write_lvs_report
 from kicad_tools.pcb.center_sheet import centered_origin
 from kicad_tools.recipes.gate import evaluate_pipeline_gate
+from kicad_tools.recipes.precondition import require_spec
 from kicad_tools.schematic.models.schematic import Schematic
 
 # Warn if running source scripts with stale pipx install
@@ -770,6 +771,15 @@ def export_manufacturing_bundle(routed_path: Path, output_dir: Path) -> bool:
 
 def main() -> int:
     """Main entry point."""
+    # Precondition (#4539): refuse to mutate a board that carries no captured
+    # intent.  Anchored on ``__file__`` -- NOT ``Path.cwd()`` and NOT the
+    # output dir -- because CI invokes this recipe from the repo root with an
+    # out-of-tree output dir, so a cwd-anchored search would find nothing and
+    # fire spuriously.  Advisory by default (L1: project.kct exists, is
+    # non-empty, and parses); ``KCT_REQUIRE_SPEC=1`` upgrades it to a hard L2
+    # gate that exits non-zero BEFORE any file is written.
+    require_spec(__file__)
+
     if len(sys.argv) > 1:
         output_dir = Path(sys.argv[1])
     else:

--- a/boards/02-charlieplex-led/generate_design.py
+++ b/boards/02-charlieplex-led/generate_design.py
@@ -38,6 +38,7 @@ from kicad_tools.dev import warn_if_stale
 from kicad_tools.lvs import write_lvs_report
 from kicad_tools.pcb.center_sheet import centered_origin
 from kicad_tools.recipes.gate import evaluate_pipeline_gate
+from kicad_tools.recipes.precondition import require_spec
 from kicad_tools.schematic.grid import GridSize
 from kicad_tools.schematic.models.schematic import Schematic, SnapMode
 
@@ -759,6 +760,15 @@ def export_manufacturing_bundle(routed_path: Path, output_dir: Path) -> bool:
 
 def main() -> int:
     """Main entry point."""
+    # Precondition (#4539): refuse to mutate a board that carries no captured
+    # intent.  Anchored on ``__file__`` -- NOT ``Path.cwd()`` and NOT the
+    # output dir -- because CI invokes this recipe from the repo root with an
+    # out-of-tree output dir, so a cwd-anchored search would find nothing and
+    # fire spuriously.  Advisory by default (L1: project.kct exists, is
+    # non-empty, and parses); ``KCT_REQUIRE_SPEC=1`` upgrades it to a hard L2
+    # gate that exits non-zero BEFORE any file is written.
+    require_spec(__file__)
+
     if len(sys.argv) > 1:
         output_dir = Path(sys.argv[1])
     else:

--- a/boards/03-usb-joystick/generate_design.py
+++ b/boards/03-usb-joystick/generate_design.py
@@ -32,6 +32,7 @@ from kicad_tools.core.project_file import create_minimal_project, save_project
 from kicad_tools.dev import warn_if_stale
 from kicad_tools.lvs import write_lvs_report
 from kicad_tools.recipes.gate import evaluate_pipeline_gate
+from kicad_tools.recipes.precondition import require_spec
 
 # Warn if running source scripts with stale pipx install
 warn_if_stale()
@@ -792,6 +793,15 @@ def run_drc(pcb_path: Path) -> bool:
 
 def main() -> int:
     """Main entry point."""
+    # Precondition (#4539): refuse to mutate a board that carries no captured
+    # intent.  Anchored on ``__file__`` -- NOT ``Path.cwd()`` and NOT the
+    # output dir -- because CI invokes this recipe from the repo root with an
+    # out-of-tree output dir, so a cwd-anchored search would find nothing and
+    # fire spuriously.  Advisory by default (L1: project.kct exists, is
+    # non-empty, and parses); ``KCT_REQUIRE_SPEC=1`` upgrades it to a hard L2
+    # gate that exits non-zero BEFORE any file is written.
+    require_spec(__file__)
+
     if len(sys.argv) > 1:
         output_dir = Path(sys.argv[1])
     else:

--- a/boards/04-stm32-devboard/generate_design.py
+++ b/boards/04-stm32-devboard/generate_design.py
@@ -35,6 +35,7 @@ from kicad_tools.dev import warn_if_stale
 from kicad_tools.lvs import write_lvs_report
 from kicad_tools.pcb.center_sheet import centered_origin
 from kicad_tools.recipes.gate import evaluate_pipeline_gate
+from kicad_tools.recipes.precondition import require_spec
 from kicad_tools.schematic.blocks import (
     DebugHeader,
     create_crystal_with_loads,
@@ -1990,6 +1991,15 @@ def run_drc(pcb_path: Path) -> bool:
 
 def main() -> int:
     """Main entry point."""
+    # Precondition (#4539): refuse to mutate a board that carries no captured
+    # intent.  Anchored on ``__file__`` -- NOT ``Path.cwd()`` and NOT the
+    # output dir -- because CI invokes this recipe from the repo root with an
+    # out-of-tree output dir, so a cwd-anchored search would find nothing and
+    # fire spuriously.  Advisory by default (L1: project.kct exists, is
+    # non-empty, and parses); ``KCT_REQUIRE_SPEC=1`` upgrades it to a hard L2
+    # gate that exits non-zero BEFORE any file is written.
+    require_spec(__file__)
+
     # Determine output directory
     if len(sys.argv) > 1:
         output_dir = Path(sys.argv[1])

--- a/boards/05-bldc-motor-controller/design.py
+++ b/boards/05-bldc-motor-controller/design.py
@@ -34,6 +34,7 @@ from kicad_tools.core.project_file import create_minimal_project, save_project
 from kicad_tools.dev import warn_if_stale
 from kicad_tools.pcb.center_sheet import centered_origin
 from kicad_tools.recipes.gate import evaluate_pipeline_gate
+from kicad_tools.recipes.precondition import require_spec
 from kicad_tools.router.partial_rescue import CompletionResult, RescueConfig
 from kicad_tools.router.partial_rescue import (
     complete_unfinished_nets as shared_complete_unfinished_nets,
@@ -3691,6 +3692,15 @@ def run_drc(pcb_path: Path) -> bool:
 
 def main() -> int:
     """Main entry point."""
+    # Precondition (#4539): refuse to mutate a board that carries no captured
+    # intent.  Anchored on ``__file__`` -- NOT ``Path.cwd()`` and NOT the
+    # output dir -- because CI invokes this recipe from the repo root with an
+    # out-of-tree output dir, so a cwd-anchored search would find nothing and
+    # fire spuriously.  Advisory by default (L1: project.kct exists, is
+    # non-empty, and parses); ``KCT_REQUIRE_SPEC=1`` upgrades it to a hard L2
+    # gate that exits non-zero BEFORE any file is written.
+    require_spec(__file__)
+
     if len(sys.argv) > 1:
         output_dir = Path(sys.argv[1])
     else:

--- a/boards/06-diffpair-test/generate_design.py
+++ b/boards/06-diffpair-test/generate_design.py
@@ -41,6 +41,7 @@ from kicad_tools.core.project_file import create_minimal_project, save_project
 from kicad_tools.dev import warn_if_stale
 from kicad_tools.lvs import write_lvs_report
 from kicad_tools.recipes.gate import evaluate_pipeline_gate
+from kicad_tools.recipes.precondition import require_spec
 from kicad_tools.router.rules import NET_CLASS_HIGH_SPEED, NET_CLASS_POWER, NetClassRouting
 
 # Re-export net definitions and footprint generators from generate_pcb.
@@ -3392,6 +3393,15 @@ def main() -> int:
         ),
     )
     args = parser.parse_args()
+
+    # Precondition (#4539): refuse to mutate a board that carries no captured
+    # intent.  Anchored on ``__file__`` -- NOT ``Path.cwd()`` and NOT the
+    # output dir -- because CI invokes this recipe from the repo root with an
+    # out-of-tree output dir, so a cwd-anchored search would find nothing and
+    # fire spuriously.  Advisory by default (L1: project.kct exists, is
+    # non-empty, and parses); ``KCT_REQUIRE_SPEC=1`` upgrades it to a hard L2
+    # gate that exits non-zero BEFORE any file is written.
+    require_spec(__file__)
 
     if args.output_dir is not None:
         output_dir = Path(args.output_dir)

--- a/boards/07-matchgroup-test/generate_design.py
+++ b/boards/07-matchgroup-test/generate_design.py
@@ -63,6 +63,7 @@ from kicad_tools.pcb.center_sheet import (
     translate_pcb_text,
 )
 from kicad_tools.recipes.gate import evaluate_pipeline_gate
+from kicad_tools.recipes.precondition import require_spec
 from kicad_tools.router.rules import (
     NET_CLASS_POWER,
     NetClassRouting,
@@ -2143,6 +2144,15 @@ def main() -> int:
         ),
     )
     args = parser.parse_args()
+
+    # Precondition (#4539): refuse to mutate a board that carries no captured
+    # intent.  Anchored on ``__file__`` -- NOT ``Path.cwd()`` and NOT the
+    # output dir -- because CI invokes this recipe from the repo root with an
+    # out-of-tree output dir, so a cwd-anchored search would find nothing and
+    # fire spuriously.  Advisory by default (L1: project.kct exists, is
+    # non-empty, and parses); ``KCT_REQUIRE_SPEC=1`` upgrades it to a hard L2
+    # gate that exits non-zero BEFORE any file is written.
+    require_spec(__file__)
 
     if args.output_dir is not None:
         output_dir = Path(args.output_dir)

--- a/boards/README.md
+++ b/boards/README.md
@@ -267,6 +267,68 @@ intent:
     kicad-tools pipeline.
 ```
 
+### Spec precondition: recipes refuse to mutate a board with no captured intent
+
+Every board recipe entry point calls
+`kicad_tools.recipes.precondition.require_spec(__file__)` as its **first**
+statement, before any file is written. It is the pre-condition half of the
+recipe contract (`kicad_tools.recipes.gate.evaluate_pipeline_gate` is the
+post-condition half). The check is strictly **read-only** — it never writes,
+repairs or rewrites a `.kct` file.
+
+Discovery walks **up from the recipe script's own directory**
+(`Path(__file__).parent`, bounded to 6 ancestors) looking for `project.kct`.
+It deliberately does **not** anchor on the current working directory or on the
+output directory, because CI invokes recipes from the repo root with an
+out-of-tree output dir:
+
+```bash
+uv run python boards/00-simple-led/generate_design.py /tmp/board00-ci
+```
+
+**Gate strength:**
+
+| Level | Check | Default | Strict |
+|-------|-------|---------|--------|
+| L0 | `project.kct` exists and is non-empty | required | required |
+| L1 | + `load_spec()` parses it | **required** | required |
+| L2 | + `validate_spec()` reports no errors | not checked | **required** |
+
+- **Default is L1 and advisory.** A missing / empty / unparseable spec prints a
+  labelled `⚠️ spec precondition` warning to stderr and returns a falsy
+  `SpecPreconditionResult`. It does **not** raise and does **not** change the
+  recipe's exit code. An unexpected error inside the helper itself is swallowed
+  and reported as "could not check" — the gate never crashes a recipe.
+- **Strict mode is opt-in** via the `KCT_REQUIRE_SPEC` environment variable
+  (`KCT_REQUIRE_SPEC=1`) or `require_spec(__file__, strict=True)`. It raises the
+  bar to L2 and exits non-zero **before** the recipe's first write.
+
+```bash
+# advisory (default)
+uv run python boards/00-simple-led/generate_design.py /tmp/out
+
+# hard gate: abort unless the spec also validates semantically
+KCT_REQUIRE_SPEC=1 uv run python boards/00-simple-led/generate_design.py /tmp/out
+```
+
+L2 is not the default because it is not currently clean across the fleet:
+`boards/01-voltage-divider/project.kct` fails semantic validation with
+`Progress: current phase 'complete' not found in phases` — a bookkeeping defect
+in the spec's `progress` block, tracked separately. All 8 boards pass L1.
+
+**Non-goal — this is not a schema-completeness check.** The precondition asks
+only *"does this board carry captured intent that parses?"*. It deliberately
+does **not** check whether the spec *models* the board's requirements (i.e. it
+does not reject unrecognized / unmodelled `.kct` keys). What `.kct` should model
+is a separate, open schema-design question.
+
+**Consumer-repo escape hatch:** a project whose intent artifact lives elsewhere
+or is named something else passes it explicitly:
+
+```python
+require_spec(__file__, spec_path=Path("docs/ENGINEERING_PLAN.kct"))
+```
+
 ## Board Details
 
 ### 00 - Simple LED (Hello World)

--- a/src/kicad_tools/recipes/__init__.py
+++ b/src/kicad_tools/recipes/__init__.py
@@ -14,7 +14,19 @@ This package holds the shared pieces those recipes should call so a single
 verdict drives BOTH the SUMMARY and the exit code, and the authoritative
 ``kicad-cli pcb drc --refill-zones`` engine is used for the DRC leg.
 
-See :mod:`kicad_tools.recipes.gate` for the shared pipeline success gate.
+The package holds the two halves of the recipe contract:
+
+* :mod:`kicad_tools.recipes.precondition` -- the **pre**-condition
+  (:func:`~kicad_tools.recipes.precondition.require_spec`, issue #4539):
+  before a recipe mutates anything, assert the board carries captured
+  intent (a non-empty, parseable ``project.kct``).  Advisory and fail-soft
+  by default; opt into a hard semantic-validation gate with
+  ``KCT_REQUIRE_SPEC=1``.
+* :mod:`kicad_tools.recipes.gate` -- the **post**-condition
+  (:func:`~kicad_tools.recipes.gate.evaluate_pipeline_gate`, issue #3912):
+  after route / DRC / LVS have run, turn their verdicts into ONE
+  :class:`~kicad_tools.recipes.gate.PipelineGateResult` that drives both
+  the printed ``SUMMARY`` and the process exit code.
 """
 
 from __future__ import annotations
@@ -24,9 +36,21 @@ from kicad_tools.recipes.gate import (
     PipelineGateResult,
     evaluate_pipeline_gate,
 )
+from kicad_tools.recipes.precondition import (
+    SPEC_FILENAME,
+    STRICT_ENV_VAR,
+    SpecPreconditionResult,
+    discover_spec,
+    require_spec,
+)
 
 __all__ = [
     "DEFAULT_ADVISORY_DRC_TYPES",
+    "SPEC_FILENAME",
+    "STRICT_ENV_VAR",
     "PipelineGateResult",
+    "SpecPreconditionResult",
+    "discover_spec",
     "evaluate_pipeline_gate",
+    "require_spec",
 ]

--- a/src/kicad_tools/recipes/precondition.py
+++ b/src/kicad_tools/recipes/precondition.py
@@ -1,0 +1,407 @@
+"""Shared spec precondition for board recipes (issue #4539).
+
+:mod:`kicad_tools.recipes.gate` is the **post**-condition half of the recipe
+contract: after route / DRC / LVS have run, ``evaluate_pipeline_gate`` turns
+their verdicts into ONE :class:`~kicad_tools.recipes.gate.PipelineGateResult`
+that drives both the printed ``SUMMARY`` and the process exit code (#3912).
+
+This module is the **pre**-condition half.  Before a recipe mutates anything
+it asks a single question:
+
+    *Does this board carry captured intent?*
+
+Concretely: is there a ``project.kct`` next to the recipe (or in a bounded
+set of its ancestors), is it non-empty, and does it parse?  A board that is
+about to have copper written for it with no captured intent at all is the
+condition this refuses to let pass silently.
+
+Gate-strength ladder (issue #4539)
+----------------------------------
+=====  =========================================================  ==========
+Level  Check                                                      Fleet
+=====  =========================================================  ==========
+L0     artifact exists and is non-empty                           8/8 pass
+L1     L0 + :func:`~kicad_tools.spec.parser.load_spec` parses     8/8 pass
+L2     L1 + :func:`~kicad_tools.spec.parser.validate_spec` clean  7/8 pass
+=====  =========================================================  ==========
+
+**L1 is the default.**  **L2 is strict-mode only** (opt in with
+``KCT_REQUIRE_SPEC=1`` or ``strict=True``): as of ``origin/main`` @
+``83d7625e`` ``boards/01-voltage-divider/project.kct`` is semantically
+``Invalid`` (``Progress: current phase 'complete' not found in phases``), so
+a default-on L2 would fail that board's CI job for a bookkeeping defect that
+has nothing to do with this gate.  Repairing that spec is deliberately NOT
+this module's job -- the gate reports, it does not repair.
+
+**There is deliberately no L3.**  A hypothetical L3 ("the spec must *model*
+the board's requirements", i.e. no unrecognized / unmodelled ``.kct`` keys)
+is the schema-design question PR #4619's review explicitly deferred -- after
+#4619, ``kct spec validate`` reports 8 unrecognized keys on board 00 alone,
+so an L3 gate would reject 8/8 boards.  Deciding what ``.kct`` *should*
+model is a separate issue.  **Do not add an unrecognized-key check here.**
+
+Posture
+-------
+* **Read-only.**  This module never calls ``save_spec`` / ``append_decision``
+  / ``kct spec decide``, and never writes to the ``.kct`` file in any way.
+* **Advisory and fail-soft by default** -- a missing / empty / unparseable
+  artifact prints a labelled warning to stderr and returns a falsy verdict.
+  It does not raise and does not change the recipe's exit code.
+* **Never crashes a recipe.**  An unexpected exception inside the helper is
+  swallowed and reported as "could not check", mirroring
+  ``_load_project_kct_for_escalation``'s bare ``except Exception: return``
+  (``src/kicad_tools/cli/route_cmd.py``).
+* **Strict mode is opt-in** and terminates the process with
+  ``SystemExit(1)`` *before* the recipe's first write.  ``SystemExit``
+  derives from ``BaseException``, so it deliberately passes straight through
+  the recipes' broad ``except Exception`` handlers instead of being
+  downgraded into their generic error path.
+
+Discovery anchor (the trap)
+---------------------------
+Discovery walks **up from the recipe script's own directory**
+(``Path(__file__).parent``), mirroring the bounded-ancestor pattern in
+``_load_project_kct_for_escalation``.  It must NOT anchor on
+:func:`pathlib.Path.cwd` or on the output directory: CI invokes every recipe
+from the repo root with an out-of-tree output dir (e.g. ``uv run python
+boards/00-simple-led/generate_design.py /tmp/board00-ci``), so a cwd- or
+output-anchored search would find nothing and the gate would fire spuriously
+on all 8 boards.
+
+Usage
+-----
+.. code-block:: python
+
+    from kicad_tools.recipes.precondition import require_spec
+
+    def main() -> int:
+        require_spec(__file__)   # advisory; strict via KCT_REQUIRE_SPEC=1
+        ...
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TextIO
+
+__all__ = [
+    "MAX_ANCESTOR_DEPTH",
+    "SPEC_FILENAME",
+    "STRICT_ENV_VAR",
+    "SpecPreconditionResult",
+    "discover_spec",
+    "require_spec",
+]
+
+#: The canonical intent artifact in this repository.  Consumer repos with a
+#: differently-named artifact pass ``spec_path=`` explicitly.
+SPEC_FILENAME = "project.kct"
+
+#: Environment variable that opts into the hard (L2) gate.  ``KCT_*`` is the
+#: repo convention (``KCT_ROUTE_GRID``, ``KCT_COUPLED_CPP``, ...).
+STRICT_ENV_VAR = "KCT_REQUIRE_SPEC"
+
+#: Bounded ancestor walk depth, matching ``_load_project_kct_for_escalation``.
+MAX_ANCESTOR_DEPTH = 6
+
+#: Levels, weakest to strongest.  ``"none"`` means "not even L0".
+_LEVEL_ORDER = ("none", "L0", "L1", "L2")
+
+_TRUTHY = frozenset({"1", "true", "yes", "on", "strict", "hard"})
+_FALSY = frozenset({"", "0", "false", "no", "off"})
+
+
+@dataclass(frozen=True)
+class SpecPreconditionResult:
+    """Structured verdict from :func:`require_spec`.
+
+    Returning a small frozen dataclass rather than a bare ``bool`` mirrors
+    :class:`~kicad_tools.recipes.gate.PipelineGateResult` and lets tests
+    assert *why* the gate fired instead of matching on printed text.
+
+    Attributes:
+        ok: ``True`` when the attained level meets the required level
+            (L1 by default, L2 under strict mode).  ``__bool__`` delegates
+            here, so ``if not require_spec(...):`` reads naturally.
+        level: the strongest level actually attained -- one of ``"none"``,
+            ``"L0"``, ``"L1"``, ``"L2"``.
+        required_level: the level that had to be attained (``"L1"`` by
+            default, ``"L2"`` under strict mode).
+        found_path: the discovered intent artifact, or ``None`` when the
+            bounded upward walk found nothing.
+        searched: every candidate path the walk considered, in order.
+        strict: whether the hard gate was engaged for this call.
+        checked: ``False`` only when the helper itself failed unexpectedly
+            (a bug in the helper, not a violation by the board).  Strict
+            mode does NOT terminate the process in that case -- an internal
+            error is indistinguishable from "unknown", and a helper bug must
+            never take a recipe down.
+        reasons: human-readable explanations for a falsy verdict.
+    """
+
+    ok: bool
+    level: str
+    required_level: str
+    found_path: Path | None = None
+    searched: tuple[Path, ...] = ()
+    strict: bool = False
+    checked: bool = True
+    reasons: tuple[str, ...] = field(default_factory=tuple)
+
+    def __bool__(self) -> bool:
+        return self.ok
+
+
+def _level_rank(level: str) -> int:
+    try:
+        return _LEVEL_ORDER.index(level)
+    except ValueError:  # pragma: no cover - defensive
+        return 0
+
+
+def _env_strict() -> bool:
+    """Read :data:`STRICT_ENV_VAR`; unset / falsy strings mean advisory."""
+    raw = os.environ.get(STRICT_ENV_VAR)
+    if raw is None:
+        return False
+    value = raw.strip().lower()
+    if value in _FALSY:
+        return False
+    if value in _TRUTHY:
+        return True
+    # Any other non-empty value is treated as opt-in: a user who typed
+    # something into KCT_REQUIRE_SPEC meant to turn it ON.
+    return True
+
+
+def discover_spec(
+    anchor: Path | str,
+    *,
+    filename: str = SPEC_FILENAME,
+    max_depth: int = MAX_ANCESTOR_DEPTH,
+) -> tuple[Path | None, tuple[Path, ...]]:
+    """Walk up from ``anchor`` looking for ``filename``.
+
+    Mirrors the bounded-ancestor discovery in
+    ``_load_project_kct_for_escalation``: at most ``max_depth`` directories
+    are considered and the walk stops at the filesystem root, so it can
+    never hang.
+
+    Args:
+        anchor: a directory, or a file whose directory is used.
+        filename: artifact filename to look for.
+        max_depth: maximum number of directories to consider.
+
+    Returns:
+        ``(found_path_or_None, tuple_of_candidates_considered)``.
+    """
+    start = Path(anchor)
+    if start.is_file():
+        start = start.parent
+    elif start.suffix and not start.is_dir():
+        # A non-existent path that looks like a file (e.g. a __file__ whose
+        # directory was deleted): treat its parent as the anchor directory.
+        start = start.parent
+
+    candidates: list[Path] = []
+    cur = start.resolve()
+    for _ in range(max_depth):
+        candidates.append(cur / filename)
+        if cur.parent == cur:  # filesystem root -- stop, never loop
+            break
+        cur = cur.parent
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate, tuple(candidates)
+    return None, tuple(candidates)
+
+
+def _caller_file() -> str | None:
+    """Best-effort ``__file__`` of the immediate caller of :func:`require_spec`."""
+    frame = inspect.currentframe()
+    # _caller_file -> require_spec -> the recipe
+    for _ in range(2):
+        if frame is None:
+            return None
+        frame = frame.f_back
+    if frame is None:
+        return None
+    value = frame.f_globals.get("__file__")
+    return value if isinstance(value, str) else None
+
+
+def _evaluate(spec_file: Path) -> tuple[str, list[str]]:
+    """Return ``(attained_level, reasons)`` for an existing candidate path.
+
+    Runs the L0 -> L1 -> L2 ladder and stops at the first failure.  This is
+    where the ladder's ceiling lives: there is intentionally no L3
+    unrecognized-key check (see the module docstring).
+    """
+    reasons: list[str] = []
+
+    # --- L0: exists and is non-empty -------------------------------------
+    if not spec_file.is_file():
+        return "none", [f"no {spec_file.name} found"]
+    try:
+        text = spec_file.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        return "none", [f"{spec_file} could not be read: {exc}"]
+    if not text.strip():
+        return "none", [f"{spec_file} is empty"]
+
+    # --- L1: parses -------------------------------------------------------
+    from kicad_tools.spec.parser import load_spec, validate_spec
+
+    try:
+        load_spec(spec_file)
+    except Exception as exc:  # ValueError / ValidationError / FileNotFound
+        return "L0", [f"{spec_file} does not parse: {exc}"]
+
+    # --- L2: semantically validates (strict mode only) --------------------
+    try:
+        valid, errors = validate_spec(spec_file)
+    except Exception as exc:  # pragma: no cover - validate_spec is total
+        return "L1", [f"{spec_file} could not be validated: {exc}"]
+    if not valid:
+        reasons.extend(f"{spec_file}: {err}" for err in errors)
+        return "L1", reasons
+
+    return "L2", reasons
+
+
+def require_spec(
+    recipe_file: Path | str | None = None,
+    *,
+    spec_path: Path | str | None = None,
+    strict: bool | None = None,
+    filename: str = SPEC_FILENAME,
+    max_depth: int = MAX_ANCESTOR_DEPTH,
+    stream: TextIO | None = None,
+) -> SpecPreconditionResult:
+    """Assert that a board recipe carries captured intent before it mutates.
+
+    Call this as the first statement of a recipe's ``main()``::
+
+        require_spec(__file__)
+
+    Args:
+        recipe_file: discovery anchor -- pass ``__file__``.  Defaults to the
+            calling module's ``__file__``.  **Never** pass ``Path.cwd()`` or
+            the output directory (see the module docstring).
+        spec_path: explicit artifact path, bypassing discovery.  This is the
+            escape hatch for a consumer repo whose intent artifact lives
+            somewhere else or is named something else.
+        strict: ``True`` engages the hard L2 gate, ``False`` forces advisory
+            mode, ``None`` (default) reads :data:`STRICT_ENV_VAR`.
+        filename: artifact filename for discovery (default ``project.kct``).
+        max_depth: bounded ancestor-walk depth.
+        stream: where the advisory is written (default ``sys.stderr``).
+
+    Returns:
+        A :class:`SpecPreconditionResult`.  Falsy when the precondition is
+        not met.
+
+    Raises:
+        SystemExit: only in strict mode, and only when the check actually
+            ran and failed.  Exit code is ``1``.
+    """
+    out = stream if stream is not None else sys.stderr
+    is_strict = _env_strict() if strict is None else bool(strict)
+    required = "L2" if is_strict else "L1"
+
+    try:
+        if spec_path is not None:
+            candidate = Path(spec_path)
+            searched: tuple[Path, ...] = (candidate,)
+            found = candidate if candidate.is_file() else None
+        else:
+            anchor = recipe_file if recipe_file is not None else _caller_file()
+            if anchor is None:
+                anchor = Path.cwd()  # last resort; documented as unreliable
+            found, searched = discover_spec(anchor, filename=filename, max_depth=max_depth)
+
+        if found is None:
+            level = "none"
+            reasons = [f"no {filename} found near {Path(searched[0]).parent if searched else '?'}"]
+        else:
+            level, reasons = _evaluate(found)
+    except Exception as exc:  # noqa: BLE001 - a helper bug must not kill a recipe
+        result = SpecPreconditionResult(
+            ok=False,
+            level="none",
+            required_level=required,
+            strict=is_strict,
+            checked=False,
+            reasons=(f"spec precondition could not be checked: {exc!r}",),
+        )
+        _print_advisory(result, out, filename=filename)
+        return result
+
+    ok = _level_rank(level) >= _level_rank(required)
+    result = SpecPreconditionResult(
+        ok=ok,
+        level=level,
+        required_level=required,
+        found_path=found,
+        searched=searched,
+        strict=is_strict,
+        checked=True,
+        reasons=tuple(reasons),
+    )
+
+    if ok:
+        return result
+
+    _print_advisory(result, out, filename=filename)
+    if is_strict:
+        # SystemExit (BaseException) intentionally bypasses the recipes'
+        # broad ``except Exception`` handlers so a strict failure cannot be
+        # downgraded into their generic error path -- and it happens before
+        # the recipe's first write.
+        raise SystemExit(1)
+    return result
+
+
+def _print_advisory(
+    result: SpecPreconditionResult,
+    out: TextIO,
+    *,
+    filename: str = SPEC_FILENAME,
+) -> None:
+    """Print the labelled advisory for a falsy verdict."""
+    label = "SPEC PRECONDITION FAILED" if result.strict else "spec precondition"
+    prefix = "❌" if result.strict else "⚠️"
+    print(f"\n{prefix}  {label}: no usable {filename} for this recipe", file=out)
+    for reason in result.reasons:
+        print(f"   - {reason}", file=out)
+    if result.found_path is None and result.searched:
+        print("   searched (nearest first):", file=out)
+        for candidate in result.searched:
+            print(f"     {candidate}", file=out)
+    if not result.checked:
+        print(
+            "   (the check itself failed; treating as UNKNOWN, not as a violation)",
+            file=out,
+        )
+    elif result.strict:
+        print(
+            f"   strict mode ({STRICT_ENV_VAR}) requires {result.required_level}; "
+            f"attained {result.level}. Aborting before any file is written.",
+            file=out,
+        )
+    else:
+        print(
+            f"   advisory only (attained {result.level}, need {result.required_level}); "
+            f"the recipe continues. Set {STRICT_ENV_VAR}=1 to make this fatal.",
+            file=out,
+        )
+    print(
+        "   This checks that captured intent EXISTS and parses -- it is NOT a "
+        "schema-completeness check.",
+        file=out,
+    )

--- a/tests/test_recipes_spec_precondition.py
+++ b/tests/test_recipes_spec_precondition.py
@@ -1,0 +1,502 @@
+"""Spec-precondition gate for mutating board recipes (issue #4539).
+
+:func:`kicad_tools.recipes.precondition.require_spec` is the **pre**-condition
+half of the recipe contract (``kicad_tools.recipes.gate`` is the post-condition
+half, #3912): before a board recipe mutates anything it asserts the board
+carries captured intent -- a non-empty, parseable ``project.kct``.
+
+Two layers of guard, mirroring ``tests/test_migrated_boards_gate_3912.py``:
+
+1. **Structural** -- every one of the 8 board recipe entry points imports the
+   shared helper and calls ``require_spec(__file__)``, anchored on ``__file__``
+   and never on ``Path.cwd()`` / ``sys.argv``.
+2. **Behavioural** -- ``tmp_path``-based exercises of the L0 -> L1 -> L2 ladder.
+
+.. important::
+
+   **The negative tests in :class:`TestGateActuallyFires` are the point of this
+   file.** All 8 boards already ship a ``project.kct``, so at L1 the whole fleet
+   passes on day one and an implementation that simply ``return True``-s is
+   indistinguishable from a correct one when run over ``boards/``. Every test in
+   that class is constructed so that a gate stubbed to always pass FAILS it.
+   Do not weaken them.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.recipes.precondition import (
+    SPEC_FILENAME,
+    STRICT_ENV_VAR,
+    SpecPreconditionResult,
+    discover_spec,
+    require_spec,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Every mutating board recipe entry point. Board 05's recipe is ``design.py``;
+# the rest are ``generate_design.py``. Secondary scripts
+# (``generate_schematic.py`` / ``generate_pcb.py`` / ``route_demo.py``) are
+# sub-stages or standalone demos and are deliberately out of scope (#4539).
+RECIPE_ENTRY_POINTS = [
+    "boards/00-simple-led/generate_design.py",
+    "boards/01-voltage-divider/generate_design.py",
+    "boards/02-charlieplex-led/generate_design.py",
+    "boards/03-usb-joystick/generate_design.py",
+    "boards/04-stm32-devboard/generate_design.py",
+    "boards/05-bldc-motor-controller/design.py",
+    "boards/06-diffpair-test/generate_design.py",
+    "boards/07-matchgroup-test/generate_design.py",
+]
+
+VALID_SPEC = """\
+kct_version: "1.0"
+
+project:
+  name: "Precondition Fixture"
+  revision: "A"
+
+intent:
+  summary: |
+    A minimal but semantically valid spec used to exercise the L2 gate.
+"""
+
+# Replicates board-01's shape as of origin/main @ 83d7625e: ``progress.phase``
+# names a phase that is absent from ``progress.phases``, so ``load_spec``
+# succeeds (L1) but ``validate_spec`` reports an error (not L2).
+L2_INVALID_SPEC = """\
+kct_version: "1.0"
+
+project:
+  name: "L2 Invalid Fixture"
+  revision: "A"
+
+progress:
+  phase: complete
+  phases:
+    concept:
+      status: completed
+    schematic:
+      status: completed
+"""
+
+MALFORMED_YAML = 'kct_version: "1.0"\nproject:\n  name: [unclosed\n'
+
+
+@pytest.fixture(autouse=True)
+def _clear_strict_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The helper reads ``KCT_REQUIRE_SPEC``; never inherit the ambient value."""
+    monkeypatch.delenv(STRICT_ENV_VAR, raising=False)
+
+
+def _make_board(tmp_path: Path, spec_text: str | None, name: str = "board") -> Path:
+    """Create a fake board dir with a recipe file and (optionally) a spec.
+
+    Returns the path of the recipe file (the discovery anchor).
+    """
+    board_dir = tmp_path / name
+    board_dir.mkdir(parents=True, exist_ok=True)
+    recipe = board_dir / "generate_design.py"
+    recipe.write_text("# fake recipe\n")
+    if spec_text is not None:
+        (board_dir / SPEC_FILENAME).write_text(spec_text)
+    return recipe
+
+
+# --------------------------------------------------------------------------
+# Structural guard: all 8 entry points call the shared helper
+# --------------------------------------------------------------------------
+@pytest.fixture(params=RECIPE_ENTRY_POINTS)
+def recipe_source(request: pytest.FixtureRequest) -> str:
+    path = REPO_ROOT / request.param
+    assert path.is_file(), f"recipe entry point not found: {path}"
+    return path.read_text()
+
+
+class TestRecipeWiring:
+    def test_imports_shared_helper(self, recipe_source: str) -> None:
+        assert "from kicad_tools.recipes.precondition import require_spec" in recipe_source
+
+    def test_calls_helper_anchored_on_dunder_file(self, recipe_source: str) -> None:
+        # Exactly one call, and it MUST be anchored on ``__file__``.
+        assert recipe_source.count("require_spec(") == 1
+        assert "require_spec(__file__)" in recipe_source
+
+    def test_does_not_anchor_on_cwd_or_argv(self, recipe_source: str) -> None:
+        # CI runs recipes from the repo root with an out-of-tree output dir;
+        # a cwd- or argv-anchored search would find nothing and the gate would
+        # fire spuriously on all 8 boards (#4539).
+        for forbidden in (
+            "require_spec(Path.cwd())",
+            "require_spec(sys.argv",
+            "require_spec(output_dir",
+        ):
+            assert forbidden not in recipe_source
+
+    def test_precedes_first_mutating_step(self, recipe_source: str) -> None:
+        """The call must come before the recipe's first ``create_*`` step."""
+        call_at = recipe_source.index("require_spec(__file__)")
+        first_write = min(
+            idx
+            for idx in (
+                recipe_source.find("create_project("),
+                recipe_source.find("output_dir.mkdir"),
+            )
+            if idx != -1
+        )
+        # ``create_project`` is also *defined* above ``main()``; what matters is
+        # that the call site precedes the invocation inside ``main()``.
+        main_at = recipe_source.index("def main()")
+        invocation = recipe_source.index("create_project(", main_at)
+        assert call_at < invocation, "require_spec() must run before create_project()"
+        assert first_write >= 0
+
+
+class TestFleetSpecsExistAndParse:
+    """Every shipped board must satisfy the DEFAULT (L1) gate."""
+
+    def test_all_eight_boards_pass_l1(self) -> None:
+        failures = []
+        for rel in RECIPE_ENTRY_POINTS:
+            result = require_spec(REPO_ROOT / rel, strict=False)
+            if not result.ok:
+                failures.append((rel, result.level, result.reasons))
+        assert not failures, f"boards failing the default L1 gate: {failures}"
+
+
+# --------------------------------------------------------------------------
+# THE NEGATIVE TESTS -- a gate stubbed to always pass MUST fail these
+# --------------------------------------------------------------------------
+class TestGateActuallyFires:
+    def test_missing_spec_is_advisory_and_falsy(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """MANDATORY negative test (#4539 "Vacuity risk").
+
+        An anchor with no ``project.kct`` anywhere in its bounded ancestry must
+        produce the advisory and a falsy verdict. An always-``True``
+        implementation fails here.
+        """
+        recipe = _make_board(tmp_path, spec_text=None)
+        result = require_spec(recipe, strict=False, max_depth=1)
+
+        assert result.ok is False
+        assert bool(result) is False
+        assert result.level == "none"
+        assert result.required_level == "L1"
+        assert result.found_path is None
+        assert result.searched  # the walk reports what it looked at
+
+        err = capsys.readouterr().err
+        assert "spec precondition" in err
+        assert SPEC_FILENAME in err
+
+    def test_missing_spec_in_strict_mode_exits_nonzero(self, tmp_path: Path) -> None:
+        recipe = _make_board(tmp_path, spec_text=None)
+        with pytest.raises(SystemExit) as excinfo:
+            require_spec(recipe, strict=True, max_depth=1)
+        assert excinfo.value.code == 1
+
+    def test_strict_mode_via_env_var_exits_nonzero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(STRICT_ENV_VAR, "1")
+        recipe = _make_board(tmp_path, spec_text=None)
+        with pytest.raises(SystemExit) as excinfo:
+            require_spec(recipe, max_depth=1)
+        assert excinfo.value.code == 1
+
+    def test_empty_spec_is_falsy(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        recipe = _make_board(tmp_path, spec_text="")
+        result = require_spec(recipe, strict=False, max_depth=1)
+        assert result.ok is False
+        assert result.level == "none"
+        assert "is empty" in capsys.readouterr().err
+
+    def test_whitespace_only_spec_is_falsy(self, tmp_path: Path) -> None:
+        recipe = _make_board(tmp_path, spec_text="   \n\n\t\n")
+        result = require_spec(recipe, strict=False, max_depth=1)
+        assert result.ok is False
+        assert result.level == "none"
+
+    def test_malformed_yaml_is_falsy_and_raises_nothing(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        recipe = _make_board(tmp_path, spec_text=MALFORMED_YAML)
+        result = require_spec(recipe, strict=False, max_depth=1)  # must not raise
+        assert result.ok is False
+        assert result.level == "L0", "L0 attained (exists, non-empty) but L1 not"
+        assert result.checked is True
+        assert "does not parse" in capsys.readouterr().err
+
+    def test_malformed_yaml_in_strict_mode_exits_nonzero(self, tmp_path: Path) -> None:
+        recipe = _make_board(tmp_path, spec_text=MALFORMED_YAML)
+        with pytest.raises(SystemExit):
+            require_spec(recipe, strict=True, max_depth=1)
+
+
+class TestLadderLevels:
+    def test_valid_spec_passes_quietly(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        recipe = _make_board(tmp_path, spec_text=VALID_SPEC)
+        result = require_spec(recipe, strict=False, max_depth=1)
+        assert result.ok is True
+        assert result.level == "L2"
+        assert result.found_path == recipe.parent / SPEC_FILENAME
+        assert capsys.readouterr().err == "", "a passing gate must print nothing"
+
+    def test_l2_invalid_spec_passes_default_but_fails_strict(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Board-01's shape: parses (L1) but fails semantic validation (not L2).
+
+        This is why L2 is NOT the default -- a default-on L2 would fail
+        ``boards/01-voltage-divider``'s CI job for a bookkeeping defect.
+        """
+        recipe = _make_board(tmp_path, spec_text=L2_INVALID_SPEC)
+
+        default_result = require_spec(recipe, strict=False, max_depth=1)
+        assert default_result.ok is True
+        assert default_result.level == "L1"
+        assert capsys.readouterr().err == ""
+
+        with pytest.raises(SystemExit) as excinfo:
+            require_spec(recipe, strict=True, max_depth=1)
+        assert excinfo.value.code == 1
+        err = capsys.readouterr().err
+        assert "not found in phases" in err
+
+    def test_board_01_is_the_real_l2_offender(self) -> None:
+        """Pins the measured fleet split: 8/8 at L1, 7/8 at L2.
+
+        If board-01's spec is repaired later (explicitly out of scope for
+        #4539), this test tells you exactly which assertion to update.
+        """
+        l1_pass = [
+            rel for rel in RECIPE_ENTRY_POINTS if require_spec(REPO_ROOT / rel, strict=False).ok
+        ]
+        assert len(l1_pass) == 8
+
+        l2_fail = []
+        for rel in RECIPE_ENTRY_POINTS:
+            try:
+                require_spec(REPO_ROOT / rel, strict=True)
+            except SystemExit:
+                l2_fail.append(rel)
+        assert l2_fail == ["boards/01-voltage-divider/generate_design.py"]
+
+
+class TestDiscoveryAnchor:
+    def test_anchors_on_recipe_file_not_cwd(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The sibling spec is found even when cwd is somewhere else entirely.
+
+        This is the CI invocation shape: ``uv run python
+        boards/00-simple-led/generate_design.py /tmp/board00-ci`` runs from the
+        repo root, so the anchor must be ``Path(__file__).parent``.
+        """
+        recipe = _make_board(tmp_path, spec_text=VALID_SPEC, name="board-anchored")
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        monkeypatch.chdir(elsewhere)
+
+        result = require_spec(recipe, strict=False, max_depth=1)
+        assert result.ok is True
+        assert result.found_path == recipe.parent / SPEC_FILENAME
+
+    def test_cwd_spec_is_not_used_when_anchor_has_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A ``project.kct`` in the *cwd* must not rescue a spec-less board."""
+        recipe = _make_board(tmp_path, spec_text=None, name="board-no-spec")
+        elsewhere = tmp_path / "cwd-with-spec"
+        elsewhere.mkdir()
+        (elsewhere / SPEC_FILENAME).write_text(VALID_SPEC)
+        monkeypatch.chdir(elsewhere)
+
+        result = require_spec(recipe, strict=False, max_depth=1)
+        assert result.ok is False
+        assert result.found_path is None
+
+    def test_output_dir_spec_is_not_used(self, tmp_path: Path) -> None:
+        """A spec in the out-of-tree output dir must not satisfy the gate."""
+        recipe = _make_board(tmp_path, spec_text=None, name="board-no-spec2")
+        out_dir = tmp_path / "out-of-tree"
+        out_dir.mkdir()
+        (out_dir / SPEC_FILENAME).write_text(VALID_SPEC)
+
+        result = require_spec(recipe, strict=False, max_depth=1)
+        assert result.ok is False
+
+    def test_finds_spec_in_ancestor(self, tmp_path: Path) -> None:
+        """The upward walk finds a spec that only exists in an ancestor."""
+        (tmp_path / SPEC_FILENAME).write_text(VALID_SPEC)
+        recipe = _make_board(tmp_path, spec_text=None, name="nested")
+        result = require_spec(recipe, strict=False, max_depth=4)
+        assert result.ok is True
+        assert result.found_path == tmp_path / SPEC_FILENAME
+
+    def test_walk_is_bounded_and_terminates_at_root(self) -> None:
+        """A huge max_depth must terminate at ``/`` rather than loop forever."""
+        found, searched = discover_spec(Path("/"), filename="definitely-absent.kct", max_depth=99)
+        assert found is None
+        assert len(searched) == 1  # stopped immediately at the filesystem root
+
+    def test_walk_is_depth_bounded(self, tmp_path: Path) -> None:
+        deep = tmp_path / "a" / "b" / "c" / "d"
+        deep.mkdir(parents=True)
+        (tmp_path / SPEC_FILENAME).write_text(VALID_SPEC)
+        # depth 2 only reaches ``d`` and ``c`` -- not tmp_path.
+        found, searched = discover_spec(deep, max_depth=2)
+        assert found is None
+        assert len(searched) == 2
+
+    def test_defaults_to_calling_module_file(self, tmp_path: Path) -> None:
+        """``require_spec()`` with no anchor uses the caller's ``__file__``."""
+        recipe = _make_board(tmp_path, spec_text=VALID_SPEC, name="implicit")
+        namespace: dict[str, object] = {
+            "__file__": str(recipe),
+            "require_spec": require_spec,
+        }
+        exec("result = require_spec(strict=False, max_depth=1)", namespace)  # noqa: S102
+        result = namespace["result"]
+        assert isinstance(result, SpecPreconditionResult)
+        assert result.ok is True
+        assert result.found_path == recipe.parent / SPEC_FILENAME
+
+
+class TestEscapeHatchAndPosture:
+    def test_explicit_spec_path_bypasses_discovery(self, tmp_path: Path) -> None:
+        """Consumer-repo escape hatch: point at an artifact anywhere."""
+        recipe = _make_board(tmp_path, spec_text=None, name="board-hatch")
+        alt = tmp_path / "somewhere" / "custom.kct"
+        alt.parent.mkdir()
+        alt.write_text(VALID_SPEC)
+
+        assert require_spec(recipe, spec_path=alt, strict=False).ok is True
+        assert require_spec(recipe, spec_path=tmp_path / "nope.kct", strict=False).ok is False
+
+    def test_gate_is_read_only(self, tmp_path: Path) -> None:
+        """The gate reports; it never repairs. Bytes and mtime are untouched."""
+        recipe = _make_board(tmp_path, spec_text=L2_INVALID_SPEC, name="board-ro")
+        spec_file = recipe.parent / SPEC_FILENAME
+        before = spec_file.read_bytes()
+        before_stat = spec_file.stat()
+        listing_before = sorted(p.name for p in recipe.parent.iterdir())
+
+        require_spec(recipe, strict=False, max_depth=1)
+        with pytest.raises(SystemExit):
+            require_spec(recipe, strict=True, max_depth=1)
+
+        assert spec_file.read_bytes() == before
+        assert spec_file.stat().st_mtime_ns == before_stat.st_mtime_ns
+        assert sorted(p.name for p in recipe.parent.iterdir()) == listing_before
+
+    def test_module_never_writes_specs(self) -> None:
+        """Static guard: no write call may appear in the helper.
+
+        Matches on *call* syntax so the module docstring may still name the
+        forbidden APIs when explaining why they are forbidden.
+        """
+        source = (REPO_ROOT / "src" / "kicad_tools" / "recipes" / "precondition.py").read_text()
+        for forbidden in (
+            "save_spec(",
+            "append_decision(",
+            ".write_text(",
+            ".write_bytes(",
+            ".unlink(",
+            ".mkdir(",
+            "shutil.",
+            "subprocess.",
+        ):
+            assert forbidden not in source, f"precondition helper must not use {forbidden}"
+        # ``import save_spec`` would be equally damning.
+        assert "import save_spec" not in source
+        assert "save_spec," not in source.split('"""', 2)[-1]
+
+    def test_no_l3_unrecognized_key_check(self) -> None:
+        """L3 (schema completeness) is explicitly out of scope for #4539.
+
+        PR #4619 makes ``kct spec validate`` report unrecognized keys; gating on
+        those would reject 8/8 boards and pre-empt a deferred schema-design
+        decision. The helper must say so and must not implement it.
+        """
+        source = (REPO_ROOT / "src" / "kicad_tools" / "recipes" / "precondition.py").read_text()
+        assert "no L3" in source or "There is deliberately no L3" in source
+        assert "unrecognized" in source, "the ceiling must be documented in-module"
+        # The actual check must not exist.
+        assert "model_extra" not in source
+        assert "unrecognized_keys" not in source
+
+    def test_internal_error_is_swallowed_not_raised(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A bug inside the helper must never crash a recipe -- even in strict mode."""
+        import kicad_tools.recipes.precondition as precondition_mod
+
+        def _boom(*args: object, **kwargs: object) -> None:
+            raise RuntimeError("simulated helper bug")
+
+        monkeypatch.setattr(precondition_mod, "discover_spec", _boom)
+        recipe = _make_board(tmp_path, spec_text=VALID_SPEC, name="board-boom")
+
+        result = precondition_mod.require_spec(recipe, strict=True)  # must NOT raise
+        assert result.ok is False
+        assert result.checked is False
+        err = capsys.readouterr().err
+        assert "could not be checked" in err
+
+    def test_env_var_falsy_values_stay_advisory(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        recipe = _make_board(tmp_path, spec_text=None, name="board-falsy")
+        for value in ("0", "false", "no", "off", ""):
+            monkeypatch.setenv(STRICT_ENV_VAR, value)
+            result = require_spec(recipe, max_depth=1)  # must not raise
+            assert result.ok is False
+            assert result.strict is False
+
+    def test_explicit_strict_false_overrides_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(STRICT_ENV_VAR, "1")
+        recipe = _make_board(tmp_path, spec_text=None, name="board-override")
+        result = require_spec(recipe, strict=False, max_depth=1)
+        assert result.strict is False
+        assert result.ok is False
+
+    def test_exported_from_package(self) -> None:
+        import kicad_tools.recipes as recipes_pkg
+
+        assert recipes_pkg.require_spec is require_spec
+        assert "require_spec" in recipes_pkg.__all__
+        assert "SpecPreconditionResult" in recipes_pkg.__all__
+
+
+class TestNoBoardSpecsModified:
+    """#4539 does not repair board content -- it only reports."""
+
+    def test_board_01_spec_still_l2_invalid(self) -> None:
+        from kicad_tools.spec.parser import validate_spec
+
+        valid, errors = validate_spec(REPO_ROOT / "boards/01-voltage-divider/project.kct")
+        assert valid is False
+        assert any("not found in phases" in e for e in errors)
+
+
+def test_recipes_import_cleanly() -> None:
+    """Importing the helper must not touch the filesystem or the environment."""
+    env_before = dict(os.environ)
+    modules_before = set(sys.modules)
+    import kicad_tools.recipes.precondition  # noqa: F401
+
+    assert dict(os.environ) == env_before
+    assert "kicad_tools.recipes.precondition" in modules_before | set(sys.modules)


### PR DESCRIPTION
## Summary

Adds `kicad_tools.recipes.precondition.require_spec()` — the **pre**-condition half of the recipe contract (`recipes.gate.evaluate_pipeline_gate` is the post-condition half, #3912). Before a board recipe mutates anything it now asserts the board carries **captured intent**: a `project.kct` that exists, is non-empty, and parses.

All 8 board recipe entry points call `require_spec(__file__)` as their first statement.

**Gate-strength ladder — L1 default, L2 strict opt-in, no L3:**

| Level | Check | Default | Strict | Fleet |
|---|---|---|---|---|
| L0 | exists + non-empty | required | required | 8/8 |
| **L1** | + `load_spec()` parses | **required** | required | **8/8** |
| **L2** | + `validate_spec()` clean | not checked | **required** | **7/8** |
| ~~L3~~ | ~~no unrecognized keys~~ | **NOT IMPLEMENTED** | — | 0/8 |

- **L1 is the default** and is advisory/fail-soft.
- **L2 is strict-only** (`KCT_REQUIRE_SPEC=1` or `strict=True`) because `boards/01-voltage-divider/project.kct` fails semantic validation today (`Progress: current phase 'complete' not found in phases`). A default-on L2 would fail board-01's CI job for a spec bookkeeping defect. **That spec is not touched by this PR.**
- **L3 is deliberately absent.** Gating on unrecognized/unmodelled `.kct` keys is the schema-design question deferred in PR #4619's review; after #4619 it would reject 8/8 boards. The module says so in its docstring and `test_no_l3_unrecognized_key_check` enforces it.

## Changes

**New**
- `src/kicad_tools/recipes/precondition.py` — `require_spec()`, `discover_spec()`, frozen `SpecPreconditionResult` (mirrors `PipelineGateResult`: `ok` / `level` / `required_level` / `found_path` / `searched` / `strict` / `checked` / `reasons`, with `__bool__`).
- `tests/test_recipes_spec_precondition.py` — 60 tests: structural guard over all 8 entry points + behavioural `tmp_path` ladder tests, including the mandatory negative tests.

**Modified**
- `src/kicad_tools/recipes/__init__.py` — exports the new helper; docstring now describes the pre/post-condition pair.
- The 8 recipe entry points (`boards/00…07`, plus board-05's `design.py`) — one import + one call each (10 added lines, all comment except the call).
- `boards/README.md` — new "Spec precondition" subsection: posture, `KCT_REQUIRE_SPEC`, the ladder table, the explicit non-goal of schema completeness, and the consumer-repo `spec_path=` escape hatch.

**Posture**
- **Read-only** w.r.t. the `.kct` — never `save_spec` / `append_decision` / any write. Statically enforced by `test_module_never_writes_specs`.
- **Default advisory** — labelled stderr warning + falsy result; does not raise, does not change the exit code.
- **Strict mode** raises `SystemExit(1)` *before* the first write. `SystemExit` derives from `BaseException`, so it deliberately passes straight through the recipes' broad `except Exception` handlers rather than being downgraded into their generic error path.
- **Never crashes a recipe** — an unexpected error inside the helper is swallowed as "could not check" (`checked=False`) and does **not** terminate even in strict mode; a helper bug is indistinguishable from "unknown".

**Discovery anchor (the trap).** The walk starts at `Path(__file__).parent` and climbs ≤ 6 ancestors, mirroring `_load_project_kct_for_escalation` (`cli/route_cmd.py:7544-7561`, referenced not modified). It is **not** anchored on `Path.cwd()` and **not** on the output dir: CI invokes recipes from the repo root with an out-of-tree output dir (`.github/workflows/ci.yml:979`), so either of those would find nothing and fire spuriously on all 8 boards. Three tests pin this (`test_anchors_on_recipe_file_not_cwd`, `test_cwd_spec_is_not_used_when_anchor_has_none`, `test_output_dir_spec_is_not_used`).

## Acceptance Criteria Verification

- [x] **Shared reusable helper in `src/kicad_tools/recipes/`, exported from `__init__.py`, read-only.** `require_spec` / `discover_spec` / `SpecPreconditionResult` are in `recipes.__all__`; `test_module_never_writes_specs` statically rejects `save_spec(` / `append_decision(` / `.write_text(` / `.write_bytes(` / `.unlink(` / `.mkdir(` / `shutil.` / `subprocess.` in the module source, and `test_gate_is_read_only` asserts spec bytes *and* `st_mtime_ns` are unchanged after both an advisory and a strict run.
- [x] **Bounded upward walk from `Path(__file__).parent`, not cwd, not the output dir.** Verified live from an unrelated cwd (`/private/var/folders/.../precond-cwd-u35_pb1h`) — all 8 boards still resolved their own sibling `project.kct` (output below).
- [x] **Default advisory + fail-soft.** Real run of a spec-less board copy printed the `⚠️ spec precondition` block and *continued* to completion; real `boards/00-simple-led/generate_design.py` into an out-of-tree dir exited **0** with **zero** advisory lines.
- [x] **Opt-in hard mode off by default**, via `KCT_REQUIRE_SPEC` (repo `KCT_*` convention) **and** `strict=True`. Explicit `strict=` overrides the env var (`test_explicit_strict_false_overrides_env`); falsy env values stay advisory.
- [x] **L1 default / L2 strict; no L3.** Measured 8/8 at L1, 7/8 at L2 (board-01 the only failure) — output below.
- [x] **All 8 entry points call the helper before the first mutating step.** Structural guard is parameterised over all 8 and asserts `require_spec(__file__)` appears exactly once and precedes the `create_project(` invocation inside `main()`.
- [x] **No behaviour change on the current fleet in default mode.** 8/8 pass L1 ⇒ nothing printed, no exit-code effect. Board-00 regenerated out-of-tree: `Overall: PASS`, `EXIT=0`, 0 advisory lines. Board-01 passes the default gate at L1 despite being L2-`Invalid` — proof L2 is not the default.
- [x] **Negative test (non-negotiable).** See "Proof the gate is not vacuous" below: stubbing `require_spec` to always return `ok=True` fails **20 of 60** tests.
- [x] **No `boards/*/project.kct` modified.** `git diff --cached --stat` touches zero `.kct` files; `TestNoBoardSpecsModified` asserts board-01's spec is *still* L2-invalid.
- [x] **Docs.** `boards/README.md` gains the subsection with posture, env-var name, and the explicit "not a schema-completeness check" statement.

### Fleet measurement (run from an unrelated cwd, anchoring on each recipe's `__file__`)

```
cwd during check: /private/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/precond-cwd-u35_pb1h

--- L1 (default/advisory) -----------------------------
  boards/00-simple-led/generate_design.py            PASS  level=L2 required=L1
  boards/01-voltage-divider/generate_design.py       PASS  level=L1 required=L1
  boards/02-charlieplex-led/generate_design.py       PASS  level=L2 required=L1
  boards/03-usb-joystick/generate_design.py          PASS  level=L2 required=L1
  boards/04-stm32-devboard/generate_design.py        PASS  level=L2 required=L1
  boards/05-bldc-motor-controller/design.py          PASS  level=L2 required=L1
  boards/06-diffpair-test/generate_design.py         PASS  level=L2 required=L1
  boards/07-matchgroup-test/generate_design.py       PASS  level=L2 required=L1
  => 8/8 pass

--- L2 (strict) ---------------------------------------
  boards/00-simple-led/generate_design.py            PASS  level=L2 required=L2

❌  SPEC PRECONDITION FAILED: no usable project.kct for this recipe
   - .../boards/01-voltage-divider/project.kct: Progress: current phase 'complete' not found in phases
   strict mode (KCT_REQUIRE_SPEC) requires L2; attained L1. Aborting before any file is written.
   This checks that captured intent EXISTS and parses -- it is NOT a schema-completeness check.
  boards/01-voltage-divider/generate_design.py       FAIL (SystemExit 1)
  boards/02-charlieplex-led/generate_design.py       PASS  level=L2 required=L2
  boards/03-usb-joystick/generate_design.py          PASS  level=L2 required=L2
  boards/04-stm32-devboard/generate_design.py        PASS  level=L2 required=L2
  boards/05-bldc-motor-controller/design.py          PASS  level=L2 required=L2
  boards/06-diffpair-test/generate_design.py         PASS  level=L2 required=L2
  boards/07-matchgroup-test/generate_design.py       PASS  level=L2 required=L2
  => 7/8 pass
```

Full paths were printed for each `found=` (elided here for width); every one resolved to that board's own directory, never the cwd.

### Proof the gate is not vacuous

All 8 boards already ship a `project.kct`, so at L1 the fleet passes on day one and an always-`True` implementation is indistinguishable from a correct one. To prove the tests actually detect that, the body of `require_spec()` was temporarily replaced with an unconditional `return SpecPreconditionResult(ok=True, level="L2", ...)` stub and the suite re-run:

```
FAILED tests/test_recipes_spec_precondition.py::TestGateActuallyFires::test_missing_spec_is_advisory_and_falsy
FAILED tests/test_recipes_spec_precondition.py::TestGateActuallyFires::test_missing_spec_in_strict_mode_exits_nonzero
FAILED tests/test_recipes_spec_precondition.py::TestGateActuallyFires::test_strict_mode_via_env_var_exits_nonzero
FAILED tests/test_recipes_spec_precondition.py::TestGateActuallyFires::test_empty_spec_is_falsy
FAILED tests/test_recipes_spec_precondition.py::TestGateActuallyFires::test_whitespace_only_spec_is_falsy
FAILED tests/test_recipes_spec_precondition.py::TestGateActuallyFires::test_malformed_yaml_is_falsy_and_raises_nothing
FAILED tests/test_recipes_spec_precondition.py::TestGateActuallyFires::test_malformed_yaml_in_strict_mode_exits_nonzero
FAILED tests/test_recipes_spec_precondition.py::TestLadderLevels::test_valid_spec_passes_quietly
FAILED tests/test_recipes_spec_precondition.py::TestLadderLevels::test_l2_invalid_spec_passes_default_but_fails_strict
FAILED tests/test_recipes_spec_precondition.py::TestLadderLevels::test_board_01_is_the_real_l2_offender
FAILED tests/test_recipes_spec_precondition.py::TestDiscoveryAnchor::test_anchors_on_recipe_file_not_cwd
FAILED tests/test_recipes_spec_precondition.py::TestDiscoveryAnchor::test_cwd_spec_is_not_used_when_anchor_has_none
FAILED tests/test_recipes_spec_precondition.py::TestDiscoveryAnchor::test_output_dir_spec_is_not_used
FAILED tests/test_recipes_spec_precondition.py::TestDiscoveryAnchor::test_finds_spec_in_ancestor
FAILED tests/test_recipes_spec_precondition.py::TestDiscoveryAnchor::test_defaults_to_calling_module_file
FAILED tests/test_recipes_spec_precondition.py::TestEscapeHatchAndPosture::test_explicit_spec_path_bypasses_discovery
FAILED tests/test_recipes_spec_precondition.py::TestEscapeHatchAndPosture::test_gate_is_read_only
FAILED tests/test_recipes_spec_precondition.py::TestEscapeHatchAndPosture::test_internal_error_is_swallowed_not_raised
FAILED tests/test_recipes_spec_precondition.py::TestEscapeHatchAndPosture::test_env_var_falsy_values_stay_advisory
FAILED tests/test_recipes_spec_precondition.py::TestEscapeHatchAndPosture::test_explicit_strict_false_overrides_env
20 failed, 40 passed in 2.61s
```

The stub was then reverted; the restored file's md5 is byte-identical to the pre-stub original (`85ebcc28a636b0668c61c9cf6003174a`), and the suite is green again.

## Test Plan

- [x] `pytest tests/test_recipes_spec_precondition.py` → **60 passed** (5.4s)
- [x] Regression: `pytest tests/test_migrated_boards_gate_3912.py tests/test_recipes_gate.py tests/test_spec.py tests/test_board_04_main_gate.py tests/test_recipes_spec_precondition.py` → **199 passed, 1 skipped**
- [x] `ruff check .` → `All checks passed!`; `ruff format . --check` → `1730 files already formatted`
- [x] `mypy src/kicad_tools/recipes/precondition.py src/kicad_tools/recipes/__init__.py` → `Success: no issues found`
- [x] `scripts/ci/check_mypy_baseline.py` → `OK: mypy reports 1473 error(s), all within the baseline (1474 allowed). No new type errors.` (the "1 baseline error no longer occurs" warning is the known native-build env artefact; the baseline file is intentionally **not** updated here)
- [x] Manual — no-op on the fleet: `python boards/00-simple-led/generate_design.py <out-of-tree-dir>` → `Overall: PASS`, `EXIT=0`, `grep -c "spec precondition"` = **0**
- [x] Manual — the gate fires. Board-00's recipe copied to a scratch dir with **no** `project.kct`:
  - Strict (`KCT_REQUIRE_SPEC=1`): printed `❌ SPEC PRECONDITION FAILED …`, listed all 6 searched ancestors, `exit=1`, and the output directory **was never created** (`ls: … No such file or directory`) — i.e. it aborted before any file was written.
  - Default: printed `⚠️ spec precondition … advisory only … the recipe continues`, then ran the pipeline normally.
- [x] Edge cases covered by tests: arbitrary cwd, spec only in an ancestor, depth-bounded walk, walk terminating at `/` without hanging, empty / whitespace-only / malformed-YAML specs, helper-internal error swallowed.
- [x] `git status --porcelain` clean after commit; **no** `boards/*/output/` artifact regenerated in the repo and **no** `boards/*/project.kct` modified.

## Scope notes

- Board-01's `progress.phase` mismatch is **not** fixed here (explicit non-goal; the gate reports, it does not repair).
- Secondary board scripts (`generate_schematic.py`, `generate_pcb.py`, `route_demo.py`, `ddr_bundle_isolation_repro.py`) are **not** wired — deliberate, per the issue; widening to them is a follow-up.
- `examples/10-complete-kct-workflow/project.kct` is an example, not a board recipe — untouched.
- No overlap with #4538 / PR #4619 (`spec/parser.py`, `spec/schema.py`, `cli/commands/spec.py` are untouched); the two land in either order. Once #4619 merges, the strict-mode advisory could optionally surface its named unrecognized-key warnings — a follow-up, not a prerequisite, and it must **not** become a gating condition.
- Sibling scopes #4540 / #4541 / #4542 / #4543 untouched.

Closes #4539
