### PR TITLE
fix(boards/04): shift C16 Reference/Value fields clear of U2 body (#4675)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Board-04: C16 field overlap on the committed schematic** (#4675) — the
+  fleet's only genuine `sch_field_overlap` advisory (`C16.Value` text
+  overlapping U2's body in `stm32_devboard.kicad_sch`) is resolved by a
+  cosmetic-only two-line edit shifting C16's `Reference`/`Value` fields one
+  2.54 mm grid step up. The originally suggested `kct sch tidy --refs C16`
+  was measured to *regress* the finding (1 warning → 2) because tidy's
+  canonical below-body placement has no collision avoidance and pushed both
+  fields deeper into U2's body — manual placement was required. Netlist/BOM
+  identity preserved; no generator or lint-rule changes.
+
 - **`kct net-status --net X` output scoping** (#4682) — two `--net` defects
   that made the filter untrustworthy. (1) `--net X --why` ignored the filter
   entirely (`--why` short-circuited before net validation and

--- a/boards/04-stm32-devboard/output/stm32_devboard.kicad_sch
+++ b/boards/04-stm32-devboard/output/stm32_devboard.kicad_sch
@@ -3147,7 +3147,7 @@
 		(dnp no)
 		(uuid "abf936d1-21c6-47fb-b6bc-f647318e3f65")
 		(property "Reference" "C16"
-			(at 199.39 80.01 0)
+			(at 199.39 77.47 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3155,7 +3155,7 @@
 			)
 		)
 		(property "Value" "4.7uF"
-			(at 199.39 82.55 0)
+			(at 199.39 80.01 0)
 			(effects
 				(font
 					(size 1.27 1.27)


### PR DESCRIPTION
## Summary

Fixes the fleet's only genuine `sch_field_overlap` advisory on committed fixtures: `C16.Value` text overlapped U2's body (`MCU_ST_STM32F1:STM32F103C8Tx`) in `boards/04-stm32-devboard/output/stm32_devboard.kicad_sch`.

Artifact-first, cosmetic-only fix per the curator's measured coordinates: both C16 fields shifted one 2.54 mm grid step up, preserving the Reference-above-Value convention.

- `Reference`: `(at 199.39 80.01 0)` -> `(at 199.39 77.47 0)`
- `Value`: `(at 199.39 82.55 0)` -> `(at 199.39 80.01 0)`

No generator, library, or lint-rule changes. No lint baseline update needed (curator verified nothing pins this warning).

## Did `kct sch tidy --refs C16` suffice? (original AC question)

**No — it regresses.** The curator measured that `kct sch tidy --refs C16` turns 1 warning into 2: its canonical below-body placement moves `Reference -> (199.39, 83.82)` and `Value -> (199.39, 86.36)`, pushing BOTH fields deeper into U2's body. `kct sch tidy` has no collision avoidance by design (`src/kicad_tools/cli/sch_tidy.py`), so manual placement into the clear zone *above* C16 was required.

## Verification

`uv run kct check boards/04-stm32-devboard/output/stm32_devboard.kicad_pcb`

Before (this branch's base, `ba206671`):

```
  Warnings:   1
      12 errors, 1 warnings, 1 infos  [connectivity, connector_edge_distance, sch_field_overlap]
  sch_field_overlap: 1 warning
  [!] sch_field_overlap
      C16.Value text overlaps U2 body [stm32_devboard.kicad_sch]
DRC:       FAILED   (38 rules checked, 12 error(s), 1 warning(s))
ERC:       PASSED   (0 error(s), 2 warning(s))
```

After:

```
  Warnings:   0
      12 errors, 0 warnings, 1 infos  [connectivity, connector_edge_distance]
DRC:       FAILED   (38 rules checked, 12 error(s), 0 warning(s))
ERC:       PASSED   (0 error(s), 2 warning(s))
```

A full `diff` of the before/after check output shows the ONLY delta is the removal of the `sch_field_overlap` finding — no new findings; the 12 connectivity errors and 2 ERC warnings are pre-existing on main and unchanged. `sch_field_overlap` is advisory severity, so board-04 E2E/LVS CI is structurally unaffected; the `(at)`-only edit guarantees netlist/BOM identity.

## Diff

- `stm32_devboard.kicad_sch`: exactly 2 changed lines (the two `(at ...)` coordinates above)
- `CHANGELOG.md`: Unreleased/Fixed entry (board-scoped fixes conventionally get one)

## Acceptance criteria (curator-amended)

- [x] `kct check` on `boards/04-stm32-devboard/output/stm32_devboard.kicad_pcb` reports zero `sch_fields` findings
- [x] Schematic diff touches ONLY `(at ...)` of C16's Reference/Value property nodes
- [x] Board-04 E2E/LVS structurally unaffected (advisory-severity rule; cosmetic contract) — CI on this PR will confirm
- [x] PR records the measured `--refs C16` regression (1 -> 2 warnings)

Closes #4675

🤖 Generated with [Claude Code](https://claude.com/claude-code)
