### PR TITLE
fix(cli): B.Cu --net-class-map sidecars now load in every consumer, not just kct route (#4683)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fields deeper into U2's body — manual placement was required. Netlist/BOM
   identity preserved; no generator or lint-rule changes.
 
+- **`--net-class-map` sidecars with layer NAMES (`"B.Cu"`) now load in every
+  consumer, not just `kct route`** (#4683) — the #4587 hardening made an
+  unresolvable layer token a hard error inside `net_class_map_from_dict` but
+  only `route_cmd` was taught to pass the board's layer stack, so the very
+  sidecar `kct route` accepted made `kct creepage` / `kct check` /
+  `kct zones hv-keepout` exit 1 without doing any work (blocking the HV
+  creepage safety gate; regression vs `45744d0a`), and — worse — made
+  `kct audit` **silently** drop the sidecar in both `_check_drc` and the HV
+  `_check_isolation` safety gate (warning-only degradation). A new canonical
+  loader, `net_class_map_from_path(path, *, pcb_text=, pcb_path=,
+  layer_stack=)` in `router/rules.py`, pairs sidecar parsing with best-effort
+  board-stack detection; all five consumer call sites now use it, resolving
+  `"B.Cu"` against the board's actual copper count (grid index 3 on a 4-layer
+  board, 1 on a 2-layer board) exactly as `kct route` does. Integer-index
+  sidecars and stack-less library callers are unchanged, and a structural
+  guard test now fails if any future consumer calls `net_class_map_from_dict`
+  directly — the invariant is *any sidecar accepted by one consumer is
+  accepted by all of them*.
+
 - **`kct net-status --net X` output scoping** (#4682) — two `--net` defects
   that made the filter untrustworthy. (1) `--net X --why` ignored the filter
   entirely (`--why` short-circuited before net validation and

--- a/src/kicad_tools/audit/auditor.py
+++ b/src/kicad_tools/audit/auditor.py
@@ -884,18 +884,23 @@ class ManufacturingAudit:
         try:
             import json as _json
 
-            from kicad_tools.router.rules import net_class_map_from_dict
+            from kicad_tools.router.rules import net_class_map_from_path
             from kicad_tools.validate import DRCChecker
 
             # Load optional net-class-map sidecar (Issue #2684).  When
             # supplied, enables the diff-pair routing-continuity and
             # length-skew rules to re-derive engagement / skew state on
             # routed boards.  When absent, rules degrade to no-ops.
+            # Canonical loader (issue #4683): passing the board path resolves
+            # layer-name tokens like "B.Cu" against the board's actual copper
+            # count -- without it, a sidecar `kct route` accepts was silently
+            # dropped here and the diff-pair rules no-op'd without a signal.
             net_class_map = None
             if self.net_class_map_path is not None:
                 try:
-                    ncm_data = _json.loads(self.net_class_map_path.read_text())
-                    net_class_map = net_class_map_from_dict(ncm_data)
+                    net_class_map = net_class_map_from_path(
+                        self.net_class_map_path, pcb_path=self.pcb_path
+                    )
                 except (OSError, _json.JSONDecodeError, TypeError, ValueError) as e:
                     logger.warning(
                         "Failed to load net-class-map from %s: %s",
@@ -1226,15 +1231,17 @@ class ManufacturingAudit:
 
         # Parse the net-class-map sidecar with the SAME block _check_drc uses
         # so HV selection agrees with the diff-pair DRC rules (issue #2684).
+        # Canonical loader (issue #4683): the board path resolves layer-name
+        # tokens like "B.Cu" so the HV ISOLATION SAFETY GATE cannot silently
+        # run without its HV classes on a sidecar that `kct route` accepts.
         net_class_map = None
         if self.net_class_map_path is not None:
             try:
-                import json as _json
+                from kicad_tools.router.rules import net_class_map_from_path
 
-                from kicad_tools.router.rules import net_class_map_from_dict
-
-                ncm_data = _json.loads(self.net_class_map_path.read_text())
-                net_class_map = net_class_map_from_dict(ncm_data)
+                net_class_map = net_class_map_from_path(
+                    self.net_class_map_path, pcb_path=self.pcb_path
+                )
             except (OSError, ValueError, TypeError) as e:
                 logger.warning(
                     "Isolation check: failed to load net-class-map from %s: %s",

--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -1632,7 +1632,7 @@ def main(argv: list[str] | None = None) -> int:
         ncm_path = _discover_net_class_map_sidecar(pcb_path)
 
     if ncm_path is not None:
-        from kicad_tools.router.rules import net_class_map_from_dict
+        from kicad_tools.router.rules import net_class_map_from_path
 
         if not ncm_path.exists():
             # Only reachable via an explicit flag (the auto-probe returns
@@ -1642,8 +1642,10 @@ def main(argv: list[str] | None = None) -> int:
         ncm_load_error: str | None = None
         net_class_map = None
         try:
-            ncm_data = json.loads(ncm_path.read_text())
-            net_class_map = net_class_map_from_dict(ncm_data)
+            # Canonical loader (issue #4683): the board path resolves
+            # layer-name tokens like "B.Cu" against the board's actual
+            # copper count, matching `kct route`'s acceptance exactly.
+            net_class_map = net_class_map_from_path(ncm_path, pcb_path=pcb_path)
         except json.JSONDecodeError as e:
             ncm_load_error = f"parsing net-class-map JSON: {e}"
         except (TypeError, ValueError) as e:

--- a/src/kicad_tools/cli/commands/creepage.py
+++ b/src/kicad_tools/cli/commands/creepage.py
@@ -161,18 +161,21 @@ def run_creepage_command(args) -> int:
             print(f"Error: standard-table lookup failed: {e}", file=sys.stderr)
             return 1
 
-    # Load the optional net-class map sidecar (reuses net_class_map_from_dict).
+    # Load the optional net-class map sidecar via the canonical loader
+    # (issue #4683): passing the board path resolves layer-name tokens like
+    # "B.Cu" against the board's ACTUAL copper count, exactly as `kct route`
+    # does -- one sidecar must be valid for every consumer.
     net_class_map = None
     ncm_arg = getattr(args, "net_class_map", None)
     if ncm_arg:
-        from kicad_tools.router.rules import net_class_map_from_dict
+        from kicad_tools.router.rules import net_class_map_from_path
 
         ncm_path = Path(ncm_arg)
         if not ncm_path.exists():
             print(f"Error: net-class-map file not found: {ncm_path}", file=sys.stderr)
             return 1
         try:
-            net_class_map = net_class_map_from_dict(json.loads(ncm_path.read_text()))
+            net_class_map = net_class_map_from_path(ncm_path, pcb_path=pcb_path)
         except json.JSONDecodeError as e:
             print(f"Error: parsing net-class-map JSON: {e}", file=sys.stderr)
             return 1

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -12082,7 +12082,7 @@ def _main_impl(argv: list[str] | None = None) -> int:
     if getattr(args, "net_class_map", None) is not None:
         import json as _ncm_json
 
-        from kicad_tools.router.rules import net_class_map_from_dict
+        from kicad_tools.router.rules import net_class_map_from_path
 
         ncm_path = Path(args.net_class_map).resolve()
         if not ncm_path.exists():
@@ -12125,8 +12125,12 @@ def _main_impl(argv: list[str] | None = None) -> int:
             # below with an actionable message rather than a silent wrong index.
             _ncm_layer_stack = None
         try:
-            args._loaded_net_class_map = net_class_map_from_dict(
-                _ncm_data, layer_stack=_ncm_layer_stack
+            # Canonical loader (issue #4683): shared with kct check / creepage /
+            # zones / audit so one sidecar is valid for every consumer.  The
+            # stack resolved from --layers above wins; JSON validity was
+            # already established by the _ncm_data parse.
+            args._loaded_net_class_map = net_class_map_from_path(
+                ncm_path, layer_stack=_ncm_layer_stack
             )
         except (TypeError, ValueError) as e:
             print(f"Error: invalid net-class-map structure: {e}", file=sys.stderr)

--- a/src/kicad_tools/cli/zones_cmd.py
+++ b/src/kicad_tools/cli/zones_cmd.py
@@ -651,8 +651,12 @@ def _print_batch_summary(gen, quiet: bool) -> None:
         print(f"\nCreated {zone_count} zone(s)")
 
 
-def _load_net_class_map(path_str: str | None):
+def _load_net_class_map(path_str: str | None, pcb_path: Path | None = None):
     """Load a net-class-map JSON sidecar (shared with ``kct creepage``).
+
+    Uses the canonical :func:`net_class_map_from_path` loader (issue #4683)
+    so layer-name tokens like ``"B.Cu"`` resolve against the board's actual
+    copper count -- the same sidecar ``kct route`` accepts must load here.
 
     Returns ``(net_class_map, error_message)``.  On success ``error_message``
     is ``None``; on failure ``net_class_map`` is ``None`` and the caller should
@@ -663,13 +667,13 @@ def _load_net_class_map(path_str: str | None):
 
     import json
 
-    from kicad_tools.router.rules import net_class_map_from_dict
+    from kicad_tools.router.rules import net_class_map_from_path
 
     ncm_path = Path(path_str)
     if not ncm_path.exists():
         return None, f"net-class-map file not found: {ncm_path}"
     try:
-        return net_class_map_from_dict(json.loads(ncm_path.read_text())), None
+        return net_class_map_from_path(ncm_path, pcb_path=pcb_path), None
     except json.JSONDecodeError as e:
         return None, f"parsing net-class-map JSON: {e}"
     except (TypeError, ValueError) as e:
@@ -712,7 +716,9 @@ def _run_hv_keepout(args) -> int:
         )
         return 1
 
-    net_class_map, ncm_error = _load_net_class_map(getattr(args, "net_class_map", None))
+    net_class_map, ncm_error = _load_net_class_map(
+        getattr(args, "net_class_map", None), pcb_path=pcb_path
+    )
     if ncm_error is not None:
         print(f"Error: {ncm_error}", file=sys.stderr)
         return 1

--- a/src/kicad_tools/router/rules.py
+++ b/src/kicad_tools/router/rules.py
@@ -16,6 +16,8 @@ from typing import TYPE_CHECKING, Literal
 from .layers import Layer, LayerStack
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
+    from pathlib import Path
+
     from .pairwise_clearance import PairwiseClearanceTable
 
 # Allowed values for :attr:`NetClassRouting.route_via`.
@@ -1794,6 +1796,90 @@ def net_class_map_from_dict(
             # names both the bad token and the net it belongs to (#4587).
             raise LayerResolutionError(f"net-class entry {net_name!r}: {e}") from e
     return result
+
+
+def net_class_map_from_path(
+    path: "str | Path",
+    *,
+    pcb_text: str | None = None,
+    pcb_path: "str | Path | None" = None,
+    layer_stack: LayerStack | None = None,
+) -> dict[str, "NetClassRouting"]:
+    """Load a ``--net-class-map`` JSON sidecar the way EVERY consumer must.
+
+    Canonical loader (issue #4683).  The #4587 hardening made an unresolvable
+    layer token (``"B.Cu"``, whose grid index depends on the board's copper
+    count) a hard :class:`LayerResolutionError` inside
+    :func:`net_class_map_from_dict` -- but only ``kct route`` was updated to
+    pass a layer stack.  Every other consumer (``kct creepage``, ``kct check``,
+    ``kct zones hv-keepout``, ``kct audit``) kept calling
+    ``net_class_map_from_dict(data)`` bare, so the SAME sidecar that routed a
+    board was rejected by the sign-off gates that validate the router's output.
+    This function is the single place that pairs "parse the sidecar" with
+    "resolve the board's layer stack" so a future consumer cannot recreate the
+    divergence: the invariant is *any sidecar accepted by one consumer is
+    accepted by all of them* (see also #4404, the same bug class for
+    ``_comment`` keys).
+
+    Stack resolution precedence:
+
+    1. ``layer_stack`` -- an already-resolved stack (e.g. ``kct route``'s
+       ``--layers``-flag table) is used as-is.
+    2. ``pcb_text`` -- raw ``.kicad_pcb`` contents, fed to
+       :func:`kicad_tools.router.io.detect_layer_stack`.
+    3. ``pcb_path`` -- read best-effort, then detected as in (2).
+
+    Stack resolution is best-effort (mirroring ``route_cmd``'s preload): if
+    the board cannot be read or detection fails, the map is still parsed with
+    ``layer_stack=None`` -- stack-independent tokens (``"F.Cu"``,
+    ``"In<k>.Cu"``) resolve, and ``"B.Cu"`` fails loud with an actionable
+    message rather than a silent wrong index.
+
+    Args:
+        path: Path to the sidecar JSON file.
+        pcb_text: Optional raw ``.kicad_pcb`` contents for stack detection.
+        pcb_path: Optional path to the board file for stack detection
+            (read best-effort; ignored when ``pcb_text`` is given).
+        layer_stack: Optional pre-resolved stack; wins over both of the above.
+
+    Returns:
+        The parsed ``{net_name: NetClassRouting}`` map.
+
+    Raises:
+        FileNotFoundError: If ``path`` does not exist.
+        json.JSONDecodeError: If the sidecar is not valid JSON.
+        TypeError: If the sidecar structure is not a dict-of-dicts.
+        ValueError: If an entry is malformed, or -- as
+            :class:`LayerResolutionError` -- if a layer token cannot be
+            resolved against the (possibly absent) stack.
+    """
+    import json
+    from pathlib import Path as _Path
+
+    sidecar_path = _Path(path)
+    if not sidecar_path.exists():
+        raise FileNotFoundError(f"net-class-map file not found: {sidecar_path}")
+    data = json.loads(sidecar_path.read_text())
+
+    stack = layer_stack
+    if stack is None:
+        # Function-scope import: router.io imports router.rules at module
+        # level, so a top-level import here would be circular.
+        from .io import detect_layer_stack
+
+        text = pcb_text
+        if text is None and pcb_path is not None:
+            try:
+                text = _Path(pcb_path).read_text()
+            except OSError:
+                text = None
+        if text is not None:
+            try:
+                stack = detect_layer_stack(text)
+            except (KeyError, OSError, ValueError):
+                stack = None
+
+    return net_class_map_from_dict(data, layer_stack=stack)
 
 
 # Threshold for classifying a 2-pin signal net as "simple" (short) vs "complex" (long).

--- a/tests/test_cli_check_net_class_map.py
+++ b/tests/test_cli_check_net_class_map.py
@@ -673,10 +673,15 @@ class TestSidecarAutoLoad:
         assert f"ignoring malformed net-class-map sidecar {scar}" in captured.err
         assert _mg_error_count(captured.out) == 0
 
-    def test_auto_sidecar_with_back_copper_avoid_layer_warns(self, tmp_path: Path, capsys):
-        """AC10: ``avoid_layers: ["B.Cu"]`` is rejected by
-        ``net_class_map_from_dict`` (no LayerStack is threaded at this
-        callsite) -- that must warn audibly and continue, never crash."""
+    def test_auto_sidecar_with_back_copper_avoid_layer_loads(self, tmp_path: Path, capsys):
+        """Issue #4683: ``avoid_layers: ["B.Cu"]`` now LOADS at this callsite.
+
+        The canonical loader threads the board's layer stack, so ``B.Cu``
+        resolves against the actual copper count (index 1 on this 2-layer
+        board) instead of being rejected -- the same sidecar ``kct route``
+        accepts must auto-load here too.  The sidecar genuinely engages:
+        the DDR group-skew rule fires.
+        """
         from kicad_tools.cli.check_cmd import main
 
         pcb = _write_matchgroup_board(tmp_path)
@@ -689,8 +694,30 @@ class TestSidecarAutoLoad:
         rc = main(self._mg_argv(pcb))
         captured = capsys.readouterr()
         assert rc != 1
+        assert "ignoring malformed net-class-map sidecar" not in captured.err
+        assert f"auto-loaded net-class-map sidecar: {scar}" in captured.err
+        # The loaded sidecar engages the group-skew rule on this board.
+        assert _mg_error_count(captured.out) >= 1
+
+    def test_auto_sidecar_with_unresolvable_layer_token_warns(self, tmp_path: Path, capsys):
+        """AC10 (re-anchored for #4683): a genuinely unresolvable layer token
+        in an auto-discovered sidecar warns audibly and continues, never
+        crashes."""
+        from kicad_tools.cli.check_cmd import main
+
+        pcb = _write_matchgroup_board(tmp_path)
+        scar = tmp_path / "ddr.net_class_map.json"
+        payload = {
+            name: {**entry, "avoid_layers": ["Bogus.Cu"]}
+            for name, entry in MATCHGROUP_SIDECAR.items()
+        }
+        scar.write_text(json.dumps(payload, indent=2))
+
+        rc = main(self._mg_argv(pcb))
+        captured = capsys.readouterr()
+        assert rc != 1
         assert f"ignoring malformed net-class-map sidecar {scar}" in captured.err
-        assert "B.Cu" in captured.err
+        assert "Bogus.Cu" in captured.err
         # Still degrades to no-sidecar behaviour rather than crashing.
         assert _mg_error_count(captured.out) == 0
 

--- a/tests/test_cli_route_net_class_map.py
+++ b/tests/test_cli_route_net_class_map.py
@@ -977,3 +977,376 @@ class TestLayerNamePreloadResolution:
         _rc, captured = self._capture_preload(minimal_pcb_4layer, sidecar, tmp_path)
         assert captured["map"]["PGND"].preferred_layers == [0, 3]
         assert captured["map"]["PGND"].avoid_layers == [1, 2]
+
+
+# =============================================================================
+# Issue #4683: canonical sidecar loader + cross-consumer invariant
+# =============================================================================
+
+# 2-layer variant: B.Cu must resolve to grid index 1 here, not 3.
+MINIMAL_PCB_2LAYER = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "PGND")
+  (gr_rect (start 100 100) (end 150 150)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+)
+"""
+
+# A minimal-but-real 4-layer board every sidecar CONSUMER can operate on:
+# outline, an AC_LINE trace on F.Cu, and a GND plane pour on In1.Cu (so
+# ``zones hv-keepout`` has a plane layer to carve).
+CONSUMER_PCB_4LAYER = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (1 "In1.Cu" signal)
+    (2 "In2.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "AC_LINE")
+  (net 2 "GND")
+  (gr_line (start 100 100) (end 160 100) (layer "Edge.Cuts") (width 0.1))
+  (gr_line (start 160 100) (end 160 140) (layer "Edge.Cuts") (width 0.1))
+  (gr_line (start 160 140) (end 100 140) (layer "Edge.Cuts") (width 0.1))
+  (gr_line (start 100 140) (end 100 100) (layer "Edge.Cuts") (width 0.1))
+  (segment (start 110 110) (end 150 110) (width 0.5) (layer "F.Cu") (net 1))
+  (zone
+    (net 2)
+    (net_name "GND")
+    (layer "In1.Cu")
+    (uuid "gnd-plane-uuid")
+    (hatch edge 0.5)
+    (priority 0)
+    (connect_pads (clearance 0.25))
+    (min_thickness 0.2)
+    (fill yes (thermal_gap 0.4) (thermal_bridge_width 0.35))
+    (polygon
+      (pts
+        (xy 101 101)
+        (xy 159 101)
+        (xy 159 139)
+        (xy 101 139)
+      )
+    )
+    (filled_polygon
+      (layer "In1.Cu")
+      (pts
+        (xy 101 101)
+        (xy 159 101)
+        (xy 159 139)
+        (xy 101 139)
+      )
+    )
+  )
+)
+"""
+
+# The filer's exact sidecar shape from issue #4683 (softstart rev-C): layer
+# NAMES, including the stack-dependent "B.Cu".
+HV_SIDECAR_ENTRY = {
+    "name": "HV",
+    "preferred_layers": ["F.Cu", "B.Cu"],
+    "avoid_layers": ["In1.Cu", "In2.Cu"],
+    "layer_cost_multiplier": 2.0,
+}
+
+
+@pytest.fixture
+def consumer_pcb_4layer(tmp_path: Path) -> Path:
+    p = tmp_path / "consumer4.kicad_pcb"
+    p.write_text(CONSUMER_PCB_4LAYER)
+    return p
+
+
+@pytest.fixture
+def hv_sidecar(tmp_path: Path) -> Path:
+    p = tmp_path / "hv_ncm.json"
+    p.write_text(json.dumps({"AC_LINE": dict(HV_SIDECAR_ENTRY)}))
+    return p
+
+
+class TestNetClassMapFromPath:
+    """Unit tests for the canonical loader (issue #4683)."""
+
+    def test_missing_file_raises_file_not_found(self, tmp_path: Path):
+        from kicad_tools.router.rules import net_class_map_from_path
+
+        with pytest.raises(FileNotFoundError, match="net-class-map file not found"):
+            net_class_map_from_path(tmp_path / "nope.json")
+
+    def test_malformed_json_raises_json_decode_error(self, tmp_path: Path):
+        from kicad_tools.router.rules import net_class_map_from_path
+
+        bad = tmp_path / "bad.json"
+        bad.write_text("{not json")
+        with pytest.raises(json.JSONDecodeError):
+            net_class_map_from_path(bad)
+
+    def test_b_cu_resolves_with_pcb_text_4layer(self, hv_sidecar: Path):
+        from kicad_tools.router.rules import net_class_map_from_path
+
+        ncm = net_class_map_from_path(hv_sidecar, pcb_text=CONSUMER_PCB_4LAYER)
+        assert ncm["AC_LINE"].preferred_layers == [0, 3]
+        assert ncm["AC_LINE"].avoid_layers == [1, 2]
+
+    def test_b_cu_resolves_with_pcb_path_4layer(self, hv_sidecar: Path, consumer_pcb_4layer: Path):
+        from kicad_tools.router.rules import net_class_map_from_path
+
+        ncm = net_class_map_from_path(hv_sidecar, pcb_path=consumer_pcb_4layer)
+        assert ncm["AC_LINE"].preferred_layers == [0, 3]
+
+    def test_b_cu_resolves_to_one_on_2layer_board(self, tmp_path: Path):
+        """Edge case from the curator's test plan: 2-layer B.Cu -> 1, not 3."""
+        from kicad_tools.router.rules import net_class_map_from_path
+
+        sidecar = tmp_path / "ncm2.json"
+        sidecar.write_text(json.dumps({"PGND": {"name": "HV", "avoid_layers": ["B.Cu"]}}))
+        ncm = net_class_map_from_path(sidecar, pcb_text=MINIMAL_PCB_2LAYER)
+        assert ncm["PGND"].avoid_layers == [1]
+
+    def test_b_cu_without_any_stack_fails_loud(self, hv_sidecar: Path):
+        """No stack source at all: B.Cu keeps the actionable hard error."""
+        from kicad_tools.router.rules import LayerResolutionError, net_class_map_from_path
+
+        with pytest.raises(LayerResolutionError, match="B.Cu"):
+            net_class_map_from_path(hv_sidecar)
+
+    def test_explicit_layer_stack_wins_over_pcb_text(self, hv_sidecar: Path):
+        """A pre-resolved stack (route's --layers table) takes precedence."""
+        from kicad_tools.router import LayerStack
+        from kicad_tools.router.rules import net_class_map_from_path
+
+        ncm = net_class_map_from_path(
+            hv_sidecar,
+            pcb_text=CONSUMER_PCB_4LAYER,
+            layer_stack=LayerStack.six_layer_sig_gnd_sig_sig_pwr_sig(),
+        )
+        # B.Cu is the LAST copper index of the six-layer stack, not 3.
+        assert ncm["AC_LINE"].preferred_layers == [0, 5]
+
+    def test_unreadable_pcb_path_is_best_effort(self, tmp_path: Path):
+        """A missing board degrades to no-stack: F.Cu still resolves."""
+        from kicad_tools.router.rules import net_class_map_from_path
+
+        sidecar = tmp_path / "ncm.json"
+        sidecar.write_text(json.dumps({"PGND": {"name": "HV", "avoid_layers": ["F.Cu"]}}))
+        ncm = net_class_map_from_path(sidecar, pcb_path=tmp_path / "missing.kicad_pcb")
+        assert ncm["PGND"].avoid_layers == [0]
+
+    def test_integer_sidecar_needs_no_stack(self, tmp_path: Path):
+        """Backwards compatibility: integer indices load with no board at all."""
+        from kicad_tools.router.rules import net_class_map_from_path
+
+        sidecar = tmp_path / "ncm.json"
+        sidecar.write_text(
+            json.dumps({"PGND": {"name": "HV", "preferred_layers": [0, 3], "avoid_layers": [1, 2]}})
+        )
+        ncm = net_class_map_from_path(sidecar)
+        assert ncm["PGND"].preferred_layers == [0, 3]
+        assert ncm["PGND"].avoid_layers == [1, 2]
+
+
+class TestCrossConsumerSidecarInvariant:
+    """One B.Cu-bearing sidecar must load in EVERY --net-class-map consumer.
+
+    Regression guard for issue #4683: the #4587 hardening was applied only to
+    ``kct route``, so the same sidecar that routed a board made ``kct
+    creepage`` / ``kct check`` / ``kct zones hv-keepout`` exit 1 and made
+    ``kct audit`` silently drop its HV classes.  Invariant (issue body): *any
+    sidecar accepted by one consumer must be accepted by all of them.*
+
+    Each consumer test spies on ``rules.net_class_map_from_dict`` (delegating
+    to the real function) to prove the sidecar was parsed WITH a resolved
+    stack: ``B.Cu`` -> grid index 3 on the shared 4-layer fixture.
+    """
+
+    @contextlib.contextmanager
+    def _spy_resolutions(self):
+        """Record every (layer_stack, resolved map) seen by from_dict."""
+        from kicad_tools.router import rules as _rules
+
+        real = _rules.net_class_map_from_dict
+        calls: list[dict] = []
+
+        def spy(data, layer_stack=None):
+            result = real(data, layer_stack=layer_stack)
+            calls.append({"layer_stack": layer_stack, "map": result})
+            return result
+
+        with patch.object(_rules, "net_class_map_from_dict", spy):
+            yield calls
+
+    def _assert_hv_resolved(self, calls: list[dict]):
+        assert calls, "consumer never parsed the net-class-map sidecar"
+        for call in calls:
+            nc = call["map"]["AC_LINE"]
+            assert nc.preferred_layers == [0, 3], "B.Cu must resolve to grid index 3"
+            assert nc.avoid_layers == [1, 2]
+
+    def test_creepage_accepts_b_cu_sidecar(
+        self, consumer_pcb_4layer: Path, hv_sidecar: Path, capsys
+    ):
+        """The filer's exact failure: ``kct creepage`` exit-1'd on B.Cu."""
+        pytest.importorskip("shapely")
+        from kicad_tools.cli.commands.creepage import run_creepage_command
+        from kicad_tools.cli.parser import create_parser
+
+        args = create_parser().parse_args(
+            [
+                "creepage",
+                str(consumer_pcb_4layer),
+                "--net-class-map",
+                str(hv_sidecar),
+                "--min",
+                "1.5",
+            ]
+        )
+        with self._spy_resolutions() as calls:
+            rc = run_creepage_command(args)
+
+        err = capsys.readouterr().err
+        assert "invalid net-class-map structure" not in err
+        assert "cannot be resolved without a layer stack" not in err
+        assert rc == 0
+        self._assert_hv_resolved(calls)
+
+    def test_check_accepts_b_cu_sidecar(self, consumer_pcb_4layer: Path, hv_sidecar: Path, capsys):
+        from kicad_tools.cli.check_cmd import main as check_main
+
+        with self._spy_resolutions() as calls:
+            check_main(
+                [
+                    str(consumer_pcb_4layer),
+                    "--net-class-map",
+                    str(hv_sidecar),
+                    "--allow-incomplete",
+                ]
+            )
+
+        err = capsys.readouterr().err
+        assert "invalid net-class-map structure" not in err
+        assert "cannot be resolved without a layer stack" not in err
+        self._assert_hv_resolved(calls)
+
+    def test_zones_hv_keepout_accepts_b_cu_sidecar(
+        self, consumer_pcb_4layer: Path, hv_sidecar: Path, capsys
+    ):
+        pytest.importorskip("shapely")
+        from kicad_tools.cli.zones_cmd import main as zones_main
+
+        with self._spy_resolutions() as calls:
+            rc = zones_main(
+                [
+                    "hv-keepout",
+                    str(consumer_pcb_4layer),
+                    "--net-class-map",
+                    str(hv_sidecar),
+                    "--clearance",
+                    "1.6",
+                    "--dry-run",
+                    "-q",
+                ]
+            )
+
+        err = capsys.readouterr().err
+        assert "invalid net-class-map structure" not in err
+        assert "cannot be resolved without a layer stack" not in err
+        assert rc == 0
+        self._assert_hv_resolved(calls)
+
+    def test_audit_drc_no_longer_silently_drops_sidecar(
+        self, consumer_pcb_4layer: Path, hv_sidecar: Path, caplog
+    ):
+        """auditor.py:_check_drc -- the SILENT degradation site (missed by the issue)."""
+        import logging
+
+        from kicad_tools.audit import ManufacturingAudit
+        from kicad_tools.schema.pcb import PCB
+
+        audit = ManufacturingAudit(
+            consumer_pcb_4layer, manufacturer="jlcpcb", net_class_map_path=hv_sidecar
+        )
+        pcb = PCB.load(consumer_pcb_4layer)
+        with caplog.at_level(logging.WARNING):
+            with self._spy_resolutions() as calls:
+                audit._check_drc(pcb)
+
+        assert "Failed to load net-class-map" not in caplog.text
+        self._assert_hv_resolved(calls)
+
+    def test_audit_isolation_no_longer_silently_drops_sidecar(
+        self, consumer_pcb_4layer: Path, hv_sidecar: Path, caplog
+    ):
+        """auditor.py:_check_isolation -- the HV SAFETY GATE degradation site."""
+        import logging
+
+        pytest.importorskip("shapely")
+        from kicad_tools.audit import ManufacturingAudit
+        from kicad_tools.schema.pcb import PCB
+
+        audit = ManufacturingAudit(
+            consumer_pcb_4layer, manufacturer="jlcpcb", net_class_map_path=hv_sidecar
+        )
+        pcb = PCB.load(consumer_pcb_4layer)
+        with caplog.at_level(logging.WARNING):
+            with self._spy_resolutions() as calls:
+                status = audit._check_isolation(pcb)
+
+        assert "failed to load net-class-map" not in caplog.text.lower()
+        self._assert_hv_resolved(calls)
+        # The sidecar actually engaged: AC_LINE classified HV.
+        assert status.hv_present is True
+
+    def test_route_accepts_b_cu_sidecar(
+        self, consumer_pcb_4layer: Path, hv_sidecar: Path, tmp_path: Path
+    ):
+        """kct route keeps accepting the sidecar (was already fixed by #4587)."""
+        with self._spy_resolutions() as calls:
+            _run_route_preload(consumer_pcb_4layer, hv_sidecar, tmp_path)
+        self._assert_hv_resolved(calls)
+
+    def test_no_consumer_bypasses_the_canonical_loader(self):
+        """Structural guard: no src call site may use from_dict directly.
+
+        A future consumer that calls ``net_class_map_from_dict(data)`` bare
+        would recreate exactly the #4683 divergence (one sidecar, divergent
+        validity across commands).  Everything outside ``router/rules.py``
+        must go through :func:`net_class_map_from_path`, which pairs parsing
+        with board-stack resolution.
+        """
+        import re as _re
+
+        import kicad_tools
+
+        src_root = Path(kicad_tools.__file__).parent
+        offenders: list[str] = []
+        for py in sorted(src_root.rglob("*.py")):
+            if py.name == "rules.py" and py.parent.name == "router":
+                continue  # the canonical loader's own home
+            if _re.search(r"net_class_map_from_dict\(", py.read_text()):
+                offenders.append(str(py.relative_to(src_root)))
+        assert offenders == [], (
+            "net_class_map_from_dict() called directly outside router/rules.py "
+            f"in {offenders}: use net_class_map_from_path(..., pcb_path=...) so "
+            "layer-name sidecars stay valid for every consumer (issue #4683)"
+        )


### PR DESCRIPTION
## Summary

Fixes the #4587 regression where a `--net-class-map` sidecar spelling layers as KiCad names (`"B.Cu"`) was accepted by `kct route` but rejected — or worse, **silently dropped** — by every other consumer. This blocked the HV creepage safety gate on the softstart rev-C sign-off (regression vs `45744d0a`).

Closes #4683

## What was broken

`net_class_map_from_dict` (post-#4587) raises a hard `LayerResolutionError` for `"B.Cu"` unless a layer stack is supplied, because B.Cu's grid index depends on the board's copper count (3 on a 4-layer board, 1 on a 2-layer board). Only `route_cmd.py` passed a stack. The five other call sites (curator enumeration — the issue listed 3 of 5):

| Site | Failure on `"B.Cu"` |
|---|---|
| `cli/commands/creepage.py` | exit 1, zero work |
| `cli/check_cmd.py` | exit 1 (explicit flag) / warn+degrade (auto-probe) |
| `cli/zones_cmd.py` (`hv-keepout`) | exit 1 |
| `audit/auditor.py` `_check_drc` | **silent** — diff-pair DRC rules no-op'd |
| `audit/auditor.py` `_check_isolation` | **silent** — the HV isolation safety gate ran without its HV classes |

## Fix (curator's recommended design)

New canonical loader in the **library** (`router/rules.py`, since the auditor is not a CLI module):

```python
net_class_map_from_path(path, *, pcb_text=None, pcb_path=None, layer_stack=None)
```

- Pairs sidecar parsing with best-effort board-stack detection (`detect_layer_stack`, function-scope import to avoid the `rules`↔`io` cycle). Precedence: explicit `layer_stack` > `pcb_text` > `pcb_path`.
- Stack detection is best-effort with route_cmd's exact semantics: if the board can't be read/detected, stack-independent tokens (`F.Cu`, `In<k>.Cu`) still resolve and `B.Cu` fails loud with the actionable message.
- All **five** consumer sites converted, each passing the board it already has in hand. `route_cmd` keeps its `--layers`-flag stack resolution and passes it through, so `--layers 2/4/6` semantics are byte-identical.
- Integer-index sidecars and stack-less library callers unchanged.

## Guard (non-negotiable per curator — 2nd instance of this bug class, cf. #4404)

- **Cross-consumer invariant test**: one B.Cu-bearing sidecar (the filer's exact `/AC_LINE` shape) driven through all 6 entry points (creepage, check, zones hv-keepout, audit `_check_drc`, audit `_check_isolation`, route preload) on a shared 4-layer fixture, with a delegating spy asserting `B.Cu → grid index 3` at every parse.
- **Structural test**: fails if any future `src/` call site invokes `net_class_map_from_dict(` outside `router/rules.py` — a new consumer cannot recreate the divergence.
- Unit tests for the loader: missing file, bad JSON, 4-layer→3, **2-layer→1** (curator edge case), no-stack fail-loud, explicit-stack precedence, unreadable-board best-effort, integer sidecar with no board.

## Acceptance criteria

- [x] Filer's exact repro passes: `kct creepage` and `kct check --net-class-map` with the quoted `/AC_LINE` entry on a 4-layer board **exit 0** (verified manually with the filer's full argv; also `zones hv-keepout` and both audit paths in tests)
- [x] `kct audit` no longer silently drops the sidecar (caplog asserts no `Failed to load net-class-map` warning; `_check_isolation` shows `hv_present=True` from the sidecar-classified net)
- [x] Cross-consumer guard test over every parse site
- [x] Integer-index sidecars and 2-layer boards unchanged (`layer_stack=None` fallback intact)

## Behavior-change note

One existing test (`test_auto_sidecar_with_back_copper_avoid_layer_warns` in `tests/test_cli_check_net_class_map.py`) asserted the OLD divergence — that check's auto-probe warns-and-drops on `B.Cu` "because no LayerStack is threaded at this callsite". That is precisely the bug; re-anchored to assert the sidecar now auto-loads and genuinely engages (group-skew rule fires), with the AC10 degradation contract preserved via a genuinely unresolvable token (`Bogus.Cu`).

## Testing

- `tests/test_cli_route_net_class_map.py`: 53 passed (includes 8 new loader unit tests + 7 cross-consumer guards)
- `tests/test_cli_check_net_class_map.py`: 44 passed (1 re-anchored → 2 tests)
- Consumer-adjacent sweep: creepage (all), zones hv-keepout, audit (all), check CLI, report collector, route match-groups/auto-fix — 568 + 361 + 129 passed, 0 failed
- `ruff check` / `ruff format --check`: clean on all touched files
- mypy baseline gate: `OK — 1472 error(s), all within baseline. No new type errors.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
