### PR TITLE
fix(route): derive the lattice deadline from --timeout/--per-net-timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`--timeout` / `--per-net-timeout` now actually bound the lattice
+  engine** (#4697) — `kct route --route-engine lattice` was time-bounded
+  **only** under `--complete`. Everywhere else both flags were accepted,
+  echoed in the routing banner, and silently discarded, producing
+  observed 60+ minute unbounded runs on `--strategy basic` — the only
+  strategy the #4280 gate allows on the lattice. Root cause: the lattice
+  negotiates the whole netset in a single `route_netset()` call, so
+  `route_all()`'s between-nets `timeout` check can never fire mid-run,
+  and the negotiation's only bound (`deadline`) was derived solely from
+  `args._complete_link_budget_s`, which nothing but `--complete` stamps.
+  Fixed at that seam: `--per-net-timeout` now supplies the per-link
+  budget on **every** lattice run (same `budget x link-count` scaling
+  `--complete` already used), and `--timeout` supplies an absolute
+  monotonic ceiling threaded through `load_pcb_for_routing(...,
+  lattice_deadline=)`; when both are present the tighter bound wins.
+  `--complete`'s existing stamp still wins verbatim (#4472 semantics
+  unchanged), and `--per-net-timeout 0` (e.g. under
+  `--deterministic-budget`, where a wall-clock bound would destroy
+  reproducibility) still yields an unbudgeted negotiation. A truncated
+  run reports partial results with the existing `deadline-exceeded`
+  decline reason rather than dying silently. Also: the six bare
+  `router.route_all()` CLI dispatch sites now forward the user's budgets
+  (binding them on the grid engine and silencing the #2794 no-timeout
+  guard that fired pointing straight back at those lines), and the
+  routing banner no longer claims a budget the dispatched engine does
+  not enforce — on the lattice it labels `--per-net-timeout` as the
+  per-link budget it really is, labels `--timeout` as a hard cap, and
+  says loudly when a run is unbounded.
 - **Board-06 regen is same-host run-to-run deterministic again** (#4536) —
   two same-seed flag-OFF regens could differ by thousands of lines,
   making the "flag-OFF run must produce a byte-identical committed

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -5656,8 +5656,12 @@ def route_with_layer_escalation(
                     # Issue #4472 (epic #4465, Phase 2): --complete localizes the
                     # lattice build + static masks to the region box, and bounds
                     # each link's search with a per-link wall-clock budget.
+                    # Issue #4697: that per-link budget is no longer --complete-only
+                    # (it now derives from --per-net-timeout on every lattice run),
+                    # and --timeout supplies an absolute ceiling alongside it.
                     localize_lattice_to_region=getattr(args, "_complete_localized", False),
-                    lattice_link_budget_s=getattr(args, "_complete_link_budget_s", None),
+                    lattice_link_budget_s=_resolve_lattice_link_budget(args),
+                    lattice_deadline=_lattice_absolute_deadline(args),
                     # Issue #4170 (Phase 2b-1): board-relative boundary stub
                     # terminals whose tip cells are carved open as same-net
                     # reconnection targets (None when no --region / no stubs).
@@ -5815,7 +5819,16 @@ def route_with_layer_escalation(
                     best_stall_patience=(getattr(args, "early_stop_patience", 2) or None),
                 )
             elif args.strategy == "basic":
-                router.route_all()
+                # Issue #4697: forward the user's budgets rather than calling
+                # route_all() bare (which tripped the #2794 no-timeout guard
+                # pointing straight back here).  This binds the GRID engine;
+                # the lattice is bounded upstream by the deadline stamped on
+                # the router at load time, since its single whole-netset
+                # negotiation never reaches route_all's between-nets check.
+                router.route_all(
+                    timeout=_budgeted_timeout(args),
+                    per_net_timeout=getattr(args, "per_net_timeout", None) or None,
+                )
             elif args.strategy == "monte-carlo":
                 router.route_all_monte_carlo(
                     num_trials=args.mc_trials,
@@ -6650,8 +6663,12 @@ def route_with_rule_relaxation(
                     # Issue #4472 (epic #4465, Phase 2): --complete localizes the
                     # lattice build + static masks to the region box, and bounds
                     # each link's search with a per-link wall-clock budget.
+                    # Issue #4697: that per-link budget is no longer --complete-only
+                    # (it now derives from --per-net-timeout on every lattice run),
+                    # and --timeout supplies an absolute ceiling alongside it.
                     localize_lattice_to_region=getattr(args, "_complete_localized", False),
-                    lattice_link_budget_s=getattr(args, "_complete_link_budget_s", None),
+                    lattice_link_budget_s=_resolve_lattice_link_budget(args),
+                    lattice_deadline=_lattice_absolute_deadline(args),
                     # Issue #4170 (Phase 2b-1): board-relative boundary stub
                     # terminals whose tip cells are carved open as same-net
                     # reconnection targets (None when no --region / no stubs).
@@ -6787,7 +6804,16 @@ def route_with_rule_relaxation(
                     best_stall_patience=(getattr(args, "early_stop_patience", 2) or None),
                 )
             elif args.strategy == "basic":
-                router.route_all()
+                # Issue #4697: forward the user's budgets rather than calling
+                # route_all() bare (which tripped the #2794 no-timeout guard
+                # pointing straight back here).  This binds the GRID engine;
+                # the lattice is bounded upstream by the deadline stamped on
+                # the router at load time, since its single whole-netset
+                # negotiation never reaches route_all's between-nets check.
+                router.route_all(
+                    timeout=_budgeted_timeout(args),
+                    per_net_timeout=getattr(args, "per_net_timeout", None) or None,
+                )
             elif args.strategy == "monte-carlo":
                 router.route_all_monte_carlo(
                     num_trials=args.mc_trials,
@@ -8868,8 +8894,12 @@ def route_with_combined_escalation(
                         # Issue #4472 (epic #4465, Phase 2): --complete localizes the
                         # lattice build + static masks to the region box, and bounds
                         # each link's search with a per-link wall-clock budget.
+                        # Issue #4697: that per-link budget is no longer --complete-only
+                        # (it now derives from --per-net-timeout on every lattice run),
+                        # and --timeout supplies an absolute ceiling alongside it.
                         localize_lattice_to_region=getattr(args, "_complete_localized", False),
-                        lattice_link_budget_s=getattr(args, "_complete_link_budget_s", None),
+                        lattice_link_budget_s=_resolve_lattice_link_budget(args),
+                        lattice_deadline=_lattice_absolute_deadline(args),
                         # Issue #4170 (Phase 2b-1): board-relative boundary stub
                         # terminals whose tip cells are carved open as same-net
                         # reconnection targets (None when no --region / no stubs).
@@ -8991,7 +9021,16 @@ def route_with_combined_escalation(
                         best_stall_patience=(getattr(args, "early_stop_patience", 2) or None),
                     )
                 elif args.strategy == "basic":
-                    router.route_all()
+                    # Issue #4697: forward the user's budgets rather than calling
+                    # route_all() bare (which tripped the #2794 no-timeout guard
+                    # pointing straight back here).  This binds the GRID engine;
+                    # the lattice is bounded upstream by the deadline stamped on
+                    # the router at load time, since its single whole-netset
+                    # negotiation never reaches route_all's between-nets check.
+                    router.route_all(
+                        timeout=_budgeted_timeout(args),
+                        per_net_timeout=getattr(args, "per_net_timeout", None) or None,
+                    )
                 elif args.strategy == "monte-carlo":
                     router.route_all_monte_carlo(
                         num_trials=args.mc_trials,
@@ -10129,6 +10168,67 @@ def _resolve_complete_link_budget(args) -> float:
     if t and t > 0:
         return float(t)
     return _COMPLETE_LINK_BUDGET_DEFAULT_S
+
+
+def _resolve_lattice_link_budget(args) -> float | None:
+    """Per-link wall-clock budget (seconds) for the lattice netset negotiation.
+
+    Issue #4697.  Generalizes :func:`_resolve_complete_link_budget` (which was
+    ``--complete``-only, issue #4472) to EVERY lattice invocation, because the
+    lattice negotiates the whole netset in a single ``route_netset`` call --
+    ``route_all``'s between-nets ``timeout`` check therefore never fires
+    mid-run and the per-link ``deadline`` is the only bound the engine knows.
+    Before this, ``--per-net-timeout`` was accepted, echoed in the routing
+    banner, and silently discarded on every non-``--complete`` lattice run.
+
+    Precedence:
+
+    1. ``--complete``'s stamp (``args._complete_link_budget_s``) wins verbatim
+       when present, preserving #4472 semantics (including its 60 s backstop
+       when ``--per-net-timeout`` is disabled).
+    2. Otherwise an active ``--per-net-timeout`` (default 30 s) becomes the
+       per-link budget, exactly as ``--complete`` already treats it.
+    3. ``--per-net-timeout 0`` (explicitly disabled -- e.g. under
+       ``--deterministic-budget``, where a wall-clock bound would destroy
+       reproducibility) yields ``None``: no per-link budget, preserving the
+       legacy unbudgeted negotiation.  ``--timeout`` can still cap such a run
+       via :func:`_lattice_absolute_deadline`.
+
+    The value is inert on the grid/mesh engines (only
+    ``Autorouter._negotiate_lattice_netset`` reads it), so it is resolved
+    unconditionally rather than gated on ``--route-engine``.
+    """
+    stamped = getattr(args, "_complete_link_budget_s", None)
+    if stamped is not None:
+        return float(stamped)
+    t = getattr(args, "per_net_timeout", None)
+    if t and t > 0:
+        return float(t)
+    return None
+
+
+def _lattice_absolute_deadline(args) -> float | None:
+    """Absolute ``time.monotonic()`` ceiling for a lattice run, or ``None``.
+
+    Issue #4697.  ``--timeout`` is documented as a TOTAL wall-clock budget for
+    the whole invocation, but the lattice never saw it: the deadline it honors
+    was only ever derived from ``--complete``'s per-link budget.  This returns
+    the already-computed routing deadline (``args._routing_deadline``, stamped
+    by :func:`_set_wall_clock_deadline` with the ``--auto-fix`` reserve already
+    carved out) so the lattice negotiation aborts no later than the rest of the
+    routing pipeline does.
+
+    An ABSOLUTE timestamp is threaded rather than a duration because the
+    whole-board lattice build happens between the CLI stamping the budget and
+    the negotiation starting; a "seconds from now" value would silently grant
+    the build's runtime as extra routing budget.
+
+    ``None`` when the user passed no ``--timeout`` (legacy: no absolute cap).
+    """
+    deadline = getattr(args, "_routing_deadline", None)
+    if deadline is None:
+        deadline = getattr(args, "_wall_clock_deadline", None)
+    return float(deadline) if deadline is not None else None
 
 
 def _apply_complete_localization(args, pcb_path: Path) -> int:
@@ -13375,8 +13475,12 @@ def _main_impl(argv: list[str] | None = None) -> int:
                 # Issue #4472 (epic #4465, Phase 2): --complete localizes the
                 # lattice build + static masks to the region box, and bounds
                 # each link's search with a per-link wall-clock budget.
+                # Issue #4697: that per-link budget is no longer --complete-only
+                # (it now derives from --per-net-timeout on every lattice run),
+                # and --timeout supplies an absolute ceiling alongside it.
                 localize_lattice_to_region=getattr(args, "_complete_localized", False),
-                lattice_link_budget_s=getattr(args, "_complete_link_budget_s", None),
+                lattice_link_budget_s=_resolve_lattice_link_budget(args),
+                lattice_deadline=_lattice_absolute_deadline(args),
                 # Issue #4170 (Phase 2b-1): board-relative boundary stub
                 # terminals whose tip cells are carved open as same-net
                 # reconnection targets (None when no --region / no stubs).
@@ -13444,8 +13548,12 @@ def _main_impl(argv: list[str] | None = None) -> int:
                 # Issue #4472 (epic #4465, Phase 2): --complete localizes the
                 # lattice build + static masks to the region box, and bounds
                 # each link's search with a per-link wall-clock budget.
+                # Issue #4697: that per-link budget is no longer --complete-only
+                # (it now derives from --per-net-timeout on every lattice run),
+                # and --timeout supplies an absolute ceiling alongside it.
                 localize_lattice_to_region=getattr(args, "_complete_localized", False),
-                lattice_link_budget_s=getattr(args, "_complete_link_budget_s", None),
+                lattice_link_budget_s=_resolve_lattice_link_budget(args),
+                lattice_deadline=_lattice_absolute_deadline(args),
                 # Issue #4170 (Phase 2b-1): board-relative boundary stub
                 # terminals whose tip cells are carved open as same-net
                 # reconnection targets (None when no --region / no stubs).
@@ -13899,11 +14007,35 @@ def _main_impl(argv: list[str] | None = None) -> int:
         # Route
         if not quiet:
             flush_print(f"\n--- Routing ({args.strategy}) ---")
+            # Issue #4697: the banner must not claim a budget the dispatched
+            # engine does not enforce.  The lattice negotiates the whole netset
+            # in ONE call, so ``--per-net-timeout`` is spent there as a PER-LINK
+            # budget scaled by link count -- not as a per-net A* cutoff -- and
+            # ``--timeout`` is a hard ceiling on that single negotiation.  Say
+            # so, and say so loudly when neither bound is in force.
+            _banner_engine = getattr(args, "route_engine", "grid") or "grid"
             if args.timeout:
-                flush_print(f"  Timeout: {args.timeout}s")
+                _cap_note = (
+                    " (hard cap on the lattice negotiation)"
+                    if (_banner_engine == "lattice")
+                    else ""
+                )
+                flush_print(f"  Timeout: {args.timeout}s{_cap_note}")
             per_net_timeout_val = getattr(args, "per_net_timeout", None)
             if per_net_timeout_val:
-                flush_print(f"  Per-net timeout: {per_net_timeout_val}s")
+                if _banner_engine == "lattice":
+                    flush_print(
+                        f"  Per-net timeout: {per_net_timeout_val}s "
+                        f"(lattice: per-LINK budget; netset deadline = "
+                        f"{per_net_timeout_val}s x link count)"
+                    )
+                else:
+                    flush_print(f"  Per-net timeout: {per_net_timeout_val}s")
+            elif _banner_engine == "lattice" and not args.timeout:
+                flush_print(
+                    "  Per-net timeout: disabled (0) -- the lattice negotiation "
+                    "is UNBOUNDED; pass --timeout to cap it"
+                )
             # Issue #2610: report the iteration backstop override if set.
             # Issue #2819: the inner parser now declares the flag (default=0),
             # so the attribute is guaranteed to exist; ``or 0`` preserves the
@@ -14003,7 +14135,16 @@ def _main_impl(argv: list[str] | None = None) -> int:
                                         getattr(args, "early_stop_patience", 2) or None
                                     ),
                                 )
-                            return router.route_all()
+                            # Issue #4697: forward the user's budgets rather than calling
+                            # route_all() bare (which tripped the #2794 no-timeout guard
+                            # pointing straight back here).  This binds the GRID engine;
+                            # the lattice is bounded upstream by the deadline stamped on
+                            # the router at load time, since its single whole-netset
+                            # negotiation never reaches route_all's between-nets check.
+                            return router.route_all(
+                                timeout=_budgeted_timeout(args),
+                                per_net_timeout=getattr(args, "per_net_timeout", None) or None,
+                            )
 
                         # coupled_only=True so pairs that the
                         # CoupledPathfinder cannot handle (3-pad nets,
@@ -14077,7 +14218,16 @@ def _main_impl(argv: list[str] | None = None) -> int:
                             best_stall_patience=(getattr(args, "early_stop_patience", 2) or None),
                         )
                     else:
-                        return router.route_all()
+                        # Issue #4697: forward the user's budgets rather than calling
+                        # route_all() bare (which tripped the #2794 no-timeout guard
+                        # pointing straight back here).  This binds the GRID engine;
+                        # the lattice is bounded upstream by the deadline stamped on
+                        # the router at load time, since its single whole-netset
+                        # negotiation never reaches route_all's between-nets check.
+                        return router.route_all(
+                            timeout=_budgeted_timeout(args),
+                            per_net_timeout=getattr(args, "per_net_timeout", None) or None,
+                        )
 
                 adaptive_result = adaptive_router.route_adaptive(
                     nets=adaptive_nets,
@@ -14238,7 +14388,16 @@ def _main_impl(argv: list[str] | None = None) -> int:
             elif args.bus_routing and args.strategy == "basic":
                 return router.route_all_with_buses(bus_config)
             elif args.strategy == "basic":
-                return router.route_all()
+                # Issue #4697: forward the user's budgets rather than calling
+                # route_all() bare (which tripped the #2794 no-timeout guard
+                # pointing straight back here).  This binds the GRID engine;
+                # the lattice is bounded upstream by the deadline stamped on
+                # the router at load time, since its single whole-netset
+                # negotiation never reaches route_all's between-nets check.
+                return router.route_all(
+                    timeout=_budgeted_timeout(args),
+                    per_net_timeout=getattr(args, "per_net_timeout", None) or None,
+                )
             elif args.differential_pairs and args.strategy in ("monte-carlo", "evolutionary"):
                 # Issue #2464: MC/GA reset the grid per trial (see
                 # _reset_for_new_trial), which would wipe pre-routed

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -1248,6 +1248,13 @@ class Autorouter:
         # best routes found so far.  ``None`` preserves the unbudgeted
         # (iteration-capped only) behaviour.
         self._lattice_link_budget_s: float | None = None
+        # Issue #4697: ABSOLUTE wall-clock cap (a ``time.monotonic()`` stamp)
+        # for the lattice netset negotiation, sourced from the CLI's
+        # ``--timeout`` routing deadline.  Unlike ``_lattice_link_budget_s``
+        # (which scales with link count) this is a hard ceiling that does not
+        # grow with the netset: whichever of the two fires first bounds the
+        # run.  ``None`` means "no absolute cap" (legacy behaviour).
+        self._lattice_deadline: float | None = None
         # Issue #4477 (epic #4465, Phase 4): pad endpoints (``"REF.PIN"``) for
         # every connection dispatched into the lattice negotiation, keyed by
         # the SAME key ``pf.failure_reasons`` uses.  Lets a ``--complete``
@@ -3220,10 +3227,24 @@ class Autorouter:
         # -- the deadline scales with the number of links being closed so a
         # small cohort stays bounded while a larger set is still given
         # proportional headroom.  ``None`` preserves the unbudgeted behaviour.
+        #
+        # Issue #4697: the per-link budget is no longer ``--complete``-only --
+        # the CLI now derives it from ``--per-net-timeout`` for every lattice
+        # run -- and ``--timeout`` additionally supplies an ABSOLUTE ceiling
+        # (``_lattice_deadline``).  When both are present the TIGHTER one wins,
+        # so ``--timeout`` can only ever shorten the run: the whole-netset
+        # negotiation (which runs once, so ``route_all``'s between-nets check
+        # can never fire mid-run) finally has a bound the user can set.
         deadline: float | None = None
         if self._lattice_link_budget_s and self._lattice_link_budget_s > 0:
             link_count = max(1, len(connections) + len(coupled))
             deadline = time.monotonic() + self._lattice_link_budget_s * link_count
+        if self._lattice_deadline is not None:
+            deadline = (
+                self._lattice_deadline
+                if deadline is None
+                else min(deadline, self._lattice_deadline)
+            )
         routes_by_key, stats = pf.route_netset(
             connections,
             coupled=coupled,

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -3428,6 +3428,7 @@ def load_pcb_for_routing(
     strategy: str = "grid",
     localize_lattice_to_region: bool = False,
     lattice_link_budget_s: float | None = None,
+    lattice_deadline: float | None = None,
     min_trace_width_floor: float | None = None,
 ) -> tuple[Autorouter, dict[str, int]]:
     """
@@ -3526,6 +3527,13 @@ def load_pcb_for_routing(
                 the lattice netset negotiation aborts within
                 ``budget x link-count`` seconds and returns the best routes so
                 far.  ``None`` preserves the unbudgeted negotiation.
+        lattice_deadline: Issue #4697.  Optional ABSOLUTE wall-clock ceiling --
+                a ``time.monotonic()`` timestamp, not a duration -- stamped on
+                ``router._lattice_deadline``.  Sourced from the CLI
+                ``--timeout`` routing deadline so a lattice run cannot outlive
+                the total budget the user asked for.  When both this and
+                ``lattice_link_budget_s`` are set the TIGHTER bound wins.
+                ``None`` means "no absolute ceiling".
         min_trace_width_floor: Issue #4700.  Minimum legal trace width (mm)
                 for the target fab tier -- the SAME
                 ``get_design_rules(layers, copper_oz).min_trace_width_mm``
@@ -4054,6 +4062,12 @@ def load_pcb_for_routing(
     # negotiation (``--complete``); ``None`` preserves the unbudgeted loop.
     if lattice_link_budget_s is not None:
         router._lattice_link_budget_s = lattice_link_budget_s
+
+    # Issue #4697: absolute wall-clock ceiling (monotonic timestamp) for the
+    # lattice netset negotiation, derived from ``--timeout``.  ``None``
+    # preserves "bounded only by the per-link budget (or not at all)".
+    if lattice_deadline is not None:
+        router._lattice_deadline = lattice_deadline
 
     # Issue #4170 (Phase 2b-1): carve bare boundary stub endpoints open as
     # same-net A* targets and store them for the Autorouter target-merge shim.

--- a/tests/test_lattice_timeout_forwarding.py
+++ b/tests/test_lattice_timeout_forwarding.py
@@ -1,0 +1,349 @@
+"""``--timeout`` / ``--per-net-timeout`` actually bound the lattice (Issue #4697).
+
+Before this fix the lattice engine was time-bounded **only** under ``--complete``:
+``_lattice_link_budget_s`` was assigned from ``args._complete_link_budget_s``, which
+is stamped nowhere else, so every other invocation handed ``route_netset`` a
+``deadline`` of ``None``.  ``--timeout`` / ``--per-net-timeout`` were accepted,
+echoed in the routing banner, and silently discarded -- and because the lattice
+negotiates the *whole netset* in a single ``route_netset`` call, ``route_all``'s
+between-nets ``timeout`` check can never fire mid-run either.  The observed result
+was 60+ minute unbounded runs on the only strategy the #4280 gate allows.
+
+These tests pin the fix at the seam it actually lands on -- the ``deadline`` the
+lattice negotiation receives -- rather than at the ``route_all()`` call site
+(verified ineffective in the issue's correction comment).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import time
+from pathlib import Path
+
+import pytest
+
+from kicad_tools.cli.route_cmd import (
+    _COMPLETE_LINK_BUDGET_DEFAULT_S,
+    _lattice_absolute_deadline,
+    _resolve_lattice_link_budget,
+)
+from kicad_tools.cli.route_cmd import (
+    main as route_main,
+)
+
+# The Phase 1 stranded-board fixture: two 0402s, NET1 pre-routed, NET2 stranded.
+# Tiny and fully deterministic -- routes in ~1s through the lattice.
+from tests.test_cli_route_complete_4471 import STRANDED_BOARD
+
+
+@pytest.fixture
+def board(tmp_path: Path) -> Path:
+    pcb = tmp_path / "stranded.kicad_pcb"
+    pcb.write_text(STRANDED_BOARD)
+    return pcb
+
+
+@pytest.fixture
+def route_netset_spy(monkeypatch):
+    """Record every ``deadline`` the lattice negotiation is handed."""
+    from kicad_tools.router.lattice.pathfinder import LatticePathfinder
+
+    original = LatticePathfinder.route_netset
+    seen: list[float | None] = []
+
+    def spy(self, connections, **kwargs):
+        seen.append(kwargs.get("deadline"))
+        return original(self, connections, **kwargs)
+
+    monkeypatch.setattr(LatticePathfinder, "route_netset", spy)
+    return seen
+
+
+def _lattice_route(board: Path, out: Path, *extra: str) -> int:
+    return route_main(
+        [
+            str(board),
+            "-o",
+            str(out),
+            "--route-engine",
+            "lattice",
+            "--strategy",
+            "basic",
+            "--backend",
+            "cpp",
+            # Pin the layer count so the run does not enter layer-escalation
+            # mode, whose own #2802 deadline check would mask the engine bound
+            # under test.
+            "--layers",
+            "2",
+            # The routing cache is keyed on board content + rules, NOT on the
+            # time budget, so a warm cache would skip the negotiation entirely
+            # and the deadline under test would never be observed.
+            "--no-cache",
+            *extra,
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# _resolve_lattice_link_budget: generalizes --complete's per-link budget.
+# ---------------------------------------------------------------------------
+class TestResolveLatticeLinkBudget:
+    def test_complete_stamp_wins_verbatim(self):
+        # --complete's #4472 stamp is authoritative -- including its 60s
+        # backstop, which must not be re-derived from a disabled
+        # --per-net-timeout.
+        args = argparse.Namespace(
+            per_net_timeout=0.0,
+            _complete_link_budget_s=_COMPLETE_LINK_BUDGET_DEFAULT_S,
+        )
+        assert _resolve_lattice_link_budget(args) == _COMPLETE_LINK_BUDGET_DEFAULT_S
+
+    def test_complete_stamp_wins_over_per_net_timeout(self):
+        args = argparse.Namespace(per_net_timeout=30.0, _complete_link_budget_s=12.5)
+        assert _resolve_lattice_link_budget(args) == 12.5
+
+    def test_derives_from_per_net_timeout_without_complete(self):
+        # The bug: this used to be None on every non---complete run.
+        args = argparse.Namespace(per_net_timeout=30.0, _complete_link_budget_s=None)
+        assert _resolve_lattice_link_budget(args) == 30.0
+
+    def test_explicit_per_net_timeout_honored(self):
+        args = argparse.Namespace(per_net_timeout=5.0, _complete_link_budget_s=None)
+        assert _resolve_lattice_link_budget(args) == 5.0
+
+    def test_disabled_per_net_timeout_preserves_unbudgeted(self):
+        # --per-net-timeout 0 (e.g. --deterministic-budget, where a wall-clock
+        # bound would destroy reproducibility) keeps the legacy unbudgeted
+        # negotiation.  --timeout can still cap such a run.
+        args = argparse.Namespace(per_net_timeout=0.0, _complete_link_budget_s=None)
+        assert _resolve_lattice_link_budget(args) is None
+
+    def test_missing_attributes_are_unbudgeted(self):
+        assert _resolve_lattice_link_budget(argparse.Namespace()) is None
+
+
+# ---------------------------------------------------------------------------
+# _lattice_absolute_deadline: --timeout becomes a hard ceiling.
+# ---------------------------------------------------------------------------
+class TestLatticeAbsoluteDeadline:
+    def test_none_without_timeout(self):
+        args = argparse.Namespace(_routing_deadline=None, _wall_clock_deadline=None)
+        assert _lattice_absolute_deadline(args) is None
+
+    def test_missing_attributes_are_uncapped(self):
+        assert _lattice_absolute_deadline(argparse.Namespace()) is None
+
+    def test_returns_routing_deadline(self):
+        stamp = time.monotonic() + 120.0
+        args = argparse.Namespace(_routing_deadline=stamp, _wall_clock_deadline=stamp + 30.0)
+        assert _lattice_absolute_deadline(args) == stamp
+
+    def test_falls_back_to_wall_clock_deadline(self):
+        stamp = time.monotonic() + 120.0
+        args = argparse.Namespace(_routing_deadline=None, _wall_clock_deadline=stamp)
+        assert _lattice_absolute_deadline(args) == stamp
+
+    def test_set_wall_clock_deadline_feeds_it(self):
+        from kicad_tools.cli.route_cmd import _set_wall_clock_deadline
+
+        args = argparse.Namespace(timeout=60.0, auto_fix=False)
+        before = time.monotonic()
+        _set_wall_clock_deadline(args)
+        got = _lattice_absolute_deadline(args)
+        assert got is not None
+        assert before < got <= before + 60.0 + 1.0
+
+
+# ---------------------------------------------------------------------------
+# Deadline combination in _negotiate_lattice_netset: the tighter bound wins.
+# ---------------------------------------------------------------------------
+class TestNegotiationDeadlineCombination:
+    def test_absolute_cap_alone_bounds_the_run(self, board: Path, tmp_path: Path):
+        from kicad_tools.router.io import load_pcb_for_routing
+
+        cap = time.monotonic() + 42.0
+        router, _ = load_pcb_for_routing(
+            board, strategy="lattice", lattice_deadline=cap, force_python=True
+        )
+        assert router._lattice_deadline == cap
+        assert router._lattice_link_budget_s is None
+
+    def test_link_budget_alone_is_unchanged(self, board: Path):
+        from kicad_tools.router.io import load_pcb_for_routing
+
+        router, _ = load_pcb_for_routing(
+            board, strategy="lattice", lattice_link_budget_s=7.5, force_python=True
+        )
+        assert router._lattice_link_budget_s == 7.5
+        assert router._lattice_deadline is None
+
+    def test_tighter_of_the_two_wins(self, board: Path, monkeypatch):
+        """A near-past absolute cap overrides a generous per-link budget."""
+        from kicad_tools.router.io import load_pcb_for_routing
+        from kicad_tools.router.lattice.pathfinder import LatticePathfinder
+
+        cap = time.monotonic() + 0.5
+        router, _ = load_pcb_for_routing(
+            board,
+            strategy="lattice",
+            # 3600s x link-count would be effectively unbounded on its own.
+            lattice_link_budget_s=3600.0,
+            lattice_deadline=cap,
+            force_python=True,
+        )
+        seen: list[float | None] = []
+        original = LatticePathfinder.route_netset
+
+        def spy(self, connections, **kwargs):
+            seen.append(kwargs.get("deadline"))
+            return original(self, connections, **kwargs)
+
+        monkeypatch.setattr(LatticePathfinder, "route_netset", spy)
+        router._negotiate_lattice_netset()
+        assert seen == [cap], "the absolute cap must clamp the link-budget deadline"
+
+    def test_loose_absolute_cap_does_not_loosen_link_budget(self, board: Path, monkeypatch):
+        from kicad_tools.router.io import load_pcb_for_routing
+        from kicad_tools.router.lattice.pathfinder import LatticePathfinder
+
+        cap = time.monotonic() + 100_000.0
+        router, _ = load_pcb_for_routing(
+            board,
+            strategy="lattice",
+            lattice_link_budget_s=1.0,
+            lattice_deadline=cap,
+            force_python=True,
+        )
+        seen: list[float | None] = []
+        original = LatticePathfinder.route_netset
+
+        def spy(self, connections, **kwargs):
+            seen.append(kwargs.get("deadline"))
+            return original(self, connections, **kwargs)
+
+        monkeypatch.setattr(LatticePathfinder, "route_netset", spy)
+        router._negotiate_lattice_netset()
+        assert len(seen) == 1
+        assert seen[0] is not None and seen[0] < cap
+
+
+# ---------------------------------------------------------------------------
+# Guard: every `--strategy basic` lattice dispatch receives a real deadline.
+# ---------------------------------------------------------------------------
+class TestCliDispatchIsBounded:
+    def test_per_net_timeout_bounds_the_lattice(self, board, tmp_path, route_netset_spy):
+        out = tmp_path / "out.kicad_pcb"
+        started = time.monotonic()
+        assert _lattice_route(board, out, "--per-net-timeout", "20") == 0
+        assert route_netset_spy, "the lattice negotiation must have run"
+        for deadline in route_netset_spy:
+            assert deadline is not None, "--per-net-timeout must reach the lattice"
+            # 20s x link-count, measured from just before the negotiation.
+            assert deadline > started
+
+    def test_timeout_alone_bounds_the_lattice(self, board, tmp_path, route_netset_spy):
+        out = tmp_path / "out.kicad_pcb"
+        started = time.monotonic()
+        # --per-net-timeout 0 removes the per-link budget, so ONLY the absolute
+        # --timeout cap can bound this run.
+        assert _lattice_route(board, out, "--per-net-timeout", "0", "--timeout", "300") == 0
+        assert route_netset_spy
+        for deadline in route_netset_spy:
+            assert deadline is not None, "--timeout must reach the lattice"
+            assert started < deadline <= started + 300.0 + 1.0
+
+    def test_default_run_is_bounded_by_the_default_per_net_timeout(
+        self, board, tmp_path, route_netset_spy
+    ):
+        out = tmp_path / "out.kicad_pcb"
+        assert _lattice_route(board, out) == 0
+        assert route_netset_spy
+        assert all(d is not None for d in route_netset_spy)
+
+    def test_no_budget_at_all_preserves_legacy_unbounded(self, board, tmp_path, route_netset_spy):
+        # Neither bound requested -> deadline stays None, exactly as before.
+        out = tmp_path / "out.kicad_pcb"
+        assert _lattice_route(board, out, "--per-net-timeout", "0") == 0
+        assert route_netset_spy
+        assert all(d is None for d in route_netset_spy)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: a short --timeout terminates the run and reports honestly.
+# ---------------------------------------------------------------------------
+class TestShortTimeoutTerminatesEarly:
+    def test_expired_timeout_declines_with_deadline_exceeded(self, board, tmp_path, capsys):
+        out = tmp_path / "out.kicad_pcb"
+        started = time.monotonic()
+        # 1ms: already spent by the time the negotiation starts, so the bound
+        # is deterministic rather than a race against the search.
+        _lattice_route(board, out, "--timeout", "0.001")
+        elapsed = time.monotonic() - started
+        captured = capsys.readouterr().out
+
+        assert "decline[deadline-exceeded]" in captured, (
+            "a deadline-truncated lattice run must report partial results with "
+            "the deadline-exceeded reason, not die silently"
+        )
+        # Zero negotiation passes ran: the deadline was checked and honored.
+        assert re.search(r"Lattice negotiation: 0/\d+ connections \(iterations=0", captured)
+        # Generous CI ceiling; the point is it is bounded at all.
+        assert elapsed < 120.0
+
+    def test_default_run_routes_the_board_and_declines_nothing(self, board, tmp_path, capsys):
+        out = tmp_path / "out.kicad_pcb"
+        assert _lattice_route(board, out) == 0
+        captured = capsys.readouterr().out
+        assert "deadline-exceeded" not in captured
+        assert re.search(r"Lattice negotiation: 2/2 connections", captured)
+        assert "(segment" in out.read_text()
+
+
+# ---------------------------------------------------------------------------
+# Banner honesty: never claim a budget the dispatched engine does not enforce.
+# ---------------------------------------------------------------------------
+class TestBannerHonesty:
+    def test_lattice_annotates_per_net_timeout_as_per_link(self, board, tmp_path, capsys):
+        out = tmp_path / "out.kicad_pcb"
+        assert _lattice_route(board, out, "--per-net-timeout", "20") == 0
+        captured = capsys.readouterr().out
+        assert "Per-net timeout: 20.0s (lattice: per-LINK budget" in captured
+        assert "netset deadline = 20.0s x link count" in captured
+
+    def test_lattice_announces_an_unbounded_run(self, board, tmp_path, capsys):
+        out = tmp_path / "out.kicad_pcb"
+        assert _lattice_route(board, out, "--per-net-timeout", "0") == 0
+        captured = capsys.readouterr().out
+        assert "the lattice negotiation is UNBOUNDED" in captured.replace("\n", " ")
+
+    def test_lattice_labels_timeout_as_a_hard_cap(self, board, tmp_path, capsys):
+        out = tmp_path / "out.kicad_pcb"
+        _lattice_route(board, out, "--timeout", "0.001")
+        captured = capsys.readouterr().out
+        assert "Timeout: 0.001s (hard cap on the lattice negotiation)" in captured
+
+    def test_grid_banner_is_unannotated(self, board, tmp_path, capsys):
+        out = tmp_path / "out.kicad_pcb"
+        route_main(
+            [
+                str(board),
+                "-o",
+                str(out),
+                "--route-engine",
+                "grid",
+                "--strategy",
+                "basic",
+                "--backend",
+                "cpp",
+                "--layers",
+                "2",
+                "--no-cache",
+                "--per-net-timeout",
+                "20",
+            ]
+        )
+        captured = capsys.readouterr().out
+        assert "Per-net timeout: 20.0s" in captured
+        assert "per-LINK budget" not in captured


### PR DESCRIPTION
## Summary

`kct route --route-engine lattice` was time-bounded **only** under `--complete`. Everywhere else `--timeout` and `--per-net-timeout` were accepted, echoed in the routing banner, and silently discarded — producing the reported 60+ minute unbounded runs on `--strategy basic`, the only strategy the #4280 gate permits on the lattice.

The shallow fix (forwarding budgets into `route_all()`) was empirically ruled out by the reporter, and the code says why: the lattice negotiates the **whole netset in a single `route_netset()` call**, so `route_all`'s between-nets `timeout` check can never fire mid-run. The negotiation's only bound is the `deadline` argument, and that was computed exclusively from `Autorouter._lattice_link_budget_s` — which `load_pcb_for_routing` only ever received from `args._complete_link_budget_s`, an attribute nothing but `--complete` stamps. `git grep timeout src/kicad_tools/router/lattice/` still returns zero hits; `deadline` is the only bound the engine knows.

This PR fixes it **at the deadline derivation**.

## Changes

**`src/kicad_tools/cli/route_cmd.py`**

- `_resolve_lattice_link_budget(args)` — generalizes `--complete`'s `_resolve_complete_link_budget` (#4472) to **every** lattice run. Precedence, documented in the docstring:
  1. `--complete`'s `_complete_link_budget_s` stamp wins verbatim (including its 60 s backstop) — #4472 semantics unchanged;
  2. otherwise an active `--per-net-timeout` (default 30 s) becomes the per-link budget, exactly as `--complete` already treats it;
  3. `--per-net-timeout 0` (e.g. under `--deterministic-budget`, where a wall-clock bound would destroy reproducibility) yields `None` — legacy unbudgeted negotiation preserved.
- `_lattice_absolute_deadline(args)` — returns `args._routing_deadline` (already derived from `--timeout` by `_set_wall_clock_deadline`, with the `--auto-fix` reserve carved out) as an **absolute** ceiling. An absolute `time.monotonic()` timestamp rather than a duration, because the whole-board lattice build happens between the CLI stamping the budget and the negotiation starting; a "seconds from now" value would silently gift the build's runtime as extra routing budget.
- All **five** `load_pcb_for_routing` call sites (`route_with_layer_escalation`, `route_with_rule_relaxation`, `route_with_combined_escalation`, and the two in `_main_impl`) now pass `lattice_link_budget_s=_resolve_lattice_link_budget(args)` + `lattice_deadline=_lattice_absolute_deadline(args)`. Because the bound is stamped **on the router at load time**, every downstream dispatch inherits it — including all six bare `route_all()` sites.
- All **six** bare `router.route_all()` dispatch sites now forward `timeout=_budgeted_timeout(args)` and `per_net_timeout=...`. On the lattice this is belt-and-braces (the real bound is upstream); on the **grid** engine it is what makes the flags bind on `--strategy basic` at all, and it silences the #2794 no-timeout guard that was firing pointed straight back at those exact lines.
- **Banner honesty**: on the lattice, `--per-net-timeout` is now labelled as the per-LINK budget it really is with the derived netset deadline spelled out (`Per-net timeout: 20.0s (lattice: per-LINK budget; netset deadline = 20.0s x link count)`), `--timeout` is labelled `(hard cap on the lattice negotiation)`, and a run with neither bound is announced as `UNBOUNDED` rather than printing nothing. The grid banner is unchanged.

**`src/kicad_tools/router/io.py`** — new `lattice_deadline: float | None = None` parameter on `load_pcb_for_routing`, stamped on `router._lattice_deadline`. Documented as an absolute monotonic timestamp, not a duration.

**`src/kicad_tools/router/core.py`** — new `Autorouter._lattice_deadline` attribute; `_negotiate_lattice_netset` takes the **tighter** of the link-budget-derived deadline and the absolute cap, so `--timeout` can only ever shorten a run. `--complete`'s existing computation is untouched.

**`CHANGELOG.md`** — Unreleased/Fixed entry.

Deliberately **not** touched: PR #4748's relief-rescue deadline regions in `core.py` (functionally distinct from the lattice netset deadline).

## Acceptance Criteria Verification

- [x] **`--route-engine lattice --strategy basic --per-net-timeout T` without `--complete` terminates within a budget derived from `T`** — `TestCliDispatchIsBounded::test_per_net_timeout_bounds_the_lattice` spies on `LatticePathfinder.route_netset` through a real CLI run and asserts `deadline is not None`; `TestBannerHonesty` pins the `T x link count` scaling in the printed derivation.
- [x] **`--timeout T` alone also bounds the lattice run (absolute cap), with documented precedence** — `test_timeout_alone_bounds_the_lattice` runs with `--per-net-timeout 0 --timeout 300` (so *only* the absolute cap can bind) and asserts `started < deadline <= started + 300`. Precedence when both are set: **the tighter bound wins** — documented in `_resolve_lattice_link_budget`'s docstring, the `_negotiate_lattice_netset` comment, and pinned by `test_tighter_of_the_two_wins` + `test_loose_absolute_cap_does_not_loosen_link_budget`.
- [x] **`--complete`'s `_complete_link_budget_s` stamp still wins/behaves as today** — `test_complete_stamp_wins_verbatim` and `test_complete_stamp_wins_over_per_net_timeout`; the full `tests/test_cli_route_complete_localize_4472.py` + `tests/test_cli_route_complete_4471.py` suites (26 tests) stay green unmodified.
- [x] **The banner never claims a budget the dispatched engine does not enforce** — four `TestBannerHonesty` cases, including `test_grid_banner_is_unannotated` (the grid path's wording is byte-identical to before).
- [x] **A deadline-truncated run reports partial results with `deadline-exceeded`, not a silent kill** — `test_expired_timeout_declines_with_deadline_exceeded` asserts both `decline[deadline-exceeded]` and `Lattice negotiation: 0/N connections (iterations=0` in the CLI output.
- [x] **Guard test: every `--strategy basic` lattice dispatch receives a non-`None` deadline when a budget is set** — `TestCliDispatchIsBounded` (4 cases) covers `--per-net-timeout`, `--timeout` alone, the default run, and the explicit opt-out.

## Test Plan

New module `tests/test_lattice_timeout_forwarding.py` — **25 tests, all passing**. It uses the existing tiny `STRANDED_BOARD` fixture (two 0402s, ~1 s per lattice route), never board-07, and never runs an unbounded route to prove the bug. Two details worth knowing for anyone extending it: the helper passes `--layers 2` so the run does not enter layer-escalation mode (whose own #2802 deadline check would mask the engine bound under test), and `--no-cache` because the routing cache is keyed on board content + rules, not on the time budget — a warm cache skips the negotiation entirely.

The short-timeout proof is deterministic rather than a race: `--timeout 0.001` is already spent by the time the negotiation starts, so the pass-zero deadline branch fires every time. Observed end-to-end:

```
--- Routing (basic) ---
  Timeout: 0.001s (hard cap on the lattice negotiation)
  Per-net timeout: 30.0s (lattice: per-LINK budget; netset deadline = 30.0s x link count)
  Lattice negotiation: 0/2 connections (iterations=0, converged=False, lattice_builds=1)
    decline[deadline-exceeded]: 2 connection(s) on 2 net(s): NET1, NET2
```

...against the same board with no `--timeout`, which still routes normally: `Lattice negotiation: 2/2 connections (iterations=1, converged=True)`.

- `uv run pytest tests/test_lattice_timeout_forwarding.py -q --no-cov` — **25 passed**
- `uv run pytest tests/test_cli_route_complete_localize_4472.py tests/test_cli_route_complete_4471.py -q --no-cov` — **26 passed**
- `uv run pytest tests/test_route_cmd_total_timeout.py tests/test_route_engine_strategy_gate.py tests/test_route_deterministic_budget{,_load_independence}.py tests/test_per_net_timeout_scaling.py tests/test_router_timeout_no_fallback_3876.py tests/test_negotiated_timeout_propagation.py -q --no-cov` — **126 passed, 1 skipped**
- `uv run pytest tests -q --no-cov -k "lattice or route_engine or route_cmd or router_io or load_pcb"` — **801 passed, 4 skipped**
- **Full suite**: `uv run pytest tests -q --no-cov -p no:randomly -n 6` — **25765 passed, 97 skipped, 0 failed** (26m26s)
- `uv run ruff check .` + `uv run ruff format --check .` — clean
- `uv run python scripts/ci/check_mypy_baseline.py` — `OK: mypy reports 1471 error(s), all within the baseline (1473 allowed). No new type errors.`
- C++ backend built in the worktree (`kct build-native`) so no run fell back to the Python A*.

Closes #4697
