### PR TITLE
docs(board-06): fix stale 28-error allowlist figures in README (#4606)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -270,6 +270,15 @@ constructor). No breaking changes.
 
 ### Fixed
 
+- **Docs: `boards/06-diffpair-test/README.md` no longer cites the pre-ratchet
+  28-error allowlist.** The CI Gate section, "Interpreting a failure" table,
+  and "Tightening the allowlist" section now state the actual pin — 18 errors
+  (9x `diffpair_length_skew` + 9x `diffpair_routing_continuity`, #3540-#3544,
+  floor ratcheted 24 -> 18 by #4019) — matching
+  `.github/routed-drc-tolerance.yml` and `EXPECTED_STRICT_GATE_ERRORS`, and
+  stop presenting closed issues #2672/#2677/#2648 as pending prerequisites
+  (#4606).
+
 - **An HV pairwise-clearance failure could flow through `kct build` /
   `kct pipeline` as a soft warning.** Neither consumer forwarded
   `--voltage-map`, and both treated route exit 3 as non-fatal with a message

--- a/boards/06-diffpair-test/README.md
+++ b/boards/06-diffpair-test/README.md
@@ -113,13 +113,16 @@ kct check output/diffpair_test_routed.kicad_pcb --mfr jlcpcb --errors-only
   Once the router populates `skew_data`, the rule fires on PCIe / MIPI
   skew violations.
 - [#2648](https://github.com/rjwalters/kicad-tools/issues/2648)
-  (Phase 3I serpentine insertion) --- still in progress at scaffold-time.
-  Until it lands, PCIe / MIPI pairs may exceed their declared
-  `skew_tolerance_mm` because the router can't yet meander to fix skew.
+  (Phase 3I serpentine insertion) --- **landed** (closed).  At
+  scaffold-time it was still in progress, so PCIe / MIPI pairs could
+  exceed their declared `skew_tolerance_mm` because the router couldn't
+  yet meander to fix skew.
 
-Per the Epic #2556 Phase 4L mitigation strategy, this board is scaffolded
-now with PCIe / MIPI pairs declared but DRC tolerated at "non-strict" if
-#2648 hasn't landed yet.  Re-route and tighten when #2648 merges.
+*Historical scaffold-time context*: per the Epic #2556 Phase 4L
+mitigation strategy, this board was scaffolded with PCIe / MIPI pairs
+declared but DRC tolerated at "non-strict" while #2648 was pending.
+Both dependencies have since landed; the remaining tolerated residual is
+the 18-error diff-pair quality block documented under "CI Gate" below.
 
 ## Measuring Changes: the Shadow Phase Is Deterministic, Full Regen Is Not (#4536)
 
@@ -297,10 +300,14 @@ The job:
    `NetClassRouting` map from `build_net_class_map()`, and runs
    `DRCChecker` with `--mfr jlcpcb`.
 3. Asserts the DRC **error count** is within the per-board allowlist in
-   `.github/routed-drc-tolerance.yml` (currently 28: 25x `ImpedanceRule`
-   per [#2672](https://github.com/rjwalters/kicad-tools/issues/2672)
-   + 3x `diffpair_clearance_intra` per
-   [#2677](https://github.com/rjwalters/kicad-tools/issues/2677)).
+   `.github/routed-drc-tolerance.yml` (currently 18: 9x
+   `diffpair_length_skew` + 9x `diffpair_routing_continuity` per
+   [#3540](https://github.com/rjwalters/kicad-tools/issues/3540)-[#3544](https://github.com/rjwalters/kicad-tools/issues/3544),
+   floor ratcheted 24 -> 18 by
+   [#4019](https://github.com/rjwalters/kicad-tools/issues/4019) with all
+   three gated paths --- committed-artifact `routed-pcb-drc-check`,
+   seed-42 Diff-Pair Routing Regression, and the Board 06 E2E fresh
+   regen --- agreeing at 18).
 4. Asserts each of the three diff-pair DRC rule_ids was actually
    exercised by the check, i.e. the JSON summary's
    `rules_checked_by_rule[rule_id] >= 1` for each of:
@@ -319,16 +326,23 @@ The job:
 | Failure mode                                                | Likely cause                                                      |
 |-------------------------------------------------------------|-------------------------------------------------------------------|
 | `Diff-pair rule(s) NOT exercised`                           | Detection broken: `coupled_routing` flag flipped, suffix detection broken, or the routed PCB has no matching pair traces. |
-| `DRC regression: <N> error(s) exceeds allowlist value 28`   | The router introduced new DRC errors beyond the documented #2672/#2677 baseline.  Bisect against the routing algorithm. |
+| `DRC regression: <N> error(s) exceeds allowlist value 18`   | The router introduced new DRC errors beyond the documented #3540-#3544 baseline (9x skew + 9x continuity, #4019 ratchet).  Bisect against the routing algorithm. |
 | Re-route step fails with non-zero exit                      | Routing algorithm regression (board hangs or crashes during `route_all`).  Reproduce locally with `--seed 42`. |
 
 ### Tightening the allowlist
 
-When [#2672](https://github.com/rjwalters/kicad-tools/issues/2672)
+The original prerequisites ---
+[#2672](https://github.com/rjwalters/kicad-tools/issues/2672)
 (impedance-width selection) and
 [#2677](https://github.com/rjwalters/kicad-tools/issues/2677) (BGA
-partner-via escape) land, the board 06 entry in
-`.github/routed-drc-tolerance.yml` should be reduced.  Eventually the
+partner-via escape) --- are both **closed**, and their error classes are
+gone from the gate.  The floor was ratcheted 24 -> 18 by
+[#4019](https://github.com/rjwalters/kicad-tools/issues/4019); the
+current residual is exactly the diff-pair quality block (9x
+`diffpair_length_skew` + 9x `diffpair_routing_continuity`,
+[#3540](https://github.com/rjwalters/kicad-tools/issues/3540)-[#3544](https://github.com/rjwalters/kicad-tools/issues/3544)).
+That residual must clear before the board 06 entry in
+`.github/routed-drc-tolerance.yml` can shrink further.  Eventually the
 entry should be **removed** entirely (per the YAML's "absence == strict
 0 errors" convention) once the board routes cleanly under JLCPCB tier-1
 rules.


### PR DESCRIPTION
## Summary

Docs-only fix for the four stale sites in `boards/06-diffpair-test/README.md` enumerated by the curator on #4606, plus a CHANGELOG bullet.

1. **CI Gate step 3** — allowlist figure corrected from "28: 25x `ImpedanceRule` (#2672) + 3x `diffpair_clearance_intra` (#2677)" to **18: 9x `diffpair_length_skew` + 9x `diffpair_routing_continuity`** (#3540-#3544), citing the #4019 floor ratchet (24 -> 18) and the three gated paths agreeing at 18, matching the tolerance file's comment block.
2. **"Interpreting a failure" table** — `exceeds allowlist value 28` / "#2672/#2677 baseline" row updated to 18 and the #3540-#3544 / #4019 baseline.
3. **"Tightening the allowlist"** — no longer presents closed #2672/#2677 as pending prerequisites; describes the current 9+9 residual as what must clear before the entry shrinks / is removed, keeping the "absence == strict 0 errors" closing sentence.
4. **"DRC Status" Phase-3 dependencies** — #2648 (Phase 3I serpentine) marked landed; the Phase 4L "non-strict" paragraph reframed as historical scaffold-time context instead of pending work.

## Ground truth verified

- `.github/routed-drc-tolerance.yml:1140` — `boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb: 18`, ratchet comment `FLOOR RATCHETED 24 -> 18 (#4019)` with the 9+9 breakdown (#3540-#3544).
- `tests/test_board_06_diffpair_test.py:850` — `EXPECTED_STRICT_GATE_ERRORS = 18`.
- Issues #2648, #2672, #2677, #4019 all confirmed CLOSED via `gh issue view`.
- The file now agrees with the #4594 "Measuring Changes" section's 18 (9+9) shadow-OFF floor.

## Verification

- `grep -nE "28|allowlist" boards/06-diffpair-test/README.md` — only remaining "28" is the census timing "1.28 s" (explicitly out of scope per the issue); all allowlist references now say 18.
- Do-not-touch figures untouched: the 18 (9+9) floor, Mode A/B table (32/35), shadow-phase counters (33/47/323), census figures, structural counts.
- Scope confined to `boards/06-diffpair-test/README.md` + `CHANGELOG.md`. No changes to `.github/routed-drc-tolerance.yml`, tests, router code, or board artifacts.
- No automated tests apply (docs only; no gate values change).

Closes #4606

🤖 Generated with [Claude Code](https://claude.com/claude-code)
