### PR TITLE
feat(cli): add --format json to config, the ipc family, and mcp setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -348,6 +348,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`--format json` on the 5 environment/integration singles** (part of
+  #4674, fourth batch of the #4543 machine-output sweep) — `config`,
+  `ipc status`, `ipc connect`, `ipc push-routes` and `mcp setup` now accept
+  the canonical `--format json` and emit one deterministic document on
+  stdout instead of prose. This finishes the `ipc` family outright and
+  finishes `mcp` (`mcp serve` stays exempt: it is a long-running server
+  whose machine contract *is* the MCP protocol). `config` covers all five
+  modes — `show` (a `sections` map of `{value, source}` per key, plus
+  `native_backends`), `paths`, `init`, `get` and `set`; because `config set`
+  only *advises* the TOML to paste rather than writing it, its document says
+  so structurally with `"applied": false` and carries the `toml` snippet.
+  `ipc status`/`connect` report `socket`/`connected`/`kicad_version` (status
+  also `instances` and sorted `open_documents`); `ipc push-routes` reports
+  `tracks`/`vias`/`net_filter`/`dry_run`/`pushed`; `mcp setup` reports
+  `client`/`config_path`/`written`/`replaced` plus the resolved `server`
+  entry. Failure paths emit `{"error": ..., "success": false}` documents
+  with exit codes unchanged, and text-mode output is byte-identical to
+  before (including the several `ipc` failure paths that deliberately print
+  without an `Error:` prefix). Audit
+  (`scripts/audit_machine_output.py`): prose-only 23 → 18, format-json
+  174 → 179. `tests/test_format_json_sweep_env.py` guards the new surfaces;
+  `docs/reference/machine-output.md` records the per-command shapes.
+
 - **`docs/research/kipy-ipc-api-evaluation.md`** (#4779) — evaluation of `kipy` (official KiCad IPC-API bindings) and `kicad-mcp-kipy` as a parser cross-check; verdict: adopt nothing (live-editor-only RPC client, no offline path, cannot run DRC); also corrects the `README.md` "Related Projects" `kipy` entry to the canonical GitLab URL with the live-editor constraint stated.
 
 - **`--format json` on the 10 prose-only holdouts inside the `datasheet`,

--- a/docs/reference/machine-output.md
+++ b/docs/reference/machine-output.md
@@ -52,13 +52,13 @@ below is issue **#4674** and should build on these helpers.
 Measured by programmatic introspection of the real argparse tree
 (`create_parser()`, recursive walk of `_SubParsersAction` leaves) — not grep:
 
-| Idiom (outer `kct` parser) | Before #4543 | After #4543 | After #4674 b1 | b2 | b3 |
-|---|---|---|---|---|---|
-| `--format` with a `json` choice | 124 | 124 | 148 | 164 | 174 |
-| Both `--format json` and legacy `--json` alias | 0 | 2 (`placement refine`, `calibrate`) | 2 | 2 | 2 |
-| `--json` boolean only | 2 | **0** | 0 | 0 | 0 |
-| `--format` without a `json` choice | 1 (`benchmark report`, `text,markdown`) | 1 | **0** | 0 | 0 |
-| Neither (prose-only) | 72 | 72 (backlog for #4674, below) | 49 | 33 | 23 |
+| Idiom (outer `kct` parser) | Before #4543 | After #4543 | After #4674 b1 | b2 | b3 | b4 |
+|---|---|---|---|---|---|---|
+| `--format` with a `json` choice | 124 | 124 | 148 | 164 | 174 | 179 |
+| Both `--format json` and legacy `--json` alias | 0 | 2 (`placement refine`, `calibrate`) | 2 | 2 | 2 | 2 |
+| `--json` boolean only | 2 | **0** | 0 | 0 | 0 | 0 |
+| `--format` without a `json` choice | 1 (`benchmark report`, `text,markdown`) | 1 | **0** | 0 | 0 | 0 |
+| Neither (prose-only) | 72 | 72 (backlog for #4674, below) | 49 | 33 | 23 | 18 |
 
 The first #4674 batch swept the grouped-subcommand families -- `mfr` (7),
 `spec` (5), `placement fix/nudge/snap/align/distribute` (5), `zones
@@ -69,9 +69,13 @@ The second batch swept the 16 mutating `sch` leaves.
 
 The third batch finished the four families that already spoke JSON on most
 of their leaves but still had prose-only holdouts -- `datasheet` (3), `lib`
-(3), `parts` (2), `pcb` (2). The remaining 23 prose-only leaves (`stitch`
-and the long tail of single commands, plus the 4 exempt and the deferred
-`route`) stay on the #4674 backlog below.
+(3), `parts` (2), `pcb` (2).
+
+The fourth batch swept the environment/integration singles -- `config`,
+`ipc status/connect/push-routes`, `mcp setup` (5) -- finishing the `ipc`
+family outright and finishing `mcp` (`mcp serve` is exempt). The remaining
+18 prose-only leaves (`stitch` and the long tail of single commands, plus
+the 4 exempt and the deferred `route`) stay on the #4674 backlog below.
 
 Issue #4543 closed the `--json`-only bucket by adding `--format {text,json}`
 alongside the existing `--json` on both commands (outer parser, forwarding
@@ -203,13 +207,45 @@ handler, so — like the `sch` shim in batch 2 — it now emits the same
 that already had `--format json`. `tests/test_format_json_sweep_families.py`
 guards these 10 surfaces.
 
-**Remaining actionable (18)** — the audit's `prose-only` bucket reads 23
+**Done (fourth #4674 batch, 5 surfaces):** the environment/integration
+singles — the leaves that report on or configure `kct`'s *surroundings*
+rather than a board file: `config`, `ipc status/connect/push-routes`,
+`mcp setup`. This finishes the `ipc` family outright and finishes `mcp`
+(`mcp serve` is exempt, above). Shapes:
+
+| Command | Document |
+|---|---|
+| `config` | `{"command": "config", "action": "show"\|"paths"\|"init"\|"get"\|"set", …}` — `show` carries `sections` (`{section: {key: {value, source}}}`) plus `native_backends` (`{backend: {available, version}}`); `paths` carries `project_config`/`user_config` (`{path, exists}`, project also `search_filenames`); `init` carries `path`/`scope`/`created`; `get` carries `key`/`section`/`option`/`value`/`source`; `set` carries the same plus `applied: false` and the `toml` snippet to paste |
+| `ipc status` | `{"command": "status", "socket", "connected", "kicad_version", "instances", "open_documents", "success"}` |
+| `ipc connect` | `{"command": "connect", "socket", "connected", "kicad_version", "success"}` |
+| `ipc push-routes` | `{"command": "push-routes", "pcb", "net_filter", "tracks", "vias", "dry_run", "pushed", "success"}` (`socket` once resolved) |
+| `mcp setup` | `{"command": "setup", "client", "config_path", "dry_run", "written", "replaced", "server", "success"}` |
+
+Two conventions this batch establishes for the remaining long tail:
+
+- **`set`-style commands that only *advise*** (`kct config set` prints the
+  TOML to paste rather than writing it) must say so structurally —
+  `"applied": false` — so a machine caller cannot mistake exit 0 for a
+  persisted change.
+- **Text-mode prose is preserved verbatim**, including the several `ipc`
+  failure paths that print *without* an `Error:` prefix. The shared
+  `_fail(...)` helper in `commands/ipc.py` takes a `text_lines` override
+  for exactly that reason; copy it rather than normalizing prose in a
+  formatting-only batch.
+
+`kct ipc push-routes` reaches its "PCB parser not available." branch for
+every existing board, because it imports `kicad_tools.pcb.parser` — a
+module that has never existed (dead since #2363). The JSON path turns that
+into a visible `{"error": …, "success": false}` document; the underlying
+wiring bug is tracked separately in #4788 and is out of scope for this
+sweep. `tests/test_format_json_sweep_env.py` guards these 5 surfaces and is
+written to pass both before and after #4788 is fixed.
+
+**Remaining actionable (13)** — the audit's `prose-only` bucket reads 18
 because it also counts the 4 exempt commands and the deferred `route`
 (sections above):
 
-- `board-metrics`, `build`, `config`, `create-pcb`, `creepage-export-rules`
-- `ipc connect`, `ipc push-routes`, `ipc status`
-- `mcp setup`
+- `board-metrics`, `build`, `create-pcb`, `creepage-export-rules`
 - `optimize-placement`, `optimize-traces`
 - `panel`
 - `pipeline`

--- a/src/kicad_tools/cli/commands/config.py
+++ b/src/kicad_tools/cli/commands/config.py
@@ -8,6 +8,8 @@ def run_config_command(args) -> int:
     from ..config_cmd import main as config_main
 
     sub_argv = []
+    if getattr(args, "format", "text") != "text":
+        sub_argv.extend(["--format", args.format])
     if args.show:
         sub_argv.append("--show")
     if args.init:

--- a/src/kicad_tools/cli/commands/ipc.py
+++ b/src/kicad_tools/cli/commands/ipc.py
@@ -1,8 +1,59 @@
-"""IPC command handlers for live KiCad instance interaction."""
+"""IPC command handlers for live KiCad instance interaction.
+
+Machine output (``--format json``, issue #4674): ``ipc status``,
+``ipc connect`` and ``ipc push-routes`` each print exactly one JSON document
+on stdout, keyed by ``command`` plus that command's own summary.  Failures
+carry an ``error`` string with the exit code unchanged, so a caller can tell
+"no KiCad running" from "IPC extra not installed" without scraping prose.
+See ``docs/reference/machine-output.md``.
+"""
 
 from __future__ import annotations
 
+from typing import Any
+
+from ..format_options import FORMAT_JSON, emit_json
+
 __all__ = ["run_ipc_command"]
+
+_IPC_MISSING_MSG = "IPC dependencies not installed. Install with: pip install 'kicad-tools[ipc]'"
+_PYNNG_MISSING_MSG = "pynng not installed. Install with: pip install 'kicad-tools[ipc]'"
+
+
+def _fmt(args) -> str:
+    """Return the requested output format for an ``ipc`` invocation."""
+    return getattr(args, "format", "text") or "text"
+
+
+def _emit(command: str, payload: dict[str, Any]) -> None:
+    """Print the single JSON document for *command* (JSON mode only)."""
+    document: dict[str, Any] = {"command": command}
+    document.update(payload)
+    emit_json(document)
+
+
+def _fail(
+    command: str,
+    output_format: str,
+    message: str,
+    *,
+    text_lines: list[str] | None = None,
+    **fields: Any,
+) -> int:
+    """Report a failure in the requested format and return exit code 1.
+
+    ``text_lines`` preserves the command's original prose verbatim (several
+    of these paths print without an ``Error:`` prefix); it defaults to the
+    conventional ``Error: <message>`` single line.
+    """
+    if output_format == FORMAT_JSON:
+        payload: dict[str, Any] = {"error": message, "success": False}
+        payload.update(fields)
+        _emit(command, payload)
+        return 1
+    for line in text_lines if text_lines is not None else [f"Error: {message}"]:
+        print(line)
+    return 1
 
 
 def run_ipc_command(args) -> int:
@@ -37,9 +88,13 @@ def _run_status(args) -> int:
 
     Discovers running KiCad instances and reports their status.
     """
+    output_format = _fmt(args)
+
     try:
         from kicad_tools.ipc.discovery import discover_instances, discover_socket
     except ImportError:
+        if output_format == FORMAT_JSON:
+            return _fail("status", output_format, _IPC_MISSING_MSG, ipc_available=False)
         print("Error: IPC dependencies not installed.")
         print("Install with: pip install 'kicad-tools[ipc]'")
         return 1
@@ -49,19 +104,38 @@ def _run_status(args) -> int:
     if socket_path:
         resolved = discover_socket(explicit_path=socket_path)
         if resolved:
-            print(f"Socket found: {resolved}")
-            return _try_connect_and_report(str(resolved))
-        else:
-            print(f"Socket not found at: {socket_path}")
-            return 1
+            if output_format != FORMAT_JSON:
+                print(f"Socket found: {resolved}")
+            return _try_connect_and_report(str(resolved), output_format, instances=[])
+        if output_format == FORMAT_JSON:
+            return _fail(
+                "status",
+                output_format,
+                f"Socket not found at: {socket_path}",
+                socket=str(socket_path),
+                connected=False,
+                instances=[],
+            )
+        print(f"Socket not found at: {socket_path}")
+        return 1
 
     # Auto-discover
     instances = discover_instances()
     if not instances:
         auto_socket = discover_socket()
         if auto_socket:
-            print(f"Socket found: {auto_socket}")
-            return _try_connect_and_report(str(auto_socket))
+            if output_format != FORMAT_JSON:
+                print(f"Socket found: {auto_socket}")
+            return _try_connect_and_report(str(auto_socket), output_format, instances=[])
+        if output_format == FORMAT_JSON:
+            return _fail(
+                "status",
+                output_format,
+                "No running KiCad instances found.",
+                socket=None,
+                connected=False,
+                instances=[],
+            )
         print("No running KiCad instances found.")
         print()
         print("To start KiCad with IPC enabled:")
@@ -71,43 +145,99 @@ def _run_status(args) -> int:
         print("  kct ipc status --socket /path/to/socket")
         return 1
 
-    print(f"Found {len(instances)} KiCad instance(s):")
-    for inst in instances:
-        print(f"  {inst}")
-    print()
+    instance_paths = sorted(str(inst.socket_path) for inst in instances)
+
+    if output_format != FORMAT_JSON:
+        print(f"Found {len(instances)} KiCad instance(s):")
+        for inst in instances:
+            print(f"  {inst}")
+        print()
 
     # Try connecting to the first instance
-    return _try_connect_and_report(str(instances[0].socket_path))
+    return _try_connect_and_report(
+        str(instances[0].socket_path), output_format, instances=instance_paths
+    )
 
 
-def _try_connect_and_report(socket_path: str) -> int:
+def _try_connect_and_report(
+    socket_path: str, output_format: str = "text", instances: list[str] | None = None
+) -> int:
     """Try connecting to KiCad and report status."""
+    instances = instances or []
+
     try:
         from kicad_tools.ipc.client import IPCClient, IPCError
     except ImportError:
+        if output_format == FORMAT_JSON:
+            return _fail(
+                "status",
+                output_format,
+                _PYNNG_MISSING_MSG,
+                socket=socket_path,
+                connected=False,
+                instances=instances,
+            )
         print("Error: pynng not installed.")
         print("Install with: pip install 'kicad-tools[ipc]'")
         return 1
 
-    print(f"Connecting to {socket_path}...")
+    if output_format != FORMAT_JSON:
+        print(f"Connecting to {socket_path}...")
     try:
         with IPCClient(socket_path) as client:
             if client.ping():
                 version = client.get_version()
-                print(f"Connected to KiCad {version}")
                 docs = client.get_open_documents()
+                if output_format == FORMAT_JSON:
+                    _emit(
+                        "status",
+                        {
+                            "socket": socket_path,
+                            "connected": True,
+                            "kicad_version": version,
+                            "instances": instances,
+                            "open_documents": sorted(
+                                str(doc.get("path", "unknown")) for doc in docs
+                            ),
+                            "success": True,
+                        },
+                    )
+                    return 0
+                print(f"Connected to KiCad {version}")
                 if docs:
                     print(f"Open documents: {len(docs)}")
                     for doc in docs:
                         print(f"  {doc.get('path', 'unknown')}")
                 return 0
-            else:
-                print("Connected but KiCad is not responding to health checks.")
-                return 1
+            return _fail(
+                "status",
+                output_format,
+                "Connected but KiCad is not responding to health checks.",
+                text_lines=["Connected but KiCad is not responding to health checks."],
+                socket=socket_path,
+                connected=False,
+                instances=instances,
+            )
     except IPCError as exc:
-        print(f"Connection failed: {exc}")
-        return 1
+        return _fail(
+            "status",
+            output_format,
+            f"Connection failed: {exc}",
+            text_lines=[f"Connection failed: {exc}"],
+            socket=socket_path,
+            connected=False,
+            instances=instances,
+        )
     except ImportError:
+        if output_format == FORMAT_JSON:
+            return _fail(
+                "status",
+                output_format,
+                _PYNNG_MISSING_MSG,
+                socket=socket_path,
+                connected=False,
+                instances=instances,
+            )
         print("Error: pynng not installed.")
         print("Install with: pip install 'kicad-tools[ipc]'")
         return 1
@@ -116,17 +246,28 @@ def _try_connect_and_report(socket_path: str) -> int:
 def _run_connect(args) -> int:
     """Test connection to a running KiCad instance."""
     socket_path = getattr(args, "socket", None)
+    output_format = _fmt(args)
 
     try:
         from kicad_tools.ipc.client import IPCClient, IPCError
         from kicad_tools.ipc.discovery import discover_socket
     except ImportError:
+        if output_format == FORMAT_JSON:
+            return _fail("connect", output_format, _IPC_MISSING_MSG, connected=False)
         print("Error: IPC dependencies not installed.")
         print("Install with: pip install 'kicad-tools[ipc]'")
         return 1
 
     resolved = discover_socket(explicit_path=socket_path)
     if not resolved:
+        if output_format == FORMAT_JSON:
+            return _fail(
+                "connect",
+                output_format,
+                "No KiCad IPC socket found.",
+                socket=str(socket_path) if socket_path else None,
+                connected=False,
+            )
         print("No KiCad IPC socket found.")
         if socket_path:
             print(f"  Checked: {socket_path}")
@@ -136,12 +277,29 @@ def _run_connect(args) -> int:
     try:
         with IPCClient(str(resolved)) as client:
             version = client.get_version()
+            if output_format == FORMAT_JSON:
+                _emit(
+                    "connect",
+                    {
+                        "socket": str(resolved),
+                        "connected": True,
+                        "kicad_version": version,
+                        "success": True,
+                    },
+                )
+                return 0
             print(f"Successfully connected to KiCad {version}")
             print(f"Socket: {resolved}")
             return 0
     except IPCError as exc:
-        print(f"Connection failed: {exc}")
-        return 1
+        return _fail(
+            "connect",
+            output_format,
+            f"Connection failed: {exc}",
+            text_lines=[f"Connection failed: {exc}"],
+            socket=str(resolved),
+            connected=False,
+        )
 
 
 def _run_push_routes(args) -> int:
@@ -150,8 +308,11 @@ def _run_push_routes(args) -> int:
     socket_path = getattr(args, "socket", None)
     net_filter = getattr(args, "net", None)
     dry_run = getattr(args, "dry_run", False)
+    output_format = _fmt(args)
 
     if not pcb_path:
+        if output_format == FORMAT_JSON:
+            return _fail("push-routes", output_format, "PCB file path required.", pushed=0)
         print("Error: PCB file path required.")
         print("Usage: kct ipc push-routes <pcb_file> [--socket PATH] [--net NAME]")
         return 1
@@ -160,6 +321,10 @@ def _run_push_routes(args) -> int:
         from kicad_tools.ipc.client import IPCClient, IPCError
         from kicad_tools.ipc.discovery import discover_socket
     except ImportError:
+        if output_format == FORMAT_JSON:
+            return _fail(
+                "push-routes", output_format, _IPC_MISSING_MSG, pcb=str(pcb_path), pushed=0
+            )
         print("Error: IPC dependencies not installed.")
         print("Install with: pip install 'kicad-tools[ipc]'")
         return 1
@@ -168,6 +333,14 @@ def _run_push_routes(args) -> int:
 
     pcb_file = Path(pcb_path)
     if not pcb_file.exists():
+        if output_format == FORMAT_JSON:
+            return _fail(
+                "push-routes",
+                output_format,
+                f"PCB file not found: {pcb_file}",
+                pcb=str(pcb_file),
+                pushed=0,
+            )
         print(f"Error: PCB file not found: {pcb_file}")
         return 1
 
@@ -175,6 +348,14 @@ def _run_push_routes(args) -> int:
     try:
         from kicad_tools.pcb.parser import parse_pcb
     except ImportError:
+        if output_format == FORMAT_JSON:
+            return _fail(
+                "push-routes",
+                output_format,
+                "PCB parser not available.",
+                pcb=str(pcb_file),
+                pushed=0,
+            )
         print("Error: PCB parser not available.")
         return 1
 
@@ -193,23 +374,45 @@ def _run_push_routes(args) -> int:
             tracks = [t for t in tracks if hasattr(t, "net") and t.net == net_code]
             vias = [v for v in vias if hasattr(v, "net") and v.net == net_code]
 
-    print(f"Found {len(tracks)} tracks and {len(vias)} vias in {pcb_file.name}")
+    # Summary fields shared by every terminal state below.
+    summary: dict[str, Any] = {
+        "pcb": str(pcb_file),
+        "net_filter": net_filter,
+        "tracks": len(tracks),
+        "vias": len(vias),
+        "dry_run": bool(dry_run),
+    }
 
-    if net_filter:
-        print(f"  Filtered to net: {net_filter}")
+    if output_format != FORMAT_JSON:
+        print(f"Found {len(tracks)} tracks and {len(vias)} vias in {pcb_file.name}")
+
+        if net_filter:
+            print(f"  Filtered to net: {net_filter}")
 
     if dry_run:
+        if output_format == FORMAT_JSON:
+            _emit("push-routes", {**summary, "pushed": 0, "success": True})
+            return 0
         print("Dry run -- no changes pushed to KiCad.")
         return 0
 
     if not tracks and not vias:
+        if output_format == FORMAT_JSON:
+            _emit("push-routes", {**summary, "pushed": 0, "success": True})
+            return 0
         print("No tracks or vias to push.")
         return 0
 
     resolved = discover_socket(explicit_path=socket_path)
     if not resolved:
-        print("No KiCad IPC socket found.")
-        return 1
+        return _fail(
+            "push-routes",
+            output_format,
+            "No KiCad IPC socket found.",
+            text_lines=["No KiCad IPC socket found."],
+            **summary,
+            pushed=0,
+        )
 
     try:
         from kicad_tools.ipc.board import BoardOperations
@@ -258,9 +461,26 @@ def _run_push_routes(args) -> int:
                 vias=ipc_vias,
                 description=f"Push routes from {pcb_file.name}",
             )
+            if output_format == FORMAT_JSON:
+                _emit(
+                    "push-routes",
+                    {
+                        **summary,
+                        "socket": str(resolved),
+                        "pushed": len(created),
+                        "success": True,
+                    },
+                )
+                return 0
             print(f"Pushed {len(created)} items to KiCad.")
             return 0
 
     except IPCError as exc:
-        print(f"Error: {exc}")
-        return 1
+        return _fail(
+            "push-routes",
+            output_format,
+            str(exc),
+            **summary,
+            socket=str(resolved),
+            pushed=0,
+        )

--- a/src/kicad_tools/cli/commands/mcp.py
+++ b/src/kicad_tools/cli/commands/mcp.py
@@ -1,10 +1,20 @@
-"""MCP server command handlers."""
+"""MCP server command handlers.
+
+Machine output (``--format json``, issue #4674): ``mcp setup`` prints exactly
+one JSON document describing the client, the config file it targets, the
+server entry it resolved, and whether it wrote (``written`` / ``replaced``) or
+only previewed (``dry_run``).  ``mcp serve`` is exempt -- it is a long-running
+server whose machine contract *is* the MCP protocol.  See
+``docs/reference/machine-output.md``.
+"""
 
 import json
 import os
 import shutil
 import sys
 from pathlib import Path
+
+from ..format_options import FORMAT_JSON, emit_json
 
 __all__ = ["run_mcp_command"]
 
@@ -145,6 +155,7 @@ def _run_setup(args) -> int:
     """
     client = getattr(args, "client", "claude-code")
     dry_run = getattr(args, "dry_run", False)
+    as_json = getattr(args, "format", "text") == FORMAT_JSON
 
     command, cmd_args = _find_kct_command()
 
@@ -160,12 +171,27 @@ def _run_setup(args) -> int:
         config_path = _get_claude_desktop_config_path()
 
     # Show what we'll do
-    print(f"MCP client: {client}")
-    print(f"Config file: {config_path}")
-    print(f"Command: {command} {' '.join(cmd_args)}")
-    print()
+    if not as_json:
+        print(f"MCP client: {client}")
+        print(f"Config file: {config_path}")
+        print(f"Command: {command} {' '.join(cmd_args)}")
+        print()
 
     if dry_run:
+        if as_json:
+            emit_json(
+                {
+                    "command": "setup",
+                    "client": client,
+                    "config_path": str(config_path),
+                    "dry_run": True,
+                    "written": False,
+                    "replaced": False,
+                    "server": server_config,
+                    "success": True,
+                }
+            )
+            return 0
         print("Dry run — no changes made.")
         print()
         print("Would write:")
@@ -184,13 +210,14 @@ def _run_setup(args) -> int:
     if "mcpServers" not in existing:
         existing["mcpServers"] = {}
 
-    if "kicad-tools" in existing["mcpServers"]:
+    replaced = "kicad-tools" in existing["mcpServers"]
+    if replaced and not as_json:
         old = existing["mcpServers"]["kicad-tools"]
         old_cmd = f"{old.get('command', '')} {' '.join(old.get('args', []))}"
         print("Replacing existing kicad-tools config:")
         print(f"  was: {old_cmd}")
         print(f"  now: {command} {' '.join(cmd_args)}")
-    else:
+    elif not replaced and not as_json:
         print("Adding kicad-tools MCP server config.")
 
     existing["mcpServers"]["kicad-tools"] = server_config
@@ -198,6 +225,21 @@ def _run_setup(args) -> int:
     # Write config
     config_path.parent.mkdir(parents=True, exist_ok=True)
     config_path.write_text(json.dumps(existing, indent=2) + "\n")
+
+    if as_json:
+        emit_json(
+            {
+                "command": "setup",
+                "client": client,
+                "config_path": str(config_path),
+                "dry_run": False,
+                "written": True,
+                "replaced": replaced,
+                "server": server_config,
+                "success": True,
+            }
+        )
+        return 0
 
     print()
     print(f"Wrote {config_path}")

--- a/src/kicad_tools/cli/config_cmd.py
+++ b/src/kicad_tools/cli/config_cmd.py
@@ -8,12 +8,20 @@ Usage:
     kct config --init          Create template config file
     kct config get <key>       Get a specific config value
     kct config set <key> <value>  Set a config value (requires manual edit)
+
+Machine output (``--format json``, issue #4674): every mode prints exactly one
+JSON document on stdout, keyed by ``command`` (always ``"config"``) and
+``action`` (``show`` / ``paths`` / ``init`` / ``get`` / ``set``).  Failures
+carry an ``error`` string with the exit code unchanged.  See
+``docs/reference/machine-output.md``.
 """
 
 import argparse
 import sys
 from pathlib import Path
+from typing import Any
 
+from kicad_tools.cli.format_options import FORMAT_JSON, add_format_flag, emit_json
 from kicad_tools.config import (
     CONFIG_FILENAMES,
     USER_CONFIG_PATH,
@@ -23,6 +31,33 @@ from kicad_tools.config import (
     get_config_paths,
 )
 from kicad_tools.utils import ensure_parent_dir
+
+#: Sections and keys rendered by ``--show``, in display order.  Single source
+#: of truth so the prose table and the JSON document can never drift.
+_SHOWN_SECTIONS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("defaults", ("format", "manufacturer", "verbose", "quiet")),
+    ("drc", ("strict", "layers")),
+    ("export", ("output_dir", "include_dnp")),
+    (
+        "route",
+        (
+            "strategy",
+            "grid_resolution",
+            "trace_width",
+            "clearance",
+            "via_drill",
+            "via_diameter",
+        ),
+    ),
+    ("parts", ("cache_dir", "cache_ttl_days")),
+)
+
+#: C++ native backends probed by ``--show``.
+_NATIVE_BACKENDS: tuple[tuple[str, str], ...] = (
+    ("router", "kicad_tools.router.cpp_backend"),
+    ("placement", "kicad_tools.placement.cpp_backend"),
+    ("drc", "kicad_tools.drc.cpp_backend"),
+)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -74,112 +109,124 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Use user config (~/.config/kicad-tools/config.toml) for --init",
     )
+    add_format_flag(parser)
 
     args = parser.parse_args(argv)
+    fmt = getattr(args, "format", "text")
 
     try:
         if args.show:
-            return _show_config()
+            return _show_config(fmt)
         elif args.init:
-            return _init_config(args.user)
+            return _init_config(args.user, fmt)
         elif args.paths:
-            return _show_paths()
+            return _show_paths(fmt)
         elif args.action == "get":
             if not args.key:
-                print("Error: 'get' requires a key argument", file=sys.stderr)
-                return 1
-            return _get_config(args.key)
+                return _fail("get", "'get' requires a key argument", fmt)
+            return _get_config(args.key, fmt)
         elif args.action == "set":
             if not args.key or not args.value:
-                print("Error: 'set' requires key and value arguments", file=sys.stderr)
-                return 1
-            return _set_config(args.key, args.value)
+                return _fail("set", "'set' requires key and value arguments", fmt)
+            return _set_config(args.key, args.value, fmt)
         else:
             # Default to showing config
-            return _show_config()
+            return _show_config(fmt)
 
     except ConfigError as e:
-        print(f"Error: {e}", file=sys.stderr)
+        action = args.action or ("init" if args.init else "paths" if args.paths else "show")
+        return _fail(action, str(e), fmt)
+
+
+def _fail(action: str, message: str, output_format: str, **fields: Any) -> int:
+    """Report a failure in the requested format and return exit code 1."""
+    if output_format == FORMAT_JSON:
+        payload: dict[str, Any] = {
+            "command": "config",
+            "action": action,
+            "error": message,
+            "success": False,
+        }
+        payload.update(fields)
+        emit_json(payload)
         return 1
 
+    print(f"Error: {message}", file=sys.stderr)
+    return 1
 
-def _show_config() -> int:
+
+def _show_config(output_format: str = "text") -> int:
     """Show effective configuration with sources."""
     config = Config.load()
+
+    sections: dict[str, dict[str, dict[str, Any]]] = {}
+    for section, keys in _SHOWN_SECTIONS:
+        section_obj = getattr(config, section)
+        sections[section] = {
+            key: {
+                "value": getattr(section_obj, key),
+                "source": config.get_source(f"{section}.{key}"),
+            }
+            for key in keys
+        }
+
+    backends = _native_backend_status()
+
+    if output_format == FORMAT_JSON:
+        emit_json(
+            {
+                "command": "config",
+                "action": "show",
+                "sections": sections,
+                "native_backends": backends,
+                "success": True,
+            }
+        )
+        return 0
 
     print("# Effective kicad-tools configuration")
     print()
 
-    # Show defaults section
-    print("[defaults]")
-    _print_value("format", config.defaults.format, config.get_source("defaults.format"))
-    _print_value(
-        "manufacturer", config.defaults.manufacturer, config.get_source("defaults.manufacturer")
-    )
-    _print_value("verbose", config.defaults.verbose, config.get_source("defaults.verbose"))
-    _print_value("quiet", config.defaults.quiet, config.get_source("defaults.quiet"))
-    print()
-
-    # Show drc section
-    print("[drc]")
-    _print_value("strict", config.drc.strict, config.get_source("drc.strict"))
-    _print_value("layers", config.drc.layers, config.get_source("drc.layers"))
-    print()
-
-    # Show export section
-    print("[export]")
-    _print_value("output_dir", config.export.output_dir, config.get_source("export.output_dir"))
-    _print_value("include_dnp", config.export.include_dnp, config.get_source("export.include_dnp"))
-    print()
-
-    # Show route section
-    print("[route]")
-    _print_value("strategy", config.route.strategy, config.get_source("route.strategy"))
-    _print_value(
-        "grid_resolution", config.route.grid_resolution, config.get_source("route.grid_resolution")
-    )
-    _print_value("trace_width", config.route.trace_width, config.get_source("route.trace_width"))
-    _print_value("clearance", config.route.clearance, config.get_source("route.clearance"))
-    _print_value("via_drill", config.route.via_drill, config.get_source("route.via_drill"))
-    _print_value("via_diameter", config.route.via_diameter, config.get_source("route.via_diameter"))
-    print()
-
-    # Show parts section
-    print("[parts]")
-    _print_value("cache_dir", config.parts.cache_dir, config.get_source("parts.cache_dir"))
-    _print_value(
-        "cache_ttl_days", config.parts.cache_ttl_days, config.get_source("parts.cache_ttl_days")
-    )
-    print()
+    for section, keys in _SHOWN_SECTIONS:
+        print(f"[{section}]")
+        for key in keys:
+            entry = sections[section][key]
+            _print_value(key, entry["value"], entry["source"])
+        print()
 
     # Show native backend status
     print("[native_backends]")
-    _print_native_backend_status()
+    _print_native_backend_status(backends)
 
     return 0
 
 
-def _print_native_backend_status() -> None:
-    """Print status of C++ native backends."""
-    backends = {
-        "router": ("kicad_tools.router.cpp_backend", "router"),
-        "placement": ("kicad_tools.placement.cpp_backend", "placement"),
-        "drc": ("kicad_tools.drc.cpp_backend", "drc"),
-    }
-    any_missing = False
-    for name, (module_path, _label) in backends.items():
+def _native_backend_status() -> dict[str, dict[str, Any]]:
+    """Probe the C++ native backends and return their status per backend."""
+    status: dict[str, dict[str, Any]] = {}
+    for name, module_path in _NATIVE_BACKENDS:
         try:
             import importlib
 
             mod = importlib.import_module(module_path)
             info = mod.get_backend_info()
-            if info.get("available"):
-                version = info.get("version", "unknown")
-                print(f'{name} = "cpp v{version}"  # installed')
-            else:
-                print(f'{name} = "python (fallback)"  # NOT installed')
-                any_missing = True
+            available = bool(info.get("available"))
+            status[name] = {
+                "available": available,
+                "version": str(info.get("version", "unknown")) if available else None,
+            }
         except Exception:
+            status[name] = {"available": False, "version": None}
+    return status
+
+
+def _print_native_backend_status(backends: dict[str, dict[str, Any]]) -> None:
+    """Print status of C++ native backends."""
+    any_missing = False
+    for name, info in backends.items():
+        if info["available"]:
+            print(f'{name} = "cpp v{info["version"]}"  # installed')
+        else:
             print(f'{name} = "python (fallback)"  # NOT installed')
             any_missing = True
     if any_missing:
@@ -207,9 +254,28 @@ def _print_value(key: str, value, source: str) -> None:
     print(f"{key} = {formatted}  # from: {source_display}")
 
 
-def _show_paths() -> int:
+def _show_paths(output_format: str = "text") -> int:
     """Show config file paths."""
     paths = get_config_paths()
+
+    if output_format == FORMAT_JSON:
+        emit_json(
+            {
+                "command": "config",
+                "action": "paths",
+                "project_config": {
+                    "path": str(paths["project"]) if paths["project"] else None,
+                    "exists": bool(paths["project"]),
+                    "search_filenames": sorted(CONFIG_FILENAMES),
+                },
+                "user_config": {
+                    "path": str(USER_CONFIG_PATH),
+                    "exists": bool(paths["user"]),
+                },
+                "success": True,
+            }
+        )
+        return 0
 
     print("Config file paths:")
     print()
@@ -230,7 +296,7 @@ def _show_paths() -> int:
     return 0
 
 
-def _init_config(user: bool = False) -> int:
+def _init_config(user: bool = False, output_format: str = "text") -> int:
     """Create a template config file."""
     if user:
         target = USER_CONFIG_PATH
@@ -238,7 +304,18 @@ def _init_config(user: bool = False) -> int:
     else:
         target = Path.cwd() / CONFIG_FILENAMES[0]  # .kicad-tools.toml
 
+    scope = "user" if user else "project"
+
     if target.exists():
+        if output_format == FORMAT_JSON:
+            return _fail(
+                "init",
+                f"Config file already exists: {target}",
+                output_format,
+                path=str(target),
+                scope=scope,
+                created=False,
+            )
         print(f"Error: Config file already exists: {target}", file=sys.stderr)
         print("Remove it first or edit manually.", file=sys.stderr)
         return 1
@@ -247,41 +324,78 @@ def _init_config(user: bool = False) -> int:
 
     try:
         target.write_text(template)
-        print(f"Created config template: {target}")
-        print()
-        print("Edit the file to customize your settings.")
-        print("Uncomment and modify values as needed.")
-        return 0
     except OSError as e:
+        if output_format == FORMAT_JSON:
+            return _fail(
+                "init",
+                f"Error writing config file: {e}",
+                output_format,
+                path=str(target),
+                scope=scope,
+                created=False,
+            )
         print(f"Error writing config file: {e}", file=sys.stderr)
         return 1
 
+    if output_format == FORMAT_JSON:
+        emit_json(
+            {
+                "command": "config",
+                "action": "init",
+                "path": str(target),
+                "scope": scope,
+                "created": True,
+                "success": True,
+            }
+        )
+        return 0
 
-def _get_config(key: str) -> int:
+    print(f"Created config template: {target}")
+    print()
+    print("Edit the file to customize your settings.")
+    print("Uncomment and modify values as needed.")
+    return 0
+
+
+def _get_config(key: str, output_format: str = "text") -> int:
     """Get a specific config value."""
     config = Config.load()
 
     # Parse the key (e.g., "defaults.format")
     parts = key.split(".")
     if len(parts) != 2:
-        print(f"Error: Invalid key format '{key}'. Use 'section.key' format.", file=sys.stderr)
-        return 1
+        return _fail(
+            "get", f"Invalid key format '{key}'. Use 'section.key' format.", output_format, key=key
+        )
 
     section, attr = parts
 
     # Get the section object
     section_obj = getattr(config, section, None)
     if section_obj is None:
-        print(f"Error: Unknown config section '{section}'", file=sys.stderr)
-        return 1
+        return _fail("get", f"Unknown config section '{section}'", output_format, key=key)
 
     # Get the value
     if not hasattr(section_obj, attr):
-        print(f"Error: Unknown key '{attr}' in section '{section}'", file=sys.stderr)
-        return 1
+        return _fail("get", f"Unknown key '{attr}' in section '{section}'", output_format, key=key)
 
     value = getattr(section_obj, attr)
     source = config.get_source(key)
+
+    if output_format == FORMAT_JSON:
+        emit_json(
+            {
+                "command": "config",
+                "action": "get",
+                "key": key,
+                "section": section,
+                "option": attr,
+                "value": value,
+                "source": source,
+                "success": True,
+            }
+        )
+        return 0
 
     if value is None:
         print("# not set")
@@ -299,7 +413,7 @@ def _get_config(key: str) -> int:
     return 0
 
 
-def _set_config(key: str, value: str) -> int:
+def _set_config(key: str, value: str, output_format: str = "text") -> int:
     """
     Guide user to set a config value.
 
@@ -309,8 +423,9 @@ def _set_config(key: str, value: str) -> int:
     # Parse the key
     parts = key.split(".")
     if len(parts) != 2:
-        print(f"Error: Invalid key format '{key}'. Use 'section.key' format.", file=sys.stderr)
-        return 1
+        return _fail(
+            "set", f"Invalid key format '{key}'. Use 'section.key' format.", output_format, key=key
+        )
 
     section, attr = parts
 
@@ -318,13 +433,11 @@ def _set_config(key: str, value: str) -> int:
     config = Config.load()
     section_obj = getattr(config, section, None)
     if section_obj is None:
-        print(f"Error: Unknown config section '{section}'", file=sys.stderr)
-        return 1
+        return _fail("set", f"Unknown config section '{section}'", output_format, key=key)
 
     # Validate key exists
     if not hasattr(section_obj, attr):
-        print(f"Error: Unknown key '{attr}' in section '{section}'", file=sys.stderr)
-        return 1
+        return _fail("set", f"Unknown key '{attr}' in section '{section}'", output_format, key=key)
 
     # Get current value type for formatting
     current = getattr(section_obj, attr)
@@ -336,28 +449,44 @@ def _set_config(key: str, value: str) -> int:
         elif value.lower() in ("false", "0", "no"):
             formatted = "false"
         else:
-            print(f"Error: Invalid boolean value '{value}'", file=sys.stderr)
-            return 1
+            return _fail("set", f"Invalid boolean value '{value}'", output_format, key=key)
     elif isinstance(current, int):
         try:
             int(value)
             formatted = value
         except ValueError:
-            print(f"Error: Invalid integer value '{value}'", file=sys.stderr)
-            return 1
+            return _fail("set", f"Invalid integer value '{value}'", output_format, key=key)
     elif isinstance(current, float):
         try:
             float(value)
             formatted = value
         except ValueError:
-            print(f"Error: Invalid float value '{value}'", file=sys.stderr)
-            return 1
+            return _fail("set", f"Invalid float value '{value}'", output_format, key=key)
     else:
         formatted = f'"{value}"'
 
     # Show what to add
     paths = get_config_paths()
     project_config = paths["project"] or Path.cwd() / CONFIG_FILENAMES[0]
+
+    if output_format == FORMAT_JSON:
+        # `set` never writes: it reports the TOML the user must add.  The
+        # `applied: false` key makes that explicit for machine callers.
+        emit_json(
+            {
+                "command": "config",
+                "action": "set",
+                "key": key,
+                "section": section,
+                "option": attr,
+                "value": formatted,
+                "applied": False,
+                "config_file": str(project_config),
+                "toml": f"[{section}]\n{attr} = {formatted}",
+                "success": True,
+            }
+        )
+        return 0
 
     print(f"To set {key} = {formatted}, add to your config file:")
     print()

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -5829,6 +5829,7 @@ def _add_config_parser(subparsers) -> None:
         nargs="?",
         help="Value to set",
     )
+    add_format_flag(config_parser)
 
 
 def _add_optimize_placement_parser(subparsers) -> None:
@@ -7265,6 +7266,7 @@ def _add_mcp_parser(subparsers) -> None:
         action="store_true",
         help="Show what would be written without making changes",
     )
+    add_format_flag(setup_parser)
 
 
 def _add_ipc_parser(subparsers) -> None:
@@ -7290,6 +7292,7 @@ def _add_ipc_parser(subparsers) -> None:
         "-s",
         help="Explicit path to KiCad IPC socket (auto-discovered if not provided)",
     )
+    add_format_flag(status_parser)
 
     # ipc connect subcommand
     connect_parser = ipc_subparsers.add_parser(
@@ -7302,6 +7305,7 @@ def _add_ipc_parser(subparsers) -> None:
         "-s",
         help="Explicit path to KiCad IPC socket (auto-discovered if not provided)",
     )
+    add_format_flag(connect_parser)
 
     # ipc push-routes subcommand
     push_parser = ipc_subparsers.add_parser(
@@ -7332,6 +7336,7 @@ def _add_ipc_parser(subparsers) -> None:
         action="store_true",
         help="Show what would be pushed without actually connecting to KiCad",
     )
+    add_format_flag(push_parser)
 
 
 def _add_init_parser(subparsers) -> None:

--- a/tests/test_format_json_sweep_env.py
+++ b/tests/test_format_json_sweep_env.py
@@ -1,0 +1,614 @@
+"""Tests for the #4674 machine-output sweep (environment/integration batch).
+
+Issue #4674 (mechanical follow-up to #4543) adds the canonical
+``--format json`` idiom to the prose-only subcommands.  Batch 1 swept the
+grouped families (``tests/test_format_json_sweep.py``), batch 2 the 16
+mutating ``sch`` leaves (``tests/test_format_json_sweep_sch.py``) and batch 3
+the four families' holdouts (``tests/test_format_json_sweep_families.py``).
+
+**This batch sweeps the environment/integration singles** -- the five leaves
+that report on or configure ``kct``'s surroundings rather than a board file:
+
+* ``config``          -- all five modes (``--show`` / ``--paths`` / ``--init``
+                         / ``get`` / ``set``) plus the bare default
+* ``ipc status``      -- socket discovery + live-KiCad handshake
+* ``ipc connect``     -- connection probe
+* ``ipc push-routes`` -- track/via push summary
+* ``mcp setup``       -- MCP client config wiring
+
+It finishes the ``ipc`` family outright and finishes ``mcp`` (``mcp serve`` is
+on the #4543 exemption list -- a long-running server whose machine contract is
+the MCP protocol itself).
+
+Same conventions as the three sibling modules (a separate file per batch so
+concurrent batches never conflict on a shared ``SWEPT_SURFACES`` literal):
+
+* Outer-parser surface: every swept leaf accepts ``--format`` with a ``json``
+  choice, and the default stays ``text``.
+* Shim forwarding: the outer ``--format json`` reaches the inner parser argv
+  for the argv-reserializing ``config`` shim -- the drift bug class
+  ``tests/test_cli_parser_drift.py`` exists for -- and the default (text)
+  invocation must NOT forward it.
+* Emission: a single valid JSON document on stdout, byte-identical across two
+  runs on the same input, structure assertions rather than byte-golden
+  payloads, ``{"error": ...}`` documents on failure with exit codes unchanged.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kicad_tools.cli.parser import create_parser
+
+FIXTURES = Path(__file__).parent / "fixtures"
+BOARD = FIXTURES / "routing-diagnostic.kicad_pcb"
+
+# Every subcommand swept by this batch, as (command path, minimal extra argv).
+SWEPT_SURFACES: dict[str, list[str]] = {
+    "config": [],
+    "ipc connect": [],
+    "ipc push-routes": ["board.kicad_pcb"],
+    "ipc status": [],
+    "mcp setup": [],
+}
+
+
+def _iter_leaves(parser, path=()):
+    subactions = [a for a in parser._actions if isinstance(a, argparse._SubParsersAction)]
+    if not subactions:
+        yield path, parser
+        return
+    for subaction in subactions:
+        for name, sub in subaction.choices.items():
+            yield from _iter_leaves(sub, (*path, name))
+
+
+@pytest.fixture(scope="module")
+def leaves():
+    return {" ".join(path): leaf for path, leaf in _iter_leaves(create_parser())}
+
+
+# ---------------------------------------------------------------------------
+# Outer-parser surface guard
+# ---------------------------------------------------------------------------
+
+
+class TestOuterSurface:
+    @pytest.mark.parametrize("command", sorted(SWEPT_SURFACES))
+    def test_leaf_has_format_json_choice(self, leaves, command):
+        """Each swept leaf declares --format with a json choice."""
+        leaf = leaves.get(command)
+        assert leaf is not None, f"outer parser has no leaf {command!r}"
+        for action in leaf._actions:
+            if "--format" in action.option_strings:
+                assert action.choices and "json" in action.choices, (
+                    f"kct {command} has --format without a 'json' choice "
+                    f"(choices={action.choices}); regresses #4674"
+                )
+                break
+        else:
+            pytest.fail(f"kct {command} lost its --format flag (regresses #4674)")
+
+    @pytest.mark.parametrize("command", sorted(SWEPT_SURFACES))
+    def test_parse_accepts_format_json(self, command):
+        """`kct <command> ... --format json` parses on the real outer parser."""
+        argv = [*command.split(), *SWEPT_SURFACES[command], "--format", "json"]
+        args = create_parser().parse_args(argv)
+        assert args.format == "json"
+
+    @pytest.mark.parametrize("command", sorted(SWEPT_SURFACES))
+    def test_default_format_is_text(self, command):
+        """The default stays text, so no existing invocation changes shape."""
+        args = create_parser().parse_args([*command.split(), *SWEPT_SURFACES[command]])
+        assert args.format == "text"
+
+    def test_mcp_serve_stays_exempt(self, leaves):
+        """`mcp serve` is on the #4543 exemption list, so it gains no flag."""
+        serve = leaves["mcp serve"]
+        assert not any("--format" in a.option_strings for a in serve._actions)
+
+
+# ---------------------------------------------------------------------------
+# Shim forwarding (outer --format json must reach the inner parser argv)
+# ---------------------------------------------------------------------------
+
+
+class TestConfigShimForwarding:
+    def test_shim_forwards_format(self):
+        from kicad_tools.cli.commands.config import run_config_command
+
+        args = create_parser().parse_args(["config", "--show", "--format", "json"])
+        with patch("kicad_tools.cli.config_cmd.main", return_value=0) as inner:
+            assert run_config_command(args) == 0
+        sub_argv = inner.call_args[0][0]
+        assert "--format" in sub_argv, f"config shim dropped --format: {sub_argv}"
+        assert sub_argv[sub_argv.index("--format") + 1] == "json"
+
+    def test_shim_forwards_format_with_positional_action(self):
+        """`config get <key> --format json` keeps both the flag and the argv."""
+        from kicad_tools.cli.commands.config import run_config_command
+
+        args = create_parser().parse_args(["config", "get", "defaults.format", "--format", "json"])
+        with patch("kicad_tools.cli.config_cmd.main", return_value=0) as inner:
+            assert run_config_command(args) == 0
+        sub_argv = inner.call_args[0][0]
+        assert sub_argv[sub_argv.index("--format") + 1] == "json"
+        assert "get" in sub_argv and "defaults.format" in sub_argv
+
+    def test_shim_omits_format_for_text_default(self):
+        """Default (text) invocations must not forward --format (behaviour pin)."""
+        from kicad_tools.cli.commands.config import run_config_command
+
+        args = create_parser().parse_args(["config", "--show"])
+        with patch("kicad_tools.cli.config_cmd.main", return_value=0) as inner:
+            assert run_config_command(args) == 0
+        assert "--format" not in inner.call_args[0][0]
+
+
+# ---------------------------------------------------------------------------
+# config emission
+# ---------------------------------------------------------------------------
+
+
+def _run_config(argv, capsys):
+    from kicad_tools.cli.commands.config import run_config_command
+
+    rc = run_config_command(create_parser().parse_args(argv))
+    return rc, capsys.readouterr().out
+
+
+@pytest.fixture
+def isolated_cwd(tmp_path, monkeypatch):
+    """Run inside an empty directory so no project config leaks in."""
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+class TestConfigEmission:
+    def test_show_document(self, isolated_cwd, capsys):
+        rc, out = _run_config(["config", "--show", "--format", "json"], capsys)
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["command"] == "config"
+        assert payload["action"] == "show"
+        assert payload["success"] is True
+        # Every advertised section is present, each key carrying value+source.
+        for section in ("defaults", "drc", "export", "route", "parts"):
+            assert section in payload["sections"], section
+        entry = payload["sections"]["route"]["clearance"]
+        assert set(entry) == {"value", "source"}
+        assert set(payload["native_backends"]) == {"router", "placement", "drc"}
+        for info in payload["native_backends"].values():
+            assert set(info) == {"available", "version"}
+
+    def test_bare_config_defaults_to_show(self, isolated_cwd, capsys):
+        """`kct config --format json` (no mode) emits the show document."""
+        rc, out = _run_config(["config", "--format", "json"], capsys)
+        assert rc == 0
+        assert json.loads(out)["action"] == "show"
+
+    def test_show_is_deterministic(self, isolated_cwd, capsys):
+        argv = ["config", "--show", "--format", "json"]
+        _, first = _run_config(argv, capsys)
+        _, second = _run_config(argv, capsys)
+        assert first == second
+
+    def test_paths_document(self, isolated_cwd, capsys):
+        rc, out = _run_config(["config", "--paths", "--format", "json"], capsys)
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["action"] == "paths"
+        assert payload["project_config"]["exists"] is False
+        assert payload["project_config"]["path"] is None
+        assert ".kicad-tools.toml" in payload["project_config"]["search_filenames"]
+        assert payload["project_config"]["search_filenames"] == sorted(
+            payload["project_config"]["search_filenames"]
+        )
+        assert isinstance(payload["user_config"]["path"], str)
+        assert isinstance(payload["user_config"]["exists"], bool)
+
+    def test_get_document(self, isolated_cwd, capsys):
+        rc, out = _run_config(["config", "get", "route.clearance", "--format", "json"], capsys)
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["action"] == "get"
+        assert payload["key"] == "route.clearance"
+        assert payload["section"] == "route"
+        assert payload["option"] == "clearance"
+        assert payload["source"] == "default"
+        assert payload["success"] is True
+        assert "value" in payload
+
+    @pytest.mark.parametrize(
+        "key,fragment",
+        [
+            ("bogus", "Invalid key format"),
+            ("nosuch.key", "Unknown config section"),
+            ("route.nosuch", "Unknown key"),
+        ],
+    )
+    def test_get_errors_are_documents(self, isolated_cwd, capsys, key, fragment):
+        rc, out = _run_config(["config", "get", key, "--format", "json"], capsys)
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["action"] == "get"
+        assert payload["success"] is False
+        assert fragment in payload["error"]
+        assert payload["key"] == key
+
+    def test_set_document_reports_it_did_not_write(self, isolated_cwd, capsys):
+        rc, out = _run_config(["config", "set", "drc.strict", "yes", "--format", "json"], capsys)
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["action"] == "set"
+        assert payload["applied"] is False, "config set never writes; say so structurally"
+        assert payload["value"] == "true"
+        assert payload["toml"] == "[drc]\nstrict = true"
+        assert payload["config_file"].endswith(".kicad-tools.toml")
+        assert not list(isolated_cwd.glob("*.toml")), "config set must not write a file"
+
+    def test_set_invalid_value_is_document(self, isolated_cwd, capsys):
+        rc, out = _run_config(["config", "set", "drc.strict", "maybe", "--format", "json"], capsys)
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["success"] is False
+        assert "Invalid boolean value" in payload["error"]
+
+    def test_init_document(self, isolated_cwd, capsys):
+        rc, out = _run_config(["config", "--init", "--format", "json"], capsys)
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["action"] == "init"
+        assert payload["created"] is True
+        assert payload["scope"] == "project"
+        assert Path(payload["path"]).exists()
+
+    def test_init_existing_file_is_document(self, isolated_cwd, capsys):
+        _run_config(["config", "--init", "--format", "json"], capsys)
+        rc, out = _run_config(["config", "--init", "--format", "json"], capsys)
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["created"] is False
+        assert payload["success"] is False
+        assert "already exists" in payload["error"]
+
+    @pytest.mark.parametrize(
+        "argv,fragment",
+        [
+            (["config", "--show"], "# Effective kicad-tools configuration"),
+            (["config", "--paths"], "Config file paths:"),
+            (["config", "set", "drc.strict", "yes"], "add to your config file:"),
+        ],
+    )
+    def test_text_mode_still_prints_prose(self, isolated_cwd, capsys, argv, fragment):
+        """Text mode still prints prose, unchanged by this batch."""
+        rc, out = _run_config(argv, capsys)
+        assert rc == 0
+        assert fragment in out
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(out)
+
+    def test_text_mode_get_prints_the_bare_value(self, isolated_cwd, capsys):
+        """`config get` prints the raw value (a scalar, not a document)."""
+        rc, out = _run_config(["config", "get", "route.strategy"], capsys)
+        assert rc == 0
+        assert out.strip() and not out.lstrip().startswith("{")
+
+
+# ---------------------------------------------------------------------------
+# ipc emission
+# ---------------------------------------------------------------------------
+
+
+def _run_ipc(argv, capsys):
+    from kicad_tools.cli.commands.ipc import run_ipc_command
+
+    rc = run_ipc_command(create_parser().parse_args(argv))
+    return rc, capsys.readouterr().out
+
+
+def _fake_client(version="9.0.1", docs=None, ping=True):
+    """A context-manager mock standing in for :class:`IPCClient`."""
+    client = MagicMock()
+    client.ping.return_value = ping
+    client.get_version.return_value = version
+    client.get_open_documents.return_value = docs if docs is not None else []
+    factory = MagicMock()
+    factory.return_value.__enter__.return_value = client
+    factory.return_value.__exit__.return_value = False
+    return factory
+
+
+class TestIpcStatusEmission:
+    def test_no_instances_is_error_document(self, capsys):
+        with (
+            patch("kicad_tools.ipc.discovery.discover_instances", return_value=[]),
+            patch("kicad_tools.ipc.discovery.discover_socket", return_value=None),
+        ):
+            rc, out = _run_ipc(["ipc", "status", "--format", "json"], capsys)
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["command"] == "status"
+        assert payload["connected"] is False
+        assert payload["success"] is False
+        assert payload["instances"] == []
+        assert "No running KiCad instances" in payload["error"]
+
+    def test_explicit_socket_not_found_is_error_document(self, capsys):
+        with patch("kicad_tools.ipc.discovery.discover_socket", return_value=None):
+            rc, out = _run_ipc(
+                ["ipc", "status", "--socket", "/nope/kicad.sock", "--format", "json"], capsys
+            )
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["socket"] == "/nope/kicad.sock"
+        assert "Socket not found" in payload["error"]
+
+    def test_connected_document(self, capsys):
+        docs = [{"path": "/b/second.kicad_pcb"}, {"path": "/a/first.kicad_sch"}]
+        with (
+            patch("kicad_tools.ipc.discovery.discover_socket", return_value="/tmp/k.sock"),
+            patch("kicad_tools.ipc.client.IPCClient", _fake_client(docs=docs)),
+        ):
+            rc, out = _run_ipc(
+                ["ipc", "status", "--socket", "/tmp/k.sock", "--format", "json"], capsys
+            )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["command"] == "status"
+        assert payload["connected"] is True
+        assert payload["kicad_version"] == "9.0.1"
+        assert payload["socket"] == "/tmp/k.sock"
+        # Collections are sorted so the document is deterministic (#4674).
+        assert payload["open_documents"] == ["/a/first.kicad_sch", "/b/second.kicad_pcb"]
+        assert payload["success"] is True
+
+    def test_connected_document_is_deterministic(self, capsys):
+        docs = [{"path": "/b/second.kicad_pcb"}, {"path": "/a/first.kicad_sch"}]
+        argv = ["ipc", "status", "--socket", "/tmp/k.sock", "--format", "json"]
+        with (
+            patch("kicad_tools.ipc.discovery.discover_socket", return_value="/tmp/k.sock"),
+            patch("kicad_tools.ipc.client.IPCClient", _fake_client(docs=docs)),
+        ):
+            _, first = _run_ipc(argv, capsys)
+            _, second = _run_ipc(argv, capsys)
+        assert first == second
+
+    def test_unhealthy_instance_is_error_document(self, capsys):
+        with (
+            patch("kicad_tools.ipc.discovery.discover_socket", return_value="/tmp/k.sock"),
+            patch("kicad_tools.ipc.client.IPCClient", _fake_client(ping=False)),
+        ):
+            rc, out = _run_ipc(
+                ["ipc", "status", "--socket", "/tmp/k.sock", "--format", "json"], capsys
+            )
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["connected"] is False
+        assert "health checks" in payload["error"]
+
+    def test_text_mode_is_not_json(self, capsys):
+        with (
+            patch("kicad_tools.ipc.discovery.discover_instances", return_value=[]),
+            patch("kicad_tools.ipc.discovery.discover_socket", return_value=None),
+        ):
+            rc, out = _run_ipc(["ipc", "status"], capsys)
+        assert rc == 1
+        assert "No running KiCad instances found." in out
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(out)
+
+
+class TestIpcConnectEmission:
+    def test_no_socket_is_error_document(self, capsys):
+        with patch("kicad_tools.ipc.discovery.discover_socket", return_value=None):
+            rc, out = _run_ipc(["ipc", "connect", "--format", "json"], capsys)
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["command"] == "connect"
+        assert payload["connected"] is False
+        assert payload["socket"] is None
+        assert "No KiCad IPC socket found" in payload["error"]
+
+    def test_connected_document(self, capsys):
+        with (
+            patch("kicad_tools.ipc.discovery.discover_socket", return_value="/tmp/k.sock"),
+            patch("kicad_tools.ipc.client.IPCClient", _fake_client(version="9.0.2")),
+        ):
+            rc, out = _run_ipc(["ipc", "connect", "--format", "json"], capsys)
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["connected"] is True
+        assert payload["kicad_version"] == "9.0.2"
+        assert payload["socket"] == "/tmp/k.sock"
+        assert payload["success"] is True
+
+    def test_connection_failure_is_error_document(self, capsys):
+        from kicad_tools.ipc.client import IPCError
+
+        factory = MagicMock()
+        factory.return_value.__enter__.side_effect = IPCError("socket refused")
+        with (
+            patch("kicad_tools.ipc.discovery.discover_socket", return_value="/tmp/k.sock"),
+            patch("kicad_tools.ipc.client.IPCClient", factory),
+        ):
+            rc, out = _run_ipc(["ipc", "connect", "--format", "json"], capsys)
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["success"] is False
+        assert "socket refused" in payload["error"]
+
+    def test_text_mode_is_not_json(self, capsys):
+        with patch("kicad_tools.ipc.discovery.discover_socket", return_value=None):
+            rc, out = _run_ipc(["ipc", "connect"], capsys)
+        assert rc == 1
+        assert "No KiCad IPC socket found." in out
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(out)
+
+
+class TestIpcPushRoutesEmission:
+    def test_missing_board_is_error_document(self, tmp_path, capsys):
+        rc, out = _run_ipc(
+            ["ipc", "push-routes", str(tmp_path / "nope.kicad_pcb"), "--format", "json"],
+            capsys,
+        )
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["command"] == "push-routes"
+        assert payload["success"] is False
+        assert payload["pushed"] == 0
+        assert "not found" in payload["error"]
+
+    def test_dry_run_document(self, capsys):
+        """A real board yields one well-formed document either way.
+
+        ``push-routes`` imports ``kicad_tools.pcb.parser``, a module that does
+        not exist (dead since #2363), so today every existing board short-
+        circuits into the "PCB parser not available." branch -- which this
+        batch turns from prose into a structured document.  The assertions are
+        written to hold both before and after that unrelated bug is fixed.
+        """
+        rc, out = _run_ipc(
+            ["ipc", "push-routes", str(BOARD), "--dry-run", "--format", "json"], capsys
+        )
+        payload = json.loads(out)
+        assert payload["command"] == "push-routes"
+        assert payload["pcb"] == str(BOARD)
+        assert payload["pushed"] == 0
+        if payload["success"]:
+            assert rc == 0
+            assert payload["dry_run"] is True
+            assert payload["net_filter"] is None
+            assert isinstance(payload["tracks"], int)
+            assert isinstance(payload["vias"], int)
+        else:
+            assert rc == 1
+            assert payload["error"]
+
+    def test_dry_run_is_deterministic(self, capsys):
+        argv = ["ipc", "push-routes", str(BOARD), "--dry-run", "--format", "json"]
+        _, first = _run_ipc(argv, capsys)
+        _, second = _run_ipc(argv, capsys)
+        assert first == second
+
+    def test_parser_unavailable_is_error_document(self, capsys):
+        """The pre-parse failure path is a document, not prose (#4674)."""
+        with patch.dict("sys.modules", {"kicad_tools.pcb.parser": None}):
+            rc, out = _run_ipc(["ipc", "push-routes", str(BOARD), "--format", "json"], capsys)
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["command"] == "push-routes"
+        assert payload["success"] is False
+        assert payload["pushed"] == 0
+        assert "PCB parser not available" in payload["error"]
+
+    def test_no_socket_is_error_document(self, capsys):
+        """With tracks in hand but no socket, the failure is still a document."""
+        board = MagicMock()
+        board.tracks = [MagicMock()]
+        board.vias = []
+        board.nets = []
+        parser_module = MagicMock()
+        parser_module.parse_pcb.return_value = board
+        with (
+            patch.dict("sys.modules", {"kicad_tools.pcb.parser": parser_module}),
+            patch("kicad_tools.ipc.discovery.discover_socket", return_value=None),
+        ):
+            rc, out = _run_ipc(["ipc", "push-routes", str(BOARD), "--format", "json"], capsys)
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["success"] is False
+        assert payload["pushed"] == 0
+        assert payload["tracks"] == 1
+        assert "No KiCad IPC socket found" in payload["error"]
+
+    def test_dry_run_text_mode_is_not_json(self, capsys):
+        rc, out = _run_ipc(["ipc", "push-routes", str(BOARD), "--dry-run"], capsys)
+        assert "Error" in out or "Dry run" in out
+        assert rc in (0, 1)
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(out)
+
+
+# ---------------------------------------------------------------------------
+# mcp setup emission
+# ---------------------------------------------------------------------------
+
+
+def _run_mcp(argv, capsys):
+    from kicad_tools.cli.commands.mcp import run_mcp_command
+
+    rc = run_mcp_command(create_parser().parse_args(argv))
+    return rc, capsys.readouterr().out
+
+
+class TestMcpSetupEmission:
+    def test_dry_run_document(self, capsys):
+        rc, out = _run_mcp(["mcp", "setup", "--dry-run", "--format", "json"], capsys)
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["command"] == "setup"
+        assert payload["client"] == "claude-code"
+        assert payload["dry_run"] is True
+        assert payload["written"] is False
+        assert payload["replaced"] is False
+        assert payload["success"] is True
+        assert isinstance(payload["config_path"], str)
+        assert set(payload["server"]) == {"command", "args", "env"}
+
+    def test_dry_run_is_deterministic(self, capsys):
+        argv = ["mcp", "setup", "--dry-run", "--format", "json"]
+        _, first = _run_mcp(argv, capsys)
+        _, second = _run_mcp(argv, capsys)
+        assert first == second
+
+    def test_write_document(self, tmp_path, capsys):
+        target = tmp_path / "mcp.json"
+        with patch(
+            "kicad_tools.cli.commands.mcp._get_claude_code_config_path", return_value=target
+        ):
+            rc, out = _run_mcp(["mcp", "setup", "--format", "json"], capsys)
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["written"] is True
+        assert payload["replaced"] is False
+        assert payload["config_path"] == str(target)
+        written = json.loads(target.read_text())
+        assert written["mcpServers"]["kicad-tools"] == payload["server"]
+
+    def test_replacing_existing_entry_is_flagged(self, tmp_path, capsys):
+        target = tmp_path / "mcp.json"
+        target.write_text(json.dumps({"mcpServers": {"kicad-tools": {"command": "old"}}}))
+        with patch(
+            "kicad_tools.cli.commands.mcp._get_claude_code_config_path", return_value=target
+        ):
+            rc, out = _run_mcp(["mcp", "setup", "--format", "json"], capsys)
+        assert rc == 0
+        assert json.loads(out)["replaced"] is True
+
+    def test_claude_desktop_client_is_reported(self, tmp_path, capsys):
+        target = tmp_path / "claude_desktop_config.json"
+        with patch(
+            "kicad_tools.cli.commands.mcp._get_claude_desktop_config_path", return_value=target
+        ):
+            rc, out = _run_mcp(
+                ["mcp", "setup", "--client", "claude-desktop", "--format", "json"], capsys
+            )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["client"] == "claude-desktop"
+        assert payload["config_path"] == str(target)
+
+    def test_text_mode_is_not_json(self, capsys):
+        """Text mode prints prose plus an indented preview, not one document."""
+        rc, out = _run_mcp(["mcp", "setup", "--dry-run"], capsys)
+        assert rc == 0
+        assert "MCP client: claude-code" in out
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(out)


### PR DESCRIPTION
## Summary

Fourth batch of the #4543 machine-output sweep (tracked by #4674): the **environment / integration singles** — the five prose-only leaves that report on or configure `kct`'s *surroundings* rather than a board file. Each is wired end-to-end (outer parser → shim → inner handler) and emits exactly one deterministic JSON document on stdout.

| Surface | Document |
|---|---|
| `config` | `{"command": "config", "action": "show"\|"paths"\|"init"\|"get"\|"set", …}` |
| `ipc status` | `{"command": "status", "socket", "connected", "kicad_version", "instances", "open_documents", "success"}` |
| `ipc connect` | `{"command": "connect", "socket", "connected", "kicad_version", "success"}` |
| `ipc push-routes` | `{"command": "push-routes", "pcb", "net_filter", "tracks", "vias", "dry_run", "pushed", "success"}` |
| `mcp setup` | `{"command": "setup", "client", "config_path", "dry_run", "written", "replaced", "server", "success"}` |

This **finishes the `ipc` family outright** and **finishes `mcp`** (`mcp serve` stays on the #4543 exemption list — a long-running server whose machine contract *is* the MCP protocol; a test pins that it gains no flag).

Audit at PR head (`scripts/audit_machine_output.py`): **prose-only 23 → 18, format-json 174 → 179.** Remaining actionable: **13** (18 minus the 4 exempt and the deferred `route`).

## Changes

- `src/kicad_tools/cli/parser.py` — `add_format_flag` on the 5 outer leaves (+5 lines, nothing else touched).
- `src/kicad_tools/cli/commands/config.py` — shim forwards `--format json` into `sub_argv`, ahead of the positionals.
- `src/kicad_tools/cli/config_cmd.py` — inner `--format` flag; JSON emission for all five modes plus the bare default. The prose `--show` table and the JSON `sections` map are now generated from **one** `_SHOWN_SECTIONS` literal so they cannot drift, and the native-backend probe is split into a data function (`_native_backend_status`) plus a printer.
- `src/kicad_tools/cli/commands/ipc.py` — JSON emission for all three leaves; shared `_emit` / `_fail` helpers.
- `src/kicad_tools/cli/commands/mcp.py` — JSON emission for `setup` (dry-run preview and the write path).
- `tests/test_format_json_sweep_env.py` — **new**, 57 tests. A *sibling* of the batch-1/2/3 modules, per the convention established in #4759/#4777, so concurrent batches never conflict on a shared `SWEPT_SURFACES` literal.
- `docs/reference/machine-output.md` — inventory row for b4, the per-command shapes, and the two conventions below.
- `CHANGELOG.md` — one entry appended to the **first** `### Added` block (the duplicate-block cleanup is #4771's, deliberately not touched here).

### Three details worth reviewer attention

1. **`config set` never writes.** It prints the TOML you must paste. Under JSON that has to be structural or a caller reads exit 0 as a persisted change — hence `"applied": false` plus the `toml` snippet. A test asserts no file is created.
2. **Text-mode prose is byte-identical**, including the several `ipc` failure paths that deliberately print *without* an `Error:` prefix (`Connection failed: …`, `No KiCad IPC socket found.`, `Socket not found at: …`). The shared `_fail(...)` takes a `text_lines` override for exactly that; the default is the conventional `Error: <message>`. Verified by diffing all `config` modes against the same commands run from the `main` checkout.
3. **`ipc push-routes` is already dead on `main`** — it imports `kicad_tools.pcb.parser`, a module that has never existed (since #2363; it is already an entry in `.github/mypy-baseline.txt`), so every existing board short-circuits into the `"PCB parser not available."` branch and exits 1. This PR does **not** fix that (formatting-only scope): it makes the failure *visible* as a document instead of prose, and I filed **#4788** for the wiring bug. The new tests are written to pass **both before and after** #4788 lands, so they will not block the fix.

## Acceptance Criteria Verification

Per-PR criteria from #4674's curated body:

- [x] **One coherent batch** — the environment/integration singles; two families finished.
- [x] **Outer parser + shim + inner emission all threaded** — no inner-only flags (the `mfr rules` dead-surface trap). `config` is the only argv-reserializing shim here; forwarding is tested in both flag orders, and the text default is pinned to *not* forward.
- [x] **JSON deterministic** — sorted keys via `emit_json`; collections sorted explicitly (`open_documents`, `search_filenames`). Byte-identical-across-two-runs tests for `config --show`, `ipc status`, `ipc push-routes`, `mcp setup`.
- [x] **`tests/test_cli_parser_drift.py` untouched and green** — no route/check parser changes; the `route --format` promotion still belongs to the route workstream.
- [x] **Per-surface `--format json` tests** — structure assertions, not byte-golden: outer-surface guard, default-stays-text, shim forwarding, success documents, `{"error": …}` documents with unchanged exit codes, and text-mode-still-prose pins.
- [x] **Family JSON schema documented** — `docs/reference/machine-output.md` (+ module docstrings on all three touched modules).

## Test Plan

| Gate | Result |
|---|---|
| `pytest tests/test_format_json_sweep_env.py` | **57 passed** |
| `pytest` on all four sweep modules + `test_cli_parser_drift.py` + `test_mcp_http.py` | **404 passed** |
| `pytest tests/ -k "cli or parser or config or format"` | **3360 passed, 7 skipped** |
| `ruff check src/ tests/…` | All checks passed |
| `ruff format --check .` | 1786 files already formatted |
| `scripts/ci/check_mypy_baseline.py` (cold, `rm -rf .mypy_cache`) | 1471 errors, all within the 1473 baseline — **no new type errors**. The `2 baseline errors no longer occur` warning reproduces identically on `main`, so it is pre-existing and the baseline was **not** updated. |
| `scripts/audit_machine_output.py` | prose-only 23 → 18, format-json 174 → 179 |

C++ backend rebuilt in the worktree (`kct build-native --force`, build version 19) — the stale `.so` at version 18 was causing an unrelated `tests/router/lattice/test_post_pass_gating.py` failure that disappeared after the rebuild.

Part of #4674