### PR TITLE
feat(pipeline): gate the --voltage-map route-skip on a kct creepage audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`kct pipeline` route-skip under `--voltage-map` now auto-runs a
+  `kct creepage` audit as the skip gate** (#4649) — refining the #4607 loud
+  refusal: when the board is already `>=`95% routed (recommend_skip) and no
+  `--force` is given, the route step spawns a non-destructive
+  `kct creepage <board> --voltage-map ... --standard ... --pollution-degree
+  ... --material-group ... --census-threshold ...` subprocess on the
+  existing copper instead of refusing outright. The destructive re-route
+  stays skipped, and the route step succeeds iff the audit exits clean; any
+  non-zero exit (including exit 2, the #4354 EXIT_HV_UNCLASSIFIED vacuity
+  guard, which is called out distinctly in the failure message) aborts the
+  pipeline. The gate is strict `returncode == 0` — deliberately not routed
+  through the shared soft exit-2-5 subprocess semantics. If the audit
+  subprocess cannot launch at all, the step falls back to the #4607
+  refusal message (manual `kct creepage` or `--force`), and `--dry-run`
+  reports the would-be audit without spawning anything. Skips without a
+  voltage map, forced re-routes, and the actual-route exit-3/4 escalation
+  are byte-identical to before.
+
 - **Local CI-equivalent gate script as an Actions-outage backstop** (#4671)
   — new `scripts/ci/local-gate.sh` mirrors the `.github/workflows/ci.yml`
   job set locally: `--cheap` (default) runs the six cheap gates,

--- a/src/kicad_tools/cli/pipeline_cmd.py
+++ b/src/kicad_tools/cli/pipeline_cmd.py
@@ -931,6 +931,119 @@ def _run_subprocess_step(
         return False, f"failed: {e}"
 
 
+def _audit_existing_copper_for_skip(ctx: PipelineContext, console: Console) -> PipelineResult:
+    """Gate the route-step skip on a ``kct creepage`` audit of existing copper.
+
+    HV skip gate (issue #4649, refining the #4607 refusal): the pipeline's
+    primary input is an already routed board, and the HV pairwise-clearance
+    audit otherwise only runs inside the ``kct route`` subprocess the skip
+    avoids.  Instead of refusing the skip outright, run a non-destructive
+    ``kct creepage`` audit on the existing copper: the (destructive)
+    re-route stays skipped, and the route step succeeds iff the audit exits
+    clean.  If the audit subprocess cannot launch at all, fall back to the
+    #4607 loud refusal (manual ``kct creepage`` or ``--force``) rather than
+    a raw traceback.
+    """
+    # `kct creepage` names two of the shared HV flags differently from the
+    # `kct route` passthrough: `creepage_standard` maps to --standard and
+    # `hv_threshold` maps to --census-threshold (documented as aligned with
+    # optimize-placement --hv-threshold).  Do not copy the route argv.
+    audit_args = [
+        "--voltage-map",
+        str(ctx.voltage_map),
+        "--standard",
+        ctx.creepage_standard,
+        "--pollution-degree",
+        str(ctx.pollution_degree),
+        "--material-group",
+        ctx.material_group,
+        "--census-threshold",
+        str(ctx.hv_threshold),
+    ]
+    manual_cmd = f"kct creepage {ctx.pcb_file.name} " + " ".join(audit_args)
+
+    if ctx.dry_run:
+        return PipelineResult(
+            step=PipelineStep.ROUTE,
+            success=True,
+            message=(f"[dry-run] Would audit existing copper (skip re-route): {manual_cmd}"),
+        )
+
+    if not ctx.quiet:
+        console.print(f"  Auditing existing copper (creepage) on {ctx.pcb_file.name}...")
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "kicad_tools.cli",
+        "creepage",
+        str(ctx.pcb_file),
+        *audit_args,
+    ]
+
+    # Strict returncode == 0 gate -- deliberately NOT _run_subprocess_step.
+    # That helper soft-passes exits 2-5, but for `kct creepage` exit 1 means
+    # a measured pair failed its bound and exit 2 is EXIT_HV_UNCLASSIFIED
+    # (#4354 vacuity guard: the board looks mains-like but no HV net was
+    # classified).  Both must fail this gate; a soft-passed exit 2 would let
+    # the skip proceed on an unauditable board -- exactly the false pass
+    # this gate exists to prevent.
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=str(ctx.pcb_file.parent),
+            capture_output=not ctx.verbose,
+            text=True,
+        )
+    except Exception as e:
+        # Fallback refusal (#4607): the audit could not run, so refuse the
+        # silent skip and point at the manual audit / --force.
+        return PipelineResult(
+            step=PipelineStep.ROUTE,
+            success=False,
+            message=(
+                "route: board is already routed so the route step would be "
+                "skipped, but --voltage-map is set and the creepage audit "
+                f"subprocess could not run ({e}); refusing to skip "
+                f"silently. Audit the existing copper with `{manual_cmd}`, "
+                "or pass --force to re-route with the audit."
+            ),
+        )
+
+    if result.returncode == 0:
+        return PipelineResult(
+            step=PipelineStep.ROUTE,
+            success=True,
+            message=("route: skipped (already routed); creepage audit clean on existing copper"),
+            skipped=True,
+        )
+
+    from .commands.creepage import EXIT_HV_UNCLASSIFIED
+
+    if result.returncode == EXIT_HV_UNCLASSIFIED:
+        reason = (
+            f"exit {EXIT_HV_UNCLASSIFIED} (HV-unclassified): the board "
+            "looks mains-like but no HV net could be classified, so the "
+            "audit is vacuous -- not a measured-pair failure"
+        )
+    else:
+        reason = f"exit {result.returncode}: existing copper failed the creepage audit"
+    stderr_tail = ""
+    stderr = (result.stderr or "").strip()
+    if stderr:
+        stderr_tail = f" [{stderr.splitlines()[-1]}]"
+    return PipelineResult(
+        step=PipelineStep.ROUTE,
+        success=False,
+        message=(
+            "route: re-route skipped (already routed), but the creepage "
+            f"audit on the existing copper failed with --voltage-map -- "
+            f"{reason}.{stderr_tail} Inspect with `{manual_cmd}`, or pass "
+            "--force to re-route with the audit."
+        ),
+    )
+
+
 def _run_step_route(ctx: PipelineContext, console: Console) -> PipelineResult:
     """Run routing step if the board is not yet sufficiently routed.
 
@@ -942,36 +1055,25 @@ def _run_step_route(ctx: PipelineContext, console: Console) -> PipelineResult:
     other pipeline steps (or are inherently complete).  ``--force`` always
     re-runs the router.
 
-    HV guard (issue #4607): with ``--voltage-map`` set the skip path refuses
-    loudly instead of skipping, because the HV pairwise-clearance audit only
-    runs inside the routing subprocess -- a silent skip would report success
-    on possibly creepage-dirty copper.
+    HV skip gate (issues #4607/#4649): with ``--voltage-map`` set the skip
+    path runs a non-destructive ``kct creepage`` audit on the existing
+    copper instead of skipping silently, because the HV pairwise-clearance
+    audit otherwise only runs inside the routing subprocess.  The skip
+    proceeds only when the audit exits clean; if the audit subprocess
+    cannot launch, the step falls back to the #4607 loud refusal.
     """
     assessment = _assess_routing_completeness(ctx.pcb_file, ctx.route_skip_threshold)
 
     if assessment.recommend_skip and not ctx.force:
-        # HV guard (issue #4607): the pipeline's primary input is an already
-        # routed board, and the HV pairwise-clearance audit only runs inside
-        # the `kct route` subprocess this skip avoids.  Silently skipping
-        # would report success on possibly creepage-dirty copper, so with a
-        # voltage map in play the skip path refuses loudly instead.  A forced
-        # re-route would be destructive to existing copper, so the user is
-        # pointed at `kct creepage` (non-destructive audit) or an explicit
-        # `--force`.
+        # HV skip gate (issues #4607/#4649): a silent skip would report
+        # success on possibly creepage-dirty copper, so with a voltage map
+        # in play the skip is gated on a non-destructive `kct creepage`
+        # audit of the existing copper (see
+        # _audit_existing_copper_for_skip).  A forced re-route would be
+        # destructive to existing copper, so a failed audit points the user
+        # at the manual audit or an explicit `--force`.
         if ctx.voltage_map:
-            return PipelineResult(
-                step=PipelineStep.ROUTE,
-                success=False,
-                message=(
-                    "route: board is already routed so the route step would "
-                    "be skipped, but --voltage-map is set and the HV "
-                    "pairwise-clearance audit only runs during routing; "
-                    "refusing to skip silently. Audit the existing copper "
-                    f"with `kct creepage {ctx.pcb_file.name} --voltage-map "
-                    f"{ctx.voltage_map}`, or pass --force to re-route with "
-                    "the audit."
-                ),
-            )
+            return _audit_existing_copper_for_skip(ctx, console)
         return PipelineResult(
             step=PipelineStep.ROUTE,
             success=True,

--- a/tests/test_pipeline_cmd.py
+++ b/tests/test_pipeline_cmd.py
@@ -1058,6 +1058,183 @@ class TestRouteVoltageMapFatalSplit:
         assert rc == 0
 
 
+class TestRouteSkipCreepageAuditGate:
+    """The route-skip path under --voltage-map is gated on a creepage audit.
+
+    Issue #4649 (refining the #4607 loud refusal): a recommend_skip board
+    with a voltage map spawns a non-destructive `kct creepage` audit on the
+    existing copper instead of refusing outright -- the (destructive)
+    re-route stays skipped, and the route step succeeds iff the audit exits
+    clean.  A launch failure falls back to the #4607 refusal.
+
+    The gate is strict ``returncode == 0``: `kct creepage` exit 2 is
+    EXIT_HV_UNCLASSIFIED (#4354 vacuity guard), which the shared
+    _run_subprocess_step helper would soft-pass -- these tests pin that it
+    fails the gate instead.
+    """
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_audit_clean_skip_proceeds_with_creepage_argv(self, mock_run, routed_pcb: Path):
+        """Clean audit: skip proceeds; argv is `creepage` with the mapped flag names."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+
+        ctx = PipelineContext(
+            pcb_file=routed_pcb,
+            quiet=True,
+            voltage_map="vm.json",
+            creepage_standard="iec62368",
+            pollution_degree=3,
+            material_group="II",
+            hv_threshold=60.0,
+        )
+        results = run_pipeline(ctx, [PipelineStep.ROUTE])
+
+        assert results[0].success is True
+        assert results[0].skipped is True
+        assert "creepage audit clean" in results[0].message
+
+        cmd_args = mock_run.call_args[0][0]
+        assert "creepage" in cmd_args
+        assert "route" not in cmd_args
+        assert cmd_args[cmd_args.index("--voltage-map") + 1] == "vm.json"
+        # Two flag names DIFFER from the `kct route` passthrough:
+        # creepage_standard -> --standard, hv_threshold -> --census-threshold.
+        assert cmd_args[cmd_args.index("--standard") + 1] == "iec62368"
+        assert cmd_args[cmd_args.index("--pollution-degree") + 1] == "3"
+        assert cmd_args[cmd_args.index("--material-group") + 1] == "II"
+        assert cmd_args[cmd_args.index("--census-threshold") + 1] == "60.0"
+        # The route-argv spellings must not leak into the audit argv.
+        assert "--creepage-standard" not in cmd_args
+        assert "--hv-threshold" not in cmd_args
+
+    @pytest.mark.parametrize("returncode", [1, 3, 4, 5])
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_audit_nonzero_fails_route_step(self, mock_run, routed_pcb: Path, returncode: int):
+        """Any non-zero audit exit fails the route step and aborts the pipeline.
+
+        Exits 3-5 would soft-pass through _run_subprocess_step's shared
+        semantics; the audit gate must be strict returncode == 0.
+        """
+        mock_run.return_value = MagicMock(returncode=returncode, stderr="", stdout="")
+
+        ctx = PipelineContext(pcb_file=routed_pcb, quiet=True, voltage_map="vm.json")
+        results = run_pipeline(ctx, [PipelineStep.ROUTE, PipelineStep.FIX_DRC, PipelineStep.AUDIT])
+
+        # Pipeline must stop at the route step -- creepage-dirty copper does
+        # not flow on to downstream steps.
+        assert len(results) == 1
+        assert results[0].success is False
+        assert results[0].skipped is False
+        assert results[0].warning is False
+        assert "kct creepage" in results[0].message
+        assert "--force" in results[0].message
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_audit_exit_2_hv_unclassified_is_fatal(self, mock_run, routed_pcb: Path):
+        """Exit 2 (EXIT_HV_UNCLASSIFIED vacuity guard) fails the gate, loudly.
+
+        Under _run_subprocess_step's soft semantics exit 2 would pass as
+        "completed with warnings" and the skip would proceed on an
+        unauditable board -- exactly the false pass this gate prevents.  The
+        message must distinguish vacuity from a measured-pair failure.
+        """
+        mock_run.return_value = MagicMock(returncode=2, stderr="", stdout="")
+
+        ctx = PipelineContext(pcb_file=routed_pcb, quiet=True, voltage_map="vm.json")
+        results = run_pipeline(ctx, [PipelineStep.ROUTE])
+
+        assert results[0].success is False
+        assert results[0].warning is False
+        assert "HV-unclassified" in results[0].message
+        assert "not a measured-pair failure" in results[0].message
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_no_voltage_map_skip_spawns_no_subprocess(self, mock_run, routed_pcb: Path):
+        """Without a voltage map the skip is byte-identical to the historical skip."""
+        ctx = PipelineContext(pcb_file=routed_pcb, quiet=True)
+        results = run_pipeline(ctx, [PipelineStep.ROUTE])
+
+        assert results[0].success is True
+        assert results[0].skipped is True
+        mock_run.assert_not_called()
+        assessment = _assess_routing_completeness(routed_pcb, ctx.route_skip_threshold)
+        assert results[0].message == assessment.summary
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_unrouted_board_route_argv_unchanged(self, mock_run, unrouted_pcb: Path):
+        """The audit only runs on the skip path; a re-route keeps the route argv."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+
+        ctx = PipelineContext(pcb_file=unrouted_pcb, quiet=True, voltage_map="vm.json")
+        results = run_pipeline(ctx, [PipelineStep.ROUTE])
+
+        assert results[0].success is True
+        cmd_args = mock_run.call_args[0][0]
+        assert "route" in cmd_args
+        assert "creepage" not in cmd_args
+        # Route-argv spellings, unchanged from #4607.
+        assert cmd_args[cmd_args.index("--creepage-standard") + 1] == "iec60664"
+        assert cmd_args[cmd_args.index("--hv-threshold") + 1] == "30.0"
+        assert "--standard" not in cmd_args
+        assert "--census-threshold" not in cmd_args
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_launch_failure_falls_back_to_refusal(self, mock_run, routed_pcb: Path):
+        """A subprocess that cannot launch falls back to the #4607 refusal."""
+        mock_run.side_effect = FileNotFoundError("python interpreter vanished")
+
+        ctx = PipelineContext(pcb_file=routed_pcb, quiet=True, voltage_map="vm.json")
+        results = run_pipeline(ctx, [PipelineStep.ROUTE, PipelineStep.FIX_DRC])
+
+        assert len(results) == 1
+        assert results[0].success is False
+        assert results[0].skipped is False
+        assert "refusing to skip" in results[0].message
+        assert "kct creepage" in results[0].message
+        assert "--force" in results[0].message
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_dry_run_describes_audit_without_subprocess(self, mock_run, routed_pcb: Path):
+        """Dry-run on the skip path reports the would-be audit and spawns nothing."""
+        from rich.console import Console
+
+        from kicad_tools.cli.pipeline_cmd import _run_step_route
+
+        ctx = PipelineContext(pcb_file=routed_pcb, quiet=True, dry_run=True, voltage_map="vm.json")
+        result = _run_step_route(ctx, Console(quiet=True))
+
+        assert result.success is True
+        assert "[dry-run]" in result.message
+        assert "Would audit existing copper" in result.message
+        assert "kct creepage" in result.message
+        assert "--voltage-map vm.json" in result.message
+        mock_run.assert_not_called()
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_main_exit_0_on_clean_audit(self, mock_run, routed_pcb: Path):
+        """End-to-end: a clean audit lets `kct pipeline --voltage-map` exit 0."""
+        from kicad_tools.cli import pipeline_cmd
+
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+
+        rc = pipeline_cmd.main(
+            [str(routed_pcb), "--step", "route", "--voltage-map", "vm.json", "--quiet"]
+        )
+        assert rc == 0
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_main_exit_1_on_dirty_audit(self, mock_run, routed_pcb: Path):
+        """End-to-end: a dirty audit makes `kct pipeline --voltage-map` exit non-zero."""
+        from kicad_tools.cli import pipeline_cmd
+
+        mock_run.return_value = MagicMock(returncode=1, stderr="", stdout="")
+
+        rc = pipeline_cmd.main(
+            [str(routed_pcb), "--step", "route", "--voltage-map", "vm.json", "--quiet"]
+        )
+        assert rc == 1
+
+
 class TestProjectInput:
     """Tests for .kicad_pro input support."""
 


### PR DESCRIPTION
## Summary

Refines the #4607 loud refusal per the judge-suggested variant: when `kct pipeline --voltage-map` sees a >=95%-routed board (recommend_skip) and no `--force`, the route step now **auto-runs a non-destructive `kct creepage` audit** on the existing copper as the skip gate, instead of refusing and pointing at a manual command. The destructive re-route stays skipped; the route step succeeds iff the audit exits clean, so the pipeline still never reports success on creepage-dirty (or unauditable) copper.

Closes #4649

## Implementation

New helper `_audit_existing_copper_for_skip` in `src/kicad_tools/cli/pipeline_cmd.py`, called from the #4607 branch of `_run_step_route`:

- **Argv**: `[sys.executable, -m, kicad_tools.cli, creepage, <pcb>, --voltage-map, --standard, --pollution-degree, --material-group, --census-threshold]`, cwd `ctx.pcb_file.parent` — mirroring how the route subprocess is spawned. Two flag names deliberately differ from the `kct route` passthrough (`creepage_standard` -> `--standard`, `hv_threshold` -> `--census-threshold`); a comment pins this so the route argv is never copied blindly.
- **Exit-code hazard handled**: the gate is a strict `returncode == 0` via direct `subprocess.run`, deliberately NOT `_run_subprocess_step` (which soft-passes exits 2-5). `kct creepage` exit 2 is `EXIT_HV_UNCLASSIFIED` (#4354 vacuity guard) — under the shared helper it would soft-pass and the skip would proceed on an unauditable board. Exit 2 gets a distinct message ("HV-unclassified ... not a measured-pair failure"); other non-zero exits report a creepage failure, with the last stderr line appended when captured. All failure messages point at the manual `kct creepage ...` command and `--force`.
- **Fallback refusal**: if the subprocess cannot launch (`FileNotFoundError` / any exception), the step fails with the #4607-style refusal message rather than a traceback.
- **Dry-run**: handled inside the new path (the old refusal returned before the dry-run branch could) — reports `[dry-run] Would audit existing copper (skip re-route): kct creepage ...` and spawns nothing.
- Unchanged: no-voltage-map skip (no subprocess, same summary message), forced re-route, and the actual-route exit-3/4 escalation.

## Tests (all 8 curated acceptance criteria)

New `TestRouteSkipCreepageAuditGate` (9 test functions, 12 collected tests) in `tests/test_pipeline_cmd.py`, `TestRouteVoltageMapFatalSplit` style:

1. Audit clean -> `success=True, skipped=True`; argv is `creepage` (not `route`) with `--voltage-map/--standard/--pollution-degree/--material-group/--census-threshold` carrying context values; route-argv spellings must not leak.
2. Audit non-zero (parametrized 1/3/4/5 — pinning strictness against the soft-2-5 helper) -> route step fails; `[ROUTE, FIX_DRC, AUDIT]` stops at ROUTE.
3. Exit 2 (EXIT_HV_UNCLASSIFIED) -> fails, NOT success-with-warnings; message distinguishes vacuity.
4. No voltage map -> no subprocess spawned; skip message byte-identical to the assessment summary.
5. Not-yet-routed board with a map -> route argv unchanged (`--creepage-standard`/`--hv-threshold` spellings, no audit).
6. Launch failure (`FileNotFoundError`) -> refusal-style failure ("refusing to skip", `kct creepage`, `--force`).
7. Dry-run -> success, would-be audit described, no subprocess.
8. Existing `TestRouteVoltageMapFatalSplit` passes unmodified (verified — including the two unmocked skip-path tests, which now exercise a real `kct creepage` subprocess that exits 1 on the missing map file and still satisfy their message/exit assertions).

Plus end-to-end `main()` exit-code tests for clean (0) and dirty (1) audits.

## Validation

- `uv run pytest tests/test_pipeline_cmd.py` — 292 passed (was 280; +12 new, 0 modified)
- `uv run ruff check` / `ruff format --check` — clean on both changed files
- `scripts/ci/check_mypy_baseline.py` — OK, no new type errors (the 2 errors mypy reports in pipeline_cmd.py are pre-existing baselined entries; baseline is line-number-agnostic so no baseline churn)

## Out of scope (follow-up)

The `kct build` extension floated in the issue — `build_cmd.py::_run_step_route` has three pre-existing-routed-artifact skip paths (~1603-1648) plus the Tier 1-3 recipe refusal `_hv_recipe_route_refusal` — is explicitly NOT included, per the curator's scope note. It skips routing (and therefore the audit) when a `*_routed.kicad_pcb` already exists with a voltage map set; that is a larger, separately reviewable change and should be filed as a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

