### PR TITLE
feat(check): emit full LVS mismatch records under meta_checks.lvs

### DIFF
--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -26,7 +26,7 @@ import argparse
 import json
 import sys
 from collections.abc import Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Literal
 
@@ -133,13 +133,28 @@ class SubCheckResult:
     ``status`` is one of ``PASSED`` / ``FAILED`` / ``NOT RUN``.  ``detail``
     is the one-line human-readable summary that appears in parentheses on
     the human stanza and as the ``detail`` field in the JSON envelope.
+
+    ``data`` (issue #4616) is an optional **structured** payload merged
+    flat into ``to_dict()`` so a machine consumer gets the full findings
+    rather than the truncated prose ``detail``.  It follows the
+    OMIT-when-absent convention already used for ``meta_checks`` itself:
+    sub-checks that carry no structured payload (DRC / ERC / Manifest)
+    leave it ``None`` and serialize byte-identically to before.  LVS
+    populates it with the v1 ``lvs.json`` record shapes produced by
+    :func:`kicad_tools.lvs.build_lvs_payload`, so ``meta_checks.lvs`` is
+    parsable field-for-field by the same code that reads
+    ``boards/*/output/lvs.json``.
     """
 
     status: SubCheckStatus
     detail: str
+    data: dict | None = None
 
-    def to_dict(self) -> dict[str, str]:
-        return {"status": self.status, "detail": self.detail}
+    def to_dict(self) -> dict:
+        out: dict = {"status": self.status, "detail": self.detail}
+        if self.data is not None:
+            out.update(self.data)
+        return out
 
 
 @dataclass
@@ -695,6 +710,17 @@ def _lvs_subcheck(sch_path: Path | None, pcb_path: Path) -> SubCheckResult:
     Always recomputes -- never reads ``output/lvs.json`` -- so a fresh
     PCB edit that breaks LVS is surfaced immediately.  Returns
     ``NOT RUN`` when no schematic is found.
+
+    Issue #4616: whenever both comparators ran, the **complete** record
+    set from *both* legs is attached to :attr:`SubCheckResult.data` using
+    the v1 ``lvs.json`` shapes (:func:`kicad_tools.lvs.build_lvs_payload`),
+    so ``meta_checks.lvs`` carries full fidelity in JSON even though
+    ``detail`` stays the bounded 3-record human summary.  This also
+    closes a data-loss bug: the old copper-dirty early return discarded
+    the already-computed label-leg mismatches entirely, so on a
+    copper-dirty board the label findings appeared in *no* output.  The
+    copper-dirty branch is now a ``detail``-selection branch, not a
+    return, and both legs are always carried.
     """
     if sch_path is None:
         return SubCheckResult(
@@ -722,35 +748,49 @@ def _lvs_subcheck(sch_path: Path | None, pcb_path: Path) -> SubCheckResult:
             detail=f"copper LVS comparator raised {type(e).__name__}: {e}",
         )
 
+    from kicad_tools.lvs.recipe import build_lvs_payload
+
+    # Stable sort orders shared by the JSON payload, the bounded ``detail``
+    # preview and the ``--verbose`` terminal expansion, so all three agree.
+    copper_records = sorted(copper.mismatches, key=lambda m: (m.kind, m.pad_a, m.pad_b))
+    label_records = sorted(result.mismatches, key=lambda m: (m.ref, m.pad))
+
+    data = build_lvs_payload(
+        replace(copper, mismatches=tuple(copper_records)),
+        replace(result, mismatches=tuple(label_records)),
+        include_schema=False,
+    )
+
     if not copper.clean:
         # The copper-extracted gate is the soundness-critical one: surface
         # it first.  Show up to the first 3 records in a stable order.
-        records = sorted(copper.mismatches, key=lambda m: (m.kind, m.pad_a, m.pad_b))
         preview = ", ".join(
-            f"{m.kind} {m.pad_a}({m.net_a})/{m.pad_b}({m.net_b})" for m in records[:3]
+            f"{m.kind} {m.pad_a}({m.net_a})/{m.pad_b}({m.net_b})" for m in copper_records[:3]
         )
-        suffix = "" if len(records) <= 3 else f" (+{len(records) - 3} more)"
+        suffix = "" if len(copper_records) <= 3 else f" (+{len(copper_records) - 3} more)"
         return SubCheckResult(
             status="FAILED",
-            detail=f"copper: {len(records)} mismatch(es): {preview}{suffix}",
+            detail=f"copper: {len(copper_records)} mismatch(es): {preview}{suffix}",
+            data=data,
         )
 
     if result.clean:
         return SubCheckResult(
             status="PASSED",
             detail="label + copper: 0 mismatch(es)",
+            data=data,
         )
 
     # Show up to the first 3 mismatches in stable (ref, pad) order so
     # the detail line is bounded but informative.
-    mismatches = sorted(result.mismatches, key=lambda m: (m.ref, m.pad))
     preview = ", ".join(
-        f"{m.ref}.{m.pad} sch={m.schematic_net!r} pcb={m.pcb_net!r}" for m in mismatches[:3]
+        f"{m.ref}.{m.pad} sch={m.schematic_net!r} pcb={m.pcb_net!r}" for m in label_records[:3]
     )
-    suffix = "" if len(mismatches) <= 3 else f" (+{len(mismatches) - 3} more)"
+    suffix = "" if len(label_records) <= 3 else f" (+{len(label_records) - 3} more)"
     return SubCheckResult(
         status="FAILED",
-        detail=f"label: {len(mismatches)} mismatch(es): {preview}{suffix}",
+        detail=f"label: {len(label_records)} mismatch(es): {preview}{suffix}",
+        data=data,
     )
 
 
@@ -971,17 +1011,52 @@ def _format_meta_status_line(name: str, sub: SubCheckResult) -> str:
     return f"{name + ':':10} {display_status:8} ({detail})"
 
 
-def print_meta_check_stanza(result: MetaCheckResult) -> None:
+def _print_lvs_verbose_expansion(sub: SubCheckResult) -> None:
+    """Print every LVS mismatch beneath the ``LVS:`` line (issue #4616).
+
+    Reads the records back out of :attr:`SubCheckResult.data` -- the same
+    structured payload the JSON envelope serializes -- so the terminal
+    expansion and ``meta_checks.lvs`` are provably the same list, in the
+    same stable order, with **no** cap.  A no-op when LVS produced no
+    structured payload (``NOT RUN`` / comparator raised) or when both
+    legs are empty.
+    """
+    data = sub.data
+    if not data:
+        return
+    copper_records = data.get("copper_mismatches") or []
+    label_records = data.get("mismatches") or []
+    if not copper_records and not label_records:
+        return
+    if copper_records:
+        print(f"  copper: {len(copper_records)} mismatch(es)")
+        for m in copper_records:
+            print(f"    {m['kind']} {m['pad_a']}({m['net_a']})/{m['pad_b']}({m['net_b']})")
+    if label_records:
+        print(f"  label: {len(label_records)} mismatch(es)")
+        for m in label_records:
+            print(f"    {m['ref']}.{m['pad']} sch={m['schematic_net']!r} pcb={m['pcb_net']!r}")
+
+
+def print_meta_check_stanza(result: MetaCheckResult, verbose: bool = False) -> None:
     """Print the per-sub-check status block + overall rollup (issue #3750).
 
     Output goes to stdout in a stable column layout so humans can
     diff it across runs.  The ``Overall:`` line is the rollup that
     matches the exit-code decision.
+
+    ``verbose`` (issue #4616) expands the ``LVS:`` row into the complete,
+    uncapped mismatch list from both comparator legs.  The status lines
+    themselves -- including the bounded 3-record ``(+N more)`` LVS
+    summary -- are byte-identical either way; ``--verbose`` only adds
+    lines beneath the ``LVS:`` row.
     """
     print()
     print(_format_meta_status_line("DRC", result.drc))
     print(_format_meta_status_line("ERC", result.erc))
     print(_format_meta_status_line("LVS", result.lvs))
+    if verbose:
+        _print_lvs_verbose_expansion(result.lvs)
     print(_format_meta_status_line("Manifest", result.manifest))
     print(f"{'Overall:':10} {result.overall}")
 
@@ -1925,11 +2000,11 @@ def main(argv: list[str] | None = None) -> int:
     elif args.format == "summary":
         output_summary(violations, results, pcb_path)
         if meta is not None:
-            print_meta_check_stanza(meta)
+            print_meta_check_stanza(meta, args.verbose)
     else:
         output_table(violations, results, pcb_path, effective_mfr, layers, args.verbose)
         if meta is not None:
-            print_meta_check_stanza(meta)
+            print_meta_check_stanza(meta, args.verbose)
 
     # Write JSON report to file if --output specified
     if args.output:

--- a/src/kicad_tools/lvs/__init__.py
+++ b/src/kicad_tools/lvs/__init__.py
@@ -30,6 +30,10 @@ Public API:
 * :class:`BoardNetlistMismatch` — exception carrying the LVSResult;
                                   raised by board recipes, never by the
                                   comparator itself.
+* :func:`build_lvs_payload` — the single producer of the v1 ``lvs.json``
+                              record shapes, shared by
+                              :func:`write_lvs_report` and ``kct check``'s
+                              ``meta_checks.lvs`` payload (issue #4616).
 * :func:`_ref_of`           — helper that resolves a footprint's
                               reference designator across both KiCad
                               serializer dialects (kept underscored
@@ -56,6 +60,7 @@ from kicad_tools.lvs.copper_lvs import (
 from kicad_tools.lvs.recipe import (
     ADVISORY_LVS_BOARDS,
     FreshCopperCheckError,
+    build_lvs_payload,
     write_lvs_report,
 )
 
@@ -70,6 +75,7 @@ __all__ = [
     "VACUOUS_KIND",
     "VACUOUS_NET",
     "_ref_of",
+    "build_lvs_payload",
     "compare_copper_netlist",
     "compare_netlists",
     "compare_partitions",

--- a/src/kicad_tools/lvs/recipe.py
+++ b/src/kicad_tools/lvs/recipe.py
@@ -285,7 +285,7 @@ def write_lvs_report(
     lvs_path = output_dir / "lvs.json"
     lvs_path.write_text(
         json.dumps(
-            _build_payload(copper_result, label_result, clean=gated_clean),
+            build_lvs_payload(copper_result, label_result, clean=gated_clean),
             indent=2,
         )
         + "\n"
@@ -303,13 +303,14 @@ def write_lvs_report(
     return copper_clean, label_clean
 
 
-def _build_payload(
+def build_lvs_payload(
     copper_result: CopperLVSResult | None,
     label_result: LVSResult | None,
     *,
-    clean: bool,
+    clean: bool | None = None,
+    include_schema: bool = True,
 ) -> dict:
-    """Assemble the v1 ``lvs.json`` payload.
+    """Assemble the v1 ``lvs.json`` payload (shared producer, issue #4616).
 
     ``mismatches`` carries the label-based mismatches (unchanged from the
     historical board-00 schema so ``_parse_lvs`` and the e2e asserter keep
@@ -318,30 +319,59 @@ def _build_payload(
     ``copper_vacuous`` / ``copper_bound_pad_count`` (additive, #4005
     review) record whether the copper verdict carried any schematic
     evidence; a vacuous copper leg forces ``clean=false``.
+
+    This is the **single** producer of the v1 record shapes.  Besides
+    :func:`write_lvs_report` (which writes ``output/lvs.json`` with the
+    full envelope), ``kct check`` embeds the same records under
+    ``meta_checks.lvs`` so a consumer can parse both surfaces with one
+    code path (issue #4616).  ``kct check`` passes
+    ``include_schema=False`` and leaves ``clean`` as ``None`` because the
+    sub-check's own ``status`` already carries the verdict and the
+    envelope is not a standalone v1 document.
+
+    Args:
+        copper_result: Copper-extracted comparator result, or ``None``
+            when that leg did not run.
+        label_result: Label-based comparator result, or ``None`` when
+            that leg did not run.
+        clean: The gated verdict.  Emitted as the ``clean`` key when not
+            ``None``; omitted entirely when ``None``.
+        include_schema: When ``True`` (default) the payload leads with
+            the ``$schema`` key, making it a standalone v1 document.
+
+    Returns:
+        A JSON-safe dict in the stable v1 key order: ``$schema``,
+        ``clean``, ``mismatches``, ``copper_mismatches``,
+        ``copper_vacuous``, ``copper_bound_pad_count``.
     """
-    payload: dict = {
-        "$schema": _LVS_SCHEMA_URL,
-        "clean": clean,
-        "mismatches": [
-            {
-                "ref": lm.ref,
-                "pad": lm.pad,
-                "schematic_net": lm.schematic_net,
-                "pcb_net": lm.pcb_net,
-            }
-            for lm in (label_result.mismatches if label_result is not None else ())
-        ],
-        "copper_mismatches": [
-            {
-                "kind": cm.kind,
-                "net_a": cm.net_a,
-                "net_b": cm.net_b,
-                "pad_a": cm.pad_a,
-                "pad_b": cm.pad_b,
-            }
-            for cm in (copper_result.mismatches if copper_result is not None else ())
-        ],
-    }
+    payload: dict = {}
+    if include_schema:
+        payload["$schema"] = _LVS_SCHEMA_URL
+    if clean is not None:
+        payload["clean"] = clean
+    payload.update(
+        {
+            "mismatches": [
+                {
+                    "ref": lm.ref,
+                    "pad": lm.pad,
+                    "schematic_net": lm.schematic_net,
+                    "pcb_net": lm.pcb_net,
+                }
+                for lm in (label_result.mismatches if label_result is not None else ())
+            ],
+            "copper_mismatches": [
+                {
+                    "kind": cm.kind,
+                    "net_a": cm.net_a,
+                    "net_b": cm.net_b,
+                    "pad_a": cm.pad_a,
+                    "pad_b": cm.pad_b,
+                }
+                for cm in (copper_result.mismatches if copper_result is not None else ())
+            ],
+        }
+    )
     if copper_result is not None:
         payload["copper_vacuous"] = copper_result.vacuous
         payload["copper_bound_pad_count"] = copper_result.bound_pad_count

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -740,6 +740,262 @@ class TestCheckMetaCheck:
 
 
 # ---------------------------------------------------------------------------
+# Issue #4616: full-fidelity LVS records under meta_checks.lvs
+# ---------------------------------------------------------------------------
+
+BOARD_02_DIR = REPO_ROOT / "boards" / "02-charlieplex-led" / "output"
+BOARD_02_SCH = BOARD_02_DIR / "charlieplex_3x3.kicad_sch"
+BOARD_02_PCB = BOARD_02_DIR / "charlieplex_3x3_routed.kicad_pcb"
+
+_LVS_RECORD_KEYS = {
+    "mismatches": {"ref", "pad", "schematic_net", "pcb_net"},
+    "copper_mismatches": {"kind", "net_a", "net_b", "pad_a", "pad_b"},
+}
+
+
+def _strip_all_segments(src_pcb: Path, dest_pcb: Path) -> Path:
+    """Copy ``src_pcb`` to ``dest_pcb`` with every routed ``segment`` removed.
+
+    Un-routing the board leaves each multi-pad net split across separate
+    copper islands, which the copper-extracted comparator reports as
+    ``open`` mismatches — a cheap way to synthesize a copper-dirty board
+    with a controllable number of findings, without touching any
+    committed artifact.
+    """
+    from kicad_tools.sexp import SExp, parse_file
+
+    doc = parse_file(src_pcb)
+    doc.children = [c for c in doc.children if not (isinstance(c, SExp) and c.name == "segment")]
+    dest_pcb.write_text(doc.to_string() + "\n")
+    return dest_pcb
+
+
+def _stage_board02_unrouted(dest_dir: Path) -> Path:
+    """Stage board 02 (charlieplex) with all segments stripped.
+
+    Yields >= 4 copper mismatches (22 at the time of writing), which is
+    what makes the ``(+N more)`` truncation observable end-to-end.
+    """
+    if not BOARD_02_SCH.exists() or not BOARD_02_PCB.exists():
+        pytest.skip("board 02 artifacts missing; run generate_design.py")
+
+    shutil.copy(BOARD_02_SCH, dest_dir / BOARD_02_SCH.name)
+    return _strip_all_segments(BOARD_02_PCB, dest_dir / BOARD_02_PCB.name)
+
+
+def _stage_board00_both_legs_dirty(dest_dir: Path) -> Path:
+    """Stage a board 00 copy that is dirty on **both** LVS comparators.
+
+    ``_swap_d1_pad_nets_in_pcb`` dirties the label leg (D1's declared pad
+    nets no longer match the schematic); stripping the segments dirties
+    the copper leg (LED_ANODE splits into two islands).  Before issue
+    #4616 the copper-dirty early return in ``_lvs_subcheck`` discarded the
+    already-computed label findings entirely, so this board's D1
+    mismatches appeared in *no* output.
+    """
+    pcb, _manifest = _stage_board00_copy(dest_dir)
+    _swap_d1_pad_nets_in_pcb(pcb, pcb)
+    _strip_all_segments(pcb, pcb)
+    return pcb
+
+
+class TestCheckLVSFullFidelity:
+    """``meta_checks.lvs`` carries every mismatch as structured data (#4616).
+
+    The ``detail`` string stays the bounded 3-record human summary; the
+    machine payload reuses the v1 ``lvs.json`` record shapes verbatim so
+    one consumer parses both surfaces.
+    """
+
+    def test_copper_dirty_board_still_carries_label_leg(self, tmp_path: Path, capsys):
+        """Regression: a copper-dirty board must not drop the label findings.
+
+        This is the data-loss bug the issue's Curator found (#4616
+        "Correction 3").  ``_lvs_subcheck`` computed the label result,
+        then early-returned on the copper leg without ever formatting or
+        attaching it — so the D1 label mismatches below were *absent*,
+        not truncated.  Fails on ``origin/main``.
+        """
+        from kicad_tools.cli.check_cmd import main
+
+        pcb = _stage_board00_both_legs_dirty(tmp_path)
+
+        assert main([str(pcb), "--format", "json"]) == 2
+        lvs = json.loads(capsys.readouterr().out)["meta_checks"]["lvs"]
+
+        assert lvs["status"] == "FAILED"
+        # The copper leg still wins the human ``detail`` line...
+        assert lvs["detail"].startswith("copper: ")
+        # ...but the label leg is no longer discarded.
+        assert [(m["ref"], m["pad"]) for m in lvs["mismatches"]] == [("D1", "1"), ("D1", "2")]
+        assert {m["schematic_net"] for m in lvs["mismatches"]} == {"GND", "LED_ANODE"}
+        assert len(lvs["copper_mismatches"]) >= 1
+
+    def test_payload_enumerates_every_copper_mismatch(self, tmp_path: Path, capsys):
+        """A board with >= 4 copper mismatches enumerates all of them."""
+        from kicad_tools.cli.check_cmd import main
+
+        pcb = _stage_board02_unrouted(tmp_path)
+
+        assert main([str(pcb), "--format", "json"]) == 2
+        lvs = json.loads(capsys.readouterr().out)["meta_checks"]["lvs"]
+
+        # ``detail`` is still the truncated prose sentence...
+        count = int(lvs["detail"].split("copper: ")[1].split(" mismatch(es)")[0])
+        assert count >= 4
+        assert f"(+{count - 3} more)" in lvs["detail"]
+        # ...while the array is complete and carries no truncation marker.
+        assert len(lvs["copper_mismatches"]) == count
+        assert "more)" not in json.dumps(lvs["copper_mismatches"])
+        # Records use the v1 lvs.json field names verbatim.
+        for record in lvs["copper_mismatches"]:
+            assert set(record) == _LVS_RECORD_KEYS["copper_mismatches"]
+        # Stable sort order: (kind, pad_a, pad_b).
+        keys = [(m["kind"], m["pad_a"], m["pad_b"]) for m in lvs["copper_mismatches"]]
+        assert keys == sorted(keys)
+
+    def test_clean_board_emits_empty_payload(self, tmp_path: Path, capsys):
+        """A PASSED board still carries the payload, with empty lists."""
+        from kicad_tools.cli.check_cmd import main
+
+        pcb, _manifest = _stage_board00_copy(tmp_path)
+
+        assert main([str(pcb), "--format", "json"]) == 0
+        lvs = json.loads(capsys.readouterr().out)["meta_checks"]["lvs"]
+
+        assert lvs["status"] == "PASSED"
+        # Consumers must never have to branch on key presence to tell
+        # "clean" from "old kct".
+        assert lvs["mismatches"] == []
+        assert lvs["copper_mismatches"] == []
+        assert lvs["copper_vacuous"] is False
+        assert lvs["copper_bound_pad_count"] is not None
+        assert lvs["copper_bound_pad_count"] > 0
+
+    def test_payload_omitted_when_lvs_not_run(self, drc_clean_pcb: Path, capsys):
+        """No schematic -> NOT RUN -> {status, detail} only."""
+        from kicad_tools.cli.check_cmd import main
+
+        assert main([str(drc_clean_pcb), "--format", "json"]) == 2
+        lvs = json.loads(capsys.readouterr().out)["meta_checks"]["lvs"]
+
+        assert lvs["status"] == "NOT RUN"
+        assert set(lvs) == {"status", "detail"}
+
+    @pytest.mark.parametrize(
+        "module_path,symbol",
+        [
+            ("kicad_tools.lvs.board_lvs", "compare_netlists"),
+            ("kicad_tools.lvs.copper_lvs", "compare_copper_netlist"),
+        ],
+    )
+    def test_payload_omitted_when_comparator_raises(
+        self, tmp_path: Path, monkeypatch, module_path: str, symbol: str
+    ):
+        """A raised comparator keeps the legacy {status, detail} shape."""
+        import importlib
+
+        from kicad_tools.cli.check_cmd import _lvs_subcheck
+
+        pcb, _manifest = _stage_board00_copy(tmp_path)
+        sch = tmp_path / "simple_led.kicad_sch"
+
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("synthetic comparator failure")
+
+        monkeypatch.setattr(importlib.import_module(module_path), symbol, _boom)
+
+        sub = _lvs_subcheck(sch, pcb)
+        assert sub.status == "FAILED"
+        assert sub.data is None
+        assert set(sub.to_dict()) == {"status", "detail"}
+        assert "RuntimeError" in sub.detail
+
+    def test_stdout_and_file_report_carry_identical_payload(self, tmp_path: Path, capsys):
+        """``--format json`` and ``-o report.json`` must agree exactly."""
+        from kicad_tools.cli.check_cmd import main
+
+        pcb = _stage_board00_both_legs_dirty(tmp_path)
+        report = tmp_path / "check.json"
+
+        assert main([str(pcb), "--format", "json", "-o", str(report)]) == 2
+
+        stdout_lvs = json.loads(capsys.readouterr().out)["meta_checks"]["lvs"]
+        file_lvs = json.loads(report.read_text())["meta_checks"]["lvs"]
+        assert stdout_lvs == file_lvs
+        assert file_lvs["mismatches"], "file report must carry the label leg too"
+
+    def test_drc_only_still_omits_meta_checks(self, tmp_path: Path, capsys):
+        """The widened payload must not leak into the --drc-only envelope."""
+        from kicad_tools.cli.check_cmd import main
+
+        pcb = _stage_board00_both_legs_dirty(tmp_path)
+
+        main([str(pcb), "--format", "json", "--drc-only"])
+        assert "meta_checks" not in json.loads(capsys.readouterr().out)
+
+    def test_other_subchecks_serialize_unchanged(self, tmp_path: Path, capsys):
+        """DRC / ERC / Manifest keep the legacy two-key JSON shape."""
+        from kicad_tools.cli.check_cmd import main
+
+        pcb, _manifest = _stage_board00_copy(tmp_path)
+
+        main([str(pcb), "--format", "json"])
+        meta = json.loads(capsys.readouterr().out)["meta_checks"]
+
+        for name in ("drc", "erc", "manifest"):
+            assert set(meta[name]) == {"status", "detail"}, name
+
+    def test_verbose_expands_list_default_stays_truncated(self, tmp_path: Path, capsys):
+        """Default terminal line is unchanged; --verbose lists everything."""
+        from kicad_tools.cli.check_cmd import main
+
+        pcb = _stage_board02_unrouted(tmp_path)
+
+        main([str(pcb)])
+        plain = capsys.readouterr().out
+        plain_lvs = next(ln for ln in plain.splitlines() if ln.startswith("LVS:"))
+        count = int(plain_lvs.split("copper: ")[1].split(" mismatch(es)")[0])
+        assert f"(+{count - 3} more)" in plain_lvs
+        # Exactly the 3 preview records appear on the default path.
+        assert plain.count("    open ") == 0
+
+        main([str(pcb), "--verbose"])
+        verbose = capsys.readouterr().out
+        verbose_lvs = next(ln for ln in verbose.splitlines() if ln.startswith("LVS:"))
+        # The status line itself is byte-identical...
+        assert verbose_lvs == plain_lvs
+        # ...and every record is listed beneath it, uncapped.
+        assert f"  copper: {count} mismatch(es)" in verbose
+        assert verbose.count("    open ") == count
+
+    def test_verbose_matches_json_payload(self, tmp_path: Path, capsys):
+        """The --verbose expansion is rendered from the JSON payload itself."""
+        from kicad_tools.cli.check_cmd import (
+            MetaCheckResult,
+            SubCheckResult,
+            _lvs_subcheck,
+            print_meta_check_stanza,
+        )
+
+        pcb = _stage_board00_both_legs_dirty(tmp_path)
+        sub = _lvs_subcheck(tmp_path / "simple_led.kicad_sch", pcb)
+        stub = SubCheckResult(status="PASSED", detail="-")
+        meta = MetaCheckResult(drc=stub, erc=stub, lvs=sub, manifest=stub)
+
+        print_meta_check_stanza(meta, verbose=True)
+        out = capsys.readouterr().out
+
+        for record in sub.data["copper_mismatches"]:
+            assert (
+                f"{record['kind']} {record['pad_a']}({record['net_a']})"
+                f"/{record['pad_b']}({record['net_b']})" in out
+            )
+        for record in sub.data["mismatches"]:
+            assert f"{record['ref']}.{record['pad']} sch=" in out
+
+
+# ---------------------------------------------------------------------------
 # Issue #4096: stale-zone-fill advisory + opt-in --refill-zones flag
 # ---------------------------------------------------------------------------
 

--- a/tests/test_lvs_recipe.py
+++ b/tests/test_lvs_recipe.py
@@ -282,6 +282,84 @@ def test_no_comparator_selected_raises_value_error(
 
 
 # ---------------------------------------------------------------------------
+# Issue #4616: build_lvs_payload is the single shared producer of the v1
+# record shapes, used by both write_lvs_report and kct check.
+# ---------------------------------------------------------------------------
+
+
+_DIRTY_COPPER_PAIR = CopperLVSResult(
+    clean=False,
+    mismatches=(
+        CopperLVSMismatch(kind="short", net_a="GND", net_b="VCC", pad_a="R1.1", pad_b="R2.2"),
+        CopperLVSMismatch(kind="open", net_a="SIG", net_b="SIG", pad_a="U1.3", pad_b="U2.4"),
+    ),
+    bound_pad_count=9,
+)
+_DIRTY_LABEL_PAIR = LVSResult(
+    clean=False,
+    mismatches=(LVSMismatch(ref="D1", pad="1", schematic_net="GND", pcb_net="VCC"),),
+)
+
+
+def test_build_lvs_payload_preserves_v1_key_order() -> None:
+    """The on-disk lvs.json key order is load-bearing (#4616 scope guard)."""
+    payload = recipe.build_lvs_payload(
+        _DIRTY_COPPER_PAIR, _DIRTY_LABEL_PAIR, clean=False, include_schema=True
+    )
+    assert list(payload) == [
+        "$schema",
+        "clean",
+        "mismatches",
+        "copper_mismatches",
+        "copper_vacuous",
+        "copper_bound_pad_count",
+    ]
+
+
+def test_build_lvs_payload_embedded_form_drops_schema_and_clean() -> None:
+    """``kct check`` embeds the records without the standalone-document keys."""
+    payload = recipe.build_lvs_payload(_DIRTY_COPPER_PAIR, _DIRTY_LABEL_PAIR, include_schema=False)
+    assert list(payload) == [
+        "mismatches",
+        "copper_mismatches",
+        "copper_vacuous",
+        "copper_bound_pad_count",
+    ]
+
+
+def test_check_meta_lvs_payload_shares_lvs_json_record_shapes() -> None:
+    """Drift guard: ``meta_checks.lvs`` records == ``lvs.json`` records (#4616).
+
+    ``kct check`` must not invent a second record shape.  Both surfaces
+    are produced by :func:`build_lvs_payload`, so a consumer that parses
+    ``boards/*/output/lvs.json`` parses the check envelope unchanged.
+    """
+    from kicad_tools.cli.check_cmd import SubCheckResult
+
+    on_disk = recipe.build_lvs_payload(_DIRTY_COPPER_PAIR, _DIRTY_LABEL_PAIR, clean=False)
+    embedded = SubCheckResult(
+        status="FAILED",
+        detail="copper: 2 mismatch(es): ...",
+        data=recipe.build_lvs_payload(_DIRTY_COPPER_PAIR, _DIRTY_LABEL_PAIR, include_schema=False),
+    ).to_dict()
+
+    for field in ("mismatches", "copper_mismatches"):
+        assert embedded[field] == on_disk[field]
+        assert [set(r) for r in embedded[field]] == [set(r) for r in on_disk[field]]
+    assert embedded["copper_vacuous"] == on_disk["copper_vacuous"]
+    assert embedded["copper_bound_pad_count"] == on_disk["copper_bound_pad_count"]
+    # The check envelope adds only its own two keys on top of the v1 fields.
+    assert set(embedded) - set(on_disk) == {"status", "detail"}
+
+
+def test_build_lvs_payload_is_exported_from_package() -> None:
+    import kicad_tools.lvs as lvs_pkg
+
+    assert "build_lvs_payload" in lvs_pkg.__all__
+    assert lvs_pkg.build_lvs_payload is recipe.build_lvs_payload
+
+
+# ---------------------------------------------------------------------------
 # Advisory allowlist constant
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`kct check` reported LVS findings only as a truncated prose `detail` string
(`"50 mismatch(es): a, b, c (+47 more)"`) with no full-fidelity form anywhere on
that path, so neither a human nor a CI consumer could enumerate or classify the
findings. As #4616 argues, being unable to enumerate the failures is what made
"accept it as an inherited baseline" the path of least resistance.

## Changes

- **`src/kicad_tools/cli/check_cmd.py`** — `SubCheckResult` gains an optional
  `data: dict | None` slot that `to_dict()` merges in flat when present
  (OMIT-when-absent, matching the `meta_checks` convention). Because `to_dict()`
  is the shared serializer for both `--format json` and `-o report.json`,
  widening it completes both machine-output paths with no edit inside either
  output function. `--verbose` expands the `LVS:` stanza into the complete
  uncapped list from both legs, rendered from the same payload the JSON carries.
- **`src/kicad_tools/lvs/recipe.py` / `lvs/__init__.py`** — `_build_payload` is
  promoted to the public shared producer `lvs.build_lvs_payload(...)` (new
  `clean=None` / `include_schema=False` knobs for the embedded form).
  `write_lvs_report` keeps emitting byte-identical `lvs.json`, so one consumer
  parses `boards/*/output/lvs.json` and `meta_checks.lvs` with the same code.
- **Data-loss bug fixed** — `_lvs_subcheck` early-returned on a copper-dirty
  board *before* formatting the label-leg result it had already computed, so on
  any copper-dirty board the label mismatches were absent from every output, not
  merely truncated. The copper-dirty branch is now a detail-selection branch,
  not a return.
- **Tests** — 256 lines in `tests/test_cli_check.py`, 78 in
  `tests/test_lvs_recipe.py`.

No new flag is added; the default terminal line (3 records + `(+N more)`) is
byte-identical to before.

## Reviewer note

The issue's acceptance criteria ask to *"populate the existing top-level `lvs`
key rather than leaving it `{}`"*. This PR instead attaches the full record set
under `meta_checks.lvs` (flat-merged alongside the existing `status`/`detail`).
Please confirm that placement is the one you want before merge — the top-level
`lvs` key is still `{}`.

## Recovery note

This branch was committed and pushed by a Builder that was killed by a host
restart before it could open the PR. The commit is unmodified; only a
test-generated `tests/fixtures/simple_rc-netlist.kicad_net` diff (worktree-local
paths + an Eeschema 10.0.5 version stamp) was discarded from the worktree.

Closes #4616
