### PR TITLE
fix(diffpair): credit the crossover census's incremental cost back to the shadow budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   copper-dirty branch is now a detail-selection branch rather than a return. Exit
   codes are unaffected — a copper-dirty board already failed (#4616).
 
+- **The crossover legality census spent the budget it was measuring.**
+  `KCT_CROSSTAIL_CENSUS=1` (#4580) is state-neutral but was not budget-neutral:
+  its lattice sweep runs inside the shadow phase's per-pair wall-clock window,
+  so census seconds were deducted from all four downstream deadlines and a
+  census-on run could differ from a census-off run through budget pressure
+  alone. The census now credits its **incremental** cost (the sweep after the
+  first legal candidate; zero when nothing is legal) back to that window and
+  reports it as a `census_s=` field appended to the `[crosstail-census]` header.
+  Default-off arithmetic is bit-identical — the credit is exactly `0.0` when the
+  census is unset (#4635).
+
 ### Known limitations
 
 - `silk_over_copper`'s aperture set is **pad-only**: untented via mask openings

--- a/boards/06-diffpair-test/README.md
+++ b/boards/06-diffpair-test/README.md
@@ -218,14 +218,67 @@ skew-checking entirely --- the error count can drop while the change is
 a regression, not a win.  Always read `coupled-ok` and reach alongside
 the raw error count, never the error count alone.
 
+### The crossover legality census (`KCT_CROSSTAIL_CENSUS=1`)
+
+The shadow constructor's crossover tails ship the **first** legal via-site
+candidate out of a 225-entry lattice and report nothing about the rest, so an
+*ordering* problem (many sites legal, a better key would pick a kinder one)
+looks exactly like a *saturation* one (almost nothing is legal, so no key can
+help).  `KCT_CROSSTAIL_CENSUS=1` ([#4580]) scans the whole lattice instead and
+prints one header per crossover:
+
+```bash
+KCT_CROSSTAIL_CENSUS=1 KCT_BOARD06_SHADOW=1 PYTHONHASHSEED=42 uv run python \
+  boards/06-diffpair-test/generate_design.py --step route --seed 42
+# [crosstail-census] net=… head=(…) goal=(…) legal=2/225 distinct_v1=1 census_s=0.0164
+```
+
+`distinct_v1` is the field that separates the two worlds: a legal set that is a
+singleton in `v1` carries the same barrel on every legal route, so no ordering
+key can move the result and the constraint lives upstream in placement / escape
+planning.
+
+**State-neutral is not the same as budget-neutral ([#4635]).** PR [#4611]'s
+prose claimed the census "cannot" change the route because it is
+"observation-only by construction".  That is true of router **state** — every
+gate the scan calls past the accept point is mutation-free, so continuing the
+sweep cannot perturb anything.  It was **not** true of the wall-clock
+**budget**: the census runs inside the shadow phase's per-pair window, and every
+downstream deadline there is computed as `<budget> - <elapsed since the window
+opened>`, so census seconds were silently deducted from the probes that follow.
+A census-on run could therefore differ from a census-off run through budget
+pressure alone.  Since #4635 the census credits its own **incremental** cost
+(the sweep after the first legal candidate — zero when nothing is legal, since
+both modes then scan the whole lattice) back to that window, so census-on and
+census-off runs get the same effective downstream budget.  The trade is
+deliberate: a census-on pair's *true* wall clock may now exceed the 30 s
+`_SHADOW_PER_PAIR_BUDGET_S` by the census's own cost, which stays visible in
+`census_s=` and in the unadjusted per-pair `[coupled-timing] elapsed=` line.
+
+**Measured on this board** (shadow-ON, seed 42, 2026-08-04 — re-measure before
+quoting): 166 crossovers, of which **150 (90.4%) have `legal=0/225`** and so
+credit exactly zero.  Total credited census time across the whole shadow phase
+is **1.28 s**; the worst single pair (USB3_TX1) accrues **0.86 s**, i.e. under
+3% of its 30 s budget.  That is a **refutation** of the budget-pressure
+hypothesis for the Mode A / Mode B flip: board-06's lattice is saturated, the
+un-instrumented loop already scans most of the 225 candidates before finding
+anything, and the incremental cost is therefore small.  [#4536] bimodality
+remains the leading explanation for a 35-vs-32 difference.  (On an *open*
+lattice the picture reverses — a synthetic fixture whose first legal candidate
+is at rank 0 pays ~3.9 ms of a ~4.0 ms census, ~39x the un-instrumented
+0.10 ms.)
+
 [#4536]: https://github.com/rjwalters/kicad-tools/issues/4536
 [#4570]: https://github.com/rjwalters/kicad-tools/issues/4570
 [#4574]: https://github.com/rjwalters/kicad-tools/issues/4574
 [#4575]: https://github.com/rjwalters/kicad-tools/issues/4575
 [#4577]: https://github.com/rjwalters/kicad-tools/issues/4577
 [#4579]: https://github.com/rjwalters/kicad-tools/issues/4579
+[#4580]: https://github.com/rjwalters/kicad-tools/issues/4580
 [#4581]: https://github.com/rjwalters/kicad-tools/issues/4581
 [#4582]: https://github.com/rjwalters/kicad-tools/issues/4582
+[#4611]: https://github.com/rjwalters/kicad-tools/pull/4611
+[#4635]: https://github.com/rjwalters/kicad-tools/issues/4635
 
 ## CI Gate (Phase 4N, #2660)
 

--- a/src/kicad_tools/router/diffpair_routing.py
+++ b/src/kicad_tools/router/diffpair_routing.py
@@ -227,6 +227,24 @@ _XY = tuple[float, float]
 # first-legal loop cannot answer the question on its own.  Diagnostic-only, off
 # by default, and observation-only when on -- it never changes which route
 # ships.  Costs a full 225-candidate sweep per crossover.
+#
+# Issue #4635 -- STATE-neutral is not BUDGET-neutral.  PR #4611's prose claimed
+# the census "cannot" cause a routing difference because it is "observation-only
+# by construction".  That is true of router STATE: every gate the scan calls
+# past the accept point is mutation-free, so continuing the sweep cannot perturb
+# anything.  It was NOT true of the wall-clock BUDGET: the census runs inside the
+# window ``spec_t0`` opens in ``route_differential_pair_coupled``, and every
+# downstream deadline there is computed as ``<budget> - (now - spec_t0)``, so
+# census seconds were silently deducted from the probes that follow.  A census-on
+# run could therefore differ from a census-off run through budget pressure alone
+# -- with no state mutation anywhere.  It now credits its own INCREMENTAL cost
+# (the sweep after the first legal candidate) back via
+# ``DiffPairRouter._census_elapsed_s``, so census-on and census-off runs get the
+# same effective downstream budget and are genuinely comparable.  The credit
+# means a census-on pair's TRUE wall clock may exceed
+# ``_SHADOW_PER_PAIR_BUDGET_S`` by the census's own cost -- a deliberate trade
+# for a default-off diagnostic; the true elapsed time stays visible in the
+# per-pair timing log and in the ``census_s=`` field of each census header.
 _CROSSTAIL_CENSUS: bool = os.environ.get("KCT_CROSSTAIL_CENSUS", "0") == "1"
 # How many legal candidates the census lists per crossover before truncating.
 # The count in the header line is always the true total, never the listed one.
@@ -3734,6 +3752,17 @@ class DiffPairRouter:
         # that the per-candidate screens are doing the repair instead.
         # Diagnostic only -- never read by a routing decision.
         self._shadow_via_gate_rejections: int = 0
+        # Issue #4635: wall-clock seconds the #4580 crossover census spent
+        # INSIDE the current spec's budgeted window, beyond what the
+        # un-instrumented first-legal loop would have spent.  The census is
+        # state-neutral (proven in #4580) but it is NOT budget-neutral: it runs
+        # inside the window ``spec_t0`` opens, so without this credit every
+        # census second is silently deducted from the downstream probe
+        # deadlines.  Accumulated in ``_synthesize_crossing_tail``, reset per
+        # spec beside ``spec_t0``, and subtracted from the elapsed term at each
+        # deadline computation.  Exactly ``0.0`` whenever the census is off, so
+        # the default path's timing arithmetic is bit-identical.
+        self._census_elapsed_s: float = 0.0
         # Issue #3089: True iff the most-recent call to
         # ``route_differential_pair_coupled`` returned because the
         # inner ``CoupledPathfinder.route_coupled`` exceeded its
@@ -5945,6 +5974,17 @@ class DiffPairRouter:
         census_legal: list[tuple[int, int, float, _XY, _XY]] = []
         census_key: Callable[[tuple[_XY, _XY]], float] | None = None
         census_first: Route | None = None
+        # Issue #4635: the census's sweep is spent inside the shadow spec's
+        # WALL-CLOCK budget, so it is state-neutral but not budget-neutral.
+        # Stamp the moment the un-instrumented loop would have RETURNED (set
+        # with ``census_first`` below) and charge only the sweep AFTER it to
+        # ``self._census_elapsed_s``, which the deadline arithmetic in
+        # ``route_differential_pair_coupled`` credits back.  Charging the whole
+        # loop would over-credit: on a saturated lattice the un-instrumented
+        # loop already scans most of the 225 candidates before it finds
+        # anything, and a crossover with NO legal candidate scanned the entire
+        # lattice in both modes -- so it correctly credits zero.
+        census_extra_t0: float | None = None
         if self.enable_shadow_construction:
             exclude = {head.net}
             exclude.update(ps.net for ps in partner_segments)
@@ -6135,10 +6175,24 @@ class DiffPairRouter:
                     )
                     if census_first is None:
                         census_first = route  # what the un-instrumented loop returns
+                        # Issue #4635: everything past this point is the
+                        # census's own cost, not the router's.
+                        census_extra_t0 = time.monotonic()
                     break  # legal -- record it and keep scanning the lattice
                 return route
         if census_on:
-            self._report_crossing_tail_census(head, goal, census_legal, len(candidate_pairs))
+            # Issue #4635: credit the INCREMENTAL sweep (post-first-legal) back
+            # to the spec's wall-clock budget.  ``census_extra_t0 is None``
+            # means no candidate was ever legal, i.e. both modes scanned the
+            # whole lattice -- nothing to credit.  The report's own stdout cost
+            # is deliberately not credited: it is bounded (at most
+            # ``_CROSSTAIL_CENSUS_LIST`` + 2 lines) and crediting it would make
+            # the ``census_s=`` field it prints self-referential.
+            census_extra_s = 0.0 if census_extra_t0 is None else time.monotonic() - census_extra_t0
+            self._census_elapsed_s += census_extra_s
+            self._report_crossing_tail_census(
+                head, goal, census_legal, len(candidate_pairs), census_extra_s
+            )
             return census_first  # observation only: the first legal candidate
         return None
 
@@ -6148,6 +6202,7 @@ class DiffPairRouter:
         goal: Pad,
         legal: list[tuple[int, int, float, _XY, _XY]],
         total: int,
+        census_s: float = 0.0,
     ) -> None:
         """Print one crossover's legality census (issue #4580).
 
@@ -6159,12 +6214,21 @@ class DiffPairRouter:
         (board-06's MIPI_CLK- landing) means no ordering key can move the
         result and the constraint lives upstream in placement / escape
         planning.
+
+        Issue #4635: ``census_s`` is this crossover's INCREMENTAL wall-clock
+        cost -- the sweep after the first legal candidate, i.e. exactly what
+        the un-instrumented loop would not have paid, and exactly what is
+        credited back to the shadow spec's budget.  Zero when no candidate was
+        legal (both modes scanned the whole lattice).  It is appended LAST so
+        the pre-existing fields keep their names and positions for anything
+        parsing this header.
         """
         print(
             f"    [crosstail-census] net={head.net_name} "
             f"head=({head.x:.5f},{head.y:.5f}) goal=({goal.x:.5f},{goal.y:.5f}) "
             f"legal={len(legal)}/{total} "
-            f"distinct_v1={len({site[3] for site in legal})}",
+            f"distinct_v1={len({site[3] for site in legal})} "
+            f"census_s={census_s:.4f}",
             flush=True,
         )
         for enum_i, rank, penalty, v1, v2 in legal[:_CROSSTAIL_CENSUS_LIST]:
@@ -9615,6 +9679,12 @@ class DiffPairRouter:
             # prior pair's decline cannot leak into this pair's per-pair
             # classification.  ``_shadow_route_pair`` sets it at each decline.
             self._last_shadow_decline_reason = None
+            # Issue #4635: reset the #4580 census's budget credit for this spec.
+            # Census time recorded OUTSIDE a spec (the escape-stub call site)
+            # pressured no spec budget, so discarding it here is correct.  With
+            # ``KCT_CROSSTAIL_CENSUS`` unset this stays exactly ``0.0`` for the
+            # whole spec and every deadline below is bit-identical to pre-#4635.
+            self._census_elapsed_s = 0.0
             # Issue #3473: iterations the corridor attempt consumed,
             # charged against the shared per-pair iteration budget so
             # the open fallback gets the REMAINDER (not a fresh full
@@ -9719,13 +9789,17 @@ class DiffPairRouter:
                 # of the hard per-pair shadow budget so the two probes
                 # together cannot exceed ``_SHADOW_PER_PAIR_BUDGET_S`` --
                 # the fail-fast contract is per PAIR, not per probe.
+                # Issue #4635: minus the #4580 census's incremental cost, so a
+                # census-on run hands this probe the same deadline a census-off
+                # run would (``0.0`` and therefore bit-identical when off).
                 n_probe_timeout = probe_timeout
                 if per_pair_timeout is not None and probe_timeout is not None:
                     n_probe_timeout = max(
                         0.5,
                         min(
                             probe_timeout,
-                            _SHADOW_PER_PAIR_BUDGET_S - (time.monotonic() - spec_t0),
+                            _SHADOW_PER_PAIR_BUDGET_S
+                            - (time.monotonic() - spec_t0 - self._census_elapsed_s),
                         ),
                     )
                 n_guide = self._single_ended_guide_route(
@@ -9762,12 +9836,15 @@ class DiffPairRouter:
                 # shadow budget so this last-resort pass cannot extend the
                 # per-pair wall-clock past ``_SHADOW_PER_PAIR_BUDGET_S`` (the
                 # normal attempts may already have spent most of it).
+                # Issue #4635: less the census's incremental cost (see above).
                 bias_timeout = probe_timeout
                 if per_pair_timeout is not None and probe_timeout is not None:
                     bias_timeout = max(
                         0.5,
                         min(
-                            probe_timeout, _SHADOW_PER_PAIR_BUDGET_S - (time.monotonic() - spec_t0)
+                            probe_timeout,
+                            _SHADOW_PER_PAIR_BUDGET_S
+                            - (time.monotonic() - spec_t0 - self._census_elapsed_s),
                         ),
                     )
                 biased = self._shadow_with_guide_bias(
@@ -9866,11 +9943,18 @@ class DiffPairRouter:
                 # corridor half (it already counts against the pair
                 # via ``spec_t0``), keeping probe+corridor <= ~50% of
                 # the per-pair budget instead of 62.5%.
+                # Issue #4635: the #4580 census's incremental cost is NOT the
+                # probe's, so it is credited back here too.  This site is
+                # reachable with the census ON and shadow construction OFF
+                # (``_CROSSTAIL_CENSUS`` is independent of
+                # ``enable_shadow_construction``), so leaving it uncorrected
+                # would make the fix partial.
                 corridor_budget: float | None = None
                 if per_pair_timeout is not None:
                     corridor_budget = max(
                         0.5,
-                        per_pair_timeout * 0.5 - (time.monotonic() - spec_t0),
+                        per_pair_timeout * 0.5
+                        - (time.monotonic() - spec_t0 - self._census_elapsed_s),
                     )
                 # Issue #3473: split the ITERATION budget the same way
                 # as the wall-clock budget -- the corridor attempt gets
@@ -9895,7 +9979,12 @@ class DiffPairRouter:
             if result is None and not shadow_fail_fast:
                 remaining_budget = per_pair_timeout
                 if per_pair_timeout is not None:
-                    remaining_budget = max(1.0, per_pair_timeout - (time.monotonic() - spec_t0))
+                    # Issue #4635: same census credit as the corridor budget
+                    # above -- this open fallback shares the ``spec_t0`` window.
+                    remaining_budget = max(
+                        1.0,
+                        per_pair_timeout - (time.monotonic() - spec_t0 - self._census_elapsed_s),
+                    )
                 # Issue #3473: the open fallback gets the REMAINDER of
                 # the shared iteration budget.  Because the corridor
                 # attempt was capped at half, the fallback always
@@ -9915,6 +10004,11 @@ class DiffPairRouter:
                     max_iterations_budget=remaining_iterations,
                 )
 
+            # Issue #4635: deliberately NOT census-adjusted.  The deadlines
+            # above credit the census's cost back so census-on and census-off
+            # runs are comparable; this is the pair's TRUE wall clock, and
+            # subtracting the census here would hide exactly the cost the credit
+            # makes the pair spend beyond ``_SHADOW_PER_PAIR_BUDGET_S``.
             spec_elapsed = time.monotonic() - spec_t0
             logger.info(
                 "diffpair coupled timing: pair=%r phase=%s elapsed=%.2fs success=%s",

--- a/tests/test_diffpair_census_budget.py
+++ b/tests/test_diffpair_census_budget.py
@@ -1,0 +1,350 @@
+"""Issue #4635: the #4580 crossover census is state-neutral but not budget-neutral.
+
+PR #4611 established that the ``KCT_CROSSTAIL_CENSUS=1`` sweep cannot perturb
+router STATE -- every gate it calls past the accept point is mutation-free.  It
+does, however, spend real wall clock inside the window ``spec_t0`` opens in
+``route_differential_pair_coupled``, and every downstream deadline in that
+window is computed as ``<budget> - (now - spec_t0)``.  So a census-on run could
+differ from a census-off run through **budget pressure alone**, with no state
+mutation anywhere -- which is exactly the confound the census exists to remove.
+
+The fix credits the census's INCREMENTAL cost (the sweep after the first legal
+candidate, i.e. the part the un-instrumented first-legal loop would never have
+paid) back to that window via ``DiffPairRouter._census_elapsed_s``.
+
+These tests pin four things:
+
+1. With the census OFF the credit is exactly ``0.0``, so the default path's
+   timing arithmetic is bit-identical.
+2. With the census ON a crossover whose first legal candidate is not the last
+   one accrues a positive credit -- and a crossover with NO legal candidate
+   accrues zero (both modes scanned the whole lattice).
+3. All four deadline sites subtract the credit, including the two that are
+   reachable with the census ON and shadow construction OFF.
+4. The cost is reported in the ``[crosstail-census]`` header, appended after
+   the pre-existing fields so their names and order are untouched.
+
+Deliberately kept in its own module: ``tests/test_diffpair_shadow.py`` owns the
+#4580 census block and is not modified by this change; its fixtures are reused
+here by import (the convention used by
+``tests/test_cli_route_complete_localize_4472.py``).
+"""
+
+from __future__ import annotations
+
+import re
+import time as _real_time
+
+import pytest
+
+from kicad_tools.router.diffpair_routing import DiffPairRouter
+from tests.test_diffpair_coupled_instrumentation_4459 import _two_pad_router_and_pair
+from tests.test_diffpair_shadow import (
+    _crossing_router,
+    _crossing_tail,
+    _CrossingPathfinder,
+    _register_unrouted_neighbour,
+    _tail_pads,
+)
+
+_HEADER_FIELDS = re.compile(
+    r"\[crosstail-census\] net=(?P<net>\S+) "
+    r"head=\((?P<head>[^)]*)\) goal=\((?P<goal>[^)]*)\) "
+    r"legal=(?P<legal>\d+)/(?P<total>\d+) "
+    r"distinct_v1=(?P<distinct>\d+) "
+    r"census_s=(?P<census_s>[0-9.]+)$"
+)
+
+
+def _census_on(monkeypatch) -> None:
+    import kicad_tools.router.diffpair_routing as dpr_mod
+
+    monkeypatch.setattr(dpr_mod, "_CROSSTAIL_CENSUS", True)
+
+
+def _census_header(capsys) -> str:
+    lines = [
+        line.strip()
+        for line in capsys.readouterr().out.splitlines()
+        if "[crosstail-census]" in line
+    ]
+    assert lines, "the census must actually have run"
+    return lines[0]
+
+
+class _SealedPathfinder(_CrossingPathfinder):
+    """Every cell blocked: the census finds ``legal=0`` out of the whole lattice.
+
+    This is the saturated extreme.  The un-instrumented loop also scans all 225
+    candidates here (it never finds one to return on), so the census costs
+    nothing extra and must credit nothing.
+    """
+
+    def _is_cell_blocked(self, gx: int, gy: int, layer_idx: int, net: int) -> bool:
+        return True
+
+
+class _FakeClock:
+    """A hand-advanced stand-in for the ``time`` module inside the router.
+
+    The budget arithmetic under test is exact float arithmetic on
+    ``time.monotonic()``; asserting it against real wall clock would flake.
+    Installed with ``monkeypatch.setattr(dpr_mod, "time", clock)`` so only
+    ``diffpair_routing``'s module-global name is replaced.
+    """
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self.now = float(start)
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def advance(self, dt: float) -> None:
+        self.now += float(dt)
+
+    def __getattr__(self, name: str):  # pragma: no cover - delegation safety net
+        return getattr(_real_time, name)
+
+
+# ---------------------------------------------------------------------------
+# The accumulator: what gets charged, and what does not
+# ---------------------------------------------------------------------------
+
+
+def test_census_off_credits_exactly_zero():
+    """The load-bearing safety property: default-off arithmetic is unchanged.
+
+    ``_census_elapsed_s`` must be exactly ``0.0`` -- not "small" -- so every
+    ``- (now - spec_t0 - self._census_elapsed_s)`` term is bit-identical to the
+    pre-#4635 ``- (now - spec_t0)``.
+    """
+    dpr = _crossing_router()
+    _register_unrouted_neighbour(dpr)
+
+    assert _crossing_tail(dpr) is not None
+    assert dpr._census_elapsed_s == 0.0
+    assert isinstance(dpr._census_elapsed_s, float)
+
+
+def test_census_on_credits_the_post_first_legal_sweep(monkeypatch, capsys):
+    """An open lattice finds its first legal candidate early, so the sweep costs.
+
+    This is the case the issue is about: 224 further candidates get validated
+    purely for the measurement, inside the shadow phase's budget.
+    """
+    _census_on(monkeypatch)
+    dpr = _crossing_router()
+
+    tail = _crossing_tail(dpr)
+
+    assert tail is not None
+    header = _census_header(capsys)
+    match = _HEADER_FIELDS.search(header)
+    assert match is not None, header
+    # Non-vacuity: the first legal candidate must not be the last one, or there
+    # would be no incremental sweep to charge for.
+    assert int(match.group("legal")) > 1
+    assert dpr._census_elapsed_s > 0.0
+
+
+def test_census_credits_the_value_it_reports(monkeypatch, capsys):
+    """The reported ``census_s`` IS the credit -- not an independent estimate."""
+    _census_on(monkeypatch)
+    dpr = _crossing_router()
+
+    assert _crossing_tail(dpr) is not None
+
+    match = _HEADER_FIELDS.search(_census_header(capsys))
+    assert match is not None
+    assert dpr._census_elapsed_s == pytest.approx(float(match.group("census_s")), abs=5e-5)
+
+
+def test_no_legal_candidate_credits_zero(monkeypatch, capsys):
+    """A saturated crossover scanned the whole lattice in BOTH modes.
+
+    Charging the whole census loop -- the naive fix -- would hand this pair a
+    budget extension it never earned.  Only the post-first-legal sweep is
+    incremental, and here there is none.
+    """
+    _census_on(monkeypatch)
+    dpr = _crossing_router()
+    head, goal = _tail_pads((5.0, 5.0), (8.0, 5.0))
+
+    tail = dpr._synthesize_crossing_tail(_SealedPathfinder(), head, goal, 0, [])
+
+    assert tail is None
+    match = _HEADER_FIELDS.search(_census_header(capsys))
+    assert match is not None
+    assert int(match.group("legal")) == 0, "fixture must be saturated for this to be meaningful"
+    assert int(match.group("total")) == 225
+    assert dpr._census_elapsed_s == 0.0
+
+
+# ---------------------------------------------------------------------------
+# The header: new field appended, existing fields untouched
+# ---------------------------------------------------------------------------
+
+
+def test_header_appends_census_s_after_the_existing_fields(capsys):
+    """Field names and order are a parsed interface -- ``census_s`` goes LAST."""
+    head, goal = _tail_pads((1.0, 2.0), (4.0, 2.0))
+
+    DiffPairRouter._report_crossing_tail_census(
+        head, goal, [(3, 7, 0.25, (1.5, 2.5), (3.5, 2.5))], 225, 0.0125
+    )
+
+    match = _HEADER_FIELDS.search(_census_header(capsys))
+    assert match is not None, "the header field names/order must be unchanged"
+    assert match.group("legal") == "1"
+    assert match.group("total") == "225"
+    assert match.group("distinct") == "1"
+    assert float(match.group("census_s")) == pytest.approx(0.0125)
+
+
+def test_report_stays_callable_without_the_cost_argument(capsys):
+    """Back-compat: existing direct callers pass four positional arguments."""
+    head, goal = _tail_pads((1.0, 2.0), (4.0, 2.0))
+
+    DiffPairRouter._report_crossing_tail_census(head, goal, [], 225)
+
+    match = _HEADER_FIELDS.search(_census_header(capsys))
+    assert match is not None
+    assert float(match.group("census_s")) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# The budget: all four deadline sites credit the census back
+# ---------------------------------------------------------------------------
+
+_CREDIT = 3.0
+_PROBE_COST = 10.0
+
+
+def _guide_route():
+    from kicad_tools.router.layers import Layer
+    from kicad_tools.router.primitives import Route, Segment
+
+    guide = Route(net=1, net_name="USB_D+")
+    guide.segments.append(
+        Segment(x1=5.0, y1=4.8, x2=25.0, y2=4.8, width=0.2, layer=Layer.F_CU, net=1)
+    )
+    return guide
+
+
+def _install_clock(monkeypatch) -> _FakeClock:
+    import kicad_tools.router.diffpair_routing as dpr_mod
+
+    clock = _FakeClock()
+    monkeypatch.setattr(dpr_mod, "time", clock)
+    return clock
+
+
+def _probe_deadlines(monkeypatch, *, shadow: bool, credit: float) -> dict[str, list[float]]:
+    """Drive one coupled spec and record every deadline the budget arithmetic hands out.
+
+    ``credit`` is injected as the census's accrued cost during the FIRST guide
+    probe -- i.e. after ``route_differential_pair_coupled`` resets the
+    accumulator for this spec, exactly where a real census would accrue it.
+    """
+    import kicad_tools.router.diffpair_routing as dpr_mod
+
+    router, pair = _two_pad_router_and_pair()
+    dpr = router._diffpair
+    dpr.enable_shadow_construction = shadow
+    clock = _install_clock(monkeypatch)
+    seen: dict[str, list[float]] = {"probe": [], "bias": [], "coupled": []}
+
+    def _guide(*_a, **kwargs):
+        seen["probe"].append(kwargs["per_net_timeout"])
+        dpr._census_elapsed_s = credit
+        clock.advance(_PROBE_COST)
+        return _guide_route()
+
+    monkeypatch.setattr(dpr, "_single_ended_guide_route", _guide)
+    monkeypatch.setattr(dpr, "_shadow_route_pair", lambda *a, **k: None)
+
+    def _biased(*a, **_k):
+        seen["bias"].append(a[8])
+        return None
+
+    monkeypatch.setattr(dpr, "_shadow_with_guide_bias", _biased)
+
+    class _StubPathfinder:
+        last_timeout_exceeded = False
+        last_iteration_limited = False
+        last_iterations = 0
+        last_best_progress = float("inf")
+        last_best_state = None
+        last_best_node = None
+        last_coupled_backend = "python"
+        last_rejections: dict[str, int] = {}
+
+        def route_coupled(self, *_a, **kwargs):
+            seen["coupled"].append(kwargs.get("timeout_seconds"))
+            return None
+
+    monkeypatch.setattr(dpr_mod, "CoupledPathfinder", lambda *a, **k: _StubPathfinder())
+
+    dpr.route_differential_pair_coupled(pair, coupled_only=True, per_pair_timeout=60.0)
+    return seen
+
+
+def test_shadow_probe_deadlines_credit_the_census(monkeypatch):
+    """Sites ``n_probe_timeout`` and ``bias_timeout`` (shadow ON).
+
+    Both are ``_SHADOW_PER_PAIR_BUDGET_S - (now - spec_t0)``.  With the census
+    credited, a census-on spec hands the swapped probe and the guide-biased
+    re-route exactly the deadlines a census-off spec would.
+    """
+    baseline = _probe_deadlines(monkeypatch, shadow=True, credit=0.0)
+    credited = _probe_deadlines(monkeypatch, shadow=True, credit=_CREDIT)
+
+    assert len(baseline["probe"]) >= 2, "the swapped N probe must have run"
+    assert baseline["bias"], "the guide-biased re-route must have run"
+    # The FIRST probe is bounded before any census time can accrue.
+    assert credited["probe"][0] == baseline["probe"][0]
+    # Every later deadline is longer by exactly the credit.
+    assert credited["probe"][1] == pytest.approx(baseline["probe"][1] + _CREDIT)
+    assert credited["bias"][0] == pytest.approx(baseline["bias"][0] + _CREDIT)
+    # Non-vacuity: the deadlines are genuinely budget-limited, not clamped to
+    # ``probe_timeout`` (a clamp would hide the credit).
+    assert baseline["probe"][1] < baseline["probe"][0]
+
+
+def test_corridor_and_open_deadlines_credit_the_census(monkeypatch):
+    """Sites ``corridor_budget`` and ``remaining_budget`` (shadow OFF).
+
+    ``_CROSSTAIL_CENSUS`` is independent of ``enable_shadow_construction``, so
+    a census-on / shadow-off run pressures these two.  Leaving them uncorrected
+    would be a partial fix that is harder to reason about than none.
+    """
+    baseline = _probe_deadlines(monkeypatch, shadow=False, credit=0.0)
+    credited = _probe_deadlines(monkeypatch, shadow=False, credit=_CREDIT)
+
+    assert len(baseline["coupled"]) == 2, "corridor attempt then open fallback"
+    corridor_base, open_base = baseline["coupled"]
+    corridor_credited, open_credited = credited["coupled"]
+    # Non-vacuity: both budgets are the remaining-time expression, not a floor.
+    assert corridor_base == pytest.approx(60.0 * 0.5 - _PROBE_COST)
+    assert open_base == pytest.approx(60.0 - _PROBE_COST)
+    assert corridor_credited == pytest.approx(corridor_base + _CREDIT)
+    assert open_credited == pytest.approx(open_base + _CREDIT)
+
+
+def test_logged_pair_wall_clock_is_not_census_adjusted(monkeypatch, caplog):
+    """``spec_elapsed`` stays the TRUE elapsed time.
+
+    Crediting the budget means a census-on pair may exceed
+    ``_SHADOW_PER_PAIR_BUDGET_S`` by the census's own cost.  That is the
+    deliberate trade; hiding it in the timing log would defeat the point.
+    """
+    import logging
+
+    with caplog.at_level(logging.INFO, logger="kicad_tools.router.diffpair_routing"):
+        _probe_deadlines(monkeypatch, shadow=False, credit=_CREDIT)
+
+    timing = [rec for rec in caplog.records if "diffpair coupled timing" in rec.getMessage()]
+    assert timing, "the per-pair timing line must still be logged"
+    # The fake clock advanced exactly ``_PROBE_COST`` during the spec, and the
+    # credit must NOT have been subtracted from the reported elapsed time.
+    assert f"elapsed={_PROBE_COST:.2f}s" in timing[-1].getMessage()


### PR DESCRIPTION
## Summary

The #4580 crossover legality census (`KCT_CROSSTAIL_CENSUS=1`) is **state**-neutral — PR #4611's Judge review confirmed every gate it calls past the accept point is mutation-free — but it was **not budget**-neutral. Its 225-candidate sweep runs inside the window `spec_t0` opens in `route_differential_pair_coupled`, and every downstream deadline in that window is computed as `<budget> - (now - spec_t0)`. So census seconds were silently deducted from the probes that follow, and a census-on run could differ from a census-off run through **budget pressure alone**, with no state mutation anywhere.

This credits the census's **incremental** cost — the sweep after the first legal candidate, i.e. exactly what the un-instrumented first-legal loop would never have paid — back to that window, so census-on and census-off runs receive the same effective downstream budget.

### Budget-contract decision (deliberate, stated per the issue)

Crediting the census's time means a census-on pair's **true** wall clock may exceed the hard `_SHADOW_PER_PAIR_BUDGET_S` bound that #3987 introduced as a fail-fast contract, by the census's own cost. **This is a deliberate choice, not an accident**: the alternative — leaving the budget uncredited — is precisely the defect this issue reports, and it would make the diagnostic unable to observe the thing it measures without perturbing it. The trade is bounded in practice (measured worst case on board-06 is 0.86 s against a 30 s budget, under 3%) and it is deliberately *visible* rather than hidden: `spec_elapsed` (the logged per-pair wall clock) is **not** adjusted, and each crossover's cost is printed as `census_s=`. The decision is written into the `_CROSSTAIL_CENSUS` comment, not just this PR body. No bounded/capped variant was adopted — an uncapped credit is exactly right for a default-off diagnostic, and a cap would reintroduce a silent census-on/census-off asymmetry at the cap.

### Measured result: this **refutes** budget pressure as the mode-flip explanation

Board-06, shadow-ON, seed 42, census on (2026-08-04, this branch):

| | value |
|---|---|
| crossovers | 166 |
| with `legal=0/225` (credit exactly zero) | **150 (90.4%)** |
| total credited across the whole shadow phase | **1.28 s** |
| worst pair (USB3_TX1) | **0.86 s** of its 30 s budget (2.9%) |
| worst single crossover | 0.22 s |

The curator's hypothesis holds: board-06's lattice is **saturated**, so the un-instrumented loop already scans most of the 225 candidates before finding anything and the incremental cost is small. Budget pressure is therefore a **weak** explanation for the 35-vs-32 Mode A/Mode B flip, and #4536 regen bimodality remains the leading one. On an *open* lattice the picture reverses — a synthetic fixture whose first legal candidate is at rank 0 pays ~3.9 ms of a ~4.0 ms census (~39x the 0.10 ms un-instrumented loop), and essentially all of it is credited.

The correction is still worth making regardless of which way that measurement fell: the point is that census-on and census-off runs are now genuinely comparable.

## Changes

- `src/kicad_tools/router/diffpair_routing.py`
  - New `DiffPairRouter._census_elapsed_s` accumulator alongside the #4459/#4575 diagnostic attributes; reset per spec beside `spec_t0`.
  - `_synthesize_crossing_tail` stamps the moment the un-instrumented loop would have **returned** (set with `census_first`) and charges only the sweep after it. No legal candidate ⇒ credits **zero** (both modes scanned the whole lattice).
  - All **four** arithmetic consumers of `spec_t0` subtract the credit: the swapped N-probe, the guide-biased probe, `corridor_budget`, and the open-fallback `remaining_budget`. The last two are reachable with the census ON and shadow construction OFF (`_CROSSTAIL_CENSUS` is independent of `enable_shadow_construction`), so leaving them out would have been a partial fix.
  - `spec_elapsed` (the logged per-pair wall clock) is **not** adjusted, with a comment saying why.
  - `_report_crossing_tail_census` takes a defaulted `census_s` parameter and appends `census_s=<seconds>` **after** the existing header fields; `net=` / `head=` / `goal=` / `legal=N/M` / `distinct_v1=` keep their names and order, and existing 4-positional-argument callers still work.
  - The `_CROSSTAIL_CENSUS` module comment now records the state-neutral vs budget-neutral distinction explicitly, including that PR #4611's "cannot … observation-only by construction" prose was true of *state* and not of *budget*.
- `tests/test_diffpair_census_budget.py` — **new file** (9 tests). `tests/test_diffpair_shadow.py` is untouched; its fixtures are reused by cross-module import.
- `boards/06-diffpair-test/README.md` — new "The crossover legality census" subsection: what it measures, the budget coupling and the same state/budget correction, and the measured board-06 numbers above.
- `CHANGELOG.md` — one bullet under `[Unreleased] → Fixed`.

## Acceptance Criteria Verification

- [x] **Default-off is bit-identical** — `test_census_off_credits_exactly_zero` asserts `_census_elapsed_s == 0.0` exactly (not "small") after driving a crossover with the census unset, so every `- (now - spec_t0 - self._census_elapsed_s)` term evaluates identically to the pre-change `- (now - spec_t0)`.
- [x] **Same effective downstream budget at all four sites** — `test_shadow_probe_deadlines_credit_the_census` (N-probe + biased probe) and `test_corridor_and_open_deadlines_credit_the_census` (corridor + open fallback) drive a real spec under a hand-advanced clock and assert each deadline is longer by *exactly* the injected credit, with non-vacuity assertions that the deadlines are budget-limited rather than clamped to `probe_timeout` or floored.
- [x] **Only the incremental cost; no legal candidate ⇒ zero** — `test_no_legal_candidate_credits_zero` drives a fully-sealed lattice (`legal=0/225`) and asserts `_census_elapsed_s == 0.0`; `test_census_credits_the_value_it_reports` pins that the credited value is the reported one.
- [x] **The census reports its own wall-clock cost, existing fields unchanged** — `test_header_appends_census_s_after_the_existing_fields` matches the whole header against a positional regex (`net= head= goal= legal=N/M distinct_v1= census_s=`), and `test_report_stays_callable_without_the_cost_argument` pins 4-positional back-compat.
- [x] **`spec_elapsed` is not adjusted** — `test_logged_pair_wall_clock_is_not_census_adjusted` asserts the logged `elapsed=` equals the full advanced clock, with a non-zero credit injected.
- [x] **State-neutral vs budget-neutral recorded where investigators look** — the `_CROSSTAIL_CENSUS` comment and `boards/06-diffpair-test/README.md`, both naming PR #4611's prose explicitly.
- [x] **`tests/test_diffpair_shadow.py` unmodified** — `git diff --stat` touches 4 files and that is not one of them; the file's 234-test suite passes unchanged.

## Test Plan

- [x] `uv run pytest tests/test_diffpair_census_budget.py -q` → **9 passed**
- [x] `uv run pytest tests/test_diffpair_shadow.py tests/test_diffpair_per_pair_timeout.py tests/test_diffpair_budget_exit_warning.py tests/test_diffpair_coupled_instrumentation_4459.py tests/test_diffpair_corridor.py -q` → **234 passed** (the budget arithmetic and the #4580 census block are exactly what those pin)
- [x] Manual: `KCT_CROSSTAIL_CENSUS=1 KCT_BOARD06_SHADOW=1 PYTHONHASHSEED=42 uv run python boards/06-diffpair-test/generate_design.py --step route --seed 42` in a scratch worktree — `census_s=` appears on every crossover header; per-pair totals in the table above. No board artifacts are included in this PR.
- [x] `uv run ruff check src tests`, `uv run ruff format --check src tests` → clean
- [x] `uv run --extra dev python scripts/ci/check_mypy_baseline.py` → within baseline (1473 of 1474 allowed; the one "no longer occurs" line is the known native-build env artifact, baseline deliberately left alone)

Closes #4635
