### PR TITLE
docs: re-anchor rotted .py:NNN citations in board scripts + add a Python citation guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -702,6 +702,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unchanged across each call — plus a guard that `kct netlist export` still
   writes its file at both the default and `-o` locations.
 
+- **Rotted `.py:NNN` citations in board scripts and `match_group_length.py`**
+  (#4796) — every cross-file line-number citation in the nine `boards/**`
+  generator scripts and in `src/kicad_tools/router/match_group_length.py` is
+  re-anchored on a symbol plus a bare file path, the convention #4774
+  established for markdown. Each sampled citation was stale: five board scripts
+  pointed at `boards/03-usb-joystick/generate_design.py:838` for a
+  `route_success` fast-fail gate that has since moved to 849, and
+  `escape.py:3303-3304` (cited as "QFN escape segments") now lands in
+  `_group_pads_by_ring`, unrelated ring-distance code — that one was re-derived
+  from scratch to `EscapeRouter._create_fine_pitch_row_escapes`. Every
+  replacement symbol was AST/grep-verified to exist before landing. A new
+  `tests/test_py_citation_rot.py` guards the class from regrowing: a fixed
+  ten-file allowlist (deliberately not a glob) is scanned for `.py:NNN` in
+  comments, docstrings and string literals, and a `CITED_SYMBOLS` table checks
+  each anchor in both directions so a rename on either side goes red. ~85
+  further citations across 29 other `src/` files (`router/core.py`,
+  `cli/route_cmd.py`, `validate/**`, …) are out of scope here and remain a
+  follow-up; comments and docstrings only, no behavior change.
+
 - **`CLAUDE.md`'s `## Releasing` section no longer ends mid-sentence** (#4797) —
   the dangling "(the tag must point at a commit that" clause is completed with
   the reason `RELEASING.md` gives: the tag must reference the commit as it

--- a/boards/00-simple-led/generate_design.py
+++ b/boards/00-simple-led/generate_design.py
@@ -970,7 +970,8 @@ def main() -> int:
         route_success = route_pcb(pcb_path, routed_path)
 
         # Step 5.5: route_success fast-fail gate (#4066, mirrors board 03's
-        # gate at boards/03-usb-joystick/generate_design.py:838).  ``route_pcb``
+        # ``route_success`` gate after ``route_pcb`` in
+        # boards/03-usb-joystick/generate_design.py).  ``route_pcb``
         # returns ``False`` when at least one trace-routable SIGNAL net failed
         # to land (``nets_routed`` < the pour-net-excluded ``total_nets``; see
         # the count accounting in ``route_pcb``).  If we fall through, the

--- a/boards/01-voltage-divider/generate_design.py
+++ b/boards/01-voltage-divider/generate_design.py
@@ -803,7 +803,8 @@ def main() -> int:
         route_success = route_pcb(pcb_path, routed_path)
 
         # Step 5.5: route_success fast-fail gate (#4066, mirrors board 03's
-        # gate at boards/03-usb-joystick/generate_design.py:838).  route_pcb
+        # ``route_success`` gate after ``route_pcb`` in
+        # boards/03-usb-joystick/generate_design.py).  route_pcb
         # runs under a wall-clock ``--timeout`` SAFETY backstop layered above
         # the load-independent per-net ``--deterministic-budget`` iteration
         # cap, so on a loaded machine that outer deadline can fire before every

--- a/boards/02-charlieplex-led/generate_design.py
+++ b/boards/02-charlieplex-led/generate_design.py
@@ -798,7 +798,8 @@ def main() -> int:
         route_success = route_pcb(pcb_path, routed_path)
 
         # Step 5.5: route_success fast-fail gate (#4066, mirrors board 03's
-        # gate at boards/03-usb-joystick/generate_design.py:838).  route_pcb
+        # ``route_success`` gate after ``route_pcb`` in
+        # boards/03-usb-joystick/generate_design.py).  route_pcb
         # runs under a wall-clock ``--timeout`` SAFETY backstop layered above
         # the load-independent per-net ``--deterministic-budget`` iteration
         # cap, so on a loaded machine that outer deadline can fire before every

--- a/boards/03-usb-joystick/generate_design.py
+++ b/boards/03-usb-joystick/generate_design.py
@@ -233,7 +233,7 @@ def fill_zones_in_routed_pcb(routed_path: Path) -> int:
     copper is computed by KiCad's fill engine -- without this step the
     routed PCB ships with empty zones, and DRC reports the power-net pads
     as stranded.  Mirrors board-05's ``fill_zones_in_routed_pcb`` at
-    ``boards/05-bldc-motor-controller/design.py:2233``.
+    ``boards/05-bldc-motor-controller/design.py``.
 
     Returns the number of zones in the routed PCB after fill.
     """

--- a/boards/03-usb-joystick/route_demo.py
+++ b/boards/03-usb-joystick/route_demo.py
@@ -8,9 +8,9 @@ skipped, ``route_all_with_diffpairs(enabled=True)`` -- which had
 drifted from the canonical recipe in ``generate_design.py:route_pcb()``
 that produced the committed routed PCB.  The drift caused
 ``kct build --step route`` (which invokes ``route_demo.py``, see
-``src/kicad_tools/cli/build_cmd.py:1189``) to produce strictly worse
-output than the committed artifact even when nothing in the router
-itself had regressed.
+``_run_step_route`` in ``src/kicad_tools/cli/build_cmd.py``) to produce
+strictly worse output than the committed artifact even when nothing in
+the router itself had regressed.
 
 Fix (Option 1a from the issue):
 ``route_demo.py`` now DELEGATES to ``generate_design.py:route_pcb()``
@@ -124,7 +124,8 @@ def main():
 
     Issue #3308: delegate to ``generate_design.py:route_pcb()`` so the
     demo cannot drift from the end-to-end recipe.  ``kct build --step
-    route`` runs this script (per ``src/kicad_tools/cli/build_cmd.py:1189``);
+    route`` runs this script (per ``_run_step_route`` in
+    ``src/kicad_tools/cli/build_cmd.py``);
     using the same code path that produced the committed routed PCB
     guarantees a fresh ``kct build`` reproduces the shipped artifact.
     """

--- a/boards/04-stm32-devboard/generate_design.py
+++ b/boards/04-stm32-devboard/generate_design.py
@@ -139,7 +139,9 @@ def create_stm32_schematic(output_dir: Path) -> Path:
     # up, for GND) to its rail endpoint so the symbol pin meets a real wire
     # endpoint (silences ``pin_not_connected``) AND so the symbol's global
     # net publication unifies with the rail's labelled net.  Mirrors sister
-    # board 05's fix (PR #3004 / design.py:108-216); see issue #3149.
+    # board 05's fix (PR #3004 -- the ``add_power`` / ``PWR_FLAG`` rail
+    # bridging in ``create_bldc_controller``,
+    # boards/05-bldc-motor-controller/design.py); see issue #3149.
     #
     # +5V: the +5V rail has no genuine ``power_output`` source -- the only
     # consumer is the AMS1117 VI pin, which is a ``power_input``.  Without
@@ -2024,7 +2026,8 @@ def main() -> int:
         route_success = route_pcb(pcb_path, routed_path)
 
         # Step 5.5a: route_success fast-fail gate (#4066, mirrors board 03's
-        # gate at boards/03-usb-joystick/generate_design.py:838).  route_pcb
+        # ``route_success`` gate after ``route_pcb`` in
+        # boards/03-usb-joystick/generate_design.py).  route_pcb
         # runs under a wall-clock ``--timeout`` SAFETY backstop layered above
         # the load-independent per-net ``--deterministic-budget`` iteration
         # cap, so on a loaded machine that outer deadline can fire before every

--- a/boards/05-bldc-motor-controller/design.py
+++ b/boards/05-bldc-motor-controller/design.py
@@ -420,8 +420,8 @@ def create_bldc_controller(output_dir: Path) -> Path:
     # schematic) reports the parts the PCB actually places. Strings must
     # mirror the PCB-side hard-codes in ``generate_d2pak`` /
     # ``generate_cap_0805`` / ``generate_inductor_smd`` /
-    # ``generate_diode_sma`` (see design.py:1433, 1758, 1851, 1870) so the
-    # schematic↔PCB drift checker stays clean. Without these, the
+    # ``generate_diode_sma`` (all four nested in ``create_bldc_pcb`` in this
+    # file) so the schematic↔PCB drift checker stays clean. Without these, the
     # manufacturing preflight ``bom_fields`` check fails with "missing
     # footprint" warnings on U1/C3/C4/L1/D2 (issue #3211).
     cascade.buck.regulator.footprint = "Package_TO_SOT_SMD:TO-263-5_TabPin3"
@@ -3299,7 +3299,7 @@ def emit_phase1_diagnostics(routed_path: Path) -> None:
 
     # Board-05's effective routing clearance is 0.15mm (the value the router
     # enforces and warns about: "grid 0.1mm > clearance/2 (0.075mm)", see
-    # route_pcb() around design.py:3040 and io.py's validate_grid_resolution
+    # ``route_pcb`` in this file and io.py's ``validate_grid_resolution``
     # warning).  This is the board's DesignRules clearance, tighter than the
     # jlcpcb-tier1 mfr floor (0.127mm) does not govern here -- use the value the
     # route actually applied so the report describes the real grid.  The grid

--- a/boards/06-diffpair-test/generate_design.py
+++ b/boards/06-diffpair-test/generate_design.py
@@ -2357,11 +2357,11 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
     #
     #   1. ``DesignRules`` now declares ``min_trace_width=0.10`` and the
     #      escape router already uses that width for fine-pitch BGA-49 /
-    #      QFN escape segments (escape.py:3303-3304, Issue #1778), so the
-    #      escape geometry succeeds even when the corridor trace is
-    #      ~0.39 mm wide.
+    #      QFN escape segments (``EscapeRouter._create_fine_pitch_row_escapes``
+    #      in escape.py, Issue #1778), so the escape geometry succeeds
+    #      even when the corridor trace is ~0.39 mm wide.
     #
-    #   2. ``DesignRules.get_neck_down_width`` (rules.py:498) now accepts
+    #   2. ``DesignRules.get_neck_down_width`` (rules.py) now accepts
     #      a ``base_width`` parameter, and the pathfinder passes the
     #      per-net-class ``trace_width`` (the impedance-resolved width)
     #      as the corridor base.  Segments taper from the impedance
@@ -2720,7 +2720,8 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
         # ``None`` disables the deadline entirely.  This mirrors the CLI, which
         # sets args.per_net_timeout = 0.0 but forwards
         # ``getattr(args, "per_net_timeout", None) or None`` -> None
-        # (route_cmd.py:3272 etc.).
+        # (the ``getattr(args, "per_net_timeout", None) or None`` forwarding
+        # in route_cmd.py).
         #
         # ``timeout=None`` (#4536): this stage previously carried a
         # ``timeout=360.0`` wall-clock SAFETY BACKSTOP with a comment claiming
@@ -2863,8 +2864,11 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
     # candidates and nudges segments perpendicular to repair them.  Without
     # this call the post-route ``kct check`` is the first thing that sees
     # the violations -- by which point the routed PCB is already serialised.
-    # See also the equivalent invocations in ``kct route`` (route_cmd.py:1985
-    # and 2511) and ``kct optimize`` (route_cmd.py:5184).
+    # See also the equivalent invocations in
+    # ``src/kicad_tools/cli/route_cmd.py``: the escalation helpers
+    # ``route_with_layer_escalation`` / ``route_with_rule_relaxation`` /
+    # ``route_with_combined_escalation``, plus the post-optimization DRC
+    # nudge pass in ``_main_impl``.
     from kicad_tools.router.drc_nudge import drc_verify_and_nudge
 
     print("\n6. DRC verify-and-nudge pass...")
@@ -3521,8 +3525,9 @@ def main() -> int:
             routed_path = output_dir / "diffpair_test_routed.kicad_pcb"
             route_success = route_pcb(pcb_path, routed_path)
 
-            # route_success fast-fail gate (#4066, mirrors board 03's gate at
-            # boards/03-usb-joystick/generate_design.py:838).  route_pcb runs
+            # route_success fast-fail gate (#4066, mirrors board 03's
+            # ``route_success`` gate after ``route_pcb`` in
+            # boards/03-usb-joystick/generate_design.py).  route_pcb runs
             # under a wall-clock ``--timeout`` SAFETY backstop layered above
             # the load-independent per-net ``--deterministic-budget`` iteration
             # cap, so on a loaded machine that outer deadline can fire before

--- a/boards/07-matchgroup-test/generate_design.py
+++ b/boards/07-matchgroup-test/generate_design.py
@@ -1280,7 +1280,8 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
       (``scripts/ci/check_matchgroup_coverage.py``) re-invokes this
       script with ``--step route --seed 42`` and asserts a byte-stable
       re-route across PRs.  ``kct route`` honours ``--seed`` by
-      seeding the global ``random`` module (route_cmd.py:5296-5299).
+      seeding the global ``random`` module (the ``random.seed(args.seed)``
+      call in ``route_cmd.py``).
       This is the issue's stated HARD LIMIT and is preserved.
     - ``--timeout 600``: outer wall-clock budget; per-net timeout
       defaults to 30 s.  600 s gives the pure-Python fallback path on
@@ -1407,7 +1408,8 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
     skip_nets = list(POUR_NETS)
 
     # Emit the JSON sidecar BEFORE invoking the subprocess.  The CI
-    # gate (scripts/ci/check_matchgroup_coverage.py:223-235) requires
+    # gate (``find_net_class_map_sidecar`` in
+    # scripts/ci/check_matchgroup_coverage.py) requires
     # the sidecar to exist on disk after the route step completes,
     # even when ``kct route`` exits non-zero (partial routing).  The
     # sidecar is the single source of truth for the group / diff-pair
@@ -1440,11 +1442,12 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
     # Issue #3012 (CLOSED via PR #3022, 2026-05-18): added the
     # ``min_spacing_cells`` floor in ``CoupledPathfinder`` so coupled
     # routing now consults
-    # ``net_class.effective_intra_pair_clearance()`` (see
-    # ``src/kicad_tools/router/diffpair_routing.py:700-704, :769-774,
-    # :828-830``).  Prior to PR #3022, ``--differential-pairs`` on
-    # board 07 produced ~459 ``diffpair_clearance_intra`` violations
-    # because both centerlines were laid at ``pair.rules.spacing``
+    # ``net_class.effective_intra_pair_clearance()`` (see the
+    # ``min_spacing_cells`` handling in
+    # ``src/kicad_tools/router/diffpair_routing.py``).  Prior to PR
+    # #3022, ``--differential-pairs`` on board 07 produced ~459
+    # ``diffpair_clearance_intra`` violations because both
+    # centerlines were laid at ``pair.rules.spacing``
     # without consulting the per-pair intra-clearance override.
     #
     # Re-enable attempt (refresh tracker #3295, 2026-06-07):
@@ -1457,7 +1460,8 @@ def route_pcb(input_path: Path, output_path: Path) -> bool:
     #
     #   - With ``--differential-pairs`` added to the command line,
     #     the ``route_all_with_diffpairs`` pre-pass
-    #     (route_cmd.py:7253-7295) enters the ``CoupledPathfinder``
+    #     (``Autorouter.route_all_with_diffpairs``, invoked from
+    #     ``_main_impl`` in route_cmd.py) enters the ``CoupledPathfinder``
     #     loop and pegs CPU at 99.7% for >40 minutes without emitting
     #     any per-pair progress (no "Routing pair ..." lines, no
     #     "coupled pathfinder" diagnostics).  The ``--timeout 600``

--- a/src/kicad_tools/router/match_group_length.py
+++ b/src/kicad_tools/router/match_group_length.py
@@ -26,13 +26,13 @@ Design notes
   paths that legitimately use match groups.  Phase 1B keeps the legacy
   :func:`~kicad_tools.router.length.create_match_group`,
   :meth:`~kicad_tools.router.core.Autorouter.add_match_group`, and
-  ``tune_match_group`` (``router/optimizer/serpentine.py:438``) code paths
+  ``tune_match_group`` (``router/optimizer/serpentine.py``) code paths
   untouched.
 
 * **Reuse, do not duplicate.**  The single source of truth for
   segment-length summation is
   :meth:`~kicad_tools.router.length.LengthTracker.calculate_route_length`
-  at ``length.py:138-153``.  The single source of truth for combined
+  in ``length.py``.  The single source of truth for combined
   segment + via length on a router-internal Route is
   :class:`DiffPairLengthTracker._measure_route`; this module reuses it
   via the private indirection :meth:`MatchGroupTracker._measure_route_total`
@@ -45,7 +45,7 @@ Design notes
 
 * **PCB-side measurement primitive delegates** to
   :meth:`DiffPairLengthTracker.measure_net_from_pcb` (the Phase 2.5c
-  sister primitive, ``diffpair_length.py:308``).  The math is genuinely
+  sister primitive in ``diffpair_length.py``).  The math is genuinely
   net-scoped (sum of segments + drilled via length for one net id),
   identical whether the net belongs to a diff pair or to an N-trace
   match group -- duplicating the body would re-introduce the exact
@@ -68,7 +68,7 @@ Design notes
   is keyed on this string (not on a tuple of net names like the
   diff-pair tracker), mirroring the existing
   :attr:`~kicad_tools.router.length.LengthTracker.match_groups`
-  ``dict[str, list[int]]`` keying at ``length.py:94``.
+  ``dict[str, list[int]]`` keying in ``length.py``.
 
 * **Reference policy.**  :meth:`get_reference_length` implements the
   Phase 1A ``length_match_reference`` semantic:
@@ -109,7 +109,7 @@ if TYPE_CHECKING:
 
 
 # =============================================================================
-# Source provenance enum (mirrors DetectionSource at diffpair_detection.py:49)
+# Source provenance enum (mirrors DetectionSource in diffpair_detection.py)
 # =============================================================================
 
 
@@ -117,7 +117,7 @@ class MatchGroupSource(Enum):
     """Where a match group came from in the Phase 1C layered detector.
 
     Mirrors :class:`~kicad_tools.router.diffpair_detection.DetectionSource`
-    at ``router/diffpair_detection.py:49-54``.  The member names align
+    in ``router/diffpair_detection.py``.  The member names align
     byte-for-byte with the diff-pair source enum for cross-detector
     consistency (``SUFFIX``, not ``SUFFIX_INFERRED``).
 
@@ -260,7 +260,7 @@ class MatchGroupTracker:
               and rebuild the name-keyed skew cache from scratch.
             * The implementation reuses
               :meth:`LengthTracker.calculate_route_length`
-              (``length.py:138-153``) as the single source of truth for
+              (in ``length.py``) as the single source of truth for
               segment summation -- no segment math lives in this module.
         """
         # Collect the set of member net ids cheaply so non-member routes
@@ -346,10 +346,11 @@ class MatchGroupTracker:
         """Return the geometric length of a route in mm, including via drill.
 
         Delegates to :meth:`LengthTracker.calculate_route_length` for the
-        segment portion (single source of truth -- see ``length.py:138-153``)
+        segment portion (single source of truth -- see
+        ``LengthTracker.calculate_route_length`` in ``length.py``)
         and to :meth:`DiffPairLengthTracker._via_length` for the per-via
         drilled-length policy (the Phase 3H formula at
-        ``diffpair_length.py:190-223``).
+        ``DiffPairLengthTracker._via_length`` in ``diffpair_length.py``).
 
         Keeping the math in the diff-pair tracker (rather than duplicating
         it here) preserves single source of truth: a future change to the
@@ -376,7 +377,7 @@ class MatchGroupTracker:
         # Via portion.  When the caller did not supply board_thickness_mm
         # (or the stack has fewer than 2 layers) we cannot compute a
         # drilled length and document that vias contribute 0.0.  Mirrors
-        # DiffPairLengthTracker._measure_route at diffpair_length.py:183.
+        # DiffPairLengthTracker._measure_route in diffpair_length.py.
         if board_thickness_mm is None or num_copper_layers <= 1:
             return total
 
@@ -442,7 +443,7 @@ class MatchGroupTracker:
 
         - ``group.reference_net_id is None`` -> the longest routed length
           among the group's members (matches the legacy ``tune_match_group``
-          longest-as-target semantics at ``serpentine.py:438``).  Returns
+          longest-as-target semantics in ``serpentine.py``).  Returns
           ``None`` when no members are routed.
         - ``group.reference_net_id`` is set -> the recorded length of that
           specific net (the "pace-car" semantic).  Returns ``None`` when
@@ -494,7 +495,7 @@ class MatchGroupTracker:
 
         Delegates byte-for-byte to
         :meth:`DiffPairLengthTracker.measure_net_from_pcb`
-        (``diffpair_length.py:308``).  The math is genuinely net-scoped
+        (in ``diffpair_length.py``).  The math is genuinely net-scoped
         (sum of segments + drilled via length for one net id) and is
         identical whether the net belongs to a differential pair or to an
         N-trace match group -- duplicating the body would re-introduce

--- a/tests/test_py_citation_rot.py
+++ b/tests/test_py_citation_rot.py
@@ -1,0 +1,366 @@
+"""Line-citation / symbol-anchor guard for Python comments and docstrings.
+
+``tests/test_docs_source_citations.py`` (issue #4764 / PR #4774) polices
+the *markdown* documentation surface.  The identical rot class lives
+inside Python comments and docstrings: a ``<file>.py:NNN`` citation is
+correct on the day it is written and silently wrong after the next
+insertion above it.  Issue #4796 measured every sampled citation in the
+board scripts as stale — one of them (``escape.py:3303-3304``) pointed at
+ring-distance code with no relationship at all to the QFN escape logic
+the comment described.
+
+**Fixed allowlist, not a glob.**  ``GUARDED_PY_FILES`` lists exact
+repo-relative paths — the ten files issue #4796 cleaned.  A glob over
+``src/`` would go red immediately: ~85 further ``.py:NNN`` citations
+across 29 other ``src/`` files (``router/core.py``, ``router/escape.py``,
+``cli/route_cmd.py``, ``validate/**`` …) are *deliberately* left alone by
+that issue — those files are 5,000–18,000 lines and churn on nearly every
+routing PR, so per-citation verification is a materially larger body of
+work tracked as a separate follow-up.  Add rows here as that follow-up
+lands; do not swap the tuple for a glob until the whole tree is clean.
+
+``tests/**`` is excluded by construction (it asserts real line numbers),
+as are the forensic trees the markdown guard documents.
+
+Issue: #4796.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import tokenize
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Exact repo-relative paths.  See the module docstring for why this is a
+# fixed allowlist rather than a glob.
+GUARDED_PY_FILES: tuple[str, ...] = (
+    "src/kicad_tools/router/match_group_length.py",
+    "boards/00-simple-led/generate_design.py",
+    "boards/01-voltage-divider/generate_design.py",
+    "boards/02-charlieplex-led/generate_design.py",
+    "boards/03-usb-joystick/generate_design.py",
+    "boards/03-usb-joystick/route_demo.py",
+    "boards/04-stm32-devboard/generate_design.py",
+    "boards/05-bldc-motor-controller/design.py",
+    "boards/06-diffpair-test/generate_design.py",
+    "boards/07-matchgroup-test/generate_design.py",
+)
+
+# A ``<file>.py:NNN`` citation.  Same pattern the markdown guards use.
+LINE_CITATION_RE = re.compile(r"\.py:\d+")
+
+# Source anchors the guarded Python files make, as
+# ``(citing file, anchor, cited source file)`` — all repo-relative.
+#
+# Checked in BOTH directions per row: the anchor must still appear in the
+# citing file (a rewrite cannot silently drop it back to a bare path) and
+# in the source file it names (a rename goes red here instead of rotting).
+#
+# The regression this table exists for is PR #4774's first pass, which
+# replaced rotten line numbers with two symbols that had never existed
+# (``Footprint.to_sexp``, ``build_parser``).  A phantom symbol is worse
+# than a stale line number because it *looks* verifiable.
+CITED_SYMBOLS: tuple[tuple[str, str, str], ...] = (
+    # src/kicad_tools/router/match_group_length.py — reuse/provenance notes
+    (
+        "src/kicad_tools/router/match_group_length.py",
+        "tune_match_group",
+        "src/kicad_tools/router/optimizer/serpentine.py",
+    ),
+    (
+        "src/kicad_tools/router/match_group_length.py",
+        "calculate_route_length",
+        "src/kicad_tools/router/length.py",
+    ),
+    (
+        "src/kicad_tools/router/match_group_length.py",
+        "match_groups",
+        "src/kicad_tools/router/length.py",
+    ),
+    (
+        "src/kicad_tools/router/match_group_length.py",
+        "measure_net_from_pcb",
+        "src/kicad_tools/router/diffpair_length.py",
+    ),
+    (
+        "src/kicad_tools/router/match_group_length.py",
+        "_via_length",
+        "src/kicad_tools/router/diffpair_length.py",
+    ),
+    (
+        "src/kicad_tools/router/match_group_length.py",
+        "_measure_route",
+        "src/kicad_tools/router/diffpair_length.py",
+    ),
+    (
+        "src/kicad_tools/router/match_group_length.py",
+        "DetectionSource",
+        "src/kicad_tools/router/diffpair_detection.py",
+    ),
+    # The five board scripts that mirror board 03's ``route_success``
+    # fast-fail gate, which lives immediately after ``route_pcb``.
+    (
+        "boards/00-simple-led/generate_design.py",
+        "route_pcb",
+        "boards/03-usb-joystick/generate_design.py",
+    ),
+    (
+        "boards/01-voltage-divider/generate_design.py",
+        "route_pcb",
+        "boards/03-usb-joystick/generate_design.py",
+    ),
+    (
+        "boards/02-charlieplex-led/generate_design.py",
+        "route_pcb",
+        "boards/03-usb-joystick/generate_design.py",
+    ),
+    (
+        "boards/04-stm32-devboard/generate_design.py",
+        "route_pcb",
+        "boards/03-usb-joystick/generate_design.py",
+    ),
+    (
+        "boards/06-diffpair-test/generate_design.py",
+        "route_pcb",
+        "boards/03-usb-joystick/generate_design.py",
+    ),
+    # boards/03-usb-joystick — the build-step entry point and board 05's
+    # zone-fill precedent.
+    (
+        "boards/03-usb-joystick/route_demo.py",
+        "_run_step_route",
+        "src/kicad_tools/cli/build_cmd.py",
+    ),
+    (
+        "boards/03-usb-joystick/generate_design.py",
+        "fill_zones_in_routed_pcb",
+        "boards/05-bldc-motor-controller/design.py",
+    ),
+    # boards/04 — board 05's PR #3004 power-symbol / PWR_FLAG rail bridging.
+    (
+        "boards/04-stm32-devboard/generate_design.py",
+        "create_bldc_controller",
+        "boards/05-bldc-motor-controller/design.py",
+    ),
+    # boards/05 — self-citations (they drift apart on an insertion above
+    # one but not the other, so they need anchors too).
+    (
+        "boards/05-bldc-motor-controller/design.py",
+        "create_bldc_pcb",
+        "boards/05-bldc-motor-controller/design.py",
+    ),
+    (
+        "boards/05-bldc-motor-controller/design.py",
+        "generate_diode_sma",
+        "boards/05-bldc-motor-controller/design.py",
+    ),
+    (
+        "boards/05-bldc-motor-controller/design.py",
+        "route_pcb",
+        "boards/05-bldc-motor-controller/design.py",
+    ),
+    (
+        "boards/05-bldc-motor-controller/design.py",
+        "validate_grid_resolution",
+        "src/kicad_tools/router/io.py",
+    ),
+    # boards/06 — escape widths, neck-down, per-net-timeout forwarding and
+    # the DRC nudge call sites.
+    (
+        "boards/06-diffpair-test/generate_design.py",
+        "_create_fine_pitch_row_escapes",
+        "src/kicad_tools/router/escape.py",
+    ),
+    (
+        "boards/06-diffpair-test/generate_design.py",
+        "get_neck_down_width",
+        "src/kicad_tools/router/rules.py",
+    ),
+    (
+        "boards/06-diffpair-test/generate_design.py",
+        'getattr(args, "per_net_timeout", None) or None',
+        "src/kicad_tools/cli/route_cmd.py",
+    ),
+    (
+        "boards/06-diffpair-test/generate_design.py",
+        "route_with_layer_escalation",
+        "src/kicad_tools/cli/route_cmd.py",
+    ),
+    (
+        "boards/06-diffpair-test/generate_design.py",
+        "route_with_rule_relaxation",
+        "src/kicad_tools/cli/route_cmd.py",
+    ),
+    (
+        "boards/06-diffpair-test/generate_design.py",
+        "route_with_combined_escalation",
+        "src/kicad_tools/cli/route_cmd.py",
+    ),
+    (
+        "boards/06-diffpair-test/generate_design.py",
+        "_main_impl",
+        "src/kicad_tools/cli/route_cmd.py",
+    ),
+    # boards/07 — the seed path, the CI gate's sidecar probe and the
+    # coupled pathfinder pre-pass.
+    (
+        "boards/07-matchgroup-test/generate_design.py",
+        "random.seed(args.seed)",
+        "src/kicad_tools/cli/route_cmd.py",
+    ),
+    (
+        "boards/07-matchgroup-test/generate_design.py",
+        "find_net_class_map_sidecar",
+        "scripts/ci/check_matchgroup_coverage.py",
+    ),
+    (
+        "boards/07-matchgroup-test/generate_design.py",
+        "CoupledPathfinder",
+        "src/kicad_tools/router/diffpair_routing.py",
+    ),
+    (
+        "boards/07-matchgroup-test/generate_design.py",
+        "min_spacing_cells",
+        "src/kicad_tools/router/diffpair_routing.py",
+    ),
+    (
+        "boards/07-matchgroup-test/generate_design.py",
+        "route_all_with_diffpairs",
+        "src/kicad_tools/router/core.py",
+    ),
+)
+
+
+def _anchor_re(anchor: str) -> re.Pattern[str]:
+    """Whole-token match for ``anchor``.
+
+    Lookarounds rather than ``\\b`` so a non-identifier anchor (a short
+    verbatim phrase such as ``getattr(args, "per_net_timeout", None) or
+    None``) is matched as reliably as an identifier one.  A near-miss
+    rename (``_run_step_routeX``) still cannot satisfy the check by
+    substring.
+    """
+    return re.compile(rf"(?<![0-9A-Za-z_]){re.escape(anchor)}(?![0-9A-Za-z_])")
+
+
+def _prose_lines(path: Path) -> list[tuple[int, str]]:
+    """Return ``(lineno, text)`` for every comment / string token in ``path``.
+
+    Only prose is policed: comments, docstrings and string literals.  Real
+    code is exempt, so a future diagnostic that legitimately *computes* a
+    ``file.py:lineno`` string cannot be forced into this guard.
+    """
+    source = path.read_text(encoding="utf-8")
+    prose: list[tuple[int, str]] = []
+    for token in tokenize.generate_tokens(io.StringIO(source).readline):
+        if token.type in (tokenize.COMMENT, tokenize.STRING):
+            for offset, text in enumerate(token.string.splitlines()):
+                prose.append((token.start[0] + offset, text))
+    return prose
+
+
+def test_guarded_py_files_exist() -> None:
+    """Every path in ``GUARDED_PY_FILES`` must exist.
+
+    A guard pointed at a moved or deleted file polices nothing and can
+    never fail.  Renaming a board script must update this tuple.
+    """
+    missing = [rel for rel in GUARDED_PY_FILES if not (REPO_ROOT / rel).is_file()]
+    assert not missing, (
+        f"GUARDED_PY_FILES names files that do not exist: {missing}.  Either "
+        f"the file moved (update the path) or it is gone (drop the row) — a "
+        f"dangling entry is silent zero coverage."
+    )
+
+
+def test_guarded_py_files_are_exact_paths() -> None:
+    """``GUARDED_PY_FILES`` must not contain glob metacharacters.
+
+    The allowlist is deliberately fixed: ~85 ``.py:NNN`` citations across
+    29 other ``src/`` files are out of scope for issue #4796 and a glob
+    would sweep them in and go red on merge.  See the module docstring.
+    """
+    globbed = [rel for rel in GUARDED_PY_FILES if any(ch in rel for ch in "*?[")]
+    assert not globbed, (
+        f"Glob patterns in GUARDED_PY_FILES: {globbed}.  List each file "
+        f"explicitly; this allowlist grows one cleaned file at a time."
+    )
+
+
+def test_no_line_number_citations() -> None:
+    """No guarded Python file cites source by ``<file>.py:NNN``.
+
+    Line numbers rot on every insertion above them and nothing else in
+    the suite notices.  Cite ``symbol`` + ``path/to/file.py`` instead —
+    that survives a refactor and ``test_cited_symbols_exist`` can verify
+    it.
+    """
+    offenders: list[str] = []
+    for rel in GUARDED_PY_FILES:
+        path = REPO_ROOT / rel
+        if not path.is_file():
+            continue
+        for lineno, text in _prose_lines(path):
+            if LINE_CITATION_RE.search(text):
+                offenders.append(f"{rel}:{lineno}: {text.strip()}")
+
+    assert not offenders, (
+        "Line-number source citations found in the guarded Python files:\n  "
+        + "\n  ".join(offenders)
+        + "\n\nReplace each with a symbol anchor — e.g. `_run_step_route` in "
+        "`src/kicad_tools/cli/build_cmd.py` — and add the (citing file, "
+        "symbol, source file) row to CITED_SYMBOLS."
+    )
+
+
+def test_cited_symbols_exist() -> None:
+    """Every anchor in ``CITED_SYMBOLS`` exists in both files of its row.
+
+    Negative controls for this test:
+
+    * rename ``tune_match_group`` in
+      ``src/kicad_tools/router/optimizer/serpentine.py`` — the
+      source-side assertion goes red;
+    * drop ``_run_step_route`` from ``boards/03-usb-joystick/route_demo.py``
+      — the citing-side assertion goes red.
+    """
+    for citing_rel, anchor, source_rel in CITED_SYMBOLS:
+        pattern = _anchor_re(anchor)
+
+        citing_path = REPO_ROOT / citing_rel
+        assert citing_path.is_file(), f"CITED_SYMBOLS names a missing file: {citing_rel}"
+        assert pattern.search(citing_path.read_text(encoding="utf-8")), (
+            f"{citing_rel} no longer mentions {anchor!r}.  Either restore the "
+            f"anchor or drop its row from CITED_SYMBOLS in {Path(__file__).name}."
+        )
+
+        source_path = REPO_ROOT / source_rel
+        assert source_path.is_file(), (
+            f"{citing_rel} cites {source_rel}, which does not exist.  Update "
+            f"the citing comment and CITED_SYMBOLS."
+        )
+        assert pattern.search(source_path.read_text(encoding="utf-8")), (
+            f"{citing_rel} cites {anchor!r} in {source_rel}, but that name no "
+            f"longer appears in the file.  It was probably renamed — update "
+            f"the comment (and this row) to the live name."
+        )
+
+
+def test_every_guarded_file_is_covered_by_cited_symbols() -> None:
+    """Each guarded file must contribute at least one ``CITED_SYMBOLS`` row.
+
+    ``test_no_line_number_citations`` alone is satisfiable by deleting the
+    citation outright.  Requiring a symbol row per file keeps the
+    cross-reference itself alive: the fix for rot is re-anchoring, not
+    forgetting.
+    """
+    cited = {citing_rel for citing_rel, _, _ in CITED_SYMBOLS}
+    uncovered = [rel for rel in GUARDED_PY_FILES if rel not in cited]
+    assert not uncovered, (
+        f"Guarded files with no CITED_SYMBOLS row: {uncovered}.  Add the "
+        f"(citing file, symbol, source file) row for each cross-reference "
+        f"the file makes, so a rename on either side goes red."
+    )


### PR DESCRIPTION
## Summary

Re-anchors every cross-file `.py:NNN` citation in the nine `boards/**` generator
scripts and in `src/kicad_tools/router/match_group_length.py` onto a **symbol +
bare file path**, the convention PR #4774 established for markdown, and adds
`tests/test_py_citation_rot.py` so the rot class cannot regrow on that surface.

Comments and docstrings only — no behavior change.

Every sampled citation was stale, matching #4774's measured 62.5% rot rate:

| Citation | Reality now |
|---|---|
| `boards/03-usb-joystick/generate_design.py:838` (cited by 5 board scripts for the `route_success` fast-fail gate) | the gate is at **849**; `route_pcb` is at 493 |
| `escape.py:3303-3304` ("QFN escape segments, Issue #1778") | lands inside `_group_pads_by_ring` — **unrelated ring-distance code** |
| `serpentine.py:438` (`tune_match_group`) | `def tune_match_group` is at **569** |
| `build_cmd.py:1189` (`kct build --step route`) | `def _run_step_route` is at **1608** |
| `rules.py:498` (`get_neck_down_width`) | at **645** |
| `check_matchgroup_coverage.py:223-235` (sidecar probe) | that range is `check_zero_violations` / `load_allowlist`; the sidecar probe is `find_net_class_map_sidecar` at 346 |

The `escape.py:3303-3304` anchor was **re-derived from scratch** per the issue's
acceptance criterion, not patched: the Issue #1778 `min_trace_width`
escape-segment logic lives in `EscapeRouter._create_fine_pitch_row_escapes`.

Scope note: the enumerated fix list said "22 occurrences"; the acceptance
criterion is `git grep -nE '\.py:[0-9]+' -- boards/**/*.py
src/kicad_tools/router/match_group_length.py` → **zero**, which is 32
occurrences (`match_group_length.py` carries 12, not the 2 the summary counted).
All 32 are fixed. The ~85 citations across 29 other `src/` files are **untouched
by design** — that carve-out is why the new guard uses a fixed allowlist rather
than a glob.

## Changes

- **`src/kicad_tools/router/match_group_length.py`** (12) — the module docstring
  and method docstrings already named the symbol next to each line number
  (`tune_match_group`, `LengthTracker.calculate_route_length`,
  `DiffPairLengthTracker.measure_net_from_pcb` / `._via_length` /
  `._measure_route`, `DetectionSource`, `LengthTracker.match_groups`); the bare
  `:NNN` is dropped and the prose re-flowed.
- **5 × board `route_success` gate cross-reference** (boards 00, 01, 02, 04, 06)
  — now "board 03's `route_success` gate after `route_pcb` in
  `boards/03-usb-joystick/generate_design.py`", per the curated instruction to
  drop the line number rather than re-guess it.
- **`boards/03-usb-joystick/route_demo.py`** (2) — `_run_step_route` in
  `src/kicad_tools/cli/build_cmd.py`.
- **`boards/03-usb-joystick/generate_design.py`** (1) — board 05's
  `fill_zones_in_routed_pcb`.
- **`boards/04-stm32-devboard/generate_design.py`** (1 + gate) — board 05's PR
  #3004 fix is now anchored on the `add_power` / `PWR_FLAG` rail bridging in
  `create_bldc_controller`.
- **`boards/05-bldc-motor-controller/design.py`** (2, self-citing) — the four
  footprint hard-codes are "all four nested in `create_bldc_pcb` in this file";
  the clearance note cites `route_pcb` + `io.py`'s `validate_grid_resolution`.
  Self-citations still get anchors: an insertion above one but not the other
  drifts them apart.
- **`boards/06-diffpair-test/generate_design.py`** (6) —
  `EscapeRouter._create_fine_pitch_row_escapes`, `DesignRules.get_neck_down_width`,
  the verbatim `getattr(args, "per_net_timeout", None) or None` forwarding
  phrase, and the DRC-nudge call sites named as
  `route_with_layer_escalation` / `route_with_rule_relaxation` /
  `route_with_combined_escalation` / `_main_impl` (the old comment split them
  into `kct route` vs `kct optimize` by line; both paths are in `route_cmd.py`,
  and the post-optimization nudge is in `_main_impl`).
- **`boards/07-matchgroup-test/generate_design.py`** (4) —
  `random.seed(args.seed)`, `find_net_class_map_sidecar`, `CoupledPathfinder`'s
  `min_spacing_cells` handling, `Autorouter.route_all_with_diffpairs`.
- **`tests/test_py_citation_rot.py`** (new, option (a) from the curated spec) —
  `GUARDED_PY_FILES` is a tuple of **exact paths** (10 files), scanned for
  `LINE_CITATION_RE = re.compile(r"\.py:\d+")` in comments / docstrings /
  string literals only (via `tokenize`, so real code that legitimately computes
  a `file.py:lineno` string is exempt). `CITED_SYMBOLS` (31 rows) checks each
  anchor **in both directions** — citing file and cited source. Four structural
  tests keep the guard from silently policing nothing:
  `test_guarded_py_files_exist`, `test_guarded_py_files_are_exact_paths` (no
  globs — documents the 85-citation carve-out), `test_no_line_number_citations`,
  `test_cited_symbols_exist`, `test_every_guarded_file_is_covered_by_cited_symbols`.
- **`CHANGELOG.md`** — one entry under the existing `[Unreleased]` → `### Fixed`.

## Acceptance Criteria Verification

Every replacement symbol was verified to exist **before** it went into the diff
(the #4774 Doctor cycle shipped two phantoms — `Footprint.to_sexp`,
`build_parser`):

```
$ rg -n '^\s*(def|class) tune_match_group\b' src/kicad_tools/router/optimizer/serpentine.py
569:def tune_match_group(
$ rg -n '^\s*(def|class) _run_step_route\b' src/kicad_tools/cli/build_cmd.py
1608:def _run_step_route(ctx: BuildContext, console: Console) -> BuildResult:
$ rg -n '^\s*(def|class) route_pcb\b' boards/03-usb-joystick/generate_design.py
493:def route_pcb(input_path: Path, output_path: Path) -> bool:
$ rg -n 'if not route_success' boards/03-usb-joystick/generate_design.py
849:        if not route_success:
$ rg -n '^\s*(def|class) (calculate_route_length|LengthTracker)\b' src/kicad_tools/router/length.py
79:class LengthTracker:
139:    def calculate_route_length(route: Route) -> float:
$ rg -n '^\s*(def|class) (measure_net_from_pcb|_via_length|_measure_route|DiffPairLengthTracker)\b' src/kicad_tools/router/diffpair_length.py
65:class DiffPairLengthTracker:
163:    def _measure_route(
202:    def _via_length(
348:    def measure_net_from_pcb(
$ rg -n '^\s*(def|class) DetectionSource\b' src/kicad_tools/router/diffpair_detection.py
49:class DetectionSource(Enum):
$ rg -n '^\s*(def|class) fill_zones_in_routed_pcb\b' boards/05-bldc-motor-controller/design.py
3477:def fill_zones_in_routed_pcb(routed_path: Path) -> int:
$ rg -n '^\s*(def|class) (create_bldc_controller|create_bldc_pcb|route_pcb|generate_d2pak|generate_cap_0805|generate_inductor_smd|generate_diode_sma)\b' boards/05-bldc-motor-controller/design.py
70:def create_bldc_controller(output_dir: Path) -> Path:
1417:def create_bldc_pcb(output_dir: Path) -> Path:
1872:    def generate_d2pak(...)
2233:    def generate_cap_0805(...)
2339:    def generate_inductor_smd(...)
2358:    def generate_diode_sma(...)
2719:def route_pcb(input_path: Path, output_path: Path) -> bool:
$ rg -n '^\s*(def|class) validate_grid_resolution\b' src/kicad_tools/router/io.py
454:def validate_grid_resolution(
$ rg -n '^\s*(def|class) get_neck_down_width\b' src/kicad_tools/router/rules.py
645:    def get_neck_down_width(          # inside class DesignRules (line 72)
$ rg -n '^\s*(def|class) find_net_class_map_sidecar\b' scripts/ci/check_matchgroup_coverage.py
346:def find_net_class_map_sidecar(board_dir: Path, routed_pcb: Path) -> Path | None:
$ rg -n '^\s*(def|class) (CoupledPathfinder)\b' src/kicad_tools/router/diffpair_routing.py
1501:class CoupledPathfinder:
$ rg -n '^\s*(def|class) route_all_with_diffpairs\b' src/kicad_tools/router/core.py
16602:    def route_all_with_diffpairs(   # inside class Autorouter (line 1129)
```

The `escape.py` re-derivation, via AST enclosing-scope lookup:

```
$ python3 -c "<ast.walk enclosing-scope lookup>"
3303 ClassDef EscapeRouter 1068 8743 / FunctionDef _group_pads_by_ring 3286 3333   <- the STALE target
4592 FunctionDef _create_fine_pitch_row_escapes 4592 5039                          <- the Issue #1778 logic
$ rg -n 'Issue #1778' src/kicad_tools/router/escape.py
4608:        Issue #1778: Escape segments use min_trace_width (manufacturer minimum)
4689:        # Issue #1778: Use min_trace_width for escape segments in fine-pitch
```

The `route_cmd.py` anchors, likewise by enclosing scope:

```
2986 _run_placement_feedback / 3147 _run_placement_delta_feedback   (per_net_timeout forwarding)
6397 route_with_layer_escalation / 7192 route_with_rule_relaxation /
9487 route_with_combined_escalation / 14857 _main_impl              (drc_verify_and_nudge)
12784 _main_impl                                                    (random.seed(args.seed))
```

- [x] All in-scope `.py:NNN` citations converted to symbol anchors
- [x] Every replacement symbol verified live (output above), no phantoms
- [x] `escape.py:3303-3304` re-derived from scratch, not patched
- [x] The 13 curation-unverified citations each independently re-read against the
      current tree before being rewritten
- [x] Guard added, scoped to exactly the 10 files this PR touches
- [x] `git grep -nE '\.py:[0-9]+' -- boards/**/*.py src/kicad_tools/router/match_group_length.py` → **zero matches**
- [x] No behavioral change (comment/docstring text only)
- [x] `CHANGELOG.md` `[Unreleased]` → `### Fixed` entry added to the existing
      merged Fixed subsection

## Test Plan

```
$ uv run pytest tests/test_py_citation_rot.py tests/test_docs_source_citations.py -q
9 passed in 0.54s

$ uv run pytest tests/ -k "docs or citation" -q
26 passed, 9 skipped, 26239 deselected in 94.98s

$ uv run pytest tests/test_changelog_gap_report.py -q
13 passed in 0.21s

$ uv run ruff check .
All checks passed!

$ uv run ruff format --check .
1792 files already formatted

$ uv run python scripts/ci/check_mypy_baseline.py
OK: mypy reports 1470 error(s), all within the baseline (1472 allowed). exit=0

$ rg -n '\.py:[0-9]+' boards/ src/kicad_tools/router/match_group_length.py --type py
(no output)
```

Negative controls (all run in the worktree, all reverted):

1. **Line-number citation reinserted** into `boards/00-simple-led/generate_design.py`:
   ```
   FAILED tests/test_py_citation_rot.py::test_no_line_number_citations
   E  AssertionError: Line-number source citations found in the guarded Python files:
   E      boards/00-simple-led/generate_design.py:973: # gate at boards/03-usb-joystick/generate_design.py:838).
   ```
2. **Phantom symbol row** (`Footprint.to_sexp`) appended to `CITED_SYMBOLS` —
   the exact #4774 failure mode:
   ```
   PHANTOM CAUGHT: src/kicad_tools/router/match_group_length.py no longer mentions 'Footprint.to_sexp'.
   ```
3. **Source-side rename** simulated (anchor present in the citing file, absent in
   the cited source):
   ```
   SOURCE-SIDE CAUGHT: ... cites 'tune_match_group' in src/kicad_tools/router/length.py,
   but that name no longer appears in the file. It was probably renamed ...
   ```

Also `python3 -m py_compile` on all 10 modified Python files (parse-clean).

## Follow-up (not in this PR)

~85 `.py:NNN` citations across 29 other `src/` files (`router/core.py`,
`router/escape.py`, `router/diffpair_routing.py`, `cli/route_cmd.py`,
`validate/**`, `schema/pcb.py`, …) remain by design — the curated scope note
recommends a dedicated issue or a per-subsystem `loom:epic`. As each file is
cleaned, add its path to `GUARDED_PY_FILES`; the guard is written to grow one
file at a time (`test_guarded_py_files_are_exact_paths` enforces that).

Closes #4796
