### PR TITLE
feat(drc): apply .kct_waivers.json waivers to the kicad-cli DRC cross-gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`kct drc --waivers`: the `.kct_waivers.json` schema now covers the
+  kicad-cli DRC cross-gate** (closes #4691) — the mandatory second-opinion
+  gate can finally state "0 unwaived errors" instead of a count comparison
+  against a known defect signature. `kct drc` reads the **same** schema-v2
+  sidecar as `kct check --waivers` (#4417) — same loader, same discovery
+  probe (`<dir>/`, `<dir>/output/`, `<dir>/../output/`), same exact-set
+  order-insensitive matching, same explicit-wins / discovered-degrades
+  contract — so one committed file carries every documented exception for a
+  board. Two normalizations bridge the engines: `rule` is matched against
+  KiCad's own violation type string verbatim (no translation table, so
+  kct-keyed ids such as `clearance_pad_pad` simply read as unused on this
+  side), and the kicad-cli item *descriptions* (the parser discards item
+  uuids) are normalized to component refs — `"Footprint C52"` → `C52`,
+  `"Pad 6 [<no net>] of U3 on F.Cu"` → `U3` — before matching, with
+  ref-less track/via findings waivable via the `nets` axis. Matched findings
+  render in a dedicated `WAIVED` section with their own count bucket in
+  table/summary output (never folded into warnings — the defect #4696
+  reports against `kct check --format summary`) and are excluded from the
+  exit gate, which is now nonzero iff **unwaived** errors remain;
+  `--format json` keeps the underlying `"severity": "error"` and adds
+  `"status": "waived"` plus `waiver_reason`/`waiver_issue`, so the
+  severity-keyed `kct audit` manufacturing gate stays blocking by default.
+  Waiver entries that match nothing surface as non-gating `UNUSED WAIVERS`
+  advisories (`unused_waivers` in JSON) rather than being injected into the
+  parsed report. `--mfr` compatibility mode does not apply waivers (a
+  design-intent waiver does not change what a fab can build) and says so.
+  With no flag and no sidecar present, output and exit codes are unchanged.
+  Replaces the downstream `drc_waivers.py` re-implementation in
+  project-shamrock/chorus.
 - **`kct check` now detects isolated copper natively: `isolated_copper`**
   (closes #4680, second slice — the dangling pair shipped separately
   below) — a new `IsolatedCopperRule` (`validate/rules/zone_fill.py`,

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -249,11 +249,37 @@ kct drc <report> [options]
 | `--mfr {jlcpcb,oshpark,pcbway,seeed}` | Apply manufacturer rules |
 | `--layers N` | Number of layers (default: 2) |
 | `--compare` | Compare manufacturer rules |
+| `--waivers PATH` | Path to a `.kct_waivers.json` sidecar (schema v2 — the same file `kct check --waivers` reads) waiving cross-gate findings by KiCad rule type + component-ref set (#4691). Auto-discovered next to the input when omitted. Not applied in `--mfr` mode |
+
+**Waivers (`--waivers`, #4691)**
+
+The `kicad-cli pcb drc` cross-gate reads the same schema-v2 sidecar as
+`kct check`, so one file carries every documented exception for a board:
+
+- `rule` matches KiCad's own violation type string verbatim
+  (`courtyards_overlap`, `clearance`, …) — no translation table, so
+  clearance-family entries keyed to kct rule ids (`clearance_pad_pad`) simply
+  read as unused on this side.
+- `items` matches the violation's **component-ref set**, normalized from the
+  kicad-cli item descriptions (`"Footprint C52"` → `C52`,
+  `"Pad 6 [<no net>] of U3 on F.Cu"` → `U3`). Matching is exact-set and
+  order-insensitive: a 2-item entry never waives a 3-item finding. Findings
+  with no refs at all (track/via-only) are waivable via `nets` instead.
+- Matched findings render in a dedicated `WAIVED` section with their own count
+  bucket (never as warnings) and are excluded from the exit gate — exit is
+  nonzero iff **unwaived** errors remain. `--format json` keeps the underlying
+  `"severity": "error"` and adds `"status": "waived"`, so the severity-keyed
+  `kct audit` manufacturing gate stays blocking by default.
+- Entries matching nothing print as non-gating `UNUSED WAIVERS` advisories
+  (and appear under `unused_waivers` in JSON), so stale waivers stay visible.
+- Explicit path wins and a missing/malformed explicit file is a hard error; a
+  malformed auto-discovered sidecar degrades to zero waivers with a warning.
 
 **Examples:**
 ```bash
 kct drc board.drc
 kct drc board.kicad_pcb --mfr jlcpcb
+kct drc board-drc.json --waivers .kct_waivers.json   # 0 unwaived errors gate
 kct drc --compare  # Show all manufacturer rules
 ```
 

--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -268,6 +268,10 @@ def _dispatch_command(args) -> int:
             sub_argv.extend(["--mfr", args.mfr])
         if args.layers != 2:
             sub_argv.extend(["--layers", str(args.layers)])
+        # Issue #4691: forward --waivers to the inner parser (a flag added only
+        # to the outer parser never reaches drc_cmd -- the #3159 drift trap).
+        if getattr(args, "waivers", None):
+            sub_argv.extend(["--waivers", args.waivers])
         return drc_cmd(sub_argv)
 
     elif args.command == "bom":

--- a/src/kicad_tools/cli/drc_cmd.py
+++ b/src/kicad_tools/cli/drc_cmd.py
@@ -21,6 +21,7 @@ import argparse
 import json
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from ..drc import (
     DRCReport,
@@ -31,6 +32,10 @@ from ..drc import (
 )
 from ..manufacturers import compare_design_rules, get_manufacturer_ids, get_profile
 from .runner import find_kicad_cli, run_drc
+
+if TYPE_CHECKING:
+    from ..drc.waivers import WaiverApplication
+    from ..validate.rules.waivers import Waivers
 
 # Default manufacturer for compatibility hints
 DEFAULT_HINT_MANUFACTURER = "jlcpcb"
@@ -122,6 +127,22 @@ def main(argv: list[str] | None = None) -> int:
         help="TOML file with [[drc.filters]] rules to suppress or reclassify violations",
     )
     parser.add_argument(
+        "--waivers",
+        dest="waivers",
+        default=None,
+        help=(
+            "Path to a .kct_waivers.json sidecar (schema version 2, the same "
+            "file kct check --waivers reads) waiving cross-gate DRC findings "
+            "by matching the violation's KiCad type against 'rule' and its "
+            "normalized component-ref set against 'items' (and optional "
+            "'nets'). Matched violations report as WAIVED and are excluded "
+            "from the error gate. Auto-discovered next to the input when this "
+            "flag is omitted (Issue #4691). Waived findings keep severity "
+            "'error' in JSON so the kct audit manufacturing gate stays "
+            "blocking by default; --mfr mode does not apply waivers."
+        ),
+    )
+    parser.add_argument(
         "--keep-report",
         action="store_true",
         help="Keep the DRC report file after running",
@@ -155,6 +176,17 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     input_path = Path(args.input)
+
+    # Load the optional .kct_waivers.json sidecar (Issue #4691) BEFORE running
+    # kicad-cli, so a bad explicit path fails fast.  Same load/degrade contract
+    # as `kct check --waivers`: an explicit --waivers path always wins and a
+    # missing/malformed explicit file is a hard error, while an auto-discovered
+    # sidecar that fails to parse degrades gracefully (warn + zero waivers).
+    # Discovery is anchored at the input path -- the board for .kicad_pcb
+    # input, the report's own directory for .json/.rpt input.
+    waivers, waiver_rc = _load_waivers(args.waivers, input_path)
+    if waiver_rc != 0:
+        return waiver_rc
 
     # Determine if input is PCB or report
     if input_path.suffix == ".kicad_pcb":
@@ -204,9 +236,27 @@ def main(argv: list[str] | None = None) -> int:
             print(f"Error loading filter config: {e}", file=sys.stderr)
             return 1
 
-    # Manufacturer check mode
+    # Manufacturer check mode.  Waivers are deliberately NOT applied here
+    # (Issue #4691, v1 scope): --mfr answers "can this fab build it?", which a
+    # design-intent waiver does not change.  Say so rather than silently
+    # ignoring a supplied sidecar.
     if args.mfr:
+        if waivers is not None and waivers.entries:
+            print(
+                "[INFO] --mfr manufacturer compatibility check does not apply "
+                "waivers; run without --mfr for the waived DRC gate.",
+                file=sys.stderr,
+            )
         return output_manufacturer_check(report, args.mfr, args.layers, args.verbose)
+
+    # Apply waivers to the parsed report (Issue #4691).  Runs before the
+    # --errors-only / --type / --net / --category filters and before the exit
+    # gate, so a waived finding is excluded from the errors list everywhere.
+    waiver_result = None
+    if waivers is not None and waivers.entries:
+        from ..drc.waivers import apply_waivers_to_report
+
+        waiver_result = apply_waivers_to_report(report, waivers)
 
     # Apply filters
     violations = list(report.violations)
@@ -239,10 +289,19 @@ def main(argv: list[str] | None = None) -> int:
     # Output
     if args.format == "json":
         output_json(
-            violations, report, show_suggestions=args.suggest, filtered_count=filter_ignored_count
+            violations,
+            report,
+            show_suggestions=args.suggest,
+            filtered_count=filter_ignored_count,
+            waiver_result=waiver_result,
         )
     elif args.format == "summary":
-        output_summary(violations, report, filtered_count=filter_ignored_count)
+        output_summary(
+            violations,
+            report,
+            filtered_count=filter_ignored_count,
+            waiver_result=waiver_result,
+        )
     else:
         output_table(
             violations,
@@ -251,17 +310,77 @@ def main(argv: list[str] | None = None) -> int:
             show_suggestions=args.suggest,
             layers=args.layers,
             filtered_count=filter_ignored_count,
+            waiver_result=waiver_result,
         )
 
-    # Exit code
+    # Exit code.  ``is_error`` already excludes waived findings (Issue #4691),
+    # so the gate is "nonzero iff UNWAIVED errors remain".  Waived findings are
+    # likewise kept out of the warning count so --strict never trips on them.
     error_count = sum(1 for v in violations if v.is_error)
-    warning_count = len(violations) - error_count
+    waived_count = sum(1 for v in violations if v.is_waived)
+    warning_count = len(violations) - error_count - waived_count
 
     if error_count > 0:
         return 1
     elif warning_count > 0 and args.strict:
         return 2
     return 0
+
+
+def _load_waivers(explicit: str | None, input_path: Path) -> tuple["Waivers | None", int]:
+    """Resolve the ``.kct_waivers.json`` sidecar for this run (Issue #4691).
+
+    Mirrors ``kct check --waivers`` exactly: an explicit path always wins and a
+    missing or malformed explicit file is a hard error; an auto-discovered
+    sidecar that fails to parse degrades to zero waivers with a warning.
+
+    Args:
+        explicit: The ``--waivers`` value, or None to auto-discover.
+        input_path: The PCB or report path used as the discovery anchor.
+
+    Returns:
+        ``(waivers, exit_code)``; a nonzero exit code means the caller must
+        return it immediately.
+    """
+    from ..validate.rules.waivers import discover_waivers_sidecar, load_waivers
+
+    if explicit is not None:
+        path: Path | None = Path(explicit).resolve()
+    else:
+        path = discover_waivers_sidecar(input_path)
+
+    if path is None:
+        return None, 0
+
+    if not path.exists():
+        print(f"Error: waivers file not found: {path}", file=sys.stderr)
+        return None, 1
+
+    try:
+        waivers = load_waivers(path)
+    except ValueError as e:
+        if explicit is not None:
+            print(f"Error: {e}", file=sys.stderr)
+            return None, 1
+        print(
+            f"WARNING: ignoring malformed waivers sidecar {path}: {e}",
+            file=sys.stderr,
+        )
+        return None, 0
+
+    if explicit is None:
+        print(f"[INFO] auto-loaded waivers sidecar: {path}", file=sys.stderr)
+    return waivers, 0
+
+
+def _print_unused_waivers(waiver_result: "WaiverApplication | None") -> None:
+    """Print the non-gating stale-waiver advisory block, if any."""
+    if waiver_result is None or not waiver_result.unused:
+        return
+    print(f"\n{'-' * 60}")
+    print("UNUSED WAIVERS (advisory, non-blocking):")
+    for message in waiver_result.unused_messages:
+        print(f"\n  [i] {message}")
 
 
 def run_drc_on_pcb(
@@ -311,10 +430,14 @@ def output_table(
     show_suggestions: bool = False,
     layers: int = 2,
     filtered_count: int = 0,
+    waiver_result: "WaiverApplication | None" = None,
 ) -> None:
     """Output violations as a formatted table."""
     error_count = sum(1 for v in violations if v.is_error)
-    warning_count = len(violations) - error_count
+    # Issue #4691/#4696: waived findings get their own bucket -- they are never
+    # folded into the warning count.
+    waived_count = sum(1 for v in violations if v.is_waived)
+    warning_count = len(violations) - error_count - waived_count
 
     print(f"\n{'=' * 60}")
     print("DRC VALIDATION SUMMARY")
@@ -328,62 +451,46 @@ def output_table(
     print("\nResults:")
     print(f"  Errors:     {error_count}")
     print(f"  Warnings:   {warning_count}")
+    if waived_count > 0:
+        print(f"  Waived:     {waived_count}")
     if filtered_count > 0:
         print(f"  Filtered:   {filtered_count} violations filtered")
 
     if not violations:
         print(f"\n{'=' * 60}")
         print("DRC PASSED - No violations found")
+        _print_unused_waivers(waiver_result)
         return
 
     # Group by type summary
     by_type: dict = {}
     for v in violations:
         if v.type_str not in by_type:
-            by_type[v.type_str] = {"errors": 0, "warnings": 0}
-        if v.is_error:
-            by_type[v.type_str]["errors"] += 1
-        else:
-            by_type[v.type_str]["warnings"] += 1
+            by_type[v.type_str] = {"errors": 0, "warnings": 0, "waived": 0}
+        by_type[v.type_str][_bucket(v)] += 1
 
     print(f"\n{'-' * 60}")
     print("BY TYPE:")
-    for vtype, counts in sorted(
-        by_type.items(), key=lambda x: -(x[1]["errors"] + x[1]["warnings"])
-    ):
-        parts = []
-        if counts["errors"]:
-            parts.append(f"{counts['errors']} error{'s' if counts['errors'] != 1 else ''}")
-        if counts["warnings"]:
-            parts.append(f"{counts['warnings']} warning{'s' if counts['warnings'] != 1 else ''}")
-        print(f"  {vtype}: {', '.join(parts)}")
+    for vtype, counts in sorted(by_type.items(), key=lambda x: -sum(x[1].values())):
+        print(f"  {vtype}: {_format_counts(counts)}")
 
     # Group by category summary
     by_category: dict = {}
     for v in violations:
         cat = v.category.value
         if cat not in by_category:
-            by_category[cat] = {"errors": 0, "warnings": 0}
-        if v.is_error:
-            by_category[cat]["errors"] += 1
-        else:
-            by_category[cat]["warnings"] += 1
+            by_category[cat] = {"errors": 0, "warnings": 0, "waived": 0}
+        by_category[cat][_bucket(v)] += 1
 
     print(f"\n{'-' * 60}")
     print("BY CATEGORY:")
-    for cat, counts in sorted(
-        by_category.items(), key=lambda x: -(x[1]["errors"] + x[1]["warnings"])
-    ):
-        parts = []
-        if counts["errors"]:
-            parts.append(f"{counts['errors']} error{'s' if counts['errors'] != 1 else ''}")
-        if counts["warnings"]:
-            parts.append(f"{counts['warnings']} warning{'s' if counts['warnings'] != 1 else ''}")
-        print(f"  {cat}: {', '.join(parts)}")
+    for cat, counts in sorted(by_category.items(), key=lambda x: -sum(x[1].values())):
+        print(f"  {cat}: {_format_counts(counts)}")
 
     # Detailed output
     errors = [v for v in violations if v.is_error]
-    warnings = [v for v in violations if not v.is_error]
+    warnings = [v for v in violations if not v.is_error and not v.is_waived]
+    waived = [v for v in violations if v.is_waived]
 
     if errors:
         print(f"\n{'-' * 60}")
@@ -400,6 +507,19 @@ def output_table(
         if len(warnings) > 10 and not verbose:
             print(f"\n  ... and {len(warnings) - 10} more warnings (use --verbose)")
 
+    # Issue #4691: waived findings stay visible in their own section so a
+    # reviewer can audit each documented exception, but never gate.
+    if waived:
+        print(f"\n{'-' * 60}")
+        print("WAIVED (documented exceptions, non-blocking):")
+        for v in waived:
+            _print_single(v, verbose, show_suggestions)
+            print(f"      Waiver reason: {v.waiver_reason}")
+            if v.waiver_issue:
+                print(f"      Waiver issue: {v.waiver_issue}")
+
+    _print_unused_waivers(waiver_result)
+
     print(f"\n{'=' * 60}")
     if errors:
         print("DRC FAILED - Fix errors before manufacturing")
@@ -407,8 +527,29 @@ def output_table(
         hint = _get_manufacturer_compatibility_hint(violations, layers=layers)
         if hint:
             print(hint)
-    else:
+    elif warnings:
         print("DRC WARNING - Review warnings")
+    else:
+        print("DRC PASSED - No unwaived violations")
+
+
+def _bucket(v: DRCViolation) -> str:
+    """Return the count bucket a violation belongs to (waived is its own)."""
+    if v.is_waived:
+        return "waived"
+    return "errors" if v.is_error else "warnings"
+
+
+def _format_counts(counts: dict) -> str:
+    """Render a {errors, warnings, waived} bucket dict, omitting empty buckets."""
+    parts = []
+    if counts.get("errors"):
+        parts.append(f"{counts['errors']} error{'s' if counts['errors'] != 1 else ''}")
+    if counts.get("warnings"):
+        parts.append(f"{counts['warnings']} warning{'s' if counts['warnings'] != 1 else ''}")
+    if counts.get("waived"):
+        parts.append(f"{counts['waived']} waived")
+    return ", ".join(parts)
 
 
 def _print_single(
@@ -418,7 +559,7 @@ def _print_single(
     indent: str = "  ",
 ) -> None:
     """Print a single violation."""
-    symbol = "X" if v.is_error else "!"
+    symbol = "~" if v.is_waived else ("X" if v.is_error else "!")
     print(f"\n{indent}[{symbol}] {v.type_str}")
     print(f"{indent}    {v.message}")
 
@@ -456,6 +597,7 @@ def output_json(
     report: DRCReport,
     show_suggestions: bool = False,
     filtered_count: int = 0,
+    waiver_result: "WaiverApplication | None" = None,
 ) -> None:
     """Output violations as JSON."""
     violations_data = []
@@ -466,10 +608,16 @@ def output_json(
             del v_dict["suggestions"]
         violations_data.append(v_dict)
 
+    # Issue #4691/#4696: waived findings are counted in their own bucket and
+    # never as warnings.  Each waived violation keeps its underlying
+    # "severity" and reports "status": "waived" (see DRCViolation.to_dict).
+    waived_count = sum(1 for v in violations if v.is_waived)
     summary: dict = {
         "errors": sum(1 for v in violations if v.is_error),
-        "warnings": sum(1 for v in violations if not v.is_error),
+        "warnings": sum(1 for v in violations if not v.is_error and not v.is_waived),
     }
+    if waived_count > 0:
+        summary["waived"] = waived_count
     if filtered_count > 0:
         summary["filtered"] = filtered_count
 
@@ -479,11 +627,16 @@ def output_json(
         "summary": summary,
         "violations": violations_data,
     }
+    if waiver_result is not None and waiver_result.unused:
+        data["unused_waivers"] = waiver_result.to_dict_list()
     print(json.dumps(data, indent=2))
 
 
 def output_summary(
-    violations: list[DRCViolation], report: DRCReport, filtered_count: int = 0
+    violations: list[DRCViolation],
+    report: DRCReport,
+    filtered_count: int = 0,
+    waiver_result: "WaiverApplication | None" = None,
 ) -> None:
     """Output violation summary by type."""
     if not violations:
@@ -491,32 +644,39 @@ def output_summary(
             print(f"No DRC violations found ({filtered_count} violations filtered).")
         else:
             print("No DRC violations found.")
+        _print_unused_waivers(waiver_result)
         return
 
     print(f"DRC Summary: {report.source_file}")
     print("=" * 50)
 
-    # Group by type
+    # Group by type.  Issue #4691/#4696: waived findings get a dedicated
+    # column -- folding them into "Warnings" is exactly the defect #4696
+    # reports against ``kct check --format summary``.
     by_type: dict = {}
     for v in violations:
         key = v.type_str
         if key not in by_type:
-            by_type[key] = {"errors": 0, "warnings": 0}
-        if v.is_error:
-            by_type[key]["errors"] += 1
-        else:
-            by_type[key]["warnings"] += 1
+            by_type[key] = {"errors": 0, "warnings": 0, "waived": 0}
+        by_type[key][_bucket(v)] += 1
 
-    print(f"{'Type':<25} {'Errors':<8} {'Warnings':<8}")
+    any_waived = any(c["waived"] for c in by_type.values())
+    waived_header = f" {'Waived':<8}" if any_waived else ""
+    print(f"{'Type':<25} {'Errors':<8} {'Warnings':<8}{waived_header}")
     print("-" * 50)
 
     for type_name, counts in sorted(by_type.items()):
-        print(f"{type_name:<25} {counts['errors']:<8} {counts['warnings']:<8}")
+        waived_col = f" {counts['waived']:<8}" if any_waived else ""
+        print(f"{type_name:<25} {counts['errors']:<8} {counts['warnings']:<8}{waived_col}")
 
     print("-" * 50)
     total_errors = sum(c["errors"] for c in by_type.values())
     total_warnings = sum(c["warnings"] for c in by_type.values())
-    print(f"{'TOTAL':<25} {total_errors:<8} {total_warnings:<8}")
+    total_waived = sum(c["waived"] for c in by_type.values())
+    waived_total_col = f" {total_waived:<8}" if any_waived else ""
+    print(f"{'TOTAL':<25} {total_errors:<8} {total_warnings:<8}{waived_total_col}")
+
+    _print_unused_waivers(waiver_result)
 
 
 def output_manufacturer_check(

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -402,6 +402,17 @@ def _add_drc_parser(subparsers) -> None:
         help="Check against manufacturer design rules",
     )
     drc_parser.add_argument("--layers", type=int, default=2, help="Number of copper layers")
+    drc_parser.add_argument(
+        "--waivers",
+        dest="waivers",
+        default=None,
+        help=(
+            "Path to a .kct_waivers.json sidecar (schema v2) waiving DRC "
+            "findings by rule + component-ref set; matched findings report as "
+            "WAIVED and are excluded from the error gate. Auto-discovered next "
+            "to the input when omitted (Issue #4691)"
+        ),
+    )
 
 
 def _add_bom_parser(subparsers) -> None:

--- a/src/kicad_tools/drc/violation.py
+++ b/src/kicad_tools/drc/violation.py
@@ -545,6 +545,17 @@ class DRCViolation:
     # Fix suggestions (populated by generate_fix_suggestions)
     suggestions: list["FixSuggestion"] = field(default_factory=list)
 
+    # Waiver state (Issue #4691).  Populated by
+    # :func:`kicad_tools.drc.waivers.apply_waivers_to_report` when a
+    # ``.kct_waivers.json`` (schema v2) entry matches this finding.  Waived
+    # findings stay visible and keep their underlying ``severity`` (so the
+    # severity-keyed ``kct audit`` manufacturing gate stays blocking) but are
+    # excluded from :attr:`is_error` and therefore from the ``kct drc``
+    # exit gate.
+    waived: bool = False
+    waiver_reason: str | None = None
+    waiver_issue: str | None = None
+
     @property
     def category(self) -> ViolationCategory:
         """Infer root-cause category from violation type and context.
@@ -617,8 +628,18 @@ class DRCViolation:
 
     @property
     def is_error(self) -> bool:
-        """Check if this is an error (vs warning)."""
-        return self.severity == Severity.ERROR
+        """Check if this is a blocking error (vs warning, or a waived finding).
+
+        A waived finding (Issue #4691) keeps ``severity == Severity.ERROR`` but
+        is no longer blocking, so it is excluded here -- this is the single
+        place the ``kct drc`` exit gate reads.
+        """
+        return self.severity == Severity.ERROR and not self.waived
+
+    @property
+    def is_waived(self) -> bool:
+        """Check if a ``.kct_waivers.json`` entry matched this finding."""
+        return self.waived
 
     @property
     def is_clearance(self) -> bool:
@@ -687,6 +708,15 @@ class DRCViolation:
             "actual_value_mm": self.actual_value_mm,
             "delta_mm": self.delta_mm,
         }
+        if self.waived:
+            # Issue #4691 (mirrors the #4403 contract in validate/violations.py):
+            # ``status`` distinguishes a waived finding at a glance while
+            # ``severity`` above keeps the underlying (usually "error") value,
+            # so severity-keyed consumers such as ``kct audit`` stay blocking.
+            result["status"] = "waived"
+            result["waived"] = True
+            result["waiver_reason"] = self.waiver_reason
+            result["waiver_issue"] = self.waiver_issue
         if self.source_position:
             result["source_position"] = self.source_position.to_dict()
         if self.suggestions:
@@ -710,6 +740,14 @@ class DRCViolation:
 # Matches patterns like "Pad 1 of U3", "Pad A1 of U3", "of C12", etc.
 _REF_PATTERN = re.compile(r"\bof\s+([A-Z]+\d+)\b", re.IGNORECASE)
 
+# KiCad describes a *whole footprint* item as "Footprint C52" (the shape
+# courtyard-overlap findings use), which ``_REF_PATTERN`` above -- anchored on
+# "... of <REF>" -- never matches.  Waiver matching (Issue #4691) needs both
+# shapes, so it uses :func:`extract_item_refs` below rather than
+# ``_extract_component_refs``, whose narrower behaviour existing consumers
+# (category inference, same-component pad clearance) depend on.
+_FOOTPRINT_REF_PATTERN = re.compile(r"\bFootprint\s+([A-Z]+\d+)\b", re.IGNORECASE)
+
 
 def _extract_component_refs(items: list[str]) -> set[str]:
     """Extract unique component reference designators from DRC item strings.
@@ -721,6 +759,36 @@ def _extract_component_refs(items: list[str]) -> set[str]:
     for item in items:
         for match in _REF_PATTERN.finditer(item):
             refs.add(match.group(1).upper())
+    return refs
+
+
+def extract_item_refs(items: list[str]) -> set[str]:
+    """Normalize kicad-cli DRC item descriptions to a set of component refs.
+
+    The kicad-cli JSON report stores each involved item as a free-text
+    description rather than a structured reference (the item ``uuid`` is not
+    retained by the parser), so waiver matching normalizes those strings to
+    reference designators first (Issue #4691).  Both shapes KiCad emits are
+    covered::
+
+        "Footprint C52"                     -> {"C52"}
+        "Pad 6 [<no net>] of U3 on F.Cu"    -> {"U3"}
+
+    Items carrying no reference at all (e.g. ``"Track [GND] on F.Cu"``,
+    ``"Via [VBUS] on F.Cu"``) contribute nothing -- such findings are waivable
+    via the ``nets`` axis instead.
+
+    Args:
+        items: Item description strings from a :class:`DRCViolation`.
+
+    Returns:
+        The set of unique, upper-cased reference designators found.
+    """
+    refs: set[str] = set()
+    for item in items:
+        for pattern in (_REF_PATTERN, _FOOTPRINT_REF_PATTERN):
+            for match in pattern.finditer(item):
+                refs.add(match.group(1).upper())
     return refs
 
 

--- a/src/kicad_tools/drc/waivers.py
+++ b/src/kicad_tools/drc/waivers.py
@@ -1,0 +1,141 @@
+"""Apply ``.kct_waivers.json`` waivers to a kicad-cli DRC report (Issue #4691).
+
+``kct check --waivers`` (Issue #4417) waives findings from kct's *own* rule
+engine.  This module carries the **same** schema-v2 sidecar -- same loader,
+same discovery probe, same exact-set matching semantics -- over to the
+``kicad-cli pcb drc`` cross-gate consumed by ``kct drc``, so both engines speak
+one waiver vocabulary and a board with a documented, intentional violation can
+still produce a "0 unwaived errors" verdict on the cross-gate side.
+
+Two normalizations bridge the two engines:
+
+* **Rule key.**  ``waiver.rule`` is matched against KiCad's own violation type
+  string (``DRCViolation.type_str``) verbatim -- no translation table.  For
+  ``courtyards_overlap`` the two engines coincide by design; clearance-family
+  ids diverge (KiCad ``clearance`` vs kct ``clearance_pad_pad``), which is
+  fine: one shared sidecar simply carries entries keyed per engine.  An entry
+  keyed to the *other* engine's rule id necessarily reads "unused" on this
+  side, which is why unused entries are advisory (never gating).
+
+* **Item set.**  The kicad-cli JSON parser keeps each involved item's free-text
+  *description* (``"Footprint C52"``, ``"Pad 6 [<no net>] of U3 on F.Cu"``) and
+  discards its ``uuid``, so descriptions are normalized to reference
+  designators via :func:`kicad_tools.drc.violation.extract_item_refs` before
+  matching.  A waiver therefore names refs (``["C52", "U10"]``) exactly as it
+  does for ``kct check``.
+
+Unlike the ``kct check`` path, unused-waiver advisories are **not** injected
+into ``DRCReport.violations``: that list is the parsed cross-gate report and
+synthetic entries would distort its by-type/by-category tables and its
+``--format json`` shape.  They are returned in :class:`WaiverApplication`
+instead and rendered by ``kct drc`` in a dedicated advisory block.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from kicad_tools.validate.rules.waivers import Waiver, Waivers
+
+from .report import DRCReport
+from .violation import DRCViolation, extract_item_refs
+
+
+@dataclass
+class WaiverApplication:
+    """Outcome of applying waivers to a DRC report.
+
+    Attributes:
+        waived: The violations that a waiver entry matched (already marked
+            ``waived=True`` in place on the report).
+        unused: Waiver entries that matched no violation -- stale entries, or
+            entries keyed to the other engine's rule ids.  Advisory only.
+    """
+
+    waived: list[DRCViolation] = field(default_factory=list)
+    unused: list[Waiver] = field(default_factory=list)
+
+    @property
+    def waived_count(self) -> int:
+        """Number of findings matched by a waiver entry."""
+        return len(self.waived)
+
+    @property
+    def unused_messages(self) -> list[str]:
+        """Human-readable advisory lines for each unused waiver entry."""
+        return [_unused_message(entry) for entry in self.unused]
+
+    def to_dict_list(self) -> list[dict]:
+        """JSON-serializable view of the unused entries (for ``--format json``)."""
+        return [
+            {
+                "rule": entry.rule,
+                "items": sorted(entry.items),
+                "nets": sorted(entry.nets),
+                "reason": entry.reason,
+                "issue": entry.issue,
+                "message": _unused_message(entry),
+            }
+            for entry in self.unused
+        ]
+
+
+def _scope_str(entry: Waiver) -> str:
+    parts = []
+    if entry.items:
+        parts.append(f"items={sorted(entry.items)}")
+    if entry.nets:
+        parts.append(f"nets={sorted(entry.nets)}")
+    return ", ".join(parts)
+
+
+def _unused_message(entry: Waiver) -> str:
+    return (
+        f"Waiver for rule {entry.rule!r} ({_scope_str(entry)}) matched no violation "
+        f"(tracking {entry.issue}); the underlying defect may already be resolved, "
+        "the refs may have changed, or the entry may be keyed to another engine's "
+        "rule id."
+    )
+
+
+def apply_waivers_to_report(report: DRCReport, waivers: Waivers) -> WaiverApplication:
+    """Mark every waiver-matched violation in ``report`` as waived, in place.
+
+    Matching is exact-set and order-insensitive on the *normalized* ref set
+    (a 2-item waiver does not waive a 3-item finding) and, when the entry names
+    ``nets``, on the violation's net set.  The first matching entry wins.
+
+    Waived violations keep their underlying ``severity`` (so severity-keyed
+    consumers such as the ``kct audit`` manufacturing gate stay blocking) but
+    report ``is_error is False``, which is what the ``kct drc`` exit gate reads.
+
+    Args:
+        report: Parsed DRC report; its violations are mutated in place.
+        waivers: Loaded schema-v2 waiver entries.
+
+    Returns:
+        A :class:`WaiverApplication` describing what was waived and which
+        entries went unused.
+    """
+    result = WaiverApplication()
+    if not waivers.entries:
+        return result
+
+    used: set[int] = set()
+    for violation in report.violations:
+        if violation.waived:
+            continue
+        refs = extract_item_refs(violation.items)
+        nets = frozenset(violation.nets)
+        for idx, entry in enumerate(waivers.entries):
+            if not entry.matches_normalized(violation.type_str, refs, nets):
+                continue
+            violation.waived = True
+            violation.waiver_reason = entry.reason
+            violation.waiver_issue = entry.issue
+            used.add(idx)
+            result.waived.append(violation)
+            break
+
+    result.unused = [entry for idx, entry in enumerate(waivers.entries) if idx not in used]
+    return result

--- a/src/kicad_tools/validate/rules/waivers.py
+++ b/src/kicad_tools/validate/rules/waivers.py
@@ -101,21 +101,44 @@ class Waiver:
     reason: str
     issue: str
 
-    def matches(self, violation: DRCViolation) -> bool:
-        """Return True when this waiver applies to ``violation``.
+    def matches_normalized(
+        self,
+        rule: str,
+        items: frozenset[str] | set[str],
+        nets: frozenset[str] | set[str],
+    ) -> bool:
+        """Engine-agnostic match core: rule id + normalized item / net sets.
+
+        This is the single definition of the waiver matching semantics.  Both
+        engines call it with their own already-normalized inputs so there is
+        exactly one waiver vocabulary (Issue #4691):
+
+        * ``kct check`` passes the finding's ``rule_id`` and its ``items`` /
+          ``nets`` tuples verbatim (see :meth:`matches`).
+        * ``kct drc`` passes KiCad's own ``type_str`` plus the refs extracted
+          from the kicad-cli item *descriptions* (see
+          :func:`kicad_tools.drc.waivers.apply_waivers_to_report`).
 
         Exact-set, order-insensitive match on ``items`` and (optionally)
         ``nets``.  An empty ``items`` / ``nets`` on the waiver means "do not
         constrain on that axis"; at least one axis is always populated (the
         loader enforces it).
         """
-        if violation.rule_id != self.rule:
+        if rule != self.rule:
             return False
-        if self.items and frozenset(violation.items) != self.items:
+        if self.items and frozenset(items) != self.items:
             return False
-        if self.nets and frozenset(violation.nets) != self.nets:
+        if self.nets and frozenset(nets) != self.nets:
             return False
         return True
+
+    def matches(self, violation: DRCViolation) -> bool:
+        """Return True when this waiver applies to a ``kct check`` finding."""
+        return self.matches_normalized(
+            violation.rule_id,
+            frozenset(violation.items),
+            frozenset(violation.nets),
+        )
 
 
 @dataclass

--- a/tests/test_cli_drc_waivers.py
+++ b/tests/test_cli_drc_waivers.py
@@ -1,0 +1,444 @@
+"""End-to-end CLI tests for ``kct drc --waivers`` (Issue #4691).
+
+Applies the schema-v2 ``.kct_waivers.json`` sidecar -- the same file, loader and
+matching semantics ``kct check --waivers`` uses (Issue #4417) -- to the
+``kicad-cli pcb drc`` cross-gate.  Everything here runs off *recorded* report
+fixtures written to ``tmp_path``; no live ``kicad-cli`` invocation is needed.
+"""
+
+from __future__ import annotations
+
+import json
+
+from kicad_tools.cli import drc_cmd
+from kicad_tools.drc.report import DRCReport
+from kicad_tools.drc.violation import extract_item_refs
+
+# A recorded ``kicad-cli pcb drc --format json`` report: one courtyard-overlap
+# error between two whole footprints ("Footprint C52"-style items) and one
+# clearance error between a pad and a track ("... of U3"-style items).
+RECORDED_REPORT: dict = {
+    "$schema": "https://schemas.kicad.org/drc.v1.json",
+    "source": "board.kicad_pcb",
+    "date": "2026-08-07T12:00:00+00:00",
+    "kicad_version": "10.0.5",
+    "coordinate_units": "mm",
+    "violations": [
+        {
+            "type": "courtyards_overlap",
+            "severity": "error",
+            "description": "Courtyards overlap",
+            "items": [
+                {
+                    "description": "Footprint C52",
+                    "uuid": "8cdb0060-0000-0000-0000-000000000001",
+                    "pos": {"x": 132.05, "y": 89.95},
+                },
+                {
+                    "description": "Footprint U10",
+                    "uuid": "d163e30f-0000-0000-0000-000000000002",
+                    "pos": {"x": 131.0, "y": 92.0},
+                },
+            ],
+        },
+        {
+            "type": "clearance",
+            "severity": "error",
+            "description": (
+                "Clearance violation (netclass 'Default' clearance 0.2000 mm; actual 0.1000 mm)"
+            ),
+            "items": [
+                {
+                    "description": "Pad 6 [VBUS] of U3 on F.Cu",
+                    "uuid": "aaaaaaaa-0000-0000-0000-000000000003",
+                    "pos": {"x": 100.0, "y": 100.0},
+                },
+                {
+                    "description": "Track [GND] on F.Cu",
+                    "uuid": "bbbbbbbb-0000-0000-0000-000000000004",
+                    "pos": {"x": 100.5, "y": 100.5},
+                },
+            ],
+        },
+    ],
+    "unconnected_items": [],
+    "schematic_parity": [],
+}
+
+COURTYARD_WAIVER = {
+    "rule": "courtyards_overlap",
+    "items": ["C52", "U10"],
+    "reason": "EE-mandated tight decoupling, <=2mm from U10 VCC",
+    "issue": "chorus#18",
+}
+
+CLEARANCE_WAIVER = {
+    "rule": "clearance",
+    "items": ["U3"],
+    "reason": "documented star-ground tie",
+    "issue": "chorus#20",
+}
+
+
+def _report(tmp_path, name="board-drc.json", data=None):
+    path = tmp_path / name
+    path.write_text(json.dumps(data if data is not None else RECORDED_REPORT))
+    return path
+
+
+def _waivers(path, entries):
+    path.write_text(json.dumps({"version": 2, "waivers": entries}))
+    return path
+
+
+class TestItemNormalization:
+    """The kicad-cli parser keeps descriptions, not uuids -- normalize them."""
+
+    def test_footprint_style_description(self):
+        assert extract_item_refs(["Footprint C52", "Footprint U10"]) == {"C52", "U10"}
+
+    def test_pad_of_style_description(self):
+        assert extract_item_refs(["Pad 6 [<no net>] of U3 on F.Cu"]) == {"U3"}
+
+    def test_mixed_and_refless_items(self):
+        refs = extract_item_refs(
+            ["Footprint C52", "Pad 6 [VBUS] of U3 on F.Cu", "Track [GND] on F.Cu"]
+        )
+        assert refs == {"C52", "U3"}
+
+    def test_refless_items_only(self):
+        # Track/via-only findings carry no refs -- waivable via `nets` instead.
+        assert extract_item_refs(["Track [GND] on F.Cu", "Via [VBUS] on F.Cu - B.Cu"]) == set()
+
+
+class TestExitGate:
+    def test_all_errors_waived_exits_zero(self, tmp_path, capsys):
+        report = _report(tmp_path)
+        waiver = _waivers(tmp_path / "w.json", [COURTYARD_WAIVER, CLEARANCE_WAIVER])
+        rc = drc_cmd.main([str(report), "--waivers", str(waiver)])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "Errors:     0" in out
+        assert "Waived:     2" in out
+        assert "WAIVED (documented exceptions, non-blocking):" in out
+        assert "DRC PASSED - No unwaived violations" in out
+
+    def test_unwaived_error_still_exits_nonzero(self, tmp_path, capsys):
+        report = _report(tmp_path)
+        waiver = _waivers(tmp_path / "w.json", [COURTYARD_WAIVER])
+        rc = drc_cmd.main([str(report), "--waivers", str(waiver)])
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "Errors:     1" in out
+        assert "Waived:     1" in out
+        assert "DRC FAILED" in out
+
+    def test_waived_never_counted_as_warning(self, tmp_path, capsys):
+        """Issue #4696: a waived error must not inflate the warning bucket."""
+        report = _report(tmp_path)
+        waiver = _waivers(tmp_path / "w.json", [COURTYARD_WAIVER, CLEARANCE_WAIVER])
+        # --strict exits 2 on warnings; waived findings must not trip it.
+        rc = drc_cmd.main([str(report), "--waivers", str(waiver), "--strict"])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "Warnings:   0" in out
+
+    def test_no_flag_no_sidecar_unchanged(self, tmp_path, capsys):
+        report = _report(tmp_path)
+        rc = drc_cmd.main([str(report)])
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "Errors:     2" in out
+        assert "Waived:" not in out
+        assert "WAIVED" not in out
+
+
+class TestMatchingSemantics:
+    def test_exact_set_not_subset(self, tmp_path, capsys):
+        """A 1-item waiver does NOT waive a 2-item finding."""
+        report = _report(tmp_path)
+        waiver = _waivers(
+            tmp_path / "w.json",
+            [{**COURTYARD_WAIVER, "items": ["C52"]}],
+        )
+        rc = drc_cmd.main([str(report), "--waivers", str(waiver)])
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "Errors:     2" in out
+        assert "Waived:" not in out
+
+    def test_order_insensitive(self, tmp_path, capsys):
+        report = _report(tmp_path)
+        waiver = _waivers(tmp_path / "w.json", [{**COURTYARD_WAIVER, "items": ["U10", "C52"]}])
+        rc = drc_cmd.main([str(report), "--waivers", str(waiver), "--format", "json"])
+        data = json.loads(capsys.readouterr().out)
+        assert rc == 1  # the clearance error is still unwaived
+        assert data["summary"]["waived"] == 1
+
+    def test_nets_only_waiver(self, tmp_path, capsys):
+        report = _report(tmp_path)
+        waiver = _waivers(
+            tmp_path / "w.json",
+            [
+                {
+                    "rule": "clearance",
+                    "nets": ["VBUS", "GND"],
+                    "reason": "documented star-ground tie",
+                    "issue": "chorus#20",
+                }
+            ],
+        )
+        rc = drc_cmd.main([str(report), "--waivers", str(waiver), "--format", "json"])
+        data = json.loads(capsys.readouterr().out)
+        assert rc == 1  # courtyard overlap remains
+        assert data["summary"]["waived"] == 1
+        waived = [v for v in data["violations"] if v.get("waived")]
+        assert waived[0]["type_str"] == "clearance"
+
+    def test_wrong_rule_id_does_not_match(self, tmp_path, capsys):
+        report = _report(tmp_path)
+        # kct's own rule id for the same family -- keyed to the other engine.
+        waiver = _waivers(
+            tmp_path / "w.json",
+            [{**CLEARANCE_WAIVER, "rule": "clearance_pad_pad"}],
+        )
+        rc = drc_cmd.main([str(report), "--waivers", str(waiver)])
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "Waived:" not in out
+
+
+class TestJsonOutput:
+    def test_status_waived_keeps_severity(self, tmp_path, capsys):
+        report = _report(tmp_path)
+        waiver = _waivers(tmp_path / "w.json", [COURTYARD_WAIVER, CLEARANCE_WAIVER])
+        rc = drc_cmd.main([str(report), "--waivers", str(waiver), "--format", "json"])
+        data = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert data["summary"] == {"errors": 0, "warnings": 0, "waived": 2}
+        for v in data["violations"]:
+            assert v["waived"] is True
+            assert v["status"] == "waived"
+            # Manufacturing-gate safety: the underlying severity is preserved
+            # so the severity-keyed kct audit gate stays blocking.
+            assert v["severity"] == "error"
+        courtyard = next(v for v in data["violations"] if v["type_str"] == "courtyards_overlap")
+        assert courtyard["waiver_reason"] == COURTYARD_WAIVER["reason"]
+        assert courtyard["waiver_issue"] == "chorus#18"
+
+    def test_json_unchanged_without_waivers(self, tmp_path, capsys):
+        report = _report(tmp_path)
+        drc_cmd.main([str(report), "--format", "json"])
+        data = json.loads(capsys.readouterr().out)
+        assert data["summary"] == {"errors": 2, "warnings": 0}
+        for v in data["violations"]:
+            assert "status" not in v
+            assert "waived" not in v
+
+
+class TestUnusedWaivers:
+    def test_unused_entry_is_visible_and_non_gating(self, tmp_path, capsys):
+        report = _report(tmp_path)
+        waiver = _waivers(
+            tmp_path / "w.json",
+            [
+                COURTYARD_WAIVER,
+                CLEARANCE_WAIVER,
+                {
+                    "rule": "courtyards_overlap",
+                    "items": ["X9", "Y9"],
+                    "reason": "stale entry",
+                    "issue": "chorus#99",
+                },
+            ],
+        )
+        rc = drc_cmd.main([str(report), "--waivers", str(waiver)])
+        out = capsys.readouterr().out
+        assert rc == 0  # advisory only -- never gates
+        assert "UNUSED WAIVERS (advisory, non-blocking):" in out
+        assert "chorus#99" in out
+
+    def test_kct_only_rule_id_reads_unused(self, tmp_path, capsys):
+        """An entry keyed to kct's rule vocabulary is advisory, not an error."""
+        report = _report(tmp_path)
+        waiver = _waivers(
+            tmp_path / "w.json",
+            [
+                COURTYARD_WAIVER,
+                CLEARANCE_WAIVER,
+                {
+                    "rule": "clearance_pad_pad",
+                    "items": ["U3", "C52"],
+                    "reason": "kct-engine entry in the shared sidecar",
+                    "issue": "chorus#21",
+                },
+            ],
+        )
+        rc = drc_cmd.main([str(report), "--waivers", str(waiver), "--format", "json"])
+        data = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        unused = data["unused_waivers"]
+        assert len(unused) == 1
+        assert unused[0]["rule"] == "clearance_pad_pad"
+        assert unused[0]["issue"] == "chorus#21"
+
+    def test_no_unused_key_when_all_used(self, tmp_path, capsys):
+        report = _report(tmp_path)
+        waiver = _waivers(tmp_path / "w.json", [COURTYARD_WAIVER, CLEARANCE_WAIVER])
+        drc_cmd.main([str(report), "--waivers", str(waiver), "--format", "json"])
+        data = json.loads(capsys.readouterr().out)
+        assert "unused_waivers" not in data
+
+
+class TestSidecarContract:
+    def test_explicit_missing_path_hard_error(self, tmp_path, capsys):
+        report = _report(tmp_path)
+        rc = drc_cmd.main([str(report), "--waivers", str(tmp_path / "nope.json")])
+        assert rc == 1
+        assert "waivers file not found" in capsys.readouterr().err
+
+    def test_explicit_malformed_hard_error(self, tmp_path, capsys):
+        report = _report(tmp_path)
+        bad = tmp_path / "bad.json"
+        bad.write_text("{not json")
+        rc = drc_cmd.main([str(report), "--waivers", str(bad)])
+        assert rc == 1
+        assert "Error:" in capsys.readouterr().err
+
+    def test_explicit_wrong_version_hard_error(self, tmp_path, capsys):
+        report = _report(tmp_path)
+        bad = tmp_path / "v1.json"
+        bad.write_text(json.dumps({"version": 1, "waivers": []}))
+        rc = drc_cmd.main([str(report), "--waivers", str(bad)])
+        assert rc == 1
+        assert "unsupported waivers version" in capsys.readouterr().err
+
+    def test_auto_discovered_sidecar_applies(self, tmp_path, capsys):
+        report = _report(tmp_path)
+        _waivers(tmp_path / ".kct_waivers.json", [COURTYARD_WAIVER, CLEARANCE_WAIVER])
+        rc = drc_cmd.main([str(report)])
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert "auto-loaded waivers sidecar" in captured.err
+        assert "Waived:     2" in captured.out
+
+    def test_auto_discovered_output_subdir(self, tmp_path, capsys):
+        (tmp_path / "output").mkdir()
+        report = _report(tmp_path)
+        _waivers(tmp_path / "output" / ".kct_waivers.json", [COURTYARD_WAIVER, CLEARANCE_WAIVER])
+        rc = drc_cmd.main([str(report)])
+        assert rc == 0
+        assert "Waived:     2" in capsys.readouterr().out
+
+    def test_auto_discovered_malformed_degrades(self, tmp_path, capsys):
+        report = _report(tmp_path)
+        (tmp_path / ".kct_waivers.json").write_text("{not json")
+        rc = drc_cmd.main([str(report)])
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "ignoring malformed waivers sidecar" in captured.err
+        assert "Errors:     2" in captured.out
+
+
+class TestFilterInteractions:
+    def test_errors_only_excludes_waived(self, tmp_path, capsys):
+        report = _report(tmp_path)
+        waiver = _waivers(tmp_path / "w.json", [COURTYARD_WAIVER])
+        rc = drc_cmd.main([str(report), "--waivers", str(waiver), "--errors-only"])
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "courtyards_overlap" not in out
+        assert "clearance" in out
+
+    def test_summary_format_has_waived_column(self, tmp_path, capsys):
+        report = _report(tmp_path)
+        waiver = _waivers(tmp_path / "w.json", [COURTYARD_WAIVER, CLEARANCE_WAIVER])
+        rc = drc_cmd.main([str(report), "--waivers", str(waiver), "--format", "summary"])
+        out = capsys.readouterr().out
+        assert rc == 0
+        header = next(line for line in out.splitlines() if line.startswith("Type"))
+        assert "Waived" in header
+        total = next(line for line in out.splitlines() if line.startswith("TOTAL"))
+        assert total.split() == ["TOTAL", "0", "0", "2"]
+
+    def test_summary_format_unchanged_without_waivers(self, tmp_path, capsys):
+        report = _report(tmp_path)
+        rc = drc_cmd.main([str(report), "--format", "summary"])
+        out = capsys.readouterr().out
+        assert rc == 1
+        header = next(line for line in out.splitlines() if line.startswith("Type"))
+        assert "Waived" not in header
+
+    def test_mfr_mode_does_not_apply_waivers(self, tmp_path, capsys):
+        report = _report(tmp_path)
+        waiver = _waivers(tmp_path / "w.json", [COURTYARD_WAIVER, CLEARANCE_WAIVER])
+        drc_cmd.main([str(report), "--waivers", str(waiver), "--mfr", "jlcpcb"])
+        assert "does not apply waivers" in capsys.readouterr().err
+
+
+class TestTextReportInput:
+    """The .rpt text-report path shares the same normalization."""
+
+    RPT = """** Drc report for board.kicad_pcb **
+** Created on 2026-08-07T12:00:00+0000 **
+
+** Found 1 DRC violations **
+[courtyards_overlap]: Courtyards overlap
+    Rule: courtyard_overlap; error
+    @(132.0500 mm, 89.9500 mm): Footprint C52
+    @(131.0000 mm, 92.0000 mm): Footprint U10
+
+** Found 0 Footprint errors **
+** End of Report **
+"""
+
+    def test_rpt_input_waived(self, tmp_path, capsys):
+        rpt = tmp_path / "board-drc.rpt"
+        rpt.write_text(self.RPT)
+        waiver = _waivers(tmp_path / "w.json", [COURTYARD_WAIVER])
+        rc = drc_cmd.main([str(rpt), "--waivers", str(waiver)])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "Waived:     1" in out
+
+
+class TestOuterParserParity:
+    """Issue #3159 drift trap: the flag must reach the inner parser."""
+
+    def test_kct_drc_waivers_reaches_inner_command(self, tmp_path, capsys):
+        from kicad_tools.cli import main as cli_main
+
+        report = _report(tmp_path)
+        waiver = _waivers(tmp_path / "w.json", [COURTYARD_WAIVER, CLEARANCE_WAIVER])
+        rc = cli_main(["drc", str(report), "--waivers", str(waiver)])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "Waived:     2" in out
+
+    def test_outer_parser_exposes_waivers(self):
+        from kicad_tools.cli.parser import create_parser
+
+        args = create_parser().parse_args(["drc", "report.json", "--waivers", "w.json"])
+        assert args.waivers == "w.json"
+
+
+class TestReportModelUnaffected:
+    def test_severity_keyed_consumers_still_see_error(self, tmp_path):
+        """A waived finding keeps severity=error for the audit gate."""
+        from kicad_tools.drc.waivers import apply_waivers_to_report
+        from kicad_tools.validate.rules.waivers import waivers_from_dict
+
+        report_path = _report(tmp_path)
+        report = DRCReport.load(report_path)
+        waivers = waivers_from_dict({"version": 2, "waivers": [COURTYARD_WAIVER]})
+        result = apply_waivers_to_report(report, waivers)
+
+        assert result.waived_count == 1
+        waived = result.waived[0]
+        assert waived.severity.value == "error"
+        assert waived.is_error is False
+        assert waived.is_waived is True
+        # Re-applying is idempotent (already-waived findings are skipped).
+        again = apply_waivers_to_report(report, waivers)
+        assert again.waived_count == 0
+        assert len(again.unused) == 1


### PR DESCRIPTION
## Summary

`kct drc` gains `--waivers`, applying the **same** schema-v2 `.kct_waivers.json`
sidecar `kct check --waivers` reads (#4417) to the `kicad-cli pcb drc`
cross-gate. One committed file now carries every documented exception for a
board, so the mandatory second-opinion gate can state **"0 unwaived errors"**
instead of a count comparison against a known defect signature (the gate shape
chorus#65's postmortem identified as a root cause of a bad sign-off).

Same loader, same discovery probe, same exact-set order-insensitive matching,
same explicit-wins / discovered-degrades contract — no second waiver
vocabulary and no schema fork. The matching semantics now live in exactly one
place, `Waiver.matches_normalized(rule, items, nets)`, which both engines call
with their own normalized inputs.

**Two normalizations bridge the engines** (this is the curator's verified
correction — the kicad-cli JSON is *not* the same shape `kct check` matches on):

- **Rule key**: `waiver.rule` matches KiCad's own `type_str` verbatim, no
  translation table. kct-keyed ids (`clearance_pad_pad`) therefore read as
  *unused* on this side, which is why unused entries are advisory only.
- **Item set**: `_parse_kicad_cli_json` discards each item's `uuid` and keeps
  the free-text description, so descriptions normalize to component refs
  before matching — `"Footprint C52"` → `C52`,
  `"Pad 6 [<no net>] of U3 on F.Cu"` → `U3`. Ref-less track/via findings carry
  no refs at all and stay waivable via the `nets` axis.

## Changes

- `src/kicad_tools/drc/violation.py` — `waived` / `waiver_reason` /
  `waiver_issue` fields on `DRCViolation`; `is_error` excludes waived (the one
  place the exit gate reads); `is_waived`; `to_dict` adds `status: "waived"` +
  reason/issue **only when waived** (default JSON shape unchanged); new
  `extract_item_refs()` covering both `"Footprint C52"` and `"… of U3"` shapes.
  `_extract_component_refs` is left untouched so category inference and
  same-component pad-clearance detection keep their narrower behaviour.
- `src/kicad_tools/drc/waivers.py` (new) — `apply_waivers_to_report()` +
  `WaiverApplication`. Unlike the `kct check` path, unused advisories are
  **not** injected into `DRCReport.violations` (that list is the parsed
  cross-gate report; synthetic entries would distort its by-type tables and
  `--format json` shape) — they are returned and rendered separately.
- `src/kicad_tools/validate/rules/waivers.py` — matcher generalized to
  `matches_normalized()`; `matches()` delegates. Loader/schema/discovery
  untouched.
- `src/kicad_tools/cli/drc_cmd.py` — `--waivers` flag; sidecar load **before**
  running kicad-cli (bad explicit path fails fast); apply step before the
  `--errors-only`/`--type`/`--net`/`--category` filters and the exit gate;
  dedicated `WAIVED` section + `Waived:` count bucket + waived column in
  `--format summary`; `UNUSED WAIVERS` advisory block; `unused_waivers` in
  JSON; waived-aware exit gate (also excluded from the `--strict` warning
  count). `--mfr` mode does not apply waivers (a design-intent waiver does not
  change what a fab can build) and prints an INFO line saying so.
- `src/kicad_tools/cli/parser.py` + `src/kicad_tools/cli/__init__.py` — flag on
  the outer parser and forwarded into `drc_cmd.main()` (#3159 drift trap).
- `docs/reference/cli.md`, `CHANGELOG.md` — documented.
- `tests/test_cli_drc_waivers.py` (new, 31 tests) — recorded kicad-cli JSON
  fixture; no live `kicad-cli` invocation.

## Acceptance Criteria Verification

- [x] **`--waivers` applies to both input shapes; matched findings render
  WAIVED and are excluded from the error gate.** Report input covered by
  `TestExitGate` (exit 0 when all errors waived, exit 1 when one is unwaived);
  the `.kicad_pcb` path shares the identical post-parse code path (waivers are
  applied to the parsed `DRCReport`, whether it came from `run_drc_on_pcb` or
  `DRCReport.load`). `.rpt` text input covered by `TestTextReportInput`.
- [x] **Auto-discovery with the same explicit/discovered contract.**
  `TestSidecarContract`: discovery next to the input and in `output/`,
  explicit-missing → 1, explicit-malformed → 1, explicit-wrong-version → 1,
  discovered-malformed → warn + zero waivers (exit still 1).
- [x] **Exact-set, order-insensitive, shared loader.** `TestMatchingSemantics`:
  a 1-item entry does not waive the 2-item finding; reversed order matches;
  nets-only entry matches; wrong-engine rule id does not.
- [x] **`"Footprint C52"` → `C52`, `"Pad 6 … of U3 …"` → `U3`.**
  `TestItemNormalization`, plus both fixtures (courtyard + clearance) exercise
  them end-to-end.
- [x] **Unused entries are visible and non-gating, incl. kct-only rule ids.**
  `TestUnusedWaivers` (exit stays 0 with a stale entry present).
- [x] **JSON keeps `severity`, adds `status: "waived"` + reason/issue;
  table/summary use a dedicated bucket, never warnings.** `TestJsonOutput`,
  `test_waived_never_counted_as_warning` (`--strict` still exits 0),
  `test_summary_format_has_waived_column`.
- [x] **Flag on outer + inner parser and forwarded.** `TestOuterParserParity`
  drives `kct drc … --waivers` through `cli.main`.
- [x] **No default-behavior change.** `test_no_flag_no_sidecar_unchanged`,
  `test_json_unchanged_without_waivers`,
  `test_summary_format_unchanged_without_waivers`.

## Test Plan

- `uv run pytest tests/test_cli_drc_waivers.py -q --no-cov` → **31 passed**
- `tests/test_cli_check_waivers.py tests/test_validate_waivers.py
  tests/test_cli_parser_drift.py` + the new file → **90 passed**
- Broad non-router selection (`-k "drc or waiver or audit or filter or
  violation"`) → **2502 passed, 20 skipped**
- `tests/router/test_board02_manufacturable_baseline.py` → **3 passed**
  (this module failed once inside a large mixed `-k` selection; verified it
  passes both on a clean baseline via `worktree.sh stash-push` **and** with
  this diff applied — an ordering artifact of that selection, not the diff)
- `uv run ruff check .` → All checks passed; `ruff format --check` → clean
- `uv run python scripts/ci/check_mypy_baseline.py` → OK, 1473 within the 1475
  baseline (no new type errors; baseline left untouched)

Not run: manual live-board verification against `kicad-cli pcb drc` (the
chorus scenario) — that fixture is not available in CI, and the recorded
report fixture is byte-shaped from a real kicad-cli 10.0.5 report.

Closes #4691