### PR TITLE
feat(router): recover the collinear merges kct route's collision gate vetoes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -692,6 +692,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`kct route` now runs a topology-preserving collinear consolidation pass
+  after the DRC nudge** (#4732, slice 2 — follows the slice-1
+  `--report-stage-quality` instrumentation in #4746) — the post-route
+  pipeline ended `optimize -> nudge -> finalize` with nothing that
+  consolidated the copper the nudge produced, and slice-1 measurement showed
+  the existing `TraceOptimizer` leaving **93.1% sub-0.25 mm fragments** on
+  board 03 with the median segment length pinned exactly at the 0.05 mm grid
+  step. Per-pass instrumentation pins the cause on the issue's **hypothesis 1
+  (collision conservatism)** and rules the rest out: `merge_collinear` takes
+  6838 -> 1490 segments but has **2725 of its 8075 candidate merges (33.7%)
+  vetoed by `path_is_clear`**, each veto chopping a collinear run in two;
+  every later pass is flat (zigzag 1490 -> 1490, staircase 1490 -> 1485,
+  45-corner 1485 -> 1488, pull-tight 1488 -> 1486), the DRC nudge is flat
+  (hypothesis 4 is *not* the cause on this board), and
+  `TraceOptimizer.optimize_route`'s revert-on-regression connectivity guard
+  fires **zero** times across all 37 routes. Those vetoes are false positives
+  by construction — a merged `A-B` + `B-C` adds no copper anywhere, so the
+  grid checker rejects it only because rasterizing one long clearance
+  envelope touches cells the two short ones did not. The new
+  `router/optimizer/consolidate.py` pass therefore needs no collision checker
+  to be safe, because it changes neither the copper nor the topology it would
+  be judged on: it removes only vertices of degree **exactly 2** whose two
+  incident segments are collinear, anti-parallel about the vertex, and share
+  layer / net / width, so every junction, terminal, via and pad vertex
+  survives by construction and the merged segment is the **exact union** of
+  what it replaces (checked, not asserted — a length guard rejects any run
+  whose merged length differs from the sum of its parts, and on the written
+  artifact every point of the pre-pass copper lies on the post-pass copper
+  and vice versa to 3e-14 mm, with per-`(net, layer)` trace length identical
+  to 1e-6 mm). Vertex keys are
+  deliberately layer-blind to match `validate_net_connectivity`'s own
+  layer-blind endpoint union-find; pad and via positions are protected
+  points; zero-length segments are counted toward vertex degree (so they
+  block a smoothing) but never merged, and the pass provably introduces
+  none. It commits through the same grid transaction the optimizer uses
+  (`apply_route_transform_grid_synced`, factored out of
+  `optimize_routes_grid_synced` — #3507/#3511 semantics unchanged) and is
+  wrapped in the same connectivity snapshot/enforce guard, with
+  `_finalize_committed_copper_or_demote` still the unconditional backstop.
+  Measured with everything else held fixed (same seed, same flags, only the
+  pass toggled): **board 03** 1486 -> 252 segments, `fragment_fraction`
+  93.1% -> 57.5%, 45°-diagonal share 7.3% -> 38.1%, 13/13 nets;
+  **board 02** 476 -> 295 segments, `fragment_fraction` 80.7% -> 58.3%,
+  8/8 nets. DRC state is identical before/after on both boards under
+  `kct check` (0 errors) *and* the `kicad-cli pcb drc --refill-zones`
+  cross-gate (identical violation and unconnected-item histograms), and
+  `kct pcb net-audit` output is byte-identical apart from the input path.
+  Gated exactly like the optimizer: `--no-optimize` / `--raw` bypasses it,
+  and `--route-engine lattice|mesh` without `--lattice-optimize` never
+  reaches it (#4281). `--report-stage-quality` gains a `post-consolidate`
+  row, recorded only when the pass actually ran. No board artifacts were
+  regenerated — all measurement ran in a scratch directory.
 - **`isolated_copper` now implements KiCad's pad-in-cluster predicate**
   (closes #4729, follow-up to #4680 / #4728) — an island is isolated iff
   its **transitive** same-net copper cluster contains **no pad**, where

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -3872,8 +3872,8 @@ def _add_route_parser(subparsers) -> None:
         action="store_true",
         help=(
             "Print advisory routing-quality metrics per post-route stage "
-            "(pre-optimize / post-optimize / post-nudge / post-finalize). "
-            "Read-only diagnostic -- never changes routed copper"
+            "(pre-optimize / post-optimize / post-nudge / post-consolidate / "
+            "post-finalize). Read-only diagnostic -- never changes routed copper"
         ),
     )
     # Issue #4502: tri-state default.  ``BooleanOptionalAction`` with

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -99,6 +99,7 @@ from kicad_tools.router.auto_pour import auto_skip_pour_nets as _auto_skip_pour_
 # CONSTRUCTION of the recorder (``_make_stage_quality_recorder``), which is
 # where the measurement cost actually lives.
 from kicad_tools.router.quality_probe import (  # noqa: E402
+    STAGE_POST_CONSOLIDATE,
     STAGE_POST_FINALIZE,
     STAGE_POST_NUDGE,
     STAGE_POST_OPTIMIZE,
@@ -1143,6 +1144,66 @@ def _resolve_route_engine(args: argparse.Namespace) -> str:
     namespace: argparse's ``choices`` guarantees a non-empty string.
     """
     return getattr(args, "route_engine", "grid") or "grid"
+
+
+def _run_consolidation_pass(
+    router: Any,
+    args: argparse.Namespace,
+    *,
+    post_passes_enabled: bool,
+    stage_recorder: Any = None,
+    quiet: bool = False,
+) -> None:
+    """Run the #4732 post-nudge collinear consolidation pass.
+
+    The pipeline used to end ``optimize -> nudge -> finalize`` with no
+    consolidation after the nudge, and the optimizer's own
+    ``merge_collinear`` leaves a third of its candidates unmerged because
+    each one is gated on a collision check (measured on board 03: 2725 of
+    8075 candidates vetoed).  This pass is topology- and
+    copper-preserving by construction -- it only removes degree-2
+    vertices between collinear, same-width, same-layer, same-net
+    segments, so the merged segment is the exact union of what it
+    replaces.  See :mod:`kicad_tools.router.optimizer.consolidate` for
+    the full measurement and the safety argument.
+
+    Gating mirrors the optimizer exactly: skipped for non-grid engines
+    without ``--lattice-optimize`` (#4281) and bypassed by
+    ``--no-optimize`` / ``--raw``.  The guard stack is the same one the
+    optimize and nudge phases use (connectivity snapshot + enforce),
+    with :func:`_finalize_committed_copper_or_demote` still the
+    unconditional backstop downstream.
+
+    No collision checker is supplied on purpose: a merged segment covers
+    exactly the copper its parts already covered, so a veto on it can
+    only be a rasterization artifact of the grid walk, never a real
+    hazard -- and passing the pipeline's checker in would simply
+    reproduce the ``merge_collinear`` veto this pass exists to recover.
+    The union property is enforced structurally instead (degree-2 +
+    collinear + anti-parallel) and checked by the length guard in
+    :func:`~kicad_tools.router.optimizer.consolidate.consolidate_segments`.
+    """
+    if not post_passes_enabled or getattr(args, "no_optimize", False):
+        return
+    if not getattr(router, "routes", None):
+        return
+
+    from kicad_tools.cli.progress import spinner
+    from kicad_tools.router.optimizer import consolidate_routes_grid_synced
+
+    snapshot = _connectivity_snapshot(router)
+    with spinner("Consolidating traces...", quiet=quiet):
+        stats = consolidate_routes_grid_synced(router)
+    _enforce_connectivity_invariant_or_exit(
+        router,
+        snapshot,
+        phase="consolidate",
+        args=args,
+        quiet=quiet,
+    )
+    _record_stage_quality(stage_recorder, STAGE_POST_CONSOLIDATE, router)
+    if not quiet and stats.runs_merged:
+        print(f"  Consolidation: {stats.summary()}")
 
 
 def _engine_post_passes_enabled(
@@ -6309,6 +6370,16 @@ def route_with_layer_escalation(
         )
         _record_stage_quality(_stage_quality, STAGE_POST_NUDGE, final_result.router)
 
+    # Issue #4732: post-nudge collinear consolidation.  Runs LAST of the
+    # geometric passes so it also absorbs fragments the nudge introduced.
+    _run_consolidation_pass(
+        final_result.router,
+        args,
+        post_passes_enabled=_post_passes_enabled,
+        stage_recorder=_stage_quality,
+        quiet=quiet,
+    )
+
     # Issue #4208 (Unit 3): re-run the Unit-2 seg-seg finalize gate
     # over the post-optimize/post-nudge copper.  An rtree-less
     # optimizer can introduce a cross-net crossing the pre-optimize
@@ -7093,6 +7164,16 @@ def route_with_rule_relaxation(
             quiet=quiet,
         )
         _record_stage_quality(_stage_quality, STAGE_POST_NUDGE, final_result.router)
+
+    # Issue #4732: post-nudge collinear consolidation.  Runs LAST of the
+    # geometric passes so it also absorbs fragments the nudge introduced.
+    _run_consolidation_pass(
+        final_result.router,
+        args,
+        post_passes_enabled=_post_passes_enabled,
+        stage_recorder=_stage_quality,
+        quiet=quiet,
+    )
 
     # Issue #4208 (Unit 3): re-run the Unit-2 seg-seg finalize gate
     # over the post-optimize/post-nudge copper.  An rtree-less
@@ -9378,6 +9459,16 @@ def route_with_combined_escalation(
             quiet=quiet,
         )
         _record_stage_quality(_stage_quality, STAGE_POST_NUDGE, final_result.router)
+
+    # Issue #4732: post-nudge collinear consolidation.  Runs LAST of the
+    # geometric passes so it also absorbs fragments the nudge introduced.
+    _run_consolidation_pass(
+        final_result.router,
+        args,
+        post_passes_enabled=_post_passes_enabled,
+        stage_recorder=_stage_quality,
+        quiet=quiet,
+    )
 
     # Issue #4208 (Unit 3): re-run the Unit-2 seg-seg finalize gate
     # over the post-optimize/post-nudge copper.  An rtree-less
@@ -12087,8 +12178,9 @@ def _main_impl(argv: list[str] | None = None) -> int:
         help=(
             "Print advisory routing-quality metrics (fragment/staircase "
             "fractions, 45-degree share, median segment length) measured "
-            "before optimize, after optimize, after the DRC nudge, and after "
-            "the finalize/demote backstop. Diagnostic only: the probe is "
+            "before optimize, after optimize, after the DRC nudge, after the "
+            "collinear consolidation pass, and after the finalize/demote "
+            "backstop. Diagnostic only: the probe is "
             "read-only and never changes routed copper or the exit code "
             "(issue #4732)."
         ),
@@ -14737,6 +14829,16 @@ def _main_impl(argv: list[str] | None = None) -> int:
             quiet=quiet,
         )
         _record_stage_quality(_stage_quality, STAGE_POST_NUDGE, router)
+
+    # Issue #4732: post-nudge collinear consolidation.  Runs LAST of the
+    # geometric passes so it also absorbs fragments the nudge introduced.
+    _run_consolidation_pass(
+        router,
+        args,
+        post_passes_enabled=_post_passes_enabled,
+        stage_recorder=_stage_quality,
+        quiet=quiet,
+    )
 
     # Issue #4208 (Unit 3): re-run the Unit-2 seg-seg finalize gate
     # over the post-optimize/post-nudge copper.  An rtree-less

--- a/src/kicad_tools/router/optimizer/__init__.py
+++ b/src/kicad_tools/router/optimizer/__init__.py
@@ -37,6 +37,12 @@ from .collision import (
     make_collision_checker,
 )
 from .config import OptimizationConfig, OptimizationStats
+from .consolidate import (
+    ConsolidationStats,
+    consolidate_net_routes,
+    consolidate_routes_grid_synced,
+    consolidate_segments,
+)
 from .serpentine import (
     SerpentineConfig,
     SerpentineGenerator,
@@ -45,7 +51,11 @@ from .serpentine import (
     add_serpentine,
     tune_match_group,
 )
-from .trace import TraceOptimizer, optimize_routes_grid_synced
+from .trace import (
+    TraceOptimizer,
+    apply_route_transform_grid_synced,
+    optimize_routes_grid_synced,
+)
 from .via_optimizer import (
     LayerConnectivityError,
     ViaOptimizationConfig,
@@ -56,6 +66,7 @@ from .via_optimizer import (
 
 __all__ = [
     "CollisionChecker",
+    "ConsolidationStats",
     "GridCollisionChecker",
     "VectorCollisionChecker",
     "make_collision_checker",
@@ -71,6 +82,10 @@ __all__ = [
     "ViaOptimizationStats",
     "ViaOptimizer",
     "add_serpentine",
+    "apply_route_transform_grid_synced",
+    "consolidate_net_routes",
+    "consolidate_routes_grid_synced",
+    "consolidate_segments",
     "optimize_route_vias",
     "optimize_routes_grid_synced",
     "tune_match_group",

--- a/src/kicad_tools/router/optimizer/consolidate.py
+++ b/src/kicad_tools/router/optimizer/consolidate.py
@@ -1,0 +1,590 @@
+"""Topology-preserving collinear consolidation of routed copper (issue #4732).
+
+Slice-1 instrumentation (``--report-stage-quality``, PR #4746) measured
+the real shape of the problem.  On board 03 under its pinned production
+recipe (seed 42, ``--backend cpp --deterministic-budget``)::
+
+    stage             segs   frag%  stair%  45deg%  zero  median_mm
+    pre-optimize      6838    99.1     0.1    19.9     0      0.050
+    post-optimize     1486    93.1     0.1     7.3     0      0.050
+    post-nudge        1486    93.1     0.1     7.3     0      0.050
+
+The optimizer cuts segment count by 78%, yet **93% of what survives is
+still sub-0.25 mm copper**, with a median segment length pinned exactly
+at the 0.05 mm grid step, and the DRC nudge moves nothing at all.
+
+Instrumenting the individual optimizer passes on that same route pins the
+cause on **hypothesis 1 of the issue (collision conservatism)**, and rules
+the others out:
+
+======================  ==============
+pass                    segments in/out
+======================  ==============
+``merge_collinear``     6838 -> 1490
+``eliminate_zigzags``   1490 -> 1490
+``compress_staircase``  1490 -> 1485
+``convert_corners_45``  1485 -> 1488
+``pull_tight``          1488 -> 1486
+======================  ==============
+
+Everything after ``merge_collinear`` is flat, and so is the DRC nudge
+(hypothesis 4).  ``TraceOptimizer.optimize_route``'s revert-on-regression
+connectivity guard fires **zero** times across all 37 routes, so it is not
+discarding the work either.  What *does* happen is inside
+``merge_collinear`` itself: every candidate merge is gated on
+``path_is_clear``, and **2725 of its 8075 candidates (33.7%) are vetoed**.
+Each veto chops one collinear run into two, and no later pass revisits it.
+
+Those vetoes are false positives by construction.  A merged
+``A-B`` + ``B-C`` is the *exact union* of two segments the board already
+carries -- it adds no copper anywhere -- so nothing about it can be a new
+hazard; the grid checker rejects it only because rasterizing one long
+segment's clearance envelope touches cells that rasterizing the two short
+ones did not.  This module is therefore the consolidation that does not
+need a collision checker to be safe, because it never changes either the
+copper or the topology it would be judged on:
+
+* Only a vertex of **degree exactly 2** is ever removed, and only when
+  its two incident segments are collinear, anti-parallel about it, and
+  share layer / net / width.  Every junction, terminal, via and pad
+  vertex survives by construction, so the connectivity graph after the
+  pass is isomorphic to the one before it (a topological *smoothing*,
+  not a rewrite).
+* The merged segment is the exact union of the segments it replaces --
+  same line, same width, same layer, same extent.  The copper footprint
+  on the board is unchanged, so DRC state cannot move either.  This was
+  verified on the written artifact, not just argued: densely sampling
+  boards 02 and 03 before and after the pass, every point of the
+  pre-pass copper lies on the post-pass copper and vice versa, to
+  3e-14 mm, and per-``(net, layer)`` total trace length is identical to
+  1e-6 mm.
+
+That makes it safe to run *after* the DRC nudge, where the pipeline
+previously had no consolidation at all, and its only observable effect
+is a shorter, saner segment list.
+
+**Why not just drop ``merge_collinear``'s collision gate instead?**
+Because that gate is load-bearing *there*.  ``merge_collinear`` merges
+whatever is adjacent in its chain's list order; it performs no vertex
+degree check, so nothing stops it from merging through a junction that
+belongs to a different chain or a sibling route -- the collision check is
+the only thing standing between it and that class of mistake, and
+``optimize_route``'s revert-on-regression guard would then throw away the
+entire route rather than the one bad merge.  Relaxing it would also
+change behaviour for every other ``TraceOptimizer`` consumer
+(``kct optimize-traces``, ``TraceOptimizer.optimize_pcb``, the board
+recipes).  A separate degree-aware pass recovers the vetoed merges
+without touching any of that, and additionally closes the
+"nudge output is never re-consolidated" ordering hole, since it runs
+after the DRC nudge rather than before it.
+
+**Vertex keys are deliberately layer-blind.**  Degree is counted over
+``(x, y)`` alone, not ``(x, y, layer)``.  That is not an oversight: the
+invariant this pass is judged against --
+:func:`~kicad_tools.router.observability.validate_net_connectivity`, via
+:mod:`~kicad_tools.router.connectivity_invariant` -- unions segment
+endpoints on their ``(x, y)`` alone as well, so in *its* model a
+coincident endpoint on another layer is a connection whether or not a via
+is present.  Keying per layer here would let the pass smooth away a
+vertex the invariant still treats as a junction, i.e. manufacture exactly
+the false regression the design exists to avoid.  Coincidence across
+layers merely makes the pass skip a merge; it can never make it perform
+an unsafe one.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass
+
+from ..primitives import Route, Segment
+
+# Cross-product ceiling (on unit vectors) for treating two segments as
+# collinear.  ~5.7e-5 degrees -- far below any real routing angle, wide
+# enough to absorb the float noise in coordinates like 32.70000000000001.
+COLLINEAR_CROSS_EPSILON = 1e-6
+
+# Absolute tolerance for "same width" (widths are authored in mm).
+WIDTH_EPSILON_MM = 1e-9
+
+# Default coordinate quantization for endpoint coincidence (mm).  Matches
+# the router-wide vertex tolerance used by the optimizer's own
+# connectivity guard (``optimizer.trace._vertex_key``).
+DEFAULT_TOLERANCE_MM = 1e-4
+
+
+@dataclass(frozen=True)
+class ConsolidationStats:
+    """What one consolidation pass did.
+
+    Attributes:
+        segments_before: Segment count over the input.
+        segments_after: Segment count over the output.
+        runs_merged: Number of maximal collinear runs collapsed into a
+            single segment.
+        runs_vetoed: Number of candidate runs left as-is because the
+            collision checker (or the union-length guard) rejected the
+            merged segment.
+        routes_changed: Number of routes whose segment list changed
+            (0 for the segment-level API, which has no routes).
+    """
+
+    segments_before: int = 0
+    segments_after: int = 0
+    runs_merged: int = 0
+    runs_vetoed: int = 0
+    routes_changed: int = 0
+
+    @property
+    def segments_removed(self) -> int:
+        """Segments eliminated by the pass."""
+        return self.segments_before - self.segments_after
+
+    def summary(self) -> str:
+        """One-line human summary for the CLI."""
+        pct = (
+            (self.segments_removed / self.segments_before * 100.0) if self.segments_before else 0.0
+        )
+        text = (
+            f"{self.segments_before} -> {self.segments_after} segments "
+            f"({self.segments_removed} removed, {pct:.1f}%), "
+            f"{self.runs_merged} collinear run(s) merged across "
+            f"{self.routes_changed} route(s)"
+        )
+        if self.runs_vetoed:
+            text += f", {self.runs_vetoed} vetoed"
+        return text
+
+
+def _qkey(x: float, y: float, tolerance: float) -> tuple[int, int]:
+    """Quantize a point so coincident endpoints share a key."""
+    if tolerance <= 0:
+        return (round(x * 1e9), round(y * 1e9))
+    return (round(x / tolerance), round(y / tolerance))
+
+
+def _length(seg: Segment) -> float:
+    """Euclidean length of ``seg`` in mm."""
+    return math.hypot(seg.x2 - seg.x1, seg.y2 - seg.y1)
+
+
+def _unit_away(seg: Segment, at_start: bool) -> tuple[float, float] | None:
+    """Unit vector of ``seg`` pointing away from the named endpoint.
+
+    ``None`` for a zero-length segment: it has no direction, and such
+    segments are never merged.
+    """
+    if at_start:
+        dx, dy = seg.x2 - seg.x1, seg.y2 - seg.y1
+    else:
+        dx, dy = seg.x1 - seg.x2, seg.y1 - seg.y2
+    norm = math.hypot(dx, dy)
+    if norm <= 0.0:
+        return None
+    return (dx / norm, dy / norm)
+
+
+def _anti_parallel(u: tuple[float, float], v: tuple[float, float]) -> bool:
+    """True when unit vectors ``u`` and ``v`` point in opposite directions.
+
+    Both point *away* from a shared vertex, so anti-parallel is exactly
+    the condition "the vertex lies strictly between the two far
+    endpoints on one straight line".  A non-negative dot product means
+    the pair doubles back on itself; merging that would silently delete
+    copper, so it is rejected.
+    """
+    cross = u[0] * v[1] - u[1] * v[0]
+    dot = u[0] * v[0] + u[1] * v[1]
+    return dot < 0.0 and abs(cross) <= COLLINEAR_CROSS_EPSILON
+
+
+class _DisjointSet:
+    """Minimal union-find over segment indices."""
+
+    def __init__(self, size: int) -> None:
+        self._parent = list(range(size))
+
+    def find(self, i: int) -> int:
+        root = i
+        while self._parent[root] != root:
+            root = self._parent[root]
+        while self._parent[i] != root:
+            self._parent[i], i = root, self._parent[i]
+        return root
+
+    def union(self, a: int, b: int) -> None:
+        ra, rb = self.find(a), self.find(b)
+        if ra != rb:
+            self._parent[max(ra, rb)] = min(ra, rb)
+
+
+def _consolidate_indexed(
+    segments: Sequence[Segment],
+    *,
+    protected_points: Iterable[tuple[float, float]],
+    tolerance: float,
+    path_is_clear: Callable[[Segment], bool] | None,
+    same_owner: Callable[[int, int], bool] | None,
+) -> tuple[list[tuple[int, Segment]], ConsolidationStats]:
+    """Core pass.  Returns ``[(source_index, segment), ...]`` plus stats.
+
+    ``source_index`` is the index of the input segment a result segment
+    came from; for a merged run it is the lowest index in that run.  The
+    caller uses it to re-attach results to whatever the input segments
+    belonged to.  Output order follows input order.
+    """
+    n = len(segments)
+    if n < 2:
+        return (
+            [(i, s) for i, s in enumerate(segments)],
+            ConsolidationStats(segments_before=n, segments_after=n),
+        )
+
+    protected = {_qkey(px, py, tolerance) for px, py in protected_points}
+
+    # vertex key -> [(segment index, is_start), ...].
+    #
+    # Zero-length segments ARE counted here even though they can never be
+    # merged: a zero-length segment sitting on an otherwise degree-2
+    # vertex raises that vertex's degree to 4, which blocks the smoothing.
+    # Leaving them out would let the pass delete the vertex and strand the
+    # zero-length stub as its own connectivity component -- and the DRC
+    # nudge is a measured producer of exactly one such segment (#4732
+    # slice-1 finding 2).
+    incident: dict[tuple[int, int], list[tuple[int, bool]]] = {}
+    usable: list[bool] = []
+    for i, seg in enumerate(segments):
+        usable.append(_length(seg) > 0.0)
+        for x, y, is_start in ((seg.x1, seg.y1, True), (seg.x2, seg.y2, False)):
+            incident.setdefault(_qkey(x, y, tolerance), []).append((i, is_start))
+
+    dsu = _DisjointSet(n)
+    smoothed: set[tuple[int, int]] = set()
+    for key, hits in incident.items():
+        if len(hits) != 2 or key in protected:
+            continue
+        (ia, a_start), (ib, b_start) = hits
+        if ia == ib:
+            continue  # a segment that loops back onto itself (or is zero-length)
+        if not usable[ia] or not usable[ib]:
+            continue
+        sa, sb = segments[ia], segments[ib]
+        if sa.layer != sb.layer or sa.net != sb.net:
+            continue
+        if abs(sa.width - sb.width) > WIDTH_EPSILON_MM:
+            continue
+        if same_owner is not None and not same_owner(ia, ib):
+            continue
+        ua = _unit_away(sa, a_start)
+        ub = _unit_away(sb, b_start)
+        if ua is None or ub is None or not _anti_parallel(ua, ub):
+            continue
+        dsu.union(ia, ib)
+        smoothed.add(key)
+
+    groups: dict[int, list[int]] = {}
+    for i in range(n):
+        if usable[i]:
+            groups.setdefault(dsu.find(i), []).append(i)
+
+    replacement: dict[int, Segment] = {}
+    dropped: set[int] = set()
+    runs_merged = 0
+    runs_vetoed = 0
+    for members in groups.values():
+        if len(members) < 2:
+            continue
+        # A run is a simple path: its two ends are the endpoint keys that
+        # were not smoothed away.  Endpoint coordinates come from the
+        # member segments themselves (never from a shared quantization
+        # bucket), so the merged segment lands on real routed copper.
+        # Anything that is not exactly two distinct ends is a shape this
+        # pass does not claim to understand -- leave it alone.
+        ends: list[tuple[tuple[int, int], float, float]] = []
+        for i in members:
+            seg = segments[i]
+            for x, y in ((seg.x1, seg.y1), (seg.x2, seg.y2)):
+                key = _qkey(x, y, tolerance)
+                if key not in smoothed:
+                    ends.append((key, x, y))
+        if len(ends) != 2 or ends[0][0] == ends[1][0]:
+            continue
+        head = min(members)
+        template = segments[head]
+        first, second = ends
+        # Orient the merged segment the way its lowest-index member runs,
+        # so the output geometry is deterministic.
+        if _qkey(template.x1, template.y1, tolerance) == second[0]:
+            first, second = second, first
+        merged = dataclasses.replace(
+            template,
+            x1=first[1],
+            y1=first[2],
+            x2=second[1],
+            y2=second[2],
+        )
+        merged_length = _length(merged)
+        if merged_length <= 0.0:
+            continue  # never introduce a zero-length segment
+        # Union guard: the merged segment must be exactly as long as the
+        # copper it replaces.  Collinearity + anti-parallelism already
+        # imply it, so this can only fire on a logic error -- but it is
+        # the cheap, always-correct invariant that makes "the copper is
+        # unchanged" a checked property rather than a claim.
+        parts_length = sum(_length(segments[m]) for m in members)
+        if abs(merged_length - parts_length) > max(tolerance, 1e-9):
+            runs_vetoed += 1
+            continue
+        if path_is_clear is not None and not path_is_clear(merged):
+            runs_vetoed += 1
+            continue
+        replacement[head] = merged
+        dropped.update(m for m in members if m != head)
+        runs_merged += 1
+
+    result: list[tuple[int, Segment]] = []
+    for i, seg in enumerate(segments):
+        if i in dropped:
+            continue
+        result.append((i, replacement.get(i, seg)))
+
+    return result, ConsolidationStats(
+        segments_before=n,
+        segments_after=len(result),
+        runs_merged=runs_merged,
+        runs_vetoed=runs_vetoed,
+    )
+
+
+def consolidate_segments(
+    segments: Sequence[Segment],
+    *,
+    protected_points: Iterable[tuple[float, float]] = (),
+    tolerance: float = DEFAULT_TOLERANCE_MM,
+    path_is_clear: Callable[[Segment], bool] | None = None,
+) -> tuple[list[Segment], ConsolidationStats]:
+    """Collapse maximal collinear runs of ``segments`` into single segments.
+
+    A run is merged only when every interior vertex it removes has degree
+    exactly 2 **in the whole input**, is not a protected point, and joins
+    two segments that are collinear, anti-parallel about it, and share
+    layer, net and width.  Everything else is returned untouched, in its
+    original relative order.
+
+    Args:
+        segments: Segments to consolidate.  The caller decides what "the
+            whole input" means -- pass every segment of a net so that
+            cross-route T-junctions are visible as degree-3 vertices.
+        protected_points: Points that must survive as vertices (via and
+            pad positions), compared at the same ``tolerance``.
+        tolerance: Coordinate quantization for endpoint coincidence (mm).
+        path_is_clear: Optional collision check applied to each merged
+            candidate; a veto keeps the originals.  **Off by default,
+            deliberately.**  A merged segment is the exact union of its
+            parts (enforced by the length guard in
+            :func:`_consolidate_indexed`), so it occupies copper the
+            board already carries -- the pipeline's own
+            ``make_collision_checker`` reports that copper as blocked
+            because it is *already committed on the grid*, which would
+            veto every merge while describing no real hazard.  The
+            parameter exists for callers whose checker models something
+            copper-union reasoning does not cover.
+
+    Returns:
+        ``(consolidated_segments, stats)``.
+    """
+    indexed, stats = _consolidate_indexed(
+        segments,
+        protected_points=protected_points,
+        tolerance=tolerance,
+        path_is_clear=path_is_clear,
+        same_owner=None,
+    )
+    return [seg for _i, seg in indexed], stats
+
+
+def consolidate_net_routes(
+    routes: Sequence[Route],
+    *,
+    pad_positions: Iterable[tuple[float, float]] = (),
+    tolerance: float = DEFAULT_TOLERANCE_MM,
+    path_is_clear: Callable[[Segment], bool] | None = None,
+) -> tuple[list[Route], ConsolidationStats]:
+    """Consolidate every route of a single net as one connectivity graph.
+
+    Vertex degree is computed over the net's **whole** copper, so a point
+    where one route's stub lands mid-run of another route is seen as
+    degree 3 and is never smoothed away -- which is exactly what keeps
+    :func:`~kicad_tools.router.observability.validate_net_connectivity`'s
+    endpoint union-find intact.  Segments are still only merged with
+    segments of their own route, so route bookkeeping (and
+    ``grid.routes`` identity) stays aligned.
+
+    Returns:
+        ``(routes, stats)`` -- the original object where a route was
+        unchanged, a new :class:`Route` where it was consolidated.
+    """
+    flat: list[Segment] = []
+    owner_index: list[int] = []
+    protected: list[tuple[float, float]] = list(pad_positions)
+    for ri, route in enumerate(routes):
+        for seg in route.segments:
+            flat.append(seg)
+            owner_index.append(ri)
+        for via in route.vias:
+            protected.append((via.x, via.y))
+
+    if len(flat) < 2:
+        return list(routes), ConsolidationStats(segments_before=len(flat), segments_after=len(flat))
+
+    indexed, raw = _consolidate_indexed(
+        flat,
+        protected_points=protected,
+        tolerance=tolerance,
+        path_is_clear=path_is_clear,
+        same_owner=lambda a, b: owner_index[a] == owner_index[b],
+    )
+    if raw.runs_merged == 0:
+        return list(routes), ConsolidationStats(
+            segments_before=len(flat),
+            segments_after=len(flat),
+            runs_vetoed=raw.runs_vetoed,
+        )
+
+    by_owner: list[list[Segment]] = [[] for _ in routes]
+    for source, seg in indexed:
+        by_owner[owner_index[source]].append(seg)
+
+    out: list[Route] = []
+    routes_changed = 0
+    for ri, route in enumerate(routes):
+        segs = by_owner[ri]
+        if len(segs) == len(route.segments):
+            out.append(route)
+            continue
+        routes_changed += 1
+        # ``dataclasses.replace`` rather than a hand-written ``Route(...)``
+        # so additive Route fields (``is_escape``, #3441) are carried
+        # forward instead of silently reset to their defaults.
+        out.append(dataclasses.replace(route, segments=segs, vias=list(route.vias)))
+
+    return out, ConsolidationStats(
+        segments_before=len(flat),
+        segments_after=len(indexed),
+        runs_merged=raw.runs_merged,
+        runs_vetoed=raw.runs_vetoed,
+        routes_changed=routes_changed,
+    )
+
+
+def consolidate_routes_grid_synced(
+    router,
+    *,
+    skip_nets: set[int] | None = None,
+    path_is_clear: Callable[[Segment], bool] | None = None,
+    tolerance: float = DEFAULT_TOLERANCE_MM,
+) -> ConsolidationStats:
+    """Consolidate every route on ``router``, keeping the grid in sync.
+
+    Groups ``router.routes`` by net, runs :func:`consolidate_net_routes`
+    per net, and commits the result through the same grid transaction the
+    optimizer uses (:func:`~kicad_tools.router.optimizer.trace.apply_route_transform_grid_synced`)
+    so cells, R-trees, ``grid.routes`` bookkeeping and the C++ mirror all
+    follow the copper.  The transaction is a formality here -- a
+    consolidated route occupies exactly the cells its fragments did --
+    but going through it keeps ``grid.routes`` pointing at the live
+    ``Route`` objects instead of stale twins.
+
+    Pad positions come from ``router.nets`` / ``router.pads`` when
+    available so a pad sitting mid-run stays a vertex; a router without
+    that metadata simply protects vias and junctions.
+
+    Args:
+        router: ``Autorouter`` whose ``routes`` are consolidated in place.
+        skip_nets: Net IDs to pass through untouched (#3508 parity).
+            Consolidation is length- and geometry-preserving, so
+            diff-pair serpentines are already safe -- the parameter
+            exists so callers can be conservative.
+        path_is_clear: Optional collision check for merged candidates.
+        tolerance: Coordinate quantization for endpoint coincidence (mm).
+
+    Returns:
+        Aggregate :class:`ConsolidationStats` for the whole router.
+    """
+    from .trace import apply_route_transform_grid_synced
+
+    routes_by_net: dict[int, list[Route]] = {}
+    for route in router.routes:
+        if skip_nets is not None and route.net in skip_nets:
+            continue
+        routes_by_net.setdefault(route.net, []).append(route)
+
+    pads_by_net = _pad_positions_by_net(router)
+
+    # ``Route`` is an unhashable (eq-able) dataclass, so identity is the
+    # only usable key.  Every original stays alive in ``routes_by_net``
+    # for the whole function, which is what makes ``id()`` safe here.
+    replacements: dict[int, Route] = {}
+    before = after = merged = vetoed = changed = 0
+    for net, net_routes in routes_by_net.items():
+        new_routes, stats = consolidate_net_routes(
+            net_routes,
+            pad_positions=pads_by_net.get(net, ()),
+            tolerance=tolerance,
+            path_is_clear=path_is_clear,
+        )
+        before += stats.segments_before
+        after += stats.segments_after
+        merged += stats.runs_merged
+        vetoed += stats.runs_vetoed
+        changed += stats.routes_changed
+        for old, new in zip(net_routes, new_routes, strict=False):
+            if new is not old:
+                replacements[id(old)] = new
+
+    if replacements:
+        apply_route_transform_grid_synced(
+            router,
+            lambda route: replacements.get(id(route), route),
+            skip_nets=skip_nets,
+        )
+
+    return ConsolidationStats(
+        segments_before=before,
+        segments_after=after,
+        runs_merged=merged,
+        runs_vetoed=vetoed,
+        routes_changed=changed,
+    )
+
+
+def _pad_positions_by_net(router) -> dict[int, list[tuple[float, float]]]:
+    """Best-effort ``{net: [(x, y), ...]}`` pad map for vertex protection.
+
+    A pad that sits mid-run is a degree-2 vertex the topology argument
+    would otherwise allow smoothing away; ``validate_net_connectivity``
+    links pads to their nearest segment *endpoint*, so removing that
+    vertex could move a pad's attachment point.  Protecting pad
+    positions keeps that link exact.  Any router shape without the
+    ``nets``/``pads`` metadata degrades to junction+via protection only.
+    """
+    pads_by_net: dict[int, list[tuple[float, float]]] = {}
+    nets = getattr(router, "nets", None)
+    pads = getattr(router, "pads", None)
+    if not isinstance(nets, dict) or not isinstance(pads, dict):
+        return pads_by_net
+    for net_id, pad_keys in nets.items():
+        positions: list[tuple[float, float]] = []
+        for key in pad_keys:
+            pad = pads.get(key)
+            if pad is None:
+                continue
+            try:
+                positions.append((pad.x, pad.y))
+            except AttributeError:  # pragma: no cover - defensive
+                continue
+        if positions:
+            pads_by_net[net_id] = positions
+    return pads_by_net

--- a/src/kicad_tools/router/optimizer/trace.py
+++ b/src/kicad_tools/router/optimizer/trace.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from ..layers import Layer
 from ..primitives import Route, Segment
 from .algorithms import (
@@ -88,6 +90,37 @@ def optimize_routes_grid_synced(
     Returns:
         The new ``router.routes`` list (also assigned on the router).
     """
+    return apply_route_transform_grid_synced(router, optimizer.optimize_route, skip_nets=skip_nets)
+
+
+def apply_route_transform_grid_synced(
+    router,
+    transform: Callable[[Route], Route],
+    *,
+    skip_nets: set[int] | None = None,
+) -> list[Route]:
+    """Replace every route with ``transform(route)`` keeping the grid in sync.
+
+    The grid-transactional machinery
+    :func:`optimize_routes_grid_synced` documents (#3507 incremental
+    unmark/mark, #3511 batched ``resync_route_occupancy``) is not
+    specific to the optimizer -- issue #4732's post-nudge consolidation
+    pass needs exactly the same transaction.  This is that machinery,
+    parameterized by the per-route transform; ``optimize_routes_grid_synced``
+    is the ``optimizer.optimize_route`` specialization of it and its
+    docstring remains the canonical explanation of *why* each step
+    exists.
+
+    Args:
+        router: ``Autorouter`` whose ``routes`` are replaced in place.
+        transform: Callable mapping a route to its replacement.  Returning
+            the input object (or an equal one) marks the route unchanged
+            and skips the grid transaction for it.
+        skip_nets: Net IDs whose routes pass through untouched (#3508).
+
+    Returns:
+        The new ``router.routes`` list (also assigned on the router).
+    """
     grid = router.grid
     optimized_routes: list[Route] = []
     # Issue #3511: (old, new) pairs for every MUTATED route, replayed
@@ -98,7 +131,7 @@ def optimize_routes_grid_synced(
         if skip_nets is not None and route.net in skip_nets:
             optimized_routes.append(route)
             continue
-        optimized = optimizer.optimize_route(route)
+        optimized = transform(route)
         if optimized is not route and (
             optimized.segments == route.segments and optimized.vias == route.vias
         ):

--- a/src/kicad_tools/router/quality_probe.py
+++ b/src/kicad_tools/router/quality_probe.py
@@ -51,7 +51,27 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 STAGE_PRE_OPTIMIZE = "pre-optimize"
 STAGE_POST_OPTIMIZE = "post-optimize"
 STAGE_POST_NUDGE = "post-nudge"
+# Issue #4732 slice 2: the topology-preserving collinear consolidation
+# pass that now runs after the DRC nudge (see
+# :mod:`kicad_tools.router.optimizer.consolidate`).  Recorded only when
+# the pass actually ran, so ``--no-optimize`` and non-grid engines still
+# show the stages they really executed.
+STAGE_POST_CONSOLIDATE = "post-consolidate"
 STAGE_POST_FINALIZE = "post-finalize"
+
+# Width of the ``stage`` column in :meth:`StageQualityRecorder.format_report`,
+# derived from the labels above so adding a longer stage name can never
+# knock the numeric columns out of alignment again.
+_STAGE_COLUMN_WIDTH = max(
+    len(_label)
+    for _label in (
+        STAGE_PRE_OPTIMIZE,
+        STAGE_POST_OPTIMIZE,
+        STAGE_POST_NUDGE,
+        STAGE_POST_CONSOLIDATE,
+        STAGE_POST_FINALIZE,
+    )
+)
 
 # Metrics whose stage-to-stage movement is the point of the probe.  Both
 # are "lower is better", which the delta arrow rendering assumes.
@@ -147,9 +167,12 @@ class StageQualityRecorder:
         if not self._stages:
             return ""
 
+        # The stage column is sized to the LONGEST label
+        # (``post-consolidate``, 16 chars) -- a narrower field silently
+        # pushes the numeric columns out of alignment for that one row.
         header = (
             "\n--- Routing quality by stage (advisory, issue #4732) ---\n"
-            f"  {'stage':<14} {'segs':>7} {'frag%':>7} {'stair%':>7} "
+            f"  {'stage':<{_STAGE_COLUMN_WIDTH}} {'segs':>7} {'frag%':>7} {'stair%':>7} "
             f"{'45deg%':>7} {'zero':>5} {'median_mm':>10}"
         )
         lines = [header]
@@ -160,7 +183,7 @@ class StageQualityRecorder:
             # not reconstructed here.
             diag_pct = m.diagonal_45_fraction * 100.0
             lines.append(
-                f"  {entry.stage:<14} {m.total_segments:>7d} "
+                f"  {entry.stage:<{_STAGE_COLUMN_WIDTH}} {m.total_segments:>7d} "
                 f"{m.fragment_fraction * 100.0:>7.1f} "
                 f"{m.staircase_fraction * 100.0:>7.1f} "
                 f"{diag_pct:>7.1f} {m.zero_length_count:>5d} "

--- a/tests/router/test_board02_manufacturable_baseline.py
+++ b/tests/router/test_board02_manufacturable_baseline.py
@@ -13,10 +13,10 @@ Baseline measurement at HEAD (worst-of-3 across seeds 42/43/44 with
 - **DRC: 0 errors, 0 warnings** at ``jlcpcb-tier1`` profile
 - **Deterministic output**: 22 routes / 24 vias / 327.93mm total
   length identical across seeds 42/43/44 -- this small 2-layer board
-  has fully converged.  Segment count is 476 on macOS-arm64 as of the
-  2026-07-14 #4196 re-baseline (up from 393; routes/vias/length/reach
+  has fully converged.  Segment count is 274 on macOS-arm64 as of the
+  2026-08-11 #4732 re-baseline (down from 476; routes/vias/length/reach
   are byte-identical, only the collinear resplit count moved -- see the
-  #4196 note in ``test_routing_output_deterministic_across_seeds``).
+  #4732 note in ``test_routing_output_deterministic_across_seeds``).
   Segment count is platform- and KiCad-version-sensitive collinear
   resplitting at identical geometry and is NOT itself a
   manufacturability signal; it is guarded by a loose band while the
@@ -648,7 +648,24 @@ def test_routing_output_deterministic_across_seeds(unrouted_pcb_path: Path) -> N
     # regression + determinism guards, so this band is intentionally loose.
     # See the #3545 PLATFORM NOTE above for the macOS-arm64 vs
     # Linux-x86_64 collinear-merge float-rounding divergence mechanism.
-    EXPECTED_SEGMENTS_RANGE = (390, 490)
+    #
+    # Re-baselined 2026-08-11 for Issue #4732 (post-nudge collinear
+    # consolidation): macOS-arm64 drops 476 -> 274 segments while routes
+    # (22), vias (24), total length (327.93mm) and reach (8/8) stay
+    # BYTE-IDENTICAL -- again the benign collinear-resplit axis, this
+    # time in the coarser direction.  The new pass merges every maximal
+    # run of collinear degree-2 segments, which is exactly the axis the
+    # #3545/#4196 PLATFORM NOTES describe as platform-divergent: the
+    # macOS-vs-Linux gap came from ``merge_collinear``'s float collision
+    # probe vetoing a different subset of merges on each platform, and
+    # the consolidation pass recovers *all* of those vetoed merges on
+    # both.  So the band is expected to NARROW and largely converge
+    # across platforms rather than split further; it is set around the
+    # measured 274 with generous room for whatever residual divergence
+    # survives.  If CI Linux-x86_64 lands outside it, widen the band --
+    # the routes/vias/length pins above are what would signal a real
+    # regression, and they are untouched.
+    EXPECTED_SEGMENTS_RANGE = (240, 340)
     got_routes, got_segments, got_vias, got_length = ref
     exact = (got_routes, got_vias, got_length)
     expected_exact = (EXPECTED_ROUTES, EXPECTED_VIAS, EXPECTED_LENGTH)
@@ -665,11 +682,13 @@ def test_routing_output_deterministic_across_seeds(unrouted_pcb_path: Path) -> N
     lo, hi = EXPECTED_SEGMENTS_RANGE
     assert lo <= got_segments <= hi, (
         f"Board 02 segment count {got_segments} outside the documented "
-        f"platform band [{lo}, {hi}] (macOS-arm64: 476, Linux-x86_64: "
-        "~390-399; see PLATFORM NOTE above and the #4196 re-baseline).  "
+        f"platform band [{lo}, {hi}] (macOS-arm64: 274 post-#4732; "
+        "pre-#4732 it was 476 on macOS-arm64 / ~390-399 on Linux-x86_64 -- "
+        "see PLATFORM NOTE above and the #4196 / #4732 re-baselines).  "
         "Routes/vias/length matched the exact pin, so this is a change in "
         "collinear segmentation -- investigate merge_collinear/path_is_clear "
-        "behaviour before widening the band.  NOTE: segment count is "
+        "and the #4732 consolidation pass before widening the band.  "
+        "NOTE: segment count is "
         "platform/KiCad-version-sensitive and is NOT itself a "
         "manufacturability signal; the exact routes/vias/length pins and "
         "the cross-seed equality check are the real guards."

--- a/tests/test_route_consolidation_pass.py
+++ b/tests/test_route_consolidation_pass.py
@@ -40,8 +40,15 @@ from kicad_tools.analysis.routing_quality import (
     compute_routing_quality_from_records,
 )
 from kicad_tools.router.layers import Layer
-from kicad_tools.router.primitives import Route, Segment
+from kicad_tools.router.optimizer.consolidate import (
+    ConsolidationStats,
+    consolidate_net_routes,
+    consolidate_routes_grid_synced,
+    consolidate_segments,
+)
+from kicad_tools.router.primitives import Route, Segment, Via
 from kicad_tools.router.quality_probe import (
+    STAGE_POST_CONSOLIDATE,
     STAGE_POST_FINALIZE,
     STAGE_POST_NUDGE,
     STAGE_POST_OPTIMIZE,
@@ -539,6 +546,425 @@ class TestRouteCmdHelpers:
 
 
 # ---------------------------------------------------------------------------
+# Slice 2: the topology-preserving collinear consolidation pass
+# ---------------------------------------------------------------------------
+
+
+def _chain(points: list[tuple[float, float]], **kwargs) -> list[Segment]:
+    """Segments walking ``points`` in order."""
+    return [_router_seg(a, b, **kwargs) for a, b in zip(points, points[1:], strict=False)]
+
+
+def _fragment_run(n: int = 5, step: float = 0.05) -> list[Segment]:
+    """``n`` collinear sub-0.25 mm fragments along +x from the origin."""
+    return _chain([(i * step, 0.0) for i in range(n + 1)])
+
+
+def _total_length(segments: list[Segment]) -> float:
+    from math import hypot
+
+    return sum(hypot(s.x2 - s.x1, s.y2 - s.y1) for s in segments)
+
+
+class _FakeGrid:
+    """Records the grid transaction ``apply_route_transform_grid_synced`` drives."""
+
+    def __init__(self) -> None:
+        self.unmarked: list[Route] = []
+        self.marked: list[Route] = []
+        self.cpp_marked: list[Route] = []
+        self.resyncs: list[list[tuple[Route, Route]]] = []
+
+    def unmark_route(self, route: Route) -> None:
+        self.unmarked.append(route)
+
+    def mark_route(self, route: Route) -> None:
+        self.marked.append(route)
+
+    def _mark_route_on_cpp_cells(self, route: Route) -> None:
+        self.cpp_marked.append(route)
+
+    def resync_route_occupancy(self, pairs) -> None:
+        self.resyncs.append(list(pairs))
+
+
+class _FakeRouter:
+    """Minimal ``Autorouter`` surface the consolidation pass touches."""
+
+    def __init__(self, routes: list[Route], pads: dict | None = None, nets: dict | None = None):
+        self.routes = routes
+        self.grid = _FakeGrid()
+        # ``snapshot_connectivity`` (the guard wrapped around the pass in
+        # ``route_cmd``) reads all three unconditionally.
+        self.pads = pads if pads is not None else {}
+        self.nets = nets if nets is not None else {}
+        self.net_names: dict[int, str] = {}
+
+
+class TestConsolidateSegments:
+    """The segment-level core: what may merge, and what may never merge."""
+
+    def test_collinear_fragment_run_collapses_to_one_segment(self):
+        segments = _fragment_run(5)
+        out, stats = consolidate_segments(segments)
+        assert len(out) == 1
+        assert (out[0].start, out[0].end) == ((0.0, 0.0), (0.25, 0.0))
+        assert stats.segments_before == 5
+        assert stats.segments_after == 1
+        assert stats.runs_merged == 1
+        assert stats.segments_removed == 4
+
+    def test_merged_segment_inherits_width_layer_net_and_name(self):
+        segments = _chain([(0.0, 0.0), (0.05, 0.0), (0.10, 0.0)], net=7, layer=Layer.B_CU)
+        out, _stats = consolidate_segments(segments)
+        assert len(out) == 1
+        assert out[0].width == segments[0].width
+        assert out[0].layer is Layer.B_CU
+        assert out[0].net == 7
+        assert out[0].net_name == segments[0].net_name
+
+    def test_total_copper_length_is_preserved(self):
+        """The pass is a union, not a shortcut: length in == length out."""
+        segments = _fragment_run(9)
+        out, _stats = consolidate_segments(segments)
+        assert _total_length(out) == pytest.approx(_total_length(segments))
+
+    def test_corner_is_not_merged(self):
+        """A direction change is a real vertex -- both legs survive."""
+        segments = _chain([(0.0, 0.0), (0.5, 0.0), (0.5, 0.5)])
+        out, stats = consolidate_segments(segments)
+        assert len(out) == 2
+        assert stats.runs_merged == 0
+
+    def test_t_junction_vertex_is_never_smoothed_away(self):
+        """Degree-3 vertex: the run splits at the branch instead of spanning it."""
+        run = _fragment_run(4)  # (0,0) .. (0.20, 0)
+        branch = _router_seg((0.10, 0.0), (0.10, 0.5))
+        out, _stats = consolidate_segments([*run, branch])
+        endpoints = {(s.start, s.end) for s in out}
+        assert ((0.0, 0.0), (0.10, 0.0)) in endpoints
+        assert ((0.10, 0.0), (0.20, 0.0)) in endpoints
+        assert ((0.10, 0.0), (0.10, 0.5)) in endpoints
+        assert len(out) == 3
+
+    def test_protected_point_survives_as_a_vertex(self):
+        """A pad/via position mid-run keeps its endpoint (issue #4732)."""
+        out, _stats = consolidate_segments(_fragment_run(4), protected_points=[(0.10, 0.0)])
+        assert len(out) == 2
+        assert {(s.start, s.end) for s in out} == {
+            ((0.0, 0.0), (0.10, 0.0)),
+            ((0.10, 0.0), (0.20, 0.0)),
+        }
+
+    def test_backtracking_pair_is_not_merged(self):
+        """Anti-parallel guard: a doubled-back pair would lose copper."""
+        segments = [
+            _router_seg((0.0, 0.0), (0.20, 0.0)),
+            _router_seg((0.20, 0.0), (0.10, 0.0)),
+        ]
+        out, stats = consolidate_segments(segments)
+        assert len(out) == 2
+        assert stats.runs_merged == 0
+
+    def test_layer_change_is_not_merged(self):
+        segments = [
+            _router_seg((0.0, 0.0), (0.05, 0.0), layer=Layer.F_CU),
+            _router_seg((0.05, 0.0), (0.10, 0.0), layer=Layer.B_CU),
+        ]
+        out, stats = consolidate_segments(segments)
+        assert len(out) == 2
+        assert stats.runs_merged == 0
+
+    def test_net_change_is_not_merged(self):
+        segments = [
+            _router_seg((0.0, 0.0), (0.05, 0.0), net=1),
+            _router_seg((0.05, 0.0), (0.10, 0.0), net=2),
+        ]
+        out, stats = consolidate_segments(segments)
+        assert len(out) == 2
+        assert stats.runs_merged == 0
+
+    def test_width_change_is_not_merged(self):
+        a = _router_seg((0.0, 0.0), (0.05, 0.0))
+        b = _router_seg((0.05, 0.0), (0.10, 0.0))
+        b.width = a.width * 2
+        out, stats = consolidate_segments([a, b])
+        assert len(out) == 2
+        assert stats.runs_merged == 0
+
+    def test_collision_veto_keeps_the_originals(self):
+        """A checker that rejects the candidate must not lose copper."""
+        segments = _fragment_run(5)
+        out, stats = consolidate_segments(segments, path_is_clear=lambda _seg: False)
+        assert out == list(segments)
+        assert stats.runs_merged == 0
+        assert stats.runs_vetoed == 1
+
+    def test_a_permissive_checker_still_merges(self):
+        out, stats = consolidate_segments(_fragment_run(5), path_is_clear=lambda _seg: True)
+        assert len(out) == 1
+        assert stats.runs_vetoed == 0
+
+    def test_zero_length_segment_is_neither_merged_nor_orphaned(self):
+        """#4732 slice-1 finding 2: the DRC nudge can emit a zero-length segment.
+
+        It must survive the pass untouched AND block the smoothing of the
+        vertex it sits on -- otherwise deleting that vertex would strand it
+        as its own connectivity component.
+        """
+        run = _fragment_run(4)
+        degenerate = _router_seg((0.10, 0.0), (0.10, 0.0))
+        out, _stats = consolidate_segments([*run, degenerate])
+        assert degenerate in out
+        assert ((0.0, 0.0), (0.10, 0.0)) in {(s.start, s.end) for s in out}
+        assert ((0.10, 0.0), (0.20, 0.0)) in {(s.start, s.end) for s in out}
+
+    def test_pass_never_introduces_a_zero_length_segment(self):
+        """#4716's waivable ``zero_length_segment`` rule must stay unfired."""
+        for segments in (_fragment_run(7), _chain([(0.0, 0.0), (0.5, 0.0), (0.5, 0.5)])):
+            out, _stats = consolidate_segments(segments)
+            assert all((s.start != s.end) for s in out)
+
+    def test_output_order_follows_input_order(self):
+        segments = [
+            *_fragment_run(3),  # indices 0..2, run along +x to (0.15, 0)
+            _router_seg((5.0, 5.0), (5.5, 5.0)),  # untouched loner
+        ]
+        out, _stats = consolidate_segments(segments)
+        assert [(s.start, s.end) for s in out] == [
+            ((0.0, 0.0), (pytest.approx(0.15), 0.0)),
+            ((5.0, 5.0), (5.5, 5.0)),
+        ]
+
+    def test_empty_and_single_segment_inputs_are_returned_unchanged(self):
+        assert consolidate_segments([]) == ([], ConsolidationStats())
+        lone = [_router_seg((0.0, 0.0), (1.0, 0.0))]
+        out, stats = consolidate_segments(lone)
+        assert out == lone
+        assert stats == ConsolidationStats(segments_before=1, segments_after=1)
+
+
+class TestConsolidateNetRoutes:
+    """Route-level bookkeeping: ownership, vias, and additive Route fields."""
+
+    def test_a_route_of_fragments_is_consolidated(self):
+        route = _route(_fragment_run(6))
+        out, stats = consolidate_net_routes([route])
+        assert len(out) == 1
+        assert len(out[0].segments) == 1
+        assert stats.routes_changed == 1
+        assert stats.runs_merged == 1
+
+    def test_unchanged_routes_keep_their_identity(self):
+        """``grid.routes`` bookkeeping depends on object identity."""
+        route = _route(_chain([(0.0, 0.0), (0.5, 0.0), (0.5, 0.5)]))
+        out, stats = consolidate_net_routes([route])
+        assert out[0] is route
+        assert stats.routes_changed == 0
+
+    def test_via_position_is_protected(self):
+        route = Route(
+            net=1,
+            net_name="NET1",
+            segments=_fragment_run(4),
+            vias=[
+                Via(
+                    x=0.10,
+                    y=0.0,
+                    drill=0.3,
+                    diameter=0.6,
+                    layers=(Layer.F_CU, Layer.B_CU),
+                    net=1,
+                )
+            ],
+        )
+        out, _stats = consolidate_net_routes([route])
+        assert {(s.start, s.end) for s in out[0].segments} == {
+            ((0.0, 0.0), (0.10, 0.0)),
+            ((0.10, 0.0), (0.20, 0.0)),
+        }
+        assert len(out[0].vias) == 1
+
+    def test_pad_position_is_protected(self):
+        route = _route(_fragment_run(4))
+        out, _stats = consolidate_net_routes([route], pad_positions=[(0.10, 0.0)])
+        assert len(out[0].segments) == 2
+
+    def test_is_escape_survives_consolidation(self):
+        """#3441: additive ``Route`` fields must not be reset by a rebuild."""
+        route = Route(net=1, net_name="NET1", segments=_fragment_run(5), is_escape=True)
+        out, _stats = consolidate_net_routes([route])
+        assert out[0] is not route
+        assert out[0].is_escape is True
+
+    def test_a_sibling_routes_landing_point_is_a_junction(self):
+        """Degree is counted over the NET, not the route (cross-route T)."""
+        trunk = _route(_fragment_run(4))
+        stub = _route([_router_seg((0.10, 0.0), (0.10, 0.5))])
+        out, _stats = consolidate_net_routes([trunk, stub])
+        assert len(out[0].segments) == 2
+        assert out[1] is stub
+
+    def test_segments_never_migrate_between_routes(self):
+        """Two routes meeting end-to-end merge nothing (owner mismatch)."""
+        left = _route(_chain([(0.0, 0.0), (0.05, 0.0)]))
+        right = _route(_chain([(0.05, 0.0), (0.10, 0.0)]))
+        out, stats = consolidate_net_routes([left, right])
+        assert stats.runs_merged == 0
+        assert out[0] is left
+        assert out[1] is right
+
+
+class TestConsolidateRoutesGridSynced:
+    """The router-level entry point and its grid transaction."""
+
+    def test_consolidates_and_drives_the_grid_transaction(self):
+        route = _route(_fragment_run(6))
+        router = _FakeRouter([route])
+        stats = consolidate_routes_grid_synced(router)
+        assert stats.segments_before == 6
+        assert stats.segments_after == 1
+        assert len(router.routes) == 1
+        assert router.routes[0] is not route
+        # Old copper ripped, new copper marked on both grids, one batched resync.
+        assert router.grid.unmarked == [route]
+        assert router.grid.marked == [router.routes[0]]
+        assert router.grid.cpp_marked == [router.routes[0]]
+        assert len(router.grid.resyncs) == 1
+
+    def test_no_grid_transaction_when_nothing_merges(self):
+        route = _route(_chain([(0.0, 0.0), (0.5, 0.0), (0.5, 0.5)]))
+        router = _FakeRouter([route])
+        stats = consolidate_routes_grid_synced(router)
+        assert stats.runs_merged == 0
+        assert router.routes[0] is route
+        assert router.grid.unmarked == []
+        assert router.grid.resyncs == []
+
+    def test_skip_nets_routes_pass_through_untouched(self):
+        """#3508 parity: a diff-pair / length-tuned net is never rewritten."""
+        protected = _route(_fragment_run(6), net=2)
+        ordinary = _route(_fragment_run(6), net=1)
+        router = _FakeRouter([protected, ordinary])
+        stats = consolidate_routes_grid_synced(router, skip_nets={2})
+        assert router.routes[0] is protected
+        assert len(router.routes[0].segments) == 6
+        assert len(router.routes[1].segments) == 1
+        assert stats.segments_before == 6  # only the un-skipped net is counted
+
+    def test_pads_from_router_metadata_are_protected(self):
+        route = _route(_fragment_run(4))
+        pad = SimpleNamespace(x=0.10, y=0.0)
+        router = _FakeRouter([route], pads={("R1", "1"): pad}, nets={1: [("R1", "1")]})
+        consolidate_routes_grid_synced(router)
+        assert len(router.routes[0].segments) == 2
+
+    def test_a_router_without_pad_metadata_still_works(self):
+        router = _FakeRouter([_route(_fragment_run(4))])
+        consolidate_routes_grid_synced(router)
+        assert len(router.routes[0].segments) == 1
+
+    def test_nets_are_consolidated_independently(self):
+        a = _route(_fragment_run(4), net=1)
+        b = _route(_fragment_run(4), net=2)
+        router = _FakeRouter([a, b])
+        stats = consolidate_routes_grid_synced(router)
+        assert stats.runs_merged == 2
+        assert stats.routes_changed == 2
+        assert all(len(r.segments) == 1 for r in router.routes)
+
+
+class TestRunConsolidationPassGating:
+    """``route_cmd._run_consolidation_pass`` gating (#4281 / ``--no-optimize``)."""
+
+    def _router(self) -> _FakeRouter:
+        return _FakeRouter([_route(_fragment_run(6))])
+
+    def test_runs_on_the_grid_engine_by_default(self, capsys):
+        from kicad_tools.cli import route_cmd
+
+        router = self._router()
+        recorder = StageQualityRecorder()
+        route_cmd._run_consolidation_pass(
+            router,
+            SimpleNamespace(no_optimize=False, strict=False, verbose=False),
+            post_passes_enabled=True,
+            stage_recorder=recorder,
+        )
+        assert len(router.routes[0].segments) == 1
+        assert recorder.get(STAGE_POST_CONSOLIDATE) is not None
+        assert "Consolidation:" in capsys.readouterr().out
+
+    def test_no_optimize_bypasses_the_pass(self):
+        from kicad_tools.cli import route_cmd
+
+        router = self._router()
+        recorder = StageQualityRecorder()
+        route_cmd._run_consolidation_pass(
+            router,
+            SimpleNamespace(no_optimize=True, strict=False, verbose=False),
+            post_passes_enabled=True,
+            stage_recorder=recorder,
+        )
+        assert len(router.routes[0].segments) == 6
+        assert recorder.stages == []
+
+    def test_disabled_post_passes_bypass_the_pass(self):
+        """#4281: lattice/mesh copper is never touched without --lattice-optimize."""
+        from kicad_tools.cli import route_cmd
+
+        router = self._router()
+        recorder = StageQualityRecorder()
+        route_cmd._run_consolidation_pass(
+            router,
+            SimpleNamespace(no_optimize=False, strict=False, verbose=False),
+            post_passes_enabled=False,
+            stage_recorder=recorder,
+        )
+        assert len(router.routes[0].segments) == 6
+        assert recorder.stages == []
+
+    def test_an_empty_router_is_a_noop(self):
+        from kicad_tools.cli import route_cmd
+
+        route_cmd._run_consolidation_pass(
+            _FakeRouter([]),
+            SimpleNamespace(no_optimize=False, strict=False, verbose=False),
+            post_passes_enabled=True,
+        )
+
+    def test_quiet_suppresses_the_summary_line(self, capsys):
+        from kicad_tools.cli import route_cmd
+
+        route_cmd._run_consolidation_pass(
+            self._router(),
+            SimpleNamespace(no_optimize=False, strict=False, verbose=False),
+            post_passes_enabled=True,
+            quiet=True,
+        )
+        assert "Consolidation:" not in capsys.readouterr().out
+
+    def test_wired_into_every_route_output_path(self):
+        """All four ``kct route`` output paths must call the pass.
+
+        The optimize/nudge wire-in has historically been copy-pasted into
+        four places; a fifth caller that forgets it would silently ship
+        un-consolidated copper on the escalation paths.
+        """
+        import inspect
+
+        from kicad_tools.cli import route_cmd
+
+        for fn in (
+            route_cmd.route_with_layer_escalation,
+            route_cmd.route_with_rule_relaxation,
+            route_cmd.route_with_combined_escalation,
+            route_cmd._main_impl,
+        ):
+            assert "_run_consolidation_pass(" in inspect.getsource(fn), fn.__name__
+
+
+# ---------------------------------------------------------------------------
 # End-to-end pipeline: a real ``kct route`` on a tiny synthetic board
 # ---------------------------------------------------------------------------
 
@@ -645,10 +1071,28 @@ class TestEndToEndPipeline:
             STAGE_PRE_OPTIMIZE,
             STAGE_POST_OPTIMIZE,
             STAGE_POST_NUDGE,
+            STAGE_POST_CONSOLIDATE,
             STAGE_POST_FINALIZE,
         ):
             assert stage in stdout, f"missing stage {stage!r} in:\n{stdout}"
         assert out.exists()
+
+    def test_stage_table_columns_stay_aligned(self):
+        """``post-consolidate`` is the longest label -- it must not shift columns."""
+        recorder = StageQualityRecorder()
+        for stage in (STAGE_PRE_OPTIMIZE, STAGE_POST_CONSOLIDATE):
+            recorder.record(stage, [_route(_staircase_router_segments())])
+        rows = [
+            line
+            for line in recorder.format_report().splitlines()
+            if line.strip().startswith(("stage", STAGE_PRE_OPTIMIZE, STAGE_POST_CONSOLIDATE))
+            and "->" not in line
+        ]
+        assert len(rows) == 3
+        # Every field after the stage label is fixed-width, so aligned rows
+        # are exactly equal in length -- a too-narrow stage column makes the
+        # ``post-consolidate`` row longer than the others.
+        assert len({len(line) for line in rows}) == 1, rows
 
     def test_no_stage_table_without_the_flag(self, tmp_path: Path):
         code, stdout, _out = _run_route(tmp_path)
@@ -689,6 +1133,32 @@ class TestEndToEndPipeline:
         rows = _parse_stage_table(stdout)
         assert STAGE_PRE_OPTIMIZE in rows
         assert STAGE_POST_OPTIMIZE not in rows
+        # Slice 2: ``--no-optimize`` bypasses consolidation as well, so the
+        # copper the user asked to keep raw stays raw.
+        assert STAGE_POST_CONSOLIDATE not in rows
+
+    def test_consolidation_never_regresses_the_tracked_fractions(self, tmp_path: Path):
+        """Slice 2's contract: post-consolidate is never worse than post-nudge."""
+        _code, stdout, _out = _run_route(tmp_path, "--report-stage-quality")
+        rows = _parse_stage_table(stdout)
+        assert {STAGE_POST_NUDGE, STAGE_POST_CONSOLIDATE} <= set(rows)
+        nudge, consolidated = rows[STAGE_POST_NUDGE], rows[STAGE_POST_CONSOLIDATE]
+        assert consolidated["segs"] <= nudge["segs"]
+        assert consolidated["frag"] <= nudge["frag"] + 1e-9
+        assert consolidated["stair"] <= nudge["stair"] + 1e-9
+
+    def test_consolidation_preserves_connectivity_and_exit_code(self, tmp_path: Path):
+        """Net-status parity: the pass must not cost a routed net."""
+        code, stdout, out = _run_route(tmp_path, "--report-stage-quality")
+        assert code == 0, stdout
+        assert "Nets routed:     2/2" in stdout, stdout
+        assert out.exists()
+
+    def test_finalize_matches_consolidate(self, tmp_path: Path):
+        """Nothing downstream of the pass re-fragments the copper."""
+        _code, stdout, _out = _run_route(tmp_path, "--report-stage-quality")
+        rows = _parse_stage_table(stdout)
+        assert rows[STAGE_POST_FINALIZE] == rows[STAGE_POST_CONSOLIDATE]
 
 
 def _parse_stage_table(stdout: str) -> dict[str, dict[str, float]]:
@@ -698,6 +1168,7 @@ def _parse_stage_table(stdout: str) -> dict[str, dict[str, float]]:
         STAGE_PRE_OPTIMIZE,
         STAGE_POST_OPTIMIZE,
         STAGE_POST_NUDGE,
+        STAGE_POST_CONSOLIDATE,
         STAGE_POST_FINALIZE,
     }
     for line in stdout.splitlines():


### PR DESCRIPTION
## Summary

`kct route`'s post-route pipeline ended `optimize -> nudge -> finalize` with nothing that consolidated the copper the DRC nudge produced, and #4746's slice-1 instrumentation measured the existing `TraceOptimizer` leaving **93.1% sub-0.25 mm fragments** on board 03, with the median segment length pinned exactly at the 0.05 mm grid step.

This is slice 2: the pass that actually improves the copper.

### Diagnosis (measured, not assumed)

I instrumented the individual optimizer passes on board 03 under its pinned production recipe. The cause is the issue's **hypothesis 1 (collision conservatism)**, and the other hypotheses are ruled out:

| pass | segments in -> out |
|---|---|
| `merge_collinear` | 6838 -> 1490 |
| `eliminate_zigzags` | 1490 -> 1490 |
| `compress_staircase` | 1490 -> 1485 |
| `convert_corners_45` | 1485 -> 1488 |
| `pull_tight` | 1488 -> 1486 |

Everything after `merge_collinear` is flat, and so is the DRC nudge (**hypothesis 4 is not the cause on this board**). `TraceOptimizer.optimize_route`'s revert-on-regression connectivity guard fires **zero** times across all 37 routes, so it is not discarding the work either. What does happen is inside `merge_collinear`: every candidate merge is gated on `path_is_clear`, and **2725 of its 8075 candidates (33.7%) are vetoed**. Each veto chops a collinear run in two, and no later pass revisits it.

Those vetoes are false positives by construction. A merged `A-B` + `B-C` is the exact union of two segments the board already carries — it adds no copper anywhere — so it cannot be a new hazard; the grid checker rejects it only because rasterizing one long clearance envelope touches cells that rasterizing the two short ones did not.

> **Note for the reviewer:** the inherited WIP on this branch claimed the cause was `optimize_route`'s connectivity guard reverting whole routes on branchy multi-pad nets. I probed that directly and it is **false** — the guard fired 0 times. That claim, and an unverified "439 of 460 committed segments come back not clear" figure, have been removed and replaced with the measurements above.

### Why not just drop `merge_collinear`'s collision gate?

Because it is load-bearing *there*. `merge_collinear` merges whatever is adjacent in its chain's list order and performs **no vertex-degree check**, so the collision probe is the only thing standing between it and merging through a junction owned by a different chain or sibling route — and `optimize_route`'s guard would then discard the whole route rather than the one bad merge. Relaxing it would also change behaviour for every other `TraceOptimizer` consumer (`kct optimize-traces`, `optimize_pcb`, the board recipes). A separate degree-aware pass recovers the vetoed merges without touching any of that, and additionally closes the "nudge output is never re-consolidated" ordering hole.

## Changes

- **`src/kicad_tools/router/optimizer/consolidate.py` (new)** — the pass. It removes only vertices of **degree exactly 2** whose two incident segments are collinear, anti-parallel about the vertex, and share layer / net / width, so every junction, terminal, via and pad vertex survives by construction and the merged segment is the **exact union** of what it replaces. The union property is *checked*, not asserted: a length guard rejects any run whose merged length differs from the sum of its parts.
  - Vertex degree is counted over the **whole net** (a sibling route's landing point is a degree-3 junction) and deliberately **layer-blind**, matching `validate_net_connectivity`'s own layer-blind endpoint union-find — keying per layer would let the pass smooth away a vertex the invariant still treats as a junction.
  - Pad and via positions are protected points; **zero-length segments count toward vertex degree** (so they block a smoothing) but are never merged, and the pass provably introduces none.
  - No collision checker is wired in, deliberately, with the rationale above documented in the module.
- **`optimizer/trace.py`** — `optimize_routes_grid_synced` is refactored into a general `apply_route_transform_grid_synced` (a pure extract-and-parameterize; #3507/#3511 semantics untouched) so the pass commits through the identical grid transaction.
- **`cli/route_cmd.py`** — `_run_consolidation_pass`, wired into all four `kct route` output paths after the nudge, wrapped in the same connectivity snapshot/enforce guard the optimize and nudge phases use; `_finalize_committed_copper_or_demote` remains the unconditional backstop.
- **`router/quality_probe.py`** — new `post-consolidate` stage; the stage column is now sized from the labels so the longest one cannot knock the numeric columns out of alignment.
- **`tests/router/test_board02_manufacturable_baseline.py`** — segment band re-pinned 476 -> 274 (see below).

## Acceptance Criteria Verification

Everything below was measured with **only the pass toggled** — same seed, same flags, same recipe — by monkeypatching `_run_consolidation_pass` to a no-op for the baseline run.

- [x] **Measured improvement** — **board 03**: 1486 -> 252 segments, `fragment_fraction` 93.1% -> 57.5%, 45°-diagonal share 7.3% -> 38.1%, median 0.050 -> 0.071 mm. **board 02**: 476 -> 295 segments, `fragment_fraction` 80.7% -> 58.3%.
- [x] **Connectivity preservation** — board 03 13/13 nets, board 02 8/8 nets, identical before/after; `kct pcb net-audit` JSON byte-identical apart from the input path.
- [x] **DRC-clean preservation** — `kct check --drc-only`: board 03 0 errors / 20 warnings both; board 02 0 errors / 0 warnings both. **`kicad-cli pcb drc --refill-zones` cross-gate**: identical violation histograms (`{lib_footprint_issues: 2, silk_over_copper: 4, text_height: 16, text_thickness: 16}` on 03, empty on 02) and identical unconnected-item counts.
- [x] **Copper is provably unchanged** — densely sampling the written artifacts, every point of the pre-pass copper lies on the post-pass copper **and vice versa**, to 3e-14 mm; per-`(net, layer)` total trace length identical to 1e-6 mm.
- [x] **Zero-length invariant** — `zero` column stays 0 at every stage on both boards; unit tests cover both "never introduces one" and "an existing one is neither merged nor orphaned".
- [x] **Gating/behavior surface** — default-on as a strengthening of the default optimizer; `--no-optimize` / `--raw` bypasses it (tested end-to-end and at the helper).
- [x] **Engine gate respected** — `_run_consolidation_pass` returns early when `_engine_post_passes_enabled` is False, so `--route-engine lattice|mesh` without `--lattice-optimize` never reaches it (#4281).
- [x] **Diff-pair protection** — `skip_nets` is threaded through and tested (#3508 parity).
- [x] **Fleet regression** — no `boards/` artifacts touched; all measurement ran in a scratch directory.
- [x] **Unit tests** — 31 new tests in `tests/test_route_consolidation_pass.py`.

**Not delivered — the staircase half.** This pass targets fragments only; `staircase_fraction` moves −0.1pp on board 03 and 0.0pp on board 02, which is why this is `Part of` and not `Closes`. Board 03 measures ~0% staircase at every stage, so (per the slice-1 comment on the issue) the staircase half needs a board-06/07-class fixture and is a separate slice.

## Test Plan

- [x] `tests/test_route_consolidation_pass.py` — 80 passed (31 new: segment-level merge/no-merge rules, collision veto, zero-length handling, route-level bookkeeping incl. `is_escape` preservation and route identity, grid-transaction assertions, `skip_nets`, CLI gating, a guard that all four output paths call the pass, and end-to-end pipeline assertions on the new stage).
- [x] `tests/router/` — 1162 passed, 1 failed → the board-02 baseline guard, re-pinned (below); green after.
- [x] **Full suite** — `pytest tests -n 4`: **25990 passed, 97 skipped, 1 failed**. The single failure is `test_route_auto_mfr_tier_integration.py::test_tier1_routes_more_nets_than_jlcpcb`, which **passes in isolation (485 s)**; it drives a wall-clock-budgeted (`--timeout 480 --backend python`) subprocess route, so it is load-sensitive under `-n 4`. Not related to this diff.
- [x] `ruff check` + `ruff format --check` on `src/` and `tests/` — clean.
- [x] `scripts/ci/check_mypy_baseline.py` run **cold** (`rm -rf .mypy_cache`) — 1471 errors, all within the 1473 baseline, no new type errors. (It reports 2 baseline entries no longer occurring; deliberately **not** `--update`d.)
- [x] `tests/test_cli_parser_drift.py` — 29 passed after the help-text update in both parsers.
- [x] C++ backend built and verified in the worktree before any measurement (`kct build-native --check` → available, build version 18).

## For the reviewer to scrutinise

1. **The board-02 baseline re-pin** (476 -> 274 segments). Routes (22), vias (24), total length (327.93 mm) and reach (8/8) are **byte-identical** — the exact pins matched, only the collinear-resplit count moved, which is the same benign axis every prior `PLATFORM NOTE` in that file documents. I set the band to `(240, 340)` rather than a point pin: the historical macOS-476 vs Linux-~390-399 gap came from `merge_collinear`'s float collision probe vetoing a *different subset* on each platform, and this pass recovers all of those on both, so I expect the platforms to converge — but I could only measure macOS-arm64. **If CI Linux lands outside the band, widen the band, not the pass.**
2. **The layer-blind vertex keying.** It is a deliberate coupling to `validate_net_connectivity`'s layer-blind union-find, argued in the module docstring. It is conservative in the safe direction (coincidence across layers only ever *skips* a merge), but it is a coupling worth a second opinion.
3. **Running with no collision checker.** The safety argument is the exact-union property, which is structurally enforced, guarded by a length check, and verified bidirectionally on two written artifacts at 3e-14 mm — but it is the load-bearing claim of this PR.

Part of #4732
