### PR TITLE
fix(route): floor trace widths at the fab's own min_trace_width_mm

### DIFF
--- a/src/kicad_tools/cli/check_cmd.py
+++ b/src/kicad_tools/cli/check_cmd.py
@@ -38,6 +38,7 @@ from kicad_tools.analysis.routing_quality import (
     evaluate_routing_quality_thresholds,
     routing_quality_gate_dict,
 )
+from kicad_tools.cli.copper_weight import parse_copper_weight_arg
 from kicad_tools.manufacturers import get_manufacturer_ids, get_profile
 from kicad_tools.schema.pcb import PCB
 from kicad_tools.sidecars import net_class_map_sidecar_candidates
@@ -254,75 +255,12 @@ def _find_pcb_file(directory: Path) -> Path | None:
     return None
 
 
-def _parse_copper_weight_arg(raw: str) -> tuple[float | None, float | None]:
-    """Parse a ``--copper`` value into ``(outer_oz, inner_oz)`` (Issue #4326).
-
-    Accepts two forms:
-
-    - **Scalar** -- ``"2"`` / ``"1.0"`` -- applies to both the outer and
-      inner layer classes, returning ``(oz, oz)``.
-    - **Keyed** -- ``"outer=2,inner=0.5"`` -- sets each layer class
-      independently.  A key omitted from the keyed form returns ``None`` for
-      that class, meaning "fall back to the stackup / profile for that layer
-      class" (so ``--copper outer=2`` overrides only the outer weight).
-
-    Raises:
-        ValueError: on empty input, unknown keys, duplicate keys, a
-            non-numeric value, or a non-positive weight -- mirroring the
-            ``--only`` / ``--skip`` category-validation contract (a clear
-            ``Error:`` + exit 1 at the call site).
-    """
-    text = raw.strip()
-    if not text:
-        raise ValueError("--copper value is empty")
-
-    if "=" not in text:
-        # Scalar form: one number for both layer classes.
-        try:
-            oz = float(text)
-        except ValueError:
-            raise ValueError(
-                f"invalid --copper value {raw!r} "
-                "(expected a number like '2' or a keyed form 'outer=2,inner=0.5')"
-            ) from None
-        if oz <= 0:
-            raise ValueError(f"--copper weight must be positive: {oz}")
-        return (oz, oz)
-
-    # Keyed form: comma-separated key=value tokens.
-    outer: float | None = None
-    inner: float | None = None
-    seen: set[str] = set()
-    for token in text.split(","):
-        token = token.strip()
-        if not token:
-            continue
-        if "=" not in token:
-            raise ValueError(f"invalid --copper token {token!r} (expected 'key=value')")
-        key, _, value = token.partition("=")
-        key = key.strip().lower()
-        value = value.strip()
-        if key not in ("outer", "inner"):
-            raise ValueError(f"unknown --copper key {key!r} (expected 'outer' or 'inner')")
-        if key in seen:
-            raise ValueError(f"duplicate --copper key {key!r}")
-        seen.add(key)
-        try:
-            oz = float(value)
-        except ValueError:
-            raise ValueError(
-                f"invalid --copper {key} value {value!r} (expected a number)"
-            ) from None
-        if oz <= 0:
-            raise ValueError(f"--copper {key} weight must be positive: {oz}")
-        if key == "outer":
-            outer = oz
-        else:
-            inner = oz
-
-    if outer is None and inner is None:
-        raise ValueError(f"--copper keyed form set no values: {raw!r}")
-    return (outer, inner)
+# Issue #4700: the ``--copper`` grammar is now shared with ``kct route`` so
+# both commands resolve the identical ``<layers>layer_<oz>oz`` manufacturer
+# design-rule key.  The implementation moved verbatim to
+# ``kicad_tools.cli.copper_weight``; this alias keeps the historical private
+# name (and its importers) working unchanged.
+_parse_copper_weight_arg = parse_copper_weight_arg
 
 
 def _net_class_map_sidecar_candidates(pcb_path: Path) -> list[Path]:

--- a/src/kicad_tools/cli/commands/routing.py
+++ b/src/kicad_tools/cli/commands/routing.py
@@ -433,7 +433,12 @@ def run_route_command(args) -> int:
     # tests/test_cli_parser_drift.py.
     if getattr(args, "max_cells", 500_000) != 500_000:
         sub_argv.extend(["--max-cells", str(args.max_cells)])
-    if args.trace_width != 0.2:
+    # Issue #4700: --trace-width now carries a ``None`` sentinel (unset) so the
+    # inner command can raise the default to the manufacturer's own minimum
+    # trace width.  Forward it only when the user actually passed a value --
+    # forwarding the sentinel would both crash the float parse and defeat the
+    # auto-fill.  Flag-off argv stays byte-identical.
+    if getattr(args, "trace_width", None) is not None:
         sub_argv.extend(["--trace-width", str(args.trace_width)])
     if args.clearance != 0.15:
         sub_argv.extend(["--clearance", str(args.clearance)])
@@ -584,6 +589,11 @@ def run_route_command(args) -> int:
         sub_argv.extend(["--min-clearance-floor", str(args.min_clearance_floor)])
     if getattr(args, "manufacturer", "jlcpcb") != "jlcpcb":
         sub_argv.extend(["--manufacturer", args.manufacturer])
+    # Issue #4700: the copper weight selects the manufacturer design-rule row
+    # (``<layers>layer_<oz>oz``) the trace-width floor is resolved from, so it
+    # must reach the inner command verbatim.
+    if getattr(args, "copper", None) is not None:
+        sub_argv.extend(["--copper", str(args.copper)])
     if getattr(args, "high_performance", False):
         sub_argv.append("--high-performance")
     if getattr(args, "skip_drc", False):

--- a/src/kicad_tools/cli/copper_weight.py
+++ b/src/kicad_tools/cli/copper_weight.py
@@ -1,0 +1,86 @@
+"""Shared ``--copper`` (copper weight) argument parsing for CLI commands.
+
+Extracted from :mod:`kicad_tools.cli.check_cmd` (Issue #4700) so ``kct
+route`` and ``kct check`` parse the identical grammar and therefore resolve
+the identical manufacturer design-rule key (``<layers>layer_<oz>oz``).  Any
+divergence there is what let ``kct route --manufacturer jlcpcb`` emit copper
+that the matching ``kct check --mfr jlcpcb --copper 2`` rejected.
+
+Behavior is unchanged from the original ``check_cmd._parse_copper_weight_arg``
+(Issue #4326); that name remains as an alias in ``check_cmd``.
+"""
+
+from __future__ import annotations
+
+__all__ = ["parse_copper_weight_arg"]
+
+
+def parse_copper_weight_arg(raw: str) -> tuple[float | None, float | None]:
+    """Parse a ``--copper`` value into ``(outer_oz, inner_oz)`` (Issue #4326).
+
+    Accepts two forms:
+
+    - **Scalar** -- ``"2"`` / ``"1.0"`` -- applies to both the outer and
+      inner layer classes, returning ``(oz, oz)``.
+    - **Keyed** -- ``"outer=2,inner=0.5"`` -- sets each layer class
+      independently.  A key omitted from the keyed form returns ``None`` for
+      that class, meaning "fall back to the stackup / profile for that layer
+      class" (so ``--copper outer=2`` overrides only the outer weight).
+
+    Raises:
+        ValueError: on empty input, unknown keys, duplicate keys, a
+            non-numeric value, or a non-positive weight -- mirroring the
+            ``--only`` / ``--skip`` category-validation contract (a clear
+            ``Error:`` + exit 1 at the call site).
+    """
+    text = raw.strip()
+    if not text:
+        raise ValueError("--copper value is empty")
+
+    if "=" not in text:
+        # Scalar form: one number for both layer classes.
+        try:
+            oz = float(text)
+        except ValueError:
+            raise ValueError(
+                f"invalid --copper value {raw!r} "
+                "(expected a number like '2' or a keyed form 'outer=2,inner=0.5')"
+            ) from None
+        if oz <= 0:
+            raise ValueError(f"--copper weight must be positive: {oz}")
+        return (oz, oz)
+
+    # Keyed form: comma-separated key=value tokens.
+    outer: float | None = None
+    inner: float | None = None
+    seen: set[str] = set()
+    for token in text.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        if "=" not in token:
+            raise ValueError(f"invalid --copper token {token!r} (expected 'key=value')")
+        key, _, value = token.partition("=")
+        key = key.strip().lower()
+        value = value.strip()
+        if key not in ("outer", "inner"):
+            raise ValueError(f"unknown --copper key {key!r} (expected 'outer' or 'inner')")
+        if key in seen:
+            raise ValueError(f"duplicate --copper key {key!r}")
+        seen.add(key)
+        try:
+            oz = float(value)
+        except ValueError:
+            raise ValueError(
+                f"invalid --copper {key} value {value!r} (expected a number)"
+            ) from None
+        if oz <= 0:
+            raise ValueError(f"--copper {key} weight must be positive: {oz}")
+        if key == "outer":
+            outer = oz
+        else:
+            inner = oz
+
+    if outer is None and inner is None:
+        raise ValueError(f"--copper keyed form set no values: {raw!r}")
+    return (outer, inner)

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -3481,7 +3481,20 @@ def _add_route_parser(subparsers) -> None:
             "effect when --grid is an explicit value."
         ),
     )
-    route_parser.add_argument("--trace-width", type=float, default=0.2, help="Trace width in mm")
+    route_parser.add_argument(
+        "--trace-width",
+        type=float,
+        default=None,
+        help=(
+            "Trace width in mm (default: 0.2, raised to the manufacturer's "
+            "minimum trace width when that floor is higher -- e.g. jlcpcb "
+            "with --copper 2 has a 0.1524mm floor). Issue #4700: the floor is "
+            "the SAME per-<layers>layer_<oz>oz value `kct check --mfr` "
+            "enforces. An explicit value BELOW the resolved floor is honored "
+            "but prints a stderr WARNING naming the dimension_trace_width "
+            "check it will fail; it is never a hard error."
+        ),
+    )
     route_parser.add_argument("--clearance", type=float, default=0.15, help="Clearance in mm")
     route_parser.add_argument(
         "--fine-pitch-clearance",
@@ -3942,6 +3955,23 @@ def _add_route_parser(subparsers) -> None:
         "--mfr",
         default="jlcpcb",
         help="Manufacturer for DRC validation and adaptive rules (default: jlcpcb)",
+    )
+    route_parser.add_argument(
+        "--copper",
+        default=None,
+        metavar="OZ",
+        help=(
+            "Copper weight in oz used to resolve the manufacturer's design "
+            "rules (Issue #4700), using the SAME grammar as `kct check "
+            "--copper`: scalar '--copper 2' applies to both layer classes, "
+            "keyed '--copper outer=2,inner=0.5' sets each independently. "
+            "Precedence: explicit --copper > the board's declared "
+            "(setup (stackup ...)) weight > 1oz. Heavy copper RAISES the "
+            "minimum trace width (jlcpcb 4-layer: 0.1016mm at 1oz, 0.1524mm "
+            "at 2oz), so passing the weight you will actually order keeps "
+            "route and `kct check --mfr` in agreement on "
+            "dimension_trace_width."
+        ),
     )
     route_parser.add_argument(
         "--high-performance",

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -4583,6 +4583,244 @@ def _resolve_mfr_design_rules(args, layer_stack):
         return None
 
 
+# Issue #4700: the historical ``--trace-width`` argparse default, kept as a
+# named constant now that the flag itself carries a ``None`` sentinel so an
+# explicit value is distinguishable from "not given".
+DEFAULT_TRACE_WIDTH_MM = 0.2
+
+# Tolerance for "is this width below the floor" comparisons.  Widths are
+# authored in mm at 4 decimal places (0.1524 = 6 mil), so 1e-9 only absorbs
+# float representation error, never a real 0.0001mm difference.
+_TRACE_WIDTH_EPS = 1e-9
+
+
+def _effective_trace_width(args) -> float:
+    """Return ``args.trace_width``, falling back to the CLI default.
+
+    ``--trace-width`` carries a ``None`` sentinel (Issue #4700) so
+    :func:`_apply_manufacturer_trace_width_floor` can tell an explicit value
+    from an unset one.  ``_main_impl`` resolves the sentinel before dispatch,
+    but the route sub-flows are also called directly (tests, embedders), so
+    every consumer reads the width through this accessor and can never see
+    ``None``.
+    """
+    width = getattr(args, "trace_width", None)
+    return DEFAULT_TRACE_WIDTH_MM if width is None else float(width)
+
+
+def _effective_layer_count_for_rules(args, pcb_path) -> int | None:
+    """Resolve the copper layer count used for manufacturer rule lookup.
+
+    Mirrors the ``--layers`` handling of the routing sub-flows: an explicit
+    choice (``2`` / ``4`` / ``4-sig`` / ``4-all`` / ``6``) yields its numeric
+    prefix; ``auto`` detects the stack from the board.  Returns ``None`` when
+    detection fails, which makes the caller fall back to the profile default
+    rather than guess.
+    """
+    raw = getattr(args, "layers", "auto")
+    if raw and raw != "auto":
+        try:
+            return int(str(raw).split("-", 1)[0])
+        except (TypeError, ValueError):
+            return None
+    try:
+        from kicad_tools.router.io import detect_layer_stack
+
+        return int(detect_layer_stack(Path(pcb_path).read_text()).num_layers)
+    except (AttributeError, OSError, TypeError, ValueError):
+        return None
+
+
+def _resolve_route_copper_oz(
+    args, pcb_path, *, probe_stackup: bool = True
+) -> tuple[float | None, float | None]:
+    """Resolve ``(outer_oz, inner_oz)`` for the manufacturer rule lookup.
+
+    Same precedence as ``kct check`` (Issue #4326): an explicit ``--copper``
+    (keyed > scalar) wins, else the board's declared ``(setup (stackup ...))``
+    copper weight, else ``None`` (leave the profile default in place).
+
+    Args:
+        args: Parsed ``kct route`` arguments.
+        pcb_path: Path to the input board.
+        probe_stackup: When ``False``, skip the board parse entirely and use
+            only ``--copper``.  The caller passes ``False`` when no
+            manufacturer floor will be resolved, so a board without
+            ``--copper`` never pays for a parse whose result is unused.
+
+    Raises:
+        ValueError: when ``--copper`` is syntactically invalid -- the caller
+            reports it as ``Error: ...`` + exit 1, matching ``kct check``.
+    """
+    cli_outer: float | None = None
+    cli_inner: float | None = None
+    raw = getattr(args, "copper", None)
+    if raw is not None:
+        from kicad_tools.cli.copper_weight import parse_copper_weight_arg
+
+        cli_outer, cli_inner = parse_copper_weight_arg(raw)
+
+    stackup_outer: float | None = None
+    stackup_inner: float | None = None
+    if not probe_stackup or (cli_outer is not None and cli_inner is not None):
+        return (cli_outer, cli_inner)
+    try:
+        from kicad_tools.physics.stackup import Stackup
+        from kicad_tools.schema.pcb import PCB
+
+        derived = Stackup.from_pcb(PCB.load(str(pcb_path))).outer_inner_copper_oz()
+        if derived is not None:
+            stackup_outer, stackup_inner = derived
+    except Exception:  # noqa: BLE001 - never crash `route` on a stackup quirk
+        stackup_outer = stackup_inner = None
+
+    return (
+        cli_outer if cli_outer is not None else stackup_outer,
+        cli_inner if cli_inner is not None else stackup_inner,
+    )
+
+
+def _sub_floor_net_class_widths(net_class_map, floor: float) -> list[tuple[str, float]]:
+    """List ``(class_name, trace_width)`` entries narrower than ``floor``.
+
+    Net-class widths are user data (Issue #4700): they are reported, never
+    silently rewritten.  Deduplicated by class name and sorted narrowest
+    first so the warning names the worst offender up front.
+    """
+    if not net_class_map:
+        return []
+    worst: dict[str, float] = {}
+    for entry in net_class_map.values():
+        width = getattr(entry, "trace_width", None)
+        if width is None:
+            continue
+        try:
+            width = float(width)
+        except (TypeError, ValueError):
+            continue
+        if width >= floor - _TRACE_WIDTH_EPS:
+            continue
+        name = str(getattr(entry, "name", "?"))
+        if name not in worst or width < worst[name]:
+            worst[name] = width
+    return sorted(worst.items(), key=lambda kv: (kv[1], kv[0]))
+
+
+def _apply_manufacturer_trace_width_floor(args, pcb_path, *, quiet: bool = False) -> int:
+    """Resolve the trace-width default/floor from the manufacturer profile.
+
+    Issue #4700.  ``kct route --manufacturer X`` used to emit copper that
+    ``kct check --mfr X`` rejected with ``dimension_trace_width``, because
+    route floored at the layer/copper-agnostic
+    :attr:`MfrLimits.min_trace` (jlcpcb 0.127mm) while check enforces the
+    per-``<layers>layer_<oz>oz`` ``min_trace_width_mm`` (jlcpcb 4-layer 2oz:
+    0.1524mm).  This runs once in ``_main_impl`` -- before every route sub-flow
+    dispatch, next to the #4568 ``--edge-clearance`` auto-fill -- and:
+
+    1. resolves the copper weights (``--copper`` > board stackup > profile)
+       and stashes them on ``args`` for the ampacity advisory, the post-route
+       DRC and the ``.kicad_pro`` / ``.kicad_dru`` sidecars;
+    2. fills the ``--trace-width`` sentinel with ``max(0.2, floor)``;
+    3. warns (stderr, never suppressed by ``--quiet``, exit code unchanged)
+       when an explicit ``--trace-width``, an explicit ``--min-trace``, or a
+       net-class ``trace_width`` sits below the floor;
+    4. raises the ``--complete`` relaxation ladder's ``--min-trace`` floor to
+       the resolved value, so tier interpolation can no longer walk down
+       through sub-floor widths.
+
+    A no-op (default 0.2, no message, no warning) when no manufacturer floor
+    resolves, so behavior without ``--manufacturer`` is unchanged.
+
+    Returns:
+        ``0`` on success, ``1`` when ``--copper`` is malformed (the caller
+        returns that exit code, matching ``kct check``).
+    """
+    from kicad_tools.router.mfr_limits import resolve_min_trace_width
+
+    manufacturer = getattr(args, "manufacturer", None)
+    try:
+        copper_outer, copper_inner = _resolve_route_copper_oz(
+            args, pcb_path, probe_stackup=bool(manufacturer)
+        )
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    # Stash for the downstream consumers that already read ``copper_oz``
+    # (``_resolve_mfr_design_rules`` and the post-route DRC / sidecars).
+    args.copper_oz = float(copper_outer) if copper_outer else 1.0
+    args._copper_oz_inner = copper_inner
+
+    layers = _effective_layer_count_for_rules(args, pcb_path)
+    floor = resolve_min_trace_width(manufacturer, layers, copper_outer)
+    # Threaded into every ``load_pcb_for_routing`` call so the library-default
+    # net classes (``Differential`` = 0.15mm) are raised to the fab floor too:
+    # those, not ``--trace-width``, are what actually width the emitted copper
+    # for classified nets.
+    args._mfr_min_trace_floor = floor
+
+    explicit_width = getattr(args, "trace_width", None)
+    if explicit_width is None:
+        resolved = DEFAULT_TRACE_WIDTH_MM if floor is None else max(DEFAULT_TRACE_WIDTH_MM, floor)
+        args.trace_width = resolved
+        if floor is not None and resolved > DEFAULT_TRACE_WIDTH_MM and not quiet:
+            print(f"Trace width: {resolved:.4g}mm (from {manufacturer} manufacturer limits)")
+    elif floor is not None and float(explicit_width) < floor - _TRACE_WIDTH_EPS:
+        print(
+            f"WARNING: --trace-width {float(explicit_width):.4g}mm is below the "
+            f"{manufacturer} minimum trace width {floor:.4g}mm "
+            f"({_mfr_rule_key(layers, copper_outer)}). Routing will proceed, but "
+            f"`kct check --mfr {manufacturer}` will report dimension_trace_width "
+            f"errors on every trace at this width.",
+            file=sys.stderr,
+        )
+
+    if floor is None:
+        return 0
+
+    # Net-class widths are user data: report, never rewrite.
+    sub_floor = _sub_floor_net_class_widths(getattr(args, "_loaded_net_class_map", None), floor)
+    if sub_floor:
+        named = ", ".join(f"{name} ({width:.4g}mm)" for name, width in sub_floor[:5])
+        more = f", +{len(sub_floor) - 5} more" if len(sub_floor) > 5 else ""
+        print(
+            f"WARNING: {len(sub_floor)} net-class trace_width value(s) are below the "
+            f"{manufacturer} minimum trace width {floor:.4g}mm "
+            f"({_mfr_rule_key(layers, copper_outer)}): {named}{more}. These widths are "
+            f"honored as authored, but `kct check --mfr {manufacturer}` will report "
+            f"dimension_trace_width errors on their traces.",
+            file=sys.stderr,
+        )
+
+    # Relaxation ladder (``--complete`` / ``--adaptive-rules``): raise the
+    # floor so interpolated tiers cannot descend below the check-side minimum.
+    explicit_min_trace = getattr(args, "min_trace", None)
+    if explicit_min_trace is None:
+        # ``get_relaxation_tiers`` clamps with ``max(min_trace_floor,
+        # mfr.min_trace)``, so handing it the check-side floor can only RAISE
+        # the ladder (jlcpcb 4-layer 2oz: 0.127 -> 0.1524mm) and never lowers
+        # it below the fab capability minimum on the tiers where the
+        # check-side value is the looser of the two (4-layer 1oz: 0.1016).
+        args.min_trace = floor
+    elif float(explicit_min_trace) < floor - _TRACE_WIDTH_EPS:
+        print(
+            f"WARNING: --min-trace {float(explicit_min_trace):.4g}mm is below the "
+            f"{manufacturer} minimum trace width {floor:.4g}mm "
+            f"({_mfr_rule_key(layers, copper_outer)}); relaxation tiers may emit "
+            f"traces that `kct check --mfr {manufacturer}` rejects with "
+            f"dimension_trace_width.",
+            file=sys.stderr,
+        )
+    return 0
+
+
+def _mfr_rule_key(layers: int | None, copper_oz: float | None) -> str:
+    """Format the manufacturer design-rule key named in #4700 warnings."""
+    layer_text = f"{layers}-layer" if layers else "profile-default layers"
+    copper_text = f"{float(copper_oz):g}oz" if copper_oz else "1oz"
+    return f"{layer_text} {copper_text}"
+
+
 def _warn_layer_selection_advisories(args, layer_stack, *, is_auto: bool) -> None:
     """Emit Issue #4314 route-time layer-selection advisories to stderr.
 
@@ -5045,7 +5283,7 @@ def route_with_layer_escalation(
     fine_pitch_cl = getattr(args, "fine_pitch_clearance", None)
     rules = DesignRules(
         grid_resolution=args.grid,
-        trace_width=args.trace_width,
+        trace_width=_effective_trace_width(args),
         trace_clearance=args.clearance,
         via_drill=args.via_drill,
         via_diameter=args.via_diameter,
@@ -5054,6 +5292,11 @@ def route_with_layer_escalation(
         # to in-pad escape for fine-pitch LQFP/QFP (and SSOP/TSSOP) when the
         # manufacturer supports via-in-pad processing.
         manufacturer=getattr(args, "manufacturer", None),
+        # Issue #4700: the fab minimum trace width for the effective
+        # layers/copper key -- raises the library net-class widths and keys
+        # the routing cache so a --copper 2 run is never served a --copper 1
+        # route.
+        min_trace_width_floor=getattr(args, "_mfr_min_trace_floor", None),
         # Issue #2891: forward escalation-in-progress flag so the escape
         # router demotes the #2880 ERROR log when an outer wrapper will
         # retry on a tier that supports via-in-pad.
@@ -6029,6 +6272,10 @@ def route_with_layer_escalation(
             manufacturer=args.manufacturer,
             layers=final_result.layer_count,
             quiet=quiet,
+            # Issue #4700: judge at the SAME copper weight the trace-width
+            # floor was resolved from (--copper > board stackup > 1oz), so
+            # the sidecars and this DRC agree with `kct check --copper`.
+            copper_oz=float(getattr(args, "copper_oz", 1.0) or 1.0),
             # Issue #2652, Epic #2556 Phase 2.5b: thread the autorouter's
             # net_class_map into the post-route DRC so the diff-pair
             # routing-continuity rule can re-derive its engagement state.
@@ -6200,7 +6447,7 @@ def route_with_rule_relaxation(
 
     # Get relaxation tiers
     tiers = get_relaxation_tiers(
-        initial_trace_width=args.trace_width,
+        initial_trace_width=_effective_trace_width(args),
         initial_clearance=args.clearance,
         initial_via_drill=args.via_drill,
         initial_via_diameter=args.via_diameter,
@@ -6305,6 +6552,11 @@ def route_with_rule_relaxation(
             # in to in-pad escape for fine-pitch LQFP/QFP/SSOP/TSSOP when
             # the manufacturer supports via-in-pad processing.
             manufacturer=getattr(args, "manufacturer", None),
+            # Issue #4700: the fab minimum trace width for the effective
+            # layers/copper key -- raises the library net-class widths and keys
+            # the routing cache so a --copper 2 run is never served a --copper 1
+            # route.
+            min_trace_width_floor=getattr(args, "_mfr_min_trace_floor", None),
             # Issue #2891: forward escalation-in-progress flag.
             auto_mfr_tier_in_progress=getattr(args, "_auto_mfr_tier_in_progress", False),
             # Issue #4433: forward --strict-layers (hard per-net avoid_layers).
@@ -6568,7 +6820,10 @@ def route_with_rule_relaxation(
                 f"({final_result.completion * 100:.0f}% completion)"
             )
             print("\nFinal design rules:")
-            print(f"  Trace width: {final_result.trace_width:.3f}mm (was {args.trace_width}mm)")
+            print(
+                f"  Trace width: {final_result.trace_width:.3f}mm "
+                f"(was {_effective_trace_width(args)}mm)"
+            )
             print(f"  Clearance:   {final_result.clearance:.3f}mm (was {args.clearance}mm)")
             if final_result.tier > 0:
                 print(f"\n  Note: Rules were relaxed ({final_result.tier_description})")
@@ -6764,6 +7019,10 @@ def route_with_rule_relaxation(
             manufacturer=args.manufacturer,
             layers=final_result.layer_count,
             quiet=quiet,
+            # Issue #4700: judge at the SAME copper weight the trace-width
+            # floor was resolved from (--copper > board stackup > 1oz), so
+            # the sidecars and this DRC agree with `kct check --copper`.
+            copper_oz=float(getattr(args, "copper_oz", 1.0) or 1.0),
             # Issue #2652, Epic #2556 Phase 2.5b: thread the autorouter's
             # net_class_map into the post-route DRC so the diff-pair
             # routing-continuity rule can re-derive its engagement state.
@@ -8348,7 +8607,7 @@ def route_with_combined_escalation(
 
     # Get relaxation tiers
     tiers = get_relaxation_tiers(
-        initial_trace_width=args.trace_width,
+        initial_trace_width=_effective_trace_width(args),
         initial_clearance=args.clearance,
         initial_via_drill=args.via_drill,
         initial_via_diameter=args.via_diameter,
@@ -8499,6 +8758,11 @@ def route_with_combined_escalation(
                 # can opt in to in-pad escape for fine-pitch LQFP/QFP/SSOP/
                 # TSSOP when the manufacturer supports via-in-pad processing.
                 manufacturer=getattr(args, "manufacturer", None),
+                # Issue #4700: the fab minimum trace width for the effective
+                # layers/copper key -- raises the library net-class widths and keys
+                # the routing cache so a --copper 2 run is never served a --copper 1
+                # route.
+                min_trace_width_floor=getattr(args, "_mfr_min_trace_floor", None),
                 # Issue #2891: forward escalation-in-progress flag.
                 auto_mfr_tier_in_progress=getattr(args, "_auto_mfr_tier_in_progress", False),
                 # Issue #4433: forward --strict-layers (hard per-net avoid_layers).
@@ -9014,6 +9278,10 @@ def route_with_combined_escalation(
             manufacturer=args.manufacturer,
             layers=final_result.layer_count,
             quiet=quiet,
+            # Issue #4700: judge at the SAME copper weight the trace-width
+            # floor was resolved from (--copper > board stackup > 1oz), so
+            # the sidecars and this DRC agree with `kct check --copper`.
+            copper_oz=float(getattr(args, "copper_oz", 1.0) or 1.0),
             # Issue #2652, Epic #2556 Phase 2.5b: thread the autorouter's
             # net_class_map into the post-route DRC so the diff-pair
             # routing-continuity rule can re-derive its engagement state.
@@ -10584,8 +10852,18 @@ def _main_impl(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--trace-width",
         type=float,
-        default=0.2,
-        help="Trace width in mm (default: 0.2)",
+        default=None,
+        help=(
+            "Trace width in mm (default: 0.2, raised to the manufacturer's "
+            "minimum trace width when that floor is higher -- e.g. jlcpcb "
+            "with --copper 2 has a 0.1524mm floor). Issue #4700: the floor "
+            "is the SAME per-<layers>layer_<oz>oz value `kct check --mfr` "
+            "enforces, so route never emits copper its own check rejects. "
+            "An explicit value BELOW the resolved floor is honored (for "
+            "deliberate exploration) but prints a stderr WARNING naming the "
+            "dimension_trace_width check it will fail; it is never a hard "
+            "error."
+        ),
     )
     parser.add_argument(
         "--clearance",
@@ -11356,6 +11634,23 @@ def _main_impl(argv: list[str] | None = None) -> int:
         help=(
             "Manufacturer profile for DRC validation (default: jlcpcb). "
             "Determines minimum clearances, trace widths, and other design rules."
+        ),
+    )
+    parser.add_argument(
+        "--copper",
+        default=None,
+        metavar="OZ",
+        help=(
+            "Copper weight in oz used to resolve the manufacturer's design "
+            "rules (Issue #4700), using the SAME grammar as `kct check "
+            "--copper`: scalar form '--copper 2' applies to both outer and "
+            "inner layers; keyed form '--copper outer=2,inner=0.5' sets each "
+            "layer class independently. Precedence: explicit --copper > the "
+            "board's declared (setup (stackup ...)) copper weight > 1oz. "
+            "Heavy copper RAISES the minimum trace width (jlcpcb 4-layer: "
+            "0.1016mm at 1oz, 0.1524mm at 2oz), so passing the weight you "
+            "will actually order keeps route and `kct check --mfr` in "
+            "agreement on dimension_trace_width."
         ),
     )
     parser.add_argument(
@@ -12621,6 +12916,18 @@ def _main_impl(argv: list[str] | None = None) -> int:
                     f"(from {args.manufacturer} manufacturer limits)"
                 )
 
+    # Issue #4700: resolve the trace-width default / floor from the SAME
+    # per-<layers>layer_<oz>oz manufacturer rule ``kct check --mfr`` enforces,
+    # so route can no longer emit copper its own matching check rejects with
+    # ``dimension_trace_width``.  Runs here -- before every route sub-flow
+    # dispatch, alongside the #4568 edge-clearance auto-fill -- so the
+    # default multi-layer, rule-relaxation and single-layer paths all share
+    # one resolution.  ``args._loaded_net_class_map`` is already populated
+    # above, so authored sub-floor class widths are reported here too.
+    _rc = _apply_manufacturer_trace_width_floor(args, pcb_path, quiet=args.quiet)
+    if _rc != 0:
+        return _rc
+
     # Issue #3400: resolve the effective ``starting_layers`` value with the
     # precedence CLI flag > project.kct EscalationPolicy field > default 2.
     # This runs before every escalation dispatch so all paths share the
@@ -12825,7 +13132,7 @@ def _main_impl(argv: list[str] | None = None) -> int:
     rules = DesignRules(
         grid_resolution=args.grid,
         grid_origin_offset=grid_origin_offset,
-        trace_width=args.trace_width,
+        trace_width=_effective_trace_width(args),
         trace_clearance=args.clearance,
         via_drill=args.via_drill,
         via_diameter=args.via_diameter,
@@ -12834,6 +13141,11 @@ def _main_impl(argv: list[str] | None = None) -> int:
         # to in-pad escape for fine-pitch SSOP/TSSOP when the manufacturer
         # supports via-in-pad processing.
         manufacturer=getattr(args, "manufacturer", None),
+        # Issue #4700: the fab minimum trace width for the effective
+        # layers/copper key -- raises the library net-class widths and keys
+        # the routing cache so a --copper 2 run is never served a --copper 1
+        # route.
+        min_trace_width_floor=getattr(args, "_mfr_min_trace_floor", None),
         # Issue #2891: forward escalation-in-progress flag so the escape
         # router demotes the #2880 ERROR log when an outer wrapper will
         # retry on a tier that supports via-in-pad.
@@ -13112,7 +13424,7 @@ def _main_impl(argv: list[str] | None = None) -> int:
         fine_pitch_report = analyze_fine_pitch_components(
             pads=router.pads,
             grid_resolution=args.grid,
-            trace_width=args.trace_width,
+            trace_width=_effective_trace_width(args),
             clearance=args.clearance,
         )
         if fine_pitch_report.has_warnings:
@@ -14504,6 +14816,10 @@ def _main_impl(argv: list[str] | None = None) -> int:
             manufacturer=args.manufacturer,
             layers=layer_stack.num_layers,
             quiet=quiet,
+            # Issue #4700: judge at the SAME copper weight the trace-width
+            # floor was resolved from (--copper > board stackup > 1oz), so
+            # the sidecars and this DRC agree with `kct check --copper`.
+            copper_oz=float(getattr(args, "copper_oz", 1.0) or 1.0),
             # Issue #2652, Epic #2556 Phase 2.5b: see other call sites.
             net_class_map=getattr(router, "net_class_map", None),
             # Issue #4178: forward --strict-drc (see other call sites).

--- a/src/kicad_tools/router/cache.py
+++ b/src/kicad_tools/router/cache.py
@@ -127,6 +127,16 @@ class CacheKey:
                 [net_a, net_b, float(required)]
                 for (net_a, net_b), required in pairwise.required_by_pair.items()
             )
+        # Issue #4700: the fab minimum trace width RAISES the built-in
+        # net-class widths (``Differential`` 0.15 -> jlcpcb 2oz 0.1524), so it
+        # changes the emitted copper.  Without it in the key, a ``--copper 1``
+        # run and a ``--copper 2`` run of the same board share an entry and the
+        # second silently gets the first's narrower traces back.  Absent floor
+        # -> ``rules_data`` is unchanged, so every pre-existing key is
+        # preserved byte-for-byte (same contract as the #4602 HV table above).
+        min_trace_floor = getattr(rules, "min_trace_width_floor", None)
+        if min_trace_floor:
+            rules_data["min_trace_width_floor"] = float(min_trace_floor)
         rules_json = json.dumps(rules_data, sort_keys=True)
         rules_hash = hashlib.sha256(rules_json.encode()).hexdigest()
 
@@ -297,6 +307,11 @@ class SubProblemSignature:
             "via_diameter": rules.via_diameter,
             "grid_resolution": rules.grid_resolution,
         }
+        # Issue #4700: see CacheKey.from_pcb_and_rules -- the fab minimum trace
+        # width changes the emitted copper, so it must key the signature too.
+        min_trace_floor = getattr(rules, "min_trace_width_floor", None)
+        if min_trace_floor:
+            rules_data["min_trace_width_floor"] = float(min_trace_floor)
         rules_json = json.dumps(rules_data, sort_keys=True)
         rules_hash = hashlib.sha256(rules_json.encode()).hexdigest()
 

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -3389,6 +3389,7 @@ def load_pcb_for_routing(
     strategy: str = "grid",
     localize_lattice_to_region: bool = False,
     lattice_link_budget_s: float | None = None,
+    min_trace_width_floor: float | None = None,
 ) -> tuple[Autorouter, dict[str, int]]:
     """
     Load a KiCad PCB file and create an Autorouter with all components.
@@ -3486,6 +3487,19 @@ def load_pcb_for_routing(
                 the lattice netset negotiation aborts within
                 ``budget x link-count`` seconds and returns the best routes so
                 far.  ``None`` preserves the unbudgeted negotiation.
+        min_trace_width_floor: Issue #4700.  Minimum legal trace width (mm)
+                for the target fab tier -- the SAME
+                ``get_design_rules(layers, copper_oz).min_trace_width_mm``
+                that ``kct check --mfr`` enforces.  The built-in and
+                auto-classified net classes assembled below carry library
+                default widths (e.g. ``Differential`` = 0.15mm) that are
+                below that floor on heavy copper (jlcpcb 2oz = 0.1524mm),
+                so route emitted copper its own check rejected with
+                ``dimension_trace_width``.  When given, those library
+                defaults are raised to the floor.  Caller-supplied net
+                classes (merged into ``router.net_class_map`` afterwards)
+                are user data and are never rewritten here.  ``None``
+                (default) preserves the pre-#4700 widths exactly.
 
     Returns:
         Tuple of (Autorouter instance, net_map dict)
@@ -3791,6 +3805,33 @@ def load_pcb_for_routing(
                     net_class_map[_name] = _routing
     except Exception as e:  # noqa: BLE001 - classification is best-effort
         logger.debug(f"Auto net classification skipped: {e}")
+
+    # Issue #4700: raise LIBRARY-default net-class widths to the fab's own
+    # minimum trace width.  ``DEFAULT_NET_CLASS_MAP`` and the auto-classifier
+    # carry fixed widths (``Differential`` = 0.15mm) that sit below the
+    # per-<layers>layer_<oz>oz floor ``kct check --mfr`` enforces on heavy
+    # copper (jlcpcb 2oz = 0.1524mm) -- the source of the reported 63
+    # identical ``Trace width 0.150mm < minimum 0.152mm`` errors.  Only the
+    # map built above is touched: a caller's own net-class map is merged into
+    # ``router.net_class_map`` later and stays user data (the CLI warns about
+    # sub-floor authored widths instead of rewriting them).
+    _width_floor = min_trace_width_floor
+    if _width_floor is None:
+        # Same value carried on the effective rules (set by ``kct route``), so
+        # in-process callers that build DesignRules directly get the floor too
+        # -- and it is exactly the value the routing cache keys on.
+        _width_floor = getattr(rules, "min_trace_width_floor", None)
+    if _width_floor and _width_floor > 0:
+        for _cls_key, _cls in list(net_class_map.items()):
+            _width = getattr(_cls, "trace_width", None)
+            if _width is not None and _width < _width_floor:
+                net_class_map[_cls_key] = replace(_cls, trace_width=_width_floor)
+                logger.debug(
+                    "net class %s trace_width %.4gmm raised to fab minimum %.4gmm",
+                    getattr(_cls, "name", _cls_key),
+                    _width,
+                    _width_floor,
+                )
 
     router = Autorouter(
         width=board_width,

--- a/src/kicad_tools/router/mfr_limits.py
+++ b/src/kicad_tools/router/mfr_limits.py
@@ -532,6 +532,70 @@ def resolve_edge_clearance(manufacturer: str | None) -> float | None:
     return None
 
 
+def resolve_min_trace_width(
+    manufacturer: str | None,
+    layers: int | None = None,
+    copper_oz: float | None = None,
+) -> float | None:
+    """Resolve the *check-side* minimum trace width floor for a manufacturer.
+
+    Shared resolution helper (Issue #4700), the trace-width analogue of
+    :func:`resolve_edge_clearance`.  Used by the ``kct route`` CLI to fill
+    the ``--trace-width`` default, guard explicitly-narrower widths, and
+    floor the ``--complete`` relaxation ladder, so route-time copper can
+    never fall below the floor that ``kct check --mfr`` enforces.
+
+    **This deliberately does NOT read** :attr:`MfrLimits.min_trace`.  That
+    field is layer-count- and copper-weight-agnostic (jlcpcb 0.127mm for
+    every configuration), whereas the DRC that ``kct check`` runs resolves
+    ``get_profile(mfr).get_design_rules(layers, copper_oz).min_trace_width_mm``
+    -- a per-``<layers>layer_<oz>oz`` value that is *higher* than
+    ``min_trace`` on heavy copper (jlcpcb ``4layer_2oz`` = 0.1524mm vs
+    ``min_trace`` = 0.127mm).  Flooring at ``min_trace`` would be a silent
+    no-op for exactly the configuration that reported this bug.
+
+    Args:
+        manufacturer: Manufacturer name (case-insensitive, aliases OK),
+            or ``None``/empty when no manufacturer is configured.
+        layers: Copper layer count for the profile lookup.  ``None`` uses
+            the profile default (4), matching
+            :meth:`ManufacturerProfile.get_design_rules`.
+        copper_oz: Outer-layer copper weight in oz for the profile lookup.
+            ``None`` uses the profile default (1.0).
+
+    Returns:
+        The profile's ``min_trace_width_mm`` in mm, or ``None`` when
+        ``manufacturer`` is falsy, unknown (no raise -- manufacturer
+        validation belongs to the CLI layer), the profile package is
+        unavailable, or the resolved floor is not positive.
+    """
+    if not manufacturer:
+        return None
+    try:
+        # Lazy import: ``kicad_tools.manufacturers`` pulls in YAML profile
+        # loading, and importing it at module scope would make the router
+        # package depend on it (and risks an import cycle).  Matches how
+        # ``cli/route_cmd.py`` reaches for ``get_profile``.
+        from kicad_tools.manufacturers import get_profile
+
+        profile = get_profile(manufacturer)
+        rules = profile.get_design_rules(
+            layers=int(layers) if layers else 4,
+            copper_oz=float(copper_oz) if copper_oz else 1.0,
+        )
+    except (ImportError, ValueError, KeyError, TypeError, IndexError, OSError):
+        return None
+
+    floor = getattr(rules, "min_trace_width_mm", None)
+    if floor is None:
+        return None
+    try:
+        floor = float(floor)
+    except (TypeError, ValueError):
+        return None
+    return floor if floor > 0 else None
+
+
 @dataclass
 class RelaxationTier:
     """A single design rule relaxation tier.

--- a/src/kicad_tools/router/rules.py
+++ b/src/kicad_tools/router/rules.py
@@ -105,6 +105,17 @@ class DesignRules:
     # preserving pre-#2605 deferred-pin behavior on fine-pitch SSOP/TSSOP.
     manufacturer: str | None = None
 
+    # Fab minimum trace width for the effective layers/copper key (Issue #4700)
+    # The SAME ``get_design_rules(layers, copper_oz).min_trace_width_mm`` that
+    # ``kct check --mfr`` enforces -- NOT the layer/copper-agnostic
+    # ``MfrLimits.min_trace``.  ``load_pcb_for_routing`` raises the built-in /
+    # auto-classified net-class widths (``Differential`` = 0.15mm) to this
+    # value so route cannot emit copper its own check rejects with
+    # ``dimension_trace_width``, and the routing cache keys on it so a run at
+    # one copper weight is never served a route computed at another.  ``None``
+    # (default) preserves pre-#4700 widths and cache keys byte-for-byte.
+    min_trace_width_floor: float | None = None
+
     # Manufacturer-tier escalation in progress flag (Issue #2891)
     # When True, the escape router demotes the "Cannot escape ... does not
     # support via-in-pad" ERROR log (escape.py Issue #2880) to DEBUG level

--- a/tests/test_mfr_limits.py
+++ b/tests/test_mfr_limits.py
@@ -15,6 +15,7 @@ from kicad_tools.router.mfr_limits import (
     get_mfr_limits,
     get_mfr_size_tier_ladder,
     get_relaxation_tiers,
+    resolve_min_trace_width,
 )
 
 
@@ -611,3 +612,132 @@ class TestFindSmallestAdmittingTier:
         tier_canonical = find_smallest_admitting_tier(100, 100, "jlcpcb")
         tier_alias = find_smallest_admitting_tier(100, 100, "JLCPCB")
         assert tier_canonical == tier_alias
+
+
+class TestResolveMinTraceWidth:
+    """Issue #4700: the check-side minimum trace width resolver.
+
+    ``kct route`` used to floor its trace widths at
+    :attr:`MfrLimits.min_trace`, which is layer-count- and
+    copper-weight-agnostic, while ``kct check --mfr`` enforces the
+    per-``<layers>layer_<oz>oz`` ``min_trace_width_mm`` from the
+    manufacturer profile.  These tests pin the *divergence* -- a resolver
+    that read ``MfrLimits.min_trace`` would be a silent no-op for the
+    configuration that reported the bug.
+    """
+
+    def test_jlcpcb_4layer_2oz_is_the_reported_floor(self):
+        """jlcpcb 4-layer 2oz resolves 0.1524mm (the reporter's key)."""
+        assert resolve_min_trace_width("jlcpcb", 4, 2.0) == pytest.approx(0.1524)
+
+    def test_jlcpcb_2oz_floor_exceeds_mfr_limits_min_trace(self):
+        """The 2oz floor is STRICTLY above MfrLimits.min_trace (no-op guard).
+
+        This is the assertion that fails for a naive #4568-shaped fix: a
+        resolver delegating to ``MFR_JLCPCB.min_trace`` returns 0.127, which
+        is below the 0.150mm copper the reporter observed, so nothing would
+        be raised and the 63 ``dimension_trace_width`` errors would persist.
+        """
+        floor = resolve_min_trace_width("jlcpcb", 4, 2.0)
+        assert floor is not None
+        assert floor > MFR_JLCPCB.min_trace
+        # And it is above the reported 0.150mm emission, so it binds.
+        assert floor > 0.150
+
+    def test_jlcpcb_2layer_2oz_is_also_the_heavy_copper_floor(self):
+        assert resolve_min_trace_width("jlcpcb", 2, 2.0) == pytest.approx(0.1524)
+
+    def test_jlcpcb_1oz_floors_are_layer_keyed(self):
+        """1oz floors differ per layer count -- 2-layer is the coarser one."""
+        assert resolve_min_trace_width("jlcpcb", 2, 1.0) == pytest.approx(0.127)
+        assert resolve_min_trace_width("jlcpcb", 4, 1.0) == pytest.approx(0.1016)
+
+    def test_defaults_match_profile_defaults(self):
+        """Omitted layers/copper use the profile default (4-layer 1oz)."""
+        assert resolve_min_trace_width("jlcpcb") == resolve_min_trace_width("jlcpcb", 4, 1.0)
+
+    def test_alias_and_case_insensitive(self):
+        assert resolve_min_trace_width("JLCPCB", 4, 2.0) == resolve_min_trace_width(
+            "jlcpcb", 4, 2.0
+        )
+
+    def test_unknown_manufacturer_returns_none(self):
+        """Unknown manufacturer degrades to None -- validation is the CLI's job."""
+        assert resolve_min_trace_width("not-a-fab", 4, 1.0) is None
+
+    def test_falsy_manufacturer_returns_none(self):
+        assert resolve_min_trace_width(None) is None
+        assert resolve_min_trace_width("") is None
+
+    def test_every_known_manufacturer_resolves_a_positive_floor(self):
+        """Parity invariant: every routable tier has a check-side floor."""
+        for name in MFR_LIMITS:
+            for copper in (1.0, 2.0):
+                floor = resolve_min_trace_width(name, 4, copper)
+                assert floor is not None, f"{name} @ {copper}oz resolved no floor"
+                assert floor > 0
+
+
+class TestRelaxationLadderRespectsCheckSideFloor:
+    """Issue #4700: ``--complete`` tiers must never dip below the check floor."""
+
+    def test_default_ladder_dips_below_the_2oz_floor(self):
+        """Baseline: without the resolved floor the ladder emits sub-floor tiers.
+
+        This documents the second sub-floor emitter the fix has to close --
+        ``MfrLimits.min_trace`` (0.127) lets tier interpolation walk right
+        through 0.1524mm.
+        """
+        tiers = get_relaxation_tiers(
+            initial_trace_width=0.2,
+            initial_clearance=0.4,
+            initial_via_drill=0.3,
+            initial_via_diameter=0.6,
+            manufacturer="jlcpcb",
+        )
+        assert min(t.trace_width for t in tiers) < 0.1524
+
+    def test_resolved_floor_clamps_every_tier(self):
+        """Threading the resolved floor keeps every tier at or above it."""
+        floor = resolve_min_trace_width("jlcpcb", 4, 2.0)
+        tiers = get_relaxation_tiers(
+            initial_trace_width=0.2,
+            initial_clearance=0.4,
+            initial_via_drill=0.3,
+            initial_via_diameter=0.6,
+            manufacturer="jlcpcb",
+            min_trace_floor=floor,
+        )
+        assert floor is not None
+        for tier in tiers:
+            assert tier.trace_width >= floor - 1e-9, tier
+
+    def test_looser_check_floor_never_lowers_the_fab_minimum(self):
+        """A 1oz check floor below MfrLimits.min_trace is clamped back up."""
+        floor = resolve_min_trace_width("jlcpcb", 4, 1.0)
+        assert floor is not None and floor < MFR_JLCPCB.min_trace
+        tiers = get_relaxation_tiers(
+            initial_trace_width=0.2,
+            initial_clearance=0.4,
+            initial_via_drill=0.3,
+            initial_via_diameter=0.6,
+            manufacturer="jlcpcb",
+            min_trace_floor=floor,
+        )
+        assert min(t.trace_width for t in tiers) >= MFR_JLCPCB.min_trace - 1e-9
+
+    def test_parity_invariant_across_all_manufacturers(self):
+        """For every tier, a floored ladder passes the matching check floor."""
+        for name in MFR_LIMITS:
+            for copper in (1.0, 2.0):
+                floor = resolve_min_trace_width(name, 4, copper)
+                assert floor is not None
+                tiers = get_relaxation_tiers(
+                    initial_trace_width=0.25,
+                    initial_clearance=0.4,
+                    initial_via_drill=0.3,
+                    initial_via_diameter=0.6,
+                    manufacturer=name,
+                    min_trace_floor=floor,
+                )
+                assert all(t.trace_width >= floor - 1e-9 for t in tiers), (name, copper)

--- a/tests/test_route_cmd_params.py
+++ b/tests/test_route_cmd_params.py
@@ -7,6 +7,31 @@ passed through the command handler to the underlying route_cmd.main().
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
+
+def _route_forward_args(**overrides) -> SimpleNamespace:
+    """Minimal ``kct route`` args namespace for the argv-forwarding tests."""
+    base = {
+        "pcb": "test.kicad_pcb",
+        "output": None,
+        "strategy": "negotiated",
+        "skip_nets": None,
+        "grid": "auto",
+        "trace_width": 0.2,
+        "clearance": 0.15,
+        "via_drill": 0.3,
+        "via_diameter": 0.6,
+        "mc_trials": 10,
+        "iterations": 15,
+        "verbose": False,
+        "dry_run": True,
+        "quiet": True,
+        "power_nets": None,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
 
 class TestRouteCommandGridParameter:
     """Tests for --grid parameter handling in route command."""
@@ -241,6 +266,7 @@ class TestRouteCommandDefaultConsistency:
     def test_parser_defaults_match_handler_checks(self):
         """Verify parser defaults match the values checked in routing.py handler."""
 
+        from kicad_tools.cli import route_cmd
         from kicad_tools.cli.parser import create_parser
 
         parser = create_parser()
@@ -252,7 +278,13 @@ class TestRouteCommandDefaultConsistency:
         # These should match the checks in routing.py
         assert args.grid == "auto", "Grid default should be 'auto'"
         assert args.clearance == 0.15, "Clearance default should be 0.15"
-        assert args.trace_width == 0.2, "Trace width default should be 0.2"
+        # Issue #4700: --trace-width carries a ``None`` sentinel so the command
+        # can tell "unset" from an explicit 0.2 and raise the default to the
+        # manufacturer's own minimum trace width.  The effective default is
+        # still 0.2 (see DEFAULT_TRACE_WIDTH_MM / _effective_trace_width).
+        assert args.trace_width is None, "Trace width default should be the None sentinel"
+        assert route_cmd.DEFAULT_TRACE_WIDTH_MM == 0.2, "Effective trace width default is 0.2"
+        assert route_cmd._effective_trace_width(args) == 0.2
         assert args.via_drill == 0.3, "Via drill default should be 0.3"
         assert args.via_diameter == 0.6, "Via diameter default should be 0.6"
 
@@ -1219,3 +1251,225 @@ class TestRouteParserPerNetTimeoutFlag:
         help_text = help_output.getvalue()
         assert "--per-net-timeout" in help_text
         assert "--timeout" in help_text
+
+
+class TestManufacturerTraceWidthFloor:
+    """Issue #4700: --trace-width resolves from the manufacturer's own floor.
+
+    ``kct route --manufacturer jlcpcb`` used to emit copper below the very
+    floor ``kct check --mfr jlcpcb`` enforces, because route floored at the
+    layer/copper-agnostic ``MfrLimits.min_trace`` (0.127mm) while check reads
+    the per-``<layers>layer_<oz>oz`` ``min_trace_width_mm`` (0.1524mm at 2oz).
+    """
+
+    @staticmethod
+    def _args(**overrides):
+        from argparse import Namespace
+
+        base = {
+            "manufacturer": "jlcpcb",
+            "copper": None,
+            "layers": "4",
+            "trace_width": None,
+            "min_trace": None,
+            "quiet": False,
+            "_loaded_net_class_map": None,
+        }
+        base.update(overrides)
+        return Namespace(**base)
+
+    @staticmethod
+    def _pcb(tmp_path):
+        """A minimal board with no explicit stackup (profile default copper)."""
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text("(kicad_pcb (version 20221018) (generator test)\n)\n")
+        return pcb
+
+    def test_unset_width_is_raised_to_the_2oz_floor(self, tmp_path, capsys):
+        """max(0.2, floor) with the floor reported once on stdout."""
+        from kicad_tools.cli import route_cmd
+
+        args = self._args(copper="2", trace_width=None)
+        # A wide-ish explicit-free run: the 0.1524 floor is below 0.2, so the
+        # default stands -- but the ladder floor must be raised.
+        assert route_cmd._apply_manufacturer_trace_width_floor(args, self._pcb(tmp_path)) == 0
+        assert args.trace_width == 0.2
+        assert args.min_trace == pytest.approx(0.1524)
+        assert args.copper_oz == 2.0
+
+    def test_binding_floor_raises_the_default_and_announces_it(self, tmp_path, capsys):
+        """A floor above 0.2 raises the default and prints one summary line."""
+        from unittest.mock import patch
+
+        from kicad_tools.cli import route_cmd
+
+        args = self._args(copper="2", trace_width=None)
+        with patch.object(route_cmd, "DEFAULT_TRACE_WIDTH_MM", 0.1):
+            with patch(
+                "kicad_tools.router.mfr_limits.resolve_min_trace_width",
+                return_value=0.1524,
+            ):
+                assert (
+                    route_cmd._apply_manufacturer_trace_width_floor(args, self._pcb(tmp_path)) == 0
+                )
+        assert args.trace_width == pytest.approx(0.1524)
+        out = capsys.readouterr().out
+        assert "Trace width:" in out
+        assert "jlcpcb" in out
+
+    def test_non_binding_floor_leaves_the_default_untouched(self, tmp_path, capsys):
+        """jlcpcb 4-layer 1oz floor (0.1016) does not move the 0.2 default."""
+        from kicad_tools.cli import route_cmd
+
+        args = self._args()
+        route_cmd._apply_manufacturer_trace_width_floor(args, self._pcb(tmp_path))
+        assert args.trace_width == 0.2
+        assert "Trace width:" not in capsys.readouterr().out
+
+    def test_explicit_sub_floor_width_warns_but_is_honored(self, tmp_path, capsys):
+        """The reporter's exact emission: 0.150mm against the 0.1524mm floor."""
+        from kicad_tools.cli import route_cmd
+
+        args = self._args(copper="2", trace_width=0.15)
+        route_cmd._apply_manufacturer_trace_width_floor(args, self._pcb(tmp_path))
+
+        # Honored, never silently rewritten.
+        assert args.trace_width == 0.15
+        err = capsys.readouterr().err
+        assert "WARNING" in err
+        assert "0.15" in err
+        assert "0.1524" in err
+        assert "jlcpcb" in err
+        assert "4-layer 2oz" in err
+        assert "dimension_trace_width" in err
+
+    def test_explicit_width_at_the_floor_does_not_warn(self, tmp_path, capsys):
+        from kicad_tools.cli import route_cmd
+
+        args = self._args(copper="2", trace_width=0.1524)
+        route_cmd._apply_manufacturer_trace_width_floor(args, self._pcb(tmp_path))
+        assert "WARNING" not in capsys.readouterr().err
+
+    def test_explicit_min_trace_below_the_floor_warns(self, tmp_path, capsys):
+        from kicad_tools.cli import route_cmd
+
+        args = self._args(copper="2", min_trace=0.127)
+        route_cmd._apply_manufacturer_trace_width_floor(args, self._pcb(tmp_path))
+        # User override wins, but the divergence is announced.
+        assert args.min_trace == 0.127
+        err = capsys.readouterr().err
+        assert "--min-trace" in err
+        assert "dimension_trace_width" in err
+
+    def test_net_class_widths_are_reported_never_rewritten(self, tmp_path, capsys):
+        from kicad_tools.cli import route_cmd
+        from kicad_tools.router.rules import NetClassRouting
+
+        ncm = {"DP": NetClassRouting(name="DIFFERENTIAL", trace_width=0.15)}
+        args = self._args(copper="2", _loaded_net_class_map=ncm)
+        route_cmd._apply_manufacturer_trace_width_floor(args, self._pcb(tmp_path))
+
+        assert ncm["DP"].trace_width == 0.15  # user data untouched
+        err = capsys.readouterr().err
+        assert "DIFFERENTIAL" in err
+        assert "dimension_trace_width" in err
+
+    def test_no_manufacturer_is_a_complete_no_op(self, tmp_path, capsys):
+        from kicad_tools.cli import route_cmd
+
+        args = self._args(manufacturer=None, copper=None)
+        route_cmd._apply_manufacturer_trace_width_floor(args, self._pcb(tmp_path))
+        assert args.trace_width == 0.2
+        assert args.min_trace is None
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert captured.err == ""
+
+    def test_unknown_manufacturer_degrades_gracefully(self, tmp_path):
+        from kicad_tools.cli import route_cmd
+
+        args = self._args(manufacturer="not-a-fab")
+        assert route_cmd._apply_manufacturer_trace_width_floor(args, self._pcb(tmp_path)) == 0
+        assert args.trace_width == 0.2
+        assert args.min_trace is None
+
+    def test_malformed_copper_exits_1(self, tmp_path, capsys):
+        from kicad_tools.cli import route_cmd
+
+        args = self._args(copper="bogus")
+        assert route_cmd._apply_manufacturer_trace_width_floor(args, self._pcb(tmp_path)) == 1
+        assert "Error:" in capsys.readouterr().err
+
+    def test_keyed_copper_form_parses_like_check(self, tmp_path):
+        from kicad_tools.cli import route_cmd
+        from kicad_tools.cli.check_cmd import _parse_copper_weight_arg
+
+        assert _parse_copper_weight_arg("outer=2,inner=0.5") == (2.0, 0.5)
+        args = self._args(copper="outer=2,inner=0.5")
+        route_cmd._apply_manufacturer_trace_width_floor(args, self._pcb(tmp_path))
+        assert args.copper_oz == 2.0
+        assert args._copper_oz_inner == 0.5
+        assert args.min_trace == pytest.approx(0.1524)
+
+    def test_layer_count_drives_the_1oz_floor(self, tmp_path):
+        from kicad_tools.cli import route_cmd
+
+        two = self._args(layers="2")
+        route_cmd._apply_manufacturer_trace_width_floor(two, self._pcb(tmp_path))
+        four = self._args(layers="4-sig")
+        route_cmd._apply_manufacturer_trace_width_floor(four, self._pcb(tmp_path))
+        assert two.min_trace == pytest.approx(0.127)
+        assert four.min_trace == pytest.approx(0.1016)
+
+
+class TestRouteCopperFlagPlumbing:
+    """Issue #4700: `kct route --copper` exists and forwards verbatim."""
+
+    def test_parser_accepts_copper_scalar_and_keyed(self):
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        assert parser.parse_args(["route", "b.kicad_pcb", "--copper", "2"]).copper == "2"
+        keyed = parser.parse_args(["route", "b.kicad_pcb", "--copper", "outer=2,inner=0.5"])
+        assert keyed.copper == "outer=2,inner=0.5"
+
+    def test_copper_default_is_none(self):
+        from kicad_tools.cli.parser import create_parser
+
+        assert create_parser().parse_args(["route", "b.kicad_pcb"]).copper is None
+
+    def test_route_help_documents_the_floor_behavior(self):
+        import contextlib
+        from io import StringIO
+
+        from kicad_tools.cli.parser import create_parser
+
+        parser = create_parser()
+        help_output = StringIO()
+        with contextlib.redirect_stdout(help_output), contextlib.suppress(SystemExit):
+            parser.parse_args(["route", "--help"])
+
+        help_text = help_output.getvalue()
+        assert "--copper" in help_text
+        # The warn-not-error contract is documented in --help per #4700.
+        assert "dimension_trace_width" in help_text
+
+    def test_forwarder_omits_unset_trace_width(self):
+        """The None sentinel must not be forwarded as the string 'None'."""
+        from kicad_tools.cli.commands.routing import run_route_command
+
+        args = _route_forward_args(trace_width=None)
+        with patch("kicad_tools.cli.route_cmd.main", return_value=0) as mock_main:
+            run_route_command(args)
+        sub_argv = mock_main.call_args[0][0]
+        assert "--trace-width" not in sub_argv
+
+    def test_forwarder_passes_explicit_trace_width_and_copper(self):
+        from kicad_tools.cli.commands.routing import run_route_command
+
+        args = _route_forward_args(trace_width=0.15, copper="2")
+        with patch("kicad_tools.cli.route_cmd.main", return_value=0) as mock_main:
+            run_route_command(args)
+        sub_argv = mock_main.call_args[0][0]
+        assert sub_argv[sub_argv.index("--trace-width") + 1] == "0.15"
+        assert sub_argv[sub_argv.index("--copper") + 1] == "2"

--- a/tests/test_router_io.py
+++ b/tests/test_router_io.py
@@ -31,6 +31,7 @@ from kicad_tools.router.io import (
     validate_routes,
 )
 from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.mfr_limits import resolve_min_trace_width
 from kicad_tools.router.pathfinder import Router
 from kicad_tools.router.primitives import Pad, Route, Segment, Via
 from kicad_tools.router.rules import (
@@ -4278,3 +4279,219 @@ class TestExtractBoardDimensionsGrLine:
         assert dims is not None
         assert dims[0] == pytest.approx(65.0)
         assert dims[1] == pytest.approx(56.0)
+
+
+# --- Issue #4700: route -> check trace-width parity -------------------------
+
+# Two pads on net DIFF_P.  The auto-classifier assigns that name the built-in
+# ``Differential`` class, whose library-default ``trace_width`` is 0.15mm --
+# BELOW jlcpcb's 0.1524mm floor at 2oz copper, and the exact 0.150mm emission
+# the reporter measured 63 times.  Placed well inboard of a 20x20 outline so a
+# single straight segment routes deterministically in well under a second.
+_PARITY_PCB_TWO_PADS = """  (footprint "Resistor_SMD:R_0805"
+    (layer "F.Cu")
+    (at 4 10)
+    (fp_text reference "R1" (at 0 -2) (layer "F.SilkS"))
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 1 "DIFF_P"))
+  )
+  (footprint "Resistor_SMD:R_0805"
+    (layer "F.Cu")
+    (at 14 10)
+    (fp_text reference "R2" (at 0 -2) (layer "F.SilkS"))
+    (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 1 "DIFF_P"))
+  )
+"""
+
+
+def _write_parity_pcb(tmp_path, name="parity"):
+    return _write_edge_pcb(tmp_path, name=f"{name}_in.kicad_pcb", extra=_PARITY_PCB_TWO_PADS)
+
+
+def _route_for_parity(tmp_path, *, extra_argv=(), name="parity"):
+    """Route the DIFF_P fixture at jlcpcb / 2oz and return the routed PCB."""
+    from kicad_tools.cli import route_cmd
+
+    pcb_file = _write_parity_pcb(tmp_path, name=name)
+    out_file = tmp_path / f"{name}_out.kicad_pcb"
+    rc = route_cmd.main(
+        [
+            str(pcb_file),
+            "-o",
+            str(out_file),
+            "--manufacturer",
+            "jlcpcb",
+            "--copper",
+            "2",
+            "--layers",
+            "2",
+            "--skip-drc",
+            "--quiet",
+            *extra_argv,
+        ]
+    )
+    assert rc == 0, f"route failed with exit {rc}"
+    return out_file
+
+
+def _trace_width_violations(pcb_path, *, layers=2, copper_oz=2.0, manufacturer="jlcpcb"):
+    """Run the same rule `kct check --mfr` runs and return its width errors."""
+    from kicad_tools.schema.pcb import PCB
+    from kicad_tools.validate import DRCChecker
+
+    results = DRCChecker(
+        PCB.load(str(pcb_path)),
+        manufacturer=manufacturer,
+        layers=layers,
+        copper_oz=copper_oz,
+    ).check_all()
+    return [v for v in results.violations if v.rule_id == "dimension_trace_width"]
+
+
+class TestRouteCheckTraceWidthParity:
+    """Issue #4700: copper from `route --manufacturer X` passes `check --mfr X`.
+
+    The reporter's invariant (item 3): both commands read a manufacturer
+    profile, so any ``dimension_trace_width`` divergence between them is a
+    tooling bug by construction.  ``route`` used to floor at the
+    layer/copper-agnostic ``MfrLimits.min_trace`` (jlcpcb 0.127mm) while
+    ``check`` enforces the per-``<layers>layer_<oz>oz`` ``min_trace_width_mm``
+    (0.1524mm at 2oz), so route emitted copper its own check rejected.
+    """
+
+    def test_routed_copper_passes_the_matching_check(self, tmp_path):
+        """The reporter's scenario: no --trace-width, jlcpcb, 2oz copper.
+
+        The routed net classifies as ``Differential`` (library default
+        0.15mm), so pre-fix this emitted 0.150mm copper -- exactly the
+        reported ``Trace width 0.150mm < minimum 0.152mm`` error.
+        """
+        out_file = _route_for_parity(tmp_path)
+
+        from kicad_tools.schema.pcb import PCB
+
+        segments = PCB.load(str(out_file)).segments
+        assert segments, "fixture must actually emit copper for this to mean anything"
+
+        floor = resolve_min_trace_width("jlcpcb", 2, 2.0)
+        assert floor == pytest.approx(0.1524)
+        assert min(seg.width for seg in segments) >= floor
+        assert _trace_width_violations(out_file) == []
+
+    def test_naive_min_trace_floor_would_not_have_fixed_it(self, tmp_path, monkeypatch):
+        """A floor sourced from ``MfrLimits.min_trace`` is a SILENT NO-OP.
+
+        This is the trap: 0.127mm is below the 0.150mm the ``Differential``
+        class emits, so nothing is raised and the reporter's errors survive.
+        Pinning it here keeps a future refactor from "simplifying"
+        ``resolve_min_trace_width`` back onto ``MfrLimits.min_trace``.
+        """
+        from kicad_tools.cli import route_cmd
+        from kicad_tools.router.mfr_limits import MFR_JLCPCB
+
+        monkeypatch.setattr(
+            "kicad_tools.router.mfr_limits.resolve_min_trace_width",
+            lambda *a, **k: MFR_JLCPCB.min_trace,
+        )
+        assert MFR_JLCPCB.min_trace == pytest.approx(0.127)
+
+        pcb_file = _write_parity_pcb(tmp_path, name="naive")
+        out_file = tmp_path / "naive_out.kicad_pcb"
+        assert (
+            route_cmd.main(
+                [
+                    str(pcb_file),
+                    "-o",
+                    str(out_file),
+                    "--manufacturer",
+                    "jlcpcb",
+                    "--copper",
+                    "2",
+                    "--layers",
+                    "2",
+                    "--skip-drc",
+                    "--quiet",
+                ]
+            )
+            == 0
+        )
+
+        from kicad_tools.schema.pcb import PCB
+
+        assert min(s.width for s in PCB.load(str(out_file)).segments) == pytest.approx(0.15)
+        violations = _trace_width_violations(out_file)
+        assert violations, "the naive floor must reproduce the reported failure"
+        assert violations[0].actual_value == pytest.approx(0.15)
+        assert violations[0].required_value == pytest.approx(0.1524)
+
+    def test_sub_floor_width_is_warned_about_at_route_time(self, tmp_path, capsys):
+        """An explicit sub-floor width is announced, not silently emitted."""
+        _route_for_parity(tmp_path, extra_argv=("--trace-width", "0.15"), name="warned")
+        err = capsys.readouterr().err
+        assert "WARNING" in err
+        assert "0.1524" in err
+        assert "dimension_trace_width" in err
+
+    def test_no_manufacturer_floor_keeps_library_widths(self, tmp_path):
+        """Without a resolvable floor the pre-#4700 class widths pass through."""
+        rules = DesignRules(grid_resolution=0.25)
+        router, _ = load_pcb_for_routing(
+            str(_write_parity_pcb(tmp_path, name="untouched")),
+            rules=rules,
+            validate_drc=False,
+        )
+        assert router.net_class_map["DIFF_P"].trace_width == pytest.approx(0.15)
+
+    def test_library_class_widths_are_raised_to_the_floor(self, tmp_path):
+        """``load_pcb_for_routing(min_trace_width_floor=...)`` clamps defaults."""
+        router, _ = load_pcb_for_routing(
+            str(_write_parity_pcb(tmp_path, name="clamped")),
+            rules=DesignRules(grid_resolution=0.25, manufacturer="jlcpcb"),
+            validate_drc=False,
+            min_trace_width_floor=0.1524,
+        )
+        assert router.net_class_map["DIFF_P"].trace_width == pytest.approx(0.1524)
+        # Classes already above the floor are untouched (no widening).
+        assert router.net_class_map["GND"].trace_width == pytest.approx(0.5)
+
+    def test_parity_holds_for_every_manufacturer_at_1oz_and_2oz(self, tmp_path):
+        """By construction: the resolved route width clears each tier's floor.
+
+        Runs the CLI's own resolution (not a reimplementation) for every
+        manufacturer in ``MFR_LIMITS`` and asserts the width it would route
+        with -- and every relaxation tier below it -- is at or above the floor
+        ``kct check --mfr`` enforces for that layers/copper key.
+        """
+        from argparse import Namespace
+
+        from kicad_tools.cli import route_cmd
+        from kicad_tools.router.mfr_limits import MFR_LIMITS, get_relaxation_tiers
+
+        pcb_file = _write_parity_pcb(tmp_path, name="parity_matrix")
+
+        for mfr in MFR_LIMITS:
+            for copper, layers in ((1.0, 2), (2.0, 2), (1.0, 4), (2.0, 4)):
+                args = Namespace(
+                    manufacturer=mfr,
+                    copper=str(copper),
+                    layers=str(layers),
+                    trace_width=None,
+                    min_trace=None,
+                    quiet=True,
+                    _loaded_net_class_map=None,
+                )
+                assert route_cmd._apply_manufacturer_trace_width_floor(args, pcb_file) == 0
+
+                floor = resolve_min_trace_width(mfr, layers, copper)
+                assert floor is not None
+                assert args.trace_width >= floor, (mfr, copper, layers)
+                assert args._mfr_min_trace_floor == pytest.approx(floor)
+
+                tiers = get_relaxation_tiers(
+                    initial_trace_width=args.trace_width,
+                    initial_clearance=0.4,
+                    initial_via_drill=0.3,
+                    initial_via_diameter=0.6,
+                    manufacturer=mfr,
+                    min_trace_floor=args.min_trace,
+                )
+                assert all(t.trace_width >= floor - 1e-9 for t in tiers), (mfr, copper, layers)


### PR DESCRIPTION
## Summary

`kct route --manufacturer jlcpcb` emitted **0.150 mm** copper that the matching
`kct check --mfr jlcpcb --copper 2` rejected with 63 identical
`dimension_trace_width` errors. The two commands read *different* manufacturer
data: route floored at `MfrLimits.min_trace` (0.127 mm — layer- and
copper-weight-agnostic) while check enforces the per-`<layers>layer_<oz>oz`
`min_trace_width_mm` from the YAML profile (jlcpcb `4layer_2oz` / `2layer_2oz`
= **0.1524 mm**).

**Root cause of the exact 0.150 mm emission** (the curator's suspected-cause
list, now confirmed): it did **not** come from `--trace-width` at all. The
built-in `Differential` net class (`net_class.py`, `trace_width=0.15`) is
assigned by the auto-classifier and *wins over* `rules.trace_width` at
emission time (`core.py:3035`). So flooring only the CLI default would have
left the reported failure completely intact — as would the naive
`MfrLimits.min_trace` (0.127) mirror of #4568, which is below 0.150 and
therefore a silent no-op. Both traps are pinned by tests.

## Changes

- **`router/mfr_limits.py`** — new `resolve_min_trace_width(manufacturer,
  layers, copper_oz)` alongside `resolve_edge_clearance`, delegating to
  `get_profile(...).get_design_rules(...).min_trace_width_mm`. Same graceful
  degradation contract (falsy/unknown → `None`, never raises); lazy import to
  avoid a router→manufacturers cycle.
- **`cli/copper_weight.py`** (new) — `parse_copper_weight_arg` moved verbatim
  out of `check_cmd` so route and check share one grammar.
  `check_cmd._parse_copper_weight_arg` remains as an alias (existing importers
  unchanged).
- **`kct route --copper OZ`** — scalar or `outer=/inner=` keyed, same grammar
  as `kct check`. Precedence: explicit flag > board `(setup (stackup ...))` >
  1 oz. Forwarded verbatim by the outer→inner argv bridge.
- **`--trace-width` sentinel** — `default=None`, auto-filled to
  `max(0.2, floor)`; announced once when the floor actually binds. Every
  consumer reads it through `_effective_trace_width(args)` so no path can see
  `None`.
- **Warn-never-rewrite guards (stderr, not suppressed by `--quiet`, exit code
  unchanged)** — explicit sub-floor `--trace-width`, sub-floor `--min-trace`,
  and sub-floor *authored* net-class widths each name the given value, the
  floor, the `<layers>-layer <oz>oz` key, and `dimension_trace_width`.
- **`load_pcb_for_routing(min_trace_width_floor=...)`** — raises the built-in +
  auto-classified net-class widths (`Differential` 0.15 → 0.1524) to the floor.
  Caller-supplied classes merge in later and are never rewritten. Also read
  from the new `DesignRules.min_trace_width_floor`, which `kct route` sets.
- **Relaxation ladder** — the resolved floor fills `--min-trace`, so
  `--complete` / `--adaptive-rules` tiers can no longer interpolate down
  through 0.1524. `get_relaxation_tiers` clamps with
  `max(min_trace_floor, mfr.min_trace)`, so this only ever raises the ladder.
- **Copper-weight plumbing** — the resolved outer oz now reaches
  `_resolve_mfr_design_rules` (previously a dead `getattr(args, "copper_oz")`),
  all four `run_post_route_drc` call sites, and the `.kicad_pro` / `.kicad_dru`
  sidecars.
- **Routing cache key** — includes the floor when set (#4602 pattern). Without
  this a `--copper 1` entry is served to a `--copper 2` run and hands back the
  narrower copper; this was observed live during development. Absent floor →
  keys byte-identical.

## Acceptance Criteria Verification

- [x] `route --manufacturer jlcpcb --copper 2` emits nothing below 0.1524 mm
      and the matching check reports zero `dimension_trace_width` —
      `TestRouteCheckTraceWidthParity::test_routed_copper_passes_the_matching_check`
      routes a real board and runs the real `DRCChecker`.
- [x] Unset `--trace-width` resolves `max(0.2, floor)`, printed once —
      `test_unset_width_is_raised_to_the_2oz_floor`,
      `test_binding_floor_raises_the_default_and_announces_it`.
- [x] Explicit sub-floor width warns with both values, the key, and the rule
      id; warn-vs-error documented in `--help` —
      `test_explicit_sub_floor_width_warns_but_is_honored`,
      `test_route_help_documents_the_floor_behavior`.
- [x] `--complete` relaxation never emits a sub-floor tier —
      `TestRelaxationLadderRespectsCheckSideFloor` (incl. the pre-fix baseline
      showing the unfloored ladder *does* dip below 0.1524).
- [x] No behavior change without `--manufacturer` —
      `test_no_manufacturer_is_a_complete_no_op`,
      `test_no_manufacturer_floor_keeps_library_widths`.
- [x] Resolver unit tests incl. 1 oz vs 2 oz vs `4layer_1oz`=0.1016 and
      unknown → `None` — `TestResolveMinTraceWidth`.
- [x] Parity invariant across every `MFR_LIMITS` entry at 1 oz and 2 oz —
      `test_parity_holds_for_every_manufacturer_at_1oz_and_2oz`,
      `test_every_known_manufacturer_resolves_a_positive_floor`.

**Anti-no-op proof** (the curator's explicit warning):
`test_jlcpcb_2oz_floor_exceeds_mfr_limits_min_trace` asserts the resolved floor
is strictly above both `MfrLimits.min_trace` (0.127) and the reported 0.150;
`test_naive_min_trace_floor_would_not_have_fixed_it` monkeypatches the resolver
back to `MfrLimits.min_trace`, routes, and asserts the board comes back at
0.150 mm with `actual_value=0.15 / required_value=0.1524` — i.e. it reproduces
the reported failure exactly.

## Test Plan

- `tests/test_mfr_limits.py` +21, `tests/test_route_cmd_params.py` +17,
  `tests/test_router_io.py` +6 — all green (348 in those three files).
- Revert-check: with `src/` reset to the parent commit, all 17 new CLI tests
  fail and the other two files fail at collection (`resolve_min_trace_width`
  does not exist). Restored and re-verified green.
- Regression: `tests/router/` 1163 passed / 5 skipped; `-k "cache or net_class
  or route_cmd or check_cmd or routing_command or design_rules"` 949 passed /
  2 skipped; `test_cli_check_ampacity_stackup.py`, `test_cli_parser_drift.py`
  green.
- `ruff check` + `ruff format --check` clean across `src/` and `tests/`;
  `scripts/ci/check_mypy_baseline.py` exits 0 (1473 ≤ 1475; baseline left
  untouched deliberately — `--update` in a native-built worktree drops the
  env-agnostic nanobind line).

## Notes for review

- `kct build` (`build_cmd._get_routing_params`) derives its trace width from
  `get_design_rules(layers=2)` at 1 oz and passes it explicitly to route; it
  is now covered by the sub-floor **warning** rather than being silently
  wrong. Deliberately not changed here (out of the issue's affected-file set).
- Layer count for the floor lookup comes from `--layers` (or board detection
  for `auto`), resolved before layer escalation. On the jlcpcb tiers only the
  2 oz rows exceed the 0.2 default, so an escalation-time layer change cannot
  lower an already-applied floor.

Closes #4700
