### PR TITLE
test(lattice): re-pin softstart proofs to current fixture + sha256 drift guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Softstart lattice proofs: re-pin to the current fixture + content-hash
+  drift guard** (#4670) — the local-only softstart routing proof
+  (`tests/router/lattice/test_softstart_routing.py`) failed at its topology
+  pre-assertion because the external fixture moved (softstart PR #26 NRST
+  star-break rework grew the anchor-star topology 287 → 295 connections).
+  The proof is re-pinned to the current artifact (softstart commit
+  `7800b04`) with re-measured completion floors, and both softstart lattice
+  test modules now pin the board file by sha256 via a shared
+  `tests/router/lattice/softstart_fixture.py` helper: fixture absent → skip
+  (unchanged CI semantics), fixture present but hash-mismatched → skip with
+  a message naming the pinned and observed hashes plus the re-pin
+  procedure, so future external drift reads as a self-explanatory skip
+  instead of a confusing assert failure. Test-only; CI never runs these
+  modules (the fixture symlink dangles there by design).
+
 - **`kct route --layers 2` no longer rejects a net-class-map whose
   `avoid_layers` names an inner layer** (#4685) — a well-formed KiCad copper
   layer name (`F.Cu`, `B.Cu`, `In<k>.Cu`) absent from the ACTIVE stack is now

--- a/tests/router/lattice/softstart_fixture.py
+++ b/tests/router/lattice/softstart_fixture.py
@@ -1,0 +1,58 @@
+"""Shared softstart rev-C fixture pinning for the lattice proofs (issue #4670).
+
+``boards/external/softstart`` is a local-only relative symlink to a sibling
+checkout of the external softstart repo; it dangles in CI and in fresh
+worktrees, so both softstart lattice proof modules skip when the board file
+is absent.
+
+Because the fixture lives in an *external* repo, it can drift underneath the
+pinned assertions (issue #4670: the NRST star-break rework, softstart PR #26,
+grew the anchor-star topology 287 -> 295 connections and the old pin failed
+with a bare topology assert).  To convert that confusing failure into a
+self-explanatory skip, the board artifact is pinned by content hash: present
+but hash-mismatched -> skip with a message naming both hashes.
+
+Re-pin procedure (when the softstart board legitimately moves):
+
+1. Update ``FIXTURE_SHA256`` below (``shasum -a 256 <board>``).
+2. Re-measure the routing proof (``pytest -s
+   tests/router/lattice/test_softstart_routing.py``) and update its topology
+   count and floors from the printed census.
+3. Re-run ``test_softstart_memory.py`` and refresh its narrative if the
+   board outline changed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[3]
+SOFTSTART_DIR = _REPO / "boards/external/softstart/output_revc"
+SOFTSTART_BOARD = SOFTSTART_DIR / "softstart_revc.kicad_pcb"
+SIDECAR = SOFTSTART_DIR / "net_class_map.json"
+
+# Content hash of the pinned board artifact (softstart commit 7800b04,
+# measured 2026-08-07).  A content hash beats a git sha because the symlink
+# target need not be a git checkout -- the artifact, not the repo state, is
+# what the proofs are pinned to.
+FIXTURE_SHA256 = "87ebe3af1bd36bde47bc6566d8b0bd9f970ef6183f51b2903ae08e790950beea"
+
+
+def fixture_skip_reason() -> str | None:
+    """Why the softstart proofs must skip, or ``None`` to run them.
+
+    Absent fixture (CI, fresh worktrees) and drifted fixture (newer local
+    softstart) both SKIP -- an external repo moving must never red this
+    suite; the pin's job is to make the drift self-explanatory.
+    """
+    if not SOFTSTART_BOARD.exists():
+        return "local-only softstart fixture absent"
+    actual = hashlib.sha256(SOFTSTART_BOARD.read_bytes()).hexdigest()
+    if actual != FIXTURE_SHA256:
+        return (
+            f"softstart fixture drifted: pinned sha256 {FIXTURE_SHA256}, "
+            f"observed {actual} -- re-pin the proofs per the procedure in "
+            f"tests/router/lattice/softstart_fixture.py (issue #4670)"
+        )
+    return None

--- a/tests/router/lattice/test_softstart_memory.py
+++ b/tests/router/lattice/test_softstart_memory.py
@@ -8,26 +8,33 @@ this is the substrate-size proof only.
 
 The board is a local-only external fixture (``boards/external/softstart``
 is a symlink that dangles in CI and fresh worktrees), so the test skips
-cleanly when it is absent -- exactly like the chorus fixtures.
+cleanly when it is absent -- exactly like the chorus fixtures.  The
+artifact is additionally pinned by content hash (``softstart_fixture``,
+issue #4670): a drifted fixture skips with an explicit message.  Verified
+against softstart commit 7800b04 (2026-08-07): the outline is still
+160x100 mm after the PR-#26 NRST star-break rework, so the #4267 P0 grid
+baseline below remains the right denominator.
 """
 
 from __future__ import annotations
-
-from pathlib import Path
 
 import pytest
 
 from kicad_tools.router.lattice.pathfinder import LatticePathfinder
 from kicad_tools.router.layers import LayerStack
 
-_REPO = Path(__file__).resolve().parents[3]
-_SOFTSTART = _REPO / "boards/external/softstart/output_revc/softstart_revc.kicad_pcb"
+from .softstart_fixture import SOFTSTART_BOARD as _SOFTSTART
+from .softstart_fixture import fixture_skip_reason
 
 _GRID_BYTES = 1.14e9  # measured grid footprint for softstart rev-C (#4267 P0)
 _BUDGET = 0.05  # "<= ~5 % of the grid" (issue #4278 acceptance 5)
 
+# Skip when the local-only fixture is absent (CI, fresh worktrees) OR when it
+# has drifted from the pinned content hash -- see softstart_fixture (#4670).
+_SKIP_REASON = fixture_skip_reason()
 
-@pytest.mark.skipif(not _SOFTSTART.exists(), reason="local-only softstart fixture absent")
+
+@pytest.mark.skipif(_SKIP_REASON is not None, reason=_SKIP_REASON or "")
 def test_softstart_revc_lattice_memory_under_five_percent_of_grid() -> None:
     text = _SOFTSTART.read_text()
     pf = LatticePathfinder.from_board(text, layer_stack=LayerStack.four_layer_all_signal())

--- a/tests/router/lattice/test_softstart_routing.py
+++ b/tests/router/lattice/test_softstart_routing.py
@@ -8,11 +8,17 @@ at its true 2.6mm width.
 
 The board is a local-only external fixture (``boards/external/softstart``
 is a symlink that dangles in CI and fresh worktrees), so the whole module
-skips cleanly when it is absent -- exactly like the memory test.
+skips cleanly when it is absent -- exactly like the memory test.  The
+artifact is additionally pinned by content hash (``softstart_fixture``,
+issue #4670): a drifted fixture skips with an explicit message instead of
+failing the topology assert.
 
-Assertions (pinned to the measured 2026-07-16 P4 verdict; see #4271):
+Assertions (re-pinned 2026-08-07 against softstart commit 7800b04, after
+the NRST star-break rework -- softstart PR #26, R30/R31 -- grew the
+anchor-star topology 287 -> 295 connections; issue #4670.  Original P4
+verdict 2026-07-16, #4271):
 
-1. ``lattice_builds == 1`` at 287-connection scale (static substrate).
+1. ``lattice_builds == 1`` at 295-connection scale (static substrate).
 2. Zero cross-net short in the emitted copper (the #3906 invariant checked
    pairwise at the per-class copper gap).
 3. Completion >= the measured floor.
@@ -29,7 +35,6 @@ from __future__ import annotations
 
 import json
 from collections import defaultdict
-from pathlib import Path
 
 import pytest
 
@@ -39,27 +44,34 @@ from kicad_tools.router.layers import LayerStack
 from kicad_tools.router.primitives import Pad
 from kicad_tools.router.rules import DesignRules, NetClassRouting
 
-_REPO = Path(__file__).resolve().parents[3]
-_SOFTSTART_DIR = _REPO / "boards/external/softstart/output_revc"
-_SOFTSTART = _SOFTSTART_DIR / "softstart_revc.kicad_pcb"
-_SIDECAR = _SOFTSTART_DIR / "net_class_map.json"
-
-# Measured floors -- pinned from the 2026-07-17 #4293 P4 re-measurement
-# (deterministic negotiation; measured 273/287 connections and 66/79 nets
-# fully connected at max_iterations=2, declines {no-path: 13,
-# pad-escape-end: 1}).  RAISED from the #4271 floors (255/55, measured
-# 267/63) because the oversize neck-down escape (#4293) converted 6 of the 7
-# pad-escape-end declines: the 2.6 mm HV_HICUR nets that could not exit the
-# dense fuse/terminal pad fields now escape at a legal neck and widen back to
-# the class width at the first lattice node.  Floors sit below the new
-# measurement for stability but above the #4271 reality, so a regression to
-# either the pre-#4293 or the epic floor (>= 40/79 nets) fails loudly.
-_CONNECTION_FLOOR = 265
-_NET_FLOOR = 60
-
-pytestmark = pytest.mark.skipif(
-    not _SOFTSTART.exists(), reason="local-only softstart fixture absent"
+from .softstart_fixture import (
+    SIDECAR as _SIDECAR,
 )
+from .softstart_fixture import (
+    SOFTSTART_BOARD as _SOFTSTART,
+)
+from .softstart_fixture import (
+    fixture_skip_reason,
+)
+
+# Measured floors -- re-pinned 2026-08-07 (#4670) against the 295-connection
+# fixture (softstart commit 7800b04, post-PR-#26 NRST star-break rework):
+# deterministic negotiation measured 288/295 connections and 78/84 nets
+# fully connected at max_iterations=2, declines {pad-escape-end: 1,
+# no-path: 6}.  History: the 2026-07-17 #4293 P4 re-measurement on the
+# 287-connection board was 273/287 and 66/79 (floors 265/60), itself RAISED
+# from the #4271 floors (255/55) when the oversize neck-down escape (#4293)
+# converted 6 of the 7 pad-escape-end declines.  Floors sit below the
+# current measurement for stability (same margins as the #4293 pin: 8
+# connections, 6 nets) but above the historical reality, so a regression to
+# the pre-#4293 or the epic floor (>= 40 nets) fails loudly.
+_CONNECTION_FLOOR = 280
+_NET_FLOOR = 72
+
+# Skip when the local-only fixture is absent (CI, fresh worktrees) OR when it
+# has drifted from the pinned content hash -- see softstart_fixture (#4670).
+_SKIP_REASON = fixture_skip_reason()
+pytestmark = pytest.mark.skipif(_SKIP_REASON is not None, reason=_SKIP_REASON or "")
 
 
 def _load_connections() -> tuple[list, dict[int, str], dict[str, NetClassRouting]]:
@@ -101,7 +113,7 @@ def _load_connections() -> tuple[list, dict[int, str], dict[str, NetClassRouting
 
 def test_softstart_lattice_routing_proof() -> None:
     conns, name_by_net, class_by_name = _load_connections()
-    assert len(conns) == 287, "anchor-star topology of the rev-C fixture"
+    assert len(conns) == 295, "anchor-star topology of the rev-C fixture (pinned, #4670)"
 
     pf = LatticePathfinder.from_board(
         _SOFTSTART.read_text(),


### PR DESCRIPTION
## Summary

Fixes the local-only softstart lattice routing proof, which failed at its topology
pre-assertion (`len(conns) == 287`, got 295) because the **external** softstart
fixture moved underneath the pin: the NRST star-break rework (softstart PR #26,
R30/R31) grew the anchor-star topology 287 -> 295 connections. Per the curated
spec (option 2 + one-time re-pin):

- **New shared helper `tests/router/lattice/softstart_fixture.py`**: pins the
  board artifact by **content hash** (sha256 of `softstart_revc.kicad_pcb` =
  `87ebe3af1bd36bde47bc6566d8b0bd9f970ef6183f51b2903ae08e790950beea`,
  softstart commit `7800b04`, both fixture files clean at that HEAD).
  `fixture_skip_reason()` returns:
  - fixture absent -> `"local-only softstart fixture absent"` (unchanged CI-skip
    semantics — CI and fresh worktrees keep skipping exactly as before);
  - present but hash mismatch -> **skip, not fail**, with a reason naming the
    pinned hash, the observed hash, and the re-pin procedure (documented in the
    helper's docstring);
  - match -> run.
- **`test_softstart_routing.py`**: topology re-pinned to 295; floors re-measured
  against the current fixture and raised `_CONNECTION_FLOOR` 265 -> **280**,
  `_NET_FLOOR` 60 -> **72** (same margins as the #4293 pin: 8 connections /
  6 nets below the measurement); docstring/comment narrative updated with the
  drift event, dates, and the floor history.
- **`test_softstart_memory.py`**: same hash guard via the shared helper.
  Verified the outline is **still 160x100 mm** at softstart `7800b04` (measured
  Edge.Cuts bbox: 160.0 x 100.0 mm), so the `_GRID_BYTES = 1.14e9` denominator
  narrative remains correct; the docstring records this verification. (The
  curation note suggesting the outline might now be 150x100 does not apply to
  this artifact.)
- CHANGELOG Unreleased entry.

## Measured values (2026-08-07, softstart `7800b04`, C++ backend built)

| Quantity | Old pin | Measured now | New pin |
|---|---|---|---|
| Anchor-star connections | 287 | **295** | `== 295` |
| Connections routed (max_iterations=2) | 273/287 | **288/295** | floor 280 |
| Nets fully connected | 66/79 | **78/84** | floor 72 |
| Declines | no-path 13, pad-escape-end 1 | **no-path 6, pad-escape-end 1** | — |

## CI note

These modules are **CI-skipped by design** — `boards/external/softstart` is a
local-only relative symlink that dangles on runners and in fresh worktrees, so
CI cannot exercise any of this. Acceptance evidence is the local run below
(issue worktree with the symlink resolving and `kct build-native` done).

## Local run output (acceptance evidence)

Full measurement run (`pytest tests/router/lattice/test_softstart_routing.py
tests/router/lattice/test_softstart_memory.py -s --no-cov -q`):

```
[softstart proof] connections 288/295 iterations=2 converged=False declines={'pad-escape-end': 1, 'no-path': 6}
[softstart proof] nets fully connected: 78/84
..
2 passed in 3345.11s (0:55:45)
```

That run used the final topology pin (295) and hash guard; the only edit after
it was raising the two floor constants to 280/72, which the deterministic
measurement above satisfies (288 >= 280, 78 >= 72). Post-edit fast sanity:
memory test re-run standalone (`1 passed in 8.78s`) and topology re-checked via
the module loader (`conns: 295, floors: 280 72, skip: None`).

## Skip-path verification

Hash mismatch (pin temporarily corrupted, then restored):

```
SKIPPED [1] tests/router/lattice/test_softstart_routing.py:114: softstart fixture drifted: pinned sha256 00000000...beea, observed 87ebe3af...beea -- re-pin the proofs per the procedure in tests/router/lattice/softstart_fixture.py (issue #4670)
SKIPPED [1] tests/router/lattice/test_softstart_memory.py:37: (same)
2 skipped in 0.54s
```

Fixture absent (board path temporarily nonexistent, then restored):

```
SKIPPED [1] tests/router/lattice/test_softstart_routing.py:114: local-only softstart fixture absent
SKIPPED [1] tests/router/lattice/test_softstart_memory.py:37: local-only softstart fixture absent
2 skipped in 0.51s
```

`ruff check` + `ruff format --check` clean on all three files. No changes
outside the two test modules + the shared helper + CHANGELOG. The committed
`boards/external/softstart` symlink is untouched (measurement ran via a
gitignored sibling link in `.loom/worktrees/`, outside the git tree).

Closes #4670
