### PR TITLE
fix(cli): kct net-status --net now scopes --why diagnoses and the text banner/summary (#4682)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   jobs keep their deliberate curl one-liner installs. No behavior change
   intended beyond the runtime bump.
 
+### Fixed
+
+- **`kct net-status --net X` output scoping** (#4682) — two `--net` defects
+  that made the filter untrustworthy. (1) `--net X --why` ignored the filter
+  entirely (`--why` short-circuited before net validation and
+  `output_why()` had no net parameter), so asking about one net printed
+  every OTHER stuck net's diagnosis; the whole-board classification is now
+  post-filtered to the selected net, with an explicit
+  `Net 'X' is not stuck (...)` statement (exit 0) when the selected net has
+  no diagnosis, and the same filtering in `--format json` (additive
+  `net_filter` key; unfiltered `--why` JSON unchanged). `--net NONEXISTENT
+  --why` now errors with the available-nets listing (exit 1) instead of
+  running unfiltered. (2) plain `--net X` rendered the board-wide summary
+  (e.g. `Incomplete: 1`) directly above an `All nets are fully connected!`
+  banner computed from the filtered set — a direct contradiction; the
+  summary and banner are now both scoped to the selection (`Summary: 1 net
+  selected (of N on board)` / `Selected net 'X' is fully connected.`). The
+  misleading `(100% connected)` literal on the Complete summary line is
+  reworded to `(all pads connected)`. Exit codes for the normal status path
+  are deliberately unchanged (board-wide even under `--net`, documented in
+  the `--net` help text); `--incomplete` keeps its board-wide header.
+
 ## [0.20.0] - 2026-08-06
 
 ### Summary

--- a/boards/00-simple-led/README.md
+++ b/boards/00-simple-led/README.md
@@ -33,7 +33,7 @@ kct check boards/00-simple-led/output/simple_led_routed.kicad_pcb
 # Overall:   PASSED   (DRC + ERC + LVS + Manifest)
 
 kct net-status boards/00-simple-led/output/simple_led_routed.kicad_pcb
-# Summary: 3 nets total — Complete: 3 (100% connected)
+# Summary: 3 nets total — Complete: 3 (all pads connected)
 ```
 
 ## Circuit Overview

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1147,20 +1147,25 @@ kct net-status <pcb_file> [options]
 | Option | Description |
 |--------|-------------|
 | `--format {table,json}` | Output format |
-| `--net NET` | Check a specific net |
+| `--net NET` | Check a specific net (scopes the summary/banner and `--why` diagnoses to it; the normal-path exit code stays board-wide) |
 | `--incomplete` | Show only incomplete / unrouted nets |
 | `--by-class` | Group output by net class |
 | `--legacy-proximity` | Use the pre-v0.20 endpoint-proximity model (default is strict real-copper geometry; mutually exclusive with `--strict`) |
-| `--why` | Explain each incomplete net (composes with the strict model) |
+| `--why` | Explain each incomplete net (composes with the strict model and with `--net`) |
 | `-v`, `--verbose` | Per-segment / per-pad detail |
 
 Exit code semantics are reused by the `preflight-routing` step in
 `kct build` and by `kct fleet status` to decide "ship-ready vs. not".
+Note the normal status path exits 2 when **any** net on the board is
+incomplete, even under `--net` with a complete selected net (kept for
+script compatibility, #4682); `--net X --why` scopes its exit code to the
+selected net (0 when X is not stuck, 2 when it is).
 
 **Examples:**
 ```bash
 kct net-status board.kicad_pcb --incomplete --format json
 kct net-status board.kicad_pcb --by-class
+kct net-status board.kicad_pcb --net DAC_CLK --why   # only DAC_CLK's diagnosis
 ```
 
 ---

--- a/src/kicad_tools/cli/net_status_cmd.py
+++ b/src/kicad_tools/cli/net_status_cmd.py
@@ -30,6 +30,12 @@ Exit Codes:
     0 - No incomplete nets
     1 - Error loading file or other error
     2 - Incomplete nets found
+
+    The exit code for the normal status path is board-wide even under
+    ``--net`` (exit 2 when ANY net on the board is incomplete, regardless of
+    the selected net's status) -- kept unchanged for script compatibility
+    (issue #4682). The ``--why`` path scopes its exit code to the selected
+    net when ``--net`` is given.
 """
 
 from __future__ import annotations
@@ -68,7 +74,13 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "--net",
-        help="Show status for a specific net by name",
+        help=(
+            "Show status for a specific net by name. Scopes the text "
+            "summary/banner (and --why diagnoses) to the selected net. "
+            "Note: the exit code stays BOARD-WIDE for the normal status "
+            "path -- exit 2 when any net on the board is incomplete, even "
+            "if the selected net is complete (issue #4682)."
+        ),
     )
     parser.add_argument(
         "--by-class",
@@ -139,14 +151,11 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Error during analysis: {e}", file=sys.stderr)
         return 1
 
-    # --why: stuck-net classifier (issue #3863). Read-only diagnostic that
-    # labels each incomplete signal net by WHY it is stuck. Handled before the
-    # normal filter/output path because it has its own output shape. Respects
-    # the strict/legacy selection (issue #4557).
-    if args.why:
-        return output_why(pcb_path, args.format, strict=strict)
-
-    # Filter results if needed
+    # --net: validate the selected net exists before dispatching to either
+    # output path. This must run ahead of the --why branch -- previously
+    # --why short-circuited first and silently ignored --net entirely
+    # (issue #4682).
+    net_status: NetStatus | None = None
     if args.net:
         net_status = result.get_net(args.net)
         if not net_status:
@@ -157,7 +166,18 @@ def main(argv: list[str] | None = None) -> int:
             if len(result.nets) > 20:
                 print(f"  ... and {len(result.nets) - 20} more", file=sys.stderr)
             return 1
-        # Create a result with just this net
+
+    # --why: stuck-net classifier (issue #3863). Read-only diagnostic that
+    # labels each incomplete signal net by WHY it is stuck. Handled before the
+    # normal filter/output path because it has its own output shape. Respects
+    # the strict/legacy selection (issue #4557) and the --net filter
+    # (issue #4682).
+    if args.why:
+        return output_why(pcb_path, args.format, strict=strict, net=args.net)
+
+    # Filter results if needed
+    if net_status is not None:
+        # Create a result with just this net (--net validated above)
         filtered = NetStatusResult(nets=[net_status], total_nets=1)
     elif args.incomplete:
         filtered = NetStatusResult(
@@ -171,9 +191,12 @@ def main(argv: list[str] | None = None) -> int:
     if args.format == "json":
         output_json(filtered, pcb_path, args.by_class, strict=strict)
     else:
-        # The summary header must always describe the unfiltered board so its
-        # counts stay internally consistent (Complete + Incomplete + Unrouted ==
-        # total). The filtered set only drives the net *list* below the header.
+        # For --incomplete the summary header must describe the unfiltered
+        # board so its counts stay internally consistent (Complete +
+        # Incomplete + Unrouted == total). The filtered set only drives the
+        # net *list* below the header. For --net the summary is instead
+        # scoped to the selection (issue #4682) so the banner and summary
+        # cannot contradict each other; ``net_filter`` selects that path.
         output_text(
             filtered,
             pcb_path,
@@ -182,9 +205,12 @@ def main(argv: list[str] | None = None) -> int:
             args.incomplete,
             summary_result=result,
             strict=strict,
+            net_filter=args.net,
         )
 
-    # Exit code
+    # Exit code. Deliberately BOARD-WIDE even under --net (issue #4682 kept
+    # this unchanged to avoid breaking script consumers; documented in the
+    # --net help text).
     if result.incomplete_count > 0 or result.unrouted_count > 0:
         return 2
     return 0
@@ -205,6 +231,7 @@ def output_text(
     incomplete_only: bool = False,
     summary_result: NetStatusResult | None = None,
     strict: bool = True,
+    net_filter: str | None = None,
 ) -> None:
     """Output results as formatted text.
 
@@ -216,30 +243,50 @@ def output_text(
             (Complete + Incomplete + Unrouted == total). Defaults to ``result``.
         strict: Which connectivity model produced ``result`` (drives the
             model line in the header, issue #4557).
+        net_filter: Name of the net selected with ``--net``, if any. When set,
+            the Summary block and the connectivity banner are BOTH scoped to
+            the selection (with the board-wide total named for context) so no
+            rendered line contradicts another (issue #4682). Note the exit
+            code computed by ``main()`` stays board-wide regardless.
     """
     summary = summary_result if summary_result is not None else result
     print(f"Net Status: {pcb_path.name}")
     print("=" * 60)
     print(f"Connectivity model: {_model_label(strict)}")
     print()
-    print(f"Summary: {summary.total_nets} nets total")
-    print(f"  Complete:   {summary.complete_count} (100% connected)")
-    print(f"  Incomplete: {summary.incomplete_count} (partially connected)")
-    print(f"  Unrouted:   {summary.unrouted_count} (0% connected)")
+    if net_filter is not None:
+        # --net: scope the counts to the selection (issue #4682). Before
+        # this, a board-wide "Incomplete: 1" rendered directly above an
+        # "All nets are fully connected!" banner derived from the filtered
+        # set -- a direct contradiction.
+        print(f"Summary: 1 net selected (of {summary.total_nets} on board)")
+        counted = result
+    else:
+        print(f"Summary: {summary.total_nets} nets total")
+        counted = summary
+    print(f"  Complete:   {counted.complete_count} (all pads connected)")
+    print(f"  Incomplete: {counted.incomplete_count} (partially connected)")
+    print(f"  Unrouted:   {counted.unrouted_count} (no pads connected)")
     print()
 
     if by_class:
         _output_by_class(result, verbose)
     else:
-        _output_flat(result, verbose, incomplete_only)
+        _output_flat(result, verbose, incomplete_only, net_filter=net_filter)
 
 
 def _output_flat(
     result: NetStatusResult,
     verbose: bool,
     incomplete_only: bool,
+    net_filter: str | None = None,
 ) -> None:
-    """Output nets in flat list format."""
+    """Output nets in flat list format.
+
+    ``net_filter`` names the ``--net`` selection when set; the fully-connected
+    banner is then worded for that scope instead of claiming board-wide
+    completeness (issue #4682).
+    """
     # Show incomplete nets with details
     if result.incomplete or result.unrouted:
         print("Incomplete Nets:")
@@ -249,7 +296,10 @@ def _output_flat(
             _print_net_status(net, verbose)
 
     elif not incomplete_only:
-        print("All nets are fully connected!")
+        if net_filter is not None:
+            print(f"Selected net '{net_filter}' is fully connected.")
+        else:
+            print("All nets are fully connected!")
 
     # Show complete nets if not filtering
     if not incomplete_only and result.complete:
@@ -381,19 +431,32 @@ def _print_recommendation(diag: StuckNetDiagnosis) -> None:
         print(f"                    {i}. {label} ({ranked.rationale}){preferred}")
 
 
-def output_why(pcb_path: Path, fmt: str, strict: bool = True) -> int:
+def output_why(pcb_path: Path, fmt: str, strict: bool = True, net: str | None = None) -> int:
     """Classify incomplete signal nets by why they are stuck and print them.
 
     ``strict`` selects the connectivity model the classifier's internal
     ``NetStatusAnalyzer`` runs use (issue #4557) -- before this parameter,
     ``--strict --why`` silently ignored ``--strict``.
 
-    Returns 2 if any stuck nets were found (matching the rest of net-status'
-    exit-code convention), 0 if the board has no stuck signal nets.
+    ``net`` scopes the output to a single net (the ``--net`` selection,
+    issue #4682): classification still runs whole-board (acceptable cost for
+    a read-only diagnostic), then the diagnoses are post-filtered to the
+    selected net. The caller (``main()``) has already validated that the net
+    exists on the board. Before this parameter, ``--net X --why`` silently
+    printed every stuck net EXCEPT the one asked about.
+
+    Returns 2 if any (selected) stuck nets were found (matching the rest of
+    net-status' exit-code convention), 0 if there are none -- so under
+    ``--net`` the exit code reflects the selected net only.
     """
-    from kicad_tools.router.stuck_classifier import classify_stuck_nets
+    from kicad_tools.router.stuck_classifier import StuckClassifierResult, classify_stuck_nets
 
     result = classify_stuck_nets(pcb_path, strict=strict)
+
+    # --net filter (issue #4682): restrict diagnoses (and every derived
+    # count) to the selected net.
+    if net is not None:
+        result = StuckClassifierResult(diagnoses=[d for d in result.diagnoses if d.net_name == net])
 
     if fmt == "json":
         data = {
@@ -401,12 +464,16 @@ def output_why(pcb_path: Path, fmt: str, strict: bool = True) -> int:
             "connectivity_model": "strict" if strict else "legacy_proximity",
             **result.to_dict(),
         }
+        if net is not None:
+            data["net_filter"] = net
         print(json.dumps(data, indent=2))
         return 2 if result.diagnoses else 0
 
     print(f"Stuck-net classification: {pcb_path.name}")
     print("=" * 70)
     print(f"Connectivity model: {_model_label(strict)}")
+    if net is not None:
+        print(f"Selected net: {net}")
     print()
     counts = result.counts
     print(f"Stuck signal nets: {len(result.diagnoses)}")
@@ -418,8 +485,11 @@ def output_why(pcb_path: Path, fmt: str, strict: bool = True) -> int:
     print()
 
     if not result.diagnoses:
-        print("No stuck signal nets -- board is fully routed (or only advisory")
-        print("plane/pour residuals remain).")
+        if net is not None:
+            print(f"Net '{net}' is not stuck (complete, or only advisory plane/pour residuals).")
+        else:
+            print("No stuck signal nets -- board is fully routed (or only advisory")
+            print("plane/pour residuals remain).")
         return 0
 
     # Group for readability, escape-blocked first (most upstream).

--- a/tests/test_net_status_cmd.py
+++ b/tests/test_net_status_cmd.py
@@ -479,3 +479,100 @@ class TestConnectivityModelSelection:
         assert main([str(unrouted_pcb)]) == 2
         capsys.readouterr()
         assert main([str(unrouted_pcb), "--legacy-proximity"]) == 2
+
+
+class TestNetFilterScoping:
+    """Issue #4682: --net must scope the banner/summary AND the --why output.
+
+    Fixture facts (``incomplete_pcb``): VCC is complete (2 pads, traced);
+    GND is incomplete (R1.2 stranded); SIG is unrouted. So VCC is the
+    "complete net on a board with other incomplete nets" case from the issue.
+    """
+
+    def test_net_filter_banner_and_summary_agree_in_scope(self, incomplete_pcb: Path, capsys):
+        """--net <complete-net> must not claim board-wide completeness.
+
+        Previously the board-wide summary ("Incomplete: 2") rendered directly
+        above "All nets are fully connected!" (derived from the filtered set)
+        -- a direct contradiction.
+        """
+        result = main([str(incomplete_pcb), "--net", "VCC"])
+        out = capsys.readouterr().out
+
+        assert "All nets are fully connected!" not in out
+        assert "Selected net 'VCC' is fully connected." in out
+        # Summary is scoped to the selection, with board total for context.
+        assert "Summary: 1 net selected (of 3 on board)" in out
+        assert "Incomplete: 0" in out
+        # Exit code deliberately stays BOARD-WIDE (documented in --net help):
+        # the board has incomplete nets, so exit 2 even though VCC is complete.
+        assert result == 2
+
+    def test_complete_percentage_literal_reworded(self, incomplete_pcb: Path, capsys):
+        """The '(100% connected)' literal read as a board-level statistic."""
+        main([str(incomplete_pcb)])
+        out = capsys.readouterr().out
+        assert "100% connected" not in out
+        assert "(all pads connected)" in out
+
+    def test_why_net_filter_complete_net(self, incomplete_pcb: Path, capsys):
+        """--net <complete-net> --why names the net and says it is not stuck.
+
+        Previously --why ignored --net entirely and printed every OTHER stuck
+        net's diagnosis (asked about DAC_CLK, told about GNDA).
+        """
+        result = main([str(incomplete_pcb), "--net", "VCC", "--why"])
+        out = capsys.readouterr().out
+
+        assert result == 0
+        assert "Selected net: VCC" in out
+        assert "Net 'VCC' is not stuck" in out
+        # No other net's diagnosis leaks into the filtered output.
+        assert "GND" not in out
+        assert "SIG" not in out
+
+    def test_why_net_filter_stuck_net(self, incomplete_pcb: Path, capsys):
+        """--net <stuck-net> --why prints only that net's diagnosis, exit 2."""
+        result = main([str(incomplete_pcb), "--net", "SIG", "--why"])
+        out = capsys.readouterr().out
+
+        assert result == 2
+        assert "Selected net: SIG" in out
+        assert "Stuck signal nets: 1" in out
+        assert "SIG" in out
+        # GND is also stuck on this board but was not asked about.
+        assert "GND" not in out
+
+    def test_why_net_filter_not_found(self, incomplete_pcb: Path, capsys):
+        """--net NONEXISTENT --why errors with the available-nets listing."""
+        result = main([str(incomplete_pcb), "--net", "NONEXISTENT", "--why"])
+        captured = capsys.readouterr()
+
+        assert result == 1
+        assert "not found" in captured.err.lower()
+        assert "Available nets" in captured.err
+
+    def test_why_json_net_filter_complete_net(self, incomplete_pcb: Path, capsys):
+        """--net X --why --format json is filtered identically to text."""
+        result = main([str(incomplete_pcb), "--net", "VCC", "--why", "--format", "json"])
+        data = json.loads(capsys.readouterr().out)
+
+        assert result == 0
+        assert data["net_filter"] == "VCC"
+        assert data["summary"]["stuck_nets"] == 0
+        assert data["nets"] == []
+
+    def test_why_json_net_filter_stuck_net(self, incomplete_pcb: Path, capsys):
+        result = main([str(incomplete_pcb), "--net", "SIG", "--why", "--format", "json"])
+        data = json.loads(capsys.readouterr().out)
+
+        assert result == 2
+        assert data["net_filter"] == "SIG"
+        assert data["summary"]["stuck_nets"] == 1
+        assert [n["net_name"] for n in data["nets"]] == ["SIG"]
+
+    def test_why_json_without_net_has_no_filter_key(self, incomplete_pcb: Path, capsys):
+        """Plain --why JSON stays byte-compatible (net_filter key is additive)."""
+        main([str(incomplete_pcb), "--why", "--format", "json"])
+        data = json.loads(capsys.readouterr().out)
+        assert "net_filter" not in data


### PR DESCRIPTION
## Summary

Fixes both `--net` output defects in `kct net-status` (issue #4682, curator-recommended approach: post-filter in `output_why`, no classifier changes).

### Defect 2: `--net X --why` ignored `--net` entirely

- `main()` now validates the `--net` selection (shared not-found error path, exit 1 with the available-nets listing) **before** the `--why` branch — previously `--why` short-circuited first and ran unfiltered.
- `output_why()` gained `net: str | None = None`; classification still runs whole-board (acceptable for a read-only diagnostic), then diagnoses are post-filtered to the selected net via a rebuilt `StuckClassifierResult`.
  - Selected net stuck → only its diagnosis, exit 2.
  - Selected net not stuck → explicit `Net 'X' is not stuck (complete, or only advisory plane/pour residuals).`, exit 0.
  - Text header names the scope: `Selected net: X`.
- `--net X --why --format json` is filtered identically, with an **additive** `net_filter` key. Unfiltered `--why` JSON is byte-unchanged (guarded by a test).

### Defect 1: contradictory banner under `--net X`

- The Summary block and the banner are now **both** scoped to the selection: `Summary: 1 net selected (of N on board)` + scoped counts, and `Selected net 'X' is fully connected.` instead of `All nets are fully connected!`. No rendered line contradicts another.
- The `(100% connected)` literal on the Complete summary line is reworded to `(all pads connected)` (and `(0% connected)` → `(no pads connected)`); the one stale doc sample (`boards/00-simple-led/README.md`) updated to match.
- `--incomplete` header behavior is unchanged (still board-wide; existing consistency regression test still passes).

### Exit-code semantics (deliberate, per curator decision)

- **Normal status path: unchanged** — still board-wide (exit 2 when *any* net is incomplete, even under `--net` with a complete selection), to avoid breaking script consumers. Now documented in the `--net` help text, the module docstring, and `docs/reference/cli.md`.
- **`--why` path: scoped to the selection when `--net` is given** (exit 0 when X is not stuck, 2 when it is) — this is the behavior the curator's acceptance criteria/test plan explicitly specify, and it is called out here as a behavior change (previously `--net X --why` exited 2 whenever *any* net was stuck, because the filter was ignored).

## Testing

- New `TestNetFilterScoping` class (8 tests) in `tests/test_net_status_cmd.py` covering: scoped banner+summary with board-wide exit code preserved; the `(100% connected)` reword; `--net <complete> --why` (exit 0, no other net leaks); `--net <stuck> --why` (exit 2, only that diagnosis); `--net NONEXISTENT --why` (exit 1 + available-nets listing); JSON filtering for both cases; and a guard that plain `--why` JSON has no `net_filter` key.
- `tests/test_net_status_cmd.py` + `tests/test_net_status.py` + `tests/test_net_status_strict.py` + `tests/test_fleet_status.py`: **160 passed**.
- Manual repro of both issue transcripts on the incomplete fixture board (VCC complete, GND incomplete, SIG unrouted) — output now matches the requested behavior in all cases.
- `ruff check` / `ruff format --check` clean on changed files; `mypy src/kicad_tools/cli/net_status_cmd.py` clean.

## Files

- `src/kicad_tools/cli/net_status_cmd.py` — main() ordering + validation, `output_why(net=...)`, scoped summary/banner, help/docstring notes
- `tests/test_net_status_cmd.py` — new `TestNetFilterScoping` class
- `docs/reference/cli.md`, `boards/00-simple-led/README.md`, `CHANGELOG.md`

Closes #4682
