### PR TITLE
fix(cli): resolve --voltage-map to an absolute path at parse time

### DIFF
--- a/src/kicad_tools/cli/build_cmd.py
+++ b/src/kicad_tools/cli/build_cmd.py
@@ -3475,6 +3475,10 @@ def main(argv: list[str] | None = None) -> int:
     if output_dir and not schematic and not pcb:
         schematic, pcb = _find_artifacts(project_dir, spec_file)
 
+    # Imported lazily (like the gate core at _audit_routed_artifact_for_skip)
+    # to keep `kct build` from paying pipeline_cmd's import cost eagerly.
+    from .pipeline_cmd import resolve_voltage_map_arg
+
     # Create build context
     ctx = BuildContext(
         project_dir=project_dir,
@@ -3491,7 +3495,11 @@ def main(argv: list[str] | None = None) -> int:
         optimize_placement=args.optimize_placement,
         smoke_check=not args.no_smoke_check,
         allow_incomplete=args.allow_incomplete,
-        voltage_map=args.voltage_map,
+        # Absolutize now, while cwd is still the user's invocation directory
+        # (#4751).  The route fallback runs with cwd=ctx.project_dir and the
+        # route-skip creepage audit with cwd=<routed artifact>.parent -- which,
+        # under -o/--output, is outside the project entirely.
+        voltage_map=resolve_voltage_map_arg(args.voltage_map),
         creepage_standard=args.creepage_standard,
         pollution_degree=args.pollution_degree,
         material_group=args.material_group,

--- a/src/kicad_tools/cli/pipeline_cmd.py
+++ b/src/kicad_tools/cli/pipeline_cmd.py
@@ -931,6 +931,33 @@ def _run_subprocess_step(
         return False, f"failed: {e}"
 
 
+def resolve_voltage_map_arg(voltage_map: str | None) -> str | None:
+    """Absolutize a user-supplied ``--voltage-map`` against the invocation cwd.
+
+    Issue #4751: the HV flag value is forwarded verbatim into subprocesses
+    that deliberately run with a working directory other than the one the
+    user invoked from -- :func:`run_creepage_skip_audit` uses
+    ``cwd=target_pcb.parent``, the pipeline route step uses
+    ``cwd=ctx.pcb_file.parent`` and ``kct build``'s route fallback uses
+    ``cwd=ctx.project_dir``.  ``kct creepage`` resolves the flag with a plain
+    ``Path(vmap_arg)`` against *its own* cwd, so a **relative** map path
+    combined with an ``--output-dir`` outside the project directory made the
+    audit look for the map in the wrong place and hard-fail the strict
+    exit-0 skip gate -- a spurious refusal for a legitimate invocation.
+
+    Resolving once at context-construction time (while the process cwd is
+    still the user's invocation cwd) makes every downstream forward --
+    audit argv, route passthrough, dry-run echo, and the ``kct creepage``
+    hint in the refusal message -- cwd-independent for free.
+
+    ``None`` (and the empty string) pass through untouched so the
+    ``if ctx.voltage_map:`` gates elsewhere keep their exact semantics.
+    """
+    if not voltage_map:
+        return voltage_map
+    return str(Path(voltage_map).resolve())
+
+
 def run_creepage_skip_audit(
     target_pcb: Path,
     *,
@@ -2592,7 +2619,9 @@ Examples:
         max_displacement=args.max_displacement,
         apply_sync=args.apply_sync,
         route_skip_threshold=args.route_skip_threshold,
-        voltage_map=args.voltage_map,
+        # Absolutize now, while cwd is still the user's invocation directory
+        # (#4751) -- the route/audit subprocesses run with a different cwd.
+        voltage_map=resolve_voltage_map_arg(args.voltage_map),
         creepage_standard=args.creepage_standard,
         pollution_degree=args.pollution_degree,
         material_group=args.material_group,

--- a/tests/test_build_cmd_errors.py
+++ b/tests/test_build_cmd_errors.py
@@ -1442,6 +1442,131 @@ class TestBuildRouteVoltageMapForwarding:
             assert flag not in argv
 
 
+class TestBuildVoltageMapAbsolutization:
+    """A relative ``--voltage-map`` survives an external ``-o`` (issue #4751).
+
+    ``_resolve_routed_pcb_path`` puts the routed artifact under
+    ``--output`` when set, and the route-skip creepage gate runs its audit
+    subprocess with ``cwd=<routed artifact>.parent``.  `kct creepage`
+    resolves ``--voltage-map`` with a plain ``Path(vmap_arg)`` against that
+    cwd, so a relative map path looked for the file in the output dir --
+    outside the project entirely -- and the strict exit-0 gate hard-failed
+    with a spurious "voltage-map file not found" refusal.  The first
+    (routing) build passed and the very next re-build failed.
+
+    The fix absolutizes the flag once in ``main()``, while the process cwd
+    is still the user's invocation directory.
+    """
+
+    @staticmethod
+    def _creepage_call(mock_run):
+        """Return the audit subprocess call (argv contains ``creepage``), or None.
+
+        The patch target is shared with every other ``subprocess.run`` in the
+        process, so the route step's neighbours (e.g. the smoke check) can
+        also land in ``call_args_list``.
+        """
+        for call in mock_run.call_args_list:
+            if call.args and "creepage" in call.args[0]:
+                return call
+        return None
+
+    def _arrange(self, tmp_path: Path) -> tuple[Path, Path, Path]:
+        """Project dir, an output dir OUTSIDE it, and a separate invocation cwd."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+
+        output_dir = tmp_path / "external_out"
+        output_dir.mkdir()
+        pcb = output_dir / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb)")
+        routed = output_dir / "board_routed.kicad_pcb"
+        routed.write_text("(kicad_pcb)")
+        # Routed sibling unambiguously newer -> the mtime skip guard fires.
+        os.utime(pcb, (1_000_000.0, 1_000_000.0))
+        os.utime(routed, (1_000_100.0, 1_000_100.0))
+
+        invocation_dir = tmp_path / "cwd"
+        invocation_dir.mkdir()
+        (invocation_dir / "vm.json").write_text("{}")
+
+        return project_dir, output_dir, invocation_dir
+
+    @staticmethod
+    def _argv(project_dir: Path, output_dir: Path, *extra: str) -> list[str]:
+        return [
+            str(project_dir),
+            "-o",
+            str(output_dir),
+            "--step",
+            "route",
+            "--no-smoke-check",
+            "--quiet",
+            *extra,
+        ]
+
+    def test_relative_map_with_external_output_dir_stays_locatable(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """The reported shape: `kct build -o <external> --voltage-map ./vm.json`."""
+        from unittest.mock import MagicMock, patch
+
+        project_dir, output_dir, invocation_dir = self._arrange(tmp_path)
+        monkeypatch.chdir(invocation_dir)
+
+        with patch("kicad_tools.cli.pipeline_cmd.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+            rc = main(self._argv(project_dir, output_dir, "--voltage-map", "vm.json"))
+
+        assert rc == 0
+        call = self._creepage_call(mock_run)
+        assert call is not None, "route-skip creepage audit never ran"
+        cmd_args = call.args[0]
+
+        forwarded = Path(cmd_args[cmd_args.index("--voltage-map") + 1])
+        assert forwarded.is_absolute()
+        assert forwarded == (invocation_dir / "vm.json").resolve()
+
+        # The audit subprocess runs from the EXTERNAL output dir, where a
+        # relative "vm.json" does not exist -- only the absolute path is
+        # locatable from there (this is the regression).
+        audit_cwd = Path(call.kwargs["cwd"])
+        assert audit_cwd.resolve() == output_dir.resolve()
+        assert not (audit_cwd / "vm.json").exists()
+        assert (audit_cwd / forwarded).exists()
+
+    def test_absolute_map_unchanged(self, tmp_path: Path, monkeypatch) -> None:
+        """An already-absolute ``--voltage-map`` is forwarded verbatim."""
+        from unittest.mock import MagicMock, patch
+
+        project_dir, output_dir, invocation_dir = self._arrange(tmp_path)
+        monkeypatch.chdir(invocation_dir)
+        absolute_map = (invocation_dir / "vm.json").resolve()
+
+        with patch("kicad_tools.cli.pipeline_cmd.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+            main(self._argv(project_dir, output_dir, "--voltage-map", str(absolute_map)))
+
+        call = self._creepage_call(mock_run)
+        assert call is not None
+        cmd_args = call.args[0]
+        assert cmd_args[cmd_args.index("--voltage-map") + 1] == str(absolute_map)
+
+    def test_no_voltage_map_spawns_no_audit(self, tmp_path: Path, monkeypatch) -> None:
+        """Without the flag the skip path is unchanged (no audit subprocess)."""
+        from unittest.mock import MagicMock, patch
+
+        project_dir, output_dir, invocation_dir = self._arrange(tmp_path)
+        monkeypatch.chdir(invocation_dir)
+
+        with patch("kicad_tools.cli.pipeline_cmd.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+            rc = main(self._argv(project_dir, output_dir))
+
+        assert rc == 0
+        assert self._creepage_call(mock_run) is None
+
+
 class TestBuildVoltageMapPassthroughHops:
     """Pin every hop of the build passthrough chain (issue #4607).
 

--- a/tests/test_pipeline_cmd.py
+++ b/tests/test_pipeline_cmd.py
@@ -1235,6 +1235,118 @@ class TestRouteSkipCreepageAuditGate:
         assert rc == 1
 
 
+class TestVoltageMapPathAbsolutization:
+    """``--voltage-map`` is absolutized at parse time (issue #4751).
+
+    The route-skip creepage audit runs its subprocess with
+    ``cwd=target_pcb.parent`` and the route step with
+    ``cwd=ctx.pcb_file.parent``, while `kct creepage` resolves the flag with
+    a plain ``Path(vmap_arg)`` against *its own* cwd.  A **relative**
+    ``--voltage-map`` therefore resolved against the artifact's directory
+    instead of the user's invocation directory -- and, with an output dir
+    outside the project, hard-failed the strict exit-0 gate with a spurious
+    "voltage-map file not found" refusal.
+    """
+
+    def test_none_passes_through(self):
+        from kicad_tools.cli.pipeline_cmd import resolve_voltage_map_arg
+
+        assert resolve_voltage_map_arg(None) is None
+
+    def test_relative_resolved_against_invocation_cwd(self, tmp_path: Path, monkeypatch):
+        from kicad_tools.cli.pipeline_cmd import resolve_voltage_map_arg
+
+        vmap = tmp_path / "vm.json"
+        vmap.write_text("{}")
+        monkeypatch.chdir(tmp_path)
+
+        resolved = resolve_voltage_map_arg("vm.json")
+        assert Path(resolved).is_absolute()
+        assert Path(resolved) == vmap.resolve()
+
+    def test_absolute_is_a_no_op(self, tmp_path: Path):
+        from kicad_tools.cli.pipeline_cmd import resolve_voltage_map_arg
+
+        vmap = (tmp_path / "vm.json").resolve()
+        vmap.write_text("{}")
+        assert resolve_voltage_map_arg(str(vmap)) == str(vmap)
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_skip_audit_argv_carries_locatable_absolute_map(
+        self, mock_run, routed_pcb: Path, tmp_path: Path, monkeypatch
+    ):
+        """Relative map + a board in another directory -> the audit can find it."""
+        from kicad_tools.cli import pipeline_cmd
+
+        invocation_dir = tmp_path / "cwd"
+        invocation_dir.mkdir()
+        vmap = invocation_dir / "vm.json"
+        vmap.write_text("{}")
+        monkeypatch.chdir(invocation_dir)
+
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+        rc = pipeline_cmd.main(
+            [str(routed_pcb), "--step", "route", "--voltage-map", "vm.json", "--quiet"]
+        )
+        assert rc == 0
+
+        cmd_args = mock_run.call_args[0][0]
+        forwarded = Path(cmd_args[cmd_args.index("--voltage-map") + 1])
+        assert forwarded.is_absolute()
+        # The subprocess cwd is the board's directory, NOT the invocation
+        # directory -- so only an absolute path stays locatable.
+        assert Path(mock_run.call_args.kwargs["cwd"]).resolve() != invocation_dir.resolve()
+        assert (Path(mock_run.call_args.kwargs["cwd"]) / forwarded).exists()
+
+    @patch("kicad_tools.cli.pipeline_cmd.subprocess.run")
+    def test_route_passthrough_argv_carries_absolute_map(
+        self, mock_run, unrouted_pcb: Path, tmp_path: Path, monkeypatch
+    ):
+        """The re-route passthrough is absolutized by the same parse-time fix."""
+        from kicad_tools.cli import pipeline_cmd
+
+        invocation_dir = tmp_path / "cwd"
+        invocation_dir.mkdir()
+        (invocation_dir / "vm.json").write_text("{}")
+        monkeypatch.chdir(invocation_dir)
+
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+        pipeline_cmd.main(
+            [str(unrouted_pcb), "--step", "route", "--voltage-map", "vm.json", "--quiet"]
+        )
+
+        cmd_args = mock_run.call_args[0][0]
+        assert "route" in cmd_args
+        forwarded = Path(cmd_args[cmd_args.index("--voltage-map") + 1])
+        assert forwarded.is_absolute()
+        assert forwarded == (invocation_dir / "vm.json").resolve()
+
+    def test_dry_run_echo_renders_resolved_path(
+        self, routed_pcb: Path, tmp_path: Path, monkeypatch
+    ):
+        """The dry-run echo prints a copy-pasteable (absolute) map path."""
+        from rich.console import Console
+
+        from kicad_tools.cli.pipeline_cmd import _run_step_route, resolve_voltage_map_arg
+
+        invocation_dir = tmp_path / "cwd"
+        invocation_dir.mkdir()
+        vmap = invocation_dir / "vm.json"
+        vmap.write_text("{}")
+        monkeypatch.chdir(invocation_dir)
+
+        ctx = PipelineContext(
+            pcb_file=routed_pcb,
+            quiet=True,
+            dry_run=True,
+            voltage_map=resolve_voltage_map_arg("vm.json"),
+        )
+        result = _run_step_route(ctx, Console(quiet=True))
+
+        assert result.success is True
+        assert f"--voltage-map {vmap.resolve()}" in result.message
+
+
 class TestProjectInput:
     """Tests for .kicad_pro input support."""
 


### PR DESCRIPTION
## Summary

`kct creepage` resolves `--voltage-map` with a plain `Path(vmap_arg)` against
**its own** working directory, but the flag value was forwarded verbatim into
subprocesses that deliberately run elsewhere: `run_creepage_skip_audit` uses
`cwd=target_pcb.parent`, the pipeline route step `cwd=ctx.pcb_file.parent`, and
`kct build`'s route fallback `cwd=ctx.project_dir`.

Under `kct build -o <dir outside the project>` the routed artifact lands in that
external dir (`_resolve_routed_pcb_path`), so the route-skip audit ran from
there and a **relative** `--voltage-map` was looked up in the wrong place: the
audit exited 1 (`voltage-map file not found`), failing the strict exit-0 skip
gate with a spurious refusal naming `kct creepage` and `--force`. The first
(routing) build passed and the very next re-build failed — a
first-run-passes/second-run-fails asymmetry.

The fix absolutizes the flag **once**, at context-construction time in each
command's `main()`, while the process cwd is still the user's invocation
directory. No subprocess `cwd` value is changed.

## Changes

- `src/kicad_tools/cli/pipeline_cmd.py` — new `resolve_voltage_map_arg()`
  (documented next to the shared gate core) and its use at the
  `PipelineContext` construction site.
- `src/kicad_tools/cli/build_cmd.py` — same call at the `BuildContext`
  construction site, via the module's established lazy `pipeline_cmd` import.
- `tests/test_pipeline_cmd.py` — `TestVoltageMapPathAbsolutization`: helper
  unit cases (`None` passthrough, relative→absolute, absolute no-op), plus
  argv assertions for the skip-audit and route passthrough and the dry-run echo.
- `tests/test_build_cmd_errors.py` — `TestBuildVoltageMapAbsolutization`: the
  reported shape end-to-end through `main()` (`-o <external dir>` +
  `--voltage-map vm.json` + pre-existing routed artifact), plus absolute-map
  and no-map control cases.

`src/kicad_tools/cli/commands/creepage.py` is unchanged (reference only).

## Acceptance Criteria Verification

- [x] **Voltage-map path resolved to an absolute path once, at
  argument-parse/context-build time, before any gate forwards it** —
  `resolve_voltage_map_arg(args.voltage_map)` at `pipeline_cmd` and `build_cmd`
  context construction; nothing downstream re-resolves.
- [x] **Both callers (pipeline skip gate, build skip gate) pass the absolutized
  path regardless of subprocess cwd** — asserted directly against the audit argv
  in both test modules, including that the audit's `cwd` is the external output
  dir where a relative `vm.json` does **not** exist while the forwarded absolute
  path does.
- [x] **Test covering: relative `--voltage-map` + `--output-dir` outside the
  project dir → audit runs and locates the map** —
  `test_relative_map_with_external_output_dir_stays_locatable`. Verified it
  **fails** on the pre-fix code (temporarily reverting the two call sites made
  it, and the two pipeline argv tests, fail; restored afterwards).
- [x] **No change to the strict exit-0 gate contract, exit-2 vacuity
  discrimination, or dry-run behavior** — all 391 existing tests in the two
  affected modules pass unchanged; `None`/empty values pass through untouched so
  every `if ctx.voltage_map:` gate keeps its exact semantics. The
  parser/shim/inner-parser passthrough hops are unaffected (resolution happens
  after the inner parse, in the same process and cwd).
- [x] **Edge cases** — absolute input is a no-op (`test_absolute_map_unchanged`),
  unset stays `None`, dry-run echo renders the resolved path (which also makes
  the printed `kct creepage …` hint copy-pasteable from any directory).

## Test Plan

```
uv run pytest tests/test_pipeline_cmd.py tests/test_build_cmd_errors.py -q --no-cov
# 391 passed

uv run pytest tests/test_build_cmd_stdout_streaming.py tests/test_build_cmd_timings.py \
  tests/test_pipeline_cli_args.py tests/test_pipeline_sync_step.py tests/creepage -q --no-cov
# 312 passed

uv run ruff check <changed files>      # All checks passed!
uv run ruff format --check <changed>   # 4 files already formatted
uv run python scripts/ci/check_mypy_baseline.py
# OK: 1473 error(s), all within the baseline (1475 allowed). No new type errors.
```

Note: `check-main-clean.sh` reports the main checkout dirty with an untracked
`.loom/SWEEP-HANDOFF.md` — pre-existing from the concurrent sweep, not produced
by this work; left untouched.

Closes #4751
