### PR TITLE
docs(releasing): add uv lock --check verification gate after version bump

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -96,6 +96,20 @@ git add pyproject.toml uv.lock CHANGELOG.md
 git commit -m "chore(release): bump version to X.Y.Z"
 ```
 
+Before pushing the branch, verify the lockfile actually matches the bumped
+version — this is the step the v0.20.0 release skipped (#4698: `uv.lock`
+stayed at 0.19.0, and every subsequent `uv` invocation dirtied every
+checkout until #4702):
+
+```bash
+uv lock --check    # must exit 0 — errors if uv.lock is stale vs pyproject.toml
+git diff --stat HEAD -- uv.lock   # expect no output (already committed above)
+```
+
+CI will **not** catch a stale lockfile: every CI job installs with
+`uv sync --frozen`, which trusts the lockfile without checking it against
+`pyproject.toml`. This local check is the only gate.
+
 ### (b) Open a pull request
 
 ```bash
@@ -230,7 +244,10 @@ above; no runner infrastructure is maintained for this repo.
 
 - [ ] `uv run python scripts/changelog_gap_report.py` exits 0 with an empty gap
       set (step (0)) — run this *before* the bump commit.
-- [ ] Version bumped in `pyproject.toml`; `uv.lock` regenerated to match.
+- [ ] Version bumped in `pyproject.toml`; `uv lock` run and the regenerated
+      `uv.lock` committed **in the same bump commit**.
+- [ ] `uv lock --check` exits 0 on the release branch before the PR is opened
+      (CI's `uv sync --frozen` will NOT catch a stale lockfile — #4698).
 - [ ] CHANGELOG entry added for `X.Y.Z`.
 - [ ] Confirmed `pyproject.toml` is authoritative (ignore the `package.json`
       npm misdetection in `/repo:release` Phase 2).


### PR DESCRIPTION
Closes #4731

## Summary

Docs-only change to `RELEASING.md`, per the Curator Enhancement on #4731:

- **Step (a)**: after the bump/commit code block, add a verification paragraph with a `uv lock --check` + `git diff --stat HEAD -- uv.lock` bash block, citing the #4698 incident (v0.20.0 bump merged with a stale `uv.lock`, dirtying every checkout until #4702) and noting that CI's `uv sync --frozen` cannot catch a stale lockfile.
- **Quick checklist**: split the bundled "bumped; regenerated" item into two checkboxes — (1) `uv lock` run and `uv.lock` committed in the same bump commit, (2) `uv lock --check` exits 0 before the PR is opened.

## Verification

- `uv lock --check` run in the worktree: exits 0 (the documented command is runnable as written).
- `git status --porcelain` shows only `RELEASING.md` modified (18 insertions, 1 deletion — matches the issue's expected diff shape).
- Fenced bash block and checklist markdown confirmed well-formed.
- No workflow/script edits (CI guard explicitly out of scope per the issue).