### PR TITLE
fix(cli,sync): route remaining export_netlist byproducts through a temp dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -648,6 +648,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`kct netlist`, `kct sch unconnected` and `kct sync` no longer leave a
+  netlist file beside the user's schematic** (#4795, third installment after
+  #4750 and #4763) — `export_netlist()` defaults `output_path` to
+  `<schematic dir>/<stem>-netlist.kicad_net` and never deletes it, so every
+  *byproduct* call site silently dropped an unrequested `*-netlist.kicad_net`
+  into the user's project directory. The nine remaining bare calls now route
+  that byproduct through a `tempfile.TemporaryDirectory()` that is torn down
+  before the caller returns: `Reconciler._build_net_adjacency` and
+  `Reconciler._assign_nets` (both consume the parsed `Netlist` in memory only),
+  `sch_find_unconnected`'s netlist cross-check (which keeps its load-bearing
+  `fallback=False` — the Python fallback would hide the very bug that check
+  exists to catch), and the `analyze` / `list` / `show` / `check` / `compare`
+  subcommands of `kct netlist` (`compare` exports *two* schematics, so neither
+  the old nor the new project directory gains a file). `kct netlist export` is
+  deliberately unchanged: there the netlist file **is** the product the user
+  asked for. Exception semantics at every site are preserved (the reconciler's
+  best-effort swallowing, the cross-check's three specific `except` messages).
+  Per-file `TestNetlistByproductLocation` regression classes in
+  `tests/test_sync.py`, `tests/test_cli_sch.py` and `tests/test_cli_netlist.py`
+  stub `kicad-cli` and assert the schematic's directory listing is byte-for-byte
+  unchanged across each call — plus a guard that `kct netlist export` still
+  writes its file at both the default and `-o` locations.
+
 - **`CLAUDE.md`'s `## Releasing` section no longer ends mid-sentence** (#4797) —
   the dangling "(the tag must point at a commit that" clause is completed with
   the reason `RELEASING.md` gives: the tag must reference the commit as it

--- a/src/kicad_tools/cli/netlist_cmd.py
+++ b/src/kicad_tools/cli/netlist_cmd.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import tempfile
 from pathlib import Path
 
 from kicad_tools.operations.netlist import (
@@ -25,6 +26,34 @@ from kicad_tools.operations.netlist import (
     NetlistNet,
     export_netlist,
 )
+
+
+def _export_netlist_to_temp(schematic_path: Path, prefix: str) -> Netlist:
+    """Export a netlist without leaving a byproduct beside the schematic.
+
+    ``export_netlist`` defaults ``output_path`` to
+    ``<schematic dir>/<stem>-netlist.kicad_net`` and never deletes it, so a
+    bare call drops an unrequested netlist file into the user's project
+    directory (#4750, #4763, #4795).  Every ``kct netlist`` subcommand except
+    ``export`` only needs the parsed :class:`Netlist` object, so the exported
+    file is routed into a temp directory that is torn down immediately.
+
+    ``kct netlist export`` deliberately does *not* use this helper -- there
+    the netlist file *is* the requested product.
+
+    Args:
+        schematic_path: Path to the .kicad_sch file to export.
+        prefix: Temp-directory prefix identifying the calling subcommand.
+
+    Returns:
+        Parsed Netlist object.
+    """
+    sch = Path(schematic_path)
+    with tempfile.TemporaryDirectory(prefix=prefix) as tmpdir:
+        return export_netlist(
+            schematic_path,
+            output_path=Path(tmpdir) / f"{sch.stem}-netlist.kicad_net",
+        )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -126,7 +155,7 @@ def main(argv: list[str] | None = None) -> int:
 
 def cmd_analyze(schematic_path: Path, format: str) -> int:
     """Show connectivity statistics."""
-    netlist = export_netlist(schematic_path)
+    netlist = _export_netlist_to_temp(schematic_path, "kct-netlist-analyze-")
     stats = netlist.summary()
 
     # Additional analysis
@@ -177,7 +206,7 @@ def print_analyze_text(stats: dict, netlist: Netlist) -> None:
 
 def cmd_list(schematic_path: Path, format: str, sort: str) -> int:
     """List all nets with connection counts."""
-    netlist = export_netlist(schematic_path)
+    netlist = _export_netlist_to_temp(schematic_path, "kct-netlist-list-")
 
     if sort == "connections":
         sorted_nets = sorted(netlist.nets, key=lambda n: -n.connection_count)
@@ -238,7 +267,7 @@ def print_list_table(nets: list[NetlistNet], netlist: Netlist) -> None:
 
 def cmd_show(schematic_path: Path, net_name: str, format: str) -> int:
     """Show specific net details."""
-    netlist = export_netlist(schematic_path)
+    netlist = _export_netlist_to_temp(schematic_path, "kct-netlist-show-")
     net = netlist.get_net(net_name)
 
     if not net:
@@ -309,7 +338,7 @@ def print_show_text(net: NetlistNet, netlist: Netlist) -> None:
 
 def cmd_check(schematic_path: Path, format: str) -> int:
     """Find connectivity issues."""
-    netlist = export_netlist(schematic_path)
+    netlist = _export_netlist_to_temp(schematic_path, "kct-netlist-check-")
 
     # Find issues
     single_pin_nets = find_single_pin_nets(netlist)
@@ -376,8 +405,8 @@ def print_check_text(result: dict, power_nets: list[NetlistNet]) -> None:
 
 def cmd_compare(old_path: Path, new_path: Path, format: str) -> int:
     """Compare two netlists."""
-    old_netlist = export_netlist(old_path)
-    new_netlist = export_netlist(new_path)
+    old_netlist = _export_netlist_to_temp(old_path, "kct-netlist-compare-old-")
+    new_netlist = _export_netlist_to_temp(new_path, "kct-netlist-compare-new-")
 
     # Compare components
     old_refs = {c.reference for c in old_netlist.components}

--- a/src/kicad_tools/cli/sch_find_unconnected.py
+++ b/src/kicad_tools/cli/sch_find_unconnected.py
@@ -42,6 +42,7 @@ import argparse
 import fnmatch
 import json
 import sys
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -278,8 +279,20 @@ def _cross_check_netlist(
     # consumer (pcbnew, KiCad, exported BOMs, fabrication outputs)
     # actually sees.  The Python fallback would *hide* the bug by
     # walking the hierarchy correctly.
+    #
+    # The export itself is a byproduct of this cross-check, not something
+    # the user asked for, so its ``output_path`` is routed into a temp
+    # directory -- a bare call would leave ``<stem>-netlist.kicad_net``
+    # beside the user's schematic (#4750, #4763, #4795).  Only the parsed
+    # ``Netlist`` object is consumed below; the file is never re-read.
+    root = Path(root_path)
     try:
-        netlist = export_netlist(root_path, fallback=False)
+        with tempfile.TemporaryDirectory(prefix="kct-unconnected-netlist-") as tmpdir:
+            netlist = export_netlist(
+                root_path,
+                output_path=Path(tmpdir) / f"{root.stem}-netlist.kicad_net",
+                fallback=False,
+            )
     except FileNotFoundError as e:
         return [], f"kicad-cli not available, netlist cross-check skipped: {e}"
     except RuntimeError as e:

--- a/src/kicad_tools/sync/reconciler.py
+++ b/src/kicad_tools/sync/reconciler.py
@@ -24,6 +24,7 @@ import json
 import math
 import re
 import shutil
+import tempfile
 from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -812,7 +813,24 @@ class Reconciler:
         try:
             from kicad_tools.operations.netlist import export_netlist
 
-            netlist = export_netlist(str(self._schematic_path))
+            # Route the kicad-cli byproduct into a temp directory.
+            #
+            # ``export_netlist`` defaults ``output_path`` to
+            # ``<schematic dir>/<stem>-netlist.kicad_net`` and never deletes
+            # it, so a bare call would drop an unrequested netlist file
+            # beside the user's schematic (#4750, #4763, #4795).  The parsed
+            # ``Netlist`` is returned in memory and the adjacency map below
+            # never re-reads the file, so the temp dir can be torn down
+            # immediately.
+            # ``str()`` first: ``_schematic_path`` is ``Path | None`` and a
+            # ``None`` path must keep degrading through the ``except`` below
+            # (as it did before this call site grew an explicit output path).
+            sch = Path(str(self._schematic_path))
+            with tempfile.TemporaryDirectory(prefix="kct-sync-adjacency-netlist-") as tmpdir:
+                netlist = export_netlist(
+                    str(sch),
+                    output_path=Path(tmpdir) / f"{sch.stem}-netlist.kicad_net",
+                )
         except Exception:
             return {}
 
@@ -1165,7 +1183,19 @@ class Reconciler:
         try:
             from kicad_tools.operations.netlist import export_netlist
 
-            netlist = export_netlist(str(self._schematic_path))
+            # Route the kicad-cli byproduct into a temp directory -- a bare
+            # call would leave ``<stem>-netlist.kicad_net`` beside the user's
+            # schematic on every sync (#4750, #4763, #4795).  The netlist is
+            # consumed as an in-memory object below, never re-read from disk.
+            # ``str()`` first: ``_schematic_path`` is ``Path | None`` and a
+            # ``None`` path must keep degrading through the ``except`` below
+            # (as it did before this call site grew an explicit output path).
+            sch = Path(str(self._schematic_path))
+            with tempfile.TemporaryDirectory(prefix="kct-sync-assign-netlist-") as tmpdir:
+                netlist = export_netlist(
+                    str(sch),
+                    output_path=Path(tmpdir) / f"{sch.stem}-netlist.kicad_net",
+                )
 
             # Add all nets from the netlist to the PCB
             for net in netlist.nets:

--- a/tests/test_cli_netlist.py
+++ b/tests/test_cli_netlist.py
@@ -1189,3 +1189,206 @@ class TestCmdExportFallbackHandling:
         assert result == 0
         captured = capsys.readouterr()
         assert "Exported KiCad netlist to:" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Netlist byproduct location (#4795)
+# ---------------------------------------------------------------------------
+
+MINIMAL_SCHEMATIC = """(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (uuid "00000000-0000-0000-0000-000000000001")
+  (paper "A4")
+  (symbol
+    (lib_id "Device:R")
+    (at 100 100 0)
+    (uuid "00000000-0000-0000-0000-000000000002")
+    (property "Reference" "R1" (at 100 97 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "10k" (at 100 103 0) (effects (font (size 1.27 1.27))))
+    (property "Footprint" "Resistor_SMD:R_0402" (at 100 100 0) (effects (hide yes)))
+  )
+  (symbol
+    (lib_id "Device:C")
+    (at 120 100 0)
+    (uuid "00000000-0000-0000-0000-000000000003")
+    (property "Reference" "C1" (at 120 97 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "100n" (at 120 103 0) (effects (font (size 1.27 1.27))))
+    (property "Footprint" "Capacitor_SMD:C_0402" (at 120 100 0) (effects (hide yes)))
+  )
+)
+"""
+
+# Minimal kicad-cli-shaped netlist matching MINIMAL_SCHEMATIC (R1 + C1).
+FAKE_EXPORTED_NETLIST = """(export (version "E")
+  (design (source "test.kicad_sch") (tool "Eeschema"))
+  (components
+    (comp (ref "R1") (value "10k") (footprint "Resistor_SMD:R_0402"))
+    (comp (ref "C1") (value "100n") (footprint "Capacitor_SMD:C_0402")))
+  (nets
+    (net (code "1") (name "/N1")
+      (node (ref "R1") (pin "1"))
+      (node (ref "C1") (pin "1")))))
+"""
+
+
+class TestNetlistByproductLocation:
+    """``kct netlist`` analysis subcommands must not litter the project dir (#4795).
+
+    ``export_netlist`` defaults ``output_path`` to
+    ``<schematic dir>/<stem>-netlist.kicad_net`` and never deletes it, so a
+    bare call from ``cmd_analyze`` / ``cmd_list`` / ``cmd_show`` /
+    ``cmd_check`` / ``cmd_compare`` dropped an unrequested netlist file
+    beside the user's schematic on every invocation.  ``cmd_export`` is the
+    one call site where that file *is* the requested product -- it is
+    covered here too, to prove the fix did not sweep it into temp routing.
+    """
+
+    @pytest.fixture
+    def schematic(self, tmp_path: Path) -> Path:
+        """A schematic in its own 'project' directory."""
+        proj = tmp_path / "project"
+        proj.mkdir()
+        sch = proj / "design.kicad_sch"
+        sch.write_text(MINIMAL_SCHEMATIC)
+        return sch
+
+    @pytest.fixture
+    def fake_kicad_cli(self, monkeypatch) -> list[Path]:
+        """Force the kicad-cli export path with a stubbed subprocess.
+
+        The stub writes a real netlist file to whatever ``--output`` path it
+        is handed, exactly like kicad-cli does -- so the byproduct lands
+        wherever ``export_netlist`` decided it should, which is the behavior
+        under test.  Returns the list of captured output paths.
+        """
+        import subprocess as _subprocess
+
+        captured_outputs: list[Path] = []
+
+        monkeypatch.setattr(
+            "kicad_tools.operations.netlist.find_kicad_cli",
+            lambda: Path("/fake/kicad-cli"),
+        )
+
+        def fake_run(cmd, *args, **kwargs):
+            out = Path(cmd[cmd.index("--output") + 1])
+            captured_outputs.append(out)
+            out.write_text(FAKE_EXPORTED_NETLIST)
+            return _subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr("kicad_tools.operations.netlist.subprocess.run", fake_run)
+        return captured_outputs
+
+    def test_kicad_cli_path_is_actually_exercised(self, schematic, fake_kicad_cli, capsys):
+        """Guard: the stub really runs, so the assertions below mean something."""
+        assert netlist_cmd.cmd_analyze(schematic, "json") == 0
+        assert fake_kicad_cli, "kicad-cli export path was never taken"
+
+    @pytest.mark.parametrize(
+        "invoke",
+        [
+            pytest.param(lambda sch: netlist_cmd.cmd_analyze(sch, "json"), id="analyze"),
+            pytest.param(lambda sch: netlist_cmd.cmd_list(sch, "json", "connections"), id="list"),
+            pytest.param(lambda sch: netlist_cmd.cmd_show(sch, "/N1", "json"), id="show"),
+            pytest.param(lambda sch: netlist_cmd.cmd_check(sch, "json"), id="check"),
+        ],
+    )
+    def test_no_byproduct_beside_schematic(self, schematic, fake_kicad_cli, capsys, invoke):
+        """No ``*-netlist.kicad_net`` is left in the schematic's directory."""
+        before = {p.name for p in schematic.parent.iterdir()}
+
+        assert invoke(schematic) == 0
+
+        assert fake_kicad_cli, "kicad-cli export path was never taken"
+        stray = sorted(p.name for p in schematic.parent.glob("*-netlist.kicad_net"))
+        assert not stray, f"subcommand left byproducts beside the schematic: {stray}"
+        assert {p.name for p in schematic.parent.iterdir()} == before
+
+    @pytest.mark.parametrize(
+        "invoke",
+        [
+            pytest.param(lambda sch: netlist_cmd.cmd_analyze(sch, "json"), id="analyze"),
+            pytest.param(lambda sch: netlist_cmd.cmd_list(sch, "json", "connections"), id="list"),
+            pytest.param(lambda sch: netlist_cmd.cmd_show(sch, "/N1", "json"), id="show"),
+            pytest.param(lambda sch: netlist_cmd.cmd_check(sch, "json"), id="check"),
+        ],
+    )
+    def test_temp_export_is_cleaned_up(self, schematic, fake_kicad_cli, capsys, invoke):
+        """The temp directory is torn down before the subcommand returns."""
+        assert invoke(schematic) == 0
+
+        assert fake_kicad_cli
+        for out in fake_kicad_cli:
+            assert out.parent != schematic.parent, f"export wrote into the project dir: {out}"
+            assert not out.exists(), f"temp netlist survived the command: {out}"
+            assert not out.parent.exists(), f"temp dir survived the command: {out.parent}"
+
+    def test_compare_leaves_no_byproduct_in_either_dir(self, tmp_path, fake_kicad_cli, capsys):
+        """``cmd_compare`` must not litter *either* schematic's directory."""
+        old_dir = tmp_path / "old_project"
+        new_dir = tmp_path / "new_project"
+        old_dir.mkdir()
+        new_dir.mkdir()
+        old_path = old_dir / "rev_a.kicad_sch"
+        new_path = new_dir / "rev_b.kicad_sch"
+        old_path.write_text(MINIMAL_SCHEMATIC)
+        new_path.write_text(MINIMAL_SCHEMATIC)
+
+        before_old = {p.name for p in old_dir.iterdir()}
+        before_new = {p.name for p in new_dir.iterdir()}
+
+        assert netlist_cmd.cmd_compare(old_path, new_path, "json") == 0
+
+        assert len(fake_kicad_cli) == 2, "both schematics should have been exported"
+        assert not sorted(old_dir.glob("*-netlist.kicad_net")), "old dir gained a netlist file"
+        assert not sorted(new_dir.glob("*-netlist.kicad_net")), "new dir gained a netlist file"
+        assert {p.name for p in old_dir.iterdir()} == before_old
+        assert {p.name for p in new_dir.iterdir()} == before_new
+        for out in fake_kicad_cli:
+            assert not out.exists()
+
+    def test_compare_temp_paths_do_not_collide(self, tmp_path, fake_kicad_cli, capsys):
+        """Same-stem schematics in different dirs get distinct temp outputs."""
+        old_dir = tmp_path / "v1"
+        new_dir = tmp_path / "v2"
+        old_dir.mkdir()
+        new_dir.mkdir()
+        old_path = old_dir / "design.kicad_sch"
+        new_path = new_dir / "design.kicad_sch"
+        old_path.write_text(MINIMAL_SCHEMATIC)
+        new_path.write_text(MINIMAL_SCHEMATIC)
+
+        assert netlist_cmd.cmd_compare(old_path, new_path, "json") == 0
+
+        assert len(fake_kicad_cli) == 2
+        assert fake_kicad_cli[0] != fake_kicad_cli[1], "compare reused one temp output path"
+
+    def test_netlist_data_survives_temp_routing(self, schematic, fake_kicad_cli, capsys):
+        """The parsed netlist still reaches the command output."""
+        assert netlist_cmd.cmd_list(schematic, "json", "name") == 0
+
+        data = json.loads(capsys.readouterr().out)
+        assert [net["name"] for net in data] == ["/N1"]
+        assert data[0]["connections"] == 2
+
+    def test_export_still_writes_its_product_at_default_location(
+        self, schematic, fake_kicad_cli, capsys
+    ):
+        """``kct netlist export`` is the product site -- it must still litter."""
+        assert netlist_cmd.cmd_export(schematic, None, "kicad") == 0
+
+        product = schematic.parent / "design-netlist.kicad_net"
+        assert product.exists(), "export no longer writes the netlist the user asked for"
+        assert "Exported KiCad netlist to:" in capsys.readouterr().out
+
+    def test_export_still_writes_its_product_at_requested_location(
+        self, schematic, tmp_path, fake_kicad_cli, capsys
+    ):
+        """``kct netlist export -o`` still writes to the requested path."""
+        requested = tmp_path / "custom.net"
+
+        assert netlist_cmd.cmd_export(schematic, requested, "kicad") == 0
+
+        assert requested.exists(), "export -o no longer writes the requested file"
+        assert "Exported KiCad netlist to:" in capsys.readouterr().out

--- a/tests/test_cli_sch.py
+++ b/tests/test_cli_sch.py
@@ -3671,3 +3671,156 @@ class TestSchValidateMissingProjectInstances:
             f"validate reported {validator_count} errors but "
             f"repair-instances dry-run reported {repair_count}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Netlist byproduct location (#4795)
+# ---------------------------------------------------------------------------
+
+# Minimal kicad-cli-shaped netlist matching TestConnectionsSubGridTolerance._SCH_EXACT
+# (a single resistor R1 with both pins wired).
+_FAKE_EXPORTED_NETLIST = """(export (version "E")
+  (design (source "exact.kicad_sch") (tool "Eeschema"))
+  (components
+    (comp (ref "R1") (value "10k")))
+  (nets
+    (net (code "1") (name "/N1")
+      (node (ref "R1") (pin "1")))
+    (net (code "2") (name "/N2")
+      (node (ref "R1") (pin "2")))))
+"""
+
+
+class TestNetlistByproductLocation:
+    """``sch unconnected``'s netlist cross-check must not litter the project dir (#4795).
+
+    ``export_netlist`` defaults ``output_path`` to
+    ``<schematic dir>/<stem>-netlist.kicad_net`` and never deletes it, so
+    the bare call in ``_cross_check_netlist`` dropped an unrequested netlist
+    file beside the user's schematic on every ``kct sch unconnected`` run.
+    The export here is purely a diagnostic byproduct -- the user asked for
+    a report, not a netlist file.
+    """
+
+    @pytest.fixture
+    def schematic(self, tmp_path: Path) -> Path:
+        """A schematic in its own 'project' directory."""
+        proj = tmp_path / "project"
+        proj.mkdir()
+        sch = proj / "exact.kicad_sch"
+        sch.write_text(TestConnectionsSubGridTolerance._SCH_EXACT)
+        return sch
+
+    @pytest.fixture
+    def fake_kicad_cli(self, monkeypatch) -> list[Path]:
+        """Force the kicad-cli export path with a stubbed subprocess.
+
+        The stub writes a real netlist file to whatever ``--output`` path it
+        is handed, exactly like kicad-cli does -- so the byproduct lands
+        wherever ``export_netlist`` decided it should, which is the behavior
+        under test.  Returns the list of captured output paths.
+        """
+        import subprocess as _subprocess
+
+        captured_outputs: list[Path] = []
+
+        monkeypatch.setattr(
+            "kicad_tools.operations.netlist.find_kicad_cli",
+            lambda: Path("/fake/kicad-cli"),
+        )
+
+        def fake_run(cmd, *args, **kwargs):
+            out = Path(cmd[cmd.index("--output") + 1])
+            captured_outputs.append(out)
+            out.write_text(_FAKE_EXPORTED_NETLIST)
+            return _subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr("kicad_tools.operations.netlist.subprocess.run", fake_run)
+        return captured_outputs
+
+    def test_kicad_cli_path_is_actually_exercised(self, schematic, fake_kicad_cli, capsys):
+        """Guard: the stub really runs, so the assertions below mean something."""
+        from kicad_tools.cli.sch_find_unconnected import main
+
+        main([str(schematic), "--format", "json"])
+
+        assert fake_kicad_cli, "kicad-cli export path was never taken"
+
+    def test_no_byproduct_beside_schematic(self, schematic, fake_kicad_cli, capsys):
+        """No ``*-netlist.kicad_net`` is left in the schematic's directory."""
+        from kicad_tools.cli.sch_find_unconnected import main
+
+        before = {p.name for p in schematic.parent.iterdir()}
+
+        main([str(schematic), "--format", "json"])
+
+        assert fake_kicad_cli, "kicad-cli export path was never taken"
+        stray = sorted(p.name for p in schematic.parent.glob("*-netlist.kicad_net"))
+        assert not stray, f"cross-check left byproducts beside the schematic: {stray}"
+        assert {p.name for p in schematic.parent.iterdir()} == before
+
+    def test_temp_export_is_cleaned_up(self, schematic, fake_kicad_cli, capsys):
+        """The temp directory is torn down before the cross-check returns."""
+        from kicad_tools.cli.sch_find_unconnected import main
+
+        main([str(schematic), "--format", "json"])
+
+        assert fake_kicad_cli
+        for out in fake_kicad_cli:
+            assert out.parent != schematic.parent, f"export wrote into the project dir: {out}"
+            assert not out.exists(), f"temp netlist survived the cross-check: {out}"
+            assert not out.parent.exists(), f"temp dir survived the cross-check: {out.parent}"
+
+    def test_cross_check_still_consumes_the_netlist(self, schematic, fake_kicad_cli, capsys):
+        """The parsed netlist still drives the cross-check (no false findings)."""
+        from kicad_tools.cli.sch_find_unconnected import main
+
+        main([str(schematic), "--format", "json"])
+        data = json.loads(capsys.readouterr().out)
+
+        # Both R1 pins are in the fake netlist -> no missing-from-netlist findings.
+        assert data["summary"]["missing_from_netlist_count"] == 0
+
+    def test_fallback_false_is_preserved(self, schematic, monkeypatch, capsys):
+        """The cross-check must keep asking for kicad-cli output only.
+
+        ``fallback=False`` is load-bearing: the Python fallback walks the
+        hierarchy correctly and would hide exactly the bug this cross-check
+        exists to catch.  Routing the byproduct to a temp dir must not drop it.
+        """
+        import kicad_tools.operations.netlist as netlist_mod
+        from kicad_tools.operations.netlist import Netlist
+
+        seen: list[dict] = []
+
+        def _spy(sch_path, *args, **kwargs):
+            seen.append(kwargs)
+            return Netlist()
+
+        monkeypatch.setattr(netlist_mod, "export_netlist", _spy)
+
+        from kicad_tools.cli.sch_find_unconnected import main
+
+        main([str(schematic), "--format", "json"])
+
+        assert seen, "export_netlist was never called"
+        assert seen[0].get("fallback") is False, "fallback=False was dropped"
+        assert "output_path" in seen[0], "byproduct was not routed to an explicit path"
+
+    def test_export_errors_still_skip_gracefully(self, schematic, monkeypatch, capsys):
+        """kicad-cli failures inside the temp-dir block keep their messages."""
+        import kicad_tools.operations.netlist as netlist_mod
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("kicad-cli failed: synthetic")
+
+        monkeypatch.setattr(netlist_mod, "export_netlist", _boom)
+
+        from kicad_tools.cli.sch_find_unconnected import main
+
+        main([str(schematic), "--format", "json"])
+        out = capsys.readouterr()
+
+        data = json.loads(out.out)
+        assert data["summary"]["missing_from_netlist_count"] == 0
+        assert "skipped" in out.err.lower()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1165,8 +1165,14 @@ class TestReconcilerApplyIntegration:
         assert len(changes) == 1
         assert changes[0].applied is True
         # Verify export_netlist was called (for smart placement and net assignment)
-        mock_export.assert_called_with(sch_path)
         assert mock_export.call_count >= 1
+        # The schematic is still the first positional argument, but the
+        # kicad-cli byproduct is now routed into a temp dir (#4795) rather
+        # than landing beside the user's schematic.
+        call_args, call_kwargs = mock_export.call_args
+        assert call_args[0] == sch_path
+        byproduct = Path(call_kwargs["output_path"])
+        assert byproduct.parent != Path(sch_path).parent
         mock_pcb.assign_nets_from_netlist.assert_called_once_with(mock_netlist)
 
         Path(sch_path).unlink()
@@ -2787,3 +2793,181 @@ class TestComputePlacementStart:
         assert x == pytest.approx(10.0)
         assert y == pytest.approx(10.0)
         assert col == 0
+
+
+# ---------------------------------------------------------------------------
+# Netlist byproduct location (#4795)
+# ---------------------------------------------------------------------------
+
+_MINIMAL_SCHEMATIC = """(kicad_sch
+  (version 20231120)
+  (generator "test")
+  (uuid "00000000-0000-0000-0000-000000000001")
+  (paper "A4")
+  (symbol
+    (lib_id "Device:R")
+    (at 100 100 0)
+    (uuid "00000000-0000-0000-0000-000000000002")
+    (property "Reference" "R1" (at 100 97 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "10k" (at 100 103 0) (effects (font (size 1.27 1.27))))
+    (property "Footprint" "Resistor_SMD:R_0402" (at 100 100 0) (effects (hide yes)))
+  )
+  (symbol
+    (lib_id "Device:C")
+    (at 120 100 0)
+    (uuid "00000000-0000-0000-0000-000000000003")
+    (property "Reference" "C1" (at 120 97 0) (effects (font (size 1.27 1.27))))
+    (property "Value" "100n" (at 120 103 0) (effects (font (size 1.27 1.27))))
+    (property "Footprint" "Capacitor_SMD:C_0402" (at 120 100 0) (effects (hide yes)))
+  )
+)
+"""
+
+# Minimal kicad-cli-shaped netlist matching _MINIMAL_SCHEMATIC (R1 + C1).
+_FAKE_EXPORTED_NETLIST = """(export (version "E")
+  (design (source "design.kicad_sch") (tool "Eeschema"))
+  (components
+    (comp (ref "R1") (value "10k") (footprint "Resistor_SMD:R_0402"))
+    (comp (ref "C1") (value "100n") (footprint "Capacitor_SMD:C_0402")))
+  (nets
+    (net (code "1") (name "/N1")
+      (node (ref "R1") (pin "1"))
+      (node (ref "C1") (pin "1")))))
+"""
+
+
+class TestNetlistByproductLocation:
+    """``Reconciler`` must not litter the user's project dir (#4795).
+
+    ``export_netlist`` defaults ``output_path`` to
+    ``<schematic dir>/<stem>-netlist.kicad_net`` and never deletes it, so
+    the bare calls in ``_build_net_adjacency`` and ``_assign_nets`` dropped
+    an unrequested netlist file beside the user's schematic on every sync.
+    Both sites consume the parsed ``Netlist`` object only, never the file.
+    """
+
+    @pytest.fixture
+    def schematic(self, tmp_path: Path) -> Path:
+        """A schematic in its own 'project' directory."""
+        proj = tmp_path / "project"
+        proj.mkdir()
+        sch = proj / "design.kicad_sch"
+        sch.write_text(_MINIMAL_SCHEMATIC)
+        return sch
+
+    @pytest.fixture
+    def fake_kicad_cli(self, monkeypatch) -> list[Path]:
+        """Force the kicad-cli export path with a stubbed subprocess.
+
+        The stub writes a real netlist file to whatever ``--output`` path it
+        is handed, exactly like kicad-cli does -- so the byproduct lands
+        wherever ``export_netlist`` decided it should, which is the behavior
+        under test.  Returns the list of captured output paths.
+        """
+        import subprocess as _subprocess
+
+        captured_outputs: list[Path] = []
+
+        monkeypatch.setattr(
+            "kicad_tools.operations.netlist.find_kicad_cli",
+            lambda: Path("/fake/kicad-cli"),
+        )
+
+        def fake_run(cmd, *args, **kwargs):
+            out = Path(cmd[cmd.index("--output") + 1])
+            captured_outputs.append(out)
+            out.write_text(_FAKE_EXPORTED_NETLIST)
+            return _subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr("kicad_tools.operations.netlist.subprocess.run", fake_run)
+        return captured_outputs
+
+    def _make_reconciler(self, schematic: Path) -> Reconciler:
+        """Create a Reconciler bound to ``schematic`` without file validation."""
+        reconciler = Reconciler.__new__(Reconciler)
+        reconciler._schematic_path = schematic
+        reconciler._pcb_path = schematic.with_suffix(".kicad_pcb")
+        return reconciler
+
+    def test_build_net_adjacency_leaves_no_byproduct(self, schematic, fake_kicad_cli):
+        """``_build_net_adjacency`` must not write beside the schematic."""
+        reconciler = self._make_reconciler(schematic)
+        before = {p.name for p in schematic.parent.iterdir()}
+
+        adjacency = reconciler._build_net_adjacency({"C1"})
+
+        assert fake_kicad_cli, "kicad-cli export path was never taken"
+        # The netlist was really consumed: C1 is new, R1 is placed.
+        assert adjacency == {"C1": {"R1"}}
+        stray = sorted(p.name for p in schematic.parent.glob("*-netlist.kicad_net"))
+        assert not stray, f"adjacency build left byproducts beside the schematic: {stray}"
+        assert {p.name for p in schematic.parent.iterdir()} == before
+
+    def test_build_net_adjacency_temp_export_is_cleaned_up(self, schematic, fake_kicad_cli):
+        """The temp directory is torn down before ``_build_net_adjacency`` returns."""
+        reconciler = self._make_reconciler(schematic)
+
+        reconciler._build_net_adjacency({"C1"})
+
+        assert fake_kicad_cli
+        for out in fake_kicad_cli:
+            assert out.parent != schematic.parent, f"export wrote into the project dir: {out}"
+            assert not out.exists(), f"temp netlist survived the call: {out}"
+            assert not out.parent.exists(), f"temp dir survived the call: {out.parent}"
+
+    def test_build_net_adjacency_still_swallows_failures(self, schematic, monkeypatch):
+        """Export failures still degrade to an empty adjacency map, not a raise."""
+        import kicad_tools.operations.netlist as netlist_mod
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("kicad-cli failed: synthetic")
+
+        monkeypatch.setattr(netlist_mod, "export_netlist", _boom)
+
+        reconciler = self._make_reconciler(schematic)
+        assert reconciler._build_net_adjacency({"C1"}) == {}
+
+    def test_assign_nets_leaves_no_byproduct(self, schematic, fake_kicad_cli):
+        """``_assign_nets`` must not write beside the schematic."""
+        reconciler = self._make_reconciler(schematic)
+        pcb = MagicMock()
+        before = {p.name for p in schematic.parent.iterdir()}
+
+        reconciler._assign_nets(pcb)
+
+        assert fake_kicad_cli, "kicad-cli export path was never taken"
+        # The netlist was really consumed (best-effort path swallows errors,
+        # so this assertion is what proves the call actually succeeded).
+        pcb.add_net.assert_called_once_with("/N1")
+        pcb.assign_nets_from_netlist.assert_called_once()
+        stray = sorted(p.name for p in schematic.parent.glob("*-netlist.kicad_net"))
+        assert not stray, f"net assignment left byproducts beside the schematic: {stray}"
+        assert {p.name for p in schematic.parent.iterdir()} == before
+
+    def test_assign_nets_temp_export_is_cleaned_up(self, schematic, fake_kicad_cli):
+        """The temp directory is torn down before ``_assign_nets`` returns."""
+        reconciler = self._make_reconciler(schematic)
+
+        reconciler._assign_nets(MagicMock())
+
+        assert fake_kicad_cli
+        for out in fake_kicad_cli:
+            assert out.parent != schematic.parent, f"export wrote into the project dir: {out}"
+            assert not out.exists(), f"temp netlist survived the call: {out}"
+            assert not out.parent.exists(), f"temp dir survived the call: {out.parent}"
+
+    def test_assign_nets_still_swallows_failures(self, schematic, monkeypatch):
+        """Net assignment stays best-effort when the export fails."""
+        import kicad_tools.operations.netlist as netlist_mod
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("kicad-cli failed: synthetic")
+
+        monkeypatch.setattr(netlist_mod, "export_netlist", _boom)
+
+        reconciler = self._make_reconciler(schematic)
+        pcb = MagicMock()
+
+        reconciler._assign_nets(pcb)  # must not raise
+
+        pcb.assign_nets_from_netlist.assert_not_called()


### PR DESCRIPTION
## Summary

Third and final installment of the `export_netlist` working-file litter class
(#4750 fixed the check path, #4763 fixed `PCB.import_from_schematic`). All nine
remaining **byproduct** call sites now route the kicad-cli netlist file through
a `tempfile.TemporaryDirectory()` instead of letting it default to
`<schematic dir>/<stem>-netlist.kicad_net` — where it was landing next to a
*user's* schematic, not a fixture, and was never deleted.

Closes #4795

## Call sites changed (9, all byproducts)

| File | Function | Netlist consumed as |
|---|---|---|
| `sync/reconciler.py` | `_build_net_adjacency` | in-memory adjacency map |
| `sync/reconciler.py` | `_assign_nets` | `pcb.assign_nets_from_netlist(netlist)` |
| `cli/sch_find_unconnected.py` | `_cross_check_netlist` | pin cross-check set |
| `cli/netlist_cmd.py` | `cmd_analyze` | `.summary()` + single-pin stats |
| `cli/netlist_cmd.py` | `cmd_list` | table/JSON net listing |
| `cli/netlist_cmd.py` | `cmd_show` | single-net detail lookup |
| `cli/netlist_cmd.py` | `cmd_check` | connectivity-issue detection |
| `cli/netlist_cmd.py` | `cmd_compare` (×2) | old/new diff — **both** project dirs stay clean |

The five `netlist_cmd.py` subcommands share a small module-private helper,
`_export_netlist_to_temp(schematic_path, prefix)`, whose docstring states why
`cmd_export` deliberately does not use it.

## Explicitly untouched

- `cli/netlist_cmd.py::cmd_export` — this is the one call site where the
  `*-netlist.kicad_net` file **is** the user-requested product. Its
  `export_netlist()` call is unchanged, and two tests pin that it still writes
  its file at the default location and at `-o`.
- `operations/netlist.py::export_netlist()` — no signature or default change;
  its docstring already prescribes exactly this caller-side pattern.
- The separate `cmd_export` "`-o` differs from default leaves both files"
  defect (kicad-format branch) — a different failure shape, left for its own
  follow-up as the issue directs.

## Behavior preserved

- `sch_find_unconnected` keeps `fallback=False` (load-bearing: the Python
  fallback walks the hierarchy correctly and would hide the very bug the
  cross-check exists to catch) and all three `except` clauses and messages.
- Both reconciler sites keep their best-effort `except Exception` swallowing —
  `_build_net_adjacency` still degrades to `{}`, `_assign_nets` still no-ops.
- `Reconciler._schematic_path` is `Path | None`; the new `Path(str(...))` keeps
  a `None` path degrading through the same `except` as before (and keeps mypy
  at the baseline).

## Tests

New `TestNetlistByproductLocation` classes (modeled on the #4750/#4763 classes
in `tests/test_pcb_sync_netlist.py` / `tests/test_pcb_import_from_schematic.py`)
in `tests/test_sync.py`, `tests/test_cli_sch.py`, `tests/test_cli_netlist.py`.
Each stubs `find_kicad_cli` + `subprocess.run` so the fake kicad-cli writes a
real netlist to whatever `--output` it is handed, then asserts:

- the schematic directory listing is unchanged (no new `*-netlist.kicad_net`),
- the export path is outside the project dir and the temp dir is torn down,
- the parsed netlist still reaches the consumer (adjacency map / `add_net` +
  `assign_nets_from_netlist` / JSON output / zero false cross-check findings),
- `cmd_compare` leaves **both** the old and new project dirs untouched and does
  not collide on temp filenames for same-stem schematics,
- `kct netlist export` still writes its product (default and `-o`).

One existing test (`test_apply_net_assignment_called_after_add`) asserted the
exact bare-call signature `export_netlist(sch_path)`; it now asserts the
schematic is still the first positional arg **and** that `output_path` points
outside the schematic's directory.

## Verification

- `uv run pytest tests/test_sync.py tests/test_cli_sch.py tests/test_cli_netlist.py tests/test_pcb_sync_netlist.py tests/test_pcb_import_from_schematic.py tests/test_sync_cli.py tests/test_build_sync_step.py` → 522 passed
- `uv run pytest tests/test_audit.py tests/test_netlist_sync_gate.py tests/test_pipeline_sync_step.py tests/test_board_05_drift_regression.py` → 202 passed
- `uv run ruff check .` / `uv run ruff format --check .` → clean
- `uv run python scripts/ci/check_mypy_baseline.py` → no new type errors (baseline untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
