### PR TITLE
fix(router): measure the Python pairwise HV search gate from per-net-class width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -648,6 +648,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The pure-Python pairwise (HV-isolation) search gate now measures from the
+  per-net-class copper width** (#4793) — the three Python search kernels added
+  by #4791 (`Router._cross_domain_trace_blocked`,
+  `Router._cross_domain_via_blocked` and the hot-loop bitmap widener
+  `Router._pairwise_expanded_blocked`) computed their widened radius
+  `ceil((half_mm + required) / res)` from the **global** `rules.trace_width / 2`
+  and `rules.via_diameter / 2`, even though the caller had already resolved a
+  per-net-class `scalar_radius`. On a board with a wide class (e.g. a 0.5 mm
+  `POWER`/HV class against a 0.2 mm global default) the search-time annulus was
+  therefore narrower than the net's real copper warrants, so the fallback A\*
+  accepted cells the (authoritative) post-route `route_pairwise_violation` gate
+  then rejected — no DRC escape, but exactly the search-proposes /
+  validation-rejects thrash #4791 exists to remove, burning the net's budget on
+  rip-up/retry or dropping it into negotiated mode instead of converging first
+  try. All three sites now resolve the routed net's name from
+  `state.id_to_name` and take the extent from `_get_trace_width_for_net` (or the
+  new `_get_via_size_for_net` sibling, wrapping the
+  `net_class.via_size if net_class else rules.via_diameter` idiom `route()`
+  already used inline), falling back to the global rules for nets with no class
+  or no name mapping. This brings the fallback into parity with the C++ backend,
+  which has always read the per-net `search_trace_half_width_mm_` /
+  `search_via_half_diam_mm_` extents `cpp_backend` pushes in via
+  `set_search_pair_widths` once per `route()`. Only reachable with a pairwise
+  voltage-map table installed **and** a non-default class width **and** the
+  pure-Python fallback in use (`--no-cpp-router`, or a worktree where the native
+  extension is not built); boards whose classes share the global width are
+  byte-identical. `tests/router/test_pairwise_python_search.py` pins the
+  class-width band (and that an equal-to-global class is a no-op), and
+  `tests/router/test_pairwise_cpp_parity.py` sweeps the whole band asserting
+  cell-for-cell Python↔C++ agreement.
+
 - **`kct netlist`, `kct sch unconnected` and `kct sync` no longer leave a
   netlist file beside the user's schematic** (#4795, third installment after
   #4750 and #4763) — `export_netlist()` defaults `output_path` to
@@ -676,6 +707,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the reason `RELEASING.md` gives: the tag must reference the commit as it
   landed on `main` (squash-merge gives it a different SHA), never a pre-merge
   `release/vX.Y.Z` branch commit.
+
 - **Multi-pin nets are no longer skipped outright on `--deterministic-budget`
   placement-feedback re-routes** (#4776) — `--deterministic-budget` sets
   `args.per_net_timeout = 0.0` as its "wall-clock cutoff disabled" sentinel, and

--- a/src/kicad_tools/router/pathfinder.py
+++ b/src/kicad_tools/router/pathfinder.py
@@ -1366,6 +1366,25 @@ class Router:
             return net_class.trace_width
         return self.rules.trace_width
 
+    def _get_via_size_for_net(self, net_name: str) -> float:
+        """Get the via diameter for a net based on its net class (Issue #4793).
+
+        Via sibling of :meth:`_get_trace_width_for_net`, wrapping the
+        ``net_class.via_size if net_class else rules.via_diameter`` idiom used
+        inline by :meth:`route` so callers that only hold a net *name* can
+        resolve the same per-class extent.
+
+        Args:
+            net_name: Name of the net
+
+        Returns:
+            Via diameter in mm
+        """
+        net_class = self._get_net_class(net_name)
+        if net_class is not None:
+            return net_class.via_size
+        return self.rules.via_diameter
+
     def _get_pad_metal_bounds(self, pad: Pad) -> tuple[int, int, int, int]:
         """Calculate the grid coordinate bounds of a pad's metal area.
 
@@ -1935,8 +1954,12 @@ class Router:
     #   (scalar disc is the scalar kernel's job; only the ring out to the
     #   widest pair is scanned), same per-pair radius arithmetic, same
     #   layer-scoped #4506 attach-zone waiver at the gap midpoint.
-    # * ``half_mm`` uses the global ``rules`` widths (the C++ default when
-    #   ``set_search_pair_widths`` has not supplied per-net extents).
+    # * ``half_mm`` is the ROUTED net's class trace width / via size (#4793),
+    #   resolved from ``state.id_to_name`` -- the Python equivalent of the
+    #   per-net extents ``cpp_backend`` pushes into the C++ kernels via
+    #   ``set_search_pair_widths`` once per ``route()`` call.  Nets with no
+    #   class (or an unmapped id) fall back to the global ``rules`` widths,
+    #   which is also the C++ default when the setter has never run.
     # * The diagonal-corner probe is NOT separately widened here: both
     #   endpoints of a diagonal step already consult the annulus via
     #   ``_is_trace_blocked``, and the ceil-rounded pair radius keeps the
@@ -1986,8 +2009,19 @@ class Router:
         state = self._pairwise_search_state(table)
         if state is None:
             return False
+        # Issue #4793: measure the widening from the ROUTED net's class trace
+        # width (the C++ kernels read ``search_trace_half_width_mm_``, which
+        # ``cpp_backend`` sets per net) -- the global default under-widens a
+        # wide class (e.g. POWER at 0.5 mm vs a 0.2 mm default).
+        own_name = state.id_to_name.get(net, "")
         return self._cross_domain_annulus_blocked(
-            gx, gy, layer, net, scalar_radius, self.rules.trace_width / 2.0, state
+            gx,
+            gy,
+            layer,
+            net,
+            scalar_radius,
+            self._get_trace_width_for_net(own_name) / 2.0,
+            state,
         )
 
     def _cross_domain_via_blocked(
@@ -2006,8 +2040,17 @@ class Router:
         state = self._pairwise_search_state(table)
         if state is None:
             return False
+        # Issue #4793: per-net-class via size, mirroring the C++
+        # ``search_via_half_diam_mm_`` extent.
+        own_name = state.id_to_name.get(net, "")
         return self._cross_domain_annulus_blocked(
-            gx, gy, layer, net, scalar_radius, self.rules.via_diameter / 2.0, state
+            gx,
+            gy,
+            layer,
+            net,
+            scalar_radius,
+            self._get_via_size_for_net(own_name) / 2.0,
+            state,
         )
 
     def _cross_domain_annulus_blocked(
@@ -2139,8 +2182,12 @@ class Router:
         from .pairwise_clearance import _norm_net_key
 
         res = self.grid.resolution
-        half_mm = self.rules.trace_width / 2.0
-        own_key = _norm_net_key(state.id_to_name.get(net, ""))
+        # Issue #4793: the dilation radius measures from the ROUTED net's
+        # class trace width, not the global default (same extent the C++
+        # bitmap-free kernels get from ``set_search_pair_widths``).
+        own_name = state.id_to_name.get(net, "")
+        half_mm = self._get_trace_width_for_net(own_name) / 2.0
+        own_key = _norm_net_key(own_name)
         net_ids_by_domain: dict[int, list[int]] = {}
         for net_id, domain in enumerate(net_to_domain):
             if domain >= 0:

--- a/tests/router/test_pairwise_cpp_parity.py
+++ b/tests/router/test_pairwise_cpp_parity.py
@@ -1367,3 +1367,115 @@ def test_layer_scoped_zone_converges_where_layer_agnostic_thrashes() -> None:
     assert blind_route is not None, "the pairwise-aware Python fallback should rescue the net"
     assert blind_violation is None
     assert "B_CU" in blind_layers
+
+
+# ---------------------------------------------------------------------------
+# Per-net-class search extents (Issue #4793): Python <-> C++ parity
+# ---------------------------------------------------------------------------
+#
+# The widened radius is measured from the ROUTED net's copper half-extent.  The
+# C++ kernels read ``search_trace_half_width_mm_`` / ``search_via_half_diam_mm_``
+# (pushed once per net by ``cpp_backend`` via ``set_search_pair_widths``); the
+# Python fallback resolves the same extent from the net's ``NetClassRouting``.
+# Before #4793 the Python side used the GLOBAL ``rules`` widths, so on a board
+# with a wide class the two backends disagreed over a 4-cell-deep band -- the
+# fallback under-blocked, proposed a path, and the post-route gate rejected it.
+# This fixture sweeps the whole band and pins cell-for-cell agreement.
+
+_WIDE_TRACE_WIDTH = 1.0  # vs the 0.2 mm global default
+_WIDE_VIA_SIZE = 1.2  # vs the 0.6 mm global default
+
+
+def _py_router_with_foreign_cell(dy: int, net_class_map):
+    """A Python Router on a 20x20 board with ONE foreign LV cell ``dy`` above.
+
+    Cell-exact mirror of the C++ fixtures' ``Grid3D.mark_blocked`` (there is no
+    public single-cell setter on ``RoutingGrid``; the search kernels read these
+    arrays directly).
+    """
+    from kicad_tools.router.layers import LayerStack
+    from kicad_tools.router.pathfinder import Router
+
+    rules = DesignRules(
+        trace_width=TRACE_WIDTH,
+        trace_clearance=DRU,
+        via_diameter=0.6,
+        via_clearance=DRU,
+        grid_resolution=0.1,
+    )
+    rules.pairwise_clearance = _table()
+    grid = RoutingGrid(width=20.0, height=20.0, rules=rules, layer_stack=LayerStack.two_layer())
+    grid._blocked[0, 100 + dy, 100] = True
+    grid._net[0, 100 + dy, 100] = LV_NET
+    router = Router(grid, rules, diagonal_routing=True, net_class_map=net_class_map)
+    router.set_net_name_to_id(dict(NET_NAMES))
+    return router
+
+
+def _cpp_pathfinder_with_foreign_cell(dy: int, half_trace_mm: float, half_via_mm: float):
+    grid = _cpp_grid()
+    _install_domains(grid)
+    from kicad_tools.router import router_cpp
+
+    pf = router_cpp.Pathfinder(grid, _cpp_rules(), True)
+    pf.set_search_pair_widths(half_trace_mm, half_via_mm)
+    grid.mark_blocked(100, 100 + dy, 0, LV_NET, False, False)
+    return pf
+
+
+# Trace: global half 0.10 -> r 17 cells; class half 0.50 -> r 21 cells.
+# Via:   global half 0.30 -> r 19 cells; class half 0.60 -> r 22 cells.
+# The sweep straddles every one of those thresholds.
+_PARITY_DISTANCES = tuple(range(15, 25))
+
+
+@requires_cpp
+@pytest.mark.parametrize(
+    ("net_class_map", "half_trace_mm", "half_via_mm"),
+    [
+        (None, TRACE_WIDTH / 2.0, 0.3),
+        (
+            {"/AC_LINE": NetClassRouting(name="HV", trace_width=_WIDE_TRACE_WIDTH, clearance=DRU)},
+            _WIDE_TRACE_WIDTH / 2.0,
+            0.3,
+        ),
+    ],
+    ids=["global-width", "wide-class-width"],
+)
+def test_trace_annulus_class_width_parity(net_class_map, half_trace_mm, half_via_mm) -> None:
+    """Python fallback and C++ agree cell-for-cell on the class-width band."""
+    verdicts = []
+    for dy in _PARITY_DISTANCES:
+        py = _py_router_with_foreign_cell(dy, net_class_map)
+        cpp = _cpp_pathfinder_with_foreign_cell(dy, half_trace_mm, half_via_mm)
+        py_blocked = py._cross_domain_trace_blocked(100, 100, 0, HV_NET, SCALAR_RADIUS)
+        cpp_blocked = cpp.cross_domain_trace_blocked(100, 100, 0, HV_NET, SCALAR_RADIUS)
+        assert py_blocked == cpp_blocked, f"backends disagree at dy={dy}"
+        verdicts.append(py_blocked)
+    # The sweep must actually straddle the boundary (otherwise agreement is
+    # vacuous -- e.g. every probe outside both radii).
+    assert True in verdicts and False in verdicts
+
+
+@requires_cpp
+def test_via_annulus_class_size_parity() -> None:
+    """Same parity for the via analogue (``via_size`` vs ``via_diameter``).
+
+    The C++ via kernel derives its own scalar radius and scans every layer;
+    the probes here sit far outside any scalar disc and the foreign cell is on
+    a single layer, so the two shapes are directly comparable.
+    """
+    wide = {
+        "/AC_LINE": NetClassRouting(
+            name="HV", trace_width=TRACE_WIDTH, clearance=DRU, via_size=_WIDE_VIA_SIZE
+        )
+    }
+    verdicts = []
+    for dy in _PARITY_DISTANCES:
+        py = _py_router_with_foreign_cell(dy, wide)
+        cpp = _cpp_pathfinder_with_foreign_cell(dy, TRACE_WIDTH / 2.0, _WIDE_VIA_SIZE / 2.0)
+        py_blocked = py._cross_domain_via_blocked(100, 100, 0, HV_NET, SCALAR_RADIUS)
+        cpp_blocked = cpp.cross_domain_via_blocked(100, 100, HV_NET)
+        assert py_blocked == cpp_blocked, f"backends disagree at dy={dy}"
+        verdicts.append(py_blocked)
+    assert True in verdicts and False in verdicts

--- a/tests/router/test_pairwise_python_search.py
+++ b/tests/router/test_pairwise_python_search.py
@@ -29,6 +29,8 @@ from __future__ import annotations
 
 import math
 
+import numpy as np
+
 from kicad_tools.router.grid import RoutingGrid
 from kicad_tools.router.layers import Layer, LayerStack
 from kicad_tools.router.pairwise_clearance import (
@@ -74,6 +76,7 @@ def _router_with_lv_wall(
     wall_net_name: str = "LV",
     wall_layers: tuple[Layer, ...] = (Layer.F_CU,),
     name_map: dict[str, int] | None = None,
+    net_class_map: dict[str, NetClassRouting] | None = None,
 ) -> tuple[Router, RoutingGrid]:
     """A 30x20 board with a 6 x 0.6 mm foreign wall centred at (15, 10)."""
     rules = _rules(with_table)
@@ -90,7 +93,7 @@ def _router_with_lv_wall(
                 layer=layer,
             )
         )
-    router = Router(grid, rules, diagonal_routing=True)
+    router = Router(grid, rules, diagonal_routing=True, net_class_map=net_class_map)
     router.set_net_name_to_id(dict(NET_NAMES) if name_map is None else name_map)
     return router, grid
 
@@ -267,6 +270,119 @@ def test_bitmap_attach_zone_clears_pairwise_contribution_layer_scoped() -> None:
     gx, gy = _grid_pos(grid, 15.0, 9.0)  # inside the zone bbox
     assert bool(extra[0, gy, gx]) is False  # waived on the licensed layer
     assert bool(extra[1, gy, gx]) is True  # NOT waived on B.Cu
+
+
+# ---------------------------------------------------------------------------
+# Per-net-class copper extents (Issue #4793)
+# ---------------------------------------------------------------------------
+#
+# The widened radius is measured from the ROUTED net's own copper half-extent:
+# ``pair_r = ceil((half_mm + required) / res)``.  Taking ``half_mm`` from the
+# global ``rules`` under-widens a wide class, so the Python search proposes
+# cells the (authoritative) post-route gate then rejects -- rip-up/retry churn
+# on exactly the HV boards the search-time gate exists to converge.  The C++
+# kernels have always measured from the per-net extents ``cpp_backend`` pushes
+# in via ``set_search_pair_widths``; these fixtures pin the Python mirror.
+#
+# Geometry (0.1 mm cells, HV<->LV requirement 1.6 mm, wall blocked out to
+# y = 9.4 once its DRU halo is counted):
+#
+#   trace, global 0.2 mm width -> pair_r = ceil((0.10 + 1.6)/0.1) = 17 cells
+#   trace, class  1.0 mm width -> pair_r = ceil((0.50 + 1.6)/0.1) = 21 cells
+#   via,   global 0.6 mm diam  -> pair_r = ceil((0.30 + 1.6)/0.1) = 19 cells
+#   via,   class  1.2 mm diam  -> pair_r = ceil((0.60 + 1.6)/0.1) = 22 cells
+#
+# so y = 7.5 (19 cells out) and y = 7.3 (21 cells out) sit in the band that
+# only the class-width radius reaches.
+
+WIDE_TRACE_WIDTH = 1.0  # 5x the 0.2 mm global default
+WIDE_VIA_SIZE = 1.2  # 2x the 0.6 mm global default
+_WIDE_TRACE_PROBE_Y = 7.5  # 19 cells: inside class-r 21, outside global-r 17
+_WIDE_VIA_PROBE_Y = 7.3  # 21 cells: inside class-r 22, outside global-r 19
+
+
+def _wide_class() -> dict[str, NetClassRouting]:
+    return {
+        "HV": NetClassRouting(
+            name="HV",
+            trace_width=WIDE_TRACE_WIDTH,
+            clearance=DRU,
+            via_size=WIDE_VIA_SIZE,
+        )
+    }
+
+
+def _default_width_class() -> dict[str, NetClassRouting]:
+    """A class that merely restates the global widths (must be a no-op)."""
+    return {"HV": NetClassRouting(name="HV", trace_width=TRACE_WIDTH, clearance=DRU, via_size=0.6)}
+
+
+def test_trace_annulus_uses_net_class_trace_width() -> None:
+    """A wide-class HV net blocks a cell the global width would let through."""
+    global_router, grid = _router_with_lv_wall()
+    gx, gy = _grid_pos(grid, 15.0, _WIDE_TRACE_PROBE_Y)
+    assert global_router._cross_domain_trace_blocked(gx, gy, 0, HV_NET, 3) is False
+
+    wide_router, _grid = _router_with_lv_wall(net_class_map=_wide_class())
+    assert wide_router._cross_domain_trace_blocked(gx, gy, 0, HV_NET, 3) is True
+
+
+def test_via_annulus_uses_net_class_via_size() -> None:
+    """Same defect, via analogue: ``via_size`` overrides ``via_diameter``."""
+    global_router, grid = _router_with_lv_wall()
+    gx, gy = _grid_pos(grid, 15.0, _WIDE_VIA_PROBE_Y)
+    assert global_router._cross_domain_via_blocked(gx, gy, 0, HV_NET, 3) is False
+
+    wide_router, _grid = _router_with_lv_wall(net_class_map=_wide_class())
+    assert wide_router._cross_domain_via_blocked(gx, gy, 0, HV_NET, 3) is True
+
+
+def test_bitmap_uses_net_class_trace_width() -> None:
+    """The hot-loop dilation bitmap widens by the class width too."""
+    global_router, grid = _router_with_lv_wall()
+    gx, gy = _grid_pos(grid, 15.0, _WIDE_TRACE_PROBE_Y)
+    global_extra = global_router._pairwise_expanded_blocked(HV_NET, 3)
+    assert global_extra is not None
+    assert bool(global_extra[0, gy, gx]) is False
+
+    wide_router, _grid = _router_with_lv_wall(net_class_map=_wide_class())
+    wide_extra = wide_router._pairwise_expanded_blocked(HV_NET, 3)
+    assert wide_extra is not None
+    assert bool(wide_extra[0, gy, gx]) is True
+
+
+def test_class_width_equal_to_global_is_a_no_op() -> None:
+    """No behaviour change when the class merely restates the global widths."""
+    plain_router, grid = _router_with_lv_wall()
+    same_router, _grid = _router_with_lv_wall(net_class_map=_default_width_class())
+    for y in (7.3, 7.5, 7.7, 7.9, 9.0):
+        gx, gy = _grid_pos(grid, 15.0, y)
+        assert plain_router._cross_domain_trace_blocked(
+            gx, gy, 0, HV_NET, 3
+        ) == same_router._cross_domain_trace_blocked(gx, gy, 0, HV_NET, 3)
+        assert plain_router._cross_domain_via_blocked(
+            gx, gy, 0, HV_NET, 3
+        ) == same_router._cross_domain_via_blocked(gx, gy, 0, HV_NET, 3)
+
+    plain_extra = plain_router._pairwise_expanded_blocked(HV_NET, 3)
+    same_extra = same_router._pairwise_expanded_blocked(HV_NET, 3)
+    assert plain_extra is not None and same_extra is not None
+    assert bool(np.array_equal(plain_extra, same_extra))
+
+
+def test_unmapped_net_id_falls_back_to_global_width() -> None:
+    """An id with no name in the projection keeps the pre-#4793 extent.
+
+    ``state.id_to_name`` is the only bridge from net *id* to the class map;
+    when it has no entry the resolver must degrade to ``rules.trace_width``
+    (the same default the C++ kernels use before ``set_search_pair_widths``).
+    """
+    router, grid = _router_with_lv_wall(net_class_map=_wide_class(), name_map=dict(NET_NAMES))
+    # HV_TAP is in the projection but carries no net class -> global width.
+    gx, gy = _grid_pos(grid, 15.0, _WIDE_TRACE_PROBE_Y)
+    assert router._cross_domain_trace_blocked(gx, gy, 0, HV_TAP_NET, 3) is False
+    near = _grid_pos(grid, 15.0, 7.9)  # 15 cells: inside the global 17
+    assert router._cross_domain_trace_blocked(*near, 0, HV_TAP_NET, 3) is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #4793

## Problem

The three pure-Python pairwise (HV-isolation) search kernels added by #4791 each
receive a `net: int` and a caller-resolved, **per-net-class-aware**
`scalar_radius` (grid cells), but then recomputed `half_mm` (mm) from the
**global** design rules:

| Site | Was | Now |
|---|---|---|
| `Router._cross_domain_trace_blocked` | `self.rules.trace_width / 2.0` | `self._get_trace_width_for_net(own_name) / 2.0` |
| `Router._cross_domain_via_blocked` | `self.rules.via_diameter / 2.0` | `self._get_via_size_for_net(own_name) / 2.0` |
| `Router._pairwise_expanded_blocked` | `half_mm = self.rules.trace_width / 2.0` | resolved from the class, `own_name` hoisted above `own_key` |

Since the widened radius is `ceil((half_mm + required) / res)`, a wide class
(e.g. a 0.5 mm HV/POWER class against a 0.2 mm global default) got an annulus
**narrower** than its real copper warrants. The post-route
`route_pairwise_violation` gate stays authoritative, so this is not a DRC
escape — but it reproduces exactly the failure mode #4791 was fixing: the search
proposes a path, validation rejects it, and the net burns budget on rip-up/retry
or falls into negotiated mode instead of converging first try.

## Fix

All three sites resolve the routed net's name from `state.id_to_name` (already
available at each site) and take the copper extent from the existing
`Router._get_trace_width_for_net`, or from a new `_get_via_size_for_net` sibling
that wraps the `net_class.via_size if net_class else rules.via_diameter` idiom
`route()` already used inline. Nets with no class — or an id absent from the
projection — keep the global rules extent, which is also the C++ default before
`set_search_pair_widths` runs.

**Python-only parity fix.** The C++ backend is the reference and is unchanged:
`cpp_backend` already pushes the per-net `search_trace_half_width_mm_` /
`search_via_half_diam_mm_` extents via `set_search_pair_widths` once per
`route()`, and `pathfinder.cpp` reads them in all three kernel families. Only
the fallback was measuring from the global default. The stale mirror-note in
`pathfinder.py` that documented the old behaviour is updated.

## Blast radius

Reachable only when a pairwise/voltage-map table is installed **and** the net's
class trace/via width differs from the global default **and** the pure-Python
fallback is in use (`--no-cpp-router`, or a worktree without the native
extension). Boards where every class shares the global width are byte-identical
— pinned by a dedicated no-op test.

## Verification

- `uv run kct build-native` in the worktree first (C++ backend available, so the
  parity tests actually execute rather than skip).
- `uv run pytest tests/router/test_pairwise_python_search.py tests/router/test_pairwise_cpp_parity.py` — **81 passed**.
- New coverage:
  - `test_pairwise_python_search.py` — trace, via and bitmap probes in the band
    only the class width reaches (y = 7.5 → 19 cells: inside class-r 21, outside
    global-r 17; y = 7.3 → 21 cells: inside class via-r 22, outside global
    via-r 19); a class that merely restates the global widths is asserted to be
    an exact no-op (including array-equality on the bitmap); an unmapped net id
    degrades to the global extent.
  - `test_pairwise_cpp_parity.py` — sweeps foreign copper at 15–24 cells,
    asserting cell-for-cell Python↔C++ agreement in **both** the global-width
    and wide-class configurations (with a non-vacuity guard that the sweep
    actually straddles the boundary), plus the via analogue.
- **Regression validity**: reverse-applying the `pathfinder.py` diff turns the
  suite red — 5 failed (3 Python-side, `test_trace_annulus_class_width_parity[wide-class-width]`, `test_via_annulus_class_size_parity`), 57 passed.
- `ruff check` / `ruff format --check` clean on all touched files.
- `scripts/ci/check_mypy_baseline.py` (after `rm -rf .mypy_cache`):
  `1470 error(s), all within the baseline (1472 allowed)`. No baseline edits —
  the "2 no longer occur" warning is the known env-dependent nanobind
  import-error pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
