### PR TITLE
feat(check): advisory routing-quality metrics in kct check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ constructor). No breaking changes.
 
 ### Added
 
+- **Advisory routing-quality metrics in `kct check`** — a new pure
+  `kicad_tools.analysis.routing_quality` module measures segment-length
+  distribution (median, sub-0.25 mm fragments), direction classes
+  (orthogonal / true-45° / off-axis), H/V staircase steps (< 0.6 mm legs),
+  zero-length segments, and per-net segment counts over the board's copper.
+  Default `kct check` prints a "Routing quality (advisory)" stanza after the
+  meta-check rollup and the JSON/`--output` envelopes gain a top-level
+  `routing_quality` object; strictly advisory — never affects the verdict or
+  exit code (even under `--strict`), no new flags, and `--drc-only` output is
+  unchanged (#4623).
+
 - **`kct route --complete`** — a targeted completion pass: auto-detect the
   still-unconnected signal nets and route only those links, with all other
   copper fixed, on the octilinear lattice engine. Implies `--preserve-existing`

--- a/src/kicad_tools/analysis/__init__.py
+++ b/src/kicad_tools/analysis/__init__.py
@@ -39,6 +39,12 @@ from .net_status import (
     PadInfo,
     build_zone_net_map,
 )
+from .routing_quality import (
+    FRAGMENT_LENGTH_MM,
+    STAIRCASE_STEP_MM,
+    RoutingQualityMetrics,
+    compute_routing_quality,
+)
 from .signal_integrity import (
     CrosstalkRisk,
     ImpedanceDiscontinuity,
@@ -61,6 +67,8 @@ from .trace_length import (
 )
 
 __all__ = [
+    "FRAGMENT_LENGTH_MM",
+    "STAIRCASE_STEP_MM",
     "AnalogComponent",
     "Bottleneck",
     "ComplexityAnalyzer",
@@ -82,6 +90,7 @@ __all__ = [
     "PowerEstimator",
     "RiskLevel",
     "RoutingComplexity",
+    "RoutingQualityMetrics",
     "Severity",
     "SignalIntegrityAnalyzer",
     "TraceCrosstalkRisk",
@@ -93,6 +102,7 @@ __all__ = [
     "TraceLengthAnalyzer",
     "TraceLengthReport",
     "build_zone_net_map",
+    "compute_routing_quality",
     "detect_analog_components",
     "infer_rail_voltage",
 ]

--- a/src/kicad_tools/analysis/routing_quality.py
+++ b/src/kicad_tools/analysis/routing_quality.py
@@ -1,0 +1,198 @@
+"""Advisory routing-quality metrics over PCB copper segments (issue #4623).
+
+``kct check``'s gates are all binary (connectivity, DRC, clearance, ERC/LVS
+rollup), so a board can be DRC-clean while carrying copper that is visibly
+poor: sub-0.25 mm fragments, H/V staircases instead of true 45° geometry,
+off-axis stubs, zero-length segments.  This module computes *descriptive*
+statistics over ``pcb.segments`` so that drift in routing quality becomes
+observable.  It is purely computational -- no CLI, no IO, and by design it
+never participates in any pass/fail verdict (the wire-in in
+``cli/check_cmd.py`` is advisory-only).
+
+Metric definitions are pinned in issue #4623; the thresholds below are
+module constants chosen to match the #4615 measurement so numbers stay
+comparable across boards and over time.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from statistics import median
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from kicad_tools.schema.pcb import PCB, Segment
+
+# Segments shorter than this are counted as "fragments" -- copper slivers
+# that almost always indicate routing churn rather than intent.  Matches
+# the #4615 measurement (67% of that board's segments were sub-0.25 mm).
+FRAGMENT_LENGTH_MM = 0.25
+
+# An orthogonal segment shorter than this that meets a perpendicular
+# orthogonal segment (same net, same layer, also shorter than this) at a
+# shared endpoint is counted as a "staircase step" -- an H/V zigzag that a
+# clean router would express as a single 45° segment.  Matches the #4615
+# measurement basis (42% staircase steps at 0.6 mm legs).
+STAIRCASE_STEP_MM = 0.6
+
+# Angular tolerance (degrees) for classifying a segment as orthogonal
+# (0°/90°) or true diagonal (45°).  Everything else is off-axis.
+ANGLE_TOLERANCE_DEG = 0.5
+
+# Coordinate tolerance (mm) for zero-length detection and endpoint
+# sharing.  KiCad coordinates are nm-quantized, so exact equality is the
+# common case; the epsilon only absorbs float noise.
+COORD_EPSILON_MM = 1e-6
+
+
+@dataclass(frozen=True)
+class RoutingQualityMetrics:
+    """Descriptive routing-quality statistics for one board.
+
+    All counts are over ``pcb.segments`` (copper trace segments).  The
+    length/direction statistics exclude zero-length segments; the
+    fractions use the same zero-length-excluded population as their
+    denominator (and are ``0.0`` when that population is empty).
+    """
+
+    total_segments: int
+    nets_with_copper: int
+    segments_per_net: float
+    zero_length_count: int
+    median_length_mm: float
+    fragment_count: int
+    fragment_fraction: float
+    orthogonal_count: int
+    diagonal_45_count: int
+    off_axis_count: int
+    staircase_step_count: int
+    staircase_fraction: float
+
+    def to_dict(self) -> dict[str, int | float]:
+        """Serialize to the stable JSON contract emitted by ``kct check``."""
+        return {
+            "total_segments": self.total_segments,
+            "nets_with_copper": self.nets_with_copper,
+            "segments_per_net": self.segments_per_net,
+            "zero_length_count": self.zero_length_count,
+            "median_length_mm": self.median_length_mm,
+            "fragment_count": self.fragment_count,
+            "fragment_fraction": self.fragment_fraction,
+            "orthogonal_count": self.orthogonal_count,
+            "diagonal_45_count": self.diagonal_45_count,
+            "off_axis_count": self.off_axis_count,
+            "staircase_step_count": self.staircase_step_count,
+            "staircase_fraction": self.staircase_fraction,
+        }
+
+
+def _quantize(point: tuple[float, float]) -> tuple[int, int]:
+    """Quantize a coordinate to the COORD_EPSILON_MM grid for hashing."""
+    return (round(point[0] / COORD_EPSILON_MM), round(point[1] / COORD_EPSILON_MM))
+
+
+def _classify_direction(dx: float, dy: float) -> str:
+    """Classify a non-zero-length segment direction.
+
+    Returns ``"horizontal"``, ``"vertical"``, ``"diagonal_45"``, or
+    ``"off_axis"``.  Horizontal/vertical together form the *orthogonal*
+    class; they are kept distinct so the staircase join can require
+    perpendicularity.
+    """
+    angle = math.degrees(math.atan2(abs(dy), abs(dx)))
+    if angle <= ANGLE_TOLERANCE_DEG:
+        return "horizontal"
+    if angle >= 90.0 - ANGLE_TOLERANCE_DEG:
+        return "vertical"
+    if abs(angle - 45.0) <= ANGLE_TOLERANCE_DEG:
+        return "diagonal_45"
+    return "off_axis"
+
+
+def compute_routing_quality(pcb: PCB) -> RoutingQualityMetrics:
+    """Compute advisory routing-quality metrics over ``pcb.segments``.
+
+    Pure and side-effect free.  Gracefully handles a board with zero
+    copper segments (all counts 0, fractions 0.0 -- never divides by
+    zero).
+    """
+    segments: list[Segment] = list(pcb.segments)
+    total_segments = len(segments)
+    net_numbers = {seg.net_number for seg in segments if seg.net_number != 0}
+    nets_with_copper = len(net_numbers)
+    segments_per_net = total_segments / nets_with_copper if nets_with_copper else 0.0
+
+    zero_length_count = 0
+    lengths: list[float] = []
+    fragment_count = 0
+    orthogonal_count = 0
+    diagonal_45_count = 0
+    off_axis_count = 0
+
+    # (net, layer, quantized endpoint) -> set of orientations of *short*
+    # orthogonal segments touching that point.  Only a perpendicular
+    # partner makes a segment a staircase step, so a segment's own entry
+    # can never make itself count.
+    short_orth_endpoints: dict[tuple[int, str, tuple[int, int]], set[str]] = {}
+    # (segment orientation, net, layer, endpoints) for each short orthogonal
+    # segment, revisited in the second pass.
+    short_orth_segments: list[tuple[str, int, str, tuple[int, int], tuple[int, int]]] = []
+
+    for seg in segments:
+        dx = seg.end[0] - seg.start[0]
+        dy = seg.end[1] - seg.start[1]
+        length = math.hypot(dx, dy)
+        if length <= COORD_EPSILON_MM:
+            zero_length_count += 1
+            continue
+
+        lengths.append(length)
+        if length < FRAGMENT_LENGTH_MM:
+            fragment_count += 1
+
+        direction = _classify_direction(dx, dy)
+        if direction in ("horizontal", "vertical"):
+            orthogonal_count += 1
+            if length < STAIRCASE_STEP_MM:
+                p1 = _quantize(seg.start)
+                p2 = _quantize(seg.end)
+                short_orth_segments.append((direction, seg.net_number, seg.layer, p1, p2))
+                for point in (p1, p2):
+                    key = (seg.net_number, seg.layer, point)
+                    short_orth_endpoints.setdefault(key, set()).add(direction)
+        elif direction == "diagonal_45":
+            diagonal_45_count += 1
+        else:
+            off_axis_count += 1
+
+    # Second pass: a short orthogonal segment is a staircase step when a
+    # perpendicular short orthogonal segment of the same net and layer
+    # shares either endpoint.  Counts segments (not pairs).
+    staircase_step_count = 0
+    for direction, net, layer, p1, p2 in short_orth_segments:
+        perpendicular = "vertical" if direction == "horizontal" else "horizontal"
+        for point in (p1, p2):
+            if perpendicular in short_orth_endpoints.get((net, layer, point), ()):
+                staircase_step_count += 1
+                break
+
+    nonzero_count = len(lengths)
+    median_length_mm = float(median(lengths)) if lengths else 0.0
+    fragment_fraction = fragment_count / nonzero_count if nonzero_count else 0.0
+    staircase_fraction = staircase_step_count / nonzero_count if nonzero_count else 0.0
+
+    return RoutingQualityMetrics(
+        total_segments=total_segments,
+        nets_with_copper=nets_with_copper,
+        segments_per_net=segments_per_net,
+        zero_length_count=zero_length_count,
+        median_length_mm=median_length_mm,
+        fragment_count=fragment_count,
+        fragment_fraction=fragment_fraction,
+        orthogonal_count=orthogonal_count,
+        diagonal_45_count=diagonal_45_count,
+        off_axis_count=off_axis_count,
+        staircase_step_count=staircase_step_count,
+        staircase_fraction=staircase_fraction,
+    )

--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -30,6 +30,12 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Literal
 
+from kicad_tools.analysis.routing_quality import (
+    FRAGMENT_LENGTH_MM,
+    STAIRCASE_STEP_MM,
+    RoutingQualityMetrics,
+    compute_routing_quality,
+)
 from kicad_tools.manufacturers import get_manufacturer_ids, get_profile
 from kicad_tools.schema.pcb import PCB
 from kicad_tools.sidecars import net_class_map_sidecar_candidates
@@ -1036,6 +1042,44 @@ def print_meta_check_stanza(result: MetaCheckResult, verbose: bool = False) -> N
     print(f"{'Overall:':10} {result.overall}")
 
 
+def print_routing_quality_stanza(metrics: RoutingQualityMetrics) -> None:
+    """Print the advisory routing-quality stanza (issue #4623).
+
+    Purely descriptive: these numbers never contribute to the verdict,
+    exit code, or meta rollup -- including under ``--strict``.  Printed
+    after the meta-check stanza in the default (meta) mode only; skipped
+    under ``--drc-only`` to preserve the legacy stdout contract (#3750),
+    mirroring how ``meta_checks`` is omitted.
+    """
+    pct_base = metrics.total_segments - metrics.zero_length_count
+
+    def pct(count: int) -> str:
+        return f"{100.0 * count / pct_base:.1f}%" if pct_base else "0.0%"
+
+    print()
+    print("Routing quality (advisory):")
+    print(
+        f"  Segments:     {metrics.total_segments} across "
+        f"{metrics.nets_with_copper} net(s) ({metrics.segments_per_net:.1f}/net)"
+    )
+    print(f"  Median length: {metrics.median_length_mm:.3f} mm")
+    print(
+        f"  Fragments (<{FRAGMENT_LENGTH_MM} mm): "
+        f"{metrics.fragment_count} ({pct(metrics.fragment_count)})"
+    )
+    print(
+        f"  Direction:    orthogonal {metrics.orthogonal_count} "
+        f"({pct(metrics.orthogonal_count)}) / 45-deg {metrics.diagonal_45_count} "
+        f"({pct(metrics.diagonal_45_count)}) / off-axis {metrics.off_axis_count} "
+        f"({pct(metrics.off_axis_count)})"
+    )
+    print(
+        f"  Staircase steps (<{STAIRCASE_STEP_MM} mm legs): "
+        f"{metrics.staircase_step_count} ({pct(metrics.staircase_step_count)})"
+    )
+    print(f"  Zero-length:  {metrics.zero_length_count}")
+
+
 CHECK_CATEGORIES = [
     "ampacity",
     "clearance",
@@ -1969,24 +2013,61 @@ def main(argv: list[str] | None = None) -> int:
             strict=args.strict,
         )
 
+    # Issue #4623: advisory routing-quality metrics.  Computed only in meta
+    # mode -- skipped entirely under --drc-only to keep the legacy stdout
+    # and on-disk JSON contracts byte-identical (#3750), mirroring how
+    # ``meta_checks`` is omitted.  Advisory ONLY: the metrics never change
+    # the verdict, exit code, or meta rollup (including under --strict);
+    # a metrics crash degrades to a stderr warning, never a failed check.
+    routing_quality: RoutingQualityMetrics | None = None
+    if not drc_only:
+        try:
+            routing_quality = compute_routing_quality(pcb)
+        except Exception as exc:
+            print(
+                f"Warning: routing-quality metrics unavailable ({exc}); "
+                "continuing without the advisory stanza",
+                file=sys.stderr,
+            )
+    routing_quality_dict = routing_quality.to_dict() if routing_quality is not None else None
+
     # Output results
     if args.format == "json":
-        output_json(violations, results, pcb_path, effective_mfr, layers, meta=meta)
+        output_json(
+            violations,
+            results,
+            pcb_path,
+            effective_mfr,
+            layers,
+            meta=meta,
+            routing_quality=routing_quality_dict,
+        )
     elif args.format == "summary":
         output_summary(violations, results, pcb_path)
         if meta is not None:
             print_meta_check_stanza(meta, args.verbose)
+        if routing_quality is not None:
+            print_routing_quality_stanza(routing_quality)
     else:
         output_table(violations, results, pcb_path, effective_mfr, layers, args.verbose)
         if meta is not None:
             print_meta_check_stanza(meta, args.verbose)
+        if routing_quality is not None:
+            print_routing_quality_stanza(routing_quality)
 
     # Write JSON report to file if --output specified
     if args.output:
         output_path = Path(args.output)
         output_path.parent.mkdir(parents=True, exist_ok=True)
         write_json_report(
-            violations, results, pcb_path, effective_mfr, layers, output_path, meta=meta
+            violations,
+            results,
+            pcb_path,
+            effective_mfr,
+            layers,
+            output_path,
+            meta=meta,
+            routing_quality=routing_quality_dict,
         )
 
     # Issue #4375: optionally emit DRC-constraint sidecars from the SAME
@@ -2581,6 +2662,7 @@ def output_json(
     mfr: str,
     layers: int,
     meta: MetaCheckResult | None = None,
+    routing_quality: dict | None = None,
 ) -> None:
     """Output violations as JSON.
 
@@ -2589,6 +2671,10 @@ def output_json(
     ``summary.passed`` / ``summary.errors`` / ``violations`` are
     unaffected.  Under ``--drc-only`` the ``meta`` parameter is ``None``
     and the field is omitted (``OMIT-when-absent`` convention).
+
+    Issue #4623: ``routing_quality`` (a ``RoutingQualityMetrics.to_dict()``
+    payload) follows the same convention -- emitted as a top-level key in
+    meta mode, omitted under ``--drc-only``.
     """
     error_count = sum(1 for v in violations if v.is_error)
     warning_count = sum(1 for v in violations if v.is_warning)
@@ -2627,6 +2713,8 @@ def output_json(
     }
     if meta is not None:
         data["meta_checks"] = meta.to_dict()
+    if routing_quality is not None:
+        data["routing_quality"] = routing_quality
     print(json.dumps(data, indent=2))
 
 
@@ -2638,12 +2726,16 @@ def write_json_report(
     layers: int,
     output_path: Path,
     meta: MetaCheckResult | None = None,
+    routing_quality: dict | None = None,
 ) -> None:
     """Write DRC results as a JSON report file.
 
     Issue #3750: ``meta_checks`` is added to the envelope when meta-mode
     is active.  Omitted under ``--drc-only`` to preserve the legacy
     on-disk schema.
+
+    Issue #4623: ``routing_quality`` follows the same OMIT-when-absent
+    convention (present in meta mode, omitted under ``--drc-only``).
     """
     error_count = sum(1 for v in violations if v.is_error)
     warning_count = sum(1 for v in violations if v.is_warning)
@@ -2676,6 +2768,8 @@ def write_json_report(
     }
     if meta is not None:
         data["meta_checks"] = meta.to_dict()
+    if routing_quality is not None:
+        data["routing_quality"] = routing_quality
     output_path.write_text(json.dumps(data, indent=2) + "\n")
 
 

--- a/tests/test_routing_quality_metrics.py
+++ b/tests/test_routing_quality_metrics.py
@@ -1,0 +1,456 @@
+"""Tests for the advisory routing-quality metrics (issue #4623).
+
+Two layers:
+
+- Unit tests for the pure ``kicad_tools.analysis.routing_quality`` module
+  on synthetic segment sets with known geometry (45°-only, staircase,
+  zero-length, fragments, off-axis, empty board).
+- CLI tests asserting the advisory wire-in in ``kct check``: the stanza
+  appears in table/summary output, ``routing_quality`` appears in
+  ``--format json`` and ``--output`` envelopes, is **absent** under
+  ``--drc-only`` (legacy contract, #3750), and never affects the exit
+  code -- including under ``--strict`` and when the computation crashes.
+
+Deliberately a standalone file (not an extension of
+``tests/test_check_cmd_coverage.py``) per the issue's parallel-wave
+guidance.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.analysis.routing_quality import (
+    FRAGMENT_LENGTH_MM,
+    STAIRCASE_STEP_MM,
+    RoutingQualityMetrics,
+    compute_routing_quality,
+)
+from kicad_tools.schema.pcb import Segment
+
+# ---------------------------------------------------------------------------
+# Unit-test scaffolding: real Segment dataclasses on a minimal PCB stub
+# (compute_routing_quality only reads ``pcb.segments``).
+# ---------------------------------------------------------------------------
+
+
+class _StubPCB:
+    def __init__(self, segments: list[Segment]):
+        self.segments = segments
+
+
+def _seg(
+    start: tuple[float, float],
+    end: tuple[float, float],
+    net: int = 1,
+    layer: str = "F.Cu",
+    width: float = 0.2,
+) -> Segment:
+    return Segment(
+        start=start,
+        end=end,
+        width=width,
+        layer=layer,
+        net_number=net,
+        net_name=f"NET{net}",
+    )
+
+
+class TestComputeRoutingQuality:
+    def test_empty_board_is_graceful(self):
+        m = compute_routing_quality(_StubPCB([]))
+        assert m.total_segments == 0
+        assert m.nets_with_copper == 0
+        assert m.segments_per_net == 0.0
+        assert m.zero_length_count == 0
+        assert m.median_length_mm == 0.0
+        assert m.fragment_count == 0
+        assert m.fragment_fraction == 0.0
+        assert m.orthogonal_count == 0
+        assert m.diagonal_45_count == 0
+        assert m.off_axis_count == 0
+        assert m.staircase_step_count == 0
+        assert m.staircase_fraction == 0.0
+
+    def test_pure_45_route(self):
+        segs = [
+            _seg((0.0, 0.0), (1.0, 1.0)),
+            _seg((1.0, 1.0), (2.0, 2.0)),
+            _seg((2.0, 2.0), (3.0, 1.0)),  # falling 45° also counts
+        ]
+        m = compute_routing_quality(_StubPCB(segs))
+        assert m.total_segments == 3
+        assert m.diagonal_45_count == 3
+        assert m.orthogonal_count == 0
+        assert m.off_axis_count == 0
+        assert m.staircase_step_count == 0
+        assert m.zero_length_count == 0
+        assert m.fragment_count == 0
+        assert m.median_length_mm == pytest.approx(math.sqrt(2.0))
+        assert m.nets_with_copper == 1
+        assert m.segments_per_net == pytest.approx(3.0)
+
+    def test_staircase_route_counts_every_step(self):
+        # Four alternating H/V legs of 0.4 mm, chained end-to-end on the
+        # same net and layer -- every one is a staircase step.
+        segs = [
+            _seg((0.0, 0.0), (0.4, 0.0)),
+            _seg((0.4, 0.0), (0.4, 0.4)),
+            _seg((0.4, 0.4), (0.8, 0.4)),
+            _seg((0.8, 0.4), (0.8, 0.8)),
+        ]
+        m = compute_routing_quality(_StubPCB(segs))
+        assert m.orthogonal_count == 4
+        assert m.staircase_step_count == 4
+        assert m.staircase_fraction == pytest.approx(1.0)
+        # 0.4 mm legs are above the fragment threshold
+        assert m.fragment_count == 0
+        assert m.diagonal_45_count == 0
+        assert m.off_axis_count == 0
+
+    def test_staircase_requires_same_layer(self):
+        segs = [
+            _seg((0.0, 0.0), (0.4, 0.0), layer="F.Cu"),
+            _seg((0.4, 0.0), (0.4, 0.4), layer="B.Cu"),
+        ]
+        m = compute_routing_quality(_StubPCB(segs))
+        assert m.staircase_step_count == 0
+
+    def test_staircase_requires_same_net(self):
+        segs = [
+            _seg((0.0, 0.0), (0.4, 0.0), net=1),
+            _seg((0.4, 0.0), (0.4, 0.4), net=2),
+        ]
+        m = compute_routing_quality(_StubPCB(segs))
+        assert m.staircase_step_count == 0
+
+    def test_staircase_requires_both_legs_short(self):
+        # Short H meeting a LONG perpendicular V: neither is a step.
+        segs = [
+            _seg((0.0, 0.0), (0.4, 0.0)),
+            _seg((0.4, 0.0), (0.4, 5.0)),
+        ]
+        m = compute_routing_quality(_StubPCB(segs))
+        assert m.staircase_step_count == 0
+
+    def test_staircase_requires_perpendicular_partner(self):
+        # Two collinear short H segments sharing an endpoint: not a step.
+        segs = [
+            _seg((0.0, 0.0), (0.4, 0.0)),
+            _seg((0.4, 0.0), (0.8, 0.0)),
+        ]
+        m = compute_routing_quality(_StubPCB(segs))
+        assert m.staircase_step_count == 0
+
+    def test_zero_length_segments_counted_and_excluded_from_stats(self):
+        segs = [
+            _seg((1.0, 1.0), (1.0, 1.0)),  # exactly zero
+            _seg((2.0, 2.0), (2.0 + 1e-7, 2.0)),  # within the 1e-6 epsilon
+            _seg((0.0, 0.0), (1.0, 0.0)),
+        ]
+        m = compute_routing_quality(_StubPCB(segs))
+        assert m.total_segments == 3
+        assert m.zero_length_count == 2
+        # Stats over the single real segment only
+        assert m.median_length_mm == pytest.approx(1.0)
+        assert m.orthogonal_count == 1
+        assert m.fragment_count == 0
+        assert m.fragment_fraction == 0.0
+
+    def test_fragments(self):
+        segs = [
+            _seg((0.0, 0.0), (0.1, 0.0)),  # 0.1 mm < FRAGMENT_LENGTH_MM
+            _seg((0.0, 1.0), (1.0, 1.0)),
+            _seg((0.0, 2.0), (1.0, 2.0)),
+            _seg((0.0, 3.0), (1.0, 3.0)),
+        ]
+        assert FRAGMENT_LENGTH_MM > 0.1
+        m = compute_routing_quality(_StubPCB(segs))
+        assert m.fragment_count == 1
+        assert m.fragment_fraction == pytest.approx(0.25)
+
+    def test_off_axis(self):
+        segs = [
+            _seg((0.0, 0.0), (1.0, 0.5)),  # ~26.6°: neither 0/90 nor 45
+        ]
+        m = compute_routing_quality(_StubPCB(segs))
+        assert m.off_axis_count == 1
+        assert m.orthogonal_count == 0
+        assert m.diagonal_45_count == 0
+
+    def test_angle_tolerance_boundaries(self):
+        # 0.4° off horizontal -> still orthogonal; 1° off -> off-axis.
+        near = math.tan(math.radians(0.4))
+        far = math.tan(math.radians(1.0))
+        m = compute_routing_quality(
+            _StubPCB(
+                [
+                    _seg((0.0, 0.0), (10.0, 10.0 * near)),
+                    _seg((0.0, 5.0), (10.0, 5.0 + 10.0 * far)),
+                ]
+            )
+        )
+        assert m.orthogonal_count == 1
+        assert m.off_axis_count == 1
+
+    def test_net_zero_excluded_from_nets_with_copper(self):
+        segs = [
+            _seg((0.0, 0.0), (1.0, 0.0), net=0),
+            _seg((0.0, 1.0), (1.0, 1.0), net=3),
+            _seg((0.0, 2.0), (1.0, 2.0), net=3),
+        ]
+        m = compute_routing_quality(_StubPCB(segs))
+        assert m.nets_with_copper == 1
+        assert m.total_segments == 3
+        assert m.segments_per_net == pytest.approx(3.0)
+
+    def test_only_net_zero_copper_has_no_division_by_zero(self):
+        m = compute_routing_quality(_StubPCB([_seg((0.0, 0.0), (1.0, 0.0), net=0)]))
+        assert m.nets_with_copper == 0
+        assert m.segments_per_net == 0.0
+
+    def test_to_dict_round_trip(self):
+        m = compute_routing_quality(
+            _StubPCB(
+                [
+                    _seg((0.0, 0.0), (0.4, 0.0)),
+                    _seg((0.4, 0.0), (0.4, 0.4)),
+                    _seg((5.0, 5.0), (5.0, 5.0)),
+                ]
+            )
+        )
+        d = m.to_dict()
+        assert d == {
+            "total_segments": 3,
+            "nets_with_copper": 1,
+            "segments_per_net": 3.0,
+            "zero_length_count": 1,
+            "median_length_mm": pytest.approx(0.4),
+            "fragment_count": 0,
+            "fragment_fraction": 0.0,
+            "orthogonal_count": 2,
+            "diagonal_45_count": 0,
+            "off_axis_count": 0,
+            "staircase_step_count": 2,
+            "staircase_fraction": 1.0,
+        }
+        # The payload must be JSON-serializable as-is.
+        json.dumps(d)
+
+    def test_thresholds_are_the_pinned_constants(self):
+        # Pinned in issue #4623 to match the #4615 measurement basis.
+        assert FRAGMENT_LENGTH_MM == 0.25
+        assert STAIRCASE_STEP_MM == 0.6
+
+
+# ---------------------------------------------------------------------------
+# CLI wire-in tests.  Board template mirrors tests/conftest.py DRC_CLEAN_PCB
+# (designed to pass all DRC checks) with a parameterizable copper block far
+# from the footprint and the board edge.
+# ---------------------------------------------------------------------------
+
+_PCB_TEMPLATE = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (37 "F.SilkS" user "F.Silkscreen")
+    (44 "Edge.Cuts" user)
+    (49 "F.Fab" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (gr_rect (start 100 100) (end 150 150)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000010")
+    (at 125 125)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS")
+      (effects (font (size 1.0 1.0) (thickness 0.15)))
+      (uuid "00000000-0000-0000-0000-000000000011"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000012"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 2 "+3.3V"))
+  )
+{segments})
+"""
+
+# Four alternating H/V 0.4 mm legs: 100% staircase steps ("terrible" metrics).
+_STAIRCASE_SEGMENTS = """  (segment (start 110 110) (end 110.4 110) (width 0.25) (layer "F.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-000000000020"))
+  (segment (start 110.4 110) (end 110.4 110.4) (width 0.25) (layer "F.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-000000000021"))
+  (segment (start 110.4 110.4) (end 110.8 110.4) (width 0.25) (layer "F.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-000000000022"))
+  (segment (start 110.8 110.4) (end 110.8 110.8) (width 0.25) (layer "F.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-000000000023"))
+"""
+
+_CLEAN_45_SEGMENTS = """  (segment (start 110 110) (end 112 112) (width 0.25) (layer "F.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-000000000020"))
+"""
+
+
+@pytest.fixture
+def staircase_pcb(tmp_path: Path) -> Path:
+    p = tmp_path / "staircase_4623.kicad_pcb"
+    p.write_text(_PCB_TEMPLATE.format(segments=_STAIRCASE_SEGMENTS))
+    return p
+
+
+@pytest.fixture
+def clean_45_pcb(tmp_path: Path) -> Path:
+    p = tmp_path / "clean45_4623.kicad_pcb"
+    p.write_text(_PCB_TEMPLATE.format(segments=_CLEAN_45_SEGMENTS))
+    return p
+
+
+class TestCheckCmdAdvisoryWireIn:
+    def test_table_output_has_stanza(self, staircase_pcb: Path, capsys):
+        from kicad_tools.cli.check_cmd import main
+
+        result = main([str(staircase_pcb), "--allow-incomplete"])
+        out = capsys.readouterr().out
+        assert result == 0
+        assert "Routing quality (advisory):" in out
+        assert "Staircase steps" in out
+        assert "Zero-length:" in out
+
+    def test_summary_output_has_stanza(self, staircase_pcb: Path, capsys):
+        from kicad_tools.cli.check_cmd import main
+
+        result = main([str(staircase_pcb), "--format", "summary", "--allow-incomplete"])
+        out = capsys.readouterr().out
+        assert result == 0
+        assert "Routing quality (advisory):" in out
+
+    def test_terrible_metrics_never_change_exit_code(
+        self, staircase_pcb: Path, clean_45_pcb: Path, capsys
+    ):
+        """AC: advisory-only -- all-staircase copper still exits 0 when
+        DRC/meta pass, with and without --strict."""
+        from kicad_tools.cli.check_cmd import main
+
+        assert main([str(clean_45_pcb), "--allow-incomplete"]) == 0
+        assert main([str(staircase_pcb), "--allow-incomplete"]) == 0
+        assert main([str(staircase_pcb), "--allow-incomplete", "--strict"]) == 0
+        capsys.readouterr()
+
+    def test_json_output_has_routing_quality(self, staircase_pcb: Path, capsys):
+        from kicad_tools.cli.check_cmd import main
+
+        result = main([str(staircase_pcb), "--format", "json", "--allow-incomplete"])
+        data = json.loads(capsys.readouterr().out)
+        assert result == 0
+        rq = data["routing_quality"]
+        assert rq["total_segments"] == 4
+        assert rq["orthogonal_count"] == 4
+        assert rq["staircase_step_count"] == 4
+        assert rq["zero_length_count"] == 0
+        assert rq["nets_with_copper"] == 1
+        # Verdict fields are untouched by the advisory metrics
+        assert data["summary"]["passed"] is True
+
+    def test_output_file_has_routing_quality(self, staircase_pcb: Path, tmp_path: Path, capsys):
+        from kicad_tools.cli.check_cmd import main
+
+        report = tmp_path / "report_4623.json"
+        result = main([str(staircase_pcb), "--output", str(report), "--allow-incomplete"])
+        capsys.readouterr()
+        assert result == 0
+        data = json.loads(report.read_text())
+        assert data["routing_quality"]["staircase_step_count"] == 4
+
+    def test_drc_only_stdout_has_no_stanza(self, staircase_pcb: Path, capsys):
+        """AC: legacy --drc-only contract (#3750) -- no advisory stanza."""
+        from kicad_tools.cli.check_cmd import main
+
+        result = main([str(staircase_pcb), "--drc-only"])
+        out = capsys.readouterr().out
+        assert result == 0
+        assert "Routing quality" not in out
+
+    def test_drc_only_json_omits_routing_quality(self, staircase_pcb: Path, capsys):
+        from kicad_tools.cli.check_cmd import main
+
+        result = main([str(staircase_pcb), "--format", "json", "--drc-only"])
+        data = json.loads(capsys.readouterr().out)
+        assert result == 0
+        assert "routing_quality" not in data
+        # Sanity: the sibling meta-mode key is omitted too (same convention)
+        assert "meta_checks" not in data
+
+    def test_drc_only_report_file_omits_routing_quality(
+        self, staircase_pcb: Path, tmp_path: Path, capsys
+    ):
+        from kicad_tools.cli.check_cmd import main
+
+        report = tmp_path / "report_drconly_4623.json"
+        result = main([str(staircase_pcb), "--output", str(report), "--drc-only"])
+        capsys.readouterr()
+        assert result == 0
+        data = json.loads(report.read_text())
+        assert "routing_quality" not in data
+        assert "meta_checks" not in data
+
+    def test_metrics_crash_degrades_to_warning(self, staircase_pcb: Path, capsys, monkeypatch):
+        """AC: a metrics crash degrades to a stderr warning, never a
+        failed check."""
+        from kicad_tools.cli import check_cmd
+
+        def _boom(pcb):
+            raise RuntimeError("synthetic metrics failure 4623")
+
+        monkeypatch.setattr(check_cmd, "compute_routing_quality", _boom)
+        result = check_cmd.main([str(staircase_pcb), "--allow-incomplete"])
+        captured = capsys.readouterr()
+        assert result == 0
+        assert "Routing quality (advisory):" not in captured.out
+        assert "routing-quality metrics unavailable" in captured.err
+
+    def test_stanza_prints_after_meta_stanza(self, staircase_pcb: Path, capsys):
+        """The advisory stanza follows the meta-check rollup in table mode."""
+        from kicad_tools.cli.check_cmd import main
+
+        main([str(staircase_pcb), "--allow-incomplete"])
+        out = capsys.readouterr().out
+        assert out.index("Overall:") < out.index("Routing quality (advisory):")
+
+    def test_stanza_helper_formats_empty_board(self, capsys):
+        """Zero-copper board: stanza renders with no division by zero."""
+        from kicad_tools.cli.check_cmd import print_routing_quality_stanza
+
+        metrics = RoutingQualityMetrics(
+            total_segments=0,
+            nets_with_copper=0,
+            segments_per_net=0.0,
+            zero_length_count=0,
+            median_length_mm=0.0,
+            fragment_count=0,
+            fragment_fraction=0.0,
+            orthogonal_count=0,
+            diagonal_45_count=0,
+            off_axis_count=0,
+            staircase_step_count=0,
+            staircase_fraction=0.0,
+        )
+        print_routing_quality_stanza(metrics)
+        out = capsys.readouterr().out
+        assert "Routing quality (advisory):" in out
+        assert "0 across 0 net(s)" in out


### PR DESCRIPTION
Closes #4623

## Summary

`kct check`'s gates are all binary, so a board can be DRC-clean while carrying copper that is visibly poor (the #4615 board: 67% sub-0.25 mm fragments, 42% staircase steps, 12.3% true 45°, 401 off-axis, 7 zero-length — and passed every gate). This PR adds **report-only advisory routing-quality metrics** (decomposition item 1 of #4615 §2; items 2–4 remain out-of-scope follow-ups):

- **New pure module** `src/kicad_tools/analysis/routing_quality.py`: `RoutingQualityMetrics` dataclass (`to_dict()`) + `compute_routing_quality(pcb)`, implementing the pinned definitions exactly — `FRAGMENT_LENGTH_MM = 0.25`, `STAIRCASE_STEP_MM = 0.6`, 0.5° angle tolerance, 1e-6 mm coordinate epsilon, staircase counted per *segment* via an O(n) endpoint hash join keyed on (net, layer, quantized point).
- **Advisory wire-in** in `check_cmd.py` (imports, `main()` output section, `output_json`, `write_json_report`, plus a `print_routing_quality_stanza` helper next to `print_meta_check_stanza`): a "Routing quality (advisory)" stanza after the meta rollup in table/summary modes, and a top-level `routing_quality` object in the JSON/`--output` envelopes (OMIT-when-absent, mirroring `meta_checks`).
- Exported from `kicad_tools.analysis` alongside the existing analyzers.

## Per-AC verification

- **Pure module, no CLI/IO** — `routing_quality.py` imports only `math`/`statistics`/`dataclasses` (+ typing-only `PCB`); mypy clean.
- **Stanza in table AND summary** — `test_table_output_has_stanza`, `test_summary_output_has_stanza`, `test_stanza_prints_after_meta_stanza` (asserts it follows `Overall:`).
- **Advisory only, incl. --strict** — `test_terrible_metrics_never_change_exit_code` (all-staircase board exits 0 with and without `--strict`); `test_metrics_crash_degrades_to_warning` (monkeypatched crash → stderr warning, exit unchanged). The metrics feed nothing in the exit-code path.
- **JSON + --output envelopes** — `test_json_output_has_routing_quality`, `test_output_file_has_routing_quality`; verdict fields untouched (`summary.passed` asserted).
- **--drc-only byte-identical** — computation is gated on `not drc_only` (exact `meta_checks` pattern), so stdout and the on-disk JSON schema are unchanged; asserted by `test_drc_only_stdout_has_no_stanza`, `test_drc_only_json_omits_routing_quality`, `test_drc_only_report_file_omits_routing_quality`.
- **No new CLI flags** — argparse untouched; `tests/test_cli_parser_drift.py` passes with zero edits.
- **No CHECK_CATEGORIES entry** — untouched; `rules_checked` / `rules_checked_by_rule` unchanged (`test_check_cmd_coverage.py` green).
- **Zero-copper board graceful** — `test_empty_board_is_graceful`, `test_only_net_zero_copper_has_no_division_by_zero`, `test_stanza_helper_formats_empty_board` (no division by zero; fractions 0.0).
- **Synthetic-geometry unit tests** — pure-45°, staircase (incl. same-layer / same-net / both-legs-short / perpendicularity negatives), zero-length (exact + epsilon), fragments, off-axis, angle-tolerance boundaries, net-0 exclusion, `to_dict()` round trip, pinned-constant guard.

## Test results

- `tests/test_routing_quality_metrics.py`: **26 passed**
- `tests/test_cli_parser_drift.py` + `tests/test_cli_check.py` + `tests/test_check_cmd_coverage.py`: **128 passed**
- Adjacent check-output consumers (`test_lvs_recipe`, `test_build_verify_step`, `test_check_fab_profile_resolution`, `test_cli_check_waivers`, `test_cli_check_ampacity_stackup`, `test_migrated_boards_gate_3912`): **118 passed**; `test_netlist_sync_gate` + `test_recipes_gate` (kicad-cli mocked): **56 passed**
- `ruff check` + `ruff format --check` clean on all touched files; `mypy` clean on the new module, `check_cmd.py`, and `analysis/__init__.py`
- Manual spot-check on `boards/00-simple-led/output/simple_led_routed.kicad_pcb`: plausible stanza, verdict PASSED, exit 0

## Notes

- One CHANGELOG bullet under [Unreleased] → Added — a merge conflict with the sibling wave PRs' bullets is expected and trivial.
- No changes to `CHECK_CATEGORIES`, the argparse block, `run_selected_checks`, or anything under `src/kicad_tools/validate/` (sibling-owned regions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)