### PR TITLE
feat(check): schematic field-geometry lint — sch_fields category (sch_field_offset / sch_field_overlap) (#4595)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ constructor). No breaking changes.
 
 ### Added
 
+- **`kct check` schematic field-geometry lint (`sch_fields`)** — new
+  warning-severity check category with two rules: `sch_field_offset` flags a
+  visible `Reference`/`Value` field farther than a threshold (default 15 mm,
+  `--sch-field-threshold`) from its symbol's placed body bbox, and
+  `sch_field_overlap` flags a field's estimated text bbox colliding with
+  another symbol's body or another symbol's visible field (the superimposed
+  `+3.3VA9`-style composites). Runs on the same resolved schematic ERC/LVS
+  use (explicit `--schematic` or sibling discovery), recurses into
+  hierarchical sub-sheets, and shares the exact `field_geometry` metric that
+  `kct sch tidy` fixes — lint reports it, tidy repairs it. Both rules are
+  advisory (`advisory-quality` bucket), never raise the error count, and
+  never block `kct build`/`kct pipeline` fab gates; under `--strict` they
+  become fatal by the pre-existing global warnings contract. Findings are
+  deterministically sorted for CI. Skipped entirely under `--drc-only`.
+  (#4595)
+
 - **Search-time HV pairwise clearance in the lattice engine** — `--voltage-map`
   + `--route-engine lattice` now *avoids* HV↔LV proximity during the A\* search
   instead of only failing the #4588 post-route gate after committing the

--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -41,6 +41,7 @@ from kicad_tools.schema.pcb import PCB
 from kicad_tools.sidecars import net_class_map_sidecar_candidates
 from kicad_tools.sync.discover import resolve_target_fab_for_pcb
 from kicad_tools.validate import DRCChecker, DRCResults, DRCViolation
+from kicad_tools.validate.rules.schematic_fields import DEFAULT_SCH_FIELD_THRESHOLD_MM
 
 # Issue #3750: meta-check status set.  ``NOT RUN`` is rendered with a space
 # in human output and ``"NOT RUN"`` in JSON; we treat it as a single token
@@ -905,6 +906,25 @@ def _manifest_subcheck(pcb_path: Path) -> SubCheckResult:
     )
 
 
+def _resolve_check_schematic(schematic: str | None, pcb_path: Path) -> Path | None:
+    """Resolve the schematic used by schematic-aware checks.
+
+    Shared by the meta sub-checks (ERC/LVS, issue #3750) and the
+    ``sch_fields`` lint category (issue #4595) so both consume the exact
+    same resolution: an explicit ``--schematic`` override wins (a missing
+    override path resolves to ``None``), otherwise sibling discovery via
+    :func:`kicad_tools.sync.discover.resolve_schematic_for_pcb` (which
+    handles ``project.kct artifacts.schematic`` and the ``_routed``-style
+    stage-suffix strip).
+    """
+    from kicad_tools.sync.discover import resolve_schematic_for_pcb
+
+    if schematic is not None:
+        candidate = Path(schematic).resolve()
+        return candidate if candidate.exists() else None
+    return resolve_schematic_for_pcb(pcb_path)
+
+
 def run_meta_checks(
     pcb_path: Path,
     drc_status: SubCheckResult,
@@ -933,14 +953,7 @@ def run_meta_checks(
             ``INCOMPLETE`` exits non-zero (the new default) or 0 (with
             ``--allow-incomplete``).
     """
-    from kicad_tools.sync.discover import resolve_schematic_for_pcb
-
-    resolved_sch: Path | None
-    if schematic is not None:
-        candidate = Path(schematic).resolve()
-        resolved_sch = candidate if candidate.exists() else None
-    else:
-        resolved_sch = resolve_schematic_for_pcb(pcb_path)
+    resolved_sch = _resolve_check_schematic(schematic, pcb_path)
 
     erc = _erc_subcheck(resolved_sch, strict)
     lvs = _lvs_subcheck(resolved_sch, pcb_path)
@@ -1099,6 +1112,7 @@ CHECK_CATEGORIES = [
     "netlist",
     "pad_grid",
     "placement",
+    "sch_fields",
     "silkscreen",
     "single_pad_net",
     "solder_mask",
@@ -1465,6 +1479,21 @@ def main(argv: list[str] | None = None) -> int:
             "Override the pad_grid L2 tolerance with an explicit value "
             "in mm (e.g. ``--pad-grid-tolerance 0.02``).  Disables "
             "auto-derivation."
+        ),
+    )
+    # Issue #4595: sch_fields schematic field-geometry lint threshold.
+    parser.add_argument(
+        "--sch-field-threshold",
+        dest="sch_field_threshold",
+        type=float,
+        default=DEFAULT_SCH_FIELD_THRESHOLD_MM,
+        metavar="MM",
+        help=(
+            "Distance in mm beyond which the sch_fields lint flags a "
+            "visible Reference/Value field as adrift from its symbol body "
+            f"(default {DEFAULT_SCH_FIELD_THRESHOLD_MM}, warning severity "
+            "only; issue #4595).  Fixed threshold -- an adaptive "
+            "per-sheet-median variant is deferred."
         ),
     )
 
@@ -1923,6 +1952,23 @@ def main(argv: list[str] | None = None) -> int:
         pad_grid_threshold = None
         pad_grid_auto_derive = True
 
+    # Issue #4595: resolve the schematic for the sch_fields lint category,
+    # via the exact resolution ERC/LVS use (explicit --schematic override,
+    # else sibling discovery).  Resolution is skipped -- and the category is
+    # therefore a silent no-op -- when the category is deselected, or under
+    # --drc-only (which pins the legacy PCB-only stdout/exit contract, so
+    # schematic-sourced findings must not appear there; documented decision).
+    # No schematic resolved => the closure emits nothing and never fails
+    # (the #4350 loud missing-schematic stderr warning covers visibility).
+    sch_fields_active = (
+        (only_set is None or "sch_fields" in only_set)
+        and "sch_fields" not in skip_set
+        and not getattr(args, "drc_only", False)
+    )
+    sch_path: Path | None = None
+    if sch_fields_active:
+        sch_path = _resolve_check_schematic(getattr(args, "schematic", None), pcb_path)
+
     # Run selected checks
     results = run_selected_checks(
         checker,
@@ -1930,6 +1976,8 @@ def main(argv: list[str] | None = None) -> int:
         skip_set,
         pad_grid_threshold=pad_grid_threshold,
         pad_grid_auto_derive=pad_grid_auto_derive,
+        sch_path=sch_path,
+        sch_field_threshold=args.sch_field_threshold,
     )
 
     # Issue #4417: apply general waivers centrally, once, AFTER all checks run.
@@ -2223,6 +2271,8 @@ def run_selected_checks(
     skip_set: set[str],
     pad_grid_threshold: float | None = None,
     pad_grid_auto_derive: bool = True,
+    sch_path: Path | None = None,
+    sch_field_threshold: float = DEFAULT_SCH_FIELD_THRESHOLD_MM,
 ) -> DRCResults:
     """Run the selected DRC checks based on filters.
 
@@ -2238,6 +2288,14 @@ def run_selected_checks(
             the board's pad-offset histogram (issue #3061).  Defaults
             to ``True`` for the CLI; ``False`` preserves the PR #3057
             fixed-0.05mm behaviour.
+        sch_path: Resolved schematic path for the ``sch_fields``
+            field-geometry lint (issue #4595), or ``None`` when no
+            schematic is available -- the category then emits nothing
+            (the #4350 missing-schematic stderr warning already covers
+            visibility).  Must default to ``None`` so library callers
+            that only exercise PCB-scoped checks are unaffected.
+        sch_field_threshold: ``sch_field_offset`` distance threshold in
+            mm (issue #4595; strictly-greater-than comparison).
     """
     results = DRCResults()
 
@@ -2253,6 +2311,18 @@ def run_selected_checks(
             auto_derive_threshold=pad_grid_auto_derive,
             aggregate=not checker.verbose,
         )
+
+    # Issue #4595: schematic field-geometry lint.  Dispatched as a
+    # CLI-level closure (like ``pad_grid``) because it runs on the
+    # resolved sibling schematic, not the PCB -- it is intentionally NOT
+    # a ``DRCChecker`` method and NOT part of ``CHECK_ALL_METHODS``.
+    # With no schematic resolved it is a silent no-op.
+    def _sch_fields_check() -> DRCResults:
+        if sch_path is None:
+            return DRCResults()
+        from kicad_tools.validate.rules.schematic_fields import check_schematic_fields
+
+        return check_schematic_fields(sch_path, threshold_mm=sch_field_threshold)
 
     # Map of category to check method.  This dict MUST stay a superset
     # of the methods invoked by ``DRCChecker.check_all`` (i.e., every
@@ -2279,6 +2349,7 @@ def run_selected_checks(
         "netlist": checker.check_netlist,
         "pad_grid": _pad_grid_check,
         "placement": checker.check_footprint_placement,
+        "sch_fields": _sch_fields_check,
         "silkscreen": checker.check_silkscreen,
         "single_pad_net": checker.check_single_pad_nets,
         "solder_mask": checker.check_solder_mask_pads,

--- a/src/kicad_tools/cli/commands/validation.py
+++ b/src/kicad_tools/cli/commands/validation.py
@@ -279,6 +279,11 @@ def run_check_command(args) -> int:
         sub_argv.append("--pad-grid-strict")
     if getattr(args, "pad_grid_tolerance", None) is not None:
         sub_argv.extend(["--pad-grid-tolerance", str(args.pad_grid_tolerance)])
+    # Issue #4595: forward the sch_fields lint threshold.  The outer parser
+    # defaults it to None so the inner check_cmd parser's default (15.0mm)
+    # stays the single source of truth.
+    if getattr(args, "sch_field_threshold", None) is not None:
+        sub_argv.extend(["--sch-field-threshold", str(args.sch_field_threshold)])
     return check_main(sub_argv)
 
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -869,6 +869,22 @@ def _add_check_parser(subparsers) -> None:
             "auto-derivation."
         ),
     )
+    # Issue #4595: sch_fields schematic field-geometry lint threshold.
+    # Declared on BOTH parsers + forwarded by the shim (see the parser-drift
+    # guard in tests/test_cli_parser_drift.py, issue #4633).
+    check_parser.add_argument(
+        "--sch-field-threshold",
+        dest="sch_field_threshold",
+        type=float,
+        default=None,
+        metavar="MM",
+        help=(
+            "Distance in mm beyond which the sch_fields lint flags a "
+            "visible Reference/Value field as adrift from its symbol body "
+            "(default 15.0, warning severity only; issue #4595).  Fixed "
+            "threshold -- an adaptive per-sheet-median variant is deferred."
+        ),
+    )
 
 
 def _add_sch_parser(subparsers) -> None:

--- a/src/kicad_tools/validate/checker.py
+++ b/src/kicad_tools/validate/checker.py
@@ -318,6 +318,13 @@ class DRCChecker:
         "connector_edge_access": CATEGORY_ADVISORY,
         "connector_edge_distance": CATEGORY_ADVISORY,
         "copper_sliver": CATEGORY_ADVISORY,
+        # Schematic field-geometry legibility lint (Issue #4595):
+        # warning-severity readability advisories on the resolved sibling
+        # schematic -- never fab-blocking.  Explicit entries are REQUIRED:
+        # category_for_rule defaults unknown ids to the fab-blocking
+        # Manufacturing bucket and there is no "sch" prefix fallback.
+        "sch_field_offset": CATEGORY_ADVISORY,
+        "sch_field_overlap": CATEGORY_ADVISORY,
         "impedance": CATEGORY_ADVISORY,
         "diffpair_clearance_intra": CATEGORY_ADVISORY,
         "diffpair_length_skew": CATEGORY_ADVISORY,

--- a/src/kicad_tools/validate/rules/__init__.py
+++ b/src/kicad_tools/validate/rules/__init__.py
@@ -14,6 +14,7 @@ from .dimensions import DimensionRules
 from .edge import EdgeClearanceRule
 from .impedance import ImpedanceRule, NetImpedanceSpec
 from .match_group_length_skew import MatchGroupLengthSkewRule
+from .schematic_fields import check_schematic_fields
 from .silkscreen import (
     check_all_silkscreen,
     check_silk_edge_clearance,
@@ -46,6 +47,7 @@ __all__ = [
     "SolderMaskPadRules",
     "ViaInPadRule",
     "check_all_silkscreen",
+    "check_schematic_fields",
     "check_silk_edge_clearance",
     "check_silk_over_copper",
     "check_silkscreen_line_width",

--- a/src/kicad_tools/validate/rules/schematic_fields.py
+++ b/src/kicad_tools/validate/rules/schematic_fields.py
@@ -1,0 +1,452 @@
+"""Schematic field-geometry lint (Issue #4595).
+
+Two warning-severity legibility rules for the ``sch_fields`` category of
+``kct check``:
+
+* ``sch_field_offset`` -- a visible ``Reference``/``Value`` field placed
+  farther than a threshold from its symbol's placed body bounding box
+  (measured with :func:`kicad_tools.schema.field_geometry.field_offset_mm`,
+  the same metric ``kct sch tidy`` fixes, so "lint reports it, tidy fixes
+  it" compose).  A field fires only when its offset is STRICTLY GREATER
+  than the threshold; a field exactly at the threshold does not fire.
+* ``sch_field_overlap`` -- a visible field's estimated text bounding box
+  intersects another symbol's placed body bbox, or another symbol's
+  visible field text bbox (the ``+3.3VA9`` superimposed-label composite
+  from the motivating report).  Each colliding pair is reported once.
+
+Both rules are WARNING severity only and are classified
+``advisory-quality`` in :attr:`DRCChecker.RULE_CATEGORY` -- they never
+raise the error count, so they can never block a fab gate (``kct build``
+/ ``kct pipeline``).  Under ``--strict`` they become fatal by the
+pre-existing global warnings-are-fatal contract, same as
+``silk_over_copper`` / ``copper_sliver`` -- no special-casing here.
+
+Threshold policy (recorded per the issue #4595 curator decision): v1
+ships a FIXED default of 15.0 mm (overridable via ``kct check
+--sch-field-threshold``).  The adaptive per-sheet-median outlier variant
+suggested in the original report is explicitly DEFERRED: healthy sheets
+measure ~4-6 mm median offsets and the motivating broken sheet 36 mm, so
+a fixed 15 mm cleanly separates the observed populations without the
+determinism/explainability cost of a data-dependent threshold.
+
+Text-bbox approximation: KiCad does not store rendered text extents in
+the schematic, so the overlap rule estimates each field's box from its
+font height ``h`` (from ``(effects (font (size h w)))``, default 1.27 mm)
+as ``height = h`` and ``width = 0.8 * h`` per character -- adequate for a
+warning-severity heuristic.  The anchor is treated as the text center
+unless a ``(justify left|right)`` effect says otherwise; vertically the
+anchor is always treated as centered.  Rotated fields (90/270) swap the
+box axes.
+
+Scope (mirrors ``kct sch tidy`` / issue #4596 so lint and remediation
+agree):
+
+* only ``Reference`` and ``Value`` fields are linted;
+* hidden fields (``(effects ... hide)``) are skipped;
+* power/virtual symbols (Reference starting with ``#``) are skipped
+  entirely -- neither their fields nor their bodies participate;
+* symbols whose ``lib_id`` cannot be resolved from the embedded
+  ``lib_symbols`` are skipped with a stderr warning, not a crash;
+* field/field overlap is only checked ACROSS symbols (a symbol's own
+  Reference/Value pair is not compared -- cross-symbol composites were
+  the motivating defect, and tidy places same-symbol fields on opposite
+  body sides);
+* a field is never compared against its own symbol's body (fields
+  legitimately sit inside large bodies, e.g. an IC's Value).
+
+Hierarchy: sub-sheets referenced by the root's ``(sheet ...)`` nodes are
+linted too (the motivating defect lived on a sub-sheet); each unique
+sheet file is linted exactly once, with a visited-set guard against
+sheet cycles.  Overlaps are only meaningful within one sheet, so
+collision checks never cross sheet files.
+
+Determinism: findings are sorted by (sheet file name, reference, field
+name, rule id, message), and all measured values are rendered with fixed
+precision, so repeated runs are byte-identical for CI.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from kicad_tools.schema.field_geometry import (
+    BBox,
+    field_offset_mm,
+    placed_body_bbox,
+)
+from kicad_tools.sexp import SExp
+
+from ..violations import DRCResults, DRCViolation
+
+__all__ = [
+    "DEFAULT_SCH_FIELD_THRESHOLD_MM",
+    "RULE_FIELD_OFFSET",
+    "RULE_FIELD_OVERLAP",
+    "check_schematic_fields",
+    "field_text_bbox",
+]
+
+#: Fixed v1 offset threshold (mm); see module docstring for the recorded
+#: adaptive-vs-fixed decision.
+DEFAULT_SCH_FIELD_THRESHOLD_MM = 15.0
+
+RULE_FIELD_OFFSET = "sch_field_offset"
+RULE_FIELD_OVERLAP = "sch_field_overlap"
+
+#: Fields in scope (mirrors ``kct sch tidy``'s TIDY_FIELDS).
+LINT_FIELDS = ("Reference", "Value")
+
+#: KiCad default schematic font height in mm.
+DEFAULT_FONT_HEIGHT_MM = 1.27
+
+#: Estimated advance width per character, as a fraction of font height.
+#: A crude monospace approximation -- see the module docstring.
+CHAR_WIDTH_FACTOR = 0.8
+
+
+def field_text_bbox(
+    text: str,
+    at: tuple[float, float],
+    rotation: float = 0.0,
+    font_height_mm: float = DEFAULT_FONT_HEIGHT_MM,
+    justify: str = "",
+) -> BBox:
+    """Estimate the axis-aligned bbox of a rendered field text.
+
+    Args:
+        text: The rendered string (the property *value*, e.g. ``"C13"``).
+        at: The field anchor position in sheet coordinates.
+        rotation: Field text rotation in degrees; 90/270 swap the axes.
+        font_height_mm: Font height ``h`` from the property's effects.
+        justify: Horizontal justification (``""``/``"left"``/``"right"``).
+            Applied along the text run direction for horizontal text;
+            vertical (90/270) text is always treated as center-anchored.
+
+    Returns:
+        ``(min_x, min_y, max_x, max_y)`` in sheet coordinates.  This is a
+        heuristic estimate (see module docstring), not a glyph-accurate
+        extent.
+    """
+    x, y = at
+    length = max(len(text), 1) * CHAR_WIDTH_FACTOR * font_height_mm
+    height = font_height_mm
+
+    vertical = rotation % 180 == 90
+    if vertical:
+        # Text runs vertically; treat the anchor as the box center.
+        return (x - height / 2, y - length / 2, x + height / 2, y + length / 2)
+
+    if justify == "left":
+        min_x, max_x = x, x + length
+    elif justify == "right":
+        min_x, max_x = x - length, x
+    else:
+        min_x, max_x = x - length / 2, x + length / 2
+    return (min_x, y - height / 2, max_x, y + height / 2)
+
+
+def _bboxes_overlap(a: BBox, b: BBox) -> bool:
+    """Strict axis-aligned intersection (touching edges do NOT overlap)."""
+    return a[0] < b[2] and a[2] > b[0] and a[1] < b[3] and a[3] > b[1]
+
+
+def _is_hidden(prop_sexp: SExp) -> bool:
+    """Check whether a property is hidden.
+
+    Handles both the KiCad 8+ ``(effects ... (hide yes))`` list form and
+    the older bare-atom ``(effects ... hide)`` form (same logic as
+    ``kct sch tidy``).
+    """
+    effects = prop_sexp.find_child("effects")
+    if effects is None:
+        return False
+    if effects.find_child("hide") is not None:
+        return True
+    return any(c.is_atom and c.value == "hide" for c in effects.children)
+
+
+def _font_height_mm(prop_sexp: SExp) -> float:
+    """Extract the font height from ``(effects (font (size h w)))``."""
+    effects = prop_sexp.find_child("effects")
+    if effects is None:
+        return DEFAULT_FONT_HEIGHT_MM
+    font = effects.find_child("font")
+    if font is None:
+        return DEFAULT_FONT_HEIGHT_MM
+    size = font.find_child("size")
+    if size is None:
+        return DEFAULT_FONT_HEIGHT_MM
+    height = size.get_float(0)
+    return height if height and height > 0 else DEFAULT_FONT_HEIGHT_MM
+
+
+def _justify(prop_sexp: SExp) -> str:
+    """Extract the horizontal justification token (``""`` = centered)."""
+    effects = prop_sexp.find_child("effects")
+    if effects is None:
+        return ""
+    justify = effects.find_child("justify")
+    if justify is None:
+        return ""
+    for child in justify.children:
+        if child.is_atom and child.value in ("left", "right"):
+            return str(child.value)
+    return ""
+
+
+@dataclass
+class _FieldRecord:
+    """A visible in-scope field of a linted symbol."""
+
+    reference: str
+    field_name: str
+    text: str
+    position: tuple[float, float]
+    text_bbox: BBox
+
+
+def _sheet_files(root: Path) -> list[Path]:
+    """Enumerate the root sheet plus all reachable sub-sheet files.
+
+    Breadth-first over each sheet's ``(sheet ...)`` nodes, resolving the
+    ``Sheetfile`` property relative to the referencing sheet's directory.
+    Each unique resolved file is returned once; missing or unparseable
+    sheets are skipped with a stderr warning (never a crash), and a
+    visited set guards against sheet cycles.
+    """
+    from kicad_tools.schema import Schematic
+
+    ordered: list[Path] = []
+    visited: set[Path] = set()
+    queue: list[Path] = [root.resolve()]
+
+    while queue:
+        sheet_path = queue.pop(0)
+        if sheet_path in visited:
+            continue
+        visited.add(sheet_path)
+        if not sheet_path.exists():
+            print(
+                f"Warning: sch_fields: sheet file not found: {sheet_path}; skipped",
+                file=sys.stderr,
+            )
+            continue
+        ordered.append(sheet_path)
+        try:
+            schematic = Schematic.load(sheet_path)
+        except Exception as exc:
+            # Already appended: the caller's per-sheet lint re-loads and
+            # re-warns; keep enumeration resilient either way.
+            print(
+                f"Warning: sch_fields: could not parse {sheet_path.name} "
+                f"for sheet enumeration ({exc})",
+                file=sys.stderr,
+            )
+            continue
+        for sheet in schematic.sheets:
+            if not sheet.filename:
+                continue
+            child = Path(sheet.filename)
+            if not child.is_absolute():
+                child = sheet_path.parent / child
+            queue.append(child.resolve())
+
+    return ordered
+
+
+def _lint_sheet(
+    sheet_path: Path,
+    threshold_mm: float,
+) -> list[tuple[tuple, DRCViolation]]:
+    """Lint one sheet file; return (sort_key, violation) pairs."""
+    from kicad_tools.schema import Schematic
+    from kicad_tools.schema.symbol import SymbolInstance
+
+    try:
+        schematic = Schematic.load(sheet_path)
+    except Exception as exc:
+        print(
+            f"Warning: sch_fields: could not parse {sheet_path.name} ({exc}); skipped",
+            file=sys.stderr,
+        )
+        return []
+
+    sheet_name = sheet_path.name
+    findings: list[tuple[tuple, DRCViolation]] = []
+
+    def _key(reference: str, field_name: str, rule_id: str, message: str) -> tuple:
+        # AC ordering: (sheet file name, reference, field name, rule id);
+        # full path + message break residual ties deterministically.
+        return (sheet_name, str(sheet_path), reference, field_name, rule_id, message)
+
+    # Pass 1: collect per-symbol body bboxes and visible in-scope fields.
+    bodies: list[tuple[str, BBox]] = []  # (reference, body bbox)
+    fields: list[_FieldRecord] = []
+    for sym_sexp in schematic.sexp.find_children("symbol"):
+        inst = SymbolInstance.from_sexp(sym_sexp)
+        reference = inst.reference
+
+        if reference.startswith("#"):
+            # Power/virtual symbols: fully out of scope (mirrors sch tidy).
+            continue
+
+        lib_sym = schematic.get_lib_symbol_resolved(inst.lib_id)
+        if lib_sym is None:
+            print(
+                f"Warning: sch_fields: {sheet_name}: {reference}: lib_id "
+                f"'{inst.lib_id}' not found in embedded lib_symbols; skipped",
+                file=sys.stderr,
+            )
+            continue
+
+        bbox = placed_body_bbox(
+            lib_sym,
+            inst.position,
+            rotation=inst.rotation,
+            mirror=inst.mirror,
+            unit=inst.unit,
+        )
+
+        symbol_fields: list[_FieldRecord] = []
+        for prop_sexp in sym_sexp.find_children("property"):
+            field_name = prop_sexp.get_string(0) or ""
+            if field_name not in LINT_FIELDS:
+                continue
+            if _is_hidden(prop_sexp):
+                continue
+            at_node = prop_sexp.find_child("at")
+            if at_node is None:
+                continue
+            pos = (at_node.get_float(0) or 0.0, at_node.get_float(1) or 0.0)
+            rot = at_node.get_float(2) or 0.0
+            text = prop_sexp.get_string(1) or ""
+
+            # Sub-check 1: field far from body (strictly greater than).
+            offset = field_offset_mm(pos, bbox)
+            if offset > threshold_mm:
+                message = (
+                    f"{reference}.{field_name} {offset:.1f}mm from body "
+                    f"(threshold {threshold_mm:.1f}mm) [{sheet_name}]"
+                )
+                findings.append(
+                    (
+                        _key(reference, field_name, RULE_FIELD_OFFSET, message),
+                        DRCViolation(
+                            rule_id="sch_field_offset",
+                            severity="warning",
+                            message=message,
+                            location=pos,
+                            actual_value=round(offset, 3),
+                            required_value=threshold_mm,
+                            items=(reference,),
+                        ),
+                    )
+                )
+
+            symbol_fields.append(
+                _FieldRecord(
+                    reference=reference,
+                    field_name=field_name,
+                    text=text,
+                    position=pos,
+                    text_bbox=field_text_bbox(
+                        text,
+                        pos,
+                        rotation=rot,
+                        font_height_mm=_font_height_mm(prop_sexp),
+                        justify=_justify(prop_sexp),
+                    ),
+                )
+            )
+
+        bodies.append((reference, bbox))
+        fields.extend(symbol_fields)
+
+    # Deterministic collision scan order regardless of file order.
+    bodies.sort(key=lambda b: b[0])
+    fields.sort(key=lambda f: (f.reference, f.field_name))
+
+    # Sub-check 2a: field text bbox vs ANOTHER symbol's body bbox.
+    for record in fields:
+        for body_ref, body_bbox in bodies:
+            if body_ref == record.reference:
+                continue  # A field over its own body is normal.
+            if _bboxes_overlap(record.text_bbox, body_bbox):
+                message = (
+                    f"{record.reference}.{record.field_name} text "
+                    f"overlaps {body_ref} body [{sheet_name}]"
+                )
+                findings.append(
+                    (
+                        _key(record.reference, record.field_name, RULE_FIELD_OVERLAP, message),
+                        DRCViolation(
+                            rule_id="sch_field_overlap",
+                            severity="warning",
+                            message=message,
+                            location=record.position,
+                            items=(record.reference, body_ref),
+                        ),
+                    )
+                )
+
+    # Sub-check 2b: field text bbox vs another SYMBOL's field text bbox
+    # (cross-symbol only; each unordered pair reported once, attributed
+    # to the lexicographically-first field).
+    for i, a in enumerate(fields):
+        for b in fields[i + 1 :]:
+            if a.reference == b.reference:
+                continue
+            if _bboxes_overlap(a.text_bbox, b.text_bbox):
+                message = (
+                    f"{a.reference}.{a.field_name} text overlaps "
+                    f"{b.reference}.{b.field_name} text [{sheet_name}]"
+                )
+                findings.append(
+                    (
+                        _key(a.reference, a.field_name, RULE_FIELD_OVERLAP, message),
+                        DRCViolation(
+                            rule_id="sch_field_overlap",
+                            severity="warning",
+                            message=message,
+                            location=a.position,
+                            items=(a.reference, b.reference),
+                        ),
+                    )
+                )
+
+    return findings
+
+
+def check_schematic_fields(
+    sch_path: Path,
+    threshold_mm: float = DEFAULT_SCH_FIELD_THRESHOLD_MM,
+) -> DRCResults:
+    """Run the schematic field-geometry lint (Issue #4595).
+
+    Args:
+        sch_path: Path to the root ``.kicad_sch``.  Sub-sheets referenced
+            via ``(sheet ...)`` nodes are linted too, each unique file
+            once.
+        threshold_mm: ``sch_field_offset`` distance threshold in mm
+            (strictly-greater-than comparison).
+
+    Returns:
+        :class:`DRCResults` containing only WARNING-severity findings,
+        deterministically sorted by (sheet file name, reference, field
+        name, rule id).
+    """
+    results = DRCResults()
+    results.rules_checked = 2
+    results.rules_checked_by_rule[RULE_FIELD_OFFSET] = 1
+    results.rules_checked_by_rule[RULE_FIELD_OVERLAP] = 1
+
+    findings: list[tuple[tuple, DRCViolation]] = []
+    for sheet_path in _sheet_files(sch_path):
+        findings.extend(_lint_sheet(sheet_path, threshold_mm))
+
+    findings.sort(key=lambda pair: pair[0])
+    for _, violation in findings:
+        results.add(violation)
+    return results

--- a/tests/test_check_cmd_coverage.py
+++ b/tests/test_check_cmd_coverage.py
@@ -164,11 +164,26 @@ class TestCategoryListMatchesDispatcher:
     the dispatcher dict are two declarations of the same set; drift
     between them produces silently-ignored CLI flags."""
 
+    # Categories dispatched as CLI-level closures that do NOT invoke any
+    # ``DRCChecker.check_*`` method, so the behavioural extractor above
+    # (which records stubbed checker methods) cannot observe them:
+    #
+    # * ``sch_fields`` (Issue #4595): schematic field-geometry lint.  It
+    #   runs on the resolved sibling ``.kicad_sch``, not the PCB, and the
+    #   bare ``run_selected_checks(checker, only_set, skip_set)`` call
+    #   used here leaves ``sch_path=None``, making the closure a silent
+    #   no-op.  It is deliberately NOT a checker method / NOT in
+    #   ``CHECK_ALL_METHODS`` -- the checker is PCB-scoped.
+    NON_CHECKER_CATEGORIES = frozenset({"sch_fields"})
+
     def test_categories_list_equals_dispatcher_keys(self) -> None:
         checker = _build_minimal_checker()
         category_to_method = _extract_dispatcher_methods(checker)
-        assert set(check_cmd.CHECK_CATEGORIES) == set(category_to_method.keys()), (
-            "CHECK_CATEGORIES must equal the keys of run_selected_checks's "
+        assert set(check_cmd.CHECK_CATEGORIES) - self.NON_CHECKER_CATEGORIES == set(
+            category_to_method.keys()
+        ), (
+            "CHECK_CATEGORIES (minus the documented non-checker closure "
+            "categories) must equal the keys of run_selected_checks's "
             "check_methods dict.  Drift means --only/--skip silently "
             "accepts/rejects unknown categories."
         )

--- a/tests/test_check_schematic_fields.py
+++ b/tests/test_check_schematic_fields.py
@@ -1,0 +1,588 @@
+"""Tests for the schematic field-geometry lint (Issue #4595).
+
+Covers the ``sch_fields`` check category: the ``sch_field_offset`` and
+``sch_field_overlap`` rules in
+``kicad_tools.validate.rules.schematic_fields``, plus the ``kct check``
+CLI wiring (``--only``/``--skip``, ``--sch-field-threshold``, warning
+severity / exit-code contract, deterministic output).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.schema import Schematic
+from kicad_tools.schema.field_geometry import field_offset_mm, placed_body_bbox
+from kicad_tools.validate.rules.schematic_fields import (
+    DEFAULT_SCH_FIELD_THRESHOLD_MM,
+    RULE_FIELD_OFFSET,
+    RULE_FIELD_OVERLAP,
+    check_schematic_fields,
+    field_text_bbox,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+# Device:R body rectangle spans x in [-1.016, 1.016], y in [-2.54, 2.54]
+# (library coords); the placed bbox at rotation 0 is symmetric about the
+# instance position.
+_LIB_SYMBOLS = """	(lib_symbols
+		(symbol "Device:R"
+			(symbol "R_0_1"
+				(rectangle (start -1.016 -2.54) (end 1.016 2.54) (stroke (width 0.254)) (fill (type none)))
+			)
+			(symbol "R_1_1"
+				(pin passive line (at 0 3.81 270) (length 1.27) (name "~" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+				(pin passive line (at 0 -3.81 90) (length 1.27) (name "~" (effects (font (size 1.27 1.27)))) (number "2" (effects (font (size 1.27 1.27)))))
+			)
+		)
+		(symbol "Test:Asym"
+			(symbol "Asym_0_1"
+				(polyline (pts (xy 0 0) (xy 4 0) (xy 4 2) (xy 0 2) (xy 0 0)) (stroke (width 0.254)) (fill (type none)))
+			)
+			(symbol "Asym_1_1"
+				(pin passive line (at 0 0 0) (length 1.27) (name "~" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+			)
+		)
+		(symbol "power:GND"
+			(symbol "GND_0_1"
+				(polyline (pts (xy 0 0) (xy 0 -1.27)) (stroke (width 0)) (fill (type none)))
+			)
+			(symbol "GND_1_1"
+				(pin power_in line (at 0 0 270) (length 0) (name "GND" (effects (font (size 1.27 1.27)))) (number "1" (effects (font (size 1.27 1.27)))))
+			)
+		)
+	)
+"""
+
+
+def _sch_document(body: str, uuid: str = "test-sch-uuid-0001") -> str:
+    return (
+        "(kicad_sch\n"
+        "\t(version 20231120)\n"
+        '\t(generator "kicadtools_test")\n'
+        '\t(generator_version "8.0")\n'
+        f'\t(uuid "{uuid}")\n'
+        '\t(paper "A4")\n'
+        f"{_LIB_SYMBOLS}"
+        f"{body}"
+        ")\n"
+    )
+
+
+def _symbol(
+    ref: str,
+    at: tuple[float, float],
+    ref_at: tuple[float, float],
+    *,
+    lib_id: str = "Device:R",
+    value: str = "10k",
+    rotation: float = 0,
+    mirror: str = "",
+    ref_hidden: bool = False,
+    value_at: tuple[float, float] | None = None,
+    value_hidden: bool = True,
+    ref_justify: str = "",
+) -> str:
+    """Render one placed-symbol s-expression."""
+    mirror_line = f"\t\t(mirror {mirror})\n" if mirror else ""
+    ref_effects = "(effects (font (size 1.27 1.27))"
+    if ref_justify:
+        ref_effects += f" (justify {ref_justify})"
+    ref_effects += " hide)" if ref_hidden else ")"
+    if value_at is None:
+        value_at = at
+    value_effects = "(effects (font (size 1.27 1.27))"
+    value_effects += " hide)" if value_hidden else ")"
+    return (
+        "\t(symbol\n"
+        f'\t\t(lib_id "{lib_id}")\n'
+        f"\t\t(at {at[0]} {at[1]} {rotation})\n"
+        f"{mirror_line}"
+        "\t\t(unit 1)\n"
+        "\t\t(in_bom yes)\n"
+        "\t\t(on_board yes)\n"
+        f'\t\t(uuid "uuid-{ref}")\n'
+        f'\t\t(property "Reference" "{ref}"\n'
+        f"\t\t\t(at {ref_at[0]} {ref_at[1]} 0)\n"
+        f"\t\t\t{ref_effects}\n"
+        "\t\t)\n"
+        f'\t\t(property "Value" "{value}"\n'
+        f"\t\t\t(at {value_at[0]} {value_at[1]} 0)\n"
+        f"\t\t\t{value_effects}\n"
+        "\t\t)\n"
+        f'\t\t(pin "1" (uuid "uuid-{ref}-p1"))\n'
+        f'\t\t(pin "2" (uuid "uuid-{ref}-p2"))\n'
+        "\t)\n"
+    )
+
+
+def _write_sch(tmp_path: Path, body: str, name: str = "test.kicad_sch") -> Path:
+    path = tmp_path / name
+    path.write_text(_sch_document(body))
+    return path
+
+
+def _by_rule(results, rule_id: str):
+    return [v for v in results.violations if v.rule_id == rule_id]
+
+
+# ---------------------------------------------------------------------------
+# Unit: sch_field_offset
+# ---------------------------------------------------------------------------
+
+
+class TestFieldOffset:
+    def test_adrift_field_flagged_once(self, tmp_path: Path) -> None:
+        # R1's Reference is ~56 mm from its body; R2 is healthy (~2.5 mm).
+        body = _symbol("R1", (100, 100), (140, 60)) + _symbol("R2", (200, 100), (200, 95))
+        sch = _write_sch(tmp_path, body)
+
+        results = check_schematic_fields(sch)
+        offsets = _by_rule(results, RULE_FIELD_OFFSET)
+        assert len(offsets) == 1
+        v = offsets[0]
+        assert v.severity == "warning"
+        assert v.items == ("R1",)
+        assert "R1.Reference" in v.message
+        assert "from body" in v.message
+        assert f"threshold {DEFAULT_SCH_FIELD_THRESHOLD_MM:.1f}mm" in v.message
+        assert v.required_value == DEFAULT_SCH_FIELD_THRESHOLD_MM
+        assert v.actual_value is not None and v.actual_value > 50
+        # No overlaps in this layout.
+        assert not _by_rule(results, RULE_FIELD_OVERLAP)
+
+    def test_all_warning_severity_never_errors(self, tmp_path: Path) -> None:
+        body = _symbol("R1", (100, 100), (140, 60))
+        sch = _write_sch(tmp_path, body)
+        results = check_schematic_fields(sch)
+        assert results.violations
+        assert all(v.severity == "warning" for v in results.violations)
+        assert results.error_count == 0
+        assert results.passed  # warnings never fail the gate
+
+    def test_threshold_override_respected(self, tmp_path: Path) -> None:
+        body = _symbol("R1", (100, 100), (140, 60)) + _symbol("R2", (200, 100), (200, 95))
+        sch = _write_sch(tmp_path, body)
+
+        # Huge threshold: nothing fires.
+        assert not check_schematic_fields(sch, threshold_mm=100.0).violations
+        # Tiny threshold: the healthy R2 fires too.
+        offsets = _by_rule(check_schematic_fields(sch, threshold_mm=1.0), RULE_FIELD_OFFSET)
+        assert {v.items[0] for v in offsets} == {"R1", "R2"}
+
+    def test_exact_threshold_does_not_fire(self, tmp_path: Path) -> None:
+        """The comparison is strictly-greater-than: offset == threshold is OK."""
+        body = _symbol("R1", (100, 100), (100, 90))
+        sch = _write_sch(tmp_path, body)
+
+        # Compute the exact same offset the lint measures, via the shared
+        # field_geometry metric.
+        schematic = Schematic.load(sch)
+        inst = schematic.symbols[0]
+        lib = schematic.get_lib_symbol_resolved(inst.lib_id)
+        assert lib is not None
+        bbox = placed_body_bbox(lib, inst.position, rotation=inst.rotation, mirror=inst.mirror)
+        offset = field_offset_mm((100.0, 90.0), bbox)
+        assert offset > 0
+
+        assert not check_schematic_fields(sch, threshold_mm=offset).violations
+        fired = check_schematic_fields(sch, threshold_mm=offset - 0.01)
+        assert len(_by_rule(fired, RULE_FIELD_OFFSET)) == 1
+
+    def test_rotation_consumed_from_field_geometry(self, tmp_path: Path) -> None:
+        """A 90-degree rotation swaps the R body extents (±1.016 x -> ±2.54 x);
+        the lint must measure against the rotated bbox."""
+        # Field at (110, 100): rotated dx = 110 - 102.54 = 7.46 mm;
+        # if rotation were ignored, dx = 110 - 101.016 = 8.98 mm.
+        body = _symbol("R1", (100, 100), (110, 100), rotation=90)
+        sch = _write_sch(tmp_path, body)
+
+        assert not check_schematic_fields(sch, threshold_mm=8.0).violations
+        fired = _by_rule(check_schematic_fields(sch, threshold_mm=7.0), RULE_FIELD_OFFSET)
+        assert len(fired) == 1
+        assert fired[0].actual_value == pytest.approx(7.46, abs=0.01)
+
+    def test_mirror_consumed_from_field_geometry(self, tmp_path: Path) -> None:
+        """Mirroring an asymmetric body must move the measured bbox."""
+        base = _symbol("A1", (100, 100), (107, 100), lib_id="Test:Asym")
+        mirrored = _symbol("A1", (100, 100), (107, 100), lib_id="Test:Asym", mirror="x")
+
+        sch_base = _write_sch(tmp_path, base, name="base.kicad_sch")
+        sch_mirrored = _write_sch(tmp_path, mirrored, name="mirrored.kicad_sch")
+
+        # Expected offsets from the shared geometry module (not hardcoded).
+        def expected(sch_path: Path) -> float:
+            schematic = Schematic.load(sch_path)
+            inst = schematic.symbols[0]
+            lib = schematic.get_lib_symbol_resolved(inst.lib_id)
+            assert lib is not None
+            bbox = placed_body_bbox(lib, inst.position, rotation=inst.rotation, mirror=inst.mirror)
+            return field_offset_mm((107.0, 100.0), bbox)
+
+        off_base = expected(sch_base)
+        off_mirrored = expected(sch_mirrored)
+        assert off_base != pytest.approx(off_mirrored)
+
+        threshold = (off_base + off_mirrored) / 2
+        results_base = check_schematic_fields(sch_base, threshold_mm=threshold)
+        results_mirrored = check_schematic_fields(sch_mirrored, threshold_mm=threshold)
+        # Exactly one of the two placements is beyond the midpoint threshold.
+        fired = [
+            bool(_by_rule(results_base, RULE_FIELD_OFFSET)),
+            bool(_by_rule(results_mirrored, RULE_FIELD_OFFSET)),
+        ]
+        assert sorted(fired) == [False, True]
+
+
+# ---------------------------------------------------------------------------
+# Unit: sch_field_overlap
+# ---------------------------------------------------------------------------
+
+
+class TestFieldOverlap:
+    def test_field_over_another_body_flagged(self, tmp_path: Path) -> None:
+        # R2's Reference text sits directly on R1's body.  R1's own fields
+        # are hidden to isolate the collision.
+        body = _symbol("R1", (100, 100), (100, 100), ref_hidden=True) + _symbol(
+            "R2", (110, 100), (100, 100)
+        )
+        sch = _write_sch(tmp_path, body)
+
+        results = check_schematic_fields(sch)
+        overlaps = _by_rule(results, RULE_FIELD_OVERLAP)
+        assert len(overlaps) == 1
+        v = overlaps[0]
+        assert v.severity == "warning"
+        assert v.items == ("R2", "R1")
+        assert "R2.Reference text overlaps R1 body" in v.message
+
+    def test_superimposed_fields_flagged(self, tmp_path: Path) -> None:
+        """Two different symbols' fields at the same coordinates (the
+        ``+3.3VA9``-style composite) must be flagged once."""
+        body = _symbol("R1", (100, 100), (100, 90)) + _symbol("R2", (140, 100), (100, 90))
+        sch = _write_sch(tmp_path, body)
+
+        results = check_schematic_fields(sch)
+        overlaps = _by_rule(results, RULE_FIELD_OVERLAP)
+        assert len(overlaps) == 1
+        v = overlaps[0]
+        assert set(v.items) == {"R1", "R2"}
+        assert "text overlaps" in v.message and ".Reference" in v.message
+
+    def test_own_body_and_same_symbol_fields_not_flagged(self, tmp_path: Path) -> None:
+        # Reference AND Value both visible, both inside the symbol's own
+        # body: neither the own-body nor the same-symbol field pair counts.
+        body = _symbol("R1", (100, 100), (100, 100), value_at=(100, 100), value_hidden=False)
+        sch = _write_sch(tmp_path, body)
+        assert not check_schematic_fields(sch).violations
+
+    def test_justify_left_shifts_text_bbox(self) -> None:
+        bbox_center = field_text_bbox("R1", (100.0, 100.0))
+        bbox_left = field_text_bbox("R1", (100.0, 100.0), justify="left")
+        bbox_right = field_text_bbox("R1", (100.0, 100.0), justify="right")
+        assert bbox_left[0] == pytest.approx(100.0)
+        assert bbox_right[2] == pytest.approx(100.0)
+        assert bbox_center[0] < 100.0 < bbox_center[2]
+
+    def test_vertical_text_swaps_axes(self) -> None:
+        h = field_text_bbox("R1234", (0.0, 0.0))
+        v = field_text_bbox("R1234", (0.0, 0.0), rotation=90)
+        assert (h[2] - h[0]) == pytest.approx(v[3] - v[1])
+        assert (h[3] - h[1]) == pytest.approx(v[2] - v[0])
+
+
+# ---------------------------------------------------------------------------
+# Unit: scope / skip contracts (mirrors kct sch tidy, issue #4596)
+# ---------------------------------------------------------------------------
+
+
+class TestSkipContracts:
+    def test_hidden_field_skipped(self, tmp_path: Path) -> None:
+        body = _symbol("R1", (100, 100), (140, 60), ref_hidden=True)
+        sch = _write_sch(tmp_path, body)
+        assert not check_schematic_fields(sch).violations
+
+    def test_power_symbol_skipped(self, tmp_path: Path) -> None:
+        body = _symbol("#PWR01", (100, 100), (160, 40), lib_id="power:GND", value="GND")
+        sch = _write_sch(tmp_path, body)
+        assert not check_schematic_fields(sch).violations
+
+    def test_unresolvable_lib_id_skipped_with_warning(self, tmp_path: Path, capsys) -> None:
+        body = _symbol("R9", (100, 100), (150, 50), lib_id="Nope:Missing")
+        sch = _write_sch(tmp_path, body)
+        results = check_schematic_fields(sch)
+        assert not results.violations
+        err = capsys.readouterr().err
+        assert "R9" in err and "Nope:Missing" in err and "skipped" in err
+
+    def test_missing_schematic_is_graceful(self, tmp_path: Path, capsys) -> None:
+        results = check_schematic_fields(tmp_path / "does_not_exist.kicad_sch")
+        assert not results.violations
+        assert "not found" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Unit: hierarchy
+# ---------------------------------------------------------------------------
+
+
+class TestHierarchy:
+    def _root_with_sub(self, tmp_path: Path, sub_name: str) -> Path:
+        sheet = (
+            "\t(sheet\n"
+            "\t\t(at 100 50)\n"
+            "\t\t(size 20 15)\n"
+            '\t\t(uuid "sheet-uuid-0001")\n'
+            f'\t\t(property "Sheetname" "Sub"\n'
+            "\t\t\t(at 100 49 0)\n"
+            "\t\t\t(effects (font (size 1.27 1.27)))\n"
+            "\t\t)\n"
+            f'\t\t(property "Sheetfile" "{sub_name}"\n'
+            "\t\t\t(at 100 66 0)\n"
+            "\t\t\t(effects (font (size 1.27 1.27)))\n"
+            "\t\t)\n"
+            "\t)\n"
+        )
+        root = tmp_path / "root.kicad_sch"
+        root.write_text(_sch_document(sheet, uuid="root-uuid"))
+        return root
+
+    def test_defect_on_sub_sheet_found(self, tmp_path: Path) -> None:
+        root = self._root_with_sub(tmp_path, "sub.kicad_sch")
+        (tmp_path / "sub.kicad_sch").write_text(
+            _sch_document(_symbol("C13", (113.03, 82.55), (132.588, 44.958)), uuid="sub-uuid")
+        )
+
+        results = check_schematic_fields(root)
+        offsets = _by_rule(results, RULE_FIELD_OFFSET)
+        assert len(offsets) == 1
+        assert "C13.Reference" in offsets[0].message
+        assert "[sub.kicad_sch]" in offsets[0].message
+
+    def test_missing_sub_sheet_is_graceful(self, tmp_path: Path, capsys) -> None:
+        root = self._root_with_sub(tmp_path, "gone.kicad_sch")
+        results = check_schematic_fields(root)
+        assert not results.violations
+        assert "gone.kicad_sch" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Unit: determinism
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminism:
+    def test_findings_sorted_and_stable(self, tmp_path: Path) -> None:
+        # Deliberately declare C2 before C1 in the file: output must be
+        # sorted by reference, not file order.
+        body = _symbol("C2", (200, 100), (150, 40)) + _symbol("C1", (100, 100), (60, 40))
+        sch = _write_sch(tmp_path, body)
+
+        first = [v.message for v in check_schematic_fields(sch).violations]
+        second = [v.message for v in check_schematic_fields(sch).violations]
+        assert first == second
+        refs = [v.items[0] for v in check_schematic_fields(sch).violations]
+        assert refs == sorted(refs)
+
+    def test_rules_checked_bookkeeping(self, tmp_path: Path) -> None:
+        sch = _write_sch(tmp_path, _symbol("R1", (100, 100), (100, 95)))
+        results = check_schematic_fields(sch)
+        assert results.rules_checked == 2
+        assert results.rules_checked_by_rule == {
+            RULE_FIELD_OFFSET: 1,
+            RULE_FIELD_OVERLAP: 1,
+        }
+
+
+# ---------------------------------------------------------------------------
+# CLI integration: kct check wiring
+# ---------------------------------------------------------------------------
+
+_PCB_TEMPLATE = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (37 "F.SilkS" user "F.Silkscreen")
+    (44 "Edge.Cuts" user)
+    (49 "F.Fab" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (gr_rect (start 100 100) (end 150 150)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+)
+"""
+
+
+@pytest.fixture
+def board_with_defective_schematic(tmp_path: Path) -> Path:
+    """A minimal PCB with a sibling schematic containing one adrift field
+    (R1.Reference ~56 mm) and one superimposed cross-symbol field pair."""
+    pcb = tmp_path / "demo.kicad_pcb"
+    pcb.write_text(_PCB_TEMPLATE)
+    body = (
+        _symbol("R1", (100, 100), (140, 60))
+        + _symbol("R2", (200, 100), (180, 90))
+        + _symbol("R3", (240, 100), (180, 90))
+    )
+    (tmp_path / "demo.kicad_sch").write_text(_sch_document(body))
+    return pcb
+
+
+@pytest.fixture
+def stub_meta_subchecks(monkeypatch):
+    """Stub the ERC/LVS/Manifest sub-checks to PASSED so the CLI tests are
+    hermetic (no kicad-cli dependence) and the exit code is driven purely
+    by the DRC/lint pipeline under test."""
+    from kicad_tools.cli import check_cmd
+
+    def _passed(*_args, **_kwargs):
+        return check_cmd.SubCheckResult(status="PASSED", detail="stubbed for test")
+
+    monkeypatch.setattr(check_cmd, "_erc_subcheck", _passed)
+    monkeypatch.setattr(check_cmd, "_lvs_subcheck", _passed)
+    monkeypatch.setattr(check_cmd, "_manifest_subcheck", _passed)
+
+
+class TestCheckCliWiring:
+    def _main(self, argv):
+        from kicad_tools.cli.check_cmd import main
+
+        return main(argv)
+
+    def test_warnings_only_exit_zero(
+        self, board_with_defective_schematic, stub_meta_subchecks, capsys
+    ) -> None:
+        rc = self._main([str(board_with_defective_schematic)])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "sch_field_offset" in out
+        assert "sch_field_overlap" in out
+
+    def test_strict_makes_warnings_fatal(
+        self, board_with_defective_schematic, stub_meta_subchecks, capsys
+    ) -> None:
+        # Pre-existing global contract (same as silk_over_copper): warnings
+        # are fatal under --strict; not special-cased for sch_fields.
+        rc = self._main([str(board_with_defective_schematic), "--only", "sch_fields", "--strict"])
+        capsys.readouterr()
+        assert rc == 2
+
+    def test_skip_silences_category(
+        self, board_with_defective_schematic, stub_meta_subchecks, capsys
+    ) -> None:
+        rc = self._main([str(board_with_defective_schematic), "--skip", "sch_fields"])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "sch_field" not in out
+
+    def test_only_runs_category_alone_json(
+        self, board_with_defective_schematic, stub_meta_subchecks, capsys
+    ) -> None:
+        rc = self._main(
+            [str(board_with_defective_schematic), "--only", "sch_fields", "--format", "json"]
+        )
+        payload = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        violations = payload["violations"]
+        assert violations
+        assert {v["rule_id"] for v in violations} == {RULE_FIELD_OFFSET, RULE_FIELD_OVERLAP}
+        assert all(v["severity"] == "warning" for v in violations)
+        assert payload["summary"]["errors"] == 0
+        assert payload["summary"]["passed"] is True
+        # Per-rule bookkeeping is always present for CI consumers.
+        assert payload["summary"]["rules_checked_by_rule"] == {
+            RULE_FIELD_OFFSET: 1,
+            RULE_FIELD_OVERLAP: 1,
+        }
+
+    def test_threshold_flag_plumbed(
+        self, board_with_defective_schematic, stub_meta_subchecks, capsys
+    ) -> None:
+        rc = self._main(
+            [
+                str(board_with_defective_schematic),
+                "--only",
+                "sch_fields",
+                "--sch-field-threshold",
+                "1000",
+                "--format",
+                "json",
+            ]
+        )
+        payload = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        # The huge threshold silences the offset rule; the overlap pair remains.
+        assert {v["rule_id"] for v in payload["violations"]} == {RULE_FIELD_OVERLAP}
+
+    def test_outer_kct_parser_forwards_threshold(
+        self, board_with_defective_schematic, stub_meta_subchecks, capsys
+    ) -> None:
+        """The flag must survive the kct -> commands/validation.py ->
+        check_cmd forwarding chain (the #4633 drift-bug class)."""
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(
+            [
+                "check",
+                str(board_with_defective_schematic),
+                "--only",
+                "sch_fields",
+                "--sch-field-threshold",
+                "1000",
+                "--format",
+                "json",
+            ]
+        )
+        from kicad_tools.cli.commands.validation import run_check_command
+
+        rc = run_check_command(args)
+        payload = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert {v["rule_id"] for v in payload["violations"]} == {RULE_FIELD_OVERLAP}
+
+    def test_consecutive_runs_byte_identical(
+        self, board_with_defective_schematic, stub_meta_subchecks, capsys
+    ) -> None:
+        rc1 = self._main(
+            [str(board_with_defective_schematic), "--only", "sch_fields", "--format", "json"]
+        )
+        out1 = capsys.readouterr().out
+        rc2 = self._main(
+            [str(board_with_defective_schematic), "--only", "sch_fields", "--format", "json"]
+        )
+        out2 = capsys.readouterr().out
+        assert rc1 == rc2 == 0
+        assert out1 == out2
+
+    def test_drc_only_never_runs_sch_fields(self, board_with_defective_schematic, capsys) -> None:
+        # Documented decision (#4595): --drc-only pins the legacy PCB-only
+        # stdout/exit contract, so the schematic lint is not run there.
+        self._main([str(board_with_defective_schematic), "--drc-only"])
+        out = capsys.readouterr().out
+        assert "sch_field" not in out
+
+    def test_no_schematic_category_silent(
+        self, tmp_path: Path, stub_meta_subchecks, capsys
+    ) -> None:
+        pcb = tmp_path / "lonely.kicad_pcb"
+        pcb.write_text(_PCB_TEMPLATE)
+        rc = self._main([str(pcb), "--only", "sch_fields", "--format", "json"])
+        payload = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert payload["violations"] == []


### PR DESCRIPTION
## Summary

Adds the `sch_fields` check category to `kct check` (issue #4595): a warning-severity schematic field-geometry lint with two rules, so a schematic PDF with adrift / superimposed labels can no longer sail through a certified bundle at ERC 0/0.

- **`sch_field_offset`** — a visible `Reference`/`Value` field farther than a threshold (default **15.0 mm**, strictly-greater-than; `--sch-field-threshold <mm>`) from the placed symbol body bbox. Measured with `schema/field_geometry.field_offset_mm` — the exact metric `kct sch tidy` (#4596) repairs, so "lint reports it, tidy fixes it" compose.
- **`sch_field_overlap`** — a visible field's estimated text bbox intersects another symbol's placed body bbox or another symbol's visible field text bbox (the `+3.3VA9`-style composite). Text bbox is a documented heuristic (font height from effects, 0.8×height per char, justify-aware, 90/270 axis swap). Each colliding pair reported once.

## Design (per the curator's recorded decisions)

- **Category, not meta-check row, not separate command**: wired as a CLI-level closure in `run_selected_checks` (the `pad_grid` pattern) — `--only sch_fields` / `--skip sch_fields`, `BY RULE:` breakdown, JSON report, and waivers all come for free. Deliberately NOT a `DRCChecker` method (the checker is PCB-scoped).
- **Schematic seam**: reuses the exact resolution ERC/LVS use — extracted the `run_meta_checks` resolution block into `_resolve_check_schematic()` (explicit `--schematic` override, else `resolve_schematic_for_pcb` sibling discovery) and both paths call it. No schematic → the category emits nothing and never fails (the #4350 loud stderr warning covers visibility).
- **Never fab-blocking**: WARNING severity only; both rule ids mapped explicitly to `CATEGORY_ADVISORY` in `DRCChecker.RULE_CATEGORY` (required — unknown ids default to the Manufacturing bucket). With only `sch_fields` findings, `kct check` exits 0; `--strict` fatality is the pre-existing global contract (same as `silk_over_copper`), not special-cased.
- **`--drc-only`**: the category is NOT run (documented decision) — `--drc-only` pins the legacy PCB-only stdout/exit contract, so schematic-sourced findings must not appear there.
- **Threshold**: fixed 15.0 mm v1 default; the adaptive per-sheet-median variant from the original report is explicitly deferred (noted in flag help + module docstring). Flag declared on BOTH parsers and forwarded by the `commands/validation.py` shim (the #4633 drift-bug class; guard is green).
- **Scope mirrors `kct sch tidy`** so lint and remediation agree: Reference/Value only, hidden fields skipped, `#`-power symbols skipped, unresolvable `lib_id` skipped with a stderr warning. Hierarchical sub-sheets are linted (each unique file once, cycle-guarded) — the motivating defect was on a sub-sheet.
- **Determinism**: findings sorted by (sheet file name, reference, field name, rule id); repeated runs byte-identical (tested).

## Drift-guard verdict (EXPECTED_COMMITTED_DRC_RULES)

**No new rule fires on the committed board-03 artifact — the guard is untouched.** Measured across all 8 committed `boards/*/output/*.kicad_sch`: 7 boards produce zero findings; board-04 produces one `sch_field_overlap` (`C16.Value text overlaps U2 body`), and board-04 has no committed-check guard (verified `EXPECTED_COMMITTED` exists only in the board-03 baseline test). `tests/router/test_board03_routing_baseline.py -m "not slow"` passes.

## Files

- `src/kicad_tools/validate/rules/schematic_fields.py` (new) — pure lint rule + `field_text_bbox` helper (kept local per read-only constraint on `schema/field_geometry.py`)
- `src/kicad_tools/cli/check_cmd.py` — category, closure, `_resolve_check_schematic`, `--sch-field-threshold`; zero contact with the #4600 dru-writer region
- `src/kicad_tools/cli/parser.py`, `src/kicad_tools/cli/commands/validation.py` — outer flag + forwarding shim
- `src/kicad_tools/validate/checker.py` — two explicit `CATEGORY_ADVISORY` entries
- `tests/test_check_schematic_fields.py` (new, 28 tests) — offset/overlap/boundary/rotation/mirror/skip-contracts/hierarchy/determinism + CLI wiring (exit codes, `--strict`, `--only`/`--skip`, threshold plumbing through the outer `kct` parser, byte-identical runs, `--drc-only`, missing schematic)
- `tests/test_check_cmd_coverage.py` — documented `NON_CHECKER_CATEGORIES` seam
- `CHANGELOG.md` — Unreleased bullet

## Test results

- `tests/test_check_schematic_fields.py` — 28 passed
- `tests/router/test_board03_routing_baseline.py -m "not slow"` + `tests/test_check_cmd_coverage.py` + `tests/test_cli_parser_drift.py` — 49 passed
- `tests/test_cli_check.py` + `tests/test_netlist_sync_gate.py` + `tests/test_lvs_recipe.py` — 126 passed
- `tests/test_cli_check_waivers.py`, `test_pad_grid_auto_derive.py`, `test_routing_quality_metrics.py`, `test_connector_edge_access.py`, `test_connectivity_rule.py`, `test_validate_courtyard_overlap.py`, `test_sch_tidy.py`, `test_mfr_profile_consistency.py` — 223 passed
- `uv run ruff check .` clean; baseline-gated mypy: no new errors (1473 ≤ 1474 baseline)
- End-to-end: `kct check boards/03-usb-joystick/.../usb_joystick_routed.kicad_pcb --only sch_fields` → discovers the sibling schematic, 2 rules checked, 0 findings

Closes #4595

🤖 Generated with [Claude Code](https://claude.com/claude-code)
