### PR TITLE
feat(router): search-time HV pairwise clearance in the lattice engine (#4602)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ constructor). No breaking changes.
 
 ### Added
 
+- **Search-time HV pairwise clearance in the lattice engine** — `--voltage-map`
+  + `--route-engine lattice` now *avoids* HV↔LV proximity during the A\* search
+  instead of only failing the #4588 post-route gate after committing the
+  copper. The lattice consumes `rules.pairwise_clearance` through a new
+  net-id-space projection (`router/lattice/pairwise.py`, mirroring the #4510
+  C++ grid projection): every committed-copper predicate widens its gap to
+  `own_half + stored_half + max(own_clr, stored_clr, pairwise(pair))`, static
+  pad keep-outs grow per-pad/per-pair, spatial query windows inflate to the
+  widest requirement the querying net participates in (the #4511
+  search-radius trap), and #4506 rated attach zones exempt in-search at the
+  same closest-gap midpoint the post-route gate probes — so search and gate
+  agree by construction. The routing cache now keys the derived pairwise
+  matrix so a scalar run's entry is never served to a `--voltage-map` run
+  (previously it silently bypassed route-time avoidance on grid too). Without
+  `--voltage-map` the lattice path is byte-identical; coupled diff-pair fat
+  envelopes are deliberately excluded (same-domain by construction; emitted
+  legs remain audited). The mesh engine stays post-route-gated only (#4602).
+
 - **Connector mating / edge-access rule in `kct check`** — new default-on
   `connector_access` category (selectable via `--only`/`--skip`, no new flags)
   with a warning-severity `connector_edge_access` rule that flags rigid-plug

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -3928,27 +3928,36 @@ def _apply_pairwise_clearance(router: "Autorouter", args, quiet: bool = False) -
     )
     pcb_path = getattr(router, "_pairwise_attach_zone_pcb_path", None)
     pathfinder = getattr(router, "router", None)
-    if pathfinder is not None and pcb_path is not None and hasattr(pathfinder, "set_attach_zones"):
-        # Issue #4588: route through the shared resolver so the grid search sees
-        # the same sheet-absolute zones the post-route audit does.  Building them
-        # inline here (pre-#4588) leaked board-relative footprint coordinates
-        # into a sheet-absolute pathfinder.
-        pathfinder.set_attach_zones(_pairwise_attach_zones(router))
+    if pcb_path is not None:
+        # Issue #4588: route through the shared resolver so every search-time
+        # consumer sees the same sheet-absolute zones the post-route audit
+        # does.  Building them inline here (pre-#4588) leaked board-relative
+        # footprint coordinates into a sheet-absolute pathfinder.  The call is
+        # memoised on the router (``_pairwise_attach_zones_cache``), which is
+        # also how the LATTICE engine's id-space projection picks the zones up
+        # at negotiation time (#4602) -- its pathfinder does not exist yet at
+        # this point, so warming the cache here is the hand-off.
+        zones = _pairwise_attach_zones(router)
+        if pathfinder is not None and hasattr(pathfinder, "set_attach_zones"):
+            pathfinder.set_attach_zones(zones)
 
     if not quiet:
         from kicad_tools.cli.progress import flush_print
 
-        # Issue #4588: name the enforcement that will ACTUALLY run.  Only the
-        # grid engines consult ``rules.pairwise_clearance`` during search
-        # (``router/pathfinder.py``, ``router/cpp_backend.py``, the C++ halo);
-        # lattice/mesh resolve clearance as a pure scalar, so claiming
-        # "route-time creepage rejection active" there was the reassuring line
-        # that made the false pass silent.  Both engines are now covered by the
-        # post-route board audit (``_audit_pairwise_clearance``).
+        # Issue #4588: name the enforcement that will ACTUALLY run.  The grid
+        # engines consult ``rules.pairwise_clearance`` during search
+        # (``router/pathfinder.py``, ``router/cpp_backend.py``, the C++ halo),
+        # and the lattice search now does too (#4602: per-pair predicate
+        # widening + HV pad keep-outs).  The mesh engine still resolves
+        # clearance as a pure scalar, so it keeps the audit-only wording --
+        # claiming "route-time rejection" there would recreate the reassuring
+        # line that made the original false pass silent.  Every engine is
+        # additionally covered by the post-route board audit
+        # (``_audit_pairwise_clearance``).
         engine = getattr(args, "route_engine", "grid") or "grid"
         enforcement = (
             "route-time rejection + post-route audit"
-            if engine == "grid"
+            if engine in ("grid", "lattice")
             else f"post-route audit only -- the {engine} search is pairwise-blind"
         )
         flush_print(
@@ -4011,7 +4020,9 @@ def _pairwise_attach_zones(router: "Autorouter") -> "tuple[AttachZone, ...]":
             )
             zones = ()
     with contextlib.suppress(AttributeError):  # exotic router stand-ins
-        router._pairwise_attach_zones_cache = zones  # type: ignore[attr-defined]
+        # The attribute is declared on ``Autorouter.__init__`` (#4602), so no
+        # ignore is needed; the suppress still guards non-Autorouter stand-ins.
+        router._pairwise_attach_zones_cache = zones
     return zones
 
 
@@ -4020,12 +4031,14 @@ def _audit_pairwise_clearance(
 ) -> "list[PairwiseViolation]":
     """Board-level post-route pairwise (HV creepage) audit -- issue #4588.
 
-    ``rules.pairwise_clearance`` is consumed **only** by the grid engines'
+    ``rules.pairwise_clearance`` is consumed by the grid engines'
     route-acceptance predicates (``router/pathfinder.py``, ``router/cpp_backend.py``
-    and the C++ ``Grid3D`` halo).  The lattice and mesh engines resolve clearance
-    as a pure scalar, so a ``--voltage-map`` run on those engines committed HV
-    copper at DRU spacing while still printing the reassuring ``HV pairwise
-    clearance: N mapped nets`` line -- a silent false pass of a safety feature.
+    and the C++ ``Grid3D`` halo) and, since #4602, by the lattice search
+    (``router/lattice``: per-pair predicate widening + HV pad keep-outs).  The
+    MESH engine still resolves clearance as a pure scalar, so a ``--voltage-map``
+    run there committed HV copper at DRU spacing while still printing the
+    reassuring ``HV pairwise clearance: N mapped nets`` line -- a silent false
+    pass of a safety feature.
 
     This audit closes that hole engine-agnostically: every engine commits copper
     by appending to ``router.routes``, so a whole-board scan of that list catches
@@ -4173,16 +4186,18 @@ def _print_pairwise_failure_banner(
         f"{getattr(args, 'material_group', 'IIIa')}"
     )
     engine = getattr(args, "route_engine", "grid") or "grid"
-    if engine != "grid":
-        # Issue #4588 gates; issue #4602 will teach the non-grid searches to
-        # AVOID the proximity instead of only reporting it.  Until then the
-        # only in-tool remedy is the engine that already enforces pairwise
-        # clearance during search (#4454 / #4511).
+    if engine not in ("grid", "lattice"):
+        # Issue #4588 gates; grid (#4454/#4511) and lattice (#4602) avoid the
+        # proximity during search, so a gate hit there means the geometry
+        # itself is over-constrained.  The MESH search is still pairwise-blind
+        # -- the only in-tool remedy is an engine that enforces pairwise
+        # clearance during search.
         print()
         print(f"  The {engine} search resolves clearance as a per-net scalar and cannot")
-        print("  avoid HV<->LV proximity (issue #4602). Remedies: re-route with")
-        print("  --route-engine grid (route-time creepage rejection), widen the HV")
-        print("  corridor in placement, or add rated attach zones (#4506).")
+        print("  avoid HV<->LV proximity (issue #4602 covered lattice only). Remedies:")
+        print("  re-route with --route-engine grid or lattice (route-time creepage")
+        print("  rejection), widen the HV corridor in placement, or add rated attach")
+        print("  zones (#4506).")
 
 
 def _warn_unresolved_net_class_map(resolution, board_net_names, nearest_fn) -> None:
@@ -14133,10 +14148,10 @@ def main(argv: list[str] | None = None) -> int:
 
     # Issue #4588: board-level pairwise (HV creepage) gate.
     #
-    # ``rules.pairwise_clearance`` is only consulted by the *grid* engines'
-    # route-acceptance predicates, so a ``--voltage-map`` run on ``--route-engine
-    # lattice``/``mesh`` previously committed HV copper at scalar-DRU spacing and
-    # still exited 0 with a SUCCESS banner.  Auditing the committed copper
+    # ``rules.pairwise_clearance`` is consulted by the *grid* engines'
+    # route-acceptance predicates and (since #4602) by the lattice search, but
+    # NOT by mesh, so a ``--voltage-map`` run on ``--route-engine mesh``
+    # commits HV copper at scalar-DRU spacing.  Auditing the committed copper
     # (``router.routes``) here catches that on every engine.  Runs *after* DRC
     # and *before* the summary predicate; a strict no-op without ``--voltage-map``
     # (and never on ``--dry-run``, where nothing was committed to disk).

--- a/src/kicad_tools/router/cache.py
+++ b/src/kicad_tools/router/cache.py
@@ -103,7 +103,7 @@ class CacheKey:
         pcb_hash = hashlib.sha256(pcb_content).hexdigest()
 
         # Hash design rules (serialize relevant fields)
-        rules_data = {
+        rules_data: dict[str, object] = {
             "trace_width": rules.trace_width,
             "trace_clearance": rules.trace_clearance,
             "via_drill": rules.via_drill,
@@ -113,6 +113,20 @@ class CacheKey:
             "preferred_layer": rules.preferred_layer.value,
             "alternate_layer": rules.alternate_layer.value,
         }
+        # Issue #4602: the derived HV pairwise matrix (--voltage-map, #4431)
+        # changes the ROUTES themselves -- grid (#4454/#4511) and lattice
+        # (#4602) avoid HV<->LV proximity during search -- so it must key the
+        # cache.  Without this a scalar run's entry was served to a
+        # --voltage-map run (silently bypassing route-time avoidance; only the
+        # #4588 post-route gate caught it) and vice versa.  Absent table ->
+        # ``rules_data`` is unchanged, so every pre-existing key is preserved
+        # byte-for-byte.
+        pairwise = getattr(rules, "pairwise_clearance", None)
+        if pairwise is not None and pairwise.required_by_pair:
+            rules_data["pairwise_required_by_pair"] = sorted(
+                [net_a, net_b, float(required)]
+                for (net_a, net_b), required in pairwise.required_by_pair.items()
+            )
         rules_json = json.dumps(rules_data, sort_keys=True)
         rules_hash = hashlib.sha256(rules_json.encode()).hexdigest()
 

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -2865,7 +2865,11 @@ class Autorouter:
         # lattice pathfinder, so HV<->LV proximity is AVOIDED during search
         # rather than merely reported by the #4588 post-route gate.  Always
         # called -- ``None`` resets a reused pathfinder (no stale projection).
-        pf.set_pairwise(self._lattice_pairwise_projection())
+        # ``hasattr``-guarded for duck-typed pathfinder stand-ins that predate
+        # the method, mirroring the ``set_attach_zones`` precedent in
+        # ``route_cmd.py`` (``LatticePathfinder`` itself always has it).
+        if hasattr(pf, "set_pairwise"):
+            pf.set_pairwise(self._lattice_pairwise_projection())
 
         coupled, reserved = self._lattice_coupled_connections()
 

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -1017,6 +1017,11 @@ class Autorouter:
         # Populated by the PCB loader and consumed only when pairwise voltage
         # rules are enabled, to derive rated-footprint attach zones.
         self._pairwise_attach_zone_pcb_path: str | None = None
+        # Memoised sheet-absolute #4506 attach zones (resolved + cached by the
+        # CLI's ``_pairwise_attach_zones`` helper, which owns the
+        # board-origin shift per PR #4603).  ``None`` = not yet resolved.
+        # Consumed here by the lattice pairwise projection (#4602).
+        self._pairwise_attach_zones_cache: tuple[Any, ...] | None = None
         # Issue #2610: stored so _create_grid_and_routers can pass it to
         # create_hybrid_router on the initial construction.
         self._max_search_iterations = int(max_search_iterations) if max_search_iterations else 0
@@ -2638,6 +2643,38 @@ class Autorouter:
             )
         return self._lattice_pathfinder
 
+    def _lattice_pairwise_projection(self) -> Any:
+        """Net-id-space HV pairwise projection for the lattice engine (#4602).
+
+        The router owns both halves the (deliberately geometry-only, #4597)
+        lattice pathfinder must never see: the name-keyed
+        ``rules.pairwise_clearance`` table and the ``net_names`` id map.  The
+        #4506 attach zones come from the CLI's ``_pairwise_attach_zones``
+        resolver output (memoised on ``_pairwise_attach_zones_cache``,
+        sheet-absolute per PR #4603) -- they are reused, never rebuilt here.
+
+        Returns ``None`` when no ``--voltage-map`` table is installed or no
+        pair resolves on this board -- the dormant signal that keeps the
+        lattice search byte-identical to the scalar path.
+        """
+        table = getattr(self.rules, "pairwise_clearance", None)
+        if table is None:
+            return None
+
+        from .lattice.pairwise import build_lattice_pairwise
+
+        name_to_id: dict[str, int] = {
+            name: int(net_id) for net_id, name in self.net_names.items() if name
+        }
+        # Defensive union with the pad-derived names: a router assembled
+        # without ``add_component`` (tests, deserialization) may have an
+        # empty ``net_names`` map while its pads still carry names.
+        for pad in self.all_pads or list(self.pads.values()):
+            if pad.net_name and pad.net_name not in name_to_id and pad.net is not None:
+                name_to_id[pad.net_name] = int(pad.net)
+        zones = self._pairwise_attach_zones_cache or ()
+        return build_lattice_pairwise(table, zones, name_to_id)
+
     @staticmethod
     def _snap_lattice_region(
         box: tuple[float, float, float, float],
@@ -2821,6 +2858,14 @@ class Autorouter:
         anchor selection untouched.
         """
         pf = self._ensure_lattice_pathfinder()
+
+        # Issue #4602: project the HV pairwise table (name-keyed, set on the
+        # shared rules by ``_apply_pairwise_clearance``) + the #4506 attach
+        # zones into net-id space and install them on the (geometry-only)
+        # lattice pathfinder, so HV<->LV proximity is AVOIDED during search
+        # rather than merely reported by the #4588 post-route gate.  Always
+        # called -- ``None`` resets a reused pathfinder (no stale projection).
+        pf.set_pairwise(self._lattice_pairwise_projection())
 
         coupled, reserved = self._lattice_coupled_connections()
 

--- a/src/kicad_tools/router/lattice/coupled.py
+++ b/src/kicad_tools/router/lattice/coupled.py
@@ -180,6 +180,16 @@ def committed_seg_clear_grown(
     and clearance, so the per-item gap is ``trace_half + stored_half +
     max(clearance, stored_clearance) + extra`` -- the fat envelope is
     spaced honestly even against oversize (e.g. 2.6 mm HV) copper.
+
+    Issue #4602 (deliberate exclusion): the fat-envelope predicates do NOT
+    apply the HV pairwise (``|delta V|``-derived) widening.  An engaged diff
+    pair is a same-domain signal pair by construction; giving the whole
+    grown envelope a multi-mm HV keep-out on top of ``pitch/2`` would make
+    every coupled run near mapped copper decline outright, and no fleet
+    board pairs an HV domain net into a diff pair.  The emitted legs remain
+    covered end-to-end: ``_pair_attach``/re-verification go through
+    ``CommittedCopper.seg_clear`` (pairwise-aware when a projection is
+    installed) and the #4588 post-route audit gates the committed copper.
     """
     pad = committed.trace_half + committed.clearance + extra + 0.5
     for c, d, cnet, hw, iclr in committed.copper[layer].query_seg(a, b, pad=pad):

--- a/src/kicad_tools/router/lattice/obstacles.py
+++ b/src/kicad_tools/router/lattice/obstacles.py
@@ -22,6 +22,7 @@ per copper layer:
 from __future__ import annotations
 
 from collections import defaultdict
+from typing import TYPE_CHECKING
 
 from ..primitives import Pad
 from .geometry import (
@@ -35,6 +36,9 @@ from .geometry import (
     seg_seg_dist,
 )
 from .quadtree import EdgeKey, NodeKey, OctilinearLattice
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .pairwise import LatticePairwise
 
 _BUCKET = 4.0  # mm; pad-lookup acceleration grid
 
@@ -166,6 +170,64 @@ class LatticeObstacleModel:
                 return True
         return False
 
+    def pairwise_pad_blocked(
+        self,
+        a: Pt,
+        b: Pt,
+        layer: int | None,
+        net: int,
+        own_half: float,
+        base_extra: float,
+        pairwise: LatticePairwise,
+    ) -> bool:
+        """Pairwise-ONLY (HV) pad keep-out for free segment ``a-b`` (#4602).
+
+        Additive to the scalar checks (``node_blocked`` / ``edge_blocked`` /
+        ``segment_blocked``), which run unchanged: this predicate fires only
+        when the PAIR requirement between the querying net and a pad's net
+        exceeds what the scalar path already keeps out.  Each pad's keep-out
+        rect is grown per-pair to ``raw pad extent + own_half +
+        required(net, pad_net)`` (i.e. ``pad_rects[idx]`` inflated by
+        ``own_half + req - agent_radius``) -- a per-PAD, per-PAIR inflation,
+        never a uniform surcharge.  ``layer is None`` checks every layer the
+        pad occupies (the through-via probe).  A hit inside a #4506 attach
+        zone covering both nets is waived -- that is what keeps a rated
+        domain-bridging footprint routable in-search.
+
+        ``base_extra`` is the scalar inflation the ordinary checks already
+        apply (``max(0, own_half + own_clr - agent_radius)``): pads whose
+        pairwise inflation does not exceed it are the scalar path's business.
+        The degenerate ``a == b`` form doubles as a point probe.
+        """
+        reach = pairwise.max_required_for(net)
+        if reach <= 0.0:
+            return False
+        floor_extra = max(base_extra, 0.0)
+        max_extra = own_half + reach - self.agent_radius
+        if max_extra <= floor_extra:
+            return False
+        x0, x1 = min(a[0], b[0]), max(a[0], b[0])
+        y0, y1 = min(a[1], b[1]), max(a[1], b[1])
+        for idx in self.pads_near(x0 - max_extra, y0 - max_extra, x1 + max_extra, y1 + max_extra):
+            pad = self.pads[idx]
+            if pad.net == net:
+                continue
+            req = pairwise.required(net, pad.net)
+            if req <= 0.0:
+                continue
+            extra_pw = own_half + req - self.agent_radius
+            if extra_pw <= floor_extra:
+                continue
+            if layer is not None and layer not in self.pad_layer_indices[idx]:
+                continue
+            rect = self.pad_rects[idx]
+            grown = (rect[0] - extra_pw, rect[1] - extra_pw, rect[2] + extra_pw, rect[3] + extra_pw)
+            if seg_rect_intersect(a, b, grown) and not pairwise.exempt_seg_pt(
+                a, b, (pad.x, pad.y), net, pad.net
+            ):
+                return True
+        return False
+
 
 class CommittedCopper:
     """Copper committed by already-routed nets in one negotiation pass.
@@ -194,6 +256,21 @@ class CommittedCopper:
     That is what lets ``--preserve-existing`` copper seeded from an earlier
     routing step keep its net-class-map clearance across the pass boundary
     instead of collapsing to the board-global floor.
+
+    Issue #4602 (search-time HV pairwise clearance): ``pairwise`` is the
+    optional net-id-space projection of ``rules.pairwise_clearance``
+    (:class:`~kicad_tools.router.lattice.pairwise.LatticePairwise`).  When
+    set, every cross-net predicate widens its gap to
+    ``own_half + stored_half + max(own_clr, stored_clr, pairwise(query,
+    stored))`` -- the required clearance depends on the PAIR, never on a
+    widened per-net scalar (widening the scalar is exactly the inadequate
+    workaround #4431 documents: it would force LV<->LV spacing to HV<->LV
+    distances).  A hit that satisfies the scalar gap but falls inside the
+    pairwise requirement may be exempted by a #4506 attach zone probed at
+    the closest-gap midpoint, mirroring ``segment_pair_violation`` so the
+    search verdict and the #4588 post-route gate agree.  ``None`` (the
+    default, and always the case without ``--voltage-map``) runs the
+    pre-#4602 scalar path byte-for-byte.
     """
 
     def __init__(
@@ -205,6 +282,7 @@ class CommittedCopper:
         via_radius: float,
         via_via_gap: float,
         same_net_via_gap: float,
+        pairwise: LatticePairwise | None = None,
     ) -> None:
         self.num_layers = num_layers
         self.trace_half = trace_half  # global default copper half-width
@@ -212,6 +290,7 @@ class CommittedCopper:
         self.via_radius = via_radius  # via body radius
         self.via_via_gap = via_via_gap  # via centre to via centre (cross-net)
         self.same_net_via_gap = same_net_via_gap  # hole-to-hole floor
+        self.pairwise = pairwise  # id-space HV pairwise projection (#4602)
         self.copper: list[SegHash] = [SegHash() for _ in range(num_layers)]
         # ``(point, net, clearance)`` -- the stored clearance is the via's own
         # net-class clearance (issue #4597), defaulting to the board-global
@@ -287,11 +366,32 @@ class CommittedCopper:
     ) -> bool:
         """True if segment ``a-b`` on ``layer`` clears other-net copper + vias."""
         own_half, own_clr = self._own(half, clearance)
-        pad = own_half + own_clr + 0.5
+        # Issue #4602: an active pairwise projection inflates the spatial query
+        # window to the widest requirement THIS net participates in (the #4511
+        # search-radius trap: a ~3 mm creepage requirement vastly exceeds the
+        # DRU scalar, so an un-inflated window silently misses far-but-
+        # forbidden copper).  Dormant/unmapped nets keep the scalar window.
+        pw = self.pairwise
+        pw_reach = pw.max_required_for(net) if pw is not None else 0.0
+        pad = own_half + max(own_clr, pw_reach) + 0.5
         for c, d, cnet, hw, iclr in self.copper[layer].query_seg(a, b, pad=pad):
+            if cnet == net:
+                continue
             gap = own_half + hw + max(own_clr, iclr)
-            if cnet != net and seg_seg_dist(a, b, c, d) < gap - 1e-9:
+            d_cc = seg_seg_dist(a, b, c, d)
+            if d_cc < gap - 1e-9:
                 return False
+            # Issue #4602: pair term.  The gap widens to the PAIR requirement
+            # (never a per-net scalar); a scalar-passing hit inside the
+            # requirement may be waived by a #4506 attach zone, probed at the
+            # closest-gap midpoint exactly as the #4588 gate probes it.
+            if pw is not None:
+                req = pw.required(net, cnet)
+                if req > max(own_clr, iclr):
+                    if d_cc < own_half + hw + req - 1e-9 and not pw.exempt_seg_seg(
+                        a, b, c, d, net, cnet
+                    ):
+                        return False
         # Issue #4597: honor the STORED via's class clearance the same way the
         # copper loop above honors a stored segment's -- a preserved HV via must
         # be cleared at its own class gap, not merely at the querying net's.
@@ -301,8 +401,18 @@ class CommittedCopper:
         for point, vnet, vclr in self.vias:
             if vnet != net:
                 via_gap = own_via_gap if vclr <= own_clr else self.via_radius + own_half + vclr
-                if seg_pt_dist(a, b, point) < via_gap - 1e-9:
+                d_vp = seg_pt_dist(a, b, point)
+                if d_vp < via_gap - 1e-9:
                     return False
+                # Issue #4602: a committed via is copper too -- the pair
+                # requirement spaces the trace from its barrel edge.
+                if pw is not None:
+                    req = pw.required(net, vnet)
+                    if req > max(own_clr, vclr):
+                        if d_vp < self.via_radius + own_half + req - 1e-9 and not pw.exempt_seg_pt(
+                            a, b, point, net, vnet
+                        ):
+                            return False
             elif seg_body_crosses_pt(a, b, point):
                 # Same-net octilinear segment whose BODY runs across a same-net
                 # via center is malformed lattice copper (#4318).  The DRC
@@ -324,17 +434,41 @@ class CommittedCopper:
     ) -> bool:
         """True if a node site on ``layer`` clears other-net copper + vias."""
         own_half, own_clr = self._own(half, clearance)
-        pad = own_half + own_clr + 0.5
+        # Issue #4602: inflate the query window to the pairwise reach (see
+        # ``seg_clear``); dormant/unmapped nets keep the scalar window.
+        pw = self.pairwise
+        pw_reach = pw.max_required_for(net) if pw is not None else 0.0
+        pad = own_half + max(own_clr, pw_reach) + 0.5
         for c, d, cnet, hw, iclr in self.copper[layer].query_seg(point, point, pad=pad):
+            if cnet == net:
+                continue
             gap = own_half + hw + max(own_clr, iclr)
-            if cnet != net and seg_pt_dist(c, d, point) < gap - 1e-9:
+            d_cc = seg_pt_dist(c, d, point)
+            if d_cc < gap - 1e-9:
                 return False
+            if pw is not None:
+                req = pw.required(net, cnet)
+                if req > max(own_clr, iclr):
+                    if d_cc < own_half + hw + req - 1e-9 and not pw.exempt_seg_pt(
+                        c, d, point, net, cnet
+                    ):
+                        return False
         # Issue #4597: ``max(own_clr, stored_via_clr)`` -- see ``seg_clear``.
         own_via_gap = self.via_radius + own_half + own_clr
         for vpt, vnet, vclr in self.vias:
+            if vnet == net:
+                continue
             via_gap = own_via_gap if vclr <= own_clr else self.via_radius + own_half + vclr
-            if vnet != net and dist(point, vpt) < via_gap - 1e-9:
+            d_vp = dist(point, vpt)
+            if d_vp < via_gap - 1e-9:
                 return False
+            if pw is not None:
+                req = pw.required(net, vnet)
+                if req > max(own_clr, vclr):
+                    if d_vp < self.via_radius + own_half + req - 1e-9 and not pw.exempt_pt_pt(
+                        point, vpt, net, vnet
+                    ):
+                        return False
         return True
 
     def via_clear(self, point: Pt, net: int) -> bool:
@@ -351,12 +485,27 @@ class CommittedCopper:
         still not applied to via-to-via pairs -- a pre-existing #4271 residual
         that is deliberately NOT widened here.
         """
-        pad = self.via_radius + self.clearance + self.trace_half + 2.0
+        # Issue #4602: a through-via is copper on EVERY layer, so its pair
+        # requirement against foreign copper applies on all of them.  The
+        # query window inflates by the net's pairwise reach (see ``seg_clear``).
+        pw = self.pairwise
+        pw_reach = pw.max_required_for(net) if pw is not None else 0.0
+        pad = self.via_radius + self.clearance + self.trace_half + 2.0 + pw_reach
         for layer in range(self.num_layers):
             for c, d, cnet, hw, iclr in self.copper[layer].query_seg(point, point, pad=pad):
+                if cnet == net:
+                    continue
                 gap = self.via_radius + hw + max(self.clearance, iclr)
-                if cnet != net and seg_pt_dist(c, d, point) < gap - 1e-9:
+                d_cc = seg_pt_dist(c, d, point)
+                if d_cc < gap - 1e-9:
                     return False
+                if pw is not None:
+                    req = pw.required(net, cnet)
+                    if req > max(self.clearance, iclr):
+                        if d_cc < self.via_radius + hw + req - 1e-9 and not pw.exempt_seg_pt(
+                            c, d, point, net, cnet
+                        ):
+                            return False
         for vpt, vnet, vclr in self.vias:
             # Cross-net vias must honor BOTH the copper gap (via_via_gap =
             # via diameter + clearance, centre-to-centre) AND the drill
@@ -374,6 +523,15 @@ class CommittedCopper:
                 gap = max(self.via_via_gap, 2.0 * self.via_radius + vclr, self.same_net_via_gap)
             else:
                 gap = self.same_net_via_gap
-            if dist(point, vpt) < gap - 1e-9:
+            d_vv = dist(point, vpt)
+            if d_vv < gap - 1e-9:
                 return False
+            # Issue #4602: barrel-to-barrel pair requirement for cross-net vias.
+            if pw is not None and vnet != net:
+                req = pw.required(net, vnet)
+                if req > 0.0:
+                    if d_vv < 2.0 * self.via_radius + req - 1e-9 and not pw.exempt_pt_pt(
+                        point, vpt, net, vnet
+                    ):
+                        return False
         return True

--- a/src/kicad_tools/router/lattice/pairwise.py
+++ b/src/kicad_tools/router/lattice/pairwise.py
@@ -1,0 +1,171 @@
+"""Net-id-space pairwise (HV) clearance projection for the lattice engine.
+
+Issue #4602 (epic #4431): the lattice search consumes
+:attr:`~kicad_tools.router.rules.DesignRules.pairwise_clearance` so HV<->LV
+proximity is *avoided* during A*, not merely reported by the #4588
+post-route gate.
+
+The lattice pathfinder is deliberately geometry-only -- it works in integer
+net ids and never sees net names or net classes (#4597 discipline).  The
+name-keyed :class:`~kicad_tools.router.pairwise_clearance.PairwiseClearanceTable`
+and the #4506 :class:`~kicad_tools.router.pairwise_clearance.AttachZone`
+tuples are therefore projected ONCE by the caller (``Autorouter``, which owns
+the ``net_names`` map) into this flat id-space carrier, mirroring the #4510
+``build_cpp_domain_matrix`` / ``attach_zones_to_net_ids`` precedent for the
+C++ grid.
+
+Dormancy contract: when no ``--voltage-map`` was supplied the projection is
+``None`` and every lattice predicate runs its pre-#4602 code byte-for-byte.
+:func:`build_lattice_pairwise` also returns ``None`` when nothing resolves
+to a widening pair on this board, keeping the fast path for such runs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Mapping, Sequence
+
+from ..pairwise_clearance import closest_gap_midpoint_xy
+from .geometry import Pt
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from ..pairwise_clearance import AttachZone, PairwiseClearanceTable
+
+# A projected attach zone: sheet-absolute bbox + the net ids it may exempt.
+ZoneIds = tuple[float, float, float, float, frozenset[int]]
+
+
+@dataclass(frozen=True)
+class LatticePairwise:
+    """Order-independent net-id pair -> required edge-to-edge clearance (mm).
+
+    Attributes:
+        required_by_pair: ``{(lo_id, hi_id): required_mm}`` -- only pairs that
+            genuinely need HV widening (values are the raw creepage
+            requirement; the scalar path still governs via ``max``).
+        zones: #4506 rated-footprint attach zones projected to net ids
+            (sheet-absolute bboxes, same space as the lattice).
+        max_by_net: per-net-id maximum requirement across every pair the net
+            participates in -- the spatial-query inflation bound (the #4511
+            "search-radius trap": a ~3 mm requirement vastly exceeds the DRU
+            scalar, so un-inflated windows silently miss far-but-forbidden
+            copper).  Nets absent from the map need no inflation at all.
+    """
+
+    required_by_pair: Mapping[tuple[int, int], float]
+    zones: tuple[ZoneIds, ...]
+    max_by_net: Mapping[int, float]
+
+    def required(self, net_a: int, net_b: int) -> float:
+        """Raw pairwise requirement for an id pair; 0.0 when unmapped."""
+        if net_a == net_b:
+            return 0.0
+        key = (net_a, net_b) if net_a < net_b else (net_b, net_a)
+        return self.required_by_pair.get(key, 0.0)
+
+    def max_required_for(self, net: int) -> float:
+        """Widest requirement ``net`` participates in; 0.0 when unmapped."""
+        return self.max_by_net.get(net, 0.0)
+
+    def exempt(self, x: float, y: float, net_a: int, net_b: int) -> bool:
+        """True when ``(x, y)`` lies in a zone covering BOTH net ids (#4506).
+
+        Mirrors :meth:`AttachZone.exempts` so the search-time verdict and the
+        #4588 post-route gate agree by construction.  Callers probe the
+        closest-gap midpoint, exactly as ``segment_pair_violation`` does.
+        """
+        for x0, y0, x1, y1, ids in self.zones:
+            if x0 <= x <= x1 and y0 <= y <= y1 and net_a in ids and net_b in ids:
+                return True
+        return False
+
+    # -- probe-point helpers (closest-gap midpoints, gate-compatible) -------
+
+    def exempt_seg_seg(self, a: Pt, b: Pt, c: Pt, d: Pt, net_a: int, net_b: int) -> bool:
+        """Zone exemption probed at the two segments' closest-gap midpoint."""
+        if not self.zones:
+            return False
+        x, y = closest_gap_midpoint_xy(a[0], a[1], b[0], b[1], c[0], c[1], d[0], d[1])
+        return self.exempt(x, y, net_a, net_b)
+
+    def exempt_seg_pt(self, a: Pt, b: Pt, p: Pt, net_a: int, net_b: int) -> bool:
+        """Zone exemption probed midway between segment ``a-b`` and point ``p``."""
+        if not self.zones:
+            return False
+        ax, ay = a
+        dx, dy = b[0] - ax, b[1] - ay
+        length2 = dx * dx + dy * dy
+        if length2 <= 1e-18:
+            cx, cy = ax, ay
+        else:
+            t = ((p[0] - ax) * dx + (p[1] - ay) * dy) / length2
+            t = max(0.0, min(1.0, t))
+            cx, cy = ax + t * dx, ay + t * dy
+        return self.exempt((cx + p[0]) / 2.0, (cy + p[1]) / 2.0, net_a, net_b)
+
+    def exempt_pt_pt(self, p: Pt, q: Pt, net_a: int, net_b: int) -> bool:
+        """Zone exemption probed at the midpoint of two point sites."""
+        if not self.zones:
+            return False
+        return self.exempt((p[0] + q[0]) / 2.0, (p[1] + q[1]) / 2.0, net_a, net_b)
+
+
+def build_lattice_pairwise(
+    table: PairwiseClearanceTable | None,
+    attach_zones: Sequence[AttachZone],
+    net_name_to_id: Mapping[str, int],
+) -> LatticePairwise | None:
+    """Project a name-keyed pairwise table onto integer net ids (#4602).
+
+    The projection shape follows :func:`~kicad_tools.router.pairwise_clearance.
+    build_cpp_domain_matrix`: a board net name may carry a leading ``/`` while
+    the table keys never do, and two distinct board nets can in principle
+    normalise to the same key, so every matching id joins the pair.  Zones are
+    translated through :func:`~kicad_tools.router.pairwise_clearance.
+    attach_zones_to_net_ids` (they must already be sheet-absolute -- the
+    ``_pairwise_attach_zones`` resolver's output, board-origin shift included
+    per PR #4603).
+
+    Returns ``None`` when nothing needs widening on this board (no table, an
+    empty matrix, or no pair whose BOTH nets resolve to board net ids) -- the
+    dormant signal that keeps every lattice predicate on its scalar path.
+    """
+    if table is None:
+        return None
+    pairs = table.required_by_pair
+    if not pairs:
+        return None
+
+    from ..pairwise_clearance import _norm_net_key, attach_zones_to_net_ids
+
+    ids_by_key: dict[str, list[int]] = {}
+    for name, net_id in net_name_to_id.items():
+        if int(net_id) >= 0:
+            ids_by_key.setdefault(_norm_net_key(name), []).append(int(net_id))
+
+    required_by_pair: dict[tuple[int, int], float] = {}
+    max_by_net: dict[int, float] = {}
+    for (name_a, name_b), required in pairs.items():
+        if required <= 0.0:
+            continue
+        for id_a in ids_by_key.get(name_a, ()):
+            for id_b in ids_by_key.get(name_b, ()):
+                if id_a == id_b:
+                    continue
+                key = (id_a, id_b) if id_a < id_b else (id_b, id_a)
+                value = max(required_by_pair.get(key, 0.0), float(required))
+                required_by_pair[key] = value
+                max_by_net[id_a] = max(max_by_net.get(id_a, 0.0), value)
+                max_by_net[id_b] = max(max_by_net.get(id_b, 0.0), value)
+    if not required_by_pair:
+        return None
+
+    zones = tuple(
+        (x0, y0, x1, y1, frozenset(ids))
+        for x0, y0, x1, y1, ids in attach_zones_to_net_ids(attach_zones, net_name_to_id)
+    )
+    return LatticePairwise(
+        required_by_pair=required_by_pair,
+        zones=zones,
+        max_by_net=max_by_net,
+    )

--- a/src/kicad_tools/router/lattice/pathfinder.py
+++ b/src/kicad_tools/router/lattice/pathfinder.py
@@ -45,7 +45,7 @@ import math
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ..layers import LayerStack
 from ..primitives import Pad, Route, Segment, Via
@@ -55,6 +55,9 @@ from .coupled import CoupledConnection
 from .geometry import Pt, Rect, dist, pt_in_rect, seg_seg_dist
 from .obstacles import CommittedCopper, LatticeObstacleModel, seg_body_crosses_pt
 from .quadtree import EdgeKey, NodeKey, OctilinearLattice, RefineRegion
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .pairwise import LatticePairwise
 
 # A negotiation connection: (opaque hashable key, start pad, end pad, net_class)
 # -- the same shape as ``mesh.pathfinder.Connection``.
@@ -282,6 +285,23 @@ class LatticePathfinder:
         # net the net-class map put at 2.0-3.2 mm.
         self._fixed_runs: list[tuple[int, Pt, Pt, int, float, float]] = []
         self._fixed_vias: list[tuple[Pt, int, float]] = []
+        # Issue #4602: optional net-id-space HV pairwise projection
+        # (:class:`.pairwise.LatticePairwise`), resolved by the CALLER from
+        # ``rules.pairwise_clearance`` + the #4506 attach zones -- the
+        # pathfinder stays geometry-only and never sees net names (#4597
+        # discipline).  ``None`` (the default, and always the case without
+        # ``--voltage-map``) keeps every predicate on its scalar path
+        # byte-for-byte.
+        self._pairwise: LatticePairwise | None = None
+
+    def set_pairwise(self, pairwise: LatticePairwise | None) -> None:
+        """Install (or clear) the id-space HV pairwise projection (#4602).
+
+        Threaded into every fresh :class:`CommittedCopper` model and every
+        static pad keep-out probe.  Passing ``None`` resets a reused
+        pathfinder so it cannot carry a stale projection across runs.
+        """
+        self._pairwise = pairwise
 
     # -- construction from a board ----------------------------------------
 
@@ -395,6 +415,7 @@ class LatticePathfinder:
             via_radius=self.rules.via_diameter / 2.0,
             via_via_gap=self._via_via_gap,
             same_net_via_gap=self._same_net_via_gap,
+            pairwise=self._pairwise,
         )
         # Issue #4355: pre-seed immovable non-listed copper so EVERY fresh
         # model (per-pass negotiation, isolated stub/pair probes, and the
@@ -593,6 +614,10 @@ class LatticePathfinder:
                 pads_block_segment_grown,
             )
         extra = max(0.0, half + clr - self._agent_radius)
+        # Issue #4602: non-fat scans additionally honour the per-PAIR HV pad
+        # keep-outs (the fat coupled path is excluded from pairwise widening
+        # in this slice -- see ``coupled.committed_seg_clear_grown``).
+        pw = None if fat else self._pairwise
 
         candidates: list[tuple[float, NodeKey, Pt]] = []
         pad_pt = (pad.x, pad.y)
@@ -619,6 +644,10 @@ class LatticePathfinder:
                         continue
                     if extra > 0.0 and obstacles.segment_blocked(point, point, layer, net, extra):
                         continue
+                    if pw is not None and obstacles.pairwise_pad_blocked(
+                        point, point, layer, net, half, extra, pw
+                    ):
+                        continue
                     if not committed.node_clear(point, layer, net, half, clr):
                         continue
                 accepted: list[Pt] | None = None
@@ -639,6 +668,11 @@ class LatticePathfinder:
                                 break
                         else:
                             if obstacles.segment_blocked(a, b, layer, net, extra):
+                                ok = False
+                                break
+                            if pw is not None and obstacles.pairwise_pad_blocked(
+                                a, b, layer, net, half, extra, pw
+                            ):
                                 ok = False
                                 break
                             if not committed.seg_clear(a, b, layer, net, half, clr):
@@ -851,6 +885,19 @@ class LatticePathfinder:
             grown = (rect[0] - grow, rect[1] - grow, rect[2] + grow, rect[3] + grow)
             if pt_in_rect(point, grown):
                 return False
+        # Issue #4602: a through-via must additionally keep the PAIR (HV)
+        # requirement from foreign pads on every layer (``layer=None``) --
+        # the barrel exists on all of them.  Dormant when no projection.
+        if self._pairwise is not None and obstacles.pairwise_pad_blocked(
+            point,
+            point,
+            None,
+            net,
+            self.rules.via_diameter / 2.0,
+            max(self._via_pad_grow, 0.0),
+            self._pairwise,
+        ):
+            return False
         return committed.via_clear(point, net)
 
     # -- the route contract ------------------------------------------------------
@@ -1006,6 +1053,9 @@ class LatticePathfinder:
         extra = max(0.0, half + clr - self._agent_radius)
 
         fat = extra_clearance > 0.0 or partner_net is not None
+        # Issue #4602: per-PAIR HV pad keep-outs for the non-fat search (the
+        # fat coupled path is excluded from pairwise widening in this slice).
+        pw = None if fat else self._pairwise
         if fat:
             # v1 coupled runs are planar; there is no fat via legality.
             allow_vias = False
@@ -1118,6 +1168,12 @@ class LatticePathfinder:
                             and not (
                                 extra > 0.0 and obstacles.segment_blocked(ea, eb, layer, net, extra)
                             )
+                            and not (
+                                pw is not None
+                                and obstacles.pairwise_pad_blocked(
+                                    ea, eb, layer, net, half, extra, pw
+                                )
+                            )
                             and committed.seg_clear(ea, eb, layer, net, half, clr)
                         )
                     edge_ok[ek] = ok
@@ -1140,6 +1196,12 @@ class LatticePathfinder:
                             and not (
                                 extra > 0.0
                                 and obstacles.segment_blocked(npt, npt, layer, net, extra)
+                            )
+                            and not (
+                                pw is not None
+                                and obstacles.pairwise_pad_blocked(
+                                    npt, npt, layer, net, half, extra, pw
+                                )
                             )
                             and committed.node_clear(npt, layer, net, half, clr)
                         )
@@ -1174,6 +1236,12 @@ class LatticePathfinder:
                                 and not (
                                     extra > 0.0
                                     and obstacles.segment_blocked(kpt, kpt, nl, net, extra)
+                                )
+                                and not (
+                                    pw is not None
+                                    and obstacles.pairwise_pad_blocked(
+                                        kpt, kpt, nl, net, half, extra, pw
+                                    )
                                 )
                                 and committed.node_clear(kpt, nl, net, half, clr)
                             )

--- a/src/kicad_tools/router/pairwise_clearance.py
+++ b/src/kicad_tools/router/pairwise_clearance.py
@@ -413,9 +413,31 @@ def _segment_edge_gap(seg_a: Segment, seg_b: Segment) -> float:
 
 def _closest_gap_midpoint(seg_a: Segment, seg_b: Segment) -> tuple[float, float]:
     """Return the midpoint between the closest points on two line segments."""
-    ux, uy = seg_a.x2 - seg_a.x1, seg_a.y2 - seg_a.y1
-    vx, vy = seg_b.x2 - seg_b.x1, seg_b.y2 - seg_b.y1
-    wx, wy = seg_a.x1 - seg_b.x1, seg_a.y1 - seg_b.y1
+    return closest_gap_midpoint_xy(
+        seg_a.x1, seg_a.y1, seg_a.x2, seg_a.y2, seg_b.x1, seg_b.y1, seg_b.x2, seg_b.y2
+    )
+
+
+def closest_gap_midpoint_xy(
+    ax1: float,
+    ay1: float,
+    ax2: float,
+    ay2: float,
+    bx1: float,
+    by1: float,
+    bx2: float,
+    by2: float,
+) -> tuple[float, float]:
+    """Coordinate-level form of :func:`_closest_gap_midpoint` (issue #4602).
+
+    The lattice engine's search-time attach-zone exemption probes the SAME
+    closest-gap midpoint the post-route validator reports, so the in-search
+    verdict and the #4588 gate agree by construction.  The lattice works on
+    bare point tuples, hence this :class:`Segment`-free entry point.
+    """
+    ux, uy = ax2 - ax1, ay2 - ay1
+    vx, vy = bx2 - bx1, by2 - by1
+    wx, wy = ax1 - bx1, ay1 - by1
     a = ux * ux + uy * uy
     b = ux * vx + uy * vy
     c = vx * vx + vy * vy
@@ -423,15 +445,15 @@ def _closest_gap_midpoint(seg_a: Segment, seg_b: Segment) -> tuple[float, float]
     e = vx * wx + vy * wy
 
     if a <= 1e-15 and c <= 1e-15:
-        return ((seg_a.x1 + seg_b.x1) / 2.0, (seg_a.y1 + seg_b.y1) / 2.0)
+        return ((ax1 + bx1) / 2.0, (ay1 + by1) / 2.0)
     if a <= 1e-15:
         t = max(0.0, min(1.0, e / c))
-        closest_b = (seg_b.x1 + t * vx, seg_b.y1 + t * vy)
-        return ((seg_a.x1 + closest_b[0]) / 2.0, (seg_a.y1 + closest_b[1]) / 2.0)
+        closest_b = (bx1 + t * vx, by1 + t * vy)
+        return ((ax1 + closest_b[0]) / 2.0, (ay1 + closest_b[1]) / 2.0)
     if c <= 1e-15:
         s = max(0.0, min(1.0, -d / a))
-        closest_a = (seg_a.x1 + s * ux, seg_a.y1 + s * uy)
-        return ((closest_a[0] + seg_b.x1) / 2.0, (closest_a[1] + seg_b.y1) / 2.0)
+        closest_a = (ax1 + s * ux, ay1 + s * uy)
+        return ((closest_a[0] + bx1) / 2.0, (closest_a[1] + by1) / 2.0)
 
     denominator = a * c - b * b
     s_num, s_den = denominator, denominator
@@ -467,8 +489,8 @@ def _closest_gap_midpoint(seg_a: Segment, seg_b: Segment) -> tuple[float, float]
 
     s = 0.0 if abs(s_num) <= 1e-15 else s_num / s_den
     t = 0.0 if abs(t_num) <= 1e-15 else t_num / t_den
-    closest_a = (seg_a.x1 + s * ux, seg_a.y1 + s * uy)
-    closest_b = (seg_b.x1 + t * vx, seg_b.y1 + t * vy)
+    closest_a = (ax1 + s * ux, ay1 + s * uy)
+    closest_b = (bx1 + t * vx, by1 + t * vy)
     return ((closest_a[0] + closest_b[0]) / 2.0, (closest_a[1] + closest_b[1]) / 2.0)
 
 

--- a/tests/router/lattice/test_pairwise_avoidance.py
+++ b/tests/router/lattice/test_pairwise_avoidance.py
@@ -1,0 +1,257 @@
+"""Search-time HV pairwise clearance in the lattice engine (issue #4602).
+
+Predicate-level coverage of the net-id-space pairwise projection
+(:mod:`kicad_tools.router.lattice.pairwise`) and its consumption by
+:class:`~kicad_tools.router.lattice.obstacles.CommittedCopper` and the
+static pad keep-outs:
+
+1. a MAPPED pair's gap is ``own_half + stored_half + max(own_clr,
+   stored_clr, pairwise_required)`` -- the requirement depends on the pair;
+2. an UNMAPPED pair is byte-identical to the scalar path;
+3. a #4506 attach zone covering both nets waives the pairwise term (but
+   never the scalar term) at the predicate level;
+4. the spatial-query window inflates to the pairwise reach, so copper far
+   beyond the scalar window is still found (the #4511 search-radius trap);
+5. the per-pad pairwise keep-out blocks a mapped foreign pad at the
+   requirement and honours the zone exemption;
+6. the id-space projection builder resolves names/ids like the #4510 C++
+   projection and returns ``None`` in every dormant case.
+"""
+
+from __future__ import annotations
+
+from kicad_tools.router.lattice.obstacles import CommittedCopper, LatticeObstacleModel
+from kicad_tools.router.lattice.pairwise import LatticePairwise, build_lattice_pairwise
+from kicad_tools.router.lattice.quadtree import OctilinearLattice
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.pairwise_clearance import (
+    AttachZone,
+    build_pairwise_clearance_table,
+)
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import DesignRules
+
+RULES = DesignRules()  # trace_width 0.2, trace_clearance 0.2 (defaults)
+HALF = RULES.trace_width / 2.0
+CLR = RULES.trace_clearance
+REQ = 3.2  # 300 V / IEC 60664-1 / PD2 / IIIa derived requirement (mm)
+
+HV, LV, OTHER = 1, 2, 3
+
+
+def _projection(
+    zones: tuple[tuple[float, float, float, float, frozenset[int]], ...] = (),
+) -> LatticePairwise:
+    return LatticePairwise(
+        required_by_pair={(HV, LV): REQ},
+        zones=zones,
+        max_by_net={HV: REQ, LV: REQ},
+    )
+
+
+def _fresh(pairwise: LatticePairwise | None = None) -> CommittedCopper:
+    return CommittedCopper(
+        2,
+        trace_half=HALF,
+        clearance=CLR,
+        via_radius=RULES.via_diameter / 2.0,
+        via_via_gap=RULES.via_diameter + CLR,
+        same_net_via_gap=RULES.via_drill + RULES.min_hole_to_hole,
+        pairwise=pairwise,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1 + 2: pair gap = max(own, stored, pairwise); unmapped pairs unchanged.
+# ---------------------------------------------------------------------------
+
+
+def test_mapped_pair_gap_widens_to_the_pairwise_requirement() -> None:
+    committed = _fresh(_projection())
+    committed.add_run(0, [(0.0, 0.0), (20.0, 0.0)], net=HV, half_width=HALF)
+
+    pw_gap = HALF + HALF + REQ  # centreline gap for the mapped pair
+    # Inside the requirement (but far beyond the scalar gap): blocked.
+    y_inside = pw_gap - 0.1
+    assert not committed.seg_clear((0.0, y_inside), (20.0, y_inside), 0, LV, HALF, CLR)
+    assert not committed.node_clear((10.0, y_inside), 0, LV, HALF, CLR)
+    # Just beyond the requirement: clear.
+    y_outside = pw_gap + 0.05
+    assert committed.seg_clear((0.0, y_outside), (20.0, y_outside), 0, LV, HALF, CLR)
+    assert committed.node_clear((10.0, y_outside), 0, LV, HALF, CLR)
+
+
+def test_unmapped_pair_keeps_the_scalar_gap() -> None:
+    """A net with no pairwise mapping spaces exactly as the scalar path does."""
+    for pairwise in (None, _projection()):
+        committed = _fresh(pairwise)
+        committed.add_run(0, [(0.0, 0.0), (20.0, 0.0)], net=HV, half_width=HALF)
+        scalar_gap = HALF + HALF + CLR
+        # OTHER participates in no pair: legal just beyond the scalar gap,
+        # regardless of whether a projection is installed.
+        y = scalar_gap + 0.05
+        assert committed.seg_clear((0.0, y), (20.0, y), 0, OTHER, HALF, CLR)
+        assert committed.node_clear((10.0, y), 0, OTHER, HALF, CLR)
+        # And still blocked inside the scalar gap.
+        assert not committed.seg_clear((0.0, 0.1), (20.0, 0.1), 0, OTHER, HALF, CLR)
+
+
+def test_same_net_copper_is_never_pairwise_blocked() -> None:
+    committed = _fresh(_projection())
+    committed.add_run(0, [(0.0, 0.0), (20.0, 0.0)], net=HV, half_width=HALF)
+    assert committed.seg_clear((0.0, 0.5), (20.0, 0.5), 0, HV, HALF, CLR)
+
+
+# ---------------------------------------------------------------------------
+# 3: attach-zone exemption at the predicate level (#4506 semantics).
+# ---------------------------------------------------------------------------
+
+
+def test_attach_zone_waives_the_pairwise_term_but_not_the_scalar_term() -> None:
+    zone = (5.0, -5.0, 15.0, 5.0, frozenset({HV, LV}))
+    committed = _fresh(_projection(zones=(zone,)))
+    committed.add_run(0, [(5.0, 0.0), (15.0, 0.0)], net=HV, half_width=HALF)
+
+    # Scalar-passing but requirement-violating copper INSIDE the zone: waived
+    # (the closest-gap midpoint falls in the zone and both nets are members).
+    assert committed.seg_clear((5.0, 1.0), (15.0, 1.0), 0, LV, HALF, CLR)
+    # The scalar gap is NEVER waived by a zone.
+    assert not committed.seg_clear((5.0, 0.1), (15.0, 0.1), 0, LV, HALF, CLR)
+    # The same proximity OUTSIDE the zone still blocks.
+    committed.add_run(0, [(30.0, 0.0), (40.0, 0.0)], net=HV, half_width=HALF)
+    assert not committed.seg_clear((30.0, 1.0), (40.0, 1.0), 0, LV, HALF, CLR)
+
+
+def test_zone_covering_only_one_net_does_not_exempt() -> None:
+    zone = (5.0, -5.0, 15.0, 5.0, frozenset({HV, OTHER}))
+    committed = _fresh(_projection(zones=(zone,)))
+    committed.add_run(0, [(5.0, 0.0), (15.0, 0.0)], net=HV, half_width=HALF)
+    assert not committed.seg_clear((5.0, 1.0), (15.0, 1.0), 0, LV, HALF, CLR)
+
+
+# ---------------------------------------------------------------------------
+# 4: the search-radius trap -- far HV copper must still be found.
+# ---------------------------------------------------------------------------
+
+
+def test_spatial_window_inflates_to_the_pairwise_reach() -> None:
+    """Copper ~3 mm away is far beyond the scalar query window (own_half +
+    own_clr + 0.5 ~= 0.8 mm) yet inside the pairwise requirement; the inflated
+    window must surface it or the predicate silently passes (#4511 analog)."""
+    committed = _fresh(_projection())
+    committed.add_run(0, [(0.0, 0.0), (20.0, 0.0)], net=HV, half_width=HALF)
+    y = 3.0  # >> scalar window, < 3.2 requirement
+    assert not committed.seg_clear((0.0, y), (20.0, y), 0, LV, HALF, CLR)
+    assert not committed.node_clear((10.0, y), 0, LV, HALF, CLR)
+
+
+def test_via_predicates_honour_the_pairwise_requirement() -> None:
+    committed = _fresh(_projection())
+    committed.add_run(0, [(0.0, 0.0), (20.0, 0.0)], net=HV, half_width=HALF)
+    via_r = RULES.via_diameter / 2.0
+    # An LV via 3 mm from HV copper is inside the requirement: blocked.
+    assert not committed.via_clear((10.0, via_r + HALF + 3.0), LV)
+    # Beyond the requirement: clear.
+    assert committed.via_clear((10.0, via_r + HALF + REQ + 0.05), LV)
+    # And an LV trace near a committed HV via is symmetric.
+    committed2 = _fresh(_projection())
+    committed2.add_via((10.0, 0.0), HV)
+    assert not committed2.seg_clear((0.0, 3.0), (20.0, 3.0), 0, LV, HALF, CLR)
+    assert committed2.seg_clear(
+        (0.0, via_r + HALF + REQ + 0.05), (20.0, via_r + HALF + REQ + 0.05), 0, LV, HALF, CLR
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5: per-pad pairwise keep-out.
+# ---------------------------------------------------------------------------
+
+
+def _pad(x: float, y: float, net: int, net_name: str) -> Pad:
+    return Pad(
+        x=x,
+        y=y,
+        width=1.0,
+        height=1.0,
+        net=net,
+        net_name=net_name,
+        layer=Layer.F_CU,
+        ref=f"R{net}",
+        pin="1",
+    )
+
+
+def _obstacles(pads: list[Pad]) -> LatticeObstacleModel:
+    lattice = OctilinearLattice((0.0, 0.0, 40.0, 40.0), [], coarse=3.2)
+    return LatticeObstacleModel(
+        lattice,
+        pads,
+        [(0,) for _ in pads],
+        2,
+        agent_radius=HALF + CLR,
+    )
+
+
+def test_pairwise_pad_blocked_blocks_a_mapped_pad_at_the_requirement() -> None:
+    obstacles = _obstacles([_pad(20.0, 20.0, HV, "HV_LINE")])
+    pw = _projection()
+    # Segment passing 3 mm from the pad edge (pad half-extent 0.5): the rect
+    # is grown to 0.5 + own_half + 3.2, so a pass at y=23.5 (3.0 mm off the
+    # edge) is blocked while y=24.0 (3.5 mm off the edge... still inside
+    # 0.5+0.1+3.2=3.8 from centre) -- use centre distances explicitly.
+    grown_reach = 0.5 + HALF + REQ  # pad half-extent + own_half + requirement
+    y_block = 20.0 + grown_reach - 0.1
+    y_clear = 20.0 + grown_reach + 0.1
+    assert obstacles.pairwise_pad_blocked((0.0, y_block), (40.0, y_block), 0, LV, HALF, 0.0, pw)
+    assert not obstacles.pairwise_pad_blocked((0.0, y_clear), (40.0, y_clear), 0, LV, HALF, 0.0, pw)
+    # Unmapped querying net: never pairwise-blocked.
+    assert not obstacles.pairwise_pad_blocked(
+        (0.0, y_block), (40.0, y_block), 0, OTHER, HALF, 0.0, pw
+    )
+    # Wrong layer: the pad only occupies layer 0.
+    assert not obstacles.pairwise_pad_blocked((0.0, y_block), (40.0, y_block), 1, LV, HALF, 0.0, pw)
+    # ``layer=None`` (the through-via probe) checks every layer.
+    assert obstacles.pairwise_pad_blocked((0.0, y_block), (40.0, y_block), None, LV, HALF, 0.0, pw)
+
+
+def test_pairwise_pad_blocked_honours_the_attach_zone() -> None:
+    obstacles = _obstacles([_pad(20.0, 20.0, HV, "HV_LINE")])
+    zone = (15.0, 15.0, 25.0, 25.0, frozenset({HV, LV}))
+    pw = _projection(zones=(zone,))
+    y = 22.0  # inside the pairwise keep-out AND inside the zone
+    assert not obstacles.pairwise_pad_blocked((15.0, y), (25.0, y), 0, LV, HALF, 0.0, pw)
+
+
+# ---------------------------------------------------------------------------
+# 6: the id-space projection builder.
+# ---------------------------------------------------------------------------
+
+
+def test_build_lattice_pairwise_projects_names_to_ids() -> None:
+    table = build_pairwise_clearance_table({"/HV_LINE": 300.0, "/LV_SENSE": 0.0}, dru=CLR)
+    zones = (
+        AttachZone(10.0, 10.0, 20.0, 20.0, frozenset({"HV_LINE", "LV_SENSE"})),
+        # A single-resolvable-net zone cannot exempt any pair and is dropped.
+        AttachZone(0.0, 0.0, 5.0, 5.0, frozenset({"HV_LINE", "ABSENT"})),
+    )
+    pw = build_lattice_pairwise(table, zones, {"/HV_LINE": HV, "/LV_SENSE": LV})
+    assert pw is not None
+    assert pw.required(HV, LV) == pw.required(LV, HV) == 3.2
+    assert pw.required(HV, OTHER) == 0.0
+    assert pw.max_required_for(HV) == pw.max_required_for(LV) == 3.2
+    assert pw.max_required_for(OTHER) == 0.0
+    assert len(pw.zones) == 1
+    assert pw.exempt(15.0, 15.0, HV, LV)
+    assert not pw.exempt(15.0, 15.0, HV, OTHER)
+    assert not pw.exempt(50.0, 50.0, HV, LV)
+
+
+def test_build_lattice_pairwise_dormant_cases_return_none() -> None:
+    table = build_pairwise_clearance_table({"/HV_LINE": 300.0, "/LV_SENSE": 0.0}, dru=CLR)
+    # No table at all.
+    assert build_lattice_pairwise(None, (), {"/HV_LINE": HV}) is None
+    # No net above the HV threshold -> empty matrix.
+    low = build_pairwise_clearance_table({"/A": 3.3, "/B": 0.0}, dru=CLR)
+    assert build_lattice_pairwise(low, (), {"/A": 1, "/B": 2}) is None
+    # A mapped pair whose nets do not resolve to board net ids.
+    assert build_lattice_pairwise(table, (), {"/UNRELATED": 7}) is None

--- a/tests/router/test_lattice_fixed_clearance_4597.py
+++ b/tests/router/test_lattice_fixed_clearance_4597.py
@@ -38,6 +38,9 @@ class _CapturingPathfinder:
         self.kwargs: dict[str, Any] = {}
         self.failure_reasons: dict[object, str] = {}
 
+    def set_pairwise(self, pairwise: Any) -> None:
+        """No-op stand-in for ``LatticePathfinder.set_pairwise`` (#4602)."""
+
     def route_netset(self, connections: list[Any], **kwargs: Any) -> tuple[dict, Any]:
         self.kwargs = kwargs
         return {}, SimpleNamespace(

--- a/tests/router/test_lattice_kelvin_anchor.py
+++ b/tests/router/test_lattice_kelvin_anchor.py
@@ -83,6 +83,9 @@ class _StubPathfinder:
         self.connections: list[tuple[object, Pad, Pad, object]] = []
         self.failure_reasons: dict[object, str] = {}
 
+    def set_pairwise(self, pairwise: Any) -> None:
+        """No-op stand-in for ``LatticePathfinder.set_pairwise`` (#4602)."""
+
     def route_netset(self, connections: list[Any], **_kwargs: Any) -> tuple[dict, Any]:
         self.connections = list(connections)
         return {}, SimpleNamespace(

--- a/tests/test_route_pairwise_gate_4588.py
+++ b/tests/test_route_pairwise_gate_4588.py
@@ -13,10 +13,14 @@ feature on a mains board.
 The gate is a post-route, board-level audit of the copper the engine actually
 committed (``router.routes``), so it is engine-agnostic.  These tests pin:
 
-1. lattice + ``--voltage-map`` + planted HV/LV proximity -> non-zero exit,
-   ``ROUTING FAILED`` banner, no ``SUCCESS`` banner;
+1. lattice + ``--voltage-map`` + planted HV/LV proximity the search cannot
+   route around (pads pinned inside the requirement) -> non-zero exit, no
+   ``SUCCESS`` banner.  Since issue #4602 the lattice search *avoids* HV<->LV
+   proximity at route time, so the tight fixture now fails as an honest
+   in-search decline (``pad-escape``) rather than as committed-then-gated
+   copper -- either way, never a silent false pass;
 2. the identical board **without** ``--voltage-map`` -> gate is a strict no-op
-   (exit 0, ``SUCCESS``, byte-identical copper);
+   (exit 0, ``SUCCESS``);
 3. grid + ``--voltage-map`` on a board with no HV/LV proximity -> still exit 0
    (the gate is not a false-positive source on the production default);
 4. a board whose only HV/LV proximity is inside a **rated domain-bridging
@@ -24,7 +28,10 @@ committed (``router.routes``), so it is engine-agnostic.  These tests pin:
    footprint positions board-relative while ``router.routes`` are
    sheet-absolute, so an unshifted attach zone silently misses on every board
    that does not sit at sheet origin -- i.e. on every real board -- turning
-   this gate into a hard false fail.
+   this gate into a hard false fail;
+5. (issue #4602) a two-domain board where a compliant detour EXISTS -> the
+   lattice search takes it and the run passes the gate with exit 0, instead
+   of committing the naive proximate path and hard-failing.
 
 Boards are fully synthetic S-expression strings (same approach as
 ``test_route_offboard_gate.py``) -- the softstart rev-C board from the original
@@ -159,6 +166,56 @@ def _bridging_board(origin_x: float, origin_y: float) -> str:
 """
 
 
+def _detour_board() -> str:
+    """Two-domain board with a compliant detour available (issue #4602).
+
+    The HV link is a short horizontal run in the board centre; the LV link is
+    a vertical run whose NAIVE shortest path crosses straight through the HV
+    corridor.  Every pad-to-pad gap is 10 mm -- well beyond the 3.2 mm derived
+    requirement (300 V / IEC 60664-1 / PD2 / IIIa) -- so, unlike
+    ``_two_domain_board(0.6)``, avoidance CAN produce compliant copper: a
+    planar detour west/east of the HV corridor and a B.Cu under-crossing both
+    exist with margin.
+
+    Pre-#4602 behaviour (verified on ``main`` @ ``08776b3d``): the lattice
+    search jogged around the HV pad at scalar-DRU spacing and the #4588
+    post-route gate fired with 3 trace-to-trace findings (0.600 / 2.200 /
+    3.000 mm against the 3.200 mm requirement), exit 3.  This fixture is the
+    pass-oracle showing the search now avoids what the gate would report.
+    """
+    parts = [
+        _fp("R1", 10, 112.0, 112.0, _pad("1", 0, 0, 1, "/HV_LINE")),
+        _fp("R2", 11, 118.0, 112.0, _pad("1", 0, 0, 1, "/HV_LINE")),
+        _fp("R3", 12, 112.0, 102.0, _pad("1", 0, 0, 2, "/LV_SENSE")),
+        _fp("R4", 13, 112.0, 122.0, _pad("1", 0, 0, 2, "/LV_SENSE")),
+    ]
+    return f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general
+    (thickness 1.6)
+  )
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup
+    (pad_to_mask_clearance 0)
+  )
+  (net 0 "")
+  (net 1 "/HV_LINE")
+  (net 2 "/LV_SENSE")
+  (gr_rect (start 100 100) (end 130 124)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+{"".join(parts)})
+"""
+
+
 def _strip_uuids(text: str) -> str:
     """Drop the freshly-generated per-element ``uuid`` lines from a board."""
     return re.sub(r'\(uuid "[^"]*"\)', "(uuid)", text)
@@ -216,37 +273,45 @@ def wide_board(tmp_path: Path) -> Path:
 class TestLatticeGate:
     """The engine that had zero pairwise awareness must no longer false-pass."""
 
-    def test_lattice_with_voltage_map_fails_on_hv_proximity(
+    def test_lattice_with_voltage_map_declines_hv_proximity_in_search(
         self, tight_board: Path, tmp_path: Path, capsys
     ) -> None:
+        """The tight fixture stays an honest FAILURE -- now declined in-search.
+
+        ``_two_domain_board(0.6)`` pins the HV and LV *pads* 0.6 mm apart --
+        inside the 3.2 mm derived requirement -- so no routing outcome can
+        produce compliant copper here.  Pre-#4602 the search committed the
+        proximate copper and the post-route gate fired; with search-time
+        avoidance (#4602) the pairwise pad keep-outs block every escape stub
+        and the connections decline honestly instead.  Either way: non-zero
+        exit, no SUCCESS banner, never a silent false pass.
+        """
         vmap = _write_voltage_map(tmp_path)
         out = tmp_path / "tight_routed.kicad_pcb"
         rc = route_main(_route_args(tight_board, out, "lattice", vmap))
         captured = capsys.readouterr().out
 
         assert rc != 0, f"expected a non-zero exit, got {rc}\n{captured}"
-        assert "ROUTING FAILED" in captured
-        assert "pairwise HV clearance violations" in captured
         # The SUCCESS banner must be unreachable in this state.
         assert "SUCCESS:" not in captured
-        # Violation lines carry the census-diffable shape and name the census.
-        assert "/HV_LINE vs /LV_SENSE:" in captured or "/LV_SENSE vs /HV_LINE:" in captured
-        assert "(required " in captured
-        assert "kct creepage" in captured
-        # The failure must name the actual cause and an in-tool remedy rather
-        # than leaving the operator with a dead end (follow-up #4602).
-        assert "issue #4602" in captured
-        assert "--route-engine grid" in captured
+        # The search now declines the geometry instead of committing it: the
+        # lattice decline census names the pad-escape refusal (the pads sit
+        # inside each other's pairwise keep-out).
+        assert "decline[pad-escape" in captured
+        # And the copper that WAS committed (if any) still passed the gate --
+        # a gate hit here would mean avoidance leaked proximate copper.
+        assert "pairwise HV clearance violations" not in captured
 
-    def test_engagement_line_does_not_claim_route_time_enforcement_on_lattice(
+    def test_engagement_line_reports_route_time_enforcement_on_lattice(
         self, tight_board: Path, tmp_path: Path, capsys
     ) -> None:
         """The pre-route ``HV pairwise clearance:`` line must be engine-honest.
 
-        The original defect was *silence*: the run printed ``(route-time
-        creepage rejection active)`` on an engine whose search never reads
-        ``rules.pairwise_clearance``.  That reassurance is what made the false
-        pass invisible, so it must not survive on the non-grid engines.
+        The original #4588 defect was *reassurance*: the run printed
+        ``(route-time creepage rejection active)`` on an engine whose search
+        never read ``rules.pairwise_clearance``.  Since #4602 the lattice
+        search DOES consume the table (per-pair predicate widening + HV pad
+        keep-outs), so it now truthfully joins the grid branch.
         """
         vmap = _write_voltage_map(tmp_path)
         out = tmp_path / "engagement.kicad_pcb"
@@ -254,8 +319,35 @@ class TestLatticeGate:
         captured = capsys.readouterr().out
 
         assert "HV pairwise clearance:" in captured
-        assert "post-route audit only" in captured
-        assert "route-time creepage rejection active" not in captured
+        assert "route-time rejection + post-route audit" in captured
+        assert "post-route audit only" not in captured
+
+    def test_engagement_line_keeps_audit_only_wording_on_mesh(self, capsys) -> None:
+        """Mesh is still pairwise-blind (#4602 scoped lattice only) and must
+        keep the audit-only wording -- claiming route-time enforcement there
+        would recreate the reassuring line that made the false pass silent.
+
+        Exercised through ``_apply_pairwise_clearance`` directly (the helper
+        that prints the line) rather than a full mesh routing run.
+        """
+        from types import SimpleNamespace
+
+        from kicad_tools.cli.route_cmd import _apply_pairwise_clearance
+
+        router = SimpleNamespace(
+            rules=SimpleNamespace(trace_clearance=0.2, pairwise_clearance=None)
+        )
+        args = SimpleNamespace(
+            _pairwise_required={("HV_LINE", "LV_SENSE"): 3.2},
+            _pairwise_voltages={"HV_LINE": HV_VOLTS, "LV_SENSE": 0.0},
+            route_engine="mesh",
+        )
+        _apply_pairwise_clearance(router, args)
+        captured = capsys.readouterr().out
+
+        assert "HV pairwise clearance:" in captured
+        assert "post-route audit only -- the mesh search is pairwise-blind" in captured
+        assert "route-time rejection" not in captured
 
     def test_engagement_line_still_reports_route_time_rejection_on_grid(
         self, wide_board: Path, tmp_path: Path, capsys
@@ -281,22 +373,75 @@ class TestLatticeGate:
         assert "SUCCESS:" in captured
         assert "pairwise HV clearance violations" not in captured
 
-    def test_gate_is_copper_identical_to_the_ungated_run(
-        self, tight_board: Path, tmp_path: Path
+    def test_copper_identical_when_no_hv_proximity_is_at_stake(
+        self, wide_board: Path, tmp_path: Path
     ) -> None:
-        """The gate audits, it never edits: same copper with and without the flag.
+        """Same copper with and without the flag when nothing needs avoiding.
 
-        The exit code differs -- that is the whole point -- but the copper
-        written to disk must be identical, proving the gate is a pure read-only
-        audit rather than a router behaviour change.  Per-element ``uuid``
-        values are freshly generated on every write and are compared out.
+        Pre-#4602 this invariant held on the TIGHT board too (the gate was a
+        pure read-only audit); with search-time avoidance the flag now
+        legitimately CHANGES the copper wherever HV<->LV proximity must be
+        avoided -- that is the whole point.  The invariant that must survive
+        is dormancy: on a board whose corridors already clear the requirement
+        by a wide margin, the pairwise-aware search takes the identical routes,
+        so the ``--voltage-map`` run's copper is byte-identical to the plain
+        run's.  Per-element ``uuid`` values are freshly generated on every
+        write and are compared out.
         """
         vmap = _write_voltage_map(tmp_path)
         gated = tmp_path / "gated.kicad_pcb"
         ungated = tmp_path / "ungated.kicad_pcb"
-        route_main(_route_args(tight_board, gated, "lattice", vmap))
-        route_main(_route_args(tight_board, ungated, "lattice", None))
+        route_main(_route_args(wide_board, gated, "lattice", vmap))
+        route_main(_route_args(wide_board, ungated, "lattice", None))
         assert _strip_uuids(gated.read_text()) == _strip_uuids(ungated.read_text())
+
+
+class TestLatticeAvoidance:
+    """Issue #4602 pass-oracle: the lattice search avoids what the gate reports.
+
+    On ``_detour_board()`` every pad-to-pad gap (10 mm) exceeds the 3.2 mm
+    derived requirement, but the LV net's naive shortest path runs straight
+    through the HV corridor.  Pre-#4602 (verified on ``main`` @ ``08776b3d``)
+    the lattice committed that path and the #4588 gate hard-failed the run
+    (exit 3, findings at 0.600 / 2.200 / 3.000 mm vs required 3.200 mm).  With
+    search-time avoidance the LV route detours (or under-crosses on B.Cu) and
+    the run passes the very same gate.
+    """
+
+    def test_detour_board_routes_clean_with_voltage_map(self, tmp_path: Path, capsys) -> None:
+        pcb = tmp_path / "detour.kicad_pcb"
+        pcb.write_text(_detour_board())
+        vmap = _write_voltage_map(tmp_path)
+        out = tmp_path / "detour_routed.kicad_pcb"
+
+        rc = route_main(_route_args(pcb, out, "lattice", vmap))
+        captured = capsys.readouterr().out
+
+        assert rc == 0, f"expected exit 0, got {rc}\n{captured}"
+        assert "SUCCESS:" in captured
+        assert "Nets routed:     2/2" in captured
+        # Zero findings from the #4588 post-route gate -- the pass oracle.
+        assert "pairwise HV clearance violations" not in captured
+        assert "ROUTING FAILED" not in captured
+        # The run banner reports route-time enforcement (#4602).
+        assert "route-time rejection + post-route audit" in captured
+
+    def test_detour_board_without_voltage_map_takes_the_naive_path(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """Dormancy control: without the flag the board still routes (exit 0)
+        and no pairwise machinery engages -- the detour is a consequence of
+        the voltage map, not a general routing behaviour change."""
+        pcb = tmp_path / "detour_plain.kicad_pcb"
+        pcb.write_text(_detour_board())
+        out = tmp_path / "detour_plain_routed.kicad_pcb"
+
+        rc = route_main(_route_args(pcb, out, "lattice", None))
+        captured = capsys.readouterr().out
+
+        assert rc == 0, captured
+        assert "SUCCESS:" in captured
+        assert "HV pairwise clearance:" not in captured
 
 
 class TestNonEscalationPath:
@@ -307,9 +452,15 @@ class TestNonEscalationPath:
     with ``--no-auto-layers``.  Both terminal paths must gate.
     """
 
-    def test_inline_path_gates_on_hv_proximity(
+    def test_inline_path_fails_on_hv_proximity(
         self, tight_board: Path, tmp_path: Path, capsys
     ) -> None:
+        """Both terminal paths stay honest failures on the tight fixture.
+
+        Since #4602 the lattice search declines the geometry in-search (the
+        pads sit inside each other's pairwise keep-out), so the inline path
+        exits non-zero on incomplete routing rather than on the gate banner.
+        """
         vmap = _write_voltage_map(tmp_path)
         out = tmp_path / "inline_routed.kicad_pcb"
         rc = route_main(
@@ -318,7 +469,7 @@ class TestNonEscalationPath:
         captured = capsys.readouterr().out
 
         assert rc != 0, f"expected a non-zero exit, got {rc}\n{captured}"
-        assert "ROUTING FAILED: pairwise HV clearance violations" in captured
+        assert "decline[pad-escape" in captured
         assert "SUCCESS:" not in captured
 
     def test_inline_path_without_voltage_map_is_a_strict_noop(

--- a/tests/test_router_cache.py
+++ b/tests/test_router_cache.py
@@ -130,6 +130,101 @@ class TestCacheKey:
         assert key1.version != key2.version
         assert key1.full_key != key2.full_key
 
+    def test_dormant_pairwise_key_byte_identical(self):
+        """Dormant pairwise (``pairwise_clearance is None``) keys are unchanged.
+
+        Issue #4602 keys the cache on the HV pairwise matrix.  Scalar users
+        (no ``--voltage-map``) must keep their pre-existing cache entries, so
+        with ``rules.pairwise_clearance is None`` the serialized rules payload
+        must gain NO pairwise component -- the hash must match the pre-#4602
+        serialization byte-for-byte.  An empty table is equally dormant.
+        """
+        import hashlib
+        import json
+
+        from kicad_tools.router.pairwise_clearance import PairwiseClearanceTable
+
+        pcb_content = "(kicad_pcb (test))"
+        rules = DesignRules(trace_width=0.2, trace_clearance=0.15)
+        assert rules.pairwise_clearance is None
+
+        key = CacheKey.compute(pcb_content, rules, 0.1)
+
+        # Reconstruct the pre-#4602 scalar-only serialization by hand.
+        legacy_rules_data = {
+            "trace_width": rules.trace_width,
+            "trace_clearance": rules.trace_clearance,
+            "via_drill": rules.via_drill,
+            "via_diameter": rules.via_diameter,
+            "via_clearance": rules.via_clearance,
+            "grid_resolution": 0.1,
+            "preferred_layer": rules.preferred_layer.value,
+            "alternate_layer": rules.alternate_layer.value,
+        }
+        legacy_hash = hashlib.sha256(
+            json.dumps(legacy_rules_data, sort_keys=True).encode()
+        ).hexdigest()
+        assert key.rules_hash == legacy_hash
+
+        # An empty pairwise table (no HV pairs) is dormant too.
+        rules.pairwise_clearance = PairwiseClearanceTable(
+            dru=0.15, net_voltages={}, required_by_pair={}
+        )
+        key_empty = CacheKey.compute(pcb_content, rules, 0.1)
+        assert key_empty.full_key == key.full_key
+
+    def test_pairwise_key_component_deterministic_and_distinct(self):
+        """The pairwise key component is deterministic and changes the key.
+
+        Issue #4602: (a) a populated pairwise table must produce a DIFFERENT
+        key from the scalar (None) case -- the original bug was a scalar
+        cache entry served to a ``--voltage-map`` run; (b) the component is
+        sorted, so tables built with different mapping insertion orders (and
+        repeated builds) hash identically.
+        """
+        from kicad_tools.router.pairwise_clearance import PairwiseClearanceTable
+
+        pcb_content = "(kicad_pcb (test))"
+        rules = DesignRules(trace_width=0.2, trace_clearance=0.15)
+        key_scalar = CacheKey.compute(pcb_content, rules, 0.1)
+
+        pairs = {
+            ("HV_BUS", "SENSE"): 1.25,
+            ("GND", "HV_BUS"): 0.8,
+            ("HV_BUS", "LV_RAIL"): 0.6,
+        }
+        rules.pairwise_clearance = PairwiseClearanceTable(
+            dru=0.15, net_voltages={"HV_BUS": 400.0}, required_by_pair=dict(pairs)
+        )
+        key_pw = CacheKey.compute(pcb_content, rules, 0.1)
+
+        # (a) The pairwise matrix keys the cache.
+        assert key_pw.rules_hash != key_scalar.rules_hash
+        assert key_pw.full_key != key_scalar.full_key
+
+        # (b) Insertion order of the mapping must not matter, and repeated
+        # builds are byte-identical.
+        reversed_pairs = dict(reversed(list(pairs.items())))
+        rules.pairwise_clearance = PairwiseClearanceTable(
+            dru=0.15,
+            net_voltages={"HV_BUS": 400.0},
+            required_by_pair=reversed_pairs,
+        )
+        key_pw_reordered = CacheKey.compute(pcb_content, rules, 0.1)
+        assert key_pw_reordered.full_key == key_pw.full_key
+
+        key_pw_repeat = CacheKey.compute(pcb_content, rules, 0.1)
+        assert key_pw_repeat.full_key == key_pw_reordered.full_key
+
+        # A different requirement value is a different key.
+        rules.pairwise_clearance = PairwiseClearanceTable(
+            dru=0.15,
+            net_voltages={"HV_BUS": 400.0},
+            required_by_pair={**pairs, ("HV_BUS", "SENSE"): 1.5},
+        )
+        key_pw_changed = CacheKey.compute(pcb_content, rules, 0.1)
+        assert key_pw_changed.full_key != key_pw.full_key
+
 
 class TestRoutingCache:
     """Tests for RoutingCache class."""


### PR DESCRIPTION
## Summary

Teaches the **lattice engine** the pairwise (|ΔV|-derived) HV clearance model so HV↔LV proximity is **avoided during the A\* search** instead of only being reported by the #4588 post-route gate. Lattice-only slice per the curated scope; the **mesh engine stays post-route-gated only** (no mesh code changes, wording preserved).

Closes #4602

## Design

- **Id-space projection, resolved by the caller** (`router/lattice/pairwise.py`, new): `Autorouter._lattice_pairwise_projection()` projects the name-keyed `rules.pairwise_clearance` table + the #4506 attach zones into a flat `LatticePairwise` carrier (`{(lo_id, hi_id): required_mm}`, id-keyed zones, per-net max-requirement map), mirroring the #4510 `build_cpp_domain_matrix` / `attach_zones_to_net_ids` precedent. The pathfinder stays geometry-only and never sees net names (#4597 discipline). Installed via `LatticePathfinder.set_pairwise(...)`; `None` resets a reused pathfinder.
- **Pair-predicate resolution, never a widened scalar**: `CommittedCopper.seg_clear` / `node_clear` / `via_clear` widen their gap to `own_half + stored_half + max(own_clr, stored_clr, pairwise(query, stored))` — `_conn_geometry` is untouched, so LV↔LV spacing is never forced to HV↔LV distances (the #4431 documented anti-pattern).
- **Search-radius trap (#4511 analog)**: every spatial query window (SegHash pads, `pads_near` boxes, `via_clear` window) inflates by `max_required_for(net)` — only for nets that participate in a pair; unmapped nets keep the fast scalar window.
- **Per-pad HV keep-outs**: new `LatticeObstacleModel.pairwise_pad_blocked` (per-pad, per-pair rect inflation; `layer=None` form for the through-via probe) threaded into stub scans, A\* edge/node legality, and `_via_ok`.
- **#4506 attach zones honoured in-search**: exemption probes the same closest-gap midpoint `segment_pair_violation` reports (`closest_gap_midpoint_xy` extracted from `pairwise_clearance.py`), so the search verdict and the gate agree by construction. Zones are reused from `_pairwise_attach_zones`' resolver output (sheet-absolute per PR #4603) — `_apply_pairwise_clearance` now warms the router-side memo so the lattice picks them up at negotiation time; never rebuilt.
- **Routing-cache fix (necessary for the ACs)**: `CacheKey` previously ignored the pairwise table, so a scalar run's cache entry was served to a `--voltage-map` run (observed live during development: a cache HIT bypassed route-time avoidance entirely — this also affected the grid engine's #4454/#4511 enforcement). The derived matrix now keys the cache; the dormant key is byte-identical.
- **Coupled fat envelopes deliberately excluded** (documented in `coupled.py`): an engaged diff pair is same-domain by construction; the emitted legs remain covered by pairwise-aware `seg_clear` re-verification plus the post-route audit.
- **Engagement/banner honesty**: lattice joins the `route-time rejection + post-route audit` branch; mesh keeps `post-route audit only`; the gate-failure remedy paragraph now prints only for engines that are still pairwise-blind (mesh).

## Acceptance criteria

- **Avoidance pass-oracle**: new `_detour_board()` fixture (every pad-pad gap 10 mm > the 3.2 mm requirement; the LV naive shortest path crosses the HV corridor; west/east planar detours and a B.Cu under-crossing exist). Verified failing on pre-change `main` @ `08776b3d` (exit 3, gate findings 0.600/2.200/3.000 mm vs required 3.200 mm — documented in the fixture docstring); now routes 2/2, exit 0, `SUCCESS`, zero gate findings, route-time banner (`TestLatticeAvoidance`).
- **Tight fixture stays an honest failure**: `_two_domain_board(0.6)` pins the pads inside the requirement, so both connections now decline in-search (`decline[pad-escape-start]`), exit non-zero, no `SUCCESS` — assertions updated for the new failure shape as the curated AC allows.
- **Byte-identical when dormant**: every new lookup is behind `pairwise is None`; `test_lattice_without_voltage_map_is_a_strict_noop` and both inline no-op tests pass unmodified. `test_gate_is_copper_identical_to_the_ungated_run` **could not** survive unmodified — with search-time avoidance the flag legitimately changes copper on the tight board (that is the feature) — so it was repurposed to the wide board, where flag-on/flag-off copper is asserted byte-identical (dormancy-in-effect).
- **Attach zones honoured in-search**: `TestAttachZoneExemptionCoordinateSpace` (bridging footprint, all three board origins, lattice + grid) passes unmodified.
- **Mesh documented as post-route-gated only**: audit-only wording preserved for mesh + new `test_engagement_line_keeps_audit_only_wording_on_mesh`; no mesh code changes.
- **Predicate-level unit tests**: `tests/router/lattice/test_pairwise_avoidance.py` — mapped-pair gap, unmapped pair unchanged, zone exemption (waives pairwise, never scalar), spatial-window inflation (far copper at 3.0 mm found), via predicates, per-pad keep-out (+ layer=None + zone), projection builder + dormant-`None` cases.
- **Board-03 drift guard**: no new check/DRC rule ids introduced; `EXPECTED_COMMITTED_DRC_RULES` untouched.

## Test results

| Suite | Result |
|---|---|
| `tests/test_route_pairwise_gate_4588.py` | 25 passed |
| `tests/router/lattice/` (incl. new `test_pairwise_avoidance.py`) | 168 passed, 2 skipped |
| `tests/router/test_pairwise_clearance.py` + `test_pairwise_cpp_parity.py` | passed |
| `tests/test_router_cache.py` | passed |
| `tests/test_route_exit_codes.py`, `test_pipeline_cli_args.py`, `test_placement_hv_domains.py` | 126 passed |
| `tests/test_pipeline_cmd.py`, `test_build_cmd_errors.py` | 343 passed |
| `ruff check` / `ruff format --check` | clean |
| `scripts/ci/check_mypy_baseline.py` | OK — no new errors (the "1 stale baseline entry" local warning is the known nanobind native-env artifact; baseline deliberately untouched) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
