### PR TITLE
fix(pcb-sync): export the sync netlist into a temp dir, not beside the schematic

### DIFF
--- a/src/kicad_tools/cli/pcb_sync_netlist.py
+++ b/src/kicad_tools/cli/pcb_sync_netlist.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import sys
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -478,7 +479,19 @@ def _assign_nets_from_schematic(pcb, schematic_path: Path) -> tuple[list[SyncAct
             export_netlist,
         )
 
-        netlist = export_netlist(str(schematic_path))
+        # Route the kicad-cli export byproduct into a temp directory.
+        #
+        # ``export_netlist`` defaults ``output_path`` to
+        # ``<schematic dir>/<stem>-netlist.kicad_net`` and never deletes
+        # it, so a bare call would drop an untracked netlist file beside
+        # the user's schematic on every sync (#4750).  ``export_netlist``
+        # returns a fully parsed ``Netlist``; nothing below re-reads the
+        # file, so the temp directory can be torn down immediately.
+        with tempfile.TemporaryDirectory(prefix="kct-sync-netlist-") as tmpdir:
+            netlist = export_netlist(
+                str(schematic_path),
+                output_path=Path(tmpdir) / f"{schematic_path.stem}-netlist.kicad_net",
+            )
     except Exception as exc:
         errors.append(f"Failed to export netlist for net assignment: {exc}")
         return actions, errors

--- a/src/kicad_tools/operations/netlist.py
+++ b/src/kicad_tools/operations/netlist.py
@@ -815,7 +815,13 @@ def export_netlist(
 
     Args:
         sch_path: Path to .kicad_sch file
-        output_path: Output path for netlist (optional, uses temp)
+        output_path: Where kicad-cli writes the exported netlist file.  When
+            omitted, defaults to ``<sch_path dir>/<stem>-netlist.kicad_net``
+            -- i.e. *beside the schematic*, not a temp location -- and the
+            file is left in place after parsing.  Callers that do not want
+            that byproduct must pass an explicit path (e.g. inside a
+            ``tempfile.TemporaryDirectory``).  Unused by the pure-Python
+            fallback, which writes nothing.
         kicad_cli: Path to kicad-cli (auto-detected if not provided)
         format: Netlist format (kicadsexpr, kicadxml)
         fallback: If True, use pure Python extraction when kicad-cli fails

--- a/tests/test_pcb_sync_netlist.py
+++ b/tests/test_pcb_sync_netlist.py
@@ -2479,7 +2479,7 @@ class TestNetAssignmentErrorSurfacing:
 
         (__builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__)
 
-        def mock_export_netlist(path):
+        def mock_export_netlist(path, *args, **kwargs):
             raise RuntimeError("kicad-cli not found")
 
         monkeypatch.setattr(
@@ -3271,3 +3271,139 @@ class TestTransactionalFlag:
         rc = pcb_commands._run_sync_netlist_command(Args(), pcb)
         assert rc == 0
         assert captured["transactional"] is True
+
+
+# Minimal kicad-cli-shaped netlist matching MINIMAL_SCHEMATIC (R1 + C1).
+FAKE_EXPORTED_NETLIST = """(export (version "E")
+  (components
+    (comp (ref "R1") (value "10k") (footprint "Resistor_SMD:R_0402"))
+    (comp (ref "C1") (value "100n") (footprint "Capacitor_SMD:C_0402")))
+  (nets
+    (net (code "1") (name "/N1")
+      (node (ref "R1") (pin "1"))
+      (node (ref "C1") (pin "1")))))
+"""
+
+
+class TestNetlistByproductLocation:
+    """``sync_netlist`` must not litter the user's project dir (#4750).
+
+    ``export_netlist`` defaults ``output_path`` to
+    ``<schematic dir>/<stem>-netlist.kicad_net`` and never deletes it, so
+    a bare call from ``_assign_nets_from_schematic`` dropped an untracked
+    netlist file beside the user's schematic on every run where kicad-cli
+    is installed.  These tests pin the explicit-temp-path threading.
+    """
+
+    @pytest.fixture
+    def project(self, tmp_path):
+        """A schematic + matching PCB in their own 'project' directory."""
+        proj = tmp_path / "project"
+        proj.mkdir()
+        sch = proj / "test.kicad_sch"
+        pcb = proj / "test.kicad_pcb"
+        sch.write_text(MINIMAL_SCHEMATIC)
+        pcb.write_text(MINIMAL_PCB_MATCHING)
+        return sch, pcb
+
+    @pytest.fixture
+    def fake_kicad_cli(self, monkeypatch):
+        """Force the kicad-cli export path with a stubbed subprocess.
+
+        The stub writes a real netlist file to whatever ``--output`` path
+        it is handed, exactly like kicad-cli does -- so the byproduct
+        lands wherever ``export_netlist`` decided it should, which is the
+        behavior under test.  Returns the list of captured output paths.
+        """
+        import subprocess as _subprocess
+
+        captured_outputs: list[Path] = []
+
+        monkeypatch.setattr(
+            "kicad_tools.operations.netlist.find_kicad_cli",
+            lambda: Path("/fake/kicad-cli"),
+        )
+
+        def fake_run(cmd, *args, **kwargs):
+            out = Path(cmd[cmd.index("--output") + 1])
+            captured_outputs.append(out)
+            out.write_text(FAKE_EXPORTED_NETLIST)
+            return _subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr("kicad_tools.operations.netlist.subprocess.run", fake_run)
+        return captured_outputs
+
+    def test_kicad_cli_path_is_actually_exercised(self, project, fake_kicad_cli):
+        """Guard: the stub really runs, so the assertions below mean something."""
+        from kicad_tools.cli.pcb_sync_netlist import sync_netlist
+
+        sch, pcb = project
+        sync_netlist(schematic_path=sch, pcb_path=pcb, dry_run=True)
+
+        assert fake_kicad_cli, "kicad-cli export path was never taken"
+
+    def test_no_byproduct_beside_schematic(self, project, fake_kicad_cli):
+        """No ``*-netlist.kicad_net`` is left in the schematic's directory."""
+        from kicad_tools.cli.pcb_sync_netlist import sync_netlist
+
+        sch, pcb = project
+        before = {p.name for p in sch.parent.iterdir()}
+
+        result = sync_netlist(schematic_path=sch, pcb_path=pcb, dry_run=True)
+        assert not result.errors, f"sync_netlist errors: {result.errors}"
+
+        stray = sorted(p.name for p in sch.parent.glob("*-netlist.kicad_net"))
+        assert not stray, f"sync-netlist left byproducts beside the schematic: {stray}"
+        assert {p.name for p in sch.parent.iterdir()} == before
+
+    def test_export_output_lands_outside_project_dir(self, project, fake_kicad_cli):
+        """The explicit output path is a temp location, not the project dir."""
+        from kicad_tools.cli.pcb_sync_netlist import sync_netlist
+
+        sch, pcb = project
+        sync_netlist(schematic_path=sch, pcb_path=pcb, dry_run=True)
+
+        assert fake_kicad_cli
+        for out in fake_kicad_cli:
+            assert out.parent != sch.parent, f"export wrote into the project dir: {out}"
+
+    def test_temp_export_is_cleaned_up(self, project, fake_kicad_cli):
+        """The temp directory is torn down before ``sync_netlist`` returns."""
+        from kicad_tools.cli.pcb_sync_netlist import sync_netlist
+
+        sch, pcb = project
+        sync_netlist(schematic_path=sch, pcb_path=pcb, dry_run=True)
+
+        assert fake_kicad_cli
+        for out in fake_kicad_cli:
+            assert not out.exists(), f"temp netlist survived sync_netlist: {out}"
+            assert not out.parent.exists(), f"temp dir survived sync_netlist: {out.parent}"
+
+    def test_nets_still_assigned_from_exported_netlist(self, project, fake_kicad_cli):
+        """Routing the export through a temp path does not lose net data."""
+        from kicad_tools.cli.pcb_sync_netlist import sync_netlist
+
+        sch, pcb = project
+        result = sync_netlist(schematic_path=sch, pcb_path=pcb, dry_run=False)
+
+        assert not result.errors, f"sync_netlist errors: {result.errors}"
+        from kicad_tools.schema.pcb import PCB
+
+        synced = PCB.load(pcb)
+        named = {n.name for n in synced.nets.values() if n.name}
+        assert "N1" in named, f"exported net missing after sync: {sorted(named)}"
+
+    def test_python_fallback_writes_no_byproduct(self, project, monkeypatch):
+        """The pure-Python fallback path also leaves the project dir clean."""
+        from kicad_tools.cli.pcb_sync_netlist import sync_netlist
+
+        monkeypatch.setattr("kicad_tools.operations.netlist.find_kicad_cli", lambda: None)
+
+        sch, pcb = project
+        before = {p.name for p in sch.parent.iterdir()}
+
+        result = sync_netlist(schematic_path=sch, pcb_path=pcb, dry_run=True)
+        assert not result.errors, f"sync_netlist errors: {result.errors}"
+
+        assert not list(sch.parent.glob("*-netlist.kicad_net"))
+        assert {p.name for p in sch.parent.iterdir()} == before


### PR DESCRIPTION
## Summary

`kct pcb sync-netlist` dropped an untracked `<stem>-netlist.kicad_net` file into the
user's project directory on every run where kicad-cli is installed. `_assign_nets_from_schematic`
called `export_netlist(str(schematic_path))` with no `output_path`, and `export_netlist`
defaults that to `<schematic dir>/<stem>-netlist.kicad_net` — then never deletes it.
#4735 / PR #4739 fixed only the test-side symptom (fixtures dirtying); this is the
library-level cause.

Implements **Option A** from the curated issue: thread an explicit `output_path` inside a
`tempfile.TemporaryDirectory`. `export_netlist` returns a fully parsed `Netlist` and nothing
downstream re-reads the file, so the temp dir is torn down immediately after the call.

## Changes

- `src/kicad_tools/cli/pcb_sync_netlist.py` — `_assign_nets_from_schematic` wraps the
  `export_netlist` call in `tempfile.TemporaryDirectory(prefix="kct-sync-netlist-")` and
  passes an explicit `output_path`; added the `tempfile` import.
- `src/kicad_tools/operations/netlist.py` — corrected the `output_path` docstring, which
  claimed "(optional, uses temp)". That was false: the default has always been
  next-to-schematic, and the file is left in place. **No behavior change here** —
  `export_netlist`'s default and the other 16 bare call sites are untouched (Option B is
  explicitly out of scope per the issue's scope guard).
- `tests/test_pcb_sync_netlist.py` — new `TestNetlistByproductLocation` (6 tests);
  widened one existing mock's signature (`mock_export_netlist(path, *args, **kwargs)`) so it
  still absorbs the new keyword argument.

No opt-in keep-artifact flag was added — `kct sch export-netlist` already covers users who
want the netlist file, so sync-netlist does not grow a duplicate knob.

## Acceptance Criteria Verification

- [x] **Explicit `output_path` threaded; byproduct removed before return** — the export
      target is `Path(tmpdir)/f"{stem}-netlist.kicad_net"`; `test_temp_export_is_cleaned_up`
      asserts both the file and its parent dir are gone once `sync_netlist` returns.
- [x] **No `*-netlist.kicad_net` beside the schematic** — verified two ways.
      Automated: `test_no_byproduct_beside_schematic` asserts the project dir's listing is
      identical before/after. Manual with real kicad-cli (`/opt/homebrew/bin/kicad-cli`):
      ran `kct pcb sync-netlist` on a scratch copy of the board-05 fixture pair; the
      directory still contained exactly `bldc_controller.kicad_pcb` +
      `bldc_controller.kicad_sch` afterwards.
- [x] **New test fails on pre-fix behavior** — temporarily reverted the source hunk to the
      bare `export_netlist(str(schematic_path))` call and re-ran the class:
      3 failed (`test_no_byproduct_beside_schematic`,
      `test_export_output_lands_outside_project_dir`, `test_temp_export_is_cleaned_up`),
      3 passed. Restored the fix; all 6 pass.
- [x] **`export_netlist` docstring matches actual behavior** — now states the default is
      beside the schematic, that the file is left in place, and that callers who don't want
      the byproduct must pass an explicit path.
- [x] **Full suite green including `TestBoard05SyncDriftRegression`** — 141 passed in
      `tests/test_pcb_sync_netlist.py`; the #4739 copy-into-tmp_path arrangement is
      unchanged and still green.
- [x] **Pure-Python fallback unchanged** — `test_python_fallback_writes_no_byproduct` pins
      that the `find_kicad_cli() is None` path still writes nothing.
- [x] **Net data still lands** — `test_nets_still_assigned_from_exported_netlist` confirms
      routing the export through a temp path does not lose the parsed nets.

## Test Plan

- `uv run pytest tests/test_pcb_sync_netlist.py -q --no-cov` → **141 passed**
- `uv run pytest tests/test_pcb_sync_netlist.py tests/test_sync.py tests/test_cli_netlist.py tests/test_pcb_import_from_schematic.py -q --no-cov` → **302 passed**
- `uv run ruff check` on the 3 changed files → All checks passed
- `uv run ruff format --check` on the 3 changed files → 3 files already formatted
- `uv run mypy src/kicad_tools/cli/pcb_sync_netlist.py` → Success, no issues
- Manual, kicad-cli installed → no `*-netlist.kicad_net` byproduct (above)

## Out-of-scope observation (not fixed here)

While running the broader test modules, the **tracked** fixture
`tests/fixtures/simple_rc-netlist.kicad_net` was rewritten in place — a sibling instance of
the same root cause at a *different* bare `export_netlist` call site. I reverted that churn
rather than committing it; per this issue's scope guard I did not touch the other call
sites. Worth a follow-up issue (it is the same shape as #4735, one call site over).

Closes #4750
