### PR TITLE
fix(dru): replace legacy pre-#4600 generated sidecars on merge; migrate committed board .kicad_dru (#4667)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -305,6 +305,20 @@ constructor). No breaking changes.
 
 ### Fixed
 
+- **Legacy pre-#4600 generated `.kicad_dru` sidecars duplicated on merge.**
+  The marker-guarded fab-floors merge (#4600) treated kct's own
+  clobber-written, unmarked sidecars as user-authored and APPENDED a second
+  copy of every tier floor instead of replacing the legacy content — rewriting
+  committed board artifacts in place (board-05's sidecar tripped the #3580
+  committed-artifacts guard, failing the Test job on main). `merge_dru_floors`
+  now recognizes the legacy generated shape (a `(version N)` header followed
+  exclusively by `generate_dru`-grammar rules with generated rule names) and
+  replaces it with the managed block; genuinely user-authored no-marker
+  content keeps the never-clobber append semantics. All eight committed
+  `boards/*/output/*.kicad_dru` sidecars were migrated to the marked format
+  (byte-identical rule floors, now sentinel-delimited), so re-export is
+  idempotent on them. (#4667)
+
 - **The `.kicad_dru` sidecar write clobbered pre-existing user content.** The
   tier-floor `.kicad_dru` written beside the board by `kct route`, `kct build`,
   `kct mfr apply-rules`, and `kct check --emit-dru`/`--emit-drc-constraints`

--- a/boards/00-simple-led/output/simple_led_routed.kicad_dru
+++ b/boards/00-simple-led/output/simple_led_routed.kicad_dru
@@ -1,4 +1,6 @@
 (version 1)
+
+# BEGIN kct fab floors (Issue #4600) -- managed, do not edit
 (rule "Trace Width - jlcpcb"
   (condition "A.Type == 'track'")
   (constraint track_width (min 0.127mm)))
@@ -28,3 +30,4 @@
   (constraint solder_mask_margin (min 0.05mm)))
 (rule "Solder Mask Dam - jlcpcb"
   (constraint physical_hole_clearance (min 0.1mm)))
+# END kct fab floors

--- a/boards/01-voltage-divider/output/voltage_divider_routed.kicad_dru
+++ b/boards/01-voltage-divider/output/voltage_divider_routed.kicad_dru
@@ -1,4 +1,6 @@
 (version 1)
+
+# BEGIN kct fab floors (Issue #4600) -- managed, do not edit
 (rule "Trace Width - jlcpcb"
   (condition "A.Type == 'track'")
   (constraint track_width (min 0.127mm)))
@@ -28,3 +30,4 @@
   (constraint solder_mask_margin (min 0.05mm)))
 (rule "Solder Mask Dam - jlcpcb"
   (constraint physical_hole_clearance (min 0.1mm)))
+# END kct fab floors

--- a/boards/02-charlieplex-led/output/charlieplex_3x3_routed.kicad_dru
+++ b/boards/02-charlieplex-led/output/charlieplex_3x3_routed.kicad_dru
@@ -1,4 +1,6 @@
 (version 1)
+
+# BEGIN kct fab floors (Issue #4600) -- managed, do not edit
 (rule "Trace Width - jlcpcb-tier1"
   (condition "A.Type == 'track'")
   (constraint track_width (min 0.127mm)))
@@ -28,3 +30,4 @@
   (constraint solder_mask_margin (min 0.05mm)))
 (rule "Solder Mask Dam - jlcpcb-tier1"
   (constraint physical_hole_clearance (min 0.1mm)))
+# END kct fab floors

--- a/boards/03-usb-joystick/output/usb_joystick_routed.kicad_dru
+++ b/boards/03-usb-joystick/output/usb_joystick_routed.kicad_dru
@@ -1,4 +1,6 @@
 (version 1)
+
+# BEGIN kct fab floors (Issue #4600) -- managed, do not edit
 (rule "Trace Width - jlcpcb-tier1"
   (condition "A.Type == 'track'")
   (constraint track_width (min 0.127mm)))
@@ -28,3 +30,4 @@
   (constraint solder_mask_margin (min 0.05mm)))
 (rule "Solder Mask Dam - jlcpcb-tier1"
   (constraint physical_hole_clearance (min 0.1mm)))
+# END kct fab floors

--- a/boards/04-stm32-devboard/output/stm32_devboard_routed.kicad_dru
+++ b/boards/04-stm32-devboard/output/stm32_devboard_routed.kicad_dru
@@ -1,4 +1,6 @@
 (version 1)
+
+# BEGIN kct fab floors (Issue #4600) -- managed, do not edit
 (rule "Trace Width - jlcpcb-tier1"
   (condition "A.Type == 'track'")
   (constraint track_width (min 0.127mm)))
@@ -28,3 +30,4 @@
   (constraint solder_mask_margin (min 0.05mm)))
 (rule "Solder Mask Dam - jlcpcb-tier1"
   (constraint physical_hole_clearance (min 0.1mm)))
+# END kct fab floors

--- a/boards/05-bldc-motor-controller/output/bldc_controller_routed.kicad_dru
+++ b/boards/05-bldc-motor-controller/output/bldc_controller_routed.kicad_dru
@@ -1,4 +1,6 @@
 (version 1)
+
+# BEGIN kct fab floors (Issue #4600) -- managed, do not edit
 (rule "Trace Width - jlcpcb"
   (condition "A.Type == 'track'")
   (constraint track_width (min 0.1016mm)))
@@ -28,3 +30,4 @@
   (constraint solder_mask_margin (min 0.05mm)))
 (rule "Solder Mask Dam - jlcpcb"
   (constraint physical_hole_clearance (min 0.1mm)))
+# END kct fab floors

--- a/boards/06-diffpair-test/output/diffpair_test_routed.kicad_dru
+++ b/boards/06-diffpair-test/output/diffpair_test_routed.kicad_dru
@@ -1,4 +1,6 @@
 (version 1)
+
+# BEGIN kct fab floors (Issue #4600) -- managed, do not edit
 (rule "Trace Width - jlcpcb"
   (condition "A.Type == 'track'")
   (constraint track_width (min 0.1016mm)))
@@ -28,3 +30,4 @@
   (constraint solder_mask_margin (min 0.05mm)))
 (rule "Solder Mask Dam - jlcpcb"
   (constraint physical_hole_clearance (min 0.1mm)))
+# END kct fab floors

--- a/boards/07-matchgroup-test/output/matchgroup_test_routed.kicad_dru
+++ b/boards/07-matchgroup-test/output/matchgroup_test_routed.kicad_dru
@@ -1,4 +1,6 @@
 (version 1)
+
+# BEGIN kct fab floors (Issue #4600) -- managed, do not edit
 (rule "Trace Width - jlcpcb"
   (condition "A.Type == 'track'")
   (constraint track_width (min 0.1016mm)))
@@ -28,3 +30,4 @@
   (constraint solder_mask_margin (min 0.05mm)))
 (rule "Solder Mask Dam - jlcpcb"
   (constraint physical_hole_clearance (min 0.1mm)))
+# END kct fab floors

--- a/src/kicad_tools/manufacturers/dru_generator.py
+++ b/src/kicad_tools/manufacturers/dru_generator.py
@@ -40,6 +40,71 @@ DRU_FLOORS_BLOCK_END = "# END kct fab floors"
 # KiCad ``.kicad_dru`` files start with a version header.
 DRU_VERSION_HEADER = "(version 1)"
 
+# ---------------------------------------------------------------------------
+# Legacy (pre-#4600) generated-sidecar detection (Issue #4667)
+# ---------------------------------------------------------------------------
+#
+# Before #4600 the ``.kicad_dru`` sidecar was clobber-written with raw
+# :func:`generate_dru` output -- no sentinel markers.  Those files are OUR
+# generated content, not user-authored, so on merge they must be REPLACED by
+# the managed block rather than appended to (appending duplicates every tier
+# floor and dirties committed board artifacts; see Issue #4667).
+#
+# Detection is deliberately strict: the file must start with a version
+# header, contain nothing but blank lines and rule s-expressions matching the
+# exact line grammar :func:`generate_dru` emits, and every rule name must be
+# one of the generated rule families (with an optional ``- <manufacturer>``
+# label suffix).  Any comment line, foreign rule name, or off-grammar line
+# (hand-edited values keep the generated grammar, so those still count as
+# legacy -- but structural edits do not) classifies the file as user-owned
+# and keeps the never-clobber append semantics from #4600.
+
+#: Rule-name families emitted by :func:`generate_dru`, sans label suffix.
+_LEGACY_RULE_NAME_RE = re.compile(
+    r"^(?:Trace Width|Clearance|Via Drill|Via Diameter|Annular Ring|"
+    r"Copper to Edge|Hole to Edge|Silkscreen Width|Silkscreen Height|"
+    r"Solder Mask Clearance|Solder Mask Dam|"
+    r"Ampacity Min Width \(.+, (?:external|internal)\))"
+    r"(?: - .+)?$"
+)
+
+_LEGACY_VERSION_LINE_RE = re.compile(r"\(version \d+\)")
+_LEGACY_RULE_OPEN_RE = re.compile(r'\(rule "([^"]+)"')
+_LEGACY_CONDITION_LINE_RE = re.compile(r'  \(condition "[^"]*"\)')
+_LEGACY_CONSTRAINT_LINE_RE = re.compile(r"  \(constraint \w+ \(min [0-9.]+mm\)\)\)")
+
+
+def _is_legacy_generated_dru(existing: str) -> bool:
+    """True when ``existing`` is a pre-#4600 clobber-written generated sidecar.
+
+    Such files carry no sentinel markers but are recognizably raw
+    :func:`generate_dru` output: a leading ``(version N)`` header followed
+    exclusively by tier-floor rules using the generated line grammar and
+    rule names.  Genuinely user-authored content (custom rule names,
+    comments, creepage markers, multi-constraint rules, ...) never matches.
+    """
+    if not re.match(r"^\s*\(version\b", existing):
+        return False
+
+    saw_rule = False
+    for line in existing.splitlines():
+        if not line.strip():
+            continue
+        if _LEGACY_VERSION_LINE_RE.fullmatch(line):
+            continue
+        rule_open = _LEGACY_RULE_OPEN_RE.fullmatch(line)
+        if rule_open:
+            if not _LEGACY_RULE_NAME_RE.match(rule_open.group(1)):
+                return False
+            saw_rule = True
+            continue
+        if _LEGACY_CONDITION_LINE_RE.fullmatch(line):
+            continue
+        if _LEGACY_CONSTRAINT_LINE_RE.fullmatch(line):
+            continue
+        return False
+    return saw_rule
+
 
 def _strip_version_header(content: str) -> str:
     """Drop a leading ``(version N)`` line so a merged file keeps exactly one."""
@@ -57,12 +122,18 @@ def merge_dru_floors(existing: str | None, dru_content: str) -> str:
     * No existing content -> ``(version 1)`` + the managed block.
     * Existing fab-floors block present -> replace only the text between the
       sentinels.
-    * Existing content without a fab-floors block (a fully user-owned file,
-      or one holding the creepage managed block) -> **append** the block,
-      preserving every existing byte, and prepend a version header only if
-      the file lacks one.  A pre-existing file is therefore never clobbered
-      or deleted -- the previous blanket ``write_text`` silently destroyed
-      HV creepage rules and hand-written custom rules.
+    * Existing content that is a **legacy pre-#4600 generated sidecar**
+      (no markers, but recognizably raw :func:`generate_dru` output; see
+      :func:`_is_legacy_generated_dru`) -> treat it as ours and REPLACE it
+      with the managed block.  Appending would duplicate every tier floor
+      on each re-emit and permanently dirty committed board artifacts
+      (Issue #4667).
+    * Other existing content without a fab-floors block (a fully user-owned
+      file, or one holding the creepage managed block) -> **append** the
+      block, preserving every existing byte, and prepend a version header
+      only if the file lacks one.  A pre-existing user file is therefore
+      never clobbered or deleted -- the previous blanket ``write_text``
+      silently destroyed HV creepage rules and hand-written custom rules.
 
     The merged result contains exactly one leading ``(version 1)`` header
     (the header inside ``dru_content`` is stripped before wrapping).
@@ -91,6 +162,12 @@ def merge_dru_floors(existing: str | None, dru_content: str) -> str:
     if pattern.search(existing):
         merged = pattern.sub(lambda _m: block, existing)
         return merged if merged.endswith("\n") else merged + "\n"
+
+    if _is_legacy_generated_dru(existing):
+        # Pre-#4600 clobber-written sidecar: the whole file is our own
+        # generated output, so replace it with the marked block instead of
+        # appending a duplicate copy of every floor (#4667).
+        return f"{DRU_VERSION_HEADER}\n\n{block}\n"
 
     # Append; ensure a version header exists (mirrors ``merge_dru_block``).
     prefix = existing if existing.endswith("\n") else existing + "\n"

--- a/tests/test_drc_constraints_export.py
+++ b/tests/test_drc_constraints_export.py
@@ -373,6 +373,59 @@ class TestDruManagedBlockMerge:
         assert '(rule "Trace Width - jlcpcb-tier1"' in merged
         assert merged.count("(version 1)") == 1
 
+    def test_legacy_generated_sidecar_is_replaced_not_appended(self, tmp_path: Path):
+        """A pre-#4600 clobber-written sidecar is replaced, not duplicated.
+
+        Issue #4667: our own generated ``.kicad_dru`` files written before
+        the managed-block merge carry no markers.  They must be recognized
+        as kct-owned and REPLACED by the managed block -- appending doubles
+        every tier floor on each re-emit and permanently dirties committed
+        board artifacts (the #3580 guard fired on board-05's sidecar).
+        """
+        from kicad_tools.manufacturers.dru_generator import (
+            DRU_FLOORS_BLOCK_BEGIN,
+            generate_dru,
+        )
+
+        board = tmp_path / "demo.kicad_pcb"
+        board.write_text("(kicad_pcb)")
+        legacy = generate_dru(
+            get_profile("jlcpcb").get_design_rules(layers=2), manufacturer_name="jlcpcb"
+        )
+        assert DRU_FLOORS_BLOCK_BEGIN not in legacy
+        dru = board.with_suffix(".kicad_dru")
+        dru.write_text(legacy, encoding="utf-8")
+
+        merged = self._emit(board)  # emits at jlcpcb-tier1
+
+        assert merged.count(DRU_FLOORS_BLOCK_BEGIN) == 1
+        # The legacy floors were replaced -- no duplicated rule families.
+        assert merged.count('(rule "Trace Width') == 1
+        assert '"Trace Width - jlcpcb"' not in merged
+        assert '"Trace Width - jlcpcb-tier1"' in merged
+        assert merged.count("(version 1)") == 1
+        # Re-emitting is byte-stable.
+        assert self._emit(board) == merged
+
+    def test_committed_board_sidecars_are_marked(self):
+        """Every committed ``boards/*/output/*.kicad_dru`` uses the marked format.
+
+        Issue #4667 migrated the legacy sidecars; a legacy-shaped committed
+        artifact would be rewritten in place by export-path tests and trip
+        the #3580 committed-artifacts guard.
+        """
+        from kicad_tools.manufacturers.dru_generator import DRU_FLOORS_BLOCK_BEGIN
+
+        repo_root = Path(__file__).resolve().parent.parent
+        sidecars = sorted(repo_root.glob("boards/*/output/*.kicad_dru"))
+        assert sidecars, "expected committed board .kicad_dru sidecars"
+        unmarked = [
+            str(p.relative_to(repo_root))
+            for p in sidecars
+            if DRU_FLOORS_BLOCK_BEGIN not in p.read_text(encoding="utf-8")
+        ]
+        assert not unmarked, f"legacy-unmarked committed sidecars: {unmarked}"
+
     def test_user_owned_file_is_never_clobbered(self, tmp_path: Path):
         """A no-marker, fully user-owned file keeps every byte of content.
 


### PR DESCRIPTION
## Summary

RELEASE BLOCKER for v0.20.0: on clean `origin/main` (post-#4653),
`tests/test_board_05_export.py` rewrote the committed
`boards/05-bldc-motor-controller/output/bldc_controller_routed.kicad_dru` in
place — `merge_dru_floors` treated our own pre-#4600 legacy-unmarked generated
sidecar as user-authored and APPENDED a duplicate `# BEGIN kct fab floors`
managed block. The #3580 committed-artifacts guard then fired at session
teardown, so main's Test job fails once Actions recovers.

## Root cause

PR #4653 (#4600) added never-clobber merge semantics: a no-marker file is
preserved and the managed block is appended alongside. But every sidecar
generated *before* #4600 is also unmarked — the merge path could not tell
"user-owned" from "our own legacy clobber-written output" and duplicated the
tier floors on each re-emit. `kct export --strict-preflight` (run by the
board-05 test against the committed PCB) exercises exactly this path via
`write_drc_constraints`.

## Fix (both options from the issue)

1. **Legacy detection in `merge_dru_floors`**
   (`src/kicad_tools/manufacturers/dru_generator.py`): a no-marker file that
   starts with a `(version N)` header and consists exclusively of
   `generate_dru`-grammar lines (`(rule "NAME"`, condition, single
   `(constraint … (min …mm)))`) with generated rule names (`Trace Width`,
   `Clearance`, …, `Ampacity Min Width (…)`, optional `- <mfr>` suffix) is
   recognized as a pre-#4600 generated sidecar and REPLACED by the managed
   block. Any comment line, foreign rule name, or off-grammar line keeps the
   #4600 append semantics — the user-owned never-clobber tests stay green
   unchanged.
2. **Migration of committed artifacts**: all 8
   `boards/*/output/*.kicad_dru` sidecars were legacy-unmarked (survey below);
   each was wrapped into the marked format via `merge_dru_floors(None, old)`
   with the rule floors byte-preserved. For board-05 the freshly generated
   floors are byte-identical to the committed rules, so the export path's
   merged output now equals the committed artifact exactly — no in-place
   mutation, guard stays meaningful (option (c) satisfied by construction).

Excluded on purpose: `src/kicad_tools/manufacturers/rules/*.kicad_dru` are
static `generate_dru` drift-guard reference exports (test_mfr.py), never merge
targets — left byte-identical.

## Survey (legacy-unmarked committed sidecars, all migrated)

boards 00, 01, 02, 03, 04, 05, 06, 07 — every `boards/*/output/*.kicad_dru`
was pre-#4600 shape. A new test
(`test_committed_board_sidecars_are_marked`) guards against regressing to the
legacy shape.

## Tests

- New: `test_legacy_generated_sidecar_is_replaced_not_appended` (replace not
  append, single block, byte-stable re-emit), `test_committed_board_sidecars_are_marked`.
- `tests/test_board_05_export.py`: 3 passed, working tree clean afterward
  (guard no longer fires).
- `tests/test_drc_constraints_export.py` + `tests/test_check_emit_dru.py` +
  `tests/creepage/test_export_rules.py` + `tests/test_mfr.py`: 124 passed,
  2 skipped.
- Double-merge idempotence asserted both in the new test and during migration.
- ruff check/format clean; mypy clean on the touched module.

Closes #4667

🤖 Generated with [Claude Code](https://claude.com/claude-code)
