### PR TITLE
fix(lvs): LVS copper leg no longer false-opens on trace endpoints inside pad copper (#4678)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,15 +115,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   contradicting `kct net-status` (strict), `kct route --complete`, and
   `kicad-cli` on the same artifact, and wedging tapeout with a finding no
   flag could waive. A new geometric bonding step (2a3) now ties an endpoint
-  to any pad whose eroded copper box (`POUR_PAD_ERODE` 0.1 mm inset, the
-  same guard as the via-in-pad and pour bonds) contains it — or whose box
-  the trace's rounded end-cap penetrates by > 1 µm — on a shared copper
-  layer, and carries the bond across the whole segment chain. The model
-  stays label-free (no `net_name` reads), an endpoint across a real
-  clearance moat can never fuse (negative test included), and
-  shapely-absent core installs keep the previous behavior. All four
-  connectivity consumers now agree by construction, with no flag
-  discipline required.
+  to any pad whose eroded copper outline (`POUR_PAD_ERODE` 0.1 mm inset, the
+  same guard as the via-in-pad and pour bonds) contains it — or whose
+  outline the trace's rounded end-cap penetrates by > 1 µm — on a shared
+  copper layer, and carries the bond across the whole segment chain. That
+  outline is **shape-aware** (circle → disk, oval → stadium, rect/roundrect
+  → size box): the plain size box over-reaches a round pad's real copper on
+  the diagonals by more than the minimum clearance (0.211 mm on a 1.7 mm
+  header pad), which would let a 45° trace-bend vertex bond across a
+  DRC-legal gap — masking a real open on a same-net trace and minting a
+  phantom short on a foreign one (both directions regression-tested). The
+  model stays label-free (no `net_name` reads), an endpoint across a real
+  clearance moat does not fuse, and shapely-absent core installs keep the
+  previous behavior. All four connectivity consumers now agree by
+  construction, with no flag discipline required.
 
 - **Board-04: C16 field overlap on the committed schematic** (#4675) — the
   fleet's only genuine `sch_field_overlap` advisory (`C16.Value` text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unchanged (the #4587 typo guard stays loud, integer maps stay
   byte-identical, and absent names are judged only against a *supplied* stack,
   never guessed).
+- **LVS copper leg no longer reports a false `open` when a trace endpoint
+  lands inside pad copper but off the pad center** (#4678) — the copper
+  partition extractor (`ConnectivityValidator.extract_pad_partition`, the
+  primitive behind `kct check`'s LVS copper leg, `lvs/recipe.py`, and
+  tapeout Gate 1) only bonded a track endpoint to a pad whose *center* was
+  within the legacy 0.01 mm proximity tolerance, so a trace legally
+  terminating inside a pad's copper but away from its center stranded the
+  pad into its own island and surfaced as an unoverridable `open` —
+  contradicting `kct net-status` (strict), `kct route --complete`, and
+  `kicad-cli` on the same artifact, and wedging tapeout with a finding no
+  flag could waive. A new geometric bonding step (2a3) now ties an endpoint
+  to any pad whose eroded copper box (`POUR_PAD_ERODE` 0.1 mm inset, the
+  same guard as the via-in-pad and pour bonds) contains it — or whose box
+  the trace's rounded end-cap penetrates by > 1 µm — on a shared copper
+  layer, and carries the bond across the whole segment chain. The model
+  stays label-free (no `net_name` reads), an endpoint across a real
+  clearance moat can never fuse (negative test included), and
+  shapely-absent core installs keep the previous behavior. All four
+  connectivity consumers now agree by construction, with no flag
+  discipline required.
 
 - **Board-04: C16 field overlap on the committed schematic** (#4675) — the
   fleet's only genuine `sch_field_overlap` advisory (`C16.Value` text

--- a/src/kicad_tools/validate/connectivity.py
+++ b/src/kicad_tools/validate/connectivity.py
@@ -777,6 +777,29 @@ class ConnectivityValidator:
                     ):
                         _connect(node_id, pad_id)
 
+        # 2a3. Geometric endpoint-in-pad-copper bonding (issue #4678).  Step
+        #      2a only bonds a segment endpoint to a pad whose *center* is
+        #      within ``POSITION_TOLERANCE`` (0.01 mm) of the endpoint.  A
+        #      trace that legally terminates inside a pad's copper but away
+        #      from the pad center — routers do this routinely on wide pads —
+        #      was invisible to that test, stranding the pad in its own
+        #      component and surfacing as a false LVS ``open`` that no flag
+        #      could override (the tapeout Gate 1 wedge).  Bond an endpoint
+        #      to any pad whose *eroded* copper box contains it (or whose
+        #      eroded box the endpoint's swept trace cap, radius ``width/2``,
+        #      penetrates) on a shared copper layer.  The
+        #      ``POUR_PAD_ERODE`` inset plus the ``> 1 µm`` cap-penetration
+        #      guard mirror steps 2c2 / 2a2: copper across a real clearance
+        #      moat (≥ 0.1 mm on any DRC-clean board) can never fuse, so this
+        #      only adds true galvanic contact — an endpoint physically inside
+        #      pad copper IS connected, exactly as kicad-cli and the strict
+        #      net-status model report it.  Bonds are injected via
+        #      ``segment_extra_nodes`` so the chain builder (2b) carries them
+        #      across the whole segment chain.  Requires shapely; core-only
+        #      installs keep the legacy center-proximity behavior.
+        if _has_shapely():
+            self._connect_endpoint_in_pad(segments, pad_layers, segment_extra_nodes)
+
         # 2b. Segment chains: pads connected through a chain of segments that
         #     share endpoints are galvanically connected even with no pad at
         #     the intermediate junctions.  Reuse the existing chain builder,
@@ -1671,6 +1694,111 @@ class ConnectivityValidator:
                 return eroded
         return circle
 
+    def _eroded_pad_polygons(self) -> dict[str, Any]:
+        """Board-frame eroded copper polygon per pad (``"REF.PAD"`` keys).
+
+        Shared geometry cache for the via-in-pad (2c2) and endpoint-in-pad
+        (2a3) bonding steps: each pad's :meth:`_pad_copper_polygon` (size box,
+        footprint-rotated, ``POUR_PAD_ERODE`` inset).  Pads without a numeric
+        number / real reference are skipped, matching
+        :meth:`extract_pad_partition` step 1.  Requires shapely (returns
+        point geometries / ``None`` entries are filtered out).
+        """
+        pad_polygons: dict[str, Any] = {}
+        for fp in self.pcb.footprints:
+            if not fp.reference or fp.reference.startswith("#"):
+                continue
+            for pad in fp.pads:
+                if pad.number is None or pad.number == "":
+                    continue
+                poly = self._pad_copper_polygon(fp, pad)
+                if poly is not None:
+                    pad_polygons[f"{fp.reference}.{pad.number}"] = poly
+        return pad_polygons
+
+    def _connect_endpoint_in_pad(
+        self,
+        segments: list,
+        pad_layers: dict[str, list[str]],
+        segment_extra_nodes: dict[int, set[str]],
+    ) -> None:
+        """Bond segment endpoints landing inside pad copper (issue #4678).
+
+        A track endpoint that lies inside a pad's copper is galvanic contact
+        with that pad — KiCad's own connectivity, ``kct net-status`` (strict)
+        and ``kct route --complete`` all treat it as connected.  The legacy
+        center-proximity test (step 2a, ``POSITION_TOLERANCE`` = 0.01 mm from
+        the pad *center*) missed it, so the LVS copper leg reported a false
+        ``open`` that blocked tapeout Gate 1 with no override.
+
+        Bond condition (conservative by construction):
+
+        * shared copper layer — the pad's copper must exist on the segment's
+          layer (``*.Cu`` through-hole pads match any copper layer), and
+        * the endpoint lies inside the pad's **eroded** copper box
+          (:meth:`_pad_copper_polygon`, ``POUR_PAD_ERODE`` = 0.1 mm inset), or
+          the endpoint's swept trace end-cap (KiCad tracks have rounded ends
+          of radius ``width / 2``) penetrates that eroded box by **more than
+          1 µm** (the step-2a2 strictly-positive contact-depth guard).
+
+        The 0.1 mm erosion exceeds the box-vs-true-shape approximation error
+        (roundrect/oval corner rounding), and DRC clearance keeps any
+        *foreign* trace's copper ≥ 0.1 mm away from pad copper — its endpoint
+        centerline sits a further ``width / 2`` (end-cap radius) beyond that —
+        so an endpoint across a real clearance moat can NEVER bond.  Only
+        true copper contact is added; no false-short path is introduced.
+
+        Bonds are recorded in ``segment_extra_nodes`` (segment index → node
+        ids), which :meth:`_build_segment_chains` unions into the segment's
+        chain component — so the pad joins every pad reachable through the
+        chain, exactly like the 2a2 via-barrel bonds.  Requires ``shapely``
+        (guarded by the caller); shapely-absent installs keep the legacy
+        center-proximity behavior.
+        """
+        pad_polygons = self._eroded_pad_polygons()
+        if not pad_polygons:
+            return
+
+        # Cheap bounding prefilter: skip the shapely test unless the endpoint
+        # is within the pad box's half-diagonal plus the trace end-cap radius
+        # of the pad center.  Uses the *uneroded* box bound, so it can only
+        # over-admit (the exact eroded test below decides), never miss.
+        pad_bounds: dict[str, tuple[float, float, float]] = {}
+        for fp in self.pcb.footprints:
+            if not fp.reference or fp.reference.startswith("#"):
+                continue
+            for pad in fp.pads:
+                if pad.number is None or pad.number == "":
+                    continue
+                pad_id = f"{fp.reference}.{pad.number}"
+                if pad_id not in pad_polygons:
+                    continue
+                cx, cy = self._transform_pad_position(
+                    pad.position, fp.position[0], fp.position[1], fp.rotation
+                )
+                w, h = pad.size
+                pad_bounds[pad_id] = (cx, cy, math.hypot(w, h) / 2.0)
+
+        for seg_index, seg in enumerate(segments):
+            cap_radius = max((seg.width or 0.0) / 2.0, 0.0)
+            for endpoint in (seg.start, seg.end):
+                ex, ey = endpoint
+                point = _ShapelyPoint(endpoint)
+                for pad_id, (cx, cy, bound) in pad_bounds.items():
+                    reach = bound + cap_radius
+                    dx, dy = ex - cx, ey - cy
+                    if dx * dx + dy * dy > reach * reach:
+                        continue
+                    # Layer gate: the pad's copper must exist on the
+                    # segment's layer for the trace metal to touch it.
+                    if not self._pad_copper_on_layer(pad_layers.get(pad_id, []), seg.layer):
+                        continue
+                    dist = pad_polygons[pad_id].distance(point)
+                    # Inside the eroded box (dist == 0), or the trace end-cap
+                    # penetrates it by > 1 µm (strictly positive contact).
+                    if dist == 0.0 or dist < cap_radius - 1e-3:
+                        segment_extra_nodes.setdefault(seg_index, set()).add(pad_id)
+
     def _connect_via_in_pad(
         self,
         pad_positions: dict[str, tuple[float, float]],
@@ -1697,16 +1825,7 @@ class ConnectivityValidator:
         drops.  Requires ``shapely`` (guarded by the caller).
         """
         # Board-frame eroded copper box per pad.
-        pad_polygons: dict[str, Any] = {}
-        for fp in self.pcb.footprints:
-            if not fp.reference or fp.reference.startswith("#"):
-                continue
-            for pad in fp.pads:
-                if pad.number is None or pad.number == "":
-                    continue
-                poly = self._pad_copper_polygon(fp, pad)
-                if poly is not None:
-                    pad_polygons[f"{fp.reference}.{pad.number}"] = poly
+        pad_polygons = self._eroded_pad_polygons()
 
         for node_id in synthetic_nodes:
             pos = pad_positions.get(node_id)

--- a/src/kicad_tools/validate/connectivity.py
+++ b/src/kicad_tools/validate/connectivity.py
@@ -39,7 +39,8 @@ if TYPE_CHECKING:
 from kicad_tools._shapely import has_shapely as _has_shapely
 
 if _has_shapely():  # pragma: no cover - import guard exercised by environment
-    from shapely.geometry import Point as _ShapelyPoint  # type: ignore[import-untyped]
+    from shapely.geometry import LineString as _ShapelyLineString  # type: ignore[import-untyped]
+    from shapely.geometry import Point as _ShapelyPoint
     from shapely.geometry import Polygon as _ShapelyPolygon
 
 
@@ -1585,7 +1586,7 @@ class ConnectivityValidator:
     # line) keeps a non-empty eroded overlap.  Verified on boards 00/03/05.
     POUR_PAD_ERODE: float = 0.1
 
-    def _pad_copper_polygon(self, fp: Any, pad: Any) -> Any | None:
+    def _pad_copper_polygon(self, fp: Any, pad: Any, shape_aware: bool = False) -> Any | None:
         """Build a board-frame shapely polygon approximating a pad's copper.
 
         The pad's ``size`` box is rotated by the footprint rotation (KiCad's
@@ -1602,6 +1603,24 @@ class ConnectivityValidator:
         into a foreign pour (which would manufacture a false short).  A pad
         fully moated out (clearance all around, no spoke) stays clear of the
         solid region and is correctly left untied.
+
+        ``shape_aware=True`` replaces the size box with the pad's actual
+        outline family *before* eroding — ``circle`` → a disk of radius
+        ``min(w, h) / 2``, ``oval`` → a stadium (the centerline of the longer
+        local axis buffered by ``min(w, h) / 2``), everything else
+        (``rect`` / ``roundrect`` / ``custom`` / unknown) → the same box as
+        before.  This matters because the box **over-reaches real copper on
+        the diagonals** of a round pad: for a circle of diameter ``d`` the
+        eroded box corner sits ``(d / 2 − POUR_PAD_ERODE)·√2`` from the
+        center, which exceeds the true copper radius ``d / 2`` by more than
+        the 0.1016 mm minimum clearance once ``d ≳ 1.2 mm`` (0.211 mm of
+        over-reach on a 1.7 mm header pad).  Any *distance-to-copper* test
+        against that phantom corner can bond across a legal clearance moat.
+        See :meth:`_connect_endpoint_in_pad` for the failure this guards.
+
+        The shape-aware outline is inscribed in the same rotated size box, so
+        it is always a **subset** of the box geometry: enabling it can only
+        make a bond test stricter, never looser.
 
         Returns ``None`` when shapely is unavailable.  Falls back to a
         zero-area point geometry when the pad has no positive size.
@@ -1620,16 +1639,37 @@ class ConnectivityValidator:
         # rotation maps the pad's local box into the board frame.
         a = math.radians(-fp.rotation)
         cos_a, sin_a = math.cos(a), math.sin(a)
-        corners = [(-w / 2, -h / 2), (w / 2, -h / 2), (w / 2, h / 2), (-w / 2, h / 2)]
-        pts = [(cx + ox * cos_a - oy * sin_a, cy + ox * sin_a + oy * cos_a) for ox, oy in corners]
-        box = _ShapelyPolygon(pts)
+
+        def _to_board(ox: float, oy: float) -> tuple[float, float]:
+            return (cx + ox * cos_a - oy * sin_a, cy + ox * sin_a + oy * cos_a)
+
+        shape = (getattr(pad, "shape", "") or "").lower() if shape_aware else ""
+        base: Any
+        if shape in ("circle", "oval"):
+            radius = min(w, h) / 2.0
+            # Stadium half-length: 0 for a circle (and for a "square" oval,
+            # which KiCad renders as a circle), positive for a true oval.
+            half = abs(w - h) / 2.0
+            if half <= 0.0:
+                base = _ShapelyPoint((cx, cy)).buffer(radius)
+            else:
+                ends = [(-half, 0.0), (half, 0.0)] if w >= h else [(0.0, -half), (0.0, half)]
+                base = _ShapelyLineString([_to_board(*e) for e in ends]).buffer(radius)
+        else:
+            corners = [(-w / 2, -h / 2), (w / 2, -h / 2), (w / 2, h / 2), (-w / 2, h / 2)]
+            base = _ShapelyPolygon([_to_board(*c) for c in corners])
         if self.POUR_PAD_ERODE > 0:
-            eroded = box.buffer(-self.POUR_PAD_ERODE)
-            # Erosion can empty a very small pad; keep the original box so the
-            # pad is still testable rather than silently dropped.
+            eroded = base.buffer(-self.POUR_PAD_ERODE)
+            # Erosion can empty a very small pad (min dimension <= 0.2 mm);
+            # keep the un-eroded outline so the pad is still testable rather
+            # than silently dropped.  That collapses the erosion margin for
+            # such pads, but the box-vs-true-copper excess is then bounded by
+            # the half-diagonal of a <= 0.2 mm box (< 0.042 mm) — under any
+            # realistic minimum clearance — so no DRC-clean false connect can
+            # slip through the un-eroded fallback either.
             if not eroded.is_empty:
                 return eroded
-        return box
+        return base
 
     @staticmethod
     def _fill_solid_region(points: list[tuple[float, float]]) -> Any | None:
@@ -1694,15 +1734,25 @@ class ConnectivityValidator:
                 return eroded
         return circle
 
-    def _eroded_pad_polygons(self) -> dict[str, Any]:
+    def _eroded_pad_polygons(self, shape_aware: bool = False) -> dict[str, Any]:
         """Board-frame eroded copper polygon per pad (``"REF.PAD"`` keys).
 
         Shared geometry cache for the via-in-pad (2c2) and endpoint-in-pad
-        (2a3) bonding steps: each pad's :meth:`_pad_copper_polygon` (size box,
-        footprint-rotated, ``POUR_PAD_ERODE`` inset).  Pads without a numeric
+        (2a3) bonding steps: each pad's :meth:`_pad_copper_polygon`
+        (footprint-rotated, ``POUR_PAD_ERODE`` inset).  Pads without a numeric
         number / real reference are skipped, matching
         :meth:`extract_pad_partition` step 1.  Requires shapely (returns
         point geometries / ``None`` entries are filtered out).
+
+        ``shape_aware`` is forwarded to :meth:`_pad_copper_polygon`: step 2a3
+        passes ``True`` (it measures *distance* to pad copper from arbitrary
+        trace-bend vertices, where the box's diagonal over-reach on round pads
+        is a real false-connect hazard); steps 2c2/2d keep the historical box
+        (``False``) — they test via centers / pour solid regions, whose
+        exposure to the corner zone is negligible, and the
+        :data:`POUR_PAD_ERODE` constant was empirically tuned against the box
+        on boards 00/03/05.  Keeping them on the box preserves the
+        zero-fixture-churn property of this change.
         """
         pad_polygons: dict[str, Any] = {}
         for fp in self.pcb.footprints:
@@ -1711,7 +1761,7 @@ class ConnectivityValidator:
             for pad in fp.pads:
                 if pad.number is None or pad.number == "":
                     continue
-                poly = self._pad_copper_polygon(fp, pad)
+                poly = self._pad_copper_polygon(fp, pad, shape_aware=shape_aware)
                 if poly is not None:
                     pad_polygons[f"{fp.reference}.{pad.number}"] = poly
         return pad_polygons
@@ -1735,18 +1785,39 @@ class ConnectivityValidator:
 
         * shared copper layer — the pad's copper must exist on the segment's
           layer (``*.Cu`` through-hole pads match any copper layer), and
-        * the endpoint lies inside the pad's **eroded** copper box
-          (:meth:`_pad_copper_polygon`, ``POUR_PAD_ERODE`` = 0.1 mm inset), or
-          the endpoint's swept trace end-cap (KiCad tracks have rounded ends
-          of radius ``width / 2``) penetrates that eroded box by **more than
-          1 µm** (the step-2a2 strictly-positive contact-depth guard).
+        * the endpoint lies inside the pad's **eroded, shape-aware** copper
+          outline (:meth:`_pad_copper_polygon` with ``shape_aware=True``:
+          circle → disk, oval → stadium, rect/roundrect → size box, each
+          inset by ``POUR_PAD_ERODE`` = 0.1 mm), or the endpoint's swept
+          trace end-cap (KiCad tracks have rounded ends of radius
+          ``width / 2``) penetrates that eroded outline by **more than 1 µm**
+          (the step-2a2 strictly-positive contact-depth guard).
 
-        The 0.1 mm erosion exceeds the box-vs-true-shape approximation error
-        (roundrect/oval corner rounding), and DRC clearance keeps any
-        *foreign* trace's copper ≥ 0.1 mm away from pad copper — its endpoint
-        centerline sits a further ``width / 2`` (end-cap radius) beyond that —
-        so an endpoint across a real clearance moat can NEVER bond.  Only
-        true copper contact is added; no false-short path is introduced.
+        Soundness (and why the geometry must be shape-aware).  This step
+        measures a *distance* from an arbitrary trace vertex to the pad
+        polygon, so the polygon has to be contained in the pad's real copper
+        in **every** direction, not just on axis.  The plain size box is not:
+        for a circle pad of diameter ``d`` its eroded corner sticks out to
+        ``(d / 2 − 0.1)·√2``, over-reaching true copper by more than the
+        0.1016 mm minimum clearance for any ``d ≳ 1.2 mm`` (0.211 mm on a
+        1.7 mm header pad).  Against that phantom corner a 45° endpoint at a
+        DRC-legal 0.13–0.21 mm copper gap measured ``dist == 0`` and bonded —
+        masking a real open on a same-net trace, and minting a phantom short
+        on a foreign one.  Both directions were reproduced on DRC-clean
+        geometry (PR #4710 review) and are now regression-tested.
+
+        With the shape-aware outline the eroded polygon is contained in the
+        true copper with ≥ 0.1 mm of margin **in every direction** (rect and
+        roundrect are exact-or-inside by construction; circle/oval are the
+        true outline inset by 0.1 mm).  DRC clearance keeps a *foreign*
+        trace's copper ≥ 0.1016 mm from that copper, and its endpoint
+        centerline sits a further ``width / 2`` (end-cap radius) beyond the
+        copper edge, so the measured distance stays above ``width / 2`` and
+        the bond does not fire.  The claim is therefore scoped, not absolute:
+        it holds for the pad-shape families modelled here, and a ``custom``
+        (polygon-primitive) pad still falls back to the size box — such a pad
+        can in principle over-reach on a concave outline, which is a known,
+        documented approximation rather than a soundness proof.
 
         Bonds are recorded in ``segment_extra_nodes`` (segment index → node
         ids), which :meth:`_build_segment_chains` unions into the segment's
@@ -1755,14 +1826,19 @@ class ConnectivityValidator:
         (guarded by the caller); shapely-absent installs keep the legacy
         center-proximity behavior.
         """
-        pad_polygons = self._eroded_pad_polygons()
+        # Shape-aware geometry (circle -> disk, oval -> stadium, rect /
+        # roundrect -> box): this step measures distance from arbitrary trace
+        # vertices, so the box's diagonal over-reach on round pads would bond
+        # across a legal clearance moat (see the soundness note above).
+        pad_polygons = self._eroded_pad_polygons(shape_aware=True)
         if not pad_polygons:
             return
 
         # Cheap bounding prefilter: skip the shapely test unless the endpoint
         # is within the pad box's half-diagonal plus the trace end-cap radius
-        # of the pad center.  Uses the *uneroded* box bound, so it can only
-        # over-admit (the exact eroded test below decides), never miss.
+        # of the pad center.  Uses the *uneroded box* bound — a superset of
+        # every shape-aware outline — so it can only over-admit (the exact
+        # eroded test below decides), never miss.
         pad_bounds: dict[str, tuple[float, float, float]] = {}
         for fp in self.pcb.footprints:
             if not fp.reference or fp.reference.startswith("#"):
@@ -1794,8 +1870,9 @@ class ConnectivityValidator:
                     if not self._pad_copper_on_layer(pad_layers.get(pad_id, []), seg.layer):
                         continue
                     dist = pad_polygons[pad_id].distance(point)
-                    # Inside the eroded box (dist == 0), or the trace end-cap
-                    # penetrates it by > 1 µm (strictly positive contact).
+                    # Inside the eroded outline (dist == 0), or the trace
+                    # end-cap penetrates it by > 1 µm (strictly positive
+                    # contact depth).
                     if dist == 0.0 or dist < cap_radius - 1e-3:
                         segment_extra_nodes.setdefault(seg_index, set()).add(pad_id)
 
@@ -1823,6 +1900,15 @@ class ConnectivityValidator:
         pad's copper (clearance forbids it), so this cannot manufacture a
         false short; it only recovers a real via-in-pad bond the centre test
         drops.  Requires ``shapely`` (guarded by the caller).
+
+        This step deliberately keeps the plain **box** approximation (it does
+        not pass ``shape_aware=True``, unlike step 2a3): it is a containment
+        test on a via *centre point*, not a distance measurement from an
+        arbitrary vertex, and a via centre landing in a round pad's phantom
+        corner zone would have to sit outside the pad's real copper entirely —
+        a DRC violation on a foreign net.  Staying on the box also preserves
+        the empirically-tuned :data:`POUR_PAD_ERODE` behaviour on boards
+        00/03/05.
         """
         # Board-frame eroded copper box per pad.
         pad_polygons = self._eroded_pad_polygons()

--- a/tests/test_copper_lvs.py
+++ b/tests/test_copper_lvs.py
@@ -1961,3 +1961,167 @@ def test_unnamed_net_fixture_kct_check_lvs_line_passes() -> None:
     )
     assert sub.status == "PASSED", f"LVS line: {sub.status} ({sub.detail})"
     assert sub.detail == "label + copper: 0 mismatch(es)"
+
+
+# ---------------------------------------------------------------------------
+# Endpoint-in-pad-copper bonding (issue #4678)
+# ---------------------------------------------------------------------------
+#
+# The legacy endpoint->pad bond required the segment endpoint to sit within
+# POSITION_TOLERANCE (0.01 mm) of the pad *center*.  A trace legally ending
+# inside pad copper but off-center stranded the pad -> a false LVS ``open``
+# that no flag could override (the tapeout Gate 1 wedge).  Step 2a3 bonds an
+# endpoint that lies inside the pad's eroded copper box (or whose trace
+# end-cap penetrates it by > 1 um) on a shared copper layer.
+
+
+def _pcb_endpoint_in_pad(
+    trace_end: tuple[float, float],
+    *,
+    trace_layer: str = "F.Cu",
+    width: float = 0.25,
+) -> str:
+    """Two-pad board: R1.1 (1x1 mm pad at 100,100) and R2.1 (at 110,100).
+
+    A single trace runs from R2.1's center to ``trace_end``.  With the
+    default geometry the endpoint lands *inside* R1.1's copper (box x in
+    [99.5, 100.5]) but 0.3 mm from the pad center — far beyond the legacy
+    0.01 mm center-proximity tolerance.
+    """
+    ex, ey = trace_end
+    return f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "SIG")
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000f1")
+    (at 100 100)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "fp-f1-ref"))
+    (property "Value" "1k" (at 0 1.5 0) (layer "F.Fab") (uuid "fp-f1-val"))
+    (pad "1" smd roundrect (at 0 0) (size 1 1) (layers "F.Cu" "F.Paste" "F.Mask")
+      (roundrect_rratio 0.25) (net 1 "SIG"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000f2")
+    (at 110 100)
+    (property "Reference" "R2" (at 0 -1.5 0) (layer "F.SilkS") (uuid "fp-f2-ref"))
+    (property "Value" "1k" (at 0 1.5 0) (layer "F.Fab") (uuid "fp-f2-val"))
+    (pad "1" smd roundrect (at 0 0) (size 1 1) (layers "F.Cu" "F.Paste" "F.Mask")
+      (roundrect_rratio 0.25) (net 1 "SIG"))
+  )
+  (segment (start 110 100) (end {ex} {ey}) (width {width}) (layer "{trace_layer}") (net 1)
+    (uuid "00000000-0000-0000-0000-0000000000f3"))
+)
+"""
+
+
+_ENDPOINT_SCHEMATIC: dict[tuple[str, str], str | None] = {
+    ("R1", "1"): "SIG",
+    ("R2", "1"): "SIG",
+}
+
+
+@requires_shapely
+def test_endpoint_inside_pad_copper_off_center_bonds(tmp_path: Path) -> None:
+    """Repro of the #4678 false open: endpoint in pad copper, off-center.
+
+    The trace ends at (100.3, 100) — inside R1.1's 1x1 mm copper box but
+    0.3 mm from the pad center (30x the legacy tolerance).  The pads must
+    land in ONE component: this is real galvanic contact, and kicad-cli,
+    ``kct net-status`` (strict) and ``kct route --complete`` all agree.
+    """
+    pcb_path = _write(tmp_path, "b.kicad_pcb", _pcb_endpoint_in_pad((100.3, 100.0)))
+    partition = ConnectivityValidator(pcb_path).extract_pad_partition()
+    assert frozenset({"R1.1", "R2.1"}) in partition, f"partition={partition}"
+    assert len(partition) == 1
+
+
+@requires_shapely
+def test_endpoint_in_pad_lvs_leg_reports_connected(tmp_path: Path) -> None:
+    """The LVS copper diff is CLEAN on the #4678 repro (no false open)."""
+    pcb_path = _write(tmp_path, "b.kicad_pcb", _pcb_endpoint_in_pad((100.3, 100.0)))
+    partition = ConnectivityValidator(pcb_path).extract_pad_partition()
+    result = compare_partitions(_ENDPOINT_SCHEMATIC, partition)
+    assert result.clean, f"expected clean LVS, got {result.mismatches}"
+
+
+@requires_shapely
+def test_endpoint_outside_pad_across_clearance_gap_does_not_bond(
+    tmp_path: Path,
+) -> None:
+    """Negative guard: an endpoint across a clearance moat must NOT bond.
+
+    The trace ends at (100.75, 100): R1.1's copper edge is at x=100.5, the
+    0.25 mm-wide trace's end-cap reaches back to x=100.625, leaving a
+    0.125 mm copper-to-copper clearance gap.  Bonding here would fabricate
+    a connection across legal clearance — masking real opens (and, with a
+    foreign net, minting false connects).  SIG must stay split (a real open).
+    """
+    pcb_path = _write(tmp_path, "b.kicad_pcb", _pcb_endpoint_in_pad((100.75, 100.0)))
+    partition = ConnectivityValidator(pcb_path).extract_pad_partition()
+    assert frozenset({"R1.1"}) in partition, f"partition={partition}"
+    result = compare_partitions(_ENDPOINT_SCHEMATIC, partition)
+    assert not result.clean
+    assert any(m.net_a == "SIG" for m in result.opens)
+
+
+@requires_shapely
+def test_endpoint_in_pad_layer_gate_preserved(tmp_path: Path) -> None:
+    """A B.Cu trace ending under an F.Cu-only pad's copper must NOT bond.
+
+    Preserves the softstart false-short fix: XY overlap across disjoint
+    copper layers is not a connection — a trace may legally run (and end)
+    directly under an SMD pad on another layer.
+    """
+    pcb_path = _write(
+        tmp_path,
+        "b.kicad_pcb",
+        _pcb_endpoint_in_pad((100.3, 100.0), trace_layer="B.Cu"),
+    )
+    partition = ConnectivityValidator(pcb_path).extract_pad_partition()
+    assert frozenset({"R1.1"}) in partition, f"partition={partition}"
+
+
+def test_endpoint_in_pad_shapely_absent_falls_back_to_legacy(tmp_path: Path) -> None:
+    """Core-only installs (no shapely) keep the legacy behavior, no crash."""
+    from unittest import mock
+
+    pcb_path = _write(tmp_path, "b.kicad_pcb", _pcb_endpoint_in_pad((100.3, 100.0)))
+    with mock.patch("kicad_tools.validate.connectivity._has_shapely", return_value=False):
+        partition = ConnectivityValidator(pcb_path).extract_pad_partition()
+    # Legacy center-proximity model: the off-center endpoint does not bond,
+    # so the pads stay split (the historical false open) — but nothing raises.
+    assert frozenset({"R1.1"}) in partition
+    assert frozenset({"R2.1"}) in partition
+
+
+@requires_shapely
+def test_endpoint_in_pad_bond_carries_across_segment_chain(tmp_path: Path) -> None:
+    """The 2a3 bond joins the pad to the WHOLE chain, not just one segment.
+
+    R2.1 -> corner -> (100.3, 100) via two chained segments: the endpoint-in-
+    pad bond on the second segment must connect R1.1 to R2.1 through the
+    chain component (the ``segment_extra_nodes`` plumbing, mirroring 2a2).
+    """
+    pcb = _pcb_endpoint_in_pad((100.3, 100.0))
+    # Replace the single segment with a two-segment chain through a corner.
+    pcb = pcb.replace(
+        '  (segment (start 110 100) (end 100.3 100.0) (width 0.25) (layer "F.Cu") (net 1)\n'
+        '    (uuid "00000000-0000-0000-0000-0000000000f3"))\n',
+        '  (segment (start 110 100) (end 105 95) (width 0.25) (layer "F.Cu") (net 1)\n'
+        '    (uuid "00000000-0000-0000-0000-0000000000f3"))\n'
+        '  (segment (start 105 95) (end 100.3 100.0) (width 0.25) (layer "F.Cu") (net 1)\n'
+        '    (uuid "00000000-0000-0000-0000-0000000000f4"))\n',
+    )
+    assert "(end 105 95)" in pcb, "chain rewrite did not apply"
+    pcb_path = _write(tmp_path, "b.kicad_pcb", pcb)
+    partition = ConnectivityValidator(pcb_path).extract_pad_partition()
+    assert frozenset({"R1.1", "R2.1"}) in partition, f"partition={partition}"

--- a/tests/test_copper_lvs.py
+++ b/tests/test_copper_lvs.py
@@ -2125,3 +2125,185 @@ def test_endpoint_in_pad_bond_carries_across_segment_chain(tmp_path: Path) -> No
     pcb_path = _write(tmp_path, "b.kicad_pcb", pcb)
     partition = ConnectivityValidator(pcb_path).extract_pad_partition()
     assert frozenset({"R1.1", "R2.1"}) in partition, f"partition={partition}"
+
+
+# ---------------------------------------------------------------------------
+# Diagonal near-miss on a ROUND pad (PR #4710 review counterexamples)
+# ---------------------------------------------------------------------------
+#
+# Modelling a pad by its size box over-reaches real copper on the diagonals:
+# for a circle of diameter d the eroded box corner sits (d/2 - 0.1)*sqrt(2)
+# from the center, i.e. 0.211 mm past the true copper edge on a 1.7 mm header
+# pad — more than the 0.1016 mm minimum clearance.  A trace endpoint (step 2a3
+# tests EVERY segment endpoint, including 45-degree bend vertices) landing in
+# that phantom corner zone measured ``dist == 0`` and bonded at DRC-clean
+# copper gaps up to ~0.21 mm.  Both dangerous directions are pinned below;
+# the fix is the shape-aware pad outline (circle -> disk, oval -> stadium).
+
+_DIAG = 0.7071067811865476  # cos(45 deg) = sin(45 deg)
+
+
+def _pcb_diagonal_near_miss_round_pad(
+    gap: float,
+    *,
+    trace_net: int = 1,
+    pad_shape: str = "circle",
+    pad_size: tuple[float, float] = (1.7, 1.7),
+    width: float = 0.25,
+) -> str:
+    """Round THT pad J1.1 (net SIG) with a trace bending past it at 45 deg.
+
+    ``J1`` is a ``pad_shape`` / ``pad_size`` through-hole pad at (100, 100);
+    ``R9.1`` is a distant pad.  The trace's bend vertex sits on the
+    45-degree diagonal at exactly ``gap`` mm of copper-to-copper clearance
+    from the pad's TRUE copper outline: for a circle the outline radius is
+    ``min(size) / 2`` about the center; for an oval it is the same radius
+    about the nearer stadium end-cap center (``(w - h) / 2`` along the long
+    axis).  The vertex is placed ``radius + gap + width / 2`` from that
+    center, so the trace's own rounded end-cap (radius ``width / 2``) stops
+    ``gap`` mm short of the copper.  With ``gap > 0.1016`` the board is
+    DRC-clean, so NO bond may ever fire; with ``gap < 0`` the end-cap is
+    genuinely inside the pad copper and the bond MUST fire.
+
+    ``trace_net`` selects the direction of the hazard: net 1 (``SIG``, the
+    pad's own net) reproduces the *masked real open*; net 2 (``OTHER``)
+    reproduces the *phantom short*.
+    """
+    w, h = pad_size
+    radius = min(w, h) / 2.0
+    # Anchor: the stadium end-cap center the diagonal radiates from (the pad
+    # center itself for a circle, where the two coincide).
+    ax = 100.0 + abs(w - h) / 2.0 if w >= h else 100.0
+    ay = 100.0 if w >= h else 100.0 + abs(w - h) / 2.0
+    reach = radius + gap + width / 2.0
+    vx = ax + reach * _DIAG
+    vy = ay + reach * _DIAG
+    pad_diameter = f"{w} {h}"
+    net_name = "SIG" if trace_net == 1 else "OTHER"
+    return f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "SIG")
+  (net 2 "OTHER")
+  (footprint "Connector:PinHeader_1x01"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000d1")
+    (at 100 100)
+    (property "Reference" "J1" (at 0 -1.5 0) (layer "F.SilkS") (uuid "fp-d1-ref"))
+    (property "Value" "Conn" (at 0 1.5 0) (layer "F.Fab") (uuid "fp-d1-val"))
+    (pad "1" thru_hole {pad_shape} (at 0 0) (size {pad_diameter}) (drill 1.0)
+      (layers "*.Cu" "*.Mask") (net 1 "SIG"))
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-0000000000d2")
+    (at 110 110)
+    (property "Reference" "R9" (at 0 -1.5 0) (layer "F.SilkS") (uuid "fp-d2-ref"))
+    (property "Value" "1k" (at 0 1.5 0) (layer "F.Fab") (uuid "fp-d2-val"))
+    (pad "1" smd roundrect (at 0 0) (size 1 1) (layers "F.Cu" "F.Paste" "F.Mask")
+      (roundrect_rratio 0.25) (net {trace_net} "{net_name}"))
+  )
+  (segment (start 110 110) (end {vx:.6f} {vy:.6f}) (width {width}) (layer "F.Cu")
+    (net {trace_net}) (uuid "00000000-0000-0000-0000-0000000000d3"))
+)
+"""
+
+
+_DIAG_SCHEMATIC_SAME_NET: dict[tuple[str, str], str | None] = {
+    ("J1", "1"): "SIG",
+    ("R9", "1"): "SIG",
+}
+
+_DIAG_SCHEMATIC_FOREIGN_NET: dict[tuple[str, str], str | None] = {
+    ("J1", "1"): "SIG",
+    ("R9", "1"): "OTHER",
+}
+
+
+@requires_shapely
+def test_diagonal_near_miss_round_pad_same_net_stays_open(tmp_path: Path) -> None:
+    """A 0.13 mm diagonal copper gap on a 1.7 mm round pad must stay OPEN.
+
+    PR #4710 review counterexample 1 (the silent one): the box model bonded
+    ``{J1.1, R9.1}`` here and reported a CLEAN LVS diff, masking a genuine
+    open that kicad-cli and strict ``kct net-status`` both flag.  The gap is
+    DRC-clean (0.13 mm > 0.1016 mm), so the endpoint is NOT in copper.
+    """
+    pcb_path = _write(tmp_path, "b.kicad_pcb", _pcb_diagonal_near_miss_round_pad(0.13, trace_net=1))
+    partition = ConnectivityValidator(pcb_path).extract_pad_partition()
+    assert frozenset({"J1.1"}) in partition, f"partition={partition}"
+    result = compare_partitions(_DIAG_SCHEMATIC_SAME_NET, partition)
+    assert not result.clean, "0.13 mm diagonal gap must remain a real open"
+    assert any(m.net_a == "SIG" for m in result.opens)
+
+
+@requires_shapely
+def test_diagonal_near_miss_round_pad_foreign_net_no_phantom_short(
+    tmp_path: Path,
+) -> None:
+    """A foreign-net trace bending past at 0.15 mm must NOT merge the pad.
+
+    PR #4710 review counterexample 2 (the loud one, and the mirror image of
+    the #4678 defect): the box model fused ``J1.1`` (SIG) with ``R9.1``
+    (OTHER) across a DRC-legal 0.15 mm clearance gap, so the LVS leg reported
+    a short that does not exist and would wedge a clean board.
+    """
+    pcb_path = _write(tmp_path, "b.kicad_pcb", _pcb_diagonal_near_miss_round_pad(0.15, trace_net=2))
+    partition = ConnectivityValidator(pcb_path).extract_pad_partition()
+    assert frozenset({"J1.1"}) in partition, f"partition={partition}"
+    assert not any({"J1.1", "R9.1"} <= set(component) for component in partition), (
+        f"phantom short: partition={partition}"
+    )
+    result = compare_partitions(_DIAG_SCHEMATIC_FOREIGN_NET, partition)
+    assert not result.shorts, f"phantom short reported: {result.shorts}"
+
+
+@requires_shapely
+def test_diagonal_endpoint_inside_round_pad_copper_still_bonds(tmp_path: Path) -> None:
+    """The shape-aware outline must not over-shrink: real contact still bonds.
+
+    Same 45-degree diagonal geometry, but the endpoint is driven 0.3 mm
+    *inside* the round pad's copper (negative gap) — genuine galvanic
+    contact, exactly the #4678 case the 2a3 step exists to recover.
+    """
+    pcb_path = _write(tmp_path, "b.kicad_pcb", _pcb_diagonal_near_miss_round_pad(-0.3, trace_net=1))
+    partition = ConnectivityValidator(pcb_path).extract_pad_partition()
+    assert frozenset({"J1.1", "R9.1"}) in partition, f"partition={partition}"
+    result = compare_partitions(_DIAG_SCHEMATIC_SAME_NET, partition)
+    assert result.clean, f"expected clean LVS, got {result.mismatches}"
+
+
+@requires_shapely
+def test_diagonal_near_miss_oval_pad_stays_open(tmp_path: Path) -> None:
+    """The same phantom-corner hazard exists on OVAL pads (stadium model).
+
+    A 2.6 x 1.8 mm oval THT pad's eroded box corner sits at (1.2, 0.8) from
+    center, 0.231 mm past the true stadium copper — well over min clearance.
+    The endpoint here has a DRC-clean 0.13 mm gap to the real outline yet
+    lands inside the eroded box, so the box model bonded it.
+    """
+    pcb_path = _write(
+        tmp_path,
+        "b.kicad_pcb",
+        _pcb_diagonal_near_miss_round_pad(0.13, trace_net=1, pad_shape="oval", pad_size=(2.6, 1.8)),
+    )
+    partition = ConnectivityValidator(pcb_path).extract_pad_partition()
+    assert frozenset({"J1.1"}) in partition, f"partition={partition}"
+
+
+@requires_shapely
+def test_endpoint_inside_oval_pad_copper_still_bonds(tmp_path: Path) -> None:
+    """Stadium erosion must not over-shrink: real oval-pad contact bonds."""
+    pcb_path = _write(
+        tmp_path,
+        "b.kicad_pcb",
+        _pcb_diagonal_near_miss_round_pad(-0.3, trace_net=1, pad_shape="oval", pad_size=(2.6, 1.8)),
+    )
+    partition = ConnectivityValidator(pcb_path).extract_pad_partition()
+    assert frozenset({"J1.1", "R9.1"}) in partition, f"partition={partition}"


### PR DESCRIPTION
## Summary

Fixes the false LVS `open` that blocked tapeout Gate 1 with no override (#4678, the chorus `DAC_CLK` repro): `kct check`'s LVS copper leg now agrees with `kct net-status` (strict), `kct route --complete`, and `kicad-cli` **by construction** when a trace endpoint lands inside pad copper but off the pad center.

This implements the curator's **Option A** (fix `extract_pad_partition` itself) rather than Option B (thread `--strict-connectivity` into `_lvs_subcheck`), so:

- default `kct check`, `lvs/recipe.py` → `boards/*/output/lvs.json`, and tapeout Gate 1 are all fixed with **no flag discipline**, and
- the flag's DRC-rule meaning stays untangled from any LVS meaning ahead of #4673 (which remains out of scope, per curation — as is the merged #4557 net-status default).

## Root cause

`ConnectivityValidator.extract_pad_partition` (the label-free primitive behind `compare_copper_netlist`) bonded a track-segment endpoint to a pad only when the endpoint was within `POSITION_TOLERANCE = 0.01 mm` of the pad **center** (`_find_pads_at_point` → `_points_close`). A trace legally terminating inside pad copper but >10 µm off-center stranded the pad into its own copper component → `compare_partitions` reported a false `open`. `--strict-connectivity` never reached the LVS leg at all.

## Fix

New step **2a3** in `extract_pad_partition` (`src/kicad_tools/validate/connectivity.py`), mirroring the established geometric-bonding pattern of 2c2 (via-in-pad) and 2d (pour bonding):

- Bond a segment endpoint to any pad whose **eroded** copper box (`_pad_copper_polygon`, `POUR_PAD_ERODE` 0.1 mm inset) contains it — or whose eroded box the trace's rounded end-cap (radius `width/2`) penetrates by **> 1 µm** (the step-2a2 strictly-positive contact-depth guard) — on a **shared copper layer**.
- Bonds are injected via `segment_extra_nodes`, so `_build_segment_chains` carries them across the whole chain (exactly like the 2a2 via-barrel bonds).
- Cheap bounding prefilter (pad half-diagonal + cap radius) keeps the shapely tests rare.
- Refactor: the inline pad-polygon build in `_connect_via_in_pad` is extracted into a shared `_eroded_pad_polygons()` helper (no behavior change).

### Soundness argument (why no over-bonding / masked shorts)

- The 0.1 mm erosion exceeds the box-vs-true-shape approximation error (roundrect/oval corner rounding), and DRC clearance keeps any foreign trace's *copper* ≥ 0.1 mm from pad copper — its endpoint centerline sits a further `width/2` (end-cap radius) beyond that. So an endpoint across a real clearance moat can never bond; the width term in the bond condition is exactly cancelled by the width term in the clearance geometry.
- Label-free property preserved: no pad/zone `net_name` reads were added.
- Layer gate preserved: a B.Cu trace ending under an F.Cu-only SMD pad does NOT bond (softstart false-short fix holds).
- shapely-absent core installs skip 2a3 and keep the legacy behavior (same degradation contract as 2c2/2d).

## Acceptance criteria (from curation)

- [x] Repro class fixed: endpoint inside pad copper, 0.3 mm (30× tolerance) from center → connected (`test_endpoint_inside_pad_copper_off_center_bonds`, `test_endpoint_in_pad_lvs_leg_reports_connected`)
- [x] Negative guard: endpoint across a 0.125 mm copper-to-copper clearance gap does NOT bond (`test_endpoint_outside_pad_across_clearance_gap_does_not_bond`)
- [x] LVS leg clean by default (Option A — no flag needed)
- [x] Label-free property preserved (no `net_name` reads added)
- [x] shapely-absent fallback, no import errors (`test_endpoint_in_pad_shapely_absent_falls_back_to_legacy`)
- [x] Board baselines pass **unchanged** — no baseline churn at all: `test_board_03_copper_lvs.py`, `test_board_04_copper_lvs.py`, `test_ci_check_copper_lvs.py` all green as-is
- Bonus: chain-carry test (`test_endpoint_in_pad_bond_carries_across_segment_chain`) and layer-gate test (`test_endpoint_in_pad_layer_gate_preserved`)

## Testing

- `tests/test_copper_lvs.py` (incl. 6 new tests + the pour-heavy board-07 artifact test, run serially): **passed**
- `tests/test_connectivity.py`, `tests/test_connectivity_rule.py`, `tests/test_board_03_copper_lvs.py`, `tests/test_board_04_copper_lvs.py`, `tests/test_ci_check_copper_lvs.py`, `tests/test_softstart_canonical.py`: **194 passed, 1 skipped** (softstart local-only skip)
- `tests/test_cli_check.py`, `tests/test_connectivity_reachability_4165.py`: **91 passed**
- net-status suites (strict model shares the extractor): `test_analysis_net_status.py`, `test_check_net_status.py`, `test_net_status_cmd.py`, `test_net_status_strict.py`, `test_net_status.py`: **180 passed**
- `ruff check` + `ruff format --check` clean on changed files
- Baseline-gated mypy (`scripts/ci/check_mypy_baseline.py`): **no new errors** (1472 ≤ 1474 baseline; the "2 stale baseline lines" warning is pre-existing and left alone per the native-env `--update` trap)

## Follow-up: shape-aware pad geometry (PR review round 1, commit `438076c1`)

The first revision modelled every pad as its **size box** in step 2a3. The
review falsified the soundness claim for **round** pads: for a circle of
diameter `d` the eroded box corner reaches `(d/2 - 0.1)*sqrt(2)` from center,
over-reaching real copper by more than the 0.1016 mm minimum clearance for any
`d >~ 1.2 mm` (0.211 mm on a 1.7 mm header pad). Because 2a3 measures a
*distance* from **every** segment endpoint (including 45-degree bend vertices,
which routers place beside THT pads at min clearance routinely), an endpoint in
that phantom corner measured `dist == 0` and bonded across a DRC-legal gap — in
both dangerous directions (masked real open at 0.13 mm same-net; phantom short
at 0.15 mm foreign-net).

**Approach chosen: a shape-aware *variant*, opted into by 2a3 only** —
`_pad_copper_polygon(fp, pad, shape_aware=True)` (plumbed through
`_eroded_pad_polygons(shape_aware=...)`): `circle` -> disk of `min(w,h)/2`,
`oval` -> stadium (long-axis centerline buffered by `min(w,h)/2`),
`rect`/`roundrect`/`custom`/unknown -> the historical size box.

*Why the variant rather than fixing `_pad_copper_polygon` outright:*

- Steps **2c2** (via-in-pad) and **2d** (pour solids) keep the box. 2c2 is a
  *containment* test on a via **centre point** — a centre in a round pad's
  phantom corner is outside real copper entirely, i.e. already a DRC violation
  on a foreign net — and 2d tests pour solid regions, whose overlap with the
  corner zone is negligible (the judge's own assessment).
- `POUR_PAD_ERODE = 0.1` was empirically **tuned against the box** on boards
  00/03/05 (thermal-spoke ties vs. corner grazes). Shrinking the geometry under
  2c2/2d would re-open that tuning and put the zero-fixture-churn property at
  risk for no soundness gain.
- The shape-aware outline is inscribed in the same rotated size box, so it is
  always a **subset** of the box: opting a step in can only make its bond test
  stricter, never looser.

The 2a3 soundness prose is corrected accordingly — the guarantee is now stated
as **scoped to the modelled shape families** (a `custom` polygon-primitive pad
still falls back to the box and remains a documented approximation), not the
absolute "can NEVER fuse" the review falsified. The `< 0.2 mm` un-eroded
fallback in `_pad_copper_polygon` also got the requested one-line rationale.

**New regression tests** (`tests/test_copper_lvs.py`):

- `test_diagonal_near_miss_round_pad_same_net_stays_open` — counterexample 1
  (0.13 mm diagonal gap, 1.7 mm circle THT pad) must remain a real `open`
- `test_diagonal_near_miss_round_pad_foreign_net_no_phantom_short` —
  counterexample 2 (0.15 mm foreign-net pass-by) must not merge the partition
- `test_diagonal_near_miss_oval_pad_stays_open` — same hazard on a 2.6x1.8 oval
- `test_diagonal_endpoint_inside_round_pad_copper_still_bonds` /
  `test_endpoint_inside_oval_pad_copper_still_bonds` — positive controls: real
  diagonal contact (0.3 mm inside copper) must still bond, i.e. the erosion
  does not over-shrink

All five fail on the box model and pass shape-aware; the original #4678 repro
(`test_endpoint_inside_pad_copper_off_center_bonds`) is unchanged and still
green. Zero fixture churn holds: board 03/04/ci-check baselines still pass
**unmodified**.

Closes #4678

🤖 Generated with [Claude Code](https://claude.com/claude-code)

