### PR TITLE
refactor(sidecars): share one net-class-map probe across all four consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   copper-dirty branch is now a detail-selection branch rather than a return. Exit
   codes are unaffected — a copper-dirty board already failed (#4616).
 
+- **`kct check` and the CI merge gates could load different net-class-map
+  sidecars.** Stem-keyed sidecar discovery (#4601) reached `kct check` only, so
+  in a directory holding both `<board-stem>.net_class_map.json` and
+  `net_class_map.json` the routed-DRC gate, the match-group gate and the
+  `kct export` report surface all loaded the *other* file — a different rule set
+  for the three gated rules locally than in the gate that guards merge, with no
+  warning on either side. All four consumers now share one stdlib-only probe
+  (`kicad_tools.sidecars`); each keeps its own directory scope, so boards
+  carrying only the bare name (every board in this repo) resolve exactly what
+  they resolved before (#4634).
+
 ### Known limitations
 
 - `silk_over_copper`'s aperture set is **pad-only**: untented via mask openings

--- a/docs/guides/drc-and-validation.md
+++ b/docs/guides/drc-and-validation.md
@@ -156,6 +156,23 @@ short-circuits the probe entirely. An auto-discovered sidecar that fails to
 parse degrades gracefully (`WARNING: ignoring malformed net-class-map sidecar
 …`, then continue with no map); an explicit one that fails is a hard error.
 
+**The probe order is shared, not a `kct check` feature.** The accepted
+filenames and their in-directory precedence live in one place —
+`kicad_tools/sidecars.py` — and all four sidecar consumers use it: `kct check`,
+the routed-DRC CI gate (`scripts/ci/check_routed_drc.py` via
+`net_class_map_resolver.py`), the match-group CI gate
+(`scripts/ci/check_matchgroup_coverage.py`) and the `kct export` report surface
+(`kicad_tools/report/net_class_map.py`). A directory holding both filename
+forms therefore resolves to the *same* file everywhere, so a board cannot be
+checked against one rule set locally and a different one by the gate that
+guards merge.
+
+What is **not** shared is how many directories each consumer searches, and that
+is deliberate. `kct check` walks the three directories listed above; the two CI
+gates and the report surface each search exactly one (`<pcb-dir>` for the
+routed-DRC gate and the report, `<board-dir>/output` for the match-group gate).
+Widening any of them would change which sidecar a board resolves.
+
 Pass `--no-net-class-map` to suppress auto-discovery and restore the
 historical no-sidecar behaviour — useful when a stale sidecar sits beside the
 board. Combining it with `--net-class-map` is a usage error. When no sidecar is
@@ -164,10 +181,14 @@ exact paths that were probed, or says that discovery was turned off.
 
 **CI resolves the map automatically.** The strict routed-PCB DRC gate
 (`scripts/ci/check_routed_drc.py`) is net-class-map-aware: it prefers a
-committed `net_class_map.json` next to the routed PCB and, for boards that
-don't commit one (e.g. board 06), derives it in-process from the board's
-`build_net_class_map()`. This keeps the CI gate's error count in parity with
-the in-pipeline DRC while leaving the standalone `kct check` no-op contract
+committed sidecar next to the routed PCB — accepting **both** filename forms in
+the same order `kct check` uses, stem-keyed
+`<board-stem>.net_class_map.json` first and bare `net_class_map.json` second —
+and, for boards that don't commit one (e.g. board 06), derives it in-process
+from the board's `build_net_class_map()`. The match-group gate
+(`scripts/ci/check_matchgroup_coverage.py`) accepts the same two names in
+`<board-dir>/output`. This keeps the CI gates' error counts in parity with the
+in-pipeline DRC while leaving the standalone `kct check` no-op contract
 unchanged.
 
 ## CLI: Compare Manufacturer Rules

--- a/scripts/ci/check_matchgroup_coverage.py
+++ b/scripts/ci/check_matchgroup_coverage.py
@@ -85,6 +85,16 @@ this gate and ``check_routed_drc.py`` compare the *same* count against the
 read the raw ``summary.errors`` integer (advisory ``connectivity`` errors
 included), which diverged from ``check_routed_drc.py``'s blocking-only
 count and forced the shared floor up to absorb the difference.
+
+Exception (Issue #4634): the net-class-map sidecar *filename* probe is
+likewise no longer duplicated -- ``find_net_class_map_sidecar`` delegates
+the name set and their in-directory precedence to
+``kicad_tools.sidecars``.  Four copies of that probe had drifted apart
+after #4601/PR #4629 taught ``kct check`` about the stem-keyed
+``<pcb_stem>.net_class_map.json`` name, so this gate could have passed a
+different sidecar to ``kct check`` than a developer's local ``kct check``
+would have auto-discovered.  The directory this gate searches
+(``board_dir/output``) is unchanged.
 """
 
 from __future__ import annotations
@@ -97,6 +107,15 @@ import sys
 from pathlib import Path
 
 import yaml
+
+# Issue #4634: the sidecar filename rules are shared with ``kct check``, the
+# routed-DRC gate and the ``kct export`` report surface via the stdlib-only
+# leaf module ``kicad_tools.sidecars``, so no two of them can resolve
+# different files for the same board.
+from kicad_tools.sidecars import (
+    first_existing_net_class_map_sidecar,
+    net_class_map_sidecar_names,
+)
 
 # Issue #4008: import the single shared blocking-error counter so this gate
 # and ``check_routed_drc.py`` agree on the count they gate against.
@@ -324,8 +343,8 @@ def find_routed_pcb(board_dir: Path) -> Path | None:
     return candidates[0]
 
 
-def find_net_class_map_sidecar(board_dir: Path) -> Path | None:
-    """Locate the board's ``net_class_map.json`` sidecar.
+def find_net_class_map_sidecar(board_dir: Path, routed_pcb: Path) -> Path | None:
+    """Locate the board's net-class-map sidecar.
 
     The Phase 3L scaffolding (Issue #2724) emits the sidecar from
     ``generate_design.write_sidecar()`` during the route step, so the
@@ -333,10 +352,21 @@ def find_net_class_map_sidecar(board_dir: Path) -> Path | None:
     is mandatory for the ``match_group_length_skew`` rule to fire under
     standalone ``kct check`` -- without it the rule degrades to a no-op
     (see ``MatchGroupLengthSkewRule`` docstring).
+
+    Issue #4634: both accepted filenames are probed in the shared order
+    (stem-keyed ``<pcb_stem>.net_class_map.json`` first, then the bare
+    ``net_class_map.json``) via :mod:`kicad_tools.sidecars`, so this gate
+    can never resolve a different file than the ``kct check`` invocation
+    it goes on to gate.  The **directory** scope is unchanged:
+    ``board_dir/output`` only.
+
+    Args:
+        board_dir: The board directory (``boards/NN-name``).
+        routed_pcb: The routed PCB the sidecar must describe -- supplies
+            the exact stem for the stem-keyed candidate.  The caller
+            already holds it from :func:`find_routed_pcb`.
     """
-    out = board_dir / "output"
-    sidecar = out / "net_class_map.json"
-    return sidecar if sidecar.is_file() else None
+    return first_existing_net_class_map_sidecar([board_dir / "output"], routed_pcb.stem)
 
 
 def _import_module_from_path(module_name: str, path: Path):
@@ -662,15 +692,17 @@ def check_board(
         )
         return 1
 
-    sidecar = find_net_class_map_sidecar(board_dir)
+    sidecar = find_net_class_map_sidecar(board_dir, routed_pcb)
     if sidecar is None:
+        expected = " or ".join(
+            f"{board_dir}/output/{name}" for name in net_class_map_sidecar_names(routed_pcb.stem)
+        )
         annotate_error(
             str(board_dir),
             (
-                "No net_class_map.json sidecar found in board output dir; "
+                "No net-class-map sidecar found in board output dir; "
                 "the match_group_length_skew rule will degrade to a no-op "
-                "without it.  Expected at "
-                f"{board_dir}/output/net_class_map.json (emitted by "
+                f"without it.  Expected at {expected} (emitted by "
                 "generate_design.write_sidecar)."
             ),
         )

--- a/scripts/ci/net_class_map_resolver.py
+++ b/scripts/ci/net_class_map_resolver.py
@@ -27,10 +27,13 @@ WITHOUT changing the standalone-CLI no-op contract:
   implementation.
 * :func:`resolve_net_class_map_sidecar` -- a context manager that yields a
   filesystem path suitable for ``--net-class-map``.  It prefers a committed
-  ``net_class_map.json`` sidecar next to the routed PCB (board 07 has one);
-  when none exists (board 06 does NOT commit one) it falls back to
-  in-process derivation, serialising the derived map to a temporary file
-  that is cleaned up on exit.
+  sidecar next to the routed PCB (board 07 has one) -- either the
+  stem-keyed ``<pcb_stem>.net_class_map.json`` or the bare
+  ``net_class_map.json``, resolved by the shared
+  :mod:`kicad_tools.sidecars` helper so this gate and ``kct check`` can
+  never load different files (Issue #4634); when none exists (board 06
+  does NOT commit one) it falls back to in-process derivation, serialising
+  the derived map to a temporary file that is cleaned up on exit.
 
 The standalone ``kct check`` behaviour is unchanged: the no-op contract
 lives in the DRC rules, and this module only affects what the CI gates
@@ -49,9 +52,23 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
-# Canonical name of the committed sidecar a board's generate_design.py may
-# emit next to its routed PCB (Phase 3M pattern; board 07 emits one).
-SIDECAR_FILENAME = "net_class_map.json"
+# Issue #4634: the sidecar *filename* rules are shared with ``kct check``
+# and the ``kct export`` report surface via the stdlib-only leaf module
+# ``kicad_tools.sidecars``.  Unlike ``count_blocking_errors``' deliberately
+# lazy ``DRCChecker`` import below, this one is module level because
+# ``SIDECAR_FILENAME`` is a module-level constant other modules and tests
+# import.  ``scripts/ci`` -> ``kicad_tools`` is the established direction
+# (never the reverse: ``scripts/ci`` has no ``__init__.py`` and is excluded
+# from the wheel), and these gates always run under ``uv run``.
+from kicad_tools.sidecars import (
+    NET_CLASS_MAP_SIDECAR_BASENAME,
+    first_existing_net_class_map_sidecar,
+)
+
+# Canonical *bare* name of the committed sidecar a board's generate_design.py
+# may emit next to its routed PCB (Phase 3M pattern; board 07 emits one).
+# Re-exported under the historical name so importers keep working.
+SIDECAR_FILENAME = NET_CLASS_MAP_SIDECAR_BASENAME
 
 
 def count_blocking_errors(data: dict[str, Any]) -> tuple[int, dict[str, int]]:
@@ -219,10 +236,17 @@ def resolve_net_class_map_sidecar(pcb_path: Path) -> Iterator[Path | None]:
 
     Resolution order (Issue #3151, Option B):
 
-    1. **Committed sidecar** -- if ``<pcb_dir>/net_class_map.json`` exists
-       (board 07's ``generate_design.py`` emits one), yield it directly.
-       This is the same sidecar the board's in-pipeline ``run_drc`` uses,
-       so the CI gate counts exactly what ``generate_design.py`` counts.
+    1. **Committed sidecar** -- if a committed sidecar exists in
+       ``<pcb_dir>`` (board 07's ``generate_design.py`` emits one), yield
+       it directly.  This is the same sidecar the board's in-pipeline
+       ``run_drc`` uses, so the CI gate counts exactly what
+       ``generate_design.py`` counts.  Both accepted filenames are probed
+       in the shared order -- stem-keyed
+       ``<pcb_stem>.net_class_map.json`` first, then the bare
+       ``net_class_map.json`` -- so this gate can never load a different
+       file than ``kct check`` does (Issue #4634).  The **directory**
+       scope is unchanged and deliberately narrower than ``kct check``'s:
+       the PCB's own directory only.
     2. **In-process derivation** -- otherwise import the board's
        ``generate_design.build_net_class_map()`` and serialise the result
        to a temporary JSON file (board 06 has no committed sidecar).  The
@@ -241,8 +265,8 @@ def resolve_net_class_map_sidecar(pcb_path: Path) -> Iterator[Path | None]:
     pcb_path = Path(pcb_path)
 
     # (1) Prefer a committed sidecar adjacent to the routed PCB.
-    committed = pcb_path.resolve().parent / SIDECAR_FILENAME
-    if committed.is_file():
+    committed = first_existing_net_class_map_sidecar([pcb_path.resolve().parent], pcb_path.stem)
+    if committed is not None:
         yield committed
         return
 

--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -32,6 +32,7 @@ from typing import Literal
 
 from kicad_tools.manufacturers import get_manufacturer_ids, get_profile
 from kicad_tools.schema.pcb import PCB
+from kicad_tools.sidecars import net_class_map_sidecar_candidates
 from kicad_tools.sync.discover import resolve_target_fab_for_pcb
 from kicad_tools.validate import DRCChecker, DRCResults, DRCViolation
 
@@ -322,46 +323,20 @@ def _net_class_map_sidecar_candidates(pcb_path: Path) -> list[Path]:
     so the "rules are INACTIVE" warning can name the paths that were
     *actually* searched instead of an invented ``output/…`` example.
 
-    Two filename conventions are probed in each directory:
-
-    - ``<pcb_stem>.net_class_map.json`` -- the stem-keyed sidecar
-      convention used by hand-maintained board trees that keep several
-      revisions side by side (``board_v24.kicad_pcb`` next to
-      ``board_v24.net_class_map.json``).
-    - ``net_class_map.json`` -- the bare name written by ``kct route``
-      (Issue #3917 Defect 1 / #4428).
-
-    Ordering is deliberate: within a directory the **stem-keyed** name
-    wins (it is evidence about *this* board, not a generic file), and
-    nearer directories win over farther ones (the pre-#4601
-    ``pcb_dir`` -> ``pcb_dir/output`` -> ``pcb_dir.parent/output``
-    order is preserved).
-
-    The stem must match **exactly**: no globbing and no un-suffixing
-    heuristics.  A directory holding ``board_v23.net_class_map.json``
-    and ``board_v24.net_class_map.json`` must never apply v23's
-    constraints to a v24 board, and ``board_routed.kicad_pcb`` looks
-    only for ``board_routed.net_class_map.json``.
+    Issue #4634 hoisted the probe itself into
+    :mod:`kicad_tools.sidecars` so the three sibling consumers (the two
+    CI merge gates and the ``kct export`` report surface) resolve the
+    same filenames in the same order; this remains a thin alias so both
+    call sites and the warning surface are unchanged.  See
+    :func:`kicad_tools.sidecars.net_class_map_sidecar_candidates` for
+    the probe order and the exact-stem contract.
 
     Returns:
         Candidate paths in probe order, de-duplicated (the
         ``<board>/output/<pcb>`` layout makes ``pcb_dir`` and
         ``pcb_dir.parent/output`` the same directory).
     """
-    pcb_dir = pcb_path.parent
-    names = [f"{pcb_path.stem}.net_class_map.json", "net_class_map.json"]
-    directories = [pcb_dir, pcb_dir / "output", pcb_dir.parent / "output"]
-
-    candidates: list[Path] = []
-    seen: set[Path] = set()
-    for directory in directories:
-        for name in names:
-            candidate = directory / name
-            if candidate in seen:
-                continue
-            seen.add(candidate)
-            candidates.append(candidate)
-    return candidates
+    return net_class_map_sidecar_candidates(pcb_path)
 
 
 def _discover_net_class_map_sidecar(pcb_path: Path) -> Path | None:

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -91,6 +91,10 @@ if TYPE_CHECKING:
 # not remove this alias without also updating those patch targets.
 from kicad_tools.router.auto_pour import auto_skip_pour_nets as _auto_skip_pour_nets  # noqa: E402
 
+# Issue #4634: the sidecar filename this writer emits is the same constant the
+# four sidecar *probes* share, so writer and readers cannot drift apart.
+from kicad_tools.sidecars import NET_CLASS_MAP_SIDECAR_BASENAME  # noqa: E402
+
 logger = logging.getLogger(__name__)
 
 
@@ -2079,7 +2083,7 @@ def _write_net_class_map_sidecar(
     if not effective_map:
         return
 
-    sidecar_path = output_path.parent / "net_class_map.json"
+    sidecar_path = output_path.parent / NET_CLASS_MAP_SIDECAR_BASENAME
 
     # Never clobber the user's --net-class-map input file (Issue #4428).
     diverted = False

--- a/src/kicad_tools/report/net_class_map.py
+++ b/src/kicad_tools/report/net_class_map.py
@@ -22,26 +22,43 @@ dual-gate-counter scenario (#4008 / PR #4029), not for ``kct export``.
 Crucially, this deliberately does NOT import from ``scripts/ci/`` —
 that path has no ``__init__.py`` and is excluded from the installed package
 (``pip install kicad-tools``), so importing it from ``src/kicad_tools/``
-would break wheel installs. The tier-1 logic here is intentionally a small,
-self-contained reimplementation of that resolver's first tier.
+would break wheel installs.
+
+Issue #4634: the *filename* probe is no longer reimplemented here. It was
+a fourth independent copy that fell out of sync when #4601/PR #4629 taught
+``kct check`` about the stem-keyed ``<pcb_stem>.net_class_map.json``
+convention, so in a directory holding both forms this surface loaded a
+different file (and therefore a different rule set) than ``kct check``.
+The names and their in-directory precedence now come from the stdlib-only
+leaf module :mod:`kicad_tools.sidecars`, which both this module and the
+``scripts/ci`` gates import. The **directory** scope stays tier-1-only
+(the PCB's own directory) — that part is intentionally unchanged.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
-# Canonical name of the committed sidecar a board's generate_design.py may
-# emit next to its routed PCB (Phase 3M pattern; boards 03/06/07 emit one).
-# Kept identical to scripts/ci/net_class_map_resolver.SIDECAR_FILENAME.
-SIDECAR_FILENAME = "net_class_map.json"
+from kicad_tools.sidecars import (
+    NET_CLASS_MAP_SIDECAR_BASENAME,
+    first_existing_net_class_map_sidecar,
+)
+
+# Canonical *bare* name of the committed sidecar a board's generate_design.py
+# may emit next to its routed PCB (Phase 3M pattern; boards 03/06/07 emit one).
+# Re-exported from kicad_tools.sidecars, which is now the single source of
+# truth shared with scripts/ci/net_class_map_resolver.SIDECAR_FILENAME.
+SIDECAR_FILENAME = NET_CLASS_MAP_SIDECAR_BASENAME
 
 
 def resolve_committed_net_class_map(pcb_path: str | Path) -> Path | None:
-    """Return the committed ``net_class_map.json`` sidecar for a routed PCB.
+    """Return the committed net-class-map sidecar for a routed PCB.
 
-    Looks for ``<pcb_dir>/net_class_map.json`` adjacent to ``pcb_path`` —
-    the same tier-1 lookup as
+    Looks in ``<pcb_dir>`` only — the same tier-1 directory scope as
     ``scripts.ci.net_class_map_resolver.resolve_net_class_map_sidecar``.
+    Within that directory the stem-keyed ``<pcb_stem>.net_class_map.json``
+    wins over the bare ``net_class_map.json`` (Issue #4634; see
+    :func:`kicad_tools.sidecars.net_class_map_sidecar_names`).
 
     Args:
         pcb_path: Path to a routed ``*.kicad_pcb`` file.
@@ -51,7 +68,9 @@ def resolve_committed_net_class_map(pcb_path: str | Path) -> Path | None:
         otherwise ``None`` (the report then keeps its graceful no-op behavior
         for the three sidecar-gated DRC rule families).
     """
-    committed = Path(pcb_path).resolve().parent / SIDECAR_FILENAME
-    if committed.is_file():
-        return committed
-    return None
+    # The directory is resolved (unchanged tier-1 behaviour); the *stem* is
+    # taken from the path as given, so a symlinked PCB looks for the sidecar
+    # named after the name the caller used -- the same stem semantics
+    # ``kct check``'s probe uses.
+    pcb = Path(pcb_path)
+    return first_existing_net_class_map_sidecar([pcb.resolve().parent], pcb.stem)

--- a/src/kicad_tools/sidecars.py
+++ b/src/kicad_tools/sidecars.py
@@ -1,0 +1,173 @@
+"""Shared sidecar-filename resolution (Issue #4634).
+
+A *sidecar* is a small JSON file committed next to a routed PCB that
+carries state the ``.kicad_pcb`` cannot express.  The net-class-map
+sidecar is the important one: it gates three DRC rule families
+(``match_group_length_skew``, ``diffpair_length_skew``,
+``diffpair_routing_continuity``) which short-circuit to a no-op when no
+map is supplied.
+
+Four independent consumers probe for that file:
+
+1. ``kicad_tools.cli.check_cmd`` -- ``kct check``'s auto-discovery.
+2. ``scripts/ci/net_class_map_resolver.py`` -- the routed-DRC CI gate.
+3. ``kicad_tools.report.net_class_map`` -- the ``kct export`` report
+   surface.
+4. ``scripts/ci/check_matchgroup_coverage.py`` -- the match-group CI gate.
+
+Before this module each of them spelled the probe out separately, and
+after PR #4629 (#4601) taught consumer 1 about the **stem-keyed**
+``<pcb_stem>.net_class_map.json`` convention the four no longer agreed on
+the filename set.  In a directory holding *both* forms, ``kct check``
+would load the stem-keyed file while both CI merge gates and the report
+loaded the bare one -- a different rule set locally than in the gate that
+guards merge, with no warning on either side (Issue #4634).
+
+This module is the single source of truth for **which names are probed
+and in what order within a directory**.  It deliberately does NOT decide
+*which directories* a consumer searches: the four consumers legitimately
+differ there (``kct check`` walks three directories, the CI gates and the
+report each search exactly one), and silently widening any of them would
+let a board resolve a sidecar it does not resolve today.  Callers pass
+their own directory list to :func:`first_existing_net_class_map_sidecar`.
+
+Placement rationale (why a top-level leaf module):
+
+* ``src/kicad_tools/`` must never import from ``scripts/ci/`` -- that
+  path has no ``__init__.py`` and is excluded from the installed wheel,
+  so importing it would break ``pip install kicad-tools``.  The shared
+  helper therefore has to live inside the package, and ``scripts/ci/ ->
+  kicad_tools`` is the already-established direction (the CI gates run
+  under ``uv run``).
+* It is NOT folded into ``kicad_tools.report.net_class_map`` because
+  importing anything under ``kicad_tools.report`` executes
+  ``report/__init__.py``, which pulls the optional ``[report]`` extra
+  (jinja2).  A CI gate must not acquire a rendering dependency to
+  resolve a filename.
+
+Accordingly this module imports **stdlib only**.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+__all__ = [
+    "NET_CLASS_MAP_SIDECAR_BASENAME",
+    "first_existing_net_class_map_sidecar",
+    "net_class_map_sidecar_candidates",
+    "net_class_map_sidecar_names",
+]
+
+# The bare, board-agnostic sidecar name.  This is what ``kct route``
+# writes next to the routed PCB (Issue #3917 Defect 1 / #4428) and what
+# every board under ``boards/NN/output/`` commits today.
+NET_CLASS_MAP_SIDECAR_BASENAME = "net_class_map.json"
+
+
+def net_class_map_sidecar_names(pcb_stem: str) -> list[str]:
+    """Return the sidecar filenames to probe in one directory, in order.
+
+    Two filename conventions are accepted:
+
+    - ``<pcb_stem>.net_class_map.json`` -- the stem-keyed sidecar
+      convention used by hand-maintained board trees that keep several
+      revisions side by side (``board_v24.kicad_pcb`` next to
+      ``board_v24.net_class_map.json``).
+    - ``net_class_map.json`` -- the bare name written by ``kct route``
+      (Issue #3917 Defect 1 / #4428).
+
+    Ordering is deliberate: within a directory the **stem-keyed** name
+    wins, because it is evidence about *this* board rather than a
+    generic file.
+
+    The stem must match **exactly**: no globbing and no un-suffixing
+    heuristics.  A directory holding ``board_v23.net_class_map.json``
+    and ``board_v24.net_class_map.json`` must never apply v23's
+    constraints to a v24 board, and ``board_routed.kicad_pcb`` looks
+    only for ``board_routed.net_class_map.json``.
+
+    Args:
+        pcb_stem: The PCB filename stem (``Path.stem``), e.g.
+            ``"board_routed"`` for ``board_routed.kicad_pcb``.
+
+    Returns:
+        Filenames in probe order: stem-keyed first, bare name second.
+        A falsy/empty stem yields the bare name only (there is no
+        meaningful stem-keyed candidate for it).
+    """
+    if not pcb_stem:
+        return [NET_CLASS_MAP_SIDECAR_BASENAME]
+    return [
+        f"{pcb_stem}.{NET_CLASS_MAP_SIDECAR_BASENAME}",
+        NET_CLASS_MAP_SIDECAR_BASENAME,
+    ]
+
+
+def net_class_map_sidecar_candidates(pcb_path: Path | str) -> list[Path]:
+    """Enumerate the candidate sidecar paths ``kct check`` auto-probes.
+
+    This is the widest of the four consumers' probes: three directories
+    x the two names from :func:`net_class_map_sidecar_names`, with
+    nearer directories winning over farther ones (the pre-#4601
+    ``pcb_dir`` -> ``pcb_dir/output`` -> ``pcb_dir.parent/output`` order
+    is preserved).
+
+    Args:
+        pcb_path: Path to the ``*.kicad_pcb`` being checked.
+
+    Returns:
+        Candidate paths in probe order, de-duplicated (the
+        ``<board>/output/<pcb>`` layout makes ``pcb_dir`` and
+        ``pcb_dir.parent/output`` the same directory).
+    """
+    pcb_path = Path(pcb_path)
+    pcb_dir = pcb_path.parent
+    directories = [pcb_dir, pcb_dir / "output", pcb_dir.parent / "output"]
+    return _candidate_paths(directories, pcb_path.stem)
+
+
+def first_existing_net_class_map_sidecar(
+    directories: Sequence[Path] | Iterable[Path],
+    pcb_stem: str,
+) -> Path | None:
+    """Return the first existing sidecar over caller-chosen directories.
+
+    The **name** precedence is shared with every other consumer (see
+    :func:`net_class_map_sidecar_names`); the **directory** scope is the
+    caller's, deliberately.  Consumers that search a single directory
+    today must keep passing a single-element sequence -- widening a
+    consumer's directory scope changes which sidecar a board resolves and
+    is out of scope for the name-unification this module exists to
+    provide (Issue #4634 AC4).
+
+    Args:
+        directories: Directories to search, nearest-wins first.
+        pcb_stem: The PCB filename stem used for the stem-keyed name.
+
+    Returns:
+        The first candidate that exists as a file, or ``None``.
+    """
+    for candidate in _candidate_paths(directories, pcb_stem):
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _candidate_paths(
+    directories: Sequence[Path] | Iterable[Path],
+    pcb_stem: str,
+) -> list[Path]:
+    """Cross directories with names, preserving order and de-duplicating."""
+    names = net_class_map_sidecar_names(pcb_stem)
+    candidates: list[Path] = []
+    seen: set[Path] = set()
+    for directory in directories:
+        for name in names:
+            candidate = Path(directory) / name
+            if candidate in seen:
+                continue
+            seen.add(candidate)
+            candidates.append(candidate)
+    return candidates

--- a/tests/test_net_class_map_sidecar_parity.py
+++ b/tests/test_net_class_map_sidecar_parity.py
@@ -1,0 +1,426 @@
+"""Cross-consumer parity for net-class-map sidecar resolution (Issue #4634).
+
+Four independent consumers probe for a board's net-class-map sidecar:
+
+1. ``kicad_tools.cli.check_cmd._discover_net_class_map_sidecar`` --
+   ``kct check``'s auto-discovery.
+2. ``scripts/ci/net_class_map_resolver.resolve_net_class_map_sidecar`` --
+   the routed-DRC CI merge gate.
+3. ``kicad_tools.report.net_class_map.resolve_committed_net_class_map`` --
+   the ``kct export`` report surface.
+4. ``scripts/ci/check_matchgroup_coverage.find_net_class_map_sidecar`` --
+   the match-group CI merge gate.
+
+PR #4629 (#4601) taught consumer 1 -- and only consumer 1 -- about the
+stem-keyed ``<pcb_stem>.net_class_map.json`` convention.  In a directory
+holding both that file and the bare ``net_class_map.json``, ``kct check``
+therefore loaded a *different* rule set than the two CI gates that guard
+merge, with no warning on either side.
+
+These tests pin the consolidation:
+
+* **AC2/AC3** -- all four agree on the filename set and on stem-keyed
+  beating bare within a directory.
+* **AC4** -- each consumer's *directory* scope is unchanged.  Consumers
+  2/3/4 must still refuse a sidecar that only exists in a directory
+  ``kct check`` reaches but they never did; widening them would silently
+  change which sidecar a board resolves, which is the exact bug class this
+  issue exists to kill.
+* **AC5** -- the three in-repo boards that commit a bare sidecar resolve
+  byte-identically to before.
+* **AC6** -- the shared helper module is a stdlib-only leaf.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.check_cmd import (
+    _discover_net_class_map_sidecar,
+    _net_class_map_sidecar_candidates,
+)
+from kicad_tools.report.net_class_map import resolve_committed_net_class_map
+from kicad_tools.sidecars import (
+    NET_CLASS_MAP_SIDECAR_BASENAME,
+    first_existing_net_class_map_sidecar,
+    net_class_map_sidecar_candidates,
+    net_class_map_sidecar_names,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CI_DIR = REPO_ROOT / "scripts" / "ci"
+SIDECAR_MODULE = REPO_ROOT / "src" / "kicad_tools" / "sidecars.py"
+
+# Boards that commit a bare ``net_class_map.json`` next to their routed PCB
+# (AC5 fixtures -- must keep resolving exactly what they resolve today).
+COMMITTED_SIDECAR_BOARDS = (
+    "03-usb-joystick",
+    "06-diffpair-test",
+    "07-matchgroup-test",
+)
+
+
+def _load_ci_module(name: str):
+    """Import a ``scripts/ci`` script by file path (no package on that path)."""
+    path = CI_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(f"{name}_parity_test_mod", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_board(root: Path, stem: str = "demo_routed") -> Path:
+    """Create ``root/boards/demo/output/<stem>.kicad_pcb`` and return the PCB."""
+    out = root / "boards" / "demo" / "output"
+    out.mkdir(parents=True, exist_ok=True)
+    pcb = out / f"{stem}.kicad_pcb"
+    pcb.write_text("(kicad_pcb)")
+    return pcb
+
+
+def _resolve_all_four(pcb: Path) -> dict[str, Path | None]:
+    """Resolve the sidecar with every consumer, from the same PCB path."""
+    resolver = _load_ci_module("net_class_map_resolver")
+    matchgroup = _load_ci_module("check_matchgroup_coverage")
+    board_dir = pcb.resolve().parent.parent
+
+    with resolver.resolve_net_class_map_sidecar(pcb) as ci_sidecar:
+        ci_resolved = None if ci_sidecar is None else Path(ci_sidecar).resolve()
+
+    return {
+        "check_cmd": _maybe_resolve(_discover_net_class_map_sidecar(pcb)),
+        "ci_routed_drc": ci_resolved,
+        "report": _maybe_resolve(resolve_committed_net_class_map(pcb)),
+        "ci_matchgroup": _maybe_resolve(matchgroup.find_net_class_map_sidecar(board_dir, pcb)),
+    }
+
+
+def _maybe_resolve(path: Path | None) -> Path | None:
+    return None if path is None else Path(path).resolve()
+
+
+# ---------------------------------------------------------------------------
+# AC2 -- the shared name contract
+# ---------------------------------------------------------------------------
+
+
+class TestSharedNameContract:
+    def test_stem_keyed_name_precedes_bare_name(self) -> None:
+        assert net_class_map_sidecar_names("board_v24") == [
+            "board_v24.net_class_map.json",
+            "net_class_map.json",
+        ]
+
+    def test_bare_basename_constant(self) -> None:
+        assert NET_CLASS_MAP_SIDECAR_BASENAME == "net_class_map.json"
+
+    def test_empty_stem_yields_bare_name_only(self) -> None:
+        assert net_class_map_sidecar_names("") == ["net_class_map.json"]
+
+    def test_check_cmd_candidates_delegate_to_the_shared_helper(self, tmp_path: Path) -> None:
+        """``check_cmd``'s private alias must be the shared probe, verbatim."""
+        pcb = _make_board(tmp_path)
+        assert _net_class_map_sidecar_candidates(pcb) == net_class_map_sidecar_candidates(pcb)
+
+    def test_check_cmd_candidate_order(self, tmp_path: Path) -> None:
+        """The pre-#4634 probe order is preserved exactly (3 dirs x 2 names)."""
+        pcb_dir = tmp_path / "boards" / "demo"
+        pcb_dir.mkdir(parents=True)
+        pcb = pcb_dir / "demo_routed.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+
+        assert _net_class_map_sidecar_candidates(pcb) == [
+            pcb_dir / "demo_routed.net_class_map.json",
+            pcb_dir / "net_class_map.json",
+            pcb_dir / "output" / "demo_routed.net_class_map.json",
+            pcb_dir / "output" / "net_class_map.json",
+            pcb_dir.parent / "output" / "demo_routed.net_class_map.json",
+            pcb_dir.parent / "output" / "net_class_map.json",
+        ]
+
+    def test_check_cmd_candidates_dedup_in_the_board_output_layout(self, tmp_path: Path) -> None:
+        """``boards/NN/output/<pcb>`` collapses dir 1 and dir 3, as before."""
+        pcb = _make_board(tmp_path)
+        pcb_dir = pcb.parent
+        assert _net_class_map_sidecar_candidates(pcb) == [
+            pcb_dir / "demo_routed.net_class_map.json",
+            pcb_dir / "net_class_map.json",
+            pcb_dir / "output" / "demo_routed.net_class_map.json",
+            pcb_dir / "output" / "net_class_map.json",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# AC3 -- all four consumers resolve the SAME file
+# ---------------------------------------------------------------------------
+
+
+class TestCrossConsumerParity:
+    def test_all_four_prefer_the_stem_keyed_sidecar(self, tmp_path: Path) -> None:
+        """A directory holding BOTH forms must resolve identically everywhere.
+
+        This is the regression test for the divergence: before #4634,
+        ``check_cmd`` returned the stem-keyed file while the two CI gates
+        and the report surface returned the bare one.  It fails if ANY
+        single consumer is reverted to the bare-only probe.
+        """
+        pcb = _make_board(tmp_path)
+        stem_keyed = pcb.parent / "demo_routed.net_class_map.json"
+        stem_keyed.write_text(json.dumps({"which": "stem-keyed"}))
+        bare = pcb.parent / NET_CLASS_MAP_SIDECAR_BASENAME
+        bare.write_text(json.dumps({"which": "bare"}))
+
+        resolved = _resolve_all_four(pcb)
+
+        assert set(resolved.values()) == {stem_keyed.resolve()}, resolved
+        for consumer, path in resolved.items():
+            assert path is not None
+            payload = json.loads(path.read_text())
+            assert payload["which"] == "stem-keyed", consumer
+
+    def test_all_four_fall_back_to_the_bare_sidecar(self, tmp_path: Path) -> None:
+        """With only the bare name present, all four still agree."""
+        pcb = _make_board(tmp_path)
+        bare = pcb.parent / NET_CLASS_MAP_SIDECAR_BASENAME
+        bare.write_text(json.dumps({"which": "bare"}))
+
+        resolved = _resolve_all_four(pcb)
+        assert set(resolved.values()) == {bare.resolve()}, resolved
+
+    def test_all_four_accept_a_stem_keyed_only_directory(self, tmp_path: Path) -> None:
+        """The stem-keyed name alone is enough for every consumer."""
+        pcb = _make_board(tmp_path)
+        stem_keyed = pcb.parent / "demo_routed.net_class_map.json"
+        stem_keyed.write_text(json.dumps({"which": "stem-keyed"}))
+
+        resolved = _resolve_all_four(pcb)
+        assert set(resolved.values()) == {stem_keyed.resolve()}, resolved
+
+    def test_stem_must_match_exactly_no_unsuffixing(self, tmp_path: Path) -> None:
+        """``board_v23.net_class_map.json`` never applies to ``board_v24``.
+
+        No consumer may glob or un-suffix: a foreign-stem sidecar is not a
+        candidate at all, so every consumer falls through to the bare name
+        (here absent) and reports "no sidecar".
+        """
+        pcb = _make_board(tmp_path, stem="board_v24")
+        foreign = pcb.parent / "board_v23.net_class_map.json"
+        foreign.write_text(json.dumps({"which": "v23"}))
+
+        resolved = _resolve_all_four(pcb)
+        assert set(resolved.values()) == {None}, resolved
+
+    def test_foreign_stem_falls_through_to_bare_everywhere(self, tmp_path: Path) -> None:
+        """A foreign-stem sidecar loses to the bare name for all four."""
+        pcb = _make_board(tmp_path, stem="board_v24")
+        (pcb.parent / "board_v23.net_class_map.json").write_text(json.dumps({"which": "v23"}))
+        bare = pcb.parent / NET_CLASS_MAP_SIDECAR_BASENAME
+        bare.write_text(json.dumps({"which": "bare"}))
+
+        resolved = _resolve_all_four(pcb)
+        assert set(resolved.values()) == {bare.resolve()}, resolved
+
+    def test_routed_suffix_is_not_stripped(self, tmp_path: Path) -> None:
+        """``demo_routed.kicad_pcb`` does not look for ``demo.net_class_map.json``."""
+        pcb = _make_board(tmp_path, stem="demo_routed")
+        (pcb.parent / "demo.net_class_map.json").write_text(json.dumps({"which": "unsuffixed"}))
+
+        resolved = _resolve_all_four(pcb)
+        assert set(resolved.values()) == {None}, resolved
+
+
+# ---------------------------------------------------------------------------
+# AC4 -- directory scope is NOT widened
+# ---------------------------------------------------------------------------
+
+
+class TestDirectoryScopeUnchanged:
+    def test_only_check_cmd_reaches_the_nested_output_dir(self, tmp_path: Path) -> None:
+        """A sidecar in ``pcb_dir/output`` is ``kct check``-only, as before.
+
+        Consumers 2/3 search ``pcb_dir`` only.  If this test starts
+        passing for them, their directory scope was silently widened and
+        boards would begin resolving sidecars they do not resolve today.
+        """
+        pcb = tmp_path / "demo_routed.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+        nested = tmp_path / "output"
+        nested.mkdir()
+        sidecar = nested / NET_CLASS_MAP_SIDECAR_BASENAME
+        sidecar.write_text(json.dumps({"which": "nested"}))
+
+        resolver = _load_ci_module("net_class_map_resolver")
+
+        assert _maybe_resolve(_discover_net_class_map_sidecar(pcb)) == sidecar.resolve()
+        assert resolve_committed_net_class_map(pcb) is None
+        with resolver.resolve_net_class_map_sidecar(pcb) as ci_sidecar:
+            # No committed sidecar in ``pcb_dir`` and no importable board
+            # recipe -> the resolver degrades to "no map", as it did before.
+            assert ci_sidecar is None
+
+    def test_matchgroup_gate_searches_only_board_output(self, tmp_path: Path) -> None:
+        """Consumer 4 stays pinned to ``board_dir/output``."""
+        matchgroup = _load_ci_module("check_matchgroup_coverage")
+        board_dir = tmp_path / "boards" / "demo"
+        out = board_dir / "output"
+        out.mkdir(parents=True)
+        pcb = out / "demo_routed.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+
+        # A sidecar in the BOARD dir (not board_dir/output) must be ignored.
+        (board_dir / NET_CLASS_MAP_SIDECAR_BASENAME).write_text("{}")
+        assert matchgroup.find_net_class_map_sidecar(board_dir, pcb) is None
+
+        # ...and one in board_dir/output must be found.
+        found = out / NET_CLASS_MAP_SIDECAR_BASENAME
+        found.write_text("{}")
+        assert _maybe_resolve(matchgroup.find_net_class_map_sidecar(board_dir, pcb)) == (
+            found.resolve()
+        )
+
+    def test_first_existing_helper_honours_caller_directory_order(self, tmp_path: Path) -> None:
+        """Nearer directories win; the helper never invents extra ones."""
+        near = tmp_path / "near"
+        far = tmp_path / "far"
+        near.mkdir()
+        far.mkdir()
+        (far / NET_CLASS_MAP_SIDECAR_BASENAME).write_text("{}")
+
+        assert first_existing_net_class_map_sidecar([near], "demo") is None
+        assert first_existing_net_class_map_sidecar([near, far], "demo") == (
+            far / NET_CLASS_MAP_SIDECAR_BASENAME
+        )
+
+    def test_first_existing_helper_prefers_stem_keyed_in_the_nearest_dir(
+        self, tmp_path: Path
+    ) -> None:
+        near = tmp_path / "near"
+        near.mkdir()
+        (near / NET_CLASS_MAP_SIDECAR_BASENAME).write_text("{}")
+        stem_keyed = near / "demo.net_class_map.json"
+        stem_keyed.write_text("{}")
+
+        assert first_existing_net_class_map_sidecar([near], "demo") == stem_keyed
+
+
+# ---------------------------------------------------------------------------
+# AC5 -- byte-identical resolution on the in-repo boards
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("board_name", COMMITTED_SIDECAR_BOARDS)
+class TestInRepoBoardParity:
+    def test_all_four_resolve_the_committed_bare_sidecar(self, board_name: str) -> None:
+        board_dir = REPO_ROOT / "boards" / board_name
+        out = board_dir / "output"
+        expected = out / NET_CLASS_MAP_SIDECAR_BASENAME
+        if not expected.is_file():
+            pytest.skip(f"{board_name} has no committed sidecar in this checkout")
+
+        pcbs = sorted(out.glob("*_routed.kicad_pcb"))
+        assert pcbs, f"{board_name} has no routed PCB artifact"
+        pcb = pcbs[0]
+
+        resolved = _resolve_all_four(pcb)
+        assert set(resolved.values()) == {expected.resolve()}, resolved
+
+    def test_no_stem_keyed_sidecar_shadows_the_committed_one(self, board_name: str) -> None:
+        """The in-repo boards commit bare names only (exposure is zero)."""
+        out = REPO_ROOT / "boards" / board_name / "output"
+        stem_keyed = [
+            p
+            for p in out.glob(f"*.{NET_CLASS_MAP_SIDECAR_BASENAME}")
+            if p.name != NET_CLASS_MAP_SIDECAR_BASENAME
+        ]
+        assert stem_keyed == [], f"unexpected stem-keyed sidecar in {out}: {stem_keyed}"
+
+
+# ---------------------------------------------------------------------------
+# AC6 -- the helper is a stdlib-only leaf
+# ---------------------------------------------------------------------------
+
+
+class TestHelperImportHygiene:
+    def test_module_level_imports_are_stdlib_only(self) -> None:
+        """Static check: ``sidecars.py`` imports nothing outside the stdlib."""
+        tree = ast.parse(SIDECAR_MODULE.read_text())
+        roots: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                roots.update(alias.name.split(".")[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom):
+                if node.level:  # a relative import is by definition not stdlib
+                    roots.add(f"<relative level {node.level}>")
+                elif node.module:
+                    roots.add(node.module.split(".")[0])
+
+        non_stdlib = roots - set(sys.stdlib_module_names)
+        assert non_stdlib == set(), f"non-stdlib imports in sidecars.py: {non_stdlib}"
+
+    def test_module_imports_in_isolation_without_the_package(self) -> None:
+        """Loading the file directly pulls in no kicad_tools / jinja2 modules.
+
+        This is the substantive AC6 property: the helper itself adds no
+        dependency.  Note it is deliberately NOT phrased as
+        ``import kicad_tools.sidecars`` -- see
+        ``test_package_import_pulls_no_optional_report_extra`` below.
+        """
+        script = (
+            "import importlib.util, sys\n"
+            f"spec = importlib.util.spec_from_file_location('_sidecars_iso', r'{SIDECAR_MODULE}')\n"
+            "mod = importlib.util.module_from_spec(spec)\n"
+            "spec.loader.exec_module(mod)\n"
+            "bad = sorted(m for m in sys.modules if m.split('.')[0] in "
+            "{'kicad_tools', 'jinja2', 'yaml', 'numpy'})\n"
+            "assert mod.NET_CLASS_MAP_SIDECAR_BASENAME == 'net_class_map.json'\n"
+            "print(bad)\n"
+        )
+        proc = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert proc.stdout.strip() == "[]", proc.stdout
+
+    def test_package_import_pulls_no_optional_report_extra(self) -> None:
+        """``import kicad_tools.sidecars`` must not require jinja2.
+
+        The eager ``kicad_tools/__init__.py`` means importing ANY
+        ``kicad_tools`` submodule also imports ``kicad_tools.router`` --
+        that is pre-existing and identical for all four consumers, which
+        already import from the package.  What matters here is the
+        constraint that motivated putting the helper OUTSIDE
+        ``kicad_tools.report``: resolving a filename must never pull the
+        optional ``[report]`` rendering extra.
+        """
+        script = (
+            "import sys\n"
+            "import kicad_tools.sidecars\n"
+            "bad = sorted(m for m in sys.modules if m.split('.')[0] == 'jinja2' "
+            "or m.startswith('kicad_tools.report'))\n"
+            "print(bad)\n"
+        )
+        proc = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=REPO_ROOT,
+        )
+        assert proc.stdout.strip() == "[]", proc.stdout
+
+    def test_helper_does_not_import_from_scripts(self) -> None:
+        """``src/`` must never depend on ``scripts/`` (excluded from the wheel)."""
+        source = SIDECAR_MODULE.read_text()
+        assert "import scripts" not in source
+        assert "from scripts" not in source


### PR DESCRIPTION
## Summary

Stem-keyed net-class-map sidecar discovery (#4601 / PR #4629) reached `kct check`
alone. Three sibling probes each spelled the filename out separately and still
accepted the bare `net_class_map.json` only, so in a directory holding **both**
`<pcb_stem>.net_class_map.json` and `net_class_map.json` the four surfaces loaded
**different files** — a different rule set for `match_group_length_skew`,
`diffpair_length_skew` and `diffpair_routing_continuity` on a developer's local
`kct check` than in the CI gates that guard merge, with no warning on either side.

This PR hoists the probe into a new stdlib-only leaf module
`src/kicad_tools/sidecars.py` and points all four consumers at it. **Names and
in-directory precedence converge; directory scope does not** — each consumer
still searches exactly the directories it searched on `473de1f8`, and a test pins
that. Widening scope would have passed every existing test while silently
changing which sidecar boards resolve, which is the exact bug class this issue
exists to kill.

Exposure is still zero: all three in-repo sidecars are bare-named, so the new
candidate never exists and resolution is byte-identical on boards 03/06/07.

## Changes

- **NEW `src/kicad_tools/sidecars.py`** — the single source of truth for the
  accepted filenames. `NET_CLASS_MAP_SIDECAR_BASENAME`,
  `net_class_map_sidecar_names(stem)` (stem-keyed first, bare second; exact stem,
  no globbing or un-suffixing), `net_class_map_sidecar_candidates(pcb_path)` (the
  3-dir `kct check` probe, deduped) and
  `first_existing_net_class_map_sidecar(directories, stem)` (name precedence over
  a **caller-chosen** directory list). Stdlib imports only.
- `cli/check_cmd.py` — `_net_class_map_sidecar_candidates()` is now a thin
  delegation. The private name, both call sites (`_discover_net_class_map_sidecar`
  and the "rules are INACTIVE" warning surface) and the emitted candidate list are
  unchanged; no flags added, renamed or removed.
- `report/net_class_map.py` — `resolve_committed_net_class_map()` calls the shared
  helper for `pcb_dir` only. `SIDECAR_FILENAME` is kept as a re-export so
  `tests/report/test_collector_net_class_map.py` needs no edit. The module
  docstring's "intentionally a small, self-contained reimplementation" rationale
  is retired.
- `scripts/ci/net_class_map_resolver.py` — tier 1 calls the shared helper for
  `pcb_dir` only; `SIDECAR_FILENAME` kept as a re-export; docstrings refreshed.
- `scripts/ci/check_matchgroup_coverage.py` — `find_net_class_map_sidecar()` now
  takes the routed PCB (the caller at `:665` already holds it from `find_routed_pcb`)
  so its stem-keyed candidate is real rather than guessed, and searches
  `board_dir/output` via the shared helper. The hard-fail message names **both**
  accepted filenames.
- `cli/route_cmd.py` — the sidecar **writer** now emits
  `NET_CLASS_MAP_SIDECAR_BASENAME` instead of its own literal, so writer and
  readers cannot drift. One line; behaviour identical. (Not in the curated
  Affected Files list — included because it is the last remaining spelling of the
  filename, and AC1's verification grep is otherwise not clean. Easy to drop if
  the reviewer prefers.)
- **NEW `tests/test_net_class_map_sidecar_parity.py`** — 26 tests covering
  AC2–AC6.
- `docs/guides/drc-and-validation.md` — AC7.
- `CHANGELOG.md` — exactly one bullet appended to `[Unreleased]` → Fixed.

## Acceptance Criteria Verification

- **AC1 — One helper, all four consumers.** ✅
  `rg -n '"net_class_map.json"' src/ scripts/` returns **one** match:
  `src/kicad_tools/sidecars.py:66`. All four consumers import from
  `kicad_tools.sidecars`.
- **AC2 — Same names, same precedence.** ✅
  `TestSharedNameContract` pins `["<stem>.net_class_map.json", "net_class_map.json"]`
  and that `check_cmd`'s private alias is byte-identical to the shared probe;
  `test_stem_must_match_exactly_no_unsuffixing` and
  `test_routed_suffix_is_not_stripped` pin the exact-stem contract across all four.
- **AC3 — Cross-consumer regression test that actually fails on a revert.** ✅
  `test_all_four_prefer_the_stem_keyed_sidecar` builds a directory holding both
  forms with distinguishable JSON payloads and asserts all four return the
  stem-keyed one. **Mutation-verified**: temporarily reverting
  `report/net_class_map.py` to the bare-only probe turns 2 tests red
  (`2 failed, 24 passed`); restoring returns to `26 passed`.
- **AC4 — Directory scope unchanged.** ✅
  `TestDirectoryScopeUnchanged` pins that a sidecar in `pcb_dir/output` is found
  by `check_cmd` and **not** by the routed-DRC resolver or the report surface, and
  that the match-group gate ignores a sidecar in `board_dir` (not
  `board_dir/output`). `test_check_cmd_candidate_order` pins the exact 3-dir × 2-name
  ordering, and `..._dedup_in_the_board_output_layout` pins the dedup collapse.
- **AC5 — Byte-identical on the three in-repo boards.** ✅
  `TestInRepoBoardParity`, parametrized over
  `boards/{03-usb-joystick,06-diffpair-test,07-matchgroup-test}`, asserts all four
  consumers return `boards/NN/output/net_class_map.json` using the **real** board
  fixtures. A second test asserts no stem-keyed sidecar exists in-repo (exposure
  still zero, re-verified on this branch).
  `git status --porcelain boards/` is empty after the full test run.
- **AC6 — No new package dependency.** ⚠️ **Partially refuted, substantively met.**
  The literal wording ("`sys.modules` after a fresh import contains … nothing
  under `kicad_tools.router`") is **not achievable for any `kicad_tools`
  submodule**: `kicad_tools/__init__.py` is eager and imports
  `constraints`/`project`/`query`/`reasoning`/`schema`, which transitively import
  `kicad_tools.router` (222 `kicad_tools` modules after
  `import kicad_tools.sidecars`). That is pre-existing and identical for all four
  consumers, every one of which already imports from the package. Three tests pin
  the properties that actually matter and are achievable:
  - `test_module_level_imports_are_stdlib_only` — AST check: every module-level
    import in `sidecars.py` resolves to `sys.stdlib_module_names`.
  - `test_module_imports_in_isolation_without_the_package` — loading the file
    directly in a subprocess pulls in **zero** `kicad_tools`/`jinja2`/`yaml`/`numpy`
    modules.
  - `test_package_import_pulls_no_optional_report_extra` — `import
    kicad_tools.sidecars` in a fresh subprocess imports **no** `jinja2` and nothing
    under `kicad_tools.report`. This is the constraint that motivated placing the
    helper outside `kicad_tools.report` in the first place.
- **AC7 — Docs match code.** ✅ `docs/guides/drc-and-validation.md` §
  "Auto-discovery" gains a "The probe order is shared, not a `kct check` feature"
  paragraph naming all four consumers and stating explicitly that directory scope
  is *not* shared; the "CI resolves the map automatically" paragraph now says both
  gates accept both filename forms.

## Test Plan

- `uv run pytest tests/test_net_class_map_sidecar_parity.py` → **26 passed**.
- Mutation check (see AC3 above) → **2 failed, 24 passed** with one consumer
  reverted; **26 passed** after restore. Working tree verified clean afterwards.
- `uv run pytest tests/test_cli_check_net_class_map.py tests/report/test_collector_net_class_map.py`
  → **58 passed** (8m15s), **zero edits** to those files.
- `uv run pytest tests/test_kct_check_parity.py` → **11 passed** in 33m53s
  (including the `integration`/`slow` real-`kct check` cases), **zero edits** to
  that file.
- `uv run python scripts/ci/check_matchgroup_coverage.py boards/07-matchgroup-test --skip-route`
  → **exit 0**. The gate resolves
  `boards/07-matchgroup-test/output/net_class_map.json`, does not hit the `:668`
  hard-fail path, and reports `match_group_length_skew` exercised, 8 errors
  (allowlist max 8), pour connectivity OK.
- `uv run ruff format . --check` → 1733 files already formatted.
  `uv run ruff check .` → All checks passed.
- `uv run python scripts/ci/check_mypy_baseline.py` (in `uv sync --frozen --extra dev`)
  → the only two "new" findings are in `placement/cmaes_strategy.py` (missing
  optional `cmaes` stub, environment) and `recovery/strategy.py`, **neither of which
  is in this diff**. No new finding in any changed file.
- `git status --porcelain boards/` → empty. `./.loom/scripts/check-main-clean.sh`
  → main worktree clean.

## Notes for the reviewer

- **`_load_ci_module` imports both `scripts/ci` scripts by file path**, the same
  pattern `tests/test_kct_check_parity.py:148` already uses.
- **`scripts/ci/net_class_map_resolver.py` now imports `kicad_tools` at module
  level**, whereas its `DRCChecker` import is deliberately lazy. This is
  unavoidable: `SIDECAR_FILENAME` is a module-level constant other modules and
  tests import, so it cannot be resolved lazily. Both gates run under `uv run`
  where `kicad_tools` is always importable. The direction is the safe one —
  `scripts/ci` → `kicad_tools`, never the reverse (`scripts/ci` has no
  `__init__.py` and is excluded from the wheel).
- **`check_routed_drc.py`, `check_diffpair_coverage.py` and
  `export/manufacturing.py` are untouched**, as the issue predicted: they call the
  resolvers rather than re-implementing the probe, so they inherit the fix.
- **Local-environment note (not a finding about this diff):** with six builder
  worktrees running concurrently, several `kicad-cli sch erc` / `kicad-cli pcb drc
  --help` subprocesses wedged (60–80 min elapsed, <0.3 s CPU), stalling anything
  that shells out to `kct check`. Both long runs above completed normally once the
  wedged `kicad-cli` children were killed. Nothing in this diff touches the ERC or
  `kicad-cli` path.

Closes #4634