### PR TITLE
fix(ipc): load boards in push-routes via schema.pcb.PCB instead of a nonexistent parser module

### DIFF
--- a/.github/mypy-baseline.txt
+++ b/.github/mypy-baseline.txt
@@ -63,7 +63,6 @@ src/kicad_tools/cli/commands/benchmark.py	var-annotated	Need type annotation for
 src/kicad_tools/cli/commands/benchmark.py	var-annotated	Need type annotation for "by_case" (hint: "by_case: dict[<type>, <type>] = ...")
 src/kicad_tools/cli/commands/impedance.py	index	Value of type "tuple[str, str] | None" is not indexable
 src/kicad_tools/cli/commands/impedance.py	operator	Cannot call function of unknown type
-src/kicad_tools/cli/commands/ipc.py	import-not-found	Cannot find implementation or library stub for module named "kicad_tools.pcb.parser"
 src/kicad_tools/cli/commands/parts.py	attr-defined	"Collection[str]" has no attribute "append"
 src/kicad_tools/cli/commands/pcb.py	attr-defined	"object" has no attribute "append"
 src/kicad_tools/cli/commands/spec.py	arg-type	Argument "completed" to "add_task" of "Progress" has incompatible type "float"; expected "int"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`kct ipc push-routes` can now actually read a board** (#4788) — the
+  handler imported the nonexistent `kicad_tools.pcb.parser` (dead since
+  #2363) behind an `except ImportError`, so every invocation exited 1 with
+  "PCB parser not available." It now loads boards via the first-party
+  `kicad_tools.schema.pcb.PCB.load()` (unguarded, so wiring regressions fail
+  loudly), reads the real model attributes (`segments`, `start`/`end`/
+  `position` tuples, `net_number`) instead of `getattr(..., 0)` fallbacks
+  that would have pushed zero-length tracks at the origin on net 0, and the
+  `--net` filter matches by net name against `PCB.nets`; an unknown net name
+  or unparseable board is now a clear error (exit 1) in both text and JSON
+  modes.
+
 - **A single relief-rescue transaction is now proportionally bounded** (#4781)
   — a rescue (including its depth-1 nested rescues, which share the parent's
   allowance) may spend at most `max(25% of the remaining stage budget, 90 s)`

--- a/src/kicad_tools/cli/commands/ipc.py
+++ b/src/kicad_tools/cli/commands/ipc.py
@@ -10,9 +10,14 @@ See ``docs/reference/machine-output.md``.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ..format_options import FORMAT_JSON, emit_json
+
+if TYPE_CHECKING:
+    from kicad_tools.ipc.proto.messages import TrackSegment as IPCTrack
+    from kicad_tools.ipc.proto.messages import Via as IPCVia
+    from kicad_tools.schema.pcb import Segment, Via
 
 __all__ = ["run_ipc_command"]
 
@@ -54,6 +59,41 @@ def _fail(
     for line in text_lines if text_lines is not None else [f"Error: {message}"]:
         print(line)
     return 1
+
+
+def _to_ipc_routes(tracks: list[Segment], vias: list[Via]) -> tuple[list[IPCTrack], list[IPCVia]]:
+    """Convert schema :class:`Segment`/:class:`Via` objects to IPC messages.
+
+    Reads the real ``kicad_tools.schema.pcb`` model attributes directly
+    (``start``/``end``/``position`` tuples in mm, ``net_number``) — no
+    ``getattr(..., default)`` fallbacks, which previously masked a total
+    attribute-name mismatch by emitting zero-length tracks at the origin on
+    net 0 (#4788).
+    """
+    from kicad_tools.ipc.proto.messages import TrackSegment as IPCTrackMsg
+    from kicad_tools.ipc.proto.messages import Vector2
+    from kicad_tools.ipc.proto.messages import Via as IPCViaMsg
+
+    ipc_tracks = [
+        IPCTrackMsg(
+            start=Vector2(x_nm=int(t.start[0] * 1e6), y_nm=int(t.start[1] * 1e6)),
+            end=Vector2(x_nm=int(t.end[0] * 1e6), y_nm=int(t.end[1] * 1e6)),
+            width_nm=int(t.width * 1e6),
+            layer=t.layer,
+            net=t.net_number,
+        )
+        for t in tracks
+    ]
+    ipc_vias = [
+        IPCViaMsg(
+            position=Vector2(x_nm=int(v.position[0] * 1e6), y_nm=int(v.position[1] * 1e6)),
+            diameter_nm=int(v.size * 1e6),
+            drill_nm=int(v.drill * 1e6),
+            net=v.net_number,
+        )
+        for v in vias
+    ]
+    return ipc_tracks, ipc_vias
 
 
 def run_ipc_command(args) -> int:
@@ -344,35 +384,42 @@ def _run_push_routes(args) -> int:
         print(f"Error: PCB file not found: {pcb_file}")
         return 1
 
-    # Read tracks from the PCB file using existing kicad-tools parsing
+    # Read tracks from the PCB file using the same board loader the other
+    # `kct pcb` handlers use.  This is a first-party core import, so it is
+    # deliberately NOT wrapped in ``except ImportError`` — a wiring
+    # regression here must fail loudly instead of masquerading as a missing
+    # optional extra (#4788: the previous import targeted the nonexistent
+    # ``kicad_tools.pcb.parser`` and the guard hid that for three releases).
+    from kicad_tools.schema.pcb import PCB
+
     try:
-        from kicad_tools.pcb.parser import parse_pcb
-    except ImportError:
-        if output_format == FORMAT_JSON:
+        board = PCB.load(pcb_file)
+    except (OSError, ValueError) as exc:
+        return _fail(
+            "push-routes",
+            output_format,
+            f"Failed to parse PCB: {exc}",
+            pcb=str(pcb_file),
+            pushed=0,
+        )
+
+    tracks = list(board.segments)
+    vias = list(board.vias)
+
+    if net_filter:
+        # Filter to a specific net by name (PCB.nets is a dict[int, Net]).
+        net = board.get_net_by_name(net_filter)
+        if net is None:
             return _fail(
                 "push-routes",
                 output_format,
-                "PCB parser not available.",
+                f"Net not found in {pcb_file.name}: {net_filter}",
                 pcb=str(pcb_file),
+                net_filter=net_filter,
                 pushed=0,
             )
-        print("Error: PCB parser not available.")
-        return 1
-
-    board = parse_pcb(pcb_file)
-    tracks = board.tracks if hasattr(board, "tracks") else []
-    vias = board.vias if hasattr(board, "vias") else []
-
-    if net_filter:
-        # Filter to specific net
-        net_code = None
-        for net in board.nets if hasattr(board, "nets") else []:
-            if hasattr(net, "name") and net.name == net_filter:
-                net_code = net.number if hasattr(net, "number") else None
-                break
-        if net_code is not None:
-            tracks = [t for t in tracks if hasattr(t, "net") and t.net == net_code]
-            vias = [v for v in vias if hasattr(v, "net") and v.net == net_code]
+        tracks = [t for t in tracks if t.net_number == net.number]
+        vias = [v for v in vias if v.net_number == net.number]
 
     # Summary fields shared by every terminal state below.
     summary: dict[str, Any] = {
@@ -416,45 +463,12 @@ def _run_push_routes(args) -> int:
 
     try:
         from kicad_tools.ipc.board import BoardOperations
-        from kicad_tools.ipc.proto.messages import TrackSegment as IPCTrack
-        from kicad_tools.ipc.proto.messages import Vector2
-        from kicad_tools.ipc.proto.messages import Via as IPCVia
 
         with IPCClient(str(resolved)) as client:
             board_ops = BoardOperations(client)
 
             # Convert kicad-tools track format to IPC format
-            ipc_tracks = []
-            for t in tracks:
-                ipc_tracks.append(
-                    IPCTrack(
-                        start=Vector2(
-                            x_nm=int(getattr(t, "start_x", 0) * 1e6),
-                            y_nm=int(getattr(t, "start_y", 0) * 1e6),
-                        ),
-                        end=Vector2(
-                            x_nm=int(getattr(t, "end_x", 0) * 1e6),
-                            y_nm=int(getattr(t, "end_y", 0) * 1e6),
-                        ),
-                        width_nm=int(getattr(t, "width", 0.25) * 1e6),
-                        layer=getattr(t, "layer", "F.Cu"),
-                        net=getattr(t, "net", 0),
-                    )
-                )
-
-            ipc_vias = []
-            for v in vias:
-                ipc_vias.append(
-                    IPCVia(
-                        position=Vector2(
-                            x_nm=int(getattr(v, "x", 0) * 1e6),
-                            y_nm=int(getattr(v, "y", 0) * 1e6),
-                        ),
-                        diameter_nm=int(getattr(v, "size", 0.8) * 1e6),
-                        drill_nm=int(getattr(v, "drill", 0.4) * 1e6),
-                        net=getattr(v, "net", 0),
-                    )
-                )
+            ipc_tracks, ipc_vias = _to_ipc_routes(tracks, vias)
 
             created = board_ops.push_routes(
                 tracks=ipc_tracks,

--- a/tests/test_cli_ipc_push_routes.py
+++ b/tests/test_cli_ipc_push_routes.py
@@ -1,0 +1,198 @@
+"""Tests for ``kct ipc push-routes`` board loading and conversion (#4788).
+
+The handler shipped (since #2363) importing ``kicad_tools.pcb.parser`` — a
+module that has never existed — so every invocation on a real board exited 1
+with "PCB parser not available."  Because the conversion loop also used
+``getattr(..., default)`` fallbacks against attribute names the real model
+does not have, fixing only the import would have silently pushed zero-length
+tracks at the origin on net 0.
+
+These tests pin the wiring to the real board loader
+(``kicad_tools.schema.pcb.PCB.load``) and the real model attribute names
+(``segments``, ``start``/``end``/``position`` tuples, ``net_number``).
+
+Fixture notes: ``stale_nets.kicad_pcb`` contains real routed copper
+(2 segments + 1 via, all on net 4 ``Net-(C11-2)``).
+``routing-diagnostic.kicad_pcb`` is deliberately UNROUTED — it is the input
+board the router suites route — so it exercises the zero-copper path.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from kicad_tools.cli.commands.ipc import _to_ipc_routes, run_ipc_command
+from kicad_tools.cli.parser import create_parser
+
+FIXTURES = Path(__file__).parent / "fixtures"
+ROUTED_BOARD = FIXTURES / "stale_nets.kicad_pcb"
+UNROUTED_BOARD = FIXTURES / "routing-diagnostic.kicad_pcb"
+
+
+def _run(argv: list[str], capsys) -> tuple[int, str]:
+    rc = run_ipc_command(create_parser().parse_args(argv))
+    return rc, capsys.readouterr().out
+
+
+class TestImportResolution:
+    """Regression tests that would have caught the dead import."""
+
+    def test_dry_run_does_not_hit_parser_unavailable(self, capsys):
+        """The dead-import era turned EVERY real board into exit 1 + this prose."""
+        rc, out = _run(["ipc", "push-routes", str(ROUTED_BOARD), "--dry-run"], capsys)
+        assert "PCB parser not available" not in out
+        assert rc == 0
+
+    def test_board_loader_is_first_party_schema_pcb(self):
+        """The handler must load boards via ``kicad_tools.schema.pcb.PCB``.
+
+        Import-resolution check: the module the handler imports at push time
+        must exist and expose ``load``.  (``kicad_tools.pcb.parser`` never
+        did; the swallowed ImportError hid that for three releases.)
+        """
+        from kicad_tools.schema.pcb import PCB
+
+        assert callable(PCB.load)
+
+
+class TestDryRun:
+    def test_routed_board_reports_nonzero_counts(self, capsys):
+        rc, out = _run(["ipc", "push-routes", str(ROUTED_BOARD), "--dry-run"], capsys)
+        assert rc == 0
+        assert "Found 2 tracks and 1 vias" in out
+        assert "Dry run" in out
+
+    def test_routed_board_json_document(self, capsys):
+        rc, out = _run(
+            ["ipc", "push-routes", str(ROUTED_BOARD), "--dry-run", "--format", "json"],
+            capsys,
+        )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["command"] == "push-routes"
+        assert payload["success"] is True
+        assert payload["tracks"] == 2
+        assert payload["vias"] == 1
+        assert payload["pushed"] == 0
+        assert payload["dry_run"] is True
+
+    def test_unrouted_board_reports_zero_and_exits_zero(self, capsys):
+        """A copper-free board is a valid (empty) push, not an error."""
+        rc, out = _run(["ipc", "push-routes", str(UNROUTED_BOARD), "--dry-run"], capsys)
+        assert rc == 0
+        assert "Found 0 tracks and 0 vias" in out
+
+
+class TestNetFilter:
+    """``--net`` must match by NAME against ``PCB.nets`` (a dict[int, Net])."""
+
+    def test_existing_net_name_selects_its_copper(self, capsys):
+        rc, out = _run(
+            [
+                "ipc",
+                "push-routes",
+                str(ROUTED_BOARD),
+                "--dry-run",
+                "--net",
+                "Net-(C11-2)",
+                "--format",
+                "json",
+            ],
+            capsys,
+        )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["net_filter"] == "Net-(C11-2)"
+        assert payload["tracks"] == 2
+        assert payload["vias"] == 1
+
+    def test_existing_net_without_copper_selects_nothing(self, capsys):
+        """GND exists in the netlist but owns no segments/vias."""
+        rc, out = _run(
+            [
+                "ipc",
+                "push-routes",
+                str(ROUTED_BOARD),
+                "--dry-run",
+                "--net",
+                "GND",
+                "--format",
+                "json",
+            ],
+            capsys,
+        )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["tracks"] == 0
+        assert payload["vias"] == 0
+
+    def test_unknown_net_name_is_a_clear_error(self, capsys):
+        rc, out = _run(
+            ["ipc", "push-routes", str(ROUTED_BOARD), "--dry-run", "--net", "NO_SUCH_NET"],
+            capsys,
+        )
+        assert rc == 1
+        assert "Net not found" in out
+        assert "NO_SUCH_NET" in out
+
+    def test_unknown_net_name_json_error_document(self, capsys):
+        rc, out = _run(
+            [
+                "ipc",
+                "push-routes",
+                str(ROUTED_BOARD),
+                "--dry-run",
+                "--net",
+                "NO_SUCH_NET",
+                "--format",
+                "json",
+            ],
+            capsys,
+        )
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["command"] == "push-routes"
+        assert payload["success"] is False
+        assert payload["pushed"] == 0
+        assert "NO_SUCH_NET" in payload["error"]
+
+
+class TestConversion:
+    """The IPC conversion must read real model attributes, not getattr defaults."""
+
+    def test_tracks_and_vias_convert_with_real_geometry(self):
+        from kicad_tools.schema.pcb import PCB
+
+        board = PCB.load(ROUTED_BOARD)
+        ipc_tracks, ipc_vias = _to_ipc_routes(board.segments, board.vias)
+
+        assert len(ipc_tracks) == 2
+        assert len(ipc_vias) == 1
+
+        for track in ipc_tracks:
+            # The getattr-fallback bug emitted zero-length tracks at the origin.
+            assert (track.start.x_nm, track.start.y_nm) != (track.end.x_nm, track.end.y_nm)
+            assert track.net == 4  # not the net-0 fallback
+            assert track.width_nm == 250_000  # 0.25 mm
+            assert track.layer == "F.Cu"
+
+        # seg-1 in the fixture: (11, 10) -> (19, 10) mm.
+        assert ipc_tracks[0].start.to_dict() == {"x": 11_000_000, "y": 10_000_000}
+        assert ipc_tracks[0].end.to_dict() == {"x": 19_000_000, "y": 10_000_000}
+
+        # via-1 in the fixture: at (19, 11) mm, size 0.6, drill 0.3, net 4.
+        via = ipc_vias[0]
+        assert via.position.to_dict() == {"x": 19_000_000, "y": 11_000_000}
+        assert via.diameter_nm == 600_000
+        assert via.drill_nm == 300_000
+        assert via.net == 4
+
+
+class TestUnparseableBoard:
+    def test_parse_failure_is_a_clear_error(self, tmp_path, capsys):
+        bad = tmp_path / "garbage.kicad_pcb"
+        bad.write_text("this is not a board")
+        rc, out = _run(["ipc", "push-routes", str(bad), "--dry-run"], capsys)
+        assert rc == 1
+        assert "Failed to parse PCB" in out

--- a/tests/test_format_json_sweep_env.py
+++ b/tests/test_format_json_sweep_env.py
@@ -468,11 +468,9 @@ class TestIpcPushRoutesEmission:
     def test_dry_run_document(self, capsys):
         """A real board yields one well-formed document either way.
 
-        ``push-routes`` imports ``kicad_tools.pcb.parser``, a module that does
-        not exist (dead since #2363), so today every existing board short-
-        circuits into the "PCB parser not available." branch -- which this
-        batch turns from prose into a structured document.  The assertions are
-        written to hold both before and after that unrelated bug is fixed.
+        Written during the dead-import era (#2363's ``kicad_tools.pcb.parser``
+        import, fixed by #4788) to hold both before and after the fix: since
+        #4788 the success branch is the one taken.
         """
         rc, out = _run_ipc(
             ["ipc", "push-routes", str(BOARD), "--dry-run", "--format", "json"], capsys
@@ -497,35 +495,39 @@ class TestIpcPushRoutesEmission:
         _, second = _run_ipc(argv, capsys)
         assert first == second
 
-    def test_parser_unavailable_is_error_document(self, capsys):
-        """The pre-parse failure path is a document, not prose (#4674)."""
-        with patch.dict("sys.modules", {"kicad_tools.pcb.parser": None}):
-            rc, out = _run_ipc(["ipc", "push-routes", str(BOARD), "--format", "json"], capsys)
+    def test_unparseable_board_is_error_document(self, tmp_path, capsys):
+        """The pre-push parse-failure path is a document, not prose (#4674).
+
+        Replaces the dead-import-era ``parser_unavailable`` test: since #4788
+        the board loader is the first-party ``kicad_tools.schema.pcb.PCB``
+        (imported unguarded), so the surviving pre-push failure mode is a
+        board that fails to parse.
+        """
+        bad = tmp_path / "garbage.kicad_pcb"
+        bad.write_text("this is not a board")
+        rc, out = _run_ipc(["ipc", "push-routes", str(bad), "--format", "json"], capsys)
         assert rc == 1
         payload = json.loads(out)
         assert payload["command"] == "push-routes"
         assert payload["success"] is False
         assert payload["pushed"] == 0
-        assert "PCB parser not available" in payload["error"]
+        assert "Failed to parse PCB" in payload["error"]
 
     def test_no_socket_is_error_document(self, capsys):
-        """With tracks in hand but no socket, the failure is still a document."""
-        board = MagicMock()
-        board.tracks = [MagicMock()]
-        board.vias = []
-        board.nets = []
-        parser_module = MagicMock()
-        parser_module.parse_pcb.return_value = board
-        with (
-            patch.dict("sys.modules", {"kicad_tools.pcb.parser": parser_module}),
-            patch("kicad_tools.ipc.discovery.discover_socket", return_value=None),
-        ):
-            rc, out = _run_ipc(["ipc", "push-routes", str(BOARD), "--format", "json"], capsys)
+        """With tracks in hand but no socket, the failure is still a document.
+
+        Uses ``stale_nets.kicad_pcb`` (2 real segments + 1 via) — the
+        routing-diagnostic board is deliberately unrouted, and an empty push
+        succeeds before socket discovery is ever attempted.
+        """
+        routed = FIXTURES / "stale_nets.kicad_pcb"
+        with patch("kicad_tools.ipc.discovery.discover_socket", return_value=None):
+            rc, out = _run_ipc(["ipc", "push-routes", str(routed), "--format", "json"], capsys)
         assert rc == 1
         payload = json.loads(out)
         assert payload["success"] is False
         assert payload["pushed"] == 0
-        assert payload["tracks"] == 1
+        assert payload["tracks"] == 2
         assert "No KiCad IPC socket found" in payload["error"]
 
     def test_dry_run_text_mode_is_not_json(self, capsys):


### PR DESCRIPTION
## Summary

`kct ipc push-routes` could never push anything: `_run_push_routes` imported `kicad_tools.pcb.parser` — a module that has never existed (dead since #2363) — behind an `except ImportError`, so every invocation on a real board exited 1 with "PCB parser not available.", disguised as a missing-extra environment problem. This PR wires the handler to the real board loader (`kicad_tools.schema.pcb.PCB.load()`, the same entry point the `kct pcb` handlers use), rewrites the conversion loop against the real model attributes, and makes the `--net` filter actually match by net name.

## Changes

- **`src/kicad_tools/cli/commands/ipc.py`**
  - Replace the dead `from kicad_tools.pcb.parser import parse_pcb` with an **unguarded** `from kicad_tools.schema.pcb import PCB` — a future wiring regression fails loudly instead of masquerading as a missing `[ipc]` extra. The `[ipc]`-extra guards on `kicad_tools.ipc.*` imports stay.
  - Wrap `PCB.load()` (not the import) in `except (OSError, ValueError)` so an unparseable board is a clear error document / exit 1 in both text and JSON modes, preserving the #4674 machine-output contract.
  - New `_to_ipc_routes()` helper reads the real model attributes (`board.segments`, `Segment.start`/`.end` tuples, `Via.position` tuple, `net_number`) — the previous `getattr(..., default)` fallbacks targeted names the model doesn't have (`tracks`, `start_x`, `.net`, `.x`) and would have silently pushed zero-length tracks at the origin on net 0.
  - `--net` filters via `PCB.get_net_by_name()` (matching by NAME against the `dict[int, Net]`); an unknown net name is a clear error instead of a silent unfiltered push.
  - The #4789 `--format json` envelope (`command`/`success` keys, error documents, exit codes) is preserved on every success and failure path.
- **`tests/test_cli_ipc_push_routes.py`** (new): import-resolution regression tests, dry-run count tests (routed + unrouted fixtures), conversion-geometry test (exact nm coordinates, widths, nets), and `--net` filter tests.
- **`tests/test_format_json_sweep_env.py`**: rewrote the two tests that mocked the dead `kicad_tools.pcb.parser` module (they cannot survive its removal, per the file's own docstring anticipating this fix): the pre-push failure document is now exercised with an unparseable board, and the no-socket document uses the routed `stale_nets.kicad_pcb` fixture. All other assertions untouched.
- **`.github/mypy-baseline.txt`**: surgical single-line removal of the now-fixed `kicad_tools.pcb.parser` import-not-found entry (no `--update`).
- **`CHANGELOG.md`**: one entry under `[Unreleased]` / `### Fixed`.

## Acceptance Criteria Verification

- [x] Dead import removed; handler loads boards via `kicad_tools.schema.pcb.PCB.load()`.
- [x] `uv run kct ipc push-routes tests/fixtures/routing-diagnostic.kicad_pcb --dry-run` exits **0** (was exit 1 with "Error: PCB parser not available."). **Deviation, flagged:** the curated criterion expected a nonzero track count from this fixture, but `routing-diagnostic.kicad_pcb` contains **zero** segments/vias by design — it is the unrouted *input* board that `tests/test_routing_diagnostic.py` and the router suites route, so it cannot be given copper without breaking them. The nonzero-count criterion is verified against `tests/fixtures/stale_nets.kicad_pcb` (2 segments + 1 via of real routed copper): `Found 2 tracks and 1 vias in stale_nets.kicad_pcb`, exit 0.
- [x] Conversion reads real model attributes — no `getattr(..., 0)` fallbacks; test pins exact geometry (e.g. seg-1 → `start (11000000, 10000000) nm`, via → `diameter 600000 nm`, net 4).
- [x] `--net` filtering works by name: `--net 'Net-(C11-2)'` selects 2 tracks + 1 via; `--net GND` (exists, no copper) selects 0; `--net NO_SUCH_NET` → `Error: Net not found in stale_nets.kicad_pcb: NO_SUCH_NET`, exit 1 (JSON: error document).
- [x] Board-parser import is unguarded (no `except ImportError`); the `[ipc]`-extra guards remain only on `kicad_tools.ipc.*` imports.
- [x] Import-resolution regression test exists (`TestImportResolution` — either test alone would have caught the original bug).

## Test Plan

- [x] `uv run pytest tests/test_cli_ipc_push_routes.py tests/test_format_json_sweep_env.py` — **68 passed**
- [x] `uv run ruff check .` — all checks passed; `ruff format --check` clean on touched files
- [x] `uv run python scripts/ci/check_mypy_baseline.py` — OK, no new type errors (1470 reported ≤ 1472 allowed; the 2 remaining not-occurring baseline lines are the pre-existing env-dependent nanobind entries, deliberately left alone)
- [x] Manual repro before/after:
  - Before: `Error: PCB parser not available.` / exit 1
  - After: `Found 0 tracks and 0 vias in routing-diagnostic.kicad_pcb` + `Dry run -- no changes pushed to KiCad.` / exit 0
- [ ] Live-KiCad socket push — manual only (no live KiCad in CI); everything up to `discover_socket()` is covered offline.

Closes #4788

🤖 Generated with [Claude Code](https://claude.com/claude-code)