### PR TITLE
feat(router): make the pure-Python fallback A* pairwise (HV) aware at search time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The pure-Python fallback A* is now pairwise (HV-isolation) aware at search time** (#4507, epic #4431 Phase 2) — the hot-loop bitmap, `_is_trace_blocked`/`_is_via_blocked` kernels and the C++ backend's fallback-router threading now mirror the C++ `cross_domain_*` search kernels (same domain projection, per-pair widened radius, layer-scoped #4506 attach-zone waiver, out-of-bounds-is-empty ring dilation), so a net that falls back on an HV board converges instead of thrashing against the Phase-1 post-route gate; fully dormant without `--voltage-map`.
+
 - **`kct ipc push-routes` can now actually read a board** (#4788) — the
   handler imported the nonexistent `kicad_tools.pcb.parser` (dead since
   #2363) behind an `except ImportError`, so every invocation exited 1 with

--- a/src/kicad_tools/router/cpp_backend.py
+++ b/src/kicad_tools/router/cpp_backend.py
@@ -1489,6 +1489,11 @@ class CppPathfinder:
         self._pairwise_cpp_payload = None
         # Issue #4530: the rebuilt payload must be re-pushed to the C++ grid.
         self._pairwise_cpp_installed = False
+        # Issue #4507: the pure-Python fallback router projects its own
+        # search-time pairwise (HV) domains through the same map -- keep it
+        # in lock-step so a fallback search on an HV board is not HV-blind.
+        if self._py_router is not None:
+            self._py_router.set_net_name_to_id(self._net_name_to_id)
 
     def set_attach_zones(self, zones) -> None:
         """Install precomputed rated-footprint necking regions."""
@@ -3059,6 +3064,11 @@ class CppPathfinder:
                 diagonal_routing=self._diagonal_routing,
             )
             self._py_router.set_attach_zones(self._attach_zones)
+            # Issue #4507: thread the net-name map through so the fallback
+            # A* can arm its search-time pairwise (HV-isolation) kernels --
+            # without it the domain projection is empty and the fallback
+            # stays HV-blind, thrashing against the Phase-1 post-route gate.
+            self._py_router.set_net_name_to_id(self._net_name_to_id)
 
         # Issue #3438: keep the fallback router's relief-probe mode in
         # lock-step with the C++ side (set via ``set_relief_mode``).

--- a/src/kicad_tools/router/pathfinder.py
+++ b/src/kicad_tools/router/pathfinder.py
@@ -24,7 +24,10 @@ import os
 import sys
 import time
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .pairwise_clearance import PairwiseClearanceTable
 
 import numpy as np
 
@@ -58,6 +61,38 @@ def _astar_trace(message: str) -> None:
     sys.stderr.write(message)
     sys.stderr.write("\n")
     sys.stderr.flush()
+
+
+@dataclass(frozen=True)
+class _PairwiseSearchState:
+    """Net-id-space pairwise (HV-isolation) projection for the Python A*.
+
+    Issue #4507 / Epic #4431 Phase 2b parity: the C++ search consults a
+    per-net domain array + domain-pair widening matrix at search time
+    (``Pathfinder::cross_domain_trace_blocked`` /
+    ``cross_domain_via_blocked``), but the pure-Python fallback A* had only
+    the Phase-1 *post-route* gate -- so on an HV board the fallback proposed
+    HV-through-LV paths the gate then rejected, burning its budget instead of
+    converging.  This carrier is the Python mirror of the state
+    ``Grid3D::set_pairwise_domains`` holds on the C++ side, built by the same
+    :func:`~kicad_tools.router.pairwise_clearance.build_cpp_domain_matrix`
+    projection so the two searches cannot disagree.
+
+    Attributes:
+        net_to_domain: Indexed by net id; ``-1`` = participates in no
+            widening pair (the projection's dormant convention).
+        matrix: Dense symmetric ``matrix[dom_a][dom_b]`` of *widening*
+            values (mm) WITHOUT the DRU floor -- ``<= 0`` means "scalar
+            clearance already governs this pair".
+        max_widen: Largest matrix entry (mm); sizes the widened scan kernel.
+        id_to_name: Net id -> board net name, for the (name-keyed) #4506
+            attach-zone waiver.
+    """
+
+    net_to_domain: list[int]
+    matrix: list[list[float]]
+    max_widen: float
+    id_to_name: dict[int, str]
 
 
 @dataclass(frozen=True)
@@ -398,6 +433,17 @@ class Router:
         # behavior matches pre-#2559 (single-clearance) routing.
         self._net_name_to_id: dict[str, int] = {}
         self._attach_zones = ()
+
+        # Issue #4507 / Epic #4431 Phase 2b parity: cached search-time
+        # pairwise (HV-isolation) projection for the pure-Python A*.
+        # ``None`` = not yet computed for the current table; otherwise a
+        # ``(table_ref, state_or_None)`` pair where ``state_or_None`` is a
+        # ``_PairwiseSearchState`` (armed) or ``None`` (dormant -- no table
+        # pairs resolve onto this board's net ids).  Rebuilt lazily by
+        # ``_pairwise_search_state`` whenever the table identity changes and
+        # invalidated by ``set_net_name_to_id`` (the projection is keyed by
+        # net id).
+        self._pairwise_search_cache: tuple[object, _PairwiseSearchState | None] | None = None
 
         # Issue #2929: Per-A*-call wall-clock instrumentation.  When
         # ``_per_call_timing_enabled`` is True, every ``route()`` invocation
@@ -1273,6 +1319,9 @@ class Router:
         disables partner detection (everything falls back to ``clearance``).
         """
         self._net_name_to_id = dict(mapping)
+        # Issue #4507: the search-time pairwise projection is keyed by net id
+        # through this map -- rebuild it on the next consult.
+        self._pairwise_search_cache = None
 
     def set_attach_zones(self, zones) -> None:
         """Install precomputed rated-footprint necking regions."""
@@ -1546,7 +1595,8 @@ class Router:
             # Issue #3229: Apply Euclidean-disc filter so the diagonal
             # corners of the bounding square do not contribute.
             combined = combined & within_disc
-            return bool(np.any(combined))
+            if bool(np.any(combined)):
+                return True
         else:
             # Standard mode: block if any cell is blocked AND has different net
             # Issue #864: Same-net cells are passable (even overlapping clearance)
@@ -1557,7 +1607,16 @@ class Router:
             # Issue #3229: Apply Euclidean-disc filter so the diagonal
             # corners of the bounding square do not contribute.
             blocked_different_net = blocked_different_net & within_disc
-            return bool(np.any(blocked_different_net))
+            if bool(np.any(blocked_different_net)):
+                return True
+
+        # Issue #4507: the scalar disc is clear -- consult the cross-domain
+        # (HV-isolation) annulus, mirroring the C++
+        # ``Pathfinder::cross_domain_trace_blocked`` tail call in
+        # ``is_trace_blocked``.  No-op (single ``getattr`` + ``None`` test)
+        # unless a pairwise voltage-map table is installed AND it projects
+        # onto this board's net ids.
+        return self._cross_domain_trace_blocked(gx, gy, layer, net, radius)
 
     def _is_foreign_pad_metal_within_radius(
         self,
@@ -1776,7 +1835,11 @@ class Router:
 
         # Fast path: if no cells are blocked, via is not blocked
         if not np.any(blocked_arr):
-            return False
+            # Issue #4507: scalar disc clear -- consult the cross-domain
+            # (HV-isolation) annulus (C++ ``cross_domain_via_blocked`` mirror).
+            return self._cross_domain_via_blocked(
+                gx, gy, layer, net, radius if radius is not None else self._via_half_cells
+            )
 
         # Some cells are blocked - need detailed checking
         # Get indices of blocked cells only
@@ -1847,7 +1910,345 @@ class Router:
             if np.any(different_net):
                 return True
 
+        # Issue #4507: every scalar-disc cell is passable -- consult the
+        # cross-domain (HV-isolation) annulus (C++ ``cross_domain_via_blocked``
+        # mirror).
+        return self._cross_domain_via_blocked(
+            gx, gy, layer, net, radius if radius is not None else self._via_half_cells
+        )
+
+    # ------------------------------------------------------------------
+    # Search-time pairwise (HV-isolation) avoidance (Issue #4507)
+    # ------------------------------------------------------------------
+    #
+    # Python siblings of the C++ ``Pathfinder::cross_domain_trace_blocked`` /
+    # ``cross_domain_via_blocked`` kernels (#4511).  Phase 2b armed only the
+    # C++ search; the pure-Python fallback A* kept proposing HV-through-LV
+    # paths that the Phase-1 post-route gate (``route_pairwise_violation``)
+    # then rejected -- so a net that fell back on an HV board burned its
+    # budget instead of converging (observed directly by PR #4780's
+    # convergence fixture: the layer-agnostic arm "burns its resume budget
+    # into the Python fallback and returns None").
+    #
+    # Mirror notes vs. the C++ kernels:
+    # * Same projection (``build_cpp_domain_matrix``), same annulus shape
+    #   (scalar disc is the scalar kernel's job; only the ring out to the
+    #   widest pair is scanned), same per-pair radius arithmetic, same
+    #   layer-scoped #4506 attach-zone waiver at the gap midpoint.
+    # * ``half_mm`` uses the global ``rules`` widths (the C++ default when
+    #   ``set_search_pair_widths`` has not supplied per-net extents).
+    # * The diagonal-corner probe is NOT separately widened here: both
+    #   endpoints of a diagonal step already consult the annulus via
+    #   ``_is_trace_blocked``, and the ceil-rounded pair radius keeps the
+    #   mid-step within the requirement, so the gate cannot disagree.
+
+    def _pairwise_search_state(
+        self, table: "PairwiseClearanceTable"
+    ) -> _PairwiseSearchState | None:
+        """Project ``table`` onto net ids for the search kernels (cached).
+
+        Returns ``None`` (dormant) when the projection resolves fewer than
+        two participating nets on this board -- the same dormant signal
+        ``build_cpp_domain_matrix`` gives the C++ setter.  The cache is keyed
+        by table identity and invalidated by :meth:`set_net_name_to_id`.
+        """
+        cached = self._pairwise_search_cache
+        if cached is not None and cached[0] is table:
+            return cached[1]
+
+        from .pairwise_clearance import build_cpp_domain_matrix
+
+        projection = build_cpp_domain_matrix(table, self._net_name_to_id)
+        state: _PairwiseSearchState | None = None
+        if projection is not None:
+            max_widen = max((max(row) for row in projection.matrix), default=0.0)
+            if max_widen > 0.0:
+                state = _PairwiseSearchState(
+                    net_to_domain=projection.net_to_domain,
+                    matrix=projection.matrix,
+                    max_widen=max_widen,
+                    id_to_name={nid: name for name, nid in self._net_name_to_id.items()},
+                )
+        self._pairwise_search_cache = (table, state)
+        return state
+
+    def _cross_domain_trace_blocked(
+        self, gx: int, gy: int, layer: int, net: int, scalar_radius: int
+    ) -> bool:
+        """True when foreign cross-domain copper sits inside the widened ring.
+
+        Python mirror of ``Pathfinder::cross_domain_trace_blocked``.  Called
+        only after the scalar kernel has cleared the inner disc.
+        """
+        table = getattr(self.rules, "pairwise_clearance", None)
+        if table is None:
+            return False
+        state = self._pairwise_search_state(table)
+        if state is None:
+            return False
+        return self._cross_domain_annulus_blocked(
+            gx, gy, layer, net, scalar_radius, self.rules.trace_width / 2.0, state
+        )
+
+    def _cross_domain_via_blocked(
+        self, gx: int, gy: int, layer: int, net: int, scalar_radius: int
+    ) -> bool:
+        """Via sibling of :meth:`_cross_domain_trace_blocked` (one layer).
+
+        The C++ ``cross_domain_via_blocked`` scans every layer itself; here
+        the per-layer scan composes with ``_check_via_placement_cached``'s
+        existing all-layer loop, so coverage is identical for the layers the
+        scalar via check itself walks.
+        """
+        table = getattr(self.rules, "pairwise_clearance", None)
+        if table is None:
+            return False
+        state = self._pairwise_search_state(table)
+        if state is None:
+            return False
+        return self._cross_domain_annulus_blocked(
+            gx, gy, layer, net, scalar_radius, self.rules.via_diameter / 2.0, state
+        )
+
+    def _cross_domain_annulus_blocked(
+        self,
+        gx: int,
+        gy: int,
+        layer: int,
+        net: int,
+        scalar_radius: int,
+        half_mm: float,
+        state: _PairwiseSearchState,
+    ) -> bool:
+        """Shared annulus walk behind the trace/via cross-domain kernels.
+
+        Scans the ring between ``scalar_radius`` (exclusive -- the scalar
+        kernel's job) and the widest pairwise radius (inclusive) for blocked
+        foreign copper whose domain pair requires widening, honouring the
+        layer-scoped #4506 attach-zone waiver at the approximate gap
+        midpoint.  Out-of-bounds cells are skipped (the scalar kernel owns
+        the out-of-bounds verdict), matching the C++ kernels.
+        """
+        net_to_domain = state.net_to_domain
+        dom = net_to_domain[net] if 0 <= net < len(net_to_domain) else -1
+        if dom < 0:
+            return False
+
+        res = self.grid.resolution
+        # Issue #864 rounding idiom: round before ceil so FP noise cannot
+        # add a phantom cell of widening.
+        wide_r = max(1, math.ceil(round((half_mm + state.max_widen) / res, 6)))
+        if wide_r <= scalar_radius:
+            return False  # the matrix never widens beyond the scalar kernel
+
+        x1 = max(0, gx - wide_r)
+        y1 = max(0, gy - wide_r)
+        x2 = min(self.grid.cols, gx + wide_r + 1)
+        y2 = min(self.grid.rows, gy + wide_r + 1)
+        if x1 >= x2 or y1 >= y2:
+            return False
+
+        blocked_region = self.grid._blocked[layer, y1:y2, x1:x2]
+        if not bool(np.any(blocked_region)):
+            return False
+        net_region = self.grid._net[layer, y1:y2, x1:x2]
+
+        ys = np.arange(y1, y2)
+        xs = np.arange(x1, x2)
+        dy_grid = ys - gy
+        dx_grid = xs - gx
+        dist_sq = (dy_grid * dy_grid)[:, None] + (dx_grid * dx_grid)[None, :]
+        annulus = (dist_sq > scalar_radius * scalar_radius) & (dist_sq <= wide_r * wide_r)
+        # Only foreign real-net copper can trip a cross-domain rule; net 0
+        # (pour / unconnected convention) never carries a domain.
+        candidates = blocked_region & annulus & (net_region != net) & (net_region != 0)
+        if not bool(np.any(candidates)):
+            return False
+
+        from .pairwise_clearance import _attach_zone_exempts
+
+        matrix = state.matrix
+        zones = self._attach_zones
+        layer_obj = self._grid_layer_object(layer)
+        own_name = state.id_to_name.get(net, "")
+        cw = self.grid.grid_to_world(gx, gy)
+        cand_rows, cand_cols = np.nonzero(candidates)
+        for row, col in zip(cand_rows, cand_cols, strict=True):
+            foreign_net = int(net_region[row, col])
+            foreign_dom = (
+                net_to_domain[foreign_net] if 0 <= foreign_net < len(net_to_domain) else -1
+            )
+            if foreign_dom < 0:
+                continue
+            required = matrix[dom][foreign_dom]
+            if required <= 0.0:
+                continue  # same domain / no widening for this pair
+            # Widened radius for THIS specific pair (<= wide_r).  A cell in
+            # the annulus but outside this pair's requirement is fine.
+            pair_r = max(1, math.ceil(round((half_mm + required) / res, 6)))
+            if int(dist_sq[row, col]) > pair_r * pair_r:
+                continue
+            if zones:
+                # Attach-zone exemption (#4506) at the approximate gap
+                # midpoint, scoped to THIS layer (#4507) -- the same consult
+                # the C++ kernels make via ``Grid3D::attach_zone_exempts``.
+                fw = self.grid.grid_to_world(x1 + int(col), y1 + int(row))
+                mid_x = (cw[0] + fw[0]) * 0.5
+                mid_y = (cw[1] + fw[1]) * 0.5
+                foreign_name = state.id_to_name.get(foreign_net, "")
+                if _attach_zone_exempts(zones, mid_x, mid_y, own_name, foreign_name, layer_obj):
+                    continue
+            return True
         return False
+
+    def _pairwise_expanded_blocked(self, net: int, scalar_radius: int) -> np.ndarray | None:
+        """Pairwise (HV-isolation) widening bitmap for the A* hot loop.
+
+        Issue #4507: the Python A* hot loop consults the pre-dilated
+        ``compute_expanded_blocked`` bitmap (one array lookup per neighbor,
+        #2430) rather than the per-step ``_is_trace_blocked`` kernel -- so
+        search-time avoidance must be OR-ed into that bitmap.  For every
+        foreign domain whose pair with ``net``'s domain requires widening,
+        the foreign copper is dilated by the pair's widened radius; the
+        #4506 attach-zone waiver then clears the *pairwise contribution*
+        (never the scalar base bitmap) on the layers the zone licences.
+
+        The zone clearing uses the zone bbox expanded by half the pair
+        radius: a kernel-waived candidate ``c`` (gap midpoint inside the
+        bbox, foreign copper inside the bbox) always lies within
+        ``bbox (+) pair_r/2``, so the bitmap never seals an attach entry the
+        midpoint convention would admit.  Where the bitmap is marginally
+        more permissive than the per-cell kernel, the post-route
+        ``route_pairwise_violation`` gate stays authoritative.
+
+        Returns ``None`` when dormant (no table, no projection, or ``net``
+        participates in no widening pair) -- the caller then uses the scalar
+        bitmap unchanged, byte-identical to pre-#4507 behaviour.
+        """
+        table = getattr(self.rules, "pairwise_clearance", None)
+        if table is None:
+            return None
+        state = self._pairwise_search_state(table)
+        if state is None:
+            return None
+        net_to_domain = state.net_to_domain
+        dom = net_to_domain[net] if 0 <= net < len(net_to_domain) else -1
+        if dom < 0:
+            return None
+
+        from .pairwise_clearance import _norm_net_key
+
+        res = self.grid.resolution
+        half_mm = self.rules.trace_width / 2.0
+        own_key = _norm_net_key(state.id_to_name.get(net, ""))
+        net_ids_by_domain: dict[int, list[int]] = {}
+        for net_id, domain in enumerate(net_to_domain):
+            if domain >= 0:
+                net_ids_by_domain.setdefault(domain, []).append(net_id)
+
+        extra: np.ndarray | None = None
+        for foreign_dom, required in enumerate(state.matrix[dom]):
+            if foreign_dom == dom or required <= 0.0:
+                continue
+            pair_r = max(1, math.ceil(round((half_mm + required) / res, 6)))
+            if pair_r <= scalar_radius:
+                continue  # the scalar dilation already covers this pair
+            foreign_ids = net_ids_by_domain.get(foreign_dom)
+            if not foreign_ids:
+                continue
+            foreign_mask = self.grid._blocked & np.isin(self.grid._net, foreign_ids)
+            if not bool(np.any(foreign_mask)):
+                continue
+            pair_extra = self._dilate_zero_padded(foreign_mask, pair_r)
+            if self._attach_zones:
+                foreign_keys = {
+                    _norm_net_key(state.id_to_name.get(net_id, "")) for net_id in foreign_ids
+                }
+                half_waiver_mm = pair_r * res / 2.0
+                for zone in self._attach_zones:
+                    if own_key not in zone.net_names:
+                        continue
+                    member_keys = [key for key in foreign_keys if key in zone.net_names]
+                    if not member_keys:
+                        continue
+                    gx1, gy1 = self.grid.world_to_grid(
+                        zone.min_x - half_waiver_mm, zone.min_y - half_waiver_mm
+                    )
+                    gx2, gy2 = self.grid.world_to_grid(
+                        zone.max_x + half_waiver_mm, zone.max_y + half_waiver_mm
+                    )
+                    gx1 = max(0, gx1)
+                    gy1 = max(0, gy1)
+                    gx2 = min(self.grid.cols - 1, gx2)
+                    gy2 = min(self.grid.rows - 1, gy2)
+                    if gx1 > gx2 or gy1 > gy2:
+                        continue
+                    for layer_idx in range(self.grid.num_layers):
+                        layer_obj = self._grid_layer_object(layer_idx)
+                        if not zone.covers_layer(own_key, layer_obj):
+                            continue
+                        if not any(zone.covers_layer(key, layer_obj) for key in member_keys):
+                            continue
+                        pair_extra[layer_idx, gy1 : gy2 + 1, gx1 : gx2 + 1] = False
+            extra = pair_extra if extra is None else (extra | pair_extra)
+        return extra
+
+    def _dilate_zero_padded(self, mask: np.ndarray, radius: int) -> np.ndarray:
+        """Euclidean-disc dilation of ``mask`` treating out-of-bounds as EMPTY.
+
+        ``RoutingGrid._dilate_blocked``'s pure-NumPy fallback pads with ones
+        (out-of-bounds = blocked), which is correct for the scalar trace
+        radius (copper must stay half-width inside the board) but wrong for
+        the pairwise widening ring: the C++ ``cross_domain_trace_blocked``
+        annulus explicitly SKIPS out-of-bounds cells ("OOB is scalar's job").
+        Ones-padding there would seal a border band ``pair_r`` cells wide --
+        far beyond the board-edge rule -- and can wall off the only compliant
+        detour.  This helper mirrors the C++ convention with zero padding.
+        """
+        if radius <= 1:
+            return mask
+        disc = self.grid._get_disc_kernel(radius)
+        try:
+            # scipy is an optional dependency (same posture as
+            # ``RoutingGrid._dilate_blocked``); the ignore must tolerate both
+            # a missing package and missing stubs across check environments.
+            from scipy.ndimage import (  # type: ignore[import-untyped, import-not-found, unused-ignore]
+                binary_dilation,
+            )
+
+            structure = np.zeros((1, disc.shape[0], disc.shape[1]), dtype=np.bool_)
+            structure[0] = disc
+            return np.asarray(binary_dilation(mask, structure=structure), dtype=np.bool_)
+        except ImportError:
+            rows, cols = self.grid.rows, self.grid.cols
+            padded = np.zeros(
+                (self.grid.num_layers, rows + 2 * radius, cols + 2 * radius), dtype=np.bool_
+            )
+            padded[:, radius : radius + rows, radius : radius + cols] = mask
+            expanded = np.zeros_like(mask)
+            kernel_size = 2 * radius + 1
+            for dy in range(kernel_size):
+                for dx in range(kernel_size):
+                    if disc[dy, dx]:
+                        expanded |= padded[:, dy : dy + rows, dx : dx + cols]
+            return expanded
+
+    def _grid_layer_object(self, layer: int) -> Layer | None:
+        """Grid layer index -> :class:`Layer` enum member (or ``None``).
+
+        The #4506 attach zones scope their waiver by KiCad layer *name*;
+        the grid's own ``_index_to_layer`` map is the translation authority
+        (the same mapping ``layer_to_index`` inverts for segments and vias).
+        ``None`` -- the layer-agnostic waiver verdict -- is returned when the
+        index is unmapped, mirroring the C++ ``layer = -1`` convention.
+        """
+        enum_value = self.grid._index_to_layer.get(layer)
+        if enum_value is None:
+            return None
+        try:
+            return Layer(enum_value)
+        except ValueError:
+            return None
 
     # Issue #3438: per-conflicted-step penalty charged by the relief
     # probe when crossing a foreign usage-0 non-obstacle cell.  Must stay
@@ -2615,6 +3016,17 @@ class Router:
             # excluded from the hard bitmap (penalised per step instead).
             relief_mode=self.relief_mode and allow_sharing,
         )
+
+        # Issue #4507 / Epic #4431 Phase 2b parity: OR the pairwise
+        # (HV-isolation) widening into the hot-loop bitmap so the pure-Python
+        # A* avoids HV<->LV proximity at search time instead of discovering
+        # it at the post-route gate.  A HARD block in negotiated mode too,
+        # matching the C++ ``cross_domain_trace_blocked`` (a creepage
+        # requirement cannot "negotiate away").  ``None`` when dormant --
+        # the bitmap is then byte-identical to pre-#4507.
+        pairwise_extra = self._pairwise_expanded_blocked(start.net, net_trace_half_width_cells)
+        if pairwise_extra is not None:
+            expanded_blocked = expanded_blocked | pairwise_extra
 
         # Issue #2430: Build crossing grid index if routed segments exist.
         if self.rules.crossing_penalty > 0.0 and self._routed_segments:

--- a/tests/router/test_pairwise_cpp_parity.py
+++ b/tests/router/test_pairwise_cpp_parity.py
@@ -1353,8 +1353,17 @@ def test_layer_scoped_zone_converges_where_layer_agnostic_thrashes() -> None:
     # It found the legal answer: cross on the layer the rated part licences.
     assert "B_CU" in layers
 
-    blind_route, _, _, blind_fallback = _route_through_a_rated_gap(layer_scoped=False)
-    # The pre-#4507 shape cannot get there: it burns the resume budget on routes
-    # the layer-scoped gate rejects and ends up in the slow Python fallback.
+    blind_route, blind_violation, blind_layers, blind_fallback = _route_through_a_rated_gap(
+        layer_scoped=False
+    )
+    # The pre-#4507 shape cannot get there in the C++ search: it burns the
+    # resume budget on routes the layer-scoped gate rejects and ends up in the
+    # slow Python fallback.
     assert blind_fallback is True, "the agnostic baseline is expected to thrash into fallback"
-    assert blind_route is None
+    # Since the pure-Python fallback became pairwise-aware and layer-scoped
+    # itself (#4507, the search-time fallback slice), it now RESCUES the net --
+    # slowly, but gate-clean and on the licensed layer -- where it previously
+    # failed outright (``blind_route is None`` was the pinned pre-slice state).
+    assert blind_route is not None, "the pairwise-aware Python fallback should rescue the net"
+    assert blind_violation is None
+    assert "B_CU" in blind_layers

--- a/tests/router/test_pairwise_python_search.py
+++ b/tests/router/test_pairwise_python_search.py
@@ -1,0 +1,370 @@
+"""Pure-Python A* search-time pairwise (HV-isolation) avoidance (Issue #4507).
+
+Epic #4431 Phase 2b armed only the C++ search (#4511): the pure-Python
+fallback A* kept proposing HV-through-LV paths that the Phase-1 post-route
+gate (``route_pairwise_violation``) then rejected -- so a net that fell back
+on an HV board burned its budget instead of converging (observed directly by
+PR #4780's convergence fixture, whose layer-agnostic arm "burns its resume
+budget into the Python fallback and returns None").
+
+This module pins the Python mirrors of the C++ search kernels:
+
+* ``Router._cross_domain_trace_blocked`` / ``_cross_domain_via_blocked`` --
+  the per-cell annulus kernels folded into ``_is_trace_blocked`` /
+  ``_is_via_blocked`` (siblings of ``Pathfinder::cross_domain_trace_blocked``
+  / ``cross_domain_via_blocked``);
+* ``Router._pairwise_expanded_blocked`` -- the hot-loop bitmap widening
+  OR-ed into ``compute_expanded_blocked``'s dilated mask (#2430), with the
+  out-of-bounds-is-EMPTY dilation convention the C++ annulus uses ("OOB is
+  scalar's job");
+* the layer-scoped #4506 attach-zone waiver in both forms; and
+* the headline convergence: a two-domain board where the HV-blind Python A*
+  hugs the LV wall at the scalar floor, and the armed search detours to the
+  full creepage requirement -- gate-clean, no post-route thrash.
+
+Everything here runs WITHOUT the C++ extension -- that is the point.
+"""
+
+from __future__ import annotations
+
+import math
+
+from kicad_tools.router.grid import RoutingGrid
+from kicad_tools.router.layers import Layer, LayerStack
+from kicad_tools.router.pairwise_clearance import (
+    AttachZone,
+    build_pairwise_clearance_table,
+    route_pairwise_violation,
+)
+from kicad_tools.router.pathfinder import Router
+from kicad_tools.router.primitives import Pad
+from kicad_tools.router.rules import DesignRules, NetClassRouting
+
+# IEC 60664-1, PD2, material group IIIa @ 150 V -> 1.6 mm (same constant the
+# C++ parity suite pins in ``test_pairwise_cpp_parity.py``).
+IEC_150V_PD2_IIIA_MM = 1.6
+DRU = 0.2
+TRACE_WIDTH = 0.2
+
+HV_NET = 1
+LV_NET = 2
+HV_TAP_NET = 3  # same 150 V domain as HV -> no widening between them
+
+NET_NAMES = {"HV": HV_NET, "LV": LV_NET, "HV_TAP": HV_TAP_NET}
+VOLTAGES = {"HV": 150.0, "LV": 0.0, "HV_TAP": 150.0}
+
+
+def _rules(with_table: bool = True) -> DesignRules:
+    rules = DesignRules(
+        trace_width=TRACE_WIDTH,
+        trace_clearance=DRU,
+        via_diameter=0.6,
+        via_clearance=DRU,
+        grid_resolution=0.1,
+    )
+    if with_table:
+        rules.pairwise_clearance = build_pairwise_clearance_table(VOLTAGES, dru=DRU)
+    return rules
+
+
+def _router_with_lv_wall(
+    with_table: bool = True,
+    *,
+    wall_net: int = LV_NET,
+    wall_net_name: str = "LV",
+    wall_layers: tuple[Layer, ...] = (Layer.F_CU,),
+    name_map: dict[str, int] | None = None,
+) -> tuple[Router, RoutingGrid]:
+    """A 30x20 board with a 6 x 0.6 mm foreign wall centred at (15, 10)."""
+    rules = _rules(with_table)
+    grid = RoutingGrid(width=30.0, height=20.0, rules=rules, layer_stack=LayerStack.two_layer())
+    for layer in wall_layers:
+        grid.add_pad(
+            Pad(
+                x=15.0,
+                y=10.0,
+                width=6.0,
+                height=0.6,
+                net=wall_net,
+                net_name=wall_net_name,
+                layer=layer,
+            )
+        )
+    router = Router(grid, rules, diagonal_routing=True)
+    router.set_net_name_to_id(dict(NET_NAMES) if name_map is None else name_map)
+    return router, grid
+
+
+def _grid_pos(grid: RoutingGrid, x: float, y: float) -> tuple[int, int]:
+    return grid.world_to_grid(x, y)
+
+
+# ---------------------------------------------------------------------------
+# Per-cell annulus kernels (``_is_trace_blocked`` / ``_is_via_blocked``)
+# ---------------------------------------------------------------------------
+
+
+def test_trace_annulus_blocks_hv_near_lv_copper() -> None:
+    """Scalar-clear, pairwise-short: the widened trace kernel hard-blocks.
+
+    0.7 mm above the LV pad edge clears the 0.2 mm scalar rule by 3x but
+    falls far short of the 1.6 mm creepage requirement.
+    """
+    router, grid = _router_with_lv_wall()
+    gx, gy = _grid_pos(grid, 15.0, 9.0)  # 0.7 mm from the pad edge at y=9.7
+    assert router._is_trace_blocked(gx, gy, 0, HV_NET) is True
+
+
+def test_trace_annulus_clear_beyond_pairwise_requirement() -> None:
+    router, grid = _router_with_lv_wall()
+    gx, gy = _grid_pos(grid, 15.0, 7.0)  # 2.7 mm gap >= 1.6 mm + widths
+    assert router._is_trace_blocked(gx, gy, 0, HV_NET) is False
+
+
+def test_trace_annulus_dormant_without_table() -> None:
+    """No voltage map -> the same position keeps its scalar verdict."""
+    router, grid = _router_with_lv_wall(with_table=False)
+    gx, gy = _grid_pos(grid, 15.0, 9.0)
+    assert router._is_trace_blocked(gx, gy, 0, HV_NET) is False
+
+
+def test_trace_annulus_dormant_without_name_map() -> None:
+    """The projection is keyed by net id -- an empty map keeps it dormant."""
+    router, grid = _router_with_lv_wall(name_map={})
+    gx, gy = _grid_pos(grid, 15.0, 9.0)
+    assert router._is_trace_blocked(gx, gy, 0, HV_NET) is False
+
+
+def test_trace_annulus_same_domain_not_widened() -> None:
+    """HV_TAP (150 V) vs an HV wall (150 V): |dV| = 0 -> no widening pair."""
+    router, grid = _router_with_lv_wall(wall_net=HV_NET, wall_net_name="HV")
+    gx, gy = _grid_pos(grid, 15.0, 9.0)
+    assert router._is_trace_blocked(gx, gy, 0, HV_TAP_NET) is False
+
+
+def test_trace_annulus_net0_copper_never_widened() -> None:
+    """Net-0 blocked cells (pours / no-net obstacles) carry no domain."""
+    router, grid = _router_with_lv_wall(wall_net=0, wall_net_name="")
+    gx, gy = _grid_pos(grid, 15.0, 9.0)
+    assert router._is_trace_blocked(gx, gy, 0, HV_NET) is False
+
+
+def test_trace_annulus_other_layer_copper_ignored() -> None:
+    """The trace kernel scans its own layer only (surface creepage)."""
+    router, grid = _router_with_lv_wall(wall_layers=(Layer.B_CU,))
+    gx, gy = _grid_pos(grid, 15.0, 9.0)
+    assert router._is_trace_blocked(gx, gy, 0, HV_NET) is False
+
+
+def test_via_annulus_blocks_and_clears() -> None:
+    router, grid = _router_with_lv_wall()
+    near = _grid_pos(grid, 15.0, 8.8)
+    far = _grid_pos(grid, 15.0, 7.0)
+    assert router._is_via_blocked(*near, 0, HV_NET) is True
+    assert router._is_via_blocked(*far, 0, HV_NET) is False
+
+
+def test_via_annulus_dormant_without_table() -> None:
+    router, grid = _router_with_lv_wall(with_table=False)
+    gx, gy = _grid_pos(grid, 15.0, 8.8)
+    assert router._is_via_blocked(gx, gy, 0, HV_NET) is False
+
+
+# ---------------------------------------------------------------------------
+# Layer-scoped attach-zone waiver (#4506 / #4699 parity)
+# ---------------------------------------------------------------------------
+
+_ZONE_BBOX = (12.0, 8.0, 18.0, 12.0)  # covers the wall and the probe points
+
+
+def _zone(net_layers: frozenset = frozenset()) -> AttachZone:
+    return AttachZone(*_ZONE_BBOX, frozenset({"HV", "LV"}), net_layers)
+
+
+def test_trace_annulus_attach_zone_waives_widening() -> None:
+    """A layer-agnostic zone (no ``net_layers``) waives the widening."""
+    router, grid = _router_with_lv_wall()
+    router.set_attach_zones((_zone(),))
+    gx, gy = _grid_pos(grid, 15.0, 9.0)
+    assert router._is_trace_blocked(gx, gy, 0, HV_NET) is False
+
+
+def test_trace_annulus_attach_zone_waiver_is_layer_scoped() -> None:
+    """A B.Cu-only zone must NOT waive the pair on F.Cu (#4699 / #4507).
+
+    Same board, same probe point; only the zone's licensed layers differ.
+    """
+    b_cu_only = frozenset({("HV", frozenset({"B.Cu"})), ("LV", frozenset({"B.Cu"}))})
+    router, grid = _router_with_lv_wall()
+    router.set_attach_zones((_zone(b_cu_only),))
+    gx, gy = _grid_pos(grid, 15.0, 9.0)
+    assert router._is_trace_blocked(gx, gy, 0, HV_NET) is True
+
+    f_cu_scoped = frozenset({("HV", frozenset({"F.Cu"})), ("LV", frozenset({"F.Cu"}))})
+    router2, grid2 = _router_with_lv_wall()
+    router2.set_attach_zones((_zone(f_cu_scoped),))
+    assert router2._is_trace_blocked(gx, gy, 0, HV_NET) is False
+
+
+def test_trace_annulus_zone_requires_both_member_nets() -> None:
+    """A zone listing only one of the two nets never waives the pair."""
+    router, grid = _router_with_lv_wall()
+    router.set_attach_zones((AttachZone(*_ZONE_BBOX, frozenset({"HV", "OTHER"}), frozenset()),))
+    gx, gy = _grid_pos(grid, 15.0, 9.0)
+    assert router._is_trace_blocked(gx, gy, 0, HV_NET) is True
+
+
+# ---------------------------------------------------------------------------
+# Hot-loop bitmap widening (``_pairwise_expanded_blocked``)
+# ---------------------------------------------------------------------------
+
+
+def test_bitmap_dormant_without_table_or_map() -> None:
+    router, _grid = _router_with_lv_wall(with_table=False)
+    assert router._pairwise_expanded_blocked(HV_NET, router._trace_half_width_cells) is None
+
+    router2, _grid2 = _router_with_lv_wall(name_map={})
+    assert router2._pairwise_expanded_blocked(HV_NET, router2._trace_half_width_cells) is None
+
+
+def test_bitmap_dormant_for_domainless_net() -> None:
+    """A net in no widening pair gets the scalar bitmap unchanged."""
+    router, _grid = _router_with_lv_wall(name_map={"HV": HV_NET, "LV": LV_NET, "OTHER": 7})
+    assert router._pairwise_expanded_blocked(7, router._trace_half_width_cells) is None
+
+
+def test_bitmap_widens_annulus_and_respects_pair_radius() -> None:
+    router, grid = _router_with_lv_wall()
+    extra = router._pairwise_expanded_blocked(HV_NET, router._trace_half_width_cells)
+    assert extra is not None
+    near = _grid_pos(grid, 15.0, 9.0)  # 0.7 mm gap < 1.6 mm requirement
+    far = _grid_pos(grid, 15.0, 7.0)  # 2.7 mm gap: outside the pair radius
+    assert bool(extra[0, near[1], near[0]]) is True
+    assert bool(extra[0, far[1], far[0]]) is False
+
+
+def test_bitmap_does_not_seal_the_board_edge() -> None:
+    """Out-of-bounds is EMPTY for the pairwise ring ("OOB is scalar's job").
+
+    ``RoutingGrid._dilate_blocked``'s fallback pads with ones; reusing it for
+    the pairwise radius would seal a ``pair_r``-wide band along every board
+    edge and wall off compliant detours.  Cells near the edge but far from
+    any foreign copper must stay free.
+    """
+    router, grid = _router_with_lv_wall()
+    extra = router._pairwise_expanded_blocked(HV_NET, router._trace_half_width_cells)
+    assert extra is not None
+    corner = _grid_pos(grid, 1.0, 1.0)  # ~11 mm from the wall, near the edge
+    assert bool(extra[0, corner[1], corner[0]]) is False
+
+
+def test_bitmap_attach_zone_clears_pairwise_contribution_layer_scoped() -> None:
+    router, grid = _router_with_lv_wall(wall_layers=(Layer.F_CU, Layer.B_CU))
+    f_cu_scoped = frozenset({("HV", frozenset({"F.Cu"})), ("LV", frozenset({"F.Cu"}))})
+    router.set_attach_zones((_zone(f_cu_scoped),))
+    extra = router._pairwise_expanded_blocked(HV_NET, router._trace_half_width_cells)
+    assert extra is not None
+    gx, gy = _grid_pos(grid, 15.0, 9.0)  # inside the zone bbox
+    assert bool(extra[0, gy, gx]) is False  # waived on the licensed layer
+    assert bool(extra[1, gy, gx]) is True  # NOT waived on B.Cu
+
+
+# ---------------------------------------------------------------------------
+# Headline: the pure-Python fallback CONVERGES on a two-domain board
+# ---------------------------------------------------------------------------
+
+# Tall LV wall: x in [14.7, 15.3], y in [3, 17], both layers.  The only way
+# across is around a wall tip, so the passing distance equals the enforced
+# clearance -- the discriminating geometry (a short wall lets the A* detour
+# arbitrarily wide by accident).
+_WALL_RECT = (14.7, 15.3, 3.0, 17.0)
+_REQUIRED = IEC_150V_PD2_IIIA_MM
+
+
+def _route_two_domain_board(with_table: bool):
+    rules = _rules(with_table)
+    grid = RoutingGrid(width=30.0, height=20.0, rules=rules, layer_stack=LayerStack.two_layer())
+    start = Pad(x=3.0, y=10.0, width=0.6, height=0.6, net=HV_NET, net_name="HV", layer=Layer.F_CU)
+    end = Pad(x=27.0, y=10.0, width=0.6, height=0.6, net=HV_NET, net_name="HV", layer=Layer.F_CU)
+    grid.add_pad(start)
+    grid.add_pad(end)
+    for layer in (Layer.F_CU, Layer.B_CU):
+        grid.add_pad(
+            Pad(x=15.0, y=10.0, width=0.6, height=14.0, net=LV_NET, net_name="LV", layer=layer)
+        )
+    nc = NetClassRouting(name="HV", trace_width=TRACE_WIDTH, clearance=DRU)
+    router = Router(grid, rules, diagonal_routing=True, net_class_map={"HV": nc})
+    router.set_net_name_to_id({"HV": HV_NET, "LV": LV_NET})
+    route = router.route(start, end, net_class=nc)
+    return router, route
+
+
+def _min_edge_gap(route) -> float:
+    x1, x2, y1, y2 = _WALL_RECT
+    best = float("inf")
+    for seg in route.segments:
+        for i in range(101):
+            t = i / 100.0
+            px = seg.x1 + t * (seg.x2 - seg.x1)
+            py = seg.y1 + t * (seg.y2 - seg.y1)
+            cx = min(max(px, x1), x2)
+            cy = min(max(py, y1), y2)
+            best = min(best, math.hypot(px - cx, py - cy))
+    return best - TRACE_WIDTH / 2.0
+
+
+def test_python_search_two_domain_board_converges() -> None:
+    """Headline (#4507): the pure-Python A* converges on an HV board.
+
+    The SAME geometry, routed by the SAME Python search, with and without the
+    pairwise table:
+
+    * WITHOUT the table the HV-blind search rounds the LV wall tip at the
+      scalar floor -- far below the 1.6 mm creepage requirement (this is the
+      route the Phase-1 gate would reject, i.e. the pre-#4507 thrash).
+    * WITH the table the search detours to the full requirement and the
+      post-route gate accepts it first try.
+    """
+    blind_router, blind_route = _route_two_domain_board(with_table=False)
+    assert blind_route is not None
+    assert _min_edge_gap(blind_route) < _REQUIRED  # the discriminating hug
+
+    armed_router, armed_route = _route_two_domain_board(with_table=True)
+    assert armed_route is not None, "domain-aware Python search failed to converge"
+    assert _min_edge_gap(armed_route) >= _REQUIRED - 1e-3
+    # The Phase-1 acceptance gate agrees with the search verdict.
+    assert (
+        route_pairwise_violation(
+            armed_route,
+            HV_NET,
+            armed_router.grid.routes,
+            armed_router.rules.pairwise_clearance,
+            id_to_name={HV_NET: "HV", LV_NET: "LV"},
+        )
+        is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# cpp_backend fallback threading (#4507)
+# ---------------------------------------------------------------------------
+
+
+def test_cpp_backend_setter_forwards_name_map_to_fallback_router() -> None:
+    """``CppPathfinder.set_net_name_to_id`` keeps the fallback in lock-step.
+
+    Without the forward the fallback Router's domain projection is empty and
+    its search-time kernels stay dormant (HV-blind) -- exactly the state this
+    slice removes.  White-box: inject a live fallback router and assert the
+    setter propagates.  This does not require the C++ extension.
+    """
+    from kicad_tools.router.cpp_backend import CppPathfinder
+
+    router, _grid = _router_with_lv_wall(with_table=False, name_map={})
+    backend = CppPathfinder.__new__(CppPathfinder)  # no C++ construction
+    backend._net_name_to_id = {}
+    backend._pairwise_cpp_payload = None
+    backend._pairwise_cpp_installed = False
+    backend._py_router = router
+    CppPathfinder.set_net_name_to_id(backend, NET_NAMES)
+    assert router._net_name_to_id == NET_NAMES


### PR DESCRIPTION
## Summary

Third partial increment of #4507 (epic #4431 Phase 2). Phase 2b (#4511) armed only the **C++** search with pairwise (HV-isolation) avoidance; the **pure-Python fallback A\*** stayed HV-blind, carrying only the Phase-1 *post-route* gate. On an HV board that means the exact thrash this phase exists to remove — the fallback proposes HV-through-LV paths, `route_pairwise_violation` rejects them, and the net fails. This is not hypothetical: PR #4780's convergence fixture observed it directly (the layer-agnostic arm "burns its resume budget into the Python fallback and returns None"). The fallback is exactly where nets land when the C++ search gives up, so an HV-blind fallback converts "C++ needed a rescue" into "net failed".

This PR mirrors the C++ `cross_domain_*` search kernels on the Python side, built on the **same** `build_cpp_domain_matrix` projection the C++ grid consumes — one implementation, no forked lookup, so the two searches cannot disagree about domains.

## Changes

- **Per-cell annulus kernels** (`Router._cross_domain_trace_blocked` / `_cross_domain_via_blocked` in `pathfinder.py`): after the scalar disc clears, scan the ring out to the widest pair for blocked foreign copper whose domain pair requires widening — same annulus shape, same per-pair radius arithmetic (`ceil((half_mm + required)/res)` with the #864 round-before-ceil idiom), same layer-scoped #4506 attach-zone waiver at the approximate gap midpoint as the C++ kernels. Folded into `_is_trace_blocked` (both sharing modes) and `_is_via_blocked` (both exit paths).
- **Hot-loop bitmap widening** (`Router._pairwise_expanded_blocked`): the Python A* hot loop consults the pre-dilated `compute_expanded_blocked` bitmap (#2430), not the per-step kernel — so the widening is OR-ed into that bitmap in `_route_impl`: foreign-domain copper dilated by each pair's widened radius, with zone waivers clearing only the *pairwise contribution* (never the scalar base) on the layers the zone licences (bbox expanded by `pair_r/2`, the midpoint-convention envelope, so an attach entry is never sealed). A HARD block in negotiated mode too, matching C++ (a creepage requirement cannot "negotiate away").
- **Out-of-bounds is EMPTY for the ring** (`_dilate_zero_padded`): `RoutingGrid._dilate_blocked`'s pure-NumPy fallback pads with ones (OOB = blocked) — correct for the scalar trace radius, wrong for the pairwise ring: at a 1.6 mm requirement it would seal a 17-cell band along every board edge and wall off the only compliant detour (found empirically: the convergence fixture failed outright until this). The C++ annulus explicitly skips OOB ("OOB is scalar's job"); the new helper mirrors that with zero padding.
- **Fallback threading** (`cpp_backend.py`): `CppPathfinder.set_net_name_to_id` now forwards to the lazily built fallback `Router`, and the lazy construction seeds it (attach zones were already forwarded) — without the map the fallback's domain projection is empty and its kernels stay dormant, i.e. the fallback would remain HV-blind in production.
- **`test_layer_scoped_zone_converges_where_layer_agnostic_thrashes` updated** (PR #4780's headline): its layer-agnostic arm pinned `blind_route is None` — the fallback failing outright, which was precisely the pre-slice HV-blindness. The C++-side contract is unchanged and still asserted (`blind_fallback is True`; layer-scoped arm converges in pure C++); the fallback outcome now asserts the *rescue*: a non-None, gate-clean route on the licensed B.Cu layer.
- **Dormancy**: without `--voltage-map` every new path is one `getattr` + `None` test per check and a byte-identical bitmap; with a table but a net in no widening pair, the projection returns the dormant signal per net.
- One-line CHANGELOG entry under `[Unreleased]` / `### Fixed`.

Not in this slice (deliberate): the C++ `pairwise_avoidance_cost` soft gradient has no Python mirror (hard blocking is the convergence-critical piece; the fallback is not a performance path), and the diagonal-corner probe is not separately widened (both endpoints of a diagonal step consult the annulus; the ceil-rounded pair radius keeps the mid-step within requirement — documented in the kernel comment block).

## Acceptance Criteria Verification

| Criterion (from #4507 / its children) | Status | Verification |
|---|---|---|
| Search-time avoidance so an HV board converges instead of thrashing (Ask item 2), now including the Python fallback | Done | `test_python_search_two_domain_board_converges`: same board, same Python search — blind rounds the LV wall tip at 0.6 mm edge gap (< 1.6 mm required, the route the gate rejects); armed detours to 2.09 mm and the gate accepts first try |
| Search agrees with the Phase-1 gate (no search↔gate disagreement) | Done | Headline test asserts `route_pairwise_violation(...) is None` on the armed route; kernels share `build_cpp_domain_matrix` with the C++ side; the #4780 fixture's fallback arm now ends gate-clean instead of failing |
| Attach-zone exemption (#4506) threaded, layer-scoped (#4699/#4780 parity) | Done | `test_trace_annulus_attach_zone_waiver_is_layer_scoped`, `test_bitmap_attach_zone_clears_pairwise_contribution_layer_scoped` — same probe point, only the zone's licensed layers differ |
| Backward compat — no `--voltage-map` ⇒ unchanged behavior | Done | Dormant unit tests (no table / empty name map / domain-less net) + `test_astar_tiebreak_determinism.py`, `test_board_route_determinism.py`, `test_preserve_existing.py` all pass |
| C++ mirrors stay consistent | Done | No C++ edits; `tests/router/test_pairwise_cpp_parity.py` (54 tests) passes on the version-19 backend after the one deliberate assertion update above |
| Softstart rev-C manual proof (item 2b residual) | Not attempted | Local-only fixture, epic-owner call — unchanged since PR #4780/#4785's notes; this is why the reference below is `Part of`, not a close |

## Test Plan

Run in the issue worktree (C++ backend built at version 19 for the parity suite; the new suite runs **without** the extension by design):

- `uv run pytest tests/router/test_pairwise_python_search.py` — **19 passed** (new suite: annulus kernels, layer-scoped zone waivers, bitmap widening + OOB-is-empty edge behavior, headline convergence, fallback name-map threading)
- `uv run pytest tests/router/test_pairwise_cpp_parity.py tests/router/test_pairwise_clearance.py tests/router/test_astar_tiebreak_determinism.py tests/router/test_board_route_determinism.py tests/router/test_preserve_existing.py` — **138 passed, 1 skipped** after the deliberate assertion update (the sole failure before it was `test_layer_scoped_zone_converges_where_layer_agnostic_thrashes`'s `blind_route is None`, i.e. the fixed behavior); parity file re-run alone: **54 passed**
- `uv run pytest tests/router/test_cpp_backend_layer_mapping.py tests/router/test_relief_rescue.py tests/router/test_pairwise_python_search.py` — **57 passed, 1 skipped**
- `uv run ruff check .` — All checks passed; `uv run ruff format --check .` — all files already formatted
- `uv run python scripts/ci/check_mypy_baseline.py` (cold, `--no-incremental`) — OK, 1471 errors within the 1473 baseline, no new type errors

Part of #4507
