### PR TITLE
polish: LVS vacuous summary, transaction sidecar announcement, justify residue, benchmark error formatting (#4736)

### DIFF
--- a/src/kicad_tools/lvs/recipe.py
+++ b/src/kicad_tools/lvs/recipe.py
@@ -424,6 +424,16 @@ def _print_summary(
     if run_label and label_result is not None:
         if label_result.clean:
             print(f"\n   label-LVS PASS: 0 mismatches ({lvs_path.name})")
+        elif label_result.vacuous:
+            # Mirror the copper leg's dedicated VACUOUS line (#4736): the
+            # generic FAIL formatter would render the single synthetic
+            # ``<vacuous>`` record as a misleading "1 mismatch(es)".
+            print(
+                "\n   label-LVS VACUOUS (treated as FAIL): PCB binds 0 pins "
+                "-- no mismatches are detectable, so 'clean' would be "
+                "zero-evidence (#4681 guard).  Wire the board's pads to "
+                "nets or skip the LVS step explicitly."
+            )
         else:
             print(f"\n   label-LVS FAIL: {len(label_result.mismatches)} mismatch(es):")
             for lm in label_result.mismatches[:5]:

--- a/src/kicad_tools/recovery/applicator.py
+++ b/src/kicad_tools/recovery/applicator.py
@@ -472,6 +472,13 @@ class StrategyApplicator:
                     justify.children = [
                         c for c in justify.children if not (c.is_atom and c.value == "mirror")
                     ]
+                    if not justify.children:
+                        # Un-mirroring emptied the node (the flip-twice
+                        # case, where the first flip created it from
+                        # nothing): drop it entirely so a double flip
+                        # restores the pre-flip byte shape instead of
+                        # leaving an empty "(justify)" behind (#4736).
+                        effects.remove(justify)
                 else:
                     justify.add("mirror")
 

--- a/src/kicad_tools/transaction.py
+++ b/src/kicad_tools/transaction.py
@@ -55,6 +55,7 @@ Example::
 from __future__ import annotations
 
 import os
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from types import TracebackType
@@ -129,6 +130,16 @@ class BoardTransaction:
         # the original exception rather than replacing it.
         if exc_type is not None:
             self.rollback()
+            # Announce the rollback and forensic sidecar on stderr (#4736):
+            # CLI adopters only print report_lines() on their explicit
+            # exit-code rollback paths, so without this the user never
+            # learns where the failed attempt was preserved.  Only reached
+            # when rollback() succeeded -- a TransactionRestoreError
+            # propagates past this point and already names the failed
+            # paths.  No overlap with the exit-code paths: those return
+            # normally through __exit__ with exc_type is None.
+            for line in self.report_lines():
+                print(line, file=sys.stderr)
         return False
 
     def rollback(self) -> None:

--- a/tests/test_format_json_sweep.py
+++ b/tests/test_format_json_sweep.py
@@ -404,6 +404,43 @@ class TestBenchmarkReportJson:
         assert "Routing Benchmark Report" in out
 
 
+class TestBenchmarkRunDifficultyError:
+    """Bless the single-line difficulty error shared by text and JSON modes.
+
+    #4727 merged the historical two-line text error (``Unknown difficulty:
+    X`` + ``Valid options: ...``) into one ``_fail()`` message so both modes
+    share it; #4736 pins that as the intended format.  The argparse layer
+    already rejects bad ``--difficulty`` values via ``choices``, so this
+    internal guard is only reachable by callers that build the args
+    namespace directly -- drive it that way.
+    """
+
+    _MESSAGE = "Unknown difficulty: bogus (valid options: easy, medium, hard)"
+
+    def _run(self, fmt: str, capsys) -> tuple[int, str]:
+        from types import SimpleNamespace
+
+        from kicad_tools.cli.commands.benchmark import run_benchmark_command
+
+        args = SimpleNamespace(
+            benchmark_command="run",
+            difficulty="bogus",
+            format=fmt,
+        )
+        rc = run_benchmark_command(args)
+        return rc, capsys.readouterr().out
+
+    def test_text_mode_single_line(self, capsys):
+        rc, out = self._run("text", capsys)
+        assert rc == 1
+        assert out.strip().splitlines() == [self._MESSAGE]
+
+    def test_json_mode_single_error_document(self, capsys):
+        rc, out = self._run("json", capsys)
+        assert rc == 1
+        assert json.loads(out) == {"error": self._MESSAGE}
+
+
 # ---------------------------------------------------------------------------
 # zones family emission (hermetic paths)
 # ---------------------------------------------------------------------------

--- a/tests/test_lvs_recipe.py
+++ b/tests/test_lvs_recipe.py
@@ -387,6 +387,54 @@ def test_build_lvs_payload_netlist_vacuous_flag() -> None:
     assert "netlist_vacuous" not in no_label
 
 
+def test_vacuous_label_summary_prints_dedicated_line(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A vacuous label leg gets its own VACUOUS summary line (#4736), not the
+    generic ``label-LVS FAIL: 1 mismatch(es)`` with a ``<vacuous>``
+    pseudo-record.  The JSON payload is unchanged."""
+    from kicad_tools.lvs.board_lvs import NETLIST_VACUOUS_NET, NETLIST_VACUOUS_REF
+
+    vacuous_label = LVSResult(
+        clean=False,
+        mismatches=(
+            LVSMismatch(
+                ref=NETLIST_VACUOUS_REF,
+                pad="board_pads=264",
+                schematic_net="sch_bound_pins=264",
+                pcb_net=NETLIST_VACUOUS_NET,
+            ),
+        ),
+    )
+    _patch_comparators(monkeypatch, copper=_CLEAN_COPPER, label=vacuous_label)
+    with pytest.raises(BoardNetlistMismatch):
+        write_lvs_report(
+            Path("sch"), Path("pcb"), tmp_path, require_clean=True, fresh_copper_check=False
+        )
+    out = capsys.readouterr().out
+    assert "label-LVS VACUOUS (treated as FAIL)" in out
+    assert "label-LVS FAIL" not in out
+    assert "<vacuous>" not in out
+    # Print-formatting only: the payload still carries the synthetic record.
+    data = _read(tmp_path)
+    assert data["netlist_vacuous"] is True
+    assert data["mismatches"][0]["ref"] == NETLIST_VACUOUS_REF
+
+
+def test_genuine_dirty_label_summary_line_unchanged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Non-vacuous label failures keep the generic FAIL formatter."""
+    _patch_comparators(monkeypatch, copper=_CLEAN_COPPER, label=_DIRTY_LABEL)
+    with pytest.raises(BoardNetlistMismatch):
+        write_lvs_report(
+            Path("sch"), Path("pcb"), tmp_path, require_clean=True, fresh_copper_check=False
+        )
+    out = capsys.readouterr().out
+    assert "label-LVS FAIL: 1 mismatch(es):" in out
+    assert "label-LVS VACUOUS" not in out
+
+
 def test_build_lvs_payload_is_exported_from_package() -> None:
     import kicad_tools.lvs as lvs_pkg
 

--- a/tests/test_mirror_golden.py
+++ b/tests/test_mirror_golden.py
@@ -220,3 +220,42 @@ class TestMirrorSerializes:
         assert proc.returncode == 0, f"kicad-cli drc failed:\n{proc.stdout}\n{proc.stderr}"
         payload = json.loads(report.read_text())
         assert payload.get("violations", []) == []
+
+
+class TestJustifyResidue:
+    """The ``(justify mirror)`` toggle must not litter the file (#4736).
+
+    A double flip creates ``(justify mirror)`` from nothing and then empties
+    it again; the empty ``(justify)`` shell must be dropped so flip-flip
+    round-trips the text effects to their original byte shape.
+    """
+
+    def test_double_flip_leaves_no_empty_justify(self, tmp_path: Path):
+        pcb = PCB.load(str(_FRONT))
+        applicator = StrategyApplicator()
+        applicator.apply_strategy(pcb, _mirror_strategy())
+        applicator.apply_strategy(pcb, _mirror_strategy())
+        out = tmp_path / "double_flipped.kicad_pcb"
+        pcb.save(str(out))
+        text = out.read_text()
+        assert "(justify)" not in text
+        # The front fixture carries no (justify ...) nodes at all, so a
+        # flip-flip must not invent any.
+        assert "(justify" not in text
+
+    def test_unmirror_preserves_other_justify_tokens(self):
+        """Pre-existing ``(justify left mirror)`` un-mirrors to
+        ``(justify left)`` -- the node survives when non-mirror tokens
+        remain."""
+        from kicad_tools.sexp import parse_string
+
+        node = parse_string(
+            '(fp_text user "X" (at 0 0) (layer "F.SilkS") '
+            "(effects (font (size 1 1) (thickness 0.15)) (justify left mirror)))"
+        )
+        StrategyApplicator._mirror_cosmetic_node(node)
+        effects = node.find_child("effects")
+        assert effects is not None
+        justify = effects.find_child("justify")
+        assert justify is not None, "non-empty justify node must survive un-mirroring"
+        assert justify.values == ["left"]

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -70,6 +70,45 @@ class TestExceptionRollback:
                 raise KeyboardInterrupt()
         assert board.read_bytes() == ORIGINAL
 
+    def test_exception_rollback_announces_sidecar_on_stderr(self, board: Path, capsys):
+        """The exception path prints report_lines() to stderr (#4736) --
+        without it the user never learns the forensic sidecar exists."""
+        with pytest.raises(RuntimeError):
+            with board_transaction(board):
+                board.write_bytes(b"mutated")
+                raise RuntimeError("boom")
+        err = capsys.readouterr().err
+        assert f"--transactional: rolled back {board}" in err
+        sidecars = _sidecars(board.parent)
+        assert len(sidecars) == 1
+        assert f"--transactional: failed attempt preserved at {sidecars[0]}" in err
+
+    def test_exception_rollback_keep_failed_false_claims_no_sidecar(self, board: Path, capsys):
+        """With keep_failed=False the announcement must not claim a sidecar
+        that was never written."""
+        with pytest.raises(RuntimeError):
+            with board_transaction(board, keep_failed=False):
+                board.write_bytes(b"mutated")
+                raise RuntimeError("boom")
+        err = capsys.readouterr().err
+        assert "rolled back" in err
+        assert "failed attempt preserved" not in err
+
+    def test_success_path_prints_nothing(self, board: Path, capsys):
+        """No announcement when the with block exits cleanly."""
+        with board_transaction(board):
+            board.write_bytes(ORIGINAL + b"(segment ok)\n")
+        assert capsys.readouterr().err == ""
+
+    def test_exit_code_rollback_path_prints_nothing_from_exit(self, board: Path, capsys):
+        """Explicit exit-code rollbacks return normally through __exit__
+        (exc_type is None), so the caller-side report_lines() print is the
+        only one -- no double announcement."""
+        with board_transaction(board) as txn:
+            board.write_bytes(b"mutated")
+            txn.rollback()
+        assert capsys.readouterr().err == ""
+
 
 # ── Explicit rollback API ───────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Implements all four non-blocking judge nits bundled in #4736, following the Curator Enhancement's per-item sketches. Three small source changes plus targeted tests; item 4 is test-only (bless the single-line format, the Curator-recommended option a). The optional `-1.600001` → `-1.6` float-reformat half of item 3 is wontfix per the issue's scope guard (no float-preservation machinery).

## Changes

1. **LVS vacuous-label summary line** (`src/kicad_tools/lvs/recipe.py`): `_print_summary` gains a `label_result.vacuous` branch before the generic FAIL formatter, printing `label-LVS VACUOUS (treated as FAIL): PCB binds 0 pins ...` (parallel to the copper leg's #4005 line) instead of `label-LVS FAIL: 1 mismatch(es)` with the `<vacuous>` pseudo-record. Print-formatting only — JSON payload untouched.
2. **Transaction sidecar announcement** (`src/kicad_tools/transaction.py`): `BoardTransaction.__exit__` prints `report_lines()` to stderr after a successful exception-path rollback, so the `.failed-<ts>` forensic sidecar location is surfaced. `TransactionRestoreError` chaining unchanged (a rollback failure propagates before the print). No double-print: exit-code rollbacks return through `__exit__` with `exc_type is None`.
3. **Empty `(justify)` residue** (`src/kicad_tools/recovery/applicator.py`): when un-mirroring empties `justify.children` (the flip-twice case), the node is removed from `effects`, restoring the pre-flip byte shape. A pre-existing non-mirror token survives: `(justify left mirror)` → `(justify left)`.
4. **Benchmark difficulty error** (test-only): blessed the single-line `Unknown difficulty: X (valid options: easy, medium, hard)` format from #4727 in both text and JSON modes. Note: argparse `choices` already rejects bad `--difficulty` at the parser layer, so the internal `_fail` guard is only reachable by direct-namespace callers — the new tests drive it that way.

## Acceptance Criteria Verification

- [x] Item 1: vacuous label leg prints the dedicated VACUOUS line; `label-LVS FAIL`/`<vacuous>` absent from output; non-vacuous FAIL output asserted unchanged; JSON payload asserted unchanged (`test_vacuous_label_summary_prints_dedicated_line`, `test_genuine_dirty_label_summary_line_unchanged`)
- [x] Item 2: exception path prints rollback + sidecar lines to stderr while the exception propagates; `keep_failed=False` claims no sidecar; success path and explicit exit-code rollback path print nothing from `__exit__` (4 new tests in `TestExceptionRollback`); `TransactionRestoreError` chaining test still passes
- [x] Item 3: double flip serializes with zero `(justify` occurrences (matching the front fixture); `(justify left mirror)` un-mirrors to `(justify left)` (`TestJustifyResidue`); float normalization explicitly wontfix'd per the issue's scope guard
- [x] Item 4: text-mode error asserted as exactly one line; JSON mode asserted as a single `{"error": ...}` document; exit code 1 in both (`TestBenchmarkRunDifficultyError`)
- [x] Each item lands with a small targeted test

## Test Plan

- [x] `uv run pytest tests/test_lvs_recipe.py tests/test_transaction.py tests/test_mirror_golden.py tests/test_format_json_sweep.py` — 155 passed
- [x] Adopter/consumer suites: `tests/test_fix_drc_cmd.py tests/test_pcb_sync_netlist.py tests/router/test_placement_delta_composed.py tests/router/test_placement_delta_feedback.py tests/test_placement_feedback.py` — 380 passed
- [x] `uv run ruff check` + `ruff format --check` on all 7 changed files — clean
- [x] `uv run python scripts/ci/check_mypy_baseline.py` — no new type errors (the 4 `applicator.py` index errors near my diff are pre-existing baseline entries)

Closes #4736

🤖 Generated with [Claude Code](https://claude.com/claude-code)