### PR TITLE
fix(connectivity): map native relationships onto internal classification instead of wholesale-replacing (#4551)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Connectivity `validate(reconcile_native=True)` no longer discards the
+  internal classification** (#4551) — the native reconciliation path used to
+  wholesale-replace `result.issues` with kicad-cli relationships hardcoded as
+  `zone_island` with empty `unconnected_pads`, so `unrouted`/`partial`/
+  `isolated` always read 0 on machines with kicad-cli (board-03 unrouted:
+  internal 16 `partial`/68 unconnected pads collapsed to 37 `zone_island`/0).
+  Native relationships now keep their authoritative *count* (#4498 fleet
+  parity: board-03 = 13, board-05 = 57) but are classified by endpoint kind:
+  zone-only relationships stay `zone_island`, while pad-bearing relationships
+  inherit the internal classification for their net and carry the pad
+  endpoint descriptions in `unconnected_pads`. Two rendering/diagnostic
+  defects fixed alongside: kicad-cli's generic "Missing connection between
+  items" message is enriched at the source with the real endpoint refs
+  ("Pad 3 [GND] of U1 on B.Cu"), fixing the default table, JSON, and
+  `summary()` in one place; and an *unexpected* kicad-cli exit code during
+  reconciliation now emits a `RuntimeWarning` naming the exit code and the
+  internal issue count being silently substituted (the expected KiCad-less
+  degradations — no board path, kicad-cli not installed — stay silent).
+  `validate(reconcile_native=False)` behavior is unchanged.
+
 - **Boards 03/06/07: committed routed artifacts refreshed with corrected 3D
   model transforms** (#4585) — the kicad-tools.org gallery cards for
   `diffpair_test_routed` (board 06, mini-PCIe socket 90° off its pad column)

--- a/src/kicad_tools/validate/connectivity.py
+++ b/src/kicad_tools/validate/connectivity.py
@@ -353,12 +353,31 @@ class ConnectivityValidator:
         result.connected_nets = connected_count
         result.zone_connected_nets = zone_connected_count
         if reconcile_native:
-            native_issues = self._native_unconnected_relationships()
+            # Issue #4551: map native relationships onto the internal
+            # classification instead of discarding it.  The per-net lookup
+            # carries the internal ``unrouted``/``partial``/``isolated``
+            # verdicts so that a native pad-bearing relationship keeps its
+            # internal type (and the reconciled result's per-type counts stay
+            # populated) while the native relationship *count* remains
+            # authoritative for the opt-in path (#4498 fleet parity).
+            internal_types = {
+                issue.net_name: issue.issue_type
+                for issue in result.issues
+                if issue.issue_type in ("unrouted", "partial", "isolated")
+            }
+            native_issues = self._native_unconnected_relationships(
+                internal_types=internal_types,
+                internal_issue_count=len(result.issues),
+            )
             if native_issues is not None:
                 result.issues = native_issues
         return result
 
-    def _native_unconnected_relationships(self) -> list[ConnectivityIssue] | None:
+    def _native_unconnected_relationships(
+        self,
+        internal_types: dict[str, str] | None = None,
+        internal_issue_count: int | None = None,
+    ) -> list[ConnectivityIssue] | None:
         """Return KiCad's per-item relationships, or ``None`` when unavailable.
 
         This is the explicit high-fidelity reconciliation path permitted by
@@ -373,6 +392,24 @@ class ConnectivityValidator:
         Refill-time connectivity is therefore authoritative for the opt-in
         path; it reports board05's exact current 57 without weakening the
         KiCad-less fail-visible model.
+
+        Args:
+            internal_types: Optional ``net_name -> issue_type`` lookup built
+                from the internal classification (``unrouted`` / ``partial``
+                / ``isolated``).  A native relationship with a pad endpoint
+                inherits the internal type for its net; zone-only
+                relationships (and nets the internal analysis did not flag)
+                keep ``zone_island``.
+            internal_issue_count: Number of internal issues that will be
+                silently substituted if this method returns ``None``.  Only
+                used to make the unexpected-exit-code warning actionable.
+
+        Returns ``None`` on the two *expected* degradations (PCB passed as an
+        object, kicad-cli not installed) without emitting anything; an
+        *unexpected* kicad-cli exit code also returns ``None`` but emits a
+        ``RuntimeWarning`` naming the exit code and the substituted internal
+        count (issue #4551 — the silent fallback made a kicad-cli crash
+        indistinguishable from the documented KiCad-less path).
         """
         if self.pcb_path is None:
             return None
@@ -405,6 +442,20 @@ class ConnectivityValidator:
                 check=False,
             )
             if proc.returncode not in (0, 5):
+                import warnings
+
+                substituted = (
+                    f"; substituting the internal analysis ({internal_issue_count} issue(s))"
+                    if internal_issue_count is not None
+                    else ""
+                )
+                warnings.warn(
+                    "kicad-cli pcb drc exited with unexpected code "
+                    f"{proc.returncode} during native connectivity "
+                    f"reconciliation{substituted}",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
                 return None
             report = DRCReport.load(report_file.name)
 
@@ -412,16 +463,37 @@ class ConnectivityValidator:
         # ``unconnected_items`` collection, NOT in ``violations`` -- the
         # geometric collection keeps its pre-#4498 meaning for every
         # ``run_geometric_drc`` consumer.
+        lookup = internal_types or {}
         issues: list[ConnectivityIssue] = []
         for index, violation in enumerate(report.connectivity_items()):
             item_ids = tuple(violation.items) or (f"native-unconnected[{index}]",)
+            net_name = violation.nets[0] if violation.nets else "<native>"
+            # Issue #4551: classify by endpoint kind + internal lookup rather
+            # than hardcoding zone_island.  Zone-only relationships keep
+            # today's meaning; a relationship with a pad endpoint inherits the
+            # internal classification for its net when one exists, so the
+            # reconciled result's unrouted/partial/isolated views stay
+            # populated on unrouted boards.
+            pad_endpoints = tuple(
+                item_id for item_id in violation.items if not item_id.startswith("Zone ")
+            )
+            issue_type = lookup.get(net_name, "zone_island") if pad_endpoints else "zone_island"
+            # kicad-cli's top-level description is the generic "Missing
+            # connection between items"; the real endpoint refs live in the
+            # per-item descriptions.  Compose them into the message so the
+            # default table, JSON, and summary() all show actual pad/zone
+            # references (issue #4551).
+            message = violation.message
+            if message == "Missing connection between items" and len(item_ids) >= 2:
+                message = f"Missing connection between {item_ids[0]} and {item_ids[1]}"
             issues.append(
                 ConnectivityIssue(
                     severity="error",
-                    issue_type="zone_island",
-                    net_name=violation.nets[0] if violation.nets else "<native>",
-                    message=violation.message,
+                    issue_type=issue_type,
+                    net_name=net_name,
+                    message=message,
                     suggestion="Connect the items reported by kicad-cli",
+                    unconnected_pads=pad_endpoints,
                     islands=tuple((item_id,) for item_id in item_ids),
                 )
             )

--- a/tests/test_connectivity.py
+++ b/tests/test_connectivity.py
@@ -151,8 +151,15 @@ def test_connectivity_and_geometry_contracts_hold_simultaneously(tmp_path, monke
     # Contract 1 -- connectivity sees all 12 relationships.
     result = ConnectivityValidator(board).validate(reconcile_native=True)
     assert len(result.issues) == 12
+    # Issue #4551 mapping: the pad<->zone relationships inherit the internal
+    # classification for GND, which on this board is itself ``zone_island``
+    # (the orphaned-fill issue), so the type set is unchanged here.
     assert {issue.issue_type for issue in result.issues} == {"zone_island"}
     assert result.error_count == 12
+    # Issue #4551: the generic kicad-cli message is enriched with the real
+    # endpoint descriptions, and pad endpoints populate unconnected_pads.
+    assert all("of U1 on B.Cu" in issue.message for issue in result.issues)
+    assert result.unconnected_pad_count == 12
 
     # Contract 2 -- geometry-only consumers see zero, from the same report.
     geo = run_geometric_drc(board)
@@ -233,6 +240,151 @@ def test_board03_connectivity_and_geometry_contracts_native(tmp_path) -> None:
         "board-03 is geometrically clean; connectivity relationships must not "
         f"be counted as geometric violations: {geometric.by_type}"
     )
+
+
+def _relationship_payload(item_pairs: list[tuple[str, str]]) -> dict:
+    """A KiCad-shaped JSON report with one relationship per endpoint pair."""
+    return {
+        "source": "board.kicad_pcb",
+        "violations": [],
+        "unconnected_items": [
+            {
+                "type": "unconnected_items",
+                "severity": "error",
+                "description": "Missing connection between items",
+                "items": [
+                    {"description": left, "pos": {"x": 1.0, "y": 1.0}},
+                    {"description": right, "pos": {"x": 2.0, "y": 2.0}},
+                ],
+            }
+            for left, right in item_pairs
+        ],
+        "schematic_parity": [],
+    }
+
+
+def test_reconcile_maps_native_relationships_onto_internal_types(tmp_path, monkeypatch) -> None:
+    """Issue #4551: native relationships inherit the internal classification.
+
+    ``PARTIALLY_CONNECTED_PCB`` classifies NET1 and GND internally as
+    ``partial``.  A native pad-bearing relationship on NET1 must carry that
+    type (so ``result.partial`` / ``unconnected_pad_count`` stay populated),
+    while a zone<->zone relationship keeps ``zone_island`` even though GND
+    also has an internal classification.  The native relationship *count*
+    stays authoritative (#4498 parity).
+    """
+    import subprocess
+
+    import kicad_tools.cli.runner as runner_mod
+
+    board = tmp_path / "board.kicad_pcb"
+    board.write_text(PARTIALLY_CONNECTED_PCB)
+
+    payload = _relationship_payload(
+        [
+            ("Pad 1 [NET1] of R2 on F.Cu", "Pad 1 [NET1] of R3 on F.Cu"),
+            ("Zone [GND] on F.Cu", "Zone [GND] on B.Cu"),
+        ]
+    )
+    monkeypatch.setattr(runner_mod, "find_kicad_cli", lambda *a, **k: Path("/usr/bin/kicad-cli"))
+    monkeypatch.setattr(subprocess, "run", _fake_kicad_cli_drc(payload))
+
+    result = ConnectivityValidator(board).validate(reconcile_native=True)
+
+    # Count parity: exactly the native relationships, no merged list.
+    assert len(result.issues) == 2
+
+    pad_issue, zone_issue = result.issues
+    assert pad_issue.issue_type == "partial"
+    assert pad_issue.net_name == "NET1"
+    assert pad_issue.unconnected_pads == (
+        "Pad 1 [NET1] of R2 on F.Cu",
+        "Pad 1 [NET1] of R3 on F.Cu",
+    )
+    assert pad_issue.message == (
+        "Missing connection between Pad 1 [NET1] of R2 on F.Cu and Pad 1 [NET1] of R3 on F.Cu"
+    )
+
+    assert zone_issue.issue_type == "zone_island"
+    assert zone_issue.unconnected_pads == ()
+
+    # The reconciled result's per-type views are populated again.
+    assert len(result.partial) == 1
+    assert len(result.zone_islands) == 1
+    assert result.unconnected_pad_count == 2
+    assert result.error_count == 2
+
+
+def test_reconcile_warns_on_unexpected_kicad_cli_exit(tmp_path, monkeypatch) -> None:
+    """Issue #4551: an unexpected kicad-cli exit code is no longer silent.
+
+    The warning names the exit code and the internal issue count being
+    substituted, and the internal result is returned intact.
+    """
+    import subprocess
+
+    import kicad_tools.cli.runner as runner_mod
+
+    board = tmp_path / "board.kicad_pcb"
+    board.write_text(PARTIALLY_CONNECTED_PCB)
+    monkeypatch.setattr(runner_mod, "find_kicad_cli", lambda *a, **k: Path("/usr/bin/kicad-cli"))
+
+    def _run(cmd, *args, **kwargs):
+        return subprocess.CompletedProcess([str(c) for c in cmd], 4, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _run)
+
+    with pytest.warns(
+        RuntimeWarning,
+        match=r"unexpected code 4 .*substituting the internal analysis \(2 issue\(s\)\)",
+    ):
+        result = ConnectivityValidator(board).validate(reconcile_native=True)
+
+    # Internal classification substituted unchanged.
+    assert len(result.issues) == 2
+    assert {issue.issue_type for issue in result.issues} == {"partial"}
+
+
+def test_reconcile_expected_degradations_stay_silent(tmp_path, monkeypatch, recwarn) -> None:
+    """Issue #4551: the documented KiCad-less paths emit no warning."""
+    import kicad_tools.cli.runner as runner_mod
+
+    board = tmp_path / "board.kicad_pcb"
+    board.write_text(PARTIALLY_CONNECTED_PCB)
+
+    # kicad-cli not installed.
+    monkeypatch.setattr(runner_mod, "find_kicad_cli", lambda *a, **k: None)
+    result = ConnectivityValidator(board).validate(reconcile_native=True)
+    assert len(result.issues) == 2
+
+    # PCB passed as an object (no path for kicad-cli to read).
+    result_obj = ConnectivityValidator(PCB.load(str(board))).validate(reconcile_native=True)
+    assert len(result_obj.issues) == 2
+
+    assert [w for w in recwarn.list if issubclass(w.category, RuntimeWarning)] == []
+
+
+def test_output_table_shows_native_endpoints_without_verbose(tmp_path, monkeypatch, capsys) -> None:
+    """Issue #4551: the default table shows real endpoint refs, not N generic lines."""
+    import subprocess
+
+    import kicad_tools.cli.runner as runner_mod
+    from kicad_tools.cli.validate_connectivity_cmd import output_table
+
+    board = tmp_path / "board.kicad_pcb"
+    board.write_text(PARTIALLY_CONNECTED_PCB)
+
+    payload = _relationship_payload([("Zone [GND] on F.Cu", "Pad 2 [GND] of R3 on F.Cu")])
+    monkeypatch.setattr(runner_mod, "find_kicad_cli", lambda *a, **k: Path("/usr/bin/kicad-cli"))
+    monkeypatch.setattr(subprocess, "run", _fake_kicad_cli_drc(payload))
+
+    result = ConnectivityValidator(board).validate(reconcile_native=True)
+    output_table(result, board, verbose=False)
+
+    out = capsys.readouterr().out
+    assert "Zone [GND] on F.Cu" in out
+    assert "Pad 2 [GND] of R3 on F.Cu" in out
+    assert "Missing connection between items" not in out
 
 
 # PCB with fully connected nets (all pads connected via tracks)


### PR DESCRIPTION
## Summary

Fixes the three fidelity defects in `validate(reconcile_native=True)` documented in #4551 (from the #4515 Judge review), implementing the curated **Option A** (map native relationships onto the internal classification):

1. **Type/count fidelity restored** — `src/kicad_tools/validate/connectivity.py`: `validate()` builds a per-net lookup of the internal `unrouted`/`partial`/`isolated` classification before reconciliation. `_native_unconnected_relationships()` no longer hardcodes `zone_island`: zone-only relationships keep `zone_island` (today's meaning), pad-bearing relationships inherit the internal classification for their net (fallback `zone_island`) and carry the pad endpoint descriptions in `unconnected_pads`, so `result.unrouted`/`partial`/`isolated` and `unconnected_pad_count` are populated again on unrouted boards. The native relationship **count** stays authoritative (#4498 fleet parity).
2. **Renderer fixed at the source** — when kicad-cli's message is the generic "Missing connection between items" and endpoint items exist, the message is composed as `Missing connection between {items[0]} and {items[1]}`, fixing the default table, `--format json`, and `summary()` in one place. No change to `validate_connectivity_cmd.py` (per the curated guidance, message enrichment alone satisfies AC2).
3. **Silent fallback made loud** — an *unexpected* kicad-cli exit code emits a `RuntimeWarning` naming the exit code and the internal issue count being substituted. The expected KiCad-less degradations (PCB passed as object, kicad-cli not installed) stay silent.

`validate(reconcile_native=False)` is byte-identical (the reconcile block is the only touched path in `validate()`; `_native_unconnected_relationships` is only called when reconciling, and its new parameters default to compatible values).

## Acceptance criteria (curated)

- [x] Reconciled result's `unrouted`/`partial`/`isolated` + `unconnected_pad_count` populated when internal analysis found them (mock regression test)
- [x] Native count parity preserved — fleet parity tests (board-03 = 13, board-05 = 57) pass **unmodified and verified locally with kicad-cli installed**
- [x] Default table shows both endpoint descriptions (renderer test via `output_table`, non-verbose)
- [x] Unexpected exit code → warning naming exit code + internal count; kicad-cli missing / PCB-object → no warning (both tested)
- [x] `reconcile_native=False` unchanged — full 69-test `tests/test_connectivity.py` suite passes
- [x] Regression tests use the existing kicad-cli-free mock harness (`_fake_kicad_cli_drc`), CI-safe without KiCad
- The `{"zone_island"}` type-set assertion in the existing mock test is deliberately kept with a comment (under the mapping, GND's internal classification on that fixture is itself `zone_island`) and strengthened with message-enrichment + `unconnected_pad_count` assertions.

## Testing

- `tests/test_connectivity.py`: 69 passed (4 new tests + 1 strengthened), including kicad-cli-gated fleet parity (13/57) locally
- `ruff check` + `ruff format --check` clean on changed files
- mypy baseline gate: `OK: 1472 error(s), all within the baseline. No new type errors.` (the 12 pre-existing `Pad`-type errors in this file are line-number-independent baseline entries; baseline file untouched)

Closes #4551

🤖 Generated with [Claude Code](https://claude.com/claude-code)
