### PR TITLE
feat(cli): add --format json to the five board-artifact producer commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`--format json` on the 5 board-artifact producers** (part of #4674,
+  fifth batch of the #4543 machine-output sweep) — `board-metrics`,
+  `create-pcb`, `panel`, `report generate` and `screenshot` now accept the
+  canonical `--format json` and emit one deterministic document on stdout
+  instead of prose, wired end-to-end (outer parser → shim → inner
+  parser/handler). Each document describes the artifact the command
+  produced: `board-metrics` wraps a run envelope
+  (`mode`/`dry_run`/`boards[]`) around each board's full `board.json` under
+  `boards[].metrics` rather than overloading that artifact's own schema
+  (text mode still prints the bare artifact); `create-pcb` reports
+  `board` geometry, `components_found`, `placement` (with sorted `failed`
+  and `warnings`), `nets` and the workflow `summary`; `panel` reports
+  `grid`/`board_count`/`tabs`/`cut_method` plus the frame features;
+  `report generate` reports `report_path`, `pdf_path`, the `data_source`
+  it used and a `figures` block naming why figures were skipped;
+  `screenshot` reports `output`, `width_px`/`height_px` and
+  `layers_rendered`. Commands that can run without writing say so
+  structurally (`saved` / `output_path: null` under `--dry-run`) so exit 0
+  cannot be mistaken for a written file. Failure paths emit
+  `{"error": ..., "success": false}` documents with exit codes unchanged,
+  and text-mode output is unchanged. `report generate` additionally
+  diverts stdout to stderr around the collector / figure / PDF stages,
+  because WeasyPrint prints a multi-line installation banner **on stdout**
+  when its native libraries are missing — which would otherwise corrupt the
+  single-document contract. Audit (`scripts/audit_machine_output.py`):
+  prose-only 18 → 13, format-json 179 → 184.
+  `tests/test_format_json_sweep_artifacts.py` guards the new surfaces;
+  `docs/reference/machine-output.md` records the per-command shapes.
+
 - **`--format json` on the 5 environment/integration singles** (part of
   #4674, fourth batch of the #4543 machine-output sweep) — `config`,
   `ipc status`, `ipc connect`, `ipc push-routes` and `mcp setup` now accept

--- a/docs/reference/machine-output.md
+++ b/docs/reference/machine-output.md
@@ -52,13 +52,13 @@ below is issue **#4674** and should build on these helpers.
 Measured by programmatic introspection of the real argparse tree
 (`create_parser()`, recursive walk of `_SubParsersAction` leaves) — not grep:
 
-| Idiom (outer `kct` parser) | Before #4543 | After #4543 | After #4674 b1 | b2 | b3 | b4 |
-|---|---|---|---|---|---|---|
-| `--format` with a `json` choice | 124 | 124 | 148 | 164 | 174 | 179 |
-| Both `--format json` and legacy `--json` alias | 0 | 2 (`placement refine`, `calibrate`) | 2 | 2 | 2 | 2 |
-| `--json` boolean only | 2 | **0** | 0 | 0 | 0 | 0 |
-| `--format` without a `json` choice | 1 (`benchmark report`, `text,markdown`) | 1 | **0** | 0 | 0 | 0 |
-| Neither (prose-only) | 72 | 72 (backlog for #4674, below) | 49 | 33 | 23 | 18 |
+| Idiom (outer `kct` parser) | Before #4543 | After #4543 | After #4674 b1 | b2 | b3 | b4 | b5 |
+|---|---|---|---|---|---|---|---|
+| `--format` with a `json` choice | 124 | 124 | 148 | 164 | 174 | 179 | 184 |
+| Both `--format json` and legacy `--json` alias | 0 | 2 (`placement refine`, `calibrate`) | 2 | 2 | 2 | 2 | 2 |
+| `--json` boolean only | 2 | **0** | 0 | 0 | 0 | 0 | 0 |
+| `--format` without a `json` choice | 1 (`benchmark report`, `text,markdown`) | 1 | **0** | 0 | 0 | 0 | 0 |
+| Neither (prose-only) | 72 | 72 (backlog for #4674, below) | 49 | 33 | 23 | 18 | 13 |
 
 The first #4674 batch swept the grouped-subcommand families -- `mfr` (7),
 `spec` (5), `placement fix/nudge/snap/align/distribute` (5), `zones
@@ -73,9 +73,12 @@ of their leaves but still had prose-only holdouts -- `datasheet` (3), `lib`
 
 The fourth batch swept the environment/integration singles -- `config`,
 `ipc status/connect/push-routes`, `mcp setup` (5) -- finishing the `ipc`
-family outright and finishing `mcp` (`mcp serve` is exempt). The remaining
-18 prose-only leaves (`stitch` and the long tail of single commands, plus
-the 4 exempt and the deferred `route`) stay on the #4674 backlog below.
+family outright and finishing `mcp` (`mcp serve` is exempt).
+
+The fifth batch swept the board-artifact producers -- `board-metrics`,
+`create-pcb`, `panel`, `report generate`, `screenshot` (5). The remaining
+13 prose-only leaves (`stitch` and the rest of the long tail, plus the 4
+exempt and the deferred `route`) stay on the #4674 backlog below.
 
 Issue #4543 closed the `--json`-only bucket by adding `--format {text,json}`
 alongside the existing `--json` on both commands (outer parser, forwarding
@@ -241,16 +244,52 @@ wiring bug is tracked separately in #4788 and is out of scope for this
 sweep. `tests/test_format_json_sweep_env.py` guards these 5 surfaces and is
 written to pass both before and after #4788 is fixed.
 
-**Remaining actionable (13)** — the audit's `prose-only` bucket reads 18
+**Done (fifth #4674 batch, 5 surfaces):** the board-artifact producers — the
+singles that turn a board or schematic into a *file on disk*:
+`board-metrics`, `create-pcb`, `panel`, `report generate`, `screenshot`.
+Shapes:
+
+| Command | Document |
+|---|---|
+| `board-metrics` | `{"command": "board-metrics", "mode": "single"\|"all", "dry_run", "boards": [{"slug", "status", "output_path", "metrics"}], "success"}` — `metrics` is the board's full `board.json`; `output_path` is `null` under `--dry-run` |
+| `create-pcb` | `{"command": "create-pcb", "schematic", "output", "board": {width_mm, height_mm, layers}, "components_found", "placement": {skipped, placed, failed[], warnings[]}, "nets": {assigned, missing_footprints[]}, "summary", "dry_run", "saved", "success"}` |
+| `panel` | `{"command": "panel", "input", "output", "grid": {rows, cols, spacing_mm}, "board_count", "tabs", "cut_method", "tab_width_mm", "tab_count", "frame", "tooling_holes", "fiducials", "success"}` |
+| `report generate` | `{"command": "generate", "input", "manufacturer", "output_dir", "project_name", "report_path", "pdf_path", "data_source": "auto-collect"\|"data-dir"\|"skeleton", "figures": {generated, skipped_reason}, "success"}` |
+| `screenshot` | `{"command": "screenshot", "input", "output", "width_px", "height_px", "layers_rendered", "success"}` |
+
+Three conventions this batch adds:
+
+- **The envelope is not the artifact.** `board-metrics` already printed a
+  JSON *artifact* (`board.json`) under `--dry-run`; `--format json` wraps a
+  distinct run envelope around it (`boards[].metrics`) rather than
+  overloading the artifact's schema, and text mode still prints the bare
+  artifact. A command whose normal output is already JSON should do the
+  same — the document describes the *run*, the artifact keeps its own
+  contract. `metrics.generated_at` is the one deliberately volatile field
+  (it belongs to the board.json contract), so determinism is asserted
+  modulo that key.
+- **Producers say whether they produced.** Anything that can run without
+  writing (`--dry-run`) reports it structurally: `saved`/`output_path`
+  rather than exit 0 alone.
+- **Third-party stdout chatter must be diverted, not trusted.**
+  `report generate` calls into a data collector, a figure generator, and
+  WeasyPrint — the last of which prints a multi-line "install my native
+  libraries" banner *on stdout* when they are missing, which would corrupt
+  the single-document contract on any machine without them. The
+  `_stdout_to_stderr_when(as_json)` helper in `report_cmd.py` captures those
+  regions and replays them on stderr; copy it for any leaf that calls
+  third-party code it does not own.
+
+`tests/test_format_json_sweep_artifacts.py` guards these 5 surfaces.
+
+**Remaining actionable (8)** — the audit's `prose-only` bucket reads 13
 because it also counts the 4 exempt commands and the deferred `route`
 (sections above):
 
-- `board-metrics`, `build`, `create-pcb`, `creepage-export-rules`
+- `build`, `creepage-export-rules`
 - `optimize-placement`, `optimize-traces`
-- `panel`
 - `pipeline`
-- `reason`, `report generate`, `route-auto`
-- `screenshot`
+- `reason`, `route-auto`
 - `stitch` (single command, but its 6k-line inner module has a bespoke
   multi-phase report — batch it alone)
 

--- a/src/kicad_tools/cli/__init__.py
+++ b/src/kicad_tools/cli/__init__.py
@@ -748,6 +748,9 @@ def _run_screenshot_command(args) -> int:
         sub_argv.append("--bw")
     if hasattr(args, "screenshot_theme") and args.screenshot_theme:
         sub_argv.extend(["--theme", args.screenshot_theme])
+    # Machine output (#4674): forward the canonical flag to the inner parser.
+    if getattr(args, "format", "text") != "text":
+        sub_argv.extend(["--format", args.format])
 
     return screenshot_cmd(sub_argv)
 
@@ -784,6 +787,9 @@ def _run_report_command(args) -> int:
             sub_argv.append("--skip-erc")
         if getattr(args, "report_skip_collect", False):
             sub_argv.append("--skip-collect")
+        # Machine output (#4674): forward the canonical flag to the inner parser.
+        if getattr(args, "format", "text") != "text":
+            sub_argv.extend(["--format", args.format])
 
     return report_cmd(sub_argv)
 

--- a/src/kicad_tools/cli/board_metrics_cmd.py
+++ b/src/kicad_tools/cli/board_metrics_cmd.py
@@ -69,6 +69,14 @@ absent or unparseable.
 Schema versioning policy: this schema is the Phase 2 (Astro site) data contract.
 Field additions must be additive — no renames, no type changes. Bump
 ``schema_version`` only for breaking changes. See ``docs/board-json-schema.md``.
+
+Machine output (``--format json``, issue #4674): the *command* prints one
+envelope document describing the run — ``{"command": "board-metrics", "mode":
+"single"|"all", "dry_run", "boards": [...], "success"}`` — where each entry in
+``boards`` carries ``slug``/``status``/``output_path`` plus the board's full
+``metrics`` (the board.json above).  That envelope is deliberately distinct
+from the ``board.json`` artifact itself, which keeps its own schema.  See
+``docs/reference/machine-output.md``.
 """
 
 from __future__ import annotations
@@ -80,6 +88,8 @@ import logging
 import re
 from datetime import datetime, timezone
 from pathlib import Path
+
+from .format_options import FORMAT_JSON, add_format_flag, emit_json
 
 logger = logging.getLogger(__name__)
 
@@ -476,51 +486,110 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Print board.json to stdout without writing any file",
     )
+    add_format_flag(parser)
     args = parser.parse_args(argv)
+    as_json = args.format == FORMAT_JSON
 
     if args.all:
-        return _run_all(Path(args.boards_dir), dry_run=args.dry_run)
+        return _run_all(Path(args.boards_dir), dry_run=args.dry_run, as_json=as_json)
 
     if not args.board:
         parser.error("a board directory is required (or use --all)")
 
     board_dir = Path(args.board)
     if not board_dir.is_dir():
-        print(f"error: board directory not found: {board_dir}")
+        message = f"error: board directory not found: {board_dir}"
+        if as_json:
+            emit_json(_envelope("single", args.dry_run, [], error=message))
+        else:
+            print(message)
         return 1
 
-    if args.dry_run:
-        metrics = extract_board_metrics(board_dir)
-        print(json.dumps(metrics, indent=2))
+    entry = _process_board(board_dir, Path(args.output) if args.output else None, args.dry_run)
+
+    if as_json:
+        emit_json(_envelope("single", args.dry_run, [entry]))
         return 0
 
-    output_path = Path(args.output) if args.output else None
-    written = emit_board_json(board_dir, output_path)
-    metrics = json.loads(written.read_text())
-    print(f"{metrics['slug']:30s} {metrics['status']:13s} -> {written}")
+    if args.dry_run:
+        print(json.dumps(entry["metrics"], indent=2))
+        return 0
+
+    print(f"{entry['slug']:30s} {entry['status']:13s} -> {entry['output_path']}")
     return 0
 
 
-def _run_all(boards_dir: Path, dry_run: bool) -> int:
+def _envelope(
+    mode: str,
+    dry_run: bool,
+    boards: list[dict],
+    *,
+    error: str | None = None,
+) -> dict:
+    """Build the ``--format json`` envelope for one ``board-metrics`` run."""
+    payload: dict = {
+        "command": "board-metrics",
+        "mode": mode,
+        "dry_run": dry_run,
+        "boards": boards,
+        "success": error is None,
+    }
+    if error is not None:
+        payload["error"] = error
+    return payload
+
+
+def _process_board(board_dir: Path, output_path: Path | None, dry_run: bool) -> dict:
+    """Extract (and, unless *dry_run*, write) one board's metrics.
+
+    Returns the per-board entry used by both the prose and the JSON paths, so
+    the two can never report different slugs/statuses for the same run.
+    """
+    if dry_run:
+        metrics = extract_board_metrics(board_dir)
+        written: Path | None = None
+    else:
+        written = emit_board_json(board_dir, output_path)
+        metrics = json.loads(written.read_text())
+    return {
+        "slug": metrics.get("slug", board_dir.name),
+        "status": metrics.get("status"),
+        "output_path": str(written) if written is not None else None,
+        "metrics": metrics,
+    }
+
+
+def _run_all(boards_dir: Path, dry_run: bool, as_json: bool = False) -> int:
     """Process every board under ``boards_dir`` in sorted order."""
     if not boards_dir.is_dir():
-        print(f"error: boards directory not found: {boards_dir}")
+        message = f"error: boards directory not found: {boards_dir}"
+        if as_json:
+            emit_json(_envelope("all", dry_run, [], error=message))
+        else:
+            print(message)
         return 1
 
-    any_board = False
+    entries: list[dict] = []
     for board_dir in _iter_board_dirs(boards_dir):
-        any_board = True
-        if dry_run:
-            metrics = extract_board_metrics(board_dir)
-            print(json.dumps(metrics, indent=2))
+        entry = _process_board(board_dir, None, dry_run)
+        entries.append(entry)
+        if as_json:
             continue
-        written = emit_board_json(board_dir)
-        metrics = json.loads(written.read_text())
-        print(f"{metrics['slug']:30s} {metrics['status']:13s} -> {written}")
+        if dry_run:
+            print(json.dumps(entry["metrics"], indent=2))
+            continue
+        print(f"{entry['slug']:30s} {entry['status']:13s} -> {entry['output_path']}")
 
-    if not any_board:
-        print(f"error: no board subdirectories found under {boards_dir}")
+    if not entries:
+        message = f"error: no board subdirectories found under {boards_dir}"
+        if as_json:
+            emit_json(_envelope("all", dry_run, [], error=message))
+        else:
+            print(message)
         return 1
+
+    if as_json:
+        emit_json(_envelope("all", dry_run, entries))
     return 0
 
 

--- a/src/kicad_tools/cli/commands/board_metrics.py
+++ b/src/kicad_tools/cli/commands/board_metrics.py
@@ -4,6 +4,10 @@ Thin shim that re-serializes the unified-parser args back into an argv list for
 the standalone :mod:`kicad_tools.cli.board_metrics_cmd` module, mirroring the
 pattern used by :func:`run_fleet_command`. This keeps behavior in sync between
 ``kct board-metrics`` and ``python -m kicad_tools.cli.board_metrics_cmd``.
+
+Machine output (``--format json``, issue #4674) is forwarded to the inner
+parser like every other flag; the document shape is described in
+``board_metrics_cmd`` and ``docs/reference/machine-output.md``.
 """
 
 __all__ = ["run_board_metrics_command"]
@@ -31,5 +35,8 @@ def run_board_metrics_command(args) -> int:
 
     if getattr(args, "board_metrics_dry_run", False):
         sub_argv.append("--dry-run")
+
+    if getattr(args, "format", "text") != "text":
+        sub_argv.extend(["--format", args.format])
 
     return board_metrics_main(sub_argv)

--- a/src/kicad_tools/cli/commands/create_pcb.py
+++ b/src/kicad_tools/cli/commands/create_pcb.py
@@ -42,4 +42,8 @@ def run_create_pcb_command(args) -> int:
     if getattr(args, "create_pcb_dry_run", False):
         sub_argv.append("--dry-run")
 
+    # Machine output (#4674): forward the canonical flag to the inner parser.
+    if getattr(args, "format", "text") != "text":
+        sub_argv.extend(["--format", args.format])
+
     return create_pcb_main(sub_argv)

--- a/src/kicad_tools/cli/commands/panel.py
+++ b/src/kicad_tools/cli/commands/panel.py
@@ -1,11 +1,37 @@
-"""Panel (panel) CLI command handler."""
+"""Panel (panel) CLI command handler.
+
+Machine output (``--format json``, issue #4674): ``kct panel`` prints exactly
+one document describing the panel it built -- the resolved ``input``/``output``
+paths, the ``grid`` geometry, ``board_count``, ``tabs``, ``cut_method`` and the
+optional frame features -- or ``{"error": ..., "success": false}`` on any
+failure, with the exit code unchanged.  See
+``docs/reference/machine-output.md``.
+"""
 
 from __future__ import annotations
 
 import sys
 from pathlib import Path
 
+from ..format_options import FORMAT_JSON, emit_json
+
 __all__ = ["run_panel_command"]
+
+
+def _fail(as_json: bool, board: str, message: str, *, text: str | None = None) -> int:
+    """Report a panel failure as a document (JSON) or prose (text)."""
+    if as_json:
+        emit_json(
+            {
+                "command": "panel",
+                "input": board,
+                "error": message,
+                "success": False,
+            }
+        )
+    else:
+        print(text if text is not None else f"Error: {message}", file=sys.stderr)
+    return 1
 
 
 def run_panel_command(args) -> int:
@@ -13,10 +39,11 @@ def run_panel_command(args) -> int:
 
     Creates a manufacturing panel from a source board PCB.
     """
+    as_json = getattr(args, "format", "text") == FORMAT_JSON
+
     board_path = Path(args.panel_input)
     if not board_path.exists():
-        print(f"Error: File not found: {board_path}", file=sys.stderr)
-        return 1
+        return _fail(as_json, str(board_path), f"File not found: {board_path}")
 
     output_path = args.panel_output
     if output_path is None:
@@ -34,13 +61,13 @@ def run_panel_command(args) -> int:
             VCutConfig,
         )
     except ImportError as exc:
-        print(
-            f"Error: {exc}\n"
+        return _fail(
+            as_json,
+            str(board_path),
+            f"{exc}\n"
             "Panelization requires Shapely. Install with: "
             "pip install kicad-tools[geometry]",
-            file=sys.stderr,
         )
-        return 1
 
     # Build config from CLI args
     cut_method = CutMethod.MOUSEBITE
@@ -90,11 +117,40 @@ def run_panel_command(args) -> int:
     try:
         panel = Panel.from_config(board_path, config)
         result_path = panel.save(output_path)
-        print(f"Panel created: {result_path}")
-        print(f"  Grid: {config.rows}x{config.cols} ({panel.board_count} boards)")
-        print(f"  Tabs: {len(panel.tabs)}")
-        print(f"  Cut method: {config.cut_method.value}")
-        return 0
     except Exception as exc:
-        print(f"Error creating panel: {exc}", file=sys.stderr)
-        return 1
+        return _fail(
+            as_json,
+            str(board_path),
+            f"creating panel: {exc}",
+            text=f"Error creating panel: {exc}",
+        )
+
+    if as_json:
+        emit_json(
+            {
+                "command": "panel",
+                "input": str(board_path),
+                "output": str(result_path),
+                "grid": {
+                    "rows": config.rows,
+                    "cols": config.cols,
+                    "spacing_mm": config.spacing,
+                },
+                "board_count": panel.board_count,
+                "tabs": len(panel.tabs),
+                "cut_method": config.cut_method.value,
+                "tab_width_mm": config.tabs.width,
+                "tab_count": config.tabs.count,
+                "frame": config.frame is not None,
+                "tooling_holes": config.tooling_holes is not None,
+                "fiducials": config.fiducials is not None,
+                "success": True,
+            }
+        )
+        return 0
+
+    print(f"Panel created: {result_path}")
+    print(f"  Grid: {config.rows}x{config.cols} ({panel.board_count} boards)")
+    print(f"  Tabs: {len(panel.tabs)}")
+    print(f"  Cut method: {config.cut_method.value}")
+    return 0

--- a/src/kicad_tools/cli/create_pcb_cmd.py
+++ b/src/kicad_tools/cli/create_pcb_cmd.py
@@ -7,6 +7,13 @@ create a blank PCB, place footprints, and assign nets.
 Example:
     kicad-tools create-pcb design.kicad_sch -o board.kicad_pcb --layers 4
     kicad-tools create-pcb design.kicad_sch --width 160 --height 100
+
+Machine output (``--format json``, issue #4674): one document describing the
+generated board -- ``board`` geometry, ``components_found``, the ``placement``
+and ``nets`` results, the workflow ``summary``, and whether the file was
+actually written (``saved``, false under ``--dry-run``).  The rich prose is
+suppressed in JSON mode so stdout carries exactly one document.  See
+``docs/reference/machine-output.md``.
 """
 
 from __future__ import annotations
@@ -17,6 +24,8 @@ from pathlib import Path
 
 from rich.console import Console
 from rich.table import Table
+
+from .format_options import FORMAT_JSON, add_format_flag, emit_json
 
 __all__ = ["main"]
 
@@ -98,13 +107,24 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Show what would be done without saving",
     )
+    add_format_flag(parser)
 
     args = parser.parse_args(argv)
     console = Console()
+    as_json = args.format == FORMAT_JSON
+
+    def say(*print_args, **print_kwargs) -> None:
+        """Print rich prose unless JSON mode owns stdout."""
+        if not as_json:
+            console.print(*print_args, **print_kwargs)
 
     schematic_path = Path(args.schematic)
     if not schematic_path.exists():
-        console.print(f"[red]Error:[/red] Schematic not found: {schematic_path}")
+        message = f"Schematic not found: {schematic_path}"
+        if as_json:
+            emit_json(_error_document(str(schematic_path), message))
+            return 1
+        console.print(f"[red]Error:[/red] {message}")
         return 1
 
     # Determine output path
@@ -116,16 +136,14 @@ def main(argv: list[str] | None = None) -> int:
     try:
         from kicad_tools.workflow import PCBFromSchematic
 
-        console.print(f"[blue]Schematic:[/blue] {schematic_path}")
-        console.print(
-            f"[blue]Board size:[/blue] {args.width} x {args.height} mm, {args.layers} layers"
-        )
+        say(f"[blue]Schematic:[/blue] {schematic_path}")
+        say(f"[blue]Board size:[/blue] {args.width} x {args.height} mm, {args.layers} layers")
 
         workflow = PCBFromSchematic(str(schematic_path))
 
         # Get components
         components = workflow.get_components()
-        console.print(f"[green]Found {len(components)} components[/green]")
+        say(f"[green]Found {len(components)} components[/green]")
 
         # Create PCB
         workflow.create_pcb(
@@ -136,16 +154,28 @@ def main(argv: list[str] | None = None) -> int:
             revision=args.revision,
             company=args.company,
         )
-        console.print("[green]PCB created[/green]")
+        say("[green]PCB created[/green]")
 
         # Place components
+        placement: dict = {
+            "skipped": bool(args.no_place),
+            "placed": 0,
+            "failed": [],
+            "warnings": [],
+        }
         if not args.no_place:
             result = workflow.place_all_components(
                 spacing=args.spacing,
                 columns=args.columns,
                 margin=args.margin,
             )
-            console.print(
+            placement["placed"] = result.success_count
+            placement["failed"] = sorted(
+                ({"reference": ref, "reason": reason} for ref, reason in result.failed),
+                key=lambda item: (item["reference"], item["reason"]),
+            )
+            placement["warnings"] = sorted(result.warnings)
+            say(
                 f"[green]Placed {result.success_count} components[/green]"
                 + (
                     f", [yellow]{result.failure_count} failed[/yellow]"
@@ -155,7 +185,7 @@ def main(argv: list[str] | None = None) -> int:
             )
 
             for warning in result.warnings:
-                console.print(f"[yellow]Warning: {warning}[/yellow]")
+                say(f"[yellow]Warning: {warning}[/yellow]")
 
             if result.failed:
                 table = Table(title="Failed Placements")
@@ -163,42 +193,81 @@ def main(argv: list[str] | None = None) -> int:
                 table.add_column("Reason")
                 for ref, reason in result.failed:
                     table.add_row(ref, reason)
-                console.print(table)
+                say(table)
 
         # Assign nets
         nets = workflow.assign_nets()
-        console.print(f"[green]Assigned {nets.success_count} net connections[/green]")
+        say(f"[green]Assigned {nets.success_count} net connections[/green]")
 
         if nets.missing_footprints:
-            console.print(
-                f"[yellow]Missing footprints: {', '.join(nets.missing_footprints)}[/yellow]"
-            )
+            say(f"[yellow]Missing footprints: {', '.join(nets.missing_footprints)}[/yellow]")
 
         # Summary
         summary = workflow.summary()
-        console.print()
+        say()
         summary_table = Table(title="PCB Summary")
         summary_table.add_column("Property")
         summary_table.add_column("Value")
         for key, value in summary.items():
             summary_table.add_row(str(key), str(value))
-        console.print(summary_table)
+        say(summary_table)
 
         # Save
         if args.dry_run:
-            console.print(f"\n[yellow]Dry run:[/yellow] Would save to {output_path}")
+            say(f"\n[yellow]Dry run:[/yellow] Would save to {output_path}")
         else:
             workflow.save(str(output_path))
-            console.print(f"\n[green]Saved:[/green] {output_path}")
+            say(f"\n[green]Saved:[/green] {output_path}")
+
+        if as_json:
+            emit_json(
+                {
+                    "command": "create-pcb",
+                    "schematic": str(schematic_path),
+                    "output": str(output_path),
+                    "board": {
+                        "width_mm": args.width,
+                        "height_mm": args.height,
+                        "layers": args.layers,
+                    },
+                    "components_found": len(components),
+                    "placement": placement,
+                    "nets": {
+                        "assigned": nets.success_count,
+                        "missing_footprints": sorted(nets.missing_footprints),
+                    },
+                    "summary": {str(key): value for key, value in summary.items()},
+                    "dry_run": bool(args.dry_run),
+                    "saved": not args.dry_run,
+                    "success": True,
+                }
+            )
 
         return 0
 
     except FileNotFoundError as e:
+        if as_json:
+            emit_json(_error_document(str(schematic_path), str(e)))
+            return 1
         console.print(f"[red]Error:[/red] {e}")
         return 1
     except Exception as e:
+        if as_json:
+            emit_json(_error_document(str(schematic_path), str(e)))
+            return 1
         console.print(f"[red]Error:[/red] {e}")
         return 1
+
+
+def _error_document(schematic: str, message: str) -> dict:
+    """The failure document shared by every ``create-pcb`` error path."""
+    return {
+        "command": "create-pcb",
+        "schematic": schematic,
+        "error": message,
+        "saved": False,
+        "success": False,
+    }
 
 
 if __name__ == "__main__":

--- a/src/kicad_tools/cli/parser.py
+++ b/src/kicad_tools/cli/parser.py
@@ -6781,6 +6781,7 @@ def _add_board_metrics_parser(subparsers) -> None:
         action="store_true",
         help="Print board.json to stdout without writing any file",
     )
+    add_format_flag(bm_parser)
 
 
 def _add_fleet_parser(subparsers) -> None:
@@ -7513,6 +7514,7 @@ def _add_panel_parser(subparsers) -> None:
         action="store_true",
         help="Add fiducial marks to the panel frame",
     )
+    add_format_flag(panel_parser)
 
 
 def _add_pipeline_parser(subparsers) -> None:
@@ -7820,6 +7822,7 @@ def _add_create_pcb_parser(subparsers) -> None:
         action="store_true",
         help="Show what would be done without saving",
     )
+    add_format_flag(create_pcb_parser)
 
 
 def _add_build_parser(subparsers) -> None:
@@ -8763,6 +8766,7 @@ def _add_screenshot_parser(subparsers) -> None:
         default=None,
         help="KiCad color theme name",
     )
+    add_format_flag(screenshot_parser)
 
 
 def _add_report_parser(subparsers) -> None:
@@ -8835,6 +8839,7 @@ def _add_report_parser(subparsers) -> None:
         action="store_true",
         help="Skip auto-collection; generate skeleton report (legacy behavior)",
     )
+    add_format_flag(gen_parser)
 
 
 def _add_export_parser(subparsers) -> None:

--- a/src/kicad_tools/cli/report_cmd.py
+++ b/src/kicad_tools/cli/report_cmd.py
@@ -5,15 +5,28 @@ Usage:
     kct report generate board.kicad_pcb --mfr jlcpcb --data-dir data/
     kct report generate board.kicad_pcb --mfr jlcpcb --no-figures
     kct report generate board.kicad_pcb --mfr jlcpcb --sch path/to/root.kicad_sch
+
+Machine output (``--format json``, issue #4674): ``report generate`` prints one
+document naming the ``report_path`` it wrote, the ``pdf_path`` when PDF
+rendering succeeded, the ``data_source`` it used (``auto-collect`` /
+``data-dir`` / ``skeleton``) and a ``figures`` block recording whether figures
+were generated or why they were skipped.  Progress prose is suppressed and
+third-party stdout chatter is diverted to stderr so stdout carries exactly one
+document; warnings keep going to stderr either way.  See
+``docs/reference/machine-output.md``.
 """
 
 from __future__ import annotations
 
 import argparse
+import contextlib
+import io
 import json
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+from .format_options import FORMAT_JSON, add_format_flag, emit_json
 
 if TYPE_CHECKING:
     from kicad_tools.report.figures import FigureEntry
@@ -81,6 +94,7 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Skip auto-collection; generate skeleton report (legacy behavior)",
     )
+    add_format_flag(gen_parser)
 
     # --- Interactive DRC report sub-command ---
     int_parser = sub.add_parser(
@@ -118,13 +132,58 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
+@contextlib.contextmanager
+def _stdout_to_stderr_when(active: bool):
+    """Divert stdout to stderr while *active* (i.e. JSON mode owns stdout).
+
+    Report generation calls into code that writes progress chatter to stdout
+    and is not this module's to change -- the data collector, the figure
+    generator, and WeasyPrint (which prints a multi-line "install my native
+    libraries" banner on stdout when they are missing).  Under ``--format
+    json`` that would corrupt the single-document contract, so it is captured
+    and replayed on stderr: the diagnostics survive, the JSON stream stays
+    parseable.
+    """
+    if not active:
+        yield
+        return
+    buffer = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(buffer):
+            yield
+    finally:
+        if buffer.getvalue():
+            print(buffer.getvalue(), end="", file=sys.stderr)
+
+
 def _run_generate(args: argparse.Namespace) -> int:
     """Execute the ``generate`` sub-command."""
+    as_json = getattr(args, "format", "text") == FORMAT_JSON
+
+    def say(message: str) -> None:
+        """Print progress prose unless JSON mode owns stdout."""
+        if not as_json:
+            print(message)
+
+    def fail(message: str) -> int:
+        """Report a failure as a document (JSON) or on stderr (text)."""
+        if as_json:
+            emit_json(
+                {
+                    "command": "generate",
+                    "input": str(args.input),
+                    "error": message,
+                    "success": False,
+                }
+            )
+        else:
+            print(message, file=sys.stderr)
+        return 1
+
     try:
         from kicad_tools.report import ReportData, ReportGenerator
     except ImportError as exc:
-        print(str(exc), file=sys.stderr)
-        return 1
+        return fail(str(exc))
 
     input_path = Path(args.input)
     project_name = input_path.stem
@@ -134,29 +193,29 @@ def _run_generate(args: argparse.Namespace) -> int:
     if input_path.suffix == ".kicad_pro":
         pcb_path = input_path.with_suffix(".kicad_pcb")
         if not pcb_path.exists():
-            print(
-                f"Error: PCB file not found: {pcb_path}",
-                file=sys.stderr,
-            )
-            return 1
+            return fail(f"Error: PCB file not found: {pcb_path}")
         input_path = pcb_path
 
     # Determine data source: explicit --data-dir, auto-collection, or skeleton
     version_dir: Path | None = None
+    data_source = "auto-collect"
     if args.data_dir:
+        data_source = "data-dir"
         data_kwargs = _load_data_dir(args.data_dir)
     elif args.skip_collect:
+        data_source = "skeleton"
         data_kwargs = {}
     else:
         # Auto-collect: write snapshots into the versioned output directory.
         # This pre-determines the version directory so figures land in the same vN/.
-        version_dir, data_kwargs = _auto_collect(
-            pcb_path=input_path,
-            output_dir=Path(args.output),
-            manufacturer=args.mfr,
-            quantity=getattr(args, "quantity", 5),
-            skip_erc=getattr(args, "skip_erc", False),
-        )
+        with _stdout_to_stderr_when(as_json):
+            version_dir, data_kwargs = _auto_collect(
+                pcb_path=input_path,
+                output_dir=Path(args.output),
+                manufacturer=args.mfr,
+                quantity=getattr(args, "quantity", 5),
+                skip_erc=getattr(args, "skip_erc", False),
+            )
 
     data = ReportData(
         project_name=project_name,
@@ -175,40 +234,71 @@ def _run_generate(args: argparse.Namespace) -> int:
     # --- Figure generation ---
     # Only attempt when: no --data-dir (pre-collected data path), no --no-figures,
     # and the input is a .kicad_pcb file.
-    if not args.no_figures and not args.data_dir and input_path.suffix == ".kicad_pcb":
+    if args.no_figures:
+        figures: dict = {"generated": False, "skipped_reason": "disabled by --no-figures"}
+    elif args.data_dir:
+        figures = {"generated": False, "skipped_reason": "pre-collected via --data-dir"}
+    elif input_path.suffix != ".kicad_pcb":
+        figures = {
+            "generated": False,
+            "skipped_reason": f"unsupported input type {input_path.suffix}",
+        }
+    else:
         if version_dir is None:
             version_dir = generator.next_version_dir(Path(args.output))
         figures_dir = version_dir / "figures"
-        _generate_figures(args, input_path, figures_dir, data)
+        with _stdout_to_stderr_when(as_json):
+            figures = _generate_figures(args, input_path, figures_dir, data)
 
     try:
         report_path = generator.generate(data, Path(args.output), version_dir=version_dir)
     except FileExistsError as exc:
-        print(f"Error: {exc}", file=sys.stderr)
-        return 1
+        return fail(f"Error: {exc}")
 
-    print(f"Report written to {report_path}")
+    say(f"Report written to {report_path}")
 
-    # Attempt to render Markdown to HTML then PDF
-    try:
-        from kicad_tools.report.renderers import render_html, render_pdf
+    # Attempt to render Markdown to HTML then PDF.
+    pdf_path: Path | None = None
+    with _stdout_to_stderr_when(as_json):
+        try:
+            from kicad_tools.report.renderers import render_html, render_pdf
 
-        md_content = report_path.read_text(encoding="utf-8")
-        figures_dir = version_dir / "figures" if version_dir is not None else None
-        html_content = render_html(
-            md_content,
-            figures_dir=(figures_dir if figures_dir is not None and figures_dir.is_dir() else None),
+            md_content = report_path.read_text(encoding="utf-8")
+            figures_dir = version_dir / "figures" if version_dir is not None else None
+            html_content = render_html(
+                md_content,
+                figures_dir=(
+                    figures_dir if figures_dir is not None and figures_dir.is_dir() else None
+                ),
+            )
+            pdf_path = report_path.with_suffix(".pdf")
+            render_pdf(html_content, pdf_path)
+            say(f"PDF report written to {pdf_path}")
+        except ImportError:
+            pdf_path = None
+            print(
+                "Hint: install 'kicad-tools[report]' for automatic PDF generation",
+                file=sys.stderr,
+            )
+        except Exception as exc:
+            pdf_path = None
+            print(f"Warning: PDF rendering failed: {exc}", file=sys.stderr)
+
+    if as_json:
+        emit_json(
+            {
+                "command": "generate",
+                "input": str(input_path),
+                "manufacturer": args.mfr,
+                "output_dir": str(args.output),
+                "project_name": project_name,
+                "report_path": str(report_path),
+                "pdf_path": str(pdf_path) if pdf_path is not None else None,
+                "data_source": data_source,
+                "figures": figures,
+                "success": True,
+            }
         )
-        pdf_path = report_path.with_suffix(".pdf")
-        render_pdf(html_content, pdf_path)
-        print(f"PDF report written to {pdf_path}")
-    except ImportError:
-        print(
-            "Hint: install 'kicad-tools[report]' for automatic PDF generation",
-            file=sys.stderr,
-        )
-    except Exception as exc:
-        print(f"Warning: PDF rendering failed: {exc}", file=sys.stderr)
 
     return 0
 
@@ -232,21 +322,27 @@ def _generate_figures(
     input_path: Path,
     figures_dir: Path,
     data: ReportData,
-) -> None:
+) -> dict:
     """Attempt figure generation, populating *data* in place.
 
     Handles graceful degradation: prints a warning to stderr and
     continues without figures if dependencies (kicad-cli / cairosvg)
     are absent.
+
+    Returns the ``figures`` block of the ``--format json`` document
+    (``{"generated": bool, "skipped_reason": str | None}``).  The caller
+    diverts stdout in JSON mode (see :func:`_stdout_to_stderr_when`), so the
+    progress line needs no special handling here.
     """
+
+    def skipped(reason: str) -> dict:
+        print(f"Warning: figure generation skipped — {reason}", file=sys.stderr)
+        return {"generated": False, "skipped_reason": reason}
+
     try:
         from kicad_tools.report import ReportFigureGenerator
     except ImportError as exc:
-        print(
-            f"Warning: figure generation skipped — {exc}",
-            file=sys.stderr,
-        )
-        return
+        return skipped(str(exc))
 
     if args.sch:
         sch_path: Path | None = Path(args.sch)
@@ -256,12 +352,7 @@ def _generate_figures(
         sch_path = find_schematic(input_path)
 
     if sch_path is None:
-        print(
-            "Warning: figure generation skipped — no schematic found. "
-            "Use --sch to specify explicitly.",
-            file=sys.stderr,
-        )
-        return
+        return skipped("no schematic found. Use --sch to specify explicitly.")
 
     try:
         fig_gen = ReportFigureGenerator()
@@ -278,10 +369,9 @@ def _generate_figures(
                 " but failed — try: DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib"
                 " kct report generate ...)"
             )
-        print(
-            f"Warning: figure generation skipped — {exc}{hint}",
-            file=sys.stderr,
-        )
+        return skipped(f"{exc}{hint}")
+
+    return {"generated": True, "skipped_reason": None}
 
 
 def _entries_to_pcb_figures(entries: list[FigureEntry]) -> dict | None:

--- a/src/kicad_tools/cli/screenshot_cmd.py
+++ b/src/kicad_tools/cli/screenshot_cmd.py
@@ -5,6 +5,12 @@ Usage:
     kct screenshot board.kicad_pcb -o board.png
     kct screenshot board.kicad_pcb --layers copper --bw
     kct screenshot schematic.kicad_sch -o schematic.png
+
+Machine output (``--format json``, issue #4674): one document carrying the
+resolved ``input``/``output`` paths, the captured ``width_px``/``height_px``
+and (for PCBs) ``layers_rendered`` in render order; failures emit
+``{"error": ..., "success": false}`` with the exit code unchanged.  See
+``docs/reference/machine-output.md``.
 """
 
 from __future__ import annotations
@@ -12,6 +18,24 @@ from __future__ import annotations
 import argparse
 import sys
 from pathlib import Path
+
+from .format_options import FORMAT_JSON, add_format_flag, emit_json
+
+
+def _fail(as_json: bool, source: str, message: str) -> int:
+    """Report a screenshot failure as a document (JSON) or prose (text)."""
+    if as_json:
+        emit_json(
+            {
+                "command": "screenshot",
+                "input": source,
+                "error": message,
+                "success": False,
+            }
+        )
+    else:
+        print(f"Error: {message}", file=sys.stderr)
+    return 1
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -56,13 +80,14 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="KiCad color theme name",
     )
+    add_format_flag(parser)
 
     args = parser.parse_args(argv)
+    as_json = args.format == FORMAT_JSON
 
     input_path = Path(args.input)
     if not input_path.exists():
-        print(f"Error: File not found: {args.input}", file=sys.stderr)
-        return 1
+        return _fail(as_json, args.input, f"File not found: {args.input}")
 
     # Determine output path
     output_path = args.output
@@ -90,16 +115,29 @@ def main(argv: list[str] | None = None) -> int:
             theme=args.theme,
         )
     else:
-        print(
-            f"Error: Unsupported file type: {input_path.suffix} "
-            "(expected .kicad_pcb or .kicad_sch)",
-            file=sys.stderr,
+        return _fail(
+            as_json,
+            args.input,
+            f"Unsupported file type: {input_path.suffix} (expected .kicad_pcb or .kicad_sch)",
         )
-        return 1
 
     if not result["success"]:
-        print(f"Error: {result['error_message']}", file=sys.stderr)
-        return 1
+        return _fail(as_json, args.input, str(result["error_message"]))
+
+    if as_json:
+        document = {
+            "command": "screenshot",
+            "input": args.input,
+            "output": str(result["output_path"]),
+            "width_px": result["width_px"],
+            "height_px": result["height_px"],
+            # Render order is meaningful (bottom-to-top compositing) and
+            # deterministic for a given input, so it is preserved, not sorted.
+            "layers_rendered": list(result.get("layers_rendered") or []),
+            "success": True,
+        }
+        emit_json(document)
+        return 0
 
     print(f"Screenshot saved to {result['output_path']}")
     print(f"  Size: {result['width_px']}x{result['height_px']} px")

--- a/tests/test_format_json_sweep_artifacts.py
+++ b/tests/test_format_json_sweep_artifacts.py
@@ -1,0 +1,742 @@
+"""Tests for the #4674 machine-output sweep (board-artifact batch).
+
+Issue #4674 (mechanical follow-up to #4543) adds the canonical
+``--format json`` idiom to the prose-only subcommands.  Batch 1 swept the
+grouped families (``tests/test_format_json_sweep.py``), batch 2 the 16
+mutating ``sch`` leaves (``tests/test_format_json_sweep_sch.py``), batch 3 the
+four families' holdouts (``tests/test_format_json_sweep_families.py``) and
+batch 4 the environment/integration singles
+(``tests/test_format_json_sweep_env.py``).
+
+**This batch sweeps the board-artifact producers** -- the five singles that
+turn a board or schematic into a file on disk:
+
+* ``board-metrics``   -- the normalized ``board.json`` per demo board
+* ``create-pcb``      -- a PCB generated from a schematic
+* ``panel``           -- a manufacturing panel generated from a board
+* ``report generate`` -- a versioned Markdown/PDF design report
+* ``screenshot``      -- a PNG capture of a board or schematic
+
+Same conventions as the four sibling modules (a separate file per batch so
+concurrent batches never conflict on a shared ``SWEPT_SURFACES`` literal):
+
+* Outer-parser surface: every swept leaf accepts ``--format`` with a ``json``
+  choice, and the default stays ``text``.
+* Shim forwarding: the outer ``--format json`` reaches the inner parser argv
+  for all four argv-reserializing shims -- the drift bug class
+  ``tests/test_cli_parser_drift.py`` exists for -- and the default (text)
+  invocation must NOT forward it.
+* Emission: a single valid JSON document on stdout, deterministic across two
+  runs on the same input, structure assertions rather than byte-golden
+  payloads, ``{"error": ...}`` documents on failure with exit codes unchanged.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kicad_tools.cli.parser import create_parser
+
+FIXTURES = Path(__file__).parent / "fixtures"
+BOARD = FIXTURES / "routing-diagnostic.kicad_pcb"
+SCHEMATIC = FIXTURES / "simple_rc.kicad_sch"
+
+# Every subcommand swept by this batch, as (command path, minimal extra argv).
+SWEPT_SURFACES: dict[str, list[str]] = {
+    "board-metrics": ["boards/00-demo"],
+    "create-pcb": ["design.kicad_sch"],
+    "panel": ["board.kicad_pcb"],
+    "report generate": ["board.kicad_pcb"],
+    "screenshot": ["board.kicad_pcb"],
+}
+
+
+def _iter_leaves(parser, path=()):
+    subactions = [a for a in parser._actions if isinstance(a, argparse._SubParsersAction)]
+    if not subactions:
+        yield path, parser
+        return
+    for subaction in subactions:
+        for name, sub in subaction.choices.items():
+            yield from _iter_leaves(sub, (*path, name))
+
+
+@pytest.fixture(scope="module")
+def leaves():
+    return {" ".join(path): leaf for path, leaf in _iter_leaves(create_parser())}
+
+
+# ---------------------------------------------------------------------------
+# Outer-parser surface guard
+# ---------------------------------------------------------------------------
+
+
+class TestOuterSurface:
+    @pytest.mark.parametrize("command", sorted(SWEPT_SURFACES))
+    def test_leaf_has_format_json_choice(self, leaves, command):
+        """Each swept leaf declares --format with a json choice."""
+        leaf = leaves.get(command)
+        assert leaf is not None, f"outer parser has no leaf {command!r}"
+        for action in leaf._actions:
+            if "--format" in action.option_strings:
+                assert action.choices and "json" in action.choices, (
+                    f"kct {command} has --format without a 'json' choice "
+                    f"(choices={action.choices}); regresses #4674"
+                )
+                break
+        else:
+            pytest.fail(f"kct {command} lost its --format flag (regresses #4674)")
+
+    @pytest.mark.parametrize("command", sorted(SWEPT_SURFACES))
+    def test_parse_accepts_format_json(self, command):
+        """`kct <command> ... --format json` parses on the real outer parser."""
+        argv = [*command.split(), *SWEPT_SURFACES[command], "--format", "json"]
+        args = create_parser().parse_args(argv)
+        assert args.format == "json"
+
+    @pytest.mark.parametrize("command", sorted(SWEPT_SURFACES))
+    def test_default_format_is_text(self, command):
+        """The default stays text, so no existing invocation changes shape."""
+        args = create_parser().parse_args([*command.split(), *SWEPT_SURFACES[command]])
+        assert args.format == "text"
+
+
+# ---------------------------------------------------------------------------
+# Shim forwarding (outer --format json must reach the inner parser argv)
+# ---------------------------------------------------------------------------
+
+
+class TestShimForwarding:
+    def test_board_metrics_shim_forwards_format(self):
+        from kicad_tools.cli.commands.board_metrics import run_board_metrics_command
+
+        args = create_parser().parse_args(
+            ["board-metrics", "boards/00-demo", "--dry-run", "--format", "json"]
+        )
+        with patch("kicad_tools.cli.board_metrics_cmd.main", return_value=0) as inner:
+            assert run_board_metrics_command(args) == 0
+        sub_argv = inner.call_args[0][0]
+        assert "--format" in sub_argv, f"board-metrics shim dropped --format: {sub_argv}"
+        assert sub_argv[sub_argv.index("--format") + 1] == "json"
+
+    def test_board_metrics_shim_omits_format_for_text_default(self):
+        from kicad_tools.cli.commands.board_metrics import run_board_metrics_command
+
+        args = create_parser().parse_args(["board-metrics", "boards/00-demo"])
+        with patch("kicad_tools.cli.board_metrics_cmd.main", return_value=0) as inner:
+            assert run_board_metrics_command(args) == 0
+        assert "--format" not in inner.call_args[0][0]
+
+    def test_create_pcb_shim_forwards_format(self):
+        from kicad_tools.cli.commands.create_pcb import run_create_pcb_command
+
+        args = create_parser().parse_args(["create-pcb", "design.kicad_sch", "--format", "json"])
+        with patch("kicad_tools.cli.create_pcb_cmd.main", return_value=0) as inner:
+            assert run_create_pcb_command(args) == 0
+        sub_argv = inner.call_args[0][0]
+        assert sub_argv[sub_argv.index("--format") + 1] == "json"
+
+    def test_create_pcb_shim_omits_format_for_text_default(self):
+        from kicad_tools.cli.commands.create_pcb import run_create_pcb_command
+
+        args = create_parser().parse_args(["create-pcb", "design.kicad_sch"])
+        with patch("kicad_tools.cli.create_pcb_cmd.main", return_value=0) as inner:
+            assert run_create_pcb_command(args) == 0
+        assert "--format" not in inner.call_args[0][0]
+
+    def test_screenshot_shim_forwards_format(self):
+        from kicad_tools.cli import _run_screenshot_command
+
+        args = create_parser().parse_args(["screenshot", "board.kicad_pcb", "--format", "json"])
+        with patch("kicad_tools.cli.screenshot_cmd.main", return_value=0) as inner:
+            assert _run_screenshot_command(args) == 0
+        sub_argv = inner.call_args[0][0]
+        assert sub_argv[sub_argv.index("--format") + 1] == "json"
+
+    def test_screenshot_shim_omits_format_for_text_default(self):
+        from kicad_tools.cli import _run_screenshot_command
+
+        args = create_parser().parse_args(["screenshot", "board.kicad_pcb"])
+        with patch("kicad_tools.cli.screenshot_cmd.main", return_value=0) as inner:
+            assert _run_screenshot_command(args) == 0
+        assert "--format" not in inner.call_args[0][0]
+
+    def test_report_shim_forwards_format(self):
+        from kicad_tools.cli import _run_report_command
+
+        args = create_parser().parse_args(
+            ["report", "generate", "board.kicad_pcb", "--format", "json"]
+        )
+        with patch("kicad_tools.cli.report_cmd.main", return_value=0) as inner:
+            assert _run_report_command(args) == 0
+        sub_argv = inner.call_args[0][0]
+        assert sub_argv[0] == "generate"
+        assert sub_argv[sub_argv.index("--format") + 1] == "json"
+
+    def test_report_shim_omits_format_for_text_default(self):
+        from kicad_tools.cli import _run_report_command
+
+        args = create_parser().parse_args(["report", "generate", "board.kicad_pcb"])
+        with patch("kicad_tools.cli.report_cmd.main", return_value=0) as inner:
+            assert _run_report_command(args) == 0
+        assert "--format" not in inner.call_args[0][0]
+
+
+# ---------------------------------------------------------------------------
+# board-metrics emission
+# ---------------------------------------------------------------------------
+
+
+def _run_board_metrics(argv, capsys):
+    from kicad_tools.cli.commands.board_metrics import run_board_metrics_command
+
+    rc = run_board_metrics_command(create_parser().parse_args(argv))
+    return rc, capsys.readouterr().out
+
+
+@pytest.fixture
+def boards_tree(tmp_path):
+    """A minimal ``boards/`` tree with one board carrying a report.md."""
+    board = tmp_path / "boards" / "01-demo"
+    mfg = board / "output" / "manufacturing"
+    mfg.mkdir(parents=True)
+    (mfg / "report.md").write_text(
+        "| Layers | 2 copper |\n"
+        "| Board Size | 50.0 x 40.0 mm |\n"
+        "| Footprints | 12 |\n"
+        "| Signal Net Completion | 100.0 % |\n"
+        "## DRC Status\n| Errors | 0 |\n"
+    )
+    return tmp_path / "boards"
+
+
+def _strip_volatile(payload: dict) -> dict:
+    """Drop the board.json ``generated_at`` wall-clock field.
+
+    ``generated_at`` is a deliberately volatile field of the *board.json*
+    contract (it is the artifact's own timestamp), so determinism is asserted
+    on everything else.
+    """
+    stripped = json.loads(json.dumps(payload))
+    for board in stripped.get("boards", []):
+        board.get("metrics", {}).pop("generated_at", None)
+    return stripped
+
+
+class TestBoardMetricsEmission:
+    def test_dry_run_document(self, boards_tree, capsys):
+        rc, out = _run_board_metrics(
+            ["board-metrics", str(boards_tree / "01-demo"), "--dry-run", "--format", "json"],
+            capsys,
+        )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["command"] == "board-metrics"
+        assert payload["mode"] == "single"
+        assert payload["dry_run"] is True
+        assert payload["success"] is True
+        assert len(payload["boards"]) == 1
+        entry = payload["boards"][0]
+        assert entry["slug"] == "01-demo"
+        assert entry["status"] == "ok"
+        assert entry["output_path"] is None, "--dry-run must not claim a written file"
+        assert entry["metrics"]["layer_count"] == 2
+        assert entry["metrics"]["board_size_mm"] == {"width": 50.0, "height": 40.0}
+
+    def test_dry_run_writes_nothing(self, boards_tree, capsys):
+        _run_board_metrics(
+            ["board-metrics", str(boards_tree / "01-demo"), "--dry-run", "--format", "json"],
+            capsys,
+        )
+        assert not (boards_tree / "01-demo" / "output" / "board.json").exists()
+
+    def test_write_document_names_the_artifact(self, boards_tree, capsys):
+        rc, out = _run_board_metrics(
+            ["board-metrics", str(boards_tree / "01-demo"), "--format", "json"], capsys
+        )
+        assert rc == 0
+        entry = json.loads(out)["boards"][0]
+        written = Path(entry["output_path"])
+        assert written.is_file()
+        assert json.loads(written.read_text())["slug"] == "01-demo"
+
+    def test_document_is_deterministic(self, boards_tree, capsys):
+        argv = ["board-metrics", str(boards_tree / "01-demo"), "--dry-run", "--format", "json"]
+        _, first = _run_board_metrics(argv, capsys)
+        _, second = _run_board_metrics(argv, capsys)
+        assert _strip_volatile(json.loads(first)) == _strip_volatile(json.loads(second))
+
+    def test_all_mode_document(self, boards_tree, capsys):
+        rc, out = _run_board_metrics(
+            ["board-metrics", "--all", "--boards-dir", str(boards_tree), "--format", "json"],
+            capsys,
+        )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["mode"] == "all"
+        assert [entry["slug"] for entry in payload["boards"]] == ["01-demo"]
+
+    def test_missing_board_is_error_document(self, tmp_path, capsys):
+        rc, out = _run_board_metrics(
+            ["board-metrics", str(tmp_path / "nope"), "--format", "json"], capsys
+        )
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["success"] is False
+        assert payload["boards"] == []
+        assert "board directory not found" in payload["error"]
+
+    def test_empty_boards_dir_is_error_document(self, tmp_path, capsys):
+        (tmp_path / "empty").mkdir()
+        rc, out = _run_board_metrics(
+            ["board-metrics", "--all", "--boards-dir", str(tmp_path / "empty"), "--format", "json"],
+            capsys,
+        )
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["mode"] == "all"
+        assert payload["success"] is False
+        assert "no board subdirectories" in payload["error"]
+
+    def test_text_mode_still_prints_the_bare_board_json(self, boards_tree, capsys):
+        """--dry-run text mode keeps printing the board.json artifact itself."""
+        rc, out = _run_board_metrics(
+            ["board-metrics", str(boards_tree / "01-demo"), "--dry-run"], capsys
+        )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["slug"] == "01-demo"
+        assert "command" not in payload, "text mode must not gain the JSON envelope"
+
+    def test_text_mode_write_prints_the_status_line(self, boards_tree, capsys):
+        rc, out = _run_board_metrics(["board-metrics", str(boards_tree / "01-demo")], capsys)
+        assert rc == 0
+        assert "01-demo" in out and "board.json" in out
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(out)
+
+
+# ---------------------------------------------------------------------------
+# create-pcb emission
+# ---------------------------------------------------------------------------
+
+
+def _run_create_pcb(argv, capsys):
+    from kicad_tools.cli.commands.create_pcb import run_create_pcb_command
+
+    rc = run_create_pcb_command(create_parser().parse_args(argv))
+    return rc, capsys.readouterr().out
+
+
+class TestCreatePcbEmission:
+    def test_dry_run_document(self, tmp_path, capsys):
+        sch = tmp_path / "simple_rc.kicad_sch"
+        sch.write_text(SCHEMATIC.read_text())
+        rc, out = _run_create_pcb(["create-pcb", str(sch), "--dry-run", "--format", "json"], capsys)
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["command"] == "create-pcb"
+        assert payload["schematic"] == str(sch)
+        assert payload["output"].endswith("simple_rc.kicad_pcb")
+        assert payload["board"] == {"width_mm": 100.0, "height_mm": 100.0, "layers": 2}
+        assert payload["components_found"] == 2
+        assert payload["placement"]["skipped"] is False
+        assert payload["placement"]["placed"] == 2
+        assert payload["placement"]["failed"] == []
+        assert payload["nets"]["assigned"] >= 1
+        assert payload["nets"]["missing_footprints"] == sorted(
+            payload["nets"]["missing_footprints"]
+        )
+        assert payload["dry_run"] is True
+        assert payload["saved"] is False
+        assert payload["success"] is True
+        assert "component_count" in payload["summary"]
+        assert not (tmp_path / "simple_rc.kicad_pcb").exists()
+
+    def test_write_document_reports_saved(self, tmp_path, capsys):
+        sch = tmp_path / "simple_rc.kicad_sch"
+        sch.write_text(SCHEMATIC.read_text())
+        out_pcb = tmp_path / "board.kicad_pcb"
+        rc, out = _run_create_pcb(
+            ["create-pcb", str(sch), "-o", str(out_pcb), "--format", "json"], capsys
+        )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["saved"] is True
+        assert payload["output"] == str(out_pcb)
+        assert out_pcb.is_file()
+
+    def test_no_place_is_flagged(self, tmp_path, capsys):
+        sch = tmp_path / "simple_rc.kicad_sch"
+        sch.write_text(SCHEMATIC.read_text())
+        rc, out = _run_create_pcb(
+            ["create-pcb", str(sch), "--dry-run", "--no-place", "--format", "json"], capsys
+        )
+        assert rc == 0
+        placement = json.loads(out)["placement"]
+        assert placement["skipped"] is True
+        assert placement["placed"] == 0
+
+    def test_document_is_deterministic(self, tmp_path, capsys):
+        sch = tmp_path / "simple_rc.kicad_sch"
+        sch.write_text(SCHEMATIC.read_text())
+        argv = ["create-pcb", str(sch), "--dry-run", "--format", "json"]
+        _, first = _run_create_pcb(argv, capsys)
+        _, second = _run_create_pcb(argv, capsys)
+        assert first == second
+
+    def test_missing_schematic_is_error_document(self, tmp_path, capsys):
+        missing = tmp_path / "nope.kicad_sch"
+        rc, out = _run_create_pcb(["create-pcb", str(missing), "--format", "json"], capsys)
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["command"] == "create-pcb"
+        assert payload["success"] is False
+        assert payload["saved"] is False
+        assert "Schematic not found" in payload["error"]
+
+    def test_unparseable_schematic_is_error_document(self, tmp_path, capsys):
+        bad = tmp_path / "garbage.kicad_sch"
+        bad.write_text("this is not a schematic")
+        rc, out = _run_create_pcb(["create-pcb", str(bad), "--format", "json"], capsys)
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["success"] is False
+        assert payload["error"]
+
+    def test_text_mode_is_not_json(self, tmp_path, capsys):
+        sch = tmp_path / "simple_rc.kicad_sch"
+        sch.write_text(SCHEMATIC.read_text())
+        rc, out = _run_create_pcb(["create-pcb", str(sch), "--dry-run"], capsys)
+        assert rc == 0
+        assert "Dry run" in out
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(out)
+
+
+# ---------------------------------------------------------------------------
+# panel emission
+# ---------------------------------------------------------------------------
+
+
+def _run_panel(argv, capsys):
+    from kicad_tools.cli.commands.panel import run_panel_command
+
+    rc = run_panel_command(create_parser().parse_args(argv))
+    return rc, capsys.readouterr().out
+
+
+@pytest.fixture
+def board_copy(tmp_path):
+    board = tmp_path / "board.kicad_pcb"
+    board.write_text(BOARD.read_text())
+    return board
+
+
+class TestPanelEmission:
+    def test_document(self, board_copy, capsys):
+        pytest.importorskip("shapely")
+        rc, out = _run_panel(["panel", str(board_copy), "--format", "json"], capsys)
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["command"] == "panel"
+        assert payload["input"] == str(board_copy)
+        assert payload["output"].endswith("board_panel.kicad_pcb")
+        assert payload["grid"] == {"rows": 2, "cols": 2, "spacing_mm": 2.0}
+        assert payload["board_count"] == 4
+        assert payload["cut_method"] == "mousebite"
+        assert payload["tabs"] >= 1
+        assert payload["frame"] is False
+        assert payload["tooling_holes"] is False
+        assert payload["fiducials"] is False
+        assert payload["success"] is True
+        assert Path(payload["output"]).is_file()
+
+    def test_frame_features_are_reported(self, board_copy, capsys):
+        pytest.importorskip("shapely")
+        rc, out = _run_panel(
+            [
+                "panel",
+                str(board_copy),
+                "--rows",
+                "1",
+                "--cols",
+                "3",
+                "--cut",
+                "vcut",
+                "--frame",
+                "--tooling-holes",
+                "--fiducials",
+                "--format",
+                "json",
+            ],
+            capsys,
+        )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["grid"]["rows"] == 1
+        assert payload["grid"]["cols"] == 3
+        assert payload["board_count"] == 3
+        assert payload["cut_method"] == "vcut"
+        assert payload["frame"] is True
+        assert payload["tooling_holes"] is True
+        assert payload["fiducials"] is True
+
+    def test_document_is_deterministic(self, board_copy, capsys):
+        pytest.importorskip("shapely")
+        argv = ["panel", str(board_copy), "--format", "json"]
+        _, first = _run_panel(argv, capsys)
+        _, second = _run_panel(argv, capsys)
+        assert first == second
+
+    def test_missing_board_is_error_document(self, tmp_path, capsys):
+        rc, out = _run_panel(
+            ["panel", str(tmp_path / "nope.kicad_pcb"), "--format", "json"], capsys
+        )
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["command"] == "panel"
+        assert payload["success"] is False
+        assert "File not found" in payload["error"]
+
+    def test_panelization_failure_is_error_document(self, board_copy, capsys):
+        pytest.importorskip("shapely")
+        with patch("kicad_tools.panel.Panel.from_config", side_effect=RuntimeError("no outline")):
+            rc, out = _run_panel(["panel", str(board_copy), "--format", "json"], capsys)
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["success"] is False
+        assert "no outline" in payload["error"]
+
+    def test_text_mode_is_not_json(self, board_copy, capsys):
+        pytest.importorskip("shapely")
+        rc, out = _run_panel(["panel", str(board_copy)], capsys)
+        assert rc == 0
+        assert "Panel created:" in out
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(out)
+
+
+# ---------------------------------------------------------------------------
+# screenshot emission
+# ---------------------------------------------------------------------------
+
+
+def _run_screenshot(argv, capsys):
+    from kicad_tools.cli import _run_screenshot_command
+
+    rc = _run_screenshot_command(create_parser().parse_args(argv))
+    return rc, capsys.readouterr().out
+
+
+def _capture_result(output_path, success=True, error=None):
+    return {
+        "success": success,
+        "error_message": error,
+        "output_path": str(output_path),
+        "width_px": 800,
+        "height_px": 600,
+        "layers_rendered": ["F.Cu", "B.Cu", "Edge.Cuts"],
+    }
+
+
+class TestScreenshotEmission:
+    def test_board_document(self, board_copy, tmp_path, capsys):
+        png = tmp_path / "shot.png"
+        with patch(
+            "kicad_tools.mcp.tools.screenshot.screenshot_board",
+            return_value=_capture_result(png),
+        ):
+            rc, out = _run_screenshot(
+                ["screenshot", str(board_copy), "-o", str(png), "--format", "json"], capsys
+            )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["command"] == "screenshot"
+        assert payload["input"] == str(board_copy)
+        assert payload["output"] == str(png)
+        assert payload["width_px"] == 800
+        assert payload["height_px"] == 600
+        # Render order is meaningful (compositing order), so it is preserved.
+        assert payload["layers_rendered"] == ["F.Cu", "B.Cu", "Edge.Cuts"]
+        assert payload["success"] is True
+
+    def test_schematic_document(self, tmp_path, capsys):
+        sch = tmp_path / "simple_rc.kicad_sch"
+        sch.write_text(SCHEMATIC.read_text())
+        png = tmp_path / "sch.png"
+        result = _capture_result(png)
+        result["layers_rendered"] = None
+        with patch("kicad_tools.mcp.tools.screenshot.screenshot_schematic", return_value=result):
+            rc, out = _run_screenshot(
+                ["screenshot", str(sch), "-o", str(png), "--format", "json"], capsys
+            )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["layers_rendered"] == []
+        assert payload["success"] is True
+
+    def test_document_is_deterministic(self, board_copy, tmp_path, capsys):
+        png = tmp_path / "shot.png"
+        argv = ["screenshot", str(board_copy), "-o", str(png), "--format", "json"]
+        with patch(
+            "kicad_tools.mcp.tools.screenshot.screenshot_board",
+            return_value=_capture_result(png),
+        ):
+            _, first = _run_screenshot(argv, capsys)
+            _, second = _run_screenshot(argv, capsys)
+        assert first == second
+
+    def test_missing_file_is_error_document(self, tmp_path, capsys):
+        missing = tmp_path / "nope.kicad_pcb"
+        rc, out = _run_screenshot(["screenshot", str(missing), "--format", "json"], capsys)
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["command"] == "screenshot"
+        assert payload["success"] is False
+        assert "File not found" in payload["error"]
+
+    def test_unsupported_suffix_is_error_document(self, tmp_path, capsys):
+        other = tmp_path / "notes.txt"
+        other.write_text("hello")
+        rc, out = _run_screenshot(["screenshot", str(other), "--format", "json"], capsys)
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["success"] is False
+        assert "Unsupported file type" in payload["error"]
+
+    def test_capture_failure_is_error_document(self, board_copy, tmp_path, capsys):
+        png = tmp_path / "shot.png"
+        with patch(
+            "kicad_tools.mcp.tools.screenshot.screenshot_board",
+            return_value=_capture_result(png, success=False, error="kicad-cli not found"),
+        ):
+            rc, out = _run_screenshot(
+                ["screenshot", str(board_copy), "-o", str(png), "--format", "json"], capsys
+            )
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["success"] is False
+        assert "kicad-cli not found" in payload["error"]
+
+    def test_text_mode_is_not_json(self, board_copy, tmp_path, capsys):
+        png = tmp_path / "shot.png"
+        with patch(
+            "kicad_tools.mcp.tools.screenshot.screenshot_board",
+            return_value=_capture_result(png),
+        ):
+            rc, out = _run_screenshot(["screenshot", str(board_copy), "-o", str(png)], capsys)
+        assert rc == 0
+        assert "Screenshot saved to" in out
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(out)
+
+
+# ---------------------------------------------------------------------------
+# report generate emission
+# ---------------------------------------------------------------------------
+
+
+def _run_report(argv, capsys):
+    from kicad_tools.cli import _run_report_command
+
+    rc = _run_report_command(create_parser().parse_args(argv))
+    return rc, capsys.readouterr().out
+
+
+class TestReportGenerateEmission:
+    def test_skeleton_document(self, board_copy, tmp_path, capsys):
+        out_dir = tmp_path / "reports"
+        rc, out = _run_report(
+            [
+                "report",
+                "generate",
+                str(board_copy),
+                "--mfr",
+                "jlcpcb",
+                "-o",
+                str(out_dir),
+                "--skip-collect",
+                "--no-figures",
+                "--format",
+                "json",
+            ],
+            capsys,
+        )
+        assert rc == 0
+        # json.loads() fails outright if stdout carries anything but the one
+        # document -- e.g. WeasyPrint's stdout banner when its native libs are
+        # missing, which is why the PDF block redirects stdout in JSON mode.
+        payload = json.loads(out)
+        assert payload["command"] == "generate"
+        assert payload["input"] == str(board_copy)
+        assert payload["manufacturer"] == "jlcpcb"
+        assert payload["output_dir"] == str(out_dir)
+        assert payload["project_name"] == "board"
+        assert payload["data_source"] == "skeleton"
+        assert payload["figures"] == {
+            "generated": False,
+            "skipped_reason": "disabled by --no-figures",
+        }
+        assert payload["success"] is True
+        assert Path(payload["report_path"]).is_file()
+        assert payload["pdf_path"] is None or Path(payload["pdf_path"]).is_file()
+
+    def test_data_dir_source_is_reported(self, board_copy, tmp_path, capsys):
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        rc, out = _run_report(
+            [
+                "report",
+                "generate",
+                str(board_copy),
+                "-o",
+                str(tmp_path / "reports"),
+                "--data-dir",
+                str(data_dir),
+                "--format",
+                "json",
+            ],
+            capsys,
+        )
+        assert rc == 0
+        payload = json.loads(out)
+        assert payload["data_source"] == "data-dir"
+        assert payload["figures"]["generated"] is False
+        assert payload["figures"]["skipped_reason"] == "pre-collected via --data-dir"
+
+    def test_missing_pcb_for_pro_input_is_error_document(self, tmp_path, capsys):
+        pro = tmp_path / "design.kicad_pro"
+        pro.write_text("{}")
+        rc, out = _run_report(
+            ["report", "generate", str(pro), "-o", str(tmp_path / "reports"), "--format", "json"],
+            capsys,
+        )
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["command"] == "generate"
+        assert payload["success"] is False
+        assert "PCB file not found" in payload["error"]
+
+    def test_text_mode_is_not_json(self, board_copy, tmp_path, capsys):
+        rc, out = _run_report(
+            [
+                "report",
+                "generate",
+                str(board_copy),
+                "-o",
+                str(tmp_path / "reports"),
+                "--skip-collect",
+                "--no-figures",
+            ],
+            capsys,
+        )
+        assert rc == 0
+        assert "Report written to" in out
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(out)


### PR DESCRIPTION
## Summary

Fifth batch of the #4543 machine-output sweep (issue #4674): the **board-artifact producers** — the five prose-only singles that turn a board or schematic into a *file on disk*. Each now accepts the canonical `--format json` and prints exactly one deterministic document on stdout, wired end-to-end (outer parser → shim → inner parser/handler).

Audit (`scripts/audit_machine_output.py`) at PR head, base `fe662585`: **prose-only 18 → 13, format-json 179 → 184.** After this batch **8 actionable** leaves remain (`build`, `creepage-export-rules`, `optimize-placement`, `optimize-traces`, `pipeline`, `reason`, `route-auto`, `stitch`); the audit bucket reads 13 because it also counts the 4 exempt commands and the deferred `route`.

`tests/test_cli_parser_drift.py` is untouched — no route/check parser changes; the `route --format` promotion still belongs to the route workstream per the design note.

## Changes

- `src/kicad_tools/cli/parser.py` — `add_format_flag` on the five outer leaves.
- Shim forwarding: `commands/board_metrics.py`, `commands/create_pcb.py`, and `cli/__init__.py`'s `_run_screenshot_command` / `_run_report_command` forward `--format json` into the inner argv (and must *not* forward it in the default text mode — pinned by tests).
- Emission: `board_metrics_cmd.py`, `create_pcb_cmd.py`, `commands/panel.py` (handler lives in the shim), `report_cmd.py`, `screenshot_cmd.py`.
- `tests/test_format_json_sweep_artifacts.py` — 56 tests, a **sibling** of the batch-1/2/3/4 modules so concurrent batches cannot conflict on a shared `SWEPT_SURFACES` literal.
- `docs/reference/machine-output.md` inventory + per-command shapes; `CHANGELOG.md` under `[Unreleased] ### Added`.

## JSON schema (this family)

| Command | Document |
|---|---|
| `board-metrics` | `{"command": "board-metrics", "mode": "single"\|"all", "dry_run": bool, "boards": [{"slug", "status", "output_path", "metrics"}], "success": bool}` — `metrics` is the board's full `board.json`; `output_path` is `null` under `--dry-run`. Errors add `"error"` with `boards: []`. |
| `create-pcb` | `{"command": "create-pcb", "schematic", "output", "board": {"width_mm", "height_mm", "layers"}, "components_found": int, "placement": {"skipped": bool, "placed": int, "failed": [{"reference", "reason"}], "warnings": [str]}, "nets": {"assigned": int, "missing_footprints": [str]}, "summary": {…}, "dry_run": bool, "saved": bool, "success": bool}` — `failed`, `warnings` and `missing_footprints` are sorted. |
| `panel` | `{"command": "panel", "input", "output", "grid": {"rows", "cols", "spacing_mm"}, "board_count": int, "tabs": int, "cut_method": "mousebite"\|"vcut", "tab_width_mm", "tab_count", "frame": bool, "tooling_holes": bool, "fiducials": bool, "success": bool}` |
| `report generate` | `{"command": "generate", "input", "manufacturer", "output_dir", "project_name", "report_path", "pdf_path": str\|null, "data_source": "auto-collect"\|"data-dir"\|"skeleton", "figures": {"generated": bool, "skipped_reason": str\|null}, "success": bool}` |
| `screenshot` | `{"command": "screenshot", "input", "output", "width_px": int, "height_px": int, "layers_rendered": [str], "success": bool}` — render order is meaningful (compositing order) and deterministic, so it is preserved rather than sorted. |

Every failure path emits `{"command": …, "error": …, "success": false}` with the **exit code unchanged**.

### Three things this batch establishes for the remaining long tail

1. **The envelope is not the artifact.** `board-metrics --dry-run` already printed a JSON *artifact* (`board.json`). `--format json` wraps a distinct run envelope around it (`boards[].metrics`) instead of overloading the artifact's schema, and text mode still prints the bare artifact. `metrics.generated_at` is the one deliberately volatile field (it belongs to the board.json contract), so the determinism test compares modulo that key.
2. **Producers say whether they produced.** `saved` / `output_path: null` under `--dry-run`, so exit 0 can never be misread as "a file was written".
3. **Third-party stdout chatter must be diverted, not trusted.** `report generate` calls the data collector, the figure generator and WeasyPrint — the last of which prints a multi-line "install my native libraries" banner **on stdout** when they are missing, which would corrupt the single-document contract on any machine without them (it reproduces on this dev box). Those regions now run under `_stdout_to_stderr_when(as_json)`: chatter is captured and replayed on stderr, the JSON stream stays parseable. Copy that helper for any leaf calling third-party code it does not own. `_generate_figures` also now returns `{"generated", "skipped_reason"}` instead of `None`, which is what makes "why were there no figures" answerable without scraping stderr.

## Acceptance Criteria Verification

- [x] **One family per PR, outer + shim + inner all threaded** — no inner-only flags; the four argv-reserializing shims are tested for both forwarding (`--format json`) and non-forwarding (text default).
- [x] **JSON deterministic** — `emit_json` sorts keys; collections sorted where order is not semantic; a determinism test (two runs, byte-compared) covers `board-metrics` (modulo the artifact's `generated_at`), `create-pcb`, `panel` and `screenshot`.
- [x] **`tests/test_cli_parser_drift.py` untouched and green.**
- [x] **Per-surface `--format json` tests** — structure assertions, not byte-golden.
- [x] **Family JSON schema documented** — table above plus `docs/reference/machine-output.md`.
- [x] **Text mode unchanged** — prose is byte-identical (including the `panel` ImportError message and the two `report` warnings that deliberately print without an `Error:` prefix); each surface has a "text mode is not JSON" test.

## Test Plan

- `uv run pytest tests/test_format_json_sweep_artifacts.py` → **56 passed**
- `uv run pytest tests/test_cli_parser_drift.py tests/test_board_metrics.py tests/test_cli.py tests/test_cli_commands.py tests/test_cli_pcb.py tests/test_cli_sch.py tests/test_project.py tests/report tests/test_panel.py tests/test_panel_cli.py tests/test_report_cmd.py tests/test_report_generator.py tests/test_report_figures.py tests/test_report_mfr_profile_and_images.py tests/test_find_schematic.py tests/test_mcp_screenshot.py tests/test_export_figures_default.py` and the four sibling sweep modules → **all passed** (1399 tests across the runs)
- `uv run ruff check` / `uv run ruff format --check` on the changed files → clean
- `uv run python scripts/ci/check_mypy_baseline.py` → **no new type errors** (1470 within the 1472 floor). The two "no longer occur" entries it warns about are the known environment artifacts (`nanobind` import-not-found from a natively-built worktree, plus a `net_status_cmd.py` line) and are **not** in this diff, so the baseline is deliberately left untightened.
- Manual smoke: all five surfaces exercised on real inputs (`kct panel`, `kct screenshot`, `kct create-pcb`, `kct board-metrics --dry-run`/`--all`, `kct report generate`) plus every error path.

Part of #4674
