### PR TITLE
docs: replace rotted rules.py line citations with symbol+file references

### DIFF
--- a/docs/guides/diff-pairs/01-declaring-pairs.md
+++ b/docs/guides/diff-pairs/01-declaring-pairs.md
@@ -23,8 +23,8 @@ usb_p = NetClassRouting(
 )
 ```
 
-Defined at `src/kicad_tools/router/rules.py:448`. This overrides KiCad group
-declarations and suffix inference.
+The `diffpair_partner` field lives in `src/kicad_tools/router/rules.py`. This
+overrides KiCad group declarations and suffix inference.
 
 ### 2. KiCad schematic DiffPair group
 

--- a/docs/guides/diff-pairs/02-clearance-and-classes.md
+++ b/docs/guides/diff-pairs/02-clearance-and-classes.md
@@ -42,17 +42,18 @@ NetClassRouting(
 )
 ```
 
-`coupled_routing` (`rules.py:451`) defaults to `False`. When `False`, the
-pair's halves are still routed *as a pair* by the diff-pair dispatch — the
-intra-pair clearance is honored at the pathfinder layer — but the
-`CoupledPathfinder` geometric coupling is bypassed. Use this for hobby
+`coupled_routing` (in `src/kicad_tools/router/rules.py`) defaults to `False`.
+When `False`, the pair's halves are still routed *as a pair* by the diff-pair
+dispatch — the intra-pair clearance is honored at the pathfinder layer — but
+the `CoupledPathfinder` geometric coupling is bypassed. Use this for hobby
 boards where tight clearance suffices without forcing coupled geometry.
 
 ### Canonical opt-in: `NET_CLASS_HIGH_SPEED`
 
-The pre-configured `NET_CLASS_HIGH_SPEED` in `rules.py:675` already has
-`coupled_routing=True` and `intra_pair_clearance=0.075`. Opt nets into it via
-`Autorouter(..., high_speed_nets=[...])` instead of redeclaring the class.
+The pre-configured `NET_CLASS_HIGH_SPEED` in `src/kicad_tools/router/rules.py`
+already has `coupled_routing=True` and `intra_pair_clearance=0.075`. Opt nets
+into it via `Autorouter(..., high_speed_nets=[...])` instead of redeclaring the
+class.
 
 ## Manufacturer profiles
 

--- a/docs/guides/diff-pairs/04-length-matching.md
+++ b/docs/guides/diff-pairs/04-length-matching.md
@@ -7,7 +7,7 @@ per Issue #630, not pair skew).
 
 ## Field
 
-`NetClassRouting.skew_tolerance_mm` at `src/kicad_tools/router/rules.py:550`
+`NetClassRouting.skew_tolerance_mm` (in `src/kicad_tools/router/rules.py`)
 holds the maximum allowed `|L_p - L_n|` for pairs in this class:
 
 ```python
@@ -31,9 +31,11 @@ nc2 = NetClassRouting(name="MIPI", skew_tolerance_mm=0.04)
 assert nc2.effective_skew_tolerance() == 0.04
 ```
 
-Defined at `rules.py:604`. Default of `0.5 mm` covers USB 3.0 / PCIe Gen 2+
-(~0.5–1 mm), MIPI D-PHY (~1 mm), and DDR4 DQ-strobe (~0.5 mm); set `3.0`
-for USB 2.0 HS.
+The fallback is the `default` parameter of
+`NetClassRouting.effective_skew_tolerance()` in
+`src/kicad_tools/router/rules.py`. Default of `0.5 mm` covers USB 3.0 /
+PCIe Gen 2+ (~0.5–1 mm), MIPI D-PHY (~1 mm), and DDR4 DQ-strobe (~0.5 mm);
+set `3.0` for USB 2.0 HS.
 
 ## Measurement: `Autorouter.update_diffpair_skew`
 

--- a/docs/guides/diff-pairs/05-protocol-recipes.md
+++ b/docs/guides/diff-pairs/05-protocol-recipes.md
@@ -85,7 +85,7 @@ assert mipi.effective_skew_tolerance() == 0.038
 
 ## Notes
 
-- The pre-configured `NET_CLASS_HIGH_SPEED` (`router/rules.py:675`) is a
+- The pre-configured `NET_CLASS_HIGH_SPEED` (in `router/rules.py`) is a
   reasonable default for USB 3.0 / PCIe / MIPI when you opt nets in via
   `Autorouter(..., high_speed_nets=[...])` — only fork your own
   `NetClassRouting` when a per-protocol field above differs.

--- a/docs/guides/diff-pairs/README.md
+++ b/docs/guides/diff-pairs/README.md
@@ -18,7 +18,7 @@ Epic #2556 (Phases 1–3).
 
 ## Canonical pre-configured class
 
-`NET_CLASS_HIGH_SPEED` in `src/kicad_tools/router/rules.py:675` already has
+`NET_CLASS_HIGH_SPEED` in `src/kicad_tools/router/rules.py` already has
 `coupled_routing=True`, `intra_pair_clearance=0.075`, and
 `length_critical=True` — opt nets into it via `high_speed_nets=[...]` on
 `Autorouter` rather than building a class from scratch.

--- a/docs/guides/match-groups/01-declaring-groups.md
+++ b/docs/guides/match-groups/01-declaring-groups.md
@@ -27,9 +27,9 @@ ddr_dq = NetClassRouting(
 )
 ```
 
-Field defined at `src/kicad_tools/router/rules.py:602`. Multiple net
-classes may declare the same group name — their members merge into a
-single group (the documented MIPI/HDMI lane-composition pattern; see
+The `length_match_group` field lives in `src/kicad_tools/router/rules.py`.
+Multiple net classes may declare the same group name — their members merge
+into a single group (the documented MIPI/HDMI lane-composition pattern; see
 guide 03). Overrides suffix inference at detection time
 (`match_group_detection.py:172`).
 

--- a/docs/guides/match-groups/02-reference-selection.md
+++ b/docs/guides/match-groups/02-reference-selection.md
@@ -1,8 +1,9 @@
 # 02 — Reference Selection
 
 `length_match_reference` decides **which trace's length the rest of the
-group must match**. Field declared at `src/kicad_tools/router/rules.py:632`;
-accessor `effective_length_match_reference()` at `rules.py:737`.
+group must match**. The `length_match_reference` field and its accessor
+`effective_length_match_reference()` both live in
+`src/kicad_tools/router/rules.py`.
 
 Reference board: [`boards/07-matchgroup-test`](../../../boards/07-matchgroup-test/)
 exercises all three policies.

--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -280,7 +280,7 @@ Diff-pair routing is configured per net class on
 - [DRC rules](diff-pairs/06-drc-rules.md) (`diffpair_clearance_intra`, `_routing_continuity`, `_length_skew`, `impedance`)
 
 The canonical pre-configured class is `NET_CLASS_HIGH_SPEED` in
-[`router/rules.py:675`](../../src/kicad_tools/router/rules.py) (already has
+[`router/rules.py`](../../src/kicad_tools/router/rules.py) (already has
 `coupled_routing=True`).
 
 ---


### PR DESCRIPTION
## Summary

Eleven `src/kicad_tools/router/rules.py:NNN` citations across 8 diff-pairs /
match-groups guide pages pointed at line numbers that no longer correspond to
the symbols the surrounding prose describes. `rules.py` has grown, so every
cited line now lands in unrelated code — `:448`, cited as the `diffpair_partner`
declaration site, falls in the pour-stitcher docstring; `:675`, cited as
`NET_CLASS_HIGH_SPEED`, falls in neck-down logic.

This adopts the durable convention PR #4738 established: cite the **symbol plus
the file**, never a line number.

## Changes

| File | Citation dropped | Symbol now cited |
|---|---|---|
| `diff-pairs/01-declaring-pairs.md` | `:448` | `diffpair_partner` |
| `diff-pairs/02-clearance-and-classes.md` | `:451`, `:675` | `coupled_routing`, `NET_CLASS_HIGH_SPEED` |
| `diff-pairs/04-length-matching.md` | `:550`, `:604` | `NetClassRouting.skew_tolerance_mm`, `NetClassRouting.effective_skew_tolerance()` `default` param |
| `diff-pairs/05-protocol-recipes.md` | `:675` | `NET_CLASS_HIGH_SPEED` |
| `diff-pairs/README.md` | `:675` | `NET_CLASS_HIGH_SPEED` |
| `match-groups/01-declaring-groups.md` | `:602` | `length_match_group` |
| `match-groups/02-reference-selection.md` | `:632`, `:737` | `length_match_reference`, `effective_length_match_reference()` |
| `guides/routing.md` | `:675` (link text) | `router/rules.py`, same relative link target |

Prose is preserved verbatim; a few lines were reflowed only where the longer
citation changed the wrap. No line numbers were "refreshed" to current values —
that would just recreate the rot.

## Acceptance Criteria Verification

- [x] **All 11 citations replaced with symbol+file references** — 11 hits before,
  8 files touched, 11 citation sites rewritten.
- [x] **`git grep -nE 'rules\.py:[0-9]+' docs/` returns no matches** — verified in
  the worktree, exit 1 / zero output.
- [x] **Every symbol written into a replacement exists in `rules.py`** —
  re-verified independently against this worktree's tree (not the issue body):
  `diffpair_partner` 1113, `coupled_routing` 1116, `skew_tolerance_mm` 1236,
  `length_match_group` 1259, `length_match_reference` 1289,
  `effective_skew_tolerance(self, default: float = 0.5)` 1409,
  `effective_length_match_reference` 1444, `NET_CLASS_HIGH_SPEED` 1689 — matching
  the curator's mapping exactly.
- [x] **Adjacent prose preserved** — no factual claims changed; the only textual
  additions are the symbol names themselves.
- [x] **Drift-guard tests green** — `uv run pytest tests/test_diffpair_docs.py
  tests/test_match_group_docs.py tests/test_check_doc_drift.py` → **42 passed**.
- [x] **`routing.md` link target still resolves** — the link text lost `:675`; the
  target `../../src/kicad_tools/router/rules.py` is unchanged and confirmed to
  resolve from `docs/guides/`.

## Test Plan

- `git grep -nE 'rules\.py:[0-9]+' docs/` → zero matches
- `uv run pytest tests/test_diffpair_docs.py tests/test_match_group_docs.py tests/test_check_doc_drift.py` → 42 passed
- `git diff --name-only` → only the 8 `docs/**` markdown files, no source changes
- Manual read of each edited paragraph — reads naturally with the line number gone

## Note (out of scope, not changed)

`docs/guides/match-groups/01-declaring-groups.md` also carries a
`match_group_detection.py:172` citation with the same rot pattern. It is a
different module and outside this issue's stated scope, so it was left alone
rather than silently expanding the diff.

Closes #4749