### PR TITLE
docs: point sidecar consumers at net_class_map_from_path (canonical loader, #4683)

### DIFF
--- a/docs/guides/drc-and-validation.md
+++ b/docs/guides/drc-and-validation.md
@@ -122,7 +122,20 @@ next to their routed PCB as `output/net_class_map.json` (see board 07's
 flag — that is the entire difference between its in-pipeline error count and
 a bare CLI run). The sidecar is produced from the board's
 `build_net_class_map()` via `net_class_map_to_dict` and consumed via
-`net_class_map_from_dict`.
+`net_class_map_from_path` (`kicad_tools.router.rules`), the canonical
+loader every consumer shares (#4683). The loader pairs "parse the sidecar"
+with "resolve the board's layer stack", so a sidecar accepted by one
+consumer is accepted by all of them. Stack-resolution precedence: an
+explicit `layer_stack` argument, else `pcb_text` (raw board contents), else
+`pcb_path` (read best-effort), else the map is parsed with
+`layer_stack=None` — stack-independent tokens like `F.Cu` / `In<k>.Cu`
+still resolve, while `B.Cu` (whose index depends on the copper count) fails
+loud rather than guessing. A well-formed copper-layer name absent from the
+*active* stack (e.g. an inner layer named in `avoid_layers` during a
+`--layers 2` pass) is treated as a vacuously satisfied constraint and
+dropped rather than rejecting the sidecar — silently for `avoid_layers`,
+with a one-line warning for `preferred_layers` (#4685, #4709). Malformed
+tokens (`Bogus.Cu`) remain fatal.
 
 **Auto-discovery.** When `--net-class-map` is omitted, `kct check` probes for a
 sidecar next to the board. Two filename conventions are accepted — the

--- a/docs/guides/match-groups/07-cli-and-sidecar.md
+++ b/docs/guides/match-groups/07-cli-and-sidecar.md
@@ -55,7 +55,7 @@ with open("net_class_map.json", "w") as f:
     json.dump(sidecar, f, indent=2)
 ```
 
-`net_class_map_to_dict` is at `src/kicad_tools/router/rules.py:1021`.
+`net_class_map_to_dict` lives in `src/kicad_tools/router/rules.py`.
 Board 03 (`boards/03-usb-joystick/generate_design.py`) is the
 canonical emitter; board 07 follows the same pattern.
 


### PR DESCRIPTION
Closes #4734

## Summary

Docs-only fix. `docs/guides/drc-and-validation.md` still told readers the net-class-map sidecar is consumed via `net_class_map_from_dict` — since #4704 that is a low-level dict parser behind the canonical loader `net_class_map_from_path`, and a structural guard test forbids new direct `src/` call sites.

## Changes

- **`docs/guides/drc-and-validation.md`** — the Sidecar-convention paragraph now names `net_class_map_from_path` (`kicad_tools.router.rules`) as the consuming API and documents its shipping semantics, verified against the `rules.py` docstring/code at `79ae8e2b`:
  - stack-resolution precedence: explicit `layer_stack` > `pcb_text` > `pcb_path`, best-effort degradation to `layer_stack=None` (`F.Cu` / `In<k>.Cu` still resolve; `B.Cu` fails loud)
  - absent-from-active-stack tolerance (#4685/#4709): a well-formed copper name not in the supplied stack is a vacuously satisfied constraint and dropped — **silently for `avoid_layers`, with a one-line warning for `preferred_layers`** (the issue prose said "dropped with a warning" for the `avoid_layers` example; the code drops `avoid_layers` silently — `on_absent=\"drop\"` vs `\"drop_warn\"` in `NetClassRouting.from_dict` — so the doc states the actual per-field behavior); malformed tokens (`Bogus.Cu`) remain fatal
- **`docs/guides/match-groups/07-cli-and-sidecar.md`** — optional in-scope tidy from the issue: dropped the rotted `rules.py:1021` line-number citation (function is now at ~1805) in favor of a durable plain file reference

## Verification

- `git grep -n net_class_map_from_dict docs/` → no matches
- `uv run pytest tests/test_match_group_docs.py` (drift-guard for the edited match-groups guide) → 6 passed
- No behavior/code changes