### PR TITLE
docs: complete the truncated '## Releasing' section in CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -625,6 +625,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`CLAUDE.md`'s `## Releasing` section no longer ends mid-sentence** (#4797) —
+  the dangling "(the tag must point at a commit that" clause is completed with
+  the reason `RELEASING.md` gives: the tag must reference the commit as it
+  landed on `main` (squash-merge gives it a different SHA), never a pre-merge
+  `release/vX.Y.Z` branch commit.
 - **Multi-pin nets are no longer skipped outright on `--deterministic-budget`
   placement-feedback re-routes** (#4776) — `--deterministic-budget` sets
   `args.per_net_timeout = 0.0` as its "wall-clock cutoff disabled" sentinel, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,9 @@ Releases go through a **PR-based flow** — see [`RELEASING.md`](RELEASING.md) f
 the canonical process. Never push the version-bump commit directly to `main`;
 the version is bumped on a branch, merged via PR, and the `vX.Y.Z` tag is
 created **only after** the bump PR merges (the tag must point at a commit that
+is actually on `main`, never a pre-merge `release/vX.Y.Z` branch commit —
+`main` squash-merges, so the commit that lands has a different SHA than the
+one on the release branch).
 
 <!-- BEGIN LOOM ORCHESTRATION -->
 This repository uses [Loom](https://github.com/rjwalters/loom) for AI-powered development orchestration — see the Loom repository for the full guide (roles, labels, worktrees, configuration). When installed, Loom also writes a locally-substituted copy of that guide to `.loom/CLAUDE.md`.


### PR DESCRIPTION
## Summary

`CLAUDE.md`'s `## Releasing` section ended mid-sentence on `main` — the
paragraph stopped at "(the tag must point at a commit that" and the file jumped
straight into the `<!-- BEGIN LOOM ORCHESTRATION -->` marker block, leaving a
dangling clause and an unclosed parenthesis.

This completes the clause with the reason `RELEASING.md` (the canonical process
document this paragraph summarizes) gives for the hard ordering rule: `main`
squash-merges, so the bump commit that lands on `main` has a **different SHA**
than the commit on the `release/vX.Y.Z` branch — which is why the tag must point
at the merged `main` commit and never at a pre-merge branch commit.

The section stays a pointer/summary; no procedural detail is added that isn't
already in `RELEASING.md` (§ "The hard ordering rule (read this)" and § "(d)
Fetch, then create an annotated tag on the merged `main` SHA").

## Changes

- `CLAUDE.md` — completed the truncated sentence in `## Releasing`
  (3 added lines, edit entirely **outside** the `REPO-SKILLS` / `LOOM
  ORCHESTRATION` marker blocks).
- `CHANGELOG.md` — one entry under `[Unreleased]` → `### Fixed`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Dangling sentence completed, accurately reflecting `RELEASING.md` (tag references the commit as it landed on `main` post-squash-merge, not the pre-merge branch commit) | ✅ | New text: "…is actually on `main`, never a pre-merge `release/vX.Y.Z` branch commit — `main` squash-merges, so the commit that lands has a different SHA than the one on the release branch)." Matches `RELEASING.md` lines 130-133 and 159-172 verbatim in substance. |
| No new claim beyond `RELEASING.md`; stays high-level | ✅ | Every assertion (squash-merge, different SHA, never tag pre-merge branch commit) is stated in `RELEASING.md`. No commands, no new steps; the existing `RELEASING.md` link still carries the procedural detail. |
| Formatting matches the rest of `CLAUDE.md` (blank line before next section, same prose style) | ✅ | Blank line before `<!-- BEGIN LOOM ORCHESTRATION -->` preserved; prose wrapped at the same ~78-col width as the surrounding paragraph; sentence continues the existing paragraph rather than starting a new block. |
| Scan the rest of `CLAUDE.md` for other truncations from the same edit | ✅ | Read the full file (69 lines). The other sections — `## Routing performance…` (+ `### Rebuilding after editing C++ sources`), `## Type checks…`, the `REPO-SKILLS` block, and the `LOOM ORCHESTRATION` block — all end in complete sentences with correct trailing blank lines. No other truncation found, so nothing to file separately. |

## Test Plan

Documentation-only; no automated test exists for this. Verified by:

1. Reading the updated `## Releasing` section end-to-end — it now reads as a
   complete, grammatical sentence with the parenthesis closed.
2. Cross-checking the completed clause against `RELEASING.md` — it contradicts
   nothing there and restates only what that document already asserts.
3. Confirmed the diff touches no Python (no `ruff` run needed) and no
   marker-managed regions.

Closes #4797
