### PR TITLE
fix(router): layer-scope the C++ HV attach-zone waiver so the search matches the pairwise gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The C++ router's HV attach-zone waiver is now layer-scoped, so the search
+  stops proposing copper the pairwise gate rejects** (#4507, epic #4431 Phase
+  2) — PR #4756 narrowed the #4506 rated-footprint exemption on the Python side
+  (a zone waives the pairwise creepage widening only on layers where *both*
+  nets have pad copper) but deliberately left the C++ `Grid3D` zone halo
+  layer-agnostic, with the layer-scoped Python `route_pairwise_violation` as
+  the acceptance check. That left the C++ search and the Python gate
+  disagreeing exactly where it hurts: the search would neck an HV net through a
+  rated part's pad field on a layer that part has no copper on, its own
+  `validate_route` waived it, and the layer-scoped post-check then rejected the
+  result — burning the net's resume budget and dropping it into the 10-100x
+  slower pure-Python fallback. `AttachZone` gains a per-net `net_layers` map
+  (net id -> grid layer indices), `Grid3D::attach_zone_exempts` gains a `layer`
+  argument, and every consult in `validate_route` and the search-time kernels
+  (`cross_domain_trace_blocked`, `cross_domain_via_blocked`) passes the layer
+  the compared copper actually shares — via-vs-via, where no single layer
+  applies, stays agnostic, matching the lattice engine's `exempt_pt_pt`
+  convention. The segment-vs-pad branch keys on the *pad's* layer (that loop is
+  deliberately layer-blind, so keying on the candidate segment would invent
+  violations for cross-layer pairs that are not in conflict), and a through-hole
+  pad keeps waiving on every layer. On a two-domain fixture whose only cheap
+  path threads a rated part's pad field on a layer the part does not occupy,
+  the layer-agnostic baseline exhausts 5 resume attempts, falls back to the
+  Python A* and **fails to route**; the layer-scoped search dives to the layer
+  the part actually licences and converges on the first attempt, gate-clean.
+  The layer projection now has a single implementation
+  (`pairwise_clearance.project_zone_layers`) shared by the lattice and C++
+  paths, so no engine can drift from the gate. Fully dormant without
+  `--voltage-map`; a zone with no layer data keeps the previous agnostic
+  verdict. `ROUTER_CPP_BUILD_VERSION` 18 -> 19 (run `kct build-native`).
 - **Nine polish fixes from the 2026-08-08/09 sweep's judge nits** (#4765) —
   each a small correctness defect in code that shipped last sweep; none
   changes routed copper or an exit code. (A) The `kct route` banner decided

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`cross_domain_trace_blocked`, `cross_domain_via_blocked`) passes the layer
   the compared copper actually shares — via-vs-via, where no single layer
   applies, stays agnostic, matching the lattice engine's `exempt_pt_pt`
-  convention. The segment-vs-pad branch keys on the *pad's* layer (that loop is
-  deliberately layer-blind, so keying on the candidate segment would invent
-  violations for cross-layer pairs that are not in conflict), and a through-hole
-  pad keeps waiving on every layer. On a two-domain fixture whose only cheap
-  path threads a rated part's pad field on a layer the part does not occupy,
+  convention. The segment-vs-pad branch keys on the *pad's* layer: that loop
+  already filters mismatched layers before the zone consult, so the only shape
+  where the two candidate keys differ is a through-hole pad, which keeps waiving
+  on every layer because the barrel spans every layer. On a two-domain fixture
+  whose only cheap path threads a rated part's pad field on a layer it does not occupy,
   the layer-agnostic baseline exhausts 5 resume attempts, falls back to the
   Python A* and **fails to route**; the layer-scoped search dives to the layer
   the part actually licences and converges on the first attempt, gate-clean.

--- a/src/kicad_tools/router/cpp/include/grid.hpp
+++ b/src/kicad_tools/router/cpp/include/grid.hpp
@@ -288,7 +288,9 @@ public:
     // partner relaxation keeps precedence (it *tightens within* a pair; the
     // matrix *widens across* domains), and an installed attach zone
     // (``set_attach_zones``) covering the gap point waives the widening --
-    // never the scalar floor.
+    // never the scalar floor.  Issue #4507: the zone consult is layer-scoped,
+    // keyed on the layer the compared copper shares (via-vs-via, where no
+    // single layer applies, stays layer-agnostic).
     ValidationResult validate_route(
         const std::vector<Segment>& segments,
         const std::vector<Via>& vias,
@@ -347,7 +349,18 @@ public:
 
     // True when an installed attach zone contains ``(x, y)`` AND has BOTH
     // ``net_a`` and ``net_b`` among its member net ids.
-    bool attach_zone_exempts(float x, float y, int net_a, int net_b) const;
+    //
+    // Issue #4507: ``layer`` is the grid layer index the two conflicting
+    // objects share; a zone waives the pair there only when BOTH nets have pad
+    // copper on that layer (``AttachZone::net_layers``).  Pass ``-1`` -- the
+    // default -- when no single layer applies (a through-via against a
+    // through-via, or a caller with no layer context), which keeps the
+    // layer-agnostic pre-#4507 verdict.  This mirrors the ``layer=None``
+    // convention of ``AttachZone.exempts`` in ``pairwise_clearance.py`` and of
+    // ``LatticePairwise.exempt`` in ``lattice/pairwise.py``, so all three
+    // engines waive on exactly the same layers.
+    bool attach_zone_exempts(float x, float y, int net_a, int net_b,
+                             int layer = -1) const;
 
     // Accessors for validation data sizes (for testing/debugging)
     size_t pad_count() const { return pads_.size(); }

--- a/src/kicad_tools/router/cpp/include/grid.hpp
+++ b/src/kicad_tools/router/cpp/include/grid.hpp
@@ -290,7 +290,8 @@ public:
     // (``set_attach_zones``) covering the gap point waives the widening --
     // never the scalar floor.  Issue #4507: the zone consult is layer-scoped,
     // keyed on the layer the compared copper shares (via-vs-via, where no
-    // single layer applies, stays layer-agnostic).
+    // single layer applies, stays layer-agnostic; the segment-vs-pad branch
+    // keys on the pad's own layer, so a through-hole pad stays agnostic too).
     ValidationResult validate_route(
         const std::vector<Segment>& segments,
         const std::vector<Via>& vias,
@@ -357,8 +358,18 @@ public:
     // through-via, or a caller with no layer context), which keeps the
     // layer-agnostic pre-#4507 verdict.  This mirrors the ``layer=None``
     // convention of ``AttachZone.exempts`` in ``pairwise_clearance.py`` and of
-    // ``LatticePairwise.exempt`` in ``lattice/pairwise.py``, so all three
-    // engines waive on exactly the same layers.
+    // ``LatticePairwise.exempt`` in ``lattice/pairwise.py``, so the three
+    // engines waive on the same layers for every comparison they all perform
+    // (segment-vs-segment, segment-vs-via, via-vs-via).
+    //
+    // The one place they cannot be compared is ``validate_route``'s
+    // segment-vs-pad branch: it passes a through-hole pad's ``layer_idx ==
+    // -1``, waiving on layers ``AttachZone.exempts`` would not, but it has no
+    // Python counterpart to disagree with -- ``route_pairwise_violation`` and
+    // ``find_pairwise_violations`` are segment-vs-segment only and never
+    // compare a segment against a pad.  That asymmetry is unchanged v18
+    // behaviour; see the comment at the ``pad_zone_layer`` assignment in
+    // ``grid.cpp``.
     bool attach_zone_exempts(float x, float y, int net_a, int net_b,
                              int layer = -1) const;
 

--- a/src/kicad_tools/router/cpp/include/types.hpp
+++ b/src/kicad_tools/router/cpp/include/types.hpp
@@ -189,7 +189,17 @@ namespace router {
 // byte-identically to version 17.  Old .so files lack both bindings, so the
 // Python plumbing in ``cpp_backend.py`` would silently no-op against a stale
 // build; the version bump forces a rebuild via ``kct build-native``.
-constexpr int ROUTER_CPP_BUILD_VERSION = 18;
+//
+// Version 19 (Issue #4507, Phase 2 of epic #4431): the attach-zone exemption
+// becomes LAYER-SCOPED.  ``AttachZone`` gains a ``net_layers`` map and
+// ``Grid3D::attach_zone_exempts`` gains a trailing ``layer`` argument, so the
+// C++ search and ``validate_route`` waive the pairwise widening on exactly the
+// layers the layer-scoped Python acceptance check (#4699 /
+// ``route_pairwise_violation``) waives it on.  A zone with an empty
+// ``net_layers`` map keeps the layer-agnostic version-18 verdict, so old
+// callers are unaffected -- but the struct field and the defaulted argument
+// are both new binding surface, hence the bump.
+constexpr int ROUTER_CPP_BUILD_VERSION = 19;
 
 // Issue #4071: fixed-capacity owner-set size for per-cell corridor
 // reservations.  Observed owner sets in practice are tiny: 1 for the
@@ -559,20 +569,33 @@ struct StoredVia {
 
 // Rated-footprint attach zone for pairwise clearance (Issue #4510 / #4506).
 //
-// Layer-agnostic axis-aligned bounding box plus the set of net ids that
-// terminate on the rated footprint.  Mirrors the frozen ``AttachZone``
-// dataclass in ``src/kicad_tools/router/pairwise_clearance.py``, except the
-// net *names* of the Python shape are translated to integer net ids by
-// ``cpp_backend.py`` before crossing the boundary (``Grid3D`` has no string
-// table).  A zone may legitimately span more than two nets (a 3-pad rated
-// connector), so membership is tested per-candidate-pair: BOTH nets of the
-// pair must be members for the widening to be waived.
+// Axis-aligned bounding box plus the set of net ids that terminate on the
+// rated footprint.  Mirrors the frozen ``AttachZone`` dataclass in
+// ``src/kicad_tools/router/pairwise_clearance.py``, except the net *names* of
+// the Python shape are translated to integer net ids by ``cpp_backend.py``
+// before crossing the boundary (``Grid3D`` has no string table).  A zone may
+// legitimately span more than two nets (a 3-pad rated connector), so
+// membership is tested per-candidate-pair: BOTH nets of the pair must be
+// members for the widening to be waived.
+//
+// Issue #4507 (epic #4431 Phase 2): the exemption is also LAYER-SCOPED, in
+// exact mirror of the #4699 Python narrowing.  ``net_layers`` maps a net id to
+// the grid layer indices on which that net has PAD copper on this footprint;
+// a pair is waived on a layer only when BOTH nets reach it.  Two escape
+// hatches preserve the old verdict where it is still correct:
+//
+//   * a net ABSENT from the map is unrestricted -- that is how a through-hole
+//     pad (``*.Cu``) keeps waiving on every layer, as the barrel requires;
+//   * an EMPTY map makes the whole zone layer-agnostic, i.e. byte-identical to
+//     the pre-#4507 (version 18) verdict, which is what hand-built zones and
+//     callers that never supply a layer map produce.
 struct AttachZone {
     float min_x = 0.0f;
     float min_y = 0.0f;
     float max_x = 0.0f;
     float max_y = 0.0f;
     std::vector<int> net_ids;
+    std::unordered_map<int, std::vector<int>> net_layers;
 };
 
 // Validation result (Issue #2439)

--- a/src/kicad_tools/router/cpp/src/bindings.cpp
+++ b/src/kicad_tools/router/cpp/src/bindings.cpp
@@ -89,7 +89,12 @@ NB_MODULE(router_cpp, m) {
         .def_rw("min_y", &AttachZone::min_y)
         .def_rw("max_x", &AttachZone::max_x)
         .def_rw("max_y", &AttachZone::max_y)
-        .def_rw("net_ids", &AttachZone::net_ids);
+        .def_rw("net_ids", &AttachZone::net_ids)
+        // Issue #4507: net id -> grid layer indices that net has PAD copper on
+        // here.  A net absent from the map is unrestricted (through-hole);
+        // leaving the whole map empty keeps the pre-#4507 layer-agnostic
+        // waiver, which is what hand-built zones produce.
+        .def_rw("net_layers", &AttachZone::net_layers);
 
     // PadBounds struct
     nb::class_<PadBounds>(m, "PadBounds")
@@ -302,9 +307,12 @@ NB_MODULE(router_cpp, m) {
              "Required pairwise clearance (mm) between two net ids; 0.0 when "
              "dormant or when either net has no domain.")
         .def("attach_zone_exempts", &Grid3D::attach_zone_exempts,
-             "x"_a, "y"_a, "net_a"_a, "net_b"_a,
+             "x"_a, "y"_a, "net_a"_a, "net_b"_a, "layer"_a = -1,
              "True when an installed attach zone contains (x, y) and lists BOTH "
-             "net ids among its members.")
+             "net ids among its members.  Issue #4507: when ``layer`` is a real "
+             "grid layer index the zone must also reach it for BOTH nets "
+             "(AttachZone.net_layers); ``layer = -1`` (the default) or a zone "
+             "with an empty net_layers map keeps the layer-agnostic verdict.")
         .def_prop_ro("max_pairwise_clearance", &Grid3D::max_pairwise_clearance,
              "Issue #4511: the widest widening (mm) in the installed domain "
              "matrix, 0.0 when dormant.  Sizes the search-time widened kernel.")

--- a/src/kicad_tools/router/cpp/src/grid.cpp
+++ b/src/kicad_tools/router/cpp/src/grid.cpp
@@ -512,7 +512,26 @@ float Grid3D::pairwise_required_clearance(int net_a, int net_b) const {
                           static_cast<size_t>(db)];
 }
 
-bool Grid3D::attach_zone_exempts(float x, float y, int net_a, int net_b) const {
+namespace {
+
+// Issue #4507: does ``net`` reach ``layer`` on this zone's rated footprint?
+//
+// A net absent from ``net_layers`` is unrestricted (through-hole ``*.Cu`` pad
+// copper, which Python omits from the projection precisely so the barrel keeps
+// waiving on every layer).  Layer lists are tiny -- at most the copper layers
+// one pad occupies -- so a linear scan beats any smarter container.
+inline bool zone_net_reaches_layer(const AttachZone& zone, int net, int layer) {
+    const auto it = zone.net_layers.find(net);
+    if (it == zone.net_layers.end()) return true;
+    for (int idx : it->second) {
+        if (idx == layer) return true;
+    }
+    return false;
+}
+
+}  // namespace
+
+bool Grid3D::attach_zone_exempts(float x, float y, int net_a, int net_b, int layer) const {
     for (const auto& zone : attach_zones_) {
         if (x < zone.min_x || x > zone.max_x || y < zone.min_y || y > zone.max_y) continue;
         bool has_a = false;
@@ -521,7 +540,14 @@ bool Grid3D::attach_zone_exempts(float x, float y, int net_a, int net_b) const {
             if (nid == net_a) has_a = true;
             if (nid == net_b) has_b = true;
         }
-        if (has_a && has_b) return true;
+        if (!has_a || !has_b) continue;
+        // Issue #4507: layer scoping.  ``layer < 0`` (no single layer applies)
+        // and an empty map both keep the pre-#4507 layer-agnostic verdict.
+        if (layer < 0 || zone.net_layers.empty()) return true;
+        if (zone_net_reaches_layer(zone, net_a, layer) &&
+            zone_net_reaches_layer(zone, net_b, layer)) {
+            return true;
+        }
     }
     return false;
 }
@@ -658,15 +684,25 @@ ValidationResult Grid3D::validate_route(
     // ``gap_point`` is a nullary callable returning the (x, y) mid-gap
     // coordinate consulted by the attach-zone exemption (#4506): a rated
     // domain-bridging footprint may neck the pair down to the scalar floor
-    // inside its courtyard, but never below it -- the exemption skips only
+    // inside its pad field, but never below it -- the exemption skips only
     // the widening, never ``base``.
+    //
+    // Issue #4507: ``zone_layer`` is the grid layer index the two compared
+    // pieces of copper share, or -1 where no single layer applies (via-vs-via).
+    // It layer-scopes the zone consult so this validator waives exactly what
+    // the layer-scoped Python acceptance check (``route_pairwise_violation``,
+    // narrowed by #4699) waives -- previously the C++ side was strictly more
+    // permissive, so the search could converge on copper the Python post-check
+    // then rejected, thrashing the negotiator.
     const bool pairwise_on = pairwise_active_;
-    auto widen = [&](float base, int foreign_net, auto&& gap_point) -> float {
+    auto widen = [&](float base, int foreign_net, int zone_layer, auto&& gap_point) -> float {
         if (!pairwise_on) return base;
         const float required = pairwise_required_clearance(exclude_net, foreign_net);
         if (required <= base) return base;
         const std::pair<float, float> p = gap_point();
-        if (attach_zone_exempts(p.first, p.second, exclude_net, foreign_net)) return base;
+        if (attach_zone_exempts(p.first, p.second, exclude_net, foreign_net, zone_layer)) {
+            return base;
+        }
         return required;
     };
 
@@ -790,7 +826,16 @@ ValidationResult Grid3D::validate_route(
             // is the midpoint between the pad centre and the closest point on
             // the candidate segment's centreline -- the pad analogue of the
             // Python validator's closest-approach midpoint.
-            required_clearance = widen(required_clearance, pad.net, [&]() {
+            // #4507: this loop is deliberately layer-BLIND (it compares the
+            // candidate against every pad, so a through-hole barrel is never
+            // missed), which makes the segment's layer the wrong key here: a
+            // spurious cross-layer seg-vs-SMD-pad pair would lose a waiver it
+            // physically deserves.  The pad's OWN layer is the copper layer
+            // this comparison is about, and it is the same layer the zone's
+            // per-net projection was derived from -- so an SMD pad keys on it
+            // and a through-hole pad (``layer_idx < 0``) stays layer-agnostic.
+            const int pad_zone_layer = pad.layer_idx;
+            required_clearance = widen(required_clearance, pad.net, pad_zone_layer, [&]() {
                 const auto cp = closest_point_on_segment(
                     pad.x, pad.y, seg.x1, seg.y1, seg.x2, seg.y2);
                 return std::pair<float, float>((pad.x + cp.first) / 2.0f,
@@ -834,7 +879,8 @@ ValidationResult Grid3D::validate_route(
             // domains; a net that is both the diff-pair partner and formally
             // cross-domain stays at ``intra_pair_clearance``.
             if (!is_partner) {
-                effective_clearance = widen(effective_clearance, other.net, [&]() {
+                // #4507: both segments are on ``seg.layer`` (enforced above).
+                effective_clearance = widen(effective_clearance, other.net, seg.layer, [&]() {
                     return closest_gap_midpoint(seg.x1, seg.y1, seg.x2, seg.y2,
                                                 other.x1, other.y1, other.x2, other.y2);
                 });
@@ -869,7 +915,8 @@ ValidationResult Grid3D::validate_route(
 
             // Issue #4510: cross-domain widening (partner branch wins).
             if (!is_partner) {
-                effective_clearance = widen(effective_clearance, sv.net, [&]() {
+                // #4507: the barrel crosses the candidate segment's layer.
+                effective_clearance = widen(effective_clearance, sv.net, seg.layer, [&]() {
                     const auto cp = closest_point_on_segment(
                         sv.x, sv.y, seg.x1, seg.y1, seg.x2, seg.y2);
                     return std::pair<float, float>((sv.x + cp.first) / 2.0f,
@@ -916,7 +963,9 @@ ValidationResult Grid3D::validate_route(
 
             // Issue #4510: cross-domain widening for the candidate via vs a
             // stored foreign segment (no diff-pair partner branch here).
-            const float effective_clearance = widen(via_clearance, seg.net, [&]() {
+            // #4507: the shared layer is the stored segment's (the candidate
+            // via's barrel spans it -- the loop above already checked that).
+            const float effective_clearance = widen(via_clearance, seg.net, seg.layer_idx, [&]() {
                 const auto cp = closest_point_on_segment(
                     via.x, via.y, seg.x1, seg.y1, seg.x2, seg.y2);
                 return std::pair<float, float>((via.x + cp.first) / 2.0f,
@@ -951,7 +1000,10 @@ ValidationResult Grid3D::validate_route(
 
             // Issue #4510: cross-domain widening for via-vs-via.  The gap
             // point is the midpoint of the two via centres.
-            const float effective_clearance = widen(via_clearance, sv.net, [&]() {
+            // #4507: two barrels share no single layer, so the zone consult
+            // stays layer-agnostic (``-1``) -- the same convention as
+            // ``LatticePairwise.exempt_pt_pt``'s default in the lattice engine.
+            const float effective_clearance = widen(via_clearance, sv.net, -1, [&]() {
                 return std::pair<float, float>((via.x + sv.x) / 2.0f, (via.y + sv.y) / 2.0f);
             });
 

--- a/src/kicad_tools/router/cpp/src/grid.cpp
+++ b/src/kicad_tools/router/cpp/src/grid.cpp
@@ -826,14 +826,34 @@ ValidationResult Grid3D::validate_route(
             // is the midpoint between the pad centre and the closest point on
             // the candidate segment's centreline -- the pad analogue of the
             // Python validator's closest-approach midpoint.
-            // #4507: this loop is deliberately layer-BLIND (it compares the
-            // candidate against every pad, so a through-hole barrel is never
-            // missed), which makes the segment's layer the wrong key here: a
-            // spurious cross-layer seg-vs-SMD-pad pair would lose a waiver it
-            // physically deserves.  The pad's OWN layer is the copper layer
-            // this comparison is about, and it is the same layer the zone's
-            // per-net projection was derived from -- so an SMD pad keys on it
-            // and a through-hole pad (``layer_idx < 0``) stays layer-agnostic.
+            // #4507: the zone consult keys on the PAD's own layer rather than
+            // on ``seg.layer``.  This loop is NOT layer-blind -- the guard at
+            // the top of it (line 768, ``Skip pads on different layers``:
+            // ``if (pad.layer_idx != -1 && pad.layer_idx != seg.layer)
+            // continue;``) already drops mismatched layers, so a cross-layer
+            // seg-vs-SMD-pad pair can never reach this line.  Only two shapes
+            // survive that filter:
+            //
+            //   (i)  a same-layer SMD pad, where ``pad.layer_idx == seg.layer``
+            //        -- the two candidate keys are literally the same value, so
+            //        the choice is a no-op; and
+            //   (ii) a through-hole pad (``layer_idx == -1``), where passing -1
+            //        keeps the consult layer-agnostic because the barrel really
+            //        does span every copper layer.
+            //
+            // So (ii) is the asymmetry's ONLY behavioural effect, and it is the
+            // whole reason for it.  ``tests/router/test_pairwise_cpp_parity.py::
+            // test_pad_branch_keys_the_waiver_on_the_pads_own_layer`` case (c)
+            // is correspondingly the only case that can distinguish the keys.
+            //
+            // One consequence worth naming: in case (ii) the -1 also exempts
+            // the CANDIDATE's net from the layer check, so this branch can
+            // waive on layers where ``AttachZone.exempts`` would not.  That is
+            // unchanged v18 behaviour and has no Python counterpart to disagree
+            // with -- ``route_pairwise_violation`` / ``find_pairwise_violations``
+            // are segment-vs-segment only and never compare a segment against a
+            // pad -- so it cannot produce the search<->gate thrash #4507 exists
+            // to remove.
             const int pad_zone_layer = pad.layer_idx;
             required_clearance = widen(required_clearance, pad.net, pad_zone_layer, [&]() {
                 const auto cp = closest_point_on_segment(

--- a/src/kicad_tools/router/cpp/src/pathfinder.cpp
+++ b/src/kicad_tools/router/cpp/src/pathfinder.cpp
@@ -580,13 +580,15 @@ bool Pathfinder::cross_domain_trace_blocked(int x, int y, int layer, int net,
             if (dist_sq > pair_r * pair_r) continue;
             // Attach-zone exemption (#4506) at the approximate gap midpoint:
             // a rated domain-bridging footprint may neck the pair down to the
-            // scalar floor inside its courtyard -- but the scalar floor was
+            // scalar floor inside its pad field -- but the scalar floor was
             // already enforced by the caller's inner scan, so waiving the
             // widening here is safe (mirrors ``validate_route``'s ``widen``).
+            // Issue #4507: scoped to THIS layer, so the search no longer
+            // accepts copper the layer-scoped Python check would reject.
             const auto fw = grid_.grid_to_world(cx, cy);
             const float mx = (cw.first + fw.first) * 0.5f;
             const float my = (cw.second + fw.second) * 0.5f;
-            if (grid_.attach_zone_exempts(mx, my, net, cell.net)) continue;
+            if (grid_.attach_zone_exempts(mx, my, net, cell.net, layer)) continue;
             return true;
         }
     }
@@ -626,7 +628,10 @@ bool Pathfinder::cross_domain_via_blocked(int x, int y, int net) const {
                 const auto fw = grid_.grid_to_world(cx, cy);
                 const float mx = (cw.first + fw.first) * 0.5f;
                 const float my = (cw.second + fw.second) * 0.5f;
-                if (grid_.attach_zone_exempts(mx, my, net, cell.net)) continue;
+                // Issue #4507: the candidate via's barrel meets this copper ON
+                // ``layer``, so the waiver is scoped to it (a via passing a
+                // rated SMD part's pad field on an inner layer is not exempt).
+                if (grid_.attach_zone_exempts(mx, my, net, cell.net, layer)) continue;
                 return true;
             }
         }
@@ -859,6 +864,9 @@ bool Pathfinder::is_via_blocked_diag(int x, int y, int net, bool allow_sharing,
             if (pair_req > required) {
                 const float mx = (candidate_x + sv.x) * 0.5f;
                 const float my = (candidate_y + sv.y) * 0.5f;
+                // Issue #4507: two barrels share no single layer, so this
+                // consult stays layer-agnostic (the defaulted ``layer = -1``),
+                // matching ``validate_route``'s via-via branch exactly.
                 if (!grid_.attach_zone_exempts(mx, my, net, sv.net)) {
                     required = pair_req;
                 }

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 # ``AttributeError`` deep in the routing code (e.g. ``router_cpp.PadBounds``
 # missing).  The guard below catches that at import time and falls back to the
 # pure-Python router with an actionable ``kct build-native`` hint.
-_REQUIRED_CPP_BUILD_VERSION = 18
+_REQUIRED_CPP_BUILD_VERSION = 19
 
 # Try to import C++ module with detailed error tracking
 _CPP_IMPORT_ERROR: str | None = None
@@ -1500,6 +1500,33 @@ class CppPathfinder:
         if self._py_router is not None:
             self._py_router.set_attach_zones(self._attach_zones)
 
+    def _grid_layer_indices(self) -> dict[str, int] | None:
+        """KiCad copper-layer name -> C++ grid layer index (Issue #4507).
+
+        The #4506 attach zones record their pad layers by KiCad *name*
+        (``"F.Cu"``), while ``Grid3D`` speaks only grid layer indices.  The
+        grid's own ``_index_to_layer`` map is the authority for that
+        translation -- it is the same mapping ``layer_to_index`` inverts when
+        segments and vias cross the boundary, so a zone can never be scoped to
+        a layer index the stored copper does not use.
+
+        Returns ``None`` when the mapping is unavailable (a bare ``CppGrid``
+        built without ``from_routing_grid``), which keeps the zones
+        layer-agnostic -- exactly the pre-#4507 verdict.
+        """
+        index_to_layer = getattr(self._grid, "_index_to_layer", None)
+        if not index_to_layer:
+            return None
+        from .layers import Layer
+
+        names: dict[str, int] = {}
+        for index, enum_value in index_to_layer.items():
+            try:
+                names[Layer(enum_value).kicad_name] = int(index)
+            except ValueError:  # pragma: no cover - defensive
+                continue
+        return names or None
+
     def _sync_pairwise_domains_to_cpp(self) -> None:
         """Install the pairwise domain matrix + attach zones on the C++ grid.
 
@@ -1538,8 +1565,8 @@ class CppPathfinder:
                 self._pairwise_cpp_payload = False
                 return
             cpp_zones = []
-            for min_x, min_y, max_x, max_y, net_ids in attach_zones_to_net_ids(
-                self._attach_zones, self._net_name_to_id
+            for min_x, min_y, max_x, max_y, net_ids, net_layers in attach_zones_to_net_ids(
+                self._attach_zones, self._net_name_to_id, self._grid_layer_indices()
             ):
                 zone = router_cpp.AttachZone()
                 zone.min_x = min_x
@@ -1547,6 +1574,14 @@ class CppPathfinder:
                 zone.max_x = max_x
                 zone.max_y = max_y
                 zone.net_ids = net_ids
+                # Issue #4507: per-net pad layers, so the C++ waiver is scoped
+                # to the layers the rated part actually has copper on -- the
+                # same scoping the Python acceptance check applies (#4699).
+                # ``None`` leaves the map empty = layer-agnostic (unchanged).
+                if net_layers:
+                    zone.net_layers = {
+                        net_id: sorted(indices) for net_id, indices in net_layers.items()
+                    }
                 cpp_zones.append(zone)
             payload = (domains.net_to_domain, domains.matrix, cpp_zones)
             self._pairwise_cpp_payload = payload

--- a/src/kicad_tools/router/lattice/pairwise.py
+++ b/src/kicad_tools/router/lattice/pairwise.py
@@ -225,25 +225,12 @@ def _project_zone_layers(
 ) -> ZoneLayers | None:
     """Project a zone's per-net pad layers into lattice layer indices (#4699).
 
-    Returns ``None`` -- the layer-agnostic verdict -- when no layer map was
-    supplied or the zone records no pad layers (older/hand-built zones).  A net
-    whose pads carry the ``*.Cu`` wildcard (through-hole) is omitted from the
-    result, which the exemption reads as "unrestricted", so a through-hole
-    rated part keeps waiving on every layer exactly as before.
+    Thin delegation to the shared
+    :func:`~kicad_tools.router.pairwise_clearance.project_zone_layers` helper
+    (issue #4507 lifted the body there): the lattice, the C++ ``Grid3D`` and the
+    #4588 gate must all read the SAME layer scoping, so there is exactly one
+    implementation of it.  ``None`` is the layer-agnostic verdict.
     """
-    from ..pairwise_clearance import ALL_COPPER_LAYERS
+    from ..pairwise_clearance import project_zone_layers
 
-    if layer_indices is None or not zone.net_layers:
-        return None
-    projected: dict[int, frozenset[int]] = {}
-    for key, layer_names in zone.net_layers:
-        if ALL_COPPER_LAYERS in layer_names:
-            continue  # through-hole pad copper exists on every layer
-        indices = frozenset(
-            idx for name in layer_names if (idx := layer_indices.get(name)) is not None
-        )
-        if not indices:
-            continue
-        for net_id in ids_by_key.get(key, ()):
-            projected[net_id] = indices
-    return projected or None
+    return project_zone_layers(zone, ids_by_key, layer_indices)

--- a/src/kicad_tools/router/pairwise_clearance.py
+++ b/src/kicad_tools/router/pairwise_clearance.py
@@ -436,28 +436,80 @@ def build_cpp_domain_matrix(
     return CppDomainMatrix(net_to_domain=net_to_domain, matrix=matrix)
 
 
+def project_zone_layers(
+    zone: AttachZone,
+    ids_by_key: Mapping[str, Sequence[int]],
+    layer_indices: Mapping[str, int] | None,
+) -> dict[int, frozenset[int]] | None:
+    """Project a zone's per-net pad layers into engine layer indices (#4699).
+
+    Shared by every id-space consumer of the #4506 exemption -- the lattice
+    projection (``lattice/pairwise.py``) and the C++ ``Grid3D`` projection
+    (:func:`attach_zones_to_net_ids`, issue #4507) -- so no engine can drift
+    into a different layer verdict than the ``AttachZone.exempts`` acceptance
+    check the #4588 gate runs.
+
+    Returns ``None`` -- the layer-agnostic verdict -- when no layer map was
+    supplied or the zone records no pad layers (older / hand-built zones).  A
+    net whose pads carry the :data:`ALL_COPPER_LAYERS` wildcard (through-hole)
+    is omitted from the result, which every consumer reads as "unrestricted",
+    so a through-hole rated part keeps waiving on every layer.
+    """
+    if layer_indices is None or not zone.net_layers:
+        return None
+    projected: dict[int, frozenset[int]] = {}
+    for key, layer_names in zone.net_layers:
+        if ALL_COPPER_LAYERS in layer_names:
+            continue  # through-hole pad copper exists on every layer
+        indices = frozenset(
+            idx for name in layer_names if (idx := layer_indices.get(name)) is not None
+        )
+        if not indices:
+            continue
+        for net_id in ids_by_key.get(key, ()):
+            projected[net_id] = indices
+    return projected or None
+
+
 def attach_zones_to_net_ids(
     zones: Sequence[AttachZone],
     net_name_to_id: Mapping[str, int],
-) -> list[tuple[float, float, float, float, list[int]]]:
+    layer_indices: Mapping[str, int] | None = None,
+) -> list[tuple[float, float, float, float, list[int], dict[int, frozenset[int]] | None]]:
     """Translate net-name-keyed attach zones to net-id tuples (Issue #4510).
 
     ``Grid3D`` works in integer net ids, so :attr:`AttachZone.net_names` must be
     resolved through the router's reverse map before crossing into C++.  A zone
     may legitimately span more than two nets (a 3-pad rated connector); zones
     that resolve to fewer than two ids cannot exempt any pair and are dropped.
+
+    ``layer_indices`` (issue #4507) maps KiCad copper-layer names to the C++
+    grid's layer indices, so each zone's per-net pad layers
+    (:attr:`AttachZone.net_layers`) project into the integer layer space
+    ``Grid3D::attach_zone_exempts`` speaks.  Omitting it -- or supplying a zone
+    that records no pad layers -- yields ``None`` in the trailing slot, the
+    layer-agnostic verdict the C++ side used before #4507.
     """
     ids_by_key: dict[str, list[int]] = {}
     for name, net_id in net_name_to_id.items():
         if int(net_id) >= 0:
             ids_by_key.setdefault(_norm_net_key(name), []).append(int(net_id))
 
-    out: list[tuple[float, float, float, float, list[int]]] = []
+    out: list[tuple[float, float, float, float, list[int], dict[int, frozenset[int]] | None]] = []
     for zone in zones:
         net_ids = sorted({nid for key in zone.net_names for nid in ids_by_key.get(key, ())})
         if len(net_ids) < 2:
             continue
-        out.append((zone.min_x, zone.min_y, zone.max_x, zone.max_y, net_ids))
+        out.append(
+            (
+                zone.min_x,
+                zone.min_y,
+                zone.max_x,
+                zone.max_y,
+                net_ids,
+                project_zone_layers(zone, ids_by_key, layer_indices),
+            )
+        )
     return out
 
 

--- a/tests/router/test_pairwise_cpp_parity.py
+++ b/tests/router/test_pairwise_cpp_parity.py
@@ -93,12 +93,17 @@ def _cpp_via(x, y, net, layer_from=0, layer_to=1, drill=0.3, diameter=0.6):
     return via
 
 
-def _cpp_zone(min_x, min_y, max_x, max_y, net_ids):
+def _cpp_zone(min_x, min_y, max_x, max_y, net_ids, net_layers=None):
     from kicad_tools.router import router_cpp
 
     zone = router_cpp.AttachZone()
     zone.min_x, zone.min_y, zone.max_x, zone.max_y = min_x, min_y, max_x, max_y
     zone.net_ids = list(net_ids)
+    # Issue #4507: ``net_layers`` maps a net id to the grid layer indices it has
+    # PAD copper on here.  Leaving it empty is the layer-agnostic (pre-#4507)
+    # verdict, which is what every pre-existing fixture in this module wants.
+    if net_layers:
+        zone.net_layers = {net: sorted(layers) for net, layers in net_layers.items()}
     return zone
 
 
@@ -452,7 +457,9 @@ def test_attach_zones_to_net_ids_translates_and_drops_unresolvable() -> None:
         AttachZone(9.0, 9.0, 10.0, 10.0, frozenset({"AC_LINE", "NOT_ON_BOARD"})),
     )
     translated = attach_zones_to_net_ids(zones, NET_NAMES)
-    assert translated == [(0.0, -1.0, 5.0, 1.0, [HV_NET, LV_NET])]
+    # Issue #4507: the trailing slot is the per-net layer projection; ``None``
+    # here because these hand-built zones record no pad layers.
+    assert translated == [(0.0, -1.0, 5.0, 1.0, [HV_NET, LV_NET], None)]
 
 
 def test_attach_zones_to_net_ids_preserves_multi_net_zones() -> None:
@@ -995,3 +1002,328 @@ def test_no_voltage_map_route_leaves_grid_dormant() -> None:
     assert route is not None
     assert cpp_grid._impl.pairwise_active is False
     assert cpp_grid._impl.max_pairwise_clearance == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 (#4507): the attach-zone waiver is LAYER-SCOPED on the C++ path too
+# ---------------------------------------------------------------------------
+#
+# PR #4756 (issue #4699) narrowed the #4506 exemption on the PYTHON side: a
+# rated footprint waives the pairwise widening only on the copper layers its
+# own pads occupy, so copper merely passing *under* an SMD part is no longer
+# exempted by an XY box it never touches.  That PR deliberately left the C++
+# ``Grid3D`` zone halo layer-agnostic (strictly more permissive), with the
+# layer-scoped Python ``route_pairwise_violation`` as the acceptance check.
+#
+# The residual is a search<->gate DISAGREEMENT, and disagreement is exactly the
+# thrash this phase exists to remove: the C++ search proposes copper its own
+# validator waives, the layer-scoped Python post-check rejects it, the router
+# boosts and retries, and the net either burns its resume budget into the slow
+# Python fallback or fails outright.  These tests pin the mirror.
+
+# A rated part whose pads sit on B.Cu only -> its waiver must not reach F.Cu.
+_B_CU_ONLY = frozenset({("AC_LINE", frozenset({"B.Cu"})), ("GND", frozenset({"B.Cu"}))})
+_LAYER_INDICES = {"F.Cu": 0, "B.Cu": 1}
+
+
+@requires_cpp
+def test_attach_zone_waiver_is_layer_scoped() -> None:
+    """A zone waives only on layers where BOTH nets have pad copper."""
+    grid = _cpp_grid()
+    _install_domains(grid)
+    grid.set_attach_zones(
+        [_cpp_zone(0.0, 0.0, 20.0, 20.0, [HV_NET, LV_NET], {HV_NET: [1], LV_NET: [1]})]
+    )
+    # Layer 1 (B.Cu) -- the part's own pad layer -- still waives.
+    assert grid.attach_zone_exempts(5.0, 5.0, HV_NET, LV_NET, 1) is True
+    # Layer 0 (F.Cu) -- copper merely passing over the pad field -- does not.
+    assert grid.attach_zone_exempts(5.0, 5.0, HV_NET, LV_NET, 0) is False
+    # No layer context (via-vs-via) keeps the layer-agnostic verdict, which is
+    # also the pre-#4507 answer the defaulted argument preserves.
+    assert grid.attach_zone_exempts(5.0, 5.0, HV_NET, LV_NET, -1) is True
+    assert grid.attach_zone_exempts(5.0, 5.0, HV_NET, LV_NET) is True
+
+
+@requires_cpp
+def test_attach_zone_without_layer_data_stays_layer_agnostic() -> None:
+    """Backward compat: an empty ``net_layers`` map waives on every layer."""
+    grid = _cpp_grid()
+    _install_domains(grid)
+    grid.set_attach_zones([_cpp_zone(0.0, 0.0, 20.0, 20.0, [HV_NET, LV_NET])])
+    for layer in (-1, 0, 1):
+        assert grid.attach_zone_exempts(5.0, 5.0, HV_NET, LV_NET, layer) is True
+
+
+@requires_cpp
+def test_layer_scoped_zone_still_requires_both_nets_to_reach_the_layer() -> None:
+    """One net short of the layer is enough to withhold the waiver."""
+    grid = _cpp_grid()
+    _install_domains(grid)
+    # HV reaches both layers (through-hole-ish), LV only B.Cu.
+    grid.set_attach_zones(
+        [_cpp_zone(0.0, 0.0, 20.0, 20.0, [HV_NET, LV_NET], {HV_NET: [0, 1], LV_NET: [1]})]
+    )
+    assert grid.attach_zone_exempts(5.0, 5.0, HV_NET, LV_NET, 1) is True
+    assert grid.attach_zone_exempts(5.0, 5.0, HV_NET, LV_NET, 0) is False
+
+
+@requires_cpp
+def test_through_hole_zone_net_is_unrestricted_on_every_layer() -> None:
+    """A net ABSENT from ``net_layers`` is unrestricted (``*.Cu`` barrels)."""
+    grid = _cpp_grid()
+    _install_domains(grid)
+    # Only LV is layer-restricted; HV is a through-hole pad, so Python omits it
+    # from the projection and the C++ side must read that as "any layer".
+    grid.set_attach_zones([_cpp_zone(0.0, 0.0, 20.0, 20.0, [HV_NET, LV_NET], {LV_NET: [0, 1]})])
+    assert grid.attach_zone_exempts(5.0, 5.0, HV_NET, LV_NET, 0) is True
+    assert grid.attach_zone_exempts(5.0, 5.0, HV_NET, LV_NET, 1) is True
+
+
+def test_attach_zones_to_net_ids_projects_pad_layers() -> None:
+    """The Python->C++ translation carries the #4699 per-net pad layers."""
+    zone = AttachZone(0.0, 0.0, 5.0, 5.0, frozenset({"AC_LINE", "GND"}), _B_CU_ONLY)
+    (translated,) = attach_zones_to_net_ids((zone,), NET_NAMES, _LAYER_INDICES)
+    assert translated[:5] == (0.0, 0.0, 5.0, 5.0, [HV_NET, LV_NET])
+    assert translated[5] == {HV_NET: frozenset({1}), LV_NET: frozenset({1})}
+
+    # No layer map supplied -> layer-agnostic (the pre-#4507 verdict).
+    (agnostic,) = attach_zones_to_net_ids((zone,), NET_NAMES)
+    assert agnostic[5] is None
+
+
+def test_attach_zones_to_net_ids_drops_through_hole_nets_from_projection() -> None:
+    """``*.Cu`` pad copper is omitted so the barrel keeps waiving everywhere."""
+    zone = AttachZone(
+        0.0,
+        0.0,
+        5.0,
+        5.0,
+        frozenset({"AC_LINE", "GND"}),
+        frozenset({("AC_LINE", frozenset({"*.Cu"})), ("GND", frozenset({"F.Cu"}))}),
+    )
+    (translated,) = attach_zones_to_net_ids((zone,), NET_NAMES, _LAYER_INDICES)
+    assert translated[5] == {LV_NET: frozenset({0})}
+
+
+def test_lattice_and_cpp_projections_share_one_implementation() -> None:
+    """The lattice and C++ zone projections cannot drift (#4507).
+
+    ``lattice.pairwise._project_zone_layers`` now delegates to the shared
+    ``pairwise_clearance.project_zone_layers`` helper, so a single edit governs
+    what every engine -- and the #4588 gate -- considers layer-covered.
+    """
+    from kicad_tools.router.lattice.pairwise import _project_zone_layers
+    from kicad_tools.router.pairwise_clearance import project_zone_layers
+
+    zone = AttachZone(0.0, 0.0, 5.0, 5.0, frozenset({"AC_LINE", "GND"}), _B_CU_ONLY)
+    ids_by_key = {"AC_LINE": [HV_NET], "GND": [LV_NET]}
+    assert _project_zone_layers(zone, ids_by_key, _LAYER_INDICES) == project_zone_layers(
+        zone, ids_by_key, _LAYER_INDICES
+    )
+
+
+@requires_cpp
+def test_validate_route_layer_scoped_zone_agrees_with_python_gate() -> None:
+    """``validate_route`` and ``AttachZone.exempts`` waive on the same layers."""
+    zone_py = AttachZone(0.0, -1.0, 5.0, 1.0, frozenset({"AC_LINE", "GND"}), _B_CU_ONLY)
+    (translated,) = attach_zones_to_net_ids((zone_py,), NET_NAMES, _LAYER_INDICES)
+    cpp_zone = _cpp_zone(*translated[:5], translated[5])
+
+    for layer_idx, layer_name, waived in ((1, "B.Cu", True), (0, "F.Cu", False)):
+        grid = _cpp_grid()
+        _install_domains(grid)
+        grid.set_attach_zones([cpp_zone])
+        # A pair 0.2 mm apart -- at the DRU floor, far below the 1.6 mm HV
+        # requirement, so only the zone can make it legal.
+        grid.add_stored_segment(0.0, 0.4, 5.0, 0.4, TRACE_WIDTH, layer_idx, LV_NET)
+        candidate = [_cpp_segment(0.0, 0.0, 5.0, 0.0, HV_NET, layer=layer_idx)]
+        assert _validate(grid, candidate).valid is waived
+        # The Python acceptance check reaches the identical verdict.
+        assert zone_py.exempts(2.5, 0.2, "AC_LINE", "GND", layer_name) is waived
+
+
+@requires_cpp
+def test_pad_branch_keys_the_waiver_on_the_pads_own_layer() -> None:
+    """The layer-BLIND pad loop must not lose a waiver it physically deserves.
+
+    ``validate_route``'s segment-vs-pad loop compares against every pad on
+    every layer (so a through-hole barrel is never missed).  Keying the zone
+    consult on the *candidate segment's* layer would therefore invent
+    violations for cross-layer seg-vs-SMD-pad pairs that are not in conflict at
+    all, so the consult keys on the PAD's own layer -- and a through-hole pad
+    (``layer_idx < 0``) stays layer-agnostic.
+    """
+    zone_ids = [HV_NET, LV_NET]
+    # LV pad copper on B.Cu (index 1) only.
+    scoping = {HV_NET: [1], LV_NET: [1]}
+
+    # (a) B.Cu SMD pad: the zone covers that layer -> waived, even though the
+    #     candidate segment being validated runs on F.Cu.
+    smd = _cpp_grid()
+    _install_domains(smd)
+    smd.set_attach_zones([_cpp_zone(0.0, -1.0, 5.0, 1.0, zone_ids, scoping)])
+    smd.add_pad(2.5, 0.4, 0.2, 0.2, LV_NET, 1, 0, DRU, False)
+    assert _validate(smd, [_cpp_segment(0.0, 0.0, 5.0, 0.0, HV_NET, layer=0)]).valid
+
+    # (b) F.Cu SMD pad: a layer the zone does NOT cover -> full widening.
+    other = _cpp_grid()
+    _install_domains(other)
+    other.set_attach_zones([_cpp_zone(0.0, -1.0, 5.0, 1.0, zone_ids, scoping)])
+    other.add_pad(2.5, 0.4, 0.2, 0.2, LV_NET, 0, 0, DRU, False)
+    assert not _validate(other, [_cpp_segment(0.0, 0.0, 5.0, 0.0, HV_NET, layer=0)]).valid
+
+    # (c) Through-hole pad (layer_idx = -1): no single layer applies -> the
+    #     zone keeps its layer-agnostic waiver, as the barrel requires.
+    barrel = _cpp_grid()
+    _install_domains(barrel)
+    barrel.set_attach_zones([_cpp_zone(0.0, -1.0, 5.0, 1.0, zone_ids, scoping)])
+    barrel.add_pad(2.5, 0.4, 0.2, 0.2, LV_NET, -1, 0, DRU, False)
+    assert _validate(barrel, [_cpp_segment(0.0, 0.0, 5.0, 0.0, HV_NET, layer=0)]).valid
+
+
+@requires_cpp
+def test_search_attach_zone_waiver_is_layer_scoped() -> None:
+    """The search-time annulus honours the same layer scoping as the validator."""
+    grid = _cpp_grid()
+    _install_domains(grid)
+    grid.set_attach_zones(
+        [_cpp_zone(0.0, 0.0, 20.0, 20.0, [HV_NET, LV_NET], {HV_NET: [1], LV_NET: [1]})]
+    )
+    pf = _pathfinder(grid)
+    grid.mark_blocked(100, 108, 0, LV_NET, False, False)
+    grid.mark_blocked(100, 108, 1, LV_NET, False, False)
+    # B.Cu (the rated part's pad layer): the pair may neck down -> not blocked.
+    assert pf.cross_domain_trace_blocked(100, 100, 1, HV_NET, SCALAR_RADIUS) is False
+    # F.Cu: copper merely crossing the pad field gets no waiver -> blocked.
+    assert pf.cross_domain_trace_blocked(100, 100, 0, HV_NET, SCALAR_RADIUS) is True
+
+
+@requires_cpp
+def test_backend_projects_zone_pad_layers_into_cpp_grid() -> None:
+    """``_sync_pairwise_domains_to_cpp`` carries the layer scoping across."""
+    py_grid, rules = _backend_grid_and_rules()
+    rules.pairwise_clearance = _table()
+    cpp_grid = CppGrid.from_routing_grid(py_grid)
+    backend = CppPathfinder(cpp_grid, rules, diagonal_routing=True)
+    backend.set_net_name_to_id(dict(NET_NAMES))
+    backend.set_attach_zones(
+        (AttachZone(0.0, -1.0, 5.0, 1.0, frozenset({"AC_LINE", "GND"}), _B_CU_ONLY),)
+    )
+
+    # The grid's own index map is the authority for name -> index.
+    assert backend._grid_layer_indices() == {"F.Cu": 0, "B.Cu": 1}
+
+    backend._sync_pairwise_domains_to_cpp()
+    _, _, cpp_zones = backend._pairwise_cpp_payload
+    assert [dict(z.net_layers) for z in cpp_zones] == [{HV_NET: [1], LV_NET: [1]}]
+    assert cpp_grid._impl.attach_zone_exempts(2.5, 0.0, HV_NET, LV_NET, 0) is False
+    assert cpp_grid._impl.attach_zone_exempts(2.5, 0.0, HV_NET, LV_NET, 1) is True
+
+
+# ---------------------------------------------------------------------------
+# Headline (#4507): layer scoping is what lets this board converge
+# ---------------------------------------------------------------------------
+
+# The convergence fixture's own net names (plain ``HV`` / ``LV``, no leading
+# slash) scoped to the rated part's B.Cu pad copper.
+_HV_LV_B_CU_ONLY = frozenset({("HV", frozenset({"B.Cu"})), ("LV", frozenset({"B.Cu"}))})
+
+
+def _route_through_a_rated_gap(layer_scoped: bool):
+    """Route one HV net whose only cheap path threads a rated part's pad field.
+
+    An LV wall spans the full board height on F.Cu with a single 3 mm gap, and
+    a rated footprint's attach zone straddles that gap -- but the part's pads
+    are on **B.Cu**, so the waiver does not licence F.Cu copper necking through
+    the gap.  The legal answer is to dive to B.Cu (where the waiver does
+    apply) and cross there.
+
+    ``layer_scoped=False`` reconstructs the pre-#4507 C++ shape exactly: the
+    zone crosses the Python/C++ boundary layer-AGNOSTIC (no layer map) while
+    the Python acceptance check stays layer-scoped.
+
+    Returns ``(route, gate_violation, layers_used, used_python_fallback)``.
+    """
+    from kicad_tools.router.layers import LayerStack
+    from kicad_tools.router.pairwise_clearance import route_pairwise_violation
+    from kicad_tools.router.primitives import Pad as PyPad
+    from kicad_tools.router.primitives import Route as PyRoute
+
+    zone = AttachZone(13.0, 7.0, 17.0, 13.0, frozenset({"HV", "LV"}), _HV_LV_B_CU_ONLY)
+    rules = DesignRules(
+        trace_width=TRACE_WIDTH,
+        trace_clearance=DRU,
+        via_diameter=0.6,
+        via_clearance=DRU,
+        grid_resolution=0.1,
+    )
+    rules.pairwise_clearance = build_pairwise_clearance_table({"HV": 150.0, "LV": 0.0}, dru=DRU)
+    grid = RoutingGrid(width=30.0, height=20.0, rules=rules, layer_stack=LayerStack.two_layer())
+    start = PyPad(x=3.0, y=10.0, width=0.6, height=0.6, net=1, net_name="HV", layer=Layer.F_CU)
+    end = PyPad(x=27.0, y=10.0, width=0.6, height=0.6, net=1, net_name="HV", layer=Layer.F_CU)
+    grid.add_pad(start)
+    grid.add_pad(end)
+    for y1, y2 in ((0.2, 8.5), (11.5, 19.8)):
+        wall = PyRoute(
+            net=2,
+            net_name="LV",
+            segments=[Segment(15.0, y1, 15.0, y2, TRACE_WIDTH, Layer.F_CU, net=2, net_name="LV")],
+        )
+        grid.mark_route(wall)
+        grid.routes.append(wall)
+
+    nc = NetClassRouting(name="HV", trace_width=TRACE_WIDTH, clearance=DRU)
+    cpp_grid = CppGrid.from_routing_grid(grid)
+    pf = CppPathfinder(cpp_grid, rules, diagonal_routing=True, net_class_map={"HV": nc})
+    pf.set_net_name_to_id({"HV": 1, "LV": 2})
+    pf.set_attach_zones((zone,))
+    if not layer_scoped:
+        pf._grid_layer_indices = lambda: None
+
+    fallback = {"used": False}
+    original = pf._try_python_fallback
+
+    def _spy(*args, **kwargs):
+        fallback["used"] = True
+        return original(*args, **kwargs)
+
+    pf._try_python_fallback = _spy
+    route = pf.route(start, end, net_class=nc)
+    violation = None
+    layers: set[str] = set()
+    if route is not None:
+        violation = route_pairwise_violation(
+            route,
+            1,
+            grid.routes,
+            rules.pairwise_clearance,
+            id_to_name={1: "HV", 2: "LV"},
+            attach_zones=(zone,),
+        )
+        layers = {seg.layer.name for seg in route.segments}
+    return route, violation, layers, fallback["used"]
+
+
+@requires_cpp
+def test_layer_scoped_zone_converges_where_layer_agnostic_thrashes() -> None:
+    """Headline (#4507): the layer-scoped search converges; the agnostic one does not.
+
+    Same board, same geometry, same C++ search -- only the zone's layer scoping
+    differs.  Layer-AGNOSTIC (the pre-#4507 C++ shape) the search keeps
+    proposing the F.Cu gap the layer-scoped Python post-check rejects, exhausts
+    its resume budget, drops into the pure-Python fallback and fails.
+    Layer-SCOPED, the search knows the F.Cu gap is illegal from the first
+    expansion, dives to the rated part's own B.Cu layer, and converges.
+    """
+    route, violation, layers, fallback = _route_through_a_rated_gap(layer_scoped=True)
+    assert route is not None, "layer-scoped search failed to converge"
+    assert violation is None, f"converged route still violates the gate: {violation}"
+    assert fallback is False, "convergence must come from the C++ search, not the fallback"
+    # It found the legal answer: cross on the layer the rated part licences.
+    assert "B_CU" in layers
+
+    blind_route, _, _, blind_fallback = _route_through_a_rated_gap(layer_scoped=False)
+    # The pre-#4507 shape cannot get there: it burns the resume budget on routes
+    # the layer-scoped gate rejects and ends up in the slow Python fallback.
+    assert blind_fallback is True, "the agnostic baseline is expected to thrash into fallback"
+    assert blind_route is None

--- a/tests/router/test_pairwise_cpp_parity.py
+++ b/tests/router/test_pairwise_cpp_parity.py
@@ -1144,40 +1144,71 @@ def test_validate_route_layer_scoped_zone_agrees_with_python_gate() -> None:
 
 @requires_cpp
 def test_pad_branch_keys_the_waiver_on_the_pads_own_layer() -> None:
-    """The layer-BLIND pad loop must not lose a waiver it physically deserves.
+    """Only the through-hole sub-case makes the pad branch's key choice visible.
 
-    ``validate_route``'s segment-vs-pad loop compares against every pad on
-    every layer (so a through-hole barrel is never missed).  Keying the zone
-    consult on the *candidate segment's* layer would therefore invent
-    violations for cross-layer seg-vs-SMD-pad pairs that are not in conflict at
-    all, so the consult keys on the PAD's own layer -- and a through-hole pad
-    (``layer_idx < 0``) stays layer-agnostic.
+    ``validate_route``'s segment-vs-pad loop is **not** layer-blind: ~40 lines
+    above the zone consult it already drops mismatched layers (``grid.cpp:768``,
+    ``Skip pads on different layers``: ``if (pad.layer_idx != -1 &&
+    pad.layer_idx != seg.layer) continue;``).  Only two shapes survive that
+    filter and reach the consult:
+
+    * a **same-layer SMD pad**, where ``pad.layer_idx == seg.layer`` -- the two
+      candidate keys are the same value there, so cases (a) and (b) pin that the
+      pad branch consults the zone at all and honours its layer scoping, but
+      they cannot distinguish the keys; and
+    * a **through-hole pad** (``layer_idx == -1``), where the pad's own layer
+      keeps the consult layer-agnostic because the barrel really does span every
+      copper layer.  Case (c) is the ONLY case that changes verdict if the key
+      is switched to ``seg.layer``, so it alone pins the design decision.
+
+    A cross-layer seg-vs-SMD-pad pair can never reach the consult -- the filter
+    above drops it first -- so a case built on that shape passes with this fix
+    fully reverted, and with no zone installed at all.  An earlier revision of
+    this test used exactly that shape for case (a); it is deliberately gone.
     """
     zone_ids = [HV_NET, LV_NET]
     # LV pad copper on B.Cu (index 1) only.
     scoping = {HV_NET: [1], LV_NET: [1]}
 
-    # (a) B.Cu SMD pad: the zone covers that layer -> waived, even though the
-    #     candidate segment being validated runs on F.Cu.
-    smd = _cpp_grid()
-    _install_domains(smd)
-    smd.set_attach_zones([_cpp_zone(0.0, -1.0, 5.0, 1.0, zone_ids, scoping)])
-    smd.add_pad(2.5, 0.4, 0.2, 0.2, LV_NET, 1, 0, DRU, False)
-    assert _validate(smd, [_cpp_segment(0.0, 0.0, 5.0, 0.0, HV_NET, layer=0)]).valid
+    def _pad_case(pad_layer: int, seg_layer: int, zone_layers=None) -> bool:
+        """Validate one HV segment against one LV pad; ``None`` installs no zone."""
+        grid = _cpp_grid()
+        _install_domains(grid)
+        if zone_layers is not None:
+            grid.set_attach_zones([_cpp_zone(0.0, -1.0, 5.0, 1.0, zone_ids, zone_layers)])
+        grid.add_pad(2.5, 0.4, 0.2, 0.2, LV_NET, pad_layer, 0, DRU, False)
+        return bool(
+            _validate(grid, [_cpp_segment(0.0, 0.0, 5.0, 0.0, HV_NET, layer=seg_layer)]).valid
+        )
 
-    # (b) F.Cu SMD pad: a layer the zone does NOT cover -> full widening.
-    other = _cpp_grid()
-    _install_domains(other)
-    other.set_attach_zones([_cpp_zone(0.0, -1.0, 5.0, 1.0, zone_ids, scoping)])
-    other.add_pad(2.5, 0.4, 0.2, 0.2, LV_NET, 0, 0, DRU, False)
-    assert not _validate(other, [_cpp_segment(0.0, 0.0, 5.0, 0.0, HV_NET, layer=0)]).valid
+    # (a) Same-layer SMD pad on a layer the zone covers -> waived.  The two
+    #     controls are what keep this non-vacuous: with no zone the identical
+    #     geometry is rejected, so the waiver is what flips the verdict, and a
+    #     zone scoped to the other layer does not waive it.
+    assert _pad_case(pad_layer=1, seg_layer=1, zone_layers=scoping) is True
+    assert _pad_case(pad_layer=1, seg_layer=1, zone_layers=None) is False
+    assert _pad_case(pad_layer=1, seg_layer=1, zone_layers={HV_NET: [0], LV_NET: [0]}) is False
 
-    # (c) Through-hole pad (layer_idx = -1): no single layer applies -> the
-    #     zone keeps its layer-agnostic waiver, as the barrel requires.
+    # (b) Same-layer SMD pad on a layer the zone does NOT cover -> full
+    #     widening.  This fails if the consult is layer-agnostic (the pre-#4507
+    #     shape, which waives here), so it pins layer scoping reaching the pad
+    #     branch at all -- but not the key choice, since the keys are equal.
+    assert _pad_case(pad_layer=0, seg_layer=0, zone_layers=scoping) is False
+
+    # (c) Through-hole pad (``layer_idx == -1``) against an F.Cu candidate: the
+    #     only case where the two candidate keys differ, so the only one that
+    #     pins the decision.  Keying on ``seg.layer`` (0 = F.Cu, a layer the
+    #     zone does not cover) would deny the waiver; the pad's own -1 keeps the
+    #     layer-agnostic verdict the barrel deserves.
     barrel = _cpp_grid()
     _install_domains(barrel)
     barrel.set_attach_zones([_cpp_zone(0.0, -1.0, 5.0, 1.0, zone_ids, scoping)])
     barrel.add_pad(2.5, 0.4, 0.2, 0.2, LV_NET, -1, 0, DRU, False)
+    # The gap point is the pad-centre/closest-approach midpoint, (2.5, 0.2).
+    # The two candidate keys genuinely disagree there ...
+    assert barrel.attach_zone_exempts(2.5, 0.2, HV_NET, LV_NET, 0) is False
+    assert barrel.attach_zone_exempts(2.5, 0.2, HV_NET, LV_NET, -1) is True
+    # ... and the pad branch takes the pad's own layer, so the pair is waived.
     assert _validate(barrel, [_cpp_segment(0.0, 0.0, 5.0, 0.0, HV_NET, layer=0)]).valid
 
 


### PR DESCRIPTION
## Summary

Phase 2 of epic #4431 (the pairwise HV-isolation clearance work) landed its two
children — #4510 (C++ domain-matrix `validate_route`) and #4511 (search-time
pairwise avoidance) — but left one **search↔gate disagreement** behind, and
disagreement is exactly the thrash this phase exists to remove.

PR #4756 (issue #4699) narrowed the #4506 rated-footprint attach-zone exemption
on the **Python** side: a zone waives the pairwise creepage widening only on the
copper layers where *both* nets have pad copper, so copper merely passing
*under* an SMD part is no longer exempted by an XY box it never touches. That PR
deliberately left the C++ `Grid3D` zone halo **layer-agnostic** — strictly more
permissive — with the layer-scoped Python `route_pairwise_violation` as the
acceptance check.

The consequence on an HV board: the C++ search necks an HV net through a rated
part's pad field on a layer that part has no copper on, its own `validate_route`
waives it, and the layer-scoped Python post-check then rejects the result. The
net burns its resume budget and drops into the 10-100x slower pure-Python
fallback — or fails outright. This PR makes the C++ waiver layer-scoped so the
search proposes only copper the gate accepts.

This is a **partial increment** of #4507. #4507 is the Phase-2 tracking issue
whose two children are already closed; this PR closes the residual C++/Python
mirror gap rather than re-implementing the phase. The remaining item on #4507 is
the manual softstart rev-C proof (softstart is a local-only fixture, so it cannot
be demonstrated from CI) — that is an epic-owner call, so the issue stays open.

## Changes

- **`AttachZone` gains `net_layers`** (`types.hpp`): net id → grid layer indices
  on which that net has pad copper on the rated footprint. Two escape hatches
  preserve the old verdict where it is still correct — a net **absent** from the
  map is unrestricted (that is how a through-hole `*.Cu` pad keeps waiving on
  every layer), and an **empty** map makes the whole zone layer-agnostic, i.e.
  byte-identical to the version-18 verdict that hand-built zones produce.
- **`Grid3D::attach_zone_exempts` gains a trailing `layer` argument**
  (default `-1` = layer-agnostic), so every existing caller keeps its verdict.
- **Every consult passes the layer the compared copper actually shares** — in
  `validate_route` (seg-vs-seg, seg-vs-via, via-vs-seg, seg-vs-pad) and in the
  search-time kernels `cross_domain_trace_blocked` / `cross_domain_via_blocked`.
  Two deliberate exceptions, both pinned by tests:
  - **via-vs-via stays agnostic** (`-1`): two barrels share no single layer.
    This matches the lattice engine's `exempt_pt_pt` convention exactly.
  - **the seg-vs-pad branch keys on the *pad's* own layer**, not the candidate
    segment's. That loop already skips mismatched layers before the zone
    consult (`grid.cpp:768`), so only two shapes reach it: a same-layer SMD pad,
    where `pad.layer_idx == seg.layer` and the two candidate keys are the same
    value, and a through-hole pad (`layer_idx == -1`), which stays agnostic
    because the barrel really does span every layer. That through-hole
    sub-case is the asymmetry's only behavioural effect — and case (c) of
    `test_pad_branch_keys_the_waiver_on_the_pads_own_layer` is correspondingly
    the only case that can distinguish the keys.
- **One implementation of the layer projection**: the body of
  `lattice/pairwise._project_zone_layers` is lifted into the shared
  `pairwise_clearance.project_zone_layers`, which the lattice engine now
  delegates to and which `attach_zones_to_net_ids` also uses — so no engine can
  drift from the #4588 gate. `attach_zones_to_net_ids` takes an optional
  `layer_indices` map and returns the projection in a new trailing tuple slot.
- **`CppPathfinder._grid_layer_indices()`** derives KiCad layer name → grid index
  from the grid's own `_index_to_layer` map (the same authority `layer_to_index`
  inverts for segments and vias), returning `None` — hence the agnostic verdict —
  for a bare `CppGrid` built without `from_routing_grid`.
- **`ROUTER_CPP_BUILD_VERSION` 18 → 19** and `_REQUIRED_CPP_BUILD_VERSION` to
  match (new struct field + new defaulted argument = new binding surface). Run
  `uv run kct build-native`.

Fully dormant without `--voltage-map`: with no domain table the widening never
fires, so the zone is never consulted.

## Acceptance Criteria Verification

| Criterion (from #4507 / its children) | Status | Verification |
|---|---|---|
| C++ `validate_route` and the search-time mirror stay exact mirrors of each other | ✅ | Both now take the same layer key per branch; `test_validate_route_layer_scoped_zone_agrees_with_python_gate` + `test_search_attach_zone_waiver_is_layer_scoped` pin validator and search to the same verdict on the same fixture |
| C++ verdict agrees with the Python acceptance gate (no search↔gate disagreement) | ✅ | `test_validate_route_layer_scoped_zone_agrees_with_python_gate` asserts `validate_route(...).valid is zone.exempts(...)` on both layers |
| Attach-zone exemption (#4506) threaded into the C++ check | ✅ | `test_backend_projects_zone_pad_layers_into_cpp_grid` walks the real `_sync_pairwise_domains_to_cpp` path from a `RoutingGrid` |
| Two-domain fixture **converges** where the previous shape thrashes (headline) | ✅ | `test_layer_scoped_zone_converges_where_layer_agnostic_thrashes`: same board, same search, only the scoping differs — agnostic burns its resume budget into the Python fallback and returns `None`; scoped converges on B.Cu with `violation is None` and never touches the fallback |
| Backward compat — no `--voltage-map` ⇒ unchanged routes | ✅ | `test_no_voltage_map_route_leaves_grid_dormant` (pre-existing) still passes; `test_attach_zone_without_layer_data_stays_layer_agnostic` pins the empty-map = version-18 verdict |
| Through-hole rated parts keep waiving on every layer | ✅ | `test_through_hole_zone_net_is_unrestricted_on_every_layer` and case (c) of `test_pad_branch_keys_the_waiver_on_the_pads_own_layer` |
| Softstart rev-C manual proof | ⬜ | Not attempted — softstart is a local-only fixture with no CI presence. This is why the reference below is `Part of`, not a close |

## Test Plan

Run in the issue worktree with the C++ backend rebuilt at version 19
(`uv run kct build-native` → `build version: 19 (required: 19)`):

- `uv run pytest tests/router/test_pairwise_cpp_parity.py` — **54 passed** (10m19s),
  including 11 new tests for this change
- `uv run pytest tests/router/test_pairwise_clearance.py tests/router/lattice` —
  **232 passed, 2 skipped** (3m14s)
- `uv run pytest tests/router` (full router suite, the broad regression gate) —
  **all passed, exit 0** (~40m, 4 env-skips, no failures)
- `uv run ruff check src/ tests/router/test_pairwise_cpp_parity.py` — All checks passed
- `uv run ruff format --check` on all four changed Python files — already formatted
- `uv run python scripts/ci/check_mypy_baseline.py` (cold, `.mypy_cache` removed) —
  OK, 1471 errors within the 1473 baseline, no new type errors
- **Full suite** (added on resume — the run above was router-scoped): `uv run pytest -q -x -n 4` — **25964 passed, 97 skipped, 0 failed** (27m24s)
- `uv run ruff format . --check` — 1784 files already formatted; `uv run ruff check .` (whole repo) — All checks passed

Part of #4507

