### PR TITLE
docs(changelog): backfill [Unreleased] and add a release-time gap report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -297,6 +297,15 @@ constructor). No breaking changes.
   additionally threw board 07's 9-pin header 20.32 mm off the board edge.
   Co-oriented footprints compute θ ≈ 0 and are byte-identical (#4448, #4583).
 
+- **A sidecar `rotate` could silently inherit a frame-mismatched packaged
+  `offset`.** A packaged LCSC transform's `offset` is a post-rotation
+  translation, meaningful only under the `rotate` it was calibrated with — but
+  the per-field sidecar/table merge let a board sidecar override `rotate` alone
+  and keep that offset, producing a plausibly-placed, quietly-wrong body. The
+  merge now rejects the split with an error naming the stale components and
+  both remedies; restating `offset` in the sidecar (including an explicit
+  `[0, 0, 0]`) wins the merge and clears it (#4636).
+
 - **Routing was nondeterministic from a dangling C++ grid reference.** The
   nanobind pathfinder constructors stored the incoming `Grid3D` as a bare C++
   reference with no keep-alive policy, so in the common
@@ -366,6 +375,14 @@ constructor). No breaking changes.
   depended on glob order; references are now merged per rule id and
   `explain(context={"manufacturer": ...})` resolves deterministically
   (#4491, #4502).
+
+- **Three `kct check` flags were declared but unreachable.** `--refill-zones`,
+  `--waivers`, and `--courtyard-waivers` existed on the inner check command but
+  were never declared on the outer `kct check` subparser, so the documented
+  `--refill-zones` was rejected outright and the two waiver-path overrides
+  silently fell back to sidecar auto-discovery. All three now reach the inner
+  command, and the route-parser drift guard is extended to the check parser
+  pair (both allowlists empty) so the class cannot recur (#4633).
 
 - **`kct build-native` could contradict `--check` seconds later.** Post-build
   verification ran in the process that had just done the build, which cannot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,158 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Summary
+
+Development since `v0.19.0`: a targeted `kct route --complete` completion pass,
+route-time enforcement of high-voltage isolation across every engine, a general
+`.kct_waivers.json` waiver mechanism for `kct check`, and a broad correctness
+sweep (KiCad-10 net dialect, export manifests, LVS identity, diff-pair shadow
+constructor). No breaking changes.
+
 ### Added
+
+- **`kct route --complete`** — a targeted completion pass: auto-detect the
+  still-unconnected signal nets and route only those links, with all other
+  copper fixed, on the octilinear lattice engine. Implies `--preserve-existing`
+  and is a byte-identical no-op on a connected board. The lattice build is
+  localized to the stranded nets' pad bounding boxes and every link carries a
+  wall-clock deadline, so a walled SMD pocket that used to grind for over ten
+  minutes now terminates and reports. `--complete-report PATH` writes per-link
+  records (endpoints, elapsed vs. budget, blocking copper) and the pass exits 8
+  when links remain unroutable; batch rescue now shells it instead of the
+  coarse grid A*. The companion `--via-in-pad-last-resort` (default off) lets
+  the lattice engine stage a same-net via-in-pad attach for a walled SMD pad
+  only after an in-layer route and an off-pad via have failed, gated on the
+  manufacturer tier floor so an unsupporting tier declines with an explicit
+  `via-in-pad-tier-unsupported` reason (#4471, #4472, #4475, #4477, #4478).
+
+- **Route-time high-voltage isolation** — `kct route` gains `--voltage-map`
+  (plus `--creepage-standard` / `--pollution-degree` / `--material-group` /
+  `--hv-threshold`) and resolves each net pair at `max(DRU, creepage(|ΔV|))`,
+  sharing the derivation with `kct creepage` and `kct optimize-placement` so
+  the three agree by construction. Enforcement spans the stack: a per-net
+  domain matrix in the C++ validator, search-time A* hard-blocking, and
+  rated-footprint attach zones that waive the widening but never the DRU floor.
+  A post-route board-level audit now gates *every* engine's exit code — the
+  lattice engine previously committed HV copper at DRU spacing and exited 0
+  (#4431, #4506, #4510, #4511, #4588).
+
+- **`kct creepage-export-rules`** — turns a `--voltage-map` into artifacts
+  `kicad-cli pcb drc` enforces: voltage-domain netclasses and net patterns
+  merged into `<project>.kicad_pro`, and pairwise clearance `(rule ...)`
+  clauses in a sentinel-delimited block in `<project>.kicad_dru`. Both are
+  idempotent and preserve user-authored content; domain-bridging footprints
+  become refdes-scoped `insideCourtyard` exclusions (#4508).
+
+- **Richer creepage model** — a `--voltage-map` entry now accepts
+  `{"min": v0, "max": v1}` as well as a scalar and the census derives the
+  worst-case endpoint stress, closing a same-potential false PASS where two
+  nets sharing a dominant state derived ΔV = 0 despite mains-class transient
+  stress (an all-scalar map still serializes byte-identically). Pairs also
+  carry a `relationship` (`board` / `same_footprint`), so component-internal
+  gaps — functional insulation governed by the part's own rating — are
+  distinguishable; `--waive-same-footprint` (default off) drops them from the
+  exit gate but still lists them `WAIVED`, and `kct audit` still blocks
+  (#4403, #4411).
+
+- **`.kct_waivers.json` — a general waiver mechanism for `kct check`** — a
+  version-2 sidecar waives findings for **any** `rule_id` by matching a
+  violation's items (and optional nets) as an exact set, via `--waivers PATH` or
+  auto-discovery; stale entries raise a `waiver_unused` advisory. Waived findings
+  leave `kct check`'s exit gate but keep `severity: "error"` in the JSON, so
+  `kct audit` stays blocking (#4417).
+
+- **Fab-profile auto-discovery for `kct check`** — `kct route` writes a
+  `fab_profile.json` sidecar recording the resolved `--manufacturer`, and
+  `kct check` resolves the effective `--mfr` by precedence (explicit `--mfr` >
+  sidecar > `project.kct` `target_fab` > `jlcpcb`), so a board routed with
+  tier-gated geometry such as via-in-pad no longer reports a false FAILED
+  against the base tier. With neither source, a non-blocking advisory names a
+  permitting tier (#3920).
+
+- **Placement refinement and edge connectors** — `--seed current` warm-starts
+  CMA-ES from the board's on-disk footprint positions (with a much tighter
+  sigma), so the optimizer refines a ratified hand floorplan instead of
+  re-imagining it from the bounds center. `kct placement check` flags an
+  off-board connector standing more than `edge_connector_max_inset` (2 mm)
+  inside the outline — one no cable can mate with — and the solver gains a
+  torque that rotates such connectors to face off-board (#4405, #4450).
+
+- **`kct pcb move-footprint --drag-endpoints`** — a translation nudge carries
+  coincident trace endpoints along with the pads instead of stranding the routed
+  copper, with `--drag-tolerance`, per-pad drag counts, `--map` batch
+  composition, and UUID-preserving dry-run reporting (#4418).
+
+- **Grid-independent different-net short verifier and repair** — a post-route
+  pass geometrically verifies emitted copper for via-via, via-segment, and
+  segment-segment different-net overlaps independently of the router's grid
+  model, then relocates each offending via onto a clearance-validated site
+  (escape-node slide, then an 8-direction ladder, with connectivity stubs).
+  This matters under `--allow-unsafe-grid`, where a coarse grid lets two nets
+  quantize into a real short that passes grid occupancy (#4470).
+
+- **Manufacturer-driven hole-to-hole via relocation** — a `--mfr`-driven
+  post-pass relocates in-pad and plane-stitch vias that violate the drill
+  hole-to-hole floor onto a clearance-validated location, re-bonds them, and
+  reports boxed-in vias rather than moving them. It never introduces a new
+  violation (#4408).
+
+- **Zone-fill island reporting** — KiCad's `unconnected_items` now land in a
+  dedicated `DRCReport.unconnected_items` collection, so orphaned zone-fill
+  islands surface without redefining `violations`, which keeps its
+  geometry-only meaning for every existing consumer (#4498).
+
+- **Kelvin / current-sense star topology** — the router recognizes
+  current-sense nets and roots their topology at the shunt pad instead of an
+  arbitrary hub, so a sense tap connects *at* the Kelvin point rather than
+  merging into the high-current segment and reading the load-current IR drop.
+  Applied by the RSMT builder and by the lattice and mesh netset drivers, which
+  previously anchored every star at `pads[0]`. Detection needs a net-name
+  pattern *and* a resolvable shunt root; other nets are untouched (#4473, #4476).
+
+- **Congestion-aware escape-corridor reservation** —
+  `--escape-corridor-reservation` (default off) clusters a dense part's pins by
+  face and destination, sizes a corridor per cluster from the congestion
+  estimator, assigns clusters to distinct inner layers, and soft-reserves those
+  cells before the general negotiation. Reservation is selective and
+  length-bounded, so it is a local escape channel rather than a board-spanning
+  attractor field — board 05 goes 25 875 cells over four layers → 2 886 over
+  two (#4474, #4519).
+
+- **Classifier-driven placement feedback for stuck nets** — a stuck-net
+  diagnosis now translates into a concrete placement delta (translate,
+  `rotate_180`, `reorder_pins`), and `kct route --placement-delta-feedback`
+  applies it, re-routes, and keeps it only on a strict routed-net improvement —
+  otherwise placement, router pads, and routes revert atomically. A kept delta
+  persists the mutated placement, since the new copper is valid only against
+  the moved footprints (#4466, #4467, #4468).
+
+- **Per-net `avoid_layers` as a hard constraint** — `--strict-layers` promotes
+  a net class's `avoid_layers` from a soft cost bias (Python-only, and absent
+  from the C++ backend) to a hard routable-layer restriction honored by both
+  backends, so an ampacity-bearing net can no longer land copper on a thin
+  inner plane when escalation reaches the all-signal rung. It also applies
+  automatically to any class declaring `target_ampacity` (#4433).
+
+- **Router failure diagnostics** — the coupled diff-pair router emits a
+  per-reason rejection histogram from the C++ joint search plus a structured
+  per-pair failure taxonomy, and the rescue path replaces the opaque `FAILED
+  (no output produced)` line with a concrete reason (blocked-by-non-rippable-
+  copper, no-legal-escape, budget-exhausted, clearance-infidelity, CLI-refused)
+  plus a grid-fidelity report naming too-narrow lanes (#4459, #4469).
+
+- **Shared pipeline gate for board recipes** —
+  `recipes.gate.evaluate_pipeline_gate()` returns one verdict from which every
+  board recipe derives **both** its printed SUMMARY and its exit code, so the
+  two can no longer disagree. The authoritative DRC leg is `kicad-cli pcb drc
+  --refill-zones` (`kct check --drc-only` trusts stale zone fills), unioned
+  with a supplemental verdict for the kct-internal rule families (#3912).
+
+- **`project.kct` precondition for mutating recipes** —
+  `recipes.precondition.require_spec()` asserts a board carries captured intent
+  (a `project.kct` that exists, is non-empty, and parses) before a recipe
+  mutates anything. Advisory and fail-soft by default, read-only w.r.t. the
+  `.kct`; `KCT_REQUIRE_SPEC=1` escalates to full semantic validation (#4539).
 
 - **`silk_overlap` DRC rule** — `kct check --only silkscreen` now detects
   silkscreen printed on top of other silkscreen, closing a gap where an entire
@@ -56,6 +207,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`kct check` splits its report into manufacturing and advisory buckets** —
+  a rule-to-category taxonomy renders a CATEGORY SUMMARY with "Manufacturing
+  DRC: N blocking" and "Advisory/quality: M advisory", so routing-intent
+  findings (connectivity, diff-pair skew and continuity, `copper_sliver`,
+  ampacity, silkscreen) no longer inflate an undifferentiated "N DRC
+  violations" count that reads as N fab-blocking defects even when `kicad-cli`
+  reports 0. Presentation only: counts, verdict, exit code, and the gating
+  advisory-rule set are unchanged (#3803).
+
+- **`copper_sliver` detection now matches KiCad's algorithm** — the native
+  component-wise tiny-vertex traversal and sliver thresholds are ported, so a
+  sub-0.0008 mm numerical kink beside an acute tip no longer hides a sliver
+  `kicad-cli` reports. Two shapely-union artifacts KiCad's integer-nm poly-set
+  union never creates are also suppressed (a low-height union seam, and a
+  keyhole pinch at a shared ring coordinate). **User-visible: board 06 goes 2
+  markers → 0**, matching `kicad-cli`; 00–05 and 07 stay clean (#4497, #4521).
+
+- **Negotiated routing bails out of terminal stalls** — when a rip-up round
+  makes zero progress and every remaining stuck net is confidently *not*
+  budget-starved, the loop breaks to PARTIAL instead of escalating the rip-up
+  radius through the full iteration budget; more iterations cannot help such a
+  set by construction (board 07 previously spent ~13 of ~14 minutes on this
+  plateau). Default on, with the old behavior bisectable (#4406).
+
 - **`silk_over_copper` now counts one violation per (silk item, mask aperture)
   pair**, matching `kicad-cli pcb drc`. Previously it de-duplicated to one
   violation per silk element. **User-visible: reported `silk_over_copper`
@@ -69,6 +244,181 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pad 28`; the real set is pads 27, 28, 29, 30) (#4612).
 
 ### Fixed
+
+- **KiCad-10 name-based net references were invisible to four copper
+  scanners.** On a board whose segments and vias name their net (`(net "GND")`)
+  instead of numbering it, the `--preserve-existing` parser returned an empty
+  set and the dialect-blind strip pass then deleted *all* existing copper — so
+  `--preserve-existing` / `--nets` / `--region` silently destroyed a fully
+  routed board. The `strip_traces` net filter, the stranded-stub strip, the
+  conflicting-via scan, and the 45° quantizer were likewise no-ops. All now
+  resolve both dialects through one shared helper, copper kct adds re-emits the
+  board's own dialect, and a guard aborts a write retaining under 10% of a
+  board's copper (#4413, #4414, #4416, #4529).
+
+- **`kct spec decide` destroyed the rest of the `.kct` file.** It was a
+  load → model → dump → overwrite cycle over models with pydantic's default
+  `extra="ignore"`, so every key the schema does not define was dropped at load
+  and deleted on write. One invocation on a copy of
+  `boards/00-simple-led/project.kct` exited 0, printed "Decision recorded", and
+  took the file from 88 lines to 74. Unknown keys now survive `model_dump` for
+  every `save_spec` caller, and `decide` splices the new entry into the
+  existing `decisions:` sequence textually, re-parsing and comparing the result
+  before committing it (#4538).
+
+- **LVS reported false shorts from per-pad unnamed-net naming.** An unnamed
+  net's auto-generated name was derived from the *queried pin*, so a k-pad
+  unnamed net splintered into k identities and was reported as C(k, 2) shorts
+  inside the one copper component that legitimately joined them. A single
+  10-pad net accounted for 45 of 50 false shorts on copper `kicad-cli pcb drc`
+  found clean. Auto-names now pick a deterministic canonical representative per
+  connected component (also making them stable across runs), and board LVS
+  compares pad partitions, not strings, when both sides carry one (#4615).
+
+- **Export manifests were keyed by bare filename.** Every artifact in a
+  subdirectory (`gerbers/`, `images/`, `vN/`) was recorded under a key that
+  does not resolve from the manifest's own directory: **70 of 118 keys across
+  the eight committed bundles failed the obvious `bundle_dir / key` walk**, and
+  same-named artifacts in different subdirectories overwrote each other. Keys
+  are now bundle-relative POSIX paths, with the legacy fallback retained so
+  committed manifests keep verifying. Separately, `kct export --mfr
+  jlcpcb-tier1` recorded a false `bom_cpl_match` FAIL because preflight
+  compared the raw tier id against an exact-match `{"jlcpcb"}` set while the
+  CPL writer resolved the fab *family*; preflight now resolves the family once,
+  and `bom_fields` is reconciled against `--auto-lcsc` (#4590, #4591).
+
+- **3D bodies rendered rotated away from their copper.** The model inserter
+  compensated translation only and always wrote an identity rotation, so a
+  footprint whose rotation is baked into its pad coordinates rather than its
+  placement angle rendered a quarter turn off. Orientation is now derived from
+  an anchor-pad vector on both footprints and baked into the model node, with
+  the centroid offset composed in the rotated frame. A sign error in that bake
+  (`rz - θ`, where KiCad's render-time negation makes `rz + θ` correct)
+  additionally threw board 07's 9-pin header 20.32 mm off the board edge.
+  Co-oriented footprints compute θ ≈ 0 and are byte-identical (#4448, #4583).
+
+- **Routing was nondeterministic from a dangling C++ grid reference.** The
+  nanobind pathfinder constructors stored the incoming `Grid3D` as a bare C++
+  reference with no keep-alive policy, so in the common
+  `Pathfinder(Grid3D(...), rules).route(...)` idiom the grid was freed as soon
+  as the factory returned and the A* then read freed heap (AddressSanitizer
+  pins it at `grid_.at()`). The symptom was run-to-run variation in segment
+  counts on identical input (#4485).
+
+- **Net-class clearances were dropped on three independent paths.** The
+  post-route sidecar writer hard-coded `<output_dir>/net_class_map.json` and
+  wrote unconditionally, so routing into the directory holding the user's
+  hand-authored map silently clobbered it — the derived map now diverts to
+  `net_class_map.effective.json` on a collision, and the user's map is merged
+  over the classifier output. Hand-authored KiCad layer names (`"In1.Cu"`) in
+  `preferred_layers` / `avoid_layers` either killed detailed routing with
+  `invalid literal for int()` or silently never matched; they now normalize to
+  grid indices against the board's own layer stack. And the lattice pathfinder
+  seeded every `--preserve-existing` obstacle at the DRU floor, spacing new
+  copper 0.166 mm from an HV net the map put at 2.0–3.2 mm (#4428, #4587, #4597).
+
+- **Creepage safety and table correctness.** A high-|V| net whose routing class
+  was not HV (a 150 V gate-drive net classed Digital) never entered the HV
+  census — a safety-gate false pass — now closed by unioning voltage-mapped
+  nets into census membership behind a new `--census-threshold` (default 30 V).
+  The IEC 60664-1 Table F.4 transcription started at the 50 V row, so every
+  working voltage ≤ 50 V mapped to 1.2 mm at PD2/IIIa — a floor no dense-board
+  adjacent-pad gap can meet, making the gate unpassable; the seven missing
+  sub-50 V rows from EN 60664-1:2007 are transcribed, dropping the floor to
+  0.40 mm (IEC 62368-1 Table 17 shares the table and is fixed too). And
+  `kct optimize-placement --voltage-map` rejected the `_`-prefixed reserved
+  keys the creepage loader skips; it now delegates to that one parser
+  (#4401, #4402, #4404).
+
+- **Connectivity analysis reported false opens and dangling vias.**
+  `kct net-status` split a cross-layer path (`pad → F.Cu → through-via →
+  In2.Cu → through-via → F.Cu → pad`) into per-layer components and reported a
+  false `incomplete`; pads are now fused across every via that spans the
+  relevant layers, with a blind/buried via declining to fuse a layer it cannot
+  reach. `kct stitch` decided via placement against the zone *outline* rather
+  than the refilled copper, so a via dropped where the pour had retreated had
+  nothing to bond to and KiCad reported it dangling; all three modes now gate on
+  same-net fill containment (#4429, #4432).
+
+- **Writer and mutation fidelity.** `kct zones hv-keepout` emitted its
+  disposition tokens as quoted strings, which KiCad 10 rejects as a hard parse
+  error, making the written board unloadable; they now serialize as bare
+  symbols. And rotating a footprint through the recovery applicator bumped only
+  the footprint angle, leaving every pad's absolute angle stale on
+  serialization — the phantom-short / wrong-gerber-aperture defect class for
+  chamfered-roundrect, trapezoid, and custom pads. Schema `Pad` objects are now
+  linked to their S-exp nodes, so `pad.rotation` round-trips (#4430, #4518).
+
+- **`kct sch fix-annotation` left cross-sheet duplicate power references in
+  place.** Canonicality was judged one symbol at a time, so two symbols on
+  different sheets both holding a canonical `#PWR40` were each skipped and the
+  error survived the repair. Uniqueness is now enforced project-wide across the
+  flattened hierarchy, first-occurrence-wins. Power nodes are also excluded from
+  the net-neutrality gate's snapshot — their designators are electrically
+  meaningless, and including them aborted an otherwise neutral repair (#4415).
+
+- **CLI plumbing defects.** The outer `kct route` parser declared
+  `--auto-layers` with `default=True`, collapsing "the user typed it" and "the
+  user typed nothing", so an explicit `--auto-layers` never reached the inner
+  command — `--complete` disabled auto-layers while printing "pass
+  `--auto-layers` to override". The flag is now tri-state. `kct explain` picked
+  `spec_references[0]`, so which manufacturer's YAML won a shared `rule_id`
+  depended on glob order; references are now merged per rule id and
+  `explain(context={"manufacturer": ...})` resolves deterministically
+  (#4491, #4502).
+
+- **`kct build-native` could contradict `--check` seconds later.** Post-build
+  verification ran in the process that had just done the build, which cannot
+  observe a replaced C extension: once `router_cpp.*.so` is dlopen'd, CPython's
+  runtime extension cache survives `sys.modules.pop` and `importlib.reload`, so
+  the probe described the *pre*-build extension — both a false "not loading
+  correctly" and a false "installed successfully!" were reproduced.
+  Verification now runs in a fresh interpreter. Separately, nanobind and the
+  scikit-build-core/cmake/ninja chain moved into the default `dev` group and
+  the `all` extra, so an unrelated `uv sync` cannot prune them (#4412, #4589).
+
+- **Misleading diagnostics.** An LCSC no-match search leaked
+  `(J1) ('NoneType' object is not iterable)` into the BOM-enrichment summary,
+  because the live JLCPCB API returns `"list": null` and `dict.get(key,
+  default)` substitutes only when the key is *absent*; it now reports a clean
+  "no matching parts found". And the auto-grid "may produce clearance violations
+  at fine-pitch pads" warning fired on a predicate omitting the fine-pitch term
+  its own text claims, so DRC-clean boards without fine-pitch pads were told
+  they were at risk (#3942, #4407).
+
+- **Rescue and mid-session C++ router state.** A per-net rescue subprocess had
+  been exiting 1 before routing anything since the auto-grid safety gate
+  landed, because the rescue command never forwarded an `--allow-unsafe-grid`
+  equivalent — bogus `no_output` failures for 8 of 8 nets; the refusal is now
+  classified `CLI_REFUSED` rather than a fabricated "crash / OOM" diagnosis.
+  And the C++ pairwise domain matrix was never re-pushed after a mid-session
+  net-map or attach-zone change, because the install was gated on a flag that
+  latches true on first install: remapped net ids reported 0.0 required
+  clearance while stale ids kept phantom widening (#4528, #4530).
+
+- **Diff-pair shadow constructor — copper legality** (opt-in, default off).
+  Constructed copper was validated against the routing grid raster only, whose
+  pad halo is deliberately shrunk in fine-pitch corridors on the promise that
+  full clearance is checked in post-routing DRC — a promise never kept for
+  diff-pair nets, which the nudge backstop skips. Exact, DRC-equivalent pad-
+  and via-clearance predicates now apply everywhere the constructor accepts
+  copper, tail candidates are ordered by how much of their length runs *coupled*
+  to the partner, and crossing-tail via sites are scored by how deeply they
+  intrude on other nets' escape channels (#4571, #4572, #4574, #4575).
+
+- **Diff-pair shadow constructor — geometry and length symmetry** (opt-in,
+  default off). Inside-bend corners folded the parallel offset across the guide
+  centerline, and sub-grid-cell steps between impedance-band rungs left
+  polyline breaks invisible to every per-segment gate but fatal to the pair —
+  a finished, length-matched pair read "1/2 pads reached" and was ripped
+  wholesale. Corner joins now mitre concave bends and bevel sub-cell steps, and
+  the assembled chain enforces the no-gap invariant. The guide is compressed
+  with a deviation-bounded 45°-legal simplifier before offsetting, the pair is
+  meander-matched at construction time, and the legs are gated on a
+  thickness-free via signature so a 0.012 mm planar match cannot ship a 3.19 mm
+  electrical skew. Rescue tails are partner-aware, and the negotiated loop stops
+  at a stranded fixed point instead of re-deriving the same failure to its
+  ceiling (#4460, #4462, #4463, #4553, #4570, #4577).
 
 - **`--net-class-map` was silently inert on every composition step.** On a
   filtered routing pass (`--nets` / `--skip-nets`, and the `--region` /

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,10 +5,11 @@ for every release. It exists to keep releases consistent with `main` branch
 protection: every commit reaches `main` through a pull request, including the
 version-bump commit.
 
-> **TL;DR** — Branch → bump commit + CHANGELOG → PR → auto-merge → `git fetch`
-> → annotated tag on the **merged `main` SHA** → push the tag. The tag is
-> created **only after** the bump commit is on `main`. Never push the
-> version-bump commit directly to `main`.
+> **TL;DR** — Reconcile the CHANGELOG (`scripts/changelog_gap_report.py`) →
+> branch → bump commit + CHANGELOG → PR → auto-merge → `git fetch` → annotated
+> tag on the **merged `main` SHA** → push the tag. The tag is created **only
+> after** the bump commit is on `main`. Never push the version-bump commit
+> directly to `main`.
 
 ## Why PR-based (not a direct push)
 
@@ -46,6 +47,35 @@ uniform rule.
 ## The release sequence
 
 Let `X.Y.Z` be the new version.
+
+### (0) Reconcile `CHANGELOG.md` against `git log <last-tag>..main`
+
+**Do this before the bump commit, not during it.** Nothing forces a CHANGELOG
+entry at PR time, so `[Unreleased]` drifts silently: between `v0.19.0` and
+2026-08-05 it documented 6 of 87 user-visible commits (#4638). Reconstructing
+two weeks of history *while* cutting a release is how a permanently wrong
+changelog ships — the tag is irrevocable once `publish.yml` uploads to PyPI.
+
+Run the gap report; it exits non-zero and names every undocumented issue:
+
+```bash
+uv run python scripts/changelog_gap_report.py            # since the latest v* tag
+uv run python scripts/changelog_gap_report.py --since v0.19.0 --json
+```
+
+The script walks `git log <tag>..HEAD`, resolves each commit to the **issue**
+number it addresses (closing keyword → `feature/issue-<N>` branch name →
+`Part of #N`), classifies user-visible vs. internal from the conventional-commit
+subject prefix, and prints the user-visible issues that `[Unreleased]` does not
+cite. Close every gap it reports — by writing a thematic `[Unreleased]` bullet,
+or, for a commit that changes nothing a package consumer observes, by adding an
+entry with its rationale to `INTERNAL_ISSUES` / `INTERNAL_COMMITS` in the
+script. **Do not** rename `[Unreleased]` to `[X.Y.Z]` yet; that happens in (a).
+
+> Note the trailing `(#NNNN)` in a squash-merge subject is the **PR** number.
+> CHANGELOG entries cite **issue** numbers — do not read them off subjects.
+
+A clean run ends with `RESULT: gap set is empty` and exit 0. Only then proceed.
 
 ### (a) Create a release branch with the bump commit
 
@@ -150,6 +180,8 @@ the merge — load-bearing.
 
 ## Quick checklist
 
+- [ ] `uv run python scripts/changelog_gap_report.py` exits 0 with an empty gap
+      set (step (0)) — run this *before* the bump commit.
 - [ ] Version bumped in `pyproject.toml`; `uv.lock` regenerated to match.
 - [ ] CHANGELOG entry added for `X.Y.Z`.
 - [ ] Confirmed `pyproject.toml` is authoritative (ignore the `package.json`

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -416,11 +416,19 @@ def main(argv: list[str] | None = None) -> int:
 
 ## Release Process
 
-1. Update version in `src/kicad_tools/__init__.py`
-2. Update `CHANGELOG.md`
-3. Create a git tag: `git tag v0.X.0`
-4. Push tag: `git push origin v0.X.0`
-5. GitHub Actions builds and publishes to PyPI
+**[`RELEASING.md`](../../RELEASING.md) is the canonical process — follow it, not
+this summary.** Releases are PR-based: the version-bump commit reaches `main`
+through a pull request, and the `vX.Y.Z` tag is created only afterwards, on the
+merged `main` SHA.
+
+1. Reconcile `CHANGELOG.md` against `git log <last-tag>..main` —
+   `uv run python scripts/changelog_gap_report.py` must exit 0 with an empty gap
+   set (`RELEASING.md` step (0))
+2. Bump the version in `pyproject.toml` (the source of truth) and regenerate
+   `uv.lock`, on a `release/vX.Y.Z` branch
+3. Open a PR and merge it via `./.loom/scripts/merge-pr.sh <PR>`
+4. Tag the **merged `main` SHA**: `git tag -a vX.Y.Z -m "Release X.Y.Z"`
+5. Push the tag — GitHub Actions builds the tagged commit and publishes to PyPI
 
 ---
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,6 +14,7 @@ Python helpers with `uv run python scripts/<name>.py`, from the repository root.
 | `deploy-site.sh` | Manual one-command deploy of the kicad-tools.org demo gallery to Cloudflare Pages (via a locally authenticated `wrangler`). |
 | `install-kct.sh` | Install kicad-tools into a consumer PCB-design repo (uv dependency + vendored `.claude/commands/kct/` skills and `ci/` gate scripts). |
 | `calibrate_area_estimate.py` | Calibration helper for the sum-of-clearances board-area estimator (#3403). |
+| `changelog_gap_report.py` | Release gate: list user-visible commits since a `v*` tag whose issue number is not cited in the CHANGELOG's `[Unreleased]` section; exits non-zero when the gap set is non-empty. Invoked by `RELEASING.md` step (0) (#4638). |
 | `check_trace_vs_zone_fills.py` | Verify track segments against foreign-net zone fill copper (clearance/short check DRC cannot yet do; #3527). |
 | `diagnose_b03_diffpair.py` | Diagnostic for why the differential-pair pre-pass fails on board 03 (#2490). |
 | `route_chorus.py` | Canonical chorus-test-revA routing recipe runner with partial-net rescue (#3474). |

--- a/scripts/changelog_gap_report.py
+++ b/scripts/changelog_gap_report.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+"""Report user-visible commits since a release tag that no CHANGELOG entry cites.
+
+Motivation (issue #4638): between ``v0.19.0`` (2026-07-20) and 2026-08-05 the
+``[Unreleased]`` section documented 6 of 87 user-visible commits.  Nothing
+surfaced the drift, so it was only discoverable by hand-walking two weeks of
+``git log``.  This script turns that walk into one command, so the
+CHANGELOG-reconciliation step in ``RELEASING.md`` is mechanical rather than
+archaeological.
+
+What it does
+------------
+1. Walks ``git log <tag>..<head>``.
+2. Resolves each commit to the **issue** number(s) it addresses, using a
+   three-tier recipe (see :func:`resolve_issue_numbers`).
+3. Classifies each commit user-visible vs. internal from its conventional-commit
+   subject prefix.
+4. Prints the user-visible issue numbers that are **not** mentioned anywhere in
+   the CHANGELOG's ``[Unreleased]`` section, and exits non-zero if that set is
+   non-empty.
+
+Note that the trailing ``(#NNNN)`` in a squash-merge subject is the **PR**
+number, never the issue number -- the CHANGELOG convention in this repo is to
+cite issues.  That is exactly why this script exists rather than a one-line
+grep.
+
+Usage
+-----
+    uv run python scripts/changelog_gap_report.py                # since latest v* tag
+    uv run python scripts/changelog_gap_report.py --since v0.19.0
+    uv run python scripts/changelog_gap_report.py --json
+    uv run python scripts/changelog_gap_report.py --offline      # no gh API calls
+
+`--offline` is lossy: without the tier-2 branch lookup, a commit whose body
+carries only a `Part of #<epic>` trailer resolves to the epic rather than to its
+own issue, so it can report a spurious gap. Prefer the default (networked) mode
+when gating a release.
+
+Exit codes
+----------
+    0 -- no gaps (or no commits since the tag).
+    1 -- one or more user-visible issues are undocumented.
+    2 -- usage / environment error (bad tag, missing CHANGELOG, git failure).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# --- classification ---------------------------------------------------------
+
+#: Conventional-commit types whose changes never reach a package consumer.
+INTERNAL_TYPES = frozenset(
+    {
+        "bench",
+        "build",
+        "chore",
+        "ci",
+        "config",
+        "docs",
+        "refactor",
+        "revert",
+        "style",
+        "test",
+        "tests",
+    }
+)
+
+_CONVENTIONAL_SUBJECT = re.compile(r"^(?P<type>[a-z]+)(?:\([^)]*\))?!?:")
+
+#: Issues whose commits carry a user-visible-looking subject but change nothing a
+#: package consumer can observe.  This is the auditable ledger backing the
+#: "classified internal" half of #4638's acceptance criteria -- add an entry (with
+#: the rationale) rather than padding the CHANGELOG with a non-user-visible bullet.
+INTERNAL_ISSUES: dict[int, str] = {
+    4479: "board-05 CI closeout: AST guard test + CI blocking bound, no shipped surface",
+}
+
+#: Commits (by SHA prefix) that carry a user-visible-looking subject, resolve to no
+#: issue at all, and are repo tooling rather than product.  Keyed by SHA because
+#: there is no issue number to key on.
+INTERNAL_COMMITS: dict[str, str] = {
+    "fcbe6660": "Claude Code permission-rule fix in .claude/settings.json",
+    "09f0545c": "Loom 0.18.0 orchestration resync",
+}
+
+
+# --- issue-number resolution ------------------------------------------------
+
+#: GitHub closing keywords.  Anchored to the start of a line so prose such as
+#: "...resolve #4506 attach zones in sheet-absolute space" is not mistaken for a
+#: closing reference (that exact sentence misattributes commit 771caf16).
+_CLOSING_REF = re.compile(
+    r"^[ \t]*[-*]?[ \t]*(?:close[sd]?|fixe[sd]?|fix|resolve[sd]?)[ \t:]+#(\d+)\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+#: Non-closing references ("Part of #N") -- used only when nothing better exists,
+#: since they usually name an epic rather than the commit's own issue.
+_PARTIAL_REF = re.compile(
+    r"^[ \t]*[-*]?[ \t]*(?:part of|contributes to)[ \t:]+#(\d+)\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+#: Trailing "(#NNNN)" in a squash-merge subject -- the PR number.
+_PR_IN_SUBJECT = re.compile(r"\(#(\d+)\)\s*$")
+
+#: Loom builders always branch ``feature/issue-<N>``.
+_ISSUE_IN_BRANCH = re.compile(r"issue-(\d+)")
+
+
+@dataclass
+class Commit:
+    """One commit in the range under review."""
+
+    sha: str
+    subject: str
+    body: str
+    issues: list[int] = field(default_factory=list)
+    tier: str = "none"
+
+    @property
+    def short_sha(self) -> str:
+        return self.sha[:8]
+
+    @property
+    def is_internal(self) -> bool:
+        match = _CONVENTIONAL_SUBJECT.match(self.subject)
+        if match is None:
+            # Non-conventional subjects ("route/complete Phase 3: ...",
+            # "board-05 Phase 3: ...") are real feature work often enough that the
+            # safe default is user-visible; the override ledgers demote the rest.
+            return False
+        return match.group("type") in INTERNAL_TYPES
+
+    @property
+    def pr_number(self) -> int | None:
+        match = _PR_IN_SUBJECT.search(self.subject)
+        return int(match.group(1)) if match else None
+
+
+class _BranchResolver:
+    """Tier-2 resolver: read the issue number out of a merged PR's branch name."""
+
+    def __init__(self, repo: str | None, offline: bool) -> None:
+        self._repo = repo
+        self._offline = offline
+        self._cache: dict[int, int | None] = {}
+        self.warned = False
+
+    def issue_for_pr(self, pr_number: int) -> int | None:
+        if self._offline or not self._repo:
+            return None
+        if pr_number in self._cache:
+            return self._cache[pr_number]
+        result = _run(
+            ["gh", "api", f"repos/{self._repo}/pulls/{pr_number}", "--jq", ".head.ref"],
+            check=False,
+        )
+        issue: int | None = None
+        if result is not None:
+            match = _ISSUE_IN_BRANCH.search(result.strip())
+            if match:
+                issue = int(match.group(1))
+        elif not self.warned:
+            self.warned = True
+            print(
+                "warning: `gh api` lookups failed; tier-2 (branch-name) resolution is "
+                "unavailable, so some commits may report as unattributed",
+                file=sys.stderr,
+            )
+        self._cache[pr_number] = issue
+        return issue
+
+
+def resolve_issue_numbers(commit: Commit, resolver: _BranchResolver) -> tuple[list[int], str]:
+    """Resolve one commit to the issue number(s) it addresses.
+
+    Three tiers, most authoritative first:
+
+    1. ``closing`` -- a ``Closes/Fixes/Resolves #N`` line in the commit body.
+    2. ``branch`` -- the merged PR's ``feature/issue-<N>`` head branch.
+    3. ``partial`` -- a ``Part of #N`` line (usually an epic, so it is the last
+       resort rather than the first).
+
+    Returns ``([], "none")`` when nothing resolves -- e.g. a direct-to-main chore
+    commit with no PR.
+    """
+    closing = sorted({int(n) for n in _CLOSING_REF.findall(commit.body)})
+    if closing:
+        return closing, "closing"
+
+    pr_number = commit.pr_number
+    if pr_number is not None:
+        issue = resolver.issue_for_pr(pr_number)
+        if issue is not None:
+            return [issue], "branch"
+
+    partial = sorted({int(n) for n in _PARTIAL_REF.findall(commit.body)})
+    if partial:
+        return partial, "partial"
+
+    return [], "none"
+
+
+# --- git / changelog plumbing ----------------------------------------------
+
+
+def _run(cmd: list[str], check: bool = True) -> str | None:
+    """Run ``cmd`` in the repo root, returning stdout (or ``None`` on failure)."""
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        if check:
+            raise
+        return None
+    if proc.returncode != 0:
+        if check:
+            raise RuntimeError(f"{' '.join(cmd)} failed: {proc.stderr.strip()}")
+        return None
+    return proc.stdout
+
+
+def latest_release_tag() -> str | None:
+    """Return the most recent ``v*`` tag reachable from HEAD, if any."""
+    out = _run(["git", "describe", "--tags", "--abbrev=0", "--match", "v*"], check=False)
+    return out.strip() if out and out.strip() else None
+
+
+def default_repo_slug() -> str | None:
+    """Derive ``owner/name`` from the ``origin`` remote, for ``gh api`` calls."""
+    out = _run(["git", "remote", "get-url", "origin"], check=False)
+    if not out:
+        return None
+    match = re.search(r"[:/]([^/:]+/[^/]+?)(?:\.git)?\s*$", out.strip())
+    return match.group(1) if match else None
+
+
+def read_commits(since: str, head: str) -> list[Commit]:
+    """Return the commits in ``since..head``, oldest first."""
+    out = _run(["git", "log", "--reverse", "--format=%x00%H%x01%s%x01%b", f"{since}..{head}"])
+    assert out is not None
+    commits: list[Commit] = []
+    for record in out.split("\x00"):
+        if not record.strip():
+            continue
+        sha, subject, body = record.split("\x01", 2)
+        commits.append(Commit(sha=sha.strip(), subject=subject.strip(), body=body))
+    return commits
+
+
+def extract_section(changelog_text: str, section: str) -> str:
+    """Return the body of the ``## [<section>]`` block, exclusive of later blocks.
+
+    An issue cited only in an *older* release section must not count as
+    documented, which is why this slices rather than searching the whole file.
+    """
+    heading = re.compile(rf"^##\s*\[{re.escape(section)}\]", re.IGNORECASE | re.MULTILINE)
+    match = heading.search(changelog_text)
+    if match is None:
+        return ""
+    rest = changelog_text[match.end() :]
+    next_heading = re.search(r"^##\s", rest, re.MULTILINE)
+    return rest[: next_heading.start()] if next_heading else rest
+
+
+def documented_issue_numbers(section_text: str) -> set[int]:
+    """Every ``#N`` mentioned in a CHANGELOG section."""
+    return {int(n) for n in re.findall(r"#(\d+)\b", section_text)}
+
+
+# --- report -----------------------------------------------------------------
+
+
+@dataclass
+class Report:
+    """The outcome of one reconciliation pass."""
+
+    since: str
+    head: str
+    total_commits: int
+    user_visible_commits: int
+    internal_commits: int
+    documented: list[int]
+    gaps: list[int]
+    gap_subjects: dict[int, list[str]]
+    unattributed: list[str]
+    overridden: list[int]
+
+    @property
+    def ok(self) -> bool:
+        return not self.gaps
+
+
+def build_report(
+    since: str,
+    head: str,
+    changelog_path: Path,
+    section: str,
+    resolver: _BranchResolver,
+) -> Report:
+    commits = read_commits(since, head)
+    section_text = extract_section(changelog_path.read_text(encoding="utf-8"), section)
+    documented = documented_issue_numbers(section_text)
+
+    user_visible = 0
+    internal = 0
+    candidates: dict[int, list[str]] = {}
+    unattributed: list[str] = []
+
+    for commit in commits:
+        commit.issues, commit.tier = resolve_issue_numbers(commit, resolver)
+        if commit.is_internal or commit.short_sha in INTERNAL_COMMITS:
+            internal += 1
+            continue
+        user_visible += 1
+        if not commit.issues:
+            unattributed.append(f"{commit.short_sha} {commit.subject}")
+            continue
+        for issue in commit.issues:
+            candidates.setdefault(issue, []).append(f"{commit.short_sha} {commit.subject}")
+
+    overridden = sorted(i for i in candidates if i in INTERNAL_ISSUES)
+    gaps = sorted(i for i in candidates if i not in documented and i not in INTERNAL_ISSUES)
+
+    return Report(
+        since=since,
+        head=head,
+        total_commits=len(commits),
+        user_visible_commits=user_visible,
+        internal_commits=internal,
+        documented=sorted(documented),
+        gaps=gaps,
+        gap_subjects={i: candidates[i] for i in gaps},
+        unattributed=unattributed,
+        overridden=overridden,
+    )
+
+
+def render_text(report: Report) -> str:
+    lines = [
+        f"CHANGELOG gap report: {report.since}..{report.head}",
+        f"  commits:       {report.total_commits} "
+        f"({report.user_visible_commits} user-visible, {report.internal_commits} internal)",
+        f"  documented:    {len(report.documented)} issue reference(s) in [Unreleased]",
+        f"  gaps:          {len(report.gaps)}",
+    ]
+    if report.gaps:
+        lines.append("")
+        lines.append("Undocumented user-visible issues:")
+        for issue in report.gaps:
+            lines.append(f"  #{issue}")
+            for subject in report.gap_subjects[issue]:
+                lines.append(f"      {subject}")
+    if report.overridden:
+        lines.append("")
+        lines.append(
+            "Classified internal via INTERNAL_ISSUES: "
+            + ", ".join(f"#{i}" for i in report.overridden)
+        )
+    if report.unattributed:
+        lines.append("")
+        lines.append("Unattributed user-visible commits (no issue to cite -- advisory only):")
+        lines.extend(f"  {entry}" for entry in report.unattributed)
+    lines.append("")
+    lines.append(
+        "RESULT: gap set is empty"
+        if report.ok
+        else f"RESULT: {len(report.gaps)} undocumented issue(s) -- update CHANGELOG [Unreleased]"
+    )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Report user-visible commits since a release tag with no CHANGELOG entry.",
+    )
+    parser.add_argument(
+        "--since",
+        metavar="TAG",
+        help="release tag to diff against (default: most recent v* tag reachable from HEAD)",
+    )
+    parser.add_argument("--head", default="HEAD", metavar="REF", help="end of the range")
+    parser.add_argument(
+        "--changelog",
+        type=Path,
+        default=REPO_ROOT / "CHANGELOG.md",
+        help="path to CHANGELOG.md",
+    )
+    parser.add_argument(
+        "--section",
+        default="Unreleased",
+        help="CHANGELOG section that must cite the issues (default: Unreleased)",
+    )
+    parser.add_argument("--repo", help="OWNER/NAME for gh API calls (default: from origin remote)")
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="skip tier-2 (PR branch name) resolution instead of calling the gh API; "
+        "lossy, may report spurious gaps for Part-of-only commits",
+    )
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    args = parser.parse_args(argv)
+
+    since = args.since or latest_release_tag()
+    if not since:
+        print("error: no v* tag found; pass --since <tag>", file=sys.stderr)
+        return 2
+    if not args.changelog.is_file():
+        print(f"error: no such CHANGELOG: {args.changelog}", file=sys.stderr)
+        return 2
+
+    resolver = _BranchResolver(args.repo or default_repo_slug(), args.offline)
+    try:
+        report = build_report(since, args.head, args.changelog, args.section, resolver)
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "since": report.since,
+                    "head": report.head,
+                    "total_commits": report.total_commits,
+                    "user_visible_commits": report.user_visible_commits,
+                    "internal_commits": report.internal_commits,
+                    "gaps": report.gaps,
+                    "gap_subjects": report.gap_subjects,
+                    "overridden": report.overridden,
+                    "unattributed": report.unattributed,
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(render_text(report))
+
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_changelog_gap_report.py
+++ b/tests/test_changelog_gap_report.py
@@ -1,0 +1,195 @@
+"""Tests for the CHANGELOG reconciliation gate (issue #4638).
+
+``scripts/changelog_gap_report.py`` backs `RELEASING.md` step (0): it walks
+``git log <tag>..HEAD``, resolves each commit to the **issue** number it
+addresses, classifies user-visible vs. internal, and reports the user-visible
+issues the ``[Unreleased]`` section does not cite.
+
+These tests exercise the pure parsing/classification helpers against synthetic
+inputs -- no git range, no network, no ``gh`` calls. The three resolution tiers
+and the changelog-section slice are the parts that can silently mis-report a
+gap, which is why they are pinned here rather than left to a manual run.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HELPER_SCRIPT_PATH = REPO_ROOT / "scripts" / "changelog_gap_report.py"
+
+
+def _load_helper_module():
+    """Import ``scripts/changelog_gap_report.py`` as a module."""
+    spec = importlib.util.spec_from_file_location("changelog_gap_report", HELPER_SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["changelog_gap_report"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+gap_report = _load_helper_module()
+
+
+class _StubResolver:
+    """Tier-2 stand-in: a fixed PR -> issue map, with a call counter."""
+
+    def __init__(self, mapping: dict[int, int] | None = None) -> None:
+        self.mapping = mapping or {}
+        self.calls: list[int] = []
+
+    def issue_for_pr(self, pr_number: int) -> int | None:
+        self.calls.append(pr_number)
+        return self.mapping.get(pr_number)
+
+
+def _commit(subject: str, body: str = "") -> object:
+    return gap_report.Commit(sha="0123456789abcdef", subject=subject, body=body)
+
+
+# --- tier 1: closing keywords ----------------------------------------------
+
+
+def test_tier1_closing_keyword_resolves_the_issue() -> None:
+    commit = _commit("fix(router): x (#4440)", "Some prose.\n\nCloses #4413\n")
+    issues, tier = gap_report.resolve_issue_numbers(commit, _StubResolver())
+    assert (issues, tier) == ([4413], "closing")
+
+
+def test_tier1_handles_multiple_closing_keywords_as_a_set() -> None:
+    commit = _commit("feat: x (#1)", "Closes #100\nFixes #100\nResolves #101\n")
+    issues, tier = gap_report.resolve_issue_numbers(commit, _StubResolver())
+    assert (issues, tier) == ([100, 101], "closing")
+
+
+def test_prose_mentioning_resolve_is_not_a_closing_reference() -> None:
+    """Line-anchoring guards the real misattribution of commit 771caf16.
+
+    Its body contains "* fix(route): resolve #4506 attach zones in
+    sheet-absolute space", which an unanchored keyword regex reads as a closing
+    reference to #4506 -- the wrong issue (the commit closes #4588).
+    """
+    body = (
+        "Close the hole with a post-route audit.\n"
+        "\n"
+        "The gate would otherwise fire on every #4506-exempt rated connector,\n"
+        "so we resolve #4506 attach zones in sheet-absolute space.\n"
+    )
+    commit = _commit("feat(route): gate every engine (#4603)", body)
+    resolver = _StubResolver({4603: 4588})
+    issues, tier = gap_report.resolve_issue_numbers(commit, resolver)
+    assert (issues, tier) == ([4588], "branch")
+
+
+# --- tier 2: PR branch name -------------------------------------------------
+
+
+def test_tier2_uses_the_pr_branch_when_no_closing_keyword() -> None:
+    commit = _commit("fix(export): key manifest files (#4608)", "No trailer here.\n")
+    resolver = _StubResolver({4608: 4590})
+    issues, tier = gap_report.resolve_issue_numbers(commit, resolver)
+    assert (issues, tier) == ([4590], "branch")
+    assert resolver.calls == [4608]
+
+
+def test_tier2_is_not_consulted_when_a_closing_keyword_exists() -> None:
+    commit = _commit("fix: x (#4608)", "Closes #4590\n")
+    resolver = _StubResolver({4608: 9999})
+    issues, _ = gap_report.resolve_issue_numbers(commit, resolver)
+    assert issues == [4590]
+    assert resolver.calls == []
+
+
+# --- tier 3: partial reference, then nothing --------------------------------
+
+
+def test_tier3_falls_back_to_part_of_when_nothing_better_exists() -> None:
+    commit = _commit("Wire the feedback loop (#4556)", "Part of #3438\n")
+    issues, tier = gap_report.resolve_issue_numbers(commit, _StubResolver())
+    assert (issues, tier) == ([3438], "partial")
+
+
+def test_a_commit_with_no_pr_and_no_issue_resolves_to_nothing() -> None:
+    """Edge case: a direct-to-main chore commit must classify, not crash."""
+    commit = _commit("chore: update loom installation to v0.16.0", "Refreshed surfaces.\n")
+    issues, tier = gap_report.resolve_issue_numbers(commit, _StubResolver())
+    assert (issues, tier) == ([], "none")
+
+
+# --- classification ---------------------------------------------------------
+
+
+def test_conventional_internal_prefixes_classify_internal() -> None:
+    for subject in (
+        "chore(loom): Install Loom 0.15.0 orchestration framework (#4495)",
+        "docs: add READMEs for benchmarks (#4618)",
+        "test: re-baseline board-07 match-group family delta (#4598)",
+        "ci: gate board end-to-end jobs on plane-net completion (#4535)",
+        "build(dev-env): pin local venv to Python 3.12 (#4452)",
+        "refactor(boards): migrate remaining 5 recipes (#4458)",
+    ):
+        assert _commit(subject).is_internal, subject
+
+
+def test_feat_fix_and_non_conventional_subjects_classify_user_visible() -> None:
+    for subject in (
+        "feat(check): general .kct_waivers.json waiver mechanism (#4445)",
+        "fix(lvs): derive unnamed-net names per component (#4625)",
+        "perf(router): speed up the A* loop (#1)",
+        "route/complete Phase 3: via-in-pad as tier-gated last resort (#4503)",
+        "board-05 Phase 3: Kelvin/current-sense topology model (#4499)",
+        "drc: align copper sliver detection with KiCad (#4517)",
+    ):
+        assert not _commit(subject).is_internal, subject
+
+
+def test_pr_number_comes_from_the_subject_suffix_only() -> None:
+    assert _commit("feat(diffpair): census (#4580) (#4611)").pr_number == 4611
+    assert _commit("chore: no pr here").pr_number is None
+
+
+# --- changelog section slicing ---------------------------------------------
+
+
+_CHANGELOG = """# Changelog
+
+## [Unreleased]
+
+### Added
+
+- **A new thing** (#111).
+
+### Fixed
+
+- **Another thing** (#222).
+
+## [0.19.0] - 2026-07-20
+
+### Added
+
+- **An old thing** (#333).
+
+## [0.18.0] - 2026-07-20
+
+- **Older still** (#444).
+"""
+
+
+def test_extract_section_stops_at_the_next_release_heading() -> None:
+    section = gap_report.extract_section(_CHANGELOG, "Unreleased")
+    assert "#111" in section and "#222" in section
+    assert "#333" not in section and "#444" not in section
+
+
+def test_an_issue_cited_only_in_an_older_section_is_not_documented() -> None:
+    documented = gap_report.documented_issue_numbers(
+        gap_report.extract_section(_CHANGELOG, "Unreleased")
+    )
+    assert documented == {111, 222}
+
+
+def test_extract_section_returns_empty_for_a_missing_section() -> None:
+    assert gap_report.extract_section(_CHANGELOG, "Nonexistent") == ""


### PR DESCRIPTION
## Summary

`[Unreleased]` documented **6 of the 87 user-visible commits** landed since the
`v0.19.0` tag (2026-07-20, `70322f59`). The next release cut would have shipped a
near-empty changelog — or reconstructed two weeks of history under time pressure,
feeding an irrevocable PyPI publish.

This PR backfills the section and adds the mechanism that makes the drift a
one-command discovery instead of a two-week archaeology dig.

Re-measured against `origin/main` @ `473de1f8` at implementation time — identical
to the curator's stamped baseline: **112 commits, 87 user-visible, 25 internal, 6
already documented → 77 issues to write.**

## Changes

- **`CHANGELOG.md`** — 38 new thematically grouped `[Unreleased]` bullets covering
  the 77 undocumented user-visible issues: `kct route --complete`, route-time HV
  isolation across every engine, `.kct_waivers.json`, the KiCad-10 name-dialect
  family, export manifest keys, LVS net identity, the diff-pair shadow
  constructor, and the rest. **Insert-only: 350 additions, 0 deletions.**
- **`scripts/changelog_gap_report.py`** (new) — walks `git log <tag>..HEAD`,
  resolves each commit to its **issue** number via the three-tier recipe (closing
  keyword → `feature/issue-<N>` branch name → `Part of #N`), classifies
  user-visible vs. internal from the conventional-commit subject prefix, and
  prints/exits non-zero on the issues `[Unreleased]` does not cite. `--json`,
  `--since`, `--head`, `--section`, `--offline`.
- **`RELEASING.md`** — new **step (0)**: reconcile the CHANGELOG (running the gap
  report) *before* the version bump, plus TL;DR and quick-checklist entries.
- **`docs/contributing/development.md`** — the stale 5-step "Release Process" list
  (it named `src/kicad_tools/__init__.py` as the version source and skipped the PR
  gate entirely) now defers to `RELEASING.md` and names step (0).
- **`scripts/README.md`** — index the new script.
- **`tests/test_changelog_gap_report.py`** (new, 13 tests) — pins the resolution
  tiers, the internal/user-visible split, and the section slice.

### Drift prevention: A + C, not B

Delivered the curator's recommendation. **Option B** (a CI gate requiring every
`feat`/`fix`/`perf` PR to touch `CHANGELOG.md`) stays rejected: it needs a new
label or a PR-body escape hatch, it would have gated ~87 Builder PRs in a
two-week window against Builders that do not author changelog entries, and it
still leaves the release-time reconciliation in place. No `.github/workflows/`
change here; a non-blocking advisory job, if ever wanted, is a separate issue.

### One design decision worth review

The subject-prefix heuristic cannot see that a commit like `board-05 Phase 6
closeout: pin exit-code gate + tighten CI blocking bound` (#4479) ships nothing a
package consumer observes. Rather than pad the changelog with a non-user-visible
bullet, the script carries an **auditable ledger** — `INTERNAL_ISSUES` (keyed by
issue) and `INTERNAL_COMMITS` (keyed by SHA, for commits with no issue at all) —
each entry carrying its rationale. That ledger *is* the machine-readable "classified
internal" half of the acceptance criteria. It currently holds 3 entries: #4479,
`fcbe6660` (a `.claude/settings.json` permission fix), and `09f0545c` (a Loom
0.18.0 resync).

## Acceptance Criteria Verification

- [x] **Every commit in `v0.19.0..origin/main` accounted for** — the gap report
  enumerates all 112, splits 87 user-visible / 25 internal, and reports an empty
  gap set. Re-counted against the current tree, not trusted from the issue.
- [x] **Every new entry cites an issue, not a PR** — resolved via the Step-1
  recipe. Spot-checked 15 numbers with
  `gh api repos/rjwalters/kicad-tools/issues/<n> --jq .pull_request` → `null` for
  all 15 (#3803, #3912, #3920, #3942, #4417, #4431, #4460, #4468, #4471, #4506,
  #4553, #4588, #4615, #4479, #4592). The curator's correction was load-bearing:
  the original body's five "issue numbers" (#4422, #4436, #4445, #4483, #4484) are
  all PRs.
- [x] **Internal commits excluded, not padded in** — 25 internal commits (Loom
  resyncs, repo-skills bumps, `.python-version` pin, README hygiene, the board-07
  test re-baseline, the board-00 sidecar untracking, the docs passes) produce no
  bullets.
- [x] **House style + Keep-a-Changelog subsections; 250–350 added lines** — 350
  added lines, at the top of the band. 38 new bullets (46 total in the section,
  including the 8 pre-existing), inside the 35–45 envelope; grouped ~2 issues per
  bullet, not one per commit. Max line width 81 chars, matching the file.
- [x] **The six pre-existing `[Unreleased]` bullets preserved byte-identical** —
  `git diff --numstat CHANGELOG.md` → `350 0`. Zero deletions is the proof; every
  hunk lands above old line 95 (`## [0.19.0]`), so no released section is touched.
- [x] **`scripts/changelog_gap_report.py` exists, runs, exits 0 with an empty gap
  set** against `v0.19.0` after the backfill.
- [x] **`RELEASING.md` gains an explicit reconciliation step naming the script**,
  before the version bump.
- [x] **No new labels, no workflow changes, no version bump, no tag.**

## Test Plan

- [x] `uv run pytest tests/test_changelog_gap_report.py` → **13 passed**.
- [x] `uv run python scripts/changelog_gap_report.py --since v0.19.0 --head origin/main`
  → `RESULT: gap set is empty`, exit **0**.
- [x] **Non-vacuity probe**: deleted the single `(#4470)` citation from
  `CHANGELOG.md` → exit **1**, `gaps: 1`, naming `#4470` and the commit
  `0e7a1b5f feat(drc): grid-independent different-net short verifier ...`.
  Restored; back to exit 0.
- [x] Edge cases from the issue: **(a)** multiple `Closes #` keywords return a set
  (unit test); **(b)** a commit with no PR and no issue classifies without crashing
  (unit test + the 3 real such commits in range); **(c)** an issue cited only in an
  older release section does not count as documented (unit test on the section
  slice); **(d)** `--since v0.19.0 --head v0.19.0` (empty range) exits **0**. Also
  verified: an unknown tag exits **2** with a message, `--json` emits the report,
  and `--offline` degrades loudly (it is documented as lossy, since a `Part of`-only
  commit then resolves to its epic).
- [x] `uv run ruff check .` → all checks passed; `uv run ruff format --check .` →
  1733 files already formatted.
- [x] `uv run mypy scripts/changelog_gap_report.py` → no issues.
  `scripts/ci/check_mypy_baseline.py` → within baseline (1473/1474). *The "1
  baseline error no longer occurs" warning is the known non-native-worktree
  artifact — deliberately not `--update`d, per the documented baseline trap.*
- [x] No `src/` changes, so no board or router behavior is affected.

## Notes for the reviewer

- The line-anchored closing-keyword regex is deliberate and is regression-tested:
  an unanchored one reads `* fix(route): resolve #4506 attach zones in
  sheet-absolute space` in commit `771caf16` as a closing reference and
  misattributes the entry to the wrong issue.
- `CHANGELOG.md` is contended in this wave. This PR rewrites only `[Unreleased]`
  and touches no surrounding released section, so single-bullet appends from
  sibling PRs should rebase cleanly.

Closes #4638
