### PR TITLE
feat(router): lattice keepout follow-ups — *.In.Cu wildcard, unknown-zone warning, pair-leg-keepout coverage (#4672)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   voltage map, forced re-routes, and the actual-route exit-3/4 escalation
   are byte-identical to before.
 
+- **Lattice keepout rule areas: `*.In.Cu` wildcard + unknown-zone-name
+  warning + pair-leg decline coverage** (#4672, the #4605 review follow-ups)
+  — the `*.In.Cu` layer spec on a keepout rule area now resolves to every
+  inner copper layer of the routing stack (previously it was silently
+  dropped, leaving multilayer boards unprotected on inner layers; on a
+  2-layer stack it correctly resolves to the empty set). A
+  `spatial_keepouts` sidecar entry naming a nonexistent rule-area zone now
+  emits a stderr warning listing the known zone names (with a distinct
+  message when the name matches a pour-void-only area that never constrains
+  routing, e.g. `kct zones hv-keepout` output); exit code is unchanged. The
+  previously untested `pair-leg-keepout` finish-gate decline (a fat coupled
+  pair whose emitted leg would enter a rule area declines and emits
+  nothing) now has direct test coverage. No behavior change for well-formed
+  inputs.
+
 - **Local CI-equivalent gate script as an Actions-outage backstop** (#4671)
   — new `scripts/ci/local-gate.sh` mirrors the `.github/workflows/ci.yml`
   job set locally: `--cheap` (default) runs the six cheap gates,

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -2749,6 +2749,40 @@ class Autorouter:
             and (not zone.keepout.tracks_allowed or not zone.keepout.vias_allowed)
             and len(zone.polygon) >= 3
         ]
+
+        # Issue #4672: a ``spatial_keepouts`` entry naming a nonexistent zone
+        # is conservative (the filter is simply never consulted) but a typo'd
+        # zone name would silently drop a per-class narrowing -- warn, naming
+        # the entry and the known rule-area zone names.  A key matching a rule
+        # area that was FILTERED OUT of ``raw_areas`` (a pour-void-only area,
+        # the ``kct zones hv-keepout`` output, or a <3-point polygon) gets a
+        # distinct message: that zone exists but never constrains routing.
+        filters = self._spatial_keepout_filters or {}
+        if filters:
+            import sys as _sys
+
+            kept_names = {zone.name for zone in raw_areas if zone.name}
+            all_names = {zone.name for zone in pcb.rule_areas if zone.name}
+            for key in sorted(filters):
+                if key in kept_names:
+                    continue
+                if key in all_names:
+                    print(
+                        f"Warning: spatial_keepouts entry {key!r} matches a rule "
+                        "area that does not block tracks or vias (e.g. a "
+                        "'kct zones hv-keepout' pour void); it will not "
+                        "constrain routing.",
+                        file=_sys.stderr,
+                    )
+                else:
+                    print(
+                        f"Warning: spatial_keepouts entry {key!r} matches no "
+                        "rule-area zone name on the board (known rule areas: "
+                        f"{', '.join(sorted(kept_names)) or 'none'}); it will "
+                        "be ignored.",
+                        file=_sys.stderr,
+                    )
+
         if not raw_areas:
             return None
 
@@ -2764,14 +2798,20 @@ class Autorouter:
                     indices.update(all_indices)
                 elif name == "F&B.Cu":
                     indices.update({0, stack.num_layers - 1})
+                elif name == "*.In.Cu":
+                    # KiCad's inner-copper wildcard: every layer that is
+                    # neither front nor back (#4672).  On a 2-layer stack it
+                    # legitimately resolves to the empty set -- there are no
+                    # inner layers -- which is correct, not an error.
+                    indices.update(i for i in all_indices if 0 < i < stack.num_layers - 1)
                 else:
                     layer_def = stack.get_layer_by_name(name)
                     if layer_def is not None:
                         indices.add(layer_def.index)
             return frozenset(indices)
 
-        # Class-name -> net-id resolution for the sidecar filter.
-        filters = self._spatial_keepout_filters or {}
+        # Class-name -> net-id resolution for the sidecar filter (``filters``
+        # bound above, before the unknown-zone-name warning pass).
         class_ids: dict[str, frozenset[int]] = {}
         if filters:
             name_to_id = self._net_name_to_id()

--- a/tests/router/lattice/test_coupled_pairs.py
+++ b/tests/router/lattice/test_coupled_pairs.py
@@ -264,6 +264,39 @@ def test_pair_declines_when_fat_envelope_is_blocked() -> None:
     assert stats2.routed == 2, pf2.failure_reasons
 
 
+def test_pair_declines_when_emitted_leg_violates_keepout() -> None:
+    # A track-keepout rule area spanning the pair corridor on both layers
+    # (#4605/#4672).  The fat centerline search deliberately skips the
+    # keepout mask, so the coarse search succeeds -- the finish gate's
+    # emitted-leg re-verification (probing every leg segment at trace_w/2)
+    # must catch the violation and decline with the ``pair-leg-keepout``
+    # attribution, emitting NOTHING (never split, #3906).
+    from kicad_tools.router.lattice.obstacles import KeepoutArea, LatticeKeepoutMask
+
+    wall = KeepoutArea(
+        polygon=((14.0, 0.0), (16.0, 0.0), (16.0, 12.0), (14.0, 12.0)),
+        layers=frozenset({0, 1}),
+        blocks_tracks=True,
+        blocks_vias=True,
+        only=None,
+        exempt=frozenset(),
+        name="pair-wall",
+    )
+    pf, pc = _pair_board()
+    pf.set_keepouts(LatticeKeepoutMask([wall]))
+    routes, stats = pf.route_netset([], coupled=[pc])
+    assert pf.pair_outcomes[pc.key] == "pair-leg-keepout", pf.pair_outcomes
+    assert pf.failure_reasons[pc.key] == "pair-leg-keepout"
+    assert routes == {}
+    assert stats.routed == 0 and stats.total == 1
+    # Control: the identical board with no keepout couples cleanly (proves
+    # the decline above is the keepout, not the corridor).
+    pf2, pc2 = _pair_board()
+    routes2, stats2 = pf2.route_netset([], coupled=[pc2])
+    assert pf2.pair_outcomes[pc2.key] == "coupled"
+    assert stats2.routed == 1 and routes2
+
+
 def test_pair_declines_on_polarity_twist_when_no_hook_room() -> None:
     # P/N swapped at the far end.  Full-height walls RIGHT behind both end
     # pad columns (grown keep-outs overlapping the pads' own) leave no hook

--- a/tests/router/lattice/test_keepout_areas.py
+++ b/tests/router/lattice/test_keepout_areas.py
@@ -244,6 +244,57 @@ def test_rule_area_round_trips_through_pcb_load_save(tmp_path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# 2b. Layer-spec resolution at the projection level (#4672).
+# ---------------------------------------------------------------------------
+
+
+def _projection_mask(tmp_path, zone_layers: str, stack: LayerStack):
+    """Project one track-blocking rule area with the given layer spec through
+    ``Autorouter._lattice_keepout_projection`` against ``stack``."""
+    from kicad_tools.router.core import Autorouter
+
+    zone_text = f"""(zone
+  (net 0)
+  (net_name "")
+  (name "inner-guard")
+  (layers {zone_layers})
+  (uuid "aaaaaaaa-0000-0000-0000-000000000009")
+  (hatch edge 0.5)
+  (keepout (tracks not_allowed) (vias not_allowed) (pads allowed) (copperpour allowed))
+  (polygon (pts (xy 10 10) (xy 20 10) (xy 20 20) (xy 10 20)))
+)"""
+    path = _board_with_rule_area(tmp_path, zone_text)
+    router = Autorouter(30, 30, strategy="lattice", layer_stack=stack)
+    router._pairwise_attach_zone_pcb_path = str(path)
+    return router._lattice_keepout_projection()
+
+
+def test_inner_wildcard_resolves_to_inner_layers_on_4_layer_stack(tmp_path) -> None:
+    mask = _projection_mask(tmp_path, '"*.In.Cu"', LayerStack.four_layer_all_signal())
+    assert mask is not None and len(mask.areas) == 1
+    assert mask.areas[0].layers == frozenset({1, 2})
+
+
+def test_inner_wildcard_resolves_to_inner_layers_on_6_layer_stack(tmp_path) -> None:
+    mask = _projection_mask(tmp_path, '"*.In.Cu"', LayerStack.six_layer_sig_gnd_sig_sig_pwr_sig())
+    assert mask is not None and len(mask.areas) == 1
+    assert mask.areas[0].layers == frozenset({1, 2, 3, 4})
+
+
+def test_inner_wildcard_is_empty_on_2_layer_stack(tmp_path) -> None:
+    # No inner layers exist: the wildcard legitimately resolves to the empty
+    # set, so an area declared ONLY on ``*.In.Cu`` never constrains routing.
+    mask = _projection_mask(tmp_path, '"*.In.Cu"', LayerStack.two_layer())
+    assert mask is None
+
+
+def test_inner_wildcard_mixed_with_named_layer_keeps_the_named_layer(tmp_path) -> None:
+    mask = _projection_mask(tmp_path, '"F.Cu" "*.In.Cu"', LayerStack.two_layer())
+    assert mask is not None and len(mask.areas) == 1
+    assert mask.areas[0].layers == frozenset({0})
+
+
+# ---------------------------------------------------------------------------
 # 3. Mask semantics.
 # ---------------------------------------------------------------------------
 

--- a/tests/test_lattice_keepout_areas.py
+++ b/tests/test_lattice_keepout_areas.py
@@ -283,6 +283,79 @@ def test_unknown_class_in_spatial_keepouts_fails_loud(tmp_path: Path, capsys) ->
     assert "HV_A" in err  # the known-classes hint
 
 
+def test_unknown_zone_name_in_spatial_keepouts_warns_but_routes(tmp_path: Path, capsys) -> None:
+    """#4672: a ``spatial_keepouts`` key matching no rule-area zone name is a
+    likely typo -- warn on stderr (naming the entry and the known rule areas)
+    but keep the conservative exit-0 semantics."""
+    pcb = tmp_path / "two_domain.kicad_pcb"
+    pcb.write_text(_board(_two_domain_guards()))
+    out = tmp_path / "routed.kicad_pcb"
+    sidecar = _write_sidecar(
+        tmp_path,
+        {
+            "hv-a-corridor-guard": {"only_classes": ["HV_A"]},
+            "hv-b-corridor-guard": {"only_classes": ["HV_B"]},
+            "hv-a-coridor-gaurd": {"only_classes": ["HV_A"]},  # typo'd zone name
+        },
+    )
+
+    rc = route_main(_route_args(pcb, out, sidecar=sidecar))
+    captured = capsys.readouterr()
+    assert rc == 0, captured.out
+    assert "spatial_keepouts entry 'hv-a-coridor-gaurd'" in captured.err
+    assert "matches no rule-area zone name" in captured.err
+    # The known-zone-names hint.
+    assert "hv-a-corridor-guard" in captured.err
+    assert "hv-b-corridor-guard" in captured.err
+    # The correctly spelled entry does NOT warn.
+    assert "entry 'hv-a-corridor-guard'" not in captured.err
+
+
+def test_spatial_keepouts_key_matching_pour_void_only_area_warns(tmp_path: Path, capsys) -> None:
+    """#4672: a key matching a real zone that was filtered out of the routing
+    mask (a ``copperpour not_allowed``-only area, the ``kct zones hv-keepout``
+    output) gets a distinct message -- the zone exists but never constrains
+    routing, the likely confusion source."""
+    pcb = tmp_path / "voided.kicad_pcb"
+    pcb.write_text(
+        _board(
+            _keepout_zone(
+                "hv-pour-void",
+                [(110, 106), (120, 106), (120, 110), (110, 110)],
+                tracks="allowed",
+                vias="allowed",
+                copperpour="not_allowed",
+            )
+        )
+    )
+    out = tmp_path / "routed.kicad_pcb"
+    sidecar = _write_sidecar(tmp_path, {"hv-pour-void": {"only_classes": ["HV_A"]}})
+
+    rc = route_main(_route_args(pcb, out, sidecar=sidecar))
+    captured = capsys.readouterr()
+    assert rc == 0, captured.out
+    assert "spatial_keepouts entry 'hv-pour-void'" in captured.err
+    assert "does not block tracks or vias" in captured.err
+
+
+def test_well_formed_spatial_keepouts_do_not_warn(tmp_path: Path, capsys) -> None:
+    pcb = tmp_path / "two_domain.kicad_pcb"
+    pcb.write_text(_board(_two_domain_guards()))
+    out = tmp_path / "routed.kicad_pcb"
+    sidecar = _write_sidecar(
+        tmp_path,
+        {
+            "hv-a-corridor-guard": {"only_classes": ["HV_A"]},
+            "hv-b-corridor-guard": {"only_classes": ["HV_B"]},
+        },
+    )
+
+    rc = route_main(_route_args(pcb, out, sidecar=sidecar))
+    captured = capsys.readouterr()
+    assert rc == 0, captured.out
+    assert "spatial_keepouts entry" not in captured.err
+
+
 def test_malformed_spatial_keepouts_block_fails_at_preload(tmp_path: Path, capsys) -> None:
     pcb = tmp_path / "two_domain.kicad_pcb"
     pcb.write_text(_board())


### PR DESCRIPTION
## Summary

Implements the three follow-ups from the #4605 review (PR #4657), per the curated spec on the issue.

### 1. `pair-leg-keepout` decline path is now tested (coverage only)

New `test_pair_declines_when_emitted_leg_violates_keepout` in `tests/router/lattice/test_coupled_pairs.py`: a track-keepout rule area spans the pair corridor on both layers. Because the fat centerline search deliberately skips the keepout mask (`ko = None if fat else self._keepouts`), the coarse search succeeds and the violation is caught only by the finish gate's emitted-leg re-verification (`pathfinder.py:1772`, probing at `trace_w/2`). Asserts:

- `pair_outcomes[pc.key] == "pair-leg-keepout"` and `failure_reasons` matches,
- `routes == {}` / `stats.routed == 0` — nothing emitted (never-split invariant, #3906),
- control: the identical board with no keepout couples cleanly (proves the decline is the keepout, not the corridor).

No production change in `pathfinder.py`.

### 2. `*.In.Cu` wildcard resolves to inner copper layers

`_resolve_layers` inside `Autorouter._lattice_keepout_projection` (`src/kicad_tools/router/core.py`) now maps `*.In.Cu` to every stack index strictly between front and back — matching KiCad's own wildcard semantics (KiCad writes `*.In.Cu` in zone layer lists). On a 2-layer stack it legitimately resolves to the empty set (there are no inner layers), which is correct rather than an error. Previously the token fell through to `get_layer_by_name` and was silently dropped, leaving multilayer boards unprotected on inner layers.

Note on integration with the recent `rules.py` work (#4704/#4709): `resolve_layer_index` / `_resolve_layer_index_list` there are scalar per-element resolvers for net-class-map sidecars where a wildcard is (correctly) an error — the zone-layer-list wildcard semantics live only in this projection resolver, so nothing is duplicated or forked.

Projection-level unit tests (new section 2b in `tests/router/lattice/test_keepout_areas.py`): resolves to `{1, 2}` on a 4-layer stack, `{1, 2, 3, 4}` on 6-layer, empty (projection returns `None`) on 2-layer, and mixed `"F.Cu" "*.In.Cu"` keeps the named layer.

### 3. Warning on unknown `spatial_keepouts` zone names

After `raw_areas` is built (and before the empty-early-return, so the warning fires even when no rule area survives filtering), `filters.keys()` is compared against zone names:

- key matches no rule-area zone at all → stderr warning naming the entry and the known (kept) rule-area zone names;
- key matches a real zone that was filtered out of the routing mask (pour-void-only area — the `kct zones hv-keepout` output — or a <3-point polygon) → distinct message saying that zone never constrains routing (the likely confusion source per the curation).

Exit code unchanged (still 0) — a sidecar may legitimately describe a board variant whose zone was removed; this is the conservative direction the review endorsed. The existing unknown-*class* check still fails loud. The duplicate later `filters = ...` binding was folded into the new earlier one.

CLI-level tests in `tests/test_lattice_keepout_areas.py`: typo'd zone name warns (naming both known guards) while routing still succeeds rc=0 and the correctly spelled entry does not warn; pour-void-matched key gets the distinct message; well-formed sidecar emits no warning.

## Test results

- `tests/router/lattice/test_keepout_areas.py` — 21 passed (17 existing + 4 new)
- `tests/router/lattice/test_coupled_pairs.py` — 26 passed (25 existing + 1 new)
- `tests/test_lattice_keepout_areas.py` — 9 passed (6 existing + 3 new)
- `tests/router/lattice/` (full dir minus the runtime-heavy board06/softstart fixtures) — 187 passed, 1 skipped
- `ruff check` + `ruff format --check` clean on all changed files
- mypy baseline gate: `OK: 1472 error(s), all within the baseline (1474 allowed). No new type errors.`

Closes #4672

🤖 Generated with [Claude Code](https://claude.com/claude-code)
