### PR TITLE
feat(router): honor KiCad keepout rule-areas in the lattice engine with per-net-class filter (#4605)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,25 @@ constructor). No breaking changes.
   envelopes are deliberately excluded (same-domain by construction; emitted
   legs remain audited). The mesh engine stays post-route-gated only (#4602).
 
+- **Keepout rule areas honored by the lattice engine, with a per-net-class
+  filter** — KiCad `(zone … (keepout …))` rule areas now parse into a
+  first-class model (`schema/pcb.py`: `Zone.keepout` flags + multi-layer
+  `Zone.layers` + `PCB.rule_areas`; previously the `keepout` child was
+  silently dropped) and `--route-engine lattice` enforces them at search
+  time: `tracks not_allowed` keeps every segment's copper edge out of the
+  area on its declared layers, `vias not_allowed` rejects through-vias whose
+  barrel would enter it, and `copperpour not_allowed`-only areas (the
+  `kct zones hv-keepout` pour voids) never constrain routing. A new
+  `spatial_keepouts` block in the `--net-class-map` sidecar scopes an area
+  per net class by zone name (`only_classes` / `except_classes`; no entry =
+  KiCad-default all-nets), which makes disjoint HV bank corridors expressible
+  as complementary keepouts — declarable spatial segregation by construction,
+  composing with (not replacing) the #4602 pairwise search-time avoidance.
+  Nets rendered unroutable by an area report keepout-attributed declines
+  (`pad-escape-*-keepout`, `no-path-keepout-constrained`); boards with no
+  track/via-blocking rule areas route byte-identically; grid/mesh warn once
+  that they do not honor rule areas (#4605).
+
 - **`kct sch tidy` — headless Reference/Value field autoplace** — new
   schematic subcommand that resets visible `Reference`/`Value` field
   positions to deterministic bbox-relative defaults (Reference centered

--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -845,6 +845,60 @@ Not covered — document, do not assume:
   copper traces, and honors a preserved via's class clearance, but a new via
   does not yet apply *its own* class clearance against other vias.
 
+### Keepout rule areas (lattice engine)
+
+The **lattice** engine (`--route-engine lattice`) honors KiCad **keepout rule
+areas** — `(zone … (keepout …))` — at search time
+([#4605](https://github.com/rjwalters/kicad-tools/issues/4605)):
+
+- `(tracks not_allowed)` keeps every routed segment's **copper edge** (not
+  just the centerline) out of the area, on the area's declared layers;
+- `(vias not_allowed)` rejects any through-via whose barrel would enter the
+  area on any of its layers;
+- `(copperpour not_allowed)` is the zone filler's business and never
+  constrains routing — the pour voids `kct zones hv-keepout` emits route
+  identically with or without this feature;
+- `pads` / `footprints` flags are ignored by the router (placement's remit).
+
+Rule areas apply to **all nets by default** (standard KiCad semantics). To
+scope an area per net class — the spatial HV-segregation primitive: disjoint
+bank corridors are just complementary keepouts — add a `spatial_keepouts`
+block to the `--net-class-map` sidecar, keyed by the rule area's **zone name**
+(the `(name "…")` node, editable in the KiCad zone properties dialog):
+
+```json
+{
+  "/HV_A": { "name": "HV_A" },
+  "/HV_B": { "name": "HV_B" },
+  "spatial_keepouts": {
+    "hv-a-corridor-guard": { "only_classes": ["HV_A"] },
+    "hv-b-corridor-guard": { "only_classes": ["HV_B"] },
+    "antenna-zone":        { "except_classes": ["RF"] }
+  }
+}
+```
+
+Per entry, exactly one of:
+
+- `only_classes` — the area constrains **only** nets in the listed classes
+  (every other net routes through freely). "Class `HV_A` stays inside region
+  A" is expressed as an area covering the **complement** of region A with
+  `only_classes: ["HV_A"]`.
+- `except_classes` — the area constrains every net **except** the listed
+  classes (e.g. an exclusion zone that the zone's own bank may still enter).
+
+A rule area with no `spatial_keepouts` entry (or no zone name) applies to all
+nets. Naming a class that exists nowhere in the effective net-class map is a
+hard error (exit 1) — a typo would otherwise silently widen or narrow a
+spatial safety constraint. A net rendered unroutable by a keepout reports a
+keepout-attributed decline (`pad-escape-*-keepout`,
+`no-path-keepout-constrained`) rather than a generic failure.
+
+**Engine support**: lattice only. `--route-engine grid` / `mesh` print a
+one-line warning when the board declares track/via-blocking rule areas and
+will route through them (KiCad's own DRC still flags the violations
+downstream).
+
 ---
 
 ## See Also

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -3879,26 +3879,125 @@ def _apply_net_class_map_sidecar(router: "Autorouter", args, quiet: bool = False
     Idempotent and a no-op when the flag was not supplied.
     """
     loaded = getattr(args, "_loaded_net_class_map", None)
-    if not loaded:
+    if loaded:
+        from kicad_tools.router.net_names import nearest_net_names
+
+        resolution, diagnostic_net_names = _resolve_net_class_map_domains(router, loaded.keys())
+
+        # Apply overrides rekeyed to the board's actual net names so
+        # ``self.net_class_map.get(net_name)`` finds them at routing time.
+        for board_net, user_key in resolution.resolved.items():
+            router.net_class_map[board_net] = loaded[user_key]
+
+        _warn_unresolved_net_class_map(resolution, diagnostic_net_names, nearest_net_names)
+
+        if not quiet:
+            from kicad_tools.cli.progress import flush_print
+
+            flush_print(
+                f"  Net-class map: merged {len(resolution.resolved)}/{resolution.total} "
+                "sidecar entries"
+            )
+
+    # Issue #4605: stash the ``spatial_keepouts`` rule-area filter block on
+    # the router for the lattice keepout projection.  Runs AFTER the merge
+    # above so class-name validation sees the sidecar-defined classes too;
+    # runs even when the sidecar declares no net-class entries at all.
+    _stash_spatial_keepout_filters(router, args, quiet=quiet)
+
+
+def _validate_spatial_keepouts_block(block: object) -> str | None:
+    """Structural validation of the ``spatial_keepouts`` sidecar block (#4605).
+
+    Shape: ``{rule_area_zone_name: {"except_classes": [str, ...]}}`` or
+    ``{... {"only_classes": [str, ...]}}`` -- one of the two per entry, never
+    both (their combination has no defined precedence).  Returns a human
+    message on the first defect, ``None`` when the block is valid (or absent).
+    Class-NAME existence is validated later against the router's merged
+    net-class map (:func:`_stash_spatial_keepout_filters`).
+    """
+    if block is None:
+        return None
+    if not isinstance(block, dict):
+        return f"expected an object, got {type(block).__name__}"
+    for zone_name, entry in block.items():
+        if not isinstance(entry, dict):
+            return f"entry {zone_name!r} must be an object, got {type(entry).__name__}"
+        unknown = set(entry) - {"except_classes", "only_classes"}
+        if unknown:
+            return f"entry {zone_name!r} has unknown key(s): {', '.join(sorted(unknown))}"
+        if "except_classes" in entry and "only_classes" in entry:
+            return f"entry {zone_name!r} sets both except_classes and only_classes"
+        if not entry:
+            return f"entry {zone_name!r} must set except_classes or only_classes"
+        for key, value in entry.items():
+            if not isinstance(value, list) or not all(isinstance(v, str) for v in value):
+                return f"entry {zone_name!r}: {key} must be a list of class-name strings"
+    return None
+
+
+def _stash_spatial_keepout_filters(router: "Autorouter", args, quiet: bool = False) -> None:
+    """Stash (and class-name-validate) the ``spatial_keepouts`` filters (#4605).
+
+    The block itself was structurally validated at preload
+    (:func:`_validate_spatial_keepouts_block`); here -- after the sidecar's
+    net-class entries have been merged into ``router.net_class_map`` -- every
+    referenced class name is checked against the classes that actually exist.
+    A typo would otherwise silently widen (``only_classes``) or narrow
+    (``except_classes``) a spatial safety constraint, so an unknown name is a
+    hard exit 1, mirroring the other sidecar preload failures.
+    """
+    filters = getattr(args, "_spatial_keepouts", None)
+    with contextlib.suppress(AttributeError):  # exotic router stand-ins
+        router._spatial_keepout_filters = filters
+    if not filters:
         return
-
-    from kicad_tools.router.net_names import nearest_net_names
-
-    resolution, diagnostic_net_names = _resolve_net_class_map_domains(router, loaded.keys())
-
-    # Apply overrides rekeyed to the board's actual net names so
-    # ``self.net_class_map.get(net_name)`` finds them at routing time.
-    for board_net, user_key in resolution.resolved.items():
-        router.net_class_map[board_net] = loaded[user_key]
-
-    _warn_unresolved_net_class_map(resolution, diagnostic_net_names, nearest_net_names)
-
+    known = {name for nc in router.net_class_map.values() if (name := getattr(nc, "name", None))}
+    for zone_name, entry in filters.items():
+        for key in ("except_classes", "only_classes"):
+            for cls_name in entry.get(key) or ():
+                if cls_name not in known:
+                    print(
+                        f"Error: spatial_keepouts[{zone_name!r}]: unknown net class "
+                        f"{cls_name!r} (known classes: {', '.join(sorted(known)) or 'none'})",
+                        file=sys.stderr,
+                    )
+                    raise SystemExit(1)
     if not quiet:
         from kicad_tools.cli.progress import flush_print
 
-        flush_print(
-            f"  Net-class map: merged {len(resolution.resolved)}/{resolution.total} sidecar entries"
-        )
+        flush_print(f"  Spatial keepouts: {len(filters)} rule-area filter(s) loaded")
+
+
+def _warn_rule_areas_other_engine(pcb_path: Path, engine: str) -> None:
+    """One-line warning when rule areas exist but the engine ignores them.
+
+    Issue #4605: only the LATTICE engine honors ``(tracks not_allowed)`` /
+    ``(vias not_allowed)`` keepout rule areas at search time.  Routing such a
+    board with grid/mesh silently commits copper straight through the
+    declared areas, so say so once -- a warning, not a gate (KiCad's own DRC
+    still catches the violation downstream).  Pour-void-only rule areas (the
+    ``kct zones hv-keepout`` output) trigger nothing: they never constrain
+    routing on any engine.  A cheap text scan on purpose -- no board model is
+    built this early.
+    """
+    if engine == "lattice":
+        return
+    try:
+        text = pcb_path.read_text()
+    except OSError:
+        return
+    for match in re.finditer(r"\(keepout\b", text):
+        window = text[match.start() : match.start() + 400]
+        if "(tracks not_allowed" in window or "(vias not_allowed" in window:
+            print(
+                "Warning: board declares track/via-blocking keepout rule areas, "
+                f"but --route-engine {engine} does not honor them (only the "
+                "lattice engine does; see issue #4605). Routed copper may "
+                "cross the declared areas.",
+                file=sys.stderr,
+            )
+            return
 
 
 def _apply_pairwise_clearance(router: "Autorouter", args, quiet: bool = False) -> None:
@@ -11884,6 +11983,7 @@ def main(argv: list[str] | None = None) -> int:
     # ``args._loaded_net_class_map`` for downstream consumers (each
     # ``load_pcb_for_routing`` site merges it into ``router.net_class_map``).
     args._loaded_net_class_map = None
+    args._spatial_keepouts = None
     if getattr(args, "net_class_map", None) is not None:
         import json as _ncm_json
 
@@ -11936,6 +12036,21 @@ def main(argv: list[str] | None = None) -> int:
         except (TypeError, ValueError) as e:
             print(f"Error: invalid net-class-map structure: {e}", file=sys.stderr)
             return 1
+        # Issue #4605: the optional ``spatial_keepouts`` block -- per-rule-area
+        # net-class filters for KiCad keepout rule areas (lattice engine).
+        # Structure is validated HERE so a malformed block short-circuits with
+        # exit 1 before any routing work; the class NAMES are validated later,
+        # once the router's merged net-class map exists
+        # (``_apply_net_class_map_sidecar``).
+        _sk_err = _validate_spatial_keepouts_block(_ncm_data.get("spatial_keepouts"))
+        if _sk_err is not None:
+            print(f"Error: invalid spatial_keepouts block: {_sk_err}", file=sys.stderr)
+            return 1
+        args._spatial_keepouts = _ncm_data.get("spatial_keepouts")
+
+    # Issue #4605: rule areas are honored by the lattice engine only -- warn
+    # once (never gate) when another engine is about to ignore them.
+    _warn_rule_areas_other_engine(pcb_path, getattr(args, "route_engine", "grid") or "grid")
 
     # Issue #4431 (Phase 1): validate and load the optional --voltage-map early
     # (mirrors the --net-class-map preload above) so a missing file / malformed

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -1022,6 +1022,16 @@ class Autorouter:
         # board-origin shift per PR #4603).  ``None`` = not yet resolved.
         # Consumed here by the lattice pairwise projection (#4602).
         self._pairwise_attach_zones_cache: tuple[Any, ...] | None = None
+        # Issue #4605: optional ``spatial_keepouts`` sidecar filter block
+        # (``{rule_area_name: {"except_classes": [...] | "only_classes":
+        # [...]}}``), stashed by the CLI's ``_apply_net_class_map_sidecar``.
+        # ``None`` = no filter -> every rule area applies to all nets
+        # (KiCad-default semantics).
+        self._spatial_keepout_filters: dict[str, Any] | None = None
+        # Memoised lattice keepout-mask projection (built at most once per
+        # router by ``_lattice_keepout_projection``).
+        self._lattice_keepouts_cache: Any = None
+        self._lattice_keepouts_resolved: bool = False
         # Issue #2610: stored so _create_grid_and_routers can pass it to
         # create_hybrid_router on the initial construction.
         self._max_search_iterations = int(max_search_iterations) if max_search_iterations else 0
@@ -2663,17 +2673,164 @@ class Autorouter:
 
         from .lattice.pairwise import build_lattice_pairwise
 
+        zones = self._pairwise_attach_zones_cache or ()
+        return build_lattice_pairwise(table, zones, self._net_name_to_id())
+
+    def _net_name_to_id(self) -> dict[str, int]:
+        """Net name -> id map (``net_names`` + a pad-derived fallback).
+
+        Shared by the lattice pairwise (#4602) and keepout (#4605)
+        projections: a router assembled without ``add_component`` (tests,
+        deserialization) may have an empty ``net_names`` map while its pads
+        still carry names.
+        """
         name_to_id: dict[str, int] = {
             name: int(net_id) for net_id, name in self.net_names.items() if name
         }
-        # Defensive union with the pad-derived names: a router assembled
-        # without ``add_component`` (tests, deserialization) may have an
-        # empty ``net_names`` map while its pads still carry names.
         for pad in self.all_pads or list(self.pads.values()):
             if pad.net_name and pad.net_name not in name_to_id and pad.net is not None:
                 name_to_id[pad.net_name] = int(pad.net)
-        zones = self._pairwise_attach_zones_cache or ()
-        return build_lattice_pairwise(table, zones, name_to_id)
+        return name_to_id
+
+    def _lattice_keepout_projection(self) -> Any:
+        """Keepout rule-area mask for the lattice engine (issue #4605).
+
+        Reads the board's ``(zone ... (keepout ...))`` rule areas from the
+        source PCB (the same recorded path the #4506 attach-zone resolver
+        uses), keeps only areas that block tracks and/or vias (a
+        ``copperpour not_allowed``-only area -- the ``kct zones hv-keepout``
+        output -- is the zone filler's business and must never affect
+        routing), shifts their polygons board-relative -> sheet-absolute
+        (``PCB.load`` exposes zone polygons board-relative, the lattice works
+        sheet-absolute -- the #4416/#4603 offset), resolves their layer specs
+        against the real copper stack, and joins the optional
+        ``spatial_keepouts`` sidecar filter (class names -> net-id sets).
+
+        The pathfinder stays geometry-only: it receives resolved polygons,
+        lattice layer indices, and net-id applicability sets -- never names
+        (#4597 discipline).  Returns ``None`` when the board declares no
+        track/via-blocking rule areas, the dormant signal that keeps the
+        lattice search byte-identical to the pre-#4605 path.
+
+        Raises:
+            ValueError: a ``spatial_keepouts`` filter names a net class that
+                exists nowhere in the router's net-class map (fail loud: a
+                typo here would silently widen or narrow a safety constraint).
+        """
+        if self._lattice_keepouts_resolved:
+            return self._lattice_keepouts_cache
+        self._lattice_keepouts_resolved = True
+        self._lattice_keepouts_cache = None
+
+        pcb_path = self._pairwise_attach_zone_pcb_path
+        if pcb_path is None:
+            return None
+
+        from .lattice.obstacles import KeepoutArea, LatticeKeepoutMask
+
+        try:
+            from kicad_tools.schema.pcb import PCB as _SchemaPCB
+
+            pcb = _SchemaPCB.load(pcb_path)
+        except Exception as exc:  # defensive: never crash routing on a bad board
+            import sys as _sys
+
+            print(
+                f"Warning: could not read keepout rule areas from {pcb_path} "
+                f"({type(exc).__name__}: {exc}); rule areas will not constrain routing.",
+                file=_sys.stderr,
+            )
+            return None
+
+        raw_areas = [
+            zone
+            for zone in pcb.rule_areas
+            if zone.keepout is not None
+            and (not zone.keepout.tracks_allowed or not zone.keepout.vias_allowed)
+            and len(zone.polygon) >= 3
+        ]
+        if not raw_areas:
+            return None
+
+        from .layers import LayerStack as _LayerStack
+
+        stack = self.layer_stack or _LayerStack.two_layer()
+        all_indices = frozenset(layer.index for layer in stack.layers)
+
+        def _resolve_layers(names: list[str]) -> frozenset[int]:
+            indices: set[int] = set()
+            for name in names:
+                if name == "*.Cu":
+                    indices.update(all_indices)
+                elif name == "F&B.Cu":
+                    indices.update({0, stack.num_layers - 1})
+                else:
+                    layer_def = stack.get_layer_by_name(name)
+                    if layer_def is not None:
+                        indices.add(layer_def.index)
+            return frozenset(indices)
+
+        # Class-name -> net-id resolution for the sidecar filter.
+        filters = self._spatial_keepout_filters or {}
+        class_ids: dict[str, frozenset[int]] = {}
+        if filters:
+            name_to_id = self._net_name_to_id()
+            by_class: dict[str, set[int]] = {}
+            known_classes: set[str] = set()
+            for net_name, nc in self.net_class_map.items():
+                cls_name = getattr(nc, "name", None)
+                if not cls_name:
+                    continue
+                known_classes.add(cls_name)
+                net_id = name_to_id.get(net_name)
+                if net_id is not None:
+                    by_class.setdefault(cls_name, set()).add(net_id)
+            for entry in filters.values():
+                for key in ("except_classes", "only_classes"):
+                    for cls_name in entry.get(key) or ():
+                        if cls_name not in known_classes:
+                            raise ValueError(
+                                f"spatial_keepouts: unknown net class {cls_name!r} "
+                                f"(known classes: {', '.join(sorted(known_classes)) or 'none'})"
+                            )
+                        class_ids[cls_name] = frozenset(by_class.get(cls_name, set()))
+
+        ox, oy = pcb.board_origin
+        areas: list[KeepoutArea] = []
+        for zone in raw_areas:
+            layer_names = zone.layers or ([zone.layer] if zone.layer else [])
+            layer_indices = _resolve_layers(layer_names)
+            if not layer_indices:
+                continue  # rule area on no routable copper layer
+            entry = filters.get(zone.name) if zone.name else None
+            only: frozenset[int] | None = None
+            exempt: frozenset[int] = frozenset()
+            if entry:
+                if entry.get("only_classes"):
+                    ids: set[int] = set()
+                    for cls_name in entry["only_classes"]:
+                        ids.update(class_ids.get(cls_name, frozenset()))
+                    only = frozenset(ids)
+                if entry.get("except_classes"):
+                    ids = set()
+                    for cls_name in entry["except_classes"]:
+                        ids.update(class_ids.get(cls_name, frozenset()))
+                    exempt = frozenset(ids)
+            assert zone.keepout is not None  # filtered above
+            areas.append(
+                KeepoutArea(
+                    polygon=tuple((x + ox, y + oy) for x, y in zone.polygon),
+                    layers=layer_indices,
+                    blocks_tracks=not zone.keepout.tracks_allowed,
+                    blocks_vias=not zone.keepout.vias_allowed,
+                    only=only,
+                    exempt=exempt,
+                    name=zone.name,
+                )
+            )
+        mask = LatticeKeepoutMask(areas)
+        self._lattice_keepouts_cache = mask if mask else None
+        return self._lattice_keepouts_cache
 
     @staticmethod
     def _snap_lattice_region(
@@ -2870,6 +3027,16 @@ class Autorouter:
         # ``route_cmd.py`` (``LatticePathfinder`` itself always has it).
         if hasattr(pf, "set_pairwise"):
             pf.set_pairwise(self._lattice_pairwise_projection())
+
+        # Issue #4605: resolve the board's keepout rule areas (+ the optional
+        # ``spatial_keepouts`` sidecar filter) into a geometry-only mask and
+        # install it, so a ``(tracks not_allowed)`` / ``(vias not_allowed)``
+        # rule area is honored DURING search.  Always called -- ``None``
+        # resets a reused pathfinder (no stale rule areas), and is the
+        # guaranteed result on boards with no track/via-blocking rule areas
+        # (byte-identical no-constraint path).
+        if hasattr(pf, "set_keepouts"):
+            pf.set_keepouts(self._lattice_keepout_projection())
 
         coupled, reserved = self._lattice_coupled_connections()
 

--- a/src/kicad_tools/router/lattice/geometry.py
+++ b/src/kicad_tools/router/lattice/geometry.py
@@ -88,6 +88,55 @@ def seg_rect_intersect(a: Pt, b: Pt, rect: Rect) -> bool:
     return False
 
 
+def polygon_bbox(poly: list[Pt] | tuple[Pt, ...]) -> Rect:
+    """Axis-aligned bounding box of a polygon vertex list."""
+    xs = [p[0] for p in poly]
+    ys = [p[1] for p in poly]
+    return (min(xs), min(ys), max(xs), max(ys))
+
+
+def pt_in_polygon(p: Pt, poly: list[Pt] | tuple[Pt, ...]) -> bool:
+    """True if ``p`` lies inside simple polygon ``poly`` (ray casting).
+
+    Boundary points may report either side (float grazing); callers that
+    need edge-inclusive behavior combine this with an edge-distance check
+    (see :func:`seg_near_polygon`), which is what the keepout mask does.
+    """
+    inside = False
+    n = len(poly)
+    px, py = p
+    for i in range(n):
+        ax, ay = poly[i]
+        bx, by = poly[(i + 1) % n]
+        if (ay > py) != (by > py):
+            x_cross = ax + (py - ay) / (by - ay) * (bx - ax)
+            if px < x_cross:
+                inside = not inside
+    return inside
+
+
+def seg_near_polygon(a: Pt, b: Pt, poly: list[Pt] | tuple[Pt, ...], inflate: float) -> bool:
+    """True if segment ``a-b`` comes within ``inflate`` of polygon ``poly``.
+
+    Issue #4605 (keepout rule areas): the copper-edge test.  A trace of
+    half-width ``inflate`` whose centreline is ``a-b`` intersects the
+    polygon iff (a) an endpoint is inside, (b) the segment crosses the
+    boundary (edge distance 0), or (c) the segment passes within
+    ``inflate`` of a boundary edge.  A degenerate ``a == b`` form doubles
+    as a point probe.  Case (b) also covers a segment that pierces a
+    concave polygon without leaving an endpoint inside.
+    """
+    if pt_in_polygon(a, poly) or pt_in_polygon(b, poly):
+        return True
+    n = len(poly)
+    for i in range(n):
+        c = poly[i]
+        d = poly[(i + 1) % n]
+        if seg_seg_dist(a, b, c, d) < inflate - 1e-9:
+            return True
+    return False
+
+
 class SegHash:
     """Uniform-bucket spatial hash over committed copper segments.
 

--- a/src/kicad_tools/router/lattice/obstacles.py
+++ b/src/kicad_tools/router/lattice/obstacles.py
@@ -22,6 +22,7 @@ per copper layer:
 from __future__ import annotations
 
 from collections import defaultdict
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from ..primitives import Pad
@@ -30,7 +31,9 @@ from .geometry import (
     Rect,
     SegHash,
     dist,
+    polygon_bbox,
     pt_in_rect,
+    seg_near_polygon,
     seg_pt_dist,
     seg_rect_intersect,
     seg_seg_dist,
@@ -225,6 +228,113 @@ class LatticeObstacleModel:
             if seg_rect_intersect(a, b, grown) and not pairwise.exempt_seg_pt(
                 a, b, (pad.x, pad.y), net, pad.net
             ):
+                return True
+        return False
+
+
+@dataclass(frozen=True)
+class KeepoutArea:
+    """One resolved keepout rule area in lattice space (issue #4605).
+
+    The CALLER (``Autorouter._lattice_keepout_projection``) resolves the
+    KiCad ``(zone ... (keepout ...))`` rule areas into this flat carrier --
+    sheet-absolute polygon, lattice layer indices, per-object-type blocking
+    flags, and a net-id applicability filter -- so the pathfinder stays
+    geometry-only and never sees net names or net classes (#4597 discipline).
+
+    Applicability (the ``spatial_keepouts`` sidecar filter): the area applies
+    to net ``n`` iff ``(only is None or n in only) and n not in exempt``.
+    ``only=None, exempt=frozenset()`` is the KiCad-default all-nets rule.
+    """
+
+    polygon: tuple[Pt, ...]
+    layers: frozenset[int]  # lattice layer indices the area covers
+    blocks_tracks: bool
+    blocks_vias: bool
+    only: frozenset[int] | None = None
+    exempt: frozenset[int] = frozenset()
+    name: str = ""
+    bbox: Rect = field(default=(0.0, 0.0, 0.0, 0.0))
+
+    def __post_init__(self) -> None:
+        if len(self.polygon) >= 3 and self.bbox == (0.0, 0.0, 0.0, 0.0):
+            object.__setattr__(self, "bbox", polygon_bbox(self.polygon))
+
+    def applies_to(self, net: int) -> bool:
+        """True when the area's rule governs net id ``net``."""
+        if self.only is not None and net not in self.only:
+            return False
+        return net not in self.exempt
+
+
+class LatticeKeepoutMask:
+    """Static per-board keepout rule-area mask for the lattice engine (#4605).
+
+    A parallel legality source to the pad masks: built once from the resolved
+    :class:`KeepoutArea` list and consulted by the same predicates the
+    pathfinder already routes every expansion through.  All queries are
+    geometric with an AABB pre-filter -- boards carry a handful of rule
+    areas, so per-query polygon checks (cached per lattice resource by the
+    search's ``edge_ok`` / ``node_ok`` memos) beat a full node/edge
+    precompute.
+
+    Semantics (KiCad rule-area flags, finding 6 of the #4605 curation):
+
+    * ``tracks not_allowed`` blocks SEGMENTS on the area's layers -- the
+      copper edge must stay out, so every query inflates by the querying
+      copper's half-width;
+    * ``vias not_allowed`` blocks a through-via whose barrel would enter the
+      area on ANY of the area's layers (a through-via exists on all layers);
+    * ``copperpour`` / ``pads`` / ``footprints`` flags are the zone filler's
+      and placement's business and are deliberately ignored here -- a
+      pour-void-only rule area (the ``kct zones hv-keepout`` output) must
+      never affect routing.
+    """
+
+    def __init__(self, areas: list[KeepoutArea] | tuple[KeepoutArea, ...]) -> None:
+        self.areas: tuple[KeepoutArea, ...] = tuple(
+            a for a in areas if len(a.polygon) >= 3 and (a.blocks_tracks or a.blocks_vias)
+        )
+
+    def __bool__(self) -> bool:
+        return bool(self.areas)
+
+    def segment_blocked(self, a: Pt, b: Pt, layer: int, net: int, half: float) -> bool:
+        """True if copper of half-width ``half`` along ``a-b`` on ``layer``
+        would enter a track-blocking rule area governing ``net``.
+
+        The degenerate ``a == b`` form doubles as a point (lattice-node)
+        probe, mirroring :meth:`LatticeObstacleModel.segment_blocked`.
+        """
+        x0, x1 = min(a[0], b[0]) - half, max(a[0], b[0]) + half
+        y0, y1 = min(a[1], b[1]) - half, max(a[1], b[1]) + half
+        for area in self.areas:
+            if not area.blocks_tracks or layer not in area.layers:
+                continue
+            if not area.applies_to(net):
+                continue
+            bx0, by0, bx1, by1 = area.bbox
+            if x1 < bx0 or bx1 < x0 or y1 < by0 or by1 < y0:
+                continue
+            if seg_near_polygon(a, b, area.polygon, half):
+                return True
+        return False
+
+    def via_blocked(self, point: Pt, net: int, via_radius: float) -> bool:
+        """True if a through-via at ``point`` would enter a via-blocking rule
+        area governing ``net`` (layer-agnostic: the barrel spans the stack,
+        so an area on any copper layer subset still intersects it)."""
+        x0, x1 = point[0] - via_radius, point[0] + via_radius
+        y0, y1 = point[1] - via_radius, point[1] + via_radius
+        for area in self.areas:
+            if not area.blocks_vias or not area.layers:
+                continue
+            if not area.applies_to(net):
+                continue
+            bx0, by0, bx1, by1 = area.bbox
+            if x1 < bx0 or bx1 < x0 or y1 < by0 or by1 < y0:
+                continue
+            if seg_near_polygon(point, point, area.polygon, via_radius):
                 return True
         return False
 

--- a/src/kicad_tools/router/lattice/pathfinder.py
+++ b/src/kicad_tools/router/lattice/pathfinder.py
@@ -53,7 +53,12 @@ from ..quantize import dogleg_points
 from ..rules import DesignRules
 from .coupled import CoupledConnection
 from .geometry import Pt, Rect, dist, pt_in_rect, seg_seg_dist
-from .obstacles import CommittedCopper, LatticeObstacleModel, seg_body_crosses_pt
+from .obstacles import (
+    CommittedCopper,
+    LatticeKeepoutMask,
+    LatticeObstacleModel,
+    seg_body_crosses_pt,
+)
 from .quadtree import EdgeKey, NodeKey, OctilinearLattice, RefineRegion
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -293,6 +298,15 @@ class LatticePathfinder:
         # ``--voltage-map``) keeps every predicate on its scalar path
         # byte-for-byte.
         self._pairwise: LatticePairwise | None = None
+        # Issue #4605: optional static keepout rule-area mask
+        # (:class:`.obstacles.LatticeKeepoutMask`), resolved by the CALLER
+        # from the board's ``(zone ... (keepout ...))`` rule areas + the
+        # ``spatial_keepouts`` sidecar filter -- the pathfinder stays
+        # geometry-only and never sees zone/net/class names.  ``None`` (the
+        # default, and always the case on a board with no track/via-blocking
+        # rule areas) keeps every predicate on its pre-#4605 path
+        # byte-for-byte.
+        self._keepouts: LatticeKeepoutMask | None = None
 
     def set_pairwise(self, pairwise: LatticePairwise | None) -> None:
         """Install (or clear) the id-space HV pairwise projection (#4602).
@@ -302,6 +316,17 @@ class LatticePathfinder:
         pathfinder so it cannot carry a stale projection across runs.
         """
         self._pairwise = pairwise
+
+    def set_keepouts(self, keepouts: LatticeKeepoutMask | None) -> None:
+        """Install (or clear) the keepout rule-area mask (#4605).
+
+        Consulted by the same three predicates every search expansion already
+        routes through (node / edge / free-segment legality) plus the via
+        gate -- no new call sites in the A* loop.  Passing ``None`` (or an
+        empty mask, normalised to ``None``) resets a reused pathfinder so it
+        cannot carry stale rule areas across runs.
+        """
+        self._keepouts = keepouts if keepouts else None
 
     # -- construction from a board ----------------------------------------
 
@@ -618,6 +643,12 @@ class LatticePathfinder:
         # keep-outs (the fat coupled path is excluded from pairwise widening
         # in this slice -- see ``coupled.committed_seg_clear_grown``).
         pw = None if fat else self._pairwise
+        # Issue #4605: keepout rule areas gate every stub candidate + dogleg
+        # leg at the leg's TRUE half-width (a tapered neck is probed as neck
+        # copper).  The fat coupled centerline skips the mask here -- the
+        # emitted offset legs are re-verified against it in
+        # ``_route_pair_impl``'s finish gate, so nothing under-masked ships.
+        ko = None if fat else self._keepouts
 
         candidates: list[tuple[float, NodeKey, Pt]] = []
         pad_pt = (pad.x, pad.y)
@@ -648,6 +679,8 @@ class LatticePathfinder:
                         point, point, layer, net, half, extra, pw
                     ):
                         continue
+                    if ko is not None and ko.segment_blocked(point, point, layer, net, half):
+                        continue
                     if not committed.node_clear(point, layer, net, half, clr):
                         continue
                 accepted: list[Pt] | None = None
@@ -673,6 +706,9 @@ class LatticePathfinder:
                             if pw is not None and obstacles.pairwise_pad_blocked(
                                 a, b, layer, net, half, extra, pw
                             ):
+                                ok = False
+                                break
+                            if ko is not None and ko.segment_blocked(a, b, layer, net, half):
                                 ok = False
                                 break
                             if not committed.seg_clear(a, b, layer, net, half, clr):
@@ -783,6 +819,34 @@ class LatticePathfinder:
             exempt_pads=exempt_pads,
         )
         return neck_stubs, neck_w
+
+    def _keepout_escape_reason(
+        self,
+        pad: Pad,
+        net: int,
+        stub_layers: tuple[int, ...] | None,
+        half: float,
+        base: str,
+    ) -> str:
+        """Refine an empty-stub decline with keepout attribution (#4605).
+
+        A pad whose OWN location sits inside an applicable track-keepout rule
+        area on every layer it could escape on can never produce a legal stub;
+        report that explicitly (``<base>-keepout``) instead of the generic
+        pad-escape decline the #3900 lesson warns against.  Any other empty
+        stub set keeps the honest base reason -- the mask is only blamed when
+        the pad point itself is provably covered.
+        """
+        keepouts = self._keepouts
+        if keepouts is None:
+            return base
+        layers = stub_layers if stub_layers is not None else self._pad_layer_indices(pad)
+        point = (pad.x, pad.y)
+        if layers and all(
+            keepouts.segment_blocked(point, point, layer, net, half) for layer in layers
+        ):
+            return base + "-keepout"
+        return base
 
     # -- via legality -----------------------------------------------------------
 
@@ -897,6 +961,11 @@ class LatticePathfinder:
             max(self._via_pad_grow, 0.0),
             self._pairwise,
         ):
+            return False
+        # Issue #4605: a ``(vias not_allowed)`` rule area governing this net
+        # rejects the through-via when its barrel would enter the area on ANY
+        # of the area's layers (the barrel spans the whole stack).
+        if self._keepouts is not None and self._keepouts.via_blocked(point, net, via_radius):
             return False
         return committed.via_clear(point, net)
 
@@ -1056,6 +1125,15 @@ class LatticePathfinder:
         # Issue #4602: per-PAIR HV pad keep-outs for the non-fat search (the
         # fat coupled path is excluded from pairwise widening in this slice).
         pw = None if fat else self._pairwise
+        # Issue #4605: keepout rule areas prune illegal resources in the same
+        # cached edge/node legality memos below.  ``ko_pruned`` records that
+        # the mask actually rejected at least one resource for THIS search, so
+        # a failing connection can report the keepout as a constraint instead
+        # of a bare "no-path" (the #3900 never-misattribute lesson).  The fat
+        # coupled centerline skips the mask in-search; its emitted legs are
+        # re-verified in ``_route_pair_impl``'s finish gate.
+        ko = None if fat else self._keepouts
+        ko_pruned = False
         if fat:
             # v1 coupled runs are planar; there is no fat via legality.
             allow_vias = False
@@ -1099,9 +1177,15 @@ class LatticePathfinder:
                 net_class=net_class,
             )
         if not stubs_a:
-            return None, "pad-escape-start"
+            reason = "pad-escape-start"
+            if not fat:
+                reason = self._keepout_escape_reason(start, net, stub_layers, half, reason)
+            return None, reason
         if not stubs_b:
-            return None, "pad-escape-end"
+            reason = "pad-escape-end"
+            if not fat:
+                reason = self._keepout_escape_reason(end, net, stub_layers, half, reason)
+            return None, reason
 
         goal: dict[_State, tuple[float, list[Pt]]] = {}
         for key, layer, poly, length in stubs_b:
@@ -1163,8 +1247,12 @@ class LatticePathfinder:
                     else:
                         ea = lattice.node_point(edge[0])
                         eb = lattice.node_point(edge[1])
+                        ko_hit = ko is not None and ko.segment_blocked(ea, eb, layer, net, half)
+                        if ko_hit:
+                            ko_pruned = True
                         ok = (
-                            not obstacles.edge_blocked(edge, layer, net)
+                            not ko_hit
+                            and not obstacles.edge_blocked(edge, layer, net)
                             and not (
                                 extra > 0.0 and obstacles.segment_blocked(ea, eb, layer, net, extra)
                             )
@@ -1191,8 +1279,12 @@ class LatticePathfinder:
                         )
                     else:
                         npt = lattice.node_point(nbr)
+                        ko_hit = ko is not None and ko.segment_blocked(npt, npt, layer, net, half)
+                        if ko_hit:
+                            ko_pruned = True
                         nok = (
-                            not obstacles.node_blocked(nbr, layer, net)
+                            not ko_hit
+                            and not obstacles.node_blocked(nbr, layer, net)
                             and not (
                                 extra > 0.0
                                 and obstacles.segment_blocked(npt, npt, layer, net, extra)
@@ -1231,8 +1323,12 @@ class LatticePathfinder:
                         nok = node_ok.get(nstate)
                         if nok is None:
                             kpt = lattice.node_point(key)
+                            ko_hit = ko is not None and ko.segment_blocked(kpt, kpt, nl, net, half)
+                            if ko_hit:
+                                ko_pruned = True
                             nok = (
-                                not obstacles.node_blocked(key, nl, net)
+                                not ko_hit
+                                and not obstacles.node_blocked(key, nl, net)
                                 and not (
                                     extra > 0.0
                                     and obstacles.segment_blocked(kpt, kpt, nl, net, extra)
@@ -1257,7 +1353,11 @@ class LatticePathfinder:
                             counter += 1
 
         if end_state is None:
-            return None, "no-path"
+            # Issue #4605: when the keepout mask actually rejected resources
+            # for this search, say so -- the area CONSTRAINED the search (it
+            # pruned candidates), which is honest without claiming it was the
+            # sole cause of the shortfall.
+            return None, "no-path-keepout-constrained" if ko_pruned else "no-path"
 
         # -- reconstruct ---------------------------------------------------
         chain: list[_State] = [end_state]
@@ -1662,6 +1762,14 @@ class LatticePathfinder:
                         return None, "pair-leg-blocked"
                     if not committed.seg_clear(a, b, layer, net):
                         return None, "pair-leg-blocked"
+                    # Issue #4605: the fat centerline search skips the keepout
+                    # mask, so the EMITTED legs (offset body + attach doglegs)
+                    # are verified against it here at their true half-width --
+                    # a coupled pair never ships copper through a rule area.
+                    if self._keepouts is not None and self._keepouts.segment_blocked(
+                        a, b, layer, net, trace_w / 2.0
+                    ):
+                        return None, "pair-leg-keepout"
                 legs.append((net, pad_a.net_name, full))
 
             # Intra-pair floor: leg-to-leg centreline separation must never

--- a/src/kicad_tools/router/rules.py
+++ b/src/kicad_tools/router/rules.py
@@ -1747,6 +1747,9 @@ def net_class_map_from_dict(
     self-document without a sibling README, e.g. a ``_comment`` string or
     a ``_meta`` dict block (issue #4248).  Because KiCad net names do not
     start with ``_`` in practice, this cannot shadow a real net entry.
+    The ``spatial_keepouts`` key is likewise reserved (issue #4605): it
+    carries per-rule-area net-class filters for KiCad keepout rule areas
+    and is parsed by the route CLI, not by this deserializer.
 
     Args:
         data: Mapping of ``net_name -> NetClassRouting-dict``.  Must be a
@@ -1774,6 +1777,12 @@ def net_class_map_from_dict(
     for net_name, entry in data.items():
         if isinstance(net_name, str) and net_name.startswith("_"):
             continue  # reserved for in-band documentation (_comment, _meta, ...)
+        if net_name == "spatial_keepouts":
+            # Issue #4605: reserved block -- per-rule-area net-class filters
+            # for KiCad keepout rule areas, parsed by the route CLI (never a
+            # net entry).  Skipped here so every sidecar consumer that only
+            # wants net classes keeps working.
+            continue
         if not isinstance(entry, dict):
             raise TypeError(
                 f"net_class_map entry for {net_name!r} must be a dict, got {type(entry).__name__}"

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -1267,11 +1267,49 @@ class Via:
 
 
 @dataclass
+class ZoneKeepout:
+    """Keepout settings of a KiCad rule area (``(zone ... (keepout ...))``).
+
+    Issue #4605: rule areas were previously dropped on parse (the ``keepout``
+    child was silently ignored), so no engine could honor a
+    ``(tracks not_allowed)`` area declared in the board.  Each flag mirrors
+    one ``(<object> allowed|not_allowed)`` child; a missing child defaults to
+    ``allowed`` (KiCad's own default for an unspecified object type).
+    """
+
+    tracks_allowed: bool = True
+    vias_allowed: bool = True
+    pads_allowed: bool = True
+    copperpour_allowed: bool = True
+    footprints_allowed: bool = True
+
+    @classmethod
+    def from_sexp(cls, sexp: SExp) -> ZoneKeepout:
+        """Parse a ``(keepout ...)`` node's per-object-type flags."""
+        keepout = cls()
+        for tag, attr in (
+            ("tracks", "tracks_allowed"),
+            ("vias", "vias_allowed"),
+            ("pads", "pads_allowed"),
+            ("copperpour", "copperpour_allowed"),
+            ("footprints", "footprints_allowed"),
+        ):
+            if child := sexp.find(tag):
+                setattr(keepout, attr, child.get_string(0) != "not_allowed")
+        return keepout
+
+
+@dataclass
 class Zone:
     """PCB copper pour zone.
 
     Represents a copper fill zone with boundary polygon and thermal relief settings.
     Zones are used for ground planes, power planes, and copper pours.
+
+    A zone carrying a ``(keepout ...)`` child is a KiCad **rule area** rather
+    than a pour: :attr:`keepout` holds its per-object-type flags (issue
+    #4605) and :meth:`is_rule_area` is True.  Rule areas are commonly
+    multi-layer (``(layers "F.Cu" "B.Cu")``), captured in :attr:`layers`.
     """
 
     net_number: int
@@ -1279,6 +1317,11 @@ class Zone:
     layer: str
     uuid: str = ""
     name: str = ""
+    # Multi-layer spec from a ``(layers ...)`` node (rule areas; may contain
+    # wildcards such as ``*.Cu`` / ``F&B.Cu``).  Empty for single-layer zones.
+    layers: list[str] = field(default_factory=list)
+    # Keepout flags when this zone is a rule area; None for pour zones.
+    keepout: ZoneKeepout | None = None
     # Boundary polygon points (x, y) in mm
     polygon: list[tuple[float, float]] = field(default_factory=list)
     # Filled polygon regions after DRC (may differ from boundary due to clearances)
@@ -1341,10 +1384,23 @@ class Zone:
             zone.net_name = net_name.get_string(0) or ""
         if layer := sexp.find("layer"):
             zone.layer = layer.get_string(0) or ""
+        # Multi-layer form (rule areas): (layers "F.Cu" "B.Cu") / (layers "*.Cu")
+        if layers := sexp.find("layers"):
+            zone.layers = [
+                layer_name
+                for i in range(len(layers.values))
+                if (layer_name := layers.get_string(i))
+            ]
+            if not zone.layer and zone.layers:
+                zone.layer = zone.layers[0]
         if uuid := sexp.find("uuid"):
             zone.uuid = uuid.get_string(0) or ""
         if name := sexp.find("name"):
             zone.name = name.get_string(0) or ""
+
+        # Rule-area keepout flags (issue #4605): (keepout (tracks not_allowed) ...)
+        if keepout := sexp.find("keepout"):
+            zone.keepout = ZoneKeepout.from_sexp(keepout)
 
         # Priority
         if priority := sexp.find("priority"):
@@ -3253,6 +3309,17 @@ class PCB:
     def zones(self) -> list[Zone]:
         """All zones (copper pours)."""
         return self._zones
+
+    @property
+    def rule_areas(self) -> list[Zone]:
+        """All keepout rule areas (zones carrying a ``(keepout ...)`` child).
+
+        Issue #4605: the first-class read path for KiCad rule areas.  Each
+        entry's :attr:`Zone.keepout` holds the per-object-type flags and
+        :attr:`Zone.layers` the (possibly multi-layer / wildcard) layer spec.
+        Polygon vertices are board-relative, like every other zone polygon.
+        """
+        return [zone for zone in self._zones if zone.keepout is not None]
 
     @property
     def graphic_lines(self) -> list[GraphicLine]:

--- a/src/kicad_tools/sexp/builders.py
+++ b/src/kicad_tools/sexp/builders.py
@@ -704,6 +704,7 @@ def keepout_node(
     no_vias: bool = True,
     no_pour: bool = True,
     uuid_str: str = "",
+    name: str = "",
 ) -> SExp:
     """Build a PCB keepout zone S-expression.
 
@@ -716,6 +717,8 @@ def keepout_node(
         no_vias: Prevent vias in this area
         no_pour: Prevent copper pour in this area
         uuid_str: Unique identifier
+        name: Optional rule-area name (issue #4605) -- the key the
+            ``spatial_keepouts`` net-class-map sidecar block filters by
 
     Example output:
         (zone
@@ -745,6 +748,8 @@ def keepout_node(
         uuid_node(uuid_str),
         SExp.list("hatch", "edge", 0.5),
     )
+    if name:
+        zone.append(SExp.list("name", name))
 
     # Add keepout settings
     keepout = SExp.list(

--- a/tests/router/lattice/test_keepout_areas.py
+++ b/tests/router/lattice/test_keepout_areas.py
@@ -1,0 +1,412 @@
+"""Keepout rule-area honoring in the lattice engine (issue #4605).
+
+Unit + pathfinder-level coverage of the spatial-constraint primitive:
+
+1. geometry: polygon containment / copper-edge inflation predicates;
+2. schema: ``(zone ... (keepout ...))`` rule areas parse into a first-class
+   model (flags, layers, polygon, name) without disturbing pour zones, and
+   round-trip through ``PCB.load`` -> ``save`` unchanged;
+3. mask semantics: per-layer coverage, half-width inflation, the
+   ``only`` / ``exempt`` net-id applicability filter, and the strict
+   independence of the ``tracks`` and ``vias`` flags -- a
+   ``copperpour not_allowed``-only area (the ``kct zones hv-keepout``
+   output) never blocks routing;
+4. pathfinder: a track-blocking wall reroutes / declines honestly (with a
+   keepout-attributed reason), a same-layer wall is dipped under via B.Cu,
+   an area governing only ANOTHER net leaves the route byte-identical to
+   the no-keepout baseline, and a pad inside its own applicable keepout
+   reports ``pad-escape-*-keepout`` (the #3900 never-misattribute lesson).
+"""
+
+from __future__ import annotations
+
+from kicad_tools.router.lattice.geometry import (
+    polygon_bbox,
+    pt_in_polygon,
+    seg_near_polygon,
+)
+from kicad_tools.router.lattice.obstacles import KeepoutArea, LatticeKeepoutMask
+from kicad_tools.router.lattice.pathfinder import LatticePathfinder
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.primitives import Pad, Route
+from kicad_tools.router.rules import DesignRules
+
+Pt = tuple[float, float]
+
+SQUARE: tuple[Pt, ...] = ((10.0, 10.0), (20.0, 10.0), (20.0, 20.0), (10.0, 20.0))
+
+
+def _pad(x: float, y: float, net: int, *, ref: str = "R1", layer: Layer = Layer.F_CU) -> Pad:
+    return Pad(
+        x=x,
+        y=y,
+        width=1.0,
+        height=1.0,
+        net=net,
+        net_name=f"N{net}",
+        layer=layer,
+        ref=ref,
+        pin="1",
+    )
+
+
+def _area(
+    polygon: tuple[Pt, ...] = SQUARE,
+    layers: frozenset[int] = frozenset({0, 1}),
+    *,
+    blocks_tracks: bool = True,
+    blocks_vias: bool = True,
+    only: frozenset[int] | None = None,
+    exempt: frozenset[int] = frozenset(),
+    name: str = "",
+) -> KeepoutArea:
+    return KeepoutArea(
+        polygon=polygon,
+        layers=layers,
+        blocks_tracks=blocks_tracks,
+        blocks_vias=blocks_vias,
+        only=only,
+        exempt=exempt,
+        name=name,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Geometry predicates.
+# ---------------------------------------------------------------------------
+
+
+def test_pt_in_polygon_and_bbox() -> None:
+    assert pt_in_polygon((15.0, 15.0), SQUARE)
+    assert not pt_in_polygon((5.0, 15.0), SQUARE)
+    assert not pt_in_polygon((25.0, 25.0), SQUARE)
+    assert polygon_bbox(SQUARE) == (10.0, 10.0, 20.0, 20.0)
+
+
+def test_seg_near_polygon_inflation_is_the_copper_edge_test() -> None:
+    half = 0.5
+    # Straddling segment: both endpoints outside, crosses the polygon.
+    assert seg_near_polygon((5.0, 15.0), (25.0, 15.0), SQUARE, half)
+    # Endpoint inside.
+    assert seg_near_polygon((15.0, 15.0), (25.0, 15.0), SQUARE, half)
+    # Outside, but the copper edge (centreline + half) grazes the boundary.
+    assert seg_near_polygon((5.0, 9.7), (25.0, 9.7), SQUARE, half)
+    # Outside with the copper edge clear of the boundary.
+    assert not seg_near_polygon((5.0, 9.4), (25.0, 9.4), SQUARE, half)
+    # Degenerate point probe.
+    assert seg_near_polygon((15.0, 15.0), (15.0, 15.0), SQUARE, half)
+    assert not seg_near_polygon((5.0, 5.0), (5.0, 5.0), SQUARE, half)
+
+
+# ---------------------------------------------------------------------------
+# 2. Schema parsing + round-trip.
+# ---------------------------------------------------------------------------
+
+
+def _rule_area_zone_text(
+    *,
+    name: str = "hv-bank-a",
+    tracks: str = "not_allowed",
+    vias: str = "not_allowed",
+    copperpour: str = "allowed",
+) -> str:
+    return f"""(zone
+  (net 0)
+  (net_name "")
+  (name "{name}")
+  (layers "F.Cu" "B.Cu")
+  (uuid "aaaaaaaa-0000-0000-0000-000000000001")
+  (hatch edge 0.5)
+  (keepout (tracks {tracks}) (vias {vias}) (pads allowed) (copperpour {copperpour}))
+  (polygon (pts (xy 10 10) (xy 20 10) (xy 20 20) (xy 10 20)))
+)"""
+
+
+def test_rule_area_parses_flags_layers_polygon_and_name() -> None:
+    from kicad_tools.schema.pcb import Zone
+    from kicad_tools.sexp.parser import parse_string
+
+    zone = Zone.from_sexp(parse_string(_rule_area_zone_text()))
+    assert zone.keepout is not None
+    assert zone.keepout.tracks_allowed is False
+    assert zone.keepout.vias_allowed is False
+    assert zone.keepout.pads_allowed is True
+    assert zone.keepout.copperpour_allowed is True
+    assert zone.name == "hv-bank-a"
+    assert zone.layers == ["F.Cu", "B.Cu"]
+    assert zone.polygon == [(10.0, 10.0), (20.0, 10.0), (20.0, 20.0), (10.0, 20.0)]
+
+
+def test_pour_zone_parsing_is_unchanged_and_not_a_rule_area() -> None:
+    from kicad_tools.schema.pcb import Zone
+    from kicad_tools.sexp.parser import parse_string
+
+    text = """(zone
+  (net 1)
+  (net_name "GND")
+  (layer "F.Cu")
+  (uuid "bbbbbbbb-0000-0000-0000-000000000002")
+  (hatch edge 0.5)
+  (connect_pads (clearance 0.2))
+  (min_thickness 0.25)
+  (fill yes (thermal_gap 0.3) (thermal_bridge_width 0.3))
+  (polygon (pts (xy 0 0) (xy 30 0) (xy 30 30) (xy 0 30)))
+)"""
+    zone = Zone.from_sexp(parse_string(text))
+    assert zone.keepout is None
+    assert zone.net_name == "GND"
+    assert zone.layer == "F.Cu"
+
+
+def test_hv_keepout_pour_void_output_is_routing_neutral() -> None:
+    """``kct zones hv-keepout`` emits ``copperpour not_allowed`` ONLY -- the
+    parsed flags must show tracks/vias allowed so the router never blocks."""
+    from kicad_tools.schema.pcb import Zone
+    from kicad_tools.sexp.builders import keepout_node
+    from kicad_tools.sexp.parser import parse_string, serialize_sexp
+
+    node = keepout_node(
+        [(0.0, 0.0), (5.0, 0.0), (5.0, 5.0), (0.0, 5.0)],
+        ["F.Cu"],
+        no_tracks=False,
+        no_vias=False,
+        no_pour=True,
+    )
+    zone = Zone.from_sexp(parse_string(serialize_sexp(node)))
+    assert zone.keepout is not None
+    assert zone.keepout.tracks_allowed is True
+    assert zone.keepout.vias_allowed is True
+    assert zone.keepout.copperpour_allowed is False
+    # The lattice mask drops it entirely.
+    mask = LatticeKeepoutMask(
+        [
+            _area(
+                tuple(zone.polygon),
+                frozenset({0}),
+                blocks_tracks=not zone.keepout.tracks_allowed,
+                blocks_vias=not zone.keepout.vias_allowed,
+            )
+        ]
+    )
+    assert not mask
+    assert not mask.segment_blocked((2.0, 2.0), (3.0, 3.0), 0, 1, 0.5)
+    assert not mask.via_blocked((2.0, 2.0), 1, 0.3)
+
+
+def test_keepout_node_emits_optional_name() -> None:
+    from kicad_tools.schema.pcb import Zone
+    from kicad_tools.sexp.builders import keepout_node
+    from kicad_tools.sexp.parser import parse_string, serialize_sexp
+
+    node = keepout_node([(0.0, 0.0), (5.0, 0.0), (5.0, 5.0)], ["F.Cu"], name="bank-a")
+    zone = Zone.from_sexp(parse_string(serialize_sexp(node)))
+    assert zone.name == "bank-a"
+
+
+def _board_with_rule_area(tmp_path, zone_text: str):
+    board = f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (gr_rect (start 0 0) (end 30 30)
+    (stroke (width 0.1) (type default)) (fill none) (layer "Edge.Cuts"))
+{zone_text}
+)"""
+    path = tmp_path / "board.kicad_pcb"
+    path.write_text(board)
+    return path
+
+
+def test_rule_area_round_trips_through_pcb_load_save(tmp_path) -> None:
+    from kicad_tools.schema.pcb import PCB
+
+    path = _board_with_rule_area(tmp_path, _rule_area_zone_text())
+    pcb = PCB.load(path)
+    assert len(pcb.rule_areas) == 1
+    area = pcb.rule_areas[0]
+    assert area.keepout is not None and area.keepout.tracks_allowed is False
+
+    out = tmp_path / "roundtrip.kicad_pcb"
+    pcb.save(out)
+    saved = out.read_text()
+    assert "(keepout" in saved
+    assert "(tracks not_allowed)" in saved
+    # And it re-parses to the same rule area.
+    pcb2 = PCB.load(out)
+    assert len(pcb2.rule_areas) == 1
+    assert pcb2.rule_areas[0].polygon == area.polygon
+
+
+# ---------------------------------------------------------------------------
+# 3. Mask semantics.
+# ---------------------------------------------------------------------------
+
+
+def test_applies_to_filter_semantics() -> None:
+    all_nets = _area()
+    assert all_nets.applies_to(1) and all_nets.applies_to(2)
+
+    only = _area(only=frozenset({1}))
+    assert only.applies_to(1)
+    assert not only.applies_to(2)
+
+    exempt = _area(exempt=frozenset({1}))
+    assert not exempt.applies_to(1)
+    assert exempt.applies_to(2)
+
+
+def test_mask_layer_subset_and_half_inflation() -> None:
+    mask = LatticeKeepoutMask([_area(layers=frozenset({0}))])
+    seg = ((5.0, 15.0), (25.0, 15.0))
+    assert mask.segment_blocked(*seg, 0, 1, 0.1)
+    # Other layers stay routable.
+    assert not mask.segment_blocked(*seg, 1, 1, 0.1)
+    # Copper-edge inflation: a fat trace grazing the boundary is blocked, a
+    # thin one at the same centreline is not.
+    graze = ((5.0, 9.5), (25.0, 9.5))
+    assert mask.segment_blocked(*graze, 0, 1, 0.8)
+    assert not mask.segment_blocked(*graze, 0, 1, 0.2)
+
+
+def test_mask_track_and_via_flags_are_independent() -> None:
+    tracks_only = LatticeKeepoutMask([_area(blocks_tracks=True, blocks_vias=False)])
+    assert tracks_only.segment_blocked((15.0, 15.0), (15.0, 15.0), 0, 1, 0.1)
+    assert not tracks_only.via_blocked((15.0, 15.0), 1, 0.3)
+
+    vias_only = LatticeKeepoutMask([_area(blocks_tracks=False, blocks_vias=True)])
+    assert not vias_only.segment_blocked((15.0, 15.0), (15.0, 15.0), 0, 1, 0.1)
+    assert vias_only.via_blocked((15.0, 15.0), 1, 0.3)
+    # The via check is layer-agnostic (through-barrel), including an area on
+    # a strict subset of layers.
+    subset = LatticeKeepoutMask([_area(layers=frozenset({1}), blocks_tracks=False)])
+    assert subset.via_blocked((15.0, 15.0), 1, 0.3)
+
+
+def test_mask_respects_net_filter() -> None:
+    mask = LatticeKeepoutMask([_area(exempt=frozenset({7}))])
+    seg = ((5.0, 15.0), (25.0, 15.0))
+    assert mask.segment_blocked(*seg, 0, 1, 0.1)
+    assert not mask.segment_blocked(*seg, 0, 7, 0.1)
+    assert mask.via_blocked((15.0, 15.0), 1, 0.3)
+    assert not mask.via_blocked((15.0, 15.0), 7, 0.3)
+
+
+# ---------------------------------------------------------------------------
+# 4. Pathfinder integration.
+# ---------------------------------------------------------------------------
+
+OUTLINE: list[Pt] = [(0.0, 0.0), (30.0, 0.0), (30.0, 20.0), (0.0, 20.0)]
+
+
+def _pathfinder() -> LatticePathfinder:
+    pads = [
+        _pad(5.0, 10.0, 1, ref="R1"),
+        _pad(25.0, 10.0, 1, ref="R2"),
+    ]
+    return LatticePathfinder(OUTLINE, pads, DesignRules(), LayerStack.two_layer())
+
+
+def _route_one(pf: LatticePathfinder) -> tuple[dict, object]:
+    conns = [((1, 0), pf.pads[0], pf.pads[1], None)]
+    return pf.route_netset(conns, max_iterations=4)
+
+
+def _copper(routes: dict) -> list[tuple]:
+    out = []
+    for route in routes.values():
+        assert isinstance(route, Route)
+        for seg in route.segments:
+            out.append((seg.layer, seg.x1, seg.y1, seg.x2, seg.y2, seg.width))
+        for via in route.vias:
+            out.append(("via", via.x, via.y))
+    return sorted(out, key=repr)
+
+
+# Full-height wall through the board middle, both layers.
+WALL: tuple[Pt, ...] = ((14.0, 0.0), (16.0, 0.0), (16.0, 20.0), (14.0, 20.0))
+
+
+def test_wall_on_both_layers_declines_with_keepout_reason() -> None:
+    pf = _pathfinder()
+    pf.set_keepouts(LatticeKeepoutMask([_area(WALL)]))
+    routes, stats = _route_one(pf)
+    assert stats.routed == 0
+    assert pf.failure_reasons[(1, 0)] == "no-path-keepout-constrained"
+
+
+def test_wall_on_top_layer_dips_under_via_bcu() -> None:
+    pf = _pathfinder()
+    pf.set_keepouts(LatticeKeepoutMask([_area(WALL, layers=frozenset({0}), blocks_vias=False)]))
+    routes, stats = _route_one(pf)
+    assert stats.routed == 1
+    copper = _copper(routes)
+    vias = [c for c in copper if c[0] == "via"]
+    assert vias, "expected a layer dip under the F.Cu wall"
+    # No F.Cu copper edge inside the wall.
+    half = DesignRules().trace_width / 2.0
+    for item in copper:
+        if item[0] == Layer.F_CU:
+            _l, x1, y1, x2, y2, _w = item
+            assert not seg_near_polygon((x1, y1), (x2, y2), WALL, half), (
+                f"F.Cu segment {item} enters the keepout"
+            )
+
+
+def test_area_governing_only_another_net_is_byte_identical_to_baseline() -> None:
+    baseline_routes, baseline_stats = _route_one(_pathfinder())
+    assert baseline_stats.routed == 1
+
+    pf = _pathfinder()
+    pf.set_keepouts(LatticeKeepoutMask([_area(WALL, only=frozenset({99}))]))
+    routes, stats = _route_one(pf)
+    assert stats.routed == 1
+    assert _copper(routes) == _copper(baseline_routes)
+
+
+def test_set_keepouts_none_resets_and_matches_baseline() -> None:
+    baseline_routes, _stats = _route_one(_pathfinder())
+
+    pf = _pathfinder()
+    pf.set_keepouts(LatticeKeepoutMask([_area(WALL)]))
+    pf.set_keepouts(None)
+    routes, stats = _route_one(pf)
+    assert stats.routed == 1
+    assert _copper(routes) == _copper(baseline_routes)
+    # An EMPTY mask is normalised to None too (dormant fast path).
+    pf2 = _pathfinder()
+    pf2.set_keepouts(LatticeKeepoutMask([]))
+    assert pf2._keepouts is None
+
+
+def test_detour_keeps_all_copper_out_of_a_partial_wall() -> None:
+    # Wall spans y in [0, 15] on both layers -- a detour over the top exists.
+    partial: tuple[Pt, ...] = ((14.0, 0.0), (16.0, 0.0), (16.0, 15.0), (14.0, 15.0))
+    pf = _pathfinder()
+    pf.set_keepouts(LatticeKeepoutMask([_area(partial)]))
+    routes, stats = _route_one(pf)
+    assert stats.routed == 1
+    for item in _copper(routes):
+        if item[0] == "via":
+            assert not seg_near_polygon(
+                (item[1], item[2]), (item[1], item[2]), partial, DesignRules().via_diameter / 2.0
+            )
+        else:
+            _l, x1, y1, x2, y2, w = item
+            assert not seg_near_polygon((x1, y1), (x2, y2), partial, w / 2.0), (
+                f"segment {item} enters the keepout"
+            )
+
+
+def test_pad_inside_own_keepout_reports_keepout_escape_reason() -> None:
+    pocket: tuple[Pt, ...] = ((2.0, 7.0), (8.0, 7.0), (8.0, 13.0), (2.0, 13.0))
+    pf = _pathfinder()
+    pf.set_keepouts(LatticeKeepoutMask([_area(pocket)]))
+    _routes, stats = _route_one(pf)
+    assert stats.routed == 0
+    assert pf.failure_reasons[(1, 0)] == "pad-escape-start-keepout"

--- a/tests/test_lattice_keepout_areas.py
+++ b/tests/test_lattice_keepout_areas.py
@@ -1,0 +1,322 @@
+"""CLI-level tests for keepout rule-area honoring on the lattice engine (#4605).
+
+The softstart-shaped acceptance fixture: a two-domain board whose HV banks are
+segregated by COMPLEMENTARY track-keepout rule areas (corridors expressed as
+keepouts -- the ``mark_region_bound`` complement construction), filtered per
+net class through the ``spatial_keepouts`` block of the ``--net-class-map``
+sidecar.  Assertions:
+
+1. the board routes 100% on ``--route-engine lattice``, every HV segment stays
+   inside its own declared region, and the #4588 post-route pairwise gate
+   passes (exit 0) -- spatial segregation by construction;
+2. a ``copperpour not_allowed``-only rule area (the ``kct zones hv-keepout``
+   output) leaves the committed copper byte-identical to the same board
+   without it -- pour voids never constrain routing;
+3. a ``spatial_keepouts`` entry naming an unknown net class fails loud
+   (exit 1) before any routing work;
+4. a structurally malformed ``spatial_keepouts`` block fails at preload;
+5. a non-lattice engine warns (once, stderr) when the board declares
+   track/via-blocking rule areas it will not honor.
+
+Boards are fully synthetic S-expression strings (the
+``test_route_pairwise_gate_4588.py`` approach) and deliberately NOT at sheet
+origin, so the board-relative -> sheet-absolute polygon shift (#4603 lesson)
+is exercised, not just the happy path.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.route_cmd import main as route_main
+
+HV_VOLTS = 300.0
+
+# Corridor bands (sheet coordinates).  Board rect: (100, 100) .. (130, 116).
+# Bank A routes in y < 105.8, bank B in y > 110.2 -- a 4.4 mm declared gap,
+# beyond the 3.2 mm requirement 300 V derives under IEC 60664-1 / PD2 / IIIa.
+A_LIMIT = 105.8
+B_LIMIT = 110.2
+
+
+def _pad(number: str, x: float, y: float, net: int, net_name: str) -> str:
+    return (
+        f'(pad "{number}" smd rect (at {x} {y}) (size 0.4 0.4) '
+        f'(layers "F.Cu" "F.Paste" "F.Mask") (net {net} "{net_name}"))'
+    )
+
+
+def _fp(ref: str, uid: int, x: float, y: float, pads: str) -> str:
+    return f"""  (footprint "Resistor_SMD:R_0603_1608Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000{uid:02d}")
+    (at {x} {y})
+    (property "Reference" "{ref}" (at 0 -1.5 0) (layer "F.SilkS"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab"))
+    {pads}
+  )
+"""
+
+
+def _keepout_zone(
+    name: str,
+    poly: list[tuple[float, float]],
+    *,
+    tracks: str = "not_allowed",
+    vias: str = "not_allowed",
+    copperpour: str = "allowed",
+    uid: str = "cccccccc-0000-0000-0000-000000000001",
+) -> str:
+    pts = " ".join(f"(xy {x} {y})" for x, y in poly)
+    return f"""  (zone
+    (net 0)
+    (net_name "")
+    (name "{name}")
+    (layers "F.Cu" "B.Cu")
+    (uuid "{uid}")
+    (hatch edge 0.5)
+    (keepout (tracks {tracks}) (vias {vias}) (pads allowed) (copperpour {copperpour}))
+    (polygon (pts {pts}))
+  )
+"""
+
+
+def _board(extra: str = "") -> str:
+    parts = [
+        _fp("R1", 10, 103.0, 103.0, _pad("1", 0, 0, 1, "/HV_A")),
+        _fp("R2", 11, 127.0, 103.0, _pad("1", 0, 0, 1, "/HV_A")),
+        _fp("R3", 12, 103.0, 113.0, _pad("1", 0, 0, 2, "/HV_B")),
+        _fp("R4", 13, 127.0, 113.0, _pad("1", 0, 0, 2, "/HV_B")),
+    ]
+    return f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general
+    (thickness 1.6)
+  )
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup
+    (pad_to_mask_clearance 0)
+  )
+  (net 0 "")
+  (net 1 "/HV_A")
+  (net 2 "/HV_B")
+  (gr_rect (start 100 100) (end 130 116)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+{"".join(parts)}{extra})
+"""
+
+
+def _two_domain_guards() -> str:
+    """Complementary corridor guards: bank A excluded from everything north of
+    ``A_LIMIT``, bank B from everything south of ``B_LIMIT``."""
+    guard_a = _keepout_zone(
+        "hv-a-corridor-guard",
+        [(100, A_LIMIT), (130, A_LIMIT), (130, 116), (100, 116)],
+        uid="cccccccc-0000-0000-0000-000000000001",
+    )
+    guard_b = _keepout_zone(
+        "hv-b-corridor-guard",
+        [(100, 100), (130, 100), (130, B_LIMIT), (100, B_LIMIT)],
+        uid="cccccccc-0000-0000-0000-000000000002",
+    )
+    return guard_a + guard_b
+
+
+def _write_sidecar(tmp_path: Path, spatial: dict | None) -> Path:
+    payload: dict = {
+        "/HV_A": {"name": "HV_A"},
+        "/HV_B": {"name": "HV_B"},
+    }
+    if spatial is not None:
+        payload["spatial_keepouts"] = spatial
+    path = tmp_path / "net_class_map.json"
+    path.write_text(json.dumps(payload))
+    return path
+
+
+def _write_voltage_map(tmp_path: Path) -> Path:
+    vmap = tmp_path / "vmap.json"
+    vmap.write_text(json.dumps({"/HV_A": HV_VOLTS, "/HV_B": 0.0}))
+    return vmap
+
+
+def _route_args(
+    pcb: Path,
+    out: Path,
+    *,
+    engine: str = "lattice",
+    sidecar: Path | None = None,
+    vmap: Path | None = None,
+) -> list[str]:
+    args = [
+        str(pcb),
+        "-o",
+        str(out),
+        "--route-engine",
+        engine,
+        "--strategy",
+        "basic",
+        "--skip-drc",
+    ]
+    if sidecar is not None:
+        args += ["--net-class-map", str(sidecar)]
+    if vmap is not None:
+        args += [
+            "--voltage-map",
+            str(vmap),
+            "--creepage-standard",
+            "iec60664",
+            "--pollution-degree",
+            "2",
+            "--material-group",
+            "IIIa",
+        ]
+    return args
+
+
+def _segments_by_net(text: str) -> dict[int, list[tuple[float, float, float, float]]]:
+    out: dict[int, list[tuple[float, float, float, float]]] = {}
+    pattern = re.compile(
+        r"\(segment\s*\(start ([-\d.]+) ([-\d.]+)\)\s*\(end ([-\d.]+) ([-\d.]+)\)"
+        r".*?\(net (\d+)",
+        re.DOTALL,
+    )
+    for m in pattern.finditer(text):
+        x1, y1, x2, y2 = (float(m.group(i)) for i in range(1, 5))
+        out.setdefault(int(m.group(5)), []).append((x1, y1, x2, y2))
+    return out
+
+
+def _copper_signature(text: str) -> list[str]:
+    """Routed copper (segments + vias) with volatile uuids stripped."""
+    body = re.sub(r'\(uuid "[^"]*"\)', "(uuid)", text)
+    items = re.findall(r"\(segment .*?\)\n", body, re.DOTALL)
+    items += re.findall(r"\(via .*?\)\n", body, re.DOTALL)
+    return sorted("".join(i.split()) for i in items)
+
+
+def test_two_domain_keepout_segregation_routes_100pct_and_passes_gate(
+    tmp_path: Path, capsys
+) -> None:
+    pcb = tmp_path / "two_domain.kicad_pcb"
+    pcb.write_text(_board(_two_domain_guards()))
+    out = tmp_path / "routed.kicad_pcb"
+    sidecar = _write_sidecar(
+        tmp_path,
+        {
+            "hv-a-corridor-guard": {"only_classes": ["HV_A"]},
+            "hv-b-corridor-guard": {"only_classes": ["HV_B"]},
+        },
+    )
+    vmap = _write_voltage_map(tmp_path)
+
+    rc = route_main(_route_args(pcb, out, sidecar=sidecar, vmap=vmap))
+    stdout = capsys.readouterr().out
+    assert rc == 0, f"expected clean run, got rc={rc}\n{stdout}"
+    assert "SUCCESS" in stdout
+
+    by_net = _segments_by_net(out.read_text())
+    assert by_net.get(1), "bank A did not route"
+    assert by_net.get(2), "bank B did not route"
+    # Every HV segment stays inside its own region: copper CENTRELINE strictly
+    # south (A) / north (B) of the declared corridor limit, with the 0.1 mm
+    # half-width margin.
+    for x1, y1, x2, y2 in by_net[1]:
+        assert max(y1, y2) <= A_LIMIT - 0.05, (
+            f"bank A segment crosses its guard: {(x1, y1, x2, y2)}"
+        )
+    for x1, y1, x2, y2 in by_net[2]:
+        assert min(y1, y2) >= B_LIMIT + 0.05, (
+            f"bank B segment crosses its guard: {(x1, y1, x2, y2)}"
+        )
+
+
+def test_pour_void_only_rule_area_leaves_copper_byte_identical(tmp_path: Path, capsys) -> None:
+    plain = tmp_path / "plain.kicad_pcb"
+    plain.write_text(_board())
+    voided = tmp_path / "voided.kicad_pcb"
+    voided.write_text(
+        _board(
+            _keepout_zone(
+                "hv-pour-void",
+                [(110, 106), (120, 106), (120, 110), (110, 110)],
+                tracks="allowed",
+                vias="allowed",
+                copperpour="not_allowed",
+            )
+        )
+    )
+
+    out_plain = tmp_path / "plain_routed.kicad_pcb"
+    out_voided = tmp_path / "voided_routed.kicad_pcb"
+    assert route_main(_route_args(plain, out_plain)) == 0
+    assert route_main(_route_args(voided, out_voided)) == 0
+    capsys.readouterr()
+
+    assert _copper_signature(out_plain.read_text()) == _copper_signature(out_voided.read_text())
+
+
+def test_unknown_class_in_spatial_keepouts_fails_loud(tmp_path: Path, capsys) -> None:
+    pcb = tmp_path / "two_domain.kicad_pcb"
+    pcb.write_text(_board(_two_domain_guards()))
+    out = tmp_path / "routed.kicad_pcb"
+    sidecar = _write_sidecar(tmp_path, {"hv-a-corridor-guard": {"only_classes": ["NOPE"]}})
+
+    with pytest.raises(SystemExit) as excinfo:
+        route_main(_route_args(pcb, out, sidecar=sidecar))
+    assert excinfo.value.code == 1
+    err = capsys.readouterr().err
+    assert "unknown net class 'NOPE'" in err
+    assert "HV_A" in err  # the known-classes hint
+
+
+def test_malformed_spatial_keepouts_block_fails_at_preload(tmp_path: Path, capsys) -> None:
+    pcb = tmp_path / "two_domain.kicad_pcb"
+    pcb.write_text(_board())
+    out = tmp_path / "routed.kicad_pcb"
+    sidecar = _write_sidecar(
+        tmp_path,
+        {"guard": {"only_classes": ["HV_A"], "except_classes": ["HV_B"]}},
+    )
+
+    rc = route_main(_route_args(pcb, out, sidecar=sidecar))
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "spatial_keepouts" in err
+    assert "both except_classes and only_classes" in err
+
+
+def test_non_lattice_engine_warns_about_unhonored_rule_areas(tmp_path: Path, capsys) -> None:
+    pcb = tmp_path / "two_domain.kicad_pcb"
+    pcb.write_text(_board(_two_domain_guards()))
+    out = tmp_path / "routed.kicad_pcb"
+
+    rc = route_main(_route_args(pcb, out, engine="grid"))
+    captured = capsys.readouterr()
+    assert rc == 0, captured.out
+    assert "does not honor" in captured.err
+    assert "lattice" in captured.err
+
+
+def test_lattice_engine_does_not_warn(tmp_path: Path, capsys) -> None:
+    pcb = tmp_path / "plain.kicad_pcb"
+    pcb.write_text(_board())
+    out = tmp_path / "routed.kicad_pcb"
+
+    rc = route_main(_route_args(pcb, out))
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "does not honor" not in captured.err


### PR DESCRIPTION
Closes #4605

## What

The lattice engine now honors KiCad **keepout rule areas** (`(zone … (keepout …))`) at search time, with an optional per-net-class applicability filter — the declarable spatial HV-segregation primitive (curated v1 slice: option 2; option 3 shipped as #4602/PR #4655, whose predicate threading this reuses rather than forks).

### Parse (the upstream gap)

- `schema/pcb.py`: `Zone.from_sexp` previously **dropped** the `(keepout …)` child. New `ZoneKeepout` flag model (`tracks/vias/pads/copperpour/footprints` allowed|not_allowed), multi-layer `Zone.layers` (`(layers "F.Cu" "B.Cu")`, wildcards preserved raw), and `PCB.rule_areas`. Pour-zone parsing untouched; `PCB.save` serializes the raw tree, so rule areas round-trip load→save byte-preserved (pinned by test).
- `sexp/builders.keepout_node` learns an optional `name` so generated rule areas are sidecar-filterable.

### Resolve (caller-side, #4271/#4597 discipline)

- `Autorouter._lattice_keepout_projection()` (memoised): loads rule areas from the recorded source-board path, keeps only track/via-blocking areas (**`copperpour not_allowed`-only areas — the `kct zones hv-keepout` output — never constrain routing**), shifts polygons board-relative → sheet-absolute (the #4603 origin lesson; the CLI fixture board deliberately sits off-origin to pin this), resolves layer specs (`*.Cu`, `F&B.Cu`, names) against the real stack, and joins the sidecar filter into net-id sets. Installed in `_negotiate_lattice_netset` via `pf.set_keepouts(...)` right beside #4602's `set_pairwise` (always called → no stale mask on reuse).
- **Sidecar filter**: reserved `spatial_keepouts` block in the `--net-class-map` sidecar, keyed by rule-area **zone name**; `only_classes` / `except_classes` (exactly one per entry); **no entry = applies to all nets (KiCad-default semantics)**. Structure validated at preload (exit 1); unknown class names fail loud after the sidecar merge (exit 1) — a typo would silently widen/narrow a spatial safety constraint. Shape documented in `docs/guides/routing.md`.

### Enforce (lattice)

- `obstacles.LatticeKeepoutMask` + frozen `KeepoutArea`: geometric queries with AABB pre-filter, composed into the exact predicates the search already consults — stub scan, `edge_ok`/`node_ok` memos, via layer-change node check, `_via_ok` — **no new call sites in the A\* loop**. Segments are inflated by the querying copper's true half-width (neck legs probed as neck copper); `vias not_allowed` is layer-agnostic for the through-barrel.
- Fat coupled centerline skips the mask in-search (the #4602 slice boundary); emitted pair legs + attach doglegs are re-verified in the finish gate (`pair-leg-keepout`) — nothing under-masked ships (#3906).
- **Failure attribution** (#3900): `pad-escape-{start,end}-keepout` only when the pad point itself is provably covered on every escape layer; `no-path-keepout-constrained` when the mask actually pruned resources in the failed search.
- **Byte-identical no-constraint path**: no track/via-blocking rule areas → projection returns `None` → every predicate runs pre-#4605 code byte-for-byte.
- Grid/mesh: documented non-support + one-line stderr warning when such areas are present (`_warn_rule_areas_other_engine`, cheap text scan, never a gate).

## Acceptance criteria → evidence

| AC | Evidence |
|---|---|
| Rule areas parse first-class; pour zones/round-trip unchanged | `test_rule_area_parses_flags_layers_polygon_and_name`, `test_pour_zone_parsing_is_unchanged…`, `test_rule_area_round_trips_through_pcb_load_save` |
| `tracks not_allowed` → zero committed segments intersect (copper edge); `vias not_allowed` blocks vias | `test_wall_on_top_layer_dips_under_via_bcu`, `test_detour_keeps_all_copper_out_of_a_partial_wall`, `test_mask_track_and_via_flags_are_independent` |
| Filter semantics (no entry = all nets; only/except) | `test_applies_to_filter_semantics`, `test_mask_respects_net_filter`, two-domain CLI fixture |
| hv-keepout pour voids don't block; identical copper | `test_hv_keepout_pour_void_output_is_routing_neutral`, `test_pour_void_only_rule_area_leaves_copper_byte_identical` (CLI, full route × 2, copper signatures equal) |
| Byte-identical no-constraint path | `test_area_governing_only_another_net_is_byte_identical_to_baseline`, `test_set_keepouts_none_resets_and_matches_baseline` |
| Softstart-shaped two-domain fixture: 100%, confined, #4588 gate exit 0 | `test_two_domain_keepout_segregation_routes_100pct_and_passes_gate` — complementary corridor-guard keepouts (`only_classes` per bank) + 300 V voltage map (3.2 mm requirement, 4.4 mm declared gap), real `kct route` CLI path, board off sheet-origin |
| Keepout-attributed failure reason | `test_pad_inside_own_keepout_reports_keepout_escape_reason`, `test_wall_on_both_layers_declines_with_keepout_reason` |
| Grid/mesh non-support documented + warned | routing guide section; `test_non_lattice_engine_warns…`, `test_lattice_engine_does_not_warn` |
| Unknown class → clear error | `test_unknown_class_in_spatial_keepouts_fails_loud` (exit 1, names the known classes); `test_malformed_spatial_keepouts_block_fails_at_preload` |

## Test results (native backend built)

- `tests/router/lattice/` (incl. #4602's `test_pairwise_avoidance.py`): **168 passed, 2 skipped** (pre-existing suite, full 12-min run) + **17 passed** new `test_keepout_areas.py`
- `tests/test_lattice_keepout_areas.py` (new CLI module): **6 passed**
- `tests/test_route_pairwise_gate_4588.py`: **25 passed**
- Sidecar/zone consumers (`test_cli_route_net_class_map`, `test_net_class_serialization`, `test_zones_hv_keepout`, `test_pcb_zones`, `test_keepout`, `test_pcb_add_zone`, `test_build_zones_step`, `test_audit_hv_isolation`, `test_cli_check_net_class_map`, `test_kct_check_parity`): **all green**
- `ruff check` / `ruff format --check`: clean on all touched files

**Pre-existing (not from this PR):** local `scripts/ci/check_mypy_baseline.py` reports one NEW error in `src/kicad_tools/recovery/strategy.py` — it reproduces identically on a clean `main` checkout in this environment (the known native-env/mypy-version baseline discrepancy; CI ubuntu is authoritative). No new mypy errors from this diff (one I introduced in `schema/pcb.py` was caught locally and fixed).

## Scope notes

- Out of scope per curation: corridor spec (expressible as complementary keepouts — the CLI fixture demonstrates exactly that construction), grid/mesh honoring, `.kicad_dru` parsing, pairwise search logic (#4602).
- Sibling #4595 owns `cli/check_cmd.py` / `validate/` this wave — neither is touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
