### PR TITLE
fix(cli): stop the deterministic-budget 0.0 sentinel from zeroing the post-negotiation rescue sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -596,6 +596,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The post-negotiation rescue sweep no longer gets a 0.0 s per-net budget on
+  placement-feedback re-routes** (#4776) — `--deterministic-budget` sets
+  `args.per_net_timeout = 0.0` as its "wall-clock cutoff disabled" sentinel, and
+  ~24 `route_all_negotiated` call sites in `route_cmd.py` normalize it away with
+  `or None`. The two placement-feedback helpers (`_run_placement_feedback`,
+  `_run_placement_delta_feedback`) did not, so the literal `0.0` reached
+  `Autorouter._post_negotiation_sweep_bounds`, which took `min(0.0, 10 s)` and
+  handed every stranded net a **zero-second** solo re-attempt — the #4159 rescue
+  sweep was a silent no-op on every placement-feedback re-route. Both call sites
+  now normalize, and the consumer additionally treats a falsy per-net budget as
+  absent (mirroring `_relief_subsearch_budget`, where `0.0` has always been
+  falsy) so no future caller can poison it; the `is None` gate on the
+  safety-backstop arm is deliberately unchanged, so no board changes which arm
+  it selects. Because this activates a path that decides routed *reach*, it was
+  gated on a back-to-back host A/B against `origin/main` @ `fe662585` (C++
+  backend build 19, `PYTHONHASHSEED=42`, `--seed 42`): board 07 keeps 26/31
+  reach, the same 5-net open set (`DQ3, DQ4, MIPI_DAT0_N, TMDS_D0_N,
+  TMDS_D1_N`), 8 blocking DRC against its floor of 8 with an identical rule
+  split (`diffpair_length_skew` 4 + `diffpair_routing_continuity` 4) and
+  **byte-identical routed copper**; board 04 routes 9/9 and never reaches the
+  path at all (0 blocking DRC on the strict-0 gate, 0 unconnected pads, LVS
+  clean, identical copper). No allowlist or gate threshold was touched. The
+  measurement is recorded in
+  `boards/07-matchgroup-test/diagnostic-runs/README.md`.
+
 - **The pure-Python fallback A* is now pairwise (HV-isolation) aware at search time** (#4507, epic #4431 Phase 2) — the hot-loop bitmap, `_is_trace_blocked`/`_is_via_blocked` kernels and the C++ backend's fallback-router threading now mirror the C++ `cross_domain_*` search kernels (same domain projection, per-pair widened radius, layer-scoped #4506 attach-zone waiver, out-of-bounds-is-empty ring dilation), so a net that falls back on an HV board converges instead of thrashing against the Phase-1 post-route gate; fully dormant without `--voltage-map`.
 
 - **`kct ipc push-routes` can now actually read a board** (#4788) — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -596,26 +596,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **The post-negotiation rescue sweep no longer gets a 0.0 s per-net budget on
+- **Multi-pin nets are no longer skipped outright on `--deterministic-budget`
   placement-feedback re-routes** (#4776) — `--deterministic-budget` sets
   `args.per_net_timeout = 0.0` as its "wall-clock cutoff disabled" sentinel, and
   ~24 `route_all_negotiated` call sites in `route_cmd.py` normalize it away with
   `or None`. The two placement-feedback helpers (`_run_placement_feedback`,
-  `_run_placement_delta_feedback`) did not, so the literal `0.0` reached
-  `Autorouter._post_negotiation_sweep_bounds`, which took `min(0.0, 10 s)` and
-  handed every stranded net a **zero-second** solo re-attempt — the #4159 rescue
-  sweep was a silent no-op on every placement-feedback re-route. Both call sites
-  now normalize, and the consumer additionally treats a falsy per-net budget as
-  absent (mirroring `_relief_subsearch_budget`, where `0.0` has always been
-  falsy) so no future caller can poison it; the `is None` gate on the
-  safety-backstop arm is deliberately unchanged, so no board changes which arm
-  it selects. Because this activates a path that decides routed *reach*, it was
+  `_run_placement_delta_feedback`) did not, so the literal `0.0` reached the
+  whole `route_all_negotiated` call — and `0.0` is **not** falsy-safe on the way
+  down. `derive_iter_per_net_cap(0.0, remaining)` collapsed to `min(0.0, cap)` =
+  `0.0` at every rip-up-loop reroute site, and `route_net_negotiated`'s
+  cumulative net deadline (`… if per_net_timeout is not None else None`) became
+  an already-expired deadline, short-circuiting **every RSMT edge of every
+  ≥3-pad net before a single A\* call**. So on a placement-feedback re-route
+  only 2-pin nets routed (those survive because the C++ backend reads `0.0` as
+  "no deadline"); every multi-pin net was dropped as a timeout failure. The same
+  `0.0` also reached `Autorouter._post_negotiation_sweep_bounds`, which took
+  `min(0.0, 10 s)` and made the #4159 rescue sweep a silent no-op on those
+  passes. Both call sites now normalize, and the sweep-bounds consumer
+  additionally treats a falsy per-net budget as absent (mirroring
+  `_relief_subsearch_budget`, where `0.0` has always been falsy) so no future
+  caller can poison it; the `is None` gate on the safety-backstop arm is
+  deliberately unchanged, so no board changes which arm it selects. Because this
+  restores routing decisions that determine routed *reach*, it was
   gated on a back-to-back host A/B against `origin/main` @ `fe662585` (C++
   backend build 19, `PYTHONHASHSEED=42`, `--seed 42`): board 07 keeps 26/31
   reach, the same 5-net open set (`DQ3, DQ4, MIPI_DAT0_N, TMDS_D0_N,
   TMDS_D1_N`), 8 blocking DRC against its floor of 8 with an identical rule
   split (`diffpair_length_skew` 4 + `diffpair_routing_continuity` 4) and
-  **byte-identical routed copper**; board 04 routes 9/9 and never reaches the
+  **byte-identical routed copper** (both placement-delta probes were refused in
+  both arms, so the final board is the initial pass's either way — an accept-gate
+  outcome, not an invariant); board 04 routes 9/9 and never reaches the
   path at all (0 blocking DRC on the strict-0 gate, 0 unconnected pads, LVS
   clean, identical copper). No allowlist or gate threshold was touched. The
   measurement is recorded in

--- a/boards/07-matchgroup-test/diagnostic-runs/README.md
+++ b/boards/07-matchgroup-test/diagnostic-runs/README.md
@@ -120,10 +120,13 @@ delta -- and it is invisible to `Autorouter._relief_subsearch_budget`
 anyway, where `0.0` is falsy and selects the same branch `None` does.
 This investigation was run against a tree where #4776 was still
 **unfixed**; that is a property of these two recorded runs, not a live
-confound. #4776 is now **FIXED** (see the next section) and the fix was
-measured to leave every number in this file unchanged.
+confound. It stays a valid confound guard because the sentinel was present
+**identically in both arms** -- but note that zeroing the sweep was only the
+*narrowest* of its effects; see the next section for what the `0.0` actually
+did to the negotiated loop itself. #4776 is now **FIXED**, and the fix was
+measured to leave every *outcome* number in this file unchanged.
 
-### #4776 is fixed -- and it re-baselined nothing (2026-08-13)
+### #4776 is fixed -- what it actually changed, and why these numbers stand (2026-08-13)
 
 #4776 normalized the `0.0` sentinel at both placement-feedback call sites
 (`_run_placement_feedback`, `_run_placement_delta_feedback`) and hardened
@@ -131,6 +134,34 @@ measured to leave every number in this file unchanged.
 as absent. Board 07's placement-delta re-routes therefore now print
 `60.0s whole-sweep / 10.0s per-net` where they used to print `0.0s per-net`,
 i.e. **the sweep is live on those passes for the first time**.
+
+**The sweep was not the only casualty -- do not repeat the earlier framing
+of this fix as "sweep-only".** The `or None` at the call sites changes
+`per_net_timeout` for the *entire* `route_all_negotiated` call, and `0.0` is
+**not** falsy-safe on the way down:
+
+* `derive_iter_per_net_cap(0.0, remaining)`
+  (`router/algorithms/negotiated.py`) returns `min(0.0, remaining_cap)` =
+  **`0.0`**, where `None` would have returned `remaining_cap` (60.0 for a
+  600 s stage). So every rip-up-loop reroute site got a zero cap, not just
+  the sweep.
+* `NegotiatedRouter.route_net_negotiated` brackets a multi-pin net with
+  `net_deadline = time.monotonic() + per_net_timeout if per_net_timeout is
+  not None else None` -- an **`is not None`** test, so `0.0` yields an
+  already-expired deadline and every RSMT edge is short-circuited to a
+  timeout failure **before a single `router.route()` call**. That block sits
+  inside `if len(pad_objs) > 2:`, so it is exactly the **≥3-pad** nets that
+  were skipped; 2-pad nets took the direct path and survived only because
+  the C++ backend is falsy-safe (`timeout_seconds = float(per_net_timeout)
+  if per_net_timeout else 0.0`, where `0.0` means *no* deadline there).
+
+So the pre-fix behaviour on a `--deterministic-budget` placement-feedback
+re-route was **not** "the rescue sweep is inert". It was: *every net with
+three or more pads was skipped outright with zero A\* calls, and only 2-pin
+nets routed.* The fix restores multi-pin routing on those passes. It follows
+that this fix **does** change the negotiated loop's trajectory on
+placement-feedback re-routes -- any claim that it "cannot influence the
+negotiated loop" is wrong and must not be reintroduced here.
 
 Because activating a reach-deciding code path is exactly the shape that got
 #4730 withdrawn (PR #4748, `6d8e9bd8`), the fix was gated on a back-to-back
@@ -156,24 +187,40 @@ the seed-invariant #3438/#4012 set, and one solo 10 s re-attempt on the live
 grid does not close any of them. So the historical numbers above stand
 as-is.
 
-Two *probe-level* numbers did move, and neither changes the outcome -- both
-probes are refused in both arms, so the final board is the initial pass's:
+Two *probe-level* numbers did move:
 
 * probe 0 `U2 mirror`: base `25 -> 23`, fix `25 -> 22` (reverted in both).
 * probe 1 `U3 translate`: base `25 -> 26` (refused by the clearance-regression
   guard), fix `25 -> 25` (refused for no strict routed-net increase).
 
-That spread is the documented host nondeterminism, not the fix: the
-`--timeout 600` stage budget is a *wall clock*, so a re-route's iteration
-count depends on machine load (base's probe passes exited at 502.4 s /
-335.6 s, the fix's at 601.3 s / 600.4 s under different instantaneous load).
-The fix cannot influence the negotiated loop at all -- it only changes a
-budget consumed *after* the loop returns.
+**Attribute these to the fix, not to host noise.** Both probe passes are
+placement-delta re-routes, i.e. exactly the passes where the pre-fix `0.0`
+skipped every ≥3-pad net; a changed multi-pin re-route trajectory is the
+straightforward explanation for a changed probe reach. Host load plausibly
+contributes as well -- `--timeout 600` is a *wall clock*, so iteration count
+tracks machine load, and the probe passes exited at 502.4 s / 335.6 s (base)
+vs 601.3 s / 600.4 s (fix) under load averages 9-17 -- but load is not the
+sole cause, and the "structurally cannot touch the loop" argument that was
+originally offered here is **false** (see the mechanism above). Treat these
+two numbers as fix-plausible.
+
+What *is* solid is the outcome: **both probes were refused in both arms**,
+so the final board is the initial pass's either way, which is why the routed
+copper is byte-identical. Note carefully that this is a **coincidence of the
+accept gate**, not an invariant -- the fix changes what that gate is choosing
+between, and `_normalize_deterministic_budget`'s docstring records the
+adjacent failure mode where the placement-delta loop's *relative* accept gate
+admits a delta `main` refuses (+1 net / +5 DRC). Board 07 sits at 8 blocking
+DRC against a floor of 8, i.e. **zero headroom**, so a future run of this
+board must re-measure the probe accept/refuse decisions rather than assume
+they replay.
 
 Wall-clock cost of the route step: 28m00s base vs 33m58s fix on this host
-(the sweep is now allowed to spend up to 60 s per placement-feedback pass
-instead of being instantly inert). The board-07 CI job carries a 90-minute
-allowance.
+(+358 s). The sweep cap accounts for at most ~120 s of that (60 s per
+placement-feedback pass, two passes); the residual is best explained by the
+negotiated loop actually routing multi-pin nets again on those re-routes,
+plus the load-driven pass-duration spread. The board-07 CI job carries a
+90-minute allowance.
 
 The two recorded CI runs predate `Autorouter._post_negotiation_sweep_bound_line`
 (added by PR #4775), so that line does not appear in their logs at all --

--- a/boards/07-matchgroup-test/diagnostic-runs/README.md
+++ b/boards/07-matchgroup-test/diagnostic-runs/README.md
@@ -118,9 +118,62 @@ byte-identical between arms; where the whole-sweep term does differ
 time), the sweep is already inert. Either way #4776 cannot produce the
 delta -- and it is invisible to `Autorouter._relief_subsearch_budget`
 anyway, where `0.0` is falsy and selects the same branch `None` does.
-This investigation was deliberately run against a tree where #4776 is
-**unfixed**; fixing it activates board 07's currently-no-op sweep in
-*both* arms and would re-baseline these numbers.
+This investigation was run against a tree where #4776 was still
+**unfixed**; that is a property of these two recorded runs, not a live
+confound. #4776 is now **FIXED** (see the next section) and the fix was
+measured to leave every number in this file unchanged.
+
+### #4776 is fixed -- and it re-baselined nothing (2026-08-13)
+
+#4776 normalized the `0.0` sentinel at both placement-feedback call sites
+(`_run_placement_feedback`, `_run_placement_delta_feedback`) and hardened
+`Autorouter._post_negotiation_sweep_bounds` to treat a falsy per-net budget
+as absent. Board 07's placement-delta re-routes therefore now print
+`60.0s whole-sweep / 10.0s per-net` where they used to print `0.0s per-net`,
+i.e. **the sweep is live on those passes for the first time**.
+
+Because activating a reach-deciding code path is exactly the shape that got
+#4730 withdrawn (PR #4748, `6d8e9bd8`), the fix was gated on a back-to-back
+host A/B, `origin/main` @ `fe662585` vs. the fix, C++ backend build 19,
+`PYTHONHASHSEED=42`, `--seed 42`, same machine, sequential (load average
+9-17 throughout -- this host was NOT quiet; CI remains authoritative):
+
+| | base (`fe662585`) | fix |
+|---|---|---|
+| `Post-negotiation sweep bound:` (initial CLI pass) | `60.0s / 10.0s` | `60.0s / 10.0s` |
+| `Post-negotiation sweep bound:` (both PDF re-routes) | **`60.0s / 0.0s`** | **`60.0s / 10.0s`** |
+| nets recovered by the sweep, all passes | 0 | 0 |
+| final reach | 26/31 | 26/31 |
+| LVS open set (by name) | `DQ3, DQ4, MIPI_DAT0_N, TMDS_D0_N, TMDS_D1_N` | *identical* |
+| blocking DRC (`--mfr jlcpcb`, advisory-filtered) | **8** (floor 8) | **8** (floor 8) |
+| blocking DRC by rule id | `diffpair_length_skew` 4, `diffpair_routing_continuity` 4 | *identical* |
+| deltas proposed / kept | 10 / 0 | 10 / 0 |
+| routed segments / vias | 826 / 206 | 826 / 206 |
+| final routed copper (segments+vias, UUIDs stripped) | — | **byte-identical to base** |
+
+The activated sweep rescues **nothing** on this board: the 5 open nets are
+the seed-invariant #3438/#4012 set, and one solo 10 s re-attempt on the live
+grid does not close any of them. So the historical numbers above stand
+as-is.
+
+Two *probe-level* numbers did move, and neither changes the outcome -- both
+probes are refused in both arms, so the final board is the initial pass's:
+
+* probe 0 `U2 mirror`: base `25 -> 23`, fix `25 -> 22` (reverted in both).
+* probe 1 `U3 translate`: base `25 -> 26` (refused by the clearance-regression
+  guard), fix `25 -> 25` (refused for no strict routed-net increase).
+
+That spread is the documented host nondeterminism, not the fix: the
+`--timeout 600` stage budget is a *wall clock*, so a re-route's iteration
+count depends on machine load (base's probe passes exited at 502.4 s /
+335.6 s, the fix's at 601.3 s / 600.4 s under different instantaneous load).
+The fix cannot influence the negotiated loop at all -- it only changes a
+budget consumed *after* the loop returns.
+
+Wall-clock cost of the route step: 28m00s base vs 33m58s fix on this host
+(the sweep is now allowed to spend up to 60 s per placement-feedback pass
+instead of being instantly inert). The board-07 CI job carries a 90-minute
+allowance.
 
 The two recorded CI runs predate `Autorouter._post_negotiation_sweep_bound_line`
 (added by PR #4775), so that line does not appear in their logs at all --

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -230,8 +230,12 @@ def _normalize_deterministic_budget(args, quiet: bool = False) -> None:
     sets ``per_net_timeout = 0.0``, which is falsy in
     ``Autorouter._relief_subsearch_budget`` and therefore selects the same
     ``RELIEF_SUBSEARCH_BUDGET_S`` branch ``None`` does -- so it is invariant
-    across both arms of that A/B and cannot explain the delta (it does bite
-    the post-negotiation sweep; that is issue #4776).  Read the
+    across both arms of that A/B and cannot explain the delta.  It used to
+    bite the post-negotiation sweep (``min(0.0, 10 s)`` made it a no-op on
+    placement-feedback re-routes); issue #4776 fixed that by normalizing the
+    sentinel at the placement-feedback call sites (``or None``) and by
+    treating a falsy per-net budget as absent in
+    ``Autorouter._post_negotiation_sweep_bounds``.  Read the
     ``DETERMINISTIC_RESCUE_DEFAULT`` docblock in ``router/core.py`` and
     ``boards/07-matchgroup-test/diagnostic-runs/README.md`` before touching
     the constant.
@@ -2965,7 +2969,13 @@ def _run_placement_feedback(
     # for a fresh ``args.timeout`` slot.  Falls back to ``args.timeout``
     # when no deadline is configured.
     timeout = _budgeted_timeout(args)
-    per_net_timeout = getattr(args, "per_net_timeout", None)
+    # Issue #4776: ``or None`` normalizes the ``--deterministic-budget``
+    # sentinel (``per_net_timeout = 0.0``, "wall-clock cutoff disabled") the
+    # same way every direct ``route_all_negotiated`` call site in this file
+    # does.  Passing the literal ``0.0`` through made the #4159
+    # post-negotiation rescue sweep compute ``min(0.0, 10.0)`` and hand every
+    # stranded net a zero-second solo budget -- a silent no-op.
+    per_net_timeout = getattr(args, "per_net_timeout", None) or None
 
     # Issue #2606: stagnation + outer-timeout guards.  Defaults match
     # the parser: patience=3, outer_timeout=None.
@@ -3123,7 +3133,10 @@ def _run_placement_delta_feedback(
     max_movement = float(getattr(args, "placement_feedback_max_movement", 5.0) or 5.0)
     use_negotiated = getattr(args, "strategy", "negotiated") == "negotiated"
     timeout = loop_timeout if loop_timeout is not None else _budgeted_timeout(args)
-    per_net_timeout = getattr(args, "per_net_timeout", None)
+    # Issue #4776: ``or None`` normalizes the ``--deterministic-budget``
+    # ``0.0`` sentinel away, matching every other call site (see
+    # ``_run_placement_feedback``).
+    per_net_timeout = getattr(args, "per_net_timeout", None) or None
     loop_verbose = (not quiet) and bool(getattr(args, "verbose", False))
 
     # Pour/plane nets are carried by copper fill, not traces; the classifier

--- a/src/kicad_tools/cli/route_cmd.py
+++ b/src/kicad_tools/cli/route_cmd.py
@@ -2972,9 +2972,17 @@ def _run_placement_feedback(
     # Issue #4776: ``or None`` normalizes the ``--deterministic-budget``
     # sentinel (``per_net_timeout = 0.0``, "wall-clock cutoff disabled") the
     # same way every direct ``route_all_negotiated`` call site in this file
-    # does.  Passing the literal ``0.0`` through made the #4159
-    # post-negotiation rescue sweep compute ``min(0.0, 10.0)`` and hand every
-    # stranded net a zero-second solo budget -- a silent no-op.
+    # does.  The literal ``0.0`` is NOT falsy-safe on the way down, and it
+    # bit more than the rescue sweep:
+    #   * ``derive_iter_per_net_cap(0.0, remaining)`` -> ``min(0.0, cap)`` =
+    #     ``0.0`` at every rip-up-loop reroute site;
+    #   * ``NegotiatedRouter.route_net_negotiated``'s cumulative net deadline
+    #     is gated on ``per_net_timeout is not None``, so ``0.0`` produced an
+    #     already-expired deadline and short-circuited every RSMT edge of
+    #     every >=3-pad net before a single ``router.route()`` call (2-pad
+    #     nets survived: the C++ backend reads ``0.0`` as "no deadline");
+    #   * ``Autorouter._post_negotiation_sweep_bounds`` computed
+    #     ``min(0.0, 10.0)``, so the #4159 rescue sweep was a no-op too.
     per_net_timeout = getattr(args, "per_net_timeout", None) or None
 
     # Issue #2606: stagnation + outer-timeout guards.  Defaults match

--- a/src/kicad_tools/router/core.py
+++ b/src/kicad_tools/router/core.py
@@ -12875,7 +12875,14 @@ class Autorouter:
             sweep_budget = POST_NEGOTIATION_SWEEP_BUDGET_S
 
         sweep_per_net = per_net_timeout
-        if sweep_per_net is None:
+        if not sweep_per_net:
+            # Issue #4776: a literal ``0.0`` is the ``--deterministic-budget``
+            # "wall-clock cutoff disabled" sentinel.  Treat it the way
+            # :meth:`_relief_subsearch_budget` already does (falsy == absent);
+            # taking ``min(0.0, 10 s)`` instead handed every stranded net a
+            # zero-second solo budget and silently no-op'd the sweep.  The
+            # ``is None`` gate on the safety-backstop arm above is
+            # deliberately unchanged.
             sweep_per_net = POST_NEGOTIATION_SWEEP_PER_NET_S
         else:
             sweep_per_net = min(sweep_per_net, POST_NEGOTIATION_SWEEP_PER_NET_S)

--- a/tests/test_post_negotiation_sweep_budget.py
+++ b/tests/test_post_negotiation_sweep_budget.py
@@ -145,6 +145,40 @@ class TestBudgetedCallerIsUnchanged:
         assert per_net == POST_NEGOTIATION_SWEEP_PER_NET_S
 
 
+class TestZeroPerNetSentinel:
+    """Issue #4776: the ``--deterministic-budget`` ``0.0`` per-net sentinel.
+
+    ``_normalize_deterministic_budget`` sets ``per_net_timeout = 0.0``
+    ("wall-clock cutoff disabled").  Two placement-feedback call sites used
+    to pass that literal through, and ``min(0.0, 10 s)`` handed every
+    stranded net a zero-second solo budget -- the sweep became a silent
+    no-op.  The consumer now treats a falsy per-net budget as absent, the
+    same way ``_relief_subsearch_budget`` always has.
+    """
+
+    def test_zero_per_net_no_longer_collapses_the_sweep(self):
+        """The board-04/board-07 shape: ``--timeout 600`` + sentinel ``0.0``."""
+        budget, per_net = _capped()._post_negotiation_sweep_bounds(600.0, 0.0, 10.0, False)
+        assert budget == POST_NEGOTIATION_SWEEP_BUDGET_S
+        assert per_net == POST_NEGOTIATION_SWEEP_PER_NET_S
+
+    def test_zero_per_net_does_not_flip_the_backstop_arm(self):
+        """The safety-backstop arm keeps its ``is None`` gate.
+
+        A literal ``0.0`` without a stage timeout stays on the historical
+        60 s / 10 s arm; it does NOT masquerade as a fully-unbudgeted caller
+        and claim the 600 s / 120 s iteration-bounded backstops.
+        """
+        budget, per_net = _capped()._post_negotiation_sweep_bounds(None, 0.0, 0.0, False)
+        assert budget == POST_NEGOTIATION_SWEEP_BUDGET_S
+        assert per_net == POST_NEGOTIATION_SWEEP_PER_NET_S
+
+    def test_bound_line_reports_the_real_per_net_budget(self):
+        line = _capped()._post_negotiation_sweep_bound_line(600.0, 0.0, 10.0, False)
+        assert "/ 10.0s per-net" in line
+        assert "/ 0.0s per-net" not in line
+
+
 class TestBoundLine:
     """The routing log must say which bound was live (#4536 evidence rule)."""
 

--- a/tests/test_route_cmd_placement_feedback.py
+++ b/tests/test_route_cmd_placement_feedback.py
@@ -1351,3 +1351,117 @@ class TestPlacementFeedbackVerboseGating:
         out = capsys.readouterr().out
         assert "Feedback iterations: 1" in out
         assert "Exit reason:" in out
+
+
+class TestDeterministicBudgetSentinelNormalization:
+    """Issue #4776: both placement-feedback helpers must forward ``None``,
+    not the literal ``0.0``, when ``--deterministic-budget`` has set the
+    ``per_net_timeout = 0.0`` "wall-clock cutoff disabled" sentinel.
+
+    These were the only two ``route_all_negotiated``-reaching call sites in
+    route_cmd.py without the ``or None`` normalization; the literal ``0.0``
+    made ``Autorouter._post_negotiation_sweep_bounds`` compute
+    ``min(0.0, 10 s)`` and silently no-op the #4159 rescue sweep on every
+    placement-feedback re-route (boards 04 and 07 in CI).
+    """
+
+    def test_run_placement_feedback_forwards_none_for_zero(self):
+        from unittest.mock import MagicMock, patch
+
+        from kicad_tools.cli.route_cmd import _run_placement_feedback
+
+        args = _pf_args(per_net_timeout=0.0)
+        router = MagicMock()
+        router.get_failed_nets.return_value = [1]
+        router.route_with_placement_feedback.return_value = MagicMock(
+            iterations=1,
+            exit_reason="pf_converged",
+            total_components_moved=0,
+            failed_nets=[],
+            placement_diff=[],
+        )
+        stub_pcb = MagicMock()
+        stub_pcb.footprints = []
+
+        with (
+            patch("kicad_tools.schema.pcb.PCB.load", return_value=stub_pcb),
+            patch("pathlib.Path.write_text", return_value=None),
+        ):
+            _run_placement_feedback(
+                router=router,
+                pcb_path=Path("/tmp/does_not_matter.kicad_pcb"),
+                args=args,
+                quiet=True,
+            )
+
+        kwargs = router.route_with_placement_feedback.call_args.kwargs
+        assert kwargs["per_net_timeout"] is None
+
+    def test_run_placement_feedback_keeps_a_real_per_net_timeout(self):
+        """An explicit positive ``--per-net-timeout`` is not relaxed."""
+        from unittest.mock import MagicMock, patch
+
+        from kicad_tools.cli.route_cmd import _run_placement_feedback
+
+        args = _pf_args(per_net_timeout=4.0)
+        router = MagicMock()
+        router.get_failed_nets.return_value = [1]
+        router.route_with_placement_feedback.return_value = MagicMock(
+            iterations=1,
+            exit_reason="pf_converged",
+            total_components_moved=0,
+            failed_nets=[],
+            placement_diff=[],
+        )
+        stub_pcb = MagicMock()
+        stub_pcb.footprints = []
+
+        with (
+            patch("kicad_tools.schema.pcb.PCB.load", return_value=stub_pcb),
+            patch("pathlib.Path.write_text", return_value=None),
+        ):
+            _run_placement_feedback(
+                router=router,
+                pcb_path=Path("/tmp/does_not_matter.kicad_pcb"),
+                args=args,
+                quiet=True,
+            )
+
+        assert router.route_with_placement_feedback.call_args.kwargs["per_net_timeout"] == 4.0
+
+    def _run_delta(self, per_net_timeout):
+        from unittest.mock import MagicMock, patch
+
+        from kicad_tools.cli.route_cmd import _run_placement_delta_feedback
+
+        args = _pf_args(
+            per_net_timeout=per_net_timeout,
+            placement_delta_feedback_budget=3,
+            placement_delta_feedback_timeout=None,
+            skip_nets=None,
+        )
+        router = MagicMock()
+        router.route_with_placement_delta_feedback.return_value = MagicMock(
+            iterations=1,
+            exit_reason="pdf_converged",
+            applied_deltas=[],
+            failed_nets=[],
+        )
+        stub_pcb = MagicMock()
+        stub_pcb.footprints = []
+
+        with patch("kicad_tools.schema.pcb.PCB.load", return_value=stub_pcb):
+            _run_placement_delta_feedback(
+                router=router,
+                pcb_path=Path("/tmp/does_not_matter.kicad_pcb"),
+                output_path=Path("/tmp/does_not_matter_routed.kicad_pcb"),
+                args=args,
+                quiet=True,
+            )
+        return router.route_with_placement_delta_feedback.call_args.kwargs
+
+    def test_run_placement_delta_feedback_forwards_none_for_zero(self):
+        assert self._run_delta(0.0)["per_net_timeout"] is None
+
+    def test_run_placement_delta_feedback_keeps_a_real_per_net_timeout(self):
+        assert self._run_delta(4.0)["per_net_timeout"] == 4.0


### PR DESCRIPTION
## Summary

`--deterministic-budget` sets `args.per_net_timeout = 0.0` as its documented
"wall-clock cutoff disabled" sentinel. ~24 `route_all_negotiated` call sites in
`route_cmd.py` normalize it away with `or None`; the two placement-feedback
helpers did not, so the literal `0.0` reached the **whole**
`route_all_negotiated` call — and `0.0` is **not** falsy-safe on the way down.

> **Mechanism corrected at the Judge's request (2026-08-13).** An earlier
> revision of this body claimed the fix "structurally cannot touch the negotiated
> loop — it only changes a budget consumed after the loop returns." **That was
> false**, and the Judge proved it. The corrected mechanism is below; the code
> fix is unchanged, and every A/B number still stands. Only the causal story and
> the attribution of the two probe deltas changed.

**What the `0.0` actually did** (verified in this worktree, and now recorded in
the journal + CHANGELOG):

1. `derive_iter_per_net_cap(0.0, remaining)` returns `min(0.0, remaining_cap)` =
   **`0.0`**, where `None` returns `remaining_cap` (60.0 for a 600 s stage). So
   every rip-up-loop reroute site got a zero cap, not just the sweep.
2. `NegotiatedRouter.route_net_negotiated` brackets a multi-pin net with
   `net_deadline = time.monotonic() + per_net_timeout if per_net_timeout is not
   None else None` — an **`is not None`** test, so `0.0` yields an
   already-expired deadline and every RSMT edge is short-circuited to a timeout
   failure **before a single `router.route()` call**. That block sits inside
   `if len(pad_objs) > 2:`, so it is exactly the **≥3-pad** nets that were
   skipped; 2-pad nets took the direct path and survived only because the C++
   backend is falsy-safe (`cpp_backend.py`: `timeout_seconds =
   float(per_net_timeout) if per_net_timeout else 0.0`, where `0.0` means *no*
   deadline).
3. The same `0.0` reached `Autorouter._post_negotiation_sweep_bounds`, which
   computed `min(0.0, POST_NEGOTIATION_SWEEP_PER_NET_S)` = `0.0` and handed every
   stranded net a **zero-second** solo re-attempt, so the #4159 rescue sweep was
   a silent no-op on those passes too.

So the real pre-fix behaviour on a `--deterministic-budget` placement-feedback
re-route was **not** merely "the rescue sweep is inert". It was: *every net with
three or more pads was skipped outright with zero A\* calls, and only 2-pin nets
routed.* This PR restores multi-pin routing on those passes — the change is
**more** valuable than originally advertised, and it **does** change the
negotiated loop's trajectory on placement-feedback re-routes.

This PR ships the curator's recommended **Option A + Option B**: normalize at the
two call sites, *and* harden the sweep-bounds consumer so no future caller can
poison it.

## Changes

- `src/kicad_tools/cli/route_cmd.py` — `_run_placement_feedback` and
  `_run_placement_delta_feedback` now read
  `getattr(args, "per_net_timeout", None) or None`, matching every other call
  site in the file. `_normalize_deterministic_budget`'s docstring no longer
  describes #4776 as a live defect; the call-site comment records the full
  three-part mechanism above (comment-only).
- `src/kicad_tools/router/core.py` — `_post_negotiation_sweep_bounds` treats a
  **falsy** per-net budget as absent (`if not sweep_per_net:`), mirroring
  `_relief_subsearch_budget`, which has always been immune because it tests
  truthiness rather than taking a `min()`.
  **The `is None` gate on the safety-backstop arm is deliberately unchanged** —
  this is the load-bearing guardrail from the issue. No board changes *which*
  arm it selects; only the per-net value that arm returns changes, and only for
  a literal `0.0`.
- `tests/test_post_negotiation_sweep_budget.py` — three new cases. Every
  pre-existing case in the selection table passes **unmodified**.
- `tests/test_route_cmd_placement_feedback.py` — call-site tests asserting both
  helpers forward `None` for `0.0` and `4.0` for `4.0`.
- `boards/07-matchgroup-test/diagnostic-runs/README.md` — the `#4776 is unfixed`
  confound note is corrected, this PR's A/B is recorded, and the mechanism is
  stated accurately (see the correction notice above).
- `CHANGELOG.md` — entry at the top of `[Unreleased]` → `### Fixed`, leading with
  the multi-pin effect.

## The board-04 + board-07 A/B (the load-bearing precondition)

A naive "normalize `0.0` → `None`" is exactly the shape that got #4730 withdrawn
on a measured board-07 regression (PR #4748, `6d8e9bd8`), so this change was
gated on a measurement, not a green unit suite.

**Conditions.** Both arms back-to-back on the same machine, sequential, C++
backend `available` build **19**, `PYTHONHASHSEED=42`, `--seed 42`.
base = `origin/main` @ `fe662585` (i.e. **after** #4781/PR #4786 merged, so this
is measured against that issue's post-merge baseline, as the curator required).
fix = this branch. **Host load average was 9–17 throughout — this host was NOT
quiet**; a host A/B is corroboration, CI is authoritative.

### Observability first (the curator's stop-and-re-diagnose gate)

| pass | base | fix |
|---|---|---|
| initial CLI-driven negotiated pass | `60.0s whole-sweep / 10.0s per-net` | `60.0s / 10.0s` (unchanged) |
| placement-delta re-route, probe 0 | **`60.0s / 0.0s`** | **`60.0s / 10.0s`** |
| placement-delta re-route, probe 1 | **`60.0s / 0.0s`** | **`60.0s / 10.0s`** |

The defect reproduces on base and is gone on fix. AC #2 satisfied.

### Board 07 — `boards/07-matchgroup-test`, allowlist floor **8**

`PYTHONHASHSEED=42 uv run python scripts/ci/check_matchgroup_coverage.py boards/07-matchgroup-test --seed 42`

| measurement | base | fix |
|---|---|---|
| match-group gate exit | **0 (PASS)** | **0 (PASS)** |
| blocking DRC (`--mfr jlcpcb`, advisory-filtered) | **8** (allowed 8) | **8** (allowed 8) |
| blocking DRC **by rule id** | `diffpair_length_skew` 4, `diffpair_routing_continuity` 4 | *identical* |
| advisory by rule id | `connectivity` 5 | *identical* |
| final reach | **26/31** | **26/31** |
| **LVS open set by net name** | `DQ3, DQ4, MIPI_DAT0_N, TMDS_D0_N, TMDS_D1_N` | *identical* |
| open pads | `U2.4, U2.8, U3.4, J2.2, J2.5` | *identical* |
| `check_net_status.py` (known-open allowlist) | exit **0** | exit **0** |
| nets recovered by the sweep, all passes | 0 | **0** |
| deltas proposed / kept | 10 / **0** | 10 / **0** |
| `match_group_length_skew` violations | 0 (baseline 1), rule exercised | *identical* |
| pour-connectivity audit | PASS (3 pour nets) | PASS |
| routed segments / vias | 826 / 206 | 826 / 206 |
| **final routed copper, UUIDs stripped** | — | **byte-identical to base (`diff` = 0 lines)** |

The activated sweep rescues **nothing** here: the 5 open nets are the
seed-invariant #3438/#4012 set and a single 10 s solo re-attempt on the live grid
closes none of them.

**Why the copper is byte-identical — read this carefully.** It is *not* because
the fix cannot reach the routing decisions (it can — see the corrected mechanism
above). It is because **both placement-delta probes were refused in both arms**,
so the board that ships is the initial pass's either way. That is an **outcome
coincidence of the accept gate, not an invariant.**
`_normalize_deterministic_budget`'s own docstring records the adjacent failure
mode: the placement-delta loop's *relative* accept gate can admit a delta `main`
refuses ("+1 net / +5 DRC"). Board 07 sits at 8 blocking DRC against a floor of
8 — **zero headroom** — and this fix changes what that gate is choosing between.
Hence the CI arm below is the authoritative check, not this host run.

### Board 04 — `boards/04-stm32-devboard`, gated **strict 0**

| measurement | base | fix |
|---|---|---|
| recipe exit | 0 | 0 |
| routed | **9/9 (100%)** | **9/9 (100%)** |
| `Post-negotiation sweep bound:` lines | **none** | **none** |
| `check_routed_drc.py` (strict 0, `--mfr jlcpcb-tier1`) | **0 errors**, exit 0 | **0 errors**, exit 0 |
| blocking DRC by rule id | `{}` | `{}` |
| `check_net_status.py` | 0 unconnected pads, exit 0 | 0 unconnected pads, exit 0 |
| LVS open set by net name | ∅ (`lvs.json` `clean: true`, 54 bound pads) | *identical file* |
| copper (segments / vias, UUIDs stripped) | 100 / 30 | 100 / 30, `diff` = 0 lines |

**Scope correction to the curator enhancement.** The enhancement states board 04
"reaches the same defect whenever its initial pass leaves failed nets". On this
host the initial pass leaves **no** failed nets (9/9), so `_run_placement_feedback`
never invokes `route_with_placement_feedback` and the sweep is never reached —
the log contains **zero** `Post-negotiation sweep bound:` lines in either arm.
Board 04 is therefore *insensitive* to this fix here; the CI arm (which does
document a partial-route case) remains the authoritative check, and its gate is
strict-0 either way.

### Divergences from the recorded board-07 journal — re-attributed, not re-baselined

`boards/07-matchgroup-test/diagnostic-runs/README.md` records final reach 26/31,
blocking DRC 8, 0 deltas kept. **All three reproduce exactly in both arms.** Two
*probe-level* numbers moved:

- probe 0 `U2 mirror`: base `25 → 23` (journal value), fix `25 → 22`.
- probe 1 `U3 translate`: base `25 → 26` (refused by the clearance-regression
  guard), fix `25 → 25` (refused for no strict routed-net increase).

**These are attributed to the fix, not dismissed as host noise.** Both probe
passes are placement-delta re-routes — exactly the passes where the pre-fix `0.0`
skipped every ≥3-pad net — so a changed multi-pin re-route trajectory is the
straightforward explanation for a changed probe reach. Host load plausibly
contributes as well (`--timeout 600` is a *wall clock*, so iteration count tracks
machine load: base's probe passes exited at 502.4 s / 335.6 s, the fix's at
601.3 s / 600.4 s under load averages 9–17), but load is **not** the sole cause,
and the "structurally cannot" argument originally offered here is withdrawn as
false. Treat both numbers as **fix-plausible**.

What *is* solid is the outcome: both probes were refused in both arms, so the
final board — and therefore the routed copper, the reach, the LVS open set and
the DRC split — is unchanged. Per the note above, that is an accept-gate
coincidence rather than an invariant.

### Edge cases measured / stated

- **`--deterministic-budget` + placement feedback with no `--timeout`** would now
  select the iteration-bounded backstop arm (600 s / 120 s), because
  `per_net_timeout` becomes `None` and the `timeout is None` gate can finally be
  met. **No board in `boards/` is in that configuration** (04 and 07 both pass
  `--timeout 600`), so this is documentation-of-behaviour, not a gate. Pinned by
  `test_zero_per_net_does_not_flip_the_backstop_arm`, which asserts a literal
  `0.0` *without* a stage timeout stays on the historical 60 s / 10 s arm rather
  than masquerading as a fully-unbudgeted caller.
- **An explicit `--per-net-timeout 4` still clamps to 4.0 s** — unchanged, pinned
  by `test_run_placement_feedback_keeps_a_real_per_net_timeout` and the existing
  `TestBudgetedCallerIsUnchanged` cases.

### Runtime note

Board 07's route step measured **28m00s** (base) vs **33m58s** (fix) on this
host — **+358 s**. The sweep cap accounts for at most ~120 s of that (60 s per
placement-feedback pass, two passes); the residual is best explained by the
negotiated loop **actually routing multi-pin nets again** on those re-routes,
plus the load-driven pass-duration spread. (The earlier revision attributed the
whole delta to load; that does not add up against a ≤120 s cap.) The board-07 CI
job carries a 90-minute allowance.

### Not absorbed

#4781 (relief-rescue vs. stage-budget proportionality) is a distinct defect in
`Autorouter._relief_rescue` and shipped separately as PR #4786; it is already in
this PR's base, so the A/B is against its post-merge baseline rather than a
pre-merge one.

### Deliberately out of scope (suggested follow-up)

The same class of bug is still live for any **non-CLI** caller that hands
`route_all_negotiated` a literal `0.0` — a board script or a library user gets
the multi-pin skip described above with no CLI normalization in front of it. The
durable fixes would be to normalize once at `route_all_negotiated`'s entry, or to
make `route_net_negotiated`'s `net_deadline` truthiness-based like
`_relief_subsearch_budget` and the C++ backend already are. The Judge explicitly
marked this **not a merge gate**, and it is left out of this PR for scope
discipline; see the follow-up note in the comments.

## Acceptance Criteria Verification

- [x] The literal `0.0` can no longer reach `route_all_negotiated` — and hence
      neither `derive_iter_per_net_cap`, `route_net_negotiated`'s net deadline,
      nor `_post_negotiation_sweep_bounds` — through either placement-feedback
      helper. Normalized at both call sites, plus consumer hardening.
- [x] A `--deterministic-budget` placement-feedback re-route with a stage
      `--timeout` prints `10.0s per-net` — measured, both board-07 PDF passes.
- [x] Budgeted callers with an explicit positive `--per-net-timeout` unchanged;
      every existing case in `tests/test_post_negotiation_sweep_budget.py`
      passes **unmodified**.
- [x] Board-07 A/B in this body: LVS open set by name + routed DRC by rule id,
      both arms. Floor 8, measured 8/8.
- [x] Board-04 A/B in this body, same two measurements. Strict 0, measured 0/0.
- [x] Neither `.github/routed-drc-tolerance.yml` nor any board gate threshold is
      touched (`git diff` covers 6 files; none is a gate/allowlist).
- [x] Journal divergences explained and **re-attributed to the fix**, not
      silently re-baselined and not dismissed as load noise.
- [x] `diagnostic-runs/README.md`'s `#4776` note and
      `_normalize_deterministic_budget`'s docstring no longer describe #4776 as
      an open defect / live confound, and the journal now records the real
      mechanism (multi-pin skip), not the sweep-only understatement.
- [x] A/B is positive, so the behaviour ships rather than being gated.

## Test Plan

- [x] `uv run pytest tests/test_post_negotiation_sweep_budget.py
      tests/test_route_cmd_placement_feedback.py
      tests/test_relief_subsearch_budget.py` — **120 passed**.
- [x] Broader sweep: `+ tests/test_route_deterministic_budget.py
      tests/test_route_deterministic_budget_load_independence.py
      tests/test_placement_feedback.py tests/test_route_cmd_total_timeout.py
      tests/test_route_cmd_params.py` — **322 passed, 1 skipped**.
- [x] `uv run ruff format --check` + `uv run ruff check` on all changed files —
      clean.
- [x] `uv run python scripts/ci/check_mypy_baseline.py` — 1470 errors within the
      1472 baseline, no new type errors. (The "2 baseline errors no longer occur"
      warning is the known native-built-worktree nanobind artifact; the baseline
      is deliberately **not** `--update`d.)
- [x] Manual (observability + reach): the two-board A/B above.
- [x] Docs-correction head re-verified: `tests/test_route_cmd_placement_feedback.py
      tests/test_post_negotiation_sweep_budget.py` — **96 passed** (the
      `route_cmd.py` edit in that commit is comment-only).
- [ ] CI: `Match-Group Routing Regression (boards/07-matchgroup-test)` and
      `Board 07 E2E` must be green **without** any allowlist edit — this is the
      authoritative arm, since the host run was taken under load average 9–17.

Closes #4776
