### PR TITLE
feat(check): add LLM-free doc-drift sub-gate to kct check (#4540)

### DIFF
--- a/.github/mypy-baseline.txt
+++ b/.github/mypy-baseline.txt
@@ -1446,6 +1446,7 @@ src/kicad_tools/validate/consistency.py	misc	Need more than N values to unpack (
 src/kicad_tools/validate/consistency.py	misc	Need more than N values to unpack (N expected)
 src/kicad_tools/validate/diffpair_engagement.py	assignment	Incompatible types in assignment (expression has type "NetClassRouting | None", variable has type "NetClassRouting")
 src/kicad_tools/validate/diffpair_skew.py	assignment	Incompatible types in assignment (expression has type "NetClassRouting | None", variable has type "NetClassRouting")
+src/kicad_tools/validate/doc_drift.py	import-untyped	Library stubs not installed for "yaml"
 src/kicad_tools/validate/filters.py	assignment	Incompatible types in assignment (expression has type "ERCViolation", variable has type "DRCViolation")
 src/kicad_tools/validate/filters.py	import-not-found	Cannot find implementation or library stub for module named "tomli"
 src/kicad_tools/validate/filters.py	unused-ignore	Unused "type: ignore" comment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   routed artifact carrying 5 zero-length segments, so error-by-default
   would have broken a shipping board.
 
+- **LLM-free doc-drift sub-gate in `kct check`** (#4540, from the
+  copperhead workflow survey #4520 idea 3) — new advisory `doc_drift`
+  category (`--only doc_drift` / `--skip doc_drift`) that diffs opt-in
+  `<!-- kct:doc-pin <resolver> <key> = <value> -->` markers in the board
+  README against machine ground truth via a resolver registry
+  (`src/kicad_tools/validate/doc_drift.py`). v1 ships one resolver,
+  `drc-tolerance` (the per-board pin in
+  `.github/routed-drc-tolerance.yml`; an absent entry resolves to the
+  yml's strict-0 convention), and two INFO-severity rule ids:
+  `doc_drift_stale_pin` (claimed value != resolved ground truth, message
+  quotes doc `file:line`, both values, and the source) and
+  `doc_drift_unresolvable_pin` (unknown resolver / typo'd routed-PCB
+  path, so the gate can't rot silently). Findings never enter
+  `error_count`, the verdict, exit codes, or any fab/tapeout gate; free
+  prose is never parsed, and zero markers / missing README / missing
+  tolerance file all pass silently (bootstrap carve-out). Markers are
+  onboarded for board 06 (18) and board 07 (8) — fixing board 07's stale
+  "currently 80" README prose to the actual pin of 8 — so a future yml
+  ratchet without the README edit trips the check. v2 candidates
+  (BOM-vs-schematic fixed-column contract, version strings, escalation
+  to WARNING) are deferred.
+
 - **`kct pipeline` route-skip under `--voltage-map` now auto-runs a
   `kct creepage` audit as the skip gate** (#4649) — refining the #4607 loud
   refusal: when the board is already `>=`95% routed (recommend_skip) and no

--- a/boards/06-diffpair-test/README.md
+++ b/boards/06-diffpair-test/README.md
@@ -308,6 +308,10 @@ The job:
    three gated paths --- committed-artifact `routed-pcb-drc-check`,
    seed-42 Diff-Pair Routing Regression, and the Board 06 E2E fresh
    regen --- agreeing at 18).
+   <!-- kct:doc-pin drc-tolerance boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb = 18 -->
+   The claim above is machine-checked by `kct check --only doc_drift`
+   (issue #4540): ratcheting the yml without updating this README
+   trips `doc_drift_stale_pin`.
 4. Asserts each of the three diff-pair DRC rule_ids was actually
    exercised by the check, i.e. the JSON summary's
    `rules_checked_by_rule[rule_id] >= 1` for each of:

--- a/boards/07-matchgroup-test/README.md
+++ b/boards/07-matchgroup-test/README.md
@@ -430,7 +430,15 @@ The gate is a sibling of the `diffpair-routing-regression` job (board
 1. Re-routes board 07 from scratch with
    `python boards/07-matchgroup-test/generate_design.py --step route --seed 42`.
 2. Asserts the resulting DRC error count is within the per-board
-   allowlist in `.github/routed-drc-tolerance.yml` (currently 80).
+   allowlist in `.github/routed-drc-tolerance.yml` (currently 8:
+   4x `diffpair_length_skew` + 4x `diffpair_routing_continuity`;
+   ratcheted 35 -> 14 -> 9 -> 8 -- see the board-07 comment block in
+   the yml.  Per the #4008 unified-counter change, both gate arms
+   compare the identical advisory-filtered *blocking* count).
+   <!-- kct:doc-pin drc-tolerance boards/07-matchgroup-test/output/matchgroup_test_routed.kicad_pcb = 8 -->
+   The claim above is machine-checked by `kct check --only doc_drift`
+   (issue #4540): ratcheting the yml without updating this README
+   trips `doc_drift_stale_pin`.
 3. Asserts the `match_group_length_skew` DRC rule was actually
    exercised --- i.e., `rules_checked_by_rule["match_group_length_skew"] >= 1`
    in the `DRCChecker` summary.  Without this assertion a regression

--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -1108,6 +1108,7 @@ CHECK_CATEGORIES = [
     "diffpair_length_skew",
     "diffpair_routing_continuity",
     "dimensions",
+    "doc_drift",
     "edge",
     "impedance",
     "match_group_length_skew",
@@ -2032,6 +2033,7 @@ def main(argv: list[str] | None = None) -> int:
         pad_grid_auto_derive=pad_grid_auto_derive,
         sch_path=sch_path,
         sch_field_threshold=args.sch_field_threshold,
+        pcb_path=pcb_path,
     )
 
     # Issue #4417: apply general waivers centrally, once, AFTER all checks run.
@@ -2383,6 +2385,7 @@ def run_selected_checks(
     pad_grid_auto_derive: bool = True,
     sch_path: Path | None = None,
     sch_field_threshold: float = DEFAULT_SCH_FIELD_THRESHOLD_MM,
+    pcb_path: Path | None = None,
 ) -> DRCResults:
     """Run the selected DRC checks based on filters.
 
@@ -2406,6 +2409,12 @@ def run_selected_checks(
             that only exercise PCB-scoped checks are unaffected.
         sch_field_threshold: ``sch_field_offset`` distance threshold in
             mm (issue #4595; strictly-greater-than comparison).
+        pcb_path: Path of the ``.kicad_pcb`` under check, used only by
+            the ``doc_drift`` category (issue #4540) to locate the board
+            README and repo root -- the PCB is never re-parsed.  Must
+            default to ``None`` so library callers that only exercise
+            PCB-object-scoped checks are unaffected; the category is
+            then a silent no-op.
     """
     results = DRCResults()
 
@@ -2434,6 +2443,20 @@ def run_selected_checks(
 
         return check_schematic_fields(sch_path, threshold_mm=sch_field_threshold)
 
+    # Issue #4540: LLM-free doc-drift lint (kct:doc-pin markers vs
+    # machine ground truth).  Dispatched as a CLI-level closure (like
+    # ``pad_grid`` / ``sch_fields``) because it needs the PCB *path* to
+    # locate the board README and repo root -- it is intentionally NOT a
+    # ``DRCChecker`` method and NOT part of ``CHECK_ALL_METHODS``.  With
+    # no pcb_path it is a silent no-op; all findings are INFO severity
+    # (advisory, never blocking).
+    def _doc_drift_check() -> DRCResults:
+        if pcb_path is None:
+            return DRCResults()
+        from kicad_tools.validate.doc_drift import check_doc_drift
+
+        return check_doc_drift(pcb_path)
+
     # Map of category to check method.  This dict MUST stay a superset
     # of the methods invoked by ``DRCChecker.check_all`` (i.e., every
     # name in ``DRCChecker.CHECK_ALL_METHODS`` must be referenced as a
@@ -2453,6 +2476,7 @@ def run_selected_checks(
         "diffpair_length_skew": checker.check_diffpair_length_skew,
         "diffpair_routing_continuity": checker.check_diffpair_routing_continuity,
         "dimensions": checker.check_dimensions,
+        "doc_drift": _doc_drift_check,
         "edge": checker.check_edge_clearances,
         "impedance": checker.check_impedance,
         "match_group_length_skew": checker.check_match_group_length_skew,

--- a/src/kicad_tools/validate/checker.py
+++ b/src/kicad_tools/validate/checker.py
@@ -326,6 +326,13 @@ class DRCChecker:
         # Manufacturing bucket and there is no "sch" prefix fallback.
         "sch_field_offset": CATEGORY_ADVISORY,
         "sch_field_overlap": CATEGORY_ADVISORY,
+        # Doc-drift lint (Issue #4540): INFO-severity documentation
+        # staleness advisories (kct:doc-pin markers vs machine ground
+        # truth) -- never fab-blocking.  Explicit entries are REQUIRED:
+        # category_for_rule defaults unknown ids to the fab-blocking
+        # Manufacturing bucket and there is no "doc" prefix fallback.
+        "doc_drift_stale_pin": CATEGORY_ADVISORY,
+        "doc_drift_unresolvable_pin": CATEGORY_ADVISORY,
         "impedance": CATEGORY_ADVISORY,
         "diffpair_clearance_intra": CATEGORY_ADVISORY,
         "diffpair_length_skew": CATEGORY_ADVISORY,

--- a/src/kicad_tools/validate/doc_drift.py
+++ b/src/kicad_tools/validate/doc_drift.py
@@ -1,0 +1,348 @@
+"""LLM-free doc-drift lint for ``kct check`` (Issue #4540).
+
+The ``doc_drift`` category diffs a fixed, machine-parseable doc contract
+against committed artifacts.  It never parses free prose: the only thing
+it evaluates is the opt-in **doc-pin marker**, an HTML comment placed
+adjacent to a numeric claim in a markdown doc:
+
+.. code-block:: markdown
+
+    <!-- kct:doc-pin drc-tolerance boards/07-matchgroup-test/output/matchgroup_test_routed.kicad_pcb = 8 -->
+
+A marker names a *resolver* (``drc-tolerance``), a *key* (here a
+repo-relative routed-PCB path), and the *claimed value*.  The check
+resolves ground truth via a small resolver registry and compares.  Two
+rule ids, both :data:`Severity.INFO` -- advisory by construction, never
+entering ``error_count``, the check verdict, exit codes, or any fab /
+tapeout gate:
+
+* ``doc_drift_stale_pin`` -- the marker's claimed value differs from the
+  resolved ground truth (the README says one number, the machine source
+  of truth says another).
+* ``doc_drift_unresolvable_pin`` -- the marker names an unknown resolver
+  or a key the resolver cannot resolve (e.g. a typo'd board path).  This
+  keeps the gate from going silently vacuous when a marker rots.
+
+v1 ships exactly one resolver:
+
+``drc-tolerance``
+    Ground truth is the per-board pin in
+    ``.github/routed-drc-tolerance.yml`` (the ``tolerances:`` map keyed
+    by repo-relative routed-PCB path).  **Absence of an entry resolves
+    to 0** -- the yml's documented "absence == strict 0 errors"
+    convention -- provided the referenced routed-PCB path exists in the
+    repo; a nonexistent path is unresolvable (typo guard).
+
+Bootstrap carve-outs (copperhead's zero-symbol discipline, per the
+issue): zero markers found => the category passes silently; missing
+README, undiscoverable repo root, or missing repo-root tolerance file
+=> silent pass.  External users and scaffolding boards are unaffected;
+the contract is strictly opt-in per claim.
+
+The check is dispatched as a ``check_cmd``-local category (like
+``pad_grid`` / ``sch_fields``) because it needs the PCB *path* -- to
+locate the board-dir README -- rather than the parsed PCB object.  It is
+deliberately NOT a :class:`DRCChecker` method and NOT part of
+``CHECK_ALL_METHODS``.
+
+Determinism: findings are sorted by (doc path, line number, rule id),
+and only marker comments are evaluated, so repeated runs are
+byte-identical for CI.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Literal
+
+from .violations import DRCResults, DRCViolation
+
+RULE_STALE_PIN = "doc_drift_stale_pin"
+RULE_UNRESOLVABLE_PIN = "doc_drift_unresolvable_pin"
+
+#: Repo-relative location of the drc-tolerance ground-truth file.  Its
+#: presence also serves as one of the repo-root discovery sentinels.
+TOLERANCE_FILE = Path(".github") / "routed-drc-tolerance.yml"
+
+# The full single-line marker form.  Anything that does not match this
+# exactly (modulo flexible whitespace) is silently treated as prose --
+# markers are opt-in, and a malformed comment is just a comment.
+_DOC_PIN_RE = re.compile(
+    r"<!--\s*kct:doc-pin\s+"
+    r"(?P<resolver>[A-Za-z0-9_-]+)\s+"
+    r"(?P<key>\S+)\s*=\s*"
+    r"(?P<value>\S+)\s*-->"
+)
+
+
+@dataclass(frozen=True)
+class DocPin:
+    """One parsed ``kct:doc-pin`` marker."""
+
+    resolver: str
+    key: str
+    claimed: str
+    doc_path: Path
+    line: int
+
+
+@dataclass(frozen=True)
+class Resolution:
+    """Outcome of resolving a doc-pin's ground truth.
+
+    ``status`` semantics:
+
+    * ``"resolved"`` -- ground truth found; ``value`` holds it and
+      ``source`` names where it came from (quoted in messages).
+    * ``"unresolvable"`` -- the key cannot be resolved (typo'd path,
+      unknown resolver); ``reason`` explains why.  Emits
+      ``doc_drift_unresolvable_pin``.
+    * ``"skip"`` -- a documented carve-out applies (e.g. the repo-root
+      tolerance file is absent); the marker is silently ignored.
+    """
+
+    status: Literal["resolved", "unresolvable", "skip"]
+    value: int | None = None
+    source: str = ""
+    reason: str = ""
+
+
+def parse_doc_pins(doc_path: Path) -> list[DocPin]:
+    """Extract all well-formed ``kct:doc-pin`` markers from a doc.
+
+    Returns an empty list when the doc does not exist or is unreadable
+    (carve-out: docs are optional).  Markers are single-line only; a
+    comment split across lines never matches and is treated as prose.
+    """
+    try:
+        text = doc_path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    pins: list[DocPin] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        for match in _DOC_PIN_RE.finditer(line):
+            pins.append(
+                DocPin(
+                    resolver=match.group("resolver"),
+                    key=match.group("key"),
+                    claimed=match.group("value"),
+                    doc_path=doc_path,
+                    line=lineno,
+                )
+            )
+    return pins
+
+
+def find_repo_root(start: Path) -> Path | None:
+    """Walk up from ``start`` looking for the repo root.
+
+    A directory counts as the root when it contains ``.git`` or the
+    tolerance file (:data:`TOLERANCE_FILE`).  Returns ``None`` when no
+    ancestor qualifies (carve-out: the check silently passes outside a
+    repo checkout).
+    """
+    current = start.resolve()
+    for candidate in (current, *current.parents):
+        if (candidate / ".git").exists() or (candidate / TOLERANCE_FILE).is_file():
+            return candidate
+    return None
+
+
+def _resolve_drc_tolerance(repo_root: Path, key: str) -> Resolution:
+    """Resolver ``drc-tolerance``: per-board pin in the tolerance yml.
+
+    ``key`` is the repo-relative routed-PCB path used as the yml map key.
+    Absence of an entry resolves to 0 (the yml's "absence == strict 0
+    errors" convention) as long as the referenced path exists in the
+    repo; a nonexistent path is unresolvable so typo'd markers cannot
+    silently compare against the 0 default.
+    """
+    tolerance_path = repo_root / TOLERANCE_FILE
+    if not tolerance_path.is_file():
+        # Carve-out per the issue: a repo without the tolerance file
+        # passes silently (external consumers of kct check).
+        return Resolution(status="skip")
+
+    if not (repo_root / key).is_file():
+        return Resolution(
+            status="unresolvable",
+            reason=(
+                f"referenced routed-PCB path {key!r} does not exist in the repo (root {repo_root})"
+            ),
+        )
+
+    import yaml
+
+    try:
+        data = yaml.safe_load(tolerance_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as e:
+        return Resolution(
+            status="unresolvable",
+            reason=f"could not read {TOLERANCE_FILE}: {e}",
+        )
+
+    tolerances = data.get("tolerances", {}) if isinstance(data, dict) else {}
+    if not isinstance(tolerances, dict):
+        return Resolution(
+            status="unresolvable",
+            reason=f"{TOLERANCE_FILE} 'tolerances' field is not a mapping",
+        )
+
+    raw = tolerances.get(key)
+    if raw is None:
+        # Absence == strict 0 errors (the yml's documented convention).
+        return Resolution(
+            status="resolved",
+            value=0,
+            source=f"{TOLERANCE_FILE} (no entry => strict 0)",
+        )
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return Resolution(
+            status="unresolvable",
+            reason=f"{TOLERANCE_FILE} entry for {key!r} is not an integer: {raw!r}",
+        )
+    return Resolution(status="resolved", value=value, source=str(TOLERANCE_FILE))
+
+
+#: Resolver registry.  v1 ships exactly one resolver; adding another is
+#: one entry here plus a function above (see Issue #4540 for deferred v2
+#: candidates: BOM-vs-schematic contract, version strings).
+RESOLVERS: dict[str, Callable[[Path, str], Resolution]] = {
+    "drc-tolerance": _resolve_drc_tolerance,
+}
+
+
+def _display_path(doc_path: Path, repo_root: Path | None) -> str:
+    """Render ``doc_path`` repo-relative when possible (stable messages)."""
+    if repo_root is not None:
+        try:
+            return doc_path.resolve().relative_to(repo_root).as_posix()
+        except ValueError:
+            pass
+    return str(doc_path)
+
+
+def _readme_candidates(pcb_path: Path) -> list[Path]:
+    """Docs scanned for markers, given the PCB path.
+
+    Board artifacts live at ``boards/NN-name/output/board.kicad_pcb``
+    with the board README at ``boards/NN-name/README.md`` (the
+    grandparent), but a PCB committed next to its README (no ``output/``
+    nesting) is also supported via the parent.  Missing candidates are
+    skipped by :func:`parse_doc_pins`.
+    """
+    resolved = pcb_path.resolve()
+    candidates = [
+        resolved.parent / "README.md",
+        resolved.parent.parent / "README.md",
+    ]
+    unique: list[Path] = []
+    for candidate in candidates:
+        if candidate not in unique:
+            unique.append(candidate)
+    return unique
+
+
+def check_doc_drift(pcb_path: Path) -> DRCResults:
+    """Run the doc-drift lint for the board owning ``pcb_path``.
+
+    Args:
+        pcb_path: Path to the ``.kicad_pcb`` being checked.  Only the
+            path is used (to locate the board README and repo root); the
+            PCB is never parsed.
+
+    Returns:
+        :class:`DRCResults` containing only INFO-severity findings
+        (``doc_drift_stale_pin`` / ``doc_drift_unresolvable_pin``),
+        sorted by (doc path, line, rule id).  Every carve-out returns an
+        empty result set.
+    """
+    results = DRCResults()
+    results.rules_checked = 2
+    results.rules_checked_by_rule[RULE_STALE_PIN] = 1
+    results.rules_checked_by_rule[RULE_UNRESOLVABLE_PIN] = 1
+
+    pins: list[DocPin] = []
+    for doc in _readme_candidates(pcb_path):
+        pins.extend(parse_doc_pins(doc))
+    if not pins:
+        return results  # Bootstrap carve-out: zero markers => silent pass.
+
+    repo_root = find_repo_root(pcb_path.resolve().parent)
+    if repo_root is None:
+        return results  # Carve-out: not inside a discoverable repo.
+
+    findings: list[tuple[tuple[str, int, str], DRCViolation]] = []
+    for pin in pins:
+        doc_rel = _display_path(pin.doc_path, repo_root)
+        resolver = RESOLVERS.get(pin.resolver)
+        if resolver is None:
+            message = (
+                f"{doc_rel}:{pin.line}: doc-pin names unknown resolver "
+                f"{pin.resolver!r} (known: {', '.join(sorted(RESOLVERS))})"
+            )
+            findings.append(
+                (
+                    (doc_rel, pin.line, RULE_UNRESOLVABLE_PIN),
+                    DRCViolation(
+                        rule_id=RULE_UNRESOLVABLE_PIN,
+                        severity="info",
+                        message=message,
+                    ),
+                )
+            )
+            continue
+
+        resolution = resolver(repo_root, pin.key)
+        if resolution.status == "skip":
+            continue
+        if resolution.status == "unresolvable":
+            message = (
+                f"{doc_rel}:{pin.line}: doc-pin key {pin.key!r} could not be "
+                f"resolved: {resolution.reason}"
+            )
+            findings.append(
+                (
+                    (doc_rel, pin.line, RULE_UNRESOLVABLE_PIN),
+                    DRCViolation(
+                        rule_id=RULE_UNRESOLVABLE_PIN,
+                        severity="info",
+                        message=message,
+                    ),
+                )
+            )
+            continue
+
+        assert resolution.value is not None
+        try:
+            claimed_value: int | None = int(pin.claimed)
+        except ValueError:
+            claimed_value = None
+        if claimed_value == resolution.value:
+            continue
+        message = (
+            f"{doc_rel}:{pin.line}: doc-pin claims {pin.resolver} "
+            f"{pin.key} = {pin.claimed}, but {resolution.source} "
+            f"pins {resolution.value}"
+        )
+        findings.append(
+            (
+                (doc_rel, pin.line, RULE_STALE_PIN),
+                DRCViolation(
+                    rule_id=RULE_STALE_PIN,
+                    severity="info",
+                    message=message,
+                    actual_value=float(resolution.value),
+                    required_value=float(claimed_value) if claimed_value is not None else None,
+                ),
+            )
+        )
+
+    findings.sort(key=lambda pair: pair[0])
+    for _, violation in findings:
+        results.add(violation)
+    return results

--- a/tests/test_check_cmd_coverage.py
+++ b/tests/test_check_cmd_coverage.py
@@ -174,7 +174,12 @@ class TestCategoryListMatchesDispatcher:
     #   used here leaves ``sch_path=None``, making the closure a silent
     #   no-op.  It is deliberately NOT a checker method / NOT in
     #   ``CHECK_ALL_METHODS`` -- the checker is PCB-scoped.
-    NON_CHECKER_CATEGORIES = frozenset({"sch_fields"})
+    # * ``doc_drift`` (Issue #4540): kct:doc-pin marker lint.  It runs on
+    #   the board README + repo ground-truth files located from the PCB
+    #   *path*, and the bare call here leaves ``pcb_path=None``, making
+    #   the closure a silent no-op.  Same rationale: not a checker
+    #   method, not in ``CHECK_ALL_METHODS``.
+    NON_CHECKER_CATEGORIES = frozenset({"sch_fields", "doc_drift"})
 
     def test_categories_list_equals_dispatcher_keys(self) -> None:
         checker = _build_minimal_checker()

--- a/tests/test_check_doc_drift.py
+++ b/tests/test_check_doc_drift.py
@@ -1,0 +1,326 @@
+"""Tests for the LLM-free doc-drift lint (Issue #4540).
+
+Covers the ``kct:doc-pin`` marker grammar, the ``drc-tolerance``
+resolver (hit / absent-entry-resolves-to-0 / unresolvable path), the
+bootstrap carve-outs (zero markers, missing README, undiscoverable repo
+root, missing tolerance file), the advisory INFO-severity guarantee
+(``error_count`` never moves), the JSON shape, the CLI dispatcher
+integration, and a committed-artifact guard asserting the onboarded
+board-06 / board-07 markers are clean against the committed
+``.github/routed-drc-tolerance.yml`` (the self-maintaining ratchet
+contract: a future yml ratchet without the README edit fails here).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from kicad_tools.cli import check_cmd
+from kicad_tools.schema.pcb import PCB
+from kicad_tools.validate import DRCChecker
+from kicad_tools.validate.doc_drift import (
+    RULE_STALE_PIN,
+    RULE_UNRESOLVABLE_PIN,
+    DocPin,
+    check_doc_drift,
+    find_repo_root,
+    parse_doc_pins,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+BOARD_06_PCB = REPO_ROOT / "boards/06-diffpair-test/output/diffpair_test_routed.kicad_pcb"
+BOARD_07_PCB = REPO_ROOT / "boards/07-matchgroup-test/output/matchgroup_test_routed.kicad_pcb"
+
+
+def _make_repo(
+    tmp_path: Path,
+    *,
+    tolerance_yaml: str | None = "tolerances:\n  boards/x/output/board.kicad_pcb: 8\n",
+    readme: str | None = None,
+    git_dir: bool = True,
+) -> Path:
+    """Build a minimal repo fixture; returns the PCB path.
+
+    Layout::
+
+        <tmp>/repo/.git/
+        <tmp>/repo/.github/routed-drc-tolerance.yml
+        <tmp>/repo/boards/x/README.md
+        <tmp>/repo/boards/x/output/board.kicad_pcb
+    """
+    repo = tmp_path / "repo"
+    board_dir = repo / "boards" / "x"
+    output_dir = board_dir / "output"
+    output_dir.mkdir(parents=True)
+    if git_dir:
+        (repo / ".git").mkdir()
+    if tolerance_yaml is not None:
+        gh = repo / ".github"
+        gh.mkdir()
+        (gh / "routed-drc-tolerance.yml").write_text(tolerance_yaml)
+    if readme is not None:
+        (board_dir / "README.md").write_text(readme)
+    pcb_path = output_dir / "board.kicad_pcb"
+    pcb_path.write_text("(kicad_pcb)")
+    return pcb_path
+
+
+def _marker(value: str = "8", key: str = "boards/x/output/board.kicad_pcb") -> str:
+    return f"<!-- kct:doc-pin drc-tolerance {key} = {value} -->\n"
+
+
+class TestMarkerGrammar:
+    def test_valid_marker_parsed(self, tmp_path: Path) -> None:
+        doc = tmp_path / "README.md"
+        doc.write_text("prose\n" + _marker("8") + "more prose\n")
+        pins = parse_doc_pins(doc)
+        assert pins == [
+            DocPin(
+                resolver="drc-tolerance",
+                key="boards/x/output/board.kicad_pcb",
+                claimed="8",
+                doc_path=doc,
+                line=2,
+            )
+        ]
+
+    def test_tolerant_whitespace(self, tmp_path: Path) -> None:
+        doc = tmp_path / "README.md"
+        doc.write_text("<!--   kct:doc-pin   drc-tolerance   a/b.kicad_pcb=42   -->\n")
+        (pin,) = parse_doc_pins(doc)
+        assert pin.resolver == "drc-tolerance"
+        assert pin.key == "a/b.kicad_pcb"
+        assert pin.claimed == "42"
+
+    def test_malformed_markers_ignored_as_prose(self, tmp_path: Path) -> None:
+        doc = tmp_path / "README.md"
+        doc.write_text(
+            # Missing '=' separator.
+            "<!-- kct:doc-pin drc-tolerance a/b.kicad_pcb 8 -->\n"
+            # Wrong prefix.
+            "<!-- kct:docpin drc-tolerance a/b.kicad_pcb = 8 -->\n"
+            # Multi-line comment (markers are single-line only).
+            "<!-- kct:doc-pin drc-tolerance\n a/b.kicad_pcb = 8 -->\n"
+            # Plain prose mentioning the syntax.
+            "use kct:doc-pin markers = good\n"
+        )
+        assert parse_doc_pins(doc) == []
+
+    def test_missing_doc_returns_empty(self, tmp_path: Path) -> None:
+        assert parse_doc_pins(tmp_path / "nope.md") == []
+
+    def test_multiple_markers_all_parsed(self, tmp_path: Path) -> None:
+        doc = tmp_path / "README.md"
+        doc.write_text(_marker("8") + "prose\n" + _marker("9", key="c/d.kicad_pcb"))
+        pins = parse_doc_pins(doc)
+        assert [(p.claimed, p.line) for p in pins] == [("8", 1), ("9", 3)]
+
+
+class TestFindRepoRoot:
+    def test_finds_git_dir(self, tmp_path: Path) -> None:
+        pcb_path = _make_repo(tmp_path, tolerance_yaml=None)
+        assert find_repo_root(pcb_path.parent) == (tmp_path / "repo").resolve()
+
+    def test_finds_tolerance_file_without_git(self, tmp_path: Path) -> None:
+        pcb_path = _make_repo(tmp_path, git_dir=False)
+        assert find_repo_root(pcb_path.parent) == (tmp_path / "repo").resolve()
+
+    def test_no_root_returns_none(self, tmp_path: Path) -> None:
+        # pytest tmp dirs are outside any git checkout, so the walk to
+        # the filesystem root finds no sentinel.
+        deep = tmp_path / "a" / "b"
+        deep.mkdir(parents=True)
+        assert find_repo_root(deep) is None
+
+
+class TestDrcToleranceResolver:
+    def test_matching_pin_no_findings(self, tmp_path: Path) -> None:
+        pcb_path = _make_repo(tmp_path, readme=_marker("8"))
+        results = check_doc_drift(pcb_path)
+        assert results.violations == []
+        assert results.rules_checked_by_rule[RULE_STALE_PIN] == 1
+        assert results.rules_checked_by_rule[RULE_UNRESOLVABLE_PIN] == 1
+
+    def test_stale_pin_fires_once_with_both_values(self, tmp_path: Path) -> None:
+        pcb_path = _make_repo(tmp_path, readme="line1\n" + _marker("80"))
+        results = check_doc_drift(pcb_path)
+        assert len(results.violations) == 1
+        v = results.violations[0]
+        assert v.rule_id == RULE_STALE_PIN
+        assert v.severity == "info"
+        # Message names the doc file:line, both values, and the source.
+        assert "boards/x/README.md:2" in v.message
+        assert "80" in v.message
+        assert "pins 8" in v.message
+        assert "routed-drc-tolerance.yml" in v.message
+
+    def test_absent_entry_resolves_to_zero(self, tmp_path: Path) -> None:
+        # The pinned key is NOT in the tolerances map: absence == strict 0.
+        yaml_text = "tolerances:\n  boards/other/output/o.kicad_pcb: 3\n"
+        pcb_path = _make_repo(tmp_path, tolerance_yaml=yaml_text, readme=_marker("0"))
+        assert check_doc_drift(pcb_path).violations == []
+
+    def test_absent_entry_mismatch_fires_stale(self, tmp_path: Path) -> None:
+        yaml_text = "tolerances:\n  boards/other/output/o.kicad_pcb: 3\n"
+        pcb_path = _make_repo(tmp_path, tolerance_yaml=yaml_text, readme=_marker("5"))
+        (v,) = check_doc_drift(pcb_path).violations
+        assert v.rule_id == RULE_STALE_PIN
+        assert "strict 0" in v.message
+
+    def test_nonexistent_key_path_is_unresolvable(self, tmp_path: Path) -> None:
+        pcb_path = _make_repo(
+            tmp_path, readme=_marker("8", key="boards/typo/output/board.kicad_pcb")
+        )
+        (v,) = check_doc_drift(pcb_path).violations
+        assert v.rule_id == RULE_UNRESOLVABLE_PIN
+        assert v.severity == "info"
+        assert "does not exist" in v.message
+
+    def test_unknown_resolver_is_unresolvable(self, tmp_path: Path) -> None:
+        readme = "<!-- kct:doc-pin bogus-resolver some/key = 8 -->\n"
+        pcb_path = _make_repo(tmp_path, readme=readme)
+        (v,) = check_doc_drift(pcb_path).violations
+        assert v.rule_id == RULE_UNRESOLVABLE_PIN
+        assert "bogus-resolver" in v.message
+        assert "drc-tolerance" in v.message  # Known resolvers are listed.
+
+    def test_non_integer_yaml_entry_is_unresolvable(self, tmp_path: Path) -> None:
+        yaml_text = "tolerances:\n  boards/x/output/board.kicad_pcb: lots\n"
+        pcb_path = _make_repo(tmp_path, tolerance_yaml=yaml_text, readme=_marker("8"))
+        (v,) = check_doc_drift(pcb_path).violations
+        assert v.rule_id == RULE_UNRESOLVABLE_PIN
+
+    def test_multiple_markers_all_evaluated(self, tmp_path: Path) -> None:
+        readme = _marker("8") + "prose\n" + _marker("99")
+        pcb_path = _make_repo(tmp_path, readme=readme)
+        violations = check_doc_drift(pcb_path).violations
+        assert [v.rule_id for v in violations] == [RULE_STALE_PIN]
+        assert "README.md:3" in violations[0].message
+
+
+class TestCarveOuts:
+    def test_zero_markers_silent_pass(self, tmp_path: Path) -> None:
+        pcb_path = _make_repo(tmp_path, readme="no markers here\n")
+        assert check_doc_drift(pcb_path).violations == []
+
+    def test_missing_readme_silent_pass(self, tmp_path: Path) -> None:
+        pcb_path = _make_repo(tmp_path, readme=None)
+        assert check_doc_drift(pcb_path).violations == []
+
+    def test_no_repo_root_silent_pass(self, tmp_path: Path) -> None:
+        # Markers exist but no .git / tolerance-file sentinel anywhere up
+        # the tree: silent pass.
+        board_dir = tmp_path / "boards" / "x"
+        output_dir = board_dir / "output"
+        output_dir.mkdir(parents=True)
+        (board_dir / "README.md").write_text(_marker("8"))
+        pcb_path = output_dir / "board.kicad_pcb"
+        pcb_path.write_text("(kicad_pcb)")
+        assert check_doc_drift(pcb_path).violations == []
+
+    def test_repo_without_tolerance_file_silent_pass(self, tmp_path: Path) -> None:
+        # .git present (root discoverable) but no tolerance file: the
+        # drc-tolerance resolver skips silently (external consumers).
+        pcb_path = _make_repo(tmp_path, tolerance_yaml=None, readme=_marker("8"))
+        assert check_doc_drift(pcb_path).violations == []
+
+
+class TestAdvisoryGuarantee:
+    """INFO severity: findings never move error/warning counts."""
+
+    def test_findings_are_info_only(self, tmp_path: Path) -> None:
+        pcb_path = _make_repo(tmp_path, readme=_marker("80"))
+        results = check_doc_drift(pcb_path)
+        assert results.info_count == 1
+        assert results.error_count == 0
+        assert results.warning_count == 0
+        assert results.passed is True
+
+    def test_json_shape(self, tmp_path: Path) -> None:
+        pcb_path = _make_repo(tmp_path, readme=_marker("80"))
+        (v,) = check_doc_drift(pcb_path).violations
+        data = v.to_dict()
+        assert data["rule_id"] == RULE_STALE_PIN
+        assert data["severity"] == "info"
+        assert data["status"] == "info"
+        assert data["waived"] is False
+        assert isinstance(data["message"], str)
+
+    def test_rules_classified_advisory_for_reporting(self) -> None:
+        # Reporting-taxonomy entries (Issue #3803 style) so the findings
+        # land in the advisory-quality bucket, never the fab-blocking one.
+        for rule_id in (RULE_STALE_PIN, RULE_UNRESOLVABLE_PIN):
+            assert DRCChecker.category_for_rule(rule_id) == DRCChecker.CATEGORY_ADVISORY
+        # And the GATING advisory set is untouched (orthogonal axis).
+        assert RULE_STALE_PIN not in DRCChecker.ADVISORY_RULE_IDS
+        assert RULE_UNRESOLVABLE_PIN not in DRCChecker.ADVISORY_RULE_IDS
+
+
+class TestDispatcherIntegration:
+    """The CLI category wiring in ``run_selected_checks``."""
+
+    @staticmethod
+    def _checker() -> DRCChecker:
+        pcb = PCB.create(width=10.0, height=10.0, layers=2)
+        return DRCChecker(pcb, manufacturer="jlcpcb", layers=2)
+
+    def test_category_registered(self) -> None:
+        assert "doc_drift" in check_cmd.CHECK_CATEGORIES
+
+    def test_no_pcb_path_is_silent_noop(self) -> None:
+        results = check_cmd.run_selected_checks(
+            self._checker(), only_set={"doc_drift"}, skip_set=set()
+        )
+        assert results.violations == []
+        assert results.rules_checked == 0
+
+    def test_pcb_path_dispatches_check(self, tmp_path: Path) -> None:
+        pcb_path = _make_repo(tmp_path, readme=_marker("80"))
+        results = check_cmd.run_selected_checks(
+            self._checker(),
+            only_set={"doc_drift"},
+            skip_set=set(),
+            pcb_path=pcb_path,
+        )
+        assert [v.rule_id for v in results.violations] == [RULE_STALE_PIN]
+        assert results.error_count == 0
+
+    def test_skip_suppresses_category(self, tmp_path: Path) -> None:
+        pcb_path = _make_repo(tmp_path, readme=_marker("80"))
+        results = check_cmd.run_selected_checks(
+            self._checker(),
+            only_set={"doc_drift"},
+            skip_set={"doc_drift"},
+            pcb_path=pcb_path,
+        )
+        assert results.violations == []
+
+
+class TestCommittedArtifactsClean:
+    """The onboarded markers must be clean on the committed tree.
+
+    This is the self-maintaining ratchet contract from Issue #4540: any
+    future PR that ratchets ``.github/routed-drc-tolerance.yml`` for
+    board 06 / board 07 without updating the board README's doc-pin
+    marker (and prose) fails HERE, closing the cross-PR staleness gap
+    that ``annotate_drift_warning`` (#2590) explicitly does not cover.
+    """
+
+    def test_board06_markers_clean(self) -> None:
+        assert BOARD_06_PCB.is_file(), "board-06 committed artifact missing"
+        results = check_doc_drift(BOARD_06_PCB)
+        assert results.violations == [], [v.message for v in results.violations]
+
+    def test_board06_readme_has_marker(self) -> None:
+        pins = parse_doc_pins(BOARD_06_PCB.parent.parent / "README.md")
+        assert any(p.resolver == "drc-tolerance" for p in pins)
+
+    def test_board07_markers_clean(self) -> None:
+        assert BOARD_07_PCB.is_file(), "board-07 committed artifact missing"
+        results = check_doc_drift(BOARD_07_PCB)
+        assert results.violations == [], [v.message for v in results.violations]
+
+    def test_board07_readme_has_marker(self) -> None:
+        pins = parse_doc_pins(BOARD_07_PCB.parent.parent / "README.md")
+        assert any(p.resolver == "drc-tolerance" for p in pins)


### PR DESCRIPTION
## Summary

Adds the LLM-free doc-drift sub-gate from the copperhead workflow survey (#4520, idea 3) as a new advisory `doc_drift` category in `kct check`, per the curated spec on #4540.

### Gate design (v1)

- **Marker contract, never prose**: only the single-line HTML comment form is evaluated —
  `<!-- kct:doc-pin <resolver> <key> = <value> -->`. Malformed comments are silently treated as prose (markers are strictly opt-in per claim).
- **New module** `src/kicad_tools/validate/doc_drift.py`: marker parser + resolver registry, unit-testable without a PCB, returning standard `DRCViolation`s so text and `--format json` output work for free.
- **One resolver**: `drc-tolerance` — ground truth is the per-board pin in `.github/routed-drc-tolerance.yml` (`tolerances:` map). An **absent entry resolves to 0** (the yml's "absence == strict 0 errors" convention); a **nonexistent routed-PCB path is unresolvable** (typo guard, so a rotted marker can't silently compare against the 0 default).
- **Two rule ids, both INFO severity**:
  - `doc_drift_stale_pin` — claimed value != resolved ground truth; message quotes the doc `file:line`, both values, and the ground-truth source.
  - `doc_drift_unresolvable_pin` — unknown resolver or unresolvable key (keeps the gate from going silently vacuous).
- **Advisory guarantee**: findings never enter `error_count`, the check verdict, exit codes, `--strict` fatality (which only escalates warnings), or any fab/tapeout gate. `scripts/ci/check_routed_drc.py` and the board-06/07 gates count via `check_all` / blocking counters that never invoke this CLI-local category at all. Verified: board-06 committed artifact reports identical `18 errors / 10 warnings / 3 infos` with and without `--skip doc_drift`.
- **Dispatch**: `check_cmd`-local closure following the `pad_grid` / `sch_fields` precedent — it needs the PCB *path* (board README at `pcb.parent.parent/README.md`, with `pcb.parent/README.md` also scanned for un-nested layouts; repo root via `.git` / tolerance-file walk-up). NOT a `DRCChecker` method, NOT in `CHECK_ALL_METHODS`; `run_selected_checks` gains an optional `pcb_path=None` parameter (library callers unaffected).
- **Bootstrap carve-outs** (copperhead zero-symbol discipline): zero markers, missing README, undiscoverable repo root, or missing tolerance file ⇒ silent pass.
- **Reporting taxonomy**: both rule ids registered `advisory-quality` in `DRCChecker.RULE_CATEGORY`; the gating `ADVISORY_RULE_IDS` set is untouched.

### Board-07 README drift fixed (verified live on main)

`boards/07-matchgroup-test/README.md` step-2 said the allowlist was "currently **80**" while `.github/routed-drc-tolerance.yml` pins **8**. Fixed to 8 with the ratchet citation (35 → 14 → 9 → 8, #4008 unified-counter note), and the claim is now pinned by a `kct:doc-pin` marker. Board-06's step-3 figure (correct at 18 post-#4652) also gets a marker. **Zero `doc_drift_*` findings on the committed tree at introduction**; any future yml ratchet without the README edit trips `doc_drift_stale_pin` — including in CI via the new committed-artifact cleanliness tests.

### Drift guards reconciled

- Board-03 baseline: `doc_drift` is not reachable from `check_all`, and board-03's README has no markers — full `tests/router/test_board03_routing_baseline.py` suite passes with no `EXPECTED_COMMITTED_DRC_RULES` change (as the curator predicted).
- Board-06 (`EXPECTED_STRICT_GATE_ERRORS = 18`) and board-07 suites: all 100 tests pass, counts unchanged.
- `tests/test_check_cmd_coverage.py` (#3046 invariant): `doc_drift` added to the documented `NON_CHECKER_CATEGORIES` allowance with rationale.
- One surgical mypy-baseline line for the untyped `yaml` import (per-file convention; no `--update`).

### Verification

- `uv run kct check boards/07-.../matchgroup_test_routed.kicad_pcb --only doc_drift` → 0 findings, DRC PASSED.
- Marker temporarily mutated to 80 → exactly one INFO `doc_drift_stale_pin` in text and `--format json` (message: `boards/07-matchgroup-test/README.md:438: doc-pin claims drc-tolerance ... = 80, but .github/routed-drc-tolerance.yml pins 8`), exit 0 (`--drc-only`); the composite exit is driven by the pre-existing board-07 LVS residual either way.
- New `tests/test_check_doc_drift.py`: 34 tests (grammar, resolver hit/absent-entry=0/unresolvable, carve-outs, INFO/JSON guarantees, dispatcher wiring, committed-artifact guard).
- Targeted suites: 292 passed (check_cmd coverage, sch_fields, pad_grid, connector access, connectivity, fix-drc, ampacity, impedance) + 100 board-06/07 + full board-03 baseline.
- Ruff clean + formatted; `scripts/ci/check_mypy_baseline.py` OK (no new errors).

### Explicit non-goals (v2 candidates, per the curated spec — no new issues filed)

- BOM refdes/value/footprint vs schematic fixed-column contract (no board has such a doc contract today; a v1 rule would be vacuous).
- Version-string pins (`pyproject.toml` vs docs) — low observed pain.
- CLI-help-vs-docs checks — docs quote help as free prose, violating the fixed-contract discipline.
- Escalating the rules to WARNING — possible follow-up after soak time.

Closes #4540
