### PR TITLE
ci: bump GitHub Actions off deprecated Node 20 runtimes (#4677)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,19 @@ jobs:
     name: Lint & Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: astral-sh/setup-uv@v4
+      # setup-uv publishes only immutable full-version tags since v8 (no
+      # @v8/@v9 major tags exist), hence the exact pin.
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           version: "latest"
+          # setup-uv >=5 auto-enables the Actions cache on hosted runners
+          # (and >=9 no longer prunes it before upload); keep the pre-v5
+          # no-cache behavior these jobs were written against.
+          enable-cache: false
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -46,11 +52,17 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: astral-sh/setup-uv@v4
+      # setup-uv publishes only immutable full-version tags since v8 (no
+      # @v8/@v9 major tags exist), hence the exact pin.
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           version: "latest"
+          # setup-uv >=5 auto-enables the Actions cache on hosted runners
+          # (and >=9 no longer prunes it before upload); keep the pre-v5
+          # no-cache behavior these jobs were written against.
+          enable-cache: false
 
       - name: Install dependencies
         run: uv sync --frozen --extra dev
@@ -105,10 +117,10 @@ jobs:
             ca-certificates curl git cmake build-essential
           kicad-cli --version
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        # Official one-liner instead of setup-uv@v4: avoids action-host
+        # Official one-liner instead of setup-uv: avoids action-host
         # coupling inside the container (mirrors the smoke job).
         run: |
           set -euo pipefail
@@ -151,13 +163,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: astral-sh/setup-uv@v4
+      # setup-uv publishes only immutable full-version tags since v8 (no
+      # @v8/@v9 major tags exist), hence the exact pin.
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           version: "latest"
+          # setup-uv >=5 auto-enables the Actions cache on hosted runners
+          # (and >=9 no longer prunes it before upload); keep the pre-v5
+          # no-cache behavior these jobs were written against.
+          enable-cache: false
 
-      # Note: deliberately NOT using actions/setup-python@v5 here. That action
+      # Note: deliberately NOT using actions/setup-python here. That action
       # exports Python_ROOT_DIR=/opt/hostedtoolcache/Python/.../x64, which is
       # sticky for cmake's find_package(Python ...) — even after activating
       # the uv venv with `source .venv/bin/activate`, cmake locates the
@@ -280,10 +298,10 @@ jobs:
             exit 1
           }
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        # setup-uv@v4 should work inside the container, but installing via
+        # setup-uv should work inside the container, but installing via
         # the official one-liner avoids any action-host coupling and keeps
         # the install deterministic across image refreshes.
         run: |
@@ -318,17 +336,23 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # Need the merge-base for `git diff origin/main...HEAD` (default
           # fetch-depth: 1 makes the diff fail with "unknown revision").
           fetch-depth: 0
 
-      - uses: astral-sh/setup-uv@v4
+      # setup-uv publishes only immutable full-version tags since v8 (no
+      # @v8/@v9 major tags exist), hence the exact pin.
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           version: "latest"
+          # setup-uv >=5 auto-enables the Actions cache on hosted runners
+          # (and >=9 no longer prunes it before upload); keep the pre-v5
+          # no-cache behavior these jobs were written against.
+          enable-cache: false
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -583,10 +607,10 @@ jobs:
             ca-certificates curl git cmake build-essential
           kicad-cli --version
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        # Official one-liner instead of setup-uv@v4: avoids action-host
+        # Official one-liner instead of setup-uv: avoids action-host
         # coupling inside the container (mirrors the test + smoke jobs).
         run: |
           set -euo pipefail
@@ -812,10 +836,10 @@ jobs:
             ca-certificates curl git cmake build-essential
           kicad-cli --version
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        # Official one-liner instead of setup-uv@v4: avoids action-host
+        # Official one-liner instead of setup-uv: avoids action-host
         # coupling inside the container (mirrors the test + smoke +
         # diffpair-routing-regression jobs).
         run: |
@@ -938,10 +962,10 @@ jobs:
             ca-certificates curl git cmake build-essential
           kicad-cli --version
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        # Official one-liner instead of setup-uv@v4: avoids action-host
+        # Official one-liner instead of setup-uv: avoids action-host
         # coupling inside the container (mirrors the test + smoke jobs).
         run: |
           set -euo pipefail
@@ -1063,7 +1087,7 @@ jobs:
             ca-certificates curl git cmake build-essential
           kicad-cli --version
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
         run: |
@@ -1159,7 +1183,7 @@ jobs:
             ca-certificates curl git cmake build-essential
           kicad-cli --version
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
         run: |
@@ -1262,7 +1286,7 @@ jobs:
             ca-certificates curl git cmake build-essential
           kicad-cli --version
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
         run: |
@@ -1409,7 +1433,7 @@ jobs:
             ca-certificates curl git cmake build-essential
           kicad-cli --version
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
         run: |
@@ -1570,7 +1594,7 @@ jobs:
             ca-certificates curl git cmake build-essential
           kicad-cli --version
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
         run: |
@@ -1776,7 +1800,7 @@ jobs:
             ca-certificates curl git cmake build-essential
           kicad-cli --version
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
         run: |
@@ -1891,7 +1915,7 @@ jobs:
             ca-certificates curl git cmake build-essential
           kicad-cli --version
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
         run: |

--- a/.github/workflows/label-external-issues.yml
+++ b/.github/workflows/label-external-issues.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Check if author is a collaborator
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -36,7 +36,7 @@ jobs:
 
       - name: Add 'external' label if not a collaborator
         if: fromJSON(steps.check.outputs.result).isCollaborator == false
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.issues.addLabels({
@@ -48,7 +48,7 @@ jobs:
 
       - name: Post welcome comment on external issues
         if: fromJSON(steps.check.outputs.result).isCollaborator == false
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const body = [

--- a/.github/workflows/nightly-ship-ready.yml
+++ b/.github/workflows/nightly-ship-ready.yml
@@ -31,11 +31,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: astral-sh/setup-uv@v4
+      # setup-uv publishes only immutable full-version tags since v8 (no
+      # @v8/@v9 major tags exist), hence the exact pin.
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           version: "latest"
+          # setup-uv >=5 auto-enables the Actions cache on hosted runners
+          # (and >=9 no longer prunes it before upload); keep the pre-v5
+          # no-cache behavior these jobs were written against.
+          enable-cache: false
 
       - name: Install dependencies
         run: uv sync --extra dev
@@ -77,7 +83,7 @@ jobs:
 
       - name: Upload ship-ready artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ship-ready-${{ github.run_id }}
           path: ship-ready-output/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,16 +14,26 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: astral-sh/setup-uv@v4
+      # setup-uv publishes only immutable full-version tags since v8 (no
+      # @v8/@v9 major tags exist), hence the exact pin.
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           version: "latest"
+          # setup-uv >=5 auto-enables the Actions cache on hosted runners
+          # (and >=9 no longer prunes it before upload); keep the pre-v5
+          # no-cache behavior these jobs were written against.
+          enable-cache: false
 
       - name: Build package
         run: uv build
 
-      - uses: actions/upload-artifact@v4
+      # upload@v7 / download@v8 are a verified-compatible pair: both speak
+      # the same v4-era artifact service API, the upload keeps the default
+      # zipped archive, and the name-based download extracts to `path`
+      # exactly as v4 did.
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -34,14 +44,20 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
 
-      - uses: astral-sh/setup-uv@v4
+      # setup-uv publishes only immutable full-version tags since v8 (no
+      # @v8/@v9 major tags exist), hence the exact pin.
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           version: "latest"
+          # setup-uv >=5 auto-enables the Actions cache on hosted runners
+          # (and >=9 no longer prunes it before upload); keep the pre-v5
+          # no-cache behavior these jobs were written against.
+          enable-cache: false
 
       - name: Publish to PyPI
         run: uv publish

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -15,11 +15,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: astral-sh/setup-uv@v4
+      # setup-uv publishes only immutable full-version tags since v8 (no
+      # @v8/@v9 major tags exist), hence the exact pin.
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           version: "latest"
+          # setup-uv >=5 auto-enables the Actions cache on hosted runners
+          # (and >=9 no longer prunes it before upload); keep the pre-v5
+          # no-cache behavior these jobs were written against.
+          enable-cache: false
 
       - name: Install KiCad symbol libraries
         # tests/test_board_03_regression.py regenerates the board 03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The other merge paths (fresh write, marked-block replace, user-content
   append) stay silent, and merged output is byte-identical to before.
 
+### Changed
+
+- **CI: GitHub Actions bumped off deprecated Node 20 runtimes** (#4677) —
+  every job log printed "Node.js 20 is deprecated" because six actions
+  across five workflow files were pinned to Node-20-era majors. Bumped:
+  `actions/checkout` v4→v7, `actions/setup-python` v5→v7,
+  `actions/github-script` v7→v9, `actions/upload-artifact` v4→v7,
+  `actions/download-artifact` v4→v8, and `astral-sh/setup-uv` v4→v9.0.0
+  (exact pin — setup-uv stopped publishing major tags at v8). setup-uv
+  invocations gained an explicit `enable-cache: false` to preserve the
+  pre-v5 no-cache behavior (v5 auto-enables the Actions cache on hosted
+  runners and v9 stopped pruning it before upload). The `ci.yml` container
+  jobs keep their deliberate curl one-liner installs. No behavior change
+  intended beyond the runtime bump.
+
 ## [0.20.0] - 2026-08-06
 
 ### Summary


### PR DESCRIPTION
## Summary

Retires the "Node.js 20 is deprecated" warning printed in every CI job log by bumping the six actions pinned to Node-20-era majors, across all five workflow files. Release notes for **every crossed major** were read before editing (per the curator's caution against blind sed-bumps); the per-action rationale is below.

Closes #4677

## Version bumps

| Action | Old | New | Uses | Files |
|---|---|---|---|---|
| `actions/checkout` | v4 | **v7** | 19 | ci.yml (16), publish.yml, slow-tests.yml, nightly-ship-ready.yml |
| `astral-sh/setup-uv` | v4 | **v9.0.0** (exact pin) | 8 | ci.yml (4), publish.yml (2), slow-tests.yml, nightly-ship-ready.yml |
| `actions/setup-python` | v5 | **v7** | 2 | ci.yml |
| `actions/github-script` | v7 | **v9** | 3 | label-external-issues.yml |
| `actions/upload-artifact` | v4 | **v7** | 2 | publish.yml, nightly-ship-ready.yml |
| `actions/download-artifact` | v4 | **v8** | 1 | publish.yml |

`rg "@v4|setup-python@v5|github-script@v7" .github/workflows/` is clean; all major tags verified to exist via `gh api repos/<r>/git/ref/tags/<tag>` (setup-uv is the exception — see below).

## Breaking-change review (per crossed major)

**actions/checkout v5/v6/v7**
- v5: Node 24 runtime; requires runner ≥ 2.327.1 (hosted runners satisfy this).
- v6: credentials persisted to a separate file instead of `.git/config` — nothing in this repo reads persisted checkout credentials.
- v7: **blocks checking out fork PRs under `pull_request_target` / `workflow_run`**. Verified no workflow in this repo uses either trigger (`rg` clean; ci.yml is plain `push`/`pull_request`), so the restriction is inert. The one non-default input in use (`fetch-depth: 0` in the routed-pcb-drc job) is unchanged across majors.

**astral-sh/setup-uv v5→v9.0.0**
- **v8 stopped publishing major/minor tags** (supply-chain hardening) — `@v8`/`@v9` literally do not exist as refs, so the pin is the immutable `@v9.0.0` tag, with a comment at each site explaining why it deviates from the repo's `@vN` style.
- v5: **`enable-cache` default flipped to on for GitHub-hosted runners**; v9: **`prune-cache` default flipped to `false`** (caches uploaded unpruned). Together these would have silently started uploading large uv caches against the repo's Actions cache quota. To keep this PR a pure runtime bump, every invocation now passes an explicit `enable-cache: false`, preserving the exact pre-v5 behavior. Enabling caching is a reasonable follow-up if wanted, but it is a deliberate decision, not a side effect.
- v6: `activate-environment`, `working-directory`, removal of `pyproject-file`/`uv-file` inputs — none used here.
- v7: Node 24; removed deprecated `server-url` input — not used. `version: "latest"` (the only input we pass) remains supported.

**actions/setup-python v6/v7**
- v6: Node 24 only. v7: ESM migration + removal of the `pip-install` input — not used. Our sole input `python-version: "3.12"` is unchanged.

**actions/github-script v8/v9**
- v8: Node 24. v9: ESM — `require('@actions/github')` no longer works inside scripts; `getOctokit` is now injected. All three inline scripts in `label-external-issues.yml` use only `context`, `github.rest.*`, `console.log`, and `return {...}` (consumed via `steps.check.outputs.result` + `fromJSON`) — all stable across v7→v9. No script changes needed.

**actions/upload-artifact v5/v6/v7 + download-artifact v5/v6/v7/v8 (compatibility pair)**
- upload v5 / download v6: Node 24-capable; v6 / v7 respectively: Node 24 by default. upload v7 / download v8: ESM; upload v7 adds an opt-in `archive: false` direct-upload mode (we keep the default zipped archive); download v8 checks `Content-Type` before unzipping (zipped uploads are extracted exactly as before) and **defaults `digest-mismatch` to `error`** — a fail-safe hardening, desirable for a publish pipeline.
- download v5's one breaking change (path nesting for **single downloads by `artifact-ids`**) does not apply: publish.yml downloads **by name** (`name: dist`), whose semantics are explicitly unchanged.
- **Pair verification (publish.yml, on-paper — cannot be exercised pre-tag):** upload@v7 and download@v8 both speak the same v4-era artifact service API (the v3→v4 boundary was the only wire-format break); upload@v7 with default `archive: true` produces a zipped artifact named `dist`, and download@v8's name-based download extracts it to `path: dist/` byte-identically to the v4/v4 pair. This rationale is also captured in a comment above the upload step.

## Deliberately untouched

- The `ci.yml` container jobs keep their **curl one-liner** uv installs (comments at the sites formerly numbered :111/:160/:286/:589/:818/:944 explain the action-host-coupling rationale). Only the stale version strings inside those comments (`setup-uv@v4`, `actions/setup-python@v5`) were updated to versionless references so they don't point at pins that no longer exist; no job was converted to an action.
- No `workflow_dispatch` was added to publish.yml (curator marked it optional). Keeping the least-watched workflow's trigger surface unchanged seemed safer than adding a guarded dispatch path in the same PR; can be a follow-up.

## Testing

- [x] `yaml.safe_load` over all five workflow files — OK
- [x] `actionlint` — clean (exit 0, no findings)
- [x] Pin inventory re-grepped: no Node-20-era pins remain
- [x] This PR's own CI run exercises every ci.yml job on the new pins
- [ ] Post-merge: dispatch `slow-tests` + `nightly-ship-ready` once each; grep one job's raw log per workflow for "Node.js 20" (fetch logs with escape-sequence-safe methods)
- [ ] **Release-operator note:** the first real `publish.yml` run on the new upload@v7/download@v8 pair will be the next `vX.Y.Z` tag — watch that run. A failure before the PyPI upload step is safely re-runnable.

An unrelated `uv.lock` staleness surfaced while validating (self-package pinned at 0.19.0 vs pyproject 0.20.0 on main); it was reverted out of this diff as out of scope.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
