### PR TITLE
fix(router): gate the copper-moving post-passes on the pairwise HV predicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   stall-relief hook) are byte-identical; a `Relief-rescue transaction bound:`
   log line records which arm was live.
 
+- **The copper-moving `--lattice-optimize` post-passes now consult the pairwise
+  HV creepage predicate before accepting a move** (#4766, epic #4431) — PR
+  #4756 widened the post-route pairwise audit but left the geometric
+  post-passes pairwise-*blind*: `TraceOptimizer` (via
+  `optimize_routes_grid_synced`) gates its moves only on
+  `CollisionChecker.path_is_clear`, and both checker implementations resolve
+  clearance as the **scalar** `grid.rules.trace_clearance`, while
+  `drc_verify_and_nudge` translates segments by up to 0.2 mm with the same
+  scalar model. Either pass could therefore close a creepage gap the search had
+  deliberately opened, leaving the audit to fail a run the optimizer had just
+  broken. Both now run the same layer-scoped predicate the search and the #4588
+  gate run: the optimizer gets a route-level accept hook on
+  `apply_route_transform_grid_synced` that vetoes an optimized route
+  (`route_pairwise_violation` against `grid.routes`) **before** the grid
+  transaction is entered, and the nudge brackets itself with a board-level
+  `find_pairwise_violations` scan and reverts every route named in a net pair
+  that is present after but not before, using the entry snapshot it already
+  takes for the #3507 resync. Both gates only undo what the pass would
+  *introduce* — an inherited shortfall on the same net pair keeps its
+  optimization and stays the audit's to report, so the passes never mask copper
+  the gate exists to fail on. Collinear consolidation is deliberately **not**
+  gated and now says why in its module docstring: its merged segment is the
+  exact union of the segments it replaces, so no gap to foreign copper can
+  shrink. The veto is coarse (a route loses its whole optimization for one bad
+  move), so the counts are surfaced — vetoed routes on stderr after the
+  optimize pass and `pairwise_reverts` in the DRC-nudge summary — and the nudge
+  re-reports `remaining_violations` post-revert rather than the flattering
+  pre-revert count. Both passes derive their context from the router
+  (`rules.pairwise_clearance`, `_pairwise_attach_zones_cache`,
+  `_net_name_to_id()`) exactly as `Autorouter._lattice_pairwise_projection`
+  does, so all eight CLI call sites are untouched. Fully dormant without
+  `--voltage-map`: no table means no context, no gate and no scan, and no board
+  under `boards/` uses that flag. No C++ change (`ROUTER_CPP_BUILD_VERSION`
+  stays 19).
 - **The C++ router's HV attach-zone waiver is now layer-scoped, so the search
   stops proposing copper the pairwise gate rejects** (#4507, epic #4431 Phase
   2) — PR #4756 narrowed the #4506 rated-footprint exemption on the Python side

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,13 +46,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   move), so the counts are surfaced — vetoed routes on stderr after the
   optimize pass and `pairwise_reverts` in the DRC-nudge summary — and the nudge
   re-reports `remaining_violations` post-revert rather than the flattering
-  pre-revert count. Both passes derive their context from the router
-  (`rules.pairwise_clearance`, `_pairwise_attach_zones_cache`,
-  `_net_name_to_id()`) exactly as `Autorouter._lattice_pairwise_projection`
-  does, so all eight CLI call sites are untouched. Fully dormant without
-  `--voltage-map`: no table means no context, no gate and no scan, and no board
-  under `boards/` uses that flag. No C++ change (`ROUTER_CPP_BUILD_VERSION`
-  stays 19).
+  pre-revert count. Both passes derive their context through the **single**
+  router resolver #4785 landed for exactly this — `PairwisePathChecker.
+  from_router` (`rules.pairwise_clearance`, `_pairwise_attach_zones_cache`,
+  `net_names` + `_net_name_to_id()`, `grid.routes`) — so the two post-passes,
+  the path-level predicate and the #4588 audit cannot resolve the table, the
+  id→name map or the #4506 zones differently; that resolver picks up three
+  fixes in the process (dormant on a table that widens nothing, `sorted()`
+  net-name tie-break so an id collision is deterministic, and it now arms on a
+  grid-less router by falling back to `router.routes`). All eight CLI call
+  sites are untouched. Fully dormant without `--voltage-map`: no table means no
+  checker, no gate and no scan, and no board under `boards/` uses that flag. No
+  C++ change (`ROUTER_CPP_BUILD_VERSION` stays 19).
 - **The C++ router's HV attach-zone waiver is now layer-scoped, so the search
   stops proposing copper the pairwise gate rejects** (#4507, epic #4431 Phase
   2) — PR #4756 narrowed the #4506 rated-footprint exemption on the Python side

--- a/src/kicad_tools/router/drc_nudge.py
+++ b/src/kicad_tools/router/drc_nudge.py
@@ -26,6 +26,7 @@ Usage::
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 import math
 from dataclasses import dataclass, field
@@ -42,6 +43,13 @@ from .geometry import (
 )
 from .io import ClearanceViolation, validate_routes
 from .layers import Layer
+from .pairwise_clearance import (
+    RouterPairwiseContext,
+    _norm_net_key,
+    find_pairwise_violations,
+    router_pairwise_context,
+    violation_pair_keys,
+)
 from .primitives import Pad, Route, Segment, Via
 from .via_clearance import segment_clears_foreign_via
 
@@ -63,6 +71,10 @@ class DRCNudgeResult:
     vias_merged: int = 0
     vias_nudged: int = 0
     passes_run: int = 0
+    # Issue #4766: routes restored to their entry geometry because the pass
+    # introduced an HV pairwise (creepage) shortfall that was not there before.
+    # Always 0 without a ``--voltage-map`` table.
+    pairwise_reverts: int = 0
     # Issue #2743: structured skip-reason counters so the user sees
     # "4/6 resolved; 2 unsupported (via-via anchored)" instead of a
     # silent 0/6 with no diagnostic.  Keyed by reason; integer counts.
@@ -85,6 +97,11 @@ class DRCNudgeResult:
             lines.append(f"  Vias nudged: {self.vias_nudged}")
         if self.vias_merged:
             lines.append(f"  Same-net vias merged: {self.vias_merged}")
+        if self.pairwise_reverts:
+            lines.append(
+                f"  HV pairwise gate: {self.pairwise_reverts} route(s) reverted to "
+                "pre-nudge geometry"
+            )
         if self.skipped:
             for reason, count in sorted(self.skipped.items()):
                 lines.append(f"  Skipped ({reason}): {count}")
@@ -1612,6 +1629,99 @@ def _find_segment(
 
 
 # ---------------------------------------------------------------------------
+# HV pairwise (creepage) revert gate -- issue #4766
+# ---------------------------------------------------------------------------
+
+
+# Bounded re-scan rounds for the pairwise revert.  Reverting a route restores
+# its ENTRY geometry, so the state walks monotonically back toward the
+# pre-pass configuration and this converges in practice after one round; the
+# cap only bounds the pathological mixed-state case (route X reverted while
+# route Y stayed nudged) and keeps the pass O(1) in scans.
+_PAIRWISE_REVERT_ROUNDS = 3
+
+
+def _pairwise_scan(router: Autorouter, context: RouterPairwiseContext) -> list:
+    """Board-level pairwise scan over ``router.routes`` (issue #4766)."""
+    return find_pairwise_violations(
+        router.routes,
+        context.table,
+        id_to_name=context.id_to_name,
+        dru=context.table.dru,
+        attach_zones=context.attach_zones,
+    )
+
+
+def _restore_route_geometry(live: Route, snapshot: Route) -> bool:
+    """Restore ``live``'s segments/vias from a ``copy_geometry`` snapshot.
+
+    Returns True when anything actually changed (the nudge mutates Segment and
+    Via objects in place, so an untouched route compares equal and is left
+    alone -- including its object identity).
+    """
+    if live.segments == snapshot.segments and live.vias == snapshot.vias:
+        return False
+    live.segments = [dataclasses.replace(seg) for seg in snapshot.segments]
+    live.vias = [dataclasses.replace(via) for via in snapshot.vias]
+    return True
+
+
+def _revert_new_pairwise_violations(
+    router: Autorouter,
+    context: RouterPairwiseContext,
+    before_keys: set[tuple[str, str]],
+    snapshot: list[tuple[Route, Route]],
+) -> int:
+    """Undo nudges that introduced a NEW pairwise (HV creepage) pair (#4766).
+
+    The nudge pass translates segments by up to ``max_displacement`` (0.2 mm)
+    using a purely scalar clearance model, so on a ``--voltage-map`` run it can
+    close a creepage gap it never measured.  This is the whole-pass mirror of
+    the optimizer's route-level gate: scan the board before and after, and
+    revert -- to the entry snapshot the pass already takes for the #3507 grid
+    resync -- every route named in a net pair that is present *after* but not
+    *before*.
+
+    Pre-existing (inherited) shortfalls are deliberately left alone: they are
+    the #4588 audit's to report, and "fixing" them here would mask copper the
+    gate is supposed to fail the run on.  Keying the comparison by net *pair*
+    rather than by coordinate is what makes that distinction hold when a
+    pre-existing violation merely moves.
+
+    Returns the number of routes whose geometry was restored.
+    """
+    by_route = {id(live): snap for snap, live in snapshot}
+    reverted = 0
+
+    for _ in range(_PAIRWISE_REVERT_ROUNDS):
+        new_keys = violation_pair_keys(_pairwise_scan(router, context)) - before_keys
+        if not new_keys:
+            break
+        offending = {name for key in new_keys for name in key}
+        changed = 0
+        for route in router.routes:
+            snap = by_route.get(id(route))
+            if snap is None:
+                continue
+            name = _norm_net_key(_resolve_route_net_name(route, context))
+            if name not in offending:
+                continue
+            if _restore_route_geometry(route, snap):
+                changed += 1
+        if not changed:
+            # Nothing left to undo (the offending copper is not this pass's).
+            break
+        reverted += changed
+
+    return reverted
+
+
+def _resolve_route_net_name(route: Route, context: RouterPairwiseContext) -> str:
+    """Net name a pairwise scan would report for ``route``."""
+    return context.id_to_name.get(route.net) or route.net_name or ""
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -1657,19 +1767,52 @@ def drc_verify_and_nudge(
     true copper state.  The pass's OWN checks (``validate_routes`` and
     the nudge gating helpers) are world-coordinate geometric and do not
     consult the grid, so a single resync at exit is sufficient.
+
+    Issue #4766: the nudge translates segments by up to ``max_displacement``
+    using a purely scalar clearance model, so under a ``--voltage-map`` run it
+    could close an HV creepage gap it never measured.  A board-level pairwise
+    scan therefore brackets the pass and every route named in a net pair that
+    is present *after* but not *before* is restored to the entry snapshot (see
+    :func:`_revert_new_pairwise_violations`); inherited shortfalls are left
+    intact for the #4588 audit to report.  Without a voltage map no scan runs
+    and this wrapper is byte-identical to the pre-#4766 path.
     """
+    # Issue #4766: the HV pairwise (creepage) predicate, derived from the
+    # router.  ``None`` without a ``--voltage-map`` table -- the dormant case,
+    # in which this wrapper behaves exactly as it did before #4766.
+    _pairwise = router_pairwise_context(router)
+
     # Issue #3507: snapshot pre-mutation geometry for the exit resync.
     # Defensive getattr: unit tests drive this pass with stub routers
-    # that carry routes but no grid -- the resync is then a no-op.
+    # that carry routes but no grid -- the resync is then a no-op.  Issue
+    # #4766 reuses the same snapshot as the revert source, so it is also
+    # taken (grid or not) whenever the pairwise gate is armed.
     _grid = getattr(router, "grid", None)
-    _grid_snapshot = [(r.copy_geometry(), r) for r in router.routes] if _grid is not None else []
+    _need_snapshot = _grid is not None or _pairwise is not None
+    _grid_snapshot = [(r.copy_geometry(), r) for r in router.routes] if _need_snapshot else []
+    _before_keys = (
+        violation_pair_keys(_pairwise_scan(router, _pairwise)) if _pairwise is not None else set()
+    )
     try:
-        return _drc_verify_and_nudge_impl(
+        result = _drc_verify_and_nudge_impl(
             router,
             max_displacement=max_displacement,
             max_passes=max_passes,
             skip_nets=skip_nets,
         )
+        if _pairwise is not None:
+            result.pairwise_reverts = _revert_new_pairwise_violations(
+                router, _pairwise, _before_keys, _grid_snapshot
+            )
+            if result.pairwise_reverts:
+                # Reverting restores the entry geometry, which may restore the
+                # scalar violation the nudge had just repaired -- report the
+                # true post-revert count rather than the pre-revert one.
+                remaining = [v for v in validate_routes(router) if not v.component_inherent]
+                if skip_nets:
+                    remaining = [v for v in remaining if v.net not in skip_nets]
+                result.remaining_violations = len(remaining)
+        return result
     finally:
         if _grid is not None:
             _grid.resync_route_occupancy(_grid_snapshot)

--- a/src/kicad_tools/router/drc_nudge.py
+++ b/src/kicad_tools/router/drc_nudge.py
@@ -44,10 +44,10 @@ from .geometry import (
 from .io import ClearanceViolation, validate_routes
 from .layers import Layer
 from .pairwise_clearance import (
-    RouterPairwiseContext,
-    _norm_net_key,
+    PairwisePathChecker,
+    PairwiseViolation,
     find_pairwise_violations,
-    router_pairwise_context,
+    normalize_net_key,
     violation_pair_keys,
 )
 from .primitives import Pad, Route, Segment, Via
@@ -1641,14 +1641,15 @@ def _find_segment(
 _PAIRWISE_REVERT_ROUNDS = 3
 
 
-def _pairwise_scan(router: Autorouter, context: RouterPairwiseContext) -> list:
+def _pairwise_scan(router: Autorouter, checker: PairwisePathChecker) -> list[PairwiseViolation]:
     """Board-level pairwise scan over ``router.routes`` (issue #4766)."""
     return find_pairwise_violations(
         router.routes,
-        context.table,
-        id_to_name=context.id_to_name,
-        dru=context.table.dru,
-        attach_zones=context.attach_zones,
+        checker.table,
+        id_to_name=checker.id_to_name,
+        dru=checker.dru,
+        attach_zones=checker.attach_zones,
+        tolerance=checker.tolerance,
     )
 
 
@@ -1668,7 +1669,7 @@ def _restore_route_geometry(live: Route, snapshot: Route) -> bool:
 
 def _revert_new_pairwise_violations(
     router: Autorouter,
-    context: RouterPairwiseContext,
+    checker: PairwisePathChecker,
     before_keys: set[tuple[str, str]],
     snapshot: list[tuple[Route, Route]],
 ) -> int:
@@ -1682,6 +1683,14 @@ def _revert_new_pairwise_violations(
     resync -- every route named in a net pair that is present *after* but not
     *before*.
 
+    The revert is **net**-granular, not route-granular: ``offending`` is a set
+    of net *names*, so every route this pass touched on an offending net is
+    restored, including routes that had no part in the new pair.  That is
+    deliberate (the pass mutates in place and cannot attribute a board-level
+    shortfall to one route), conservative, and bounded by the pass's own
+    snapshot -- but a reader costing this out should model it as "all touched
+    copper on the two nets", not "the two offending routes".
+
     Pre-existing (inherited) shortfalls are deliberately left alone: they are
     the #4588 audit's to report, and "fixing" them here would mask copper the
     gate is supposed to fail the run on.  Keying the comparison by net *pair*
@@ -1694,7 +1703,7 @@ def _revert_new_pairwise_violations(
     reverted = 0
 
     for _ in range(_PAIRWISE_REVERT_ROUNDS):
-        new_keys = violation_pair_keys(_pairwise_scan(router, context)) - before_keys
+        new_keys = violation_pair_keys(_pairwise_scan(router, checker)) - before_keys
         if not new_keys:
             break
         offending = {name for key in new_keys for name in key}
@@ -1703,7 +1712,7 @@ def _revert_new_pairwise_violations(
             snap = by_route.get(id(route))
             if snap is None:
                 continue
-            name = _norm_net_key(_resolve_route_net_name(route, context))
+            name = _resolve_route_net_key(route, checker)
             if name not in offending:
                 continue
             if _restore_route_geometry(route, snap):
@@ -1716,9 +1725,15 @@ def _revert_new_pairwise_violations(
     return reverted
 
 
-def _resolve_route_net_name(route: Route, context: RouterPairwiseContext) -> str:
-    """Net name a pairwise scan would report for ``route``."""
-    return context.id_to_name.get(route.net) or route.net_name or ""
+def _resolve_route_net_key(route: Route, checker: PairwisePathChecker) -> str:
+    """Normalised net key a pairwise scan would report for ``route``.
+
+    Same normalisation :func:`~kicad_tools.router.pairwise_clearance.
+    violation_pair_key` applies to the scan's output, so the two key spaces
+    compare directly.
+    """
+    id_to_name = checker.id_to_name or {}
+    return normalize_net_key(id_to_name.get(route.net) or route.net_name or "")
 
 
 # ---------------------------------------------------------------------------
@@ -1777,10 +1792,13 @@ def drc_verify_and_nudge(
     intact for the #4588 audit to report.  Without a voltage map no scan runs
     and this wrapper is byte-identical to the pre-#4766 path.
     """
-    # Issue #4766: the HV pairwise (creepage) predicate, derived from the
-    # router.  ``None`` without a ``--voltage-map`` table -- the dormant case,
-    # in which this wrapper behaves exactly as it did before #4766.
-    _pairwise = router_pairwise_context(router)
+    # Issue #4766: the HV pairwise (creepage) context, resolved through the one
+    # shared router resolver (#4507's ``PairwisePathChecker.from_router``) that
+    # the optimizer's route-level gate and the path-level predicate also use,
+    # so no pass can resolve the table or the zones differently.  ``None``
+    # without a ``--voltage-map`` table -- the dormant case, in which this
+    # wrapper behaves exactly as it did before #4766.
+    _pairwise = PairwisePathChecker.from_router(router)
 
     # Issue #3507: snapshot pre-mutation geometry for the exit resync.
     # Defensive getattr: unit tests drive this pass with stub routers

--- a/src/kicad_tools/router/optimizer/__init__.py
+++ b/src/kicad_tools/router/optimizer/__init__.py
@@ -52,9 +52,11 @@ from .serpentine import (
     tune_match_group,
 )
 from .trace import (
+    PairwiseRouteGate,
     TraceOptimizer,
     apply_route_transform_grid_synced,
     optimize_routes_grid_synced,
+    pairwise_route_gate,
 )
 from .via_optimizer import (
     LayerConnectivityError,
@@ -73,6 +75,7 @@ __all__ = [
     "LayerConnectivityError",
     "OptimizationConfig",
     "OptimizationStats",
+    "PairwiseRouteGate",
     "SerpentineConfig",
     "SerpentineGenerator",
     "SerpentineResult",
@@ -88,5 +91,6 @@ __all__ = [
     "consolidate_segments",
     "optimize_route_vias",
     "optimize_routes_grid_synced",
+    "pairwise_route_gate",
     "tune_match_group",
 ]

--- a/src/kicad_tools/router/optimizer/consolidate.py
+++ b/src/kicad_tools/router/optimizer/consolidate.py
@@ -78,6 +78,20 @@ without touching any of that, and additionally closes the
 "nudge output is never re-consolidated" ordering hole, since it runs
 after the DRC nudge rather than before it.
 
+**No HV pairwise gate here either (issue #4766).**  The two copper-*moving*
+post-passes -- ``TraceOptimizer`` via
+:func:`~kicad_tools.router.optimizer.trace.optimize_routes_grid_synced` and
+:func:`~kicad_tools.router.drc_nudge.drc_verify_and_nudge` -- now consult the
+pairwise (creepage) predicate before accepting a move, because both can put
+copper somewhere it was not.  This pass cannot: the merged segment is the exact
+union of the segments it replaces, on the same line, width and layer, so every
+edge-to-edge gap from this net to *any* foreign copper is bit-for-bit what it
+was before the merge.  A pairwise gate here could therefore only ever return
+"clear" -- and, being route-level, would additionally risk discarding a whole
+route's consolidation over a shortfall the pass did not create.  It is left out
+by construction rather than by omission; the #4588 audit remains the backstop
+for inherited shortfalls.
+
 **Vertex keys are deliberately layer-blind.**  Degree is counted over
 ``(x, y)`` alone, not ``(x, y, layer)``.  That is not an oversight: the
 invariant this pass is judged against --
@@ -495,7 +509,11 @@ def consolidate_routes_grid_synced(
     follow the copper.  The transaction is a formality here -- a
     consolidated route occupies exactly the cells its fragments did --
     but going through it keeps ``grid.routes`` pointing at the live
-    ``Route`` objects instead of stale twins.
+    ``Route`` objects instead of stale twins.  For the same reason no
+    ``accept=`` veto hook is supplied (issue #4766): the transform is
+    copper-preserving, so the HV pairwise predicate the optimizer arms
+    there could only ever return "clear" here -- see this module's
+    docstring.
 
     Pad positions come from ``router.nets`` / ``router.pads`` when
     available so a pad sitting mid-run stays a vertex; a router without

--- a/src/kicad_tools/router/optimizer/trace.py
+++ b/src/kicad_tools/router/optimizer/trace.py
@@ -7,10 +7,9 @@ from collections.abc import Callable
 
 from ..layers import Layer
 from ..pairwise_clearance import (
+    PairwisePathChecker,
     PairwiseViolation,
-    RouterPairwiseContext,
     route_pairwise_violation,
-    router_pairwise_context,
     violation_pair_key,
 )
 from ..primitives import Route, Segment
@@ -62,14 +61,26 @@ class PairwiseRouteGate:
     :func:`apply_route_transform_grid_synced`, so a vetoed route never enters
     the unmark/mark window at all.
 
+    Its context comes from the single
+    :meth:`~kicad_tools.router.pairwise_clearance.PairwisePathChecker.from_router`
+    resolver (#4507), the same one the path-level predicate uses, so the two
+    copper-moving post-passes and the predicate cannot resolve the table, the
+    id->name map or the #4506 zones differently.
+
     Two properties worth stating plainly:
 
     * **The veto is coarse.**  A single bad move costs the whole route its
       optimization, not just the offending segment.  That is the
       correctness-first choice; the count is recorded (and reported) so the
-      loss is measurable rather than silent.  Segment-level granularity would
-      have to widen the R-tree broad phase first (``_rtree_clearance_inflation``
-      is cached pre-pairwise -- #4507/#4511 territory), so it is a follow-up.
+      loss is measurable rather than silent.  Segment-level granularity is a
+      follow-up and is *reachable today*: the checker's
+      :meth:`~kicad_tools.router.pairwise_clearance.PairwisePathChecker.path_is_clear`
+      is signature-compatible with :class:`~kicad_tools.router.optimizer.
+      collision.CollisionChecker` and walks ``grid.routes`` directly, so it can
+      be ``AND``-composed with the scalar checker inside ``TraceOptimizer``
+      with no R-tree broad-phase change.  What it needs is a decision on the
+      per-segment cost (an O(routes x segments) walk per candidate path,
+      un-pruned by the R-tree), not a new primitive.
     * **It only vetoes what the pass would INTRODUCE.**  A route that already
       violates the same net pair before optimization keeps its optimization:
       inherited shortfalls are the audit's to report, and vetoing them would
@@ -78,36 +89,34 @@ class PairwiseRouteGate:
       already-dirty route -- is vetoed.
     """
 
-    def __init__(self, router, context: RouterPairwiseContext) -> None:
-        self.router = router
-        self.context = context
+    def __init__(self, checker: PairwisePathChecker) -> None:
+        self.checker = checker
         self.vetoes = 0
         self.worst: PairwiseViolation | None = None
 
     def _foreign_routes(self) -> list[Route]:
         """Committed copper to judge against.
 
-        ``grid.routes`` is what the grid ``Pathfinder``'s own route validator
-        uses, and at route *i* it holds post-optimize copper for ``0..i-1`` and
-        pre-optimize copper for ``i+1..n`` -- the same incremental-visibility
+        Comes from the checker's live ``foreign_routes`` view, i.e.
+        ``grid.routes`` -- what the grid ``Pathfinder``'s own route validator
+        uses.  At route *i* it holds post-optimize copper for ``0..i-1`` and
+        pre-optimize copper for ``i+1..n``, the same incremental-visibility
         contract the pass already documents for its collision checker.  A stub
-        router without a grid falls back to ``router.routes``.
+        router without a grid falls back to ``router.routes`` inside
+        :meth:`PairwisePathChecker.from_router`.
         """
-        grid = getattr(self.router, "grid", None)
-        routes = getattr(grid, "routes", None)
-        if routes is None:
-            routes = getattr(self.router, "routes", None)
-        return list(routes) if routes is not None else []
+        return list(self.checker.foreign_routes())
 
     def _violation(self, route: Route, net: int, foreign: list[Route]) -> PairwiseViolation | None:
         return route_pairwise_violation(
             route,
             net,
             foreign,
-            self.context.table,
-            id_to_name=self.context.id_to_name,
-            dru=self.context.table.dru,
-            attach_zones=self.context.attach_zones,
+            self.checker.table,
+            id_to_name=self.checker.id_to_name,
+            dru=self.checker.dru,
+            attach_zones=self.checker.attach_zones,
+            tolerance=self.checker.tolerance,
         )
 
     def __call__(self, original: Route, optimized: Route) -> bool:
@@ -153,12 +162,12 @@ class PairwiseRouteGate:
             print(line, file=sys.stderr)
 
 
-def pairwise_route_gate(router) -> PairwiseRouteGate | None:
+def pairwise_route_gate(router: object) -> PairwiseRouteGate | None:
     """Build the #4766 accept gate for ``router``, or ``None`` when dormant."""
-    context = router_pairwise_context(router)
-    if context is None:
+    checker = PairwisePathChecker.from_router(router)
+    if checker is None:
         return None
-    return PairwiseRouteGate(router, context)
+    return PairwiseRouteGate(checker)
 
 
 def optimize_routes_grid_synced(

--- a/src/kicad_tools/router/optimizer/trace.py
+++ b/src/kicad_tools/router/optimizer/trace.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Callable
 
 from ..layers import Layer
+from ..pairwise_clearance import (
+    PairwiseViolation,
+    RouterPairwiseContext,
+    route_pairwise_violation,
+    router_pairwise_context,
+    violation_pair_key,
+)
 from ..primitives import Route, Segment
 from .algorithms import (
     _find_staircase_end,
@@ -33,6 +41,124 @@ from .geometry import (
 )
 from .pcb import optimize_pcb, parse_net_names, parse_segments, replace_segments
 from .via_optimizer import ViaOptimizationConfig, ViaOptimizer
+
+
+class PairwiseRouteGate:
+    """Route-level pairwise-clearance accept predicate (issue #4766).
+
+    The optimizer's own hazard gate (``TraceOptimizer._path_is_clear`` ->
+    ``CollisionChecker.path_is_clear``) resolves clearance as the **scalar**
+    ``grid.rules.trace_clearance`` in both checker implementations, so a
+    ``--voltage-map`` run's HV creepage requirement was invisible to it: the
+    pass could straighten, chamfer or pull-tight a trace straight through a gap
+    the search had deliberately opened, and only the post-route #4588 audit
+    would notice.
+
+    This gate runs the SAME predicate the search and the audit run
+    (:func:`~kicad_tools.router.pairwise_clearance.route_pairwise_violation`,
+    with the layer-scoped #4506/#4699 attach-zone exemption) against the
+    optimized geometry, and vetoes the move by keeping the pre-optimization
+    route.  It is deliberately checked **before** the grid transaction in
+    :func:`apply_route_transform_grid_synced`, so a vetoed route never enters
+    the unmark/mark window at all.
+
+    Two properties worth stating plainly:
+
+    * **The veto is coarse.**  A single bad move costs the whole route its
+      optimization, not just the offending segment.  That is the
+      correctness-first choice; the count is recorded (and reported) so the
+      loss is measurable rather than silent.  Segment-level granularity would
+      have to widen the R-tree broad phase first (``_rtree_clearance_inflation``
+      is cached pre-pairwise -- #4507/#4511 territory), so it is a follow-up.
+    * **It only vetoes what the pass would INTRODUCE.**  A route that already
+      violates the same net pair before optimization keeps its optimization:
+      inherited shortfalls are the audit's to report, and vetoing them would
+      merely freeze the geometry of every HV route on a board that arrived
+      dirty.  Anything else -- including a *different* pair appearing on an
+      already-dirty route -- is vetoed.
+    """
+
+    def __init__(self, router, context: RouterPairwiseContext) -> None:
+        self.router = router
+        self.context = context
+        self.vetoes = 0
+        self.worst: PairwiseViolation | None = None
+
+    def _foreign_routes(self) -> list[Route]:
+        """Committed copper to judge against.
+
+        ``grid.routes`` is what the grid ``Pathfinder``'s own route validator
+        uses, and at route *i* it holds post-optimize copper for ``0..i-1`` and
+        pre-optimize copper for ``i+1..n`` -- the same incremental-visibility
+        contract the pass already documents for its collision checker.  A stub
+        router without a grid falls back to ``router.routes``.
+        """
+        grid = getattr(self.router, "grid", None)
+        routes = getattr(grid, "routes", None)
+        if routes is None:
+            routes = getattr(self.router, "routes", None)
+        return list(routes) if routes is not None else []
+
+    def _violation(self, route: Route, net: int, foreign: list[Route]) -> PairwiseViolation | None:
+        return route_pairwise_violation(
+            route,
+            net,
+            foreign,
+            self.context.table,
+            id_to_name=self.context.id_to_name,
+            dru=self.context.table.dru,
+            attach_zones=self.context.attach_zones,
+        )
+
+    def __call__(self, original: Route, optimized: Route) -> bool:
+        """True to accept ``optimized``; False to keep ``original``."""
+        foreign = self._foreign_routes()
+        violation = self._violation(optimized, original.net, foreign)
+        if violation is None:
+            return True
+        # Only pay for the "was it already like this?" scan on a hit.
+        prior = self._violation(original, original.net, foreign)
+        if prior is not None and violation_pair_key(prior) == violation_pair_key(violation):
+            # Inherited shortfall on the same net pair: not introduced here.
+            return True
+        self.vetoes += 1
+        shortfall = violation.required_mm - violation.actual_mm
+        if self.worst is None or shortfall > (self.worst.required_mm - self.worst.actual_mm):
+            self.worst = violation
+        return False
+
+    def advisory(self) -> str | None:
+        """One-line summary of what the gate cost, or ``None`` if it cost nothing."""
+        if not self.vetoes or self.worst is None:
+            return None
+        return (
+            f"  HV pairwise gate: {self.vetoes} route(s) kept pre-optimization "
+            f"geometry (worst: {self.worst.net_a} vs {self.worst.net_b} "
+            f"{self.worst.actual_mm:.3f}mm < {self.worst.required_mm:.3f}mm required "
+            f"at ({self.worst.x:.3f}, {self.worst.y:.3f}))"
+        )
+
+    def report(self) -> None:
+        """Surface the veto count (issue #4766 AC8).
+
+        Printed to stderr, matching the router's existing advisory precedent
+        (``_warn_layer_selection_advisories``, #4314): ``--quiet``'s contract is
+        about stdout, and a silently-discarded optimization on a safety-critical
+        HV board is exactly the thing that must not go unreported.  Nothing is
+        printed when no route was vetoed, so every dormant (no ``--voltage-map``)
+        run stays byte-identical.
+        """
+        line = self.advisory()
+        if line is not None:
+            print(line, file=sys.stderr)
+
+
+def pairwise_route_gate(router) -> PairwiseRouteGate | None:
+    """Build the #4766 accept gate for ``router``, or ``None`` when dormant."""
+    context = router_pairwise_context(router)
+    if context is None:
+        return None
+    return PairwiseRouteGate(router, context)
 
 
 def optimize_routes_grid_synced(
@@ -87,10 +213,24 @@ def optimize_routes_grid_synced(
             the final artifact), and straightening one side of a
             coupled pair breaks the constant-gap geometry.
 
+    Issue #4766: under a ``--voltage-map`` run this pass also consults the
+    pairwise (HV creepage) predicate before accepting a route -- see
+    :class:`PairwiseRouteGate`.  Without a voltage map the gate is not built at
+    all and the pass is byte-identical to the pre-#4766 path.
+
     Returns:
         The new ``router.routes`` list (also assigned on the router).
     """
-    return apply_route_transform_grid_synced(router, optimizer.optimize_route, skip_nets=skip_nets)
+    gate = pairwise_route_gate(router)
+    routes = apply_route_transform_grid_synced(
+        router, optimizer.optimize_route, skip_nets=skip_nets, accept=gate
+    )
+    if gate is not None:
+        # Issue #4766 AC8: record the coarse-veto cost on the router (for
+        # tests / callers) and surface it once per pass.
+        router._pairwise_optimize_vetoes = gate.vetoes
+        gate.report()
+    return routes
 
 
 def apply_route_transform_grid_synced(
@@ -98,6 +238,7 @@ def apply_route_transform_grid_synced(
     transform: Callable[[Route], Route],
     *,
     skip_nets: set[int] | None = None,
+    accept: Callable[[Route, Route], bool] | None = None,
 ) -> list[Route]:
     """Replace every route with ``transform(route)`` keeping the grid in sync.
 
@@ -117,6 +258,14 @@ def apply_route_transform_grid_synced(
             the input object (or an equal one) marks the route unchanged
             and skips the grid transaction for it.
         skip_nets: Net IDs whose routes pass through untouched (#3508).
+        accept: Issue #4766: optional ``(original, transformed) -> bool``
+            veto hook, consulted BEFORE the grid transaction so a rejected
+            transform never enters the unmark/mark window.  ``False`` keeps
+            the original route object (identity-preserving, exactly as an
+            unchanged transform would).  ``None`` -- the default, and what
+            the copper-preserving consolidation pass uses -- disables the
+            hook entirely, so callers that opt out are byte-identical to the
+            pre-#4766 path.
 
     Returns:
         The new ``router.routes`` list (also assigned on the router).
@@ -132,6 +281,11 @@ def apply_route_transform_grid_synced(
             optimized_routes.append(route)
             continue
         optimized = transform(route)
+        if accept is not None and optimized is not route and not accept(route, optimized):
+            # Issue #4766: vetoed (e.g. the transform would close an HV
+            # pairwise gap).  Fall back to the pre-transform route BEFORE the
+            # grid transaction below, so the grid is never touched for it.
+            optimized = route
         if optimized is not route and (
             optimized.segments == route.segments and optimized.vias == route.vias
         ):

--- a/src/kicad_tools/router/pairwise_clearance.py
+++ b/src/kicad_tools/router/pairwise_clearance.py
@@ -1010,6 +1010,95 @@ def find_pairwise_violations(
     return out
 
 
+class RouterPairwiseContext(NamedTuple):
+    """Everything a post-route pass needs to run the pairwise predicate (#4766).
+
+    The copper-*moving* post-passes (``TraceOptimizer`` via
+    :func:`~kicad_tools.router.optimizer.trace.optimize_routes_grid_synced`,
+    and :func:`~kicad_tools.router.drc_nudge.drc_verify_and_nudge`) were
+    pairwise-blind: their only hazard gate resolves clearance as the scalar
+    ``grid.rules.trace_clearance``, so they could close an HV creepage gap the
+    search had deliberately opened.  Both now consult the SAME predicate the
+    search and the #4588 audit use -- and they resolve it identically, through
+    this one context, so no pass can drift into a different verdict.
+
+    Attributes:
+        table: The installed ``rules.pairwise_clearance`` requirement table.
+        attach_zones: The #4506 rated-footprint necking regions, layer-scoped
+            per #4699 (``AttachZone.net_layers``).
+        id_to_name: Net id -> board net name, for routes whose ``net_name``
+            string is unset mid-pipeline (ids are authoritative there).
+    """
+
+    table: PairwiseClearanceTable
+    attach_zones: tuple[AttachZone, ...]
+    id_to_name: dict[int, str]
+
+
+def router_pairwise_context(router: object) -> RouterPairwiseContext | None:
+    """Derive the pairwise predicate context from a router (issue #4766).
+
+    Returns ``None`` -- the dormant signal that keeps every post-pass
+    byte-identical to the pre-#4766 path -- when no ``--voltage-map`` table is
+    installed, or when the installed table needs no widening for any pair.
+
+    Everything is read off the ``Autorouter`` itself, exactly as
+    :meth:`~kicad_tools.router.core.Autorouter._lattice_pairwise_projection`
+    already does for the lattice search:
+
+    * ``router.rules.pairwise_clearance`` -- the table
+      ``_apply_pairwise_clearance`` installs from ``--voltage-map``;
+    * ``router._pairwise_attach_zones_cache`` -- the memoised #4506 zone set the
+      CLI's ``_pairwise_attach_zones`` resolver warms (unset -> **no**
+      exemptions, i.e. the conservative "veto rather than silently waive"
+      direction, never an unsafe accept);
+    * ``router._net_name_to_id()`` (plus ``router.net_names``) inverted for
+      ``id_to_name``.
+
+    Deriving the context here rather than threading it through parameters is
+    what keeps the post-pass call sites (four for the optimizer, four for the
+    nudge, all in ``cli/route_cmd.py``) untouched.
+    """
+    rules = getattr(router, "rules", None)
+    table = getattr(rules, "pairwise_clearance", None) if rules is not None else None
+    if table is None or not getattr(table, "required_by_pair", None):
+        return None
+
+    zones = tuple(getattr(router, "_pairwise_attach_zones_cache", None) or ())
+
+    id_to_name: dict[int, str] = {}
+    net_names = getattr(router, "net_names", None) or {}
+    if hasattr(net_names, "items"):
+        for net_id, name in net_names.items():
+            if name:
+                id_to_name.setdefault(int(net_id), str(name))
+    resolver = getattr(router, "_net_name_to_id", None)
+    if callable(resolver):
+        # Sorted so a name collision on one id resolves deterministically.
+        for name, net_id in sorted(resolver().items()):
+            id_to_name.setdefault(int(net_id), name)
+
+    return RouterPairwiseContext(table=table, attach_zones=zones, id_to_name=id_to_name)
+
+
+def violation_pair_key(violation: PairwiseViolation) -> tuple[str, str]:
+    """Order-independent, ``/``-stripped net-pair key of a violation (#4766)."""
+    a = _norm_net_key(violation.net_a)
+    b = _norm_net_key(violation.net_b)
+    return (a, b) if a <= b else (b, a)
+
+
+def violation_pair_keys(violations: Iterable[PairwiseViolation]) -> set[tuple[str, str]]:
+    """Set of :func:`violation_pair_key` values for a violation list (#4766).
+
+    The post-pass gates compare a before/after scan by *net pair*, not by
+    coordinate: a pre-existing (inherited) shortfall that merely moves must not
+    be mistaken for one the pass introduced, or the pass would start
+    "repairing" copper the #4588 audit is supposed to keep reporting.
+    """
+    return {violation_pair_key(v) for v in violations}
+
+
 def _resolve_net_name(id_to_name: Mapping[int, str] | None, net_id: int, fallback: str) -> str:
     """Resolve a net id to its board net name, falling back to a known string."""
     if id_to_name is not None:

--- a/src/kicad_tools/router/pairwise_clearance.py
+++ b/src/kicad_tools/router/pairwise_clearance.py
@@ -858,10 +858,17 @@ class PairwisePathChecker:
     each route before mutating it and re-marks it after, so a snapshot taken at
     construction time would go stale mid-pass.
 
-    Instances only exist when a voltage map is active --
-    :meth:`from_router` returns ``None`` otherwise (the dormancy contract every
-    pairwise consumer follows), so callers guard with a single ``is None``
-    check and the scalar-only path stays byte-identical.
+    Instances only exist when a voltage map is active *and* the table it
+    installed actually widens some pair -- :meth:`from_router` returns ``None``
+    otherwise (the dormancy contract every pairwise consumer follows), so
+    callers guard with a single ``is None`` check and the scalar-only path
+    stays byte-identical.
+
+    This is the one resolver for router-derived pairwise context: the #4766
+    copper-moving post-passes build their route-level gates from these same
+    four fields (:attr:`table`, :attr:`id_to_name`, :attr:`attach_zones` and
+    :meth:`foreign_routes`), so no pass can drift into a different verdict
+    from the path-level predicate or from the #4588 audit.
     """
 
     table: PairwiseClearanceTable
@@ -884,16 +891,21 @@ class PairwisePathChecker:
         ``add_component``), and the #4506 zones from the CLI resolver's
         memoised ``_pairwise_attach_zones_cache`` hand-off (#4602 precedent).
 
-        Returns ``None`` when no voltage map installed a table (or the router
-        has no grid) -- the caller's signal to skip pairwise consultation
-        entirely.
+        Returns ``None`` when no voltage map installed a table, **or** when the
+        installed table widens nothing (``required_by_pair`` empty) -- either
+        way the caller's signal to skip pairwise consultation entirely.  A
+        table that asks for no widening can only ever answer "clear", so
+        arming a scan for it would be pure cost (#4766).
+
+        A router **without a grid** still yields a checker: ``foreign_routes``
+        then falls back to ``router.routes``.  The copper-moving post-passes
+        (#4766) are driven in unit tests by stub routers that carry routes but
+        no grid, and the pathfinder-facing consumers pass a real router where
+        the two are the same live list anyway.
         """
         rules = getattr(router, "rules", None)
         table = getattr(rules, "pairwise_clearance", None) if rules is not None else None
-        if table is None:
-            return None
-        grid = getattr(router, "grid", None)
-        if grid is None:
+        if table is None or not getattr(table, "required_by_pair", None):
             return None
 
         id_to_name: dict[int, str] = {
@@ -903,13 +915,17 @@ class PairwisePathChecker:
         }
         name_to_id_fn = getattr(router, "_net_name_to_id", None)
         if callable(name_to_id_fn):
-            for name, net_id in name_to_id_fn().items():
+            # Sorted so a name collision on one id resolves deterministically
+            # (#4766): an unsorted walk lets dict order pick the winner.
+            for name, net_id in sorted(name_to_id_fn().items()):
                 id_to_name.setdefault(int(net_id), name)
 
         zones = getattr(router, "_pairwise_attach_zones_cache", None) or ()
+        grid = getattr(router, "grid", None)
+        source: object = router if grid is None else grid
         return cls(
             table=table,
-            foreign_routes=lambda: grid.routes,
+            foreign_routes=lambda: getattr(source, "routes", None) or (),
             id_to_name=id_to_name or None,
             attach_zones=tuple(zones),
         )
@@ -1010,75 +1026,15 @@ def find_pairwise_violations(
     return out
 
 
-class RouterPairwiseContext(NamedTuple):
-    """Everything a post-route pass needs to run the pairwise predicate (#4766).
+def normalize_net_key(name: str) -> str:
+    """Public form of the pairwise net-name normaliser (#4766).
 
-    The copper-*moving* post-passes (``TraceOptimizer`` via
-    :func:`~kicad_tools.router.optimizer.trace.optimize_routes_grid_synced`,
-    and :func:`~kicad_tools.router.drc_nudge.drc_verify_and_nudge`) were
-    pairwise-blind: their only hazard gate resolves clearance as the scalar
-    ``grid.rules.trace_clearance``, so they could close an HV creepage gap the
-    search had deliberately opened.  Both now consult the SAME predicate the
-    search and the #4588 audit use -- and they resolve it identically, through
-    this one context, so no pass can drift into a different verdict.
-
-    Attributes:
-        table: The installed ``rules.pairwise_clearance`` requirement table.
-        attach_zones: The #4506 rated-footprint necking regions, layer-scoped
-            per #4699 (``AttachZone.net_layers``).
-        id_to_name: Net id -> board net name, for routes whose ``net_name``
-            string is unset mid-pipeline (ids are authoritative there).
+    Consumers outside this module (the DRC nudge's revert gate) need to key
+    routes the same way :func:`violation_pair_key` keys violations; exporting
+    the normaliser keeps them from reaching across a module boundary for the
+    private :func:`_norm_net_key`.
     """
-
-    table: PairwiseClearanceTable
-    attach_zones: tuple[AttachZone, ...]
-    id_to_name: dict[int, str]
-
-
-def router_pairwise_context(router: object) -> RouterPairwiseContext | None:
-    """Derive the pairwise predicate context from a router (issue #4766).
-
-    Returns ``None`` -- the dormant signal that keeps every post-pass
-    byte-identical to the pre-#4766 path -- when no ``--voltage-map`` table is
-    installed, or when the installed table needs no widening for any pair.
-
-    Everything is read off the ``Autorouter`` itself, exactly as
-    :meth:`~kicad_tools.router.core.Autorouter._lattice_pairwise_projection`
-    already does for the lattice search:
-
-    * ``router.rules.pairwise_clearance`` -- the table
-      ``_apply_pairwise_clearance`` installs from ``--voltage-map``;
-    * ``router._pairwise_attach_zones_cache`` -- the memoised #4506 zone set the
-      CLI's ``_pairwise_attach_zones`` resolver warms (unset -> **no**
-      exemptions, i.e. the conservative "veto rather than silently waive"
-      direction, never an unsafe accept);
-    * ``router._net_name_to_id()`` (plus ``router.net_names``) inverted for
-      ``id_to_name``.
-
-    Deriving the context here rather than threading it through parameters is
-    what keeps the post-pass call sites (four for the optimizer, four for the
-    nudge, all in ``cli/route_cmd.py``) untouched.
-    """
-    rules = getattr(router, "rules", None)
-    table = getattr(rules, "pairwise_clearance", None) if rules is not None else None
-    if table is None or not getattr(table, "required_by_pair", None):
-        return None
-
-    zones = tuple(getattr(router, "_pairwise_attach_zones_cache", None) or ())
-
-    id_to_name: dict[int, str] = {}
-    net_names = getattr(router, "net_names", None) or {}
-    if hasattr(net_names, "items"):
-        for net_id, name in net_names.items():
-            if name:
-                id_to_name.setdefault(int(net_id), str(name))
-    resolver = getattr(router, "_net_name_to_id", None)
-    if callable(resolver):
-        # Sorted so a name collision on one id resolves deterministically.
-        for name, net_id in sorted(resolver().items()):
-            id_to_name.setdefault(int(net_id), name)
-
-    return RouterPairwiseContext(table=table, attach_zones=zones, id_to_name=id_to_name)
+    return _norm_net_key(name)
 
 
 def violation_pair_key(violation: PairwiseViolation) -> tuple[str, str]:

--- a/tests/router/test_post_pass_pairwise_gate_4766.py
+++ b/tests/router/test_post_pass_pairwise_gate_4766.py
@@ -1,0 +1,516 @@
+"""HV pairwise (creepage) gating of the copper-moving post-passes (issue #4766).
+
+PR #4756 (issue #4699) widened the post-route pairwise audit to fresh +
+preserved copper, and deliberately left one search-side gap open: the
+``--lattice-optimize`` post-passes could still *move* copper without ever
+consulting the pairwise predicate.  Two of the three geometric post-passes
+could therefore close an HV creepage gap the search had opened, and only the
+board-level audit would notice:
+
+* ``TraceOptimizer`` (via ``optimize_routes_grid_synced``) -- its only hazard
+  gate is ``CollisionChecker.path_is_clear``, and both checker implementations
+  resolve clearance as the scalar ``grid.rules.trace_clearance``.
+* ``drc_verify_and_nudge`` -- translates segments by up to 0.2 mm with the same
+  scalar model.
+
+The third, ``consolidate_routes_grid_synced``, provably cannot: its merged
+segment is the exact union of the segments it replaces, so no gap to foreign
+copper can shrink.  It is deliberately NOT gated (see the ``consolidate``
+module docstring) and this file pins that too.
+
+Every test here is dormant-by-construction without a ``--voltage-map`` table:
+the "no table" variants double as the proof that the fixtures would fail on
+pre-#4766 ``main``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from kicad_tools.router.core import Autorouter
+from kicad_tools.router.drc_nudge import drc_verify_and_nudge
+from kicad_tools.router.layers import Layer
+from kicad_tools.router.optimizer import (
+    OptimizationConfig,
+    TraceOptimizer,
+    consolidate_routes_grid_synced,
+    optimize_routes_grid_synced,
+    pairwise_route_gate,
+)
+from kicad_tools.router.pairwise_clearance import (
+    AttachZone,
+    PairwiseClearanceTable,
+    find_pairwise_violations,
+    router_pairwise_context,
+    violation_pair_keys,
+)
+from kicad_tools.router.primitives import Route, Segment
+from kicad_tools.router.rules import DesignRules
+
+
+@dataclass
+class _StubRouter:
+    """Minimal Autorouter stand-in -- the shape the nudge unit tests drive."""
+
+    routes: list[Route] = field(default_factory=list)
+    existing_routes: list[Route] = field(default_factory=list)
+    rules: DesignRules = field(default_factory=DesignRules)
+    pads: dict = field(default_factory=dict)
+    nets: dict = field(default_factory=dict)
+    net_names: dict = field(default_factory=dict)
+    net_class_map: dict | None = None
+
+
+ID_TO_NAME = {1: "HV", 2: "LV", 3: "OBST"}
+
+# One HV pair: HV vs LV must hold 1.5 mm, everything else only the 0.2 mm DRU
+# floor.  Shaped exactly like what ``--voltage-map`` installs.
+TABLE = PairwiseClearanceTable(
+    dru=0.2,
+    net_voltages={"HV": 230.0, "LV": 0.0, "OBST": 0.0},
+    required_by_pair={("HV", "LV"): 1.5},
+)
+
+
+def _route(net: int, name: str, points: list[tuple[float, float]], width: float = 0.25) -> Route:
+    segments = [
+        Segment(
+            x1=a[0],
+            y1=a[1],
+            x2=b[0],
+            y2=b[1],
+            width=width,
+            layer=Layer.F_CU,
+            net=net,
+            net_name=name,
+        )
+        for a, b in zip(points, points[1:], strict=False)
+    ]
+    return Route(net=net, net_name=name, segments=segments)
+
+
+def _commit(router: Autorouter, route: Route) -> None:
+    router.grid.mark_route(route)
+    router.routes.append(route)
+
+
+def _staircase(start_y: float, end_y: float, steps: int = 5) -> list[tuple[float, float]]:
+    """Descending staircase from ``(5, start_y)`` -- what compress_staircase eats."""
+    drop = (start_y - end_y) / steps
+    points = [(5.0, start_y)]
+    x, y = 5.0, start_y
+    for _ in range(steps):
+        x += 3.0
+        points.append((x, y))
+        y -= drop
+        points.append((x, y))
+    return points
+
+
+def _optimize_fixture(
+    *, hv_y: float = 10.0, lv_end_y: float = 11.5, hv_x2: float = 15.0
+) -> tuple[Autorouter, Route]:
+    """HV rail below a staircase whose compression swings LV down over it.
+
+    ``compress_staircase`` replaces the staircase with a diagonal + horizontal
+    pair, i.e. it drops the whole run to ``lv_end_y`` immediately -- copper
+    lands directly above the HV rail at a gap the scalar checker is perfectly
+    happy with (1.25 mm >> 0.2 mm DRU) and the pairwise requirement is not.
+    """
+    router = Autorouter(width=40.0, height=40.0)
+    router.net_names = dict(ID_TO_NAME)
+    _commit(router, _route(1, "HV", [(5.0, hv_y), (hv_x2, hv_y)]))
+    lv = _route(2, "LV", _staircase(14.0, lv_end_y))
+    _commit(router, lv)
+    return router, lv
+
+
+def _nudge_fixture(lv_y: float) -> tuple[Autorouter, Route]:
+    """HV rail below an LV trace that OBST crowds from above.
+
+    The nudge's only escape from the OBST clearance violation is downward, by
+    ~0.12 mm -- inside its 0.2 mm budget, and straight into the HV creepage
+    requirement it cannot see.
+    """
+    router = Autorouter(width=40.0, height=40.0)
+    router.net_names = dict(ID_TO_NAME)
+    _commit(router, _route(1, "HV", [(5.0, 10.0), (25.0, 10.0)]))
+    lv = _route(2, "LV", [(8.0, lv_y), (22.0, lv_y)])
+    _commit(router, lv)
+    _commit(router, _route(3, "OBST", [(8.0, lv_y + 0.35), (22.0, lv_y + 0.35)]))
+    return router, lv
+
+
+def _pairs(router: Autorouter) -> set[tuple[str, str]]:
+    return violation_pair_keys(
+        find_pairwise_violations(router.routes, TABLE, id_to_name=ID_TO_NAME, dru=TABLE.dru)
+    )
+
+
+def _geometry(route: Route) -> list[tuple[float, float, float, float]]:
+    return [(s.x1, s.y1, s.x2, s.y2) for s in route.segments]
+
+
+def _optimizer() -> TraceOptimizer:
+    # No collision checker: the scalar gate is not what is under test here, and
+    # leaving it out makes the pairwise gate the only thing that can veto.
+    return TraceOptimizer(config=OptimizationConfig(minimize_vias=False))
+
+
+def _arm(router: Autorouter, *, zones: tuple[AttachZone, ...] = ()) -> None:
+    router.rules.pairwise_clearance = TABLE
+    router._pairwise_attach_zones_cache = zones
+
+
+class TestRouterPairwiseContext:
+    """The single context resolver both post-passes share."""
+
+    def test_dormant_without_a_voltage_map_table(self):
+        router, _ = _optimize_fixture()
+        assert router_pairwise_context(router) is None
+        assert pairwise_route_gate(router) is None
+
+    def test_dormant_when_the_table_needs_no_widening(self):
+        router, _ = _optimize_fixture()
+        router.rules.pairwise_clearance = PairwiseClearanceTable(
+            dru=0.2, net_voltages={"HV": 3.3}, required_by_pair={}
+        )
+        assert router_pairwise_context(router) is None
+
+    def test_context_carries_table_zones_and_id_map(self):
+        router, _ = _optimize_fixture()
+        zone = AttachZone(0.0, 0.0, 1.0, 1.0, frozenset({"HV", "LV"}))
+        _arm(router, zones=(zone,))
+        context = router_pairwise_context(router)
+        assert context is not None
+        assert context.table is TABLE
+        assert context.attach_zones == (zone,)
+        assert context.id_to_name[1] == "HV"
+        assert context.id_to_name[2] == "LV"
+
+    def test_unset_zone_cache_degrades_to_no_exemptions(self):
+        """Never an unsafe accept: no cache means nothing is waived."""
+        router, _ = _optimize_fixture()
+        router.rules.pairwise_clearance = TABLE
+        context = router_pairwise_context(router)
+        assert context is not None
+        assert context.attach_zones == ()
+
+
+class TestOptimizePairwiseGate:
+    """AC1 / AC4 / AC8 -- the trace-optimize pass."""
+
+    def test_ungated_optimize_introduces_a_violation(self):
+        """The pre-#4766 behaviour, and the reason this file exists."""
+        router, lv = _optimize_fixture()
+        assert _pairs(router) == set()
+
+        optimize_routes_grid_synced(router, _optimizer())
+
+        assert _geometry(lv) != _geometry(router.routes[1])
+        assert _pairs(router) == {("HV", "LV")}
+
+    def test_gated_optimize_keeps_the_pre_optimization_route(self):
+        router, lv = _optimize_fixture()
+        _arm(router)
+        before = _geometry(lv)
+
+        optimize_routes_grid_synced(router, _optimizer())
+
+        assert router.routes[1] is lv, "vetoed route must keep its identity"
+        assert _geometry(lv) == before
+        assert _pairs(router) == set()
+
+    def test_vetoed_route_never_enters_the_grid_transaction(self):
+        router, lv = _optimize_fixture()
+        _arm(router)
+
+        optimize_routes_grid_synced(router, _optimizer())
+
+        assert lv in router.grid.routes
+        assert _geometry(router.grid.routes[-1]) == _geometry(lv)
+
+    def test_optimization_that_stays_clear_is_accepted(self):
+        """Same staircase, HV moved out of range -- the gate must not fire."""
+        router, lv = _optimize_fixture(hv_y=4.0)
+        _arm(router)
+        before = _geometry(lv)
+
+        optimize_routes_grid_synced(router, _optimizer())
+
+        assert _geometry(router.routes[1]) != before
+        assert router._pairwise_optimize_vetoes == 0
+
+    def test_inherited_shortfall_does_not_freeze_the_route(self):
+        """A pair that already violates before the pass is not this pass's doing."""
+        router, lv = _optimize_fixture(lv_end_y=11.0, hv_x2=25.0)
+        _arm(router)
+        assert _pairs(router) == {("HV", "LV")}, "fixture must start dirty"
+        before = _geometry(lv)
+
+        optimize_routes_grid_synced(router, _optimizer())
+
+        assert _geometry(router.routes[1]) != before
+        assert router._pairwise_optimize_vetoes == 0
+        # ... and the audit still reports it.
+        assert _pairs(router) == {("HV", "LV")}
+
+    def test_veto_count_is_recorded_and_surfaced(self, capsys):
+        """AC8: the coarse veto's cost must be measurable, not silent."""
+        router, _ = _optimize_fixture()
+        _arm(router)
+
+        optimize_routes_grid_synced(router, _optimizer())
+
+        assert router._pairwise_optimize_vetoes == 1
+        err = capsys.readouterr().err
+        assert "HV pairwise gate: 1 route(s) kept pre-optimization geometry" in err
+        assert "LV vs HV" in err
+
+    def test_nothing_is_reported_when_nothing_is_vetoed(self, capsys):
+        router, _ = _optimize_fixture(hv_y=4.0)
+        _arm(router)
+
+        optimize_routes_grid_synced(router, _optimizer())
+
+        assert capsys.readouterr().err == ""
+
+
+class TestAttachZoneLayerScoping:
+    """AC1 -- the #4506/#4699 exemption must reach the gate, layer-scoped."""
+
+    def _zone(self, layers: frozenset[str]) -> AttachZone:
+        # Wide enough to contain the closest-gap midpoint the violation reports.
+        return AttachZone(
+            5.0,
+            9.0,
+            16.0,
+            13.0,
+            frozenset({"HV", "LV"}),
+            frozenset({("HV", layers), ("LV", layers)}),
+        )
+
+    def test_zone_on_the_conflict_layer_waives_the_veto(self):
+        router, lv = _optimize_fixture()
+        _arm(router, zones=(self._zone(frozenset({"F.Cu"})),))
+        before = _geometry(lv)
+
+        optimize_routes_grid_synced(router, _optimizer())
+
+        assert _geometry(router.routes[1]) != before
+        assert router._pairwise_optimize_vetoes == 0
+
+    def test_zone_on_another_layer_does_not_waive_the_veto(self):
+        router, lv = _optimize_fixture()
+        _arm(router, zones=(self._zone(frozenset({"In1.Cu"})),))
+        before = _geometry(lv)
+
+        optimize_routes_grid_synced(router, _optimizer())
+
+        assert _geometry(router.routes[1]) == before
+        assert router._pairwise_optimize_vetoes == 1
+
+
+class TestNudgePairwiseRevert:
+    """AC2 / AC8 -- the DRC nudge pass."""
+
+    def test_ungated_nudge_introduces_a_violation(self):
+        router, lv = _nudge_fixture(11.78)
+        assert _pairs(router) == set()
+
+        result = drc_verify_and_nudge(router)
+
+        assert result.segments_nudged == 1
+        assert result.pairwise_reverts == 0
+        assert _pairs(router) == {("HV", "LV")}
+
+    def test_gated_nudge_reverts_to_the_entry_snapshot(self):
+        router, lv = _nudge_fixture(11.78)
+        _arm(router)
+        before = _geometry(lv)
+
+        result = drc_verify_and_nudge(router)
+
+        assert result.pairwise_reverts == 1
+        assert _geometry(lv) == before
+        assert _pairs(router) == set()
+        # The reverted route re-opens the scalar violation the nudge fixed --
+        # reported honestly rather than as a pre-revert success.
+        assert result.remaining_violations == 1
+        assert "HV pairwise gate: 1 route(s) reverted to pre-nudge geometry" in result.summary()
+
+    def test_inherited_violation_is_not_reverted(self):
+        """A pair already dirty at entry stays the audit's problem, not the gate's."""
+        router, lv = _nudge_fixture(11.0)
+        _arm(router)
+        assert _pairs(router) == {("HV", "LV")}
+        before = _geometry(lv)
+
+        result = drc_verify_and_nudge(router)
+
+        assert result.pairwise_reverts == 0
+        assert _geometry(lv) != before
+        assert _pairs(router) == {("HV", "LV")}
+
+    def test_clear_nudge_is_left_alone(self):
+        router, lv = _nudge_fixture(20.0)
+        _arm(router)
+        before = _geometry(lv)
+
+        result = drc_verify_and_nudge(router)
+
+        assert result.pairwise_reverts == 0
+        assert _geometry(lv) != before
+
+
+class TestPostPassesTogether:
+    """AC4 headline -- optimize + nudge introduce nothing the audit did not see."""
+
+    def test_full_post_pass_chain_introduces_no_new_pairs(self):
+        router, _ = _optimize_fixture()
+        _arm(router)
+        before = _pairs(router)
+
+        optimize_routes_grid_synced(router, _optimizer())
+        drc_verify_and_nudge(router)
+        consolidate_routes_grid_synced(router)
+
+        assert _pairs(router) - before == set()
+
+    def test_full_post_pass_chain_is_dirty_without_the_table(self):
+        """The same chain on the pre-#4766 (dormant) path -- fails-on-main proof."""
+        router, _ = _optimize_fixture()
+        before = _pairs(router)
+
+        optimize_routes_grid_synced(router, _optimizer())
+        drc_verify_and_nudge(router)
+        consolidate_routes_grid_synced(router)
+
+        assert _pairs(router) - before == {("HV", "LV")}
+
+
+class TestConsolidationIsNotGated:
+    """AC3 -- copper-preserving by construction, so no gate is added."""
+
+    def test_consolidation_runs_identically_with_the_table_armed(self):
+        armed_geometry = None
+        for arm in (False, True):
+            router = Autorouter(width=40.0, height=40.0)
+            router.net_names = dict(ID_TO_NAME)
+            _commit(router, _route(1, "HV", [(5.0, 10.0), (25.0, 10.0)]))
+            # Collinear run one merge away from a single segment, held at the
+            # HV requirement boundary so a route-level veto would be visible.
+            _commit(
+                router,
+                _route(2, "LV", [(8.0, 11.7), (12.0, 11.7), (16.0, 11.7), (20.0, 11.7)]),
+            )
+            if arm:
+                _arm(router)
+
+            stats = consolidate_routes_grid_synced(router)
+
+            assert stats.runs_merged == 1
+            geometry = _geometry(router.routes[1])
+            assert len(geometry) == 1
+            if armed_geometry is None:
+                armed_geometry = geometry
+            else:
+                assert geometry == armed_geometry
+
+
+class TestDormancy:
+    """AC6 -- no ``--voltage-map`` means the predicate is never even consulted."""
+
+    def test_no_pairwise_scan_happens_without_a_table(self, monkeypatch):
+        def explode(*_args, **_kwargs):  # pragma: no cover - must never run
+            raise AssertionError("dormant run consulted the pairwise predicate")
+
+        monkeypatch.setattr(
+            "kicad_tools.router.pairwise_clearance.find_pairwise_violations", explode
+        )
+        monkeypatch.setattr(
+            "kicad_tools.router.pairwise_clearance.route_pairwise_violation", explode
+        )
+        monkeypatch.setattr("kicad_tools.router.optimizer.trace.route_pairwise_violation", explode)
+
+        router, _ = _optimize_fixture()
+        optimize_routes_grid_synced(router, _optimizer())
+        drc_verify_and_nudge(router)
+        consolidate_routes_grid_synced(router)
+
+    def test_dormant_optimize_output_matches_the_ungated_transform(self):
+        """Geometry from the gated code path with no table == ungated geometry."""
+        expected = [(5.0, 14.0, 7.5, 11.5), (7.5, 11.5, 20.0, 11.5)]
+        router, _ = _optimize_fixture()
+
+        optimize_routes_grid_synced(router, _optimizer())
+
+        assert _geometry(router.routes[1]) == expected
+        assert not hasattr(router, "_pairwise_optimize_vetoes")
+
+    def test_dormant_nudge_reports_zero_reverts(self):
+        router, _ = _nudge_fixture(11.78)
+        result = drc_verify_and_nudge(router)
+        assert result.pairwise_reverts == 0
+        assert "HV pairwise gate" not in result.summary()
+
+
+class TestEdgeCases:
+    def test_empty_route_list(self):
+        router = Autorouter(width=40.0, height=40.0)
+        router.net_names = dict(ID_TO_NAME)
+        _arm(router)
+
+        optimize_routes_grid_synced(router, _optimizer())
+        result = drc_verify_and_nudge(router)
+
+        assert router.routes == []
+        assert result.pairwise_reverts == 0
+
+    def test_nudge_on_a_router_without_a_grid(self):
+        """The stub-router shape the nudge unit tests drive (no grid, no resync)."""
+        rules = DesignRules(trace_clearance=0.2)
+        rules.pairwise_clearance = TABLE
+        lv = _route(2, "LV", [(8.0, 11.78), (22.0, 11.78)])
+        stub = _StubRouter(
+            routes=[
+                _route(1, "HV", [(5.0, 10.0), (25.0, 10.0)]),
+                lv,
+                _route(3, "OBST", [(8.0, 12.13), (22.0, 12.13)]),
+            ],
+            rules=rules,
+            net_names=dict(ID_TO_NAME),
+        )
+        before = _geometry(lv)
+
+        result = drc_verify_and_nudge(stub)  # type: ignore[arg-type]
+
+        # The gate is armed and reverts even without a grid to resync.
+        assert result.pairwise_reverts == 1
+        assert _geometry(lv) == before
+
+    def test_zone_resolving_to_a_single_net_cannot_waive(self):
+        router, lv = _optimize_fixture()
+        _arm(router, zones=(AttachZone(5.0, 9.0, 16.0, 13.0, frozenset({"HV"})),))
+        before = _geometry(lv)
+
+        optimize_routes_grid_synced(router, _optimizer())
+
+        assert _geometry(router.routes[1]) == before
+        assert router._pairwise_optimize_vetoes == 1
+
+
+@pytest.mark.parametrize("armed", [False, True])
+def test_skip_nets_still_bypasses_the_pass(armed):
+    """#3508 protection is upstream of the gate and stays intact."""
+    router, lv = _optimize_fixture()
+    if armed:
+        _arm(router)
+    before = _geometry(lv)
+
+    optimize_routes_grid_synced(router, _optimizer(), skip_nets={2})
+
+    assert router.routes[1] is lv
+    assert _geometry(lv) == before

--- a/tests/router/test_post_pass_pairwise_gate_4766.py
+++ b/tests/router/test_post_pass_pairwise_gate_4766.py
@@ -164,7 +164,7 @@ def _arm(router: Autorouter, *, zones: tuple[AttachZone, ...] = ()) -> None:
     router._pairwise_attach_zones_cache = zones
 
 
-class TestRouterPairwiseContext:
+class TestPairwisePathCheckerFromRouter:
     """The ONE router-derived context resolver every pairwise consumer shares.
 
     Both post-passes here and #4507's path-level predicate resolve their table,

--- a/tests/router/test_post_pass_pairwise_gate_4766.py
+++ b/tests/router/test_post_pass_pairwise_gate_4766.py
@@ -42,8 +42,8 @@ from kicad_tools.router.optimizer import (
 from kicad_tools.router.pairwise_clearance import (
     AttachZone,
     PairwiseClearanceTable,
+    PairwisePathChecker,
     find_pairwise_violations,
-    router_pairwise_context,
     violation_pair_keys,
 )
 from kicad_tools.router.primitives import Route, Segment
@@ -165,11 +165,18 @@ def _arm(router: Autorouter, *, zones: tuple[AttachZone, ...] = ()) -> None:
 
 
 class TestRouterPairwiseContext:
-    """The single context resolver both post-passes share."""
+    """The ONE router-derived context resolver every pairwise consumer shares.
+
+    Both post-passes here and #4507's path-level predicate resolve their table,
+    id->name map and #4506 zones through ``PairwisePathChecker.from_router``.
+    A second resolver would be free to drift into a different verdict on the
+    same router, so this class pins the resolver's contract rather than a
+    per-pass copy of it.
+    """
 
     def test_dormant_without_a_voltage_map_table(self):
         router, _ = _optimize_fixture()
-        assert router_pairwise_context(router) is None
+        assert PairwisePathChecker.from_router(router) is None
         assert pairwise_route_gate(router) is None
 
     def test_dormant_when_the_table_needs_no_widening(self):
@@ -177,26 +184,53 @@ class TestRouterPairwiseContext:
         router.rules.pairwise_clearance = PairwiseClearanceTable(
             dru=0.2, net_voltages={"HV": 3.3}, required_by_pair={}
         )
-        assert router_pairwise_context(router) is None
+        assert PairwisePathChecker.from_router(router) is None
+        assert pairwise_route_gate(router) is None
 
     def test_context_carries_table_zones_and_id_map(self):
         router, _ = _optimize_fixture()
         zone = AttachZone(0.0, 0.0, 1.0, 1.0, frozenset({"HV", "LV"}))
         _arm(router, zones=(zone,))
-        context = router_pairwise_context(router)
-        assert context is not None
-        assert context.table is TABLE
-        assert context.attach_zones == (zone,)
-        assert context.id_to_name[1] == "HV"
-        assert context.id_to_name[2] == "LV"
+        checker = PairwisePathChecker.from_router(router)
+        assert checker is not None
+        assert checker.table is TABLE
+        assert checker.attach_zones == (zone,)
+        assert checker.id_to_name is not None
+        assert checker.id_to_name[1] == "HV"
+        assert checker.id_to_name[2] == "LV"
 
     def test_unset_zone_cache_degrades_to_no_exemptions(self):
         """Never an unsafe accept: no cache means nothing is waived."""
         router, _ = _optimize_fixture()
         router.rules.pairwise_clearance = TABLE
-        context = router_pairwise_context(router)
-        assert context is not None
-        assert context.attach_zones == ()
+        checker = PairwisePathChecker.from_router(router)
+        assert checker is not None
+        assert checker.attach_zones == ()
+
+    def test_id_collision_resolves_deterministically(self):
+        """Two names on one id must not depend on the mapping's iteration order."""
+        rules = DesignRules(trace_clearance=0.2)
+        rules.pairwise_clearance = TABLE
+        forward = _StubRouter(rules=rules)
+        forward._net_name_to_id = lambda: {"HV": 1, "AAA": 1}  # type: ignore[attr-defined]
+        reverse = _StubRouter(rules=rules)
+        reverse._net_name_to_id = lambda: {"AAA": 1, "HV": 1}  # type: ignore[attr-defined]
+
+        a = PairwisePathChecker.from_router(forward)
+        b = PairwisePathChecker.from_router(reverse)
+        assert a is not None and b is not None
+        assert a.id_to_name == b.id_to_name == {1: "AAA"}
+
+    def test_a_router_without_a_grid_still_arms_on_its_own_routes(self):
+        """The nudge's stub-router shape: routes but no grid (see AC6)."""
+        rules = DesignRules(trace_clearance=0.2)
+        rules.pairwise_clearance = TABLE
+        route = _route(1, "HV", [(5.0, 10.0), (25.0, 10.0)])
+        stub = _StubRouter(routes=[route], rules=rules, net_names=dict(ID_TO_NAME))
+
+        checker = PairwisePathChecker.from_router(stub)
+        assert checker is not None
+        assert list(checker.foreign_routes()) == [route]
 
 
 class TestOptimizePairwiseGate:


### PR DESCRIPTION
## Summary

The `--lattice-optimize` post-passes could **move copper without ever consulting the pairwise (HV creepage) predicate**, the search-side gap PR #4756 deliberately deferred. `TraceOptimizer` gates its moves only on `CollisionChecker.path_is_clear`, and *both* checker implementations (`GridCollisionChecker`, `VectorCollisionChecker`) resolve clearance as the **scalar** `grid.rules.trace_clearance`; `drc_verify_and_nudge` translates segments by up to 0.2 mm with the same scalar model. Either pass could therefore close a gap the search had deliberately opened, leaving the #4588 audit to fail a run the optimizer had just broken.

Both now run the same layer-scoped predicate the search and the audit run. The third post-pass, collinear consolidation, provably cannot create a hazard and is deliberately **not** gated (AC3).

**Seam chosen: Option A (route-level accept gate), as recommended.** `route_cmd.py` is a **zero-line diff** — both passes derive their context from the `router` object exactly as `Autorouter._lattice_pairwise_projection` already does, so none of the 4 + 4 CLI call sites move. The route-level seam also sidesteps the curated finding (a): `RoutingGrid._rtree_clearance_inflation` is cached from `rules.max_clearance` at construction, before `_apply_pairwise_clearance` installs the table, and `invalidate_spatial_index` has no caller in `src/` — so the R-tree broad phase cannot return a candidate at pairwise range. **`invalidate_spatial_index` is not called here** (#4507/#4511 territory).

## Changes

- **`router/pairwise_clearance.py`** — both passes resolve their context through the **single** `PairwisePathChecker.from_router` resolver #4785 landed (`rules.pairwise_clearance`, `_pairwise_attach_zones_cache`, `net_names`/`_net_name_to_id()` inverted deterministically). No second resolver is introduced: `from_router` picks up the three behaviours this PR needs — dormant when the table widens nothing (`required_by_pair` empty), a `sorted()` net-name walk so an id collision is deterministic, and it now arms on a grid-less router by falling back to `router.routes`. Plus `normalize_net_key` / `violation_pair_key` / `violation_pair_keys` for the pair-level set difference. No change to `route_pairwise_violation` / `find_pairwise_violations` / `segment_pair_violation` semantics.
- **`router/optimizer/trace.py`** — `apply_route_transform_grid_synced` gains an optional `accept=(original, transformed) -> bool` hook, consulted **before** the grid transaction so a vetoed route never enters the unmark/mark window. `optimize_routes_grid_synced` arms it with the new `PairwiseRouteGate`, which runs `route_pairwise_violation` against `grid.routes` (the same reference set the grid `Pathfinder` validator uses) with the layer-scoped attach-zone exemption.
- **`router/drc_nudge.py`** — `drc_verify_and_nudge` brackets itself with a board-level `find_pairwise_violations` scan and reverts every route named in a net pair present *after* but not *before*, restoring from the entry snapshot it already takes for the #3507 resync. `DRCNudgeResult.pairwise_reverts` + a summary line; `remaining_violations` is recomputed post-revert (a revert can restore the scalar violation the nudge just repaired — reported honestly rather than at the flattering pre-revert count).
- **`router/optimizer/consolidate.py`** — docstring only: why the union property makes a gate unnecessary (and actively harmful, being route-level) here.
- **`tests/router/test_post_pass_pairwise_gate_4766.py`** — 28 new tests (see Test Plan). Filed as a new file rather than editing `test_pairwise_clearance.py` / `test_post_pass_gating.py`, to avoid colliding with concurrent work in this sweep.

**Both gates only undo what the pass would INTRODUCE.** An inherited shortfall on the same net pair keeps its optimization / its nudge and stays the audit's to report — otherwise the passes would freeze (optimizer) or silently "repair" (nudge) copper the #4588 gate exists to fail the run on.

**Trade-off, stated plainly:** the optimizer veto is **coarse** — one bad move costs the whole route its optimization. That is the correctness-first reading of the AC. Segment-level granularity needs no new primitive and no R-tree broad-phase change (`PairwisePathChecker.path_is_clear` is signature-compatible with `CollisionChecker` and walks `grid.routes` linearly); what it needs is a decision on the per-segment cost, so it is a documented follow-up, not this PR.

## Acceptance Criteria Verification

- **AC1 — optimize consults the predicate.** `PairwiseRouteGate` vetoes via `route_pairwise_violation` with `attach_zones` carried through, so its verdict matches the #4588 gate by construction. Covered by `test_gated_optimize_keeps_the_pre_optimization_route`, `test_vetoed_route_never_enters_the_grid_transaction`, `test_optimization_that_stays_clear_is_accepted`, and the layer-scoping pair below.
- **AC2 — nudge consults the predicate.** `test_gated_nudge_reverts_to_the_entry_snapshot` (revert + honest `remaining_violations`) and `test_inherited_violation_is_not_reverted` (inherited pair survives and is still audit-reported).
- **AC3 — consolidation documented, not gated.** Module docstring + `consolidate_routes_grid_synced` note; `TestConsolidationIsNotGated` pins that arming the table changes nothing.
- **AC4 — headline regression test.** `test_full_post_pass_chain_introduces_no_new_pairs` (armed: `_pairs(router) - before == set()`) paired with `test_full_post_pass_chain_is_dirty_without_the_table`, which runs the identical chain on the dormant (pre-#4766) path and asserts it **does** introduce `('HV','LV')` — the fails-on-main proof, executed rather than asserted.
- **AC5 — audit semantics unchanged.** `tests/test_route_pairwise_gate_4588.py` passes **unmodified** (not touched in this diff).
- **AC6 — dormancy.** `TestDormancy::test_no_pairwise_scan_happens_without_a_table` monkeypatches `find_pairwise_violations` / `route_pairwise_violation` to raise and runs optimize + nudge + consolidate: nothing consults the predicate. Plus a geometry-equality check and a "no `_pairwise_optimize_vetoes` attribute" check.
- **AC7 — fleet no-op.** See below. **Zero copper change.** `.github/routed-drc-tolerance.yml` is untouched.
- **AC8 — observability.** Optimizer: `router._pairwise_optimize_vetoes` + a one-line stderr advisory naming the worst shortfall (the `_warn_layer_selection_advisories` #4314 precedent; nothing is printed when nothing is vetoed, so `--quiet` stdout is untouched). Nudge: `DRCNudgeResult.pairwise_reverts` in `summary()`, which `route_cmd` already prints non-quiet.
- **AC9 — no C++ change.** `src/kicad_tools/router/cpp/**` untouched; `ROUTER_CPP_BUILD_VERSION` stays **19** (`kct build-native --check` -> `build version: 19 (required: 19)` in this worktree).

### AC7 evidence (measured, not assumed)

1. `grep -rn 'voltage-map|lattice-optimize' boards/` -> **0 hits**, so the gate is dormant fleet-wide.
2. **Board 02 A/B** — the pinned deterministic recipe (`--strategy negotiated --iterations 30 --deterministic-budget --seed 42 --skip-nets GND --manufacturer jlcpcb`, `PYTHONHASHSEED=42`) run on this branch and on the `main` checkout at the same baseline: **298 copper items each, set-identical (0 only-main, 0 only-branch)**, 8/8 nets both, `DRC PASSED` both.
3. **Board 03 A/B** — the `test_board03_routing_baseline.py::_run_kct_route` recipe (`--backend cpp --deterministic-budget --differential-pairs --net-class-map`, seed 42, `PYTHONHASHSEED=42`): **257 copper items each, set-identical**, 13/13 nets both.

(Note for a reviewer: both boards' *committed* artifacts differ from what either side produces today — that is pre-existing drift from earlier merges, and `main` reproduces exactly what this branch produces, which is the comparison that matters here.)

## Test Plan

- [x] `uv run pytest tests/router/` — **1203 passed, 5 skipped** (includes the 28 new tests).
- [x] All non-router tests importing `drc_nudge` / `optimizer` / `pairwise` (73 files) — **2978 passed, 43 skipped**.
- [x] `tests/test_route_pairwise_gate_4588.py`, `tests/router/test_pairwise_clearance.py`, `tests/test_trace_optimizer.py`, `tests/router/test_grid_resync_3507.py`, `tests/test_route_consolidation_pass.py`, `tests/test_drc_nudge*.py` — all green, none modified.
- [x] `uv run ruff format . --check` (1786 files) and `uv run ruff check .` — clean.
- [x] `uv run python scripts/ci/check_mypy_baseline.py` — `OK: 1471 error(s), all within the baseline (1473 allowed)`. The "2 baseline errors no longer occur" warning reproduces **identically on `main`** (checked), so it is pre-existing; the baseline was **not** updated.
- [x] `uv run kct build-native --check` -> build version 19.
- [x] Edge cases covered: empty `router.routes`; a stub router with no grid; an attach zone resolving to a single net (conservative veto); unset `_pairwise_attach_zones_cache` (degrades to *no* exemptions, never an unsafe accept); `skip_nets` protection unchanged with the gate armed.

## Notes for the Judge

- The optimizer advisory goes to **stderr and is not suppressed by `--quiet`**, following the #4314 advisory precedent; that was the only way to satisfy AC8 for the optimize pass while keeping `route_cmd.py` at a zero-line diff (the pass has no stats object the CLI prints). Say the word if you would rather have it plumbed through `route_cmd`.
- The "inherited pair" carve-out uses `route_pairwise_violation`'s *first* finding on the pre-transform route, so a route dirty on **two** pairs may be vetoed even if the second pair also pre-existed. That direction is conservative (keeps the original geometry) and is documented in `PairwiseRouteGate`.
- The nudge revert loop is bounded at 3 rounds (`_PAIRWISE_REVERT_ROUNDS`); reverting restores entry geometry, so it converges in one round in practice.

Closes #4766
