### PR TITLE
fix(ci): run the mypy baseline gate cold so a stale .mypy_cache can't fake a new error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   runs, plus project-dir-listing, temp-cleanup, `str`-path, Python-fallback,
   and export-failure cases) pin the behavior, and the integration tests now
   assert the fixtures directory is unchanged across the call.
+- **The mypy baseline gate now runs cold, so a stale `.mypy_cache/` can no
+  longer invent a "NEW type error"** (#4767) —
+  `scripts/ci/check_mypy_baseline.py` invoked a bare `mypy src/` with no cache
+  control of any kind (no `--cache-dir`, no `cache_dir` in `[tool.mypy]`, no
+  `MYPY_CACHE_DIR` anywhere in the tree), so every local run reused the
+  incremental cache at `<cwd>/.mypy_cache`. CI is structurally the opposite —
+  there is no `actions/cache` in `.github/workflows/` and the Type Check job
+  pins `astral-sh/setup-uv` with `enable-cache: false` — so CI is always cold
+  and local is always warm, and only the local verdict was untrustworthy. The
+  cache outlives the tree it was computed from: `.mypy_cache/` is gitignored,
+  so `git reset --hard`, `git clean -fd` (ignored paths need `-x`), a rebase,
+  a force-push, and a Loom worktree reuse all leave it in place. Because the
+  gate diffs a signature multiset over all of `src/`, one replayed cached
+  error anywhere trips exit 2 and prints a filename unrelated to the diff —
+  which is what cost two independent PR reviews a cycle each during the
+  2026-08-08/09 sweep (PRs #4746, #4762), both on a phantom error in
+  `recovery/strategy.py`, a file neither PR touched. `run_mypy()` now passes
+  `--no-incremental` by default, and `--incremental` (alias `--warm-cache`)
+  is the documented opt-in for a tight burn-down loop. Measured cost of the
+  default: ~20 s vs ~0.5 s warm on `src/` — a price CI already paid on every
+  push. Exit-code semantics (0 within baseline / 1 tool failure / 2 new
+  errors), `diff_against_baseline`, `write_baseline`, and the #4558
+  version-drift guard are all unchanged, and `.github/mypy-baseline.txt` is
+  byte-identical (a new test pins both nanobind signatures so a future
+  `--update` cannot silently drop one). `pnpm typecheck` / `pnpm check:all`
+  still run a bare incremental `uv run mypy src/`, so the trap and its
+  `rm -rf .mypy_cache` remedy are now documented in `CLAUDE.md`, `README.md`'s
+  fresh-worktree checklist, and `docs/contributing/development.md`.
 - **The relief rescue's deterministic sub-search bound stays opt-in — the
   fleet-default flip is withdrawn** (#4730) — #4536 gave
   `Autorouter.route_all_negotiated` a `deterministic_rescue=` opt-in that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,20 @@ suspect the auto-detection missed something (e.g. a touched build flag).
 
 See `README.md` "Fresh worktree checklist" for the full setup sequence.
 
+## Type checks: distrust a local mypy error outside your diff
+
+`.mypy_cache/` is gitignored, so it survives `git reset --hard`,
+`git clean -fd`, rebases, and worktree reuse — bare `mypy` /
+`pnpm typecheck` can replay an error computed against an older tree, in a
+file nobody touched. CI never reproduces it (no `actions/cache`; the Type
+Check job pins `enable-cache: false`), which is exactly how two PR reviews
+lost a cycle each to a phantom failure.
+
+`scripts/ci/check_mypy_baseline.py` is immune by construction — it runs
+`--no-incremental` (~20 s; `--incremental` opts back into the cache). For
+anything else, `rm -rf .mypy_cache` and re-run **before** investigating. Never
+use `--update` to make a phantom error go away; it bakes it into the baseline.
+
 <!-- BEGIN REPO-SKILLS -->
 This repository has [Repo Skills](https://github.com/rjwalters/repo) v0.10.0 installed —
 general repository hygiene and environment commands invoked as `/repo:<command>`. Run

--- a/README.md
+++ b/README.md
@@ -790,6 +790,15 @@ uv run ruff format .
    build it. After `cd` into the worktree, run `uv run kct build-native`
    once before any routing benchmarks.
 
+3. **If a local `mypy` error names a file outside your diff, `rm -rf
+   .mypy_cache` and re-run before investigating it.** `.mypy_cache/` is
+   gitignored, so it survives `git reset --hard`, `git clean -fd`, a rebase,
+   and a worktree reuse — bare `mypy` / `pnpm typecheck` can replay an error
+   computed against an older tree. CI is always cold (no `actions/cache`), so
+   it will not reproduce the phantom. `scripts/ci/check_mypy_baseline.py` is
+   already immune (it runs `--no-incremental`); see
+   [`docs/contributing/development.md`](docs/contributing/development.md#the-stale-mypy_cache-trap).
+
 The build's `nanobind` dependency is composed into the default dev
 dependency-group, so a plain `uv sync` keeps it resolved and a later
 `uv sync` (e.g. adding `--extra placement`) will not prune it. If you

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -269,6 +269,43 @@ ruff format src/
 mypy src/kicad_tools/
 ```
 
+CI does not run bare `mypy` — it runs the baseline gate, which fails only on
+errors beyond the committed `.github/mypy-baseline.txt` ledger:
+
+```bash
+uv run python scripts/ci/check_mypy_baseline.py
+```
+
+#### The stale `.mypy_cache/` trap
+
+**If a local type error names a file that is not in your diff, clear the cache
+and re-run before investigating it.**
+
+```bash
+rm -rf .mypy_cache     # or: /repo:tidy --caches
+```
+
+Bare `mypy`, `pnpm typecheck`, and `pnpm check:all` are all **incremental**:
+mypy reuses `<cwd>/.mypy_cache/`, validating each cached module by
+`(mtime, size)`. `.mypy_cache/` is gitignored, so `git reset --hard`,
+`git clean -fd` (ignored paths need `-x`), a rebase, a force-push, and a Loom
+worktree reset **all leave it in place** — a cache computed against an older
+tree can outlive that tree and replay an error that no longer exists.
+
+CI never hits this: there is no `actions/cache` in `.github/workflows/` and the
+Type Check job pins `astral-sh/setup-uv` with `enable-cache: false`, so every
+CI run is cold. That asymmetry is why a local "NEW type error" can be green on
+CI — it cost two independent PR reviews a cycle each during the 2026-08-08/09
+sweep (PRs #4746, #4762), both on a phantom error in a file neither PR touched.
+
+`scripts/ci/check_mypy_baseline.py` is immune by construction: it passes
+`--no-incremental`, so its verdict never depends on a cache. That costs ~20 s
+per run (vs ~0.5 s warm) on `src/`; pass `--incremental` (alias `--warm-cache`)
+for a tight burn-down loop, and re-confirm any finding cold before acting on it.
+
+Do **not** reach for `--update` to make a phantom error go away — that bakes it
+into the ledger. The remedy is a cold re-run.
+
 ### Pre-commit Hooks
 
 Install pre-commit hooks to run checks automatically:

--- a/scripts/ci/check_mypy_baseline.py
+++ b/scripts/ci/check_mypy_baseline.py
@@ -31,6 +31,25 @@ This means:
   * Adding a brand-new error -> gate fails.
   * Moving code around (line numbers shift) -> gate passes.
 
+Why this gate runs COLD (no incremental cache) by default
+---------------------------------------------------------
+``run_mypy`` passes ``--no-incremental`` so a pre-existing ``.mypy_cache/``
+can never influence the verdict.  CI is structurally always-cold -- there is
+no ``actions/cache`` in ``.github/workflows/`` and the Type Check job pins
+``astral-sh/setup-uv`` with ``enable-cache: false`` -- while a local run is
+incremental by default, so the two execution models disagreed and only the
+local one was unreliable.  During the 2026-08-08/09 sweep that asymmetry cost
+two independent Judges a review cycle each (PRs #4746 and #4762): both saw a
+"NEW" error in ``src/kicad_tools/recovery/strategy.py``, a file in neither
+diff, replayed from a stale cache in a reused issue worktree.  ``.mypy_cache/``
+is gitignored, so ``git reset --hard``, a worktree reset, and ``git clean -fd``
+all leave it in place; nothing in the sweep clears it.
+
+The measured cost of going cold is ~20 s on ``src/`` (vs ~0.5 s warm), which
+CI already pays on every push.  Pass ``--incremental`` (alias ``--warm-cache``)
+to opt back into the cache for a tight burn-down loop -- but re-confirm any
+finding with a cold run before acting on it.
+
 Burn-down intent
 ----------------
 The baseline is a debt ledger, not a target.  When you fix type errors, run
@@ -123,15 +142,26 @@ def parse_mypy_output(output: str) -> Counter[str]:
     return counts
 
 
-def run_mypy(target: str) -> str:
+def run_mypy(target: str, *, incremental: bool = False) -> str:
     """Run mypy over ``target`` and return its combined stdout+stderr.
 
     Mypy exits 1 when it finds errors and 0 when clean; both are normal here.
     A different/failed invocation (e.g. config error) is detected by the
     caller via the absence of parseable error lines AND a non-summary tail.
+
+    ``incremental`` defaults to ``False``, which adds ``--no-incremental`` so a
+    stale ``.mypy_cache/`` cannot replay a phantom error into the gate's
+    verdict (see the module docstring: PRs #4746/#4762).  ``--no-incremental``
+    is preferred over ``--cache-dir=/dev/null``: it has the same effect on the
+    read path, is portable, and does not depend on a device node.  Pass
+    ``incremental=True`` only for a deliberate warm-cache burn-down loop.
     """
+    argv = ["mypy"]
+    if not incremental:
+        argv.append("--no-incremental")
+    argv.append(target)
     proc = subprocess.run(
-        ["mypy", target],
+        argv,
         capture_output=True,
         text=True,
         check=False,
@@ -348,6 +378,19 @@ def main(argv: list[str] | None = None) -> int:
         "Use this when burning down errors so the floor ratchets to the new count.",
     )
     parser.add_argument(
+        "--incremental",
+        "--warm-cache",
+        dest="incremental",
+        action="store_true",
+        help="Reuse mypy's incremental .mypy_cache/ instead of running cold. "
+        "OFF by default: CI never has a cache (no actions/cache; setup-uv pins "
+        "enable-cache: false), and a stale local cache has already produced "
+        "phantom 'NEW error' verdicts in files outside the diff (PRs #4746, "
+        "#4762). Use this only for a tight burn-down loop -- it trades ~20s of "
+        "runtime for a verdict CI cannot reproduce, so re-confirm any finding "
+        "with a cold run.",
+    )
+    parser.add_argument(
         "--mypy-output",
         default=None,
         help="Read mypy output from this file instead of invoking mypy "
@@ -363,7 +406,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.mypy_output is not None:
         raw = Path(args.mypy_output).read_text()
     else:
-        raw = run_mypy(args.target)
+        raw = run_mypy(args.target, incremental=args.incremental)
         drift = mypy_version_drift()
 
     current = parse_mypy_output(raw)

--- a/tests/test_ci_mypy_baseline.py
+++ b/tests/test_ci_mypy_baseline.py
@@ -28,9 +28,12 @@ Out of scope:
 from __future__ import annotations
 
 import importlib.util
+import os
+import shutil
 import sys
 from collections import Counter
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import yaml
@@ -142,6 +145,26 @@ def test_baseline_lines_have_signature_shape() -> None:
             continue
         parts = line.split("\t")
         assert len(parts) == 3, f"baseline line is not a 3-field signature: {line!r}"
+
+
+def test_baseline_keeps_both_nanobind_signatures() -> None:
+    """Both env-dependent nanobind signatures must survive any regeneration.
+
+    PR #3879 / issue #3877: the nanobind import diagnostic differs by whether
+    nanobind is installed (``import-not-found`` in a bare env vs
+    ``import-untyped`` in a native-built one).  The baseline deliberately
+    carries BOTH so the gate is green either way.  A ``--update`` run in a
+    native-built worktree drops the ``import-not-found`` line and breaks CI
+    Type Check, so pin the pair here rather than relying on review to catch it.
+    """
+    text = BASELINE_PATH.read_text()
+    for code in ("import-not-found", "import-untyped"):
+        expected = f"src/kicad_tools/cli/build_native_cmd.py\t{code}\t"
+        assert expected in text, (
+            f"baseline lost the nanobind {code!r} signature -- most likely a "
+            "`--update` run in an environment-specific worktree. Restore both "
+            "lines from origin/main before merging."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -392,3 +415,142 @@ def test_main_synthetic_output_skips_drift_guard(mod, tmp_path: Path, monkeypatc
     assert mod.main(["--baseline", str(baseline), "--mypy-output", str(mypy_out)]) == 0
     out = capsys.readouterr().out
     assert "MYPY VERSION DRIFT" not in out
+
+
+# ---------------------------------------------------------------------------
+# Cold-by-default incremental-cache control (issue #4767)
+#
+# CI is structurally always-cold (no actions/cache; setup-uv pins
+# enable-cache: false), while a local run is incremental by default.  Two
+# Judges (PRs #4746, #4762) burned a review cycle each on a stale-cache
+# phantom error, so the gate now disables the cache read by default.
+# ---------------------------------------------------------------------------
+
+
+class _RecordingRun:
+    """Stand-in for ``subprocess.run`` that records argv and fakes a clean run."""
+
+    def __init__(self, stdout: str = "Success: no issues found in 1 source file\n") -> None:
+        self.argv: list[str] | None = None
+        self._stdout = stdout
+
+    def __call__(self, argv, *_args, **_kwargs):
+        self.argv = list(argv)
+        return SimpleNamespace(stdout=self._stdout, stderr="")
+
+
+def test_run_mypy_is_cold_by_default(mod, monkeypatch) -> None:
+    """The default invocation must disable the incremental cache read."""
+    rec = _RecordingRun()
+    monkeypatch.setattr(mod.subprocess, "run", rec)
+    mod.run_mypy("src/")
+    assert rec.argv == ["mypy", "--no-incremental", "src/"]
+
+
+def test_run_mypy_incremental_opt_out_drops_cold_flag(mod, monkeypatch) -> None:
+    """``incremental=True`` restores the warm-cache invocation verbatim."""
+    rec = _RecordingRun()
+    monkeypatch.setattr(mod.subprocess, "run", rec)
+    mod.run_mypy("src/", incremental=True)
+    assert rec.argv == ["mypy", "src/"]
+    assert "--no-incremental" not in rec.argv
+
+
+def test_main_runs_cold_by_default(mod, tmp_path: Path, monkeypatch) -> None:
+    """A real (non ``--mypy-output``) run threads the cold default through."""
+    seen: dict[str, object] = {}
+
+    def _fake_run_mypy(target: str, *, incremental: bool = False) -> str:
+        seen["target"] = target
+        seen["incremental"] = incremental
+        return "Success: no issues found in 1 source file\n"
+
+    monkeypatch.setattr(mod, "run_mypy", _fake_run_mypy)
+    monkeypatch.setattr(mod, "mypy_version_drift", lambda: None)
+    baseline = tmp_path / "baseline.txt"
+    assert mod.main(["--baseline", str(baseline)]) == 0
+    assert seen["incremental"] is False
+
+
+def test_main_incremental_flag_opts_into_warm_cache(mod, tmp_path: Path, monkeypatch) -> None:
+    """``--incremental`` / ``--warm-cache`` reach ``run_mypy``."""
+    seen: list[bool] = []
+
+    def _fake_run_mypy(target: str, *, incremental: bool = False) -> str:
+        seen.append(incremental)
+        return "Success: no issues found in 1 source file\n"
+
+    monkeypatch.setattr(mod, "run_mypy", _fake_run_mypy)
+    monkeypatch.setattr(mod, "mypy_version_drift", lambda: None)
+    baseline = tmp_path / "baseline.txt"
+    assert mod.main(["--baseline", str(baseline), "--incremental"]) == 0
+    assert mod.main(["--baseline", str(baseline), "--warm-cache"]) == 0
+    assert seen == [True, True]
+
+
+def test_incremental_flag_is_documented_in_help(mod, capsys) -> None:
+    """The escape hatch is useless if `--help` does not explain the trade-off."""
+    with pytest.raises(SystemExit):
+        mod.main(["--help"])
+    help_text = capsys.readouterr().out
+    assert "--incremental" in help_text
+    assert "--warm-cache" in help_text
+    assert ".mypy_cache" in help_text
+
+
+def test_mypy_output_runs_never_invoke_mypy(mod, tmp_path: Path, monkeypatch) -> None:
+    """Synthetic ``--mypy-output`` runs must not touch the new flag path."""
+
+    def _boom(*_args, **_kwargs):
+        raise AssertionError("run_mypy must not be invoked for --mypy-output runs")
+
+    monkeypatch.setattr(mod, "run_mypy", _boom)
+    out = _write(tmp_path, "mypy.txt", "src/a.py:10: error: bad thing  [misc]\n")
+    baseline = tmp_path / "baseline.txt"
+    assert mod.main(["--baseline", str(baseline), "--update", "--mypy-output", str(out)]) == 0
+    assert mod.main(["--baseline", str(baseline), "--mypy-output", str(out)]) == 0
+
+
+# Same byte length in both states, so the file's (mtime, size) validation key
+# is identical -- exactly the condition under which mypy replays a cached
+# result instead of re-checking.
+_STALE_STATE_A = 'def f() -> int:\n    return "a"\n'  # errors: str returned as int
+_STALE_STATE_B = 'def f() -> str:\n    return "a"\n'  # clean
+
+
+@pytest.mark.skipif(shutil.which("mypy") is None, reason="mypy binary not on PATH")
+def test_cold_run_ignores_a_poisoned_cache(mod, tmp_path: Path, monkeypatch) -> None:
+    """The property that matters: a stale cache cannot change the cold verdict.
+
+    Seeds ``.mypy_cache/`` from a state that errors, then swaps in a clean
+    state of identical byte length while restoring the original mtime.  The
+    warm run replays the stale error (this is the phantom failure from PRs
+    #4746/#4762 in miniature); the cold run must report the truth.
+    """
+    project = tmp_path / "proj"
+    project.mkdir()
+    module = project / "mod_a.py"
+    module.write_text(_STALE_STATE_A)
+    monkeypatch.chdir(project)
+
+    seeded = mod.run_mypy("mod_a.py", incremental=True)
+    assert "Incompatible return value type" in seeded, (
+        f"test premise broken: state A should error, got:\n{seeded}"
+    )
+    assert (project / ".mypy_cache").is_dir(), "warm run did not write a cache to poison"
+
+    stat_before = module.stat()
+    module.write_text(_STALE_STATE_B)
+    assert module.stat().st_size == stat_before.st_size, "states must be the same byte length"
+    os.utime(module, (stat_before.st_atime, stat_before.st_mtime))
+
+    warm = mod.run_mypy("mod_a.py", incremental=True)
+    cold = mod.run_mypy("mod_a.py")
+
+    assert "Incompatible return value type" in warm, (
+        f"test premise broken: the cache was not actually poisoned, got:\n{warm}"
+    )
+    assert "Incompatible return value type" not in cold, (
+        f"cold run replayed the stale cached error -- the gate is still trapped:\n{cold}"
+    )
+    assert mod.parse_mypy_output(cold) == Counter(), cold


### PR DESCRIPTION
## Summary

The mypy baseline gate could fail locally with a "NEW type error" that does not
exist, in a file that is not in the diff, while CI's Type Check job on the same
commit is green. `run_mypy()` was a bare `subprocess.run(["mypy", target])` with
**no cache control of any kind** — no `--cache-dir`, no `cache_dir` in
`[tool.mypy]`, no `mypy.ini`/`setup.cfg`, no `MYPY_CACHE_DIR` anywhere in the
tree — so every local run reused mypy's incremental cache at
`<cwd>/.mypy_cache`. CI is structurally the opposite: no `actions/cache` in
`.github/workflows/` and `astral-sh/setup-uv` pinned with `enable-cache: false`
(`ci.yml:65`). **CI is always cold, local is always warm, and only the local
verdict was untrustworthy.** That asymmetry is the whole bug.

The cache outlives the tree it was computed from: `.mypy_cache/` is gitignored,
so `git reset --hard`, `git clean -fd` (ignored paths need `-x`), a rebase, a
force-push, and a Loom worktree reuse all leave it in place. Because
`diff_against_baseline` compares a signature multiset over **all** of `src/`,
one replayed cached error anywhere trips exit 2 and prints a filename unrelated
to the diff under review — which is exactly what cost two independent PR
reviews a cycle each during the 2026-08-08/09 sweep (#4746, #4762), both on a
phantom error in `recovery/strategy.py`.

This makes the gate cold by default rather than documenting a workaround for a
trigger nobody has characterized. Two reviewers already demonstrated that
discoverability is the part that fails, so an opt-in `--fresh` flag was
rejected as the primary fix and kept only as the inverse escape hatch.

## Changes

- **`scripts/ci/check_mypy_baseline.py`**
  - `run_mypy(target, *, incremental=False)` builds argv and inserts
    `--no-incremental` unless explicitly opted out. (`--no-incremental` over
    `--cache-dir=/dev/null`: same effect on the read path, portable, no device
    node.)
  - New `--incremental` / `--warm-cache` CLI flag, threaded to `run_mypy`, with
    `--help` text that names the trade-off and the two burned PRs.
  - Module docstring gains a "Why this gate runs COLD" section (CI has no
    `actions/cache`; the two phantom failures; the measured cost).
- **`tests/test_ci_mypy_baseline.py`** — 8 new tests (see Test Plan).
- **`docs/contributing/development.md`** — new "The stale `.mypy_cache/` trap"
  subsection under § Type Checking with Mypy: why bare `mypy` / `pnpm
  typecheck` stay incremental, why git never clears the cache, the
  `rm -rf .mypy_cache` (or `/repo:tidy --caches`) remedy, and an explicit "do
  **not** reach for `--update`".
- **`README.md`** — step 3 of the "Fresh worktree checklist", alongside the
  existing `uv sync --frozen` / `kct build-native` steps.
- **`CLAUDE.md`** — a short dev-checks note **outside** both the
  `REPO-SKILLS` and `LOOM ORCHESTRATION` marker blocks (this is the surface
  both Judges actually had loaded).
- **`CHANGELOG.md`** — entry under `## [Unreleased]` → `### Fixed`.

Deliberately **not** changed: `package.json`'s `typecheck` / `check:all` still
run a bare incremental `uv run mypy src/`. That is the reason the docs are
part of this PR rather than optional.

## Acceptance Criteria Verification

| Criterion | Status |
|---|---|
| `run_mypy()` disables the cache read by default | ✅ argv is `["mypy", "--no-incremental", target]`; pinned by `test_run_mypy_is_cold_by_default` |
| Opt-out flag restores warm behavior, documented in `--help` | ✅ `--incremental` / `--warm-cache`; `test_incremental_flag_is_documented_in_help` |
| Exit-code semantics unchanged (0/1/2); no change to `diff_against_baseline`, `signature`, `normalize_message`, `load_baseline`, `write_baseline` | ✅ diff touches only the docstring, `run_mypy`, the new argparse block, and the one call site |
| Version-drift guard untouched and still fires | ✅ `mypy_version_drift` / `emit_drift_warning` / the `--update` warning at (now) lines 410-420 are byte-identical; their 11 existing tests pass |
| `.github/mypy-baseline.txt` byte-identical to `origin/main` | ✅ `git diff origin/main -- .github/mypy-baseline.txt` → **0 lines**; both nanobind signatures survive |
| Module docstring states why the gate runs cold | ✅ new section naming the no-`actions/cache` fact and PRs #4746/#4762 |
| `docs/contributing/development.md` documents the trap | ✅ new "The stale `.mypy_cache/` trap" subsection |
| `README.md` fresh-worktree checklist warning | ✅ new step 3 |
| `CLAUDE.md` dev-checks note outside the marker blocks | ✅ inserted between the C++ section and `<!-- BEGIN REPO-SKILLS -->` |
| No file under `.claude/commands/loom/` or `.loom/` modified | ✅ `git diff --cached --name-only` is the 6 files listed above |
| `CHANGELOG.md` records the behavior change | ✅ `## [Unreleased]` → first `### Fixed` |

## Test Plan

**Automated** (`uv run pytest tests/test_ci_mypy_baseline.py` — 40 passed,
32 pre-existing + 8 new; the whole file runs in ~2 s):

- `test_run_mypy_is_cold_by_default` / `test_run_mypy_incremental_opt_out_drops_cold_flag` — argv assertions for both flag states.
- `test_main_runs_cold_by_default` / `test_main_incremental_flag_opts_into_warm_cache` — the CLI actually reaches `run_mypy` (both spellings).
- `test_incremental_flag_is_documented_in_help` — the escape hatch is useless if `--help` doesn't explain it.
- `test_mypy_output_runs_never_invoke_mypy` — synthetic `--mypy-output` runs never touch the new flag path.
- `test_cold_run_ignores_a_poisoned_cache` — **the test that pins the property, not the argv shape.** Seeds `.mypy_cache/` from a state that errors, then swaps in a clean state of *identical byte length* and restores the original mtime (mypy's cache validation key is `(mtime, size)`). Asserts the warm run replays the stale error — i.e. the poison genuinely took — and the cold run reports the truth. Skips if `mypy` is not on PATH.
- `test_baseline_keeps_both_nanobind_signatures` — drift guard so a future cold-run `--update` in a native-built worktree cannot silently drop the `import-not-found` line.

**Manual — both directions proven, in this worktree, against real `src/`:**

1. *No phantom failure.* Perturbed `strategy.py` to
   `self._generate_move_strategiez(` (same byte length as the real attribute),
   ran the gate warm to bake the error into `.mypy_cache`, then restored the
   file byte-for-byte and reset its mtime so the cache key was unchanged. With
   the tree **byte-identical to HEAD** (`git status --short` on that path is
   empty):
   - `--incremental` → **exit 2**, `1 NEW mypy error … recovery/strategy.py: "StrategyGenerator" has no attribute "_generate_move_strategiez"` — the exact phantom from #4746/#4762, reproduced on demand.
   - default (cold) → **exit 0**, `OK: mypy reports 1471 error(s), all within the baseline (1473 allowed)`.
2. *Genuine regressions still caught.* Seeded a real new error
   (`self._generate_via_strategiez(`) and ran the **default** gate → **exit 2**
   with the correct `::error file=…` annotation. Reverted afterwards.
3. *Cost.* Cold gate on a clean tree: **16.6 s** wall (14.4 s user), vs 16.9 s
   for the warm-but-cold-cache seed run. No CI job-timeout risk (Type Check
   sets none).
4. *Edge cases.* Gate passes with **no** `.mypy_cache` at all (`rm -rf` then
   run); `--update` still works (wrote 1471 errors / 888 unique signatures to a
   scratch path — the committed baseline was **not** touched).
5. *Regression signal.* The gate's output on this branch is
   `OK: mypy reports 1471 error(s), all within the baseline (1473 allowed)` —
   identical to main. The change alters **how** mypy is invoked, not what it
   finds.

**Repo checks:** `uv run ruff check .` → All checks passed; `uv run ruff format
. --check` → 1779 files already formatted;
`uv run pytest tests/test_ci_mypy_baseline.py tests/test_changelog_gap_report.py
tests/test_check_doc_drift.py` → 84 passed.

## Notes for review

- The pre-existing untracked `.loom/SWEEP-HANDOFF.md` in the **main** checkout
  (which makes `check-main-clean.sh` exit 3) predates this session — it is in
  the starting `git status` snapshot and was not created or touched here.
- `CLAUDE.md`'s `## Releasing` section ends mid-sentence ("…points at a commit
  that") on main. Pre-existing, out of scope, left alone.

Closes #4767
