### PR TITLE
fix(route): gate grid-resolution advisories on the engine that routes on the grid

### DIFF
--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -10533,6 +10533,7 @@ def compute_dry_run_grid_plan(
     clearance: float,
     num_layers: int,
     max_cells: int,
+    engine: str = "grid",
 ) -> DryRunGridPlan | None:
     """Compute the analytical grid/cell/budget plan for ``--dry-run``.
 
@@ -10547,6 +10548,10 @@ def compute_dry_run_grid_plan(
         clearance: Trace clearance in mm (feeds the candidate DRC filter).
         num_layers: Number of routing layers (``layer_stack.num_layers``).
         max_cells: Cell budget from ``--max-cells``.
+        engine: Route engine (``--route-engine``), forwarded to the selector so
+            the memory-cap clearance advisory is not emitted for engines that
+            never route on the grid (issue #4690).  Diagnostics-only; every
+            reported figure is unchanged.
 
     Returns:
         A ``DryRunGridPlan``, or ``None`` if the board has no detectable
@@ -10576,6 +10581,7 @@ def compute_dry_run_grid_plan(
         board_width=board_width,
         board_height=board_height,
         max_cells=max_cells,
+        engine=engine,
     )
 
     # Off-grid counts keyed by resolution, from the selector's candidate trials.
@@ -12760,12 +12766,19 @@ def _main_impl(argv: list[str] | None = None) -> int:
         board_width = board_dims[0] if board_dims else None
         board_height = board_dims[1] if board_dims else None
         max_cells = getattr(args, "max_cells", 500_000)
+        # Issue #4690: the grid-quality advisories emitted below the selector
+        # describe (and prescribe remedies for) grid routing.  Thread the
+        # engine through so mesh/lattice runs do not receive advice that the
+        # #4271 gate-skip line -- printed a few lines later in the same log --
+        # simultaneously declares inapplicable.
+        _route_engine = getattr(args, "route_engine", "grid") or "grid"
         grid_auto_result = auto_select_grid_resolution(
             pads=pad_positions,
             clearance=args.clearance,
             board_width=board_width,
             board_height=board_height,
             max_cells=max_cells,
+            engine=_route_engine,
         )
 
         # When grid_strategy is adaptive (default), attempt multi-resolution
@@ -12783,6 +12796,7 @@ def _main_impl(argv: list[str] | None = None) -> int:
                     board_width=board_width,
                     board_height=board_height,
                     max_cells=max_cells,
+                    engine=_route_engine,
                 )
             except Exception:
                 # Fall back: try with pad positions (won't have ref info)
@@ -12792,6 +12806,7 @@ def _main_impl(argv: list[str] | None = None) -> int:
                     board_width=board_width,
                     board_height=board_height,
                     max_cells=max_cells,
+                    engine=_route_engine,
                 )
 
         if multi_res_plan is not None and multi_res_plan.is_multi_resolution:
@@ -12827,13 +12842,21 @@ def _main_impl(argv: list[str] | None = None) -> int:
         # blocked exactly the boards those engines exist for (softstart rev-C
         # falls in the #4242 grid gap: safe grid 0.0635mm exceeds every cell
         # budget).  The #3911 refusal stays fully intact for the grid engine.
-        _route_engine = getattr(args, "route_engine", "grid")
         if grid_auto_result.memory_forced_unsafe_grid and _route_engine != "grid":
             if not args.quiet:
                 print(
                     f"  Auto-grid safety gate: skipped for --route-engine "
                     f"{_route_engine} (no copper is routed on the grid; the "
                     f"{_route_engine} engine uses exact geometry)"
+                )
+                # Issue #4690: the memory cap bound, but --max-cells only buys a
+                # finer *grid*, which this engine does not route on.  Say so
+                # explicitly so the "increase max_cells" reflex (a multi-million
+                # cell grid the #4242 budget refuses) is not the takeaway.
+                print(
+                    "    (the auto-grid memory cap bound here, but --max-cells "
+                    f"tunes grid routing only and does not affect {_route_engine} "
+                    "results)"
                 )
         elif grid_auto_result.memory_forced_unsafe_grid and not (
             args.force or getattr(args, "allow_unsafe_grid", False)
@@ -13222,6 +13245,7 @@ def _main_impl(argv: list[str] | None = None) -> int:
             clearance=args.clearance,
             num_layers=layer_stack.num_layers,
             max_cells=getattr(args, "max_cells", 500_000),
+            engine=getattr(args, "route_engine", "grid") or "grid",
         )
         if dry_run_plan is not None:
             if not quiet:
@@ -13417,7 +13441,25 @@ def _main_impl(argv: list[str] | None = None) -> int:
 
     # Analyze fine-pitch components for grid compatibility warnings
     # This runs automatically to warn users about potential routing issues
-    if not quiet:
+    #
+    # Issue #4690: the whole report is about *grid* compatibility -- per-pad
+    # "off-grid by 0.02mm" advisories, "Use finer grid: --grid 0.0635", and the
+    # ">50% of pads are off-grid ... Routing quality will be degraded" WARNING.
+    # Under --route-engine mesh/lattice no copper is emitted from the grid (the
+    # grid object is a coordinate substrate only, per the #4271/#4283 record),
+    # so every line of it is inapplicable -- and it directly contradicts the
+    # "no copper is routed on the grid" gate-skip line in the same log.  Worse,
+    # its remedy is harmful here: refining the grid to 0.0635/0.025mm on a
+    # 160x100mm board demands millions of cells the #4242 budget cap refuses.
+    # Skip the analysis for non-grid engines and say why in one line.
+    _fine_pitch_engine = getattr(args, "route_engine", "grid") or "grid"
+    if not quiet and _fine_pitch_engine != "grid":
+        flush_print(
+            f"\n  Fine-pitch grid analysis: skipped for --route-engine "
+            f"{_fine_pitch_engine} (pads are reached by exact geometry, not by "
+            f"grid alignment)"
+        )
+    elif not quiet:
         from kicad_tools.router.fine_pitch import analyze_fine_pitch_components
         from kicad_tools.router.output import show_fine_pitch_warnings
 

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -1101,6 +1101,7 @@ def auto_select_grid_resolution(
     board_height: float | None = None,
     max_cells: int = 500_000,
     candidates: list[float] | None = None,
+    engine: str = "grid",
 ) -> GridAutoSelection:
     """Automatically select optimal grid resolution based on pad positions.
 
@@ -1121,6 +1122,15 @@ def auto_select_grid_resolution(
                    to the fixed list.  This handles packages like
                    SSOP/TSSOP with 0.65mm pitch whose pads don't align
                    to any standard grid size.
+        engine: Route engine that will consume this grid (``--route-engine``:
+                ``"grid"`` / ``"mesh"`` / ``"lattice"``).  Issue #4690: the
+                memory-cap "may produce clearance violations" ``UserWarning``
+                predicts a *grid-routing* failure mode, so it is demoted to an
+                INFO log for the mesh/lattice engines, which emit no copper
+                from the grid (the same predicate as the #4271 gate skip).
+                Purely a diagnostics gate -- every returned field, including
+                ``memory_forced_unsafe_grid``, is computed identically for
+                every engine.
 
     Returns:
         GridAutoSelection with the chosen resolution and analysis details.
@@ -1454,6 +1464,27 @@ def auto_select_grid_resolution(
                 f"backstop.",
                 stacklevel=2,
             )
+        elif has_fine_pitch and engine != "grid":
+            # Issue #4690: the alarm below predicts a grid-routing failure mode
+            # ("routing may produce clearance violations at fine-pitch pads")
+            # and prescribes a grid-routing remedy ("increase max_cells").
+            # Under --route-engine mesh/lattice NO copper is emitted from the
+            # grid -- the same premise the #4271 safety-gate skip already
+            # states -- so both the prediction and the remedy are inapplicable,
+            # and the remedy is actively harmful (it steers the user toward a
+            # multi-million-cell grid that the #4242 budget cap refuses).
+            # Demote to INFO so the selection event stays observable without
+            # contradicting the gate-skip line printed in the same log.
+            logger.info(
+                "Auto-grid: memory budget cap selected grid %smm > clearance/2 "
+                "(%smm) even at max_cells=%s; --route-engine %s routes on exact "
+                "geometry (no copper is emitted from the grid), so no "
+                "grid-quantisation clearance risk applies.",
+                best_resolution,
+                recommended_max,
+                f"{effective_max_cells:,}",
+                engine,
+            )
         elif has_fine_pitch:
             # Genuine #3911 risk: the memory cap coerced a grid > clearance/2
             # AND the board carries fine-pitch pads whose inter-pad channel the
@@ -1518,6 +1549,7 @@ def compute_multi_resolution_plan(
     off_grid_escalation_threshold: float = 10.0,
     min_off_grid_pads_to_escalate: int = 2,
     min_escalation_fine_resolution: float = 0.005,
+    engine: str = "grid",
 ) -> MultiResolutionGridPlan | None:
     """Compute a multi-resolution grid plan for adaptive routing.
 
@@ -1556,6 +1588,10 @@ def compute_multi_resolution_plan(
             fine resolution (mm).  Lower than ``min_fine_resolution`` so
             the solver can find a (resolution, offset) that aligns
             sub-0.05mm pad coordinates (issue #2837).  Default 0.005mm.
+        engine: Route engine that will consume the plan; forwarded verbatim
+            to :func:`auto_select_grid_resolution` so the memory-cap
+            advisory is not emitted for engines that never route on the
+            grid (issue #4690).  Diagnostics-only; the plan is unchanged.
 
     Returns:
         MultiResolutionGridPlan if fine-pitch components detected or
@@ -1583,6 +1619,9 @@ def compute_multi_resolution_plan(
         board_width=board_width,
         board_height=board_height,
         max_cells=max_cells,
+        # Issue #4690: forward the route engine so the memory-cap advisory is
+        # not emitted for engines that never route on the grid.
+        engine=engine,
     )
     coarse_resolution = uniform_result.resolution
 
@@ -3756,6 +3795,13 @@ def load_pcb_for_routing(
         # the authoritative message).  Scope the warning emission to at-risk
         # fine-pitch boards; the strict-mode raise is unchanged (still gated on
         # ``strict_drc``), so this is a diagnostics-only narrowing.
+        #
+        # Issue #4690: narrow it further to the grid engine.  ``strategy`` IS
+        # the ``--route-engine`` selector; under ``mesh``/``lattice`` no copper
+        # is emitted from the grid (see the #4271 gate-skip rationale), so a
+        # "grid resolution may cause clearance violations" heads-up describes a
+        # failure mode those engines cannot have -- and directly contradicts
+        # the gate-skip line printed in the same log.
         _pad_positions = [
             PadPosition(x=pad["x"], y=pad["y"]) for comp in components for pad in comp["pads"]
         ]
@@ -3764,7 +3810,7 @@ def load_pcb_for_routing(
         validate_grid_resolution(
             rules.grid_resolution,
             rules.trace_clearance,
-            warn=_has_fine_pitch,
+            warn=_has_fine_pitch and strategy == "grid",
             strict=strict_drc,
         )
 

--- a/tests/test_route_grid_safety_gate.py
+++ b/tests/test_route_grid_safety_gate.py
@@ -11,12 +11,35 @@ caller explicitly opts in with ``--allow-unsafe-grid`` or ``--force``.
 These tests drive ``route_cmd.main()`` up to the gate by stubbing the
 grid-analysis helpers (a real 200x200mm route would take minutes and the gate
 fires long before any copper is placed).
+
+Issue #4690 extends this file to the *rest* of the grid advisories that used to
+contradict the #4271 gate-skip line in the same log: the auto-grid memory-cap
+``UserWarning``, the ``validate_grid_resolution`` ``UserWarning``, and the
+fine-pitch component analysis ("N pads off-grid", "Use finer grid: --grid ...",
+"Routing quality will be degraded").  All three are now gated on the engine
+actually routing on the grid; all three must still fire for ``--route-engine
+grid``.
 """
 
+import logging
+import warnings
 from unittest.mock import patch
 
+import pytest
+
 from kicad_tools.cli import route_cmd
-from kicad_tools.router.io import GridAutoSelection, PadPosition
+from kicad_tools.router.io import (
+    DesignRules,
+    GridAutoSelection,
+    PadPosition,
+    auto_select_grid_resolution,
+    compute_multi_resolution_plan,
+    load_pcb_for_routing,
+)
+
+# Engines that never emit copper from the grid (#4271/#4283), so every
+# grid-quality advisory is inapplicable to them.
+_NON_GRID_ENGINES = ["lattice", "mesh"]
 
 
 class _GateReached(Exception):
@@ -165,3 +188,288 @@ def test_grid_engine_gate_unchanged_by_engine_bypass(tmp_path, capsys):
     assert code == 1
     assert gate_reached is False
     assert "--allow-unsafe-grid" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Issue #4690: the auto-grid memory-cap UserWarning
+# ---------------------------------------------------------------------------
+#
+# The board below is the #3911 reproducer from
+# ``tests/test_grid_auto_selection.py`` -- 20 pads on a 0.127mm imperial
+# lattice (so the #3441 rescue candidate does not help and never fires) plus
+# one 0.5mm-pitch pair that makes the board read as fine-pitch.  The memory
+# cap therefore coerces a grid > clearance/2 with a finer safe candidate
+# available: exactly the state that emits "memory budget cap forces".
+
+
+def _memory_capped_fine_pitch_pads() -> list[PadPosition]:
+    pads = [PadPosition(x=10.0 + i * 1.27 + 0.0635, y=20.0) for i in range(20)]
+    pads += [PadPosition(x=50.0, y=60.0), PadPosition(x=50.5, y=60.0)]
+    return pads
+
+
+def _select_memory_capped(**kwargs) -> tuple[GridAutoSelection, list[str]]:
+    """Run the selector on the memory-capped board, capturing warning texts."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = auto_select_grid_resolution(
+            _memory_capped_fine_pitch_pads(),
+            clearance=0.15,
+            board_width=100.0,
+            board_height=100.0,
+            max_cells=500_000,
+            candidates=[0.5, 0.25, 0.127, 0.1, 0.065, 0.05, 0.0508],
+            **kwargs,
+        )
+    return result, [str(w.message) for w in caught]
+
+
+def test_memory_cap_warning_fires_for_default_engine():
+    """Callers that do not pass ``engine`` keep the pre-#4690 behavior."""
+    result, texts = _select_memory_capped()
+    assert result.memory_forced_unsafe_grid is True
+    assert any("memory budget cap forces" in t for t in texts), texts
+    assert any("Routing may produce clearance violations" in t for t in texts), texts
+
+
+def test_memory_cap_warning_fires_for_explicit_grid_engine():
+    """``engine="grid"`` is byte-identical to the default."""
+    result, texts = _select_memory_capped(engine="grid")
+    assert result.memory_forced_unsafe_grid is True
+    assert any("memory budget cap forces" in t for t in texts), texts
+
+
+@pytest.mark.parametrize("engine", _NON_GRID_ENGINES)
+def test_memory_cap_warning_suppressed_for_non_grid_engines(engine):
+    """No copper comes off the grid, so the clearance alarm must not fire.
+
+    The alarm both predicts a grid-routing failure ("may produce clearance
+    violations at fine-pitch pads") and prescribes a grid-routing remedy
+    ("increase max_cells"), directly contradicting the #4271 gate-skip line
+    printed in the same log -- and the remedy is actively harmful (it steers
+    the user toward a multi-million-cell grid the #4242 cap refuses).
+    """
+    _result, texts = _select_memory_capped(engine=engine)
+    assert not any("memory budget cap forces" in t for t in texts), texts
+    assert not any("Routing may produce clearance violations" in t for t in texts), texts
+
+
+@pytest.mark.parametrize("engine", _NON_GRID_ENGINES)
+def test_memory_forced_unsafe_grid_flag_still_computed_for_non_grid(engine):
+    """Suppression is diagnostics-only: the #3911 flag is engine-invariant.
+
+    The #4271 gate-skip line is printed *because* this flag is True, so
+    clearing it would silently delete the very message this issue keeps.
+    """
+    result, _texts = _select_memory_capped(engine=engine)
+    assert result.memory_forced_unsafe_grid is True
+    assert result.resolution == _select_memory_capped(engine="grid")[0].resolution
+
+
+@pytest.mark.parametrize("engine", _NON_GRID_ENGINES)
+def test_memory_cap_event_still_observable_at_info_for_non_grid(engine, caplog):
+    """Suppressed, not silenced: the event is demoted to an INFO log."""
+    with caplog.at_level(logging.INFO, logger="kicad_tools.router.io"):
+        _select_memory_capped(engine=engine)
+    messages = [rec.getMessage() for rec in caplog.records]
+    assert any(
+        "memory budget cap selected grid" in m and f"--route-engine {engine}" in m for m in messages
+    ), messages
+
+
+@pytest.mark.parametrize("engine", _NON_GRID_ENGINES)
+def test_multi_resolution_plan_forwards_engine_to_selector(engine):
+    """``compute_multi_resolution_plan`` is the adaptive-strategy call path."""
+    pads = _memory_capped_fine_pitch_pads()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        compute_multi_resolution_plan(
+            pads=pads,
+            clearance=0.15,
+            board_width=100.0,
+            board_height=100.0,
+            max_cells=500_000,
+            engine=engine,
+        )
+    texts = [str(w.message) for w in caught]
+    assert not any("memory budget cap forces" in t for t in texts), texts
+
+
+def test_multi_resolution_plan_warns_for_grid_engine():
+    """The same call on the grid engine still emits the advisory."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        compute_multi_resolution_plan(
+            pads=_memory_capped_fine_pitch_pads(),
+            clearance=0.15,
+            board_width=100.0,
+            board_height=100.0,
+            max_cells=500_000,
+        )
+    texts = [str(w.message) for w in caught]
+    assert any("memory budget cap forces" in t for t in texts), texts
+
+
+# ---------------------------------------------------------------------------
+# Issue #4690: the validate_grid_resolution UserWarning at the load site
+# ---------------------------------------------------------------------------
+
+_FINE_PITCH_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+  )
+  (gr_rect (start 100 100) (end 150 140) (layer "Edge.Cuts"))
+  (net 0 "")
+  (footprint "Test"
+    (layer "F.Cu")
+    (at 120 120)
+    (fp_text reference "R1" (at 0 0) (layer "F.SilkS"))
+    (pad "1" smd rect (at 0 0) (size 0.3 0.3) (layers "F.Cu") (net 0 ""))
+    (pad "2" smd rect (at 0.5 0) (size 0.3 0.3) (layers "F.Cu") (net 0 ""))
+  )
+)"""
+
+
+def _load_with_strategy(tmp_path, **kwargs) -> list[str]:
+    """Load a fine-pitch board on a grid > clearance/2, capturing warnings."""
+    pcb_file = tmp_path / "fine_pitch.kicad_pcb"
+    pcb_file.write_text(_FINE_PITCH_PCB)
+    # grid=0.15 > clearance/2 (0.1) but <= clearance (0.2): the advisory band.
+    rules = DesignRules(grid_resolution=0.15, trace_clearance=0.2)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        load_pcb_for_routing(
+            str(pcb_file),
+            rules=rules,
+            validate_drc=True,
+            strict_drc=False,
+            **kwargs,
+        )
+    return [str(w.message) for w in caught]
+
+
+def test_load_grid_resolution_warning_fires_for_grid_strategy(tmp_path):
+    """Default (grid) strategy keeps the #3942 fine-pitch heads-up."""
+    texts = _load_with_strategy(tmp_path)
+    assert any("may cause clearance violations" in t for t in texts), texts
+
+
+@pytest.mark.parametrize("engine", _NON_GRID_ENGINES)
+def test_load_grid_resolution_warning_suppressed_for_non_grid(tmp_path, engine):
+    """``strategy`` IS ``--route-engine``; mesh/lattice do not route on the grid."""
+    texts = _load_with_strategy(tmp_path, strategy=engine)
+    assert not any("may cause clearance violations" in t for t in texts), texts
+
+
+# ---------------------------------------------------------------------------
+# Issue #4690: the fine-pitch component analysis block in route_cmd
+# ---------------------------------------------------------------------------
+
+_OFF_GRID_ROUTABLE_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (gr_rect (start 100 100) (end 130 120) (layer "Edge.Cuts"))
+  (net 0 "")
+  (net 1 "NET1")
+  (net 2 "NET2")
+  (footprint "U1"
+    (layer "F.Cu")
+    (at 105 105)
+    (fp_text reference "U1" (at 0 0) (layer "F.SilkS"))
+    (pad "1" smd rect (at 0.03 0.03) (size 0.3 0.3) (layers "F.Cu") (net 1 "NET1"))
+    (pad "2" smd rect (at 0.53 0.03) (size 0.3 0.3) (layers "F.Cu") (net 2 "NET2"))
+  )
+  (footprint "U2"
+    (layer "F.Cu")
+    (at 120 115)
+    (fp_text reference "U2" (at 0 0) (layer "F.SilkS"))
+    (pad "1" smd rect (at 0.03 0.03) (size 0.3 0.3) (layers "F.Cu") (net 1 "NET1"))
+    (pad "2" smd rect (at 0.53 0.03) (size 0.3 0.3) (layers "F.Cu") (net 2 "NET2"))
+  )
+)"""
+
+# Every grid-quality string the lattice log must not contain.
+_GRID_ADVISORY_MARKERS = [
+    "Fine-Pitch Component Analysis",
+    "Fine-pitch components detected",
+    "pads off-grid",
+    "Use finer grid",
+    "Routing quality will be degraded",
+    "for better pad alignment",
+]
+
+
+def _route_cli(tmp_path, extra_args) -> tuple[int, list[str]]:
+    """Run ``route_cmd.main`` past the fine-pitch block on a tiny board.
+
+    ``--layers 2`` pins the fixed-layer path (``--auto-layers`` diverts to
+    ``route_with_layer_escalation``, which never reaches the block under test).
+    Returns the exit code and the texts of any ``warnings.warn`` emissions.
+    """
+    pcb_file = tmp_path / "off_grid.kicad_pcb"
+    pcb_file.write_text(_OFF_GRID_ROUTABLE_PCB)
+    out = tmp_path / "routed.kicad_pcb"
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        code = route_cmd.main(
+            [
+                str(pcb_file),
+                "-o",
+                str(out),
+                "--grid",
+                "0.15",
+                "--clearance",
+                "0.2",
+                "--layers",
+                "2",
+                *extra_args,
+            ]
+        )
+    return code, [str(w.message) for w in caught]
+
+
+def test_fine_pitch_advisories_fire_for_grid_engine(tmp_path, capsys):
+    """The default grid engine keeps every advisory (#2254 behavior intact)."""
+    _route_cli(tmp_path, [])
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    for marker in _GRID_ADVISORY_MARKERS:
+        assert marker in combined, f"grid engine lost advisory {marker!r}"
+    assert "skipped for --route-engine" not in combined
+
+
+@pytest.mark.parametrize("engine", _NON_GRID_ENGINES)
+def test_fine_pitch_advisories_suppressed_for_non_grid_engines(tmp_path, engine, capsys):
+    """The whole grid-compatibility report is skipped, with a reason line.
+
+    This is the contradiction the issue reported: the same log said "no copper
+    is routed on the grid" and then recommended ``--grid 0.0635``.
+    """
+    _code, warn_texts = _route_cli(tmp_path, ["--route-engine", engine, "--strategy", "basic"])
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    for marker in _GRID_ADVISORY_MARKERS:
+        assert marker not in combined, f"{engine} engine still emitted {marker!r}"
+    assert f"Fine-pitch grid analysis: skipped for --route-engine {engine}" in combined
+    # ...and no grid-resolution UserWarning escaped either (io.py site).
+    assert not any("may cause clearance violations" in t for t in warn_texts), warn_texts
+
+
+@pytest.mark.parametrize("engine", ["grid", *_NON_GRID_ENGINES])
+def test_quiet_emits_no_fine_pitch_output_on_any_engine(tmp_path, engine, capsys):
+    """--quiet behavior is unchanged: neither branch prints (#4690 AC)."""
+    extra = ["--quiet", "--route-engine", engine]
+    if engine != "grid":
+        extra += ["--strategy", "basic"]
+    _route_cli(tmp_path, extra)
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    for marker in [*_GRID_ADVISORY_MARKERS, "Fine-pitch grid analysis: skipped"]:
+        assert marker not in combined, f"--quiet leaked {marker!r} on {engine}"


### PR DESCRIPTION
## Summary

`kct route --route-engine lattice` stated at line 16 that *"no copper is routed on the grid; the lattice engine uses exact geometry"* and then, 700 lines later in the same log, warned that **96% of pads were off-grid**, that **routing quality would be degraded**, and recommended **`--grid 0.0635`**. That recommendation is worse than noise: on the reporter's 160×100 mm board it demands millions of cells that the #4242 budget cap refuses, and it predicts clearance violations that an exact-geometry engine cannot produce.

Only one of the four emission sites was engine-aware (the #4271 gate-skip line). This PR makes the other three honour the same predicate — `route_engine != "grid"` — so the log stops contradicting itself. Per the curated analysis this is option 1 (suppress): the #4271/#4283 record confirms line 16's parenthetical is correct, so every grid-quality advisory is inapplicable under mesh/lattice.

## Changes

**`src/kicad_tools/cli/route_cmd.py`**
- Fine-pitch component analysis block (`_main_impl`): `analyze_fine_pitch_components` / `show_fine_pitch_warnings` are skipped entirely for non-grid engines, replaced by one line — `Fine-pitch grid analysis: skipped for --route-engine lattice (pads are reached by exact geometry, not by grid alignment)`. The grid branch is byte-identical (the existing `if not quiet:` became `elif not quiet:`).
- Auto-grid call sites: `_route_engine` is now computed once before the selector and threaded into `auto_select_grid_resolution` + both `compute_multi_resolution_plan` calls (the redundant re-derivation at the #4271 gate is removed).
- The #4271 skip line gains a second line noting that `--max-cells` tunes grid routing only and does not affect this engine's results — the issue's option 3, so "increase max_cells" is not the reader's takeaway.
- `compute_dry_run_grid_plan` gains the same `engine` passthrough so `--dry-run` on a lattice run is consistent.

**`src/kicad_tools/router/io.py`**
- `auto_select_grid_resolution(..., engine: str = "grid")`: the memory-cap `UserWarning` ("*forces grid … Routing may produce clearance violations at fine-pitch pads. Increase max_cells …*") is demoted to a `logger.info` for non-grid engines, so the event stays observable without alarming. `compute_multi_resolution_plan` forwards `engine` verbatim.
- `load_pcb_for_routing`: the `validate_grid_resolution` warn gate becomes `warn=_has_fine_pitch and strategy == "grid"`. `strategy` **is** the `--route-engine` selector and was already in scope at that call site.

**Deliberately untouched** (per the curated scope): the #3441 `lattice_rescued` warning (that flag is pad-lattice alignment, *not* the lattice engine), the `memory_forced_unsafe_grid` flag computation, the #3911 hard-error refusal, the #3942 fine-pitch predicates, and `fine_pitch.py` / `output.py` report text.

## Acceptance Criteria Verification

- [x] **With `--route-engine lattice`/`mesh`, none of the per-footprint off-grid advisories, "Use finer grid: --grid …", or the ">50% of pads off-grid … Routing quality will be degraded" WARNING is emitted** — `test_fine_pitch_advisories_suppressed_for_non_grid_engines` drives `route_cmd.main()` end-to-end on a 4-pad off-grid board and asserts the absence of all six marker strings.
- [x] **Neither `UserWarning` is raised under lattice/mesh** — `test_memory_cap_warning_suppressed_for_non_grid_engines` (io.py site 2, via `warnings.catch_warnings(record=True)`) and `test_load_grid_resolution_warning_suppressed_for_non_grid` (site 3), plus a warning assertion inside the end-to-end CLI test.
- [x] **With `--route-engine grid` (default) all four diagnostics still fire** — `test_fine_pitch_advisories_fire_for_grid_engine` asserts every marker is still present; `test_memory_cap_warning_fires_for_default_engine` / `..._for_explicit_grid_engine` / `test_multi_resolution_plan_warns_for_grid_engine` / `test_load_grid_resolution_warning_fires_for_grid_strategy` cover the two `UserWarning`s. The #3441 and #3942 wording assertions in `tests/test_grid_auto_selection.py` and `tests/test_router_io.py` are unchanged and green.
- [x] **The #3911 refusal and the #4271 gate-skip line are unchanged** — the seven pre-existing tests in this file still pass unmodified; `test_memory_forced_unsafe_grid_flag_still_computed_for_non_grid` pins the flag (and the selected resolution) as engine-invariant, since the #4271 line is printed *because* that flag is True.
- [x] **`--quiet` behavior unchanged on all engines** — `test_quiet_emits_no_fine_pitch_output_on_any_engine` (parametrized over grid/lattice/mesh) asserts neither the advisories nor the new skip line leak.

## Test Plan

- `tests/test_route_grid_safety_gate.py` — **27 passed** (7 pre-existing + 20 new, covering the selector `engine` parameter, the multi-resolution forwarder, the `load_pcb_for_routing` strategy gate, the end-to-end CLI fine-pitch block, and `--quiet`).
- Regression suites named in the issue's test plan plus the touched-symbol neighbours: `test_grid_auto_selection.py`, `test_grid_safety_gate_fleet.py`, `test_fine_pitch.py`, `test_router_io.py`, `test_route_max_cells_flag.py`, `test_route_dry_run_analytical_plan_4263.py` — **375 passed**.
- Broader engine/grid selection: `pytest tests/ -k "route_engine or lattice_gate or engine_gate or route_cmd or grid_resolution or adaptive_grid or preflight"` — **552 passed, 2 skipped**.
- `ruff check .` clean; `ruff format --check .` clean (1774 files).
- `scripts/ci/check_mypy_baseline.py`: `OK: mypy reports 1473 error(s), all within the baseline (1475 allowed). No new type errors.` (Baseline deliberately not `--update`d — the native-built worktree drops env-agnostic lines.)
- Manual repro on a 30×20 mm off-grid fixture at `--grid 0.15 --clearance 0.2 --layers 2`:
  - `--route-engine grid` → `--- Fine-Pitch Component Analysis ---`, `Use finer grid: --grid 0.025 or --grid 0.075`, `WARNING: 100% of pads (4/4) are off-grid`, plus the `io.py` `UserWarning` — all still present.
  - `--route-engine lattice --strategy basic` → all of the above gone, replaced by the single skip line; no `UserWarning`.

Closes #4690
