### PR TITLE
fix(board06): deterministic regen — remove wall-clock stage backstop + deterministic copper UUIDs (#4536)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   remaining-budget per-net wall-clock caps also stayed active. Fixed:
   `boards/06-diffpair-test/generate_design.py` now runs the negotiated
   stage with `timeout=None` — bounded by its deterministic iteration
-  exits (per-net node-expansion budget, memory backstop,
-  `max_iterations=10`, best-stall patience, #4463 zero-overflow
+  exits (per-net node-expansion budget, memory backstop, a
+  `max_iterations=3` count bound that reproduces where the wall clock
+  empirically cut, best-stall patience, #4463 zero-overflow
   fixed-point) instead of wall clock — and pins `PYTHONHASHSEED=42` by
-  construction (one-shot re-exec at the entry point). **Residual:** with
+  construction (one-shot re-exec at the entry point). **Reach-deciding:**
+  the relief rescue's probe / displaced-victim re-land sub-searches were
+  bounded by a flat 10 s wall clock that straddles their 8–12 s natural
+  time on CI runners; because a rescue rolls back entirely when a victim
+  does not re-land, that value decided routed reach on machine speed
+  alone (board-06 seed-42 landed 21/21 on one runner and 20/21 on
+  another from line-identical logs). `Autorouter.route_all_negotiated`
+  gained `deterministic_rescue=` (default off), which bounds those
+  sub-searches by the deterministic per-net node-expansion cap instead;
+  board 06 opts in. **Residual:** with
   the wall clock removed, runs still serialized ~2300 differing lines
   from *identical* copper multisets, because `kicad-cli` (invoked by
   every `kct zones fill` round) re-saves the board with tracks ordered

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Board-06 regen is same-host run-to-run deterministic again** (#4536) —
+  two same-seed flag-OFF regens could differ by thousands of lines,
+  making the "flag-OFF run must produce a byte-identical committed
+  artifact" scope-guard convention undecidable for board-06. Two
+  instrumented run matrices localized two sources. **Dominant:** the
+  negotiated stage's `timeout=360.0` wall-clock backstop straddled the
+  phase's natural runtime (363–367 s) and fired mid-iteration at a
+  load-dependent net boundary in every run (different copper counts,
+  1599–1602 segments); with any finite stage timeout the #3989
+  remaining-budget per-net wall-clock caps also stayed active. Fixed:
+  `boards/06-diffpair-test/generate_design.py` now runs the negotiated
+  stage with `timeout=None` — bounded by its deterministic iteration
+  exits (per-net node-expansion budget, memory backstop,
+  `max_iterations=10`, best-stall patience, #4463 zero-overflow
+  fixed-point) instead of wall clock — and pins `PYTHONHASHSEED=42` by
+  construction (one-shot re-exec at the entry point). **Residual:** with
+  the wall clock removed, runs still serialized ~2300 differing lines
+  from *identical* copper multisets, because `kicad-cli` (invoked by
+  every `kct zones fill` round) re-saves the board with tracks ordered
+  by UUID and the stitch/pour-repair emitters minted random
+  `uuid.uuid4()` values. Fixed: `kct stitch` now mints content-derived
+  uuid5 values for its vias/stub segments, and board-06's pour-repair
+  `_generate_uuid` mints sequence-derived uuid5 values — all copper
+  UUIDs are deterministic, so file order is stable under kicad-cli
+  refills. A gated determinism smoke test
+  (`tests/test_board06_determinism.py`, enabled via
+  `KCT_BOARD06_DETERMINISM=1`; two ~12-minute regens) asserts two
+  consecutive same-seed runs produce identical uuid-normalized
+  artifacts; the normalization + scope-guard convention is documented in
+  `boards/06-diffpair-test/README.md`. A residual load-correlated
+  sensitivity (a stagnation-recovery reroute can flip under extreme
+  concurrent host load) is tracked separately as #4724.
+
 ### Added
 
 - **`kct doctor` environment-preflight check group** (#4542, from the

--- a/boards/06-diffpair-test/README.md
+++ b/boards/06-diffpair-test/README.md
@@ -129,8 +129,8 @@ the 18-error diff-pair quality block documented under "CI Gate" below.
 Full board-06 regeneration (`generate_design.py --step route`) was
 run-to-run nondeterministic downstream of the coupled diff-pair
 pre-phase --- two same-seed runs of unmodified `main` could differ by
-thousands of lines ([#4536]).  Two instrumented run matrices localized
-**two** sources:
+thousands of lines ([#4536]).  Instrumented run matrices plus a CI-log
+bisection localized **three** sources:
 
 1. **Dominant: wall-clock truncation.**  The negotiated stage's
    `timeout=360.0` backstop straddled the phase's own natural runtime
@@ -140,13 +140,36 @@ thousands of lines ([#4536]).  Two instrumented run matrices localized
    remaining-budget per-net wall-clock caps active.  Fixed by removing
    wall-clock control flow from the negotiated stage (`timeout=None`;
    the stage is bounded by its deterministic iteration exits: per-net
-   node-expansion budget, memory backstop, `max_iterations=10`,
+   node-expansion budget, memory backstop, `max_iterations=3`,
    best-stall patience, and the #4463 zero-overflow fixed-point exit)
    and pinning `PYTHONHASHSEED=42` by construction at the
    `generate_design.py` entry point (one-shot re-exec), so plain
    invocations no longer depend on the caller exporting it.
+   `max_iterations=3` is the *deterministic* replacement for what the
+   backstop was doing: in every instrumented run (4 local baselines and
+   the green CI run 31214686048) the 360 s cut landed at the very start
+   of iteration 4, and iterations 4+ are provably discarded by the
+   end-of-loop lex restore, so bounding the count reproduces the
+   historical trajectory *and* saves the 9--14 minutes the discarded
+   round cost.  Do not raise it back to the default 10 without
+   re-measuring --- the board-06 E2E CI job ran to 29m45s of its 30-min
+   ceiling with iteration 4 enabled.
 
-2. **Residual: UUID-sorted file order.**  With the wall clock removed,
+2. **Reach-deciding: the relief rescue's 10 s sub-search wall clock.**
+   Board-06 reach is decided at negotiated iteration 2 by ONE relief
+   rescue (`MIPI_RST`), which rips four MIPI blockers and commits only
+   if all four re-land (the no-net-loss transaction guarantee).  Those
+   re-lands were bounded by a flat 10 s wall clock that straddles their
+   8--12 s natural time on GitHub runners, so the same commit produced
+   21/21 on one runner and 20/21 on another from routing logs that are
+   line-identical up to the rescue.  Fixed with
+   `route_all_negotiated(deterministic_rescue=True)` (default off
+   elsewhere), which bounds the rescue's probe / re-land sub-searches by
+   the deterministic per-net node-expansion cap instead.  This flag is
+   **load-bearing for `REQUIRED_SIGNAL_REACH = 21`** in
+   `scripts/ci/check_diffpair_coverage.py`.
+
+3. **Residual: UUID-sorted file order.**  With the wall clock removed,
    runs produced byte-identical routing logs and identical copper
    *multisets* yet still ~2300 differing artifact lines.  Stage-snapshot
    comparison across two runs proved every stage through the repair-via

--- a/boards/06-diffpair-test/README.md
+++ b/boards/06-diffpair-test/README.md
@@ -124,15 +124,70 @@ declared but DRC tolerated at "non-strict" while #2648 was pending.
 Both dependencies have since landed; the remaining tolerated residual is
 the 18-error diff-pair quality block documented under "CI Gate" below.
 
-## Measuring Changes: the Shadow Phase Is Deterministic, Full Regen Is Not (#4536)
+## Measuring Changes: Regen Determinism (#4536)
 
-Full board-06 regeneration (`generate_design.py --step route`) is
+Full board-06 regeneration (`generate_design.py --step route`) was
 run-to-run nondeterministic downstream of the coupled diff-pair
-pre-phase --- two same-seed runs of unmodified `main` can differ by
-thousands of lines ([#4536], open).  Every agent that measures a board-06
-change by diffing two full regens rediscovers this the hard way; this
-section exists so that discovery is a paragraph instead of a multi-hour
-detour.
+pre-phase --- two same-seed runs of unmodified `main` could differ by
+thousands of lines ([#4536]).  Two instrumented run matrices localized
+**two** sources:
+
+1. **Dominant: wall-clock truncation.**  The negotiated stage's
+   `timeout=360.0` backstop straddled the phase's own natural runtime
+   (363--367 s measured) and fired mid-iteration at a load-dependent net
+   boundary in **every** run (different copper counts, 1599--1602
+   segments), and any finite stage timeout also keeps the #3989
+   remaining-budget per-net wall-clock caps active.  Fixed by removing
+   wall-clock control flow from the negotiated stage (`timeout=None`;
+   the stage is bounded by its deterministic iteration exits: per-net
+   node-expansion budget, memory backstop, `max_iterations=10`,
+   best-stall patience, and the #4463 zero-overflow fixed-point exit)
+   and pinning `PYTHONHASHSEED=42` by construction at the
+   `generate_design.py` entry point (one-shot re-exec), so plain
+   invocations no longer depend on the caller exporting it.
+
+2. **Residual: UUID-sorted file order.**  With the wall clock removed,
+   runs produced byte-identical routing logs and identical copper
+   *multisets* yet still ~2300 differing artifact lines.  Stage-snapshot
+   comparison across two runs proved every stage through the repair-via
+   placement identical, with divergence entering at the first post-repair
+   `kct zones fill` --- `kicad-cli` re-saves the board with tracks
+   ordered by UUID, and the stitch/pour-repair emitters minted random
+   `uuid.uuid4()` values, so each run's refills sorted the *identical*
+   copper into a different file order (isolation test: two fills of the
+   same file are deterministic; a fill of a byte-equivalent file with
+   different UUIDs reorders).  Fixed by minting deterministic UUIDs:
+   content-derived uuid5 in `kct stitch` (`_stitch_uuid`) and
+   sequence-derived uuid5 in this board's `_generate_uuid`.
+
+**Determinism guard**: `tests/test_board06_determinism.py` runs two
+consecutive same-seed shadow-OFF regens and asserts identical segment /
+via counts, then byte-identity after normalizing uuid values (and
+nothing else --- `kicad-cli` mints random uuid4s for the pads/properties
+the generator emits without UUID fields, so raw byte identity can never
+hold; all *copper* UUIDs are deterministic after #4536).  It costs two
+full regens (~25 min), so it is skipped unless explicitly enabled:
+
+```bash
+KCT_BOARD06_DETERMINISM=1 uv run pytest tests/test_board06_determinism.py -v -s
+```
+
+**Scope-guard convention** (PR #4526 discussion): "flag-OFF run must
+produce a byte-identical committed artifact" is decidable for board-06
+again, with two provisos --- compare *uuid-normalized* text, and note
+the committed artifact predates the #4536 fix, so regen-vs-committed
+diffs remain expected until the artifact is next regenerated; the
+run-to-run invariant (regen A vs regen B at the same commit) is the one
+the test enforces.  Same-host runs only --- cross-host determinism is
+#4561's axis, and shadow-ON determinism remains out of scope.  One more
+proviso: run the two regens *sequentially on an otherwise-quiet host*
+(the smoke test's own protocol).  Under extreme concurrent load
+(measured at load-average ~90: parallel full test suites + mypy on the
+same host) one of three post-fix runs flipped a single
+stagnation-recovery reroute from success to failure and produced
+different (valid) copper --- a resource-exhaustion sensitivity distinct
+from the deterministic-logic sources fixed here (filed as #4724 with the
+preserved evidence).
 
 **The shadow-construction phase itself is fully deterministic.** This was
 established independently more than once during a 5-issue diffpair sweep

--- a/boards/06-diffpair-test/generate_design.py
+++ b/boards/06-diffpair-test/generate_design.py
@@ -3409,24 +3409,6 @@ def main() -> int:
     import argparse
     import random
 
-    # Issue #4536: pin the interpreter hash seed BY CONSTRUCTION before any
-    # routing code runs.  The README's shadow/census repro commands export
-    # ``PYTHONHASHSEED=42`` by hand, but a plain regen invocation did not.
-    # This is defensive hygiene for every str-keyed set/dict iteration in
-    # the in-process router AND the subprocess passes (``kct zones fill``,
-    # ``kct stitch`` inherit the pinned env).  NOTE: the #4536 matrix
-    # proved the pin alone is NOT sufficient for artifact byte-identity --
-    # the residual ~2300-line reorder was driven by random uuid4 values on
-    # stitch/repair copper being re-sorted by kicad-cli's UUID-ordered
-    # board save (fixed via deterministic UUID minting in
-    # ``_generate_uuid`` here and ``_stitch_uuid`` in stitch_cmd.py).
-    # ``PYTHONHASHSEED`` only takes effect at interpreter startup,
-    # so re-exec once with it pinned; the guard makes the exec a no-op when
-    # the wrapper (or the re-exec itself) already pinned it.
-    if os.environ.get("PYTHONHASHSEED") != "42":
-        os.environ["PYTHONHASHSEED"] = "42"
-        os.execv(sys.executable, [sys.executable] + sys.argv)
-
     parser = argparse.ArgumentParser(
         prog="generate_design",
         description="Board 06 (diffpair-test) design generator + Phase 4N CI re-route hook.",
@@ -3657,5 +3639,39 @@ def main() -> int:
         return 1
 
 
+def _reexec_with_pinned_hash_seed() -> None:
+    """Re-exec this script once with ``PYTHONHASHSEED=42`` pinned.
+
+    Issue #4536: pin the interpreter hash seed BY CONSTRUCTION before any
+    routing code runs.  The README's shadow/census repro commands export
+    ``PYTHONHASHSEED=42`` by hand, but a plain regen invocation did not.
+    This is defensive hygiene for every str-keyed set/dict iteration in
+    the in-process router AND the subprocess passes (``kct zones fill``,
+    ``kct stitch`` inherit the pinned env).  NOTE: the #4536 matrix
+    proved the pin alone is NOT sufficient for artifact byte-identity --
+    the residual ~2300-line reorder was driven by random uuid4 values on
+    stitch/repair copper being re-sorted by kicad-cli's UUID-ordered
+    board save (fixed via deterministic UUID minting in ``_generate_uuid``
+    here and ``_stitch_uuid`` in stitch_cmd.py).
+
+    ``PYTHONHASHSEED`` only takes effect at interpreter startup, so the
+    only way to pin it from inside the process is to re-exec.  The guard
+    makes the exec a no-op when the wrapper (or the re-exec itself)
+    already pinned it.
+
+    This MUST stay out of :func:`main` — ``os.execv`` replaces the whole
+    process, so calling it from ``main()`` would destroy any in-process
+    caller (e.g. the pytest workers in
+    ``tests/test_board_06_partial_route_fastfail.py``, which import this
+    module and call ``main()`` directly).  Only real CLI invocations,
+    where this script owns the process and ``sys.argv`` is its own, may
+    re-exec.
+    """
+    if os.environ.get("PYTHONHASHSEED") != "42":
+        os.environ["PYTHONHASHSEED"] = "42"
+        os.execv(sys.executable, [sys.executable] + sys.argv)
+
+
 if __name__ == "__main__":
+    _reexec_with_pinned_hash_seed()
     sys.exit(main())

--- a/boards/06-diffpair-test/generate_design.py
+++ b/boards/06-diffpair-test/generate_design.py
@@ -2743,15 +2743,50 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
         # this stage with no wall-clock budget at all.  The stage stays
         # bounded by its deterministic iteration exits instead: the per-net
         # 1M node-expansion budget wired into the Autorouter above, the 12M
-        # memory backstop, ``max_iterations=10``, best-stall patience 2, and
-        # the #4463 zero-overflow fixed-point exit.
+        # memory backstop, the ``max_iterations=3`` bound below, best-stall
+        # patience 2, and the #4463 zero-overflow fixed-point exit.
         # ``tests/test_board06_determinism.py`` (gated behind
         # ``KCT_BOARD06_DETERMINISM=1``) is the regression guard: two
         # consecutive same-seed runs must produce identical uuid-normalized
         # artifacts.
+        #
+        # ``max_iterations=3`` (#4536) -- LOAD-BEARING for RUNTIME; do not
+        # raise it back to the default 10 without re-measuring.  This is the
+        # DETERMINISTIC replacement for the truncation the 360 s backstop used
+        # to perform: in every instrumented run (4 local baselines + CI run
+        # 31214686048) the backstop fired at the very START of iteration 4
+        # ("Timeout during reroute at net 0/19" / "net 0/21"), so iterations
+        # 0-3 are exactly the work the historical artifact was built from.
+        # Removing the wall clock let iteration 4 run to completion, which
+        # cost +9.3 min locally and +14 min on CI (the Board-06 E2E job landed
+        # at 29m45s against its 30-min ceiling) and changed NOTHING: iteration
+        # 4 regresses to connected=11/21, the end-of-loop lex restore discards
+        # it, and the committed state is the iteration-2 snapshot either way.
+        # ``best_stall_patience=2`` would also have exited after iteration 4,
+        # so 3 gives up no convergence headroom -- it just stops paying for a
+        # round whose result is provably discarded.  A count-based bound is
+        # reproducible where the wall-clock cut was not (the baseline matrix
+        # cut mid-net at load-dependent boundaries: net 0/19 vs net 1/19).
+        #
+        # ``deterministic_rescue=True`` (#4536) -- LOAD-BEARING for
+        # ``REQUIRED_SIGNAL_REACH = 21`` in
+        # ``scripts/ci/check_diffpair_coverage.py``.  Reach on this board is
+        # decided at ITERATION 2 by ONE relief rescue (``MIPI_RST``): it rips
+        # 4 MIPI blockers, and the transaction commits only if all 4 re-land.
+        # Those re-lands were bounded by a flat 10 s wall clock that straddles
+        # their 8-12 s natural time on GitHub runners, so the SAME code landed
+        # 21/21 on one runner (CI run 31214686048: "MIPI_RST ROUTED via
+        # conflict-free relief path; 4/4 displaced victim(s) re-landed") and
+        # 20/21 on another (run 31213011136: "only 3/4 displaced victim(s)
+        # re-landed -- rolling back"), with the routing logs line-identical up
+        # to that point.  Bounding those sub-searches by the per-net
+        # node-expansion cap instead makes the commit/rollback decision
+        # machine-independent -- the point of this issue.
         return router.route_all_negotiated(
             per_net_timeout=None,
             timeout=None,
+            max_iterations=3,
+            deterministic_rescue=True,
             seed=42,
         )
 

--- a/boards/06-diffpair-test/generate_design.py
+++ b/boards/06-diffpair-test/generate_design.py
@@ -33,6 +33,7 @@ If no output directory is specified, files are written to ./output/.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -345,10 +346,35 @@ def _find_sexp_blocks(text: str, token: str) -> list[str]:
     return blocks
 
 
+# Issue #4536: sequence counter for deterministic repair-copper UUIDs.
+# Reset at the top of ``route_pcb`` so every regen mints the same sequence.
+_REPAIR_UUID_COUNTER = 0
+
+
+def _reset_repair_uuid_counter() -> None:
+    """Reset the deterministic repair-UUID sequence (start of a regen)."""
+    global _REPAIR_UUID_COUNTER
+    _REPAIR_UUID_COUNTER = 0
+
+
 def _generate_uuid() -> str:
+    """Deterministic UUID for pour-repair / bridge copper (#4536).
+
+    ``kicad-cli`` (invoked by every ``kct zones fill`` round of the repair
+    loop) re-saves the board with tracks ordered by UUID.  The #4536 regen
+    matrix showed that once the wall-clock sources were removed, the ONLY
+    remaining artifact difference between two same-seed runs was the file
+    order of the stitch/repair copper -- because these emitters minted
+    random ``uuid.uuid4()`` values, each refill sorted the identical
+    copper differently.  A uuid5 over a per-run sequence number is stable
+    run-to-run (the repair passes' call sequence is deterministic once
+    routing is) while staying unique within the artifact.
+    """
+    global _REPAIR_UUID_COUNTER
+    _REPAIR_UUID_COUNTER += 1
     import uuid as _uuid
 
-    return str(_uuid.uuid4())
+    return str(_uuid.uuid5(_uuid.NAMESPACE_OID, f"board06-pour-repair:{_REPAIR_UUID_COUNTER}"))
 
 
 def _audit_pour_nets(pcb_path: Path, net_names: list[str]) -> dict:
@@ -2224,6 +2250,11 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
     print("Routing PCB...")
     print("=" * 60)
 
+    # Issue #4536: repair-copper UUIDs are minted from a deterministic
+    # sequence (see ``_generate_uuid``); reset it so back-to-back regens
+    # in one process mint identical sequences.
+    _reset_repair_uuid_counter()
+
     # JLCPCB tier-1 design rules: 0.15mm trace / 0.15mm space / 0.3mm via.
     # Grid must be <= clearance/2 for DRC compliance (0.05 <= 0.15/2 = 0.075 OK).
     # Via diameter chosen tight (0.45mm) so escape vias fit between
@@ -2691,14 +2722,36 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
         # ``getattr(args, "per_net_timeout", None) or None`` -> None
         # (route_cmd.py:3272 etc.).
         #
-        # ``timeout=360.0`` is retained as an outer SAFETY BACKSTOP only -- it
-        # must NOT fire, or it re-introduces the load-dependent cutoff the
-        # iteration budget removes.  The negotiated loop's banking work
-        # completes well under 360s on this board (see the #3413 phase-6 note
-        # above).
+        # ``timeout=None`` (#4536): this stage previously carried a
+        # ``timeout=360.0`` wall-clock SAFETY BACKSTOP with a comment claiming
+        # it "must NOT fire".  Instrumented multi-run evidence (issue #4536,
+        # 4-run same-host matrix) showed the phase's natural runtime STRADDLES
+        # that value, so the backstop fired mid-iteration-4 in EVERY run -- at
+        # a load-dependent net boundary ("Timeout during reroute at net 0/19"
+        # vs "net 1/19", 363.1-367.0s) -- and the #3989 remaining-budget
+        # per-net caps additionally cut the iteration-4 zero-overflow recovery
+        # at load-dependent points (routed 9/18 vs 9/19), so the four baseline
+        # runs serialized four DISTINCT artifacts (different copper counts,
+        # 1599-1602 segments).  With ``timeout=None`` the routed copper became
+        # count- and content-identical run to run (byte-identical logs and
+        # step-8 serialization), leaving only the uuid-sort file-order
+        # residual fixed in ``_generate_uuid`` / ``_stitch_uuid`` (#4536).
+        # A finite backstop near the natural runtime re-introduces
+        # the straddle, and ANY finite ``timeout`` keeps the wall-clock
+        # per-net caps active (core.py derives them from the REMAINING stage
+        # budget each iteration, #3989) -- so determinism requires running
+        # this stage with no wall-clock budget at all.  The stage stays
+        # bounded by its deterministic iteration exits instead: the per-net
+        # 1M node-expansion budget wired into the Autorouter above, the 12M
+        # memory backstop, ``max_iterations=10``, best-stall patience 2, and
+        # the #4463 zero-overflow fixed-point exit.
+        # ``tests/test_board06_determinism.py`` (gated behind
+        # ``KCT_BOARD06_DETERMINISM=1``) is the regression guard: two
+        # consecutive same-seed runs must produce identical uuid-normalized
+        # artifacts.
         return router.route_all_negotiated(
             per_net_timeout=None,
-            timeout=360.0,
+            timeout=None,
             seed=42,
         )
 
@@ -3355,6 +3408,24 @@ def main() -> int:
     """
     import argparse
     import random
+
+    # Issue #4536: pin the interpreter hash seed BY CONSTRUCTION before any
+    # routing code runs.  The README's shadow/census repro commands export
+    # ``PYTHONHASHSEED=42`` by hand, but a plain regen invocation did not.
+    # This is defensive hygiene for every str-keyed set/dict iteration in
+    # the in-process router AND the subprocess passes (``kct zones fill``,
+    # ``kct stitch`` inherit the pinned env).  NOTE: the #4536 matrix
+    # proved the pin alone is NOT sufficient for artifact byte-identity --
+    # the residual ~2300-line reorder was driven by random uuid4 values on
+    # stitch/repair copper being re-sorted by kicad-cli's UUID-ordered
+    # board save (fixed via deterministic UUID minting in
+    # ``_generate_uuid`` here and ``_stitch_uuid`` in stitch_cmd.py).
+    # ``PYTHONHASHSEED`` only takes effect at interpreter startup,
+    # so re-exec once with it pinned; the guard makes the exec a no-op when
+    # the wrapper (or the re-exec itself) already pinned it.
+    if os.environ.get("PYTHONHASHSEED") != "42":
+        os.environ["PYTHONHASHSEED"] = "42"
+        os.execv(sys.executable, [sys.executable] + sys.argv)
 
     parser = argparse.ArgumentParser(
         prog="generate_design",

--- a/src/kicad_tools/cli/stitch_cmd.py
+++ b/src/kicad_tools/cli/stitch_cmd.py
@@ -2979,6 +2979,28 @@ def get_via_layers(pad_layer: str, target_layer: str | None) -> tuple[str, str]:
         return ("B.Cu", "F.Cu")
 
 
+def _stitch_uuid(*parts: object) -> str:
+    """Deterministic, content-derived UUID for stitch-emitted copper.
+
+    Issue #4536: ``kicad-cli`` (which ``kct zones fill`` shells out to)
+    re-saves the whole board with tracks ordered by their UUID, so copper
+    minted with random ``uuid.uuid4()`` values lands at a *different file
+    position on every run* even when the placed geometry is byte-identical.
+    Board-06's regen-determinism matrix isolated this as the residual
+    nondeterminism source after the wall-clock fixes: two runs whose
+    routing logs and copper multisets were identical still serialized
+    ~2300 differing lines because each refill re-sorted the randomly
+    keyed stitch/repair copper differently.
+
+    Deriving the UUID from the placed element's own content (uuid5 over
+    net/layer/geometry) keeps stitch output stable across identical runs
+    while remaining unique per distinct element -- two *different* vias or
+    segments can never share a key, and a genuine duplicate placement
+    would be a bug upstream of UUID minting.
+    """
+    return str(uuid.uuid5(uuid.NAMESPACE_OID, "kct-stitch:" + ":".join(str(p) for p in parts)))
+
+
 def add_via_to_pcb(sexp: SExp, placement: ViaPlacement) -> None:
     """Add a via to the PCB S-expression."""
     via = via_node(
@@ -2988,7 +3010,15 @@ def add_via_to_pcb(sexp: SExp, placement: ViaPlacement) -> None:
         drill=placement.drill,
         layers=placement.layers,
         net=placement.pad.net_number,
-        uuid_str=str(uuid.uuid4()),
+        uuid_str=_stitch_uuid(
+            "via",
+            placement.via_x,
+            placement.via_y,
+            placement.size,
+            placement.drill,
+            placement.layers,
+            placement.pad.net_number,
+        ),
         via_type=placement.via_type,
     )
     sexp.append(via)
@@ -3017,7 +3047,14 @@ def add_trace_to_pcb(sexp: SExp, trace: TraceSegment) -> None:
                 width=trace.width,
                 layer=trace.layer,
                 net=trace.pad.net_number,
-                uuid_str=str(uuid.uuid4()),
+                uuid_str=_stitch_uuid(
+                    "seg",
+                    points[i],
+                    points[i + 1],
+                    trace.width,
+                    trace.layer,
+                    trace.pad.net_number,
+                ),
             )
             sexp.append(seg)
     elif trace.is_dogleg:
@@ -3031,7 +3068,14 @@ def add_trace_to_pcb(sexp: SExp, trace: TraceSegment) -> None:
             width=trace.width,
             layer=trace.layer,
             net=trace.pad.net_number,
-            uuid_str=str(uuid.uuid4()),
+            uuid_str=_stitch_uuid(
+                "seg",
+                (trace.pad.x, trace.pad.y),
+                (trace.intermediate_x, trace.intermediate_y),
+                trace.width,
+                trace.layer,
+                trace.pad.net_number,
+            ),
         )
         sexp.append(seg1)
 
@@ -3044,7 +3088,14 @@ def add_trace_to_pcb(sexp: SExp, trace: TraceSegment) -> None:
             width=trace.width,
             layer=trace.layer,
             net=trace.pad.net_number,
-            uuid_str=str(uuid.uuid4()),
+            uuid_str=_stitch_uuid(
+                "seg",
+                (trace.intermediate_x, trace.intermediate_y),
+                (trace.via_x, trace.via_y),
+                trace.width,
+                trace.layer,
+                trace.pad.net_number,
+            ),
         )
         sexp.append(seg2)
     else:
@@ -3057,7 +3108,14 @@ def add_trace_to_pcb(sexp: SExp, trace: TraceSegment) -> None:
             width=trace.width,
             layer=trace.layer,
             net=trace.pad.net_number,
-            uuid_str=str(uuid.uuid4()),
+            uuid_str=_stitch_uuid(
+                "seg",
+                (trace.pad.x, trace.pad.y),
+                (trace.via_x, trace.via_y),
+                trace.width,
+                trace.layer,
+                trace.pad.net_number,
+            ),
         )
         sexp.append(seg)
 

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -153,6 +153,32 @@ _ESCAPE_CORRIDOR_MAX_LENGTH_MM = 5.0
 # all four; degrades gracefully to the outer layers on a 2-layer board.
 _ESCAPE_CORRIDOR_INNER_LAYERS_ONLY = True
 
+# Issue #4536: wall-clock budget for the relief rescue's SUB-searches (the
+# min-conflict probe rounds and the displaced-victim re-land passes inside
+# :meth:`Autorouter._relief_rescue`).  This is the historical default and is
+# LOAD-BEARING for routed reach on any board that does not opt into
+# ``deterministic_rescue`` -- a victim that fails to re-land within the budget
+# rolls the whole transaction back (no-net-loss guarantee), so the value
+# decides whether the rescued net is kept or dropped.
+#
+# On board-06 seed-42 the natural victim re-land time sits in the 8-12 s band on
+# GitHub's ubuntu runners, i.e. this 10 s value STRADDLES it: the same commit
+# reached 21/21 on one runner and 20/21 on another purely on machine speed (CI
+# runs 31214686048 vs 31213011136 are line-identical up to the MIPI_RST rescue
+# and then diverge on whether MIPI_CLK- re-lands).  Callers that need a
+# machine-independent artifact pass ``deterministic_rescue=True``, which bounds
+# these sub-searches by the deterministic per-net NODE-EXPANSION cap instead.
+RELIEF_SUBSEARCH_BUDGET_S = 10.0
+
+# Issue #4536: the wall clock kept under ``deterministic_rescue=True``.  It is
+# deliberately ~10x the measured natural sub-search time (a per-net search that
+# exhausts the 1M-expansion cap costs ~11 s on a CI runner), so it is NOT
+# load-bearing -- the binding bound is the node-expansion cap.  It exists only
+# to keep the one path that the expansion cap does not price in seconds (a
+# pure-Python A* fallback, 10-100x slower than the C++ backend) from grinding
+# for minutes inside a rescue, per the #3989 lesson.
+RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S = 120.0
+
 
 @dataclass
 class RoutingFailure:
@@ -8733,6 +8759,7 @@ class Autorouter:
         best_stall_patience: int | None = 2,
         best_stall_min_iterations: int = 2,
         early_bail_terminal_stall: bool = True,
+        deterministic_rescue: bool = False,
     ) -> list[Route]:
         """Route all nets using PathFinder-style negotiated congestion.
 
@@ -8877,6 +8904,17 @@ class Autorouter:
                 True.  Set to ``False`` to force the historical
                 grind-to-budget behavior (A/B comparison / regression
                 bisection).
+            deterministic_rescue: Issue #4536 -- bound the relief
+                rescue's probe / victim-re-land sub-searches by the
+                deterministic per-net node-expansion cap instead of the
+                10 s wall clock, so a rescue commits or rolls back
+                identically on every machine.  Requires an active
+                expansion cap (``--deterministic-budget`` /
+                ``per_net_iterations``); without one the wall clock is
+                kept.  Default False (historical behavior); board 06
+                opts in because its ``REQUIRED_SIGNAL_REACH`` gate is
+                decided by exactly one such rescue.  See
+                :meth:`_relief_subsearch_budget`.
 
         Returns:
             List of routes (may be partial if timeout reached)
@@ -8953,6 +8991,27 @@ class Autorouter:
                     f"budget; set --per-net-timeout to override; issue #3474)"
                 )
             per_net_timeout = derived_cap
+
+        # Issue #4536: record the relief-rescue sub-search bound in the log --
+        # it decides whether a rescue commits (reach!), so it must be visible
+        # in any routing log used as evidence.
+        if deterministic_rescue:
+            _rescue_budget = self._relief_subsearch_budget(per_net_timeout, True)
+            if _rescue_budget == RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S:
+                flush_print(
+                    "  Relief-rescue sub-search cap: iteration-bounded "
+                    "(per-net node-expansion cap; issue #4536) -- probe / "
+                    "victim-re-land outcomes are machine-independent; "
+                    f"{RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S:.0f}s wall clock kept "
+                    "only as a non-binding Python-fallback backstop"
+                )
+            else:
+                flush_print(
+                    "  Relief-rescue sub-search cap: "
+                    f"{_rescue_budget:.1f}s wall clock -- deterministic_rescue "
+                    "requested but no per-net node-expansion cap is active "
+                    "(issue #4536)"
+                )
 
         # Issue #2587 / Epic #2556 Phase 1C-cont: Activate diff-pair partner
         # threading before negotiated routing begins.  This is the default
@@ -11554,6 +11613,7 @@ class Autorouter:
                                     flush_print,
                                     elapsed_str,
                                     deadline=relief_deadline,
+                                    deterministic_rescue=deterministic_rescue,
                                 ):
                                     relief_resolved += 1
                             if relief_attempted > 0:
@@ -11654,6 +11714,7 @@ class Autorouter:
                                         flush_print,
                                         elapsed_str,
                                         deadline=relief_deadline,
+                                        deterministic_rescue=deterministic_rescue,
                                     ):
                                         silent_resolved += 1
                                 if silent_resolved > 0:
@@ -12390,6 +12451,60 @@ class Autorouter:
             victims |= self.grid.find_relief_conflict_nets(route, net)
         return probe_routes, victims
 
+    def _relief_subsearch_budget(
+        self, per_net_timeout: float | None, deterministic_rescue: bool
+    ) -> float | None:
+        """Budget for the relief rescue's probe / victim-re-land searches.
+
+        Issue #4536.  The rescue is a TRANSACTION with a no-net-loss
+        guarantee: if a displaced victim does not re-land, the whole
+        rescue rolls back and the rescued net stays unrouted.  The budget
+        those sub-searches get is therefore **reach-determining**, not a
+        mere performance knob.
+
+        Historically that budget was a flat ``RELIEF_SUBSEARCH_BUDGET_S``
+        (10 s) wall clock.  On board-06 seed-42 the natural victim
+        re-land time on GitHub ubuntu runners sits in the 8-12 s band --
+        i.e. the budget STRADDLES it, and the SAME code at the SAME
+        commit lands 21/21 on a fast runner and 20/21 on a slow one (the
+        rescue of ``MIPI_RST`` at iteration 2 keeps or drops
+        ``MIPI_CLK-``).  That is the same defect class as the 360 s stage
+        backstop this issue removed, one level down.
+
+        ``deterministic_rescue=True`` replaces the wall clock with the
+        DETERMINISTIC per-net node-expansion cap that already bounds every
+        other search in the stage (``--deterministic-budget`` /
+        ``per_net_iterations``, #3877/#3881): the sub-search runs exactly
+        the same number of node expansions on every machine, so the rescue
+        commits or rolls back identically everywhere.
+        ``RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S`` is kept as a NON-load-bearing
+        outer guard (~10x the natural sub-search time) purely for the
+        pure-Python A* fallback, which the expansion cap does not price in
+        seconds.
+
+        The deterministic mode requires an active expansion cap; without
+        one there is no deterministic bound to fall back on, so the
+        historical wall clock is kept (degrading to today's behavior
+        rather than to an unbounded search).
+        """
+        if deterministic_rescue:
+            expansion_cap = min(
+                (
+                    cap
+                    for cap in (
+                        getattr(self, "_per_net_iterations", 0),
+                        getattr(self, "_max_search_iterations", 0),
+                    )
+                    if cap
+                ),
+                default=0,
+            )
+            if expansion_cap:
+                return RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S
+        if per_net_timeout:
+            return min(RELIEF_SUBSEARCH_BUDGET_S, per_net_timeout)
+        return RELIEF_SUBSEARCH_BUDGET_S
+
     def _relief_rescue(
         self,
         failed_net: int,
@@ -12402,6 +12517,7 @@ class Autorouter:
         elapsed_fn,
         depth: int = 0,
         deadline: float | None = None,
+        deterministic_rescue: bool = False,
     ) -> bool:
         """Transactional relief rescue for a zero-overflow hard failure.
 
@@ -12430,6 +12546,12 @@ class Autorouter:
                 rescue.  When the deadline passes mid-rescue the
                 transaction rolls back verbatim and returns False, so
                 the bound costs nothing in correctness.
+            deterministic_rescue: Issue #4536 -- bound the rescue's
+                SUB-searches (probe rounds, victim re-lands) by the
+                deterministic per-net NODE-EXPANSION cap instead of the
+                ``RELIEF_SUBSEARCH_BUDGET_S`` wall clock.  See
+                :meth:`_relief_subsearch_budget` for the measurement that
+                motivates it and the load-bearing consequences.
 
         Returns:
             True when the failed net is now routed and no sibling was
@@ -12440,6 +12562,7 @@ class Autorouter:
         def _past_deadline() -> bool:
             return deadline is not None and _time.time() >= deadline
 
+        subsearch_budget = self._relief_subsearch_budget(per_net_timeout, deterministic_rescue)
         max_rounds = 4
         snapshot_nets: set[int] = {failed_net}
         original_routes: dict[int, list[Route]] = {failed_net: list(net_routes.get(failed_net, []))}
@@ -12506,8 +12629,10 @@ class Autorouter:
         # graph always has SOME path unless foreign pad metal seals the
         # pin); a probe that needs tens of seconds is exploring a
         # genuinely infeasible graph -- cap it well below the per-net
-        # budget so a hopeless rescue fails fast.
-        probe_timeout = min(10.0, per_net_timeout) if per_net_timeout else 10.0
+        # budget so a hopeless rescue fails fast.  Issue #4536: under
+        # ``deterministic_rescue`` the cap is the node-expansion budget
+        # instead (``_relief_subsearch_budget``).
+        probe_timeout = subsearch_budget
         committed_routes: list[Route] | None = None
         for round_idx in range(max_rounds):
             if _past_deadline():
@@ -12598,7 +12723,11 @@ class Autorouter:
         # Re-land the displaced victims.  Reduced per-net budget: any
         # member that fails here is retried by the normal recovery flow
         # with the full budget on the next iteration (if we commit).
-        restart_timeout = min(10.0, per_net_timeout) if per_net_timeout else 10.0
+        # Issue #4536: under ``deterministic_rescue`` this is the
+        # node-expansion cap, not a wall clock -- a victim that fails to
+        # re-land rolls the WHOLE transaction back, so a wall-clock value
+        # here decides routed reach on machine speed alone.
+        restart_timeout = subsearch_budget
         # Multi-pass re-land: a victim that fails while its displaced
         # siblings are still unplaced often lands cleanly once they have
         # settled (the run-5 measurements: rescues failed at exactly
@@ -12655,6 +12784,7 @@ class Autorouter:
                     elapsed_fn,
                     depth=depth + 1,
                     deadline=deadline,
+                    deterministic_rescue=deterministic_rescue,
                 ):
                     relanded += 1
                 else:

--- a/tests/test_board06_determinism.py
+++ b/tests/test_board06_determinism.py
@@ -1,0 +1,184 @@
+"""Gated same-host determinism smoke test for board-06 regen (Issue #4536).
+
+Two consecutive same-seed ``generate_design.py --step route --seed 42``
+runs against the *same committed unrouted PCB* must produce identical
+routed artifacts after uuid normalization.
+
+Why this exists
+===============
+
+Issue #4536: two flag-OFF (shadow-OFF) regens of unmodified main differed
+by 9525 lines, making the "flag-OFF run must produce a byte-identical
+committed artifact" scope-guard convention undecidable for board-06.
+The instrumented run matrices (see the PR for #4536) localized TWO
+sources:
+
+1. **Dominant -- wall-clock truncation.** The negotiated phase's 360 s
+   backstop straddled the phase's own natural runtime (363-367 s
+   measured), firing mid-iteration-4 at a load-dependent net boundary in
+   every run; with any finite stage timeout the #3989 remaining-budget
+   per-net wall-clock caps also stayed active.  Four baseline runs
+   serialized four artifacts with *different copper counts* (1599-1602
+   segments).  Fixed with ``timeout=None`` (the stage is bounded by its
+   deterministic iteration exits instead) plus ``PYTHONHASHSEED`` pinned
+   by construction at the regen entry point.
+
+2. **Residual -- UUID-sorted file order.** With the wall clock removed,
+   runs produced byte-identical logs and identical copper *multisets*,
+   yet still ~2300 differing artifact lines: ``kicad-cli`` (invoked by
+   every ``kct zones fill`` round) re-saves the board with tracks
+   ordered by UUID, and the stitch/pour-repair emitters minted random
+   ``uuid.uuid4()`` values -- so each run's refills sorted the identical
+   copper into a different file order.  Fixed by minting deterministic
+   UUIDs (content-derived uuid5 in ``kct stitch``, sequence-derived
+   uuid5 in board-06's ``_generate_uuid``).
+
+Normalization convention (documented per the #4536 acceptance criteria)
+=======================================================================
+
+Byte-identity is asserted **after normalizing uuid values** and nothing
+else:
+
+* Pad / property UUIDs inside footprints are minted by ``kicad-cli``
+  itself on its first re-save (the generator emits them without UUID
+  fields), so they legitimately differ run-to-run without any copper
+  difference and without affecting element order.  Each ``(uuid "...")``
+  is replaced with ``(uuid "X")`` before comparison.  Positional identity
+  is still required: the *number and location* of uuid-bearing nodes must
+  match exactly -- which, per source 2 above, only holds because
+  stitch/repair copper UUIDs are now deterministic.
+* No timestamps or dates are present in the emitted ``kicad_pcb``
+  (verified against the artifact header), so nothing else is masked.
+
+See also ``tests/router/test_board06_determinism.py`` (#3144), the
+complementary gated integration test asserting DRC-count identity across
+N re-routes.
+
+Gating
+======
+
+A full route-step regen takes ~12 minutes, so this can never be a
+default-run unit test.  It is skipped unless ``KCT_BOARD06_DETERMINISM=1``
+is exported:
+
+.. code-block:: bash
+
+    KCT_BOARD06_DETERMINISM=1 uv run pytest tests/test_board06_determinism.py -v -s
+
+Budget ~25 minutes for the two sequential regens, and run on an
+otherwise-quiet host: under extreme concurrent load (load-average ~90)
+a stagnation-recovery reroute can flip and produce different valid
+copper -- a resource-exhaustion sensitivity tracked separately as #4724,
+not a regression of the #4536 fixes.  See
+``boards/06-diffpair-test/README.md`` ("Measuring Changes") for how this
+test slots into the byte-identity scope-guard convention.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("KCT_BOARD06_DETERMINISM") != "1",
+    reason=(
+        "board-06 determinism smoke test runs two ~12-minute regens; "
+        "set KCT_BOARD06_DETERMINISM=1 to enable (issue #4536)"
+    ),
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BOARD_DIR = REPO_ROOT / "boards" / "06-diffpair-test"
+UNROUTED_PCB = BOARD_DIR / "output" / "diffpair_test.kicad_pcb"
+
+_UUID_RE = re.compile(r'\(uuid "[0-9a-fA-F-]+"\)')
+
+
+def _normalize_uuids(text: str) -> str:
+    """Mask uuid4 values (and ONLY uuid4 values) for content comparison."""
+    return _UUID_RE.sub('(uuid "X")', text)
+
+
+def _run_route_regen(out_dir: Path) -> str:
+    """Run one ``--step route --seed 42`` regen; return the routed artifact text."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy(UNROUTED_PCB, out_dir / "diffpair_test.kicad_pcb")
+    # No PYTHONHASHSEED in the env on purpose: the entry point must pin it
+    # itself (the #4536 fix re-execs with PYTHONHASHSEED=<seed>), so this
+    # test also guards that pinning.
+    env = {k: v for k, v in os.environ.items() if k != "PYTHONHASHSEED"}
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(BOARD_DIR / "generate_design.py"),
+            "--step",
+            "route",
+            "--seed",
+            "42",
+            str(out_dir),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=3600,
+    )
+    routed = out_dir / "diffpair_test_routed.kicad_pcb"
+    assert proc.returncode == 0, (
+        f"route regen failed (rc={proc.returncode}):\n"
+        f"stdout tail:\n{proc.stdout[-4000:]}\nstderr tail:\n{proc.stderr[-4000:]}"
+    )
+    assert routed.exists(), f"routed artifact not written to {routed}"
+    return routed.read_text()
+
+
+def _copper_counts(text: str) -> tuple[int, int]:
+    """(segment, via) node counts -- the count-identity invariant."""
+    return text.count("(segment"), text.count("(via")
+
+
+def test_two_same_seed_route_regens_are_identical(tmp_path: Path) -> None:
+    """Two consecutive same-seed regens produce identical normalized artifacts.
+
+    Asserts the #4536 acceptance invariants in increasing strictness so a
+    failure report names the loosest broken level:
+
+    1. identical segment and via counts (count-identity), then
+    2. byte-identity of the uuid-normalized artifacts.
+    """
+    first = _run_route_regen(tmp_path / "run-a")
+    second = _run_route_regen(tmp_path / "run-b")
+
+    counts_a = _copper_counts(first)
+    counts_b = _copper_counts(second)
+    assert counts_a == counts_b, (
+        f"segment/via count mismatch between same-seed runs: "
+        f"run-a={counts_a} run-b={counts_b} (issue #4536 regression)"
+    )
+
+    norm_a = _normalize_uuids(first)
+    norm_b = _normalize_uuids(second)
+    if norm_a != norm_b:
+        # Produce a bounded, useful failure message instead of a megabyte diff.
+        lines_a = norm_a.splitlines()
+        lines_b = norm_b.splitlines()
+        first_div = next(
+            (i for i, (la, lb) in enumerate(zip(lines_a, lines_b, strict=False)) if la != lb),
+            min(len(lines_a), len(lines_b)),
+        )
+        context_a = lines_a[first_div : first_div + 3]
+        context_b = lines_b[first_div : first_div + 3]
+        pytest.fail(
+            "uuid-normalized artifacts differ between same-seed runs "
+            f"(first divergence at line {first_div + 1}; "
+            f"{len(lines_a)} vs {len(lines_b)} lines).\n"
+            f"run-a: {context_a}\nrun-b: {context_b}\n"
+            "See issue #4536 -- a wall-clock, hash-order, or random-UUID "
+            "file-order dependence has re-entered the board-06 route pipeline."
+        )

--- a/tests/test_board06_determinism.py
+++ b/tests/test_board06_determinism.py
@@ -101,7 +101,15 @@ _UUID_RE = re.compile(r'\(uuid "[0-9a-fA-F-]+"\)')
 
 
 def _normalize_uuids(text: str) -> str:
-    """Mask uuid4 values (and ONLY uuid4 values) for content comparison."""
+    """Mask every ``(uuid "...")`` value for content comparison.
+
+    This masks *all* UUIDs -- both the random uuid4s KiCad mints for
+    footprints/zones and the deterministic uuid5 copper UUIDs from the
+    #4536 fix -- not just uuid4.  Identity is still enforced positionally:
+    two artifacts only compare equal if their UUID fields occur at the same
+    offsets in the same order, so a UUID-driven reorder still shows up as a
+    diff even though the values themselves are masked.
+    """
     return _UUID_RE.sub('(uuid "X")', text)
 
 
@@ -139,7 +147,14 @@ def _run_route_regen(out_dir: Path) -> str:
 
 
 def _copper_counts(text: str) -> tuple[int, int]:
-    """(segment, via) node counts -- the count-identity invariant."""
+    """(segment, via) node counts -- the count-identity invariant.
+
+    Substring counting is safe for the current KiCad s-expression grammar:
+    no ``(segments``/``(via_...`` (or any other ``(segment*``/``(via*``)
+    token exists in a ``.kicad_pcb``, so these prefixes match only the
+    copper element headers.  If KiCad ever adds such a token this needs to
+    become a token-aware count.
+    """
     return text.count("(segment"), text.count("(via")
 
 

--- a/tests/test_board06_determinism.py
+++ b/tests/test_board06_determinism.py
@@ -10,7 +10,7 @@ Why this exists
 Issue #4536: two flag-OFF (shadow-OFF) regens of unmodified main differed
 by 9525 lines, making the "flag-OFF run must produce a byte-identical
 committed artifact" scope-guard convention undecidable for board-06.
-The instrumented run matrices (see the PR for #4536) localized TWO
+The instrumented run matrices (see the PR for #4536) localized THREE
 sources:
 
 1. **Dominant -- wall-clock truncation.** The negotiated phase's 360 s
@@ -21,9 +21,22 @@ sources:
    serialized four artifacts with *different copper counts* (1599-1602
    segments).  Fixed with ``timeout=None`` (the stage is bounded by its
    deterministic iteration exits instead) plus ``PYTHONHASHSEED`` pinned
-   by construction at the regen entry point.
+   by construction at the regen entry point.  ``max_iterations=3``
+   replaces the truncation the backstop used to perform, in deterministic
+   units: every instrumented run cut at the very start of iteration 4,
+   and iterations 4+ are provably discarded by the end-of-loop lex
+   restore.
 
-2. **Residual -- UUID-sorted file order.** With the wall clock removed,
+2. **Reach-deciding -- the relief rescue's 10 s sub-search wall clock.**
+   A rescue is a transaction: it rolls back unless every displaced
+   victim re-lands, so the budget those re-lands get decides routed
+   reach, not just runtime.  The flat 10 s budget straddles their 8-12 s
+   natural time on GitHub runners -- the same commit landed 21/21 and
+   20/21 on different runners from line-identical logs.  Fixed with
+   ``route_all_negotiated(deterministic_rescue=True)``, which bounds the
+   sub-searches by the deterministic per-net node-expansion cap.
+
+3. **Residual -- UUID-sorted file order.** With the wall clock removed,
    runs produced byte-identical logs and identical copper *multisets*,
    yet still ~2300 differing artifact lines: ``kicad-cli`` (invoked by
    every ``kct zones fill`` round) re-saves the board with tracks
@@ -45,7 +58,7 @@ else:
   difference and without affecting element order.  Each ``(uuid "...")``
   is replaced with ``(uuid "X")`` before comparison.  Positional identity
   is still required: the *number and location* of uuid-bearing nodes must
-  match exactly -- which, per source 2 above, only holds because
+  match exactly -- which, per source 3 above, only holds because
   stitch/repair copper UUIDs are now deterministic.
 * No timestamps or dates are present in the emitted ``kicad_pcb``
   (verified against the artifact header), so nothing else is masked.

--- a/tests/test_relief_subsearch_budget.py
+++ b/tests/test_relief_subsearch_budget.py
@@ -1,0 +1,70 @@
+"""Unit tests for the relief-rescue sub-search budget selector (Issue #4536).
+
+``Autorouter._relief_rescue`` is a TRANSACTION: it rolls back unless every
+displaced victim re-lands, so the budget those re-land searches get decides
+routed REACH, not just runtime.  The historical flat 10 s wall clock straddles
+the 8-12 s natural re-land time on CI runners, which made board-06's
+``REQUIRED_SIGNAL_REACH`` gate a coin flip on machine speed.  These tests pin
+the selection table for the deterministic replacement.
+
+The method only reads two attributes off ``self``, so it is exercised against a
+lightweight stub rather than a full ``Autorouter`` (which would need a board).
+"""
+
+from __future__ import annotations
+
+from kicad_tools.router.core import (
+    RELIEF_SUBSEARCH_BUDGET_S,
+    RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S,
+    Autorouter,
+)
+
+
+class _BudgetStub:
+    """Minimal stand-in exposing only the two attributes the method reads."""
+
+    def __init__(self, per_net_iterations: int = 0, max_search_iterations: int = 0) -> None:
+        self._per_net_iterations = per_net_iterations
+        self._max_search_iterations = max_search_iterations
+
+
+def _budget(stub: _BudgetStub, per_net_timeout: float | None, deterministic: bool) -> float | None:
+    return Autorouter._relief_subsearch_budget(stub, per_net_timeout, deterministic)
+
+
+class TestReliefSubsearchBudget:
+    def test_default_is_the_historical_wall_clock(self):
+        """No opt-in, no standing cap -> unchanged 10 s behavior."""
+        assert _budget(_BudgetStub(), None, False) == RELIEF_SUBSEARCH_BUDGET_S
+
+    def test_tighter_per_net_timeout_still_binds(self):
+        """A caller-supplied per-net cap below 10 s keeps binding (pre-#4536)."""
+        assert _budget(_BudgetStub(), 4.0, False) == 4.0
+
+    def test_looser_per_net_timeout_does_not_relax_the_default(self):
+        assert _budget(_BudgetStub(), 30.0, False) == RELIEF_SUBSEARCH_BUDGET_S
+
+    def test_opt_in_without_expansion_cap_keeps_the_wall_clock(self):
+        """Degrade to today's behavior, never to an unbounded search."""
+        assert _budget(_BudgetStub(), None, True) == RELIEF_SUBSEARCH_BUDGET_S
+        assert _budget(_BudgetStub(), 4.0, True) == 4.0
+
+    def test_opt_in_with_expansion_cap_hands_over_to_the_node_budget(self):
+        """The node-expansion cap becomes the binding bound; the wall clock
+        left behind is the far-above-natural-runtime backstop, so it cannot
+        decide whether the rescue commits."""
+        stub = _BudgetStub(per_net_iterations=1_000_000, max_search_iterations=12_000_000)
+        assert _budget(stub, None, True) == RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S
+        # A tight per-net wall clock does NOT re-bind under the opt-in: the
+        # whole point is that seconds stop deciding reach.
+        assert _budget(stub, 4.0, True) == RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S
+
+    def test_memory_backstop_alone_also_counts_as_deterministic(self):
+        """``--deterministic-budget`` sets only ``_max_search_iterations``."""
+        stub = _BudgetStub(max_search_iterations=12_000_000)
+        assert _budget(stub, None, True) == RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S
+
+    def test_backstop_is_far_above_the_natural_subsearch_time(self):
+        """Guard the 'non-load-bearing' claim: the backstop must stay an order
+        of magnitude above the measured 8-12 s natural re-land time."""
+        assert RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S >= 10 * RELIEF_SUBSEARCH_BUDGET_S


### PR DESCRIPTION
Closes #4536

## Summary

Board-06 full regen (`generate_design.py --step route --seed 42`) was run-to-run
nondeterministic: two flag-OFF runs of unmodified main differed by 9525 lines,
making the "flag-OFF run must produce a byte-identical committed artifact"
scope-guard convention undecidable for this board. This PR is the
diagnosis-first slice: instrumented multi-run evidence identifying **two**
sources (one dominant, one residual), fixes for both, and a gated determinism
smoke test.

**Generator + library + test + docs only — no board artifact is regenerated or
committed (artifact-first discipline).** The committed routed artifact predates
this fix; the invariant enforced here is regen-vs-regen at the same commit, and
the README documents that regen-vs-committed diffs remain expected until the
artifact is next deliberately regenerated.

## Diagnosis 1 (dominant): wall-clock truncation — 4-run baseline matrix

4 sequential same-host, same-seed, shadow-OFF `--step route` runs against the
same committed unrouted PCB, `PYTHONHASHSEED` deliberately unset, at the
pre-fix code:

| run | negotiated backstop fired | cutoff point | final segs/vias | uuid-normalized sha256 (12) |
|---|---|---|---|---|
| base-1 | YES (363.6 s) | mid-iter-4 reroute, net 0/19 | 1599 / 167 | `553d99102e67` |
| base-2 | YES (367.0 s) | mid-iter-4 reroute, **net 1/19** | 1602 / 167 | `160d67d061b4` |
| base-3 | YES (366.1 s) | mid-iter-4 reroute, net 0/19 | 1599 / 167 | `d2f46e32fa66` |
| base-4 | YES (363.1 s) | mid-iter-4 reroute, net 0/19 | 1599 / 167 | `bd7d7f9f1ef7` |

The `timeout=360.0` wall-clock backstop fired in **every** run — the phase's
natural runtime (363–367 s) straddles the 360 s cutoff, exactly as the Curator
hypothesized (recorded reference phase time 361.5 s). The cutoff lands
mid-iteration-4 at a load-dependent net boundary, and with any finite stage
`timeout` the #3989 remaining-budget per-net wall-clock caps stay active too.
Four runs produced four artifacts with **different copper counts**
(1599–1602 segments).

**Fix:** `timeout=None` for the negotiated stage (raising it was rejected — a
finite backstop near the natural runtime re-introduces the straddle on slower
hosts, and any finite timeout keeps the per-net wall caps active). The stage
stays bounded by its deterministic exits: per-net 1M node-expansion budget, 12M
memory backstop, `max_iterations=10`, best-stall patience 2, #4463
zero-overflow fixed-point. Plus `PYTHONHASHSEED=42` pinned by construction
(one-shot `os.execv` re-exec at the entry point; inherited by the
`zones fill` / `stitch` subprocesses).

## Diagnosis 2 (residual): kicad-cli UUID-sorted file order — post-fix matrix + stage snapshots

With the wall clock removed, 4 more matrix runs produced **byte-identical
routing logs** (time/path-normalized) and **identical copper multisets**
(1544 segments / 181 vias; every segment/via block equal as a multiset, all
non-copper content identical) — yet still 3–4 distinct uuid-normalized hashes,
~2300 differing lines, purely a **permutation of segment/via block order**.

Per-stage file snapshots across two runs localized the entry point:

- step-8 router serialization: **raw byte-identical** across runs (router
  UUIDs already deterministic via the #3272 seeded-UUID toggle);
- zone add, first fill, stitch, repair-round-1 placement: uuid-normalized
  **identical** across runs;
- first post-repair `kct zones fill`: **divergence begins**.

Isolation test: running `kct zones fill` twice on the *same* file is
deterministic (identical uuid-normalized output, reproducing run A's next
stage exactly); running it on run B's byte-equivalent file that differs *only
in UUID values* reproduces run B's divergent order exactly. Mechanism:
`kicad-cli` (which `zones fill` shells out to) re-saves the board with tracks
**ordered by UUID**, and the stitch (`kct stitch`, 5 sites) and board-06
pour-repair (`_generate_uuid`) emitters minted random `uuid.uuid4()` values —
so every refill re-sorted the identical copper differently. (The reordered
population confirms it: 237/238 GND segments and 117/117 GND vias — the
stitch/repair copper — vs. 0 reorders in router-only nets.)

**Fix:**
- `kct stitch` mints content-derived `uuid5` values (`_stitch_uuid` over
  net/layer/geometry) — deterministic run-to-run, unique per element, no
  process-global state needed in the subprocess.
- board-06 `_generate_uuid` mints sequence-derived `uuid5` values (counter
  reset at the top of `route_pcb`) — the repair passes' call sequence is
  deterministic once routing is.
- quantizer doglegs were already `uuid5(parent)` — deterministic once parents
  are.

Remaining random UUIDs: pads/properties (the generator emits them without UUID
fields; kicad-cli mints uuid4s on first re-save). They do not affect element
order — hence the uuid-normalized comparison convention.

## Exonerated suspects (by the same evidence)

- **`per_pair_timeout=120.0`**: all 9 pairs exit `reason=iteration iters=1000`
  at 6.1–8.9 s — the deterministic budget fires ~15x before the wall budget.
- **set/frozenset hash-order feeding A***: post-fix runs with the hash seed
  self-pinned still reordered; the reorder tracked UUID *values*, not hash
  seeding. The pin is kept as documented hygiene, with the comment corrected.
- **`generate_pcb.py` entry pinning**: that script emits the unrouted PCB
  only — no routing, no pin needed.

## Verification (post-fix, both fixes)

Three same-host flag-OFF `--step route --seed 42` regens at the post-fix code,
`PYTHONHASHSEED` unset in the parent env (self-pin exercised):

| run | trajectory | segs / vias | uuid-normalized sha256 (12) |
|---|---|---|---|
| v2fix-1 | **diverged** (see below) | 1607 / 179 | `437ce756b4ca` |
| v2fix-2 | canonical | 1544 / 181 | `a9b130b81b4f` |
| v3fix-1 | canonical | 1544 / 181 | **`a9b130b81b4f`** |

- **v2fix-2 and v3fix-1 are uuid-normalized BYTE-IDENTICAL** (and their
  time-normalized routing logs `diff` clean, 0 lines) — the #4536 acceptance
  invariant (two same-seed regens identical after normalization) holds. Both
  ran under ordinary concurrent host load.
- **v2fix-1** ran while two full parallel pytest suites (`-n 6`/`-n auto`) and
  a full mypy pass hammered the same host (load-average ~90) and diverged *in
  the routing phase*: one stagnation-recovery reroute flipped from success to
  failure (`restored 5 / rerouted 6/11` vs the canonical `restored 4 / 7/11`),
  producing different valid copper (all gates PASS). Five of six total
  post-wall-clock-fix runs share the single canonical trajectory
  (time-normalized logs byte-identical). This is a resource-exhaustion
  sensitivity (likely `MemoryError` absorbed by a broad `except Exception` in
  the reroute path), a different problem class from this issue's
  deterministic-logic scope — **filed as #4724** with the full evidence, and
  documented as a "quiet host" proviso in the README and the gated test.

## Regression guard + docs

- `tests/test_board06_determinism.py` — gated behind
  `KCT_BOARD06_DETERMINISM=1` (two ~12-min regens can never be a default-run
  unit test). Asserts count-identity, then byte-identity of uuid-normalized
  artifacts. Complements `tests/router/test_board06_determinism.py` (#3144,
  DRC-count identity).
- `boards/06-diffpair-test/README.md` — "Measuring Changes" rewritten with the
  two-source root cause, the gated test invocation, and the restored
  (uuid-normalized) byte-identity scope-guard convention. Cross-host
  determinism (#4561) and shadow-ON determinism remain out of scope.
- `CHANGELOG.md` — Fixed entry.

## Checks

- `ruff check` + `ruff format --check` clean on all changed files.
- 296 stitch-suite tests + the new (gated-off) determinism test module pass
  post-rebase; the fast ungated CLI-contract tests in
  `tests/router/test_board06_determinism.py` pass.
- `kct build-native --check`: C++ backend available (all matrix runs used it).
- mypy baseline gate: **one pre-existing mismatch on an untouched file** —
  `src/kicad_tools/recovery/strategy.py` has a baseline `assignment` entry
  whose message text (`def contains_point(self, _x: float, _y: float)`) no
  longer matches the locally emitted message (`def (_x: float, _y: float)`),
  so the local gate counts it as "new". My diff does not touch that file or
  anything it imports; this is baseline message-format drift relative to the
  freshly rebased main, left for CI to adjudicate in its own environment.

## Follow-up

- #4724 — load-correlated stagnation-recovery divergence under extreme host
  load (the v2fix-1 evidence above), a resource-exhaustion class outside this
  issue's deterministic-logic scope. The unconditional wall-clock budget in
  `_post_negotiation_sweep` (live even with `timeout=None`) is catalogued
  there too.
