### PR TITLE
fix(check): via-in-pad advisory names the resolution source instead of always saying "Defaulting" (#4701)

### DIFF
--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -28,7 +28,7 @@ import sys
 from collections.abc import Sequence
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import Literal
+from typing import Literal, NamedTuple
 
 from kicad_tools.analysis.routing_quality import (
     FRAGMENT_LENGTH_MM,
@@ -397,11 +397,33 @@ def _discover_fab_profile_sidecar(pcb_path: Path) -> Path | None:
     return None
 
 
+MfrResolutionSource = Literal["cli", "sidecar", "project_kct", "default"]
+"""Where an effective ``--mfr`` value came from (#4701).
+
+Mirrors the four precedence tiers of :func:`_resolve_effective_check_mfr` 1:1,
+so downstream consumers (e.g. the via-in-pad advisory) can word their output
+without re-deriving how the tier was resolved.
+"""
+
+
+class ResolvedMfr(NamedTuple):
+    """Result of :func:`_resolve_effective_check_mfr` (#4701).
+
+    ``source`` records which precedence tier produced ``mfr`` so callers can
+    report *how* the tier was resolved (declared vs. defaulted) instead of
+    only *what* it resolved to.
+    """
+
+    mfr: str
+    messages: list[str]
+    source: MfrResolutionSource
+
+
 def _resolve_effective_check_mfr(
     cli_mfr: str | None,
     pcb_path: Path,
     default: str = "jlcpcb",
-) -> tuple[str, list[str]]:
+) -> ResolvedMfr:
     """Resolve the manufacturer profile ``kct check`` judges against (#3920).
 
     A routed ``.kicad_pcb`` carries no embedded fab-tier hint, so bare ``kct
@@ -424,16 +446,18 @@ def _resolve_effective_check_mfr(
     handling).
 
     Returns:
-        ``(effective_mfr, messages)`` where ``messages`` are stderr lines
-        (``[INFO] auto-loaded ...`` / ``WARNING: ignoring ...``) the caller
-        should print.  Kept as return values (not printed here) so the
-        resolution is unit-testable in isolation.
+        A :class:`ResolvedMfr` of ``(effective_mfr, messages, source)`` where
+        ``messages`` are stderr lines (``[INFO] auto-loaded ...`` /
+        ``WARNING: ignoring ...``) the caller should print, and ``source``
+        names which precedence tier produced ``effective_mfr`` (#4701). Kept
+        as return values (not printed here) so the resolution is
+        unit-testable in isolation.
     """
     messages: list[str] = []
 
     # Precedence 1: an explicit flag always wins.
     if cli_mfr is not None:
-        return cli_mfr, messages
+        return ResolvedMfr(cli_mfr, messages, "cli")
 
     valid_ids = set(get_manufacturer_ids())
 
@@ -455,7 +479,7 @@ def _resolve_effective_check_mfr(
                 )
             else:
                 messages.append(f"[INFO] auto-loaded fab profile: {mfr} (from {sidecar})")
-                return mfr, messages
+                return ResolvedMfr(mfr, messages, "sidecar")
 
     # Precedence 3: project.kct target_fab.
     target_fab = resolve_target_fab_for_pcb(pcb_path)
@@ -468,10 +492,10 @@ def _resolve_effective_check_mfr(
             messages.append(
                 f"[INFO] auto-loaded fab profile: {target_fab} (from project.kct target_fab)"
             )
-            return target_fab, messages
+            return ResolvedMfr(target_fab, messages, "project_kct")
 
     # Precedence 4: historical default.
-    return default, messages
+    return ResolvedMfr(default, messages, "default")
 
 
 def _profile_supports_via_in_pad(mfr: str) -> bool:
@@ -488,15 +512,25 @@ def _profile_supports_via_in_pad(mfr: str) -> bool:
         return False
 
 
-def _maybe_emit_via_in_pad_tier_advisory(mfr: str, violations: Sequence) -> None:
+def _maybe_emit_via_in_pad_tier_advisory(
+    mfr: str,
+    violations: Sequence,
+    source: MfrResolutionSource = "default",
+) -> None:
     """Emit a non-blocking via-in-pad tier hint when it would help (#3920).
 
-    Belt-and-suspenders for a standalone routed board with NO ``fab_profile.json``
-    sidecar and NO ``project.kct``: if the active profile does not support
-    via-in-pad, the DRC results contain ``via_in_pad`` findings, and at least
-    one registered profile DOES permit via-in-pad, print a loud, actionable
-    stderr advisory naming the permitting tier.  This turns a scary,
-    unexplained ``FAILED`` into a self-explaining one.
+    If the active profile does not support via-in-pad, the DRC results
+    contain ``via_in_pad`` findings, and at least one registered profile DOES
+    permit via-in-pad, print a loud, actionable stderr advisory naming the
+    permitting tier.  This turns a scary, unexplained ``FAILED`` into a
+    self-explaining one.
+
+    ``source`` (from :func:`_resolve_effective_check_mfr`, #4701) says *how*
+    ``mfr`` was resolved, so the final sentence can distinguish a genuinely
+    defaulted tier from one the board explicitly declared (via ``--mfr``, a
+    ``fab_profile.json`` sidecar, or ``project.kct`` ``target_fab``) --
+    otherwise a declared-but-unsupported tier would misleadingly read as
+    "Defaulting to the base tier" even though nothing was defaulted.
 
     CRITICAL: this is advisory only.  It must NOT change the verdict or exit
     code -- it only prints to stderr.
@@ -524,12 +558,23 @@ def _maybe_emit_via_in_pad_tier_advisory(mfr: str, violations: Sequence) -> None
     if permitting is None:
         return
 
+    # #4701: the final sentence names *how* `mfr` was resolved so a declared
+    # (non-default) tier is never reported as "defaulted".
+    if source == "project_kct":
+        tail = f"Board declares {mfr!r} (project.kct target_fab)."
+    elif source == "sidecar":
+        tail = f"Board declares {mfr!r} (fab_profile.json sidecar)."
+    elif source == "cli":
+        tail = f"Profile {mfr!r} was passed explicitly via --mfr."
+    else:
+        tail = "Defaulting to the base tier."
+
     print(
         f"WARNING: {vip_count} via_in_pad finding(s) at profile {mfr!r}. "
         "Via-in-pad is a tier-gated capability: it is LEGAL at "
         f"{permitting} (via_in_pad_supported). If this board targets a higher "
         f"fab tier, re-run with --mfr {permitting} (or pass the intended "
-        "--mfr). Defaulting to the base tier.",
+        f"--mfr). {tail}",
         file=sys.stderr,
     )
 
@@ -1697,7 +1742,7 @@ def main(argv: list[str] | None = None) -> int:
     # FAILED on legal tier-gated geometry (e.g. via-in-pad, legal at
     # jlcpcb-tier1).  Precedence: explicit --mfr > fab_profile.json sidecar >
     # project.kct target_fab > jlcpcb default.  An explicit flag always wins.
-    effective_mfr, mfr_notices = _resolve_effective_check_mfr(args.mfr, pcb_path)
+    effective_mfr, mfr_notices, mfr_source = _resolve_effective_check_mfr(args.mfr, pcb_path)
     for _line in mfr_notices:
         print(_line, file=sys.stderr)
 
@@ -2115,13 +2160,14 @@ def main(argv: list[str] | None = None) -> int:
             skip_set,
         )
 
-    # Issue #3920 (Layer 2): belt-and-suspenders advisory for a standalone
-    # routed board with NO fab_profile.json sidecar and NO project.kct.  When
-    # the active profile does not permit via-in-pad yet the results contain
-    # via_in_pad findings AND a registered profile DOES permit them, print a
-    # loud, actionable stderr hint naming the permitting tier.  This is
-    # advisory ONLY -- it must not change the verdict or exit code.
-    _maybe_emit_via_in_pad_tier_advisory(effective_mfr, results.violations)
+    # Issue #3920 (Layer 2): non-blocking advisory when the active profile
+    # does not permit via-in-pad yet the results contain via_in_pad findings
+    # AND a registered profile DOES permit them.  Prints a loud, actionable
+    # stderr hint naming the permitting tier, worded per how `effective_mfr`
+    # was resolved (#4701) so a declared tier is never reported as
+    # "defaulted".  This is advisory ONLY -- it must not change the verdict
+    # or exit code.
+    _maybe_emit_via_in_pad_tier_advisory(effective_mfr, results.violations, source=mfr_source)
 
     # Issue #4623 / #4651: advisory routing-quality metrics + opt-in
     # threshold gate.  Metrics are computed in meta mode -- skipped under

--- a/tests/test_check_fab_profile_resolution.py
+++ b/tests/test_check_fab_profile_resolution.py
@@ -167,50 +167,62 @@ class TestResolveEffectiveCheckMfr:
         pcb = _write_pcb(tmp_path)
         _write_sidecar(tmp_path, "jlcpcb-tier1")
         _write_project_kct(tmp_path, "jlcpcb-tier1")
-        mfr, messages = _resolve_effective_check_mfr("jlcpcb", pcb)
+        mfr, messages, source = _resolve_effective_check_mfr("jlcpcb", pcb)
         assert mfr == "jlcpcb"
         # An explicit flag short-circuits before any discovery message.
         assert messages == []
+        assert source == "cli"
 
     def test_sidecar_wins_over_project_kct_and_default(self, tmp_path: Path) -> None:
         pcb = _write_pcb(tmp_path)
         _write_sidecar(tmp_path, "jlcpcb-tier1")
         _write_project_kct(tmp_path, "jlcpcb")  # lower-precedence, different value
-        mfr, messages = _resolve_effective_check_mfr(None, pcb)
+        mfr, messages, source = _resolve_effective_check_mfr(None, pcb)
         assert mfr == "jlcpcb-tier1"
         assert any("auto-loaded fab profile: jlcpcb-tier1" in m for m in messages)
         assert any("fab_profile.json" in m or "from" in m for m in messages)
+        assert source == "sidecar"
 
     def test_project_kct_wins_over_default(self, tmp_path: Path) -> None:
         pcb = _write_pcb(tmp_path)
         _write_project_kct(tmp_path, "jlcpcb-tier1")
-        mfr, messages = _resolve_effective_check_mfr(None, pcb)
+        mfr, messages, source = _resolve_effective_check_mfr(None, pcb)
         assert mfr == "jlcpcb-tier1"
         assert any("project.kct target_fab" in m for m in messages)
+        assert source == "project_kct"
 
     def test_falls_back_to_default(self, tmp_path: Path) -> None:
         pcb = _write_pcb(tmp_path)
-        mfr, messages = _resolve_effective_check_mfr(None, pcb)
+        mfr, messages, source = _resolve_effective_check_mfr(None, pcb)
         assert mfr == "jlcpcb"
         assert messages == []
+        assert source == "default"
 
     def test_full_precedence_ladder(self, tmp_path: Path) -> None:
         """explicit > sidecar > project.kct > default, asserted stepwise."""
         pcb = _write_pcb(tmp_path)
 
         # 4. default only
-        assert _resolve_effective_check_mfr(None, pcb)[0] == "jlcpcb"
+        resolved = _resolve_effective_check_mfr(None, pcb)
+        assert resolved.mfr == "jlcpcb"
+        assert resolved.source == "default"
 
         # 3. project.kct beats default
         _write_project_kct(tmp_path, "jlcpcb-tier1")
-        assert _resolve_effective_check_mfr(None, pcb)[0] == "jlcpcb-tier1"
+        resolved = _resolve_effective_check_mfr(None, pcb)
+        assert resolved.mfr == "jlcpcb-tier1"
+        assert resolved.source == "project_kct"
 
         # 2. sidecar beats project.kct
         _write_sidecar(tmp_path, "pcbway")
-        assert _resolve_effective_check_mfr(None, pcb)[0] == "pcbway"
+        resolved = _resolve_effective_check_mfr(None, pcb)
+        assert resolved.mfr == "pcbway"
+        assert resolved.source == "sidecar"
 
         # 1. explicit beats sidecar
-        assert _resolve_effective_check_mfr("jlcpcb", pcb)[0] == "jlcpcb"
+        resolved = _resolve_effective_check_mfr("jlcpcb", pcb)
+        assert resolved.mfr == "jlcpcb"
+        assert resolved.source == "cli"
 
 
 # ---------------------------------------------------------------------------
@@ -222,30 +234,45 @@ class TestSidecarGracefulDegradation:
     def test_malformed_json_warns_and_falls_back(self, tmp_path: Path) -> None:
         pcb = _write_pcb(tmp_path)
         (tmp_path / "fab_profile.json").write_text("{not valid json")
-        mfr, messages = _resolve_effective_check_mfr(None, pcb)
+        mfr, messages, source = _resolve_effective_check_mfr(None, pcb)
         assert mfr == "jlcpcb"
         assert any("malformed fab-profile sidecar" in m for m in messages)
+        assert source == "default"
+
+    def test_malformed_sidecar_falls_back_to_project_kct(self, tmp_path: Path) -> None:
+        """A malformed sidecar degrades to the NEXT precedence tier, not the
+        historical default, when a valid ``project.kct`` is also present."""
+        pcb = _write_pcb(tmp_path)
+        (tmp_path / "fab_profile.json").write_text("{not valid json")
+        _write_project_kct(tmp_path, "jlcpcb-tier1")
+        mfr, messages, source = _resolve_effective_check_mfr(None, pcb)
+        assert mfr == "jlcpcb-tier1"
+        assert any("malformed fab-profile sidecar" in m for m in messages)
+        assert source == "project_kct"
 
     def test_unknown_profile_id_warns_and_falls_back(self, tmp_path: Path) -> None:
         pcb = _write_pcb(tmp_path)
         _write_sidecar(tmp_path, "definitely-not-a-real-fab")
-        mfr, messages = _resolve_effective_check_mfr(None, pcb)
+        mfr, messages, source = _resolve_effective_check_mfr(None, pcb)
         assert mfr == "jlcpcb"
         assert any("unknown profile" in m for m in messages)
+        assert source == "default"
 
     def test_missing_mfr_field_warns_and_falls_back(self, tmp_path: Path) -> None:
         pcb = _write_pcb(tmp_path)
         (tmp_path / "fab_profile.json").write_text(json.dumps({"source": "x"}))
-        mfr, messages = _resolve_effective_check_mfr(None, pcb)
+        mfr, messages, source = _resolve_effective_check_mfr(None, pcb)
         assert mfr == "jlcpcb"
         assert any("no 'mfr' field" in m for m in messages)
+        assert source == "default"
 
     def test_unknown_target_fab_in_project_kct_warns_and_falls_back(self, tmp_path: Path) -> None:
         pcb = _write_pcb(tmp_path)
         _write_project_kct(tmp_path, "not-a-real-fab")
-        mfr, messages = _resolve_effective_check_mfr(None, pcb)
+        mfr, messages, source = _resolve_effective_check_mfr(None, pcb)
         assert mfr == "jlcpcb"
         assert any("unknown profile" in m for m in messages)
+        assert source == "default"
 
 
 # ---------------------------------------------------------------------------
@@ -264,8 +291,9 @@ class TestFabProfileSidecarRoundTrip:
         assert payload["mfr"] == "jlcpcb-tier1"
         assert payload["source"] == "kct route --manufacturer"
 
-        mfr, _ = _resolve_effective_check_mfr(None, pcb)
+        mfr, _messages, source = _resolve_effective_check_mfr(None, pcb)
         assert mfr == "jlcpcb-tier1"
+        assert source == "sidecar"
 
     def test_empty_manufacturer_writes_nothing(self, tmp_path: Path) -> None:
         pcb = _write_pcb(tmp_path)
@@ -285,6 +313,45 @@ class TestViaInPadTierAdvisory:
         assert "via_in_pad finding(s) at profile 'jlcpcb'" in err
         assert "jlcpcb-tier1" in err
         assert "--mfr" in err
+
+    def test_default_source_still_says_defaulting(self, capsys) -> None:
+        """#4701: with no source (or an explicit ``source="default"``) the
+        original 'Defaulting to the base tier.' wording is preserved."""
+        _maybe_emit_via_in_pad_tier_advisory(
+            "jlcpcb", [_FakeViolation("via_in_pad")], source="default"
+        )
+        err = capsys.readouterr().err
+        assert "Defaulting to the base tier." in err
+
+    def test_project_kct_source_names_itself_not_defaulting(self, capsys) -> None:
+        """#4701: a declared (project.kct) tier must NOT say 'Defaulting'."""
+        _maybe_emit_via_in_pad_tier_advisory(
+            "jlcpcb", [_FakeViolation("via_in_pad")], source="project_kct"
+        )
+        err = capsys.readouterr().err
+        assert "Defaulting to the base tier" not in err
+        assert "project.kct target_fab" in err
+        assert "'jlcpcb'" in err
+
+    def test_sidecar_source_names_itself_not_defaulting(self, capsys) -> None:
+        """#4701: a declared (fab_profile.json sidecar) tier must NOT say
+        'Defaulting'."""
+        _maybe_emit_via_in_pad_tier_advisory(
+            "jlcpcb", [_FakeViolation("via_in_pad")], source="sidecar"
+        )
+        err = capsys.readouterr().err
+        assert "Defaulting to the base tier" not in err
+        assert "fab_profile.json sidecar" in err
+        assert "'jlcpcb'" in err
+
+    def test_cli_source_names_itself_not_defaulting(self, capsys) -> None:
+        """#4701: an explicit --mfr tier must NOT say 'Defaulting' either --
+        the CLI flag was not a fallback."""
+        _maybe_emit_via_in_pad_tier_advisory("jlcpcb", [_FakeViolation("via_in_pad")], source="cli")
+        err = capsys.readouterr().err
+        assert "Defaulting to the base tier" not in err
+        assert "passed explicitly via --mfr" in err
+        assert "'jlcpcb'" in err
 
     def test_no_advisory_when_active_profile_permits(self, capsys) -> None:
         _maybe_emit_via_in_pad_tier_advisory("jlcpcb-tier1", [_FakeViolation("via_in_pad")])
@@ -340,6 +407,36 @@ class TestCheckCliEndToEnd:
         err = capsys.readouterr().err
         assert "project.kct target_fab" in err
 
+    def test_project_kct_declared_base_tier_advisory_is_not_defaulted(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """#4701 regression: a board declaring ``target_fab: jlcpcb`` via
+        ``project.kct`` still fails via-in-pad findings at that tier, but the
+        advisory must name the declared source instead of claiming the tier
+        was defaulted -- the exact scenario from the issue reproduction."""
+        pcb = _write_pcb(tmp_path)
+        _write_project_kct(tmp_path, "jlcpcb")
+        rc = main([str(pcb), "--drc-only", "--only", "via_in_pad"])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "auto-loaded fab profile: jlcpcb (from project.kct target_fab)" in err
+        assert "via_in_pad finding(s) at profile 'jlcpcb'" in err
+        assert "Defaulting to the base tier" not in err
+        assert "Board declares 'jlcpcb' (project.kct target_fab)." in err
+
+    def test_sidecar_declared_base_tier_advisory_is_not_defaulted(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """#4701: same as above but the tier is declared via the
+        fab_profile.json sidecar rather than project.kct."""
+        pcb = _write_pcb(tmp_path)
+        _write_sidecar(tmp_path, "jlcpcb")
+        rc = main([str(pcb), "--drc-only", "--only", "via_in_pad"])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "Defaulting to the base tier" not in err
+        assert "Board declares 'jlcpcb' (fab_profile.json sidecar)." in err
+
     def test_explicit_base_tier_overrides_sidecar(self, tmp_path: Path, capsys) -> None:
         """AC: explicit --mfr jlcpcb still surfaces the via_in_pad findings."""
         pcb = _write_pcb(tmp_path)
@@ -349,6 +446,9 @@ class TestCheckCliEndToEnd:
         err = capsys.readouterr().err
         # Explicit flag wins: no sidecar auto-load line.
         assert "auto-loaded fab profile" not in err
+        # #4701: an explicit --mfr must not be reported as a fallback default.
+        assert "Defaulting to the base tier" not in err
+        assert "passed explicitly via --mfr" in err
 
     def test_advisory_is_verdict_invariant(self, tmp_path: Path, capsys) -> None:
         """The Layer-2 advisory must NOT change the exit code.


### PR DESCRIPTION
## Summary

`kct check`'s via-in-pad tier advisory always said "Defaulting to the base
tier" — even when the tier was explicitly declared via `--mfr`, a
`fab_profile.json` sidecar, or `project.kct` `target_fab`. That contradicted
the `[INFO] auto-loaded fab profile: ... (from project.kct target_fab)`
line printed immediately above it, and led operators to believe their
declaration hadn't taken effect.

## Root cause

`_resolve_effective_check_mfr()` resolved the effective profile with the
documented precedence (`--mfr` > `fab_profile.json` sidecar > `project.kct`
`target_fab` > `jlcpcb` default) but discarded *which* tier won — only the
profile id and stderr notice lines survived. `_maybe_emit_via_in_pad_tier_advisory()`
then hard-coded "Defaulting to the base tier." as its final sentence
regardless of how the tier was actually resolved.

## Fix

- `_resolve_effective_check_mfr()` now returns a `ResolvedMfr(mfr, messages,
  source)` `NamedTuple`, where `source` is one of `"cli" | "sidecar" |
  "project_kct" | "default"` — one value per precedence tier, all four
  `return` paths updated 1:1.
- The source is threaded through the single production call site into
  `_maybe_emit_via_in_pad_tier_advisory(mfr, violations, source=...)`.
- The advisory now branches only its final sentence:
  - `default` → unchanged: `"Defaulting to the base tier."`
  - `project_kct` → `"Board declares '<mfr>' (project.kct target_fab)."`
  - `sidecar` → `"Board declares '<mfr>' (fab_profile.json sidecar)."`
  - `cli` → `"Profile '<mfr>' was passed explicitly via --mfr."`
- Fixed the advisory's stale docstring (claimed the "standalone board with
  NO sidecar and NO project.kct" precondition was enforced — it never was).

Resolution precedence, verdict, exit code, and the `[INFO]`/`WARNING`
notice lines are all byte-identical to before — this is wording-only.

## Test evidence

- `tests/test_check_fab_profile_resolution.py`: 35 tests, all passing
  (`uv run pytest tests/test_check_fab_profile_resolution.py -q --no-cov`
  → `35 passed in 0.69s`). New/updated coverage:
  - `_resolve_effective_check_mfr` source assertions for every precedence
    path, including the malformed-sidecar → `project_kct` fallback and the
    unknown-`target_fab` → `default` fallback.
  - `TestViaInPadTierAdvisory`: per-source wording tests (`default`,
    `project_kct`, `sidecar`, `cli`), each asserting the absence/presence
    of "Defaulting to the base tier."
  - `TestCheckCliEndToEnd`: end-to-end regression reproducing the exact
    issue scenario — `project.kct` declares `target_fab: jlcpcb` (a tier
    without `via_in_pad_supported`), board has via-in-pad findings, and the
    advisory now says `"Board declares 'jlcpcb' (project.kct target_fab)."`
    instead of "Defaulting"; plus sidecar and explicit-`--mfr` analogues.
- `uv run ruff check` / `uv run ruff format --check` — clean on both changed
  files.
- `uv run python scripts/ci/check_mypy_baseline.py` — `OK: mypy reports 1473
  error(s), all within the baseline (1475 allowed). No new type errors.`
  (baseline left untouched, not `--update`d).
- Manual verification (temp dir with a `project.kct` declaring `target_fab:
  jlcpcb` one level above a synthetic via-in-pad board):
  - With `project.kct`: `[INFO] auto-loaded fab profile: jlcpcb (from
    project.kct target_fab)` followed by `... Board declares 'jlcpcb'
    (project.kct target_fab).` — no contradiction.
  - Without `project.kct`: advisory still ends `... Defaulting to the base
    tier.`

## Scope

Cosmetic/wording only, per the issue's stated scope — no change to tier
resolution, verdict, or exit code. Diff is limited to the resolver +
advisory region of `src/kicad_tools/cli/check_cmd.py` (~lines 400-580,
call sites ~1745/~2170) and `tests/test_check_fab_profile_resolution.py`.

Closes #4701