### PR TITLE
feat(router): path-level pairwise (HV) clearance predicate for copper-moving passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -340,6 +340,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`docs/research/kipy-ipc-api-evaluation.md`** (#4779) — evaluation of `kipy` (official KiCad IPC-API bindings) and `kicad-mcp-kipy` as a parser cross-check; verdict: adopt nothing (live-editor-only RPC client, no offline path, cannot run DRC); also corrects the `README.md` "Related Projects" `kipy` entry to the canonical GitLab URL with the live-editor constraint stated.
 
+- **A path-level pairwise (HV) clearance predicate the copper-moving post-passes
+  can consult** (#4507, epic #4431 Phase 2) — `pairwise_clearance` gains
+  `path_pairwise_violation(x1, y1, x2, y2, layer, width, exclude_net, …)` (the
+  coordinate-level form of the `route_pairwise_violation` acceptance gate; both
+  now delegate to one shared walk, so predicate and gate agree by construction)
+  and `PairwisePathChecker` — a bound checker whose `path_is_clear` matches the
+  optimizer's `CollisionChecker` calling convention positionally, built from a
+  live router via `PairwisePathChecker.from_router` (returns `None` without a
+  `--voltage-map`, the standard dormancy contract). This is the API surface the
+  `--lattice-optimize` pairwise-blindness fix (#4766) composes with the scalar
+  collision checker; no existing behavior changes in this slice.
 - **`--format json` on the 10 prose-only holdouts inside the `datasheet`,
   `lib`, `parts` and `pcb` families** (part of #4674, third batch of the
   #4543 machine-output sweep) — `datasheet cache`, `datasheet convert`,

--- a/src/kicad_tools/router/pairwise_clearance.py
+++ b/src/kicad_tools/router/pairwise_clearance.py
@@ -41,11 +41,12 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Iterable, Mapping, NamedTuple, Sequence
+from typing import TYPE_CHECKING, Callable, Iterable, Mapping, NamedTuple, Sequence
 
 from kicad_tools.core.geometry import segment_to_segment_distance
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
+    from kicad_tools.router.layers import Layer
     from kicad_tools.router.primitives import Route, Segment
     from kicad_tools.schema.pcb import Footprint
 
@@ -711,6 +712,40 @@ def route_pairwise_violation(
     # ``exclude_net`` is the route's own net id and is authoritative mid-route
     # (``route.net``/``route.net_name`` may be unset before finalisation).
     moving_name = _resolve_net_name(id_to_name, exclude_net, route.net_name)
+    return _segments_pairwise_violation(
+        route.segments,
+        moving_name,
+        exclude_net,
+        foreign_routes,
+        table,
+        id_to_name=id_to_name,
+        floor=floor,
+        attach_zones=attach_zones,
+        tolerance=tolerance,
+    )
+
+
+def _segments_pairwise_violation(
+    segments: Sequence[Segment],
+    moving_name: str,
+    exclude_net: int,
+    foreign_routes: Iterable[Route],
+    table: PairwiseClearanceTable,
+    *,
+    id_to_name: Mapping[int, str] | None,
+    floor: float,
+    attach_zones: Sequence[AttachZone],
+    tolerance: float,
+) -> PairwiseViolation | None:
+    """Shared moving-copper-vs-foreign-routes walk (issue #4507).
+
+    ONE implementation backs both :func:`route_pairwise_violation` (the
+    post-route acceptance gate) and :func:`path_pairwise_violation` (the
+    candidate-path predicate), so a copper-moving pass that consults the
+    predicate can never disagree with the gate that audits its output --
+    the same single-implementation discipline :func:`project_zone_layers`
+    enforces for the #4506 layer scoping.
+    """
     for other in foreign_routes:
         if other.net == exclude_net:
             continue
@@ -720,7 +755,7 @@ def route_pairwise_violation(
         required = table.required_clearance(moving_name, foreign_name)
         if required <= floor + tolerance:
             continue
-        for seg in route.segments:
+        for seg in segments:
             for oseg in other.segments:
                 violation = segment_pair_violation(
                     seg,
@@ -735,6 +770,189 @@ def route_pairwise_violation(
                 if violation is not None:
                     return violation
     return None
+
+
+def path_pairwise_violation(
+    x1: float,
+    y1: float,
+    x2: float,
+    y2: float,
+    layer: Layer,
+    width: float,
+    exclude_net: int,
+    foreign_routes: Iterable[Route],
+    table: PairwiseClearanceTable | None,
+    *,
+    net_name: str | None = None,
+    id_to_name: Mapping[int, str] | None = None,
+    dru: float | None = None,
+    attach_zones: Sequence[AttachZone] = (),
+    tolerance: float = _PASS_TOLERANCE,
+) -> PairwiseViolation | None:
+    """Check ONE candidate path against the pairwise (HV) requirement (#4507).
+
+    The coordinate-level form of :func:`route_pairwise_violation`: instead of
+    a finished :class:`~kicad_tools.router.primitives.Route` it takes the
+    ``(x1, y1) -> (x2, y2)`` path a copper-moving pass is *about to commit* --
+    the exact shape the optimizer's
+    :meth:`~kicad_tools.router.optimizer.collision.CollisionChecker.path_is_clear`
+    hook already speaks (the first seven parameters match it positionally on
+    purpose).  Issue #4766 consults this before accepting a moved segment, so
+    the ``--lattice-optimize`` post-passes stop proposing copper the pairwise
+    audit backstop then flags.
+
+    Scope matches the audit exactly (trace-to-trace, same copper layer, #4506
+    attach-zone exemption included): both delegate to the same
+    :func:`_segments_pairwise_violation` walk, so predicate and gate agree by
+    construction.  Pad/via geometry remains the scalar checks' and the
+    ``kct creepage`` census' remit.
+
+    The moving net's name resolves from ``net_name`` when supplied, else from
+    ``id_to_name[exclude_net]``.  An unresolvable moving net returns ``None``
+    -- identical to the gate's empty ``route.net_name`` fallback, where an
+    unmatchable name can participate in no widening pair.  ``table=None`` (no
+    ``--voltage-map``) is likewise a strict no-op.
+    """
+    if table is None:
+        return None
+    moving_name = (
+        net_name if net_name is not None else _resolve_net_name(id_to_name, exclude_net, "")
+    )
+    if not moving_name:
+        return None
+    floor = table.dru if dru is None else dru
+
+    # Lazy import mirrors the module's TYPE_CHECKING-only primitives import
+    # (this module stays importable without the router package loaded).
+    from kicad_tools.router.primitives import Segment
+
+    candidate = Segment(x1, y1, x2, y2, width, layer, net=exclude_net, net_name=moving_name)
+    return _segments_pairwise_violation(
+        (candidate,),
+        moving_name,
+        exclude_net,
+        foreign_routes,
+        table,
+        id_to_name=id_to_name,
+        floor=floor,
+        attach_zones=attach_zones,
+        tolerance=tolerance,
+    )
+
+
+@dataclass(frozen=True)
+class PairwisePathChecker:
+    """Bound pairwise (HV) path predicate for copper-moving passes (#4507).
+
+    Packages everything :func:`path_pairwise_violation` needs -- the resolved
+    :class:`PairwiseClearanceTable`, a **live view** of the board's committed
+    foreign copper, the id->name map and the #4506 attach zones -- behind the
+    optimizer's ``path_is_clear(x1, y1, x2, y2, layer, width, exclude_net)``
+    calling convention (:class:`~kicad_tools.router.optimizer.collision.
+    CollisionChecker`), so issue #4766 can compose it with the existing scalar
+    collision checker: a moved segment is acceptable only when the scalar
+    checker AND this predicate both pass.
+
+    ``foreign_routes`` is a zero-argument callable re-evaluated on every query
+    (typically ``lambda: grid.routes``): the grid-synced optimize loop unmarks
+    each route before mutating it and re-marks it after, so a snapshot taken at
+    construction time would go stale mid-pass.
+
+    Instances only exist when a voltage map is active --
+    :meth:`from_router` returns ``None`` otherwise (the dormancy contract every
+    pairwise consumer follows), so callers guard with a single ``is None``
+    check and the scalar-only path stays byte-identical.
+    """
+
+    table: PairwiseClearanceTable
+    foreign_routes: Callable[[], Iterable[Route]]
+    id_to_name: Mapping[int, str] | None = None
+    attach_zones: Sequence[AttachZone] = ()
+    dru: float | None = None
+    tolerance: float = _PASS_TOLERANCE
+
+    @classmethod
+    def from_router(cls, router: object) -> PairwisePathChecker | None:
+        """Build the checker from a live ``Autorouter``; ``None`` when dormant.
+
+        Reads the same authorities the acceptance gate reads: the table from
+        ``router.rules.pairwise_clearance``, foreign copper live from
+        ``router.grid.routes`` (the same foreign-copper source the pathfinder's
+        ``Router._validate_route_clearance`` gate walks), names from
+        ``router.net_names`` (plus the pad-derived fallback
+        ``Autorouter._net_name_to_id`` adds for routers assembled without
+        ``add_component``), and the #4506 zones from the CLI resolver's
+        memoised ``_pairwise_attach_zones_cache`` hand-off (#4602 precedent).
+
+        Returns ``None`` when no voltage map installed a table (or the router
+        has no grid) -- the caller's signal to skip pairwise consultation
+        entirely.
+        """
+        rules = getattr(router, "rules", None)
+        table = getattr(rules, "pairwise_clearance", None) if rules is not None else None
+        if table is None:
+            return None
+        grid = getattr(router, "grid", None)
+        if grid is None:
+            return None
+
+        id_to_name: dict[int, str] = {
+            int(net_id): name
+            for net_id, name in (getattr(router, "net_names", None) or {}).items()
+            if name
+        }
+        name_to_id_fn = getattr(router, "_net_name_to_id", None)
+        if callable(name_to_id_fn):
+            for name, net_id in name_to_id_fn().items():
+                id_to_name.setdefault(int(net_id), name)
+
+        zones = getattr(router, "_pairwise_attach_zones_cache", None) or ()
+        return cls(
+            table=table,
+            foreign_routes=lambda: grid.routes,
+            id_to_name=id_to_name or None,
+            attach_zones=tuple(zones),
+        )
+
+    def path_violation(
+        self,
+        x1: float,
+        y1: float,
+        x2: float,
+        y2: float,
+        layer: Layer,
+        width: float,
+        exclude_net: int,
+    ) -> PairwiseViolation | None:
+        """First pairwise shortfall for the candidate path, or ``None``."""
+        return path_pairwise_violation(
+            x1,
+            y1,
+            x2,
+            y2,
+            layer,
+            width,
+            exclude_net,
+            self.foreign_routes(),
+            self.table,
+            id_to_name=self.id_to_name,
+            dru=self.dru,
+            attach_zones=self.attach_zones,
+            tolerance=self.tolerance,
+        )
+
+    def path_is_clear(
+        self,
+        x1: float,
+        y1: float,
+        x2: float,
+        y2: float,
+        layer: Layer,
+        width: float,
+        exclude_net: int,
+    ) -> bool:
+        """``CollisionChecker``-shaped verdict: True when no pair falls short."""
+        return self.path_violation(x1, y1, x2, y2, layer, width, exclude_net) is None
 
 
 def find_pairwise_violations(

--- a/tests/router/test_pairwise_clearance.py
+++ b/tests/router/test_pairwise_clearance.py
@@ -26,9 +26,11 @@ from kicad_tools.router.layers import Layer
 from kicad_tools.router.pairwise_clearance import (
     AttachZone,
     PairwiseClearanceTable,
+    PairwisePathChecker,
     build_attach_zones,
     build_pairwise_clearance_table,
     find_pairwise_violations,
+    path_pairwise_violation,
     route_pairwise_violation,
     segment_pair_violation,
 )
@@ -617,3 +619,237 @@ def test_apply_pairwise_clearance_noop_without_voltage_map() -> None:
     args = SimpleNamespace(_pairwise_voltages=None, _pairwise_required=None)
     _apply_pairwise_clearance(router, args, quiet=True)
     assert rules.pairwise_clearance is None
+
+
+# ---------------------------------------------------------------------------
+# Path-level predicate + bound checker (#4507; consumed by #4766)
+# ---------------------------------------------------------------------------
+
+
+def _foreign_gnd_route(y: float = 0.4, layer: Layer = Layer.F_CU) -> Route:
+    return Route(net=2, net_name="/GND", segments=[_seg(0, y, 5, y, 2, "/GND", layer=layer)])
+
+
+def test_path_predicate_flags_hv_lv_below_requirement() -> None:
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    v = path_pairwise_violation(
+        0.0,
+        0.0,
+        5.0,
+        0.0,
+        Layer.F_CU,
+        0.2,
+        1,
+        [_foreign_gnd_route()],
+        table,
+        net_name="/AC_LINE",
+    )
+    assert v is not None
+    assert v.required_mm == pytest.approx(IEC_150V_PD2_IIIA_MM)
+    assert v.actual_mm == pytest.approx(0.2, abs=1e-6)
+    assert (v.net_a, v.net_b) == ("/AC_LINE", "/GND")
+
+
+def test_path_predicate_accepts_same_domain_at_dru() -> None:
+    table = _table({"/AC_LINE": 150.0, "/AC_LINE_TAP": 150.0})
+    tap = Route(net=2, net_name="/AC_LINE_TAP", segments=[_seg(0, 0.4, 5, 0.4, 2, "/AC_LINE_TAP")])
+    assert (
+        path_pairwise_violation(
+            0.0, 0.0, 5.0, 0.0, Layer.F_CU, 0.2, 1, [tap], table, net_name="/AC_LINE"
+        )
+        is None
+    )
+
+
+def test_path_predicate_ignores_other_layer_copper() -> None:
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    assert (
+        path_pairwise_violation(
+            0.0,
+            0.0,
+            5.0,
+            0.0,
+            Layer.F_CU,
+            0.2,
+            1,
+            [_foreign_gnd_route(layer=Layer.B_CU)],
+            table,
+            net_name="/AC_LINE",
+        )
+        is None
+    )
+
+
+def test_path_predicate_skips_own_net_copper() -> None:
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    own = Route(net=1, net_name="/AC_LINE", segments=[_seg(0, 0.3, 5, 0.3, 1, "/AC_LINE")])
+    assert (
+        path_pairwise_violation(
+            0.0, 0.0, 5.0, 0.0, Layer.F_CU, 0.2, 1, [own], table, net_name="/AC_LINE"
+        )
+        is None
+    )
+
+
+def test_path_predicate_resolves_moving_name_from_ids() -> None:
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    anonymous = Route(net=2, net_name="", segments=[_seg(0, 0.4, 5, 0.4, 2, "")])
+    v = path_pairwise_violation(
+        0.0,
+        0.0,
+        5.0,
+        0.0,
+        Layer.F_CU,
+        0.2,
+        1,
+        [anonymous],
+        table,
+        id_to_name={1: "/AC_LINE", 2: "/GND"},
+    )
+    assert v is not None
+    assert (v.net_a, v.net_b) == ("/AC_LINE", "/GND")
+
+
+def test_path_predicate_unresolvable_moving_net_matches_gate_semantics() -> None:
+    """An unnamed moving net resolves no pair -- exactly the gate's verdict."""
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    foreign = [_foreign_gnd_route()]
+    assert path_pairwise_violation(0.0, 0.0, 5.0, 0.0, Layer.F_CU, 0.2, 1, foreign, table) is None
+    # The gate reaches the same verdict for a route whose net_name is unset.
+    unnamed = Route(net=1, net_name="", segments=[_seg(0, 0, 5, 0, 1, "")])
+    assert route_pairwise_violation(unnamed, 1, foreign, table) is None
+
+
+def test_path_predicate_dormant_without_table() -> None:
+    assert (
+        path_pairwise_violation(
+            0.0,
+            0.0,
+            5.0,
+            0.0,
+            Layer.F_CU,
+            0.2,
+            1,
+            [_foreign_gnd_route()],
+            None,
+            net_name="/AC_LINE",
+        )
+        is None
+    )
+
+
+def test_path_predicate_agrees_with_route_gate() -> None:
+    """Predicate and acceptance gate return the SAME finding on the same copper.
+
+    They share ``_segments_pairwise_violation`` by construction; this pins the
+    contract #4766 relies on -- a moved segment the predicate accepts cannot be
+    flagged by the audit backstop, and vice versa.
+    """
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    foreign = [_foreign_gnd_route()]
+    for y in (0.0, 2.5):  # violating and clean geometries
+        as_route = Route(net=1, net_name="/AC_LINE", segments=[_seg(0, y, 5, y, 1, "/AC_LINE")])
+        assert path_pairwise_violation(
+            0.0, y, 5.0, y, Layer.F_CU, 0.2, 1, foreign, table, net_name="/AC_LINE"
+        ) == route_pairwise_violation(as_route, 1, foreign, table)
+
+
+def test_path_predicate_honours_layer_scoped_attach_zone() -> None:
+    """The #4506/#4699 layer-scoped waiver applies to candidate paths too."""
+    table = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    zone = _smd_zone()  # pads on F.Cu only
+    # On the pad layer the zone waives the (above-DRU) proximity...
+    assert (
+        path_pairwise_violation(
+            0.0,
+            0.0,
+            5.0,
+            0.0,
+            Layer.F_CU,
+            0.2,
+            1,
+            [_foreign_gnd_route(y=0.5)],
+            table,
+            net_name="/AC_LINE",
+            attach_zones=(zone,),
+        )
+        is None
+    )
+    # ...but the same XY geometry on an inner layer stays a violation.
+    assert (
+        path_pairwise_violation(
+            0.0,
+            0.0,
+            5.0,
+            0.0,
+            Layer.IN1_CU,
+            0.2,
+            1,
+            [_foreign_gnd_route(y=0.5, layer=Layer.IN1_CU)],
+            table,
+            net_name="/AC_LINE",
+            attach_zones=(zone,),
+        )
+        is not None
+    )
+
+
+def test_checker_from_router_dormant_without_table() -> None:
+    router = SimpleNamespace(rules=DesignRules(), grid=SimpleNamespace(routes=[]))
+    assert PairwisePathChecker.from_router(router) is None
+
+
+def test_checker_from_router_builds_live_checker() -> None:
+    rules = DesignRules(trace_clearance=DRU)
+    rules.pairwise_clearance = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    grid = SimpleNamespace(routes=[])
+    router = SimpleNamespace(
+        rules=rules,
+        grid=grid,
+        net_names={1: "/AC_LINE", 2: "/GND"},
+        _pairwise_attach_zones_cache=None,
+    )
+    checker = PairwisePathChecker.from_router(router)
+    assert checker is not None
+    # No foreign copper yet -> clear.
+    assert checker.path_is_clear(0.0, 0.0, 5.0, 0.0, Layer.F_CU, 0.2, 1)
+    # The checker sees copper committed AFTER construction (live view): the
+    # grid-synced optimize loop unmarks/re-marks routes mid-pass, so a
+    # construction-time snapshot would go stale.
+    grid.routes.append(_foreign_gnd_route())
+    assert not checker.path_is_clear(0.0, 0.0, 5.0, 0.0, Layer.F_CU, 0.2, 1)
+    v = checker.path_violation(0.0, 0.0, 5.0, 0.0, Layer.F_CU, 0.2, 1)
+    assert v is not None and (v.net_a, v.net_b) == ("/AC_LINE", "/GND")
+    # Own-net copper never conflicts.
+    assert checker.path_is_clear(0.0, 0.0, 5.0, 0.0, Layer.F_CU, 0.2, 2)
+
+
+def test_checker_from_router_uses_pad_derived_name_fallback() -> None:
+    """A router with an empty ``net_names`` map still resolves via its pads."""
+    rules = DesignRules(trace_clearance=DRU)
+    rules.pairwise_clearance = _table({"/AC_LINE": 150.0, "/GND": 0.0})
+    router = SimpleNamespace(
+        rules=rules,
+        grid=SimpleNamespace(routes=[_foreign_gnd_route()]),
+        net_names={},
+        _net_name_to_id=lambda: {"/AC_LINE": 1, "/GND": 2},
+    )
+    checker = PairwisePathChecker.from_router(router)
+    assert checker is not None
+    assert not checker.path_is_clear(0.0, 0.0, 5.0, 0.0, Layer.F_CU, 0.2, 1)
+
+
+def test_checker_matches_collision_checker_protocol_signature() -> None:
+    """``path_is_clear`` stays call-compatible with the optimizer protocol.
+
+    #4766 composes this checker with ``make_collision_checker``'s output; if
+    either side renames or reorders a parameter the composition breaks, so pin
+    the positional shape here.
+    """
+    import inspect
+
+    from kicad_tools.router.optimizer.collision import CollisionChecker
+
+    protocol_params = list(inspect.signature(CollisionChecker.path_is_clear).parameters)
+    checker_params = list(inspect.signature(PairwisePathChecker.path_is_clear).parameters)
+    assert checker_params == protocol_params


### PR DESCRIPTION
## Summary

Second increment of #4507 (Phase 2 of epic #4431, pairwise HV-isolation
clearance). Slice 1 (PR #4780) closed the C++/Python attach-zone layer-scoping
mirror gap. This slice delivers the **predicate API surface** the next
consumer needs: issue #4766 (the `--lattice-optimize` post-passes are
pairwise-creepage-blind) requires "the same pair-keyed requirement +
layer-scoped attach-zone exemption the search uses" as a callable it can
consult **before accepting a moved segment** — but the only Python surfaces
were route-level (`route_pairwise_violation`, needs a finished `Route`) or a
bare segment pair (`segment_pair_violation`, caller does all resolution).
Nothing spoke the optimizer's
`path_is_clear(x1, y1, x2, y2, layer, width, exclude_net)` shape, so #4766
would have had to inline name resolution, foreign-copper iteration and zone
probing — exactly the drift-prone duplication this epic keeps eliminating.

## Changes (all in `src/kicad_tools/router/pairwise_clearance.py` + tests + CHANGELOG)

- **`path_pairwise_violation(x1, y1, x2, y2, layer, width, exclude_net, foreign_routes, table, *, net_name=None, id_to_name=None, dru=None, attach_zones=(), tolerance=…)`** —
  the coordinate-level form of the acceptance gate. The first seven parameters
  positionally match the optimizer's `CollisionChecker.path_is_clear` protocol
  on purpose. Scope matches the audit exactly (trace-to-trace, same copper
  layer, #4506/#4699 layer-scoped attach-zone exemption included). An
  unresolvable moving-net name returns `None` — identical to the gate's empty
  `route.net_name` fallback; `table=None` is a strict no-op.
- **`_segments_pairwise_violation`** — the foreign-routes walk **extracted
  unchanged** from `route_pairwise_violation`; both the gate and the new
  predicate delegate to this ONE implementation, so a pass consulting the
  predicate can never disagree with the audit backstop that flags its output
  (same single-implementation discipline as `project_zone_layers` in PR #4780).
- **`PairwisePathChecker`** — a frozen dataclass binding the table, a **live**
  foreign-copper view (zero-arg callable, re-evaluated per query because the
  grid-synced optimize loop unmarks/re-marks routes mid-pass), the id→name map
  and the #4506 zones. `path_is_clear(...)` is call-compatible with the
  optimizer's `CollisionChecker` protocol (pinned by a signature test);
  `path_violation(...)` returns the `PairwiseViolation` for diagnostics.
  `PairwisePathChecker.from_router(router)` builds it from a live `Autorouter`
  (same authorities the gate reads: `rules.pairwise_clearance`, `grid.routes`,
  `net_names` + the pad-derived `_net_name_to_id` fallback, the memoised
  `_pairwise_attach_zones_cache` hand-off) and returns **`None` when dormant**
  — the standard no-`--voltage-map` contract, one `is None` guard for callers.

**No behavior change in this slice**: `route_pairwise_violation` is a pure
extraction refactor (loop body byte-identical), and nothing consumes the new
API yet — #4766 wires it into the optimize/nudge passes, composed with the
scalar collision checker.

## What this slice deliberately does NOT do

- **No optimizer integration** — that is issue #4766's own acceptance
  criteria, sequenced after this API lands.
- **No C++ changes** — no `BUILD_VERSION` bump needed; the C++ search/validate
  surfaces were completed by #4510/#4511/PR #4780.
- **Softstart rev-C manual proof** — still the remaining open item on #4507;
  local-only fixture, epic-owner call (unchanged from PR #4780's note).

## Test Plan

Run in the issue worktree (C++ backend present at build version 19, untouched
by this slice):

- `uv run pytest tests/router/test_pairwise_clearance.py` — **52 passed**
  (15 new: predicate flags HV↔LV below requirement / accepts same-domain at
  DRU / other-layer copper ignored / own-net skipped / id-map name resolution /
  unresolvable-name-matches-gate / dormant without table / **predicate==gate
  agreement on violating and clean geometry** / layer-scoped zone waiver on the
  pad layer but not an inner layer / `from_router` dormancy, live-view,
  pad-derived-name fallback / protocol signature pin)
- `uv run pytest tests/router -q -n 4` (full router suite) — **1188 passed,
  5 skipped, exit 0** (11m33s; only pre-existing #3907 off-angle warnings)
- `uv run ruff check .` — All checks passed; `uv run ruff format . --check` —
  1785 files already formatted
- `uv run python scripts/ci/check_mypy_baseline.py` (cold, `.mypy_cache`
  removed) — OK: 1471 errors within the 1473 baseline, no new type errors

Part of #4507