### PR TITLE
test(diffpair): make the crossover-census gate assertion rank-independent

### DIFF
--- a/tests/test_diffpair_shadow.py
+++ b/tests/test_diffpair_shadow.py
@@ -4729,23 +4729,68 @@ def test_crossing_tail_census_counts_the_whole_legal_set(monkeypatch, capsys):
     assert int(legal) > 1, "an unobstructed lattice has many legal candidates"
 
 
+def _complete_census_listing(monkeypatch, capsys, *, foreign_pad: bool) -> list[str]:
+    """Census the crossing-tail fixture with NOTHING truncated (issue #4637).
+
+    The per-candidate listing is capped at ``_CROSSTAIL_CENSUS_LIST`` = 12 and
+    the fixture's open lattice yields 135 legal candidates, so a membership
+    assertion over the printed listing is otherwise a statement about a
+    penalty-ranked PREFIX -- it holds only while the candidate of interest
+    happens to rank in the top 12, and goes vacuous with no failure signal the
+    moment the sort key, the lattice or the fixture geometry shifts.  Raising
+    the cap past the whole 225-pair lattice makes the listing the complete
+    legal set, and asserting the truncation notice is ABSENT keeps
+    "the listing is complete" a checked fact rather than an assumption a
+    larger lattice could silently invalidate.
+    """
+    import kicad_tools.router.diffpair_routing as dpr_mod
+
+    _census_on(monkeypatch)
+    monkeypatch.setattr(dpr_mod, "_CROSSTAIL_CENSUS_LIST", 10_000)
+    dpr = _crossing_router()
+    _register_unrouted_neighbour(dpr)
+    if foreign_pad:
+        dpr.autorouter.grid.add_pad(_pad_at(8.0, 4.4, net=99, name="OTHER"))
+
+    assert _crossing_tail(dpr) is not None
+
+    lines = _census_lines(capsys)
+    assert not any("not listed" in line for line in lines), (
+        "the listing must not truncate here -- a truncated listing makes the "
+        "membership assertions rank-dependent again"
+    )
+    listed = [line for line in lines if "v2=" in line]
+    assert listed, "the census must list the legal candidates it found"
+    return listed
+
+
 def test_crossing_tail_census_never_lists_a_candidate_a_gate_rejected(monkeypatch, capsys):
     """The census reports legality, so it must apply every gate, not skip them.
 
     The site at ``(8.0, 4.4)`` is covered by a foreign pad ON THE GRID, so the
     #4571 pad screen vetoes it; a census that enumerated candidates instead of
     validating them would happily list it.
+
+    Issue #4637: stated DIFFERENTIALLY and over the COMPLETE legal set.  An
+    absence-only assertion cannot tell "the gate rejected it" from "the fixture
+    never produced it", and an absence over the truncated 12-of-135 listing is
+    additionally hostage to where the site ranks.  The positive control -- the
+    same site IS censused once the vetoing pad is gone -- pins the fixture, and
+    the uncapped listing makes the negative rank-independent.
     """
-    _census_on(monkeypatch)
-    dpr = _crossing_router()
-    _register_unrouted_neighbour(dpr)
-    dpr.autorouter.grid.add_pad(_pad_at(8.0, 4.4, net=99, name="OTHER"))
+    site = "v2=(8.00000,4.40000)"
 
-    assert _crossing_tail(dpr) is not None
+    rejected = _complete_census_listing(monkeypatch, capsys, foreign_pad=True)
+    assert not any(site in line for line in rejected), (
+        "the #4571 pad screen vetoed this site, so the census must not list it"
+    )
 
-    listed = [line for line in _census_lines(capsys) if "v2=" in line]
-    assert listed, "the census must list the legal candidates it found"
-    assert not any("v2=(8.00000,4.40000)" in line for line in listed)
+    admitted = _complete_census_listing(monkeypatch, capsys, foreign_pad=False)
+    assert any(site in line for line in admitted), (
+        "positive control: without the vetoing pad the fixture DOES produce "
+        "this site -- its absence above is the gate, not a missing candidate"
+    )
+    assert len(rejected) < len(admitted), "the pad must shrink the legal set"
 
 
 def test_crossing_tail_census_reports_a_singleton_via_site_lattice(capsys):


### PR DESCRIPTION
## Summary

**Correction up front, per the curator's re-scope: the test was NOT vacuous on `6623f59f` — it was rank-fragile.** I reproduced the curator's measurement against the current tree (`473de1f8`) and it holds exactly: with all gates on the fixture yields `legal=135/225`, and with `_route_pad_violation` stubbed to `(0.0, None)` it yields `legal=225/225` with `v2=(8.00000,4.40000)` at **rank 0**, so the *existing* assertion already failed on that regression. This PR does not claim to fix a vacuous test.

The real defect is that non-vacuity was an **unasserted coincidence**. `_CROSSTAIL_CENSUS_LIST = 12` truncates the per-candidate listing to 12 of 135 legal candidates (91% hidden), and the negative assertion only bit because the vetoed site happened to be the globally lowest-`_pair_penalty` pair. Any change to the sort key, the `_via_candidates` lattice, or `_register_unrouted_neighbour`'s geometry pushes it past rank 12 and the test **silently goes vacuous with no failure signal**. This PR makes the assertion rank-independent and differential.

## Changes

`tests/test_diffpair_shadow.py` only (+53 / -8, one file):

- New helper `_complete_census_listing(monkeypatch, capsys, *, foreign_pad)` — runs the crossing-tail fixture with the census on and `_CROSSTAIL_CENSUS_LIST` monkeypatched to `10_000` (past the whole 225-pair lattice), **asserts the `"... N further legal candidate(s) not listed"` notice is absent**, and keeps the existing `assert listed, "the census must list the legal candidates it found"` liveness check. Asserting the truncation notice absent is what makes "the listing is complete" a *checked fact* rather than an assumption a larger lattice could silently invalidate.
- `test_crossing_tail_census_never_lists_a_candidate_a_gate_rejected` rewritten as a **differential** assertion over the complete legal set:
  - negative: with the foreign pad on the grid, `v2=(8.00000,4.40000)` is absent from all **135** legal candidates (previously: absent from 12 of them);
  - **positive control**: without the vetoing pad, the same site **is** present in the legal set (15 pairs carry it) — this is what distinguishes "the gate rejected it" from "the fixture never produced it";
  - count cross-check: `len(rejected) < len(admitted)`.

**No production code touched** — `src/kicad_tools/router/diffpair_routing.py` is untouched (scope guard for #4635, which is building against the same census code in the same wave). No shared helper or fixture was renamed or removed; the change is purely additive plus the one rewritten test body, so cross-module importers of this file are unaffected.

## Acceptance Criteria Verification

- [x] **Correction acknowledged** — see the Summary; the test was rank-fragile, not vacuous.
- [x] **Assertion no longer rank-dependent** — made over the complete legal set (cap raised past the lattice, truncation notice asserted absent), not a penalty-ranked prefix. Visible from the diff alone.
- [x] **Positive control present** — the site is asserted *present* in the census's legal set when the vetoing pad is absent.
- [x] **Negative control demonstrated, not assumed** — see the recorded output below.
- [x] **Still fails if the census silently never runs** — `assert listed, "the census must list the legal candidates it found"` is retained inside the helper (and reached twice, once per arm).
- [x] **AC-3 audit re-verified against the tree** — see the table below; confirmed as-is, no seventh case.
- [x] `uv run pytest tests/test_diffpair_shadow.py -q` → **180 passed**; no other test in the file modified.

## Measurements (current tree, `473de1f8`)

Curator's numbers reproduced exactly:

| Run | `legal/total` | rank of `v2=(8.0,4.4)` |
|---|---|---|
| pad on grid, all gates | `135/225` | *(rejected — absent)* |
| pad on grid, `_route_pad_violation` → `(0.0, None)` | `225/225` | **0** |
| **no pad**, all gates (positive control) | `225/225` | **0** (15 pairs carry the site) |

### Negative control (required)

`DiffPairRouter._route_pad_violation` stubbed to `(0.0, None)` via a session-scoped pytest plugin (no tracked file edited):

```
>       assert not any(site in line for line in rejected), (
            "the #4571 pad screen vetoed this site, so the census must not list it"
        )
E       AssertionError: the #4571 pad screen vetoed this site, so the census must not list it
E       assert not True

tests/test_diffpair_shadow.py:4784: AssertionError
FAILED tests/test_diffpair_shadow.py::test_crossing_tail_census_never_lists_a_candidate_a_gate_rejected
1 failed, 179 deselected in 0.20s
```

Reverting the stub: `7 passed, 173 deselected` (`-k census`), `180 passed` (whole file).

### Rank-independence, demonstrated directly

The negative control alone does not prove rank-independence — it fires at rank 0, where the *old* form also fired. So I additionally perturbed the sort key (`_channel_seal_penalty` → `-hypot(x-8.0, y-4.4)`, which sorts the site of interest **last**) with the `#4571` screen still bypassed, and compared the two assertion forms:

```
A. gates ON, stock sort key
    legal=135/225   listed(old cap=12)=12   listed(new uncapped)=135
    OLD form (absence in top 12): PASS
    NEW form (absence in all 135): PASS

B. #4571 screen OFF, stock sort key
    legal=225/225   listed(old cap=12)=12   listed(new uncapped)=225
    OLD form (absence in top 12): FAIL
    NEW form (absence in all 225): FAIL

C. #4571 screen OFF, sort key perturbed   <-- the fragility
    legal=225/225   listed(old cap=12)=12   listed(new uncapped)=225
    OLD form (absence in top 12): PASS     <-- vacuous, regression missed
    NEW form (absence in all 225): FAIL    <-- regression still caught
```

Row C is the defect this issue is about, exhibited: the old form passes with the gate switched off. The new form does not.

## AC-3 audit (re-verified against this tree)

Confirmed the curator's table — exactly one test read the truncated per-candidate listing for a load-bearing assertion, and it is the one fixed here. `grep -rn "_census_lines|crosstail-census|_CROSSTAIL_CENSUS" tests/` finds no consumer outside this block.

| Test | Reads truncated listing? | Verdict |
|---|---|---|
| `test_crossing_tail_census_is_off_by_default` | no (asserts no output at all) | fine |
| `test_crossing_tail_census_ships_the_route_it_would_have_shipped` | existence only | fine |
| `test_crossing_tail_census_counts_the_whole_legal_set` | no — reads the untruncated header `legal=N/M` | fine |
| `test_crossing_tail_census_never_lists_a_candidate_a_gate_rejected` | **was yes** | **fixed here** |
| `test_crossing_tail_census_reports_a_singleton_via_site_lattice` | direct renderer call, 2 candidates, under the cap; reads header | fine |
| `test_crossing_tail_census_announces_truncation_instead_of_hiding_it` | truncation is the subject, asserted explicitly and symbolically | fine |

No seventh case found.

## Out of scope (deliberately, per the curator's guidance)

- The originally-proposed option (2) — calling `_report_crossing_tail_census` directly with a hand-built list — was **not** taken: it exercises the renderer, bypasses the collection loop where gating happens, and would make the test genuinely vacuous w.r.t. `#4571`.
- Option (3) (shrink the fixture) was not taken: it re-creates the same fragility and disturbs geometry five-plus tests share.
- `_CROSSTAIL_CENSUS_LIST = 12` is left as-is — it is a human-readability cap on a debug print, already pinned by the truncation test.

## Test Plan

- [x] `uv run pytest tests/test_diffpair_shadow.py -k census -q` → 7 passed
- [x] `uv run pytest tests/test_diffpair_shadow.py -q` → 180 passed (whole file; census fixtures are shared with the #4574 crossing-tail tests)
- [x] Negative control: screen stubbed → revised test FAILS (output above); stub reverted → passes
- [x] Rank-independence: truncation notice asserted absent; perturbed-key demo above
- [x] `test_crossing_tail_census_is_off_by_default` still passes — census output does not leak into a normal run
- [x] `uv run ruff check tests/test_diffpair_shadow.py` → All checks passed
- [x] `uv run ruff format --check tests/test_diffpair_shadow.py` → already formatted
- [x] `./.loom/scripts/check-main-clean.sh` → main worktree clean

Closes #4637

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6JktQ72LZbL4qctf9ELed