### PR TITLE
fix(router): tolerate absent-from-stack layer names in net-class-map sidecars (vacuous constraints, #4685)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`kct route --layers 2` no longer rejects a net-class-map whose
+  `avoid_layers` names an inner layer** (#4685) — a well-formed KiCad copper
+  layer name (`F.Cu`, `B.Cu`, `In<k>.Cu`) absent from the ACTIVE stack is now
+  tolerated instead of fatal: `avoid_layers` entries are dropped silently
+  (vacuously satisfied — the grid has no such layer to route on) and
+  `preferred_layers` entries are dropped with a one-line stderr warning naming
+  the net class and token (the preference cannot be honored). This restores
+  layer-subset composition (the HV-outer recipe: route the HV backbone at
+  `--layers 2`, then everything else at `--layers 4 --preserve-existing`) with
+  ONE shared sidecar describing the physical board. The semantics live in the
+  shared resolver (`_resolve_layer_index_list`, threaded per-field from
+  `NetClassRouting.from_dict`), so every consumer — `kct route`'s `--layers`
+  preload and the canonical `net_class_map_from_path` loader used by
+  `check`/`creepage`/`zones`/`audit` — behaves identically. Malformed tokens
+  (`"Bogus.Cu"`), integer indices, and the stack-less resolution path are
+  unchanged (the #4587 typo guard stays loud, integer maps stay
+  byte-identical, and absent names are judged only against a *supplied* stack,
+  never guessed).
+
 - **Board-04: C16 field overlap on the committed schematic** (#4675) — the
   fleet's only genuine `sch_field_overlap` advisory (`C16.Value` text
   overlapping U2's body in `stm32_devboard.kicad_sch`) is resolved by a

--- a/src/kicad_tools/router/rules.py
+++ b/src/kicad_tools/router/rules.py
@@ -7,6 +7,7 @@ This module provides:
 - Predefined net classes for common use cases
 """
 
+import logging
 import re
 from collections.abc import Mapping
 from dataclasses import dataclass, field
@@ -19,6 +20,8 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
     from pathlib import Path
 
     from .pairwise_clearance import PairwiseClearanceTable
+
+logger = logging.getLogger(__name__)
 
 # Allowed values for :attr:`NetClassRouting.route_via`.
 # - ``"pathfinder"`` (default) -- ordinary trace, standard pathfinder routing.
@@ -786,9 +789,13 @@ def resolve_layer_index(
     Raises:
         LayerResolutionError: The value is not one of the accepted forms, names
             a layer absent from ``layer_stack``, or is ``"B.Cu"`` with no stack
-            available.  Never silently dropped: a dropped hard-avoid entry puts
-            an ampacity-bearing net back on a thin inner plane, which is exactly
-            what #4433 exists to prevent.
+            available.  Never silently dropped HERE: a dropped hard-avoid entry
+            puts an ampacity-bearing net back on a thin inner plane, which is
+            exactly what #4433 exists to prevent.  The ONE sanctioned drop path
+            lives in :func:`_resolve_layer_index_list` (#4685): a well-formed
+            KiCad copper name absent from a *supplied* stack may be dropped
+            there (vacuously satisfied during a layer-subset pass) -- that
+            check runs against the active stack, never by guessing indices.
     """
     where = f" ({context})" if context else ""
 
@@ -829,10 +836,25 @@ def resolve_layer_index(
     )
 
 
+def _is_wellformed_copper_layer_name(token: str) -> bool:
+    """True when ``token`` has the shape of a KiCad copper layer name.
+
+    Issue #4685.  These are exactly the shapes :func:`resolve_layer_index`
+    recognizes on its stack-less path (``"F.Cu"``, ``"In<k>.Cu"``) plus
+    ``"B.Cu"``.  A well-formed name that happens to be absent from the ACTIVE
+    stack (``"In1.Cu"`` during a ``--layers 2`` pass) is a valid statement
+    about the physical board, not a typo -- unlike ``"Bogus.Cu"``, which
+    matches none of these shapes and stays a hard error.
+    """
+    return token in ("F.Cu", "B.Cu") or _INNER_COPPER_NAME_RE.match(token) is not None
+
+
 def _resolve_layer_index_list(
     values: object,
     layer_stack: LayerStack | None,
     context: str,
+    *,
+    on_absent: Literal["error", "drop", "drop_warn"] = "error",
 ) -> list[int] | None:
     """Normalize a whole ``preferred_layers`` / ``avoid_layers`` list (#4587).
 
@@ -840,6 +862,29 @@ def _resolve_layer_index_list(
     and hard-avoid paths test for).  Every element is resolved via
     :func:`resolve_layer_index`, so a mixed ``[3, "In1.Cu"]`` list is accepted
     and stored as ``[3, 1]`` -- satisfying the ``list[int]`` field annotation.
+
+    Issue #4685: ``on_absent`` selects the policy for a WELL-FORMED KiCad
+    copper layer name (see :func:`_is_wellformed_copper_layer_name`) that is
+    absent from a *supplied* ``layer_stack`` -- e.g. ``"In1.Cu"`` while
+    routing with ``--layers 2``.  A sidecar describes the physical board, not
+    one invocation's layer subset, so layer-subset composition passes (the
+    HV-outer recipe: route HV at ``--layers 2``, everything else at
+    ``--layers 4 --preserve-existing``) must be able to share one sidecar:
+
+    - ``"error"`` (default): raise :class:`LayerResolutionError`, the pre-#4685
+      behavior.  Kept for any future caller that resolves layers where absence
+      IS a misconfiguration.
+    - ``"drop"``: drop the entry silently -- used for ``avoid_layers``, where
+      an absent layer is vacuously satisfied (the grid cannot route there).
+    - ``"drop_warn"``: drop the entry with a one-line warning naming the
+      owning net class and token -- used for ``preferred_layers``, where the
+      preference genuinely cannot be honored.
+
+    The policy NEVER applies to malformed tokens (``"Bogus.Cu"``), integer
+    indices (in or out of range -- integer maps stay byte-identical per the
+    #4587 contract), or when ``layer_stack`` is ``None`` (guessing an index
+    stack-lessly and then dropping would be a silent wrong answer; the
+    stack-less path is unchanged).
     """
     if values is None:
         return None
@@ -847,7 +892,31 @@ def _resolve_layer_index_list(
         raise LayerResolutionError(
             f"invalid layer list {values!r} ({context}): expected a list of {_ACCEPTED_LAYER_FORMS}"
         )
-    return [resolve_layer_index(v, layer_stack, context=context) for v in values]
+    resolved: list[int] = []
+    for v in values:
+        if on_absent != "error" and layer_stack is not None and isinstance(v, str):
+            token = v.strip()
+            if (
+                not token.lstrip("-").isdigit()
+                and _is_wellformed_copper_layer_name(token)
+                and layer_stack.get_layer_by_name(token) is None
+            ):
+                # Well-formed KiCad copper name, absent from the ACTIVE stack:
+                # the layer is not routable in this pass, so an avoid-constraint
+                # on it is vacuously satisfied and a preference for it cannot
+                # be honored.  Never fatal (#4685).
+                if on_absent == "drop_warn":
+                    logger.warning(
+                        "layer %r (%s) is not present in this board's %d-layer "
+                        "stack; dropping the preference (it cannot be honored "
+                        "in this routing pass)",
+                        v,
+                        context,
+                        layer_stack.num_layers,
+                    )
+                continue
+        resolved.append(resolve_layer_index(v, layer_stack, context=context))
+    return resolved
 
 
 @dataclass
@@ -1492,6 +1561,14 @@ class NetClassRouting:
         ``layer_stack`` to resolve names against the board's actual stackup --
         required for ``"B.Cu"``, whose index depends on the layer count.
 
+        Issue #4685: a well-formed KiCad copper name absent from the supplied
+        stack (``"In1.Cu"`` while routing ``--layers 2``) is NOT fatal: it is
+        dropped -- silently for ``avoid_layers`` (vacuously satisfied: the
+        grid has no such layer to route on) and with a one-line warning for
+        ``preferred_layers`` (the preference cannot be honored).  This lets
+        the two passes of a layer-subset composition recipe share one sidecar.
+        Malformed tokens (``"Bogus.Cu"``) remain fatal.
+
         Round-trip property: see :meth:`to_dict`.  Names normalize to ints on
         the way in and ``to_dict`` emits ints, so the round trip is idempotent.
 
@@ -1532,11 +1609,13 @@ class NetClassRouting:
                 data.get("preferred_layers"),
                 layer_stack,
                 f"net class {data['name']!r} preferred_layers",
+                on_absent="drop_warn",
             ),
             avoid_layers=_resolve_layer_index_list(
                 data.get("avoid_layers"),
                 layer_stack,
                 f"net class {data['name']!r} avoid_layers",
+                on_absent="drop",
             ),
             layer_cost_multiplier=data.get("layer_cost_multiplier", 2.0),
             length_constraint=length_constraint,

--- a/tests/test_cli_route_net_class_map.py
+++ b/tests/test_cli_route_net_class_map.py
@@ -828,6 +828,29 @@ def _run_route_preload(pcb: Path, sidecar: Path, tmp_path: Path, *extra_args: st
     )
 
 
+def _capture_preload(pcb: Path, sidecar: Path, tmp_path: Path, *extra_args: str):
+    """Run the preload with a spy that records the resolved map + stack.
+
+    The spy delegates to the real ``net_class_map_from_dict``, so this is a
+    genuine end-to-end check of the CLI plumbing (stack selection + kwarg
+    forwarding), not a mock of the code under test.
+    """
+    from kicad_tools.router import rules as _rules
+
+    real = _rules.net_class_map_from_dict
+    captured: dict = {}
+
+    def spy(data, layer_stack=None):
+        result = real(data, layer_stack=layer_stack)
+        captured["layer_stack"] = layer_stack
+        captured["map"] = result
+        return result
+
+    with patch.object(_rules, "net_class_map_from_dict", spy):
+        rc = _run_route_preload(pcb, sidecar, tmp_path, *extra_args)
+    return rc, captured
+
+
 class TestLayerNamePreloadResolution:
     """A layer-name sidecar is normalized at preload, before any routing.
 
@@ -838,26 +861,8 @@ class TestLayerNamePreloadResolution:
     """
 
     def _capture_preload(self, pcb: Path, sidecar: Path, tmp_path: Path, *extra_args: str):
-        """Run the preload with a spy that records the resolved map + stack.
-
-        The spy delegates to the real ``net_class_map_from_dict``, so this is a
-        genuine end-to-end check of the CLI plumbing (stack selection + kwarg
-        forwarding), not a mock of the code under test.
-        """
-        from kicad_tools.router import rules as _rules
-
-        real = _rules.net_class_map_from_dict
-        captured: dict = {}
-
-        def spy(data, layer_stack=None):
-            result = real(data, layer_stack=layer_stack)
-            captured["layer_stack"] = layer_stack
-            captured["map"] = result
-            return result
-
-        with patch.object(_rules, "net_class_map_from_dict", spy):
-            rc = _run_route_preload(pcb, sidecar, tmp_path, *extra_args)
-        return rc, captured
+        """See module-level :func:`_capture_preload` (hoisted for #4685 reuse)."""
+        return _capture_preload(pcb, sidecar, tmp_path, *extra_args)
 
     def test_ampacity_class_with_layer_names_does_not_crash(
         self, minimal_pcb_4layer: Path, tmp_path: Path, capsys
@@ -945,19 +950,22 @@ class TestLayerNamePreloadResolution:
         assert "Top" in err  # names the offending value
         assert "PGND" in err  # names the owning net-class key
 
-    def test_layer_absent_from_stack_exits_1(
-        self, minimal_pcb_4layer: Path, tmp_path: Path, capsys
+    def test_wellformed_layer_absent_from_stack_is_dropped(
+        self, minimal_pcb_4layer: Path, tmp_path: Path
     ):
-        """``In3.Cu`` on a 4-layer board is a misconfiguration, not layer 3."""
+        """``In3.Cu`` absent from a 4-layer board is vacuously satisfied (#4685).
+
+        Pre-#4685 this was fatal at preload; a well-formed KiCad copper name
+        that the active stack simply lacks is now dropped, never guessed
+        (``In3.Cu`` must NOT resolve to grid index 3 -- that is B.Cu here).
+        """
         sidecar = tmp_path / "ncm.json"
         sidecar.write_text(json.dumps({"PGND": {"name": "HV", "avoid_layers": ["In3.Cu"]}}))
 
-        rc = _run_route_preload(minimal_pcb_4layer, sidecar, tmp_path)
+        rc, captured = self._capture_preload(minimal_pcb_4layer, sidecar, tmp_path)
 
-        assert rc == 1
-        err = capsys.readouterr().err
-        assert "invalid net-class-map structure" in err
-        assert "In3.Cu" in err
+        assert rc != 1
+        assert captured["map"]["PGND"].avoid_layers == []
 
     def test_integer_sidecar_is_unchanged(self, minimal_pcb_4layer: Path, tmp_path: Path):
         """No-op guard: an integer-valued sidecar preloads exactly as before."""
@@ -977,6 +985,151 @@ class TestLayerNamePreloadResolution:
         _rc, captured = self._capture_preload(minimal_pcb_4layer, sidecar, tmp_path)
         assert captured["map"]["PGND"].preferred_layers == [0, 3]
         assert captured["map"]["PGND"].avoid_layers == [1, 2]
+
+
+# =============================================================================
+# Issue #4685: layer-subset composition -- one sidecar, every --layers subset
+# =============================================================================
+
+
+class TestLayerSubsetComposition:
+    """A sidecar describes the BOARD, not one invocation's layer subset (#4685).
+
+    The HV-outer composition recipe routes the HV backbone at ``--layers 2``
+    (inner layers physically absent, forcing outer copper) and everything else
+    at ``--layers 4 --preserve-existing`` -- both passes sharing ONE sidecar.
+    A well-formed KiCad copper name absent from the ACTIVE stack is therefore
+    tolerated: ``avoid_layers`` entries are vacuously satisfied (dropped
+    silently); ``preferred_layers`` entries cannot be honored (dropped with a
+    one-line warning).  Malformed tokens stay fatal (#4587 typo guard).
+    """
+
+    # The filer's exact sidecar entry shape (softstart rev-C, issue #4685).
+    FILER_ENTRY = {
+        "name": "HV",
+        "preferred_layers": ["F.Cu", "B.Cu"],
+        "avoid_layers": ["In1.Cu", "In2.Cu"],
+        "layer_cost_multiplier": 2.0,
+    }
+
+    def _sidecar(self, tmp_path: Path) -> Path:
+        p = tmp_path / "shared_ncm.json"
+        p.write_text(json.dumps({"PGND": dict(self.FILER_ENTRY)}))
+        return p
+
+    def test_shared_sidecar_loads_at_both_layer_subsets(
+        self, minimal_pcb_4layer: Path, tmp_path: Path
+    ):
+        """The SAME unmodified file preloads at ``--layers 2`` AND ``--layers 4``."""
+        sidecar = self._sidecar(tmp_path)
+
+        rc2, two = _capture_preload(minimal_pcb_4layer, sidecar, tmp_path, "--layers", "2")
+        assert rc2 != 1
+        # Inner layers do not exist in the 2-layer pass: the avoid-constraint
+        # is vacuously satisfied and dropped; F.Cu/B.Cu resolve to 0/1.
+        assert two["map"]["PGND"].avoid_layers == []
+        assert two["map"]["PGND"].preferred_layers == [0, 1]
+
+        rc4, four = _capture_preload(minimal_pcb_4layer, sidecar, tmp_path, "--layers", "4")
+        assert rc4 != 1
+        # On the full stack the identical file resolves completely.
+        assert four["map"]["PGND"].avoid_layers == [1, 2]
+        assert four["map"]["PGND"].preferred_layers == [0, 3]
+
+    def test_avoid_layers_absent_drops_silently(self, tmp_path: Path, caplog):
+        """No warning spam: 52 vacuous avoid entries must not print 52 lines."""
+        import logging
+
+        from kicad_tools.router import LayerStack
+        from kicad_tools.router.rules import net_class_map_from_dict
+
+        with caplog.at_level(logging.DEBUG, logger="kicad_tools.router.rules"):
+            ncm = net_class_map_from_dict(
+                {"PGND": {"name": "HV", "avoid_layers": ["In1.Cu", "In2.Cu"]}},
+                layer_stack=LayerStack.two_layer(),
+            )
+        assert ncm["PGND"].avoid_layers == []
+        assert caplog.records == []
+
+    def test_preferred_layers_absent_warns_and_drops(self, tmp_path: Path, caplog):
+        """The unhonorable preference warns ONCE, naming net class and token."""
+        import logging
+
+        from kicad_tools.router import LayerStack
+        from kicad_tools.router.rules import net_class_map_from_dict
+
+        with caplog.at_level(logging.WARNING, logger="kicad_tools.router.rules"):
+            ncm = net_class_map_from_dict(
+                {"PGND": {"name": "HV", "preferred_layers": ["In1.Cu", "F.Cu"]}},
+                layer_stack=LayerStack.two_layer(),
+            )
+        assert ncm["PGND"].preferred_layers == [0]
+        warnings_ = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings_) == 1
+        message = warnings_[0].getMessage()
+        assert "'In1.Cu'" in message
+        assert "net class 'HV' preferred_layers" in message
+
+    def test_malformed_token_still_fatal_with_stack(
+        self, minimal_pcb_4layer: Path, tmp_path: Path, capsys
+    ):
+        """``Bogus.Cu`` is a typo, not a subset artifact: exit 1 is preserved."""
+        sidecar = tmp_path / "ncm.json"
+        sidecar.write_text(json.dumps({"PGND": {"name": "HV", "avoid_layers": ["Bogus.Cu"]}}))
+
+        rc = _run_route_preload(minimal_pcb_4layer, sidecar, tmp_path, "--layers", "2")
+
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "invalid net-class-map structure" in err
+        assert "Bogus.Cu" in err
+        assert "PGND" in err
+
+    def test_out_of_range_integers_pass_through_unchanged(self, tmp_path: Path):
+        """No new validation on ints: the #4587 byte-identical contract holds."""
+        from kicad_tools.router import LayerStack
+        from kicad_tools.router.rules import net_class_map_from_dict
+
+        ncm = net_class_map_from_dict(
+            {"PGND": {"name": "HV", "avoid_layers": [1, 2], "preferred_layers": [0, 7]}},
+            layer_stack=LayerStack.two_layer(),
+        )
+        assert ncm["PGND"].avoid_layers == [1, 2]
+        assert ncm["PGND"].preferred_layers == [0, 7]
+
+    def test_policy_default_is_still_fatal(self):
+        """Direct list resolution without a policy keeps the #4587 behavior."""
+        from kicad_tools.router import LayerStack
+        from kicad_tools.router.rules import LayerResolutionError, _resolve_layer_index_list
+
+        with pytest.raises(LayerResolutionError, match="In1.Cu"):
+            _resolve_layer_index_list(
+                ["In1.Cu"], LayerStack.two_layer(), "net class 'HV' avoid_layers"
+            )
+
+    def test_stackless_path_is_unchanged(self):
+        """Without a stack there is no ACTIVE subset to judge against: no drops."""
+        from kicad_tools.router.rules import net_class_map_from_dict
+
+        ncm = net_class_map_from_dict(
+            {"PGND": {"name": "HV", "avoid_layers": ["In1.Cu"]}},
+        )
+        # Stack-independent resolution, exactly as before #4685.
+        assert ncm["PGND"].avoid_layers == [1]
+
+    def test_canonical_loader_applies_the_same_semantics(self, tmp_path: Path):
+        """`net_class_map_from_path` + a detected 2-layer stack tolerates inners.
+
+        This is the cross-consumer half of the invariant: ``kct check`` /
+        ``creepage`` / ``zones`` on the 2-layer intermediate board must accept
+        the same sidecar the route passes consume (#4683 + #4685).
+        """
+        from kicad_tools.router.rules import net_class_map_from_path
+
+        sidecar = self._sidecar(tmp_path)
+        ncm = net_class_map_from_path(sidecar, pcb_text=MINIMAL_PCB_2LAYER)
+        assert ncm["PGND"].avoid_layers == []
+        assert ncm["PGND"].preferred_layers == [0, 1]
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

`kct route --layers 2` hard-failed (exit 1, no board written) on any net-class-map whose `avoid_layers` named an inner layer, because the #4587 strict layer-token resolution treated "well-formed KiCad copper name absent from the ACTIVE stack" the same as a typo. A constraint on a layer that does not exist in the routing pass is **vacuously satisfied** — refusing to load the sidecar turned a satisfied constraint into a fatal error and broke the layer-subset (HV-outer) composition recipe, where the `--layers 2` HV pass and the `--layers 4 --preserve-existing` pass must share one sidecar.

## What changed

`_resolve_layer_index_list` (`src/kicad_tools/router/rules.py`) gains an `on_absent: Literal["error","drop","drop_warn"]` policy, applied ONLY when:

- a `layer_stack` is supplied (the ACTIVE subset is known), AND
- the token is a well-formed KiCad copper name (`F.Cu`, `B.Cu`, `In<k>.Cu` — new `_is_wellformed_copper_layer_name` helper), AND
- the stack lacks that layer.

Threaded per-field from `NetClassRouting.from_dict`:

- `avoid_layers` → `"drop"` — silent (vacuously satisfied; no warning spam across 52 entries)
- `preferred_layers` → `"drop_warn"` — one-line `logging` warning naming the net class and token (reaches stderr via the default lastResort handler; verified end-to-end through the CLI)

Because the policy lives in the shared resolver, both the canonical `net_class_map_from_path` loader (#4704: check/creepage/zones/audit) and direct `net_class_map_from_dict` callers (route preload) get identical semantics.

**Explicitly unchanged (per the #4587/#4433 contract):**

- Malformed tokens (`"Bogus.Cu"`, `true`, nested lists) stay a hard `LayerResolutionError` with or without a stack — the #4704 degradation test pair in `tests/test_cli_check_net_class_map.py` passes unmodified.
- Integer indices: no new validation (out-of-range ints pass through, byte-identical).
- The stack-less path never drops — an absent name is judged only against the *supplied* stack, never by guessing indices (`In1.Cu` → 1 would hard-block B.Cu on a 2-layer grid, a silent wrong answer).
- `resolve_layer_index` itself (used at access time by `hard_avoided_layer_indices`) keeps its fatal contract; the sanctioned drop path exists only in the list resolver.

## Repro (filer's shape, `tests/fixtures/routing-diagnostic.kicad_pcb` + sidecar with `avoid_layers: ["In1.Cu","In2.Cu"]`)

Before (main @ e1de0ff7):

```
Error: invalid net-class-map structure: net-class entry 'NET1': layer 'In1.Cu'
(net class 'HV' avoid_layers) is not present in this board's 2-layer stack
(available: ['F.Cu', 'B.Cu'])
exit 1, no output board
```

After: route runs to completion (3 nets routed), output board written, exit 0. The identical unmodified sidecar also resolves fully at `--layers 4` (`avoid_layers == [1, 2]`, `preferred_layers == [0, 3]`).

## Tests

- Replaced `test_layer_absent_from_stack_exits_1` (asserted the old fatal behavior) with `test_wellformed_layer_absent_from_stack_is_dropped` (asserts drop, and that `In3.Cu` is NOT guessed as index 3).
- New `TestLayerSubsetComposition` class (8 tests): shared-sidecar-across-`--layers`-subsets (filer's exact entry shape), avoid-drop-silent (caplog empty at DEBUG), preferred-drop-warn (exactly one warning naming `'HV'` + `'In1.Cu'`), malformed-still-fatal at `--layers 2`, out-of-range-int passthrough, default-policy-still-fatal, stack-less-path-unchanged, canonical-loader-same-semantics (`net_class_map_from_path` + 2-layer `pcb_text`).
- `tests/test_cli_route_net_class_map.py` + `tests/test_cli_check_net_class_map.py`: 105 passed.
- `tests/test_net_class_serialization.py`: 48 passed.
- ruff check/format clean; mypy clean on `rules.py`.

Closes #4685

🤖 Generated with [Claude Code](https://claude.com/claude-code)
