### PR TITLE
feat(sch): kct sch tidy — headless Reference/Value field autoplace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ constructor). No breaking changes.
 
 ### Added
 
+- **`kct sch tidy` — headless Reference/Value field autoplace** — new
+  schematic subcommand that resets visible `Reference`/`Value` field
+  positions to deterministic bbox-relative defaults (Reference centered
+  above the placed symbol body, Value centered below, grid-aligned and
+  horizontal), honoring symbol rotation and mirroring — a diff-reviewable,
+  CI-runnable stand-in for Eeschema's GUI-only "Autoplace Fields"
+  (Eeschema-parity is an explicit non-goal). Supports `--threshold <mm>`
+  (only touch fields farther than this from the body), `--refs` scoping,
+  `--dry-run` before/after offset reports (`--format text|json`), and
+  `--backup`. Strictly cosmetic: only field `(at x y angle)` nodes change —
+  structural-diff, BOM, and kicad-cli netlist invariance are asserted in
+  tests. Power/virtual symbols and hidden fields are skipped by default;
+  unresolvable `lib_id`s warn instead of crashing. The underlying geometry
+  (placed body bbox, field-offset metric, default positions) lives in a new
+  shared `kicad_tools.schema.field_geometry` module so the companion
+  field-geometry lint (#4595) can reuse the exact same metric (#4596).
+
 - **Connector mating / edge-access rule in `kct check`** — new default-on
   `connector_access` category (selectable via `--only`/`--skip`, no new flags)
   with a warning-severity `connector_edge_access` rule that flags rigid-plug

--- a/src/kicad_tools/cli/commands/schematic.py
+++ b/src/kicad_tools/cli/commands/schematic.py
@@ -29,7 +29,7 @@ def run_sch_command(args) -> int:
             " add-label, cleanup-wires, remove-wire, insert-inline,"
         )
         print("          disconnect, reconnect-pin, move-component, remove-component, re-annotate,")
-        print("          repair-instances, fix-annotation")
+        print("          repair-instances, fix-annotation, tidy")
         return 1
 
     schematic_path = Path(args.schematic)
@@ -584,6 +584,22 @@ def run_sch_command(args) -> int:
         if args.format != "text":
             sub_argv.extend(["--format", args.format])
         return move_component_main(sub_argv) or 0
+
+    elif args.sch_command == "tidy":
+        from ..sch_tidy import main as tidy_main
+
+        sub_argv = [str(schematic_path)]
+        if args.threshold:
+            sub_argv.extend(["--threshold", str(args.threshold)])
+        if args.refs:
+            sub_argv.extend(["--refs", args.refs])
+        if args.dry_run:
+            sub_argv.append("--dry-run")
+        if args.backup:
+            sub_argv.append("--backup")
+        if args.format != "text":
+            sub_argv.extend(["--format", args.format])
+        return tidy_main(sub_argv) or 0
 
     elif args.sch_command == "remove-component":
         from ..sch_remove_component import main as remove_component_main

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1704,6 +1704,53 @@ def _add_sch_parser(subparsers) -> None:
         "--format", choices=["text", "json"], default="text", help="Output format"
     )
 
+    # sch tidy
+    sch_tidy = sch_subparsers.add_parser(
+        "tidy",
+        help=(
+            "Reset Reference/Value field positions to bbox-relative defaults "
+            "(headless field autoplace)"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=(
+            "Reset visible Reference/Value field positions to deterministic\n"
+            "offsets from each symbol's placed body bounding box: Reference\n"
+            "centered above the body, Value centered below, grid-aligned and\n"
+            "horizontal. Honors symbol rotation and mirroring. This is a\n"
+            "headless, diff-reviewable field autoplace -- parity with\n"
+            "Eeschema's autoplace algorithm is an explicit non-goal.\n"
+            "\n"
+            "Cosmetic only: nothing but the field (at x y angle) positions\n"
+            "changes, so netlist/ERC/BOM/CPL are unchanged.\n"
+            "\n"
+            "Power/virtual symbols ('#'-prefixed references) and hidden\n"
+            "fields are skipped unless explicitly named via --refs.\n"
+            "Multi-unit symbols: each placed unit's body bbox is estimated\n"
+            "from that unit's pin extents (per-unit body graphics are not\n"
+            "tracked), so placement can be coarser; use --refs to scope\n"
+            "around units needing hand placement."
+        ),
+    )
+    sch_tidy.add_argument("schematic", help="Path to .kicad_sch file")
+    sch_tidy.add_argument(
+        "--threshold",
+        type=float,
+        default=0.0,
+        metavar="MM",
+        help=(
+            "Only touch fields farther than this many mm from the symbol body "
+            "bbox (default 0 = tidy all in-scope fields)"
+        ),
+    )
+    sch_tidy.add_argument(
+        "--refs", help="Comma-separated reference designators to tidy (e.g., C13,C15)"
+    )
+    sch_tidy.add_argument("--dry-run", "-n", action="store_true", help="Preview without modifying")
+    sch_tidy.add_argument("--backup", action="store_true", help="Create backup before modifying")
+    sch_tidy.add_argument(
+        "--format", choices=["text", "json"], default="text", help="Output format"
+    )
+
     # sch remove-component
     sch_remove_component = sch_subparsers.add_parser(
         "remove-component", help="Remove a symbol from a schematic"

--- a/src/kicad_tools/cli/sch_tidy.py
+++ b/src/kicad_tools/cli/sch_tidy.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""
+Tidy (autoplace) Reference/Value fields on a KiCad schematic.
+
+Resets the positions of visible ``Reference`` and ``Value`` fields to
+deterministic offsets relative to each symbol's placed body bounding box:
+Reference centered above the body, Value centered below, both grid-aligned
+and horizontal. This is a headless, diff-reviewable stand-in for Eeschema's
+"Autoplace Fields" -- byte-parity with Eeschema's algorithm (side selection
+by pin density, collision avoidance) is an explicit non-goal.
+
+The operation is strictly cosmetic: only the ``(at x y angle)`` of
+Reference/Value ``property`` nodes changes. Symbol positions, pins, wires,
+all other properties, and all other file content are untouched, so the
+netlist, ERC, BOM, and CPL are provably unchanged.
+
+Usage:
+    kct sch tidy sheet.kicad_sch
+    kct sch tidy sheet.kicad_sch --dry-run
+    kct sch tidy sheet.kicad_sch --threshold 15
+    kct sch tidy sheet.kicad_sch --refs C13,C15
+    kct sch tidy sheet.kicad_sch --backup --format json
+
+Options:
+    --threshold <mm>       Only touch fields farther than this from the body
+                           bbox (default 0 = tidy all in-scope fields)
+    --refs R1,C13,...      Scope to the listed reference designators
+    --dry-run              Show before/after offsets without modifying
+    --backup               Create backup before modifying
+    --format {text,json}   Output format (default: text)
+
+Notes:
+    - Power/virtual symbols (Reference starting with '#') are skipped unless
+      explicitly named via --refs.
+    - Hidden fields are never moved.
+    - Symbols whose lib_id is not in the schematic's embedded lib_symbols
+      are skipped with a warning.
+    - Multi-unit symbols: each placed unit's body bbox is estimated from
+      that unit's pin extents (per-unit body graphics are not tracked), so
+      placement can be coarser than for single-unit symbols. Use --refs to
+      scope around any unit that needs hand placement.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import shutil
+import sys
+from collections.abc import Iterator
+from dataclasses import dataclass
+from dataclasses import field as dc_field
+from datetime import datetime
+from pathlib import Path
+
+from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
+from kicad_tools.schema import Schematic
+from kicad_tools.schema.field_geometry import (
+    default_field_positions,
+    field_offset_mm,
+    placed_body_bbox,
+)
+from kicad_tools.schema.symbol import SymbolInstance
+from kicad_tools.sexp import SExp
+
+#: Fields managed by tidy.
+TIDY_FIELDS = ("Reference", "Value")
+
+_POSITION_EPSILON = 1e-4
+
+
+@dataclass
+class FieldChange:
+    """A planned (or applied) position change for one field."""
+
+    field: str
+    old_position: tuple[float, float]
+    new_position: tuple[float, float]
+    old_angle: float
+    new_angle: float
+    old_offset: float
+    new_offset: float
+    prop_sexp: SExp | None = dc_field(repr=False, compare=False, default=None)
+
+    def to_dict(self) -> dict:
+        return {
+            "field": self.field,
+            "old_position": [round(self.old_position[0], 4), round(self.old_position[1], 4)],
+            "new_position": [round(self.new_position[0], 4), round(self.new_position[1], 4)],
+            "old_offset": round(self.old_offset, 3),
+            "new_offset": round(self.new_offset, 3),
+        }
+
+
+@dataclass
+class SymbolTidyPlan:
+    """Planned field changes for one placed symbol (unit)."""
+
+    reference: str
+    lib_id: str
+    unit: int = 1
+    changes: list[FieldChange] = dc_field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "reference": self.reference,
+            "lib_id": self.lib_id,
+            "unit": self.unit,
+            "changes": [c.to_dict() for c in self.changes],
+        }
+
+
+@dataclass
+class TidyResult:
+    """Result of a tidy plan or apply."""
+
+    symbols: list[SymbolTidyPlan] = dc_field(default_factory=list)
+    warnings: list[str] = dc_field(default_factory=list)
+
+    @property
+    def fields_changed(self) -> int:
+        return sum(len(s.changes) for s in self.symbols)
+
+
+def _iter_placed_symbols(schematic: Schematic) -> Iterator[tuple[SymbolInstance, SExp]]:
+    """Yield (parsed instance, raw sexp node) for each placed symbol.
+
+    Only direct children of the root are placed symbols; the embedded
+    ``lib_symbols`` definitions are nested one level deeper and are not
+    yielded.
+    """
+    for sym_sexp in schematic.sexp.find_children("symbol"):
+        yield SymbolInstance.from_sexp(sym_sexp), sym_sexp
+
+
+def _find_property_node(sym_sexp: SExp, name: str) -> SExp | None:
+    """Find a direct-child property node by field name."""
+    for prop in sym_sexp.find_children("property"):
+        if prop.get_string(0) == name:
+            return prop
+    return None
+
+
+def _is_hidden(prop_sexp: SExp) -> bool:
+    """Check whether a property is hidden.
+
+    Handles both the KiCad 8+ ``(effects ... (hide yes))`` list form and the
+    older bare-atom ``(effects ... hide)`` form.
+    """
+    effects = prop_sexp.find_child("effects")
+    if effects is None:
+        return False
+    if effects.find_child("hide") is not None:
+        return True
+    return any(c.is_atom and c.value == "hide" for c in effects.children)
+
+
+def plan_tidy(
+    schematic: Schematic,
+    threshold: float = 0.0,
+    refs: list[str] | None = None,
+) -> TidyResult:
+    """Compute the field position changes tidy would make.
+
+    Pure planning -- does not modify the schematic.
+
+    Args:
+        schematic: The loaded schematic.
+        threshold: Only plan changes for fields whose current distance from
+            the body bbox exceeds this many mm (0 = all in-scope fields).
+        refs: If given, restrict to these reference designators. Explicitly
+            listed references are tidied even if they are power/virtual
+            symbols (``#``-prefixed), which are otherwise skipped.
+    """
+    result = TidyResult()
+    refs_set = set(refs) if refs else None
+
+    for inst, sym_sexp in _iter_placed_symbols(schematic):
+        reference = inst.reference
+
+        if refs_set is not None:
+            if reference not in refs_set:
+                continue
+        elif reference.startswith("#"):
+            # Power/virtual symbols: skip unless explicitly named.
+            continue
+
+        lib_sym = schematic.get_lib_symbol_resolved(inst.lib_id)
+        if lib_sym is None:
+            result.warnings.append(
+                f"{reference}: lib_id '{inst.lib_id}' not found in embedded lib_symbols; skipped"
+            )
+            continue
+
+        bbox = placed_body_bbox(
+            lib_sym,
+            inst.position,
+            rotation=inst.rotation,
+            mirror=inst.mirror,
+            unit=inst.unit,
+        )
+        defaults = default_field_positions(bbox)
+
+        plan = SymbolTidyPlan(reference=reference, lib_id=inst.lib_id, unit=inst.unit)
+        for field_name in TIDY_FIELDS:
+            prop = _find_property_node(sym_sexp, field_name)
+            if prop is None or _is_hidden(prop):
+                continue
+            at_node = prop.find_child("at")
+            if at_node is None:
+                continue
+
+            old_x = at_node.get_float(0) or 0.0
+            old_y = at_node.get_float(1) or 0.0
+            old_angle = at_node.get_float(2) or 0.0
+            old_offset = field_offset_mm((old_x, old_y), bbox)
+
+            if threshold > 0 and old_offset <= threshold:
+                continue
+
+            new_x, new_y, new_angle = defaults[field_name]
+            if (
+                math.isclose(new_x, old_x, abs_tol=_POSITION_EPSILON)
+                and math.isclose(new_y, old_y, abs_tol=_POSITION_EPSILON)
+                and math.isclose(new_angle, old_angle, abs_tol=_POSITION_EPSILON)
+            ):
+                continue  # Already in place -- keep the file byte-identical.
+
+            plan.changes.append(
+                FieldChange(
+                    field=field_name,
+                    old_position=(old_x, old_y),
+                    new_position=(new_x, new_y),
+                    old_angle=old_angle,
+                    new_angle=new_angle,
+                    old_offset=old_offset,
+                    new_offset=field_offset_mm((new_x, new_y), bbox),
+                    prop_sexp=prop,
+                )
+            )
+
+        if plan.changes:
+            result.symbols.append(plan)
+
+    return result
+
+
+def tidy_fields(
+    schematic: Schematic,
+    threshold: float = 0.0,
+    refs: list[str] | None = None,
+) -> TidyResult:
+    """Apply bbox-relative default positions to Reference/Value fields.
+
+    Only the ``(at x y angle)`` of the affected property nodes is modified.
+    Returns the applied :class:`TidyResult`.
+    """
+    result = plan_tidy(schematic, threshold=threshold, refs=refs)
+
+    for plan in result.symbols:
+        for change in plan.changes:
+            if change.prop_sexp is None:  # pragma: no cover - set during planning
+                continue
+            at_node = change.prop_sexp.find_child("at")
+            if at_node is None:  # pragma: no cover - guarded during planning
+                continue
+            at_node.set_value(0, change.new_position[0])
+            at_node.set_value(1, change.new_position[1])
+            at_node.set_value(2, 0)
+
+    if result.fields_changed:
+        schematic.invalidate_cache()
+
+    return result
+
+
+def _result_to_dict(result: TidyResult, dry_run: bool) -> dict:
+    return {
+        "dry_run": dry_run,
+        "modified": (not dry_run) and result.fields_changed > 0,
+        "symbols_changed": len(result.symbols),
+        "fields_changed": result.fields_changed,
+        "symbols": [s.to_dict() for s in result.symbols],
+        "warnings": result.warnings,
+    }
+
+
+def _print_text(result: TidyResult, dry_run: bool) -> None:
+    if dry_run:
+        print("DRY RUN - No changes will be made")
+        print("=" * 60)
+
+    for plan in result.symbols:
+        unit_note = f" unit {plan.unit}" if plan.unit != 1 else ""
+        print(f"{plan.reference}{unit_note} ({plan.lib_id}):")
+        for c in plan.changes:
+            print(
+                f"  {c.field}: ({c.old_position[0]:.2f}, {c.old_position[1]:.2f})"
+                f" [{c.old_offset:.1f} mm]"
+                f" -> ({c.new_position[0]:.2f}, {c.new_position[1]:.2f})"
+                f" [{c.new_offset:.1f} mm]"
+            )
+
+    for w in result.warnings:
+        print(f"Warning: {w}", file=sys.stderr)
+
+    verb = "would change" if dry_run else "changed"
+    print(f"{len(result.symbols)} symbol(s), {result.fields_changed} field(s) {verb}")
+
+
+def run_tidy(args) -> int:
+    """Execute the tidy command."""
+    schematic_path = Path(args.schematic)
+
+    try:
+        sch = Schematic.load(schematic_path)
+    except (FileNotFoundError, KiCadFileNotFoundError):
+        print(f"Error: Schematic not found: {schematic_path}", file=sys.stderr)
+        return 1
+
+    refs: list[str] | None = None
+    if args.refs:
+        refs = [r.strip() for r in args.refs.split(",") if r.strip()]
+
+    if args.dry_run:
+        result = plan_tidy(sch, threshold=args.threshold, refs=refs)
+        if args.format == "json":
+            print(json.dumps(_result_to_dict(result, dry_run=True), indent=2))
+        else:
+            _print_text(result, dry_run=True)
+        return 0
+
+    if args.backup:
+        backup_path = f"{schematic_path}.backup-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+        shutil.copy2(schematic_path, backup_path)
+        if args.format != "json":
+            print(f"Backup created: {backup_path}")
+
+    result = tidy_fields(sch, threshold=args.threshold, refs=refs)
+
+    if result.fields_changed:
+        sch.save()
+
+    if args.format == "json":
+        print(json.dumps(_result_to_dict(result, dry_run=False), indent=2))
+    else:
+        _print_text(result, dry_run=False)
+
+    return 0
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description=(
+            "Reset Reference/Value field positions to bbox-relative defaults "
+            "(headless field autoplace; deterministic, not Eeschema-parity)"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("schematic", help="Path to .kicad_sch file")
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.0,
+        metavar="MM",
+        help=(
+            "Only touch fields farther than this many mm from the symbol "
+            "body bbox (default 0 = tidy all in-scope fields)"
+        ),
+    )
+    parser.add_argument(
+        "--refs",
+        help="Comma-separated reference designators to tidy (e.g., C13,C15)",
+    )
+    parser.add_argument("--dry-run", "-n", action="store_true", help="Preview without modifying")
+    parser.add_argument("--backup", action="store_true", help="Create backup before modifying")
+    parser.add_argument("--format", choices=["text", "json"], default="text", help="Output format")
+
+    args = parser.parse_args(argv)
+    return run_tidy(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/kicad_tools/schema/__init__.py
+++ b/src/kicad_tools/schema/__init__.py
@@ -6,6 +6,12 @@ from .bom import (
     BOMItem,
     extract_bom,
 )
+from .field_geometry import (
+    DEFAULT_FIELD_CLEARANCE_MM,
+    default_field_positions,
+    field_offset_mm,
+    placed_body_bbox,
+)
 from .hierarchy import (
     HierarchyBuilder,
     HierarchyNode,
@@ -54,6 +60,10 @@ __all__ = [
     "BOMItem",
     "BOMGroup",
     "extract_bom",
+    "DEFAULT_FIELD_CLEARANCE_MM",
+    "default_field_positions",
+    "field_offset_mm",
+    "placed_body_bbox",
     "PCB",
     "Layer",
     "Net",

--- a/src/kicad_tools/schema/field_geometry.py
+++ b/src/kicad_tools/schema/field_geometry.py
@@ -1,0 +1,198 @@
+"""
+Shared geometry for schematic symbol field placement.
+
+This module is the single source of truth for the "field distance from the
+symbol body" metric and the deterministic default field positions used by
+``kct sch tidy`` (and reusable by schematic lint rules) -- pure geometry with
+no CLI dependencies.
+
+Coordinate conventions
+----------------------
+
+* Library symbol geometry (``LibrarySymbol.graphics`` / ``pins``) is in
+  library coordinates: Y-up, relative to the symbol origin.
+* Placed (sheet) coordinates are Y-down. The transform applied here matches
+  :meth:`LibrarySymbol.get_pin_position`: mirror, then rotation (both in
+  library coordinates), then Y negation, then translation to the instance
+  position.
+* Bounding boxes are ``(min_x, min_y, max_x, max_y)`` in sheet coordinates,
+  so "above the symbol" is *smaller* y and "below" is *larger* y.
+"""
+
+from __future__ import annotations
+
+import math
+
+from .library import (
+    KICAD_GRID,
+    LibrarySymbol,
+    SymbolArc,
+    SymbolCircle,
+    SymbolPolyline,
+    SymbolRectangle,
+)
+
+__all__ = [
+    "DEFAULT_FIELD_CLEARANCE_MM",
+    "placed_body_bbox",
+    "field_offset_mm",
+    "default_field_positions",
+]
+
+#: Bounding box in sheet coordinates: (min_x, min_y, max_x, max_y).
+BBox = tuple[float, float, float, float]
+
+#: Clearance between the symbol body bbox edge and a tidied field anchor.
+DEFAULT_FIELD_CLEARANCE_MM = 1.27
+
+
+def _snap_to_grid(value: float, grid: float = KICAD_GRID) -> float:
+    """Snap *value* to the nearest grid multiple, rounded to 2 decimals.
+
+    KiCad grid multiples of 1.27 mm are exact 2-decimal values, so the
+    rounding only strips float noise (e.g. ``3.8099999999999996`` -> ``3.81``).
+    """
+    return round(round(value / grid) * grid, 2)
+
+
+def _transform_point(
+    x: float,
+    y: float,
+    rotation: float,
+    mirror: str,
+) -> tuple[float, float]:
+    """Transform a library-coordinate point to a sheet-coordinate offset.
+
+    Applies mirror, then rotation (both in library Y-up coordinates), then
+    negates Y to convert to sheet Y-down coordinates. This mirrors the
+    transform in :meth:`LibrarySymbol.get_pin_position` so bboxes and pin
+    positions stay consistent.
+    """
+    if mirror == "x":
+        x = -x
+    elif mirror == "y":
+        y = -y
+
+    if rotation != 0:
+        angle_rad = math.radians(rotation)
+        cos_a = math.cos(angle_rad)
+        sin_a = math.sin(angle_rad)
+        x, y = x * cos_a - y * sin_a, x * sin_a + y * cos_a
+
+    return x, -y
+
+
+def _local_extent_points(
+    lib_symbol: LibrarySymbol,
+    unit: int | None = None,
+) -> list[tuple[float, float]]:
+    """Collect library-coordinate points spanning the symbol body extents.
+
+    For multi-unit symbols with a known *unit*, the extents of that unit's
+    pins are used (``LibrarySymbol.graphics`` merges all units, so graphics
+    extents would span every unit). Otherwise body graphics extents are
+    preferred, falling back to pin extents for symbols without body graphics
+    (e.g. power symbols).
+    """
+    if unit is not None and lib_symbol.units > 1:
+        unit_pins = [p.position for p in lib_symbol.pins if p.unit == unit]
+        if unit_pins:
+            return unit_pins
+
+    points: list[tuple[float, float]] = []
+    for g in lib_symbol.graphics:
+        if isinstance(g, SymbolRectangle):
+            points.append(g.start)
+            points.append(g.end)
+        elif isinstance(g, SymbolPolyline):
+            points.extend(g.points)
+        elif isinstance(g, SymbolCircle):
+            cx, cy = g.center
+            points.append((cx - g.radius, cy - g.radius))
+            points.append((cx + g.radius, cy + g.radius))
+        elif isinstance(g, SymbolArc):
+            # Start/mid/end under-approximate the true arc extents slightly;
+            # good enough for field placement.
+            points.append(g.start)
+            points.append(g.mid)
+            points.append(g.end)
+
+    if not points:
+        points = [p.position for p in lib_symbol.pins]
+
+    return points
+
+
+def placed_body_bbox(
+    lib_symbol: LibrarySymbol,
+    position: tuple[float, float],
+    rotation: float = 0.0,
+    mirror: str = "",
+    unit: int | None = None,
+) -> BBox:
+    """Compute the placed body bounding box of a symbol in sheet coordinates.
+
+    Args:
+        lib_symbol: The resolved library symbol definition.
+        position: The instance ``(at x y)`` position on the sheet.
+        rotation: The instance rotation in degrees.
+        mirror: The instance mirror mode ("", "x", "y").
+        unit: The placed unit for multi-unit symbols (see
+            :func:`_local_extent_points`).
+
+    Returns:
+        ``(min_x, min_y, max_x, max_y)`` in sheet coordinates. Degenerate
+        (zero-size at *position*) if the symbol has neither graphics nor pins.
+    """
+    points = _local_extent_points(lib_symbol, unit=unit)
+    if not points:
+        return (position[0], position[1], position[0], position[1])
+
+    xs: list[float] = []
+    ys: list[float] = []
+    for lx, ly in points:
+        dx, dy = _transform_point(lx, ly, rotation, mirror)
+        xs.append(position[0] + dx)
+        ys.append(position[1] + dy)
+
+    return (min(xs), min(ys), max(xs), max(ys))
+
+
+def field_offset_mm(field_at: tuple[float, float], bbox: BBox) -> float:
+    """Distance in mm from a field anchor point to a body bbox.
+
+    Returns 0.0 when the point lies inside (or on the edge of) the bbox;
+    otherwise the Euclidean distance to the nearest bbox point.
+    """
+    x, y = field_at
+    min_x, min_y, max_x, max_y = bbox
+    dx = max(min_x - x, 0.0, x - max_x)
+    dy = max(min_y - y, 0.0, y - max_y)
+    return math.hypot(dx, dy)
+
+
+def default_field_positions(
+    bbox: BBox,
+    clearance: float = DEFAULT_FIELD_CLEARANCE_MM,
+) -> dict[str, tuple[float, float, float]]:
+    """Deterministic default field positions relative to a placed body bbox.
+
+    ``Reference`` is centered above the bbox top edge and ``Value`` centered
+    below the bbox bottom edge (sheet coordinates, Y-down), each *clearance*
+    mm away and snapped to the KiCad 1.27 mm grid. Because the grid snap
+    moves a point by at most half a grid step (0.635 mm) and the default
+    clearance is a full step, the snapped anchors always remain outside the
+    bbox interior.
+
+    Returns:
+        Mapping of field name to ``(x, y, angle)`` with angle always 0
+        (horizontal text).
+    """
+    min_x, min_y, max_x, max_y = bbox
+    center_x = _snap_to_grid((min_x + max_x) / 2.0)
+    reference_y = _snap_to_grid(min_y - clearance)
+    value_y = _snap_to_grid(max_y + clearance)
+    return {
+        "Reference": (center_x, reference_y, 0.0),
+        "Value": (center_x, value_y, 0.0),
+    }

--- a/tests/test_sch_tidy.py
+++ b/tests/test_sch_tidy.py
@@ -1,0 +1,712 @@
+"""Tests for the sch tidy command and the shared field_geometry module.
+
+Covers bbox computation (graphics, pin fallback, rotation/mirror), the
+field-offset metric, default field positions, the tidy command itself
+(--refs, --threshold, --dry-run, hidden/power/unresolvable skips), and the
+cosmetic-only invariance guarantees (structural diff, BOM, netlist).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.sch_tidy import (
+    main as tidy_main,
+)
+from kicad_tools.cli.sch_tidy import (
+    tidy_fields,
+)
+from kicad_tools.schema import Schematic
+from kicad_tools.schema.bom import extract_bom_from_schematic
+from kicad_tools.schema.field_geometry import (
+    DEFAULT_FIELD_CLEARANCE_MM,
+    default_field_positions,
+    field_offset_mm,
+    placed_body_bbox,
+)
+from kicad_tools.schema.library import LibrarySymbol
+from kicad_tools.sexp.parser import SExp, parse_string
+
+REAL_FIXTURE = (
+    Path(__file__).parent.parent / "boards" / "00-simple-led" / "output" / "simple_led.kicad_sch"
+)
+
+# ---------------------------------------------------------------------------
+# Library symbol fixtures (parsed via LibrarySymbol.from_sexp)
+# ---------------------------------------------------------------------------
+
+RESISTOR_LIB_SYMBOL = """\
+(symbol "Device:R"
+  (property "Reference" "R" (at 0 0 0) (effects (font (size 1.27 1.27))))
+  (property "Value" "R" (at 0 0 0) (effects (font (size 1.27 1.27))))
+  (symbol "R_0_1"
+    (rectangle (start -1.016 -2.54) (end 1.016 2.54)
+      (stroke (width 0.254) (type default)) (fill (type none)))
+  )
+  (symbol "R_1_1"
+    (pin passive line (at 0 3.81 270) (length 1.27) (name "1" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+    (pin passive line (at 0 -3.81 90) (length 1.27) (name "2" (effects (font (size 1.27 1.27)))) (number "2" (effects (font (size 1.27 1.27)))))
+  )
+)
+"""
+
+PIN_ONLY_LIB_SYMBOL = """\
+(symbol "power:GND"
+  (property "Reference" "#PWR" (at 0 0 0) (effects (font (size 1.27 1.27)) hide))
+  (property "Value" "GND" (at 0 0 0) (effects (font (size 1.27 1.27))))
+  (symbol "GND_1_1"
+    (pin power_in line (at 0 0 270) (length 0) (name "GND" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+  )
+)
+"""
+
+
+def _lib_symbol(text: str) -> LibrarySymbol:
+    return LibrarySymbol.from_sexp(parse_string(text))
+
+
+# ---------------------------------------------------------------------------
+# Schematic fixtures
+# ---------------------------------------------------------------------------
+
+
+def _resistor_instance(
+    ref: str,
+    uuid: str,
+    x: float,
+    y: float,
+    rot: int = 0,
+    mirror: str = "",
+    ref_at: tuple[float, float, float] | None = None,
+    val_at: tuple[float, float, float] | None = None,
+    hide_ref: bool = False,
+) -> str:
+    """Build a placed Device:R symbol instance sexp string."""
+    rx, ry, ra = ref_at if ref_at else (x + 30, y + 30, 0)
+    vx, vy, va = val_at if val_at else (x - 30, y - 30, 0)
+    mirror_str = f" (mirror {mirror})" if mirror else ""
+    hide_str = " hide" if hide_ref else ""
+    return f"""\
+  (symbol (lib_id "Device:R") (at {x} {y} {rot}){mirror_str} (unit 1)
+    (in_bom yes) (on_board yes) (dnp no)
+    (uuid "{uuid}")
+    (property "Reference" "{ref}" (at {rx} {ry} {ra}) (effects (font (size 1.27 1.27)){hide_str}))
+    (property "Value" "10k" (at {vx} {vy} {va}) (effects (font (size 1.27 1.27))))
+    (property "Footprint" "Resistor_SMD:R_0402_1005Metric" (at {x} {y} 0) (effects (font (size 1.27 1.27)) hide))
+    (pin "1" (uuid "{uuid}-p1"))
+    (pin "2" (uuid "{uuid}-p2"))
+  )
+"""
+
+
+def _schematic(symbols: str, extra_lib_symbols: str = "") -> str:
+    return f"""\
+(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (generator_version "8.0")
+  (uuid "00000000-0000-0000-0000-000000000001")
+  (paper "A4")
+  (lib_symbols
+{RESISTOR_LIB_SYMBOL}{PIN_ONLY_LIB_SYMBOL}{extra_lib_symbols}  )
+{symbols})
+"""
+
+
+ROTATION_FIXTURE = _schematic(
+    _resistor_instance("R1", "aaaaaaaa-0000-0000-0000-000000000001", 50, 50, rot=0)
+    + _resistor_instance("R2", "aaaaaaaa-0000-0000-0000-000000000002", 100, 50, rot=90)
+    + _resistor_instance("R3", "aaaaaaaa-0000-0000-0000-000000000003", 150, 50, rot=180)
+    + _resistor_instance("R4", "aaaaaaaa-0000-0000-0000-000000000004", 50, 100, rot=270)
+    + _resistor_instance("R5", "aaaaaaaa-0000-0000-0000-000000000005", 100, 100, rot=90, mirror="y")
+)
+
+POWER_FIXTURE = _schematic(
+    _resistor_instance("R1", "bbbbbbbb-0000-0000-0000-000000000001", 50, 50)
+    + """\
+  (symbol (lib_id "power:GND") (at 100 100 0) (unit 1)
+    (in_bom yes) (on_board yes) (dnp no)
+    (uuid "bbbbbbbb-0000-0000-0000-000000000002")
+    (property "Reference" "#PWR01" (at 130 130 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "GND" (at 130 135 0) (effects (font (size 1.27 1.27))))
+    (pin "1" (uuid "bbbbbbbb-0000-0000-0000-000000000002-p1"))
+  )
+"""
+)
+
+UNRESOLVED_FIXTURE = _schematic(
+    _resistor_instance("R1", "cccccccc-0000-0000-0000-000000000001", 50, 50)
+    + """\
+  (symbol (lib_id "Missing:Symbol") (at 100 100 0) (unit 1)
+    (in_bom yes) (on_board yes) (dnp no)
+    (uuid "cccccccc-0000-0000-0000-000000000002")
+    (property "Reference" "U1" (at 130 130 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "MYSTERY" (at 130 135 0) (effects (font (size 1.27 1.27))))
+  )
+"""
+)
+
+MULTI_UNIT_LIB_SYMBOL = """\
+(symbol "Lib:Dual"
+  (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+  (property "Value" "Dual" (at 0 0 0) (effects (font (size 1.27 1.27))))
+  (symbol "Dual_1_1"
+    (pin input line (at -2.54 2.54 0) (length 1.27) (name "A" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+    (pin output line (at 2.54 -2.54 180) (length 1.27) (name "Y" (effects (font (size 1.27 1.27)))) (number "2" (effects (font (size 1.27 1.27)))))
+  )
+  (symbol "Dual_2_1"
+    (pin input line (at -5.08 5.08 0) (length 1.27) (name "B" (effects (font (size 1.27 1.27)))) (number "3" (effects (font (size 1.27 1.27)))))
+    (pin output line (at 5.08 -5.08 180) (length 1.27) (name "Z" (effects (font (size 1.27 1.27)))) (number "4" (effects (font (size 1.27 1.27)))))
+  )
+)
+"""
+
+MULTI_UNIT_FIXTURE = _schematic(
+    """\
+  (symbol (lib_id "Lib:Dual") (at 50 50 0) (unit 1)
+    (in_bom yes) (on_board yes) (dnp no)
+    (uuid "dddddddd-0000-0000-0000-000000000001")
+    (property "Reference" "U1" (at 90 90 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "Dual" (at 90 95 0) (effects (font (size 1.27 1.27))))
+  )
+  (symbol (lib_id "Lib:Dual") (at 120 50 0) (unit 2)
+    (in_bom yes) (on_board yes) (dnp no)
+    (uuid "dddddddd-0000-0000-0000-000000000002")
+    (property "Reference" "U1" (at 20 20 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "Dual" (at 20 25 0) (effects (font (size 1.27 1.27))))
+  )
+""",
+    extra_lib_symbols=MULTI_UNIT_LIB_SYMBOL,
+)
+
+
+def _load(content: str) -> Schematic:
+    return Schematic(parse_string(content))
+
+
+def _write(tmp_path: Path, content: str, name: str = "test.kicad_sch") -> Path:
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _symbol_bbox(sch: Schematic, ref: str, unit: int = 1):
+    """Recompute the placed body bbox for a symbol in a schematic."""
+    for inst in sch.symbols:
+        if inst.reference == ref and inst.unit == unit:
+            lib_sym = sch.get_lib_symbol_resolved(inst.lib_id)
+            assert lib_sym is not None
+            return placed_body_bbox(
+                lib_sym, inst.position, rotation=inst.rotation, mirror=inst.mirror, unit=inst.unit
+            )
+    raise AssertionError(f"symbol {ref} not found")
+
+
+def _field_at(
+    sch: Schematic, ref: str, field_name: str, unit: int = 1
+) -> tuple[float, float, float]:
+    for sym_sexp in sch.sexp.find_children("symbol"):
+        ref_val = None
+        unit_val = 1
+        if u := sym_sexp.find_child("unit"):
+            unit_val = u.get_int(0) or 1
+        for prop in sym_sexp.find_children("property"):
+            if prop.get_string(0) == "Reference":
+                ref_val = prop.get_string(1)
+        if ref_val != ref or unit_val != unit:
+            continue
+        for prop in sym_sexp.find_children("property"):
+            if prop.get_string(0) == field_name:
+                at = prop.find_child("at")
+                assert at is not None
+                return (at.get_float(0) or 0.0, at.get_float(1) or 0.0, at.get_float(2) or 0.0)
+    raise AssertionError(f"field {field_name} of {ref} not found")
+
+
+# ---------------------------------------------------------------------------
+# field_geometry: placed_body_bbox
+# ---------------------------------------------------------------------------
+
+
+class TestPlacedBodyBbox:
+    def test_bbox_from_rectangle_graphics(self):
+        lib = _lib_symbol(RESISTOR_LIB_SYMBOL)
+        bbox = placed_body_bbox(lib, (100.0, 50.0))
+        assert bbox == pytest.approx((98.984, 47.46, 101.016, 52.54))
+
+    def test_bbox_rotation_90_swaps_extents(self):
+        lib = _lib_symbol(RESISTOR_LIB_SYMBOL)
+        bbox0 = placed_body_bbox(lib, (100.0, 50.0), rotation=0)
+        bbox90 = placed_body_bbox(lib, (100.0, 50.0), rotation=90)
+        w0, h0 = bbox0[2] - bbox0[0], bbox0[3] - bbox0[1]
+        w90, h90 = bbox90[2] - bbox90[0], bbox90[3] - bbox90[1]
+        assert (w90, h90) == pytest.approx((h0, w0))
+
+    def test_bbox_rotation_180_matches_symmetric_body(self):
+        lib = _lib_symbol(RESISTOR_LIB_SYMBOL)
+        bbox0 = placed_body_bbox(lib, (100.0, 50.0), rotation=0)
+        bbox180 = placed_body_bbox(lib, (100.0, 50.0), rotation=180)
+        assert bbox180 == pytest.approx(bbox0)
+
+    def test_bbox_mirror_asymmetric_polyline(self):
+        text = """\
+(symbol "Lib:Tri"
+  (symbol "Tri_0_1"
+    (polyline (pts (xy 0 0) (xy 2.54 0) (xy 2.54 1.27) (xy 0 0))
+      (stroke (width 0.254) (type default)) (fill (type none)))
+  )
+)
+"""
+        lib = _lib_symbol(text)
+        bbox = placed_body_bbox(lib, (0.0, 0.0))
+        assert bbox[0] == pytest.approx(0.0)
+        assert bbox[2] == pytest.approx(2.54)
+        # mirror "x" negates library x
+        bbox_m = placed_body_bbox(lib, (0.0, 0.0), mirror="x")
+        assert bbox_m[0] == pytest.approx(-2.54)
+        assert bbox_m[2] == pytest.approx(0.0)
+
+    def test_bbox_from_circle_graphics(self):
+        text = """\
+(symbol "Lib:C"
+  (symbol "C_0_1"
+    (circle (center 1 1) (radius 2)
+      (stroke (width 0.254) (type default)) (fill (type none)))
+  )
+)
+"""
+        lib = _lib_symbol(text)
+        bbox = placed_body_bbox(lib, (10.0, 10.0))
+        # library (x, y) -> sheet (x, -y): center (1, -1), radius 2
+        assert bbox == pytest.approx((9.0, 7.0, 13.0, 11.0))
+
+    def test_bbox_pin_fallback_without_graphics(self):
+        lib = _lib_symbol(PIN_ONLY_LIB_SYMBOL)
+        assert not lib.graphics
+        bbox = placed_body_bbox(lib, (100.0, 100.0))
+        # single pin at library origin -> degenerate bbox at position
+        assert bbox == pytest.approx((100.0, 100.0, 100.0, 100.0))
+
+    def test_bbox_empty_symbol_is_degenerate_at_position(self):
+        lib = _lib_symbol('(symbol "Lib:Empty")')
+        assert placed_body_bbox(lib, (5.0, 7.0)) == (5.0, 7.0, 5.0, 7.0)
+
+    def test_bbox_multi_unit_uses_unit_pins(self):
+        lib = _lib_symbol(MULTI_UNIT_LIB_SYMBOL)
+        assert lib.units == 2
+        bbox1 = placed_body_bbox(lib, (0.0, 0.0), unit=1)
+        bbox2 = placed_body_bbox(lib, (0.0, 0.0), unit=2)
+        assert bbox1 == pytest.approx((-2.54, -2.54, 2.54, 2.54))
+        assert bbox2 == pytest.approx((-5.08, -5.08, 5.08, 5.08))
+
+
+# ---------------------------------------------------------------------------
+# field_geometry: field_offset_mm
+# ---------------------------------------------------------------------------
+
+
+class TestFieldOffset:
+    BBOX = (10.0, 20.0, 30.0, 40.0)
+
+    def test_inside_is_zero(self):
+        assert field_offset_mm((20.0, 30.0), self.BBOX) == 0.0
+
+    def test_on_edge_is_zero(self):
+        assert field_offset_mm((10.0, 30.0), self.BBOX) == 0.0
+
+    def test_axis_distance(self):
+        assert field_offset_mm((5.0, 30.0), self.BBOX) == pytest.approx(5.0)
+        assert field_offset_mm((20.0, 45.0), self.BBOX) == pytest.approx(5.0)
+
+    def test_corner_distance(self):
+        assert field_offset_mm((7.0, 16.0), self.BBOX) == pytest.approx(5.0)
+
+
+# ---------------------------------------------------------------------------
+# field_geometry: default_field_positions
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultFieldPositions:
+    def test_reference_above_value_below(self):
+        bbox = (98.984, 47.46, 101.016, 52.54)
+        positions = default_field_positions(bbox)
+        rx, ry, ra = positions["Reference"]
+        vx, vy, va = positions["Value"]
+        assert ry < bbox[1]  # above (sheet Y-down)
+        assert vy > bbox[3]  # below
+        assert ra == 0.0
+        assert va == 0.0
+        # grid aligned
+        for coord in (rx, ry, vx, vy):
+            assert coord / 1.27 == pytest.approx(round(coord / 1.27))
+
+    def test_positions_outside_but_close_for_all_rotations(self):
+        lib = _lib_symbol(RESISTOR_LIB_SYMBOL)
+        for rot in (0, 90, 180, 270):
+            for mirror in ("", "y"):
+                bbox = placed_body_bbox(lib, (100.0, 50.0), rotation=rot, mirror=mirror)
+                for _name, (x, y, _angle) in default_field_positions(bbox).items():
+                    offset = field_offset_mm((x, y), bbox)
+                    assert 0.0 < offset <= 3.0, (rot, mirror, _name, offset)
+
+    def test_custom_clearance(self):
+        bbox = (0.0, 0.0, 2.54, 2.54)
+        positions = default_field_positions(bbox, clearance=2.54)
+        assert positions["Reference"][1] == pytest.approx(-2.54)
+        assert positions["Value"][1] == pytest.approx(5.08)
+
+    def test_clearance_survives_grid_snap(self):
+        # Off-grid bbox edges: snap moves by <= 0.635, clearance is 1.27
+        bbox = (10.1, 20.3, 30.7, 40.9)
+        positions = default_field_positions(bbox)
+        assert positions["Reference"][1] < bbox[1]
+        assert positions["Value"][1] > bbox[3]
+        assert DEFAULT_FIELD_CLEARANCE_MM == 1.27
+
+
+# ---------------------------------------------------------------------------
+# tidy: core behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestTidyCore:
+    def test_tidy_all_rotations_and_mirror(self):
+        sch = _load(ROTATION_FIXTURE)
+        result = tidy_fields(sch)
+        assert len(result.symbols) == 5
+        assert result.fields_changed == 10
+        assert not result.warnings
+
+        for ref in ("R1", "R2", "R3", "R4", "R5"):
+            bbox = _symbol_bbox(sch, ref)
+            for field_name in ("Reference", "Value"):
+                x, y, angle = _field_at(sch, ref, field_name)
+                offset = field_offset_mm((x, y), bbox)
+                assert 0.0 < offset <= 3.0, (ref, field_name, offset)
+                assert angle == 0.0
+
+    def test_tidy_round_trips_and_reparses(self, tmp_path):
+        path = _write(tmp_path, ROTATION_FIXTURE)
+        sch = Schematic.load(path)
+        tidy_fields(sch)
+        sch.save()
+
+        reloaded = Schematic.load(path)
+        assert len(reloaded.symbols) == 5
+        assert {s.reference for s in reloaded.symbols} == {"R1", "R2", "R3", "R4", "R5"}
+
+    def test_tidy_is_idempotent(self, tmp_path):
+        path = _write(tmp_path, ROTATION_FIXTURE)
+        sch = Schematic.load(path)
+        tidy_fields(sch)
+        sch.save()
+        first = path.read_text()
+
+        sch2 = Schematic.load(path)
+        result = tidy_fields(sch2)
+        assert result.fields_changed == 0
+        sch2.save()
+        assert path.read_text() == first
+
+    def test_angle_reset_to_horizontal(self):
+        content = _schematic(
+            _resistor_instance(
+                "R1",
+                "eeeeeeee-0000-0000-0000-000000000001",
+                50,
+                50,
+                ref_at=(80, 80, 90),
+                val_at=(20, 20, 45),
+            )
+        )
+        sch = _load(content)
+        tidy_fields(sch)
+        assert _field_at(sch, "R1", "Reference")[2] == 0.0
+        assert _field_at(sch, "R1", "Value")[2] == 0.0
+
+    def test_refs_scoping_leaves_others_byte_identical(self):
+        sch = _load(ROTATION_FIXTURE)
+        before = {ref: _serialize_symbol(sch, ref) for ref in ("R1", "R2", "R3", "R4", "R5")}
+        result = tidy_fields(sch, refs=["R2"])
+        assert [p.reference for p in result.symbols] == ["R2"]
+        after = {ref: _serialize_symbol(sch, ref) for ref in ("R1", "R2", "R3", "R4", "R5")}
+        assert after["R2"] != before["R2"]
+        for ref in ("R1", "R3", "R4", "R5"):
+            assert after[ref] == before[ref], ref
+
+    def test_threshold_skips_nearby_fields(self):
+        # Fields ~42mm away (default fixture offsets) vs a close pair
+        content = _schematic(
+            _resistor_instance("R1", "ffffffff-0000-0000-0000-000000000001", 50, 50)
+            + _resistor_instance(
+                "R2",
+                "ffffffff-0000-0000-0000-000000000002",
+                100,
+                50,
+                ref_at=(100, 45, 0),
+                val_at=(100, 55, 0),
+            )
+        )
+        sch = _load(content)
+        result = tidy_fields(sch, threshold=15.0)
+        assert [p.reference for p in result.symbols] == ["R1"]
+
+    def test_power_symbols_skipped_by_default(self):
+        sch = _load(POWER_FIXTURE)
+        result = tidy_fields(sch)
+        assert [p.reference for p in result.symbols] == ["R1"]
+
+    def test_power_symbol_tidied_when_named_in_refs(self):
+        sch = _load(POWER_FIXTURE)
+        result = tidy_fields(sch, refs=["#PWR01"])
+        assert [p.reference for p in result.symbols] == ["#PWR01"]
+        # Reference field of the GND lib symbol is visible in this fixture's
+        # placed instance; both fields should now be near the (degenerate) bbox.
+        x, y, _ = _field_at(sch, "#PWR01", "Value")
+        assert field_offset_mm((x, y), _symbol_bbox(sch, "#PWR01")) <= 3.0
+
+    def test_hidden_field_not_moved(self):
+        content = _schematic(
+            _resistor_instance("R1", "11111111-0000-0000-0000-000000000001", 50, 50, hide_ref=True)
+        )
+        sch = _load(content)
+        result = tidy_fields(sch)
+        assert result.fields_changed == 1  # only Value
+        assert result.symbols[0].changes[0].field == "Value"
+        assert _field_at(sch, "R1", "Reference")[:2] == (80.0, 80.0)
+
+    def test_unresolvable_lib_id_warns_and_skips(self):
+        sch = _load(UNRESOLVED_FIXTURE)
+        result = tidy_fields(sch)
+        assert [p.reference for p in result.symbols] == ["R1"]
+        assert len(result.warnings) == 1
+        assert "U1" in result.warnings[0]
+        assert "Missing:Symbol" in result.warnings[0]
+        # untouched
+        assert _field_at(sch, "U1", "Reference")[:2] == (130.0, 130.0)
+
+    def test_multi_unit_each_unit_placed_near_its_instance(self):
+        sch = _load(MULTI_UNIT_FIXTURE)
+        result = tidy_fields(sch)
+        assert len(result.symbols) == 2
+        assert {p.unit for p in result.symbols} == {1, 2}
+
+        x1, _, _ = _field_at(sch, "U1", "Reference", unit=1)
+        x2, _, _ = _field_at(sch, "U1", "Reference", unit=2)
+        assert x1 == pytest.approx(50.0, abs=1.5)
+        assert x2 == pytest.approx(120.0, abs=1.5)
+
+
+def _serialize_symbol(sch: Schematic, ref: str) -> str:
+    for sym_sexp in sch.sexp.find_children("symbol"):
+        for prop in sym_sexp.find_children("property"):
+            if prop.get_string(0) == "Reference" and prop.get_string(1) == ref:
+                return sym_sexp.to_string()
+    raise AssertionError(f"symbol {ref} not found")
+
+
+# ---------------------------------------------------------------------------
+# tidy: cosmetic-only invariance
+# ---------------------------------------------------------------------------
+
+
+def _normalize_field_ats(root: SExp) -> None:
+    """Zero the (at ...) of Reference/Value properties on placed symbols."""
+    for sym_sexp in root.find_children("symbol"):
+        for prop in sym_sexp.find_children("property"):
+            if prop.get_string(0) in ("Reference", "Value"):
+                if at := prop.find_child("at"):
+                    at.set_value(0, 0)
+                    at.set_value(1, 0)
+                    at.set_value(2, 0)
+
+
+class TestInvariance:
+    def test_structural_diff_only_field_ats_change(self, tmp_path):
+        path = _write(tmp_path, ROTATION_FIXTURE)
+        before_tree = parse_string(path.read_text())
+
+        sch = Schematic.load(path)
+        result = tidy_fields(sch)
+        assert result.fields_changed > 0
+        sch.save()
+
+        after_tree = parse_string(path.read_text())
+
+        _normalize_field_ats(before_tree)
+        _normalize_field_ats(after_tree)
+        assert before_tree.to_string() == after_tree.to_string()
+
+    @pytest.mark.skipif(not REAL_FIXTURE.exists(), reason="board fixture not available")
+    def test_structural_diff_on_real_fixture(self, tmp_path):
+        path = tmp_path / "simple_led.kicad_sch"
+        shutil.copy(REAL_FIXTURE, path)
+        before_tree = parse_string(path.read_text())
+
+        sch = Schematic.load(path)
+        result = tidy_fields(sch)
+        assert result.fields_changed > 0
+        sch.save()
+
+        after_tree = parse_string(path.read_text())
+        _normalize_field_ats(before_tree)
+        _normalize_field_ats(after_tree)
+        assert before_tree.to_string() == after_tree.to_string()
+
+    @pytest.mark.skipif(not REAL_FIXTURE.exists(), reason="board fixture not available")
+    def test_bom_invariance_on_real_fixture(self, tmp_path):
+        path = tmp_path / "simple_led.kicad_sch"
+        shutil.copy(REAL_FIXTURE, path)
+
+        bom_before = extract_bom_from_schematic(Schematic.load(path))
+
+        sch = Schematic.load(path)
+        tidy_fields(sch)
+        sch.save()
+
+        bom_after = extract_bom_from_schematic(Schematic.load(path))
+        assert bom_after == bom_before
+
+    @pytest.mark.skipif(not REAL_FIXTURE.exists(), reason="board fixture not available")
+    def test_netlist_invariance_on_real_fixture(self, tmp_path):
+        from kicad_tools.cli.export_netlist import export_netlist, load_netlist
+        from kicad_tools.cli.runner import find_kicad_cli
+
+        kicad_cli = find_kicad_cli()
+        if kicad_cli is None:
+            pytest.skip("kicad-cli not available")
+
+        path = tmp_path / "simple_led.kicad_sch"
+        shutil.copy(REAL_FIXTURE, path)
+
+        def _netlist_signature(net_path: Path):
+            netlist = load_netlist(net_path)
+            components = sorted((c.reference, c.value, c.footprint) for c in netlist.components)
+            nets = sorted(
+                (net.name, tuple(sorted((n.reference, n.pin) for n in net.nodes)))
+                for net in netlist.nets
+            )
+            return components, nets
+
+        before_out = tmp_path / "before.net"
+        ok, err = export_netlist(path, before_out, kicad_cli)
+        assert ok, err
+        before = _netlist_signature(before_out)
+
+        sch = Schematic.load(path)
+        result = tidy_fields(sch)
+        assert result.fields_changed > 0
+        sch.save()
+
+        after_out = tmp_path / "after.net"
+        ok, err = export_netlist(path, after_out, kicad_cli)
+        assert ok, err
+        after = _netlist_signature(after_out)
+
+        assert after == before
+
+
+# ---------------------------------------------------------------------------
+# tidy: CLI entry point
+# ---------------------------------------------------------------------------
+
+
+class TestTidyCli:
+    def test_dry_run_leaves_file_byte_identical(self, tmp_path, capsys):
+        path = _write(tmp_path, ROTATION_FIXTURE)
+        original = path.read_bytes()
+
+        rc = tidy_main([str(path), "--dry-run"])
+        assert rc == 0
+        assert path.read_bytes() == original
+
+        out = capsys.readouterr().out
+        assert "DRY RUN" in out
+        assert "R1" in out
+        assert "->" in out  # before/after offsets
+        assert "would change" in out
+
+    def test_dry_run_json(self, tmp_path, capsys):
+        path = _write(tmp_path, ROTATION_FIXTURE)
+        original = path.read_bytes()
+
+        rc = tidy_main([str(path), "--dry-run", "--format", "json"])
+        assert rc == 0
+        assert path.read_bytes() == original
+
+        data = json.loads(capsys.readouterr().out)
+        assert data["dry_run"] is True
+        assert data["modified"] is False
+        assert data["symbols_changed"] == 5
+        assert data["fields_changed"] == 10
+        change = data["symbols"][0]["changes"][0]
+        assert {"field", "old_position", "new_position", "old_offset", "new_offset"} <= set(change)
+
+    def test_apply_writes_file(self, tmp_path, capsys):
+        path = _write(tmp_path, ROTATION_FIXTURE)
+        original = path.read_bytes()
+
+        rc = tidy_main([str(path)])
+        assert rc == 0
+        assert path.read_bytes() != original
+        assert "changed" in capsys.readouterr().out
+
+        sch = Schematic.load(path)
+        bbox = _symbol_bbox(sch, "R1")
+        x, y, _ = _field_at(sch, "R1", "Reference")
+        assert field_offset_mm((x, y), bbox) <= 3.0
+
+    def test_apply_json_output(self, tmp_path, capsys):
+        path = _write(tmp_path, ROTATION_FIXTURE)
+        rc = tidy_main([str(path), "--format", "json"])
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["dry_run"] is False
+        assert data["modified"] is True
+        assert data["fields_changed"] == 10
+
+    def test_backup_created(self, tmp_path):
+        path = _write(tmp_path, ROTATION_FIXTURE)
+        original = path.read_bytes()
+
+        rc = tidy_main([str(path), "--backup"])
+        assert rc == 0
+
+        backups = list(tmp_path.glob("*.backup-*"))
+        assert len(backups) == 1
+        assert backups[0].read_bytes() == original
+
+    def test_refs_cli(self, tmp_path, capsys):
+        path = _write(tmp_path, ROTATION_FIXTURE)
+        rc = tidy_main([str(path), "--refs", "R1,R3", "--format", "json"])
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert {s["reference"] for s in data["symbols"]} == {"R1", "R3"}
+
+    def test_threshold_cli(self, tmp_path, capsys):
+        path = _write(tmp_path, ROTATION_FIXTURE)
+        rc = tidy_main([str(path), "--threshold", "100", "--format", "json"])
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["fields_changed"] == 0
+        assert data["modified"] is False
+
+    def test_missing_file_errors(self, tmp_path, capsys):
+        rc = tidy_main([str(tmp_path / "missing.kicad_sch")])
+        assert rc == 1
+        assert "not found" in capsys.readouterr().err.lower()
+
+    def test_kct_dispatch(self, tmp_path, capsys):
+        """The `kct sch tidy` dispatch path reaches the command."""
+        from kicad_tools.cli import main as kct_main
+
+        path = _write(tmp_path, ROTATION_FIXTURE)
+        rc = kct_main(["sch", "tidy", str(path), "--dry-run", "--format", "json"])
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["fields_changed"] == 10


### PR DESCRIPTION
## Summary

Implements `kct sch tidy` — a headless, diff-reviewable stand-in for Eeschema's GUI-only "Autoplace Fields". Resets visible `Reference`/`Value` field positions to deterministic bbox-relative defaults: Reference centered above the placed symbol body bounding box, Value centered below, both grid-aligned (1.27 mm) and horizontal, honoring symbol rotation and mirroring. Per the curated scope, Eeschema-algorithm parity is an explicit non-goal.

Closes #4596

## What's included

- **`src/kicad_tools/schema/field_geometry.py` (new)** — shared, command-agnostic geometry: `placed_body_bbox()` (graphics extents transformed with the same mirror-then-rotate-then-Y-negate convention as `LibrarySymbol.get_pin_position`, with pin-extent fallback for graphics-less symbols and per-unit pin extents for multi-unit symbols), `field_offset_mm()` (point-to-bbox distance, 0 inside), and `default_field_positions()` (grid-snapped Reference-above / Value-below anchors). Exported from `kicad_tools.schema` so the companion lint (#4595) can import the exact same metric without touching CLI code.
- **`src/kicad_tools/cli/sch_tidy.py` (new)** — command implementation modeled on `sch_move_component.py`: pure `plan_tidy()` + `tidy_fields()` + `run_tidy()` + `main()`. Flags: `--threshold <mm>` (only touch fields farther than this from the body; 0 = all in-scope), `--refs` scoping (explicitly named refs override the power-symbol skip), `--dry-run` (file untouched; per-symbol before/after offsets), `--backup`, `--format text|json`.
- **Parser/dispatch registration** — `tidy` subparser in `_add_sch_parser()` (with a description documenting the v1 bbox-relative policy and the multi-unit pin-extent limitation, per AC) and the dispatch branch in `run_sch_command()`.
- **`tests/test_sch_tidy.py` (new, 40 tests)** — geometry units + command + CLI + invariance.
- CHANGELOG bullet under Unreleased/Added.

## Behaviour details

- Only the `(at x y angle)` of Reference/Value property nodes is modified (angle reset to 0); everything else is untouched.
- Power/virtual symbols (`#`-prefixed) and hidden fields (both `(hide yes)` list and legacy bare-atom `hide` forms) are skipped by default.
- Symbols whose `lib_id` is not in the embedded `lib_symbols` are skipped with a warning, exit code stays 0.
- Fields already at their default position are left alone, so re-running tidy is a byte-identical no-op (idempotence is tested).
- Multi-unit symbols: each placed unit's bbox comes from that unit's pins (`LibrarySymbol.graphics` merges all units); documented in `--help`.

## Cosmetic-only invariance (tested)

- **Structural diff**: before/after trees serialized after normalizing only the Reference/Value `at` nodes are byte-identical — on both the synthetic rotation fixture and the real `boards/00-simple-led` schematic.
- **BOM invariance**: `schema/bom.py` extraction identical before/after on the real fixture.
- **Netlist invariance**: `kicad-cli` netlist export compares equal before/after on the real fixture (skip-if-`kicad-cli`-unavailable via `find_kicad_cli()`).

## Test results

- `tests/test_sch_tidy.py`: 40 passed (includes the kicad-cli netlist leg locally).
- Neighboring suites (`-k "sch_ or schema or bom or sexp or parser"`): 3494 passed, 14 skipped.
- `ruff check .` / `ruff format --check .`: clean.
- mypy baseline gate (`scripts/ci/check_mypy_baseline.py`): OK — no new type errors.

## Out of scope (per curator)

- No `kct check` lint rule (#4595, later wave) and no changes to `cli/check_cmd.py` (owned by sibling #4600 this wave).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
