### PR TITLE
fix(router): stop absorbing resource exhaustion and drop the sweep's wall clock in deterministic mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `docs/research/`, and `boards/07-matchgroup-test/diagnostic-runs/` are
   deliberately untouched — those are dated forensic records where the line
   number *is* the evidence.
+- **Host resource exhaustion aborts a route instead of silently changing
+  one, and the post-negotiation rescue sweep stops using a wall clock in
+  deterministic mode** (#4724) — the residual, load-correlated divergence
+  left over from #4536: one board-06 regen taken on a host at load-average
+  ~90 re-landed one fewer net in stagnation recovery (`restored 5 / rerouted
+  6`) than five same-code runs on a quiet host (`restored 4 / rerouted 7`),
+  then diverged chaotically. Both artifacts were valid and passed every
+  gate, so nothing failed loudly — the run was simply not the run the same
+  command produces on a quiet machine. Two environment-sensitive decision
+  points are closed. **(1) Exception transparency:** the router's broad
+  `except Exception` handlers exist so a malformed board or a fixture grid
+  cannot abort a route, but they also absorbed `MemoryError` — converting a
+  *host* failure into a routing *decision* ("this Steiner cell is free",
+  "this component has no pitch", "this rip-up did not fire", "use the
+  10-100x slower Python backend"). A new `router/resource_guard.py`
+  re-raises resource exhaustion (`MemoryError`, `RecursionError`, `ENOMEM`
+  `OSError`, and a native `bad_alloc` rethrown as `RuntimeError`) with a
+  named `[resource-exhaustion]` line, applied to the seven broad handlers on
+  the negotiated reroute path; every ordinary exception keeps its historical
+  fallback byte-for-byte. The C++ grid-mirror fallback also now names the
+  failing exception type in its log instead of reporting "unknown reason".
+  **(2) Sweep budget semantics:** the #4159 post-negotiation rescue sweep
+  applied its 60 s whole-pass / 10 s per-net wall clocks even to callers
+  running unbudgeted (`timeout=None` / `per_net_timeout=None`) in the
+  deterministic-budget mode #4536 established precisely so no wall clock
+  decides anything — and a per-net search that runs to its 1M-expansion cap
+  costs ~11 s on a CI runner, so the 10 s bound straddled it the same way
+  the relief rescue's 10 s sub-search budget did. `_post_negotiation_sweep`
+  now selects its bounds through `_post_negotiation_sweep_bounds`, which
+  hands an unbudgeted run with an active node-expansion cap to the cap
+  (keeping 600 s / 120 s as non-binding Python-fallback backstops) and logs
+  which bound is live, mirroring #4536's evidence discipline. The arm
+  self-scopes by construction: every caller that passes a `timeout`, and
+  every capless run, keeps the historical numbers exactly. Also: the gated
+  board-06 determinism smoke test now prints host load-average before,
+  between and after its regens (and in its failure message) so a flake is
+  attributable to load rather than argued about. No board recipe, DRC
+  allowlist or reach floor is touched; reproducing the load-90 divergence
+  itself remains out of reach by construction.
 - **The relief rescue's deterministic sub-search bound stays opt-in — the
   fleet-default flip is withdrawn** (#4730) — #4536 gave
   `Autorouter.route_all_negotiated` a `deterministic_rescue=` opt-in that

--- a/src/kicad_tools/router/algorithms/__init__.py
+++ b/src/kicad_tools/router/algorithms/__init__.py
@@ -25,6 +25,8 @@ from .negotiated import (
     PER_NET_CAP_STAGE_FRACTION,
     POST_NEGOTIATION_SWEEP_BUDGET_S,
     POST_NEGOTIATION_SWEEP_PER_NET_S,
+    POST_NEGOTIATION_SWEEP_PER_NET_SAFETY_BACKSTOP_S,
+    POST_NEGOTIATION_SWEEP_SAFETY_BACKSTOP_S,
     NegotiatedRouter,
     calculate_congestion_tuned_params,
     calculate_history_increment,
@@ -58,6 +60,9 @@ __all__ = [
     # Post-negotiation rescue sweep (Issue #4159)
     "POST_NEGOTIATION_SWEEP_BUDGET_S",
     "POST_NEGOTIATION_SWEEP_PER_NET_S",
+    # Deterministic-mode replacements for the two above (Issue #4724)
+    "POST_NEGOTIATION_SWEEP_PER_NET_SAFETY_BACKSTOP_S",
+    "POST_NEGOTIATION_SWEEP_SAFETY_BACKSTOP_S",
     # Per-net A* cap derivation (Issue #3474 R1)
     "PER_NET_CAP_FLOOR_S",
     "PER_NET_CAP_STAGE_FRACTION",

--- a/src/kicad_tools/router/algorithms/negotiated.py
+++ b/src/kicad_tools/router/algorithms/negotiated.py
@@ -72,6 +72,28 @@ GRACE_PASS_PER_NET_S = GRACE_PASS_TIER_CAPS_S[-1]
 POST_NEGOTIATION_SWEEP_BUDGET_S = 60.0
 POST_NEGOTIATION_SWEEP_PER_NET_S = 10.0
 
+# Issue #4724: the sweep bounds kept when the CALLER runs unbudgeted
+# (``timeout=None`` / ``per_net_timeout=None``) AND a per-net node-expansion
+# cap is active -- i.e. the deterministic-budget mode #4536 established, where
+# a wall clock must not decide anything.
+#
+# The two bounds above ARE load-bearing in that mode: a per-net search that
+# exhausts the 1,000,000-expansion cap costs ~11 s on a CI runner, so the 10 s
+# per-net cap STRADDLES it (the same straddle that made the relief rescue's
+# 10 s sub-search budget a coin flip on machine speed, #4536), and a handful of
+# stranded nets is enough for the 60 s whole-sweep ceiling to cut the tail at a
+# load-dependent net boundary.  Both decide WHICH nets get rescued -- routed
+# reach -- not merely runtime.
+#
+# These replacements are ~10x the natural times, matching
+# ``RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S``: deliberately NOT load-bearing, kept
+# only so the one path the expansion cap does not price in seconds (the
+# pure-Python A* fallback, 10-100x slower) cannot grind for many minutes inside
+# a post-loop sweep (the #3989 lesson).  Callers that DO pass a ``timeout``
+# keep the historical bounds unchanged.
+POST_NEGOTIATION_SWEEP_SAFETY_BACKSTOP_S = 600.0
+POST_NEGOTIATION_SWEEP_PER_NET_SAFETY_BACKSTOP_S = 120.0
+
 # Issue #3474 R1: abort threshold for a single grace attempt that grossly
 # overruns its cap.  ``route_fn`` legally spends a small multiple of the
 # per-call cap (see the ~15x note above), but a 100x+ overrun means a

--- a/src/kicad_tools/router/algorithms/steiner.py
+++ b/src/kicad_tools/router/algorithms/steiner.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 import math
 from typing import TYPE_CHECKING, Any, Callable
 
+from ..resource_guard import reraise_if_resource_exhaustion
+
 if TYPE_CHECKING:
     from ..primitives import Pad
 
@@ -103,6 +105,14 @@ def make_blocked_cell_predicate(
     behaviour is preserved byte-for-byte on grids that cannot answer
     occupancy queries.
 
+    Issue #4724: "any per-cell exception" excludes HOST resource
+    exhaustion.  Every fallback here changes where a Steiner branch point
+    lands -- i.e. it changes the routed result -- so absorbing a
+    ``MemoryError`` from the grid's occupancy scan would silently make a
+    loaded host route differently from a quiet one.  Each handler defers
+    to :func:`~..resource_guard.reraise_if_resource_exhaustion` first;
+    ordinary fixture/mock exceptions keep their historical fallback.
+
     Args:
         grid: ``RoutingGrid`` / ``CppGrid``-compatible object exposing
             ``get_routable_indices()``, ``is_blocked_for_net(gx, gy,
@@ -119,6 +129,7 @@ def make_blocked_cell_predicate(
     try:
         routable_indices: list[int] = list(grid.get_routable_indices())
     except Exception:
+        reraise_if_resource_exhaustion("steiner: routable-layer probe")
         return None
     if not routable_indices or not hasattr(grid, "is_blocked_for_net"):
         return None
@@ -134,6 +145,7 @@ def make_blocked_cell_predicate(
     except Exception:
         # Fixture/mock rules without these attributes: keep the 1-cell
         # margin.
+        reraise_if_resource_exhaustion("steiner: relocation-margin resolution")
         margin_cells = 1
 
     def _point_blocked(gx: int, gy: int) -> bool:
@@ -151,6 +163,7 @@ def make_blocked_cell_predicate(
                     return False
             return True
         except Exception:
+            reraise_if_resource_exhaustion("steiner: blocked-cell occupancy scan")
             return False
 
     return _point_blocked

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -40,6 +40,8 @@ from .algorithms import (
     PER_NET_CAP_STAGE_FRACTION,
     POST_NEGOTIATION_SWEEP_BUDGET_S,
     POST_NEGOTIATION_SWEEP_PER_NET_S,
+    POST_NEGOTIATION_SWEEP_PER_NET_SAFETY_BACKSTOP_S,
+    POST_NEGOTIATION_SWEEP_SAFETY_BACKSTOP_S,
     HierarchicalRouter,
     MonteCarloRouter,
     MSTRouter,
@@ -98,6 +100,7 @@ from .placement_feedback import (
     write_placement_delta_json,
 )
 from .primitives import Obstacle, Pad, Route, Via
+from .resource_guard import reraise_if_resource_exhaustion
 from .rules import (
     DEFAULT_NET_CLASS_MAP,
     SIMPLE_NET_THRESHOLD_MM,
@@ -7953,6 +7956,10 @@ class Autorouter:
                 max_ripups_per_net=self._route_all_max_ripups_per_net,
             )
         except Exception as exc:  # pragma: no cover - defensive
+            # Issue #4724: a swallowed rip-up is a routing-decision change
+            # (the failed net stays failed), so host exhaustion aborts here
+            # rather than quietly costing the board a net.
+            reraise_if_resource_exhaustion("core: BLOCKED_BY_COMPONENT rip-up")
             flush_print(f"  BLOCKED_BY_COMPONENT rip-up raised {type(exc).__name__}: {exc}")
             return []
 
@@ -8134,6 +8141,9 @@ class Autorouter:
                 net_names=self.net_names,
             )
         except Exception as exc:  # pragma: no cover - defensive
+            # Issue #4724: see the route_all sibling above -- exhaustion must
+            # not be absorbed into "the rescue did not fire".
+            reraise_if_resource_exhaustion("core: BLOCKED_BY_COMPONENT rip-up (negotiated)")
             flush_print(
                 f"  BLOCKED_BY_COMPONENT rip-up (negotiated) raised {type(exc).__name__}: {exc}"
             )
@@ -12313,19 +12323,23 @@ class Autorouter:
                 # loop already timed out the remaining budget is spent, so the
                 # sweep runs on its own contained allowance.  The per-net cap
                 # keeps one genuinely-impossible net from eating the sweep.
-                sweep_remaining: float | None = None
-                if timeout is not None:
-                    sweep_remaining = timeout - (time.time() - start_time)
-                if sweep_remaining is not None and sweep_remaining > 0 and not timed_out:
-                    sweep_budget = min(POST_NEGOTIATION_SWEEP_BUDGET_S, sweep_remaining)
-                else:
-                    sweep_budget = POST_NEGOTIATION_SWEEP_BUDGET_S
-                sweep_deadline = time.time() + max(0.0, sweep_budget)
-                sweep_per_net = per_net_timeout
-                if sweep_per_net is None:
-                    sweep_per_net = POST_NEGOTIATION_SWEEP_PER_NET_S
-                else:
-                    sweep_per_net = min(sweep_per_net, POST_NEGOTIATION_SWEEP_PER_NET_S)
+                #
+                # Issue #4724: the selection lives in
+                # ``_post_negotiation_sweep_bounds`` because both bounds decide
+                # WHICH stranded nets get rescued -- an unbudgeted
+                # (deterministic-budget) caller hands them to the node-expansion
+                # cap instead of a wall clock, exactly as #4536 did for the
+                # relief rescue.  Budgeted callers are unchanged.
+                sweep_elapsed = time.time() - start_time
+                sweep_budget, sweep_per_net = self._post_negotiation_sweep_bounds(
+                    timeout, per_net_timeout, sweep_elapsed, timed_out
+                )
+                flush_print(
+                    self._post_negotiation_sweep_bound_line(
+                        timeout, per_net_timeout, sweep_elapsed, timed_out
+                    )
+                )
+                sweep_deadline = time.time() + sweep_budget
                 sweep_rescued = self._post_negotiation_sweep(
                     stranded_nets=sweep_stranded,
                     net_routes=net_routes,
@@ -12531,6 +12545,34 @@ class Autorouter:
             victims |= self.grid.find_relief_conflict_nets(route, net)
         return probe_routes, victims
 
+    def _active_expansion_cap(self) -> int:
+        """The binding per-net node-expansion cap, or ``0`` when uncapped.
+
+        The deterministic bound this router can hand a sub-search is the
+        SMALLER of the tuned per-net cap (``--per-net-iterations`` /
+        ``per_net_iterations``, #3881) and the memory backstop
+        (``--max-search-iterations``, #2610); ``--deterministic-budget``
+        sets both, an explicit flag may set only one.  ``0`` means neither
+        is active, i.e. there is no machine-independent bound available and
+        a wall clock has to stay in force.
+
+        Extracted (Issue #4724) so the relief rescue (#4536) and the
+        post-negotiation sweep (#4159) ask the SAME question -- a second
+        copy of this ``min()`` is exactly how two budget selectors drift
+        into disagreeing about what "deterministic mode" means.
+        """
+        return min(
+            (
+                cap
+                for cap in (
+                    getattr(self, "_per_net_iterations", 0),
+                    getattr(self, "_max_search_iterations", 0),
+                )
+                if cap
+            ),
+            default=0,
+        )
+
     def _relief_subsearch_budget(
         self, per_net_timeout: float | None, deterministic_rescue: bool
     ) -> float | None:
@@ -12575,20 +12617,8 @@ class Autorouter:
         now carries the value per call, so the choice is made where the
         measurement is.
         """
-        if deterministic_rescue:
-            expansion_cap = min(
-                (
-                    cap
-                    for cap in (
-                        getattr(self, "_per_net_iterations", 0),
-                        getattr(self, "_max_search_iterations", 0),
-                    )
-                    if cap
-                ),
-                default=0,
-            )
-            if expansion_cap:
-                return RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S
+        if deterministic_rescue and self._active_expansion_cap():
+            return RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S
         if per_net_timeout:
             return min(RELIEF_SUBSEARCH_BUDGET_S, per_net_timeout)
         return RELIEF_SUBSEARCH_BUDGET_S
@@ -12639,6 +12669,120 @@ class Autorouter:
             f"  Relief-rescue sub-search cap: {wall_clock:.1f}s wall clock -- "
             "deterministic rescue is off for this route (the default; opt in with "
             "deterministic_rescue=True; issue #4730)"
+        )
+
+    def _post_negotiation_sweep_bounds(
+        self,
+        timeout: float | None,
+        per_net_timeout: float | None,
+        elapsed: float,
+        timed_out: bool,
+    ) -> tuple[float, float | None]:
+        """Bounds for the #4159 post-negotiation rescue sweep.
+
+        Returns ``(whole_sweep_budget_s, per_net_budget_s)``.
+
+        Issue #4724.  The sweep decides WHICH stranded nets get one solo
+        re-attempt on the live grid, so both of its historical bounds --
+        ``POST_NEGOTIATION_SWEEP_BUDGET_S`` (60 s for the whole pass) and
+        ``POST_NEGOTIATION_SWEEP_PER_NET_S`` (10 s per net) -- decide routed
+        REACH, not runtime.  They were applied UNCONDITIONALLY, including on
+        the deterministic-budget callers that pass ``timeout=None`` /
+        ``per_net_timeout=None`` precisely so that no wall clock decides
+        anything (the #4536 rationale, board 06's regen).  A capped per-net
+        search that runs to its 1M-expansion cap costs ~11 s on a CI runner,
+        so the 10 s per-net bound straddles it exactly the way the relief
+        rescue's 10 s sub-search budget did.
+
+        Selection table -- the same shape as
+        :meth:`_relief_subsearch_budget`, so the two cannot drift:
+
+        * **Unbudgeted caller + active expansion cap** -> the deterministic
+          arm: the node-expansion cap is the binding bound and the returned
+          wall clocks are the ~10x non-binding backstops
+          (``POST_NEGOTIATION_SWEEP_SAFETY_BACKSTOP_S`` /
+          ``POST_NEGOTIATION_SWEEP_PER_NET_SAFETY_BACKSTOP_S``) that keep a
+          pure-Python fallback from grinding.
+        * **Unbudgeted caller, no expansion cap** -> unchanged 60 s / 10 s.
+          There is no machine-independent bound to fall back on, so the
+          historical wall clock is kept rather than degrading to an
+          unbounded sweep (identical reasoning to #4536's capless arm).
+        * **Budgeted caller** (``timeout`` set) -> unchanged: the sweep gets
+          ``min(60 s, remaining stage budget)`` when the loop exited with
+          budget left, else its own contained 60 s allowance, and the per-net
+          cap is clamped by any caller ``per_net_timeout``.
+
+        Args:
+            timeout: The stage wall-clock budget the caller passed, or
+                ``None`` for an unbudgeted (deterministic) run.
+            per_net_timeout: The caller's per-net A* budget, or ``None``.
+            elapsed: Seconds spent in the negotiated loop so far (used only
+                to compute the remaining stage budget of a budgeted caller).
+            timed_out: Whether the loop exited on the stage timeout (then
+                the remaining budget is spent and the sweep runs on its own
+                contained allowance, as before).
+        """
+        if timeout is None and per_net_timeout is None and self._active_expansion_cap():
+            return (
+                POST_NEGOTIATION_SWEEP_SAFETY_BACKSTOP_S,
+                POST_NEGOTIATION_SWEEP_PER_NET_SAFETY_BACKSTOP_S,
+            )
+
+        sweep_remaining: float | None = None
+        if timeout is not None:
+            sweep_remaining = timeout - elapsed
+        if sweep_remaining is not None and sweep_remaining > 0 and not timed_out:
+            sweep_budget = min(POST_NEGOTIATION_SWEEP_BUDGET_S, sweep_remaining)
+        else:
+            sweep_budget = POST_NEGOTIATION_SWEEP_BUDGET_S
+
+        sweep_per_net = per_net_timeout
+        if sweep_per_net is None:
+            sweep_per_net = POST_NEGOTIATION_SWEEP_PER_NET_S
+        else:
+            sweep_per_net = min(sweep_per_net, POST_NEGOTIATION_SWEEP_PER_NET_S)
+        return max(0.0, sweep_budget), sweep_per_net
+
+    def _post_negotiation_sweep_bound_line(
+        self,
+        timeout: float | None,
+        per_net_timeout: float | None,
+        elapsed: float,
+        timed_out: bool,
+    ) -> str:
+        """Routing-log line recording which sweep bound is live (Issue #4724).
+
+        Same evidence discipline as :meth:`_relief_subsearch_bound_line`
+        (#4536): the bound decides which stranded nets get a rescue, so a
+        routing log used as A/B evidence has to say which one was in force.
+        The ``iteration-bounded`` wording is the greppable evidence token;
+        do not reword it.
+        """
+        budget, per_net = self._post_negotiation_sweep_bounds(
+            timeout, per_net_timeout, elapsed, timed_out
+        )
+        if budget == POST_NEGOTIATION_SWEEP_SAFETY_BACKSTOP_S:
+            return (
+                "  Post-negotiation sweep bound: iteration-bounded "
+                "(per-net node-expansion cap; issue #4724) -- which stranded "
+                "nets are rescued is machine-independent; "
+                f"{POST_NEGOTIATION_SWEEP_SAFETY_BACKSTOP_S:.0f}s/"
+                f"{POST_NEGOTIATION_SWEEP_PER_NET_SAFETY_BACKSTOP_S:.0f}s wall "
+                "clocks kept only as non-binding Python-fallback backstops"
+            )
+        per_net_str = "unbounded" if per_net is None else f"{per_net:.1f}s"
+        if timeout is not None:
+            why = "the caller passed a stage timeout (issue #4159)"
+        elif per_net_timeout is not None:
+            why = "the caller passed an explicit per-net wall clock (issue #4159)"
+        else:
+            why = (
+                "no per-net node-expansion cap is active, so the "
+                "machine-dependent bound is kept (issue #4724)"
+            )
+        return (
+            f"  Post-negotiation sweep bound: {budget:.1f}s whole-sweep / "
+            f"{per_net_str} per-net wall clock -- {why}"
         )
 
     def _relief_rescue(
@@ -13692,6 +13836,14 @@ class Autorouter:
             per_net_timeout: Per-net A* budget for each solo attempt.
             deadline: Optional absolute ``time.time()`` ceiling for the
                 whole sweep.  Checked before each net.
+
+        Note:
+            Both bounds decide WHICH stranded nets get their one attempt,
+            so they are reach-determining, not runtime knobs.  The caller
+            selects them through
+            :meth:`_post_negotiation_sweep_bounds`, which hands an
+            unbudgeted (deterministic-budget) run to the per-net
+            node-expansion cap instead of a wall clock (Issue #4724).
 
         Returns:
             The list of net IDs successfully rescued (committed).

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -26,6 +26,8 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
+from .resource_guard import reraise_if_resource_exhaustion
+
 if TYPE_CHECKING:
     import numpy as np
 
@@ -2337,6 +2339,13 @@ class CppPathfinder:
         :meth:`_convert_result_to_route`.  Returns an empty dict (without
         caching) when no Python source grid is attached, so a later
         attachment can still populate the cache.
+
+        Issue #4724: the empty-dict fallback is CACHED and feeds two
+        routing decisions (neck-down widths and the fine-pitch clearance
+        carve-out), so absorbing a host ``MemoryError`` here would change
+        the emitted copper for the rest of the run on a loaded machine
+        only.  Exhaustion re-raises; a genuine data defect still degrades
+        to ``{}`` exactly as before.
         """
         pitches = self._component_pitches_cache
         if pitches is not None:
@@ -2347,6 +2356,7 @@ class CppPathfinder:
         try:
             pitches = py_grid.compute_component_pitches()
         except Exception:
+            reraise_if_resource_exhaustion("cpp_backend: component-pitch computation")
             pitches = {}
         self._component_pitches_cache = pitches
         return pitches
@@ -3422,6 +3432,7 @@ def create_hybrid_router(
     Returns:
         Either CppPathfinder or Python Router instance
     """
+    construction_error: str | None = None
     if _CPP_AVAILABLE and not force_python:
         try:
             cpp_grid = CppGrid.from_routing_grid(grid)
@@ -3433,13 +3444,23 @@ def create_hybrid_router(
                 max_search_iterations=max_search_iterations,
                 per_net_iterations=per_net_iterations,
             )
-        except Exception:
-            # Fall back to Python if C++ initialization fails
-            pass
+        except Exception as exc:
+            # Fall back to Python if C++ initialization fails.
+            #
+            # Issue #4724: NOT for a host allocation failure.  Building the
+            # C++ grid mirror is the largest single allocation in a route,
+            # so it is the likeliest place for memory pressure to land --
+            # and swapping the backend mid-run swaps the SEARCH, i.e. the
+            # run silently becomes a different (and 10-100x slower) run.
+            # Exhaustion aborts; a genuine construction defect still falls
+            # back, now with its type named in the log instead of being
+            # reported as "unknown reason".
+            reraise_if_resource_exhaustion("cpp_backend: C++ grid mirror construction")
+            construction_error = f"C++ backend construction failed: {type(exc).__name__}: {exc}"
 
     # Fall back to Python implementation
     if not force_python:
-        reason = _CPP_IMPORT_ERROR or "unknown reason"
+        reason = construction_error or _CPP_IMPORT_ERROR or "unknown reason"
         logger.warning(
             "C++ router backend not available -- using pure Python (10-100x slower). Reason: %s",
             reason,

--- a/src/kicad_tools/router/resource_guard.py
+++ b/src/kicad_tools/router/resource_guard.py
@@ -1,0 +1,119 @@
+"""Keep resource-exhaustion failures out of routing decisions (Issue #4724).
+
+The router is full of deliberately-broad ``except Exception`` handlers whose
+contract is *"a defect in an optional/defensive computation must never abort a
+route"*.  That contract is right for a malformed board, a fixture grid without
+an occupancy API, or a diagnostic that cannot run -- and wrong for
+**resource exhaustion**.
+
+A ``MemoryError`` (or a native allocation failure surfacing through the C++
+grid mirror) raised inside one net's search is not a property of the board: it
+is a property of the *host at that instant*.  When a broad handler absorbs it,
+the router silently degrades a decision -- "this Steiner cell is free", "this
+component has no pitch", "this reroute failed" -- and the run continues onto a
+DIFFERENT trajectory.  That is exactly the #4724 signature: board 06's
+stagnation recovery reported ``restored 5 / rerouted 6`` on a host at
+load-average ~90 where five same-code runs on a quiet host all reported
+``restored 4 / rerouted 7``, then diverged chaotically from there.  Both
+artifacts were valid and passed every gate, so nothing failed loudly; the run
+was simply not the run the same command produces on a quiet machine.
+
+The rule this module enforces: **an exhausted host must abort the route, not
+change it.**  Call :func:`reraise_if_resource_exhaustion` as the first
+statement of a broad handler that sits on a routing-decision path.  Ordinary
+exceptions fall through untouched (legacy behaviour byte-for-byte); an
+exhaustion failure is announced on stderr with its type and the handler's
+context, then re-raised with its original traceback.
+
+Deliberately NOT applied to handlers whose fallback cannot change a search
+outcome -- the GPU-backend init/sync handlers in ``grid.py``, for instance,
+already log and fall back to the CPU backend, which is a legitimate
+degradation on a machine whose *accelerator* memory is full.
+"""
+
+from __future__ import annotations
+
+import errno
+import sys
+
+__all__ = ["is_resource_exhaustion", "reraise_if_resource_exhaustion"]
+
+# Substrings a NATIVE allocation failure carries when the binding layer
+# surfaces it as a plain ``RuntimeError`` rather than translating it to
+# ``MemoryError`` (nanobind translates ``std::bad_alloc`` to ``MemoryError``,
+# but a C++ layer that catches and rethrows with its own message does not).
+_NATIVE_ALLOCATION_MARKERS = (
+    "bad_alloc",
+    "bad alloc",
+    "cannot allocate memory",
+    "out of memory",
+)
+
+
+def is_resource_exhaustion(exc: BaseException | None) -> bool:
+    """Is ``exc`` a host-resource failure rather than a board/data failure?
+
+    Recognised:
+
+    * :class:`MemoryError` -- including the nanobind translation of a C++
+      ``std::bad_alloc`` from the grid mirror / pathfinder.
+    * :class:`RecursionError` -- stack exhaustion; load-correlated in the
+      same way (a deeper interpreter stack under a loaded host is not the
+      mechanism, but the failure is a host limit, not a board property).
+    * :class:`OSError` with ``errno.ENOMEM`` -- e.g. an mmap/thread/alloc
+      refusal from the OS.
+    * :class:`RuntimeError` whose message names a native allocation failure
+      (see :data:`_NATIVE_ALLOCATION_MARKERS`) -- the rethrow case above.
+
+    Everything else -- ``ValueError``, ``AttributeError``, ``KeyError``, the
+    fixture-grid ``TypeError``s the broad handlers exist for -- is NOT
+    exhaustion and must keep its historical fallback.
+    """
+    if exc is None:
+        return False
+    if isinstance(exc, MemoryError | RecursionError):
+        return True
+    if isinstance(exc, OSError) and exc.errno == errno.ENOMEM:
+        return True
+    if isinstance(exc, RuntimeError):
+        text = str(exc).lower()
+        return any(marker in text for marker in _NATIVE_ALLOCATION_MARKERS)
+    return False
+
+
+def reraise_if_resource_exhaustion(context: str) -> None:
+    """Re-raise the in-flight exception when it is resource exhaustion.
+
+    Call this as the FIRST statement inside a broad ``except Exception``
+    handler on a routing-decision path::
+
+        try:
+            ...
+        except Exception:
+            reraise_if_resource_exhaustion("steiner: blocked-cell probe")
+            return None  # unchanged legacy fallback
+
+    It reads the exception being handled from :func:`sys.exc_info`, so a bare
+    ``except Exception:`` handler does not have to grow an ``as exc`` binding.
+    A non-exhaustion exception (or no active exception at all) returns
+    silently and the caller's fallback runs exactly as before.
+
+    Args:
+        context: Short human-readable identity of the guarded handler, e.g.
+            ``"steiner: blocked-cell probe"``.  Named in the stderr line so a
+            log that reaches a bug report says WHICH decision was at risk.
+
+    Raises:
+        BaseException: the in-flight exception, with its original traceback,
+            when :func:`is_resource_exhaustion` accepts it.
+    """
+    exc = sys.exc_info()[1]
+    if not is_resource_exhaustion(exc):
+        return
+    print(
+        f"  [resource-exhaustion] {context}: {type(exc).__name__}: {exc} -- "
+        "aborting instead of degrading a routing decision (issue #4724)",
+        file=sys.stderr,
+        flush=True,
+    )
+    raise

--- a/tests/test_board06_determinism.py
+++ b/tests/test_board06_determinism.py
@@ -87,7 +87,10 @@ Budget ~25 minutes for the two sequential regens, and run on an
 otherwise-quiet host: under extreme concurrent load (load-average ~90)
 a stagnation-recovery reroute can flip and produce different valid
 copper -- a resource-exhaustion sensitivity tracked separately as #4724,
-not a regression of the #4536 fixes.  See
+not a regression of the #4536 fixes.  The test prints the host
+load-average before, between and after the regens (and repeats it in any
+failure message) so a flaked run is attributable to load rather than
+argued about (#4724).  See
 ``boards/06-diffpair-test/README.md`` ("Measuring Changes") for how this
 test slots into the byte-identity scope-guard convention.
 """
@@ -116,6 +119,30 @@ BOARD_DIR = REPO_ROOT / "boards" / "06-diffpair-test"
 UNROUTED_PCB = BOARD_DIR / "output" / "diffpair_test.kicad_pcb"
 
 _UUID_RE = re.compile(r'\(uuid "[0-9a-fA-F-]+"\)')
+
+
+def _loadavg_line(when: str) -> str:
+    """One-line host load-average record for run attribution (Issue #4724).
+
+    The residual divergence #4724 tracks is LOAD-CORRELATED: the single
+    diverging run of the #4536 verification matrix was taken on a host at
+    load-average ~90 (two parallel pytest suites plus a mypy pass), and its
+    stagnation recovery re-landed one fewer net than the five quiet-host
+    runs.  Without the load recorded next to the result, a future flake of
+    this test is unattributable -- "the fix regressed" and "the host was
+    saturated" look identical in the failure message.
+
+    ``os.getloadavg`` is absent on Windows, where the record degrades to a
+    stated unavailability rather than failing the test.
+    """
+    try:
+        one, five, fifteen = os.getloadavg()
+    except (OSError, AttributeError):  # pragma: no cover - platform-dependent
+        return f"[board06-determinism] load-average {when}: unavailable on this platform"
+    return (
+        f"[board06-determinism] load-average {when}: "
+        f"{one:.2f} {five:.2f} {fifteen:.2f} (cpus={os.cpu_count()})"
+    )
 
 
 def _normalize_uuids(text: str) -> str:
@@ -185,14 +212,25 @@ def test_two_same_seed_route_regens_are_identical(tmp_path: Path) -> None:
     1. identical segment and via counts (count-identity), then
     2. byte-identity of the uuid-normalized artifacts.
     """
+    # Issue #4724: record the host load around each regen (visible under
+    # ``-s``, and captured in the failure message below) so a divergence can
+    # be attributed to -- or cleared of -- host saturation.
+    load_lines = [_loadavg_line("before run-a")]
+    print(load_lines[-1], flush=True)
     first = _run_route_regen(tmp_path / "run-a")
+    load_lines.append(_loadavg_line("between runs"))
+    print(load_lines[-1], flush=True)
     second = _run_route_regen(tmp_path / "run-b")
+    load_lines.append(_loadavg_line("after run-b"))
+    print(load_lines[-1], flush=True)
+    load_report = "\n".join(load_lines)
 
     counts_a = _copper_counts(first)
     counts_b = _copper_counts(second)
     assert counts_a == counts_b, (
         f"segment/via count mismatch between same-seed runs: "
-        f"run-a={counts_a} run-b={counts_b} (issue #4536 regression)"
+        f"run-a={counts_a} run-b={counts_b} (issue #4536 regression)\n"
+        f"{load_report}"
     )
 
     norm_a = _normalize_uuids(first)
@@ -212,6 +250,9 @@ def test_two_same_seed_route_regens_are_identical(tmp_path: Path) -> None:
             f"(first divergence at line {first_div + 1}; "
             f"{len(lines_a)} vs {len(lines_b)} lines).\n"
             f"run-a: {context_a}\nrun-b: {context_b}\n"
+            f"{load_report}\n"
             "See issue #4536 -- a wall-clock, hash-order, or random-UUID "
-            "file-order dependence has re-entered the board-06 route pipeline."
+            "file-order dependence has re-entered the board-06 route pipeline. "
+            "Check the load-average lines first: a saturated host is the "
+            "known #4724 sensitivity, not a #4536 regression."
         )

--- a/tests/test_post_negotiation_sweep_budget.py
+++ b/tests/test_post_negotiation_sweep_budget.py
@@ -1,0 +1,249 @@
+"""Unit tests for the post-negotiation sweep bound selector (Issue #4724).
+
+The #4159 rescue sweep gives every still-stranded net ONE solo attempt on the
+live grid, gated by two wall clocks: ``POST_NEGOTIATION_SWEEP_BUDGET_S`` (60 s
+for the whole pass) and ``POST_NEGOTIATION_SWEEP_PER_NET_S`` (10 s per net).
+Both decide WHICH nets get rescued -- routed reach -- and both were applied
+even to callers running unbudgeted (``timeout=None`` / ``per_net_timeout=None``)
+in the deterministic-budget mode #4536 established precisely so that no wall
+clock decides anything.  A per-net search that runs to its 1M-expansion cap
+costs ~11 s on a CI runner, so the 10 s per-net bound straddles it the same way
+the relief rescue's 10 s sub-search budget did (#4536).
+
+These tests pin the selection table.  Budgeted callers must be unchanged --
+that is the compatibility half of the fix, and the reason the new arm is keyed
+on ``timeout is None`` AND an active node-expansion cap rather than on a new
+flag.  The selector reads only two attributes off ``self``, so it is exercised
+against a lightweight stub, mirroring ``tests/test_relief_subsearch_budget.py``.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from kicad_tools.router.core import (
+    POST_NEGOTIATION_SWEEP_BUDGET_S,
+    POST_NEGOTIATION_SWEEP_PER_NET_S,
+    POST_NEGOTIATION_SWEEP_PER_NET_SAFETY_BACKSTOP_S,
+    POST_NEGOTIATION_SWEEP_SAFETY_BACKSTOP_S,
+    Autorouter,
+)
+
+# The cap values ``--deterministic-budget`` installs (route_cmd.py).
+DETERMINISTIC_PER_NET_ITERATIONS = 1_000_000
+DETERMINISTIC_MAX_SEARCH_ITERATIONS = 12_000_000
+
+
+class _BoundsStub:
+    """Minimal stand-in exposing only the two attributes the selector reads."""
+
+    _active_expansion_cap = Autorouter._active_expansion_cap
+    _post_negotiation_sweep_bounds = Autorouter._post_negotiation_sweep_bounds
+    _post_negotiation_sweep_bound_line = Autorouter._post_negotiation_sweep_bound_line
+
+    def __init__(self, per_net_iterations: int = 0, max_search_iterations: int = 0) -> None:
+        self._per_net_iterations = per_net_iterations
+        self._max_search_iterations = max_search_iterations
+
+
+def _capped() -> _BoundsStub:
+    return _BoundsStub(
+        per_net_iterations=DETERMINISTIC_PER_NET_ITERATIONS,
+        max_search_iterations=DETERMINISTIC_MAX_SEARCH_ITERATIONS,
+    )
+
+
+class TestActiveExpansionCap:
+    def test_uncapped_router_reports_zero(self):
+        assert _BoundsStub()._active_expansion_cap() == 0
+
+    def test_the_smaller_of_the_two_caps_binds(self):
+        assert _capped()._active_expansion_cap() == DETERMINISTIC_PER_NET_ITERATIONS
+
+    def test_memory_backstop_alone_counts(self):
+        """An explicit ``--max-search-iterations`` without a per-net cap."""
+        stub = _BoundsStub(max_search_iterations=DETERMINISTIC_MAX_SEARCH_ITERATIONS)
+        assert stub._active_expansion_cap() == DETERMINISTIC_MAX_SEARCH_ITERATIONS
+
+    def test_relief_rescue_asks_the_same_question(self):
+        """#4724 extracted this helper OUT of ``_relief_subsearch_budget``.
+
+        A second copy of the ``min()`` is how two budget selectors drift into
+        disagreeing about what "deterministic mode" means, so pin that the
+        relief selector still routes through the shared helper.
+        """
+        source = inspect.getsource(Autorouter._relief_subsearch_budget)
+        assert "_active_expansion_cap()" in source
+
+
+class TestUnbudgetedCaller:
+    """``timeout=None`` + ``per_net_timeout=None`` -- board 06's regen."""
+
+    def test_with_expansion_cap_the_wall_clocks_stop_being_load_bearing(self):
+        budget, per_net = _capped()._post_negotiation_sweep_bounds(None, None, 0.0, False)
+        assert budget == POST_NEGOTIATION_SWEEP_SAFETY_BACKSTOP_S
+        assert per_net == POST_NEGOTIATION_SWEEP_PER_NET_SAFETY_BACKSTOP_S
+
+    def test_the_backstops_are_far_above_the_natural_times_they_replace(self):
+        """~10x, matching ``RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S``'s sizing.
+
+        A backstop that merely nudges the old value up would still straddle
+        the ~11 s capped-search time and keep deciding reach.
+        """
+        assert POST_NEGOTIATION_SWEEP_SAFETY_BACKSTOP_S >= 10 * POST_NEGOTIATION_SWEEP_BUDGET_S
+        assert (
+            POST_NEGOTIATION_SWEEP_PER_NET_SAFETY_BACKSTOP_S
+            >= 10 * POST_NEGOTIATION_SWEEP_PER_NET_S
+        )
+
+    def test_elapsed_time_cannot_move_the_deterministic_arm(self):
+        """The whole point: no ``time.time()``-derived value reaches the bound."""
+        first = _capped()._post_negotiation_sweep_bounds(None, None, 0.0, False)
+        later = _capped()._post_negotiation_sweep_bounds(None, None, 9_999.0, False)
+        timed_out = _capped()._post_negotiation_sweep_bounds(None, None, 9_999.0, True)
+        assert first == later == timed_out
+
+    def test_without_an_expansion_cap_the_historical_bounds_are_kept(self):
+        """Degrade to today's behaviour, never to an unbounded sweep."""
+        budget, per_net = _BoundsStub()._post_negotiation_sweep_bounds(None, None, 0.0, False)
+        assert budget == POST_NEGOTIATION_SWEEP_BUDGET_S
+        assert per_net == POST_NEGOTIATION_SWEEP_PER_NET_S
+
+    def test_an_explicit_per_net_wall_clock_opts_back_out(self):
+        """A caller that asked for seconds still gets seconds."""
+        budget, per_net = _capped()._post_negotiation_sweep_bounds(None, 4.0, 0.0, False)
+        assert budget == POST_NEGOTIATION_SWEEP_BUDGET_S
+        assert per_net == 4.0
+
+
+class TestBudgetedCallerIsUnchanged:
+    """Every ``timeout``-carrying caller keeps the exact pre-#4724 numbers."""
+
+    def test_remaining_stage_budget_clamps_the_sweep(self):
+        budget, per_net = _capped()._post_negotiation_sweep_bounds(600.0, None, 570.0, False)
+        assert budget == 30.0
+        assert per_net == POST_NEGOTIATION_SWEEP_PER_NET_S
+
+    def test_ample_remaining_budget_yields_the_flat_ceiling(self):
+        budget, _ = _capped()._post_negotiation_sweep_bounds(600.0, None, 10.0, False)
+        assert budget == POST_NEGOTIATION_SWEEP_BUDGET_S
+
+    def test_a_timed_out_loop_gets_the_contained_allowance(self):
+        budget, _ = _capped()._post_negotiation_sweep_bounds(600.0, None, 610.0, True)
+        assert budget == POST_NEGOTIATION_SWEEP_BUDGET_S
+
+    def test_overrun_without_the_timeout_flag_never_goes_negative(self):
+        budget, _ = _capped()._post_negotiation_sweep_bounds(600.0, None, 610.0, False)
+        assert budget == POST_NEGOTIATION_SWEEP_BUDGET_S
+
+    def test_a_tight_per_net_timeout_still_binds(self):
+        _, per_net = _capped()._post_negotiation_sweep_bounds(600.0, 4.0, 0.0, False)
+        assert per_net == 4.0
+
+    def test_a_loose_per_net_timeout_does_not_relax_the_cap(self):
+        _, per_net = _capped()._post_negotiation_sweep_bounds(600.0, 30.0, 0.0, False)
+        assert per_net == POST_NEGOTIATION_SWEEP_PER_NET_S
+
+
+class TestBoundLine:
+    """The routing log must say which bound was live (#4536 evidence rule)."""
+
+    def test_deterministic_arm_is_greppable(self):
+        line = _capped()._post_negotiation_sweep_bound_line(None, None, 0.0, False)
+        assert "Post-negotiation sweep bound" in line
+        assert "iteration-bounded" in line
+        assert "#4724" in line
+
+    def test_capless_arm_names_the_missing_cap(self):
+        line = _BoundsStub()._post_negotiation_sweep_bound_line(None, None, 0.0, False)
+        assert "iteration-bounded" not in line
+        assert "no per-net node-expansion cap is active" in line
+
+    def test_budgeted_arm_names_the_stage_timeout(self):
+        line = _capped()._post_negotiation_sweep_bound_line(600.0, None, 570.0, False)
+        assert "iteration-bounded" not in line
+        assert "stage timeout" in line
+        assert "30.0s whole-sweep" in line
+
+    def test_explicit_per_net_wall_clock_arm_says_so(self):
+        line = _capped()._post_negotiation_sweep_bound_line(None, 4.0, 0.0, False)
+        assert "explicit per-net wall clock" in line
+
+
+# ---------------------------------------------------------------------------
+# End-to-end wiring: the bound the loop SELECTS is the bound it REPORTS
+# ---------------------------------------------------------------------------
+
+
+def _build_starved_router(**kwargs) -> Autorouter:
+    """A long-haul net the batch loop cannot land, plus an easy net.
+
+    Mirrors ``tests/router/test_post_negotiation_sweep.py``: patching the
+    batch's internal per-net path strands net 1 while leaving the sweep's own
+    ``route_net`` path real, so the sweep actually engages.
+    """
+    router = Autorouter(width=40.0, height=20.0, **kwargs)
+    router.add_component(
+        "R1",
+        [
+            {"number": "1", "x": 2.0, "y": 10.0, "net": 1, "net_name": "LONGHAUL"},
+            {"number": "2", "x": 38.0, "y": 10.0, "net": 1, "net_name": "LONGHAUL"},
+        ],
+    )
+    router.add_component(
+        "R2",
+        [
+            {"number": "1", "x": 10.0, "y": 2.0, "net": 2, "net_name": "NET2"},
+            {"number": "2", "x": 10.0, "y": 18.0, "net": 2, "net_name": "NET2"},
+        ],
+    )
+    orig = router._route_net_negotiated
+
+    def patched(net, pf, per_net_timeout=None):
+        if net == 1:
+            return []
+        return orig(net, pf, per_net_timeout=per_net_timeout)
+
+    router._route_net_negotiated = patched
+    return router
+
+
+class TestLoopWiring:
+    def test_unbudgeted_capped_run_reports_and_uses_the_iteration_bound(self, capsys):
+        ar = _build_starved_router(
+            max_search_iterations=DETERMINISTIC_MAX_SEARCH_ITERATIONS,
+            per_net_iterations=DETERMINISTIC_PER_NET_ITERATIONS,
+        )
+        routes = ar.route_all_negotiated(
+            max_iterations=2, timeout=None, adaptive=False, perturbation=False
+        )
+        out = capsys.readouterr().out
+        assert "Post-negotiation sweep bound: iteration-bounded" in out
+        # The sweep still does its job under the new bound.
+        assert {r.net for r in routes} == {1, 2}
+
+    def test_budgeted_run_still_reports_the_wall_clock(self, capsys):
+        ar = _build_starved_router(
+            max_search_iterations=DETERMINISTIC_MAX_SEARCH_ITERATIONS,
+            per_net_iterations=DETERMINISTIC_PER_NET_ITERATIONS,
+        )
+        ar.route_all_negotiated(max_iterations=2, timeout=30.0, adaptive=False, perturbation=False)
+        out = capsys.readouterr().out
+        # Isolate the sweep's own line: the run also prints the #3881 per-net
+        # A* cap line, which legitimately says "iteration-bounded" too.
+        sweep_line = next(ln for ln in out.splitlines() if "Post-negotiation sweep bound" in ln)
+        assert "iteration-bounded" not in sweep_line
+        assert "stage timeout" in sweep_line
+
+    def test_no_stranded_nets_prints_no_bound_line(self, capsys):
+        """The sweep block is skipped entirely, so the log is unchanged."""
+        ar = Autorouter(width=40.0, height=20.0)
+        ar.add_component(
+            "R2",
+            [
+                {"number": "1", "x": 10.0, "y": 2.0, "net": 2, "net_name": "NET2"},
+                {"number": "2", "x": 10.0, "y": 18.0, "net": 2, "net_name": "NET2"},
+            ],
+        )
+        ar.route_all_negotiated(max_iterations=2, timeout=None, adaptive=False, perturbation=False)
+        assert "Post-negotiation sweep bound" not in capsys.readouterr().out

--- a/tests/test_relief_subsearch_budget.py
+++ b/tests/test_relief_subsearch_budget.py
@@ -45,6 +45,11 @@ class _BudgetStub:
 
     # Borrowed unbound so the stub gets the real selection logic without a board.
     _relief_subsearch_budget = Autorouter._relief_subsearch_budget
+    # Issue #4724 extracted the "is a node-expansion cap active?" question into
+    # a shared helper so the relief rescue and the post-negotiation sweep
+    # cannot drift on what deterministic mode means; the selector calls it on
+    # ``self``, so the stub borrows it too.
+    _active_expansion_cap = Autorouter._active_expansion_cap
 
     def __init__(self, per_net_iterations: int = 0, max_search_iterations: int = 0) -> None:
         self._per_net_iterations = per_net_iterations

--- a/tests/test_router_resource_guard.py
+++ b/tests/test_router_resource_guard.py
@@ -1,0 +1,200 @@
+"""Resource exhaustion must abort a route, never change one (Issue #4724).
+
+The router's broad ``except Exception`` handlers exist so a malformed board,
+a fixture grid without an occupancy API, or an optional diagnostic cannot
+abort a route.  Under host memory pressure the SAME handlers convert a
+``MemoryError`` into a routing DECISION -- "this Steiner cell is free", "this
+component has no pitch", "this rip-up did not fire" -- and the run silently
+continues on a different trajectory.  That is the #4724 signature: board-06's
+stagnation recovery reported ``restored 5 / rerouted 6`` on a host at
+load-average ~90 where five same-code runs on a quiet host all reported
+``restored 4 / rerouted 7``.
+
+These tests pin both halves of the contract at each guarded handler:
+
+* an exhaustion failure PROPAGATES (with its type intact), and
+* an ordinary exception keeps its historical fallback byte-for-byte.
+"""
+
+from __future__ import annotations
+
+import errno
+
+import pytest
+
+from kicad_tools.router.algorithms.steiner import make_blocked_cell_predicate
+from kicad_tools.router.resource_guard import (
+    is_resource_exhaustion,
+    reraise_if_resource_exhaustion,
+)
+
+
+class TestIsResourceExhaustion:
+    def test_memory_error_is_exhaustion(self):
+        assert is_resource_exhaustion(MemoryError("out of memory"))
+
+    def test_recursion_error_is_exhaustion(self):
+        assert is_resource_exhaustion(RecursionError())
+
+    def test_enomem_oserror_is_exhaustion(self):
+        assert is_resource_exhaustion(OSError(errno.ENOMEM, "Cannot allocate memory"))
+
+    def test_other_oserror_is_not_exhaustion(self):
+        assert not is_resource_exhaustion(OSError(errno.ENOENT, "No such file"))
+
+    def test_native_bad_alloc_rethrown_as_runtime_error_is_exhaustion(self):
+        """A C++ layer that catches and rethrows loses the MemoryError type."""
+        assert is_resource_exhaustion(RuntimeError("std::bad_alloc while building grid"))
+
+    def test_ordinary_runtime_error_is_not_exhaustion(self):
+        assert not is_resource_exhaustion(RuntimeError("no path found"))
+
+    @pytest.mark.parametrize("exc", [ValueError("x"), AttributeError("y"), KeyError("z")])
+    def test_board_and_fixture_failures_are_not_exhaustion(self, exc):
+        """The failures the broad handlers were written for stay absorbed."""
+        assert not is_resource_exhaustion(exc)
+
+    def test_no_active_exception_is_not_exhaustion(self):
+        assert not is_resource_exhaustion(None)
+
+
+class TestReraiseHelper:
+    def test_reraises_the_original_exception_object(self):
+        sentinel = MemoryError("mirror allocation failed")
+        with pytest.raises(MemoryError) as caught:
+            try:
+                raise sentinel
+            except Exception:
+                reraise_if_resource_exhaustion("unit: probe")
+        assert caught.value is sentinel
+
+    def test_reports_the_type_and_context_on_stderr(self, capsys):
+        with pytest.raises(MemoryError):
+            try:
+                raise MemoryError("boom")
+            except Exception:
+                reraise_if_resource_exhaustion("unit: probe")
+        err = capsys.readouterr().err
+        assert "[resource-exhaustion]" in err
+        assert "unit: probe" in err
+        assert "MemoryError" in err
+
+    def test_returns_silently_for_an_ordinary_exception(self, capsys):
+        fell_through = False
+        try:
+            raise ValueError("bad board data")
+        except Exception:
+            reraise_if_resource_exhaustion("unit: probe")
+            fell_through = True
+        assert fell_through
+        assert capsys.readouterr().err == ""
+
+    def test_is_a_no_op_outside_an_except_block(self):
+        """Never manufactures a ``No active exception to re-raise``."""
+        reraise_if_resource_exhaustion("unit: probe")
+
+
+class _Grid:
+    """Grid stub whose occupancy API raises a caller-chosen exception."""
+
+    resolution = 0.1
+
+    def __init__(self, exc: BaseException | None = None, indices=(0, 1)) -> None:
+        self._exc = exc
+        self._indices = list(indices)
+
+    def get_routable_indices(self):
+        return self._indices
+
+    def is_blocked_for_net(self, gx, gy, layer_idx, net):  # noqa: ARG002
+        if self._exc is not None:
+            raise self._exc
+        return False
+
+
+class _Rules:
+    trace_width = 0.2
+    trace_clearance = 0.2
+
+
+class TestSteinerBlockedCellPredicate:
+    """``_point_blocked``'s fallback decides where a branch point lands."""
+
+    def test_ordinary_failure_still_reports_the_cell_free(self):
+        predicate = make_blocked_cell_predicate(_Grid(TypeError("mock grid")), _Rules(), net=3)
+        assert predicate is not None
+        assert predicate(5, 5) is False
+
+    def test_memory_error_propagates_instead_of_reporting_free(self):
+        predicate = make_blocked_cell_predicate(_Grid(MemoryError("grid scan")), _Rules(), net=3)
+        assert predicate is not None
+        with pytest.raises(MemoryError):
+            predicate(5, 5)
+
+    def test_ordinary_routable_index_failure_still_disables_relocation(self):
+        class _NoIndices(_Grid):
+            def get_routable_indices(self):
+                raise AttributeError("fixture grid")
+
+        assert make_blocked_cell_predicate(_NoIndices(), _Rules(), net=3) is None
+
+    def test_memory_error_from_routable_index_probe_propagates(self):
+        class _OomIndices(_Grid):
+            def get_routable_indices(self):
+                raise MemoryError("layer table")
+
+        with pytest.raises(MemoryError):
+            make_blocked_cell_predicate(_OomIndices(), _Rules(), net=3)
+
+    def test_ordinary_margin_failure_keeps_the_one_cell_margin(self):
+        class _BadRules:
+            @property
+            def trace_width(self):
+                raise AttributeError("mock rules")
+
+        predicate = make_blocked_cell_predicate(_Grid(), _BadRules(), net=3)
+        assert predicate is not None
+        assert predicate(5, 5) is False
+
+    def test_memory_error_from_margin_math_propagates(self):
+        class _OomRules:
+            @property
+            def trace_width(self):
+                raise MemoryError("rules table")
+
+        with pytest.raises(MemoryError):
+            make_blocked_cell_predicate(_Grid(), _OomRules(), net=3)
+
+
+class _PitchPathfinder:
+    """Minimal stand-in exposing only what ``_get_component_pitches`` reads."""
+
+    from kicad_tools.router.cpp_backend import CppPathfinder as _Real
+
+    _get_component_pitches = _Real._get_component_pitches
+
+    def __init__(self, exc: BaseException) -> None:
+        self._component_pitches_cache = None
+
+        class _PyGrid:
+            def compute_component_pitches(self):
+                raise exc
+
+        class _Grid3D:
+            _py_grid = _PyGrid()
+
+        self._grid = _Grid3D()
+
+
+class TestComponentPitchCache:
+    """An empty pitch map is CACHED and drives neck-down + clearance."""
+
+    def test_ordinary_failure_still_degrades_to_an_empty_map(self):
+        assert _PitchPathfinder(ValueError("bad footprint"))._get_component_pitches() == {}
+
+    def test_memory_error_propagates_instead_of_caching_an_empty_map(self):
+        pathfinder = _PitchPathfinder(MemoryError("pitch table"))
+        with pytest.raises(MemoryError):
+            pathfinder._get_component_pitches()
+        # Nothing was cached, so a later call on a recovered host still works.
+        assert pathfinder._component_pitches_cache is None


### PR DESCRIPTION
## Summary

Closes #4724 — the residual, **load-correlated** divergence left over from #4536.

One board-06 regen taken on a host at load-average ~90 re-landed one fewer net inside stagnation recovery #1 (`restored 5 / rerouted 6`) than five same-code runs on a quiet host (`restored 4 / rerouted 7`), then diverged chaotically. Both artifacts were valid and passed every gate — nothing failed loudly; the run was simply not the run the same command produces on a quiet machine.

This PR closes the two **environment-sensitive decision points** the issue identified. It does **not** claim to have reproduced the load-90 divergence (the issue explicitly lists that as not required, and it is not reproducible on demand) — see "What this PR does NOT claim" below.

### Premise re-verification against current `main` (post-#4748)

The curated body predates the #4748 merge, so every claim was re-checked at `65ccd628`:

| Curated claim | Status on current main |
|---|---|
| Mechanism 2 confirmed: `sweep_budget = POST_NEGOTIATION_SWEEP_BUDGET_S` applied unconditionally under `timeout=None` | **Still true** (was `core.py:12316-12328` before this PR) |
| `POST_NEGOTIATION_SWEEP_BUDGET_S = 60.0` in `algorithms/negotiated.py:72` | **Still true** |
| "31 `except Exception` handlers in core.py" | **Still true** (31) |
| "mirror whatever shape #4748 lands (derived default vs. caller flag)" | #4730 was **withdrawn**; #4748 kept `DETERMINISTIC_RESCUE_DEFAULT = False` + a **per-call switch**. This PR mirrors the *selector* shape (`_relief_subsearch_budget`), **not** a new caller flag — see the design note below |

**Stale premise:** the curated Sequencing section recommends waiting for #4748 and mirroring a possible fleet-default flip. #4748 merged as `6d8e9bd8` with the flip **withdrawn**, so there is no new flag to mirror; the convention that actually landed is "a selector method that hands a sub-budget to the node-expansion cap **when one is active**, keeps a ~10x non-binding wall clock as a Python-fallback backstop, and logs which bound is live". That is exactly the shape used here.

### Design note: why no new flag

The sweep's deterministic arm is keyed on facts the router already knows — `timeout is None` **and** `per_net_timeout is None` **and** an active node-expansion cap — rather than on a new `deterministic_sweep=` kwarg. Reason: unlike #4730's rescue flip (which changed behaviour for *every* caller and measurably regressed board 07), this arm **self-scopes by construction**. Every caller that passes a `timeout`, every caller that passes a `per_net_timeout`, and every capless run keep the historical numbers *exactly*. The only callers that change are the ones that already declared "no wall clock decides anything here" — the `--deterministic-budget` / board-06 shape.

## Changes

### 1. Exception transparency (mechanism 1)

New `src/kicad_tools/router/resource_guard.py`:

- `is_resource_exhaustion(exc)` — `MemoryError`, `RecursionError`, `OSError(ENOMEM)`, and a native `bad_alloc` rethrown as a `RuntimeError` (nanobind translates `std::bad_alloc` to `MemoryError`, but a C++ layer that catches and rethrows does not).
- `reraise_if_resource_exhaustion(context)` — call as the first statement of a broad handler; reads the in-flight exception from `sys.exc_info()` (so bare `except Exception:` sites need no `as exc` binding), prints one greppable `[resource-exhaustion] <context>: <Type>: <msg>` line on stderr, and re-raises with the original traceback. Non-exhaustion exceptions return silently and the caller's fallback runs **byte-for-byte as before**.

**Audit — broad handlers reachable from `_route_net_negotiated`.** The name-based call graph over `src/kicad_tools/router/` over-approximates badly (it collapses `Router.route` / `Autorouter.route_all`, yielding 858 "reachable" functions), so the path was walked by hand from `_route_net_negotiated` → its nine core.py helpers → `NegotiatedRouter.route_net_negotiated` → Steiner + `self.router.route`.

Guarded (7):

| Site | Fallback it used to take on `MemoryError` |
|---|---|
| `algorithms/steiner.py` `make_blocked_cell_predicate` (routable-layer probe) | returns `None` → Steiner-point relocation silently disabled |
| `algorithms/steiner.py` `make_blocked_cell_predicate` (margin math) | margin collapses to 1 cell → different relocation |
| `algorithms/steiner.py` `_point_blocked` (occupancy scan) | reports the cell **free** → branch point lands elsewhere |
| `cpp_backend.py` `CppPathfinder._get_component_pitches` | **caches** `{}` for the rest of the run → changes neck-down widths and the fine-pitch clearance carve-out |
| `cpp_backend.py` `create_hybrid_router` | silently swaps to the 10-100x slower pure-Python search mid-run |
| `core.py` `_attempt_blocked_component_ripup` | rip-up rescue reported as "did not fire" → net stays failed |
| `core.py` `_attempt_blocked_component_ripup_negotiated` | same, on the negotiated path |

Inspected and **deliberately not** guarded (rationale in `resource_guard.py`'s module docstring):

- `grid.py:987` `_init_gpu_backend` / `grid.py:1169` `_sync_to_gpu` — already log the exception, and a GPU-memory failure falling back to the CPU backend is a legitimate degradation that does not change search decisions.
- `core.py` the two `checkpoint_callback` handlers in `route_all_negotiated` — a caller-supplied persistence hook; already log `{exc!r}`; cannot change routing.
- `core.py` `_analyze_failure_budgeted` — diagnostics only.
- `algorithms/negotiated.py` `route_net_negotiated` and `pathfinder.py` (pure-Python A*) have **no** broad handlers at all, so the per-net search itself was already transparent.

`create_hybrid_router` additionally now names the failing exception type in its fallback log instead of reporting `Reason: unknown reason` (a C++ construction failure was indistinguishable from "extension not importable").

### 2. Deterministic-mode sweep budget (mechanism 2)

`Autorouter._post_negotiation_sweep_bounds(timeout, per_net_timeout, elapsed, timed_out) -> (whole_sweep_s, per_net_s)` now owns the selection, mirroring `_relief_subsearch_budget`:

| Caller | Bound |
|---|---|
| Unbudgeted (`timeout=None`, `per_net_timeout=None`) **with** an active node-expansion cap | node-expansion cap; `600 s` / `120 s` kept as **non-binding** Python-fallback backstops |
| Unbudgeted, **no** cap | unchanged `60 s` / `10 s` (degrade to today's behaviour, never to an unbounded sweep) |
| Any caller with `timeout` or an explicit `per_net_timeout` | **unchanged**, including `min(60 s, remaining stage budget)` |

Why those two bounds were load-bearing: the sweep decides *which* stranded nets get their one solo attempt, and a per-net search that runs to its 1,000,000-expansion cap costs ~11 s on a CI runner — so the 10 s per-net bound **straddles** it exactly the way the relief rescue's 10 s sub-search budget did (#4536).

`_post_negotiation_sweep_bound_line` logs which bound is live (the `iteration-bounded` token is the greppable evidence string, matching #4536's discipline), printed only when the sweep actually engages.

The "is a node-expansion cap active?" question is extracted to `_active_expansion_cap()` and **shared** with `_relief_subsearch_budget` — a behaviour-preserving refactor (pinned by the existing `tests/test_relief_subsearch_budget.py` plus a new assertion that the relief selector still routes through the shared helper), so the rescue and the sweep cannot drift on what "deterministic mode" means.

### 3. Attributability

`tests/test_board06_determinism.py` prints `os.getloadavg()` before, between and after its two regens, and repeats the record in both failure messages, with a pointer that a saturated host is the known #4724 sensitivity rather than a #4536 regression. Degrades to a stated "unavailable on this platform" where `getloadavg` is absent.

## Acceptance Criteria Verification

- [x] **Exception-transparency (mechanism 1)** — `MemoryError` / native allocation failures on the negotiated reroute path re-raise with the type and net-path context named; the audited handler set is enumerated above.
- [x] **Deterministic-mode sweep budget (mechanism 2)** — under `timeout=None` / `per_net_timeout=None` with an active cap, the sweep makes no wall-clock-dependent routing decision; budgeted callers keep current behaviour (pinned by `TestBudgetedCallerIsUnchanged`).
- [x] **Attributability** — load-average printed at run start (and twice more) by the `KCT_BOARD06_DETERMINISM=1` smoke test.
- [x] **Generic router-library change only** — no board-specific special-casing; no board recipe touched (`boards/` is untouched by this diff).
- [x] **No DRC allowlist raised** — no allowlist, tolerance or reach floor is in the diff.
- [x] Board-06 route regen re-run locally: **21/21 signal nets**, `POUR CONNECTIVITY: PASS`, `POST-QUANTIZE CLEARANCE: PASS`, `POST-LEGALIZE GATE: PASS`, `No in-router DRC violations detected`.
- [x] **NOT required:** reproducing the load-90 divergence — not attempted (see below).

## Test Plan

- [x] `tests/test_router_resource_guard.py` (new, 22 tests) — classification table; the helper re-raises the original object, names it on stderr, and is a no-op both for ordinary exceptions and outside an `except` block; per-site: Steiner occupancy scan / routable-index probe / margin math and the cached component-pitch map each **propagate** `MemoryError` while keeping their historical fallback for `TypeError` / `AttributeError` / `ValueError`.
- [x] `tests/test_post_negotiation_sweep_budget.py` (new, 22 tests) — the full selection table, the "elapsed time cannot move the deterministic arm" invariant, the ~10x backstop sizing, all four bound-line arms, and end-to-end wiring through `route_all_negotiated` (starved-net fixture): the unbudgeted capped run logs `iteration-bounded` **and still rescues**, the budgeted run logs the wall-clock arm, and a run with nothing stranded prints no bound line at all.
- [x] `tests/router` + `tests/test_relief_subsearch_budget.py` + `tests/test_two_phase_stall_recovery.py`: **1232 passed, 5 skipped** (the 6 initial failures were the existing `_BudgetStub` not borrowing the newly-extracted `_active_expansion_cap`; the stub now borrows it and all pass).
- [x] `tests/test_steiner.py tests/test_router_cpp_*.py tests/test_lattice_*.py`: **188 passed, 6 skipped** — including `test_router_cpp_fallback_warning_3456.py`, which the `create_hybrid_router` log change could have broken.
- [x] `uv run ruff check .` — All checks passed. `uv run ruff format . --check` — 1782 files already formatted.
- [x] `uv run python scripts/ci/check_mypy_baseline.py` — `OK: mypy reports 1471 error(s), all within the baseline (1473 allowed)`.
- [x] `uv run kct build-native --check` — C++ backend available before any routing measurement.
- [x] **Board-06 route regen** (`--step route --seed 42`, into a scratch dir, C++ backend, this branch): exit 0, 21/21, gates PASS, and — the load-relevant line — stagnation recovery #1 reported **`restored 4 / rerouted 7`**, i.e. the *canonical* arm the five quiet-host runs took, not the load-90 divergent `restored 5 / rerouted 6`.

### Note on the mypy baseline warning

The gate also emits `::warning:: 2 baseline error(s) no longer occur`. Both are pre-existing and unrelated to this diff: `build_native_cmd.py import-not-found nanobind` (the known env-dependent trap — it resolves only in a worktree where the native extension is built, so removing it would break CI) and a `net_status_cmd.py misc` entry. The baseline is deliberately left untouched.

## What this PR does NOT claim

- **The load-90 divergence is not reproduced, and no fix for it is claimed.** The issue's own acceptance criteria list reproduction as not required. What is claimed is narrower and checkable: two identified environment-sensitive decision points on that path no longer exist (one wall clock removed from deterministic mode; one class of host failure no longer convertible into a routing decision).
- **No claim of a board-06 determinism fix from a single run.** The single regen above is *consistency* evidence, not a determinism proof. The stronger statement available here is structural rather than statistical: in that run the sweep block never executed (no `Post-negotiation sweep bound` line in the log) and no exhaustion occurred, so **both** changed code paths were inert and the routed trajectory is unchanged by construction — which is also why no `main`-baseline copper-count comparison was run. (Board-06's copper counts have legitimately moved since the #4536-era `1544/181` figure quoted in the issue, as several router PRs have merged; this run produced `1558/181`.)
- **No coupled-pair improvement is claimed.** Verified by name at pair level: all nine pairs (`MIPI_CLK`, `MIPI_D0`, `PCIE_RX`, `PCIE_TX`, `USB2_D`, `USB3_RX1`, `USB3_RX2`, `USB3_TX1`, `USB3_TX2`) report `coupled=False class=joint-A*-plateau`, the known board-06 baseline. This PR does not touch the coupled path.

## Scope / collision notes

- `core.py`'s budget region is shared with the open investigation #4770 (board-07's deterministic-bound rescue outcome). This diff stays out of the rescue's *policy*: `DETERMINISTIC_RESCUE_DEFAULT`, `RELIEF_SUBSEARCH_BUDGET_S`, `RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S` and the per-call `deterministic_rescue` threading from #4748 are all untouched. The only edit inside `_relief_subsearch_budget` is replacing an inline `min()` with the extracted `_active_expansion_cap()` call — same values, same arms.
- Two unrelated observations left as notes rather than fixed here: `_analyze_failure_budgeted` carries its own `_FAILURE_ANALYSIS_BUDGET_S` wall clock (affects diagnostics content only, not routing decisions), and `[Unreleased]` in `CHANGELOG.md` still has two `### Fixed` subsections (#4771) — this entry went into the first/newer one as instructed.
