### PR TITLE
test(pcb-sync): keep board-05 netlist byproduct out of tests/fixtures

### DIFF
--- a/tests/test_pcb_sync_netlist.py
+++ b/tests/test_pcb_sync_netlist.py
@@ -2790,8 +2790,16 @@ class TestBoard05SyncDriftRegression:
         dst_pcb = tmp_path / "bldc_controller_synced.kicad_pcb"
         shutil.copy(_BOARD_05_PCB, dst_pcb)
 
+        # Copy the schematic into tmp_path too: sync_netlist's kicad-cli
+        # path writes ``<stem>-netlist.kicad_net`` next to the schematic
+        # it is given, and passing the fixture-dir schematic directly
+        # would leave that untracked byproduct in tests/fixtures/ (#4735).
+        # The schematic is flat (single file), so one copy suffices.
+        dst_sch = tmp_path / "bldc_controller.kicad_sch"
+        shutil.copy(_BOARD_05_SCH, dst_sch)
+
         result = sync_netlist(
-            schematic_path=_BOARD_05_SCH,
+            schematic_path=dst_sch,
             pcb_path=dst_pcb,
             dry_run=False,
             remove_orphan_nets=True,


### PR DESCRIPTION
Closes #4735

## Summary

The `synced_pcb` fixture in `TestBoard05SyncDriftRegression` passed the fixture-dir schematic (`tests/fixtures/board05_sync_drift/bldc_controller.kicad_sch`) straight into `sync_netlist`. On machines with kicad-cli installed, `export_netlist` defaults its output path to `<schematic dir>/<stem>-netlist.kicad_net`, so every run left an untracked `bldc_controller-netlist.kicad_net` in `tests/fixtures/` — recurring `git status` noise that tripped clean-tree checks in multiple sweep sessions (#4714, #4710, #4728).

Fix (Option A from the Curator Enhancement, test-only): copy the schematic into `tmp_path` alongside the existing PCB copy and pass the copy to `sync_netlist`. The byproduct now lands in `tmp_path` and is cleaned up by pytest. The schematic is flat/single-file, so one copy suffices. The frozen fixture pair (`bldc_controller.kicad_sch`, `bldc_controller_drifted.kicad_pcb`, pinned from `9f11c3ab` / #3521) is untouched. The library-level alternative (threading `output_path` through `_assign_nets_from_schematic`) is intentionally out of scope per the issue.

## Test evidence (kicad-cli present locally, so the write path was exercised)

- `uv run pytest tests/test_pcb_sync_netlist.py -x -q` — **135 passed** (1:42)
- `git status --porcelain tests/fixtures/` after the run — **empty** (acceptance criterion)
- Board05 subset run twice back-to-back — 4 passed both times (no dependence on a pre-existing netlist)
- `ruff check` + `ruff format --check` on the changed file — clean
- Fixture directory contains only the two frozen files after all runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)