### PR TITLE
fix(stitch): align kct stitch with the net-status strict connectivity model (#4679)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   guard test now fails if any future consumer calls `net_class_map_from_dict`
   directly — the invariant is *any sidecar accepted by one consumer is
   accepted by all of them*.
+- **`kct stitch` now honors the strict connectivity model `kct net-status`
+  prints its remedy from** (#4679) — net-status could name a plane-net pad
+  "needs via to plane" while running the printed
+  `kct stitch <file> --net <NET>` command reported "No unconnected pads
+  found on target nets". Three defects fixed. (1) *Model divergence*:
+  stitch's "already connected" gate was a 0.5mm endpoint-proximity heuristic
+  with no notion of "reaches the plane" — an SMD pad tied to a stub trace
+  going nowhere counted as connected. For target nets with real fill copper,
+  the strict copper-contact model (`NetStatusAnalyzer`, the engine behind
+  net-status, via a new scoped `analyze_nets()`) now VETOES a
+  proximity-"connected" skip for any pad it reports unconnected, so the
+  net-status remedy applies by construction; the veto is one-directional
+  (the strict model never *suppresses* stitching — its "largest island"
+  connected set tie-breaks arbitrarily when the fill bonds no pads) and
+  nets without fill copper keep the legacy gate unchanged. (2) *Name-only
+  net references*: stitch's pad/via/track/drill extractors silently dropped
+  KiCad-10 name-only `(net "NAME")` inline references (the `kicad-cli pcb
+  drc --save-board` dialect, which also deletes the header net table), so
+  on such boards stitch found NO pads at all — the exact "No unconnected
+  pads found" no-op the issue reproduced. A shared `resolve_net_num()`
+  resolver plus header-table synthesis in `get_net_map()` (mirroring
+  `PCB._synthesize_net_table`, #4416) makes all stitch extractors
+  dialect-aware. (3) *Output accounting*: stitch now distinguishes "No pads
+  found on target net(s): X" (naming the nets, with a cross-check hint)
+  from "All N pads already connected", and surfaces a stderr warning when
+  the strict model could not run — a stitch/net-status disagreement can no
+  longer be silent. Bonus: `NetStatus.suggested_fix` embeds the real
+  analyzed filename instead of a hardcoded `board.kicad_pcb`, so the
+  printed remedy is copy-pasteable.
 
 - **`kct net-status --net X` output scoping** (#4682) — two `--net` defects
   that made the filter untrustworthy. (1) `--net X --why` ignored the filter

--- a/src/kicad_tools/analysis/net_status.py
+++ b/src/kicad_tools/analysis/net_status.py
@@ -66,6 +66,10 @@ class NetStatus:
         plane_layers: All layers with copper zones for this net
         has_routing: Whether this net has any trace segments
         has_vias: Whether this net has any vias
+        source_file: Path of the analyzed ``.kicad_pcb`` file (as given to
+            the analyzer), used to render a copy-pasteable
+            :attr:`suggested_fix`. Empty when the analyzer was handed an
+            in-memory ``PCB`` with no path (issue #4679).
     """
 
     net_number: int
@@ -80,6 +84,7 @@ class NetStatus:
     has_routing: bool = False
     has_vias: bool = False
     has_filled_zone: bool = False  # A zone on this net produced fill copper
+    source_file: str = ""
 
     @property
     def connected_count(self) -> int:
@@ -169,11 +174,17 @@ class NetStatus:
 
     @property
     def suggested_fix(self) -> str:
-        """Suggest fix based on net type."""
+        """Suggest fix based on net type.
+
+        Uses the real analyzed filename (:attr:`source_file`) so the printed
+        remedy is copy-pasteable; before issue #4679 this hardcoded a literal
+        ``board.kicad_pcb`` regardless of the file analyzed.
+        """
         if self.is_plane_net:
             layers = self.plane_layers or ([self.plane_layer] if self.plane_layer else [])
             layers_info = ", ".join(layers) if layers else "unknown"
-            return f"kct stitch board.kicad_pcb --net {self.net_name} (zones on {layers_info})"
+            board = self.source_file or "board.kicad_pcb"
+            return f"kct stitch {board} --net {self.net_name} (zones on {layers_info})"
         return f"Route traces to connect {self.unconnected_count} pads"
 
     def to_dict(self) -> dict:
@@ -418,8 +429,13 @@ class NetStatusAnalyzer:
 
         if isinstance(pcb, (str, Path)):
             self.pcb = PCBClass.load(str(pcb))
+            # Remember the path as given so per-net suggested fixes can print
+            # a copy-pasteable command (issue #4679).
+            self.source_file: str = str(pcb)
         else:
             self.pcb = pcb
+            pcb_path = getattr(pcb, "path", None)
+            self.source_file = str(pcb_path) if pcb_path else ""
         self.strict = strict
         # Strict-mode geometry caches (Issue #4176), keyed by object id.
         self._segment_poly_cache: dict[int, Any] = {}
@@ -488,6 +504,40 @@ class NetStatusAnalyzer:
 
         return result
 
+    def analyze_nets(self, net_names: set[str] | frozenset[str] | list[str]) -> NetStatusResult:
+        """Analyze only the named nets (scoped work-list variant, issue #4679).
+
+        Runs the same per-net connectivity analysis as :meth:`analyze` but
+        restricted to ``net_names``, so callers that only care about a few
+        nets (e.g. ``kct stitch`` consulting the strict model for its target
+        plane nets) do not pay for a whole-board analysis.
+
+        Unlike :meth:`analyze`, the pour-net advisory reclassification pass is
+        skipped (irrelevant for a per-net work list);
+        ``NetStatusResult.advisory_incomplete_names`` is left empty.
+
+        Args:
+            net_names: Net names to analyze. Names that do not exist on the
+                board are silently absent from the result (callers can detect
+                this by comparing ``result.nets`` against their request).
+
+        Returns:
+            NetStatusResult containing status for just the selected nets.
+        """
+        wanted = set(net_names)
+        result = NetStatusResult()
+
+        nets = {n: net for n, net in self.pcb.nets.items() if n != 0 and net.name in wanted}
+        result.total_nets = len(nets)
+
+        zone_nets = self._build_zone_net_map()
+        for net_number, net in nets.items():
+            result.nets.append(self._analyze_net(net_number, net.name, zone_nets))
+
+        status_order = {"incomplete": 0, "unrouted": 1, "complete": 2}
+        result.nets.sort(key=lambda n: (status_order.get(n.status, 3), n.net_name))
+        return result
+
     def _build_zone_net_map(self) -> dict[int, list[str]]:
         """Build mapping of net numbers to zone layers.
 
@@ -515,6 +565,7 @@ class NetStatusAnalyzer:
         status = NetStatus(
             net_number=net_number,
             net_name=net_name,
+            source_file=self.source_file,
         )
 
         # Check if this is a plane net

--- a/src/kicad_tools/cli/stitch_cmd.py
+++ b/src/kicad_tools/cli/stitch_cmd.py
@@ -291,6 +291,18 @@ class StitchResult:
     # Each entry is (pad, reason).  These pads are ALSO recorded in
     # ``pads_skipped`` so existing summaries still count them.
     needs_routed_fanout: list[tuple[PadInfo, str]] = field(default_factory=list)
+    # Issue #4679: number of pads enumerated on the target nets, BEFORE any
+    # connectivity gating.  Lets the output distinguish "the target nets have
+    # no pads at all" (say so explicitly, naming the nets) from "N pads found,
+    # all already connected" -- previously both printed the same misleading
+    # "No unconnected pads found on target nets." message.
+    pads_found: int = 0
+    # Issue #4679: non-empty when the strict copper-contact connectivity model
+    # (NetStatusAnalyzer, the engine behind `kct net-status`) could not run
+    # for the target nets; stitch then falls back to the legacy proximity
+    # gate and the output surfaces this so a stitch/net-status disagreement
+    # is never silent.
+    strict_model_error: str = ""
 
 
 @dataclass
@@ -381,24 +393,89 @@ DEFAULT_THERMAL_REFERENCE_PREFIXES: tuple[str, ...] = ("Q",)
 
 
 def get_net_map(sexp: SExp) -> dict[int, str]:
-    """Build a mapping of net number to net name."""
-    net_map = {}
+    """Build a mapping of net number to net name.
+
+    KiCad 10's ``kicad-cli pcb drc --save-board`` deletes the top-level
+    ``(net N "name")`` declaration table and rewrites every inline reference
+    to the name-only ``(net "NAME")`` form (issue #4679; mirrors
+    ``PCB._synthesize_net_table``, issue #4416).  When no header declarations
+    survive, synthesize a stable table from the inline name-only references
+    (document order, numbered from 1) so name-based lookups keep working --
+    otherwise every pad/segment/via on such a board is invisible to stitch.
+    """
+    net_map: dict[int, str] = {}
     for child in sexp.iter_children():
         if child.tag == "net":
             net_num = child.get_int(0)
             net_name = child.get_string(1)
             if net_num is not None and net_name is not None:
                 net_map[net_num] = net_name
-    return net_map
+    if net_map:
+        return net_map
+
+    # No header table: synthesize from inline name-only references.
+    names: list[str] = []
+    seen: set[str] = set()
+
+    def _collect(node: SExp) -> None:
+        net_node = node.find_child("net")
+        if net_node is not None and net_node.get_int(0) is None:
+            name = net_node.get_string(0)
+            if name and name not in seen:
+                seen.add(name)
+                names.append(name)
+
+    for child in sexp.iter_children():
+        if child.tag in ("segment", "arc", "via", "zone"):
+            _collect(child)
+        elif child.tag == "footprint":
+            for pad in child.find_children("pad"):
+                _collect(pad)
+    return dict(enumerate(names, start=1))
+
+
+def get_name_to_net_map(sexp: SExp) -> dict[str, int]:
+    """Build the reverse mapping of net name to net number.
+
+    Used by :func:`resolve_net_num` to resolve KiCad-10 name-only inline
+    references ``(net "NAME")`` back to a numeric net id (issue #4679).
+    """
+    return {name: num for num, name in get_net_map(sexp).items() if name}
+
+
+def resolve_net_num(net_node: SExp | None, name_to_num: dict[str, int]) -> int | None:
+    """Resolve an inline pad/segment/via net reference to a net number.
+
+    Supports all three inline dialects (issue #4679):
+
+    * ``(net N)`` and ``(net N "NAME")`` -- numeric reference (KiCad <= 9)
+    * ``(net "NAME")`` -- KiCad 10 name-only reference (also emitted by
+      ``kicad-cli pcb drc --save-board``)
+
+    Args:
+        net_node: The ``net`` child node of a pad/segment/via, or ``None``.
+        name_to_num: Reverse net map from :func:`get_name_to_net_map`.
+
+    Returns:
+        The net number, or ``None`` when the node is absent or the name
+        cannot be resolved.
+    """
+    if net_node is None:
+        return None
+    num = net_node.get_int(0)
+    if num is not None:
+        return num
+    name = net_node.get_string(0)
+    if name:
+        return name_to_num.get(name)
+    return None
 
 
 def get_net_number(sexp: SExp, net_name: str) -> int | None:
     """Get the net number for a given net name."""
-    for child in sexp.iter_children():
-        if child.tag == "net":
-            name = child.get_string(1)
-            if name == net_name:
-                return child.get_int(0)
+    for num, name in get_net_map(sexp).items():
+        if name == net_name:
+            return num
     return None
 
 
@@ -658,8 +735,16 @@ def find_all_plane_nets(sexp: SExp) -> dict[str, str]:
 
 
 def find_pads_on_nets(sexp: SExp, net_names: set[str]) -> list[PadInfo]:
-    """Find all pads (SMD and through-hole) on the specified nets."""
+    """Find all pads (SMD and through-hole) on the specified nets.
+
+    Handles numeric ``(net N "NAME")`` and KiCad-10 name-only ``(net "NAME")``
+    pad references (issue #4679): before the fix, name-only pads resolved to
+    ``None`` and were silently dropped, so ``kct stitch`` reported "No
+    unconnected pads found" on boards rewritten by ``kicad-cli --save-board``
+    even when ``kct net-status`` named stranded pads on the same nets.
+    """
     net_map = get_net_map(sexp)
+    name_to_num = {name: num for num, name in net_map.items() if name}
     target_net_nums = {num for num, name in net_map.items() if name in net_names}
 
     pads = []
@@ -705,11 +790,11 @@ def find_pads_on_nets(sexp: SExp, net_names: set[str]) -> list[PadInfo]:
             if pad_type not in ("smd", "thru_hole"):
                 continue
 
-            # Check if pad is on a target net
+            # Check if pad is on a target net (numeric or name-only ref)
             net_node = pad.find_child("net")
             if not net_node:
                 continue
-            net_num = net_node.get_int(0)
+            net_num = resolve_net_num(net_node, name_to_num)
             if net_num not in target_net_nums:
                 continue
 
@@ -785,6 +870,7 @@ def find_smd_pad_bboxes_on_nets(
         angles).
     """
     bboxes: list[tuple[int, float, float, float, float]] = []
+    name_to_num = get_name_to_net_map(sexp)
 
     for fp in sexp.iter_children():
         if fp.tag != "footprint":
@@ -812,7 +898,7 @@ def find_smd_pad_bboxes_on_nets(
             net_node = pad.find_child("net")
             if not net_node:
                 continue
-            net_num = net_node.get_int(0)
+            net_num = resolve_net_num(net_node, name_to_num)
             if net_num is None or net_num not in net_numbers:
                 continue
 
@@ -892,6 +978,7 @@ def find_all_pad_bboxes(
     bboxes: list[tuple[float, float, float, float, int]] = []
     if exclude_nets is None:
         exclude_nets = set()
+    name_to_num = get_name_to_net_map(sexp)
 
     for fp in sexp.iter_children():
         if fp.tag != "footprint":
@@ -913,7 +1000,7 @@ def find_all_pad_bboxes(
             net_node = pad.find_child("net")
             if not net_node:
                 continue
-            net_num = net_node.get_int(0)
+            net_num = resolve_net_num(net_node, name_to_num)
             if net_num is None or net_num in exclude_nets:
                 continue
 
@@ -1020,12 +1107,13 @@ def _via_drill_inside_pad_bbox(
 def find_existing_vias(sexp: SExp, net_numbers: set[int]) -> list[tuple[float, float, int]]:
     """Find existing vias on the specified nets. Returns list of (x, y, net_num)."""
     vias = []
+    name_to_num = get_name_to_net_map(sexp)
     for child in sexp.iter_children():
         if child.tag == "via":
             net_node = child.find_child("net")
             if not net_node:
                 continue
-            net_num = net_node.get_int(0)
+            net_num = resolve_net_num(net_node, name_to_num)
             if net_num not in net_numbers:
                 continue
 
@@ -1040,12 +1128,13 @@ def find_existing_vias(sexp: SExp, net_numbers: set[int]) -> list[tuple[float, f
 def find_existing_tracks(sexp: SExp, net_numbers: set[int]) -> list[tuple[float, float, int]]:
     """Find track endpoints on the specified nets. Returns list of (x, y, net_num)."""
     points = []
+    name_to_num = get_name_to_net_map(sexp)
     for child in sexp.iter_children():
         if child.tag == "segment":
             net_node = child.find_child("net")
             if not net_node:
                 continue
-            net_num = net_node.get_int(0)
+            net_num = resolve_net_num(net_node, name_to_num)
             if net_num not in net_numbers:
                 continue
 
@@ -1079,13 +1168,14 @@ def find_all_track_segments(sexp: SExp, exclude_nets: set[int] | None = None) ->
     segments = []
     if exclude_nets is None:
         exclude_nets = set()
+    name_to_num = get_name_to_net_map(sexp)
 
     for child in sexp.iter_children():
         if child.tag == "segment":
             net_node = child.find_child("net")
             if not net_node:
                 continue
-            net_num = net_node.get_int(0)
+            net_num = resolve_net_num(net_node, name_to_num)
             if net_num is None or net_num in exclude_nets:
                 continue
 
@@ -1132,13 +1222,14 @@ def find_all_board_vias(
     vias = []
     if exclude_nets is None:
         exclude_nets = set()
+    name_to_num = get_name_to_net_map(sexp)
 
     for child in sexp.iter_children():
         if child.tag == "via":
             net_node = child.find_child("net")
             if not net_node:
                 continue
-            net_num = net_node.get_int(0)
+            net_num = resolve_net_num(net_node, name_to_num)
             if net_num is None or net_num in exclude_nets:
                 continue
 
@@ -1177,6 +1268,7 @@ def find_all_pads(
     pads = []
     if exclude_nets is None:
         exclude_nets = set()
+    name_to_num = get_name_to_net_map(sexp)
 
     for fp in sexp.iter_children():
         if fp.tag != "footprint":
@@ -1200,7 +1292,7 @@ def find_all_pads(
             net_node = pad.find_child("net")
             if not net_node:
                 continue
-            net_num = net_node.get_int(0)
+            net_num = resolve_net_num(net_node, name_to_num)
             if net_num is None or net_num in exclude_nets:
                 continue
 
@@ -1279,6 +1371,7 @@ def find_all_drills(
         exclude_nets = set()
     if pad_exclude_nets is None:
         pad_exclude_nets = set()
+    name_to_num = get_name_to_net_map(sexp)
 
     for child in sexp.iter_children():
         # Vias
@@ -1288,7 +1381,7 @@ def find_all_drills(
             net_node = child.find_child("net")
             if not net_node:
                 continue
-            net_num = net_node.get_int(0)
+            net_num = resolve_net_num(net_node, name_to_num)
             if net_num is None or net_num in exclude_nets:
                 continue
             at_node = child.find_child("at")
@@ -1324,7 +1417,7 @@ def find_all_drills(
             net_node = pad.find_child("net")
             if not net_node:
                 continue
-            net_num = net_node.get_int(0)
+            net_num = resolve_net_num(net_node, name_to_num)
             if net_num is None or net_num in pad_exclude_nets:
                 continue
             drill_node = pad.find_child("drill")
@@ -3674,6 +3767,7 @@ def find_thermal_pad_candidates(
         pad (one entry per pad, not per footprint).
     """
     net_map = get_net_map(sexp)
+    name_to_num = {name: num for num, name in net_map.items() if name}
     target_net_nums = {num for num, name in net_map.items() if name in net_names}
 
     candidates: list[ThermalPadCandidate] = []
@@ -3727,11 +3821,11 @@ def find_thermal_pad_candidates(
             if pad_type not in ("smd", "thru_hole"):
                 continue
 
-            # Pad must be on a target plane net.
+            # Pad must be on a target plane net (numeric or name-only ref).
             net_node = pad.find_child("net")
             if not net_node:
                 continue
-            net_num = net_node.get_int(0)
+            net_num = resolve_net_num(net_node, name_to_num)
             if net_num not in target_net_nums:
                 continue
 
@@ -4455,6 +4549,36 @@ def run_blanket_stitch(
     return result
 
 
+def _compute_strict_pad_sets(
+    pcb_path: Path, net_names: set[str]
+) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+    """Compute per-net strict-model pad connectivity sets (issue #4679).
+
+    Runs :class:`kicad_tools.analysis.net_status.NetStatusAnalyzer` -- the
+    strict copper-contact model behind ``kct net-status`` -- scoped to
+    ``net_names`` and returns ``(unconnected_by_net, connected_by_net)``,
+    each keyed by net name with values of ``REF.PAD`` pad-name sets.
+
+    ``run_stitch`` uses the unconnected sets to VETO the legacy proximity
+    heuristic's "already connected" skip for target nets that have real fill
+    copper, so a pad ``kct net-status`` reports as "needs via to plane" is in
+    stitch's work list by construction (the two tools can no longer silently
+    contradict each other on the same file).  The connected sets are returned
+    for completeness/diagnostics; they deliberately do NOT suppress stitching
+    (see the gate comment in ``run_stitch``).
+    """
+    from kicad_tools.analysis.net_status import NetStatusAnalyzer
+
+    analyzer = NetStatusAnalyzer(pcb_path, strict=True)
+    scoped = analyzer.analyze_nets(net_names)
+    unconnected: dict[str, set[str]] = {}
+    connected: dict[str, set[str]] = {}
+    for net in scoped.nets:
+        unconnected[net.net_name] = {p.full_name for p in net.unconnected_pads}
+        connected[net.net_name] = {p.full_name for p in net.connected_pads}
+    return unconnected, connected
+
+
 def run_stitch(
     pcb_path: Path,
     net_names: list[str],
@@ -4540,6 +4664,7 @@ def run_stitch(
     # Find pads on target nets
     net_name_set = set(net_names)
     pads = find_pads_on_nets(sexp, net_name_set)
+    result.pads_found = len(pads)
 
     if not pads:
         return result
@@ -4556,6 +4681,29 @@ def run_stitch(
     same_net_zone_polys: list[ZonePolygon] = []
     for net_name in net_names:
         same_net_zone_polys.extend(extract_zone_polygons(sexp, net_name))
+
+    # Issue #4679: strict-model veto data for the "already connected" gate.
+    #
+    # `kct net-status` decides connectivity with the strict copper-contact
+    # model (real shapely geometry, per-fill-island zone connectivity), while
+    # stitch historically used a 0.5mm endpoint-proximity heuristic
+    # (`is_pad_connected`) with no notion of "reaches the plane" -- so a pad
+    # net-status named as "needs via to plane" could be silently skipped as
+    # "connected" here (an SMD pad tied to a stub trace that never reaches
+    # the pour).  For every target net that has real fill copper we consult
+    # the strict model; its unconnected set VETOES a proximity-"connected"
+    # skip in the per-pad loop below, so the net-status remedy applies by
+    # construction.  Nets with no fill copper are exempt (nothing poured yet
+    # -- the strict island model has no plane to anchor to there and would
+    # flag every pad of an unrouted plane net except an arbitrary
+    # largest-island representative).
+    nets_with_fill = {fp.net_name for fp in same_net_filled_polys}
+    strict_sets: tuple[dict[str, set[str]], dict[str, set[str]]] | None = None
+    if nets_with_fill:
+        try:
+            strict_sets = _compute_strict_pad_sets(pcb_path, net_name_set)
+        except Exception as exc:  # pragma: no cover - defensive fallback
+            result.strict_model_error = f"{type(exc).__name__}: {exc}"
 
     # Find other-net copper for clearance checking to prevent shorts
     other_net_tracks = find_all_track_segments(sexp, exclude_nets=net_numbers)
@@ -4828,14 +4976,34 @@ def run_stitch(
         eff_other_net_tracks = other_net_tracks + cross_net_stitch_tracks
         eff_other_net_vias = other_net_vias + cross_net_stitch_vias
 
-        # Check if already connected
-        if is_pad_connected(
+        # Check if already connected (legacy proximity heuristic), then let
+        # the strict copper-contact model VETO a "connected" skip for filled
+        # nets (issue #4679).  The veto is one-directional on purpose:
+        #
+        # * A pad `kct net-status` names as "needs via to plane" (strict
+        #   unconnected) is in stitch's work list by construction, even when
+        #   a stub trace endpoint sits within the 0.5mm proximity radius --
+        #   the old silent "already connected" false skip.
+        # * The strict model never CREATES a skip: its "connected" set is
+        #   "largest island", which tie-breaks arbitrarily between singleton
+        #   islands when the fill bonds no pad at all, so trusting it to
+        #   suppress stitching would strand pads legacy stitching handled.
+        #   Extra vias are recoverable; stranded pads ship defects.
+        connected = is_pad_connected(
             pad,
             existing_vias,
             track_points,
             same_net_filled_polygons=same_net_filled_polys,
             same_net_zone_polygons=same_net_zone_polys,
+        )
+        if (
+            connected
+            and strict_sets is not None
+            and pad.net_name in nets_with_fill
+            and f"{pad.reference}.{pad.pad_number}" in strict_sets[0].get(pad.net_name, set())
         ):
+            connected = False
+        if connected:
             result.already_connected += 1
             continue
 
@@ -5478,8 +5646,29 @@ def output_result(
             )
             print(f"  {net_name} -> {layer}{source}")
 
+    # Issue #4679: surface a strict-model failure so a disagreement with
+    # `kct net-status` is never silent (stitch fell back to the legacy
+    # proximity gate for this run).
+    if result.strict_model_error:
+        print(
+            "\nWarning: strict connectivity model unavailable "
+            f"({result.strict_model_error}); fell back to the legacy "
+            "proximity gate -- results may disagree with `kct net-status`.",
+            file=sys.stderr,
+        )
+
     if not result.vias_added and not result.pads_skipped:
-        if result.already_connected > 0:
+        # Issue #4679: distinguish the three quiet outcomes explicitly --
+        # (a) the target nets have no pads at all (name them), (b) N pads
+        # found and every one already connected, (c) the legacy catch-all.
+        if result.pads_found == 0:
+            nets_str = ", ".join(result.target_nets) if result.target_nets else "(none)"
+            print(f"\nNo pads found on target net(s): {nets_str}")
+            print(
+                "  The net name(s) may not match any net on this board, or "
+                "the net(s) have zero pads -- cross-check with `kct net-status`."
+            )
+        elif result.already_connected > 0:
             print(f"\nAll {result.already_connected} pads already connected.")
         else:
             print("\nNo unconnected pads found on target nets.")

--- a/tests/test_stitch_net_status_agreement.py
+++ b/tests/test_stitch_net_status_agreement.py
@@ -1,0 +1,418 @@
+"""Cross-tool agreement tests: ``kct stitch`` vs ``kct net-status`` (issue #4679).
+
+``kct net-status`` decides connectivity with the strict copper-contact model
+(real shapely geometry with per-fill-island zone connectivity) and prints a
+literal ``kct stitch <file> --net <NET>`` remedy for plane-net pads it reports
+as "needs via to plane".  Before issue #4679 running that exact command could
+answer "No unconnected pads found on target nets": stitch's gate was a 0.5mm
+endpoint-proximity heuristic with no notion of "reaches the plane", and its
+pad enumeration silently dropped KiCad-10 name-only ``(net "NAME")`` pad
+references entirely (the ``kicad-cli pcb drc --save-board`` dialect).
+
+These tests pin the contract that the printed remedy actually applies:
+
+* A pad strict net-status names as stranded from a filled plane is in
+  stitch's work list on the SAME file -- it either receives a via or appears
+  in ``pads_skipped`` with an explicit reason (fixture A).
+* When every pad genuinely reaches the plane both tools agree it is a no-op
+  and stitch says "All N pads already connected" (fixture B).
+* Naming a net with zero pads produces an explicit "No pads found" message
+  that names the net, instead of the misleading catch-all (fixture C).
+* Name-only net references (with or without a surviving header net table)
+  are enumerated, so the "found no pads at all" failure mode is fixed.
+* ``NetStatus.suggested_fix`` embeds the real analyzed filename.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.analysis.net_status import NetStatus, NetStatusAnalyzer
+from kicad_tools.cli.stitch_cmd import (
+    find_existing_vias,
+    find_pads_on_nets,
+    get_name_to_net_map,
+    get_net_map,
+    output_result,
+    resolve_net_num,
+    run_stitch,
+)
+from kicad_tools.core.sexp_file import load_pcb
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+#
+# 2-layer board, plane net GNDA poured (and FILLED) on B.Cu:
+#   C1.1 @ (110, 110): SMD pad on F.Cu tied only to a 2mm stub trace on F.Cu
+#       -- proximity-"connected" to stitch's legacy gate, but the copper
+#       never reaches the plane: strict net-status reports it stranded.
+#   C2.1 @ (120, 110), C3.1 @ (130, 110): SMD pads escaped through a short
+#       trace to a via whose barrel lands on the B.Cu fill island -- bonded.
+#
+# The fill rectangle spans x=105..135 so a stitch via placed next to C1 lands
+# on real same-net fill (the #4432 off-fill gate does not interfere).
+
+_BOARD_HEADER = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+"""
+
+_ZONE_GNDA_FILLED = """  (zone (net 1) (net_name "GNDA") (layer "B.Cu") (uuid "zone-gnda")
+    (hatch edge 0.5)
+    (connect_pads (clearance 0.2))
+    (min_thickness 0.25)
+    (filled_areas_thickness no)
+    (fill yes (thermal_gap 0.5) (thermal_bridge_width 0.5))
+    (polygon
+      (pts (xy 105 105) (xy 135 105) (xy 135 115) (xy 105 115))
+    )
+    (filled_polygon
+      (layer "B.Cu")
+      (pts (xy 105 105) (xy 135 105) (xy 135 115) (xy 105 115))
+    )
+  )
+"""
+
+
+def _footprint(ref: str, x: float, y: float, net_ref: str) -> str:
+    """One-pad SMD footprint on F.Cu with a 1x1mm pad at its origin."""
+    return f"""  (footprint "Test:OnePad"
+    (layer "F.Cu")
+    (uuid "fp-{ref}")
+    (at {x} {y})
+    (property "Reference" "{ref}" (at 0 -1.5 0) (layer "F.SilkS") (uuid "ref-{ref}"))
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu" "F.Paste" "F.Mask") (net {net_ref}))
+  )
+"""
+
+
+def _stranded_board(*, stranded_pad_has_via: bool) -> str:
+    """Board text for fixtures A (stranded C1.1) and B (all bonded)."""
+    parts = [_BOARD_HEADER]
+    parts.append('  (net 0 "")\n  (net 1 "GNDA")\n  (net 2 "SIG")\n')
+    parts.append(_footprint("C1", 110, 110, '1 "GNDA"'))
+    parts.append(_footprint("C2", 120, 110, '1 "GNDA"'))
+    parts.append(_footprint("C3", 130, 110, '1 "GNDA"'))
+    # C1.1: stub trace to nowhere (fixture A) or a real via escape (fixture B)
+    if stranded_pad_has_via:
+        parts.append(
+            '  (segment (start 110 110) (end 110.8 110) (width 0.25) (layer "F.Cu")'
+            ' (net 1) (uuid "seg-c1"))\n'
+            '  (via (at 110.8 110) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu")'
+            ' (net 1) (uuid "via-c1"))\n'
+        )
+    else:
+        parts.append(
+            '  (segment (start 110 110) (end 112 110) (width 0.25) (layer "F.Cu")'
+            ' (net 1) (uuid "seg-c1-stub"))\n'
+        )
+    # C2.1 and C3.1: trace + via landing on the B.Cu fill island
+    parts.append(
+        '  (segment (start 120 110) (end 120.8 110) (width 0.25) (layer "F.Cu")'
+        ' (net 1) (uuid "seg-c2"))\n'
+        '  (via (at 120.8 110) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu")'
+        ' (net 1) (uuid "via-c2"))\n'
+        '  (segment (start 130 110) (end 130.8 110) (width 0.25) (layer "F.Cu")'
+        ' (net 1) (uuid "seg-c3"))\n'
+        '  (via (at 130.8 110) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu")'
+        ' (net 1) (uuid "via-c3"))\n'
+    )
+    parts.append(_ZONE_GNDA_FILLED)
+    parts.append(")\n")
+    return "".join(parts)
+
+
+@pytest.fixture
+def stranded_pad_pcb(tmp_path: Path) -> Path:
+    """Fixture A: C1.1 has only a stub trace -- strictly stranded."""
+    pcb_file = tmp_path / "stranded_a.kicad_pcb"
+    pcb_file.write_text(_stranded_board(stranded_pad_has_via=False))
+    return pcb_file
+
+
+@pytest.fixture
+def all_bonded_pcb(tmp_path: Path) -> Path:
+    """Fixture B: every GNDA pad reaches the B.Cu plane through a via."""
+    pcb_file = tmp_path / "bonded_b.kicad_pcb"
+    pcb_file.write_text(_stranded_board(stranded_pad_has_via=True))
+    return pcb_file
+
+
+# ---------------------------------------------------------------------------
+# Fixture A: strict net-status names a stranded pad -> stitch must act on it
+# ---------------------------------------------------------------------------
+
+
+class TestStrandedPadAgreement:
+    def test_net_status_reports_pad_stranded(self, stranded_pad_pcb: Path):
+        """Precondition: the strict model names C1.1 'needs via to plane'."""
+        analyzer = NetStatusAnalyzer(stranded_pad_pcb, strict=True)
+        result = analyzer.analyze()
+        gnda = result.get_net("GNDA")
+        assert gnda is not None
+        assert gnda.is_plane_net
+        assert gnda.status == "incomplete"
+        assert [p.full_name for p in gnda.unconnected_pads] == ["C1.1"]
+
+    def test_stitch_acts_on_strictly_stranded_pad(self, stranded_pad_pcb: Path):
+        """The pad net-status names must be in stitch's work list.
+
+        Before issue #4679 the 0.5mm proximity gate saw C1.1's stub-trace
+        endpoint at the pad center and skipped it as "already connected" --
+        the printed net-status remedy was a no-op.
+        """
+        result = run_stitch(stranded_pad_pcb, ["GNDA"], dry_run=True)
+
+        assert result.pads_found == 3
+        acted_on = {f"{p.pad.reference}.{p.pad.pad_number}" for p in result.vias_added} | {
+            f"{p.reference}.{p.pad_number}" for p, _reason in result.pads_skipped
+        }
+        assert "C1.1" in acted_on
+        # The two genuinely bonded pads are recognized as connected.
+        assert result.already_connected == 2
+
+    def test_stitch_proposes_via_for_stranded_pad(self, stranded_pad_pcb: Path):
+        """On this uncongested fixture the stranded pad gets an actual via."""
+        result = run_stitch(stranded_pad_pcb, ["GNDA"], dry_run=True)
+        via_pads = {f"{p.pad.reference}.{p.pad.pad_number}" for p in result.vias_added}
+        assert via_pads == {"C1.1"}
+
+    def test_no_silent_contradiction_message(self, stranded_pad_pcb: Path, capsys):
+        """'No unconnected pads found' must be impossible while net-status
+        names a stranded pad on the same artifact."""
+        result = run_stitch(stranded_pad_pcb, ["GNDA"], dry_run=True)
+        output_result(result, dry_run=True)
+        out = capsys.readouterr().out
+        assert "No unconnected pads found" not in out
+        assert "No pads found on target net(s)" not in out
+
+
+# ---------------------------------------------------------------------------
+# Fixture B: both tools agree the net is complete -> explicit no-op message
+# ---------------------------------------------------------------------------
+
+
+class TestAllBondedAgreement:
+    def test_net_status_reports_complete(self, all_bonded_pcb: Path):
+        analyzer = NetStatusAnalyzer(all_bonded_pcb, strict=True)
+        gnda = analyzer.analyze().get_net("GNDA")
+        assert gnda is not None
+        assert gnda.status == "complete"
+
+    def test_stitch_reports_all_connected(self, all_bonded_pcb: Path, capsys):
+        result = run_stitch(all_bonded_pcb, ["GNDA"], dry_run=True)
+
+        assert result.pads_found == 3
+        assert result.already_connected == 3
+        assert not result.vias_added
+        assert not result.pads_skipped
+
+        output_result(result, dry_run=True)
+        out = capsys.readouterr().out
+        assert "All 3 pads already connected." in out
+
+
+# ---------------------------------------------------------------------------
+# Fixture C: zero pads on the target net -> explicit, self-diagnosing message
+# ---------------------------------------------------------------------------
+
+
+class TestZeroPadsMessage:
+    def test_zero_pad_net_named_explicitly(self, stranded_pad_pcb: Path, capsys):
+        """A net with no pads must be reported as such, naming the net --
+        not with the ambiguous 'No unconnected pads found on target nets.'"""
+        result = run_stitch(stranded_pad_pcb, ["SIG"], dry_run=True)
+
+        assert result.pads_found == 0
+        output_result(result, dry_run=True)
+        out = capsys.readouterr().out
+        assert "No pads found on target net(s): SIG" in out
+        assert "No unconnected pads found" not in out
+
+    def test_nonexistent_net_named_explicitly(self, stranded_pad_pcb: Path, capsys):
+        result = run_stitch(stranded_pad_pcb, ["NO_SUCH_NET"], dry_run=True)
+        assert result.pads_found == 0
+        output_result(result, dry_run=True)
+        out = capsys.readouterr().out
+        assert "No pads found on target net(s): NO_SUCH_NET" in out
+
+
+# ---------------------------------------------------------------------------
+# Name-only net references (issue #4679 pad-enumeration defect)
+# ---------------------------------------------------------------------------
+
+
+def _name_only_board(*, keep_header_table: bool) -> str:
+    """Board where every inline net reference is KiCad-10 name-only.
+
+    ``keep_header_table=False`` reproduces the ``kicad-cli pcb drc
+    --save-board`` dialect where the top-level ``(net N "name")`` table is
+    deleted entirely.
+    """
+    parts = [_BOARD_HEADER]
+    if keep_header_table:
+        parts.append('  (net 0 "")\n  (net 1 "GNDA")\n  (net 2 "SIG")\n')
+    parts.append(_footprint("C1", 110, 110, '"GNDA"'))
+    parts.append(_footprint("C2", 120, 110, '"GNDA"'))
+    parts.append(
+        '  (segment (start 120 110) (end 120.8 110) (width 0.25) (layer "F.Cu")'
+        ' (net "GNDA") (uuid "seg-c2"))\n'
+        '  (via (at 120.8 110) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu")'
+        ' (net "GNDA") (uuid "via-c2"))\n'
+    )
+    parts.append(
+        """  (zone (net "GNDA") (layer "B.Cu") (uuid "zone-gnda")
+    (hatch edge 0.5)
+    (connect_pads (clearance 0.2))
+    (min_thickness 0.25)
+    (fill yes (thermal_gap 0.5) (thermal_bridge_width 0.5))
+    (polygon
+      (pts (xy 105 105) (xy 135 105) (xy 135 115) (xy 105 115))
+    )
+    (filled_polygon
+      (layer "B.Cu")
+      (pts (xy 105 105) (xy 135 105) (xy 135 115) (xy 105 115))
+    )
+  )
+"""
+    )
+    parts.append(")\n")
+    return "".join(parts)
+
+
+class TestNameOnlyNetReferences:
+    def test_pads_found_with_header_table(self, tmp_path: Path):
+        """Name-only pad refs resolve through the header net table."""
+        pcb_file = tmp_path / "name_only_header.kicad_pcb"
+        pcb_file.write_text(_name_only_board(keep_header_table=True))
+        sexp = load_pcb(pcb_file)
+
+        pads = find_pads_on_nets(sexp, {"GNDA"})
+        assert {f"{p.reference}.{p.pad_number}" for p in pads} == {"C1.1", "C2.1"}
+        assert all(p.net_number == 1 for p in pads)
+        assert all(p.net_name == "GNDA" for p in pads)
+
+    def test_pads_found_without_header_table(self, tmp_path: Path):
+        """kicad-cli --save-board strips the header net table; a synthesized
+        table keeps pads visible (before #4679: empty pad list -> the
+        misleading 'No unconnected pads found on target nets.')."""
+        pcb_file = tmp_path / "name_only_stripped.kicad_pcb"
+        pcb_file.write_text(_name_only_board(keep_header_table=False))
+        sexp = load_pcb(pcb_file)
+
+        net_map = get_net_map(sexp)
+        assert "GNDA" in net_map.values()
+
+        pads = find_pads_on_nets(sexp, {"GNDA"})
+        assert {f"{p.reference}.{p.pad_number}" for p in pads} == {"C1.1", "C2.1"}
+
+        # Same-net copper is attributed consistently (vias resolve to the
+        # same synthesized number the pads got).
+        net_numbers = {p.net_number for p in pads}
+        vias = find_existing_vias(sexp, net_numbers)
+        assert len(vias) == 1
+
+    def test_run_stitch_end_to_end_on_name_only_board(self, tmp_path: Path, capsys):
+        """The filer's failure shape: name-only board, stranded SMD pad.
+
+        Stitch must find the pads and propose a via for the stranded one
+        instead of reporting that no pads exist.
+        """
+        pcb_file = tmp_path / "name_only_e2e.kicad_pcb"
+        pcb_file.write_text(_name_only_board(keep_header_table=False))
+
+        result = run_stitch(pcb_file, ["GNDA"], dry_run=True)
+        assert result.pads_found == 2
+
+        output_result(result, dry_run=True)
+        out = capsys.readouterr().out
+        assert "No pads found on target net(s)" not in out
+        assert "No unconnected pads found" not in out
+
+    def test_resolve_net_num_dialects(self):
+        """Unit: numeric, numeric+name, and name-only refs all resolve."""
+        from kicad_tools.sexp import parse_string
+
+        name_to_num = {"GNDA": 7}
+        numeric = parse_string("(pad (net 7))").find_child("net")
+        numeric_named = parse_string('(pad (net 7 "GNDA"))').find_child("net")
+        name_only = parse_string('(pad (net "GNDA"))').find_child("net")
+        unknown = parse_string('(pad (net "OTHER"))').find_child("net")
+
+        assert resolve_net_num(numeric, name_to_num) == 7
+        assert resolve_net_num(numeric_named, name_to_num) == 7
+        assert resolve_net_num(name_only, name_to_num) == 7
+        assert resolve_net_num(unknown, name_to_num) is None
+        assert resolve_net_num(None, name_to_num) is None
+
+    def test_get_name_to_net_map(self, tmp_path: Path):
+        pcb_file = tmp_path / "name_map.kicad_pcb"
+        pcb_file.write_text(_name_only_board(keep_header_table=True))
+        sexp = load_pcb(pcb_file)
+        assert get_name_to_net_map(sexp)["GNDA"] == 1
+
+
+# ---------------------------------------------------------------------------
+# suggested_fix embeds the real filename (issue #4679 bonus defect)
+# ---------------------------------------------------------------------------
+
+
+class TestSuggestedFixFilename:
+    def test_suggested_fix_uses_source_file(self):
+        status = NetStatus(
+            net_number=1,
+            net_name="GNDA",
+            is_plane_net=True,
+            plane_layers=["In1.Cu"],
+            source_file="boards/chorus_v24.kicad_pcb",
+        )
+        assert "kct stitch boards/chorus_v24.kicad_pcb --net GNDA" in status.suggested_fix
+
+    def test_suggested_fix_falls_back_without_source(self):
+        status = NetStatus(
+            net_number=1,
+            net_name="GNDA",
+            is_plane_net=True,
+            plane_layers=["In1.Cu"],
+        )
+        assert "kct stitch board.kicad_pcb --net GNDA" in status.suggested_fix
+
+    def test_analyzer_threads_path_into_statuses(self, stranded_pad_pcb: Path):
+        analyzer = NetStatusAnalyzer(stranded_pad_pcb, strict=True)
+        gnda = analyzer.analyze().get_net("GNDA")
+        assert gnda is not None
+        assert str(stranded_pad_pcb) in gnda.suggested_fix
+        assert "board.kicad_pcb" not in gnda.suggested_fix
+
+
+# ---------------------------------------------------------------------------
+# Scoped strict analysis (NetStatusAnalyzer.analyze_nets)
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeNetsScoped:
+    def test_scoped_analysis_matches_full(self, stranded_pad_pcb: Path):
+        analyzer = NetStatusAnalyzer(stranded_pad_pcb, strict=True)
+        scoped = analyzer.analyze_nets({"GNDA"})
+
+        assert [n.net_name for n in scoped.nets] == ["GNDA"]
+        gnda = scoped.nets[0]
+        assert [p.full_name for p in gnda.unconnected_pads] == ["C1.1"]
+        assert {p.full_name for p in gnda.connected_pads} == {"C2.1", "C3.1"}
+
+    def test_scoped_analysis_unknown_net_is_absent(self, stranded_pad_pcb: Path):
+        analyzer = NetStatusAnalyzer(stranded_pad_pcb, strict=True)
+        scoped = analyzer.analyze_nets({"NOT_A_NET"})
+        assert scoped.nets == []


### PR DESCRIPTION
## Summary

`kct net-status` could name a plane-net pad "needs via to plane" and print a literal remedy (`kct stitch <file> --net <NET>`) that, when run on the same file, answered "No unconnected pads found on target nets". This PR closes that loop: the printed remedy now applies by construction, and every quiet outcome is self-diagnosing.

Closes #4679

## What was fixed

### 1. Model divergence — strict-model veto in `run_stitch` (`stitch_cmd.py`)

Stitch's "already connected" gate was `is_pad_connected`, a 0.5mm endpoint-proximity heuristic with no concept of "reaches the plane" (SMD pads never consulted zone geometry at all). An SMD pad tied to a stub trace going nowhere counted as connected and was silently skipped.

For every target net that has **real fill copper**, `run_stitch` now runs the strict copper-contact model (`NetStatusAnalyzer` — the exact engine behind `kct net-status` — via a new scoped `analyze_nets()` on `analysis/net_status.py`) and uses its unconnected set (`REF.PAD` keys) to **veto** a proximity-"connected" skip. A pad net-status names is therefore in stitch's work list by construction: it either gets a via or lands in `pads_skipped` with an explicit per-pad reason.

**The veto is deliberately one-directional.** The strict model's "connected" set is "largest island", which tie-breaks *arbitrarily* between singleton islands when the fill bonds no pad (the existing `TestStitchFillContainmentGate` fixture caught exactly this during development). Letting the strict model *suppress* stitching would strand pads that legacy stitching handled — extra vias are recoverable, stranded pads ship defects. Nets with no fill copper keep the legacy gate unchanged (nothing poured yet — the island model has no plane to anchor to), which also preserves the unfilled-board stitch workflow byte-for-byte.

If the strict model fails to run, stitch falls back to the legacy gate and prints a stderr warning naming the error — the fallback is never silent (`StitchResult.strict_model_error`).

### 2. Name-only net references — the empty-pad-list defect (`stitch_cmd.py`)

The curator's read of the exact message printed ("No unconnected pads found" requires `find_pads_on_nets` returning an *empty* list) pointed at a second defect, and it is real: stitch's pad/via/track/drill extractors parsed inline net refs with `get_int(0)` only, silently dropping KiCad-10 name-only `(net "NAME")` references — the dialect `kicad-cli pcb drc --save-board` writes (it also deletes the header net table entirely). The zone extractors already had name-only fallbacks, which is why the filer's run *auto-detected the layer from the zone* and then found zero pads: precisely the reproduced contradiction.

Fixed with a shared `resolve_net_num()` resolver applied at every number-only extraction site (`find_pads_on_nets`, `find_smd_pad_bboxes_on_nets`, `find_all_pad_bboxes`, `find_existing_vias`, `find_existing_tracks`, `find_all_track_segments`, `find_all_board_vias`, `find_all_pads`, `find_all_drills` x2, `find_thermal_pad_candidates`), plus header-table **synthesis** in `get_net_map()` for the stripped-header case (mirrors `PCB._synthesize_net_table`, #4416). Obstacle/clearance registries stay net-consistent because all sites resolve through the same deterministic map.

### 3. Output accounting — three distinguishable outcomes (`output_result`)

- zero pads on the target nets → `No pads found on target net(s): <names>` with a cross-check hint (previously the misleading catch-all)
- N pads found, all connected → `All N pads already connected.`
- vias proposed/placed → unchanged
- strict-model fallback → stderr warning

### Bonus: `suggested_fix` filename (`analysis/net_status.py`)

`NetStatus.suggested_fix` hardcoded `board.kicad_pcb`. `NetStatusAnalyzer` now threads the analyzed path (as given, or `PCB.path` for preloaded objects) into each `NetStatus.source_file`, so the printed remedy is copy-pasteable. Falls back to the old literal only when no path is known.

## Acceptance criteria (curator enrichment)

- [x] Pad P named by strict net-status → stitch on the SAME file proposes a via for P or prints an explicit per-pad reason; the contradiction message is impossible (fixture A tests + smoke run below)
- [x] Output distinguishes zero-pads-found / all-connected / vias-proposed (fixture B + C tests)
- [x] Stitch's plane-net decision agrees with the strict copper-contact model (veto; stub-trace-to-nowhere no longer suppresses stitching)
- [x] `suggested_fix` prints the real analyzed filename
- [x] Existing behavior unchanged where the models already agree: full `test_stitch_cmd.py` (296), all stitch-related suites, board-05 stitch pipeline all pass unmodified

## End-to-end smoke (fixture A shape)

```
$ kct net-status .../demo_a.kicad_pcb --incomplete
[!] GNDA (1 pads unconnected) -- Plane net on B.Cu
  C1.1     @ (110.00, 110.00) -- needs via to plane
  -> Fix: kct stitch .../demo_a.kicad_pcb --net GNDA (zones on B.Cu)

$ kct stitch .../demo_a.kicad_pcb --net GNDA --dry-run
GNDA -> B.Cu:
  Added via near C1.1 @ (111.00, 110.00)
  = 2 pads already connected
```

## Deferred (with rationale)

- **`kct check` connectivity / LVS divergence** — explicitly fenced to #4678 by the curator scope guard; untouched.
- **Full name-only-dialect audit of non-stitch raw-SExp consumers** — this PR makes every *stitch* extractor dialect-aware; other CLI surfaces that parse raw SExp net refs are out of this issue's scope.
- **Strict-model "connected" as a skip signal** — intentionally not adopted (largest-island tie-break artifact, see above); revisit only if net-status itself gains fill-anchored island semantics.

## Tests

- New `tests/test_stitch_net_status_agreement.py`: 18 tests — fixture A (stranded stub-trace pad: net-status precondition, work-list inclusion, via proposed, no contradiction message), fixture B (all bonded: both tools no-op, "All 3 pads already connected"), fixture C (zero-pads message names the net), name-only refs (header present, header stripped, end-to-end run), `resolve_net_num` dialect unit, `suggested_fix` filename (3), scoped `analyze_nets` (2).
- Regression: `test_stitch_cmd.py` (296), `test_net_status*.py` + `test_analysis_net_status.py` + `test_check_net_status.py` (180), `test_stitch_mfr/via_halo/bga_outer_ring/thermal_stitch/board_05_thermal/build_stitch_step` (65), `test_board_05_stitch_pipeline.py` (4), `test_grid_plane_net_halo.py` + `test_pipeline_cmd.py` (294), `test_write_verification/fix_vias/via_hole_to_hole_guard` (141) — all pass.
- `ruff check` / `ruff format` clean on changed files; mypy baseline gate passes (no new errors; 2 baseline errors resolved, baseline left untouched per the surgical-edit convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
