### PR TITLE
fix(router): proportional bound on a single relief-rescue transaction (#4781)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A single relief-rescue transaction is now proportionally bounded** (#4781)
+  — a rescue (including its depth-1 nested rescues, which share the parent's
+  allowance) may spend at most `max(25% of the remaining stage budget, 90 s)`
+  before rolling back verbatim at the existing `_past_deadline()` check sites;
+  previously one board-07 transaction burned 279 s (46% of the 600 s stage)
+  and still rolled back, starving the rip-up iteration that lands the 26th
+  net. No-deadline stages (board 06's deterministic regen, the two-phase
+  stall-relief hook) are byte-identical; a `Relief-rescue transaction bound:`
+  log line records which arm was live.
+
 - **The C++ router's HV attach-zone waiver is now layer-scoped, so the search
   stops proposing copper the pairwise gate rejects** (#4507, epic #4431 Phase
   2) — PR #4756 narrowed the #4506 rated-footprint exemption on the Python side

--- a/boards/07-matchgroup-test/diagnostic-runs/README.md
+++ b/boards/07-matchgroup-test/diagnostic-runs/README.md
@@ -337,6 +337,70 @@ changed hands. And it is not a re-land *ordering* effect inside
 victims either. The rescue layer's only contribution to the delta is the
 *time* it spends.
 
+## Proportional relief-rescue transaction bound: A/B measurement (#4781)
+
+**What changed.** Issue #4781 (carved from the #4770 measurement above)
+bounds a single `_relief_rescue` transaction -- including its depth-1
+nested rescues, which SHARE the parent's allowance -- to
+`max(25% of the remaining stage budget, 90 s)`
+(`RELIEF_RESCUE_TXN_FRACTION` / `RELIEF_RESCUE_TXN_FLOOR_S` in
+`router/core.py`), evaluated only at the existing `_past_deadline()`
+check sites. The 90 s floor was calibrated against this file's #4770
+tables: the longest transaction the healthy `main` arm ever completes is
+70.6 s (`DQ4`, initial pass, CI), so on a main-shaped trajectory the
+bound never fires; the pathological `DQ3` transaction (279.1 s at ~337 s
+remaining) would be cut at 90 s, returning ~189 s to the rip-up loop.
+With no stage deadline (`timeout=None`) the bound is structurally inert.
+
+**What was compared.** Same-host local A/B (Apple Silicon, 28 cores),
+both arms `PYTHONHASHSEED=42 uv run python generate_design.py --step
+route --seed 42`: **B** = `main` @ `3a37d414`, **A** = the #4781 bound on
+top of the same head. The A arm's log prints the new evidence banner 3x
+(once per negotiated pass):
+
+```
+  Relief-rescue transaction bound: proportional -- one rescue transaction (nested rescues share the parent's allowance) may spend at most max(25% of the remaining stage budget, 90s) before rolling back verbatim (issue #4781)
+```
+
+**The measured outcome: a clean null on the healthy trajectory,
+identical to design intent.**
+
+| | B (`main`) | A (#4781 bound) |
+|---|---|---|
+| final reach | 26/31 | 26/31 |
+| copper-LVS opens | `DQ3, DQ4, MIPI_DAT0_N, TMDS_D0_N, TMDS_D1_N` | identical (`check_copper_lvs.py --expect-opens` passes both) |
+| blocking DRC (`check_routed_drc.py`, jlcpcb) | **8** (== allowlist) | **8** (== allowlist) |
+| deltas proposed / kept | 10 / 0 | 10 / 0 |
+| transaction-allowance aborts | n/a | **0** |
+| normalized PCB md5 (uuid-stripped, sorted) | `797984ea...` | `797984ea...` -- **identical artifact** |
+
+Per-pass rescue-transaction tables (same elapsed-marker method as the
+#4770 tables; durations include nested rescues):
+
+| pass | B: transactions / total s / longest | A: transactions / total s / longest |
+|---|---|---|
+| initial | 31 / 419.4 s / 56.9 s (`DQ4`) | 31 / 376.6 s / 46.1 s (`DQ4`) |
+| probe 0 | 48 / 388.2 s / 29.5 s (`MIPI_DAT1_P`) | 48 / 444.5 s / 30.7 s (`TMDS_D1_N`) |
+| probe 1 | 33 / 389.2 s / 48.7 s (`DQS_N`) | 33 / 397.9 s / 48.7 s (`DQS_N`) |
+
+Same transaction counts per pass (31/48/33), same commits per pass
+(4/5/2), and every transaction sits well under the 90 s floor on this
+host -- the differences are wall-clock jitter under load, and the
+committed geometry is bit-identical after uuid normalization. The
+pathological arm (a 279 s transaction) is exercised by the injected-clock
+unit tests in `tests/router/test_relief_rescue.py`
+(`TestReliefRescueProportionalBound`) rather than by this fixture, which
+does not produce one on `main`'s sub-search bound (`DQ3` gives up in
+seconds here -- see the #4770 section above for why the deterministic
+bound was what made it pathological).
+
+**Board 06 cross-check** (the board that needs rescues to *complete*):
+`check_diffpair_coverage.py boards/06-diffpair-test --seed 42` on the A
+arm passes -- signal reach 21/21 (required 21), pour connectivity OK, all
+3 diff-pair rules exercised, 18 errors within the 18 allowlist. Board 06
+routes with `timeout=None`, so `relief_deadline is None` and the bound is
+structurally inert there (the byte-identical no-deadline arm).
+
 The mechanism is **budget displacement**:
 
 1. the deterministic bound lets relief sub-searches run far longer (the

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -189,6 +189,53 @@ RELIEF_SUBSEARCH_BUDGET_S = 10.0
 # for minutes inside a rescue, per the #3989 lesson.
 RELIEF_SUBSEARCH_SAFETY_BACKSTOP_S = 120.0
 
+# Issue #4781: proportional bound on a single relief-rescue TRANSACTION.  The
+# sub-search budgets above bound each stage of a rescue (probe rounds, victim
+# re-lands, nested rescues), but their PRODUCT is unbounded -- the #3413 defect
+# one level up.  Measured on board 07 (#4770, CI run 31281260812): one ``DQ3``
+# transaction spent 279.1 s -- 46% of the whole 600 s stage -- ripping 9
+# blockers and then rolling back verbatim, and the rip-up iteration that
+# produces the board's 26th net is the one that time starved.
+#
+# The bound: a transaction (INCLUDING its depth-1 nested rescues, which share
+# the parent's allowance -- the parent's commit gate depends on them, so a
+# separate allowance would just rebuild the unbounded product) may spend at
+# most ``max(RELIEF_RESCUE_TXN_FRACTION * remaining, RELIEF_RESCUE_TXN_FLOOR_S)``
+# where ``remaining = deadline - transaction_start`` is the stage budget left
+# when the transaction begins.  It is evaluated ONLY at the existing
+# ``_past_deadline()`` check sites (top of each probe round, per victim
+# re-land, before each nested rescue) -- never inside the A* sub-searches --
+# so a single sub-search can still legally overshoot the allowance by up to
+# one sub-search budget (120 s worst case under ``deterministic_rescue``).
+# On breach the transaction rolls back verbatim via the existing
+# ``_rollback()``; aborting early is free by construction (the board is
+# restored either way) -- it can only cost rescues that would have succeeded.
+#
+# Calibration, from the #4770 per-pass rescue tables
+# (``boards/07-matchgroup-test/diagnostic-runs/README.md``):
+#
+#   * The FLOOR (90 s) sits above the longest transaction the healthy `main`
+#     arm ever completes (70.6 s, ``DQ4``, board 07 initial pass) -- so on a
+#     main-shaped trajectory the bound never fires and board 07's A/B inputs
+#     are unchanged.  Near the stage end the stage deadline is checked first,
+#     so the floor never EXTENDS a transaction past ``deadline``.
+#   * The FRACTION (25%) caps an early-stage pathological transaction: the
+#     ``DQ3`` rescue began with ~337 s of stage remaining, so its allowance
+#     becomes max(84.3, 90) = 90 s instead of the 279.1 s it actually spent,
+#     returning ~189 s to the rip-up loop that produces reach.
+#
+# The bound is FLAT, not scaled by how much the rescue has already achieved:
+# ``DQ3`` had "achieved" 9 rips and 7/9 re-lands at 279 s and still rolled
+# back -- progress through the rescue pipeline is not a predictor of commit,
+# so paying more for it just re-opens the hole.
+#
+# When the stage has no deadline (``timeout=None`` -> ``relief_deadline is
+# None``: board 06's deterministic regen, the two-phase stall-relief hook)
+# there is no denominator and the bound is structurally inert -- behavior is
+# byte-identical to pre-#4781.
+RELIEF_RESCUE_TXN_FRACTION = 0.25
+RELIEF_RESCUE_TXN_FLOOR_S = 90.0
+
 # Issue #4730: the default for the relief-rescue sub-search bound, shared by
 # every entry point that can reach a rescue -- :meth:`Autorouter._relief_rescue`,
 # :meth:`Autorouter.route_all_negotiated`, :meth:`Autorouter.route_all_two_phase`,
@@ -9156,6 +9203,12 @@ class Autorouter:
         # the default (#4730).
         flush_print(self._relief_subsearch_bound_line(per_net_timeout, deterministic_rescue))
 
+        # Issue #4781: record the relief-rescue TRANSACTION bound too -- it
+        # decides how much of the stage one rescue can burn before rolling
+        # back (i.e. how many rip-up iterations the stage can afford), so an
+        # A/B log must show which arm was live.
+        flush_print(self._relief_txn_bound_line(timeout))
+
         # Issue #2587 / Epic #2556 Phase 1C-cont: Activate diff-pair partner
         # threading before negotiated routing begins.  This is the default
         # path for ``kct route`` (negotiated strategy is enabled by default
@@ -12724,6 +12777,38 @@ class Autorouter:
             "deterministic_rescue=True; issue #4730)"
         )
 
+    def _relief_txn_bound_line(self, timeout: float | None) -> str:
+        """Routing-log line recording the relief-rescue TRANSACTION bound in force.
+
+        Issue #4781.  Same evidence discipline as
+        :meth:`_relief_subsearch_bound_line` (#4536): the bound decides how
+        much of the stage budget a single rescue can burn before rolling
+        back -- i.e. it decides how many rip-up iterations the stage can
+        afford, which decides reach -- so any routing log used as A/B
+        evidence has to say which arm was live.  The
+        ``Relief-rescue transaction bound:`` prefix is the greppable
+        evidence token; do not reword it.
+
+        Args:
+            timeout: The stage wall-clock budget of the calling loop, or
+                ``None`` when the stage runs without a deadline (then
+                ``relief_deadline is None`` and the bound is structurally
+                inert -- there is no "remaining stage budget" denominator).
+        """
+        if timeout is not None:
+            return (
+                "  Relief-rescue transaction bound: proportional -- one rescue "
+                "transaction (nested rescues share the parent's allowance) may "
+                f"spend at most max({RELIEF_RESCUE_TXN_FRACTION:.0%} of the "
+                f"remaining stage budget, {RELIEF_RESCUE_TXN_FLOOR_S:.0f}s) "
+                "before rolling back verbatim (issue #4781)"
+            )
+        return (
+            "  Relief-rescue transaction bound: none -- the stage has no "
+            "wall-clock deadline, so transactions are bounded by their "
+            "sub-search caps only (issue #4781)"
+        )
+
     def _post_negotiation_sweep_bounds(
         self,
         timeout: float | None,
@@ -12851,6 +12936,7 @@ class Autorouter:
         depth: int = 0,
         deadline: float | None = None,
         deterministic_rescue: bool = DETERMINISTIC_RESCUE_DEFAULT,
+        txn_deadline: float | None = None,
     ) -> bool:
         """Transactional relief rescue for a zero-overflow hard failure.
 
@@ -12878,7 +12964,14 @@ class Autorouter:
                 and blew the loop's whole wall budget on one hopeless
                 rescue.  When the deadline passes mid-rescue the
                 transaction rolls back verbatim and returns False, so
-                the bound costs nothing in correctness.
+                the bound costs nothing in correctness.  Issue #4781:
+                the stage deadline alone is NOT a per-transaction
+                allowance -- a rescue finishing at 544 s of a 600 s
+                stage never trips it, having already spent the budget
+                the rip-up loop needed (board 07's ``DQ3``: 279.1 s,
+                46% of the stage, rolled back).  When ``deadline`` is
+                set, the transaction is additionally bounded by the
+                proportional allowance below.
             deterministic_rescue: Issue #4536 / #4730 -- bound the
                 rescue's SUB-searches (probe rounds, victim re-lands) by
                 the deterministic per-net NODE-EXPANSION cap instead of
@@ -12893,6 +12986,19 @@ class Autorouter:
                 the wall clock is kept either way.  See
                 :meth:`_relief_subsearch_budget` for the measurement that
                 motivates it and the load-bearing consequences.
+            txn_deadline: Issue #4781: the absolute ``time.time()`` bound
+                on THIS transaction's proportional allowance.  Callers
+                leave it ``None``; a depth-0 transaction with a
+                ``deadline`` derives it as ``transaction_start +
+                max(RELIEF_RESCUE_TXN_FRACTION * remaining,
+                RELIEF_RESCUE_TXN_FLOOR_S)`` and passes it down to its
+                depth-1 nested rescues so the whole transaction --
+                nested rescues INCLUDED -- shares one allowance (a
+                nested rescue is part of the parent's commit gate, so a
+                fresh allowance per nesting level would rebuild the
+                unbounded product this bound removes).  Evaluated only
+                at the existing ``_past_deadline()`` check sites; see
+                :data:`RELIEF_RESCUE_TXN_FRACTION` for the calibration.
 
         Returns:
             True when the failed net is now routed and no sibling was
@@ -12900,8 +13006,41 @@ class Autorouter:
         """
         import time as _time
 
+        # Issue #4781: proportional per-transaction allowance.  Derived
+        # only when the stage has a deadline -- with ``deadline=None``
+        # (board 06's deterministic regen, the two-phase stall-relief
+        # hook) there is no "remaining stage budget" denominator and this
+        # arm is byte-identical to pre-#4781 behavior.  Nested rescues
+        # (depth > 0) inherit the parent's ``txn_deadline`` instead of
+        # deriving their own.
+        if deadline is not None and txn_deadline is None:
+            _txn_start = _time.time()
+            _txn_remaining = deadline - _txn_start
+            txn_deadline = _txn_start + max(
+                RELIEF_RESCUE_TXN_FRACTION * _txn_remaining,
+                RELIEF_RESCUE_TXN_FLOOR_S,
+            )
+
         def _past_deadline() -> bool:
-            return deadline is not None and _time.time() >= deadline
+            if deadline is None:
+                return False
+            now = _time.time()
+            if now >= deadline:
+                return True
+            return txn_deadline is not None and now >= txn_deadline
+
+        def _deadline_reason() -> str:
+            # Only called after ``_past_deadline()`` returned True.  The
+            # stage-deadline arm keeps the historical wording; the
+            # transaction-allowance arm is the #4781 greppable evidence
+            # token for an A/B log.
+            if deadline is not None and _time.time() >= deadline:
+                return "deadline exceeded"
+            return (
+                "transaction allowance exhausted "
+                f"(max({RELIEF_RESCUE_TXN_FRACTION:.0%} of remaining stage "
+                f"budget, {RELIEF_RESCUE_TXN_FLOOR_S:.0f}s); issue #4781)"
+            )
 
         subsearch_budget = self._relief_subsearch_budget(per_net_timeout, deterministic_rescue)
         max_rounds = 4
@@ -12978,7 +13117,7 @@ class Autorouter:
         for round_idx in range(max_rounds):
             if _past_deadline():
                 flush_print_fn(
-                    f"  Relief rescue: {failed_name} deadline exceeded "
+                    f"  Relief rescue: {failed_name} {_deadline_reason()} "
                     f"(round {round_idx + 1}) -- rolling back ({elapsed_fn()})"
                 )
                 _rollback()
@@ -13126,6 +13265,11 @@ class Autorouter:
                     depth=depth + 1,
                     deadline=deadline,
                     deterministic_rescue=deterministic_rescue,
+                    # Issue #4781: nested rescues SHARE the parent
+                    # transaction's proportional allowance -- they are
+                    # part of the parent's commit gate, so a fresh
+                    # allowance here would rebuild the unbounded product.
+                    txn_deadline=txn_deadline,
                 ):
                     relanded += 1
                 else:
@@ -14354,6 +14498,16 @@ class Autorouter:
             # signature default.  Without the partial the two-phase path had no
             # switch at all -- it silently inherited whatever
             # ``_relief_rescue``'s signature said.
+            #
+            # Issue #4781: no ``deadline`` is bound here, so rescues on this
+            # path run with ``deadline=None`` and the proportional
+            # per-transaction bound is structurally EXEMPT (it is a fraction
+            # of the REMAINING stage budget, which does not exist without a
+            # deadline).  Deliberate: binding the stage deadline here would
+            # newly arm the #3413 mid-transaction abort on the default
+            # ``kct route`` path -- a behavior change to boards that route
+            # through ``route_all_two_phase``, out of #4781's measured scope.
+            # ``route_all_two_phase`` logs the exemption as evidence.
             relief_rescue=functools.partial(
                 self._relief_rescue, deterministic_rescue=deterministic_rescue
             ),
@@ -14424,6 +14578,28 @@ class Autorouter:
             _banner_per_net_timeout = derive_per_net_cap(per_net_timeout, timeout)
         flush_print(
             self._relief_subsearch_bound_line(_banner_per_net_timeout, deterministic_rescue)
+        )
+
+        # Issue #4781: the proportional TRANSACTION bound is structurally
+        # EXEMPT on this path.  The #3471 stall-relief hook calls
+        # ``_relief_rescue`` positionally with 8 arguments (see
+        # ``_create_two_phase_router``) and threads no ``deadline``, so
+        # ``relief_deadline is None`` inside every rescue this path runs and
+        # the proportional allowance has no "remaining stage budget"
+        # denominator.  Threading the stage deadline into the hook would
+        # newly arm the #3413 mid-transaction stage-deadline abort on the
+        # default ``kct route`` path (boards 04/05 route through here) -- a
+        # separate behavior change from #4781's measured defect, which lives
+        # on the negotiated entry point.  The line reports the exemption so
+        # A/B logs state which arm was live (evidence discipline of #4536).
+        # Worded specifically (not via ``_relief_txn_bound_line(None)``):
+        # this STAGE may well have a ``timeout``; it is the rescues that
+        # never receive it.
+        flush_print(
+            "  Relief-rescue transaction bound: exempt -- the two-phase "
+            "stall-relief hook (#3471) carries no stage deadline into its "
+            "rescues, so the proportional bound has no remaining-budget "
+            "denominator on this path (issue #4781)"
         )
 
         tp_router = self._create_two_phase_router(deterministic_rescue=deterministic_rescue)

--- a/tests/router/test_relief_rescue.py
+++ b/tests/router/test_relief_rescue.py
@@ -709,3 +709,308 @@ class TestReliefRescueDiffPairAtomicTransaction:
         assert rip_spy.call_args.args[0] == [1], "no partner may be folded into the rip"
         assert net_routes[1] == [committed]
         assert committed in router.routes
+
+
+class _FakeClock:
+    """Injected ``time.time`` replacement -- advances only when told to.
+
+    Issue #4781 tests drive ``_relief_rescue``'s deadline checks with this
+    instead of wall-clock sleeps, so the proportionality abort is
+    deterministic on any machine.
+    """
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+
+class TestReliefRescueProportionalBound:
+    """Issue #4781: proportional per-transaction allowance.
+
+    A single rescue transaction (including its depth-1 nested rescues,
+    which SHARE the parent's allowance) may spend at most
+    ``max(RELIEF_RESCUE_TXN_FRACTION * remaining_stage_budget,
+    RELIEF_RESCUE_TXN_FLOOR_S)``, evaluated only at the existing
+    ``_past_deadline()`` check sites.  On breach the transaction rolls
+    back verbatim (the no-net-loss guarantee is untouched); with no
+    stage deadline the bound is structurally inert.
+    """
+
+    def _fixture(self, *, extra_net3_route: bool = False):
+        """Net 1 failed; net 2 (and optionally net 3) routed victims."""
+        router = _make_simple_router(num_nets=3)
+        neg_router = NegotiatedRouter(
+            grid=router.grid,
+            router=router.router,
+            rules=router.rules,
+            net_class_map={},
+        )
+        route2 = _seg_route(2, "N2", 8.0)
+        router._mark_route(route2)
+        router.grid.mark_route_usage(route2)
+        router.routes.append(route2)
+        net_routes: dict[int, list[Route]] = {1: [], 2: [route2]}
+        route3 = None
+        if extra_net3_route:
+            route3 = _seg_route(3, "N3", 12.0)
+            router._mark_route(route3)
+            router.grid.mark_route_usage(route3)
+            router.routes.append(route3)
+            net_routes[3] = [route3]
+        pads_by_net = {
+            net_id: [router.pads[p] for p in pad_ids] for net_id, pad_ids in router.nets.items()
+        }
+        return router, neg_router, net_routes, pads_by_net, route2, route3
+
+    def test_exceeding_allowance_aborts_and_restores_verbatim(self):
+        """(a) A transaction past its allowance aborts at a check site.
+
+        Stage: 1000 s remaining -> allowance = max(25% * 1000, 90) = 250 s.
+        Round 1 rips a victim and 'costs' 300 s; the round-2 check site
+        must abort on the TRANSACTION allowance (the stage deadline, 1000 s
+        away, has not passed) and restore the board verbatim.
+        """
+        router, neg_router, net_routes, pads_by_net, route2, _ = self._fixture()
+        clock = _FakeClock(start=1000.0)
+        probe = _seg_route(1, "N1", 4.0)
+        msgs: list[str] = []
+
+        def probe_side_effect(net_id, present_factor, per_net_timeout=None):
+            clock.now += 300.0  # round 1 burns past the 250 s allowance
+            return ([probe], {2})
+
+        with (
+            patch("time.time", clock),
+            patch.object(Autorouter, "_relief_probe", side_effect=probe_side_effect),
+        ):
+            ok = router._relief_rescue(
+                failed_net=1,
+                neg_router=neg_router,
+                net_routes=net_routes,
+                pads_by_net=pads_by_net,
+                present_factor=1.0,
+                per_net_timeout=2.0,
+                flush_print_fn=msgs.append,
+                elapsed_fn=lambda: "0s",
+                deadline=1000.0 + 1000.0,
+            )
+
+        assert ok is False
+        joined = "\n".join(msgs)
+        assert "transaction allowance exhausted" in joined, (
+            "the abort must be attributed to the #4781 allowance, not the stage deadline"
+        )
+        assert "deadline exceeded" not in joined
+        # Verbatim restore: the EXACT original Route objects, both maps.
+        assert net_routes[2] == [route2]
+        assert route2 in router.routes
+        assert net_routes[1] == []
+
+    def test_within_allowance_is_unaffected(self):
+        """(b) A transaction inside its allowance commits normally."""
+        router, neg_router, net_routes, pads_by_net, route2, _ = self._fixture()
+        clock = _FakeClock(start=1000.0)
+        probe_conflicted = _seg_route(1, "N1", 4.0)
+        probe_free = _seg_route(1, "N1", 4.0)
+        committed_1 = _seg_route(1, "N1", 4.0)
+        relanded_2 = _seg_route(2, "N2", 8.0)
+        probe_calls: list[int] = []
+        msgs: list[str] = []
+
+        def probe_side_effect(net_id, present_factor, per_net_timeout=None):
+            probe_calls.append(net_id)
+            clock.now += 40.0  # well inside the 250 s allowance
+            if len(probe_calls) == 1:
+                return ([probe_conflicted], {2})
+            return ([probe_free], set())
+
+        def route_side_effect(net_id, present_cost_factor, per_net_timeout=None):
+            return [committed_1] if net_id == 1 else [relanded_2]
+
+        with (
+            patch("time.time", clock),
+            patch.object(Autorouter, "_relief_probe", side_effect=probe_side_effect),
+            patch.object(Autorouter, "_route_net_negotiated", side_effect=route_side_effect),
+        ):
+            ok = router._relief_rescue(
+                failed_net=1,
+                neg_router=neg_router,
+                net_routes=net_routes,
+                pads_by_net=pads_by_net,
+                present_factor=1.0,
+                per_net_timeout=2.0,
+                flush_print_fn=msgs.append,
+                elapsed_fn=lambda: "0s",
+                deadline=1000.0 + 1000.0,
+            )
+
+        assert ok is True
+        assert net_routes[1] == [committed_1]
+        assert net_routes[2] == [relanded_2]
+        joined = "\n".join(msgs)
+        assert "transaction allowance exhausted" not in joined
+        assert "deadline exceeded" not in joined
+
+    def test_nested_rescue_shares_parent_allowance(self):
+        """(c) A depth-1 nested rescue inherits the PARENT's allowance.
+
+        The parent starts with 1000 s remaining (allowance 250 s) and has
+        spent 240 s when the nested rescue for its stranded victim begins.
+        If the nested rescue derived its OWN allowance it would get
+        max(25% * 760, 90) = 190 s (deadline ~ t0+430) and sail past the
+        t0+260 probe; sharing the parent's t0+250 allowance, it must abort
+        at its round-2 check site instead -- which then fails the parent's
+        commit gate and rolls the whole transaction back verbatim.
+        """
+        router, neg_router, net_routes, pads_by_net, route2, route3 = self._fixture(
+            extra_net3_route=True
+        )
+        clock = _FakeClock(start=1000.0)
+        probe_a = _seg_route(1, "N1", 4.0)
+        probe_free = _seg_route(1, "N1", 4.0)
+        committed_1 = _seg_route(1, "N1", 4.0)
+        probe_nested = _seg_route(2, "N2", 8.0)
+        probe_calls: list[int] = []
+        msgs: list[str] = []
+
+        def probe_side_effect(net_id, present_factor, per_net_timeout=None):
+            probe_calls.append(net_id)
+            if len(probe_calls) == 1:
+                clock.now = 1000.0 + 240.0  # parent spends 240 s of its 250 s
+                return ([probe_a], {2})
+            if len(probe_calls) == 2:
+                return ([probe_free], set())
+            # Nested rescue's round-1 probe (net 2): crosses net 3 and
+            # pushes the SHARED allowance (t0+250) past, while staying far
+            # inside what a freshly-derived nested allowance would permit.
+            clock.now = 1000.0 + 260.0
+            return ([probe_nested], {3})
+
+        def route_side_effect(net_id, present_cost_factor, per_net_timeout=None):
+            if net_id == 1:
+                return [committed_1]
+            return []  # victim 2 never re-lands via plain A*
+
+        with (
+            patch("time.time", clock),
+            patch.object(Autorouter, "_relief_probe", side_effect=probe_side_effect),
+            patch.object(Autorouter, "_route_net_negotiated", side_effect=route_side_effect),
+        ):
+            ok = router._relief_rescue(
+                failed_net=1,
+                neg_router=neg_router,
+                net_routes=net_routes,
+                pads_by_net=pads_by_net,
+                present_factor=1.0,
+                per_net_timeout=2.0,
+                flush_print_fn=msgs.append,
+                elapsed_fn=lambda: "0s",
+                deadline=1000.0 + 1000.0,
+            )
+
+        assert ok is False
+        # The nested rescue (for N2) aborted on the SHARED allowance...
+        nested_aborts = [m for m in msgs if "N2" in m and "transaction allowance exhausted" in m]
+        assert nested_aborts, (
+            f"nested rescue must abort on the parent's allowance (messages: {msgs})"
+        )
+        # ...and the whole outer transaction rolled back verbatim.
+        assert net_routes[1] == []
+        assert net_routes[2] == [route2]
+        assert net_routes[3] == [route3]
+        assert route2 in router.routes
+        assert route3 in router.routes
+        assert committed_1 not in router.routes
+
+    def test_no_deadline_arm_is_unchanged(self):
+        """(d) With no stage deadline the bound is structurally inert."""
+        router, neg_router, net_routes, pads_by_net, _route2, _ = self._fixture()
+        clock = _FakeClock(start=1000.0)
+        probe_conflicted = _seg_route(1, "N1", 4.0)
+        probe_free = _seg_route(1, "N1", 4.0)
+        committed_1 = _seg_route(1, "N1", 4.0)
+        relanded_2 = _seg_route(2, "N2", 8.0)
+        probe_calls: list[int] = []
+        msgs: list[str] = []
+
+        def probe_side_effect(net_id, present_factor, per_net_timeout=None):
+            probe_calls.append(net_id)
+            clock.now += 10_000_000.0  # absurd elapsed time; must not matter
+            if len(probe_calls) == 1:
+                return ([probe_conflicted], {2})
+            return ([probe_free], set())
+
+        def route_side_effect(net_id, present_cost_factor, per_net_timeout=None):
+            return [committed_1] if net_id == 1 else [relanded_2]
+
+        with (
+            patch("time.time", clock),
+            patch.object(Autorouter, "_relief_probe", side_effect=probe_side_effect),
+            patch.object(Autorouter, "_route_net_negotiated", side_effect=route_side_effect),
+        ):
+            ok = router._relief_rescue(
+                failed_net=1,
+                neg_router=neg_router,
+                net_routes=net_routes,
+                pads_by_net=pads_by_net,
+                present_factor=1.0,
+                per_net_timeout=2.0,
+                flush_print_fn=msgs.append,
+                elapsed_fn=lambda: "0s",
+                deadline=None,
+            )
+
+        assert ok is True
+        assert net_routes[1] == [committed_1]
+        joined = "\n".join(msgs)
+        assert "transaction allowance exhausted" not in joined
+        assert "deadline exceeded" not in joined
+
+    def test_stage_deadline_wording_is_preserved(self):
+        """The historical stage-deadline abort keeps its exact wording."""
+        router, neg_router, net_routes, pads_by_net, route2, _ = self._fixture()
+        clock = _FakeClock(start=1000.0)
+        probe = _seg_route(1, "N1", 4.0)
+        msgs: list[str] = []
+
+        def probe_side_effect(net_id, present_factor, per_net_timeout=None):
+            clock.now += 60.0  # past the 50 s stage deadline, inside the 90 s floor
+            return ([probe], {2})
+
+        with (
+            patch("time.time", clock),
+            patch.object(Autorouter, "_relief_probe", side_effect=probe_side_effect),
+        ):
+            ok = router._relief_rescue(
+                failed_net=1,
+                neg_router=neg_router,
+                net_routes=net_routes,
+                pads_by_net=pads_by_net,
+                present_factor=1.0,
+                per_net_timeout=2.0,
+                flush_print_fn=msgs.append,
+                elapsed_fn=lambda: "0s",
+                deadline=1000.0 + 50.0,
+            )
+
+        assert ok is False
+        joined = "\n".join(msgs)
+        assert "deadline exceeded (round 2)" in joined, (
+            "when the STAGE deadline trips, the pre-#4781 wording must be kept"
+        )
+        assert "transaction allowance exhausted" not in joined
+        assert net_routes[2] == [route2]
+
+    def test_bound_evidence_lines(self):
+        """AC 4: greppable evidence line states the bound in force."""
+        router = _make_simple_router()
+        armed = router._relief_txn_bound_line(600.0)
+        assert armed.startswith("  Relief-rescue transaction bound: proportional")
+        assert "25%" in armed
+        assert "90s" in armed
+        assert "#4781" in armed
+        inert = router._relief_txn_bound_line(None)
+        assert inert.startswith("  Relief-rescue transaction bound: none")
+        assert "#4781" in inert


### PR DESCRIPTION
Closes #4781

## Problem

A single `_relief_rescue` transaction could consume an unbounded share of the negotiated stage's wall budget and still roll back. Each rescue stage (probe rounds x victim re-lands x depth-1 nested rescues) is individually bounded, but their product is not — the #3413 defect one level up. Measured on board 07 (#4770, CI run 31281260812): one `DQ3` transaction spent **279.1 s — 46% of the 600 s stage** — and restored the board verbatim, starving the rip-up iteration that lands board 07's 26th net.

## The bound

A transaction — **including its depth-1 nested rescues, which share the parent's allowance** — may spend at most:

```
max(RELIEF_RESCUE_TXN_FRACTION (25%) * remaining_stage_budget, RELIEF_RESCUE_TXN_FLOOR_S (90 s))
```

where `remaining = deadline - transaction_start`. Evaluated **only at the existing `_past_deadline()` check sites** (top of each probe round, per victim re-land, before each nested rescue) — no new checks inside the A* sub-searches. On breach the transaction rolls back verbatim via the existing `_rollback()` and returns `False`; the no-net-loss guarantee is untouched.

## Design decisions (the issue's open questions)

- **Denominator**: remaining stage budget at transaction start, with a **90 s floor** calibrated above the longest transaction the healthy `main` arm ever completes (70.6 s, the #4770 tables) — so a main-shaped trajectory never trips the bound, and board 07's A/B inputs stay unchanged. Near stage end the stage deadline binds first, so the floor never *extends* a transaction.
- **Flat, not achievement-scaled**: `DQ3` had "achieved" 9 rips and 7/9 re-lands at 279 s and still rolled back — progress through the rescue pipeline is not a predictor of commit.
- **Nested rescues share the parent's allowance** (`txn_deadline` passed down): they are part of the parent's commit gate, so a fresh allowance per level would rebuild the unbounded product. Tested explicitly.
- **Two-phase stall-relief hook (#3471): structurally exempt (AC 5, documented)** — the hook calls `_relief_rescue` positionally with 8 args and threads no `deadline`, so the bound has no remaining-budget denominator there. Binding the stage deadline into the hook would newly arm the #3413 mid-transaction abort on the default `kct route` path (boards 04/05), a separate behavior change outside this issue's measured scope. Documented at the `functools.partial` binding, and `route_all_two_phase` logs the exemption.
- **No-deadline arm byte-identical** (`timeout=None` → `relief_deadline is None`): `txn_deadline` is never derived, `_past_deadline()` short-circuits exactly as before. Board 06's deterministic regen is this arm.
- `DETERMINISTIC_RESCUE_DEFAULT` remains `False`; **no changes to #4776's surface** (`route_cmd.py`, `_post_negotiation_sweep_bounds`, `per_net_timeout` sentinel handling untouched).

## Evidence line (AC 4)

Every negotiated routing log now records the live arm (greppable prefix `Relief-rescue transaction bound:`), following the `_relief_subsearch_bound_line` pattern; `route_all_two_phase` logs its exemption.

## Gate results

**Board-07 A/B (AC 7)** — same-host (28-core Apple Silicon), both arms `PYTHONHASHSEED=42 ... --step route --seed 42`; B = `main` @ 3a37d414, A = this PR. Recorded in `boards/07-matchgroup-test/diagnostic-runs/README.md`:

| | B (`main`) | A (bound) |
|---|---|---|
| final reach | 26/31 | 26/31 |
| copper-LVS opens | `DQ3, DQ4, MIPI_DAT0_N, TMDS_D0_N, TMDS_D1_N` | identical — `check_copper_lvs.py --expect-opens` passes both |
| blocking DRC (`check_routed_drc.py`, jlcpcb) | 8 (== allowlist 8) | 8 (== allowlist 8) |
| deltas proposed / kept | 10 / 0 | 10 / 0 |
| transaction-allowance aborts | n/a | 0 |
| normalized PCB md5 (uuid-stripped, sorted) | `797984ea...` | `797984ea...` — **identical artifact** |

Per-pass rescue tables: identical transaction counts (31/48/33) and commits (4/5/2) in every pass; longest transaction 56.9 s (B) / 48.7 s (A), all under the 90 s floor. **No allowlist or `--expect-opens` edits.** The pathological 279 s case is exercised by the injected-clock unit tests (it does not occur under `main`'s sub-search bound — see the #4770 section).

**Board-06 (AC 8)**: `check_diffpair_coverage.py boards/06-diffpair-test --seed 42` passes on the PR head — signal reach **21/21** (required 21), pour connectivity OK, all 3 diff-pair rules exercised, 18 errors within allowlist 18. Board 06 routes with `timeout=None`, so the bound is structurally inert there (verified byte-identical arm).

**Unit/lint/type gates**:
- `tests/router/` + `tests/test_relief_subsearch_budget.py`: **1205 passed, 5 skipped, 0 failed** (clean full run)
- New `TestReliefRescueProportionalBound` (injected `_FakeClock`, no sleeps): (a) over-allowance abort + verbatim restore, (b) within-allowance no-op, (c) nested-sharing rule (aborts at the shared t0+250 where a fresh allowance would have permitted t0+430), (d) no-deadline arm unchanged, plus stage-deadline wording preservation and evidence-line checks
- `ruff check` / `ruff format --check`: clean
- `scripts/ci/check_mypy_baseline.py`: OK (1471 errors, all within the 1473 baseline; no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)