### PR TITLE
fix(lvs): label-leg vacuity guard + both legs named in kct check LVS detail (#4681)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,6 +277,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   placement, zones, nets untouched) and DRC output is identical pre/post.
   Renders remain git-ignored; the gallery picks up the fix at the next
   operator redeploy.
+- **`kct check` LVS: net-less PCBs no longer emit one pseudo-mismatch per
+  schematic pin, and `detail` names both comparator legs** (#4681) — on a
+  board whose pads carry no `(net ...)` bindings, the label-based (netlist)
+  leg used to emit one all-`pcb_net: null` record per bound schematic pin
+  (264 on the filed board) while the `detail` prose reported only the
+  copper leg's count, so consumers naturally paired `detail` with the
+  wrong array. The label leg now has a vacuity guard mirroring the copper
+  leg's #4005 guard: zero PCB net bindings (with pads present and >=1
+  bound schematic pin) yields a single synthetic record
+  (`ref="<vacuous>"`, `pcb_net="<no-pcb-evidence>"`, evidence counters in
+  the other fields) and an additive `netlist_vacuous: true` flag in both
+  `lvs.json` and `meta_checks.lvs`; the result is still dirty (no
+  evidence is not a pass). Explicit no-connect sentinels count as raw
+  evidence, so all-NC boards and genuine partial mismatches keep their
+  per-pad records. Whenever either leg is dirty, `kct check`'s LVS
+  `detail` now names both legs' outcomes (e.g.
+  `copper: 2 mismatch(es): ...; label: 264 mismatch(es)` or
+  `label: vacuous (no PCB pad carries a net binding); copper: 0
+  mismatch(es)`), and `build_lvs_payload`'s docstring states the leg
+  mapping explicitly (`mismatches` = label leg, `copper_mismatches` =
+  copper leg). v1 `lvs.json` keys/shapes are unchanged; additions only.
 
 - **Softstart lattice proofs: re-pin to the current fixture + content-hash
   drift guard** (#4670) — the local-only softstart routing proof

--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -705,6 +705,15 @@ def _lvs_subcheck(sch_path: Path | None, pcb_path: Path) -> SubCheckResult:
     copper-dirty board the label findings appeared in *no* output.  The
     copper-dirty branch is now a ``detail``-selection branch, not a
     return, and both legs are always carried.
+
+    Issue #4681: whenever either leg is dirty, ``detail`` names **both**
+    legs' outcomes so a consumer can pair the prose with the right
+    embedded array — ``mismatches`` is the label (netlist) leg,
+    ``copper_mismatches`` the copper leg (see
+    :func:`kicad_tools.lvs.build_lvs_payload`).  A label leg with zero
+    PCB net bindings reports an explicit ``vacuous`` verdict (single
+    synthetic record + ``netlist_vacuous: true``) instead of one
+    pseudo-mismatch per bound schematic pin.
     """
     if sch_path is None:
         return SubCheckResult(
@@ -745,16 +754,28 @@ def _lvs_subcheck(sch_path: Path | None, pcb_path: Path) -> SubCheckResult:
         include_schema=False,
     )
 
+    # Issue #4681: the label leg's outcome, phrased for the ``detail``
+    # line.  A vacuous verdict (zero PCB net bindings) is spelled out so
+    # nobody reads the single synthetic ``mismatches`` record as a real
+    # per-pin finding.
+    if result.vacuous:
+        label_summary = "label: vacuous (no PCB pad carries a net binding)"
+    else:
+        label_summary = f"label: {len(label_records)} mismatch(es)"
+
     if not copper.clean:
         # The copper-extracted gate is the soundness-critical one: surface
         # it first.  Show up to the first 3 records in a stable order.
+        # The label leg's count rides along (#4681) so ``detail`` names
+        # both legs and a consumer knows which array holds which findings.
         preview = ", ".join(
             f"{m.kind} {m.pad_a}({m.net_a})/{m.pad_b}({m.net_b})" for m in copper_records[:3]
         )
         suffix = "" if len(copper_records) <= 3 else f" (+{len(copper_records) - 3} more)"
         return SubCheckResult(
             status="FAILED",
-            detail=f"copper: {len(copper_records)} mismatch(es): {preview}{suffix}",
+            detail=f"copper: {len(copper_records)} mismatch(es): {preview}{suffix}"
+            f"; {label_summary}",
             data=data,
         )
 
@@ -762,6 +783,13 @@ def _lvs_subcheck(sch_path: Path | None, pcb_path: Path) -> SubCheckResult:
         return SubCheckResult(
             status="PASSED",
             detail="label + copper: 0 mismatch(es)",
+            data=data,
+        )
+
+    if result.vacuous:
+        return SubCheckResult(
+            status="FAILED",
+            detail=f"{label_summary}; copper: 0 mismatch(es)",
             data=data,
         )
 
@@ -773,7 +801,8 @@ def _lvs_subcheck(sch_path: Path | None, pcb_path: Path) -> SubCheckResult:
     suffix = "" if len(label_records) <= 3 else f" (+{len(label_records) - 3} more)"
     return SubCheckResult(
         status="FAILED",
-        detail=f"label: {len(label_records)} mismatch(es): {preview}{suffix}",
+        detail=f"label: {len(label_records)} mismatch(es): {preview}{suffix}"
+        "; copper: 0 mismatch(es)",
         data=data,
     )
 

--- a/src/kicad_tools/lvs/__init__.py
+++ b/src/kicad_tools/lvs/__init__.py
@@ -43,6 +43,8 @@ Public API:
 """
 
 from kicad_tools.lvs.board_lvs import (
+    NETLIST_VACUOUS_NET,
+    NETLIST_VACUOUS_REF,
     BoardNetlistMismatch,
     LVSMismatch,
     LVSResult,
@@ -72,6 +74,8 @@ __all__ = [
     "FreshCopperCheckError",
     "LVSMismatch",
     "LVSResult",
+    "NETLIST_VACUOUS_NET",
+    "NETLIST_VACUOUS_REF",
     "VACUOUS_KIND",
     "VACUOUS_NET",
     "_ref_of",

--- a/src/kicad_tools/lvs/board_lvs.py
+++ b/src/kicad_tools/lvs/board_lvs.py
@@ -56,6 +56,19 @@ from kicad_tools.sexp import SExp, parse_file
 # all once both sides are recognized as placeholders.
 _PLACEHOLDER_NET_RE = re.compile(r"^Net-\(.*\)$")
 
+# --- Label-leg vacuity guard (issue #4681, mirroring copper's #4005 guard) ---
+#
+# Sentinel ``ref`` carried by the single synthetic mismatch emitted when the
+# PCB side contributes **zero** net bindings (see :func:`compare_netlists`).
+# Angle brackets keep it out of the legal KiCad reference-designator space,
+# the same convention as :data:`kicad_tools.lvs.copper_lvs.VACUOUS_NET`.
+NETLIST_VACUOUS_REF = "<vacuous>"
+
+# Sentinel "net name" carried on the synthetic vacuity record's ``pcb_net``
+# side: it states explicitly that the PCB supplied no evidence, instead of
+# the ``null`` a real unconnected pad would carry.
+NETLIST_VACUOUS_NET = "<no-pcb-evidence>"
+
 
 def _is_placeholder_net(name: str | None) -> TypeGuard[str]:
     """True when ``name`` is an auto-generated (unnamed-net) placeholder.
@@ -97,6 +110,19 @@ class LVSResult:
 
     clean: bool
     mismatches: tuple[LVSMismatch, ...]
+
+    @property
+    def vacuous(self) -> bool:
+        """True when this result is the PCB-evidence vacuity verdict (#4681).
+
+        A vacuous result means the PCB side supplied zero net bindings
+        (see :func:`compare_netlists`), so the comparator observed
+        nothing — ``clean`` is forced ``False`` and the sole mismatch
+        carries ``ref=NETLIST_VACUOUS_REF``.  Derived from the mismatch
+        list (not stored) so JSON round-trips and hand-built results
+        preserve it, mirroring ``CopperLVSResult.vacuous``.
+        """
+        return any(m.ref == NETLIST_VACUOUS_REF for m in self.mismatches)
 
 
 class BoardNetlistMismatch(Exception):
@@ -307,12 +333,51 @@ def compare_netlists(sch_path: str | Path, pcb_path: str | Path) -> LVSResult:
         :class:`LVSResult`.  Always returned -- mismatches are data, not
         exceptions.  Callers (recipes) raise
         :class:`BoardNetlistMismatch` themselves when they want to fail.
+
+        **Vacuity guard (issue #4681):** when the PCB supplies zero net
+        bindings while the board has pads and the schematic binds >=1
+        pin, the result is a single synthetic mismatch with
+        ``ref=NETLIST_VACUOUS_REF`` / ``pcb_net=NETLIST_VACUOUS_NET``
+        (and ``LVSResult.vacuous`` is ``True``) instead of one
+        pseudo-mismatch per bound schematic pin.  The result is still
+        dirty: no evidence is not a pass (same rationale as the copper
+        leg's #4005 guard).
     """
     sch_path = Path(sch_path)
     pcb_path = Path(pcb_path)
 
     sch_map = _schematic_pin_to_net(sch_path)
     pcb_map = _pcb_pin_to_net(pcb_path)
+
+    # --- Vacuity guard (issue #4681, mirroring the copper leg's #4005
+    #     guard): when the PCB side supplies **zero** net bindings — every
+    #     pad lacks a ``(net ...)`` child or carries only the empty net-0
+    #     name — while the board has pads and the schematic binds at least
+    #     one pin, the comparator has no PCB evidence at all.  Diffing
+    #     anyway would emit one pseudo-mismatch per bound schematic pin
+    #     (264 all-``pcb_net=null`` records on the #4681 board), which
+    #     reads as N real defects instead of one degraded input.  Refuse:
+    #     return a single synthetic record so the result is still dirty
+    #     (no evidence is not a pass) and consumers see an explicit
+    #     vacuous verdict.
+    #
+    #     Raw (pre-normalization) bindings count as evidence on purpose:
+    #     an explicit no-connect sentinel (``unconnected-(REF-PIN-PadN)``)
+    #     is a deliberate per-pad binding even though it normalizes to
+    #     ``None`` below, so a small board of NC pads still gets the real
+    #     per-pad diff (test_board_lvs_nc_sentinel.py pins that).  Any
+    #     board with >=1 net-bearing pad is likewise unchanged — genuine
+    #     partial mismatches keep their per-pad records.
+    sch_bound = sum(1 for v in sch_map.values() if v is not None)
+    pcb_bound = sum(1 for v in pcb_map.values() if v)  # non-None AND non-empty
+    if pcb_map and sch_bound and not pcb_bound:
+        vacuity = LVSMismatch(
+            ref=NETLIST_VACUOUS_REF,
+            pad=f"board_pads={len(pcb_map)}",
+            schematic_net=f"sch_bound_pins={sch_bound}",
+            pcb_net=NETLIST_VACUOUS_NET,
+        )
+        return LVSResult(clean=False, mismatches=(vacuity,))
 
     # The PCB's net 0 — encoded as an empty-string ``(net 0 "")`` net
     # name — is the "no connection" placeholder, not a real net.

--- a/src/kicad_tools/lvs/recipe.py
+++ b/src/kicad_tools/lvs/recipe.py
@@ -312,13 +312,29 @@ def build_lvs_payload(
 ) -> dict:
     """Assemble the v1 ``lvs.json`` payload (shared producer, issue #4616).
 
-    ``mismatches`` carries the label-based mismatches (unchanged from the
-    historical board-00 schema so ``_parse_lvs`` and the e2e asserter keep
-    working).  ``copper_mismatches`` is an additive field recording the
-    copper-extracted shorts/opens so a copper-dirty board is reflected too.
+    **Leg mapping (issue #4681, explicit so consumers pair the arrays
+    with the right comparator):**
+
+    * ``mismatches``        — the **label-based (netlist) leg**
+      (:func:`kicad_tools.lvs.board_lvs.compare_netlists`): per-pin
+      ``{ref, pad, schematic_net, pcb_net}`` records diffing each pad's
+      declared ``(net ...)`` label against the schematic.  Unchanged
+      from the historical board-00 schema so ``_parse_lvs`` and the e2e
+      asserter keep working.
+    * ``copper_mismatches`` — the **copper-extracted leg**
+      (:func:`kicad_tools.lvs.copper_lvs.compare_copper_netlist`):
+      ``{kind, net_a, net_b, pad_a, pad_b}`` shorts/opens diffing the
+      physical copper partition against the schematic.  Additive field
+      so a copper-dirty board is reflected too.
+
     ``copper_vacuous`` / ``copper_bound_pad_count`` (additive, #4005
     review) record whether the copper verdict carried any schematic
     evidence; a vacuous copper leg forces ``clean=false``.
+    ``netlist_vacuous`` (additive, #4681) is the label leg's sibling
+    flag: ``true`` when the PCB supplied zero net bindings, in which
+    case ``mismatches`` holds a single synthetic
+    ``ref="<vacuous>"`` record instead of one pseudo-mismatch per bound
+    schematic pin.
 
     This is the **single** producer of the v1 record shapes.  Besides
     :func:`write_lvs_report` (which writes ``output/lvs.json`` with the
@@ -342,7 +358,8 @@ def build_lvs_payload(
     Returns:
         A JSON-safe dict in the stable v1 key order: ``$schema``,
         ``clean``, ``mismatches``, ``copper_mismatches``,
-        ``copper_vacuous``, ``copper_bound_pad_count``.
+        ``copper_vacuous``, ``copper_bound_pad_count``,
+        ``netlist_vacuous``.
     """
     payload: dict = {}
     if include_schema:
@@ -375,6 +392,8 @@ def build_lvs_payload(
     if copper_result is not None:
         payload["copper_vacuous"] = copper_result.vacuous
         payload["copper_bound_pad_count"] = copper_result.bound_pad_count
+    if label_result is not None:
+        payload["netlist_vacuous"] = label_result.vacuous
     return payload
 
 

--- a/tests/test_board_lvs_vacuous.py
+++ b/tests/test_board_lvs_vacuous.py
@@ -1,0 +1,195 @@
+"""Label-leg vacuity guard for a net-less PCB side (issue #4681).
+
+The #4681 filer's board produced 264 label-LVS records, every one with
+``pcb_net: null``: the PCB side supplied **zero** net bindings, so every
+bound schematic pin trivially "mismatched".  N pseudo-mismatches read as
+N real defects instead of one degraded input.
+
+Mirroring the copper leg's #4005 vacuity guard, :func:`compare_netlists`
+now refuses to diff a zero-PCB-evidence board pad-by-pad: it returns a
+single synthetic mismatch (``ref="<vacuous>"``,
+``pcb_net="<no-pcb-evidence>"``) and the result is still dirty — no
+evidence is not a pass.  These tests pin exactly when the guard fires:
+
+* board has pads, schematic binds pins, PCB binds nothing -> vacuous;
+* >=1 net-bearing PCB pad                                 -> per-pad diff
+  unchanged (genuine partial mismatches keep their records);
+* NC sentinels are *raw* evidence (deliberate per-pad bindings), so an
+  all-NC board still gets the real per-pad diff;
+* schematic binds zero pins -> guard never fires (that zero-evidence
+  case belongs to the copper leg's #4005 guard);
+* board has zero pads at all -> guard never fires (a missing PCB side is
+  a different failure and keeps its per-key records).
+
+The comparator's file-walking front-ends are monkeypatched with canned
+``{(ref, pad) -> net}`` maps (same technique as
+``test_board_lvs_nc_sentinel.py``) so the guard logic is exercised
+hermetically.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import kicad_tools.lvs.board_lvs as board_lvs
+from kicad_tools.lvs.board_lvs import (
+    NETLIST_VACUOUS_NET,
+    NETLIST_VACUOUS_REF,
+    LVSMismatch,
+    LVSResult,
+    compare_netlists,
+)
+
+
+def _compare(
+    monkeypatch: pytest.MonkeyPatch,
+    sch_map: dict[tuple[str, str], str | None],
+    pcb_map: dict[tuple[str, str], str | None],
+) -> board_lvs.LVSResult:
+    """Run compare_netlists over canned pin->net maps."""
+    monkeypatch.setattr(board_lvs, "_schematic_pin_to_net", lambda _p: dict(sch_map))
+    monkeypatch.setattr(board_lvs, "_pcb_pin_to_net", lambda _p: dict(pcb_map))
+    return compare_netlists("dummy.kicad_sch", "dummy.kicad_pcb")
+
+
+class TestVacuityGuardFires:
+    """Zero PCB net bindings + bound schematic pins -> one synthetic record."""
+
+    def test_all_pads_without_nets_yields_single_synthetic_record(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The #4681 shape: every pad lacks a ``(net ...)`` child.
+
+        Before the guard this emitted one ``pcb_net=null`` record per
+        bound schematic pin (264 on the filer's board).  Now: exactly one
+        synthetic record, still dirty.
+        """
+        sch_map = {
+            ("R7", "2"): "DAC_CLK",
+            ("U10", "2"): "DAC_CLK",
+            ("C1", "1"): "PWR_FLAG",
+            ("C10", "1"): "+3.3V",
+        }
+        pcb_map: dict[tuple[str, str], str | None] = dict.fromkeys(sch_map, None)
+        result = _compare(monkeypatch, sch_map, pcb_map)
+
+        assert result.clean is False  # no evidence is not a pass
+        assert result.vacuous is True
+        assert len(result.mismatches) == 1  # NOT one per bound pin
+        m = result.mismatches[0]
+        assert m.ref == NETLIST_VACUOUS_REF
+        assert m.pcb_net == NETLIST_VACUOUS_NET
+        # Evidence counters ride on the synthetic record.
+        assert m.pad == "board_pads=4"
+        assert m.schematic_net == "sch_bound_pins=4"
+
+    def test_empty_net0_names_are_not_evidence(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Pads carrying only the empty ``(net 0 "")`` name are unbound too."""
+        result = _compare(
+            monkeypatch,
+            sch_map={("R1", "1"): "VCC", ("R1", "2"): "GND"},
+            pcb_map={("R1", "1"): "", ("R1", "2"): None},
+        )
+        assert result.vacuous is True
+        assert len(result.mismatches) == 1
+
+
+class TestVacuityGuardDoesNotFire:
+    """Any real PCB evidence (or no schematic evidence) keeps the old diff."""
+
+    def test_single_net_bearing_pad_keeps_per_pad_records(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Genuine partial mismatches are unchanged (acceptance criterion 2)."""
+        result = _compare(
+            monkeypatch,
+            sch_map={("R1", "1"): "VCC", ("R1", "2"): "GND", ("C1", "1"): "GND"},
+            pcb_map={("R1", "1"): "VCC", ("R1", "2"): None, ("C1", "1"): None},
+        )
+        assert result.vacuous is False
+        assert result.clean is False
+        # The two unbound pads each keep their own genuine record.
+        assert {(m.ref, m.pad) for m in result.mismatches} == {("R1", "2"), ("C1", "1")}
+        assert all(m.pcb_net is None for m in result.mismatches)
+
+    def test_nc_sentinels_count_as_raw_evidence(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An all-NC board is deliberately bound pad-by-pad, not evidence-free.
+
+        The sentinel normalizes to ``None`` for comparison, but it is a
+        per-pad binding the writer produced on purpose — so the genuine
+        open on U1.1 must survive as its own record (the
+        ``test_board_lvs_nc_sentinel.py`` contract), not collapse into a
+        vacuity verdict.
+        """
+        result = _compare(
+            monkeypatch,
+            sch_map={("U1", "1"): "SWDIO", ("U1", "2"): None},
+            pcb_map={
+                ("U1", "1"): "unconnected-(U1-SWDIO-Pad1)",
+                ("U1", "2"): "unconnected-(U1-NC-Pad2)",
+            },
+        )
+        assert result.vacuous is False
+        assert result.clean is False
+        assert len(result.mismatches) == 1
+        m = result.mismatches[0]
+        assert (m.ref, m.pad) == ("U1", "1")
+        assert m.schematic_net == "SWDIO"
+        assert m.pcb_net is None
+
+    def test_wireless_schematic_never_trips_the_label_guard(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Zero *schematic* evidence is the copper leg's #4005 territory.
+
+        A fixture schematic that binds no pins has nothing for the label
+        leg to compare; both sides are ``None`` everywhere, so the result
+        is clean here and the copper leg's vacuity guard carries the
+        zero-evidence verdict (boards 06/07 behavior must not change).
+        """
+        result = _compare(
+            monkeypatch,
+            sch_map={("R1", "1"): None, ("R1", "2"): None},
+            pcb_map={("R1", "1"): None, ("R1", "2"): None},
+        )
+        assert result.vacuous is False
+        assert result.clean is True
+
+    def test_board_with_zero_pads_keeps_per_key_records(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No pads at all is a different failure than unbound pads."""
+        result = _compare(
+            monkeypatch,
+            sch_map={("R1", "1"): "VCC", ("R1", "2"): "GND"},
+            pcb_map={},
+        )
+        assert result.vacuous is False
+        assert result.clean is False
+        assert len(result.mismatches) == 2
+
+
+class TestVacuousProperty:
+    """``LVSResult.vacuous`` is derived, so round-trips preserve it."""
+
+    def test_hand_built_results_report_vacuous_correctly(self) -> None:
+        genuine = LVSResult(
+            clean=False,
+            mismatches=(LVSMismatch(ref="D1", pad="1", schematic_net="GND", pcb_net=None),),
+        )
+        assert genuine.vacuous is False
+
+        synthetic = LVSResult(
+            clean=False,
+            mismatches=(
+                LVSMismatch(
+                    ref=NETLIST_VACUOUS_REF,
+                    pad="board_pads=2",
+                    schematic_net="sch_bound_pins=2",
+                    pcb_net=NETLIST_VACUOUS_NET,
+                ),
+            ),
+        )
+        assert synthetic.vacuous is True
+
+        assert LVSResult(clean=True, mismatches=()).vacuous is False

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -783,6 +783,26 @@ def _stage_board02_unrouted(dest_dir: Path) -> Path:
     return _strip_all_segments(BOARD_02_PCB, dest_dir / BOARD_02_PCB.name)
 
 
+def _strip_all_pad_nets(src_pcb: Path, dest_pcb: Path) -> Path:
+    """Copy ``src_pcb`` to ``dest_pcb`` with every pad's ``(net ...)`` child removed.
+
+    Reproduces the #4681 board shape: the PCB side supplies **zero** net
+    bindings, so the label leg has no evidence at all.  The copper leg is
+    untouched — :meth:`ConnectivityValidator.extract_pad_partition` never
+    reads pad net labels.
+    """
+    from kicad_tools.sexp import SExp, parse_file
+
+    doc = parse_file(src_pcb)
+    for fp in doc.find_all("footprint"):
+        for pad in fp.find_all("pad"):
+            pad.children = [
+                c for c in pad.children if not (isinstance(c, SExp) and c.name == "net")
+            ]
+    dest_pcb.write_text(doc.to_string() + "\n")
+    return dest_pcb
+
+
 def _stage_board00_both_legs_dirty(dest_dir: Path) -> Path:
     """Stage a board 00 copy that is dirty on **both** LVS comparators.
 
@@ -871,6 +891,7 @@ class TestCheckLVSFullFidelity:
         assert lvs["copper_vacuous"] is False
         assert lvs["copper_bound_pad_count"] is not None
         assert lvs["copper_bound_pad_count"] > 0
+        assert lvs["netlist_vacuous"] is False
 
     def test_payload_omitted_when_lvs_not_run(self, drc_clean_pcb: Path, capsys):
         """No schematic -> NOT RUN -> {status, detail} only."""
@@ -993,6 +1014,76 @@ class TestCheckLVSFullFidelity:
             )
         for record in sub.data["mismatches"]:
             assert f"{record['ref']}.{record['pad']} sch=" in out
+
+
+class TestCheckLVSVacuousLabelLeg:
+    """A net-less PCB degrades loudly, and ``detail`` names both legs (#4681).
+
+    The filed board emitted 264 label records, every one ``pcb_net:
+    null`` — the PCB side supplied zero net bindings, so each bound
+    schematic pin trivially "mismatched" — while ``detail`` reported the
+    *copper* leg's 2 findings.  Two fixes are pinned here: the label leg
+    now returns one explicit vacuous verdict instead of N pseudo-records,
+    and ``detail`` names both legs' outcomes so a consumer can pair the
+    prose with the right embedded array.
+    """
+
+    def test_netless_board_reports_vacuous_not_per_pin_records(self, tmp_path: Path, capsys):
+        """Zero PCB net bindings -> one synthetic record + netlist_vacuous."""
+        from kicad_tools.cli.check_cmd import main
+        from kicad_tools.lvs.board_lvs import NETLIST_VACUOUS_NET, NETLIST_VACUOUS_REF
+
+        pcb, _manifest = _stage_board00_copy(tmp_path)
+        _strip_all_pad_nets(pcb, pcb)
+
+        assert main([str(pcb), "--format", "json"]) == 2
+        lvs = json.loads(capsys.readouterr().out)["meta_checks"]["lvs"]
+
+        assert lvs["status"] == "FAILED"  # no evidence is not a pass
+        assert lvs["netlist_vacuous"] is True
+        # ONE synthetic record — not one pseudo-mismatch per bound pin.
+        assert len(lvs["mismatches"]) == 1
+        assert lvs["mismatches"][0]["ref"] == NETLIST_VACUOUS_REF
+        assert lvs["mismatches"][0]["pcb_net"] == NETLIST_VACUOUS_NET
+        # ``detail`` spells out the vacuity and names the other leg too.
+        assert "label: vacuous" in lvs["detail"]
+        assert "copper: 0 mismatch(es)" in lvs["detail"]
+
+    def test_detail_counts_match_embedded_arrays(self, tmp_path: Path, capsys):
+        """Regression (#4681): per-leg counts in ``detail`` == array lengths.
+
+        The filer paired ``detail`` ("copper: 2 mismatch(es)") with the
+        ``mismatches`` array (264 records) because the prose named only
+        one leg.  Both legs' counts now appear, and each equals the
+        length of its embedded array.
+        """
+        from kicad_tools.cli.check_cmd import main
+
+        pcb = _stage_board00_both_legs_dirty(tmp_path)
+
+        assert main([str(pcb), "--format", "json"]) == 2
+        lvs = json.loads(capsys.readouterr().out)["meta_checks"]["lvs"]
+
+        copper_count = int(lvs["detail"].split("copper: ")[1].split(" mismatch(es)")[0])
+        label_count = int(lvs["detail"].split("label: ")[1].split(" mismatch(es)")[0])
+        assert copper_count == len(lvs["copper_mismatches"]) > 0
+        assert label_count == len(lvs["mismatches"]) > 0
+        assert lvs["netlist_vacuous"] is False
+
+    def test_label_dirty_detail_names_copper_leg_too(self, tmp_path: Path, capsys):
+        """Copper-clean/label-dirty boards also name both legs in ``detail``."""
+        from kicad_tools.cli.check_cmd import main
+
+        pcb, _manifest = _stage_board00_copy(tmp_path)
+        _swap_d1_pad_nets_in_pcb(pcb, pcb)
+
+        assert main([str(pcb), "--format", "json"]) == 2
+        lvs = json.loads(capsys.readouterr().out)["meta_checks"]["lvs"]
+
+        assert lvs["detail"].startswith("label: ")
+        assert "; copper: 0 mismatch(es)" in lvs["detail"]
+        label_count = int(lvs["detail"].split("label: ")[1].split(" mismatch(es)")[0])
+        assert label_count == len(lvs["mismatches"]) == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_lvs_recipe.py
+++ b/tests/test_lvs_recipe.py
@@ -313,6 +313,7 @@ def test_build_lvs_payload_preserves_v1_key_order() -> None:
         "copper_mismatches",
         "copper_vacuous",
         "copper_bound_pad_count",
+        "netlist_vacuous",
     ]
 
 
@@ -324,6 +325,7 @@ def test_build_lvs_payload_embedded_form_drops_schema_and_clean() -> None:
         "copper_mismatches",
         "copper_vacuous",
         "copper_bound_pad_count",
+        "netlist_vacuous",
     ]
 
 
@@ -348,8 +350,41 @@ def test_check_meta_lvs_payload_shares_lvs_json_record_shapes() -> None:
         assert [set(r) for r in embedded[field]] == [set(r) for r in on_disk[field]]
     assert embedded["copper_vacuous"] == on_disk["copper_vacuous"]
     assert embedded["copper_bound_pad_count"] == on_disk["copper_bound_pad_count"]
+    assert embedded["netlist_vacuous"] == on_disk["netlist_vacuous"]
     # The check envelope adds only its own two keys on top of the v1 fields.
     assert set(embedded) - set(on_disk) == {"status", "detail"}
+
+
+def test_build_lvs_payload_netlist_vacuous_flag() -> None:
+    """``netlist_vacuous`` mirrors the label leg's vacuity verdict (#4681)."""
+    from kicad_tools.lvs.board_lvs import NETLIST_VACUOUS_NET, NETLIST_VACUOUS_REF
+
+    vacuous_label = LVSResult(
+        clean=False,
+        mismatches=(
+            LVSMismatch(
+                ref=NETLIST_VACUOUS_REF,
+                pad="board_pads=264",
+                schematic_net="sch_bound_pins=264",
+                pcb_net=NETLIST_VACUOUS_NET,
+            ),
+        ),
+    )
+    assert vacuous_label.vacuous is True
+
+    payload = recipe.build_lvs_payload(_CLEAN_COPPER, vacuous_label, include_schema=False)
+    assert payload["netlist_vacuous"] is True
+    # The synthetic record is the ONLY label record — not one per pin.
+    assert len(payload["mismatches"]) == 1
+    assert payload["mismatches"][0]["ref"] == NETLIST_VACUOUS_REF
+
+    # Genuine mismatches do not trip the flag.
+    dirty = recipe.build_lvs_payload(_CLEAN_COPPER, _DIRTY_LABEL, include_schema=False)
+    assert dirty["netlist_vacuous"] is False
+
+    # Leg not run -> key omitted (same contract as ``copper_vacuous``).
+    no_label = recipe.build_lvs_payload(_CLEAN_COPPER, None, include_schema=False)
+    assert "netlist_vacuous" not in no_label
 
 
 def test_build_lvs_payload_is_exported_from_package() -> None:


### PR DESCRIPTION
## Summary

Fixes the #4681 consumer-facing LVS defect: on a board whose pads carry no `(net ...)` bindings, `kct check`'s `meta_checks.lvs.mismatches` emitted **264 all-`pcb_net: null` pseudo-records** (one per bound schematic pin) that did not correspond to the 2 findings named in `detail` — because `detail` reported only the *copper* leg while the array held the *label* leg's degenerate diff.

Implements the curated two-part fix (both in scope per the Curator enrichment):

### Part A — vacuity guard for the label leg (mirrors the copper leg's #4005 guard)

- `compare_netlists` (`src/kicad_tools/lvs/board_lvs.py`): when the PCB side supplies **zero** net bindings while the board has pads and the schematic binds >=1 pin, return a **single synthetic record** (`ref="<vacuous>"`, `pcb_net="<no-pcb-evidence>"`, evidence counters `board_pads=N` / `sch_bound_pins=M` in the other fields) instead of one pseudo-mismatch per pin. Result stays **dirty** — no evidence is not a pass.
- **Raw** (pre-normalization) bindings count as evidence on purpose: explicit no-connect sentinels (`unconnected-(REF-PIN-PadN)`) are deliberate per-pad bindings, so all-NC boards keep the genuine per-pad diff (`test_board_lvs_nc_sentinel.py` contract preserved). Any board with >=1 net-bearing pad — genuine partial mismatches — is byte-identical to before.
- `LVSResult` gains a derived `.vacuous` property (mirrors `CopperLVSResult.vacuous`; derived, so hand-built results and round-trips preserve it). New constants `NETLIST_VACUOUS_REF` / `NETLIST_VACUOUS_NET` exported from `kicad_tools.lvs`.
- `build_lvs_payload` (`src/kicad_tools/lvs/recipe.py`): additive `netlist_vacuous` key (sibling to `copper_vacuous`), emitted whenever the label leg ran. v1 `lvs.json` keys/shapes otherwise unchanged — additions only, appended after `copper_bound_pad_count`.

### Part B — `detail` pairs with the split correctly

- `_lvs_subcheck` (`src/kicad_tools/cli/check_cmd.py`): whenever either leg is dirty, `detail` names **both** legs' outcomes:
  - copper-dirty: `copper: N mismatch(es): <preview>; label: M mismatch(es)` (or `label: vacuous (...)`)
  - label-dirty/copper-clean: `label: M mismatch(es): <preview>; copper: 0 mismatch(es)`
  - label-vacuous: `label: vacuous (no PCB pad carries a net binding); copper: 0 mismatch(es)`
- `build_lvs_payload`'s docstring (the schema surface) now states the leg mapping explicitly: `mismatches` = label/netlist leg, `copper_mismatches` = copper leg.
- The `PASSED` detail (`label + copper: 0 mismatch(es)`) and all existing count-parsing conventions are unchanged (the copper count still precedes the first ` mismatch(es)` token).

Per the Curator's refutation, #4601-style stem-keyed netlist-sidecar discovery is **not** implicated (the label leg reads pad nets from the `.kicad_pcb` directly) and is not touched.

## Acceptance criteria

- [x] Net-less fixture → explicit vacuous verdict (single synthetic record), still dirty — `test_netless_board_reports_vacuous_not_per_pin_records` (board-00 copy with every pad's `(net ...)` child stripped; copper leg untouched since it is label-free)
- [x] Genuine partial mismatches unchanged — `test_single_net_bearing_pad_keeps_per_pad_records`, NC-sentinel + placeholder suites green
- [x] `detail` names both legs whenever either is dirty; per-leg counts equal embedded array lengths — `test_detail_counts_match_embedded_arrays`, `test_label_dirty_detail_names_copper_leg_too`
- [x] v1 `lvs.json` backward compatible; golden key-order tests updated additively
- [x] Leg mapping documented in the payload docstring

## Testing

- New: `tests/test_board_lvs_vacuous.py` (9 hermetic guard tests), `TestCheckLVSVacuousLabelLeg` (3 integration tests through `kct check --format json`), `test_build_lvs_payload_netlist_vacuous_flag`
- Regression (all green): `test_cli_check.py` (84), `test_lvs_recipe.py` + `test_board_lvs_*` + `test_board_lvs_vacuous.py` (57), `test_board_00_lvs.py` / `test_ci_check_copper_lvs.py` / `test_copper_lvs.py` / `test_board_lvs_hierarchical.py` / `test_lvs.py` / `test_check_board_e2e.py` / `test_board_metrics.py` (211)
- `ruff check` + `ruff format --check` clean on touched files; mypy baseline gate: no new errors (1472, floor 1474)

Closes #4681
