### PR TITLE
fix(creepage): always serialize gate_passed + waived_count in --format json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The other merge paths (fresh write, marked-block replace, user-content
   append) stay silent, and merged output is byte-identical to before.
 
+- **`kct creepage --format json` now serializes the exit-code verdict**
+  (#4687) — the report-level JSON always carries `gate_passed` (the
+  waiver-aware verdict the CLI exit code follows) and `waived_count`
+  alongside the existing raw, waiver-blind `passed`, in both the phase-1
+  (`--min`) and standard-derived schemas. Previously the only verdict field
+  in the document was `passed`, so under `--waive-same-footprint` a JSON
+  consumer read `passed: false` while the process exited 0. Additive keys
+  only; `passed` semantics, per-pair `pass`/`waived` serialization, and the
+  `kct audit` manufacturing-readiness gate are unchanged.
+
 ### Changed
 
 - **CI: GitHub Actions bumped off deprecated Node 20 runtimes** (#4677) —

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -565,7 +565,12 @@ def _add_creepage_parser(subparsers) -> None:
         "--format",
         choices=["table", "json"],
         default="table",
-        help="Output format (default: table)",
+        help=(
+            "Output format (default: table).  JSON carries two verdicts (#4687): "
+            "'passed' is the raw, waiver-blind result (what kct audit uses), "
+            "while 'gate_passed' honors --waive-same-footprint and is what the "
+            "exit code follows -- CI consumers should key on 'gate_passed'."
+        ),
     )
 
 

--- a/src/kicad_tools/creepage/engine.py
+++ b/src/kicad_tools/creepage/engine.py
@@ -390,7 +390,8 @@ class CreepageReport:
     """Full census of HV creepage/clearance pairs for a board.
 
     In phase-1 mode (manual ``--min`` only) ``standard`` is ``None`` and the
-    serialized schema is byte-for-byte identical to phase 1.  In phase-2 mode a
+    serialized schema is the phase-1 schema (plus the additive report-level
+    verdict keys ``gate_passed`` / ``waived_count``, #4687).  In phase-2 mode a
     ``standard`` context (id/edition/PD/material group + derived-requirement
     provenance) is attached.
     """
@@ -456,7 +457,14 @@ class CreepageReport:
         return self.voltage_map is not None
 
     def to_dict(self) -> dict[str, Any]:
-        # Phase-1 backward compatibility: no standard -> exact phase-1 schema.
+        # Verdict semantics (#4687): ``passed`` is the RAW, waiver-blind result
+        # (what ``kct audit`` keys off); ``gate_passed`` is the waiver-aware
+        # verdict the standalone CLI exit code follows.  Both are always
+        # serialized so JSON consumers can gate unconditionally on
+        # ``gate_passed`` -- without waivers the two are identical.
+        waived_count = sum(1 for p in self.pairs if p.waived)
+        # Phase-1 backward compatibility: no standard -> phase-1 schema (plus
+        # the additive verdict keys above, #4687).
         if self.standard is None:
             return {
                 "board": self.board,
@@ -466,6 +474,8 @@ class CreepageReport:
                 "pair_count": len(self.pairs),
                 "pairs": [p.to_dict() for p in self.pairs],
                 "passed": self.passed,
+                "gate_passed": self.gate_passed,
+                "waived_count": waived_count,
             }
         d: dict[str, Any] = {
             "board": self.board,
@@ -492,6 +502,8 @@ class CreepageReport:
             "pair_count": len(self.pairs),
             "pairs": [p.to_dict() for p in self.pairs],
             "passed": self.passed,
+            "gate_passed": self.gate_passed,
+            "waived_count": waived_count,
         }
         # Per-net voltage mode (#4371): the requirement varies per pair, so the
         # report-level scalar requirement / working voltage are null (already set

--- a/tests/creepage/test_creepage_cli.py
+++ b/tests/creepage/test_creepage_cli.py
@@ -82,6 +82,10 @@ def test_json_census_schema(tmp_path, capsys):
     assert payload["pair_count"] == len(payload["pairs"])
     assert payload["pair_count"] >= 2  # HV-vs-GND and HV-vs-edge
     assert payload["passed"] is True
+    # #4687: the exit-code verdict + waived count are always serialized; with no
+    # waiver active gate_passed is identical to the raw passed.
+    assert payload["gate_passed"] is True
+    assert payload["waived_count"] == 0
 
     kinds = {p["kind"] for p in payload["pairs"]}
     assert {"conductor", "edge"} <= kinds
@@ -128,6 +132,8 @@ def test_no_hv_nets_json_empty_census(tmp_path, capsys):
     assert payload["pairs"] == []
     assert payload["pair_count"] == 0
     assert payload["passed"] is True
+    assert payload["gate_passed"] is True  # vacuously true, like passed (#4687)
+    assert payload["waived_count"] == 0
 
 
 # ---------------------------------------------------------------------------
@@ -279,7 +285,9 @@ def test_benign_suspect_named_board_exits_zero(tmp_path, capsys):
 def test_same_footprint_tagged_in_json(tmp_path, capsys):
     pcb = _write(tmp_path, board_same_footprint_only_source())
     ncm = _hv_map_file(tmp_path)
-    _run(["creepage", str(pcb), "--net-class-map", str(ncm), "--min", "1.0", "--format", "json"])
+    rc = _run(
+        ["creepage", str(pcb), "--net-class-map", str(ncm), "--min", "1.0", "--format", "json"]
+    )
     payload = json.loads(capsys.readouterr().out)
     src = next(p for p in payload["pairs"] if p["net_b"] == "SRC_NEG")
     gnd = next(p for p in payload["pairs"] if p["net_b"] == "GND")
@@ -287,6 +295,12 @@ def test_same_footprint_tagged_in_json(tmp_path, capsys):
     assert gnd["relationship"] == "board"
     # Without the waiver flag nothing is marked waived.
     assert "waived" not in src
+    # #4687: no waiver -> gate_passed mirrors the raw passed and both agree with
+    # the exit code.
+    assert rc == 1
+    assert payload["passed"] is False
+    assert payload["gate_passed"] is False
+    assert payload["waived_count"] == 0
 
 
 def test_waiver_off_same_footprint_fail_exits_nonzero(tmp_path, capsys):
@@ -350,7 +364,7 @@ def test_waiver_on_board_fail_still_exits_nonzero(tmp_path, capsys):
 def test_waiver_on_json_marks_waived_true(tmp_path, capsys):
     pcb = _write(tmp_path, board_same_footprint_only_source())
     ncm = _hv_map_file(tmp_path)
-    _run(
+    rc = _run(
         [
             "creepage",
             str(pcb),
@@ -370,6 +384,37 @@ def test_waiver_on_json_marks_waived_true(tmp_path, capsys):
     assert "waived" not in gnd  # board pairs are never waived
     # The report-level passed stays False (raw) -- only the exit code (gate) flips.
     assert payload["passed"] is False
+    # #4687: the JSON now also carries the verdict the exit code was computed
+    # from, so a CI consumer keying on gate_passed agrees with the process.
+    assert rc == 0
+    assert payload["gate_passed"] is True
+    assert payload["waived_count"] == sum(1 for p in payload["pairs"] if p.get("waived"))
+    assert payload["waived_count"] >= 1
+
+
+def test_waiver_on_board_fail_json_gate_passed_false(tmp_path, capsys):
+    # A board-level fail keeps gate_passed False even with waived pairs (#4687).
+    pcb = _write(tmp_path, board_same_footprint_fail_source())
+    ncm = _hv_map_file(tmp_path)
+    rc = _run(
+        [
+            "creepage",
+            str(pcb),
+            "--net-class-map",
+            str(ncm),
+            "--min",
+            "1.0",
+            "--waive-same-footprint",
+            "--format",
+            "json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert payload["passed"] is False
+    assert payload["gate_passed"] is False
+    assert payload["waived_count"] == sum(1 for p in payload["pairs"] if p.get("waived"))
+    assert payload["waived_count"] >= 1
 
 
 def test_missing_pcb_file_errors(tmp_path, capsys):

--- a/tests/creepage/test_creepage_engine.py
+++ b/tests/creepage/test_creepage_engine.py
@@ -849,3 +849,54 @@ def test_relationship_serialized_always_and_waived_only_when_true(tmp_path):
     assert same_fp.to_dict()["waived"] is True
     assert board.to_dict()["relationship"] == "board"
     assert "waived" not in board.to_dict()
+
+
+# ---------------------------------------------------------------------------
+# Report-level verdict serialization: gate_passed + waived_count (Issue #4687)
+# ---------------------------------------------------------------------------
+
+
+def test_to_dict_phase1_serializes_gate_passed_and_waived_count(tmp_path):
+    # The phase-1 (no standard) schema always carries BOTH verdicts plus the
+    # waived count -- gate_passed is what the CLI exit code follows.
+    report = _census_samefp(_load(tmp_path, board_same_footprint_only_source()))
+    d = report.to_dict()
+    assert d["passed"] is False
+    assert d["gate_passed"] is False  # no waiver active: identical to passed
+    assert d["waived_count"] == 0
+
+    for p in report.pairs:
+        if p.relationship == "same_footprint":
+            p.waived = True
+    n_waived = sum(1 for p in report.pairs if p.waived)
+    assert n_waived >= 1
+    d = report.to_dict()
+    assert d["passed"] is False  # raw verdict unchanged (kct audit gate, #4403)
+    assert d["gate_passed"] is True  # the exit-code verdict (#4687)
+    assert d["waived_count"] == n_waived
+
+
+def test_to_dict_phase2_serializes_gate_passed_and_waived_count(tmp_path):
+    # The phase-2 (standard) schema branch carries the same verdict fields.
+    report = _census_samefp(_load(tmp_path, board_same_footprint_only_source()))
+    report.standard = "iec60664"  # exercise the phase-2 serialization branch
+    report.standard_edition = "2007"
+    for p in report.pairs:
+        if p.relationship == "same_footprint":
+            p.waived = True
+    n_waived = sum(1 for p in report.pairs if p.waived)
+    d = report.to_dict()
+    assert d["standard"] == "iec60664"
+    assert d["passed"] is False
+    assert d["gate_passed"] is True
+    assert d["waived_count"] == n_waived
+
+
+def test_to_dict_empty_report_verdicts_vacuously_true():
+    # Zero pairs: both verdicts vacuously true, zero waived (#4687 edge case).
+    from kicad_tools.creepage.engine import CreepageReport
+
+    d = CreepageReport(net_class="HV", min_mm=1.0).to_dict()
+    assert d["passed"] is True
+    assert d["gate_passed"] is True
+    assert d["waived_count"] == 0

--- a/tests/creepage/test_creepage_standards_cli.py
+++ b/tests/creepage/test_creepage_standards_cli.py
@@ -278,6 +278,8 @@ def test_min_only_json_schema_unchanged(tmp_path, capsys):
     _run(["creepage", str(pcb), "--net-class-map", str(ncm), "--min", "1.5", "--format", "json"])
     payload = json.loads(capsys.readouterr().out)
     # Exactly the phase-1 top-level keys -- no phase-2 fields leak in.
+    # (``gate_passed`` / ``waived_count`` are always-on additive verdict keys,
+    # #4687 -- the exit-code gate and waiver tally, present in both schemas.)
     assert set(payload.keys()) == {
         "board",
         "net_class",
@@ -286,6 +288,8 @@ def test_min_only_json_schema_unchanged(tmp_path, capsys):
         "pair_count",
         "pairs",
         "passed",
+        "gate_passed",
+        "waived_count",
     }
     for pair in payload["pairs"]:
         # Drift-guard: ``relationship`` is now an always-on additive key (#4403);


### PR DESCRIPTION
## Summary

`kct creepage --format json` emitted only the raw, waiver-blind `passed` verdict, so under
`--waive-same-footprint` a JSON consumer read `passed: false` while the process exited 0 —
the exit code follows the waiver-aware `report.gate_passed`, which was never serialized.

Closes #4687

## Changes

- **`src/kicad_tools/creepage/engine.py`** — `CreepageReport.to_dict()` now always emits
  `gate_passed` (the exit-code verdict) and `waived_count` in **both** schema branches
  (phase-1 `--min` and standard-derived). Additive keys only; `passed` stays the raw
  verdict that `kct audit manufacturing-readiness` keys off (#4403 safety guard —
  untouched, the audit path consumes the `passed` *property*, not the dict). Updated the
  "exact phase-1 schema" comment and the class docstring accordingly.
- **`src/kicad_tools/cli/parser.py`** — `--format` help text now documents the dual-verdict
  semantics (`passed` = waiver-blind / audit, `gate_passed` = exit code / CI key).
- **`tests/creepage/test_creepage_engine.py`** — new serialization tests: phase-1 branch,
  phase-2 branch, and the zero-pairs edge case (both verdicts vacuously true,
  `waived_count: 0`).
- **`tests/creepage/test_creepage_cli.py`** — JSON output asserted against the exit code in
  all four quadrants: no-waiver pass, no-waiver fail, waiver rescuing a same-footprint-only
  fail (exit 0 + `gate_passed: true` + `waived_count >= 1`), and waiver with a residual
  board-level fail (exit 1 + `gate_passed: false`).
- **`tests/creepage/test_creepage_standards_cli.py`** — updated the phase-1 exact-key
  drift guard (`test_min_only_json_schema_unchanged`) for the two intentional additive
  keys. (Note: the curator enrichment stated no exact-key drift guard existed — this one
  lives in the standards CLI test file, not the two files checked.)
- **`CHANGELOG.md`** — entry under Unreleased.

## Acceptance criteria (from curator enrichment)

- [x] Waived same-footprint-only fails: exit 0, `passed: false`, `gate_passed: true`,
      `waived_count == <waived pairs>` (`test_waiver_on_json_marks_waived_true`)
- [x] Same board without the flag: exit 1, `passed: false`, `gate_passed: false`,
      `waived_count: 0` (`test_same_footprint_tagged_in_json`)
- [x] Fully-passing board, no flag: `passed: true`, `gate_passed: true`, `waived_count: 0`
      (`test_json_census_schema`)
- [x] Phase-1 (no `--standard`) JSON carries the new fields (engine + CLI tests)
- [x] `kct audit` unchanged (`tests/test_audit_hv_isolation.py` passes; audit reads the
      `passed` property, not the dict)
- [x] Existing `pairs[].pass` / `pairs[].waived` serialization unchanged
- [x] Zero-pairs edge case (`test_to_dict_empty_report_verdicts_vacuously_true`,
      `test_no_hv_nets_json_empty_census`)

## Testing

- `uv run pytest tests/creepage/ tests/test_audit_hv_isolation.py` — **248 passed**
- `uv run ruff check` / `uv run ruff format --check` on all changed files — clean
- `uv run python scripts/ci/check_mypy_baseline.py` — no new type errors (1472 within
  the 1474 baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
