### PR TITLE
feat(cli): add --format json to the datasheet/lib/parts/pcb prose-only holdouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,6 +237,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`--format json` on the 10 prose-only holdouts inside the `datasheet`,
+  `lib`, `parts` and `pcb` families** (part of #4674, third batch of the
+  #4543 machine-output sweep) — `datasheet cache`, `datasheet convert`,
+  `datasheet download`, `lib create-symbol-lib`, `lib create-footprint-lib`,
+  `lib generate-footprint`, `parts cache`, `parts sync-catalog`,
+  `pcb export-dsn` and `pcb import-ses` now accept the canonical
+  `--format json` and emit one deterministic document on stdout instead of
+  prose, wired end-to-end (outer parser → shim → inner parser/handler).
+  Each document is keyed by `command` plus that command's own summary:
+  `action`/`cleared` for the two cache commands, `path`/`file_size_bytes`/
+  `source` for `download`, `layers`/`nets`/`components` for `export-dsn`,
+  `wires`/`vias` for `import-ses`. The three `lib` commands are
+  unimplemented placeholders, so under JSON the non-implementation *is* the
+  payload (`{"implemented": false, "error": ..., "tracking_issue": ...}`)
+  and the exit code stays 2 — a caller can now distinguish "not
+  implemented" from a crash without scraping stderr. `datasheet convert`
+  carries its markdown under a `markdown` key when no `-o` sink was given.
+  `parts sync-catalog` suppresses its download progress chatter in JSON
+  mode so stdout stays a single document, and the inner `parts cache`
+  action subparsers default `--format` to `argparse.SUPPRESS` so the flag
+  works on either side of the action word. `commands/pcb.py`'s shared "file
+  not found" guard runs before every handler, so it now emits the same
+  `{"error": ...}` document — closing that hole for the ~20 `pcb` leaves
+  that already had `--format json`. Text-mode output and exit codes are
+  unchanged throughout. Audit (`scripts/audit_machine_output.py`):
+  prose-only 33 → 23, format-json 164 → 174.
 - **`kct drc --waivers`: the `.kct_waivers.json` schema now covers the
   kicad-cli DRC cross-gate** (closes #4691) — the mandatory second-opinion
   gate can finally state "0 unwaived errors" instead of a count comparison

--- a/docs/reference/machine-output.md
+++ b/docs/reference/machine-output.md
@@ -52,22 +52,26 @@ below is issue **#4674** and should build on these helpers.
 Measured by programmatic introspection of the real argparse tree
 (`create_parser()`, recursive walk of `_SubParsersAction` leaves) — not grep:
 
-| Idiom (outer `kct` parser) | Before #4543 | After #4543 | After #4674 b1 | After #4674 b2 |
-|---|---|---|---|---|
-| `--format` with a `json` choice | 124 | 124 | 148 | 164 |
-| Both `--format json` and legacy `--json` alias | 0 | 2 (`placement refine`, `calibrate`) | 2 | 2 |
-| `--json` boolean only | 2 | **0** | 0 | 0 |
-| `--format` without a `json` choice | 1 (`benchmark report`, `text,markdown`) | 1 | **0** | 0 |
-| Neither (prose-only) | 72 | 72 (backlog for #4674, below) | 49 | 33 |
+| Idiom (outer `kct` parser) | Before #4543 | After #4543 | After #4674 b1 | b2 | b3 |
+|---|---|---|---|---|---|
+| `--format` with a `json` choice | 124 | 124 | 148 | 164 | 174 |
+| Both `--format json` and legacy `--json` alias | 0 | 2 (`placement refine`, `calibrate`) | 2 | 2 | 2 |
+| `--json` boolean only | 2 | **0** | 0 | 0 | 0 |
+| `--format` without a `json` choice | 1 (`benchmark report`, `text,markdown`) | 1 | **0** | 0 | 0 |
+| Neither (prose-only) | 72 | 72 (backlog for #4674, below) | 49 | 33 | 23 |
 
 The first #4674 batch swept the grouped-subcommand families -- `mfr` (7),
 `spec` (5), `placement fix/nudge/snap/align/distribute` (5), `zones
 add/batch/fill/hv-keepout` (4), `benchmark run/compare` (2) -- and added the
 `json` choice to `benchmark report`, closing the `format-nojson` bucket.
 
-The second batch swept the 16 mutating `sch` leaves. The remaining 33
-prose-only leaves (`stitch` and the long tail of single commands, plus the 4
-exempt and the deferred `route`) stay on the #4674 backlog below.
+The second batch swept the 16 mutating `sch` leaves.
+
+The third batch finished the four families that already spoke JSON on most
+of their leaves but still had prose-only holdouts -- `datasheet` (3), `lib`
+(3), `parts` (2), `pcb` (2). The remaining 23 prose-only leaves (`stitch`
+and the long tail of single commands, plus the 4 exempt and the deferred
+`route`) stay on the #4674 backlog below.
 
 Issue #4543 closed the `--json`-only bucket by adding `--format {text,json}`
 alongside the existing `--json` on both commands (outer parser, forwarding
@@ -168,19 +172,46 @@ itself. `tests/test_format_json_sweep_sch.py` guards these 16 surfaces
 (outer flag, both shim shapes, emission, determinism, error documents, and
 that `--dry-run` still writes nothing).
 
-**Remaining actionable (28)** — the audit's `prose-only` bucket reads 33
+**Done (third #4674 batch, 10 surfaces):** the prose-only holdouts inside
+four families whose other leaves already spoke JSON --
+`datasheet cache/convert/download`, `lib create-symbol-lib/`
+`create-footprint-lib/generate-footprint`, `parts cache/sync-catalog`,
+`pcb export-dsn/import-ses`. Each emits one document keyed by `command`
+plus that command's own summary (`cleared` / `action` for the two cache
+commands, `layers`/`nets`/`components` for `export-dsn`,
+`wires`/`vias` for `import-ses`, `path`/`file_size_bytes`/`source` for
+`download`). Three details worth reusing:
+
+- The three `lib` commands are **unimplemented placeholders** that exit 2.
+  Under JSON the non-implementation *is* the payload
+  (`{"implemented": false, "error": ..., "tracking_issue": ...}`) so a
+  caller can tell "not implemented" from a crash without scraping stderr;
+  the exit code is unchanged.
+- `datasheet convert` writes markdown to stdout when no `-o` is given, so
+  in JSON mode it carries the conversion under a `markdown` key; with
+  `-o` it reports `output` and omits `markdown`.
+- `parts cache` is the one swept surface whose *inner* parser has its own
+  subparsers. Its per-action subparsers declare `--format` with
+  `argparse.SUPPRESS` as the default, so an unspecified flag on the
+  action cannot clobber the value parsed by the `cache` parser
+  (`kct parts cache --format json stats` and
+  `kct parts cache stats --format json` both resolve to json).
+
+`commands/pcb.py`'s shared "file not found" guard runs before every `pcb`
+handler, so — like the `sch` shim in batch 2 — it now emits the same
+`{"error": ...}` document; that closes the hole for the ~20 `pcb` leaves
+that already had `--format json`. `tests/test_format_json_sweep_families.py`
+guards these 10 surfaces.
+
+**Remaining actionable (18)** — the audit's `prose-only` bucket reads 23
 because it also counts the 4 exempt commands and the deferred `route`
 (sections above):
 
 - `board-metrics`, `build`, `config`, `create-pcb`, `creepage-export-rules`
-- `datasheet cache`, `datasheet convert`, `datasheet download`
 - `ipc connect`, `ipc push-routes`, `ipc status`
-- `lib create-footprint-lib`, `lib create-symbol-lib`, `lib generate-footprint`
 - `mcp setup`
 - `optimize-placement`, `optimize-traces`
 - `panel`
-- `parts cache`, `parts sync-catalog`
-- `pcb export-dsn`, `pcb import-ses`
 - `pipeline`
 - `reason`, `report generate`, `route-auto`
 - `screenshot`

--- a/src/kicad_tools/cli/commands/datasheet.py
+++ b/src/kicad_tools/cli/commands/datasheet.py
@@ -28,6 +28,8 @@ def run_datasheet_command(args) -> int:
             sub_argv.extend(["-o", args.output])
         if args.force:
             sub_argv.append("--force")
+        if getattr(args, "format", "text") != "text":
+            sub_argv.extend(["--format", args.format])
         return datasheet_main(sub_argv) or 0
 
     elif args.datasheet_command == "list":
@@ -40,6 +42,8 @@ def run_datasheet_command(args) -> int:
         sub_argv = ["cache", args.cache_action]
         if getattr(args, "older_than", None):
             sub_argv.extend(["--older-than", str(args.older_than)])
+        if getattr(args, "format", "text") != "text":
+            sub_argv.extend(["--format", args.format])
         return datasheet_main(sub_argv) or 0
 
     elif args.datasheet_command == "convert":
@@ -48,6 +52,8 @@ def run_datasheet_command(args) -> int:
             sub_argv.extend(["-o", args.output])
         if args.pages:
             sub_argv.extend(["--pages", args.pages])
+        if getattr(args, "format", "text") != "text":
+            sub_argv.extend(["--format", args.format])
         return datasheet_main(sub_argv) or 0
 
     elif args.datasheet_command == "extract-images":

--- a/src/kicad_tools/cli/commands/library.py
+++ b/src/kicad_tools/cli/commands/library.py
@@ -83,15 +83,16 @@ def run_lib_command(args) -> int:
         )
 
     elif args.lib_command == "create-symbol-lib":
-        return create_symbol_library(args.path)
+        return create_symbol_library(args.path, getattr(args, "format", "text"))
 
     elif args.lib_command == "create-footprint-lib":
-        return create_footprint_library(args.path)
+        return create_footprint_library(args.path, getattr(args, "format", "text"))
 
     elif args.lib_command == "generate-footprint":
         return generate_footprint(
             args.library,
             args.type,
+            getattr(args, "format", "text"),
             pins=getattr(args, "pins", None),
             pitch=getattr(args, "pitch", None),
             body_width=getattr(args, "body_width", None),

--- a/src/kicad_tools/cli/commands/parts.py
+++ b/src/kicad_tools/cli/commands/parts.py
@@ -52,6 +52,8 @@ def run_parts_command(args) -> int:
 
     elif args.parts_command == "cache":
         sub_argv = ["cache", args.cache_action]
+        if getattr(args, "format", "text") != "text":
+            sub_argv.extend(["--format", args.format])
         return parts_main(sub_argv) or 0
 
     elif args.parts_command == "sync-catalog":
@@ -60,6 +62,8 @@ def run_parts_command(args) -> int:
             sub_argv.append("--force")
         if args.base_url:
             sub_argv.extend(["--base-url", args.base_url])
+        if getattr(args, "format", "text") != "text":
+            sub_argv.extend(["--format", args.format])
         return parts_main(sub_argv) or 0
 
     elif args.parts_command == "suggest":

--- a/src/kicad_tools/cli/commands/pcb.py
+++ b/src/kicad_tools/cli/commands/pcb.py
@@ -19,7 +19,17 @@ def run_pcb_command(args) -> int:
 
     pcb_path = Path(args.pcb)
     if not pcb_path.exists():
-        print(f"Error: File not found: {pcb_path}", file=sys.stderr)
+        message = f"Error: File not found: {pcb_path}"
+        # This guard runs before any per-command handler, so it has to
+        # honour --format json itself (#4674) -- otherwise the one error
+        # every pcb leaf can hit is the one error that never produces a
+        # document.
+        if getattr(args, "format", None) == "json":
+            from ..format_options import emit_json
+
+            emit_json({"command": args.pcb_command, "error": message, "success": False})
+        else:
+            print(message, file=sys.stderr)
         return 1
 
     # Handle zones command
@@ -1655,6 +1665,10 @@ def _run_export_dsn_command(args, pcb_path: Path) -> int:
     """Handle the 'pcb export-dsn' command."""
     from kicad_tools.export.dsn import KiCadToDSNExporter
 
+    from ..format_options import emit_json
+
+    as_json = getattr(args, "format", "text") == "json"
+
     output = getattr(args, "output", None)
     if output is None:
         output = pcb_path.with_suffix(".dsn")
@@ -1665,8 +1679,34 @@ def _run_export_dsn_command(args, pcb_path: Path) -> int:
         exporter = KiCadToDSNExporter(str(pcb_path))
         exporter.export(str(output))
     except Exception as e:
-        print(f"Error exporting DSN: {e}", file=sys.stderr)
+        message = f"Error exporting DSN: {e}"
+        if as_json:
+            emit_json(
+                {
+                    "command": "export-dsn",
+                    "pcb": str(pcb_path),
+                    "output": str(output),
+                    "error": message,
+                    "success": False,
+                }
+            )
+            return 1
+        print(message, file=sys.stderr)
         return 1
+
+    if as_json:
+        emit_json(
+            {
+                "command": "export-dsn",
+                "pcb": str(pcb_path),
+                "output": str(output),
+                "layers": len(exporter.layers),
+                "nets": len(exporter.nets),
+                "components": len(exporter.footprints),
+                "success": True,
+            }
+        )
+        return 0
 
     print(f"Exported DSN to {output}")
     print(f"  Layers: {len(exporter.layers)}")
@@ -1679,24 +1719,56 @@ def _run_import_ses_command(args, pcb_path: Path) -> int:
     """Handle the 'pcb import-ses' command."""
     from kicad_tools.export.ses import SESToKiCadImporter
 
+    from ..format_options import emit_json
+
+    as_json = getattr(args, "format", "text") == "json"
     ses_path = Path(args.ses)
-    if not ses_path.exists():
-        print(f"Error: SES file not found: {ses_path}", file=sys.stderr)
-        return 1
 
     output = getattr(args, "output", None)
     if output is not None:
         output = Path(output)
+    dest = output or pcb_path
+
+    def fail(message: str) -> int:
+        if as_json:
+            emit_json(
+                {
+                    "command": "import-ses",
+                    "pcb": str(pcb_path),
+                    "ses": str(ses_path),
+                    "output": str(dest),
+                    "error": message,
+                    "success": False,
+                }
+            )
+        else:
+            print(message, file=sys.stderr)
+        return 1
+
+    if not ses_path.exists():
+        return fail(f"Error: SES file not found: {ses_path}")
 
     try:
         importer = SESToKiCadImporter(str(ses_path))
         importer.parse()
         importer.merge_into(str(pcb_path), str(output) if output else None)
     except Exception as e:
-        print(f"Error importing SES: {e}", file=sys.stderr)
-        return 1
+        return fail(f"Error importing SES: {e}")
 
-    dest = output or pcb_path
+    if as_json:
+        emit_json(
+            {
+                "command": "import-ses",
+                "pcb": str(pcb_path),
+                "ses": str(ses_path),
+                "output": str(dest),
+                "wires": len(importer.wires),
+                "vias": len(importer.vias),
+                "success": True,
+            }
+        )
+        return 0
+
     print(f"Imported SES routes into {dest}")
     print(f"  Wires: {len(importer.wires)}")
     print(f"  Vias: {len(importer.vias)}")

--- a/src/kicad_tools/cli/datasheet_cmd.py
+++ b/src/kicad_tools/cli/datasheet_cmd.py
@@ -23,6 +23,7 @@ import json
 import sys
 from pathlib import Path
 
+from kicad_tools.cli.format_options import add_format_flag, emit_json
 from kicad_tools.utils import ensure_parent_dir
 
 
@@ -64,6 +65,7 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Force download even if cached",
     )
+    add_format_flag(download_parser)
 
     # list subcommand
     list_parser = subparsers.add_parser("list", help="List cached datasheets")
@@ -88,6 +90,7 @@ def main(argv: list[str] | None = None) -> int:
         type=int,
         help="For clear: only clear entries older than N days",
     )
+    add_format_flag(cache_parser)
 
     # convert subcommand (PDF parsing)
     convert_parser = subparsers.add_parser("convert", help="Convert PDF to markdown")
@@ -97,6 +100,7 @@ def main(argv: list[str] | None = None) -> int:
         "--pages",
         help="Page range to convert (e.g., '1-10' or '1,2,5')",
     )
+    add_format_flag(convert_parser)
 
     # extract-images subcommand
     images_parser = subparsers.add_parser("extract-images", help="Extract images from PDF")
@@ -408,6 +412,7 @@ def _run_download(args) -> int:
     """Run datasheet download command."""
     from kicad_tools.datasheet.manager import DatasheetManager
 
+    as_json = getattr(args, "format", "text") == "json"
     manager = DatasheetManager()
 
     output_dir = Path(args.output) if args.output else None
@@ -418,6 +423,20 @@ def _run_download(args) -> int:
             output_dir=output_dir,
             force=args.force,
         )
+
+        if as_json:
+            emit_json(
+                {
+                    "command": "download",
+                    "part": args.part,
+                    "path": str(datasheet.local_path),
+                    "file_size_bytes": datasheet.file_size,
+                    "file_size_mb": round(datasheet.file_size_mb, 2),
+                    "source": datasheet.source,
+                    "success": True,
+                }
+            )
+            return 0
 
         print(f"Downloaded datasheet for {args.part}")
         print(f"  Path: {datasheet.local_path}")
@@ -431,6 +450,17 @@ def _run_download(args) -> int:
         # Surface install guidance instead of a misleading "no datasheet found",
         # mirroring how main()/_info()/_extract_package() already report missing
         # dependencies (issue #4139).
+        if as_json:
+            emit_json(
+                {
+                    "command": "download",
+                    "part": args.part,
+                    "error": str(e),
+                    "hint": "Install with: pip install kicad-tools[parts]",
+                    "success": False,
+                }
+            )
+            return 1
         print(f"Error: {e}", file=sys.stderr)
         print(
             "Install with: pip install kicad-tools[parts]",
@@ -438,6 +468,16 @@ def _run_download(args) -> int:
         )
         return 1
     except Exception as e:
+        if as_json:
+            emit_json(
+                {
+                    "command": "download",
+                    "part": args.part,
+                    "error": f"Failed to download datasheet: {e}",
+                    "success": False,
+                }
+            )
+            return 1
         print(f"Failed to download datasheet: {e}", file=sys.stderr)
         return 1
 
@@ -487,7 +527,11 @@ def _run_cache(args) -> int:
     """Run cache management command."""
     from kicad_tools.datasheet.manager import DatasheetManager
 
+    as_json = getattr(args, "format", "text") == "json"
     manager = DatasheetManager()
+
+    if as_json:
+        return _run_cache_json(manager, args)
 
     if args.action == "stats":
         stats = manager.cache_stats()
@@ -521,35 +565,108 @@ def _run_cache(args) -> int:
     return 0
 
 
+def _run_cache_json(manager, args) -> int:
+    """Emit the ``datasheet cache`` change/report summary as one document."""
+    payload: dict = {"command": "cache", "action": args.action, "success": True}
+
+    if args.action == "stats":
+        stats = manager.cache_stats()
+        payload.update(
+            {
+                "cache_dir": str(stats["cache_dir"]),
+                "total_count": stats["total_count"],
+                "valid_count": stats["valid_count"],
+                "expired_count": stats["expired_count"],
+                "total_size_mb": round(stats["total_size_mb"], 2),
+                "ttl_days": stats["ttl_days"],
+                "sources": dict(sorted(stats["sources"].items())),
+            }
+        )
+    elif args.action == "clear":
+        older_than = args.older_than
+        payload["older_than_days"] = older_than
+        payload["cleared"] = (
+            manager.clear_cache(older_than_days=older_than) if older_than else manager.clear_cache()
+        )
+    elif args.action == "clear-expired":
+        payload["cleared"] = manager.cache.clear_expired()
+
+    emit_json(payload)
+    return 0
+
+
 def _convert(args) -> int:
     """Handle convert command."""
+    as_json = getattr(args, "format", "text") == "json"
+
+    def fail(message: str) -> int:
+        if as_json:
+            emit_json(
+                {
+                    "command": "convert",
+                    "pdf": str(args.pdf),
+                    "error": message,
+                    "success": False,
+                }
+            )
+        else:
+            print(f"Error: {message}", file=sys.stderr)
+        return 1
+
     try:
         from ..datasheet.parser import DatasheetParser
     except ImportError as e:
+        if as_json:
+            emit_json(
+                {
+                    "command": "convert",
+                    "pdf": str(args.pdf),
+                    "error": str(e),
+                    "hint": "Install with: pip install kicad-tools[datasheet]",
+                    "success": False,
+                }
+            )
+            return 1
         print(f"Error: {e}", file=sys.stderr)
         print("Install with: pip install kicad-tools[datasheet]", file=sys.stderr)
         return 1
 
     pdf_path = Path(args.pdf)
     if not pdf_path.exists():
-        print(f"Error: File not found: {pdf_path}", file=sys.stderr)
-        return 1
+        return fail(f"File not found: {pdf_path}")
 
     try:
         parser = DatasheetParser(pdf_path)
         pages = _parse_pages(args.pages)
         markdown = parser.to_markdown(pages)
 
-        if args.output:
-            output_path = Path(args.output)
+        output_path = Path(args.output) if args.output else None
+        if output_path is not None:
             ensure_parent_dir(output_path).write_text(markdown)
+
+        if as_json:
+            payload = {
+                "command": "convert",
+                "pdf": str(pdf_path),
+                "output": str(output_path) if output_path else None,
+                "pages": args.pages,
+                "success": True,
+            }
+            if output_path is None:
+                # No sink to write to, so the conversion result *is* the
+                # payload -- otherwise the document would report success
+                # while discarding the only thing the command produced.
+                payload["markdown"] = markdown
+            emit_json(payload)
+            return 0
+
+        if output_path is not None:
             print(f"Converted to: {output_path}")
         else:
             print(markdown)
 
     except Exception as e:
-        print(f"Error: {e}", file=sys.stderr)
-        return 1
+        return fail(str(e))
 
     return 0
 

--- a/src/kicad_tools/cli/lib.py
+++ b/src/kicad_tools/cli/lib.py
@@ -21,6 +21,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from kicad_tools.cli.format_options import add_format_flag, emit_json
 from kicad_tools.footprints.library_path import (
     detect_kicad_library_path,
 )
@@ -272,41 +273,76 @@ def _find_footprint(library: str, footprint_name: str) -> Path | None:
     return None
 
 
-def create_symbol_library(path: str) -> int:
+#: Exit code the three placeholder ``lib`` commands return ("not implemented").
+_NOT_IMPLEMENTED_EXIT = 2
+
+
+def _report_not_implemented(
+    command: str,
+    tracking_issue: int,
+    output_format: str,
+    **fields: Any,
+) -> int:
+    """Report an unimplemented ``lib`` command in the requested format.
+
+    The three placeholder commands have no work to do, so their whole
+    contract is *"not implemented, tracked by issue N"*.  Under
+    ``--format json`` (#4674) that has to be a document rather than prose,
+    otherwise a caller cannot distinguish "unimplemented" from a crash
+    without scraping stderr.  The exit code is unchanged in both modes.
+    """
+    url = f"https://github.com/rjwalters/kicad-tools/issues/{tracking_issue}"
+    if output_format == "json":
+        payload: dict[str, Any] = {
+            "command": command,
+            "implemented": False,
+            "error": f"{command} is not yet implemented",
+            "tracking_issue": url,
+            "success": False,
+        }
+        payload.update(fields)
+        emit_json(payload)
+        return _NOT_IMPLEMENTED_EXIT
+
+    print(f"Error: {command} is not yet implemented.", file=sys.stderr)
+    print(f"This feature requires: {url}")
+    return _NOT_IMPLEMENTED_EXIT
+
+
+def create_symbol_library(path: str, output_format: str = "text") -> int:
     """Create a new empty symbol library.
 
     Note: This feature requires issue #85 (Add symbol library creation and save support).
 
     Args:
         path: Path for the new .kicad_sym file
+        output_format: ``"text"`` (prose) or ``"json"`` (single document)
 
     Returns:
-        Exit code (0 for success)
+        Exit code (2 for "not implemented")
     """
-    print("Error: create-symbol-lib is not yet implemented.", file=sys.stderr)
-    print("This feature requires: https://github.com/rjwalters/kicad-tools/issues/85")
-    return 2  # Exit code 2 for "not implemented"
+    return _report_not_implemented("create-symbol-lib", 85, output_format, path=path)
 
 
-def create_footprint_library(path: str) -> int:
+def create_footprint_library(path: str, output_format: str = "text") -> int:
     """Create a new empty footprint library.
 
     Note: This feature requires issue #87 (Add FootprintLibrary class).
 
     Args:
         path: Path for the new .pretty directory
+        output_format: ``"text"`` (prose) or ``"json"`` (single document)
 
     Returns:
-        Exit code (0 for success)
+        Exit code (2 for "not implemented")
     """
-    print("Error: create-footprint-lib is not yet implemented.", file=sys.stderr)
-    print("This feature requires: https://github.com/rjwalters/kicad-tools/issues/87")
-    return 2
+    return _report_not_implemented("create-footprint-lib", 87, output_format, path=path)
 
 
 def generate_footprint(
     library: str,
     footprint_type: str,
+    output_format: str = "text",
     **kwargs,
 ) -> int:
     """Generate a parametric footprint.
@@ -316,14 +352,20 @@ def generate_footprint(
     Args:
         library: Target library path
         footprint_type: Footprint type (soic, qfp, chip, etc.)
+        output_format: ``"text"`` (prose) or ``"json"`` (single document)
         **kwargs: Type-specific options (pins, pitch, body-width, etc.)
 
     Returns:
-        Exit code (0 for success)
+        Exit code (2 for "not implemented")
     """
-    print("Error: generate-footprint is not yet implemented.", file=sys.stderr)
-    print("This feature requires: https://github.com/rjwalters/kicad-tools/issues/88")
-    return 2
+    return _report_not_implemented(
+        "generate-footprint",
+        88,
+        output_format,
+        library=library,
+        type=footprint_type,
+        parameters={key: value for key, value in sorted(kwargs.items()) if value is not None},
+    )
 
 
 def export_library(
@@ -494,6 +536,7 @@ def main(argv: list[str] | None = None) -> int:
         help="Create new symbol library (not yet implemented)",
     )
     create_sym_parser.add_argument("path", help="Path for new .kicad_sym file")
+    add_format_flag(create_sym_parser)
 
     # lib create-footprint-lib (placeholder)
     create_fp_parser = subparsers.add_parser(
@@ -501,6 +544,7 @@ def main(argv: list[str] | None = None) -> int:
         help="Create new footprint library (not yet implemented)",
     )
     create_fp_parser.add_argument("path", help="Path for new .pretty directory")
+    add_format_flag(create_fp_parser)
 
     # lib generate-footprint (placeholder)
     generate_parser = subparsers.add_parser(
@@ -518,6 +562,7 @@ def main(argv: list[str] | None = None) -> int:
     generate_parser.add_argument("--body-width", type=float, help="Body width in mm")
     generate_parser.add_argument("--body-size", type=float, help="Body size (square) in mm")
     generate_parser.add_argument("--prefix", help="Footprint name prefix")
+    add_format_flag(generate_parser)
 
     # lib export
     export_parser = subparsers.add_parser("export", help="Export library to JSON")
@@ -584,15 +629,16 @@ def main(argv: list[str] | None = None) -> int:
         )
 
     elif args.lib_command == "create-symbol-lib":
-        return create_symbol_library(args.path)
+        return create_symbol_library(args.path, args.format)
 
     elif args.lib_command == "create-footprint-lib":
-        return create_footprint_library(args.path)
+        return create_footprint_library(args.path, args.format)
 
     elif args.lib_command == "generate-footprint":
         return generate_footprint(
             args.library,
             args.type,
+            args.format,
             pins=args.pins,
             pitch=args.pitch,
             body_width=args.body_width,

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -2874,6 +2874,7 @@ def _add_pcb_parser(subparsers) -> None:
         dest="output",
         help="Output DSN file path (default: <pcb-stem>.dsn next to input)",
     )
+    add_format_flag(pcb_export_dsn)
 
     # pcb import-ses
     pcb_import_ses = pcb_subparsers.add_parser(
@@ -2890,6 +2891,7 @@ def _add_pcb_parser(subparsers) -> None:
         dest="output",
         help="Output PCB file path (default: overwrite input PCB)",
     )
+    add_format_flag(pcb_import_ses)
 
 
 def _add_lib_parser(subparsers) -> None:
@@ -2945,12 +2947,14 @@ def _add_lib_parser(subparsers) -> None:
         "create-symbol-lib", help="Create new symbol library (not yet implemented)"
     )
     lib_create_sym.add_argument("path", help="Path for new .kicad_sym file")
+    add_format_flag(lib_create_sym)
 
     # lib create-footprint-lib
     lib_create_fp = lib_subparsers.add_parser(
         "create-footprint-lib", help="Create new footprint library (not yet implemented)"
     )
     lib_create_fp.add_argument("path", help="Path for new .pretty directory")
+    add_format_flag(lib_create_fp)
 
     # lib generate-footprint
     lib_generate = lib_subparsers.add_parser(
@@ -2965,6 +2969,7 @@ def _add_lib_parser(subparsers) -> None:
     lib_generate.add_argument("--body-width", type=float, help="Body width in mm")
     lib_generate.add_argument("--body-size", type=float, help="Body size (square) in mm")
     lib_generate.add_argument("--prefix", help="Footprint name prefix")
+    add_format_flag(lib_generate)
 
     # lib export
     lib_export = lib_subparsers.add_parser("export", help="Export library to JSON")
@@ -5271,6 +5276,7 @@ def _add_parts_parser(subparsers) -> None:
         default="stats",
         help="Cache action (default: stats)",
     )
+    add_format_flag(parts_cache)
 
     # parts sync-catalog
     parts_sync = parts_subparsers.add_parser(
@@ -5283,6 +5289,7 @@ def _add_parts_parser(subparsers) -> None:
     parts_sync.add_argument(
         "--base-url", default=None, help="Override dataset base URL (advanced/testing)"
     )
+    add_format_flag(parts_sync)
 
     # parts suggest
     parts_suggest = parts_subparsers.add_parser(
@@ -5339,6 +5346,7 @@ def _add_datasheet_parser(subparsers) -> None:
     datasheet_download.add_argument(
         "--force", action="store_true", help="Force download even if cached"
     )
+    add_format_flag(datasheet_download)
 
     # datasheet list
     datasheet_list = datasheet_subparsers.add_parser("list", help="List cached datasheets")
@@ -5356,12 +5364,14 @@ def _add_datasheet_parser(subparsers) -> None:
     datasheet_cache.add_argument(
         "--older-than", type=int, help="For clear: only clear entries older than N days"
     )
+    add_format_flag(datasheet_cache)
 
     # datasheet convert
     ds_convert = datasheet_subparsers.add_parser("convert", help="Convert PDF to markdown")
     ds_convert.add_argument("pdf", help="Path to PDF file")
     ds_convert.add_argument("-o", "--output", help="Output file path (default: stdout)")
     ds_convert.add_argument("--pages", help="Page range (e.g., '1-10' or '1,2,5')")
+    add_format_flag(ds_convert)
 
     # datasheet extract-images
     ds_images = datasheet_subparsers.add_parser("extract-images", help="Extract images from PDF")

--- a/src/kicad_tools/cli/parts_cmd.py
+++ b/src/kicad_tools/cli/parts_cmd.py
@@ -19,6 +19,8 @@ import json
 import sys
 from pathlib import Path
 
+from kicad_tools.cli.format_options import add_format_flag, emit_json
+
 
 def main(argv: list[str] | None = None) -> int:
     """Parts command entry point."""
@@ -146,14 +148,27 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="Override dataset base URL (advanced/testing)",
     )
+    add_format_flag(sync_parser)
 
     # cache subcommand
     cache_parser = subparsers.add_parser("cache", help="Cache management")
+    add_format_flag(cache_parser)
     cache_subparsers = cache_parser.add_subparsers(dest="cache_action", help="Cache commands")
 
-    cache_subparsers.add_parser("stats", help="Show cache statistics")
-    cache_subparsers.add_parser("clear", help="Clear all cached parts")
-    cache_subparsers.add_parser("clear-expired", help="Clear expired entries only")
+    for _action in ("stats", "clear", "clear-expired"):
+        _action_parser = cache_subparsers.add_parser(
+            _action,
+            help={
+                "stats": "Show cache statistics",
+                "clear": "Clear all cached parts",
+                "clear-expired": "Clear expired entries only",
+            }[_action],
+        )
+        # SUPPRESS (not the usual "text" default) so an unspecified
+        # --format on the action subparser does not clobber the value
+        # parsed by ``cache_parser``: both ``parts cache --format json
+        # stats`` and ``parts cache stats --format json`` must work.
+        add_format_flag(_action_parser, default=argparse.SUPPRESS)
 
     args = parser.parse_args(argv)
 
@@ -181,23 +196,50 @@ def main(argv: list[str] | None = None) -> int:
 
 def _sync_catalog(args) -> int:
     """Handle the sync-catalog command."""
+    as_json = getattr(args, "format", "text") == "json"
+
+    def fail(message: str, hint: str | None = None) -> int:
+        if as_json:
+            payload = {
+                "command": "sync-catalog",
+                "error": message,
+                "success": False,
+            }
+            if hint:
+                payload["hint"] = hint
+            emit_json(payload)
+            return 1
+        print(f"Error: {message}", file=sys.stderr)
+        if hint:
+            print(hint, file=sys.stderr)
+        return 1
+
     try:
         from ..parts.jlcparts_catalog import JLCPARTS_DATA_BASE, sync_catalog
     except ImportError as e:
-        print(f"Error: {e}", file=sys.stderr)
-        print("Install with: pip install kicad-tools[parts]", file=sys.stderr)
-        return 1
+        return fail(str(e), "Install with: pip install kicad-tools[parts]")
 
     base_url = args.base_url or JLCPARTS_DATA_BASE
     try:
-        dest = sync_catalog(base_url=base_url, force=args.force, progress=True)
+        # Progress chatter goes to stdout, which must stay a single JSON
+        # document in machine mode.
+        dest = sync_catalog(base_url=base_url, force=args.force, progress=not as_json)
     except ImportError as e:
-        print(f"Error: {e}", file=sys.stderr)
-        print("Install with: pip install kicad-tools[parts]", file=sys.stderr)
-        return 1
+        return fail(str(e), "Install with: pip install kicad-tools[parts]")
     except Exception as e:
-        print(f"Error: failed to sync jlcparts catalog: {e}", file=sys.stderr)
-        return 1
+        return fail(f"failed to sync jlcparts catalog: {e}")
+
+    if as_json:
+        emit_json(
+            {
+                "command": "sync-catalog",
+                "base_url": base_url,
+                "force": bool(args.force),
+                "path": str(dest),
+                "success": True,
+            }
+        )
+        return 0
 
     print(f"Offline catalog available at: {dest}")
     return 0
@@ -343,6 +385,30 @@ def _cache(args) -> int:
     from ..parts import PartsCache
 
     cache = PartsCache()
+
+    if getattr(args, "format", "text") == "json":
+        action = args.cache_action or "stats"
+        payload: dict = {"command": "cache", "action": action, "success": True}
+        if action == "stats":
+            stats = cache.stats()
+            payload.update(
+                {
+                    "db_path": str(stats["db_path"]),
+                    "total": stats["total"],
+                    "valid": stats["valid"],
+                    "expired": stats["expired"],
+                    "ttl_days": stats["ttl_days"],
+                    "oldest": stats["oldest"],
+                    "newest": stats["newest"],
+                    "categories": dict(sorted(stats["categories"].items())),
+                }
+            )
+        elif action == "clear":
+            payload["cleared"] = cache.clear()
+        elif action == "clear-expired":
+            payload["cleared"] = cache.clear_expired()
+        emit_json(payload)
+        return 0
 
     if not args.cache_action or args.cache_action == "stats":
         stats = cache.stats()

--- a/tests/test_format_json_sweep_families.py
+++ b/tests/test_format_json_sweep_families.py
@@ -1,0 +1,681 @@
+"""Tests for the #4674 machine-output sweep (mixed-family long-tail batch).
+
+Issue #4674 (mechanical follow-up to #4543) adds the canonical
+``--format json`` idiom to the prose-only subcommands.  Batch 1 swept the
+grouped families (``tests/test_format_json_sweep.py``) and batch 2 the 16
+mutating ``sch`` leaves (``tests/test_format_json_sweep_sch.py``).
+
+**This batch finishes the four families whose siblings already spoke JSON
+but which each still had prose-only holdouts** -- ten surfaces:
+
+* ``datasheet`` -- ``cache``, ``convert``, ``download``
+* ``lib``       -- ``create-symbol-lib``, ``create-footprint-lib``,
+                   ``generate-footprint`` (the three "not yet implemented"
+                   placeholders: under JSON the *non-implementation* is the
+                   payload, with the exit code unchanged at 2)
+* ``parts``     -- ``cache``, ``sync-catalog``
+* ``pcb``       -- ``export-dsn``, ``import-ses``
+
+Same conventions as the two sibling modules (a separate file per batch so
+concurrent batches never conflict on a shared ``SWEPT_SURFACES`` literal):
+
+* Outer-parser surface: every swept leaf accepts ``--format`` with a
+  ``json`` choice.
+* Shim forwarding: the outer ``--format json`` reaches the inner parser
+  argv for the argv-reserializing families (``datasheet``, ``parts``) --
+  the drift bug class ``tests/test_cli_parser_drift.py`` exists for -- and
+  the default (text) invocation must NOT forward it.
+* Emission: a single valid JSON document on stdout, byte-identical across
+  two runs on the same input, with structure assertions rather than
+  byte-golden payloads; ``{"error": ...}`` documents on failure with the
+  exit codes unchanged.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kicad_tools.cli.parser import create_parser
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+# Every subcommand swept by this batch, as (command path, minimal extra argv).
+SWEPT_SURFACES: dict[str, list[str]] = {
+    "datasheet cache": [],
+    "datasheet convert": ["ds.pdf"],
+    "datasheet download": ["STM32F103"],
+    "lib create-footprint-lib": ["out.pretty"],
+    "lib create-symbol-lib": ["out.kicad_sym"],
+    "lib generate-footprint": ["out.pretty", "soic"],
+    "parts cache": [],
+    "parts sync-catalog": [],
+    "pcb export-dsn": ["b.kicad_pcb"],
+    "pcb import-ses": ["b.kicad_pcb", "routes.ses"],
+}
+
+
+def _iter_leaves(parser, path=()):
+    subactions = [a for a in parser._actions if isinstance(a, argparse._SubParsersAction)]
+    if not subactions:
+        yield path, parser
+        return
+    for subaction in subactions:
+        for name, sub in subaction.choices.items():
+            yield from _iter_leaves(sub, (*path, name))
+
+
+@pytest.fixture(scope="module")
+def leaves():
+    return {" ".join(path): leaf for path, leaf in _iter_leaves(create_parser())}
+
+
+# ---------------------------------------------------------------------------
+# Outer-parser surface guard
+# ---------------------------------------------------------------------------
+
+
+class TestOuterSurface:
+    @pytest.mark.parametrize("command", sorted(SWEPT_SURFACES))
+    def test_leaf_has_format_json_choice(self, leaves, command):
+        """Each swept leaf declares --format with a json choice."""
+        leaf = leaves.get(command)
+        assert leaf is not None, f"outer parser has no leaf {command!r}"
+        for action in leaf._actions:
+            if "--format" in action.option_strings:
+                assert action.choices and "json" in action.choices, (
+                    f"kct {command} has --format without a 'json' choice "
+                    f"(choices={action.choices}); regresses #4674"
+                )
+                break
+        else:
+            pytest.fail(f"kct {command} lost its --format flag (regresses #4674)")
+
+    @pytest.mark.parametrize("command", sorted(SWEPT_SURFACES))
+    def test_parse_accepts_format_json(self, command):
+        """`kct <command> ... --format json` parses on the real outer parser."""
+        argv = [*command.split(), *SWEPT_SURFACES[command], "--format", "json"]
+        args = create_parser().parse_args(argv)
+        assert args.format == "json"
+
+    @pytest.mark.parametrize("command", sorted(SWEPT_SURFACES))
+    def test_default_format_is_text(self, command):
+        """The default stays text, so no existing invocation changes shape."""
+        args = create_parser().parse_args([*command.split(), *SWEPT_SURFACES[command]])
+        assert args.format == "text"
+
+
+# ---------------------------------------------------------------------------
+# Shim forwarding (outer --format json must reach the inner parser argv)
+# ---------------------------------------------------------------------------
+
+
+class TestShimForwarding:
+    @pytest.mark.parametrize(
+        "command",
+        [c for c in sorted(SWEPT_SURFACES) if c.startswith("datasheet ")],
+    )
+    def test_datasheet_shim_forwards_format(self, command):
+        from kicad_tools.cli.commands.datasheet import run_datasheet_command
+
+        argv = [*command.split(), *SWEPT_SURFACES[command], "--format", "json"]
+        args = create_parser().parse_args(argv)
+        with patch("kicad_tools.cli.datasheet_cmd.main", return_value=0) as inner:
+            assert run_datasheet_command(args) == 0
+        sub_argv = inner.call_args[0][0]
+        assert "--format" in sub_argv, f"datasheet shim dropped --format for {command}: {sub_argv}"
+        assert sub_argv[sub_argv.index("--format") + 1] == "json"
+
+    @pytest.mark.parametrize(
+        "command",
+        [c for c in sorted(SWEPT_SURFACES) if c.startswith("parts ")],
+    )
+    def test_parts_shim_forwards_format(self, command):
+        from kicad_tools.cli.commands.parts import run_parts_command
+
+        argv = [*command.split(), *SWEPT_SURFACES[command], "--format", "json"]
+        args = create_parser().parse_args(argv)
+        with patch("kicad_tools.cli.parts_cmd.main", return_value=0) as inner:
+            assert run_parts_command(args) == 0
+        sub_argv = inner.call_args[0][0]
+        assert "--format" in sub_argv, f"parts shim dropped --format for {command}: {sub_argv}"
+        assert sub_argv[sub_argv.index("--format") + 1] == "json"
+
+    def test_shims_omit_format_for_text_default(self):
+        """Default (text) invocations must not forward --format (behaviour pin)."""
+        from kicad_tools.cli.commands.datasheet import run_datasheet_command
+        from kicad_tools.cli.commands.parts import run_parts_command
+
+        args = create_parser().parse_args(["datasheet", "cache"])
+        with patch("kicad_tools.cli.datasheet_cmd.main", return_value=0) as inner:
+            run_datasheet_command(args)
+        assert "--format" not in inner.call_args[0][0]
+
+        args = create_parser().parse_args(["parts", "sync-catalog"])
+        with patch("kicad_tools.cli.parts_cmd.main", return_value=0) as inner:
+            run_parts_command(args)
+        assert "--format" not in inner.call_args[0][0]
+
+    def test_parts_cache_inner_accepts_format_on_either_side(self):
+        """The inner ``parts cache`` subparser tree must not eat --format.
+
+        ``cache`` is the only swept surface whose inner parser has its own
+        subparsers, so an action subparser with a plain ``text`` default
+        would clobber the value parsed by the ``cache`` parser.  Both
+        orderings have to resolve to json.
+        """
+        from kicad_tools.cli.parts_cmd import main as parts_main
+
+        seen = []
+        with patch("kicad_tools.parts.PartsCache", side_effect=AssertionError("unused")):
+            for argv in (
+                ["cache", "--format", "json", "stats"],
+                ["cache", "stats", "--format", "json"],
+            ):
+                with patch("kicad_tools.cli.parts_cmd._cache", return_value=0) as handler:
+                    parts_main(argv)
+                seen.append(handler.call_args[0][0].format)
+        assert seen == ["json", "json"]
+
+
+# ---------------------------------------------------------------------------
+# lib placeholders: the non-implementation is the payload
+# ---------------------------------------------------------------------------
+
+
+class TestLibPlaceholderEmission:
+    def _run(self, argv, capsys):
+        from kicad_tools.cli.commands.library import run_lib_command
+
+        rc = run_lib_command(create_parser().parse_args(argv))
+        return rc, capsys.readouterr().out
+
+    @pytest.mark.parametrize(
+        "command",
+        [c for c in sorted(SWEPT_SURFACES) if c.startswith("lib ")],
+    )
+    def test_json_document_and_exit_code(self, command, capsys):
+        argv = [*command.split(), *SWEPT_SURFACES[command], "--format", "json"]
+        rc, out = self._run(argv, capsys)
+        assert rc == 2, "the 'not implemented' exit code must not change"
+        payload = json.loads(out)
+        assert payload["command"] == command.split()[1]
+        assert payload["implemented"] is False
+        assert payload["success"] is False
+        assert "not yet implemented" in payload["error"]
+        assert payload["tracking_issue"].startswith("https://github.com/")
+
+    def test_generate_footprint_reports_its_parameters(self, capsys):
+        rc, out = self._run(
+            [
+                "lib",
+                "generate-footprint",
+                "out.pretty",
+                "soic",
+                "--pins",
+                "8",
+                "--pitch",
+                "1.27",
+                "--format",
+                "json",
+            ],
+            capsys,
+        )
+        assert rc == 2
+        payload = json.loads(out)
+        assert payload["library"] == "out.pretty"
+        assert payload["type"] == "soic"
+        # Unset options are omitted rather than emitted as nulls.
+        assert payload["parameters"] == {"pins": 8, "pitch": 1.27}
+
+    def test_json_is_deterministic(self, capsys):
+        argv = ["lib", "create-symbol-lib", "out.kicad_sym", "--format", "json"]
+        _, first = self._run(argv, capsys)
+        _, second = self._run(argv, capsys)
+        assert first == second
+
+    def test_text_default_unchanged(self, capsys):
+        rc, out = self._run(["lib", "create-symbol-lib", "out.kicad_sym"], capsys)
+        assert rc == 2
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(out)
+
+
+# ---------------------------------------------------------------------------
+# datasheet emission
+# ---------------------------------------------------------------------------
+
+
+class _StubDatasheet:
+    part_number = "STM32F103"
+    manufacturer = "ST"
+    local_path = Path("/cache/STM32F103.pdf")
+    source_url = "https://example.invalid/ds.pdf"
+    source = "stub"
+    file_size = 2048
+    file_size_mb = 0.001953125
+
+
+class _StubDatasheetManager:
+    """Minimal stand-in so the tests never touch the real user cache."""
+
+    cleared = 0
+
+    def __init__(self, *args, **kwargs):
+        self.cache = self
+
+    def download_by_part(self, part, output_dir=None, force=False):
+        return _StubDatasheet()
+
+    def cache_stats(self):
+        return {
+            "cache_dir": Path("/cache/datasheets"),
+            "total_count": 2,
+            "valid_count": 1,
+            "expired_count": 1,
+            "total_size_mb": 1.5,
+            "ttl_days": 90,
+            "sources": {"octopart": 1, "digikey": 1},
+        }
+
+    def clear_cache(self, older_than_days=None):
+        return 7 if older_than_days else 9
+
+    def clear_expired(self):
+        return 3
+
+
+@pytest.fixture
+def stub_datasheet_manager():
+    pytest.importorskip("kicad_tools.datasheet.manager")
+    with patch("kicad_tools.datasheet.manager.DatasheetManager", _StubDatasheetManager):
+        yield
+
+
+def _run_datasheet(argv, capsys):
+    from kicad_tools.cli.commands.datasheet import run_datasheet_command
+
+    rc = run_datasheet_command(create_parser().parse_args(argv))
+    return rc, capsys.readouterr().out
+
+
+class TestDatasheetEmission:
+    def test_cache_stats_document(self, stub_datasheet_manager, capsys):
+        rc, out = _run_datasheet(["datasheet", "cache", "stats", "--format", "json"], capsys)
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["command"] == "cache"
+        assert payload["action"] == "stats"
+        assert payload["total_count"] == 2
+        assert payload["ttl_days"] == 90
+        # sources are sorted for determinism
+        assert list(payload["sources"]) == sorted(payload["sources"])
+        assert payload["success"] is True
+
+    def test_cache_stats_is_deterministic(self, stub_datasheet_manager, capsys):
+        argv = ["datasheet", "cache", "stats", "--format", "json"]
+        _, first = _run_datasheet(argv, capsys)
+        _, second = _run_datasheet(argv, capsys)
+        assert first == second
+
+    def test_cache_clear_reports_count(self, stub_datasheet_manager, capsys):
+        rc, out = _run_datasheet(["datasheet", "cache", "clear", "--format", "json"], capsys)
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload == {
+            "action": "clear",
+            "cleared": 9,
+            "command": "cache",
+            "older_than_days": None,
+            "success": True,
+        }
+
+    def test_cache_clear_honours_older_than(self, stub_datasheet_manager, capsys):
+        rc, out = _run_datasheet(
+            ["datasheet", "cache", "clear", "--older-than", "30", "--format", "json"], capsys
+        )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["older_than_days"] == 30
+        assert payload["cleared"] == 7
+
+    def test_cache_text_default_unchanged(self, stub_datasheet_manager, capsys):
+        rc, out = _run_datasheet(["datasheet", "cache", "stats"], capsys)
+        assert rc == 0
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(out)
+
+    def test_download_document(self, stub_datasheet_manager, capsys):
+        rc, out = _run_datasheet(["datasheet", "download", "STM32F103", "--format", "json"], capsys)
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["command"] == "download"
+        assert payload["part"] == "STM32F103"
+        assert payload["path"].endswith("STM32F103.pdf")
+        assert payload["file_size_bytes"] == 2048
+        assert payload["source"] == "stub"
+        assert payload["success"] is True
+
+    def test_download_failure_is_json_document(self, capsys):
+        pytest.importorskip("kicad_tools.datasheet.manager")
+
+        class _Boom(_StubDatasheetManager):
+            def download_by_part(self, part, output_dir=None, force=False):
+                raise RuntimeError("no source responded")
+
+        with patch("kicad_tools.datasheet.manager.DatasheetManager", _Boom):
+            rc, out = _run_datasheet(
+                ["datasheet", "download", "NOPART", "--format", "json"], capsys
+            )
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["success"] is False
+        assert "no source responded" in payload["error"]
+
+    def test_convert_missing_pdf_is_json_document(self, tmp_path, capsys):
+        rc, out = _run_datasheet(
+            ["datasheet", "convert", str(tmp_path / "nope.pdf"), "--format", "json"], capsys
+        )
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["command"] == "convert"
+        assert payload["success"] is False
+        # Either the PDF is missing or the optional parser dependency is --
+        # both must arrive as one structured document, never as prose.
+        assert payload["error"]
+
+    def test_convert_carries_markdown_when_no_output_file(self, tmp_path, capsys):
+        pytest.importorskip("kicad_tools.datasheet.parser")
+
+        class _StubParser:
+            def __init__(self, path):
+                self.path = path
+
+            def to_markdown(self, pages=None):
+                return "# Title\n\nbody\n"
+
+        pdf = tmp_path / "ds.pdf"
+        pdf.write_bytes(b"%PDF-1.4\n")
+
+        with patch("kicad_tools.datasheet.parser.DatasheetParser", _StubParser):
+            rc, out = _run_datasheet(["datasheet", "convert", str(pdf), "--format", "json"], capsys)
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["output"] is None
+        assert payload["markdown"] == "# Title\n\nbody\n"
+
+    def test_convert_reports_output_path_instead_of_markdown(self, tmp_path, capsys):
+        pytest.importorskip("kicad_tools.datasheet.parser")
+
+        class _StubParser:
+            def __init__(self, path):
+                self.path = path
+
+            def to_markdown(self, pages=None):
+                return "# Title\n"
+
+        pdf = tmp_path / "ds.pdf"
+        pdf.write_bytes(b"%PDF-1.4\n")
+        out_file = tmp_path / "ds.md"
+
+        with patch("kicad_tools.datasheet.parser.DatasheetParser", _StubParser):
+            rc, out = _run_datasheet(
+                ["datasheet", "convert", str(pdf), "-o", str(out_file), "--format", "json"],
+                capsys,
+            )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["output"] == str(out_file)
+        assert "markdown" not in payload
+        assert out_file.read_text() == "# Title\n"
+
+
+# ---------------------------------------------------------------------------
+# parts emission
+# ---------------------------------------------------------------------------
+
+
+class _StubPartsCache:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def stats(self):
+        return {
+            "db_path": Path("/cache/parts.db"),
+            "total": 12,
+            "valid": 10,
+            "expired": 2,
+            "ttl_days": 7,
+            "oldest": "2026-01-01T00:00:00",
+            "newest": "2026-01-02T00:00:00",
+            "categories": {"resistor": 7, "capacitor": 5},
+        }
+
+    def clear(self):
+        return 12
+
+    def clear_expired(self):
+        return 2
+
+
+def _run_parts(argv, capsys):
+    from kicad_tools.cli.commands.parts import run_parts_command
+
+    rc = run_parts_command(create_parser().parse_args(argv))
+    return rc, capsys.readouterr().out
+
+
+class TestPartsEmission:
+    @pytest.fixture(autouse=True)
+    def _stub_cache(self):
+        pytest.importorskip("kicad_tools.parts")
+        with patch("kicad_tools.parts.PartsCache", _StubPartsCache):
+            yield
+
+    def test_cache_stats_document(self, capsys):
+        rc, out = _run_parts(["parts", "cache", "stats", "--format", "json"], capsys)
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["command"] == "cache"
+        assert payload["action"] == "stats"
+        assert payload["total"] == 12
+        assert list(payload["categories"]) == sorted(payload["categories"])
+        assert payload["success"] is True
+
+    def test_cache_stats_is_deterministic(self, capsys):
+        argv = ["parts", "cache", "stats", "--format", "json"]
+        _, first = _run_parts(argv, capsys)
+        _, second = _run_parts(argv, capsys)
+        assert first == second
+
+    def test_cache_clear_reports_count(self, capsys):
+        rc, out = _run_parts(["parts", "cache", "clear", "--format", "json"], capsys)
+        assert rc == 0
+        assert json.loads(out) == {
+            "action": "clear",
+            "cleared": 12,
+            "command": "cache",
+            "success": True,
+        }
+
+    def test_cache_text_default_unchanged(self, capsys):
+        rc, out = _run_parts(["parts", "cache", "stats"], capsys)
+        assert rc == 0
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(out)
+
+    def test_sync_catalog_document(self, tmp_path, capsys):
+        pytest.importorskip("kicad_tools.parts.jlcparts_catalog")
+        dest = tmp_path / "catalog.sqlite3"
+        calls = {}
+
+        def _fake_sync(base_url, force, progress):
+            calls["progress"] = progress
+            return dest
+
+        with patch("kicad_tools.parts.jlcparts_catalog.sync_catalog", _fake_sync):
+            rc, out = _run_parts(["parts", "sync-catalog", "--format", "json"], capsys)
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["command"] == "sync-catalog"
+        assert payload["path"] == str(dest)
+        assert payload["force"] is False
+        assert payload["success"] is True
+        assert calls["progress"] is False, "progress chatter must not pollute the JSON document"
+
+    def test_sync_catalog_failure_is_json_document(self, capsys):
+        pytest.importorskip("kicad_tools.parts.jlcparts_catalog")
+
+        def _boom(base_url, force, progress):
+            raise RuntimeError("network down")
+
+        with patch("kicad_tools.parts.jlcparts_catalog.sync_catalog", _boom):
+            rc, out = _run_parts(["parts", "sync-catalog", "--format", "json"], capsys)
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["success"] is False
+        assert "network down" in payload["error"]
+
+
+# ---------------------------------------------------------------------------
+# pcb export-dsn / import-ses emission
+# ---------------------------------------------------------------------------
+
+
+def _run_pcb(argv, capsys):
+    from kicad_tools.cli.commands.pcb import run_pcb_command
+
+    rc = run_pcb_command(create_parser().parse_args(argv))
+    return rc, capsys.readouterr().out
+
+
+class TestPcbExchangeEmission:
+    BOARD = FIXTURES / "routing-diagnostic.kicad_pcb"
+
+    def test_export_dsn_document(self, tmp_path, capsys):
+        out_file = tmp_path / "board.dsn"
+        rc, out = _run_pcb(
+            [
+                "pcb",
+                "export-dsn",
+                str(self.BOARD),
+                "-o",
+                str(out_file),
+                "--format",
+                "json",
+            ],
+            capsys,
+        )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["command"] == "export-dsn"
+        assert payload["output"] == str(out_file)
+        assert payload["layers"] >= 1
+        assert payload["nets"] >= 1
+        assert payload["components"] >= 1
+        assert payload["success"] is True
+        assert out_file.exists()
+
+    def test_export_dsn_is_deterministic(self, tmp_path, capsys):
+        argv = [
+            "pcb",
+            "export-dsn",
+            str(self.BOARD),
+            "-o",
+            str(tmp_path / "board.dsn"),
+            "--format",
+            "json",
+        ]
+        _, first = _run_pcb(argv, capsys)
+        _, second = _run_pcb(argv, capsys)
+        assert first == second
+
+    def test_export_dsn_text_default_unchanged(self, tmp_path, capsys):
+        rc, out = _run_pcb(
+            ["pcb", "export-dsn", str(self.BOARD), "-o", str(tmp_path / "b.dsn")], capsys
+        )
+        assert rc == 0
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(out)
+
+    def test_missing_board_is_json_document(self, tmp_path, capsys):
+        """The shim's shared file guard runs before any handler (#4674)."""
+        rc, out = _run_pcb(
+            ["pcb", "export-dsn", str(tmp_path / "nope.kicad_pcb"), "--format", "json"], capsys
+        )
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["command"] == "export-dsn"
+        assert payload["success"] is False
+        assert "File not found" in payload["error"]
+
+    def test_missing_board_text_default_unchanged(self, tmp_path, capsys):
+        from kicad_tools.cli.commands.pcb import run_pcb_command
+
+        args = create_parser().parse_args(["pcb", "export-dsn", str(tmp_path / "nope.kicad_pcb")])
+        assert run_pcb_command(args) == 1
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "File not found" in captured.err
+
+    def test_import_ses_missing_ses_is_json_document(self, tmp_path, capsys):
+        rc, out = _run_pcb(
+            [
+                "pcb",
+                "import-ses",
+                str(self.BOARD),
+                str(tmp_path / "nope.ses"),
+                "--format",
+                "json",
+            ],
+            capsys,
+        )
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["command"] == "import-ses"
+        assert payload["success"] is False
+        assert "SES file not found" in payload["error"]
+
+    def test_import_ses_document(self, tmp_path, capsys):
+        """A successful import emits the wire/via counts as one document."""
+        ses = tmp_path / "routes.ses"
+        ses.write_text("(session routes.ses)\n")
+        out_pcb = tmp_path / "routed.kicad_pcb"
+
+        class _StubImporter:
+            wires = [1, 2, 3]
+            vias = [1]
+
+            def __init__(self, path):
+                self.path = path
+
+            def parse(self):
+                return None
+
+            def merge_into(self, pcb, output=None):
+                Path(output or pcb).write_text("stub")
+
+        with patch("kicad_tools.export.ses.SESToKiCadImporter", _StubImporter):
+            rc, out = _run_pcb(
+                [
+                    "pcb",
+                    "import-ses",
+                    str(self.BOARD),
+                    str(ses),
+                    "-o",
+                    str(out_pcb),
+                    "--format",
+                    "json",
+                ],
+                capsys,
+            )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["wires"] == 3
+        assert payload["vias"] == 1
+        assert payload["output"] == str(out_pcb)
+        assert payload["success"] is True


### PR DESCRIPTION
## Scope of this batch (batch 3 of #4674)

**Chosen scope: the ten prose-only holdouts inside four families whose other leaves already spoke JSON** — `datasheet` (3), `lib` (3), `parts` (2), `pcb` (2).

`stitch` is **not** in this batch. It is a single command backed by a 6k-line inner module with a bespoke multi-phase report; per the tracker comment it deserves its own batch, and pairing it with mechanical work would make both halves harder to review. The remaining true singles (`board-metrics`, `build`, `config`, `create-pcb`, `creepage-export-rules`, `ipc *`, `mcp setup`, `optimize-*`, `panel`, `pipeline`, `reason`, `report generate`, `route-auto`, `screenshot`) stay on the backlog and split cleanly into one or two more batches.

Why *these* ten hang together: each is the odd leaf out in a family that is otherwise fully JSON-capable (`datasheet search/list/info`, `lib list/symbols/footprint-info/...`, `parts lookup/search/availability/suggest`, and ~20 `pcb` leaves all already accept `--format json`). Sweeping them finishes four families outright rather than leaving four partially-converted surfaces behind.

## Summary

Adds the canonical `--format json` idiom, wired end-to-end (outer parser → `commands/*.py` shim → inner parser/handler), to:

| Family | Leaves |
|---|---|
| `datasheet` | `cache`, `convert`, `download` |
| `lib` | `create-symbol-lib`, `create-footprint-lib`, `generate-footprint` |
| `parts` | `cache`, `sync-catalog` |
| `pcb` | `export-dsn`, `import-ses` |

Audit at PR head (`scripts/audit_machine_output.py`, base `05d41949`): **prose-only 33 → 23, format-json 164 → 174.**

## Changes

- **`src/kicad_tools/cli/parser.py`** — `add_format_flag` on the ten outer leaves.
- **`commands/datasheet.py`, `commands/parts.py`** — shim forwarding (`--format json` appended to `sub_argv`, omitted for the `text` default). Both new call sites read the attribute with `getattr(args, "format", "text")` so hand-built `Namespace` callers (e.g. `tests/parts/test_jlcparts_catalog.py::test_cli_dispatch_sync_catalog`) keep working.
- **`commands/library.py` + `cli/lib.py`** — the three placeholders take an `output_format` argument and route through one `_report_not_implemented` helper. They are unimplemented and exit `2`; under JSON the *non-implementation is the payload* — `{"implemented": false, "error": ..., "tracking_issue": ...}` — so a caller can distinguish "not implemented" from a crash without scraping stderr. **Exit code unchanged (2).**
- **`cli/datasheet_cmd.py`** — `--format` on the `download`/`cache`/`convert` inner parsers plus emission. `convert` writes markdown to stdout when no `-o` is given, so in JSON mode it carries the conversion under a `markdown` key; with `-o` it reports `output` and omits `markdown`.
- **`cli/parts_cmd.py`** — `--format` on `sync-catalog` and on the `cache` parser. `cache` is the only swept surface whose *inner* parser has its own subparsers, so the per-action subparsers declare `--format` with `default=argparse.SUPPRESS`: an unspecified flag on the action cannot clobber the value parsed by the `cache` parser, and both `parts cache --format json stats` and `parts cache stats --format json` resolve to json. `sync-catalog` also passes `progress=False` in JSON mode so download chatter cannot pollute the single document.
- **`commands/pcb.py`** — emission for `export-dsn` (`layers`/`nets`/`components`) and `import-ses` (`wires`/`vias`), plus `{"error": ...}` documents on their failure paths. The shim's **shared "file not found" guard** runs before every `pcb` handler, so — exactly as batch 2 did for the `sch` shim — it now honours `--format json` itself. That is a deliberate small widening beyond the two new leaves: it closes the same hole for the ~20 `pcb` leaves that already had `--format json`, where the one error every leaf can hit was the one error that never produced a document. Text mode is byte-identical.
- **`tests/test_format_json_sweep_families.py`** (new, 66 tests) — a **sibling** of `test_format_json_sweep.py` / `test_format_json_sweep_sch.py` rather than an edit to either, so concurrent batches cannot conflict on a shared `SWEPT_SURFACES` literal (the convention batch 2 established).
- **`docs/reference/machine-output.md`** — inventory table gains a b3 column, the ten leaves move from the backlog to a "Done (third batch)" section, remaining actionable 28 → 18.
- **`CHANGELOG.md`** — entry under `## [Unreleased]` → first `### Added`.

## Acceptance Criteria Verification

Per-PR criteria from the issue:

- [x] **One coherent family scope** — four families' holdouts, stated above; outer parser + shim + inner emission all threaded, no inner-only flags (`scripts/audit_machine_output.py` confirms all ten are reachable from the outer tree).
- [x] **JSON deterministic** — sorted keys via `emit_json`, sorted `sources`/`categories` maps, no wall-clock fields. Byte-identical-across-two-runs tests for `lib create-symbol-lib`, `datasheet cache stats`, `parts cache stats`, `pcb export-dsn`.
- [x] **`tests/test_cli_parser_drift.py` green and untouched** — it guards the `route`/`check` pairs only; no route/check parser changes here.
- [x] **Per-surface `--format json` tests** — structure assertions (not byte-golden), plus error documents, exit-code preservation, and text-mode-unchanged pins for every swept surface.
- [x] **Exit codes unchanged** — `2` for the `lib` placeholders, `1` on every error path, `0` on success, in both modes.

## Test Plan

```
uv run pytest tests/test_format_json_sweep_families.py           # 66 passed
uv run pytest tests/test_format_json_sweep.py \
             tests/test_format_json_sweep_sch.py \
             tests/test_machine_output_idiom.py \
             tests/test_cli_parser_drift.py \
             tests/test_docs_source_citations.py                 # 361 passed
uv run pytest tests/test_cli_lib.py tests/test_cli_pcb.py \
             tests/test_datasheet.py tests/test_cli_commands.py \
             tests/test_cli.py tests/parts                       # 518 passed
uv run ruff check .                                              # All checks passed
uv run ruff format . --check                                     # 1784 files already formatted
uv run python scripts/ci/check_mypy_baseline.py                  # OK, no new type errors
uv run python scripts/audit_machine_output.py                    # prose-only 33 -> 23
```

Note: the mypy gate prints a pre-existing `2 baseline error(s) no longer occur` advisory warning that also reproduces without this diff (none of the four touched modules' baseline signatures changed; `cli/lib.py` has no baseline entries at all). The baseline is left untouched.

Manual smoke tests (text mode unchanged, JSON mode a single document):

```
kct lib create-symbol-lib /tmp/x.kicad_sym --format json           # rc=2, implemented:false
kct lib generate-footprint /tmp/lib soic --pins 8 --format json    # rc=2, parameters:{pins:8}
kct parts cache stats --format json                                # rc=0
kct datasheet cache stats --format json                            # rc=0
kct datasheet convert /tmp/nope.pdf --format json                  # rc=1, {"error": ...}
kct pcb export-dsn tests/fixtures/routing-diagnostic.kicad_pcb -o /tmp/rd.dsn --format json
kct pcb export-dsn /tmp/missing.kicad_pcb --format json            # rc=1, {"error": ...}
kct pcb import-ses <board> /tmp/missing.ses --format json          # rc=1, {"error": ...}
```

Part of #4674