### PR TITLE
feat(check): connectivity rule decides by strict real-geometry model by default (#4673)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`kct check`'s connectivity DRC rule now uses the strict real-geometry
+  model by default** (#4673, the #4557 follow-up) — `ConnectivityRule`,
+  `DRCChecker(strict_connectivity=...)`, and both `kct check` CLI parsers
+  now default to deciding segment↔segment / segment↔pad / segment↔via
+  unions by real shapely copper-shape intersection (KiCad semantics,
+  #4176) instead of the legacy 0.01mm endpoint-proximity tolerance, so
+  `kct check` finally agrees with `kct net-status` (strict default since
+  #4557) and with `kicad-cli`: endpoint-proximity false opens on poured
+  boards can no longer appear, and over-connected nets the legacy model
+  passed now correctly fire. Fleet verification (boards 00-07 committed
+  routed artifacts) measured **zero count change** — the pour residuals
+  the legacy model once reported are already absorbed by the #3914
+  advisory suppression and the #4229 pad-in-pour fix, which apply in
+  both models, so the flip removes the model divergence without moving
+  any baseline. New `--legacy-connectivity` flag opts back
+  into the old proximity model; `--strict-connectivity` is kept as an
+  accepted no-op for script compatibility (it now restates the default)
+  and `--legacy-connectivity` wins when both are given. Strict mode
+  requires shapely (a core dependency since #3824) and fails loud if it
+  is missing. `connectivity` remains classified advisory and excluded
+  from the routed-DRC CI gate, so blocking-gate behavior is unchanged.
+  The known blind-via/unspanned-pad over-connect residual (a blind via
+  whose 2D copper overlaps a pad on a layer the via does not span still
+  bonds to it) is documented and pinned by a test rather than fixed —
+  rare geometry, and the failure direction matches the legacy model's
+  over-connect bias.
+
 - **`tests/benchmark_results.json` untracked and gitignored** (#4684) — the
   routing-benchmark test (`tests/test_router_integration.py`) rewrites this
   file with wall-clock timings on every run, leaving the working tree

--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -1222,15 +1222,30 @@ def main(argv: list[str] | None = None) -> int:
         dest="strict_connectivity",
         action="store_true",
         help=(
-            "Decide the connectivity DRC rule by REAL geometric copper contact "
-            "(shapely polygon intersection) instead of the default 0.01mm "
-            "endpoint-proximity tolerance. The default model unions a segment "
-            "endpoint with a pad/via/segment whenever their reference points "
-            "land within 0.01mm, even when the actual copper (segment width, "
-            "pad shape) does not touch -- so it can pass a net that "
-            "'kicad-cli pcb drc' reports as unconnected. --strict-connectivity "
-            "matches KiCad's connectivity semantics (issue #4176). Requires "
-            "shapely. (Distinct from --strict, which makes warnings fatal.)"
+            "No-op kept for script compatibility: real-geometry (strict) "
+            "connectivity is now the DEFAULT (issue #4673, matching the "
+            "kct net-status default from issue #4557). The connectivity DRC "
+            "rule decides copper unions by REAL geometric copper contact "
+            "(shapely polygon intersection), matching KiCad's connectivity "
+            "semantics (issue #4176). Use --legacy-connectivity to opt back "
+            "into the old 0.01mm endpoint-proximity model. (Distinct from "
+            "--strict, which makes warnings fatal.)"
+        ),
+    )
+    parser.add_argument(
+        "--legacy-connectivity",
+        dest="legacy_connectivity",
+        action="store_true",
+        help=(
+            "Opt the connectivity DRC rule back into the LEGACY 0.01mm "
+            "endpoint-proximity model (the pre-#4673 default). The legacy "
+            "model unions a segment endpoint with a pad/via/segment whenever "
+            "their reference points land within 0.01mm even when the actual "
+            "copper does not touch -- so it can pass a net that 'kicad-cli "
+            "pcb drc' reports as unconnected, and it reports false opens on "
+            "poured boards that the strict default correctly bonds. Takes "
+            "precedence over --strict-connectivity (a no-op) if both are "
+            "given."
         ),
     )
     parser.add_argument(
@@ -1936,7 +1951,11 @@ def main(argv: list[str] | None = None) -> int:
             # graceful no-op (AC5).
             emit_measurements=True,
             courtyard_waivers=courtyard_waivers,
-            strict_connectivity=args.strict_connectivity,
+            # Issue #4673: strict (real-geometry) connectivity is the
+            # default; --legacy-connectivity is the explicit opt-out and
+            # takes precedence over --strict-connectivity, which is now a
+            # compatibility no-op restating the default.
+            strict_connectivity=not getattr(args, "legacy_connectivity", False),
         )
     except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)

--- a/src/kicad_tools/cli/commands/validation.py
+++ b/src/kicad_tools/cli/commands/validation.py
@@ -215,9 +215,14 @@ def run_check_command(args) -> int:
         sub_argv.append("--errors-only")
     if args.strict:
         sub_argv.append("--strict")
-    # Issue #4176: forward the connectivity real-geometry opt-in.
+    # Issue #4176 / #4673: strict (real-geometry) connectivity is now the
+    # default; --strict-connectivity is a compatibility no-op but is still
+    # forwarded verbatim, and --legacy-connectivity is the opt-out that
+    # actually changes behavior (it wins if both are given).
     if getattr(args, "strict_connectivity", False):
         sub_argv.append("--strict-connectivity")
+    if getattr(args, "legacy_connectivity", False):
+        sub_argv.append("--legacy-connectivity")
     # Issue #3920: forward an explicit --mfr regardless of value so that
     # check_main can distinguish "no flag given" (None → auto-resolve from
     # sidecar/project.kct) from an explicit choice that must always win. The

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -672,10 +672,22 @@ def _add_check_parser(subparsers) -> None:
         dest="strict_connectivity",
         action="store_true",
         help=(
-            "Decide the connectivity DRC rule by REAL geometric copper contact "
-            "(shapely polygon intersection) instead of the default 0.01mm "
-            "endpoint-proximity tolerance, matching KiCad (issue #4176). "
-            "Requires shapely. Distinct from --strict (warnings fatal)."
+            "No-op kept for script compatibility: real-geometry (strict) "
+            "connectivity is now the DEFAULT for the connectivity DRC rule "
+            "(issue #4673, matching kct net-status since issue #4557). Use "
+            "--legacy-connectivity to opt back into the old proximity model. "
+            "Distinct from --strict (warnings fatal)."
+        ),
+    )
+    check_parser.add_argument(
+        "--legacy-connectivity",
+        dest="legacy_connectivity",
+        action="store_true",
+        help=(
+            "Opt the connectivity DRC rule back into the LEGACY 0.01mm "
+            "endpoint-proximity model (the pre-#4673 default). Takes "
+            "precedence over --strict-connectivity (a no-op) if both are "
+            "given."
         ),
     )
     check_parser.add_argument(

--- a/src/kicad_tools/validate/checker.py
+++ b/src/kicad_tools/validate/checker.py
@@ -75,7 +75,7 @@ class DRCChecker:
         verbose: bool = False,
         emit_measurements: bool = False,
         courtyard_waivers: CourtyardWaivers | None = None,
-        strict_connectivity: bool = False,
+        strict_connectivity: bool = True,
         copper_oz_outer: float | None = None,
         copper_oz_inner: float | None = None,
     ) -> None:
@@ -128,16 +128,21 @@ class DRCChecker:
                 entry (instead of blocking errors), and an ``info`` "unused
                 waiver" finding for entries naming an absent component.  When
                 omitted, every overlap is a blocking error (Issue #4137).
-            strict_connectivity: When True, ``check_connectivity`` decides
-                segment↔segment / segment↔pad / segment↔via unions by real
-                geometric copper contact (shapely polygon intersection)
-                instead of the default 0.01mm endpoint-proximity tolerance,
-                matching KiCad's connectivity semantics (Issue #4176).  A net
-                whose copper the default model over-connects (reported
-                "complete" while ``kicad-cli pcb drc`` finds it unconnected)
-                then correctly fires the connectivity rule.  Default False
-                preserves the legacy tolerance model so existing ``kct check``
-                output is unchanged.
+            strict_connectivity: When True (the default since Issue #4673,
+                matching the ``kct net-status`` default flipped by Issue
+                #4557), ``check_connectivity`` decides segment↔segment /
+                segment↔pad / segment↔via unions by real geometric copper
+                contact (shapely polygon intersection) instead of the legacy
+                0.01mm endpoint-proximity tolerance, matching KiCad's
+                connectivity semantics (Issue #4176).  A net whose copper the
+                legacy model over-connects (reported "complete" while
+                ``kicad-cli pcb drc`` finds it unconnected) then correctly
+                fires the connectivity rule, and the legacy model's
+                endpoint-proximity false opens on poured boards disappear.
+                Pass False (``kct check --legacy-connectivity``) to opt back
+                into the legacy tolerance model.  Strict mode requires
+                shapely (a core dependency since #3824) and fails loud if it
+                is missing.
             copper_oz_outer: Optional override for the *ampacity* gate's
                 outer-layer (F.Cu / B.Cu) copper weight in oz (Issue #4326).
                 When provided, replaces ``design_rules.outer_copper_oz``
@@ -163,8 +168,10 @@ class DRCChecker:
         self.courtyard_waivers = courtyard_waivers
         # Issue #4176: when True, the connectivity rule decides segment /
         # pad / via unions by real geometric copper contact (shapely polygon
-        # intersection) instead of the default 0.01mm endpoint-proximity
-        # tolerance, matching KiCad.  Default False preserves legacy behavior.
+        # intersection) instead of the legacy 0.01mm endpoint-proximity
+        # tolerance, matching KiCad.  Default True since Issue #4673 (the
+        # #4557 strict-default flip extended from net-status to kct check);
+        # pass False to opt back into the legacy tolerance model.
         self.strict_connectivity = strict_connectivity
         self.warn_on_inactive_skew_rules = warn_on_inactive_skew_rules
         self.verbose = verbose

--- a/src/kicad_tools/validate/rules/connectivity.py
+++ b/src/kicad_tools/validate/rules/connectivity.py
@@ -71,19 +71,25 @@ class ConnectivityRule(DRCRule):
     name = "Net Connectivity"
     description = "Detects multi-pad nets that are not fully connected by traces, vias, or zones"
 
-    def __init__(self, *, strict: bool = False) -> None:
+    def __init__(self, *, strict: bool = True) -> None:
         """Create the connectivity rule.
 
         Args:
             strict: Forwarded to :class:`NetStatusAnalyzer` as its ``strict``
-                flag (Issue #4176).  When ``True``, segment↔segment /
-                segment↔pad / segment↔via connectivity is decided by real
-                geometric copper contact (shapely polygon intersection)
-                instead of the default 0.01mm endpoint-proximity tolerance, so
-                a net kct's default model over-connects (reported "complete"
-                while ``kicad-cli pcb drc`` finds it unconnected) correctly
-                fires here.  The default (``False``) preserves the legacy
-                tolerance model so existing ``kct check`` output is unchanged.
+                flag (Issue #4176).  When ``True`` (the default since Issue
+                #4673, matching the ``NetStatusAnalyzer`` /
+                ``kct net-status`` default flipped by Issue #4557),
+                segment↔segment / segment↔pad / segment↔via connectivity is
+                decided by real geometric copper contact (shapely polygon
+                intersection) instead of the legacy 0.01mm endpoint-proximity
+                tolerance, so a net the legacy model over-connects (reported
+                "complete" while ``kicad-cli pcb drc`` finds it unconnected)
+                correctly fires here — and the endpoint-proximity *false
+                opens* the legacy model reports on poured boards disappear.
+                Pass ``False`` (``kct check --legacy-connectivity``) to opt
+                back into the legacy tolerance model.  Strict mode requires
+                shapely (a core dependency since #3824) and fails loud if it
+                is missing.
         """
         self.strict = strict
 

--- a/tests/test_cli_parser_drift.py
+++ b/tests/test_cli_parser_drift.py
@@ -818,6 +818,57 @@ def test_no_net_class_map_is_on_both_check_parsers():
 
 @pytest.mark.parametrize(
     "flag",
+    ["--strict-connectivity", "--legacy-connectivity"],
+)
+def test_connectivity_mode_flags_are_on_both_check_parsers(flag):
+    """#4673 flag-inversion pin: the connectivity-mode flags live on BOTH parsers.
+
+    ``--legacy-connectivity`` is the behavior-changing opt-out of the new
+    strict (real-geometry) connectivity default; ``--strict-connectivity``
+    is kept as a compatibility no-op restating the default.  Both must be
+    accepted by the outer ``kct check`` parser (the user-facing surface)
+    and the inner ``check_cmd.py`` parser.
+    """
+    inner = _inner_check_parser_flags()
+    outer = _outer_subparser_flags("check")
+
+    assert flag in inner, f"{flag} is missing from the inner check_cmd.py parser"
+    assert flag in outer, (
+        f"{flag} is missing from the outer parser.py check subparser "
+        "(`kct check` would reject it with 'unrecognized arguments')"
+    )
+
+
+def test_check_shim_forwards_legacy_connectivity():
+    """The outer shim must forward ``--legacy-connectivity`` to the inner main.
+
+    Declaring the flag on the outer parser alone would parse it and then
+    discard it (#2819 failure mode) -- the user would silently get the
+    strict default instead of the requested legacy model.
+    """
+    from kicad_tools.cli.commands.validation import run_check_command
+    from kicad_tools.cli.parser import create_parser
+
+    args = create_parser().parse_args(["check", "board.kicad_pcb", "--legacy-connectivity"])
+    with patch("kicad_tools.cli.check_cmd.main", return_value=0) as inner_main:
+        assert run_check_command(args) == 0
+    sub_argv = inner_main.call_args[0][0]
+    assert "--legacy-connectivity" in sub_argv, (
+        f"run_check_command dropped --legacy-connectivity; got {sub_argv}"
+    )
+
+    # Absent flag must not be forwarded (default strict behavior preserved).
+    args = create_parser().parse_args(["check", "board.kicad_pcb"])
+    with patch("kicad_tools.cli.check_cmd.main", return_value=0) as inner_main:
+        run_check_command(args)
+    sub_argv = inner_main.call_args[0][0]
+    assert "--legacy-connectivity" not in sub_argv, (
+        "--legacy-connectivity forwarded even though it was not supplied"
+    )
+
+
+@pytest.mark.parametrize(
+    "flag",
     ["--refill-zones", "--courtyard-waivers", "--waivers"],
 )
 def test_drifted_check_flags_are_on_both_parsers(flag):

--- a/tests/test_connectivity_rule.py
+++ b/tests/test_connectivity_rule.py
@@ -608,8 +608,10 @@ class TestConnectivityRuleRegistry:
 
 
 class TestConnectivityRuleStrict:
-    """Issue #4176: ``ConnectivityRule(strict=True)`` uses real geometric
-    copper contact, so a net the default tolerance model over-connects fires."""
+    """Issues #4176 / #4673: ``ConnectivityRule`` decides connectivity by real
+    geometric copper contact BY DEFAULT (strict), so a net the legacy
+    tolerance model over-connects fires; ``strict=False`` /
+    ``--legacy-connectivity`` is the explicit legacy opt-out."""
 
     # Two pads joined by two thin segments whose inner endpoints are 0.009mm
     # apart (< 0.01 tolerance) on perpendicular headings.  At 0.001mm width the
@@ -632,7 +634,9 @@ class TestConnectivityRuleStrict:
 """
     )
 
-    def test_default_passes_strict_fires(self, tmp_path: Path) -> None:
+    def test_default_is_strict_and_fires_legacy_opt_out_passes(self, tmp_path: Path) -> None:
+        """#4673: strict (real geometry) is the DEFAULT; ``strict=False`` is
+        the legacy opt-out that preserves the old tolerance model."""
         import pytest
 
         pytest.importorskip("shapely")
@@ -645,14 +649,18 @@ class TestConnectivityRuleStrict:
         pcb = PCB.load(pcb_path)
         rules = get_profile("jlcpcb").get_design_rules(2, 1.0)
 
-        # Default (tolerance) model over-connects: no error.
-        assert ConnectivityRule().check(pcb, rules).error_count == 0
-        # Strict (real geometry) model: the pads are on separate copper -> error.
-        strict = ConnectivityRule(strict=True).check(pcb, rules)
-        assert strict.error_count == 1
-        assert strict.errors[0].nets == ("SIG",)
+        # Default = strict (real geometry): the pads are on separate copper
+        # -> error.  No ``strict`` argument anywhere -- this pins the real
+        # constructor default consumers hit (#4673).
+        default = ConnectivityRule().check(pcb, rules)
+        assert default.error_count == 1
+        assert default.errors[0].nets == ("SIG",)
+        # Explicit strict matches the default.
+        assert ConnectivityRule(strict=True).check(pcb, rules).error_count == 1
+        # Legacy opt-out (tolerance model) over-connects: no error.
+        assert ConnectivityRule(strict=False).check(pcb, rules).error_count == 0
 
-    def test_checker_forwards_strict_connectivity(self, tmp_path: Path) -> None:
+    def test_checker_defaults_strict_and_forwards_legacy_opt_out(self, tmp_path: Path) -> None:
         import pytest
 
         pytest.importorskip("shapely")
@@ -663,5 +671,33 @@ class TestConnectivityRuleStrict:
         pcb_path.write_text(self._OVER_CONNECT_PCB)
         pcb = PCB.load(pcb_path)
 
-        assert DRCChecker(pcb).check_connectivity().error_count == 0
+        # #4673: DRCChecker defaults strict -> the over-connected net fires.
+        assert DRCChecker(pcb).check_connectivity().error_count == 1
         assert DRCChecker(pcb, strict_connectivity=True).check_connectivity().error_count == 1
+        # Legacy opt-out preserved.
+        assert DRCChecker(pcb, strict_connectivity=False).check_connectivity().error_count == 0
+
+    def test_cli_default_strict_and_legacy_flag(self, tmp_path: Path) -> None:
+        """CLI wiring (#4673): default is strict; ``--legacy-connectivity``
+        restores the legacy model; ``--strict-connectivity`` is a no-op that
+        restates the default; ``--legacy-connectivity`` wins if both given."""
+        import pytest
+
+        pytest.importorskip("shapely")
+        from kicad_tools.cli.check_cmd import main
+
+        pcb_path = tmp_path / "over_connect.kicad_pcb"
+        pcb_path.write_text(self._OVER_CONNECT_PCB)
+        # --drc-only scopes the exit code to the DRC result (the meta
+        # rollup would exit 2 INCOMPLETE here regardless, because the
+        # fixture has no schematic for ERC/LVS).
+        argv = [str(pcb_path), "--only", "connectivity", "--drc-only"]
+
+        # Default: strict -> the over-connected net fires (exit 2).
+        assert main(list(argv)) == 2
+        # --strict-connectivity: accepted no-op, same result.
+        assert main([*argv, "--strict-connectivity"]) == 2
+        # --legacy-connectivity: legacy tolerance model over-connects -> pass.
+        assert main([*argv, "--legacy-connectivity"]) == 0
+        # Precedence: --legacy-connectivity wins over the no-op.
+        assert main([*argv, "--strict-connectivity", "--legacy-connectivity"]) == 0

--- a/tests/test_net_status_strict.py
+++ b/tests/test_net_status_strict.py
@@ -437,3 +437,79 @@ def test_two_disjoint_fills_not_unioned(strict: bool):
     )
     assert gnd.connected_count == 1
     assert gnd.unconnected_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Issue #4673 Part 3: blind-via / unspanned-pad bonding residual (PINNED).
+#
+# In strict mode, via copper geometries are deliberately LAYER-UNFILTERED when
+# bonding to pads (``copper_geoms.extend((self._via_geom(via), None) ...)`` and
+# the chain-merge ``_find_pads_touching_geom(via_geom, pad_positions)`` call in
+# ``net_status.py``).  Rationale: a via barrel is modeled as one vertical
+# copper cylinder, and for the overwhelmingly-common through-via the barrel
+# really does reach every layer, so filtering would only add cost.  The
+# accepted consequence -- flagged in the #4665 review and pinned here rather
+# than fixed -- is that a BLIND via whose 2D copper footprint overlaps a pad
+# on a layer the via does NOT span still bonds to that pad, over-connecting
+# relative to the physical board (KiCad would report the open).  The geometry
+# is rare (a blind via landing exactly on top of an unspanned pad is itself a
+# layout smell that other DRC rules flag), and the failure direction matches
+# the legacy model's known over-connect bias rather than introducing a new
+# false-open class.  If the layer-span filter is ever added, these pins must
+# be flipped DELIBERATELY (first test's expectation becomes "incomplete") --
+# and the fleet connectivity counts re-verified.
+# ---------------------------------------------------------------------------
+
+
+def _blind_via_board(*, via_layers: str) -> str:
+    """Two F.Cu pads joined only through a B.Cu trace + two vias at the pad centers.
+
+    The vias span ``via_layers``.  With a through span (``"F.Cu" "B.Cu"``) the
+    bond is physically real.  With a blind ``"In1.Cu" "B.Cu"`` span the via
+    copper never reaches F.Cu, so the F.Cu pads are physically open -- but the
+    2D via footprint still overlaps the pad copper.
+    """
+    return f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (general (thickness 1.6))
+  (layers (0 "F.Cu" signal) (1 "In1.Cu" signal) (2 "In2.Cu" signal)
+    (31 "B.Cu" signal) (44 "Edge.Cuts" user))
+  (net 0 "")
+  (net 1 "SIG")
+  (footprint "R" (layer "F.Cu") (uuid "fp1") (at 100 100)
+    (property "Reference" "R1" (at 0 0 0) (layer "F.SilkS") (uuid "r1"))
+    (pad "1" smd rect (at 0 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "SIG")))
+  (footprint "R" (layer "F.Cu") (uuid "fp2") (at 110 100)
+    (property "Reference" "R2" (at 0 0 0) (layer "F.SilkS") (uuid "r2"))
+    (pad "1" smd rect (at 0 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "SIG")))
+  (segment (start 100 100) (end 110 100) (width 0.25) (layer "B.Cu") (net 1) (uuid "s1"))
+  (via (at 100 100) (size 0.6) (drill 0.3) (layers {via_layers}) (net 1) (uuid "v1"))
+  (via (at 110 100) (size 0.6) (drill 0.3) (layers {via_layers}) (net 1) (uuid "v2"))
+)
+"""
+
+
+def test_pin_blind_via_bonds_unspanned_pad_overconnect():
+    """PIN (#4673 Part 3): a blind via overlapping an unspanned pad still bonds.
+
+    The In1.Cu-B.Cu blind vias never reach F.Cu, so the F.Cu pads are
+    physically open; KiCad would report SIG unconnected.  Strict mode's
+    layer-unfiltered via->pad bonding nonetheless reports ``complete``.
+    This test pins the ACCEPTED over-connect residual -- see the block
+    comment above for the rationale.  If via->pad bonding gains a
+    layer-span filter, flip this expectation to ``incomplete``.
+    """
+    board = _blind_via_board(via_layers='"In1.Cu" "B.Cu"')
+    assert _status(board, "SIG", strict=True) == "complete"
+
+
+def test_through_via_bonds_pads_legitimately():
+    """Control for the pin above: through-vias really do span F.Cu.
+
+    Identical geometry with F.Cu-B.Cu through-vias is physically connected;
+    both the current behavior and any future layer-span-filtered fix must
+    keep reporting ``complete`` here.
+    """
+    board = _blind_via_board(via_layers='"F.Cu" "B.Cu"')
+    assert _status(board, "SIG", strict=True) == "complete"


### PR DESCRIPTION
## Summary

Flips the `kct check` connectivity DRC rule to the strict real-geometry connectivity model by default, completing the #4557 follow-up: `ConnectivityRule` was the last surface still on the legacy 0.01mm endpoint-proximity model after `kct net-status` (#4557) and the LVS copper leg (#4710) moved to real-geometry semantics. `kct check` and `kct net-status` now agree.

Closes #4673

### Part 1 — default flip + flag inversion

- `ConnectivityRule(*, strict: bool = True)` (`validate/rules/connectivity.py`)
- `DRCChecker(strict_connectivity: bool = True)` (`validate/checker.py`)
- New `--legacy-connectivity` opt-out on **both** `kct check` parsers (`cli/check_cmd.py` + `cli/parser.py`), forwarded through the outer shim (`cli/commands/validation.py`)
- `--strict-connectivity` kept as an accepted **no-op** for script compatibility (help text now says it restates the default)
- Explicit precedence: `--legacy-connectivity` wins when both flags are given (tested)
- Strict mode fails loud if shapely is missing (shapely is a core dep since #3824) — noted in the CHANGELOG entry

### Part 2 — fleet before/after verification (boards 00–07 committed artifacts)

Method: `kct check <board> --only connectivity --format json --drc-only` per artifact, once with `--legacy-connectivity` ("before" — byte-identical to the pre-flip default) and once with the new default ("after"). Runs executed **in the worktree**; `kct check` without `--refill-zones` is read-only, and `git status` confirmed no artifact churn.

| Board (routed artifact) | Legacy (before) | Strict (after) | Delta |
|---|---|---|---|
| 00-simple-led | 0 | 0 | none |
| 01-voltage-divider | 0 | 0 | none |
| 02-charlieplex-led | 0 | 0 | none |
| 03-usb-joystick | 0 | 0 | none |
| 04-stm32-devboard | 0 | 0 | none |
| 05-bldc-motor-controller | 0 | 0 | none |
| 06-diffpair-test | 0 | 0 | none |
| 07-matchgroup-test | 5 | 5 | none (same 5 nets: DQ3, DQ4, MIPI_DAT0_N, TMDS_D0_N, TMDS_D1_N — the known #3438 seed-invariant unroutables) |

**Zero count change across the fleet.** The pour residuals the curator named as the baseline risk (board-05's 53 advisory findings from the #4665 review, board-06's 16 false opens) are already absorbed at the rule level by the #3914 `has_filled_zone` advisory suppression and the #4229 pad-in-pour fix, both of which apply in **both** models — so the flip removes the model divergence without moving any committed baseline.

Supplementary checks:
- **Unrouted artifacts** (genuine-open direction): board-00 unrouted 3→3, board-05 unrouted 44→44 — real opens keep firing at identical counts.
- **Board-03 drift guard**: full `kct check --drc-only --format json` rule-id/severity histograms are byte-identical in both modes (no connectivity findings at all; no blocking rule id changes). The routed-DRC CI gate counts blocking errors only and `connectivity` is classified advisory (`.github/routed-drc-tolerance.yml`), so the blocking gate is unchanged by construction *and* by measurement.

### Part 3 — blind-via/unspanned-pad residual: pinned, not fixed

Strict-mode via→pad bonding is deliberately layer-unfiltered (barrel modeled as one vertical copper cylinder — correct for through-vias, the overwhelmingly common case). The accepted consequence: a blind via whose 2D copper overlaps a pad on a layer the via does not span still bonds, over-connecting relative to KiCad. Two new tests in `tests/test_net_status_strict.py` pin this (`test_pin_blind_via_bonds_unspanned_pad_overconnect` + a through-via control), with a block comment documenting the rationale and the deliberate-flip instruction if a layer-span filter is ever added. Rare geometry; the failure direction matches the legacy model's over-connect bias (no new false-open class).

## Testing

- `tests/test_net_status_strict.py` + `tests/test_connectivity_rule.py` + `tests/test_cli_parser_drift.py`: **69 passed** (new: strict-default pin, legacy opt-out, CLI default/no-op/precedence, parser-parity + shim-forwarding pins for `--legacy-connectivity`, blind-via residual pins)
- Broad affected sweep (28 test files: check/net-status/connectivity/DRC/audit/board suites): **1134 passed, 5 skipped**, plus 5 `tests/test_drc_regression.py` failures under `-n auto` that are contention flakes — the file passes **5/5 in 34s** when re-run standalone (`--no-cov`); it is a router-iteration + kicad-cli suite with a 300s timeout marker and zero overlap with this diff (matches the known kicad-cli-under-parallel-load flake pattern)
- `ruff check` + `ruff format --check`: clean on all changed files
- `scripts/ci/check_mypy_baseline.py`: OK — 1472 errors, all within baseline (no new type errors; the 2-stale-entries warning is the known native-env artifact, baseline untouched per repo guidance)
