### PR TITLE
feat(cli): add --format json to the 16 mutating sch subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   With no flag and no sidecar present, output and exit codes are unchanged.
   Replaces the downstream `drc_waivers.py` re-implementation in
   project-shamrock/chorus.
+- **`--format json` on the 16 mutating `kct sch` subcommands** (part of
+  #4674, second batch of the #4543 machine-output sweep) — `sch
+  add-bypass-cap`, `add-component`, `add-junction`, `add-label`,
+  `add-no-connect`, `add-pull-resistor`, `add-wire`, `disconnect`,
+  `insert-inline`, `reconnect-pin`, `replace`, `set-footprint`,
+  `set-label-direction`, `set-reference`, `set-symbol-property` and
+  `set-value` now accept the canonical `--format json` and emit one
+  deterministic change-summary document on stdout
+  (`{"command", "schematic", "dry_run", "success", ...}`) instead of prose.
+  Each of the 16 lives in its own inner module, so they share a new
+  wrapper (`cli/sch_json.py`) that brackets the existing prose
+  implementation rather than rewriting 16 report writers: prose is
+  captured and discarded, `record(...)` accumulates the per-command
+  summary, and captured stderr is replayed after the document (and
+  becomes the `error` value on failure). Exit codes and text-mode output
+  are unchanged. The `sch` shim's own "file not found" guard now emits
+  the same `{"error": ...}` document. Audit
+  (`scripts/audit_machine_output.py`): prose-only 49 → 33,
+  format-json 148 → 164.
 - **`kct check` now detects isolated copper natively: `isolated_copper`**
   (closes #4680, second slice — the dangling pair shipped separately
   below) — a new `IsolatedCopperRule` (`validate/rules/zone_fill.py`,

--- a/docs/reference/machine-output.md
+++ b/docs/reference/machine-output.md
@@ -52,20 +52,22 @@ below is issue **#4674** and should build on these helpers.
 Measured by programmatic introspection of the real argparse tree
 (`create_parser()`, recursive walk of `_SubParsersAction` leaves) — not grep:
 
-| Idiom (outer `kct` parser) | Before #4543 | After #4543 | After #4674 batch 1 |
-|---|---|---|---|
-| `--format` with a `json` choice | 124 | 124 | 148 |
-| Both `--format json` and legacy `--json` alias | 0 | 2 (`placement refine`, `calibrate`) | 2 |
-| `--json` boolean only | 2 | **0** | 0 |
-| `--format` without a `json` choice | 1 (`benchmark report`, `text,markdown`) | 1 | **0** |
-| Neither (prose-only) | 72 | 72 (backlog for #4674, below) | 49 |
+| Idiom (outer `kct` parser) | Before #4543 | After #4543 | After #4674 b1 | After #4674 b2 |
+|---|---|---|---|---|
+| `--format` with a `json` choice | 124 | 124 | 148 | 164 |
+| Both `--format json` and legacy `--json` alias | 0 | 2 (`placement refine`, `calibrate`) | 2 | 2 |
+| `--json` boolean only | 2 | **0** | 0 | 0 |
+| `--format` without a `json` choice | 1 (`benchmark report`, `text,markdown`) | 1 | **0** | 0 |
+| Neither (prose-only) | 72 | 72 (backlog for #4674, below) | 49 | 33 |
 
 The first #4674 batch swept the grouped-subcommand families -- `mfr` (7),
 `spec` (5), `placement fix/nudge/snap/align/distribute` (5), `zones
 add/batch/fill/hv-keepout` (4), `benchmark run/compare` (2) -- and added the
 `json` choice to `benchmark report`, closing the `format-nojson` bucket.
-The remaining 49 prose-only leaves (the 16 `sch` mutating commands, `stitch`,
-and the long tail of single commands) stay on the #4674 backlog below.
+
+The second batch swept the 16 mutating `sch` leaves. The remaining 33
+prose-only leaves (`stitch` and the long tail of single commands, plus the 4
+exempt and the deferred `route`) stay on the #4674 backlog below.
 
 Issue #4543 closed the `--json`-only bucket by adding `--format {text,json}`
 alongside the existing `--json` on both commands (outer parser, forwarding
@@ -133,7 +135,40 @@ commands should emit a JSON change-summary (precedent: `kct sch tidy`,
 `benchmark report` (the former `format-nojson` holdout).
 `tests/test_format_json_sweep.py` guards these surfaces.
 
-**Remaining actionable (44)** — the audit's `prose-only` bucket reads 49
+**Done (second #4674 batch, 16 surfaces):** the mutating `sch` family --
+`add-bypass-cap`, `add-component`, `add-junction`, `add-label`,
+`add-no-connect`, `add-pull-resistor`, `add-wire`, `disconnect`,
+`insert-inline`, `reconnect-pin`, `replace`, `set-footprint`,
+`set-label-direction`, `set-reference`, `set-symbol-property`, `set-value`.
+
+Unlike the grouped families, each of these lives in its own inner module, so
+they share one wrapper -- `src/kicad_tools/cli/sch_json.py` -- rather than 16
+hand-written JSON writers. It brackets the existing prose implementation:
+in JSON mode the prose is captured and discarded, the inner module's
+`record(...)` / `append(...)` calls accumulate the per-command change
+summary, and exactly one document is printed. Captured stderr is replayed
+after the document (and becomes the `error` value when the exit code is
+non-zero), so the exit codes and the diagnostics both survive unchanged.
+The shared envelope is:
+
+```json
+{
+  "command": "add-junction",
+  "schematic": "board.kicad_sch",
+  "dry_run": true,
+  "success": true
+}
+```
+
+plus the command's own keys (e.g. `changed` / `not_found` / `files_modified`
+for the `set-*` batch commands, `planned` / `placed` for the `add-*`
+placement commands). `commands/schematic.py`'s own "file not found" guard
+runs before any inner module, so it emits the same `{"error": ...}` document
+itself. `tests/test_format_json_sweep_sch.py` guards these 16 surfaces
+(outer flag, both shim shapes, emission, determinism, error documents, and
+that `--dry-run` still writes nothing).
+
+**Remaining actionable (28)** — the audit's `prose-only` bucket reads 33
 because it also counts the 4 exempt commands and the deferred `route`
 (sections above):
 
@@ -148,11 +183,6 @@ because it also counts the 4 exempt commands and the deferred `route`
 - `pcb export-dsn`, `pcb import-ses`
 - `pipeline`
 - `reason`, `report generate`, `route-auto`
-- `sch add-bypass-cap`, `sch add-component`, `sch add-junction`,
-  `sch add-label`, `sch add-no-connect`, `sch add-pull-resistor`,
-  `sch add-wire`, `sch disconnect`, `sch insert-inline`, `sch reconnect-pin`,
-  `sch replace`, `sch set-footprint`, `sch set-label-direction`,
-  `sch set-reference`, `sch set-symbol-property`, `sch set-value`
 - `screenshot`
 - `stitch` (single command, but its 6k-line inner module has a bespoke
   multi-phase report — batch it alone)

--- a/src/kicad_tools/cli/commands/schematic.py
+++ b/src/kicad_tools/cli/commands/schematic.py
@@ -34,7 +34,16 @@ def run_sch_command(args) -> int:
 
     schematic_path = Path(args.schematic)
     if not schematic_path.exists():
-        print(f"Error: File not found: {schematic_path}", file=sys.stderr)
+        message = f"Error: File not found: {schematic_path}"
+        # The shim's own guard runs before any inner module, so it has to
+        # honour --format json itself (#4674) -- otherwise the one error every
+        # sch leaf can hit is the one error that never produces a document.
+        if getattr(args, "format", None) == "json":
+            from ..format_options import emit_json
+
+            emit_json({"command": args.sch_command, "error": message, "success": False})
+        else:
+            print(message, file=sys.stderr)
         return 1
 
     if args.sch_command == "summary":
@@ -181,6 +190,7 @@ def run_sch_command(args) -> int:
             backup=getattr(args, "backup", True),
             validate=getattr(args, "validate", True),
             strict=getattr(args, "strict", False),
+            output_format=getattr(args, "format", "text"),
         )
 
     elif args.sch_command == "suggest-footprint":
@@ -223,6 +233,7 @@ def run_sch_command(args) -> int:
             map_path=map_path,
             dry_run=getattr(args, "dry_run", False),
             backup=getattr(args, "backup", True),
+            output_format=getattr(args, "format", "text"),
         )
 
     elif args.sch_command == "set-reference":
@@ -236,6 +247,7 @@ def run_sch_command(args) -> int:
             map_path=map_path,
             dry_run=getattr(args, "dry_run", False),
             backup=getattr(args, "backup", True),
+            output_format=getattr(args, "format", "text"),
         )
 
     elif args.sch_command == "set-symbol-property":
@@ -248,6 +260,7 @@ def run_sch_command(args) -> int:
             value=args.value,
             dry_run=getattr(args, "dry_run", False),
             backup=getattr(args, "backup", True),
+            output_format=getattr(args, "format", "text"),
         )
 
     elif args.sch_command == "replace":
@@ -262,6 +275,8 @@ def run_sch_command(args) -> int:
             sub_argv.append("--dry-run")
         if args.backup:
             sub_argv.append("--backup")
+        if getattr(args, "format", "text") != "text":
+            sub_argv.extend(["--format", args.format])
         return replace_main(sub_argv) or 0
 
     elif args.sch_command == "sync-hierarchy":
@@ -308,6 +323,8 @@ def run_sch_command(args) -> int:
             sub_argv.append("--dry-run")
         if args.backup:
             sub_argv.append("--backup")
+        if getattr(args, "format", "text") != "text":
+            sub_argv.extend(["--format", args.format])
         return set_label_dir_main(sub_argv) or 0
 
     elif args.sch_command == "add-no-connect":
@@ -330,6 +347,8 @@ def run_sch_command(args) -> int:
             sub_argv.append("--dry-run")
         if args.backup:
             sub_argv.append("--backup")
+        if getattr(args, "format", "text") != "text":
+            sub_argv.extend(["--format", args.format])
         return add_nc_main(sub_argv) or 0
 
     elif args.sch_command == "add-component":
@@ -360,6 +379,8 @@ def run_sch_command(args) -> int:
             sub_argv.append("--dry-run")
         if args.backup:
             sub_argv.append("--backup")
+        if getattr(args, "format", "text") != "text":
+            sub_argv.extend(["--format", args.format])
         return add_comp_main(sub_argv) or 0
 
     elif args.sch_command == "add-bypass-cap":
@@ -379,6 +400,8 @@ def run_sch_command(args) -> int:
             sub_argv.append("--dry-run")
         if args.backup:
             sub_argv.append("--backup")
+        if getattr(args, "format", "text") != "text":
+            sub_argv.extend(["--format", args.format])
         return add_bypass_main(sub_argv) or 0
 
     elif args.sch_command == "add-pull-resistor":
@@ -407,6 +430,8 @@ def run_sch_command(args) -> int:
             sub_argv.append("--backup")
         if args.force:
             sub_argv.append("--force")
+        if getattr(args, "format", "text") != "text":
+            sub_argv.extend(["--format", args.format])
         return add_pull_main(sub_argv) or 0
 
     elif args.sch_command == "add-wire":
@@ -422,6 +447,8 @@ def run_sch_command(args) -> int:
             sub_argv.append("--dry-run")
         if args.backup:
             sub_argv.append("--backup")
+        if getattr(args, "format", "text") != "text":
+            sub_argv.extend(["--format", args.format])
         return add_wire_main(sub_argv) or 0
 
     elif args.sch_command == "add-junction":
@@ -433,6 +460,8 @@ def run_sch_command(args) -> int:
             sub_argv.append("--dry-run")
         if args.backup:
             sub_argv.append("--backup")
+        if getattr(args, "format", "text") != "text":
+            sub_argv.extend(["--format", args.format])
         return add_junc_main(sub_argv) or 0
 
     elif args.sch_command == "add-label":
@@ -451,6 +480,8 @@ def run_sch_command(args) -> int:
             sub_argv.append("--dry-run")
         if args.backup:
             sub_argv.append("--backup")
+        if getattr(args, "format", "text") != "text":
+            sub_argv.extend(["--format", args.format])
         return add_label_main(sub_argv) or 0
 
     elif args.sch_command == "cleanup-wires":
@@ -522,6 +553,8 @@ def run_sch_command(args) -> int:
             sub_argv.append("--dry-run")
         if args.backup:
             sub_argv.append("--backup")
+        if getattr(args, "format", "text") != "text":
+            sub_argv.extend(["--format", args.format])
         return insert_inline_main(sub_argv) or 0
 
     elif args.sch_command == "disconnect":
@@ -540,6 +573,8 @@ def run_sch_command(args) -> int:
             sub_argv.append("--dry-run")
         if args.backup:
             sub_argv.append("--backup")
+        if getattr(args, "format", "text") != "text":
+            sub_argv.extend(["--format", args.format])
         return disconnect_main(sub_argv) or 0
 
     elif args.sch_command == "reconnect-pin":
@@ -564,6 +599,8 @@ def run_sch_command(args) -> int:
             sub_argv.append("--dry-run")
         if args.backup:
             sub_argv.append("--backup")
+        if getattr(args, "format", "text") != "text":
+            sub_argv.extend(["--format", args.format])
         return reconnect_pin_main(sub_argv) or 0
 
     elif args.sch_command == "move-component":

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -1082,6 +1082,7 @@ def _add_sch_parser(subparsers) -> None:
     sch_replace.add_argument("--footprint", help="New footprint")
     sch_replace.add_argument("--dry-run", action="store_true", help="Show changes without applying")
     sch_replace.add_argument("--backup", action="store_true", help="Create backup before modifying")
+    add_format_flag(sch_replace)
 
     # sch set-footprint
     sch_set_fp = sch_subparsers.add_parser(
@@ -1113,6 +1114,7 @@ def _add_sch_parser(subparsers) -> None:
         action="store_true",
         help="Fail on any pin-count mismatch, even in batch mode",
     )
+    add_format_flag(sch_set_fp)
 
     # sch assign-footprints
     sch_assign_fp = sch_subparsers.add_parser(
@@ -1229,6 +1231,7 @@ def _add_sch_parser(subparsers) -> None:
         "--dry-run", "-n", action="store_true", help="Preview changes without modifying files"
     )
     sch_set_val.add_argument("--backup", action="store_true", help="Create backup before modifying")
+    add_format_flag(sch_set_val)
 
     # sch set-reference
     sch_set_ref = sch_subparsers.add_parser(
@@ -1246,6 +1249,7 @@ def _add_sch_parser(subparsers) -> None:
         "--dry-run", "-n", action="store_true", help="Preview changes without modifying files"
     )
     sch_set_ref.add_argument("--backup", action="store_true", help="Create backup before modifying")
+    add_format_flag(sch_set_ref)
 
     # sch set-symbol-property
     sch_set_prop = sch_subparsers.add_parser(
@@ -1267,6 +1271,7 @@ def _add_sch_parser(subparsers) -> None:
     sch_set_prop.add_argument(
         "--backup", action="store_true", help="Create backup before modifying"
     )
+    add_format_flag(sch_set_prop)
 
     # sch sync-hierarchy
     sch_sync = sch_subparsers.add_parser(
@@ -1342,6 +1347,7 @@ def _add_sch_parser(subparsers) -> None:
     sch_set_label_dir.add_argument(
         "--backup", action="store_true", help="Create backup before modifying"
     )
+    add_format_flag(sch_set_label_dir)
     # sch add-no-connect
     sch_add_nc = sch_subparsers.add_parser("add-no-connect", help="Add no-connect markers to pins")
     sch_add_nc.add_argument("schematic", help="Path to .kicad_sch file")
@@ -1358,6 +1364,7 @@ def _add_sch_parser(subparsers) -> None:
         "--dry-run", "-n", action="store_true", help="Preview without modifying"
     )
     sch_add_nc.add_argument("--backup", action="store_true", help="Create backup before modifying")
+    add_format_flag(sch_add_nc)
 
     # sch add-component
     sch_add_comp = sch_subparsers.add_parser(
@@ -1403,6 +1410,7 @@ def _add_sch_parser(subparsers) -> None:
     sch_add_comp.add_argument(
         "--backup", action="store_true", help="Create backup before modifying"
     )
+    add_format_flag(sch_add_comp)
 
     # sch add-bypass-cap
     sch_add_bypass = sch_subparsers.add_parser(
@@ -1442,6 +1450,7 @@ def _add_sch_parser(subparsers) -> None:
     sch_add_bypass.add_argument(
         "--backup", action="store_true", help="Create backup before modifying"
     )
+    add_format_flag(sch_add_bypass)
 
     # sch add-pull-resistor
     sch_add_pull = sch_subparsers.add_parser(
@@ -1493,6 +1502,7 @@ def _add_sch_parser(subparsers) -> None:
     sch_add_pull.add_argument(
         "--force", action="store_true", help="Place even if collision detected"
     )
+    add_format_flag(sch_add_pull)
 
     # sch add-wire
     sch_add_wire = sch_subparsers.add_parser("add-wire", help="Add wire segments to the schematic")
@@ -1526,6 +1536,7 @@ def _add_sch_parser(subparsers) -> None:
     sch_add_wire.add_argument(
         "--backup", action="store_true", help="Create backup before modifying"
     )
+    add_format_flag(sch_add_wire)
 
     # sch add-junction
     sch_add_junc = sch_subparsers.add_parser("add-junction", help="Add a junction to the schematic")
@@ -1544,6 +1555,7 @@ def _add_sch_parser(subparsers) -> None:
     sch_add_junc.add_argument(
         "--backup", action="store_true", help="Create backup before modifying"
     )
+    add_format_flag(sch_add_junc)
 
     # sch add-label
     sch_add_label = sch_subparsers.add_parser(
@@ -1587,6 +1599,7 @@ def _add_sch_parser(subparsers) -> None:
     sch_add_label.add_argument(
         "--backup", action="store_true", help="Create backup before modifying"
     )
+    add_format_flag(sch_add_label)
 
     # sch cleanup-wires
     sch_cleanup = sch_subparsers.add_parser(
@@ -1710,6 +1723,7 @@ def _add_sch_parser(subparsers) -> None:
     sch_insert_inline.add_argument(
         "--backup", action="store_true", help="Create backup before modifying"
     )
+    add_format_flag(sch_insert_inline)
 
     # sch disconnect
     sch_disconnect = sch_subparsers.add_parser("disconnect", help="Disconnect a pin from its net")
@@ -1729,6 +1743,7 @@ def _add_sch_parser(subparsers) -> None:
     sch_disconnect.add_argument(
         "--backup", action="store_true", help="Create backup before modifying"
     )
+    add_format_flag(sch_disconnect)
 
     # sch reconnect-pin
     sch_reconnect_pin = sch_subparsers.add_parser(
@@ -1750,6 +1765,7 @@ def _add_sch_parser(subparsers) -> None:
     sch_reconnect_pin.add_argument(
         "--backup", action="store_true", help="Create backup before modifying"
     )
+    add_format_flag(sch_reconnect_pin)
 
     # sch move-component
     sch_move_component = sch_subparsers.add_parser(

--- a/src/kicad_tools/cli/sch_add_bypass_cap.py
+++ b/src/kicad_tools/cli/sch_add_bypass_cap.py
@@ -32,6 +32,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
+from kicad_tools.cli.sch_json import add_format_flag, record, run_with_json_summary
 from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
 from kicad_tools.schema import Schematic
 from kicad_tools.schema.instances import build_instance_path, find_project_name
@@ -383,6 +384,18 @@ def run_add_bypass_cap(args) -> int:
             )
             break
 
+    record(
+        target={"reference": args.ref, "pin": args.pin, "position": [pin_pos[0], pin_pos[1]]},
+        capacitor={
+            "reference": cap_reference,
+            "value": args.value,
+            "position": [cap_pos[0], cap_pos[1]],
+        },
+        ground={"net": args.ground_net, "position": [gnd_pos[0], gnd_pos[1]]},
+        planned=[{"kind": a.kind, "description": a.description} for a in planned],
+        placed=False,
+    )
+
     # --- Report planned actions ---
     if args.dry_run:
         print("DRY RUN - No changes will be made")
@@ -399,6 +412,7 @@ def run_add_bypass_cap(args) -> int:
     if args.backup:
         backup_path = f"{schematic_path}.backup-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
         shutil.copy2(schematic_path, backup_path)
+        record(backup=backup_path)
         print(f"Backup created: {backup_path}")
 
     # --- Apply changes ---
@@ -450,6 +464,8 @@ def run_add_bypass_cap(args) -> int:
 
     # 6. Save
     sch.save()
+
+    record(placed=True)
 
     print("\nBypass capacitor placed successfully:")
     print(f"  Reference: {cap_reference}")
@@ -556,8 +572,16 @@ def main(argv=None):
     parser.add_argument("--dry-run", "-n", action="store_true", help="Preview without modifying")
     parser.add_argument("--backup", action="store_true", help="Create backup before modifying")
 
+    add_format_flag(parser)
+
     args = parser.parse_args(argv)
-    return run_add_bypass_cap(args)
+    return run_with_json_summary(
+        "add-bypass-cap",
+        args.schematic,
+        lambda: run_add_bypass_cap(args),
+        output_format=args.format,
+        dry_run=args.dry_run,
+    )
 
 
 if __name__ == "__main__":

--- a/src/kicad_tools/cli/sch_add_component.py
+++ b/src/kicad_tools/cli/sch_add_component.py
@@ -37,6 +37,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
+from kicad_tools.cli.sch_json import add_format_flag, record, run_with_json_summary
 from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
 from kicad_tools.schema import LibraryManager, Schematic
 from kicad_tools.schema.instances import build_instance_path, find_project_name
@@ -458,6 +459,19 @@ def run_add_component(args) -> int:
                     )
                     break  # One junction per target point is enough
 
+    record(
+        lib_id=args.lib_id,
+        reference=args.reference or None,
+        value=args.value or None,
+        footprint=args.footprint or None,
+        position=[position[0], position[1]],
+        rotation=rotation,
+        mirror=mirror or None,
+        power_symbol=is_power,
+        planned=[{"kind": a.kind, "description": a.description} for a in planned],
+        placed=False,
+    )
+
     # --- Report planned actions ---
     if args.dry_run:
         print("DRY RUN - No changes will be made")
@@ -474,6 +488,7 @@ def run_add_component(args) -> int:
     if args.backup:
         backup_path = f"{schematic_path}.backup-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
         shutil.copy2(schematic_path, backup_path)
+        record(backup=backup_path)
         print(f"Backup created: {backup_path}")
 
     # --- Apply changes ---
@@ -565,6 +580,13 @@ def run_add_component(args) -> int:
     # 6. Save
     sch.save()
 
+    record(
+        placed=True,
+        lib_id=sym_instance.lib_id,
+        reference=sym_instance.reference,
+        value=sym_instance.value,
+    )
+
     print(f"\nComponent placed successfully: {sym_instance.lib_id}")
     if not is_power:
         print(f"  Reference: {sym_instance.reference}")
@@ -622,8 +644,16 @@ def main(argv=None):
     parser.add_argument("--dry-run", "-n", action="store_true", help="Preview without modifying")
     parser.add_argument("--backup", action="store_true", help="Create backup before modifying")
 
+    add_format_flag(parser)
+
     args = parser.parse_args(argv)
-    return run_add_component(args)
+    return run_with_json_summary(
+        "add-component",
+        args.schematic,
+        lambda: run_add_component(args),
+        output_format=args.format,
+        dry_run=args.dry_run,
+    )
 
 
 if __name__ == "__main__":

--- a/src/kicad_tools/cli/sch_add_junction.py
+++ b/src/kicad_tools/cli/sch_add_junction.py
@@ -20,6 +20,7 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
+from kicad_tools.cli.sch_json import add_format_flag, record, run_with_json_summary
 from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
 from kicad_tools.schema import Schematic
 
@@ -40,6 +41,7 @@ def run_add_junction(args) -> int:
         return 1
 
     position = (_snap(args.at[0]), _snap(args.at[1]))
+    record(position=[position[0], position[1]], junctions_added=0)
 
     print(f"Planned: Junction at ({position[0]:.2f}, {position[1]:.2f})")
 
@@ -50,10 +52,12 @@ def run_add_junction(args) -> int:
     if args.backup:
         backup_path = f"{schematic_path}.backup-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
         shutil.copy2(schematic_path, backup_path)
+        record(backup=backup_path)
         print(f"Backup created: {backup_path}")
 
     junc = sch.add_junction(position)
     sch.save()
+    record(position=[junc.position[0], junc.position[1]], junctions_added=1)
 
     print(f"Junction added at ({junc.position[0]:.2f}, {junc.position[1]:.2f})")
     return 0
@@ -76,9 +80,16 @@ def main(argv=None):
     )
     parser.add_argument("--dry-run", "-n", action="store_true", help="Preview without modifying")
     parser.add_argument("--backup", action="store_true", help="Create backup before modifying")
+    add_format_flag(parser)
 
     args = parser.parse_args(argv)
-    return run_add_junction(args)
+    return run_with_json_summary(
+        "add-junction",
+        args.schematic,
+        lambda: run_add_junction(args),
+        output_format=args.format,
+        dry_run=args.dry_run,
+    )
 
 
 if __name__ == "__main__":

--- a/src/kicad_tools/cli/sch_add_label.py
+++ b/src/kicad_tools/cli/sch_add_label.py
@@ -31,6 +31,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
+from kicad_tools.cli.sch_json import add_format_flag, record, run_with_json_summary
 from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
 from kicad_tools.schema import Schematic
 
@@ -194,6 +195,19 @@ def run_add_label(args) -> int:
                 )
                 break
 
+    record(
+        label={
+            "name": name,
+            "type": label_type,
+            "shape": shape,
+            "position": [position[0], position[1]],
+            "rotation": rotation,
+        },
+        connect_targets=[[t[0], t[1]] for t in connect_targets],
+        planned=[{"kind": a.kind, "description": a.description} for a in planned],
+        placed=False,
+    )
+
     # Report planned actions
     if args.dry_run:
         print("DRY RUN - No changes will be made")
@@ -210,6 +224,7 @@ def run_add_label(args) -> int:
     if args.backup:
         backup_path = f"{schematic_path}.backup-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
         shutil.copy2(schematic_path, backup_path)
+        record(backup=backup_path)
         print(f"Backup created: {backup_path}")
 
     # Apply changes
@@ -237,6 +252,8 @@ def run_add_label(args) -> int:
 
     # 3. Save
     sch.save()
+
+    record(placed=True)
 
     print(f"\nLabel placed successfully: {label_instance.text}")
     print(f"  Type: {label_type}")
@@ -287,8 +304,16 @@ def main(argv=None):
     parser.add_argument("--dry-run", "-n", action="store_true", help="Preview without modifying")
     parser.add_argument("--backup", action="store_true", help="Create backup before modifying")
 
+    add_format_flag(parser)
+
     args = parser.parse_args(argv)
-    return run_add_label(args)
+    return run_with_json_summary(
+        "add-label",
+        args.schematic,
+        lambda: run_add_label(args),
+        output_format=args.format,
+        dry_run=args.dry_run,
+    )
 
 
 if __name__ == "__main__":

--- a/src/kicad_tools/cli/sch_add_no_connect.py
+++ b/src/kicad_tools/cli/sch_add_no_connect.py
@@ -30,6 +30,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
+from kicad_tools.cli.sch_json import add_format_flag, record, run_with_json_summary
 from kicad_tools.schema import LibraryManager, Schematic
 from kicad_tools.sexp import SExp
 
@@ -201,6 +202,8 @@ def run_add_no_connect(args) -> int:
         print(f"Error: Schematic not found: {schematic_path}", file=sys.stderr)
         return 1
 
+    record(markers=[], markers_added=0)
+
     # Set up library manager
     lib_manager = LibraryManager()
 
@@ -251,6 +254,19 @@ def run_add_no_connect(args) -> int:
             )
         ]
 
+    record(
+        markers=[
+            {
+                "reference": a.reference,
+                "pin": a.pin_number,
+                "pin_name": a.pin_name,
+                "position": [a.position[0], a.position[1]],
+            }
+            for a in actions
+        ],
+        markers_added=0,
+    )
+
     # Report planned changes
     if args.dry_run:
         print("DRY RUN - No changes will be made")
@@ -270,11 +286,13 @@ def run_add_no_connect(args) -> int:
     if args.backup:
         backup_path = f"{schematic_path}.backup-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
         shutil.copy2(schematic_path, backup_path)
+        record(backup=backup_path)
         print(f"Backup created: {backup_path}")
 
     # Apply changes
     count = add_no_connect_markers(sch, actions)
     sch.save()
+    record(markers_added=count)
 
     print(f"\nAdded {count} no-connect marker(s)")
     return 0
@@ -296,9 +314,16 @@ def main(argv=None):
     parser.add_argument("--lib", action="append", dest="libs", help="Specific library file")
     parser.add_argument("--dry-run", action="store_true", help="Preview without modifying")
     parser.add_argument("--backup", action="store_true", help="Create backup before modifying")
+    add_format_flag(parser)
 
     args = parser.parse_args(argv)
-    return run_add_no_connect(args)
+    return run_with_json_summary(
+        "add-no-connect",
+        args.schematic,
+        lambda: run_add_no_connect(args),
+        output_format=args.format,
+        dry_run=args.dry_run,
+    )
 
 
 if __name__ == "__main__":

--- a/src/kicad_tools/cli/sch_add_pull_resistor.py
+++ b/src/kicad_tools/cli/sch_add_pull_resistor.py
@@ -38,6 +38,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
+from kicad_tools.cli.sch_json import add_format_flag, record, run_with_json_summary
 from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
 from kicad_tools.schema import LibraryManager, Schematic
 from kicad_tools.schema.instances import build_instance_path, find_project_name
@@ -617,6 +618,20 @@ def run_add_pull_resistor(args) -> int:
             )
         )
 
+    record(
+        target={"reference": args.ref, "pin": args.pin, "position": [pin_pos[0], pin_pos[1]]},
+        resistor={
+            "reference": reference,
+            "value": value,
+            "direction": direction,
+            "position": [res_x, res_y],
+        },
+        power_net=power_net,
+        rerouted=rerouted,
+        planned=[{"kind": a.kind, "description": a.description} for a in planned],
+        placed=False,
+    )
+
     # --- Report planned actions ---
     if args.dry_run:
         print("DRY RUN - No changes will be made")
@@ -633,6 +648,7 @@ def run_add_pull_resistor(args) -> int:
     if args.backup:
         backup_path = f"{schematic_path}.backup-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
         shutil.copy2(schematic_path, backup_path)
+        record(backup=backup_path)
         print(f"Backup created: {backup_path}")
 
     # --- Apply changes ---
@@ -681,6 +697,8 @@ def run_add_pull_resistor(args) -> int:
 
     # 5. Save
     sch.save()
+
+    record(placed=True)
 
     print(f"\nPull-{direction} resistor placed successfully")
     print(f"  Reference: {reference}")
@@ -734,8 +752,16 @@ def main(argv=None):
     parser.add_argument("--backup", action="store_true", help="Create backup before modifying")
     parser.add_argument("--force", action="store_true", help="Place even if collision detected")
 
+    add_format_flag(parser)
+
     args = parser.parse_args(argv)
-    return run_add_pull_resistor(args)
+    return run_with_json_summary(
+        "add-pull-resistor",
+        args.schematic,
+        lambda: run_add_pull_resistor(args),
+        output_format=args.format,
+        dry_run=args.dry_run,
+    )
 
 
 if __name__ == "__main__":

--- a/src/kicad_tools/cli/sch_add_wire.py
+++ b/src/kicad_tools/cli/sch_add_wire.py
@@ -28,6 +28,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
+from kicad_tools.cli.sch_json import add_format_flag, record, run_with_json_summary
 from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
 from kicad_tools.schema import Schematic
 
@@ -145,6 +146,13 @@ def run_add_wire(args) -> int:
                     )
                     break  # One junction per point is enough
 
+    record(
+        planned=[{"kind": a.kind, "description": a.description} for a in planned],
+        junction_points=[[p[0], p[1]] for p in junction_points],
+        wires_added=0,
+        junctions_added=0,
+    )
+
     if not planned:
         print("No wire segments to add (all zero-length after snapping)")
         return 0
@@ -165,6 +173,7 @@ def run_add_wire(args) -> int:
     if args.backup:
         backup_path = f"{schematic_path}.backup-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
         shutil.copy2(schematic_path, backup_path)
+        record(backup=backup_path)
         print(f"Backup created: {backup_path}")
 
     # Apply changes: add wire segments
@@ -183,6 +192,8 @@ def run_add_wire(args) -> int:
 
     # Save
     sch.save()
+
+    record(wires_added=wires_added, junctions_added=len(junction_points))
 
     print(f"\nWires added: {wires_added}")
     if junction_points:
@@ -222,9 +233,16 @@ def main(argv=None):
     )
     parser.add_argument("--dry-run", "-n", action="store_true", help="Preview without modifying")
     parser.add_argument("--backup", action="store_true", help="Create backup before modifying")
+    add_format_flag(parser)
 
     args = parser.parse_args(argv)
-    return run_add_wire(args)
+    return run_with_json_summary(
+        "add-wire",
+        args.schematic,
+        lambda: run_add_wire(args),
+        output_format=args.format,
+        dry_run=args.dry_run,
+    )
 
 
 if __name__ == "__main__":

--- a/src/kicad_tools/cli/sch_disconnect.py
+++ b/src/kicad_tools/cli/sch_disconnect.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
+from kicad_tools.cli.sch_json import add_format_flag, record, run_with_json_summary
 from kicad_tools.schema import LibraryManager, Schematic
 from kicad_tools.sexp import SExp
 
@@ -183,9 +184,16 @@ def run_disconnect(args) -> int:
         )
         return 1
 
+    record(
+        pin={"reference": args.ref, "pin": args.pin, "position": [pos[0], pos[1]]},
+        wires_removed=0,
+        no_connect_added=False,
+    )
+
     # Preview mode
     if args.dry_run:
         wires = _find_wires_at_point(sch, pos)
+        record(wires_to_remove=len(wires), no_connect_added=bool(args.add_nc))
         print("DRY RUN - No changes will be made")
         print("=" * 60)
         print(f"Pin: {args.ref} pin {args.pin} at ({pos[0]:.2f}, {pos[1]:.2f})")
@@ -198,10 +206,15 @@ def run_disconnect(args) -> int:
     if args.backup:
         backup_path = f"{schematic_path}.backup-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
         shutil.copy2(schematic_path, backup_path)
+        record(backup=backup_path)
         print(f"Backup created: {backup_path}")
 
     # Execute disconnect
     result = disconnect_pin(sch, pos, add_no_connect=args.add_nc)
+    record(
+        wires_removed=result.wires_removed,
+        no_connect_added=bool(result.no_connect_added),
+    )
 
     if result.wires_removed == 0:
         print(f"No wires found at {args.ref} pin {args.pin} ({pos[0]:.2f}, {pos[1]:.2f})")
@@ -234,8 +247,16 @@ def main(argv=None):
     parser.add_argument("--dry-run", action="store_true", help="Preview without modifying")
     parser.add_argument("--backup", action="store_true", help="Create backup before modifying")
 
+    add_format_flag(parser)
+
     args = parser.parse_args(argv)
-    return run_disconnect(args)
+    return run_with_json_summary(
+        "disconnect",
+        args.schematic,
+        lambda: run_disconnect(args),
+        output_format=args.format,
+        dry_run=args.dry_run,
+    )
 
 
 if __name__ == "__main__":

--- a/src/kicad_tools/cli/sch_insert_inline.py
+++ b/src/kicad_tools/cli/sch_insert_inline.py
@@ -54,6 +54,7 @@ from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
 from kicad_tools.schema import LibraryManager, Schematic
 from kicad_tools.schema.library import LibrarySymbol
 
+from .sch_json import add_format_flag, record, run_with_json_summary
 from .sch_remove_wire import (
     _wire_start_end,
     find_nearest_wire,
@@ -492,6 +493,24 @@ def run_insert_inline(args) -> int:
             )
         )
 
+    record(
+        component={
+            "lib_id": args.lib_id,
+            "reference": reference,
+            "value": args.value,
+            "footprint": args.footprint,
+            "position": [comp_pos[0], comp_pos[1]],
+            "rotation": rotation,
+        },
+        wire={
+            "start": [effective_start[0], effective_start[1]],
+            "end": [effective_end[0], effective_end[1]],
+        },
+        pins={"a": args.pin_a, "b": args.pin_b},
+        planned=[{"kind": a.kind, "description": a.description} for a in planned],
+        inserted=False,
+    )
+
     # --- Report planned actions ---
     if args.dry_run:
         print("DRY RUN - No changes will be made")
@@ -508,6 +527,7 @@ def run_insert_inline(args) -> int:
     if args.backup:
         backup_path = f"{schematic_path}.backup-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
         shutil.copy2(schematic_path, backup_path)
+        record(backup=backup_path)
         print(f"Backup created: {backup_path}")
 
     # --- Apply changes ---
@@ -552,6 +572,8 @@ def run_insert_inline(args) -> int:
 
     # 6. Save
     sch.save()
+
+    record(inserted=True)
 
     print("\nComponent inserted inline successfully:")
     print(f"  Reference: {reference}")
@@ -616,8 +638,16 @@ def main(argv=None):
     parser.add_argument("--dry-run", "-n", action="store_true", help="Preview without modifying")
     parser.add_argument("--backup", action="store_true", help="Create backup before modifying")
 
+    add_format_flag(parser)
+
     args = parser.parse_args(argv)
-    return run_insert_inline(args)
+    return run_with_json_summary(
+        "insert-inline",
+        args.schematic,
+        lambda: run_insert_inline(args),
+        output_format=args.format,
+        dry_run=args.dry_run,
+    )
 
 
 if __name__ == "__main__":

--- a/src/kicad_tools/cli/sch_json.py
+++ b/src/kicad_tools/cli/sch_json.py
@@ -1,0 +1,156 @@
+"""Machine-output helpers for the mutating ``kct sch`` subcommands.
+
+Issue #4674 (mechanical follow-up to #4543) adds the canonical
+``--format json`` idiom to the prose-only subcommands.  The ``sch`` mutating
+family is unusual in that its 16 leaves live in 16 separate inner modules
+(``sch_add_component.py``, ``sch_set_value.py``, ...) that each grew their own
+free-form prose reporting.  Rather than rewrite 16 report writers, this module
+provides the one shared wrapper they all route through.
+
+Contract (per ``docs/reference/machine-output.md``)::
+
+    {
+      "command":   "add-junction",          # the sch leaf name
+      "schematic": "board.kicad_sch",       # the file operated on
+      "dry_run":   true,                    # was this a preview?
+      "success":   true,                    # exit code == 0
+      ...                                   # per-command change summary
+      "error":     "..."                    # only when success is false
+    }
+
+Exactly one JSON document goes to stdout; the command's human prose is
+captured and discarded, and its stderr diagnostics are replayed to the real
+stderr *after* the document so the machine channel stays clean.  Exit codes
+are unchanged in both modes, and text mode is byte-identical to before
+(:func:`run_with_json_summary` calls the runner directly when the format is
+not ``json``).
+
+Inner modules add their per-command change summary with :func:`record` /
+:func:`append`, which are no-ops outside an active JSON emission -- so the
+same call sites work unmodified in text mode.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import sys
+from collections.abc import Callable
+from typing import Any
+
+from kicad_tools.cli.format_options import FORMAT_JSON, add_format_flag, emit_json
+
+__all__ = [
+    "add_format_flag",
+    "append",
+    "record",
+    "run_with_json_summary",
+    "wants_json",
+]
+
+
+# Stack of in-flight change summaries.  A stack (rather than a single slot)
+# keeps nesting well-defined if one sch command ever drives another.
+_ACTIVE: list[dict[str, Any]] = []
+
+
+def wants_json(output_format: str | None) -> bool:
+    """Return ``True`` when *output_format* selects the machine channel."""
+    return output_format == FORMAT_JSON
+
+
+def record(**fields: Any) -> None:
+    """Merge *fields* into the enclosing JSON change summary.
+
+    No-op when no emission is active (i.e. in text mode), so inner modules
+    can call it unconditionally.
+    """
+    if _ACTIVE:
+        _ACTIVE[-1].update(fields)
+
+
+def append(key: str, item: Any) -> None:
+    """Append *item* to the list at *key* in the enclosing change summary.
+
+    No-op in text mode, like :func:`record`.
+    """
+    if _ACTIVE:
+        _ACTIVE[-1].setdefault(key, []).append(item)
+
+
+def _emit(
+    command: str,
+    schematic: Any,
+    dry_run: bool,
+    returncode: int,
+    fields: dict[str, Any],
+    out_buf: io.StringIO,
+    err_buf: io.StringIO,
+) -> None:
+    """Print the single JSON document, then replay captured stderr."""
+    payload: dict[str, Any] = {
+        "command": command,
+        "schematic": str(schematic),
+        "dry_run": bool(dry_run),
+        "success": returncode == 0,
+    }
+    payload.update(fields)
+    if returncode != 0 and "error" not in payload:
+        # Inner modules report failures as prose; surface the last thing they
+        # said as the structured error rather than losing it.
+        message = err_buf.getvalue().strip() or out_buf.getvalue().strip()
+        payload["error"] = message or f"sch {command} failed"
+    emit_json(payload)
+    diagnostics = err_buf.getvalue()
+    if diagnostics:
+        sys.stderr.write(diagnostics)
+
+
+def run_with_json_summary(
+    command: str,
+    schematic: Any,
+    runner: Callable[[], int | None],
+    *,
+    output_format: str | None = "text",
+    dry_run: bool = False,
+) -> int:
+    """Run *runner*, emitting a JSON change summary when JSON was requested.
+
+    Args:
+        command: The ``sch`` leaf name (``"add-junction"``, ``"set-value"``, ...).
+        schematic: The schematic path the command operates on.
+        runner: Zero-arg callable performing the command; returns an exit code
+            (``None`` is treated as ``0``, matching the family's convention).
+        output_format: The resolved ``--format`` value.
+        dry_run: Whether this invocation was a preview.
+
+    Returns:
+        The runner's exit code, unchanged in both modes.
+    """
+    if not wants_json(output_format):
+        return runner() or 0
+
+    fields: dict[str, Any] = {}
+    out_buf = io.StringIO()
+    err_buf = io.StringIO()
+    _ACTIVE.append(fields)
+    try:
+        try:
+            with contextlib.redirect_stdout(out_buf), contextlib.redirect_stderr(err_buf):
+                returncode = runner() or 0
+        except SystemExit as exc:
+            # Several inner modules exit rather than return; still emit the
+            # document (with the same exit code) before unwinding.
+            code = exc.code
+            returncode = code if isinstance(code, int) else (0 if code is None else 1)
+            _emit(command, schematic, dry_run, returncode, fields, out_buf, err_buf)
+            raise
+        except BaseException:
+            # Never swallow diagnostics when an unexpected error escapes.
+            sys.stderr.write(err_buf.getvalue())
+            raise
+    finally:
+        _ACTIVE.pop()
+
+    _emit(command, schematic, dry_run, returncode, fields, out_buf, err_buf)
+    return returncode

--- a/src/kicad_tools/cli/sch_reconnect_pin.py
+++ b/src/kicad_tools/cli/sch_reconnect_pin.py
@@ -30,6 +30,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 
+from kicad_tools.cli.sch_json import add_format_flag, record, run_with_json_summary
 from kicad_tools.exceptions import FileNotFoundError as KiCadFileNotFoundError
 from kicad_tools.schema import LibraryManager, Schematic
 from kicad_tools.schema.instances import build_instance_path, find_project_name
@@ -573,6 +574,13 @@ def run_reconnect_pin(args) -> int:
         )
         return 1
 
+    record(
+        pin={"reference": args.ref, "pin": args.pin, "position": [pos[0], pos[1]]},
+        to_net=args.to_net,
+        planned=[{"kind": a.kind, "description": a.description} for a in planned],
+        reconnected=False,
+    )
+
     # Report
     if args.dry_run:
         print("DRY RUN - No changes will be made")
@@ -595,6 +603,7 @@ def run_reconnect_pin(args) -> int:
     if args.backup:
         backup_path = f"{schematic_path}.backup-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
         shutil.copy2(schematic_path, backup_path)
+        record(backup=backup_path)
         print(f"Backup created: {backup_path}")
 
     # Derive project info for instances block
@@ -607,6 +616,8 @@ def run_reconnect_pin(args) -> int:
     execute_reconnect(sch, pos, stub, args.to_net, project_name, instance_path)
 
     sch.save()
+
+    record(reconnected=True)
 
     print(f"\nReconnected {args.ref} pin {args.pin} to {args.to_net}")
     return 0
@@ -627,8 +638,16 @@ def main(argv=None):
     parser.add_argument("--dry-run", "-n", action="store_true", help="Preview without modifying")
     parser.add_argument("--backup", action="store_true", help="Create backup before modifying")
 
+    add_format_flag(parser)
+
     args = parser.parse_args(argv)
-    return run_reconnect_pin(args)
+    return run_with_json_summary(
+        "reconnect-pin",
+        args.schematic,
+        lambda: run_reconnect_pin(args),
+        output_format=args.format,
+        dry_run=args.dry_run,
+    )
 
 
 if __name__ == "__main__":

--- a/src/kicad_tools/cli/sch_replace_symbol.py
+++ b/src/kicad_tools/cli/sch_replace_symbol.py
@@ -36,6 +36,7 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
+from kicad_tools.cli.sch_json import add_format_flag, record, run_with_json_summary
 from kicad_tools.operations.symbol_ops import replace_symbol_lib_id
 
 
@@ -57,9 +58,20 @@ def main(argv=None):
     )
     parser.add_argument("--dry-run", action="store_true", help="Show changes without modifying")
     parser.add_argument("--backup", action="store_true", help="Create backup before modifying")
+    add_format_flag(parser)
 
     args = parser.parse_args(argv)
+    return run_with_json_summary(
+        "replace",
+        args.schematic,
+        lambda: run_replace_symbol(args),
+        output_format=args.format,
+        dry_run=args.dry_run,
+    )
 
+
+def run_replace_symbol(args) -> int:
+    """Execute the replace command against a parsed argument namespace."""
     # Validate input
     if not Path(args.schematic).exists():
         print(f"Error: File not found: {args.schematic}", file=sys.stderr)
@@ -69,6 +81,7 @@ def main(argv=None):
     if args.backup and not args.dry_run:
         backup_path = f"{args.schematic}.backup-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
         shutil.copy2(args.schematic, backup_path)
+        record(backup=backup_path)
         print(f"Backup created: {backup_path}")
 
     try:
@@ -87,6 +100,27 @@ def main(argv=None):
     except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
+
+    record(
+        reference=result.reference,
+        old_lib_id=result.old_lib_id,
+        new_lib_id=result.new_lib_id,
+        old_pin_count=result.old_pin_count,
+        new_pin_count=result.new_pin_count,
+        changes=list(result.changes_made),
+        pin_type_changes=[
+            {
+                "pin_number": ptc.pin_number,
+                "pin_name": ptc.pin_name,
+                "old_type": ptc.old_type,
+                "new_type": ptc.new_type,
+            }
+            for ptc in result.pin_type_changes
+        ],
+        wires_adjusted=result.wires_adjusted,
+        preserved_properties=list(result.preserved_properties),
+        lib_symbol_updated=bool(result.lib_symbol_updated),
+    )
 
     # Output results
     if args.dry_run:
@@ -132,6 +166,8 @@ def main(argv=None):
             print("   The embedded pin definitions were NOT updated.")
             print("   Use --lib-path to provide the new symbol's library file")
             print("   so that pin types are updated and ERC regressions are avoided.")
+
+    return 0
 
 
 if __name__ == "__main__":

--- a/src/kicad_tools/cli/sch_set_footprint.py
+++ b/src/kicad_tools/cli/sch_set_footprint.py
@@ -30,6 +30,7 @@ from kicad_tools.cli.modify_schematic import (
     find_symbol_text_range,
     set_footprint_text,
 )
+from kicad_tools.cli.sch_json import add_format_flag, record, run_with_json_summary
 from kicad_tools.core.sexp_file import load_footprint
 from kicad_tools.footprints.library_path import (
     LibraryPaths,
@@ -182,6 +183,7 @@ def run_set_footprint(
     strict: bool = False,
     config_override: str | Path | None = None,
     mapping: dict[str, str] | None = None,
+    output_format: str = "text",
 ) -> int:
     """Run the set-footprint operation.
 
@@ -199,8 +201,44 @@ def run_set_footprint(
     do not abort unless ``strict=True``. ``ref``/``footprint``/``map_path``
     are ignored when ``mapping`` is provided.
 
+    With ``output_format="json"`` the prose report is replaced by a single
+    machine-readable change summary (see :mod:`kicad_tools.cli.sch_json`).
+
     Returns 0 on success, 1 on error.
     """
+    return run_with_json_summary(
+        "set-footprint",
+        schematic_path,
+        lambda: _run_set_footprint(
+            schematic_path=schematic_path,
+            ref=ref,
+            footprint=footprint,
+            map_path=map_path,
+            dry_run=dry_run,
+            backup=backup,
+            validate=validate,
+            strict=strict,
+            config_override=config_override,
+            mapping=mapping,
+        ),
+        output_format=output_format,
+        dry_run=dry_run,
+    )
+
+
+def _run_set_footprint(
+    schematic_path: Path,
+    ref: str | None,
+    footprint: str | None,
+    map_path: Path | None,
+    dry_run: bool,
+    backup: bool,
+    validate: bool,
+    strict: bool,
+    config_override: str | Path | None,
+    mapping: dict[str, str] | None,
+) -> int:
+    """Prose implementation of :func:`run_set_footprint`."""
     if not schematic_path.exists():
         print(f"Error: File not found: {schematic_path}", file=sys.stderr)
         return 1
@@ -236,6 +274,10 @@ def run_set_footprint(
         return 1
 
     single_ref_mode = not batch_mode
+    record(
+        batch_mode=batch_mode,
+        assignments=[{"reference": r, "footprint": f} for r, f in sorted(mapping.items())],
+    )
 
     # --- Pin-count validation (best-effort, before any modification) ---
     if validate:
@@ -327,6 +369,13 @@ def run_set_footprint(
                 print(f"Error writing {sch_file}: {e}", file=sys.stderr)
                 total_errors += 1
 
+    record(
+        changed=total_changed,
+        errors=total_errors,
+        not_found=sorted(remaining),
+        files_modified=sorted(str(f) for f in modified_files),
+    )
+
     # Summary
     print()
     if dry_run:
@@ -377,6 +426,7 @@ def main(argv: list[str] | None = None):
         action="store_true",
         help="Fail on any pin-count mismatch, even in batch mode",
     )
+    add_format_flag(parser)
 
     args = parser.parse_args(argv)
 
@@ -403,6 +453,7 @@ def main(argv: list[str] | None = None):
         backup=not args.no_backup,
         validate=args.validate,
         strict=args.strict,
+        output_format=args.format,
     )
 
 

--- a/src/kicad_tools/cli/sch_set_label_direction.py
+++ b/src/kicad_tools/cli/sch_set_label_direction.py
@@ -23,6 +23,8 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from kicad_tools.cli.sch_json import add_format_flag, record, run_with_json_summary
+
 VALID_SHAPES = ("input", "output", "bidirectional", "tri_state", "passive")
 
 
@@ -259,9 +261,20 @@ def main(argv: list[str] | None = None) -> int:
         "--dry-run", "-n", action="store_true", help="Preview changes without modifying files"
     )
     parser.add_argument("--backup", action="store_true", help="Create backup before modifying")
+    add_format_flag(parser)
 
     args = parser.parse_args(argv)
+    return run_with_json_summary(
+        "set-label-direction",
+        args.schematic,
+        lambda: _run_set_label_direction(args),
+        output_format=args.format,
+        dry_run=args.dry_run,
+    )
 
+
+def _run_set_label_direction(args) -> int:
+    """Execute set-label-direction against a parsed argument namespace."""
     schematic_path = Path(args.schematic)
     if not schematic_path.exists():
         print(f"Error: File not found: {schematic_path}", file=sys.stderr)
@@ -283,6 +296,24 @@ def main(argv: list[str] | None = None) -> int:
     if not result.success:
         print(f"Error: {result.error}", file=sys.stderr)
         return 1
+
+    record(
+        name=args.name,
+        shape=args.shape,
+        changes=[
+            {
+                "file": c.file_path,
+                "element_type": c.element_type,
+                "label_name": c.label_name,
+                "line_number": c.line_number,
+                "old_shape": c.old_shape,
+                "new_shape": c.new_shape,
+            }
+            for c in sorted(result.changes, key=lambda c: (c.file_path, c.line_number))
+        ],
+        labels_changed=len(result.changes),
+        files_modified=sorted(result.files_modified),
+    )
 
     if not result.changes:
         print(result.error or f"No labels named '{args.name}' found.")

--- a/src/kicad_tools/cli/sch_set_reference.py
+++ b/src/kicad_tools/cli/sch_set_reference.py
@@ -27,6 +27,7 @@ import sys
 from pathlib import Path
 
 from kicad_tools.cli.modify_schematic import create_backup
+from kicad_tools.cli.sch_json import add_format_flag, record, run_with_json_summary
 from kicad_tools.cli.sch_re_annotate import (
     _apply_reference_rename,
     _extract_symbols_from_text,
@@ -89,11 +90,33 @@ def run_set_reference(
     map_path: Path | None = None,
     dry_run: bool = False,
     backup: bool = True,
+    output_format: str = "text",
 ) -> int:
     """Run the set-reference operation.
 
+    With ``output_format="json"`` the prose report is replaced by a single
+    machine-readable change summary (see :mod:`kicad_tools.cli.sch_json`).
+
     Returns 0 on success, 1 on error.
     """
+    return run_with_json_summary(
+        "set-reference",
+        schematic_path,
+        lambda: _run_set_reference(schematic_path, ref, new_ref, map_path, dry_run, backup),
+        output_format=output_format,
+        dry_run=dry_run,
+    )
+
+
+def _run_set_reference(
+    schematic_path: Path,
+    ref: str | None,
+    new_ref: str | None,
+    map_path: Path | None,
+    dry_run: bool,
+    backup: bool,
+) -> int:
+    """Prose implementation of :func:`run_set_reference`."""
     if not schematic_path.exists():
         print(f"Error: File not found: {schematic_path}", file=sys.stderr)
         return 1
@@ -145,6 +168,8 @@ def run_set_reference(
             print(f"Error: {err}", file=sys.stderr)
         return 1
 
+    record(renames=[{"from": o, "to": n} for o, n in sorted(mapping.items())])
+
     # Dry-run output
     if dry_run:
         print(f"Dry run: {len(mapping)} reference(s) would be renamed:")
@@ -194,6 +219,11 @@ def run_set_reference(
                 print(f"Error writing {sch_file}: {e}", file=sys.stderr)
                 return 1
 
+    record(
+        renamed=len(mapping),
+        files_modified=sorted(str(f) for f in modified_files),
+    )
+
     # Summary
     total_renamed = len(mapping)
     print(f"Renamed {total_renamed} reference(s) across {len(modified_files)} file(s).")
@@ -225,6 +255,7 @@ def main(argv: list[str] | None = None):
         "--dry-run", "-n", action="store_true", help="Preview changes without modifying files"
     )
     parser.add_argument("--no-backup", action="store_true", help="Skip creating backup files")
+    add_format_flag(parser)
 
     args = parser.parse_args(argv)
 
@@ -249,6 +280,7 @@ def main(argv: list[str] | None = None):
         map_path=args.map_file,
         dry_run=args.dry_run,
         backup=not args.no_backup,
+        output_format=args.format,
     )
 
 

--- a/src/kicad_tools/cli/sch_set_symbol_property.py
+++ b/src/kicad_tools/cli/sch_set_symbol_property.py
@@ -23,6 +23,7 @@ from kicad_tools.cli.modify_schematic import (
     find_symbol_text_range,
     set_symbol_flag_text,
 )
+from kicad_tools.cli.sch_json import add_format_flag, record, run_with_json_summary
 from kicad_tools.cli.sch_set_footprint import _collect_schematic_files
 
 # Recognized symbol-level boolean flags
@@ -54,11 +55,35 @@ def run_set_symbol_property(
     value: str,
     dry_run: bool = False,
     backup: bool = True,
+    output_format: str = "text",
 ) -> int:
     """Run the set-symbol-property operation.
 
+    With ``output_format="json"`` the prose report is replaced by a single
+    machine-readable change summary (see :mod:`kicad_tools.cli.sch_json`).
+
     Returns 0 on success, 1 on error.
     """
+    return run_with_json_summary(
+        "set-symbol-property",
+        schematic_path,
+        lambda: _run_set_symbol_property(
+            schematic_path, ref, property_name, value, dry_run, backup
+        ),
+        output_format=output_format,
+        dry_run=dry_run,
+    )
+
+
+def _run_set_symbol_property(
+    schematic_path: Path,
+    ref: str,
+    property_name: str,
+    value: str,
+    dry_run: bool,
+    backup: bool,
+) -> int:
+    """Prose implementation of :func:`run_set_symbol_property`."""
     if not schematic_path.exists():
         print(f"Error: File not found: {schematic_path}", file=sys.stderr)
         return 1
@@ -80,6 +105,13 @@ def run_set_symbol_property(
             file=sys.stderr,
         )
         return 1
+
+    record(
+        reference=ref,
+        property=property_name,
+        value=normalized,
+        applied=False,
+    )
 
     # Collect all schematic files (root + sub-sheets)
     all_files = _collect_schematic_files(schematic_path)
@@ -107,6 +139,7 @@ def run_set_symbol_property(
             flag_match = re.search(rf"\({re.escape(property_name)}\s+(yes|no)\)", block)
             if flag_match:
                 old_val = flag_match.group(1)
+                record(old_value=old_val, file=str(sch_file))
                 print(
                     f"  {ref}: {property_name} '{old_val}' -> '{normalized}' (in {sch_file.name})"
                 )
@@ -130,6 +163,7 @@ def run_set_symbol_property(
         # Write back
         if backup:
             bak = create_backup(sch_file)
+            record(backup=str(bak))
             print(f"  Backup: {bak.name}")
 
         try:
@@ -138,6 +172,7 @@ def run_set_symbol_property(
             print(f"Error writing {sch_file}: {e}", file=sys.stderr)
             return 1
 
+        record(applied=True, file=str(sch_file))
         print(f"  {msg} (in {sch_file.name})")
         return 0
 
@@ -183,6 +218,8 @@ def main(argv: list[str] | None = None):
         help="Skip creating backup files",
     )
 
+    add_format_flag(parser)
+
     args = parser.parse_args(argv)
 
     return run_set_symbol_property(
@@ -192,6 +229,7 @@ def main(argv: list[str] | None = None):
         value=args.value,
         dry_run=args.dry_run,
         backup=not args.no_backup,
+        output_format=args.format,
     )
 
 

--- a/src/kicad_tools/cli/sch_set_value.py
+++ b/src/kicad_tools/cli/sch_set_value.py
@@ -28,6 +28,7 @@ from kicad_tools.cli.modify_schematic import (
     find_symbol_text_range,
     set_value_text,
 )
+from kicad_tools.cli.sch_json import add_format_flag, record, run_with_json_summary
 from kicad_tools.cli.sch_set_footprint import (
     _collect_schematic_files,
     _load_mapping,
@@ -41,11 +42,33 @@ def run_set_value(
     map_path: Path | None = None,
     dry_run: bool = False,
     backup: bool = True,
+    output_format: str = "text",
 ) -> int:
     """Run the set-value operation.
 
+    With ``output_format="json"`` the prose report is replaced by a single
+    machine-readable change summary (see :mod:`kicad_tools.cli.sch_json`).
+
     Returns 0 on success, 1 on error.
     """
+    return run_with_json_summary(
+        "set-value",
+        schematic_path,
+        lambda: _run_set_value(schematic_path, ref, value, map_path, dry_run, backup),
+        output_format=output_format,
+        dry_run=dry_run,
+    )
+
+
+def _run_set_value(
+    schematic_path: Path,
+    ref: str | None,
+    value: str | None,
+    map_path: Path | None,
+    dry_run: bool,
+    backup: bool,
+) -> int:
+    """Prose implementation of :func:`run_set_value`."""
     if not schematic_path.exists():
         print(f"Error: File not found: {schematic_path}", file=sys.stderr)
         return 1
@@ -127,6 +150,13 @@ def run_set_value(
                 print(f"Error writing {sch_file}: {e}", file=sys.stderr)
                 total_errors += 1
 
+    record(
+        changed=total_changed,
+        errors=total_errors,
+        not_found=sorted(remaining),
+        files_modified=sorted(str(f) for f in modified_files),
+    )
+
     # Summary
     print()
     if dry_run:
@@ -163,6 +193,7 @@ def main(argv: list[str] | None = None):
         "--dry-run", "-n", action="store_true", help="Preview changes without modifying files"
     )
     parser.add_argument("--no-backup", action="store_true", help="Skip creating backup files")
+    add_format_flag(parser)
 
     args = parser.parse_args(argv)
 
@@ -187,6 +218,7 @@ def main(argv: list[str] | None = None):
         map_path=args.map_file,
         dry_run=args.dry_run,
         backup=not args.no_backup,
+        output_format=args.format,
     )
 
 

--- a/tests/test_format_json_sweep_sch.py
+++ b/tests/test_format_json_sweep_sch.py
@@ -1,0 +1,468 @@
+"""Tests for the #4674 machine-output sweep -- ``sch`` mutating family (batch 2).
+
+Batch 1 (PR #4727, ``tests/test_format_json_sweep.py``) swept the grouped
+families whose whole family is served by one inner module.  This batch sweeps
+the 16 mutating ``kct sch`` leaves, which are unusual in that each lives in its
+own inner module:
+
+    add-bypass-cap  add-component  add-junction  add-label  add-no-connect
+    add-pull-resistor  add-wire  disconnect  insert-inline  reconnect-pin
+    replace  set-footprint  set-label-direction  set-reference
+    set-symbol-property  set-value
+
+They all route through :mod:`kicad_tools.cli.sch_json`, which emits one
+deterministic change-summary document and suppresses the prose report.
+
+Covered here, mirroring the batch-1 conventions:
+
+* Outer-parser surface: every swept leaf declares ``--format`` with a ``json``
+  choice, and the real outer parser accepts ``--format json``.
+* Shim forwarding: ``commands/schematic.py`` reaches the inner surface for both
+  shim shapes -- argv re-serialization (12 leaves) and direct ``run_*`` keyword
+  calls (4 leaves) -- and does *not* forward on the text default.
+* Emission: hermetic ``--dry-run`` paths emit a single valid JSON document on
+  stdout, byte-identical across two runs (determinism), with structure
+  assertions rather than byte-golden payloads.
+* Error paths emit ``{"error": ...}`` documents with unchanged exit codes.
+* Text mode is unchanged (still prose, still not JSON).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kicad_tools.cli.parser import create_parser
+
+FIXTURE_SCH = Path("tests/fixtures/simple_rc.kicad_sch")
+
+# ---------------------------------------------------------------------------
+# Outer-parser surface guard
+# ---------------------------------------------------------------------------
+
+# Every sch leaf swept by this batch, as (leaf name, minimal extra argv after
+# the schematic positional).
+SWEPT_SCH_SURFACES: dict[str, list[str]] = {
+    "add-bypass-cap": ["--ref", "U1", "--pin", "1"],
+    "add-component": ["--lib-id", "Device:R", "--at", "100", "100"],
+    "add-junction": ["--at", "100", "100"],
+    "add-label": ["--type", "global", "--name", "NET1", "--at", "100", "100"],
+    "add-no-connect": ["--auto"],
+    "add-pull-resistor": ["--ref", "U1", "--pin", "1", "--direction", "up", "--value", "10k"],
+    "add-wire": ["--from", "100", "100", "--to", "120", "100"],
+    "disconnect": ["--ref", "U1", "--pin", "1"],
+    "insert-inline": ["--lib-id", "Device:R", "--near", "100", "40"],
+    "reconnect-pin": ["--ref", "U1", "--pin", "1", "--to-net", "GND"],
+    "replace": ["U1", "Device:C_Small"],
+    "set-footprint": ["--ref", "U1", "--footprint", "Device:R_0402"],
+    "set-label-direction": ["--name", "NET1", "--shape", "input"],
+    "set-reference": ["--ref", "U1", "--new-ref", "U9"],
+    "set-symbol-property": ["--ref", "U1", "--property", "dnp", "--value", "yes"],
+    "set-value": ["--ref", "U1", "--value", "10k"],
+}
+
+# The 12 leaves whose shim re-serializes an argv for an inner ``main()``,
+# mapped to the inner module path the shim imports.
+ARGV_SHIM_LEAVES: dict[str, str] = {
+    "add-bypass-cap": "kicad_tools.cli.sch_add_bypass_cap.main",
+    "add-component": "kicad_tools.cli.sch_add_component.main",
+    "add-junction": "kicad_tools.cli.sch_add_junction.main",
+    "add-label": "kicad_tools.cli.sch_add_label.main",
+    "add-no-connect": "kicad_tools.cli.sch_add_no_connect.main",
+    "add-pull-resistor": "kicad_tools.cli.sch_add_pull_resistor.main",
+    "add-wire": "kicad_tools.cli.sch_add_wire.main",
+    "disconnect": "kicad_tools.cli.sch_disconnect.main",
+    "insert-inline": "kicad_tools.cli.sch_insert_inline.main",
+    "reconnect-pin": "kicad_tools.cli.sch_reconnect_pin.main",
+    "replace": "kicad_tools.cli.sch_replace_symbol.main",
+    "set-label-direction": "kicad_tools.cli.sch_set_label_direction.main",
+}
+
+# The 4 leaves whose shim calls a ``run_*`` helper with keyword arguments.
+DIRECT_CALL_LEAVES: dict[str, str] = {
+    "set-footprint": "kicad_tools.cli.sch_set_footprint.run_set_footprint",
+    "set-reference": "kicad_tools.cli.sch_set_reference.run_set_reference",
+    "set-symbol-property": "kicad_tools.cli.sch_set_symbol_property.run_set_symbol_property",
+    "set-value": "kicad_tools.cli.sch_set_value.run_set_value",
+}
+
+
+def _iter_leaves(parser, path=()):
+    subactions = [a for a in parser._actions if isinstance(a, argparse._SubParsersAction)]
+    if not subactions:
+        yield path, parser
+        return
+    for subaction in subactions:
+        for name, sub in subaction.choices.items():
+            yield from _iter_leaves(sub, (*path, name))
+
+
+@pytest.fixture(scope="module")
+def leaves():
+    return {" ".join(path): leaf for path, leaf in _iter_leaves(create_parser())}
+
+
+def _argv(leaf: str, schematic: str | Path) -> list[str]:
+    return ["sch", leaf, str(schematic), *SWEPT_SCH_SURFACES[leaf]]
+
+
+class TestOuterSurface:
+    def test_batch_covers_sixteen_leaves(self):
+        assert len(SWEPT_SCH_SURFACES) == 16
+        assert set(ARGV_SHIM_LEAVES) | set(DIRECT_CALL_LEAVES) == set(SWEPT_SCH_SURFACES)
+
+    @pytest.mark.parametrize("leaf", sorted(SWEPT_SCH_SURFACES))
+    def test_leaf_has_format_json_choice(self, leaves, leaf):
+        """Each swept leaf declares --format with a json choice."""
+        parser = leaves.get(f"sch {leaf}")
+        assert parser is not None, f"outer parser has no leaf 'sch {leaf}'"
+        for action in parser._actions:
+            if "--format" in action.option_strings:
+                assert action.choices and "json" in action.choices, (
+                    f"kct sch {leaf} has --format without a 'json' choice "
+                    f"(choices={action.choices}); regresses #4674"
+                )
+                break
+        else:
+            pytest.fail(f"kct sch {leaf} lost its --format flag (regresses #4674)")
+
+    @pytest.mark.parametrize("leaf", sorted(SWEPT_SCH_SURFACES))
+    def test_parse_accepts_format_json(self, leaf):
+        """`kct sch <leaf> ... --format json` parses on the real outer parser."""
+        args = create_parser().parse_args([*_argv(leaf, "b.kicad_sch"), "--format", "json"])
+        assert args.format == "json"
+
+    @pytest.mark.parametrize("leaf", sorted(SWEPT_SCH_SURFACES))
+    def test_format_defaults_to_text(self, leaf):
+        args = create_parser().parse_args(_argv(leaf, "b.kicad_sch"))
+        assert args.format == "text"
+
+
+# ---------------------------------------------------------------------------
+# Shim forwarding (commands/schematic.py must reach the inner surface)
+# ---------------------------------------------------------------------------
+
+
+class TestShimForwarding:
+    """The shim's own existence check runs first, so point it at a real file."""
+
+    @pytest.mark.parametrize("leaf", sorted(ARGV_SHIM_LEAVES))
+    def test_argv_shim_forwards_format(self, leaf):
+        from kicad_tools.cli.commands.schematic import run_sch_command
+
+        args = create_parser().parse_args([*_argv(leaf, FIXTURE_SCH), "--format", "json"])
+        with patch(ARGV_SHIM_LEAVES[leaf], return_value=0) as inner:
+            assert run_sch_command(args) == 0
+        sub_argv = inner.call_args[0][0]
+        assert "--format" in sub_argv, f"sch shim dropped --format for {leaf}: {sub_argv}"
+        assert sub_argv[sub_argv.index("--format") + 1] == "json"
+
+    @pytest.mark.parametrize("leaf", sorted(ARGV_SHIM_LEAVES))
+    def test_argv_shim_omits_format_for_text_default(self, leaf):
+        """Default (text) invocations must not forward --format (behaviour pin)."""
+        from kicad_tools.cli.commands.schematic import run_sch_command
+
+        args = create_parser().parse_args(_argv(leaf, FIXTURE_SCH))
+        with patch(ARGV_SHIM_LEAVES[leaf], return_value=0) as inner:
+            assert run_sch_command(args) == 0
+        assert "--format" not in inner.call_args[0][0]
+
+    @pytest.mark.parametrize("leaf", sorted(DIRECT_CALL_LEAVES))
+    def test_direct_call_shim_threads_output_format(self, leaf):
+        from kicad_tools.cli.commands.schematic import run_sch_command
+
+        args = create_parser().parse_args([*_argv(leaf, FIXTURE_SCH), "--format", "json"])
+        with patch(DIRECT_CALL_LEAVES[leaf], return_value=0) as inner:
+            assert run_sch_command(args) == 0
+        assert inner.call_args.kwargs["output_format"] == "json"
+
+    @pytest.mark.parametrize("leaf", sorted(DIRECT_CALL_LEAVES))
+    def test_direct_call_shim_defaults_to_text(self, leaf):
+        from kicad_tools.cli.commands.schematic import run_sch_command
+
+        args = create_parser().parse_args(_argv(leaf, FIXTURE_SCH))
+        with patch(DIRECT_CALL_LEAVES[leaf], return_value=0) as inner:
+            assert run_sch_command(args) == 0
+        assert inner.call_args.kwargs["output_format"] == "text"
+
+
+# ---------------------------------------------------------------------------
+# Emission (hermetic dry-run paths through the real CLI dispatch)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def sch(tmp_path) -> Path:
+    """A writable copy of the simple RC fixture (R1, C1, six wires)."""
+    target = tmp_path / "simple_rc.kicad_sch"
+    shutil.copy2(FIXTURE_SCH, target)
+    return target
+
+
+def _run(argv, capsys) -> tuple[int, str]:
+    from kicad_tools.cli.commands.schematic import run_sch_command
+
+    rc = run_sch_command(create_parser().parse_args(argv))
+    return rc, capsys.readouterr().out
+
+
+# (leaf, extra argv) invocations that succeed hermetically against the fixture.
+HERMETIC_DRY_RUNS: dict[str, list[str]] = {
+    "add-junction": ["--at", "100", "100", "--dry-run"],
+    "add-wire": ["--from", "100", "100", "--to", "120", "100", "--dry-run"],
+    "add-label": ["--type", "global", "--name", "NET1", "--at", "100", "100", "--dry-run"],
+    "add-no-connect": ["--auto", "--dry-run"],
+    "disconnect": ["--ref", "R1", "--pin", "1", "--dry-run"],
+    "reconnect-pin": ["--ref", "R1", "--pin", "1", "--to-net", "GND", "--dry-run"],
+    "replace": ["R1", "Device:C_Small", "--dry-run"],
+    "set-label-direction": ["--name", "NET1", "--shape", "input", "--dry-run"],
+    "set-reference": ["--ref", "R1", "--new-ref", "R9", "--dry-run"],
+    "set-symbol-property": ["--ref", "R1", "--property", "dnp", "--value", "yes", "--dry-run"],
+    "set-value": ["--ref", "R1", "--value", "10k", "--dry-run"],
+    "set-footprint": ["--ref", "R1", "--footprint", "Device:R_0402", "--dry-run", "--no-validate"],
+}
+
+
+class TestEmission:
+    @pytest.mark.parametrize("leaf", sorted(HERMETIC_DRY_RUNS))
+    def test_single_document_with_envelope(self, leaf, sch, capsys):
+        rc, out = _run(
+            ["sch", leaf, str(sch), *HERMETIC_DRY_RUNS[leaf], "--format", "json"], capsys
+        )
+        assert rc == 0, out
+        payload = json.loads(out)  # exactly one JSON document
+        assert payload["command"] == leaf
+        assert payload["schematic"] == str(sch)
+        assert payload["dry_run"] is True
+        assert payload["success"] is True
+
+    @pytest.mark.parametrize("leaf", sorted(HERMETIC_DRY_RUNS))
+    def test_deterministic(self, leaf, sch, capsys):
+        argv = ["sch", leaf, str(sch), *HERMETIC_DRY_RUNS[leaf], "--format", "json"]
+        _, first = _run(argv, capsys)
+        _, second = _run(argv, capsys)
+        assert first == second, f"kct sch {leaf} --format json is not deterministic"
+
+    @pytest.mark.parametrize("leaf", sorted(HERMETIC_DRY_RUNS))
+    def test_text_default_is_not_json(self, leaf, sch, capsys):
+        rc, out = _run(["sch", leaf, str(sch), *HERMETIC_DRY_RUNS[leaf]], capsys)
+        assert rc == 0, out
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(out)
+
+    @pytest.mark.parametrize("leaf", sorted(HERMETIC_DRY_RUNS))
+    def test_dry_run_leaves_the_schematic_untouched(self, leaf, sch, capsys):
+        before = sch.read_bytes()
+        _run(["sch", leaf, str(sch), *HERMETIC_DRY_RUNS[leaf], "--format", "json"], capsys)
+        assert sch.read_bytes() == before
+
+
+class TestPayloadStructure:
+    """Spot-check the per-command change summaries (not byte-golden)."""
+
+    def test_add_junction(self, sch, capsys):
+        _, out = _run(
+            [
+                "sch",
+                "add-junction",
+                str(sch),
+                "--at",
+                "100",
+                "100",
+                "--dry-run",
+                "--format",
+                "json",
+            ],
+            capsys,
+        )
+        payload = json.loads(out)
+        assert payload["junctions_added"] == 0  # dry run
+        assert len(payload["position"]) == 2
+
+    def test_add_wire(self, sch, capsys):
+        _, out = _run(
+            [
+                "sch",
+                "add-wire",
+                str(sch),
+                "--from",
+                "100",
+                "100",
+                "--to",
+                "120",
+                "100",
+                "--dry-run",
+                "--format",
+                "json",
+            ],
+            capsys,
+        )
+        payload = json.loads(out)
+        assert payload["wires_added"] == 0
+        assert [a["kind"] for a in payload["planned"]] == ["wire"]
+
+    def test_set_value(self, sch, capsys):
+        _, out = _run(
+            ["sch", "set-value", str(sch), "--ref", "R1", "--value", "10k", "--dry-run"]
+            + ["--format", "json"],
+            capsys,
+        )
+        payload = json.loads(out)
+        assert payload["changed"] == 1
+        assert payload["not_found"] == []
+        assert payload["files_modified"] == []
+
+    def test_set_footprint(self, sch, capsys):
+        _, out = _run(
+            [
+                "sch",
+                "set-footprint",
+                str(sch),
+                "--ref",
+                "R1",
+                "--footprint",
+                "Device:R_0402",
+                "--dry-run",
+                "--no-validate",
+                "--format",
+                "json",
+            ],
+            capsys,
+        )
+        payload = json.loads(out)
+        assert payload["batch_mode"] is False
+        assert payload["assignments"] == [{"reference": "R1", "footprint": "Device:R_0402"}]
+        assert payload["changed"] == 1
+
+    def test_set_reference(self, sch, capsys):
+        _, out = _run(
+            ["sch", "set-reference", str(sch), "--ref", "R1", "--new-ref", "R9", "--dry-run"]
+            + ["--format", "json"],
+            capsys,
+        )
+        payload = json.loads(out)
+        assert payload["renames"] == [{"from": "R1", "to": "R9"}]
+
+    def test_set_symbol_property(self, sch, capsys):
+        _, out = _run(
+            [
+                "sch",
+                "set-symbol-property",
+                str(sch),
+                "--ref",
+                "R1",
+                "--property",
+                "dnp",
+                "--value",
+                "yes",
+                "--dry-run",
+                "--format",
+                "json",
+            ],
+            capsys,
+        )
+        payload = json.loads(out)
+        assert payload["reference"] == "R1"
+        assert payload["property"] == "dnp"
+        assert payload["value"] == "yes"
+        assert payload["applied"] is False
+
+    def test_replace(self, sch, capsys):
+        _, out = _run(
+            ["sch", "replace", str(sch), "R1", "Device:C_Small", "--dry-run", "--format", "json"],
+            capsys,
+        )
+        payload = json.loads(out)
+        assert payload["reference"] == "R1"
+        assert payload["old_lib_id"] == "Device:R"
+        assert payload["new_lib_id"] == "Device:C_Small"
+        assert isinstance(payload["changes"], list)
+
+    def test_reconnect_pin(self, sch, capsys):
+        _, out = _run(
+            ["sch", "reconnect-pin", str(sch), "--ref", "R1", "--pin", "1", "--to-net", "GND"]
+            + ["--dry-run", "--format", "json"],
+            capsys,
+        )
+        payload = json.loads(out)
+        assert payload["to_net"] == "GND"
+        assert payload["reconnected"] is False
+        assert payload["pin"]["reference"] == "R1"
+
+    def test_disconnect(self, sch, capsys):
+        _, out = _run(
+            ["sch", "disconnect", str(sch), "--ref", "R1", "--pin", "1", "--dry-run"]
+            + ["--format", "json"],
+            capsys,
+        )
+        payload = json.loads(out)
+        assert payload["wires_to_remove"] >= 1
+        assert payload["wires_removed"] == 0  # dry run
+
+
+class TestErrorDocuments:
+    def test_missing_schematic_is_json_error(self, tmp_path, capsys):
+        """The shim's own existence guard honours --format json."""
+        rc, out = _run(
+            ["sch", "add-junction", str(tmp_path / "nope.kicad_sch")]
+            + ["--at", "1", "1", "--format", "json"],
+            capsys,
+        )
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["success"] is False
+        assert "error" in payload
+        assert payload["command"] == "add-junction"
+
+    def test_missing_schematic_text_mode_stays_prose(self, tmp_path, capsys):
+        rc, out = _run(
+            ["sch", "add-junction", str(tmp_path / "nope.kicad_sch"), "--at", "1", "1"], capsys
+        )
+        assert rc == 1
+        assert out == ""  # prose goes to stderr in text mode
+
+    def test_unresolvable_pin_is_json_error(self, sch, capsys):
+        rc, out = _run(
+            ["sch", "disconnect", str(sch), "--ref", "ZZ99", "--pin", "1", "--format", "json"],
+            capsys,
+        )
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["success"] is False
+        assert "ZZ99" in payload["error"]
+
+    def test_unknown_reference_is_json_error(self, sch, capsys):
+        rc, out = _run(
+            ["sch", "set-reference", str(sch), "--ref", "ZZ99", "--new-ref", "ZZ1"]
+            + ["--dry-run", "--format", "json"],
+            capsys,
+        )
+        assert rc == 1
+        assert "error" in json.loads(out)
+
+    def test_error_exit_code_matches_text_mode(self, sch, capsys):
+        argv = ["sch", "disconnect", str(sch), "--ref", "ZZ99", "--pin", "1"]
+        text_rc, _ = _run(argv, capsys)
+        json_rc, _ = _run([*argv, "--format", "json"], capsys)
+        assert text_rc == json_rc == 1
+
+
+class TestApplyPathEmitsSummary:
+    """A non-dry-run write still produces exactly one document."""
+
+    def test_set_value_applied(self, sch, capsys):
+        rc, out = _run(
+            ["sch", "set-value", str(sch), "--ref", "R1", "--value", "22k", "--format", "json"],
+            capsys,
+        )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["dry_run"] is False
+        assert payload["changed"] == 1
+        assert payload["files_modified"] == [str(sch)]
+        assert '"22k"' in sch.read_text()


### PR DESCRIPTION
Part of #4674 — second batch of the mechanical `--format json` sweep (batch 1 was PR #4727).

## Summary

Adds the canonical `--format json` idiom to the **16 mutating `kct sch` subcommands**, the largest remaining batch on the #4674 tracker:

`add-bypass-cap`, `add-component`, `add-junction`, `add-label`, `add-no-connect`, `add-pull-resistor`, `add-wire`, `disconnect`, `insert-inline`, `reconnect-pin`, `replace`, `set-footprint`, `set-label-direction`, `set-reference`, `set-symbol-property`, `set-value`

Audit (`scripts/audit_machine_output.py`, base `32016f97`): **prose-only 49 → 33, format-json 148 → 164.** Remaining #4674 backlog (`stitch` + the long-tail singles) is unchanged and still tracked on the issue.

## Changes

**One shared wrapper instead of 16 rewritten report writers.** Unlike batch 1's grouped families (one inner module serves the whole family), each of these 16 leaves lives in its own inner module with its own free-form prose report. `src/kicad_tools/cli/sch_json.py` brackets the existing implementation:

- In JSON mode, prose stdout is captured and discarded; `record(...)` / `append(...)` calls (no-ops in text mode) accumulate the per-command change summary; exactly one deterministic document is printed via `format_options.emit_json` (sorted keys).
- Captured stderr is replayed **after** the document, and becomes the `error` value when the exit code is non-zero — so diagnostics survive and every failure path yields an `{"error": ...}` document without touching 16 error branches by hand.
- `SystemExit` from inner modules that `sys.exit(1)` (e.g. `sch replace`) still emits the document before unwinding, so exit codes are unchanged.

Shared envelope, plus per-command keys:

```json
{
  "command": "add-junction",
  "schematic": "board.kicad_sch",
  "dry_run": true,
  "success": true,
  "position": [100.33, 100.33],
  "junctions_added": 0
}
```

Per-command additions are `changed` / `not_found` / `files_modified` for the `set-*` batch commands, `planned` / `placed` for the `add-*` placement commands, `renames` for `set-reference`, `pin_type_changes` / `preserved_properties` for `replace`, etc.

**Both shim shapes threaded.** `commands/schematic.py` carries two call conventions and both are wired: `--format` is re-serialized into `sub_argv` for the 12 argv-style leaves, and passed as `output_format=` for the 4 `run_*()` direct-call leaves (`set-footprint`, `set-reference`, `set-symbol-property`, `set-value`, whose signatures gained a defaulted `output_format: str = "text"` — in-process callers such as `sch_assign_footprints` are unaffected).

**One shim-level fix in scope:** `run_sch_command`'s own "file not found" guard runs *before* any inner module, so under `--format json` it was the one error no `sch` leaf could ever report structurally. It now emits the same `{"error": ..., "success": false}` document. Text mode there is unchanged.

`parser.py` gains 16 `add_format_flag(...)` calls. No inner-only flags are left unreachable (the `mfr rules` dead-surface trap from #4543).

## Acceptance Criteria Verification

- [x] **One family per PR, outer parser + shim + inner emission all threaded** — verified programmatically against the real `create_parser()` tree; all 16 leaves expose `--format` with a `json` choice, and both shim shapes are asserted in tests.
- [x] **JSON deterministic** — `emit_json` sorts keys; `test_deterministic` runs each of the 12 hermetic surfaces twice on the same input and asserts byte-identical output.
- [x] **`tests/test_cli_parser_drift.py` green and untouched** — no route/check parser pairs are involved.
- [x] **Per-surface `--format json` tests, structural not byte-golden** — `tests/test_format_json_sweep_sch.py`.
- [x] **Exit codes unchanged** — `test_error_exit_code_matches_text_mode` pins text/JSON parity; text mode is byte-identical (the wrapper calls the runner directly when the format is not `json`).
- [x] **Family JSON schema documented** — `docs/reference/machine-output.md` inventory table and backlog updated (49 → 33), with the envelope and the wrapper's mechanics written up.

**Test-file placement note:** batch 1's per-surface guards live in `tests/test_format_json_sweep.py`. This batch uses a sibling module, `tests/test_format_json_sweep_sch.py`, rather than extending batch 1's `SWEPT_SURFACES` dict — two other #4674-adjacent batches (#4700, #4691) are in flight concurrently, and a shared dict literal is a guaranteed conflict. The conventions and assertions are the same.

## Test Plan

```
tests/test_format_json_sweep_sch.py .................. 144 passed   (new)
tests/test_format_json_sweep.py
tests/test_machine_output_idiom.py
tests/test_cli_parser_drift.py ...................... 291 passed total
tests/test_sch_*.py + test_cli_sch.py + test_cli.py
  + test_cli_commands.py ............................ 756 + 418 passed
```

- `ruff check` + `ruff format --check` clean on all 22 changed files.
- `scripts/ci/check_mypy_baseline.py`: `OK: mypy reports 1473 error(s), all within the baseline (1475 allowed). No new type errors.` (baseline file deliberately not `--update`d).
- Manual smoke of all 16 surfaces through `uv run kct sch <leaf> ... --format json`, including error paths (missing file, unresolvable pin, unknown reference) and non-dry-run writes.
