### PR TITLE
chore: regenerate uv.lock for v0.20.0 self-package pin (#4698)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1766,7 +1766,7 @@ wheels = [
 
 [[package]]
 name = "kicad-tools"
-version = "0.19.0"
+version = "0.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

Regenerates `uv.lock` so the self-package pin matches `pyproject.toml` (0.20.0). The v0.20.0 release bump (#4669) edited `pyproject.toml` on the release branch without running `uv lock`, so every non-frozen `uv` invocation (`uv run`, `uv sync`, `uv lock`) re-locked and rewrote `uv.lock:1769`, permanently dirtying every checkout (observed independently by three builders during the 2026-08-07 sweep: #4692/#4694/#4695).

Closes #4698

## Diff

Exactly the expected 1-line change — no third-party pin churn:

```diff
 [[package]]
 name = "kicad-tools"
-version = "0.19.0"
+version = "0.20.0"
```

## Verification

- `uv lock` produced only the 1-line self-package bump (resolution otherwise unchanged; `Resolved 247 packages`).
- `uv lock --check` is a no-op afterward — a fresh checkout will see zero diff.
- Non-frozen `uv sync --extra dev` produces zero further diff on `uv.lock`.
- `uv sync --frozen --extra dev` still succeeds (the exact CI Install path in `ci.yml`).
- #4558 lockfile-drift guard: mypy pin in the lock is unchanged (`mypy==1.19.1`), so `scripts/ci/check_mypy_baseline.py`'s warn-only version guard stays quiet; `tests/test_ci_mypy_baseline.py` + `tests/test_native_extra_composition.py` pass (36 passed).

## Operator step after merge

In the **main checkout**, drop the sweep quarantine stash — it contains only this same regeneration and becomes redundant once this merges:

```bash
git stash drop stash@{0}   # 72ef870c, loom-quarantine: run=sweep-20260807T005508Z-25302-7dd50347 issue=4676
```

(Verify the stash ref first with `git stash list`; a Builder in a worktree cannot drop it.)

## Scope

`uv.lock` only. Per the curator's scope guard, `pyproject.toml`, CI, and `RELEASING.md` are untouched; the suggested `RELEASING.md` checklist addition ("run `uv lock` after the version bump") is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
