### PR TITLE
feat(cli): --transactional snapshot/rollback for in-place board mutations (#4541)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   1 on drift **or** any `fail`-status preflight (`warn` never affects the
   exit code). A missing tool is always a reported `fail` row, never a
   traceback.
+- **`--transactional` snapshot/rollback for in-place board mutations**
+  (#4541, from the copperhead survey #4520 idea 4) — new file-scoped
+  transaction helper `kicad_tools.transaction.board_transaction()` snapshots
+  the mutated file's bytes on entry and, on failure (exception, Ctrl-C, or
+  an explicit `rollback()` on a non-zero exit path), restores it
+  byte-identical via an atomic tmp-sibling + `os.replace` write while
+  preserving the failed attempt as a `<file>.failed-<UTC-timestamp>`
+  forensic sidecar (suppressible with `keep_failed=False`). Success leaves
+  no litter; unchanged files are skipped on rollback; files created inside
+  the transaction are removed again; subprocess mutations of the file are
+  covered too. Adopted as an opt-in `--transactional` flag on two flagship
+  commands: `kct fix-drc` (wraps the whole multi-pass run; rolls back on
+  exit 1 no-progress and exit 3 connectivity-rollback, while exit 2 partial
+  repair keeps the applied fixes; the existing per-pass connectivity
+  snapshot machinery is unchanged) and `kct pcb sync-netlist` (rolls back
+  on any non-zero exit; with `-o`, a partially-written output file is
+  removed and the input is never touched). Default behavior of both
+  commands without the flag is byte-for-byte unchanged. The git-scoped
+  variant (repo-wide `reset --hard` + `clean -fd` per copperhead) was
+  rejected — see the issue for rationale; broader adoption across the other
+  in-place mutating commands is a follow-up backlog.
 
 - **`kct pipeline` route-skip under `--voltage-map` now auto-runs a
   `kct creepage` audit as the skip gate** (#4649) — refining the #4607 loud

--- a/src/kicad_tools/cli/commands/pcb.py
+++ b/src/kicad_tools/cli/commands/pcb.py
@@ -936,6 +936,7 @@ def _run_sync_netlist_command(args, pcb_path: Path) -> int:
     force = getattr(args, "force", False)
     auto_rename = getattr(args, "auto_rename", False)
     remove_orphan_nets = getattr(args, "remove_orphan_nets", False)
+    transactional = getattr(args, "transactional", False)
 
     return run_sync_netlist(
         schematic_path=schematic_path,
@@ -947,6 +948,7 @@ def _run_sync_netlist_command(args, pcb_path: Path) -> int:
         force=force,
         auto_rename=auto_rename,
         remove_orphan_nets=remove_orphan_nets,
+        transactional=transactional,
     )
 
 

--- a/src/kicad_tools/cli/commands/validation.py
+++ b/src/kicad_tools/cli/commands/validation.py
@@ -179,6 +179,8 @@ def run_fix_drc_command(args) -> int:
         sub_argv.append("--no-connectivity-check")
     if getattr(args, "verify", False):
         sub_argv.append("--verify")
+    if getattr(args, "transactional", False):
+        sub_argv.append("--transactional")
     if args.format != "text":
         sub_argv.extend(["--format", args.format])
     # Use command-level quiet or global quiet

--- a/src/kicad_tools/cli/fix_drc_cmd.py
+++ b/src/kicad_tools/cli/fix_drc_cmd.py
@@ -29,6 +29,7 @@ from kicad_tools.drc.report import DRCReport
 from kicad_tools.drc.violation import ViolationType
 from kicad_tools.manufacturers import get_all_manufacturer_names, get_profile
 from kicad_tools.manufacturers.base import DesignRules
+from kicad_tools.transaction import board_transaction
 
 
 @dataclass
@@ -194,6 +195,17 @@ Examples:
         action="store_true",
         help="Suppress progress output (for scripting)",
     )
+    parser.add_argument(
+        "--transactional",
+        action="store_true",
+        help=(
+            "Snapshot the output file before repairing and roll it back "
+            "byte-identical if the run fails (exception, Ctrl-C, no-progress "
+            "exit 1, or connectivity-rollback exit 3); the failed attempt is "
+            "preserved as a <file>.failed-<timestamp> sidecar. Exit 2 "
+            "(partial repair) keeps the applied repairs."
+        ),
+    )
 
     args = parser.parse_args(argv)
 
@@ -212,16 +224,51 @@ Examples:
         print("Error: --max-passes must be at least 1", file=sys.stderr)
         return 1
 
-    # Effective max passes: dry-run forces single pass since no geometry changes
-    effective_max_passes = 1 if args.dry_run else args.max_passes
-
-    # Get initial DRC report
+    # Get initial DRC report (detection only -- does not mutate the board)
     report = _get_drc_report(args.drc_report, pcb_path, manufacturer=args.mfr, layers=args.layers)
     if report is None:
         return 1
 
     # Determine output path used for saving
     output_path = Path(args.output) if args.output else pcb_path
+
+    if not getattr(args, "transactional", False):
+        return _execute_repair(args, pcb_path, output_path, report)
+
+    # --transactional (issue #4541): wrap the whole multi-pass run in a
+    # file-scoped snapshot/rollback transaction.  Exceptions and Ctrl-C roll
+    # back via the context manager; the exit-code failure paths (1 = no
+    # progress / error, 3 = connectivity rollback) roll back explicitly.
+    # Exit 2 (partial repair) keeps the applied repairs -- boards with
+    # non-repairable violations (silkscreen, edge clearance, ...) can never
+    # reach exit 0, so treating 2 as failure would discard valid repairs on
+    # nearly every real board.  The per-pass connectivity snapshot machinery
+    # inside _execute_repair is unchanged; it serves semantic regression
+    # rollback mid-run, while this transaction provides whole-command
+    # failure safety.
+    with board_transaction(output_path) as txn:
+        exit_code = _execute_repair(args, pcb_path, output_path, report)
+        if exit_code in (1, 3):
+            txn.rollback()
+            for line in txn.report_lines():
+                print(line, file=sys.stderr)
+        return exit_code
+
+
+def _execute_repair(
+    args: argparse.Namespace,
+    pcb_path: Path,
+    output_path: Path,
+    report: DRCReport,
+) -> int:
+    """Run the multi-pass repair loop and return the command exit code.
+
+    Split out of :func:`main` so ``--transactional`` can wrap the whole
+    mutation in a :func:`kicad_tools.transaction.board_transaction`
+    (issue #4541) without duplicating the pass logic.
+    """
+    # Effective max passes: dry-run forces single pass since no geometry changes
+    effective_max_passes = 1 if args.dry_run else args.max_passes
 
     # --verify: snapshot violation counts from pure-Python DRC before repair
     verify_before: DRCReport | None = None
@@ -434,9 +481,10 @@ Examples:
 
         # Re-run detection for next pass (unless this is the last allowed pass)
         if pass_num < effective_max_passes:
-            report = _run_python_drc(output_path, manufacturer=args.mfr, layers=args.layers)
-            if report is None:
+            next_report = _run_python_drc(output_path, manufacturer=args.mfr, layers=args.layers)
+            if next_report is None:
                 break
+            report = next_report
 
     # Output results
     if not args.quiet:

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2188,6 +2188,16 @@ def _add_pcb_parser(subparsers) -> None:
         action="store_true",
         help="Remove nets with no pad references after net assignment",
     )
+    pcb_sync_netlist.add_argument(
+        "--transactional",
+        action="store_true",
+        help=(
+            "Snapshot the target file before syncing and roll it back "
+            "byte-identical on failure (exception, Ctrl-C, or sync errors); "
+            "the failed attempt is preserved as a <file>.failed-<timestamp> "
+            "sidecar"
+        ),
+    )
 
     # pcb zones
     pcb_zones = pcb_subparsers.add_parser("zones", help="List copper pour zones")
@@ -5048,6 +5058,17 @@ def _add_fix_drc_parser(subparsers) -> None:
         choices=["text", "json", "summary"],
         default="text",
         help="Output format (default: text)",
+    )
+    fix_drc_parser.add_argument(
+        "--transactional",
+        action="store_true",
+        help=(
+            "Snapshot the output file before repairing and roll it back "
+            "byte-identical if the run fails (exception, Ctrl-C, no-progress "
+            "exit 1, or connectivity-rollback exit 3); the failed attempt is "
+            "preserved as a <file>.failed-<timestamp> sidecar. Exit 2 "
+            "(partial repair) keeps the applied repairs."
+        ),
     )
 
 

--- a/src/kicad_tools/cli/pcb_sync_netlist.py
+++ b/src/kicad_tools/cli/pcb_sync_netlist.py
@@ -11,8 +11,11 @@ Supports --dry-run to preview changes without modifying files.
 from __future__ import annotations
 
 import json
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
+
+from kicad_tools.transaction import board_transaction
 
 
 @dataclass
@@ -828,6 +831,7 @@ def run_sync_netlist(
     force: bool = False,
     auto_rename: bool = False,
     remove_orphan_nets: bool = False,
+    transactional: bool = False,
 ) -> int:
     """Run the sync-netlist command.
 
@@ -844,10 +848,50 @@ def run_sync_netlist(
             before applying renames.
         remove_orphan_nets: If True, remove nets with no pad references after
             net assignment.
+        transactional: If True, snapshot the target file before syncing and
+            roll it back byte-identical on failure (exception, Ctrl-C, or a
+            non-zero exit).  The failed attempt is preserved as a
+            ``<file>.failed-<timestamp>`` sidecar (issue #4541).
 
     Returns:
         Exit code (0 for success, 1 for errors).
     """
+    # --transactional (issue #4541): the mutated file is the output path
+    # when given, otherwise the input PCB (in-place overwrite).  Exceptions
+    # and Ctrl-C roll back via the context manager; the exit-code failure
+    # path (sync errors -> exit 1) rolls back explicitly.
+    target_path = output_path or pcb_path
+    with board_transaction(target_path, enabled=transactional) as txn:
+        exit_code = _run_sync_netlist_impl(
+            schematic_path=schematic_path,
+            pcb_path=pcb_path,
+            dry_run=dry_run,
+            output_path=output_path,
+            output_format=output_format,
+            remove_orphans=remove_orphans,
+            force=force,
+            auto_rename=auto_rename,
+            remove_orphan_nets=remove_orphan_nets,
+        )
+        if exit_code != 0:
+            txn.rollback()
+            for line in txn.report_lines():
+                print(line, file=sys.stderr)
+        return exit_code
+
+
+def _run_sync_netlist_impl(
+    schematic_path: Path,
+    pcb_path: Path,
+    dry_run: bool = False,
+    output_path: Path | None = None,
+    output_format: str = "text",
+    remove_orphans: bool = False,
+    force: bool = False,
+    auto_rename: bool = False,
+    remove_orphan_nets: bool = False,
+) -> int:
+    """Sync implementation shared by the transactional and plain paths."""
     # First pass: compute diff (renames not applied yet unless auto_rename)
     result = sync_netlist(
         schematic_path=schematic_path,

--- a/src/kicad_tools/transaction.py
+++ b/src/kicad_tools/transaction.py
@@ -1,0 +1,246 @@
+"""File-scoped snapshot/rollback transactions for in-place board mutations.
+
+``kct`` commands that mutate a ``.kicad_pcb`` / ``.kicad_sch`` **in place**
+historically had no uniform failure-safety: a crash or partial failure
+mid-mutation could leave the user's only copy of a board corrupted or
+half-written.  :class:`BoardTransaction` (usually constructed via the
+:func:`board_transaction` factory) closes that gap with a *file-scoped*
+snapshot/rollback context manager (issue #4541).
+
+Guarantees
+----------
+
+* **Byte-identical restore** — on an exception escaping the ``with`` block,
+  or on an explicit :meth:`BoardTransaction.rollback` call, every wrapped
+  path is restored to the exact bytes it held on entry.  Paths that did not
+  exist on entry are removed again on rollback.
+* **Atomic restore** — the restore write goes through a sibling temp file +
+  ``os.fsync`` + ``os.replace`` (same pattern as the router's atomic save),
+  so a crash *mid-restore* cannot leave a half-written board either.
+* **Forensic sidecar** — the failed attempt is preserved next to the input
+  as ``<file>.failed-<UTC-timestamp><suffix>`` before restoring, so a
+  failed mutation can be inspected after the fact.  Pass
+  ``keep_failed=False`` to suppress the sidecar.
+* **No litter on success** — when the ``with`` block exits cleanly without
+  a rollback, no temp files or sidecars remain on disk.
+* **Ctrl-C coverage** — ``KeyboardInterrupt`` (and any other
+  ``BaseException``) propagates through the ``with`` block, so an interrupt
+  mid-mutation triggers the same rollback before re-raising.
+* **Loud restore failures** — if the rollback itself cannot restore a file
+  (e.g. read-only directory), :class:`TransactionRestoreError` is raised;
+  a failed restore is never silently swallowed.
+
+Because most ``kct`` commands report failure via non-zero exit codes rather
+than exceptions, adopting commands should also call
+:meth:`BoardTransaction.rollback` explicitly on their failure exit paths.
+Rollback is cheap and idempotent: paths whose current bytes already match
+the entry snapshot are skipped entirely (no restore, no sidecar), so it is
+safe to call on exit paths where no mutation actually happened.
+
+Snapshots are held in memory (boards are single-digit MB).  Because the
+snapshot/restore operates on the *file*, mutations performed by
+subprocesses (e.g. ``kicad-cli`` zone refills) are covered too.
+
+Example::
+
+    from kicad_tools.transaction import board_transaction
+
+    with board_transaction(pcb_path, enabled=args.transactional) as txn:
+        exit_code = do_mutation(pcb_path)
+        if exit_code != 0:
+            txn.rollback()
+        return exit_code
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from types import TracebackType
+from typing import Literal
+
+__all__ = [
+    "BoardTransaction",
+    "TransactionRestoreError",
+    "board_transaction",
+]
+
+
+class TransactionRestoreError(RuntimeError):
+    """Raised when a transactional rollback could not fully restore a file.
+
+    This is deliberately loud: if the rollback cannot put the original
+    bytes back (or write the forensic sidecar), the user must know their
+    file may be in the failed post-mutation state.
+    """
+
+
+class BoardTransaction:
+    """File-scoped snapshot/rollback transaction (see module docstring).
+
+    Prefer the :func:`board_transaction` factory for construction.
+
+    Attributes:
+        paths: The wrapped file paths.
+        enabled: When ``False`` the transaction is a complete no-op
+            (no snapshot, no rollback) — this lets callers wire an opt-in
+            ``--transactional`` flag without branching around the ``with``.
+        keep_failed: Whether rollback preserves the failed attempt as a
+            forensic sidecar before restoring.
+        restored: Paths actually restored by :meth:`rollback` (paths whose
+            bytes were unchanged are skipped and never appear here).
+        sidecars: Forensic sidecar paths written by :meth:`rollback`.
+    """
+
+    def __init__(
+        self,
+        *paths: str | Path,
+        enabled: bool = True,
+        keep_failed: bool = True,
+    ) -> None:
+        if not paths:
+            raise ValueError("BoardTransaction requires at least one path")
+        self.paths: list[Path] = [Path(p) for p in paths]
+        self.enabled = enabled
+        self.keep_failed = keep_failed
+        self.restored: list[Path] = []
+        self.sidecars: list[Path] = []
+        self._snapshots: dict[Path, bytes | None] = {}
+        self._entered = False
+
+    def __enter__(self) -> BoardTransaction:
+        if self.enabled:
+            for path in self.paths:
+                # None means "did not exist on entry" -> rollback unlinks.
+                self._snapshots[path] = path.read_bytes() if path.exists() else None
+        self._entered = True
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> Literal[False]:
+        # Any escaping BaseException (including KeyboardInterrupt from a
+        # Ctrl-C mid-mutation) triggers rollback; the exception always
+        # propagates.  A TransactionRestoreError raised here chains onto
+        # the original exception rather than replacing it.
+        if exc_type is not None:
+            self.rollback()
+        return False
+
+    def rollback(self) -> None:
+        """Restore every wrapped path to its entry snapshot.
+
+        Paths whose current bytes already equal the entry snapshot are
+        skipped (no restore, no sidecar), which makes this method cheap
+        and idempotent — safe to call on failure exit paths even when no
+        mutation actually happened.
+
+        Raises:
+            TransactionRestoreError: If any restore (or sidecar write)
+                failed.  All paths are attempted before raising so one
+                bad path cannot block restoring the others.
+        """
+        if not self.enabled or not self._entered:
+            return
+
+        errors: list[str] = []
+        for path in self.paths:
+            snapshot = self._snapshots.get(path)
+            try:
+                current: bytes | None = path.read_bytes() if path.exists() else None
+            except OSError as e:
+                errors.append(f"could not read current state of {path}: {e}")
+                continue
+
+            if current == snapshot:
+                continue  # unchanged (or already rolled back) -> nothing to do
+
+            # Preserve the failed attempt for forensics BEFORE restoring,
+            # so even a failed restore leaves the sidecar behind.
+            if self.keep_failed and current is not None:
+                sidecar = self._sidecar_path(path)
+                try:
+                    sidecar.write_bytes(current)
+                    self.sidecars.append(sidecar)
+                except OSError as e:
+                    errors.append(f"could not write forensic sidecar for {path}: {e}")
+
+            try:
+                self._restore(path, snapshot)
+                self.restored.append(path)
+            except OSError as e:
+                errors.append(f"could not restore {path}: {e}")
+
+        if errors:
+            raise TransactionRestoreError(
+                "transactional rollback failed to fully restore the pre-command "
+                "state:\n  " + "\n  ".join(errors)
+            )
+
+    @staticmethod
+    def _restore(path: Path, snapshot: bytes | None) -> None:
+        """Atomically restore *path* to *snapshot* (or remove it if None)."""
+        if snapshot is None:
+            path.unlink(missing_ok=True)
+            return
+        # Atomic write: sibling tmp file -> fsync -> os.replace.  The
+        # sibling-in-same-dir placement makes os.replace a same-filesystem
+        # rename (atomic on POSIX), mirroring route_cmd's atomic save, so a
+        # crash mid-restore cannot leave a half-written board.
+        tmp_path = path.with_name(path.name + ".txn-restore.tmp")
+        try:
+            tmp_path.write_bytes(snapshot)
+            with open(tmp_path, "rb") as f:
+                os.fsync(f.fileno())
+            os.replace(tmp_path, path)
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    @staticmethod
+    def _sidecar_path(path: Path) -> Path:
+        """Pick a non-clobbering ``<file>.failed-<UTC-timestamp><suffix>`` name."""
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        candidate = path.with_name(f"{path.name}.failed-{stamp}{path.suffix}")
+        counter = 1
+        while candidate.exists():
+            candidate = path.with_name(f"{path.name}.failed-{stamp}-{counter}{path.suffix}")
+            counter += 1
+        return candidate
+
+    def report_lines(self) -> list[str]:
+        """Human-readable summary of the last rollback (for CLI stderr)."""
+        lines: list[str] = []
+        for path in self.restored:
+            lines.append(f"--transactional: rolled back {path} to its pre-command state")
+        for sidecar in self.sidecars:
+            lines.append(f"--transactional: failed attempt preserved at {sidecar}")
+        return lines
+
+
+def board_transaction(
+    *paths: str | Path,
+    enabled: bool = True,
+    keep_failed: bool = True,
+) -> BoardTransaction:
+    """Create a file-scoped snapshot/rollback transaction over *paths*.
+
+    See the module docstring for the full guarantees.  With
+    ``enabled=False`` the returned transaction is a complete no-op, which
+    lets CLI commands wire an opt-in ``--transactional`` flag without
+    branching around the ``with`` block.
+
+    Args:
+        paths: One or more files to protect.  Paths that do not exist yet
+            are supported — rollback removes them again.
+        enabled: Master switch; ``False`` disables snapshotting entirely.
+        keep_failed: Preserve the failed attempt as a
+            ``<file>.failed-<UTC-timestamp><suffix>`` sidecar on rollback.
+
+    Returns:
+        A :class:`BoardTransaction` context manager.
+    """
+    return BoardTransaction(*paths, enabled=enabled, keep_failed=keep_failed)

--- a/tests/test_fix_drc_cmd.py
+++ b/tests/test_fix_drc_cmd.py
@@ -3321,3 +3321,152 @@ class TestCategoryAlignment:
             f"fix-drc reported {fix_drc_count} violations but check reported "
             f"{check_count}; the two tools must use the same DRC categories"
         )
+
+
+# ── --transactional flag (issue #4541) ──────────────────────────────
+
+
+class TestTransactionalFlag:
+    """Tests for the opt-in --transactional snapshot/rollback wrapper."""
+
+    def test_success_leaves_no_sidecar_or_tmp_litter(
+        self, pcb_clearance: Path, report_clearance: Path, tmp_path: Path
+    ):
+        """A successful transactional run keeps the repairs and leaves no litter."""
+        result = main(
+            [
+                str(pcb_clearance),
+                "--drc-report",
+                str(report_clearance),
+                "--transactional",
+                "--no-connectivity-check",
+                "--quiet",
+            ]
+        )
+        assert result in (0, 2)
+        assert list(tmp_path.glob("*.failed-*")) == []
+        assert list(tmp_path.glob("*.tmp")) == []
+
+    def test_exception_rolls_back_byte_identical(
+        self, pcb_clearance: Path, report_clearance: Path, tmp_path: Path, monkeypatch
+    ):
+        """A crash mid-repair restores the input and preserves a sidecar."""
+        from kicad_tools.cli import fix_drc_cmd
+
+        original_bytes = pcb_clearance.read_bytes()
+
+        def corrupt_and_raise(**kwargs):
+            kwargs["output_path"].write_text("(kicad_pcb corrupted mid-write")
+            raise RuntimeError("simulated crash mid-repair")
+
+        monkeypatch.setattr(fix_drc_cmd, "_run_single_pass", corrupt_and_raise)
+
+        with pytest.raises(RuntimeError, match="simulated crash"):
+            main(
+                [
+                    str(pcb_clearance),
+                    "--drc-report",
+                    str(report_clearance),
+                    "--transactional",
+                    "--no-connectivity-check",
+                    "--quiet",
+                ]
+            )
+
+        assert pcb_clearance.read_bytes() == original_bytes
+        sidecars = list(tmp_path.glob("*.failed-*"))
+        assert len(sidecars) == 1
+        assert sidecars[0].read_text() == "(kicad_pcb corrupted mid-write"
+
+    def test_no_progress_exit_1_rolls_back(
+        self, pcb_clearance: Path, report_clearance: Path, tmp_path: Path, monkeypatch
+    ):
+        """The non-zero-exit failure path (exit 1) rolls back too (#4541)."""
+        from kicad_tools.cli import fix_drc_cmd
+
+        original_bytes = pcb_clearance.read_bytes()
+
+        def corrupt_without_progress(**kwargs):
+            # Mutates the file but reports zero repairs -> exit code 1.
+            kwargs["output_path"].write_text("(kicad_pcb formatting-drift-only rewrite)")
+            return (
+                RepairResult(total_violations=1, repaired=0),
+                DrillRepairResult(),
+            )
+
+        monkeypatch.setattr(fix_drc_cmd, "_run_single_pass", corrupt_without_progress)
+
+        result = main(
+            [
+                str(pcb_clearance),
+                "--drc-report",
+                str(report_clearance),
+                "--transactional",
+                "--no-connectivity-check",
+                "--quiet",
+            ]
+        )
+
+        assert result == 1
+        assert pcb_clearance.read_bytes() == original_bytes
+        assert len(list(tmp_path.glob("*.failed-*"))) == 1
+
+    def test_default_behavior_unchanged_without_flag(
+        self, pcb_clearance: Path, report_clearance: Path, tmp_path: Path, monkeypatch
+    ):
+        """Without --transactional there is no snapshot, rollback, or sidecar."""
+        from kicad_tools.cli import fix_drc_cmd
+
+        def corrupt_and_raise(**kwargs):
+            kwargs["output_path"].write_text("corrupted")
+            raise RuntimeError("simulated crash mid-repair")
+
+        monkeypatch.setattr(fix_drc_cmd, "_run_single_pass", corrupt_and_raise)
+
+        with pytest.raises(RuntimeError):
+            main(
+                [
+                    str(pcb_clearance),
+                    "--drc-report",
+                    str(report_clearance),
+                    "--no-connectivity-check",
+                    "--quiet",
+                ]
+            )
+
+        # opt-in semantics: the corruption survives and no sidecar appears
+        assert pcb_clearance.read_text() == "corrupted"
+        assert list(tmp_path.glob("*.failed-*")) == []
+
+    def test_outer_parser_forwards_transactional(self, monkeypatch):
+        """kct fix-drc --transactional reaches the inner parser (drift guard)."""
+        from kicad_tools.cli.commands.validation import run_fix_drc_command
+
+        captured: dict[str, list[str]] = {}
+
+        def fake_main(sub_argv):
+            captured["argv"] = sub_argv
+            return 0
+
+        monkeypatch.setattr("kicad_tools.cli.fix_drc_cmd.main", fake_main)
+
+        class Args:
+            pcb = "board.kicad_pcb"
+            drc_report = None
+            mfr = "jlcpcb"
+            layers = 2
+            max_displacement = 0.5
+            margin = 0.01
+            only = None
+            output = None
+            dry_run = False
+            max_passes = 1
+            local_reroute = True
+            no_connectivity_check = False
+            verify = False
+            transactional = True
+            format = "text"
+            quiet = False
+
+        assert run_fix_drc_command(Args()) == 0
+        assert "--transactional" in captured["argv"]

--- a/tests/test_pcb_sync_netlist.py
+++ b/tests/test_pcb_sync_netlist.py
@@ -3096,3 +3096,170 @@ class TestSyncOffBoardWarnings:
 
         assert not any("placed outside board outline" in w for w in result.warnings)
         assert not any("No Edge.Cuts outline detected" in w for w in result.warnings)
+
+
+# ── --transactional flag (issue #4541) ──────────────────────────────
+
+
+class TestTransactionalFlag:
+    """Tests for the opt-in --transactional snapshot/rollback wrapper."""
+
+    def test_parser_accepts_transactional_flag(self):
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(
+            [
+                "pcb",
+                "sync-netlist",
+                "--schematic",
+                "test.kicad_sch",
+                "--transactional",
+                "test.kicad_pcb",
+            ]
+        )
+        assert args.transactional is True
+
+    def test_success_leaves_no_sidecar(self, tmp_path):
+        """A clean transactional sync leaves no sidecar or tmp litter."""
+        from kicad_tools.cli.pcb_sync_netlist import run_sync_netlist
+
+        sch = tmp_path / "test.kicad_sch"
+        pcb = tmp_path / "test.kicad_pcb"
+        sch.write_text(MINIMAL_SCHEMATIC)
+        pcb.write_text(MINIMAL_PCB_MATCHING)
+
+        rc = run_sync_netlist(sch, pcb, dry_run=False, transactional=True)
+
+        assert rc == 0
+        assert list(tmp_path.glob("*.failed-*")) == []
+        assert list(tmp_path.glob("*.tmp")) == []
+
+    def test_save_failure_rolls_back_byte_identical(self, tmp_path, monkeypatch):
+        """A failed save (exit 1) restores the input PCB and keeps a sidecar."""
+        from kicad_tools.cli.pcb_sync_netlist import run_sync_netlist
+        from kicad_tools.schema.pcb import PCB
+
+        sch = tmp_path / "test.kicad_sch"
+        pcb = tmp_path / "test.kicad_pcb"
+        sch.write_text(MINIMAL_SCHEMATIC)
+        pcb.write_text(PCB_MISSING_R1)
+        original_bytes = pcb.read_bytes()
+
+        def corrupt_and_raise(self, path):
+            Path(path).write_text("(kicad_pcb corrupted mid-save")
+            raise OSError("disk full mid-save")
+
+        monkeypatch.setattr(PCB, "save", corrupt_and_raise)
+
+        rc = run_sync_netlist(sch, pcb, dry_run=False, transactional=True)
+
+        assert rc == 1  # save failure lands in result.errors -> exit 1
+        assert pcb.read_bytes() == original_bytes
+        sidecars = list(tmp_path.glob("*.failed-*"))
+        assert len(sidecars) == 1
+        assert sidecars[0].read_text() == "(kicad_pcb corrupted mid-save"
+
+    def test_exception_rolls_back_byte_identical(self, tmp_path, monkeypatch):
+        """An exception escaping the sync restores the input PCB."""
+        from kicad_tools.cli import pcb_sync_netlist as mod
+
+        sch = tmp_path / "test.kicad_sch"
+        pcb = tmp_path / "test.kicad_pcb"
+        sch.write_text(MINIMAL_SCHEMATIC)
+        pcb.write_text(PCB_MISSING_R1)
+        original_bytes = pcb.read_bytes()
+
+        def corrupt_and_raise(pcb_obj, schematic_path):
+            pcb.write_text("half-written by a crash")
+            raise RuntimeError("simulated crash mid-sync")
+
+        monkeypatch.setattr(mod, "_assign_nets_from_schematic", corrupt_and_raise)
+
+        with pytest.raises(RuntimeError, match="simulated crash"):
+            mod.run_sync_netlist(sch, pcb, dry_run=False, transactional=True)
+
+        assert pcb.read_bytes() == original_bytes
+        assert len(list(tmp_path.glob("*.failed-*"))) == 1
+
+    def test_default_behavior_unchanged_without_flag(self, tmp_path, monkeypatch):
+        """Without transactional=True there is no rollback and no sidecar."""
+        from kicad_tools.cli.pcb_sync_netlist import run_sync_netlist
+        from kicad_tools.schema.pcb import PCB
+
+        sch = tmp_path / "test.kicad_sch"
+        pcb = tmp_path / "test.kicad_pcb"
+        sch.write_text(MINIMAL_SCHEMATIC)
+        pcb.write_text(PCB_MISSING_R1)
+
+        def corrupt_and_raise(self, path):
+            Path(path).write_text("(kicad_pcb corrupted mid-save")
+            raise OSError("disk full mid-save")
+
+        monkeypatch.setattr(PCB, "save", corrupt_and_raise)
+
+        rc = run_sync_netlist(sch, pcb, dry_run=False)
+
+        assert rc == 1
+        # opt-in semantics: the corruption survives and no sidecar appears
+        assert pcb.read_text() == "(kicad_pcb corrupted mid-save"
+        assert list(tmp_path.glob("*.failed-*")) == []
+
+    def test_output_path_rollback_removes_created_file(self, tmp_path, monkeypatch):
+        """With -o, a failed sync removes the partially-written output file."""
+        from kicad_tools.cli.pcb_sync_netlist import run_sync_netlist
+        from kicad_tools.schema.pcb import PCB
+
+        sch = tmp_path / "test.kicad_sch"
+        pcb = tmp_path / "test.kicad_pcb"
+        out = tmp_path / "out.kicad_pcb"
+        sch.write_text(MINIMAL_SCHEMATIC)
+        pcb.write_text(PCB_MISSING_R1)
+        original_bytes = pcb.read_bytes()
+
+        def corrupt_and_raise(self, path):
+            Path(path).write_text("(kicad_pcb corrupted mid-save")
+            raise OSError("disk full mid-save")
+
+        monkeypatch.setattr(PCB, "save", corrupt_and_raise)
+
+        rc = run_sync_netlist(sch, pcb, dry_run=False, output_path=out, transactional=True)
+
+        assert rc == 1
+        assert not out.exists()  # created-then-failed output is removed
+        assert pcb.read_bytes() == original_bytes  # input never touched
+        # forensic sidecar preserves the partial output
+        sidecars = list(tmp_path.glob("out.kicad_pcb.failed-*"))
+        assert len(sidecars) == 1
+
+    def test_dispatcher_forwards_transactional(self, tmp_path, monkeypatch):
+        """The pcb sync-netlist dispatcher forwards the flag."""
+        from kicad_tools.cli.commands import pcb as pcb_commands
+
+        sch = tmp_path / "test.kicad_sch"
+        pcb = tmp_path / "test.kicad_pcb"
+        sch.write_text(MINIMAL_SCHEMATIC)
+        pcb.write_text(MINIMAL_PCB_MATCHING)
+
+        captured: dict[str, object] = {}
+
+        def fake_run(**kwargs):
+            captured.update(kwargs)
+            return 0
+
+        monkeypatch.setattr("kicad_tools.cli.pcb_sync_netlist.run_sync_netlist", fake_run)
+
+        class Args:
+            schematic = str(sch)
+            output = None
+            dry_run = False
+            format = "text"
+            remove_orphans = False
+            force = False
+            auto_rename = False
+            remove_orphan_nets = False
+            transactional = True
+
+        rc = pcb_commands._run_sync_netlist_command(Args(), pcb)
+        assert rc == 0
+        assert captured["transactional"] is True

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -1,0 +1,328 @@
+"""Tests for the file-scoped snapshot/rollback transaction helper (issue #4541)."""
+
+import hashlib
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.transaction import (
+    BoardTransaction,
+    TransactionRestoreError,
+    board_transaction,
+)
+
+ORIGINAL = b'(kicad_pcb (version 20240108) (net 0 "") (net 1 "GND"))\n'
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+@pytest.fixture
+def board(tmp_path: Path) -> Path:
+    f = tmp_path / "board.kicad_pcb"
+    f.write_bytes(ORIGINAL)
+    return f
+
+
+def _sidecars(directory: Path) -> list[Path]:
+    return sorted(directory.glob("*.failed-*"))
+
+
+# ── Rollback on exception ───────────────────────────────────────────────
+
+
+class TestExceptionRollback:
+    def test_truncating_mutation_restored_byte_identical(self, board: Path):
+        original_sha = _sha256(board)
+        with pytest.raises(ValueError, match="boom"):
+            with board_transaction(board):
+                board.write_bytes(b"(kicad")  # truncated mid-write
+                raise ValueError("boom")
+        assert board.read_bytes() == ORIGINAL
+        assert _sha256(board) == original_sha
+
+    def test_appending_mutation_restored_byte_identical(self, board: Path):
+        with pytest.raises(RuntimeError):
+            with board_transaction(board):
+                board.write_bytes(ORIGINAL + b"(segment ...)\n")
+                raise RuntimeError("mid-mutation failure")
+        assert board.read_bytes() == ORIGINAL
+
+    def test_exception_propagates_unchanged(self, board: Path):
+        """The original exception is re-raised, not swallowed by rollback."""
+
+        class CustomError(Exception):
+            pass
+
+        with pytest.raises(CustomError):
+            with board_transaction(board):
+                board.write_bytes(b"garbage")
+                raise CustomError()
+
+    def test_keyboard_interrupt_rolls_back(self, board: Path):
+        """Ctrl-C mid-mutation must restore the file and propagate."""
+        with pytest.raises(KeyboardInterrupt):
+            with board_transaction(board):
+                board.write_bytes(b"half-written")
+                raise KeyboardInterrupt()
+        assert board.read_bytes() == ORIGINAL
+
+
+# ── Explicit rollback API ───────────────────────────────────────────────
+
+
+class TestExplicitRollback:
+    def test_explicit_rollback_restores(self, board: Path):
+        """Commands that fail via exit codes call rollback() directly."""
+        with board_transaction(board) as txn:
+            board.write_bytes(b"mutated")
+            txn.rollback()
+            assert board.read_bytes() == ORIGINAL
+        assert board.read_bytes() == ORIGINAL
+
+    def test_rollback_is_idempotent(self, board: Path):
+        with board_transaction(board) as txn:
+            board.write_bytes(b"mutated")
+            txn.rollback()
+            txn.rollback()  # second call is a no-op
+        assert board.read_bytes() == ORIGINAL
+        # only one sidecar despite two rollback calls
+        assert len(_sidecars(board.parent)) == 1
+
+    def test_rollback_noop_when_unchanged(self, board: Path):
+        """Unchanged files: no restore, no sidecar (cheap failure exits)."""
+        with board_transaction(board) as txn:
+            txn.rollback()
+            assert txn.restored == []
+            assert txn.sidecars == []
+        assert _sidecars(board.parent) == []
+        assert board.read_bytes() == ORIGINAL
+
+    def test_report_lines_mention_restore_and_sidecar(self, board: Path):
+        with board_transaction(board) as txn:
+            board.write_bytes(b"mutated")
+            txn.rollback()
+        lines = txn.report_lines()
+        assert any(str(board) in line and "rolled back" in line for line in lines)
+        assert any("failed attempt preserved" in line for line in lines)
+
+
+# ── Forensic sidecar ────────────────────────────────────────────────────
+
+
+class TestForensicSidecar:
+    def test_sidecar_preserves_failed_attempt(self, board: Path):
+        failed_bytes = b"the failed mutation attempt"
+        with pytest.raises(RuntimeError):
+            with board_transaction(board):
+                board.write_bytes(failed_bytes)
+                raise RuntimeError()
+        sidecars = _sidecars(board.parent)
+        assert len(sidecars) == 1
+        assert sidecars[0].read_bytes() == failed_bytes
+
+    def test_sidecar_name_format(self, board: Path):
+        """Sidecar is <file>.failed-<UTC-timestamp><suffix>."""
+        with pytest.raises(RuntimeError):
+            with board_transaction(board):
+                board.write_bytes(b"garbage")
+                raise RuntimeError()
+        (sidecar,) = _sidecars(board.parent)
+        assert re.fullmatch(
+            r"board\.kicad_pcb\.failed-\d{8}T\d{6}Z(-\d+)?\.kicad_pcb",
+            sidecar.name,
+        ), sidecar.name
+
+    def test_keep_failed_false_suppresses_sidecar(self, board: Path):
+        with pytest.raises(RuntimeError):
+            with board_transaction(board, keep_failed=False):
+                board.write_bytes(b"garbage")
+                raise RuntimeError()
+        assert board.read_bytes() == ORIGINAL
+        assert _sidecars(board.parent) == []
+
+    def test_sidecar_names_do_not_clobber(self, board: Path):
+        """Two rollbacks in the same second get distinct sidecar names."""
+        for attempt in (b"first failure", b"second failure"):
+            with pytest.raises(RuntimeError):
+                with board_transaction(board):
+                    board.write_bytes(attempt)
+                    raise RuntimeError()
+        sidecars = _sidecars(board.parent)
+        assert len(sidecars) == 2
+        assert {s.read_bytes() for s in sidecars} == {b"first failure", b"second failure"}
+
+
+# ── Success path ────────────────────────────────────────────────────────
+
+
+class TestSuccessPath:
+    def test_success_leaves_no_litter(self, board: Path):
+        """Clean exit: mutation kept, no temp files, no sidecars."""
+        before_listing = set(board.parent.iterdir())
+        mutated = ORIGINAL + b"(via ...)\n"
+        with board_transaction(board):
+            board.write_bytes(mutated)
+        assert board.read_bytes() == mutated
+        assert set(board.parent.iterdir()) == before_listing
+
+    def test_no_tmp_residue_after_rollback(self, board: Path):
+        with pytest.raises(RuntimeError):
+            with board_transaction(board):
+                board.write_bytes(b"garbage")
+                raise RuntimeError()
+        assert list(board.parent.glob("*.tmp")) == []
+
+
+# ── Multi-path and missing-file handling ────────────────────────────────
+
+
+class TestMultiPath:
+    def test_multiple_paths_all_restored(self, tmp_path: Path):
+        a = tmp_path / "a.kicad_pcb"
+        b = tmp_path / "b.kicad_pcb"
+        a.write_bytes(b"contents of a")
+        b.write_bytes(b"contents of b")
+        with pytest.raises(RuntimeError):
+            with board_transaction(a, b):
+                a.write_bytes(b"mutated a")
+                b.write_bytes(b"mutated b")
+                raise RuntimeError()
+        assert a.read_bytes() == b"contents of a"
+        assert b.read_bytes() == b"contents of b"
+
+    def test_only_changed_paths_get_sidecars(self, tmp_path: Path):
+        a = tmp_path / "a.kicad_pcb"
+        b = tmp_path / "b.kicad_pcb"
+        a.write_bytes(b"contents of a")
+        b.write_bytes(b"contents of b")
+        with pytest.raises(RuntimeError):
+            with board_transaction(a, b):
+                a.write_bytes(b"mutated a")  # b untouched
+                raise RuntimeError()
+        sidecars = _sidecars(tmp_path)
+        assert len(sidecars) == 1
+        assert sidecars[0].name.startswith("a.kicad_pcb.failed-")
+
+    def test_missing_file_on_entry_is_removed_on_rollback(self, tmp_path: Path):
+        """A path created inside the transaction is unlinked by rollback."""
+        out = tmp_path / "new-output.kicad_pcb"
+        assert not out.exists()
+        with pytest.raises(RuntimeError):
+            with board_transaction(out):
+                out.write_bytes(b"partial output")
+                raise RuntimeError()
+        assert not out.exists()
+        # the partial output is still preserved for forensics
+        (sidecar,) = _sidecars(tmp_path)
+        assert sidecar.read_bytes() == b"partial output"
+
+    def test_requires_at_least_one_path(self):
+        with pytest.raises(ValueError):
+            BoardTransaction()
+
+
+# ── enabled=False (opt-in wiring) ───────────────────────────────────────
+
+
+class TestDisabled:
+    def test_disabled_is_complete_noop(self, board: Path):
+        """enabled=False: no snapshot, no rollback, mutation survives failure."""
+        with pytest.raises(RuntimeError):
+            with board_transaction(board, enabled=False):
+                board.write_bytes(b"mutated without protection")
+                raise RuntimeError()
+        assert board.read_bytes() == b"mutated without protection"
+        assert _sidecars(board.parent) == []
+
+    def test_disabled_explicit_rollback_is_noop(self, board: Path):
+        with board_transaction(board, enabled=False) as txn:
+            board.write_bytes(b"mutated")
+            txn.rollback()
+        assert board.read_bytes() == b"mutated"
+
+
+# ── Restore failure is loud ─────────────────────────────────────────────
+
+
+class TestRestoreFailure:
+    @pytest.mark.skipif(
+        hasattr(os, "geteuid") and os.geteuid() == 0,
+        reason="root bypasses directory permission checks",
+    )
+    def test_read_only_directory_raises_loudly(self, tmp_path: Path):
+        """A rollback that cannot restore must raise, never silently pass."""
+        subdir = tmp_path / "boards"
+        subdir.mkdir()
+        board = subdir / "board.kicad_pcb"
+        board.write_bytes(ORIGINAL)
+        try:
+            with pytest.raises(TransactionRestoreError):
+                with board_transaction(board) as txn:
+                    board.write_bytes(b"mutated")
+                    # Read-only dir: sidecar + atomic-restore tmp writes fail.
+                    subdir.chmod(0o555)
+                    txn.rollback()
+        finally:
+            subdir.chmod(0o755)
+        # file is left in the failed state -- but the user was told loudly
+        assert board.read_bytes() == b"mutated"
+
+    @pytest.mark.skipif(
+        hasattr(os, "geteuid") and os.geteuid() == 0,
+        reason="root bypasses directory permission checks",
+    )
+    def test_restore_error_chains_onto_original_exception(self, tmp_path: Path):
+        """When rollback fails during exception handling, both surface."""
+        subdir = tmp_path / "boards"
+        subdir.mkdir()
+        board = subdir / "board.kicad_pcb"
+        board.write_bytes(ORIGINAL)
+        try:
+            with pytest.raises(TransactionRestoreError) as excinfo:
+                with board_transaction(board):
+                    board.write_bytes(b"mutated")
+                    subdir.chmod(0o555)
+                    raise RuntimeError("original failure")
+            assert isinstance(excinfo.value.__context__, RuntimeError)
+        finally:
+            subdir.chmod(0o755)
+
+
+# ── Atomic restore mechanics ────────────────────────────────────────────
+
+
+class TestAtomicRestore:
+    def test_restore_goes_through_os_replace(self, board: Path, monkeypatch):
+        """Restore must use the tmp-sibling + os.replace pattern."""
+        replace_calls: list[tuple[str, str]] = []
+        real_replace = os.replace
+
+        def spy_replace(src, dst, **kwargs):
+            replace_calls.append((str(src), str(dst)))
+            return real_replace(src, dst, **kwargs)
+
+        monkeypatch.setattr("kicad_tools.transaction.os.replace", spy_replace)
+        with pytest.raises(RuntimeError):
+            with board_transaction(board):
+                board.write_bytes(b"garbage")
+                raise RuntimeError()
+        assert board.read_bytes() == ORIGINAL
+        assert any(dst == str(board) and ".txn-restore.tmp" in src for src, dst in replace_calls)
+
+    def test_subprocess_style_mutation_is_covered(self, board: Path):
+        """External-process mutations (fresh file bytes) are rolled back too.
+
+        Simulates a subprocess (e.g. kicad-cli zone refill) by replacing the
+        file wholesale rather than writing through a Python handle.
+        """
+        replacement = board.parent / "external-write.tmp"
+        replacement.write_bytes(b"externally rewritten")
+        with pytest.raises(RuntimeError):
+            with board_transaction(board):
+                os.replace(replacement, board)
+                raise RuntimeError()
+        assert board.read_bytes() == ORIGINAL


### PR DESCRIPTION
## Summary

Implements the curated v1 scope of #4541: a **file-scoped snapshot/rollback transaction helper** plus opt-in `--transactional` adoption on exactly the two flagship commands named by the curator (`kct fix-drc`, `kct pcb sync-netlist`). No backlog commands were swept.

### New helper — `src/kicad_tools/transaction.py`

`board_transaction(*paths, enabled=True, keep_failed=True)` (class `BoardTransaction`):

- **Byte-identical restore** on an escaping exception (including `KeyboardInterrupt` — Ctrl-C mid-mutation rolls back for free) or an explicit `txn.rollback()` for non-zero-exit failure paths.
- **Atomic restore** via tmp-sibling + `os.fsync` + `os.replace`, mirroring `route_cmd`'s atomic save — a crash mid-restore cannot leave a half-written board.
- **Forensic sidecar** `<file>.failed-<UTC-timestamp><suffix>` written *before* restoring (non-clobbering names); `keep_failed=False` suppresses it.
- **No litter on success**; **cheap idempotent rollback** (paths whose bytes match the snapshot are skipped — no restore, no sidecar), so failure exit paths can call it unconditionally.
- Paths that don't exist on entry are supported: rollback unlinks the created file (used by `sync-netlist -o`).
- File-level snapshotting covers **subprocess mutations** (tested by simulating an external `os.replace` rewrite).
- Restore failures raise `TransactionRestoreError` **loudly** (tested via read-only directory), chaining onto the original exception.
- `enabled=False` is a complete no-op so commands can wire the opt-in flag without branching around the `with`.

### Adoption

- **`kct fix-drc --transactional`** — wraps the whole multi-pass run (body extracted to `_execute_repair`, behavior-preserving). Rolls back on **exit 1** (no progress / error) and **exit 3** (connectivity rollback), plus exceptions/Ctrl-C. **Exit 2 (partial repair) deliberately keeps the applied repairs**: exit 2 also fires when only non-repairable violations (silkscreen, edge clearance, ...) remain, so treating it as failure would discard valid repairs on nearly every real board. The existing per-pass connectivity snapshot machinery is unchanged (it serves semantic mid-run rollback; this flag is whole-command failure safety). Help text documents the exit-code semantics.
- **`kct pcb sync-netlist --transactional`** — rolls back on any non-zero exit (sync errors, e.g. a failed save) plus exceptions. The protected file is the mutation target: the input for in-place overwrite, or the `-o` output (a partially-written output is removed; the input is never touched).
- Flags registered on both the outer `parser.py` subparsers and the inner `fix_drc_cmd.py` parser; forwarded through `commands/validation.py` / `commands/pcb.py` shims (no drift-guard allowlist changes needed — verified `tests/test_cli_parser_drift.py` passes).
- Default behavior of both commands **without the flag is byte-for-byte unchanged** (explicit test: corruption survives and no sidecar appears when the flag is absent).

### Acceptance criteria

All curated criteria met: helper with documented guarantees; byte-identical (sha256-asserted) rollback for truncating and appending mutations; rollback on non-zero-exit paths of both adopted commands; sidecar written/suppressed; success no-litter (directory-listing assertion); atomic restore via `os.replace` (spy-asserted); opt-in flags with help text; fix-drc per-pass snapshots unchanged; CHANGELOG entry.

### Tests

- `tests/test_transaction.py` (new, 24 tests): exception rollback (truncate/append, sha256), explicit rollback + idempotency, KeyboardInterrupt, sidecar format/suppression/non-clobbering, success no-litter, multi-path, missing-file-on-entry, `enabled=False`, read-only-dir loud failure (+ exception chaining), `os.replace` atomicity spy, subprocess-style mutation.
- `tests/test_fix_drc_cmd.py::TestTransactionalFlag` (5 tests): success no-litter; exception rollback; exit-1 rollback; opt-in default unchanged; outer-parser forwarding.
- `tests/test_pcb_sync_netlist.py::TestTransactionalFlag` (7 tests): parser flag; success no-sidecar; save-failure (exit 1) rollback; exception rollback; opt-in default unchanged; `-o` output-file removal; dispatcher forwarding.
- Full affected suites green: 304 passed (`test_transaction.py`, `test_fix_drc_cmd.py`, `test_pcb_sync_netlist.py`, `test_cli_parser_drift.py`) + 161 adjacent (netlist sync gate, pin-to-pad, hierarchical sync, pipeline args, violation types).
- Manual: `kct fix-drc --transactional` end-to-end via the real CLI on the clearance fixture — exit 0, repair applied, zero litter.

### Checks

- `ruff check` / `ruff format --check`: clean on all changed files.
- mypy baseline gate (`scripts/ci/check_mypy_baseline.py`): **OK, no new errors** (three would-be new errors were fixed: `Literal[False]` on `__exit__` so mypy knows exceptions propagate, and a narrowed `report` reassignment in the pass loop). Baseline file untouched per the known `--update` native-env trap.

Closes #4541

🤖 Generated with [Claude Code](https://claude.com/claude-code)
