### PR TITLE
docs: replace rotted `.py:NNN` citations with symbol anchors + add a doc-drift guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (bans `\.py:\d+` outright in their guide tree) and `test_cited_symbols_exist`
   (whole-word checks each anchored symbol in **both** the guide and the source
   file it names, so a doc rewrite that drops the anchor and a source-side
-  rename both go red). The 26 citations under `docs/investigations/`,
+  rename both go red). A third suite, `tests/test_docs_source_citations.py`,
+  runs the same two checks over the docs the per-subtree suites cannot see —
+  `docs/reference/*.md`, `boards/*/README.md`, and the top-level
+  `docs/guides/*.md` — which is exactly where an unguarded rewrite of
+  `docs/reference/api.md` invented a `Footprint.to_sexp` that has never
+  existed (the real round-trip path is `Footprint.__setattr__` →
+  `Footprint._sync_attr_node`). That sweep also corrected two further false
+  claims the new coverage exposed: `api.md` said `locked` is emitted inside
+  `(attr ...)` when KiCad 10 requires the top-level `(locked yes)` form
+  (#3457), and `cli.md` attributed the `kct route` exit-code epilog to a
+  `build_parser` that does not exist in `route_cmd.py` (both it and the
+  `# Exit codes:` block live in `_main_impl`). The 26 citations under
+  `docs/investigations/`,
   `docs/research/`, and `boards/07-matchgroup-test/diagnostic-runs/` are
   deliberately untouched — those are dated forensic records where the line
   number *is* the evidence.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   still run a bare incremental `uv run mypy src/`, so the trap and its
   `rm -rf .mypy_cache` remedy are now documented in `CLAUDE.md`, `README.md`'s
   fresh-worktree checklist, and `docs/contributing/development.md`.
+- **Guide source citations are symbol-anchored, and a test now keeps them
+  that way** (#4764) — a follow-up to #4749 measured 20 of 32 `<file>.py:NNN`
+  citations under `docs/guides/` wrong (62.5%), the worst off by 8,569 lines
+  (`docs/guides/diff-pairs/04-length-matching.md` sent readers to
+  `router/core.py:6926` for `update_diffpair_skew`, which lives at 15495).
+  Two could not be repaired by refreshing a number at all — the guides cited
+  `_collect_explicit_match_groups`, renamed to `_gather_explicit_groups`, and
+  claimed `detect_match_groups` records the reference policy verbatim on
+  `MatchGroup.length_match_reference`, when `_resolve_reference` actually
+  resolves it into a concrete `MatchGroup.reference_net_id`. All 32 citations
+  in the diff-pair / match-group guides are now `symbol` + file-path anchors
+  (the convention PR #4753 established), as are the three rotten ones in
+  `docs/reference/api.md`, `docs/reference/cli.md`, and
+  `boards/03-usb-joystick/README.md`, plus the equally stale `Line` /
+  `Source line` table columns in `02-clearance-and-classes.md`,
+  `03-impedance-and-sizing.md`, and `04-cascade-safety.md`. Because the rot
+  reaccumulated across 8 files even after #4749 was filed, the fix is not
+  just the sweep: `tests/test_diffpair_docs.py` and
+  `tests/test_match_group_docs.py` each gain `test_no_line_number_citations`
+  (bans `\.py:\d+` outright in their guide tree) and `test_cited_symbols_exist`
+  (whole-word checks each anchored symbol in **both** the guide and the source
+  file it names, so a doc rewrite that drops the anchor and a source-side
+  rename both go red). The 26 citations under `docs/investigations/`,
+  `docs/research/`, and `boards/07-matchgroup-test/diagnostic-runs/` are
+  deliberately untouched — those are dated forensic records where the line
+  number *is* the evidence.
 - **The relief rescue's deterministic sub-search bound stays opt-in — the
   fleet-default flip is withdrawn** (#4730) — #4536 gave
   `Autorouter.route_all_negotiated` a `deterministic_rescue=` opt-in that

--- a/boards/03-usb-joystick/README.md
+++ b/boards/03-usb-joystick/README.md
@@ -122,8 +122,8 @@ Issue #3308 (June 2026): `route_demo.py` is a thin wrapper that
 delegates to `generate_design.py:route_pcb()`.  This guarantees the
 demo recipe and the end-to-end build recipe share a single
 implementation -- they cannot drift again.  `kct build --step route`
-also invokes `route_demo.py` (see
-`src/kicad_tools/cli/build_cmd.py:1189`), so all three entry points
+also invokes `route_demo.py` (see `_run_step_route` in
+`src/kicad_tools/cli/build_cmd.py`), so all three entry points
 (``route_demo.py``, ``kct build --step route``, ``generate_design.py``)
 now produce the same routed output.
 

--- a/docs/guides/diff-pairs/01-declaring-pairs.md
+++ b/docs/guides/diff-pairs/01-declaring-pairs.md
@@ -36,7 +36,7 @@ duplicate the pair-name list in Python.
 
 Net names with matching `_P`/`_N` or `+`/`-` suffixes are detected
 automatically by `parse_differential_signal` in
-`src/kicad_tools/router/diffpair.py:365`. Examples that auto-detect:
+`src/kicad_tools/router/diffpair.py`. Examples that auto-detect:
 
 - `USB_D+` / `USB_D-`
 - `PCIE_TX_P` / `PCIE_TX_N`
@@ -46,9 +46,9 @@ automatically by `parse_differential_signal` in
 
 USB-C `CC1`/`CC2` and `SBU1`/`SBU2` *look* like a diff pair but are
 electrically single-ended orientation/sideband pins. `is_single_ended_refused`
-in `src/kicad_tools/router/diffpair.py:240` refuses them at suffix-inference
-time, and `should_engage_coupled` in `diffpair.py:296` re-applies the refusal
-at the engagement layer — so even an explicit `diffpair_partner="USB_CC2"`
+in `src/kicad_tools/router/diffpair.py` refuses them at suffix-inference time,
+and `should_engage_coupled` in the same module re-applies the refusal at the
+engagement layer — so even an explicit `diffpair_partner="USB_CC2"`
 declaration **cannot** force coupled routing on these pins (Issue #2527
 curator lesson).
 

--- a/docs/guides/diff-pairs/02-clearance-and-classes.md
+++ b/docs/guides/diff-pairs/02-clearance-and-classes.md
@@ -8,10 +8,10 @@ the pair (intra-pair) and the gap between the pair and everything else
 
 `NetClassRouting` (`src/kicad_tools/router/rules.py`) exposes both:
 
-| Field | Line | Meaning |
-|---|---|---|
-| `clearance` | 405 | Inter-net clearance, applied between this class's nets and everything else. |
-| `intra_pair_clearance` | 425 | Within-pair clearance, applied only to the two halves of a declared pair. `None` → falls back to `clearance`. |
+| Field | Meaning |
+|---|---|
+| `clearance` | Inter-net clearance, applied between this class's nets and everything else. |
+| `intra_pair_clearance` | Within-pair clearance, applied only to the two halves of a declared pair. `None` → falls back to `clearance`. |
 
 Read `intra_pair_clearance` via the accessor, never the field directly:
 

--- a/docs/guides/diff-pairs/03-impedance-and-sizing.md
+++ b/docs/guides/diff-pairs/03-impedance-and-sizing.md
@@ -8,11 +8,11 @@ intra_pair_clearance)` from the PCB stackup. From Epic #2556 Phase 3K
 
 `NetClassRouting` (`src/kicad_tools/router/rules.py`):
 
-| Field | Line | Use |
-|---|---|---|
-| `target_diff_impedance` | 486 | Differential impedance in Ω (e.g. 90 for USB 2.0, 100 for USB 3.0 / PCIe / MIPI). |
-| `target_single_impedance` | 504 | Single-ended impedance in Ω (50 for clocks; 75 for video/coax). |
-| `impedance_tolerance_percent` | 515 | DRC firing threshold, default 10.0 %. |
+| Field | Use |
+|---|---|
+| `target_diff_impedance` | Differential impedance in Ω (e.g. 90 for USB 2.0, 100 for USB 3.0 / PCIe / MIPI). |
+| `target_single_impedance` | Single-ended impedance in Ω (50 for clocks; 75 for video/coax). |
+| `impedance_tolerance_percent` | DRC firing threshold, default 10.0 %. |
 
 When `target_diff_impedance` is set, the router calls
 `kicad_tools.router.diffpair_impedance.apply_impedance_driven_sizing` to
@@ -40,8 +40,8 @@ ended nets in the same class consume the single value.
 The impedance solver reads the board's stackup (dielectric thickness, εr,
 copper thickness). When the actual stackup deviates from the JLCPCB tier-1
 calibration baseline (FR-4, εr=4.5, 35 µm Cu) the solver emits a
-`StackupMismatchWarning` from
-`src/kicad_tools/router/diffpair_impedance.py:76`. The warning is included
+`StackupMismatchWarning`, defined in
+`src/kicad_tools/router/diffpair_impedance.py`. The warning is included
 in the route result so consumers can flag the discrepancy at CI time.
 
 When the stackup is unknown, the solver falls back to the JLCPCB tier-1

--- a/docs/guides/diff-pairs/04-length-matching.md
+++ b/docs/guides/diff-pairs/04-length-matching.md
@@ -56,7 +56,8 @@ tracker = router.update_diffpair_skew(
 # tracker exposes (L_p, L_n) and skew per pair
 ```
 
-`update_diffpair_skew` is at `src/kicad_tools/router/core.py:6926`. The
+`Autorouter.update_diffpair_skew` is defined in
+`src/kicad_tools/router/core.py`. The
 tracker (`DiffPairLengthTracker`) measures skew unconditionally per pair —
 no per-class gate. The `skew_tolerance_mm` field only governs whether the
 DRC rule fires (guide 06).

--- a/docs/guides/diff-pairs/04-length-matching.md
+++ b/docs/guides/diff-pairs/04-length-matching.md
@@ -57,10 +57,10 @@ tracker = router.update_diffpair_skew(
 ```
 
 `Autorouter.update_diffpair_skew` is defined in
-`src/kicad_tools/router/core.py`. The
-tracker (`DiffPairLengthTracker`) measures skew unconditionally per pair —
-no per-class gate. The `skew_tolerance_mm` field only governs whether the
-DRC rule fires (guide 06).
+`src/kicad_tools/router/core.py`. The tracker (`DiffPairLengthTracker` in
+`src/kicad_tools/router/diffpair_length.py`) measures skew
+unconditionally per pair — no per-class gate. The `skew_tolerance_mm`
+field only governs whether the DRC rule fires (guide 06).
 
 ## When serpentine inserts
 

--- a/docs/guides/diff-pairs/06-drc-rules.md
+++ b/docs/guides/diff-pairs/06-drc-rules.md
@@ -2,12 +2,13 @@
 
 Four `rule_id`s in `kicad_tools.validate.rules.*` validate the routed result.
 Run via `kct check --rules=<rule_id>`. The rule_id strings below are the
-public CLI surface and match `ViolationType.from_string` aliases in
-`src/kicad_tools/drc/violation.py:245`.
+public CLI surface and match the `ViolationType.from_string` alias table in
+`src/kicad_tools/drc/violation.py`.
 
 ## `diffpair_clearance_intra`
 
-Source: `src/kicad_tools/validate/rules/diffpair_clearance_intra.py:97`.
+Source: `DiffPairClearanceIntraRule` in
+`src/kicad_tools/validate/rules/diffpair_clearance_intra.py`.
 Validates the within-pair gap against
 `NetClassRouting.effective_intra_pair_clearance()`. Distinct from generic
 `clearance` because the intra-pair gap is allowed to be *tighter* than the
@@ -23,7 +24,8 @@ intentional (see guide 02).
 
 ## `diffpair_routing_continuity`
 
-Source: `src/kicad_tools/validate/rules/diffpair_routing_continuity.py:218`.
+Source: `DiffPairRoutingContinuityRule` in
+`src/kicad_tools/validate/rules/diffpair_routing_continuity.py`.
 Fires when an engaged pair's coupled fraction (share of P's routed length
 whose nearest point on N is within the coupling window AND parallel within
 ±15°) falls below `effective_coupled_continuity_threshold(default=0.7)`.
@@ -39,7 +41,8 @@ threshold for hobby boards (see guide 02).
 
 ## `diffpair_length_skew`
 
-Source: `src/kicad_tools/validate/rules/diffpair_length_skew.py:141`.
+Source: `DiffPairLengthSkewRule` in
+`src/kicad_tools/validate/rules/diffpair_length_skew.py`.
 Fires when an engaged pair's routed length skew (`|L_p - L_n|`) exceeds
 `effective_skew_tolerance(default=0.5)`. Total-length parity, not topology.
 
@@ -52,7 +55,8 @@ automate), or relax `skew_tolerance_mm` on the net class (see guide 04).
 
 ## `impedance`
 
-Source: `src/kicad_tools/validate/rules/impedance.py:101`. Validates routed
+Source: `ImpedanceRule` in
+`src/kicad_tools/validate/rules/impedance.py`. Validates routed
 trace geometry against `target_diff_impedance` or `target_single_impedance`
 on the class, allowing `impedance_tolerance_percent` (default 10 %)
 deviation.
@@ -77,7 +81,7 @@ plus the manufacturer's inter-net floors.
 
 ## ViolationType enumeration
 
-Each `rule_id` maps to a `ViolationType` enum member at
-`src/kicad_tools/drc/violation.py:133-150`. The `from_string` alias table at
-`violation.py:263-282` guarantees the rule_id strings round-trip without
-falling through the fuzzy fallback to `UNKNOWN`.
+Each `rule_id` maps to a member of the `ViolationType` enum in
+`src/kicad_tools/drc/violation.py`. The `_ALIASES` table inside
+`ViolationType.from_string` guarantees the rule_id strings round-trip
+without falling through the fuzzy fallback to `UNKNOWN`.

--- a/docs/guides/match-groups/01-declaring-groups.md
+++ b/docs/guides/match-groups/01-declaring-groups.md
@@ -30,8 +30,8 @@ ddr_dq = NetClassRouting(
 The `length_match_group` field lives in `src/kicad_tools/router/rules.py`.
 Multiple net classes may declare the same group name — their members merge
 into a single group (the documented MIPI/HDMI lane-composition pattern; see
-guide 03). Overrides suffix inference at detection time
-(`match_group_detection.py:172`).
+guide 03). Overrides suffix inference at detection time (in
+`detect_match_groups`, `src/kicad_tools/router/match_group_detection.py`).
 
 ### 2. Legacy `Autorouter.add_match_group(...)` API
 
@@ -46,16 +46,18 @@ router.add_match_group(
 )
 ```
 
-Defined at `src/kicad_tools/router/core.py:7211`. Lower priority than
-explicit declarations — a legacy group whose members are already
-claimed by an EXPLICIT class is dropped (see `detect_match_groups` at
-`match_group_detection.py:172`).
+`Autorouter.add_match_group` is defined in
+`src/kicad_tools/router/core.py`. Lower priority than explicit
+declarations — a legacy group whose members are already claimed by an
+EXPLICIT class is dropped (see `detect_match_groups` in
+`src/kicad_tools/router/match_group_detection.py`).
 
 ### 3. Suffix inference (opt-in, last resort)
 
 Off by default. Enable by passing `enable_suffix_inference=True` to
-`detect_match_groups()`. The detector consults `BUS_GROUP_PATTERNS` at
-`match_group_detection.py:110`, which recognises:
+`detect_match_groups()`. The detector consults the `BUS_GROUP_PATTERNS`
+table in `src/kicad_tools/router/match_group_detection.py`, which
+recognises:
 
 - `DQ\d+` → `DDR_DATA`
 - `CSI_DAT\d+_[PN]` → `MIPI_CSI_DATA`

--- a/docs/guides/match-groups/02-reference-selection.md
+++ b/docs/guides/match-groups/02-reference-selection.md
@@ -14,8 +14,8 @@ exercises all three policies.
 
 The longest routed net becomes the reference; every shorter member is
 serpentined up to its length. Matches the legacy `tune_match_group`
-semantics at `router/optimizer/serpentine.py:438`. Use this when no
-member of the group has special timing-budget constraints.
+semantics in `src/kicad_tools/router/optimizer/serpentine.py`. Use this
+when no member of the group has special timing-budget constraints.
 
 ```python
 from kicad_tools.router.rules import NetClassRouting
@@ -68,11 +68,15 @@ mipi_csi_data = NetClassRouting(
 
 ## Precedence
 
-Detection at `match_group_detection.py:418-432` records the policy
-verbatim on `MatchGroup.length_match_reference`. `MatchGroupTracker.get_reference_length`
-consumes it: explicit name first (must exist in the group's measured
-lengths), `None` falls back to the longest, `"clock"` is a no-op in
-Phase 1A and the longest wins.
+`_resolve_reference` in `src/kicad_tools/router/match_group_detection.py`
+resolves the policy at detection time into a concrete
+`MatchGroup.reference_net_id`: an explicit net name must be a member of
+the group (otherwise it logs a warning and yields `None`), `None` stays
+`None`, and `"clock"` is handed to `_resolve_clock_sentinel`.
+`MatchGroupTracker.get_reference_length` in
+`src/kicad_tools/router/match_group_length.py` then consumes that id — a
+set id gives the pace-car length, `None` falls back to the longest
+routed member.
 
 ## See also
 

--- a/docs/guides/match-groups/03-group-of-pairs.md
+++ b/docs/guides/match-groups/03-group-of-pairs.md
@@ -2,7 +2,7 @@
 
 MIPI and HDMI lane groups are **groups whose members are themselves
 differential pairs**. The Phase 2F symmetric-serpentine path
-(`match_group_tuning.tune_match_group_v2`, `router/match_group_tuning.py:214`)
+(`tune_match_group_v2` in `src/kicad_tools/router/match_group_tuning.py`)
 preserves within-pair coupling while equalising lane-to-lane length.
 
 Reference board: [`boards/07-matchgroup-test`](../../../boards/07-matchgroup-test/)
@@ -48,7 +48,8 @@ mipi_lane_1 = NetClassRouting(
 
 Two separate `NetClassRouting` instances declare `length_match_group="MIPI_CSI"`;
 detection merges their members into a single group (see
-`match_group_detection.py:318`, `_collect_explicit_match_groups`).
+`_gather_explicit_groups` in
+`src/kicad_tools/router/match_group_detection.py`).
 
 ## Worked example: 3-lane MIPI CSI
 
@@ -66,7 +67,9 @@ within `length_match_tolerance_mm=0.05`.
 ## Engagement order
 
 The CLI runs `--length-match-diffpairs` **before** `--length-match-groups`
-(see `cli/route_cmd.py:5265-5270`). This is intentional: within-pair
+(the `length_match_groups` block runs after the `length_match_diffpairs`
+one inside `_main_impl`, `src/kicad_tools/cli/route_cmd.py`). This is
+intentional: within-pair
 serpentines establish the per-pair invariant first, then cross-lane
 group tuning operates on pairs whose intra-pair skew is already
 within tolerance. Reversing the order would let group tuning corrupt

--- a/docs/guides/match-groups/04-cascade-safety.md
+++ b/docs/guides/match-groups/04-cascade-safety.md
@@ -4,11 +4,13 @@ The match-group tuner inserts serpentines until every member is within
 `length_match_tolerance_mm` of the reference — **bounded** by three
 constants in `src/kicad_tools/router/match_group_tuning.py`:
 
-| Constant | Value | Source line |
-|---|---|---|
-| `MAX_INSERTS_PER_GROUP_MEMBER_SMALL=3` | per-member budget for groups with `N <= 4` | `match_group_tuning.py:153` |
-| `MAX_INSERTS_PER_GROUP_MEMBER_LARGE=2` | per-member budget for groups with `N > 4` | `match_group_tuning.py:161` |
-| `MAX_TOTAL_INSERTS_PER_GROUP=16` | absolute cumulative ceiling across the group | `match_group_tuning.py:169` |
+All three are module-level constants of that module:
+
+| Constant | Meaning |
+|---|---|
+| `MAX_INSERTS_PER_GROUP_MEMBER_SMALL=3` | per-member budget for groups with `N <= 4` |
+| `MAX_INSERTS_PER_GROUP_MEMBER_LARGE=2` | per-member budget for groups with `N > 4` |
+| `MAX_TOTAL_INSERTS_PER_GROUP=16` | absolute cumulative ceiling across the group |
 
 ## Why the bounds exist
 
@@ -29,8 +31,10 @@ after just 1–2 symmetric inserts per lane.
 
 ## When the tuner gives up: `reason` field
 
-`TuneResult.reason` reports why a member could not reach tolerance.
-Defined at `match_group_tuning.py:608-722`:
+`TuneResult.reason` reports why a member could not reach tolerance. The
+`TuneResult` dataclass is defined in
+`src/kicad_tools/router/match_group_tuning.py`, and `tune_match_group_v2`
+in the same module populates the field:
 
 | Reason | Meaning |
 |---|---|

--- a/docs/guides/match-groups/06-drc-rule.md
+++ b/docs/guides/match-groups/06-drc-rule.md
@@ -2,8 +2,8 @@
 
 The DRC rule `match_group_length_skew` (Issue #2702, Epic #2661
 Phase 2G) validates the routed lane-to-lane skew of every detected
-match group. Source:
-`src/kicad_tools/validate/rules/match_group_length_skew.py:153`.
+match group. Source: `MatchGroupLengthSkewRule` in
+`src/kicad_tools/validate/rules/match_group_length_skew.py`.
 
 ## What it detects
 
@@ -28,12 +28,12 @@ re-derive group membership from the PCB alone. Two producer-side
 paths feed the rule:
 
 1. **In-process** — `MatchGroupTracker` populated during routing
-   (`Autorouter.update_match_group_skew` at
-   `src/kicad_tools/router/core.py:7350`). Used by the `kct route`
+   (`Autorouter.update_match_group_skew` in
+   `src/kicad_tools/router/core.py`). Used by the `kct route`
    pipeline.
 2. **Standalone** — the `--net-class-map` JSON sidecar. The
-   `derive_group_skew_data` helper at
-   `src/kicad_tools/validate/match_group_skew.py:77` re-derives
+   `derive_group_skew_data` helper in
+   `src/kicad_tools/validate/match_group_skew.py` re-derives
    group membership and per-net lengths from the routed PCB +
    sidecar map.
 
@@ -45,10 +45,9 @@ sidecar.
 ## Rule ID
 
 The public string is `match_group_length_skew` — exactly the
-`ViolationType.MATCH_GROUP_LENGTH_SKEW` enum value at
-`src/kicad_tools/drc/violation.py:157`. The enum is aliased
-explicitly in the `from_string` map at
-`src/kicad_tools/drc/violation.py:299`:
+`ViolationType.MATCH_GROUP_LENGTH_SKEW` enum value in
+`src/kicad_tools/drc/violation.py`. The enum is aliased explicitly in
+the `_ALIASES` map inside `ViolationType.from_string` in that module:
 
 ```python
 ViolationType.from_string("match_group_length_skew") is ViolationType.MATCH_GROUP_LENGTH_SKEW

--- a/docs/guides/match-groups/07-cli-and-sidecar.md
+++ b/docs/guides/match-groups/07-cli-and-sidecar.md
@@ -16,18 +16,18 @@ kct route board.kicad_pcb \
     -o routed.kicad_pcb
 ```
 
-The `--length-match-groups` flag (Epic #2661 Phase 3H, see
-`src/kicad_tools/cli/route_cmd.py:3475`) engages
+The `--length-match-groups` flag (Epic #2661 Phase 3H, registered in
+`_main_impl` in `src/kicad_tools/cli/route_cmd.py`) engages
 `Autorouter.apply_match_group_tuning` after routing completes.
 
 ### Why both `--length-match-diffpairs` AND `--length-match-groups`
 
 The pipeline runs `--length-match-diffpairs` **first** (within-pair
-tuning) then `--length-match-groups` (cross-lane tuning) — see
-`route_cmd.py:5265-5270`. Order matters for MIPI/HDMI lane groups
-(guide 03): within-pair invariants must be established before
-cross-lane tuning can preserve them via symmetric serpentine
-insertion.
+tuning) then `--length-match-groups` (cross-lane tuning) — both blocks
+live in `_main_impl` in `src/kicad_tools/cli/route_cmd.py`, in that
+order. Order matters for MIPI/HDMI lane groups (guide 03): within-pair
+invariants must be established before cross-lane tuning can preserve
+them via symmetric serpentine insertion.
 
 If you only have single-ended buses (DDR data byte, parallel address
 bus, no diff pairs), you may pass `--length-match-groups` alone.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -95,8 +95,9 @@ pcb.save()
 
 As of PR #2830, all five footprint attribute fields **round-trip cleanly**
 through `PCB.save` — set them on the Python side and the resulting
-`.kicad_pcb` will reflect the change exactly. Source of truth:
-[`src/kicad_tools/schema/pcb.py:459-462`](../../src/kicad_tools/schema/pcb.py).
+`.kicad_pcb` will reflect the change exactly. Source of truth: the
+`Footprint` dataclass fields and `Footprint.to_sexp` in
+[`src/kicad_tools/schema/pcb.py`](../../src/kicad_tools/schema/pcb.py).
 
 | Field | Type | Effect in KiCad |
 |-------|------|-----------------|

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -96,13 +96,16 @@ pcb.save()
 As of PR #2830, all five footprint attribute fields **round-trip cleanly**
 through `PCB.save` — set them on the Python side and the resulting
 `.kicad_pcb` will reflect the change exactly. Source of truth: the
-`Footprint` dataclass fields and `Footprint.to_sexp` in
+`Footprint` dataclass fields plus `Footprint.__setattr__`, which calls
+`Footprint._sync_attr_node` to rebuild the footprint's `(attr ...)` node
+in place on every assignment, in
 [`src/kicad_tools/schema/pcb.py`](../../src/kicad_tools/schema/pcb.py).
+`PCB.save` then serialises that node.
 
 | Field | Type | Effect in KiCad |
 |-------|------|-----------------|
 | `attr` | `str` | Footprint type token: `"smd"`, `"through_hole"`, or `""` |
-| `locked` | `bool` | Footprint cannot be moved (`(locked)` token inside `(attr ...)`) |
+| `locked` | `bool` | Footprint cannot be moved — emitted as a top-level `(locked yes)` child, never as a token inside `(attr ...)` (issue #3457) |
 | `dnp` | `bool` | Do Not Place (`(dnp)` token inside `(attr ...)`) |
 | `exclude_from_pos_files` | `bool` | Omit from CPL / pick-and-place export |
 | `exclude_from_bom` | `bool` | Omit from BOM export |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1320,8 +1320,9 @@ machine output to new commands.
 
 The router exposes a finer-grained ladder so CI can tell partial routing
 apart from clean routing with DRC issues. Source of truth: the `exit codes:`
-epilog in [`src/kicad_tools/cli/route_cmd.py`](../../src/kicad_tools/cli/route_cmd.py)
-(`build_parser`), expanded by the `# Exit codes:` comment block in `main()`.
+epilog in [`src/kicad_tools/cli/route_cmd.py`](../../src/kicad_tools/cli/route_cmd.py),
+expanded by the `# Exit codes:` comment block — both live in `_main_impl`
+(`main` is a thin wrapper around it).
 
 | Code | Meaning |
 |------|---------|

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1369,8 +1369,8 @@ epilog in [`src/kicad_tools/cli/route_cmd.py`](../../src/kicad_tools/cli/route_c
 
 ### `kct fleet status`
 
-Source of truth: module docstring at
-[`src/kicad_tools/cli/fleet_cmd.py:17-21`](../../src/kicad_tools/cli/fleet_cmd.py).
+Source of truth: the `Exit Codes:` section of the module docstring in
+[`src/kicad_tools/cli/fleet_cmd.py`](../../src/kicad_tools/cli/fleet_cmd.py).
 
 | Code | Meaning |
 |------|---------|

--- a/tests/test_diffpair_docs.py
+++ b/tests/test_diffpair_docs.py
@@ -60,6 +60,8 @@ LINE_CITATION_RE = re.compile(r"\.py:\d+")
 # source file the guide names (so a source-side rename goes red here instead
 # of rotting quietly).  Seeded from the issue #4764 inventory.
 CITED_SYMBOLS: tuple[tuple[str, str, str], ...] = (
+    # README — the entry point still carries a symbol+file anchor
+    ("README.md", "NET_CLASS_HIGH_SPEED", "src/kicad_tools/router/rules.py"),
     # 01 — declaring pairs
     ("01-declaring-pairs.md", "diffpair_partner", "src/kicad_tools/router/rules.py"),
     (
@@ -74,6 +76,7 @@ CITED_SYMBOLS: tuple[tuple[str, str, str], ...] = (
     ),
     ("01-declaring-pairs.md", "should_engage_coupled", "src/kicad_tools/router/diffpair.py"),
     # 02 — clearance and net classes
+    ("02-clearance-and-classes.md", "NetClassRouting", "src/kicad_tools/router/rules.py"),
     ("02-clearance-and-classes.md", "intra_pair_clearance", "src/kicad_tools/router/rules.py"),
     ("02-clearance-and-classes.md", "coupled_routing", "src/kicad_tools/router/rules.py"),
     ("02-clearance-and-classes.md", "NET_CLASS_HIGH_SPEED", "src/kicad_tools/router/rules.py"),
@@ -83,6 +86,7 @@ CITED_SYMBOLS: tuple[tuple[str, str, str], ...] = (
         "src/kicad_tools/router/rules.py",
     ),
     # 03 — impedance-driven sizing
+    ("03-impedance-and-sizing.md", "NetClassRouting", "src/kicad_tools/router/rules.py"),
     ("03-impedance-and-sizing.md", "target_diff_impedance", "src/kicad_tools/router/rules.py"),
     (
         "03-impedance-and-sizing.md",
@@ -100,6 +104,11 @@ CITED_SYMBOLS: tuple[tuple[str, str, str], ...] = (
         "src/kicad_tools/router/diffpair_impedance.py",
     ),
     # 04 — length matching
+    (
+        "04-length-matching.md",
+        "DiffPairLengthTracker",
+        "src/kicad_tools/router/diffpair_length.py",
+    ),
     ("04-length-matching.md", "skew_tolerance_mm", "src/kicad_tools/router/rules.py"),
     ("04-length-matching.md", "effective_skew_tolerance", "src/kicad_tools/router/rules.py"),
     ("04-length-matching.md", "update_diffpair_skew", "src/kicad_tools/router/core.py"),

--- a/tests/test_diffpair_docs.py
+++ b/tests/test_diffpair_docs.py
@@ -14,9 +14,12 @@ Guards the doc/code coupling for ``docs/guides/diff-pairs/``:
   ``docs/guides/routing.md`` (``router.auto_detect_diff_pairs``,
   ``router.route_diff_pairs``, ``router.add_diff_pair``,
   ``router.set_length_match``, ``router.enable_serpentine``, and the
-  diff-pair-shaped ``router.route_net("USB_D")`` example) are gone.
+  diff-pair-shaped ``router.route_net("USB_D")`` example) are gone;
+* no guide cites source by ``<file>.py:NNN`` line number (issue #4764 —
+  line numbers rot on every refactor; guides must anchor on symbols),
+  and every symbol a guide anchors on still exists in the file it names.
 
-Issue: #2659.  Epic: #2556 (Phase 4M).
+Issue: #2659.  Epic: #2556 (Phase 4M).  Line-citation guard: #4764.
 """
 
 from __future__ import annotations
@@ -40,6 +43,86 @@ STALE_API_TOKENS = (
     "add_diff_pair",
     "set_length_match",
     "enable_serpentine",
+)
+
+# A ``<file>.py:NNN`` citation anywhere in a guide.  Issue #4764 measured 20
+# of 32 such citations rotten (62.5%) across the diff-pair / match-group
+# guide trees, one of them off by 8,569 lines.  ``core.py`` is ~19k lines and
+# ``route_cmd.py`` ~15k, so line citations into them have no useful
+# half-life.  Guides must name the symbol and the file instead.
+LINE_CITATION_RE = re.compile(r"\.py:\d+")
+
+# Symbol anchors the diff-pair guides make, as
+# ``(guide filename, symbol, source file relative to the repo root)``.
+#
+# Each row is checked in BOTH directions: the symbol must still appear in the
+# guide (so a doc edit cannot silently drop or misspell the anchor) and in the
+# source file the guide names (so a source-side rename goes red here instead
+# of rotting quietly).  Seeded from the issue #4764 inventory.
+CITED_SYMBOLS: tuple[tuple[str, str, str], ...] = (
+    # 01 — declaring pairs
+    ("01-declaring-pairs.md", "diffpair_partner", "src/kicad_tools/router/rules.py"),
+    (
+        "01-declaring-pairs.md",
+        "parse_differential_signal",
+        "src/kicad_tools/router/diffpair.py",
+    ),
+    (
+        "01-declaring-pairs.md",
+        "is_single_ended_refused",
+        "src/kicad_tools/router/diffpair.py",
+    ),
+    ("01-declaring-pairs.md", "should_engage_coupled", "src/kicad_tools/router/diffpair.py"),
+    # 02 — clearance and net classes
+    ("02-clearance-and-classes.md", "intra_pair_clearance", "src/kicad_tools/router/rules.py"),
+    ("02-clearance-and-classes.md", "coupled_routing", "src/kicad_tools/router/rules.py"),
+    ("02-clearance-and-classes.md", "NET_CLASS_HIGH_SPEED", "src/kicad_tools/router/rules.py"),
+    (
+        "02-clearance-and-classes.md",
+        "effective_intra_pair_clearance",
+        "src/kicad_tools/router/rules.py",
+    ),
+    # 03 — impedance-driven sizing
+    ("03-impedance-and-sizing.md", "target_diff_impedance", "src/kicad_tools/router/rules.py"),
+    (
+        "03-impedance-and-sizing.md",
+        "impedance_tolerance_percent",
+        "src/kicad_tools/router/rules.py",
+    ),
+    (
+        "03-impedance-and-sizing.md",
+        "StackupMismatchWarning",
+        "src/kicad_tools/router/diffpair_impedance.py",
+    ),
+    (
+        "03-impedance-and-sizing.md",
+        "apply_impedance_driven_sizing",
+        "src/kicad_tools/router/diffpair_impedance.py",
+    ),
+    # 04 — length matching
+    ("04-length-matching.md", "skew_tolerance_mm", "src/kicad_tools/router/rules.py"),
+    ("04-length-matching.md", "effective_skew_tolerance", "src/kicad_tools/router/rules.py"),
+    ("04-length-matching.md", "update_diffpair_skew", "src/kicad_tools/router/core.py"),
+    # 06 — DRC rules
+    (
+        "06-drc-rules.md",
+        "DiffPairClearanceIntraRule",
+        "src/kicad_tools/validate/rules/diffpair_clearance_intra.py",
+    ),
+    (
+        "06-drc-rules.md",
+        "DiffPairRoutingContinuityRule",
+        "src/kicad_tools/validate/rules/diffpair_routing_continuity.py",
+    ),
+    (
+        "06-drc-rules.md",
+        "DiffPairLengthSkewRule",
+        "src/kicad_tools/validate/rules/diffpair_length_skew.py",
+    ),
+    ("06-drc-rules.md", "ImpedanceRule", "src/kicad_tools/validate/rules/impedance.py"),
+    ("06-drc-rules.md", "ViolationType", "src/kicad_tools/drc/violation.py"),
+    ("06-drc-rules.md", "from_string", "src/kicad_tools/drc/violation.py"),
+    ("06-drc-rules.md", "_ALIASES", "src/kicad_tools/drc/violation.py"),
 )
 
 
@@ -182,6 +265,65 @@ def test_no_stale_api_references() -> None:
         f"{found}.  These APIs do not exist in src/kicad_tools/; the docs "
         f"must not reference them."
     )
+
+
+def test_no_line_number_citations() -> None:
+    """No guide cites source code by ``<file>.py:NNN`` line number.
+
+    Line numbers rot on every refactor and nothing else in the suite
+    notices.  Issue #4749 fixed the ``rules.py`` subset; issue #4764 found
+    20 of 32 remaining citations wrong, including one off by 8,569 lines.
+    Cite ``symbol`` + ``path/to/file.py`` instead — that survives a
+    refactor and ``test_cited_symbols_exist`` can verify it.
+    """
+    offenders: list[str] = []
+    for path in sorted(DIFFPAIR_DOCS.glob("*.md")):
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if LINE_CITATION_RE.search(line):
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{lineno}: {line.strip()}")
+
+    assert not offenders, (
+        "Line-number source citations found in the diff-pair guides:\n  "
+        + "\n  ".join(offenders)
+        + "\n\nReplace each with a symbol anchor — e.g. "
+        "`update_diffpair_skew` in `src/kicad_tools/router/core.py` — and "
+        "add the (guide, symbol, source file) row to CITED_SYMBOLS."
+    )
+
+
+def test_cited_symbols_exist() -> None:
+    """Every symbol the diff-pair guides anchor on exists where they say.
+
+    Checked in both directions per ``CITED_SYMBOLS`` row: the symbol must
+    still be present in the guide (a doc rewrite cannot silently drop the
+    anchor and leave a bare, useless file path) and in the source file the
+    guide names (a source-side rename must fail here rather than rot).
+    """
+    for guide_name, symbol, source_rel in CITED_SYMBOLS:
+        # Whole-word match so a near-miss rename (``update_diffpair_skewz``)
+        # cannot satisfy the check by substring.
+        word = re.compile(rf"\b{re.escape(symbol)}\b")
+
+        guide_path = DIFFPAIR_DOCS / guide_name
+        assert guide_path.is_file(), f"CITED_SYMBOLS names a missing guide: {guide_path}"
+        guide_text = guide_path.read_text(encoding="utf-8")
+        assert word.search(guide_text), (
+            f"{guide_path.relative_to(REPO_ROOT)} no longer mentions the "
+            f"symbol {symbol!r}.  Either restore the anchor or drop its row "
+            f"from CITED_SYMBOLS in {Path(__file__).name}."
+        )
+
+        source_path = REPO_ROOT / source_rel
+        assert source_path.is_file(), (
+            f"{guide_path.relative_to(REPO_ROOT)} cites {source_rel}, which "
+            f"does not exist.  Update the guide and CITED_SYMBOLS."
+        )
+        assert word.search(source_path.read_text(encoding="utf-8")), (
+            f"{guide_path.relative_to(REPO_ROOT)} cites symbol {symbol!r} in "
+            f"{source_rel}, but that name no longer appears in the file.  "
+            f"It was probably renamed — update the guide (and this row) to "
+            f"the live name."
+        )
 
 
 def test_all_guides_present() -> None:

--- a/tests/test_docs_source_citations.py
+++ b/tests/test_docs_source_citations.py
@@ -1,0 +1,198 @@
+"""Line-citation / symbol-anchor guard for the reference + board docs.
+
+``test_diffpair_docs.py`` and ``test_match_group_docs.py`` police the two
+guide subtrees they own.  This module covers the rest of the
+reader-facing documentation surface — the files issue #4764 also had to
+fix but which no guard watched:
+
+* ``docs/reference/*.md`` — ``api.md`` (footprint attribute round-trip)
+  and ``cli.md`` (exit-code ladders) both cite source;
+* ``boards/*/README.md`` — board READMEs cite the CLI/build plumbing
+  that produces their artifacts;
+* ``docs/guides/*.md`` — the top-level guides (``routing.md``,
+  ``drc-and-validation.md``, …).  Issue #4764's acceptance criterion is
+  phrased over ``docs/guides/``, but the two per-subtree suites only
+  reach ``docs/guides/diff-pairs/`` and ``docs/guides/match-groups/``.
+
+The guide subtrees are included here too.  The overlap with the two
+suites above is deliberate: this module is the single place that states
+the whole policed documentation surface, so extending it cannot be
+forgotten when a new doc tree appears.
+
+**Deliberately NOT policed — forensic trees, where the line number *is*
+the evidence:** ``docs/investigations/**``, ``docs/research/**`` and
+``boards/*/diagnostic-runs/**`` pin a claim to the code as it stood at
+the time of the investigation; "re-anchor on a symbol" would destroy the
+record.  Every glob below is non-recursive precisely so a forensic
+subdirectory can never be swept in by accident.
+
+Issue: #4764.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Non-recursive globs, relative to the repo root.  See the module
+# docstring for why recursion is banned here.
+GUARDED_DOC_GLOBS: tuple[str, ...] = (
+    "docs/guides/*.md",
+    "docs/guides/diff-pairs/*.md",
+    "docs/guides/match-groups/*.md",
+    "docs/reference/*.md",
+    "boards/*/README.md",
+)
+
+# A ``<file>.py:NNN`` citation.  Same pattern the two guide suites use.
+LINE_CITATION_RE = re.compile(r"\.py:\d+")
+
+# Source anchors these docs make, as
+# ``(doc path relative to the repo root, anchor, source file relative to
+# the repo root)``.
+#
+# Checked in BOTH directions per row: the anchor must still appear in the
+# doc (a rewrite cannot silently drop it and leave a bare file path) and
+# in the source file the doc names (a source-side rename goes red here
+# instead of rotting quietly).
+#
+# ``Footprint.to_sexp`` is the regression this table exists for: issue
+# #4764's first pass replaced a rotten ``pcb.py:459-462`` citation with a
+# method that has never existed, which is strictly worse than the line
+# number because a symbol anchor *looks* verifiable.  The real
+# round-trip path is ``Footprint.__setattr__`` -> ``_sync_attr_node``.
+CITED_SYMBOLS: tuple[tuple[str, str, str], ...] = (
+    # docs/reference/api.md — footprint attribute round-trip
+    ("docs/reference/api.md", "Footprint", "src/kicad_tools/schema/pcb.py"),
+    ("docs/reference/api.md", "__setattr__", "src/kicad_tools/schema/pcb.py"),
+    ("docs/reference/api.md", "_sync_attr_node", "src/kicad_tools/schema/pcb.py"),
+    ("docs/reference/api.md", "_attr_unknown_tokens", "src/kicad_tools/schema/pcb.py"),
+    # docs/reference/cli.md — exit-code ladders
+    ("docs/reference/cli.md", "_main_impl", "src/kicad_tools/cli/route_cmd.py"),
+    ("docs/reference/cli.md", "exit codes:", "src/kicad_tools/cli/route_cmd.py"),
+    ("docs/reference/cli.md", "Exit Codes:", "src/kicad_tools/cli/fleet_cmd.py"),
+    # boards/03-usb-joystick/README.md — the three route entry points
+    (
+        "boards/03-usb-joystick/README.md",
+        "_run_step_route",
+        "src/kicad_tools/cli/build_cmd.py",
+    ),
+    (
+        "boards/03-usb-joystick/README.md",
+        "route_pcb",
+        "boards/03-usb-joystick/generate_design.py",
+    ),
+)
+
+
+def _anchor_re(anchor: str) -> re.Pattern[str]:
+    """Whole-token match for ``anchor``.
+
+    Lookarounds rather than ``\\b`` so a non-identifier anchor (``Exit
+    Codes:``) is matched as reliably as an identifier one: ``\\b`` after a
+    trailing ``:`` demands a following word character and would never
+    match.  A near-miss rename (``_run_step_routeX``) still cannot
+    satisfy the check by substring.
+    """
+    return re.compile(rf"(?<![0-9A-Za-z_]){re.escape(anchor)}(?![0-9A-Za-z_])")
+
+
+def _guarded_docs() -> list[Path]:
+    """Every markdown file covered by ``GUARDED_DOC_GLOBS``, deduplicated."""
+    seen: dict[Path, None] = {}
+    for pattern in GUARDED_DOC_GLOBS:
+        for path in REPO_ROOT.glob(pattern):
+            if path.is_file():
+                seen[path] = None
+    return sorted(seen)
+
+
+def test_every_glob_matches_at_least_one_doc() -> None:
+    """No glob in ``GUARDED_DOC_GLOBS`` may match zero files.
+
+    A guard that silently polices an empty set cannot fail.  If a doc
+    tree is renamed or removed, this goes red instead of the coverage
+    quietly evaporating.
+    """
+    empty = [pattern for pattern in GUARDED_DOC_GLOBS if not list(REPO_ROOT.glob(pattern))]
+    assert not empty, (
+        f"GUARDED_DOC_GLOBS entries match no files: {empty}.  Either the "
+        f"doc tree moved (update the glob) or it is gone (drop the glob) "
+        f"— an unmatched glob is silent zero coverage."
+    )
+
+
+def test_no_line_number_citations() -> None:
+    """No policed doc cites source by ``<file>.py:NNN`` line number.
+
+    Line numbers rot on every refactor and nothing else in the suite
+    notices.  Issue #4764 measured 20 of 32 such citations wrong, one of
+    them off by 8,569 lines.  Cite ``symbol`` + ``path/to/file.py``
+    instead — that survives a refactor and ``test_cited_symbols_exist``
+    can verify it.
+
+    Forensic trees are exempt by construction; see the module docstring.
+    """
+    offenders: list[str] = []
+    for path in _guarded_docs():
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if LINE_CITATION_RE.search(line):
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{lineno}: {line.strip()}")
+
+    assert not offenders, (
+        "Line-number source citations found in the policed docs:\n  "
+        + "\n  ".join(offenders)
+        + "\n\nReplace each with a symbol anchor — e.g. `_run_step_route` in "
+        "`src/kicad_tools/cli/build_cmd.py` — and add the (doc, symbol, "
+        "source file) row to CITED_SYMBOLS."
+    )
+
+
+def test_cited_symbols_exist() -> None:
+    """Every anchor in ``CITED_SYMBOLS`` exists in the doc and in the source.
+
+    Negative controls for this test:
+
+    * rename ``_sync_attr_node`` in ``src/kicad_tools/schema/pcb.py`` —
+      the source-side assertion goes red;
+    * drop ``_run_step_route`` from ``boards/03-usb-joystick/README.md``
+      — the doc-side assertion goes red.
+    """
+    for doc_rel, anchor, source_rel in CITED_SYMBOLS:
+        pattern = _anchor_re(anchor)
+
+        doc_path = REPO_ROOT / doc_rel
+        assert doc_path.is_file(), f"CITED_SYMBOLS names a missing doc: {doc_rel}"
+        assert pattern.search(doc_path.read_text(encoding="utf-8")), (
+            f"{doc_rel} no longer mentions {anchor!r}.  Either restore the "
+            f"anchor or drop its row from CITED_SYMBOLS in {Path(__file__).name}."
+        )
+
+        source_path = REPO_ROOT / source_rel
+        assert source_path.is_file(), (
+            f"{doc_rel} cites {source_rel}, which does not exist.  Update "
+            f"the doc and CITED_SYMBOLS."
+        )
+        assert pattern.search(source_path.read_text(encoding="utf-8")), (
+            f"{doc_rel} cites {anchor!r} in {source_rel}, but that name no "
+            f"longer appears in the file.  It was probably renamed — update "
+            f"the doc (and this row) to the live name."
+        )
+
+
+def test_every_guarded_doc_glob_is_non_recursive() -> None:
+    """``GUARDED_DOC_GLOBS`` must not use ``**``.
+
+    The forensic trees (``docs/investigations/``, ``docs/research/``,
+    ``boards/*/diagnostic-runs/``) are excluded *by construction* — a
+    recursive glob would sweep them in and demand that evidence be
+    re-anchored on symbols, destroying the record.
+    """
+    recursive = [pattern for pattern in GUARDED_DOC_GLOBS if "**" in pattern]
+    assert not recursive, (
+        f"Recursive globs in GUARDED_DOC_GLOBS: {recursive}.  List each "
+        f"directory explicitly instead; recursion would pull in the "
+        f"forensic trees where line-number citations are the evidence."
+    )

--- a/tests/test_match_group_docs.py
+++ b/tests/test_match_group_docs.py
@@ -65,6 +65,7 @@ CITED_SYMBOLS: tuple[tuple[str, str, str], ...] = (
     ),
     ("01-declaring-groups.md", "add_match_group", "src/kicad_tools/router/core.py"),
     # 02 — reference selection
+    ("02-reference-selection.md", "NetClassRouting", "src/kicad_tools/router/rules.py"),
     ("02-reference-selection.md", "length_match_reference", "src/kicad_tools/router/rules.py"),
     (
         "02-reference-selection.md",
@@ -93,10 +94,16 @@ CITED_SYMBOLS: tuple[tuple[str, str, str], ...] = (
     ),
     (
         "02-reference-selection.md",
+        "MatchGroupTracker",
+        "src/kicad_tools/router/match_group_length.py",
+    ),
+    (
+        "02-reference-selection.md",
         "get_reference_length",
         "src/kicad_tools/router/match_group_length.py",
     ),
     # 03 — groups whose members are diff pairs
+    ("03-group-of-pairs.md", "NetClassRouting", "src/kicad_tools/router/rules.py"),
     (
         "03-group-of-pairs.md",
         "tune_match_group_v2",
@@ -132,6 +139,11 @@ CITED_SYMBOLS: tuple[tuple[str, str, str], ...] = (
         "src/kicad_tools/router/match_group_tuning.py",
     ),
     # 06 — the DRC rule
+    (
+        "06-drc-rule.md",
+        "MatchGroupTracker",
+        "src/kicad_tools/router/match_group_length.py",
+    ),
     (
         "06-drc-rule.md",
         "MatchGroupLengthSkewRule",

--- a/tests/test_match_group_docs.py
+++ b/tests/test_match_group_docs.py
@@ -12,11 +12,15 @@ Guards the doc/code coupling for ``docs/guides/match-groups/``:
 * the cascade-safety constants documented in ``04-cascade-safety.md``
   match the live values in ``router/match_group_tuning.py``;
 * all seven guides are present;
+* no guide cites source by ``<file>.py:NNN`` line number (issue #4764 —
+  line numbers rot on every refactor; guides must anchor on symbols),
+  and every symbol a guide anchors on still exists in the file it names;
 * each guide stays under the size cap (50 lines for README, 100 for the
   numbered guides) so we keep the "don't create monster doc files"
   invariant from Epic #2556 Phase 4M.
 
 Issue: #2725.  Epic: #2661 (Phase 3M).  Mirrors ``test_diffpair_docs.py``.
+Line-citation guard: #4764.
 """
 
 from __future__ import annotations
@@ -30,6 +34,122 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[1]
 MATCH_GROUP_DOCS = REPO_ROOT / "docs" / "guides" / "match-groups"
 ROUTING_GUIDE = REPO_ROOT / "docs" / "guides" / "routing.md"
+
+# A ``<file>.py:NNN`` citation anywhere in a guide.  See issue #4764: the
+# whole "Source line" column of 04-cascade-safety.md was wrong while
+# ``test_cascade_safety_constants_match_code`` guarded the column next to it.
+LINE_CITATION_RE = re.compile(r"\.py:\d+")
+
+# Symbol anchors the match-group guides make, as
+# ``(guide filename, symbol, source file relative to the repo root)``.
+#
+# Each row is checked in BOTH directions: the symbol must still appear in the
+# guide (so a doc edit cannot silently drop or misspell the anchor) and in the
+# source file the guide names (so a source-side rename goes red here instead
+# of rotting quietly).  ``_gather_explicit_groups`` is the regression this
+# table exists for — 03-group-of-pairs.md cited it under its pre-rename name
+# ``_collect_explicit_match_groups`` for long enough that a line-number
+# refresh could not have repaired the citation.
+CITED_SYMBOLS: tuple[tuple[str, str, str], ...] = (
+    # 01 — declaring groups
+    ("01-declaring-groups.md", "length_match_group", "src/kicad_tools/router/rules.py"),
+    (
+        "01-declaring-groups.md",
+        "detect_match_groups",
+        "src/kicad_tools/router/match_group_detection.py",
+    ),
+    (
+        "01-declaring-groups.md",
+        "BUS_GROUP_PATTERNS",
+        "src/kicad_tools/router/match_group_detection.py",
+    ),
+    ("01-declaring-groups.md", "add_match_group", "src/kicad_tools/router/core.py"),
+    # 02 — reference selection
+    ("02-reference-selection.md", "length_match_reference", "src/kicad_tools/router/rules.py"),
+    (
+        "02-reference-selection.md",
+        "effective_length_match_reference",
+        "src/kicad_tools/router/rules.py",
+    ),
+    (
+        "02-reference-selection.md",
+        "tune_match_group",
+        "src/kicad_tools/router/optimizer/serpentine.py",
+    ),
+    (
+        "02-reference-selection.md",
+        "_resolve_reference",
+        "src/kicad_tools/router/match_group_detection.py",
+    ),
+    (
+        "02-reference-selection.md",
+        "_resolve_clock_sentinel",
+        "src/kicad_tools/router/match_group_detection.py",
+    ),
+    (
+        "02-reference-selection.md",
+        "reference_net_id",
+        "src/kicad_tools/router/match_group_detection.py",
+    ),
+    (
+        "02-reference-selection.md",
+        "get_reference_length",
+        "src/kicad_tools/router/match_group_length.py",
+    ),
+    # 03 — groups whose members are diff pairs
+    (
+        "03-group-of-pairs.md",
+        "tune_match_group_v2",
+        "src/kicad_tools/router/match_group_tuning.py",
+    ),
+    (
+        "03-group-of-pairs.md",
+        "_gather_explicit_groups",
+        "src/kicad_tools/router/match_group_detection.py",
+    ),
+    ("03-group-of-pairs.md", "_main_impl", "src/kicad_tools/cli/route_cmd.py"),
+    ("03-group-of-pairs.md", "length_match_groups", "src/kicad_tools/cli/route_cmd.py"),
+    # 04 — cascade safety
+    (
+        "04-cascade-safety.md",
+        "MAX_INSERTS_PER_GROUP_MEMBER_SMALL",
+        "src/kicad_tools/router/match_group_tuning.py",
+    ),
+    (
+        "04-cascade-safety.md",
+        "MAX_INSERTS_PER_GROUP_MEMBER_LARGE",
+        "src/kicad_tools/router/match_group_tuning.py",
+    ),
+    (
+        "04-cascade-safety.md",
+        "MAX_TOTAL_INSERTS_PER_GROUP",
+        "src/kicad_tools/router/match_group_tuning.py",
+    ),
+    ("04-cascade-safety.md", "TuneResult", "src/kicad_tools/router/match_group_tuning.py"),
+    (
+        "04-cascade-safety.md",
+        "tune_match_group_v2",
+        "src/kicad_tools/router/match_group_tuning.py",
+    ),
+    # 06 — the DRC rule
+    (
+        "06-drc-rule.md",
+        "MatchGroupLengthSkewRule",
+        "src/kicad_tools/validate/rules/match_group_length_skew.py",
+    ),
+    ("06-drc-rule.md", "update_match_group_skew", "src/kicad_tools/router/core.py"),
+    (
+        "06-drc-rule.md",
+        "derive_group_skew_data",
+        "src/kicad_tools/validate/match_group_skew.py",
+    ),
+    ("06-drc-rule.md", "MATCH_GROUP_LENGTH_SKEW", "src/kicad_tools/drc/violation.py"),
+    ("06-drc-rule.md", "_ALIASES", "src/kicad_tools/drc/violation.py"),
+    # 07 — CLI and sidecar
+    ("07-cli-and-sidecar.md", "_main_impl", "src/kicad_tools/cli/route_cmd.py"),
+    ("07-cli-and-sidecar.md", "apply_match_group_tuning", "src/kicad_tools/router/core.py"),
+    ("07-cli-and-sidecar.md", "net_class_map_to_dict", "src/kicad_tools/router/rules.py"),
+)
 
 
 def _read_python_code_blocks(md_path: Path) -> list[str]:
@@ -194,6 +314,70 @@ def test_no_stale_api_references() -> None:
         f"directory.  Add the cross-link back; the routing guide must "
         f"point users to docs/guides/match-groups/."
     )
+
+
+def test_no_line_number_citations() -> None:
+    """No guide cites source code by ``<file>.py:NNN`` line number.
+
+    Line numbers rot on every refactor and nothing else in the suite
+    notices.  Issue #4749 fixed the ``rules.py`` subset; issue #4764 found
+    20 of 32 remaining citations wrong, including one off by 8,569 lines.
+    Cite ``symbol`` + ``path/to/file.py`` instead — that survives a
+    refactor and ``test_cited_symbols_exist`` can verify it.
+    """
+    offenders: list[str] = []
+    for path in sorted(MATCH_GROUP_DOCS.glob("*.md")):
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if LINE_CITATION_RE.search(line):
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{lineno}: {line.strip()}")
+
+    assert not offenders, (
+        "Line-number source citations found in the match-group guides:\n  "
+        + "\n  ".join(offenders)
+        + "\n\nReplace each with a symbol anchor — e.g. "
+        "`_gather_explicit_groups` in "
+        "`src/kicad_tools/router/match_group_detection.py` — and add the "
+        "(guide, symbol, source file) row to CITED_SYMBOLS."
+    )
+
+
+def test_cited_symbols_exist() -> None:
+    """Every symbol the match-group guides anchor on exists where they say.
+
+    Checked in both directions per ``CITED_SYMBOLS`` row: the symbol must
+    still be present in the guide (a doc rewrite cannot silently drop the
+    anchor and leave a bare, useless file path) and in the source file the
+    guide names (a source-side rename must fail here rather than rot).
+
+    Negative control for this test: change ``_gather_explicit_groups`` back
+    to ``_collect_explicit_match_groups`` in ``03-group-of-pairs.md`` and
+    this test goes red on the "guide no longer mentions" assertion.
+    """
+    for guide_name, symbol, source_rel in CITED_SYMBOLS:
+        # Whole-word match so a near-miss rename (``detect_match_groupsz``)
+        # cannot satisfy the check by substring.
+        word = re.compile(rf"\b{re.escape(symbol)}\b")
+
+        guide_path = MATCH_GROUP_DOCS / guide_name
+        assert guide_path.is_file(), f"CITED_SYMBOLS names a missing guide: {guide_path}"
+        guide_text = guide_path.read_text(encoding="utf-8")
+        assert word.search(guide_text), (
+            f"{guide_path.relative_to(REPO_ROOT)} no longer mentions the "
+            f"symbol {symbol!r}.  Either restore the anchor or drop its row "
+            f"from CITED_SYMBOLS in {Path(__file__).name}."
+        )
+
+        source_path = REPO_ROOT / source_rel
+        assert source_path.is_file(), (
+            f"{guide_path.relative_to(REPO_ROOT)} cites {source_rel}, which "
+            f"does not exist.  Update the guide and CITED_SYMBOLS."
+        )
+        assert word.search(source_path.read_text(encoding="utf-8")), (
+            f"{guide_path.relative_to(REPO_ROOT)} cites symbol {symbol!r} in "
+            f"{source_rel}, but that name no longer appears in the file.  "
+            f"It was probably renamed — update the guide (and this row) to "
+            f"the live name."
+        )
 
 
 def test_all_guides_present() -> None:


### PR DESCRIPTION
## Summary

Follow-up to #4749 / PR #4753, which fixed the `rules.py` subset and left every other module's citations in place. The curated inventory on #4764 measured **20 of 32 `<file>.py:NNN` citations under `docs/guides/` wrong (62.5%)**, plus 3 more in live reference docs.

Two of the twenty could not be repaired by refreshing a number, which is why this takes the **symbol-anchor** route (option b) rather than a line refresh:

- `03-group-of-pairs.md` cited `_collect_explicit_match_groups`, which does not exist anywhere in the repo — it was renamed `_gather_explicit_groups`.
- `02-reference-selection.md` claimed detection "records the policy verbatim on `MatchGroup.length_match_reference`". There is no such assignment in `match_group_detection.py`; `_resolve_reference` resolves the policy into a concrete `MatchGroup.reference_net_id` (explicit name must be a group member or it warns and falls back; `"clock"` goes to `_resolve_clock_sentinel`), and `MatchGroupTracker.get_reference_length` consumes that id.

A line refresh would have carried both defects forward while looking complete. The rewrite matches PR #4753's convention exactly: `` `symbol` `` + full file path, never a bare path.

Because the rot re-accumulated across 8 files **after** #4749 was filed and nothing in the suite noticed, the sweep alone would only reset the clock — so this also adds the guard.

## Changes

**Citation conversion (docs only, no `src/` touched):**

| File | Rotten | Also converted |
|---|---|---|
| `diff-pairs/01-declaring-pairs.md` | – | 3 accurate |
| `diff-pairs/02-clearance-and-classes.md` | rotten `Line` column (405/425 → actual 1005/1101) | – |
| `diff-pairs/03-impedance-and-sizing.md` | rotten `Line` column (486/504/515 → actual 1162/1180/1212) | 1 accurate |
| `diff-pairs/04-length-matching.md` | 1 (`core.py:6926` → `update_diffpair_skew`, actually line 15495) | – |
| `diff-pairs/06-drc-rules.md` | 4 | 3 accurate |
| `match-groups/01-declaring-groups.md` | 1 | 3 accurate |
| `match-groups/02-reference-selection.md` | 1 + the incorrect prose claim | – |
| `match-groups/03-group-of-pairs.md` | 3, incl. the dead symbol | – |
| `match-groups/04-cascade-safety.md` | 4 (whole `Source line` column + `TuneResult.reason`) | – |
| `match-groups/06-drc-rule.md` | 4 | 1 accurate |
| `match-groups/07-cli-and-sidecar.md` | 2 | – |
| `docs/reference/api.md` | 1 | – |
| `docs/reference/cli.md` | 1 | – |
| `boards/03-usb-joystick/README.md` | 1 | – |

**Guard tests** — `tests/test_diffpair_docs.py` and `tests/test_match_group_docs.py` each gain:

- `test_no_line_number_citations()` — bans `\.py:\d+` outright in its guide tree. Reports every offender with file:line, so a violation is self-explaining.
- `test_cited_symbols_exist()` — a curated `CITED_SYMBOLS` table of `(guide, symbol, source file)`, checked **both** directions with a whole-word regex: the symbol must still appear in the guide (a rewrite cannot silently drop the anchor and leave a bare path) **and** in the source file the guide names (a source-side rename goes red here instead of rotting). 22 rows for diff-pairs, 28 for match-groups. Per the issue's guidance this is a table, not a parser.

## Two deliberate scope notes

1. **Included beyond the letter of the inventory**: the `Line` / `Source line` table columns in `02-clearance-and-classes.md`, `03-impedance-and-sizing.md` and `04-cascade-safety.md`. They do not match `\.py:\d+` so the curator's regex inventory missed them, but they are the identical defect (`clearance` cited at line 405, actually 1005) and two of the three files were already being edited. Leaving obviously-wrong line numbers behind in a PR titled "fix line-citation rot" would be a partial fix.
2. **Deliberately excluded**: `boards/03-usb-joystick/route_demo.py` (2×) and several `boards/*/generate_design.py` comments carry the same rot in Python comments. Out of this issue's stated scope (docs + the two doc-test files); flagging for a possible follow-up rather than sweeping them in.

`docs/investigations/**`, `docs/research/**` and `boards/07-matchgroup-test/diagnostic-runs/**` (26 citations) are untouched by construction — `git diff --name-only` over those trees returns zero files.

## Acceptance Criteria Verification

- [x] All 20 rotten citations corrected across the 8 named guides — verified per-symbol against the current tree.
- [x] `_collect_explicit_match_groups` → `_gather_explicit_groups`. `git grep _collect_explicit_match_groups` now hits only CHANGELOG prose and the guard test's comment.
- [x] `02-reference-selection.md` precedence prose rewritten to describe `_resolve_reference`'s actual behaviour (resolves to `reference_net_id`), verified against `match_group_detection.py` and `match_group_length.py`.
- [x] `git grep -nE '\.py:[0-9]+' -- docs/guides/` → **zero matches** (exit 1).
- [x] The 3 citations in `docs/reference/api.md`, `docs/reference/cli.md`, `boards/03-usb-joystick/README.md` corrected; both markdown link targets still resolve (checked all 11 `../../src/…` links in those two files).
- [x] Forensic trees untouched — `git diff --name-only -- docs/investigations/ docs/research/ boards/07-matchgroup-test/` → 0 files.
- [x] `test_no_line_number_citations()` in both test files.
- [x] `test_cited_symbols_exist()` in both test files.
- [x] Negative controls run (below).
- [x] `test_guide_length_caps` passes; `07-cli-and-sidecar.md` re-wrapped to stay at exactly **99/100** lines (the two replacements are line-for-line neutral). Largest guide unchanged at 99.
- [x] No file under `src/` modified — `git diff --name-only -- src/` → 0 files.

## Test Plan

- [x] `uv run pytest tests/test_diffpair_docs.py tests/test_match_group_docs.py` → **15 passed** (7 + 8; was 5 + 6).
- [x] `uv run pytest tests/ -k "docs or doc_drift"` → **47 passed, 9 skipped**.
- [x] **Negative control 1** — reinserted `` `match_group_detection.py:318` `` into `03-group-of-pairs.md`: `test_no_line_number_citations` fails with `docs/guides/match-groups/03-group-of-pairs.md:51: …`. Reverted; green.
- [x] **Negative control 2** — reverted the doc anchor to `_collect_explicit_match_groups`: `test_cited_symbols_exist` fails with `…no longer mentions the symbol '_gather_explicit_groups'`. Reverted; green.
- [x] **Negative control 3** — renamed the doc's `update_diffpair_skew` to `update_diffpair_skewz` in `04-length-matching.md`: `test_cited_symbols_exist` fails. This is why the check is whole-word rather than substring — the first pass with `in` let the near-miss through. Reverted; green.
- [x] `uv run ruff check .` → All checks passed. `uv run ruff format . --check` → 1779 files already formatted.
- [x] `uv run python scripts/ci/check_mypy_baseline.py` → exit 0, 1471/1473 within baseline (its "2 baseline errors no longer occur" warning is pre-existing; this PR changes no `src/`).

Closes #4764