### PR TITLE
fix(mfr): marker-guarded managed block for the .kicad_dru sidecar (never clobber user content)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -270,6 +270,23 @@ constructor). No breaking changes.
 
 ### Fixed
 
+- **The `.kicad_dru` sidecar write clobbered pre-existing user content.** The
+  tier-floor `.kicad_dru` written beside the board by `kct route`, `kct build`,
+  `kct mfr apply-rules`, and `kct check --emit-dru`/`--emit-drc-constraints`
+  was a blanket overwrite that silently deleted the marker-delimited HV
+  creepage rules merged by `kct creepage export-rules` (#4508) and any
+  hand-written custom rules. The fab-tier floors now live in their own
+  sentinel-delimited managed block (`# BEGIN kct fab floors ...` /
+  `# END kct fab floors`, mirroring the creepage exporter's merge dialect):
+  re-emitting replaces only that block, a pre-existing user-owned file is
+  preserved with the block merged in alongside its content, the merged file
+  keeps exactly one leading `(version 1)` header, and the creepage and
+  fab-floors managed blocks coexist in one file. Bare `kct check` (no
+  `--emit-*` flags) continues to write nothing beside the board — now locked
+  in by a regression test — and the `.kct/CONVENTIONS.md` cross-gate
+  convention vendored by `install-kct.sh` documents that `kicad-cli` auto-loads
+  these sidecars, sharing rule floors with `kct check` by design (#4600).
+
 - **An HV pairwise-clearance failure could flow through `kct build` /
   `kct pipeline` as a soft warning.** Neither consumer forwarded
   `--voltage-map`, and both treated route exit 3 as non-fatal with a message

--- a/scripts/install-kct.sh
+++ b/scripts/install-kct.sh
@@ -511,6 +511,18 @@ sign-off.
 2. **Cross-gate DRC for manufacturing sign-off.** `kct check` alone is
    insufficient — always also run `kicad-cli pcb drc --refill-zones`. `kct check`
    can miss marginals (e.g. 0.1000 vs 0.1016 mm) and read stale zone fills.
+   Know what the second referee reads: kct writes `<board>.kicad_pro` /
+   `<board>.kicad_dru` sidecars beside the board (`kct route` and `kct build`
+   always; `kct check` only under `--emit-dru` / `--emit-drc-constraints`),
+   and `kicad-cli` auto-loads both from the board's directory. The cross-gate
+   therefore judges against kct's fab-tier rule floors **by design** — the two
+   referees are independent at the geometry-engine level, not the rule-floor
+   level (without the sidecars, kicad-cli falls back to KiCad's stricter
+   factory defaults and reports false violations on tier-legal geometry). The
+   `.kicad_dru` floors live in a marker-guarded managed block; hand-written
+   custom rules and `kct creepage export-rules` content outside the markers
+   are preserved across re-emits. To audit the rule floors independently,
+   inspect — or temporarily remove — the sidecars before running `kicad-cli`.
 3. **Artifact-first.** The committed board artifact is shipping truth. A
    `generate_design.py`/regeneration may diverge by design and is NOT
    authoritative over a committed board.

--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -2149,6 +2149,11 @@ def _emit_drc_sidecars(
     not change the check verdict.  A write failure degrades to a stderr
     warning rather than raising (mirrors ``kct mfr apply-rules``).  Written
     paths are reported on stderr so JSON stdout stays uncorrupted.
+
+    The ``.kicad_dru`` rules are emitted inside a marker-guarded managed
+    block (Issue #4600): re-emitting replaces only the block, and content
+    outside it -- hand-written custom rules, the ``kct creepage
+    export-rules`` block (#4508) -- is preserved, never clobbered.
     """
     # ``net_class_map`` is keyed by board-net name with the SAME class object
     # shared across every net in that class (and a ``--net-class-map`` sidecar
@@ -2181,14 +2186,21 @@ def _emit_drc_sidecars(
                 net_classes=net_classes,
             )
         else:
-            from kicad_tools.manufacturers.dru_generator import generate_dru
+            from kicad_tools.manufacturers.dru_generator import generate_dru, merge_dru_floors
 
             dru_path = pcb_path.with_suffix(".kicad_dru")
+            # Issue #4600: merge into a marker-guarded managed block instead of
+            # a blanket overwrite, so hand-written rules and the creepage
+            # managed block (#4508) in a pre-existing file survive the emit.
+            existing_dru = dru_path.read_text(encoding="utf-8") if dru_path.exists() else None
             dru_path.write_text(
-                generate_dru(
-                    checker.design_rules,
-                    manufacturer_name=manufacturer_id,
-                    net_classes=net_classes,
+                merge_dru_floors(
+                    existing_dru,
+                    generate_dru(
+                        checker.design_rules,
+                        manufacturer_name=manufacturer_id,
+                        net_classes=net_classes,
+                    ),
                 ),
                 encoding="utf-8",
             )

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -2181,6 +2181,13 @@ def _write_drc_constraint_sidecars(
     unknown manufacturer degrades to a non-fatal warning, never a route
     failure.
 
+    Both sidecars have preserve-and-merge semantics: the ``.kicad_pro``
+    keeps existing project content and overwrites only the constraint /
+    severity entries, and the ``.kicad_dru`` tier floors land inside a
+    marker-guarded managed block (Issue #4600) so hand-written custom rules
+    and the ``kct creepage export-rules`` block (#4508) in a pre-existing
+    file survive every route.
+
     Args:
         output_path: Path to the routed PCB file.  The sidecars are written
             to the same directory (``<board>.kicad_pro`` / ``.kicad_dru``).

--- a/src/kicad_tools/manufacturers/__init__.py
+++ b/src/kicad_tools/manufacturers/__init__.py
@@ -34,7 +34,7 @@ from .base import (
     load_rotation_corrections,
     match_rotation_correction,
 )
-from .dru_generator import generate_dru
+from .dru_generator import generate_dru, merge_dru_floors
 from .flashpcb import FLASHPCB_PROFILE
 from .jlcpcb import JLCPCB_PROFILE
 from .jlcpcb_tier1 import JLCPCB_TIER1_PROFILE
@@ -65,6 +65,7 @@ __all__ = [
     "load_rotation_corrections",
     "match_rotation_correction",
     "generate_dru",
+    "merge_dru_floors",
     "build_default_netclass",
     "build_project_data",
     "build_project_rules",

--- a/src/kicad_tools/manufacturers/dru_generator.py
+++ b/src/kicad_tools/manufacturers/dru_generator.py
@@ -16,12 +16,87 @@ Usage:
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING, Sequence
 
 from .base import DesignRules
 
 if TYPE_CHECKING:
     from kicad_tools.router.rules import NetClassRouting
+
+# ---------------------------------------------------------------------------
+# Managed fab-floors block (Issue #4600)
+# ---------------------------------------------------------------------------
+
+# Sentinel markers delimiting the kct-owned fab-floor rules inside a
+# ``.kicad_dru`` sidecar.  On re-emit only the text BETWEEN these markers is
+# replaced; everything else in the file -- hand-written custom rules, the
+# ``kct creepage export-rules`` managed block (which uses its own, distinct
+# markers; see ``kicad_tools.creepage.export_rules.DRU_BLOCK_BEGIN``) -- is
+# preserved verbatim, so the two managed blocks coexist in one file.
+DRU_FLOORS_BLOCK_BEGIN = "# BEGIN kct fab floors (Issue #4600) -- managed, do not edit"
+DRU_FLOORS_BLOCK_END = "# END kct fab floors"
+
+# KiCad ``.kicad_dru`` files start with a version header.
+DRU_VERSION_HEADER = "(version 1)"
+
+
+def _strip_version_header(content: str) -> str:
+    """Drop a leading ``(version N)`` line so a merged file keeps exactly one."""
+    return re.sub(r"^\s*\(version[^)]*\)\s*\n?", "", content, count=1)
+
+
+def merge_dru_floors(existing: str | None, dru_content: str) -> str:
+    """Merge :func:`generate_dru` output into ``.kicad_dru`` content (#4600).
+
+    The tier-floor rules are wrapped in a sentinel-delimited managed block and
+    merged into ``existing`` with the same semantics as the creepage
+    exporter's ``merge_dru_block`` (Issue #4508) -- one merge dialect, two
+    distinct marker pairs:
+
+    * No existing content -> ``(version 1)`` + the managed block.
+    * Existing fab-floors block present -> replace only the text between the
+      sentinels.
+    * Existing content without a fab-floors block (a fully user-owned file,
+      or one holding the creepage managed block) -> **append** the block,
+      preserving every existing byte, and prepend a version header only if
+      the file lacks one.  A pre-existing file is therefore never clobbered
+      or deleted -- the previous blanket ``write_text`` silently destroyed
+      HV creepage rules and hand-written custom rules.
+
+    The merged result contains exactly one leading ``(version 1)`` header
+    (the header inside ``dru_content`` is stripped before wrapping).
+
+    Idempotent: re-merging identical inputs yields byte-identical output.
+
+    Args:
+        existing: Current ``.kicad_dru`` file content, or ``None`` when the
+            file does not exist yet.
+        dru_content: Fresh :func:`generate_dru` output (with its leading
+            version header) to install as the managed block.
+
+    Returns:
+        The full merged ``.kicad_dru`` file content.
+    """
+    body = _strip_version_header(dru_content).strip("\n")
+    block = f"{DRU_FLOORS_BLOCK_BEGIN}\n{body}\n{DRU_FLOORS_BLOCK_END}"
+
+    if existing is None or not existing.strip():
+        return f"{DRU_VERSION_HEADER}\n\n{block}\n"
+
+    pattern = re.compile(
+        re.escape(DRU_FLOORS_BLOCK_BEGIN) + r".*?" + re.escape(DRU_FLOORS_BLOCK_END),
+        re.DOTALL,
+    )
+    if pattern.search(existing):
+        merged = pattern.sub(lambda _m: block, existing)
+        return merged if merged.endswith("\n") else merged + "\n"
+
+    # Append; ensure a version header exists (mirrors ``merge_dru_block``).
+    prefix = existing if existing.endswith("\n") else existing + "\n"
+    if not re.search(r"^\s*\(version\b", existing, re.MULTILINE):
+        prefix = f"{DRU_VERSION_HEADER}\n" + prefix
+    return f"{prefix}\n{block}\n"
 
 
 def generate_dru(

--- a/src/kicad_tools/manufacturers/project_generator.py
+++ b/src/kicad_tools/manufacturers/project_generator.py
@@ -299,6 +299,15 @@ def write_drc_constraints(
     schema can't express.  An existing ``.kicad_pro`` is preserved and
     only the constraint/severity entries are overwritten.
 
+    The ``.kicad_dru`` half has matching preserve-and-merge semantics
+    (Issue #4600): the tier-floor rules land inside a sentinel-delimited
+    managed block (see
+    :func:`~kicad_tools.manufacturers.dru_generator.merge_dru_floors`) and
+    re-emitting replaces only that block.  Hand-written custom rules and
+    the ``kct creepage export-rules`` managed block (#4508) outside the
+    fab-floors markers survive verbatim; a pre-existing user-owned file
+    is never clobbered -- the block is merged in alongside its content.
+
     Args:
         pcb_path: Path to the routed board.
         rules: Manufacturer design rules to translate.
@@ -351,11 +360,22 @@ def write_drc_constraints(
     written.append(pro_path)
 
     if write_dru:
-        from .dru_generator import generate_dru
+        from .dru_generator import generate_dru, merge_dru_floors
 
         dru_path = pcb_path.with_suffix(".kicad_dru")
+        try:
+            existing_dru: str | None = (
+                dru_path.read_text(encoding="utf-8") if dru_path.exists() else None
+            )
+        except OSError:
+            # Unreadable existing file -- nothing recoverable to preserve;
+            # write cleanly (mirrors the corrupt-``.kicad_pro`` fallback).
+            existing_dru = None
         dru_path.write_text(
-            generate_dru(rules, manufacturer_name=manufacturer_id, net_classes=net_classes),
+            merge_dru_floors(
+                existing_dru,
+                generate_dru(rules, manufacturer_name=manufacturer_id, net_classes=net_classes),
+            ),
             encoding="utf-8",
         )
         written.append(dru_path)

--- a/tests/creepage/test_export_rules.py
+++ b/tests/creepage/test_export_rules.py
@@ -346,6 +346,49 @@ def test_merge_dru_block_appends_when_absent_and_is_idempotent():
 
 
 # ---------------------------------------------------------------------------
+# Interop with the fab-floors managed block (#4600)
+# ---------------------------------------------------------------------------
+
+
+def test_creepage_block_survives_write_drc_constraints(tmp_path):
+    """A sidecar re-emit (`kct route`/`build`/`check --emit-dru`) preserves us.
+
+    Issue #4600: `write_drc_constraints` used a blanket ``write_text`` that
+    deleted this module's managed block (plus hand-written rules).  It now
+    merges its own, distinctly-marked fab-floors block -- both managed
+    blocks and the hand-written rule must coexist in one valid file.
+    """
+    from kicad_tools.manufacturers import get_profile, write_drc_constraints
+    from kicad_tools.manufacturers.dru_generator import (
+        DRU_FLOORS_BLOCK_BEGIN,
+        DRU_FLOORS_BLOCK_END,
+    )
+
+    board = tmp_path / "board.kicad_pcb"
+    board.write_text("(kicad_pcb)")
+    handwritten = '(version 1)\n\n(rule "hand_rule" (constraint track_width (min 0.15mm)))\n'
+    creepage_body = '(rule "kct_creepage_pair" (constraint clearance (min 1.5mm)))'
+    dru = board.with_suffix(".kicad_dru")
+    dru.write_text(merge_dru_block(handwritten, creepage_body))
+
+    rules = get_profile("jlcpcb-tier1").get_design_rules(layers=4)
+    write_drc_constraints(board, rules, manufacturer_id="jlcpcb-tier1", layers=4)
+
+    merged = dru.read_text()
+    assert "hand_rule" in merged
+    assert creepage_body in merged
+    assert DRU_BLOCK_BEGIN in merged and DRU_BLOCK_END in merged
+    assert DRU_FLOORS_BLOCK_BEGIN in merged and DRU_FLOORS_BLOCK_END in merged
+    assert merged.count("(version 1)") == 1
+
+    # And the reverse: a creepage re-export preserves the fab-floors block.
+    re_exported = merge_dru_block(merged, creepage_body)
+    assert DRU_FLOORS_BLOCK_BEGIN in re_exported
+    assert re_exported.count(DRU_BLOCK_BEGIN) == 1
+    assert re_exported.count(DRU_FLOORS_BLOCK_BEGIN) == 1
+
+
+# ---------------------------------------------------------------------------
 # Round-trip: emitted rules parse back via the DRU importer
 # ---------------------------------------------------------------------------
 

--- a/tests/test_check_emit_dru.py
+++ b/tests/test_check_emit_dru.py
@@ -12,9 +12,10 @@ is no separately-resolved profile that could drift.
 
 The load-bearing contracts pinned here:
 
-1. **Parity by construction** -- the emitted ``.kicad_dru`` is byte-identical
-   to ``generate_dru(checker.design_rules, ...)`` for the resolved tier /
-   layer / copper, so the two engines cannot silently diverge.
+1. **Parity by construction** -- the emitted ``.kicad_dru`` managed block is
+   byte-identical to ``generate_dru(checker.design_rules, ...)`` (wrapped via
+   ``merge_dru_floors``, #4600) for the resolved tier / layer / copper, so
+   the two engines cannot silently diverge.
 2. **DRU-only vs both** -- ``--emit-dru`` writes only the ``.kicad_dru``;
    ``--emit-drc-constraints`` also writes the ``.kicad_pro`` whose applied
    Default netclass clearance is required for kicad-cli clearance parity
@@ -31,7 +32,7 @@ import pytest
 
 from kicad_tools.cli.check_cmd import _emit_drc_sidecars, main
 from kicad_tools.manufacturers import get_profile
-from kicad_tools.manufacturers.dru_generator import generate_dru
+from kicad_tools.manufacturers.dru_generator import generate_dru, merge_dru_floors
 from kicad_tools.router.rules import NetClassRouting
 from kicad_tools.schema.pcb import PCB
 from kicad_tools.validate import DRCChecker
@@ -105,7 +106,9 @@ def test_emit_dru_matches_checker_resolved_rules(
         copper_oz=copper,
         copper_oz_outer=copper,
     )
-    expected = generate_dru(checker.design_rules, manufacturer_name=mfr)
+    # The rules land inside the managed fab-floors block (#4600); a fresh
+    # file is byte-identical to the merged generate_dru output.
+    expected = merge_dru_floors(None, generate_dru(checker.design_rules, manufacturer_name=mfr))
     assert dru_path.read_text(encoding="utf-8") == expected
 
     # And the emitted floors track the profile minimums for that tier.
@@ -172,10 +175,13 @@ def test_emit_dedups_shared_ampacity_class_to_one_rule_pair(board_copy: Path) ->
     assert dru.count("Ampacity Min Width (POWER, internal)") == 1
     # Byte-identical to a SINGLE deduplicated class -- the DRU carries no
     # per-net redundancy.
-    expected = generate_dru(
-        checker.design_rules,
-        manufacturer_name="jlcpcb",
-        net_classes=[NetClassRouting(name="POWER", target_ampacity=15.0)],
+    expected = merge_dru_floors(
+        None,
+        generate_dru(
+            checker.design_rules,
+            manufacturer_name="jlcpcb",
+            net_classes=[NetClassRouting(name="POWER", target_ampacity=15.0)],
+        ),
     )
     assert dru == expected
 
@@ -294,3 +300,61 @@ def test_emit_degrades_on_unwritable_dir(board_copy: Path, capsys, monkeypatch) 
     # Verdict unchanged despite the failed sidecar write, and a warning fired.
     assert rc == plain_rc
     assert "could not emit" in captured.err.lower()
+
+
+# ---------------------------------------------------------------------------
+# Bare check writes NOTHING beside the board (#4600 regression)
+# ---------------------------------------------------------------------------
+
+
+def test_bare_check_leaves_board_directory_clean(board_copy: Path) -> None:
+    """``kct check --mfr <tier>`` without ``--emit-*`` writes no sidecars.
+
+    Issue #4600 locks in the current clean behavior: check-path sidecar
+    emission is opt-in (#4386), so a bare check must leave the board's
+    directory byte-for-byte unchanged -- no untracked ``.kicad_dru`` /
+    ``.kicad_pro`` for a later ``kicad-cli pcb drc`` to silently consume.
+    """
+    before = sorted(p.name for p in board_copy.parent.iterdir())
+    rc = main([str(board_copy), "--mfr", "jlcpcb-tier1", "--allow-incomplete"])
+    assert rc in (0, 2)  # a verdict, not a tool error
+
+    after = sorted(p.name for p in board_copy.parent.iterdir())
+    assert after == before
+    assert not board_copy.with_suffix(".kicad_dru").exists()
+    assert not board_copy.with_suffix(".kicad_pro").exists()
+
+
+# ---------------------------------------------------------------------------
+# Emit merges the managed block -- pre-existing DRU content survives (#4600)
+# ---------------------------------------------------------------------------
+
+
+def test_emit_dru_preserves_existing_creepage_and_user_rules(board_copy: Path) -> None:
+    """``--emit-dru`` merges into the managed block instead of clobbering.
+
+    A pre-existing ``.kicad_dru`` holding the ``kct creepage export-rules``
+    managed block (#4508) plus a hand-written rule must survive the emit
+    with both intact -- the old blanket ``write_text`` silently deleted
+    them.
+    """
+    from kicad_tools.creepage.export_rules import DRU_BLOCK_BEGIN, merge_dru_block
+    from kicad_tools.manufacturers.dru_generator import DRU_FLOORS_BLOCK_BEGIN
+
+    creepage_body = '(rule "kct creepage"\n  (constraint clearance (min 1.5mm)))'
+    hand_rule = '(rule "Hand Rule"\n  (constraint clearance (min 2mm)))'
+    dru_path = board_copy.with_suffix(".kicad_dru")
+    dru_path.write_text(
+        merge_dru_block(f"(version 1)\n{hand_rule}\n", creepage_body),
+        encoding="utf-8",
+    )
+
+    main([str(board_copy), "--mfr", "jlcpcb", "--emit-dru", "--allow-incomplete"])
+
+    merged = dru_path.read_text(encoding="utf-8")
+    assert creepage_body in merged
+    assert hand_rule in merged
+    assert DRU_BLOCK_BEGIN in merged
+    assert DRU_FLOORS_BLOCK_BEGIN in merged
+    assert '(rule "Trace Width - jlcpcb"' in merged
+    assert merged.count("(version 1)") == 1

--- a/tests/test_drc_constraints_export.py
+++ b/tests/test_drc_constraints_export.py
@@ -253,9 +253,12 @@ def test_write_drc_constraints_threads_net_classes_to_dru(tmp_path: Path):
     assert "Ampacity Min Width (POWER, external)" in dru_text
     assert "Ampacity Min Width (POWER, internal)" in dru_text
     # ...and the emitted text must be byte-identical to a direct
-    # generate_dru call with the same net_classes (no drift in the wiring).
-    assert dru_text == generate_dru(
-        rules, manufacturer_name="jlcpcb-tier1", net_classes=net_classes
+    # generate_dru call with the same net_classes wrapped in the managed
+    # fab-floors block (#4600) -- no drift in the wiring.
+    from kicad_tools.manufacturers.dru_generator import merge_dru_floors
+
+    assert dru_text == merge_dru_floors(
+        None, generate_dru(rules, manufacturer_name="jlcpcb-tier1", net_classes=net_classes)
     )
 
 
@@ -271,7 +274,155 @@ def test_write_drc_constraints_without_net_classes_omits_ampacity(tmp_path: Path
 
     dru_text = board.with_suffix(".kicad_dru").read_text()
     assert "Ampacity Min Width" not in dru_text
-    assert dru_text == generate_dru(rules, manufacturer_name="jlcpcb-tier1")
+    from kicad_tools.manufacturers.dru_generator import merge_dru_floors
+
+    assert dru_text == merge_dru_floors(None, generate_dru(rules, manufacturer_name="jlcpcb-tier1"))
+
+
+# ---------------------------------------------------------------------------
+# Managed fab-floors block: merge, never clobber (#4600)
+# ---------------------------------------------------------------------------
+
+
+class TestDruManagedBlockMerge:
+    """``write_drc_constraints`` merges the ``.kicad_dru``, never clobbers.
+
+    Issue #4600: the old blanket ``write_text`` silently destroyed the
+    marker-delimited HV creepage rules written by ``kct creepage
+    export-rules`` (#4508) and any hand-written custom rules.  The tier
+    floors now live in their own sentinel-delimited managed block (mirroring
+    the creepage exporter's ``merge_dru_block`` dialect) and re-emitting
+    replaces only that block.
+    """
+
+    def _emit(self, board: Path) -> str:
+        rules = get_profile("jlcpcb-tier1").get_design_rules(layers=4)
+        write_drc_constraints(board, rules, manufacturer_id="jlcpcb-tier1", layers=4)
+        return board.with_suffix(".kicad_dru").read_text(encoding="utf-8")
+
+    def test_fresh_write_wraps_rules_in_managed_block(self, tmp_path: Path):
+        from kicad_tools.manufacturers.dru_generator import (
+            DRU_FLOORS_BLOCK_BEGIN,
+            DRU_FLOORS_BLOCK_END,
+        )
+
+        board = tmp_path / "demo.kicad_pcb"
+        board.write_text("(kicad_pcb)")
+        dru_text = self._emit(board)
+
+        assert dru_text.startswith("(version 1)\n")
+        assert dru_text.count("(version 1)") == 1
+        assert DRU_FLOORS_BLOCK_BEGIN in dru_text
+        assert DRU_FLOORS_BLOCK_END in dru_text
+        # The floors are inside the block, after the BEGIN marker.
+        assert dru_text.index(DRU_FLOORS_BLOCK_BEGIN) < dru_text.index('(rule "Trace Width')
+
+    def test_reemit_is_idempotent(self, tmp_path: Path):
+        board = tmp_path / "demo.kicad_pcb"
+        board.write_text("(kicad_pcb)")
+        first = self._emit(board)
+        second = self._emit(board)
+        assert second == first
+
+    def test_reemit_replaces_only_the_managed_block(self, tmp_path: Path):
+        """A tier change swaps the block content; foreign rules survive."""
+        from kicad_tools.manufacturers.dru_generator import DRU_FLOORS_BLOCK_BEGIN
+
+        board = tmp_path / "demo.kicad_pcb"
+        board.write_text("(kicad_pcb)")
+        first = self._emit(board)
+        # A user appends a hand-written rule after the managed block.
+        hand_rule = '(rule "My HV Gap"\n  (constraint clearance (min 2.5mm)))\n'
+        dru = board.with_suffix(".kicad_dru")
+        dru.write_text(first + "\n" + hand_rule, encoding="utf-8")
+
+        # Re-emit at a different tier: the block floors change...
+        rules = get_profile("jlcpcb").get_design_rules(layers=2)
+        write_drc_constraints(board, rules, manufacturer_id="jlcpcb", layers=2)
+        merged = dru.read_text(encoding="utf-8")
+
+        assert '"Trace Width - jlcpcb"' in merged
+        assert '"Trace Width - jlcpcb-tier1"' not in merged
+        # ...exactly one block remains, and the hand-written rule survives.
+        assert merged.count(DRU_FLOORS_BLOCK_BEGIN) == 1
+        assert hand_rule.strip() in merged
+        assert merged.count("(version 1)") == 1
+
+    def test_creepage_block_survives_reemit(self, tmp_path: Path):
+        """The #4508 creepage managed block outlives a sidecar re-emit."""
+        from kicad_tools.creepage.export_rules import (
+            DRU_BLOCK_BEGIN,
+            DRU_BLOCK_END,
+            merge_dru_block,
+        )
+
+        board = tmp_path / "demo.kicad_pcb"
+        board.write_text("(kicad_pcb)")
+        creepage_body = (
+            '(rule "kct creepage 150V<->3p3V"\n'
+            "  (condition \"A.NetClass == 'kct_150V' && B.NetClass == 'kct_3p3V'\")\n"
+            "  (constraint clearance (min 1.5mm)))"
+        )
+        dru = board.with_suffix(".kicad_dru")
+        dru.write_text(merge_dru_block(None, creepage_body), encoding="utf-8")
+
+        merged = self._emit(board)
+        assert DRU_BLOCK_BEGIN in merged
+        assert DRU_BLOCK_END in merged
+        assert creepage_body in merged
+        assert '(rule "Trace Width - jlcpcb-tier1"' in merged
+        assert merged.count("(version 1)") == 1
+
+    def test_user_owned_file_is_never_clobbered(self, tmp_path: Path):
+        """A no-marker, fully user-owned file keeps every byte of content.
+
+        The managed block is merged in ALONGSIDE the user's rules (the
+        stronger option from #4600's acceptance criteria) rather than
+        skipping the write -- the sidecar must still deliver the tier
+        floors for kicad-cli floor parity (#3919).
+        """
+        board = tmp_path / "demo.kicad_pcb"
+        board.write_text("(kicad_pcb)")
+        user_content = '(version 1)\n(rule "Antenna Keepout"\n  (constraint clearance (min 3mm)))\n'
+        dru = board.with_suffix(".kicad_dru")
+        dru.write_text(user_content, encoding="utf-8")
+
+        merged = self._emit(board)
+        assert merged.startswith(user_content)
+        assert '(rule "Antenna Keepout"' in merged
+        assert '(rule "Trace Width - jlcpcb-tier1"' in merged
+        assert merged.count("(version 1)") == 1
+
+    def test_user_file_without_version_header_gains_exactly_one(self, tmp_path: Path):
+        board = tmp_path / "demo.kicad_pcb"
+        board.write_text("(kicad_pcb)")
+        dru = board.with_suffix(".kicad_dru")
+        dru.write_text('(rule "Bare"\n  (constraint clearance (min 1mm)))\n', encoding="utf-8")
+
+        merged = self._emit(board)
+        assert merged.startswith("(version 1)\n")
+        assert merged.count("(version 1)") == 1
+        assert '(rule "Bare"' in merged
+
+    def test_merged_file_still_parses_as_design_rules(self, tmp_path: Path):
+        """Creepage block + user rule + fab floors: still valid DRU syntax."""
+        from kicad_tools.core.sexp_file import load_design_rules
+        from kicad_tools.creepage.export_rules import merge_dru_block
+
+        board = tmp_path / "demo.kicad_pcb"
+        board.write_text("(kicad_pcb)")
+        seeded = merge_dru_block(
+            '(version 1)\n(rule "Hand Rule"\n  (constraint clearance (min 2mm)))\n',
+            '(rule "kct creepage"\n  (constraint clearance (min 1.5mm)))',
+        )
+        dru = board.with_suffix(".kicad_dru")
+        dru.write_text(seeded, encoding="utf-8")
+
+        self._emit(board)
+        sexp = load_design_rules(dru)
+        # version + 3 rule sources parsed (comments are skipped by the parser)
+        rule_tags = [v for v in sexp.values if getattr(v, "tag", None) == "rule"]
+        assert len(rule_tags) >= 3
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the real defect the curator isolated in #4600: the `.kicad_dru` sidecar write shared by `kct route`, `kct build`, `kct mfr apply-rules`, and `kct check --emit-dru`/`--emit-drc-constraints` was a blanket `write_text` that silently deleted the marker-delimited HV creepage rules merged by `kct creepage export-rules` (#4508) and any hand-written custom rules — while the sibling `.kicad_pro` write already had preserve-and-merge semantics.

Beside-the-board placement is intentional (#3919 floor parity) and is unchanged; nothing moves to a temp dir and nothing is deleted after a run.

## Changes

- **`src/kicad_tools/manufacturers/dru_generator.py`** — new `merge_dru_floors(existing, dru_content)` plus `DRU_FLOORS_BLOCK_BEGIN`/`END` sentinels. Mirrors the creepage exporter's `merge_dru_block` dialect (#4508) with **distinct markers**, so the fab-floors and creepage managed blocks coexist in one file:
  - no existing file → `(version 1)` + managed block;
  - existing fab-floors block → replace only the text between the sentinels;
  - existing content without the block (user-owned file, or one holding the creepage block) → **append** the block, preserving every byte, adding a version header only if missing.
  - The merged file keeps exactly one leading `(version 1)` (the header inside `generate_dru` output is stripped before wrapping). `generate_dru` itself is byte-for-byte unchanged (the static `rules/*.kicad_dru` drift guard and all its other consumers are untouched).
- **`src/kicad_tools/manufacturers/project_generator.py`** — `write_drc_constraints` DRU half now reads-and-merges via `merge_dru_floors` (unreadable existing file falls back to a clean write, mirroring the corrupt-`.kicad_pro` path). Docstring documents the managed-block contract.
- **`src/kicad_tools/cli/check_cmd.py`** — the `--emit-dru`-only branch of `_emit_drc_sidecars` merges instead of clobbering; the read happens inside the existing `except OSError` degrade path, so a sidecar failure still warns without changing the verdict. Edits confined to the dru-writer region (sibling #4595 owns other parts of this file); no flag changes (`test_cli_parser_drift.py` green).
- **`src/kicad_tools/cli/route_cmd.py`** — docstring-only note on `_write_drc_constraint_sidecars` (no logic change).
- **`scripts/install-kct.sh`** — convention #2 in the Stage 6c `CONVENTIONS_EOF` heredoc now states that kct writes the sidecars beside the board (route/build always; check only under `--emit-*`), that `kicad-cli` auto-loads them (rule-floor parity by design, geometry engines stay independent), and how to audit floors independently. `.kct/CONVENTIONS.md` itself lives only in consumer repos; the heredoc is the in-repo canonical text.
- **`CHANGELOG.md`** — Unreleased → Fixed bullet.

### Decision: user-owned no-marker file

Per the issue's preferred option, a fully user-owned `.kicad_dru` is **preserved with the managed block merged in alongside its content** (matching the creepage exporter's append semantics) rather than skip-with-warning — the sidecar must still deliver the tier floors for kicad-cli floor parity (#3919), and appending preserves every user byte. Documented in the docstrings and pinned by `test_user_owned_file_is_never_clobbered`.

## Tests

- `tests/test_drc_constraints_export.py` — new `TestDruManagedBlockMerge`: fresh write wraps rules in the block with a single leading version header; re-emit idempotent; tier change replaces only the block while a hand-written rule survives; the #4508 creepage block survives a re-emit; user-owned no-marker file never clobbered; header added exactly once; merged three-source file still parses via `load_design_rules`. The two byte-parity assertions updated to the merge-wrapped expected text (drift guard intact).
- `tests/test_check_emit_dru.py` — new `test_bare_check_leaves_board_directory_clean` (bare `kct check --mfr <tier>` writes nothing beside the board — locks in the clean behavior the original report thought was broken) and `test_emit_dru_preserves_existing_creepage_and_user_rules`; parity assertions updated to the managed-block form.
- `tests/creepage/test_export_rules.py` — interop test: creepage block + hand-written rule survive `write_drc_constraints`, and a creepage re-export preserves the fab-floors block (both directions, one file, one version header).

## Test results

- `tests/test_drc_constraints_export.py` + `tests/test_check_emit_dru.py` + `tests/creepage/test_export_rules.py`: **54 passed**
- `tests/test_mfr.py`, `tests/test_route_post_drc_geometric.py`, `tests/test_init_cmd.py`, `tests/test_file_formats.py`, `tests/test_cli_check_ampacity_net_class_map.py`, `tests/test_fab_rules.py`: **176 passed, 2 skipped**
- `tests/test_cli_parser_drift.py` + `tests/test_connectivity.py`: **91 passed**
- `ruff check` / `ruff format --check`: clean on all touched files; `mypy` clean on the manufacturers modules (route_cmd's 30 errors are pre-existing baseline, byte-identical without this diff); `bash -n scripts/install-kct.sh` OK.

## Acceptance criteria

- [x] Tier-floor rules emitted inside a marker-delimited managed block; re-emit replaces only that block
- [x] Creepage-exported `.kicad_dru` survives route/build/check-emit with creepage block + hand-written rules intact
- [x] User-owned no-marker file never silently overwritten or deleted (content preserved, block merged in)
- [x] Merged file valid: exactly one leading `(version 1)`; parses via `load_design_rules` round-trip
- [x] Bare `kct check --mfr <tier>` writes nothing beside the board (regression test)
- [x] Emit paths still announce written sidecar paths on stderr (paths unchanged; existing tests green)
- [x] Convention #2 heredoc documents the sidecar/kicad-cli auto-load interaction
- [x] Sidecar write failure still degrades to a warning (`test_emit_degrades_on_unwritable_dir` green)

Closes #4600

🤖 Generated with [Claude Code](https://claude.com/claude-code)
