### PR TITLE
feat(check): probe stem-keyed net-class-map sidecars and name probed paths

### DIFF
--- a/docs/guides/drc-and-validation.md
+++ b/docs/guides/drc-and-validation.md
@@ -124,6 +124,44 @@ a bare CLI run). The sidecar is produced from the board's
 `build_net_class_map()` via `net_class_map_to_dict` and consumed via
 `net_class_map_from_dict`.
 
+**Auto-discovery.** When `--net-class-map` is omitted, `kct check` probes for a
+sidecar next to the board. Two filename conventions are accepted — the
+stem-keyed `<board-stem>.net_class_map.json` (hand-maintained trees that keep
+several board revisions side by side) and the bare `net_class_map.json` written
+by `kct route` — searched in this order:
+
+```
+<board-dir>/<board-stem>.net_class_map.json
+<board-dir>/net_class_map.json
+<board-dir>/output/<board-stem>.net_class_map.json
+<board-dir>/output/net_class_map.json
+<board-dir>/../output/<board-stem>.net_class_map.json
+<board-dir>/../output/net_class_map.json
+```
+
+The first existing file wins: within a directory the stem-keyed name beats the
+bare one, and nearer directories beat farther ones. When a sidecar is picked up
+this way, `kct check` says so on stderr:
+
+```
+[INFO] auto-loaded net-class-map sidecar: /path/to/board_v24.net_class_map.json
+```
+
+The stem must match **exactly** — no globbing, no un-suffixing. A directory
+holding both `board_v23.net_class_map.json` and `board_v24.net_class_map.json`
+never applies v23's constraints to `board_v24.kicad_pcb`, and a board routed to
+`board_routed.kicad_pcb` looks for `board_routed.net_class_map.json`, *not*
+`board.net_class_map.json`. An explicit `--net-class-map` always wins and
+short-circuits the probe entirely. An auto-discovered sidecar that fails to
+parse degrades gracefully (`WARNING: ignoring malformed net-class-map sidecar
+…`, then continue with no map); an explicit one that fails is a hard error.
+
+Pass `--no-net-class-map` to suppress auto-discovery and restore the
+historical no-sidecar behaviour — useful when a stale sidecar sits beside the
+board. Combining it with `--net-class-map` is a usage error. When no sidecar is
+found (or discovery is disabled), the "rules are INACTIVE" warning names the
+exact paths that were probed, or says that discovery was turned off.
+
 **CI resolves the map automatically.** The strict routed-PCB DRC gate
 (`scripts/ci/check_routed_drc.py`) is net-class-map-aware: it prefers a
 committed `net_class_map.json` next to the routed PCB and, for boards that

--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -300,8 +300,57 @@ def _parse_copper_weight_arg(raw: str) -> tuple[float | None, float | None]:
     return (outer, inner)
 
 
+def _net_class_map_sidecar_candidates(pcb_path: Path) -> list[Path]:
+    """Enumerate the net-class-map sidecar paths the auto-probe checks.
+
+    Split out from :func:`_discover_net_class_map_sidecar` (Issue #4601)
+    so the "rules are INACTIVE" warning can name the paths that were
+    *actually* searched instead of an invented ``output/…`` example.
+
+    Two filename conventions are probed in each directory:
+
+    - ``<pcb_stem>.net_class_map.json`` -- the stem-keyed sidecar
+      convention used by hand-maintained board trees that keep several
+      revisions side by side (``board_v24.kicad_pcb`` next to
+      ``board_v24.net_class_map.json``).
+    - ``net_class_map.json`` -- the bare name written by ``kct route``
+      (Issue #3917 Defect 1 / #4428).
+
+    Ordering is deliberate: within a directory the **stem-keyed** name
+    wins (it is evidence about *this* board, not a generic file), and
+    nearer directories win over farther ones (the pre-#4601
+    ``pcb_dir`` -> ``pcb_dir/output`` -> ``pcb_dir.parent/output``
+    order is preserved).
+
+    The stem must match **exactly**: no globbing and no un-suffixing
+    heuristics.  A directory holding ``board_v23.net_class_map.json``
+    and ``board_v24.net_class_map.json`` must never apply v23's
+    constraints to a v24 board, and ``board_routed.kicad_pcb`` looks
+    only for ``board_routed.net_class_map.json``.
+
+    Returns:
+        Candidate paths in probe order, de-duplicated (the
+        ``<board>/output/<pcb>`` layout makes ``pcb_dir`` and
+        ``pcb_dir.parent/output`` the same directory).
+    """
+    pcb_dir = pcb_path.parent
+    names = [f"{pcb_path.stem}.net_class_map.json", "net_class_map.json"]
+    directories = [pcb_dir, pcb_dir / "output", pcb_dir.parent / "output"]
+
+    candidates: list[Path] = []
+    seen: set[Path] = set()
+    for directory in directories:
+        for name in names:
+            candidate = directory / name
+            if candidate in seen:
+                continue
+            seen.add(candidate)
+            candidates.append(candidate)
+    return candidates
+
+
 def _discover_net_class_map_sidecar(pcb_path: Path) -> Path | None:
-    """Probe conventional locations for a ``net_class_map.json`` sidecar.
+    """Probe conventional locations for a net-class-map sidecar.
 
     Issue #3917 Defect 2: ``kct route`` writes a ``net_class_map.json``
     sidecar next to the routed PCB (in the output directory).  ``kct
@@ -309,28 +358,15 @@ def _discover_net_class_map_sidecar(pcb_path: Path) -> Path | None:
     rules fire without the user having to pass ``--net-class-map`` by
     hand -- mirroring the existing schematic auto-discovery.
 
-    Candidate locations, in priority order, relative to the resolved
-    PCB path:
-
-    - ``<pcb_dir>/net_class_map.json`` (sidecar written alongside a
-      routed board that lives in its own output directory)
-    - ``<pcb_dir>/output/net_class_map.json`` (board dir with an
-      ``output/`` subtree)
-    - ``<pcb_dir>/../output/net_class_map.json`` (routed PCB inside
-      ``output/`` with the sidecar as a sibling -- redundant with the
-      first candidate but kept for the ``<board>/output/<pcb>`` layout)
+    Issue #4601 widened the probe to also accept the stem-keyed
+    ``<pcb_stem>.net_class_map.json`` convention.  See
+    :func:`_net_class_map_sidecar_candidates` for the full probe order.
 
     Returns:
         The first existing candidate path, or ``None`` when no sidecar
         is found.
     """
-    pcb_dir = pcb_path.parent
-    candidates = [
-        pcb_dir / "net_class_map.json",
-        pcb_dir / "output" / "net_class_map.json",
-        pcb_dir.parent / "output" / "net_class_map.json",
-    ]
-    for candidate in candidates:
+    for candidate in _net_class_map_sidecar_candidates(pcb_path):
         if candidate.is_file():
             return candidate
     return None
@@ -1266,7 +1302,22 @@ def main(argv: list[str] | None = None) -> int:
             "fields (see kicad_tools.router.rules.NetClassRouting.to_dict). "
             "When supplied, enables the diff-pair routing_continuity and "
             "length_skew rules to fire on routed boards; without it those "
-            "rules degrade to no-ops (Issue #2684)."
+            "rules degrade to no-ops (Issue #2684). Auto-discovered next to "
+            "the board when this flag is omitted -- as "
+            "<board-stem>.net_class_map.json or net_class_map.json, in the "
+            "board dir then output/ then ../output/ (Issue #4601). Use "
+            "--no-net-class-map to suppress that auto-discovery."
+        ),
+    )
+    parser.add_argument(
+        "--no-net-class-map",
+        dest="no_net_class_map",
+        action="store_true",
+        help=(
+            "Suppress net-class-map sidecar auto-discovery, restoring the "
+            "no-sidecar behaviour (the diff-pair / match-group skew rules "
+            "stay inactive). Cannot be combined with --net-class-map "
+            "(Issue #4601)."
         ),
     )
     parser.add_argument(
@@ -1323,6 +1374,19 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     args = parser.parse_args(argv)
+
+    # Issue #4601: --no-net-class-map suppresses sidecar auto-discovery.
+    # Pairing it with an explicit --net-class-map is a usage error rather
+    # than a silent precedence puzzle.
+    if getattr(args, "no_net_class_map", False) and args.net_class_map is not None:
+        print(
+            "Error: --no-net-class-map cannot be combined with "
+            f"--net-class-map {args.net_class_map!r}: one disables sidecar "
+            "auto-discovery, the other names a sidecar to load. Pass exactly "
+            "one of them.",
+            file=sys.stderr,
+        )
+        return 1
 
     # Parse and validate filter options
     only_set: set[str] | None = None
@@ -1431,9 +1495,16 @@ def main(argv: list[str] | None = None) -> int:
     # to the routed PCB.  An explicit flag always wins and short-circuits
     # the probe (AC3: no double-load).
     ncm_explicit = args.net_class_map is not None
+    # Issue #4601: --no-net-class-map suppresses the probe only (the
+    # explicit-flag combination was already rejected above).
+    ncm_suppressed = bool(getattr(args, "no_net_class_map", False))
+    ncm_candidates: list[Path] = []
     if ncm_explicit:
         ncm_path: Path | None = Path(args.net_class_map).resolve()
+    elif ncm_suppressed:
+        ncm_path = None
     else:
+        ncm_candidates = _net_class_map_sidecar_candidates(pcb_path)
         ncm_path = _discover_net_class_map_sidecar(pcb_path)
 
     if ncm_path is not None:
@@ -1495,14 +1566,35 @@ def main(argv: list[str] | None = None) -> int:
             if (only_set is None or rule in only_set) and rule not in skip_set
         ]
         if _inactive_rules:
-            print(
+            # Issue #4601: name what was actually probed instead of an
+            # invented example path that may not correspond to the layout
+            # in use.
+            _head = (
                 "WARNING: the following rules are INACTIVE without "
                 "--net-class-map and will silently pass: "
-                f"{', '.join(_inactive_rules)}.  Pass the routed board's "
-                "sidecar (e.g. output/net_class_map.json) to validate "
-                "length-match skew.",
-                file=sys.stderr,
+                f"{', '.join(_inactive_rules)}."
             )
+            if ncm_suppressed:
+                _tail = (
+                    "  Sidecar auto-discovery was disabled with "
+                    "--no-net-class-map; drop that flag or pass a sidecar "
+                    "explicitly with --net-class-map to validate "
+                    "length-match skew."
+                )
+            elif ncm_path is not None:
+                _tail = (
+                    f"  The sidecar at {ncm_path} could not be loaded (see "
+                    "the warning above); fix it or pass a different one with "
+                    "--net-class-map to validate length-match skew."
+                )
+            else:
+                _probed = "".join(f"\n  {candidate}" for candidate in ncm_candidates)
+                _tail = (
+                    f"  No sidecar was found at any of:{_probed}\n"
+                    "Pass one explicitly with --net-class-map, or place it at "
+                    "one of the paths above, to validate length-match skew."
+                )
+            print(_head + _tail, file=sys.stderr)
 
     # Load optional courtyard-waivers sidecar (Issue #4137).  An explicit
     # --courtyard-waivers path always wins and a malformed explicit file is a

--- a/src/kicad_tools/cli/commands/validation.py
+++ b/src/kicad_tools/cli/commands/validation.py
@@ -259,6 +259,9 @@ def run_check_command(args) -> int:
         sub_argv.extend(["--schematic", args.schematic])
     if getattr(args, "net_class_map", None):
         sub_argv.extend(["--net-class-map", args.net_class_map])
+    # Issue #4601: forward the sidecar auto-discovery opt-out.
+    if getattr(args, "no_net_class_map", False):
+        sub_argv.append("--no-net-class-map")
     # Issue #3061: forward pad_grid tolerance flags.
     if getattr(args, "pad_grid_strict", False):
         sub_argv.append("--pad-grid-strict")

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -790,7 +790,22 @@ def _add_check_parser(subparsers) -> None:
             "Path to a JSON sidecar mapping net names to NetClassRouting "
             "fields.  When supplied, enables the diff-pair DRC rules "
             "(routing_continuity, length_skew) to fire on routed boards "
-            "(Issue #2684)."
+            "(Issue #2684).  Auto-discovered next to the board when this "
+            "flag is omitted -- as <board-stem>.net_class_map.json or "
+            "net_class_map.json, in the board dir then output/ then "
+            "../output/ (Issue #4601).  Use --no-net-class-map to suppress "
+            "that auto-discovery."
+        ),
+    )
+    check_parser.add_argument(
+        "--no-net-class-map",
+        dest="no_net_class_map",
+        action="store_true",
+        help=(
+            "Suppress net-class-map sidecar auto-discovery, restoring the "
+            "no-sidecar behaviour (the diff-pair / match-group skew rules "
+            "stay inactive).  Cannot be combined with --net-class-map "
+            "(Issue #4601)."
         ),
     )
     # Issue #3061: per-board auto-derive of the pad_grid tolerance is the

--- a/src/kicad_tools/validate/checker.py
+++ b/src/kicad_tools/validate/checker.py
@@ -669,8 +669,8 @@ class DRCChecker:
         self._inactive_skew_warned.add(rule_name)
         print(
             f"WARNING: rule {rule_name!r} is INACTIVE without a net-class-map "
-            "sidecar and will silently pass; pass the routed board's sidecar "
-            "(e.g. output/net_class_map.json) to validate length-match skew.",
+            "sidecar and will silently pass; supply a net-class-map sidecar "
+            "to validate length-match skew.",
             file=sys.stderr,
         )
 

--- a/tests/test_cli_check_net_class_map.py
+++ b/tests/test_cli_check_net_class_map.py
@@ -488,6 +488,227 @@ class TestSidecarAutoLoad:
         # Fell back to no-sidecar -> rule is a no-op.
         assert _mg_error_count(captured.out) == 0
 
+    # ---------------------------------------------------------------
+    # Issue #4601: the probe also accepts the stem-keyed
+    # ``<pcb_stem>.net_class_map.json`` convention, the INACTIVE warning
+    # names the paths it actually probed, and ``--no-net-class-map``
+    # suppresses discovery.
+    # ---------------------------------------------------------------
+
+    @staticmethod
+    def _mg_argv(pcb: Path, *extra: str) -> list[str]:
+        return [
+            str(pcb),
+            "--only",
+            "match_group_length_skew",
+            "--format",
+            "json",
+            "--allow-incomplete",
+            *extra,
+        ]
+
+    def test_auto_load_stem_keyed_sidecar(self, tmp_path: Path, capsys):
+        """AC1/AC2: ``<pcb_stem>.net_class_map.json`` beside the board is
+        auto-loaded, reported, and engages the gated rule."""
+        from kicad_tools.cli.check_cmd import main
+
+        pcb = _write_matchgroup_board(tmp_path)  # ddr.kicad_pcb
+        scar = tmp_path / "ddr.net_class_map.json"
+        scar.write_text(json.dumps(MATCHGROUP_SIDECAR, indent=2))
+
+        rc = main(self._mg_argv(pcb))
+        captured = capsys.readouterr()
+        assert f"auto-loaded net-class-map sidecar: {scar}" in captured.err
+        assert _mg_error_count(captured.out) >= 1
+        assert rc == 2
+
+    def test_stem_keyed_beats_bare_in_same_directory(self, tmp_path: Path, capsys):
+        """AC3: within a directory the stem-keyed name wins over the bare one."""
+        from kicad_tools.cli.check_cmd import main
+
+        pcb = _write_matchgroup_board(tmp_path)
+        stem_scar = tmp_path / "ddr.net_class_map.json"
+        stem_scar.write_text(json.dumps(MATCHGROUP_SIDECAR, indent=2))
+        _write_matchgroup_sidecar(tmp_path)  # bare net_class_map.json
+
+        main(self._mg_argv(pcb))
+        captured = capsys.readouterr()
+        assert f"auto-loaded net-class-map sidecar: {stem_scar}" in captured.err
+        assert f"sidecar: {tmp_path / 'net_class_map.json'}" not in captured.err
+
+    def test_nearer_directory_beats_farther(self, tmp_path: Path, capsys):
+        """AC3: the pcb_dir -> output/ -> ../output/ order is preserved."""
+        from kicad_tools.cli.check_cmd import main
+
+        board_dir = tmp_path / "board"
+        board_dir.mkdir()
+        pcb = _write_matchgroup_board(board_dir)
+
+        near = board_dir / "output"
+        near.mkdir()
+        near_scar = near / "ddr.net_class_map.json"
+        near_scar.write_text(json.dumps(MATCHGROUP_SIDECAR, indent=2))
+
+        far = tmp_path / "output"
+        far.mkdir()
+        (far / "ddr.net_class_map.json").write_text(json.dumps(MATCHGROUP_SIDECAR, indent=2))
+
+        main(self._mg_argv(pcb))
+        captured = capsys.readouterr()
+        assert f"auto-loaded net-class-map sidecar: {near_scar}" in captured.err
+
+    def test_stem_keyed_sidecar_in_parent_output(self, tmp_path: Path, capsys):
+        """The ``<board>/output/<pcb>`` layout finds a stem-keyed sibling."""
+        from kicad_tools.cli.check_cmd import main
+
+        out_dir = tmp_path / "output"
+        out_dir.mkdir()
+        pcb = _write_matchgroup_board(out_dir)
+        scar = out_dir / "ddr.net_class_map.json"
+        scar.write_text(json.dumps(MATCHGROUP_SIDECAR, indent=2))
+
+        main(self._mg_argv(pcb))
+        captured = capsys.readouterr()
+        assert f"auto-loaded net-class-map sidecar: {scar}" in captured.err
+
+    def test_foreign_stem_sidecar_is_ignored(self, tmp_path: Path, capsys):
+        """AC4: a stem-keyed sidecar for a *different* board revision is not
+        loaded -- exact-stem matching, never a glob."""
+        from kicad_tools.cli.check_cmd import main
+
+        pcb = _write_matchgroup_board(tmp_path)  # ddr.kicad_pcb
+        (tmp_path / "ddr_v23_mfg.net_class_map.json").write_text(
+            json.dumps(MATCHGROUP_SIDECAR, indent=2)
+        )
+
+        main(self._mg_argv(pcb))
+        captured = capsys.readouterr()
+        assert "auto-loaded net-class-map sidecar" not in captured.err
+        assert _mg_error_count(captured.out) == 0
+
+    def test_routed_stem_is_not_unsuffixed(self, tmp_path: Path, capsys):
+        """Hazard 2: ``<name>_routed.kicad_pcb`` does not fall back to
+        ``<name>.net_class_map.json``."""
+        from kicad_tools.cli.check_cmd import main
+
+        pcb = tmp_path / "ddr_routed.kicad_pcb"
+        pcb.write_text(MATCHGROUP_PCB)
+        (tmp_path / "ddr.net_class_map.json").write_text(json.dumps(MATCHGROUP_SIDECAR, indent=2))
+
+        main(self._mg_argv(pcb))
+        captured = capsys.readouterr()
+        assert "auto-loaded net-class-map sidecar" not in captured.err
+
+    def test_sidecar_directory_is_rejected(self, tmp_path: Path, capsys):
+        """A stem-keyed *directory* is not a sidecar (``is_file()`` guard)."""
+        from kicad_tools.cli.check_cmd import main
+
+        pcb = _write_matchgroup_board(tmp_path)
+        (tmp_path / "ddr.net_class_map.json").mkdir()
+
+        main(self._mg_argv(pcb))
+        captured = capsys.readouterr()
+        assert "auto-loaded net-class-map sidecar" not in captured.err
+
+    def test_inactive_warning_lists_probed_paths(self, tmp_path: Path, capsys):
+        """AC8: with no sidecar anywhere the warning enumerates the actual
+        candidates instead of an invented ``output/`` example."""
+        from kicad_tools.cli.check_cmd import (
+            _net_class_map_sidecar_candidates,
+            main,
+        )
+
+        pcb = _write_matchgroup_board(tmp_path)
+
+        main(self._mg_argv(pcb))
+        captured = capsys.readouterr()
+        assert "INACTIVE" in captured.err
+        for candidate in _net_class_map_sidecar_candidates(pcb):
+            assert str(candidate) in captured.err
+        # The invented example path is gone.
+        assert "(e.g. output/net_class_map.json)" not in captured.err
+
+    def test_no_net_class_map_suppresses_discovery(self, tmp_path: Path, capsys):
+        """AC6/AC9: ``--no-net-class-map`` behaves exactly like "no sidecar",
+        and the warning says discovery was disabled rather than listing paths."""
+        from kicad_tools.cli.check_cmd import main
+
+        pcb = _write_matchgroup_board(tmp_path)
+        (tmp_path / "ddr.net_class_map.json").write_text(json.dumps(MATCHGROUP_SIDECAR, indent=2))
+
+        rc = main(self._mg_argv(pcb, "--no-net-class-map"))
+        captured = capsys.readouterr()
+        assert "auto-loaded net-class-map sidecar" not in captured.err
+        assert _mg_error_count(captured.out) == 0
+        assert rc != 2
+        assert "--no-net-class-map" in captured.err
+        assert str(tmp_path / "ddr.net_class_map.json") not in captured.err
+
+    def test_no_net_class_map_conflicts_with_explicit(self, tmp_path: Path, capsys):
+        """AC7: the two flags together are a usage error, not a precedence
+        puzzle."""
+        from kicad_tools.cli.check_cmd import main
+
+        pcb = _write_matchgroup_board(tmp_path)
+        scar = _write_matchgroup_sidecar(tmp_path)
+
+        rc = main(self._mg_argv(pcb, "--no-net-class-map", "--net-class-map", str(scar)))
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "--no-net-class-map" in captured.err
+        assert "--net-class-map" in captured.err
+
+    def test_malformed_stem_keyed_auto_sidecar_falls_back(self, tmp_path: Path, capsys):
+        """AC10: a malformed stem-keyed auto-sidecar warns audibly and keeps
+        going (mirrors the bare-name contract)."""
+        from kicad_tools.cli.check_cmd import main
+
+        pcb = _write_matchgroup_board(tmp_path)
+        scar = tmp_path / "ddr.net_class_map.json"
+        scar.write_text("not { valid json")
+
+        rc = main(self._mg_argv(pcb))
+        captured = capsys.readouterr()
+        assert rc != 1
+        assert f"ignoring malformed net-class-map sidecar {scar}" in captured.err
+        assert _mg_error_count(captured.out) == 0
+
+    def test_auto_sidecar_with_back_copper_avoid_layer_warns(self, tmp_path: Path, capsys):
+        """AC10: ``avoid_layers: ["B.Cu"]`` is rejected by
+        ``net_class_map_from_dict`` (no LayerStack is threaded at this
+        callsite) -- that must warn audibly and continue, never crash."""
+        from kicad_tools.cli.check_cmd import main
+
+        pcb = _write_matchgroup_board(tmp_path)
+        scar = tmp_path / "ddr.net_class_map.json"
+        payload = {
+            name: {**entry, "avoid_layers": ["B.Cu"]} for name, entry in MATCHGROUP_SIDECAR.items()
+        }
+        scar.write_text(json.dumps(payload, indent=2))
+
+        rc = main(self._mg_argv(pcb))
+        captured = capsys.readouterr()
+        assert rc != 1
+        assert f"ignoring malformed net-class-map sidecar {scar}" in captured.err
+        assert "B.Cu" in captured.err
+        # Still degrades to no-sidecar behaviour rather than crashing.
+        assert _mg_error_count(captured.out) == 0
+
+    def test_explicit_flag_still_wins_over_stem_keyed_sidecar(self, tmp_path: Path, capsys):
+        """AC5: an explicit path short-circuits the widened probe too."""
+        from kicad_tools.cli.check_cmd import main
+
+        pcb = _write_matchgroup_board(tmp_path)
+        (tmp_path / "ddr.net_class_map.json").write_text("not { valid json")
+        explicit = tmp_path / "explicit.json"
+        explicit.write_text(json.dumps(MATCHGROUP_SIDECAR, indent=2))
+
+        main(self._mg_argv(pcb, "--net-class-map", str(explicit)))
+        captured = capsys.readouterr()
+        assert "auto-loaded net-class-map sidecar" not in captured.err
+        assert "malformed net-class-map sidecar" not in captured.err
+        assert _mg_error_count(captured.out) >= 1
+
 
 class TestSidecarWrittenByRoute:
     """Issue #3917 Defect 1: the route step persists the net-class map as a


### PR DESCRIPTION
## Summary

`kct check` has auto-discovered a net-class-map sidecar since #3917 Defect 2 —
**that machinery was not rebuilt.** The real defect is narrower: the probe only
knew the *bare* filename `net_class_map.json`, so board trees that key the
sidecar to the board stem (`board_v24.kicad_pcb` beside
`board_v24.net_class_map.json`) were invisible to it and the three gated rules
(`match_group_length_skew`, `diffpair_length_skew`,
`diffpair_routing_continuity`) silently no-opped. The "rules are INACTIVE"
warning then pointed at an invented `output/net_class_map.json` example that did
not exist in that layout.

This PR widens the probe to the stem-keyed name (exact match only), makes the
warning name the paths it actually probed, adds a `--no-net-class-map` escape
hatch, and documents auto-discovery.

## Changes

- **`src/kicad_tools/cli/check_cmd.py`**
  - New `_net_class_map_sidecar_candidates(pcb_path)` enumerates the probe set;
    `_discover_net_class_map_sidecar` now consumes it (return type unchanged).
    Each of the three existing directories (`pcb_dir` → `pcb_dir/output` →
    `pcb_dir.parent/output`) is probed for `<pcb_stem>.net_class_map.json`
    **then** bare `net_class_map.json`. Candidates are de-duplicated (the
    `<board>/output/<pcb>` layout collapses two directories into one).
  - New `--no-net-class-map` (store_true) suppresses the probe only. Pairing it
    with `--net-class-map` returns 1 with a message naming the conflict, checked
    immediately after `parse_args`.
  - The INACTIVE warning now has three tails: enumerate the probed candidates
    (no sidecar found), say discovery was disabled (`--no-net-class-map`), or
    point at the sidecar that failed to load. The invented
    `output/net_class_map.json` example is gone.
  - `--net-class-map` help documents auto-discovery, matching the
    `--courtyard-waivers` phrasing.
- **`src/kicad_tools/validate/checker.py`** — `_warn_inactive_skew_rule` drops
  the same invented example (this surface has no PCB path and cannot enumerate
  candidates). The `warn_on_inactive_skew_rules` guard and per-rule dedup are
  untouched.
- **`src/kicad_tools/cli/parser.py` / `src/kicad_tools/cli/commands/validation.py`**
  — plumbing only, so `--no-net-class-map` is actually reachable from `kct
  check`. The user-facing `check` subparser lives in `parser.py`, and
  `run_check_command` forwards flags into `check_cmd.main`; without these two
  hunks the new flag would be `unrecognized arguments` on the real CLI. Not in
  the curated Affected Files list, but neither file is on any reserved list.
  Total: one new argparse block + a 2-line forward.
- **`docs/guides/drc-and-validation.md`** — new "Auto-discovery" paragraph in
  the Sidecar convention section: the six-path probe order, the `[INFO]` line,
  the exact-stem rule, explicit-flag precedence, graceful degradation, and
  `--no-net-class-map`.
- **`tests/test_cli_check_net_class_map.py`** — 13 new tests appended to
  `TestSidecarAutoLoad`. `git diff --numstat` on the test file is `221 0` —
  **zero deleted lines**, so the four pre-existing tests are byte-identical.

## Acceptance Criteria Verification

**AC1/AC2 — stem-keyed sidecar auto-loads and is reported.** Scratch tree with
`mg_v24.kicad_pcb` + `mg_v24.net_class_map.json` + a stale
`mg_v23_mfg.net_class_map.json`.

Baseline on `main` (`256a6932`), same tree:

```
WARNING: the following rules are INACTIVE without --net-class-map and will silently pass: match_group_length_skew.  Pass the routed board's sidecar (e.g. output/net_class_map.json) to validate length-match skew.
DRC PASSED: mg_v24.kicad_pcb
  0 rules checked, no violations found.
DRC:       PASSED   (0 rules checked, 0 error(s), 0 warning(s))
```

This branch, same tree, same command:

```
[INFO] auto-loaded net-class-map sidecar: /private/tmp/.../verify-4601/mg_v24.net_class_map.json
Rule ID                        Errors   Warnings   Infos
match_group_length_skew        0        0          1
DRC:       PASSED   (1 rules checked, 0 error(s), 0 warning(s))
```

0 rules checked → 1 rule checked, and the INFO line names the file actually used.

**AC3 — stem-keyed beats bare in a directory; directory order preserved.**
`test_stem_keyed_beats_bare_in_same_directory` (both files present, asserts the
stem-keyed one is the one reported) and `test_nearer_directory_beats_farther`
(identical sidecars in `board/output/` and `../output/`, asserts the nearer wins).

**AC4 — foreign stem is not loaded.** With `mg_v24.net_class_map.json` removed
so only the stale `mg_v23_mfg.net_class_map.json` remains:

```
WARNING: the following rules are INACTIVE without --net-class-map and will silently pass: match_group_length_skew.  No sidecar was found at any of:
  /private/tmp/.../verify-4601/mg_v24.net_class_map.json
  /private/tmp/.../verify-4601/net_class_map.json
  /private/tmp/.../verify-4601/output/mg_v24.net_class_map.json
  /private/tmp/.../verify-4601/output/net_class_map.json
  /private/tmp/.../scratchpad/output/mg_v24.net_class_map.json
  /private/tmp/.../scratchpad/output/net_class_map.json
Pass one explicitly with --net-class-map, or place it at one of the paths above, to validate length-match skew.
```

Also pinned by `test_foreign_stem_sidecar_is_ignored`.

**AC5 — explicit flag still short-circuits the probe.** Pre-existing
`test_explicit_flag_skips_autoprobe` passes unmodified; new
`test_explicit_flag_still_wins_over_stem_keyed_sidecar` puts a *malformed*
stem-keyed sidecar next to the board and asserts neither the INFO line nor the
malformed-sidecar warning appears (the probe never ran).

**AC6/AC9 — `--no-net-class-map`.** Same tree as AC1 (sidecar present):

```
WARNING: the following rules are INACTIVE without --net-class-map and will silently pass: match_group_length_skew.  Sidecar auto-discovery was disabled with --no-net-class-map; drop that flag or pass a sidecar explicitly with --net-class-map to validate length-match skew.
DRC:       PASSED   (0 rules checked, 0 error(s), 0 warning(s))
```

No INFO line, no path list, rules inactive — identical to "no sidecar at all".

**AC7 — conflicting flags exit 1.**

```
$ kct check .../mg_v24.kicad_pcb --no-net-class-map --net-class-map .../mg_v24.net_class_map.json
Error: --no-net-class-map cannot be combined with --net-class-map '/private/tmp/.../mg_v24.net_class_map.json': one disables sidecar auto-discovery, the other names a sidecar to load. Pass exactly one of them.
$ echo $?
1
```

**AC8 — warning enumerates real paths; invented example gone.** See the AC4
output. `test_inactive_warning_lists_probed_paths` asserts every path returned by
`_net_class_map_sidecar_candidates` appears in stderr and that
`(e.g. output/net_class_map.json)` does not.
`grep -rn "output/net_class_map.json" src/kicad_tools/cli/check_cmd.py src/kicad_tools/validate/checker.py` → no matches.

**AC10 — graceful degradation stays audible, including the `B.Cu` case.**
`test_malformed_stem_keyed_auto_sidecar_falls_back` (bad JSON) and
`test_auto_sidecar_with_back_copper_avoid_layer_warns` both assert
`WARNING: ignoring malformed net-class-map sidecar <path>: <reason>`, `rc != 1`,
and fall-back to no-map. The `avoid_layers: ["B.Cu"]` test additionally asserts
`"B.Cu"` appears in the reason — confirming the `router/rules.py:820-823`
rejection (no `LayerStack` is threaded at this callsite) surfaces loudly rather
than crashing. The layer-stack plumbing itself is **out of scope** per the
curated ruling and remains unfixed; this PR only makes the failure audible.

**AC11/AC12 — help + docs.** `--net-class-map` help in both `check_cmd.py` and
`parser.py` now ends with the auto-discovery sentence and the
`--no-net-class-map` pointer; the DRC guide gained the Auto-discovery paragraph.

**AC13 — reserved regions untouched.** `git diff --stat` is exactly:

```
 docs/guides/drc-and-validation.md          |  38 +++
 src/kicad_tools/cli/check_cmd.py           | 140 ++++++++++----
 src/kicad_tools/cli/commands/validation.py |   3 +
 src/kicad_tools/cli/parser.py              |  17 +-
 src/kicad_tools/validate/checker.py        |   4 +-
 tests/test_cli_check_net_class_map.py      | 221 +++++++++++++++++++++
```

`src/kicad_tools/cli/route_cmd.py` is **not** in the diff (#4622). The `lvs` key
and the `_lvs_*` region of `check_cmd.py` are untouched (#4616). The
`pcb_path.with_suffix(".kicad_dru")` line is untouched (#4600). No shared-resolver
refactor: `report/net_class_map.py`, `scripts/ci/net_class_map_resolver.py` and
`courtyard_waivers.py` keep their independent bare-name probes.

**AC14 — no regression on a real board.** Bare `kct check` on
`boards/07-matchgroup-test/output/matchgroup_test_routed.kicad_pcb`:

| | sidecar resolved | result |
|---|---|---|
| `main` @ `256a6932` | `boards/07-matchgroup-test/output/net_class_map.json` | 51 rules, 13 errors, 10 warnings |
| this branch | same file | 51 rules, 13 errors, 10 warnings |

Board 07's output dir has no stem-keyed sidecar, so the bare name still wins.
`git status --porcelain` in `boards/` is clean.

## Test Plan

- `pytest tests/test_cli_check_net_class_map.py tests/test_cli_check_ampacity_net_class_map.py tests/test_check_cmd_coverage.py` → **70 passed**.
- `pytest -k "cli_parser or check_cmd or parser_drift or cli_help or inactive or skew"` → **245 passed, 10 skipped**.
- `TestSidecarAutoLoad` → **17 passed** (4 pre-existing + 13 new).
- `ruff format . --check` → 1728 files already formatted; `ruff check .` → All checks passed.
- `scripts/ci/check_mypy_baseline.py` → `OK: mypy reports 1473 error(s), all within the baseline (1474 allowed). No new type errors.` (The one "no longer occurs" entry is the env-dependent nanobind `import-not-found` line that a native-built worktree resolves — baseline deliberately **not** regenerated.)
- Manual verification done in a scratch dir under `/private/tmp`, not in any board directory.

## Follow-ups (deliberately not in this PR)

1. **Four duplicate bare-name probes** remain: `check_cmd._discover_net_class_map_sidecar`, `report/net_class_map.resolve_committed_net_class_map:39`, `scripts/ci/net_class_map_resolver.SIDECAR_FILENAME:54`, and the structurally identical `courtyard_waivers.discover_courtyard_waivers_sidecar:174`. Only `check_cmd`'s was widened; the other three still see bare names only. Consolidation is a cross-cutting refactor explicitly excluded here.
2. **Layer-stack plumbing** — `check_cmd.py` calls `net_class_map_from_dict(ncm_data)` with no `LayerStack`, so `avoid_layers: ["B.Cu"]` is rejected; same at the `zones` / `creepage` / `auditor` callsites. Excluded by the curated ruling and being filed separately.
3. **`tests/conftest.py:16-20`** — `isolate_pcb_from_sidecars`'s docstring enumerates only the three bare-name candidates. Its *behaviour* is still correct (it copies the PCB into an empty dir, so no candidate of either naming convention resolves), but the docstring is now incomplete. Left untouched to respect the file scope.

Closes #4601
