### PR TITLE
feat(cli): add --format json to the grouped-family subcommands (part of #4674, batch 1: mfr/spec/placement/zones/benchmark)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`--format json` on the grouped-family subcommands (first #4674 batch:
+  24 surfaces)** — the mechanical sweep executing #4543's canonical
+  machine-output idiom, batch 1. `kct mfr
+  list/info/rules/compare/export-dru/apply-rules/validate`, `kct spec
+  init/validate/status/decide/check`, `kct placement
+  fix/nudge/snap/align/distribute`, `kct zones add/batch/fill/hv-keepout`,
+  and `kct benchmark run/compare` all accept `--format {text,json}`
+  (threaded outer parser → shim → inner parser via the
+  `format_options.py` helpers), and `kct benchmark report` gains a `json`
+  choice — closing the `format-nojson` audit bucket. JSON mode emits one
+  deterministic document on stdout (sorted keys; progress/chatter
+  suppressed or on stderr; errors become `{"error": ...}` documents with
+  the same exit codes); text output is byte-identical to before. The dead
+  inner-only `mfr rules --json` surface (unreachable through `kct`;
+  documented in `docs/reference/machine-output.md`) is retired in favour
+  of the wired `--format json`. Audit: prose-only 72 → 49; `--format`
+  with `json` 124 → 148. New regression guards in
+  `tests/test_format_json_sweep.py`; remaining backlog (16 `sch` mutating
+  commands, `stitch`, long-tail singles) tracked on #4674.
+
 - **`kct check` now detects dangling copper natively: `track_dangling` +
   `via_dangling`** (part of #4680, the #4612 gap shape for the remaining
   rule classes) — a new `DanglingCopperRule`

--- a/docs/reference/machine-output.md
+++ b/docs/reference/machine-output.md
@@ -52,13 +52,20 @@ below is issue **#4674** and should build on these helpers.
 Measured by programmatic introspection of the real argparse tree
 (`create_parser()`, recursive walk of `_SubParsersAction` leaves) — not grep:
 
-| Idiom (outer `kct` parser) | Before #4543 | After #4543 |
-|---|---|---|
-| `--format` with a `json` choice | 124 | 124 |
-| Both `--format json` and legacy `--json` alias | 0 | 2 (`placement refine`, `calibrate`) |
-| `--json` boolean only | 2 | **0** |
-| `--format` without a `json` choice | 1 (`benchmark report`, `text,markdown`) | 1 |
-| Neither (prose-only) | 72 | 72 (backlog for #4674, below) |
+| Idiom (outer `kct` parser) | Before #4543 | After #4543 | After #4674 batch 1 |
+|---|---|---|---|
+| `--format` with a `json` choice | 124 | 124 | 148 |
+| Both `--format json` and legacy `--json` alias | 0 | 2 (`placement refine`, `calibrate`) | 2 |
+| `--json` boolean only | 2 | **0** | 0 |
+| `--format` without a `json` choice | 1 (`benchmark report`, `text,markdown`) | 1 | **0** |
+| Neither (prose-only) | 72 | 72 (backlog for #4674, below) | 49 |
+
+The first #4674 batch swept the grouped-subcommand families -- `mfr` (7),
+`spec` (5), `placement fix/nudge/snap/align/distribute` (5), `zones
+add/batch/fill/hv-keepout` (4), `benchmark run/compare` (2) -- and added the
+`json` choice to `benchmark report`, closing the `format-nojson` bucket.
+The remaining 49 prose-only leaves (the 16 `sch` mutating commands, `stitch`,
+and the long tail of single commands) stay on the #4674 backlog below.
 
 Issue #4543 closed the `--json`-only bucket by adding `--format {text,json}`
 alongside the existing `--json` on both commands (outer parser, forwarding
@@ -83,10 +90,12 @@ reachable through `kct`:
 
 - `sch_symbol_info.py` `--json` — inner only; the user-facing `kct sch info`
   contract is `--format {text,json}`, translated by `commands/schematic.py`.
-- `mfr.py` `mfr rules --json` — **dead surface**: unreachable through `kct`
-  because the shim rebuilds `sub_argv` from outer args and the outer
-  `kct mfr rules` has no machine-output flag. The #4674 sweep should wire
-  the outer `--format` and retire this dead flag path.
+- `mfr.py` `mfr rules --json` — **retired** (first #4674 batch): the flag was
+  a dead surface, unreachable through `kct` because the shim rebuilds
+  `sub_argv` from outer args and the outer `kct mfr rules` had no
+  machine-output flag. `kct mfr rules --format json` is now wired end-to-end
+  (outer parser → shim → inner parser) and the inner `--json` boolean was
+  removed rather than aliased — it never shipped on any reachable surface.
 - `route_cmd.py` inner `--format` — deliberately allowlisted as inner-only
   (`tests/test_cli_parser_drift.py`, `INNER_ONLY_ALLOWLIST`), so `kct route`
   is prose-only at the user-facing surface today. See "Deferred" below.
@@ -111,27 +120,33 @@ is the separate mechanical sweep **#4674**.
 |---|---|
 | `route` | Inner `route_cmd.py` already has `--format`, but it is intentionally allowlisted as inner-only. Promoting it to the outer parser requires removing the `INNER_ONLY_ALLOWLIST` entry and adding shim forwarding under the route drift guard — owned by the route workstream, not the mechanical sweep. |
 
-### Sweep backlog for #4674 — should gain `--format {text,json}` (67)
+### Sweep backlog for #4674 — should gain `--format {text,json}`
 
 Read-only/reporting commands should emit their report as JSON; mutating
 commands should emit a JSON change-summary (precedent: `kct sch tidy`,
 `kct sch cleanup-wires`, `kct pcb sync-netlist` all do).
 
-- `benchmark compare`, `benchmark run`
+**Done (first #4674 batch, 24 surfaces):** `mfr list/info/rules/compare/`
+`export-dru/apply-rules/validate`, `spec init/validate/status/decide/check`,
+`placement fix/nudge/snap/align/distribute`, `zones add/batch/fill/`
+`hv-keepout`, `benchmark run/compare`, plus the `json` choice on
+`benchmark report` (the former `format-nojson` holdout).
+`tests/test_format_json_sweep.py` guards these surfaces.
+
+**Remaining actionable (44)** — the audit's `prose-only` bucket reads 49
+because it also counts the 4 exempt commands and the deferred `route`
+(sections above):
+
 - `board-metrics`, `build`, `config`, `create-pcb`, `creepage-export-rules`
 - `datasheet cache`, `datasheet convert`, `datasheet download`
 - `ipc connect`, `ipc push-routes`, `ipc status`
 - `lib create-footprint-lib`, `lib create-symbol-lib`, `lib generate-footprint`
 - `mcp setup`
-- `mfr apply-rules`, `mfr compare`, `mfr export-dru`, `mfr info`, `mfr list`,
-  `mfr rules`, `mfr validate`
 - `optimize-placement`, `optimize-traces`
 - `panel`
 - `parts cache`, `parts sync-catalog`
 - `pcb export-dsn`, `pcb import-ses`
 - `pipeline`
-- `placement align`, `placement distribute`, `placement fix`,
-  `placement nudge`, `placement snap`
 - `reason`, `report generate`, `route-auto`
 - `sch add-bypass-cap`, `sch add-component`, `sch add-junction`,
   `sch add-label`, `sch add-no-connect`, `sch add-pull-resistor`,
@@ -139,12 +154,9 @@ commands should emit a JSON change-summary (precedent: `kct sch tidy`,
   `sch replace`, `sch set-footprint`, `sch set-label-direction`,
   `sch set-reference`, `sch set-symbol-property`, `sch set-value`
 - `screenshot`
-- `spec check`, `spec decide`, `spec init`, `spec status`, `spec validate`
-- `stitch`
-- `zones add`, `zones batch`, `zones fill`, `zones hv-keepout`
+- `stitch` (single command, but its 6k-line inner module has a bespoke
+  multi-phase report — batch it alone)
 
-Additional sweep item outside the 72: `benchmark report` has
-`--format {text,markdown}` — add a `json` choice (no new flag needed).
 
 ## Interop note (survey idea 7)
 

--- a/src/kicad_tools/cli/commands/benchmark.py
+++ b/src/kicad_tools/cli/commands/benchmark.py
@@ -4,6 +4,22 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from ..format_options import emit_json
+
+
+def _wants_json(args) -> bool:
+    """True when the canonical ``--format json`` spelling was requested."""
+    return getattr(args, "format", "text") == "json"
+
+
+def _fail(args, message: str) -> int:
+    """Report an error and return 1 (single JSON document in JSON mode)."""
+    if _wants_json(args):
+        emit_json({"error": message})
+    else:
+        print(message)
+    return 1
+
 
 def run_benchmark_command(args) -> int:
     """Handle benchmark command and subcommands."""
@@ -44,20 +60,23 @@ def _run_benchmark(args) -> int:
     if strategies:
         strategy_list = [s.strip() for s in strategies.split(",")]
 
+    json_mode = _wants_json(args)
+
     # Parse difficulty filter
     difficulty_filter = None
     if difficulty:
         try:
             difficulty_filter = Difficulty(difficulty)
         except ValueError:
-            print(f"Unknown difficulty: {difficulty}")
-            print("Valid options: easy, medium, hard")
-            return 1
+            return _fail(
+                args, f"Unknown difficulty: {difficulty} (valid options: easy, medium, hard)"
+            )
 
-    runner = BenchmarkRunner(base_dir=Path.cwd(), verbose=verbose)
+    runner = BenchmarkRunner(base_dir=Path.cwd(), verbose=verbose and not json_mode)
 
-    print("Running routing benchmarks...")
-    print()
+    if not json_mode:
+        print("Running routing benchmarks...")
+        print()
 
     results = runner.run_all(
         cases=case_names,
@@ -66,15 +85,28 @@ def _run_benchmark(args) -> int:
     )
 
     if not results:
-        print("No benchmarks were run.")
-        return 1
+        return _fail(args, "No benchmarks were run.")
 
-    runner.print_summary()
+    if not json_mode:
+        runner.print_summary()
 
     # Save results if requested
+    saved_to = None
     if save or output:
         output_path = runner.save_results(path=output)
-        print(f"\nResults saved to: {output_path}")
+        saved_to = str(output_path)
+        if not json_mode:
+            print(f"\nResults saved to: {output_path}")
+
+    if json_mode:
+        emit_json(
+            {
+                "results": [
+                    r.to_dict() for r in sorted(results, key=lambda r: (r.case_name, r.strategy))
+                ],
+                "saved_to": saved_to,
+            }
+        )
 
     return 0
 
@@ -88,27 +120,29 @@ def _compare_benchmark(args) -> int:
         load_baseline,
     )
 
+    json_mode = _wants_json(args)
+
     baseline_path = getattr(args, "baseline", None)
     verbose = getattr(args, "verbose", False)
     fail_on_warning = getattr(args, "fail_on_warning", False)
 
     if not baseline_path:
-        print("Error: --baseline is required")
-        return 1
+        return _fail(args, "Error: --baseline is required")
 
     baseline_path = Path(baseline_path)
     if not baseline_path.exists():
-        print(f"Error: Baseline file not found: {baseline_path}")
-        return 1
+        return _fail(args, f"Error: Baseline file not found: {baseline_path}")
 
     # Load baseline
-    print(f"Loading baseline from: {baseline_path}")
+    if not json_mode:
+        print(f"Loading baseline from: {baseline_path}")
     baseline = load_baseline(baseline_path)
-    print(f"  Found {len(baseline)} baseline results")
+    if not json_mode:
+        print(f"  Found {len(baseline)} baseline results")
 
-    # Run current benchmarks
-    print("\nRunning current benchmarks...")
-    runner = BenchmarkRunner(base_dir=Path.cwd(), verbose=verbose)
+        # Run current benchmarks
+        print("\nRunning current benchmarks...")
+    runner = BenchmarkRunner(base_dir=Path.cwd(), verbose=verbose and not json_mode)
 
     # Get case names from baseline to run same tests
     baseline_cases = list({r.case_name for r in baseline})
@@ -117,20 +151,44 @@ def _compare_benchmark(args) -> int:
     results = runner.run_all(cases=baseline_cases, strategies=baseline_strategies)
 
     if not results:
-        print("No benchmarks were run.")
-        return 1
+        return _fail(args, "No benchmarks were run.")
 
     # Check for regressions
-    print("\nChecking for regressions...")
+    if not json_mode:
+        print("\nChecking for regressions...")
     regressions = check_regression(results, baseline)
-
-    report = format_regression_report(regressions)
-    print()
-    print(report)
 
     # Determine exit code
     errors = [r for r in regressions if r.severity == "error"]
     warnings = [r for r in regressions if r.severity == "warning"]
+
+    if json_mode:
+        emit_json(
+            {
+                "baseline": str(baseline_path),
+                "baseline_count": len(baseline),
+                "regressions": [
+                    {
+                        "case_name": r.case_name,
+                        "strategy": r.strategy,
+                        "metric": r.metric,
+                        "baseline_value": r.baseline_value,
+                        "current_value": r.current_value,
+                        "threshold": r.threshold,
+                        "severity": r.severity,
+                        "change_percent": r.change_percent,
+                    }
+                    for r in sorted(regressions, key=lambda r: (r.case_name, r.strategy, r.metric))
+                ],
+                "errors": len(errors),
+                "warnings": len(warnings),
+                "ok": not errors and not (fail_on_warning and warnings),
+            }
+        )
+    else:
+        report = format_regression_report(regressions)
+        print()
+        print(report)
 
     if errors:
         return 1
@@ -148,17 +206,20 @@ def _generate_report(args) -> int:
     format_type = getattr(args, "format", "text")
 
     if not input_path:
-        print("Error: Input file is required")
-        return 1
+        return _fail(args, "Error: Input file is required")
 
     input_path = Path(input_path)
     if not input_path.exists():
-        print(f"Error: File not found: {input_path}")
-        return 1
+        return _fail(args, f"Error: File not found: {input_path}")
 
     results = load_baseline(input_path)
 
-    if format_type == "markdown":
+    if format_type == "json":
+        by_case: dict[str, list[dict]] = {}
+        for r in sorted(results, key=lambda r: (r.case_name, r.strategy)):
+            by_case.setdefault(r.case_name, []).append(r.to_dict())
+        emit_json({"input": str(input_path), "cases": by_case})
+    elif format_type == "markdown":
         _print_markdown_report(results)
     else:
         _print_text_report(results)

--- a/src/kicad_tools/cli/commands/manufacturer.py
+++ b/src/kicad_tools/cli/commands/manufacturer.py
@@ -6,6 +6,12 @@ from pathlib import Path
 __all__ = ["run_mfr_command"]
 
 
+def _forward_format(args, sub_argv: list) -> None:
+    """Forward the outer ``--format`` choice to the inner ``mfr`` parser."""
+    if getattr(args, "format", "text") != "text":
+        sub_argv.extend(["--format", args.format])
+
+
 def run_mfr_command(args) -> int:
     """Handle manufacturer subcommands."""
     if not args.mfr_command:
@@ -16,16 +22,21 @@ def run_mfr_command(args) -> int:
     from ..mfr import main as mfr_main
 
     if args.mfr_command == "list":
-        return mfr_main(["list"]) or 0
+        sub_argv = ["list"]
+        _forward_format(args, sub_argv)
+        return mfr_main(sub_argv) or 0
 
     elif args.mfr_command == "info":
-        return mfr_main(["info", args.manufacturer]) or 0
+        sub_argv = ["info", args.manufacturer]
+        _forward_format(args, sub_argv)
+        return mfr_main(sub_argv) or 0
 
     elif args.mfr_command == "rules":
         sub_argv = ["rules", args.manufacturer]
         # Always pass layers and copper to ensure inner command uses correct values
         sub_argv.extend(["--layers", str(args.layers)])
         sub_argv.extend(["--copper", str(args.copper)])
+        _forward_format(args, sub_argv)
         return mfr_main(sub_argv) or 0
 
     elif args.mfr_command == "compare":
@@ -33,6 +44,7 @@ def run_mfr_command(args) -> int:
         # Always pass layers and copper to ensure inner command uses correct values
         sub_argv.extend(["--layers", str(args.layers)])
         sub_argv.extend(["--copper", str(args.copper)])
+        _forward_format(args, sub_argv)
         return mfr_main(sub_argv) or 0
 
     elif args.mfr_command == "apply-rules":
@@ -45,6 +57,7 @@ def run_mfr_command(args) -> int:
             sub_argv.extend(["--output", args.output])
         if args.dry_run:
             sub_argv.append("--dry-run")
+        _forward_format(args, sub_argv)
         return mfr_main(sub_argv) or 0
 
     elif args.mfr_command == "validate":
@@ -53,6 +66,7 @@ def run_mfr_command(args) -> int:
             sub_argv.extend(["--layers", str(args.layers)])
         if args.copper != 1.0:
             sub_argv.extend(["--copper", str(args.copper)])
+        _forward_format(args, sub_argv)
         return mfr_main(sub_argv) or 0
 
     elif args.mfr_command == "export-dru":
@@ -63,6 +77,7 @@ def run_mfr_command(args) -> int:
             sub_argv.extend(["--copper", str(args.copper)])
         if args.output:
             sub_argv.extend(["--output", args.output])
+        _forward_format(args, sub_argv)
         return mfr_main(sub_argv) or 0
 
     elif args.mfr_command == "import-dru":

--- a/src/kicad_tools/cli/commands/placement.py
+++ b/src/kicad_tools/cli/commands/placement.py
@@ -53,6 +53,8 @@ def run_placement_command(args) -> int:
         # Use command-level quiet or global quiet
         if getattr(args, "quiet", False) or getattr(args, "global_quiet", False):
             sub_argv.append("--quiet")
+        if getattr(args, "format", "text") != "text":
+            sub_argv.extend(["--format", args.format])
         return placement_main(sub_argv) or 0
 
     elif args.placement_command == "nudge":
@@ -69,6 +71,8 @@ def run_placement_command(args) -> int:
             sub_argv.append("--verbose")
         if getattr(args, "quiet", False) or getattr(args, "global_quiet", False):
             sub_argv.append("--quiet")
+        if getattr(args, "format", "text") != "text":
+            sub_argv.extend(["--format", args.format])
         return placement_main(sub_argv) or 0
 
     elif args.placement_command == "optimize":
@@ -132,6 +136,8 @@ def run_placement_command(args) -> int:
             sub_argv.append("--verbose")
         if getattr(args, "quiet", False) or getattr(args, "global_quiet", False):
             sub_argv.append("--quiet")
+        if getattr(args, "format", "text") != "text":
+            sub_argv.extend(["--format", args.format])
         return placement_main(sub_argv) or 0
 
     elif args.placement_command == "align":
@@ -151,6 +157,8 @@ def run_placement_command(args) -> int:
             sub_argv.append("--verbose")
         if getattr(args, "quiet", False) or getattr(args, "global_quiet", False):
             sub_argv.append("--quiet")
+        if getattr(args, "format", "text") != "text":
+            sub_argv.extend(["--format", args.format])
         return placement_main(sub_argv) or 0
 
     elif args.placement_command == "distribute":
@@ -168,6 +176,8 @@ def run_placement_command(args) -> int:
             sub_argv.append("--verbose")
         if getattr(args, "quiet", False) or getattr(args, "global_quiet", False):
             sub_argv.append("--quiet")
+        if getattr(args, "format", "text") != "text":
+            sub_argv.extend(["--format", args.format])
         return placement_main(sub_argv) or 0
 
     elif args.placement_command == "suggest":

--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -40,6 +40,8 @@ def run_zones_command(args) -> int:
         # Use global quiet flag
         if getattr(args, "global_quiet", False):
             sub_argv.append("--quiet")
+        if getattr(args, "format", "text") != "text":
+            sub_argv.extend(["--format", args.format])
         return zones_main(sub_argv) or 0
 
     elif args.zones_command == "list":
@@ -62,6 +64,8 @@ def run_zones_command(args) -> int:
         # Use global quiet flag
         if getattr(args, "global_quiet", False):
             sub_argv.append("--quiet")
+        if getattr(args, "format", "text") != "text":
+            sub_argv.extend(["--format", args.format])
         return zones_main(sub_argv) or 0
 
     elif args.zones_command == "hv-keepout":
@@ -82,6 +86,8 @@ def run_zones_command(args) -> int:
             sub_argv.append("--dry-run")
         if getattr(args, "global_quiet", False):
             sub_argv.append("--quiet")
+        if getattr(args, "format", "text") != "text":
+            sub_argv.extend(["--format", args.format])
         return zones_main(sub_argv) or 0
 
     elif args.zones_command == "fill":
@@ -97,6 +103,8 @@ def run_zones_command(args) -> int:
         # Use global quiet flag
         if getattr(args, "global_quiet", False):
             sub_argv.append("--quiet")
+        if getattr(args, "format", "text") != "text":
+            sub_argv.extend(["--format", args.format])
         return zones_main(sub_argv) or 0
 
     return 1

--- a/src/kicad_tools/cli/commands/spec.py
+++ b/src/kicad_tools/cli/commands/spec.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+from ..format_options import emit_json
+
 __all__ = ["run_spec_command"]
+
+
+def _wants_json(args) -> bool:
+    """True when the canonical ``--format json`` spelling was requested."""
+    return getattr(args, "spec_format", "text") == "json"
 
 
 def run_spec_command(args) -> int:
@@ -49,8 +56,13 @@ def _run_spec_init(args) -> int:
         # Default to project.kct in current directory
         output_path = Path("project.kct")
 
+    json_mode = _wants_json(args)
+
     # Check if file exists
     if output_path.exists() and not getattr(args, "spec_force", False):
+        if json_mode:
+            emit_json({"error": f"File already exists: {output_path} (use --force to overwrite)"})
+            return 1
         console.print(f"[red]Error:[/red] File already exists: {output_path}")
         console.print("Use --force to overwrite")
         return 1
@@ -69,6 +81,16 @@ def _run_spec_init(args) -> int:
         # Write file
         output_path.write_text(content, encoding="utf-8")
 
+        if json_mode:
+            emit_json(
+                {
+                    "created": str(output_path),
+                    "name": name,
+                    "template": template,
+                }
+            )
+            return 0
+
         console.print(f"[green]Created:[/green] {output_path}")
         console.print(f"Template: {template}")
         console.print("\nNext steps:")
@@ -79,9 +101,15 @@ def _run_spec_init(args) -> int:
         return 0
 
     except ValueError as e:
+        if json_mode:
+            emit_json({"error": str(e)})
+            return 1
         console.print(f"[red]Error:[/red] {e}")
         return 1
     except OSError as e:
+        if json_mode:
+            emit_json({"error": f"Error writing file: {e}"})
+            return 1
         console.print(f"[red]Error writing file:[/red] {e}")
         return 1
 
@@ -96,6 +124,17 @@ def _run_spec_validate(args) -> int:
     spec_file = Path(args.spec_file)
 
     is_valid, errors, warnings = validate_spec_detailed(spec_file)
+
+    if _wants_json(args):
+        emit_json(
+            {
+                "file": str(spec_file),
+                "valid": is_valid,
+                "errors": list(errors),
+                "warnings": list(warnings),
+            }
+        )
+        return 0 if is_valid else 1
 
     if is_valid:
         console.print(f"[green]Valid:[/green] {spec_file}")
@@ -134,8 +173,15 @@ def _run_spec_status(args) -> int:
     try:
         spec = load_spec(spec_file)
     except Exception as e:
+        if _wants_json(args):
+            emit_json({"error": f"Error loading spec: {e}"})
+            return 1
         console.print(f"[red]Error loading spec:[/red] {e}")
         return 1
+
+    if _wants_json(args):
+        emit_json(_status_payload(spec_file, spec))
+        return 0
 
     # Project info
     console.print(
@@ -234,6 +280,64 @@ def _run_spec_status(args) -> int:
     return 0
 
 
+def _status_payload(spec_file: Path, spec) -> dict:
+    """Machine rendering of ``kct spec status`` (mirrors the prose report)."""
+
+    def _enum_value(value):
+        return value.value if hasattr(value, "value") else value
+
+    payload: dict = {
+        "file": str(spec_file),
+        "project": {
+            "name": spec.project.name,
+            "revision": spec.project.revision,
+        },
+        "summary": spec.intent.summary if spec.intent else None,
+        "phase": None,
+        "completion_percent": None,
+        "phases": {},
+        "blockers": [],
+        "decisions": [],
+        "validation": None,
+    }
+
+    if spec.progress:
+        payload["phase"] = _enum_value(spec.progress.phase)
+        payload["completion_percent"] = spec.get_completion_percentage()
+        for phase_key, phase in (spec.progress.phases or {}).items():
+            checklist = phase.checklist or []
+            done = sum(1 for item in checklist if item.startswith(("[x]", "[X]")))
+            payload["phases"][phase_key] = {
+                "status": _enum_value(phase.status),
+                "checklist_done": done,
+                "checklist_total": len(checklist),
+            }
+        payload["blockers"] = list(spec.progress.blockers or [])
+
+    if spec.decisions:
+        payload["decisions"] = [
+            {
+                "date": str(decision.date),
+                "topic": decision.topic,
+                "choice": decision.choice,
+            }
+            for decision in spec.decisions
+        ]
+
+    if spec.validation and spec.validation.last_run:
+        validation: dict = {"last_run": str(spec.validation.last_run), "schematic": {}}
+        if spec.validation.schematic:
+            for check, result in spec.validation.schematic.items():
+                validation["schematic"][check] = {
+                    "status": result.status,
+                    "errors": result.errors,
+                    "warnings": result.warnings,
+                }
+        payload["validation"] = validation
+
+    return payload
+
+
 def _run_spec_decide(args) -> int:
     """Record a design decision in the .kct specification file."""
     from datetime import date
@@ -245,10 +349,14 @@ def _run_spec_decide(args) -> int:
 
     console = Console()
     spec_file = Path(args.spec_file)
+    json_mode = _wants_json(args)
 
     try:
         spec = load_spec(spec_file)
     except Exception as e:
+        if json_mode:
+            emit_json({"error": f"Error loading spec: {e}"})
+            return 1
         console.print(f"[red]Error loading spec:[/red] {e}")
         return 1
 
@@ -274,11 +382,28 @@ def _run_spec_decide(args) -> int:
     # is left untouched.
     try:
         append_decision(spec_file, decision)
+        if json_mode:
+            emit_json(
+                {
+                    "file": str(spec_file),
+                    "recorded": True,
+                    "date": str(decision.date),
+                    "phase": phase.value if hasattr(phase, "value") else phase,
+                    "topic": decision.topic,
+                    "choice": decision.choice,
+                    "rationale": decision.rationale,
+                    "alternatives": decision.alternatives,
+                }
+            )
+            return 0
         console.print(f"[green]Decision recorded:[/green] {decision.topic}")
         console.print(f"  Choice: {decision.choice}")
         console.print(f"  Rationale: {decision.rationale}")
         return 0
     except Exception as e:
+        if json_mode:
+            emit_json({"error": f"Error saving spec: {e}"})
+            return 1
         console.print(f"[red]Error saving spec:[/red] {e}")
         return 1
 
@@ -291,15 +416,22 @@ def _run_spec_check(args) -> int:
 
     console = Console()
     spec_file = Path(args.spec_file)
+    json_mode = _wants_json(args)
     item_path = args.check_item  # Format: "phase.item text" or "item text"
 
     try:
         spec = load_spec(spec_file)
     except Exception as e:
+        if json_mode:
+            emit_json({"error": f"Error loading spec: {e}"})
+            return 1
         console.print(f"[red]Error loading spec:[/red] {e}")
         return 1
 
     if not spec.progress or not spec.progress.phases:
+        if json_mode:
+            emit_json({"error": "No progress phases defined in spec"})
+            return 1
         console.print("[red]Error:[/red] No progress phases defined in spec")
         return 1
 
@@ -320,17 +452,29 @@ def _run_spec_check(args) -> int:
 
     # Find phase
     if phase_name not in spec.progress.phases:
+        if json_mode:
+            emit_json(
+                {
+                    "error": f"Phase not found: {phase_name}",
+                    "available_phases": list(spec.progress.phases.keys()),
+                }
+            )
+            return 1
         console.print(f"[red]Error:[/red] Phase not found: {phase_name}")
         console.print(f"Available phases: {', '.join(spec.progress.phases.keys())}")
         return 1
 
     phase = spec.progress.phases[phase_name]
     if not phase.checklist:
+        if json_mode:
+            emit_json({"error": f"No checklist in phase: {phase_name}"})
+            return 1
         console.print(f"[red]Error:[/red] No checklist in phase: {phase_name}")
         return 1
 
     # Find and update item
     found = False
+    checked_item = None
     for i, item in enumerate(phase.checklist):
         # Strip checkbox prefix for comparison
         item_content = item.lstrip("[ ]xX").strip()
@@ -338,10 +482,20 @@ def _run_spec_check(args) -> int:
             # Mark as complete
             phase.checklist[i] = f"[x] {item_content}"
             found = True
-            console.print(f"[green]Checked:[/green] {item_content}")
+            checked_item = item_content
+            if not json_mode:
+                console.print(f"[green]Checked:[/green] {item_content}")
             break
 
     if not found:
+        if json_mode:
+            emit_json(
+                {
+                    "error": f"Item not found: {item_text}",
+                    "available_items": list(phase.checklist),
+                }
+            )
+            return 1
         console.print(f"[red]Error:[/red] Item not found: {item_text}")
         console.print("Available items:")
         for item in phase.checklist:
@@ -351,7 +505,18 @@ def _run_spec_check(args) -> int:
     # Save
     try:
         save_spec(spec, spec_file)
+        if json_mode:
+            emit_json(
+                {
+                    "file": str(spec_file),
+                    "phase": phase_name,
+                    "checked": checked_item,
+                }
+            )
         return 0
     except Exception as e:
+        if json_mode:
+            emit_json({"error": f"Error saving spec: {e}"})
+            return 1
         console.print(f"[red]Error saving spec:[/red] {e}")
         return 1

--- a/src/kicad_tools/cli/format_options.py
+++ b/src/kicad_tools/cli/format_options.py
@@ -26,6 +26,8 @@ conflict, because ``--json`` only ever means ``--format json``.
 from __future__ import annotations
 
 import argparse
+import json
+from typing import Any
 
 FORMAT_TEXT = "text"
 FORMAT_JSON = "json"
@@ -78,6 +80,17 @@ def wants_json(
     if getattr(args, json_attr, False):
         return True
     return getattr(args, format_attr, None) == FORMAT_JSON
+
+
+def emit_json(payload: Any) -> None:
+    """Print *payload* as the single JSON document on stdout.
+
+    The machine-output contract (docs/reference/machine-output.md) is one
+    deterministic JSON document per invocation: keys are sorted, and any
+    non-serializable value (e.g. ``Path``) falls back to ``str``.  Human
+    chatter must go to stderr or be suppressed when JSON mode is active.
+    """
+    print(json.dumps(payload, indent=2, sort_keys=True, default=str))
 
 
 def normalize_format_alias(

--- a/src/kicad_tools/cli/mfr.py
+++ b/src/kicad_tools/cli/mfr.py
@@ -18,10 +18,10 @@ Usage:
 """
 
 import argparse
-import json
 import sys
 from pathlib import Path
 
+from kicad_tools.cli.format_options import add_format_flag, emit_json
 from kicad_tools.manufacturers import (
     compare_design_rules,
     find_compatible_manufacturers,
@@ -31,8 +31,67 @@ from kicad_tools.manufacturers import (
 from kicad_tools.units import get_current_formatter
 
 
+def _wants_json(args) -> bool:
+    """True when the canonical ``--format json`` spelling was requested."""
+    return getattr(args, "format", "text") == "json"
+
+
+def _fail(args, message: str, *, stderr: bool = False) -> None:
+    """Report an error and exit 1.
+
+    ``message`` is the full human-readable line (printed verbatim in text
+    mode, preserving historical output); in JSON mode it becomes the
+    ``error`` field of the single JSON document on stdout.
+    """
+    if _wants_json(args):
+        emit_json({"error": message})
+    else:
+        print(message, file=sys.stderr if stderr else sys.stdout)
+    sys.exit(1)
+
+
+def _profile_payload(profile) -> dict:
+    """Full machine rendering of a manufacturer profile (mirrors cmd_info)."""
+    payload: dict = profile.to_dict()
+    if profile.assembly:
+        payload["assembly"] = {
+            "min_component_pitch_mm": profile.assembly.min_component_pitch_mm,
+            "min_bga_pitch_mm": profile.assembly.min_bga_pitch_mm,
+            "supports_double_sided": profile.assembly.supports_double_sided,
+        }
+    else:
+        payload["assembly"] = None
+    if profile.parts_library:
+        lib = profile.parts_library
+        payload["parts_library"] = {
+            "name": lib.name,
+            "catalog_url": lib.catalog_url,
+            "tiers": lib.tiers,
+        }
+    else:
+        payload["parts_library"] = None
+    return payload
+
+
 def cmd_list(args):
     """List available manufacturers."""
+    if _wants_json(args):
+        emit_json(
+            {
+                "manufacturers": [
+                    {
+                        "id": profile.id,
+                        "name": profile.name,
+                        "supports_assembly": profile.supports_assembly(),
+                        "parts_library": (
+                            profile.parts_library.name if profile.parts_library else None
+                        ),
+                    }
+                    for profile in sorted(list_manufacturers(), key=lambda p: p.id)
+                ]
+            }
+        )
+        return
     print(f"\n{'=' * 60}")
     print("AVAILABLE MANUFACTURERS")
     print(f"{'=' * 60}\n")
@@ -55,8 +114,11 @@ def cmd_info(args):
     try:
         profile = get_profile(args.manufacturer)
     except ValueError as e:
-        print(f"Error: {e}")
-        sys.exit(1)
+        _fail(args, f"Error: {e}")
+
+    if _wants_json(args):
+        emit_json(_profile_payload(profile))
+        return
 
     print(f"\n{'=' * 60}")
     print(f"{profile.name.upper()}")
@@ -102,10 +164,21 @@ def cmd_rules(args):
     try:
         profile = get_profile(args.manufacturer)
     except ValueError as e:
-        print(f"Error: {e}")
-        sys.exit(1)
+        _fail(args, f"Error: {e}")
 
     rules = profile.get_design_rules(args.layers, args.copper)
+
+    if _wants_json(args):
+        emit_json(
+            {
+                "manufacturer": profile.id,
+                "layers": args.layers,
+                "copper_oz": args.copper,
+                "rules": rules.to_dict(),
+            }
+        )
+        return
+
     fmt = get_current_formatter()
 
     print(f"\n{'=' * 60}")
@@ -143,11 +216,6 @@ def cmd_rules(args):
     if rules.inner_copper_oz > 0:
         print(f"  Inner copper:       {rules.inner_copper_oz} oz")
 
-    if args.json:
-        print(f"\n{'─' * 60}")
-        print("JSON:")
-        print(json.dumps(rules.to_dict(), indent=2))
-
     print(f"\n{'=' * 60}")
 
 
@@ -157,6 +225,24 @@ def cmd_compare(args):
         layers=args.layers,
         copper_oz=args.copper,
     )
+
+    if _wants_json(args):
+        manufacturers = {}
+        for mfr in sorted(rules_by_mfr):
+            profile = get_profile(mfr)
+            manufacturers[mfr] = {
+                "rules": rules_by_mfr[mfr].to_dict(),
+                "supports_assembly": profile.supports_assembly(),
+                "parts_library": (profile.parts_library.name if profile.parts_library else None),
+            }
+        emit_json(
+            {
+                "layers": args.layers,
+                "copper_oz": args.copper,
+                "manufacturers": manufacturers,
+            }
+        )
+        return
 
     print(f"\n{'=' * 70}")
     print(f"MANUFACTURER COMPARISON - {args.layers}-LAYER {args.copper}oz")
@@ -265,8 +351,7 @@ def cmd_export_dru(args):
     try:
         profile = get_profile(args.manufacturer)
     except ValueError as e:
-        print(f"Error: {e}")
-        sys.exit(1)
+        _fail(args, f"Error: {e}")
 
     rules = profile.get_design_rules(args.layers, args.copper)
 
@@ -284,6 +369,16 @@ def cmd_export_dru(args):
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     output_path.write_text(dru_content)
+    if _wants_json(args):
+        emit_json(
+            {
+                "manufacturer": profile.id,
+                "layers": args.layers,
+                "copper_oz": args.copper,
+                "output": str(output_path),
+            }
+        )
+        return
     print(f"DRC rules exported to: {output_path}")
 
 
@@ -298,40 +393,55 @@ def cmd_apply_rules(args):
     )
     from kicad_tools.core.sexp_file import load_pcb, save_pcb
 
+    json_mode = _wants_json(args)
+
     try:
         profile = get_profile(args.manufacturer)
     except ValueError as e:
-        print(f"Error: {e}")
-        sys.exit(1)
+        _fail(args, f"Error: {e}")
 
     rules = profile.get_design_rules(args.layers, args.copper)
     file_path = Path(args.file)
 
     if not file_path.exists():
-        print(f"Error: File not found: {file_path}", file=sys.stderr)
-        sys.exit(1)
+        _fail(args, f"Error: File not found: {file_path}", stderr=True)
 
-    print(f"\n{'=' * 60}")
-    print(f"APPLYING {profile.name.upper()} DESIGN RULES")
-    print(f"{'=' * 60}")
-    print(f"\nFile: {file_path}")
-    print(f"Configuration: {args.layers}-layer, {args.copper}oz copper")
+    payload = {
+        "file": str(file_path),
+        "manufacturer": profile.id,
+        "layers": args.layers,
+        "copper_oz": args.copper,
+        "dry_run": bool(args.dry_run),
+        "rules": rules.to_dict(),
+    }
 
-    print("\nDesign Rules to Apply:")
-    print(
-        f"  Min clearance:     {rules.min_clearance_mm:.4f} mm ({rules.min_clearance_mil:.1f} mil)"
-    )
-    print(
-        f"  Min trace width:   {rules.min_trace_width_mm:.4f} mm ({rules.min_trace_width_mil:.1f} mil)"
-    )
-    print(f"  Min via diameter:  {rules.min_via_diameter_mm:.3f} mm")
-    print(f"  Min via drill:     {rules.min_via_drill_mm:.3f} mm")
-    print(f"  Min annular ring:  {rules.min_annular_ring_mm:.3f} mm")
-    print(f"  Copper to edge:    {rules.min_copper_to_edge_mm:.3f} mm")
+    if not json_mode:
+        print(f"\n{'=' * 60}")
+        print(f"APPLYING {profile.name.upper()} DESIGN RULES")
+        print(f"{'=' * 60}")
+        print(f"\nFile: {file_path}")
+        print(f"Configuration: {args.layers}-layer, {args.copper}oz copper")
+
+        print("\nDesign Rules to Apply:")
+        print(
+            f"  Min clearance:     {rules.min_clearance_mm:.4f} mm "
+            f"({rules.min_clearance_mil:.1f} mil)"
+        )
+        print(
+            f"  Min trace width:   {rules.min_trace_width_mm:.4f} mm "
+            f"({rules.min_trace_width_mil:.1f} mil)"
+        )
+        print(f"  Min via diameter:  {rules.min_via_diameter_mm:.3f} mm")
+        print(f"  Min via drill:     {rules.min_via_drill_mm:.3f} mm")
+        print(f"  Min annular ring:  {rules.min_annular_ring_mm:.3f} mm")
+        print(f"  Copper to edge:    {rules.min_copper_to_edge_mm:.3f} mm")
 
     if args.dry_run:
-        print("\n(dry run - no changes made)")
-        print(f"\n{'=' * 60}")
+        if json_mode:
+            emit_json(payload)
+        else:
+            print("\n(dry run - no changes made)")
+            print(f"\n{'=' * 60}")
         return
 
     # Handle project files (.kicad_pro)
@@ -339,8 +449,7 @@ def cmd_apply_rules(args):
         try:
             data = load_project(file_path)
         except Exception as e:
-            print(f"Error loading project: {e}", file=sys.stderr)
-            sys.exit(1)
+            _fail(args, f"Error loading project: {e}", stderr=True)
 
         # Apply manufacturer rules
         apply_manufacturer_rules(
@@ -379,36 +488,44 @@ def cmd_apply_rules(args):
         output_path = Path(args.output) if args.output else file_path
         try:
             save_project(data, output_path)
-            print(f"\nProject file updated: {output_path}")
+            if not json_mode:
+                print(f"\nProject file updated: {output_path}")
         except Exception as e:
-            print(f"Error saving project: {e}", file=sys.stderr)
-            sys.exit(1)
+            _fail(args, f"Error saving project: {e}", stderr=True)
+
+        payload["updated"] = "project"
+        payload["output"] = str(output_path)
 
     # Handle PCB files (.kicad_pcb) - update zone clearances
     elif file_path.suffix == ".kicad_pcb":
         try:
             sexp = load_pcb(file_path)
         except Exception as e:
-            print(f"Error loading PCB: {e}", file=sys.stderr)
-            sys.exit(1)
+            _fail(args, f"Error loading PCB: {e}", stderr=True)
 
         zones_updated = _update_zone_clearances(sexp, rules.min_clearance_mm)
 
-        if zones_updated > 0:
-            print(
-                f"\nUpdated {zones_updated} zone(s) with clearance: {rules.min_clearance_mm:.4f} mm"
-            )
-        else:
-            print("\nNo zones found to update.")
+        if not json_mode:
+            if zones_updated > 0:
+                print(
+                    f"\nUpdated {zones_updated} zone(s) with clearance: "
+                    f"{rules.min_clearance_mm:.4f} mm"
+                )
+            else:
+                print("\nNo zones found to update.")
 
         # Save
         output_path = Path(args.output) if args.output else file_path
         try:
             save_pcb(sexp, output_path)
-            print(f"PCB file updated: {output_path}")
+            if not json_mode:
+                print(f"PCB file updated: {output_path}")
         except Exception as e:
-            print(f"Error saving PCB: {e}", file=sys.stderr)
-            sys.exit(1)
+            _fail(args, f"Error saving PCB: {e}", stderr=True)
+
+        payload["updated"] = "pcb"
+        payload["output"] = str(output_path)
+        payload["zones_updated"] = zones_updated
 
         # A bare .kicad_pcb has no sibling .kicad_pro, so kicad-cli pcb drc
         # silently falls back to KiCad factory defaults (0.20 mm track/clearance,
@@ -419,6 +536,7 @@ def cmd_apply_rules(args):
         # already succeeded, so a sidecar failure only warns.
         from kicad_tools.manufacturers import write_drc_constraints
 
+        sidecars: list[str] = []
         try:
             written = write_drc_constraints(
                 output_path,
@@ -428,17 +546,27 @@ def cmd_apply_rules(args):
                 copper_oz=args.copper,
             )
             if written:
-                print("DRC-constraint sidecars updated: " + ", ".join(str(p) for p in written))
+                sidecars = [str(p) for p in written]
+                if not json_mode:
+                    print("DRC-constraint sidecars updated: " + ", ".join(sidecars))
         except (ValueError, OSError, KeyError) as e:
             print(
                 f"Warning: could not write DRC-constraint sidecars: {e}",
                 file=sys.stderr,
             )
+        payload["sidecars"] = sidecars
 
     else:
+        if json_mode:
+            emit_json({"error": f"Unsupported file type: {file_path.suffix}"})
+            sys.exit(1)
         print(f"Error: Unsupported file type: {file_path.suffix}", file=sys.stderr)
         print("Supported: .kicad_pro, .kicad_pcb")
         sys.exit(1)
+
+    if json_mode:
+        emit_json(payload)
+        return
 
     print(f"\n{'=' * 60}")
     print(f"Manufacturer set to: {profile.name} ({profile.id})")
@@ -481,47 +609,66 @@ def cmd_validate(args):
     """Validate a PCB design against manufacturer design rules."""
     from kicad_tools.core.sexp_file import load_pcb
 
+    json_mode = _wants_json(args)
+
     try:
         profile = get_profile(args.manufacturer)
     except ValueError as e:
-        print(f"Error: {e}")
-        sys.exit(1)
+        _fail(args, f"Error: {e}")
 
     rules = profile.get_design_rules(args.layers, args.copper)
     file_path = Path(args.file)
 
     if not file_path.exists():
-        print(f"Error: File not found: {file_path}", file=sys.stderr)
-        sys.exit(1)
+        _fail(args, f"Error: File not found: {file_path}", stderr=True)
 
     if file_path.suffix != ".kicad_pcb":
-        print(f"Error: Expected .kicad_pcb file, got: {file_path.suffix}", file=sys.stderr)
-        sys.exit(1)
+        _fail(args, f"Error: Expected .kicad_pcb file, got: {file_path.suffix}", stderr=True)
 
     try:
         sexp = load_pcb(file_path)
     except Exception as e:
-        print(f"Error loading PCB: {e}", file=sys.stderr)
-        sys.exit(1)
+        _fail(args, f"Error loading PCB: {e}", stderr=True)
 
-    print(f"\n{'=' * 60}")
-    print(f"VALIDATING AGAINST {profile.name.upper()} RULES")
-    print(f"{'=' * 60}")
-    print(f"\nFile: {file_path}")
-    print(f"Configuration: {args.layers}-layer, {args.copper}oz copper")
+    if not json_mode:
+        print(f"\n{'=' * 60}")
+        print(f"VALIDATING AGAINST {profile.name.upper()} RULES")
+        print(f"{'=' * 60}")
+        print(f"\nFile: {file_path}")
+        print(f"Configuration: {args.layers}-layer, {args.copper}oz copper")
 
-    print("\nDesign Rules:")
-    print(
-        f"  Min clearance:     {rules.min_clearance_mm:.4f} mm ({rules.min_clearance_mil:.1f} mil)"
-    )
-    print(
-        f"  Min trace width:   {rules.min_trace_width_mm:.4f} mm ({rules.min_trace_width_mil:.1f} mil)"
-    )
-    print(f"  Min via diameter:  {rules.min_via_diameter_mm:.3f} mm")
-    print(f"  Min via drill:     {rules.min_via_drill_mm:.3f} mm")
+        print("\nDesign Rules:")
+        print(
+            f"  Min clearance:     {rules.min_clearance_mm:.4f} mm "
+            f"({rules.min_clearance_mil:.1f} mil)"
+        )
+        print(
+            f"  Min trace width:   {rules.min_trace_width_mm:.4f} mm "
+            f"({rules.min_trace_width_mil:.1f} mil)"
+        )
+        print(f"  Min via diameter:  {rules.min_via_diameter_mm:.3f} mm")
+        print(f"  Min via drill:     {rules.min_via_drill_mm:.3f} mm")
 
     # Run validation checks
     violations = _validate_pcb_design(sexp, rules)
+
+    if json_mode:
+        emit_json(
+            {
+                "file": str(file_path),
+                "manufacturer": profile.id,
+                "layers": args.layers,
+                "copper_oz": args.copper,
+                "rules": rules.to_dict(),
+                "violations": [
+                    {"type": v_type, "detail": v_details} for v_type, v_details in violations
+                ],
+                "ok": not violations,
+            }
+        )
+        if violations:
+            sys.exit(1)
+        return
 
     print(f"\n{'-' * 60}")
 
@@ -655,11 +802,13 @@ Examples:
 
     # list
     p_list = subparsers.add_parser("list", help="List manufacturers")
+    add_format_flag(p_list)
     p_list.set_defaults(func=cmd_list)
 
     # info
     p_info = subparsers.add_parser("info", help="Show manufacturer info")
     p_info.add_argument("manufacturer", help="Manufacturer ID")
+    add_format_flag(p_info)
     p_info.set_defaults(func=cmd_info)
 
     # rules
@@ -667,13 +816,17 @@ Examples:
     p_rules.add_argument("manufacturer", help="Manufacturer ID")
     p_rules.add_argument("-l", "--layers", type=int, default=2, help="Layer count (default: 2)")
     p_rules.add_argument("-c", "--copper", type=float, default=1.0, help="Copper weight (oz)")
-    p_rules.add_argument("--json", action="store_true", help="Include JSON output")
+    # The historical inner-only "--json" boolean (append-JSON-after-prose) was
+    # a dead surface -- unreachable through kct because the outer parser never
+    # declared it.  Retired in favour of the canonical --format json (#4674).
+    add_format_flag(p_rules)
     p_rules.set_defaults(func=cmd_rules)
 
     # compare
     p_compare = subparsers.add_parser("compare", help="Compare manufacturers")
     p_compare.add_argument("-l", "--layers", type=int, default=2, help="Layer count (default: 2)")
     p_compare.add_argument("-c", "--copper", type=float, default=1.0, help="Copper weight (oz)")
+    add_format_flag(p_compare)
     p_compare.set_defaults(func=cmd_compare)
 
     # find
@@ -691,6 +844,7 @@ Examples:
     p_dru.add_argument("-l", "--layers", type=int, default=2, help="Layer count (default: 2)")
     p_dru.add_argument("-c", "--copper", type=float, default=1.0, help="Copper weight (oz)")
     p_dru.add_argument("-o", "--output", type=Path, help="Output path")
+    add_format_flag(p_dru)
     p_dru.set_defaults(func=cmd_export_dru)
 
     # apply-rules
@@ -706,6 +860,7 @@ Examples:
     p_apply.add_argument("-c", "--copper", type=float, default=1.0, help="Copper weight (oz)")
     p_apply.add_argument("-o", "--output", help="Output file (default: modify in place)")
     p_apply.add_argument("--dry-run", action="store_true", help="Show changes without applying")
+    add_format_flag(p_apply)
     p_apply.set_defaults(func=cmd_apply_rules)
 
     # validate
@@ -719,6 +874,7 @@ Examples:
     p_validate.add_argument("manufacturer", help="Manufacturer ID (jlcpcb, seeed, etc.)")
     p_validate.add_argument("-l", "--layers", type=int, default=2, help="Layer count (default: 2)")
     p_validate.add_argument("-c", "--copper", type=float, default=1.0, help="Copper weight (oz)")
+    add_format_flag(p_validate)
     p_validate.set_defaults(func=cmd_validate)
 
     args = parser.parse_args(argv)

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -8,6 +8,7 @@ The parser is organized into subparsers for each major command category.
 import argparse
 
 from kicad_tools import __version__
+from kicad_tools.cli.format_options import add_format_flag
 from kicad_tools.manufacturers import get_all_manufacturer_names
 
 __all__ = ["create_parser"]
@@ -2964,22 +2965,26 @@ def _add_mfr_parser(subparsers) -> None:
     mfr_subparsers = mfr_parser.add_subparsers(dest="mfr_command", help="Manufacturer commands")
 
     # mfr list
-    mfr_subparsers.add_parser("list", help="List available manufacturers")
+    mfr_list = mfr_subparsers.add_parser("list", help="List available manufacturers")
+    add_format_flag(mfr_list)
 
     # mfr info
     mfr_info = mfr_subparsers.add_parser("info", help="Show manufacturer details")
     mfr_info.add_argument("manufacturer", help="Manufacturer ID (jlcpcb, seeed, etc.)")
+    add_format_flag(mfr_info)
 
     # mfr rules
     mfr_rules = mfr_subparsers.add_parser("rules", help="Show design rules")
     mfr_rules.add_argument("manufacturer", help="Manufacturer ID")
     mfr_rules.add_argument("-l", "--layers", type=int, default=4, help="Layer count")
     mfr_rules.add_argument("-c", "--copper", type=float, default=1.0, help="Copper weight (oz)")
+    add_format_flag(mfr_rules)
 
     # mfr compare
     mfr_compare = mfr_subparsers.add_parser("compare", help="Compare manufacturers")
     mfr_compare.add_argument("-l", "--layers", type=int, default=2, help="Layer count (default: 2)")
     mfr_compare.add_argument("-c", "--copper", type=float, default=1.0, help="Copper weight (oz)")
+    add_format_flag(mfr_compare)
 
     # mfr apply-rules
     mfr_apply = mfr_subparsers.add_parser(
@@ -2991,6 +2996,7 @@ def _add_mfr_parser(subparsers) -> None:
     mfr_apply.add_argument("-c", "--copper", type=float, default=1.0, help="Copper weight (oz)")
     mfr_apply.add_argument("-o", "--output", help="Output file (default: modify in place)")
     mfr_apply.add_argument("--dry-run", action="store_true", help="Show changes without applying")
+    add_format_flag(mfr_apply)
 
     # mfr validate
     mfr_validate = mfr_subparsers.add_parser(
@@ -3000,6 +3006,7 @@ def _add_mfr_parser(subparsers) -> None:
     mfr_validate.add_argument("manufacturer", help="Manufacturer ID (jlcpcb, seeed, etc.)")
     mfr_validate.add_argument("-l", "--layers", type=int, default=2, help="Layer count")
     mfr_validate.add_argument("-c", "--copper", type=float, default=1.0, help="Copper weight (oz)")
+    add_format_flag(mfr_validate)
 
     # mfr export-dru
     mfr_export_dru = mfr_subparsers.add_parser(
@@ -3011,6 +3018,7 @@ def _add_mfr_parser(subparsers) -> None:
         "-c", "--copper", type=float, default=1.0, help="Copper weight (oz)"
     )
     mfr_export_dru.add_argument("-o", "--output", type=str, help="Output file path")
+    add_format_flag(mfr_export_dru)
 
     # mfr import-dru
     mfr_import_dru = mfr_subparsers.add_parser(
@@ -3044,6 +3052,7 @@ def _add_zones_parser(subparsers) -> None:
     zones_add.add_argument("--min-thickness", type=float, default=0.25, help="Min thickness in mm")
     zones_add.add_argument("-v", "--verbose", action="store_true")
     zones_add.add_argument("--dry-run", action="store_true")
+    add_format_flag(zones_add)
 
     # zones list
     zones_list = zones_subparsers.add_parser("list", help="List existing zones")
@@ -3066,6 +3075,7 @@ def _add_zones_parser(subparsers) -> None:
     zones_batch.add_argument("--clearance", type=float, default=0.3, help="Clearance in mm")
     zones_batch.add_argument("-v", "--verbose", action="store_true")
     zones_batch.add_argument("--dry-run", action="store_true")
+    add_format_flag(zones_batch)
 
     # zones hv-keepout
     zones_hv = zones_subparsers.add_parser(
@@ -3103,6 +3113,7 @@ def _add_zones_parser(subparsers) -> None:
     )
     zones_hv.add_argument("-v", "--verbose", action="store_true")
     zones_hv.add_argument("--dry-run", action="store_true")
+    add_format_flag(zones_hv)
 
     # zones fill
     zones_fill = zones_subparsers.add_parser("fill", help="Fill all zones in a PCB")
@@ -3113,6 +3124,7 @@ def _add_zones_parser(subparsers) -> None:
     zones_fill.add_argument(
         "--dry-run", action="store_true", help="Show what would be done, no output"
     )
+    add_format_flag(zones_fill)
 
 
 def _add_stitch_parser(subparsers) -> None:
@@ -5397,6 +5409,7 @@ def _add_placement_parser(subparsers) -> None:
     placement_fix.add_argument(
         "-q", "--quiet", action="store_true", help="Suppress progress output"
     )
+    add_format_flag(placement_fix)
 
     # placement nudge (fast pad clearance repair)
     placement_nudge = placement_subparsers.add_parser(
@@ -5413,6 +5426,7 @@ def _add_placement_parser(subparsers) -> None:
     placement_nudge.add_argument(
         "-q", "--quiet", action="store_true", help="Suppress progress output"
     )
+    add_format_flag(placement_nudge)
 
     # placement optimize
     placement_optimize = placement_subparsers.add_parser(
@@ -5550,6 +5564,7 @@ def _add_placement_parser(subparsers) -> None:
     placement_snap.add_argument(
         "-q", "--quiet", action="store_true", help="Suppress progress output"
     )
+    add_format_flag(placement_snap)
 
     # placement align
     placement_align = placement_subparsers.add_parser(
@@ -5588,6 +5603,7 @@ def _add_placement_parser(subparsers) -> None:
     placement_align.add_argument(
         "-q", "--quiet", action="store_true", help="Suppress progress output"
     )
+    add_format_flag(placement_align)
 
     # placement distribute
     placement_distribute = placement_subparsers.add_parser(
@@ -5622,6 +5638,7 @@ def _add_placement_parser(subparsers) -> None:
     placement_distribute.add_argument(
         "-q", "--quiet", action="store_true", help="Suppress progress output"
     )
+    add_format_flag(placement_distribute)
 
     # placement suggest
     placement_suggest = placement_subparsers.add_parser(
@@ -8023,6 +8040,7 @@ def _add_spec_parser(subparsers) -> None:
         action="store_true",
         help="Overwrite existing file",
     )
+    add_format_flag(spec_init, dest="spec_format")
 
     # spec validate
     spec_validate = spec_subparsers.add_parser(
@@ -8035,6 +8053,7 @@ def _add_spec_parser(subparsers) -> None:
         metavar="FILE",
         help="Path to .kct file",
     )
+    add_format_flag(spec_validate, dest="spec_format")
 
     # spec status
     spec_status = spec_subparsers.add_parser(
@@ -8047,6 +8066,7 @@ def _add_spec_parser(subparsers) -> None:
         metavar="FILE",
         help="Path to .kct file",
     )
+    add_format_flag(spec_status, dest="spec_format")
 
     # spec decide
     spec_decide = spec_subparsers.add_parser(
@@ -8082,6 +8102,7 @@ def _add_spec_parser(subparsers) -> None:
         dest="decide_alternatives",
         help="Comma-separated alternative options considered",
     )
+    add_format_flag(spec_decide, dest="spec_format")
 
     # spec check
     spec_check = spec_subparsers.add_parser(
@@ -8099,6 +8120,7 @@ def _add_spec_parser(subparsers) -> None:
         metavar="ITEM",
         help="Checklist item to mark complete (format: 'phase.item' or 'item')",
     )
+    add_format_flag(spec_check, dest="spec_format")
 
 
 def _add_benchmark_parser(subparsers) -> None:
@@ -8148,6 +8170,7 @@ def _add_benchmark_parser(subparsers) -> None:
         action="store_true",
         help="Show detailed progress",
     )
+    add_format_flag(benchmark_run)
 
     # benchmark compare
     benchmark_compare = benchmark_subparsers.add_parser(
@@ -8171,6 +8194,7 @@ def _add_benchmark_parser(subparsers) -> None:
         action="store_true",
         help="Show detailed progress",
     )
+    add_format_flag(benchmark_compare)
 
     # benchmark report
     benchmark_report = benchmark_subparsers.add_parser(
@@ -8184,7 +8208,7 @@ def _add_benchmark_parser(subparsers) -> None:
     )
     benchmark_report.add_argument(
         "--format",
-        choices=["text", "markdown"],
+        choices=["text", "markdown", "json"],
         default="text",
         help="Output format (default: text)",
     )

--- a/src/kicad_tools/cli/placement_cmd.py
+++ b/src/kicad_tools/cli/placement_cmd.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from kicad_tools.optim import OptimizationResult, OptimizationWorkflow
 
+from kicad_tools.cli.format_options import add_format_flag, emit_json
 from kicad_tools.placement import (
     Conflict,
     PlacementAnalyzer,
@@ -27,6 +28,20 @@ from kicad_tools.placement import (
 )
 from kicad_tools.placement.analyzer import DesignRules
 from kicad_tools.placement.fixer import FixStrategy
+
+
+def _wants_json(args) -> bool:
+    """True when the canonical ``--format json`` spelling was requested."""
+    return getattr(args, "format", "text") == "json"
+
+
+def _fail(args, message: str) -> int:
+    """Report an error and return 1 (single JSON document in JSON mode)."""
+    if _wants_json(args):
+        emit_json({"error": message})
+    else:
+        print(message, file=sys.stderr)
+    return 1
 
 
 def cmd_check(args) -> int:
@@ -100,12 +115,14 @@ def cmd_nudge(args) -> int:
     """
     from kicad_tools.cli.progress import spinner
 
-    quiet = getattr(args, "quiet", False)
+    json_mode = _wants_json(args)
+    # JSON mode suppresses prose/progress; the payload at the end is the
+    # single stdout document.
+    quiet = getattr(args, "quiet", False) or json_mode
 
     pcb_path = Path(args.pcb)
     if not pcb_path.exists():
-        print(f"Error: File not found: {pcb_path}", file=sys.stderr)
-        return 1
+        return _fail(args, f"Error: File not found: {pcb_path}")
 
     # Build design rules
     rules = DesignRules(
@@ -139,6 +156,23 @@ def cmd_nudge(args) -> int:
             dry_run=args.dry_run,
         )
 
+    if json_mode:
+        emit_json(
+            {
+                "pcb": str(pcb_path),
+                "output": str(output_path),
+                "dry_run": bool(args.dry_run),
+                "anchored": sorted(anchored),
+                "success": bool(result.success),
+                "fixes_applied": result.fixes_applied,
+                "new_conflicts": result.new_conflicts,
+                "message": result.message,
+            }
+        )
+        if args.dry_run:
+            return 0
+        return 0 if result.success else 1
+
     if not quiet:
         print(f"\n{result.message}")
 
@@ -157,12 +191,14 @@ def cmd_fix(args) -> int:
     """Suggest and apply fixes for placement conflicts."""
     from kicad_tools.cli.progress import spinner
 
-    quiet = getattr(args, "quiet", False)
+    json_mode = _wants_json(args)
+    # JSON mode suppresses prose/progress; the payload at the end is the
+    # single stdout document.
+    quiet = getattr(args, "quiet", False) or json_mode
 
     pcb_path = Path(args.pcb)
     if not pcb_path.exists():
-        print(f"Error: File not found: {pcb_path}", file=sys.stderr)
-        return 1
+        return _fail(args, f"Error: File not found: {pcb_path}")
 
     # Build design rules
     rules = DesignRules(
@@ -198,6 +234,25 @@ def cmd_fix(args) -> int:
                 output_path=fix_output_path,
                 dry_run=args.dry_run,
             )
+
+        if json_mode:
+            emit_json(
+                {
+                    "pcb": str(pcb_path),
+                    "output": str(fix_output_path),
+                    "strategy": args.strategy,
+                    "only": only_type,
+                    "dry_run": bool(args.dry_run),
+                    "anchored": sorted(fix_anchored),
+                    "success": bool(fix_result.success),
+                    "fixes_applied": fix_result.fixes_applied,
+                    "new_conflicts": fix_result.new_conflicts,
+                    "message": fix_result.message,
+                }
+            )
+            if args.dry_run:
+                return 0
+            return 0 if fix_result.success else 1
 
         if not quiet:
             print(f"\n{fix_result.message}")
@@ -243,6 +298,37 @@ def cmd_fix(args) -> int:
             timeout=timeout,
         )
 
+    if json_mode:
+        emit_json(
+            {
+                "pcb": str(pcb_path),
+                "output": str(output_path),
+                "strategy": args.strategy,
+                "only": only_type,
+                "dry_run": bool(args.dry_run),
+                "anchored": sorted(anchored),
+                "success": bool(result.success),
+                "total_passes": result.total_passes,
+                "initial_conflicts": result.initial_conflicts,
+                "remaining_conflicts": result.remaining_conflicts,
+                "fixes_applied": result.total_fixes_applied,
+                "passes": [
+                    {
+                        "pass": pr.pass_number,
+                        "conflicts_before": pr.conflicts_before,
+                        "conflicts_after": pr.conflicts_after,
+                        "fixes_applied": pr.fixes_applied,
+                        "escalation_factor": pr.escalation_factor,
+                    }
+                    for pr in result.pass_results
+                ],
+                "message": result.message,
+            }
+        )
+        if args.dry_run:
+            return 0
+        return 0 if result.success else 1
+
     if not quiet:
         # Per-pass progress when verbose
         if args.verbose and result.pass_results:
@@ -279,20 +365,21 @@ def cmd_snap(args) -> int:
     from kicad_tools.optim import PlacementConfig, PlacementOptimizer, snap_to_grid
     from kicad_tools.schema.pcb import PCB
 
-    quiet = getattr(args, "quiet", False)
+    json_mode = _wants_json(args)
+    # JSON mode suppresses prose/progress; the payload at the end is the
+    # single stdout document.
+    quiet = getattr(args, "quiet", False) or json_mode
 
     pcb_path = Path(args.pcb)
     if not pcb_path.exists():
-        print(f"Error: File not found: {pcb_path}", file=sys.stderr)
-        return 1
+        return _fail(args, f"Error: File not found: {pcb_path}")
 
     # Load PCB
     try:
         with spinner("Loading PCB...", quiet=quiet):
             pcb = PCB.load(str(pcb_path))
     except Exception as e:
-        print(f"Error loading PCB: {e}", file=sys.stderr)
-        return 1
+        return _fail(args, f"Error loading PCB: {e}")
 
     # Create optimizer from PCB
     config = PlacementConfig()
@@ -310,15 +397,27 @@ def cmd_snap(args) -> int:
     if not quiet:
         print(f"Snapped {count} components")
 
+    output_path = Path(args.output) if args.output else pcb_path
+    payload = {
+        "pcb": str(pcb_path),
+        "output": str(output_path),
+        "grid_mm": args.grid,
+        "rotation_snap_deg": rotation_snap,
+        "dry_run": bool(args.dry_run),
+        "components": len(optimizer.components),
+        "snapped": count,
+    }
+
     if args.dry_run:
-        if not quiet:
+        if json_mode:
+            payload["updated"] = 0
+            emit_json(payload)
+        elif not quiet:
             print("\n(Dry run - no changes made)")
             print(optimizer.report())
         return 0
 
     # Write results
-    output_path = Path(args.output) if args.output else pcb_path
-
     try:
         with spinner("Writing snapped placement...", quiet=quiet):
             updated = optimizer.write_to_pcb(pcb)
@@ -329,8 +428,11 @@ def cmd_snap(args) -> int:
             print(f"Saved to: {output_path}")
 
     except Exception as e:
-        print(f"Error saving PCB: {e}", file=sys.stderr)
-        return 1
+        return _fail(args, f"Error saving PCB: {e}")
+
+    if json_mode:
+        payload["updated"] = updated
+        emit_json(payload)
 
     return 0
 
@@ -638,24 +740,24 @@ def cmd_align(args) -> int:
     from kicad_tools.optim import PlacementConfig, PlacementOptimizer, align_components
     from kicad_tools.schema.pcb import PCB
 
-    quiet = getattr(args, "quiet", False)
+    json_mode = _wants_json(args)
+    # JSON mode suppresses prose/progress; the payload at the end is the
+    # single stdout document.
+    quiet = getattr(args, "quiet", False) or json_mode
 
     pcb_path = Path(args.pcb)
     if not pcb_path.exists():
-        print(f"Error: File not found: {pcb_path}", file=sys.stderr)
-        return 1
+        return _fail(args, f"Error: File not found: {pcb_path}")
 
     if not args.components:
-        print("Error: No components specified. Use --components R1,R2,R3", file=sys.stderr)
-        return 1
+        return _fail(args, "Error: No components specified. Use --components R1,R2,R3")
 
     # Load PCB
     try:
         with spinner("Loading PCB...", quiet=quiet):
             pcb = PCB.load(str(pcb_path))
     except Exception as e:
-        print(f"Error loading PCB: {e}", file=sys.stderr)
-        return 1
+        return _fail(args, f"Error loading PCB: {e}")
 
     # Create optimizer from PCB
     config = PlacementConfig()
@@ -681,14 +783,27 @@ def cmd_align(args) -> int:
     if not quiet:
         print(f"Aligned {count} components")
 
+    output_path = Path(args.output) if args.output else pcb_path
+    payload = {
+        "pcb": str(pcb_path),
+        "output": str(output_path),
+        "axis": args.axis,
+        "reference": args.reference,
+        "tolerance_mm": args.tolerance,
+        "dry_run": bool(args.dry_run),
+        "components": refs,
+        "aligned": count,
+    }
+
     if args.dry_run:
-        if not quiet:
+        if json_mode:
+            payload["updated"] = 0
+            emit_json(payload)
+        elif not quiet:
             print("\n(Dry run - no changes made)")
         return 0
 
     # Write results
-    output_path = Path(args.output) if args.output else pcb_path
-
     try:
         with spinner("Writing aligned placement...", quiet=quiet):
             updated = optimizer.write_to_pcb(pcb)
@@ -699,8 +814,11 @@ def cmd_align(args) -> int:
             print(f"Saved to: {output_path}")
 
     except Exception as e:
-        print(f"Error saving PCB: {e}", file=sys.stderr)
-        return 1
+        return _fail(args, f"Error saving PCB: {e}")
+
+    if json_mode:
+        payload["updated"] = updated
+        emit_json(payload)
 
     return 0
 
@@ -711,26 +829,24 @@ def cmd_distribute(args) -> int:
     from kicad_tools.optim import PlacementConfig, PlacementOptimizer, distribute_components
     from kicad_tools.schema.pcb import PCB
 
-    quiet = getattr(args, "quiet", False)
+    json_mode = _wants_json(args)
+    # JSON mode suppresses prose/progress; the payload at the end is the
+    # single stdout document.
+    quiet = getattr(args, "quiet", False) or json_mode
 
     pcb_path = Path(args.pcb)
     if not pcb_path.exists():
-        print(f"Error: File not found: {pcb_path}", file=sys.stderr)
-        return 1
+        return _fail(args, f"Error: File not found: {pcb_path}")
 
     if not args.components:
-        print(
-            "Error: No components specified. Use --components LED1,LED2,LED3,LED4", file=sys.stderr
-        )
-        return 1
+        return _fail(args, "Error: No components specified. Use --components LED1,LED2,LED3,LED4")
 
     # Load PCB
     try:
         with spinner("Loading PCB...", quiet=quiet):
             pcb = PCB.load(str(pcb_path))
     except Exception as e:
-        print(f"Error loading PCB: {e}", file=sys.stderr)
-        return 1
+        return _fail(args, f"Error loading PCB: {e}")
 
     # Create optimizer from PCB
     config = PlacementConfig()
@@ -758,14 +874,26 @@ def cmd_distribute(args) -> int:
         else:
             print(f"Distributed {count} components evenly")
 
+    output_path = Path(args.output) if args.output else pcb_path
+    payload = {
+        "pcb": str(pcb_path),
+        "output": str(output_path),
+        "axis": args.axis,
+        "spacing_mm": spacing,
+        "dry_run": bool(args.dry_run),
+        "components": refs,
+        "distributed": count,
+    }
+
     if args.dry_run:
-        if not quiet:
+        if json_mode:
+            payload["updated"] = 0
+            emit_json(payload)
+        elif not quiet:
             print("\n(Dry run - no changes made)")
         return 0
 
     # Write results
-    output_path = Path(args.output) if args.output else pcb_path
-
     try:
         with spinner("Writing distributed placement...", quiet=quiet):
             updated = optimizer.write_to_pcb(pcb)
@@ -776,8 +904,11 @@ def cmd_distribute(args) -> int:
             print(f"Saved to: {output_path}")
 
     except Exception as e:
-        print(f"Error saving PCB: {e}", file=sys.stderr)
-        return 1
+        return _fail(args, f"Error saving PCB: {e}")
+
+    if json_mode:
+        payload["updated"] = updated
+        emit_json(payload)
 
     return 0
 
@@ -1707,6 +1838,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     fix_parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
     fix_parser.add_argument("-q", "--quiet", action="store_true", help="Suppress progress output")
+    add_format_flag(fix_parser)
 
     # Nudge subcommand (fast pad clearance repair)
     nudge_parser = subparsers.add_parser(
@@ -1736,6 +1868,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     nudge_parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
     nudge_parser.add_argument("-q", "--quiet", action="store_true", help="Suppress progress output")
+    add_format_flag(nudge_parser)
 
     # Snap subcommand
     snap_parser = subparsers.add_parser("snap", help="Snap components to grid")
@@ -1764,6 +1897,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     snap_parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
     snap_parser.add_argument("-q", "--quiet", action="store_true", help="Suppress progress output")
+    add_format_flag(snap_parser)
 
     # Align subcommand
     align_parser = subparsers.add_parser("align", help="Align components in row or column")
@@ -1804,6 +1938,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     align_parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
     align_parser.add_argument("-q", "--quiet", action="store_true", help="Suppress progress output")
+    add_format_flag(align_parser)
 
     # Distribute subcommand
     distribute_parser = subparsers.add_parser("distribute", help="Distribute components evenly")
@@ -1840,6 +1975,7 @@ def main(argv: list[str] | None = None) -> int:
     distribute_parser.add_argument(
         "-q", "--quiet", action="store_true", help="Suppress progress output"
     )
+    add_format_flag(distribute_parser)
 
     # Optimize subcommand
     optimize_parser = subparsers.add_parser(

--- a/src/kicad_tools/cli/zones_cmd.py
+++ b/src/kicad_tools/cli/zones_cmd.py
@@ -12,6 +12,22 @@ import argparse
 import sys
 from pathlib import Path
 
+from kicad_tools.cli.format_options import add_format_flag, emit_json
+
+
+def _wants_json(args) -> bool:
+    """True when the canonical ``--format json`` spelling was requested."""
+    return getattr(args, "format", "text") == "json"
+
+
+def _fail(args, message: str) -> int:
+    """Report an error and return 1 (single JSON document in JSON mode)."""
+    if _wants_json(args):
+        emit_json({"error": message})
+    else:
+        print(message, file=sys.stderr)
+    return 1
+
 
 def parse_bbox(spec: str) -> list[tuple[float, float]]:
     """Parse a ``MINX,MINY,MAXX,MAXY`` bbox string into a polygon.
@@ -194,6 +210,7 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Suppress progress output",
     )
+    add_format_flag(add_parser)
 
     # zones list
     list_parser = subparsers.add_parser("list", help="List existing zones in a PCB")
@@ -241,6 +258,7 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Suppress progress output",
     )
+    add_format_flag(batch_parser)
 
     # zones hv-keepout
     hv_parser = subparsers.add_parser(
@@ -296,6 +314,7 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Suppress progress output",
     )
+    add_format_flag(hv_parser)
 
     # zones fill
     fill_parser = subparsers.add_parser("fill", help="Fill all zones in a PCB")
@@ -326,6 +345,7 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Suppress progress output",
     )
+    add_format_flag(fill_parser)
 
     args = parser.parse_args(argv)
 
@@ -353,8 +373,7 @@ def _run_add(args) -> int:
 
     pcb_path = Path(args.pcb)
     if not pcb_path.exists():
-        print(f"Error: File not found: {pcb_path}", file=sys.stderr)
-        return 1
+        return _fail(args, f"Error: File not found: {pcb_path}")
 
     # Determine output path. No -o means overwrite the input in place,
     # consistent with `zones fill` and `optimize-placement`. This makes a
@@ -362,7 +381,10 @@ def _run_add(args) -> int:
     # call reads its own prior output instead of the pristine input.
     output_path = Path(args.output) if args.output else pcb_path
 
-    quiet = args.quiet
+    json_mode = _wants_json(args)
+    # JSON mode suppresses the prose progress report; the payload at the end
+    # is the single stdout document (overlap warnings still go to stderr).
+    quiet = args.quiet or json_mode
 
     # Parse optional region/island boundary (mutually exclusive in argparse).
     boundary = None
@@ -372,8 +394,7 @@ def _run_add(args) -> int:
         elif args.region:
             boundary = parse_region(args.region)
     except ValueError as e:
-        print(f"Error: {e}", file=sys.stderr)
-        return 1
+        return _fail(args, f"Error: {e}")
 
     if not quiet:
         print(f"Loading PCB: {pcb_path}")
@@ -381,8 +402,7 @@ def _run_add(args) -> int:
     try:
         gen = ZoneGenerator.from_pcb(str(pcb_path))
     except Exception as e:
-        print(f"Error loading PCB: {e}", file=sys.stderr)
-        return 1
+        return _fail(args, f"Error loading PCB: {e}")
 
     # Add the zone
     try:
@@ -397,8 +417,7 @@ def _run_add(args) -> int:
             boundary=boundary,
         )
     except ValueError as e:
-        print(f"Error: {e}", file=sys.stderr)
-        return 1
+        return _fail(args, f"Error: {e}")
 
     if not quiet:
         print("\nZone created:")
@@ -414,8 +433,25 @@ def _run_add(args) -> int:
         for w in gen.warnings:
             print(f"  WARNING: {w.message}", file=sys.stderr)
 
+    payload = {
+        "pcb": str(pcb_path),
+        "output": str(output_path),
+        "dry_run": bool(args.dry_run),
+        "zone": {
+            "net": zone.config.net,
+            "layer": zone.config.layer,
+            "priority": zone.config.priority,
+            "clearance_mm": zone.config.clearance,
+            "boundary_points": len(zone.boundary),
+        },
+        "warnings": [w.message for w in gen.warnings],
+    }
+
     if args.dry_run:
-        if not quiet:
+        if json_mode:
+            payload["saved"] = False
+            emit_json(payload)
+        elif not quiet:
             print("\n--- Dry run - not saving ---")
             print("\nGenerated S-expression:")
             print(gen.generate_sexp())
@@ -428,10 +464,12 @@ def _run_add(args) -> int:
     try:
         gen.save(output_path)
     except Exception as e:
-        print(f"Error: Write verification failed: {e}", file=sys.stderr)
-        return 1
+        return _fail(args, f"Error: Write verification failed: {e}")
 
-    if not quiet:
+    if json_mode:
+        payload["saved"] = True
+        emit_json(payload)
+    elif not quiet:
         print("Done!")
 
     return 0
@@ -525,25 +563,25 @@ def _run_batch(args) -> int:
 
     pcb_path = Path(args.pcb)
     if not pcb_path.exists():
-        print(f"Error: File not found: {pcb_path}", file=sys.stderr)
-        return 1
+        return _fail(args, f"Error: File not found: {pcb_path}")
 
     # Parse power nets spec
     try:
         power_nets = parse_power_nets(args.power_nets)
     except ValueError as e:
-        print(f"Error: {e}", file=sys.stderr)
-        return 1
+        return _fail(args, f"Error: {e}")
 
     if not power_nets:
-        print("Error: No power nets specified", file=sys.stderr)
-        return 1
+        return _fail(args, "Error: No power nets specified")
 
     # Determine output path. No -o means overwrite the input in place,
     # consistent with `zones fill` and `optimize-placement`.
     output_path = Path(args.output) if args.output else pcb_path
 
-    quiet = args.quiet
+    json_mode = _wants_json(args)
+    # JSON mode suppresses the prose progress report; the payload at the end
+    # is the single stdout document (errors/warnings still go to stderr).
+    quiet = args.quiet or json_mode
 
     if not quiet:
         print(f"Loading PCB: {pcb_path}")
@@ -551,8 +589,7 @@ def _run_batch(args) -> int:
     try:
         gen = ZoneGenerator.from_pcb(str(pcb_path))
     except Exception as e:
-        print(f"Error loading PCB: {e}", file=sys.stderr)
-        return 1
+        return _fail(args, f"Error loading PCB: {e}")
 
     # Auto-assign priorities (by pad-cluster bbox area) and carve outlines
     # for same-layer groups so overlapping zones receive disjoint copper
@@ -567,13 +604,13 @@ def _run_batch(args) -> int:
         # Carving genuinely cannot produce disjoint copper for some net
         # (fully-coincident pad clusters).  Refuse rather than silently
         # writing zero-copper zones.
-        print(f"Error: {e}", file=sys.stderr)
-        return 1
+        return _fail(args, f"Error: {e}")
 
     if not quiet:
         print(f"\nAdding {len(power_nets)} zone(s):")
 
     errors = []
+    created = []
     for net_name, layer in power_nets:
         # Keyed by (net, layer): a net on multiple layers must get the
         # correct per-layer outline (full board where it is sole, carved
@@ -588,13 +625,21 @@ def _run_batch(args) -> int:
                 clearance=args.clearance,
                 boundary=boundary,
             )
+            created.append(
+                {
+                    "net": net_name,
+                    "layer": layer,
+                    "priority": priority,
+                    "carved": boundary is not None,
+                }
+            )
             if not quiet:
                 carved = " (carved)" if boundary is not None else ""
                 print(f"  {net_name} on {layer} (priority {priority}){carved}")
         except ValueError as e:
             errors.append(f"  {net_name}: {e}")
 
-    if errors:
+    if errors and not json_mode:
         print("\nErrors:", file=sys.stderr)
         for err in errors:
             print(err, file=sys.stderr)
@@ -605,8 +650,22 @@ def _run_batch(args) -> int:
         for w in gen.warnings:
             print(f"  WARNING: {w.message}", file=sys.stderr)
 
+    payload = {
+        "pcb": str(pcb_path),
+        "output": str(output_path),
+        "dry_run": bool(args.dry_run),
+        "clearance_mm": args.clearance,
+        "zones": created,
+        "zone_count": len(created),
+        "errors": [e.strip() for e in errors],
+        "warnings": [w.message for w in gen.warnings],
+    }
+
     if args.dry_run:
-        if not quiet:
+        if json_mode:
+            payload["saved"] = False
+            emit_json(payload)
+        elif not quiet:
             print("\n--- Dry run - not saving ---")
             _print_batch_summary(gen, quiet)
             if args.verbose:
@@ -621,10 +680,12 @@ def _run_batch(args) -> int:
     try:
         gen.save(output_path)
     except Exception as e:
-        print(f"Error: Write verification failed: {e}", file=sys.stderr)
-        return 1
+        return _fail(args, f"Error: Write verification failed: {e}")
 
-    if not quiet:
+    if json_mode:
+        payload["saved"] = True
+        emit_json(payload)
+    elif not quiet:
         _print_batch_summary(gen, quiet)
 
     return 0 if not errors else 1
@@ -694,34 +755,30 @@ def _run_hv_keepout(args) -> int:
     from kicad_tools.sexp import parse_file
     from kicad_tools.zones.hv_keepout import build_hv_keepout_plan
 
-    quiet = getattr(args, "quiet", False)
+    json_mode = _wants_json(args)
+    # JSON mode suppresses the prose progress report; the payload at the end
+    # is the single stdout document (errors still go to stderr).
+    quiet = getattr(args, "quiet", False) or json_mode
 
     if not has_shapely():
-        print(
+        return _fail(
+            args,
             "Error: hv-keepout requires shapely (a core dependency); "
             "it is not importable in this environment.",
-            file=sys.stderr,
         )
-        return 1
 
     pcb_path = Path(args.pcb)
     if not pcb_path.exists():
-        print(f"Error: File not found: {pcb_path}", file=sys.stderr)
-        return 1
+        return _fail(args, f"Error: File not found: {pcb_path}")
 
     if args.clearance <= 0:
-        print(
-            f"Error: --clearance must be positive (got {args.clearance}).",
-            file=sys.stderr,
-        )
-        return 1
+        return _fail(args, f"Error: --clearance must be positive (got {args.clearance}).")
 
     net_class_map, ncm_error = _load_net_class_map(
         getattr(args, "net_class_map", None), pcb_path=pcb_path
     )
     if ncm_error is not None:
-        print(f"Error: {ncm_error}", file=sys.stderr)
-        return 1
+        return _fail(args, f"Error: {ncm_error}")
 
     # No -o means overwrite the input in place, consistent with 'zones fill'.
     output_path = Path(args.output) if args.output else pcb_path
@@ -736,13 +793,24 @@ def _run_hv_keepout(args) -> int:
     try:
         pcb = PCB.load(str(pcb_path))
     except Exception as e:
-        print(f"Error loading PCB: {e}", file=sys.stderr)
-        return 1
+        return _fail(args, f"Error loading PCB: {e}")
 
     net_class = getattr(args, "net_class", "HV") or "HV"
     hv_nets = resolve_hv_nets(pcb, net_class, net_class_map)
 
+    payload = {
+        "pcb": str(pcb_path),
+        "output": str(output_path),
+        "net_class": net_class,
+        "clearance_mm": args.clearance,
+        "dry_run": bool(args.dry_run),
+    }
+
     if not hv_nets:
+        if json_mode:
+            payload.update({"hv_nets": [], "keepout_count": 0, "saved": False})
+            emit_json(payload)
+            return 0
         # Clean no-op mirroring `kct creepage`'s guidance (issue #4372 edge a).
         print(
             f"No '{net_class}' nets found "
@@ -758,7 +826,16 @@ def _run_hv_keepout(args) -> int:
         plane_layers=plane_layers,
     )
 
-    if not quiet or args.dry_run:
+    payload.update(
+        {
+            "hv_nets": sorted(plan.hv_nets.values()),
+            "plane_layers": list(plan.plane_layers),
+            "excluded_layers": list(plan.excluded_layers),
+            "keepout_count": plan.keepout_count,
+        }
+    )
+
+    if (not quiet or args.dry_run) and not json_mode:
         print(f"\nHV nets ({len(plan.hv_nets)}): {', '.join(sorted(plan.hv_nets.values()))}")
         print(f"Clearance: {plan.clearance_mm} mm")
         print(
@@ -773,7 +850,10 @@ def _run_hv_keepout(args) -> int:
                 print(f"  Void {i}: {len(void.points)} pts on {', '.join(void.layers)}")
 
     if plan.keepout_count == 0:
-        if not plan.plane_layers:
+        if json_mode:
+            payload["saved"] = False
+            emit_json(payload)
+        elif not plan.plane_layers:
             print(
                 "No target plane layers to void (supply --plane-layers, or add plane pours first)."
             )
@@ -782,7 +862,10 @@ def _run_hv_keepout(args) -> int:
         return 0
 
     if args.dry_run:
-        if not quiet:
+        if json_mode:
+            payload["saved"] = False
+            emit_json(payload)
+        elif not quiet:
             print("\n--- Dry run - not saving ---")
         return 0
 
@@ -790,8 +873,7 @@ def _run_hv_keepout(args) -> int:
     try:
         doc = parse_file(pcb_path)
     except Exception as e:
-        print(f"Error parsing PCB for write: {e}", file=sys.stderr)
-        return 1
+        return _fail(args, f"Error parsing PCB for write: {e}")
 
     for node in plan.zone_nodes():
         doc.append(node)
@@ -804,18 +886,23 @@ def _run_hv_keepout(args) -> int:
 
         save_pcb(doc, output_path)
     except Exception as e:
-        print(f"Error: Write failed: {e}", file=sys.stderr)
-        return 1
+        return _fail(args, f"Error: Write failed: {e}")
 
     if not quiet:
         print(f"Wrote {plan.keepout_count} keepout zone(s).")
 
+    refilled = False
     if args.refill:
         rc = _refill_after_keepout(output_path, quiet)
         if rc != 0:
             return rc
+        refilled = True
 
-    if not quiet:
+    if json_mode:
+        payload["saved"] = True
+        payload["refilled"] = refilled
+        emit_json(payload)
+    elif not quiet:
         print("Done!")
 
     return 0
@@ -851,24 +938,37 @@ def _run_fill(args) -> int:
     """Fill zones in a PCB using kicad-cli."""
     from .runner import find_kicad_cli, run_fill_zones
 
+    json_mode = _wants_json(args)
+
     pcb_path = Path(args.pcb)
     if not pcb_path.exists():
-        print(f"Error: File not found: {pcb_path}", file=sys.stderr)
-        return 1
+        return _fail(args, f"Error: File not found: {pcb_path}")
 
     kicad_cli = find_kicad_cli()
     if not kicad_cli:
-        print(
+        return _fail(
+            args,
             "Error: kicad-cli not found. Install KiCad 8 from https://www.kicad.org/download/",
-            file=sys.stderr,
         )
-        return 1
 
     output_path = Path(args.output) if args.output else None
 
-    quiet = getattr(args, "quiet", False)
+    # JSON mode suppresses the prose progress report; the payload at the end
+    # is the single stdout document (errors still go to stderr).
+    quiet = getattr(args, "quiet", False) or json_mode
+
+    payload = {
+        "pcb": str(pcb_path),
+        "output": str(output_path if output_path else pcb_path),
+        "net": args.net,
+        "dry_run": bool(args.dry_run),
+    }
 
     if args.dry_run:
+        if json_mode:
+            payload["filled"] = False
+            emit_json(payload)
+            return 0
         print(f"Would fill zones in: {pcb_path}")
         if args.net:
             print(f"  Net filter: {args.net}")
@@ -893,10 +993,12 @@ def _run_fill(args) -> int:
     result = run_fill_zones(pcb_path, output_path, kicad_cli=kicad_cli)
 
     if not result.success:
-        print(f"Error: {result.stderr}", file=sys.stderr)
-        return 1
+        return _fail(args, f"Error: {result.stderr}")
 
-    if not quiet:
+    if json_mode:
+        payload["filled"] = True
+        emit_json(payload)
+    elif not quiet:
         target = output_path if output_path else pcb_path
         print(f"Zones filled: {target}")
 

--- a/tests/test_format_json_sweep.py
+++ b/tests/test_format_json_sweep.py
@@ -1,0 +1,538 @@
+"""Tests for the #4674 machine-output sweep (grouped-family batch).
+
+Issue #4674 (mechanical follow-up to #4543): add the canonical
+``--format json`` idiom to the prose-only subcommand families.  This batch
+covers the grouped families:
+
+* ``mfr``       -- list, info, rules, compare, export-dru, apply-rules,
+                   validate (and retires the dead inner ``mfr rules --json``
+                   surface documented in docs/reference/machine-output.md)
+* ``spec``      -- init, validate, status, decide, check
+* ``benchmark`` -- run, compare (new flag) + report (gains a ``json`` choice)
+* ``zones``     -- add, batch, fill, hv-keepout
+* ``placement`` -- align, distribute, fix, nudge, snap
+
+Covers, per the #4543 idiom test conventions
+(``tests/test_machine_output_idiom.py``):
+
+* Outer-parser surface: every swept leaf accepts ``--format`` with a
+  ``json`` choice (regression guard so a surface cannot silently drop out).
+* Shim forwarding: the outer ``--format json`` reaches the inner parser
+  argv for the three argv-reserializing families (mfr, zones, placement) --
+  the drift bug class ``tests/test_cli_parser_drift.py`` exists for.
+* Emission: hermetic surfaces emit a single valid JSON document on stdout,
+  byte-identical across two runs on the same input (determinism), with
+  structure assertions rather than byte-golden payloads.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from unittest.mock import patch
+
+import pytest
+
+from kicad_tools.cli.parser import create_parser
+
+# ---------------------------------------------------------------------------
+# Outer-parser surface guard
+# ---------------------------------------------------------------------------
+
+# Every subcommand swept by this batch, as (command path, minimal extra argv).
+SWEPT_SURFACES: dict[str, list[str]] = {
+    "mfr list": [],
+    "mfr info": ["jlcpcb"],
+    "mfr rules": ["jlcpcb"],
+    "mfr compare": [],
+    "mfr export-dru": ["jlcpcb"],
+    "mfr apply-rules": ["proj.kicad_pro", "jlcpcb"],
+    "mfr validate": ["b.kicad_pcb", "jlcpcb"],
+    "spec init": ["Name"],
+    "spec validate": ["p.kct"],
+    "spec status": ["p.kct"],
+    "spec decide": ["p.kct", "--topic", "t", "--choice", "c", "--rationale", "r"],
+    "spec check": ["p.kct", "item"],
+    "benchmark run": [],
+    "benchmark compare": ["--baseline", "b.json"],
+    "benchmark report": ["results.json"],
+    "zones add": ["b.kicad_pcb", "--net", "GND", "--layer", "B.Cu"],
+    "zones batch": ["b.kicad_pcb", "--power-nets", "GND:B.Cu"],
+    "zones fill": ["b.kicad_pcb"],
+    "zones hv-keepout": ["b.kicad_pcb", "--clearance", "1.0"],
+    "placement align": ["b.kicad_pcb", "--components", "R1,R2"],
+    "placement distribute": ["b.kicad_pcb", "--components", "R1,R2"],
+    "placement fix": ["b.kicad_pcb"],
+    "placement nudge": ["b.kicad_pcb"],
+    "placement snap": ["b.kicad_pcb"],
+}
+
+
+def _iter_leaves(parser, path=()):
+    subactions = [a for a in parser._actions if isinstance(a, argparse._SubParsersAction)]
+    if not subactions:
+        yield path, parser
+        return
+    for subaction in subactions:
+        for name, sub in subaction.choices.items():
+            yield from _iter_leaves(sub, (*path, name))
+
+
+@pytest.fixture(scope="module")
+def leaves():
+    return {" ".join(path): leaf for path, leaf in _iter_leaves(create_parser())}
+
+
+class TestOuterSurface:
+    @pytest.mark.parametrize("command", sorted(SWEPT_SURFACES))
+    def test_leaf_has_format_json_choice(self, leaves, command):
+        """Each swept leaf declares --format with a json choice."""
+        leaf = leaves.get(command)
+        assert leaf is not None, f"outer parser has no leaf {command!r}"
+        for action in leaf._actions:
+            if "--format" in action.option_strings:
+                assert action.choices and "json" in action.choices, (
+                    f"kct {command} has --format without a 'json' choice "
+                    f"(choices={action.choices}); regresses #4674"
+                )
+                break
+        else:
+            pytest.fail(f"kct {command} lost its --format flag (regresses #4674)")
+
+    @pytest.mark.parametrize("command", sorted(SWEPT_SURFACES))
+    def test_parse_accepts_format_json(self, command):
+        """`kct <command> ... --format json` parses on the real outer parser."""
+        argv = [*command.split(), *SWEPT_SURFACES[command], "--format", "json"]
+        args = create_parser().parse_args(argv)
+        # spec uses a prefixed dest to match its family convention.
+        attr = "spec_format" if command.startswith("spec ") else "format"
+        assert getattr(args, attr) == "json"
+
+
+# ---------------------------------------------------------------------------
+# Shim forwarding (outer --format json must reach the inner parser argv)
+# ---------------------------------------------------------------------------
+
+
+class TestShimForwarding:
+    @pytest.mark.parametrize(
+        "command",
+        [c for c in sorted(SWEPT_SURFACES) if c.startswith("mfr ")],
+    )
+    def test_mfr_shim_forwards_format(self, command):
+        from kicad_tools.cli.commands.manufacturer import run_mfr_command
+
+        argv = [*command.split(), *SWEPT_SURFACES[command], "--format", "json"]
+        args = create_parser().parse_args(argv)
+        with patch("kicad_tools.cli.mfr.main", return_value=0) as inner:
+            assert run_mfr_command(args) == 0
+        sub_argv = inner.call_args[0][0]
+        assert "--format" in sub_argv, f"mfr shim dropped --format for {command}: {sub_argv}"
+        assert sub_argv[sub_argv.index("--format") + 1] == "json"
+
+    @pytest.mark.parametrize(
+        "command",
+        [c for c in sorted(SWEPT_SURFACES) if c.startswith("zones ")],
+    )
+    def test_zones_shim_forwards_format(self, command):
+        from kicad_tools.cli.commands.routing import run_zones_command
+
+        argv = [*command.split(), *SWEPT_SURFACES[command], "--format", "json"]
+        args = create_parser().parse_args(argv)
+        with patch("kicad_tools.cli.zones_cmd.main", return_value=0) as inner:
+            assert run_zones_command(args) == 0
+        sub_argv = inner.call_args[0][0]
+        assert "--format" in sub_argv, f"zones shim dropped --format for {command}: {sub_argv}"
+        assert sub_argv[sub_argv.index("--format") + 1] == "json"
+
+    @pytest.mark.parametrize(
+        "command",
+        [c for c in sorted(SWEPT_SURFACES) if c.startswith("placement ")],
+    )
+    def test_placement_shim_forwards_format(self, command):
+        from kicad_tools.cli.commands.placement import run_placement_command
+
+        argv = [*command.split(), *SWEPT_SURFACES[command], "--format", "json"]
+        args = create_parser().parse_args(argv)
+        with patch("kicad_tools.cli.placement_cmd.main", return_value=0) as inner:
+            assert run_placement_command(args) == 0
+        sub_argv = inner.call_args[0][0]
+        assert "--format" in sub_argv, f"placement shim dropped --format for {command}: {sub_argv}"
+        assert sub_argv[sub_argv.index("--format") + 1] == "json"
+
+    def test_shims_omit_format_for_text_default(self):
+        """Default (text) invocations must not forward --format (behaviour pin)."""
+        from kicad_tools.cli.commands.manufacturer import run_mfr_command
+        from kicad_tools.cli.commands.routing import run_zones_command
+
+        args = create_parser().parse_args(["mfr", "rules", "jlcpcb"])
+        with patch("kicad_tools.cli.mfr.main", return_value=0) as inner:
+            run_mfr_command(args)
+        assert "--format" not in inner.call_args[0][0]
+
+        args = create_parser().parse_args(["zones", "fill", "b.kicad_pcb"])
+        with patch("kicad_tools.cli.zones_cmd.main", return_value=0) as inner:
+            run_zones_command(args)
+        assert "--format" not in inner.call_args[0][0]
+
+
+# ---------------------------------------------------------------------------
+# Inner mfr parser: dead --json surface retired (#4543 design note)
+# ---------------------------------------------------------------------------
+
+
+class TestMfrEmission:
+    def _run(self, argv, capsys) -> str:
+        from kicad_tools.cli.mfr import main as mfr_main
+
+        assert mfr_main(argv) in (None, 0)
+        return capsys.readouterr().out
+
+    def test_inner_rules_json_flag_retired(self):
+        """The dead inner-only ``mfr rules --json`` boolean is gone.
+
+        It was unreachable through ``kct`` (the shim never forwarded it) and
+        docs/reference/machine-output.md scheduled its retirement in favour
+        of the canonical --format json.
+        """
+        from kicad_tools.cli.mfr import main as mfr_main
+
+        with pytest.raises(SystemExit):
+            mfr_main(["rules", "jlcpcb", "--json"])
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["list"],
+            ["info", "jlcpcb"],
+            ["rules", "jlcpcb", "--layers", "4"],
+            ["compare"],
+        ],
+        ids=lambda a: a[0],
+    )
+    def test_json_is_single_deterministic_document(self, argv, capsys):
+        first = self._run([*argv, "--format", "json"], capsys)
+        second = self._run([*argv, "--format", "json"], capsys)
+        assert first == second, f"mfr {argv[0]} JSON output is not deterministic"
+        json.loads(first)  # single valid JSON document
+
+    def test_list_payload_structure(self, capsys):
+        payload = json.loads(self._run(["list", "--format", "json"], capsys))
+        assert payload["manufacturers"], "expected at least one manufacturer"
+        ids = [m["id"] for m in payload["manufacturers"]]
+        assert ids == sorted(ids), "manufacturers must be sorted for determinism"
+        assert {"id", "name", "supports_assembly", "parts_library"} <= set(
+            payload["manufacturers"][0]
+        )
+
+    def test_rules_payload_structure(self, capsys):
+        payload = json.loads(self._run(["rules", "jlcpcb", "--format", "json"], capsys))
+        assert payload["manufacturer"] == "jlcpcb"
+        assert payload["layers"] == 2  # inner default
+        assert "min_trace_width_mm" in payload["rules"]
+
+    def test_error_is_json_document(self, capsys):
+        from kicad_tools.cli.mfr import main as mfr_main
+
+        with pytest.raises(SystemExit) as excinfo:
+            mfr_main(["info", "nosuchmfr", "--format", "json"])
+        assert excinfo.value.code == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert "error" in payload
+
+    def test_text_default_is_not_json(self, capsys):
+        out = self._run(["list"], capsys)
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(out)
+
+
+# ---------------------------------------------------------------------------
+# spec family emission (self-contained handlers)
+# ---------------------------------------------------------------------------
+
+
+class TestSpecEmission:
+    def _run(self, argv, capsys) -> tuple[int, str]:
+        from kicad_tools.cli.commands.spec import run_spec_command
+
+        rc = run_spec_command(create_parser().parse_args(argv))
+        return rc, capsys.readouterr().out
+
+    def test_init_validate_status_decide_roundtrip(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        spec_file = tmp_path / "proj.kct"
+
+        rc, out = self._run(
+            ["spec", "init", "Widget", "-o", str(spec_file), "--format", "json"], capsys
+        )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload == {
+            "created": str(spec_file),
+            "name": "Widget",
+            "template": "minimal",
+        }
+
+        rc, out = self._run(["spec", "validate", str(spec_file), "--format", "json"], capsys)
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["valid"] is True
+        assert payload["errors"] == []
+
+        rc, out = self._run(["spec", "status", str(spec_file), "--format", "json"], capsys)
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["project"]["name"] == "Widget"
+        assert "phases" in payload and "completion_percent" in payload
+
+        # status must be deterministic across runs
+        rc, out2 = self._run(["spec", "status", str(spec_file), "--format", "json"], capsys)
+        assert out == out2
+
+        rc, out = self._run(
+            [
+                "spec",
+                "decide",
+                str(spec_file),
+                "--topic",
+                "Buck",
+                "--choice",
+                "LM2596",
+                "--rationale",
+                "cheap",
+                "--format",
+                "json",
+            ],
+            capsys,
+        )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["recorded"] is True
+        assert payload["topic"] == "Buck"
+
+        # the recorded decision shows up in status
+        rc, out = self._run(["spec", "status", str(spec_file), "--format", "json"], capsys)
+        assert json.loads(out)["decisions"][-1]["choice"] == "LM2596"
+
+    def test_init_existing_file_is_json_error(self, tmp_path, capsys):
+        spec_file = tmp_path / "proj.kct"
+        spec_file.write_text("existing")
+        rc, out = self._run(
+            ["spec", "init", "Widget", "-o", str(spec_file), "--format", "json"], capsys
+        )
+        assert rc == 1
+        assert "error" in json.loads(out)
+
+    def test_check_error_is_json(self, tmp_path, capsys):
+        rc, out = self._run(
+            ["spec", "check", str(tmp_path / "missing.kct"), "item", "--format", "json"],
+            capsys,
+        )
+        assert rc == 1
+        assert "error" in json.loads(out)
+
+    def test_text_default_unchanged(self, tmp_path, capsys):
+        spec_file = tmp_path / "p.kct"
+        rc, out = self._run(["spec", "init", "Widget", "-o", str(spec_file)], capsys)
+        assert rc == 0
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(out)
+
+
+# ---------------------------------------------------------------------------
+# benchmark report --format json (upgrade of the format-nojson holdout)
+# ---------------------------------------------------------------------------
+
+
+class TestBenchmarkReportJson:
+    @pytest.fixture()
+    def results_file(self, tmp_path):
+        from kicad_tools.benchmark.result import BenchmarkResult
+
+        results = {
+            "results": [
+                BenchmarkResult(
+                    case_name="charlieplex",
+                    strategy="basic",
+                    nets_total=4,
+                    nets_routed=3,
+                ).to_dict(),
+                BenchmarkResult(
+                    case_name="charlieplex",
+                    strategy="negotiated",
+                    nets_total=4,
+                    nets_routed=4,
+                ).to_dict(),
+            ]
+        }
+        path = tmp_path / "results.json"
+        path.write_text(json.dumps(results))
+        return path
+
+    def _run(self, argv, capsys) -> tuple[int, str]:
+        from kicad_tools.cli.commands.benchmark import run_benchmark_command
+
+        rc = run_benchmark_command(create_parser().parse_args(argv))
+        return rc, capsys.readouterr().out
+
+    def test_report_json_payload(self, results_file, capsys):
+        rc, out = self._run(["benchmark", "report", str(results_file), "--format", "json"], capsys)
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["input"] == str(results_file)
+        rows = payload["cases"]["charlieplex"]
+        assert [r["strategy"] for r in rows] == ["basic", "negotiated"]
+        assert rows[0]["nets_routed"] == 3
+
+    def test_report_json_deterministic(self, results_file, capsys):
+        _, first = self._run(["benchmark", "report", str(results_file), "--format", "json"], capsys)
+        _, second = self._run(
+            ["benchmark", "report", str(results_file), "--format", "json"], capsys
+        )
+        assert first == second
+
+    def test_report_missing_file_json_error(self, tmp_path, capsys):
+        rc, out = self._run(
+            ["benchmark", "report", str(tmp_path / "nope.json"), "--format", "json"], capsys
+        )
+        assert rc == 1
+        assert "error" in json.loads(out)
+
+    def test_report_text_default_unchanged(self, results_file, capsys):
+        rc, out = self._run(["benchmark", "report", str(results_file)], capsys)
+        assert rc == 0
+        assert "Routing Benchmark Report" in out
+
+
+# ---------------------------------------------------------------------------
+# zones family emission (hermetic paths)
+# ---------------------------------------------------------------------------
+
+FIXTURE_PCB = "tests/fixtures/projects/multilayer_zones.kicad_pcb"
+
+
+class TestZonesEmission:
+    def _run(self, argv, capsys) -> tuple[int, str]:
+        from kicad_tools.cli.zones_cmd import main as zones_main
+
+        rc = zones_main(argv)
+        return rc, capsys.readouterr().out
+
+    def test_add_dry_run_json(self, capsys):
+        rc, out = self._run(
+            [
+                "add",
+                FIXTURE_PCB,
+                "--net",
+                "GND",
+                "--layer",
+                "B.Cu",
+                "--dry-run",
+                "--format",
+                "json",
+            ],
+            capsys,
+        )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["zone"] == {
+            "net": "GND",
+            "layer": "B.Cu",
+            "priority": 0,
+            "clearance_mm": 0.3,
+            "boundary_points": payload["zone"]["boundary_points"],
+        }
+        assert payload["dry_run"] is True
+        assert payload["saved"] is False
+
+    def test_add_dry_run_json_deterministic(self, capsys):
+        argv = [
+            "add",
+            FIXTURE_PCB,
+            "--net",
+            "GND",
+            "--layer",
+            "B.Cu",
+            "--dry-run",
+            "--format",
+            "json",
+        ]
+        _, first = self._run(argv, capsys)
+        _, second = self._run(argv, capsys)
+        assert first == second
+
+    def test_fill_dry_run_json(self, capsys, monkeypatch):
+        import kicad_tools.cli.runner as runner_mod
+
+        monkeypatch.setattr(runner_mod, "find_kicad_cli", lambda: "/usr/bin/kicad-cli")
+        rc, out = self._run(["fill", FIXTURE_PCB, "--dry-run", "--format", "json"], capsys)
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["filled"] is False
+        assert payload["dry_run"] is True
+        assert payload["pcb"] == FIXTURE_PCB
+
+    def test_missing_file_is_json_error(self, capsys):
+        rc, out = self._run(
+            ["add", "no-such.kicad_pcb", "--net", "GND", "--layer", "B.Cu", "--format", "json"],
+            capsys,
+        )
+        assert rc == 1
+        assert "error" in json.loads(out)
+
+    def test_add_text_default_unchanged(self, capsys):
+        rc, out = self._run(
+            ["add", FIXTURE_PCB, "--net", "GND", "--layer", "B.Cu", "--dry-run"], capsys
+        )
+        assert rc == 0
+        assert "Zone created:" in out
+
+
+# ---------------------------------------------------------------------------
+# placement family emission (hermetic dry-run paths)
+# ---------------------------------------------------------------------------
+
+
+class TestPlacementEmission:
+    def _run(self, argv, capsys) -> tuple[int, str]:
+        from kicad_tools.cli.placement_cmd import main as placement_main
+
+        rc = placement_main(argv)
+        return rc, capsys.readouterr().out
+
+    def test_snap_dry_run_json(self, capsys):
+        rc, out = self._run(["snap", FIXTURE_PCB, "--dry-run", "--format", "json"], capsys)
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["dry_run"] is True
+        assert payload["grid_mm"] == 0.5
+        assert payload["components"] > 0
+        assert {"snapped", "updated", "pcb", "output"} <= set(payload)
+
+    def test_align_dry_run_json(self, capsys):
+        rc, out = self._run(
+            ["align", FIXTURE_PCB, "--components", "R1,R2", "--dry-run", "--format", "json"],
+            capsys,
+        )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["components"] == ["R1", "R2"]
+        assert payload["axis"] == "row"
+        assert "aligned" in payload
+
+    def test_nudge_dry_run_json(self, capsys):
+        rc, out = self._run(["nudge", FIXTURE_PCB, "--dry-run", "--format", "json"], capsys)
+        assert rc == 0
+        payload = json.loads(out)
+        assert {"success", "fixes_applied", "new_conflicts", "message"} <= set(payload)
+
+    def test_fix_dry_run_json(self, capsys):
+        rc, out = self._run(["fix", FIXTURE_PCB, "--dry-run", "--format", "json"], capsys)
+        assert rc == 0
+        payload = json.loads(out)
+        assert {"success", "passes", "initial_conflicts", "remaining_conflicts"} <= set(payload)
+
+    def test_missing_file_is_json_error(self, capsys):
+        rc, out = self._run(["snap", "no-such.kicad_pcb", "--format", "json"], capsys)
+        assert rc == 1
+        assert "error" in json.loads(out)


### PR DESCRIPTION
## Summary

First batch of the #4674 mechanical sweep, executing the canonical machine-output idiom decided in #4543 (PR #4718). This batch covers the **grouped-subcommand families** — the surfaces where one inner module serves a whole family — and ships 24 surfaces end-to-end plus the `benchmark report` upgrade.

**Part of #4674** (tracker stays open for the remaining backlog).

### Surfaces covered (24 new + 1 upgrade)

| Family | Subcommands | Wiring |
|---|---|---|
| `mfr` | list, info, rules, compare, export-dru, apply-rules, validate | outer parser → `commands/manufacturer.py` shim → inner `mfr.py` |
| `spec` | init, validate, status, decide, check | outer parser → self-contained `commands/spec.py` handlers |
| `placement` | fix, nudge, snap, align, distribute | outer parser → `commands/placement.py` shim → inner `placement_cmd.py` |
| `zones` | add, batch, fill, hv-keepout | outer parser → `commands/routing.py` shim → inner `zones_cmd.py` |
| `benchmark` | run, compare (new flag); **report gains a `json` choice** | outer parser → self-contained `commands/benchmark.py` handlers |

All additions use the #4718 `format_options.py` helpers (`add_format_flag`, plus a new `emit_json` helper for the single-document contract).

### Contract per docs/reference/machine-output.md

- One deterministic JSON document on stdout (sorted keys; sorted collections where source order is not meaningful).
- Prose/progress suppressed in JSON mode or routed to stderr (the `placement fix` fixer chatter was already stderr-only; verified stdout purity).
- Error paths emit `{"error": ...}` documents with **unchanged exit codes**; text-mode error text is byte-identical to before.
- Text-mode output byte-identical to before on every surface.

### Dead-surface retirement

`mfr rules --json` (inner-only, unreachable through `kct` — the dead surface called out in the design note) is **retired**, replaced by the fully-wired `--format json`. It never shipped on any reachable surface, so no alias is kept.

### Post-change audit buckets (`scripts/audit_machine_output.py` at this head)

| Bucket | Before (758b993b) | After |
|---|---|---|
| `format-json` | 124 | **148** |
| `both` (canonical + legacy alias) | 2 | 2 |
| `json-bool` | 0 | 0 |
| `format-nojson` | 1 (`benchmark report`) | **0** |
| `prose-only` | 72 | **49** |

Remaining `prose-only` = 44 actionable (16 `sch` mutating commands, `stitch`, 27 long-tail singles) + 4 exempt (`interactive`, `mcp serve`, `run`, `footprint generate`) + `route` (deferred to the route workstream per the design note's `INNER_ONLY_ALLOWLIST` decision). The design-note backlog section is updated accordingly.

### Deferred (documented on #4674)

- `sch` family (16 mutating commands — 16 separate inner modules, each needs a bespoke change-summary payload)
- `stitch` (single command but a 6k-line inner module with a multi-phase report — batch it alone)
- long-tail singles (`board-metrics`, `build`, `config`, `datasheet *`, `ipc *`, `lib create-*`, `panel`, `pipeline`, `reason`, `report generate`, `route-auto`, `screenshot`, …)

### Tests

- New `tests/test_format_json_sweep.py` (56 tests): outer-surface guard (every swept leaf keeps `--format` with a `json` choice), shim-forwarding guards for the three argv-reserializing families (the `test_cli_parser_drift.py` bug class), hermetic emission tests with determinism checks (byte-identical double runs), JSON-error-document checks, and text-default-unchanged pins.
- `tests/test_cli_parser_drift.py`: **untouched and green** (this batch touches neither the `route` nor `check` pairs; the route `--format` promotion stays deferred per the design note).
- `tests/test_machine_output_idiom.py`: green (legacy-only bucket still empty).
- Existing family suites green: test_mfr, test_spec, test_zones_cmd, test_zones_batch_priority, test_zones_hv_keepout, test_placement_nudge, test_placement_iterative_fix, test_benchmarks, test_pcb_zones, test_place_unplaced, test_cli_commands, test_alignment, test_placement, manufacturer registry/propagation/consistency, build-zones/optimize-placement/board-05 (900+ tests, 0 failures).
- `ruff check` / `ruff format --check`: clean. Mypy baseline gate: OK (no new errors; the one new-code hit was annotated away).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
