### PR TITLE
feat(3d): per-part rotate/offset overrides for the LCSC model tier

### DIFF
--- a/docs/guides/lcsc-3d-models.md
+++ b/docs/guides/lcsc-3d-models.md
@@ -37,6 +37,123 @@ kct pcb add-3d-models board.kicad_pcb --lcsc-models lcsc_models.json --fetch-lcs
 The sidecar is **lib_id-keyed** (not reference-designator-keyed): each synthetic
 lib id in the fleet is unique per board, so one C-number per lib id suffices.
 
+## Per-part `rotate` / `offset` transforms
+
+The three installed-library tiers *derive* a body's transform geometrically, by
+comparing the target footprint's pad field against the source `.kicad_mod`. The
+LCSC tier has **no source footprint at all** — it synthesizes the `(model ...)`
+node from nothing but a C-number — so there is nothing to derive from, and
+EasyEDA bodies are authored in whatever orientation the part vendor chose. The
+identity rotation the tier emits by default is therefore a *guess*, and for many
+parts it is wrong by a quarter turn.
+
+Authored corrections come from two places, in this order (first non-`None`
+wins, **merged per field**):
+
+| Precedence | Source | Scope |
+|---|---|---|
+| 1 | Per-board sidecar entry in **object form** | One board — a local escape hatch |
+| 2 | Packaged table `src/kicad_tools/pcb/lcsc_model_transforms.py` | The whole fleet + every downstream consumer of the wheel |
+| 3 | Identity (`rotate (xyz 0 0 0)`, `offset (xyz 0 0 0)`) | Every part with no entry anywhere |
+
+Merging is **per field**: a sidecar entry that overrides only `rotate` still
+inherits the packaged `offset`, and vice versa.
+
+### Sidecar object form
+
+```json
+{
+  "Module:Joystick_Analog": "C50950",
+  "Connector_PCIE:PCIE_Mini_Edge": {
+    "lcsc": "C444929",
+    "rotate": [0, 0, -90],
+    "offset": [0, 0, 0]
+  }
+}
+```
+
+The bare-string form stays valid and unchanged. In the object form `lcsc` is
+required; `rotate` and `offset` are independently optional and must each be
+exactly 3 finite numbers. A malformed sidecar is a **build error** (`ValueError`
+naming the file and the offending key), and **unknown keys are rejected rather
+than ignored** — a typo'd `"rotation"` fails loudly instead of degrading to a
+silent, green no-op.
+
+### The packaged table
+
+`lcsc_model_transforms.LCSC_MODEL_TRANSFORMS` is keyed by **C-number**, not by
+lib id. An LCSC C-number is a stable, global, vendor-issued identifier and a
+body's native orientation is a property of *the part*; the fleet's lib ids are
+unique per board (see above), so a lib_id-keyed table would have a reuse rate of
+~zero. Keyed by C-number, one calibration is correct for every board, and it
+ships in the wheel to downstream consumers.
+
+Prefer the packaged table. Reach for the sidecar object form only to correct a
+wrong or missing packaged value without waiting for a release.
+
+### Frame semantics
+
+KiCad applies a model's transforms in the order **scale → rotate → offset**, in
+the *model frame*: X matches the footprint 2D X, **Y is negated** relative to
+the footprint 2D frame, and Z is up from the board.
+
+- `rotate` is written **verbatim** into the emitted node. The LCSC tier's
+  derived `theta` is always `0` (there is no source footprint), so nothing
+  composes with it and it can never double-apply.
+- `offset` is **added to** the pad-centroid delta `(dx, -dy)` that the shared
+  offset machinery already injects. Its **Z passes through untouched** — that is
+  the knob for a STEP whose origin is not on the board plane.
+- Because `offset` is applied *after* `rotate`, it is a post-rotation
+  translation. Practical consequence: **set `rotate` first, render, and only
+  then measure `offset`.**
+- A footprint's own `(at x y angle)` rotates the whole footprint *including* its
+  model, so an authored per-part transform is **placement-angle independent**.
+  Calibrate once per part; never per instance. This is the property that makes a
+  part-keyed table sound.
+
+### Calibrating a per-part transform
+
+**Only a render can tell you whether a number is right.** The automated tests
+around this mechanism verify *plumbing and process* — that the composition,
+signs, model-frame Y negation and Z passthrough are wired correctly, and that
+every packaged entry carries provenance. They can **never** verify that the
+authored value for a given part is correct. CI has no KiCad and cannot render.
+
+So: run this loop, look at the picture, and only then commit a number.
+
+```bash
+# 1. Scratch copy with the stale model node stripped.  (add-3d-models is
+#    insert-only until #4586 lands, so it will not rewrite an existing ref.)
+cp boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb /tmp/cal.kicad_pcb
+#    ...strip the existing (model ...) block for the part under test...
+
+# 2. Re-insert with the candidate transform in the packaged table (or in a
+#    scratch sidecar, which is faster to iterate on).
+uv run kct pcb add-3d-models /tmp/cal.kicad_pcb \
+    --lcsc-models /tmp/sidecar.json
+
+# 3. Render and LOOK.  (KCT_LCSC_3D_DIR is setdefault-ed by the render runner.)
+uv run kct render /tmp/cal.kicad_pcb          # isometric 3d-front.png / 3d-back.png
+
+# 4. For an unambiguous read, add an orthographic top view zoomed on the part.
+kicad-cli pcb render /tmp/cal.kicad_pcb --side top --zoom 5 \
+    --pivot <X>,<Y>,0 -o /tmp/top.png
+```
+
+**Compare `+90` and `-90` visually — do not reason your way to a sign.** Most
+connector bodies are not symmetric under a 180° flip, so the mating face lands on
+the wrong side for the wrong sign even when the long axis looks right. Useful
+objective tiebreakers, both readable off an orthographic top view: the body's
+long axis must be parallel to the footprint's pad field, and the body must lie
+inside the `Edge.Cuts` outline rather than hanging across a board edge.
+
+Then record what you saw. **Every packaged entry must carry a
+`TransformProvenance`** (board, refdes, ISO date, the literal command, and notes
+on what the render showed); `tests/test_lcsc_models.py` walks the table and
+**fails** on any entry whose provenance is missing or malformed. That is the
+structural gate: an uncalibrated guess cannot land green, so the only way into
+the table is a human who actually rendered.
+
 ## Cache and environment variables
 
 - **`KCT_LCSC_3D_DIR`** — the on-disk STEP cache directory. Default:
@@ -65,10 +182,11 @@ lib id in the fleet is unique per board, so one C-number per lib id suffices.
 - **Origin-authored placement (approximation).** An EasyEDA STEP is a bare
   `.step` with no `.kicad_mod`, so there is no source pad centroid. The body is
   treated as origin-centered (`source_anchor=(0, 0)`), and the shared offset
-  machinery lands its origin on the target footprint's pad centroid. Scale and
-  rotation are left at KiCad defaults; a fetched body whose native orientation
-  differs from the footprint silkscreen may sit rotated. These bodies are
-  cosmetic render aids.
+  machinery lands its origin on the target footprint's pad centroid. Scale is
+  always left at the KiCad default; rotation and any extra offset come from the
+  authored per-part transform described above (identity when no entry exists, so
+  an uncorrected body whose native orientation differs from the footprint
+  silkscreen may still sit rotated). These bodies are cosmetic render aids.
 - **Licensing.** EasyEDA/LCSC models are design-use-oriented and **not**
   explicitly redistributable — they are cached locally and **never committed**
   to the repo. Only the portable `${KCT_LCSC_3D_DIR}` path-variable ref is

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2125,7 +2125,9 @@ def _add_pcb_parser(subparsers) -> None:
         "C-number, enabling the LCSC/EasyEDA fetch-on-demand tier. Bodies are "
         "resolved from a cache dir (${KCT_LCSC_3D_DIR}, default "
         "~/.cache/kicad-tools/lcsc-3d/) and emitted as portable "
-        "${KCT_LCSC_3D_DIR}/C#####.step refs",
+        "${KCT_LCSC_3D_DIR}/C#####.step refs. An entry may also use the object "
+        'form {"lcsc": "C#####", "rotate": [0,0,90], "offset": [0,0,0]} to '
+        "override the packaged per-part transform table for that board",
     )
     pcb_add_models.add_argument(
         "--fetch-lcsc",

--- a/src/kicad_tools/cli/pcb_add_3d_models.py
+++ b/src/kicad_tools/cli/pcb_add_3d_models.py
@@ -48,7 +48,9 @@ def run_add_3d_models(
             the ``..._EP2.6x2.6mm`` variant — the model body is identical).
         lcsc_models: Optional path to an ``lcsc_models.json`` sidecar mapping
             ``lib_id -> C-number``, enabling the LCSC/EasyEDA fetch-on-demand
-            tier.
+            tier.  Entries may also use the object form
+            (``{"lcsc": "C…", "rotate": [...], "offset": [...]}``) to override
+            the packaged per-part transform table.
         fetch_lcsc: When True, fetch a missing LCSC STEP from EasyEDA on a
             cache miss (default: cache-only; also enabled by
             ``KCT_LCSC_FETCH``).
@@ -59,10 +61,10 @@ def run_add_3d_models(
         Exit code (0 success, 1 error).
     """
     from kicad_tools.footprints.library_path import detect_kicad_library_path
-    from kicad_tools.pcb.lcsc_models import fetch_enabled, load_lcsc_mapping
+    from kicad_tools.pcb.lcsc_models import LcscModelEntry, fetch_enabled, load_lcsc_mapping
     from kicad_tools.pcb.models3d import add_model_refs
 
-    lcsc_mapping: dict[str, str] | None = None
+    lcsc_mapping: dict[str, LcscModelEntry] | None = None
     if lcsc_models is not None:
         try:
             lcsc_mapping = load_lcsc_mapping(lcsc_models)
@@ -120,6 +122,7 @@ def run_add_3d_models(
         "variant_matches": report.variant_matches,
         "substitution_matches": report.substitution_matches,
         "lcsc_matches": report.lcsc_matches,
+        "lcsc_transforms": report.lcsc_transforms,
     }
 
     if output_format == "json":
@@ -149,6 +152,10 @@ def run_add_3d_models(
             print("  LCSC/EasyEDA fetched models used (cached STEP):")
             for lib_id, cnum in sorted(report.lcsc_matches.items()):
                 print(f"    {lib_id} -> {cnum}")
+        if report.lcsc_transforms:
+            print("  Per-part LCSC transforms applied:")
+            for lib_id, desc in sorted(report.lcsc_transforms.items()):
+                print(f"    {lib_id}: {desc}")
         if report.already_present:
             print(f"  Already had models: {len(report.already_present)}")
         if report.no_model_in_library:

--- a/src/kicad_tools/pcb/lcsc_model_transforms.py
+++ b/src/kicad_tools/pcb/lcsc_model_transforms.py
@@ -1,0 +1,243 @@
+"""Curated per-part 3D-body transforms for the LCSC/EasyEDA model tier.
+
+The three installed-library ``add-3d-models`` tiers *derive* a body's offset
+and rotation geometrically, by comparing the target footprint's pad field
+against the source ``.kicad_mod`` (``models3d._pad_anchor`` /
+``models3d._pad_field_orientation``).  The fourth tier — LCSC/EasyEDA
+fetch-on-demand (:mod:`kicad_tools.pcb.lcsc_models`) — has **no source
+footprint at all**: it synthesizes a ``(model ...)`` node from nothing but a
+C-number, so there is nothing to derive a rotation from.  EasyEDA STEP bodies
+are authored in whatever orientation the part vendor chose, so the identity
+rotation that tier emits by default is a *guess*, and for many parts it is
+wrong by a quarter turn.
+
+This module is where the fleet's **authored** corrections live: an explicit,
+curated ``C-number -> transform`` table, mirroring the shape of the adjacent
+:mod:`kicad_tools.pcb.model_substitutions` (policy docstring, dict constant,
+single accessor).
+
+**Why keyed by C-number.**  An LCSC C-number is a stable, global,
+vendor-issued identifier for a physical part, and a body's native orientation
+is a property of *that part*, not of any board.  ``lib_id``s in this fleet are
+not stable — ``docs/guides/lcsc-3d-models.md`` notes each synthetic lib id is
+unique per board — so a lib_id-keyed table would have a reuse rate of ~zero.
+Keyed by C-number, one calibration is correct for every board and every
+downstream consumer that installs this package.
+
+**Placement-angle independence.**  A footprint's own ``(at x y angle)``
+rotates the whole footprint *including* its 3D body, so a per-part transform
+authored here stays correct at any board placement angle.  Calibrate once per
+part; never per instance.
+
+**Frame semantics.**  KiCad applies a model's transforms in the order
+**scale -> rotate -> offset**, in the *model frame*: X matches the footprint 2D
+X, **Y is negated** relative to the footprint 2D frame, and Z is up from the
+board.  Because ``offset`` is applied *after* ``rotate``, the ``offset`` here
+is a post-rotation translation — so when calibrating a part, set ``rotate``
+first, render, and only then measure ``offset``.
+
+**Precedence** (resolved in ``models3d._resolve_lcsc``, first non-``None``
+wins, merged per field):
+
+1. A per-board ``lcsc_models.json`` sidecar entry in object form
+   (``{"lib_id": {"lcsc": "C...", "rotate": [...], "offset": [...]}}``).
+2. This packaged table.
+3. Identity (``rotate (xyz 0 0 0)`` / ``offset (xyz 0 0 0)``) — unchanged
+   behavior for every part with no entry anywhere.
+
+**Provenance is mandatory, and enforced.**  Every entry MUST carry a
+:class:`TransformProvenance` recording the board, refdes, ISO date, and the
+exact command used to verify it *by rendering*.  ``tests/test_lcsc_models.py``
+walks this table and fails on any entry whose provenance is missing or
+malformed.  This is a structural rule, not a documentation nicety: **only a
+render can tell you whether a number is right**, CI has no KiCad to render
+with, so the only defensible gate is "a human must have rendered this."  An
+uncalibrated guess cannot land green.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from math import isfinite
+
+__all__ = [
+    "LCSC_MODEL_TRANSFORMS",
+    "LcscModelTransform",
+    "TransformProvenance",
+    "entry_problems",
+    "lookup_transform",
+    "table_problems",
+]
+
+Triple = tuple[float, float, float]
+
+_ISO_DATE_RE = re.compile(r"^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$")
+
+# Mirrors ``lcsc_models._LCSC_ID_RE``; duplicated (rather than imported) to
+# keep this curated data module free of any dependency on the network client.
+_LCSC_C_NUMBER_RE = re.compile(r"^C\d+$")
+
+
+@dataclass(frozen=True)
+class TransformProvenance:
+    """Evidence that a table entry was verified by an actual render.
+
+    Attributes:
+        board: Repo-relative board directory the calibration was rendered
+            from (e.g. ``"boards/06-diffpair-test"``).
+        refdes: The reference designator inspected (e.g. ``"J3"``).
+        verified: ISO ``YYYY-MM-DD`` date the render was inspected.
+        command: The literal command sequence used, so the check is
+            reproducible by the next person.
+        notes: Optional free text — what the render showed, which candidate
+            signs were compared, and why this one won.
+    """
+
+    board: str
+    refdes: str
+    verified: str
+    command: str
+    notes: str = ""
+
+
+@dataclass(frozen=True)
+class LcscModelTransform:
+    """A curated ``(rotate, offset)`` correction for one LCSC part.
+
+    Both triples are in the **model frame** (see the module docstring): X as
+    the footprint 2D X, Y negated versus footprint 2D Y, Z up from the board.
+    ``rotate`` is written verbatim into the emitted ``(rotate (xyz ...))``;
+    ``offset`` is *added to* the pad-centroid delta the shared offset
+    machinery already injects, and its Z component passes straight through
+    (the knob for a STEP whose origin is not on the board plane).
+
+    ``provenance`` is typed optional only so that a forgetful author gets a
+    **test failure** rather than a ``TypeError`` at import — see
+    :func:`entry_problems`.  A ``None`` provenance is never acceptable in the
+    committed table.
+    """
+
+    rotate: Triple | None = None
+    offset: Triple | None = None
+    provenance: TransformProvenance | None = None
+
+
+# --------------------------------------------------------------------------
+# The curated table
+# --------------------------------------------------------------------------
+# Every entry below was verified by rendering the board named in its
+# provenance and *looking at the body*.  Do not add an entry you have not
+# rendered: the emission tests verify plumbing (composition, sign, frame),
+# never the correctness of a number.  See "Calibrating a per-part transform"
+# in docs/guides/lcsc-3d-models.md for the recipe.
+LCSC_MODEL_TRANSFORMS: dict[str, LcscModelTransform] = {
+    # Mini-PCIe / M.2-style edge socket.  The EasyEDA body is authored with
+    # its 52-position card slot running along the model X axis (native XY
+    # extents ~29.9 x 9.7 mm), while the footprint's pad column runs along
+    # footprint Y -- so the identity rotation lays the socket across the
+    # board edge at 90 degrees to its own pads (issue #4584).
+    "C444929": LcscModelTransform(
+        rotate=(0.0, 0.0, -90.0),
+        provenance=TransformProvenance(
+            board="boards/06-diffpair-test",
+            refdes="J3",
+            verified="2026-08-04",
+            command=(
+                "kct pcb add-3d-models /tmp/cal.kicad_pcb --lcsc-models "
+                "/tmp/sidecar.json && kct render /tmp/cal.kicad_pcb && "
+                "kicad-cli pcb render /tmp/cal.kicad_pcb --side top --zoom 5 "
+                "--pivot 4.6,-0.2,0 -o /tmp/edge.png"
+            ),
+            notes=(
+                "All three candidates (0, +90, -90) were rendered on a "
+                "scratch copy of diffpair_test_routed.kicad_pcb with J3's "
+                "stale model node stripped.  At rotate 0 the body lies "
+                "east-west and hangs ~10 mm off the right board edge -- the "
+                "reported symptom.  Both +/-90 put the long axis north-south, "
+                "parallel to the 12-pad column at x=193.5.  -90 wins on the "
+                "board-edge criterion: measured on the top orthographic "
+                "render, the body spans board X 187.9..197.6 (0.9 mm clear of "
+                "the Edge.Cuts right edge at x=198.5), while +90 spans "
+                "189.4..199.1 and pokes 0.6 mm past it.  -90 also points the "
+                "card-entry slot off-board (+X); +90 points it inboard, at "
+                "U3.  A front-side render confirms the body seats on the "
+                "board surface, so no offset is needed."
+            ),
+        ),
+    ),
+}
+
+
+# --------------------------------------------------------------------------
+# Lookup + validation
+# --------------------------------------------------------------------------
+
+
+def lookup_transform(c_number: str) -> LcscModelTransform | None:
+    """Return the curated transform for *c_number*, or ``None`` if unlisted.
+
+    Consulted by the LCSC resolver after a per-board sidecar override, and
+    before falling back to identity.
+    """
+    return LCSC_MODEL_TRANSFORMS.get(c_number)
+
+
+def _triple_problems(label: str, value: object) -> list[str]:
+    """Return reasons *value* is not a usable 3-tuple of finite numbers."""
+    if value is None:
+        return []
+    if not isinstance(value, tuple) or len(value) != 3:
+        return [f"{label} must be a 3-tuple, got {value!r}"]
+    problems: list[str] = []
+    for axis, component in zip("xyz", value, strict=True):
+        if isinstance(component, bool) or not isinstance(component, (int, float)):
+            problems.append(f"{label}.{axis} must be a number, got {component!r}")
+        elif not isfinite(float(component)):
+            problems.append(f"{label}.{axis} must be finite, got {component!r}")
+    return problems
+
+
+def entry_problems(c_number: str, entry: LcscModelTransform) -> list[str]:
+    """Return every reason *entry* is not fit to ship, or ``[]`` when it is.
+
+    Enforced by a test over :data:`LCSC_MODEL_TRANSFORMS`.  The provenance
+    rules are the load-bearing part: an entry with no recorded render is an
+    uncalibrated guess, and this repo has already shipped one of those green
+    (#4457).  CI cannot render, so "a human rendered it and said so" is the
+    strongest gate available.
+    """
+    problems: list[str] = []
+    if not _LCSC_C_NUMBER_RE.match(c_number):
+        problems.append(f"key {c_number!r} is not a C-number ('C' followed by digits)")
+    if entry.rotate is None and entry.offset is None:
+        problems.append("entry specifies neither rotate nor offset (it would be a no-op)")
+    problems.extend(_triple_problems("rotate", entry.rotate))
+    problems.extend(_triple_problems("offset", entry.offset))
+
+    prov = entry.provenance
+    if prov is None:
+        problems.append(
+            "missing provenance: every entry must record the render that "
+            "verified it (board, refdes, ISO date, command)"
+        )
+        return problems
+    for field_name in ("board", "refdes", "command"):
+        value = getattr(prov, field_name)
+        if not isinstance(value, str) or not value.strip():
+            problems.append(f"provenance.{field_name} must be a non-empty string")
+    if not isinstance(prov.verified, str) or not _ISO_DATE_RE.match(prov.verified):
+        problems.append(
+            f"provenance.verified must be an ISO YYYY-MM-DD date, got {prov.verified!r}"
+        )
+    return problems
+
+
+def table_problems() -> dict[str, list[str]]:
+    """Return ``{c_number: problems}`` for every unfit entry in the table."""
+    found: dict[str, list[str]] = {}
+    for c_number, entry in LCSC_MODEL_TRANSFORMS.items():
+        problems = entry_problems(c_number, entry)
+        if problems:
+            found[c_number] = problems
+    return found

--- a/src/kicad_tools/pcb/lcsc_models.py
+++ b/src/kicad_tools/pcb/lcsc_models.py
@@ -20,10 +20,18 @@ are treated as **origin-authored**: the resolver returns
 shared ``add_model_refs_to_text`` offset math computes ``dx, dy =
 target_anchor`` -- the body's origin lands on the target footprint's pad
 centroid.  This is an approximation (origin-centered placement, not
-pin-1-registered) and scale/rotation are left at KiCad defaults (``1 1 1`` /
-``0 0 0``); a fetched body whose native orientation differs from the
-footprint's silkscreen may sit rotated.  These limitations are acceptable for
-cosmetic render bodies and noted for future per-mapping overrides.
+pin-1-registered).
+
+**Orientation policy.**  There is likewise no source footprint to *derive* a
+rotation from, and EasyEDA bodies are authored in whatever orientation the
+part vendor chose, so the tier's default identity rotation is a guess that is
+wrong for many parts.  Authored per-part corrections therefore come from two
+places, resolved in ``models3d._resolve_lcsc`` (first non-``None`` wins,
+merged per field): a per-board sidecar entry in **object form**
+(:class:`LcscModelEntry`), then the packaged, C-number-keyed table in
+:mod:`kicad_tools.pcb.lcsc_model_transforms`, then identity.  See
+``docs/guides/lcsc-3d-models.md`` for the frame semantics and the calibration
+recipe.
 
 **Offline / CI safety.**  The fetch is opt-in.  A model resolves only when the
 cache already holds the STEP, or when fetching is explicitly enabled (via the
@@ -35,21 +43,28 @@ never fails for want of a body, and CI never needs network.
 from __future__ import annotations
 
 import json
+import math
 import os
 import re
 import urllib.error
 import urllib.request
+from dataclasses import dataclass
 from pathlib import Path
 
 __all__ = [
     "DEFAULT_CACHE_ENV_VAR",
     "LCSC_MODEL_PATH_VAR",
+    "LcscModelEntry",
     "fetch_enabled",
     "load_lcsc_mapping",
     "lcsc_cache_dir",
     "resolve_lcsc_step",
     "synthesize_model_block",
 ]
+
+# A model-frame (x, y, z) triple, as written into ``(offset ...)`` /
+# ``(rotate ...)``.
+Triple = tuple[float, float, float]
 
 # Env var naming the on-disk LCSC STEP cache directory.  It doubles as the
 # ``(model ...)`` path variable emitted into committed ``.kicad_pcb`` files
@@ -123,13 +138,114 @@ def fetch_enabled(flag: bool = False) -> bool:
     return val in {"1", "true", "yes", "on"}
 
 
-def load_lcsc_mapping(sidecar_path: Path | str) -> dict[str, str]:
+@dataclass(frozen=True)
+class LcscModelEntry:
+    """One resolved sidecar entry: a C-number plus optional per-part transforms.
+
+    *rotate* and *offset* are model-frame triples (X as the footprint 2D X, Y
+    negated versus footprint 2D Y, Z up from the board).  ``None`` means "this
+    sidecar says nothing about that field", which lets the packaged
+    :mod:`kicad_tools.pcb.lcsc_model_transforms` table supply it — the merge is
+    per field, so a sidecar that overrides only ``rotate`` does not suppress a
+    packaged ``offset``.
+    """
+
+    lcsc: str
+    rotate: Triple | None = None
+    offset: Triple | None = None
+
+
+# Keys accepted in the sidecar's object form.  Anything else is a build error:
+# a typo'd ``"rotation"`` must not degrade to a silent, green no-op -- that is
+# precisely the failure mode the override mechanism exists to prevent.
+_ENTRY_KEYS = frozenset({"lcsc", "rotate", "offset"})
+
+
+def _parse_triple(path: Path, lib_id: str, field_name: str, value: object) -> Triple:
+    """Validate an object-form ``rotate``/``offset`` array, or raise ``ValueError``."""
+    if not isinstance(value, list) or len(value) != 3:
+        raise ValueError(
+            f"LCSC sidecar {path}: {field_name!r} for {lib_id!r} must be an array of "
+            f"exactly 3 numbers, got {value!r}"
+        )
+    out: list[float] = []
+    for component in value:
+        # ``bool`` is an ``int`` subclass; a JSON ``true`` is not a coordinate.
+        if isinstance(component, bool) or not isinstance(component, (int, float)):
+            raise ValueError(
+                f"LCSC sidecar {path}: {field_name!r} for {lib_id!r} must contain only "
+                f"numbers, got {component!r}"
+            )
+        as_float = float(component)
+        if not math.isfinite(as_float):
+            raise ValueError(
+                f"LCSC sidecar {path}: {field_name!r} for {lib_id!r} must contain only "
+                f"finite numbers, got {component!r}"
+            )
+        out.append(as_float)
+    return (out[0], out[1], out[2])
+
+
+def _parse_entry(path: Path, lib_id: str, value: object) -> LcscModelEntry:
+    """Parse one sidecar value (bare C-number string, or the object form)."""
+    if isinstance(value, str):
+        c_number = value
+        rotate: Triple | None = None
+        offset: Triple | None = None
+    elif isinstance(value, dict):
+        unknown = sorted(set(value) - _ENTRY_KEYS)
+        if unknown:
+            raise ValueError(
+                f"LCSC sidecar {path}: unknown key(s) {unknown} for {lib_id!r} "
+                f"(expected any of {sorted(_ENTRY_KEYS)})"
+            )
+        raw_lcsc = value.get("lcsc")
+        if not isinstance(raw_lcsc, str):
+            raise ValueError(
+                f"LCSC sidecar {path}: object form for {lib_id!r} must contain a "
+                "string 'lcsc' C-number"
+            )
+        c_number = raw_lcsc
+        rotate = (
+            _parse_triple(path, lib_id, "rotate", value["rotate"]) if "rotate" in value else None
+        )
+        offset = (
+            _parse_triple(path, lib_id, "offset", value["offset"]) if "offset" in value else None
+        )
+    else:
+        raise ValueError(
+            f"LCSC sidecar {path}: entry for {lib_id!r} must be a string C-number or an "
+            "object with an 'lcsc' key"
+        )
+    # The C-number is untrusted and flows into a cache filename, a request
+    # URL, and a committed board ref; a malformed value (path traversal,
+    # URL injection, non-C string) is a build error, matching the
+    # malformed-sidecar posture above.  Validated identically on both forms.
+    if not _is_valid_lcsc_id(c_number):
+        raise ValueError(
+            f"LCSC sidecar {path}: invalid C-number {c_number!r} for {lib_id!r} "
+            "(expected 'C' followed by digits, e.g. 'C50950')"
+        )
+    return LcscModelEntry(lcsc=c_number, rotate=rotate, offset=offset)
+
+
+def load_lcsc_mapping(sidecar_path: Path | str) -> dict[str, LcscModelEntry]:
     """Load a ``lib_id -> C-number`` sidecar (``lcsc_models.json``).
 
-    The sidecar is a flat JSON object, e.g.
-    ``{"Module:Joystick_Analog": "C50950"}``.  Raises ``ValueError`` on a
-    malformed file (not silently ignored -- a broken committed sidecar is a
-    build error, distinct from a runtime network failure).
+    Two per-entry forms are accepted:
+
+    * **bare string** -- ``{"Module:Joystick_Analog": "C50950"}``, meaning "use
+      this C-number with whatever transform the packaged table supplies (or
+      identity)";
+    * **object** -- ``{"Connector:Part": {"lcsc": "C444929", "rotate": [0, 0,
+      90], "offset": [0, 0, 0]}}``, a board-local override of the packaged
+      :mod:`kicad_tools.pcb.lcsc_model_transforms` table.  ``rotate`` and
+      ``offset`` are independently optional.
+
+    Raises ``ValueError`` on a malformed file (not silently ignored -- a broken
+    committed sidecar is a build error, distinct from a runtime network
+    failure).  Unknown object keys are rejected rather than ignored, so a
+    typo'd ``"rotation"`` fails loudly instead of silently doing nothing.
     """
     path = Path(sidecar_path)
     try:
@@ -140,22 +256,11 @@ def load_lcsc_mapping(sidecar_path: Path | str) -> dict[str, str]:
         raise ValueError(f"malformed LCSC sidecar {path}: {e}") from e
     if not isinstance(raw, dict):
         raise ValueError(f"LCSC sidecar {path} must be a JSON object of lib_id -> C-number")
-    mapping: dict[str, str] = {}
+    mapping: dict[str, LcscModelEntry] = {}
     for key, value in raw.items():
-        if not isinstance(key, str) or not isinstance(value, str):
-            raise ValueError(
-                f"LCSC sidecar {path}: entries must be string lib_id -> string C-number"
-            )
-        # The C-number is untrusted and flows into a cache filename, a request
-        # URL, and a committed board ref; a malformed value (path traversal,
-        # URL injection, non-C string) is a build error, matching the
-        # malformed-sidecar posture above.
-        if not _is_valid_lcsc_id(value):
-            raise ValueError(
-                f"LCSC sidecar {path}: invalid C-number {value!r} for {key!r} "
-                "(expected 'C' followed by digits, e.g. 'C50950')"
-            )
-        mapping[key] = value
+        if not isinstance(key, str):
+            raise ValueError(f"LCSC sidecar {path}: entry keys must be string lib_ids")
+        mapping[key] = _parse_entry(path, key, value)
     return mapping
 
 
@@ -307,23 +412,63 @@ def resolve_lcsc_step(
     return step_path
 
 
-def synthesize_model_block(lcsc_id: str) -> str:
+def _fmt_num(value: float) -> str:
+    """Format a float the way KiCad writes model offsets (no trailing zeros).
+
+    Deliberately identical to ``models3d._fmt_num`` so a synthesized block and
+    a block the shared offset machinery has rewritten are byte-comparable.
+    ``tests/test_lcsc_models.py`` asserts the two stay in agreement.
+    """
+    if value == 0.0:
+        value = 0.0  # normalize -0.0 -> 0.0
+    rounded = round(value, 6)
+    if rounded == int(rounded):
+        return str(int(rounded))
+    return f"{rounded:g}"
+
+
+def _fmt_xyz(triple: Triple | None, default: Triple) -> str:
+    """Render ``(xyz x y z)`` for *triple*, falling back to *default*."""
+    x, y, z = default if triple is None else triple
+    return f"(xyz {_fmt_num(x)} {_fmt_num(y)} {_fmt_num(z)})"
+
+
+def synthesize_model_block(
+    lcsc_id: str,
+    *,
+    rotate: Triple | None = None,
+    offset: Triple | None = None,
+) -> str:
     """Build a dedented ``(model ...)`` block referencing the LCSC cache.
 
-    The path uses the portable ``${KCT_LCSC_3D_DIR}`` variable and a baseline
-    ``(offset (xyz 0 0 0))`` so the shared offset machinery injects the full
-    target pad-centroid delta as the model's final offset.
+    The path uses the portable ``${KCT_LCSC_3D_DIR}`` variable.  With no
+    override the block is the historical identity node -- ``(offset (xyz 0 0
+    0))`` (so the shared offset machinery injects the full target pad-centroid
+    delta as the model's final offset), ``(scale (xyz 1 1 1))``, ``(rotate
+    (xyz 0 0 0))``.
+
+    Args:
+        lcsc_id: LCSC part number (e.g. ``"C444929"``).
+        rotate: Optional model-frame rotation triple, written **verbatim**.
+            The LCSC tier's derived ``theta`` is always ``0`` (there is no
+            source footprint to derive one from), so nothing composes with
+            this value.
+        offset: Optional model-frame offset triple.  It seeds the node's
+            ``(offset ...)``, and the shared pad-centroid delta ``(dx, -dy)``
+            is then *added* into its X/Y by ``models3d._apply_offset_delta``;
+            Z passes through untouched.  Because KiCad applies scale ->
+            rotate -> offset, this is a post-rotation translation.
     """
     return (
         f'(model "{LCSC_MODEL_PATH_VAR}/{lcsc_id}.step"\n'
         "\t(offset\n"
-        "\t\t(xyz 0 0 0)\n"
+        f"\t\t{_fmt_xyz(offset, (0.0, 0.0, 0.0))}\n"
         "\t)\n"
         "\t(scale\n"
         "\t\t(xyz 1 1 1)\n"
         "\t)\n"
         "\t(rotate\n"
-        "\t\t(xyz 0 0 0)\n"
+        f"\t\t{_fmt_xyz(rotate, (0.0, 0.0, 0.0))}\n"
         "\t)\n"
         ")"
     )

--- a/src/kicad_tools/pcb/models3d.py
+++ b/src/kicad_tools/pcb/models3d.py
@@ -60,9 +60,10 @@ Used by ``kct pcb add-3d-models``.
 from __future__ import annotations
 
 import math
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from kicad_tools.footprints.library_path import (
     LibraryPaths,
@@ -71,8 +72,20 @@ from kicad_tools.footprints.library_path import (
 )
 from kicad_tools.pcb.model_substitutions import substitute_lib_id
 
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from kicad_tools.pcb.lcsc_models import LcscModelEntry
+
+# The LCSC sidecar mapping accepted by the tier-4 resolver.  A bare ``str``
+# value (a plain ``lib_id -> C-number`` dict) stays valid for callers written
+# before the per-part override mechanism (#4584); an ``LcscModelEntry`` value
+# additionally carries the sidecar's object-form ``rotate``/``offset``.  Typed
+# as a ``Mapping`` (covariant in its value type) so a caller may pass either a
+# ``dict[str, str]`` or a ``dict[str, LcscModelEntry]`` without a cast.
+LcscMapping = Mapping[str, "str | LcscModelEntry"]
+
 __all__ = [
     "FootprintBlock",
+    "LcscMapping",
     "ModelPatchReport",
     "ResolvedModels",
     "add_model_refs",
@@ -565,6 +578,29 @@ def _find_variant_mod(paths: LibraryPaths, library: str, name: str) -> Path | No
     return candidates[0]
 
 
+def _describe_lcsc_transform(
+    rotate: tuple[float, float, float] | None,
+    offset: tuple[float, float, float] | None,
+    *,
+    rotate_from_sidecar: bool,
+    offset_from_sidecar: bool,
+) -> str:
+    """Render a one-line ``rotate=... offset=...`` summary naming each source."""
+    parts: list[str] = []
+    if rotate is not None:
+        source = "sidecar" if rotate_from_sidecar else "packaged table"
+        parts.append(f"rotate={_fmt_triple(rotate)} [{source}]")
+    if offset is not None:
+        source = "sidecar" if offset_from_sidecar else "packaged table"
+        parts.append(f"offset={_fmt_triple(offset)} [{source}]")
+    return " ".join(parts)
+
+
+def _fmt_triple(triple: tuple[float, float, float]) -> str:
+    """Render a transform triple for human-readable reporting."""
+    return "(" + ", ".join(_fmt_num(v) for v in triple) + ")"
+
+
 def make_library_resolver(
     library_paths: LibraryPaths | None = None,
     *,
@@ -572,10 +608,11 @@ def make_library_resolver(
     allow_substitutions: bool = True,
     variant_log: dict[str, str] | None = None,
     substitution_log: dict[str, str] | None = None,
-    lcsc_mapping: dict[str, str] | None = None,
+    lcsc_mapping: LcscMapping | None = None,
     lcsc_fetch: bool = False,
     lcsc_cache_dir: Path | None = None,
     lcsc_log: dict[str, str] | None = None,
+    lcsc_transform_log: dict[str, str] | None = None,
     lcsc_warn: Callable[[str], None] | None = None,
 ) -> Resolver:
     """Build a resolver that reads model refs from installed KiCad libraries.
@@ -602,6 +639,11 @@ def make_library_resolver(
        synthesized ``(model ...)`` ref points at ``${KCT_LCSC_3D_DIR}`` and is
        authored as **origin-centered** (``source_anchor=(0.0, 0.0)``) so the
        shared offset machinery lands the body on the target pad centroid.
+       Because there is no source footprint, no rotation is *derivable*; any
+       per-part ``rotate``/``offset`` correction comes from the sidecar's
+       object form or the packaged
+       :mod:`kicad_tools.pcb.lcsc_model_transforms` table (in that order,
+       merged per field, falling back to identity).
 
     Args:
         library_paths: Explicit library location (default: auto-detect).
@@ -616,12 +658,18 @@ def make_library_resolver(
             substitution, so callers can report them.
         lcsc_mapping: Optional ``lib_id -> C-number`` sidecar mapping enabling
             the LCSC tier (tier 4).  Only lib ids present here are eligible.
+            Values may be a bare C-number ``str`` or an
+            :class:`~kicad_tools.pcb.lcsc_models.LcscModelEntry` carrying
+            per-part ``rotate``/``offset`` overrides.
         lcsc_fetch: When True, fetch a missing STEP from EasyEDA on a cache
             miss; default cache-only (no network).
         lcsc_cache_dir: Optional LCSC STEP cache directory (default:
             :func:`kicad_tools.pcb.lcsc_models.lcsc_cache_dir`).
         lcsc_log: Optional dict populated with ``lib_id -> C-number`` for every
             resolved LCSC match, so callers can report them.
+        lcsc_transform_log: Optional dict populated with ``lib_id ->
+            description`` for every LCSC body that received a non-identity
+            per-part transform, naming the source of each field.
         lcsc_warn: Optional ``callable(str)`` invoked on a fetch failure.
     """
     paths = library_paths if library_paths is not None else detect_kicad_library_path()
@@ -660,12 +708,28 @@ def make_library_resolver(
         has no mapping, or the STEP is neither cached nor fetchable."""
         if not lcsc_mapping:
             return None
-        lcsc_id = lcsc_mapping.get(lib_id)
-        if not lcsc_id:
+        entry = lcsc_mapping.get(lib_id)
+        if not entry:
             return None
         # Imported lazily so the module (and the three installed-library tiers)
         # never depend on the LCSC client unless the LCSC tier is actually used.
-        from kicad_tools.pcb.lcsc_models import resolve_lcsc_step, synthesize_model_block
+        from kicad_tools.pcb.lcsc_model_transforms import lookup_transform
+        from kicad_tools.pcb.lcsc_models import (
+            LcscModelEntry,
+            resolve_lcsc_step,
+            synthesize_model_block,
+        )
+
+        # Accept a bare ``str`` C-number (legacy callers passing a plain
+        # ``dict[str, str]``) or the richer sidecar entry.
+        if isinstance(entry, LcscModelEntry):
+            lcsc_id = entry.lcsc
+            sidecar_rotate = entry.rotate
+            sidecar_offset = entry.offset
+        else:
+            lcsc_id = entry
+            sidecar_rotate = None
+            sidecar_offset = None
 
         step_path = resolve_lcsc_step(
             lcsc_id,
@@ -679,9 +743,32 @@ def make_library_resolver(
             return None
         if lcsc_log is not None:
             lcsc_log[lib_id] = lcsc_id
+        # Per-part transform precedence, merged per field so a sidecar that
+        # overrides only ``rotate`` still inherits a packaged ``offset``:
+        #   per-board sidecar object form > packaged table > identity.
+        packaged = lookup_transform(lcsc_id)
+        packaged_rotate = packaged.rotate if packaged is not None else None
+        packaged_offset = packaged.offset if packaged is not None else None
+        rotate = sidecar_rotate if sidecar_rotate is not None else packaged_rotate
+        offset = sidecar_offset if sidecar_offset is not None else packaged_offset
+        if lcsc_transform_log is not None and (rotate is not None or offset is not None):
+            lcsc_transform_log[lib_id] = _describe_lcsc_transform(
+                rotate,
+                offset,
+                rotate_from_sidecar=sidecar_rotate is not None,
+                offset_from_sidecar=sidecar_offset is not None,
+            )
         # Origin-authored body: explicit (0, 0) source anchor so the shared
-        # offset math shifts by the full target pad centroid.
-        return ResolvedModels(models=[synthesize_model_block(lcsc_id)], source_anchor=(0.0, 0.0))
+        # offset math shifts by the full target pad centroid.  ``source_orientation``
+        # is deliberately left ``None`` -- there is no source footprint to
+        # derive a pad-field orientation from, so ``theta`` stays 0 and
+        # ``_apply_rotate_delta`` is a no-op.  That is what makes it safe to
+        # write the override rotation verbatim here: the two can never
+        # double-apply.
+        return ResolvedModels(
+            models=[synthesize_model_block(lcsc_id, rotate=rotate, offset=offset)],
+            source_anchor=(0.0, 0.0),
+        )
 
     def resolve(lib_id: str) -> ResolvedModels | None:
         if lib_id in cache:
@@ -736,6 +823,9 @@ class ModelPatchReport:
     lcsc_matches: dict[str, str] = field(default_factory=dict)
     """Lib ids whose model came from the LCSC/EasyEDA fetch tier
     (``lib_id -> C-number``)."""
+    lcsc_transforms: dict[str, str] = field(default_factory=dict)
+    """Lib ids whose LCSC body received a non-identity per-part transform
+    (``lib_id -> human-readable summary naming each field's source``)."""
 
     @property
     def changed(self) -> bool:
@@ -780,7 +870,13 @@ def add_model_refs_to_text(pcb_text: str, resolver: Resolver) -> tuple[str, Mode
         # 2D frame; the model frame's Y negation and KiCad's render-time
         # negation of the written (rotate ...) cancel, so _apply_rotate_delta
         # bakes a model-frame Z of +theta.  When either orientation is underivable
-        # (single-pad parts, LCSC-synthesized bodies) theta stays 0.
+        # (single-pad parts, LCSC-synthesized bodies) theta stays 0.  For the
+        # LCSC tier that is permanent by construction -- there is no source
+        # footprint -- so its orientation correction is *authored* instead, and
+        # is already baked into the synthesized block by
+        # ``make_library_resolver._resolve_lcsc`` (sidecar object form >
+        # packaged lcsc_model_transforms table > identity).  theta == 0 there
+        # is what guarantees the two can never double-apply.
         target_orientation = _pad_field_orientation(body)
         theta = 0.0
         if source_orientation is not None and target_orientation is not None:
@@ -827,7 +923,7 @@ def add_model_refs(
     resolver: Resolver | None = None,
     allow_variants: bool = True,
     allow_substitutions: bool = True,
-    lcsc_mapping: dict[str, str] | None = None,
+    lcsc_mapping: LcscMapping | None = None,
     lcsc_fetch: bool = False,
     lcsc_cache_dir: Path | None = None,
     lcsc_warn: Callable[[str], None] | None = None,
@@ -848,8 +944,11 @@ def add_model_refs(
             exact + variant matching both miss (reported in
             ``substitution_matches``). Ignored when *resolver* is supplied.
         lcsc_mapping: Optional ``lib_id -> C-number`` sidecar enabling the LCSC
-            fetch tier (reported in ``lcsc_matches``). Ignored when *resolver*
-            is supplied.
+            fetch tier (reported in ``lcsc_matches``). Values may be a bare
+            C-number ``str`` or an
+            :class:`~kicad_tools.pcb.lcsc_models.LcscModelEntry` carrying
+            per-part ``rotate``/``offset`` overrides (reported in
+            ``lcsc_transforms``). Ignored when *resolver* is supplied.
         lcsc_fetch: When True, fetch a missing LCSC STEP on a cache miss;
             default cache-only (no network). Ignored when *resolver* is
             supplied.
@@ -867,6 +966,7 @@ def add_model_refs(
     variant_log: dict[str, str] = {}
     substitution_log: dict[str, str] = {}
     lcsc_log: dict[str, str] = {}
+    lcsc_transform_log: dict[str, str] = {}
     if resolver is None:
         resolver = make_library_resolver(
             library_paths,
@@ -878,6 +978,7 @@ def add_model_refs(
             lcsc_fetch=lcsc_fetch,
             lcsc_cache_dir=lcsc_cache_dir,
             lcsc_log=lcsc_log,
+            lcsc_transform_log=lcsc_transform_log,
             lcsc_warn=lcsc_warn,
         )
     new_text, report = add_model_refs_to_text(text, resolver)
@@ -890,6 +991,9 @@ def add_model_refs(
     }
     report.lcsc_matches = {
         lib_id: cnum for lib_id, cnum in lcsc_log.items() if lib_id in report.patched
+    }
+    report.lcsc_transforms = {
+        lib_id: desc for lib_id, desc in lcsc_transform_log.items() if lib_id in report.patched
     }
     if report.changed and not dry_run:
         dest = Path(output_path) if output_path is not None else pcb_path

--- a/tests/test_lcsc_models.py
+++ b/tests/test_lcsc_models.py
@@ -15,16 +15,28 @@ from __future__ import annotations
 
 import io
 import json
+import re
 from pathlib import Path
 from unittest import mock
 
 import pytest
 
 from kicad_tools.footprints.library_path import LibraryPaths
+from kicad_tools.pcb import lcsc_model_transforms
+from kicad_tools.pcb.lcsc_model_transforms import (
+    LCSC_MODEL_TRANSFORMS,
+    LcscModelTransform,
+    TransformProvenance,
+    entry_problems,
+    lookup_transform,
+    table_problems,
+)
 from kicad_tools.pcb.lcsc_models import (
     DEFAULT_CACHE_ENV_VAR,
     LCSC_MODEL_PATH_VAR,
+    LcscModelEntry,
     _fetch_lcsc_step,
+    _fmt_num,
     _parse_3d_uuid,
     fetch_enabled,
     lcsc_cache_dir,
@@ -306,7 +318,16 @@ class TestSidecar:
     def test_loads_lib_id_to_cnumber(self, tmp_path):
         sidecar = tmp_path / "lcsc_models.json"
         sidecar.write_text(json.dumps({"Module:Joystick_Analog": "C50950"}))
-        assert load_lcsc_mapping(sidecar) == {"Module:Joystick_Analog": "C50950"}
+        assert load_lcsc_mapping(sidecar) == {
+            "Module:Joystick_Analog": LcscModelEntry(lcsc="C50950")
+        }
+
+    def test_bare_string_form_carries_no_transform(self, tmp_path):
+        sidecar = tmp_path / "lcsc_models.json"
+        sidecar.write_text(json.dumps({"Module:Joystick_Analog": "C50950"}))
+        entry = load_lcsc_mapping(sidecar)["Module:Joystick_Analog"]
+        assert entry.rotate is None
+        assert entry.offset is None
 
     def test_malformed_json_raises_value_error(self, tmp_path):
         sidecar = tmp_path / "bad.json"
@@ -346,8 +367,133 @@ class TestSidecar:
 
 
 # --------------------------------------------------------------------------
+# Sidecar object form: per-part rotate/offset overrides (#4584)
+# --------------------------------------------------------------------------
+
+
+class TestSidecarObjectForm:
+    def test_object_form_with_rotate_and_offset(self, tmp_path):
+        sidecar = tmp_path / "lcsc_models.json"
+        sidecar.write_text(
+            json.dumps(
+                {
+                    "Connector_PCIE:PCIE_Mini_Edge": {
+                        "lcsc": "C444929",
+                        "rotate": [0, 0, -90],
+                        "offset": [1.5, -2, 0.25],
+                    }
+                }
+            )
+        )
+        assert load_lcsc_mapping(sidecar) == {
+            "Connector_PCIE:PCIE_Mini_Edge": LcscModelEntry(
+                lcsc="C444929", rotate=(0.0, 0.0, -90.0), offset=(1.5, -2.0, 0.25)
+            )
+        }
+
+    def test_object_form_fields_are_independently_optional(self, tmp_path):
+        sidecar = tmp_path / "lcsc_models.json"
+        sidecar.write_text(
+            json.dumps(
+                {
+                    "A:RotateOnly": {"lcsc": "C1", "rotate": [0, 0, 90]},
+                    "B:OffsetOnly": {"lcsc": "C2", "offset": [0, 0, 1]},
+                    "C:Neither": {"lcsc": "C3"},
+                }
+            )
+        )
+        mapping = load_lcsc_mapping(sidecar)
+        assert mapping["A:RotateOnly"] == LcscModelEntry("C1", rotate=(0.0, 0.0, 90.0))
+        assert mapping["B:OffsetOnly"] == LcscModelEntry("C2", offset=(0.0, 0.0, 1.0))
+        assert mapping["C:Neither"] == LcscModelEntry("C3")
+
+    def test_mixed_bare_and_object_forms_in_one_sidecar(self, tmp_path):
+        sidecar = tmp_path / "lcsc_models.json"
+        sidecar.write_text(
+            json.dumps(
+                {
+                    "Module:Joystick_Analog": "C50950",
+                    "Connector_PCIE:PCIE_Mini_Edge": {"lcsc": "C444929", "rotate": [0, 0, -90]},
+                }
+            )
+        )
+        mapping = load_lcsc_mapping(sidecar)
+        assert mapping["Module:Joystick_Analog"] == LcscModelEntry("C50950")
+        assert mapping["Connector_PCIE:PCIE_Mini_Edge"].rotate == (0.0, 0.0, -90.0)
+
+    def test_object_form_validates_cnumber_like_bare_form(self, tmp_path):
+        sidecar = tmp_path / "lcsc_models.json"
+        sidecar.write_text(json.dumps({"Lib:Name": {"lcsc": "../outside/pwned"}}))
+        with pytest.raises(ValueError, match="invalid C-number"):
+            load_lcsc_mapping(sidecar)
+
+    def test_object_form_requires_lcsc_key(self, tmp_path):
+        sidecar = tmp_path / "lcsc_models.json"
+        sidecar.write_text(json.dumps({"Lib:Name": {"rotate": [0, 0, 90]}}))
+        with pytest.raises(ValueError, match="must contain a string 'lcsc'"):
+            load_lcsc_mapping(sidecar)
+
+    def test_unknown_key_is_rejected_not_ignored(self, tmp_path):
+        # A typo'd "rotation" must fail loudly.  Silently ignoring it would
+        # produce a green no-op -- exactly the failure this mechanism exists
+        # to prevent.
+        sidecar = tmp_path / "lcsc_models.json"
+        sidecar.write_text(json.dumps({"Lib:Name": {"lcsc": "C1", "rotation": [0, 0, 90]}}))
+        with pytest.raises(ValueError, match="unknown key"):
+            load_lcsc_mapping(sidecar)
+
+    @pytest.mark.parametrize(
+        ("bad", "pattern"),
+        [
+            ([0, 0], "exactly 3 numbers"),
+            ([0, 0, 0, 0], "exactly 3 numbers"),
+            ("0,0,90", "exactly 3 numbers"),
+            ({"z": 90}, "exactly 3 numbers"),
+            ([0, 0, "90"], "only numbers"),
+            ([0, 0, True], "only numbers"),
+            ([0, 0, float("nan")], "only finite numbers"),
+            ([0, float("inf"), 0], "only finite numbers"),
+        ],
+    )
+    def test_malformed_triples_are_build_errors(self, tmp_path, bad, pattern):
+        sidecar = tmp_path / "lcsc_models.json"
+        # NaN/inf are not valid JSON but json.dumps emits them by default and
+        # json.loads accepts them back -- exercise the loader's own guard.
+        sidecar.write_text(json.dumps({"Lib:Name": {"lcsc": "C1", "rotate": bad}}))
+        with pytest.raises(ValueError, match=pattern):
+            load_lcsc_mapping(sidecar)
+
+    def test_error_message_names_sidecar_path_and_key(self, tmp_path):
+        sidecar = tmp_path / "board_sidecar.json"
+        sidecar.write_text(json.dumps({"Lib:Name": {"lcsc": "C1", "offset": [0, 0]}}))
+        with pytest.raises(ValueError) as exc:
+            load_lcsc_mapping(sidecar)
+        message = str(exc.value)
+        assert str(sidecar) in message
+        assert "offset" in message
+        assert "Lib:Name" in message
+
+
+# --------------------------------------------------------------------------
 # Synthesized model block
 # --------------------------------------------------------------------------
+
+# The exact bytes the LCSC tier emitted before per-part overrides existed
+# (#4584).  Pinned verbatim: with no override the output must not drift by a
+# single byte, because every committed board artifact carries these.
+IDENTITY_BLOCK = (
+    '(model "${KCT_LCSC_3D_DIR}/C50950.step"\n'
+    "\t(offset\n"
+    "\t\t(xyz 0 0 0)\n"
+    "\t)\n"
+    "\t(scale\n"
+    "\t\t(xyz 1 1 1)\n"
+    "\t)\n"
+    "\t(rotate\n"
+    "\t\t(xyz 0 0 0)\n"
+    "\t)\n"
+    ")"
+)
 
 
 class TestSynthesize:
@@ -357,6 +503,174 @@ class TestSynthesize:
         assert "${KCT_LCSC_3D_DIR}" in block
         assert "(offset" in block and "(xyz 0 0 0)" in block
         assert block.endswith(")")
+
+    def test_no_override_is_byte_identical_to_the_historical_output(self):
+        assert synthesize_model_block("C50950") == IDENTITY_BLOCK
+
+    def test_explicit_zero_triples_are_indistinguishable_from_identity(self):
+        # An author writing rotate=[0,0,0] must not produce different bytes
+        # from omitting it -- otherwise a no-op entry would churn artifacts.
+        assert (
+            synthesize_model_block("C50950", rotate=(0.0, 0.0, 0.0), offset=(0.0, 0.0, 0.0))
+            == IDENTITY_BLOCK
+        )
+
+    def test_rotate_only_golden(self):
+        assert synthesize_model_block("C444929", rotate=(0.0, 0.0, -90.0)) == (
+            '(model "${KCT_LCSC_3D_DIR}/C444929.step"\n'
+            "\t(offset\n"
+            "\t\t(xyz 0 0 0)\n"
+            "\t)\n"
+            "\t(scale\n"
+            "\t\t(xyz 1 1 1)\n"
+            "\t)\n"
+            "\t(rotate\n"
+            "\t\t(xyz 0 0 -90)\n"
+            "\t)\n"
+            ")"
+        )
+
+    def test_offset_only_golden(self):
+        assert synthesize_model_block("C444929", offset=(1.5, -2.0, 0.25)) == (
+            '(model "${KCT_LCSC_3D_DIR}/C444929.step"\n'
+            "\t(offset\n"
+            "\t\t(xyz 1.5 -2 0.25)\n"
+            "\t)\n"
+            "\t(scale\n"
+            "\t\t(xyz 1 1 1)\n"
+            "\t)\n"
+            "\t(rotate\n"
+            "\t\t(xyz 0 0 0)\n"
+            "\t)\n"
+            ")"
+        )
+
+    def test_rotate_and_offset_golden(self):
+        assert synthesize_model_block(
+            "C444929", rotate=(0.0, 0.0, -90.0), offset=(1.5, -2.0, 0.25)
+        ) == (
+            '(model "${KCT_LCSC_3D_DIR}/C444929.step"\n'
+            "\t(offset\n"
+            "\t\t(xyz 1.5 -2 0.25)\n"
+            "\t)\n"
+            "\t(scale\n"
+            "\t\t(xyz 1 1 1)\n"
+            "\t)\n"
+            "\t(rotate\n"
+            "\t\t(xyz 0 0 -90)\n"
+            "\t)\n"
+            ")"
+        )
+
+    def test_scale_is_never_touched_by_an_override(self):
+        block = synthesize_model_block("C1", rotate=(1.0, 2.0, 3.0), offset=(4.0, 5.0, 6.0))
+        assert "\t(scale\n\t\t(xyz 1 1 1)\n\t)\n" in block
+
+    @pytest.mark.parametrize(
+        "value", [0.0, -0.0, 1.0, -90.0, 1.5, -2.0, 0.25, 1.2699999999, 1e-9, 123456.789]
+    )
+    def test_number_formatting_matches_the_offset_machinery(self, value):
+        # The synthesized block and a block ``_apply_offset_delta`` has
+        # rewritten must format numbers identically, or an override would
+        # change bytes purely by being re-run through the other formatter.
+        from kicad_tools.pcb.models3d import _fmt_num as models3d_fmt_num
+
+        assert _fmt_num(value) == models3d_fmt_num(value)
+
+
+# --------------------------------------------------------------------------
+# Packaged per-part transform table (#4584)
+# --------------------------------------------------------------------------
+
+
+GOOD_PROVENANCE = TransformProvenance(
+    board="boards/06-diffpair-test",
+    refdes="J3",
+    verified="2026-08-04",
+    command="kct render boards/06-diffpair-test",
+)
+
+
+class TestPackagedTransformTable:
+    def test_every_entry_carries_render_provenance(self):
+        """CI cannot render, so an entry may only enter the table if a human
+        did -- and recorded it.  This is the structural gate that keeps an
+        uncalibrated guess from landing green (the #4457 failure mode)."""
+        problems = table_problems()
+        assert problems == {}, f"unfit packaged transform entries: {problems}"
+
+    def test_table_is_c_number_keyed(self):
+        for key in LCSC_MODEL_TRANSFORMS:
+            assert re.match(r"^C\d+$", key), f"table key {key!r} is not a C-number"
+
+    def test_lookup_returns_none_for_unlisted_part(self):
+        assert lookup_transform("C999999999") is None
+
+    def test_calibrated_pcie_mini_edge_entry(self):
+        # The part that motivated the mechanism (#4584): mini-PCIe edge socket
+        # whose EasyEDA body is authored a quarter turn off its pad column.
+        entry = lookup_transform("C444929")
+        assert entry is not None
+        assert entry.rotate == (0.0, 0.0, -90.0)
+        assert entry.provenance is not None
+        assert entry.provenance.refdes == "J3"
+
+    # ---- the enforcing test must actually reject bad entries -------------
+
+    def test_entry_without_provenance_is_rejected(self):
+        problems = entry_problems("C1", LcscModelTransform(rotate=(0.0, 0.0, 90.0)))
+        assert any("missing provenance" in p for p in problems)
+
+    @pytest.mark.parametrize(
+        ("prov", "pattern"),
+        [
+            (TransformProvenance("", "J3", "2026-08-04", "kct render x"), "provenance.board"),
+            (TransformProvenance("b", "  ", "2026-08-04", "kct render x"), "provenance.refdes"),
+            (TransformProvenance("b", "J3", "2026-08-04", ""), "provenance.command"),
+            (TransformProvenance("b", "J3", "yesterday", "kct render x"), "provenance.verified"),
+            (TransformProvenance("b", "J3", "2026-13-04", "kct render x"), "provenance.verified"),
+            (TransformProvenance("b", "J3", "04/08/2026", "kct render x"), "provenance.verified"),
+        ],
+    )
+    def test_incomplete_provenance_is_rejected(self, prov, pattern):
+        problems = entry_problems(
+            "C1", LcscModelTransform(rotate=(0.0, 0.0, 90.0), provenance=prov)
+        )
+        assert any(pattern in p for p in problems), problems
+
+    def test_no_op_entry_is_rejected(self):
+        problems = entry_problems("C1", LcscModelTransform(provenance=GOOD_PROVENANCE))
+        assert any("neither rotate nor offset" in p for p in problems)
+
+    def test_non_c_number_key_is_rejected(self):
+        problems = entry_problems(
+            "Connector_PCIE:PCIE_Mini_Edge",
+            LcscModelTransform(rotate=(0.0, 0.0, 90.0), provenance=GOOD_PROVENANCE),
+        )
+        assert any("is not a C-number" in p for p in problems)
+
+    @pytest.mark.parametrize(
+        "bad_rotate",
+        [(0.0, 0.0), (0.0, 0.0, 0.0, 0.0), [0.0, 0.0, 90.0], (0.0, 0.0, float("nan")), "0,0,90"],
+    )
+    def test_malformed_triple_is_rejected(self, bad_rotate):
+        problems = entry_problems(
+            "C1", LcscModelTransform(rotate=bad_rotate, provenance=GOOD_PROVENANCE)
+        )
+        assert problems
+
+    def test_table_walk_fails_when_an_uncalibrated_entry_is_added(self, monkeypatch):
+        """The end-to-end proof that the gate bites: inject a guessed entry
+        with no provenance and the same check that guards the real table
+        reports it."""
+        monkeypatch.setitem(
+            lcsc_model_transforms.LCSC_MODEL_TRANSFORMS,
+            "C7654321",
+            LcscModelTransform(rotate=(0.0, 0.0, 90.0)),
+        )
+        problems = table_problems()
+        assert "C7654321" in problems
+        assert any("missing provenance" in p for p in problems["C7654321"])
 
 
 # --------------------------------------------------------------------------
@@ -498,6 +812,197 @@ class TestLcscOffset:
         assert report.patched == ["Module:Joystick_Analog"]
         # The inserted model's own offset carries the target pad-centroid delta.
         assert "(xyz 2 1.27 0)" in new_text
+
+
+# --------------------------------------------------------------------------
+# Per-part transform precedence: sidecar > packaged table > identity (#4584)
+# --------------------------------------------------------------------------
+
+
+def _lcsc_resolver(tmp_path, mapping, c_number="C50950"):
+    """A tier-4-only resolver whose cache already holds *c_number*."""
+    cache = tmp_path / "cache"
+    cache.mkdir(exist_ok=True)
+    (cache / f"{c_number}.step").write_bytes(FAKE_STEP)
+    return make_library_resolver(
+        _empty_library(tmp_path),
+        lcsc_mapping=mapping,
+        lcsc_cache_dir=cache,
+    )
+
+
+class TestTransformPrecedence:
+    LIB_ID = "Module:Joystick_Analog"
+
+    def test_no_entry_anywhere_stays_identity(self, tmp_path):
+        resolver = _lcsc_resolver(tmp_path, {self.LIB_ID: "C50950"})
+        resolved = resolver(self.LIB_ID)
+        assert resolved is not None
+        assert "(rotate\n\t\t(xyz 0 0 0)\n" in resolved.models[0]
+
+    def test_packaged_table_applies_to_a_bare_string_sidecar(self, tmp_path, monkeypatch):
+        monkeypatch.setitem(
+            lcsc_model_transforms.LCSC_MODEL_TRANSFORMS,
+            "C50950",
+            LcscModelTransform(rotate=(0.0, 0.0, -90.0), provenance=GOOD_PROVENANCE),
+        )
+        resolver = _lcsc_resolver(tmp_path, {self.LIB_ID: "C50950"})
+        resolved = resolver(self.LIB_ID)
+        assert resolved is not None
+        assert "(rotate\n\t\t(xyz 0 0 -90)\n" in resolved.models[0]
+
+    def test_sidecar_object_form_wins_over_the_packaged_table(self, tmp_path, monkeypatch):
+        monkeypatch.setitem(
+            lcsc_model_transforms.LCSC_MODEL_TRANSFORMS,
+            "C50950",
+            LcscModelTransform(rotate=(0.0, 0.0, -90.0), provenance=GOOD_PROVENANCE),
+        )
+        resolver = _lcsc_resolver(
+            tmp_path, {self.LIB_ID: LcscModelEntry("C50950", rotate=(0.0, 0.0, 180.0))}
+        )
+        resolved = resolver(self.LIB_ID)
+        assert resolved is not None
+        assert "(rotate\n\t\t(xyz 0 0 180)\n" in resolved.models[0]
+
+    def test_sidecar_object_form_applies_when_the_table_is_silent(self, tmp_path):
+        resolver = _lcsc_resolver(
+            tmp_path, {self.LIB_ID: LcscModelEntry("C50950", rotate=(0.0, 0.0, 45.0))}
+        )
+        resolved = resolver(self.LIB_ID)
+        assert resolved is not None
+        assert "(rotate\n\t\t(xyz 0 0 45)\n" in resolved.models[0]
+
+    def test_merge_is_per_field_not_all_or_nothing(self, tmp_path, monkeypatch):
+        # A sidecar overriding only rotate must NOT suppress a packaged offset.
+        monkeypatch.setitem(
+            lcsc_model_transforms.LCSC_MODEL_TRANSFORMS,
+            "C50950",
+            LcscModelTransform(
+                rotate=(0.0, 0.0, -90.0), offset=(0.0, 0.0, 1.25), provenance=GOOD_PROVENANCE
+            ),
+        )
+        resolver = _lcsc_resolver(
+            tmp_path, {self.LIB_ID: LcscModelEntry("C50950", rotate=(0.0, 0.0, 180.0))}
+        )
+        resolved = resolver(self.LIB_ID)
+        assert resolved is not None
+        assert "(rotate\n\t\t(xyz 0 0 180)\n" in resolved.models[0]
+        assert "(offset\n\t\t(xyz 0 0 1.25)\n" in resolved.models[0]
+
+    def test_merge_is_per_field_in_the_other_direction(self, tmp_path, monkeypatch):
+        monkeypatch.setitem(
+            lcsc_model_transforms.LCSC_MODEL_TRANSFORMS,
+            "C50950",
+            LcscModelTransform(
+                rotate=(0.0, 0.0, -90.0), offset=(0.0, 0.0, 1.25), provenance=GOOD_PROVENANCE
+            ),
+        )
+        resolver = _lcsc_resolver(
+            tmp_path, {self.LIB_ID: LcscModelEntry("C50950", offset=(0.0, 0.0, 3.0))}
+        )
+        resolved = resolver(self.LIB_ID)
+        assert resolved is not None
+        assert "(rotate\n\t\t(xyz 0 0 -90)\n" in resolved.models[0]
+        assert "(offset\n\t\t(xyz 0 0 3)\n" in resolved.models[0]
+
+    def test_transform_log_names_each_field_source(self, tmp_path, monkeypatch):
+        monkeypatch.setitem(
+            lcsc_model_transforms.LCSC_MODEL_TRANSFORMS,
+            "C50950",
+            LcscModelTransform(
+                rotate=(0.0, 0.0, -90.0), offset=(0.0, 0.0, 1.25), provenance=GOOD_PROVENANCE
+            ),
+        )
+        cache = tmp_path / "cache"
+        cache.mkdir()
+        (cache / "C50950.step").write_bytes(FAKE_STEP)
+        log: dict[str, str] = {}
+        resolver = make_library_resolver(
+            _empty_library(tmp_path),
+            lcsc_mapping={self.LIB_ID: LcscModelEntry("C50950", rotate=(0.0, 0.0, 180.0))},
+            lcsc_cache_dir=cache,
+            lcsc_transform_log=log,
+        )
+        resolver(self.LIB_ID)
+        assert log == {
+            self.LIB_ID: "rotate=(0, 0, 180) [sidecar] offset=(0, 0, 1.25) [packaged table]"
+        }
+
+    def test_identity_leaves_the_transform_log_empty(self, tmp_path):
+        cache = tmp_path / "cache"
+        cache.mkdir()
+        (cache / "C50950.step").write_bytes(FAKE_STEP)
+        log: dict[str, str] = {}
+        resolver = make_library_resolver(
+            _empty_library(tmp_path),
+            lcsc_mapping={self.LIB_ID: "C50950"},
+            lcsc_cache_dir=cache,
+            lcsc_transform_log=log,
+        )
+        resolver(self.LIB_ID)
+        assert log == {}
+
+
+class TestTransformComposition:
+    """The override must compose with -- never replace -- the centroid delta."""
+
+    LIB_ID = "Module:Joystick_Analog"
+
+    def test_lcsc_tier_never_derives_an_orientation(self, tmp_path):
+        # theta stays 0 for this tier by construction, which is what makes it
+        # safe to write the override rotation verbatim: _apply_rotate_delta
+        # can never compose with (and so double-apply) it.
+        resolver = _lcsc_resolver(
+            tmp_path, {self.LIB_ID: LcscModelEntry("C50950", rotate=(0.0, 0.0, -90.0))}
+        )
+        resolved = resolver(self.LIB_ID)
+        assert resolved is not None
+        assert resolved.source_orientation is None
+        assert resolved.source_anchor == (0.0, 0.0)
+
+    def test_rotate_is_verbatim_even_with_a_nonzero_pad_centroid(self, tmp_path):
+        # PCB_LCSC's single pad sits at (2.0, -1.27), so the centroid delta is
+        # nonzero.  The rotation must still be exactly what was authored.
+        resolver = _lcsc_resolver(
+            tmp_path, {self.LIB_ID: LcscModelEntry("C50950", rotate=(0.0, 0.0, -90.0))}
+        )
+        new_text, report = add_model_refs_to_text(PCB_LCSC, resolver)
+        assert report.patched == [self.LIB_ID]
+        assert "(xyz 0 0 -90)" in new_text
+
+    def test_offset_override_adds_to_the_pad_centroid_delta(self, tmp_path):
+        # centroid delta is (dx, -dy) = (2.0, +1.27); override adds (0.5, 0.25).
+        resolver = _lcsc_resolver(
+            tmp_path, {self.LIB_ID: LcscModelEntry("C50950", offset=(0.5, 0.25, 0.0))}
+        )
+        new_text, _ = add_model_refs_to_text(PCB_LCSC, resolver)
+        assert "(xyz 2.5 1.52 0)" in new_text
+
+    def test_offset_override_z_passes_through_untouched(self, tmp_path):
+        # _apply_offset_delta never rewrites Z, so the authored Z survives the
+        # centroid composition verbatim -- the knob for a STEP whose origin is
+        # off the board plane.
+        resolver = _lcsc_resolver(
+            tmp_path, {self.LIB_ID: LcscModelEntry("C50950", offset=(0.0, 0.0, -3.5))}
+        )
+        new_text, _ = add_model_refs_to_text(PCB_LCSC, resolver)
+        assert "(xyz 2 1.27 -3.5)" in new_text
+
+    def test_rotate_and_offset_compose_independently(self, tmp_path):
+        resolver = _lcsc_resolver(
+            tmp_path,
+            {
+                self.LIB_ID: LcscModelEntry(
+                    "C50950", rotate=(0.0, 0.0, -90.0), offset=(0.5, 0.25, 1.0)
+                )
+            },
+        )
+        new_text, _ = add_model_refs_to_text(PCB_LCSC, resolver)
+        # The rotation does NOT rotate the centroid delta: source_anchor is
+        # (0, 0) for this tier, so R_theta * source_anchor == (0, 0) for any
+        # theta and the two are fully independent.
+        assert "(xyz 2.5 1.52 1)" in new_text
+        assert "(xyz 0 0 -90)" in new_text
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_pcb_add_3d_models.py
+++ b/tests/test_pcb_add_3d_models.py
@@ -1174,3 +1174,141 @@ class TestOrientationConventionRotation:
         rotate_xyz = re.search(r"\(rotate\s*\(xyz ([^)]+)\)", pcb.read_text())
         assert rotate_xyz is not None
         assert rotate_xyz.group(1).strip() == "0 0 0"
+
+
+# --------------------------------------------------------------------------
+# LCSC tier: authored per-part transforms compose with the centroid delta
+# --------------------------------------------------------------------------
+# The three installed-library tiers derive their transforms geometrically; the
+# LCSC tier cannot (there is no source .kicad_mod), so its correction is
+# authored -- in the packaged lcsc_model_transforms table or a per-board
+# sidecar (#4584).  These cases pin the *composition* end to end, through
+# add_model_refs_to_text: rotate verbatim, offset added to the pad-centroid
+# delta, model-frame Y negation, Z passthrough.
+
+
+# A multi-pad footprint whose pad centroid is deliberately NOT the origin:
+# pads at (10, 4) and (10, -4) -> centroid (10, 0)... plus a third at (10, 6)
+# so the centroid is (10, 2), nonzero in both axes.
+PCB_LCSC_OFFCENTRE = """(kicad_pcb
+\t(version 20240108)
+\t(generator "kicad_tools")
+\t(footprint "Connector_PCIE:PCIE_Mini_Edge"
+\t\t(layer "F.Cu")
+\t\t(at 193.5 92.5)
+\t\t(pad "1" smd rect
+\t\t\t(at 10 4)
+\t\t\t(size 0.5 0.6)
+\t\t\t(layers "F.Cu" "F.Mask" "F.Paste")
+\t\t)
+\t\t(pad "2" smd rect
+\t\t\t(at 10 -4)
+\t\t\t(size 0.5 0.6)
+\t\t\t(layers "F.Cu" "F.Mask" "F.Paste")
+\t\t)
+\t\t(pad "3" smd rect
+\t\t\t(at 10 6)
+\t\t\t(size 0.5 0.6)
+\t\t\t(layers "F.Cu" "F.Mask" "F.Paste")
+\t\t)
+\t)
+)
+"""
+
+_FAKE_STEP = b"ISO-10303-21;\r\nHEADER;\r\nEND-ISO-10303-21;\r\n"
+
+
+def _lcsc_only_resolver(tmp_path: Path, mapping, *, cached=("C444929", "C50950")):
+    """A resolver where only the LCSC tier can hit (empty footprint library)."""
+    from kicad_tools.pcb.models3d import make_library_resolver as _mk
+
+    footprints = tmp_path / "footprints"
+    footprints.mkdir(exist_ok=True)
+    cache = tmp_path / "lcsc-cache"
+    cache.mkdir(exist_ok=True)
+    for c_number in cached:
+        (cache / f"{c_number}.step").write_bytes(_FAKE_STEP)
+    return _mk(
+        LibraryPaths(footprints_path=footprints, source="config"),
+        lcsc_mapping=mapping,
+        lcsc_cache_dir=cache,
+    )
+
+
+class TestLcscPerPartTransform:
+    LIB_ID = "Connector_PCIE:PCIE_Mini_Edge"
+
+    def test_centroid_is_off_origin_in_both_axes(self, tmp_path):
+        """Guard the fixture itself: a zero centroid would make the
+        composition assertions below vacuous."""
+        block = iter_footprint_blocks(PCB_LCSC_OFFCENTRE)[0]
+        body = PCB_LCSC_OFFCENTRE[block.start : block.end + 1]
+        assert _pad_anchor(body) == (10.0, 2.0)
+
+    def test_override_composes_with_a_nonzero_pad_centroid(self, tmp_path):
+        from kicad_tools.pcb.lcsc_models import LcscModelEntry
+
+        resolver = _lcsc_only_resolver(
+            tmp_path,
+            {
+                self.LIB_ID: LcscModelEntry(
+                    "C444929", rotate=(0.0, 0.0, -90.0), offset=(0.5, 0.25, 1.75)
+                )
+            },
+        )
+        new_text, report = add_model_refs_to_text(PCB_LCSC_OFFCENTRE, resolver)
+        assert report.patched == [self.LIB_ID]
+        # rotate: written verbatim (the LCSC tier's derived theta is always 0).
+        assert "(xyz 0 0 -90)" in new_text
+        # offset: authored (0.5, 0.25, 1.75) + centroid delta (10, -2) in the
+        # model frame (Y negated vs the footprint 2D centroid (10, 2)); Z is
+        # never rewritten by the offset machinery.
+        assert "(xyz 10.5 -1.75 1.75)" in new_text
+
+    def test_bare_mapping_for_an_unlisted_part_is_unchanged_from_identity(self, tmp_path):
+        # C50950 carries no packaged transform, so this is the pre-#4584 path.
+        resolver = _lcsc_only_resolver(tmp_path, {self.LIB_ID: "C50950"})
+        new_text, report = add_model_refs_to_text(PCB_LCSC_OFFCENTRE, resolver)
+        assert report.patched == [self.LIB_ID]
+        assert "(xyz 0 0 0)" in new_text  # rotate untouched
+        assert "(xyz 10 -2 0)" in new_text  # pure centroid delta
+
+    def test_bare_mapping_picks_up_the_packaged_table(self, tmp_path):
+        # The committed board-06 sidecar uses the bare-string form; the
+        # calibrated C444929 correction must still reach the emitted node.
+        resolver = _lcsc_only_resolver(tmp_path, {self.LIB_ID: "C444929"})
+        new_text, report = add_model_refs_to_text(PCB_LCSC_OFFCENTRE, resolver)
+        assert report.patched == [self.LIB_ID]
+        assert "(xyz 0 0 -90)" in new_text
+
+    def test_theta_stays_zero_so_the_rotate_delta_cannot_double_apply(self, tmp_path):
+        """The invariant that licenses writing the override verbatim."""
+        from kicad_tools.pcb.lcsc_models import LcscModelEntry
+
+        resolver = _lcsc_only_resolver(
+            tmp_path, {self.LIB_ID: LcscModelEntry("C444929", rotate=(0.0, 0.0, -90.0))}
+        )
+        resolved = resolver(self.LIB_ID)
+        assert isinstance(resolved, ResolvedModels)
+        assert resolved.source_orientation is None
+        # ...and the target footprint DOES have a derivable orientation, so
+        # this is a real guard, not a vacuous one.
+        block = iter_footprint_blocks(PCB_LCSC_OFFCENTRE)[0]
+        body = PCB_LCSC_OFFCENTRE[block.start : block.end + 1]
+        assert _pad_field_orientation(body) is not None
+        # The rotate delta is therefore a no-op on the authored value.
+        assert _apply_rotate_delta(resolved.models[0], 0.0) == resolved.models[0]
+
+    def test_source_anchor_stays_origin_so_rotation_and_offset_are_independent(self, tmp_path):
+        """R_theta * (0, 0) == (0, 0) for every theta, so an override rotation
+        can never perturb the centroid offset."""
+        from kicad_tools.pcb.lcsc_models import LcscModelEntry
+
+        rotated = _lcsc_only_resolver(
+            tmp_path, {self.LIB_ID: LcscModelEntry("C50950", rotate=(0.0, 0.0, -90.0))}
+        )
+        plain = _lcsc_only_resolver(tmp_path, {self.LIB_ID: "C50950"})
+        rotated_text, _ = add_model_refs_to_text(PCB_LCSC_OFFCENTRE, rotated)
+        plain_text, _ = add_model_refs_to_text(PCB_LCSC_OFFCENTRE, plain)
+        for text in (rotated_text, plain_text):
+            assert "(xyz 10 -2 0)" in text


### PR DESCRIPTION
## Summary

The three installed-library `add-3d-models` tiers *derive* a body's offset and
rotation geometrically, by comparing the target footprint's pad field against
the source `.kicad_mod`. The LCSC/EasyEDA fetch-on-demand tier has **no source
footprint at all** — it synthesizes a `(model ...)` node from nothing but a
C-number — so `source_orientation` is underivable and theta stays 0. EasyEDA
STEP bodies are authored in whatever orientation the part vendor chose, so the
identity rotation that tier emits is a *guess*, and for many parts it is wrong
by a quarter turn. `PCIE_Mini_Edge` (C444929) on board 06 renders 90° off its
own pad column with no fix path.

## Changes

- **`src/kicad_tools/pcb/lcsc_model_transforms.py`** (new) — a packaged
  `C-number -> transform` table, mirroring the shape of the adjacent
  `pcb/model_substitutions` (policy docstring, dict constant, single accessor).
  Keyed by C-number because a body's native orientation is a property of the
  *physical part*, not of any board — and because synthetic lib_ids are unique
  per board, so a lib_id-keyed table would have a reuse rate of ~zero.
- **`src/kicad_tools/pcb/lcsc_models.py`** — the `lcsc_models.json` sidecar
  gains an object form, `{"lib_id": {"lcsc": "C...", "rotate": [...],
  "offset": [...]}}`. The bare string form (`"lib_id": "C444929"`) remains
  valid and unchanged.
- **`src/kicad_tools/pcb/models3d.py`** — `_resolve_lcsc` resolves the two
  override sources (first non-`None` wins, **merged per field**): sidecar
  entry, then packaged table, then identity. `offset` **composes with**, rather
  than replaces, the pad-centroid delta the shared offset machinery already
  injects; its Z component passes through for STEP bodies whose origin is off
  the board plane.
- **`cli/pcb_add_3d_models.py` / `cli/parser.py`** — plumbing so the sidecar's
  object form is reachable from the real CLI.
- **`docs/guides/lcsc-3d-models.md`** — sidecar object-form schema, the
  precedence order, the model-frame semantics (scale → rotate → offset, Y
  negated versus the footprint 2D frame), and the calibration procedure.

Parts with no entry anywhere keep identity transforms, so **every existing
board emits byte-identical model nodes**.

## Provenance is enforced, not documented

Every packaged-table entry MUST carry a `TransformProvenance` (board, refdes,
ISO date, the exact command used, and notes). `tests/test_lcsc_models.py` walks
the table and fails on missing or malformed provenance. This is a structural
rule: only a render can tell you whether a number is right, CI has no KiCad to
render with, so the only defensible gate is "a human must have rendered this."
An uncalibrated guess cannot land green.

C444929 is calibrated to `rotate (0, 0, -90)`. All three candidates (0, +90,
−90) were rendered on a scratch copy of `diffpair_test_routed.kicad_pcb` with
J3's stale model node stripped. At rotate 0 the body lies east–west and hangs
~10 mm off the right board edge — the reported symptom. −90 wins on the
board-edge criterion: the body spans board X 187.9…197.6 (0.9 mm clear of the
Edge.Cuts right edge at 198.5) while +90 spans 189.4…199.1 and pokes 0.6 mm
past it. −90 also points the card-entry slot off-board. A front-side render
confirms the body seats on the board surface, so no offset is needed.

## Verification

- `uv run pytest tests/test_lcsc_models.py tests/test_pcb_add_3d_models.py` —
  **184 passed**
- `uv run ruff check .` / `ruff format --check .` — clean
- `uv run python scripts/ci/check_mypy_baseline.py` — within baseline, no new
  type errors

## Scope note

Acceptance criterion 3 (*"Board 06 J3 renders with body aligned to its pad
column"*) is satisfied at the **capability** level — the transform is now
resolved for C444929 on any board. Regenerating board 06's *committed artifact*
is #4585's job, which is explicitly gated on this issue and #4583.

## Recovery note

This work was staged but never committed by a Builder that was killed by a host
restart. The staged tree was recovered unmodified, re-verified with the three
gates above, and rebased onto `origin/main` @ `ea12d442`.

Closes #4584
