### PR TITLE
feat(dru): warn when merge_dru_floors takes the legacy-replace path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Stderr warning when `merge_dru_floors` migrates a legacy sidecar**
+  (#4676) — the pre-#4600 legacy-replace branch added in #4667 now emits a
+  one-line stderr notice naming the `.kicad_dru` file (threaded from both
+  `kct check --emit-dru` and `write_drc_constraints` via a new optional
+  `path` kwarg), so a hand-authored file caught by the detector's narrow
+  documented false-positive window is replaced loudly instead of silently.
+  The other merge paths (fresh write, marked-block replace, user-content
+  append) stay silent, and merged output is byte-identical to before.
+
 ## [0.20.0] - 2026-08-06
 
 ### Summary

--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -2249,6 +2249,7 @@ def _emit_drc_sidecars(
                         manufacturer_name=manufacturer_id,
                         net_classes=net_classes,
                     ),
+                    path=dru_path,
                 ),
                 encoding="utf-8",
             )

--- a/src/kicad_tools/manufacturers/dru_generator.py
+++ b/src/kicad_tools/manufacturers/dru_generator.py
@@ -17,11 +17,14 @@ Usage:
 from __future__ import annotations
 
 import re
+import sys
 from typing import TYPE_CHECKING, Sequence
 
 from .base import DesignRules
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from kicad_tools.router.rules import NetClassRouting
 
 # ---------------------------------------------------------------------------
@@ -111,7 +114,11 @@ def _strip_version_header(content: str) -> str:
     return re.sub(r"^\s*\(version[^)]*\)\s*\n?", "", content, count=1)
 
 
-def merge_dru_floors(existing: str | None, dru_content: str) -> str:
+def merge_dru_floors(
+    existing: str | None,
+    dru_content: str,
+    path: str | Path | None = None,
+) -> str:
     """Merge :func:`generate_dru` output into ``.kicad_dru`` content (#4600).
 
     The tier-floor rules are wrapped in a sentinel-delimited managed block and
@@ -145,9 +152,20 @@ def merge_dru_floors(existing: str | None, dru_content: str) -> str:
             file does not exist yet.
         dru_content: Fresh :func:`generate_dru` output (with its leading
             version header) to install as the managed block.
+        path: Optional path of the ``.kicad_dru`` file the content came
+            from, used only to name the file in the one-line stderr warning
+            emitted when the legacy-replace branch fires (see below).  Has
+            no effect on the merged output.
 
     Returns:
         The full merged ``.kicad_dru`` file content.
+
+    Warning behavior (#4676): when the legacy pre-#4600 branch is taken --
+    and only then -- a one-line notice is printed to stderr, because the
+    strict detector has a narrow documented false-positive window (a
+    hand-authored file matching exactly the generated grammar and rule
+    families is replaced).  The other branches stay silent so the warning
+    is a reliable signal that the legacy migration specifically occurred.
     """
     body = _strip_version_header(dru_content).strip("\n")
     block = f"{DRU_FLOORS_BLOCK_BEGIN}\n{body}\n{DRU_FLOORS_BLOCK_END}"
@@ -166,7 +184,17 @@ def merge_dru_floors(existing: str | None, dru_content: str) -> str:
     if _is_legacy_generated_dru(existing):
         # Pre-#4600 clobber-written sidecar: the whole file is our own
         # generated output, so replace it with the marked block instead of
-        # appending a duplicate copy of every floor (#4667).
+        # appending a duplicate copy of every floor (#4667).  Warn so the
+        # rare hand-authored file caught by the detector's documented
+        # false-positive window is replaced loudly, not silently (#4676).
+        name = str(path) if path is not None else ".kicad_dru content"
+        print(
+            f"Warning: {name}: pre-#4600 generated sidecar detected -- "
+            f"replaced with the marked managed block (see Issue #4667). "
+            f"Hand-authored rules matching the generated grammar are treated "
+            f"as generated; restore from VCS if this file was yours.",
+            file=sys.stderr,
+        )
         return f"{DRU_VERSION_HEADER}\n\n{block}\n"
 
     # Append; ensure a version header exists (mirrors ``merge_dru_block``).

--- a/src/kicad_tools/manufacturers/project_generator.py
+++ b/src/kicad_tools/manufacturers/project_generator.py
@@ -375,6 +375,7 @@ def write_drc_constraints(
             merge_dru_floors(
                 existing_dru,
                 generate_dru(rules, manufacturer_name=manufacturer_id, net_classes=net_classes),
+                path=dru_path,
             ),
             encoding="utf-8",
         )

--- a/tests/test_drc_constraints_export.py
+++ b/tests/test_drc_constraints_export.py
@@ -407,6 +407,87 @@ class TestDruManagedBlockMerge:
         # Re-emitting is byte-stable.
         assert self._emit(board) == merged
 
+    def test_legacy_replace_warns_on_stderr_exactly_once(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ):
+        """The legacy-replace branch warns to stderr; all others are silent.
+
+        Issue #4676 (review follow-up to #4667): the strict legacy detector
+        has a narrow documented false-positive window -- a hand-authored
+        file matching exactly the generated grammar is replaced.  The
+        one-line stderr warning makes that replacement visible; it must
+        fire ONLY on the legacy branch so it is a reliable migration
+        signal, and it must name the file when a path is supplied.
+        """
+        from kicad_tools.manufacturers.dru_generator import (
+            generate_dru,
+            merge_dru_floors,
+        )
+
+        fresh = generate_dru(
+            get_profile("jlcpcb-tier1").get_design_rules(layers=4),
+            manufacturer_name="jlcpcb-tier1",
+        )
+        legacy = generate_dru(
+            get_profile("jlcpcb").get_design_rules(layers=2), manufacturer_name="jlcpcb"
+        )
+        dru_path = tmp_path / "demo.kicad_dru"
+
+        # Legacy branch with a path: exactly one stderr line naming the file.
+        warned = merge_dru_floors(legacy, fresh, path=dru_path)
+        err = capsys.readouterr().err
+        assert err.count("\n") == 1
+        assert str(dru_path) in err
+        assert "pre-#4600 generated sidecar" in err
+        assert "#4667" in err
+
+        # Legacy branch without a path: still warns, with a generic name.
+        merge_dru_floors(legacy, fresh)
+        err = capsys.readouterr().err
+        assert "pre-#4600 generated sidecar" in err
+        assert ".kicad_dru content" in err
+
+        # The warning is additive only: output is identical with/without path.
+        assert warned == merge_dru_floors(legacy, fresh)
+        capsys.readouterr()
+
+        # Silent: fresh write (existing=None) ...
+        marked = merge_dru_floors(None, fresh, path=dru_path)
+        # ... marked-block replace (also the idempotent second merge of a
+        # migrated file, so the warning fires at most once per migration) ...
+        assert merge_dru_floors(warned, fresh, path=dru_path) == warned
+        merge_dru_floors(marked, fresh, path=dru_path)
+        # ... and user-content append.
+        user_file = '(version 1)\n(rule "My HV Gap"\n  (constraint clearance (min 2.5mm)))\n'
+        appended = merge_dru_floors(user_file, fresh, path=dru_path)
+        assert user_file.strip("\n") in appended
+        assert capsys.readouterr().err == ""
+
+    def test_legacy_replace_warning_reaches_stderr_via_write_path(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ):
+        """``write_drc_constraints`` threads the real path into the warning."""
+        from kicad_tools.manufacturers.dru_generator import generate_dru
+
+        board = tmp_path / "demo.kicad_pcb"
+        board.write_text("(kicad_pcb)")
+        dru = board.with_suffix(".kicad_dru")
+        dru.write_text(
+            generate_dru(
+                get_profile("jlcpcb").get_design_rules(layers=2), manufacturer_name="jlcpcb"
+            ),
+            encoding="utf-8",
+        )
+
+        self._emit(board)
+        err = capsys.readouterr().err
+        assert str(dru) in err
+        assert "pre-#4600 generated sidecar" in err
+
+        # Second emit hits the marked-replace branch: silence.
+        self._emit(board)
+        assert capsys.readouterr().err == ""
+
     def test_committed_board_sidecars_are_marked(self):
         """Every committed ``boards/*/output/*.kicad_dru`` uses the marked format.
 


### PR DESCRIPTION
Closes #4676

## Summary

Follow-up to the #4668 review (Issue #4667): `merge_dru_floors` now emits a
one-line stderr warning when — and only when — the pre-#4600 legacy-replace
branch fires, so the detector's narrow documented false-positive window (a
hand-authored `.kicad_dru` matching exactly the generated grammar and
rule-family names) replaces the file loudly instead of silently.

## Changes

- `src/kicad_tools/manufacturers/dru_generator.py` — optional,
  backward-compatible `path: str | Path | None = None` kwarg on
  `merge_dru_floors`, used only to name the file in the warning (generic
  `".kicad_dru content"` fallback when `None`). Warning prints to stderr
  (`print(..., file=sys.stderr)`, matching surrounding CLI convention) only
  in the legacy branch; docstring documents the behavior.
- `src/kicad_tools/cli/check_cmd.py` — threads `path=dru_path` at the
  `--emit-dru` call site.
- `src/kicad_tools/manufacturers/project_generator.py` — threads
  `path=dru_path` in `write_drc_constraints`.
- `tests/test_drc_constraints_export.py` — two new tests:
  - `test_legacy_replace_warns_on_stderr_exactly_once`: exactly one stderr
    line on the legacy path (with the path string, and generic name when
    `path` omitted); silence on `existing=None`, marked-block replace
    (including the idempotent re-merge of a just-migrated file, so the
    warning fires at most once per migration), and user-content append;
    merged output identical with/without `path`.
  - `test_legacy_replace_warning_reaches_stderr_via_write_path`: the real
    path reaches the warning through `write_drc_constraints`; second emit
    (now marked) is silent.
- `CHANGELOG.md` — Unreleased/Added entry.

## Acceptance criteria (from curator enrichment)

- [x] Exactly one stderr line when the legacy-replace branch is taken,
  naming the file and stating a pre-#4600 generated sidecar was migrated.
- [x] No warning on `existing=None`/empty, marked-block replace, or append.
- [x] Merged output byte-identical on every path — warning is additive only.
- [x] Signature backward-compatible; existing callers/tests pass unmodified
  except the two call sites threading `dru_path`.
- [x] New test asserts warning fires exactly on the legacy path (including
  the path string), with companion silence assertions.

## Testing

- `uv run pytest tests/test_drc_constraints_export.py` — 25 passed
- `uv run pytest tests/test_check_emit_dru.py tests/creepage/test_export_rules.py` — 33 passed
- `ruff check` / `ruff format --check` clean on all changed files;
  `mypy src/kicad_tools/manufacturers/dru_generator.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
