### PR TITLE
fix(cli): reach --refill-zones/--waivers on `kct check` + guard check parser drift

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -267,10 +267,11 @@ kct check <pcb_file> [options]
 
 | Option | Description |
 |--------|-------------|
-| `--format {table,json}` | Output format |
+| `--format {table,json,summary}` | Output format |
 | `--mfr {jlcpcb,oshpark,pcbway}` | Manufacturer rules |
-| `--rules RULES` | Custom rules file |
 | `--refill-zones` | Refill zone fills in-place via `kicad-cli pcb drc --refill-zones --save-board` before checking (mutates the board file; kills stale-fill clearance false positives, #4113) |
+| `--waivers PATH` | Path to a general `.kct_waivers.json` sidecar (schema v2) waiving findings for any rule (#4417). Auto-discovered next to the board when omitted |
+| `--courtyard-waivers PATH` | Path to a `.courtyard_waivers.json` sidecar waiving specific courtyard-overlap pairs (#4137). Auto-discovered next to the board when omitted |
 
 **Examples:**
 ```bash

--- a/src/kicad_tools/cli/commands/validation.py
+++ b/src/kicad_tools/cli/commands/validation.py
@@ -262,6 +262,18 @@ def run_check_command(args) -> int:
     # Issue #4601: forward the sidecar auto-discovery opt-out.
     if getattr(args, "no_net_class_map", False):
         sub_argv.append("--no-net-class-map")
+    # Issue #4633: forward the zone-refill opt-in (#4096/#4113) and the two
+    # waiver-sidecar path overrides (#4137 / #4417).  All three were declared
+    # on the inner check_cmd parser only, so `kct check --refill-zones` (and
+    # the explicit waiver paths) failed with "unrecognized arguments" until
+    # this shim + the outer subparser learned about them.  The parser-drift
+    # guard in tests/test_cli_parser_drift.py now pins all three.
+    if getattr(args, "refill_zones", False):
+        sub_argv.append("--refill-zones")
+    if getattr(args, "courtyard_waivers", None):
+        sub_argv.extend(["--courtyard-waivers", args.courtyard_waivers])
+    if getattr(args, "waivers", None):
+        sub_argv.extend(["--waivers", args.waivers])
     # Issue #3061: forward pad_grid tolerance flags.
     if getattr(args, "pad_grid_strict", False):
         sub_argv.append("--pad-grid-strict")

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -674,6 +674,20 @@ def _add_check_parser(subparsers) -> None:
         ),
     )
     check_parser.add_argument(
+        "--refill-zones",
+        dest="refill_zones",
+        action="store_true",
+        help=(
+            "Before checking, run `kicad-cli pcb drc --refill-zones "
+            "--save-board` to bring the on-disk zone fills back in sync with "
+            "the copper (issue #4096).  WARNING: this MUTATES the board file "
+            "in place (--save-board rewrites <pcb>).  Fixes phantom "
+            "clearance_*_zone findings caused by stale committed fills.  "
+            "Requires kicad-cli (KiCad 8+); degrades gracefully with a "
+            "warning if kicad-cli is not installed."
+        ),
+    )
+    check_parser.add_argument(
         "--mfr",
         "-m",
         choices=get_all_manufacturer_names(),
@@ -806,6 +820,29 @@ def _add_check_parser(subparsers) -> None:
             "no-sidecar behaviour (the diff-pair / match-group skew rules "
             "stay inactive).  Cannot be combined with --net-class-map "
             "(Issue #4601)."
+        ),
+    )
+    check_parser.add_argument(
+        "--courtyard-waivers",
+        dest="courtyard_waivers",
+        default=None,
+        help=(
+            "Path to a .courtyard_waivers.json sidecar waiving specific "
+            "courtyard-overlap pairs.  Matching overlapping pairs report as "
+            "WAIVED instead of failing the gate.  Auto-discovered next to the "
+            "board when this flag is omitted (Issue #4137)."
+        ),
+    )
+    check_parser.add_argument(
+        "--waivers",
+        dest="waivers",
+        default=None,
+        help=(
+            "Path to a general .kct_waivers.json sidecar (schema version 2) "
+            "waiving findings for ANY rule by matching the violation's items "
+            "(and optional nets) set.  Matched findings report as WAIVED "
+            "instead of failing the gate.  Auto-discovered next to the board "
+            "when this flag is omitted (Issue #4417)."
         ),
     )
     # Issue #3061: per-board auto-derive of the pad_grid tolerance is the

--- a/tests/test_cli_parser_drift.py
+++ b/tests/test_cli_parser_drift.py
@@ -1,4 +1,13 @@
-"""Argparse-drift regression test (Issues #2817, #2819).
+"""Argparse-drift regression test (Issues #2817, #2819, #4633).
+
+This module guards **two** three-hop parser pairs against the same bug
+class:
+
+* ``route`` -- ``parser.py :: _add_route_parser`` ->
+  ``commands/routing.py :: run_route_command`` -> ``route_cmd.main``.
+* ``check`` -- ``parser.py :: _add_check_parser`` ->
+  ``commands/validation.py :: run_check_command`` -> ``check_cmd.main``
+  (added by #4633; see the ``check``-pair section near the bottom).
 
 This test prevents a recurring class of bug where a flag is added to one
 of the two ``route`` parsers without being added to the other (and to
@@ -36,6 +45,22 @@ why the flag does not belong on the other parser.  In most cases the
 right answer is to add it to BOTH parsers and to the forwarding shim --
 see the ``--per-net-timeout`` block in ``commands/routing.py`` for the
 model pattern.
+
+The ``check`` pair went unguarded until #4633, and had accumulated
+**three** live instances of the bug class in the meantime -- all three
+declared on ``check_cmd.py`` only and rejected by the real ``kct check``
+with ``error: unrecognized arguments``:
+
+* ``--refill-zones`` (#4113, ``d42248ee``) -- entirely unreachable
+  through the ``kct`` entry point despite being advertised in
+  ``CHANGELOG.md`` and ``docs/reference/cli.md``.
+* ``--courtyard-waivers`` (#4137/#4150, ``07fd58f1``) and ``--waivers``
+  (#4417/#4445, ``59e36c47``) -- degraded partially rather than loudly,
+  because both sidecars are auto-discovered next to the board, so only
+  the explicit-path override was unreachable.
+
+#4633 added all three to the outer parser and the shim, so both
+``check`` allowlists below start out empty.
 """
 
 from __future__ import annotations
@@ -542,4 +567,325 @@ def test_fix_drc_threads_manufacturer_into_drc_checker():
     )
     assert kwargs.get("layers") == 4, (
         "_run_python_drc must thread --layers into DRCChecker(layers=...)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# ``check`` parser pair (#4633)
+# ---------------------------------------------------------------------------
+#
+# ``kct check`` has the identical three-hop forwarding shape as ``route``:
+#
+#     parser.py :: _add_check_parser
+#         -> commands/validation.py :: run_check_command
+#             -> check_cmd.py :: main
+#
+# and went unguarded until #4633, by which point three flags had drifted
+# (``--refill-zones``, ``--courtyard-waivers``, ``--waivers`` -- see the
+# module docstring).  The allowlists below are DELIBERATELY EMPTY.
+
+# Flags that legitimately exist ONLY on the inner ``check_cmd.py`` parser.
+#
+# Empty by construction: as of #4633 every inner ``check`` flag is also
+# declared on the outer ``kct check`` subparser and forwarded by the shim.
+# A future entry belongs here only if the flag is genuinely internal-only
+# (a debug/profiling/experimental toggle that must NOT be advertised on the
+# ``kct`` surface), and must carry a one-line justification -- exactly like
+# the route ``INNER_ONLY_ALLOWLIST`` entries above.  A user-facing,
+# documented flag is a DRIFT BUG: add it to _add_check_parser and
+# run_check_command instead of allowlisting it.
+INNER_ONLY_CHECK_ALLOWLIST: frozenset[str] = frozenset(set())
+
+# Flags that legitimately exist ONLY on the outer ``kct check`` subparser.
+#
+# Empty by construction, mirroring the route ``OUTER_ONLY_ALLOWLIST``.  A
+# future entry belongs here only if the shim consumes the flag entirely
+# before building ``sub_argv`` (so it is never forwarded and the inner
+# parser has no equivalent), and must carry a one-line justification.
+# Otherwise an outer-only flag parses cleanly and is then silently dropped
+# -- the #2819 failure mode, applied to ``check``.
+OUTER_ONLY_CHECK_ALLOWLIST: frozenset[str] = frozenset(set())
+
+
+def _inner_check_parser_flags(prog: str = "kct check") -> set[str]:
+    """Capture the inner ``check_cmd.main`` parser without parsing argv.
+
+    ``prog`` is parameterised ONLY so the vacuity control below can prove
+    that a wrong prog string fails loudly rather than silently capturing
+    nothing.  Production callers must use the default.
+
+    .. warning::
+
+       The inner check parser's ``prog`` is ``"kct check"``, NOT
+       ``"kicad-tools check"`` (``check_cmd.py`` ``main()``), whereas the
+       inner *route* parser uses ``"kicad-tools route"``.  Copy-pasting
+       ``_inner_route_parser_flags`` and its prog filter here captures
+       nothing.  The hard ``assert`` below is what turns that mistake into
+       a loud failure instead of a permanently-green, vacuous test.
+    """
+    from kicad_tools.cli.check_cmd import main as check_main
+
+    captured: dict[str, argparse.ArgumentParser] = {}
+    real_parse_args = argparse.ArgumentParser.parse_args
+
+    def fake_parse_args(self, *args, **kwargs):
+        if getattr(self, "prog", "") == prog:
+            captured["parser"] = self
+            raise SystemExit(0)
+        return real_parse_args(self, *args, **kwargs)
+
+    with patch.object(argparse.ArgumentParser, "parse_args", fake_parse_args):
+        with pytest.raises(SystemExit):
+            check_main([])
+
+    assert "parser" in captured, (
+        f"failed to capture inner check parser with prog={prog!r} -- "
+        "check_cmd.main's prog string has changed; update "
+        "_inner_check_parser_flags rather than letting this test go vacuous"
+    )
+    return _flags_from_parser(captured["parser"])
+
+
+def test_check_inner_only_flags_are_in_allowlist():
+    """Every flag on the inner check parser must be on the outer one.
+
+    Guards the direction that actually shipped three times (#4113,
+    #4137, #4417): a flag declared on ``check_cmd.py`` only, so
+    ``kct check --flag`` dies with ``error: unrecognized arguments``.
+    """
+    inner = _inner_check_parser_flags()
+    outer = _outer_subparser_flags("check")
+
+    unexpected_inner_only = (inner - outer) - INNER_ONLY_CHECK_ALLOWLIST
+
+    if unexpected_inner_only:
+        flag_list = "\n  ".join(sorted(unexpected_inner_only))
+        pytest.fail(
+            "Argparse drift detected: the following flags are accepted by "
+            "the inner 'check_cmd.py' parser but rejected by the outer "
+            "'kct check' parser:\n  "
+            f"{flag_list}\n\n"
+            "Fix by adding each flag to BOTH:\n"
+            "  1. src/kicad_tools/cli/parser.py :: _add_check_parser\n"
+            "  2. src/kicad_tools/cli/commands/validation.py :: "
+            "run_check_command (forward to sub_argv)\n\n"
+            "Model after the --refill-zones / --waivers blocks added by "
+            "#4633.  If the flag is genuinely internal-only "
+            "(debug/profiling), add it to INNER_ONLY_CHECK_ALLOWLIST in "
+            "tests/test_cli_parser_drift.py with justification."
+        )
+
+
+def test_check_outer_only_flags_are_in_allowlist():
+    """Every flag on the outer check parser must be on the inner one.
+
+    Guards the #2819 direction applied to ``check``: a flag the outer
+    parser accepts but the shim never forwards, so the user-supplied
+    value is silently discarded.
+    """
+    inner = _inner_check_parser_flags()
+    outer = _outer_subparser_flags("check")
+
+    unexpected_outer_only = (outer - inner) - OUTER_ONLY_CHECK_ALLOWLIST
+
+    if unexpected_outer_only:
+        flag_list = "\n  ".join(sorted(unexpected_outer_only))
+        pytest.fail(
+            "Argparse drift detected: the following flags are accepted by "
+            "the outer 'kct check' parser but rejected by the inner "
+            "'check_cmd.py' parser:\n  "
+            f"{flag_list}\n\n"
+            "These flags will be silently dropped by the forwarding shim, "
+            "so any user-supplied value is ignored.  Fix by:\n"
+            "  1. src/kicad_tools/cli/check_cmd.py :: main "
+            "(add matching add_argument)\n"
+            "  2. src/kicad_tools/cli/commands/validation.py :: "
+            "run_check_command (forward to sub_argv)\n\n"
+            "If the flag is genuinely consumed by the shim and "
+            "intentionally never forwarded, add it to "
+            "OUTER_ONLY_CHECK_ALLOWLIST with justification."
+        )
+
+
+def test_check_allowlist_entries_are_actually_inner_only():
+    """Sanity: ``INNER_ONLY_CHECK_ALLOWLIST`` must not go stale.
+
+    Mirrors ``test_allowlist_entries_are_actually_inner_only`` for the
+    check pair, so an allowlisted flag that later gains an outer
+    declaration stops masking future drift for that flag.
+    """
+    inner = _inner_check_parser_flags()
+    outer = _outer_subparser_flags("check")
+
+    stale: set[str] = set()
+    for flag in INNER_ONLY_CHECK_ALLOWLIST:
+        if flag not in inner:
+            stale.add(f"{flag} (not on inner parser at all)")
+        elif flag in outer:
+            stale.add(f"{flag} (now on outer parser -- remove from allowlist)")
+
+    if stale:
+        entries = "\n  ".join(sorted(stale))
+        pytest.fail(
+            "Stale entries in INNER_ONLY_CHECK_ALLOWLIST:\n  "
+            f"{entries}\n\n"
+            "Remove these entries from tests/test_cli_parser_drift.py."
+        )
+
+
+def test_check_allowlist_entries_are_actually_outer_only():
+    """Sanity: ``OUTER_ONLY_CHECK_ALLOWLIST`` must not go stale."""
+    inner = _inner_check_parser_flags()
+    outer = _outer_subparser_flags("check")
+
+    stale: set[str] = set()
+    for flag in OUTER_ONLY_CHECK_ALLOWLIST:
+        if flag not in outer:
+            stale.add(f"{flag} (not on outer parser at all)")
+        elif flag in inner:
+            stale.add(f"{flag} (now on inner parser -- remove from allowlist)")
+
+    if stale:
+        entries = "\n  ".join(sorted(stale))
+        pytest.fail(
+            "Stale entries in OUTER_ONLY_CHECK_ALLOWLIST:\n  "
+            f"{entries}\n\n"
+            "Remove these entries from tests/test_cli_parser_drift.py."
+        )
+
+
+def test_inner_check_parser_capture_is_not_vacuous():
+    """Negative control for the ``prog``-string trap (#4633).
+
+    The inner check parser uses ``prog="kct check"`` while the outer
+    subparser inherits ``"kicad-tools check"``.  A filter on the wrong
+    prog would capture nothing; depending on how the helper is written
+    that either fails loudly or degrades into comparing a set against
+    itself (a permanently-green test).  This pins the loud behaviour:
+
+    1. the default capture returns a non-empty flag set, and
+    2. a wrong prog string raises ``AssertionError``, it does not
+       silently return an empty set.
+    """
+    inner = _inner_check_parser_flags()
+    assert inner, "inner check parser capture returned an empty flag set"
+    # A few flags that have been on the inner parser since long before
+    # #4633 -- if these vanish, the capture is looking at the wrong parser.
+    assert {"--errors-only", "--strict", "--layers"} <= inner, (
+        f"inner check capture looks wrong; got {sorted(inner)}"
+    )
+
+    with pytest.raises(AssertionError, match="failed to capture inner check parser"):
+        _inner_check_parser_flags(prog="kicad-tools check")
+
+
+def test_no_net_class_map_is_on_both_check_parsers():
+    """Direct regression pin for #4601 / PR #4629.
+
+    ``--no-net-class-map`` is the flag whose Judge review surfaced the
+    missing ``check`` guard (#4633).  It is correct on both parsers
+    today; pin it so it cannot drift.
+    """
+    inner = _inner_check_parser_flags()
+    outer = _outer_subparser_flags("check")
+
+    assert "--no-net-class-map" in inner, (
+        "--no-net-class-map is missing from the inner check_cmd.py parser "
+        "(this would regress #4601)"
+    )
+    assert "--no-net-class-map" in outer, (
+        "--no-net-class-map is missing from the outer parser.py check "
+        "subparser (this would regress #4601)"
+    )
+
+
+@pytest.mark.parametrize(
+    "flag",
+    ["--refill-zones", "--courtyard-waivers", "--waivers"],
+)
+def test_drifted_check_flags_are_on_both_parsers(flag):
+    """Direct regression pins for the three drift instances fixed by #4633.
+
+    Each was declared on ``check_cmd.py`` only and rejected by the real
+    ``kct check`` CLI:  ``--refill-zones`` (#4113) was entirely
+    unreachable; ``--courtyard-waivers`` (#4137) and ``--waivers``
+    (#4417) lost only their explicit-path override because both sidecars
+    are auto-discovered next to the board.
+    """
+    inner = _inner_check_parser_flags()
+    outer = _outer_subparser_flags("check")
+
+    assert flag in inner, f"{flag} is missing from the inner check_cmd.py parser"
+    assert flag in outer, (
+        f"{flag} is missing from the outer parser.py check subparser "
+        "(this would regress #4633 -- `kct check` would reject it with "
+        "'unrecognized arguments')"
+    )
+
+
+def test_check_shim_forwards_drifted_flags_to_inner_main():
+    """The shim must actually forward the #4633 flags, not just parse them.
+
+    Declaring the flags on the outer parser alone would fix the
+    ``unrecognized arguments`` error while still discarding the value --
+    the #2819 failure mode.  This drives the real
+    ``create_parser() -> run_check_command`` path and asserts the flags
+    and their values land in the argv handed to ``check_cmd.main``.
+    """
+    from kicad_tools.cli.commands.validation import run_check_command
+    from kicad_tools.cli.parser import create_parser
+
+    args = create_parser().parse_args(
+        [
+            "check",
+            "board.kicad_pcb",
+            "--refill-zones",
+            "--courtyard-waivers",
+            "/tmp/cw.json",
+            "--waivers",
+            "/tmp/w.json",
+        ]
+    )
+
+    with patch("kicad_tools.cli.check_cmd.main", return_value=0) as inner_main:
+        assert run_check_command(args) == 0
+
+    assert inner_main.call_count == 1
+    sub_argv = inner_main.call_args[0][0]
+
+    assert "--refill-zones" in sub_argv, f"run_check_command dropped --refill-zones; got {sub_argv}"
+    for opt, value in (
+        ("--courtyard-waivers", "/tmp/cw.json"),
+        ("--waivers", "/tmp/w.json"),
+    ):
+        assert opt in sub_argv, f"run_check_command dropped {opt}; got {sub_argv}"
+        assert sub_argv[sub_argv.index(opt) + 1] == value, (
+            f"run_check_command forwarded {opt} without its value; got {sub_argv}"
+        )
+
+
+def test_check_shim_omits_drifted_flags_when_unset():
+    """Absent flags must not be forwarded (default behaviour preserved).
+
+    Note the value-bearing flags use a truthiness guard, matching the
+    existing ``--net-class-map`` block: an empty-string path is treated
+    as "not supplied" rather than forwarded as ``--waivers ''``.
+    """
+    from kicad_tools.cli.commands.validation import run_check_command
+    from kicad_tools.cli.parser import create_parser
+
+    args = create_parser().parse_args(["check", "board.kicad_pcb"])
+    with patch("kicad_tools.cli.check_cmd.main", return_value=0) as inner_main:
+        run_check_command(args)
+    sub_argv = inner_main.call_args[0][0]
+    for opt in ("--refill-zones", "--courtyard-waivers", "--waivers"):
+        assert opt not in sub_argv, f"{opt} forwarded even though it was not supplied"
+
+    args = create_parser().parse_args(["check", "board.kicad_pcb", "--waivers", ""])
+    with patch("kicad_tools.cli.check_cmd.main", return_value=0) as inner_main:
+        run_check_command(args)
+    sub_argv = inner_main.call_args[0][0]
+    assert "--waivers" not in sub_argv, (
+        "an empty --waivers path should be treated as absent (matching the "
+        f"--net-class-map truthiness guard); got {sub_argv}"
     )


### PR DESCRIPTION
## Summary

`tests/test_cli_parser_drift.py` guarded only the `route` / `fix-drc` parser pairs. The `check` pair (`parser.py::_add_check_parser` → `commands/validation.py::run_check_command` → `check_cmd.main`) has the identical three-hop shape and had **no guard** — and had already accumulated **three live instances** of the bug class it exists to prevent.

Measured on `main` @ `473de1f8` (re-verified on this branch's base before the fix):

```
outer `kct check` subparser:  23 long flags
inner `check_cmd.main`:       26 long flags

INNER-ONLY (accepted by check_cmd.main, REJECTED by `kct check`):
  --courtyard-waivers
  --refill-zones
  --waivers
OUTER-ONLY: (none)
```

| Flag | Added by | Impact before this PR |
|---|---|---|
| `--refill-zones` | #4113 | **Entirely unreachable** through `kct` despite being advertised in `CHANGELOG.md:437` and `docs/reference/cli.md` |
| `--courtyard-waivers` | #4137 | Only the explicit-path override lost (sidecar auto-discovers next to the board) |
| `--waivers` | #4417 | Same partial degradation — which is why the drift stayed invisible |

Per the route allowlist's own documented rule ("in most cases the right answer is to add it to BOTH parsers"), all three are **fixed**, not allowlisted. Both new `check` allowlists therefore land **empty**, mirroring the existing `OUTER_ONLY_ALLOWLIST`.

## Changes

**`src/kicad_tools/cli/parser.py`** — `_add_check_parser` gains `--refill-zones` (`dest=refill_zones`, `store_true`, keeping the "**WARNING: this MUTATES the board file in place**" wording now that the flag is reachable), `--courtyard-waivers` (`dest=courtyard_waivers`, `default=None`) and `--waivers` (`dest=waivers`, `default=None`). Dests match `check_cmd.main` exactly.

**`src/kicad_tools/cli/commands/validation.py`** — `run_check_command` forwards all three into `sub_argv` in the established `getattr`-guarded style, modelled on the `--net-class-map` block.

**`tests/test_cli_parser_drift.py`** — new `check`-pair section (route/fix-drc code untouched; `INNER_ONLY_ALLOWLIST` / `OUTER_ONLY_ALLOWLIST` not renamed or restructured):

- `_inner_check_parser_flags(prog="kct check")` — filters on the correct prog and keeps a hard `assert` on capture.
- `INNER_ONLY_CHECK_ALLOWLIST` / `OUTER_ONLY_CHECK_ALLOWLIST`, both empty, each with a comment explaining the empty state and the criteria for a future entry.
- Symmetric containment in both directions + two stale-allowlist sanity tests.
- `test_inner_check_parser_capture_is_not_vacuous` — the prog-string negative control.
- Direct pins: `--no-net-class-map` (the #4601 flag that surfaced this) and a parametrized pin over the three drifted flags.
- Two shim tests proving the values reach `check_cmd.main` (not merely parse), and that absent flags are not forwarded.
- Module docstring extended to cover the `check` pair and cite the three drift instances.

**`docs/reference/cli.md`** — `### check` option table only: dropped the phantom `--rules RULES` row (exists on **neither** parser — verified `unrecognized arguments`), corrected `--format` to `{table,json,summary}`, added `--waivers` / `--courtyard-waivers` rows.

`CHANGELOG.md` deliberately untouched — declared out of scope by the issue to avoid a four-way wave-1 collision.

## Acceptance Criteria Verification

- [x] Symmetric containment asserted for the `check` pair (`inner - outer ⊆ INNER_ONLY_CHECK_ALLOWLIST`, `outer - inner ⊆ OUTER_ONLY_CHECK_ALLOWLIST`).
- [x] Both new allowlists empty, each documenting the empty state and future-entry criteria.
- [x] Stale-allowlist sanity tests exist for both `check` directions.
- [x] All three flags declared on `_add_check_parser` **and** forwarded by `run_check_command`, dests matching `check_cmd.main`.
- [x] All three parse through the real CLI and the value reaches `check_cmd.main` — see "Manual CLI verification" below.
- [x] `--no-net-class-map` pinned on both `check` parsers.
- [x] **Negative control demonstrated** (output below) — the containment test fails and names the flag.
- [x] `_inner_check_parser_flags()` filters on `prog == "kct check"` and asserts the capture succeeded; a dedicated test proves a wrong prog raises rather than going vacuous.
- [x] Route/fix-drc tests unchanged in behavior; existing allowlists untouched.
- [x] `docs/reference/cli.md` table corrected.
- [x] `uv run pytest tests/test_cli_parser_drift.py -v` → **26 passed**; `uv run ruff check .` → *All checks passed*; `uv run ruff format . --check` → *1731 files already formatted*; mypy baseline gate (`scripts/ci/check_mypy_baseline.py`) → *1473 errors, all within the baseline (1474 allowed). No new type errors.*

### Negative control #1 (required, AC-bearing) — flag removed from `_add_check_parser`

Temporarily deleted the `--no-net-class-map` `add_argument` block from `_add_check_parser` (leaving it on `check_cmd.main`), then re-ran the suite:

```
FAILED tests/test_cli_parser_drift.py::test_check_inner_only_flags_are_in_allowlist
FAILED tests/test_cli_parser_drift.py::test_no_net_class_map_is_on_both_check_parsers
2 failed, 24 passed in 1.14s

E  Failed: Argparse drift detected: the following flags are accepted by the inner
E  'check_cmd.py' parser but rejected by the outer 'kct check' parser:
E    --no-net-class-map
E
E  Fix by adding each flag to BOTH:
E    1. src/kicad_tools/cli/parser.py :: _add_check_parser
E    2. src/kicad_tools/cli/commands/validation.py :: run_check_command (forward to sub_argv)
```

The block was then restored (`git diff --stat` confirms `parser.py` carries only the three additions).

### Negative control #2 (prog-string vacuity)

`test_inner_check_parser_capture_is_not_vacuous` pins the loud behaviour: the default capture returns a non-empty set containing long-standing inner flags, and `_inner_check_parser_flags(prog="kicad-tools check")` — the copy-paste-from-route mistake — raises `AssertionError: failed to capture inner check parser`, rather than returning `set()` and letting the containment test compare the outer parser with itself.

### Manual CLI verification (the hop no unit test covers)

```console
$ uv run kct check --help | grep -E 'refill-zones|waivers'
  --refill-zones        Before checking, run `kicad-cli pcb drc --refill-zones
  --courtyard-waivers COURTYARD_WAIVERS
  --waivers WAIVERS     Path to a general .kct_waivers.json sidecar (schema

$ uv run kct check boards/00-simple-led/output/simple_led_routed.kicad_pcb --waivers /tmp/nope-4633.json
Error: waivers file not found: /private/tmp/nope-4633.json          # value REACHED check_cmd.main

$ uv run kct check boards/00-simple-led/output/simple_led_routed.kicad_pcb --courtyard-waivers /tmp/nope-4633.json
Error: courtyard-waivers file not found: /private/tmp/nope-4633.json

$ uv run kct check /tmp/.../nonexistent-4633.kicad_pcb --refill-zones
Error: Path not found: /tmp/.../nonexistent-4633.kicad_pcb          # parses; no "unrecognized arguments"
```

All three previously produced `kicad-tools: error: unrecognized arguments`.

`--refill-zones` end-to-end was exercised only against a **copy** in a scratch directory, never a tracked `boards/*/output/*.kicad_pcb`; that run (kicad-cli refill on a loaded host) was long-running and cut short, so end-to-end refill behaviour is unchanged/unverified by this PR — reachability is what changed, and it is covered by the shim-forwarding unit test plus the CLI probe above. `git status --porcelain` is clean in the worktree and `check-main-clean.sh` reports the main checkout clean.

### Edge case noted

`--waivers ""` (empty string) is treated as **absent** and not forwarded — the `getattr(args, "waivers", None)` truthiness guard matches the existing `--net-class-map` semantics exactly. Pinned by `test_check_shim_omits_drifted_flags_when_unset`.

### On the suspected cause

The curator's structural hypothesis holds up: every `check` test in the suite calls `check_cmd.main()` directly, so a flag added there is fully exercised by CI while the outer hop is never touched. This PR makes the outer hop a test-visible surface, which is the structural fix rather than a process reminder.

## Test Plan

- [x] `uv run pytest tests/test_cli_parser_drift.py -q` → 26 passed
- [x] Negative control #1 (flag removal) → 2 failed as designed, then restored
- [x] Negative control #2 (prog vacuity) → covered by a permanent test
- [x] Manual CLI verification of all three flags
- [x] `uv run ruff check .` / `uv run ruff format . --check` / mypy baseline gate
- [x] Regression sweep over `tests/test_cli_check*.py`, `tests/test_build_parser_parity.py`, `tests/test_check_cmd_coverage.py` — no failures

### ⚠️ Wave-1 merge note

`src/kicad_tools/cli/check_cmd.py` is owned by #4634 and is **read-only** here (no edit overlap). But this PR installs a guard that fails if `check_cmd.main` gains a flag `_add_check_parser` lacks — so whichever of this PR / #4634 merges second must re-run `tests/test_cli_parser_drift.py` and mirror any new inner `check` flag onto the outer parser + shim. That is the guard doing its job.

Closes #4633
