### PR TITLE
fix(cli): route startup banner shows the user-supplied input path

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -5006,6 +5006,9 @@ def route_with_layer_escalation(
     # zone for any net the user explicitly committed to pouring -- without
     # this, the all-power guard suppresses every zone and a --skip-nets
     # GND target ends up with neither traces nor a zone.
+    # Issue #4689: capture the user-supplied path for the banner BEFORE the
+    # staging rebind below re-points ``pcb_path`` at the staged output copy.
+    display_input_path = pcb_path
     if getattr(args, "auto_pour", True):
         from kicad_tools.router.auto_pour import auto_pour_if_missing
 
@@ -5091,7 +5094,7 @@ def route_with_layer_escalation(
         flush_print("=" * 60)
         flush_print("KiCad PCB Autorouter - Layer Escalation Mode")
         flush_print("=" * 60)
-        flush_print(f"Input:          {pcb_path}")
+        flush_print(f"Input:          {display_input_path}")
         flush_print(f"Output:         {output_path}")
         flush_print(f"Strategy:       {args.strategy}")
         flush_print(f"Max layers:     {args.max_layers}")
@@ -6088,6 +6091,9 @@ def route_with_rule_relaxation(
     # first so the user's INPUT is left untouched (issue #2548).
     # Issue #3092: forward user-supplied skip_nets as force_pour_nets (see
     # the layer-escalation site above for the rationale).
+    # Issue #4689: capture the user-supplied path for the banner BEFORE the
+    # staging rebind below re-points ``pcb_path`` at the staged output copy.
+    display_input_path = pcb_path
     if getattr(args, "auto_pour", True):
         from kicad_tools.router.auto_pour import auto_pour_if_missing
 
@@ -6148,7 +6154,7 @@ def route_with_rule_relaxation(
         flush_print("=" * 60)
         flush_print("KiCad PCB Autorouter - Adaptive Rules Mode")
         flush_print("=" * 60)
-        flush_print(f"Input:          {pcb_path}")
+        flush_print(f"Input:          {display_input_path}")
         flush_print(f"Output:         {output_path}")
         flush_print(f"Strategy:       {args.strategy}")
         flush_print(f"Manufacturer:   {args.manufacturer}")
@@ -8233,6 +8239,9 @@ def route_with_combined_escalation(
     # first so the user's INPUT is left untouched (issue #2548).
     # Issue #3092: forward user-supplied skip_nets as force_pour_nets (see
     # the layer-escalation site above for the rationale).
+    # Issue #4689: capture the user-supplied path for the banner BEFORE the
+    # staging rebind below re-points ``pcb_path`` at the staged output copy.
+    display_input_path = pcb_path
     if getattr(args, "auto_pour", True):
         from kicad_tools.router.auto_pour import auto_pour_if_missing
 
@@ -8296,7 +8305,7 @@ def route_with_combined_escalation(
         flush_print("=" * 60)
         flush_print("KiCad PCB Autorouter - Combined Escalation Mode")
         flush_print("=" * 60)
-        flush_print(f"Input:          {pcb_path}")
+        flush_print(f"Input:          {display_input_path}")
         flush_print(f"Output:         {output_path}")
         flush_print(f"Strategy:       {args.strategy}")
         flush_print(f"Manufacturer:   {args.manufacturer}")
@@ -12627,6 +12636,9 @@ def _main_impl(argv: list[str] | None = None) -> int:
     # Issue #3092: forward user-supplied skip_nets as force_pour_nets so
     # an all-power board (e.g. board 01 VIN/VOUT/GND) still emits a zone
     # for any net the user explicitly committed to pouring.
+    # Issue #4689: capture the user-supplied path for the banner BEFORE the
+    # staging rebind below re-points ``pcb_path`` at the staged output copy.
+    display_input_path = pcb_path
     if getattr(args, "auto_pour", True):
         from kicad_tools.router.auto_pour import auto_pour_if_missing
 
@@ -12765,7 +12777,7 @@ def _main_impl(argv: list[str] | None = None) -> int:
         print("=" * 60)
         print("KiCad PCB Autorouter")
         print("=" * 60)
-        print(f"Input:    {pcb_path}")
+        print(f"Input:    {display_input_path}")
         print(f"Output:   {output_path}")
         print(f"Strategy: {args.strategy}")
         print(f"Layers:   {layer_stack.name} ({layer_stack.num_layers} layers)")

--- a/tests/test_route_cmd_input_preservation.py
+++ b/tests/test_route_cmd_input_preservation.py
@@ -252,3 +252,172 @@ class TestAutoPourDoesNotModifyInput:
 
         # Both outputs must zone the same set of nets.
         assert _zoned_nets(out1.read_text()) == _zoned_nets(out2.read_text())
+
+
+# ---------------------------------------------------------------------------
+# Banner accuracy: the startup banner's ``Input:`` line must show the
+# user-supplied path, not the staged output copy (issue #4689).
+#
+# ``_stage_input_for_auto_pour`` rebinds ``pcb_path`` to ``output_path``
+# (see the helper tests above); the four functions that print the startup
+# banner AFTER staging used to report that rebound value on ``Input:``,
+# so the banner claimed the OUTPUT file was the input. Each site now
+# captures ``display_input_path`` before the rebind and prints that on
+# ``Input:`` instead.
+#
+# The #4263 analytical ``--dry-run`` short-circuit prints the banner and
+# returns before ``load_pcb_for_routing`` runs (auto-pour staging has
+# already happened by then), so it exercises exactly the bug path
+# cheaply. For the three escalation-mode functions (layer escalation,
+# rule relaxation, combined escalation), ``--dry-run`` only skips the
+# final save -- the full (near-instant, zero-net) routing loop still
+# runs -- but the banner assertion is identical.
+# ---------------------------------------------------------------------------
+
+
+class TestRouteStartupBannerInputLine:
+    """CLI-level (capsys) checks that ``Input:`` names the user's argument."""
+
+    def test_single_attempt_banner_shows_user_input(self, tmp_path: Path, capsys):
+        """Plain ``kct route IN -o OUT --no-auto-layers`` (the reporter's repro
+        path: single-attempt ``_main_impl``, banner at route_cmd.py:~12768)."""
+        from kicad_tools.cli.route_cmd import main as route_main
+
+        input_pcb = tmp_path / "board.kicad_pcb"
+        output_pcb = tmp_path / "step1.kicad_pcb"
+        input_pcb.write_text(_make_pcb_with_pour_candidates())
+
+        rc = route_main([str(input_pcb), "-o", str(output_pcb), "--dry-run", "--no-auto-layers"])
+        assert rc == 0
+
+        out = capsys.readouterr().out
+        input_line = next(line for line in out.splitlines() if line.startswith("Input:"))
+        output_line = next(line for line in out.splitlines() if line.startswith("Output:"))
+
+        assert str(input_pcb) in input_line
+        assert str(output_pcb) not in input_line
+        assert str(output_pcb) in output_line
+
+    def test_layer_escalation_banner_shows_user_input(self, tmp_path: Path, capsys):
+        """``--auto-layers`` (the default) drives ``route_with_layer_escalation``
+        (banner at route_cmd.py:~5094)."""
+        from kicad_tools.cli.route_cmd import main as route_main
+
+        input_pcb = tmp_path / "board.kicad_pcb"
+        output_pcb = tmp_path / "step1.kicad_pcb"
+        input_pcb.write_text(_make_pcb_with_pour_candidates())
+
+        rc = route_main([str(input_pcb), "-o", str(output_pcb), "--dry-run"])
+        assert rc == 0
+
+        out = capsys.readouterr().out
+        input_line = next(line for line in out.splitlines() if line.startswith("Input:"))
+        output_line = next(line for line in out.splitlines() if line.startswith("Output:"))
+
+        assert str(input_pcb) in input_line
+        assert str(output_pcb) not in input_line
+        assert str(output_pcb) in output_line
+
+    def test_rule_relaxation_banner_shows_user_input(self, tmp_path: Path, capsys):
+        """``--adaptive-rules --no-auto-layers`` drives
+        ``route_with_rule_relaxation`` (banner at route_cmd.py:~6151)."""
+        from kicad_tools.cli.route_cmd import main as route_main
+
+        input_pcb = tmp_path / "board.kicad_pcb"
+        output_pcb = tmp_path / "step1.kicad_pcb"
+        input_pcb.write_text(_make_pcb_with_pour_candidates())
+
+        rc = route_main(
+            [
+                str(input_pcb),
+                "-o",
+                str(output_pcb),
+                "--dry-run",
+                "--no-auto-layers",
+                "--adaptive-rules",
+            ]
+        )
+        assert rc == 0
+
+        out = capsys.readouterr().out
+        input_line = next(line for line in out.splitlines() if line.startswith("Input:"))
+        output_line = next(line for line in out.splitlines() if line.startswith("Output:"))
+
+        assert str(input_pcb) in input_line
+        assert str(output_pcb) not in input_line
+        assert str(output_pcb) in output_line
+
+    def test_combined_escalation_banner_shows_user_input(self, tmp_path: Path, capsys):
+        """``--adaptive-rules`` with default ``--auto-layers`` drives
+        ``route_with_combined_escalation`` (banner at route_cmd.py:~8299)."""
+        from kicad_tools.cli.route_cmd import main as route_main
+
+        input_pcb = tmp_path / "board.kicad_pcb"
+        output_pcb = tmp_path / "step1.kicad_pcb"
+        input_pcb.write_text(_make_pcb_with_pour_candidates())
+
+        rc = route_main([str(input_pcb), "-o", str(output_pcb), "--dry-run", "--adaptive-rules"])
+        assert rc == 0
+
+        out = capsys.readouterr().out
+        input_line = next(line for line in out.splitlines() if line.startswith("Input:"))
+        output_line = next(line for line in out.splitlines() if line.startswith("Output:"))
+
+        assert str(input_pcb) in input_line
+        assert str(output_pcb) not in input_line
+        assert str(output_pcb) in output_line
+
+    def test_banner_input_equals_output_unchanged(self, tmp_path: Path, capsys):
+        """Pipeline case (``kct build``): input == output, so both banner
+        lines legitimately show the same path -- the fix must not disturb
+        this pre-existing, accidentally-correct case."""
+        from kicad_tools.cli.route_cmd import main as route_main
+
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text(_make_pcb_with_pour_candidates())
+
+        rc = route_main([str(pcb), "-o", str(pcb), "--dry-run", "--no-auto-layers"])
+        assert rc == 0
+
+        out = capsys.readouterr().out
+        input_line = next(line for line in out.splitlines() if line.startswith("Input:"))
+        output_line = next(line for line in out.splitlines() if line.startswith("Output:"))
+
+        assert str(pcb) in input_line
+        assert str(pcb) in output_line
+
+    def test_two_step_composition_banners_identify_the_right_file(self, tmp_path: Path, capsys):
+        """Two-step composition sanity check from the issue body: step 2's
+        banner must read ``Input: step1`` / ``Output: step2`` -- the two
+        lines differ and correctly identify which file was consumed."""
+        from kicad_tools.cli.route_cmd import main as route_main
+
+        board = tmp_path / "board.kicad_pcb"
+        step1 = tmp_path / "step1.kicad_pcb"
+        step2 = tmp_path / "step2.kicad_pcb"
+        board.write_text(_make_pcb_with_pour_candidates())
+
+        # Step 1: board -> step1.
+        rc1 = route_main([str(board), "-o", str(step1), "--dry-run", "--no-auto-layers"])
+        assert rc1 == 0
+        out1 = capsys.readouterr().out
+        input_line1 = next(line for line in out1.splitlines() if line.startswith("Input:"))
+        output_line1 = next(line for line in out1.splitlines() if line.startswith("Output:"))
+        assert str(board) in input_line1
+        assert str(step1) in output_line1
+
+        # Step 1 must have produced step1.kicad_pcb for step 2 to consume.
+        assert step1.exists()
+
+        # Step 2: step1 -> step2.
+        rc2 = route_main([str(step1), "-o", str(step2), "--dry-run", "--no-auto-layers"])
+        assert rc2 == 0
+        out2 = capsys.readouterr().out
+        input_line2 = next(line for line in out2.splitlines() if line.startswith("Input:"))
+        output_line2 = next(line for line in out2.splitlines() if line.startswith("Output:"))
+
+        # The reported bug: step 2's banner used to show step2 (the OUTPUT)
+        # on the Input line. It must now show step1 (the actual input).
+        assert str(step1) in input_line2
+        assert str(step2) not in input_line2
+        assert str(step2) in output_line2


### PR DESCRIPTION
## Summary

- `_stage_input_for_auto_pour()` rebinds `pcb_path` to the staged `output_path`
  copy before auto-pour runs; the startup banner printed *after* staging then
  reported that rebound value on the `Input:` line, so the banner claimed the
  **output** file was the input. Reproduced on all four banner sites that
  print after staging.
- Each of the four affected functions now captures `display_input_path =
  pcb_path` immediately before the staging rebind, and prints that on
  `Input:` instead. `Output:` is unchanged in all cases, and the staged
  `pcb_path` value used by downstream routing/pour logic is untouched
  (display-only fix).

## Changes

`src/kicad_tools/cli/route_cmd.py`:
- `_main_impl` (single-attempt path, the reporter's repro) — capture at the
  auto-pour block, banner at `print(f"Input:    {display_input_path}")`.
- `route_with_layer_escalation` — same pattern, `--auto-layers` (default) mode.
- `route_with_rule_relaxation` — same pattern, `--adaptive-rules` mode.
- `route_with_combined_escalation` — same pattern, combined `--auto-layers
  --adaptive-rules` mode.

`tests/test_route_cmd_input_preservation.py`:
- New `TestRouteStartupBannerInputLine` class with CLI-level (`capsys` +
  `--dry-run`) tests covering all four banner sites, the input==output
  pipeline case (banner behavior unchanged), and the two-step composition
  scenario from the issue body (`board -> step1 -> step2`, confirming step
  2's banner reads `Input: step1` / `Output: step2`).

## Acceptance Criteria Verification

- [x] `kct route board.kicad_pcb -o step1.kicad_pcb` prints `Input:
      board.kicad_pcb` (user-supplied) and `Output: step1.kicad_pcb` in the
      single-attempt banner — verified by
      `test_single_attempt_banner_shows_user_input`.
- [x] Same holds in `--auto-layers`, `--adaptive-rules`, and combined
      escalation modes — verified by
      `test_layer_escalation_banner_shows_user_input`,
      `test_rule_relaxation_banner_shows_user_input`,
      `test_combined_escalation_banner_shows_user_input`.
- [x] Composition sanity check restored: two-step chain shows `Input: b` /
      `Output: c` at step 2, the two lines differ and correctly identify the
      consumed file — verified by
      `test_two_step_composition_banners_identify_the_right_file`.
- [x] input == output (pipeline case): banner behavior unchanged (both lines
      show the same path) — verified by
      `test_banner_input_equals_output_unchanged`.
- [x] `Output:` line content unchanged in all modes — asserted in every new
      test.
- [x] No behavioral change to staging/auto-pour: `_stage_input_for_auto_pour`
      and the `pcb_path == staged output_path` call-site identity are
      untouched; only a new `display_input_path` variable was added ahead of
      each existing rebind.

## Test Plan

```
uv run pytest tests/test_route_cmd_input_preservation.py -q --no-cov
# 12 passed in 1.61s (6 pre-existing + 6 new banner tests)

uv run ruff check src/kicad_tools/cli/route_cmd.py tests/test_route_cmd_input_preservation.py
# All checks passed!

uv run ruff format --check src/kicad_tools/cli/route_cmd.py tests/test_route_cmd_input_preservation.py
# 2 files already formatted

uv run python scripts/ci/check_mypy_baseline.py
# OK: mypy reports 1473 error(s), all within the baseline (1475 allowed). No new type errors.
```

Manual verification (mirrors the issue's two-step repro): confirmed via the
new `test_two_step_composition_banners_identify_the_right_file` that step 2's
banner shows `Input: <...>/step1.kicad_pcb` and `Output: <...>/step2.kicad_pcb`
— the two lines differ and correctly identify which file was consumed.

Closes #4689