### PR TITLE
feat(check): routing-quality threshold gate + waivable zero_length_segment rule (#4651)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exit code). A missing tool is always a reported `fail` row, never a
   traceback.
 
+- **Opt-in routing-quality threshold gate for `kct check`** (#4651) — new
+  `--max-fragment-fraction` / `--max-staircase-fraction` flags (on both the
+  `kct` and standalone `kct check` parsers) turn the #4623 advisory
+  routing-quality metrics into a real gate: when a supplied ceiling
+  (0.0–1.0) is exceeded, an error-severity
+  `routing_quality_fragment_fraction` / `routing_quality_staircase_fraction`
+  violation is emitted and the check exits 2 (a fraction exactly equal to
+  the ceiling passes). The `routing_quality` JSON object gains the applied
+  `thresholds`, a `gate_passed` verdict, and per-metric `gate_breaches`
+  when gating is enabled, so CI consumers can see why the gate fired.
+  Without the flags, behavior is byte-identical to the advisory-only
+  contract — no board starts failing without opting in. Because gating is
+  an explicit opt-in it also engages under `--drc-only`, and a metrics
+  crash with gating requested is a hard exit-1 (an explicitly requested
+  gate never silently passes because it could not measure). Threshold
+  evaluation lives in `kicad_tools.analysis.routing_quality`
+  (`evaluate_routing_quality_thresholds` / `ThresholdBreach`, exported
+  from `kicad_tools.analysis`).
+
+- **`zero_length_segment` DRC rule — zero-length copper segments are now
+  real, waivable findings** (#4651) — zero-length segments (start == end)
+  are always routing artifacts; the #4623 metrics counted them
+  (`zero_length_count`) but nothing reported them. A new
+  `zero_length_segment` rule (registered in `DRCChecker.check_all` and as
+  a `kct check` `--only`/`--skip` category) emits one warning per
+  zero-length segment with net, layer, and position, and flows through
+  the central `.kct_waivers.json` mechanism (#4417) — waivable per
+  segment (by the `layer@(x,y)` `items` id, which matches the reported
+  location) or per net (by `nets`). Detection reuses the analysis
+  module's coordinate tolerance, so the advisory stanza's count and the
+  rule's finding count always agree. Severity is warning (fatal under
+  `--strict`), not error: the #4651 fleet pre-check found board-05's
+  routed artifact carrying 5 zero-length segments, so error-by-default
+  would have broken a shipping board.
+
 - **`kct pipeline` route-skip under `--voltage-map` now auto-runs a
   `kct creepage` audit as the skip gate** (#4649) — refining the #4607 loud
   refusal: when the board is already `>=`95% routed (recommend_skip) and no

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -274,6 +274,8 @@ kct check <pcb_file> [options]
 | `--refill-zones` | Refill zone fills in-place via `kicad-cli pcb drc --refill-zones --save-board` before checking (mutates the board file; kills stale-fill clearance false positives, #4113) |
 | `--waivers PATH` | Path to a general `.kct_waivers.json` sidecar (schema v2) waiving findings for any rule (#4417). Auto-discovered next to the board when omitted |
 | `--courtyard-waivers PATH` | Path to a `.courtyard_waivers.json` sidecar waiving specific courtyard-overlap pairs (#4137). Auto-discovered next to the board when omitted |
+| `--max-fragment-fraction F` | Opt-in routing-quality gate (#4651): fail (exit 2) when the share of copper segments shorter than 0.25 mm exceeds `F` (0.0–1.0; equal passes). Default: unset (advisory metrics only) |
+| `--max-staircase-fraction F` | Opt-in routing-quality gate (#4651): fail (exit 2) when the share of short H/V staircase steps exceeds `F` (0.0–1.0; equal passes). Default: unset (advisory metrics only) |
 
 **Examples:**
 ```bash

--- a/src/kicad_tools/analysis/__init__.py
+++ b/src/kicad_tools/analysis/__init__.py
@@ -41,9 +41,14 @@ from .net_status import (
 )
 from .routing_quality import (
     FRAGMENT_LENGTH_MM,
+    RULE_FRAGMENT_FRACTION,
+    RULE_STAIRCASE_FRACTION,
     STAIRCASE_STEP_MM,
     RoutingQualityMetrics,
+    ThresholdBreach,
     compute_routing_quality,
+    evaluate_routing_quality_thresholds,
+    routing_quality_gate_dict,
 )
 from .signal_integrity import (
     CrosstalkRisk,
@@ -68,6 +73,8 @@ from .trace_length import (
 
 __all__ = [
     "FRAGMENT_LENGTH_MM",
+    "RULE_FRAGMENT_FRACTION",
+    "RULE_STAIRCASE_FRACTION",
     "STAIRCASE_STEP_MM",
     "AnalogComponent",
     "Bottleneck",
@@ -93,6 +100,7 @@ __all__ = [
     "RoutingQualityMetrics",
     "Severity",
     "SignalIntegrityAnalyzer",
+    "ThresholdBreach",
     "TraceCrosstalkRisk",
     "TraceIntegrityAnalyzer",
     "ThermalAnalyzer",
@@ -104,5 +112,7 @@ __all__ = [
     "build_zone_net_map",
     "compute_routing_quality",
     "detect_analog_components",
+    "evaluate_routing_quality_thresholds",
     "infer_rail_voltage",
+    "routing_quality_gate_dict",
 ]

--- a/src/kicad_tools/analysis/routing_quality.py
+++ b/src/kicad_tools/analysis/routing_quality.py
@@ -45,6 +45,12 @@ ANGLE_TOLERANCE_DEG = 0.5
 # common case; the epsilon only absorbs float noise.
 COORD_EPSILON_MM = 1e-6
 
+# Rule ids emitted by the opt-in threshold gate (issue #4651).  Defined
+# here (next to the metric definitions) so the CLI wire-in and any JSON
+# consumer share a single source for the identifiers.
+RULE_FRAGMENT_FRACTION = "routing_quality_fragment_fraction"
+RULE_STAIRCASE_FRACTION = "routing_quality_staircase_fraction"
+
 
 @dataclass(frozen=True)
 class RoutingQualityMetrics:
@@ -85,6 +91,120 @@ class RoutingQualityMetrics:
             "staircase_step_count": self.staircase_step_count,
             "staircase_fraction": self.staircase_fraction,
         }
+
+
+@dataclass(frozen=True)
+class ThresholdBreach:
+    """One routing-quality metric that exceeded its opt-in ceiling.
+
+    Produced by :func:`evaluate_routing_quality_thresholds` (issue
+    #4651).  The CLI converts each breach into a real ``DRCViolation``
+    so the gate participates in the normal verdict / exit-code path;
+    this dataclass stays free of any ``validate`` dependency so the
+    analysis package remains purely computational.
+
+    Attributes:
+        rule_id: Stable violation rule id
+            (:data:`RULE_FRAGMENT_FRACTION` /
+            :data:`RULE_STAIRCASE_FRACTION`).
+        metric: The ``RoutingQualityMetrics`` field name that breached
+            (e.g. ``"fragment_fraction"``).
+        actual: The measured value.
+        limit: The user-supplied ceiling it exceeded.
+        message: Human-readable description of the breach.
+    """
+
+    rule_id: str
+    metric: str
+    actual: float
+    limit: float
+    message: str
+
+
+def evaluate_routing_quality_thresholds(
+    metrics: RoutingQualityMetrics,
+    *,
+    max_fragment_fraction: float | None = None,
+    max_staircase_fraction: float | None = None,
+) -> list[ThresholdBreach]:
+    """Evaluate opt-in routing-quality ceilings over computed metrics.
+
+    Pure function (issue #4651): compares each supplied ceiling against
+    the corresponding metric and returns one :class:`ThresholdBreach`
+    per exceeded threshold.  A ``None`` ceiling means "not gated on this
+    metric" -- with both ceilings ``None`` the result is always empty,
+    which is exactly today's advisory-only behavior.
+
+    Comparison is strictly-greater-than: a metric exactly **equal** to
+    its ceiling passes (so ``--max-fragment-fraction 0.0`` fails only
+    when at least one fragment exists).
+    """
+    breaches: list[ThresholdBreach] = []
+    if max_fragment_fraction is not None and metrics.fragment_fraction > max_fragment_fraction:
+        breaches.append(
+            ThresholdBreach(
+                rule_id=RULE_FRAGMENT_FRACTION,
+                metric="fragment_fraction",
+                actual=metrics.fragment_fraction,
+                limit=max_fragment_fraction,
+                message=(
+                    f"Routing-quality gate: fragment_fraction "
+                    f"{metrics.fragment_fraction:.4f} exceeds the "
+                    f"--max-fragment-fraction ceiling {max_fragment_fraction:.4f} "
+                    f"({metrics.fragment_count} segment(s) shorter than "
+                    f"{FRAGMENT_LENGTH_MM} mm)"
+                ),
+            )
+        )
+    if max_staircase_fraction is not None and metrics.staircase_fraction > max_staircase_fraction:
+        breaches.append(
+            ThresholdBreach(
+                rule_id=RULE_STAIRCASE_FRACTION,
+                metric="staircase_fraction",
+                actual=metrics.staircase_fraction,
+                limit=max_staircase_fraction,
+                message=(
+                    f"Routing-quality gate: staircase_fraction "
+                    f"{metrics.staircase_fraction:.4f} exceeds the "
+                    f"--max-staircase-fraction ceiling {max_staircase_fraction:.4f} "
+                    f"({metrics.staircase_step_count} H/V staircase step(s) with "
+                    f"legs shorter than {STAIRCASE_STEP_MM} mm)"
+                ),
+            )
+        )
+    return breaches
+
+
+def routing_quality_gate_dict(
+    breaches: list[ThresholdBreach],
+    *,
+    max_fragment_fraction: float | None,
+    max_staircase_fraction: float | None,
+) -> dict[str, object]:
+    """Serialize the threshold-gate outcome for the ``routing_quality`` JSON.
+
+    Issue #4651: when gating is enabled, the ``routing_quality`` object
+    gains the applied thresholds and a pass/fail verdict so CI consumers
+    can see *why* the gate fired.  Emitted only when at least one
+    ceiling was supplied (the no-flag JSON contract stays byte-identical
+    to the advisory-only #4646 shape).
+    """
+    return {
+        "thresholds": {
+            "max_fragment_fraction": max_fragment_fraction,
+            "max_staircase_fraction": max_staircase_fraction,
+        },
+        "gate_passed": not breaches,
+        "gate_breaches": [
+            {
+                "rule_id": b.rule_id,
+                "metric": b.metric,
+                "actual": b.actual,
+                "limit": b.limit,
+            }
+            for b in breaches
+        ],
+    }
 
 
 def _quantize(point: tuple[float, float]) -> tuple[int, int]:

--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -35,6 +35,8 @@ from kicad_tools.analysis.routing_quality import (
     STAIRCASE_STEP_MM,
     RoutingQualityMetrics,
     compute_routing_quality,
+    evaluate_routing_quality_thresholds,
+    routing_quality_gate_dict,
 )
 from kicad_tools.manufacturers import get_manufacturer_ids, get_profile
 from kicad_tools.schema.pcb import PCB
@@ -1117,6 +1119,7 @@ CHECK_CATEGORIES = [
     "single_pad_net",
     "solder_mask",
     "via_in_pad",
+    "zero_length_segment",
     "zones",
 ]
 
@@ -1496,8 +1499,57 @@ def main(argv: list[str] | None = None) -> int:
             "per-sheet-median variant is deferred."
         ),
     )
+    # Issue #4651: opt-in routing-quality threshold gate over the advisory
+    # #4623 metrics.  Default None = advisory-only (today's behavior).
+    parser.add_argument(
+        "--max-fragment-fraction",
+        dest="max_fragment_fraction",
+        type=float,
+        default=None,
+        metavar="FRACTION",
+        help=(
+            "Opt-in routing-quality gate (issue #4651): fail the check when "
+            "the routed board's fragment_fraction (share of copper segments "
+            f"shorter than {FRAGMENT_LENGTH_MM} mm) exceeds this ceiling "
+            "(0.0-1.0). Exceeding emits an error-severity "
+            "routing_quality_fragment_fraction violation and exits 2; a "
+            "fraction exactly equal to the ceiling passes. Default: unset "
+            "(advisory-only metrics, no gating)."
+        ),
+    )
+    parser.add_argument(
+        "--max-staircase-fraction",
+        dest="max_staircase_fraction",
+        type=float,
+        default=None,
+        metavar="FRACTION",
+        help=(
+            "Opt-in routing-quality gate (issue #4651): fail the check when "
+            "the routed board's staircase_fraction (share of copper segments "
+            f"that are H/V staircase steps with legs shorter than "
+            f"{STAIRCASE_STEP_MM} mm) exceeds this ceiling (0.0-1.0). "
+            "Exceeding emits an error-severity "
+            "routing_quality_staircase_fraction violation and exits 2; a "
+            "fraction exactly equal to the ceiling passes. Default: unset "
+            "(advisory-only metrics, no gating)."
+        ),
+    )
 
     args = parser.parse_args(argv)
+
+    # Issue #4651: validate the routing-quality ceilings up front.  The
+    # metrics are fractions in [0, 1], so anything outside that range is a
+    # usage error rather than a silently-inert gate.
+    for _flag, _value in (
+        ("--max-fragment-fraction", args.max_fragment_fraction),
+        ("--max-staircase-fraction", args.max_staircase_fraction),
+    ):
+        if _value is not None and not (0.0 <= _value <= 1.0):
+            print(
+                f"Error: {_flag} must be a fraction between 0.0 and 1.0, got {_value}",
+                file=sys.stderr,
+            )
+            return 1
 
     # Issue #4601: --no-net-class-map suppresses sidecar auto-discovery.
     # Pairing it with an explicit --net-class-map is a usage error rather
@@ -2019,6 +2071,78 @@ def main(argv: list[str] | None = None) -> int:
     # advisory ONLY -- it must not change the verdict or exit code.
     _maybe_emit_via_in_pad_tier_advisory(effective_mfr, results.violations)
 
+    # Issue #4623 / #4651: advisory routing-quality metrics + opt-in
+    # threshold gate.  Metrics are computed in meta mode -- skipped under
+    # --drc-only to keep the legacy stdout and on-disk JSON contracts
+    # byte-identical (#3750), mirroring how ``meta_checks`` is omitted --
+    # EXCEPT when a --max-*-fraction ceiling was passed: gating is an
+    # explicit opt-in, so it engages under --drc-only too (the advisory
+    # stanza and ``routing_quality`` JSON object then appear there as
+    # well).  Without threshold flags the metrics stay advisory ONLY:
+    # they never change the verdict, exit code, or meta rollup
+    # (including under --strict); a metrics crash degrades to a stderr
+    # warning, never a failed check.  With gating requested, a metrics
+    # crash IS fatal (exit 1) -- an explicitly requested gate must never
+    # silently pass because it could not measure.
+    drc_only = getattr(args, "drc_only", False)
+    rq_gating = args.max_fragment_fraction is not None or args.max_staircase_fraction is not None
+    routing_quality: RoutingQualityMetrics | None = None
+    if not drc_only or rq_gating:
+        try:
+            routing_quality = compute_routing_quality(pcb)
+        except Exception as exc:
+            if rq_gating:
+                print(
+                    f"Error: routing-quality metrics unavailable ({exc}); "
+                    "cannot evaluate --max-fragment-fraction / "
+                    "--max-staircase-fraction",
+                    file=sys.stderr,
+                )
+                return 1
+            print(
+                f"Warning: routing-quality metrics unavailable ({exc}); "
+                "continuing without the advisory stanza",
+                file=sys.stderr,
+            )
+    # Widened to dict[str, object] because the opt-in gate (below) merges
+    # in nested threshold/verdict structures alongside the scalar metrics.
+    routing_quality_dict: dict[str, object] | None = None
+    if routing_quality is not None:
+        routing_quality_dict = {**routing_quality.to_dict()}
+
+    # Issue #4651: evaluate the opt-in ceilings and convert each breach
+    # into a real error-severity violation so the gate participates in
+    # the normal verdict / exit-code path (table/JSON output, error
+    # counts, DRC sub-check status, meta rollup).  Severity is error by
+    # design: the ceiling only exists because the caller opted in, so
+    # exceeding it is a deliberate CI failure, not an advisory.  The
+    # ``routing_quality`` JSON object gains the applied thresholds and
+    # pass/fail verdict so consumers can see why the gate fired.
+    if rq_gating and routing_quality is not None and routing_quality_dict is not None:
+        rq_breaches = evaluate_routing_quality_thresholds(
+            routing_quality,
+            max_fragment_fraction=args.max_fragment_fraction,
+            max_staircase_fraction=args.max_staircase_fraction,
+        )
+        for rq_breach in rq_breaches:
+            results.add(
+                DRCViolation(
+                    rule_id=rq_breach.rule_id,
+                    severity="error",
+                    message=rq_breach.message,
+                    actual_value=rq_breach.actual,
+                    required_value=rq_breach.limit,
+                )
+            )
+        routing_quality_dict = {
+            **routing_quality_dict,
+            **routing_quality_gate_dict(
+                rq_breaches,
+                max_fragment_fraction=args.max_fragment_fraction,
+                max_staircase_fraction=args.max_staircase_fraction,
+            ),
+        }
+
     # Apply errors-only filter
     violations = list(results.violations)
     if args.errors_only:
@@ -2054,7 +2178,8 @@ def main(argv: list[str] | None = None) -> int:
     # Issue #3750: compute the meta-check rollup once and reuse it for
     # both the human stanza and the JSON envelope.  Skipped entirely
     # under --drc-only to preserve the legacy stdout/exit-code contract.
-    drc_only = getattr(args, "drc_only", False)
+    # (``drc_only`` itself is resolved earlier, before the routing-quality
+    # metrics block, #4651.)
     meta: MetaCheckResult | None = None
     if not drc_only:
         meta = run_meta_checks(
@@ -2063,24 +2188,6 @@ def main(argv: list[str] | None = None) -> int:
             schematic=getattr(args, "schematic", None),
             strict=args.strict,
         )
-
-    # Issue #4623: advisory routing-quality metrics.  Computed only in meta
-    # mode -- skipped entirely under --drc-only to keep the legacy stdout
-    # and on-disk JSON contracts byte-identical (#3750), mirroring how
-    # ``meta_checks`` is omitted.  Advisory ONLY: the metrics never change
-    # the verdict, exit code, or meta rollup (including under --strict);
-    # a metrics crash degrades to a stderr warning, never a failed check.
-    routing_quality: RoutingQualityMetrics | None = None
-    if not drc_only:
-        try:
-            routing_quality = compute_routing_quality(pcb)
-        except Exception as exc:
-            print(
-                f"Warning: routing-quality metrics unavailable ({exc}); "
-                "continuing without the advisory stanza",
-                file=sys.stderr,
-            )
-    routing_quality_dict = routing_quality.to_dict() if routing_quality is not None else None
 
     # Output results
     if args.format == "json":
@@ -2357,6 +2464,7 @@ def run_selected_checks(
         "single_pad_net": checker.check_single_pad_nets,
         "solder_mask": checker.check_solder_mask_pads,
         "via_in_pad": checker.check_via_in_pad,
+        "zero_length_segment": checker.check_zero_length_segments,
         "zones": checker.check_zones,
     }
 

--- a/src/kicad_tools/cli/commands/validation.py
+++ b/src/kicad_tools/cli/commands/validation.py
@@ -284,6 +284,13 @@ def run_check_command(args) -> int:
     # stays the single source of truth.
     if getattr(args, "sch_field_threshold", None) is not None:
         sub_argv.extend(["--sch-field-threshold", str(args.sch_field_threshold)])
+    # Issue #4651: forward the opt-in routing-quality threshold ceilings.
+    # Both default to None (advisory-only, no gating) so the inner parser's
+    # semantics stay the single source of truth.
+    if getattr(args, "max_fragment_fraction", None) is not None:
+        sub_argv.extend(["--max-fragment-fraction", str(args.max_fragment_fraction)])
+    if getattr(args, "max_staircase_fraction", None) is not None:
+        sub_argv.extend(["--max-staircase-fraction", str(args.max_staircase_fraction)])
     return check_main(sub_argv)
 
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -890,6 +890,40 @@ def _add_check_parser(subparsers) -> None:
             "threshold -- an adaptive per-sheet-median variant is deferred."
         ),
     )
+    # Issue #4651: opt-in routing-quality threshold gate over the advisory
+    # #4623 metrics.  Declared on BOTH parsers + forwarded by the shim (see
+    # the parser-drift guard in tests/test_cli_parser_drift.py, #4633).
+    check_parser.add_argument(
+        "--max-fragment-fraction",
+        dest="max_fragment_fraction",
+        type=float,
+        default=None,
+        metavar="FRACTION",
+        help=(
+            "Opt-in routing-quality gate (issue #4651): fail the check when "
+            "the routed board's fragment_fraction (share of copper segments "
+            "shorter than 0.25 mm) exceeds this ceiling (0.0-1.0). Exceeding "
+            "emits an error-severity routing_quality_fragment_fraction "
+            "violation and exits 2; equal-to-ceiling passes. Default: unset "
+            "(advisory-only metrics, no gating)."
+        ),
+    )
+    check_parser.add_argument(
+        "--max-staircase-fraction",
+        dest="max_staircase_fraction",
+        type=float,
+        default=None,
+        metavar="FRACTION",
+        help=(
+            "Opt-in routing-quality gate (issue #4651): fail the check when "
+            "the routed board's staircase_fraction (share of copper segments "
+            "that are H/V staircase steps with legs shorter than 0.6 mm) "
+            "exceeds this ceiling (0.0-1.0). Exceeding emits an "
+            "error-severity routing_quality_staircase_fraction violation and "
+            "exits 2; equal-to-ceiling passes. Default: unset (advisory-only "
+            "metrics, no gating)."
+        ),
+    )
 
 
 def _add_sch_parser(subparsers) -> None:

--- a/src/kicad_tools/validate/checker.py
+++ b/src/kicad_tools/validate/checker.py
@@ -241,6 +241,7 @@ class DRCChecker:
         "check_single_pad_nets",
         "check_pad_grid_alignment",
         "check_via_in_pad",
+        "check_zero_length_segments",
         "check_zones",
     )
 
@@ -1116,6 +1117,27 @@ class DRCChecker:
             via-in-pad (e.g., jlcpcb-tier1, pcbway).
         """
         rule = ViaInPadRule()
+        return self._absolutize(rule.check(self.pcb, self.design_rules))
+
+    def check_zero_length_segments(self) -> DRCResults:
+        """Check for zero-length copper trace segments (issue #4651).
+
+        Zero-length segments are always routing artifacts: the advisory
+        routing-quality metrics (#4623) count and exclude them; this
+        rule reports each one as a per-segment warning (with net, layer
+        and position) so they become actionable and waivable via the
+        central ``.kct_waivers.json`` mechanism (#4417).  Uses the same
+        detection tolerance as the analysis module so the advisory
+        stanza's ``zero_length_count`` and this rule's finding count
+        always agree.
+
+        Returns:
+            DRCResults containing one ``zero_length_segment`` warning
+            per zero-length segment.
+        """
+        from .rules.zero_length_segment import ZeroLengthSegmentRule
+
+        rule = ZeroLengthSegmentRule()
         return self._absolutize(rule.check(self.pcb, self.design_rules))
 
     def check_zones(self) -> DRCResults:

--- a/src/kicad_tools/validate/rules/zero_length_segment.py
+++ b/src/kicad_tools/validate/rules/zero_length_segment.py
@@ -1,0 +1,114 @@
+"""Zero-length copper segment rule (issue #4651).
+
+Zero-length segments -- copper trace segments whose start and end
+coincide -- are always routing artifacts: they contribute no
+connectivity, confuse length-matching math, and can survive save/load
+round-trips indefinitely.  The advisory routing-quality metrics
+(:mod:`kicad_tools.analysis.routing_quality`, issue #4623) detect and
+count them (``zero_length_count``) but exclude them from every
+statistic; until this rule nothing ever *reported* them as findings.
+
+This rule promotes each zero-length segment to a real, per-segment DRC
+finding so the artifacts become actionable and -- because it is a
+normal ``DRCRule`` flowing through :meth:`DRCChecker.check_all` -- each
+finding is waivable through the central ``.kct_waivers.json`` mechanism
+(:mod:`kicad_tools.validate.rules.waivers`, issue #4417) with no extra
+plumbing.
+
+**Detection parity:** the rule uses the exact same predicate as the
+analysis module (``length <= COORD_EPSILON_MM``, imported from
+:mod:`kicad_tools.analysis.routing_quality`), so the advisory stanza's
+``zero_length_count`` and this rule's violation count can never
+diverge on the same board.
+
+**Severity:** ``warning``, not ``error``.  The issue-#4651 fleet
+pre-check (2026-08-07) found the repository's own board-05
+(``bldc_controller_routed.kicad_pcb``) carrying 5 zero-length
+segments, so defaulting to error would immediately fail a shipping
+board.  Warning surfaces the artifacts everywhere (and is fatal under
+``--strict``) while the waiver path and future cleanup harden it.
+
+**Waiver matching:** each finding carries the segment's net in
+``nets`` and a stable ``layer@(x,y)`` identifier in ``items`` (the
+sheet-absolute coordinate, matching the reported finding location, to
+4 decimals), so a waiver entry can target either one specific segment
+(by ``items``) or every zero-length artifact on a net (by ``nets``).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+from kicad_tools.analysis.routing_quality import COORD_EPSILON_MM
+
+from ..violations import DRCResults, DRCViolation
+from .base import DRCRule
+
+if TYPE_CHECKING:
+    from kicad_tools.manufacturers import DesignRules
+    from kicad_tools.schema.pcb import PCB
+
+
+class ZeroLengthSegmentRule(DRCRule):
+    """Flag every zero-length copper trace segment as a routing artifact."""
+
+    rule_id = "zero_length_segment"
+    name = "Zero-Length Segment"
+    description = (
+        "Detects copper trace segments whose start and end coincide "
+        "(always routing artifacts; excluded from routing-quality stats)"
+    )
+
+    def check(
+        self,
+        pcb: PCB,
+        design_rules: DesignRules,
+    ) -> DRCResults:
+        """Emit one warning per zero-length segment in ``pcb.segments``.
+
+        Args:
+            pcb: The PCB to check.
+            design_rules: Design rules (unused by this rule but required
+                by the base-class interface).
+
+        Returns:
+            DRCResults with one per-segment ``zero_length_segment``
+            warning carrying net + layer + position (needed for
+            ``.kct_waivers.json`` matching).
+        """
+        results = DRCResults()
+        results.rules_checked = 1
+
+        # Compose the waiver-matching ``items`` id in sheet-absolute
+        # coordinates so it agrees with the reported finding location
+        # (``DRCChecker._absolutize`` shifts ``location`` but never
+        # touches ``items``).
+        ox, oy = getattr(pcb, "board_origin", (0.0, 0.0))
+
+        for seg in pcb.segments:
+            dx = seg.end[0] - seg.start[0]
+            dy = seg.end[1] - seg.start[1]
+            if math.hypot(dx, dy) > COORD_EPSILON_MM:
+                continue
+
+            x, y = seg.start
+            net_label = seg.net_name if seg.net_name else f"net {seg.net_number}"
+            results.add(
+                DRCViolation(
+                    rule_id=self.rule_id,
+                    severity="warning",
+                    message=(
+                        f"Zero-length segment on '{net_label}' ({seg.layer}) -- "
+                        f"routing artifact carrying no copper; remove it "
+                        f"(width {seg.width:.3f} mm)"
+                    ),
+                    location=(x, y),
+                    layer=seg.layer,
+                    actual_value=0.0,
+                    items=(f"{seg.layer}@({x + ox:.4f},{y + oy:.4f})",),
+                    nets=(seg.net_name,) if seg.net_name else (),
+                )
+            )
+
+        return results

--- a/tests/test_routing_quality_metrics.py
+++ b/tests/test_routing_quality_metrics.py
@@ -454,3 +454,304 @@ class TestCheckCmdAdvisoryWireIn:
         out = capsys.readouterr().out
         assert "Routing quality (advisory):" in out
         assert "0 across 0 net(s)" in out
+
+
+# ---------------------------------------------------------------------------
+# Issue #4651: opt-in threshold gating over the advisory metrics.
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateRoutingQualityThresholds:
+    """Unit tests for the pure threshold-evaluation function."""
+
+    @staticmethod
+    def _metrics(fragment_fraction: float = 0.0, staircase_fraction: float = 0.0):
+        return RoutingQualityMetrics(
+            total_segments=10,
+            nets_with_copper=2,
+            segments_per_net=5.0,
+            zero_length_count=0,
+            median_length_mm=1.0,
+            fragment_count=int(round(10 * fragment_fraction)),
+            fragment_fraction=fragment_fraction,
+            orthogonal_count=10,
+            diagonal_45_count=0,
+            off_axis_count=0,
+            staircase_step_count=int(round(10 * staircase_fraction)),
+            staircase_fraction=staircase_fraction,
+        )
+
+    def test_no_thresholds_no_breaches(self):
+        from kicad_tools.analysis.routing_quality import (
+            evaluate_routing_quality_thresholds,
+        )
+
+        m = self._metrics(fragment_fraction=1.0, staircase_fraction=1.0)
+        assert evaluate_routing_quality_thresholds(m) == []
+
+    def test_equal_to_ceiling_passes(self):
+        """AC: exceed -> violation; equal/below -> pass."""
+        from kicad_tools.analysis.routing_quality import (
+            evaluate_routing_quality_thresholds,
+        )
+
+        m = self._metrics(fragment_fraction=0.5, staircase_fraction=0.4)
+        assert (
+            evaluate_routing_quality_thresholds(
+                m, max_fragment_fraction=0.5, max_staircase_fraction=0.4
+            )
+            == []
+        )
+
+    def test_below_ceiling_passes(self):
+        from kicad_tools.analysis.routing_quality import (
+            evaluate_routing_quality_thresholds,
+        )
+
+        m = self._metrics(fragment_fraction=0.1, staircase_fraction=0.1)
+        assert (
+            evaluate_routing_quality_thresholds(
+                m, max_fragment_fraction=0.5, max_staircase_fraction=0.5
+            )
+            == []
+        )
+
+    def test_fragment_breach(self):
+        from kicad_tools.analysis.routing_quality import (
+            RULE_FRAGMENT_FRACTION,
+            evaluate_routing_quality_thresholds,
+        )
+
+        m = self._metrics(fragment_fraction=0.6)
+        breaches = evaluate_routing_quality_thresholds(m, max_fragment_fraction=0.5)
+        assert len(breaches) == 1
+        b = breaches[0]
+        assert b.rule_id == RULE_FRAGMENT_FRACTION
+        assert b.metric == "fragment_fraction"
+        assert b.actual == pytest.approx(0.6)
+        assert b.limit == pytest.approx(0.5)
+        assert "fragment_fraction" in b.message
+
+    def test_staircase_breach(self):
+        from kicad_tools.analysis.routing_quality import (
+            RULE_STAIRCASE_FRACTION,
+            evaluate_routing_quality_thresholds,
+        )
+
+        m = self._metrics(staircase_fraction=0.9)
+        breaches = evaluate_routing_quality_thresholds(m, max_staircase_fraction=0.42)
+        assert len(breaches) == 1
+        assert breaches[0].rule_id == RULE_STAIRCASE_FRACTION
+        assert breaches[0].metric == "staircase_fraction"
+
+    def test_both_breach(self):
+        from kicad_tools.analysis.routing_quality import (
+            evaluate_routing_quality_thresholds,
+        )
+
+        m = self._metrics(fragment_fraction=1.0, staircase_fraction=1.0)
+        breaches = evaluate_routing_quality_thresholds(
+            m, max_fragment_fraction=0.0, max_staircase_fraction=0.0
+        )
+        assert len(breaches) == 2
+
+    def test_zero_ceiling_passes_on_clean_board(self):
+        """--max-fragment-fraction 0.0 passes when zero fragments exist."""
+        from kicad_tools.analysis.routing_quality import (
+            evaluate_routing_quality_thresholds,
+        )
+
+        m = self._metrics(fragment_fraction=0.0, staircase_fraction=0.0)
+        assert (
+            evaluate_routing_quality_thresholds(
+                m, max_fragment_fraction=0.0, max_staircase_fraction=0.0
+            )
+            == []
+        )
+
+    def test_gate_dict_shape(self):
+        from kicad_tools.analysis.routing_quality import (
+            evaluate_routing_quality_thresholds,
+            routing_quality_gate_dict,
+        )
+
+        m = self._metrics(staircase_fraction=1.0)
+        breaches = evaluate_routing_quality_thresholds(m, max_staircase_fraction=0.5)
+        d = routing_quality_gate_dict(
+            breaches, max_fragment_fraction=None, max_staircase_fraction=0.5
+        )
+        assert d["thresholds"] == {
+            "max_fragment_fraction": None,
+            "max_staircase_fraction": 0.5,
+        }
+        assert d["gate_passed"] is False
+        assert d["gate_breaches"] == [
+            {
+                "rule_id": "routing_quality_staircase_fraction",
+                "metric": "staircase_fraction",
+                "actual": 1.0,
+                "limit": 0.5,
+            }
+        ]
+
+    def test_gate_dict_passing(self):
+        from kicad_tools.analysis.routing_quality import routing_quality_gate_dict
+
+        d = routing_quality_gate_dict([], max_fragment_fraction=0.5, max_staircase_fraction=None)
+        assert d["gate_passed"] is True
+        assert d["gate_breaches"] == []
+
+
+class TestCheckCmdThresholdGate:
+    """CLI wire-in tests for --max-fragment-fraction / --max-staircase-fraction.
+
+    The ``staircase_pcb`` fixture has staircase_fraction == 1.0 and
+    fragment_fraction == 0.0; ``clean_45_pcb`` has both at 0.0.
+    """
+
+    def test_staircase_ceiling_exceeded_fails(self, staircase_pcb: Path, capsys):
+        from kicad_tools.cli.check_cmd import main
+
+        rc = main(
+            [
+                str(staircase_pcb),
+                "--max-staircase-fraction",
+                "0.5",
+                "--format",
+                "json",
+                "--allow-incomplete",
+            ]
+        )
+        data = json.loads(capsys.readouterr().out)
+        assert rc == 2
+        gate_violations = [
+            v for v in data["violations"] if v["rule_id"] == "routing_quality_staircase_fraction"
+        ]
+        assert len(gate_violations) == 1
+        v = gate_violations[0]
+        assert v["severity"] == "error"
+        assert v["actual_value"] == pytest.approx(1.0)
+        assert v["required_value"] == pytest.approx(0.5)
+        rq = data["routing_quality"]
+        assert rq["gate_passed"] is False
+        assert rq["thresholds"]["max_staircase_fraction"] == pytest.approx(0.5)
+        assert rq["thresholds"]["max_fragment_fraction"] is None
+        assert rq["gate_breaches"][0]["metric"] == "staircase_fraction"
+
+    def test_equal_ceiling_passes(self, staircase_pcb: Path, capsys):
+        """staircase_fraction == 1.0 with ceiling 1.0 -> pass (AC)."""
+        from kicad_tools.cli.check_cmd import main
+
+        rc = main(
+            [
+                str(staircase_pcb),
+                "--max-staircase-fraction",
+                "1.0",
+                "--format",
+                "json",
+                "--allow-incomplete",
+            ]
+        )
+        data = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert data["routing_quality"]["gate_passed"] is True
+        assert data["routing_quality"]["gate_breaches"] == []
+        assert not [v for v in data["violations"] if v["rule_id"].startswith("routing_quality_")]
+
+    def test_clean_board_passes_zero_ceilings(self, clean_45_pcb: Path, capsys):
+        from kicad_tools.cli.check_cmd import main
+
+        rc = main(
+            [
+                str(clean_45_pcb),
+                "--max-fragment-fraction",
+                "0.0",
+                "--max-staircase-fraction",
+                "0.0",
+                "--allow-incomplete",
+            ]
+        )
+        capsys.readouterr()
+        assert rc == 0
+
+    def test_no_flags_json_has_no_gate_keys(self, staircase_pcb: Path, capsys):
+        """AC: no new flags -> byte-identical advisory-only contract."""
+        from kicad_tools.cli.check_cmd import main
+
+        rc = main([str(staircase_pcb), "--format", "json", "--allow-incomplete"])
+        data = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        rq = data["routing_quality"]
+        assert "thresholds" not in rq
+        assert "gate_passed" not in rq
+        assert "gate_breaches" not in rq
+
+    def test_gate_engages_under_drc_only(self, staircase_pcb: Path, capsys):
+        """Gating is an explicit opt-in, so it works under --drc-only too."""
+        from kicad_tools.cli.check_cmd import main
+
+        rc = main(
+            [
+                str(staircase_pcb),
+                "--drc-only",
+                "--max-staircase-fraction",
+                "0.5",
+                "--format",
+                "json",
+            ]
+        )
+        data = json.loads(capsys.readouterr().out)
+        assert rc == 2
+        assert data["routing_quality"]["gate_passed"] is False
+
+    def test_drc_only_without_flags_still_omits_routing_quality(self, staircase_pcb: Path, capsys):
+        from kicad_tools.cli.check_cmd import main
+
+        rc = main([str(staircase_pcb), "--drc-only", "--format", "json"])
+        data = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert "routing_quality" not in data
+
+    def test_out_of_range_ceiling_is_usage_error(self, staircase_pcb: Path, capsys):
+        from kicad_tools.cli.check_cmd import main
+
+        assert main([str(staircase_pcb), "--max-fragment-fraction", "1.5"]) == 1
+        assert main([str(staircase_pcb), "--max-staircase-fraction", "-0.1"]) == 1
+        err = capsys.readouterr().err
+        assert "must be a fraction between 0.0 and 1.0" in err
+
+    def test_metrics_crash_is_fatal_when_gating(self, staircase_pcb: Path, capsys, monkeypatch):
+        """An explicitly requested gate must never silently pass because it
+        could not measure."""
+        from kicad_tools.cli import check_cmd
+
+        def _boom(pcb):
+            raise RuntimeError("synthetic metrics failure 4651")
+
+        monkeypatch.setattr(check_cmd, "compute_routing_quality", _boom)
+        rc = check_cmd.main(
+            [str(staircase_pcb), "--max-staircase-fraction", "0.5", "--allow-incomplete"]
+        )
+        err = capsys.readouterr().err
+        assert rc == 1
+        assert "cannot evaluate" in err
+
+    def test_report_file_carries_gate_verdict(self, staircase_pcb: Path, tmp_path: Path, capsys):
+        from kicad_tools.cli.check_cmd import main
+
+        report = tmp_path / "report_4651.json"
+        rc = main(
+            [
+                str(staircase_pcb),
+                "--max-staircase-fraction",
+                "0.5",
+                "--output",
+                str(report),
+                "--allow-incomplete",
+            ]
+        )
+        capsys.readouterr()
+        assert rc == 2
+        data = json.loads(report.read_text())
+        assert data["routing_quality"]["gate_passed"] is False
+        assert data["summary"]["passed"] is False

--- a/tests/test_zero_length_segment_rule.py
+++ b/tests/test_zero_length_segment_rule.py
@@ -1,0 +1,268 @@
+"""Tests for the ``zero_length_segment`` DRC rule (issue #4651).
+
+Zero-length segments are always routing artifacts; the advisory
+routing-quality metrics (#4623) count them (``zero_length_count``) but
+until #4651 nothing reported them as findings.  This file covers:
+
+- the rule unit behaviour on a synthetic board (per-segment warning with
+  net + layer + position, clean board emits nothing);
+- detection parity: the rule's finding count always equals the advisory
+  stanza's ``zero_length_count`` on the same board;
+- waivability through the central ``.kct_waivers.json`` mechanism
+  (#4417), both by ``items`` (one specific segment) and by ``nets``
+  (every artifact on a net);
+- severity contract: warning by default (exit 0), fatal under
+  ``--strict`` (the #4651 fleet pre-check found board-05 carrying five
+  zero-length segments, so error-by-default would break a shipping
+  board).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.analysis.routing_quality import compute_routing_quality
+from kicad_tools.schema.pcb import PCB
+
+# Mirrors the #4623 template in tests/test_routing_quality_metrics.py:
+# DRC-clean apart from the parameterizable segment block.
+_PCB_TEMPLATE = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general (thickness 1.6) (legacy_teardrops no))
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (37 "F.SilkS" user "F.Silkscreen")
+    (44 "Edge.Cuts" user)
+    (49 "F.Fab" user)
+  )
+  (setup (pad_to_mask_clearance 0))
+  (net 0 "")
+  (net 1 "GND")
+  (net 2 "+3.3V")
+  (gr_rect (start 100 100) (end 150 150)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+  (footprint "Resistor_SMD:R_0402_1005Metric"
+    (layer "F.Cu")
+    (uuid "00000000-0000-0000-0000-000000000010")
+    (at 125 125)
+    (property "Reference" "R1" (at 0 -1.5 0) (layer "F.SilkS")
+      (effects (font (size 1.0 1.0) (thickness 0.15)))
+      (uuid "00000000-0000-0000-0000-000000000011"))
+    (property "Value" "10k" (at 0 1.5 0) (layer "F.Fab") (uuid "00000000-0000-0000-0000-000000000012"))
+    (pad "1" smd roundrect (at -0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 1 "GND"))
+    (pad "2" smd roundrect (at 0.51 0) (size 0.54 0.64)
+      (layers "F.Cu" "F.Paste" "F.Mask") (roundrect_rratio 0.25) (net 2 "+3.3V"))
+  )
+{segments})
+"""
+
+# Two zero-length artifacts (nets GND and +3.3V) plus one normal segment.
+_ZERO_LENGTH_SEGMENTS = """  (segment (start 110 110) (end 110 110) (width 0.25) (layer "F.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-000000000020"))
+  (segment (start 112 118) (end 112 118) (width 0.25) (layer "B.Cu") (net 2)
+    (uuid "00000000-0000-0000-0000-000000000021"))
+  (segment (start 120 120) (end 122 122) (width 0.25) (layer "F.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-000000000022"))
+"""
+
+_CLEAN_SEGMENTS = """  (segment (start 110 110) (end 112 112) (width 0.25) (layer "F.Cu") (net 1)
+    (uuid "00000000-0000-0000-0000-000000000020"))
+"""
+
+
+@pytest.fixture
+def zero_length_pcb(tmp_path: Path) -> Path:
+    p = tmp_path / "zero_length_4651.kicad_pcb"
+    p.write_text(_PCB_TEMPLATE.format(segments=_ZERO_LENGTH_SEGMENTS))
+    return p
+
+
+@pytest.fixture
+def clean_pcb(tmp_path: Path) -> Path:
+    p = tmp_path / "clean_4651.kicad_pcb"
+    p.write_text(_PCB_TEMPLATE.format(segments=_CLEAN_SEGMENTS))
+    return p
+
+
+def _run_check_json(board: Path, capsys, *extra: str) -> tuple[int, dict]:
+    from kicad_tools.cli.check_cmd import main
+
+    rc = main(
+        [str(board), "--only", "zero_length_segment", "--format", "json", "--drc-only", *extra]
+    )
+    return rc, json.loads(capsys.readouterr().out)
+
+
+def _zl_violations(data: dict) -> list[dict]:
+    return [v for v in data["violations"] if v["rule_id"] == "zero_length_segment"]
+
+
+class TestZeroLengthSegmentRule:
+    def test_emits_one_warning_per_segment(self, zero_length_pcb: Path, capsys):
+        rc, data = _run_check_json(zero_length_pcb, capsys)
+        violations = _zl_violations(data)
+        # Warning severity: found but non-blocking by default.
+        assert rc == 0
+        assert len(violations) == 2
+        for v in violations:
+            assert v["severity"] == "warning"
+            assert v["location"] is not None
+            assert len(v["items"]) == 1
+            assert len(v["nets"]) == 1
+        by_net = {v["nets"][0]: v for v in violations}
+        assert set(by_net) == {"GND", "+3.3V"}
+        assert by_net["GND"]["layer"] == "F.Cu"
+        assert by_net["+3.3V"]["layer"] == "B.Cu"
+        # The items id carries the layer and the reported (sheet-absolute)
+        # position so a waiver can target one specific segment.
+        assert by_net["GND"]["items"][0].startswith("F.Cu@(")
+        gx, gy = by_net["GND"]["location"]
+        assert gx == pytest.approx(110.0)
+        assert gy == pytest.approx(110.0)
+
+    def test_clean_board_emits_nothing(self, clean_pcb: Path, capsys):
+        rc, data = _run_check_json(clean_pcb, capsys)
+        assert rc == 0
+        assert _zl_violations(data) == []
+        assert data["summary"]["warnings"] == 0
+
+    def test_strict_makes_warnings_fatal(self, zero_length_pcb: Path, capsys):
+        rc, data = _run_check_json(zero_length_pcb, capsys, "--strict")
+        assert rc == 2
+        assert len(_zl_violations(data)) == 2
+
+    def test_count_agrees_with_advisory_metrics(self, zero_length_pcb: Path, capsys):
+        """AC: stanza zero_length_count == rule violation count (same board)."""
+        rc, data = _run_check_json(zero_length_pcb, capsys)
+        assert rc == 0
+        metrics = compute_routing_quality(PCB.load(zero_length_pcb))
+        assert metrics.zero_length_count == len(_zl_violations(data)) == 2
+
+    def test_items_id_matches_reported_location(self, zero_length_pcb: Path, capsys):
+        """The waiver-matching items id and the JSON location agree."""
+        _, data = _run_check_json(zero_length_pcb, capsys)
+        for v in _zl_violations(data):
+            layer_part, coord_part = v["items"][0].split("@")
+            assert layer_part == v["layer"]
+            x, y = (float(t) for t in coord_part.strip("()").split(","))
+            assert x == pytest.approx(v["location"][0], abs=1e-3)
+            assert y == pytest.approx(v["location"][1], abs=1e-3)
+
+
+class TestZeroLengthSegmentWaivers:
+    """The rule flows through the central .kct_waivers.json mechanism (#4417)."""
+
+    def test_items_waiver_waives_one_segment(self, zero_length_pcb: Path, capsys):
+        # First run: harvest the exact items id from the JSON output (the
+        # workflow a waiver author follows).
+        _, data = _run_check_json(zero_length_pcb, capsys)
+        gnd = next(v for v in _zl_violations(data) if v["nets"] == ["GND"])
+
+        waiver = zero_length_pcb.parent / "w_items.json"
+        waiver.write_text(
+            json.dumps(
+                {
+                    "version": 2,
+                    "waivers": [
+                        {
+                            "rule": "zero_length_segment",
+                            "items": gnd["items"],
+                            "reason": "known router artifact, cleanup tracked",
+                            "issue": "kicad-tools#4651",
+                        }
+                    ],
+                }
+            )
+        )
+        rc, data = _run_check_json(zero_length_pcb, capsys, "--waivers", str(waiver))
+        assert rc == 0
+        violations = _zl_violations(data)
+        waived = [v for v in violations if v["waived"]]
+        active = [v for v in violations if not v["waived"]]
+        assert len(waived) == 1
+        assert waived[0]["nets"] == ["GND"]
+        assert waived[0]["status"] == "waived"
+        assert waived[0]["waiver_issue"] == "kicad-tools#4651"
+        assert len(active) == 1
+        assert active[0]["nets"] == ["+3.3V"]
+
+    def test_nets_waiver_with_strict_flips_exit(self, zero_length_pcb: Path, capsys):
+        """Waiving both artifacts (by nets) relieves the --strict gate."""
+        waiver = zero_length_pcb.parent / "w_nets.json"
+        waiver.write_text(
+            json.dumps(
+                {
+                    "version": 2,
+                    "waivers": [
+                        {
+                            "rule": "zero_length_segment",
+                            "nets": ["GND"],
+                            "reason": "known artifact on GND stitching",
+                            "issue": "kicad-tools#4651",
+                        },
+                        {
+                            "rule": "zero_length_segment",
+                            "nets": ["+3.3V"],
+                            "reason": "known artifact on 3V3 fanout",
+                            "issue": "kicad-tools#4651",
+                        },
+                    ],
+                }
+            )
+        )
+        # Unwaived: --strict fails on the two warnings.
+        rc, _ = _run_check_json(zero_length_pcb, capsys, "--strict")
+        assert rc == 2
+        # Waived: both findings report WAIVED and the gate passes.
+        rc, data = _run_check_json(zero_length_pcb, capsys, "--strict", "--waivers", str(waiver))
+        assert rc == 0
+        assert all(v["waived"] for v in _zl_violations(data))
+        assert data["summary"]["waived"] == 2
+        assert data["summary"]["warnings"] == 0
+
+
+class TestRegistration:
+    def test_rule_runs_in_default_check_all_set(self, zero_length_pcb: Path, capsys):
+        """No --only: the rule is part of the standard category set."""
+        from kicad_tools.cli.check_cmd import main
+
+        rc = main([str(zero_length_pcb), "--format", "json", "--drc-only"])
+        data = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert len(_zl_violations(data)) == 2
+
+    def test_checker_check_all_includes_rule(self, zero_length_pcb: Path):
+        from kicad_tools.validate import DRCChecker
+
+        checker = DRCChecker(PCB.load(zero_length_pcb), manufacturer="jlcpcb", layers=2)
+        results = checker.check_all()
+        zl = [v for v in results.violations if v.rule_id == "zero_length_segment"]
+        assert len(zl) == 2
+
+    def test_skip_category_suppresses_rule(self, zero_length_pcb: Path, capsys):
+        from kicad_tools.cli.check_cmd import main
+
+        rc = main(
+            [
+                str(zero_length_pcb),
+                "--skip",
+                "zero_length_segment",
+                "--format",
+                "json",
+                "--drc-only",
+            ]
+        )
+        data = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert _zl_violations(data) == []


### PR DESCRIPTION
## Summary

Implements items 1-2 of #4651 (routing-quality follow-ups deferred from #4623), per the curator's rescope. Item 3 (router cleanup pass) is explicitly OUT of scope — see the carve-out note below.

### Item 1 — opt-in routing-quality threshold gate

- New `kct check` flags `--max-fragment-fraction FRACTION` / `--max-staircase-fraction FRACTION` (default `None` = advisory-only, exactly today's behavior). Declared on **both** parsers (`check_cmd.py` inner + `parser.py` outer) and forwarded by the `commands/validation.py` shim — `tests/test_cli_parser_drift.py` stays green with both check allowlists still empty.
- Threshold evaluation is a pure function in `kicad_tools.analysis.routing_quality` (`evaluate_routing_quality_thresholds` over `RoutingQualityMetrics`), keeping `check_cmd.py` to wiring. `ThresholdBreach`, the rule-id constants, and `routing_quality_gate_dict` are exported from `kicad_tools.analysis`.
- Exceeding a ceiling emits a real **error**-severity violation (`routing_quality_fragment_fraction` / `routing_quality_staircase_fraction`) that flows through the normal verdict path: table/JSON output, error counts, DRC sub-check status, meta rollup, exit 2. Comparison is strictly-greater-than: a fraction exactly **equal** to the ceiling passes (per AC).
  - Severity decision (curator left it to Builder): error, documented in the flag help — the ceiling only exists because the caller opted in, so exceeding it is a deliberate CI failure, not an advisory.
- The `routing_quality` JSON object gains `thresholds`, `gate_passed`, and `gate_breaches` when gating is enabled; with no flags the JSON shape is byte-identical to the #4646 advisory-only contract.
- Because gating is an explicit opt-in it also engages under `--drc-only` (the stanza + JSON object then appear there too); without the flags the legacy `--drc-only` contract is untouched (existing #4623 tests still pass unmodified).
- A metrics crash **with gating requested** is a hard exit 1 ("an explicitly requested gate must never silently pass because it could not measure"); without gating it keeps the #4623 degrade-to-stderr-warning contract.
- Out-of-range ceilings (outside 0.0–1.0) are a usage error (exit 1).

### Item 2 — `zero_length_segment` as a waivable DRC rule

- New `src/kicad_tools/validate/rules/zero_length_segment.py` (`rule_id: zero_length_segment`), registered in the required pair: `DRCChecker.CHECK_ALL_METHODS` + the `check_methods` dict / `CHECK_CATEGORIES` in `cli/check_cmd.py` (`tests/test_check_cmd_coverage.py` green), so it flows through the central `.kct_waivers.json` mechanism (#4417) for free.
- One violation **per zero-length segment** with net + layer + position. `items` carries a stable `layer@(x,y)` id in sheet-absolute coordinates (agreeing with the reported `location`, which `_absolutize` shifts), so a waiver can target one specific segment by `items` or every artifact on a net by `nets`.
- Detection reuses `COORD_EPSILON_MM` from `kicad_tools.analysis.routing_quality` (same `length <= eps` predicate), so the advisory stanza's `zero_length_count` and the rule's finding count cannot diverge — pinned by a test.
- **Severity: warning, not error** — per the curator's mandated fleet pre-check (results below), board-05 currently carries zero-length segments, so error-by-default would immediately fail a shipping board. Warnings are fatal under `--strict`, and the waiver path lets boards harden.

### Fleet zero-length pre-check (curator-required, 2026-08-07, this branch)

All `boards/*/output/*.kicad_pcb`:

| Board | zero_length_count |
|---|---|
| 00, 01, 02, 03, 04, 06, 07 (all artifacts) | 0 |
| **05 `bldc_controller_routed.kicad_pcb`** | **5** (incl. nets BST_A / BST_B / BST_C on F.Cu) |

### Item 3 carve-out (NOT silently dropped)

The router cleanup pass (post-route consolidation of sub-0.25 mm fragments and H/V staircases into 45° geometry; 67% fragments / 42% staircase on the #4615 measurement board) is router-engine work and **no tracking issue exists for it yet** — searched open/closed issues for a cleanup-pass issue and found none. Per the curator's instruction, flagging here so Architect/Champion can file it under the mesh-router/octilinear line, referencing #4615 §2 and #4651.

## Acceptance criteria

- [x] `kct check` with no new flags behaves identically to today (all pre-existing #4623/#4646 tests pass unmodified)
- [x] `--max-fragment-fraction` / `--max-staircase-fraction` gate correctly (exceed → violation + exit 2; equal/below → pass); on both parsers (`test_cli_parser_drift.py` green)
- [x] `routing_quality` JSON carries thresholds + verdict when gating is enabled
- [x] `zero_length_segment` emits per-segment violations, waivable via `.kct_waivers.json`, registered in `CHECK_ALL_METHODS` + CLI dict (`test_check_cmd_coverage.py` green)
- [x] Advisory-stanza `zero_length_count` and the rule's violation count agree (pinned by test)
- [x] Item 3 explicitly deferred with a pointer (this section; no issue exists yet — needs filing)

## Testing

- 54 tests in `tests/test_routing_quality_metrics.py` (incl. 18 new: threshold unit tests with boundary cases, CLI gate wire-in, `--drc-only` interplay, crash-fatal-when-gating, report-file verdict) + new `tests/test_zero_length_segment_rule.py` (rule unit, metrics parity, items/nets waivers, `--strict`, registration).
- Broad batch: `test_cli_check*.py test_check*.py test_drc_report_formats.py test_cli_parser_drift.py` → **535 passed**; board-05 suites (`drc_allowlist`, `drc_hotspot_regression`) + `fix_drc_cmd`, `pad_grid_preflight`, `connectivity_rule` → **158 passed**.
- `ruff check` / `ruff format --check` clean; mypy baseline gate OK (1472 ≤ 1474 baseline; the only non-new error is the pre-existing baselined `checker.py` FilterEngine arg-type).
- End-to-end through the real `kct` entry point: board-05 shows the three BST zero-length warnings; board-02 with `--max-staircase-fraction 0.01` fails with `actual 0.01015 > limit 0.01` and full JSON gate detail.

Closes #4651

🤖 Generated with [Claude Code](https://claude.com/claude-code)
