### PR TITLE
fix(skills): gate /kct:tapeout on assembly-affecting warnings, not errors alone

### DIFF
--- a/.claude/commands/kct/help.md
+++ b/.claude/commands/kct/help.md
@@ -88,9 +88,10 @@ the files actually present:
    convention files rather than restating them here (they are owned by the
    installer and must not be duplicated a third time):
 
-   - **`.kct/CONVENTIONS.md`** — the three load-bearing Epic #4054 conventions
-     verbatim (build the native router backend, cross-gate DRC with
-     `kicad-cli pcb drc --refill-zones`, artifact-first). Read this before
+   - **`.kct/CONVENTIONS.md`** — the four load-bearing conventions verbatim
+     (build the native router backend, cross-gate DRC with
+     `kicad-cli pcb drc --refill-zones`, artifact-first, and per-rule
+     manufacturing warning baselines). Read this before
      routing or manufacturing sign-off. If `.kct/CONVENTIONS.md` is absent
      (an install predating it), fall back to the guarded kicad-tools block in
      the repo's `CLAUDE.md`, which carries the same pointer.

--- a/.claude/commands/kct/manufacturing-readiness.md
+++ b/.claude/commands/kct/manufacturing-readiness.md
@@ -72,7 +72,8 @@ kct check <board.kicad_pcb> --mfr <tier>
   ```bash
   kct check <board.kicad_pcb> --mfr <tier> --net-class-map <path/to/net_class_map.json>
   ```
-- A clean exit here is necessary but **not sufficient**. Proceed to Gate 2 regardless — do not treat a green Gate 1 as sign-off.
+- **Quote the per-rule warning breakdown, not the aggregate.** `kct check`'s table output prints a per-rule `BY RULE:` breakdown of warnings; the sign-off verdict must quote that breakdown (rule → warning count) rather than a single aggregate total, even when the check exits clean. A warning **baseline is only meaningful per rule**: "N warnings, non-regressive vs. the baseline" can be satisfied by an aggregate while an entire defect class (e.g. silkscreen over exposed pads — a real assembly risk) hides inside it across repeated sign-offs. When recording or re-verifying a warning baseline, record and compare counts rule-by-rule. For a machine-readable form, pass `--output <report.json>` — the JSON envelope's `violations[]` carry a `rule_id` and severity per finding, so per-rule counts are a one-line derivation.
+- A clean exit here is necessary but **not sufficient**. Proceed to Gate 2 regardless — do not treat a green Gate 1 as sign-off. Warnings do not affect the exit code, so a "clean" Gate 1 says nothing about the warning population — that is exactly why the per-rule quote above is mandatory.
 
 ### Gate 2 — the mandatory independent cross-gate (NOT optional)
 
@@ -120,7 +121,7 @@ kct audit <board.kicad_pcb> --mfr <tier> \
 
 Sign off **only if all applicable gates** hold:
 
-1. Gate 1 `kct check --mfr <tier>` exits clean at the resolved tier.
+1. Gate 1 `kct check --mfr <tier>` exits clean at the resolved tier, **and** the verdict quotes the per-rule `BY RULE:` warning breakdown (not just an aggregate warning total) so a later re-verification can diff the warning population rule-by-rule.
 2. Gate 2 `kicad-cli pcb drc --refill-zones` reports **0 new errors** (and actually ran — a missing `kicad-cli` is a blocker, not a pass).
 3. Gate 3 `kct export --mfr <tier>` wrote a fresh `manifest.json`.
 4. **(HV/mains boards only)** Gate 4 `kct audit --hv-standard ...` exits 0 with a clean HV/isolation verdict — a `NOT_READY` (exit 2) isolation gate is a hard blocker; an un-gated HV path (`WARNING`, no requirement specified) is not sign-off either.
@@ -137,4 +138,5 @@ If any applicable gate fails or could not run, report **NOT signed off**, name t
 
 - `kct check --help` / `kct export --help` — authoritative `--mfr` tier choices (sourced from `kicad_tools.manufacturers.get_manufacturer_ids()`).
 - The `--refill-zones` cross-gate convention (Epic #4054 convention #2) was established after a 2026-07-04 defect where `kct check` alone missed a live short and read stale zone fills.
+- The per-rule warning-quote requirement was established after #4614: an aggregate "warnings match baseline" result concealed dozens of `silk_over_copper` warnings (silkscreen over exposed pads — an assembly risk) across two sign-offs; the fab order was aborted at the vendor site. A baseline compared per rule would have surfaced it immediately.
 - `/kct:ee-review` — sibling `kct` skill for analog/placement-blocked boards (advisory decisions, not copper).

--- a/.claude/commands/kct/tapeout.md
+++ b/.claude/commands/kct/tapeout.md
@@ -2,7 +2,7 @@
 name: tapeout
 invocation: /kct:tapeout
 suggestedModel: sonnet
-description: Produce a complete, fab-ready export bundle for a routed board — or refuse loudly. Superset of /kct:manufacturing-readiness: runs the three sign-off pre-gates, then adds a BOM part-number-resolution gate, schematic + assembly-view PDFs, a human-readable README, and a manifest that checksums the entire final bundle. "tapeout returned 0" means "upload this directory as-is."
+description: Produce a complete, fab-ready export bundle for a routed board — or refuse loudly. Superset of /kct:manufacturing-readiness: runs the three sign-off pre-gates, then adds a BOM part-number-resolution gate, a per-rule warning-review gate (assembly-affecting warnings block unless explicitly acknowledged), schematic + assembly-view PDFs, a human-readable README, and a manifest that checksums the entire final bundle. "tapeout returned 0" means "upload this directory as-is."
 ---
 
 # Tapeout
@@ -39,7 +39,7 @@ Model resolves through the harness's normal precedence chain (explicit dispatch 
 
 **Arguments**: `$ARGUMENTS`
 
-`$ARGUMENTS` is `<board-path> [--mfr <tier>] [--assembly | --pcb-only] [--output <dir>]`.
+`$ARGUMENTS` is `<board-path> [--mfr <tier>] [--assembly | --pcb-only] [--output <dir>] [--ack-warnings <rule,...>]`.
 
 | Token | Meaning |
 |-------|---------|
@@ -48,6 +48,7 @@ Model resolves through the harness's normal precedence chain (explicit dispatch 
 | `--assembly` | Produce a **full assembly package**: gerbers + drill **and** BOM + CPL with part-number resolution. In this mode the BOM gate (Gate 4) is a **hard gate** — any unresolved BOM line fails the tapeout. |
 | `--pcb-only` | Produce a **bare-board package**: gerbers + drill only. **Skips BOM and CPL entirely** (Gate 4 and the CPL half of Gate 3 are not run). Use when you are ordering the PCB alone and sourcing/assembling parts yourself. |
 | `--output <dir>` | Where the bundle is written. Optional; defaults to `<pcb-dir>/manufacturing/` (the `kct export` default). |
+| `--ack-warnings <rule,...>` | **Optional.** Explicitly acknowledge nonzero **assembly-affecting** warning counts for the named rules (comma-separated `rule_id`s, e.g. `--ack-warnings silk_over_copper,silk_edge_clearance`). Each acknowledged rule becomes a per-rule accepted-risk line in `README.txt` (Gate 7). Without an acknowledgement covering **every** assembly-affecting rule that has a nonzero warning count, Gate 4b **refuses** the tapeout. This is a *skill* argument (an acknowledgement ritual), not a `kct check` CLI flag. |
 
 **`--assembly` and `--pcb-only` are mutually exclusive.** If both are passed, refuse. **If neither is passed, default to `--assembly`** — the safe default is the *complete* package; a caller who wants the reduced bare-board package must ask for it explicitly.
 
@@ -77,7 +78,7 @@ If the resolved tier is not in that set, stop and ask — do not silently fall b
 
 `tapeout` is a **superset** of `/kct:manufacturing-readiness` — it does **not** re-invent the sign-off gates. Before generating any package, satisfy the full sign-off ritual documented in **`.claude/commands/kct/manufacturing-readiness.md`** at the resolved tier:
 
-1. **Gate 1 — `kct check <board.kicad_pcb> --mfr <tier>`** exits clean (DRC / manufacturing-rules + ERC/LVS/Manifest sub-checks; `--net-class-map` auto-discovered).
+1. **Gate 1 — `kct check <board.kicad_pcb> --mfr <tier>`** exits clean (DRC / manufacturing-rules + ERC/LVS/Manifest sub-checks; `--net-class-map` auto-discovered). For tapeout, additionally pass `--output <dir>/check-report.json` (an existing `kct check` flag) so the run leaves a machine-readable report in the bundle: Gate 4b derives its per-rule warning table from that file, and Gate 8 checksums it. Do **not** run a separate fourth `kct check` just for the warning table — reuse this gate's report.
 2. **Gate 2 — the mandatory independent cross-gate `kicad-cli pcb drc --refill-zones <board.kicad_pcb>`** reports **0 new errors**. This is **not optional and not skippable**: it is a second, independent DRC engine that catches stale-zone-fill shorts `kct check` misses. A missing `kicad-cli` is a **hard blocker**, not a pass.
 3. **Gate 3 — `kct export <board.kicad_pcb> --output <dir> --mfr <tier>`** produces gerbers, drill, and (in `--assembly` mode) BOM + CPL, plus a first-pass `manifest.json`.
 
@@ -103,6 +104,31 @@ The gate then:
 3. **Fails** `--assembly` tapeout if **any** line is unresolved. A complete assembly package has zero human-selection-required lines by definition; surface the unresolved report and refuse.
 
 The distinction is load-bearing: **matcher-broken → refuse the whole tapeout** (the package is not trustworthy); **no-match on specific parts → unresolved report → refuse `--assembly`** (the human must pick parts before this can ship as an assembly order). Never let a silently-empty part-number column pass as "resolved."
+
+### Gate 4b — warning review (per-rule table + assembly-affecting acknowledgement)
+
+**"0 errors" and "fit to fabricate" are not the same claim.** `kct check`'s exit code is driven by errors — warnings never fail Gate 1 — but some warning classes are genuine **assembly risks** (silkscreen printed over an exposed pad can interfere with solder wetting), and they must not ride through a gate whose stated meaning is "upload this directory as-is." This gate forces the warning population to be *looked at*, per rule, before the bundle is declared upload-ready. It runs in both `--assembly` and `--pcb-only` modes.
+
+1. **Derive a per-rule warning table** from Gate 1's machine-readable report (`<dir>/check-report.json` — see the pre-gates note; do not re-run `kct check`). Group the JSON `violations[]` by `rule_id`, warnings only:
+
+   ```bash
+   jq '[.violations[] | select(.severity=="warning")]
+       | group_by(.rule_id)
+       | map({rule: .[0].rule_id, count: length})' <dir>/check-report.json
+   ```
+
+   **Print this table in the tapeout report.** Reporting an aggregate warning total alone ("N warnings") is **non-compliant** — an aggregate can satisfy a "matches baseline / non-regressive" check indefinitely while concealing an entire defect class. The per-rule table is the artifact that prevents that.
+
+2. **Check the assembly-affecting rule set.** At minimum, the following rules are **assembly-affecting** (treat this set as a floor, not a ceiling — extend it when a new rule clearly affects assembly or is a manufacturer-profile floor):
+
+   - `silk_over_copper` — silk over an exposed pad interferes with solder wetting
+   - `silkscreen_line_width` — the compared floor comes from the manufacturer profile, so every warning is a hard fab-constraint violation, not a preference
+   - `silk_edge_clearance`
+   - `silk_overlap`
+
+3. **Require explicit acknowledgement of any nonzero count in that set.** A nonzero assembly-affecting warning count is acceptable **only** when explicitly acknowledged: the caller passed `--ack-warnings` naming that exact rule, or a human-authored accepted-risk decision exists and you record it as one accepted-risk line **per rule** in `README.txt` (Gate 7). Silence is not acknowledgement, and a passing Gate 1 exit code is not acknowledgement. **Unacknowledged assembly-affecting warnings ⇒ TAPEOUT REFUSED** — never exit 0, never write the final manifest. Warnings outside the assembly-affecting set appear in the table but do not require acknowledgement.
+
+**Gate condition:** the per-rule warning table was derived from Gate 1's JSON report and printed in the tapeout report, **and** every assembly-affecting rule with a nonzero warning count carries an explicit acknowledgement (or all assembly-affecting counts are zero).
 
 ### Gate 5 — schematic PDF (full hierarchy)
 
@@ -140,9 +166,10 @@ Write `<dir>/README.txt` enumerating **every** deliverable in the bundle so a hu
 - The mode (`--assembly` or `--pcb-only`) and what that implies (BOM/CPL present or intentionally absent).
 - A list of every file in the output directory with a one-line description (gerbers/drill archive, BOM, CPL, schematic PDF, assembly-view PDFs, renders, manifest).
 - **Hand-solder / THT items** (carried from the CPL's THT-exclusion note) — parts the assembler will *not* place and someone must hand-solder.
+- The **per-rule warning table** from Gate 4b (rule → warning count; not an aggregate total), and **one acknowledgement line per assembly-affecting rule with a nonzero count** — naming the rule, the count, and why the risk is accepted (from `--ack-warnings` or the recorded accepted-risk decision). If every assembly-affecting count is zero, state that explicitly.
 - Any **accepted-risk notes** carried forward from sign-off docs (e.g. a documented DRC waiver). If none, say "no accepted-risk waivers."
 
-**Gate condition:** `README.txt` exists and names the board file, the tier, and the mode.
+**Gate condition:** `README.txt` exists, names the board file, the tier, and the mode, **and** contains the per-rule warning table plus one acknowledgement line per assembly-affecting rule with a nonzero count (or the explicit statement that all assembly-affecting counts are zero).
 
 ### Gate 8 — full-bundle manifest (checksums the entire output dir)
 
@@ -151,19 +178,21 @@ The `manifest.json` `kct export` wrote in Gate 3 only covers **what `kct export`
 - Enumerate **all** files in `<dir>` (recursively), and record a checksum (e.g. SHA-256) for each.
 - Record the **exact board file** name and the **resolved tier**.
 - Record the mode (`--assembly` / `--pcb-only`).
+- Record the **per-rule warning counts** from Gate 4b (a `rule_id` → warning-count map, plus the list of acknowledged assembly-affecting rules), so a later re-verification can diff the warning population **per rule** rather than against an aggregate total. An aggregate-only warning number in the manifest is non-compliant for the same reason it is in Gate 4b.
 
-**Gate condition:** a `manifest.json` exists, is newer than every other file it lists, and its file set equals the actual contents of `<dir>` (nothing in the directory is unchecksummed, nothing checksummed is missing). A stale or partial manifest is a **failure** — it breaks the "upload as-is" contract.
+**Gate condition:** a `manifest.json` exists, is newer than every other file it lists, its file set equals the actual contents of `<dir>` (nothing in the directory is unchecksummed, nothing checksummed is missing), and it records the per-rule warning counts. A stale or partial manifest is a **failure** — it breaks the "upload as-is" contract.
 
 ## Tapeout verdict
 
 Emit a **complete, orderable package** (manifest written, exit 0) **only if all applicable gates hold**:
 
-1. Pre-gates 1–3 (`/kct:manufacturing-readiness`) sign off at the resolved tier.
+1. Pre-gates 1–3 (`/kct:manufacturing-readiness`) sign off at the resolved tier (Gate 1 run with `--output <dir>/check-report.json`).
 2. Gate 4 BOM resolution: in `--assembly`, **zero** unresolved lines **and** resolution machinery intact (part-number column actually populated, not silently empty). Skipped in `--pcb-only`.
-3. Gate 5 schematic PDF present and fresh.
-4. Gate 6 both assembly-view PDFs present and non-empty.
-5. Gate 7 `README.txt` present and naming board + tier + mode.
-6. Gate 8 full-bundle `manifest.json` covers **every** file in the output dir and is the newest artifact.
+3. Gate 4b warning review: the **per-rule** warning table derived from Gate 1's JSON report and printed (an aggregate total alone does not satisfy this), **and** every assembly-affecting rule with a nonzero warning count explicitly acknowledged — or all assembly-affecting counts are zero. **"0 errors + an aggregate warning total" is never sufficient for this verdict.**
+4. Gate 5 schematic PDF present and fresh.
+5. Gate 6 both assembly-view PDFs present and non-empty.
+6. Gate 7 `README.txt` present, naming board + tier + mode, and carrying the per-rule warning table + per-rule acknowledgement lines (or the all-zero statement).
+7. Gate 8 full-bundle `manifest.json` covers **every** file in the output dir, records the per-rule warning counts, and is the newest artifact.
 
 If any applicable gate fails or could not run, **do not write the final manifest**. Report **TAPEOUT REFUSED**, name the failing gate, and quote the specific violation(s). Never emit a manifest — and never imply "upload as-is" — on a partial run.
 
@@ -172,6 +201,7 @@ If any applicable gate fails or could not run, **do not write the final manifest
 Refuse the tapeout, loudly, when any of these hold:
 
 - **Any pre-gate fails** — `kct check` not clean, the `kicad-cli pcb drc --refill-zones` cross-gate reports new errors, or `kct export` did not produce its first-pass bundle.
+- **Unacknowledged assembly-affecting warnings (Gate 4b)** — any rule in the assembly-affecting set (`silk_over_copper`, `silkscreen_line_width`, `silk_edge_clearance`, `silk_overlap`, at minimum) has a nonzero warning count with no matching `--ack-warnings` entry or per-rule accepted-risk line. Quote the per-rule warning table in the refusal. "0 errors" is not "fit to fabricate" — these two claims must never be conflated by this skill.
 - **`--assembly` with unresolved BOM lines** — one or more components have no fab-orderable part number (human selection required). Surface the unresolved report; do not ship an incomplete assembly order.
 - **BOM-resolution machinery unavailable** — the requested capability could not run: the `[parts]` extra is missing (so `--auto-lcsc` soft-fails to an empty column — **#4104**), or there is no network for part matching. This is a **refusal**, not a silently-empty BOM that exits 0.
 - **Requested capability unavailable** generally — e.g. `kicad-cli` not on `PATH` (drawings and the cross-gate cannot run), or the resolved tier is not in `get_manufacturer_ids()`.
@@ -190,6 +220,7 @@ Refuse the tapeout, loudly, when any of these hold:
 
 - **`/kct:manufacturing-readiness`** (`.claude/commands/kct/manufacturing-readiness.md`) — the sign-off ritual `tapeout` delegates its three pre-gates to. `tapeout` is a strict superset: sign-off + BOM-resolution gate + drawings + README + full-bundle manifest.
 - **#4104** — `kct export --auto-lcsc` soft-fails to an empty LCSC column when the `[parts]` extra is missing (export still exits 0). This is the known BOM-resolution gap the Gate 4 contract must **not** silently swallow: verify the part-number column independently; do not trust the exit code.
+- **#4614** — a board returned a clean tapeout while carrying dozens of `silk_over_copper` warnings (silkscreen printed across exposed pads); the fab order was aborted at the vendor site. Every finding was warning-severity, so the error-driven gates never looked at them. Gate 4b (the per-rule warning table + assembly-affecting acknowledgement) exists because of that incident.
 - `kct check --help` / `kct export --help` — authoritative `--mfr` tier choices (sourced from `kicad_tools.manufacturers.get_manufacturer_ids()`).
 - `src/kicad_tools/cli/export_cmd.py`, `src/kicad_tools/export/bom_enrich.py` — the `--auto-lcsc` / `--no-auto-lcsc` enrichment behavior Gate 4 wraps.
 - `/kct:ee-review` — sibling `kct` skill for analog/placement-blocked boards (advisory decisions, not copper).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,19 @@ constructor). No breaking changes.
 
 ### Fixed
 
+- **`/kct:tapeout` certified "upload as-is" on errors alone — assembly-affecting
+  warnings rode through.** The tapeout skill contract gains a warning-review
+  gate (Gate 4b): a per-rule warning table is derived from Gate 1's `kct check
+  --output` JSON report and printed (an aggregate total alone is
+  non-compliant), and any nonzero count in the assembly-affecting set
+  (`silk_over_copper`, `silkscreen_line_width`, `silk_edge_clearance`,
+  `silk_overlap`) forces TAPEOUT REFUSED unless explicitly acknowledged via
+  `--ack-warnings` or a per-rule accepted-risk line; Gate 7's README and Gate
+  8's manifest now carry the per-rule counts. `/kct:manufacturing-readiness`
+  sign-off quotes the per-rule `BY RULE:` warning breakdown, and the installer
+  vendors a 4th `.kct/CONVENTIONS.md` convention: manufacturing warning
+  baselines are recorded per rule, never as an aggregate (#4614).
+
 - **KiCad-10 name-based net references were invisible to four copper
   scanners.** On a board whose segments and vias name their net (`(net "GND")`)
   instead of numbering it, the `--preserve-existing` parser returned an empty

--- a/scripts/install-kct.sh
+++ b/scripts/install-kct.sh
@@ -483,7 +483,8 @@ VENDORED_FILES+=(".kct/ci/README.md")
 ok "vendored ${#CI_GATE_FILES[@]} CI gate script(s) + README into .kct/ci/"
 
 # ----- Stage 6c: vendor load-bearing conventions into .kct/CONVENTIONS.md ----
-# The three load-bearing Epic #4054 conventions live here verbatim. This file
+# The four load-bearing conventions (Epic #4054 #1-#3, plus the per-rule
+# warning-baseline convention from #4614) live here verbatim. This file
 # is the "guaranteed-present, survives CLAUDE.md divergence" artifact: the
 # installer owns it outright and overwrites it on every run (same refresh
 # semantics as .kct/ci/README.md and .kct/install-metadata.json). Moving the
@@ -513,6 +514,12 @@ sign-off.
 3. **Artifact-first.** The committed board artifact is shipping truth. A
    `generate_design.py`/regeneration may diverge by design and is NOT
    authoritative over a committed board.
+4. **Manufacturing warning baselines are recorded per rule.** "Non-regressive
+   vs an aggregate warning total" is NOT a valid baseline check — an aggregate
+   can conceal an entire defect class (e.g. silkscreen over exposed pads, an
+   assembly risk) indefinitely. Record and compare warning counts rule-by-rule
+   (`kct check`'s BY RULE breakdown, or per-rule counts derived from the
+   `--output` JSON report's violations).
 CONVENTIONS_EOF
 }
 do_action "write .kct/CONVENTIONS.md" write_conventions

--- a/tests/install/test_install_kct.py
+++ b/tests/install/test_install_kct.py
@@ -216,11 +216,12 @@ def test_path_install_produces_all_artifacts(
     assert "refill-zones" not in claude
     assert "Existing content stays." in claude  # pre-existing content preserved
 
-    # The three conventions live verbatim in the vendored .kct/CONVENTIONS.md.
+    # The four conventions live verbatim in the vendored .kct/CONVENTIONS.md.
     conventions = (target_repo / ".kct" / "CONVENTIONS.md").read_text()
     assert "build-native" in conventions
     assert "refill-zones" in conventions
     assert "Artifact-first" in conventions
+    assert "per rule" in conventions
 
     # Metadata is valid JSON with the schema fields.
     meta = json.loads((target_repo / ".kct" / "install-metadata.json").read_text())
@@ -556,17 +557,25 @@ def test_vendored_gates_run_standalone_from_consumer(
 def test_conventions_vendored_with_verbatim_conventions(
     target_repo: Path, fake_uv_env: dict[str, str]
 ) -> None:
-    """The three load-bearing Epic #4054 conventions are vendored verbatim."""
+    """The four load-bearing conventions are vendored verbatim.
+
+    (1)-(3) are the Epic #4054 conventions; (4) is the per-rule warning-baseline
+    convention from #4614.
+    """
     result = run_installer(target_repo, "--path", str(REPO_ROOT), env=fake_uv_env)
     assert result.returncode == 0, result.stderr
 
     conventions = target_repo / ".kct" / "CONVENTIONS.md"
     assert conventions.exists()
     text = conventions.read_text()
-    # (1) native backend build, (2) cross-gate DRC, (3) artifact-first.
+    # (1) native backend build, (2) cross-gate DRC, (3) artifact-first,
+    # (4) per-rule warning baselines.
     assert "build-native" in text
     assert "refill-zones" in text
     assert "Artifact-first" in text
+    assert "warning baselines are recorded per rule" in text
+    # The anti-pattern is named explicitly: an aggregate total is not a baseline.
+    assert "aggregate" in text
 
     # Recorded in the metadata manifest alongside the other vendored artifacts.
     meta = json.loads((target_repo / ".kct" / "install-metadata.json").read_text())


### PR DESCRIPTION
Closes #4614

## Summary

`/kct:tapeout` certified "upload this directory as-is" on **errors alone** — a bundle carrying 34 `silk_over_copper` warnings (silkscreen over exposed pads, a solder-wetting risk) rode through certification and the fab order was aborted at the vendor site. Per the curated scope this is a **skill-contract + installer-conventions fix only**: no Python check machinery, no CLI flags, no severity escalation (siblings #4623/#4624 own `check_cmd.py` / `silkscreen.py`).

## Changes

- **`.claude/commands/kct/tapeout.md`** — new **Gate 4b (warning review)**: derive a per-rule warning table from Gate 1's `kct check --output <dir>/check-report.json` JSON report (`jq` over `violations[]` grouped by `rule_id`, warnings only; reuses Gate 1's run, no fourth check invocation) and print it; an aggregate warning total alone is declared non-compliant. Names the assembly-affecting set — `silk_over_copper`, `silkscreen_line_width`, `silk_edge_clearance`, `silk_overlap` (a floor, not a ceiling) — and any nonzero count forces **TAPEOUT REFUSED** unless explicitly acknowledged via the new `--ack-warnings <rule,...>` *skill* argument or a per-rule accepted-risk line. Gate 7's README condition now requires the table + one acknowledgement line per nonzero assembly-affecting rule (or an explicit all-zero statement); Gate 8's manifest records per-rule warning counts + acknowledged rules so re-verification diffs per rule. Verdict + refusal conditions extended accordingly.
- **`.claude/commands/kct/manufacturing-readiness.md`** — Gate 1 and the sign-off verdict must quote the per-rule `BY RULE:` warning breakdown (never just an aggregate); states a warning baseline is only meaningful per rule. No tier-id literals introduced (tier-enum gate).
- **`scripts/install-kct.sh`** (Stage 6c heredoc) — 4th vendored convention in `.kct/CONVENTIONS.md`: manufacturing warning baselines are recorded **per rule**; "non-regressive vs an aggregate total" is not a valid baseline check. Same refresh semantics (installer overwrites on every run — consumers pick it up on reinstall).
- **`.claude/commands/kct/help.md`** — conventions pointer updated three → four (kept consistent with the heredoc; small addition beyond the curated file list).
- **`tests/install/test_install_kct.py`** — conventions assertions extended (`"warning baselines are recorded per rule"`, `"aggregate"`, `"per rule"`).
- **`CHANGELOG.md`** — one bullet under `[Unreleased]` → Fixed.

## Per-AC verification

- **AC1** — Gate 4b requires the per-rule table derived from the JSON report with the exact `jq` derivation; "an aggregate warning total alone is non-compliant" stated verbatim.
- **AC2** — assembly-affecting set named; nonzero counts require `--ack-warnings` or a per-rule accepted-risk line, else TAPEOUT REFUSED (never exit 0 / no manifest).
- **AC3** — Gate 7 gate condition extended (table + per-rule ack lines or all-zero statement).
- **AC4** — Gate 8 records a `rule_id` → count map + acknowledged-rule list; gate condition extended.
- **AC5** — manufacturing-readiness Gate 1 bullet + verdict item 1 quote the `BY RULE:` breakdown; per-rule-baseline language added.
- **AC6** — Stage 6c heredoc gains convention 4; installer tests updated three → four.
- **AC7** — `git status` diff touches no `src/kicad_tools/**` file; no CLI flags added (`tests/test_cli_parser_drift.py` green, untouched).
- **AC8** — `tests/test_kct_skills_consumer_generic.py` green; no repo-internal path literals or tier ids added to skill bodies.

## Test results

- `uv run pytest tests/install/test_install_kct.py tests/test_kct_skills_consumer_generic.py tests/test_cli_parser_drift.py -q` → **77 passed**
- `uv run ruff check` + `ruff format --check` on the touched test file → clean; `bash -n scripts/install-kct.sh` → clean
- **Manual (test plan)**: ran `kct check --output` on `boards/03-usb-joystick/output/usb_joystick_routed.kicad_pcb`; the AC1 `jq` derivation matched the human `BY RULE:` table exactly (`silk_over_copper: 4`, `silkscreen_text_height: 16`). Errors are correctly excluded (verified on a synthetic envelope with a mixed-severity population).
- Manual read-through: the verdict list now explicitly states "0 errors + an aggregate warning total is never sufficient"; a nonzero `silk_over_copper` count without an acknowledgement reads as TAPEOUT REFUSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)