### PR TITLE
fix(cli): auto-skipped pour nets join the --net-class-map resolution domain (#4688)

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -3867,28 +3867,37 @@ def _preserved_net_names(router: "Autorouter", exclude: "set[str]") -> list[str]
 
 
 def _resolve_net_class_map_domains(
-    router: "Autorouter", user_keys
-) -> "tuple[NetClassMapResolution, list[str]]":
-    """Resolve sidecar keys against the routable *then* the preserved domain.
+    router: "Autorouter", user_keys, auto_skipped_names: "list[str] | None" = None
+) -> "tuple[NetClassMapResolution, list[str], int]":
+    """Resolve sidecar keys against the routable, preserved, then pour domains.
 
-    Returns the merged :class:`NetClassMapResolution` plus the union of both
-    name domains (for the nearest-name hints in the unresolved diagnostic).
+    Returns the merged :class:`NetClassMapResolution`, the union of the name
+    domains (for the nearest-name hints in the unresolved diagnostic), and
+    the number of keys resolved in phase 3 (for the summary-line annotation).
 
-    **Two-phase and strictly additive** (Issue #4622).  Phase 1 resolves every
-    key against ``router.net_names`` exactly as before.  Phase 2 re-resolves
-    *only* the keys phase 1 left unmatched, against the preserved-only names.
+    **Multi-phase and strictly additive** (Issues #4622, #4688).  Phase 1
+    resolves every key against ``router.net_names`` exactly as before.
+    Phase 2 re-resolves *only* the keys phase 1 left unmatched, against the
+    preserved-only names.  Phase 3 (Issue #4688) re-resolves the keys still
+    unmatched after phases 1-2 against ``auto_skipped_names`` — the exact
+    board net names ``_auto_skip_pour_nets`` removed from routing (pour nets
+    satisfied by zones, plus ``route_via="manual"`` nets).  Those nets carry
+    only zone copper, so they enter neither ``router.net_names`` nor
+    ``router.existing_routes`` and previously produced false "no similar
+    board net found" warnings for GND / +3.3V on every board with pours.
 
-    A naive union of the two domains would be one line shorter and would also
+    A naive union of the domains would be one line shorter and would also
     make the reported repro pass, but it is wrong: :func:`resolve_net_key`
     matches on the suffix after the last ``/``, so a union can make a
     currently-**resolved** key **ambiguous** — routable ``/HV/LINE`` plus
     preserved ``/LV/LINE`` turns a bare ``LINE`` key ambiguous, and ambiguous
     keys are deliberately applied to *neither* candidate.  That would silently
     drop the clearance of a net that *is* being routed this pass: a new
-    instance of the very bug class this fixes.  Two-phase cannot do that,
-    because a key that resolved in phase 1 never reaches phase 2.
+    instance of the very bug class this fixes.  The phased scheme cannot do
+    that, because a key that resolved in an earlier phase never reaches a
+    later one.
 
-    A key matching no net in *either* domain still lands in ``unmatched``, so
+    A key matching no net in *any* domain still lands in ``unmatched``, so
     genuine typos keep producing the (never ``--quiet``-suppressed) warning.
     """
     from kicad_tools.router.net_names import (
@@ -3897,21 +3906,39 @@ def _resolve_net_class_map_domains(
     )
 
     routable_names = list(router.net_names.values())
-    primary = resolve_net_class_map_keys(user_keys, routable_names)
+    resolution = resolve_net_class_map_keys(user_keys, routable_names)
 
     preserved_names = _preserved_net_names(router, set(routable_names))
-    if not preserved_names or not primary.unmatched:
-        return primary, routable_names
+    if preserved_names and resolution.unmatched:
+        secondary = resolve_net_class_map_keys(resolution.unmatched, preserved_names)
+        resolution = NetClassMapResolution(
+            # Domains are disjoint by construction, so no resolved board net
+            # can be claimed by two phases.
+            resolved={**resolution.resolved, **secondary.resolved},
+            unmatched=list(secondary.unmatched),
+            ambiguous={**resolution.ambiguous, **secondary.ambiguous},
+        )
 
-    secondary = resolve_net_class_map_keys(primary.unmatched, preserved_names)
-    merged = NetClassMapResolution(
-        # Domains are disjoint by construction, so no resolved board net can
-        # be claimed by both phases.
-        resolved={**primary.resolved, **secondary.resolved},
-        unmatched=list(secondary.unmatched),
-        ambiguous={**primary.ambiguous, **secondary.ambiguous},
-    )
-    return merged, routable_names + preserved_names
+    # Phase 3 (Issue #4688): auto-skipped pour/manual net names, minus any
+    # already covered by the earlier domains (keeps the domains disjoint,
+    # preserving the additive argument above) and deduplicated defensively.
+    covered = set(routable_names) | set(preserved_names)
+    skipped_domain: list[str] = []
+    for name in auto_skipped_names or []:
+        if name and name not in covered and name not in skipped_domain:
+            skipped_domain.append(name)
+
+    pour_matched = 0
+    if skipped_domain and resolution.unmatched:
+        tertiary = resolve_net_class_map_keys(resolution.unmatched, skipped_domain)
+        pour_matched = len(tertiary.resolved)
+        resolution = NetClassMapResolution(
+            resolved={**resolution.resolved, **tertiary.resolved},
+            unmatched=list(tertiary.unmatched),
+            ambiguous={**resolution.ambiguous, **tertiary.ambiguous},
+        )
+
+    return resolution, routable_names + preserved_names + skipped_domain, pour_matched
 
 
 def _apply_net_class_map_sidecar(router: "Autorouter", args, quiet: bool = False) -> None:
@@ -3947,13 +3974,26 @@ def _apply_net_class_map_sidecar(router: "Autorouter", args, quiet: bool = False
     widened with the net names carried by ``router.existing_routes`` using a
     **two-phase, additive** scheme (see :func:`_resolve_net_class_map_domains`).
 
+    Issue #4688: auto-skipped pour nets (zone-satisfied ``GND`` / ``+3.3V``
+    and ``route_via="manual"`` nets) have *only* zone copper, so they appear
+    in neither domain above and their exact-name sidecar keys false-positived
+    the misconfiguration warning.  A third resolution phase over
+    ``args._auto_skipped_net_names`` (stashed at the ``_auto_skip_pour_nets``
+    call sites) fixes that.  Phase-3-resolved keys ARE merged into
+    ``router.net_class_map``: harmless for routing (the nets' pads are
+    rewritten to net 0) and it lets downstream consumers — notably
+    post-route DRC via ``run_post_route_drc(net_class_map=...)`` — see the
+    pour nets' ``clearance`` / ``zone_connection`` overrides.
+
     Idempotent and a no-op when the flag was not supplied.
     """
     loaded = getattr(args, "_loaded_net_class_map", None)
     if loaded:
         from kicad_tools.router.net_names import nearest_net_names
 
-        resolution, diagnostic_net_names = _resolve_net_class_map_domains(router, loaded.keys())
+        resolution, diagnostic_net_names, pour_matched = _resolve_net_class_map_domains(
+            router, loaded.keys(), getattr(args, "_auto_skipped_net_names", None)
+        )
 
         # Apply overrides rekeyed to the board's actual net names so
         # ``self.net_class_map.get(net_name)`` finds them at routing time.
@@ -3965,9 +4005,15 @@ def _apply_net_class_map_sidecar(router: "Autorouter", args, quiet: bool = False
         if not quiet:
             from kicad_tools.cli.progress import flush_print
 
+            pour_note = (
+                f" ({pour_matched} appl{'ies' if pour_matched == 1 else 'y'} "
+                "to auto-skipped pour nets)"
+                if pour_matched
+                else ""
+            )
             flush_print(
                 f"  Net-class map: merged {len(resolution.resolved)}/{resolution.total} "
-                "sidecar entries"
+                f"sidecar entries{pour_note}"
             )
 
     # Issue #4605: stash the ``spatial_keepouts`` rule-area filter block on
@@ -4977,6 +5023,10 @@ def route_with_layer_escalation(
 
     # Auto-classify pour nets and extend skip_nets
     _skipped, _no_zone = _auto_skip_pour_nets(pcb_path, skip_nets, quiet=quiet)
+    # Issue #4688: stash the auto-skipped names (exact board net names) so the
+    # --net-class-map resolver's phase 3 can match sidecar keys naming them —
+    # they enter neither router.net_names nor router.existing_routes.
+    args._auto_skipped_net_names = list(_skipped)
 
     # Issue #3155: capture preserved copper ONCE from the staged input before
     # any routing or checkpoint write mutates it.  The escalation loop below
@@ -6055,6 +6105,10 @@ def route_with_rule_relaxation(
 
     # Auto-classify pour nets and extend skip_nets
     _skipped, _no_zone = _auto_skip_pour_nets(pcb_path, skip_nets, quiet=quiet)
+    # Issue #4688: stash the auto-skipped names (exact board net names) so the
+    # --net-class-map resolver's phase 3 can match sidecar keys naming them —
+    # they enter neither router.net_names nor router.existing_routes.
+    args._auto_skipped_net_names = list(_skipped)
 
     # Get relaxation tiers
     tiers = get_relaxation_tiers(
@@ -8196,6 +8250,10 @@ def route_with_combined_escalation(
 
     # Auto-classify pour nets and extend skip_nets
     _skipped, _no_zone = _auto_skip_pour_nets(pcb_path, skip_nets, quiet=quiet)
+    # Issue #4688: stash the auto-skipped names (exact board net names) so the
+    # --net-class-map resolver's phase 3 can match sidecar keys naming them —
+    # they enter neither router.net_names nor router.existing_routes.
+    args._auto_skipped_net_names = list(_skipped)
 
     # Get relaxation tiers
     tiers = get_relaxation_tiers(
@@ -12586,6 +12644,10 @@ def _main_impl(argv: list[str] | None = None) -> int:
 
     # Auto-classify pour nets and extend skip_nets
     _skipped, _no_zone = _auto_skip_pour_nets(pcb_path, skip_nets, quiet=args.quiet)
+    # Issue #4688: stash the auto-skipped names (exact board net names) so the
+    # --net-class-map resolver's phase 3 can match sidecar keys naming them —
+    # they enter neither router.net_names nor router.existing_routes.
+    args._auto_skipped_net_names = list(_skipped)
 
     # Issue #3155: capture preserved copper once before routing/checkpoints.
     _preserve = bool(getattr(args, "preserve_existing", False))

--- a/tests/test_cli_route_net_class_map.py
+++ b/tests/test_cli_route_net_class_map.py
@@ -771,6 +771,274 @@ class TestPreservedNetResolutionDomain:
 
 
 # =============================================================================
+# Issue #4688: auto-skipped pour nets join the resolution domain (phase 3)
+# =============================================================================
+
+
+class TestAutoSkippedPourNetResolutionDomain:
+    """Sidecar keys naming AUTO-SKIPPED pour nets must not false-positive.
+
+    ``_auto_skip_pour_nets`` removes zone-satisfied pour nets (``GND``,
+    ``+3.3V``) from routing before the router loads, so those nets enter
+    neither ``router.net_names`` (their pads are rewritten to net 0) nor
+    ``router.existing_routes`` (they have zone copper, not route copper).
+    The two-phase #4622 resolver therefore reported their exact-name sidecar
+    keys as unmatched — ``'GND' -> nearest board net(s): /PGND`` — crying
+    wolf on the two most important power nets of every board with pours.
+
+    The fix is a strictly additive **phase 3** over the auto-skipped names
+    stashed on ``args._auto_skipped_net_names`` (mirrors
+    :class:`TestPreservedNetResolutionDomain`, the #4622 twin).
+    """
+
+    def test_auto_skipped_pour_key_resolves_without_warning(self, capsys):
+        """The reported defect: exact-name pour keys no longer warn."""
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        router = _stub_router({1: "/FUSED_LINE", 2: "/PGND"})
+        loaded = {
+            "GND": _sidecar_entry("Power", clearance=0.3),
+            "+3.3V": _sidecar_entry("Power", clearance=0.3),
+        }
+        args = SimpleNamespace(
+            _loaded_net_class_map=loaded,
+            _auto_skipped_net_names=["+3.3V", "GND"],
+        )
+
+        _apply_net_class_map_sidecar(router, args, quiet=True)
+
+        # Merge disposition: phase-3 keys ARE rekeyed into router.net_class_map
+        # so post-route DRC sees the pour nets' overrides.
+        assert router.net_class_map["GND"].clearance == pytest.approx(0.3)
+        assert router.net_class_map["+3.3V"].clearance == pytest.approx(0.3)
+        err = capsys.readouterr().err
+        assert "WARNING" not in err
+        assert "GND" not in err
+
+    def test_merged_count_includes_pour_matches(self, capsys):
+        """The ``merged N/M`` numerator counts phase-3 matches + annotates."""
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        router = _stub_router({1: "/FUSED_LINE"})
+        loaded = {
+            "FUSED_LINE": _sidecar_entry("HV", clearance=1.0),
+            "GND": _sidecar_entry("Power", clearance=0.3),
+            "+3.3V": _sidecar_entry("Power", clearance=0.3),
+        }
+        args = SimpleNamespace(
+            _loaded_net_class_map=loaded,
+            _auto_skipped_net_names=["GND", "+3.3V"],
+        )
+
+        _apply_net_class_map_sidecar(router, args, quiet=False)
+
+        out = capsys.readouterr()
+        assert "merged 3/3 sidecar entries" in out.out
+        assert "(2 apply to auto-skipped pour nets)" in out.out
+        assert "WARNING" not in out.err
+
+    def test_single_pour_match_annotation_grammar(self, capsys):
+        """One phase-3 match reads ``1 applies``, not ``1 apply``."""
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        router = _stub_router({1: "/FUSED_LINE"})
+        loaded = {"GND": _sidecar_entry("Power", clearance=0.3)}
+        args = SimpleNamespace(
+            _loaded_net_class_map=loaded,
+            _auto_skipped_net_names=["GND"],
+        )
+
+        _apply_net_class_map_sidecar(router, args, quiet=False)
+
+        assert "(1 applies to auto-skipped pour nets)" in capsys.readouterr().out
+
+    def test_key_matching_no_domain_still_warns_under_quiet(self, capsys):
+        """Rev-B protection: a genuine typo still warns, even with --quiet."""
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        router = _stub_router({1: "/FUSED_LINE"})
+        loaded = {
+            "GND": _sidecar_entry("Power", clearance=0.3),
+            "LINE_TYPO": _sidecar_entry("HV", clearance=1.0),
+        }
+        args = SimpleNamespace(
+            _loaded_net_class_map=loaded,
+            _auto_skipped_net_names=["GND"],
+        )
+
+        # quiet=True is the softstart-rev-B condition: the warning must
+        # still reach stderr even with --quiet.
+        _apply_net_class_map_sidecar(router, args, quiet=True)
+
+        assert "LINE_TYPO" not in router.net_class_map
+        err = capsys.readouterr().err
+        assert "WARNING" in err
+        assert "1/2 entries matched" in err
+        assert "LINE_TYPO" in err
+        # The resolved pour key no longer consumes a hint slot.
+        assert "'GND'" not in err
+
+    def test_unmatched_hint_can_name_a_pour_net(self, capsys):
+        """Nearest-name hints draw on the pour domain too."""
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        router = _stub_router({1: "/FUSED_LINE"})
+        loaded = {"PGND": _sidecar_entry("Power", clearance=0.3)}  # typo-ish
+        args = SimpleNamespace(
+            _loaded_net_class_map=loaded,
+            _auto_skipped_net_names=["GND"],
+        )
+
+        _apply_net_class_map_sidecar(router, args, quiet=True)
+
+        err = capsys.readouterr().err
+        assert "0/1 entries matched" in err
+        assert "GND" in err
+
+    def test_suffix_collision_does_not_regress_routable_match(self, capsys):
+        """Additive guard: a phase-1 match cannot become ambiguous.
+
+        A naive union of routable ``/HV/LINE`` and auto-skipped ``/LV/LINE``
+        would turn the bare key ``LINE`` ambiguous and apply it to NEITHER —
+        silently dropping the clearance of a net that IS being routed.
+        Phase 3 only sees keys phases 1-2 left unmatched.
+        """
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        router = _stub_router({1: "/HV/LINE"})
+        loaded = {"LINE": _sidecar_entry("HV", clearance=2.0)}
+        args = SimpleNamespace(
+            _loaded_net_class_map=loaded,
+            _auto_skipped_net_names=["/LV/LINE"],
+        )
+
+        _apply_net_class_map_sidecar(router, args, quiet=True)
+
+        assert router.net_class_map["/HV/LINE"].clearance == pytest.approx(2.0)
+        assert "/LV/LINE" not in router.net_class_map
+        err = capsys.readouterr().err
+        assert "AMBIGUOUS" not in err
+        assert "WARNING" not in err
+
+    def test_suffix_collision_does_not_regress_preserved_match(self, capsys):
+        """Same additive guard for a phase-2 (preserved) match."""
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        router = _stub_router_with_preserved({5: "NODE_A"}, {1: "/HV/LINE"})
+        loaded = {"LINE": _sidecar_entry("HV", clearance=2.0)}
+        args = SimpleNamespace(
+            _loaded_net_class_map=loaded,
+            _auto_skipped_net_names=["/LV/LINE"],
+        )
+
+        _apply_net_class_map_sidecar(router, args, quiet=True)
+
+        assert router.net_class_map["/HV/LINE"].clearance == pytest.approx(2.0)
+        err = capsys.readouterr().err
+        assert "AMBIGUOUS" not in err
+        assert "WARNING" not in err
+
+    @pytest.mark.parametrize("placement", ["routable", "preserved", "auto_skipped"])
+    def test_exact_name_key_never_unmatched(self, placement, capsys):
+        """Invariant (issue suggestion 3): a key byte-equal to a board net
+        name never lands in ``unmatched`` when that net is routable,
+        preserved, or auto-skipped."""
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        name = "+3.3V"
+        routable = {1: name} if placement == "routable" else {1: "/OTHER"}
+        preserved = {2: name} if placement == "preserved" else {}
+        skipped = [name] if placement == "auto_skipped" else []
+        router = _stub_router_with_preserved(routable, preserved)
+        loaded = {name: _sidecar_entry("Power", clearance=0.3)}
+        args = SimpleNamespace(
+            _loaded_net_class_map=loaded,
+            _auto_skipped_net_names=skipped,
+        )
+
+        _apply_net_class_map_sidecar(router, args, quiet=True)
+
+        assert router.net_class_map[name].clearance == pytest.approx(0.3)
+        assert "WARNING" not in capsys.readouterr().err
+
+    def test_ambiguous_within_pour_domain_applied_to_neither(self, capsys):
+        """A key ambiguous among POUR nets is still applied to neither."""
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        router = _stub_router({5: "NODE_A"})
+        loaded = {"GND": _sidecar_entry("Power", clearance=0.3)}
+        args = SimpleNamespace(
+            _loaded_net_class_map=loaded,
+            _auto_skipped_net_names=["/A/GND", "/B/GND"],
+        )
+
+        _apply_net_class_map_sidecar(router, args, quiet=True)
+
+        assert "/A/GND" not in router.net_class_map
+        assert "/B/GND" not in router.net_class_map
+        err = capsys.readouterr().err
+        assert "AMBIGUOUS" in err
+        assert "0/1 entries matched" in err
+
+    def test_absent_attribute_is_a_no_op(self, capsys):
+        """A router path that never stashed the attribute behaves as before."""
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        router = _stub_router({1: "/FUSED_LINE"})
+        loaded = {
+            "FUSED_LINE": _sidecar_entry("Heavy", priority=5),
+            "GND": _sidecar_entry("Power", clearance=0.3),
+        }
+        args = SimpleNamespace(_loaded_net_class_map=loaded)  # no stash
+
+        _apply_net_class_map_sidecar(router, args, quiet=True)
+
+        assert router.net_class_map["/FUSED_LINE"].priority == 5
+        err = capsys.readouterr().err
+        assert "1/2 entries matched" in err
+        assert "'GND'" in err
+
+    def test_empty_list_is_a_no_op(self, capsys):
+        """A board with zero pour nets: phase-3 domain empty, output unchanged."""
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        router = _stub_router({1: "/FUSED_LINE"})
+        loaded = {"FUSED_LINE": _sidecar_entry("Heavy", priority=5)}
+        args = SimpleNamespace(
+            _loaded_net_class_map=loaded,
+            _auto_skipped_net_names=[],
+        )
+
+        _apply_net_class_map_sidecar(router, args, quiet=False)
+
+        out = capsys.readouterr()
+        assert router.net_class_map["/FUSED_LINE"].priority == 5
+        assert "merged 1/1 sidecar entries" in out.out
+        assert "apply to auto-skipped pour nets" not in out.out
+        assert "WARNING" not in out.err
+
+    def test_pour_name_overlapping_earlier_domain_is_dropped(self, capsys):
+        """A name in both an earlier domain and the stash resolves once."""
+        from kicad_tools.cli.route_cmd import _apply_net_class_map_sidecar
+
+        router = _stub_router({1: "GND"})
+        loaded = {"GND": _sidecar_entry("Power", clearance=0.3)}
+        args = SimpleNamespace(
+            _loaded_net_class_map=loaded,
+            _auto_skipped_net_names=["GND"],
+        )
+
+        _apply_net_class_map_sidecar(router, args, quiet=False)
+
+        out = capsys.readouterr()
+        assert router.net_class_map["GND"].clearance == pytest.approx(0.3)
+        assert "merged 1/1 sidecar entries" in out.out
+        # Resolved in phase 1, so no pour annotation.
+        assert "apply to auto-skipped pour nets" not in out.out
+        assert "WARNING" not in out.err
+
+
+# =============================================================================
 # Issue #4587: KiCad layer NAMES in the sidecar resolve at preload
 # =============================================================================
 


### PR DESCRIPTION
Closes #4688

## Summary

`kct route` resolved `--net-class-map` sidecar keys against `router.net_names` (phase 1) and the preserved-copper names from `router.existing_routes` (phase 2, #4622). Auto-skipped pour nets (`GND`, `+3.3V`) carry only **zone** copper — that is exactly why they were auto-skipped — so they appeared in neither domain and their exact-name keys landed in `unmatched`, producing the reported false positives (`'GND' -> nearest board net(s): /PGND`, `97/118` instead of `99/118`) and consuming `max_hints = 12` slots that genuine typos need.

Per the Curator's recommended approach (the issue's option 2, done in the #4622 additive style — NOT the naive full-net-list union, which could turn an already-resolved key ambiguous via suffix matching and silently drop a routed net's clearance):

- The four `_auto_skip_pour_nets` call sites (layer escalation `route_with_layer_escalation`, rule relaxation `route_with_rule_relaxation`, combined escalation `route_with_combined_escalation`, and standalone `main()`) now stash the returned exact board net names on `args._auto_skipped_net_names`. The stash in `main()` happens before both `_apply_net_class_map_sidecar` call sites there (`:12811` initial load and `:12866` fresh re-load), so all engine paths and re-load sites are covered.
- `_resolve_net_class_map_domains` gains a **phase 3**: only the keys phases 1-2 left unmatched are re-resolved against the auto-skipped names (deduplicated, and names already in an earlier domain removed, keeping the domains disjoint so the additive no-new-ambiguity argument holds unchanged).
- Phase-3 matches leave `unmatched` (no warning line, no hint-slot consumption), count in the `merged M/N` numerator, and the summary line is annotated `(K apply to auto-skipped pour nets)` when K > 0.
- Nearest-name hints for genuinely-unmatched keys now draw on the pour domain too.

## Merge disposition for `router.net_class_map` (the issue's "Worth confirming separately")

**Phase-3-resolved keys ARE merged into `router.net_class_map`**, rekeyed to the board net name, exactly like phase-1/2 matches. This is harmless for routing (the auto-skipped nets' pads are rewritten to net 0, so the router never looks them up) and it means downstream consumers of `router.net_class_map` — notably post-route DRC via `run_post_route_drc(net_class_map=...)` at `route_cmd.py:~5900` — now see the pour nets' `clearance` / `zone_connection` / `is_pour_net` sidecar overrides instead of silently losing them. Zone *creation* was never affected (`auto_pour_if_missing` classifies by name pattern before the sidecar merge), and the raw sidecar threading for the #4428 derived-sidecar writer (`args._loaded_net_class_map`) is untouched.

## Rev-B protection (unchanged)

- A key matching **no** domain (routable, preserved, or auto-skipped) still warns, still with nearest-name hints, still on stderr, still never suppressed by `--quiet`. The `_warn_unresolved_net_class_map` docstring contract is untouched.
- Pre-existing guards `test_key_matching_neither_domain_still_warns` and `test_warning_not_suppressed_by_quiet` pass unmodified, and the new class re-asserts the typo-still-warns-under-quiet condition with a pour domain present.

## Known residual gap (out of scope, per the Curator)

In `--nets` route-only mode `skip_nets` is the large inverted set (#4322), so a pour net is already in `skip_nets` before `_auto_skip_pour_nets` runs and is absent from the returned auto-skip list — the warning can still fire for it there. Widening phase 3 to the whole `skip_nets` list would put user-typed `--skip-nets` strings into a resolution domain; that trade-off deserves its own issue if it bites.

## Tests

New class `TestAutoSkippedPourNetResolutionDomain` (12 tests, modeled on `TestPreservedNetResolutionDomain`) in `tests/test_cli_route_net_class_map.py`:

- reporter's repro: exact-name pour keys resolve, no warning, merged into `router.net_class_map`
- `merged M/N` counts phase-3 matches + annotation (plus 1-vs-many grammar)
- typo still warns under `quiet=True` (rev-B guard) and no longer shares hint slots with pour keys
- unmatched-key hints can name a pour net
- suffix-collision additive guards for both phase-1 and phase-2 matches (bare `LINE` vs routable/preserved `/HV/LINE` + auto-skipped `/LV/LINE` does NOT go ambiguous)
- parametrized invariant (issue suggestion 3): a key byte-equal to a board net name never lands in `unmatched` when the net is routable, preserved, or auto-skipped
- ambiguity within the pour domain applied to neither
- absent stash attribute / empty list / overlap-with-earlier-domain no-ops

## Evidence

- `uv run pytest tests/test_cli_route_net_class_map.py -q` — **75 passed** (63 pre-existing + 12 new)
- `uv run pytest tests/test_net_names.py -q` — **24 passed**
- `uv run ruff check` + `ruff format --check` on both changed files — clean
- `uv run python scripts/ci/check_mypy_baseline.py` — OK, no new type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)