### PR TITLE
fix(cli): report the armed lattice budget, honor --report-stage-quality under --quiet, and 7 more sweep nits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Nine polish fixes from the 2026-08-08/09 sweep's judge nits** (#4765) —
+  each a small correctness defect in code that shipped last sweep; none
+  changes routed copper or an exit code. (A) The `kct route` banner decided
+  its `UNBOUNDED` line from the raw `--timeout`/`--per-net-timeout` flags, so
+  `--complete --per-net-timeout 0` announced an unbounded lattice negotiation
+  while `_apply_complete_localization`'s 60 s per-link backstop was already
+  armed; it now keys off the resolved `_resolve_lattice_link_budget` /
+  `_lattice_absolute_deadline` values and reports the budget actually in
+  force. (B) `--quiet` silently discarded an explicitly-requested
+  `--report-stage-quality` table; the opt-in now wins (the `recorder is None`
+  guard already carried the entire "not requested" case). (C) The
+  "lazy" `StageQualityRecorder` import was a bare `sys.modules` hit — the
+  module is already executed by the eager stage-constant import — and is
+  hoisted to module scope with an accurate comment. (D) The `45deg%`
+  denominator moves from the renderer to a read-only
+  `RoutingQualityMetrics.diagonal_45_fraction` property, beside the
+  `fragment_fraction` / `staircase_fraction` contract (no new dataclass
+  field: `to_dict()` is a stable JSON contract). (E) A DRC finding that mixes
+  a pad with a ref-less track item normalizes to a smaller ref set than
+  "exact-set" suggests, so a one-ref waiver covers a *class* of findings; the
+  behaviour is kept (narrowing it would retroactively un-waive shipped
+  sidecars) but is now documented on `apply_waivers_to_report` and in
+  `docs/reference/cli.md`, pinned by regression tests, with `nets` as the
+  documented narrowing remedy. (F) `kct drc boards/NN/output/drc.json` never
+  probed `boards/NN/` for `.kct_waivers.json` (all three of the shared
+  discovery probes collapse into the report's own directory); report input
+  now falls back to the report directory's parent. (H) The documented
+  "4+ trailing tokens are never trimmed" path of `_sync_at_angle` gets its
+  first test. (I) The residual #3441 lattice-rescue `UserWarning`
+  ("quantisation margin is reduced at fine-pitch pads") predicts a grid-only
+  failure mode and is demoted to INFO for `--route-engine mesh|lattice`,
+  completing #4761's gate on the sibling branch; every `GridAutoSelection`
+  field stays engine-invariant. (J) All ~16 `args.route_engine` reads in
+  `route_cmd.py` now go through one `_resolve_route_engine` helper, so a
+  `route_engine=None` namespace can no longer resolve to `"grid"` at ten
+  sites and `None` at six (including three `strategy=` arguments to
+  `load_pcb_for_routing`). (K) The non-grid "Fine-pitch grid analysis:
+  skipped" line printed even on boards where the grid path prints nothing;
+  it is now gated on the same `has_warnings` predicate the grid path uses.
 - **`PCB.import_from_schematic()` no longer drops a `*-netlist.kicad_net`
   beside the user's schematic** (#4763) — the same defect #4750 fixed in
   `pcb sync-netlist`, at the second call site. `export_netlist` defaults

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -265,6 +265,21 @@ The `kicad-cli pcb drc` cross-gate reads the same schema-v2 sidecar as
   `"Pad 6 [<no net>] of U3 on F.Cu"` → `U3`). Matching is exact-set and
   order-insensitive: a 2-item entry never waives a 3-item finding. Findings
   with no refs at all (track/via-only) are waivable via `nets` instead.
+- **Caveat — findings that are only *partly* ref-less (#4765).** The ref set is
+  normalized from the item descriptions, and a track/via item contributes
+  nothing to it (`"Track [GND] on F.Cu"` yields no ref). So a finding whose
+  items are `["Pad 1 of U3", "Track [GND] on F.Cu"]` normalizes to `{U3}` and
+  *is* matched exactly by a one-item `"items": ["U3"]` entry — the entry waives
+  a whole class of `U3` findings, not just the one that was reviewed. This is
+  intentional (narrowing it would retroactively un-waive existing sidecars);
+  when any item in a finding carries no reference designator, additionally
+  constrain the entry with `"nets": [...]` so it stays specific to the finding
+  you actually reviewed.
+- Auto-discovery is anchored at the input path: the board directory for
+  `.kicad_pcb` input, and for `.json`/`.rpt` report input the report's own
+  directory plus its `output/` siblings — falling back to the report
+  directory's parent, so `kct drc boards/NN/output/drc.json` still finds
+  `boards/NN/.kct_waivers.json` (#4765).
 - Matched findings render in a dedicated `WAIVED` section with their own count
   bucket (never as warnings) and are excluded from the exit gate — exit is
   nonzero iff **unwaived** errors remain. `--format json` keeps the underlying

--- a/src/kicad_tools/analysis/routing_quality.py
+++ b/src/kicad_tools/analysis/routing_quality.py
@@ -88,6 +88,21 @@ class RoutingQualityMetrics:
     staircase_step_count: int
     staircase_fraction: float
 
+    @property
+    def diagonal_45_fraction(self) -> float:
+        """Share of nonzero-length segments running at 45 degrees.
+
+        Issue #4765: the 45-degree share was the one fraction whose
+        zero-length-excluded denominator was reconstructed by a renderer
+        (``StageQualityRecorder.format_report``) instead of living beside
+        ``fragment_fraction`` / ``staircase_fraction`` on this class.  It is
+        a derived **property** rather than a field on purpose: :meth:`to_dict`
+        is a stable JSON contract, so the serialized keys stay exactly as
+        they were.  ``0.0`` when every segment is zero-length.
+        """
+        nonzero = self.total_segments - self.zero_length_count
+        return self.diagonal_45_count / nonzero if nonzero else 0.0
+
     def to_dict(self) -> dict[str, int | float]:
         """Serialize to the stable JSON contract emitted by ``kct check``."""
         return {

--- a/src/kicad_tools/cli/drc_cmd.py
+++ b/src/kicad_tools/cli/drc_cmd.py
@@ -334,6 +334,11 @@ def _load_waivers(explicit: str | None, input_path: Path) -> tuple["Waivers | No
     missing or malformed explicit file is a hard error; an auto-discovered
     sidecar that fails to parse degrades to zero waivers with a warning.
 
+    Issue #4765: for ``.json``/``.rpt`` report input the discovery anchor is
+    the report's own directory, so the board directory one level up (the
+    canonical ``boards/NN/`` home of ``.kct_waivers.json`` when the input is
+    ``boards/NN/output/drc.json``) is probed as a last resort.
+
     Args:
         explicit: The ``--waivers`` value, or None to auto-discover.
         input_path: The PCB or report path used as the discovery anchor.
@@ -348,6 +353,20 @@ def _load_waivers(explicit: str | None, input_path: Path) -> tuple["Waivers | No
         path: Path | None = Path(explicit).resolve()
     else:
         path = discover_waivers_sidecar(input_path)
+        if path is None and input_path.suffix in (".json", ".rpt"):
+            # Issue #4765: for REPORT input the anchor is the report, not the
+            # board -- and ``discover_waivers_sidecar`` probes ``<dir>/``,
+            # ``<dir>/output/`` and ``<dir>/../output/``.  For the canonical
+            # ``boards/NN/output/drc.json`` layout those collapse to
+            # ``boards/NN/output/`` (twice) and ``boards/NN/output/output/``,
+            # so the board directory -- exactly where the sidecar lives for
+            # the ``.kicad_pcb`` path -- is never probed.  Add that one
+            # anchor here rather than widening the shared discovery helper,
+            # which ``kct check --waivers`` also uses with correct
+            # ``.kicad_pcb`` anchoring.
+            board_dir_candidate = input_path.parent.parent / ".kct_waivers.json"
+            if board_dir_candidate.is_file():
+                path = board_dir_candidate
 
     if path is None:
         return None, 0

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -91,15 +91,19 @@ if TYPE_CHECKING:
 # not remove this alias without also updating those patch targets.
 from kicad_tools.router.auto_pour import auto_skip_pour_nets as _auto_skip_pour_nets  # noqa: E402
 
-# Issue #4732: the per-stage routing-quality probe's canonical stage labels.
-# Only the (cheap, pure-python) label constants are imported eagerly; the
-# recorder itself is constructed lazily in ``_make_stage_quality_recorder``
-# and only when ``--report-stage-quality`` is passed.
+# Issue #4732: the per-stage routing-quality probe's canonical stage labels
+# plus the recorder itself.  Issue #4765: the recorder used to be imported
+# function-locally to keep it "lazy", but importing the stage constants here
+# already executes the whole ``quality_probe`` module, so that inner import
+# was a bare ``sys.modules`` hit.  ``--report-stage-quality`` still gates
+# CONSTRUCTION of the recorder (``_make_stage_quality_recorder``), which is
+# where the measurement cost actually lives.
 from kicad_tools.router.quality_probe import (  # noqa: E402
     STAGE_POST_FINALIZE,
     STAGE_POST_NUDGE,
     STAGE_POST_OPTIMIZE,
     STAGE_PRE_OPTIMIZE,
+    StageQualityRecorder,
 )
 
 # Issue #4634: the sidecar filename this writer emits is the same constant the
@@ -1091,8 +1095,6 @@ def _make_stage_quality_recorder(args: argparse.Namespace) -> Any:
     """
     if not getattr(args, "report_stage_quality", False):
         return None
-    from kicad_tools.router.quality_probe import StageQualityRecorder
-
     return StageQualityRecorder()
 
 
@@ -1111,12 +1113,36 @@ def _record_stage_quality(recorder: Any, stage: str, router: Any) -> None:
 
 
 def _print_stage_quality_report(recorder: Any, *, quiet: bool = False) -> None:
-    """Print the #4732 advisory per-stage table (no-op when disabled)."""
-    if recorder is None or quiet:
+    """Print the #4732 advisory per-stage table (no-op when disabled).
+
+    Issue #4765: ``--quiet`` no longer cancels the table.  A non-None
+    recorder means the user passed ``--report-stage-quality``
+    (:func:`_make_stage_quality_recorder` returns None otherwise), so the
+    ``recorder is None`` guard already carries the entire "not requested"
+    case -- suppressing an explicit opt-in on top of that discarded the
+    request silently.  ``quiet`` is still ACCEPTED (call-site compatibility)
+    but deliberately ignored.
+    """
+    if recorder is None:
         return
     report = recorder.format_report()
     if report:
         print(report)
+
+
+def _resolve_route_engine(args: argparse.Namespace) -> str:
+    """The active ``--route-engine`` selector, normalized to a non-empty str.
+
+    Issue #4765: ``args.route_engine`` was read at ~16 sites in this module,
+    ten of which normalized a falsy value with ``or "grid"`` while six did
+    not -- so a programmatically-built ``Namespace`` carrying
+    ``route_engine=None`` resolved to ``"grid"`` at some sites and ``None``
+    at others (notably the ``strategy=`` argument of
+    ``load_pcb_for_routing`` in the escalation paths).  Every read now goes
+    through this one helper.  No behaviour change for a CLI-parsed
+    namespace: argparse's ``choices`` guarantees a non-empty string.
+    """
+    return getattr(args, "route_engine", "grid") or "grid"
 
 
 def _engine_post_passes_enabled(
@@ -1152,7 +1178,7 @@ def _engine_post_passes_enabled(
     absent-flag path is exactly the #4281 skip (byte-identical output for a
     plain ``--route-engine lattice`` run).
     """
-    engine = getattr(args, "route_engine", "grid") or "grid"
+    engine = _resolve_route_engine(args)
     if engine == "grid":
         return True
     if getattr(args, "lattice_optimize", False):
@@ -1192,7 +1218,7 @@ def _mark_nongrid_routes_for_post_pass(
     No-op unless the engine is non-grid AND ``--lattice-optimize`` is set, so the
     default path (and every grid run) is completely untouched.
     """
-    engine = getattr(args, "route_engine", "grid") or "grid"
+    engine = _resolve_route_engine(args)
     if engine == "grid" or not getattr(args, "lattice_optimize", False):
         return
     marked = 0
@@ -4247,7 +4273,7 @@ def _apply_pairwise_clearance(router: "Autorouter", args, quiet: bool = False) -
         # line that made the original false pass silent.  Every engine is
         # additionally covered by the post-route board audit
         # (``_audit_pairwise_clearance``).
-        engine = getattr(args, "route_engine", "grid") or "grid"
+        engine = _resolve_route_engine(args)
         enforcement = (
             "route-time rejection + post-route audit"
             if engine in ("grid", "lattice")
@@ -4549,7 +4575,7 @@ def _print_pairwise_failure_banner(
         f"{getattr(args, 'pollution_degree', 2)} --material-group "
         f"{getattr(args, 'material_group', 'IIIa')}"
     )
-    engine = getattr(args, "route_engine", "grid") or "grid"
+    engine = _resolve_route_engine(args)
     if engine not in ("grid", "lattice"):
         # Issue #4588 gates; grid (#4454/#4511) and lattice (#4602) avoid the
         # proximity during search, so a gate hit there means the geometry
@@ -5652,7 +5678,7 @@ def route_with_layer_escalation(
                     layer_stack=layer_stack,
                     force_python=force_python,
                     # Issue #4268: thread the mesh-router strategy selector through.
-                    strategy=getattr(args, "route_engine", "grid"),
+                    strategy=_resolve_route_engine(args),
                     validate_drc=not args.force,
                     strict_drc=False,
                     # Issue #3155: incremental routing.  When set, existing
@@ -6292,7 +6318,7 @@ def route_with_layer_escalation(
     if final_result.router.routes:
         _finalize_committed_copper_or_demote(final_result.router, quiet=quiet)
     _record_stage_quality(_stage_quality, STAGE_POST_FINALIZE, final_result.router)
-    _print_stage_quality_report(_stage_quality, quiet=quiet)
+    _print_stage_quality_report(_stage_quality)
 
     # Finalize: cleanup -> sexp -> stats (canonical ordering)
     _final_multi_pad_ids = {n for n, p in final_result.router.nets.items() if n > 0 and len(p) >= 2}
@@ -6673,7 +6699,7 @@ def route_with_rule_relaxation(
                     layer_stack=layer_stack,
                     force_python=force_python,
                     # Issue #4268: thread the mesh-router strategy selector through.
-                    strategy=getattr(args, "route_engine", "grid"),
+                    strategy=_resolve_route_engine(args),
                     validate_drc=not args.force,
                     strict_drc=False,
                     # Issue #3155: incremental routing (see route_with_layer_escalation).
@@ -7077,7 +7103,7 @@ def route_with_rule_relaxation(
     if final_result.router.routes:
         _finalize_committed_copper_or_demote(final_result.router, quiet=quiet)
     _record_stage_quality(_stage_quality, STAGE_POST_FINALIZE, final_result.router)
-    _print_stage_quality_report(_stage_quality, quiet=quiet)
+    _print_stage_quality_report(_stage_quality)
 
     # Finalize: cleanup -> sexp -> stats (canonical ordering)
     _final_multi_pad_ids = {n for n, p in final_result.router.nets.items() if n > 0 and len(p) >= 2}
@@ -8915,7 +8941,7 @@ def route_with_combined_escalation(
                         layer_stack=layer_stack,
                         force_python=force_python,
                         # Issue #4268: thread the mesh-router strategy selector through.
-                        strategy=getattr(args, "route_engine", "grid"),
+                        strategy=_resolve_route_engine(args),
                         validate_drc=not args.force,
                         strict_drc=False,
                         # Issue #3155: incremental routing (see route_with_layer_escalation).
@@ -9362,7 +9388,7 @@ def route_with_combined_escalation(
     if final_result.router.routes:
         _finalize_committed_copper_or_demote(final_result.router, quiet=quiet)
     _record_stage_quality(_stage_quality, STAGE_POST_FINALIZE, final_result.router)
-    _print_stage_quality_report(_stage_quality, quiet=quiet)
+    _print_stage_quality_report(_stage_quality)
 
     # Finalize: cleanup -> sexp -> stats (canonical ordering)
     _final_multi_pad_ids = {n for n, p in final_result.router.nets.items() if n > 0 and len(p) >= 2}
@@ -9569,7 +9595,7 @@ def _validate_route_engine_strategy(args) -> int:
     grid`` -- this gate is a strict no-op on the production default), or 2
     (usage error) with a message on stderr naming the remedy.
     """
-    engine = getattr(args, "route_engine", "grid")
+    engine = _resolve_route_engine(args)
     if engine == "grid":
         return 0
 
@@ -12829,7 +12855,7 @@ def _main_impl(argv: list[str] | None = None) -> int:
 
     # Issue #4605: rule areas are honored by the lattice engine only -- warn
     # once (never gate) when another engine is about to ignore them.
-    _warn_rule_areas_other_engine(pcb_path, getattr(args, "route_engine", "grid") or "grid")
+    _warn_rule_areas_other_engine(pcb_path, _resolve_route_engine(args))
 
     # Issue #4431 (Phase 1): validate and load the optional --voltage-map early
     # (mirrors the --net-class-map preload above) so a missing file / malformed
@@ -13000,7 +13026,7 @@ def _main_impl(argv: list[str] | None = None) -> int:
         # engine through so mesh/lattice runs do not receive advice that the
         # #4271 gate-skip line -- printed a few lines later in the same log --
         # simultaneously declares inapplicable.
-        _route_engine = getattr(args, "route_engine", "grid") or "grid"
+        _route_engine = _resolve_route_engine(args)
         grid_auto_result = auto_select_grid_resolution(
             pads=pad_positions,
             clearance=args.clearance,
@@ -13474,7 +13500,7 @@ def _main_impl(argv: list[str] | None = None) -> int:
             clearance=args.clearance,
             num_layers=layer_stack.num_layers,
             max_cells=getattr(args, "max_cells", 500_000),
-            engine=getattr(args, "route_engine", "grid") or "grid",
+            engine=_resolve_route_engine(args),
         )
         if dry_run_plan is not None:
             if not quiet:
@@ -13496,7 +13522,7 @@ def _main_impl(argv: list[str] | None = None) -> int:
                 layer_stack=layer_stack,
                 force_python=force_python,
                 # Issue #4268: thread the mesh-router strategy selector through.
-                strategy=getattr(args, "route_engine", "grid"),
+                strategy=_resolve_route_engine(args),
                 validate_drc=not args.force,
                 strict_drc=False,  # Only fail on hard constraint (grid > clearance)
                 # Issue #3155: incremental routing (see route_with_layer_escalation).
@@ -13570,7 +13596,7 @@ def _main_impl(argv: list[str] | None = None) -> int:
                 layer_stack=layer_stack,
                 force_python=force_python,
                 # Issue #4268: thread the mesh-router strategy selector through.
-                strategy=getattr(args, "route_engine", "grid"),
+                strategy=_resolve_route_engine(args),
                 validate_drc=not args.force,
                 strict_drc=False,
                 load_existing_routes=getattr(args, "preserve_existing", False),
@@ -13689,16 +13715,17 @@ def _main_impl(argv: list[str] | None = None) -> int:
     # its remedy is harmful here: refining the grid to 0.0635/0.025mm on a
     # 160x100mm board demands millions of cells the #4242 budget cap refuses.
     # Skip the analysis for non-grid engines and say why in one line.
-    _fine_pitch_engine = getattr(args, "route_engine", "grid") or "grid"
-    if not quiet and _fine_pitch_engine != "grid":
-        flush_print(
-            f"\n  Fine-pitch grid analysis: skipped for --route-engine "
-            f"{_fine_pitch_engine} (pads are reached by exact geometry, not by "
-            f"grid alignment)"
-        )
-    elif not quiet:
+    #
+    # Issue #4765: say it ONLY when the grid path would have said something.
+    # ``analyze_fine_pitch_components`` is read-only pad arithmetic (it builds
+    # no grid), so it is still called on the non-grid path -- reusing the exact
+    # ``has_warnings`` predicate the grid path gates its output on -- and its
+    # own output is suppressed.  A board with no fine-pitch findings therefore
+    # prints nothing on EVERY engine, instead of announcing the absence of
+    # output that would have been absent anyway (#4690 noise).
+    _fine_pitch_engine = _resolve_route_engine(args)
+    if not quiet:
         from kicad_tools.router.fine_pitch import analyze_fine_pitch_components
-        from kicad_tools.router.output import show_fine_pitch_warnings
 
         fine_pitch_report = analyze_fine_pitch_components(
             pads=router.pads,
@@ -13706,6 +13733,16 @@ def _main_impl(argv: list[str] | None = None) -> int:
             trace_width=_effective_trace_width(args),
             clearance=args.clearance,
         )
+    if not quiet and _fine_pitch_engine != "grid":
+        if fine_pitch_report.has_warnings:
+            flush_print(
+                f"\n  Fine-pitch grid analysis: skipped for --route-engine "
+                f"{_fine_pitch_engine} (pads are reached by exact geometry, not by "
+                f"grid alignment)"
+            )
+    elif not quiet:
+        from kicad_tools.router.output import show_fine_pitch_warnings
+
         if fine_pitch_report.has_warnings:
             # Issue #3441: ``use_waypoint_injection`` is backend-aware --
             # waypoint injection (#2330) only exists in the pure-Python
@@ -14044,7 +14081,7 @@ def _main_impl(argv: list[str] | None = None) -> int:
             # budget scaled by link count -- not as a per-net A* cutoff -- and
             # ``--timeout`` is a hard ceiling on that single negotiation.  Say
             # so, and say so loudly when neither bound is in force.
-            _banner_engine = getattr(args, "route_engine", "grid") or "grid"
+            _banner_engine = _resolve_route_engine(args)
             if args.timeout:
                 _cap_note = (
                     " (hard cap on the lattice negotiation)"
@@ -14063,10 +14100,31 @@ def _main_impl(argv: list[str] | None = None) -> int:
                 else:
                     flush_print(f"  Per-net timeout: {per_net_timeout_val}s")
             elif _banner_engine == "lattice" and not args.timeout:
-                flush_print(
-                    "  Per-net timeout: disabled (0) -- the lattice negotiation "
-                    "is UNBOUNDED; pass --timeout to cap it"
-                )
+                # Issue #4765: "UNBOUNDED" must be decided from the RESOLVED
+                # budgets, not the raw flags.  ``--complete`` stamps
+                # ``args._complete_link_budget_s`` (the 60s #4472 backstop)
+                # BEFORE this banner runs, and that stamp is what
+                # ``_resolve_lattice_link_budget`` threads into the
+                # negotiation -- so ``--complete --per-net-timeout 0`` IS
+                # bounded even though both flags read as "off".
+                _banner_link_budget = _resolve_lattice_link_budget(args)
+                if _banner_link_budget is not None:
+                    flush_print(
+                        f"  Per-net timeout: disabled (0) -- the lattice "
+                        f"negotiation is bounded at {_banner_link_budget:g}s "
+                        f"per link (netset deadline = {_banner_link_budget:g}s "
+                        f"x link count)"
+                    )
+                elif _lattice_absolute_deadline(args) is not None:
+                    flush_print(
+                        "  Per-net timeout: disabled (0) -- the lattice "
+                        "negotiation is bounded by this run's wall-clock deadline"
+                    )
+                else:
+                    flush_print(
+                        "  Per-net timeout: disabled (0) -- the lattice negotiation "
+                        "is UNBOUNDED; pass --timeout to cap it"
+                    )
             # Issue #2610: report the iteration backstop override if set.
             # Issue #2819: the inner parser now declares the flag (default=0),
             # so the attribute is guaranteed to exist; ``or 0`` preserves the
@@ -14689,7 +14747,7 @@ def _main_impl(argv: list[str] | None = None) -> int:
     if router.routes:
         _finalize_committed_copper_or_demote(router, quiet=quiet)
     _record_stage_quality(_stage_quality, STAGE_POST_FINALIZE, router)
-    _print_stage_quality_report(_stage_quality, quiet=quiet)
+    _print_stage_quality_report(_stage_quality)
 
     if _post_passes_enabled and router.routes:
         # Get post-optimization statistics

--- a/src/kicad_tools/drc/waivers.py
+++ b/src/kicad_tools/drc/waivers.py
@@ -105,6 +105,18 @@ def apply_waivers_to_report(report: DRCReport, waivers: Waivers) -> WaiverApplic
     (a 2-item waiver does not waive a 3-item finding) and, when the entry names
     ``nets``, on the violation's net set.  The first matching entry wins.
 
+    Caveat -- "exact-set" is exact over the NORMALIZED set, and
+    :func:`extract_item_refs` contributes nothing for a ref-less item
+    description such as ``"Track [GND] on F.Cu"`` or ``"Via [VBUS] on F.Cu"``.
+    A finding whose items are ``["Pad 1 of U3", "Track [GND] on F.Cu"]``
+    therefore normalizes to ``{"U3"}`` and IS matched by a one-item
+    ``items: ["U3"]`` entry -- i.e. such an entry waives a class of ``U3``
+    findings rather than the single reviewed one.  This is deliberate
+    (narrowing it would retroactively un-waive entries in existing sidecars,
+    issue #4765); an entry covering a finding with any ref-less item should
+    additionally constrain ``nets`` so it stays specific.  Pinned by
+    ``tests/test_cli_drc_waivers.py``.
+
     Waived violations keep their underlying ``severity`` (so severity-keyed
     consumers such as the ``kct audit`` manufacturing gate stay blocking) but
     report ``is_error is False``, which is what the ``kct drc`` exit gate reads.

--- a/src/kicad_tools/router/io.py
+++ b/src/kicad_tools/router/io.py
@@ -1128,9 +1128,12 @@ def auto_select_grid_resolution(
                 predicts a *grid-routing* failure mode, so it is demoted to an
                 INFO log for the mesh/lattice engines, which emit no copper
                 from the grid (the same predicate as the #4271 gate skip).
-                Purely a diagnostics gate -- every returned field, including
-                ``memory_forced_unsafe_grid``, is computed identically for
-                every engine.
+                Issue #4765 extends the same demotion to the sibling #3441
+                lattice-rescue ``UserWarning`` ("quantisation margin is
+                reduced at fine-pitch pads"), which predicts the same
+                grid-only failure mode.  Purely a diagnostics gate -- every
+                returned field, including ``memory_forced_unsafe_grid`` and
+                ``lattice_rescued``, is computed identically for every engine.
 
     Returns:
         GridAutoSelection with the chosen resolution and analysis details.
@@ -1454,16 +1457,35 @@ def auto_select_grid_resolution(
             # (DRC-sufficient per #2387) but > clearance/2, so keep an
             # honest -- and accurate -- heads-up rather than the "forced"
             # phrasing of the generic memory-cap warning.
-            warnings.warn(
+            rescue_prefix = (
                 f"Auto-grid: lattice rescue selected grid {best_resolution}mm "
                 f"(> clearance/2 = {recommended_max}mm, <= clearance = "
                 f"{clearance}mm) because it aligns the board's dominant pad "
                 f"lattice ({best_off_grid}/{total_pads} pads off-grid). "
-                f"Quantisation margin is reduced at fine-pitch pads; the "
-                f"router's edge-to-edge clearance enforcement is the "
-                f"backstop.",
-                stacklevel=2,
             )
+            if engine == "grid":
+                warnings.warn(
+                    rescue_prefix + "Quantisation margin is reduced at "
+                    "fine-pitch pads; the router's edge-to-edge clearance "
+                    "enforcement is the backstop.",
+                    stacklevel=2,
+                )
+            else:
+                # Issue #4765: same premise as the #4690 demotion below --
+                # the reduced-quantisation-margin prediction is a GRID
+                # routing failure mode, and under --route-engine mesh/lattice
+                # no copper is emitted from the grid, so it cannot apply.
+                # Keep the selection event observable at INFO instead of
+                # contradicting the gate-skip line printed in the same log.
+                # The rescue itself (and every returned field) is unchanged;
+                # only the reporting channel differs.
+                logger.info(
+                    "%s--route-engine %s routes on exact geometry (no copper "
+                    "is emitted from the grid), so no grid-quantisation "
+                    "clearance risk applies.",
+                    rescue_prefix,
+                    engine,
+                )
         elif has_fine_pitch and engine != "grid":
             # Issue #4690: the alarm below predicts a grid-routing failure mode
             # ("routing may produce clearance violations at fine-pitch pads")

--- a/src/kicad_tools/router/quality_probe.py
+++ b/src/kicad_tools/router/quality_probe.py
@@ -155,8 +155,10 @@ class StageQualityRecorder:
         lines = [header]
         for entry in self._stages:
             m = entry.metrics
-            nonzero = m.total_segments - m.zero_length_count
-            diag_pct = (m.diagonal_45_count / nonzero * 100.0) if nonzero else 0.0
+            # Issue #4765: the zero-length-excluded denominator is owned by
+            # RoutingQualityMetrics (like fragment_fraction / staircase_fraction),
+            # not reconstructed here.
+            diag_pct = m.diagonal_45_fraction * 100.0
             lines.append(
                 f"  {entry.stage:<14} {m.total_segments:>7d} "
                 f"{m.fragment_fraction * 100.0:>7.1f} "

--- a/tests/test_at_angle_residue.py
+++ b/tests/test_at_angle_residue.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -27,7 +28,8 @@ from kicad_tools.recovery import (
     StrategyApplicator,
     StrategyType,
 )
-from kicad_tools.schema.pcb import PCB
+from kicad_tools.schema.pcb import PCB, _sync_at_angle
+from kicad_tools.sexp.parser import SExp, parse_string
 
 _BOARD_TEMPLATE = """(kicad_pcb
 	(version 20260206)
@@ -153,6 +155,46 @@ class TestRotationWriteThroughResidue:
         lines = _at_lines(_saved(pcb, path))
         assert "(at 100 100 0)" in lines
         assert "(at 0 0 0)" in lines
+
+
+class TestExtraTrailingTokensAreNeverTrimmed:
+    """Issue #4765: the documented 4+-children non-trim path had no test.
+
+    ``_sync_at_angle`` only deletes the angle token from a node with EXACTLY
+    three children (``x y angle``).  A node carrying extra trailing tokens is
+    left structurally intact even when the write-through owns the angle token
+    and the angle returns to zero -- deleting index 2 there would corrupt the
+    node by shifting the trailing tokens into the angle slot.
+    """
+
+    @staticmethod
+    def _at_node(text: str) -> SExp:
+        return parse_string(text)
+
+    def test_four_token_node_keeps_all_children_when_angle_returns_to_zero(self):
+        node = self._at_node("(at 1 2 45 unlocked)")
+        owner = SimpleNamespace()
+        owner.__dict__["_at_angle_synthetic"] = True
+
+        _sync_at_angle(owner, node, 0.0)
+
+        assert len(node.children) == 4
+        assert node.children[2].value == 0.0
+        # The trailing token is untouched and the synthetic flag is retained
+        # (nothing was trimmed, so nothing was "given back").
+        assert node.children[3].value == "unlocked"
+        assert owner.__dict__["_at_angle_synthetic"] is True
+
+    def test_three_token_node_is_still_trimmed(self):
+        """The control: the same inputs minus the trailing token DO trim."""
+        node = self._at_node("(at 1 2 45)")
+        owner = SimpleNamespace()
+        owner.__dict__["_at_angle_synthetic"] = True
+
+        _sync_at_angle(owner, node, 0.0)
+
+        assert len(node.children) == 2
+        assert owner.__dict__["_at_angle_synthetic"] is False
 
 
 class TestMirrorRoundTripLeavesNoResidue:

--- a/tests/test_cli_drc_waivers.py
+++ b/tests/test_cli_drc_waivers.py
@@ -442,3 +442,139 @@ class TestReportModelUnaffected:
         again = apply_waivers_to_report(report, waivers)
         assert again.waived_count == 0
         assert len(again.unused) == 1
+
+
+# Two clearance findings that involve the SAME footprint ref (U3) against a
+# ref-less track item, on different nets.  ``extract_item_refs`` drops the
+# track, so both normalize to the identical ref set {"U3"}.
+_TWO_MIXED_FINDINGS: dict = {
+    **RECORDED_REPORT,
+    "violations": [
+        {
+            "type": "clearance",
+            "severity": "error",
+            "description": "Clearance violation (GND)",
+            "items": [
+                {"description": "Pad 1 [VBUS] of U3 on F.Cu", "uuid": "1", "pos": {}},
+                {"description": "Track [GND] on F.Cu", "uuid": "2", "pos": {}},
+            ],
+        },
+        {
+            "type": "clearance",
+            "severity": "error",
+            "description": "Clearance violation (SCL)",
+            "items": [
+                {"description": "Pad 2 [SDA] of U3 on F.Cu", "uuid": "3", "pos": {}},
+                {"description": "Track [SCL] on F.Cu", "uuid": "4", "pos": {}},
+            ],
+        },
+    ],
+}
+
+
+class TestPartiallyReflessFindings:
+    """Issue #4765: "exact-set" is exact over the NORMALIZED ref set.
+
+    A track/via item contributes no reference designator, so a finding that
+    mixes a pad with a track normalizes to a SMALLER set than its item count
+    suggests and is matched by a correspondingly small waiver.  That is
+    deliberate -- narrowing it would retroactively un-waive existing
+    sidecars -- so these tests pin the behaviour and demonstrate the ``nets``
+    remedy that keeps such an entry specific.
+    """
+
+    def test_refless_item_is_dropped_from_the_normalized_set(self):
+        assert extract_item_refs(["Pad 1 of U3", "Track [GND] on F.Cu"]) == {"U3"}
+
+    def test_one_ref_waiver_matches_the_mixed_finding(self, tmp_path, capsys):
+        report = _report(tmp_path, data=_TWO_MIXED_FINDINGS)
+        waiver = _waivers(
+            tmp_path / "w.json",
+            [{"rule": "clearance", "items": ["U3"], "reason": "reviewed", "issue": "#4765"}],
+        )
+        rc = drc_cmd.main([str(report), "--waivers", str(waiver), "--format", "json"])
+        data = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        # Documented consequence: the entry waives the whole CLASS of U3
+        # clearance findings, not only the one that was reviewed.
+        assert data["summary"]["waived"] == 2
+
+    def test_adding_nets_narrows_the_same_waiver_to_one_finding(self, tmp_path, capsys):
+        report = _report(tmp_path, data=_TWO_MIXED_FINDINGS)
+        waiver = _waivers(
+            tmp_path / "w.json",
+            [
+                {
+                    "rule": "clearance",
+                    "items": ["U3"],
+                    "nets": ["VBUS", "GND"],
+                    "reason": "reviewed",
+                    "issue": "#4765",
+                }
+            ],
+        )
+        rc = drc_cmd.main([str(report), "--waivers", str(waiver), "--format", "json"])
+        data = json.loads(capsys.readouterr().out)
+        assert rc == 1  # the SCL/SDA finding is NOT waived
+        assert data["summary"]["waived"] == 1
+        waived = [v for v in data["violations"] if v.get("waived")]
+        assert waived[0]["nets"] == ["VBUS", "GND"]
+
+
+class TestReportInputDiscoversBoardDir:
+    """Issue #4765: ``boards/NN/output/drc.json`` must find ``boards/NN/``.
+
+    ``discover_waivers_sidecar`` is anchored at the input path, which for
+    report input is the report -- so its three probes collapse to the report
+    directory and ``<report dir>/output/``, never the board directory where
+    the sidecar lives for the ``.kicad_pcb`` path.
+    """
+
+    def _board_layout(self, tmp_path):
+        board_dir = tmp_path / "boards" / "07"
+        (board_dir / "output").mkdir(parents=True)
+        report = _report(board_dir / "output", data=RECORDED_REPORT)
+        return board_dir, report
+
+    def test_board_dir_sidecar_is_discovered_for_report_input(self, tmp_path, capsys):
+        board_dir, report = self._board_layout(tmp_path)
+        sidecar = _waivers(board_dir / ".kct_waivers.json", [COURTYARD_WAIVER, CLEARANCE_WAIVER])
+        rc = drc_cmd.main([str(report)])
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert f"auto-loaded waivers sidecar: {sidecar}" in captured.err
+        assert "Waived:     2" in captured.out
+
+    def test_report_dir_sidecar_still_wins_over_the_board_dir(self, tmp_path, capsys):
+        board_dir, report = self._board_layout(tmp_path)
+        _waivers(board_dir / ".kct_waivers.json", [COURTYARD_WAIVER, CLEARANCE_WAIVER])
+        nearer = _waivers(board_dir / "output" / ".kct_waivers.json", [COURTYARD_WAIVER])
+        rc = drc_cmd.main([str(report)])
+        captured = capsys.readouterr()
+        assert rc == 1  # only the courtyard finding is waived by the nearer file
+        assert f"auto-loaded waivers sidecar: {nearer}" in captured.err
+
+    def test_explicit_path_still_wins(self, tmp_path, capsys):
+        board_dir, report = self._board_layout(tmp_path)
+        _waivers(board_dir / ".kct_waivers.json", [COURTYARD_WAIVER, CLEARANCE_WAIVER])
+        explicit = _waivers(tmp_path / "explicit.json", [COURTYARD_WAIVER])
+        rc = drc_cmd.main([str(report), "--waivers", str(explicit)])
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "auto-loaded waivers sidecar" not in captured.err
+        assert "Waived:     1" in captured.out
+
+    def test_missing_explicit_path_is_still_a_hard_error(self, tmp_path, capsys):
+        board_dir, report = self._board_layout(tmp_path)
+        _waivers(board_dir / ".kct_waivers.json", [COURTYARD_WAIVER])
+        rc = drc_cmd.main([str(report), "--waivers", str(tmp_path / "nope.json")])
+        assert rc == 1
+        assert "waivers file not found" in capsys.readouterr().err
+
+    def test_no_sidecar_anywhere_is_unchanged(self, tmp_path, capsys):
+        _board_dir, report = self._board_layout(tmp_path)
+        rc = drc_cmd.main([str(report)])
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "auto-loaded waivers sidecar" not in captured.err
+        assert "Errors:     2" in captured.out

--- a/tests/test_lattice_timeout_forwarding.py
+++ b/tests/test_lattice_timeout_forwarding.py
@@ -324,6 +324,34 @@ class TestBannerHonesty:
         captured = capsys.readouterr().out
         assert "Timeout: 0.001s (hard cap on the lattice negotiation)" in captured
 
+    def test_complete_backstop_is_reported_instead_of_unbounded(self, board, tmp_path, capsys):
+        """Issue #4765: ``--complete --per-net-timeout 0`` IS bounded.
+
+        ``_apply_complete_localization`` stamps the 60 s #4472 backstop on
+        ``args._complete_link_budget_s`` BEFORE the banner runs, and
+        ``_resolve_lattice_link_budget`` threads that value into the
+        negotiation -- so keying the banner off the raw flags claimed the
+        exact opposite of what the run does.
+        """
+        out = tmp_path / "out.kicad_pcb"
+        _lattice_route(board, out, "--complete", "--per-net-timeout", "0")
+        captured = capsys.readouterr().out.replace("\n", " ")
+        assert "UNBOUNDED" not in captured
+        assert (
+            f"the lattice negotiation is bounded at "
+            f"{_COMPLETE_LINK_BUDGET_DEFAULT_S:g}s per link" in captured
+        )
+
+    def test_unbounded_line_is_byte_identical_without_the_stamp(self, board, tmp_path, capsys):
+        """No stamp + no --timeout still prints the original wording."""
+        out = tmp_path / "out.kicad_pcb"
+        assert _lattice_route(board, out, "--per-net-timeout", "0") == 0
+        captured = capsys.readouterr().out
+        assert (
+            "  Per-net timeout: disabled (0) -- the lattice negotiation "
+            "is UNBOUNDED; pass --timeout to cap it" in captured
+        )
+
     def test_grid_banner_is_unannotated(self, board, tmp_path, capsys):
         out = tmp_path / "out.kicad_pcb"
         route_main(

--- a/tests/test_route_consolidation_pass.py
+++ b/tests/test_route_consolidation_pass.py
@@ -283,6 +283,65 @@ class TestStageQualityRecorder:
         assert payload["stages"][0]["stage"] == STAGE_PRE_OPTIMIZE
         assert payload["stages"][0]["staircase_fraction"] == 1.0
 
+    def test_45deg_percentage_comes_from_the_metrics_property(self):
+        """Issue #4765: the denominator lives on RoutingQualityMetrics.
+
+        The rendered ``45deg%`` column must equal
+        ``diagonal_45_fraction * 100`` -- i.e. the formatter no longer
+        reconstructs the zero-length-excluded denominator that the dataclass
+        already owns for ``fragment_fraction`` / ``staircase_fraction``.
+        """
+        rec = StageQualityRecorder()
+        rec.record(STAGE_PRE_OPTIMIZE, [_route(_staircase_router_segments())])
+        rec.record(STAGE_POST_OPTIMIZE, [_route([_router_seg((0.0, 0.0), (0.9, 0.9))])])
+        for stage in (STAGE_PRE_OPTIMIZE, STAGE_POST_OPTIMIZE):
+            m = rec.get(stage)
+            assert m is not None
+            nonzero = m.total_segments - m.zero_length_count
+            expected = (m.diagonal_45_count / nonzero) if nonzero else 0.0
+            assert m.diagonal_45_fraction == pytest.approx(expected)
+        # The 45-degree route renders as 100.0 in the table; the staircase as 0.0.
+        report_lines = rec.format_report().splitlines()
+        pre_line = next(
+            line for line in report_lines if line.strip().startswith(STAGE_PRE_OPTIMIZE)
+        )
+        post_line = next(
+            line for line in report_lines if line.strip().startswith(STAGE_POST_OPTIMIZE)
+        )
+        assert pre_line.split()[4] == "0.0"
+        assert post_line.split()[4] == "100.0"
+
+    def test_45deg_fraction_is_zero_when_every_segment_is_zero_length(self):
+        """The all-zero-length denominator returns 0.0 rather than raising."""
+        from kicad_tools.analysis.routing_quality import RoutingQualityMetrics
+
+        m = RoutingQualityMetrics(
+            total_segments=3,
+            nets_with_copper=1,
+            segments_per_net=3.0,
+            zero_length_count=3,
+            median_length_mm=0.0,
+            fragment_count=0,
+            fragment_fraction=0.0,
+            orthogonal_count=0,
+            diagonal_45_count=0,
+            off_axis_count=0,
+            staircase_step_count=0,
+            staircase_fraction=0.0,
+        )
+        assert m.diagonal_45_fraction == 0.0
+
+    def test_45deg_fraction_is_not_a_serialized_field(self):
+        """Scope guard: ``to_dict()`` is a stable JSON contract."""
+        from kicad_tools.analysis.routing_quality import RoutingQualityMetrics
+
+        rec = StageQualityRecorder()
+        rec.record(STAGE_PRE_OPTIMIZE, [_route(_staircase_router_segments())])
+        m = rec.get(STAGE_PRE_OPTIMIZE)
+        assert m is not None
+        assert "diagonal_45_fraction" not in m.to_dict()
+        assert "diagonal_45_fraction" not in RoutingQualityMetrics.__dataclass_fields__
+
     def test_recorder_does_not_mutate_routes(self):
         """The probe is read-only -- that is what makes it copper-safe."""
         segments = _staircase_router_segments()
@@ -427,13 +486,42 @@ class TestRouteCmdHelpers:
         route_cmd._record_stage_quality(recorder, STAGE_PRE_OPTIMIZE, None)
         assert recorder.stages == []
 
-    def test_print_is_silent_when_quiet(self, capsys):
+    def test_print_survives_quiet(self, capsys):
+        """Issue #4765: an explicit --report-stage-quality outranks --quiet.
+
+        A non-None recorder can only exist when the user asked for the
+        report, so suppressing it under ``--quiet`` discarded an explicit
+        opt-in silently.  ``quiet`` is still accepted and ignored.
+        """
         from kicad_tools.cli import route_cmd
 
         recorder = StageQualityRecorder()
         recorder.record(STAGE_PRE_OPTIMIZE, [_route(_staircase_router_segments())])
         route_cmd._print_stage_quality_report(recorder, quiet=True)
+        assert "Routing quality by stage" in capsys.readouterr().out
+
+    def test_print_is_a_noop_when_disabled_even_without_quiet(self, capsys):
+        """The default path is unchanged: no flag => no recorder => no output."""
+        from kicad_tools.cli import route_cmd
+
+        route_cmd._print_stage_quality_report(None, quiet=True)
+        route_cmd._print_stage_quality_report(None, quiet=False)
         assert capsys.readouterr().out == ""
+
+    def test_recorder_import_is_not_function_local(self):
+        """Issue #4765: the recorder is imported at module scope.
+
+        ``route_cmd`` already imports the stage constants from
+        ``quality_probe`` eagerly, so the whole module is executed at import
+        time and a function-local import bought nothing.
+        """
+        import inspect
+
+        from kicad_tools.cli import route_cmd
+
+        source = inspect.getsource(route_cmd._make_stage_quality_recorder)
+        assert "import" not in source
+        assert route_cmd.StageQualityRecorder is StageQualityRecorder
 
     def test_print_emits_the_table(self, capsys):
         from kicad_tools.cli import route_cmd

--- a/tests/test_route_grid_safety_gate.py
+++ b/tests/test_route_grid_safety_gate.py
@@ -22,7 +22,10 @@ grid``.
 """
 
 import logging
+import re
 import warnings
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -277,6 +280,86 @@ def test_memory_cap_event_still_observable_at_info_for_non_grid(engine, caplog):
     ), messages
 
 
+# ---------------------------------------------------------------------------
+# Issue #4765: the sibling #3441 lattice-rescue warning gets the same gate
+#
+# NOTE: ``lattice_rescued`` is the #3441 PAD-LATTICE GRID rescue (grid
+# alignment to the board's dominant pad lattice).  It has nothing to do with
+# ``--route-engine lattice``.
+# ---------------------------------------------------------------------------
+
+
+def _lattice_rescue_pads() -> list[PadPosition]:
+    """The #3441 reproducer: a dominant 0.1mm lattice + a small off-lattice
+    cluster, so the rescue adopts 0.1mm (> clearance/2 = 0.075mm)."""
+    pads = [PadPosition(x=10.0 + i * 0.7, y=20.0 + j * 0.9) for i in range(10) for j in range(6)]
+    pads += [PadPosition(x=60.635 + k * 1.27, y=50.635) for k in range(6)]
+    return pads
+
+
+def _select_lattice_rescued(**kwargs) -> tuple[GridAutoSelection, list[str]]:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = auto_select_grid_resolution(
+            _lattice_rescue_pads(),
+            clearance=0.15,
+            board_width=100.0,
+            board_height=100.0,
+            max_cells=500_000,
+            candidates=[0.5, 0.25, 0.127, 0.1, 0.065, 0.05, 0.0508],
+            **kwargs,
+        )
+    return result, [str(w.message) for w in caught]
+
+
+def test_lattice_rescue_warning_fires_for_grid_engine():
+    """The #3441 heads-up is unchanged where it applies."""
+    result, texts = _select_lattice_rescued(engine="grid")
+    assert result.lattice_rescued is True
+    assert any("lattice rescue selected grid" in t for t in texts), texts
+    assert any("Quantisation margin is reduced at fine-pitch pads" in t for t in texts), texts
+
+
+def test_lattice_rescue_warning_fires_for_default_engine():
+    """Callers that do not pass ``engine`` keep the pre-#4765 behavior."""
+    _result, texts = _select_lattice_rescued()
+    assert any("Quantisation margin is reduced at fine-pitch pads" in t for t in texts), texts
+
+
+@pytest.mark.parametrize("engine", _NON_GRID_ENGINES)
+def test_lattice_rescue_warning_suppressed_for_non_grid_engines(engine):
+    """The reduced-quantisation-margin prediction is a GRID failure mode.
+
+    Under mesh/lattice no copper comes off the grid, so predicting reduced
+    quantisation margin at fine-pitch pads contradicts the gate-skip line in
+    the same log -- the identical premise #4690 accepted for the sibling
+    memory-cap branch.
+    """
+    result, texts = _select_lattice_rescued(engine=engine)
+    assert result.lattice_rescued is True
+    assert not any("lattice rescue selected grid" in t for t in texts), texts
+    assert not any("Quantisation margin is reduced" in t for t in texts), texts
+
+
+@pytest.mark.parametrize("engine", _NON_GRID_ENGINES)
+def test_lattice_rescue_event_still_observable_at_info(engine, caplog):
+    """Suppressed, not silenced."""
+    with caplog.at_level(logging.INFO, logger="kicad_tools.router.io"):
+        _select_lattice_rescued(engine=engine)
+    messages = [rec.getMessage() for rec in caplog.records]
+    assert any(
+        "lattice rescue selected grid" in m and f"--route-engine {engine}" in m for m in messages
+    ), messages
+
+
+@pytest.mark.parametrize("engine", _NON_GRID_ENGINES)
+def test_lattice_rescue_selection_is_engine_invariant(engine):
+    """Diagnostics-only: every returned field matches the grid engine's."""
+    grid_result, _ = _select_lattice_rescued(engine="grid")
+    other_result, _ = _select_lattice_rescued(engine=engine)
+    assert other_result == grid_result
+
+
 @pytest.mark.parametrize("engine", _NON_GRID_ENGINES)
 def test_multi_resolution_plan_forwards_engine_to_selector(engine):
     """``compute_multi_resolution_plan`` is the adaptive-strategy call path."""
@@ -395,6 +478,39 @@ _OFF_GRID_ROUTABLE_PCB = """(kicad_pcb
   )
 )"""
 
+# Issue #4765: the same board with every pad ON the 0.15mm grid, so
+# ``analyze_fine_pitch_components`` reports ``has_warnings is False`` and the
+# GRID path prints nothing at all.  The non-grid path must print nothing
+# either -- announcing the skip of an analysis that had nothing to say is
+# noise the grid engine never emits.
+_ON_GRID_COARSE_PCB = """(kicad_pcb
+  (version 20240108)
+  (generator "test")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (gr_rect (start 100 100) (end 130 120) (layer "Edge.Cuts"))
+  (net 0 "")
+  (net 1 "NET1")
+  (net 2 "NET2")
+  (footprint "U1"
+    (layer "F.Cu")
+    (at 105 105)
+    (fp_text reference "U1" (at 0 0) (layer "F.SilkS"))
+    (pad "1" smd rect (at 0 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "NET1"))
+    (pad "2" smd rect (at 1.5 0) (size 0.6 0.6) (layers "F.Cu") (net 2 "NET2"))
+  )
+  (footprint "U2"
+    (layer "F.Cu")
+    (at 120 115.5)
+    (fp_text reference "U2" (at 0 0) (layer "F.SilkS"))
+    (pad "1" smd rect (at 0 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "NET1"))
+    (pad "2" smd rect (at 1.5 0) (size 0.6 0.6) (layers "F.Cu") (net 2 "NET2"))
+  )
+)"""
+
 # Every grid-quality string the lattice log must not contain.
 _GRID_ADVISORY_MARKERS = [
     "Fine-Pitch Component Analysis",
@@ -406,7 +522,7 @@ _GRID_ADVISORY_MARKERS = [
 ]
 
 
-def _route_cli(tmp_path, extra_args) -> tuple[int, list[str]]:
+def _route_cli(tmp_path, extra_args, board: str = _OFF_GRID_ROUTABLE_PCB) -> tuple[int, list[str]]:
     """Run ``route_cmd.main`` past the fine-pitch block on a tiny board.
 
     ``--layers 2`` pins the fixed-layer path (``--auto-layers`` diverts to
@@ -414,7 +530,7 @@ def _route_cli(tmp_path, extra_args) -> tuple[int, list[str]]:
     Returns the exit code and the texts of any ``warnings.warn`` emissions.
     """
     pcb_file = tmp_path / "off_grid.kicad_pcb"
-    pcb_file.write_text(_OFF_GRID_ROUTABLE_PCB)
+    pcb_file.write_text(board)
     out = tmp_path / "routed.kicad_pcb"
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
@@ -473,3 +589,78 @@ def test_quiet_emits_no_fine_pitch_output_on_any_engine(tmp_path, engine, capsys
     combined = captured.out + captured.err
     for marker in [*_GRID_ADVISORY_MARKERS, "Fine-pitch grid analysis: skipped"]:
         assert marker not in combined, f"--quiet leaked {marker!r} on {engine}"
+
+
+# ---------------------------------------------------------------------------
+# Issue #4765: the skip line must not out-talk the grid path it replaces
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("engine", _NON_GRID_ENGINES)
+def test_skip_line_absent_when_the_board_has_no_fine_pitch_findings(tmp_path, engine, capsys):
+    """A clean board prints nothing on the grid path -- so nothing here either."""
+    _route_cli(
+        tmp_path,
+        ["--route-engine", engine, "--strategy", "basic"],
+        board=_ON_GRID_COARSE_PCB,
+    )
+    combined = "".join(capsys.readouterr())
+    # Sanity: the run really did reach the fine-pitch block.
+    assert "Total nets:" in combined
+    assert "Fine-pitch grid analysis: skipped" not in combined
+
+
+def test_clean_board_grid_output_is_unchanged(tmp_path, capsys):
+    """The control: the grid engine says nothing about a clean board either."""
+    _route_cli(tmp_path, [], board=_ON_GRID_COARSE_PCB)
+    combined = "".join(capsys.readouterr())
+    for marker in _GRID_ADVISORY_MARKERS:
+        assert marker not in combined, f"clean board emitted {marker!r} on the grid engine"
+
+
+@pytest.mark.parametrize("engine", _NON_GRID_ENGINES)
+def test_skip_line_still_prints_when_findings_exist(tmp_path, engine, capsys):
+    """...and the line keeps its exact wording when there IS something to skip."""
+    _route_cli(tmp_path, ["--route-engine", engine, "--strategy", "basic"])
+    combined = "".join(capsys.readouterr())
+    assert (
+        f"Fine-pitch grid analysis: skipped for --route-engine {engine} (pads are "
+        f"reached by exact geometry, not by grid alignment)" in combined.replace("\n", " ")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Issue #4765: one normalization helper for every ``route_engine`` read
+# ---------------------------------------------------------------------------
+
+
+class TestResolveRouteEngine:
+    def test_missing_attribute_defaults_to_grid(self):
+        assert route_cmd._resolve_route_engine(SimpleNamespace()) == "grid"
+
+    def test_none_normalizes_to_grid(self):
+        """The inconsistency this helper removes: six sites returned None here."""
+        assert route_cmd._resolve_route_engine(SimpleNamespace(route_engine=None)) == "grid"
+
+    def test_empty_string_normalizes_to_grid(self):
+        assert route_cmd._resolve_route_engine(SimpleNamespace(route_engine="")) == "grid"
+
+    @pytest.mark.parametrize("engine", ["grid", "mesh", "lattice"])
+    def test_explicit_engine_is_returned_verbatim(self, engine):
+        assert route_cmd._resolve_route_engine(SimpleNamespace(route_engine=engine)) == engine
+
+    def test_no_bare_route_engine_reads_remain(self):
+        """Every read goes through the helper.
+
+        The only surviving ``getattr(args, "route_engine", ...)`` calls are the
+        helper's own body and the ``--complete`` engine-selection block, which
+        compares against ``parser.get_default("route_engine")`` to detect "the
+        user did not choose" -- a different question that must NOT be
+        normalized away.
+        """
+        source = Path(route_cmd.__file__).read_text()
+        reads = re.findall(r'getattr\(args, "route_engine"[^)]*\)', source)
+        assert reads == [
+            'getattr(args, "route_engine", "grid")',
+            'getattr(args, "route_engine", engine_default)',
+        ], reads


### PR DESCRIPTION
## Summary

Eight of the nine curated polish items from the 2026-08-08/09 sweep's judge nits, in one PR. Each is independently justified and localized; none changes routed copper, an exit code, or a JSON contract.

**Item G is declined** — the nit's premise does not survive re-measurement (details below, with the measurement). The two dropped items and the split-out lattice-cap item are **not** implemented, and the `#4776` scope guard is honored: `_post_negotiation_sweep_bounds`, `_active_expansion_cap` and the `route_with_placement_feedback` call sites are untouched (`git diff` contains none of those symbols).

## Changes

| Item | File | Change |
|---|---|---|
| A | `src/kicad_tools/cli/route_cmd.py` (`_main_impl` banner) | The `UNBOUNDED` line is now decided from `_resolve_lattice_link_budget(args)` / `_lattice_absolute_deadline(args)` instead of the raw flags |
| B | `src/kicad_tools/cli/route_cmd.py` (`_print_stage_quality_report`) | Dropped the `quiet` short-circuit (kwarg kept, accepted-and-ignored); dropped `quiet=quiet` at the four call sites |
| C | `src/kicad_tools/cli/route_cmd.py` (module imports, `_make_stage_quality_recorder`) | `StageQualityRecorder` hoisted into the existing module-scope `quality_probe` import; comment corrected |
| D | `src/kicad_tools/analysis/routing_quality.py`, `src/kicad_tools/router/quality_probe.py` | New read-only `RoutingQualityMetrics.diagonal_45_fraction` **property**; `format_report` renders it |
| E | `src/kicad_tools/drc/waivers.py`, `docs/reference/cli.md` | Documented the partially-ref-less caveat + the `nets` remedy; pinning tests. No semantics change |
| F | `src/kicad_tools/cli/drc_cmd.py` (`_load_waivers`) | Report input falls back to the report directory's **parent** when discovering `.kct_waivers.json` |
| H | `tests/test_at_angle_residue.py` | First test for the documented 4+-children `(at ...)` non-trim path |
| I | `src/kicad_tools/router/io.py` (`auto_select_grid_resolution`) | The `lattice_rescued` `UserWarning` is demoted to `logger.info` when `engine != "grid"` |
| J | `src/kicad_tools/cli/route_cmd.py` | New `_resolve_route_engine` helper; all 16 reads routed through it |
| K | `src/kicad_tools/cli/route_cmd.py` (fine-pitch block) | Shape **(i)**: still calls `analyze_fine_pitch_components` on the non-grid path, suppresses its output, and gates the skip line on `fine_pitch_report.has_warnings` |

Plus a `CHANGELOG.md` entry in the first `### Fixed` block under `## [Unreleased]`.

## Acceptance Criteria Verification

### A — banner reports the armed budget

A/B on the `STRANDED_BOARD` fixture, `--route-engine lattice --complete --per-net-timeout 0 --layers 2` (same argv, `main`'s `src/` vs this branch's):

```
BEFORE:  Per-net timeout: disabled (0) -- the lattice negotiation is UNBOUNDED; pass --timeout to cap it
AFTER :  Per-net timeout: disabled (0) -- the lattice negotiation is bounded at 60s per link (netset deadline = 60s x link count)
```

- [x] Budget armed ⇒ the banner reports it and contains no `UNBOUNDED` (`test_complete_backstop_is_reported_instead_of_unbounded`)
- [x] No stamp, no `--timeout` ⇒ the original line prints byte-identically (`test_unbounded_line_is_byte_identical_without_the_stamp` asserts the exact two-line string)
- [x] Grid/mesh banner untouched — the change is confined to the `elif _banner_engine == "lattice"` branch (`test_grid_banner_is_unannotated` unchanged and green)

### B — `--report-stage-quality` outranks `--quiet`

- [x] `_print_stage_quality_report(recorder, quiet=True)` prints the table (`test_print_survives_quiet`)
- [x] `_print_stage_quality_report(None, quiet=False)` still prints nothing (`test_print_is_a_noop_when_disabled_even_without_quiet`, both quiet values)
- [x] A `--quiet` run without the flag is byte-identical: the recorder is `None`, so the first guard returns before any output. The `--quiet`-on-every-engine test in `tests/test_route_grid_safety_gate.py` stays green unmodified

The existing `test_print_is_silent_when_quiet` **is** the old behaviour, so it is rewritten rather than kept — it is the only pre-existing test this PR modifies.

### C — no fake-lazy import

- [x] `rg 'from kicad_tools.router.quality_probe import' src/kicad_tools/cli/route_cmd.py` → the module-scope import only; `test_recorder_import_is_not_function_local` asserts `_make_stage_quality_recorder`'s source contains no `import`
- [x] The comment no longer claims lazy construction (it now states that flag-gating applies to *construction*, not to the import)
- [x] `TestRouteCmdHelpers::test_recorder_is_none_without_the_flag` / `test_recorder_is_built_with_the_flag` unchanged and green

### D — the fraction lives on the metrics type

- [x] `diagonal_45_fraction` is a property; `to_dict()` keys/values unchanged (`test_45deg_fraction_is_not_a_serialized_field` asserts both `to_dict()` and `__dataclass_fields__`)
- [x] `format_report()` renders the same numbers (`test_45deg_percentage_comes_from_the_metrics_property` checks the rendered column against `diagonal_45_fraction * 100` for a staircase stage → `0.0` and a 45° stage → `100.0`)
- [x] `total_segments == zero_length_count` returns `0.0` rather than raising (`test_45deg_fraction_is_zero_when_every_segment_is_zero_length`)

### E — partially-ref-less findings (docs + pinning tests only)

- [x] `["Pad 1 [VBUS] of U3 on F.Cu", "Track [GND] on F.Cu"]` is waived by `{"rule": "clearance", "items": ["U3"]}` — and so is a *second* same-rule `U3` finding on `SDA/SCL`, which is the point: `waived == 2` (`test_one_ref_waiver_matches_the_mixed_finding`)
- [x] Adding `"nets": ["VBUS", "GND"]` narrows it to `waived == 1`, exit 1 (`test_adding_nets_narrows_the_same_waiver_to_one_finding`)
- [x] `docs/reference/cli.md` documents the caveat and the remedy — prose plus a symbol-free description, no `<file>.py:NNN` citation (the #4774 guards `tests/test_docs_source_citations.py`, `tests/test_diffpair_docs.py`, `tests/test_match_group_docs.py` are green)
- [x] `Waiver.matches_normalized` and `extract_item_refs` are not in the diff

### F — report input finds the board dir

Manual verification with `boards/07/output/drc.json` + `boards/07/.kct_waivers.json` (scratch tree, one waived `courtyards_overlap`):

```
BEFORE (main src):    Errors: 1   exit=1      (no "auto-loaded waivers sidecar" line)
AFTER  (this branch): [INFO] auto-loaded waivers sidecar: .../boards/07/.kct_waivers.json
                      Errors: 0   Waived: 1   exit=0
```

- [x] Auto-discovery reaches `boards/NN/.kct_waivers.json` (`test_board_dir_sidecar_is_discovered_for_report_input`)
- [x] A nearer `output/` sidecar still wins (`test_report_dir_sidecar_still_wins_over_the_board_dir`); explicit `--waivers` still wins (`test_explicit_path_still_wins`); a missing explicit path is still a hard error (`test_missing_explicit_path_is_still_a_hard_error`); no sidecar anywhere is unchanged (`test_no_sidecar_anywhere_is_unchanged`)
- [x] `discover_waivers_sidecar` is untouched, so `.kicad_pcb` ordering and `kct check --waivers` are unaffected (`tests/test_cli_check_waivers.py`, `tests/test_validate_waivers.py` green)

### G — DECLINED (the nit's premise does not reproduce)

The issue says the comment misattributes ~2.5 ms because `kicad_tools.benchmark` "is already imported unconditionally by `kicad_tools.cli.commands.benchmark`". Re-measured on this branch — **that is not true**. `src/kicad_tools/cli/commands/benchmark.py` imports the benchmark package only *inside function bodies*; `src/kicad_tools/cli/parser.py` is the only module-scope importer in the tree:

```
$ rg -n '^\s*(from|import)\s+.*benchmark' src/kicad_tools --glob '!**/benchmark/**'
src/kicad_tools/cli/parser.py:17:from kicad_tools.benchmark.cases import Difficulty    # <- column 0
src/kicad_tools/cli/commands/benchmark.py:44,117,204,290                              # <- all indented
src/kicad_tools/cli/commands/__init__.py:19:from .benchmark import run_benchmark_command   # the CLI module, not the package
```

An `__import__` tracer confirms the first importer of `kicad_tools.benchmark*` during `import kicad_tools` is `cli/parser.py` line 17, and `python -X importtime -c "import kicad_tools"` (5 runs) puts that import's **cumulative** cost at **2040 / 2062 / 2186 / 2098 / 2059 µs** against a total `kicad_tools` cumulative of 272–288 ms — i.e. ~2.1 ms and ~0.75% of startup. The ~11–15 µs figure in the issue is the *second*, already-cached `sys.modules` line that appears under `kicad_tools.benchmark` in the same tree.

The existing comment ("~2.5 ms … well under 1% of CLI startup") is therefore accurate in both attribution and magnitude, so rewriting it as "~0.01 ms" would replace a true statement with a false one. `parser.py` is not in this diff. Declining rather than growing the PR, per the issue's own instruction.

### H — 4+-token `(at ...)`

- [x] `(at 1 2 45 unlocked)` with `_at_angle_synthetic=True` and `angle=0.0` keeps 4 children, `children[2] == 0.0`, trailing token intact (`test_four_token_node_keeps_all_children_when_angle_returns_to_zero`), with a 3-child control that *does* trim
- [x] `_sync_at_angle` is not in the diff

### I — the #3441 rescue warning follows #4761's gate

(`lattice_rescued` here is the **pad-lattice grid rescue**, not `--route-engine lattice`.)

- [x] `engine="grid"` (and the default) still emit the `UserWarning` with its current text — the grid string is assembled from the same prefix + tail, so it is byte-identical (`test_lattice_rescue_warning_fires_for_grid_engine`, `..._for_default_engine`)
- [x] `engine="lattice"|"mesh"` emit no `UserWarning` and log the event at INFO (`test_lattice_rescue_warning_suppressed_for_non_grid_engines`, `test_lattice_rescue_event_still_observable_at_info`)
- [x] `GridAutoSelection` is identical across engines — asserted as full dataclass equality (`test_lattice_rescue_selection_is_engine_invariant`)
- [x] The #3911 refusal and the #4271 skip line are untouched

### J — one normalization helper

- [x] `rg 'getattr\(args, "route_engine"' src/kicad_tools/cli/route_cmd.py` returns exactly two hits: the helper body and the `parser.get_default` comparison in the `--complete` engine-selection block (which is a different question and was **not** rewritten). Pinned by `test_no_bare_route_engine_reads_remain`
- [x] `_resolve_route_engine(SimpleNamespace(route_engine=None)) == "grid"` and `_resolve_route_engine(SimpleNamespace()) == "grid"` (`TestResolveRouteEngine`)
- [x] No output change for any CLI-producible value — argparse `choices` guarantees a non-empty string, so all 16 sites resolve exactly as before

### K — the skip line only speaks when the grid path would

Shape **(i)** (the safer default named in the issue). A/B on two boards, `--route-engine lattice`:

```
                    BEFORE (main)   AFTER (this branch)
clean board         skip line       (nothing)
fine-pitch board    skip line       skip line
```

- [x] Non-grid + no findings ⇒ no skip line (`test_skip_line_absent_when_the_board_has_no_fine_pitch_findings`, which also asserts the run really reached the block)
- [x] Non-grid + findings ⇒ the line prints with its current wording (`test_skip_line_still_prints_when_findings_exist`, exact-string)
- [x] Grid output byte-identical in both cases (`test_fine_pitch_advisories_fire_for_grid_engine` unchanged; new `test_clean_board_grid_output_is_unchanged`)
- [x] `--quiet` suppresses everything on every engine (`test_quiet_emits_no_fine_pitch_output_on_any_engine` unchanged; the analysis call itself is inside `if not quiet`)

## Test Plan

- `uv run pytest tests/test_route_grid_safety_gate.py tests/test_grid_safety_gate_fleet.py tests/test_lattice_timeout_forwarding.py tests/test_cli_drc_waivers.py tests/test_cli_check_waivers.py tests/test_validate_waivers.py tests/test_at_angle_residue.py tests/test_route_consolidation_pass.py` → **229 passed**
- `uv run pytest tests/test_docs_source_citations.py tests/test_diffpair_docs.py tests/test_match_group_docs.py tests/test_routing_quality_metrics.py tests/test_fine_pitch.py` → **83 passed** (the #4774 doc-citation guards)
- Full suite (`uv run pytest -q -n 4`) → **25886 passed, 97 skipped** in 30m10s (exit 0)
- `uv run ruff check .` → All checks passed; `uv run ruff format . --check` → 1783 files already formatted
- `uv run python scripts/ci/check_mypy_baseline.py` (cold, ~16 s) → `OK: mypy reports 1471 error(s), all within the baseline (1473 allowed)`. The "2 baseline errors no longer occur" warning is **pre-existing** — the identical output is produced by the same script on `main`.
- C++ backend built in this worktree (`kct build-native`) before any routing test.

Closes #4765
