### PR TITLE
fix(3d): reject a sidecar rotate that inherits a frame-mismatched packaged offset

### DIFF
--- a/docs/guides/lcsc-3d-models.md
+++ b/docs/guides/lcsc-3d-models.md
@@ -48,7 +48,7 @@ identity rotation the tier emits by default is therefore a *guess*, and for many
 parts it is wrong by a quarter turn.
 
 Authored corrections come from two places, in this order (first non-`None`
-wins, **merged per field**):
+wins, **merged per field** — with one guard, below):
 
 | Precedence | Source | Scope |
 |---|---|---|
@@ -56,8 +56,36 @@ wins, **merged per field**):
 | 2 | Packaged table `src/kicad_tools/pcb/lcsc_model_transforms.py` | The whole fleet + every downstream consumer of the wheel |
 | 3 | Identity (`rotate (xyz 0 0 0)`, `offset (xyz 0 0 0)`) | Every part with no entry anywhere |
 
-Merging is **per field**: a sidecar entry that overrides only `rotate` still
-inherits the packaged `offset`, and vice versa.
+Merging is **per field**: a sidecar entry that overrides only `offset` still
+inherits the packaged `rotate`, and vice versa.
+
+#### Guard: a packaged `offset` belongs to its sibling `rotate`
+
+`offset` is applied *after* `rotate` (see [Frame semantics](#frame-semantics)),
+so a packaged `offset` is only meaningful in the frame of the `rotate` it was
+measured under. The per-field merge therefore stops short of one case: a sidecar
+that overrides `rotate` to a **different** value while silently inheriting a
+packaged `offset` is a **build error** (`ValueError` naming the lib id, the
+C-number, both triples and the packaged entry's provenance) — not a
+plausible-but-wrong body.
+
+The invalidated components are `X`/`Y` when the two rotations differ only about
+Z (a Z-axis spin leaves height above the board untouched), and `X`/`Y`/`Z` when
+they differ about X or Y as well (an off-Z rotation tilts the body). The error
+only fires when at least one invalidated component is non-zero — a packaged
+`offset` of `[0, 0, 1.25]` (the "STEP origin is off the board plane" knob) is
+still inherited freely under a Z-only rotation change.
+
+Two ways to resolve it, both of which force a decision rather than inheriting
+one:
+
+- **Restate `offset` in the sidecar** — including an explicit `[0, 0, 0]`, which
+  suppresses the packaged value. Re-render first; that is the point.
+- **Drop the sidecar `rotate`**, keeping the calibrated `(rotate, offset)` pair.
+
+The symmetric case is *not* an error: a sidecar overriding only `offset` while
+inheriting the packaged `rotate` is fine, because its author necessarily
+measured with the packaged rotation active.
 
 ### Sidecar object form
 
@@ -105,7 +133,11 @@ the footprint 2D frame, and Z is up from the board.
   the knob for a STEP whose origin is not on the board plane.
 - Because `offset` is applied *after* `rotate`, it is a post-rotation
   translation. Practical consequence: **set `rotate` first, render, and only
-  then measure `offset`.**
+  then measure `offset`.** The corollary: an authored `offset` is calibrated
+  *for* the `rotate` beside it, and changing one without re-measuring the other
+  invalidates the pair — which is why overriding a packaged `rotate` from a
+  sidecar without restating its `offset` is rejected (see
+  [the guard above](#guard-a-packaged-offset-belongs-to-its-sibling-rotate)).
 - A footprint's own `(at x y angle)` rotates the whole footprint *including* its
   model, so an authored per-part transform is **placement-angle independent**.
   Calibrate once per part; never per instance. This is the property that makes a

--- a/src/kicad_tools/pcb/lcsc_model_transforms.py
+++ b/src/kicad_tools/pcb/lcsc_model_transforms.py
@@ -36,14 +36,34 @@ board.  Because ``offset`` is applied *after* ``rotate``, the ``offset`` here
 is a post-rotation translation — so when calibrating a part, set ``rotate``
 first, render, and only then measure ``offset``.
 
-**Precedence** (resolved in ``models3d._resolve_lcsc``, first non-``None``
-wins, merged per field):
+**Precedence** (resolved by :func:`resolve_merged_transform`, called from
+``models3d._resolve_lcsc``; first non-``None`` wins, merged per field except
+where the split-calibration guard below applies):
 
 1. A per-board ``lcsc_models.json`` sidecar entry in object form
    (``{"lib_id": {"lcsc": "C...", "rotate": [...], "offset": [...]}}``).
 2. This packaged table.
 3. Identity (``rotate (xyz 0 0 0)`` / ``offset (xyz 0 0 0)``) — unchanged
    behavior for every part with no entry anywhere.
+
+**A packaged ``offset`` is calibrated for its sibling ``rotate``, and the
+merge will not split the pair silently** (issue #4636).  Because ``offset``
+is a *post-rotation* translation, an offset measured in one frame points
+somewhere else in another.  So a sidecar that changes ``rotate`` while
+inheriting a packaged ``offset`` whose invalidated components are non-zero is
+a hard :class:`ValueError`, not a quiet almost-right body.  The invalidated
+components are ``X``/``Y`` when the two rotations differ only about Z (a
+Z-axis rotation leaves Z invariant), and ``X``/``Y``/``Z`` when they differ
+about X or Y as well (an off-Z rotation tilts the body, so Z is no longer
+invariant either).  Three merges stay legal and silent:
+
+* a sidecar that **restates** ``offset`` (including an explicit ``[0, 0, 0]``,
+  which suppresses the packaged value) — the calibrator acknowledged it;
+* a sidecar ``rotate`` **equal** to the packaged ``rotate`` — the frame did
+  not change;
+* the symmetric case, a sidecar overriding only ``offset`` and inheriting the
+  packaged ``rotate`` — that offset was necessarily measured *with* the
+  packaged rotation active, so it is already in the right frame.
 
 **Provenance is mandatory, and enforced.**  Every entry MUST carry a
 :class:`TransformProvenance` recording the board, refdes, ISO date, and the
@@ -67,6 +87,7 @@ __all__ = [
     "TransformProvenance",
     "entry_problems",
     "lookup_transform",
+    "resolve_merged_transform",
     "table_problems",
 ]
 
@@ -181,6 +202,141 @@ def lookup_transform(c_number: str) -> LcscModelTransform | None:
     before falling back to identity.
     """
     return LCSC_MODEL_TRANSFORMS.get(c_number)
+
+
+# --------------------------------------------------------------------------
+# The sidecar/table merge, and the split-calibration guard (#4636)
+# --------------------------------------------------------------------------
+
+_IDENTITY_ROTATE: Triple = (0.0, 0.0, 0.0)
+
+
+def _fmt_triple(triple: Triple) -> str:
+    """Render a triple the way a sidecar/table author writes one."""
+    return "(" + ", ".join(f"{component:g}" for component in triple) + ")"
+
+
+def _invalidated_offset_axes(sidecar_rotate: Triple, packaged_rotate: Triple) -> tuple[str, ...]:
+    """Return the offset axes a rotation change from *packaged* to *sidecar* invalidates.
+
+    A pure Z-axis rotation delta spins the body about the board normal: the
+    in-plane X/Y components of a post-rotation offset now point elsewhere, but
+    the Z component (height above the board) is unchanged.  Any X or Y
+    component in the delta *tilts* the body, which moves it vertically too, so
+    every axis of the offset is then suspect.
+    """
+    if sidecar_rotate[0] == packaged_rotate[0] and sidecar_rotate[1] == packaged_rotate[1]:
+        return ("x", "y")
+    return ("x", "y", "z")
+
+
+def _provenance_clause(provenance: TransformProvenance | None) -> str:
+    """Name where and when the packaged offset was rendered, if recorded."""
+    if provenance is None:
+        return " (no provenance recorded)"
+    return f" (verified on {provenance.board} {provenance.refdes}, {provenance.verified})"
+
+
+def _split_calibration_message(
+    c_number: str,
+    lib_id: str,
+    sidecar_rotate: Triple,
+    packaged: LcscModelTransform,
+    packaged_rotate: Triple,
+    packaged_offset: Triple,
+    stale: list[str],
+) -> str:
+    """The error text for an inherited offset measured in a different frame."""
+    return (
+        f"per-part 3D transform conflict for {lib_id!r} (LCSC {c_number}): the "
+        f"sidecar overrides rotate={_fmt_triple(sidecar_rotate)} but inherits the "
+        f"packaged offset={_fmt_triple(packaged_offset)}, which was calibrated "
+        f"under rotate={_fmt_triple(packaged_rotate)}"
+        f"{_provenance_clause(packaged.provenance)}. "
+        f"offset is applied *after* rotate, so {', '.join(stale)} "
+        f"{'points' if len(stale) == 1 else 'point'} somewhere else in the new "
+        f"frame. Fix: restate offset in the sidecar entry for {lib_id!r} — use "
+        f"[0, 0, 0] if a re-render shows none is needed — or drop the sidecar "
+        f"rotate to keep the calibrated (rotate, offset) pair intact."
+    )
+
+
+def resolve_merged_transform(
+    c_number: str,
+    lib_id: str,
+    sidecar_rotate: Triple | None,
+    sidecar_offset: Triple | None,
+) -> tuple[Triple | None, Triple | None]:
+    """Merge a sidecar entry over the packaged table, rejecting a split calibration.
+
+    Implements the precedence documented in the module docstring: each field is
+    taken from the sidecar when it says something, else from the packaged
+    table, else left ``None`` (identity).
+
+    Args:
+        c_number: The LCSC C-number the sidecar entry resolved to.
+        lib_id: The footprint lib id being resolved — named in the error
+            message, because ``LcscModelEntry`` does not retain the sidecar
+            file path.
+        sidecar_rotate: The sidecar's ``rotate``, or ``None`` when it says
+            nothing about rotation.
+        sidecar_offset: The sidecar's ``offset``, or ``None`` when it says
+            nothing about translation.
+
+    Returns:
+        The merged ``(rotate, offset)``; either element may be ``None``,
+        meaning "identity for this field".
+
+    Raises:
+        ValueError: When the sidecar changes ``rotate`` while silently
+            inheriting a packaged ``offset`` whose invalidated components are
+            non-zero — the offset was measured in a frame that no longer
+            applies.  Restating ``offset`` in the sidecar (``[0, 0, 0]``
+            counts) always escapes this.
+
+    Rotation equality is compared exactly.  Both sides are authored literals,
+    never the result of arithmetic, so an exact comparison is the right test —
+    and a sidecar that writes ``360`` where the table writes ``0`` has
+    *stated* a rotation it never rendered, which is exactly the class of
+    unverified number this guard exists to catch.
+    """
+    packaged = lookup_transform(c_number)
+    packaged_rotate = packaged.rotate if packaged is not None else None
+    packaged_offset = packaged.offset if packaged is not None else None
+
+    if (
+        packaged is not None
+        and packaged_offset is not None
+        and sidecar_rotate is not None
+        and sidecar_offset is None
+    ):
+        # A packaged entry may carry an offset with no rotate; that offset was
+        # then calibrated in the identity frame.
+        effective_rotate = packaged_rotate if packaged_rotate is not None else _IDENTITY_ROTATE
+        if tuple(sidecar_rotate) != tuple(effective_rotate):
+            invalidated = _invalidated_offset_axes(sidecar_rotate, effective_rotate)
+            # ``-0.0 != 0.0`` is False, so a signed zero is correctly benign.
+            stale = [
+                f"its {axis.upper()} component ({packaged_offset[index]:g})"
+                for index, axis in enumerate("xyz")
+                if axis in invalidated and packaged_offset[index] != 0.0
+            ]
+            if stale:
+                raise ValueError(
+                    _split_calibration_message(
+                        c_number,
+                        lib_id,
+                        sidecar_rotate,
+                        packaged,
+                        effective_rotate,
+                        packaged_offset,
+                        stale,
+                    )
+                )
+
+    rotate = sidecar_rotate if sidecar_rotate is not None else packaged_rotate
+    offset = sidecar_offset if sidecar_offset is not None else packaged_offset
+    return rotate, offset
 
 
 def _triple_problems(label: str, value: object) -> list[str]:

--- a/src/kicad_tools/pcb/lcsc_models.py
+++ b/src/kicad_tools/pcb/lcsc_models.py
@@ -29,9 +29,11 @@ wrong for many parts.  Authored per-part corrections therefore come from two
 places, resolved in ``models3d._resolve_lcsc`` (first non-``None`` wins,
 merged per field): a per-board sidecar entry in **object form**
 (:class:`LcscModelEntry`), then the packaged, C-number-keyed table in
-:mod:`kicad_tools.pcb.lcsc_model_transforms`, then identity.  See
-``docs/guides/lcsc-3d-models.md`` for the frame semantics and the calibration
-recipe.
+:mod:`kicad_tools.pcb.lcsc_model_transforms`, then identity.  The one
+exception to the per-field merge: a sidecar ``rotate`` may not silently
+inherit a packaged ``offset`` calibrated under a different rotation — that
+raises ``ValueError`` (#4636).  See ``docs/guides/lcsc-3d-models.md`` for the
+frame semantics and the calibration recipe.
 
 **Offline / CI safety.**  The fetch is opt-in.  A model resolves only when the
 cache already holds the STEP, or when fetching is explicitly enabled (via the
@@ -146,8 +148,16 @@ class LcscModelEntry:
     negated versus footprint 2D Y, Z up from the board).  ``None`` means "this
     sidecar says nothing about that field", which lets the packaged
     :mod:`kicad_tools.pcb.lcsc_model_transforms` table supply it — the merge is
-    per field, so a sidecar that overrides only ``rotate`` does not suppress a
-    packaged ``offset``.
+    per field, so a sidecar that overrides only ``offset`` does not suppress a
+    packaged ``rotate``.
+
+    The merge is per field in the other direction too, with one guard: because
+    ``offset`` is applied *after* ``rotate``, a packaged ``offset`` is only
+    meaningful in the frame of its sibling ``rotate``.  So a sidecar that
+    overrides ``rotate`` to a *different* value while inheriting a packaged
+    ``offset`` with non-zero invalidated components raises ``ValueError``
+    rather than emitting a plausible-but-wrong body (#4636).  Restating
+    ``offset`` here — ``[0, 0, 0]`` counts — always resolves it.
     """
 
     lcsc: str

--- a/src/kicad_tools/pcb/models3d.py
+++ b/src/kicad_tools/pcb/models3d.py
@@ -643,7 +643,9 @@ def make_library_resolver(
        per-part ``rotate``/``offset`` correction comes from the sidecar's
        object form or the packaged
        :mod:`kicad_tools.pcb.lcsc_model_transforms` table (in that order,
-       merged per field, falling back to identity).
+       merged per field, falling back to identity) — except that a sidecar
+       ``rotate`` may not silently inherit a packaged ``offset`` calibrated
+       under a different rotation, which raises ``ValueError`` (#4636).
 
     Args:
         library_paths: Explicit library location (default: auto-detect).
@@ -713,7 +715,7 @@ def make_library_resolver(
             return None
         # Imported lazily so the module (and the three installed-library tiers)
         # never depend on the LCSC client unless the LCSC tier is actually used.
-        from kicad_tools.pcb.lcsc_model_transforms import lookup_transform
+        from kicad_tools.pcb.lcsc_model_transforms import resolve_merged_transform
         from kicad_tools.pcb.lcsc_models import (
             LcscModelEntry,
             resolve_lcsc_step,
@@ -743,14 +745,12 @@ def make_library_resolver(
             return None
         if lcsc_log is not None:
             lcsc_log[lib_id] = lcsc_id
-        # Per-part transform precedence, merged per field so a sidecar that
-        # overrides only ``rotate`` still inherits a packaged ``offset``:
-        #   per-board sidecar object form > packaged table > identity.
-        packaged = lookup_transform(lcsc_id)
-        packaged_rotate = packaged.rotate if packaged is not None else None
-        packaged_offset = packaged.offset if packaged is not None else None
-        rotate = sidecar_rotate if sidecar_rotate is not None else packaged_rotate
-        offset = sidecar_offset if sidecar_offset is not None else packaged_offset
+        # Per-part transform precedence — per-board sidecar object form >
+        # packaged table > identity — merged per field, except that a sidecar
+        # ``rotate`` may not silently inherit a packaged ``offset`` calibrated
+        # under a different rotation (raises ValueError; see #4636 and the
+        # ``lcsc_model_transforms`` module docstring).
+        rotate, offset = resolve_merged_transform(lcsc_id, lib_id, sidecar_rotate, sidecar_offset)
         if lcsc_transform_log is not None and (rotate is not None or offset is not None):
             lcsc_transform_log[lib_id] = _describe_lcsc_transform(
                 rotate,

--- a/tests/test_lcsc_models.py
+++ b/tests/test_lcsc_models.py
@@ -29,6 +29,7 @@ from kicad_tools.pcb.lcsc_model_transforms import (
     TransformProvenance,
     entry_problems,
     lookup_transform,
+    resolve_merged_transform,
     table_problems,
 )
 from kicad_tools.pcb.lcsc_models import (
@@ -941,6 +942,209 @@ class TestTransformPrecedence:
         )
         resolver(self.LIB_ID)
         assert log == {}
+
+
+class TestSplitCalibrationGuard:
+    """A packaged ``offset`` is calibrated for its sibling ``rotate`` (#4636).
+
+    ``offset`` is applied *after* ``rotate``, so an offset measured in one
+    frame points somewhere else in another.  A sidecar that changes ``rotate``
+    while silently inheriting such an offset must fail loudly instead of
+    emitting an almost-right body -- the worst failure mode for a transform
+    whose only real validation is a human looking at a render.
+    """
+
+    LIB_ID = "Module:Joystick_Analog"
+
+    @staticmethod
+    def _packaged(monkeypatch, **kwargs):
+        monkeypatch.setitem(
+            lcsc_model_transforms.LCSC_MODEL_TRANSFORMS,
+            "C50950",
+            LcscModelTransform(provenance=GOOD_PROVENANCE, **kwargs),
+        )
+
+    # -- the defect ---------------------------------------------------------
+
+    def test_sidecar_rotate_inheriting_an_xy_offset_raises(self, tmp_path, monkeypatch):
+        self._packaged(monkeypatch, rotate=(0.0, 0.0, -90.0), offset=(1.5, -0.25, 0.0))
+        resolver = _lcsc_resolver(
+            tmp_path, {self.LIB_ID: LcscModelEntry("C50950", rotate=(0.0, 0.0, 90.0))}
+        )
+        with pytest.raises(ValueError) as excinfo:
+            resolver(self.LIB_ID)
+        message = str(excinfo.value)
+        # Both sources named, plus the render that measured the offset.
+        assert self.LIB_ID in message
+        assert "C50950" in message
+        assert "(1.5, -0.25, 0)" in message  # the packaged offset
+        assert "(0, 0, -90)" in message  # the rotation it was calibrated under
+        assert "(0, 0, 90)" in message  # the sidecar rotation
+        assert "boards/06-diffpair-test" in message
+        assert "J3" in message
+        assert "2026-08-04" in message
+        # And the remedy.
+        assert "[0, 0, 0]" in message
+
+    def test_message_names_only_the_invalidated_nonzero_components(self, tmp_path, monkeypatch):
+        # Z is invariant under a Z-only rotation delta, so a nonzero Z must not
+        # be cited as evidence even when X/Y are what trip the guard.
+        self._packaged(monkeypatch, rotate=(0.0, 0.0, -90.0), offset=(1.5, 0.0, 1.25))
+        resolver = _lcsc_resolver(
+            tmp_path, {self.LIB_ID: LcscModelEntry("C50950", rotate=(0.0, 0.0, 90.0))}
+        )
+        with pytest.raises(ValueError) as excinfo:
+            resolver(self.LIB_ID)
+        message = str(excinfo.value)
+        assert "its X component (1.5)" in message
+        assert "Y component" not in message  # zero -- nothing to invalidate
+        assert "Z component" not in message  # rotation-invariant here
+
+    def test_off_z_rotation_invalidates_a_z_only_offset_too(self, tmp_path, monkeypatch):
+        # Tilting the body about X/Y moves it vertically, so "Z is
+        # rotation-invariant" no longer holds.
+        self._packaged(monkeypatch, offset=(0.0, 0.0, 1.25))
+        resolver = _lcsc_resolver(
+            tmp_path, {self.LIB_ID: LcscModelEntry("C50950", rotate=(0.0, 15.0, 0.0))}
+        )
+        with pytest.raises(ValueError) as excinfo:
+            resolver(self.LIB_ID)
+        assert "its Z component (1.25)" in str(excinfo.value)
+
+    def test_packaged_offset_without_a_rotate_is_calibrated_in_the_identity_frame(
+        self, tmp_path, monkeypatch
+    ):
+        # No packaged ``rotate`` means the offset was measured at identity, so
+        # any sidecar rotation still changes the frame.
+        self._packaged(monkeypatch, offset=(1.5, -0.25, 0.0))
+        resolver = _lcsc_resolver(
+            tmp_path, {self.LIB_ID: LcscModelEntry("C50950", rotate=(0.0, 0.0, 90.0))}
+        )
+        with pytest.raises(ValueError) as excinfo:
+            resolver(self.LIB_ID)
+        assert "(0, 0, 0)" in str(excinfo.value)
+
+    def test_missing_provenance_still_produces_a_message(self, tmp_path, monkeypatch):
+        # provenance is typed optional (a forgetful author gets a test failure,
+        # not a TypeError) -- building the error must not AttributeError.
+        monkeypatch.setitem(
+            lcsc_model_transforms.LCSC_MODEL_TRANSFORMS,
+            "C50950",
+            LcscModelTransform(rotate=(0.0, 0.0, -90.0), offset=(1.5, -0.25, 0.0)),
+        )
+        resolver = _lcsc_resolver(
+            tmp_path, {self.LIB_ID: LcscModelEntry("C50950", rotate=(0.0, 0.0, 90.0))}
+        )
+        with pytest.raises(ValueError, match="no provenance recorded"):
+            resolver(self.LIB_ID)
+
+    # -- what must stay legal ----------------------------------------------
+
+    def test_z_only_offset_survives_a_z_only_rotation_change(self, tmp_path, monkeypatch):
+        # The "STEP origin is off the board plane" knob is rotation-invariant
+        # under a Z spin.  Over-rejecting here would break the documented use.
+        self._packaged(monkeypatch, rotate=(0.0, 0.0, -90.0), offset=(0.0, 0.0, 1.25))
+        resolver = _lcsc_resolver(
+            tmp_path, {self.LIB_ID: LcscModelEntry("C50950", rotate=(0.0, 0.0, 180.0))}
+        )
+        resolved = resolver(self.LIB_ID)
+        assert resolved is not None
+        assert "(rotate\n\t\t(xyz 0 0 180)\n" in resolved.models[0]
+        assert "(offset\n\t\t(xyz 0 0 1.25)\n" in resolved.models[0]
+
+    def test_signed_zero_offset_components_count_as_zero(self, tmp_path, monkeypatch):
+        self._packaged(monkeypatch, rotate=(0.0, 0.0, -90.0), offset=(-0.0, -0.0, 1.25))
+        resolver = _lcsc_resolver(
+            tmp_path, {self.LIB_ID: LcscModelEntry("C50950", rotate=(0.0, 0.0, 180.0))}
+        )
+        assert resolver(self.LIB_ID) is not None
+
+    def test_a_redundant_identical_rotate_does_not_change_the_frame(self, tmp_path, monkeypatch):
+        self._packaged(monkeypatch, rotate=(0.0, 0.0, -90.0), offset=(1.5, -0.25, 0.0))
+        resolver = _lcsc_resolver(
+            tmp_path, {self.LIB_ID: LcscModelEntry("C50950", rotate=(0.0, 0.0, -90.0))}
+        )
+        resolved = resolver(self.LIB_ID)
+        assert resolved is not None
+        assert "(rotate\n\t\t(xyz 0 0 -90)\n" in resolved.models[0]
+
+    def test_restating_the_offset_acknowledges_it(self, tmp_path, monkeypatch):
+        self._packaged(monkeypatch, rotate=(0.0, 0.0, -90.0), offset=(1.5, -0.25, 0.0))
+        resolver = _lcsc_resolver(
+            tmp_path,
+            {
+                self.LIB_ID: LcscModelEntry(
+                    "C50950", rotate=(0.0, 0.0, 90.0), offset=(-0.25, 1.5, 0.0)
+                )
+            },
+        )
+        resolved = resolver(self.LIB_ID)
+        assert resolved is not None
+        assert "(rotate\n\t\t(xyz 0 0 90)\n" in resolved.models[0]
+
+    def test_an_explicit_zero_offset_is_a_valid_acknowledgement(self, tmp_path, monkeypatch):
+        # The documented escape hatch: sidecar (0, 0, 0) wins the merge and
+        # suppresses the packaged value.
+        self._packaged(monkeypatch, rotate=(0.0, 0.0, -90.0), offset=(1.5, -0.25, 0.0))
+        resolver = _lcsc_resolver(
+            tmp_path,
+            {
+                self.LIB_ID: LcscModelEntry(
+                    "C50950", rotate=(0.0, 0.0, 90.0), offset=(0.0, 0.0, 0.0)
+                )
+            },
+        )
+        resolved = resolver(self.LIB_ID)
+        assert resolved is not None
+        assert "(rotate\n\t\t(xyz 0 0 90)\n" in resolved.models[0]
+
+    def test_a_bare_string_sidecar_inherits_a_calibrated_pair(self, tmp_path, monkeypatch):
+        # The normal path: nothing was overridden, so nothing is out of frame.
+        self._packaged(monkeypatch, rotate=(0.0, 0.0, -90.0), offset=(1.5, -0.25, 0.0))
+        resolver = _lcsc_resolver(tmp_path, {self.LIB_ID: "C50950"})
+        resolved = resolver(self.LIB_ID)
+        assert resolved is not None
+        assert "(rotate\n\t\t(xyz 0 0 -90)\n" in resolved.models[0]
+
+    def test_the_symmetric_case_is_not_a_defect(self, tmp_path, monkeypatch):
+        # A sidecar offset inheriting a packaged rotate is fine: its author
+        # necessarily measured with the packaged rotation active.
+        self._packaged(monkeypatch, rotate=(0.0, 0.0, -90.0), offset=(1.5, -0.25, 0.0))
+        resolver = _lcsc_resolver(
+            tmp_path, {self.LIB_ID: LcscModelEntry("C50950", offset=(0.0, 0.0, 3.0))}
+        )
+        resolved = resolver(self.LIB_ID)
+        assert resolved is not None
+        assert "(rotate\n\t\t(xyz 0 0 -90)\n" in resolved.models[0]
+        assert "(offset\n\t\t(xyz 0 0 3)\n" in resolved.models[0]
+
+    def test_no_packaged_entry_means_nothing_to_inherit(self, tmp_path):
+        resolver = _lcsc_resolver(
+            tmp_path, {self.LIB_ID: LcscModelEntry("C50950", rotate=(0.0, 0.0, 45.0))}
+        )
+        assert resolver(self.LIB_ID) is not None
+
+    # -- the committed sidecars (AC 4) --------------------------------------
+
+    @pytest.mark.parametrize(
+        "sidecar",
+        [
+            "boards/03-usb-joystick/lcsc_models.json",
+            "boards/06-diffpair-test/lcsc_models.json",
+        ],
+    )
+    def test_committed_sidecars_never_trip_the_guard(self, sidecar):
+        """Both committed sidecars are bare-string form, so no packaged offset
+        can ever be split by one -- assert it, so a future table addition
+        cannot quietly break a board."""
+        path = Path(__file__).resolve().parents[1] / sidecar
+        mapping = load_lcsc_mapping(path)
+        assert mapping
+        for lib_id, entry in mapping.items():
+            c_number = entry.lcsc if isinstance(entry, LcscModelEntry) else entry
+            sidecar_rotate = entry.rotate if isinstance(entry, LcscModelEntry) else None
+            sidecar_offset = entry.offset if isinstance(entry, LcscModelEntry) else None
+            resolve_merged_transform(c_number, lib_id, sidecar_rotate, sidecar_offset)
 
 
 class TestTransformComposition:

--- a/tests/test_pcb_add_3d_models.py
+++ b/tests/test_pcb_add_3d_models.py
@@ -1312,3 +1312,95 @@ class TestLcscPerPartTransform:
         plain_text, _ = add_model_refs_to_text(PCB_LCSC_OFFCENTRE, plain)
         for text in (rotated_text, plain_text):
             assert "(xyz 10 -2 0)" in text
+
+
+# --------------------------------------------------------------------------
+# CLI surface for the split-calibration guard (issue #4636)
+# --------------------------------------------------------------------------
+
+
+class TestSplitCalibrationCliSurface:
+    """A sidecar ``rotate`` inheriting a frame-mismatched packaged ``offset``
+    must reach the operator as a nonzero exit plus the message, on both output
+    formats.  ``run_add_3d_models`` already wraps ``add_model_refs`` in a
+    catch-all, so no CLI plumbing is involved -- this pins that it stays true.
+    """
+
+    LIB_ID = "Connector_PCIE:PCIE_Mini_Edge"
+
+    def _setup(self, tmp_path, monkeypatch):
+        import json
+
+        from kicad_tools.pcb import lcsc_model_transforms
+        from kicad_tools.pcb.lcsc_model_transforms import (
+            LcscModelTransform,
+            TransformProvenance,
+        )
+        from kicad_tools.pcb.lcsc_models import DEFAULT_CACHE_ENV_VAR
+
+        monkeypatch.setitem(
+            lcsc_model_transforms.LCSC_MODEL_TRANSFORMS,
+            "C444929",
+            LcscModelTransform(
+                rotate=(0.0, 0.0, -90.0),
+                offset=(1.5, -0.25, 0.0),
+                provenance=TransformProvenance(
+                    board="boards/06-diffpair-test",
+                    refdes="J3",
+                    verified="2026-08-04",
+                    command="kct render boards/06-diffpair-test",
+                ),
+            ),
+        )
+        cache = tmp_path / "lcsc-cache"
+        cache.mkdir(exist_ok=True)
+        (cache / "C444929.step").write_bytes(_FAKE_STEP)
+        monkeypatch.setenv(DEFAULT_CACHE_ENV_VAR, str(cache))
+        footprints = tmp_path / "footprints"
+        footprints.mkdir(exist_ok=True)
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text(PCB_LCSC_OFFCENTRE)
+        sidecar = tmp_path / "lcsc_models.json"
+        sidecar.write_text(json.dumps({self.LIB_ID: {"lcsc": "C444929", "rotate": [0, 0, 90]}}))
+        return pcb, sidecar, footprints
+
+    def test_text_format_exits_1_and_prints_to_stderr(self, tmp_path, monkeypatch, capsys):
+        from kicad_tools.cli.pcb_add_3d_models import run_add_3d_models
+
+        pcb, sidecar, footprints = self._setup(tmp_path, monkeypatch)
+        rc = run_add_3d_models(pcb, lib_path=footprints, lcsc_models=sidecar, output_format="text")
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "per-part 3D transform conflict" in err
+        assert self.LIB_ID in err
+        assert "C444929" in err
+        # The board is left untouched by a rejected merge.
+        assert pcb.read_text() == PCB_LCSC_OFFCENTRE
+
+    def test_json_format_exits_1_and_reports_the_error_key(self, tmp_path, monkeypatch, capsys):
+        import json
+
+        from kicad_tools.cli.pcb_add_3d_models import run_add_3d_models
+
+        pcb, sidecar, footprints = self._setup(tmp_path, monkeypatch)
+        rc = run_add_3d_models(pcb, lib_path=footprints, lcsc_models=sidecar, output_format="json")
+        assert rc == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert "per-part 3D transform conflict" in payload["error"]
+        assert "[0, 0, 0]" in payload["error"]  # the remedy
+
+    def test_the_documented_escape_hatch_unblocks_the_run(self, tmp_path, monkeypatch, capsys):
+        import json
+
+        from kicad_tools.cli.pcb_add_3d_models import run_add_3d_models
+
+        pcb, sidecar, footprints = self._setup(tmp_path, monkeypatch)
+        sidecar.write_text(
+            json.dumps(
+                {self.LIB_ID: {"lcsc": "C444929", "rotate": [0, 0, 90], "offset": [0, 0, 0]}}
+            )
+        )
+        rc = run_add_3d_models(pcb, lib_path=footprints, lcsc_models=sidecar, output_format="json")
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["patched"] == [self.LIB_ID]


### PR DESCRIPTION
## Summary

A packaged LCSC transform's `offset` is a **post-rotation** translation, so it is only meaningful in the frame of the `rotate` it was calibrated under. The per-field sidecar/table merge in `models3d._resolve_lcsc` let a board sidecar override `rotate` alone and silently inherit that offset, applying an X/Y translation measured in a frame that no longer exists — a plausibly-placed, quietly-wrong body, which is the worst failure mode for a transform whose only real validation is a human looking at a render.

Implements **Option 2** (reject the split explicitly), scoped by the five-condition predicate from the curator enhancement so it does not over-reject the legitimate "STEP origin is off the board plane" Z knob.

Exposure today is still zero — `LCSC_MODEL_TRANSFORMS` has one `rotate`-only entry (`C444929`) and both committed sidecars are bare-string form — so this hardens a trap laid for the *second* calibration rather than fixing a live misrender.

## Changes

- **`src/kicad_tools/pcb/lcsc_model_transforms.py`** — new `resolve_merged_transform(c_number, lib_id, sidecar_rotate, sidecar_offset)` performs the merge and raises `ValueError` when **all** of: the sidecar overrides `rotate`; the offset is *inherited* (sidecar `offset is None`); a packaged entry supplies an `offset`; the sidecar rotation differs from the packaged one (a packaged entry with no `rotate` is treated as calibrated at identity); and at least one **invalidated** offset component is non-zero. Invalidated = `{X, Y}` for a Z-only rotation delta, `{X, Y, Z}` when the delta is off-Z (a tilt moves the body vertically, so Z stops being rotation-invariant). The precedence docstring now states the rule and the three merges that stay legal.
- **`src/kicad_tools/pcb/models3d.py`** — the two independent merge lines in `_resolve_lcsc` become one call to the helper; the inline comment and the `make_library_resolver` docstring are corrected. Deliberately kept to ~3 code lines inside `_resolve_lcsc` so #4586's later `--refresh` work on this file rebases cleanly.
- **`src/kicad_tools/pcb/lcsc_models.py`** — docstring-only: module precedence summary + `LcscModelEntry`, which both asserted the unqualified per-field contract (the `LcscModelEntry` example was flipped to the symmetric direction, which remains unconditionally true).
- **`docs/guides/lcsc-3d-models.md`** — new "Guard: a packaged `offset` belongs to its sibling `rotate`" subsection under the precedence table, plus a corollary sentence in **Frame semantics**, right beside "set `rotate` first, render, and only then measure `offset`" — where a calibrator will actually be reading.
- **Tests** — new `TestSplitCalibrationGuard` (13 cases) in `tests/test_lcsc_models.py` and `TestSplitCalibrationCliSurface` (3 cases) in `tests/test_pcb_add_3d_models.py`.

The error message names the `lib_id`, the C-number, the packaged `rotate`/`offset`, the sidecar `rotate`, the packaged entry's provenance (board / refdes / verified date), which invalidated components are stale, and both remedies. Escape hatch, as specified: restating `offset` in the sidecar — including an explicit `[0, 0, 0]` — wins the merge and resolves the error, so the guard forces a *decision* rather than blocking a legitimate override.

## Acceptance Criteria Verification

- [x] **Sidecar `rotate` cannot silently inherit a frame-mismatched packaged `offset`** — `ValueError` from `resolve_merged_transform`, five-condition predicate as specified. `test_sidecar_rotate_inheriting_an_xy_offset_raises`, `test_off_z_rotation_invalidates_a_z_only_offset_too`, `test_packaged_offset_without_a_rotate_is_calibrated_in_the_identity_frame`.
- [x] **Rule stated at the precedence docstring, and all six sites updated** — `git grep -n -i "per field\|per-field" -- src docs` now returns 10 hits across the 4 files (plus 2 unrelated C++ router hits); every one is qualified by the guard. Sites: `lcsc_model_transforms.py:40`, `lcsc_models.py:30,33,151,154`, `models3d.py:646,749`, `docs/guides/lcsc-3d-models.md:51,59,66`.
- [x] **Tests cover the split case and the cases that must remain legal** — Z-only offset under a Z-only rotation delta, redundant identical `rotate`, restated sidecar `offset` (both a real value and an explicit `[0,0,0]`), bare-string sidecar over a calibrated pair, symmetric `offset`-only override, no packaged entry, signed-zero offset components, and `provenance=None` (must not `AttributeError` while building the message).
- [x] **Behavior for the two committed sidecars is unchanged** — `test_committed_sidecars_never_trip_the_guard` loads `boards/03-usb-joystick/lcsc_models.json` and `boards/06-diffpair-test/lcsc_models.json` through `load_lcsc_mapping` and runs every entry through the helper. Guards AC 4 against a future table addition rather than relying on today's bare-string form.
- [x] **Error message names all required facts** — asserted componentwise in `test_sidecar_rotate_inheriting_an_xy_offset_raises` (lib id, C-number, both triples, board, refdes, date, `[0, 0, 0]` remedy) and `test_message_names_only_the_invalidated_nonzero_components`.
- [x] **`test_merge_is_per_field_not_all_or_nothing` and `test_merge_is_per_field_in_the_other_direction` pass without modification** — `git diff` touches no line in `tests/test_lcsc_models.py:875-906`; the only edit above the new class is the `resolve_merged_transform` import. Both are green.
- [x] **No file under `boards/*/output/` modified** — `git show --stat` lists only the 6 files above; `git status` in the worktree is clean after commit.

## Test Plan

- `uv run pytest tests/test_lcsc_models.py tests/test_pcb_add_3d_models.py tests/test_render_cmd.py` → **244 passed** (131 + 71 + 42; 16 of them new).
- `uv run ruff check .` → All checks passed. `uv run ruff format --check .` → 1731 files already formatted.
- `uv run python scripts/ci/check_mypy_baseline.py` → `OK: mypy reports 1473 error(s), all within the baseline (1474 allowed). No new type errors.` (The baseline file is deliberately left untouched — see the known `--update` native-env trap.)
- **Manual, per the issue's test plan**: `uv run kct pcb add-3d-models boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb --lcsc-models boards/06-diffpair-test/lcsc_models.json --dry-run --format json` → exit 0, no error, `git status -- boards/` clean.
- **CLI surface**: exit 1 with the message on stderr under `--format text` and as `{"error": ...}` under `--format json`; the target `.kicad_pcb` is byte-identical after a rejected run; the `[0, 0, 0]` escape hatch returns the run to exit 0 with the footprint patched.

## Notes

- `CHANGELOG.md` intentionally untouched (three-way contended in this wave).
- Rotation equality is compared **exactly**, per the curator's guidance — both sides are authored literals, never arithmetic results. The docstring records why that is the *right* test rather than merely an acceptable one: a sidecar writing `360` where the table writes `0` has stated a rotation it never rendered, which is the class of unverified number this guard exists to catch.
- `-0.0` is correctly benign (`-0.0 != 0.0` is `False`), covered by `test_signed_zero_offset_components_count_as_zero`.

Closes #4636
