### PR TITLE
fix(net-status): flip default to strict real-geometry connectivity (#4557)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -267,6 +267,22 @@ constructor). No breaking changes.
 
 ### Changed
 
+- **`kct net-status` / `NetStatusAnalyzer` default to strict real-geometry
+  connectivity** — the default connectivity model is now shapely copper-shape
+  intersection (`strict=True`), matching `kicad-cli pcb drc` semantics. The
+  legacy 0.01mm endpoint-proximity model diverged from KiCad in both
+  directions: it over-connected copper whose reference points were merely near
+  (#4176) and false-flagged pads open when a trace endpoint landed inside pad
+  copper but away from the pad *center* — 16 false opens on board 06's poured
+  nets (`GND`/`+1V2`/`VBUS_USB`), now 0 by default. Board 07's 5 genuine
+  #3438 opens are unchanged. `--legacy-proximity` (CLI) / `strict=False`
+  (API) opt back into the old model; `--strict` remains accepted as a no-op.
+  Output now names the model in use, `--why` respects the selection
+  (previously `--strict --why` silently ignored `--strict`), and strict-mode
+  segment/pad bonds are now layer-gated so a 2D copper overlap on a different
+  layer can no longer fuse copper a via does not electrically span.
+  `kct check` connectivity defaults are unchanged (#4557).
+
 - **`kct check` splits its report into manufacturing and advisory buckets** —
   a rule-to-category taxonomy renders a CATEGORY SUMMARY with "Manufacturing
   DRC: N blocking" and "Advisory/quality: M advisory", so routing-intent

--- a/src/kicad_tools/analysis/net_status.py
+++ b/src/kicad_tools/analysis/net_status.py
@@ -3,6 +3,11 @@
 This module provides detailed net connectivity status reporting, showing which nets
 are complete, incomplete, or unrouted, with details on what's missing.
 
+Connectivity is decided by real geometric copper contact (shapely polygon
+intersection, matching ``kicad-cli pcb drc`` semantics) by default; pass
+``strict=False`` to opt into the legacy 0.01mm endpoint-proximity model
+(see ``NetStatusAnalyzer.POSITION_TOLERANCE`` for the trade-offs).
+
 Example:
     >>> from kicad_tools.schema.pcb import PCB
     >>> from kicad_tools.analysis.net_status import NetStatusAnalyzer
@@ -372,32 +377,42 @@ class NetStatusAnalyzer:
     # Tolerance for matching point positions (in mm).
     #
     # This is an endpoint-proximity radius, NOT a geometric-contact test:
-    # in the default (non-strict) mode, two copper elements (segment
+    # in the legacy (``strict=False``) mode, two copper elements (segment
     # endpoints, pad centers, via centers) are unioned whenever their
     # reference points land within this radius, even if their actual copper
     # shapes (segment width, pad size) do not touch.  KiCad's connectivity
-    # engine instead requires real geometric overlap, so the default model
-    # can report a net "complete" that KiCad (``kicad-cli pcb drc``) reports
-    # as having unconnected items (Issue #4176).  Pass ``strict=True`` to use
-    # real shapely copper-shape intersection and match KiCad.
+    # engine instead requires real geometric overlap, so the legacy model
+    # both over-connects (reports a net "complete" that KiCad reports as
+    # having unconnected items, Issue #4176) and under-connects (reports a
+    # pad open when a trace endpoint lands inside the pad copper but more
+    # than this radius from the pad *center* -- 16 false opens on board 06,
+    # Issue #4557).  The default is therefore ``strict=True`` (real shapely
+    # copper-shape intersection, matching KiCad); pass ``strict=False`` to
+    # opt back into the legacy proximity model.
     POSITION_TOLERANCE = 0.01
 
-    def __init__(self, pcb: str | Path | PCB, *, strict: bool = False) -> None:
+    def __init__(self, pcb: str | Path | PCB, *, strict: bool = True) -> None:
         """Initialize the analyzer.
 
         Args:
             pcb: Path to PCB file or loaded PCB object.
-            strict: When ``True``, segment↔segment, segment↔pad, and
-                segment↔via connectivity is decided by real geometric copper
-                contact (shapely polygon intersection: a segment is its
-                centerline buffered by ``width / 2``; a pad/via is its copper
-                shape) instead of the ``POSITION_TOLERANCE`` endpoint-proximity
-                radius.  This matches KiCad's connectivity semantics
-                (Issue #4176).  The default (``False``) preserves the legacy
-                tolerance-based behavior so existing consumers are unaffected.
-                Requires ``shapely``; strict mode fails loud (rather than
+            strict: When ``True`` (the default since Issue #4557),
+                segment↔segment, segment↔pad, and segment↔via connectivity is
+                decided by real geometric copper contact (shapely polygon
+                intersection: a segment is its centerline buffered by
+                ``width / 2``; a pad/via is its copper shape).  This matches
+                KiCad's connectivity semantics (Issue #4176) and is what CI's
+                plane-net gate trusts.  Requires ``shapely`` (a core
+                dependency since #3824); strict mode fails loud (rather than
                 silently degrading to the tolerance model) if it is
-                unavailable.
+                unavailable.  Pass ``False`` to opt into the legacy
+                ``POSITION_TOLERANCE`` endpoint-proximity model, which is
+                cheaper (~1.5-2x) but diverges from KiCad in both directions:
+                it can report proximity-unioned copper "complete" that KiCad
+                reports open (#4176), and it reports false opens when a trace
+                endpoint lands inside pad copper but away from the pad center
+                (#4557).  Legitimate uses are perf-sensitive inner loops that
+                only consume before/after deltas.
         """
         from kicad_tools.schema.pcb import PCB as PCBClass
 
@@ -693,7 +708,12 @@ class NetStatusAnalyzer:
                 seg = segments[seg_idx]
                 if self.strict:
                     component_pads.update(
-                        self._find_pads_touching_geom(self._segment_poly(seg), pad_positions)
+                        self._find_pads_touching_geom(
+                            self._segment_poly(seg),
+                            pad_positions,
+                            layer=seg.layer,
+                            pad_layers=pad_layers,
+                        )
                     )
                 else:
                     component_pads.update(self._find_pads_at_point(seg.start, pad_positions))
@@ -758,7 +778,12 @@ class NetStatusAnalyzer:
                 seg = segments[seg_idx]
                 if self.strict:
                     chain_pads.update(
-                        self._find_pads_touching_geom(self._segment_poly(seg), pad_positions)
+                        self._find_pads_touching_geom(
+                            self._segment_poly(seg),
+                            pad_positions,
+                            layer=seg.layer,
+                            pad_layers=pad_layers,
+                        )
                     )
                 else:
                     chain_pads.update(self._find_pads_at_point(seg.start, pad_positions))
@@ -822,10 +847,17 @@ class NetStatusAnalyzer:
         # Strict (Issue #4176): two pads bond when both copper polygons
         # intersect the same segment / via copper geometry.
         if self.strict:
-            copper_geoms = [self._segment_poly(seg) for seg in segments]
-            copper_geoms.extend(self._via_geom(via) for via in vias)
-            for geom in copper_geoms:
-                touching = self._find_pads_touching_geom(geom, pad_positions)
+            # Segment geometry carries its layer (Issue #4557: a 2D copper
+            # polygon must not bond a pad that does not exist on that layer);
+            # via barrels span layers, so they stay layer-unfiltered here.
+            copper_geoms: list[tuple[Any, str | None]] = [
+                (self._segment_poly(seg), seg.layer) for seg in segments
+            ]
+            copper_geoms.extend((self._via_geom(via), None) for via in vias)
+            for geom, geom_layer in copper_geoms:
+                touching = self._find_pads_touching_geom(
+                    geom, pad_positions, layer=geom_layer, pad_layers=pad_layers
+                )
                 for i, pad_id in enumerate(touching):
                     for other_id in touching[i + 1 :]:
                         graph[pad_id].add(other_id)
@@ -1267,13 +1299,17 @@ class NetStatusAnalyzer:
         Returns:
             List of sets, each containing segment indices in a connected component
 
-        In the default mode two segments are chained when any of their
+        In the legacy mode two segments are chained when any of their
         endpoints land within ``POSITION_TOLERANCE`` of each other.  In
-        ``strict`` mode (Issue #4176) they are chained iff their real copper
-        polygons (each segment's centerline buffered by ``width / 2``)
-        intersect — matching KiCad, which does not bond two traces whose
-        copper does not physically touch even when their endpoints are within
-        the snap tolerance.
+        ``strict`` mode (Issue #4176) they are chained iff they are on the
+        SAME copper layer and their real copper polygons (each segment's
+        centerline buffered by ``width / 2``) intersect — matching KiCad,
+        which does not bond two traces whose copper does not physically touch
+        even when their endpoints are within the snap tolerance.  The
+        same-layer gate matters because copper polygons are 2D: without it a
+        trace crossing OVER another trace on a different layer would chain
+        (Issue #4557 — cross-layer joins are handled by
+        ``_merge_chains_via_vias`` with ``_via_spans_layer`` gating instead).
         """
         if not segments:
             return []
@@ -1287,7 +1323,9 @@ class NetStatusAnalyzer:
             for j, seg_b in enumerate(segments):
                 if i != j:
                     if self.strict:
-                        connected = self._geoms_touch(polys[i], polys[j])
+                        connected = seg_a.layer == seg_b.layer and self._geoms_touch(
+                            polys[i], polys[j]
+                        )
                     else:
                         connected = (
                             self._points_close(seg_a.start, seg_b.start)
@@ -1426,18 +1464,35 @@ class NetStatusAnalyzer:
         self,
         geom: Any,
         pad_positions: dict[str, tuple[float, float]],
+        *,
+        layer: str | None = None,
+        pad_layers: dict[str, list[str]] | None = None,
     ) -> list[str]:
         """Strict analogue of ``_find_pads_at_point``: pads whose copper touches ``geom``.
 
         Only pads present in ``pad_positions`` (i.e. on the net being analyzed)
         are considered, matching the point-based helper's contract.
+
+        When ``layer`` and ``pad_layers`` are both given (segment geometry,
+        Issue #4557), a pad only matches if it exists on that copper layer
+        (``*.Cu`` wildcard aware) — the copper polygons are 2D, so without the
+        gate an inner-layer trace passing UNDER a surface pad would falsely
+        bond it.
         """
         if geom is None:
             return []
         pad_polys = self._pad_polys()
-        return [
-            pad_id for pad_id in pad_positions if self._geoms_touch(geom, pad_polys.get(pad_id))
-        ]
+        matches: list[str] = []
+        for pad_id in pad_positions:
+            if (
+                layer is not None
+                and pad_layers is not None
+                and not self._pad_layer_matches_zone(pad_layers.get(pad_id, []), layer)
+            ):
+                continue
+            if self._geoms_touch(geom, pad_polys.get(pad_id)):
+                matches.append(pad_id)
+        return matches
 
     # Canonical copper layer ordering from top to bottom.
     # Promoted to ``kicad_tools.core.layers`` in Issue #3487 so the DRC

--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -428,6 +428,8 @@ def _dispatch_command(args) -> int:
             sub_argv.append("--why")
         if hasattr(args, "net_status_strict") and args.net_status_strict:
             sub_argv.append("--strict")
+        if hasattr(args, "net_status_legacy_proximity") and args.net_status_legacy_proximity:
+            sub_argv.append("--legacy-proximity")
         return net_status_cmd(sub_argv)
 
     elif args.command == "clean":

--- a/src/kicad_tools/cli/net_status_cmd.py
+++ b/src/kicad_tools/cli/net_status_cmd.py
@@ -10,16 +10,21 @@ Usage:
     kicad-net-status board.kicad_pcb --by-class
     kicad-net-status board.kicad_pcb --format json
     kicad-net-status board.kicad_pcb --strict
+    kicad-net-status board.kicad_pcb --legacy-proximity
 
 Connectivity model:
-    By default, connectivity is decided by a 0.01mm endpoint-proximity
-    tolerance: a segment endpoint is unioned with a pad / via / other segment
-    whenever their reference points land within 0.01mm, without testing
-    whether the real copper (segment width, pad shape) actually touches. This
-    can over-connect relative to KiCad, reporting a net "complete" that
-    ``kicad-cli pcb drc`` reports as having unconnected items (issue #4176).
-    Pass ``--strict`` to decide connectivity by real geometric copper contact
-    (shapely polygon intersection), which matches KiCad's semantics.
+    By default (since issue #4557), connectivity is decided by real geometric
+    copper contact (shapely polygon intersection), matching the semantics of
+    ``kicad-cli pcb drc`` (issue #4176). ``--strict`` selects the same model
+    explicitly (kept as a no-op for script compatibility).
+    Pass ``--legacy-proximity`` to opt into the legacy 0.01mm
+    endpoint-proximity tolerance: a segment endpoint is unioned with a pad /
+    via / other segment whenever their reference points land within 0.01mm,
+    without testing whether the real copper (segment width, pad shape)
+    actually touches. That model diverges from KiCad in both directions -- it
+    can report proximity-unioned copper "complete" that KiCad reports open
+    (issue #4176), and it reports false opens when a trace endpoint lands
+    inside pad copper but away from the pad center (issue #4557).
 
 Exit Codes:
     0 - No incomplete nets
@@ -33,7 +38,7 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from kicad_tools.analysis.net_status import NetStatus, NetStatusAnalyzer, NetStatusResult
 
@@ -77,18 +82,28 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Show all pads with coordinates",
     )
-    parser.add_argument(
+    model_group = parser.add_mutually_exclusive_group()
+    model_group.add_argument(
         "--strict",
         action="store_true",
         help=(
             "Decide connectivity by REAL geometric copper contact (shapely "
-            "polygon intersection) instead of the default 0.01mm endpoint "
-            "proximity tolerance. The default model unions a segment endpoint "
-            "with a pad/via/segment whenever their reference points land "
-            "within 0.01mm, even if the actual copper (segment width, pad "
-            "shape) does not touch -- so it can report a net 'complete' that "
-            "'kicad-cli pcb drc' reports as unconnected. --strict matches "
-            "KiCad's connectivity semantics (issue #4176). Requires shapely."
+            "polygon intersection), matching KiCad's connectivity semantics "
+            "(issue #4176). This has been the DEFAULT since issue #4557; the "
+            "flag is kept as an explicit no-op for script compatibility."
+        ),
+    )
+    model_group.add_argument(
+        "--legacy-proximity",
+        action="store_true",
+        dest="legacy_proximity",
+        help=(
+            "Opt into the legacy 0.01mm endpoint-proximity connectivity "
+            "model: a segment endpoint is unioned with a pad/via/segment "
+            "whenever their reference points land within 0.01mm, even if the "
+            "actual copper (segment width, pad shape) does not touch. "
+            "Faster (~1.5-2x) but diverges from KiCad in both directions "
+            "(issues #4176, #4557). Mutually exclusive with --strict."
         ),
     )
     parser.add_argument(
@@ -110,9 +125,15 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Error: PCB not found: {pcb_path}", file=sys.stderr)
         return 1
 
+    # Connectivity model selection (issue #4557): strict (real copper
+    # geometry) is the default; --strict is an explicit no-op kept for script
+    # compatibility; --legacy-proximity opts back into the endpoint-proximity
+    # model. The two flags are mutually exclusive (argparse-enforced).
+    strict = not args.legacy_proximity
+
     # Run analysis
     try:
-        analyzer = NetStatusAnalyzer(pcb_path, strict=args.strict)
+        analyzer = NetStatusAnalyzer(pcb_path, strict=strict)
         result = analyzer.analyze()
     except Exception as e:
         print(f"Error during analysis: {e}", file=sys.stderr)
@@ -120,9 +141,10 @@ def main(argv: list[str] | None = None) -> int:
 
     # --why: stuck-net classifier (issue #3863). Read-only diagnostic that
     # labels each incomplete signal net by WHY it is stuck. Handled before the
-    # normal filter/output path because it has its own output shape.
+    # normal filter/output path because it has its own output shape. Respects
+    # the strict/legacy selection (issue #4557).
     if args.why:
-        return output_why(pcb_path, args.format)
+        return output_why(pcb_path, args.format, strict=strict)
 
     # Filter results if needed
     if args.net:
@@ -147,7 +169,7 @@ def main(argv: list[str] | None = None) -> int:
 
     # Output
     if args.format == "json":
-        output_json(filtered, pcb_path, args.by_class)
+        output_json(filtered, pcb_path, args.by_class, strict=strict)
     else:
         # The summary header must always describe the unfiltered board so its
         # counts stay internally consistent (Complete + Incomplete + Unrouted ==
@@ -159,12 +181,20 @@ def main(argv: list[str] | None = None) -> int:
             args.by_class,
             args.incomplete,
             summary_result=result,
+            strict=strict,
         )
 
     # Exit code
     if result.incomplete_count > 0 or result.unrouted_count > 0:
         return 2
     return 0
+
+
+def _model_label(strict: bool) -> str:
+    """Human-readable name of the connectivity model in use (issue #4557)."""
+    if strict:
+        return "strict (real copper geometry, matches kicad-cli)"
+    return "legacy endpoint-proximity (0.01mm tolerance)"
 
 
 def output_text(
@@ -174,6 +204,7 @@ def output_text(
     by_class: bool = False,
     incomplete_only: bool = False,
     summary_result: NetStatusResult | None = None,
+    strict: bool = True,
 ) -> None:
     """Output results as formatted text.
 
@@ -183,10 +214,13 @@ def output_text(
             ``--incomplete`` filters complete nets out of ``result``, the header
             must still describe the full board so its counts stay consistent
             (Complete + Incomplete + Unrouted == total). Defaults to ``result``.
+        strict: Which connectivity model produced ``result`` (drives the
+            model line in the header, issue #4557).
     """
     summary = summary_result if summary_result is not None else result
     print(f"Net Status: {pcb_path.name}")
     print("=" * 60)
+    print(f"Connectivity model: {_model_label(strict)}")
     print()
     print(f"Summary: {summary.total_nets} nets total")
     print(f"  Complete:   {summary.complete_count} (100% connected)")
@@ -289,10 +323,12 @@ def output_json(
     result: NetStatusResult,
     pcb_path: Path,
     by_class: bool = False,
+    strict: bool = True,
 ) -> None:
     """Output results as JSON."""
-    data = {
+    data: dict[str, Any] = {
         "pcb": str(pcb_path),
+        "connectivity_model": "strict" if strict else "legacy_proximity",
         "summary": {
             "total_nets": result.total_nets,
             "complete": result.complete_count,
@@ -345,23 +381,32 @@ def _print_recommendation(diag: StuckNetDiagnosis) -> None:
         print(f"                    {i}. {label} ({ranked.rationale}){preferred}")
 
 
-def output_why(pcb_path: Path, fmt: str) -> int:
+def output_why(pcb_path: Path, fmt: str, strict: bool = True) -> int:
     """Classify incomplete signal nets by why they are stuck and print them.
+
+    ``strict`` selects the connectivity model the classifier's internal
+    ``NetStatusAnalyzer`` runs use (issue #4557) -- before this parameter,
+    ``--strict --why`` silently ignored ``--strict``.
 
     Returns 2 if any stuck nets were found (matching the rest of net-status'
     exit-code convention), 0 if the board has no stuck signal nets.
     """
     from kicad_tools.router.stuck_classifier import classify_stuck_nets
 
-    result = classify_stuck_nets(pcb_path)
+    result = classify_stuck_nets(pcb_path, strict=strict)
 
     if fmt == "json":
-        data = {"pcb": str(pcb_path), **result.to_dict()}
+        data = {
+            "pcb": str(pcb_path),
+            "connectivity_model": "strict" if strict else "legacy_proximity",
+            **result.to_dict(),
+        }
         print(json.dumps(data, indent=2))
         return 2 if result.diagnoses else 0
 
     print(f"Stuck-net classification: {pcb_path.name}")
     print("=" * 70)
+    print(f"Connectivity model: {_model_label(strict)}")
     print()
     counts = result.counts
     print(f"Stuck signal nets: {len(result.diagnoses)}")

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -6497,19 +6497,29 @@ def _add_net_status_parser(subparsers) -> None:
             "(issue #3863)."
         ),
     )
-    net_status_parser.add_argument(
+    model_group = net_status_parser.add_mutually_exclusive_group()
+    model_group.add_argument(
         "--strict",
         dest="net_status_strict",
         action="store_true",
         help=(
             "Decide connectivity by REAL geometric copper contact (shapely "
-            "polygon intersection) instead of the default 0.01mm endpoint "
-            "proximity tolerance. The default model unions a segment endpoint "
-            "with a pad/via/segment whenever their reference points land "
-            "within 0.01mm even if the actual copper (segment width, pad "
-            "shape) does not touch -- so it can report a net 'complete' that "
-            "'kicad-cli pcb drc' reports as unconnected. --strict matches "
-            "KiCad's connectivity semantics (issue #4176). Requires shapely."
+            "polygon intersection), matching KiCad's connectivity semantics "
+            "(issue #4176). This has been the DEFAULT since issue #4557; the "
+            "flag is kept as an explicit no-op for script compatibility."
+        ),
+    )
+    model_group.add_argument(
+        "--legacy-proximity",
+        dest="net_status_legacy_proximity",
+        action="store_true",
+        help=(
+            "Opt into the legacy 0.01mm endpoint-proximity connectivity "
+            "model: a segment endpoint is unioned with a pad/via/segment "
+            "whenever their reference points land within 0.01mm, even if the "
+            "actual copper (segment width, pad shape) does not touch. "
+            "Faster (~1.5-2x) but diverges from KiCad in both directions "
+            "(issues #4176, #4557). Mutually exclusive with --strict."
         ),
     )
 

--- a/src/kicad_tools/router/stuck_classifier.py
+++ b/src/kicad_tools/router/stuck_classifier.py
@@ -452,6 +452,7 @@ def _find_blocking_strict_nets_from_pcb(
     *,
     radius_mm: float = 2.0,
     max_blockers: int = 3,
+    strict: bool = True,
 ) -> list[str]:
     """Strict signal nets whose committed copper boxes in *target_net*'s pads.
 
@@ -467,10 +468,15 @@ def _find_blocking_strict_nets_from_pcb(
 
     Vendored from #3861 (``partial_rescue._find_blocking_strict_nets_from_pcb``)
     -- the frame-correct geometry is load-bearing; see module docstring.
+
+    ``strict`` is the *analyzer* connectivity-model selection (issue #4557:
+    real copper geometry when ``True``, legacy endpoint-proximity when
+    ``False``) -- unrelated to the "strict nets" routing-priority naming
+    used throughout this function.
     """
     from kicad_tools.analysis.net_status import NetStatusAnalyzer
 
-    analysis = NetStatusAnalyzer(pcb).analyze()
+    analysis = NetStatusAnalyzer(pcb, strict=strict).analyze()
     status = analysis.get_net(target_net)
     if status is None or not status.unconnected_pads:
         return []
@@ -795,15 +801,21 @@ def classify_stuck_nets_from_pcb(
     dense_cluster_threshold: int = DEFAULT_DENSE_CLUSTER_THRESHOLD,
     max_blockers: int = 3,
     excluded_nets: frozenset[str] = frozenset(),
+    strict: bool = True,
 ) -> StuckClassifierResult:
     """Classify every unfinished signal net on *pcb* (already-loaded PCB).
 
     Split out from :func:`classify_stuck_nets` so it can be unit-tested with a
     small synthetic board without round-tripping through a file.
+
+    ``strict`` selects the ``NetStatusAnalyzer`` connectivity model (issue
+    #4557: real copper geometry when ``True``, legacy endpoint-proximity when
+    ``False``) -- NOT to be confused with the "strict nets" routing-priority
+    naming used for the rip-up pool below.
     """
     from kicad_tools.analysis.net_status import NetStatusAnalyzer
 
-    analysis = NetStatusAnalyzer(pcb).analyze()
+    analysis = NetStatusAnalyzer(pcb, strict=strict).analyze()
 
     # Strict signal nets = fully-connected multi-pad signal nets.  This is the
     # rip-up pool the M2 stage would draw from, and the set #3861's blocker
@@ -874,6 +886,7 @@ def classify_stuck_nets_from_pcb(
             strict_nets,
             radius_mm=blocker_radius_mm,
             max_blockers=max_blockers,
+            strict=strict,
         )
 
         # 3) Local congestion = densest foreign-obstruction count over the
@@ -1411,11 +1424,15 @@ def classify_stuck_nets(
     dense_cluster_threshold: int = DEFAULT_DENSE_CLUSTER_THRESHOLD,
     max_blockers: int = 3,
     excluded_nets: frozenset[str] = frozenset(),
+    strict: bool = True,
 ) -> StuckClassifierResult:
     """Classify every unfinished signal net on the PCB at *pcb_path*.
 
     READ-ONLY: loads the board, analyses connectivity + geometry, and returns
     the per-net classification.  Never mutates the board.
+
+    ``strict`` selects the ``NetStatusAnalyzer`` connectivity model (issue
+    #4557); see :func:`classify_stuck_nets_from_pcb`.
     """
     from kicad_tools.schema.pcb import PCB
 
@@ -1430,4 +1447,5 @@ def classify_stuck_nets(
         dense_cluster_threshold=dense_cluster_threshold,
         max_blockers=max_blockers,
         excluded_nets=excluded_nets,
+        strict=strict,
     )

--- a/tests/test_board_06_diffpair_test.py
+++ b/tests/test_board_06_diffpair_test.py
@@ -1190,3 +1190,101 @@ class TestPostQuantizeClearanceGate:
         assert generate_design_mod._clearance_signature(pcb_path) == set()
         ok = generate_design_mod._check_post_quantize_clearances(pcb_path, set())
         assert ok is True
+
+
+# =============================================================================
+# Issue #4557: default connectivity model = strict (real copper geometry)
+# =============================================================================
+
+
+class TestDefaultNetStatusOnCommittedArtifact:
+    """The DEFAULT ``NetStatusAnalyzer`` path reports 0 opens on board 06.
+
+    Issue #4557: the legacy endpoint-proximity model (0.01mm radius against
+    pad *centers*) false-flagged 16 open pads on the committed routed
+    artifact (``GND`` 14, ``+1V2`` 1, ``VBUS_USB`` 1) because the router
+    lands trace endpoints inside pad copper but away from pad centers
+    (e.g. ``+1V2`` pad U2.C3 entered 0.125mm off-center).  ``kicad-cli pcb
+    drc`` and strict mode both report 0.  The analyzer default is now
+    ``strict=True``; these tests pin the *default* code path -- no
+    ``strict`` argument may appear anywhere in them.
+    """
+
+    @pytest.fixture(scope="class")
+    def routed_pcb_path(self) -> Path:
+        routed = OUTPUT_DIR / "diffpair_test_routed.kicad_pcb"
+        if not routed.exists():
+            pytest.skip(f"Routed PCB artifact missing: {routed}")
+        return routed
+
+    @pytest.fixture(scope="class")
+    def default_result(self, routed_pcb_path: Path):
+        pytest.importorskip("shapely")
+        from kicad_tools.analysis.net_status import NetStatusAnalyzer
+
+        # Default construction -- the path every no-kwargs consumer hits.
+        return NetStatusAnalyzer(routed_pcb_path).analyze()
+
+    def test_default_path_reports_zero_open_pads(self, default_result) -> None:
+        incomplete = [n.net_name for n in default_result.incomplete]
+        unrouted = [n.net_name for n in default_result.unrouted]
+        assert incomplete == [] and unrouted == [], (
+            f"Default (strict) connectivity must report 0 incomplete / 0 "
+            f"unrouted nets on the committed board-06 artifact (kicad-cli "
+            f"agrees); got incomplete={incomplete}, unrouted={unrouted}. "
+            f"A regression here means the default connectivity model "
+            f"diverged from real copper geometry again (issue #4557)."
+        )
+        assert default_result.total_unconnected_pads == 0
+
+    @pytest.mark.parametrize("net_name", ["GND", "+1V2", "VBUS_USB"])
+    def test_previously_false_open_nets_complete(self, default_result, net_name: str) -> None:
+        """The three nets the legacy model false-flagged are complete."""
+        status = default_result.get_net(net_name)
+        assert status is not None, f"net {net_name!r} missing from analysis"
+        assert status.status == "complete", (
+            f"{net_name} must be complete under the default (strict) model "
+            f"(it is connected through zone pours; the legacy proximity model "
+            f"false-flagged it open, issue #4557); got {status.status} with "
+            f"{status.unconnected_count} unconnected pads."
+        )
+
+    def test_legacy_opt_out_reproduces_historical_false_opens(self, routed_pcb_path: Path) -> None:
+        """Characterization: ``strict=False`` still shows the legacy 16 opens.
+
+        Pins the explicit legacy opt-out's divergence so a silent behavior
+        change in either model is caught.  If the committed artifact is ever
+        regenerated with pad-center trace landings this count may change --
+        update the pin alongside the artifact refresh.
+        """
+        from kicad_tools.analysis.net_status import NetStatusAnalyzer
+
+        result = NetStatusAnalyzer(routed_pcb_path, strict=False).analyze()
+        opens_by_net = {n.net_name: n.unconnected_count for n in result.incomplete}
+        assert opens_by_net == {"GND": 14, "+1V2": 1, "VBUS_USB": 1}, (
+            f"Legacy proximity model characterization drifted: expected the "
+            f"historical 16 false opens (GND 14, +1V2 1, VBUS_USB 1); got "
+            f"{opens_by_net}."
+        )
+
+    def test_default_path_deterministic(self, routed_pcb_path: Path, default_result) -> None:
+        """Two default runs produce identical per-net verdicts and pad lists."""
+        pytest.importorskip("shapely")
+        from kicad_tools.analysis.net_status import NetStatusAnalyzer
+
+        second = NetStatusAnalyzer(routed_pcb_path).analyze()
+
+        def _snapshot(result):
+            return [
+                (
+                    n.net_name,
+                    n.status,
+                    tuple(p.full_name for p in n.unconnected_pads),
+                )
+                for n in result.nets
+            ]
+
+        assert _snapshot(default_result) == _snapshot(second), (
+            "Default (strict) net-status output must be deterministic across "
+            "runs on the same artifact (issue #4557 AC)."
+        )

--- a/tests/test_board_07_matchgroup_test.py
+++ b/tests/test_board_07_matchgroup_test.py
@@ -661,3 +661,46 @@ class TestNetCountBudget:
         for p_name, n_name in diffpairs.items():
             assert p_name in nets, f"Diff pair positive net {p_name!r} not in NETS"
             assert n_name in nets, f"Diff pair negative net {n_name!r} not in NETS"
+
+
+# =============================================================================
+# Issue #4557: genuine-open guard under the strict-by-default flip
+# =============================================================================
+
+
+class TestDefaultNetStatusGenuineOpens:
+    """The DEFAULT ``NetStatusAnalyzer`` path still reports board 07's real opens.
+
+    Issue #4557 flipped the analyzer default to strict (real copper
+    geometry).  The flip removes board 06's 16 FALSE opens but must not mask
+    board 07's 5 GENUINE opens (#3438) -- measured identical under both
+    connectivity models.  No ``strict`` argument may appear in these tests:
+    they pin the default code path consumers actually hit.
+    """
+
+    # The 5 known-unroutable nets on the committed artifact (#3438).
+    EXPECTED_OPEN_NETS = {"DQ3", "DQ4", "MIPI_DAT0_N", "TMDS_D0_N", "TMDS_D1_N"}
+
+    @pytest.fixture(scope="class")
+    def default_result(self):
+        pytest.importorskip("shapely")
+        routed = OUTPUT_DIR / "matchgroup_test_routed.kicad_pcb"
+        if not routed.exists():
+            pytest.skip(f"Routed PCB artifact missing: {routed}")
+        from kicad_tools.analysis.net_status import NetStatusAnalyzer
+
+        # Default construction -- no strict kwarg (issue #4557).
+        return NetStatusAnalyzer(routed).analyze()
+
+    def test_genuine_opens_still_reported(self, default_result) -> None:
+        open_nets = {n.net_name for n in default_result.incomplete} | {
+            n.net_name for n in default_result.unrouted
+        }
+        assert open_nets == self.EXPECTED_OPEN_NETS, (
+            f"Default (strict) connectivity must keep reporting board 07's 5 "
+            f"genuine opens (#3438) -- the #4557 default flip must not mask "
+            f"real opens.  Expected {sorted(self.EXPECTED_OPEN_NETS)}, got "
+            f"{sorted(open_nets)}.  Fewer nets here WITHOUT a router "
+            f"improvement on the committed artifact means the connectivity "
+            f"model started over-connecting; more means a regression."
+        )

--- a/tests/test_net_status_cmd.py
+++ b/tests/test_net_status_cmd.py
@@ -414,3 +414,68 @@ class TestEdgeCases:
         result = main([str(only_unconnected)])
         # Should handle gracefully (net 0 is typically excluded)
         assert result in (0, 1, 2)
+
+
+class TestConnectivityModelSelection:
+    """Issue #4557: strict is the default; --legacy-proximity is the opt-out."""
+
+    def test_strict_flag_is_accepted_noop(self, connected_pcb: Path, capsys):
+        """--strict stays accepted for script compat and matches the default."""
+        assert main([str(connected_pcb), "--strict"]) == 0
+        strict_out = capsys.readouterr().out
+        assert main([str(connected_pcb)]) == 0
+        default_out = capsys.readouterr().out
+        assert strict_out == default_out
+
+    def test_legacy_proximity_flag_accepted(self, connected_pcb: Path, capsys):
+        assert main([str(connected_pcb), "--legacy-proximity"]) == 0
+        out = capsys.readouterr().out
+        assert "legacy endpoint-proximity" in out
+
+    def test_strict_and_legacy_mutually_exclusive(self, connected_pcb: Path, capsys):
+        with pytest.raises(SystemExit) as excinfo:
+            main([str(connected_pcb), "--strict", "--legacy-proximity"])
+        assert excinfo.value.code == 2
+
+    def test_text_output_names_model_default(self, connected_pcb: Path, capsys):
+        main([str(connected_pcb)])
+        out = capsys.readouterr().out
+        assert "Connectivity model: strict (real copper geometry" in out
+
+    def test_json_output_names_model_default(self, connected_pcb: Path, capsys):
+        main([str(connected_pcb), "--format", "json"])
+        data = json.loads(capsys.readouterr().out)
+        assert data["connectivity_model"] == "strict"
+
+    def test_json_output_names_model_legacy(self, connected_pcb: Path, capsys):
+        main([str(connected_pcb), "--format", "json", "--legacy-proximity"])
+        data = json.loads(capsys.readouterr().out)
+        assert data["connectivity_model"] == "legacy_proximity"
+
+    def test_why_output_names_model(self, connected_pcb: Path, capsys):
+        """--why states which connectivity model produced the verdict."""
+        main([str(connected_pcb), "--why"])
+        out = capsys.readouterr().out
+        assert "Connectivity model: strict (real copper geometry" in out
+
+    def test_why_respects_legacy_selection(self, connected_pcb: Path, capsys):
+        """--legacy-proximity --why threads the model into the classifier.
+
+        Before #4557, ``--strict --why`` silently ignored the model flag
+        because ``classify_stuck_nets_from_pcb`` hardcoded default-mode
+        analyzers.
+        """
+        main([str(connected_pcb), "--why", "--legacy-proximity"])
+        out = capsys.readouterr().out
+        assert "Connectivity model: legacy endpoint-proximity" in out
+
+    def test_why_json_names_model(self, connected_pcb: Path, capsys):
+        main([str(connected_pcb), "--why", "--format", "json"])
+        data = json.loads(capsys.readouterr().out)
+        assert data["connectivity_model"] == "strict"
+
+    def test_exit_codes_unchanged_by_model_on_genuine_open(self, unrouted_pcb: Path, capsys):
+        """A truly disconnected board exits 2 under BOTH models (no masking)."""
+        assert main([str(unrouted_pcb)]) == 2
+        capsys.readouterr()
+        assert main([str(unrouted_pcb), "--legacy-proximity"]) == 2

--- a/tests/test_net_status_strict.py
+++ b/tests/test_net_status_strict.py
@@ -1,11 +1,15 @@
 """Tests for ``NetStatusAnalyzer(strict=True)`` real-geometry connectivity.
 
-Issue #4176: the default net-status connectivity model unions copper on a
+Issue #4176: the legacy net-status connectivity model unions copper on a
 0.01mm endpoint-proximity radius (``_points_close``) without testing whether
 the real copper shapes (segment width, pad size) actually touch, so it can
 report a net "complete" that ``kicad-cli pcb drc`` reports as unconnected
 (over-connecting relative to KiCad).  ``strict=True`` decides connectivity by
-real shapely copper-shape intersection instead, matching KiCad.
+real shapely copper-shape intersection instead, matching KiCad.  Since issue
+#4557 strict is the DEFAULT (the legacy model also under-connects: a trace
+endpoint inside pad copper but >0.01mm from the pad center was false-flagged
+open -- 16 false opens on board 06); ``strict=False`` is the explicit legacy
+opt-out.
 
 These fixtures are minimal synthetic PCBs built from S-expression strings (no
 external board files), following the convention in ``test_net_status.py``.
@@ -124,13 +128,13 @@ def test_strict_reports_complete_when_segment_reaches_into_pad():
 # --------------------------------------------------------------------------
 # AC #4: segment endpoints within the old 0.01mm tolerance but with
 # non-overlapping copper.  Proves the mode flag changes behavior AND that the
-# default is preserved.
+# legacy opt-out (``strict=False``) is preserved.
 # --------------------------------------------------------------------------
 
 
-def test_default_over_connects_endpoints_within_tolerance():
+def test_legacy_over_connects_endpoints_within_tolerance():
     # gap 0.009mm (< 0.01 tolerance), width 0.001mm (buffered copper 0.0005mm
-    # each side, so the copper is ~0.008mm short of touching).  The default
+    # each side, so the copper is ~0.008mm short of touching).  The legacy
     # endpoint-proximity model unions the two chains -> complete.
     board = _two_segment_board(gap=0.009, width=0.001)
     assert _status(board, "SIG", strict=False) == "complete"
@@ -156,14 +160,65 @@ def test_strict_and_default_agree_when_copper_actually_overlaps():
 # --------------------------------------------------------------------------
 
 
-def test_analyzer_defaults_to_non_strict(tmp_path: Path):
-    analyzer = _analyzer(_pad_seg_board(seg_end_x=109.9), tmp_path)
-    assert analyzer.strict is False
+def test_analyzer_defaults_to_strict(tmp_path: Path):
+    # Issue #4557: strict (real copper geometry) is the default.  Construct
+    # WITHOUT any ``strict`` argument so this pins the real constructor
+    # default, not a helper's.
+    path = tmp_path / "board.kicad_pcb"
+    path.write_text(_pad_seg_board(seg_end_x=109.9))
+    analyzer = NetStatusAnalyzer(path)
+    assert analyzer.strict is True
+
+
+def test_default_path_reports_complete_when_segment_reaches_into_pad(tmp_path: Path):
+    # Issue #4557 regression: the trace ends at 109.9 -- inside R2.1's copper
+    # (edge at 109.7) but 0.1mm from the pad CENTER at 110.0, i.e. 10x outside
+    # the legacy 0.01mm proximity radius.  The legacy model false-flags this
+    # open; the strict default must report complete.  No ``strict`` argument
+    # anywhere -- this exercises the default code path consumers hit.
+    path = tmp_path / "board.kicad_pcb"
+    path.write_text(_pad_seg_board(seg_end_x=109.9))
+    result = NetStatusAnalyzer(path).analyze()
+    net_status = result.get_net("SIG")
+    assert net_status is not None
+    assert net_status.status == "complete"
+
+
+def test_default_path_keeps_truly_disconnected_net_open(tmp_path: Path):
+    # Genuine-open guard (issue #4557): a multi-pad net with NO copper at all
+    # must stay unrouted/incomplete under the new strict default -- the flip
+    # must not mask real opens.  No ``strict`` argument anywhere.
+    board = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal) (44 "Edge.Cuts" user))
+  (net 0 "")
+  (net 1 "SIG")
+  (footprint "R" (layer "F.Cu") (uuid "fp1") (at 100 100)
+    (property "Reference" "R1" (at 0 0 0) (layer "F.SilkS") (uuid "r1"))
+    (pad "1" smd rect (at 0 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "SIG")))
+  (footprint "R" (layer "F.Cu") (uuid "fp2") (at 110 100)
+    (property "Reference" "R2" (at 0 0 0) (layer "F.SilkS") (uuid "r2"))
+    (pad "1" smd rect (at 0 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "SIG")))
+)
+"""
+    path = tmp_path / "board.kicad_pcb"
+    path.write_text(board)
+    result = NetStatusAnalyzer(path).analyze()
+    net_status = result.get_net("SIG")
+    assert net_status is not None
+    assert net_status.status in ("incomplete", "unrouted")
+    assert net_status.unconnected_count >= 1
 
 
 def test_strict_flag_is_recorded(tmp_path: Path):
     analyzer = _analyzer(_pad_seg_board(seg_end_x=109.9), tmp_path, strict=True)
     assert analyzer.strict is True
+
+
+def test_legacy_opt_out_flag_is_recorded(tmp_path: Path):
+    analyzer = _analyzer(_pad_seg_board(seg_end_x=109.9), tmp_path, strict=False)
+    assert analyzer.strict is False
 
 
 def test_zero_width_segment_does_not_crash_strict():
@@ -200,6 +255,11 @@ def test_strict_requires_shapely(monkeypatch, tmp_path: Path):
     path.write_text(_pad_seg_board(seg_end_x=109.9))
     with pytest.raises(ModuleNotFoundError):
         NetStatusAnalyzer(path, strict=True)
+    # Since #4557 the DEFAULT construction is strict, so it fails loud too.
+    with pytest.raises(ModuleNotFoundError):
+        NetStatusAnalyzer(path)
+    # The explicit legacy opt-out still works without shapely.
+    NetStatusAnalyzer(path, strict=False)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Flips `NetStatusAnalyzer` / `kct net-status` to **strict real-geometry connectivity by default** (shapely copper-shape intersection, matching `kicad-cli pcb drc`), removing board 06's 16 false opens while preserving every genuine open. The legacy 0.01mm endpoint-proximity model remains available as an explicit opt-out.

Closes #4557

## Verified fleet numbers (committed artifacts, this branch)

| Board | default (now strict) | `--legacy-proximity` | Match with curator's measurements |
|---|---|---|---|
| 06 | **0 nets / 0 pads open**, exit 0 | 3 nets / 16 pads (`GND` 14, `+1V2` 1, `VBUS_USB` 1), exit 2 | yes |
| 07 | 5 nets / 5 pads (`DQ3`, `DQ4`, `MIPI_DAT0_N`, `TMDS_D0_N`, `TMDS_D1_N`, #3438), exit 2 | identical | yes — no masking |
| 05 | 5 nets / 53 pads, all advisory pour residuals | identical | yes |

Timing (`analyze()` wall): board 06 0.49s → 0.94s, board 07 0.53s → 0.81s, board 05 0.21s → 0.32s — same ~1.5–2x, sub-second envelope the curator measured.

## Changes

- **Analyzer** (`analysis/net_status.py`): `strict: bool = True` default; `POSITION_TOLERANCE` comment + docstrings rewritten (legacy model documented as diverging in *both* directions). `require_shapely` fail-loud now runs for default construction; explicit `strict=False` still degrades gracefully.
- **CLI** (`cli/net_status_cmd.py`, `cli/parser.py`, `cli/__init__.py`): new `--legacy-proximity` opt-out on both the inner `kicad-net-status` parser and the outer `kct net-status` parser + forwarding shim; `--strict` kept as an accepted no-op for script compat (argparse-enforced mutual exclusion with the opt-out). Text output prints `Connectivity model: …` in the header; JSON gains a `connectivity_model` field; `--why` prints/embeds the model too.
- **`--why` plumbing** (`router/stuck_classifier.py`): `classify_stuck_nets`, `classify_stuck_nets_from_pcb`, and `_find_blocking_strict_nets_from_pcb` thread an analyzer-`strict` parameter (default `True`). Previously `--strict --why` silently ignored `--strict`. Docstrings disambiguate analyzer-strict from the unrelated "strict nets" routing-priority naming.
- **Strict-mode layer gating** (exposed by the flip; caught by the existing blind-via regression test `test_blind_via_does_not_bridge_unspanned_inner_segment`): strict chained segment copper by 2D polygon intersection with **no layer check**, so an In2.Cu trace 2D-overlapping an F.Cu trace/pad fused them — the new default would have masked a real open. Now: segment↔segment chaining requires same layer; segment→pad bonds require the pad to exist on the segment's layer (`*.Cu`-wildcard aware via the existing `_pad_layer_matches_zone`); via bonds stay layer-unfiltered at the pad (barrels span layers; via↔segment was already `_via_spans_layer`-gated). Fleet strict numbers verified unchanged after this fix (table above).
- **CHANGELOG**: entry under Unreleased → Changed.

## Exit-code semantics (AC)

`kct net-status` still exits 2 on incomplete/unrouted. Board 06 default invocation flips **2 → 0** — truthful, since kicad-cli and CI's strict plane-net gate both report it clean. Board 07 stays **2**. `--legacy-proximity` on board 06 still exits 2 (characterized in tests). Conflicting `--strict --legacy-proximity` exits 2 via argparse usage error.

## Caller audit (all 14 no-kwarg `NetStatusAnalyzer(` sites at `d4faaa11`)

**Inherit the new strict default (no code change; one-shot/report/diagnostic surfaces — expected win):**
- `cli/build_cmd.py:2750`, `cli/pipeline_cmd.py:321,1886`, `cli/pcb_query.py:202`, `cli/fleet_cmd.py:1006` — user-facing gates/reports; now agree with kicad-cli
- `report/collector.py:275` (reads `total_nets` only), `:550`
- `mcp/tools/routing.py:67,189`, `mcp/tools/analysis.py:227,628,711`
- `router/stuck_classifier.py:473,806` — now threaded (default `True`), selectable from `--why`
- `router/placement_delta.py:285`, `router/placement_nudge.py:195,313,604` — before/after-delta consumers; inherit strict (files untouched — placement_nudge is owned by in-flight #4550). Both suites pass; per-call cost stays sub-second on fleet boards. If a hot-loop regression is ever measured these are the legitimate `strict=False` pin candidates per the issue guidance.
- CI scripts: `scripts/ci/check_board_05_blocking.py:134` (re-ran: `blocking_incomplete_count = 0`, OK), `scripts/ci/check_diffpair_coverage.py:344` (signal-completion count; strict only removes false incompletes), `scripts/ci/board_route_determinism_smoke.sh:163` (determinism verified below)

**Already-explicit (no change):** `cli/net_status_cmd.py` (now computes from flags), `validate/rules/connectivity.py:112` (`strict=self.strict` — `kct check` unaffected), `scripts/ci/check_net_status.py:136` (`strict=True`).

## Scope guards honored

- `validate/` and `cli/check_cmd.py` untouched (PR #4656 owns those). `kct check --format json` on board 06 verified **byte-identical** between main and this branch (only env diffs: absolute path + artifact-mtime staleness line). `ConnectivityRule.rule_id` untouched → board-03 drift guard unaffected (its suite passes in the board batch).
- `router/io.py` (#4568), `route_cmd.py` entry guard (PR #4661), `partial_rescue`/`placement_nudge` (#4550): untouched.
- Committed board artifacts untouched (read-only fixtures).
- `tests/test_cli_parser_drift.py`: passes unchanged — it guards the `route`/`check` parser pairs only; `net-status` has no inner/outer drift guard, and the new flag was added to inner parser + outer parser + forwarding shim.

## Determinism (AC)

`kct net-status` run twice on board 06: text and JSON outputs byte-identical. Also pinned in `TestDefaultNetStatusOnCommittedArtifact::test_default_path_deterministic` (per-net verdicts + unconnected-pad name tuples across two default analyzer runs).

## Tests

- `tests/test_net_status_strict.py` — analyzer-default pin (real constructor, no helper defaults), #4557 off-center pad-entry regression through the default path, no-copper genuine-open guard, shapely fail-loud for default construction + graceful legacy, legacy naming updates
- `tests/test_board_06_diffpair_test.py::TestDefaultNetStatusOnCommittedArtifact` — 0 opens via default path, `GND`/`+1V2`/`VBUS_USB` pinned complete by name, legacy 16-open characterization, determinism pin
- `tests/test_board_07_matchgroup_test.py::TestDefaultNetStatusGenuineOpens` — exact 5-net #3438 set preserved via default path
- `tests/test_net_status_cmd.py::TestConnectivityModelSelection` — flag no-op/opt-out/mutual-exclusion, model naming in text/JSON/`--why`, `--legacy-proximity --why` threading, exit-code no-masking

**Results:** 177 passed (net-status/analysis/stuck-classifier), 159 passed (board 06/07 + connectivity rule + check_net_status + parser drift), 578 passed (all remaining suites referencing `NetStatusAnalyzer`: build preflight, clearance via-barrel, reachability, fleet, MCP routing, pipeline, report collector, route persistence), 353 passed (MCP analysis, fleet DRC, pipeline, placement delta), 55 passed (placement nudge/delta + route-complete report). Ruff clean, format clean, mypy baseline gate passes (2 baseline errors *removed*; baseline intentionally not tightened — the `--update` native-env trap drops the env-agnostic nanobind line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
