### PR TITLE
fix(cli): kct check --format summary counts waived errors under a dedicated Waived column

### DIFF
--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -3065,30 +3065,47 @@ def output_summary(
     print(f"DRC Summary: {pcb_path.name}")
     print("=" * 50)
 
-    # Group by rule_id
+    # Group by rule_id.
+    #
+    # Issue #4696: waived findings must land in their own bucket -- checking
+    # ``is_waived`` first, mirroring ``output_table`` (above) -- so a waived
+    # error/warning/info never inflates the ``Errors``/``Warnings``/``Infos``
+    # columns. Without this, every waived finding falls through the
+    # ``is_error``/``is_info`` cascade (both ``False`` for waived findings)
+    # into the bare ``else`` and is misreported as a warning, causing the
+    # table's TOTAL Warnings to disagree with the ``DRC:`` prose line (which
+    # is computed from ``is_warning`` and correctly excludes waived).
     by_rule: dict[str, dict[str, int]] = {}
     for v in violations:
         key = v.rule_id
         if key not in by_rule:
-            by_rule[key] = {"errors": 0, "warnings": 0, "infos": 0}
-        if v.is_error:
+            by_rule[key] = {"errors": 0, "warnings": 0, "infos": 0, "waived": 0}
+        if v.is_waived:
+            by_rule[key]["waived"] += 1
+        elif v.is_error:
             by_rule[key]["errors"] += 1
         elif v.is_info:
             by_rule[key]["infos"] += 1
         else:
             by_rule[key]["warnings"] += 1
 
-    print(f"{'Rule ID':<30} {'Errors':<8} {'Warnings':<10} {'Infos':<8}")
-    print("-" * 60)
+    print(f"{'Rule ID':<30} {'Errors':<8} {'Warnings':<10} {'Infos':<8} {'Waived':<8}")
+    print("-" * 68)
 
     for rule_id, counts in sorted(by_rule.items()):
-        print(f"{rule_id:<30} {counts['errors']:<8} {counts['warnings']:<10} {counts['infos']:<8}")
+        print(
+            f"{rule_id:<30} {counts['errors']:<8} {counts['warnings']:<10} "
+            f"{counts['infos']:<8} {counts['waived']:<8}"
+        )
 
-    print("-" * 60)
+    print("-" * 68)
     total_errors = sum(c["errors"] for c in by_rule.values())
     total_warnings = sum(c["warnings"] for c in by_rule.values())
     total_infos = sum(c["infos"] for c in by_rule.values())
-    print(f"{'TOTAL':<30} {total_errors:<8} {total_warnings:<10} {total_infos:<8}")
+    total_waived = sum(c["waived"] for c in by_rule.values())
+    print(
+        f"{'TOTAL':<30} {total_errors:<8} {total_warnings:<10} {total_infos:<8} {total_waived:<8}"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_check_waivers.py
+++ b/tests/test_cli_check_waivers.py
@@ -10,11 +10,13 @@ ignores ``waived``) stays blocking by default.
 from __future__ import annotations
 
 import json
+import re
 
 import pytest
 
 from kicad_tools.cli import check_cmd
 from kicad_tools.drc.report import parse_json_report
+from kicad_tools.validate.violations import DRCResults, DRCViolation
 
 pytest.importorskip("shapely")
 
@@ -201,3 +203,119 @@ class TestCliWaivers:
         assert len(unused) == 1
         assert unused[0]["severity"] == "info"
         assert "x#2" in unused[0]["message"]
+
+
+class TestFormatSummaryWaived:
+    """Issue #4696: ``--format summary`` must not fold waived errors into
+
+    the ``Warnings`` column -- the per-rule table and the ``TOTAL`` row need
+    a dedicated ``Waived`` column, mirroring ``output_table``, so the
+    table's ``Warnings`` total agrees with the ``DRC:`` prose line.
+    """
+
+    def test_waived_error_gets_own_column_and_totals_agree_with_prose(self, tmp_path, capsys):
+        board = _board_file(tmp_path, refs_positions=[("U1", (10.0, 10.0)), ("C1", (11.0, 10.0))])
+        waiver = tmp_path / "w.json"
+        _write_waiver(
+            waiver,
+            [
+                {
+                    "rule": "courtyards_overlap",
+                    "items": ["U1", "C1"],
+                    "reason": "EE-mandated tight decoupling",
+                    "issue": "chorus#18",
+                }
+            ],
+        )
+        check_cmd.main(
+            [
+                str(board),
+                "--only",
+                "courtyard_overlap",
+                "--waivers",
+                str(waiver),
+                "--format",
+                "summary",
+            ]
+        )
+        out = capsys.readouterr().out
+        # The exit code is driven by the meta-check rollup (no schematic
+        # discovered next to this synthetic fixture -> INCOMPLETE); this
+        # test is only about the summary-format DRC accounting, not the
+        # exit code, so it doesn't assert `rc` here.
+
+        lines = out.splitlines()
+        header = next(line for line in lines if line.startswith("Rule ID"))
+        assert "Waived" in header
+
+        rule_row = next(line for line in lines if line.startswith("courtyards_overlap"))
+        # Columns: rule_id, errors, warnings, infos, waived.
+        _, errors, warnings, infos, waived = rule_row.split()
+        assert (errors, warnings, infos, waived) == ("0", "0", "0", "1")
+
+        total_row = next(line for line in lines if line.startswith("TOTAL"))
+        _, total_errors, total_warnings, total_infos, total_waived = total_row.split()
+        assert (total_errors, total_warnings, total_infos, total_waived) == ("0", "0", "0", "1")
+
+        # The prose "DRC:" line (from the meta-check stanza) is computed
+        # independently via `is_warning`, which also excludes waived
+        # findings -- the two totals must agree.
+        prose_match = re.search(
+            r"DRC:\s+\S+\s+\(\d+ rules checked, (\d+) error\(s\), (\d+) warning\(s\)\)",
+            out,
+        )
+        assert prose_match is not None
+        prose_errors, prose_warnings = prose_match.groups()
+        assert prose_errors == total_errors
+        assert prose_warnings == total_warnings
+
+    def test_output_summary_waived_warning_and_info_excluded_from_own_severity(
+        self, tmp_path, capsys
+    ):
+        """Direct unit test: waived warnings/infos must not leak into the
+
+        ``Warnings``/``Infos`` columns either -- the ``is_waived``-first
+        bucket order fixes all three severities at once (not just error).
+        """
+        violations = [
+            DRCViolation(
+                rule_id="clearance_trace_trace",
+                severity="warning",
+                message="waived warning",
+                waived=True,
+                waiver_reason="test",
+                waiver_issue="x#1",
+            ),
+            DRCViolation(
+                rule_id="clearance_trace_trace",
+                severity="warning",
+                message="live warning",
+            ),
+            DRCViolation(
+                rule_id="silkscreen_overlap",
+                severity="info",
+                message="waived info",
+                waived=True,
+                waiver_reason="test",
+                waiver_issue="x#2",
+            ),
+        ]
+        results = DRCResults(violations=violations, rules_checked=2)
+        check_cmd.output_summary(violations, results, tmp_path / "board.kicad_pcb")
+        out = capsys.readouterr().out
+
+        clearance_row = next(
+            line for line in out.splitlines() if line.startswith("clearance_trace_trace")
+        )
+        _, errors, warnings, infos, waived = clearance_row.split()
+        assert (errors, warnings, infos, waived) == ("0", "1", "0", "1")
+
+        silkscreen_row = next(
+            line for line in out.splitlines() if line.startswith("silkscreen_overlap")
+        )
+        _, s_errors, s_warnings, s_infos, s_waived = silkscreen_row.split()
+        assert (s_errors, s_warnings, s_infos, s_waived) == ("0", "0", "0", "1")
+
+        total_row = next(line for line in out.splitlines() if line.startswith("TOTAL"))
+        _, t_errors, t_warnings, t_infos, t_waived = total_row.split()
+        assert (t_errors, t_warnings, t_infos, t_waived) == ("0", "1", "0", "2")


### PR DESCRIPTION
## Summary

Closes #4696

`kct check --format summary` printed two disagreeing totals in the same
output: the per-rule table's `Warnings` column folded in waived findings
(all severities), while the `DRC:` prose line beneath (computed from
`is_warning`, which correctly excludes waived) did not — so `TOTAL Warnings`
and the prose warning count diverged by exactly the waived count.

Root cause: `output_summary`'s bucket cascade checked `is_error` then
`is_info`, falling through to a bare `else` (`warnings`) for anything else.
`DRCViolation.is_error` / `is_warning` / `is_info` all return `False` for a
waived finding, so every waived finding — regardless of its real severity —
fell into the `else` branch and was misreported as a warning.

## Fix

`output_summary` now checks `v.is_waived` first in the bucket cascade (before
`is_error`/`is_info`), adds a `waived` bucket per rule, and renders it as a
new `Waived` column in the header, per-rule rows, and `TOTAL` row —
mirroring `output_table`'s existing pattern (`check_cmd.py:2774-2782`).

Only `output_summary` was touched. `output_json` / `write_json_report` and
the `--output` JSON report are unchanged (already correct per the issue).

## Test plan

- New tests in `tests/test_cli_check_waivers.py::TestFormatSummaryWaived`:
  - `test_waived_error_gets_own_column_and_totals_agree_with_prose` — end to
    end via `check_cmd.main(..., "--format", "summary")` with a waived
    `courtyards_overlap` error: asserts the `Waived` header is present, the
    rule row shows `0 errors / 0 warnings / 0 infos / 1 waived`, and the
    `TOTAL` row's Errors/Warnings agree with the parsed `DRC:` prose line's
    error(s)/warning(s) counts.
  - `test_output_summary_waived_warning_and_info_excluded_from_own_severity`
    — direct unit test of `output_summary` with synthetic `DRCViolation`s
    covering a waived *warning* and a waived *info*, confirming the
    `is_waived`-first fix applies to all three severities, not just error.
- Full existing suite in `tests/test_cli_check_waivers.py` (7 tests) and
  `tests/test_cli_check.py` / `tests/test_kct_check_parity.py` pass
  unchanged — confirms `--format json` semantics are untouched.
- Manual repro of the issue's example (waived `courtyards_overlap` error,
  `--format summary --drc-only`) now prints `0 0 0 1` for the rule and
  `TOTAL 0 0 0 1` instead of misfiling the waived error under `Warnings`.

```
$ uv run pytest tests/test_cli_check_waivers.py -q
9 passed in 0.55s

$ uv run ruff check src/kicad_tools/cli/check_cmd.py tests/test_cli_check_waivers.py
All checks passed!

$ uv run ruff format --check src/kicad_tools/cli/check_cmd.py tests/test_cli_check_waivers.py
2 files already formatted

$ uv run python scripts/ci/check_mypy_baseline.py
OK: mypy reports 1473 error(s), all within the baseline (1475 allowed). No new type errors.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)