### PR TITLE
docs(router): record why board 07 regressed under the deterministic rescue bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   paths, so no engine can drift from the gate. Fully dormant without
   `--voltage-map`; a zone with no layer data keeps the previous agnostic
   verdict. `ROUTER_CPP_BUILD_VERSION` 18 -> 19 (run `kct build-native`).
+- **`DETERMINISTIC_RESCUE_DEFAULT`'s docblock now records *why* board 07
+  regressed instead of naming the investigation as future work** (#4770) —
+  documentation only; the constant's value is unchanged (`False`) and no
+  DRC allowlist or reach floor moved. The A/B was re-mined from the three
+  recorded CI runs and re-run locally at `HEAD` with the C++ backend built,
+  and both halves of the intuitive reading turn out to be wrong. **No net's
+  rescue flips commit-vs-rollback**: on board 07 the deterministic bound is a
+  straight reach *loss* in the negotiated pass (26/31 → 24/31), because a
+  single `DQ3` relief transaction that gives up in 2.6 s under the 10 s wall
+  clock instead runs **279.1 s — 46 % of the 600 s stage budget** and rolls
+  back anyway, so the pass completes 2 rip-up iterations instead of 5 and
+  never reaches the one that produces board 07's 26th net. The advertised
+  `+1 net` is then produced downstream by `PlacementDeltaFeedbackLoop`'s
+  `run_delta`, whose accept-gate is *relative* (`new_count > pre_count`): the
+  depressed baseline admits the `U3 translate` placement delta that `main`
+  refuses at 25 → 25, and that delta — not the rescue — carries the `+5 DRC`
+  (4× `clearance_pad_segment` at 0.094 mm on `DQ1`/`DQ2` and 0.076 mm on
+  `DQ4`/`DQS_N`, 2× `clearance_segment_via` at 0.049 mm on `DQ1`/`DQ2`, 1×
+  `match_group_length_skew` with `ADDR_BUS` at 11.030 mm instead of 0.000 mm,
+  less the `DQS_N`/`DQS_P` diff-pair pair that stops firing only because
+  `DQS_N` went unrouted). Five of the seven new errors sit on copper with no
+  connection to the reach delta at all. Recommendation recorded on #4730:
+  keep the opt-in permanently. The full journal (per-pass rescue tables,
+  per-violation attribution, reproduction recipe) lands in
+  `boards/07-matchgroup-test/diagnostic-runs/README.md`;
+  `_normalize_deterministic_budget`'s docstring and board 07's README are
+  updated in lockstep, and a new `TestPlacementDeltaFeedbackCaveat` pins the
+  two structural claims the finding rests on — that
+  `PlacementDeltaFeedbackLoop.run_delta` threads no `deterministic_rescue`
+  (so "flip the constant, not the CLI" stays true) and that
+  `Autorouter._post_negotiation_sweep_bounds` cannot see the flag (so the
+  #4159 sweep stays excluded as a confound).
 - **Nine polish fixes from the 2026-08-08/09 sweep's judge nits** (#4765) —
   each a small correctness defect in code that shipped last sweep; none
   changes routed copper or an exit code. (A) The `kct route` banner decided

--- a/boards/07-matchgroup-test/README.md
+++ b/boards/07-matchgroup-test/README.md
@@ -225,6 +225,23 @@ refused.  The refusal is recorded, with its measurements, in
 section carries `routed_before` / `routed_after` and `revert_reason`) so
 the decision is auditable rather than invisible.
 
+**The acceptance test is *relative*, and #4770 measured what that costs.**
+`PlacementDeltaFeedbackLoop.run_delta` keeps a delta on
+`new_count > pre_count` --- a comparison against the reach the loop
+currently holds, not against an absolute floor.  So anything that
+*depresses* the initial negotiated pass's reach also lowers the bar this
+probe has to clear.  Issue #4770's A/B is the worked example: with the
+relief-rescue sub-search bound switched from its 10 s wall clock to the
+deterministic per-net expansion cap (#4730's withdrawn flip), the
+negotiated pass completes 2 rip-up iterations instead of 5 and enters the
+loop at 24/31 instead of 26/31 --- and *on CI* this same `U3` translate
+then measures 23 -> 27, clears the gate, and is **kept**, taking blocking
+DRC from 8 to 13 with exactly the 0.076 / 0.094 mm `U1`-escape clearances
+and the 11.03 mm `ADDR_BUS` skew described above.  The `+1 net` in that
+measurement is this delta, not a router improvement.  Full journal:
+`diagnostic-runs/README.md`, section "Deterministic relief-rescue bound:
+A/B measurement (#4770)".
+
 Two useful side effects of running the loop, both measured on the same
 host:
 

--- a/boards/07-matchgroup-test/diagnostic-runs/README.md
+++ b/boards/07-matchgroup-test/diagnostic-runs/README.md
@@ -66,6 +66,355 @@ needs it too for any in-process dict/set iteration that affects pre-
 route preparation. The CI workflow (`.github/workflows/ci.yml`) also
 sets `PYTHONHASHSEED=42` on the matchgroup-routing-regression job.
 
+## Deterministic relief-rescue bound: A/B measurement (#4770)
+
+**Question this section answers** (issue #4770, the stated precondition for
+any #4730 reattempt): board 07 measured `+1 net / +5 DRC` when
+`DETERMINISTIC_RESCUE_DEFAULT` was flipped to `True`. *Which* rescues
+change outcome, *whose* copper carries the extra DRC, and is that DRC
+intrinsic to the extra net or an artifact?
+
+**Answer, in one line: none of it is rescue output.** No rescue keeps any
+of the nets that changed hands, and none of the extra DRC is on copper a
+rescue committed. The deterministic bound *loses* two nets in the
+negotiated pass, and the `+1` and the `+5` are both produced afterwards,
+by the placement-delta feedback loop keeping a delta it refuses on `main`.
+
+### What was compared
+
+| | **B** -- 10 s wall clock (`main`) | **A** -- iteration-bounded (#4730 flip) |
+|---|---|---|
+| head / CI run | `6cfa8842` / run `31277512785` | `6071d1b2` / run `31281260812` (reproduced on `721fc052` / run `31283738762`) |
+| `Relief-rescue sub-search cap:` | `10.0s wall clock -- deterministic rescue is off for this route` | `iteration-bounded (per-net node-expansion cap; issue #4536)` |
+
+Both arms run the identical command line (the `--deterministic-budget`
+`--placement-delta-feedback` invocation `route_pcb` builds in
+`../generate_design.py`), so the *only* difference is the value
+`Autorouter._relief_subsearch_budget` returns: `RELIEF_SUBSEARCH_BUDGET_S`
+(10 s) in B, `RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S` (120 s, non-binding) in A.
+
+**Confound guard.** `Autorouter._post_negotiation_sweep_bounds` takes
+`(timeout, per_net_timeout, elapsed, timed_out)` and never reads
+`deterministic_rescue`, so the #4159 sweep bound is identical in both arms
+by construction (pinned by `TestPlacementDeltaFeedbackCaveat` in
+`tests/test_relief_subsearch_budget.py`). Confirmed empirically on a
+same-`HEAD` local A/B (see "Host re-run" below): at the *same pass index*
+the two arms print the byte-identical line, e.g. for the initial
+CLI-driven pass in both:
+
+```
+  Post-negotiation sweep bound: 60.0s whole-sweep / 10.0s per-net wall clock -- the caller passed a stage timeout (issue #4159)
+```
+
+In *either* arm the later placement-feedback re-routes print
+`0.0s per-net` instead of `10.0s` (A: `60.0s / 0.0s`; B: `52.3s / 0.0s`).
+That is **#4776** -- the literal `0.0` from
+`_normalize_deterministic_budget` reaching `route_all_negotiated` through
+`_run_placement_delta_feedback` -- and a `0.0s` per-net budget makes the
+sweep a **silent no-op**, in both arms. So the only pass where the sweep
+can do anything is the initial CLI-driven one, and there the line is
+byte-identical between arms; where the whole-sweep term does differ
+(`60.0s` vs `52.3s`, just `min(60 s, remaining)` reacting to elapsed
+time), the sweep is already inert. Either way #4776 cannot produce the
+delta -- and it is invisible to `Autorouter._relief_subsearch_budget`
+anyway, where `0.0` is falsy and selects the same branch `None` does.
+This investigation was deliberately run against a tree where #4776 is
+**unfixed**; fixing it activates board 07's currently-no-op sweep in
+*both* arms and would re-baseline these numbers.
+
+The two recorded CI runs predate `Autorouter._post_negotiation_sweep_bound_line`
+(added by PR #4775), so that line does not appear in their logs at all --
+which is itself evidence it cannot be the cause.
+
+### The measured outcome
+
+| | B (10 s wall clock) | A (iteration-bounded) |
+|---|---|---|
+| initial negotiated pass | **5** rip-up iterations in 600.0 s | **2** rip-up iterations in 602.4 s |
+| reach after that pass | 25 -> **26/31** (iter 2 onward) | **24/31** (iter 1, then the stage timeout fires) |
+| unrouted entering the delta loop | 5 | 7 |
+| deltas proposed / kept | 10 / **0** | 14 / **1** |
+| `U2 mirror` probe | routed 25 -> 21, reverted | routed 23 -> 22, reverted |
+| `U3 translate` probe | routed 25 -> 25, reverted (*no strict routed-net increase*) | routed 23 -> **27**, **KEPT** |
+| final reach | **26/31** | **27/31** |
+| blocking DRC (`kct check --mfr jlcpcb`, advisory-filtered) | **8** (== allowlist) | **13** |
+| copper-LVS opens | `DQ3, DQ4, MIPI_DAT0_N, TMDS_D0_N, TMDS_D1_N` | `DQS_N, MIPI_DAT0_P, TMDS_D0_N, TMDS_D1_N` |
+
+Both arms' negotiated passes exit on the same `--timeout 600` stage
+deadline ("Stopped due to timeout - returning best partial result" in
+both logs). The bound does not buy the stage more time; it changes how
+that fixed time is spent.
+
+**The deterministic bound *does* deliver what it promises.** The second
+A-side run (`721fc052` / run `31283738762`, a different head on a
+different runner) reproduces the first line for line: initial pass
+24/31 in 598.4 s, 7 unrouted, `Deltas proposed: 14`, `Deltas kept: 1`,
+`kept: U3 translate (net MIPI_CLK_N)`, final 27/31, `DRC error count: 13`.
+The outcome it makes machine-independent is simply a worse one on this
+board. Reproducibility was never the objection; the routed result is.
+
+### Which rescues differ (the per-net answer)
+
+There is **no single net whose rescue flips commit-vs-rollback**, and --
+the load-bearing part -- **not one of the nets whose routed state
+differs between the arms is a rescue commit in either arm.**
+
+Note first *which* pass produces each arm's artifact. B keeps no delta,
+so its artifact is the initial negotiated pass; A keeps the `U3
+translate`, so its artifact is the second probe pass. The rescues that
+actually **commit** into each shipped board are:
+
+| arm | artifact pass | rescues that committed |
+|---|---|---|
+| B | initial | `TMDS_D1_P` (x2), `MIPI_DAT1_P`, `MIPI_CLK_N` |
+| A | probe 1 (`U3 translate` kept) | `TMDS_D2_N`, `MIPI_DAT1_P` |
+
+Set that against the reach delta -- gained `DQ3`, `DQ4`,
+`MIPI_DAT0_N`; lost `DQS_N`, `MIPI_DAT0_P` -- and the two lists are
+**disjoint**. Every net that changed hands did so through ordinary
+negotiated routing under a different placement, not through a rescue.
+
+What the bound *does* change is the rescue trajectory, wholesale, from
+the first pass onward -- a rescue that would have died at 10 s runs on
+into the 120 s backstop and displaces every later attempt in the pass.
+In the initial pass, for instance:
+
+* `MIPI_CLK_N` commits in B and is never even attempted in A;
+  `MIPI_DAT1_P` commits in B and rolls back on victims in A;
+* `DQ2` and `DQS_N` are attempted in A and not in B; `MIPI_DAT0_P` is
+  attempted in B and not in A;
+* `DQ3`, `DQ4`, `TMDS_D0_N` and `MIPI_DAT0_N` are each retried **three
+  times** in B where A gets one attempt -- the direct consequence of B
+  completing five rip-up iterations to A's two.
+
+The net effect of the rescue layer alone is **negative**: A ends the
+negotiated pass at 24/31, two nets *behind* B's 26/31. Board 07 is
+sub-search-budget-*starved*, not sub-search-budget-*straddled* the way
+board 06 is (#4536); relaxing the bound spends the stage budget that
+board 07's reach actually depends on.
+
+#### The single decisive rescue: `DQ3`
+
+Both arms' initial pass reaches `DQ3` at the same point (~253 s / ~265 s
+into iteration 1) and both rescues **roll back**. What differs is the
+price, straight from the logs' own elapsed markers:
+
+| | B (10 s wall clock) | A (iteration-bounded) |
+|---|---|---|
+| `DQ4` rescue | `180.0s` -> `250.6s` = **70.6 s**, rolled back (8/9 victims) | `182.8s` -> `262.9s` = **80.1 s**, rolled back (8/9 victims) |
+| `DQ3` rescue | `253.2s` -> `255.8s` = **2.6 s**, `has NO relief path (round 2)` | `265.1s` -> `544.2s` = **279.1 s**, ripped 9 blockers, `only 7/9 displaced victim(s) re-landed -- rolling back` |
+| what happens next | iter 1 ends 25/31 at ~260 s; **iter 2 runs and reaches 26/31**; iters 3-4 hold | iter 1 ends 24/31; the 600 s stage deadline fires at 602.4 s; **iteration 2 never runs** |
+
+Under the 10 s bound `DQ3`'s probe gives up in 2.6 s. Under the
+deterministic bound the same probe *finds* a relief path, rips nine
+blockers, and then spends **279 s -- 46 % of the entire 600 s stage
+budget** failing to re-land two of them, before restoring the board
+verbatim. Counting `DQ4`, arm A spends ~360 s (60 % of the stage) inside
+two transactions that both leave the board exactly as they found it.
+
+That is what costs the two nets: **the rip-up iteration that produces
+board 07's 26th net is the one the flip cannot afford to run.**
+
+Per-pass totals, same measure:
+
+| pass | B: completed rescue transactions / total s / longest | A: completed / total s / longest |
+|---|---|---|
+| initial | 21 / 445.6 s / 70.6 s (`DQ4`) | 12 / 514.4 s / **279.1 s** (`DQ3`) |
+| probe 0 | 19 / 295.0 s / 42.0 s | 15 / 418.2 s / 134.3 s |
+| probe 1 | 21 / 375.8 s / 56.5 s | 18 / 658.4 s / 145.2 s |
+
+Fewer transactions, more seconds, in every pass. (Both arms hit the
+`C++ pathfinder gave up ...; falling back to the pure-Python A*` path
+about equally often -- 37 times in B, 35 in A -- so the divergence is the
+bound, not a different backend mix.)
+
+### Where the +1 net actually comes from
+
+`PlacementDeltaFeedbackLoop.run_delta` keeps a delta on
+`new_count > pre_count and not regressed_drc` -- and **both** terms are
+**relative**, measured against the state the loop currently holds rather
+than against an absolute floor. So:
+
+* on `main` the loop enters with 25 routed and the `U3 translate` probe
+  measures 25 -> 25: no strict increase, **reverted**;
+* under the flip the loop enters with 23 routed and the *same* target
+  footprint's translate measures 23 -> 27: strict increase, **kept**.
+
+The clearance term is relative in the same way, and the host re-run
+caught it doing so. There, `main`'s probe *did* gain a net (25 -> 26)
+and was still refused -- `revert_reason: "clearance violations 0 -> 2"`
+in `output/matchgroup_test_routed_placement_delta.json`, the #4468 guard
+board 07's `../README.md` documents for this host. Under the flip the
+same move is measured from a worse starting state and **neither** term
+fires. A depressed baseline does not just lower the reach bar; it also
+lowers the clearance the move has to beat.
+
+(The `25` / `23` are the loop's own internal `_routed_count()`, which
+runs one below the pass's reported reach on this board -- the same
+off-by-one `../README.md` already flags for its probe table. The
+*relative* comparison is unaffected: what matters is that the flip's
+baseline is two lower than `main`'s, which is exactly the pass-level
+26 -> 24.)
+
+The `+1 net` is therefore not a rescue outcome at all. It is a placement
+change that `main` refuses and the flip admits, because the flip
+depressed the baseline the accept-gate compares against. Both A-side CI
+runs and the local re-run agree on the kept delta (`U3 translate`,
+justified by `MIPI_CLK_N`), so this is not a single-run accident.
+
+### Where the +5 DRC is (rule ids and nets)
+
+Blocking (advisory-filtered) errors, from the `BY RULE` block of
+`kct check --mfr jlcpcb` in each arm's Board 07 End-to-End job:
+
+| rule id | B | A | delta |
+|---|---|---|---|
+| `diffpair_length_skew` | 4 | 3 | **-1** |
+| `diffpair_routing_continuity` | 4 | 3 | **-1** |
+| `clearance_pad_segment` | 0 | 4 | **+4** |
+| `clearance_segment_via` | 0 | 2 | **+2** |
+| `match_group_length_skew` | 0 | 1 | **+1** |
+| **blocking total** | **8** | **13** | **+5** |
+
+First, what actually changed hands. The two open sets differ by five
+nets, not one:
+
+* **newly routed under the flip**: `DQ3`, `DQ4`, `MIPI_DAT0_N`
+* **newly open under the flip**: `DQS_N`, `MIPI_DAT0_P`
+* net `+1`.
+
+Per violation, with the classification the issue asked for
+(newly-kept-net / displaced-victim / neighbour). Nets and geometry are
+from `kct check --mfr jlcpcb --errors-only --format json` on the A-arm
+artifact; the coordinates are the final (sheet-centred) frame:
+
+1. **`clearance_segment_via` x2**, 0.049 mm against the 0.1016 mm jlcpcb
+   floor, nets **`DQ1` / `DQ2`**, `F.Cu` at `(124.209, 68.779)` --
+   `U1`'s DDR escape. **Neighbour**: both nets are routed in *both*
+   arms; neither is newly kept, and no rescue that touched them
+   committed.
+2. **`clearance_pad_segment` x2**, 0.094 mm, nets **`DQ1` / `DQ2`**,
+   `F.Cu` at `(118.5, 68.6)`. **Neighbour**, same two nets.
+3. **`clearance_pad_segment` x2**, 0.076 mm, nets **`DQ4` / `DQS_N`**,
+   `F.Cu` at `(118.5, 64.6)`. This is the only pair that touches the
+   delta: `DQ4` is one of the three **newly-kept** nets and `DQS_N` is
+   one of the two the flip **lost** (its pad is still there; its copper
+   is not). So the flip's new copper is failing clearance against the
+   pad of the net it dropped.
+4. **`match_group_length_skew` x1**: `ADDR_BUS` skew **11.0299 mm**
+   against a 0.500 mm tolerance. `ADDR_BUS` is `A0`-`A7` -- **disjoint
+   from every net whose routed state changed**, so this is a pure
+   **neighbour** regression. On `main` the tuner reports
+   `ADDR_BUS: 8 members (7 tuned, 0 clean, 0 rolled back ...)` and the
+   group lands at 0.000 mm; under the flip it reports `(6 tuned, 0 clean,
+   1 rolled back ...)`.
+5. The two **negative** entries are not improvements: `DQS_N`/`DQS_P`
+   stops producing its `diffpair_length_skew` (11.034 mm) and
+   `diffpair_routing_continuity` (4.5 %) findings only because **`DQS_N`
+   is unrouted in A**, so the pair is no longer "engaged" and the rules
+   stop firing. A lost net is scoring as -2 DRC.
+
+So of the seven new errors, **five sit on copper with no connection to
+the reach delta at all** (`DQ1`/`DQ2`, `ADDR_BUS`), and the remaining two
+are a newly-kept net clashing with a newly-dropped net's pad. **None is
+on copper a rescue committed**: the only rescues that commit into the A
+artifact are `TMDS_D2_N` and `MIPI_DAT1_P`, and neither appears in any
+of the seven.
+
+Items 1-4 are precisely the cost the board's own `../README.md` already
+records for this delta ("two `U1`-escape clearances drop to 0.076 /
+0.094 mm against the 0.102 mm jlcpcb floor (blocking DRC 10 -> 13) and
+the `ADDR_BUS` length-match tuner is left at 11.03 mm skew instead of
+0.000 mm"). The flip did not discover a new failure mode; it re-admitted
+a documented bad trade.
+
+### Verdict: intrinsic, or artifact?
+
+**Neither of the two hypotheses the issue offered.** It is not intrinsic
+to keeping a net via a rescue -- no rescue keeps any of the nets that
+changed hands. And it is not a re-land *ordering* effect inside
+`Autorouter._relief_rescue` -- the extra errors are not on displaced
+victims either. The rescue layer's only contribution to the delta is the
+*time* it spends.
+
+The mechanism is **budget displacement**:
+
+1. the deterministic bound lets relief sub-searches run far longer (the
+   `DQ3` transaction: 2.6 s -> 279.1 s, rolling back either way);
+2. the negotiated stage's `--timeout 600` is unchanged, so it completes
+   2 rip-up iterations instead of 5 and ends 2 nets *behind*;
+3. `PlacementDeltaFeedbackLoop.run_delta`'s accept-gate is relative, so
+   the depressed baseline admits a placement delta `main` refuses;
+4. that delta -- not the rescue -- brings both the `+1 net` and the
+   `+5 DRC`.
+
+The corollary matters for #4730: **the `+1 net` is not evidence that the
+deterministic bound helps board 07.** Held at a fixed placement, the
+bound is a straight 2-net regression on this board. The recommendation
+recorded on #4730 is therefore *(c) accept the negative result as
+permanent* -- not a per-board scoping (which `DETERMINISTIC_RESCUE_DEFAULT
+= False` plus board 06's explicit opt-in already is) and not a rescue
+change in service of a reattempt (there was never a reach gain to bank).
+
+The investigation did expose an independent router defect, filed as
+**#4781**: a single rescue transaction can consume ~46 % of a stage
+budget and roll back, because `Autorouter._relief_rescue`'s only
+whole-transaction bound is the *stage* deadline (#3413) and its
+sub-search bound (#4536) bounds the parts, not their product. That is a
+routing-throughput issue in its own right, not a route back to this flip.
+
+### Host re-run (same `HEAD`, both arms)
+
+The two CI runs above are the authoritative measurement (board 07's
+`../README.md` "Host-vs-CI divergence" section documents that
+probe-level routed counts differ between macOS arm64 and CI even at a
+fixed seed). A same-`HEAD` local A/B was run on top of `c7313b39` for the
+two things the historical CI logs cannot show -- that the
+`Relief-rescue sub-search cap:` line differs between arms and the
+`Post-negotiation sweep bound:` line does not -- with
+`PYTHONHASHSEED=42 uv run python scripts/ci/check_matchgroup_coverage.py
+boards/07-matchgroup-test --seed 42` and the C++ backend built. The host
+was heavily loaded by concurrent agents (load average 40-66 on 28 cores),
+which perturbs the wall-clock arm by construction; the host numbers are
+therefore corroboration and the CI numbers stand.
+
+It corroborates cleanly. **Both headline outcomes reproduced on the
+host**, despite the load:
+
+| | local B (10 s wall clock) | local A (iteration-bounded) |
+|---|---|---|
+| `Relief-rescue sub-search cap:` | `10.0s wall clock -- deterministic rescue is off ...` | `iteration-bounded (per-net node-expansion cap; issue #4536) ...` |
+| initial pass | 25/31 at iter 1, **26/31** at iter 2, held to iter 10 | **24/31** at iter 1 (matching CI exactly), 25/31 at iter 2 |
+| deltas kept | **0** (`U3 translate` reverted, `clearance violations 0 -> 2`) | **1** -- `kept: U3 translate (net MIPI_CLK_N)` |
+| final reach / blocking DRC | **26/31** / **8** (gate exit 0) | **27/31** / **13** (gate exit 2) |
+
+The one host/CI difference is how many rip-up iterations fit in the
+600 s stage -- unsurprising, since the *stage deadline is still a wall
+clock* even in the deterministic arm. Worth stating plainly: the #4536
+bound makes the rescue's own commit/roll-back decisions
+machine-independent, it does **not** make the pass machine-independent,
+because the number of iterations that fit is still a function of machine
+speed. On board 07 that iteration count is the term that decides reach.
+
+### Reproducing this A/B
+
+```bash
+./.loom/scripts/worktree.sh <n> && cd .loom/worktrees/issue-<n>
+uv run kct build-native                       # MUST report "available"
+# B side: no source change.
+# A side: DETERMINISTIC_RESCUE_DEFAULT = True in
+#         src/kicad_tools/router/core.py -- nothing else.
+PYTHONHASHSEED=42 uv run python scripts/ci/check_matchgroup_coverage.py \
+  boards/07-matchgroup-test --seed 42 2>&1 | tee /tmp/board07-<arm>.log
+```
+
+Flip the **constant**, not the CLI. Board 07 re-routes through
+`PlacementDeltaFeedbackLoop`, whose `negotiated_kwargs` carries only
+`timeout` / `per_net_timeout` and forwards no `deterministic_rescue`, so
+wiring the flag at the CLI's own `route_all_negotiated` call site would
+not reach the passes that produced these numbers -- it would be a
+different experiment.
+
 ## Files in this directory
 
 - `README.md` -- this file.

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -217,8 +217,24 @@ def _normalize_deterministic_budget(args, quiet: bool = False) -> None:
     (``DETERMINISTIC_RESCUE_DEFAULT`` is ``False``): board 07 regressed with it
     on (changed LVS open set, routed-DRC 8 -> 13 against an allowlist main sits
     exactly at), so ``--deterministic-budget`` still means "wall-clock rescue
-    bound" for every ``kct route`` caller.  No call site passes the flag; the
-    constant is the single switch to flip when that regression is understood.
+    bound" for every ``kct route`` caller.  No call site passes the flag.
+
+    Issue #4770 measured WHY and closed the question: the opt-in is permanent,
+    not provisional.  On board 07 the deterministic bound does not buy a net --
+    it LOSES two (26/31 -> 24/31 in the negotiated pass), because relief
+    sub-searches that used to die at 10 s run on toward the 120 s backstop and
+    the unchanged stage ``--timeout`` then covers 2 rip-up iterations instead
+    of 5.  The reported "+1 net / +5 DRC" is produced downstream by the
+    placement-delta feedback loop's RELATIVE accept-gate admitting a placement
+    delta ``main`` refuses.  Note the interaction this normalizer owns: (1)
+    sets ``per_net_timeout = 0.0``, which is falsy in
+    ``Autorouter._relief_subsearch_budget`` and therefore selects the same
+    ``RELIEF_SUBSEARCH_BUDGET_S`` branch ``None`` does -- so it is invariant
+    across both arms of that A/B and cannot explain the delta (it does bite
+    the post-negotiation sweep; that is issue #4776).  Read the
+    ``DETERMINISTIC_RESCUE_DEFAULT`` docblock in ``router/core.py`` and
+    ``boards/07-matchgroup-test/diagnostic-runs/README.md`` before touching
+    the constant.
     """
     if not getattr(args, "deterministic_budget", False):
         return

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -219,15 +219,68 @@ RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S = 120.0
 # attribution was wrong -- board 07 never reaches ``route_all_two_phase``, and
 # the regression reproduced unchanged.
 #
+# WHY, measured (issue #4770).  Both halves of the intuitive reading -- "a
+# rescue now commits, and its copper costs 5 DRC" -- are FALSE.  Full journal,
+# with the per-pass rescue tables and the reproduction recipe:
+# ``boards/07-matchgroup-test/diagnostic-runs/README.md``, section
+# "Deterministic relief-rescue bound: A/B measurement (#4770)".
+#
+#   * NO net's rescue flips commit-vs-rollback.  On board 07 the bound is a
+#     straight REACH LOSS in the negotiated pass: 26/31 -> 24/31.  Sub-searches
+#     that used to die at ``RELIEF_SUBSEARCH_BUDGET_S`` run on toward the
+#     120 s backstop, so the UNCHANGED ``--timeout 600`` stage budget covers
+#     2 rip-up iterations instead of 5.  One transaction carries most of it:
+#     ``DQ3``'s rescue gives up in 2.6 s under the 10 s bound (``has NO relief
+#     path``) but runs 279.1 s -- 46% of the whole stage -- under the
+#     deterministic one before rolling back anyway (``only 7/9 displaced
+#     victim(s) re-landed``).  The rip-up iteration that produces board 07's
+#     26th net is the one the flip cannot afford to run.
+#   * The "+1 net" is a PLACEMENT DELTA, not reach.  Board 07 re-routes under
+#     ``--placement-delta-feedback``, and ``PlacementDeltaFeedbackLoop``'s
+#     ``run_delta`` keeps a delta on ``new_count > pre_count`` -- a RELATIVE
+#     gate.  Entering the loop at 25 routed, main measures the ``U3 translate``
+#     probe at 25 -> 25 and REVERTS it (``Deltas kept: 0``); entering at 23,
+#     the flip measures 23 -> 27 and KEEPS it.  The depressed baseline is what
+#     admits it.
+#   * The "+5 DRC" is that delta's already-documented cost (see
+#     ``boards/07-matchgroup-test/README.md``, "Placement-delta feedback"), on
+#     copper that is not rescue output: 2x ``clearance_pad_segment`` +
+#     2x ``clearance_segment_via`` on ``DQ1``/``DQ2`` (routed in BOTH arms),
+#     2x ``clearance_pad_segment`` on ``DQ4``/``DQS_N``, and 1x
+#     ``match_group_length_skew`` with ``ADDR_BUS`` (``A0``-``A7``, disjoint
+#     from every net whose routed state changed) at 11.030 mm instead of
+#     0.000 mm -- less the ``DQS_N``/``DQS_P`` diff-pair skew + continuity pair
+#     that stops firing only because ``DQS_N`` went UNROUTED.
+#
+# So the trade is not "one more net for five more errors".  Held at a fixed
+# placement the bound COSTS board 07 two nets, and the apparent gain is a
+# second-order effect of a relative accept-gate.  #4770's recommendation,
+# recorded on #4730: keep the opt-in PERMANENTLY.  Reproducibility was never
+# the objection -- the A arm is bit-stable across two runners and two heads;
+# the outcome it makes machine-independent is simply the worse one here.
+#
+# Reproducing the A/B means flipping THIS CONSTANT, not wiring the CLI.
+# Board 07's re-route passes go through ``PlacementDeltaFeedbackLoop``, whose
+# ``negotiated_kwargs`` carries only ``timeout`` / ``per_net_timeout`` and
+# forwards no ``deterministic_rescue``; a CLI-level ``deterministic_rescue=``
+# on the ``route_all_negotiated`` call site would never reach them, so it would
+# be a DIFFERENT experiment from the one that produced the numbers above.
+# ``TestPlacementDeltaFeedbackCaveat`` in
+# ``tests/test_relief_subsearch_budget.py`` fails if that stops being true, so
+# this paragraph cannot rot silently.
+#
 # What #4730 did land is the per-call switch.  Every entry point above takes
 # ``deterministic_rescue``, and ``_create_two_phase_router`` binds it onto the
 # positional #3471 stall-relief hook with a ``functools.partial``, so opting a
 # path in (or a future fleet flip) is a value change backed by measurement
 # rather than a rewiring job.  Board 06 depends on the opt-in: it passes
 # ``deterministic_rescue=True`` explicitly because its 21/21 reach gate is
-# otherwise a coin flip on runner speed.  Reattempting the flip means first
-# understanding board 07's rescue outcome -- which nets its rescues keep, and
-# why the kept copper carries +5 DRC.
+# otherwise a coin flip on runner speed.  Board 07 is the opposite case and
+# #4770 settled it: it is sub-search-budget-STARVED, not straddled, so the
+# per-board opt-in is the right shape and this default is not a placeholder
+# awaiting more evidence.  What would have to change before the question is
+# worth reopening is board 07's INPUTS -- a rescue that cannot spend ~46% of a
+# stage budget and roll back (issue #4781) -- not another A/B of this flag.
 DETERMINISTIC_RESCUE_DEFAULT = False
 
 

--- a/tests/test_relief_subsearch_budget.py
+++ b/tests/test_relief_subsearch_budget.py
@@ -15,6 +15,12 @@ that.  So :data:`DETERMINISTIC_RESCUE_DEFAULT` is ``False`` on every entry
 point (``TestDeterministicRescueDefault``) and board 06 keeps its explicit
 opt-in.
 
+Issue #4770 measured why and made the opt-in PERMANENT: the bound does not
+buy board 07 a net, it loses two (26/31 -> 24/31 in the negotiated pass), and
+the reported ``+1 net / +5 DRC`` comes from the placement-delta feedback
+loop's relative accept-gate downstream.  ``TestPlacementDeltaFeedbackCaveat``
+pins the two structural claims that finding rests on.
+
 What the issue did land is the per-call switch, pinned by
 ``TestPerCallThreading``: every entry point that can reach a rescue takes
 ``deterministic_rescue``, and the two-phase stall-relief hook -- which calls
@@ -161,6 +167,46 @@ class TestDeterministicRescueDefault:
         assert _budget(_BudgetStub(), None, DETERMINISTIC_RESCUE_DEFAULT) == (
             RELIEF_SUBSEARCH_BUDGET_S
         )
+
+
+class TestPlacementDeltaFeedbackCaveat:
+    """Issue #4770: doc-drift guards for the two claims the A/B rests on.
+
+    The ``DETERMINISTIC_RESCUE_DEFAULT`` docblock tells the next person two
+    things that are only true as long as the code below stays as it is:
+
+    1. reproduce the A/B by flipping the CONSTANT, because board 07's
+       re-route passes go through :class:`PlacementDeltaFeedbackLoop`, which
+       forwards no ``deterministic_rescue`` -- so a CLI-level wiring is a
+       DIFFERENT experiment; and
+    2. the #4159 post-negotiation sweep bound is identical in both arms by
+       construction, which is what excludes it as a confound.
+
+    Neither is a behaviour this repo wants to freeze -- they are statements
+    the docblock makes.  If a future change falsifies one, this class goes
+    red so the docblock is corrected in the same PR instead of rotting into
+    a confidently wrong explanation.
+    """
+
+    def test_placement_delta_loop_forwards_no_deterministic_rescue(self):
+        """Claim 1.  If this fails, ``PlacementDeltaFeedbackLoop`` gained the
+        parameter -- update the docblock's "flip the constant, not the CLI"
+        paragraph, because a CLI wiring would then reach board 07's re-routes
+        and the two experiments would finally be equivalent."""
+        from kicad_tools.router.placement_feedback import PlacementDeltaFeedbackLoop
+
+        params = inspect.signature(PlacementDeltaFeedbackLoop.run_delta).parameters
+        assert "deterministic_rescue" not in params
+
+    def test_sweep_bound_cannot_see_the_rescue_flag(self):
+        """Claim 2.  ``_post_negotiation_sweep_bounds`` takes only
+        ``(timeout, per_net_timeout, elapsed, timed_out)``, so #4770's A/B
+        arms print the same ``Post-negotiation sweep bound:`` line (confirmed
+        empirically: ``60.0s whole-sweep / 10.0s per-net`` in both) and the
+        #4159 sweep is excluded as a cause of the ``+1 net / +5 DRC``."""
+        params = inspect.signature(Autorouter._post_negotiation_sweep_bounds).parameters
+        assert list(params)[1:] == ["timeout", "per_net_timeout", "elapsed", "timed_out"]
+        assert "deterministic_rescue" not in params
 
 
 class TestReliefSubsearchBoundLine:


### PR DESCRIPTION
## Summary

Issue #4770 is an **investigation**, and this PR is its written finding. Board 07 measured `+1 net / +5 DRC` when #4730 flipped `DETERMINISTIC_RESCUE_DEFAULT` to `True`; the issue asked *which* rescues change outcome, *whose* copper carries the extra DRC, and whether that DRC is intrinsic or an artifact.

**Both halves of the intuitive reading are false, and the finding is a negative result: the opt-in stays permanently.**

* **No net's rescue flips commit-vs-rollback**, and not one of the nets that changed hands is a rescue commit in either arm. The deterministic bound is a straight **reach loss** in the negotiated pass (26/31 → 24/31): `DQ3`'s relief transaction gives up in **2.6 s** under the 10 s wall clock but runs **279.1 s — 46 % of the 600 s stage budget** under the deterministic one and rolls back anyway, so the pass completes 2 rip-up iterations instead of 5 and never reaches the one that lands board 07's 26th net.
* **The `+1 net` is a placement delta.** `PlacementDeltaFeedbackLoop.run_delta` keeps a delta on `new_count > pre_count and not regressed_drc` — both terms **relative**. The depressed baseline admits the `U3 translate` delta that `main` refuses.
* **The `+5 DRC` is that delta's already-documented cost**, on copper no rescue committed. Five of the seven new errors have no connection to the reach delta at all.

Verdict: **neither intrinsic nor a re-land ordering artifact — budget displacement.** Recommendation posted on #4730: **(c) accept the negative result as permanent.** The independent router defect the investigation exposed (a rescue can spend ~46 % of a stage budget and roll back) is filed separately as **#4781** — explicitly *not* a route back to the flip.

`DETERMINISTIC_RESCUE_DEFAULT` is **unchanged (`False`)**. No allowlist raised, no reach floor lowered, no board artifact regenerated in the diff.

## Changes

| File | What |
|---|---|
| `src/kicad_tools/router/core.py` | `DETERMINISTIC_RESCUE_DEFAULT` docblock: the closing *charter* ("reattempting the flip means first understanding board 07's rescue outcome") is replaced by the *answer*, plus the "flip the constant, not the CLI" caveat. Comments only. |
| `src/kicad_tools/cli/route_cmd.py` | `_normalize_deterministic_budget` docstring updated in lockstep so the two cannot drift; notes that its own `per_net_timeout = 0.0` is falsy in `Autorouter._relief_subsearch_budget` and therefore invariant across the A/B arms. Docstring only. |
| `boards/07-matchgroup-test/diagnostic-runs/README.md` | **The main deliverable** — the measurement journal: A/B table, per-pass rescue accounting, the `DQ3` comparison, per-violation attribution, the verdict, the host re-run, and the reproduction recipe. |
| `boards/07-matchgroup-test/README.md` | Cross-links the finding from the "Placement-delta feedback" narrative — the relative accept-gate is now shown with a worked example of what it costs. |
| `tests/test_relief_subsearch_budget.py` | New `TestPlacementDeltaFeedbackCaveat` (2 tests) pinning the two structural claims the finding rests on. |
| `CHANGELOG.md` | Entry under the **first** `[Unreleased]` `### Fixed` (per #4771; no reorganisation). |

## The measurement

| | **B** — 10 s wall clock (`main`) | **A** — iteration-bounded (#4730 flip) |
|---|---|---|
| head / CI run | `6cfa8842` / `31277512785` | `6071d1b2` / `31281260812` (+ `721fc052` / `31283738762`) |
| `Relief-rescue sub-search cap:` | `10.0s wall clock -- deterministic rescue is off …` | `iteration-bounded (per-net node-expansion cap; issue #4536) …` |
| initial negotiated pass | **5** rip-up iterations → **26/31** | **2** rip-up iterations → **24/31** |
| deltas proposed / kept | 10 / **0** | 14 / **1** (`U3 translate`) |
| final reach | **26/31** | **27/31** |
| blocking DRC | **8** (== allowlist) | **13** |
| copper-LVS opens | `DQ3, DQ4, MIPI_DAT0_N, TMDS_D0_N, TMDS_D1_N` | `DQS_N, MIPI_DAT0_P, TMDS_D0_N, TMDS_D1_N` |

DRC delta by rule (from each arm's Board 07 End-to-End `BY RULE` block, nets from `kct check --format json` on the A artifact):

| rule id | B | A | Δ | nets |
|---|---|---|---|---|
| `clearance_pad_segment` | 0 | 4 | **+4** | `DQ1`/`DQ2` @ 0.094 mm ×2; `DQ4`/`DQS_N` @ 0.076 mm ×2 |
| `clearance_segment_via` | 0 | 2 | **+2** | `DQ1`/`DQ2` @ 0.049 mm |
| `match_group_length_skew` | 0 | 1 | **+1** | `ADDR_BUS` (`A0`–`A7`) 11.030 mm vs 0.000 mm |
| `diffpair_length_skew` | 4 | 3 | −1 | `DQS_N`/`DQS_P` stops firing — `DQS_N` went **unrouted** |
| `diffpair_routing_continuity` | 4 | 3 | −1 | same |
| **total** | **8** | **13** | **+5** | |

`DQ1`, `DQ2` and `ADDR_BUS` are routed in *both* arms and are neither rescued nor displaced — five of the seven new errors are pure neighbours. The remaining two are a newly-kept net (`DQ4`) clashing with the pad of a newly-dropped one (`DQS_N`). The only rescues that commit into the shipped boards are `TMDS_D1_P`×2/`MIPI_DAT1_P`/`MIPI_CLK_N` (B) and `TMDS_D2_N`/`MIPI_DAT1_P` (A) — disjoint from every net whose routed state changed, and absent from all seven violations.

## Acceptance Criteria Verification

- [x] **A/B re-run, both logs captured, `Relief-rescue sub-search cap:` quoted from each.** Local same-`HEAD` A/B on `c7313b39` with the C++ backend built (`kct build-native --check` → available). B: `Relief-rescue sub-search cap: 10.0s wall clock -- deterministic rescue is off for this route …`. A: `Relief-rescue sub-search cap: iteration-bounded (per-net node-expansion cap; issue #4536) …`. Plus the three recorded CI job logs re-fetched and mined.
- [x] **`Post-negotiation sweep bound:` confirmed identical across arms.** Byte-identical on the initial CLI-driven pass in both: `60.0s whole-sweep / 10.0s per-net wall clock -- the caller passed a stage timeout (issue #4159)`. In the later placement-feedback passes both arms print `0.0s per-net` (#4776), i.e. the sweep is a silent no-op there in *both* arms. Also excluded by construction — `Autorouter._post_negotiation_sweep_bounds` never receives the flag — now pinned by a test.
- [x] **Nets whose rescue outcome differs are named** (§"Which rescues differ"), together with the stronger finding that none of them is a net that changed hands.
- [x] **Each additional DRC violation attributed with rule id + nets and classified.** Table above; full detail in the journal.
- [x] **Verdict on intrinsic vs re-land ordering artifact recorded**: neither — budget displacement, with the `DQ3` 2.6 s → 279.1 s evidence that distinguishes them.
- [x] **Recommendation posted on #4730**, choosing exactly one option: **(c)**. https://github.com/rjwalters/kicad-tools/issues/4730#issuecomment-5260300774
- [x] **`DETERMINISTIC_RESCUE_DEFAULT` docblock updated** with which nets and what kind of DRC.
- [x] **Docblock records the `PlacementDeltaFeedbackLoop` caveat** (a CLI-only wiring is not equivalent to a constant flip on this board), and `TestPlacementDeltaFeedbackCaveat` fails if that stops being true.
- [x] **`DETERMINISTIC_RESCUE_DEFAULT` value unchanged (`False`)** — `grep -n "^DETERMINISTIC_RESCUE_DEFAULT" src/kicad_tools/router/core.py` → `284:DETERMINISTIC_RESCUE_DEFAULT = False`.
- [x] **No DRC allowlist raised, no reach floor lowered** — `.github/routed-drc-tolerance.yml` and `.github/workflows/ci.yml` are not in the diff.
- [x] **No regenerated board artifact in the diff** — `git status --porcelain boards/` shows only the two READMEs; `boards/07-matchgroup-test/output/` restored to `HEAD`.

## Test Plan

- [x] `uv run pytest tests/test_relief_subsearch_budget.py tests/test_post_negotiation_sweep_budget.py tests/test_board_07_matchgroup_test.py tests/test_docs_source_citations.py tests/test_two_phase_stall_recovery.py tests/test_board06_determinism.py` → **114 passed, 1 skipped**
- [x] `uv run pytest tests/test_changelog_gap_report.py tests/test_diffpair_docs.py tests/test_match_group_docs.py` → **28 passed**
- [x] `uv run ruff check .` → All checks passed; `uv run ruff format . --check` → 1784 files already formatted
- [x] `rm -rf .mypy_cache && uv run python scripts/ci/check_mypy_baseline.py` (cold, per repo `CLAUDE.md`) → **1471 errors, all within the 1473 baseline**
- [x] `uv run kct check --only doc_drift boards/07-matchgroup-test/output/matchgroup_test_routed.kicad_pcb` → DRC PASSED, 0 errors (the board's doc-pin for the allowlist value `8` is untouched)
- [x] Doc citations use **symbol anchors**, never `path.py:NNN` (#4774)
- [x] Full suite: see the check run on this PR

### Manual verification (the primary deliverable)

Both arms run end to end locally on `c7313b39`, C++ backend built, `PYTHONHASHSEED=42 uv run python scripts/ci/check_matchgroup_coverage.py boards/07-matchgroup-test --seed 42`:

* **local B**: 25/31 → **26/31**, `Deltas kept: 0`, `DRC error count: 8 (allowed: 8)`, exit **0**
* **local A**: **24/31** initial pass (matching CI exactly), `kept: U3 translate (net MIPI_CLK_N)`, **27/31**, `DRC error count: 13 (allowed: 8)`, exit **2**

i.e. **both headline outcomes reproduced on the host**, despite it being heavily loaded by concurrent agents (load average 40–66 on 28 cores). The one host/CI difference is how many rip-up iterations fit in the 600 s stage — recorded in the journal, along with the observation it implies: the #4536 bound makes the rescue's own decisions machine-independent but does **not** make the pass machine-independent, because the stage deadline is still a wall clock and on board 07 the iteration count is the term that decides reach.

## Out of scope (respected)

No change to `DETERMINISTIC_RESCUE_DEFAULT`'s value (#4730), no fix for the `0.0` per-net leak (#4776 — deliberately left unfixed so this A/B's baseline stands), no attempt on board 07's reach (#3438), and no change to the relief-rescue algorithm — that motivated a follow-up, **#4781**, not an edit here.

Closes #4770

🤖 Generated with [Claude Code](https://claude.com/claude-code)
