### PR TITLE
fix(router): audit preserved copper and pad/layer-scope the HV attach-zone waiver

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -1527,6 +1527,12 @@ def _finalize_routes(
     # otherwise appear twice (once from ``router.routes``, once from the
     # preserved set).  Skip any preserved route whose net id is present in
     # the freshly-routed set so the freshly-routed copper wins.
+    # Issue #4699: the post-route pairwise gate must audit the copper the
+    # OUTPUT actually carries, which is the freshly-routed set plus exactly the
+    # preserved routes re-emitted below.  Record that set on the router so
+    # ``_audited_trace_copper`` never has to re-derive (or guess) it.  Always
+    # set -- an empty list is the meaningful "nothing preserved" answer.
+    _emitted_preserved: list[Route] = []
     if preserve_existing:
         source_routes = preserved_routes if preserved_routes is not None else router.existing_routes
         if source_routes:
@@ -1543,8 +1549,9 @@ def _finalize_routes(
             preserved_sexp = _serialize_preserved_routes(
                 source_routes, exclude_net_ids=routed_net_ids, name_only=name_only
             )
+            _emitted_preserved = [r for r in source_routes if r.net not in routed_net_ids]
             if preserved_sexp:
-                emitted = [r for r in source_routes if r.net not in routed_net_ids]
+                emitted = _emitted_preserved
                 preserved_segments = sum(len(r.segments) for r in emitted)
                 preserved_vias = sum(len(r.vias) for r in emitted)
                 route_sexp = f"{route_sexp}\n\t{preserved_sexp}" if route_sexp else preserved_sexp
@@ -1553,6 +1560,10 @@ def _finalize_routes(
                         f"  Preserved existing: {preserved_segments} segments, "
                         f"{preserved_vias} vias ({len(emitted)} routes)"
                     )
+
+    # Issue #4699: hand the gate the exact preserved set that was written.
+    with contextlib.suppress(AttributeError):  # exotic router stand-ins
+        router._emitted_preserved_routes = _emitted_preserved
 
     # Step 3: Compute statistics from the cleaned routes
     stats = router.get_statistics(nets_to_route_ids=multi_pad_net_ids)
@@ -4249,6 +4260,60 @@ def _pairwise_attach_zones(router: "Autorouter") -> "tuple[AttachZone, ...]":
     return zones
 
 
+def _audited_trace_copper(router: "Autorouter", *, id_to_name=None) -> "list[Route]":
+    """Every trace route the output board carries -- fresh AND preserved (#4699).
+
+    The #4588 gate audited ``router.routes`` only.  With ``--preserve-existing``
+    (implied by ``--complete``) the board ALSO carries the input board's copper,
+    re-emitted by :func:`_finalize_routes` from a separate list, so any
+    pairwise shortfall between fresh and preserved copper -- or between two
+    preserved routes -- was structurally unreportable.
+
+    Preference order for the preserved half:
+
+    1. ``router._emitted_preserved_routes`` -- recorded by
+       :func:`_finalize_routes` and therefore *exactly* the preserved routes
+       written to the output (empty list when nothing was preserved).  This is
+       always present after finalize, which every gate call site runs first.
+    2. ``router.existing_routes`` minus the re-routed net ids -- the same
+       dedupe rule :func:`_finalize_routes` applies, for callers (unit tests,
+       stand-in routers) that never went through finalize.
+
+    Preserved routes are re-keyed to the board's net ids by NAME where the name
+    resolves: ``find_pairwise_violations`` prefers ``id_to_name`` over a route's
+    own ``net_name``, so a preserved route whose id disagrees with the routing
+    session's numbering would otherwise be audited under the wrong net's
+    voltage -- the silent-blindness failure mode this issue is about.
+    """
+    from kicad_tools.router.primitives import Route
+
+    routes: list[Route] = list(getattr(router, "routes", None) or [])
+
+    preserved = getattr(router, "_emitted_preserved_routes", None)
+    if preserved is None:
+        source = list(getattr(router, "existing_routes", None) or [])
+        routed_net_ids = {r.net for r in routes} - set(getattr(router, "_stub_terminals", {}) or {})
+        preserved = [r for r in source if r.net not in routed_net_ids]
+
+    if preserved:
+        name_to_id = {name: nid for nid, name in (id_to_name or {}).items() if name}
+        for route in preserved:
+            net_id = name_to_id.get(route.net_name, route.net)
+            if net_id == route.net:
+                routes.append(route)
+            else:
+                # Shallow re-key: the segment/via lists are shared, not copied.
+                routes.append(
+                    Route(
+                        net=net_id,
+                        net_name=route.net_name,
+                        segments=route.segments,
+                        vias=route.vias,
+                    )
+                )
+    return routes
+
+
 def _audit_pairwise_clearance(
     router: "Autorouter", args, *, id_to_name=None
 ) -> "list[PairwiseViolation]":
@@ -4267,6 +4332,19 @@ def _audit_pairwise_clearance(
     by appending to ``router.routes``, so a whole-board scan of that list catches
     what the search let through, regardless of which search produced it.
 
+    Issue #4699: ``router.routes`` alone is NOT the board.  Under
+    ``--preserve-existing`` (which ``--complete`` implies) the copper loaded
+    from the input board is re-emitted verbatim from a separate list, so a
+    routes-only scan could never report a trace-to-trace shortfall involving
+    preserved copper -- four of the nine violations in the #4699 report were in
+    that structurally-invisible class.  The scan therefore runs over
+    :func:`_audited_trace_copper`: the freshly-routed copper PLUS exactly the
+    preserved routes ``_finalize_routes`` re-emitted, i.e. the trace copper the
+    output file actually carries.  Pre-existing input-board violations
+    consequently fail the run too -- deliberately: the gate's contract is that
+    a SUCCESS banner means the *written board* is clean, and a board is no
+    safer for having inherited its unsafe copper rather than routed it.
+
     Returns a list of :class:`~kicad_tools.router.pairwise_clearance.PairwiseViolation`
     sorted worst-shortfall-first.  A strict no-op (empty list, no board load, no
     scan) when ``--voltage-map`` was not supplied, so every pre-existing run is
@@ -4282,7 +4360,7 @@ def _audit_pairwise_clearance(
     table = getattr(rules, "pairwise_clearance", None) if rules is not None else None
     if table is None:
         return []
-    routes = list(getattr(router, "routes", None) or [])
+    routes = _audited_trace_copper(router, id_to_name=id_to_name)
     if not routes:
         return []
 
@@ -4398,7 +4476,11 @@ def _print_pairwise_failure_banner(
     print("Routed copper is closer than the --voltage-map derived creepage")
     print("requirement for these net pairs. This board is NOT safe to manufacture.")
     print()
-    print("Scope of this gate: trace-to-trace, same layer only. Pad and via")
+    print("Scope of this gate: trace-to-trace, same layer only, over ALL trace")
+    print("copper the output carries -- freshly routed AND preserved (#4699).")
+    print("A finding between preserved routes was inherited from the input")
+    print("board, not created by this run; re-route those nets (or fix the")
+    print("input) -- the written board is unsafe either way. Pad and via")
     print("geometry are not scanned here -- 'kct creepage' is the authoritative")
     print("full census:")
     vm = getattr(args, "voltage_map", None)

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -1048,6 +1048,12 @@ class Autorouter:
         # board-origin shift per PR #4603).  ``None`` = not yet resolved.
         # Consumed here by the lattice pairwise projection (#4602).
         self._pairwise_attach_zones_cache: tuple[Any, ...] | None = None
+        # Issue #4699: the preserved routes the CLI's ``_finalize_routes``
+        # actually re-emitted into the output board.  ``None`` = finalize has
+        # not run yet; the #4588 post-route pairwise gate audits this copper
+        # alongside ``self.routes`` so preserved trace copper is not
+        # structurally invisible to the safety gate.
+        self._emitted_preserved_routes: list[Any] | None = None
         # Issue #4605: optional ``spatial_keepouts`` sidecar filter block
         # (``{rule_area_name: {"except_classes": [...] | "only_classes":
         # [...]}}``), stashed by the CLI's ``_apply_net_class_map_sidecar``.
@@ -2700,7 +2706,14 @@ class Autorouter:
         from .lattice.pairwise import build_lattice_pairwise
 
         zones = self._pairwise_attach_zones_cache or ()
-        return build_lattice_pairwise(table, zones, self._net_name_to_id())
+        # Issue #4699: the #4506 exemption is layer-scoped (a zone waives a
+        # pair only on layers where BOTH nets have pad copper), so the search
+        # needs the board-layer-name -> lattice-index map to agree with the
+        # #4588 gate by construction.
+        layer_indices = {
+            layer_def.name: layer_def.index for layer_def in getattr(self.layer_stack, "layers", ())
+        }
+        return build_lattice_pairwise(table, zones, self._net_name_to_id(), layer_indices or None)
 
     def _net_name_to_id(self) -> dict[str, int]:
         """Net name -> id map (``net_names`` + a pad-derived fallback).

--- a/src/kicad_tools/router/lattice/obstacles.py
+++ b/src/kicad_tools/router/lattice/obstacles.py
@@ -226,7 +226,7 @@ class LatticeObstacleModel:
             rect = self.pad_rects[idx]
             grown = (rect[0] - extra_pw, rect[1] - extra_pw, rect[2] + extra_pw, rect[3] + extra_pw)
             if seg_rect_intersect(a, b, grown) and not pairwise.exempt_seg_pt(
-                a, b, (pad.x, pad.y), net, pad.net
+                a, b, (pad.x, pad.y), net, pad.net, layer
             ):
                 return True
         return False
@@ -499,7 +499,7 @@ class CommittedCopper:
                 req = pw.required(net, cnet)
                 if req > max(own_clr, iclr):
                     if d_cc < own_half + hw + req - 1e-9 and not pw.exempt_seg_seg(
-                        a, b, c, d, net, cnet
+                        a, b, c, d, net, cnet, layer
                     ):
                         return False
         # Issue #4597: honor the STORED via's class clearance the same way the
@@ -520,7 +520,7 @@ class CommittedCopper:
                     req = pw.required(net, vnet)
                     if req > max(own_clr, vclr):
                         if d_vp < self.via_radius + own_half + req - 1e-9 and not pw.exempt_seg_pt(
-                            a, b, point, net, vnet
+                            a, b, point, net, vnet, layer
                         ):
                             return False
             elif seg_body_crosses_pt(a, b, point):
@@ -560,7 +560,7 @@ class CommittedCopper:
                 req = pw.required(net, cnet)
                 if req > max(own_clr, iclr):
                     if d_cc < own_half + hw + req - 1e-9 and not pw.exempt_seg_pt(
-                        c, d, point, net, cnet
+                        c, d, point, net, cnet, layer
                     ):
                         return False
         # Issue #4597: ``max(own_clr, stored_via_clr)`` -- see ``seg_clear``.
@@ -576,7 +576,7 @@ class CommittedCopper:
                 req = pw.required(net, vnet)
                 if req > max(own_clr, vclr):
                     if d_vp < self.via_radius + own_half + req - 1e-9 and not pw.exempt_pt_pt(
-                        point, vpt, net, vnet
+                        point, vpt, net, vnet, layer
                     ):
                         return False
         return True
@@ -613,7 +613,7 @@ class CommittedCopper:
                     req = pw.required(net, cnet)
                     if req > max(self.clearance, iclr):
                         if d_cc < self.via_radius + hw + req - 1e-9 and not pw.exempt_seg_pt(
-                            c, d, point, net, cnet
+                            c, d, point, net, cnet, layer
                         ):
                             return False
         for vpt, vnet, vclr in self.vias:

--- a/src/kicad_tools/router/lattice/pairwise.py
+++ b/src/kicad_tools/router/lattice/pairwise.py
@@ -31,8 +31,13 @@ from .geometry import Pt
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from ..pairwise_clearance import AttachZone, PairwiseClearanceTable
 
-# A projected attach zone: sheet-absolute bbox + the net ids it may exempt.
-ZoneIds = tuple[float, float, float, float, frozenset[int]]
+# A projected attach zone: sheet-absolute bbox, the net ids it may exempt, and
+# (issue #4699) the lattice layer indices each of those nets has PAD copper on.
+# The trailing element is optional -- ``None`` (or a 5-tuple, as older callers
+# and hand-built test fixtures produce) means the pre-#4699 layer-agnostic
+# verdict, and a net absent from the map is unrestricted.
+ZoneLayers = Mapping[int, frozenset[int]]
+ZoneIds = tuple[float, float, float, float, frozenset[int], "ZoneLayers | None"]
 
 
 @dataclass(frozen=True)
@@ -56,6 +61,16 @@ class LatticePairwise:
     zones: tuple[ZoneIds, ...]
     max_by_net: Mapping[int, float]
 
+    def __post_init__(self) -> None:
+        # Accept the pre-#4699 5-tuple zone shape (hand-built fixtures, older
+        # callers) by padding it with the layer-agnostic ``None``.
+        if any(len(zone) < 6 for zone in self.zones):
+            object.__setattr__(
+                self,
+                "zones",
+                tuple(zone if len(zone) >= 6 else (*zone, None) for zone in self.zones),
+            )
+
     def required(self, net_a: int, net_b: int) -> float:
         """Raw pairwise requirement for an id pair; 0.0 when unmapped."""
         if net_a == net_b:
@@ -67,28 +82,41 @@ class LatticePairwise:
         """Widest requirement ``net`` participates in; 0.0 when unmapped."""
         return self.max_by_net.get(net, 0.0)
 
-    def exempt(self, x: float, y: float, net_a: int, net_b: int) -> bool:
+    def exempt(self, x: float, y: float, net_a: int, net_b: int, layer: int | None = None) -> bool:
         """True when ``(x, y)`` lies in a zone covering BOTH net ids (#4506).
 
         Mirrors :meth:`AttachZone.exempts` so the search-time verdict and the
-        #4588 post-route gate agree by construction.  Callers probe the
+        #4588 post-route gate agree by construction -- including the #4699
+        layer scoping: a zone waives a pair on ``layer`` only when both nets
+        have pad copper there.  ``layer is None`` keeps the layer-agnostic
+        verdict (via-to-via, where no single layer applies).  Callers probe the
         closest-gap midpoint, exactly as ``segment_pair_violation`` does.
         """
-        for x0, y0, x1, y1, ids in self.zones:
-            if x0 <= x <= x1 and y0 <= y <= y1 and net_a in ids and net_b in ids:
+        for x0, y0, x1, y1, ids, layers in self.zones:
+            if not (x0 <= x <= x1 and y0 <= y <= y1 and net_a in ids and net_b in ids):
+                continue
+            if layer is None or not layers:
+                return True
+            a_layers = layers.get(net_a)
+            b_layers = layers.get(net_b)
+            if (a_layers is None or layer in a_layers) and (b_layers is None or layer in b_layers):
                 return True
         return False
 
     # -- probe-point helpers (closest-gap midpoints, gate-compatible) -------
 
-    def exempt_seg_seg(self, a: Pt, b: Pt, c: Pt, d: Pt, net_a: int, net_b: int) -> bool:
+    def exempt_seg_seg(
+        self, a: Pt, b: Pt, c: Pt, d: Pt, net_a: int, net_b: int, layer: int | None = None
+    ) -> bool:
         """Zone exemption probed at the two segments' closest-gap midpoint."""
         if not self.zones:
             return False
         x, y = closest_gap_midpoint_xy(a[0], a[1], b[0], b[1], c[0], c[1], d[0], d[1])
-        return self.exempt(x, y, net_a, net_b)
+        return self.exempt(x, y, net_a, net_b, layer)
 
-    def exempt_seg_pt(self, a: Pt, b: Pt, p: Pt, net_a: int, net_b: int) -> bool:
+    def exempt_seg_pt(
+        self, a: Pt, b: Pt, p: Pt, net_a: int, net_b: int, layer: int | None = None
+    ) -> bool:
         """Zone exemption probed midway between segment ``a-b`` and point ``p``."""
         if not self.zones:
             return False
@@ -101,19 +129,20 @@ class LatticePairwise:
             t = ((p[0] - ax) * dx + (p[1] - ay) * dy) / length2
             t = max(0.0, min(1.0, t))
             cx, cy = ax + t * dx, ay + t * dy
-        return self.exempt((cx + p[0]) / 2.0, (cy + p[1]) / 2.0, net_a, net_b)
+        return self.exempt((cx + p[0]) / 2.0, (cy + p[1]) / 2.0, net_a, net_b, layer)
 
-    def exempt_pt_pt(self, p: Pt, q: Pt, net_a: int, net_b: int) -> bool:
+    def exempt_pt_pt(self, p: Pt, q: Pt, net_a: int, net_b: int, layer: int | None = None) -> bool:
         """Zone exemption probed at the midpoint of two point sites."""
         if not self.zones:
             return False
-        return self.exempt((p[0] + q[0]) / 2.0, (p[1] + q[1]) / 2.0, net_a, net_b)
+        return self.exempt((p[0] + q[0]) / 2.0, (p[1] + q[1]) / 2.0, net_a, net_b, layer)
 
 
 def build_lattice_pairwise(
     table: PairwiseClearanceTable | None,
     attach_zones: Sequence[AttachZone],
     net_name_to_id: Mapping[str, int],
+    layer_indices: Mapping[str, int] | None = None,
 ) -> LatticePairwise | None:
     """Project a name-keyed pairwise table onto integer net ids (#4602).
 
@@ -126,6 +155,12 @@ def build_lattice_pairwise(
     ``_pairwise_attach_zones`` resolver's output, board-origin shift included
     per PR #4603).
 
+    ``layer_indices`` (issue #4699) maps KiCad copper-layer names to lattice
+    layer indices so each zone's per-net pad layers project into the lattice's
+    integer layer space; the search's exemption then matches the #4588 gate's
+    layer scoping by construction.  ``None`` (or an unresolvable layer) leaves
+    that zone layer-agnostic, i.e. exactly the pre-#4699 verdict.
+
     Returns ``None`` when nothing needs widening on this board (no table, an
     empty matrix, or no pair whose BOTH nets resolve to board net ids) -- the
     dormant signal that keeps every lattice predicate on its scalar path.
@@ -136,7 +171,7 @@ def build_lattice_pairwise(
     if not pairs:
         return None
 
-    from ..pairwise_clearance import _norm_net_key, attach_zones_to_net_ids
+    from ..pairwise_clearance import _norm_net_key
 
     ids_by_key: dict[str, list[int]] = {}
     for name, net_id in net_name_to_id.items():
@@ -160,12 +195,55 @@ def build_lattice_pairwise(
     if not required_by_pair:
         return None
 
-    zones = tuple(
-        (x0, y0, x1, y1, frozenset(ids))
-        for x0, y0, x1, y1, ids in attach_zones_to_net_ids(attach_zones, net_name_to_id)
-    )
+    zones: list[ZoneIds] = []
+    for zone in attach_zones:
+        net_ids = sorted({nid for key in zone.net_names for nid in ids_by_key.get(key, ())})
+        if len(net_ids) < 2:
+            # Cannot exempt any pair (mirrors ``attach_zones_to_net_ids``).
+            continue
+        zones.append(
+            (
+                zone.min_x,
+                zone.min_y,
+                zone.max_x,
+                zone.max_y,
+                frozenset(net_ids),
+                _project_zone_layers(zone, ids_by_key, layer_indices),
+            )
+        )
     return LatticePairwise(
         required_by_pair=required_by_pair,
-        zones=zones,
+        zones=tuple(zones),
         max_by_net=max_by_net,
     )
+
+
+def _project_zone_layers(
+    zone: AttachZone,
+    ids_by_key: Mapping[str, list[int]],
+    layer_indices: Mapping[str, int] | None,
+) -> ZoneLayers | None:
+    """Project a zone's per-net pad layers into lattice layer indices (#4699).
+
+    Returns ``None`` -- the layer-agnostic verdict -- when no layer map was
+    supplied or the zone records no pad layers (older/hand-built zones).  A net
+    whose pads carry the ``*.Cu`` wildcard (through-hole) is omitted from the
+    result, which the exemption reads as "unrestricted", so a through-hole
+    rated part keeps waiving on every layer exactly as before.
+    """
+    from ..pairwise_clearance import ALL_COPPER_LAYERS
+
+    if layer_indices is None or not zone.net_layers:
+        return None
+    projected: dict[int, frozenset[int]] = {}
+    for key, layer_names in zone.net_layers:
+        if ALL_COPPER_LAYERS in layer_names:
+            continue  # through-hole pad copper exists on every layer
+        indices = frozenset(
+            idx for name in layer_names if (idx := layer_indices.get(name)) is not None
+        )
+        if not indices:
+            continue
+        for net_id in ids_by_key.get(key, ()):
+            projected[net_id] = indices
+    return projected or None

--- a/src/kicad_tools/router/pairwise_clearance.py
+++ b/src/kicad_tools/router/pairwise_clearance.py
@@ -60,13 +60,53 @@ _PASS_TOLERANCE = 1e-4
 ATTACH_ZONE_MARGIN_MM = 0.5
 
 
+# KiCad's "this pad exists on every copper layer" wildcard (through-hole pads).
+ALL_COPPER_LAYERS = "*.Cu"
+
+
+def _norm_layer_key(layer: object) -> str:
+    """Normalise a layer reference to its KiCad name.
+
+    Accepts a :class:`~kicad_tools.core.types.CopperLayer` enum member (which
+    carries ``kicad_name``), a raw ``"F.Cu"``-style string, or anything whose
+    ``str()`` is the layer name.
+    """
+    name = getattr(layer, "kicad_name", None)
+    if isinstance(name, str):
+        return name
+    return str(layer)
+
+
 @dataclass(frozen=True)
 class AttachZone:
-    """Layer-agnostic rated-footprint necking region.
+    """Rated-footprint necking region (#4506), pad-scoped and layer-scoped.
 
     ``net_names`` contains every connected net terminating on the footprint.
     Pairwise widening is waived only when the gap point is inside the bbox and
     *both* nets are members; the scalar DRU check has already run separately.
+
+    Issue #4699 narrowed the region twice, because the gate's blanket
+    courtyard-bbox waiver silently disagreed with ``kct creepage``'s much
+    narrower ``--waive-same-footprint`` (component-internal pad pairs only) and
+    turned real trace-to-trace shortfalls into *silent* passes:
+
+    * **Pad-scoped** -- the bbox spans the footprint's CONNECTED PADS (plus
+      :data:`ATTACH_ZONE_MARGIN_MM`), not its courtyard.  The physical licence
+      for sub-creepage copper here is that the rated part's own pin pitch
+      dictates the spacing of the copper attaching to it; that argument covers
+      the pad field, not the body overhang / courtyard keep-out ring, where
+      through-traffic merely happens to pass.
+    * **Layer-scoped** -- ``net_layers`` records, per net, the copper layers on
+      which that net actually has pad copper on this footprint.  A pair is
+      waived on a given layer only when BOTH nets have pad copper there, so
+      copper crossing *under* an SMD part on an inner layer is no longer
+      exempted by an XY bbox it never touches.  Through-hole pads carry the
+      :data:`ALL_COPPER_LAYERS` wildcard and therefore still waive on every
+      layer, as the barrel geometry requires.
+
+    ``net_layers`` is optional: an empty frozenset (hand-built zones, older
+    callers) restores the pre-#4699 layer-agnostic behaviour, and a net absent
+    from it is unrestricted.
     """
 
     min_x: float
@@ -74,16 +114,48 @@ class AttachZone:
     max_x: float
     max_y: float
     net_names: frozenset[str]
+    net_layers: frozenset[tuple[str, frozenset[str]]] = frozenset()
 
-    def exempts(self, x: float, y: float, net_a: str, net_b: str) -> bool:
+    def layers_for(self, net: str) -> frozenset[str]:
+        """Copper layers on which ``net`` has pad copper here (empty = any)."""
+        if not self.net_layers:
+            return frozenset()
+        key = _norm_net_key(net)
+        for name, layers in self.net_layers:
+            if name == key:
+                return layers
+        return frozenset()
+
+    def covers_layer(self, net: str, layer: object) -> bool:
+        """True when ``net``'s pad copper reaches ``layer`` on this footprint."""
+        layers = self.layers_for(net)
+        if not layers or ALL_COPPER_LAYERS in layers:
+            return True
+        return _norm_layer_key(layer) in layers
+
+    def exempts(
+        self,
+        x: float,
+        y: float,
+        net_a: str,
+        net_b: str,
+        layer: object | None = None,
+    ) -> bool:
+        """True when this zone waives the pairwise widening for the pair.
+
+        ``layer`` is the copper layer the two conflicting objects share.
+        ``None`` means "no single layer applies" (e.g. a through-via against a
+        through-via) and keeps the layer-agnostic verdict.
+        """
         a = _norm_net_key(net_a)
         b = _norm_net_key(net_b)
-        return (
-            self.min_x <= x <= self.max_x
-            and self.min_y <= y <= self.max_y
-            and a in self.net_names
-            and b in self.net_names
-        )
+        if not (self.min_x <= x <= self.max_x and self.min_y <= y <= self.max_y):
+            return False
+        if a not in self.net_names or b not in self.net_names:
+            return False
+        if layer is None:
+            return True
+        return self.covers_layer(a, layer) and self.covers_layer(b, layer)
 
 
 def build_attach_zones(
@@ -91,44 +163,46 @@ def build_attach_zones(
     *,
     margin: float = ATTACH_ZONE_MARGIN_MM,
 ) -> tuple[AttachZone, ...]:
-    """Build flat courtyard-bbox attach zones once for a routing session.
+    """Build the flat pad-bbox attach zones once for a routing session.
 
-    The canonical courtyard polygon resolver supplies geometry when possible.
-    Footprints without a resolvable courtyard fall back to the transformed pad
-    bounding box, including pad extents.  Empty/unconnected/single-net
-    footprints cannot exempt a pair and are omitted.
+    The region is the bounding box of the footprint's *connected* pads plus
+    ``margin`` (issue #4699 -- pre-#4699 this preferred the far larger
+    courtyard polygon, which waived HV proximity across the whole body
+    outline).  Each zone also records, per net, the copper layers that net's
+    pads occupy, so the exemption cannot reach a layer the part has no copper
+    on.  Empty/unconnected/single-net footprints cannot exempt a pair and are
+    omitted.
     """
-    from shapely.geometry import Polygon  # type: ignore[import-untyped]
-
-    from kicad_tools.geometry.courtyard import _courtyard_polygon, _fp_transform
+    from kicad_tools.geometry.courtyard import _fp_transform
 
     zones: list[AttachZone] = []
     for footprint in footprints:
-        names = frozenset(_norm_net_key(pad.net_name) for pad in footprint.pads if pad.net_name)
+        connected = [pad for pad in footprint.pads if pad.net_name]
+        names = frozenset(_norm_net_key(pad.net_name) for pad in connected)
         if len(names) < 2:
             continue
 
         bounds: list[tuple[float, float, float, float]] = []
-        for side in ("F", "B"):
-            polygon = _courtyard_polygon(footprint, side, Polygon)
-            if polygon is not None:
-                min_x, min_y, max_x, max_y = polygon.bounds
-                bounds.append((float(min_x), float(min_y), float(max_x), float(max_y)))
-
-        if not bounds:
-            transform = _fp_transform(footprint)
-            for pad in footprint.pads:
-                x, y = transform(pad.position)
-                # Pad rotation is absolute in the board frame (it already
-                # includes the parent footprint rotation).  Project all four
-                # rectangular corners onto board axes so the fallback never
-                # excludes rotated pad copper.
-                angle = math.radians(-getattr(pad, "rotation", 0.0))
-                cos_rot = math.cos(angle)
-                sin_rot = math.sin(angle)
-                half_w = abs(cos_rot) * pad.size[0] / 2.0 + abs(sin_rot) * pad.size[1] / 2.0
-                half_h = abs(sin_rot) * pad.size[0] / 2.0 + abs(cos_rot) * pad.size[1] / 2.0
-                bounds.append((x - half_w, y - half_h, x + half_w, y + half_h))
+        layers_by_net: dict[str, set[str]] = {}
+        transform = _fp_transform(footprint)
+        for pad in connected:
+            x, y = transform(pad.position)
+            # Pad rotation is absolute in the board frame (it already
+            # includes the parent footprint rotation).  Project all four
+            # rectangular corners onto board axes so the bbox never
+            # excludes rotated pad copper.
+            angle = math.radians(-getattr(pad, "rotation", 0.0))
+            cos_rot = math.cos(angle)
+            sin_rot = math.sin(angle)
+            half_w = abs(cos_rot) * pad.size[0] / 2.0 + abs(sin_rot) * pad.size[1] / 2.0
+            half_h = abs(sin_rot) * pad.size[0] / 2.0 + abs(cos_rot) * pad.size[1] / 2.0
+            bounds.append((x - half_w, y - half_h, x + half_w, y + half_h))
+            key = _norm_net_key(pad.net_name)
+            copper = {
+                layer for layer in (getattr(pad, "layers", None) or ()) if layer.endswith(".Cu")
+            }
+            if copper:
+                layers_by_net.setdefault(key, set()).update(copper)
         if not bounds:
             continue
 
@@ -139,6 +213,9 @@ def build_attach_zones(
                 max(b[2] for b in bounds) + margin,
                 max(b[3] for b in bounds) + margin,
                 names,
+                frozenset(
+                    (net, frozenset(layers)) for net, layers in layers_by_net.items() if layers
+                ),
             )
         )
     return tuple(zones)
@@ -150,8 +227,9 @@ def _attach_zone_exempts(
     y: float,
     net_a: str,
     net_b: str,
+    layer: object | None = None,
 ) -> bool:
-    return any(zone.exempts(x, y, net_a, net_b) for zone in zones)
+    return any(zone.exempts(x, y, net_a, net_b, layer) for zone in zones)
 
 
 def _norm_net_key(name: str) -> str:
@@ -536,7 +614,7 @@ def segment_pair_violation(
         return None
     gap_x, gap_y = _closest_gap_midpoint(seg_a, seg_b)
     if gap >= floor - tolerance and _attach_zone_exempts(
-        attach_zones, gap_x, gap_y, a_name, b_name
+        attach_zones, gap_x, gap_y, a_name, b_name, seg_a.layer
     ):
         return None
     return PairwiseViolation(

--- a/tests/router/lattice/test_pairwise_avoidance.py
+++ b/tests/router/lattice/test_pairwise_avoidance.py
@@ -246,6 +246,75 @@ def test_build_lattice_pairwise_projects_names_to_ids() -> None:
     assert not pw.exempt(50.0, 50.0, HV, LV)
 
 
+def test_projected_zone_is_layer_scoped_like_the_gate() -> None:
+    """Issue #4699: search and #4588 gate must agree on the layer scoping.
+
+    An SMD rated footprint's pads exist on ``F.Cu`` only, so the zone waives
+    the pairwise term on lattice layer 0 and nowhere else.  If the search kept
+    the old layer-agnostic waiver it would happily commit inner-layer copper
+    the gate now condemns -- trading a silent pass for an unroutable board.
+    """
+    table = build_pairwise_clearance_table({"/HV_LINE": 300.0, "/LV_SENSE": 0.0}, dru=CLR)
+    zones = (
+        AttachZone(
+            10.0,
+            10.0,
+            20.0,
+            20.0,
+            frozenset({"HV_LINE", "LV_SENSE"}),
+            frozenset(
+                {("HV_LINE", frozenset({"F.Cu"})), ("LV_SENSE", frozenset({"F.Cu"}))},
+            ),
+        ),
+    )
+    pw = build_lattice_pairwise(
+        table,
+        zones,
+        {"/HV_LINE": HV, "/LV_SENSE": LV},
+        {"F.Cu": 0, "In1.Cu": 1, "B.Cu": 2},
+    )
+    assert pw is not None
+    assert pw.exempt(15.0, 15.0, HV, LV, 0)
+    assert not pw.exempt(15.0, 15.0, HV, LV, 1)
+    # No layer supplied (via-to-via) keeps the layer-agnostic verdict.
+    assert pw.exempt(15.0, 15.0, HV, LV)
+
+
+def test_committed_copper_respects_the_layer_scoped_zone() -> None:
+    """The predicate consuming the projection must honour the scoping too."""
+    zone = (5.0, -5.0, 15.0, 5.0, frozenset({HV, LV}), {HV: frozenset({0}), LV: frozenset({0})})
+    committed = _fresh(_projection(zones=(zone,)))
+    committed.add_run(0, [(5.0, 0.0), (15.0, 0.0)], net=HV, half_width=HALF)
+    committed.add_run(1, [(5.0, 0.0), (15.0, 0.0)], net=HV, half_width=HALF)
+
+    # Layer 0 is a pad layer of both nets -> waived, exactly as before #4699.
+    assert committed.seg_clear((5.0, 1.0), (15.0, 1.0), 0, LV, HALF, CLR)
+    # Layer 1 carries no pad copper for this footprint -> no waiver.
+    assert not committed.seg_clear((5.0, 1.0), (15.0, 1.0), 1, LV, HALF, CLR)
+
+
+def test_through_hole_zone_projection_stays_layer_agnostic() -> None:
+    """``*.Cu`` pads really do exist on every layer -- keep waiving there."""
+    table = build_pairwise_clearance_table({"/HV_LINE": 300.0, "/LV_SENSE": 0.0}, dru=CLR)
+    zones = (
+        AttachZone(
+            10.0,
+            10.0,
+            20.0,
+            20.0,
+            frozenset({"HV_LINE", "LV_SENSE"}),
+            frozenset(
+                {("HV_LINE", frozenset({"*.Cu"})), ("LV_SENSE", frozenset({"*.Cu"}))},
+            ),
+        ),
+    )
+    pw = build_lattice_pairwise(
+        table, zones, {"/HV_LINE": HV, "/LV_SENSE": LV}, {"F.Cu": 0, "In1.Cu": 1}
+    )
+    assert pw is not None
+    assert pw.exempt(15.0, 15.0, HV, LV, 1)
+
+
 def test_build_lattice_pairwise_dormant_cases_return_none() -> None:
     table = build_pairwise_clearance_table({"/HV_LINE": 300.0, "/LV_SENSE": 0.0}, dru=CLR)
     # No table at all.

--- a/tests/router/test_pairwise_clearance.py
+++ b/tests/router/test_pairwise_clearance.py
@@ -336,7 +336,17 @@ def test_build_attach_zones_rotates_pad_extents_without_courtyard() -> None:
     )
 
 
-def test_build_attach_zones_uses_courtyard_bbox_and_margin() -> None:
+def test_build_attach_zones_ignores_the_courtyard_and_spans_the_pads() -> None:
+    """Issue #4699: the region is the PAD field, never the courtyard.
+
+    Pre-#4699 a resolvable courtyard polygon won outright, so the exemption
+    covered the part's whole body outline (here 2 x 4 mm + margin) -- copper
+    merely passing under the body was waived along with the copper that
+    genuinely necks down to the rated pins.  ``kct creepage`` waives no such
+    thing, which is how a gate-clean board could still fail the census.  The
+    zone now spans the connected pads (+ margin) only: the same 1.2 x 1.6 mm
+    box the pad-bounds path above produces, courtyard notwithstanding.
+    """
     footprint = SimpleNamespace(
         position=(10.0, 20.0),
         rotation=0.0,
@@ -355,7 +365,7 @@ def test_build_attach_zones_uses_courtyard_bbox_and_margin() -> None:
     )
     (zone,) = build_attach_zones([footprint], margin=0.5)
     assert (zone.min_x, zone.min_y, zone.max_x, zone.max_y) == pytest.approx(
-        (8.5, 17.5, 11.5, 22.5)
+        (8.9, 19.2, 11.1, 20.8)
     )
 
 
@@ -429,6 +439,122 @@ def test_find_pairwise_violations_attach_zone_never_waives_below_dru() -> None:
     ]
     zone = AttachZone(-1.0, -1.0, 6.0, 1.5, frozenset({"AC_LINE", "GND"}))
     assert len(find_pairwise_violations(routes, table, attach_zones=(zone,))) == 1
+
+
+# ---------------------------------------------------------------------------
+# Issue #4699: the attach-zone waiver is layer-scoped
+# ---------------------------------------------------------------------------
+
+
+def _smd_zone() -> AttachZone:
+    """A rated bridging footprint whose pads are SMD copper on ``F.Cu`` only."""
+    return AttachZone(
+        -1.0,
+        -1.0,
+        6.0,
+        1.5,
+        frozenset({"AC_LINE", "GND"}),
+        frozenset(
+            {("AC_LINE", frozenset({"F.Cu"})), ("GND", frozenset({"F.Cu"}))},
+        ),
+    )
+
+
+def _inner_layer_board_routes() -> list[Route]:
+    """The same HV/LV proximity as ``_hv_lv_board_routes``, but on ``In1.Cu``."""
+    return [
+        Route(
+            net=1,
+            net_name="/AC_LINE",
+            segments=[_seg(0, 0, 5, 0, 1, "/AC_LINE", layer=Layer.IN1_CU)],
+        ),
+        Route(
+            net=2,
+            net_name="/GND",
+            segments=[_seg(0, 0.5, 5, 0.5, 2, "/GND", layer=Layer.IN1_CU)],
+        ),
+    ]
+
+
+def test_attach_zone_still_waives_on_a_layer_its_pads_occupy() -> None:
+    """The waiver survives where it is physically justified (pad layer)."""
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    assert find_pairwise_violations(_hv_lv_board_routes(), table, attach_zones=(_smd_zone(),)) == []
+
+
+def test_attach_zone_does_not_waive_copper_passing_underneath() -> None:
+    """Issue #4699: an XY bbox must not exempt a layer the part has no copper on.
+
+    ``AttachZone`` was layer-agnostic, so inner-layer copper merely crossing
+    *beneath* a rated SMD footprint was waived by a courtyard box it never
+    touches -- while ``kct creepage`` (which has no such waiver) condemned the
+    very same pair.  Two of the nine violations in the #4699 report were on
+    ``In1.Cu``.
+    """
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    violations = find_pairwise_violations(
+        _inner_layer_board_routes(), table, attach_zones=(_smd_zone(),)
+    )
+    assert len(violations) == 1, violations
+    assert violations[0].actual_mm == pytest.approx(0.3)
+
+
+def test_through_hole_pads_still_waive_on_every_layer() -> None:
+    """A ``*.Cu`` (through-hole) pad genuinely has copper on all layers."""
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    tht = AttachZone(
+        -1.0,
+        -1.0,
+        6.0,
+        1.5,
+        frozenset({"AC_LINE", "GND"}),
+        frozenset({("AC_LINE", frozenset({"*.Cu"})), ("GND", frozenset({"*.Cu"}))}),
+    )
+    assert find_pairwise_violations(_inner_layer_board_routes(), table, attach_zones=(tht,)) == []
+
+
+def test_zone_without_recorded_layers_keeps_the_agnostic_verdict() -> None:
+    """Hand-built / pre-#4699 zones (no ``net_layers``) are unrestricted."""
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    legacy = AttachZone(-1.0, -1.0, 6.0, 1.5, frozenset({"AC_LINE", "GND"}))
+    assert (
+        find_pairwise_violations(_inner_layer_board_routes(), table, attach_zones=(legacy,)) == []
+    )
+
+
+def test_build_attach_zones_records_per_net_pad_layers() -> None:
+    """The resolver captures each net's pad layers, wildcard included."""
+    footprint = SimpleNamespace(
+        position=(10.0, 20.0),
+        rotation=0.0,
+        graphics=[],
+        pads=[
+            SimpleNamespace(
+                position=(-0.4, 0.0),
+                size=(0.4, 0.6),
+                net_name="/AC_LINE",
+                layers=["F.Cu", "F.Paste", "F.Mask"],
+            ),
+            SimpleNamespace(
+                position=(0.4, 0.0),
+                size=(0.4, 0.6),
+                net_name="/GND",
+                layers=["*.Cu", "*.Mask"],
+            ),
+        ],
+    )
+    (zone,) = build_attach_zones([footprint], margin=0.5)
+    assert dict(zone.net_layers) == {
+        "AC_LINE": frozenset({"F.Cu"}),
+        "GND": frozenset({"*.Cu"}),
+    }
+    assert zone.covers_layer("/AC_LINE", Layer.F_CU)
+    assert not zone.covers_layer("/AC_LINE", Layer.IN1_CU)
+    # The through-hole net reaches every layer.
+    assert zone.covers_layer("/GND", Layer.IN1_CU)
+    # A pair is waived only where BOTH nets have pad copper.
+    assert zone.exempts(10.0, 20.0, "/AC_LINE", "/GND", Layer.F_CU)
+    assert not zone.exempts(10.0, 20.0, "/AC_LINE", "/GND", Layer.IN1_CU)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_route_pairwise_gate_4588.py
+++ b/tests/test_route_pairwise_gate_4588.py
@@ -216,6 +216,54 @@ def _detour_board() -> str:
 """
 
 
+def _preserved_violation_board() -> str:
+    """Board whose *preserved* copper already violates the requirement (#4699).
+
+    ``/HV_LINE`` and ``/LV_SENSE`` carry hand-placed ``(segment ...)`` copper
+    0.6 mm apart (0.4 mm edge-to-edge, well inside the 3.2 mm requirement and
+    well outside the 0.2 mm DRU floor) and have no pads at all, so the router
+    never re-routes them -- with ``--preserve-existing`` that copper is
+    re-emitted verbatim into the output.  ``/SIG_A`` is an ordinary two-pad
+    link in the far corner that gives the run something to route.
+
+    Pre-#4699 the post-route audit scanned ``router.routes`` only, so this
+    board routed to a clean SUCCESS while the file it wrote carried a 0.4 mm
+    gap at 300 V.
+    """
+    parts = [
+        _fp("R1", 10, 103.0, 120.0, _pad("1", 0, 0, 3, "/SIG_A")),
+        _fp("R2", 11, 127.0, 120.0, _pad("1", 0, 0, 3, "/SIG_A")),
+    ]
+    return f"""(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (generator_version "8.0")
+  (general
+    (thickness 1.6)
+  )
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (setup
+    (pad_to_mask_clearance 0)
+  )
+  (net 0 "")
+  (net 1 "/HV_LINE")
+  (net 2 "/LV_SENSE")
+  (net 3 "/SIG_A")
+  (gr_rect (start 100 100) (end 130 124)
+    (stroke (width 0.1) (type default))
+    (fill none)
+    (layer "Edge.Cuts")
+  )
+  (segment (start 105 105) (end 125 105) (width 0.2) (layer "F.Cu") (net 1))
+  (segment (start 105 105.6) (end 125 105.6) (width 0.2) (layer "F.Cu") (net 2))
+{"".join(parts)})
+"""
+
+
 def _strip_uuids(text: str) -> str:
     """Drop the freshly-generated per-element ``uuid`` lines from a board."""
     return re.sub(r'\(uuid "[^"]*"\)', "(uuid)", text)
@@ -597,6 +645,73 @@ class TestAttachZoneExemptionCoordinateSpace:
         assert "broken.kicad_pcb" in err
 
 
+class TestPreservedCopperIsInScope:
+    """Issue #4699: ``--preserve-existing`` copper is on the board, so audit it.
+
+    The #4588 gate scanned ``router.routes``.  Preserved copper is re-emitted
+    from a *separate* list, so a trace-to-trace shortfall involving it could
+    never be reported -- the run printed SUCCESS over a file it had just
+    written unsafe copper into.
+    """
+
+    def test_preserved_violation_fails_the_run_end_to_end(self, tmp_path: Path, capsys) -> None:
+        pcb = tmp_path / "preserved.kicad_pcb"
+        pcb.write_text(_preserved_violation_board())
+        vmap = _write_voltage_map(tmp_path)
+        out = tmp_path / "preserved_routed.kicad_pcb"
+
+        rc = route_main(
+            _route_args(pcb, out, "lattice", vmap) + ["--preserve-existing"],
+        )
+        captured = capsys.readouterr().out
+
+        assert rc != 0, f"expected a non-zero exit, got {rc}\n{captured}"
+        assert "SUCCESS:" not in captured
+        assert "pairwise HV clearance violations" in captured
+        assert "/HV_LINE vs /LV_SENSE" in captured or "/LV_SENSE vs /HV_LINE" in captured
+        # The banner explains the preserved-copper provenance (#4699).
+        assert "preserved" in captured
+
+    def test_same_board_without_voltage_map_is_still_a_strict_noop(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """Dormancy: the audit widening never engages without ``--voltage-map``."""
+        pcb = tmp_path / "preserved_noflag.kicad_pcb"
+        pcb.write_text(_preserved_violation_board())
+        out = tmp_path / "preserved_noflag_routed.kicad_pcb"
+
+        rc = route_main(
+            _route_args(pcb, out, "lattice", None) + ["--preserve-existing"],
+        )
+        captured = capsys.readouterr().out
+
+        assert rc == 0, captured
+        assert "SUCCESS:" in captured
+        assert "pairwise HV clearance violations" not in captured
+
+    def test_run_without_preserve_existing_does_not_audit_dropped_copper(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """Without ``--preserve-existing`` that copper is stripped, not written.
+
+        Auditing it anyway would fail a run over geometry the output does not
+        contain -- the mirror-image false signal of the bug being fixed.
+        """
+        pcb = tmp_path / "stripped.kicad_pcb"
+        pcb.write_text(_preserved_violation_board())
+        vmap = _write_voltage_map(tmp_path)
+        out = tmp_path / "stripped_routed.kicad_pcb"
+
+        rc = route_main(_route_args(pcb, out, "lattice", vmap))
+        captured = capsys.readouterr().out
+
+        assert rc == 0, captured
+        assert "SUCCESS:" in captured
+        assert "pairwise HV clearance violations" not in captured
+        # The violating copper really is absent from the written board.
+        assert "(net 1)" not in out.read_text()
+
+
 class TestAuditHelper:
     """Unit-level coverage of the gate helper's edge cases (no routing)."""
 
@@ -701,6 +816,140 @@ class TestAuditHelper:
             _pairwise_attach_zone_pcb_path=None,
         )
         assert _audit_pairwise_clearance(router, args) == []
+
+    def test_preserved_copper_is_audited_alongside_fresh_copper(self) -> None:
+        """Issue #4699: a fresh-vs-preserved pair must be reportable at all.
+
+        The gate scanned ``router.routes`` only, so under ``--preserve-existing``
+        (implied by ``--complete``) a trace-to-trace shortfall against copper
+        loaded from the input board was *structurally* unreportable -- four of
+        the nine violations in the #4699 report were in that class, and the
+        audit dutifully found zero.
+        """
+        from types import SimpleNamespace
+
+        from kicad_tools.cli.route_cmd import _audit_pairwise_clearance
+        from kicad_tools.router.layers import Layer
+        from kicad_tools.router.pairwise_clearance import build_pairwise_clearance_table
+        from kicad_tools.router.primitives import Route, Segment
+
+        table = build_pairwise_clearance_table({"/HV": HV_VOLTS, "/LV": 0.0}, dru=0.2)
+        fresh = Route(
+            net=1,
+            net_name="/HV",
+            segments=[Segment(0, 0, 5, 0, 0.2, Layer.F_CU, net=1, net_name="/HV")],
+        )
+        preserved = Route(
+            net=2,
+            net_name="/LV",
+            segments=[Segment(0, 0.5, 5, 0.5, 0.2, Layer.F_CU, net=2, net_name="/LV")],
+        )
+        args = SimpleNamespace(_pairwise_required={("HV", "LV"): 3.2})
+        router = SimpleNamespace(
+            rules=SimpleNamespace(pairwise_clearance=table),
+            routes=[fresh],
+            existing_routes=[preserved],
+            _pairwise_attach_zone_pcb_path=None,
+        )
+
+        violations = _audit_pairwise_clearance(router, args)
+
+        assert len(violations) == 1, violations
+        assert {violations[0].net_a, violations[0].net_b} == {"/HV", "/LV"}
+        # Edge-to-edge gap is 0.3 mm (0.5 centre - two 0.1 half-widths).
+        assert violations[0].actual_mm == pytest.approx(0.3)
+
+    def test_preserved_vs_preserved_violations_are_reported_too(self) -> None:
+        """A pre-existing input-board defect still makes the OUTPUT unsafe.
+
+        Documented decision (#4699): the gate's contract is that a SUCCESS
+        banner means the *written* board is clean.  A shortfall between two
+        preserved routes was inherited rather than created by this run, but the
+        board is no safer for it, so it fails the run and the banner says where
+        it came from.
+        """
+        from types import SimpleNamespace
+
+        from kicad_tools.cli.route_cmd import _audit_pairwise_clearance
+        from kicad_tools.router.layers import Layer
+        from kicad_tools.router.pairwise_clearance import build_pairwise_clearance_table
+        from kicad_tools.router.primitives import Route, Segment
+
+        table = build_pairwise_clearance_table({"/HV": HV_VOLTS, "/LV": 0.0}, dru=0.2)
+        preserved = [
+            Route(
+                net=1,
+                net_name="/HV",
+                segments=[Segment(0, 0, 5, 0, 0.2, Layer.F_CU, net=1, net_name="/HV")],
+            ),
+            Route(
+                net=2,
+                net_name="/LV",
+                segments=[Segment(0, 0.5, 5, 0.5, 0.2, Layer.F_CU, net=2, net_name="/LV")],
+            ),
+        ]
+        args = SimpleNamespace(_pairwise_required={("HV", "LV"): 3.2})
+        router = SimpleNamespace(
+            rules=SimpleNamespace(pairwise_clearance=table),
+            routes=[],
+            _emitted_preserved_routes=preserved,
+            _pairwise_attach_zone_pcb_path=None,
+        )
+
+        assert len(_audit_pairwise_clearance(router, args)) == 1
+
+    def test_preserved_copper_that_was_rerouted_is_not_double_audited(self) -> None:
+        """Only the preserved routes the output actually carries are scanned.
+
+        ``_finalize_routes`` drops a preserved route whose net was re-routed
+        (the fresh copper wins).  Auditing the dropped geometry would invent
+        violations against copper that is not on the board.
+        """
+        from types import SimpleNamespace
+
+        from kicad_tools.cli.route_cmd import _audited_trace_copper
+        from kicad_tools.router.layers import Layer
+        from kicad_tools.router.primitives import Route, Segment
+
+        fresh = Route(
+            net=1,
+            net_name="/HV",
+            segments=[Segment(0, 0, 5, 0, 0.2, Layer.F_CU, net=1, net_name="/HV")],
+        )
+        stale = Route(
+            net=1,
+            net_name="/HV",
+            segments=[Segment(0, 9, 5, 9, 0.2, Layer.F_CU, net=1, net_name="/HV")],
+        )
+        router = SimpleNamespace(routes=[fresh], existing_routes=[stale])
+
+        assert _audited_trace_copper(router) == [fresh]
+
+    def test_preserved_routes_are_rekeyed_by_name_not_by_stale_id(self) -> None:
+        """Name-vs-id disagreement must not silently mis-key the audit.
+
+        ``find_pairwise_violations`` prefers ``id_to_name`` over a route's own
+        ``net_name``; a preserved route carrying a stale id would then be
+        audited under a *different* net's voltage -- silently, and in the
+        permissive direction.
+        """
+        from types import SimpleNamespace
+
+        from kicad_tools.cli.route_cmd import _audited_trace_copper
+        from kicad_tools.router.layers import Layer
+        from kicad_tools.router.primitives import Route, Segment
+
+        preserved = Route(
+            net=77,  # stale numbering from a previous board revision
+            net_name="/LV",
+            segments=[Segment(0, 0.5, 5, 0.5, 0.2, Layer.F_CU, net=77, net_name="/LV")],
+        )
+        router = SimpleNamespace(routes=[], existing_routes=[preserved])
+
+        (audited,) = _audited_trace_copper(router, id_to_name={1: "/HV", 2: "/LV"})
+
+        assert audited.net == 2
+        assert audited.net_name == "/LV"
 
     def test_formatter_shape_and_more_tail(self) -> None:
         from kicad_tools.cli.route_cmd import _format_pairwise_violations


### PR DESCRIPTION
## Summary

Two independent blind spots let `kct route --voltage-map` exit SUCCESS over a board carrying same-layer trace-to-trace creepage shortfalls that `kct creepage` condemns (#4699).

1. **Audit scope.** The #4588 post-route gate scanned `router.routes` only. Under `--preserve-existing` (implied by `--complete`) the written board *also* carries copper re-emitted from a separate list, so any shortfall involving preserved copper was **structurally unreportable** — 4 of the reporter's 9 violations were in that class, and the audit found zero.
2. **Exemption semantics.** The #4506 `AttachZone` waived the pairwise widening anywhere inside a rated footprint's **courtyard** bbox, on **any layer**. `kct creepage --waive-same-footprint` waives only component-internal pad pairs, so the two tools silently disagreed on in-scope trace-trace pairs — including the two `In1.Cu` pairs, which a layer-agnostic XY box exempted purely for passing *under* an SMD part.

Note on the issue's Q3: curation's finding is confirmed — the #4602 predicate really is pair-keyed (`pw.required(net, cnet)`), so no change was needed there.

## Changes

- `route_cmd.py`
  - `_audited_trace_copper()` (new): fresh routes **plus** exactly the preserved routes `_finalize_routes` re-emitted. Preserved routes are re-keyed by **name** where the name resolves, so a stale net id cannot silently audit them under another net's voltage.
  - `_finalize_routes()` records that emitted set on the router (`_emitted_preserved_routes`); the fallback (`existing_routes` minus re-routed nets) mirrors the same dedupe rule for callers that never finalize.
  - `_audit_pairwise_clearance()` scans the combined set; the failure banner states the preserved-copper provenance.
- `pairwise_clearance.py` — `AttachZone` narrowed twice: the region is the **connected-pad bbox** (+ margin) rather than the courtyard, and it is **layer-scoped** via a new `net_layers` field (per net, the copper layers its pads occupy). Through-hole `*.Cu` pads keep waiving on every layer. `net_layers` is optional, so hand-built zones keep the old agnostic verdict.
- `lattice/pairwise.py`, `lattice/obstacles.py`, `core.py` — the search consumes the identical scoping: zone projections carry per-net lattice layer indices (via a new `layer_indices` argument fed from the router's layer stack) and every `CommittedCopper` / pad-keepout probe threads its layer through, so search and gate stay agreed by construction. The 5-tuple zone shape is still accepted.

**Documented decision (AC edge case):** a preserved-vs-preserved shortfall was *inherited*, not created by the run — but the board it writes is unsafe either way, so it fails the gate and the banner says where it came from.

**Deliberately not changed:** the C++ `Grid3D` zone halo stays layer-agnostic (more permissive); the authoritative acceptance check on that path is the Python `route_pairwise_violation`, which is layer-scoped. Two mechanisms curation listed as contributors — pairwise-blind `--lattice-optimize` post-passes and `fixed_copper`'s listed-net exclusion (#4355) — are search-side and remain; they are now *caught* by the widened audit, which is the backstop AC.

## Acceptance Criteria Verification

- [x] **Unit test: a routes-vs-`existing_routes` violation is reported** — `TestAuditHelper::test_preserved_copper_is_audited_alongside_fresh_copper` (previously structurally impossible).
- [x] **Silencing mechanism identified + regression-tested; exemption semantics reconciled** — the layer-agnostic courtyard waiver; narrowed to pad-bbox + per-net pad layers, decision documented in `AttachZone`'s docstring. Tests: `test_attach_zone_does_not_waive_copper_passing_underneath` (inner-layer pair under a rated bbox), `test_attach_zone_still_waives_on_a_layer_its_pads_occupy`, `test_through_hole_pads_still_waive_on_every_layer`, `test_build_attach_zones_ignores_the_courtyard_and_spans_the_pads`. Narrowing is strictly one-directional: it can only turn silent passes into loud failures.
- [x] **SUCCESS implies zero non-exempt violations over ALL committed trace copper** — `TestPreservedCopperIsInScope::test_preserved_violation_fails_the_run_end_to_end` (exit non-zero, banner printed, `SUCCESS:` absent), plus the mirror-image guard `test_run_without_preserve_existing_does_not_audit_dropped_copper` (never fail over copper the output does not contain).
- [x] **Behaviour without `--voltage-map` is unchanged** — `test_same_board_without_voltage_map_is_still_a_strict_noop` and the pre-existing dormancy/byte-identical-copper tests still pass.
- [x] **Existing suites pass** — `tests/test_route_pairwise_gate_4588.py` and the whole of `tests/router/`.

## Test Plan

- `tests/test_route_pairwise_gate_4588.py` — 32 passed (7 new: 4 audit-helper unit, 3 end-to-end `--preserve-existing`).
- `tests/router/test_pairwise_clearance.py` — 39 passed (5 new layer-scope tests; 1 existing courtyard test rewritten to pin the new pad-bbox semantics).
- `tests/router/lattice/test_pairwise_avoidance.py` — 14 passed (3 new search/gate agreement tests).
- `tests/router/` (full directory) — **1163 passed, 5 skipped**.
- Preserve/finalize-adjacent suites (`test_router_cleanup`, `test_route_pipeline_connectivity`, `test_cli_route_complete_4471`, `test_cli_route_complete_walled_4478`, `router/test_preserve_existing`, lattice/mesh preserve-obstacle, `test_layer_escalation`, `test_cli_route_net_class_map`, …) — 257 + 175 passed.
- `ruff format` + `ruff check` clean on every changed file; `scripts/ci/check_mypy_baseline.py` — no new type errors (2 baseline errors resolved).
- Not run: the reporter's softstart rev-C repro (local-only fixture, never a CI dependency).

Closes #4699
