### PR TITLE
polish: scope rollback reports, derive difficulty choices from the enum, drop zero-angle (at) residue

### DIFF
--- a/.github/mypy-baseline.txt
+++ b/.github/mypy-baseline.txt
@@ -994,10 +994,8 @@ src/kicad_tools/schema/instances.py	attr-defined	"object" has no attribute "uuid
 src/kicad_tools/schema/instances.py	unused-ignore	Unused "type: ignore" comment
 src/kicad_tools/schema/instances.py	unused-ignore	Unused "type: ignore" comment
 src/kicad_tools/schema/library.py	assignment	Incompatible types in assignment (expression has type "str | None", variable has type "str")
-src/kicad_tools/schema/pcb.py	arg-type	Argument N to "add" of "SExp" has incompatible type "object"; expected "SExp | str | int | float"
 src/kicad_tools/schema/pcb.py	arg-type	Argument N to "extract_bom" has incompatible type "Path"; expected "str"
 src/kicad_tools/schema/pcb.py	arg-type	Argument N to "int" has incompatible type "str | None"; expected "str | Buffer | SupportsInt | SupportsIndex | SupportsTrunc"
-src/kicad_tools/schema/pcb.py	arg-type	Argument N to "set_value" of "SExp" has incompatible type "object"; expected "str | int | float"
 src/kicad_tools/schema/pcb.py	arg-type	Argument N to "set_value" of "SExp" has incompatible type "object"; expected "str | int | float"
 src/kicad_tools/schema/pcb.py	assignment	Incompatible types in assignment (expression has type "Net | None", variable has type "Net")
 src/kicad_tools/schema/pcb.py	assignment	Incompatible types in assignment (expression has type "Net | None", variable has type "Net")

--- a/src/kicad_tools/benchmark/cases.py
+++ b/src/kicad_tools/benchmark/cases.py
@@ -18,6 +18,17 @@ class Difficulty(Enum):
     MEDIUM = "medium"
     HARD = "hard"
 
+    @classmethod
+    def values(cls) -> list[str]:
+        """The difficulty vocabulary, in declaration order.
+
+        Single source of truth for the CLI (issue #4752): both the
+        ``kct benchmark run --difficulty`` argparse ``choices`` and the
+        "valid options" text of the handler's unknown-difficulty error
+        derive from this, so neither can drift from the enum.
+        """
+        return [member.value for member in cls]
+
 
 @dataclass
 class BenchmarkCase:

--- a/src/kicad_tools/cli/commands/benchmark.py
+++ b/src/kicad_tools/cli/commands/benchmark.py
@@ -68,9 +68,10 @@ def _run_benchmark(args) -> int:
         try:
             difficulty_filter = Difficulty(difficulty)
         except ValueError:
-            return _fail(
-                args, f"Unknown difficulty: {difficulty} (valid options: easy, medium, hard)"
-            )
+            # Vocabulary comes from the enum itself (#4752) so this message
+            # cannot drift from the parser's --difficulty choices.
+            valid = ", ".join(Difficulty.values())
+            return _fail(args, f"Unknown difficulty: {difficulty} (valid options: {valid})")
 
     runner = BenchmarkRunner(base_dir=Path.cwd(), verbose=verbose and not json_mode)
 

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -8,6 +8,13 @@ The parser is organized into subparsers for each major command category.
 import argparse
 
 from kicad_tools import __version__
+
+# ``--difficulty`` choices come from the Difficulty enum itself so they cannot
+# drift from the handler's "valid options" error text (issue #4752).  The
+# benchmark package's runner/generators are import-light (the router is behind
+# TYPE_CHECKING), so this costs ~2.5 ms on top of an already-imported
+# ``kicad_tools`` -- measured, and well under 1% of CLI startup.
+from kicad_tools.benchmark.cases import Difficulty
 from kicad_tools.cli.format_options import add_format_flag
 from kicad_tools.manufacturers import get_all_manufacturer_names
 
@@ -8220,7 +8227,7 @@ def _add_benchmark_parser(subparsers) -> None:
     )
     benchmark_run.add_argument(
         "--difficulty",
-        choices=["easy", "medium", "hard"],
+        choices=Difficulty.values(),
         help="Filter by difficulty level",
     )
     benchmark_run.add_argument(

--- a/src/kicad_tools/schema/pcb.py
+++ b/src/kicad_tools/schema/pcb.py
@@ -244,6 +244,39 @@ class Net:
     name: str
 
 
+def _sync_at_angle(owner: object, at_node: SExp, angle: float) -> None:
+    """Write *angle* into an ``(at x y [angle])`` node, residue-free.
+
+    KiCad omits the angle token entirely when the rotation is zero, so a
+    node that arrived as a 2-token ``(at x y)`` must go back to 2 tokens
+    when its angle returns to zero.  Otherwise a mirror/un-mirror (or
+    rotate-and-back) round trip leaves a cosmetic ``(at x y 0)`` behind in
+    the saved file -- harmless to KiCad, but diff noise (issue #4752).
+
+    Only the token *this* write-through appended is ever removed, tracked
+    per-owner via ``_at_angle_synthetic``: a node the file supplied as an
+    explicit 3-token ``(at x y 0)`` keeps its zero, so byte-fidelity for
+    boards written that way is unchanged.  Nodes carrying extra trailing
+    tokens (4+ children) are never trimmed either.
+
+    Args:
+        owner: The ``Pad``/``Footprint`` owning *at_node* (holds the
+            synthetic-token flag in its ``__dict__``).
+        at_node: The ``(at ...)`` S-expression node to update.
+        angle: The new rotation in degrees.
+    """
+    if len(at_node.children) >= 3:
+        synthetic = owner.__dict__.get("_at_angle_synthetic", False)
+        if angle == 0.0 and synthetic and len(at_node.children) == 3:
+            del at_node.children[2]
+            owner.__dict__["_at_angle_synthetic"] = False
+        else:
+            at_node.set_value(2, angle)
+    elif angle != 0.0:
+        at_node.add(angle)
+        owner.__dict__["_at_angle_synthetic"] = True
+
+
 @dataclass
 class Pad:
     """Component pad."""
@@ -307,11 +340,7 @@ class Pad:
                 # than the ``object`` of ``__setattr__``'s signature (keeps
                 # mypy at baseline, matching ``Footprint.__setattr__``'s
                 # already-baselined pattern).
-                angle = float(value)  # type: ignore[arg-type]
-                if len(at_node.children) >= 3:
-                    at_node.set_value(2, angle)
-                elif angle != 0.0:
-                    at_node.add(angle)
+                _sync_at_angle(self, at_node, float(value))  # type: ignore[arg-type]
 
         elif name == "position":
             # Pad ``(at x y ...)`` stores FOOTPRINT-LOCAL coordinates (no
@@ -801,10 +830,7 @@ class Footprint:
         elif name == "rotation":
             at_node = sexp_node.find_child("at")
             if at_node is not None:
-                if len(at_node.children) >= 3:
-                    at_node.set_value(2, value)
-                elif value != 0.0:
-                    at_node.add(value)
+                _sync_at_angle(self, at_node, float(value))  # type: ignore[arg-type]
 
         elif name == "layer":
             layer_node = sexp_node.find_child("layer")

--- a/src/kicad_tools/transaction.py
+++ b/src/kicad_tools/transaction.py
@@ -59,13 +59,27 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from types import TracebackType
-from typing import Literal
+from typing import Literal, NamedTuple
 
 __all__ = [
     "BoardTransaction",
+    "RollbackMark",
     "TransactionRestoreError",
     "board_transaction",
 ]
+
+
+class RollbackMark(NamedTuple):
+    """High-water mark into a transaction's rollback record.
+
+    Obtained from :meth:`BoardTransaction.mark` and passed back to
+    :meth:`BoardTransaction.report_lines` to report only what a *single*
+    rollback did, rather than everything accumulated since transaction
+    entry (issue #4752).
+    """
+
+    restored: int
+    sidecars: int
 
 
 class TransactionRestoreError(RuntimeError):
@@ -129,6 +143,12 @@ class BoardTransaction:
         # propagates.  A TransactionRestoreError raised here chains onto
         # the original exception rather than replacing it.
         if exc_type is not None:
+            # Scope the announcement to THIS rollback (#4752): ``restored``
+            # / ``sidecars`` accumulate for the whole transaction lifetime,
+            # so an adopter that already rolled back earlier in the same
+            # ``with`` block would otherwise see those older lines replayed
+            # here alongside the new ones.
+            mark = self.mark()
             self.rollback()
             # Announce the rollback and forensic sidecar on stderr (#4736):
             # CLI adopters only print report_lines() on their explicit
@@ -138,7 +158,7 @@ class BoardTransaction:
             # propagates past this point and already names the failed
             # paths.  No overlap with the exit-code paths: those return
             # normally through __exit__ with exc_type is None.
-            for line in self.report_lines():
+            for line in self.report_lines(since=mark):
                 print(line, file=sys.stderr)
         return False
 
@@ -222,12 +242,35 @@ class BoardTransaction:
             counter += 1
         return candidate
 
-    def report_lines(self) -> list[str]:
-        """Human-readable summary of the last rollback (for CLI stderr)."""
+    def mark(self) -> RollbackMark:
+        """Capture the current rollback high-water mark.
+
+        Take a mark *before* a :meth:`rollback` and pass it to
+        :meth:`report_lines` afterwards to report only that rollback's
+        effects (issue #4752).
+        """
+        return RollbackMark(len(self.restored), len(self.sidecars))
+
+    def report_lines(self, since: RollbackMark | None = None) -> list[str]:
+        """Human-readable rollback summary (for CLI stderr).
+
+        ``restored`` / ``sidecars`` accumulate over the whole transaction
+        lifetime, so with the default ``since=None`` this reports *every*
+        rollback the transaction has performed.  That is what the
+        print-once-and-exit CLI adopters want.  A caller that runs several
+        operations inside one ``with`` block should instead take a
+        :meth:`mark` before each rollback and pass it here, so earlier,
+        unrelated lines are not replayed.
+
+        Args:
+            since: Only report paths recorded after this mark.  ``None``
+                (default) reports the whole transaction lifetime.
+        """
+        start = since if since is not None else RollbackMark(0, 0)
         lines: list[str] = []
-        for path in self.restored:
+        for path in self.restored[start.restored :]:
             lines.append(f"--transactional: rolled back {path} to its pre-command state")
-        for sidecar in self.sidecars:
+        for sidecar in self.sidecars[start.sidecars :]:
             lines.append(f"--transactional: failed attempt preserved at {sidecar}")
         return lines
 

--- a/tests/test_at_angle_residue.py
+++ b/tests/test_at_angle_residue.py
@@ -1,0 +1,180 @@
+"""No zero-angle residue in the ``(at ...)`` write-through (issue #4752).
+
+KiCad omits the angle token entirely when a footprint/pad rotation is zero,
+so ``(at x y)`` is the on-disk form for an unrotated part.  The
+rotation write-through in ``schema/pcb.py`` used to *append* an angle token
+on the first nonzero assignment and then ``set_value`` it forever after --
+so a transient rotation that returned to zero (the recovery applicator's
+mirror path, which flips ``theta -> 180 - theta`` twice) left a cosmetic
+``(at x y 0)`` behind.  Harmless to KiCad, pure noise in a diff.
+
+The token this write-through appended is now dropped again when the angle
+returns to zero; a token the *file* supplied is never removed, so boards
+written with an explicit ``(at x y 0)`` keep their bytes.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.recovery import (
+    Action,
+    Difficulty,
+    ResolutionStrategy,
+    StrategyApplicator,
+    StrategyType,
+)
+from kicad_tools.schema.pcb import PCB
+
+_BOARD_TEMPLATE = """(kicad_pcb
+	(version 20260206)
+	(generator "pcbnew")
+	(generator_version "10.0")
+	(paper "A4")
+	(layers
+		(0 "F.Cu" signal)
+		(2 "B.Cu" signal)
+		(1 "F.Mask" user)
+		(3 "B.Mask" user)
+		(5 "F.SilkS" user "F.Silkscreen")
+		(7 "B.SilkS" user "B.Silkscreen")
+		(13 "F.Paste" user)
+		(15 "B.Paste" user)
+		(25 "Edge.Cuts" user)
+		(29 "B.CrtYd" user "B.Courtyard")
+		(31 "F.CrtYd" user "F.Courtyard")
+		(33 "B.Fab" user)
+		(35 "F.Fab" user)
+	)
+	(net 0 "")
+	(footprint "Test:Residue"
+		(layer "F.Cu")
+		(uuid "11111111-1111-1111-1111-111111111111")
+		(at 100 100{fp_angle})
+		(property "Reference" "U1"
+			(at 0 2 0)
+			(layer "F.SilkS")
+			(uuid "22222222-2222-2222-2222-222222222222")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "1" smd rect
+			(at 0 0{pad_angle})
+			(size 1 1)
+			(layers "F.Cu" "F.Paste" "F.Mask")
+			(uuid "33333333-3333-3333-3333-333333333333")
+		)
+		(pad "2" smd rect
+			(at 1 0 45)
+			(size 1 1)
+			(layers "F.Cu" "F.Paste" "F.Mask")
+			(uuid "44444444-4444-4444-4444-444444444444")
+		)
+	)
+)
+"""
+
+
+def _write_board(tmp_path: Path, *, fp_angle: str = "", pad_angle: str = "") -> Path:
+    path = tmp_path / "residue.kicad_pcb"
+    path.write_text(_BOARD_TEMPLATE.format(fp_angle=fp_angle, pad_angle=pad_angle))
+    return path
+
+
+def _at_lines(text: str) -> list[str]:
+    """Every ``(at ...)`` node in *text*, whitespace-normalized."""
+    return [re.sub(r"\s+", " ", m).strip() for m in re.findall(r"\(at [^)]*\)", text)]
+
+
+def _saved(pcb: PCB, path: Path) -> str:
+    pcb.save(str(path))
+    return path.read_text()
+
+
+def _mirror(pcb: PCB) -> None:
+    strategy = ResolutionStrategy(
+        type=StrategyType.MIRROR_COMPONENT,
+        difficulty=Difficulty.MEDIUM,
+        confidence=1.0,
+        actions=[Action(type="mirror", target="U1", params={})],
+    )
+    result = StrategyApplicator().apply_strategy(pcb, strategy)
+    assert result.success is True, result.message
+
+
+class TestRotationWriteThroughResidue:
+    def test_footprint_angle_token_dropped_when_rotation_returns_to_zero(self, tmp_path: Path):
+        path = _write_board(tmp_path)
+        pcb = PCB.load(str(path))
+        fp = pcb.footprints[0]
+
+        fp.rotation = 90.0
+        assert "(at 100 100 90)" in _saved(pcb, path)
+
+        fp.rotation = 0.0
+        assert "(at 100 100)" in _at_lines(_saved(pcb, path))
+        assert "(at 100 100 0)" not in _saved(pcb, path)
+
+    def test_pad_angle_token_dropped_when_rotation_returns_to_zero(self, tmp_path: Path):
+        path = _write_board(tmp_path)
+        pcb = PCB.load(str(path))
+        pad = pcb.footprints[0].pads[0]
+
+        pad.rotation = 90.0
+        assert "(at 0 0 90)" in _at_lines(_saved(pcb, path))
+
+        pad.rotation = 0.0
+        assert "(at 0 0 0)" not in _at_lines(_saved(pcb, path))
+        assert "(at 0 0)" in _at_lines(_saved(pcb, path))
+
+    @pytest.mark.parametrize("angle", [90.0, 180.0, 45.5])
+    def test_nonzero_angles_still_written(self, tmp_path: Path, angle: float):
+        path = _write_board(tmp_path)
+        pcb = PCB.load(str(path))
+        pcb.footprints[0].rotation = angle
+        text = _saved(pcb, path)
+        assert f"(at 100 100 {angle:g})" in text
+        assert PCB.load(str(path)).footprints[0].rotation == pytest.approx(angle)
+
+    def test_file_supplied_zero_angle_token_is_preserved(self, tmp_path: Path):
+        """A board written as ``(at x y 0)`` keeps its explicit zero -- the
+        write-through only removes the token it added itself."""
+        path = _write_board(tmp_path, fp_angle=" 0", pad_angle=" 0")
+        pcb = PCB.load(str(path))
+        pcb.footprints[0].rotation = 0.0
+        pcb.footprints[0].pads[0].rotation = 0.0
+        lines = _at_lines(_saved(pcb, path))
+        assert "(at 100 100 0)" in lines
+        assert "(at 0 0 0)" in lines
+
+
+class TestMirrorRoundTripLeavesNoResidue:
+    """The originating report: mirror + un-mirror grew ``(at 0 0 0)``."""
+
+    def test_double_mirror_restores_original_at_tokens(self, tmp_path: Path):
+        path = _write_board(tmp_path)
+        before = _at_lines(path.read_text())
+
+        pcb = PCB.load(str(path))
+        _mirror(pcb)
+        _mirror(pcb)
+        after = _at_lines(_saved(pcb, path))
+
+        assert after == before
+
+    def test_single_mirror_still_writes_the_angle(self, tmp_path: Path):
+        path = _write_board(tmp_path)
+        pcb = PCB.load(str(path))
+        _mirror(pcb)
+        lines = _at_lines(_saved(pcb, path))
+        # theta -> 180 - theta for both the footprint and its pads.
+        assert "(at 100 100 180)" in lines
+        assert "(at 0 0 180)" in lines
+        assert "(at 1 0 135)" in lines

--- a/tests/test_benchmark_difficulty_vocabulary.py
+++ b/tests/test_benchmark_difficulty_vocabulary.py
@@ -1,0 +1,59 @@
+"""The benchmark difficulty vocabulary has one source of truth (issue #4752).
+
+``kct benchmark run --difficulty`` previously hardcoded its valid values in
+two unrelated places: argparse ``choices`` in ``cli/parser.py`` and a
+"valid options: easy, medium, hard" string in the handler's error message
+(``cli/commands/benchmark.py``).  Adding a member to ``Difficulty`` updated
+neither, so the two could silently drift from the enum and from each other.
+
+Both now derive from ``Difficulty.values()``; these tests fail if anyone
+re-hardcodes either site.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from kicad_tools.benchmark.cases import Difficulty
+from kicad_tools.cli.commands.benchmark import _run_benchmark
+from kicad_tools.cli.parser import create_parser
+
+
+def _difficulty_action() -> argparse.Action:
+    """The ``--difficulty`` action of the ``benchmark run`` subparser."""
+    parser = create_parser()
+    subparsers = next(a for a in parser._actions if isinstance(a, argparse._SubParsersAction))
+    benchmark = subparsers.choices["benchmark"]
+    benchmark_subparsers = next(
+        a for a in benchmark._actions if isinstance(a, argparse._SubParsersAction)
+    )
+    run = benchmark_subparsers.choices["run"]
+    return next(a for a in run._actions if "--difficulty" in a.option_strings)
+
+
+class TestDifficultyVocabulary:
+    def test_enum_values_are_the_declared_order(self):
+        assert Difficulty.values() == ["easy", "medium", "hard"]
+        assert Difficulty.values() == [d.value for d in Difficulty]
+
+    def test_parser_choices_come_from_the_enum(self):
+        action = _difficulty_action()
+        assert list(action.choices or []) == Difficulty.values()
+
+    def test_error_message_vocabulary_comes_from_the_enum(self, capsys):
+        """The handler's unknown-difficulty message must name exactly the
+        enum's values -- not a hand-maintained copy of them."""
+        args = argparse.Namespace(difficulty="impossible", format="text")
+        assert _run_benchmark(args) == 1
+        out = capsys.readouterr().out
+        assert "Unknown difficulty: impossible" in out
+        assert f"(valid options: {', '.join(Difficulty.values())})" in out
+        for value in Difficulty.values():
+            assert value in out
+
+    @pytest.mark.parametrize("value", Difficulty.values())
+    def test_every_enum_value_is_accepted_by_the_parser(self, value: str):
+        args = create_parser().parse_args(["benchmark", "run", "--difficulty", value])
+        assert args.difficulty == value

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -149,6 +149,63 @@ class TestExplicitRollback:
         assert any("failed attempt preserved" in line for line in lines)
 
 
+# ── Report scoping (multi-operation transactions) ───────────────────────
+
+
+class TestReportScoping:
+    """``restored``/``sidecars`` accumulate for the whole transaction, so a
+    caller running several operations in one ``with`` block must be able to
+    report just one rollback's effects (issue #4752)."""
+
+    def test_report_lines_since_mark_excludes_earlier_rollback(self, board: Path):
+        with board_transaction(board) as txn:
+            board.write_bytes(b"first attempt")
+            txn.rollback()
+            mark = txn.mark()
+            board.write_bytes(b"second attempt")
+            txn.rollback()
+
+        # txn.sidecars is chronological (filename sort is not).
+        first_sidecar, second_sidecar = txn.sidecars
+        scoped = txn.report_lines(since=mark)
+        assert len([ln for ln in scoped if "rolled back" in ln]) == 1
+        assert any(str(second_sidecar) in ln for ln in scoped)
+        assert not any(str(first_sidecar) in ln for ln in scoped)
+
+    def test_report_lines_default_still_covers_whole_lifetime(self, board: Path):
+        """Back-compat for the print-once-and-exit CLI adopters."""
+        with board_transaction(board) as txn:
+            board.write_bytes(b"first attempt")
+            txn.rollback()
+            board.write_bytes(b"second attempt")
+            txn.rollback()
+
+        lines = txn.report_lines()
+        assert len([ln for ln in lines if "rolled back" in ln]) == 2
+        assert len([ln for ln in lines if "failed attempt preserved" in ln]) == 2
+
+    def test_mark_on_fresh_transaction_is_zeroed(self, board: Path):
+        with board_transaction(board) as txn:
+            assert txn.mark() == (0, 0)
+
+    def test_exception_path_does_not_replay_earlier_rollback(self, board: Path, capsys):
+        """The ``__exit__`` announcement covers only the rollback it triggered."""
+        with pytest.raises(RuntimeError):
+            with board_transaction(board) as txn:
+                board.write_bytes(b"first attempt")
+                txn.rollback()  # earlier, unrelated operation
+                board.write_bytes(b"second attempt")
+                raise RuntimeError("boom")
+
+        err = capsys.readouterr().err
+        first_sidecar, second_sidecar = txn.sidecars
+        # One restore line, and only the sidecar from the failing operation.
+        assert len(re.findall(r"--transactional: rolled back ", err)) == 1
+        assert str(second_sidecar) in err
+        assert str(first_sidecar) not in err
+        assert board.read_bytes() == ORIGINAL
+
+
 # ── Forensic sidecar ────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Three independent, non-blocking Judge nits from the 2026-08-08 sweep (all
originating in the review of merged PR #4742). Polish only — no behavior
change for any current caller.

## Changes

**1. `BoardTransaction.report_lines()` accumulation** (`src/kicad_tools/transaction.py`)

`restored`/`sidecars` accumulate for the whole transaction lifetime, so the
`__exit__` exception-path announcement replayed every earlier rollback's lines.
Added `BoardTransaction.mark()` → `RollbackMark` (a `NamedTuple` high-water
mark) and `report_lines(since=...)`; `__exit__` takes a mark before its
rollback and reports only that rollback's effects. The default
`report_lines()` still covers the whole lifetime, so the two print-once-and-exit
CLI adopters (`fix_drc_cmd.py`, `pcb_sync_netlist.py`) are unchanged — and the
accumulation contract is now stated in the docstring.

**2. Difficulty-list drift** (`benchmark/cases.py`, `cli/parser.py`, `cli/commands/benchmark.py`)

The handler's `"valid options: easy, medium, hard"` string and the argparse
`choices=["easy", "medium", "hard"]` were two hand-maintained copies of the
`Difficulty` enum. Both now derive from a new `Difficulty.values()` classmethod
— the single source of truth. `parser.py` imports the enum from
`kicad_tools.benchmark.cases` directly; the benchmark package's
runner/generators keep the router behind `TYPE_CHECKING`, so the added CLI
startup cost is **~2.5 ms measured** on top of an already-imported
`kicad_tools` (<1% of the ~330 ms startup).

**3. `(at x y)` → `(at x y 0)` angle-token residue** (`schema/pcb.py`)

The rotation write-through appended an angle token on the first nonzero
assignment and `set_value`d it forever after, so a transient rotation that
returned to zero — the recovery applicator's mirror path, which applies
`theta -> 180 - theta` twice — left a cosmetic `(at x y 0)` behind.
`Pad.__setattr__` and `Footprint.__setattr__` now share a `_sync_at_angle`
helper that drops **only the token the write-through itself added** (tracked
per-owner via `_at_angle_synthetic`). A file-supplied explicit `(at x y 0)`
keeps its zero, so byte-fidelity for boards written that way is unchanged, and
nodes with 4+ tokens are never trimmed. `recovery/applicator.py` needed no
edit — it exercises the setters.

The helper's `float()` narrowing also removed two `object`-typed SExp
`arg-type` errors; `.github/mypy-baseline.txt` was tightened by exactly those
two lines (surgical edit, not `--update`, which in a locally-built worktree
drops the environment-specific `nanobind` `import-not-found` line that CI still
reports).

## Acceptance Criteria Verification

- [x] **Nit 1** — exception-path `__exit__` print emits only lines recorded
      within the scope chosen by the fix (high-water mark), and the
      whole-lifetime default is documented in `report_lines()`'s docstring.
      Verified by `TestReportScoping::test_exception_path_does_not_replay_earlier_rollback`.
- [x] **Nit 2** — exactly one source of truth (`Difficulty.values()`); parser
      `choices` and the `_fail` message both derive from it; no heavy import
      added (measured 2.5 ms). Verified by
      `tests/test_benchmark_difficulty_vocabulary.py` (asserts parser choices
      == enum values, and that the error text names exactly the enum values).
- [x] **Nit 3** — a mirror round-trip (mirror twice) of a footprint/pad whose
      `(at x y)` had no angle token leaves the token list unchanged; regression
      test added (`TestMirrorRoundTripLeavesNoResidue`), confirmed to FAIL
      against the pre-fix write-through (3 failures) and pass after.
- [x] **All tests from PR #4742 stay green unmodified** — `tests/test_mirror_golden.py`
      untouched and passing; `tests/test_transaction.py` only gained a new class.

## Test Plan

- [x] `tests/test_transaction.py` — 32 passed (4 new: `since`-scoped report,
      whole-lifetime default, zeroed fresh mark, exception-path non-replay)
- [x] `tests/test_benchmark_difficulty_vocabulary.py` — 6 passed (new file)
- [x] `tests/test_at_angle_residue.py` — 8 passed (new file; 3 of them fail
      against the pre-fix helper, verified)
- [x] `tests/test_mirror_golden.py tests/test_pcb_attr_roundtrip.py tests/test_pcb_move_footprint.py tests/test_cli_parser_drift.py tests/test_ipc_transactions.py` — 103 passed
- [x] `-k "rotation or mirror or at_angle or roundtrip or round_trip or serializ or footprint_locked or kicad10"` — 797 passed, 26 skipped
- [x] `-k "parser or benchmark_difficulty or applicator or transaction"` — 480 passed, 9 skipped
- [x] `tests/test_pcb*.py` (schema subset) + `tests/test_recovery*.py` — 422 passed
- [x] `uv run ruff check src/ tests/` clean; `uv run ruff format --check src/ tests/` clean
- [x] `uv run python scripts/ci/check_mypy_baseline.py` — no new type errors (1471 within 1473 allowed)
- [x] CLI smoke: `kct benchmark run --difficulty bogus` → `choose from easy, medium, hard`; `kct --version` startup ~0.45 s

Closes #4752