### PR TITLE
chore(deps): add Dependabot config (actions, pip, site npm)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels: ["tier:maintenance"]
+    groups:
+      github-actions:
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels: ["tier:maintenance"]
+    groups:
+      pip-minor-patch:
+        patterns: ["*"]
+        # native-toolchain / ABI coupling: these get their own reviewable PRs
+        exclude-patterns: ["nanobind", "cmake", "numpy"]
+        update-types: ["minor", "patch"]
+    # majors deliberately ungrouped: one reviewable PR each
+
+  - package-ecosystem: "npm"
+    directory: "/site"
+    schedule:
+      interval: "weekly"
+    labels: ["tier:maintenance"]
+    groups:
+      site-minor-patch:
+        patterns: ["*"]
+        # site framework: its own reviewable PRs
+        exclude-patterns: ["astro"]
+        update-types: ["minor", "patch"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,19 +4,20 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    labels: ["tier:maintenance"]
+    labels: ["dependencies", "tier:maintenance"]
     groups:
       github-actions:
         patterns: ["*"]
-        update-types: ["major", "minor", "patch"]
+        update-types: ["minor", "patch"]
+    # majors deliberately ungrouped: one reviewable PR each
 
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
-    labels: ["tier:maintenance"]
+    labels: ["dependencies", "tier:maintenance"]
     groups:
-      pip-minor-patch:
+      python-minor-patch:
         patterns: ["*"]
         # native-toolchain / ABI coupling: these get their own reviewable PRs
         exclude-patterns: ["nanobind", "cmake", "numpy"]
@@ -27,10 +28,10 @@ updates:
     directory: "/site"
     schedule:
       interval: "weekly"
-    labels: ["tier:maintenance"]
+    labels: ["dependencies", "tier:maintenance"]
     groups:
       site-minor-patch:
         patterns: ["*"]
         # site framework: its own reviewable PRs
-        exclude-patterns: ["astro"]
+        exclude-patterns: ["astro", "@astrojs/*"]
         update-types: ["minor", "patch"]


### PR DESCRIPTION
Adds `.github/dependabot.yml` declaring three update ecosystems, all on a weekly cadence with minor/patch updates grouped into one PR per ecosystem and majors deliberately ungrouped (one reviewable PR each):

- **`github-actions` at `/`** — workflow action bumps, minor/patch grouped.
- **`uv` at `/`** — Python dependency bumps against `uv.lock` (the file that pins real versions here; CI runs `uv sync --frozen`). Excludes `nanobind`, `cmake`, and `numpy` (native-toolchain / ABI coupling — bump those deliberately).
- **`npm` at `/site`** — site dependency bumps. Excludes `astro` and `@astrojs/*` so the site framework gets its own PRs.

All entries label their PRs `dependencies` + `tier:maintenance`. `loom:review-requested` is deliberately not seeded — auto-injecting Dependabot PRs into the Judge queue is an operator policy decision.

Review history: the initial `pip` ecosystem entry was rejected by Judge (pip cannot manage a uv-locked repo) and corrected to `uv` in 859d63f, confirmed by GitHub's dependabot.yml validation check.
