### PR TITLE
fix(router): withdraw the deterministic-rescue default flip, keep the per-call switch

### DIFF
--- a/boards/06-diffpair-test/README.md
+++ b/boards/06-diffpair-test/README.md
@@ -165,14 +165,11 @@ bisection localized **three** sources:
    line-identical up to the rescue.  Fixed with
    `route_all_negotiated(deterministic_rescue=True)`, which bounds the
    rescue's probe / re-land sub-searches by the deterministic per-net
-   node-expansion cap instead.  This board opted in first (#4536); #4730
-   made it the **default** for every expansion-capped *negotiated* run
-   (`--deterministic-budget` / `per_net_iterations`), leaving capless runs
-   on the historical wall clock by construction — and leaving the
-   escape/two-phase path (boards 03/04/07) on it too, where board 07's
-   measured regression scoped the flip out
-   (`TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT`).  The explicit `True` here
-   is kept as documentation because it is **load-bearing for
+   node-expansion cap instead.  This board opted in first (#4536) and
+   remains an explicit opt-in: #4730 proposed making it the fleet default
+   and withdrew the flip on a measured board-07 regression, so
+   `DETERMINISTIC_RESCUE_DEFAULT` is `False` on every entry point.  The
+   `True` here is therefore not documentary — it is **load-bearing for
    `REQUIRED_SIGNAL_REACH = 21`** in
    `scripts/ci/check_diffpair_coverage.py`.
 

--- a/boards/06-diffpair-test/README.md
+++ b/boards/06-diffpair-test/README.md
@@ -166,9 +166,12 @@ bisection localized **three** sources:
    `route_all_negotiated(deterministic_rescue=True)`, which bounds the
    rescue's probe / re-land sub-searches by the deterministic per-net
    node-expansion cap instead.  This board opted in first (#4536); #4730
-   made it the **default** for every expansion-capped run
+   made it the **default** for every expansion-capped *negotiated* run
    (`--deterministic-budget` / `per_net_iterations`), leaving capless runs
-   on the historical wall clock by construction.  The explicit `True` here
+   on the historical wall clock by construction — and leaving the
+   escape/two-phase path (boards 03/04/07) on it too, where board 07's
+   measured regression scoped the flip out
+   (`TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT`).  The explicit `True` here
    is kept as documentation because it is **load-bearing for
    `REQUIRED_SIGNAL_REACH = 21`** in
    `scripts/ci/check_diffpair_coverage.py`.

--- a/boards/06-diffpair-test/README.md
+++ b/boards/06-diffpair-test/README.md
@@ -163,10 +163,14 @@ bisection localized **three** sources:
    8--12 s natural time on GitHub runners, so the same commit produced
    21/21 on one runner and 20/21 on another from routing logs that are
    line-identical up to the rescue.  Fixed with
-   `route_all_negotiated(deterministic_rescue=True)` (default off
-   elsewhere), which bounds the rescue's probe / re-land sub-searches by
-   the deterministic per-net node-expansion cap instead.  This flag is
-   **load-bearing for `REQUIRED_SIGNAL_REACH = 21`** in
+   `route_all_negotiated(deterministic_rescue=True)`, which bounds the
+   rescue's probe / re-land sub-searches by the deterministic per-net
+   node-expansion cap instead.  This board opted in first (#4536); #4730
+   made it the **default** for every expansion-capped run
+   (`--deterministic-budget` / `per_net_iterations`), leaving capless runs
+   on the historical wall clock by construction.  The explicit `True` here
+   is kept as documentation because it is **load-bearing for
+   `REQUIRED_SIGNAL_REACH = 21`** in
    `scripts/ci/check_diffpair_coverage.py`.
 
 3. **Residual: UUID-sorted file order.**  With the wall clock removed,

--- a/boards/06-diffpair-test/generate_design.py
+++ b/boards/06-diffpair-test/generate_design.py
@@ -2783,14 +2783,12 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
         # node-expansion cap instead makes the commit/rollback decision
         # machine-independent -- the point of this issue.
         #
-        # #4730 made ``deterministic_rescue=True`` the DEFAULT of
-        # ``route_all_negotiated`` (it self-scopes to expansion-capped runs,
-        # and this board is one; the two-phase/escape path stayed on the wall
-        # clock after board 07 regressed), so the explicit kwarg below is now
-        # redundant on this path.  It is KEPT deliberately, as
-        # executable documentation of the load-bearing dependency above: this
-        # board's reach gate must not silently inherit a default that a future
-        # fleet-wide A/B could flip back.
+        # #4730 proposed making ``deterministic_rescue=True`` the fleet
+        # default and WITHDREW the flip on a measured board-07 regression
+        # (``DETERMINISTIC_RESCUE_DEFAULT`` is ``False``), so the explicit
+        # kwarg below is the only thing switching the deterministic bound on
+        # for this board.  Do not drop it on the assumption that a default
+        # covers it.
         return router.route_all_negotiated(
             per_net_timeout=None,
             timeout=None,

--- a/boards/06-diffpair-test/generate_design.py
+++ b/boards/06-diffpair-test/generate_design.py
@@ -2783,9 +2783,11 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
         # node-expansion cap instead makes the commit/rollback decision
         # machine-independent -- the point of this issue.
         #
-        # #4730 made ``deterministic_rescue=True`` the fleet DEFAULT (it
-        # self-scopes to expansion-capped runs, and this board is one), so the
-        # explicit kwarg below is now redundant.  It is KEPT deliberately, as
+        # #4730 made ``deterministic_rescue=True`` the DEFAULT of
+        # ``route_all_negotiated`` (it self-scopes to expansion-capped runs,
+        # and this board is one; the two-phase/escape path stayed on the wall
+        # clock after board 07 regressed), so the explicit kwarg below is now
+        # redundant on this path.  It is KEPT deliberately, as
         # executable documentation of the load-bearing dependency above: this
         # board's reach gate must not silently inherit a default that a future
         # fleet-wide A/B could flip back.

--- a/boards/06-diffpair-test/generate_design.py
+++ b/boards/06-diffpair-test/generate_design.py
@@ -2782,6 +2782,13 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
         # to that point.  Bounding those sub-searches by the per-net
         # node-expansion cap instead makes the commit/rollback decision
         # machine-independent -- the point of this issue.
+        #
+        # #4730 made ``deterministic_rescue=True`` the fleet DEFAULT (it
+        # self-scopes to expansion-capped runs, and this board is one), so the
+        # explicit kwarg below is now redundant.  It is KEPT deliberately, as
+        # executable documentation of the load-bearing dependency above: this
+        # board's reach gate must not silently inherit a default that a future
+        # fleet-wide A/B could flip back.
         return router.route_all_negotiated(
             per_net_timeout=None,
             timeout=None,

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -214,6 +214,14 @@ def _normalize_deterministic_budget(args, quiet: bool = False) -> None:
     live -- so no ``kct route`` call site passes the flag explicitly, and a
     run without ``--deterministic-budget`` keeps the historical
     ``RELIEF_SUBSEARCH_BUDGET_S`` wall clock unchanged.
+
+    That flip is scoped to the NEGOTIATED entry point.  Escape-routed boards
+    (03/04/07) go through ``route_with_escape`` -> ``route_all_two_phase``,
+    which defaults to ``TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT`` (``False``)
+    because board 07 regressed on that path in the #4730 fleet A/B (changed
+    LVS open set, routed-DRC 8 -> 13).  ``--deterministic-budget`` therefore
+    still means "wall-clock rescue bound" on those boards; the constant is the
+    single switch to flip when the regression is understood.
     """
     if not getattr(args, "deterministic_budget", False):
         return
@@ -5807,6 +5815,15 @@ def route_with_layer_escalation(
                 # clock.  Wiring it to the CLI flag explicitly would be
                 # equivalent here but would hide that a caller who sets
                 # ``--per-net-iterations`` alone gets the same guarantee.
+                #
+                # The escape / two-phase branches above are silent too, but for
+                # the opposite reason: ``route_with_escape`` and
+                # ``route_all_two_phase`` default to
+                # ``TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT`` (False), the
+                # documented board-07 negative result, so the escape-routed
+                # boards keep the historical wall clock until that regression
+                # is understood.  Both call sites take the kwarg, so opting a
+                # board in is a one-line change here when it is.
                 router.route_all_negotiated(
                     max_iterations=args.iterations,
                     timeout=_attempt_timeout,
@@ -6801,6 +6818,15 @@ def route_with_rule_relaxation(
                 # clock.  Wiring it to the CLI flag explicitly would be
                 # equivalent here but would hide that a caller who sets
                 # ``--per-net-iterations`` alone gets the same guarantee.
+                #
+                # The escape / two-phase branches above are silent too, but for
+                # the opposite reason: ``route_with_escape`` and
+                # ``route_all_two_phase`` default to
+                # ``TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT`` (False), the
+                # documented board-07 negative result, so the escape-routed
+                # boards keep the historical wall clock until that regression
+                # is understood.  Both call sites take the kwarg, so opting a
+                # board in is a one-line change here when it is.
                 router.route_all_negotiated(
                     max_iterations=args.iterations,
                     timeout=_attempt_timeout,

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -206,22 +206,14 @@ def _normalize_deterministic_budget(args, quiet: bool = False) -> None:
     No-op when ``--deterministic-budget`` is not set, so legacy behaviour is
     preserved bit-for-bit.
 
-    Issue #4730: the pinned caps in (2)/(2b) are also what activates the
-    DETERMINISTIC relief-rescue sub-search bound.  ``route_all_negotiated``
-    defaults ``deterministic_rescue=True``, and
-    ``Autorouter._relief_subsearch_budget`` hands the rescue's probe /
-    victim-re-land searches over to the node-expansion cap only when one is
-    live -- so no ``kct route`` call site passes the flag explicitly, and a
-    run without ``--deterministic-budget`` keeps the historical
-    ``RELIEF_SUBSEARCH_BUDGET_S`` wall clock unchanged.
-
-    That flip is scoped to the NEGOTIATED entry point.  Escape-routed boards
-    (03/04/07) go through ``route_with_escape`` -> ``route_all_two_phase``,
-    which defaults to ``TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT`` (``False``)
-    because board 07 regressed on that path in the #4730 fleet A/B (changed
-    LVS open set, routed-DRC 8 -> 13).  ``--deterministic-budget`` therefore
-    still means "wall-clock rescue bound" on those boards; the constant is the
-    single switch to flip when the regression is understood.
+    Issue #4730: the pinned caps in (2)/(2b) are what a DETERMINISTIC
+    relief-rescue sub-search bound would hand its probe / victim-re-land
+    searches to -- but that bound stays OPT-IN
+    (``DETERMINISTIC_RESCUE_DEFAULT`` is ``False``): board 07 regressed with it
+    on (changed LVS open set, routed-DRC 8 -> 13 against an allowlist main sits
+    exactly at), so ``--deterministic-budget`` still means "wall-clock rescue
+    bound" for every ``kct route`` caller.  No call site passes the flag; the
+    constant is the single switch to flip when that regression is understood.
     """
     if not getattr(args, "deterministic_budget", False):
         return
@@ -5807,23 +5799,16 @@ def route_with_layer_escalation(
                 )
             elif args.strategy == "negotiated":
                 # Issue #4730: ``deterministic_rescue`` is deliberately NOT
-                # passed here.  Its default is ``DETERMINISTIC_RESCUE_DEFAULT``
-                # (True) and ``_relief_subsearch_budget`` only hands the relief
-                # rescue's sub-searches to the node-expansion cap when one is
-                # live, so the flag self-scopes to ``--deterministic-budget``
-                # runs and a plain ``kct route`` keeps the historical wall
-                # clock.  Wiring it to the CLI flag explicitly would be
-                # equivalent here but would hide that a caller who sets
-                # ``--per-net-iterations`` alone gets the same guarantee.
-                #
-                # The escape / two-phase branches above are silent too, but for
-                # the opposite reason: ``route_with_escape`` and
-                # ``route_all_two_phase`` default to
-                # ``TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT`` (False), the
-                # documented board-07 negative result, so the escape-routed
-                # boards keep the historical wall clock until that regression
-                # is understood.  Both call sites take the kwarg, so opting a
-                # board in is a one-line change here when it is.
+                # passed here -- and neither is it on the escape / two-phase
+                # branches above.  Every one of those entry points defaults to
+                # ``DETERMINISTIC_RESCUE_DEFAULT`` (False), the documented
+                # board-07 negative result: with the deterministic bound in
+                # force board 07's copper-LVS open set changed and its
+                # routed-DRC went 8 -> 13 against an allowlist main sits
+                # exactly at.  So ``kct route`` keeps the historical wall clock
+                # on every path until that regression is understood.  All the
+                # call sites take the kwarg, so opting a board in is a one-line
+                # change here once its own A/B backs it.
                 router.route_all_negotiated(
                     max_iterations=args.iterations,
                     timeout=_attempt_timeout,
@@ -6810,23 +6795,16 @@ def route_with_rule_relaxation(
                 )
             elif args.strategy == "negotiated":
                 # Issue #4730: ``deterministic_rescue`` is deliberately NOT
-                # passed here.  Its default is ``DETERMINISTIC_RESCUE_DEFAULT``
-                # (True) and ``_relief_subsearch_budget`` only hands the relief
-                # rescue's sub-searches to the node-expansion cap when one is
-                # live, so the flag self-scopes to ``--deterministic-budget``
-                # runs and a plain ``kct route`` keeps the historical wall
-                # clock.  Wiring it to the CLI flag explicitly would be
-                # equivalent here but would hide that a caller who sets
-                # ``--per-net-iterations`` alone gets the same guarantee.
-                #
-                # The escape / two-phase branches above are silent too, but for
-                # the opposite reason: ``route_with_escape`` and
-                # ``route_all_two_phase`` default to
-                # ``TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT`` (False), the
-                # documented board-07 negative result, so the escape-routed
-                # boards keep the historical wall clock until that regression
-                # is understood.  Both call sites take the kwarg, so opting a
-                # board in is a one-line change here when it is.
+                # passed here -- and neither is it on the escape / two-phase
+                # branches above.  Every one of those entry points defaults to
+                # ``DETERMINISTIC_RESCUE_DEFAULT`` (False), the documented
+                # board-07 negative result: with the deterministic bound in
+                # force board 07's copper-LVS open set changed and its
+                # routed-DRC went 8 -> 13 against an allowlist main sits
+                # exactly at.  So ``kct route`` keeps the historical wall clock
+                # on every path until that regression is understood.  All the
+                # call sites take the kwarg, so opting a board in is a one-line
+                # change here once its own A/B backs it.
                 router.route_all_negotiated(
                     max_iterations=args.iterations,
                     timeout=_attempt_timeout,

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -205,6 +205,15 @@ def _normalize_deterministic_budget(args, quiet: bool = False) -> None:
 
     No-op when ``--deterministic-budget`` is not set, so legacy behaviour is
     preserved bit-for-bit.
+
+    Issue #4730: the pinned caps in (2)/(2b) are also what activates the
+    DETERMINISTIC relief-rescue sub-search bound.  ``route_all_negotiated``
+    defaults ``deterministic_rescue=True``, and
+    ``Autorouter._relief_subsearch_budget`` hands the rescue's probe /
+    victim-re-land searches over to the node-expansion cap only when one is
+    live -- so no ``kct route`` call site passes the flag explicitly, and a
+    run without ``--deterministic-budget`` keeps the historical
+    ``RELIEF_SUBSEARCH_BUDGET_S`` wall clock unchanged.
     """
     if not getattr(args, "deterministic_budget", False):
         return
@@ -5789,6 +5798,15 @@ def route_with_layer_escalation(
                     max_iterations=getattr(args, "two_phase_iterations", None) or args.iterations,
                 )
             elif args.strategy == "negotiated":
+                # Issue #4730: ``deterministic_rescue`` is deliberately NOT
+                # passed here.  Its default is ``DETERMINISTIC_RESCUE_DEFAULT``
+                # (True) and ``_relief_subsearch_budget`` only hands the relief
+                # rescue's sub-searches to the node-expansion cap when one is
+                # live, so the flag self-scopes to ``--deterministic-budget``
+                # runs and a plain ``kct route`` keeps the historical wall
+                # clock.  Wiring it to the CLI flag explicitly would be
+                # equivalent here but would hide that a caller who sets
+                # ``--per-net-iterations`` alone gets the same guarantee.
                 router.route_all_negotiated(
                     max_iterations=args.iterations,
                     timeout=_attempt_timeout,
@@ -6774,6 +6792,15 @@ def route_with_rule_relaxation(
                     max_iterations=getattr(args, "two_phase_iterations", None) or args.iterations,
                 )
             elif args.strategy == "negotiated":
+                # Issue #4730: ``deterministic_rescue`` is deliberately NOT
+                # passed here.  Its default is ``DETERMINISTIC_RESCUE_DEFAULT``
+                # (True) and ``_relief_subsearch_budget`` only hands the relief
+                # rescue's sub-searches to the node-expansion cap when one is
+                # live, so the flag self-scopes to ``--deterministic-budget``
+                # runs and a plain ``kct route`` keeps the historical wall
+                # clock.  Wiring it to the CLI flag explicitly would be
+                # equivalent here but would hide that a caller who sets
+                # ``--per-net-iterations`` alone gets the same guarantee.
                 router.route_all_negotiated(
                     max_iterations=args.iterations,
                     timeout=_attempt_timeout,

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -12685,11 +12685,15 @@ class Autorouter:
             deterministic_rescue: Issue #4536 / #4730 -- bound the
                 rescue's SUB-searches (probe rounds, victim re-lands) by
                 the deterministic per-net NODE-EXPANSION cap instead of
-                the ``RELIEF_SUBSEARCH_BUDGET_S`` wall clock.  Default
-                True (#4730), which also covers the two-phase stall-relief
-                hook that calls this method positionally; without an
-                active expansion cap the wall clock is kept, so capless
-                callers are unaffected.  See
+                the ``RELIEF_SUBSEARCH_BUDGET_S`` wall clock.  Defaults to
+                :data:`DETERMINISTIC_RESCUE_DEFAULT` (``False`` -- #4730
+                measured a board-07 regression with it on, so it stays
+                opt-in).  The two-phase stall-relief hook calls this
+                method POSITIONALLY, so it carries the value on a
+                ``functools.partial`` bound in
+                :meth:`_create_two_phase_router` rather than inheriting
+                this signature default.  Without an active expansion cap
+                the wall clock is kept either way.  See
                 :meth:`_relief_subsearch_budget` for the measurement that
                 motivates it and the load-bearing consequences.
 

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -168,14 +168,13 @@ _ESCAPE_CORRIDOR_INNER_LAYERS_ONLY = True
 # runs 31214686048 vs 31213011136 are line-identical up to the MIPI_RST rescue
 # and then diverge on whether MIPI_CLK- re-lands).
 #
-# Issue #4730 therefore made ``deterministic_rescue=True`` the DEFAULT of the
-# NEGOTIATED entry point: whenever a per-net node-expansion cap is active
-# (``--deterministic-budget`` / ``per_net_iterations``) these sub-searches are
-# bounded by that cap instead and this wall clock stops deciding reach.  It
-# still binds -- unchanged, by construction -- on capless runs, for callers that
-# explicitly opt out with ``deterministic_rescue=False``, and on the two-phase
-# path (see ``TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT`` for the board-07 A/B that
-# scoped the flip out of it).
+# ``deterministic_rescue=True`` swaps this wall clock for the per-net
+# node-expansion cap whenever one is active (``--deterministic-budget`` /
+# ``per_net_iterations``), which takes machine speed out of the rescue's
+# commit/roll-back decision.  Issue #4730 tried making that the fleet default
+# and MEASURED A REGRESSION -- see ``DETERMINISTIC_RESCUE_DEFAULT`` -- so this
+# value remains the default bound everywhere except callers that opt in
+# explicitly (board 06).
 RELIEF_SUBSEARCH_BUDGET_S = 10.0
 
 # Issue #4536: the wall clock kept under ``deterministic_rescue=True``.  It is
@@ -187,31 +186,20 @@ RELIEF_SUBSEARCH_BUDGET_S = 10.0
 # for minutes inside a rescue, per the #3989 lesson.
 RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S = 120.0
 
-# Issue #4730: the default for the relief-rescue sub-search bound on the
-# NEGOTIATED entry point -- shared by :meth:`Autorouter.route_all_negotiated`
-# and :meth:`Autorouter._relief_rescue`.  Named rather than repeated as a
-# literal so the sites cannot drift, and so the fleet A/B that flipped it has a
-# single greppable switch to flip back.
+# Issue #4730: the default for the relief-rescue sub-search bound, shared by
+# every entry point that can reach a rescue -- :meth:`Autorouter._relief_rescue`,
+# :meth:`Autorouter.route_all_negotiated`, :meth:`Autorouter.route_all_two_phase`,
+# :meth:`Autorouter._create_two_phase_router` and the ``route_with_escape*``
+# forwarders.  Named rather than repeated as a literal so the sites cannot
+# drift, and so a future flip has a single greppable switch.
 #
-# Safe by construction: ``_relief_subsearch_budget`` only hands the sub-searches
-# to the node-expansion cap when one is ACTIVE, so a capless run selects
-# ``RELIEF_SUBSEARCH_BUDGET_S`` exactly as it did before the flip.
-#
-# Fleet A/B (boards 00-06 + board-05 routing regression + diff-pair regression)
-# is green on this path: A = PR head 6071d1b2, CI run 31281260812; B = main
-# 6cfa8842, run 31277512785.  The TWO-PHASE path is scoped out -- see
-# ``TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT`` below.
-DETERMINISTIC_RESCUE_DEFAULT = True
-
-# Issue #4730: the TWO-PHASE entry point keeps the historical wall clock.
-#
-# This is the issue's documented per-board NEGATIVE RESULT, not an oversight.
-# ``kct route`` sends every escape-routed board (03/04/07 auto-enable on dense
-# packages) through ``route_with_escape`` -> :meth:`Autorouter.route_all_two_phase`,
-# whose #3471 stall-relief hook reaches ``_relief_rescue``.  With the flip
-# inherited there, board 07 -- the only board whose two-phase route actually
-# fires rescues -- regressed in the fleet A/B (A = PR head 6071d1b2, CI run
-# 31281260812; B = main 6cfa8842, run 31277512785):
+# It stays OPT-IN (``False``).  #4730 proposed making the deterministic bound
+# the fleet default and the A/B says no: board 07 -- routed through the
+# NEGOTIATED entry point (``route_all_negotiated``; its log prints the
+# ``iteration-bounded`` arm 3x, the two-phase banner not at all) -- regressed
+# with the flip in force.  Measured twice, on two heads and two runners
+# (A = 6071d1b2 / CI run 31281260812 and 721fc052 / run 31283738762;
+# B = main 6cfa8842 / run 31277512785):
 #
 #   * Board 07 E2E: the copper-LVS open set changed from
 #     {DQ3, DQ4, MIPI_DAT0_N, TMDS_D0_N, TMDS_D1_N} to
@@ -223,17 +211,21 @@ DETERMINISTIC_RESCUE_DEFAULT = True
 # #4730's Acceptance forbids absorbing that ("No board's DRC allowlist is
 # raised to absorb a regression"; "If any board regresses on reach or DRC, keep
 # the opt-in and document the per-board decision instead of forcing the
-# default"), so the flip is SCOPED to the negotiated entry point and this path
-# stays byte-identical to pre-#4730.
+# default"), so this is the issue's recorded NEGATIVE RESULT, not an oversight.
+# An earlier attempt scoped the flip out of the TWO-PHASE path instead; that
+# attribution was wrong -- board 07 never reaches ``route_all_two_phase``, and
+# the regression reproduced unchanged.
 #
-# The path is no longer hard-wired, though -- that was the second defect the
-# scoping had to fix.  ``route_all_two_phase(deterministic_rescue=True)`` (and
-# the ``route_with_escape`` / ``route_with_escape_and_diffpairs`` forwarders)
-# opt in per call, and ``_create_two_phase_router`` binds the value onto the
-# positional stall-relief hook, so a future flip has a real switch: change this
-# constant once board 07's rescue outcome (which nets its rescues keep, and why
-# the kept copper carries +5 DRC) is understood.
-TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT = False
+# What #4730 did land is the per-call switch.  Every entry point above takes
+# ``deterministic_rescue``, and ``_create_two_phase_router`` binds it onto the
+# positional #3471 stall-relief hook with a ``functools.partial``, so opting a
+# path in (or a future fleet flip) is a value change backed by measurement
+# rather than a rewiring job.  Board 06 depends on the opt-in: it passes
+# ``deterministic_rescue=True`` explicitly because its 21/21 reach gate is
+# otherwise a coin flip on runner speed.  Reattempting the flip means first
+# understanding board 07's rescue outcome -- which nets its rescues keep, and
+# why the kept copper carries +5 DRC.
+DETERMINISTIC_RESCUE_DEFAULT = False
 
 
 @dataclass
@@ -9001,15 +8993,15 @@ class Autorouter:
                 identically on every machine.  Requires an active
                 expansion cap (``--deterministic-budget`` /
                 ``per_net_iterations``); without one the wall clock is
-                kept, so a capless run is behavior-identical BY
-                CONSTRUCTION.  Default True (#4730): the rescue is a
-                transaction whose budget decides routed REACH, and a
+                kept.  Worth opting into where the rescue decides a
+                reach gate -- board 06 reached 21/21 on a fast runner
+                and 20/21 on a slow one at the same commit, because the
                 10 s wall clock straddles the measured 8-12 s natural
-                re-land time on CI runners -- board 06 reached 21/21 on
-                a fast runner and 20/21 on a slow one at the same
-                commit.  Pass ``False`` to force the historical
-                wall-clock bound (A/B comparison / regression
-                bisection).  See :meth:`_relief_subsearch_budget`.
+                re-land time on CI runners.  Defaults to
+                :data:`DETERMINISTIC_RESCUE_DEFAULT` (``False``): #4730
+                measured a board-07 regression on this entry point with
+                it on, so it stays opt-in.  See that constant and
+                :meth:`_relief_subsearch_budget`.
 
         Returns:
             List of routes (may be partial if timeout reached)
@@ -9032,20 +9024,18 @@ class Autorouter:
 
         # If hierarchical mode is requested, delegate to two-phase routing.
         #
-        # Issue #4730: ``deterministic_rescue`` is deliberately NOT forwarded
-        # here.  This method's default is ``DETERMINISTIC_RESCUE_DEFAULT``
-        # (True), so forwarding it would silently re-flip the two-phase path
-        # that the board-07 A/B scoped out (see
-        # ``TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT``) for every caller that
-        # merely asked for hierarchical mode.  A caller that wants the
-        # deterministic bound on the two-phase path calls
-        # ``route_all_two_phase(deterministic_rescue=True)`` directly.
+        # Issue #4730: forward ``deterministic_rescue`` so a caller's explicit
+        # opt-in is not silently dropped on the way to the path that actually
+        # runs the rescue.  Both signatures share
+        # ``DETERMINISTIC_RESCUE_DEFAULT``, so this changes nothing for a
+        # default call.
         if hierarchical:
             return self.route_all_two_phase(
                 use_negotiated=True,
                 corridor_width_factor=2.0,
                 progress_callback=progress_callback,
                 timeout=timeout,
+                deterministic_rescue=deterministic_rescue,
             )
 
         # Issue #3474 R1 (budget integrity): when a stage budget exists but
@@ -9098,13 +9088,9 @@ class Autorouter:
 
         # Issue #4536: record the relief-rescue sub-search bound in the log --
         # it decides whether a rescue commits (reach!), so it must be visible
-        # in any routing log used as evidence.
-        #
-        # Issue #4730: ``deterministic_rescue`` now defaults to True, so the
-        # wall-clock arm is reached by ordinary capless runs that never
-        # "requested" anything -- its wording must stay neutral.  Only the
-        # opt-out arm can name a caller decision, because with a True default
-        # ``deterministic_rescue=False`` is necessarily explicit.
+        # in any routing log used as evidence.  It reports the value THIS call
+        # is running under, so an opt-in run is distinguishable in the log from
+        # the default (#4730).
         flush_print(self._relief_subsearch_bound_line(per_net_timeout, deterministic_rescue))
 
         # Issue #2587 / Epic #2556 Phase 1C-cont: Activate diff-pair partner
@@ -12581,15 +12567,13 @@ class Autorouter:
         historical wall clock is kept (degrading to the pre-#4536
         behavior rather than to an unbounded search).
 
-        Issue #4730 made ``deterministic_rescue=True`` the DEFAULT of
-        :meth:`route_all_negotiated` and :meth:`_relief_rescue`.  That
-        capless fallback is what makes the flipped default safe by
-        construction: it is scoped to exactly the runs that already have
-        a machine-independent bound to hand over to, and every capless
-        run keeps selecting ``RELIEF_SUBSEARCH_BUDGET_S`` unchanged.
-        :meth:`route_all_two_phase` is scoped out of the flip on a measured
-        board-07 regression (:data:`TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT`)
-        and passes ``False`` down to its stall-relief hook.
+        Issue #4730 proposed making ``deterministic_rescue=True`` the
+        fleet default and measured a board-07 regression on the
+        negotiated entry point, so it stays OPT-IN
+        (:data:`DETERMINISTIC_RESCUE_DEFAULT` is ``False``); board 06
+        opts in explicitly.  Every entry point that can reach a rescue
+        now carries the value per call, so the choice is made where the
+        measurement is.
         """
         if deterministic_rescue:
             expansion_cap = min(
@@ -12620,23 +12604,20 @@ class Autorouter:
         ``iteration-bounded`` wording is the greppable evidence line; do not
         reword it.
 
-        Issue #4730 flipped ``deterministic_rescue`` to default True on the
-        negotiated entry point, which makes the wall-clock arm reachable by an
-        ordinary capless run that never "requested" anything -- so that arm's
-        wording is NEUTRAL (it states the fact, not a caller decision).
-
-        The third arm (deterministic rescue OFF) is reached two ways, so it
-        names neither: an explicit ``deterministic_rescue=False`` from a
-        caller, or :meth:`route_all_two_phase`'s own
-        :data:`TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT` (``False``, the board-07
-        negative result recorded at that constant).
+        The arms state facts, not caller intent.  The deterministic bound is
+        opt-in (:data:`DETERMINISTIC_RESCUE_DEFAULT` is ``False`` after #4730's
+        measured board-07 regression), so the OFF arm is reached both by the
+        ordinary default and by an explicit opt-out, and the capless
+        wall-clock arm is reached by an opt-in run that simply has no
+        expansion cap to hand the sub-searches to.  Neither arm claims a
+        request it cannot know about.
 
         Emitted by both routing entry points that can reach a relief rescue:
         :meth:`route_all_negotiated` and :meth:`route_all_two_phase` (whose
         stall-relief hook, #3471, calls :meth:`_relief_rescue` positionally
         with the bound bound on by ``functools.partial``).  Each reports the
-        value ITS call is running under, so the two paths' different defaults
-        are visible in the log rather than assumed.
+        value ITS call is running under, so an opt-in is visible in the log
+        rather than assumed.
         """
         budget = self._relief_subsearch_budget(per_net_timeout, deterministic_rescue)
         if deterministic_rescue and budget == RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S:
@@ -12656,8 +12637,8 @@ class Autorouter:
             )
         return (
             f"  Relief-rescue sub-search cap: {wall_clock:.1f}s wall clock -- "
-            "deterministic rescue is off for this route (explicit caller opt-out, "
-            "or the two-phase path default; issue #4730)"
+            "deterministic rescue is off for this route (the default; opt in with "
+            "deterministic_rescue=True; issue #4730)"
         )
 
     def _relief_rescue(
@@ -14082,7 +14063,7 @@ class Autorouter:
 
     def _create_two_phase_router(
         self,
-        deterministic_rescue: bool = TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT,
+        deterministic_rescue: bool = DETERMINISTIC_RESCUE_DEFAULT,
     ) -> TwoPhaseRouter:
         """Create a TwoPhaseRouter with access to Autorouter state.
 
@@ -14090,10 +14071,10 @@ class Autorouter:
             deterministic_rescue: Bound the #3471 stall-relief hook's rescue
                 sub-searches by the per-net node-expansion cap instead of the
                 ``RELIEF_SUBSEARCH_BUDGET_S`` wall clock (Issue #4536).
-                Defaults to :data:`TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT`
-                (``False``) -- see that constant for the board-07 A/B that
-                scoped #4730's fleet flip out of this path, and why the value
-                must remain reachable per call rather than hard-wired.
+                Defaults to :data:`DETERMINISTIC_RESCUE_DEFAULT` (``False``) --
+                see that constant for #4730's measured negative result and why
+                the value must remain reachable per call rather than
+                hard-wired.
         """
 
         # Issue #2527: Provide a builder for ``pads_by_net`` that honours
@@ -14162,8 +14143,8 @@ class Autorouter:
             # 8 arguments, so binding the sub-search bound as a keyword is the
             # only way this path can carry a value other than the method's own
             # signature default.  Without the partial the two-phase path had no
-            # opt-out at all (and, with #4730's flip, silently inherited
-            # ``DETERMINISTIC_RESCUE_DEFAULT``).
+            # switch at all -- it silently inherited whatever
+            # ``_relief_rescue``'s signature said.
             relief_rescue=functools.partial(
                 self._relief_rescue, deterministic_rescue=deterministic_rescue
             ),
@@ -14179,7 +14160,7 @@ class Autorouter:
         per_net_timeout: float | None = None,
         initial_routes: list[Route] | None = None,
         max_iterations: int = 20,
-        deterministic_rescue: bool = TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT,
+        deterministic_rescue: bool = DETERMINISTIC_RESCUE_DEFAULT,
     ) -> list[Route]:
         """Route all nets using two-phase global+detailed routing.
 
@@ -14205,12 +14186,9 @@ class Autorouter:
             deterministic_rescue: Bound the #3471 stall-relief hook's relief
                 rescue sub-searches by the per-net node-expansion cap instead
                 of the ``RELIEF_SUBSEARCH_BUDGET_S`` wall clock (Issue #4536).
-                Defaults to :data:`TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT`
-                (``False``): #4730 flipped the NEGOTIATED entry point's default
-                to ``True`` but board 07 -- routed through this path -- came
-                back with a changed LVS open set and +5 routed-DRC errors over
-                an allowlist main sits exactly at, so the flip is deliberately
-                scoped out here.  Pass ``True`` to opt this path in.
+                Defaults to :data:`DETERMINISTIC_RESCUE_DEFAULT` (``False``,
+                #4730's measured negative result).  Pass ``True`` to opt this
+                path in.
 
         Returns:
             List of routes (may be partial if timeout reached or some nets fail)
@@ -17614,7 +17592,7 @@ class Autorouter:
         progress_callback: ProgressCallback | None = None,
         timeout: float | None = None,
         per_net_timeout: float | None = None,
-        deterministic_rescue: bool = TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT,
+        deterministic_rescue: bool = DETERMINISTIC_RESCUE_DEFAULT,
     ) -> tuple[list[Route], list[LengthMismatchWarning]]:
         """Compose escape routing with the differential-pair pre-pass.
 
@@ -17659,7 +17637,7 @@ class Autorouter:
             per_net_timeout: Optional per-net A* wall-clock timeout.
             deterministic_rescue: Forwarded to ``route_all_two_phase`` for the
                 main pass (Issue #4730).  Defaults to
-                :data:`TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT`.
+                :data:`DETERMINISTIC_RESCUE_DEFAULT`.
 
         Returns:
             A ``(routes, length_warnings)`` tuple mirroring
@@ -17761,7 +17739,7 @@ class Autorouter:
         progress_callback: ProgressCallback | None = None,
         timeout: float | None = None,
         per_net_timeout: float | None = None,
-        deterministic_rescue: bool = TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT,
+        deterministic_rescue: bool = DETERMINISTIC_RESCUE_DEFAULT,
     ) -> list[Route]:
         """Route with automatic escape routing for dense packages.
 
@@ -17782,10 +17760,8 @@ class Autorouter:
                 (Issue #2768; part of board 05 BLDC regression #2746).
             deterministic_rescue: Forwarded to ``route_all_two_phase``
                 (Issue #4730).  Defaults to
-                :data:`TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT` (``False``) --
-                this is the entry point ``kct route`` uses for boards 03/04/07,
-                the ones the fleet A/B measured a regression on, so the opt-in
-                is per call rather than inherited.
+                :data:`DETERMINISTIC_RESCUE_DEFAULT` (``False``) -- opting a
+                board in is a per-call decision backed by its own A/B.
 
         Returns:
             List of all routes (escapes + regular routing)

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -155,19 +155,24 @@ _ESCAPE_CORRIDOR_INNER_LAYERS_ONLY = True
 
 # Issue #4536: wall-clock budget for the relief rescue's SUB-searches (the
 # min-conflict probe rounds and the displaced-victim re-land passes inside
-# :meth:`Autorouter._relief_rescue`).  This is the historical default and is
-# LOAD-BEARING for routed reach on any board that does not opt into
-# ``deterministic_rescue`` -- a victim that fails to re-land within the budget
-# rolls the whole transaction back (no-net-loss guarantee), so the value
-# decides whether the rescued net is kept or dropped.
+# :meth:`Autorouter._relief_rescue`).  This is the historical value and is
+# LOAD-BEARING for routed reach on every run that is NOT expansion-capped -- a
+# victim that fails to re-land within the budget rolls the whole transaction
+# back (no-net-loss guarantee), so the value decides whether the rescued net is
+# kept or dropped.
 #
 # On board-06 seed-42 the natural victim re-land time sits in the 8-12 s band on
 # GitHub's ubuntu runners, i.e. this 10 s value STRADDLES it: the same commit
 # reached 21/21 on one runner and 20/21 on another purely on machine speed (CI
 # runs 31214686048 vs 31213011136 are line-identical up to the MIPI_RST rescue
-# and then diverge on whether MIPI_CLK- re-lands).  Callers that need a
-# machine-independent artifact pass ``deterministic_rescue=True``, which bounds
-# these sub-searches by the deterministic per-net NODE-EXPANSION cap instead.
+# and then diverge on whether MIPI_CLK- re-lands).
+#
+# Issue #4730 therefore made ``deterministic_rescue=True`` the DEFAULT: whenever
+# a per-net node-expansion cap is active (``--deterministic-budget`` /
+# ``per_net_iterations``) these sub-searches are bounded by that cap instead and
+# this wall clock stops deciding reach.  It still binds -- unchanged, by
+# construction -- on capless runs and for callers that explicitly opt out with
+# ``deterministic_rescue=False``.
 RELIEF_SUBSEARCH_BUDGET_S = 10.0
 
 # Issue #4536: the wall clock kept under ``deterministic_rescue=True``.  It is
@@ -178,6 +183,18 @@ RELIEF_SUBSEARCH_BUDGET_S = 10.0
 # pure-Python A* fallback, 10-100x slower than the C++ backend) from grinding
 # for minutes inside a rescue, per the #3989 lesson.
 RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S = 120.0
+
+# Issue #4730: the fleet default for the relief-rescue sub-search bound, shared
+# by :meth:`Autorouter.route_all_negotiated`, :meth:`Autorouter._relief_rescue`
+# and the two-phase stall-relief hook (which calls ``_relief_rescue``
+# positionally, so it inherits this value).  Named rather than repeated as a
+# literal so the three sites cannot drift, and so the fleet A/B that flipped it
+# has a single greppable switch to flip back.
+#
+# Safe by construction: ``_relief_subsearch_budget`` only hands the sub-searches
+# to the node-expansion cap when one is ACTIVE, so a capless run selects
+# ``RELIEF_SUBSEARCH_BUDGET_S`` exactly as it did before the flip.
+DETERMINISTIC_RESCUE_DEFAULT = True
 
 
 @dataclass
@@ -8793,7 +8810,7 @@ class Autorouter:
         best_stall_patience: int | None = 2,
         best_stall_min_iterations: int = 2,
         early_bail_terminal_stall: bool = True,
-        deterministic_rescue: bool = False,
+        deterministic_rescue: bool = DETERMINISTIC_RESCUE_DEFAULT,
     ) -> list[Route]:
         """Route all nets using PathFinder-style negotiated congestion.
 
@@ -8938,17 +8955,22 @@ class Autorouter:
                 True.  Set to ``False`` to force the historical
                 grind-to-budget behavior (A/B comparison / regression
                 bisection).
-            deterministic_rescue: Issue #4536 -- bound the relief
-                rescue's probe / victim-re-land sub-searches by the
-                deterministic per-net node-expansion cap instead of the
-                10 s wall clock, so a rescue commits or rolls back
+            deterministic_rescue: Issue #4536 / #4730 -- bound the
+                relief rescue's probe / victim-re-land sub-searches by
+                the deterministic per-net node-expansion cap instead of
+                the 10 s wall clock, so a rescue commits or rolls back
                 identically on every machine.  Requires an active
                 expansion cap (``--deterministic-budget`` /
                 ``per_net_iterations``); without one the wall clock is
-                kept.  Default False (historical behavior); board 06
-                opts in because its ``REQUIRED_SIGNAL_REACH`` gate is
-                decided by exactly one such rescue.  See
-                :meth:`_relief_subsearch_budget`.
+                kept, so a capless run is behavior-identical BY
+                CONSTRUCTION.  Default True (#4730): the rescue is a
+                transaction whose budget decides routed REACH, and a
+                10 s wall clock straddles the measured 8-12 s natural
+                re-land time on CI runners -- board 06 reached 21/21 on
+                a fast runner and 20/21 on a slow one at the same
+                commit.  Pass ``False`` to force the historical
+                wall-clock bound (A/B comparison / regression
+                bisection).  See :meth:`_relief_subsearch_budget`.
 
         Returns:
             List of routes (may be partial if timeout reached)
@@ -9029,23 +9051,13 @@ class Autorouter:
         # Issue #4536: record the relief-rescue sub-search bound in the log --
         # it decides whether a rescue commits (reach!), so it must be visible
         # in any routing log used as evidence.
-        if deterministic_rescue:
-            _rescue_budget = self._relief_subsearch_budget(per_net_timeout, True)
-            if _rescue_budget == RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S:
-                flush_print(
-                    "  Relief-rescue sub-search cap: iteration-bounded "
-                    "(per-net node-expansion cap; issue #4536) -- probe / "
-                    "victim-re-land outcomes are machine-independent; "
-                    f"{RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S:.0f}s wall clock kept "
-                    "only as a non-binding Python-fallback backstop"
-                )
-            else:
-                flush_print(
-                    "  Relief-rescue sub-search cap: "
-                    f"{_rescue_budget:.1f}s wall clock -- deterministic_rescue "
-                    "requested but no per-net node-expansion cap is active "
-                    "(issue #4536)"
-                )
+        #
+        # Issue #4730: ``deterministic_rescue`` now defaults to True, so the
+        # wall-clock arm is reached by ordinary capless runs that never
+        # "requested" anything -- its wording must stay neutral.  Only the
+        # opt-out arm can name a caller decision, because with a True default
+        # ``deterministic_rescue=False`` is necessarily explicit.
+        flush_print(self._relief_subsearch_bound_line(per_net_timeout, deterministic_rescue))
 
         # Issue #2587 / Epic #2556 Phase 1C-cont: Activate diff-pair partner
         # threading before negotiated routing begins.  This is the default
@@ -12518,8 +12530,15 @@ class Autorouter:
 
         The deterministic mode requires an active expansion cap; without
         one there is no deterministic bound to fall back on, so the
-        historical wall clock is kept (degrading to today's behavior
-        rather than to an unbounded search).
+        historical wall clock is kept (degrading to the pre-#4536
+        behavior rather than to an unbounded search).
+
+        Issue #4730 made ``deterministic_rescue=True`` the DEFAULT of
+        :meth:`route_all_negotiated` and :meth:`_relief_rescue`.  That
+        capless fallback is what makes the flipped default safe by
+        construction: it is scoped to exactly the runs that already have
+        a machine-independent bound to hand over to, and every capless
+        run keeps selecting ``RELIEF_SUBSEARCH_BUDGET_S`` unchanged.
         """
         if deterministic_rescue:
             expansion_cap = min(
@@ -12539,6 +12558,50 @@ class Autorouter:
             return min(RELIEF_SUBSEARCH_BUDGET_S, per_net_timeout)
         return RELIEF_SUBSEARCH_BUDGET_S
 
+    def _relief_subsearch_bound_line(
+        self, per_net_timeout: float | None, deterministic_rescue: bool
+    ) -> str:
+        """Routing-log line recording which relief-rescue sub-search bound is live.
+
+        Issue #4536 put this in the log because the bound decides whether a
+        rescue COMMITS -- i.e. it decides routed reach, so any routing log
+        used as A/B evidence has to say which one was in force.  The
+        ``iteration-bounded`` wording is the greppable evidence line; do not
+        reword it.
+
+        Issue #4730 flipped ``deterministic_rescue`` to default True, which
+        makes the wall-clock arm reachable by an ordinary capless run that
+        never "requested" anything -- so that arm's wording is NEUTRAL (it
+        states the fact, not a caller decision).  Only the opt-out arm names
+        a caller, because with a True default ``deterministic_rescue=False``
+        is necessarily explicit.
+
+        Emitted by both routing entry points that can reach a relief rescue:
+        :meth:`route_all_negotiated` and :meth:`route_all_two_phase` (whose
+        stall-relief hook, #3471, calls :meth:`_relief_rescue` positionally
+        and therefore inherits :data:`DETERMINISTIC_RESCUE_DEFAULT`).
+        """
+        budget = self._relief_subsearch_budget(per_net_timeout, deterministic_rescue)
+        if deterministic_rescue and budget == RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S:
+            return (
+                "  Relief-rescue sub-search cap: iteration-bounded "
+                "(per-net node-expansion cap; issue #4536) -- probe / "
+                "victim-re-land outcomes are machine-independent; "
+                f"{RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S:.0f}s wall clock kept "
+                "only as a non-binding Python-fallback backstop"
+            )
+        wall_clock = float(budget if budget else RELIEF_SUBSEARCH_BUDGET_S)
+        if deterministic_rescue:
+            return (
+                f"  Relief-rescue sub-search cap: {wall_clock:.1f}s wall clock -- "
+                "no per-net node-expansion cap is active, so the machine-dependent "
+                "bound is kept (issue #4536)"
+            )
+        return (
+            f"  Relief-rescue sub-search cap: {wall_clock:.1f}s wall clock -- "
+            "deterministic rescue disabled by caller (issue #4730)"
+        )
+
     def _relief_rescue(
         self,
         failed_net: int,
@@ -12551,7 +12614,7 @@ class Autorouter:
         elapsed_fn,
         depth: int = 0,
         deadline: float | None = None,
-        deterministic_rescue: bool = False,
+        deterministic_rescue: bool = DETERMINISTIC_RESCUE_DEFAULT,
     ) -> bool:
         """Transactional relief rescue for a zero-overflow hard failure.
 
@@ -12580,10 +12643,14 @@ class Autorouter:
                 rescue.  When the deadline passes mid-rescue the
                 transaction rolls back verbatim and returns False, so
                 the bound costs nothing in correctness.
-            deterministic_rescue: Issue #4536 -- bound the rescue's
-                SUB-searches (probe rounds, victim re-lands) by the
-                deterministic per-net NODE-EXPANSION cap instead of the
-                ``RELIEF_SUBSEARCH_BUDGET_S`` wall clock.  See
+            deterministic_rescue: Issue #4536 / #4730 -- bound the
+                rescue's SUB-searches (probe rounds, victim re-lands) by
+                the deterministic per-net NODE-EXPANSION cap instead of
+                the ``RELIEF_SUBSEARCH_BUDGET_S`` wall clock.  Default
+                True (#4730), which also covers the two-phase stall-relief
+                hook that calls this method positionally; without an
+                active expansion cap the wall clock is kept, so capless
+                callers are unaffected.  See
                 :meth:`_relief_subsearch_budget` for the measurement that
                 motivates it and the load-bearing consequences.
 
@@ -14061,6 +14128,25 @@ class Autorouter:
         # Issue #2587 / Epic #2556 Phase 1C-cont: Activate diff-pair partner
         # threading before two-phase routing begins.
         self._prepare_routing()
+
+        # Issue #4730: this path reaches a relief rescue too -- the #3471
+        # stall-relief hook wired in ``_create_two_phase_router`` calls
+        # ``_relief_rescue`` positionally, so it inherits
+        # ``DETERMINISTIC_RESCUE_DEFAULT``.  ``kct route`` sends every
+        # escape-routed board here (``route_with_escape``), so without this
+        # line the boards whose gates the flip is measured against would have
+        # no record of which bound was live.
+        #
+        # Mirror the two-phase router's own #3474 per-net cap derivation so the
+        # reported wall clock is the one a rescue would actually get; with an
+        # expansion cap active both sides bypass the derivation and the
+        # deterministic arm is selected regardless of this value.
+        _banner_per_net_timeout = per_net_timeout
+        if per_net_timeout is None and not getattr(self, "_max_search_iterations", 0):
+            _banner_per_net_timeout = derive_per_net_cap(per_net_timeout, timeout)
+        flush_print(
+            self._relief_subsearch_bound_line(_banner_per_net_timeout, DETERMINISTIC_RESCUE_DEFAULT)
+        )
 
         tp_router = self._create_two_phase_router()
         result = tp_router.route_all(

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import functools
 import logging
 import math
 import os
@@ -167,12 +168,14 @@ _ESCAPE_CORRIDOR_INNER_LAYERS_ONLY = True
 # runs 31214686048 vs 31213011136 are line-identical up to the MIPI_RST rescue
 # and then diverge on whether MIPI_CLK- re-lands).
 #
-# Issue #4730 therefore made ``deterministic_rescue=True`` the DEFAULT: whenever
-# a per-net node-expansion cap is active (``--deterministic-budget`` /
-# ``per_net_iterations``) these sub-searches are bounded by that cap instead and
-# this wall clock stops deciding reach.  It still binds -- unchanged, by
-# construction -- on capless runs and for callers that explicitly opt out with
-# ``deterministic_rescue=False``.
+# Issue #4730 therefore made ``deterministic_rescue=True`` the DEFAULT of the
+# NEGOTIATED entry point: whenever a per-net node-expansion cap is active
+# (``--deterministic-budget`` / ``per_net_iterations``) these sub-searches are
+# bounded by that cap instead and this wall clock stops deciding reach.  It
+# still binds -- unchanged, by construction -- on capless runs, for callers that
+# explicitly opt out with ``deterministic_rescue=False``, and on the two-phase
+# path (see ``TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT`` for the board-07 A/B that
+# scoped the flip out of it).
 RELIEF_SUBSEARCH_BUDGET_S = 10.0
 
 # Issue #4536: the wall clock kept under ``deterministic_rescue=True``.  It is
@@ -184,17 +187,53 @@ RELIEF_SUBSEARCH_BUDGET_S = 10.0
 # for minutes inside a rescue, per the #3989 lesson.
 RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S = 120.0
 
-# Issue #4730: the fleet default for the relief-rescue sub-search bound, shared
-# by :meth:`Autorouter.route_all_negotiated`, :meth:`Autorouter._relief_rescue`
-# and the two-phase stall-relief hook (which calls ``_relief_rescue``
-# positionally, so it inherits this value).  Named rather than repeated as a
-# literal so the three sites cannot drift, and so the fleet A/B that flipped it
-# has a single greppable switch to flip back.
+# Issue #4730: the default for the relief-rescue sub-search bound on the
+# NEGOTIATED entry point -- shared by :meth:`Autorouter.route_all_negotiated`
+# and :meth:`Autorouter._relief_rescue`.  Named rather than repeated as a
+# literal so the sites cannot drift, and so the fleet A/B that flipped it has a
+# single greppable switch to flip back.
 #
 # Safe by construction: ``_relief_subsearch_budget`` only hands the sub-searches
 # to the node-expansion cap when one is ACTIVE, so a capless run selects
 # ``RELIEF_SUBSEARCH_BUDGET_S`` exactly as it did before the flip.
+#
+# Fleet A/B (boards 00-06 + board-05 routing regression + diff-pair regression)
+# is green on this path: A = PR head 6071d1b2, CI run 31281260812; B = main
+# 6cfa8842, run 31277512785.  The TWO-PHASE path is scoped out -- see
+# ``TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT`` below.
 DETERMINISTIC_RESCUE_DEFAULT = True
+
+# Issue #4730: the TWO-PHASE entry point keeps the historical wall clock.
+#
+# This is the issue's documented per-board NEGATIVE RESULT, not an oversight.
+# ``kct route`` sends every escape-routed board (03/04/07 auto-enable on dense
+# packages) through ``route_with_escape`` -> :meth:`Autorouter.route_all_two_phase`,
+# whose #3471 stall-relief hook reaches ``_relief_rescue``.  With the flip
+# inherited there, board 07 -- the only board whose two-phase route actually
+# fires rescues -- regressed in the fleet A/B (A = PR head 6071d1b2, CI run
+# 31281260812; B = main 6cfa8842, run 31277512785):
+#
+#   * Board 07 E2E: the copper-LVS open set changed from
+#     {DQ3, DQ4, MIPI_DAT0_N, TMDS_D0_N, TMDS_D1_N} to
+#     {DQS_N, MIPI_DAT0_P, TMDS_D0_N, TMDS_D1_N}, breaking the
+#     ``--expect-opens`` drift guard (a DIFFERENT set of nets is open).
+#   * Match-Group Routing Regression: reach 26/31 -> 27/31, but routed-DRC
+#     8 -> 13 against an allowlist of 8 that main sits exactly at.
+#
+# #4730's Acceptance forbids absorbing that ("No board's DRC allowlist is
+# raised to absorb a regression"; "If any board regresses on reach or DRC, keep
+# the opt-in and document the per-board decision instead of forcing the
+# default"), so the flip is SCOPED to the negotiated entry point and this path
+# stays byte-identical to pre-#4730.
+#
+# The path is no longer hard-wired, though -- that was the second defect the
+# scoping had to fix.  ``route_all_two_phase(deterministic_rescue=True)`` (and
+# the ``route_with_escape`` / ``route_with_escape_and_diffpairs`` forwarders)
+# opt in per call, and ``_create_two_phase_router`` binds the value onto the
+# positional stall-relief hook, so a future flip has a real switch: change this
+# constant once board 07's rescue outcome (which nets its rescues keep, and why
+# the kept copper carries +5 DRC) is understood.
+TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT = False
 
 
 @dataclass
@@ -8991,7 +9030,16 @@ class Autorouter:
         if _yield_cap is not None:
             timeout = min(timeout, float(_yield_cap)) if timeout else float(_yield_cap)
 
-        # If hierarchical mode is requested, delegate to two-phase routing
+        # If hierarchical mode is requested, delegate to two-phase routing.
+        #
+        # Issue #4730: ``deterministic_rescue`` is deliberately NOT forwarded
+        # here.  This method's default is ``DETERMINISTIC_RESCUE_DEFAULT``
+        # (True), so forwarding it would silently re-flip the two-phase path
+        # that the board-07 A/B scoped out (see
+        # ``TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT``) for every caller that
+        # merely asked for hierarchical mode.  A caller that wants the
+        # deterministic bound on the two-phase path calls
+        # ``route_all_two_phase(deterministic_rescue=True)`` directly.
         if hierarchical:
             return self.route_all_two_phase(
                 use_negotiated=True,
@@ -12539,6 +12587,9 @@ class Autorouter:
         construction: it is scoped to exactly the runs that already have
         a machine-independent bound to hand over to, and every capless
         run keeps selecting ``RELIEF_SUBSEARCH_BUDGET_S`` unchanged.
+        :meth:`route_all_two_phase` is scoped out of the flip on a measured
+        board-07 regression (:data:`TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT`)
+        and passes ``False`` down to its stall-relief hook.
         """
         if deterministic_rescue:
             expansion_cap = min(
@@ -12569,17 +12620,23 @@ class Autorouter:
         ``iteration-bounded`` wording is the greppable evidence line; do not
         reword it.
 
-        Issue #4730 flipped ``deterministic_rescue`` to default True, which
-        makes the wall-clock arm reachable by an ordinary capless run that
-        never "requested" anything -- so that arm's wording is NEUTRAL (it
-        states the fact, not a caller decision).  Only the opt-out arm names
-        a caller, because with a True default ``deterministic_rescue=False``
-        is necessarily explicit.
+        Issue #4730 flipped ``deterministic_rescue`` to default True on the
+        negotiated entry point, which makes the wall-clock arm reachable by an
+        ordinary capless run that never "requested" anything -- so that arm's
+        wording is NEUTRAL (it states the fact, not a caller decision).
+
+        The third arm (deterministic rescue OFF) is reached two ways, so it
+        names neither: an explicit ``deterministic_rescue=False`` from a
+        caller, or :meth:`route_all_two_phase`'s own
+        :data:`TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT` (``False``, the board-07
+        negative result recorded at that constant).
 
         Emitted by both routing entry points that can reach a relief rescue:
         :meth:`route_all_negotiated` and :meth:`route_all_two_phase` (whose
         stall-relief hook, #3471, calls :meth:`_relief_rescue` positionally
-        and therefore inherits :data:`DETERMINISTIC_RESCUE_DEFAULT`).
+        with the bound bound on by ``functools.partial``).  Each reports the
+        value ITS call is running under, so the two paths' different defaults
+        are visible in the log rather than assumed.
         """
         budget = self._relief_subsearch_budget(per_net_timeout, deterministic_rescue)
         if deterministic_rescue and budget == RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S:
@@ -12599,7 +12656,8 @@ class Autorouter:
             )
         return (
             f"  Relief-rescue sub-search cap: {wall_clock:.1f}s wall clock -- "
-            "deterministic rescue disabled by caller (issue #4730)"
+            "deterministic rescue is off for this route (explicit caller opt-out, "
+            "or the two-phase path default; issue #4730)"
         )
 
     def _relief_rescue(
@@ -14022,8 +14080,21 @@ class Autorouter:
     # TWO-PHASE ROUTING (GLOBAL + DETAILED)
     # =========================================================================
 
-    def _create_two_phase_router(self) -> TwoPhaseRouter:
-        """Create a TwoPhaseRouter with access to Autorouter state."""
+    def _create_two_phase_router(
+        self,
+        deterministic_rescue: bool = TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT,
+    ) -> TwoPhaseRouter:
+        """Create a TwoPhaseRouter with access to Autorouter state.
+
+        Args:
+            deterministic_rescue: Bound the #3471 stall-relief hook's rescue
+                sub-searches by the per-net node-expansion cap instead of the
+                ``RELIEF_SUBSEARCH_BUDGET_S`` wall clock (Issue #4536).
+                Defaults to :data:`TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT`
+                (``False``) -- see that constant for the board-07 A/B that
+                scoped #4730's fleet flip out of this path, and why the value
+                must remain reachable per call rather than hard-wired.
+        """
 
         # Issue #2527: Provide a builder for ``pads_by_net`` that honours
         # ``_escape_pad_overrides`` so the two-phase router's stall-recovery
@@ -14086,7 +14157,16 @@ class Autorouter:
             # blocker": non-rippable foreign escape copper, the board-05
             # ISENSE-cluster mechanism) get the same last-resort
             # transactional escalation ``route_all_negotiated`` has.
-            relief_rescue=self._relief_rescue,
+            #
+            # Issue #4730: the hook calls ``_relief_rescue`` POSITIONALLY with
+            # 8 arguments, so binding the sub-search bound as a keyword is the
+            # only way this path can carry a value other than the method's own
+            # signature default.  Without the partial the two-phase path had no
+            # opt-out at all (and, with #4730's flip, silently inherited
+            # ``DETERMINISTIC_RESCUE_DEFAULT``).
+            relief_rescue=functools.partial(
+                self._relief_rescue, deterministic_rescue=deterministic_rescue
+            ),
         )
 
     def route_all_two_phase(
@@ -14099,6 +14179,7 @@ class Autorouter:
         per_net_timeout: float | None = None,
         initial_routes: list[Route] | None = None,
         max_iterations: int = 20,
+        deterministic_rescue: bool = TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT,
     ) -> list[Route]:
         """Route all nets using two-phase global+detailed routing.
 
@@ -14121,6 +14202,15 @@ class Autorouter:
                 reserved on the grid (Issue #2294).
             max_iterations: Maximum rip-up-and-reroute iterations for the
                 Phase 2 detailed negotiated routing loop (default: 20).
+            deterministic_rescue: Bound the #3471 stall-relief hook's relief
+                rescue sub-searches by the per-net node-expansion cap instead
+                of the ``RELIEF_SUBSEARCH_BUDGET_S`` wall clock (Issue #4536).
+                Defaults to :data:`TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT`
+                (``False``): #4730 flipped the NEGOTIATED entry point's default
+                to ``True`` but board 07 -- routed through this path -- came
+                back with a changed LVS open set and +5 routed-DRC errors over
+                an allowlist main sits exactly at, so the flip is deliberately
+                scoped out here.  Pass ``True`` to opt this path in.
 
         Returns:
             List of routes (may be partial if timeout reached or some nets fail)
@@ -14131,11 +14221,12 @@ class Autorouter:
 
         # Issue #4730: this path reaches a relief rescue too -- the #3471
         # stall-relief hook wired in ``_create_two_phase_router`` calls
-        # ``_relief_rescue`` positionally, so it inherits
-        # ``DETERMINISTIC_RESCUE_DEFAULT``.  ``kct route`` sends every
-        # escape-routed board here (``route_with_escape``), so without this
-        # line the boards whose gates the flip is measured against would have
-        # no record of which bound was live.
+        # ``_relief_rescue`` positionally, with the bound bound onto it by a
+        # ``functools.partial``.  ``kct route`` sends every escape-routed board
+        # here (``route_with_escape``), so without this line the boards whose
+        # gates the flip is measured against would have no record of which
+        # bound was live.  It reports the value THIS call is running under, not
+        # a module constant, so an opt-in call is distinguishable in the log.
         #
         # Mirror the two-phase router's own #3474 per-net cap derivation so the
         # reported wall clock is the one a rescue would actually get; with an
@@ -14145,10 +14236,10 @@ class Autorouter:
         if per_net_timeout is None and not getattr(self, "_max_search_iterations", 0):
             _banner_per_net_timeout = derive_per_net_cap(per_net_timeout, timeout)
         flush_print(
-            self._relief_subsearch_bound_line(_banner_per_net_timeout, DETERMINISTIC_RESCUE_DEFAULT)
+            self._relief_subsearch_bound_line(_banner_per_net_timeout, deterministic_rescue)
         )
 
-        tp_router = self._create_two_phase_router()
+        tp_router = self._create_two_phase_router(deterministic_rescue=deterministic_rescue)
         result = tp_router.route_all(
             use_negotiated=use_negotiated,
             corridor_width_factor=corridor_width_factor,
@@ -17523,6 +17614,7 @@ class Autorouter:
         progress_callback: ProgressCallback | None = None,
         timeout: float | None = None,
         per_net_timeout: float | None = None,
+        deterministic_rescue: bool = TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT,
     ) -> tuple[list[Route], list[LengthMismatchWarning]]:
         """Compose escape routing with the differential-pair pre-pass.
 
@@ -17565,6 +17657,9 @@ class Autorouter:
             progress_callback: Optional callback for progress updates.
             timeout: Optional board-level wall-clock budget in seconds.
             per_net_timeout: Optional per-net A* wall-clock timeout.
+            deterministic_rescue: Forwarded to ``route_all_two_phase`` for the
+                main pass (Issue #4730).  Defaults to
+                :data:`TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT`.
 
         Returns:
             A ``(routes, length_warnings)`` tuple mirroring
@@ -17621,6 +17716,7 @@ class Autorouter:
                     progress_callback=progress_callback,
                     timeout=timeout,
                     per_net_timeout=per_net_timeout,
+                    deterministic_rescue=deterministic_rescue,
                 )
             else:
                 main_routes = self.route_all(
@@ -17665,6 +17761,7 @@ class Autorouter:
         progress_callback: ProgressCallback | None = None,
         timeout: float | None = None,
         per_net_timeout: float | None = None,
+        deterministic_rescue: bool = TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT,
     ) -> list[Route]:
         """Route with automatic escape routing for dense packages.
 
@@ -17683,6 +17780,12 @@ class Autorouter:
                 Forwarded to ``route_all_two_phase`` so dense-package nets
                 cannot consume an unbounded share of the board-level budget
                 (Issue #2768; part of board 05 BLDC regression #2746).
+            deterministic_rescue: Forwarded to ``route_all_two_phase``
+                (Issue #4730).  Defaults to
+                :data:`TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT` (``False``) --
+                this is the entry point ``kct route`` uses for boards 03/04/07,
+                the ones the fleet A/B measured a regression on, so the opt-in
+                is per call rather than inherited.
 
         Returns:
             List of all routes (escapes + regular routing)
@@ -17722,6 +17825,7 @@ class Autorouter:
                 progress_callback=progress_callback,
                 timeout=timeout,
                 per_net_timeout=per_net_timeout,
+                deterministic_rescue=deterministic_rescue,
             )
         else:
             main_routes = self.route_all(

--- a/tests/test_board06_determinism.py
+++ b/tests/test_board06_determinism.py
@@ -34,7 +34,10 @@ sources:
    natural time on GitHub runners -- the same commit landed 21/21 and
    20/21 on different runners from line-identical logs.  Fixed with
    ``route_all_negotiated(deterministic_rescue=True)``, which bounds the
-   sub-searches by the deterministic per-net node-expansion cap.
+   sub-searches by the deterministic per-net node-expansion cap.  Board 06
+   opted in first (#4536); #4730 made that the DEFAULT for every
+   expansion-capped run, so the kwarg in ``generate_design.py`` is now
+   redundant-but-documentary rather than the only thing switching it on.
 
 3. **Residual -- UUID-sorted file order.** With the wall clock removed,
    runs produced byte-identical logs and identical copper *multisets*,

--- a/tests/test_board06_determinism.py
+++ b/tests/test_board06_determinism.py
@@ -36,8 +36,11 @@ sources:
    ``route_all_negotiated(deterministic_rescue=True)``, which bounds the
    sub-searches by the deterministic per-net node-expansion cap.  Board 06
    opted in first (#4536); #4730 made that the DEFAULT for every
-   expansion-capped run, so the kwarg in ``generate_design.py`` is now
+   expansion-capped run of ``route_all_negotiated`` -- the path this board
+   uses -- so the kwarg in ``generate_design.py`` is now
    redundant-but-documentary rather than the only thing switching it on.
+   (The two-phase/escape path keeps the wall clock; see
+   ``TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT`` for board 07's negative A/B.)
 
 3. **Residual -- UUID-sorted file order.** With the wall clock removed,
    runs produced byte-identical logs and identical copper *multisets*,

--- a/tests/test_board06_determinism.py
+++ b/tests/test_board06_determinism.py
@@ -35,12 +35,11 @@ sources:
    20/21 on different runners from line-identical logs.  Fixed with
    ``route_all_negotiated(deterministic_rescue=True)``, which bounds the
    sub-searches by the deterministic per-net node-expansion cap.  Board 06
-   opted in first (#4536); #4730 made that the DEFAULT for every
-   expansion-capped run of ``route_all_negotiated`` -- the path this board
-   uses -- so the kwarg in ``generate_design.py`` is now
-   redundant-but-documentary rather than the only thing switching it on.
-   (The two-phase/escape path keeps the wall clock; see
-   ``TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT`` for board 07's negative A/B.)
+   opted in first (#4536) and still opts in explicitly: #4730 proposed
+   making it the fleet default and withdrew the flip on a measured
+   board-07 regression, so ``DETERMINISTIC_RESCUE_DEFAULT`` is ``False``
+   and the kwarg in ``generate_design.py`` is the only thing switching the
+   bound on for this board.
 
 3. **Residual -- UUID-sorted file order.** With the wall clock removed,
    runs produced byte-identical logs and identical copper *multisets*,

--- a/tests/test_relief_subsearch_budget.py
+++ b/tests/test_relief_subsearch_budget.py
@@ -7,23 +7,19 @@ the 8-12 s natural re-land time on CI runners, which made board-06's
 ``REQUIRED_SIGNAL_REACH`` gate a coin flip on machine speed.  These tests pin
 the selection table for the deterministic replacement.
 
-Issue #4730 made the deterministic bound the default of the NEGOTIATED entry
-point (:data:`DETERMINISTIC_RESCUE_DEFAULT`).  That is only safe because the
-selector degrades to the historical wall clock whenever no per-net
-node-expansion cap is active, so a capless run is behavior-identical BY
-CONSTRUCTION -- the property the "inherited default" cases below lock down,
-alongside the signature defaults and the routing-log line that reports which
-bound is live.
+Issue #4730 proposed making the deterministic bound the fleet default and
+WITHDREW the flip: board 07 -- routed through the NEGOTIATED entry point --
+came back from the A/B with a changed copper-LVS open set and routed-DRC
+8 -> 13 against an allowlist of 8, and #4730's Acceptance forbids absorbing
+that.  So :data:`DETERMINISTIC_RESCUE_DEFAULT` is ``False`` on every entry
+point (``TestDeterministicRescueDefault``) and board 06 keeps its explicit
+opt-in.
 
-The TWO-PHASE entry point is scoped OUT of that flip
-(:data:`TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT` is ``False``): board 07 -- the
-only board whose two-phase route fires rescues -- came back from the fleet A/B
-with a changed copper-LVS open set and routed-DRC 8 -> 13 against an allowlist
-of 8, and #4730's Acceptance forbids absorbing that.  ``TestTwoPhasePathScoping``
-pins both halves of the resolution: the path default stays historical, AND the
-bound is threaded through as a real per-call switch (the hook calls
-``_relief_rescue`` positionally, so a ``functools.partial`` is what makes an
-opt-in reachable at all).
+What the issue did land is the per-call switch, pinned by
+``TestPerCallThreading``: every entry point that can reach a rescue takes
+``deterministic_rescue``, and the two-phase stall-relief hook -- which calls
+``_relief_rescue`` POSITIONALLY -- carries it on a ``functools.partial``, so a
+future flip is a value change rather than a rewiring job.
 
 The methods only read two attributes off ``self``, so they are exercised against
 a lightweight stub rather than a full ``Autorouter`` (which would need a board).
@@ -40,7 +36,6 @@ from kicad_tools.router.core import (
     DETERMINISTIC_RESCUE_DEFAULT,
     RELIEF_SUBSEARCH_BUDGET_S,
     RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S,
-    TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT,
     Autorouter,
 )
 
@@ -103,18 +98,26 @@ class TestReliefSubsearchBudget:
 
 
 class TestDeterministicRescueDefault:
-    """Issue #4730: the deterministic bound is the fleet default."""
+    """Issue #4730: the deterministic bound stays OPT-IN, on every path."""
 
-    def test_route_all_negotiated_defaults_to_the_deterministic_bound(self):
+    def test_the_flip_stayed_withdrawn(self):
+        """The measured negative result: with the bound on by default, board
+        07's copper-LVS open set changed and its routed-DRC went 8 -> 13 over
+        an allowlist of 8 that main sits exactly at (CI runs 31281260812 and
+        31283738762 vs main's 31277512785).  #4730's Acceptance forbids
+        absorbing that, so the default must remain ``False`` until board 07's
+        rescue outcome is understood."""
+        assert DETERMINISTIC_RESCUE_DEFAULT is False
+
+    def test_route_all_negotiated_uses_the_shared_default(self):
         default = (
             inspect.signature(Autorouter.route_all_negotiated)
             .parameters["deterministic_rescue"]
             .default
         )
         assert default is DETERMINISTIC_RESCUE_DEFAULT
-        assert DETERMINISTIC_RESCUE_DEFAULT is True
 
-    def test_relief_rescue_defaults_to_the_deterministic_bound(self):
+    def test_relief_rescue_uses_the_shared_default(self):
         """The recursion and the two-phase hook both land on this default."""
         default = (
             inspect.signature(Autorouter._relief_rescue).parameters["deterministic_rescue"].default
@@ -126,8 +129,7 @@ class TestDeterministicRescueDefault:
         ``_relief_rescue`` POSITIONALLY with 8 arguments, so the flag must stay
         behind them -- otherwise that path would silently receive a victim
         count as its rescue mode, and the ``functools.partial`` that binds the
-        two-phase path's own default (#4730) would collide with a positional
-        argument."""
+        bound (#4730) would collide with a positional argument."""
         params = list(inspect.signature(Autorouter._relief_rescue).parameters)
         assert params[0] == "self"
         assert params[1:9] == [
@@ -142,83 +144,74 @@ class TestDeterministicRescueDefault:
         ]
         assert params.index("deterministic_rescue") >= 9
 
-    def test_inherited_default_without_a_cap_keeps_the_wall_clock(self):
-        """The safety property of the flip: capless runs are byte-identical to
-        the pre-#4730 behavior because there is no deterministic bound to hand
-        over to."""
-        stub = _BudgetStub()
-        assert _budget(stub, None, DETERMINISTIC_RESCUE_DEFAULT) == RELIEF_SUBSEARCH_BUDGET_S
-        assert _budget(stub, 4.0, DETERMINISTIC_RESCUE_DEFAULT) == 4.0
-        assert _budget(stub, None, DETERMINISTIC_RESCUE_DEFAULT) == _budget(stub, None, False)
-
-    def test_inherited_default_with_a_cap_hands_over_to_the_node_budget(self):
-        stub = _BudgetStub(per_net_iterations=1_000_000, max_search_iterations=12_000_000)
-        assert (
-            _budget(stub, None, DETERMINISTIC_RESCUE_DEFAULT) == RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S
+    def test_default_selects_exactly_the_historical_bound(self):
+        """The safety property of the withdrawal: an inherited default is
+        indistinguishable from an explicit opt-out, capped or not."""
+        for stub in (
+            _BudgetStub(),
+            _BudgetStub(per_net_iterations=1_000_000, max_search_iterations=12_000_000),
+        ):
+            assert _budget(stub, None, DETERMINISTIC_RESCUE_DEFAULT) == _budget(stub, None, False)
+            assert _budget(stub, 4.0, DETERMINISTIC_RESCUE_DEFAULT) == _budget(stub, 4.0, False)
+        assert _budget(_BudgetStub(), None, DETERMINISTIC_RESCUE_DEFAULT) == (
+            RELIEF_SUBSEARCH_BUDGET_S
         )
 
 
 class TestReliefSubsearchBoundLine:
-    """The routing-log line is the greppable A/B evidence for the flip."""
+    """The routing-log line is the greppable A/B evidence for the bound."""
 
     def test_cap_active_reports_the_iteration_bound(self):
         stub = _BudgetStub(per_net_iterations=1_000_000, max_search_iterations=12_000_000)
-        line = _line(stub, None, DETERMINISTIC_RESCUE_DEFAULT)
+        line = _line(stub, None, True)
         # Load-bearing evidence token -- board CI logs are grepped for it.
         assert "iteration-bounded" in line
         assert "machine-independent" in line
         assert "requested" not in line
 
-    def test_inherited_default_without_a_cap_does_not_claim_a_request(self):
-        """#4730 acceptance: with a True default, an ordinary capless run never
-        'requested' anything, so the wall-clock arm must stay neutral."""
-        line = _line(_BudgetStub(), None, DETERMINISTIC_RESCUE_DEFAULT)
+    def test_opt_in_without_a_cap_states_the_fact_not_a_request(self):
+        """This arm is reached by an opt-in run that simply has no expansion
+        cap to hand the sub-searches to, so it reports the bound rather than
+        attributing a decision."""
+        line = _line(_BudgetStub(), None, True)
         assert "requested" not in line
         assert "iteration-bounded" not in line
         assert f"{RELIEF_SUBSEARCH_BUDGET_S:.1f}s wall clock" in line
         assert "no per-net node-expansion cap is active" in line
         assert "off for this route" not in line
 
-    def test_off_arm_does_not_attribute_the_choice_to_one_source(self):
-        """``deterministic_rescue=False`` reaches this arm two ways -- an
-        explicit caller opt-out on the negotiated path, or
-        ``TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT`` on the two-phase path -- so
-        the wording must name both rather than blaming a caller."""
+    def test_off_arm_names_the_default_and_the_way_in(self):
+        """``deterministic_rescue=False`` is what ordinary runs inherit, so the
+        wording must not blame a caller -- it says this is the default and how
+        to opt in."""
         stub = _BudgetStub(per_net_iterations=1_000_000)
-        line = _line(stub, None, False)
+        line = _line(stub, None, DETERMINISTIC_RESCUE_DEFAULT)
         assert "off for this route" in line
-        assert "caller opt-out" in line
-        assert "two-phase path default" in line
+        assert "the default" in line
+        assert "deterministic_rescue=True" in line
         assert "iteration-bounded" not in line
         assert f"{RELIEF_SUBSEARCH_BUDGET_S:.1f}s wall clock" in line
 
     def test_every_arm_carries_the_same_greppable_prefix(self):
         capped = _BudgetStub(per_net_iterations=1_000_000)
         for line in (
+            _line(capped, None, True),
+            _line(_BudgetStub(), None, True),
             _line(capped, None, DETERMINISTIC_RESCUE_DEFAULT),
-            _line(_BudgetStub(), None, DETERMINISTIC_RESCUE_DEFAULT),
-            _line(capped, None, False),
         ):
             assert line.startswith("  Relief-rescue sub-search cap: ")
 
 
-class TestTwoPhasePathScoping:
-    """Issue #4730: the flip is scoped OUT of the two-phase path (board 07's
-    measured regression), and that path gets a real per-call switch."""
+class TestPerCallThreading:
+    """Issue #4730's durable half: every path that can reach a rescue carries
+    the bound per call, so opting one in is a measured value change."""
 
-    def test_two_phase_default_is_the_historical_wall_clock(self):
-        """The documented negative result: board 07's copper-LVS open set
-        changed and routed-DRC went 8 -> 13 over an allowlist of 8 when this
-        path inherited the flip, so it must stay off."""
-        assert TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT is False
-        assert TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT is not DETERMINISTIC_RESCUE_DEFAULT
-
-    def test_route_all_two_phase_takes_the_flag_and_defaults_it_to_the_path_value(self):
+    def test_route_all_two_phase_takes_the_flag(self):
         param = inspect.signature(Autorouter.route_all_two_phase).parameters.get(
             "deterministic_rescue"
         )
         assert param is not None, "the two-phase path must expose the opt-in/opt-out"
-        assert param.default is TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT
+        assert param.default is DETERMINISTIC_RESCUE_DEFAULT
 
     def test_escape_entry_points_forward_the_flag(self):
         """``kct route`` reaches the two-phase path through these, so the
@@ -229,7 +222,18 @@ class TestTwoPhasePathScoping:
         ):
             param = inspect.signature(method).parameters.get("deterministic_rescue")
             assert param is not None, f"{method.__name__} must forward the flag"
-            assert param.default is TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT
+            assert param.default is DETERMINISTIC_RESCUE_DEFAULT
+
+    def test_hierarchical_delegation_forwards_an_explicit_opt_in(self):
+        """``route_all_negotiated(hierarchical=True)`` hands the whole route to
+        the two-phase path; dropping the flag there would silently discard a
+        caller's opt-in."""
+        stub = MagicMock()
+        stub._negotiated_timeout_cap = None
+
+        Autorouter.route_all_negotiated(stub, hierarchical=True, deterministic_rescue=True)
+
+        assert stub.route_all_two_phase.call_args.kwargs["deterministic_rescue"] is True
 
     def test_create_two_phase_router_binds_the_bound_onto_the_positional_hook(self, monkeypatch):
         """The #3471 hook calls ``_relief_rescue`` positionally, so a plain
@@ -246,14 +250,14 @@ class TestTwoPhasePathScoping:
         Autorouter._create_two_phase_router(stub)
         hook = captured["relief_rescue"]
         assert isinstance(hook, functools.partial)
-        assert hook.keywords["deterministic_rescue"] is TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT
+        assert hook.keywords["deterministic_rescue"] is DETERMINISTIC_RESCUE_DEFAULT
 
         # The 8 positional arguments the hook passes must still land on the
         # underlying method, with the bound arriving as a keyword.
         hook(1, 2, 3, 4, 5, 6, 7, 8)
         args, kwargs = stub._relief_rescue.call_args
         assert args == (1, 2, 3, 4, 5, 6, 7, 8)
-        assert kwargs == {"deterministic_rescue": TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT}
+        assert kwargs == {"deterministic_rescue": DETERMINISTIC_RESCUE_DEFAULT}
 
     def test_create_two_phase_router_honors_an_explicit_opt_in(self, monkeypatch):
         captured: dict = {}
@@ -268,7 +272,7 @@ class TestTwoPhasePathScoping:
 
     def test_route_all_two_phase_forwards_the_flag_to_hook_and_banner(self, monkeypatch):
         """Both the wiring and the log line must report the value THIS call
-        runs under -- the banner previously hardcoded the module constant."""
+        runs under -- the banner must not fall back to the module constant."""
         printed: list[str] = []
         monkeypatch.setattr(core, "flush_print", lambda line: printed.append(line))
 

--- a/tests/test_relief_subsearch_budget.py
+++ b/tests/test_relief_subsearch_budget.py
@@ -1,4 +1,4 @@
-"""Unit tests for the relief-rescue sub-search budget selector (Issue #4536).
+"""Unit tests for the relief-rescue sub-search budget selector (Issues #4536, #4730).
 
 ``Autorouter._relief_rescue`` is a TRANSACTION: it rolls back unless every
 displaced victim re-lands, so the budget those re-land searches get decides
@@ -7,13 +7,23 @@ the 8-12 s natural re-land time on CI runners, which made board-06's
 ``REQUIRED_SIGNAL_REACH`` gate a coin flip on machine speed.  These tests pin
 the selection table for the deterministic replacement.
 
-The method only reads two attributes off ``self``, so it is exercised against a
-lightweight stub rather than a full ``Autorouter`` (which would need a board).
+Issue #4730 made the deterministic bound the fleet DEFAULT
+(:data:`DETERMINISTIC_RESCUE_DEFAULT`).  That is only safe because the selector
+degrades to the historical wall clock whenever no per-net node-expansion cap is
+active, so a capless run is behavior-identical BY CONSTRUCTION -- the property
+the "inherited default" cases below lock down, alongside the signature defaults
+and the routing-log line that reports which bound is live.
+
+The methods only read two attributes off ``self``, so they are exercised against
+a lightweight stub rather than a full ``Autorouter`` (which would need a board).
 """
 
 from __future__ import annotations
 
+import inspect
+
 from kicad_tools.router.core import (
+    DETERMINISTIC_RESCUE_DEFAULT,
     RELIEF_SUBSEARCH_BUDGET_S,
     RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S,
     Autorouter,
@@ -21,7 +31,10 @@ from kicad_tools.router.core import (
 
 
 class _BudgetStub:
-    """Minimal stand-in exposing only the two attributes the method reads."""
+    """Minimal stand-in exposing only the two attributes the methods read."""
+
+    # Borrowed unbound so the stub gets the real selection logic without a board.
+    _relief_subsearch_budget = Autorouter._relief_subsearch_budget
 
     def __init__(self, per_net_iterations: int = 0, max_search_iterations: int = 0) -> None:
         self._per_net_iterations = per_net_iterations
@@ -32,9 +45,13 @@ def _budget(stub: _BudgetStub, per_net_timeout: float | None, deterministic: boo
     return Autorouter._relief_subsearch_budget(stub, per_net_timeout, deterministic)
 
 
+def _line(stub: _BudgetStub, per_net_timeout: float | None, deterministic: bool) -> str:
+    return Autorouter._relief_subsearch_bound_line(stub, per_net_timeout, deterministic)
+
+
 class TestReliefSubsearchBudget:
-    def test_default_is_the_historical_wall_clock(self):
-        """No opt-in, no standing cap -> unchanged 10 s behavior."""
+    def test_opt_out_is_the_historical_wall_clock(self):
+        """Explicit opt-out, no standing cap -> unchanged 10 s behavior."""
         assert _budget(_BudgetStub(), None, False) == RELIEF_SUBSEARCH_BUDGET_S
 
     def test_tighter_per_net_timeout_still_binds(self):
@@ -68,3 +85,97 @@ class TestReliefSubsearchBudget:
         """Guard the 'non-load-bearing' claim: the backstop must stay an order
         of magnitude above the measured 8-12 s natural re-land time."""
         assert RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S >= 10 * RELIEF_SUBSEARCH_BUDGET_S
+
+
+class TestDeterministicRescueDefault:
+    """Issue #4730: the deterministic bound is the fleet default."""
+
+    def test_route_all_negotiated_defaults_to_the_deterministic_bound(self):
+        default = (
+            inspect.signature(Autorouter.route_all_negotiated)
+            .parameters["deterministic_rescue"]
+            .default
+        )
+        assert default is DETERMINISTIC_RESCUE_DEFAULT
+        assert DETERMINISTIC_RESCUE_DEFAULT is True
+
+    def test_relief_rescue_defaults_to_the_deterministic_bound(self):
+        """The recursion and the two-phase hook both land on this default."""
+        default = (
+            inspect.signature(Autorouter._relief_rescue).parameters["deterministic_rescue"].default
+        )
+        assert default is DETERMINISTIC_RESCUE_DEFAULT
+
+    def test_two_phase_hook_arity_leaves_the_default_in_force(self):
+        """The #3471 stall-relief hook in ``algorithms/two_phase.py`` calls
+        ``_relief_rescue`` POSITIONALLY with 8 arguments, so the flag must stay
+        behind them or that path would silently receive a victim count as its
+        rescue mode."""
+        params = list(inspect.signature(Autorouter._relief_rescue).parameters)
+        assert params[0] == "self"
+        assert params[1:9] == [
+            "failed_net",
+            "neg_router",
+            "net_routes",
+            "pads_by_net",
+            "present_factor",
+            "per_net_timeout",
+            "flush_print_fn",
+            "elapsed_fn",
+        ]
+        assert params.index("deterministic_rescue") >= 9
+
+    def test_inherited_default_without_a_cap_keeps_the_wall_clock(self):
+        """The safety property of the flip: capless runs are byte-identical to
+        the pre-#4730 behavior because there is no deterministic bound to hand
+        over to."""
+        stub = _BudgetStub()
+        assert _budget(stub, None, DETERMINISTIC_RESCUE_DEFAULT) == RELIEF_SUBSEARCH_BUDGET_S
+        assert _budget(stub, 4.0, DETERMINISTIC_RESCUE_DEFAULT) == 4.0
+        assert _budget(stub, None, DETERMINISTIC_RESCUE_DEFAULT) == _budget(stub, None, False)
+
+    def test_inherited_default_with_a_cap_hands_over_to_the_node_budget(self):
+        stub = _BudgetStub(per_net_iterations=1_000_000, max_search_iterations=12_000_000)
+        assert (
+            _budget(stub, None, DETERMINISTIC_RESCUE_DEFAULT) == RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S
+        )
+
+
+class TestReliefSubsearchBoundLine:
+    """The routing-log line is the greppable A/B evidence for the flip."""
+
+    def test_cap_active_reports_the_iteration_bound(self):
+        stub = _BudgetStub(per_net_iterations=1_000_000, max_search_iterations=12_000_000)
+        line = _line(stub, None, DETERMINISTIC_RESCUE_DEFAULT)
+        # Load-bearing evidence token -- board CI logs are grepped for it.
+        assert "iteration-bounded" in line
+        assert "machine-independent" in line
+        assert "requested" not in line
+
+    def test_inherited_default_without_a_cap_does_not_claim_a_request(self):
+        """#4730 acceptance: with a True default, an ordinary capless run never
+        'requested' anything, so the wall-clock arm must stay neutral."""
+        line = _line(_BudgetStub(), None, DETERMINISTIC_RESCUE_DEFAULT)
+        assert "requested" not in line
+        assert "iteration-bounded" not in line
+        assert f"{RELIEF_SUBSEARCH_BUDGET_S:.1f}s wall clock" in line
+        assert "no per-net node-expansion cap is active" in line
+        assert "disabled by caller" not in line
+
+    def test_opt_out_names_the_caller_decision(self):
+        """With a True default, ``deterministic_rescue=False`` is necessarily
+        explicit -- the only arm that may attribute the choice to a caller."""
+        stub = _BudgetStub(per_net_iterations=1_000_000)
+        line = _line(stub, None, False)
+        assert "disabled by caller" in line
+        assert "iteration-bounded" not in line
+        assert f"{RELIEF_SUBSEARCH_BUDGET_S:.1f}s wall clock" in line
+
+    def test_every_arm_carries_the_same_greppable_prefix(self):
+        capped = _BudgetStub(per_net_iterations=1_000_000)
+        for line in (
+            _line(capped, None, DETERMINISTIC_RESCUE_DEFAULT),
+            _line(_BudgetStub(), None, DETERMINISTIC_RESCUE_DEFAULT),
+            _line(capped, None, False),
+        ):
+            assert line.startswith("  Relief-rescue sub-search cap: ")

--- a/tests/test_relief_subsearch_budget.py
+++ b/tests/test_relief_subsearch_budget.py
@@ -7,12 +7,23 @@ the 8-12 s natural re-land time on CI runners, which made board-06's
 ``REQUIRED_SIGNAL_REACH`` gate a coin flip on machine speed.  These tests pin
 the selection table for the deterministic replacement.
 
-Issue #4730 made the deterministic bound the fleet DEFAULT
-(:data:`DETERMINISTIC_RESCUE_DEFAULT`).  That is only safe because the selector
-degrades to the historical wall clock whenever no per-net node-expansion cap is
-active, so a capless run is behavior-identical BY CONSTRUCTION -- the property
-the "inherited default" cases below lock down, alongside the signature defaults
-and the routing-log line that reports which bound is live.
+Issue #4730 made the deterministic bound the default of the NEGOTIATED entry
+point (:data:`DETERMINISTIC_RESCUE_DEFAULT`).  That is only safe because the
+selector degrades to the historical wall clock whenever no per-net
+node-expansion cap is active, so a capless run is behavior-identical BY
+CONSTRUCTION -- the property the "inherited default" cases below lock down,
+alongside the signature defaults and the routing-log line that reports which
+bound is live.
+
+The TWO-PHASE entry point is scoped OUT of that flip
+(:data:`TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT` is ``False``): board 07 -- the
+only board whose two-phase route fires rescues -- came back from the fleet A/B
+with a changed copper-LVS open set and routed-DRC 8 -> 13 against an allowlist
+of 8, and #4730's Acceptance forbids absorbing that.  ``TestTwoPhasePathScoping``
+pins both halves of the resolution: the path default stays historical, AND the
+bound is threaded through as a real per-call switch (the hook calls
+``_relief_rescue`` positionally, so a ``functools.partial`` is what makes an
+opt-in reachable at all).
 
 The methods only read two attributes off ``self``, so they are exercised against
 a lightweight stub rather than a full ``Autorouter`` (which would need a board).
@@ -20,12 +31,16 @@ a lightweight stub rather than a full ``Autorouter`` (which would need a board).
 
 from __future__ import annotations
 
+import functools
 import inspect
+from unittest.mock import MagicMock
 
+from kicad_tools.router import core
 from kicad_tools.router.core import (
     DETERMINISTIC_RESCUE_DEFAULT,
     RELIEF_SUBSEARCH_BUDGET_S,
     RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S,
+    TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT,
     Autorouter,
 )
 
@@ -106,11 +121,13 @@ class TestDeterministicRescueDefault:
         )
         assert default is DETERMINISTIC_RESCUE_DEFAULT
 
-    def test_two_phase_hook_arity_leaves_the_default_in_force(self):
+    def test_two_phase_hook_arity_keeps_the_flag_keyword_only_in_practice(self):
         """The #3471 stall-relief hook in ``algorithms/two_phase.py`` calls
         ``_relief_rescue`` POSITIONALLY with 8 arguments, so the flag must stay
-        behind them or that path would silently receive a victim count as its
-        rescue mode."""
+        behind them -- otherwise that path would silently receive a victim
+        count as its rescue mode, and the ``functools.partial`` that binds the
+        two-phase path's own default (#4730) would collide with a positional
+        argument."""
         params = list(inspect.signature(Autorouter._relief_rescue).parameters)
         assert params[0] == "self"
         assert params[1:9] == [
@@ -160,14 +177,18 @@ class TestReliefSubsearchBoundLine:
         assert "iteration-bounded" not in line
         assert f"{RELIEF_SUBSEARCH_BUDGET_S:.1f}s wall clock" in line
         assert "no per-net node-expansion cap is active" in line
-        assert "disabled by caller" not in line
+        assert "off for this route" not in line
 
-    def test_opt_out_names_the_caller_decision(self):
-        """With a True default, ``deterministic_rescue=False`` is necessarily
-        explicit -- the only arm that may attribute the choice to a caller."""
+    def test_off_arm_does_not_attribute_the_choice_to_one_source(self):
+        """``deterministic_rescue=False`` reaches this arm two ways -- an
+        explicit caller opt-out on the negotiated path, or
+        ``TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT`` on the two-phase path -- so
+        the wording must name both rather than blaming a caller."""
         stub = _BudgetStub(per_net_iterations=1_000_000)
         line = _line(stub, None, False)
-        assert "disabled by caller" in line
+        assert "off for this route" in line
+        assert "caller opt-out" in line
+        assert "two-phase path default" in line
         assert "iteration-bounded" not in line
         assert f"{RELIEF_SUBSEARCH_BUDGET_S:.1f}s wall clock" in line
 
@@ -179,3 +200,87 @@ class TestReliefSubsearchBoundLine:
             _line(capped, None, False),
         ):
             assert line.startswith("  Relief-rescue sub-search cap: ")
+
+
+class TestTwoPhasePathScoping:
+    """Issue #4730: the flip is scoped OUT of the two-phase path (board 07's
+    measured regression), and that path gets a real per-call switch."""
+
+    def test_two_phase_default_is_the_historical_wall_clock(self):
+        """The documented negative result: board 07's copper-LVS open set
+        changed and routed-DRC went 8 -> 13 over an allowlist of 8 when this
+        path inherited the flip, so it must stay off."""
+        assert TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT is False
+        assert TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT is not DETERMINISTIC_RESCUE_DEFAULT
+
+    def test_route_all_two_phase_takes_the_flag_and_defaults_it_to_the_path_value(self):
+        param = inspect.signature(Autorouter.route_all_two_phase).parameters.get(
+            "deterministic_rescue"
+        )
+        assert param is not None, "the two-phase path must expose the opt-in/opt-out"
+        assert param.default is TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT
+
+    def test_escape_entry_points_forward_the_flag(self):
+        """``kct route`` reaches the two-phase path through these, so the
+        switch has to exist there or boards 03/04/07 cannot be opted in."""
+        for method in (
+            Autorouter.route_with_escape,
+            Autorouter.route_with_escape_and_diffpairs,
+        ):
+            param = inspect.signature(method).parameters.get("deterministic_rescue")
+            assert param is not None, f"{method.__name__} must forward the flag"
+            assert param.default is TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT
+
+    def test_create_two_phase_router_binds_the_bound_onto_the_positional_hook(self, monkeypatch):
+        """The #3471 hook calls ``_relief_rescue`` positionally, so a plain
+        bound method carries no bound at all -- the partial is the fix."""
+        captured: dict = {}
+
+        class _FakeTwoPhaseRouter:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr(core, "TwoPhaseRouter", _FakeTwoPhaseRouter)
+        stub = MagicMock()
+
+        Autorouter._create_two_phase_router(stub)
+        hook = captured["relief_rescue"]
+        assert isinstance(hook, functools.partial)
+        assert hook.keywords["deterministic_rescue"] is TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT
+
+        # The 8 positional arguments the hook passes must still land on the
+        # underlying method, with the bound arriving as a keyword.
+        hook(1, 2, 3, 4, 5, 6, 7, 8)
+        args, kwargs = stub._relief_rescue.call_args
+        assert args == (1, 2, 3, 4, 5, 6, 7, 8)
+        assert kwargs == {"deterministic_rescue": TWO_PHASE_DETERMINISTIC_RESCUE_DEFAULT}
+
+    def test_create_two_phase_router_honors_an_explicit_opt_in(self, monkeypatch):
+        captured: dict = {}
+
+        class _FakeTwoPhaseRouter:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr(core, "TwoPhaseRouter", _FakeTwoPhaseRouter)
+        Autorouter._create_two_phase_router(MagicMock(), deterministic_rescue=True)
+        assert captured["relief_rescue"].keywords["deterministic_rescue"] is True
+
+    def test_route_all_two_phase_forwards_the_flag_to_hook_and_banner(self, monkeypatch):
+        """Both the wiring and the log line must report the value THIS call
+        runs under -- the banner previously hardcoded the module constant."""
+        printed: list[str] = []
+        monkeypatch.setattr(core, "flush_print", lambda line: printed.append(line))
+
+        for requested in (False, True):
+            printed.clear()
+            stub = MagicMock()
+            stub._relief_subsearch_bound_line.return_value = f"banner:{requested}"
+
+            Autorouter.route_all_two_phase(stub, deterministic_rescue=requested)
+
+            assert stub._create_two_phase_router.call_args.kwargs == {
+                "deterministic_rescue": requested
+            }
+            assert stub._relief_subsearch_bound_line.call_args.args[1] is requested
+            assert f"banner:{requested}" in printed

--- a/tests/test_two_phase_stall_recovery.py
+++ b/tests/test_two_phase_stall_recovery.py
@@ -359,11 +359,22 @@ class TestTwoPhaseStallReliefRescue:
             )
 
     def test_create_two_phase_router_threads_relief_rescue(self, autorouter_with_two_phase):
-        """``_create_two_phase_router`` must thread ``_relief_rescue``."""
+        """``_create_two_phase_router`` must thread ``_relief_rescue``.
+
+        Issue #4730 wrapped the hook in a ``functools.partial`` so the
+        sub-search bound can ride along on a call the #3471 hook makes
+        POSITIONALLY -- unwrap it before identity-checking the method, and
+        pin the bound keyword while we are here.
+        """
+        import functools
+
+        from kicad_tools.router.core import DETERMINISTIC_RESCUE_DEFAULT
+
         ar = autorouter_with_two_phase
-        tp_router = ar._create_two_phase_router()
-        assert tp_router._relief_rescue is not None
-        assert tp_router._relief_rescue.__func__ is type(ar)._relief_rescue
+        hook = ar._create_two_phase_router()._relief_rescue
+        assert isinstance(hook, functools.partial)
+        assert hook.func.__func__ is type(ar)._relief_rescue
+        assert hook.keywords == {"deterministic_rescue": DETERMINISTIC_RESCUE_DEFAULT}
 
     def test_relief_invoked_for_ripup_fast_fails(self, autorouter_with_two_phase):
         """Nets the rip-up could not rescue must each get one relief


### PR DESCRIPTION
## Summary

The relief rescue is a **transaction** — it rolls back verbatim unless every displaced victim re-lands — so the budget its probe / re-land **sub-searches** get decides routed **reach**, not runtime. The historical flat 10 s wall clock (`RELIEF_SUBSEARCH_BUDGET_S`) straddles the measured 8–12 s natural re-land time on GitHub runners, which made board-06's reach gate a coin flip on machine speed (21/21 vs 20/21 at the *same* commit, #4536).

This PR set out to make the deterministic replacement the fleet default (#4730, Curator's Option A). **The A/B says no, so the flip is withdrawn** and recorded as #4730's negative result. What ships is the other half of the issue: the bound is now a real **per-call switch on every entry point that can reach a rescue**, so a future flip is a measured value change instead of a rewiring job.

## The measured negative result

Board 07 regresses with the deterministic bound in force. Measured twice, on two heads and two runners — A = `6071d1b2` ([run 31281260812](https://github.com/rjwalters/kicad-tools/actions/runs/31281260812)) and `721fc052` ([run 31283738762](https://github.com/rjwalters/kicad-tools/actions/runs/31283738762)); B = main `6cfa8842` ([run 31277512785](https://github.com/rjwalters/kicad-tools/actions/runs/31277512785)):

| Job | B (main) | A (flip on) | Verdict |
|---|---|---|---|
| Boards 00/01/02/03/04/05 | pass | pass | no change |
| Board 06 E2E + Diff-Pair Regression (explicit opt-in) | pass | pass | unchanged ✅ |
| **Board 07 E2E (LVS known opens)** | opens `DQ3, DQ4, MIPI_DAT0_N, TMDS_D0_N, TMDS_D1_N` | opens `DQS_N, MIPI_DAT0_P, TMDS_D0_N, TMDS_D1_N` | **regression** (`--expect-opens` drift guard breaks) |
| **Match-Group Routing Regression (board 07)** | 26/31, DRC **8** (allowlist 8) | 27/31, DRC **13** | **regression** (+5 over an allowlist main sits exactly at) |

Reach goes *up* by one net, but the routed copper is materially worse. #4730's Acceptance is explicit that this is not absorbable ("No board's DRC allowlist is raised to absorb a regression"; "If any board regresses on reach or DRC, keep the opt-in and document the per-board decision instead of forcing the default"), so nothing is re-baselined: no `.github/routed-drc-tolerance.yml`, no `--expect-opens` set, no reach floor, no budget constant.

**Attribution corrected.** The previous revision blamed the two-phase path and scoped the flip out of `route_all_two_phase`. That was wrong: board 07 routes through the **negotiated** entry point (`route_with_escape` → `route_all` → `route_all_negotiated`), its log prints the `iteration-bounded` arm 3× and the two-phase arm zero times, and the regression reproduced byte-for-byte. The docblocks now record the negative result against the path that produced it.

## Changes

- **`src/kicad_tools/router/core.py`**
  - `DETERMINISTIC_RESCUE_DEFAULT = False` — one named constant, now shared by **every** entry point that can reach a rescue: `_relief_rescue`, `route_all_negotiated`, `route_all_two_phase`, `_create_two_phase_router`, `route_with_escape`, `route_with_escape_and_diffpairs`. The two-constant split from the previous revision is gone; it encoded an attribution that measurement refuted, and both values were `False`. The docblock carries the board-07 table and the flip-back condition.
  - **Per-call threading kept** (the judge's "genuinely valuable" half): `_create_two_phase_router` binds `functools.partial(self._relief_rescue, deterministic_rescue=...)`, because the #3471 stall-relief hook calls with 8 **positional** args and a bare bound method could never carry a value; the depth-1 recursive rescue forwards it; `route_all_two_phase` reports **this call's** value in the banner rather than a module constant.
  - `route_all_negotiated(hierarchical=True)` now **forwards** `deterministic_rescue` to `route_all_two_phase` — with a shared default this is a no-op for ordinary calls and closes the footgun the judge flagged (an explicit opt-in was silently dropped on delegation).
  - Banner: the OFF arm is the ordinary default now, so it names the default and the way in (`deterministic rescue is off for this route (the default; opt in with deterministic_rescue=True; issue #4730)`) instead of blaming a caller. The greppable `iteration-bounded` evidence wording is **unchanged**.
- **`src/kicad_tools/cli/route_cmd.py`** — documents why no `kct route` call site passes the flag: every path defaults to the historical wall clock, so `--deterministic-budget` does not change rescue bounding on any board.
- **Docs**: `boards/06-diffpair-test/{README.md,generate_design.py}` and `tests/test_board06_determinism.py` now say board 06's `deterministic_rescue=True` is the **only** thing switching the bound on for that board (it was briefly described as redundant-but-documentary under the flipped default) — it is load-bearing for `REQUIRED_SIGNAL_REACH = 21`.
- **`tests/test_relief_subsearch_budget.py`** — selector matrix unchanged; the default-tests now pin the withdrawal (with the measured evidence in the docstring), and `TestPerCallThreading` pins the switch on every entry point, the partial binding + positional-forwarding contract, the hierarchical forwarding, and the banner arms.
- **`tests/test_two_phase_stall_recovery.py:361`** — fixed for the partial (`hook.func.__func__`, plus a `hook.keywords` assertion). This was the Test-job failure on `721fc052`.

## Behavior vs main

Byte-identical on every board: the only reachable value is `False` (main's behavior) except board 06's explicit `True` (unchanged from main). The one new observable is an additional `Relief-rescue sub-search cap:` log line on the two-phase path, which is evidence, not routing input.

## Test Plan

Run in `.loom/worktrees/issue-4730` with the C++ backend built (`kct build-native --check` → available, build 18), rebased onto `main` @ `627f3e44`:

- `tests/test_relief_subsearch_budget.py` + `tests/test_two_phase_stall_recovery.py` — **34 passed**.
- `tests/router/`, `test_router_core.py`, `test_router_integration.py`, `test_router_determinism.py`, `test_board06_determinism.py`, `test_negotiated_timeout_propagation.py`, `test_negotiated_congestion_model.py`, `test_route_all_negotiated_partial_state.py`, `test_route_all_negotiated_overflow_regression.py`, `test_escape_diffpair.py` (+ the two above) — **1530 passed, 7 skipped** (22m11s).
- Lint: `ruff format . --check` (1779 files) + `ruff check .` clean.
- Types: `scripts/ci/check_mypy_baseline.py` → 1471 errors, all within the 1473 baseline, no new errors, baseline untouched. (A phantom `recovery/strategy.py` error from a stale worktree `.mypy_cache` — the one two judges chased, #4767 — disappears after `rm -rf .mypy_cache`.)
- Live: board 00 capless **and** `--deterministic-budget` both log `10.0s wall clock -- deterministic rescue is off for this route (the default; …)`; board 03 (escape → two-phase, `--deterministic-budget --seed 42`) logs the same line, i.e. the pre-#4730 bound on every path.

**Acceptance gates for this head: Board 07 End-to-End and Match-Group Routing Regression back at main's numbers** (26/31, DRC 8, the 5-net expected open set), plus a green Test job.

Closes #4730
